### PR TITLE
fix(routing): gray-box budget clamp + capacity-503 rate penalty (postmortem layers 3-4)

### DIFF
--- a/coordinator/api/capacity_cooldown_followups_test.go
+++ b/coordinator/api/capacity_cooldown_followups_test.go
@@ -49,7 +49,7 @@ func TestCapacityCooldown404NotLoadedStrikes(t *testing.T) {
 	lazy := makeRoutableProvider(t, reg, "p-lazy-load", model)
 	for round := 0; round < 4; round++ {
 		for i := 0; i < 3; i++ {
-			srv.noteInferenceError(lazy.ID, capacityTestPending(model, lazy.ID, round*10+i), http.StatusNotFound, notLoaded)
+			srv.noteInferenceError(lazy.ID, capacityTestPending(model, lazy.ID, round*10+i), http.StatusNotFound, notLoaded, "")
 		}
 		srv.noteInferenceSuccess(capacityTestPending(model, lazy.ID, round))
 	}
@@ -60,7 +60,7 @@ func TestCapacityCooldown404NotLoadedStrikes(t *testing.T) {
 	// Black hole flavor: 404s forever, zero accepts — trips at the threshold.
 	stuck := makeRoutableProvider(t, reg, "p-never-loads", model)
 	for i := 0; i < 5; i++ {
-		srv.noteInferenceError(stuck.ID, capacityTestPending(model, stuck.ID, i), http.StatusNotFound, notLoaded)
+		srv.noteInferenceError(stuck.ID, capacityTestPending(model, stuck.ID, i), http.StatusNotFound, notLoaded, "")
 	}
 	if !reg.CapacityCooldownActive(stuck.ID, model) {
 		t.Fatal("a box that 404s 'not loaded' forever with zero accepts did not trip")
@@ -70,7 +70,7 @@ func TestCapacityCooldown404NotLoadedStrikes(t *testing.T) {
 	// request-shape error) never strikes, no matter how many arrive.
 	notFound := makeRoutableProvider(t, reg, "p-model-not-found", model)
 	for i := 0; i < 10; i++ {
-		srv.noteInferenceError(notFound.ID, capacityTestPending(model, notFound.ID, i), http.StatusNotFound, "model not found")
+		srv.noteInferenceError(notFound.ID, capacityTestPending(model, notFound.ID, i), http.StatusNotFound, "model not found", "")
 	}
 	if reg.CapacityCooldownActive(notFound.ID, model) {
 		t.Fatal("request-shape 404 'model not found' tripped the capacity cooldown")
@@ -98,7 +98,7 @@ func TestCapacityRateExcludesColdModelMiss(t *testing.T) {
 	// must stay empty.
 	cold := makeRoutableProvider(t, reg, "p-cold-miss", model)
 	for i := 0; i < sampleFloor; i++ {
-		srv.noteInferenceError(cold.ID, capacityTestPending(model, cold.ID, i), http.StatusNotFound, notLoaded)
+		srv.noteInferenceError(cold.ID, capacityTestPending(model, cold.ID, i), http.StatusNotFound, notLoaded, "")
 		srv.noteInferenceSuccess(capacityTestPending(model, cold.ID, i))
 	}
 	if rate, samples := reg.CapacityRejectRate(cold.ID, model); samples != 0 || rate != 0 {
@@ -109,7 +109,7 @@ func TestCapacityRateExcludesColdModelMiss(t *testing.T) {
 	// the rate — the mechanism the penalty exists for.
 	gray := makeRoutableProvider(t, reg, "p-graybox", model)
 	for i := 0; i < sampleFloor; i++ {
-		srv.noteInferenceError(gray.ID, capacityTestPending(model, gray.ID, i), http.StatusServiceUnavailable, genuine)
+		srv.noteInferenceError(gray.ID, capacityTestPending(model, gray.ID, i), http.StatusServiceUnavailable, genuine, "")
 		srv.noteInferenceSuccess(capacityTestPending(model, gray.ID, i))
 	}
 	if rate, samples := reg.CapacityRejectRate(gray.ID, model); samples == 0 || rate <= 0 {
@@ -142,7 +142,7 @@ func TestCapacityRejectDeterministicBatchBudgetArmsNoGrayBoxState(t *testing.T) 
 	// binding term was the context, identical fleet-wide.
 	det := makeRoutableProvider(t, reg, "p-oversized-prompt", model)
 	setProviderModelBudget(t, reg, det.ID, model, 5_000_000)
-	srv.noteInferenceError(det.ID, capacityTestPending(model, det.ID, 0), http.StatusServiceUnavailable, batchBudget)
+	srv.noteInferenceError(det.ID, capacityTestPending(model, det.ID, 0), http.StatusServiceUnavailable, batchBudget, "")
 	if reg.BudgetClampActive(det.ID, model) {
 		t.Fatal("a request-deterministic batch-budget reject must not arm the budget clamp")
 	}
@@ -152,7 +152,7 @@ func TestCapacityRejectDeterministicBatchBudgetArmsNoGrayBoxState(t *testing.T) 
 	// ...but repeated ones with zero interleaved accepts still trip the
 	// black-hole cooldown (the budget-misreporting signature).
 	for i := 1; i < 5; i++ {
-		srv.noteInferenceError(det.ID, capacityTestPending(model, det.ID, i), http.StatusServiceUnavailable, batchBudget)
+		srv.noteInferenceError(det.ID, capacityTestPending(model, det.ID, i), http.StatusServiceUnavailable, batchBudget, "")
 	}
 	if !reg.CapacityCooldownActive(det.ID, model) {
 		t.Fatal("repeated deterministic batch-budget rejects with zero accepts must still trip the cooldown")
@@ -163,12 +163,71 @@ func TestCapacityRejectDeterministicBatchBudgetArmsNoGrayBoxState(t *testing.T) 
 	// provider-specific capacity signal: full gray-box state.
 	pressured := makeRoutableProvider(t, reg, "p-pressured", model)
 	setProviderModelBudget(t, reg, pressured.ID, model, 90_000)
-	srv.noteInferenceError(pressured.ID, capacityTestPending(model, pressured.ID, 0), http.StatusServiceUnavailable, batchBudget)
+	srv.noteInferenceError(pressured.ID, capacityTestPending(model, pressured.ID, 0), http.StatusServiceUnavailable, batchBudget, "")
 	if !reg.BudgetClampActive(pressured.ID, model) {
 		t.Fatal("a node-pressured batch-budget reject (budget < context) must arm the budget clamp")
 	}
 	if _, samples := reg.CapacityRejectRate(pressured.ID, model); samples != 1 {
 		t.Fatalf("a node-pressured batch-budget reject must derate: samples=%d, want 1", samples)
+	}
+}
+
+// The gray-box request-shape classification must TRUST a provider's
+// structured ErrorReason over the stale heartbeat-budget heuristic, exactly
+// like the dispatch failover does (Codex review of #523, round 4): a newer
+// provider that says request_exceeds_node_budget with a "batch token budget"
+// string is reporting a node-specific capacity failure — even when its stale
+// reported budget still reads >= the model context — so the reject must feed
+// the full gray-box state, not be misrouted to the strike-only request-shape
+// path. Conversely an explicit request_exceeds_context reason is request-
+// deterministic regardless of string or budget.
+func TestGrayBoxClassificationTrustsStructuredReason(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	st := store.NewMemory(store.Config{AdminKey: "test-key"})
+	reg := registry.New(logger)
+	srv := NewServer(reg, st, ServerConfig{}, logger)
+
+	const model = "reasoned-batch-budget-model"
+	const batchBudget = "token_budget_exhausted: request exceeds batch token budget"
+	registerModelContext(t, st, model, 131072)
+
+	// Structured node-specific reason + stale budget >= context: the reason
+	// wins — full gray-box state (clamp + rate), not the request-shape path.
+	nodeBudget := makeRoutableProvider(t, reg, "p-reasoned-node", model)
+	setProviderModelBudget(t, reg, nodeBudget.ID, model, 5_000_000)
+	srv.noteInferenceError(nodeBudget.ID, capacityTestPending(model, nodeBudget.ID, 0),
+		http.StatusServiceUnavailable, batchBudget, "request_exceeds_node_budget")
+	if !reg.BudgetClampActive(nodeBudget.ID, model) {
+		t.Fatal("a structured request_exceeds_node_budget reason must feed the clamp despite the stale >=context budget snapshot")
+	}
+	if _, samples := reg.CapacityRejectRate(nodeBudget.ID, model); samples != 1 {
+		t.Fatalf("a structured node-budget reject must derate: samples=%d, want 1", samples)
+	}
+
+	// No reason (legacy provider): the budget heuristic still applies —
+	// budget >= context reads request-deterministic, strike-only.
+	legacy := makeRoutableProvider(t, reg, "p-reasonless", model)
+	setProviderModelBudget(t, reg, legacy.ID, model, 5_000_000)
+	srv.noteInferenceError(legacy.ID, capacityTestPending(model, legacy.ID, 0),
+		http.StatusServiceUnavailable, batchBudget, "")
+	if reg.BudgetClampActive(legacy.ID, model) {
+		t.Fatal("reasonless deterministic batch-budget reject must stay strike-only (heuristic unchanged)")
+	}
+
+	// Explicit request_exceeds_context reason on a NON-batch capacity string
+	// from a pressured-looking provider: request-deterministic — no gray-box
+	// state, even though the budget heuristic alone would have said transient.
+	ctxReason := makeRoutableProvider(t, reg, "p-reasoned-ctx", model)
+	setProviderModelBudget(t, reg, ctxReason.ID, model, 90_000)
+	srv.noteInferenceError(ctxReason.ID, capacityTestPending(model, ctxReason.ID, 0),
+		http.StatusServiceUnavailable,
+		"token_budget_exhausted: request requires 200000 tokens but only 90000 available",
+		"request_exceeds_context")
+	if reg.BudgetClampActive(ctxReason.ID, model) {
+		t.Fatal("an explicit request_exceeds_context reason must not arm the clamp")
+	}
+	if _, samples := reg.CapacityRejectRate(ctxReason.ID, model); samples != 0 {
+		t.Fatalf("an explicit request_exceeds_context reason must not derate: samples=%d, want 0", samples)
 	}
 }
 

--- a/coordinator/api/capacity_cooldown_followups_test.go
+++ b/coordinator/api/capacity_cooldown_followups_test.go
@@ -77,6 +77,98 @@ func TestCapacityCooldown404NotLoadedStrikes(t *testing.T) {
 	}
 }
 
+// Cold "model not loaded" misses must NOT derate the gray-box capacity-503
+// RATE window, even over the sample floor and with interleaved accepts (the
+// normal lazy-load lifecycle) — the rate window has no accept-reset, so
+// counting a healthy box's reloads would penalize it. A genuine token-budget
+// 503 on the same path DOES derate. Codex review of #523.
+func TestCapacityRateExcludesColdModelMiss(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	st := store.NewMemory(store.Config{AdminKey: "test-key"})
+	reg := registry.New(logger)
+	srv := NewServer(reg, st, ServerConfig{}, logger)
+
+	const model = "gemma-4-26b-8bit"
+	const notLoaded = "model 'gemma-4-26b-8bit' is not loaded on this provider"
+	const genuine = "token_budget_exhausted: request exceeds active token budget"
+	const sampleFloor = 8 // registry.capacityRateMinSample (unexported)
+
+	// Cold-miss box: cold "not loaded" 404s over the sample floor, each followed
+	// by a served completion (the normal lazy-load lifecycle). The rate window
+	// must stay empty.
+	cold := makeRoutableProvider(t, reg, "p-cold-miss", model)
+	for i := 0; i < sampleFloor; i++ {
+		srv.noteInferenceError(cold.ID, capacityTestPending(model, cold.ID, i), http.StatusNotFound, notLoaded)
+		srv.noteInferenceSuccess(capacityTestPending(model, cold.ID, i))
+	}
+	if rate, samples := reg.CapacityRejectRate(cold.ID, model); samples != 0 || rate != 0 {
+		t.Fatalf("cold 'not loaded' misses derated the capacity-reject rate: rate=%.2f samples=%d, want 0/0", rate, samples)
+	}
+
+	// Gray-box: genuine token-budget 503s with interleaved accepts DO accumulate
+	// the rate — the mechanism the penalty exists for.
+	gray := makeRoutableProvider(t, reg, "p-graybox", model)
+	for i := 0; i < sampleFloor; i++ {
+		srv.noteInferenceError(gray.ID, capacityTestPending(model, gray.ID, i), http.StatusServiceUnavailable, genuine)
+		srv.noteInferenceSuccess(capacityTestPending(model, gray.ID, i))
+	}
+	if rate, samples := reg.CapacityRejectRate(gray.ID, model); samples == 0 || rate <= 0 {
+		t.Fatalf("genuine token-budget 503s must derate the rate: rate=%.2f samples=%d", rate, samples)
+	}
+}
+
+// After-commit client-gone regression (Codex review of #523): a stream that
+// commits BEFORE the pair's first windowed reject, then the consumer
+// disconnects and the provider completes into the PARKED settlement path
+// (handleComplete, consumerGone=true), must still enter the capacity-503 rate
+// denominator. noteInferenceSuccess — which re-offers the outcome on clean
+// completion — never runs on this path, so without the handleComplete re-offer
+// the served completion vanishes and a few later 503s overstate a healthy
+// pair's reject rate.
+func TestCapacityRateParkedCompletionCountsAtHandleComplete(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	st := store.NewMemory(store.Config{AdminKey: "test-key"})
+	reg := registry.New(logger)
+	srv := NewServer(reg, st, ServerConfig{}, logger)
+
+	const model = "gemma-4-26b-8bit"
+	p := makeRoutableProvider(t, reg, "p-parked", model)
+
+	pr := capacityTestPending(model, p.ID, 1)
+	pr.ConsumerKey = "test-key"
+
+	// Commit first content while the pair is healthy (no reject in-window yet):
+	// mirrors commitFirstContent — the offer records nothing, so the request
+	// still owes its one rate outcome (RateOutcomeCountedSafe stays false).
+	if reg.RecordCapacityAccept(pr.ProviderID, model) {
+		t.Fatal("commit-time accept with an empty reject window must not record a rate outcome")
+	}
+
+	// The pair goes gray while the (now client-gone) stream is still serving.
+	reg.RecordCapacityReject(pr.ProviderID, model)
+	if _, samples := reg.CapacityRejectRate(pr.ProviderID, model); samples != 1 {
+		t.Fatalf("setup: samples=%d after one reject, want 1", samples)
+	}
+
+	// Consumer disconnected mid-stream: the request is parked (no reader), then
+	// the provider completes. handleComplete claims the parked record
+	// (consumerGone=true) and must re-offer the served completion.
+	srv.holdForSettlement(pr)
+	srv.handleComplete(p.ID, p, &protocol.InferenceCompleteMessage{
+		Type:      protocol.TypeInferenceComplete,
+		RequestID: pr.RequestID,
+		Usage:     protocol.UsageInfo{PromptTokens: 100, CompletionTokens: 200},
+	})
+
+	rate, samples := reg.CapacityRejectRate(pr.ProviderID, model)
+	if samples != 2 {
+		t.Fatalf("samples=%d after the parked completion, want 2 (1 reject + the served client-gone stream) — the parked completion never entered the denominator", samples)
+	}
+	if rate != 0.5 {
+		t.Fatalf("rate=%.2f, want 0.5 (1 reject / 2 outcomes)", rate)
+	}
+}
+
 // The generic-path accept regression (P2 #1): a busy box serving a LONG
 // /v1/completions stream sheds 5 capacity rejects inside the window. The
 // stream's first content is an ACCEPT interleaved with the rejects, so the

--- a/coordinator/api/capacity_cooldown_followups_test.go
+++ b/coordinator/api/capacity_cooldown_followups_test.go
@@ -117,6 +117,61 @@ func TestCapacityRateExcludesColdModelMiss(t *testing.T) {
 	}
 }
 
+// A "batch token budget" reject that classifyRejection proves REQUEST-
+// deterministic (the rejecting provider's reported budget is not below the
+// model context, so the prompt exceeded the fleet-wide context) indicts the
+// request, not the provider: it must arm NEITHER the one-shot budget clamp NOR
+// the no-reset capacity-503 rate window — a single oversized prompt would
+// otherwise gate/derate a healthy pair. It still counts a cooldown strike (a
+// budget-misreporting box rejects normal prompts with this exact string, and
+// the cooldown's accept-reset makes strikes safe for healthy pairs). When the
+// reported budget IS below the context (node memory pressure — provider-
+// specific), the same string feeds the full gray-box state. Codex review of
+// #523, round 3.
+func TestCapacityRejectDeterministicBatchBudgetArmsNoGrayBoxState(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	st := store.NewMemory(store.Config{AdminKey: "test-key"})
+	reg := registry.New(logger)
+	srv := NewServer(reg, st, ServerConfig{}, logger)
+
+	const model = "batch-budget-model"
+	const batchBudget = "token_budget_exhausted: request exceeds batch token budget"
+	registerModelContext(t, st, model, 131072)
+
+	// Deterministic: reported budget (5M) >= model context (131072) — the
+	// binding term was the context, identical fleet-wide.
+	det := makeRoutableProvider(t, reg, "p-oversized-prompt", model)
+	setProviderModelBudget(t, reg, det.ID, model, 5_000_000)
+	srv.noteInferenceError(det.ID, capacityTestPending(model, det.ID, 0), http.StatusServiceUnavailable, batchBudget)
+	if reg.BudgetClampActive(det.ID, model) {
+		t.Fatal("a request-deterministic batch-budget reject must not arm the budget clamp")
+	}
+	if _, samples := reg.CapacityRejectRate(det.ID, model); samples != 0 {
+		t.Fatalf("a request-deterministic batch-budget reject must not derate: samples=%d, want 0", samples)
+	}
+	// ...but repeated ones with zero interleaved accepts still trip the
+	// black-hole cooldown (the budget-misreporting signature).
+	for i := 1; i < 5; i++ {
+		srv.noteInferenceError(det.ID, capacityTestPending(model, det.ID, i), http.StatusServiceUnavailable, batchBudget)
+	}
+	if !reg.CapacityCooldownActive(det.ID, model) {
+		t.Fatal("repeated deterministic batch-budget rejects with zero accepts must still trip the cooldown")
+	}
+
+	// Node-pressured: reported budget (90k) < model context (131072) — the
+	// binding term may have been THIS node's shrunk KV budget, a genuine
+	// provider-specific capacity signal: full gray-box state.
+	pressured := makeRoutableProvider(t, reg, "p-pressured", model)
+	setProviderModelBudget(t, reg, pressured.ID, model, 90_000)
+	srv.noteInferenceError(pressured.ID, capacityTestPending(model, pressured.ID, 0), http.StatusServiceUnavailable, batchBudget)
+	if !reg.BudgetClampActive(pressured.ID, model) {
+		t.Fatal("a node-pressured batch-budget reject (budget < context) must arm the budget clamp")
+	}
+	if _, samples := reg.CapacityRejectRate(pressured.ID, model); samples != 1 {
+		t.Fatalf("a node-pressured batch-budget reject must derate: samples=%d, want 1", samples)
+	}
+}
+
 // After-commit client-gone regression (Codex review of #523): a stream that
 // commits BEFORE the pair's first windowed reject, then the consumer
 // disconnects and the provider completes into the PARKED settlement path

--- a/coordinator/api/capacity_cooldown_test.go
+++ b/coordinator/api/capacity_cooldown_test.go
@@ -105,7 +105,7 @@ func TestCapacityCooldownTripsMetricLogAndRoutingDiverts(t *testing.T) {
 	// The incident pattern: every dispatch to the black hole bounces with the
 	// capacity string (classified 503) and it never serves anything.
 	for i := 0; i < 8; i++ {
-		srv.noteInferenceError(blackHole.ID, capacityTestPending(model, blackHole.ID, i), 503, rejectStr)
+		srv.noteInferenceError(blackHole.ID, capacityTestPending(model, blackHole.ID, i), 503, rejectStr, "")
 	}
 	if !reg.CapacityCooldownActive(blackHole.ID, model) {
 		t.Fatal("black-hole provider not in capacity cooldown after 8 zero-accept rejects")
@@ -142,7 +142,7 @@ func TestCapacityCooldownTripsMetricLogAndRoutingDiverts(t *testing.T) {
 	// keeps SERVING (accepts interleaved), so it must NEVER trip.
 	for round := 0; round < 5; round++ {
 		for i := 0; i < 4; i++ {
-			srv.noteInferenceError(healthy.ID, capacityTestPending(model, healthy.ID, round*10+i), 503, rejectStr)
+			srv.noteInferenceError(healthy.ID, capacityTestPending(model, healthy.ID, round*10+i), 503, rejectStr, "")
 		}
 		srv.noteInferenceSuccess(capacityTestPending(model, healthy.ID, round))
 	}
@@ -153,7 +153,7 @@ func TestCapacityCooldownTripsMetricLogAndRoutingDiverts(t *testing.T) {
 	// Client-shape 4xx carrying a capacity-looking string never strikes.
 	other := makeRoutableProvider(t, reg, "p-4xx", model)
 	for i := 0; i < 10; i++ {
-		srv.noteInferenceError(other.ID, capacityTestPending(model, other.ID, i), 400, rejectStr)
+		srv.noteInferenceError(other.ID, capacityTestPending(model, other.ID, i), 400, rejectStr, "")
 	}
 	if reg.CapacityCooldownActive(other.ID, model) {
 		t.Fatal("client-shape 4xx with a capacity string tripped the capacity cooldown")
@@ -164,7 +164,7 @@ func TestCapacityCooldownTripsMetricLogAndRoutingDiverts(t *testing.T) {
 	ctxProvider := makeRoutableProvider(t, reg, "p-ctx", model)
 	for i := 0; i < 10; i++ {
 		srv.noteInferenceError(ctxProvider.ID, capacityTestPending(model, ctxProvider.ID, i), 503,
-			"token_budget_exhausted: request exceeds model context window (200000 prompt tokens > 131072 context)")
+			"token_budget_exhausted: request exceeds model context window (200000 prompt tokens > 131072 context)", "")
 	}
 	if reg.CapacityCooldownActive(ctxProvider.ID, model) {
 		t.Fatal("deterministic context-overflow rejections tripped the capacity cooldown")
@@ -211,7 +211,7 @@ func TestCapacityCooldownRetryReselectionEscapesSink(t *testing.T) {
 			// The sink instantly capacity-rejects; the retry loop records the
 			// failure and re-selects.
 			sinkPicks++
-			srv.noteInferenceError(sink.ID, pr, 503, rejectStr)
+			srv.noteInferenceError(sink.ID, pr, 503, rejectStr, "")
 			reg.SetProviderIdle(sink.ID)
 			continue
 		}

--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -306,7 +306,19 @@ func (s *Server) noteInferenceError(providerID string, pr *registry.PendingReque
 	if (statusCode == http.StatusTooManyRequests || statusCode == http.StatusNotFound ||
 		statusCode >= http.StatusInternalServerError) &&
 		isCapacityRejectStrike(errStr) {
-		if s.registry.RecordCapacityReject(providerID, pr.Model) {
+		// A cold "model not loaded" miss is benign warm-up lifecycle, not
+		// capacity dishonesty. It still feeds the black-hole cooldown (a box
+		// that 404s forever with zero accepts is a black hole), but it must NOT
+		// derate the pair's gray-box capacity-503 RATE (capacity_rate.go) — that
+		// window has no accept-reset, so counting a healthy box's normal reloads
+		// would penalize it. Genuine capacity/token-budget 503s derate.
+		var tripped bool
+		if isColdModelMissRejection(errStr) {
+			tripped = s.registry.RecordCapacityRejectLifecycle(providerID, pr.Model)
+		} else {
+			tripped = s.registry.RecordCapacityReject(providerID, pr.Model)
+		}
+		if tripped {
 			s.ddIncr(metricCapacityCooldownTripped, []string{"provider_id:" + providerID, "model:" + pr.Model})
 			s.logger.Warn("capacity-reject cooldown tripped: provider+model capacity-rejecting with zero interleaved accepts — routing will skip the pair until the cooldown expires",
 				"provider_id", providerID,

--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -311,11 +311,20 @@ func (s *Server) noteInferenceError(providerID string, pr *registry.PendingReque
 		// that 404s forever with zero accepts is a black hole), but it must NOT
 		// derate the pair's gray-box capacity-503 RATE (capacity_rate.go) — that
 		// window has no accept-reset, so counting a healthy box's normal reloads
-		// would penalize it. Genuine capacity/token-budget 503s derate.
+		// would penalize it. A "batch token budget" reject that classifyRejection
+		// proves REQUEST-deterministic (provider budget not below the model
+		// context ⇒ the binding term was the fleet-wide context) indicts the
+		// request, not the provider: it counts a cooldown strike only — arming
+		// the one-shot clamp or the no-reset rate window off a single oversized
+		// prompt would gate/derate a healthy pair. Genuine capacity/token-budget
+		// 503s feed everything.
 		var tripped bool
-		if isColdModelMissRejection(errStr) {
+		switch {
+		case isColdModelMissRejection(errStr):
 			tripped = s.registry.RecordCapacityRejectLifecycle(providerID, pr.Model)
-		} else {
+		case s.isRequestShapeBatchBudgetReject(providerID, pr.Model, errStr):
+			tripped = s.registry.RecordCapacityRejectRequestShape(providerID, pr.Model)
+		default:
 			tripped = s.registry.RecordCapacityReject(providerID, pr.Model)
 		}
 		if tripped {
@@ -336,6 +345,41 @@ func (s *Server) noteInferenceError(providerID string, pr *registry.PendingReque
 // inference-error breaker) and routing.provider_breaker_open (node health) so
 // black-hole trips are independently alertable.
 const metricCapacityCooldownTripped = "routing.capacity_cooldown_tripped"
+
+// isRequestShapeBatchBudgetReject reports whether a capacity-class rejection
+// is a "batch token budget" reject that classifyRejection proves REQUEST-
+// deterministic: the rejecting provider's reported token budget is not below
+// the model's context window, so the provider's admission cap
+// min(context, budget) was the CONTEXT — the prompt is too big fleet-wide and
+// every provider rejects it identically. Such a reject must arm neither the
+// one-shot budget clamp nor the no-reset capacity-503 rate window
+// (RecordCapacityRejectRequestShape). When the reported budget IS below the
+// context, the binding term may have been this node's memory-pressured KV
+// budget — a genuine provider-specific capacity signal — and the reject feeds
+// the full gray-box state (same discrimination the dispatch failover uses:
+// classifyRejection in inference_failure_class.go, DAR-347).
+//
+// Inputs mirror the dispatch path exactly: providerBudget from the provider's
+// last heartbeat (ReportedTokenBudgetMaxForModel), modelContext from the model
+// registry record. Called only inside the isCapacityRejectStrike branch, so
+// explicit context-overflow strings never reach it (they never strike at all).
+// The string gate keeps the two lookups off every other rejection.
+func (s *Server) isRequestShapeBatchBudgetReject(providerID, model, errStr string) bool {
+	e := strings.ToLower(strings.TrimSpace(errStr))
+	e = strings.ReplaceAll(e, "’", "'")
+	if !strings.Contains(e, "batch token budget") {
+		return false
+	}
+	var providerBudget int64
+	if p := s.registry.GetProvider(providerID); p != nil {
+		providerBudget = p.ReportedTokenBudgetMaxForModel(model)
+	}
+	modelContext := 0
+	if rec, err := s.store.GetModelRegistryRecord(model); err == nil && rec != nil {
+		modelContext = rec.MaxContextLength
+	}
+	return classifyRejection("", errStr, providerBudget, modelContext) == rejectionDeterministicUnservable
+}
 
 // noteInferenceSuccess clears the inference-error strike state for the serving
 // provider-model pair on a clean completion (streaming relay ended without a

--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -336,8 +336,12 @@ func (s *Server) noteInferenceSuccess(pr *registry.PendingRequest) {
 	// A clean completion is an ACCEPT for the capacity-reject cooldown: clear
 	// the pair's reject streak, any active capacity cooldown, and the re-trip
 	// backoff. Belt-and-braces with the commit-time accept (commitFirstContent)
-	// and the only accept signal on paths that never stream content.
-	s.registry.RecordCapacityAccept(pr.ProviderID, pr.Model)
+	// and the only accept signal on paths that never stream content. For the
+	// capacity-503 RATE window (capacity_rate.go) one served request must
+	// count exactly ONE outcome, so this completion-time accept only counts
+	// there when no commit-time accept already did (ContentCommittedSafe is
+	// stamped immediately before every commit-time RecordCapacityAccept).
+	s.registry.RecordCapacityAcceptOutcome(pr.ProviderID, pr.Model, !pr.ContentCommittedSafe())
 	// A clean completion proves the node is healthy — close its node-health
 	// breaker (and reset the exponential backoff) if it had tripped.
 	if _, closed := s.registry.RecordProviderOutcome(pr.ProviderID, true, 200, ""); closed {

--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -338,10 +338,16 @@ func (s *Server) noteInferenceSuccess(pr *registry.PendingRequest) {
 	// backoff. Belt-and-braces with the commit-time accept (commitFirstContent)
 	// and the only accept signal on paths that never stream content. For the
 	// capacity-503 RATE window (capacity_rate.go) one served request must
-	// count exactly ONE outcome, so this completion-time accept only counts
-	// there when no commit-time accept already did (ContentCommittedSafe is
-	// stamped immediately before every commit-time RecordCapacityAccept).
-	s.registry.RecordCapacityAcceptOutcome(pr.ProviderID, pr.Model, !pr.ContentCommittedSafe())
+	// count exactly ONE outcome, so this completion-time accept re-offers the
+	// outcome only when the commit-time accept did not actually RECORD one
+	// (RateOutcomeCountedSafe — stamped from RecordCapacityAccept's return at
+	// every commit site). Keying on the recorded outcome rather than on
+	// ContentCommittedSafe covers the stream that committed BEFORE the pair's
+	// first windowed reject (nothing recorded then — accepts only store while
+	// a reject is in-window) but was still serving during the rejects: it
+	// enters the denominator here instead of vanishing and letting a few
+	// later 503s overstate a healthy pair's reject rate.
+	s.registry.RecordCapacityAcceptOutcome(pr.ProviderID, pr.Model, !pr.RateOutcomeCountedSafe())
 	// A clean completion proves the node is healthy — close its node-health
 	// breaker (and reset the exponential backoff) if it had tripped.
 	if _, closed := s.registry.RecordProviderOutcome(pr.ProviderID, true, 200, ""); closed {
@@ -3751,7 +3757,9 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 			// generic path has no preamble filter, so this is the first chunk of
 			// ANY kind rather than strictly first content — fine as an accept
 			// signal: a black hole capacity-rejects, it never emits a chunk.)
-			s.registry.RecordCapacityAccept(provider.ID, pr.Model)
+			if s.registry.RecordCapacityAccept(provider.ID, pr.Model) {
+				pr.MarkRateOutcomeCounted()
+			}
 			committed = true
 		} else {
 			select {
@@ -3824,7 +3832,9 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 				// capacity-cooldown ACCEPT at first content for the same reason.
 				pr.MarkFirstContentArrived()
 				pr.MarkContentCommitted()
-				s.registry.RecordCapacityAccept(provider.ID, pr.Model)
+				if s.registry.RecordCapacityAccept(provider.ID, pr.Model) {
+					pr.MarkRateOutcomeCounted()
+				}
 				committed = true
 			} else {
 				select {

--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -258,8 +258,11 @@ func (s *Server) refundProviderExtra(pr *registry.PendingRequest) {
 //
 // It emits the cool-down metric on the inference-error transition and the
 // provider_breaker_open metric on the node-health transition into quarantine.
-// errStr is the provider's error message ("" for synthetic timeouts).
-func (s *Server) noteInferenceError(providerID string, pr *registry.PendingRequest, statusCode int, errStr string) {
+// errStr is the provider's error message and errReason its structured
+// InferenceErrorMessage.ErrorReason ("" for synthetic timeouts and legacy
+// providers) — the reason feeds the gray-box request-shape classification the
+// same way the dispatch failover trusts it (classifyRejection P1).
+func (s *Server) noteInferenceError(providerID string, pr *registry.PendingRequest, statusCode int, errStr, errReason string) {
 	if providerID == "" || pr == nil {
 		return
 	}
@@ -322,7 +325,7 @@ func (s *Server) noteInferenceError(providerID string, pr *registry.PendingReque
 		switch {
 		case isColdModelMissRejection(errStr):
 			tripped = s.registry.RecordCapacityRejectLifecycle(providerID, pr.Model)
-		case s.isRequestShapeBatchBudgetReject(providerID, pr.Model, errStr):
+		case s.isRequestShapeBatchBudgetReject(providerID, pr.Model, errStr, errReason):
 			tripped = s.registry.RecordCapacityRejectRequestShape(providerID, pr.Model)
 		default:
 			tripped = s.registry.RecordCapacityReject(providerID, pr.Model)
@@ -347,27 +350,33 @@ func (s *Server) noteInferenceError(providerID string, pr *registry.PendingReque
 const metricCapacityCooldownTripped = "routing.capacity_cooldown_tripped"
 
 // isRequestShapeBatchBudgetReject reports whether a capacity-class rejection
-// is a "batch token budget" reject that classifyRejection proves REQUEST-
-// deterministic: the rejecting provider's reported token budget is not below
-// the model's context window, so the provider's admission cap
-// min(context, budget) was the CONTEXT — the prompt is too big fleet-wide and
-// every provider rejects it identically. Such a reject must arm neither the
-// one-shot budget clamp nor the no-reset capacity-503 rate window
+// is PROVEN request-deterministic by classifyRejection: a "batch token budget"
+// reject from a provider whose reported token budget is not below the model's
+// context window (the admission cap min(context, budget) was the CONTEXT — the
+// prompt is too big fleet-wide), or an explicit request_exceeds_context
+// structured reason. Such a reject must arm neither the one-shot budget clamp
+// nor the no-reset capacity-503 rate window
 // (RecordCapacityRejectRequestShape). When the reported budget IS below the
 // context, the binding term may have been this node's memory-pressured KV
 // budget — a genuine provider-specific capacity signal — and the reject feeds
 // the full gray-box state (same discrimination the dispatch failover uses:
 // classifyRejection in inference_failure_class.go, DAR-347).
 //
-// Inputs mirror the dispatch path exactly: providerBudget from the provider's
-// last heartbeat (ReportedTokenBudgetMaxForModel), modelContext from the model
-// registry record. Called only inside the isCapacityRejectStrike branch, so
-// explicit context-overflow strings never reach it (they never strike at all).
-// The string gate keeps the two lookups off every other rejection.
-func (s *Server) isRequestShapeBatchBudgetReject(providerID, model, errStr string) bool {
+// Inputs mirror the dispatch path exactly: the structured errReason
+// (InferenceErrorMessage.ErrorReason — a provider that says
+// request_exceeds_node_budget / capacity_busy is TRUSTED over the stale
+// heartbeat-budget heuristic, so a stale snapshot that still reads >= context
+// cannot misroute a genuine node-capacity failure away from the gray-box
+// trackers), providerBudget from the provider's last heartbeat
+// (ReportedTokenBudgetMaxForModel), and modelContext from the model registry
+// record. Called only inside the isCapacityRejectStrike branch, so explicit
+// context-overflow STRINGS never reach it (they never strike at all). The
+// cheap gate keeps the two lookups off every other rejection.
+func (s *Server) isRequestShapeBatchBudgetReject(providerID, model, errStr, errReason string) bool {
 	e := strings.ToLower(strings.TrimSpace(errStr))
 	e = strings.ReplaceAll(e, "’", "'")
-	if !strings.Contains(e, "batch token budget") {
+	reason := strings.ToLower(strings.TrimSpace(errReason))
+	if !strings.Contains(e, "batch token budget") && reason != "request_exceeds_context" {
 		return false
 	}
 	var providerBudget int64
@@ -378,7 +387,7 @@ func (s *Server) isRequestShapeBatchBudgetReject(providerID, model, errStr strin
 	if rec, err := s.store.GetModelRegistryRecord(model); err == nil && rec != nil {
 		modelContext = rec.MaxContextLength
 	}
-	return classifyRejection("", errStr, providerBudget, modelContext) == rejectionDeterministicUnservable
+	return classifyRejection(errReason, errStr, providerBudget, modelContext) == rejectionDeterministicUnservable
 }
 
 // noteInferenceSuccess clears the inference-error strike state for the serving
@@ -436,9 +445,9 @@ func (s *Server) noteInferenceSuccess(pr *registry.PendingRequest) {
 // so arms where cancelDispatch did refund are safe, and a failed pre-commit
 // attempt never reaches settlement (its channels are closed and it is neither
 // pending nor parked), so this can never double-credit against a settle.
-func (s *Server) noteDispatchProviderError(provider *registry.Provider, pr *registry.PendingRequest, statusCode int, errStr string, held *[]string) (discardedHeld bool) {
+func (s *Server) noteDispatchProviderError(provider *registry.Provider, pr *registry.PendingRequest, statusCode int, errStr, errReason string, held *[]string) (discardedHeld bool) {
 	if provider != nil {
-		s.noteInferenceError(provider.ID, pr, statusCode, errStr)
+		s.noteInferenceError(provider.ID, pr, statusCode, errStr, errReason)
 	}
 	s.refundProviderExtra(pr)
 	if held == nil || len(*held) == 0 {
@@ -1657,7 +1666,7 @@ func (s *Server) handleStreamingResponseWithFirstChunk(w http.ResponseWriter, r 
 				case errMsg, ok := <-pr.ErrorCh:
 					if ok && errMsg.Error != "" {
 						s.refundReservedBalance(pr, "provider_error:"+pr.RequestID)
-						s.noteInferenceError(pr.ProviderID, pr, errMsg.StatusCode, errMsg.Error)
+						s.noteInferenceError(pr.ProviderID, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason)
 						s.ddIncr("inference.in_band_error", []string{"model:" + pr.Model, "reason:provider_error"})
 						s.updateInferenceRouteOutcomeForPending(pr, postCommitProviderErrorOutcome(pr, errMsg))
 						errData, _ := json.Marshal(map[string]any{
@@ -1801,7 +1810,7 @@ func (s *Server) handleStreamingResponseWithFirstChunk(w http.ResponseWriter, r 
 				continue
 			}
 			s.refundReservedBalance(pr, "provider_error:"+pr.RequestID)
-			s.noteInferenceError(pr.ProviderID, pr, errMsg.StatusCode, errMsg.Error)
+			s.noteInferenceError(pr.ProviderID, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason)
 			s.ddIncr("inference.in_band_error", []string{"model:" + pr.Model, "reason:provider_error"})
 			s.updateInferenceRouteOutcomeForPending(pr, postCommitProviderErrorOutcome(pr, errMsg))
 			errData, _ := json.Marshal(map[string]any{
@@ -1892,7 +1901,7 @@ func (s *Server) handleResponsesStreamingResponseWithFirstChunk(w http.ResponseW
 				continue
 			}
 			s.refundReservedBalance(pr, "provider_error:"+pr.RequestID)
-			s.noteInferenceError(pr.ProviderID, pr, errMsg.StatusCode, errMsg.Error)
+			s.noteInferenceError(pr.ProviderID, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason)
 			s.ddIncr("inference.in_band_error", []string{"model:" + pr.Model, "reason:provider_error"})
 			s.updateInferenceRouteOutcomeForPending(pr, postCommitProviderErrorOutcome(pr, errMsg))
 			emitter.emitError("provider_error", errMsg.Error)
@@ -1934,7 +1943,7 @@ func (s *Server) handleNonStreamingResponseWithFirstChunk(w http.ResponseWriter,
 				case errMsg, ok := <-pr.ErrorCh:
 					if ok && errMsg.Error != "" {
 						s.refundReservedBalance(pr, "provider_error:"+pr.RequestID)
-						s.noteInferenceError(pr.ProviderID, pr, errMsg.StatusCode, errMsg.Error)
+						s.noteInferenceError(pr.ProviderID, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason)
 						s.updateInferenceRouteOutcomeForPending(pr, preResponseProviderErrorOutcome(pr, errMsg))
 						statusCode := errMsg.StatusCode
 						if statusCode == 0 {
@@ -2064,7 +2073,7 @@ func (s *Server) handleNonStreamingResponseWithFirstChunk(w http.ResponseWriter,
 				continue
 			}
 			s.refundReservedBalance(pr, "provider_error:"+pr.RequestID)
-			s.noteInferenceError(pr.ProviderID, pr, errMsg.StatusCode, errMsg.Error)
+			s.noteInferenceError(pr.ProviderID, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason)
 			s.updateInferenceRouteOutcomeForPending(pr, preResponseProviderErrorOutcome(pr, errMsg))
 			statusCode := errMsg.StatusCode
 			if statusCode == 0 {
@@ -3825,7 +3834,7 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 				s.sendProviderCancel(provider, requestID)
 				refundExtra()
 				refundReservation()
-				s.noteInferenceError(provider.ID, pr, errMsg.StatusCode, errMsg.Error)
+				s.noteInferenceError(provider.ID, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason)
 				s.updateInferenceRouteOutcomeForPending(pr, preCommitProviderErrorOutcome(pr, errMsg))
 				statusCode := errMsg.StatusCode
 				if statusCode == 0 {
@@ -3844,7 +3853,7 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 		s.sendProviderCancel(provider, requestID)
 		refundExtra()
 		refundReservation()
-		s.noteInferenceError(provider.ID, pr, errMsg.StatusCode, errMsg.Error)
+		s.noteInferenceError(provider.ID, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason)
 		s.updateInferenceRouteOutcomeForPending(pr, preCommitProviderErrorOutcome(pr, errMsg))
 		statusCode := errMsg.StatusCode
 		if statusCode == 0 {
@@ -3900,7 +3909,7 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 					s.sendProviderCancel(provider, requestID)
 					refundExtra()
 					refundReservation()
-					s.noteInferenceError(provider.ID, pr, errMsg.StatusCode, errMsg.Error)
+					s.noteInferenceError(provider.ID, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason)
 					s.updateInferenceRouteOutcomeForPending(pr, preCommitProviderErrorOutcome(pr, errMsg))
 					statusCode := errMsg.StatusCode
 					if statusCode == 0 {
@@ -3919,7 +3928,7 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 			s.sendProviderCancel(provider, requestID)
 			refundExtra()
 			refundReservation()
-			s.noteInferenceError(provider.ID, pr, errMsg.StatusCode, errMsg.Error)
+			s.noteInferenceError(provider.ID, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason)
 			s.updateInferenceRouteOutcomeForPending(pr, preCommitProviderErrorOutcome(pr, errMsg))
 			statusCode := errMsg.StatusCode
 			if statusCode == 0 {
@@ -3937,7 +3946,7 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 			// breaker (single-attempt path: no retry here, but repeated
 			// stalls must still accumulate into the routing cooldown). No
 			// provider message on this synthetic timeout, so errStr is "".
-			s.noteInferenceError(provider.ID, pr, http.StatusGatewayTimeout, "")
+			s.noteInferenceError(provider.ID, pr, http.StatusGatewayTimeout, "", "")
 			s.ddIncr("inference.dispatches", []string{"status:timeout"})
 			s.updateInferenceRouteOutcomeForPending(pr, pendingRouteOutcome(pr, "timeout", "accepted_timeout", http.StatusGatewayTimeout))
 			writeJSON(w, http.StatusGatewayTimeout, errorResponse("timeout", "provider accepted but timed out before first chunk"))

--- a/coordinator/api/dispatch.go
+++ b/coordinator/api/dispatch.go
@@ -419,7 +419,13 @@ func (d *dispatchState) commitFirstContent(pr *registry.PendingRequest, chunk st
 	// legitimately sheds concurrent dispatches — waiting for the completion
 	// accept (noteInferenceSuccess) would let transient fullness masquerade as
 	// the zero-accepts black-hole signature. See registry/capacity_cooldown.go.
-	d.s.registry.RecordCapacityAccept(pr.ProviderID, pr.Model)
+	// The return says whether the pair's capacity-503 RATE window actually
+	// stored this accept (only while a reject is in-window) — stamp it so the
+	// completion-time accept knows whether the request still owes its one
+	// denominator outcome (noteInferenceSuccess).
+	if d.s.registry.RecordCapacityAccept(pr.ProviderID, pr.Model) {
+		pr.MarkRateOutcomeCounted()
+	}
 }
 
 // successRoutingOutcome builds a success outcome for the committed attempt.

--- a/coordinator/api/dispatch.go
+++ b/coordinator/api/dispatch.go
@@ -993,8 +993,8 @@ func (d *dispatchState) dispatchPrimary() dispatchOutcome {
 // provider error and, unless held boilerplate was discarded (which emits its own
 // pre-content failover counter), emits the generic retry counter. This is the
 // exact `if !s.noteDispatchProviderError(...) { s.ddIncr(retry) }` pattern.
-func (d *dispatchState) noteDispatchRetry(provider *registry.Provider, pr *registry.PendingRequest, statusCode int, errStr string, held *[]string) {
-	if !d.s.noteDispatchProviderError(provider, pr, statusCode, errStr, held) {
+func (d *dispatchState) noteDispatchRetry(provider *registry.Provider, pr *registry.PendingRequest, statusCode int, errStr, errReason string, held *[]string) {
+	if !d.s.noteDispatchProviderError(provider, pr, statusCode, errStr, errReason, held) {
 		d.s.ddIncr("inference.dispatches", []string{"status:retry"})
 	}
 }
@@ -1160,7 +1160,7 @@ func (d *dispatchState) waitFirstChunk() (outcome dispatchOutcome) {
 					s.cancelDispatch(provider, pr)
 					d.setLastInferenceError(provider, errMsg)
 					d.lastFailedVersion = failedProviderVersion(provider)
-					d.noteDispatchRetry(provider, pr, errMsg.StatusCode, errMsg.Error, &d.heldChunks)
+					d.noteDispatchRetry(provider, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason, &d.heldChunks)
 					d.provider = nil
 					d.pr = nil
 					return outcomeRetry
@@ -1202,7 +1202,7 @@ func (d *dispatchState) waitFirstChunk() (outcome dispatchOutcome) {
 			if s.metrics != nil {
 				s.metrics.IncCounter("inference_dispatches_total", MetricLabel{"result", "retry"})
 			}
-			d.noteDispatchRetry(provider, pr, errMsg.StatusCode, errMsg.Error, &d.heldChunks)
+			d.noteDispatchRetry(provider, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason, &d.heldChunks)
 			d.provider = nil
 			d.pr = nil
 			return outcomeRetry
@@ -1375,7 +1375,7 @@ func (d *dispatchState) waitNoBackup() dispatchOutcome {
 					s.cancelDispatch(provider, pr)
 					d.setLastInferenceError(provider, errMsg)
 					d.lastFailedVersion = failedProviderVersion(provider)
-					d.noteDispatchRetry(provider, pr, errMsg.StatusCode, errMsg.Error, &d.heldChunks)
+					d.noteDispatchRetry(provider, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason, &d.heldChunks)
 					d.provider = nil
 					d.pr = nil
 					return outcomeRetry
@@ -1397,7 +1397,7 @@ func (d *dispatchState) waitNoBackup() dispatchOutcome {
 			if s.metrics != nil {
 				s.metrics.IncCounter("inference_dispatches_total", MetricLabel{"result", "retry"})
 			}
-			d.noteDispatchRetry(provider, pr, errMsg.StatusCode, errMsg.Error, &d.heldChunks)
+			d.noteDispatchRetry(provider, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason, &d.heldChunks)
 			d.provider = nil
 			d.pr = nil
 			return outcomeRetry
@@ -1489,7 +1489,7 @@ func (d *dispatchState) runRace(backupProvider *registry.Provider, backupPR *reg
 					s.cancelDispatch(provider, pr)
 					d.setLastInferenceError(provider, errMsg)
 					d.lastFailedVersion = failedProviderVersion(provider)
-					d.noteDispatchRetry(provider, pr, errMsg.StatusCode, errMsg.Error, &d.heldChunks)
+					d.noteDispatchRetry(provider, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason, &d.heldChunks)
 					d.provider = nil
 					d.pr = nil
 					return outcomeRetry
@@ -1528,7 +1528,7 @@ func (d *dispatchState) runRace(backupProvider *registry.Provider, backupPR *reg
 					d.excludeProviders[backupProvider.ID] = struct{}{}
 					d.lastFailedVersion = failedProviderVersion(backupProvider)
 					d.updateSpeculativeFailure(backupPR, errMsg)
-					s.noteDispatchProviderError(backupProvider, backupPR, errMsg.StatusCode, errMsg.Error, &backupHeld)
+					s.noteDispatchProviderError(backupProvider, backupPR, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason, &backupHeld)
 					// Preserve a deterministic-unservable verdict from this loser so the
 					// surviving primary's error can't mask it (see latchDeterministicLoser).
 					d.latchDeterministicLoser(backupProvider, errMsg)
@@ -1576,7 +1576,7 @@ func (d *dispatchState) runRace(backupProvider *registry.Provider, backupPR *reg
 			s.cancelDispatch(provider, pr)
 			d.lastFailedVersion = failedProviderVersion(provider)
 			d.updateSpeculativeFailure(pr, errMsg)
-			s.noteDispatchProviderError(provider, pr, errMsg.StatusCode, errMsg.Error, &d.heldChunks)
+			s.noteDispatchProviderError(provider, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason, &d.heldChunks)
 			// Preserve a deterministic-unservable verdict from this loser so the
 			// surviving backup's error can't mask it (see latchDeterministicLoser).
 			d.latchDeterministicLoser(provider, errMsg)
@@ -1592,7 +1592,7 @@ func (d *dispatchState) runRace(backupProvider *registry.Provider, backupPR *reg
 			s.cancelDispatch(backupProvider, backupPR)
 			d.lastFailedVersion = failedProviderVersion(backupProvider)
 			d.updateSpeculativeFailure(backupPR, errMsg)
-			s.noteDispatchProviderError(backupProvider, backupPR, errMsg.StatusCode, errMsg.Error, &backupHeld)
+			s.noteDispatchProviderError(backupProvider, backupPR, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason, &backupHeld)
 			// Preserve a deterministic-unservable verdict from this loser so the
 			// surviving primary's error can't mask it (see latchDeterministicLoser).
 			d.latchDeterministicLoser(backupProvider, errMsg)
@@ -1616,10 +1616,10 @@ func (d *dispatchState) runRace(backupProvider *registry.Provider, backupPR *reg
 			// acceptedWait timeout path so a stalling provider/model
 			// (shape-keyed) trips its cooldown.
 			if len(d.heldChunks) > 0 {
-				s.noteInferenceError(provider.ID, pr, http.StatusGatewayTimeout, "")
+				s.noteInferenceError(provider.ID, pr, http.StatusGatewayTimeout, "", "")
 			}
 			if len(backupHeld) > 0 {
-				s.noteInferenceError(backupProvider.ID, backupPR, http.StatusGatewayTimeout, "")
+				s.noteInferenceError(backupProvider.ID, backupPR, http.StatusGatewayTimeout, "", "")
 			}
 			s.cancelDispatch(provider, pr)
 			s.registry.RecordWarmPoolTTFTMiss(d.model, d.deadline)
@@ -1675,7 +1675,7 @@ func (d *dispatchState) raceBackupChunkClosedWaitPrimary(provider *registry.Prov
 					d.setLastInferenceError(provider, errMsg2)
 					d.lastFailedVersion = failedProviderVersion(provider)
 					d.updateSpeculativeFailure(pr, errMsg2)
-					d.noteDispatchRetry(provider, pr, errMsg2.StatusCode, errMsg2.Error, &d.heldChunks)
+					d.noteDispatchRetry(provider, pr, errMsg2.StatusCode, errMsg2.Error, errMsg2.ErrorReason, &d.heldChunks)
 					d.provider = nil
 					d.pr = nil
 					d.requestID = ""
@@ -1700,7 +1700,7 @@ func (d *dispatchState) raceBackupChunkClosedWaitPrimary(provider *registry.Prov
 			d.setLastInferenceError(provider, errMsg2)
 			d.lastFailedVersion = failedProviderVersion(provider)
 			d.updateSpeculativeFailure(pr, errMsg2)
-			d.noteDispatchRetry(provider, pr, errMsg2.StatusCode, errMsg2.Error, &d.heldChunks)
+			d.noteDispatchRetry(provider, pr, errMsg2.StatusCode, errMsg2.Error, errMsg2.ErrorReason, &d.heldChunks)
 			d.provider = nil
 			d.pr = nil
 			d.requestID = ""
@@ -1772,7 +1772,7 @@ func (d *dispatchState) racePrimaryFailedWaitBackup(backupProvider *registry.Pro
 					d.setLastInferenceError(backupProvider, errMsg2)
 					d.lastFailedVersion = failedProviderVersion(backupProvider)
 					d.updateSpeculativeFailure(backupPR, errMsg2)
-					d.noteDispatchRetry(backupProvider, backupPR, errMsg2.StatusCode, errMsg2.Error, &backupHeld)
+					d.noteDispatchRetry(backupProvider, backupPR, errMsg2.StatusCode, errMsg2.Error, errMsg2.ErrorReason, &backupHeld)
 					d.provider = nil
 					d.pr = nil
 					return outcomeRetry
@@ -1802,7 +1802,7 @@ func (d *dispatchState) racePrimaryFailedWaitBackup(backupProvider *registry.Pro
 			d.setLastInferenceError(backupProvider, errMsg2)
 			d.lastFailedVersion = failedProviderVersion(backupProvider)
 			d.updateSpeculativeFailure(backupPR, errMsg2)
-			s.noteDispatchProviderError(backupProvider, backupPR, errMsg2.StatusCode, errMsg2.Error, &backupHeld)
+			s.noteDispatchProviderError(backupProvider, backupPR, errMsg2.StatusCode, errMsg2.Error, errMsg2.ErrorReason, &backupHeld)
 			d.provider = nil
 			d.pr = nil
 			return outcomeRetry
@@ -1867,7 +1867,7 @@ func (d *dispatchState) raceBackupErrWaitPrimary(provider *registry.Provider, pr
 					s.cancelDispatch(provider, pr)
 					d.setLastInferenceError(provider, errMsg2)
 					d.lastFailedVersion = failedProviderVersion(provider)
-					d.noteDispatchRetry(provider, pr, errMsg2.StatusCode, errMsg2.Error, &d.heldChunks)
+					d.noteDispatchRetry(provider, pr, errMsg2.StatusCode, errMsg2.Error, errMsg2.ErrorReason, &d.heldChunks)
 					d.provider = nil
 					d.pr = nil
 					return outcomeRetry
@@ -1887,7 +1887,7 @@ func (d *dispatchState) raceBackupErrWaitPrimary(provider *registry.Provider, pr
 			d.setLastInferenceError(provider, errMsg2)
 			d.lastFailedVersion = failedProviderVersion(provider)
 			d.updateSpeculativeFailure(pr, errMsg2)
-			s.noteDispatchProviderError(provider, pr, errMsg2.StatusCode, errMsg2.Error, &d.heldChunks)
+			s.noteDispatchProviderError(provider, pr, errMsg2.StatusCode, errMsg2.Error, errMsg2.ErrorReason, &d.heldChunks)
 			d.provider = nil
 			d.pr = nil
 			d.requestID = ""
@@ -2002,7 +2002,7 @@ func (d *dispatchState) waitAccepted() (outcome dispatchOutcome) {
 					if s.metrics != nil {
 						s.metrics.IncCounter("inference_dispatches_total", MetricLabel{"result", "retry"})
 					}
-					d.noteDispatchRetry(provider, pr, errMsg.StatusCode, errMsg.Error, &d.heldChunks)
+					d.noteDispatchRetry(provider, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason, &d.heldChunks)
 					d.provider = nil
 					d.pr = nil
 					return outcomeRetry
@@ -2034,7 +2034,7 @@ func (d *dispatchState) waitAccepted() (outcome dispatchOutcome) {
 			if s.metrics != nil {
 				s.metrics.IncCounter("inference_dispatches_total", MetricLabel{"result", "retry"})
 			}
-			d.noteDispatchRetry(provider, pr, errMsg.StatusCode, errMsg.Error, &d.heldChunks)
+			d.noteDispatchRetry(provider, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason, &d.heldChunks)
 			d.provider = nil
 			d.pr = nil
 			return outcomeRetry
@@ -2047,7 +2047,7 @@ func (d *dispatchState) waitAccepted() (outcome dispatchOutcome) {
 			// that repeatedly acks and stalls enters cooldown instead
 			// of soaking retries forever. (504 is one of the breaker's
 			// counted codes; this arm is where those 504s originate.)
-			s.noteInferenceError(provider.ID, pr, http.StatusGatewayTimeout, "")
+			s.noteInferenceError(provider.ID, pr, http.StatusGatewayTimeout, "", "")
 			d.setLastError("provider accepted but timed out before first chunk", http.StatusGatewayTimeout)
 			if d.preambleLiveness {
 				d.setLastError("provider sent preamble but stalled before first content", http.StatusGatewayTimeout)

--- a/coordinator/api/inference_failure_class.go
+++ b/coordinator/api/inference_failure_class.go
@@ -257,6 +257,25 @@ func isCapacityRejectStrike(errStr string) bool {
 	return true
 }
 
+// isColdModelMissRejection reports whether a capacity-class rejection is the
+// BENIGN cold "model not loaded" lifecycle miss (a lazy load on first touch),
+// as opposed to a genuine capacity/token-budget shed. Matching mirrors the
+// "not loaded" / "no model loaded" markers in capacityClassMarkers (substring,
+// case-insensitive, curly-apostrophe-normalised).
+//
+// A cold miss must still feed the black-hole cooldown (a box that 404s FOREVER
+// with zero accepts is a black hole — RecordCapacityRejectLifecycle keeps
+// feeding it) but must NOT derate the pair's gray-box capacity-503 RATE: that
+// window has no accept-reset, so counting a healthy box's normal reloads would
+// penalize it as if its reported budget were dishonest. Callers gate on this
+// AFTER isCapacityRejectStrike (a non-capacity "model not found" never reaches
+// here).
+func isColdModelMissRejection(errStr string) bool {
+	s := strings.ToLower(strings.TrimSpace(errStr))
+	s = strings.ReplaceAll(s, "’", "'")
+	return strings.Contains(s, "not loaded") || strings.Contains(s, "no model loaded")
+}
+
 // capacityClassMarkers are BUCKET A substrings: ADMITTED-but-unservable or
 // lifecycle rejections that should reclassify a provider 5xx to an uptime-neutral
 // 429. Drop a newly-observed capacity string here (predicates that need more than

--- a/coordinator/api/provider.go
+++ b/coordinator/api/provider.go
@@ -1590,6 +1590,19 @@ func (s *Server) handleComplete(providerID string, provider *registry.Provider, 
 	// unchanged.
 	if consumerGone {
 		s.emitClientGone(pr.Model, pr.EstimatedPromptTokens, providerChipFamily(provider), phaseAfterCommit)
+		// A parked (after-commit client-gone) completion is still a SERVED
+		// provider dispatch, so it owes its one capacity-503 rate-window outcome
+		// (capacity_rate.go denominator). On the clean-completion path
+		// noteInferenceSuccess re-offers it, but that never runs here — the
+		// consumer handler already returned. Re-offer it now, keyed on the
+		// recorded outcome exactly as noteInferenceSuccess does: a stream that
+		// committed BEFORE the pair's first windowed reject recorded nothing at
+		// commit (RateOutcomeCountedSafe=false), so without this it would vanish
+		// from the denominator and a few later 503s would overstate a healthy
+		// pair's reject rate. A commit that already recorded passes
+		// countRateOutcome=false and cannot double-count. Uses pr.ProviderID
+		// (the committed attempt's provider) to match the commit-time key.
+		s.registry.RecordCapacityAcceptOutcome(pr.ProviderID, pr.Model, !pr.RateOutcomeCountedSafe())
 	}
 
 	// Store SE signature for the consumer response headers.

--- a/coordinator/registry/budget_clamp.go
+++ b/coordinator/registry/budget_clamp.go
@@ -134,10 +134,11 @@ type budgetClampEntry struct {
 // recordBudgetClampLocked arms (or re-arms) the pair's budget clamp on a
 // capacity-shaped rejection. A re-reject is fresh evidence: the clamp window
 // restarts and the accept proof resets. budgetReported says whether the pair
-// currently reports a token budget; it is STICKY across re-arms (a re-reject
-// during a reconnect's budgetless window must not downgrade the identity's
-// demonstrated budget reporting). Caller holds the r.mu write lock (called
-// from RecordCapacityReject).
+// currently reports a token budget; it is STICKY across re-arms of a LIVE
+// clamp (a re-reject during a reconnect's budgetless window must not downgrade
+// the identity's demonstrated budget reporting) but is NOT inherited from a
+// TTL-expired entry — see the in-body comment. Caller holds the r.mu write
+// lock (called from RecordCapacityReject).
 func (r *Registry) recordBudgetClampLocked(key capacityRejectKey, budgetReported bool, now time.Time) {
 	if !r.budgetClampCfg.Enabled {
 		return
@@ -152,7 +153,15 @@ func (r *Registry) recordBudgetClampLocked(key capacityRejectKey, budgetReported
 			}
 		}
 	}
-	if prev, ok := r.budgetClamps[key]; ok {
+	// Sticky-or the demonstrated budget reporting from the PREVIOUS entry —
+	// but only while that entry is still inside its TTL. The sticky-or exists
+	// so a re-reject during a live clamp's budgetless reconnect window cannot
+	// downgrade the identity's demonstrated reporting; a TTL-EXPIRED entry is a
+	// clamp cycle that already failed open, and inheriting its budgetReported
+	// would let a later benign budgetless reject (cold "not loaded" miss,
+	// pre-heartbeat window) re-arm as stale-budget dishonesty and gate the pair
+	// for another TTL — exactly what the budgetless-armed exemption forbids.
+	if prev, ok := r.budgetClamps[key]; ok && now.Before(prev.clampedAt.Add(r.budgetClampCfg.TTL)) {
 		budgetReported = budgetReported || prev.budgetReported
 	}
 	r.budgetClamps[key] = &budgetClampEntry{clampedAt: now, budgetReported: budgetReported}

--- a/coordinator/registry/budget_clamp.go
+++ b/coordinator/registry/budget_clamp.go
@@ -118,13 +118,26 @@ type budgetClampEntry struct {
 	// acceptedSince records release condition (b): an accept landed for the
 	// pair after clampedAt.
 	acceptedSince bool
+	// budgetReported records whether the pair was REPORTING a token budget
+	// when the clamp armed (sticky across re-arms). It is what keeps the clamp
+	// holding through a budgetless window — a reconnected session has
+	// BackendCapacity == nil until its first heartbeat, and without this flag
+	// the snapshot's activeTokenBudgetMax == 0 would route the pair down the
+	// legacy memory-admission path and shed the clamp exactly when it must
+	// hold (a stable identity cannot drop a clamp by reconnecting). Pairs that
+	// NEVER reported a budget (legacy providers) keep budgetReported == false
+	// and keep their documented exemption: a single 503 cannot gate them.
+	budgetReported bool
 }
 
 // recordBudgetClampLocked arms (or re-arms) the pair's budget clamp on a
 // capacity-shaped rejection. A re-reject is fresh evidence: the clamp window
-// restarts and the accept proof resets. Caller holds the r.mu write lock
-// (called from RecordCapacityReject).
-func (r *Registry) recordBudgetClampLocked(key capacityRejectKey, now time.Time) {
+// restarts and the accept proof resets. budgetReported says whether the pair
+// currently reports a token budget; it is STICKY across re-arms (a re-reject
+// during a reconnect's budgetless window must not downgrade the identity's
+// demonstrated budget reporting). Caller holds the r.mu write lock (called
+// from RecordCapacityReject).
+func (r *Registry) recordBudgetClampLocked(key capacityRejectKey, budgetReported bool, now time.Time) {
 	if !r.budgetClampCfg.Enabled {
 		return
 	}
@@ -138,7 +151,35 @@ func (r *Registry) recordBudgetClampLocked(key capacityRejectKey, now time.Time)
 			}
 		}
 	}
-	r.budgetClamps[key] = &budgetClampEntry{clampedAt: now}
+	if prev, ok := r.budgetClamps[key]; ok {
+		budgetReported = budgetReported || prev.budgetReported
+	}
+	r.budgetClamps[key] = &budgetClampEntry{clampedAt: now, budgetReported: budgetReported}
+}
+
+// providerReportsTokenBudgetLocked reports whether the provider's CURRENT
+// backend snapshot carries a token budget for the model (the arming-time input
+// to budgetClampEntry.budgetReported). A missing provider (the reject often
+// races the disconnect that caused it) or a missing/budgetless slot reads
+// false — the sticky-or in recordBudgetClampLocked keeps an identity's
+// demonstrated reporting from being downgraded by such a race. Caller holds
+// r.mu (either mode); takes p.mu internally (r.mu → p.mu lock order).
+func (r *Registry) providerReportsTokenBudgetLocked(providerID, modelID string) bool {
+	p := r.providers[providerID]
+	if p == nil {
+		return false
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.BackendCapacity == nil {
+		return false
+	}
+	for _, slot := range p.BackendCapacity.Slots {
+		if slot.Model == modelID {
+			return slot.ActiveTokenBudgetMax > 0
+		}
+	}
+	return false
 }
 
 // noteBudgetClampAcceptLocked records release condition (b): the pair accepted
@@ -159,12 +200,20 @@ func (r *Registry) noteBudgetClampAcceptLocked(key capacityRejectKey) {
 // heartbeatAt is when the provider's CURRENT BackendCapacity was delivered
 // (p.LastHeartbeat — Heartbeat overwrites BackendCapacity and stamps
 // LastHeartbeat in the same critical section). rawBudgetRemaining is the
-// pair's live raw headroom from that snapshot (max - used - queued, unclamped).
-// The clamp holds while:
+// pair's live raw headroom from that snapshot (max - used - queued, unclamped)
+// and budgetReported says whether the snapshot carries a budget for the pair
+// at all (activeTokenBudgetMax > 0). The clamp holds while:
 //   - the entry exists and is inside its TTL (fail-open bound), and
 //   - release has not been proven: acceptedSince (condition b) AND a heartbeat
 //     strictly after the clamp showing meaningful headroom (condition a).
-func (r *Registry) budgetClampActiveLocked(providerID, modelID string, heartbeatAt time.Time, rawBudgetRemaining int64, now time.Time) bool {
+//
+// A budgetless snapshot (reconnect before the first heartbeat, or the model's
+// slot missing from the current capacity report) can never satisfy condition
+// (a), so a pair clamped while budget-reporting KEEPS holding through it —
+// reconnecting must not shed the clamp onto the legacy memory-admission path
+// (the stable fault key exists precisely so it can't). Pairs armed while
+// budgetless (entry.budgetReported == false: legacy providers) never hold.
+func (r *Registry) budgetClampActiveLocked(providerID, modelID string, heartbeatAt time.Time, rawBudgetRemaining int64, budgetReported bool, now time.Time) bool {
 	if !r.budgetClampCfg.Enabled {
 		return false
 	}
@@ -174,6 +223,11 @@ func (r *Registry) budgetClampActiveLocked(providerID, modelID string, heartbeat
 	}
 	if !now.Before(e.clampedAt.Add(r.budgetClampCfg.TTL)) {
 		return false // TTL lapsed: fail open (a re-reject re-arms)
+	}
+	if !budgetReported {
+		// No live budget snapshot to judge release against: hold iff the pair
+		// was budget-reporting when clamped (legacy pairs stay exempt).
+		return e.budgetReported
 	}
 	released := e.acceptedSince &&
 		heartbeatAt.After(e.clampedAt) &&
@@ -194,14 +248,16 @@ func (r *Registry) BudgetClampActive(providerID, modelID string) bool {
 	p.mu.Lock()
 	heartbeatAt := p.LastHeartbeat
 	var rawRemaining int64
+	var budgetReported bool
 	if p.BackendCapacity != nil {
 		for _, slot := range p.BackendCapacity.Slots {
 			if slot.Model == modelID {
 				rawRemaining = slot.ActiveTokenBudgetMax - slot.ActiveTokenBudgetUsed - slot.QueuedTokenBudget
+				budgetReported = slot.ActiveTokenBudgetMax > 0
 				break
 			}
 		}
 	}
 	p.mu.Unlock()
-	return r.budgetClampActiveLocked(providerID, modelID, heartbeatAt, rawRemaining, time.Now())
+	return r.budgetClampActiveLocked(providerID, modelID, heartbeatAt, rawRemaining, budgetReported, time.Now())
 }

--- a/coordinator/registry/budget_clamp.go
+++ b/coordinator/registry/budget_clamp.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/eigeninference/d-inference/coordinator/env"
+	"github.com/eigeninference/d-inference/coordinator/protocol"
 )
 
 // Budget clamp on capacity-shaped provider 503s — the fast, surgical half of
@@ -256,20 +257,20 @@ func (r *Registry) budgetClampActiveLocked(providerID, modelID string, heartbeat
 	return !released
 }
 
-// BudgetClampActive reports whether the (provider, model) pair's token budget
-// is currently clamped for admission. Exposed for tests and observability; the
-// routing hot path uses budgetClampActiveLocked under the already-held r.mu.
-func (r *Registry) BudgetClampActive(providerID, modelID string) bool {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
+// providerBudgetSnapshotLocked reads the pair's live budget snapshot — the
+// heartbeat freshness anchor, the raw headroom (max - used - queued,
+// unclamped), and whether the current capacity report carries a budget for the
+// model at all. A missing provider or a missing/budgetless slot reads
+// zero/false. Caller holds r.mu (either mode); takes p.mu internally
+// (r.mu → p.mu lock order).
+func (r *Registry) providerBudgetSnapshotLocked(providerID, modelID string) (heartbeatAt time.Time, rawRemaining int64, budgetReported bool) {
 	p := r.providers[providerID]
 	if p == nil {
-		return false
+		return time.Time{}, 0, false
 	}
 	p.mu.Lock()
-	heartbeatAt := p.LastHeartbeat
-	var rawRemaining int64
-	var budgetReported bool
+	defer p.mu.Unlock()
+	heartbeatAt = p.LastHeartbeat
 	if p.BackendCapacity != nil {
 		for _, slot := range p.BackendCapacity.Slots {
 			if slot.Model == modelID {
@@ -279,6 +280,107 @@ func (r *Registry) BudgetClampActive(providerID, modelID string) bool {
 			}
 		}
 	}
-	p.mu.Unlock()
+	return heartbeatAt, rawRemaining, budgetReported
+}
+
+// dropInactiveBudgetClampLocked deletes the pair's clamp entry when it can no
+// longer gate admission, so the entry's lifecycle matches its effect:
+//   - armed budgetless (entry.budgetReported == false: the exemption means it
+//     NEVER gates, so keeping it only costs the accept fast path);
+//   - TTL lapsed (fail-open — a re-reject re-arms fresh anyway);
+//   - fully released (accept proof AND a strictly-fresher heartbeat with
+//     meaningful headroom, evaluated against the provider's live snapshot).
+//
+// Deleting on release matters twice over: a lingering released entry (a) keeps
+// pulling every subsequent RecordCapacityAccept for the pair onto the r.mu
+// write lock (the fast-path gate keys on map presence), and (b) revives as a
+// block on the identity's next reconnect — the budgetless pre-heartbeat hold
+// branch treats an unreleased-looking entry as an active clamp, re-blocking a
+// pair that already proved recovery. A deleted entry re-arms from scratch on
+// the next reject, with budgetReported re-read at arm time. Called from the
+// accept path (RecordCapacityAcceptOutcome); the heartbeat release sweep uses
+// the snapshot variant below. Caller holds the r.mu WRITE lock.
+func (r *Registry) dropInactiveBudgetClampLocked(providerID, modelID string, now time.Time) {
+	heartbeatAt, rawRemaining, budgetReported := r.providerBudgetSnapshotLocked(providerID, modelID)
+	r.dropInactiveBudgetClampSnapshotLocked(providerID, modelID, heartbeatAt, rawRemaining, budgetReported, now)
+}
+
+// dropInactiveBudgetClampSnapshotLocked is dropInactiveBudgetClampLocked with
+// the budget snapshot supplied by the caller instead of re-read from
+// r.providers. The heartbeat release sweep passes the just-delivered
+// heartbeat's OWN stamped time and slot values, so the release proof cannot be
+// voided by a disconnect racing in between the heartbeat stamping the provider
+// and the sweep running — a re-read would find no provider, skip the delete,
+// and let the released entry re-block the identity's next reconnect. Caller
+// holds the r.mu WRITE lock.
+func (r *Registry) dropInactiveBudgetClampSnapshotLocked(providerID, modelID string, heartbeatAt time.Time, rawRemaining int64, budgetReported bool, now time.Time) {
+	key := capacityRejectKey{ProviderID: r.faultKeyLocked(providerID), ModelID: modelID}
+	e, ok := r.budgetClamps[key]
+	if !ok {
+		return
+	}
+	if !e.budgetReported || !now.Before(e.clampedAt.Add(r.budgetClampCfg.TTL)) {
+		delete(r.budgetClamps, key)
+		return
+	}
+	if !e.acceptedSince {
+		return
+	}
+	if budgetReported &&
+		heartbeatAt.After(e.clampedAt) &&
+		rawRemaining >= budgetClampReleaseMinHeadroomTokens {
+		delete(r.budgetClamps, key)
+	}
+}
+
+// releaseBudgetClampsOnHeartbeat drops any clamp entries for the provider's
+// heartbeat-reported models that the just-stamped capacity snapshot proves
+// inactive (released / TTL-expired / budgetless-armed). Called from Heartbeat
+// AFTER BackendCapacity and LastHeartbeat are written, so the
+// accept-then-heartbeat release order cleans up even when the pair gets no
+// further traffic — otherwise the released entry would linger and re-block the
+// identity's next reconnect before its first heartbeat.
+//
+// heartbeatAt and capacity are the heartbeat's OWN stamped time and (clamped)
+// report, evaluated directly rather than re-read from r.providers, so a
+// disconnect racing in after the heartbeat cannot void this heartbeat's
+// release proof. The common case (no clamp state for the provider) is a
+// read-locked probe with one map lookup per reported slot; the write lock is
+// taken only when an entry actually exists.
+func (r *Registry) releaseBudgetClampsOnHeartbeat(providerID string, heartbeatAt time.Time, capacity *protocol.BackendCapacity) {
+	if !r.budgetClampCfg.Enabled || capacity == nil || len(capacity.Slots) == 0 {
+		return
+	}
+	r.mu.RLock()
+	faultKey := r.faultKeyLocked(providerID)
+	var found []protocol.BackendSlotCapacity
+	for _, slot := range capacity.Slots {
+		if _, ok := r.budgetClamps[capacityRejectKey{ProviderID: faultKey, ModelID: slot.Model}]; ok {
+			found = append(found, slot)
+		}
+	}
+	r.mu.RUnlock()
+	if len(found) == 0 {
+		return
+	}
+	r.mu.Lock()
+	now := time.Now()
+	for _, slot := range found {
+		rawRemaining := slot.ActiveTokenBudgetMax - slot.ActiveTokenBudgetUsed - slot.QueuedTokenBudget
+		r.dropInactiveBudgetClampSnapshotLocked(providerID, slot.Model, heartbeatAt, rawRemaining, slot.ActiveTokenBudgetMax > 0, now)
+	}
+	r.mu.Unlock()
+}
+
+// BudgetClampActive reports whether the (provider, model) pair's token budget
+// is currently clamped for admission. Exposed for tests and observability; the
+// routing hot path uses budgetClampActiveLocked under the already-held r.mu.
+func (r *Registry) BudgetClampActive(providerID, modelID string) bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if r.providers[providerID] == nil {
+		return false
+	}
+	heartbeatAt, rawRemaining, budgetReported := r.providerBudgetSnapshotLocked(providerID, modelID)
 	return r.budgetClampActiveLocked(providerID, modelID, heartbeatAt, rawRemaining, budgetReported, time.Now())
 }

--- a/coordinator/registry/budget_clamp.go
+++ b/coordinator/registry/budget_clamp.go
@@ -212,7 +212,11 @@ func (r *Registry) noteBudgetClampAcceptLocked(key capacityRejectKey) {
 // (a), so a pair clamped while budget-reporting KEEPS holding through it —
 // reconnecting must not shed the clamp onto the legacy memory-admission path
 // (the stable fault key exists precisely so it can't). Pairs armed while
-// budgetless (entry.budgetReported == false: legacy providers) never hold.
+// budgetless (entry.budgetReported == false: legacy providers, cold "not
+// loaded" misses, a first dispatch before the first heartbeat) NEVER hold —
+// not even once a later heartbeat starts reporting a budget, since no dispatch
+// could get through the clamp to produce the accept proof (the reject was
+// never a stale-budget lie to begin with).
 func (r *Registry) budgetClampActiveLocked(providerID, modelID string, heartbeatAt time.Time, rawBudgetRemaining int64, budgetReported bool, now time.Time) bool {
 	if !r.budgetClampCfg.Enabled {
 		return false
@@ -224,10 +228,27 @@ func (r *Registry) budgetClampActiveLocked(providerID, modelID string, heartbeat
 	if !now.Before(e.clampedAt.Add(r.budgetClampCfg.TTL)) {
 		return false // TTL lapsed: fail open (a re-reject re-arms)
 	}
+	if !e.budgetReported {
+		// Armed while the pair reported NO token budget: a legacy provider, a
+		// cold "model not loaded" miss, or a first dispatch before the first
+		// capacity heartbeat. The clamp exists to override a STALE BUDGET, and a
+		// budgetless reject is not a stale-budget lie — it must never gate.
+		// Crucially, this must hold even after a LATER heartbeat starts
+		// reporting a budget (the budgeted release branch below would otherwise
+		// find acceptedSince=false and gate until TTL): the clamp would block
+		// dispatch, so no accept could ever land to prove release, stranding the
+		// warmed-up pair. A subsequent genuine reject while budget-reporting
+		// re-arms with budgetReported=true (sticky-or in recordBudgetClampLocked)
+		// and THAT gates.
+		return false
+	}
 	if !budgetReported {
-		// No live budget snapshot to judge release against: hold iff the pair
-		// was budget-reporting when clamped (legacy pairs stay exempt).
-		return e.budgetReported
+		// Armed while budget-reporting, but the current snapshot carries no
+		// budget (reconnect before the first heartbeat, or the model's slot
+		// missing from the live report): hold — reconnecting must not shed the
+		// clamp onto the legacy memory-admission path (the stable fault key
+		// exists precisely so it can't).
+		return true
 	}
 	released := e.acceptedSince &&
 		heartbeatAt.After(e.clampedAt) &&

--- a/coordinator/registry/budget_clamp.go
+++ b/coordinator/registry/budget_clamp.go
@@ -1,0 +1,207 @@
+package registry
+
+import (
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/env"
+)
+
+// Budget clamp on capacity-shaped provider 503s — the fast, surgical half of
+// the "gray box" fix.
+//
+// Prod gap (2026-07, gemma-4-26b-qat-4bit on mixed boxes co-resident with
+// gpt-oss-20b, DEDICATED_MODELS off): 11,581 provider 503s of the
+// capacity/token-budget shape in 6h from boxes whose heartbeats looked nearly
+// idle — active_token_budget_used ~72k of active_token_budget_max ~5.2M
+// (~1.4%) at ADMIT time. The heartbeat budget is stale-OPTIMISTIC: the
+// provider's live KV gate shrinks with real MLX memory pressure between
+// heartbeats and accounts for co-resident engines, so it rejects requests the
+// last-reported budget says fit. Because the boxes still served ~60% of
+// dispatches, every existing breaker was blind by design: the pair
+// capacity-cooldown (capacity_cooldown.go) and the node capacity streak
+// (health_ejection.go) both require ZERO interleaved accepts, and each accept
+// reset them. The scheduler kept believing the stale budget and kept
+// dispatching.
+//
+// THE CLAMP: the moment the api layer classifies a provider error as a
+// capacity/token-budget rejection for a (provider, model) pair
+// (RecordCapacityReject — the same entry point that feeds the cooldown), the
+// registry stops believing the pair's heartbeat budget: admission treats the
+// slot as FULL (freeMemoryAdmits' budget branch rejects, providerBudgetFits
+// reports zero live headroom), so the pair immediately stops attracting new
+// dispatches. One 503 is enough — the provider itself just told us its live
+// gate is rejecting, which is strictly fresher evidence than any heartbeat.
+//
+// RELEASE requires provider-side proof, not just the next optimistic
+// heartbeat. BOTH must hold (so release lands at whichever comes later):
+//
+//	(a) a heartbeat DELIVERED STRICTLY AFTER the clamp whose budget snapshot
+//	    shows meaningful headroom (raw max - used - queued >=
+//	    budgetClampReleaseMinHeadroomTokens) — the provider re-stated its
+//	    budget knowing about the rejection-time pressure; and
+//	(b) an accept (RecordCapacityAccept: first content chunk or clean
+//	    completion) landed for the pair AFTER the clamp — the pair proved it
+//	    is actually serving work. In-flight requests dispatched before the
+//	    clamp keep producing accepts, so a healthy-but-momentarily-full box
+//	    releases within roughly one heartbeat interval.
+//
+// FAIL OPEN: a clamp expires after budgetClampTTL (default 5 min) no matter
+// what, so a missed release path (e.g. a pair that gets zero traffic and
+// therefore zero accepts) can never strand a slot forever. A re-reject after
+// release or expiry simply re-arms the clamp — a persistent gray box costs
+// ~one bounced request per release cycle, and the capacity-rate penalty
+// (capacity_rate.go) keeps it deprioritized in between.
+//
+// SCOPE: the clamp only gates slots that REPORT a token budget
+// (active_token_budget_max > 0) — it exists to override a stale budget, and
+// its release condition is budget-defined. Legacy providers without budget
+// telemetry keep the existing protections (pair cooldown at threshold 5,
+// node-level streaks) and are never clamped, so a single 503 cannot gate them.
+//
+// Keyed by the STABLE fault identity (faultKeyLocked: serial → SE-key →
+// account → session fallback) like every sibling breaker, so a reconnect
+// cannot shed the clamp; migrated on identity rebind (migrateFaultStateLocked)
+// and deliberately NOT cleared by Disconnect. Map is bounded by the same
+// opportunistic >1024 sweep as the sibling cooldown maps. All state is guarded
+// by r.mu; the routing-path reads happen under r.mu held in either mode.
+const (
+	// envBudgetClamp is the kill switch. Default ON; set to false/0 to restore
+	// pre-clamp behavior (stale-heartbeat admission).
+	envBudgetClamp = "EIGENINFERENCE_BUDGET_CLAMP"
+	// envBudgetClampTTLSecs caps how long a clamp can hold without release —
+	// the fail-open bound. Default 300s.
+	envBudgetClampTTLSecs = "EIGENINFERENCE_BUDGET_CLAMP_TTL_SECONDS"
+)
+
+const (
+	defaultBudgetClampTTL = 5 * time.Minute
+	// budgetClampReleaseMinHeadroomTokens is the "meaningful headroom" floor a
+	// post-clamp heartbeat must show before release condition (a) holds. 1024
+	// mirrors the provider's own token-budget floor (BatchScheduler+Telemetry:
+	// tokenBudgetMax floored at 1024): a pressured box reports max ≈ used +
+	// (little), so requiring at least the provider's own minimum serving
+	// budget of free room filters heartbeats that merely restate the pressure.
+	budgetClampReleaseMinHeadroomTokens = 1024
+)
+
+// budgetClampConfig carries the env-tunable clamp parameters, read once at
+// Registry construction (coordinator restart applies changes), mirroring
+// capacityCooldownConfig.
+type budgetClampConfig struct {
+	// Enabled is the kill switch (EIGENINFERENCE_BUDGET_CLAMP, default true).
+	Enabled bool
+	// TTL is the fail-open bound: a clamp never outlives clampedAt+TTL.
+	TTL time.Duration
+}
+
+// loadBudgetClampConfig reads the EIGENINFERENCE_BUDGET_CLAMP* env tunables,
+// clamping nonsensical values back to the defaults.
+func loadBudgetClampConfig() budgetClampConfig {
+	cfg := budgetClampConfig{
+		Enabled: env.EnvBool(envBudgetClamp, true),
+		TTL:     time.Duration(env.EnvInt(envBudgetClampTTLSecs, int(defaultBudgetClampTTL/time.Second))) * time.Second,
+	}
+	if cfg.TTL <= 0 {
+		cfg.TTL = defaultBudgetClampTTL
+	}
+	return cfg
+}
+
+// budgetClampEntry is one pair's active (or released/expired-awaiting-sweep)
+// clamp. Written ONLY under the r.mu write lock (armed/re-armed in
+// RecordCapacityReject, accept flag in RecordCapacityAccept); routing paths
+// read it under r.mu in either mode.
+type budgetClampEntry struct {
+	// clampedAt is when the capacity-503 landed — the freshness reference for
+	// release condition (a) and the TTL anchor.
+	clampedAt time.Time
+	// acceptedSince records release condition (b): an accept landed for the
+	// pair after clampedAt.
+	acceptedSince bool
+}
+
+// recordBudgetClampLocked arms (or re-arms) the pair's budget clamp on a
+// capacity-shaped rejection. A re-reject is fresh evidence: the clamp window
+// restarts and the accept proof resets. Caller holds the r.mu write lock
+// (called from RecordCapacityReject).
+func (r *Registry) recordBudgetClampLocked(key capacityRejectKey, now time.Time) {
+	if !r.budgetClampCfg.Enabled {
+		return
+	}
+	// Opportunistic sweep (mirrors the sibling cooldown maps): session-keyed
+	// entries for churned identities are never re-keyed, so bound the map by
+	// dropping TTL-expired clamps once it grows.
+	if len(r.budgetClamps) > 1024 {
+		for k, e := range r.budgetClamps {
+			if !now.Before(e.clampedAt.Add(r.budgetClampCfg.TTL)) {
+				delete(r.budgetClamps, k)
+			}
+		}
+	}
+	r.budgetClamps[key] = &budgetClampEntry{clampedAt: now}
+}
+
+// noteBudgetClampAcceptLocked records release condition (b): the pair accepted
+// work after the clamp. The entry is kept (not deleted) — release also needs a
+// strictly-fresher heartbeat with meaningful headroom, which the routing-path
+// read evaluates against the provider's live budget fields. Caller holds the
+// r.mu write lock (called from RecordCapacityAccept).
+func (r *Registry) noteBudgetClampAcceptLocked(key capacityRejectKey) {
+	if e, ok := r.budgetClamps[key]; ok {
+		e.acceptedSince = true
+	}
+}
+
+// budgetClampActiveLocked reports whether admission must treat the pair's slot
+// as FULL right now. READ-ONLY (no lazy delete) — routing paths call it under
+// r.mu held in either mode, mirroring capacityCooldownActiveLocked.
+//
+// heartbeatAt is when the provider's CURRENT BackendCapacity was delivered
+// (p.LastHeartbeat — Heartbeat overwrites BackendCapacity and stamps
+// LastHeartbeat in the same critical section). rawBudgetRemaining is the
+// pair's live raw headroom from that snapshot (max - used - queued, unclamped).
+// The clamp holds while:
+//   - the entry exists and is inside its TTL (fail-open bound), and
+//   - release has not been proven: acceptedSince (condition b) AND a heartbeat
+//     strictly after the clamp showing meaningful headroom (condition a).
+func (r *Registry) budgetClampActiveLocked(providerID, modelID string, heartbeatAt time.Time, rawBudgetRemaining int64, now time.Time) bool {
+	if !r.budgetClampCfg.Enabled {
+		return false
+	}
+	e, ok := r.budgetClamps[capacityRejectKey{ProviderID: r.faultKeyLocked(providerID), ModelID: modelID}]
+	if !ok {
+		return false
+	}
+	if !now.Before(e.clampedAt.Add(r.budgetClampCfg.TTL)) {
+		return false // TTL lapsed: fail open (a re-reject re-arms)
+	}
+	released := e.acceptedSince &&
+		heartbeatAt.After(e.clampedAt) &&
+		rawBudgetRemaining >= budgetClampReleaseMinHeadroomTokens
+	return !released
+}
+
+// BudgetClampActive reports whether the (provider, model) pair's token budget
+// is currently clamped for admission. Exposed for tests and observability; the
+// routing hot path uses budgetClampActiveLocked under the already-held r.mu.
+func (r *Registry) BudgetClampActive(providerID, modelID string) bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	p := r.providers[providerID]
+	if p == nil {
+		return false
+	}
+	p.mu.Lock()
+	heartbeatAt := p.LastHeartbeat
+	var rawRemaining int64
+	if p.BackendCapacity != nil {
+		for _, slot := range p.BackendCapacity.Slots {
+			if slot.Model == modelID {
+				rawRemaining = slot.ActiveTokenBudgetMax - slot.ActiveTokenBudgetUsed - slot.QueuedTokenBudget
+				break
+			}
+		}
+	}
+	p.mu.Unlock()
+	return r.budgetClampActiveLocked(providerID, modelID, heartbeatAt, rawRemaining, time.Now())
+}

--- a/coordinator/registry/budget_clamp_test.go
+++ b/coordinator/registry/budget_clamp_test.go
@@ -560,9 +560,12 @@ func TestBudgetClampInactiveEntriesAreDeleted(t *testing.T) {
 	t.Run("budgetless-armed entry dropped on the next accept", func(t *testing.T) {
 		r := New(testLogger())
 		p := makeSchedulerProvider(t, r, "budgetless-drop", model, 100) // no token budget
-		r.RecordCapacityRejectLifecycle(p.ID, model)
+		// A generic capacity reject during a budgetless window arms a
+		// never-gating entry (lifecycle misses no longer touch the clamp at
+		// all — see RecordCapacityRejectLifecycle).
+		r.RecordCapacityReject(p.ID, model)
 		if !clampEntryExists(r, p.ID) {
-			t.Fatal("setup: lifecycle reject must have armed a (never-gating) entry")
+			t.Fatal("setup: budgetless reject must have armed a (never-gating) entry")
 		}
 		r.RecordCapacityAccept(p.ID, model)
 		if clampEntryExists(r, p.ID) {
@@ -590,6 +593,81 @@ func TestBudgetClampInactiveEntriesAreDeleted(t *testing.T) {
 			t.Fatal("fully released clamp entry must be deleted so the pair returns to the accept fast path")
 		}
 	})
+}
+
+// A TTL-EXPIRED clamp entry must not donate its budgetReported state to a
+// later budgetless re-arm (Codex review of #523, round 4): the expired cycle
+// already failed open, and inheriting its sticky bit would turn a benign
+// budgetless reject (cold "not loaded" miss, pre-heartbeat window) into a
+// budget-armed clamp that gates for another TTL — exactly what the
+// budgetless-armed exemption forbids.
+func TestBudgetClampExpiredEntryDoesNotDonateBudgetState(t *testing.T) {
+	r := New(testLogger())
+	const model = "gemma-4-26b-qat-4bit"
+	p := makeTokenBudgetProvider(t, r, "expired-donor", model, 100, grayBoxBudgetUsed, grayBoxBudgetMax, 100)
+
+	// Budget-reporting clamp arms, then only TTL-fails open (no accept, no
+	// heartbeat — the entry lingers).
+	r.RecordCapacityReject(p.ID, model)
+	ageBudgetClamp(r, p.ID, model, defaultBudgetClampTTL+time.Second)
+	if r.BudgetClampActive(p.ID, model) {
+		t.Fatal("setup: expired clamp must have failed open")
+	}
+
+	// The pair enters a budgetless window (pre-heartbeat / unload) and a
+	// benign reject re-arms. The fresh arm must read the CURRENT budgetless
+	// state, not inherit budgetReported=true from the expired cycle.
+	p.mu.Lock()
+	p.BackendCapacity = nil
+	p.mu.Unlock()
+	r.RecordCapacityReject(p.ID, model)
+	if r.BudgetClampActive(p.ID, model) {
+		t.Fatal("budgetless re-arm inherited budgetReported from the TTL-expired entry and gated the pair")
+	}
+	if sel, _ := reserveOnce(r, model, "post-expiry-budgetless"); sel == nil {
+		t.Fatal("a budgetless reject after an expired clamp cycle must not block admission")
+	}
+}
+
+// A lifecycle cold-404 miss must not touch the budget clamp EVEN when the
+// stale heartbeat snapshot still reports the slot's budget (Codex review of
+// #523, round 4): a provider that idle-unloads the model after its last
+// heartbeat (the normal 1h idle-unload + lazy-reload fleet cycle) still SHOWS
+// budget in the snapshot, so an exemption keyed on snapshot budgetless-ness
+// arms a real gating clamp from a routine re-warm 404 — and with the clamp
+// blocking dispatch, no accept can prove release until TTL. The forever-404
+// black hole stays covered by the zero-accept cooldown.
+func TestBudgetClampLifecycleMissWithStaleBudgetSnapshotDoesNotClamp(t *testing.T) {
+	r := New(testLogger())
+	const model = "gemma-4-26b-qat-4bit"
+	// Stale snapshot: the slot still reports a healthy budget even though the
+	// model was idle-unloaded (which is why the 404 happened).
+	p := makeTokenBudgetProvider(t, r, "rewarm-box", model, 100, grayBoxBudgetUsed, grayBoxBudgetMax, 100)
+
+	r.RecordCapacityRejectLifecycle(p.ID, model)
+	if r.BudgetClampActive(p.ID, model) {
+		t.Fatal("a lifecycle cold-404 must not arm a gating clamp from the stale budget snapshot")
+	}
+	r.mu.RLock()
+	_, armed := r.budgetClamps[capacityRejectKey{ProviderID: r.faultKeyLocked(p.ID), ModelID: model}]
+	r.mu.RUnlock()
+	if armed {
+		t.Fatal("a lifecycle cold-404 must not touch the clamp map at all")
+	}
+	if sel, _ := reserveOnce(r, model, "rewarm"); sel == nil {
+		t.Fatal("a re-warming pair must stay admittable (the reload dispatch is what warms it)")
+	}
+	// The black-hole safety is unchanged: forever-404 (zero accepts) still
+	// trips the cooldown, and the rate window stays untouched.
+	for i := 0; i < defaultCapacityCooldownThreshold-1; i++ {
+		r.RecordCapacityRejectLifecycle(p.ID, model)
+	}
+	if !r.CapacityCooldownActive(p.ID, model) {
+		t.Fatal("forever-404 with zero accepts must still trip the black-hole cooldown")
+	}
+	if _, samples := r.CapacityRejectRate(p.ID, model); samples != 0 {
+		t.Fatalf("lifecycle misses must not derate: samples=%d, want 0", samples)
+	}
 }
 
 // setAttestationAndBind completes a valid attestation for an already-registered

--- a/coordinator/registry/budget_clamp_test.go
+++ b/coordinator/registry/budget_clamp_test.go
@@ -411,6 +411,187 @@ func TestBudgetClampAndRateConcurrentAccess(t *testing.T) {
 	wg.Wait()
 }
 
+// A RELEASED clamp's entry must not linger and revive as a block on the
+// identity's next reconnect (Codex review of #523, round 3): before the fix
+// the released entry stayed in budgetClamps, and the reconnected session's
+// budgetless pre-heartbeat window read map presence as an active clamp —
+// re-blocking a pair that had already proven recovery. Covers both release
+// orders (the heartbeat sweep and the accept-path drop).
+func TestBudgetClampReleasedEntryDoesNotReviveOnReconnect(t *testing.T) {
+	const model = "gemma-4-26b-qat-4bit"
+
+	run := func(t *testing.T, serial, sess1, sess2 string, release func(r *Registry, providerID string)) {
+		t.Helper()
+		r := New(testLogger())
+		p1 := attestSchedulerProvider(t, r, sess1, model, serial, 100)
+		p1.mu.Lock()
+		p1.BackendCapacity.Slots[0].ActiveTokenBudgetUsed = grayBoxBudgetUsed
+		p1.BackendCapacity.Slots[0].ActiveTokenBudgetMax = grayBoxBudgetMax
+		p1.mu.Unlock()
+
+		r.RecordCapacityReject(p1.ID, model)
+		if !r.BudgetClampActive(p1.ID, model) {
+			t.Fatal("setup: clamp must be active")
+		}
+		release(r, p1.ID)
+		if r.BudgetClampActive(p1.ID, model) {
+			t.Fatal("setup: clamp must have released")
+		}
+		r.mu.RLock()
+		_, lingering := r.budgetClamps[capacityRejectKey{ProviderID: "serial:" + serial, ModelID: model}]
+		r.mu.RUnlock()
+		if lingering {
+			t.Fatal("released clamp entry must be deleted, not linger in budgetClamps")
+		}
+
+		// Reconnect before the original TTL, budgetless (no heartbeat yet): the
+		// pair already proved recovery, so nothing may block admission.
+		r.Disconnect(sess1)
+		p2 := attestSchedulerProvider(t, r, sess2, model, serial, 100)
+		p2.mu.Lock()
+		p2.BackendCapacity = nil
+		p2.mu.Unlock()
+		if r.BudgetClampActive(p2.ID, model) {
+			t.Fatal("released clamp revived on the reconnected session's budgetless pre-heartbeat window")
+		}
+		if sel, _ := reserveOnce(r, model, "post-release-reconnect"); sel == nil {
+			t.Fatal("reconnect after a full release must be admittable")
+		}
+	}
+
+	t.Run("released by the heartbeat sweep (accept then heartbeat, no further traffic)", func(t *testing.T) {
+		run(t, "SER-REL-HB", "rel-hb-1", "rel-hb-2", func(r *Registry, providerID string) {
+			r.RecordCapacityAccept(providerID, model)
+			time.Sleep(2 * time.Millisecond)
+			sendBudgetHeartbeat(r, providerID, model, grayBoxBudgetUsed, grayBoxBudgetMax)
+		})
+	})
+	t.Run("released by the accept-path drop (heartbeat then accept)", func(t *testing.T) {
+		run(t, "SER-REL-AC", "rel-ac-1", "rel-ac-2", func(r *Registry, providerID string) {
+			time.Sleep(2 * time.Millisecond)
+			sendBudgetHeartbeat(r, providerID, model, grayBoxBudgetUsed, grayBoxBudgetMax)
+			r.RecordCapacityAccept(providerID, model)
+		})
+	})
+}
+
+// The heartbeat release sweep must evaluate the heartbeat's OWN snapshot, not
+// re-read r.providers: a Disconnect racing in between the heartbeat stamping
+// the provider and the sweep running would otherwise find no provider, skip
+// the delete, and let the released entry re-block the identity's next
+// reconnect (Codex round-3 review follow-up). Simulated deterministically by
+// disconnecting BEFORE the sweep runs with the heartbeat's values — the
+// 2-minute disconnectedStableIDs cache keeps the session resolvable, exactly
+// as in the production race.
+func TestBudgetClampHeartbeatReleaseSurvivesDisconnectRace(t *testing.T) {
+	r := New(testLogger())
+	const model, serial = "gemma-4-26b-qat-4bit", "SER-REL-RACE"
+
+	p1 := attestSchedulerProvider(t, r, "rel-race-1", model, serial, 100)
+	p1.mu.Lock()
+	p1.BackendCapacity.Slots[0].ActiveTokenBudgetUsed = grayBoxBudgetUsed
+	p1.BackendCapacity.Slots[0].ActiveTokenBudgetMax = grayBoxBudgetMax
+	p1.mu.Unlock()
+
+	r.RecordCapacityReject(p1.ID, model)
+	r.RecordCapacityAccept(p1.ID, model)
+	time.Sleep(2 * time.Millisecond)
+
+	// The heartbeat that proves release arrives... and the provider disconnects
+	// before the sweep runs. Replay the sweep exactly as Heartbeat would have
+	// called it, with the heartbeat's own stamped time and report.
+	heartbeatAt := time.Now()
+	capacity := &protocol.BackendCapacity{
+		TotalMemoryGB: 64,
+		Slots: []protocol.BackendSlotCapacity{{
+			Model:                 model,
+			State:                 "running",
+			ActiveTokenBudgetUsed: grayBoxBudgetUsed,
+			ActiveTokenBudgetMax:  grayBoxBudgetMax,
+		}},
+	}
+	r.Disconnect("rel-race-1")
+	r.releaseBudgetClampsOnHeartbeat("rel-race-1", heartbeatAt, capacity)
+
+	r.mu.RLock()
+	_, lingering := r.budgetClamps[capacityRejectKey{ProviderID: "serial:" + serial, ModelID: model}]
+	r.mu.RUnlock()
+	if lingering {
+		t.Fatal("release proof voided by the disconnect race — the sweep must evaluate the heartbeat's own snapshot")
+	}
+
+	// The reconnect (budgetless, pre-heartbeat) must not be blocked.
+	p2 := attestSchedulerProvider(t, r, "rel-race-2", model, serial, 100)
+	p2.mu.Lock()
+	p2.BackendCapacity = nil
+	p2.mu.Unlock()
+	if r.BudgetClampActive(p2.ID, model) {
+		t.Fatal("released clamp revived on reconnect after the disconnect race")
+	}
+}
+
+// Inactive clamp entries (released / TTL-expired / budgetless-armed) must be
+// DELETED, not merely read as inactive: RecordCapacityAccept's healthy-pair
+// fast path keys on map presence, so a lingering entry would pull every later
+// accept for the pair onto the r.mu write lock indefinitely (Codex review of
+// #523, round 3). An ACTIVE clamp's entry must survive its accepts until the
+// full release proof.
+func TestBudgetClampInactiveEntriesAreDeleted(t *testing.T) {
+	const model = "gemma-4-26b-qat-4bit"
+
+	clampEntryExists := func(r *Registry, providerID string) bool {
+		r.mu.RLock()
+		defer r.mu.RUnlock()
+		_, ok := r.budgetClamps[capacityRejectKey{ProviderID: r.faultKeyLocked(providerID), ModelID: model}]
+		return ok
+	}
+
+	t.Run("TTL-expired entry dropped on the next accept", func(t *testing.T) {
+		r := New(testLogger())
+		p := makeTokenBudgetProvider(t, r, "ttl-drop", model, 100, grayBoxBudgetUsed, grayBoxBudgetMax, 100)
+		r.RecordCapacityReject(p.ID, model)
+		ageBudgetClamp(r, p.ID, model, defaultBudgetClampTTL+time.Second)
+		r.RecordCapacityAccept(p.ID, model)
+		if clampEntryExists(r, p.ID) {
+			t.Fatal("TTL-expired clamp entry must be deleted by the accept path")
+		}
+	})
+
+	t.Run("budgetless-armed entry dropped on the next accept", func(t *testing.T) {
+		r := New(testLogger())
+		p := makeSchedulerProvider(t, r, "budgetless-drop", model, 100) // no token budget
+		r.RecordCapacityRejectLifecycle(p.ID, model)
+		if !clampEntryExists(r, p.ID) {
+			t.Fatal("setup: lifecycle reject must have armed a (never-gating) entry")
+		}
+		r.RecordCapacityAccept(p.ID, model)
+		if clampEntryExists(r, p.ID) {
+			t.Fatal("budgetless-armed (never-gating) clamp entry must be deleted by the accept path")
+		}
+	})
+
+	t.Run("active entry survives accepts until the full release proof", func(t *testing.T) {
+		r := New(testLogger())
+		p := makeTokenBudgetProvider(t, r, "active-keep", model, 100, grayBoxBudgetUsed, grayBoxBudgetMax, 100)
+		r.RecordCapacityReject(p.ID, model)
+		// Accept with a stale (pre-clamp) heartbeat: release unproven — the
+		// entry must stay (and keep gating).
+		r.RecordCapacityAccept(p.ID, model)
+		if !clampEntryExists(r, p.ID) {
+			t.Fatal("an unreleased clamp entry must survive the accept (release still needs the fresh heartbeat)")
+		}
+		if !r.BudgetClampActive(p.ID, model) {
+			t.Fatal("unreleased clamp must still gate")
+		}
+		// The fresh-headroom heartbeat completes the proof: the sweep deletes.
+		time.Sleep(2 * time.Millisecond)
+		sendBudgetHeartbeat(r, p.ID, model, grayBoxBudgetUsed, grayBoxBudgetMax)
+		if clampEntryExists(r, p.ID) {
+			t.Fatal("fully released clamp entry must be deleted so the pair returns to the accept fast path")
+		}
+	})
+}
+
 // setAttestationAndBind completes a valid attestation for an already-registered
 // provider through the real SetAttestationResult path (which performs the
 // fault-state migration under test).

--- a/coordinator/registry/budget_clamp_test.go
+++ b/coordinator/registry/budget_clamp_test.go
@@ -532,6 +532,47 @@ func TestGrayBoxSelectionShareDropsWithFix(t *testing.T) {
 	})
 }
 
+// A clamp armed while the pair reported NO budget (a cold "model not loaded"
+// miss, or a first dispatch before the first capacity heartbeat) must NOT
+// retroactively gate the pair once a later heartbeat starts reporting a
+// budget: the reject was budgetless, so it is not the stale-budget lie the
+// clamp exists to override, and — because the clamp would block dispatch — no
+// accept could ever land to prove release, stranding the warmed-up pair until
+// TTL (Codex review of #523). Contrast TestBudgetClampSurvivesReconnect, where
+// the clamp armed while budget-reporting and MUST hold.
+func TestBudgetClampArmedBudgetlessDoesNotGateAfterBudgetAppears(t *testing.T) {
+	r := New(testLogger())
+	const model = "gemma-4-26b-qat-4bit"
+	// The slot reports NO token budget (cold / pre-load): the reject arms the
+	// clamp with budgetReported=false.
+	p := makeSchedulerProvider(t, r, "cold-box", model, 100)
+
+	r.RecordCapacityReject(p.ID, model)
+	if r.BudgetClampActive(p.ID, model) {
+		t.Fatal("a budgetless capacity reject must not gate the pair (legacy/cold exemption)")
+	}
+
+	// The model finishes loading; the first budget heartbeat arrives (strictly
+	// after the clamp, with meaningful headroom). Pre-fix, the budgeted release
+	// branch found acceptedSince=false and re-activated the clamp until TTL.
+	time.Sleep(2 * time.Millisecond)
+	sendBudgetHeartbeat(r, p.ID, model, grayBoxBudgetUsed, grayBoxBudgetMax)
+	if r.BudgetClampActive(p.ID, model) {
+		t.Fatal("a clamp armed while budgetless must not activate once a budget heartbeat arrives — no dispatch could produce the accept proof, so it would strand until TTL")
+	}
+	if sel, _ := reserveOnce(r, model, "warmed-up"); sel == nil {
+		t.Fatal("warmed-up pair must be admittable — a budgetless-armed clamp must never gate it")
+	}
+
+	// But a GENUINE reject now (while budget-reporting) DOES arm a gating clamp:
+	// the sticky-or upgrades budgetReported, so this is real stale-budget
+	// dishonesty, not warm-up.
+	r.RecordCapacityReject(p.ID, model)
+	if !r.BudgetClampActive(p.ID, model) {
+		t.Fatal("a capacity reject while the pair reports a budget must gate (real gray-box signal)")
+	}
+}
+
 // A clamped identity that reconnects has NO BackendCapacity until its first
 // heartbeat. The clamp must keep holding through that budgetless window — the
 // snapshot falling back to the legacy memory-admission path would shed the

--- a/coordinator/registry/budget_clamp_test.go
+++ b/coordinator/registry/budget_clamp_test.go
@@ -531,3 +531,52 @@ func TestGrayBoxSelectionShareDropsWithFix(t *testing.T) {
 		}
 	})
 }
+
+// A clamped identity that reconnects has NO BackendCapacity until its first
+// heartbeat. The clamp must keep holding through that budgetless window — the
+// snapshot falling back to the legacy memory-admission path would shed the
+// clamp at the exact moment the stable fault key exists to prevent it (Codex
+// review of #523). Release then works normally once the first post-clamp
+// budget heartbeat + an accept land.
+func TestBudgetClampHoldsAcrossReconnectBeforeFirstHeartbeat(t *testing.T) {
+	r := New(testLogger())
+	const model, serial = "gemma-4-26b-qat-4bit", "SER-CLAMP-HB"
+
+	p1 := attestSchedulerProvider(t, r, "clamp-hb-sess-1", model, serial, 100)
+	p1.mu.Lock()
+	p1.BackendCapacity.Slots[0].ActiveTokenBudgetUsed = grayBoxBudgetUsed
+	p1.BackendCapacity.Slots[0].ActiveTokenBudgetMax = grayBoxBudgetMax
+	p1.mu.Unlock()
+
+	r.RecordCapacityReject(p1.ID, model)
+	if !r.BudgetClampActive(p1.ID, model) {
+		t.Fatal("setup: clamp must be active")
+	}
+	r.Disconnect("clamp-hb-sess-1")
+
+	// Reconnect: registration completes, attestation binds the same stable
+	// identity, but the first heartbeat has NOT arrived — BackendCapacity nil.
+	p2 := attestSchedulerProvider(t, r, "clamp-hb-sess-2", model, serial, 100)
+	p2.mu.Lock()
+	p2.BackendCapacity = nil
+	p2.mu.Unlock()
+
+	if !r.BudgetClampActive(p2.ID, model) {
+		t.Fatal("clamp must hold through the reconnected session's budgetless pre-heartbeat window")
+	}
+	if sel, _ := reserveOnce(r, model, "reconnect-pre-heartbeat"); sel != nil {
+		t.Fatal("budgetless reconnect window shed the clamp — admission fell back to the legacy memory path")
+	}
+
+	// Release proof through the new session: accept + first post-clamp budget
+	// heartbeat with meaningful headroom.
+	r.RecordCapacityAccept(p2.ID, model)
+	time.Sleep(2 * time.Millisecond)
+	sendBudgetHeartbeat(r, p2.ID, model, grayBoxBudgetUsed, grayBoxBudgetMax)
+	if r.BudgetClampActive(p2.ID, model) {
+		t.Fatal("release proof through the reconnected session must lift the clamp")
+	}
+	if sel, _ := reserveOnce(r, model, "post-release"); sel == nil {
+		t.Fatal("released pair must admit again")
+	}
+}

--- a/coordinator/registry/budget_clamp_test.go
+++ b/coordinator/registry/budget_clamp_test.go
@@ -1,0 +1,533 @@
+package registry
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/attestation"
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+)
+
+// Tests for the gray-box budget clamp (budget_clamp.go): after ONE
+// capacity-shaped 503, admission stops believing the pair's stale-optimistic
+// heartbeat budget and treats the slot as full; release requires provider-side
+// proof (a strictly-fresher heartbeat with meaningful headroom AND an accept),
+// with a TTL fail-open so a missed release path can never strand a slot.
+// Regression suite for the 2026-07 gray-box incident: 11,581 capacity 503s in
+// 6h from boxes whose heartbeats reported ~1.4% budget used while their live
+// KV gates rejected — invisible to every zero-interleaved-accepts breaker
+// because the boxes also served ~60% of dispatches.
+
+// grayBoxBudget mirrors the incident heartbeat: ~72k used of ~5.2M advertised.
+const (
+	grayBoxBudgetUsed = int64(72_000)
+	grayBoxBudgetMax  = int64(5_200_000)
+)
+
+// sendBudgetHeartbeat drives the REAL heartbeat path (the same one prod
+// heartbeats take), delivering a fresh BackendCapacity snapshot with the given
+// slot budget. LastHeartbeat and BackendCapacity are stamped in the same
+// critical section, which is exactly the freshness anchor the clamp release
+// compares against.
+func sendBudgetHeartbeat(r *Registry, providerID, model string, used, max int64) {
+	active := model
+	r.Heartbeat(providerID, &protocol.HeartbeatMessage{
+		Type:        protocol.TypeHeartbeat,
+		Status:      "idle",
+		ActiveModel: &active,
+		SystemMetrics: protocol.SystemMetrics{
+			MemoryPressure: 0.1, CPUUsage: 0.1, ThermalState: "nominal",
+		},
+		BackendCapacity: &protocol.BackendCapacity{
+			TotalMemoryGB: 64,
+			Slots: []protocol.BackendSlotCapacity{{
+				Model:                 model,
+				State:                 "running",
+				ActiveTokenBudgetUsed: used,
+				ActiveTokenBudgetMax:  max,
+			}},
+		},
+	})
+}
+
+// reserveOnce runs the production reservation path once and releases the
+// reservation, returning the selected provider (nil = no route) and decision.
+func reserveOnce(r *Registry, model, requestID string) (*Provider, RoutingDecision) {
+	p, decision := r.ReserveProviderEx(model, &PendingRequest{
+		RequestID:             requestID,
+		Model:                 model,
+		EstimatedPromptTokens: 500,
+		RequestedMaxTokens:    256,
+	})
+	if p != nil {
+		p.RemovePending(requestID)
+		r.SetProviderIdle(p.ID)
+	}
+	return p, decision
+}
+
+// ageBudgetClamp rewinds the pair's clamp time by d (simulating TTL passage
+// without sleeping), keyed by the pair's CURRENT fault key.
+func ageBudgetClamp(r *Registry, providerID, model string, d time.Duration) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	key := capacityRejectKey{ProviderID: r.faultKeyLocked(providerID), ModelID: model}
+	if e, ok := r.budgetClamps[key]; ok {
+		e.clampedAt = e.clampedAt.Add(-d)
+	}
+}
+
+// One capacity-503 must IMMEDIATELY stop admission for a request that fit
+// moments earlier — the heartbeat still advertises ~5.1M free tokens, but the
+// provider's live gate just proved it rejects. The rejection must read as
+// TRANSIENT capacity (429/queue material), not structural absence, on both the
+// routing decision and the preflight.
+func TestBudgetClampBlocksAdmissionOnFirstCapacityReject(t *testing.T) {
+	r := New(testLogger())
+	const model = "gemma-4-26b-qat-4bit"
+	p := makeTokenBudgetProvider(t, r, "gray-box", model, 100, grayBoxBudgetUsed, grayBoxBudgetMax, 100)
+
+	if sel, _ := reserveOnce(r, model, "pre-clamp"); sel == nil {
+		t.Fatal("setup: request must fit the advertised budget before the clamp")
+	}
+
+	if r.RecordCapacityReject(p.ID, model) {
+		t.Fatal("one reject must not trip the pair cooldown (threshold 5) — the clamp is the fast path")
+	}
+	if !r.BudgetClampActive(p.ID, model) {
+		t.Fatal("clamp must be active after one capacity reject")
+	}
+	sel, decision := reserveOnce(r, model, "post-clamp")
+	if sel != nil {
+		t.Fatalf("clamped pair was admitted (provider %s) — admission believed the stale heartbeat budget", sel.ID)
+	}
+	if decision.CapacityRejections != 1 {
+		t.Fatalf("decision.CapacityRejections = %d, want 1 (clamp is transient capacity, not structural absence)", decision.CapacityRejections)
+	}
+	cc, capRej, _ := r.QuickCapacityCheck(model, 500, 256, RequestTraits{})
+	if cc != 0 || capRej != 1 {
+		t.Fatalf("preflight (candidates=%d, capacityRejections=%d), want (0, 1) — preflight must mirror routing", cc, capRej)
+	}
+}
+
+// The clamp releases ONLY on provider-side proof: an accept alone (in-flight
+// request committing content) is not enough while the freshest heartbeat still
+// predates the clamp, and a fresh heartbeat alone is not enough without an
+// accept. Both together — in either order — release.
+func TestBudgetClampReleaseRequiresFreshHeartbeatAndAccept(t *testing.T) {
+	const model = "gemma-4-26b-qat-4bit"
+
+	t.Run("accept then heartbeat", func(t *testing.T) {
+		r := New(testLogger())
+		p := makeTokenBudgetProvider(t, r, "gray-1", model, 100, grayBoxBudgetUsed, grayBoxBudgetMax, 100)
+		r.RecordCapacityReject(p.ID, model)
+
+		// Accept lands (an in-flight request committed content), but the only
+		// budget snapshot the coordinator holds STILL predates the clamp — the
+		// stale-optimistic view must not admit again.
+		r.RecordCapacityAccept(p.ID, model)
+		if !r.BudgetClampActive(p.ID, model) {
+			t.Fatal("accept with a stale (pre-clamp) heartbeat must NOT release the clamp")
+		}
+		if sel, _ := reserveOnce(r, model, "still-clamped"); sel != nil {
+			t.Fatal("admission resumed on a stale heartbeat")
+		}
+
+		// A strictly-fresher heartbeat with meaningful headroom completes the
+		// proof: release.
+		time.Sleep(2 * time.Millisecond)
+		sendBudgetHeartbeat(r, p.ID, model, grayBoxBudgetUsed, grayBoxBudgetMax)
+		if r.BudgetClampActive(p.ID, model) {
+			t.Fatal("fresh heartbeat + prior accept must release the clamp")
+		}
+		if sel, _ := reserveOnce(r, model, "released"); sel == nil {
+			t.Fatal("released pair must be admittable again")
+		}
+	})
+
+	t.Run("heartbeat then accept", func(t *testing.T) {
+		r := New(testLogger())
+		p := makeTokenBudgetProvider(t, r, "gray-2", model, 100, grayBoxBudgetUsed, grayBoxBudgetMax, 100)
+		r.RecordCapacityReject(p.ID, model)
+
+		time.Sleep(2 * time.Millisecond)
+		sendBudgetHeartbeat(r, p.ID, model, grayBoxBudgetUsed, grayBoxBudgetMax)
+		if !r.BudgetClampActive(p.ID, model) {
+			t.Fatal("a fresh optimistic heartbeat ALONE must not release the clamp — that heartbeat is exactly what the clamp distrusts")
+		}
+		if sel, _ := reserveOnce(r, model, "hb-only"); sel != nil {
+			t.Fatal("admission resumed without an accept")
+		}
+
+		r.RecordCapacityAccept(p.ID, model)
+		if r.BudgetClampActive(p.ID, model) {
+			t.Fatal("accept after a fresh heartbeat must release the clamp (whichever proof comes later wins)")
+		}
+		if sel, _ := reserveOnce(r, model, "released-2"); sel == nil {
+			t.Fatal("released pair must be admittable again")
+		}
+	})
+}
+
+// A post-clamp heartbeat that merely restates the pressure (raw remaining
+// below the meaningful-headroom floor) must not release even with an accept:
+// the box is serving what it has but has no room for more.
+func TestBudgetClampNoMeaningfulHeadroomDoesNotRelease(t *testing.T) {
+	r := New(testLogger())
+	const model = "gemma-4-26b-qat-4bit"
+	p := makeTokenBudgetProvider(t, r, "gray-tight", model, 100, grayBoxBudgetUsed, grayBoxBudgetMax, 100)
+
+	r.RecordCapacityReject(p.ID, model)
+	r.RecordCapacityAccept(p.ID, model)
+	time.Sleep(2 * time.Millisecond)
+	// Fresh heartbeat, but used ≈ max: remaining 512 < the 1024-token floor.
+	sendBudgetHeartbeat(r, p.ID, model, 99_488, 100_000)
+	if !r.BudgetClampActive(p.ID, model) {
+		t.Fatal("a pressure-restating heartbeat (remaining < 1024) must not release the clamp")
+	}
+
+	// The next heartbeat with real headroom releases (accept proof persists).
+	sendBudgetHeartbeat(r, p.ID, model, 10_000, 100_000)
+	if r.BudgetClampActive(p.ID, model) {
+		t.Fatal("meaningful headroom + accept must release")
+	}
+}
+
+// FAIL OPEN: a clamp whose release path never completes (zero traffic → zero
+// accepts) expires after the TTL, so a slot can never be stranded. A
+// subsequent reject re-arms it.
+func TestBudgetClampTTLFailOpen(t *testing.T) {
+	r := New(testLogger())
+	const model = "gemma-4-26b-qat-4bit"
+	p := makeTokenBudgetProvider(t, r, "gray-ttl", model, 100, grayBoxBudgetUsed, grayBoxBudgetMax, 100)
+
+	r.RecordCapacityReject(p.ID, model)
+	if sel, _ := reserveOnce(r, model, "clamped"); sel != nil {
+		t.Fatal("setup: clamp must block")
+	}
+	ageBudgetClamp(r, p.ID, model, defaultBudgetClampTTL+time.Second)
+	if r.BudgetClampActive(p.ID, model) {
+		t.Fatal("clamp must fail open after its TTL")
+	}
+	if sel, _ := reserveOnce(r, model, "ttl-open"); sel == nil {
+		t.Fatal("TTL-expired clamp must admit again with no accept/heartbeat proof")
+	}
+	// A fresh capacity-503 re-arms immediately.
+	r.RecordCapacityReject(p.ID, model)
+	if sel, _ := reserveOnce(r, model, "re-armed"); sel != nil {
+		t.Fatal("post-TTL reject must re-arm the clamp")
+	}
+}
+
+// A re-reject after release is fresh evidence: the clamp re-arms with a new
+// clamp time, so the heartbeat that released the PREVIOUS clamp is stale for
+// the new one and the accept proof starts over.
+func TestBudgetClampReArmResetsReleaseProof(t *testing.T) {
+	r := New(testLogger())
+	const model = "gemma-4-26b-qat-4bit"
+	p := makeTokenBudgetProvider(t, r, "gray-reclamp", model, 100, grayBoxBudgetUsed, grayBoxBudgetMax, 100)
+
+	// Clamp → full release.
+	r.RecordCapacityReject(p.ID, model)
+	r.RecordCapacityAccept(p.ID, model)
+	time.Sleep(2 * time.Millisecond)
+	sendBudgetHeartbeat(r, p.ID, model, grayBoxBudgetUsed, grayBoxBudgetMax)
+	if r.BudgetClampActive(p.ID, model) {
+		t.Fatal("setup: clamp must have released")
+	}
+
+	// Re-reject: the release-time heartbeat and accept must not carry over.
+	time.Sleep(2 * time.Millisecond)
+	r.RecordCapacityReject(p.ID, model)
+	if !r.BudgetClampActive(p.ID, model) {
+		t.Fatal("re-reject must re-arm the clamp with fresh proof requirements")
+	}
+	if sel, _ := reserveOnce(r, model, "re-clamped"); sel != nil {
+		t.Fatal("re-armed clamp must block admission")
+	}
+}
+
+// Kill switch: EIGENINFERENCE_BUDGET_CLAMP=false restores the old behavior —
+// a capacity reject leaves admission believing the heartbeat budget (only the
+// threshold-5 pair cooldown remains, which one reject cannot trip).
+func TestBudgetClampKillSwitch(t *testing.T) {
+	t.Setenv(envBudgetClamp, "false")
+	r := New(testLogger())
+	const model = "gemma-4-26b-qat-4bit"
+	p := makeTokenBudgetProvider(t, r, "gray-off", model, 100, grayBoxBudgetUsed, grayBoxBudgetMax, 100)
+
+	r.RecordCapacityReject(p.ID, model)
+	if r.BudgetClampActive(p.ID, model) {
+		t.Fatal("disabled clamp reads active")
+	}
+	if sel, _ := reserveOnce(r, model, "kill-switch"); sel == nil {
+		t.Fatal("with the clamp disabled, one reject must not block admission (old behavior)")
+	}
+}
+
+// SCOPE: the clamp only overrides token-budget admission. A legacy provider
+// whose slot reports no budget keeps the existing protections (pair cooldown
+// at threshold 5) — one 503 must not gate it.
+func TestBudgetClampLegacyBudgetlessProviderNotClamped(t *testing.T) {
+	r := New(testLogger())
+	const model = "legacy-model"
+	p := makeSchedulerProvider(t, r, "legacy-box", model, 100) // no ActiveTokenBudgetMax
+
+	r.RecordCapacityReject(p.ID, model)
+	if sel, _ := reserveOnce(r, model, "legacy"); sel == nil {
+		t.Fatal("a budget-less provider must not be admission-gated by a single capacity reject")
+	}
+}
+
+// The clamp keys by STABLE identity: a disconnect/reconnect with the same
+// serial (fresh session UUID) must not shed it — the reconnect exploit that
+// wiped every session-keyed breaker must stay closed for the clamp too.
+func TestBudgetClampSurvivesReconnect(t *testing.T) {
+	r := New(testLogger())
+	const model, serial = "gemma-4-26b-qat-4bit", "SER-CLAMP"
+
+	p1 := attestSchedulerProvider(t, r, "clamp-sess-1", model, serial, 100)
+	p1.mu.Lock()
+	p1.BackendCapacity.Slots[0].ActiveTokenBudgetUsed = grayBoxBudgetUsed
+	p1.BackendCapacity.Slots[0].ActiveTokenBudgetMax = grayBoxBudgetMax
+	p1.mu.Unlock()
+
+	r.RecordCapacityReject(p1.ID, model)
+	if !r.BudgetClampActive(p1.ID, model) {
+		t.Fatal("setup: clamp must be active")
+	}
+	r.Disconnect("clamp-sess-1")
+
+	p2 := attestSchedulerProvider(t, r, "clamp-sess-2", model, serial, 100)
+	p2.mu.Lock()
+	p2.BackendCapacity.Slots[0].ActiveTokenBudgetUsed = grayBoxBudgetUsed
+	p2.BackendCapacity.Slots[0].ActiveTokenBudgetMax = grayBoxBudgetMax
+	p2.mu.Unlock()
+
+	if !r.BudgetClampActive(p2.ID, model) {
+		t.Fatal("clamp must re-attach to the reconnected session via the stable fault key")
+	}
+	if sel, _ := reserveOnce(r, model, "reconnect"); sel != nil {
+		t.Fatal("reconnect must not shed the clamp — admission resumed")
+	}
+	// Release still works through the new session: accept + fresh heartbeat.
+	r.RecordCapacityAccept(p2.ID, model)
+	time.Sleep(2 * time.Millisecond)
+	sendBudgetHeartbeat(r, p2.ID, model, grayBoxBudgetUsed, grayBoxBudgetMax)
+	if r.BudgetClampActive(p2.ID, model) {
+		t.Fatal("release proof through the reconnected session must lift the clamp")
+	}
+}
+
+// Clamp + rate state must MIGRATE on an identity (re)bind: strikes recorded
+// pre-attestation live under the session fallback key and must follow the
+// stable identity when attestation binds — otherwise a gray box sheds its
+// record at the exact moment its identity improves.
+func TestBudgetClampAndRateStateMigrateOnFirstBind(t *testing.T) {
+	r := New(testLogger())
+	const model = "gemma-4-26b-qat-4bit"
+	p := makeTokenBudgetProvider(t, r, "migrate-sess", model, 100, grayBoxBudgetUsed, grayBoxBudgetMax, 100)
+
+	// Session-keyed clamp + rate outcomes (no attestation yet).
+	r.RecordCapacityReject(p.ID, model)
+	r.RecordCapacityAcceptOutcome(p.ID, model, true)
+
+	// Attestation binds session → serial; state must migrate.
+	setAttestationAndBind(t, r, p, "SER-MIG-CLAMP")
+
+	r.mu.RLock()
+	sessKey := capacityRejectKey{ProviderID: "migrate-sess", ModelID: model}
+	serialKey := capacityRejectKey{ProviderID: "serial:SER-MIG-CLAMP", ModelID: model}
+	_, sessClamp := r.budgetClamps[sessKey]
+	_, serialClamp := r.budgetClamps[serialKey]
+	sessRejects := len(r.capacityRateRejects[sessKey])
+	serialRejects := len(r.capacityRateRejects[serialKey])
+	serialAccepts := len(r.capacityRateAccepts[serialKey])
+	r.mu.RUnlock()
+
+	if sessClamp || sessRejects > 0 {
+		t.Fatal("session-keyed gray-box state orphaned after the identity bind")
+	}
+	if !serialClamp {
+		t.Fatal("budget clamp did not migrate to the stable identity")
+	}
+	if serialRejects != 1 || serialAccepts != 1 {
+		t.Fatalf("rate window did not migrate: rejects=%d accepts=%d, want 1/1", serialRejects, serialAccepts)
+	}
+	// And the clamp still gates the (unchanged) session id via faultKeyLocked.
+	if !r.BudgetClampActive(p.ID, model) {
+		t.Fatal("migrated clamp must still gate the live session")
+	}
+}
+
+// Race coverage: reserves (which read clamp + rate state under selection
+// locks), capacity rejects/accepts (which write it), and real heartbeats (which
+// replace BackendCapacity and stamp the freshness anchor) all running
+// concurrently must be data-race-free and never panic. Run with -race.
+func TestBudgetClampAndRateConcurrentAccess(t *testing.T) {
+	r := New(testLogger())
+	const model = "gemma-4-26b-qat-4bit"
+	p := makeTokenBudgetProvider(t, r, "race-box", model, 100, 0, grayBoxBudgetMax, 100)
+	makeTokenBudgetProvider(t, r, "race-peer", model, 50, 0, 200_000, 50)
+
+	done := make(chan struct{})
+	var wg sync.WaitGroup
+	worker := func(fn func(i int)) {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; ; i++ {
+				select {
+				case <-done:
+					return
+				default:
+					fn(i)
+				}
+			}
+		}()
+	}
+	worker(func(i int) { r.RecordCapacityReject(p.ID, model) })
+	worker(func(i int) {
+		r.RecordCapacityAcceptOutcome(p.ID, model, i%2 == 0)
+	})
+	worker(func(i int) { sendBudgetHeartbeat(r, p.ID, model, int64(i%1000), grayBoxBudgetMax) })
+	worker(func(i int) { r.BudgetClampActive(p.ID, model) })
+	worker(func(i int) { r.CapacityRejectRate(p.ID, model) })
+	worker(func(i int) {
+		rid := fmt.Sprintf("race-%d", i)
+		if sel, _ := r.ReserveProviderEx(model, &PendingRequest{
+			RequestID: rid, Model: model, EstimatedPromptTokens: 100, RequestedMaxTokens: 64,
+		}); sel != nil {
+			sel.RemovePending(rid)
+			r.SetProviderIdle(sel.ID)
+		}
+	})
+	worker(func(i int) { r.QuickCapacityCheck(model, 100, 64, RequestTraits{}) })
+
+	time.Sleep(150 * time.Millisecond)
+	close(done)
+	wg.Wait()
+}
+
+// setAttestationAndBind completes a valid attestation for an already-registered
+// provider through the real SetAttestationResult path (which performs the
+// fault-state migration under test).
+func setAttestationAndBind(t *testing.T, r *Registry, p *Provider, serial string) {
+	t.Helper()
+	p.SetAttestationResult(&attestation.VerificationResult{Valid: true, SerialNumber: serial})
+	if got := faultKeyOf(r, p.ID); got != "serial:"+serial {
+		t.Fatalf("bind failed: fault key = %q, want serial:%s", got, serial)
+	}
+}
+
+// THE prod regression (Jul 6 gray-box scenario): a provider whose heartbeat
+// advertises a huge budget but whose dispatches capacity-503 ~40% of the time
+// with interleaved accepts. Every pre-fix breaker is blind (each accept resets
+// the zero-interleaved-accepts discriminators), so the faster gray box keeps
+// winning selection outright. With the fix, its capacity-503 rate sinks it in
+// cost ranking and its selection share drops materially; the healthy peers
+// absorb the traffic. The kill switches restore the old (blind) behavior —
+// asserted here as the without-fix baseline.
+func TestGrayBoxSelectionShareDropsWithFix(t *testing.T) {
+	const model = "gemma-4-26b-qat-4bit"
+	const iterations = 60
+	const measureTail = 25 // selection share measured over the last N iterations
+
+	// runScenario drives the production selection loop against one gray box
+	// (fast: observed 200 TPS, huge advertised budget) and three identical
+	// healthy peers (slower: 60 TPS). Gray outcomes follow a fixed 40%
+	// capacity-503 pattern (R A A R A) with interleaved accepts — each reject
+	// is paired with an accept from a concurrently in-flight request (the prod
+	// gray box served ~60%), and both boxes heartbeat every iteration (the
+	// prod 15-30s cadence, compressed), so the CLAMP keeps releasing and the
+	// sustained defense under test is the rate penalty.
+	runScenario := func(t *testing.T) (grayTailShare float64, sawPenalty bool, maxRate float64) {
+		t.Helper()
+		r := New(testLogger())
+		// The gray box heartbeats IDLE-LOOKING (used=0 of 5.2M — maximally
+		// stale-optimistic, the prod signature) and is the fastest box, so the
+		// cost scheduler prefers it outright until something teaches it better.
+		gray := makeTokenBudgetProvider(t, r, "gray-box", model, 200, 0, grayBoxBudgetMax, 200)
+		healthy := make([]*Provider, 3)
+		for i := range healthy {
+			healthy[i] = makeTokenBudgetProvider(t, r, fmt.Sprintf("healthy-%d", i), model, 60, 0, 200_000, 60)
+		}
+
+		pattern := []bool{true, false, false, true, false} // true = capacity-503 (40%)
+		grayOutcome := 0
+		grayTailSelections := 0
+		for i := 0; i < iterations; i++ {
+			// Heartbeats: everyone re-advertises an optimistic budget (the
+			// gray box's is stale-optimistic by definition).
+			sendBudgetHeartbeat(r, gray.ID, model, 0, grayBoxBudgetMax)
+			for _, h := range healthy {
+				sendBudgetHeartbeat(r, h.ID, model, 0, 200_000)
+			}
+
+			rid := fmt.Sprintf("req-%d", i)
+			sel, decision := r.ReserveProviderEx(model, &PendingRequest{
+				RequestID:             rid,
+				Model:                 model,
+				EstimatedPromptTokens: 200,
+				RequestedMaxTokens:    512,
+			})
+			if sel == nil {
+				t.Fatalf("iteration %d: no provider selectable", i)
+			}
+			sel.RemovePending(rid)
+			r.SetProviderIdle(sel.ID)
+
+			if sel.ID == gray.ID {
+				if i >= iterations-measureTail {
+					grayTailSelections++
+				}
+				if decision.CapacityRateMs > 0 {
+					sawPenalty = true
+				}
+				if decision.CapacityRejectRate > maxRate {
+					maxRate = decision.CapacityRejectRate
+				}
+				if pattern[grayOutcome%len(pattern)] {
+					// Capacity-503 — and an interleaved accept from an
+					// in-flight request committing content (the gray-box
+					// signature that blinds every reset-on-accept breaker).
+					r.RecordCapacityReject(gray.ID, model)
+					r.RecordCapacityAccept(gray.ID, model)
+				} else {
+					r.RecordCapacityAccept(gray.ID, model)
+				}
+				grayOutcome++
+			} else {
+				r.RecordCapacityAccept(sel.ID, model)
+			}
+		}
+		return float64(grayTailSelections) / float64(measureTail), sawPenalty, maxRate
+	}
+
+	t.Run("without fix (kill switches) the gray box stays preferred", func(t *testing.T) {
+		t.Setenv(envBudgetClamp, "false")
+		t.Setenv(envCapacityRatePenaltyMs, "0")
+		share, sawPenalty, _ := runScenario(t)
+		if sawPenalty {
+			t.Fatal("kill switch off: no penalty may be applied")
+		}
+		if share < 0.9 {
+			t.Fatalf("without the fix the faster gray box must keep winning (share = %.2f, want >= 0.9) — if this fails the baseline no longer reproduces the prod blindness", share)
+		}
+	})
+
+	t.Run("with fix the gray box loses its monopoly", func(t *testing.T) {
+		share, sawPenalty, maxRate := runScenario(t)
+		if !sawPenalty {
+			t.Fatal("the capacity-503 rate penalty never appeared in a winning decision")
+		}
+		if maxRate <= capacityRateThreshold {
+			t.Fatalf("measured reject rate %.2f never exceeded the threshold %.2f", maxRate, capacityRateThreshold)
+		}
+		if share > 0.6 {
+			t.Fatalf("gray box selection share = %.2f over the last %d iterations, want <= 0.6 (healthy peers must absorb traffic)", share, measureTail)
+		}
+	})
+}

--- a/coordinator/registry/capacity_cooldown.go
+++ b/coordinator/registry/capacity_cooldown.go
@@ -176,7 +176,7 @@ func (r *Registry) RecordCapacityReject(providerID, modelID string) (tripped boo
 	// capacity-503 rate (capacity_rate.go — accepts deliberately do NOT reset
 	// it, unlike the strike streak below).
 	clampKey := capacityRejectKey{ProviderID: r.faultKeyLocked(providerID), ModelID: modelID}
-	r.recordBudgetClampLocked(clampKey, now)
+	r.recordBudgetClampLocked(clampKey, r.providerReportsTokenBudgetLocked(providerID, modelID), now)
 	r.recordCapacityRateRejectLocked(clampKey, now)
 
 	cfg := r.capacityCooldownCfg
@@ -287,22 +287,31 @@ func (r *Registry) claimCapacityProbeLocked(providerID, modelID string, now time
 // is also left untouched: ejection doesn't cancel in-flight work, so content
 // can flow from an ejected node, and lifting the quarantine early on it would
 // defeat the cooldown — recovery goes through the half-open success probe.
-func (r *Registry) RecordCapacityAccept(providerID, modelID string) {
-	r.RecordCapacityAcceptOutcome(providerID, modelID, true)
+// It returns whether a capacity-503 RATE outcome was actually recorded for
+// this accept (see RecordCapacityAcceptOutcome) so commit-time callers can
+// stamp the request (MarkRateOutcomeCounted) and the completion-time accept
+// can decide whether the request still owes its one rate outcome.
+func (r *Registry) RecordCapacityAccept(providerID, modelID string) (rateOutcomeRecorded bool) {
+	return r.RecordCapacityAcceptOutcome(providerID, modelID, true)
 }
 
 // RecordCapacityAcceptOutcome is RecordCapacityAccept with explicit control
 // over the capacity-503 RATE window's denominator (capacity_rate.go).
-// countRateOutcome=true records ONE served-dispatch outcome; the api layer
-// sets it true exactly once per served request — at the commit point (first
-// content chunk), or at clean completion on paths that never committed content
-// — and false for the redundant completion-time accept after a commit, so a
-// request that both commits and completes cleanly cannot double-count and
-// dilute the reject rate. The cooldown/streak/clamp accept semantics below are
-// identical for both values (belt-and-braces accepts stay harmless there).
-func (r *Registry) RecordCapacityAcceptOutcome(providerID, modelID string, countRateOutcome bool) {
+// countRateOutcome=true OFFERS one served-dispatch outcome; whether it was
+// actually RECORDED is the return value — the rate window only stores accepts
+// while the pair has a reject in-window (recordCapacityRateAcceptLocked), so a
+// commit that lands before any reject is an offer that records nothing. The
+// api layer offers at the commit point (first content chunk) and stamps the
+// request when the offer recorded (MarkRateOutcomeCounted); the completion-
+// time accept re-offers ONLY when the commit-time offer did not record
+// (!RateOutcomeCountedSafe) — so a long stream that committed pre-reject and
+// completed during the reject window still enters the denominator exactly
+// once, and a request whose commit already recorded cannot double-count and
+// dilute the reject rate. The cooldown/streak/clamp accept semantics below
+// are identical for both values (belt-and-braces accepts stay harmless there).
+func (r *Registry) RecordCapacityAcceptOutcome(providerID, modelID string, countRateOutcome bool) (rateOutcomeRecorded bool) {
 	if providerID == "" || modelID == "" {
-		return
+		return false
 	}
 	// Fast path: this runs once per served request, and for a healthy pair all
 	// the maps are empty — check under the read lock so the serving hot path
@@ -322,7 +331,9 @@ func (r *Registry) RecordCapacityAcceptOutcome(providerID, modelID string, count
 	capacityTripped := r.healthEjectionLastTripCapacity[key.ProviderID]
 	r.mu.RUnlock()
 	if !hasStrikes && !hasCooldown && !hasTrips && !hasClamp && !hasRateRejects && !hasNodeStreak && !capacityTripped {
-		return
+		// Nothing recorded: with no reject in the rate window the accept
+		// would not be stored anyway (see recordCapacityRateAcceptLocked).
+		return false
 	}
 	r.mu.Lock()
 	now := time.Now()
@@ -337,7 +348,7 @@ func (r *Registry) RecordCapacityAcceptOutcome(providerID, modelID string, count
 	// IS the signal).
 	r.noteBudgetClampAcceptLocked(key)
 	if countRateOutcome {
-		r.recordCapacityRateAcceptLocked(key, now)
+		rateOutcomeRecorded = r.recordCapacityRateAcceptLocked(key, now)
 	}
 	delete(r.healthEjectionCapacityStreaks, key.ProviderID)
 	if r.healthEjectionLastTripCapacity[key.ProviderID] {
@@ -345,6 +356,7 @@ func (r *Registry) RecordCapacityAcceptOutcome(providerID, modelID string, count
 		delete(r.healthEjectionLastTripCapacity, key.ProviderID)
 	}
 	r.mu.Unlock()
+	return rateOutcomeRecorded
 }
 
 // CapacityCooldownActive reports whether the (provider, model) pair is

--- a/coordinator/registry/capacity_cooldown.go
+++ b/coordinator/registry/capacity_cooldown.go
@@ -167,11 +167,22 @@ func (r *Registry) RecordCapacityReject(providerID, modelID string) (tripped boo
 	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	now := time.Now()
+
+	// Gray-box trackers ride the SAME classified entry point but have their own
+	// kill switches, independent of the cooldown threshold: the budget clamp
+	// stops admission believing the pair's stale heartbeat budget immediately
+	// (budget_clamp.go), and the rate window accumulates the reject side of the
+	// capacity-503 rate (capacity_rate.go — accepts deliberately do NOT reset
+	// it, unlike the strike streak below).
+	clampKey := capacityRejectKey{ProviderID: r.faultKeyLocked(providerID), ModelID: modelID}
+	r.recordBudgetClampLocked(clampKey, now)
+	r.recordCapacityRateRejectLocked(clampKey, now)
+
 	cfg := r.capacityCooldownCfg
 	if cfg.Threshold <= 0 {
 		return false // disabled via EIGENINFERENCE_CAPACITY_COOLDOWN_THRESHOLD=0
 	}
-	now := time.Now()
 
 	// Opportunistic sweep (mirrors error_cooldown.go): session provider ids are
 	// per-connection UUIDs that never get re-keyed — bound the maps by dropping
@@ -277,28 +288,57 @@ func (r *Registry) claimCapacityProbeLocked(providerID, modelID string, now time
 // can flow from an ejected node, and lifting the quarantine early on it would
 // defeat the cooldown — recovery goes through the half-open success probe.
 func (r *Registry) RecordCapacityAccept(providerID, modelID string) {
+	r.RecordCapacityAcceptOutcome(providerID, modelID, true)
+}
+
+// RecordCapacityAcceptOutcome is RecordCapacityAccept with explicit control
+// over the capacity-503 RATE window's denominator (capacity_rate.go).
+// countRateOutcome=true records ONE served-dispatch outcome; the api layer
+// sets it true exactly once per served request — at the commit point (first
+// content chunk), or at clean completion on paths that never committed content
+// — and false for the redundant completion-time accept after a commit, so a
+// request that both commits and completes cleanly cannot double-count and
+// dilute the reject rate. The cooldown/streak/clamp accept semantics below are
+// identical for both values (belt-and-braces accepts stay harmless there).
+func (r *Registry) RecordCapacityAcceptOutcome(providerID, modelID string, countRateOutcome bool) {
 	if providerID == "" || modelID == "" {
 		return
 	}
 	// Fast path: this runs once per served request, and for a healthy pair all
 	// the maps are empty — check under the read lock so the serving hot path
-	// does not serialize on r.mu write acquisition.
+	// does not serialize on r.mu write acquisition. A rate-outcome accept only
+	// needs the write lock when the pair has rejects in its rate window
+	// (recordCapacityRateAcceptLocked is what builds the denominator, and a
+	// zero-reject pair's rate is 0 regardless — capacityRatePenaltyLocked
+	// fast-exits on rejects==0 — so skipping the append loses nothing).
 	r.mu.RLock()
 	key := capacityRejectKey{ProviderID: r.faultKeyLocked(providerID), ModelID: modelID}
 	_, hasStrikes := r.capacityRejectStrikes[key]
 	_, hasCooldown := r.capacityCooldowns[key]
 	_, hasTrips := r.capacityCooldownTrips[key]
+	_, hasClamp := r.budgetClamps[key]
+	hasRateRejects := len(r.capacityRateRejects[key]) > 0
 	_, hasNodeStreak := r.healthEjectionCapacityStreaks[key.ProviderID]
 	capacityTripped := r.healthEjectionLastTripCapacity[key.ProviderID]
 	r.mu.RUnlock()
-	if !hasStrikes && !hasCooldown && !hasTrips && !hasNodeStreak && !capacityTripped {
+	if !hasStrikes && !hasCooldown && !hasTrips && !hasClamp && !hasRateRejects && !hasNodeStreak && !capacityTripped {
 		return
 	}
 	r.mu.Lock()
+	now := time.Now()
 	key = capacityRejectKey{ProviderID: r.faultKeyLocked(providerID), ModelID: modelID}
 	delete(r.capacityRejectStrikes, key)
 	delete(r.capacityCooldowns, key)
 	delete(r.capacityCooldownTrips, key)
+	// Gray-box trackers: the accept is PROOF for the clamp's release condition
+	// (b) — never an instant release, which still needs a strictly-fresher
+	// heartbeat with meaningful headroom — and ONE served outcome for the rate
+	// window (which deliberately has NO reset semantics: the accept/reject mix
+	// IS the signal).
+	r.noteBudgetClampAcceptLocked(key)
+	if countRateOutcome {
+		r.recordCapacityRateAcceptLocked(key, now)
+	}
 	delete(r.healthEjectionCapacityStreaks, key.ProviderID)
 	if r.healthEjectionLastTripCapacity[key.ProviderID] {
 		delete(r.healthEjectionTrips, key.ProviderID)

--- a/coordinator/registry/capacity_cooldown.go
+++ b/coordinator/registry/capacity_cooldown.go
@@ -161,7 +161,35 @@ type capacityRejectKey struct {
 // While a cooldown is ACTIVE, strikes are still recorded (in-flight stragglers
 // dispatched before the trip land here) but never extend or re-arm it —
 // otherwise stragglers could push recovery out indefinitely.
+//
+// This is the DERATING entry point: a genuine capacity/token-budget 503 feeds
+// all three trackers, including the gray-box capacity-503 rate window
+// (capacity_rate.go). A benign cold "model not loaded" lazy-load miss must go
+// to RecordCapacityRejectLifecycle instead so it does NOT derate the rate.
 func (r *Registry) RecordCapacityReject(providerID, modelID string) (tripped bool) {
+	return r.recordCapacityReject(providerID, modelID, true)
+}
+
+// RecordCapacityRejectLifecycle records a BENIGN lifecycle capacity miss — a
+// cold "model not loaded" lazy-load 404 on first touch. It feeds the
+// black-hole cooldown (a box that 404s FOREVER with zero accepts is still a
+// black hole, caught by the zero-interleaved-accepts discriminator) and,
+// harmlessly, the budget clamp (a budgetless-armed clamp never gates — see
+// budgetClampActiveLocked), but it does NOT derate the pair in the gray-box
+// capacity-503 RATE window. That window deliberately has NO accept-reset, so
+// counting a healthy box's normal reload misses would accumulate a false
+// reject rate and penalize it as if its reported budget were dishonest. The
+// api layer routes cold "not loaded"/"no model loaded" rejections here;
+// genuine capacity/token-budget 503s go to RecordCapacityReject and DO derate.
+func (r *Registry) RecordCapacityRejectLifecycle(providerID, modelID string) (tripped bool) {
+	return r.recordCapacityReject(providerID, modelID, false)
+}
+
+// recordCapacityReject is the shared implementation. deratePair gates the
+// gray-box capacity-503 rate window: true for genuine capacity rejects, false
+// for benign lifecycle (cold-load) misses. The cooldown and the budget clamp
+// are fed on both paths.
+func (r *Registry) recordCapacityReject(providerID, modelID string, deratePair bool) (tripped bool) {
 	if providerID == "" || modelID == "" {
 		return false
 	}
@@ -174,10 +202,15 @@ func (r *Registry) RecordCapacityReject(providerID, modelID string) (tripped boo
 	// stops admission believing the pair's stale heartbeat budget immediately
 	// (budget_clamp.go), and the rate window accumulates the reject side of the
 	// capacity-503 rate (capacity_rate.go — accepts deliberately do NOT reset
-	// it, unlike the strike streak below).
+	// it, unlike the strike streak below). The rate window is fed ONLY for a
+	// derating reject: a cold-load lifecycle miss (deratePair=false) is warm-up,
+	// not capacity dishonesty, and must not accumulate a rate the window can
+	// never reset off.
 	clampKey := capacityRejectKey{ProviderID: r.faultKeyLocked(providerID), ModelID: modelID}
 	r.recordBudgetClampLocked(clampKey, r.providerReportsTokenBudgetLocked(providerID, modelID), now)
-	r.recordCapacityRateRejectLocked(clampKey, now)
+	if deratePair {
+		r.recordCapacityRateRejectLocked(clampKey, now)
+	}
 
 	cfg := r.capacityCooldownCfg
 	if cfg.Threshold <= 0 {

--- a/coordinator/registry/capacity_cooldown.go
+++ b/coordinator/registry/capacity_cooldown.go
@@ -174,18 +174,26 @@ func (r *Registry) RecordCapacityReject(providerID, modelID string) (tripped boo
 }
 
 // RecordCapacityRejectLifecycle records a BENIGN lifecycle capacity miss — a
-// cold "model not loaded" lazy-load 404 on first touch. It feeds the
-// black-hole cooldown (a box that 404s FOREVER with zero accepts is still a
-// black hole, caught by the zero-interleaved-accepts discriminator) and,
-// harmlessly, the budget clamp (a budgetless-armed clamp never gates — see
-// budgetClampActiveLocked), but it does NOT derate the pair in the gray-box
-// capacity-503 RATE window. That window deliberately has NO accept-reset, so
-// counting a healthy box's normal reload misses would accumulate a false
-// reject rate and penalize it as if its reported budget were dishonest. The
-// api layer routes cold "not loaded"/"no model loaded" rejections here;
-// genuine capacity/token-budget 503s go to RecordCapacityReject and DO derate.
+// cold "model not loaded" lazy-load 404 on first touch, or the identical miss
+// after the 1h idle-unload (the normal fleet re-warm cycle). It feeds ONLY the
+// black-hole cooldown: a box that 404s FOREVER with zero accepts is still a
+// black hole, caught by the zero-interleaved-accepts discriminator.
+//
+// It arms NEITHER gray-box tracker. Not the rate window (no accept-reset, so
+// counting normal reload misses would accumulate a false reject rate) — and
+// not the budget clamp either: the lifecycle classification takes PRECEDENCE
+// over whatever the budget snapshot says. A provider that idle-unloaded the
+// model AFTER its last heartbeat still SHOWS the slot budget in the stale
+// snapshot, so keying the exemption on snapshot budgetless-ness (arming a
+// "budgetless" entry) would arm a REAL gating clamp from a routine re-warm
+// 404 — and with the clamp blocking dispatch, no accept could land to prove
+// release, stranding the pair until TTL. A cold miss is a statement about
+// model residency, never about token-budget honesty, so it must not touch the
+// clamp regardless of the snapshot. The api layer routes cold "not loaded"/
+// "no model loaded" rejections here; genuine capacity/token-budget 503s go to
+// RecordCapacityReject and feed everything.
 func (r *Registry) RecordCapacityRejectLifecycle(providerID, modelID string) (tripped bool) {
-	return r.recordCapacityReject(providerID, modelID, false, true)
+	return r.recordCapacityReject(providerID, modelID, false, false)
 }
 
 // RecordCapacityRejectRequestShape records a capacity-vocabulary rejection the

--- a/coordinator/registry/capacity_cooldown.go
+++ b/coordinator/registry/capacity_cooldown.go
@@ -165,9 +165,12 @@ type capacityRejectKey struct {
 // This is the DERATING entry point: a genuine capacity/token-budget 503 feeds
 // all three trackers, including the gray-box capacity-503 rate window
 // (capacity_rate.go). A benign cold "model not loaded" lazy-load miss must go
-// to RecordCapacityRejectLifecycle instead so it does NOT derate the rate.
+// to RecordCapacityRejectLifecycle instead so it does NOT derate the rate, and
+// a provably request-deterministic reject (oversized prompt — identical
+// fleet-wide) must go to RecordCapacityRejectRequestShape so it arms NO
+// gray-box state at all.
 func (r *Registry) RecordCapacityReject(providerID, modelID string) (tripped bool) {
-	return r.recordCapacityReject(providerID, modelID, true)
+	return r.recordCapacityReject(providerID, modelID, true, true)
 }
 
 // RecordCapacityRejectLifecycle records a BENIGN lifecycle capacity miss — a
@@ -182,14 +185,36 @@ func (r *Registry) RecordCapacityReject(providerID, modelID string) (tripped boo
 // api layer routes cold "not loaded"/"no model loaded" rejections here;
 // genuine capacity/token-budget 503s go to RecordCapacityReject and DO derate.
 func (r *Registry) RecordCapacityRejectLifecycle(providerID, modelID string) (tripped bool) {
-	return r.recordCapacityReject(providerID, modelID, false)
+	return r.recordCapacityReject(providerID, modelID, false, true)
+}
+
+// RecordCapacityRejectRequestShape records a capacity-vocabulary rejection the
+// api layer has PROVEN request-deterministic — a "batch token budget" reject
+// from a provider whose reported budget is not below the model context, so the
+// binding term was the model context and every provider rejects the same
+// prompt identically (classifyRejection: rejectionDeterministicUnservable).
+// Such a reject indicts the REQUEST, not the provider: it must arm NEITHER the
+// one-shot budget clamp NOR the no-reset rate window, or a single oversized
+// prompt would clamp/derate a healthy pair (and, for the clamp, block the very
+// dispatches whose accepts prove release).
+//
+// It still counts a cooldown STRIKE, deliberately: isCapacityRejectStrike
+// includes "batch token budget" because a box misreporting a huge budget
+// rejects NORMAL prompts with exactly this string — and such a box classifies
+// as request-deterministic here too (its advertised budget >= context IS the
+// lie). The cooldown's zero-interleaved-accepts discriminator is what makes
+// that safe for healthy pairs (threshold 5 in 60s with NO accept; any accept
+// resets the streak), a safety the clamp and rate window by design lack.
+func (r *Registry) RecordCapacityRejectRequestShape(providerID, modelID string) (tripped bool) {
+	return r.recordCapacityReject(providerID, modelID, false, false)
 }
 
 // recordCapacityReject is the shared implementation. deratePair gates the
-// gray-box capacity-503 rate window: true for genuine capacity rejects, false
-// for benign lifecycle (cold-load) misses. The cooldown and the budget clamp
-// are fed on both paths.
-func (r *Registry) recordCapacityReject(providerID, modelID string, deratePair bool) (tripped bool) {
+// gray-box capacity-503 rate window (true only for genuine capacity rejects);
+// armClamp gates the budget clamp (false only for request-deterministic
+// rejects, which indict the request rather than the provider). The cooldown
+// strike is fed on all paths.
+func (r *Registry) recordCapacityReject(providerID, modelID string, deratePair, armClamp bool) (tripped bool) {
 	if providerID == "" || modelID == "" {
 		return false
 	}
@@ -205,9 +230,13 @@ func (r *Registry) recordCapacityReject(providerID, modelID string, deratePair b
 	// it, unlike the strike streak below). The rate window is fed ONLY for a
 	// derating reject: a cold-load lifecycle miss (deratePair=false) is warm-up,
 	// not capacity dishonesty, and must not accumulate a rate the window can
-	// never reset off.
+	// never reset off. The clamp is armed only when the reject indicts the
+	// PROVIDER (armClamp=false for request-deterministic rejects — an oversized
+	// prompt says nothing about the pair's budget honesty).
 	clampKey := capacityRejectKey{ProviderID: r.faultKeyLocked(providerID), ModelID: modelID}
-	r.recordBudgetClampLocked(clampKey, r.providerReportsTokenBudgetLocked(providerID, modelID), now)
+	if armClamp {
+		r.recordBudgetClampLocked(clampKey, r.providerReportsTokenBudgetLocked(providerID, modelID), now)
+	}
 	if deratePair {
 		r.recordCapacityRateRejectLocked(clampKey, now)
 	}
@@ -378,8 +407,13 @@ func (r *Registry) RecordCapacityAcceptOutcome(providerID, modelID string, count
 	// (b) — never an instant release, which still needs a strictly-fresher
 	// heartbeat with meaningful headroom — and ONE served outcome for the rate
 	// window (which deliberately has NO reset semantics: the accept/reject mix
-	// IS the signal).
+	// IS the signal). Then drop the entry if it is now inactive (this accept
+	// completed the release proof, the TTL lapsed, or it was armed budgetless):
+	// a lingering inactive entry would keep every later accept for the pair off
+	// the read-lock fast path above and would re-block the identity's next
+	// budgetless reconnect window.
 	r.noteBudgetClampAcceptLocked(key)
+	r.dropInactiveBudgetClampLocked(providerID, modelID, now)
 	if countRateOutcome {
 		rateOutcomeRecorded = r.recordCapacityRateAcceptLocked(key, now)
 	}

--- a/coordinator/registry/capacity_rate.go
+++ b/coordinator/registry/capacity_rate.go
@@ -32,11 +32,17 @@ import (
 // still serves. Outcomes age out of the window naturally, so the penalty
 // decays on its own once the 503s stop.
 //
-// One served request counts as ONE accept outcome: the api layer records the
-// accept for this window at the commit point (first content chunk — or, on
-// paths that never commit content, at clean completion) and passes
-// countRateOutcome=false for the redundant completion-time accept
-// (RecordCapacityAcceptOutcome), so the denominator is per-dispatch honest.
+// One served request counts as ONE accept outcome: the api layer OFFERS the
+// accept at the commit point (first content chunk) and stamps the request when
+// the offer actually recorded (accepts are only stored while a reject is in
+// the window — see recordCapacityRateAcceptLocked); at clean completion it
+// re-offers only when the commit-time offer did not record
+// (!RateOutcomeCountedSafe), which covers both paths that never commit content
+// AND streams that committed BEFORE the pair's first windowed reject but were
+// still serving during it — without the re-offer those served requests would
+// vanish from the denominator and a few later rejects would overstate a
+// healthy pair's rate. Commit-recorded XOR completion-recorded, so the
+// denominator is per-dispatch honest.
 // Rejects are recorded once per failed dispatch attempt by
 // RecordCapacityReject.
 //
@@ -96,20 +102,23 @@ func (r *Registry) recordCapacityRateRejectLocked(key capacityRejectKey, now tim
 // RecordCapacityAccept's healthy-pair read-lock fast path intact (a served
 // request on a never-rejecting pair never takes the write lock for this).
 // Once the reject side has fully decayed, the pair's slices are dropped
-// instead — state returns to empty and the fast path is restored. Caller
-// holds the r.mu write lock (called from RecordCapacityAccept with
-// countRateOutcome=true).
-func (r *Registry) recordCapacityRateAcceptLocked(key capacityRejectKey, now time.Time) {
+// instead — state returns to empty and the fast path is restored. Returns
+// whether the accept was actually stored, so the api layer can stamp the
+// request (MarkRateOutcomeCounted) and let its completion re-offer when the
+// commit-time offer recorded nothing. Caller holds the r.mu write lock
+// (called from RecordCapacityAccept with countRateOutcome=true).
+func (r *Registry) recordCapacityRateAcceptLocked(key capacityRejectKey, now time.Time) (recorded bool) {
 	if r.capacityRateCfg.PenaltyMs <= 0 {
-		return
+		return false
 	}
 	if countInWindow(r.capacityRateRejects[key], now) == 0 {
 		delete(r.capacityRateRejects, key)
 		delete(r.capacityRateAccepts, key)
-		return
+		return false
 	}
 	sweepCapacityRateMapLocked(r.capacityRateAccepts, now)
 	r.capacityRateAccepts[key] = appendWindowedOutcome(r.capacityRateAccepts[key], now)
+	return true
 }
 
 // appendWindowedOutcome slides the window (keeps only in-window timestamps)

--- a/coordinator/registry/capacity_rate.go
+++ b/coordinator/registry/capacity_rate.go
@@ -1,0 +1,191 @@
+package registry
+
+import (
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/env"
+)
+
+// Capacity-503 rate penalty — the gray-box derater, the slow half of the
+// gray-box fix (see budget_clamp.go for the incident).
+//
+// A "gray box" fails a material FRACTION of its dispatches with
+// capacity-shaped 503s while serving the rest (prod: gemma per-request success
+// decayed 57%→25% over 20h on mixed boxes whose heartbeats looked idle). Every
+// zero-interleaved-accepts breaker is blind to it by construction: each accept
+// resets the pair cooldown streak and the node capacity streak. This tracker
+// deliberately has NO accept-triggered reset — that reset IS the blindness
+// being fixed. Instead it keeps a sliding window (capacityRateWindow) of
+// capacity-503s AND accepts per (stable identity, model) pair and computes
+//
+//	rate = capacity503s / (capacity503s + accepts)
+//
+// over the window. When the pair has at least capacityRateMinSample outcomes
+// and the rate exceeds capacityRateThreshold, the scheduler adds a cost
+// penalty PROPORTIONAL to the rate (rate × EIGENINFERENCE_CAPACITY_RATE_PENALTY_MS,
+// default 15000ms) to the pair's candidate in buildCandidateWithReason. A box
+// serving 75% fine keeps serving with a mild handicap; a 40%-error box sinks
+// well below the near-tie window (nearTieCostWindowMs = 3000) and only
+// receives traffic when healthier peers are worse. Nothing is ejected — the
+// candidate stays in the pool, so the fail-open selection machinery
+// (selectBestCandidateLockedFull) is untouched and a degraded-but-only fleet
+// still serves. Outcomes age out of the window naturally, so the penalty
+// decays on its own once the 503s stop.
+//
+// One served request counts as ONE accept outcome: the api layer records the
+// accept for this window at the commit point (first content chunk — or, on
+// paths that never commit content, at clean completion) and passes
+// countRateOutcome=false for the redundant completion-time accept
+// (RecordCapacityAcceptOutcome), so the denominator is per-dispatch honest.
+// Rejects are recorded once per failed dispatch attempt by
+// RecordCapacityReject.
+//
+// Keyed by the STABLE fault identity like every sibling tracker: reconnects
+// cannot reset the window, entries migrate on identity rebind
+// (migrateFaultStateLocked), Disconnect does NOT clear them, and the maps are
+// bounded by the same opportunistic >1024 sweep. Guarded by r.mu.
+const (
+	// envCapacityRatePenaltyMs scales the penalty (and is the kill switch: 0
+	// or negative disables the tracker entirely — no recording, no penalty).
+	envCapacityRatePenaltyMs = "EIGENINFERENCE_CAPACITY_RATE_PENALTY_MS"
+)
+
+const (
+	defaultCapacityRatePenaltyMs = 15_000.0
+	// capacityRateWindow is the sliding window outcomes are counted over.
+	capacityRateWindow = 5 * time.Minute
+	// capacityRateThreshold is the reject rate above which the penalty
+	// applies. Below it the pair pays nothing (occasional sheds from a busy
+	// box are normal and must stay penalty-free).
+	capacityRateThreshold = 0.25
+	// capacityRateMinSample is the minimum windowed outcomes
+	// (rejects + accepts) before a penalty can apply — a tiny unlucky sample
+	// must not derate a healthy pair (fail-open).
+	capacityRateMinSample = 8
+)
+
+// capacityRateConfig carries the env-tunable penalty scale, read once at
+// Registry construction, mirroring capacityCooldownConfig.
+type capacityRateConfig struct {
+	// PenaltyMs scales the cost penalty: penalty = rate × PenaltyMs once the
+	// threshold and minimum sample are met. <= 0 disables (kill switch).
+	PenaltyMs float64
+}
+
+func loadCapacityRateConfig() capacityRateConfig {
+	return capacityRateConfig{
+		PenaltyMs: env.EnvFloat(envCapacityRatePenaltyMs, defaultCapacityRatePenaltyMs),
+	}
+}
+
+// recordCapacityRateRejectLocked appends one capacity-503 outcome for the pair
+// and prunes the window. Caller holds the r.mu write lock (called from
+// RecordCapacityReject).
+func (r *Registry) recordCapacityRateRejectLocked(key capacityRejectKey, now time.Time) {
+	if r.capacityRateCfg.PenaltyMs <= 0 {
+		return
+	}
+	sweepCapacityRateMapLocked(r.capacityRateRejects, now)
+	r.capacityRateRejects[key] = appendWindowedOutcome(r.capacityRateRejects[key], now)
+}
+
+// recordCapacityRateAcceptLocked appends one served-dispatch outcome for the
+// pair and prunes the window. Accepts are recorded only while the pair has a
+// capacity-503 inside the window: the penalty math fast-exits at rejects==0
+// regardless, so pre-reject accepts add nothing, and skipping them keeps
+// RecordCapacityAccept's healthy-pair read-lock fast path intact (a served
+// request on a never-rejecting pair never takes the write lock for this).
+// Once the reject side has fully decayed, the pair's slices are dropped
+// instead — state returns to empty and the fast path is restored. Caller
+// holds the r.mu write lock (called from RecordCapacityAccept with
+// countRateOutcome=true).
+func (r *Registry) recordCapacityRateAcceptLocked(key capacityRejectKey, now time.Time) {
+	if r.capacityRateCfg.PenaltyMs <= 0 {
+		return
+	}
+	if countInWindow(r.capacityRateRejects[key], now) == 0 {
+		delete(r.capacityRateRejects, key)
+		delete(r.capacityRateAccepts, key)
+		return
+	}
+	sweepCapacityRateMapLocked(r.capacityRateAccepts, now)
+	r.capacityRateAccepts[key] = appendWindowedOutcome(r.capacityRateAccepts[key], now)
+}
+
+// appendWindowedOutcome slides the window (keeps only in-window timestamps)
+// and appends the new outcome, reusing the backing array.
+func appendWindowedOutcome(outcomes []time.Time, now time.Time) []time.Time {
+	kept := outcomes[:0]
+	for _, ts := range outcomes {
+		if now.Sub(ts) < capacityRateWindow {
+			kept = append(kept, ts)
+		}
+	}
+	return append(kept, now)
+}
+
+// sweepCapacityRateMapLocked bounds a rate map by dropping pairs whose newest
+// outcome has aged out of the window, once the map grows (mirrors the sibling
+// cooldown sweeps — churned session-keyed identities are never re-keyed).
+func sweepCapacityRateMapLocked(m map[capacityRejectKey][]time.Time, now time.Time) {
+	if len(m) <= 1024 {
+		return
+	}
+	for key, outcomes := range m {
+		if len(outcomes) == 0 || now.Sub(outcomes[len(outcomes)-1]) >= capacityRateWindow {
+			delete(m, key)
+		}
+	}
+}
+
+// countInWindow counts timestamps still inside the window without mutating the
+// slice, so read paths stay safe under r.mu.RLock.
+func countInWindow(outcomes []time.Time, now time.Time) int {
+	n := 0
+	for _, ts := range outcomes {
+		if now.Sub(ts) < capacityRateWindow {
+			n++
+		}
+	}
+	return n
+}
+
+// capacityRatePenaltyLocked returns the cost penalty (ms) and the measured
+// capacity-reject rate for the pair. Penalty is nonzero only when the window
+// holds at least capacityRateMinSample outcomes AND the rate exceeds
+// capacityRateThreshold; the rate is returned whenever computable so callers
+// can expose it for observability. READ-ONLY — callers hold r.mu in either
+// mode (buildCandidateWithReason runs under the selection locks).
+func (r *Registry) capacityRatePenaltyLocked(providerID, modelID string, now time.Time) (penaltyMs, rate float64) {
+	if r.capacityRateCfg.PenaltyMs <= 0 {
+		return 0, 0
+	}
+	key := capacityRejectKey{ProviderID: r.faultKeyLocked(providerID), ModelID: modelID}
+	rejects := countInWindow(r.capacityRateRejects[key], now)
+	if rejects == 0 {
+		return 0, 0 // hot-path fast exit: healthy pairs pay nothing
+	}
+	accepts := countInWindow(r.capacityRateAccepts[key], now)
+	total := rejects + accepts
+	rate = float64(rejects) / float64(total)
+	if total < capacityRateMinSample || rate <= capacityRateThreshold {
+		return 0, rate
+	}
+	return rate * r.capacityRateCfg.PenaltyMs, rate
+}
+
+// CapacityRejectRate exposes the pair's windowed capacity-reject rate and
+// sample count for tests and observability.
+func (r *Registry) CapacityRejectRate(providerID, modelID string) (rate float64, samples int) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	now := time.Now()
+	key := capacityRejectKey{ProviderID: r.faultKeyLocked(providerID), ModelID: modelID}
+	rejects := countInWindow(r.capacityRateRejects[key], now)
+	accepts := countInWindow(r.capacityRateAccepts[key], now)
+	total := rejects + accepts
+	if total == 0 {
+		return 0, 0
+	}
+	return float64(rejects) / float64(total), total
+}

--- a/coordinator/registry/capacity_rate_test.go
+++ b/coordinator/registry/capacity_rate_test.go
@@ -266,3 +266,56 @@ func TestCapacityRateNeverClosesRouting(t *testing.T) {
 		t.Fatal("penalty must be visible on the decision")
 	}
 }
+
+// A stream that commits BEFORE the pair's first windowed reject must still
+// enter the rate denominator when it is serving THROUGH the rejects: the
+// commit-time offer records nothing (accepts only store while a reject is
+// in-window), so the completion-time accept — keyed on the RECORDED outcome
+// (RateOutcomeCountedSafe), not on ContentCommittedSafe — re-offers it. Codex
+// review of #523: without this, a healthy pair serving long streams looked
+// like a 100%-reject gray box after a few later 503s.
+func TestCapacityRatePreRejectCommitCountsAtCompletion(t *testing.T) {
+	r := New(testLogger())
+	const model = "gemma-4-26b-qat-4bit"
+	p := makeTokenBudgetProvider(t, r, "pre-reject-commit", model, 100, grayBoxBudgetUsed, grayBoxBudgetMax, 100)
+
+	// Long stream commits first content while the pair is healthy: the offer
+	// must report NOT recorded (nothing in the reject window yet).
+	if recorded := r.RecordCapacityAccept(p.ID, model); recorded {
+		t.Fatal("commit-time accept with an empty reject window must not record a rate outcome")
+	}
+
+	// The box goes gray while the stream is still serving: 8 capacity-503s.
+	for i := 0; i < capacityRateMinSample; i++ {
+		r.RecordCapacityReject(p.ID, model)
+	}
+
+	// Completion: the api layer re-offers because the commit-time offer did
+	// not record (this is the noteInferenceSuccess wiring:
+	// countRateOutcome = !RateOutcomeCountedSafe → true here).
+	if recorded := r.RecordCapacityAcceptOutcome(p.ID, model, true); !recorded {
+		t.Fatal("completion-time re-offer during the reject window must record the request's one outcome")
+	}
+
+	rate, samples := r.CapacityRejectRate(p.ID, model)
+	if samples != capacityRateMinSample+1 {
+		t.Fatalf("samples = %d, want %d (8 rejects + the served stream)", samples, capacityRateMinSample+1)
+	}
+	wantRate := float64(capacityRateMinSample) / float64(capacityRateMinSample+1)
+	if rate != wantRate {
+		t.Fatalf("rate = %v, want %v — the served stream must be in the denominator", rate, wantRate)
+	}
+
+	// And the double-count guard: a request that commits DURING the reject
+	// window records at commit (offer returns true), so its completion-time
+	// call passes countRateOutcome=false and adds nothing.
+	if recorded := r.RecordCapacityAccept(p.ID, model); !recorded {
+		t.Fatal("commit-time accept with rejects in-window must record")
+	}
+	if recorded := r.RecordCapacityAcceptOutcome(p.ID, model, false); recorded {
+		t.Fatal("completion after a recorded commit must not record a second outcome")
+	}
+	if _, samples := r.CapacityRejectRate(p.ID, model); samples != capacityRateMinSample+2 {
+		t.Fatalf("samples = %d, want %d — one request must count exactly once", samples, capacityRateMinSample+2)
+	}
+}

--- a/coordinator/registry/capacity_rate_test.go
+++ b/coordinator/registry/capacity_rate_test.go
@@ -190,6 +190,37 @@ func TestCapacityRateOutcomeDedupe(t *testing.T) {
 	}
 }
 
+// A benign lifecycle capacity miss (cold "model not loaded" lazy-load) must
+// feed the black-hole cooldown but must NOT derate the gray-box capacity-503
+// RATE: that window has no accept-reset, so counting a healthy box's normal
+// reloads would penalize it as if its reported budget were dishonest. Contrast
+// RecordCapacityReject, which DOES derate. Codex review of #523.
+func TestCapacityRateLifecycleRejectFeedsCooldownNotRate(t *testing.T) {
+	r := New(testLogger())
+	const provider, model = "prov-lifecycle", "gemma-4-26b-qat-4bit"
+
+	// A pure run of lifecycle cold-404 misses (no accepts) must still trip the
+	// black-hole cooldown — a box that never loads is a black hole.
+	for i := 0; i < defaultCapacityCooldownThreshold; i++ {
+		r.RecordCapacityRejectLifecycle(provider, model)
+	}
+	if !r.CapacityCooldownActive(provider, model) {
+		t.Fatal("lifecycle cold-404 misses must still feed the black-hole cooldown (forever-404 = black hole)")
+	}
+	// ...but they must NOT have accumulated any gray-box capacity-503 rate.
+	if rate, samples := r.CapacityRejectRate(provider, model); samples != 0 || rate != 0 {
+		t.Fatalf("lifecycle misses derated the rate: rate=%.2f samples=%d, want 0/0 (the rate window must ignore cold-load misses)", rate, samples)
+	}
+
+	// A GENUINE derating reject on a fresh pair DOES accumulate the rate,
+	// proving the two entry points diverge only on the rate window.
+	const genuine = "prov-genuine"
+	seedRateOutcomes(r, genuine, model, capacityRateMinSample, 0)
+	if _, samples := r.CapacityRejectRate(genuine, model); samples != capacityRateMinSample {
+		t.Fatalf("genuine capacity rejects must derate: samples=%d, want %d", samples, capacityRateMinSample)
+	}
+}
+
 // Kill switch: EIGENINFERENCE_CAPACITY_RATE_PENALTY_MS=0 disables recording
 // and the penalty entirely.
 func TestCapacityRateKillSwitch(t *testing.T) {

--- a/coordinator/registry/capacity_rate_test.go
+++ b/coordinator/registry/capacity_rate_test.go
@@ -1,0 +1,268 @@
+package registry
+
+import (
+	"math"
+	"testing"
+	"time"
+)
+
+// Tests for the capacity-503 rate penalty (capacity_rate.go): the gray-box
+// derater. Unlike every zero-interleaved-accepts breaker, the rate window has
+// NO accept-triggered reset — a pair failing a material fraction of dispatches
+// while serving the rest accumulates an honest reject rate and pays a
+// proportional cost penalty; nothing is ejected and the penalty decays as
+// outcomes age out.
+
+// capacityRatePenaltyOf reads the pair's penalty and rate under the lock, as
+// buildCandidateWithReason does.
+func capacityRatePenaltyOf(r *Registry, providerID, model string) (penaltyMs, rate float64) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.capacityRatePenaltyLocked(providerID, model, time.Now())
+}
+
+// seedRateOutcomes drives the real entry points: rejects first (accepts only
+// count into the window while a reject is present — see
+// recordCapacityRateAcceptLocked), then accepts.
+func seedRateOutcomes(r *Registry, providerID, model string, rejects, accepts int) {
+	for i := 0; i < rejects; i++ {
+		r.RecordCapacityReject(providerID, model)
+	}
+	for i := 0; i < accepts; i++ {
+		r.RecordCapacityAcceptOutcome(providerID, model, true)
+	}
+}
+
+// ageCapacityRateRejects rewinds the pair's reject outcomes by d.
+func ageCapacityRateRejects(r *Registry, providerID, model string, d time.Duration) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	key := capacityRejectKey{ProviderID: r.faultKeyLocked(providerID), ModelID: model}
+	outcomes := r.capacityRateRejects[key]
+	aged := make([]time.Time, len(outcomes))
+	for i, ts := range outcomes {
+		aged[i] = ts.Add(-d)
+	}
+	r.capacityRateRejects[key] = aged
+}
+
+// Below the minimum sample no penalty may apply, no matter how bad the rate —
+// a tiny unlucky sample must not derate a healthy pair (fail-open).
+func TestCapacityRateBelowMinSampleNoPenalty(t *testing.T) {
+	r := New(testLogger())
+	const provider, model = "prov-small-sample", "gemma-4-26b-qat-4bit"
+
+	seedRateOutcomes(r, provider, model, 3, 2) // 5 outcomes, rate 0.6
+	if penalty, rate := capacityRatePenaltyOf(r, provider, model); penalty != 0 {
+		t.Fatalf("penalty = %v with only 5 outcomes (rate %.2f), want 0 below minSample %d", penalty, rate, capacityRateMinSample)
+	}
+	// Crossing the sample floor with the rate still above threshold turns the
+	// penalty on: 4R + 6A = 10 outcomes, rate 0.4.
+	seedRateOutcomes(r, provider, model, 1, 4)
+	penalty, rate := capacityRatePenaltyOf(r, provider, model)
+	if math.Abs(rate-0.4) > 1e-9 {
+		t.Fatalf("rate = %v, want 0.4", rate)
+	}
+	if want := 0.4 * defaultCapacityRatePenaltyMs; math.Abs(penalty-want) > 1e-6 {
+		t.Fatalf("penalty = %v, want rate x default = %v", penalty, want)
+	}
+}
+
+// The penalty is proportional to the rate and lands in the routing cost —
+// visible on the winning RoutingDecision's cost breakdown — while a pair at or
+// below the threshold pays nothing.
+func TestCapacityRatePenaltyInRoutingCost(t *testing.T) {
+	t.Setenv(envBudgetClamp, "false") // isolate the rate mechanism from the clamp
+	r := New(testLogger())
+	const model = "gemma-4-26b-qat-4bit"
+	p := makeTokenBudgetProvider(t, r, "rated-box", model, 100, 0, 5_000_000, 100)
+
+	// 4 rejects + 6 accepts = rate 0.4 over 10 outcomes.
+	seedRateOutcomes(r, p.ID, model, 4, 6)
+
+	sel, decision := r.ReserveProviderEx(model, &PendingRequest{
+		RequestID: "rate-cost", Model: model, EstimatedPromptTokens: 100, RequestedMaxTokens: 256,
+	})
+	if sel == nil {
+		t.Fatal("penalized pair must STILL be routable (derated, never ejected)")
+	}
+	sel.RemovePending("rate-cost")
+	r.SetProviderIdle(sel.ID)
+
+	wantPenalty := 0.4 * defaultCapacityRatePenaltyMs
+	if math.Abs(decision.CapacityRateMs-wantPenalty) > 1e-6 {
+		t.Fatalf("decision.CapacityRateMs = %v, want %v", decision.CapacityRateMs, wantPenalty)
+	}
+	if math.Abs(decision.CapacityRejectRate-0.4) > 1e-9 {
+		t.Fatalf("decision.CapacityRejectRate = %v, want 0.4", decision.CapacityRejectRate)
+	}
+	// The breakdown-sum invariant must hold with the new term.
+	sum := decision.StateMs + decision.QueueMs + decision.PendingMs +
+		decision.BacklogMs + decision.ThisReqMs + decision.HealthMs + decision.CapacityRateMs
+	if diff := sum - decision.CostMs; diff > 0.001 || diff < -0.001 {
+		t.Fatalf("breakdown sum %f != CostMs %f", sum, decision.CostMs)
+	}
+}
+
+// At or below the threshold the pair pays nothing: a box serving with
+// occasional sheds keeps its normal ranking.
+func TestCapacityRateAtThresholdNoPenalty(t *testing.T) {
+	r := New(testLogger())
+	const provider, model = "prov-threshold", "gemma-4-26b-qat-4bit"
+
+	// 2 rejects + 6 accepts = rate 0.25 == threshold (not strictly above).
+	seedRateOutcomes(r, provider, model, 2, 6)
+	if penalty, rate := capacityRatePenaltyOf(r, provider, model); penalty != 0 {
+		t.Fatalf("penalty = %v at rate %.2f == threshold, want 0 (strictly-above semantics)", penalty, rate)
+	}
+}
+
+// Outcomes age out of the window naturally — no reset event required. Once the
+// rejects decay the penalty is gone, and the next accept clears the residual
+// state entirely (restoring the healthy-pair fast path).
+func TestCapacityRateDecays(t *testing.T) {
+	r := New(testLogger())
+	const provider, model = "prov-decay", "gemma-4-26b-qat-4bit"
+
+	seedRateOutcomes(r, provider, model, 4, 6)
+	if penalty, _ := capacityRatePenaltyOf(r, provider, model); penalty <= 0 {
+		t.Fatal("setup: penalty must be active at rate 0.4")
+	}
+	ageCapacityRateRejects(r, provider, model, capacityRateWindow+time.Second)
+	if penalty, rate := capacityRatePenaltyOf(r, provider, model); penalty != 0 || rate != 0 {
+		t.Fatalf("penalty=%v rate=%v after the rejects aged out, want 0/0", penalty, rate)
+	}
+	// An accept on the fully-decayed pair clears the residual slices.
+	r.RecordCapacityAcceptOutcome(provider, model, true)
+	r.mu.RLock()
+	key := capacityRejectKey{ProviderID: provider, ModelID: model}
+	_, hasRejects := r.capacityRateRejects[key]
+	_, hasAccepts := r.capacityRateAccepts[key]
+	r.mu.RUnlock()
+	if hasRejects || hasAccepts {
+		t.Fatal("decayed rate state must be dropped on the next accept")
+	}
+}
+
+// THE gray-box property: accepts must NOT reset the reject side of the window
+// (that reset is the blindness being fixed). Contrast with the cooldown strike
+// streak, which the same accept call deliberately clears.
+func TestCapacityRateAcceptsDoNotResetRejects(t *testing.T) {
+	r := New(testLogger())
+	const provider, model = "prov-noreset", "gemma-4-26b-qat-4bit"
+
+	seedRateOutcomes(r, provider, model, 4, 0)
+	for i := 0; i < 6; i++ {
+		r.RecordCapacityAccept(provider, model)
+	}
+	rate, samples := r.CapacityRejectRate(provider, model)
+	if samples != 10 || math.Abs(rate-0.4) > 1e-9 {
+		t.Fatalf("rate window after interleaved accepts = (rate %.2f, samples %d), want (0.40, 10) — accepts must add to the denominator, never wipe the rejects", rate, samples)
+	}
+	// The cooldown strike streak WAS cleared by those accepts (its designed
+	// discriminator) — proving the two trackers are decoupled.
+	r.mu.RLock()
+	strikes := len(r.capacityRejectStrikes[capacityRejectKey{ProviderID: provider, ModelID: model}])
+	r.mu.RUnlock()
+	if strikes != 0 {
+		t.Fatalf("cooldown strikes = %d after accepts, want 0 (accept-reset is the cooldown's contract)", strikes)
+	}
+}
+
+// One served request counts ONE outcome: the completion-time accept after a
+// commit-time accept must not double-count (countRateOutcome=false), or the
+// denominator dilutes and the measured rate reads low.
+func TestCapacityRateOutcomeDedupe(t *testing.T) {
+	r := New(testLogger())
+	const provider, model = "prov-dedupe", "gemma-4-26b-qat-4bit"
+
+	seedRateOutcomes(r, provider, model, 4, 0)
+	for i := 0; i < 6; i++ {
+		r.RecordCapacityAcceptOutcome(provider, model, true)  // commit-time
+		r.RecordCapacityAcceptOutcome(provider, model, false) // completion-time (same request)
+	}
+	rate, samples := r.CapacityRejectRate(provider, model)
+	if samples != 10 {
+		t.Fatalf("samples = %d, want 10 — the completion-time accept double-counted", samples)
+	}
+	if math.Abs(rate-0.4) > 1e-9 {
+		t.Fatalf("rate = %v, want 0.4", rate)
+	}
+}
+
+// Kill switch: EIGENINFERENCE_CAPACITY_RATE_PENALTY_MS=0 disables recording
+// and the penalty entirely.
+func TestCapacityRateKillSwitch(t *testing.T) {
+	t.Setenv(envCapacityRatePenaltyMs, "0")
+	r := New(testLogger())
+	const provider, model = "prov-rate-off", "gemma-4-26b-qat-4bit"
+
+	seedRateOutcomes(r, provider, model, 10, 2)
+	if penalty, rate := capacityRatePenaltyOf(r, provider, model); penalty != 0 || rate != 0 {
+		t.Fatalf("disabled tracker returned penalty=%v rate=%v, want 0/0", penalty, rate)
+	}
+	if _, samples := r.CapacityRejectRate(provider, model); samples != 0 {
+		t.Fatalf("disabled tracker recorded %d outcomes, want 0", samples)
+	}
+}
+
+// The env tunable scales the penalty.
+func TestCapacityRatePenaltyEnvTunable(t *testing.T) {
+	t.Setenv(envCapacityRatePenaltyMs, "30000")
+	r := New(testLogger())
+	const provider, model = "prov-rate-env", "gemma-4-26b-qat-4bit"
+
+	seedRateOutcomes(r, provider, model, 4, 6) // rate 0.4
+	penalty, _ := capacityRatePenaltyOf(r, provider, model)
+	if want := 0.4 * 30_000.0; math.Abs(penalty-want) > 1e-6 {
+		t.Fatalf("penalty = %v, want %v with EIGENINFERENCE_CAPACITY_RATE_PENALTY_MS=30000", penalty, want)
+	}
+}
+
+// The rate window keys by STABLE identity: disconnect/reconnect with the same
+// serial keeps the accumulated outcomes.
+func TestCapacityRateSurvivesReconnect(t *testing.T) {
+	r := New(testLogger())
+	const model, serial = "gemma-4-26b-qat-4bit", "SER-RATE"
+
+	p1 := attestSchedulerProvider(t, r, "rate-sess-1", model, serial, 100)
+	seedRateOutcomes(r, p1.ID, model, 4, 6)
+	r.Disconnect("rate-sess-1")
+
+	p2 := attestSchedulerProvider(t, r, "rate-sess-2", model, serial, 100)
+	rate, samples := r.CapacityRejectRate(p2.ID, model)
+	if samples != 10 || math.Abs(rate-0.4) > 1e-9 {
+		t.Fatalf("rate window after reconnect = (rate %.2f, samples %d), want (0.40, 10) — the window was wiped by the reconnect", rate, samples)
+	}
+	if penalty, _ := capacityRatePenaltyOf(r, p2.ID, model); penalty <= 0 {
+		t.Fatal("penalty must still apply through the reconnected session")
+	}
+}
+
+// The penalty derates without ejecting: with every peer WORSE than the
+// penalized pair, the pair still serves (the fail-open selection machinery is
+// untouched).
+func TestCapacityRateNeverClosesRouting(t *testing.T) {
+	t.Setenv(envBudgetClamp, "false")
+	r := New(testLogger())
+	const model = "gemma-4-26b-qat-4bit"
+	p := makeTokenBudgetProvider(t, r, "only-box", model, 100, 0, 5_000_000, 100)
+
+	// Drive the rate high (0.75, well over the sample floor) while keeping
+	// accepts interleaved, so the pair COOLDOWN (zero-interleaved-accepts
+	// discriminator) never trips and the rate penalty is the mechanism under
+	// test.
+	for i := 0; i < 4; i++ {
+		seedRateOutcomes(r, p.ID, model, 3, 1)
+	}
+	sel, decision := r.ReserveProviderEx(model, &PendingRequest{
+		RequestID: "sole", Model: model, EstimatedPromptTokens: 100, RequestedMaxTokens: 256,
+	})
+	if sel == nil {
+		t.Fatalf("a fully-penalized pair must remain routable when it is the only candidate (decision: %+v)", decision)
+	}
+	sel.RemovePending("sole")
+	if decision.CapacityRateMs <= 0 {
+		t.Fatal("penalty must be visible on the decision")
+	}
+}

--- a/coordinator/registry/health_ejection.go
+++ b/coordinator/registry/health_ejection.go
@@ -294,6 +294,39 @@ func (r *Registry) migrateFaultStateLocked(oldKey, newKey string) {
 		}
 	}
 
+	// Gray-box budget clamp: the entry with the LATER clamp time wins whole
+	// (its clampedAt anchors both the TTL and the release-freshness check, and
+	// its acceptedSince belongs to that clamp window).
+	for k, entry := range r.budgetClamps {
+		if k.ProviderID == oldKey {
+			nk := k
+			nk.ProviderID = newKey
+			if cur, ok := r.budgetClamps[nk]; !ok || entry.clampedAt.After(cur.clampedAt) {
+				r.budgetClamps[nk] = entry
+			}
+			delete(r.budgetClamps, k)
+		}
+	}
+
+	// Capacity-503 rate windows: union the outcome slices (window pruning
+	// re-normalizes them on the next record / read), like the strike slices.
+	for k, outcomes := range r.capacityRateRejects {
+		if k.ProviderID == oldKey {
+			nk := k
+			nk.ProviderID = newKey
+			r.capacityRateRejects[nk] = append(r.capacityRateRejects[nk], outcomes...)
+			delete(r.capacityRateRejects, k)
+		}
+	}
+	for k, outcomes := range r.capacityRateAccepts {
+		if k.ProviderID == oldKey {
+			nk := k
+			nk.ProviderID = newKey
+			r.capacityRateAccepts[nk] = append(r.capacityRateAccepts[nk], outcomes...)
+			delete(r.capacityRateAccepts, k)
+		}
+	}
+
 	// Stable-identity health ejection.
 	if w, ok := r.healthEjectionWindows[oldKey]; ok {
 		if dst, exists := r.healthEjectionWindows[newKey]; exists {

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -1318,6 +1318,26 @@ type Registry struct {
 	capacityCooldowns     map[capacityRejectKey]*capacityCooldownEntry // cooldown expiry + half-open probe claim per (provider, model)
 	capacityCooldownTrips map[capacityRejectKey]int                    // trip count per (provider, model) (exponential backoff)
 
+	// budgetClamps implements the gray-box budget clamp (budget_clamp.go):
+	// after a capacity-shaped 503, admission stops believing the pair's
+	// stale-optimistic heartbeat budget and treats the slot as FULL until the
+	// provider proves recovery (fresh heartbeat with headroom + an accept) or
+	// the clamp TTL fail-opens. Keyed by stable fault identity; migrated on
+	// rebind; NOT cleared on Disconnect. Guarded by r.mu.
+	budgetClampCfg budgetClampConfig
+	budgetClamps   map[capacityRejectKey]*budgetClampEntry
+
+	// capacityRateRejects / capacityRateAccepts implement the capacity-503
+	// rate penalty (capacity_rate.go): sliding windows of capacity rejects and
+	// served dispatches per (stable identity, model). Unlike every breaker
+	// above there is NO accept-triggered reset — the rate is exactly the
+	// gray-box signal the zero-interleaved-accepts discriminators are blind
+	// to. Keyed by stable fault identity; migrated on rebind; NOT cleared on
+	// Disconnect. Guarded by r.mu.
+	capacityRateCfg     capacityRateConfig
+	capacityRateRejects map[capacityRejectKey][]time.Time
+	capacityRateAccepts map[capacityRejectKey][]time.Time
+
 	// Stable-identity health ejection (health_ejection.go). Keyed by a STABLE
 	// identity (serial/SE-key/account), NOT the session UUID, and DELIBERATELY
 	// NOT deleted on Disconnect — so a zombie that fails ~every request while
@@ -1432,6 +1452,11 @@ func New(logger *slog.Logger) *Registry {
 		capacityRejectStrikes:          make(map[capacityRejectKey][]time.Time),
 		capacityCooldowns:              make(map[capacityRejectKey]*capacityCooldownEntry),
 		capacityCooldownTrips:          make(map[capacityRejectKey]int),
+		budgetClampCfg:                 loadBudgetClampConfig(),
+		budgetClamps:                   make(map[capacityRejectKey]*budgetClampEntry),
+		capacityRateCfg:                loadCapacityRateConfig(),
+		capacityRateRejects:            make(map[capacityRejectKey][]time.Time),
+		capacityRateAccepts:            make(map[capacityRejectKey][]time.Time),
 		healthEjectionWindows:          make(map[string]*providerHealthWindow),
 		healthEjectionUntil:            make(map[string]time.Time),
 		healthEjectionTrips:            make(map[string]int),

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -215,6 +215,15 @@ type PendingRequest struct {
 	// timingMu (written in the dispatch/handler goroutine, read in the provider
 	// read-loop goroutine).
 	contentCommitted bool
+	// rateOutcomeCounted marks that this request's ONE capacity-503 rate
+	// outcome (capacity_rate.go denominator) was recorded by the commit-time
+	// accept — RecordCapacityAccept returned rateOutcomeRecorded=true. The
+	// completion-time accept (noteInferenceSuccess) re-offers the outcome only
+	// when this is false, so a stream that committed BEFORE the pair's first
+	// windowed reject but was still serving during it still counts, and a
+	// commit-recorded request cannot double-count. Guarded by timingMu like
+	// contentCommitted (same writer/reader goroutines).
+	rateOutcomeCounted bool
 }
 
 // MarkFirstChunkArrived stamps Timing.FirstChunkAt to now exactly once, under
@@ -299,6 +308,32 @@ func (pr *PendingRequest) ContentCommittedSafe() bool {
 	pr.timingMu.Lock()
 	defer pr.timingMu.Unlock()
 	return pr.contentCommitted
+}
+
+// MarkRateOutcomeCounted records that the commit-time capacity accept stored
+// this request's one capacity-503 rate outcome (see the rateOutcomeCounted
+// field). Called in the dispatch/handler goroutine right after
+// RecordCapacityAccept returns rateOutcomeRecorded=true.
+func (pr *PendingRequest) MarkRateOutcomeCounted() {
+	if pr == nil {
+		return
+	}
+	pr.timingMu.Lock()
+	pr.rateOutcomeCounted = true
+	pr.timingMu.Unlock()
+}
+
+// RateOutcomeCountedSafe reports whether the commit-time accept already stored
+// this request's rate outcome, read under timingMu. The completion-time accept
+// (noteInferenceSuccess) uses it to decide whether the request still owes its
+// one denominator entry.
+func (pr *PendingRequest) RateOutcomeCountedSafe() bool {
+	if pr == nil {
+		return false
+	}
+	pr.timingMu.Lock()
+	defer pr.timingMu.Unlock()
+	return pr.rateOutcomeCounted
 }
 
 type TokenAdmission struct {

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -2779,6 +2779,15 @@ func (r *Registry) Heartbeat(id string, msg *protocol.HeartbeatMessage) {
 	}
 	p.mu.Unlock()
 
+	// This heartbeat may be the release proof for a budget clamp
+	// (budget_clamp.go): drop any clamp entry this heartbeat's snapshot proves
+	// inactive so a released pair returns to the accept fast path and cannot
+	// be re-blocked by a lingering entry on its next reconnect. The sweep
+	// evaluates the heartbeat's OWN stamped time and report (not a re-read of
+	// the provider), so a racing disconnect cannot void the release proof.
+	// Cheap no-op probe when the provider has no clamp state.
+	r.releaseBudgetClampsOnHeartbeat(id, now, msg.BackendCapacity)
+
 	r.PersistProviderThrottled(p)
 	// Persist accumulated uptime (throttled) so it survives restarts/reconnects;
 	// the heartbeat path is otherwise the only place uptime grows.

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -1150,15 +1150,17 @@ func (r *Registry) snapshotProviderLockedEx(p *Provider, model string, traits Re
 
 	// Gray-box budget clamp (budget_clamp.go): when a capacity-503 has proven
 	// the pair's live gate is rejecting, admission must not believe the
-	// stale-optimistic heartbeat budget. Only budget-reporting slots are
-	// clamped; p.LastHeartbeat is when the CURRENT BackendCapacity was
-	// delivered (Heartbeat stamps both in one critical section), which is what
-	// the release-freshness check compares against the clamp time. p.mu and
-	// r.mu are both held here (see lock discipline above).
-	if snap.activeTokenBudgetMax > 0 {
-		rawRemaining := snap.activeTokenBudgetMax - snap.activeTokenBudgetUsed - snap.queuedTokenBudget
-		snap.budgetClamped = r.budgetClampActiveLocked(p.ID, model, p.LastHeartbeat, rawRemaining, now)
-	}
+	// stale-optimistic heartbeat budget. Evaluated for budgetless snapshots
+	// too — a reconnected session has no BackendCapacity until its first
+	// heartbeat, and a clamp armed on a budget-reporting pair must keep
+	// holding through that window instead of shedding onto the legacy memory
+	// path (never-budget-reporting legacy pairs stay exempt inside the check).
+	// p.LastHeartbeat is when the CURRENT BackendCapacity was delivered
+	// (Heartbeat stamps both in one critical section), which is what the
+	// release-freshness check compares against the clamp time. p.mu and r.mu
+	// are both held here (see lock discipline above).
+	rawRemaining := snap.activeTokenBudgetMax - snap.activeTokenBudgetUsed - snap.queuedTokenBudget
+	snap.budgetClamped = r.budgetClampActiveLocked(p.ID, model, p.LastHeartbeat, rawRemaining, snap.activeTokenBudgetMax > 0, now)
 
 	return snap, true
 }
@@ -1203,16 +1205,19 @@ func reportedFreeForLoadAdmits(catalogSizeGB float64, freeForLoadGB *float64) (a
 // Providers that report a token budget use budget-based admission;
 // legacy providers fall back to memory-based estimation.
 func freeMemoryAdmits(snap routingSnapshot, reqPromptTokens, reqMaxTokens int) bool {
+	// Gray-box budget clamp: a capacity-503 proved the provider's live gate
+	// rejects while the heartbeat budget below still advertises headroom
+	// (stale-optimistic). While the clamp holds, the slot is FULL — no
+	// request fits — until the provider proves recovery (fresh heartbeat with
+	// headroom + an accept) or the clamp TTL fail-opens. Checked BEFORE the
+	// budget branch: a clamped budget-reporting pair whose current session
+	// has no budget snapshot yet (reconnect before the first heartbeat) must
+	// reject here, not fall through to the legacy memory path below. See
+	// budget_clamp.go.
+	if snap.budgetClamped {
+		return false
+	}
 	if snap.activeTokenBudgetMax > 0 {
-		// Gray-box budget clamp: a capacity-503 proved the provider's live
-		// gate rejects while the heartbeat budget below still advertises
-		// headroom (stale-optimistic). While the clamp holds, the slot is
-		// FULL — no request fits — until the provider proves recovery (fresh
-		// heartbeat with headroom + an accept) or the clamp TTL fail-opens.
-		// See budget_clamp.go.
-		if snap.budgetClamped {
-			return false
-		}
 		requestTokens := int64(reqPromptTokens) + int64(reqMaxTokens)
 		// Include coordinator-side pending tokens not yet reflected in the
 		// provider's heartbeat. Avoid double-counting active/queued backend
@@ -2094,11 +2099,10 @@ func (r *Registry) quickCapacityCheck(model string, estimatedPromptTokens, reque
 		snap.fleetMedianTPS = r.tpsRegistry.Median(model, p.Hardware.ChipFamily)
 
 		// Gray-box budget clamp — same evaluation as snapshotProviderLockedEx
+		// (including the budgetless-snapshot hold for reconnecting sessions)
 		// so the preflight cannot report capacity that routing then refuses.
-		if snap.activeTokenBudgetMax > 0 {
-			rawRemaining := snap.activeTokenBudgetMax - snap.activeTokenBudgetUsed - snap.queuedTokenBudget
-			snap.budgetClamped = r.budgetClampActiveLocked(p.ID, model, p.LastHeartbeat, rawRemaining, now)
-		}
+		rawRemaining := snap.activeTokenBudgetMax - snap.activeTokenBudgetUsed - snap.queuedTokenBudget
+		snap.budgetClamped = r.budgetClampActiveLocked(p.ID, model, p.LastHeartbeat, rawRemaining, snap.activeTokenBudgetMax > 0, now)
 
 		p.mu.Unlock()
 

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -97,6 +97,16 @@ type routingSnapshot struct {
 	activeTokenBudgetUsed int64
 	activeTokenBudgetMax  int64
 	queuedTokenBudget     int64
+	// budgetClamped means the gray-box budget clamp (budget_clamp.go) is
+	// active for this (provider, model) pair: a capacity-shaped 503 proved the
+	// provider's LIVE admission gate is rejecting, so the heartbeat budget
+	// above is stale-optimistic and admission must treat the slot as FULL
+	// (freeMemoryAdmits rejects; providerBudgetFits reports zero live
+	// headroom). The budget fields themselves stay RAW — cost/backlog math,
+	// the structural servability ceiling (snapshotStructuralBudget), and
+	// telemetry keep reading the provider-reported truth. Only set when the
+	// slot reports a token budget (activeTokenBudgetMax > 0).
+	budgetClamped bool
 	// kvBytesPerToken is the provider-reported per-token KV-cache cost (bytes)
 	// for THIS model's slot (BackendSlotCapacity.KVBytesPerToken). 0 = unreported
 	// (callers fall back to the kvCacheBytesPerToken default). Used by the
@@ -128,6 +138,10 @@ type routingCandidate struct {
 	effectiveQueue int
 	breakdown      costBreakdown
 	effectiveTPS   float64 // Phase 4 load-scaled TPS used in this candidate's cost
+	// capacityRejectRate is the pair's windowed capacity-503 rate
+	// (capacity_rate.go), captured at candidate build so the winning
+	// RoutingDecision can expose it. 0 when no rejects are in the window.
+	capacityRejectRate float64
 }
 
 // candidateRejection enumerates why a provider that passed structural
@@ -192,7 +206,12 @@ type costBreakdown struct {
 	BacklogMs float64
 	ThisReqMs float64
 	HealthMs  float64
-	TTFTMs    float64 // calibrated TTFT estimate for this candidate (gate/ceiling input)
+	// CapacityRateMs is the gray-box capacity-503 rate penalty
+	// (capacity_rate.go): rate × EIGENINFERENCE_CAPACITY_RATE_PENALTY_MS once
+	// the pair's windowed reject rate clears the threshold with a minimum
+	// sample. 0 for healthy pairs, so the cost is byte-for-byte unchanged.
+	CapacityRateMs float64
+	TTFTMs         float64 // calibrated TTFT estimate for this candidate (gate/ceiling input)
 	// RawTTFTMs is the pre-calibration ttftMsFromSnapshot value. The calibrator
 	// learns against it (see ttft_calibration.go) so the feedback loop converges
 	// on the absolute actual/predicted ratio instead of compounding.
@@ -204,18 +223,27 @@ type costBreakdown struct {
 // selection. Returned by ReserveProviderEx so callers can emit metrics
 // and structured logs without reaching into registry internals.
 type RoutingDecision struct {
-	ProviderID         string  // winning provider, empty if no selection
-	Model              string  // requested model
-	CostMs             float64 // total cost of the winning candidate
-	StateMs            float64 // slot-state penalty contribution
-	QueueMs            float64 // pendingForModel × queueDepthPenaltyMs
-	PendingMs          float64 // totalPending × totalPendingPenaltyMs
-	BacklogMs          float64 // tokens-ahead / decodeTPS contribution
-	ThisReqMs          float64 // this request's prefill+decode contribution
-	HealthMs           float64 // memory/CPU/thermal/GPU-util contribution
-	EffectiveQueue     int     // max(pendingForModel, backendRunning+backendWaiting)
-	CandidateCount     int     // total candidates that passed all gates
-	CapacityRejections int     // candidates rejected by the free-memory admission gate (transient: full)
+	ProviderID string  // winning provider, empty if no selection
+	Model      string  // requested model
+	CostMs     float64 // total cost of the winning candidate
+	StateMs    float64 // slot-state penalty contribution
+	QueueMs    float64 // pendingForModel × queueDepthPenaltyMs
+	PendingMs  float64 // totalPending × totalPendingPenaltyMs
+	BacklogMs  float64 // tokens-ahead / decodeTPS contribution
+	ThisReqMs  float64 // this request's prefill+decode contribution
+	HealthMs   float64 // memory/CPU/thermal/GPU-util contribution
+	// CapacityRateMs is the gray-box capacity-503 rate penalty added to the
+	// winner's cost (capacity_rate.go); 0 for healthy pairs. In-memory
+	// observability only — not persisted (inference_routes has no column and
+	// the schema is not altered for it).
+	CapacityRateMs float64
+	// CapacityRejectRate is the winner's windowed capacity-503 rate at
+	// selection time (rejects / (rejects + accepts)); 0 when no rejects are in
+	// the window. Same persistence note as CapacityRateMs.
+	CapacityRejectRate float64
+	EffectiveQueue     int // max(pendingForModel, backendRunning+backendWaiting)
+	CandidateCount     int // total candidates that passed all gates
+	CapacityRejections int // candidates rejected by the free-memory admission gate (transient: full)
 	// ModelTooLargeRejections counts providers that serve the model but whose
 	// total memory can never fit it (permanent). Kept separate from
 	// CapacityRejections so callers don't emit a 429/"over capacity, retry"
@@ -389,6 +417,8 @@ func (r *Registry) ReserveProviderEx(model string, pr *PendingRequest, excludeID
 		BacklogMs:               bd.BacklogMs,
 		ThisReqMs:               bd.ThisReqMs,
 		HealthMs:                bd.HealthMs,
+		CapacityRateMs:          bd.CapacityRateMs,
+		CapacityRejectRate:      selected.capacityRejectRate,
 		EffectiveQueue:          selected.effectiveQueue,
 		CandidateCount:          candidateCount,
 		CapacityRejections:      capacityRejections,
@@ -1118,6 +1148,18 @@ func (r *Registry) snapshotProviderLockedEx(p *Provider, model string, traits Re
 	snap.availableOnDisk = !snap.modelLoaded
 	snap.fleetMedianTPS = r.tpsRegistry.Median(model, p.Hardware.ChipFamily)
 
+	// Gray-box budget clamp (budget_clamp.go): when a capacity-503 has proven
+	// the pair's live gate is rejecting, admission must not believe the
+	// stale-optimistic heartbeat budget. Only budget-reporting slots are
+	// clamped; p.LastHeartbeat is when the CURRENT BackendCapacity was
+	// delivered (Heartbeat stamps both in one critical section), which is what
+	// the release-freshness check compares against the clamp time. p.mu and
+	// r.mu are both held here (see lock discipline above).
+	if snap.activeTokenBudgetMax > 0 {
+		rawRemaining := snap.activeTokenBudgetMax - snap.activeTokenBudgetUsed - snap.queuedTokenBudget
+		snap.budgetClamped = r.budgetClampActiveLocked(p.ID, model, p.LastHeartbeat, rawRemaining, now)
+	}
+
 	return snap, true
 }
 
@@ -1162,6 +1204,15 @@ func reportedFreeForLoadAdmits(catalogSizeGB float64, freeForLoadGB *float64) (a
 // legacy providers fall back to memory-based estimation.
 func freeMemoryAdmits(snap routingSnapshot, reqPromptTokens, reqMaxTokens int) bool {
 	if snap.activeTokenBudgetMax > 0 {
+		// Gray-box budget clamp: a capacity-503 proved the provider's live
+		// gate rejects while the heartbeat budget below still advertises
+		// headroom (stale-optimistic). While the clamp holds, the slot is
+		// FULL — no request fits — until the provider proves recovery (fresh
+		// heartbeat with headroom + an accept) or the clamp TTL fail-opens.
+		// See budget_clamp.go.
+		if snap.budgetClamped {
+			return false
+		}
 		requestTokens := int64(reqPromptTokens) + int64(reqMaxTokens)
 		// Include coordinator-side pending tokens not yet reflected in the
 		// provider's heartbeat. Avoid double-counting active/queued backend
@@ -1350,7 +1401,14 @@ func (r *Registry) buildCandidateWithReason(snap routingSnapshot, pr *PendingReq
 	}
 	thisReqMs += longPromptPenalty(reqPrompt, ttftBlockMs)
 	healthMs := healthPenaltyMs(snap.systemMetrics, snap.gpuMemoryActiveGB, snap.totalMemoryGB)
-	cost := statePenalty + queueMs + pendingMs + backlogMs + thisReqMs + healthMs
+	// Gray-box capacity-503 rate penalty (capacity_rate.go): a pair rejecting
+	// a material fraction of dispatches with capacity 503s — while serving the
+	// rest, so no zero-accepts breaker can see it — sinks in cost ranking
+	// proportionally to its windowed reject rate. A soft derater, never an
+	// ejection: the candidate stays in the pool, so a degraded-but-only fleet
+	// still serves, and the penalty decays as outcomes age out of the window.
+	capacityRateMs, capacityRejectRate := r.capacityRatePenaltyLocked(snap.provider.ID, snap.model, time.Now())
+	cost := statePenalty + queueMs + pendingMs + backlogMs + thisReqMs + healthMs + capacityRateMs
 
 	// Estimated time-to-first-token for this candidate. Used for the
 	// OpenRouter TTFT ceiling: public routes only select providers whose
@@ -1367,21 +1425,23 @@ func (r *Registry) buildCandidateWithReason(snap routingSnapshot, pr *PendingReq
 	ttftMs := calibratedTTFTMs(snap, rawTTFTMs)
 
 	return &routingCandidate{
-		provider:       snap.provider,
-		snapshot:       snap,
-		costMs:         cost,
-		effectiveQueue: effectiveQueue,
-		effectiveTPS:   effectiveTPS,
+		provider:           snap.provider,
+		snapshot:           snap,
+		costMs:             cost,
+		effectiveQueue:     effectiveQueue,
+		effectiveTPS:       effectiveTPS,
+		capacityRejectRate: capacityRejectRate,
 		breakdown: costBreakdown{
-			StateMs:   statePenalty,
-			QueueMs:   queueMs,
-			PendingMs: pendingMs,
-			BacklogMs: backlogMs,
-			ThisReqMs: thisReqMs,
-			HealthMs:  healthMs,
-			TTFTMs:    ttftMs,
-			RawTTFTMs: rawTTFTMs,
-			Total:     cost,
+			StateMs:        statePenalty,
+			QueueMs:        queueMs,
+			PendingMs:      pendingMs,
+			BacklogMs:      backlogMs,
+			ThisReqMs:      thisReqMs,
+			HealthMs:       healthMs,
+			CapacityRateMs: capacityRateMs,
+			TTFTMs:         ttftMs,
+			RawTTFTMs:      rawTTFTMs,
+			Total:          cost,
 		},
 	}, rejectNone, true
 }
@@ -2032,6 +2092,13 @@ func (r *Registry) quickCapacityCheck(model string, estimatedPromptTokens, reque
 		snap.modelLoaded = slotStateModelLoaded(snap.slotState)
 		snap.availableOnDisk = !snap.modelLoaded
 		snap.fleetMedianTPS = r.tpsRegistry.Median(model, p.Hardware.ChipFamily)
+
+		// Gray-box budget clamp — same evaluation as snapshotProviderLockedEx
+		// so the preflight cannot report capacity that routing then refuses.
+		if snap.activeTokenBudgetMax > 0 {
+			rawRemaining := snap.activeTokenBudgetMax - snap.activeTokenBudgetUsed - snap.queuedTokenBudget
+			snap.budgetClamped = r.budgetClampActiveLocked(p.ID, model, p.LastHeartbeat, rawRemaining, now)
+		}
 
 		p.mu.Unlock()
 

--- a/coordinator/registry/scheduler_test.go
+++ b/coordinator/registry/scheduler_test.go
@@ -64,7 +64,7 @@ func TestReserveProviderExReturnsCostBreakdown(t *testing.T) {
 	}
 	// Sum of components should approximately equal the total cost.
 	sum := decision.StateMs + decision.QueueMs + decision.PendingMs +
-		decision.BacklogMs + decision.ThisReqMs + decision.HealthMs
+		decision.BacklogMs + decision.ThisReqMs + decision.HealthMs + decision.CapacityRateMs
 	if diff := sum - decision.CostMs; diff > 0.001 || diff < -0.001 {
 		t.Fatalf("breakdown sum %f != CostMs %f", sum, decision.CostMs)
 	}

--- a/coordinator/registry/servability.go
+++ b/coordinator/registry/servability.go
@@ -144,6 +144,15 @@ func snapshotStructuralBudget(snap routingSnapshot) (budget int64, known bool) {
 // a merely-busy fleet ahead of the queue.
 func liveRemainingBudget(snap routingSnapshot) (budget int64, known bool) {
 	if snap.activeTokenBudgetMax > 0 {
+		// Gray-box budget clamp (budget_clamp.go): a capacity-503 proved the
+		// live gate rejects, so the pair's LIVE headroom is zero regardless of
+		// the stale-optimistic heartbeat budget. Live-semantics readers only —
+		// the STRUCTURAL ceiling (snapshotStructuralBudget → PredictServable)
+		// stays raw on purpose: the clamp is transient (TTL-bounded) and must
+		// never feed the fleet-level structural 429.
+		if snap.budgetClamped {
+			return 0, true
+		}
 		rem := snap.activeTokenBudgetMax - snap.activeTokenBudgetUsed - snap.queuedTokenBudget
 		if rem < 0 {
 			rem = 0


### PR DESCRIPTION
# PR body — `fix/budget-clamp-gray-box` @ `da7957ca`

> **Suggested title:** `fix(routing): gray-box budget clamp + capacity-503 rate penalty`
> **Base:** `master` (branched from `76447bc0`) · 1 commit · worktree `.worktrees/budget-clamp`
> **Deploy batch:** **A** (before the shed lift, before the v0.7.5 provider release)

## Problem

Postmortem **layers 3 and 4** (`docs/reports/2026-07-06-gemma4-serving-failure-postmortem.md`): during the Jul 6 open-pool window, mixed boxes co-resident with gpt-oss served ~60% of their gemma dispatches while failing the other ~40% with capacity-shaped 503s — **11,581 provider 503s in 6 hours** ("gray boxes").

- **Layer 3 — breakers blind by design:** every existing capacity breaker (pair cooldown in `capacity_cooldown.go`, node capacity streak in `health_ejection.go`) requires *zero interleaved accepts*; each accept reset the streak, so a box failing 40% of dispatches was never tripped.
- **Layer 4 — heartbeat trust:** the provider's live KV gate rejects while its last heartbeat still advertises a ~1.4%-used token budget (`active_token_budget_used` ~72k of ~5.2M at admit time). The heartbeat budget is stale-*optimistic*; coordinator admission believed it and kept dispatching.

## What changed (per commit)

One commit, `da7957ca`, two complementary mechanisms — both keyed by the **stable fault identity** (`faultKeyLocked`: serial → SE-key → account → session), migrated on identity rebind, never cleared on `Disconnect`:

1. **Budget clamp** (`coordinator/registry/budget_clamp.go`, new): on the first capacity-shaped 503 for a (provider, model) pair (same classified `RecordCapacityReject` entry point that feeds the cooldown), admission stops believing the pair's heartbeat budget — the slot is treated **FULL** (`freeMemoryAdmits` budget branch rejects; `liveRemainingBudget` in `servability.go` reports zero live headroom; the *structural* ceiling stays raw so the transient clamp can never feed the fleet-level structural 429). **Release requires provider-side proof, whichever lands later:** (a) a heartbeat delivered *strictly after* the clamp whose raw budget shows ≥ **1024 tokens** of headroom, and (b) an accept for the pair after the clamp. **Fail-open:** 5-minute TTL, so a zero-traffic pair can never strand; a re-reject re-arms. Scoped to budget-reporting slots only (`activeTokenBudgetMax > 0`) — legacy providers keep the existing threshold-5 pair cooldown and are never one-shot clamped.
2. **Capacity-503 rate penalty** (`coordinator/registry/capacity_rate.go`, new): a 5-minute sliding window of capacity-503s AND accepts per (identity, model) with **no accept-triggered reset** (that reset *was* the blindness). Above a 0.25 reject rate with ≥8 windowed outcomes, `buildCandidateWithReason` adds `rate × EIGENINFERENCE_CAPACITY_RATE_PENALTY_MS` (default 15,000 ms) to the candidate's cost — proportional deration, never ejection; fail-open selection untouched; the penalty decays as outcomes age out. One served request counts exactly one accept outcome: the completion-time accept is deduped against the commit-time accept via the new `RecordCapacityAcceptOutcome(provider, model, !pr.ContentCommittedSafe())` (`api/consumer.go`).

Observability: `RoutingDecision` gains `CapacityRateMs` and `CapacityRejectRate` (in-memory only — telemetry rows keep RAW budgets, **no DB schema change, wire protocol unchanged**). Both trackers are migrated in `migrateFaultStateLocked` (`health_ejection.go`) and bounded by the sibling >1024 opportunistic sweeps.

## Before / After

```mermaid
flowchart TB
  subgraph Before["Before — gray box invisible (layers 3+4)"]
    A1[dispatch to mixed box] --> B1{provider live KV gate}
    B1 -- "40%: capacity 503" --> C1[RecordCapacityReject<br/>streak +1]
    B1 -- "60%: serves" --> D1[RecordCapacityAccept<br/>streak RESET to 0]
    D1 --> E1[breaker never trips]
    C1 --> E1
    E1 --> F1[admission re-reads heartbeat budget:<br/>~1.4% used → believes it]
    F1 --> A1
  end
  subgraph After["After — clamp + rate penalty"]
    A2[dispatch to mixed box] --> B2{provider live KV gate}
    B2 -- "first capacity 503" --> C2[RecordCapacityReject →<br/>recordBudgetClampLocked +<br/>recordCapacityRateRejectLocked]
    C2 --> D2["slot treated FULL:<br/>freeMemoryAdmits=false,<br/>liveRemainingBudget=0"]
    D2 --> E2{"release proof?<br/>(a) fresher heartbeat ≥1024 headroom<br/>AND (b) accept after clamp"}
    E2 -- no --> F2[stays clamped, ≤5 min TTL fail-open]
    E2 -- yes --> G2[released; re-reject re-arms]
    B2 -- serves --> H2[accept counted ONCE in rate window,<br/>NO streak reset]
    H2 --> I2["rate >0.25 @ ≥8 outcomes →<br/>cost += rate × 15000ms<br/>(derated, never ejected)"]
  end
```

Code flow delta: `RecordCapacityReject` → *(new)* `recordBudgetClampLocked` + `recordCapacityRateRejectLocked`; `RecordCapacityAccept` → wrapper over *(new)* `RecordCapacityAcceptOutcome` → `noteBudgetClampAcceptLocked` + deduped `recordCapacityRateAcceptLocked`; `snapshotProviderLockedEx` / `quickCapacityCheck` → *(new)* `snap.budgetClamped` via `budgetClampActiveLocked`; `freeMemoryAdmits` + `liveRemainingBudget` consume it; `buildCandidateWithReason` → *(new)* `capacityRatePenaltyLocked` cost term.

## New envs

| Env | Default | Semantics | Runbook flip |
|---|---|---|---|
| `EIGENINFERENCE_BUDGET_CLAMP` | `true` | Kill switch for the budget clamp; `false`/`0` restores stale-heartbeat admission | Active from Deploy A; leave default. Kill switch only if clamp misbehaves |
| `EIGENINFERENCE_BUDGET_CLAMP_TTL_SECONDS` | `300` | Fail-open bound: a clamp never outlives `clampedAt + TTL` | Leave default |
| `EIGENINFERENCE_CAPACITY_RATE_PENALTY_MS` | `15000` | Penalty scale: `cost += rate × this` once rate >0.25 with ≥8 outcomes; `0`/negative disables the tracker entirely | Active from Deploy A; leave default |

(Window 5 min, threshold 0.25, min-sample 8, release headroom 1024 tokens are code constants, not envs.)

## Test evidence

`coordinator/registry/budget_clamp_test.go` (533 lines) + `capacity_rate_test.go` (268 lines):

- **`TestGrayBoxSelectionShareDropsWithFix`** — the prod gray-box scenario (40% 503s with interleaved accepts): selection share drops with the fix; monopoly preserved with both kill switches off (pins the old behavior).
- Clamp lifecycle: `TestBudgetClampBlocksAdmissionOnFirstCapacityReject`, `TestBudgetClampReleaseRequiresFreshHeartbeatAndAccept` (both orders), `TestBudgetClampNoMeaningfulHeadroomDoesNotRelease`, `TestBudgetClampTTLFailOpen`, `TestBudgetClampReArmResetsReleaseProof`, `TestBudgetClampLegacyBudgetlessProviderNotClamped`, `TestBudgetClampKillSwitch`.
- Rate window: `TestCapacityRateAcceptsDoNotResetRejects` (the core semantic), `TestCapacityRateOutcomeDedupe` (one outcome per served request), `TestCapacityRateBelowMinSampleNoPenalty`, `TestCapacityRateAtThresholdNoPenalty`, `TestCapacityRateDecays`, `TestCapacityRateNeverClosesRouting` (sole-candidate fail-open), `TestCapacityRateKillSwitch`.
- Identity: `TestBudgetClampSurvivesReconnect`, `TestCapacityRateSurvivesReconnect`, `TestBudgetClampAndRateStateMigrateOnFirstBind`; `TestBudgetClampAndRateConcurrentAccess` (-race hammer).

Suite status: full `registry` (-race) + `api` suites green, golangci-lint clean (Warden session); **re-verified 2026-07-07 by ship-prep: `go test ./registry/... ./api/...` ok in the worktree**.

## Review status

Built and tested by the **Warden** session (JOURNAL.md row, 2026-07-06): registry -race + api suites green, golangci-lint clean. Committed locally, not yet pushed — orchestrator review on the PR itself.

## Rollout notes

- **Deploy batch A** (with coord-a). Must precede any gemma shed lift.
- Nothing dormant: clamp + rate penalty are **active immediately at deploy** (defaults on). They only affect pairs that emit capacity-503s, so today's healthy fleet is byte-identical.
- Post-deploy verify with the postmortem gray-box SQL (appendix): capacity-503 share from previously-gray boxes must drop; watch clamp arm/release counts and `CapacityRejectRate` on routing decisions.
- Rollback: env kill switches (`EIGENINFERENCE_BUDGET_CLAMP=false`, `EIGENINFERENCE_CAPACITY_RATE_PENALTY_MS=0`) — no code revert needed.
- Merge-order note: conflicts with coord-a in `registry/scheduler.go` (both touch `snapshotProviderLockedEx`/`freeMemoryAdmits`); whichever merges second takes a small rebase. No conflict with coord-b.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/523"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786081377&installation_id=133247490&pr_number=523&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F523&signature=0db4d06810f9d1fea3760aa8caa8a56388d339330b3833b581a09b43db0f9adf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->