### PR TITLE
fix(registry): per-model solo-TPS quality caps + pooled-KV admission (postmortem layer 6)

### DIFF
--- a/coordinator/registry/concurrency_cap.go
+++ b/coordinator/registry/concurrency_cap.go
@@ -136,8 +136,12 @@ func (r *Registry) QualityCapOvercommit() float64 {
 // parseModelFloatMap parses the "model=value,..." CSV form (mirroring
 // envModelIntMap for EIGENINFERENCE_WARM_POOL_MIN_WARM, with float values).
 // Keys are lowercased so lookups on resolved build ids match
-// case-insensitively. Malformed entries and non-positive values are skipped;
-// an empty or all-invalid input yields nil (no entries). Shared by the
+// case-insensitively. Malformed, non-positive, and non-finite values are all
+// skipped — strconv.ParseFloat happily yields NaN and ±Inf ("m=NaN" passes a
+// naive v <= 0 filter because NaN comparisons are always false), and either
+// one flows into int(math.Ceil(...)) / qualityConcurrency as an
+// implementation-defined integer, silently strangling the model to cap 1.
+// An empty or all-invalid input yields nil (no entries). Shared by the
 // per-model overcommit overrides (qualityCapOvercommitByModelEnv) and the
 // solo-TPS seed (modelSoloTPSSeedEnv).
 func parseModelFloatMap(raw string) map[string]float64 {
@@ -160,7 +164,7 @@ func parseModelFloatMap(raw string) map[string]float64 {
 			continue
 		}
 		v, err := strconv.ParseFloat(strings.TrimSpace(value), 64)
-		if err != nil || v <= 0 {
+		if err != nil || math.IsNaN(v) || math.IsInf(v, 0) || v <= 0 {
 			continue
 		}
 		out[model] = v

--- a/coordinator/registry/concurrency_cap.go
+++ b/coordinator/registry/concurrency_cap.go
@@ -200,10 +200,12 @@ type soloModelTPS struct {
 // resolvedSoloModelTPSLocked resolves the static solo decode rate the quality
 // cap should use for (p, model). Fallback chain, most- to least-specific:
 //
-//  1. per-(model, chip) solo median — gated samples only (solo_tps.go) — once
-//     it has ≥ qualityCapSoloMinSamples samples;
-//  2. model-wide solo median pooled across chip families (conservative
-//     cross-chip transfer), same sample floor;
+//  1. per-(model, chip CLASS) solo median — gated samples only (solo_tps.go),
+//     keyed by chipClassKey (family+tier) so a fast tier never lends its rate
+//     to a slow one — once it has ≥ qualityCapSoloMinSamples samples;
+//  2. the MIN of the per-class solo medians across chip classes (conservative
+//     cross-class transfer, SoloMedianAllChips), same total-sample floor — can
+//     never exceed the slowest class's rate, so it never over-caps a slow box;
 //  3. the modelSoloTPSSeedEnv seed (cold-start answer — the TPS registry is
 //     in-memory and restart-wiped);
 //  4. the provider-level resolvedDecodeTPS(p) — exactly the pre-per-model
@@ -219,7 +221,7 @@ type soloModelTPS struct {
 // r.mu and p.mu.
 func (r *Registry) resolvedSoloModelTPSLocked(p *Provider, model string) soloModelTPS {
 	if qualityCapPerModelTPS {
-		if tps, n := r.tpsRegistry.SoloMedian(model, p.Hardware.ChipFamily); n >= qualityCapSoloMinSamples && tps > 0 {
+		if tps, n := r.tpsRegistry.SoloMedian(model, chipClassKey(p.Hardware)); n >= qualityCapSoloMinSamples && tps > 0 {
 			return soloModelTPS{tps: tps, perModel: true}
 		}
 		if tps, n := r.tpsRegistry.SoloMedianAllChips(model); n >= qualityCapSoloMinSamples && tps > 0 {

--- a/coordinator/registry/concurrency_cap.go
+++ b/coordinator/registry/concurrency_cap.go
@@ -46,11 +46,44 @@ const defaultQualityCapOvercommit = 1.2
 // the global overcommit.
 const qualityCapOvercommitByModelEnv = env.EnvPrefix + "_QUALITY_CONCURRENCY_OVERCOMMIT_BY_MODEL"
 
+// Per-model solo-TPS source for the quality cap (the postmortem layer-6 root
+// fix — see resolvedSoloModelTPSLocked):
+//
+//   - qualityCapPerModelTPSEnv is the kill switch (bool, default TRUE). false
+//     restores the provider-level resolvedDecodeTPS(p) rate at every quality-cap
+//     site exactly.
+//   - qualityCapSoloMinSamplesEnv is the minimum solo sample count (per chip,
+//     or pooled across chips) before a solo median is trusted (int, default 5).
+//   - modelSoloTPSSeedEnv is the cold-start seed, a "model=tok/s" CSV keyed by
+//     concrete resolved build id (matched case-insensitively), e.g.
+//     "gemma-4-26b-qat-4bit=14,gpt-oss-20b=30". The TPS registry is in-memory
+//     and restart-wiped, so the seed is the answer until gated solo samples
+//     accumulate (e.g. while a model warms behind a shed).
+const (
+	qualityCapPerModelTPSEnv    = env.EnvPrefix + "_QUALITY_CAP_PER_MODEL_TPS"
+	qualityCapSoloMinSamplesEnv = env.EnvPrefix + "_QUALITY_CAP_SOLO_MIN_SAMPLES"
+	modelSoloTPSSeedEnv         = env.EnvPrefix + "_MODEL_SOLO_TPS_SEED"
+)
+
+// defaultQualityCapSoloMinSamples is the solo-median trust floor when
+// EIGENINFERENCE_QUALITY_CAP_SOLO_MIN_SAMPLES is unset.
+const defaultQualityCapSoloMinSamples = 5
+
 // qualityCapOvercommitByModel holds the parsed per-model overrides. Like the
 // package's other startup-configured routing knobs (prefillToDecodeRatio,
 // ttftOccupancyAlpha), it is written once by SetQualityConcurrencyCap before
 // the coordinator serves and only read on routing paths thereafter.
 var qualityCapOvercommitByModel map[string]float64
+
+// qualityCapPerModelTPS / qualityCapSoloMinSamples / modelSoloTPSSeed are the
+// parsed per-model solo-TPS knobs. Same lifecycle as
+// qualityCapOvercommitByModel: written once by SetQualityConcurrencyCap before
+// serving, read-only on routing paths.
+var (
+	qualityCapPerModelTPS    = true
+	qualityCapSoloMinSamples = defaultQualityCapSoloMinSamples
+	modelSoloTPSSeed         map[string]float64
+)
 
 // SetQualityConcurrencyCap configures the per-provider quality-concurrency
 // admission cap. enabled=false leaves the legacy flat cap unchanged. floorTPS
@@ -76,7 +109,13 @@ func (r *Registry) SetQualityConcurrencyCap(enabled bool, overcommit, floorTPS f
 	if fallback < 1 {
 		fallback = 1
 	}
-	qualityCapOvercommitByModel = parseQualityCapOvercommitByModel(os.Getenv(qualityCapOvercommitByModelEnv))
+	qualityCapOvercommitByModel = parseModelFloatMap(os.Getenv(qualityCapOvercommitByModelEnv))
+	qualityCapPerModelTPS = env.EnvBool(qualityCapPerModelTPSEnv, true)
+	qualityCapSoloMinSamples = env.EnvInt(qualityCapSoloMinSamplesEnv, defaultQualityCapSoloMinSamples)
+	if qualityCapSoloMinSamples < 1 {
+		qualityCapSoloMinSamples = 1
+	}
+	modelSoloTPSSeed = parseModelFloatMap(os.Getenv(modelSoloTPSSeedEnv))
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.qualityCapEnabled = enabled
@@ -94,11 +133,14 @@ func (r *Registry) QualityCapOvercommit() float64 {
 	return r.qualityCapOvercommit
 }
 
-// parseQualityCapOvercommitByModel parses the "model=overcommit,..." CSV form
-// (mirroring envModelIntMap for EIGENINFERENCE_WARM_POOL_MIN_WARM, with float
-// values). Malformed entries and non-positive values are skipped; an empty or
-// all-invalid input yields nil (no overrides).
-func parseQualityCapOvercommitByModel(raw string) map[string]float64 {
+// parseModelFloatMap parses the "model=value,..." CSV form (mirroring
+// envModelIntMap for EIGENINFERENCE_WARM_POOL_MIN_WARM, with float values).
+// Keys are lowercased so lookups on resolved build ids match
+// case-insensitively. Malformed entries and non-positive values are skipped;
+// an empty or all-invalid input yields nil (no entries). Shared by the
+// per-model overcommit overrides (qualityCapOvercommitByModelEnv) and the
+// solo-TPS seed (modelSoloTPSSeedEnv).
+func parseModelFloatMap(raw string) map[string]float64 {
 	raw = strings.TrimSpace(raw)
 	if raw == "" {
 		return nil
@@ -139,17 +181,83 @@ func (r *Registry) qualityCapOvercommitForModelLocked(model string) float64 {
 	return r.qualityCapOvercommit
 }
 
+// soloModelTPS is a static single-stream decode rate for a (provider, model)
+// pair plus its provenance. perModel is true when the rate came from a
+// model-specific source — a gated solo median or the seed env — which is
+// trustworthy for capping even when the provider never reported a registration
+// benchmark; false means the rate is the provider-level resolvedDecodeTPS
+// chain (registration benchmark, or the model-agnostic sqrt-bandwidth proxy
+// that only dedicated models may be capped from).
+type soloModelTPS struct {
+	tps      float64
+	perModel bool
+}
+
+// resolvedSoloModelTPSLocked resolves the static solo decode rate the quality
+// cap should use for (p, model). Fallback chain, most- to least-specific:
+//
+//  1. per-(model, chip) solo median — gated samples only (solo_tps.go) — once
+//     it has ≥ qualityCapSoloMinSamples samples;
+//  2. model-wide solo median pooled across chip families (conservative
+//     cross-chip transfer), same sample floor;
+//  3. the modelSoloTPSSeedEnv seed (cold-start answer — the TPS registry is
+//     in-memory and restart-wiped);
+//  4. the provider-level resolvedDecodeTPS(p) — exactly the pre-per-model
+//     behavior, including its sqrt-bandwidth fallback semantics.
+//
+// The rate is deliberately STATIC (never an under-load EWMA): an observed rate
+// collapses under the very overload the cap exists to prevent, which would
+// drive the cap to 1 in a feedback loop. Solo medians preserve that property
+// because ingest is gated on a fully uncontended box.
+//
+// The qualityCapPerModelTPSEnv kill switch (false) short-circuits to (4),
+// restoring resolvedDecodeTPS(p) at every wired site exactly. Caller holds
+// r.mu and p.mu.
+func (r *Registry) resolvedSoloModelTPSLocked(p *Provider, model string) soloModelTPS {
+	if qualityCapPerModelTPS {
+		if tps, n := r.tpsRegistry.SoloMedian(model, p.Hardware.ChipFamily); n >= qualityCapSoloMinSamples && tps > 0 {
+			return soloModelTPS{tps: tps, perModel: true}
+		}
+		if tps, n := r.tpsRegistry.SoloMedianAllChips(model); n >= qualityCapSoloMinSamples && tps > 0 {
+			return soloModelTPS{tps: tps, perModel: true}
+		}
+		if tps, ok := modelSoloTPSSeed[strings.ToLower(model)]; ok {
+			return soloModelTPS{tps: tps, perModel: true}
+		}
+	}
+	return soloModelTPS{tps: resolvedDecodeTPS(p), perModel: false}
+}
+
 // effectiveMaxConcurrencyForModelLocked returns the per-provider admission
+// concurrency cap for model from an explicit provider-level static rate
+// (resolvedDecodeTPS). Kept for callers/tests that already resolved the rate;
+// production admission paths use effectiveMaxConcurrencyForModelResolvedLocked
+// so the cap consumes the per-model solo rate. Caller holds r.mu and p.mu.
+func (r *Registry) effectiveMaxConcurrencyForModelLocked(p *Provider, model string, staticDecodeTPS float64) int {
+	return r.effectiveMaxConcurrencyForModelRateLocked(p, model, soloModelTPS{tps: staticDecodeTPS})
+}
+
+// effectiveMaxConcurrencyForModelResolvedLocked is the per-model admission cap
+// with the static solo rate resolved internally (resolvedSoloModelTPSLocked).
+// This is what fixes the postmortem layer-6 failure: a mixed box benchmarked
+// on gpt-oss (58–93 tok/s) no longer lends gemma its provider-level rate — the
+// gemma cap is computed from gemma's own solo median (10–18 tok/s → cap 1–2).
+// Caller holds r.mu and p.mu.
+func (r *Registry) effectiveMaxConcurrencyForModelResolvedLocked(p *Provider, model string) int {
+	return r.effectiveMaxConcurrencyForModelRateLocked(p, model, r.resolvedSoloModelTPSLocked(p, model))
+}
+
+// effectiveMaxConcurrencyForModelRateLocked returns the per-provider admission
 // concurrency cap for model: the MINIMUM of the legacy cap
 // (p.maxConcurrencyForModelLocked — a provider-reported per-slot MaxConcurrency
 // if set, else the flat fallback) and quality_concurrency × overcommit. Taking
 // the min means a provider that self-reports a TIGHTER cap still binds (it knows
 // its backend best), while a provider that reports a looser cap — or none — is
-// still held to the quality bar, so neither path can over-admit. staticDecodeTPS
-// must be the provider's single-stream (static) decode rate for the model
-// (resolvedDecodeTPS), not the observed-under-load value (which collapses under
-// the overload this cap exists to prevent). Caller holds r.mu and p.mu.
-func (r *Registry) effectiveMaxConcurrencyForModelLocked(p *Provider, model string, staticDecodeTPS float64) int {
+// still held to the quality bar, so neither path can over-admit. rate must be a
+// single-stream (static) decode rate for the model, not the observed-under-load
+// value (which collapses under the overload this cap exists to prevent).
+// Caller holds r.mu and p.mu.
+func (r *Registry) effectiveMaxConcurrencyForModelRateLocked(p *Provider, model string, rate soloModelTPS) int {
 	base := p.maxConcurrencyForModelLocked(model)
 	if !r.qualityCapEnabled {
 		return base
@@ -161,13 +269,16 @@ func (r *Registry) effectiveMaxConcurrencyForModelLocked(p *Provider, model stri
 	// a fast non-dedicated model from it could shed healthy traffic. Only cap from
 	// the bandwidth fallback for DEDICATED models, which are known-slow and urgently
 	// need it; a non-dedicated model without a real benchmark keeps the legacy flat
-	// cap until its provider reports decode_tps.
-	if p.DecodeTPS <= 0 {
+	// cap until its provider reports decode_tps. A PER-MODEL rate (solo median or
+	// seed — rate.perModel) is model-specific by construction, so the guard does
+	// not apply to it: those models are capped even without a registration
+	// benchmark.
+	if p.DecodeTPS <= 0 && !rate.perModel {
 		if _, dedicated := r.dedicatedPatternForLocked(model); !dedicated {
 			return base
 		}
 	}
-	qc := qualityConcurrency(staticDecodeTPS, r.qualityCapFloorTPS, effectiveTPSLoadFactor, base, r.qualityCapFallback)
+	qc := qualityConcurrency(rate.tps, r.qualityCapFloorTPS, effectiveTPSLoadFactor, base, r.qualityCapFallback)
 	capped := int(math.Ceil(float64(qc) * r.qualityCapOvercommitForModelLocked(model)))
 	if capped < 1 {
 		capped = 1
@@ -178,22 +289,18 @@ func (r *Registry) effectiveMaxConcurrencyForModelLocked(p *Provider, model stri
 	return base
 }
 
-// hasConcurrencyHeadroomForModelCapLocked mirrors
+// hasConcurrencyHeadroomForModelCapResolvedLocked mirrors
 // Provider.hasConcurrencyHeadroomForModelLocked but applies the registry's
-// quality-concurrency cap to the per-model limit. staticDecodeTPS is the
-// provider's single-stream decode rate for the model. Caller holds r.mu and
-// p.mu.
-func (r *Registry) hasConcurrencyHeadroomForModelCapLocked(p *Provider, model string, staticDecodeTPS float64) bool {
-	return p.pendingLoadForModelLocked(model) < r.effectiveMaxConcurrencyForModelLocked(p, model, staticDecodeTPS) &&
-		p.pendingCount() < p.maxConcurrency()
-}
-
-// hasConcurrencyHeadroomForModelCapResolvedLocked is hasConcurrencyHeadroomForModelCapLocked
-// with the provider's static single-stream decode rate resolved internally. Used
-// by the public capacity feeds (ModelCapacitySnapshot) so /v1/models[/capacity]
-// report the SAME headroom the routing path enforces — otherwise a capped box is
+// quality-concurrency cap to the per-model limit, with the static single-stream
+// decode rate resolved internally — per-model (solo median / seed) when
+// available, else the provider-level rate. It is the single production entry
+// point: the routing snapshot, the queue-drain preflight, the final admit
+// re-check, the warm-pool saturation gate, and the public capacity feeds
+// (ModelCapacitySnapshot) all consume it, so /v1/models[/capacity] report the
+// SAME headroom the routing path enforces — otherwise a capped box is
 // advertised as routable and upstream routers keep sending requests it 429s.
 // Caller holds r.mu and p.mu.
 func (r *Registry) hasConcurrencyHeadroomForModelCapResolvedLocked(p *Provider, model string) bool {
-	return r.hasConcurrencyHeadroomForModelCapLocked(p, model, resolvedDecodeTPS(p))
+	return p.pendingLoadForModelLocked(model) < r.effectiveMaxConcurrencyForModelResolvedLocked(p, model) &&
+		p.pendingCount() < p.maxConcurrency()
 }

--- a/coordinator/registry/concurrency_cap.go
+++ b/coordinator/registry/concurrency_cap.go
@@ -204,10 +204,12 @@ type soloModelTPS struct {
 //     keyed by chipClassKey (family+tier) so a fast tier never lends its rate
 //     to a slow one — once it has ≥ qualityCapSoloMinSamples samples;
 //  2. the MIN of the per-class solo medians across chip classes (conservative
-//     cross-class transfer, SoloMedianAllChips), same total-sample floor — can
-//     never exceed the slowest class's rate, so it never over-caps a slow box;
-//  3. the modelSoloTPSSeedEnv seed (cold-start answer — the TPS registry is
-//     in-memory and restart-wiped);
+//     cross-class transfer, SoloMedianAllChips), same total-sample floor. When
+//     a modelSoloTPSSeedEnv seed exists, it is an upper bound on that transfer:
+//     observations from faster classes cannot widen an unsampled slower class's
+//     cap above its configured cold-start estimate;
+//  3. the modelSoloTPSSeedEnv seed when there is no trusted cross-class rate
+//     (the TPS registry is in-memory and restart-wiped);
 //  4. the provider-level resolvedDecodeTPS(p) — exactly the pre-per-model
 //     behavior, including its sqrt-bandwidth fallback semantics.
 //
@@ -224,11 +226,15 @@ func (r *Registry) resolvedSoloModelTPSLocked(p *Provider, model string) soloMod
 		if tps, n := r.tpsRegistry.SoloMedian(model, chipClassKey(p.Hardware)); n >= qualityCapSoloMinSamples && tps > 0 {
 			return soloModelTPS{tps: tps, perModel: true}
 		}
+		seed, hasSeed := modelSoloTPSSeed[strings.ToLower(model)]
 		if tps, n := r.tpsRegistry.SoloMedianAllChips(model); n >= qualityCapSoloMinSamples && tps > 0 {
+			if hasSeed && seed < tps {
+				tps = seed
+			}
 			return soloModelTPS{tps: tps, perModel: true}
 		}
-		if tps, ok := modelSoloTPSSeed[strings.ToLower(model)]; ok {
-			return soloModelTPS{tps: tps, perModel: true}
+		if hasSeed {
+			return soloModelTPS{tps: seed, perModel: true}
 		}
 	}
 	return soloModelTPS{tps: resolvedDecodeTPS(p), perModel: false}

--- a/coordinator/registry/concurrency_cap_test.go
+++ b/coordinator/registry/concurrency_cap_test.go
@@ -421,6 +421,28 @@ func TestQualityCapPerModelTPSPostmortemRegression(t *testing.T) {
 	})
 }
 
+// TestQualityCapSeedBoundsCrossClassTransfer pins cold-class safety when the
+// only live solo samples come from a faster chip class. A configured model seed
+// is the conservative cold-start estimate for an unsampled class, so faster
+// cross-class observations must not widen that class's quality cap above it.
+func TestQualityCapSeedBoundsCrossClassTransfer(t *testing.T) {
+	reg := New(testLogger())
+	enablePerModelQualityCap(t, reg, gemmaBuild+"=14", "", "")
+	p := mixedBoxProvider(t, reg, "unsampled-slow-class", 93)
+	p.mu.Lock()
+	p.Hardware.ChipFamily = "M2"
+	p.Hardware.ChipTier = "Pro"
+	p.mu.Unlock()
+
+	for i := 0; i < qualityCapSoloMinSamples; i++ {
+		reg.tpsRegistry.RecordSolo(gemmaBuild, "M4|Max", 40)
+	}
+
+	if got := resolveSolo(reg, p, gemmaBuild); got.tps != 14 || !got.perModel {
+		t.Fatalf("unsampled slow-class resolver = %+v, want seed 14 (faster cross-class median 40 must not override the configured cold-start bound)", got)
+	}
+}
+
 // TestQualityCapPerModelTPSKillSwitchRestoresOldBehavior pins the kill switch:
 // EIGENINFERENCE_QUALITY_CAP_PER_MODEL_TPS=false must restore the provider-
 // level resolvedDecodeTPS(p) at the cap exactly — reproducing the postmortem's

--- a/coordinator/registry/concurrency_cap_test.go
+++ b/coordinator/registry/concurrency_cap_test.go
@@ -380,6 +380,102 @@ func TestQualityCapProjectedDecodeTPSAtDefaultHoldsNearFloor(t *testing.T) {
 	}
 }
 
+// TestQualityCapPerModelTPSPostmortemRegression is THE 2026-07-06 gemma
+// postmortem layer-6 scenario: a mixed box whose registration benchmark was
+// taken on gpt-oss (93 tok/s) hosts a gemma slot that actually decodes ~14
+// tok/s solo. The old cap consumed the provider-LEVEL rate for every model, so
+// gemma got cap ceil(qc 19 × 1.2) = 23 — and the coordinator marched 8–11
+// concurrent gemma requests onto exactly the boxes that collapse past batch 3.
+// With the per-model solo source, gemma's cap must come from gemma's own solo
+// median (14 ≤ floor 15 → qc 1 → cap 2) while gpt-oss keeps its wide cap from
+// the benchmark. Reverting the resolver wiring makes the gemma assertion fail
+// (cap becomes 23 again).
+func TestQualityCapPerModelTPSPostmortemRegression(t *testing.T) {
+	run := func(t *testing.T, seedGemma func(reg *Registry)) {
+		reg := New(testLogger())
+		enablePerModelQualityCap(t, reg, "", "", "")
+		seedGemma(reg)
+		p := mixedBoxProvider(t, reg, "mixed-93", 93)
+
+		if got := effCapResolved(reg, p, gemmaBuild); got != 2 {
+			t.Fatalf("gemma cap on the mixed box = %d, want 2 (solo 14 ≤ floor 15 → qc 1 × overcommit 1.2; NOT the benchmark-derived 23)", got)
+		}
+		if got := effCapResolved(reg, p, gptossBuild); got != 23 {
+			t.Fatalf("gpt-oss cap on the mixed box = %d, want 23 (its own 93 tok/s benchmark stays wide)", got)
+		}
+	}
+
+	t.Run("solo_median_recorded", func(t *testing.T) {
+		run(t, func(reg *Registry) {
+			for _, v := range []float64{12, 13, 14, 15, 16} {
+				reg.tpsRegistry.RecordSolo(gemmaBuild, "M3", v)
+			}
+		})
+	})
+	t.Run("seed_env_cold_start", func(t *testing.T) {
+		run(t, func(reg *Registry) {
+			t.Setenv(modelSoloTPSSeedEnv, gemmaBuild+"=14")
+			// Re-parse with the seed present (startup order: env → setter).
+			enableQualityCap(t, reg, "")
+		})
+	})
+}
+
+// TestQualityCapPerModelTPSKillSwitchRestoresOldBehavior pins the kill switch:
+// EIGENINFERENCE_QUALITY_CAP_PER_MODEL_TPS=false must restore the provider-
+// level resolvedDecodeTPS(p) at the cap exactly — reproducing the postmortem's
+// buggy wide gemma cap (23 from the gpt-oss benchmark) even though a trusted
+// gemma solo median exists. This doubles as the proof that the regression test
+// above fails without the fix: the old code path IS the switch-off path.
+func TestQualityCapPerModelTPSKillSwitchRestoresOldBehavior(t *testing.T) {
+	reg := New(testLogger())
+	enablePerModelQualityCap(t, reg, gemmaBuild+"=14", "false", "")
+	for i := 0; i < 10; i++ {
+		reg.tpsRegistry.RecordSolo(gemmaBuild, "M3", 14)
+	}
+	p := mixedBoxProvider(t, reg, "mixed-93", 93)
+
+	if got := effCapResolved(reg, p, gemmaBuild); got != 23 {
+		t.Fatalf("kill switch off: gemma cap = %d, want the old provider-level 23 (byte-for-byte legacy behavior)", got)
+	}
+	// And it must match the explicit provider-level path exactly.
+	if resolved, legacy := effCapResolved(reg, p, gemmaBuild), effCap(reg, p, gemmaBuild); resolved != legacy {
+		t.Fatalf("kill switch off: resolved cap %d != legacy explicit-rate cap %d", resolved, legacy)
+	}
+}
+
+// TestQualityCapPerModelRateCapsWithoutRegistrationBenchmark: the DecodeTPS<=0
+// guard exists because the sqrt-bandwidth fallback is model-agnostic — but a
+// PER-MODEL rate (solo median / seed) is trustworthy by construction, so a
+// non-dedicated model on a benchmark-less box is still capped from it. Without
+// any per-model source the old guard semantics hold (flat cap).
+func TestQualityCapPerModelRateCapsWithoutRegistrationBenchmark(t *testing.T) {
+	reg := New(testLogger())
+	enablePerModelQualityCap(t, reg, "", "", "")
+	for i := 0; i < 5; i++ {
+		reg.tpsRegistry.RecordSolo(gemmaBuild, "M3", 14)
+	}
+
+	mkNoBenchmark := func(id string) *Provider {
+		p := mixedBoxProvider(t, reg, id, 0) // DecodeTPS unset
+		p.mu.Lock()
+		p.Hardware.MemoryBandwidthGBs = 800 // sqrt(800) ≈ 28 fallback
+		p.mu.Unlock()
+		return p
+	}
+
+	// Solo median present → capped even without a registration benchmark.
+	p := mkNoBenchmark("no-bench")
+	if got := effCapResolved(reg, p, gemmaBuild); got != 2 {
+		t.Fatalf("no-benchmark box with solo median: gemma cap = %d, want 2", got)
+	}
+	// No per-model source (gpt-oss): non-dedicated + bandwidth fallback → the
+	// old guard keeps the flat cap (don't shed a fast model on a coarse proxy).
+	if got := effCapResolved(reg, p, gptossBuild); got != 24 {
+		t.Fatalf("no-benchmark box without per-model source: gpt-oss cap = %d, want flat 24", got)
+	}
+}
+
 // TestWarmTargetDedicatedWholePool: for a dedicated model UNDER DEMAND the
 // warm-pool target is the entire eligible pool (warm + eligibleCold), so idle
 // dedicated boxes get warmed. With NO demand for that build it is left at the

--- a/coordinator/registry/pooled_admission.go
+++ b/coordinator/registry/pooled_admission.go
@@ -113,7 +113,13 @@ func providerPooledTokenBudget(slots []protocol.BackendSlotCapacity) pooledToken
 	if budgetSlots == 0 {
 		pool.byteMode = false
 	}
-	pool.totalBytes = pool.committedBytes + sharedFreeBytes
+	// totalBytes mirrors the token path's total (providerTokenBudget: LIVE
+	// used + shared free), NOT committed+potential. committedBytes carries
+	// MaxTokensPotential only as the pending de-dup baseline (subtracted in
+	// pooledBudgetAdmits' extra); adding it into the pool total too would
+	// double-count a co-resident slot's not-yet-materialized future growth as
+	// extra physical KV capacity, letting an in-gap burst overcommit the box.
+	pool.totalBytes = pool.usedBytes + sharedFreeBytes
 	return pool
 }
 
@@ -148,4 +154,42 @@ func pooledBudgetAdmits(snap routingSnapshot, requestTokens int64) bool {
 		extra = 0
 	}
 	return pool.used+extra+requestTokens <= pool.total
+}
+
+// pooledRemainingTokens is the capacity-snapshot analog of pooledBudgetAdmits:
+// how many tokens of a model whose per-token KV rate is modelRate still fit the
+// shared pool once every model's coordinator-pending tokens are charged.
+// pooledBudgetAdmits(snap, n) admits iff n <= pooledRemainingTokens(pool, …,
+// snap.kvBytesPerToken) with the same inputs, so the public capacity feed
+// (/v1/models[/capacity]) cannot advertise pooled headroom the admission gate
+// refuses. Both branch identically: BYTES when the pool is byte-reconstructable
+// (byteMode), every pending charge normalized (pendingBytesKnown), and THIS
+// model's KV rate is known (modelRate > 0 — its resident slot; 0 for a
+// cold/absent slot, matching the gate's cold path); token accounting otherwise.
+// Returns -1 when the provider reports no pooled budget (total <= 0) — the "no
+// pooled constraint" sentinel that leaves the per-slot numbers unclamped.
+func pooledRemainingTokens(pool pooledTokenBudget, pendingTokensAllModels int, pendingBytesAllModels int64, pendingBytesKnown bool, modelRate int64) int64 {
+	if pool.total <= 0 {
+		return -1
+	}
+	if pool.byteMode && pendingBytesKnown && modelRate > 0 {
+		extra := pendingBytesAllModels - pool.committedBytes
+		if extra < 0 {
+			extra = 0
+		}
+		remBytes := pool.totalBytes - pool.usedBytes - extra
+		if remBytes < 0 {
+			remBytes = 0
+		}
+		return remBytes / modelRate
+	}
+	extra := int64(pendingTokensAllModels) - pool.committed
+	if extra < 0 {
+		extra = 0
+	}
+	rem := pool.total - pool.used - extra
+	if rem < 0 {
+		rem = 0
+	}
+	return rem
 }

--- a/coordinator/registry/pooled_admission.go
+++ b/coordinator/registry/pooled_admission.go
@@ -87,6 +87,13 @@ type pooledTokenBudget struct {
 	// KV rate, for normalizing coordinator-pending charges into bytes. Nil
 	// when no budget slot reports a rate.
 	kvBytesPerToken map[string]int64
+	// maxKVBytesPerToken is the largest clamped per-token KV rate across the
+	// budget slots. Only meaningful in byteMode (where every budget slot reports
+	// a positive rate, so it is > 0). It is the conservative rate used to price
+	// a COLD/absent request (one whose own model has no resident slot, so its
+	// rate is 0) in bytes rather than collapsing the whole byte-reconstructable
+	// pool to token accounting and under-charging a large-KV cold burst.
+	maxKVBytesPerToken int64
 }
 
 // providerPooledTokenBudget reconstructs the provider's pooled budget from its
@@ -129,6 +136,9 @@ func providerPooledTokenBudget(slots []protocol.BackendSlotCapacity) pooledToken
 			pool.kvBytesPerToken = make(map[string]int64, len(slots))
 		}
 		pool.kvBytesPerToken[slot.Model] = rate
+		if rate > pool.maxKVBytesPerToken {
+			pool.maxKVBytesPerToken = rate
+		}
 		pool.usedBytes += slotUsed * rate
 		pool.committedBytes += c * rate
 		// Per-slot free headroom in bytes; all slots see the same shared byte
@@ -159,22 +169,36 @@ func providerPooledTokenBudget(slots []protocol.BackendSlotCapacity) pooledToken
 // reported no pooled budget (legacy provider, or a snapshot built without
 // backend capacity) — no pooled constraint, the caller's other gates decide.
 //
-// The check runs in BYTES when the pool is byte-reconstructable (byteMode),
-// every pending charge was normalizable (snap.pendingBytesKnown), and the
-// incoming request's own KV rate is known (snap.kvBytesPerToken — this
-// model's slot; 0 for a cold/absent slot). Any gap falls back to token
-// accounting, which is byte-for-byte the legacy-provider behavior.
+// The check runs in BYTES when the pool is byte-reconstructable (byteMode) and
+// every pending charge was normalizable (snap.pendingBytesKnown). The incoming
+// request's own KV rate (snap.kvBytesPerToken — this model's slot) prices it;
+// when that is 0 (a cold/absent slot) the request is priced CONSERVATIVELY at
+// the box's max resident rate (pool.maxKVBytesPerToken) rather than collapsing
+// to token accounting, so a large-KV cold request on a mixed-KV box is not
+// under-charged against a token view of a byte-reconstructable pool. Token
+// accounting is used ONLY when the pool is not byte-reconstructable
+// (!byteMode) or a pending charge could not be normalized (!pendingBytesKnown)
+// — byte-for-byte the legacy-provider behavior.
 func pooledBudgetAdmits(snap routingSnapshot, requestTokens int64) bool {
 	pool := snap.pooledTokenBudget
 	if pool.total <= 0 {
 		return true
 	}
-	if pool.byteMode && snap.pendingBytesKnown && snap.kvBytesPerToken > 0 {
-		extra := snap.pendingMaxBytesAllModels - pool.committedBytes
-		if extra < 0 {
-			extra = 0
+	if pool.byteMode && snap.pendingBytesKnown {
+		reqRate := snap.kvBytesPerToken
+		if reqRate <= 0 {
+			// Cold/absent slot: price at the box's max resident rate. Guaranteed
+			// > 0 in byteMode; the guard covers the impossible 0 case by falling
+			// through to token accounting.
+			reqRate = pool.maxKVBytesPerToken
 		}
-		return pool.usedBytes+extra+requestTokens*snap.kvBytesPerToken <= pool.totalBytes
+		if reqRate > 0 {
+			extra := snap.pendingMaxBytesAllModels - pool.committedBytes
+			if extra < 0 {
+				extra = 0
+			}
+			return pool.usedBytes+extra+requestTokens*reqRate <= pool.totalBytes
+		}
 	}
 	extra := int64(snap.pendingMaxTokensAllModels) - pool.committed
 	if extra < 0 {
@@ -190,25 +214,34 @@ func pooledBudgetAdmits(snap routingSnapshot, requestTokens int64) bool {
 // snap.kvBytesPerToken) with the same inputs, so the public capacity feed
 // (/v1/models[/capacity]) cannot advertise pooled headroom the admission gate
 // refuses. Both branch identically: BYTES when the pool is byte-reconstructable
-// (byteMode), every pending charge normalized (pendingBytesKnown), and THIS
-// model's KV rate is known (modelRate > 0 — its resident slot; 0 for a
-// cold/absent slot, matching the gate's cold path); token accounting otherwise.
-// Returns -1 when the provider reports no pooled budget (total <= 0) — the "no
-// pooled constraint" sentinel that leaves the per-slot numbers unclamped.
+// (byteMode) and every pending charge normalized (pendingBytesKnown), pricing
+// this model at modelRate when its resident slot reports one (> 0) and at the
+// box's max resident rate (pool.maxKVBytesPerToken) for a cold/absent slot
+// (modelRate == 0) — the SAME cold-rate substitution pooledBudgetAdmits uses,
+// so the two stay equivalent. Token accounting ONLY when !byteMode or
+// !pendingBytesKnown. Returns -1 when the provider reports no pooled budget
+// (total <= 0) — the "no pooled constraint" sentinel that leaves the per-slot
+// numbers unclamped.
 func pooledRemainingTokens(pool pooledTokenBudget, pendingTokensAllModels int, pendingBytesAllModels int64, pendingBytesKnown bool, modelRate int64) int64 {
 	if pool.total <= 0 {
 		return -1
 	}
-	if pool.byteMode && pendingBytesKnown && modelRate > 0 {
-		extra := pendingBytesAllModels - pool.committedBytes
-		if extra < 0 {
-			extra = 0
+	if pool.byteMode && pendingBytesKnown {
+		rate := modelRate
+		if rate <= 0 {
+			rate = pool.maxKVBytesPerToken // cold/absent slot: box's max rate
 		}
-		remBytes := pool.totalBytes - pool.usedBytes - extra
-		if remBytes < 0 {
-			remBytes = 0
+		if rate > 0 {
+			extra := pendingBytesAllModels - pool.committedBytes
+			if extra < 0 {
+				extra = 0
+			}
+			remBytes := pool.totalBytes - pool.usedBytes - extra
+			if remBytes < 0 {
+				remBytes = 0
+			}
+			return remBytes / rate
 		}
-		return remBytes / modelRate
 	}
 	extra := int64(pendingTokensAllModels) - pool.committed
 	if extra < 0 {

--- a/coordinator/registry/pooled_admission.go
+++ b/coordinator/registry/pooled_admission.go
@@ -30,6 +30,30 @@ import "github.com/eigeninference/d-inference/coordinator/protocol"
 // against it — the byte form is what makes a small-KV model's burst visible
 // to a big-KV co-resident and vice versa.
 
+// maxKVBytesPerToken bounds a slot's reported per-token KV cost before it enters
+// byte-pool math. Heartbeat token counts are clamped to ~10B upstream, but
+// slot.KVBytesPerToken is UNBOUNDED — a garbage or malicious rate multiplied by
+// a large token count overflows int64 to a negative usedBytes/totalBytes, which
+// silently breaks admission (a negative pool total either rejects everything or,
+// with a negative left side, admits everything). 16 MiB/token is ~160× gemma's
+// real ~100 kB/token, so every legitimate rate passes untouched; the product
+// with the 10B-token clamp is 1.68e17, and the per-slot sums stay far below
+// int64max (9.2e18).
+const maxKVBytesPerToken = 1 << 24 // 16 MiB per token
+
+// clampKVBytesPerToken floors a per-token KV rate at 0 and caps it at
+// maxKVBytesPerToken so byte-pool products cannot overflow. A negative rate is
+// treated as absent (0), matching the pool's "no byte rate" handling.
+func clampKVBytesPerToken(r int64) int64 {
+	if r < 0 {
+		return 0
+	}
+	if r > maxKVBytesPerToken {
+		return maxKVBytesPerToken
+	}
+	return r
+}
+
 // pooledTokenBudget is a provider's reconstructed whole-box token budget,
 // carried in token units always and additionally in byte units when every
 // budget slot reports KVBytesPerToken (byteMode).
@@ -92,7 +116,10 @@ func providerPooledTokenBudget(slots []protocol.BackendSlotCapacity) pooledToken
 			c = 0
 		}
 		pool.committed += c
-		if slot.KVBytesPerToken <= 0 {
+		// Clamp the raw rate ONCE (overflow guard, see maxKVBytesPerToken) and
+		// use the clamped value for the map store and every byte product below.
+		rate := clampKVBytesPerToken(slot.KVBytesPerToken)
+		if rate <= 0 {
 			// A budget slot without a KV rate makes byte reconstruction
 			// impossible for the whole pool (legacy provider build).
 			pool.byteMode = false
@@ -101,12 +128,12 @@ func providerPooledTokenBudget(slots []protocol.BackendSlotCapacity) pooledToken
 		if pool.kvBytesPerToken == nil {
 			pool.kvBytesPerToken = make(map[string]int64, len(slots))
 		}
-		pool.kvBytesPerToken[slot.Model] = slot.KVBytesPerToken
-		pool.usedBytes += slotUsed * slot.KVBytesPerToken
-		pool.committedBytes += c * slot.KVBytesPerToken
+		pool.kvBytesPerToken[slot.Model] = rate
+		pool.usedBytes += slotUsed * rate
+		pool.committedBytes += c * rate
 		// Per-slot free headroom in bytes; all slots see the same shared byte
 		// pool, so the largest is the live shared headroom (counted once).
-		if free := (slot.ActiveTokenBudgetMax - slotUsed) * slot.KVBytesPerToken; free > sharedFreeBytes {
+		if free := (slot.ActiveTokenBudgetMax - slotUsed) * rate; free > sharedFreeBytes {
 			sharedFreeBytes = free
 		}
 	}

--- a/coordinator/registry/pooled_admission.go
+++ b/coordinator/registry/pooled_admission.go
@@ -18,8 +18,9 @@ import (
 // gap by admitting against the reconstructed whole-box pool with ALL models'
 // coordinator-pending tokens counted. Inert for single-model providers (the
 // pool reduces to the slot's own budget and the arithmetic matches the
-// per-slot check exactly) and for legacy providers that report no token
-// budget (total = 0).
+// per-slot check exactly). Legacy providers that report neither a token budget
+// nor a KV rate remain unconstrained; a modern slot with a positive KV rate and
+// a zero budget is authoritative known-zero capacity and must fail closed.
 //
 // Units: the shared pool is physically BYTES of unified memory, and
 // co-resident models spend it at different per-token rates
@@ -81,6 +82,15 @@ func resolvedPooledKVBytesPerToken(pool pooledTokenBudget, reportedRate int64) i
 	return clampKVBytesPerToken(rate)
 }
 
+// knownZeroTokenBudget distinguishes an authoritative zero from an omitted
+// legacy budget. Engine V2 reports KVBytesPerToken whenever it knows the model's
+// rate, including when its live fleet clamp leaves room for zero tokens. That
+// model-local zero must bind even if a co-resident model still has pooled
+// headroom.
+func knownZeroTokenBudget(maxTokens, kvBytesPerToken int64) bool {
+	return maxTokens <= 0 && clampKVBytesPerToken(kvBytesPerToken) > 0
+}
+
 // addPooledKVByteCharge adds tokens*rate without wrapping. An overflowed
 // pending charge must reject against every finite pool, so saturation at
 // MaxInt64 is both conservative and sufficient for admission/capacity math.
@@ -101,6 +111,11 @@ func addPooledKVByteCharge(total, tokens, rate int64) int64 {
 // carried in token units always and additionally in byte units when every
 // budget slot reports KVBytesPerToken (byteMode).
 type pooledTokenBudget struct {
+	// hasBudgetReport distinguishes an authoritative provider budget from the
+	// zero value used by legacy providers. Engine V2 can truthfully report
+	// ActiveTokenBudgetMax == 0 after its live fleet clamp while still reporting
+	// KVBytesPerToken > 0; that means known-full, not "budget unavailable."
+	hasBudgetReport bool
 	// used is Σ (ActiveTokenBudgetUsed + QueuedTokenBudget) across budget
 	// slots — reservations the provider itself reports as live.
 	used int64
@@ -136,20 +151,41 @@ type pooledTokenBudget struct {
 }
 
 // providerPooledTokenBudget reconstructs the provider's pooled budget from its
-// backend slots. Slots without a token budget (ActiveTokenBudgetMax <= 0) are
-// ignored and negative per-slot values floored, mirroring providerTokenBudget.
-// A nil/empty slice (or no budget slots at all) yields the zero value, which
-// pooledBudgetAdmits treats as "no pooled constraint".
+// backend slots. A legacy slot with neither a positive token budget nor a KV
+// rate is ignored. A positive KV rate is retained even when the token budget is
+// zero: Engine V2 uses that combination to report authoritative known-zero
+// capacity after its live fleet clamp. Only positive maxima contribute shared
+// headroom. Negative per-slot values are floored, mirroring providerTokenBudget.
+// A nil/empty or entirely legacy slice yields the unconstrained zero value.
 func providerPooledTokenBudget(slots []protocol.BackendSlotCapacity) pooledTokenBudget {
 	used, total := providerTokenBudget(slots)
 	pool := pooledTokenBudget{used: used, total: total, byteMode: true}
-	budgetSlots := 0
+	reportedSlots := 0
 	var sharedFreeBytes int64
 	for _, slot := range slots {
-		if slot.ActiveTokenBudgetMax <= 0 {
+		// Retain a reported rate before considering the token maximum. A v2
+		// slot can have a known rate and an authoritative zero max; pending,
+		// incoming, and capacity math must still agree on that model's rate.
+		rate := clampKVBytesPerToken(slot.KVBytesPerToken)
+		if slot.ActiveTokenBudgetMax <= 0 && rate <= 0 {
+			// True legacy/unknown slot: neither field carries a constraint.
 			continue
 		}
-		budgetSlots++
+		reportedSlots++
+		if rate <= 0 {
+			// A positive token budget without a KV rate keeps the exact legacy
+			// token-mode behavior for the whole provider.
+			pool.byteMode = false
+		} else {
+			if pool.kvBytesPerToken == nil {
+				pool.kvBytesPerToken = make(map[string]int64, len(slots))
+			}
+			pool.kvBytesPerToken[slot.Model] = rate
+			if rate > pool.maxResidentKVBytesPerToken {
+				pool.maxResidentKVBytesPerToken = rate
+			}
+		}
+
 		slotUsed := slot.ActiveTokenBudgetUsed + slot.QueuedTokenBudget
 		if slotUsed < 0 {
 			slotUsed = 0
@@ -161,32 +197,28 @@ func providerPooledTokenBudget(slots []protocol.BackendSlotCapacity) pooledToken
 		if c < 0 {
 			c = 0
 		}
-		pool.committed += c
-		// Clamp the raw rate ONCE (overflow guard, see maxKVBytesPerToken) and
-		// use the clamped value for the map store and every byte product below.
-		rate := clampKVBytesPerToken(slot.KVBytesPerToken)
-		if rate <= 0 {
-			// A budget slot without a KV rate makes byte reconstruction
-			// impossible for the whole pool (legacy provider build).
-			pool.byteMode = false
+		if rate > 0 {
+			// Live/committed use remains physical even when the current max is
+			// zero. Saturation makes malformed reports fail closed.
+			pool.usedBytes = addPooledKVByteCharge(pool.usedBytes, slotUsed, rate)
+			pool.committedBytes = addPooledKVByteCharge(pool.committedBytes, c, rate)
+		}
+		if slot.ActiveTokenBudgetMax <= 0 {
+			// Known-zero contributes no new headroom.
 			continue
 		}
-		if pool.kvBytesPerToken == nil {
-			pool.kvBytesPerToken = make(map[string]int64, len(slots))
+		pool.committed += c
+		if rate <= 0 {
+			continue
 		}
-		pool.kvBytesPerToken[slot.Model] = rate
-		if rate > pool.maxResidentKVBytesPerToken {
-			pool.maxResidentKVBytesPerToken = rate
-		}
-		pool.usedBytes += slotUsed * rate
-		pool.committedBytes += c * rate
 		// Per-slot free headroom in bytes; all slots see the same shared byte
 		// pool, so the largest is the live shared headroom (counted once).
-		if free := (slot.ActiveTokenBudgetMax - slotUsed) * rate; free > sharedFreeBytes {
+		if free := addPooledKVByteCharge(0, slot.ActiveTokenBudgetMax-slotUsed, rate); free > sharedFreeBytes {
 			sharedFreeBytes = free
 		}
 	}
-	if budgetSlots == 0 {
+	pool.hasBudgetReport = reportedSlots > 0
+	if !pool.hasBudgetReport {
 		pool.byteMode = false
 	}
 	// totalBytes mirrors the token path's total (providerTokenBudget: LIVE
@@ -195,7 +227,11 @@ func providerPooledTokenBudget(slots []protocol.BackendSlotCapacity) pooledToken
 	// pooledBudgetAdmits' extra); adding it into the pool total too would
 	// double-count a co-resident slot's not-yet-materialized future growth as
 	// extra physical KV capacity, letting an in-gap burst overcommit the box.
-	pool.totalBytes = pool.usedBytes + sharedFreeBytes
+	if pool.usedBytes > math.MaxInt64-sharedFreeBytes {
+		pool.totalBytes = math.MaxInt64
+	} else {
+		pool.totalBytes = pool.usedBytes + sharedFreeBytes
+	}
 	return pool
 }
 
@@ -204,9 +240,9 @@ func providerPooledTokenBudget(slots []protocol.BackendSlotCapacity) pooledToken
 // (snap.pendingMaxTokensAllModels / snap.pendingMaxBytesAllModels) are charged
 // against it. The subtraction of the committed baseline mirrors the per-slot
 // check's committedTokenBudget subtraction (avoid double-counting requests the
-// heartbeat already reflects), floored at zero. total <= 0 means the provider
-// reported no pooled budget (legacy provider, or a snapshot built without
-// backend capacity) — no pooled constraint, the caller's other gates decide.
+// heartbeat already reflects), floored at zero. hasBudgetReport=false means a
+// legacy provider (or a snapshot built without backend capacity) reported no
+// pooled constraint. An authoritative report whose total is zero is known-full.
 //
 // The check runs in BYTES when the pool is byte-reconstructable (byteMode) and
 // every pending charge was normalizable (snap.pendingBytesKnown). The single
@@ -217,8 +253,11 @@ func providerPooledTokenBudget(slots []protocol.BackendSlotCapacity) pooledToken
 // the snapshot predates/omits byte accumulation.
 func pooledBudgetAdmits(snap routingSnapshot, requestTokens int64) bool {
 	pool := snap.pooledTokenBudget
-	if pool.total <= 0 {
+	if !pool.hasBudgetReport {
 		return true
+	}
+	if pool.total <= 0 {
+		return requestTokens == 0
 	}
 	if pool.byteMode && snap.pendingBytesKnown {
 		reqRate := resolvedPooledKVBytesPerToken(pool, snap.kvBytesPerToken)
@@ -256,12 +295,15 @@ func pooledBudgetAdmits(snap routingSnapshot, requestTokens int64) bool {
 // this model through resolvedPooledKVBytesPerToken — the same known/default
 // policy pooledBudgetAdmits uses — so the two stay equivalent. Token accounting
 // only when !byteMode or !pendingBytesKnown. Returns -1 when the provider
-// reports no pooled budget
-// (total <= 0) — the "no pooled constraint" sentinel that leaves the per-slot
-// numbers unclamped.
+// reports no pooled budget (hasBudgetReport=false) — the "no pooled constraint"
+// sentinel that leaves the per-slot numbers unclamped. An authoritative zero
+// budget returns 0.
 func pooledRemainingTokens(pool pooledTokenBudget, pendingTokensAllModels int, pendingBytesAllModels int64, pendingBytesKnown bool, modelRate int64) int64 {
-	if pool.total <= 0 {
+	if !pool.hasBudgetReport {
 		return -1
+	}
+	if pool.total <= 0 {
+		return 0
 	}
 	if pool.byteMode && pendingBytesKnown {
 		rate := resolvedPooledKVBytesPerToken(pool, modelRate)

--- a/coordinator/registry/pooled_admission.go
+++ b/coordinator/registry/pooled_admission.go
@@ -1,6 +1,10 @@
 package registry
 
-import "github.com/eigeninference/d-inference/coordinator/protocol"
+import (
+	"math"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+)
 
 // pooled_admission.go — provider-level (all-models) token-budget admission.
 //
@@ -22,10 +26,11 @@ import "github.com/eigeninference/d-inference/coordinator/protocol"
 // (BackendSlotCapacity.KVBytesPerToken — a 26B model's token costs ~10× a
 // small model's), so tokens are not a common unit across slots. When every
 // budget slot reports its KV rate, the pool and all charges against it are
-// normalized into bytes; otherwise (any legacy slot, or a pending/incoming
-// request whose model has no reported rate) the check falls back to token
-// accounting, which is exactly the pre-byte behavior. Token accounting
-// denominates the pool in the LARGEST per-slot free-token view (the
+// normalized into bytes. A pending/incoming request whose cold model has no
+// reported rate is charged at a bounded conservative default so it cannot
+// disable byte accounting for a reconstructable pool. Otherwise (any legacy
+// slot) the check falls back to token accounting, exactly the pre-byte behavior.
+// Token accounting denominates the pool in the LARGEST per-slot free-token view (the
 // smallest-KV model's), so a big-KV model's pending burst is under-charged
 // against it — the byte form is what makes a small-KV model's burst visible
 // to a big-KV co-resident and vice versa.
@@ -52,6 +57,44 @@ func clampKVBytesPerToken(r int64) int64 {
 		return maxKVBytesPerToken
 	}
 	return r
+}
+
+// resolvedPooledKVBytesPerToken returns the byte rate used by every pooled-KV
+// charge. A positive provider-reported model rate is clamped and preserved. A
+// cold/unknown model on a byte-reconstructable pool is priced at the larger of
+// the coordinator's conservative cold-model default and the largest resident
+// rate. Resident rates alone cannot safely estimate a different model that has
+// not loaded yet, while retaining a higher observed resident rate avoids
+// weakening the fallback. Legacy/non-reconstructable pools return 0 and retain
+// token accounting.
+func resolvedPooledKVBytesPerToken(pool pooledTokenBudget, reportedRate int64) int64 {
+	if !pool.byteMode {
+		return 0
+	}
+	if rate := clampKVBytesPerToken(reportedRate); rate > 0 {
+		return rate
+	}
+	rate := int64(kvCacheBytesPerToken)
+	if pool.maxResidentKVBytesPerToken > rate {
+		rate = pool.maxResidentKVBytesPerToken
+	}
+	return clampKVBytesPerToken(rate)
+}
+
+// addPooledKVByteCharge adds tokens*rate without wrapping. An overflowed
+// pending charge must reject against every finite pool, so saturation at
+// MaxInt64 is both conservative and sufficient for admission/capacity math.
+func addPooledKVByteCharge(total, tokens, rate int64) int64 {
+	if total >= math.MaxInt64 {
+		return math.MaxInt64
+	}
+	if tokens <= 0 || rate <= 0 {
+		return total
+	}
+	if tokens > (math.MaxInt64-total)/rate {
+		return math.MaxInt64
+	}
+	return total + tokens*rate
 }
 
 // pooledTokenBudget is a provider's reconstructed whole-box token budget,
@@ -87,13 +130,9 @@ type pooledTokenBudget struct {
 	// KV rate, for normalizing coordinator-pending charges into bytes. Nil
 	// when no budget slot reports a rate.
 	kvBytesPerToken map[string]int64
-	// maxKVBytesPerToken is the largest clamped per-token KV rate across the
-	// budget slots. Only meaningful in byteMode (where every budget slot reports
-	// a positive rate, so it is > 0). It is the conservative rate used to price
-	// a COLD/absent request (one whose own model has no resident slot, so its
-	// rate is 0) in bytes rather than collapsing the whole byte-reconstructable
-	// pool to token accounting and under-charging a large-KV cold burst.
-	maxKVBytesPerToken int64
+	// maxResidentKVBytesPerToken is the largest clamped rate among budget
+	// slots. It can raise, but never lower, the conservative cold-model default.
+	maxResidentKVBytesPerToken int64
 }
 
 // providerPooledTokenBudget reconstructs the provider's pooled budget from its
@@ -136,8 +175,8 @@ func providerPooledTokenBudget(slots []protocol.BackendSlotCapacity) pooledToken
 			pool.kvBytesPerToken = make(map[string]int64, len(slots))
 		}
 		pool.kvBytesPerToken[slot.Model] = rate
-		if rate > pool.maxKVBytesPerToken {
-			pool.maxKVBytesPerToken = rate
+		if rate > pool.maxResidentKVBytesPerToken {
+			pool.maxResidentKVBytesPerToken = rate
 		}
 		pool.usedBytes += slotUsed * rate
 		pool.committedBytes += c * rate
@@ -170,41 +209,40 @@ func providerPooledTokenBudget(slots []protocol.BackendSlotCapacity) pooledToken
 // backend capacity) — no pooled constraint, the caller's other gates decide.
 //
 // The check runs in BYTES when the pool is byte-reconstructable (byteMode) and
-// every pending charge was normalizable (snap.pendingBytesKnown). The incoming
-// request's own KV rate (snap.kvBytesPerToken — this model's slot) prices it;
-// when that is 0 (a cold/absent slot) the request is priced CONSERVATIVELY at
-// the box's max resident rate (pool.maxKVBytesPerToken) rather than collapsing
-// to token accounting, so a large-KV cold request on a mixed-KV box is not
-// under-charged against a token view of a byte-reconstructable pool. Token
-// accounting is used ONLY when the pool is not byte-reconstructable
-// (!byteMode) or a pending charge could not be normalized (!pendingBytesKnown)
-// — byte-for-byte the legacy-provider behavior.
+// every pending charge was normalizable (snap.pendingBytesKnown). The single
+// resolvedPooledKVBytesPerToken policy prices both resident and cold/absent
+// requests: resident rates are preserved after clamping; cold unknown rates use
+// at least the conservative default, never a cheap resident-only estimate.
+// Token accounting is used only when the pool is not byte-reconstructable or
+// the snapshot predates/omits byte accumulation.
 func pooledBudgetAdmits(snap routingSnapshot, requestTokens int64) bool {
 	pool := snap.pooledTokenBudget
 	if pool.total <= 0 {
 		return true
 	}
 	if pool.byteMode && snap.pendingBytesKnown {
-		reqRate := snap.kvBytesPerToken
-		if reqRate <= 0 {
-			// Cold/absent slot: price at the box's max resident rate. Guaranteed
-			// > 0 in byteMode; the guard covers the impossible 0 case by falling
-			// through to token accounting.
-			reqRate = pool.maxKVBytesPerToken
-		}
+		reqRate := resolvedPooledKVBytesPerToken(pool, snap.kvBytesPerToken)
 		if reqRate > 0 {
 			extra := snap.pendingMaxBytesAllModels - pool.committedBytes
 			if extra < 0 {
 				extra = 0
 			}
-			return pool.usedBytes+extra+requestTokens*reqRate <= pool.totalBytes
+			remaining := pool.totalBytes - pool.usedBytes
+			if remaining < 0 || extra > remaining || requestTokens < 0 {
+				return false
+			}
+			return requestTokens <= (remaining-extra)/reqRate
 		}
 	}
 	extra := int64(snap.pendingMaxTokensAllModels) - pool.committed
 	if extra < 0 {
 		extra = 0
 	}
-	return pool.used+extra+requestTokens <= pool.total
+	remaining := pool.total - pool.used
+	if remaining < 0 || extra > remaining || requestTokens < 0 {
+		return false
+	}
+	return requestTokens <= remaining-extra
 }
 
 // pooledRemainingTokens is the capacity-snapshot analog of pooledBudgetAdmits:
@@ -215,11 +253,10 @@ func pooledBudgetAdmits(snap routingSnapshot, requestTokens int64) bool {
 // (/v1/models[/capacity]) cannot advertise pooled headroom the admission gate
 // refuses. Both branch identically: BYTES when the pool is byte-reconstructable
 // (byteMode) and every pending charge normalized (pendingBytesKnown), pricing
-// this model at modelRate when its resident slot reports one (> 0) and at the
-// box's max resident rate (pool.maxKVBytesPerToken) for a cold/absent slot
-// (modelRate == 0) — the SAME cold-rate substitution pooledBudgetAdmits uses,
-// so the two stay equivalent. Token accounting ONLY when !byteMode or
-// !pendingBytesKnown. Returns -1 when the provider reports no pooled budget
+// this model through resolvedPooledKVBytesPerToken — the same known/default
+// policy pooledBudgetAdmits uses — so the two stay equivalent. Token accounting
+// only when !byteMode or !pendingBytesKnown. Returns -1 when the provider
+// reports no pooled budget
 // (total <= 0) — the "no pooled constraint" sentinel that leaves the per-slot
 // numbers unclamped.
 func pooledRemainingTokens(pool pooledTokenBudget, pendingTokensAllModels int, pendingBytesAllModels int64, pendingBytesKnown bool, modelRate int64) int64 {
@@ -227,29 +264,26 @@ func pooledRemainingTokens(pool pooledTokenBudget, pendingTokensAllModels int, p
 		return -1
 	}
 	if pool.byteMode && pendingBytesKnown {
-		rate := modelRate
-		if rate <= 0 {
-			rate = pool.maxKVBytesPerToken // cold/absent slot: box's max rate
-		}
+		rate := resolvedPooledKVBytesPerToken(pool, modelRate)
 		if rate > 0 {
 			extra := pendingBytesAllModels - pool.committedBytes
 			if extra < 0 {
 				extra = 0
 			}
-			remBytes := pool.totalBytes - pool.usedBytes - extra
-			if remBytes < 0 {
-				remBytes = 0
+			remBytes := pool.totalBytes - pool.usedBytes
+			if remBytes <= 0 || extra >= remBytes {
+				return 0
 			}
-			return remBytes / rate
+			return (remBytes - extra) / rate
 		}
 	}
 	extra := int64(pendingTokensAllModels) - pool.committed
 	if extra < 0 {
 		extra = 0
 	}
-	rem := pool.total - pool.used - extra
-	if rem < 0 {
-		rem = 0
+	rem := pool.total - pool.used
+	if rem <= 0 || extra >= rem {
+		return 0
 	}
-	return rem
+	return rem - extra
 }

--- a/coordinator/registry/pooled_admission.go
+++ b/coordinator/registry/pooled_admission.go
@@ -16,8 +16,23 @@ import "github.com/eigeninference/d-inference/coordinator/protocol"
 // pool reduces to the slot's own budget and the arithmetic matches the
 // per-slot check exactly) and for legacy providers that report no token
 // budget (total = 0).
+//
+// Units: the shared pool is physically BYTES of unified memory, and
+// co-resident models spend it at different per-token rates
+// (BackendSlotCapacity.KVBytesPerToken — a 26B model's token costs ~10× a
+// small model's), so tokens are not a common unit across slots. When every
+// budget slot reports its KV rate, the pool and all charges against it are
+// normalized into bytes; otherwise (any legacy slot, or a pending/incoming
+// request whose model has no reported rate) the check falls back to token
+// accounting, which is exactly the pre-byte behavior. Token accounting
+// denominates the pool in the LARGEST per-slot free-token view (the
+// smallest-KV model's), so a big-KV model's pending burst is under-charged
+// against it — the byte form is what makes a small-KV model's burst visible
+// to a big-KV co-resident and vice versa.
 
-// pooledTokenBudget is a provider's reconstructed whole-box token budget.
+// pooledTokenBudget is a provider's reconstructed whole-box token budget,
+// carried in token units always and additionally in byte units when every
+// budget slot reports KVBytesPerToken (byteMode).
 type pooledTokenBudget struct {
 	// used is Σ (ActiveTokenBudgetUsed + QueuedTokenBudget) across budget
 	// slots — reservations the provider itself reports as live.
@@ -31,6 +46,23 @@ type pooledTokenBudget struct {
 	// (which add across slots) plus the shared free headroom counted exactly
 	// once (per-slot maxes are NOT additive).
 	total int64
+
+	// usedBytes / committedBytes / totalBytes are the byte-normalized analogs
+	// of used / committed / total: each slot's token quantities × that slot's
+	// KVBytesPerToken, with the shared free headroom again counted once (the
+	// largest per-slot free BYTE view — in byte space every slot observes the
+	// same shared pool). Only meaningful when byteMode is true.
+	usedBytes      int64
+	committedBytes int64
+	totalBytes     int64
+	// byteMode is true when there is at least one budget slot and EVERY budget
+	// slot reports KVBytesPerToken > 0, i.e. the pool can be reconstructed in
+	// bytes. False ⇒ pooledBudgetAdmits uses token accounting exactly.
+	byteMode bool
+	// kvBytesPerToken maps each budget slot's model to its reported per-token
+	// KV rate, for normalizing coordinator-pending charges into bytes. Nil
+	// when no budget slot reports a rate.
+	kvBytesPerToken map[string]int64
 }
 
 // providerPooledTokenBudget reconstructs the provider's pooled budget from its
@@ -40,10 +72,17 @@ type pooledTokenBudget struct {
 // pooledBudgetAdmits treats as "no pooled constraint".
 func providerPooledTokenBudget(slots []protocol.BackendSlotCapacity) pooledTokenBudget {
 	used, total := providerTokenBudget(slots)
-	var committed int64
+	pool := pooledTokenBudget{used: used, total: total, byteMode: true}
+	budgetSlots := 0
+	var sharedFreeBytes int64
 	for _, slot := range slots {
 		if slot.ActiveTokenBudgetMax <= 0 {
 			continue
+		}
+		budgetSlots++
+		slotUsed := slot.ActiveTokenBudgetUsed + slot.QueuedTokenBudget
+		if slotUsed < 0 {
+			slotUsed = 0
 		}
 		c := slot.ActiveTokenBudgetUsed + slot.QueuedTokenBudget
 		if slot.MaxTokensPotential > c {
@@ -52,24 +91,59 @@ func providerPooledTokenBudget(slots []protocol.BackendSlotCapacity) pooledToken
 		if c < 0 {
 			c = 0
 		}
-		committed += c
+		pool.committed += c
+		if slot.KVBytesPerToken <= 0 {
+			// A budget slot without a KV rate makes byte reconstruction
+			// impossible for the whole pool (legacy provider build).
+			pool.byteMode = false
+			continue
+		}
+		if pool.kvBytesPerToken == nil {
+			pool.kvBytesPerToken = make(map[string]int64, len(slots))
+		}
+		pool.kvBytesPerToken[slot.Model] = slot.KVBytesPerToken
+		pool.usedBytes += slotUsed * slot.KVBytesPerToken
+		pool.committedBytes += c * slot.KVBytesPerToken
+		// Per-slot free headroom in bytes; all slots see the same shared byte
+		// pool, so the largest is the live shared headroom (counted once).
+		if free := (slot.ActiveTokenBudgetMax - slotUsed) * slot.KVBytesPerToken; free > sharedFreeBytes {
+			sharedFreeBytes = free
+		}
 	}
-	return pooledTokenBudget{used: used, committed: committed, total: total}
+	if budgetSlots == 0 {
+		pool.byteMode = false
+	}
+	pool.totalBytes = pool.committedBytes + sharedFreeBytes
+	return pool
 }
 
 // pooledBudgetAdmits reports whether a request of requestTokens fits the
 // provider's shared pool once every model's coordinator-side pending tokens
-// (pendingMaxTokensAllModels) are charged against it. The subtraction of
-// pool.committed mirrors the per-slot check's committedTokenBudget subtraction
-// (avoid double-counting requests the heartbeat already reflects), floored at
-// zero. total <= 0 means the provider reported no pooled budget (legacy
-// provider, or a snapshot built without backend capacity) — no pooled
-// constraint, the caller's other gates decide.
-func pooledBudgetAdmits(pool pooledTokenBudget, pendingMaxTokensAllModels int, requestTokens int64) bool {
+// (snap.pendingMaxTokensAllModels / snap.pendingMaxBytesAllModels) are charged
+// against it. The subtraction of the committed baseline mirrors the per-slot
+// check's committedTokenBudget subtraction (avoid double-counting requests the
+// heartbeat already reflects), floored at zero. total <= 0 means the provider
+// reported no pooled budget (legacy provider, or a snapshot built without
+// backend capacity) — no pooled constraint, the caller's other gates decide.
+//
+// The check runs in BYTES when the pool is byte-reconstructable (byteMode),
+// every pending charge was normalizable (snap.pendingBytesKnown), and the
+// incoming request's own KV rate is known (snap.kvBytesPerToken — this
+// model's slot; 0 for a cold/absent slot). Any gap falls back to token
+// accounting, which is byte-for-byte the legacy-provider behavior.
+func pooledBudgetAdmits(snap routingSnapshot, requestTokens int64) bool {
+	pool := snap.pooledTokenBudget
 	if pool.total <= 0 {
 		return true
 	}
-	extra := int64(pendingMaxTokensAllModels) - pool.committed
+	if pool.byteMode && snap.pendingBytesKnown && snap.kvBytesPerToken > 0 {
+		extra := snap.pendingMaxBytesAllModels - pool.committedBytes
+		if extra < 0 {
+			extra = 0
+		}
+		return pool.usedBytes+extra+requestTokens*snap.kvBytesPerToken <= pool.totalBytes
+	}
+	extra := int64(snap.pendingMaxTokensAllModels) - pool.committed
 	if extra < 0 {
 		extra = 0
 	}

--- a/coordinator/registry/pooled_admission.go
+++ b/coordinator/registry/pooled_admission.go
@@ -1,0 +1,77 @@
+package registry
+
+import "github.com/eigeninference/d-inference/coordinator/protocol"
+
+// pooled_admission.go — provider-level (all-models) token-budget admission.
+//
+// A provider's per-model slots do NOT own private KV budgets: each slot's
+// ActiveTokenBudgetMax is (that slot's committed tokens) + the box's ONE
+// shared live KV headroom (see providerTokenBudget, utilization.go). The
+// per-slot admission check in freeMemoryAdmits therefore lets two co-resident
+// models double-spend the shared pool inside the ~30s heartbeat gap: a burst
+// admitted against model A's slot max is invisible to model B's slot max
+// until the next heartbeat re-reports both. The pooled check here closes that
+// gap by admitting against the reconstructed whole-box pool with ALL models'
+// coordinator-pending tokens counted. Inert for single-model providers (the
+// pool reduces to the slot's own budget and the arithmetic matches the
+// per-slot check exactly) and for legacy providers that report no token
+// budget (total = 0).
+
+// pooledTokenBudget is a provider's reconstructed whole-box token budget.
+type pooledTokenBudget struct {
+	// used is Σ (ActiveTokenBudgetUsed + QueuedTokenBudget) across budget
+	// slots — reservations the provider itself reports as live.
+	used int64
+	// committed is the all-slots analog of committedTokenBudget: Σ per slot of
+	// max(used+queued, MaxTokensPotential). It is the heartbeat-visible
+	// commitment baseline subtracted from coordinator-pending tokens so
+	// requests the provider already accounts for are not double-counted.
+	committed int64
+	// total is the pooled capacity from providerTokenBudget: committed tokens
+	// (which add across slots) plus the shared free headroom counted exactly
+	// once (per-slot maxes are NOT additive).
+	total int64
+}
+
+// providerPooledTokenBudget reconstructs the provider's pooled budget from its
+// backend slots. Slots without a token budget (ActiveTokenBudgetMax <= 0) are
+// ignored and negative per-slot values floored, mirroring providerTokenBudget.
+// A nil/empty slice (or no budget slots at all) yields the zero value, which
+// pooledBudgetAdmits treats as "no pooled constraint".
+func providerPooledTokenBudget(slots []protocol.BackendSlotCapacity) pooledTokenBudget {
+	used, total := providerTokenBudget(slots)
+	var committed int64
+	for _, slot := range slots {
+		if slot.ActiveTokenBudgetMax <= 0 {
+			continue
+		}
+		c := slot.ActiveTokenBudgetUsed + slot.QueuedTokenBudget
+		if slot.MaxTokensPotential > c {
+			c = slot.MaxTokensPotential
+		}
+		if c < 0 {
+			c = 0
+		}
+		committed += c
+	}
+	return pooledTokenBudget{used: used, committed: committed, total: total}
+}
+
+// pooledBudgetAdmits reports whether a request of requestTokens fits the
+// provider's shared pool once every model's coordinator-side pending tokens
+// (pendingMaxTokensAllModels) are charged against it. The subtraction of
+// pool.committed mirrors the per-slot check's committedTokenBudget subtraction
+// (avoid double-counting requests the heartbeat already reflects), floored at
+// zero. total <= 0 means the provider reported no pooled budget (legacy
+// provider, or a snapshot built without backend capacity) — no pooled
+// constraint, the caller's other gates decide.
+func pooledBudgetAdmits(pool pooledTokenBudget, pendingMaxTokensAllModels int, requestTokens int64) bool {
+	if pool.total <= 0 {
+		return true
+	}
+	extra := int64(pendingMaxTokensAllModels) - pool.committed
+	if extra < 0 {
+		extra = 0
+	}
+	return pool.used+extra+requestTokens <= pool.total
+}

--- a/coordinator/registry/pooled_admission_test.go
+++ b/coordinator/registry/pooled_admission_test.go
@@ -645,60 +645,138 @@ func TestModelCapacitySnapshotByteModePooledClamp(t *testing.T) {
 // TestPooledColdUnknownKVChargedInBytes is the cold unknown-KV regression: on a
 // byte-reconstructable mixed-KV box, a COLD request (its own model has no
 // resident slot, so snap.kvBytesPerToken == 0) must be priced CONSERVATIVELY in
-// bytes at the box's max resident rate, NOT collapse to token accounting that
-// under-charges a large-KV burst against the small-KV token view of the pool.
-// Fails without the maxKVBytesPerToken cold-rate substitution.
+// bytes at the bounded unknown-model default, NOT collapse to token accounting
+// or borrow a rate that only describes resident models.
 func TestPooledColdUnknownKVChargedInBytes(t *testing.T) {
-	t.Run("mixed_kv_cold_priced_at_max_rate", func(t *testing.T) {
+	t.Run("mixed_kv_cold_priced_at_default_rate", func(t *testing.T) {
 		slots := []protocol.BackendSlotCapacity{
 			{Model: "big-kv", ActiveTokenBudgetMax: 10_000, KVBytesPerToken: 100_000},   // 1 GB view
 			{Model: "small-kv", ActiveTokenBudgetMax: 100_000, KVBytesPerToken: 10_000}, // same 1 GB
 		}
 		pool := providerPooledTokenBudget(slots)
-		if !pool.byteMode || pool.maxKVBytesPerToken != 100_000 {
-			t.Fatalf("pool byteMode=%v maxKVBytesPerToken=%d, want true / 100000", pool.byteMode, pool.maxKVBytesPerToken)
+		if !pool.byteMode {
+			t.Fatal("pool byteMode = false, want true")
+		}
+		if got := resolvedPooledKVBytesPerToken(pool, 0); got != kvCacheBytesPerToken {
+			t.Fatalf("resolved cold KV rate = %d, want conservative default %d", got, kvCacheBytesPerToken)
 		}
 		cold := routingSnapshot{
 			kvBytesPerToken:   0, // cold/absent slot
 			pendingBytesKnown: true,
 			pooledTokenBudget: pool,
 		}
-		// 50k tokens: token fallback would admit (50k ≤ 100k token pool); byte
-		// pricing at the 100 kB/token max rate = 5 GB ≫ 1 GB pool → reject.
+		// 50k tokens: token fallback would admit (50k <= 100k token pool), but
+		// conservative byte pricing is far beyond the 1 GB pool.
 		if pooledBudgetAdmits(cold, 50_000) {
-			t.Fatal("cold large-KV request admitted via token fallback (5 GB into a 1 GB byte pool)")
+			t.Fatal("cold unknown-KV request admitted via token/resident-rate fallback")
 		}
-		// Control: 8k tokens = 0.8 GB fits the 1 GB byte pool.
-		if !pooledBudgetAdmits(cold, 8_000) {
-			t.Fatal("cold request rejected although 0.8 GB fits the 1 GB byte pool")
+		// Control: 2k tokens at the default rate remain below 1 GB.
+		if !pooledBudgetAdmits(cold, 2_000) {
+			t.Fatal("cold request rejected although its conservative byte charge fits the pool")
 		}
-		// Capacity feed mirrors the gate: 1 GB ÷ 100 kB/token = 10k tokens.
-		if rem := pooledRemainingTokens(pool, 0, 0, true, 0); rem != 10_000 {
-			t.Fatalf("cold pooledRemainingTokens = %d, want 10_000 (byte pool ÷ max rate)", rem)
+		wantRemaining := pool.totalBytes / kvCacheBytesPerToken
+		if rem := pooledRemainingTokens(pool, 0, 0, true, 0); rem != wantRemaining {
+			t.Fatalf("cold pooledRemainingTokens = %d, want %d (byte pool / default rate)", rem, wantRemaining)
 		}
 	})
 
-	// Single-KV byteMode box: a cold request priced at the sole resident rate is
-	// arithmetically identical to token accounting, so the boundary is unchanged.
-	t.Run("single_kv_cold_equals_token_boundary", func(t *testing.T) {
+	// A known resident model still uses its reported rate, so its established
+	// byte/token boundary is unchanged by the cold-model default.
+	t.Run("known_model_keeps_reported_rate_boundary", func(t *testing.T) {
 		pool := providerPooledTokenBudget([]protocol.BackendSlotCapacity{
 			{Model: "m", ActiveTokenBudgetMax: 10_000, KVBytesPerToken: 50_000},
 		})
-		cold := routingSnapshot{kvBytesPerToken: 0, pendingBytesKnown: true, pooledTokenBudget: pool}
-		if !pooledBudgetAdmits(cold, 10_000) {
-			t.Fatal("cold request at the exact 10k boundary rejected (single-KV byte pricing changed the boundary)")
+		known := routingSnapshot{kvBytesPerToken: 50_000, pendingBytesKnown: true, pooledTokenBudget: pool}
+		if !pooledBudgetAdmits(known, 10_000) {
+			t.Fatal("known request at the exact 10k boundary rejected")
 		}
-		if pooledBudgetAdmits(cold, 10_001) {
-			t.Fatal("cold request past the 10k boundary admitted (single-KV budget loosened)")
+		if pooledBudgetAdmits(known, 10_001) {
+			t.Fatal("known request past the 10k boundary admitted")
 		}
 	})
+}
+
+// TestPooledFirstColdRequestUsesConservativeDefault pins the unknown-model
+// boundary: resident slots only reveal THEIR KV rates, so the largest resident
+// rate is not a safe price for a first request to a cold model. A box with only
+// a cheap 10 kB/token resident model has a 1 GB pool; a 3k-token cold request
+// fits at that resident rate but exceeds the pool at the bounded conservative
+// default used for an unknown model.
+func TestPooledFirstColdRequestUsesConservativeDefault(t *testing.T) {
+	pool := providerPooledTokenBudget([]protocol.BackendSlotCapacity{
+		{Model: "resident-small-kv", ActiveTokenBudgetMax: 100_000, KVBytesPerToken: 10_000},
+	})
+	snap := routingSnapshot{
+		kvBytesPerToken:   0, // first request: cold model has no slot-reported rate
+		pendingBytesKnown: true,
+		pooledTokenBudget: pool,
+	}
+
+	if pooledBudgetAdmits(snap, 3_000) {
+		t.Fatal("first cold request priced at resident-only KV max instead of the conservative unknown-model default")
+	}
+	wantRemaining := pool.totalBytes / kvCacheBytesPerToken
+	if got := pooledRemainingTokens(pool, 0, 0, true, 0); got != wantRemaining {
+		t.Fatalf("cold pooled remaining = %d, want %d from conservative default rate", got, wantRemaining)
+	}
+}
+
+// TestPooledPendingColdRequestKeepsByteAccounting pins the second-request
+// boundary. Once an unknown cold request is pending, its missing resident slot
+// must be charged at the same conservative default rather than disabling byte
+// accounting for the entire provider. Otherwise a subsequent resident request
+// falls back to the much looser token pool and double-spends physical KV bytes.
+func TestPooledPendingColdRequestKeepsByteAccounting(t *testing.T) {
+	const residentRate = int64(10_000)
+	p := &Provider{
+		BackendCapacity: &protocol.BackendCapacity{Slots: []protocol.BackendSlotCapacity{
+			{Model: "resident-small-kv", ActiveTokenBudgetMax: 100_000, KVBytesPerToken: residentRate},
+		}},
+		pendingReqs: map[string]*PendingRequest{
+			"cold": {
+				RequestID:          "cold",
+				Model:              "cold-unknown-kv",
+				RequestedMaxTokens: 2_100,
+			},
+		},
+	}
+
+	var snap routingSnapshot
+	fillSnapshotPendingAndPool(&snap, p, "resident-small-kv")
+	snap.kvBytesPerToken = residentRate
+
+	wantPendingBytes := int64(2_100) * kvCacheBytesPerToken
+	if !snap.pendingBytesKnown {
+		t.Error("cold pending request disabled provider byte accounting")
+	}
+	if snap.pendingMaxBytesAllModels != wantPendingBytes {
+		t.Errorf("cold pending bytes = %d, want %d at conservative default rate", snap.pendingMaxBytesAllModels, wantPendingBytes)
+	}
+	if pooledBudgetAdmits(snap, 20_000) {
+		t.Error("subsequent resident request admitted via token fallback after cold pending request consumed byte headroom")
+	}
+	wantRemaining := (snap.pooledTokenBudget.totalBytes - wantPendingBytes) / residentRate
+	if got := pooledRemainingTokens(
+		snap.pooledTokenBudget,
+		snap.pendingMaxTokensAllModels,
+		snap.pendingMaxBytesAllModels,
+		snap.pendingBytesKnown,
+		snap.kvBytesPerToken,
+	); got != wantRemaining {
+		t.Errorf("resident pooled remaining = %d, want %d after default-priced cold pending request", got, wantRemaining)
+	}
+
+	overflowTokens := int64(math.MaxInt64/kvCacheBytesPerToken + 1)
+	if got := addPooledKVByteCharge(0, overflowTokens, resolvedPooledKVBytesPerToken(snap.pooledTokenBudget, 0)); got != math.MaxInt64 {
+		t.Errorf("overflowing cold pending charge = %d, want saturated MaxInt64", got)
+	}
 }
 
 // TestPooledRemainingTokensMatchesAdmits pins the equivalence the capacity feed
 // relies on: pooledBudgetAdmits(snap, n) admits IFF n <= pooledRemainingTokens(
 // pool, …, snap.kvBytesPerToken), across the byte path (known rate), the byte
-// COLD path (rate 0 → max resident rate substitution), token mode, and the
-// pending-unknown fall-through. Both must apply the SAME cold-rate substitution.
+// COLD path (rate 0 -> bounded default substitution), token mode, and the
+// pending-unknown fall-through. Both must apply the SAME rate resolver.
 func TestPooledRemainingTokensMatchesAdmits(t *testing.T) {
 	bytePool := providerPooledTokenBudget([]protocol.BackendSlotCapacity{
 		{Model: "big-kv", ActiveTokenBudgetMax: 10_000, KVBytesPerToken: 100_000},

--- a/coordinator/registry/pooled_admission_test.go
+++ b/coordinator/registry/pooled_admission_test.go
@@ -1,0 +1,222 @@
+package registry
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+)
+
+func TestProviderPooledTokenBudget(t *testing.T) {
+	cases := []struct {
+		name      string
+		slots     []protocol.BackendSlotCapacity
+		used      int64
+		committed int64
+		total     int64
+	}{
+		{name: "nil_slots"},
+		{
+			name: "single_slot",
+			slots: []protocol.BackendSlotCapacity{
+				{Model: "a", ActiveTokenBudgetMax: 10_000, ActiveTokenBudgetUsed: 1_000, QueuedTokenBudget: 500, MaxTokensPotential: 3_000},
+			},
+			used:      1_500,
+			committed: 3_000, // potential dominates used+queued
+			total:     10_000,
+		},
+		{
+			name: "two_slots_shared_headroom_counted_once",
+			// Both slots see the same 8k shared free headroom:
+			// maxA = 2k committed + 8k, maxB = 1k committed + 8k.
+			slots: []protocol.BackendSlotCapacity{
+				{Model: "a", ActiveTokenBudgetMax: 10_000, ActiveTokenBudgetUsed: 2_000},
+				{Model: "b", ActiveTokenBudgetMax: 9_000, ActiveTokenBudgetUsed: 1_000},
+			},
+			used:      3_000,
+			committed: 3_000,
+			total:     11_000, // 3k committed + 8k shared free ONCE (not 19k)
+		},
+		{
+			name: "budgetless_slot_ignored_negatives_floored",
+			slots: []protocol.BackendSlotCapacity{
+				{Model: "a", ActiveTokenBudgetMax: 10_000, ActiveTokenBudgetUsed: -50, MaxTokensPotential: -10},
+				{Model: "legacy", ActiveTokenBudgetMax: 0, ActiveTokenBudgetUsed: 5_000},
+			},
+			used:      0,
+			committed: 0,
+			total:     10_000,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := providerPooledTokenBudget(tc.slots)
+			if got.used != tc.used || got.committed != tc.committed || got.total != tc.total {
+				t.Fatalf("providerPooledTokenBudget = %+v, want {used:%d committed:%d total:%d}",
+					got, tc.used, tc.committed, tc.total)
+			}
+		})
+	}
+}
+
+// TestPooledAdmissionCoResidencyDoubleSpend is the heartbeat-gap regression,
+// driven through the REAL reservation path: two co-resident models report
+// per-slot maxes that each equal the ONE shared 10k KV pool. A burst to model
+// A consumes the whole pool coordinator-side while the provider's heartbeat
+// still reads used=0 — the old per-slot check (same-model pending only) then
+// happily admitted model B against ITS stale slot max, double-spending the
+// pool. The pooled check must reject B. Fails without the
+// pooledBudgetAdmits call in freeMemoryAdmits.
+func TestPooledAdmissionCoResidencyDoubleSpend(t *testing.T) {
+	reg := New(testLogger())
+	p := makeSchedulerProvider(t, reg, "shared-box", gptossBuild, 93)
+	addAdvertisedModel(p, gemmaBuild)
+	p.mu.Lock()
+	p.BackendCapacity.Slots[0].ActiveTokenBudgetMax = 10_000
+	p.BackendCapacity.Slots = append(p.BackendCapacity.Slots, protocol.BackendSlotCapacity{
+		Model:                gemmaBuild,
+		State:                "running",
+		ActiveTokenBudgetMax: 10_000,
+	})
+	p.mu.Unlock()
+
+	// Burst model A (gpt-oss): five requests × (100 prompt + 1_900 max) =
+	// 10_000 tokens — exactly the pool — all inside one heartbeat gap.
+	for i := 0; i < 5; i++ {
+		pr := &PendingRequest{
+			RequestID:             fmt.Sprintf("burst-%d", i),
+			Model:                 gptossBuild,
+			EstimatedPromptTokens: 100,
+			RequestedMaxTokens:    1_900,
+		}
+		if got := reg.ReserveProvider(gptossBuild, pr); got == nil {
+			t.Fatalf("burst request %d rejected; 5×2k must fit the 10k pool", i)
+		}
+	}
+	// A sixth same-model request must be rejected (slot and pool both full) —
+	// the pre-existing per-slot behavior, unchanged.
+	if got := reg.ReserveProvider(gptossBuild, &PendingRequest{
+		RequestID: "burst-overflow", Model: gptossBuild, EstimatedPromptTokens: 100, RequestedMaxTokens: 1_900,
+	}); got != nil {
+		t.Fatalf("6th same-model request admitted past the slot budget on %q", got.ID)
+	}
+
+	// Model B (gemma) within the same gap: B's slot still reads max 10_000 /
+	// used 0, so the old check admits — but the shared pool is already fully
+	// pending to A. Must be rejected.
+	if got := reg.ReserveProvider(gemmaBuild, &PendingRequest{
+		RequestID: "victim", Model: gemmaBuild, EstimatedPromptTokens: 100, RequestedMaxTokens: 1_900,
+	}); got != nil {
+		t.Fatalf("gemma admitted during the heartbeat gap — co-resident double-spend of the shared KV pool (provider %q)", got.ID)
+	}
+}
+
+// TestPooledAdmissionAllowsCoResidentWithinPool is the non-regression control:
+// when the pool has real headroom left, a co-resident model's request IS
+// admitted — the pooled gate only charges what is actually pending.
+func TestPooledAdmissionAllowsCoResidentWithinPool(t *testing.T) {
+	reg := New(testLogger())
+	p := makeSchedulerProvider(t, reg, "shared-box", gptossBuild, 93)
+	addAdvertisedModel(p, gemmaBuild)
+	p.mu.Lock()
+	p.BackendCapacity.Slots[0].ActiveTokenBudgetMax = 10_000
+	p.BackendCapacity.Slots = append(p.BackendCapacity.Slots, protocol.BackendSlotCapacity{
+		Model:                gemmaBuild,
+		State:                "running",
+		ActiveTokenBudgetMax: 10_000,
+	})
+	p.mu.Unlock()
+
+	for i := 0; i < 2; i++ { // 4k of the 10k pool
+		pr := &PendingRequest{
+			RequestID:             fmt.Sprintf("burst-%d", i),
+			Model:                 gptossBuild,
+			EstimatedPromptTokens: 100,
+			RequestedMaxTokens:    1_900,
+		}
+		if got := reg.ReserveProvider(gptossBuild, pr); got == nil {
+			t.Fatalf("burst request %d rejected with pool mostly free", i)
+		}
+	}
+	if got := reg.ReserveProvider(gemmaBuild, &PendingRequest{
+		RequestID: "fits", Model: gemmaBuild, EstimatedPromptTokens: 100, RequestedMaxTokens: 1_900,
+	}); got == nil {
+		t.Fatal("gemma rejected although the pool has 6k headroom (pooled gate over-rejecting)")
+	}
+}
+
+// TestFreeMemoryAdmitsSingleModelUnchanged pins that the pooled check is
+// arithmetically inert for single-model providers: for one budget slot the
+// pool reduces to that slot's own budget and the admission boundary is
+// byte-for-byte the old per-slot one — including the case where
+// MaxTokensPotential dominates used+queued in the committed baseline.
+func TestFreeMemoryAdmitsSingleModelUnchanged(t *testing.T) {
+	slot := protocol.BackendSlotCapacity{
+		Model:                 "m",
+		ActiveTokenBudgetMax:  10_000,
+		ActiveTokenBudgetUsed: 3_000,
+		QueuedTokenBudget:     500,
+		MaxTokensPotential:    6_000,
+	}
+	// Old per-slot formula: used+queued + max(0, pending − max(used+queued,
+	// potential)) + req ≤ max → 3_500 + 1_000 + req ≤ 10_000 → req ≤ 5_500.
+	mkSnap := func(pending int) routingSnapshot {
+		return routingSnapshot{
+			pendingMaxTokens:          pending,
+			pendingMaxTokensAllModels: pending, // single model: identical
+			activeTokenBudgetUsed:     slot.ActiveTokenBudgetUsed,
+			activeTokenBudgetMax:      slot.ActiveTokenBudgetMax,
+			queuedTokenBudget:         slot.QueuedTokenBudget,
+			maxTokensPotential:        slot.MaxTokensPotential,
+			pooledTokenBudget:         providerPooledTokenBudget([]protocol.BackendSlotCapacity{slot}),
+		}
+	}
+	if !freeMemoryAdmits(mkSnap(7_000), 0, 5_500) {
+		t.Fatal("request at the exact old boundary (5_500) rejected — pooled check changed single-model behavior")
+	}
+	if freeMemoryAdmits(mkSnap(7_000), 0, 5_501) {
+		t.Fatal("request past the old boundary (5_501) admitted — budget admission loosened")
+	}
+}
+
+// TestFreeMemoryAdmitsPooledRejectsGapDoubleSpend is the pure-function version
+// of the double-spend regression (fails without the pooledBudgetAdmits call):
+// model B's own slot budget admits, but the all-models pending has consumed
+// the pool.
+func TestFreeMemoryAdmitsPooledRejectsGapDoubleSpend(t *testing.T) {
+	slots := []protocol.BackendSlotCapacity{
+		{Model: "a", ActiveTokenBudgetMax: 10_000},
+		{Model: "b", ActiveTokenBudgetMax: 10_000},
+	}
+	snap := routingSnapshot{
+		// Snapshot for model B: no same-model pending, stale heartbeat (used 0).
+		pendingMaxTokens:          0,
+		pendingMaxTokensAllModels: 10_000, // model A's in-gap burst
+		activeTokenBudgetMax:      10_000,
+		pooledTokenBudget:         providerPooledTokenBudget(slots),
+	}
+	if freeMemoryAdmits(snap, 100, 1_900) {
+		t.Fatal("admitted 2k tokens into a pool with 10k already pending to a co-resident model (per-slot double-spend)")
+	}
+	// Same snapshot with only 4k pending across models → admits.
+	snap.pendingMaxTokensAllModels = 4_000
+	if !freeMemoryAdmits(snap, 100, 1_900) {
+		t.Fatal("rejected 2k tokens although the pool has 6k of headroom")
+	}
+}
+
+// TestFreeMemoryAdmitsLegacyProviderUnchanged: providers that report no token
+// budget (ActiveTokenBudgetMax == 0) never reach the budget branch — the
+// legacy memory-estimation path is untouched by the pooled fields.
+func TestFreeMemoryAdmitsLegacyProviderUnchanged(t *testing.T) {
+	snap := routingSnapshot{
+		modelLoaded:               true,
+		totalMemoryGB:             64,
+		gpuMemoryActiveGB:         10,
+		modelSizeGB:               14,
+		pendingMaxTokensAllModels: 1 << 30, // must be ignored on the legacy path
+	}
+	if !freeMemoryAdmits(snap, 100, 1_900) {
+		t.Fatal("legacy (budget-less) admission changed: loaded model with free memory must admit")
+	}
+}

--- a/coordinator/registry/pooled_admission_test.go
+++ b/coordinator/registry/pooled_admission_test.go
@@ -51,6 +51,137 @@ func TestProviderPooledTokenBudgetClampsKVByteRate(t *testing.T) {
 	}
 }
 
+// TestPooledKnownZeroBudgetRejects distinguishes a modern Engine V2 slot whose
+// positive KV rate makes a zero budget authoritative from a legacy slot that
+// reports neither field. A live fleet clamp can truthfully drive the v2 token
+// budget to zero while KVBytesPerToken remains known; treating total==0 as the
+// legacy "no constraint" sentinel would fail open.
+func TestPooledKnownZeroBudgetRejects(t *testing.T) {
+	pool := providerPooledTokenBudget([]protocol.BackendSlotCapacity{
+		{Model: "known-full", ActiveTokenBudgetMax: 0, KVBytesPerToken: 800_000},
+	})
+	snap := routingSnapshot{
+		kvBytesPerToken:   800_000,
+		pendingBytesKnown: true,
+		pooledTokenBudget: pool,
+	}
+	if pooledBudgetAdmits(snap, 1) {
+		t.Fatal("known-zero Engine V2 budget admitted a request as if it were an unconstrained legacy slot")
+	}
+	if got := pooledRemainingTokens(pool, 0, 0, true, 800_000); got != 0 {
+		t.Fatalf("known-zero pooled remaining = %d, want 0", got)
+	}
+
+	legacy := providerPooledTokenBudget([]protocol.BackendSlotCapacity{{Model: "legacy"}})
+	legacySnap := routingSnapshot{pooledTokenBudget: legacy}
+	if !pooledBudgetAdmits(legacySnap, 1) {
+		t.Fatal("legacy slot with no budget or KV rate became constrained")
+	}
+	if got := pooledRemainingTokens(legacy, 0, 0, false, 0); got != -1 {
+		t.Fatalf("legacy pooled remaining = %d, want -1 no-constraint sentinel", got)
+	}
+}
+
+// TestPooledZeroBudgetResidentRateStaysSymmetric pins the mixed-slot case. A
+// resident v2 model can report a positive KV rate with a zero budget after the
+// live fleet clamp. Its rate must remain available even though the slot adds no
+// budget: pending aggregation, incoming admission, and ModelCapacitySnapshot
+// must all price that model at the same reported rate.
+func TestPooledZeroBudgetResidentRateStaysSymmetric(t *testing.T) {
+	const (
+		budgetedRate  = int64(10_000)
+		knownZeroRate = int64(800_000)
+	)
+	reg := New(testLogger())
+	p := makeSchedulerProvider(t, reg, "mixed-known-zero", gptossBuild, 93)
+	addAdvertisedModel(p, gemmaBuild)
+	p.mu.Lock()
+	p.BackendCapacity.Slots[0].State = "running"
+	p.BackendCapacity.Slots[0].ActiveTokenBudgetMax = 100_000
+	p.BackendCapacity.Slots[0].KVBytesPerToken = budgetedRate
+	p.BackendCapacity.Slots = append(p.BackendCapacity.Slots, protocol.BackendSlotCapacity{
+		Model:                gemmaBuild,
+		State:                "running",
+		ActiveTokenBudgetMax: 0,
+		KVBytesPerToken:      knownZeroRate,
+	})
+	pool := providerPooledTokenBudget(p.BackendCapacity.Slots)
+	p.mu.Unlock()
+
+	if got := pool.kvBytesPerToken[gemmaBuild]; got != knownZeroRate {
+		t.Fatalf("zero-budget resident KV rate = %d, want reported %d", got, knownZeroRate)
+	}
+
+	// Pending work for the zero-budget resident must use its real rate, not the
+	// 400 kB/token unknown-model default.
+	p.mu.Lock()
+	p.pendingReqs["known-zero-pending"] = &PendingRequest{
+		RequestID:          "known-zero-pending",
+		Model:              gemmaBuild,
+		RequestedMaxTokens: 1,
+	}
+	var pendingSnap routingSnapshot
+	fillSnapshotPendingAndPool(&pendingSnap, p, gemmaBuild)
+	delete(p.pendingReqs, "known-zero-pending")
+	p.mu.Unlock()
+	if !pendingSnap.pendingBytesKnown {
+		t.Fatal("zero-budget resident disabled byte accounting")
+	}
+	if got := pendingSnap.pendingMaxBytesAllModels; got != knownZeroRate {
+		t.Fatalf("zero-budget resident pending bytes = %d, want reported rate %d", got, knownZeroRate)
+	}
+
+	capacityForGemma := func() ModelCapacity {
+		t.Helper()
+		for _, capacity := range reg.ModelCapacitySnapshot() {
+			if capacity.ModelID == gemmaBuild {
+				return capacity
+			}
+		}
+		t.Fatalf("missing capacity row for %s", gemmaBuild)
+		return ModelCapacity{}
+	}
+
+	// The model-local zero is authoritative even while the co-resident model
+	// still exposes the full shared pool. The known-zero model must reject and
+	// stay non-routable; the positive-budget model remains usable.
+	if gemma := capacityForGemma(); gemma.Ready || gemma.RoutableProviders != 0 {
+		t.Fatalf("known-zero model with abundant pooled headroom = %+v, want not ready/routable", gemma)
+	}
+	if got := reg.ReserveProvider(gemmaBuild, &PendingRequest{
+		RequestID: "known-zero-probe", Model: gemmaBuild, RequestedMaxTokens: 1,
+	}); got != nil {
+		t.Fatalf("known-zero model admitted from co-resident pooled headroom on provider %q", got.ID)
+	}
+	if got := reg.ReserveProvider(gptossBuild, &PendingRequest{
+		RequestID: "positive-budget-probe", Model: gptossBuild, RequestedMaxTokens: 1,
+	}); got == nil {
+		t.Fatal("positive-budget co-resident was blocked by another model's known-zero budget")
+	} else {
+		got.RemovePending("positive-budget-probe")
+	}
+
+	// Leave 500 kB of the shared 1 GB pool. That fits one token only under the
+	// incorrect 400 kB default; the reported 800 kB rate yields zero capacity.
+	p.mu.Lock()
+	p.pendingReqs["small-kv-burst"] = &PendingRequest{
+		RequestID:          "small-kv-burst",
+		Model:              gptossBuild,
+		RequestedMaxTokens: 99_950,
+	}
+	p.mu.Unlock()
+
+	gemma := capacityForGemma()
+	if gemma.Ready || gemma.RoutableProviders != 0 {
+		t.Fatalf("zero-budget resident capacity = %+v, want not ready/routable with less than one reported-rate token left", gemma)
+	}
+	if got := reg.ReserveProvider(gemmaBuild, &PendingRequest{
+		RequestID: "probe", Model: gemmaBuild, RequestedMaxTokens: 1,
+	}); got != nil {
+		t.Fatalf("zero-budget resident admitted one 800 kB token into 500 kB headroom on provider %q", got.ID)
+	}
+}
+
 func TestProviderPooledTokenBudget(t *testing.T) {
 	cases := []struct {
 		name      string

--- a/coordinator/registry/pooled_admission_test.go
+++ b/coordinator/registry/pooled_admission_test.go
@@ -346,6 +346,88 @@ func TestPooledAdmissionByteDoubleSpendRealPath(t *testing.T) {
 	}
 }
 
+// TestFreeMemoryAdmitsColdModelChargesPool is the cold-slot pooled-gate
+// regression (pure-function form): the target model reports NO budget slot
+// (activeTokenBudgetMax == 0, not loaded here), so it skips the budget branch
+// entirely — but a resident co-model's slot reports the shared pool, and the
+// in-gap pending burst has already consumed it. The cold request must be
+// charged against the pool too, or it double-spends the same KV the resident
+// pending will occupy. Fails without the cold-path pooledBudgetAdmits call.
+func TestFreeMemoryAdmitsColdModelChargesPool(t *testing.T) {
+	slots := []protocol.BackendSlotCapacity{
+		{Model: "resident", ActiveTokenBudgetMax: 10_000},
+	}
+	mkSnap := func(pendingAllModels int) routingSnapshot {
+		return routingSnapshot{
+			// Snapshot for a COLD model: no slot, no budget, model not loaded.
+			pendingMaxTokensAllModels: pendingAllModels,
+			pooledTokenBudget:         providerPooledTokenBudget(slots),
+		}
+	}
+	if freeMemoryAdmits(mkSnap(10_000), 100, 1_900) {
+		t.Fatal("cold request admitted into a pool fully pending to a resident model (cold path skipped the pooled gate)")
+	}
+	// Control: with 4k of the 10k pool pending, the 2k cold request fits.
+	if !freeMemoryAdmits(mkSnap(4_000), 100, 1_900) {
+		t.Fatal("cold request rejected although the pool has 6k of headroom")
+	}
+}
+
+// TestPooledAdmissionColdModelDoubleSpendRealPath mirrors
+// TestPooledAdmissionCoResidencyDoubleSpend with the target model COLD: gemma
+// is advertised but has no backend slot, so its requests take the
+// non-budget admission path. An in-gap burst to the resident gpt-oss slot
+// consumes the whole shared pool; the cold gemma request must still be
+// rejected. Fails without the cold-path pooled gate in freeMemoryAdmits.
+func TestPooledAdmissionColdModelDoubleSpendRealPath(t *testing.T) {
+	reg := New(testLogger())
+	p := makeSchedulerProvider(t, reg, "shared-box", gptossBuild, 93)
+	addAdvertisedModel(p, gemmaBuild) // advertised, NOT loaded: no gemma slot
+	p.mu.Lock()
+	p.BackendCapacity.Slots[0].ActiveTokenBudgetMax = 10_000
+	p.mu.Unlock()
+
+	// Burst the resident model: five requests × 2k tokens = the whole pool.
+	for i := 0; i < 5; i++ {
+		pr := &PendingRequest{
+			RequestID:             fmt.Sprintf("burst-%d", i),
+			Model:                 gptossBuild,
+			EstimatedPromptTokens: 100,
+			RequestedMaxTokens:    1_900,
+		}
+		if got := reg.ReserveProvider(gptossBuild, pr); got == nil {
+			t.Fatalf("burst request %d rejected; 5×2k must fit the 10k pool", i)
+		}
+	}
+	// Cold gemma within the same gap: no slot to check, but the pool is fully
+	// pending to gpt-oss — the post-load KV for this request does not exist.
+	if got := reg.ReserveProvider(gemmaBuild, &PendingRequest{
+		RequestID: "victim", Model: gemmaBuild, EstimatedPromptTokens: 100, RequestedMaxTokens: 1_900,
+	}); got != nil {
+		t.Fatalf("cold gemma admitted during the heartbeat gap — pool double-spend via the budget-less path (provider %q)", got.ID)
+	}
+
+	// Control: on a fresh box with only 4k pending, the cold request admits.
+	reg2 := New(testLogger())
+	p2 := makeSchedulerProvider(t, reg2, "shared-box-2", gptossBuild, 93)
+	addAdvertisedModel(p2, gemmaBuild)
+	p2.mu.Lock()
+	p2.BackendCapacity.Slots[0].ActiveTokenBudgetMax = 10_000
+	p2.mu.Unlock()
+	for i := 0; i < 2; i++ {
+		if got := reg2.ReserveProvider(gptossBuild, &PendingRequest{
+			RequestID: fmt.Sprintf("light-%d", i), Model: gptossBuild, EstimatedPromptTokens: 100, RequestedMaxTokens: 1_900,
+		}); got == nil {
+			t.Fatalf("light burst request %d rejected", i)
+		}
+	}
+	if got := reg2.ReserveProvider(gemmaBuild, &PendingRequest{
+		RequestID: "fits", Model: gemmaBuild, EstimatedPromptTokens: 100, RequestedMaxTokens: 1_900,
+	}); got == nil {
+		t.Fatal("cold gemma rejected although the pool has 6k of headroom (cold pooled gate over-rejecting)")
+	}
+}
+
 // TestFreeMemoryAdmitsLegacyProviderUnchanged: providers that report no token
 // budget (ActiveTokenBudgetMax == 0) never reach the budget branch — the
 // legacy memory-estimation path is untouched by the pooled fields.

--- a/coordinator/registry/pooled_admission_test.go
+++ b/coordinator/registry/pooled_admission_test.go
@@ -205,6 +205,147 @@ func TestFreeMemoryAdmitsPooledRejectsGapDoubleSpend(t *testing.T) {
 	}
 }
 
+// TestProviderPooledTokenBudgetByteNormalization pins the byte-space
+// reconstruction: per-slot token quantities scale by that slot's own
+// KVBytesPerToken, the shared free headroom is the largest per-slot free BYTE
+// view counted once, and a single budget slot without a KV rate disables byte
+// mode for the whole pool (legacy provider build).
+func TestProviderPooledTokenBudgetByteNormalization(t *testing.T) {
+	// Big-KV model A: 10k tokens × 100kB/token headroom = 1 GB.
+	// Small-KV model B: 100k tokens × 10kB/token = the SAME 1 GB pool.
+	slots := []protocol.BackendSlotCapacity{
+		{Model: "a", ActiveTokenBudgetMax: 10_000, KVBytesPerToken: 100_000},
+		{Model: "b", ActiveTokenBudgetMax: 100_000, KVBytesPerToken: 10_000},
+	}
+	pool := providerPooledTokenBudget(slots)
+	if !pool.byteMode {
+		t.Fatal("byteMode = false with every budget slot reporting a KV rate")
+	}
+	if pool.totalBytes != 1_000_000_000 || pool.usedBytes != 0 || pool.committedBytes != 0 {
+		t.Fatalf("byte pool = {used:%d committed:%d total:%d}, want {0 0 1e9} (shared free bytes counted once)",
+			pool.usedBytes, pool.committedBytes, pool.totalBytes)
+	}
+	// Token space is denominated by the LARGEST free-token view (B's 100k) —
+	// the very distortion byte mode exists to correct.
+	if pool.total != 100_000 {
+		t.Fatalf("token pool total = %d, want 100_000", pool.total)
+	}
+
+	// One budget slot without a rate → byte reconstruction impossible.
+	mixed := providerPooledTokenBudget([]protocol.BackendSlotCapacity{
+		{Model: "a", ActiveTokenBudgetMax: 10_000, KVBytesPerToken: 100_000},
+		{Model: "legacy", ActiveTokenBudgetMax: 9_000},
+	})
+	if mixed.byteMode {
+		t.Fatal("byteMode = true although a budget slot reports no KVBytesPerToken")
+	}
+}
+
+// TestFreeMemoryAdmitsByteNormalizedHeterogeneousKV is the X-unit regression:
+// co-resident slots with different KVBytesPerToken share ONE byte pool, so
+// token counts are not a common unit. A 90k-token pending burst on the
+// small-KV model (10 kB/token = 0.9 GB) leaves only 0.1 GB of the 1 GB pool,
+// so a 3k-token request to the big-KV model (100 kB/token = 0.3 GB) must be
+// rejected — token accounting (93k ≤ 100k) would admit it and the box OOMs.
+// Fails without the byte-normalized branch in pooledBudgetAdmits.
+func TestFreeMemoryAdmitsByteNormalizedHeterogeneousKV(t *testing.T) {
+	slots := []protocol.BackendSlotCapacity{
+		{Model: "big-kv", ActiveTokenBudgetMax: 10_000, KVBytesPerToken: 100_000},
+		{Model: "small-kv", ActiveTokenBudgetMax: 100_000, KVBytesPerToken: 10_000},
+	}
+	mkSnap := func(pendingSmallKVTokens int64) routingSnapshot {
+		return routingSnapshot{
+			// Snapshot for the big-KV model: no same-model pending, stale
+			// heartbeat (used 0), all pending is the small-KV burst.
+			activeTokenBudgetMax:      10_000,
+			kvBytesPerToken:           100_000,
+			pendingMaxTokensAllModels: int(pendingSmallKVTokens),
+			pendingMaxBytesAllModels:  pendingSmallKVTokens * 10_000,
+			pendingBytesKnown:         true,
+			pooledTokenBudget:         providerPooledTokenBudget(slots),
+		}
+	}
+	// 90k small-KV tokens pending = 0.9 GB; +0.3 GB request = 1.2 GB > 1 GB.
+	if freeMemoryAdmits(mkSnap(90_000), 100, 2_900) {
+		t.Fatal("admitted 0.3 GB of big-KV request into a byte pool with 0.9 GB already pending (token/byte unit confusion)")
+	}
+	// Control: 40k small-KV tokens pending = 0.4 GB; +0.3 GB = 0.7 GB ≤ 1 GB.
+	if !freeMemoryAdmits(mkSnap(40_000), 100, 2_900) {
+		t.Fatal("rejected a request although the byte pool has 0.6 GB of headroom (byte gate over-rejecting)")
+	}
+}
+
+// TestFreeMemoryAdmitsByteModeCorrectsTokenOverReject is the reverse sanity
+// case: when heartbeat skew leaves the token pool denominated by a SMALLER
+// free view than the true byte pool, token accounting over-rejects small-KV
+// work that genuinely fits in bytes. With the fix the byte check admits;
+// without it the token check (61k > 50k) wrongly rejects.
+func TestFreeMemoryAdmitsByteModeCorrectsTokenOverReject(t *testing.T) {
+	slots := []protocol.BackendSlotCapacity{
+		// Big-KV slot sees 1 GB free (10k × 100 kB); small-KV slot's staler
+		// view reports only 0.5 GB (50k × 10 kB). Token total = max(10k, 50k)
+		// = 50k tokens; byte total = max(1 GB, 0.5 GB) = 1 GB.
+		{Model: "big-kv", ActiveTokenBudgetMax: 10_000, KVBytesPerToken: 100_000},
+		{Model: "small-kv", ActiveTokenBudgetMax: 50_000, KVBytesPerToken: 10_000},
+	}
+	snap := routingSnapshot{
+		// Snapshot for the small-KV model with a 60k-token (0.6 GB) small-KV
+		// burst pending elsewhere on the box and a 1k-token (10 MB) request.
+		activeTokenBudgetMax:      50_000,
+		kvBytesPerToken:           10_000,
+		pendingMaxTokensAllModels: 60_000,
+		pendingMaxBytesAllModels:  600_000_000,
+		pendingBytesKnown:         true,
+		pooledTokenBudget:         providerPooledTokenBudget(slots),
+	}
+	if !pooledBudgetAdmits(snap, 1_000) {
+		t.Fatal("rejected 10 MB into a 1 GB byte pool holding 0.6 GB (token-unit over-rejection not corrected)")
+	}
+}
+
+// TestPooledAdmissionByteDoubleSpendRealPath drives the heterogeneous-KV
+// double-spend through the REAL reservation path: a small-KV burst that fits
+// the pool token-wise exhausts it byte-wise, so a big-KV co-resident request
+// inside the same heartbeat gap must be rejected. Fails without byte
+// normalization (token accounting reads 93k ≤ 100k and admits).
+func TestPooledAdmissionByteDoubleSpendRealPath(t *testing.T) {
+	reg := New(testLogger())
+	p := makeSchedulerProvider(t, reg, "shared-box", gptossBuild, 93)
+	addAdvertisedModel(p, gemmaBuild)
+	p.mu.Lock()
+	// gpt-oss: 10 kB/token → 100k-token view of the 1 GB shared pool.
+	p.BackendCapacity.Slots[0].ActiveTokenBudgetMax = 100_000
+	p.BackendCapacity.Slots[0].KVBytesPerToken = 10_000
+	// gemma: 100 kB/token → 10k-token view of the SAME 1 GB pool.
+	p.BackendCapacity.Slots = append(p.BackendCapacity.Slots, protocol.BackendSlotCapacity{
+		Model:                gemmaBuild,
+		State:                "running",
+		ActiveTokenBudgetMax: 10_000,
+		KVBytesPerToken:      100_000,
+	})
+	p.mu.Unlock()
+
+	// Burst gpt-oss: nine requests × 10k tokens = 90k tokens = 0.9 GB pending.
+	for i := 0; i < 9; i++ {
+		pr := &PendingRequest{
+			RequestID:             fmt.Sprintf("burst-%d", i),
+			Model:                 gptossBuild,
+			EstimatedPromptTokens: 500,
+			RequestedMaxTokens:    9_500,
+		}
+		if got := reg.ReserveProvider(gptossBuild, pr); got == nil {
+			t.Fatalf("burst request %d rejected; 9×10k tokens (0.9 GB) must fit the 1 GB pool", i)
+		}
+	}
+	// Gemma within the same gap: 3k tokens ≤ its 10k slot view and 93k ≤ 100k
+	// in token space — but 0.3 GB does NOT fit the 0.1 GB of byte headroom.
+	if got := reg.ReserveProvider(gemmaBuild, &PendingRequest{
+		RequestID: "victim", Model: gemmaBuild, EstimatedPromptTokens: 100, RequestedMaxTokens: 2_900,
+	}); got != nil {
+		t.Fatalf("gemma admitted during the heartbeat gap — token-unit accounting double-spent the byte pool (provider %q)", got.ID)
+	}
+}
+
 // TestFreeMemoryAdmitsLegacyProviderUnchanged: providers that report no token
 // budget (ActiveTokenBudgetMax == 0) never reach the budget branch — the
 // legacy memory-estimation path is untouched by the pooled fields.

--- a/coordinator/registry/pooled_admission_test.go
+++ b/coordinator/registry/pooled_admission_test.go
@@ -491,6 +491,113 @@ func TestModelCapacitySnapshotPooledBudgetClamp(t *testing.T) {
 	}
 }
 
+// TestPooledByteTotalFromLiveUsedNotCommitted is the double-count regression
+// (Finding 3): the byte pool total must be built from LIVE used bytes plus the
+// shared free headroom — mirroring the token path (providerTokenBudget uses
+// used+sharedFree) — NOT from committedBytes, which carries MaxTokensPotential
+// as the pending de-dup baseline. A co-resident slot whose potential (0.4 GB)
+// far exceeds its used (0) would otherwise inflate the 1 GB physical pool to
+// 1.4 GB, letting an in-gap burst overcommit the box's real KV. Fails without
+// the pool.usedBytes+sharedFreeBytes total in providerPooledTokenBudget.
+func TestPooledByteTotalFromLiveUsedNotCommitted(t *testing.T) {
+	slots := []protocol.BackendSlotCapacity{
+		// Big-KV slot with an active request whose POTENTIAL growth (4k tokens =
+		// 0.4 GB) dwarfs its live used (0). Shared free = 10k × 100 kB = 1 GB.
+		{Model: "big-kv", ActiveTokenBudgetMax: 10_000, KVBytesPerToken: 100_000, MaxTokensPotential: 4_000},
+		// Small-KV co-resident sees the SAME 1 GB pool (100k × 10 kB).
+		{Model: "small-kv", ActiveTokenBudgetMax: 100_000, KVBytesPerToken: 10_000},
+	}
+	pool := providerPooledTokenBudget(slots)
+	if !pool.byteMode {
+		t.Fatal("byteMode = false with every budget slot reporting a KV rate")
+	}
+	if pool.usedBytes != 0 {
+		t.Fatalf("usedBytes = %d, want 0 (no live used/queued on either slot)", pool.usedBytes)
+	}
+	if pool.committedBytes != 400_000_000 {
+		t.Fatalf("committedBytes = %d, want 4e8 (0.4 GB de-dup baseline from MaxTokensPotential)", pool.committedBytes)
+	}
+	if pool.totalBytes != 1_000_000_000 {
+		t.Fatalf("totalBytes = %d, want 1e9 (live used + shared free); committed potential must NOT inflate the pool total", pool.totalBytes)
+	}
+
+	// The admission gate must charge against the 1 GB physical pool, not the
+	// inflated 1.4 GB. A 12k-token big-KV request is 1.2 GB — slot A's 0.4 GB of
+	// potential is a de-dup baseline, not spare capacity, so it must be rejected.
+	snap := routingSnapshot{
+		activeTokenBudgetMax:      10_000,
+		kvBytesPerToken:           100_000,
+		pendingMaxBytesAllModels:  0,
+		pendingMaxTokensAllModels: 0,
+		pendingBytesKnown:         true,
+		pooledTokenBudget:         pool,
+	}
+	if pooledBudgetAdmits(snap, 12_000) {
+		t.Fatal("admitted 1.2 GB into a 1 GB byte pool — MaxTokensPotential double-counted as physical KV capacity")
+	}
+	// Control: 8k tokens = 0.8 GB genuinely fits the 1 GB pool.
+	if !pooledBudgetAdmits(snap, 8_000) {
+		t.Fatal("rejected 0.8 GB that fits the 1 GB byte pool (byte total under-counted)")
+	}
+}
+
+// TestModelCapacitySnapshotByteModePooledClamp is the byte-unit capacity-feed
+// regression (Finding 1): on a mixed-KV provider the public snapshot must
+// clamp advertised budget in BYTES, matching pooledBudgetAdmits, not in tokens.
+// A 0.9 GB small-KV burst leaves only 0.1 GB of the 1 GB pool — ~1k tokens for
+// the 100 kB/token big-KV model — but token accounting reads 90k << the 100k
+// token pool and would advertise ~10k gemma tokens the admission gate refuses.
+// Fails without routing the snapshot through the byte-aware pooledRemainingTokens.
+func TestModelCapacitySnapshotByteModePooledClamp(t *testing.T) {
+	reg := New(testLogger())
+	p := makeSchedulerProvider(t, reg, "shared-box", gptossBuild, 93)
+	addAdvertisedModel(p, gemmaBuild)
+	p.mu.Lock()
+	// gpt-oss small-KV: 10 kB/token → 100k-token view of the 1 GB pool.
+	p.BackendCapacity.Slots[0].ActiveTokenBudgetMax = 100_000
+	p.BackendCapacity.Slots[0].KVBytesPerToken = 10_000
+	// gemma big-KV: 100 kB/token → 10k-token view of the SAME 1 GB pool.
+	p.BackendCapacity.Slots = append(p.BackendCapacity.Slots, protocol.BackendSlotCapacity{
+		Model:                gemmaBuild,
+		State:                "running",
+		ActiveTokenBudgetMax: 10_000,
+		KVBytesPerToken:      100_000,
+	})
+	p.mu.Unlock()
+
+	// Burst gpt-oss: nine × 10k tokens = 90k tokens = 0.9 GB pending, all inside
+	// one heartbeat gap (slot used stays 0).
+	for i := 0; i < 9; i++ {
+		if got := reg.ReserveProvider(gptossBuild, &PendingRequest{
+			RequestID: fmt.Sprintf("burst-%d", i), Model: gptossBuild, EstimatedPromptTokens: 500, RequestedMaxTokens: 9_500,
+		}); got == nil {
+			t.Fatalf("burst request %d rejected; 0.9 GB must fit the 1 GB pool", i)
+		}
+	}
+
+	caps := make(map[string]ModelCapacity)
+	for _, c := range reg.ModelCapacitySnapshot() {
+		caps[c.ModelID] = c
+	}
+	gemma, ok := caps[gemmaBuild]
+	if !ok {
+		t.Fatalf("missing capacity row for %s", gemmaBuild)
+	}
+	// Byte-accurate: 0.1 GB remaining ÷ 100 kB/token = 1_000 gemma tokens.
+	// Token-mode (the bug) reports 100k pool − 90k pending = 10_000.
+	if gemma.TokenBudgetRemaining != 1_000 {
+		t.Fatalf("gemma token_budget_remaining = %d, want 1_000 (0.1 GB byte headroom); token-mode over-advertised the pool", gemma.TokenBudgetRemaining)
+	}
+
+	// Snapshot verdict must match the admission gate: a 3k-token (0.3 GB) gemma
+	// request does NOT fit the 0.1 GB byte headroom, so ReserveProvider rejects.
+	if got := reg.ReserveProvider(gemmaBuild, &PendingRequest{
+		RequestID: "probe", Model: gemmaBuild, EstimatedPromptTokens: 100, RequestedMaxTokens: 2_900,
+	}); got != nil {
+		t.Fatalf("gemma admitted 0.3 GB into 0.1 GB byte headroom (snapshot/gate disagree; provider %q)", got.ID)
+	}
+}
+
 // TestFreeMemoryAdmitsLegacyProviderUnchanged: providers that report no token
 // budget (ActiveTokenBudgetMax == 0) never reach the budget branch — the
 // legacy memory-estimation path is untouched by the pooled fields.

--- a/coordinator/registry/pooled_admission_test.go
+++ b/coordinator/registry/pooled_admission_test.go
@@ -642,6 +642,114 @@ func TestModelCapacitySnapshotByteModePooledClamp(t *testing.T) {
 	}
 }
 
+// TestPooledColdUnknownKVChargedInBytes is the cold unknown-KV regression: on a
+// byte-reconstructable mixed-KV box, a COLD request (its own model has no
+// resident slot, so snap.kvBytesPerToken == 0) must be priced CONSERVATIVELY in
+// bytes at the box's max resident rate, NOT collapse to token accounting that
+// under-charges a large-KV burst against the small-KV token view of the pool.
+// Fails without the maxKVBytesPerToken cold-rate substitution.
+func TestPooledColdUnknownKVChargedInBytes(t *testing.T) {
+	t.Run("mixed_kv_cold_priced_at_max_rate", func(t *testing.T) {
+		slots := []protocol.BackendSlotCapacity{
+			{Model: "big-kv", ActiveTokenBudgetMax: 10_000, KVBytesPerToken: 100_000},   // 1 GB view
+			{Model: "small-kv", ActiveTokenBudgetMax: 100_000, KVBytesPerToken: 10_000}, // same 1 GB
+		}
+		pool := providerPooledTokenBudget(slots)
+		if !pool.byteMode || pool.maxKVBytesPerToken != 100_000 {
+			t.Fatalf("pool byteMode=%v maxKVBytesPerToken=%d, want true / 100000", pool.byteMode, pool.maxKVBytesPerToken)
+		}
+		cold := routingSnapshot{
+			kvBytesPerToken:   0, // cold/absent slot
+			pendingBytesKnown: true,
+			pooledTokenBudget: pool,
+		}
+		// 50k tokens: token fallback would admit (50k ≤ 100k token pool); byte
+		// pricing at the 100 kB/token max rate = 5 GB ≫ 1 GB pool → reject.
+		if pooledBudgetAdmits(cold, 50_000) {
+			t.Fatal("cold large-KV request admitted via token fallback (5 GB into a 1 GB byte pool)")
+		}
+		// Control: 8k tokens = 0.8 GB fits the 1 GB byte pool.
+		if !pooledBudgetAdmits(cold, 8_000) {
+			t.Fatal("cold request rejected although 0.8 GB fits the 1 GB byte pool")
+		}
+		// Capacity feed mirrors the gate: 1 GB ÷ 100 kB/token = 10k tokens.
+		if rem := pooledRemainingTokens(pool, 0, 0, true, 0); rem != 10_000 {
+			t.Fatalf("cold pooledRemainingTokens = %d, want 10_000 (byte pool ÷ max rate)", rem)
+		}
+	})
+
+	// Single-KV byteMode box: a cold request priced at the sole resident rate is
+	// arithmetically identical to token accounting, so the boundary is unchanged.
+	t.Run("single_kv_cold_equals_token_boundary", func(t *testing.T) {
+		pool := providerPooledTokenBudget([]protocol.BackendSlotCapacity{
+			{Model: "m", ActiveTokenBudgetMax: 10_000, KVBytesPerToken: 50_000},
+		})
+		cold := routingSnapshot{kvBytesPerToken: 0, pendingBytesKnown: true, pooledTokenBudget: pool}
+		if !pooledBudgetAdmits(cold, 10_000) {
+			t.Fatal("cold request at the exact 10k boundary rejected (single-KV byte pricing changed the boundary)")
+		}
+		if pooledBudgetAdmits(cold, 10_001) {
+			t.Fatal("cold request past the 10k boundary admitted (single-KV budget loosened)")
+		}
+	})
+}
+
+// TestPooledRemainingTokensMatchesAdmits pins the equivalence the capacity feed
+// relies on: pooledBudgetAdmits(snap, n) admits IFF n <= pooledRemainingTokens(
+// pool, …, snap.kvBytesPerToken), across the byte path (known rate), the byte
+// COLD path (rate 0 → max resident rate substitution), token mode, and the
+// pending-unknown fall-through. Both must apply the SAME cold-rate substitution.
+func TestPooledRemainingTokensMatchesAdmits(t *testing.T) {
+	bytePool := providerPooledTokenBudget([]protocol.BackendSlotCapacity{
+		{Model: "big-kv", ActiveTokenBudgetMax: 10_000, KVBytesPerToken: 100_000},
+		{Model: "small-kv", ActiveTokenBudgetMax: 100_000, KVBytesPerToken: 10_000},
+	})
+	tokenPool := providerPooledTokenBudget([]protocol.BackendSlotCapacity{
+		{Model: "a", ActiveTokenBudgetMax: 10_000},
+		{Model: "b", ActiveTokenBudgetMax: 10_000},
+	})
+	cases := []struct {
+		name string
+		snap routingSnapshot
+	}{
+		{"byte_known_rate", routingSnapshot{
+			kvBytesPerToken: 100_000, pendingBytesKnown: true,
+			pendingMaxTokensAllModels: 20_000, pendingMaxBytesAllModels: 20_000 * 10_000,
+			pooledTokenBudget: bytePool,
+		}},
+		{"byte_cold_rate", routingSnapshot{
+			kvBytesPerToken: 0, pendingBytesKnown: true,
+			pendingMaxTokensAllModels: 10_000, pendingMaxBytesAllModels: 10_000 * 10_000,
+			pooledTokenBudget: bytePool,
+		}},
+		{"token_mode", routingSnapshot{
+			pendingMaxTokensAllModels: 4_000,
+			pooledTokenBudget:         tokenPool,
+		}},
+		{"byte_pending_unknown_falls_to_token", routingSnapshot{
+			kvBytesPerToken: 100_000, pendingBytesKnown: false,
+			pendingMaxTokensAllModels: 5_000,
+			pooledTokenBudget:         bytePool,
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rem := pooledRemainingTokens(
+				tc.snap.pooledTokenBudget,
+				tc.snap.pendingMaxTokensAllModels,
+				tc.snap.pendingMaxBytesAllModels,
+				tc.snap.pendingBytesKnown,
+				tc.snap.kvBytesPerToken,
+			)
+			for n := int64(1); n <= rem+50; n++ {
+				if admits, want := pooledBudgetAdmits(tc.snap, n), n <= rem; admits != want {
+					t.Fatalf("n=%d: pooledBudgetAdmits=%v, but (n<=rem=%d)=%v", n, admits, rem, want)
+				}
+			}
+		})
+	}
+}
+
 // TestFreeMemoryAdmitsLegacyProviderUnchanged: providers that report no token
 // budget (ActiveTokenBudgetMax == 0) never reach the budget branch — the
 // legacy memory-estimation path is untouched by the pooled fields.

--- a/coordinator/registry/pooled_admission_test.go
+++ b/coordinator/registry/pooled_admission_test.go
@@ -2,10 +2,54 @@ package registry
 
 import (
 	"fmt"
+	"math"
 	"testing"
 
 	"github.com/eigeninference/d-inference/coordinator/protocol"
 )
+
+// TestProviderPooledTokenBudgetClampsKVByteRate is the overflow regression: a
+// slot reporting an absurd (unbounded) KVBytesPerToken multiplied by a normal
+// token count wraps int64 to a NEGATIVE usedBytes/totalBytes, which breaks the
+// byte-pool admission (a negative total either rejects everything or, with a
+// negative left side, admits everything). The clamp caps the rate at
+// maxKVBytesPerToken so all products and sums stay positive and admission fails
+// closed. Fails without clampKVBytesPerToken in providerPooledTokenBudget.
+func TestProviderPooledTokenBudgetClampsKVByteRate(t *testing.T) {
+	const normalMax = 400_000
+	slots := []protocol.BackendSlotCapacity{
+		{Model: "a", ActiveTokenBudgetMax: normalMax, ActiveTokenBudgetUsed: 200_000, KVBytesPerToken: math.MaxInt64 / 2},
+	}
+	pool := providerPooledTokenBudget(slots)
+	if !pool.byteMode {
+		t.Fatal("byteMode = false with a (clamped) positive KV rate")
+	}
+	if pool.usedBytes < 0 || pool.committedBytes < 0 || pool.totalBytes < 0 {
+		t.Fatalf("byte pool overflowed to negative: used=%d committed=%d total=%d (KV rate not clamped)",
+			pool.usedBytes, pool.committedBytes, pool.totalBytes)
+	}
+	if pool.totalBytes < pool.usedBytes {
+		t.Fatalf("totalBytes %d < usedBytes %d (overflow)", pool.totalBytes, pool.usedBytes)
+	}
+	if got := pool.kvBytesPerToken["a"]; got != maxKVBytesPerToken {
+		t.Fatalf("stored KV rate = %d, want clamp %d (raw absurd rate not clamped)", got, maxKVBytesPerToken)
+	}
+	// Admission must fail-closed for a request that overflows the pool, not
+	// admit-everything off a wrapped negative total. Free headroom is
+	// (400k − 200k) = 200k tokens at the clamped rate.
+	snap := routingSnapshot{
+		activeTokenBudgetMax: normalMax,
+		kvBytesPerToken:      maxKVBytesPerToken,
+		pendingBytesKnown:    true,
+		pooledTokenBudget:    pool,
+	}
+	if pooledBudgetAdmits(snap, 10_000_000_000) {
+		t.Fatal("admitted a 10B-token request into a finite byte pool (overflow admitted-everything)")
+	}
+	if !pooledBudgetAdmits(snap, 100_000) {
+		t.Fatal("rejected a 100k-token request that fits the 200k-token byte headroom")
+	}
+}
 
 func TestProviderPooledTokenBudget(t *testing.T) {
 	cases := []struct {

--- a/coordinator/registry/pooled_admission_test.go
+++ b/coordinator/registry/pooled_admission_test.go
@@ -428,6 +428,69 @@ func TestPooledAdmissionColdModelDoubleSpendRealPath(t *testing.T) {
 	}
 }
 
+// TestModelCapacitySnapshotPooledBudgetClamp: the public capacity feed
+// (/v1/models[/capacity]) must not advertise per-slot budget headroom the
+// pooled admission gate would reject. Co-resident slots each re-report the
+// ONE shared 10k pool; after an in-gap 10k burst to gpt-oss, gemma's slot
+// fields still read used=0/max=10k — but a gemma request would be rejected
+// (pooledBudgetAdmits), so its row must report zero remaining budget and not
+// be Ready. Fails without the pooledBudgetRemaining clamp in
+// ModelCapacitySnapshot.
+func TestModelCapacitySnapshotPooledBudgetClamp(t *testing.T) {
+	build := func(pendingTokens int) *Registry {
+		reg := New(testLogger())
+		p := makeSchedulerProvider(t, reg, "shared-box", gptossBuild, 93)
+		addAdvertisedModel(p, gemmaBuild)
+		p.mu.Lock()
+		p.BackendCapacity.Slots[0].ActiveTokenBudgetMax = 10_000
+		p.BackendCapacity.Slots = append(p.BackendCapacity.Slots, protocol.BackendSlotCapacity{
+			Model:                gemmaBuild,
+			State:                "running",
+			ActiveTokenBudgetMax: 10_000,
+		})
+		p.mu.Unlock()
+		for i := 0; i < pendingTokens/2_000; i++ {
+			if got := reg.ReserveProvider(gptossBuild, &PendingRequest{
+				RequestID: fmt.Sprintf("burst-%d", i), Model: gptossBuild, EstimatedPromptTokens: 100, RequestedMaxTokens: 1_900,
+			}); got == nil {
+				t.Fatalf("burst request %d rejected", i)
+			}
+		}
+		return reg
+	}
+	capsByModel := func(reg *Registry) map[string]ModelCapacity {
+		out := make(map[string]ModelCapacity)
+		for _, c := range reg.ModelCapacitySnapshot() {
+			out[c.ModelID] = c
+		}
+		return out
+	}
+
+	// Pool fully pending to gpt-oss: gemma's stale slot (used 0 / max 10k)
+	// must not surface as remaining budget or readiness.
+	full := capsByModel(build(10_000))
+	gemma, ok := full[gemmaBuild]
+	if !ok {
+		t.Fatalf("missing capacity row for %s", gemmaBuild)
+	}
+	if gemma.TokenBudgetRemaining != 0 {
+		t.Fatalf("gemma token_budget_remaining = %d, want 0 (pool fully pending to co-resident gpt-oss)", gemma.TokenBudgetRemaining)
+	}
+	if gemma.Ready || gemma.CanAccept || gemma.RoutableProviders != 0 {
+		t.Fatalf("gemma row = %+v, want not ready/routable with the shared pool exhausted", gemma)
+	}
+
+	// Control: 4k of the 10k pool pending → 6k remaining, still routable.
+	part := capsByModel(build(4_000))
+	gemma = part[gemmaBuild]
+	if gemma.TokenBudgetRemaining != 6_000 {
+		t.Fatalf("gemma token_budget_remaining = %d, want 6_000 (10k pool − 4k pending)", gemma.TokenBudgetRemaining)
+	}
+	if !gemma.Ready || gemma.RoutableProviders != 1 {
+		t.Fatalf("gemma row = %+v, want ready/routable with 6k pooled headroom", gemma)
+	}
+}
+
 // TestFreeMemoryAdmitsLegacyProviderUnchanged: providers that report no token
 // budget (ActiveTokenBudgetMax == 0) never reach the budget branch — the
 // legacy memory-estimation path is untouched by the pooled fields.

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -4499,6 +4499,9 @@ type providerCapSnap struct {
 	activeTokenBudgetMax  int64
 	activeTokenBudgetUsed int64
 	queuedTokenBudget     int64
+	// tokenBudgetKnownZero distinguishes an Engine V2 model whose positive KV
+	// rate makes max==0 authoritative from a legacy model that omitted both.
+	tokenBudgetKnownZero bool
 	// pooledBudgetRemaining is the provider's whole-box pooled token budget
 	// left after charging ALL models' coordinator-pending tokens — the same
 	// pool the admission gate (pooledBudgetAdmits) enforces, so this public
@@ -4629,6 +4632,7 @@ func (r *Registry) ModelCapacitySnapshot() []ModelCapacity {
 					snap.activeTokenBudgetMax = slot.ActiveTokenBudgetMax
 					snap.activeTokenBudgetUsed = slot.ActiveTokenBudgetUsed
 					snap.queuedTokenBudget = slot.QueuedTokenBudget
+					snap.tokenBudgetKnownZero = knownZeroTokenBudget(slot.ActiveTokenBudgetMax, slot.KVBytesPerToken)
 					snap.backlogTokens = float64(slot.MaxTokensPotential)
 					break
 				}
@@ -4695,7 +4699,7 @@ func (r *Registry) ModelCapacitySnapshot() []ModelCapacity {
 		// the -1 no-budget sentinel) counts as exhausted for every model on the
 		// box, cold ones included: the admission gate charges those against the
 		// shared pool too (freeMemoryAdmits' cold-slot pooled gate).
-		hasBudgetHeadroom := (s.activeTokenBudgetMax <= 0 ||
+		hasBudgetHeadroom := !s.tokenBudgetKnownZero && (s.activeTokenBudgetMax <= 0 ||
 			s.activeTokenBudgetUsed+s.queuedTokenBudget < s.activeTokenBudgetMax) &&
 			s.pooledBudgetRemaining != 0
 		if s.hasHeadroom && hasBudgetHeadroom {

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -4421,6 +4421,15 @@ type providerCapSnap struct {
 	activeTokenBudgetMax  int64
 	activeTokenBudgetUsed int64
 	queuedTokenBudget     int64
+	// pooledBudgetRemaining is the provider's whole-box pooled token budget
+	// left after charging ALL models' coordinator-pending tokens — the same
+	// pool the admission gate (pooledBudgetAdmits) enforces, so this public
+	// capacity feed cannot advertise per-slot headroom dispatch would reject:
+	// co-resident slots each re-report the ONE shared KV headroom, and an
+	// in-gap burst to model A is invisible to model B's slot fields until the
+	// next heartbeat. -1 = provider reports no pooled budget (legacy), which
+	// leaves the per-slot numbers unclamped.
+	pooledBudgetRemaining int64
 }
 
 // publiclyRoutableLocked reports whether a provider passes the public routing
@@ -4459,6 +4468,29 @@ func (r *Registry) ModelCapacitySnapshot() []ModelCapacity {
 		decodeTPS := resolvedDecodeTPS(p)
 		prefillTPS := resolvedPrefillTPS(p)
 
+		// Reconstruct the whole-box pooled budget remaining after charging
+		// every model's coordinator-pending tokens (mirrors pooledBudgetAdmits'
+		// token accounting: pending beyond the heartbeat-visible committed
+		// baseline spends the pool). Token units — this surface reports token
+		// budgets; byte normalization stays an admission-gate concern.
+		pooledRemaining := int64(-1)
+		if p.BackendCapacity != nil {
+			if pool := providerPooledTokenBudget(p.BackendCapacity.Slots); pool.total > 0 {
+				pendingAll := 0
+				for _, pr := range p.pendingReqs {
+					pendingAll += pendingTokenBudget(pr)
+				}
+				extra := int64(pendingAll) - pool.committed
+				if extra < 0 {
+					extra = 0
+				}
+				pooledRemaining = pool.total - pool.used - extra
+				if pooledRemaining < 0 {
+					pooledRemaining = 0
+				}
+			}
+		}
+
 		// Enumerate every model this provider serves.
 		for _, m := range p.Models {
 			if !r.modelAllowedByCatalogLocked(m) {
@@ -4480,11 +4512,12 @@ func (r *Registry) ModelCapacitySnapshot() []ModelCapacity {
 			}
 
 			snap := providerCapSnap{
-				model:          m.ID,
-				hasHeadroom:    hasHeadroom,
-				effectiveTPS:   decodeTPS,
-				prefillTPS:     prefillTPS,
-				activeRequests: modelPending,
+				model:                 m.ID,
+				hasHeadroom:           hasHeadroom,
+				effectiveTPS:          decodeTPS,
+				prefillTPS:            prefillTPS,
+				activeRequests:        modelPending,
+				pooledBudgetRemaining: pooledRemaining,
 			}
 
 			// Check backend capacity for this model's slot.
@@ -4561,14 +4594,25 @@ func (r *Registry) ModelCapacitySnapshot() []ModelCapacity {
 			if headroom < 0 {
 				headroom = 0
 			}
+			// Per-slot headroom cannot exceed the provider's pooled remaining:
+			// each co-resident slot re-reports the ONE shared KV headroom, so
+			// in-gap pending to another model already spent it. Without the
+			// clamp this surface advertises capacity pooledBudgetAdmits rejects.
+			if s.pooledBudgetRemaining >= 0 && headroom > s.pooledBudgetRemaining {
+				headroom = s.pooledBudgetRemaining
+			}
 			a.budgetRemaining += headroom
 			a.budgetTotal += s.activeTokenBudgetMax
 		}
 		// Routable providers require both concurrency headroom AND token-budget
 		// headroom. A provider with exhausted token budget should not make the
-		// model appear immediately ready.
-		hasBudgetHeadroom := s.activeTokenBudgetMax <= 0 ||
-			s.activeTokenBudgetUsed+s.queuedTokenBudget < s.activeTokenBudgetMax
+		// model appear immediately ready. An exhausted POOLED budget (0 — not
+		// the -1 no-budget sentinel) counts as exhausted for every model on the
+		// box, cold ones included: the admission gate charges those against the
+		// shared pool too (freeMemoryAdmits' cold-slot pooled gate).
+		hasBudgetHeadroom := (s.activeTokenBudgetMax <= 0 ||
+			s.activeTokenBudgetUsed+s.queuedTokenBudget < s.activeTokenBudgetMax) &&
+			s.pooledBudgetRemaining != 0
 		if s.hasHeadroom && hasBudgetHeadroom {
 			a.routable++
 			a.anyImmediateSlot = true

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -4582,10 +4582,12 @@ func (r *Registry) ModelCapacitySnapshot() []ModelCapacity {
 			}
 
 			// Per-model pooled remaining: byte-aware when the box is byte-
-			// reconstructable and this model's slot reports a KV rate, else token
-			// accounting — exactly pooledBudgetAdmits' branch. Cold/absent slots
-			// have no rate (map miss ⇒ 0), which lands on the token path just like
-			// the gate's cold-model path. Inert for single-KV/legacy boxes.
+			// reconstructable, else token accounting — exactly pooledBudgetAdmits'
+			// branch. Cold/absent slots have no rate (map miss ⇒ 0); on a byte-
+			// reconstructable pool they are priced at the box's max resident rate
+			// (the same cold-rate substitution the gate uses), so this feed stays
+			// equivalent to the gate on the cold path too. Inert for single-KV/
+			// legacy boxes.
 			pooledRemaining := pooledRemainingTokens(
 				poolSnap.pooledTokenBudget,
 				poolSnap.pendingMaxTokensAllModels,

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -2732,13 +2732,18 @@ func (r *Registry) Heartbeat(id string, msg *protocol.HeartbeatMessage) {
 		// Solo gate: a slot EWMA is additionally recorded as a SOLO sample only
 		// when the whole box is uncontended at heartbeat time (Σ running+waiting
 		// ≤ 1 across ALL slots — the one allowance is the sample-generating
-		// request itself) AND the slot is the one that OWNS that request
-		// (running+waiting > 0). Both halves matter: without the second, every
-		// co-resident slot with a nonzero (stale, decayed) EWMA would be
-		// re-recorded as a fresh solo observation on each ~30s heartbeat,
-		// contaminating OTHER models' medians with samples no request produced —
-		// a fully idle box records nothing, because there is no fresh
-		// observation to record. The unconditional Record keeps its
+		// request itself) AND the slot has an actual RUNNING decode
+		// (NumRunning > 0). Both halves matter. Requiring NumRunning (not
+		// running+waiting) excludes a purely-QUEUED box: the provider reports
+		// NumWaiting from its pending set while ObservedDecodeTPS is a retained
+		// EWMA (BatchScheduler+Telemetry.swift), so a box with one queued-but-
+		// not-yet-decoding request would otherwise mint that stale EWMA as a
+		// fresh solo sample every ~30s heartbeat and, once the min-sample floor
+		// is reached, base the model's quality cap on traffic no running request
+		// produced. It also keeps the prior round's owner-slot-only rule: an
+		// idle co-resident slot with a decayed EWMA is NumRunning == 0, so it is
+		// never re-sampled, and a fully idle box records nothing. The
+		// unconditional Record keeps its
 		// load-inclusive semantics for TTFT estimation (fleetMedianTPS); the
 		// gated RecordSolo feeds the quality-concurrency cap's per-model static
 		// rate (resolvedSoloModelTPSLocked). See solo_tps.go.
@@ -2746,7 +2751,7 @@ func (r *Registry) Heartbeat(id string, msg *protocol.HeartbeatMessage) {
 		for _, slot := range p.BackendCapacity.Slots {
 			if slot.ObservedDecodeTPS > 0 {
 				r.tpsRegistry.Record(slot.Model, chipFamily, slot.ObservedDecodeTPS)
-				if soloEligible && slot.NumRunning+slot.NumWaiting > 0 {
+				if soloEligible && slot.NumRunning > 0 {
 					r.tpsRegistry.RecordSolo(slot.Model, chipFamily, slot.ObservedDecodeTPS)
 				}
 			}
@@ -4537,27 +4542,19 @@ func (r *Registry) ModelCapacitySnapshot() []ModelCapacity {
 		decodeTPS := resolvedDecodeTPS(p)
 		prefillTPS := resolvedPrefillTPS(p)
 
-		// Reconstruct the whole-box pooled budget remaining after charging
-		// every model's coordinator-pending tokens (mirrors pooledBudgetAdmits'
-		// token accounting: pending beyond the heartbeat-visible committed
-		// baseline spends the pool). Token units — this surface reports token
-		// budgets; byte normalization stays an admission-gate concern.
-		pooledRemaining := int64(-1)
+		// Reconstruct the whole-box pooled budget and its all-models
+		// coordinator-pending charges (token and, when every pending request
+		// normalizes, byte) ONCE per provider — the SAME accumulation the
+		// admission gate uses (fillSnapshotPendingAndPool). The per-model
+		// remaining differs only by that model's KV rate in byte mode, so it is
+		// finalized inside the model loop via pooledRemainingTokens, keeping this
+		// feed's verdict identical to pooledBudgetAdmits' on a mixed-KV box (a
+		// pool exhausted in BYTES by a small-KV burst must not surface token
+		// headroom for a big-KV co-resident). Token units out; byte
+		// normalization stays internal.
+		var poolSnap routingSnapshot
 		if p.BackendCapacity != nil {
-			if pool := providerPooledTokenBudget(p.BackendCapacity.Slots); pool.total > 0 {
-				pendingAll := 0
-				for _, pr := range p.pendingReqs {
-					pendingAll += pendingTokenBudget(pr)
-				}
-				extra := int64(pendingAll) - pool.committed
-				if extra < 0 {
-					extra = 0
-				}
-				pooledRemaining = pool.total - pool.used - extra
-				if pooledRemaining < 0 {
-					pooledRemaining = 0
-				}
-			}
+			fillSnapshotPendingAndPool(&poolSnap, p, "")
 		}
 
 		// Enumerate every model this provider serves.
@@ -4579,6 +4576,19 @@ func (r *Registry) ModelCapacitySnapshot() []ModelCapacity {
 					modelPending++
 				}
 			}
+
+			// Per-model pooled remaining: byte-aware when the box is byte-
+			// reconstructable and this model's slot reports a KV rate, else token
+			// accounting — exactly pooledBudgetAdmits' branch. Cold/absent slots
+			// have no rate (map miss ⇒ 0), which lands on the token path just like
+			// the gate's cold-model path. Inert for single-KV/legacy boxes.
+			pooledRemaining := pooledRemainingTokens(
+				poolSnap.pooledTokenBudget,
+				poolSnap.pendingMaxTokensAllModels,
+				poolSnap.pendingMaxBytesAllModels,
+				poolSnap.pendingBytesKnown,
+				poolSnap.pooledTokenBudget.kvBytesPerToken[m.ID],
+			)
 
 			snap := providerCapSnap{
 				model:                 m.ID,

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -2729,6 +2729,10 @@ func (r *Registry) Heartbeat(id string, msg *protocol.HeartbeatMessage) {
 	p.BackendCapacity = msg.BackendCapacity
 	if p.BackendCapacity != nil {
 		chipFamily := p.Hardware.ChipFamily
+		// Solo samples are keyed by chip CLASS (family+tier, chipClassKey) so a
+		// fast tier (M4 Max) never lends its rate to a slow one (M4 Pro); the
+		// load-inclusive Record stays family-keyed (fleetMedianTPS semantics).
+		chipClass := chipClassKey(p.Hardware)
 		// Solo gate: a slot EWMA is additionally recorded as a SOLO sample only
 		// when the whole box is uncontended at heartbeat time (Σ running+waiting
 		// ≤ 1 across ALL slots — the one allowance is the sample-generating
@@ -2752,7 +2756,7 @@ func (r *Registry) Heartbeat(id string, msg *protocol.HeartbeatMessage) {
 			if slot.ObservedDecodeTPS > 0 {
 				r.tpsRegistry.Record(slot.Model, chipFamily, slot.ObservedDecodeTPS)
 				if soloEligible && slot.NumRunning > 0 {
-					r.tpsRegistry.RecordSolo(slot.Model, chipFamily, slot.ObservedDecodeTPS)
+					r.tpsRegistry.RecordSolo(slot.Model, chipClass, slot.ObservedDecodeTPS)
 				}
 			}
 		}

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -4584,10 +4584,10 @@ func (r *Registry) ModelCapacitySnapshot() []ModelCapacity {
 			// Per-model pooled remaining: byte-aware when the box is byte-
 			// reconstructable, else token accounting — exactly pooledBudgetAdmits'
 			// branch. Cold/absent slots have no rate (map miss ⇒ 0); on a byte-
-			// reconstructable pool they are priced at the box's max resident rate
-			// (the same cold-rate substitution the gate uses), so this feed stays
-			// equivalent to the gate on the cold path too. Inert for single-KV/
-			// legacy boxes.
+			// reconstructable pool they are priced at the greater of the
+			// conservative coordinator default and the box's max resident rate
+			// (the same cold-rate resolver the gate uses), so this feed stays
+			// equivalent to the gate on the cold path too. Inert for legacy boxes.
 			pooledRemaining := pooledRemainingTokens(
 				poolSnap.pooledTokenBudget,
 				poolSnap.pendingMaxTokensAllModels,

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -2669,9 +2669,20 @@ func (r *Registry) Heartbeat(id string, msg *protocol.HeartbeatMessage) {
 	p.BackendCapacity = msg.BackendCapacity
 	if p.BackendCapacity != nil {
 		chipFamily := p.Hardware.ChipFamily
+		// Solo gate: a slot EWMA is additionally recorded as a SOLO sample only
+		// when the whole box is uncontended at heartbeat time (Σ running+waiting
+		// ≤ 1 across ALL slots — the one allowance is the sample-generating
+		// request itself). The unconditional Record keeps its load-inclusive
+		// semantics for TTFT estimation (fleetMedianTPS); the gated RecordSolo
+		// feeds the quality-concurrency cap's per-model static rate
+		// (resolvedSoloModelTPSLocked). See solo_tps.go.
+		soloEligible := soloSampleEligible(p.BackendCapacity)
 		for _, slot := range p.BackendCapacity.Slots {
 			if slot.ObservedDecodeTPS > 0 {
 				r.tpsRegistry.Record(slot.Model, chipFamily, slot.ObservedDecodeTPS)
+				if soloEligible {
+					r.tpsRegistry.RecordSolo(slot.Model, chipFamily, slot.ObservedDecodeTPS)
+				}
 			}
 		}
 	}

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -2672,15 +2672,21 @@ func (r *Registry) Heartbeat(id string, msg *protocol.HeartbeatMessage) {
 		// Solo gate: a slot EWMA is additionally recorded as a SOLO sample only
 		// when the whole box is uncontended at heartbeat time (Σ running+waiting
 		// ≤ 1 across ALL slots — the one allowance is the sample-generating
-		// request itself). The unconditional Record keeps its load-inclusive
-		// semantics for TTFT estimation (fleetMedianTPS); the gated RecordSolo
-		// feeds the quality-concurrency cap's per-model static rate
-		// (resolvedSoloModelTPSLocked). See solo_tps.go.
+		// request itself) AND the slot is the one that OWNS that request
+		// (running+waiting > 0). Both halves matter: without the second, every
+		// co-resident slot with a nonzero (stale, decayed) EWMA would be
+		// re-recorded as a fresh solo observation on each ~30s heartbeat,
+		// contaminating OTHER models' medians with samples no request produced —
+		// a fully idle box records nothing, because there is no fresh
+		// observation to record. The unconditional Record keeps its
+		// load-inclusive semantics for TTFT estimation (fleetMedianTPS); the
+		// gated RecordSolo feeds the quality-concurrency cap's per-model static
+		// rate (resolvedSoloModelTPSLocked). See solo_tps.go.
 		soloEligible := soloSampleEligible(p.BackendCapacity)
 		for _, slot := range p.BackendCapacity.Slots {
 			if slot.ObservedDecodeTPS > 0 {
 				r.tpsRegistry.Record(slot.Model, chipFamily, slot.ObservedDecodeTPS)
-				if soloEligible {
+				if soloEligible && slot.NumRunning+slot.NumWaiting > 0 {
 					r.tpsRegistry.RecordSolo(slot.Model, chipFamily, slot.ObservedDecodeTPS)
 				}
 			}

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -1264,9 +1264,11 @@ func freeMemoryAdmits(snap routingSnapshot, reqPromptTokens, reqMaxTokens int) b
 	// load — so in-gap pending on a resident model must not be double-spendable
 	// by a cold request that skips the budget branch above. The reconstructed
 	// pool charges all-models coordinator pending plus this request; a cold
-	// model has no reported KV rate (snap.kvBytesPerToken == 0), so the check
-	// runs in token units. No-op for legacy providers with no budget slots at
-	// all (pool.total == 0).
+	// model has no reported KV rate (snap.kvBytesPerToken == 0), so on a
+	// byte-reconstructable pool it is priced conservatively in bytes at the
+	// box's max resident rate (pooledBudgetAdmits' cold-rate substitution),
+	// falling to token units only when the pool is not byte-reconstructable.
+	// No-op for legacy providers with no budget slots at all (pool.total == 0).
 	if !pooledBudgetAdmits(snap, requestTokens) {
 		return false
 	}

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -1235,6 +1235,14 @@ func freeMemoryAdmits(snap routingSnapshot, reqPromptTokens, reqMaxTokens int) b
 		return false
 	}
 	requestTokens := int64(reqPromptTokens) + int64(reqMaxTokens)
+	// Engine V2 keeps reporting a positive KV rate when its live fleet clamp
+	// drives this model's budget to zero. That is authoritative known-full
+	// capacity, not the legacy "budget unavailable" shape (both fields absent).
+	// Bind it before consulting co-resident pooled headroom: another model's
+	// positive budget cannot widen this model-local zero.
+	if knownZeroTokenBudget(snap.activeTokenBudgetMax, snap.kvBytesPerToken) {
+		return false
+	}
 	if snap.activeTokenBudgetMax > 0 {
 		// Include coordinator-side pending tokens not yet reflected in the
 		// provider's heartbeat. Avoid double-counting active/queued backend
@@ -1270,7 +1278,7 @@ func freeMemoryAdmits(snap routingSnapshot, reqPromptTokens, reqMaxTokens int) b
 	// byte-reconstructable pool it is priced conservatively in bytes at the
 	// bounded unknown-model default (resolvedPooledKVBytesPerToken),
 	// falling to token units only when the pool is not byte-reconstructable.
-	// No-op for legacy providers with no budget slots at all (pool.total == 0).
+	// No-op for legacy providers with neither budget nor KV-rate reports.
 	if !pooledBudgetAdmits(snap, requestTokens) {
 		return false
 	}

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -82,10 +82,12 @@ type routingSnapshot struct {
 	pendingMaxTokensAllModels int
 	// pendingMaxBytesAllModels is the byte-normalized analog: each pending
 	// request's token budget × its model's reported KVBytesPerToken. Valid
-	// only when pendingBytesKnown — every pending request's model had a
-	// reported KV rate (see fillSnapshotPendingAndPool). Co-resident models
-	// spend the ONE shared pool at different per-token byte rates, so tokens
-	// are not a common unit across models (pooled_admission.go).
+	// only when pendingBytesKnown. A cold request without a reported model rate
+	// is charged at the bounded conservative default (see
+	// fillSnapshotPendingAndPool), so it cannot disable byte accounting for a
+	// reconstructable pool. Co-resident models spend the ONE shared pool at
+	// different per-token byte rates, so tokens are not a common unit across
+	// models (pooled_admission.go).
 	pendingMaxBytesAllModels int64
 	pendingBytesKnown        bool
 	backendRunning           int
@@ -1266,7 +1268,7 @@ func freeMemoryAdmits(snap routingSnapshot, reqPromptTokens, reqMaxTokens int) b
 	// pool charges all-models coordinator pending plus this request; a cold
 	// model has no reported KV rate (snap.kvBytesPerToken == 0), so on a
 	// byte-reconstructable pool it is priced conservatively in bytes at the
-	// box's max resident rate (pooledBudgetAdmits' cold-rate substitution),
+	// bounded unknown-model default (resolvedPooledKVBytesPerToken),
 	// falling to token units only when the pool is not byte-reconstructable.
 	// No-op for legacy providers with no budget slots at all (pool.total == 0).
 	if !pooledBudgetAdmits(snap, requestTokens) {
@@ -1331,11 +1333,11 @@ func freeMemoryAdmits(snap routingSnapshot, reqPromptTokens, reqMaxTokens int) b
 // fillSnapshotPendingAndPool populates snap's reconstructed pooled budget and
 // its coordinator-pending aggregates — the per-model filtered pair
 // (pendingForModel / pendingMaxTokens) and the all-models totals in token and,
-// when normalizable, byte units. Byte normalization needs each pending
-// request's model to have a reported KVBytesPerToken (a budget slot in the
-// pool); any pending request that can't be normalized — e.g. for a cold model
-// with no resident slot — flips pendingBytesKnown off and pooledBudgetAdmits
-// falls back to token accounting for the whole check. Shared by the dispatch
+// when normalizable, byte units. Byte normalization uses each resident model's
+// reported KVBytesPerToken and the same bounded conservative default as
+// incoming/capacity math for a cold model with no resident slot. Only a legacy
+// pool that cannot be reconstructed in bytes leaves pendingBytesKnown false.
+// Shared by the dispatch
 // snapshot (snapshotProviderLockedEx) and the queue preflight
 // (QuickCapacityCheck…) so the two admission paths cannot drift. Caller holds
 // p.mu.
@@ -1348,11 +1350,8 @@ func fillSnapshotPendingAndPool(snap *routingSnapshot, p *Provider, model string
 		tokens := pendingTokenBudget(pr)
 		snap.pendingMaxTokensAllModels += tokens
 		if bytesKnown {
-			if rate := snap.pooledTokenBudget.kvBytesPerToken[pr.Model]; rate > 0 {
-				snap.pendingMaxBytesAllModels += int64(tokens) * rate
-			} else {
-				bytesKnown = false
-			}
+			rate := resolvedPooledKVBytesPerToken(snap.pooledTokenBudget, snap.pooledTokenBudget.kvBytesPerToken[pr.Model])
+			snap.pendingMaxBytesAllModels = addPooledKVByteCharge(snap.pendingMaxBytesAllModels, int64(tokens), rate)
 		}
 		if pr.Model != model {
 			continue

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -66,22 +66,28 @@ const (
 )
 
 type routingSnapshot struct {
-	provider           *Provider
-	model              string
-	chipFamily         string // hardware chip family (e.g. "M3"); keys the TTFT calibrator
-	slotState          string
-	hasHeadroom        bool
-	totalPending       int
-	pendingForModel    int
-	pendingMaxTokens   int
-	backendRunning     int
-	backendWaiting     int
-	maxTokensPotential int64
-	decodeTPS          float64
-	prefillTPS         float64
-	systemMetrics      protocol.SystemMetrics
-	gpuMemoryActiveGB  float64
-	totalMemoryGB      float64
+	provider         *Provider
+	model            string
+	chipFamily       string // hardware chip family (e.g. "M3"); keys the TTFT calibrator
+	slotState        string
+	hasHeadroom      bool
+	totalPending     int
+	pendingForModel  int
+	pendingMaxTokens int
+	// pendingMaxTokensAllModels is pendingMaxTokens WITHOUT the model filter:
+	// the token budgets of every coordinator-pending request on this provider,
+	// any model. Feeds the pooled-budget admission check (pooledBudgetAdmits)
+	// so co-resident models cannot double-spend the one shared KV pool inside
+	// the heartbeat gap.
+	pendingMaxTokensAllModels int
+	backendRunning            int
+	backendWaiting            int
+	maxTokensPotential        int64
+	decodeTPS                 float64
+	prefillTPS                float64
+	systemMetrics             protocol.SystemMetrics
+	gpuMemoryActiveGB         float64
+	totalMemoryGB             float64
 	// freeForLoadGB is the provider-reported max additional model-weight (GB) it
 	// can load right now (net of cap/reserve/headroom, idle models reclaimed).
 	// When non-nil it is the authoritative cold-load gate; nil = legacy provider
@@ -97,6 +103,11 @@ type routingSnapshot struct {
 	activeTokenBudgetUsed int64
 	activeTokenBudgetMax  int64
 	queuedTokenBudget     int64
+	// pooledTokenBudget is the provider's reconstructed whole-box token budget
+	// (all budget slots; shared headroom counted once — providerPooledTokenBudget).
+	// Zero value when the provider reports no backend capacity / no budget
+	// slots, which disables the pooled admission check.
+	pooledTokenBudget pooledTokenBudget
 	// kvBytesPerToken is the provider-reported per-token KV-cache cost (bytes)
 	// for THIS model's slot (BackendSlotCapacity.KVBytesPerToken). 0 = unreported
 	// (callers fall back to the kvCacheBytesPerToken default). Used by the
@@ -1068,11 +1079,13 @@ func (r *Registry) snapshotProviderLockedEx(p *Provider, model string, traits Re
 	}
 
 	for _, pr := range p.pendingReqs {
+		tokens := pendingTokenBudget(pr)
+		snap.pendingMaxTokensAllModels += tokens
 		if pr.Model != model {
 			continue
 		}
 		snap.pendingForModel++
-		snap.pendingMaxTokens += pendingTokenBudget(pr)
+		snap.pendingMaxTokens += tokens
 	}
 	// Concurrency headroom with the quality-concurrency cap: a slow model whose
 	// quality batch is below the flat fallback (e.g. Gemma at ~14 tok/s solo →
@@ -1091,6 +1104,7 @@ func (r *Registry) snapshotProviderLockedEx(p *Provider, model string, traits Re
 		if p.BackendCapacity.TotalMemoryGB > 0 {
 			snap.totalMemoryGB = p.BackendCapacity.TotalMemoryGB
 		}
+		snap.pooledTokenBudget = providerPooledTokenBudget(p.BackendCapacity.Slots)
 		for _, slot := range p.BackendCapacity.Slots {
 			if slot.Model != model {
 				continue
@@ -1173,7 +1187,18 @@ func freeMemoryAdmits(snap routingSnapshot, reqPromptTokens, reqMaxTokens int) b
 		if coordinatorExtra < 0 {
 			coordinatorExtra = 0
 		}
-		return snap.activeTokenBudgetUsed+snap.queuedTokenBudget+coordinatorExtra+requestTokens <= snap.activeTokenBudgetMax
+		if snap.activeTokenBudgetUsed+snap.queuedTokenBudget+coordinatorExtra+requestTokens > snap.activeTokenBudgetMax {
+			return false
+		}
+		// The per-slot max still encodes this model's own context/KV ceiling, but
+		// it is NOT a private budget: co-resident slots share the box's ONE KV
+		// pool (each slot's max = own committed + the SAME shared headroom), so a
+		// burst admitted against model A within the heartbeat gap is invisible to
+		// model B's slot max until the next heartbeat. The request must therefore
+		// also fit the reconstructed whole-box pool with EVERY model's
+		// coordinator-pending tokens charged (see pooled_admission.go). Reduces
+		// exactly to the per-slot check for single-model providers.
+		return pooledBudgetAdmits(snap.pooledTokenBudget, snap.pendingMaxTokensAllModels, requestTokens)
 	}
 
 	if !snap.modelLoaded {
@@ -1994,11 +2019,13 @@ func (r *Registry) quickCapacityCheck(model string, estimatedPromptTokens, reque
 			hasBackendCapacity: p.BackendCapacity != nil,
 		}
 		for _, pending := range p.pendingReqs {
+			tokens := pendingTokenBudget(pending)
+			snap.pendingMaxTokensAllModels += tokens
 			if pending.Model != model {
 				continue
 			}
 			snap.pendingForModel++
-			snap.pendingMaxTokens += pendingTokenBudget(pending)
+			snap.pendingMaxTokens += tokens
 		}
 		if snap.hasBackendCapacity {
 			snap.gpuMemoryActiveGB = p.BackendCapacity.GPUMemoryActiveGB
@@ -2006,6 +2033,7 @@ func (r *Registry) quickCapacityCheck(model string, estimatedPromptTokens, reque
 			if p.BackendCapacity.TotalMemoryGB > 0 {
 				snap.totalMemoryGB = p.BackendCapacity.TotalMemoryGB
 			}
+			snap.pooledTokenBudget = providerPooledTokenBudget(p.BackendCapacity.Slots)
 			for _, slot := range p.BackendCapacity.Slots {
 				if slot.Model != model {
 					continue

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -1075,12 +1075,14 @@ func (r *Registry) snapshotProviderLockedEx(p *Provider, model string, traits Re
 		snap.pendingMaxTokens += pendingTokenBudget(pr)
 	}
 	// Concurrency headroom with the quality-concurrency cap: a slow model whose
-	// quality batch is below the flat fallback (e.g. Gemma at ~23 tok/s solo →
+	// quality batch is below the flat fallback (e.g. Gemma at ~14 tok/s solo →
 	// batch 1-2) stops being admittable once it is at its quality cap, so load
-	// spreads across boxes instead of collapsing a few. Uses the static
-	// single-stream decode rate (snap.decodeTPS = resolvedDecodeTPS), not the
-	// observed-under-load value. No-op (legacy flat cap) when the cap is disabled.
-	snap.hasHeadroom = r.hasConcurrencyHeadroomForModelCapLocked(p, model, snap.decodeTPS)
+	// spreads across boxes instead of collapsing a few. The cap resolves the
+	// model's own static solo rate internally (solo median / seed → provider
+	// benchmark fallback) — NOT snap.decodeTPS, which stays the provider-level
+	// rate for TTFT/cost estimation, and NOT the observed-under-load value.
+	// No-op (legacy flat cap) when the cap is disabled.
+	snap.hasHeadroom = r.hasConcurrencyHeadroomForModelCapResolvedLocked(p, model)
 	snap.hasBackendCapacity = p.BackendCapacity != nil
 
 	if p.BackendCapacity != nil {
@@ -1967,10 +1969,10 @@ func (r *Registry) quickCapacityCheck(model string, estimatedPromptTokens, reque
 		}
 
 		// Concurrency gate (with the quality-concurrency cap, same as the dispatch
-		// snapshot — uses the static single-stream decode rate so routing and the
-		// shed preflight stay consistent and a slow model's quality cap counts a
-		// saturated box as a capacity rejection here too).
-		if !r.hasConcurrencyHeadroomForModelCapLocked(p, model, resolvedDecodeTPS(p)) {
+		// snapshot — resolves the model's own static solo rate internally so
+		// routing and the shed preflight stay consistent and a slow model's
+		// quality cap counts a saturated box as a capacity rejection here too).
+		if !r.hasConcurrencyHeadroomForModelCapResolvedLocked(p, model) {
 			p.mu.Unlock()
 			capacityRejections++
 			continue

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -1147,7 +1147,7 @@ func (r *Registry) snapshotProviderLockedEx(p *Provider, model string, traits Re
 			snap.activeTokenBudgetUsed = slot.ActiveTokenBudgetUsed
 			snap.activeTokenBudgetMax = slot.ActiveTokenBudgetMax
 			snap.queuedTokenBudget = slot.QueuedTokenBudget
-			snap.kvBytesPerToken = slot.KVBytesPerToken
+			snap.kvBytesPerToken = clampKVBytesPerToken(slot.KVBytesPerToken)
 			snap.stepsExecuted = slot.StepsExecuted
 			snap.admits = slot.Admits
 			snap.firstTokensEmitted = slot.FirstTokensEmitted
@@ -2152,7 +2152,7 @@ func (r *Registry) quickCapacityCheck(model string, estimatedPromptTokens, reque
 				snap.activeTokenBudgetMax = slot.ActiveTokenBudgetMax
 				snap.queuedTokenBudget = slot.QueuedTokenBudget
 				snap.maxTokensPotential = slot.MaxTokensPotential
-				snap.kvBytesPerToken = slot.KVBytesPerToken
+				snap.kvBytesPerToken = clampKVBytesPerToken(slot.KVBytesPerToken)
 				snap.stepsExecuted = slot.StepsExecuted
 				snap.admits = slot.Admits
 				snap.firstTokensEmitted = slot.FirstTokensEmitted

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -80,14 +80,22 @@ type routingSnapshot struct {
 	// so co-resident models cannot double-spend the one shared KV pool inside
 	// the heartbeat gap.
 	pendingMaxTokensAllModels int
-	backendRunning            int
-	backendWaiting            int
-	maxTokensPotential        int64
-	decodeTPS                 float64
-	prefillTPS                float64
-	systemMetrics             protocol.SystemMetrics
-	gpuMemoryActiveGB         float64
-	totalMemoryGB             float64
+	// pendingMaxBytesAllModels is the byte-normalized analog: each pending
+	// request's token budget × its model's reported KVBytesPerToken. Valid
+	// only when pendingBytesKnown — every pending request's model had a
+	// reported KV rate (see fillSnapshotPendingAndPool). Co-resident models
+	// spend the ONE shared pool at different per-token byte rates, so tokens
+	// are not a common unit across models (pooled_admission.go).
+	pendingMaxBytesAllModels int64
+	pendingBytesKnown        bool
+	backendRunning           int
+	backendWaiting           int
+	maxTokensPotential       int64
+	decodeTPS                float64
+	prefillTPS               float64
+	systemMetrics            protocol.SystemMetrics
+	gpuMemoryActiveGB        float64
+	totalMemoryGB            float64
 	// freeForLoadGB is the provider-reported max additional model-weight (GB) it
 	// can load right now (net of cap/reserve/headroom, idle models reclaimed).
 	// When non-nil it is the authoritative cold-load gate; nil = legacy provider
@@ -1078,15 +1086,7 @@ func (r *Registry) snapshotProviderLockedEx(p *Provider, model string, traits Re
 		minRAMGb:      r.catalogMinRAMGbLocked(model),
 	}
 
-	for _, pr := range p.pendingReqs {
-		tokens := pendingTokenBudget(pr)
-		snap.pendingMaxTokensAllModels += tokens
-		if pr.Model != model {
-			continue
-		}
-		snap.pendingForModel++
-		snap.pendingMaxTokens += tokens
-	}
+	fillSnapshotPendingAndPool(&snap, p, model)
 	// Concurrency headroom with the quality-concurrency cap: a slow model whose
 	// quality batch is below the flat fallback (e.g. Gemma at ~14 tok/s solo →
 	// batch 1-2) stops being admittable once it is at its quality cap, so load
@@ -1104,7 +1104,6 @@ func (r *Registry) snapshotProviderLockedEx(p *Provider, model string, traits Re
 		if p.BackendCapacity.TotalMemoryGB > 0 {
 			snap.totalMemoryGB = p.BackendCapacity.TotalMemoryGB
 		}
-		snap.pooledTokenBudget = providerPooledTokenBudget(p.BackendCapacity.Slots)
 		for _, slot := range p.BackendCapacity.Slots {
 			if slot.Model != model {
 				continue
@@ -1196,9 +1195,11 @@ func freeMemoryAdmits(snap routingSnapshot, reqPromptTokens, reqMaxTokens int) b
 		// burst admitted against model A within the heartbeat gap is invisible to
 		// model B's slot max until the next heartbeat. The request must therefore
 		// also fit the reconstructed whole-box pool with EVERY model's
-		// coordinator-pending tokens charged (see pooled_admission.go). Reduces
-		// exactly to the per-slot check for single-model providers.
-		return pooledBudgetAdmits(snap.pooledTokenBudget, snap.pendingMaxTokensAllModels, requestTokens)
+		// coordinator-pending tokens charged — byte-normalized per slot KV rate
+		// when reported, since co-resident models spend the pool at different
+		// bytes/token (see pooled_admission.go). Reduces exactly to the per-slot
+		// check for single-model providers.
+		return pooledBudgetAdmits(snap, requestTokens)
 	}
 
 	if !snap.modelLoaded {
@@ -1254,6 +1255,41 @@ func freeMemoryAdmits(snap routingSnapshot, reqPromptTokens, reqMaxTokens int) b
 
 	free := snap.totalMemoryGB - snap.gpuMemoryActiveGB
 	return free >= required
+}
+
+// fillSnapshotPendingAndPool populates snap's reconstructed pooled budget and
+// its coordinator-pending aggregates — the per-model filtered pair
+// (pendingForModel / pendingMaxTokens) and the all-models totals in token and,
+// when normalizable, byte units. Byte normalization needs each pending
+// request's model to have a reported KVBytesPerToken (a budget slot in the
+// pool); any pending request that can't be normalized — e.g. for a cold model
+// with no resident slot — flips pendingBytesKnown off and pooledBudgetAdmits
+// falls back to token accounting for the whole check. Shared by the dispatch
+// snapshot (snapshotProviderLockedEx) and the queue preflight
+// (QuickCapacityCheck…) so the two admission paths cannot drift. Caller holds
+// p.mu.
+func fillSnapshotPendingAndPool(snap *routingSnapshot, p *Provider, model string) {
+	if p.BackendCapacity != nil {
+		snap.pooledTokenBudget = providerPooledTokenBudget(p.BackendCapacity.Slots)
+	}
+	bytesKnown := snap.pooledTokenBudget.byteMode
+	for _, pr := range p.pendingReqs {
+		tokens := pendingTokenBudget(pr)
+		snap.pendingMaxTokensAllModels += tokens
+		if bytesKnown {
+			if rate := snap.pooledTokenBudget.kvBytesPerToken[pr.Model]; rate > 0 {
+				snap.pendingMaxBytesAllModels += int64(tokens) * rate
+			} else {
+				bytesKnown = false
+			}
+		}
+		if pr.Model != model {
+			continue
+		}
+		snap.pendingForModel++
+		snap.pendingMaxTokens += tokens
+	}
+	snap.pendingBytesKnown = bytesKnown
 }
 
 func pendingTokenBudget(pr *PendingRequest) int {
@@ -2018,22 +2054,13 @@ func (r *Registry) quickCapacityCheck(model string, estimatedPromptTokens, reque
 			minRAMGb:           r.catalogMinRAMGbLocked(model),
 			hasBackendCapacity: p.BackendCapacity != nil,
 		}
-		for _, pending := range p.pendingReqs {
-			tokens := pendingTokenBudget(pending)
-			snap.pendingMaxTokensAllModels += tokens
-			if pending.Model != model {
-				continue
-			}
-			snap.pendingForModel++
-			snap.pendingMaxTokens += tokens
-		}
+		fillSnapshotPendingAndPool(&snap, p, model)
 		if snap.hasBackendCapacity {
 			snap.gpuMemoryActiveGB = p.BackendCapacity.GPUMemoryActiveGB
 			snap.freeForLoadGB = p.BackendCapacity.FreeForLoadGB
 			if p.BackendCapacity.TotalMemoryGB > 0 {
 				snap.totalMemoryGB = p.BackendCapacity.TotalMemoryGB
 			}
-			snap.pooledTokenBudget = providerPooledTokenBudget(p.BackendCapacity.Slots)
 			for _, slot := range p.BackendCapacity.Slots {
 				if slot.Model != model {
 					continue

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -1176,8 +1176,8 @@ func reportedFreeForLoadAdmits(catalogSizeGB float64, freeForLoadGB *float64) (a
 // Providers that report a token budget use budget-based admission;
 // legacy providers fall back to memory-based estimation.
 func freeMemoryAdmits(snap routingSnapshot, reqPromptTokens, reqMaxTokens int) bool {
+	requestTokens := int64(reqPromptTokens) + int64(reqMaxTokens)
 	if snap.activeTokenBudgetMax > 0 {
-		requestTokens := int64(reqPromptTokens) + int64(reqMaxTokens)
 		// Include coordinator-side pending tokens not yet reflected in the
 		// provider's heartbeat. Avoid double-counting active/queued backend
 		// budgets that are still present in the coordinator pending set until
@@ -1200,6 +1200,19 @@ func freeMemoryAdmits(snap routingSnapshot, reqPromptTokens, reqMaxTokens int) b
 		// bytes/token (see pooled_admission.go). Reduces exactly to the per-slot
 		// check for single-model providers.
 		return pooledBudgetAdmits(snap, requestTokens)
+	}
+
+	// Cold-slot pooled gate: this model reports no budget slot (not loaded
+	// here), but when ANY resident slot reports a token budget the box still
+	// has its ONE shared KV pool, and this request lands in it after the
+	// load — so in-gap pending on a resident model must not be double-spendable
+	// by a cold request that skips the budget branch above. The reconstructed
+	// pool charges all-models coordinator pending plus this request; a cold
+	// model has no reported KV rate (snap.kvBytesPerToken == 0), so the check
+	// runs in token units. No-op for legacy providers with no budget slots at
+	// all (pool.total == 0).
+	if !pooledBudgetAdmits(snap, requestTokens) {
+		return false
 	}
 
 	if !snap.modelLoaded {

--- a/coordinator/registry/solo_tps.go
+++ b/coordinator/registry/solo_tps.go
@@ -1,0 +1,107 @@
+package registry
+
+import (
+	"sort"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+)
+
+// solo_tps.go is the solo-gated half of TPSRegistry: per-(model, chip) decode
+// rates sampled ONLY while the reporting box was uncontended, so a mixed box's
+// gemma sample is never smeared by a concurrent gpt-oss batch. These medians
+// are the per-model static rate the quality-concurrency cap consumes
+// (resolvedSoloModelTPSLocked, concurrency_cap.go) — the root fix for the
+// 2026-07-06 gemma postmortem layer 6, where the cap read the provider-LEVEL
+// registration benchmark (gpt-oss 58–93 tok/s) and granted gemma caps of
+// 12–23 on boxes where gemma actually decodes 10–18 solo.
+//
+// The load-inclusive store (Record/Median, tps_registry.go) is untouched: its
+// consumers (fleetMedianTPS → TTFT estimation) want under-load samples.
+
+// RecordSolo adds a solo (uncontended-box) decode TPS sample for the given
+// model and chip family. Callers must pre-gate on soloSampleEligible — this
+// method itself only validates the sample value, mirroring Record.
+func (r *TPSRegistry) RecordSolo(model, chipFamily string, tps float64) {
+	if tps <= 0 || model == "" {
+		return
+	}
+	key := tpsKey{Model: model, ChipFamily: chipFamily}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	samples := r.soloSamples[key]
+	if len(samples) >= r.maxSamples {
+		// Drop oldest sample (FIFO ring), same shape as Record.
+		samples = samples[1:]
+	}
+	r.soloSamples[key] = append(samples, tps)
+}
+
+// SoloMedian returns the median solo decode TPS for the given model and chip
+// family plus the number of samples behind it. (0, 0) when no solo samples
+// exist. The count lets callers apply a min-sample trust floor before using
+// the median for admission decisions.
+func (r *TPSRegistry) SoloMedian(model, chipFamily string) (float64, int) {
+	key := tpsKey{Model: model, ChipFamily: chipFamily}
+	r.mu.RLock()
+	samples := r.soloSamples[key]
+	sorted := make([]float64, len(samples))
+	copy(sorted, samples)
+	r.mu.RUnlock()
+	return medianOfCopied(sorted), len(sorted)
+}
+
+// SoloMedianAllChips returns the model-wide solo median pooled across every
+// chip family that has at least one solo sample, plus the total sample count.
+// It is the conservative cross-chip transfer used when a specific (model,
+// chip) pair has too few samples: some real solo measurement of the model
+// beats a provider-level benchmark taken on a different model.
+func (r *TPSRegistry) SoloMedianAllChips(model string) (float64, int) {
+	r.mu.RLock()
+	var pooled []float64
+	for key, samples := range r.soloSamples {
+		if key.Model != model {
+			continue
+		}
+		pooled = append(pooled, samples...)
+	}
+	r.mu.RUnlock()
+	return medianOfCopied(pooled), len(pooled)
+}
+
+// medianOfCopied returns the median of samples, sorting in place (callers pass
+// a private copy). 0 for an empty slice.
+func medianOfCopied(sorted []float64) float64 {
+	if len(sorted) == 0 {
+		return 0
+	}
+	sort.Float64s(sorted)
+	mid := len(sorted) / 2
+	if len(sorted)%2 == 0 {
+		return (sorted[mid-1] + sorted[mid]) / 2
+	}
+	return sorted[mid]
+}
+
+// soloSampleEligible reports whether a heartbeat's capacity snapshot qualifies
+// its slot EWMAs as SOLO samples: the whole box — every slot, every co-resident
+// model — has at most one running-or-waiting request. The ≤1 allowance is the
+// request that produced the EWMA itself; ANY other activity anywhere on the
+// box disqualifies, which is exactly what keeps mixed-box samples honest
+// (a gemma EWMA measured while gpt-oss batches on the same GPU is a contended
+// rate, not a solo one). Negative counts (already clamped upstream by
+// clampBackendCapacity) are defensively ignored.
+func soloSampleEligible(bc *protocol.BackendCapacity) bool {
+	if bc == nil {
+		return false
+	}
+	load := 0
+	for _, slot := range bc.Slots {
+		if n := slot.NumRunning + slot.NumWaiting; n > 0 {
+			load += n
+		}
+		if load > 1 {
+			return false
+		}
+	}
+	return true
+}

--- a/coordinator/registry/solo_tps.go
+++ b/coordinator/registry/solo_tps.go
@@ -19,8 +19,10 @@ import (
 // consumers (fleetMedianTPS → TTFT estimation) want under-load samples.
 
 // RecordSolo adds a solo (uncontended-box) decode TPS sample for the given
-// model and chip family. Callers must pre-gate on soloSampleEligible — this
-// method itself only validates the sample value, mirroring Record.
+// model and chip family. Callers must pre-gate on soloSampleEligible AND on
+// the slot owning the box's one active request (NumRunning+NumWaiting > 0,
+// see the heartbeat ingest in registry.go) — this method itself only
+// validates the sample value, mirroring Record.
 func (r *TPSRegistry) RecordSolo(model, chipFamily string, tps float64) {
 	if tps <= 0 || model == "" {
 		return
@@ -83,13 +85,16 @@ func medianOfCopied(sorted []float64) float64 {
 }
 
 // soloSampleEligible reports whether a heartbeat's capacity snapshot qualifies
-// its slot EWMAs as SOLO samples: the whole box — every slot, every co-resident
-// model — has at most one running-or-waiting request. The ≤1 allowance is the
-// request that produced the EWMA itself; ANY other activity anywhere on the
-// box disqualifies, which is exactly what keeps mixed-box samples honest
-// (a gemma EWMA measured while gpt-oss batches on the same GPU is a contended
-// rate, not a solo one). Negative counts (already clamped upstream by
-// clampBackendCapacity) are defensively ignored.
+// as an uncontended box for SOLO sampling: the whole box — every slot, every
+// co-resident model — has at most one running-or-waiting request. The ≤1
+// allowance is the request that produced the EWMA itself; ANY other activity
+// anywhere on the box disqualifies, which is exactly what keeps mixed-box
+// samples honest (a gemma EWMA measured while gpt-oss batches on the same GPU
+// is a contended rate, not a solo one). This is the BOX-level half of the
+// gate; the heartbeat ingest additionally records only the slot that owns the
+// one active request, so idle co-resident slots cannot re-report a stale
+// decayed EWMA as a fresh solo observation every heartbeat. Negative counts
+// (already clamped upstream by clampBackendCapacity) are defensively ignored.
 func soloSampleEligible(bc *protocol.BackendCapacity) bool {
 	if bc == nil {
 		return false

--- a/coordinator/registry/solo_tps.go
+++ b/coordinator/registry/solo_tps.go
@@ -20,9 +20,10 @@ import (
 
 // RecordSolo adds a solo (uncontended-box) decode TPS sample for the given
 // model and chip family. Callers must pre-gate on soloSampleEligible AND on
-// the slot owning the box's one active request (NumRunning+NumWaiting > 0,
-// see the heartbeat ingest in registry.go) — this method itself only
-// validates the sample value, mirroring Record.
+// the slot having an actual running decode (NumRunning > 0, see the heartbeat
+// ingest in registry.go) so a purely-queued box's retained EWMA is not
+// sampled — this method itself only validates the sample value, mirroring
+// Record.
 func (r *TPSRegistry) RecordSolo(model, chipFamily string, tps float64) {
 	if tps <= 0 || model == "" {
 		return
@@ -91,10 +92,11 @@ func medianOfCopied(sorted []float64) float64 {
 // anywhere on the box disqualifies, which is exactly what keeps mixed-box
 // samples honest (a gemma EWMA measured while gpt-oss batches on the same GPU
 // is a contended rate, not a solo one). This is the BOX-level half of the
-// gate; the heartbeat ingest additionally records only the slot that owns the
-// one active request, so idle co-resident slots cannot re-report a stale
-// decayed EWMA as a fresh solo observation every heartbeat. Negative counts
-// (already clamped upstream by clampBackendCapacity) are defensively ignored.
+// gate; the heartbeat ingest additionally records only a slot with an actual
+// running decode (NumRunning > 0), so neither an idle co-resident slot nor a
+// purely-queued box can re-report a stale decayed EWMA as a fresh solo
+// observation every heartbeat. Negative counts (already clamped upstream by
+// clampBackendCapacity) are defensively ignored.
 func soloSampleEligible(bc *protocol.BackendCapacity) bool {
 	if bc == nil {
 		return false

--- a/coordinator/registry/solo_tps.go
+++ b/coordinator/registry/solo_tps.go
@@ -18,17 +18,32 @@ import (
 // The load-inclusive store (Record/Median, tps_registry.go) is untouched: its
 // consumers (fleetMedianTPS → TTFT estimation) want under-load samples.
 
+// chipClassKey keys the solo-sample store at a FINER grain than ChipFamily
+// alone: an M4 Max and an M4 Pro are the same family but 3–4× apart in decode
+// throughput, so pooling them by family lets a fast tier's rate raise a slow
+// tier's quality cap — the exact over-admission this cap exists to prevent.
+// The class is ChipFamily|ChipTier (e.g. "M4|Max"); the raw ChipName is the
+// fallback when the family is absent. Byte-for-byte the form #526's
+// prefillChipClass uses, so the solo and prefill rings key identically.
+func chipClassKey(hw protocol.Hardware) string {
+	if hw.ChipFamily == "" {
+		return hw.ChipName
+	}
+	return hw.ChipFamily + "|" + hw.ChipTier
+}
+
 // RecordSolo adds a solo (uncontended-box) decode TPS sample for the given
-// model and chip family. Callers must pre-gate on soloSampleEligible AND on
-// the slot having an actual running decode (NumRunning > 0, see the heartbeat
-// ingest in registry.go) so a purely-queued box's retained EWMA is not
-// sampled — this method itself only validates the sample value, mirroring
-// Record.
-func (r *TPSRegistry) RecordSolo(model, chipFamily string, tps float64) {
+// model and chip CLASS (chipClassKey — family+tier, not family alone). Callers
+// must pre-gate on soloSampleEligible AND on the slot having an actual running
+// decode (NumRunning > 0, see the heartbeat ingest in registry.go) so a
+// purely-queued box's retained EWMA is not sampled — this method itself only
+// validates the sample value, mirroring Record. The tpsKey.ChipFamily field
+// carries the chip-class string for solo entries.
+func (r *TPSRegistry) RecordSolo(model, chipClass string, tps float64) {
 	if tps <= 0 || model == "" {
 		return
 	}
-	key := tpsKey{Model: model, ChipFamily: chipFamily}
+	key := tpsKey{Model: model, ChipFamily: chipClass}
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	samples := r.soloSamples[key]
@@ -40,11 +55,11 @@ func (r *TPSRegistry) RecordSolo(model, chipFamily string, tps float64) {
 }
 
 // SoloMedian returns the median solo decode TPS for the given model and chip
-// family plus the number of samples behind it. (0, 0) when no solo samples
-// exist. The count lets callers apply a min-sample trust floor before using
-// the median for admission decisions.
-func (r *TPSRegistry) SoloMedian(model, chipFamily string) (float64, int) {
-	key := tpsKey{Model: model, ChipFamily: chipFamily}
+// CLASS (chipClassKey) plus the number of samples behind it. (0, 0) when no
+// solo samples exist. The count lets callers apply a min-sample trust floor
+// before using the median for admission decisions.
+func (r *TPSRegistry) SoloMedian(model, chipClass string) (float64, int) {
+	key := tpsKey{Model: model, ChipFamily: chipClass}
 	r.mu.RLock()
 	samples := r.soloSamples[key]
 	sorted := make([]float64, len(samples))
@@ -53,22 +68,49 @@ func (r *TPSRegistry) SoloMedian(model, chipFamily string) (float64, int) {
 	return medianOfCopied(sorted), len(sorted)
 }
 
-// SoloMedianAllChips returns the model-wide solo median pooled across every
-// chip family that has at least one solo sample, plus the total sample count.
-// It is the conservative cross-chip transfer used when a specific (model,
-// chip) pair has too few samples: some real solo measurement of the model
-// beats a provider-level benchmark taken on a different model.
+// SoloMedianAllChips is the CONSERVATIVE cross-class transfer used when a
+// provider's own chip class has too few solo samples: it returns the MINIMUM
+// of the per-class medians across every chip class that has at least one solo
+// sample for the model, plus the TOTAL sample count across those classes.
+//
+// SAFETY INVARIANT: the resolver must never hand a slow box a rate faster than
+// its own class demonstrated. Pooling every sample into one median (the old
+// behavior) lets a fast, sample-heavy class dominate and return a rate above a
+// slow box's real capability — over-capping it into the very quality collapse
+// this cap prevents. Taking the min of per-class medians instead can never
+// exceed the slowest class's typical rate: worst case it UNDER-caps a fast box
+// (safe, quality-protective), never over-caps a slower one.
+//
+// The returned int is the total sample count across classes, so the resolver's
+// existing >= qualityCapSoloMinSamples trust floor is unchanged. The
+// tpsKey.ChipFamily field carries the chip-class string for solo entries, so
+// grouping by key.Model + key.ChipFamily groups by class.
 func (r *TPSRegistry) SoloMedianAllChips(model string) (float64, int) {
 	r.mu.RLock()
-	var pooled []float64
+	perClass := make(map[string][]float64)
 	for key, samples := range r.soloSamples {
-		if key.Model != model {
+		if key.Model != model || len(samples) == 0 {
 			continue
 		}
-		pooled = append(pooled, samples...)
+		// append copies the values, so perClass is safe to sort after RUnlock.
+		perClass[key.ChipFamily] = append(perClass[key.ChipFamily], samples...)
 	}
 	r.mu.RUnlock()
-	return medianOfCopied(pooled), len(pooled)
+
+	minMedian, total := 0.0, 0
+	have := false
+	for _, samples := range perClass {
+		// samples is a private copy; medianOfCopied sorts it in place.
+		m := medianOfCopied(samples)
+		total += len(samples)
+		if m <= 0 {
+			continue
+		}
+		if !have || m < minMedian {
+			minMedian, have = m, true
+		}
+	}
+	return minMedian, total
 }
 
 // medianOfCopied returns the median of samples, sorting in place (callers pass

--- a/coordinator/registry/solo_tps_test.go
+++ b/coordinator/registry/solo_tps_test.go
@@ -1,0 +1,351 @@
+package registry
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+)
+
+const gptossBuild = "gpt-oss-20b"
+
+// enablePerModelQualityCap enables the quality cap exactly like
+// enableQualityCap (floor 15, fallback 4, default overcommit) and pins the
+// per-model solo-TPS envs — seed CSV, kill switch, min-sample floor — so
+// ambient operator settings can't leak in. Package-level knobs are restored to
+// defaults on cleanup so tests that never call SetQualityConcurrencyCap can't
+// observe leftovers.
+func enablePerModelQualityCap(t *testing.T, reg *Registry, seed, killSwitch, minSamples string) {
+	t.Helper()
+	t.Cleanup(func() {
+		qualityCapPerModelTPS = true
+		qualityCapSoloMinSamples = defaultQualityCapSoloMinSamples
+		modelSoloTPSSeed = nil
+		qualityCapOvercommitByModel = nil
+	})
+	t.Setenv(modelSoloTPSSeedEnv, seed)
+	t.Setenv(qualityCapPerModelTPSEnv, killSwitch)
+	t.Setenv(qualityCapSoloMinSamplesEnv, minSamples)
+	enableQualityCap(t, reg, "")
+}
+
+// resolveSolo evaluates the quality-cap solo-rate resolver under the locks the
+// routing path holds.
+func resolveSolo(reg *Registry, p *Provider, model string) soloModelTPS {
+	reg.mu.RLock()
+	defer reg.mu.RUnlock()
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return reg.resolvedSoloModelTPSLocked(p, model)
+}
+
+// effCapResolved evaluates the production per-model admission cap (solo rate
+// resolved internally) under the routing-path locks — the value every
+// production admission site now consumes via
+// hasConcurrencyHeadroomForModelCapResolvedLocked.
+func effCapResolved(reg *Registry, p *Provider, model string) int {
+	reg.mu.RLock()
+	defer reg.mu.RUnlock()
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return reg.effectiveMaxConcurrencyForModelResolvedLocked(p, model)
+}
+
+// mixedBoxProvider builds the postmortem's mixed box: registration benchmark
+// taken on gpt-oss (fast), with BOTH a gpt-oss and a gemma token-budget slot.
+func mixedBoxProvider(t *testing.T, reg *Registry, id string, decodeTPS float64) *Provider {
+	t.Helper()
+	p := makeSchedulerProvider(t, reg, id, gptossBuild, decodeTPS)
+	addAdvertisedModel(p, gemmaBuild)
+	p.mu.Lock()
+	p.BackendCapacity.Slots[0].ActiveTokenBudgetMax = 500_000
+	p.BackendCapacity.Slots = append(p.BackendCapacity.Slots, protocol.BackendSlotCapacity{
+		Model:                gemmaBuild,
+		State:                "running",
+		ActiveTokenBudgetMax: 400_000,
+	})
+	p.mu.Unlock()
+	return p
+}
+
+// --- Solo sample store ---
+
+func TestSoloMedianReturnsMedianAndCount(t *testing.T) {
+	r := NewTPSRegistry()
+	for _, v := range []float64{18, 10, 14, 12, 16} {
+		r.RecordSolo("model-a", "m4", v)
+	}
+	tps, n := r.SoloMedian("model-a", "m4")
+	if tps != 14 || n != 5 {
+		t.Fatalf("SoloMedian = (%v, %d), want (14, 5)", tps, n)
+	}
+	// The load-inclusive store must be untouched by solo recording.
+	if got := r.Median("model-a", "m4"); got != 0 {
+		t.Fatalf("Median = %v, want 0 (RecordSolo must not feed the load-inclusive store)", got)
+	}
+}
+
+func TestSoloMedianEmptyAndInvalidSamples(t *testing.T) {
+	r := NewTPSRegistry()
+	if tps, n := r.SoloMedian("missing", "m4"); tps != 0 || n != 0 {
+		t.Fatalf("SoloMedian(empty) = (%v, %d), want (0, 0)", tps, n)
+	}
+	r.RecordSolo("model", "m4", 0)
+	r.RecordSolo("model", "m4", -3)
+	r.RecordSolo("", "m4", 50)
+	if tps, n := r.SoloMedian("model", "m4"); tps != 0 || n != 0 {
+		t.Fatalf("SoloMedian(after invalid samples) = (%v, %d), want (0, 0)", tps, n)
+	}
+}
+
+func TestSoloMedianFIFOCap(t *testing.T) {
+	r := NewTPSRegistry()
+	for i := 0; i < 50; i++ {
+		r.RecordSolo("model", "chip", 100)
+	}
+	for i := 0; i < 10; i++ {
+		r.RecordSolo("model", "chip", 200)
+	}
+	// 40 × 100 + 10 × 200 after FIFO eviction → median 100, count capped at 50.
+	tps, n := r.SoloMedian("model", "chip")
+	if tps != 100 || n != 50 {
+		t.Fatalf("SoloMedian = (%v, %d), want (100, 50) after FIFO eviction", tps, n)
+	}
+}
+
+func TestSoloMedianAllChipsPoolsAcrossFamilies(t *testing.T) {
+	r := NewTPSRegistry()
+	r.RecordSolo("model", "m1", 20)
+	r.RecordSolo("model", "m1", 20)
+	r.RecordSolo("model", "m4", 30)
+	r.RecordSolo("model", "m4", 30)
+	r.RecordSolo("model", "m4", 30)
+	r.RecordSolo("other-model", "m4", 999) // different model must not pollute
+	tps, n := r.SoloMedianAllChips("model")
+	if tps != 30 || n != 5 {
+		t.Fatalf("SoloMedianAllChips = (%v, %d), want (30, 5)", tps, n)
+	}
+}
+
+// --- Heartbeat ingest gating ---
+
+func soloHeartbeat(slots []protocol.BackendSlotCapacity) *protocol.HeartbeatMessage {
+	return &protocol.HeartbeatMessage{
+		Type:   protocol.TypeHeartbeat,
+		Status: "serving",
+		BackendCapacity: &protocol.BackendCapacity{
+			TotalMemoryGB: 64,
+			Slots:         slots,
+		},
+	}
+}
+
+// TestSoloRecordingGatedOnUncontendedBox drives the REAL heartbeat ingest
+// path: a slot EWMA becomes a solo sample only when the whole box has at most
+// one running-or-waiting request (the sample-generating request itself). Any
+// co-resident activity — another model running, or waiting queue depth —
+// disqualifies the sample; the load-inclusive store records regardless.
+func TestSoloRecordingGatedOnUncontendedBox(t *testing.T) {
+	reg := New(testLogger())
+	makeSchedulerProvider(t, reg, "box", gemmaBuild, 93)
+
+	// Uncontended: gemma serving exactly the sample-generating request.
+	reg.Heartbeat("box", soloHeartbeat([]protocol.BackendSlotCapacity{
+		{Model: gemmaBuild, State: "running", NumRunning: 1, ObservedDecodeTPS: 14},
+		{Model: gptossBuild, State: "idle", NumRunning: 0, NumWaiting: 0},
+	}))
+	if _, n := reg.tpsRegistry.SoloMedian(gemmaBuild, "M3"); n != 1 {
+		t.Fatalf("solo samples after uncontended heartbeat = %d, want 1", n)
+	}
+
+	// Fully idle box reporting a (decayed) EWMA also qualifies.
+	reg.Heartbeat("box", soloHeartbeat([]protocol.BackendSlotCapacity{
+		{Model: gemmaBuild, State: "idle", ObservedDecodeTPS: 15},
+	}))
+	if _, n := reg.tpsRegistry.SoloMedian(gemmaBuild, "M3"); n != 2 {
+		t.Fatalf("solo samples after idle heartbeat = %d, want 2", n)
+	}
+
+	// Co-resident model busy → gemma's EWMA is a contended rate: NOT solo.
+	reg.Heartbeat("box", soloHeartbeat([]protocol.BackendSlotCapacity{
+		{Model: gemmaBuild, State: "running", NumRunning: 1, ObservedDecodeTPS: 5},
+		{Model: gptossBuild, State: "running", NumRunning: 1, ObservedDecodeTPS: 40},
+	}))
+	// Same-slot queue depth also disqualifies (batch of 2 on one model).
+	reg.Heartbeat("box", soloHeartbeat([]protocol.BackendSlotCapacity{
+		{Model: gemmaBuild, State: "running", NumRunning: 1, NumWaiting: 1, ObservedDecodeTPS: 6},
+	}))
+	if _, n := reg.tpsRegistry.SoloMedian(gemmaBuild, "M3"); n != 2 {
+		t.Fatalf("solo samples after contended heartbeats = %d, want 2 (contended samples must be rejected)", n)
+	}
+	// The load-inclusive store keeps EVERY sample (TTFT estimation semantics).
+	if got := reg.tpsRegistry.Median(gemmaBuild, "M3"); got != (6+14)/2.0 {
+		t.Fatalf("load-inclusive median = %v, want 10 (all four gemma samples recorded: 14,15,5,6)", got)
+	}
+}
+
+// --- Resolver fallback chain ---
+
+func TestResolvedSoloModelTPSFallbackChain(t *testing.T) {
+	reg := New(testLogger())
+	enablePerModelQualityCap(t, reg, gemmaBuild+"=14", "", "")
+	p := mixedBoxProvider(t, reg, "mixed", 93) // ChipFamily "M3"
+
+	// (c) seed only — no solo samples anywhere.
+	if got := resolveSolo(reg, p, gemmaBuild); got.tps != 14 || !got.perModel {
+		t.Fatalf("seed fallback = %+v, want tps 14, perModel true", got)
+	}
+
+	// (b) cross-chip pooled median once total n ≥ floor (5), even though the
+	// provider's own chip family (M3) has no samples yet.
+	for i, v := range []float64{16, 16, 16, 20, 20} {
+		chip := "M1"
+		if i >= 3 {
+			chip = "M2"
+		}
+		reg.tpsRegistry.RecordSolo(gemmaBuild, chip, v)
+	}
+	if got := resolveSolo(reg, p, gemmaBuild); got.tps != 16 || !got.perModel {
+		t.Fatalf("cross-chip fallback = %+v, want tps 16 (pooled median), perModel true", got)
+	}
+
+	// (a) per-(model, chip) median wins over cross-chip and seed once trusted.
+	for _, v := range []float64{10, 12, 12, 12, 30} {
+		reg.tpsRegistry.RecordSolo(gemmaBuild, "M3", v)
+	}
+	if got := resolveSolo(reg, p, gemmaBuild); got.tps != 12 || !got.perModel {
+		t.Fatalf("per-chip solo median = %+v, want tps 12, perModel true", got)
+	}
+
+	// (d) a model with no solo data and no seed falls back to the provider-level
+	// rate (the registration benchmark).
+	if got := resolveSolo(reg, p, gptossBuild); got.tps != 93 || got.perModel {
+		t.Fatalf("provider-level fallback = %+v, want tps 93, perModel false", got)
+	}
+}
+
+func TestResolvedSoloModelTPSMinSampleFloor(t *testing.T) {
+	reg := New(testLogger())
+	// Floor raised to 6: five per-chip samples are NOT yet trusted.
+	enablePerModelQualityCap(t, reg, "", "", "6")
+	p := mixedBoxProvider(t, reg, "mixed", 93)
+	for i := 0; i < 5; i++ {
+		reg.tpsRegistry.RecordSolo(gemmaBuild, "M3", 14)
+	}
+	if got := resolveSolo(reg, p, gemmaBuild); got.tps != 93 || got.perModel {
+		t.Fatalf("below min samples = %+v, want provider-level (93, perModel false)", got)
+	}
+	reg.tpsRegistry.RecordSolo(gemmaBuild, "M3", 14)
+	if got := resolveSolo(reg, p, gemmaBuild); got.tps != 14 || !got.perModel {
+		t.Fatalf("at min samples = %+v, want (14, perModel true)", got)
+	}
+}
+
+func TestResolvedSoloModelTPSKillSwitch(t *testing.T) {
+	reg := New(testLogger())
+	// Kill switch OFF: solo medians and seed present but must be ignored —
+	// resolvedDecodeTPS(p) exactly, at every consumer.
+	enablePerModelQualityCap(t, reg, gemmaBuild+"=14", "false", "")
+	p := mixedBoxProvider(t, reg, "mixed", 93)
+	for i := 0; i < 10; i++ {
+		reg.tpsRegistry.RecordSolo(gemmaBuild, "M3", 14)
+	}
+	if got := resolveSolo(reg, p, gemmaBuild); got.tps != 93 || got.perModel {
+		t.Fatalf("kill switch off: resolver = %+v, want provider-level (93, perModel false)", got)
+	}
+}
+
+// --- Seed parsing ---
+
+func TestParseModelFloatMapSeedEntries(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+		want map[string]float64
+	}{
+		{"empty", "", nil},
+		{"single", "gemma-4-26b-qat-4bit=14", map[string]float64{"gemma-4-26b-qat-4bit": 14}},
+		{"multi_with_spaces", " gemma-4-26b-qat-4bit=14 , gpt-oss-20b=30 ", map[string]float64{"gemma-4-26b-qat-4bit": 14, "gpt-oss-20b": 30}},
+		{"uppercase_key_lowered", "GPT-OSS-20B=30", map[string]float64{"gpt-oss-20b": 30}},
+		{"bad_entries_skipped", "bogus,=3,x=,gemma=abc,gemma=0,gemma=-2,good=14.5", map[string]float64{"good": 14.5}},
+		{"all_invalid", "bogus,=3,x=abc", nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseModelFloatMap(tc.raw)
+			if len(got) != len(tc.want) {
+				t.Fatalf("parseModelFloatMap(%q) = %v, want %v", tc.raw, got, tc.want)
+			}
+			for k, v := range tc.want {
+				if got[k] != v {
+					t.Fatalf("parseModelFloatMap(%q)[%q] = %v, want %v", tc.raw, k, got[k], v)
+				}
+			}
+		})
+	}
+}
+
+// TestSoloSeedColdStart is the restart scenario: the TPS registry is in-memory
+// and wiped by a coordinator restart, so on a fresh registry the seed env must
+// carry the per-model cap alone (gemma-qat solo ≈ 14 from prod data → cap 2)
+// until gated solo samples re-accumulate.
+func TestSoloSeedColdStart(t *testing.T) {
+	reg := New(testLogger()) // fresh registry == post-restart state
+	enablePerModelQualityCap(t, reg, "gemma-4-26b-qat-4bit=14,gpt-oss-20b=30", "", "")
+	p := mixedBoxProvider(t, reg, "mixed", 93)
+
+	if got := effCapResolved(reg, p, gemmaBuild); got != 2 {
+		t.Fatalf("cold-start gemma cap = %d, want 2 (seed 14 ≤ floor 15 → qc 1 × 1.2)", got)
+	}
+	if got := effCapResolved(reg, p, gptossBuild); got != 4 {
+		t.Fatalf("cold-start gpt-oss cap = %d, want 4 (seed 30 → qc 3 → ceil(3.6))", got)
+	}
+}
+
+// --- Warm-pool consistency ---
+
+// TestWarmPoolSnapshotDecodeSampleUsesSoloResolver: the warm-pool fleet
+// snapshot's decode samples (→ soloDecodeTPS → warm-target quality
+// concurrency) must come from the SAME solo resolver as the admission cap —
+// here the gemma solo median (14) — not the collapsed under-load slot EWMA
+// (2.6) and not the provider-level benchmark (93). Otherwise admission would
+// cap a box at 2 while the warm-pool controller plans capacity as if it could
+// take 19.
+func TestWarmPoolSnapshotDecodeSampleUsesSoloResolver(t *testing.T) {
+	reg := New(testLogger())
+	enablePerModelQualityCap(t, reg, "", "", "")
+	p := makeSchedulerProvider(t, reg, "gemma-box", gemmaBuild, 93)
+	p.mu.Lock()
+	p.BackendCapacity.Slots[0].ObservedDecodeTPS = 2.6 // collapsed contended EWMA
+	p.mu.Unlock()
+	for i := 0; i < 5; i++ {
+		reg.tpsRegistry.RecordSolo(gemmaBuild, "M3", 14)
+	}
+
+	snap := reg.warmPoolFleetSnapshot(time.Now())[gemmaBuild]
+	if snap.soloDecodeTPS != 14 {
+		t.Fatalf("warm-pool soloDecodeTPS = %v, want 14 (solo median; EWMA 2.6 and benchmark 93 must not feed the warm target)", snap.soloDecodeTPS)
+	}
+	if snap.serviceDecodeTPS != 2.6 {
+		t.Fatalf("warm-pool serviceDecodeTPS = %v, want observed 2.6 (E[S] keeps load-inclusive semantics)", snap.serviceDecodeTPS)
+	}
+}
+
+// TestSoloResolverConvergesAcrossManyBoxes is a small sanity spread: several
+// mixed boxes with different provider-level benchmarks all resolve the SAME
+// per-model rate once the solo median is trusted — the property that makes
+// caps chip-honest instead of benchmark-inherited.
+func TestSoloResolverConvergesAcrossManyBoxes(t *testing.T) {
+	reg := New(testLogger())
+	enablePerModelQualityCap(t, reg, "", "", "")
+	for i := 0; i < 5; i++ {
+		reg.tpsRegistry.RecordSolo(gemmaBuild, "M3", 14)
+	}
+	for i, bench := range []float64{58, 73, 93} {
+		p := mixedBoxProvider(t, reg, fmt.Sprintf("box-%d", i), bench)
+		if got := effCapResolved(reg, p, gemmaBuild); got != 2 {
+			t.Fatalf("box benchmarked %v tok/s: gemma cap = %d, want 2 regardless of the provider-level benchmark", bench, got)
+		}
+	}
+}

--- a/coordinator/registry/solo_tps_test.go
+++ b/coordinator/registry/solo_tps_test.go
@@ -218,6 +218,41 @@ func TestSoloRecordingOnlySamplesActiveSlot(t *testing.T) {
 	}
 }
 
+// TestSoloRecordingRequiresRunningDecode is the queued-but-not-running
+// regression (Finding 3 of the final round): a box with one QUEUED request and
+// no running decode is box-wide uncontended (soloEligible), and the owning slot
+// has NumWaiting > 0 — but its ObservedDecodeTPS is a retained EWMA with no
+// running decode behind it. The prior round's NumRunning+NumWaiting > 0 gate
+// would mint that stale EWMA as a fresh solo sample every heartbeat; the
+// tightened NumRunning > 0 gate must not. A running-and-uncontended heartbeat
+// still records. Fails without the NumRunning > 0 gate in the heartbeat ingest.
+func TestSoloRecordingRequiresRunningDecode(t *testing.T) {
+	reg := New(testLogger())
+	makeSchedulerProvider(t, reg, "box", gemmaBuild, 93)
+
+	// Queued but NOT decoding: NumRunning 0 / NumWaiting 1. Box-wide load = 1
+	// (uncontended), but observed_decode_tps is a stale retained EWMA — no
+	// running request produced it, so it must NOT be sampled.
+	reg.Heartbeat("box", soloHeartbeat([]protocol.BackendSlotCapacity{
+		{Model: gemmaBuild, State: "running", NumRunning: 0, NumWaiting: 1, ObservedDecodeTPS: 14},
+	}))
+	if _, n := reg.tpsRegistry.SoloMedian(gemmaBuild, "M3"); n != 0 {
+		t.Fatalf("solo samples after queued-but-not-running heartbeat = %d, want 0 (stale EWMA, no running decode)", n)
+	}
+
+	// Running and uncontended: NumRunning 1 / NumWaiting 0 → a real solo sample.
+	reg.Heartbeat("box", soloHeartbeat([]protocol.BackendSlotCapacity{
+		{Model: gemmaBuild, State: "running", NumRunning: 1, NumWaiting: 0, ObservedDecodeTPS: 12},
+	}))
+	if _, n := reg.tpsRegistry.SoloMedian(gemmaBuild, "M3"); n != 1 {
+		t.Fatalf("solo samples after running-uncontended heartbeat = %d, want 1", n)
+	}
+	// The load-inclusive store records BOTH heartbeats' EWMAs regardless.
+	if got := reg.tpsRegistry.Median(gemmaBuild, "M3"); got != (12+14)/2.0 {
+		t.Fatalf("load-inclusive median = %v, want 13 (both EWMAs recorded: 14, 12)", got)
+	}
+}
+
 // --- Resolver fallback chain ---
 
 func TestResolvedSoloModelTPSFallbackChain(t *testing.T) {

--- a/coordinator/registry/solo_tps_test.go
+++ b/coordinator/registry/solo_tps_test.go
@@ -114,7 +114,13 @@ func TestSoloMedianFIFOCap(t *testing.T) {
 	}
 }
 
-func TestSoloMedianAllChipsPoolsAcrossFamilies(t *testing.T) {
+// TestSoloMedianAllChipsMinOfClassMedians pins the CONSERVATIVE cross-class
+// transfer: SoloMedianAllChips returns the MINIMUM of the per-class medians
+// (never the pooled median, which a fast, sample-heavy class can dominate) plus
+// the TOTAL sample count. A slow class (m1, median 20) and a fast class (m4,
+// median 30) → the min (20), so the rate can never exceed the slowest class's
+// typical rate and can never over-cap a slow box.
+func TestSoloMedianAllChipsMinOfClassMedians(t *testing.T) {
 	r := NewTPSRegistry()
 	r.RecordSolo("model", "m1", 20)
 	r.RecordSolo("model", "m1", 20)
@@ -123,8 +129,19 @@ func TestSoloMedianAllChipsPoolsAcrossFamilies(t *testing.T) {
 	r.RecordSolo("model", "m4", 30)
 	r.RecordSolo("other-model", "m4", 999) // different model must not pollute
 	tps, n := r.SoloMedianAllChips("model")
-	if tps != 30 || n != 5 {
-		t.Fatalf("SoloMedianAllChips = (%v, %d), want (30, 5)", tps, n)
+	if tps != 20 || n != 5 {
+		t.Fatalf("SoloMedianAllChips = (%v, %d), want (20, 5) — min of class medians, total count", tps, n)
+	}
+
+	// A fast class with MANY samples must not drag the min up: the pooled median
+	// would be 30, but the slow class's median (12) is what a slow box can do.
+	r2 := NewTPSRegistry()
+	for i := 0; i < 20; i++ {
+		r2.RecordSolo("m", "M4|Max", 30) // fast, sample-heavy
+	}
+	r2.RecordSolo("m", "M1", 12) // slow, one sample
+	if tps, n := r2.SoloMedianAllChips("m"); tps != 12 || n != 21 {
+		t.Fatalf("SoloMedianAllChips = (%v, %d), want (12, 21) — fast class must not dominate the min", tps, n)
 	}
 }
 
@@ -153,11 +170,12 @@ func TestSoloRecordingGatedOnUncontendedBox(t *testing.T) {
 	makeSchedulerProvider(t, reg, "box", gemmaBuild, 93)
 
 	// Uncontended: gemma serving exactly the sample-generating request.
+	// Solo samples are keyed by chip CLASS ("M3|Max"), not family ("M3").
 	reg.Heartbeat("box", soloHeartbeat([]protocol.BackendSlotCapacity{
 		{Model: gemmaBuild, State: "running", NumRunning: 1, ObservedDecodeTPS: 14},
 		{Model: gptossBuild, State: "idle", NumRunning: 0, NumWaiting: 0},
 	}))
-	if _, n := reg.tpsRegistry.SoloMedian(gemmaBuild, "M3"); n != 1 {
+	if _, n := reg.tpsRegistry.SoloMedian(gemmaBuild, "M3|Max"); n != 1 {
 		t.Fatalf("solo samples after uncontended heartbeat = %d, want 1", n)
 	}
 
@@ -167,7 +185,7 @@ func TestSoloRecordingGatedOnUncontendedBox(t *testing.T) {
 	reg.Heartbeat("box", soloHeartbeat([]protocol.BackendSlotCapacity{
 		{Model: gemmaBuild, State: "idle", ObservedDecodeTPS: 15},
 	}))
-	if _, n := reg.tpsRegistry.SoloMedian(gemmaBuild, "M3"); n != 1 {
+	if _, n := reg.tpsRegistry.SoloMedian(gemmaBuild, "M3|Max"); n != 1 {
 		t.Fatalf("solo samples after idle heartbeat = %d, want 1 (idle EWMA must not be recorded)", n)
 	}
 
@@ -180,7 +198,7 @@ func TestSoloRecordingGatedOnUncontendedBox(t *testing.T) {
 	reg.Heartbeat("box", soloHeartbeat([]protocol.BackendSlotCapacity{
 		{Model: gemmaBuild, State: "running", NumRunning: 1, NumWaiting: 1, ObservedDecodeTPS: 6},
 	}))
-	if _, n := reg.tpsRegistry.SoloMedian(gemmaBuild, "M3"); n != 1 {
+	if _, n := reg.tpsRegistry.SoloMedian(gemmaBuild, "M3|Max"); n != 1 {
 		t.Fatalf("solo samples after contended heartbeats = %d, want 1 (contended samples must be rejected)", n)
 	}
 	// The load-inclusive store keeps EVERY sample (TTFT estimation semantics).
@@ -206,10 +224,10 @@ func TestSoloRecordingOnlySamplesActiveSlot(t *testing.T) {
 			{Model: gptossBuild, State: "idle", ObservedDecodeTPS: 60}, // stale EWMA, no request
 		}))
 	}
-	if _, n := reg.tpsRegistry.SoloMedian(gemmaBuild, "M3"); n != 5 {
+	if _, n := reg.tpsRegistry.SoloMedian(gemmaBuild, "M3|Max"); n != 5 {
 		t.Fatalf("active-slot solo samples = %d, want 5", n)
 	}
-	if _, n := reg.tpsRegistry.SoloMedian(gptossBuild, "M3"); n != 0 {
+	if _, n := reg.tpsRegistry.SoloMedian(gptossBuild, "M3|Max"); n != 0 {
 		t.Fatalf("idle co-resident slot recorded %d solo samples, want 0 (stale EWMA contamination)", n)
 	}
 	// The load-inclusive store still sees both slots' EWMAs.
@@ -236,7 +254,7 @@ func TestSoloRecordingRequiresRunningDecode(t *testing.T) {
 	reg.Heartbeat("box", soloHeartbeat([]protocol.BackendSlotCapacity{
 		{Model: gemmaBuild, State: "running", NumRunning: 0, NumWaiting: 1, ObservedDecodeTPS: 14},
 	}))
-	if _, n := reg.tpsRegistry.SoloMedian(gemmaBuild, "M3"); n != 0 {
+	if _, n := reg.tpsRegistry.SoloMedian(gemmaBuild, "M3|Max"); n != 0 {
 		t.Fatalf("solo samples after queued-but-not-running heartbeat = %d, want 0 (stale EWMA, no running decode)", n)
 	}
 
@@ -244,7 +262,7 @@ func TestSoloRecordingRequiresRunningDecode(t *testing.T) {
 	reg.Heartbeat("box", soloHeartbeat([]protocol.BackendSlotCapacity{
 		{Model: gemmaBuild, State: "running", NumRunning: 1, NumWaiting: 0, ObservedDecodeTPS: 12},
 	}))
-	if _, n := reg.tpsRegistry.SoloMedian(gemmaBuild, "M3"); n != 1 {
+	if _, n := reg.tpsRegistry.SoloMedian(gemmaBuild, "M3|Max"); n != 1 {
 		t.Fatalf("solo samples after running-uncontended heartbeat = %d, want 1", n)
 	}
 	// The load-inclusive store records BOTH heartbeats' EWMAs regardless.
@@ -290,6 +308,137 @@ func TestResolvedSoloModelTPSFallbackChain(t *testing.T) {
 	// rate (the registration benchmark).
 	if got := resolveSolo(reg, p, gptossBuild); got.tps != 93 || got.perModel {
 		t.Fatalf("provider-level fallback = %+v, want tps 93, perModel false", got)
+	}
+}
+
+// setChipClass overrides a provider's chip family/tier so tests can drive the
+// class-keyed solo resolver (chipClassKey = family|tier).
+func setChipClass(p *Provider, family, tier string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.Hardware.ChipFamily = family
+	p.Hardware.ChipTier = tier
+}
+
+// TestSoloResolverChipClassKeying is the correctness-critical safety test for
+// Fix 2: solo caps are keyed by chip CLASS (family+tier), and the cross-class
+// fallback is the MIN of per-class medians. Together these guarantee the
+// resolver never hands a slow box a rate faster than its own class demonstrated
+// — the over-admission that collapses a slow box under load.
+func TestSoloResolverChipClassKeying(t *testing.T) {
+	// (a) same-class primary lookup applies: an M3|Max box uses M3|Max samples.
+	t.Run("same_class_primary", func(t *testing.T) {
+		reg := New(testLogger())
+		enablePerModelQualityCap(t, reg, "", "", "")
+		p := mixedBoxProvider(t, reg, "m3max", 93)
+		setChipClass(p, "M3", "Max")
+		for _, v := range []float64{10, 12, 12, 12, 30} { // median 12
+			reg.tpsRegistry.RecordSolo(gemmaBuild, "M3|Max", v)
+		}
+		if got := resolveSolo(reg, p, gemmaBuild); got.tps != 12 || !got.perModel {
+			t.Fatalf("same-class resolver = %+v, want tps 12, perModel true", got)
+		}
+	})
+
+	// (b) cross-tier isolation: an M4|Pro box must NOT inherit the fast M4|Max
+	// tier's rate. With family-only keying both tiers pooled under "M4" and the
+	// Pro box got the Max rate; class keying keeps them separate, so the Pro box
+	// resolves to its OWN slower median.
+	t.Run("cross_tier_isolation", func(t *testing.T) {
+		reg := New(testLogger())
+		enablePerModelQualityCap(t, reg, "", "", "")
+		p := mixedBoxProvider(t, reg, "m4pro", 93)
+		setChipClass(p, "M4", "Pro")
+		for i := 0; i < 5; i++ {
+			reg.tpsRegistry.RecordSolo(gemmaBuild, "M4|Max", 40) // fast tier
+		}
+		for _, v := range []float64{14, 15, 15, 15, 16} { // slow tier, median 15
+			reg.tpsRegistry.RecordSolo(gemmaBuild, "M4|Pro", v)
+		}
+		if got := resolveSolo(reg, p, gemmaBuild); got.tps != 15 {
+			t.Fatalf("M4|Pro resolved %v, want 15 (its own class median), NOT the M4|Max 40", got.tps)
+		}
+	})
+
+	// (c) conservative cross-class fallback: a box whose own class has no samples
+	// falls to SoloMedianAllChips, which returns the MIN of class medians — the
+	// slow class (10), never the fast one (40). A slow box can never be over-capped.
+	t.Run("conservative_cross_class_fallback", func(t *testing.T) {
+		reg := New(testLogger())
+		enablePerModelQualityCap(t, reg, "", "", "")
+		p := mixedBoxProvider(t, reg, "m2max", 93)
+		setChipClass(p, "M2", "Max") // no M2|Max samples exist
+		for i := 0; i < 5; i++ {
+			reg.tpsRegistry.RecordSolo(gemmaBuild, "M4|Max", 40) // fast class
+		}
+		for i := 0; i < 5; i++ {
+			reg.tpsRegistry.RecordSolo(gemmaBuild, "M1", 10) // slow class
+		}
+		if got := resolveSolo(reg, p, gemmaBuild); got.tps != 10 || !got.perModel {
+			t.Fatalf("cross-class fallback = %+v, want tps 10 (min of class medians), NOT the fast 40", got)
+		}
+	})
+
+	// (d) cold-start safety: a cold-class box with only FASTER classes present
+	// still gets the conservative min of those class medians (25, the slower of
+	// the two), never the fastest (40).
+	t.Run("cold_class_conservative_min", func(t *testing.T) {
+		reg := New(testLogger())
+		enablePerModelQualityCap(t, reg, "", "", "")
+		p := mixedBoxProvider(t, reg, "m2ultra", 93)
+		setChipClass(p, "M2", "Ultra") // no M2|Ultra samples exist
+		for i := 0; i < 5; i++ {
+			reg.tpsRegistry.RecordSolo(gemmaBuild, "M4|Max", 40) // fastest
+		}
+		for i := 0; i < 5; i++ {
+			reg.tpsRegistry.RecordSolo(gemmaBuild, "M3|Max", 25) // slower of the two
+		}
+		if got := resolveSolo(reg, p, gemmaBuild); got.tps != 25 {
+			t.Fatalf("cold-class resolver = %v, want 25 (conservative min), never the fastest 40", got.tps)
+		}
+	})
+}
+
+// TestSoloClassKeyingEndToEndNoCrossTierOverCap drives the REAL heartbeat
+// ingest so both the ingest key (registry.go) and the resolver key
+// (concurrency_cap.go) are exercised: two same-family boxes of different tiers
+// (M4 Max fast, M4 Pro slow) serving gemma solo. With chip-CLASS keying the
+// slow box's cap comes from its OWN 14 tok/s (→ cap 2) while the fast box keeps
+// its wide cap from 40 tok/s. With family-only keying both tiers pool under
+// "M4" and the slow box's cap inflates from the fast box's samples — the exact
+// cross-tier over-admission this fix prevents. Reverting either the ingest or
+// the resolver keying trips one of the two assertions.
+func TestSoloClassKeyingEndToEndNoCrossTierOverCap(t *testing.T) {
+	reg := New(testLogger())
+	enablePerModelQualityCap(t, reg, "", "", "5")
+
+	mk := func(id, family, tier string) *Provider {
+		p := makeSchedulerProvider(t, reg, id, gemmaBuild, 93)
+		p.mu.Lock()
+		p.Hardware.ChipFamily = family
+		p.Hardware.ChipTier = tier
+		p.mu.Unlock()
+		return p
+	}
+	fast := mk("fast", "M4", "Max")
+	slow := mk("slow", "M4", "Pro")
+
+	// Five uncontended solo heartbeats each: fast decodes gemma at 40, slow at
+	// 14. One running gemma request per heartbeat gates the sample in.
+	for i := 0; i < 5; i++ {
+		reg.Heartbeat("fast", soloHeartbeat([]protocol.BackendSlotCapacity{
+			{Model: gemmaBuild, State: "running", NumRunning: 1, ObservedDecodeTPS: 40},
+		}))
+		reg.Heartbeat("slow", soloHeartbeat([]protocol.BackendSlotCapacity{
+			{Model: gemmaBuild, State: "running", NumRunning: 1, ObservedDecodeTPS: 14},
+		}))
+	}
+
+	if got := effCapResolved(reg, slow, gemmaBuild); got != 2 {
+		t.Fatalf("slow (M4|Pro) gemma cap = %d, want 2 (its own 14 tok/s); family keying inflates it from the fast M4|Max box", got)
+	}
+	if got := effCapResolved(reg, fast, gemmaBuild); got <= 2 {
+		t.Fatalf("fast (M4|Max) gemma cap = %d, want wide (its own 40 tok/s), not dragged down cross-tier", got)
 	}
 }
 

--- a/coordinator/registry/solo_tps_test.go
+++ b/coordinator/registry/solo_tps_test.go
@@ -269,6 +269,10 @@ func TestParseModelFloatMapSeedEntries(t *testing.T) {
 		{"multi_with_spaces", " gemma-4-26b-qat-4bit=14 , gpt-oss-20b=30 ", map[string]float64{"gemma-4-26b-qat-4bit": 14, "gpt-oss-20b": 30}},
 		{"uppercase_key_lowered", "GPT-OSS-20B=30", map[string]float64{"gpt-oss-20b": 30}},
 		{"bad_entries_skipped", "bogus,=3,x=,gemma=abc,gemma=0,gemma=-2,good=14.5", map[string]float64{"good": 14.5}},
+		// strconv.ParseFloat accepts NaN/±Inf spellings; NaN in particular
+		// slips past a naive v <= 0 filter (NaN comparisons are always false)
+		// and would drive the cap math to an implementation-defined integer.
+		{"non_finite_skipped", "a=NaN,b=+Inf,c=Inf,d=-Inf,e=Infinity,good=2", map[string]float64{"good": 2}},
 		{"all_invalid", "bogus,=3,x=abc", nil},
 	}
 	for _, tc := range cases {

--- a/coordinator/registry/solo_tps_test.go
+++ b/coordinator/registry/solo_tps_test.go
@@ -284,7 +284,9 @@ func TestResolvedSoloModelTPSFallbackChain(t *testing.T) {
 	}
 
 	// (b) cross-chip pooled median once total n ≥ floor (5), even though the
-	// provider's own chip family (M3) has no samples yet.
+	// provider's own chip family (M3) has no samples yet. The configured seed
+	// remains an upper bound for an unsampled class, so the faster pooled median
+	// cannot widen this provider's cold-start cap.
 	for i, v := range []float64{16, 16, 16, 20, 20} {
 		chip := "M1"
 		if i >= 3 {
@@ -292,8 +294,8 @@ func TestResolvedSoloModelTPSFallbackChain(t *testing.T) {
 		}
 		reg.tpsRegistry.RecordSolo(gemmaBuild, chip, v)
 	}
-	if got := resolveSolo(reg, p, gemmaBuild); got.tps != 16 || !got.perModel {
-		t.Fatalf("cross-chip fallback = %+v, want tps 16 (pooled median), perModel true", got)
+	if got := resolveSolo(reg, p, gemmaBuild); got.tps != 14 || !got.perModel {
+		t.Fatalf("cross-chip fallback = %+v, want seed-bounded tps 14 (pooled median 16), perModel true", got)
 	}
 
 	// (a) per-(model, chip) median wins over cross-chip and seed once trusted.

--- a/coordinator/registry/solo_tps_test.go
+++ b/coordinator/registry/solo_tps_test.go
@@ -143,9 +143,11 @@ func soloHeartbeat(slots []protocol.BackendSlotCapacity) *protocol.HeartbeatMess
 
 // TestSoloRecordingGatedOnUncontendedBox drives the REAL heartbeat ingest
 // path: a slot EWMA becomes a solo sample only when the whole box has at most
-// one running-or-waiting request (the sample-generating request itself). Any
-// co-resident activity — another model running, or waiting queue depth —
-// disqualifies the sample; the load-inclusive store records regardless.
+// one running-or-waiting request (the sample-generating request itself) AND
+// the slot is the one running it. Any co-resident activity — another model
+// running, or waiting queue depth — disqualifies the sample, and a fully idle
+// box records nothing (a decayed EWMA with no active request is not a fresh
+// observation); the load-inclusive store records regardless.
 func TestSoloRecordingGatedOnUncontendedBox(t *testing.T) {
 	reg := New(testLogger())
 	makeSchedulerProvider(t, reg, "box", gemmaBuild, 93)
@@ -159,12 +161,14 @@ func TestSoloRecordingGatedOnUncontendedBox(t *testing.T) {
 		t.Fatalf("solo samples after uncontended heartbeat = %d, want 1", n)
 	}
 
-	// Fully idle box reporting a (decayed) EWMA also qualifies.
+	// Fully idle box: the reported EWMA is a stale decayed value with no
+	// request behind it — NOT a fresh solo observation. Recording it would let
+	// an idle box mint one bogus sample per heartbeat.
 	reg.Heartbeat("box", soloHeartbeat([]protocol.BackendSlotCapacity{
 		{Model: gemmaBuild, State: "idle", ObservedDecodeTPS: 15},
 	}))
-	if _, n := reg.tpsRegistry.SoloMedian(gemmaBuild, "M3"); n != 2 {
-		t.Fatalf("solo samples after idle heartbeat = %d, want 2", n)
+	if _, n := reg.tpsRegistry.SoloMedian(gemmaBuild, "M3"); n != 1 {
+		t.Fatalf("solo samples after idle heartbeat = %d, want 1 (idle EWMA must not be recorded)", n)
 	}
 
 	// Co-resident model busy → gemma's EWMA is a contended rate: NOT solo.
@@ -176,12 +180,41 @@ func TestSoloRecordingGatedOnUncontendedBox(t *testing.T) {
 	reg.Heartbeat("box", soloHeartbeat([]protocol.BackendSlotCapacity{
 		{Model: gemmaBuild, State: "running", NumRunning: 1, NumWaiting: 1, ObservedDecodeTPS: 6},
 	}))
-	if _, n := reg.tpsRegistry.SoloMedian(gemmaBuild, "M3"); n != 2 {
-		t.Fatalf("solo samples after contended heartbeats = %d, want 2 (contended samples must be rejected)", n)
+	if _, n := reg.tpsRegistry.SoloMedian(gemmaBuild, "M3"); n != 1 {
+		t.Fatalf("solo samples after contended heartbeats = %d, want 1 (contended samples must be rejected)", n)
 	}
 	// The load-inclusive store keeps EVERY sample (TTFT estimation semantics).
 	if got := reg.tpsRegistry.Median(gemmaBuild, "M3"); got != (6+14)/2.0 {
 		t.Fatalf("load-inclusive median = %v, want 10 (all four gemma samples recorded: 14,15,5,6)", got)
+	}
+}
+
+// TestSoloRecordingOnlySamplesActiveSlot is the idle-co-resident contamination
+// regression: with model A running the box's ONE active request, model B's
+// idle slot keeps re-reporting its stale decayed EWMA in every heartbeat.
+// Only A may be sampled — otherwise B accumulates one duplicate "solo"
+// sample per ~30s heartbeat from a single long-past observation, reaches the
+// min-sample trust floor without any real measurement, and B's quality cap is
+// then derived from a rate no request produced.
+func TestSoloRecordingOnlySamplesActiveSlot(t *testing.T) {
+	reg := New(testLogger())
+	makeSchedulerProvider(t, reg, "box", gemmaBuild, 93)
+
+	for i := 0; i < 5; i++ {
+		reg.Heartbeat("box", soloHeartbeat([]protocol.BackendSlotCapacity{
+			{Model: gemmaBuild, State: "running", NumRunning: 1, ObservedDecodeTPS: 14},
+			{Model: gptossBuild, State: "idle", ObservedDecodeTPS: 60}, // stale EWMA, no request
+		}))
+	}
+	if _, n := reg.tpsRegistry.SoloMedian(gemmaBuild, "M3"); n != 5 {
+		t.Fatalf("active-slot solo samples = %d, want 5", n)
+	}
+	if _, n := reg.tpsRegistry.SoloMedian(gptossBuild, "M3"); n != 0 {
+		t.Fatalf("idle co-resident slot recorded %d solo samples, want 0 (stale EWMA contamination)", n)
+	}
+	// The load-inclusive store still sees both slots' EWMAs.
+	if got := reg.tpsRegistry.Median(gptossBuild, "M3"); got != 60 {
+		t.Fatalf("load-inclusive median for idle slot = %v, want 60", got)
 	}
 }
 

--- a/coordinator/registry/tps_registry.go
+++ b/coordinator/registry/tps_registry.go
@@ -8,10 +8,22 @@ import (
 // TPSRegistry aggregates observed decode TPS values from heartbeats,
 // keyed by model and chip family. Used to provide fleet-calibrated
 // estimates for providers that haven't reported observed TPS yet.
+//
+// It holds two independent sample stores with the same 50-sample FIFO+median
+// shape but deliberately different ingest semantics:
+//
+//   - samples (Record/Median): EVERY reported EWMA, including under-load ones.
+//     Feeds fleetMedianTPS → TTFT estimation, whose load-inclusive semantics
+//     are intentional (an estimate of what a request will actually see).
+//   - soloSamples (RecordSolo/SoloMedian, solo_tps.go): only samples taken
+//     while the WHOLE box was uncontended. Feeds the quality-concurrency cap,
+//     which needs a static solo rate that cannot collapse under the very
+//     overload the cap exists to prevent.
 type TPSRegistry struct {
-	mu         sync.RWMutex
-	samples    map[tpsKey][]float64
-	maxSamples int
+	mu          sync.RWMutex
+	samples     map[tpsKey][]float64
+	soloSamples map[tpsKey][]float64
+	maxSamples  int
 }
 
 type tpsKey struct {
@@ -21,8 +33,9 @@ type tpsKey struct {
 
 func NewTPSRegistry() *TPSRegistry {
 	return &TPSRegistry{
-		samples:    make(map[tpsKey][]float64),
-		maxSamples: 50, // keep last 50 observations per model+chip
+		samples:     make(map[tpsKey][]float64),
+		soloSamples: make(map[tpsKey][]float64),
+		maxSamples:  50, // keep last 50 observations per model+chip
 	}
 }
 

--- a/coordinator/registry/warm_pool_controller.go
+++ b/coordinator/registry/warm_pool_controller.go
@@ -87,13 +87,20 @@ type warmPoolModelSnapshot struct {
 	// backend slots for this model (the observable L in Little's Law).
 	running int
 	waiting int
-	// soloDecodeTPS / prefillTPS / maxProviderConc are representative (median)
-	// rates and the per-provider concurrency cap across providers serving the
-	// model, used for quality concurrency and the E[S] service-time estimate.
-	soloDecodeTPS   float64
-	prefillTPS      float64
-	maxProviderConc int
-	eligibleCold    []warmPoolCandidate
+	// soloDecodeTPS / serviceDecodeTPS / prefillTPS / maxProviderConc are
+	// representative (median) rates and the per-provider concurrency cap across
+	// providers serving the model. soloDecodeTPS is the STATIC solo rate from
+	// the quality-cap resolver (resolvedSoloModelTPSLocked) and feeds quality
+	// concurrency, so warm targets and admission caps use the same math and
+	// cannot disagree. serviceDecodeTPS keeps the observed-EWMA-preferring
+	// chain (resolvedModelTPSLocked) and feeds only the E[S] service-time
+	// estimate, which deliberately wants the load-inclusive rate a request
+	// actually sees.
+	soloDecodeTPS    float64
+	serviceDecodeTPS float64
+	prefillTPS       float64
+	maxProviderConc  int
+	eligibleCold     []warmPoolCandidate
 	// coldIneligible / coldDisq tally cold (on-disk, not-warm) providers that
 	// FAILED the warm-pool candidate gate, by reason — diagnostics for why
 	// eligibleCold is smaller than the raw cold count.
@@ -327,7 +334,16 @@ func (c *warmPoolController) planObserveOnly(now time.Time, reserve func([]model
 		p := pressure[model]
 		q := queue[model]
 		f := fleet[model]
-		svc := estimateServiceTime(f.prefillTPS, f.soloDecodeTPS, params)
+		// E[S] from the load-inclusive service rate (what a request actually
+		// sees); quality concurrency below from the solo rate (the admission
+		// cap's math). Falls back to the solo rate when no service samples
+		// exist (both medians share the same provider set, so this only guards
+		// the degenerate empty case).
+		serviceTPS := f.serviceDecodeTPS
+		if serviceTPS <= 0 {
+			serviceTPS = f.soloDecodeTPS
+		}
+		svc := estimateServiceTime(f.prefillTPS, serviceTPS, params)
 		target := c.targetWarm(f, p, q, params, svc, now)
 
 		gap := target - f.warm
@@ -524,7 +540,10 @@ func (r *Registry) warmPoolFleetSnapshot(now time.Time) map[string]warmPoolModel
 	out := make(map[string]warmPoolModelSnapshot)
 	// Per-model rate samples (from every eligible provider serving the model,
 	// warm or warmable) collapsed to a representative median at the end.
+	// decodeSamples carries the quality-cap solo rate (→ qualityConcurrency);
+	// serviceSamples the observed-EWMA service rate (→ E[S]).
 	decodeSamples := make(map[string][]float64)
+	serviceSamples := make(map[string][]float64)
 	prefillSamples := make(map[string][]float64)
 	concSamples := make(map[string][]float64)
 	for _, p := range r.providers {
@@ -548,8 +567,17 @@ func (r *Registry) warmPoolFleetSnapshot(now time.Time) map[string]warmPoolModel
 					s.warmSaturated++
 				}
 				out[model] = s
-				decodeTPS, prefillTPS := resolvedModelTPSLocked(p, model)
-				decodeSamples[model] = append(decodeSamples[model], decodeTPS)
+				// decodeSamples feed soloDecodeTPS → qualityConcurrency in the
+				// warm target. Use the SAME solo resolver as the admission cap
+				// (solo median / seed → provider benchmark), NOT the per-slot
+				// observed EWMA: the EWMA is a contended rate, and planning warm
+				// targets from it while admission caps from the solo rate would
+				// let the two disagree. The observed-EWMA chain
+				// (resolvedModelTPSLocked) still feeds serviceSamples/prefill —
+				// E[S] wants the load-inclusive rate a request actually sees.
+				serviceTPS, prefillTPS := resolvedModelTPSLocked(p, model)
+				decodeSamples[model] = append(decodeSamples[model], r.resolvedSoloModelTPSLocked(p, model).tps)
+				serviceSamples[model] = append(serviceSamples[model], serviceTPS)
 				prefillSamples[model] = append(prefillSamples[model], prefillTPS)
 				concSamples[model] = append(concSamples[model], float64(p.maxConcurrencyForModelLocked(model)))
 				continue
@@ -560,8 +588,10 @@ func (r *Registry) warmPoolFleetSnapshot(now time.Time) map[string]warmPoolModel
 			if reason == warmColdEligible {
 				s.eligibleCold = append(s.eligibleCold, candidate)
 				out[model] = s
-				decodeTPS, prefillTPS := resolvedModelTPSLocked(p, model)
-				decodeSamples[model] = append(decodeSamples[model], decodeTPS)
+				// Same solo-resolver / service-rate split as the warm branch above.
+				serviceTPS, prefillTPS := resolvedModelTPSLocked(p, model)
+				decodeSamples[model] = append(decodeSamples[model], r.resolvedSoloModelTPSLocked(p, model).tps)
+				serviceSamples[model] = append(serviceSamples[model], serviceTPS)
 				prefillSamples[model] = append(prefillSamples[model], prefillTPS)
 				concSamples[model] = append(concSamples[model], float64(p.maxConcurrencyForModelLocked(model)))
 			} else {
@@ -578,6 +608,7 @@ func (r *Registry) warmPoolFleetSnapshot(now time.Time) map[string]warmPoolModel
 	for model, s := range out {
 		sort.Slice(s.eligibleCold, func(i, j int) bool { return s.eligibleCold[i].score > s.eligibleCold[j].score })
 		s.soloDecodeTPS = medianFloat(decodeSamples[model])
+		s.serviceDecodeTPS = medianFloat(serviceSamples[model])
 		s.prefillTPS = medianFloat(prefillSamples[model])
 		s.maxProviderConc = int(medianFloat(concSamples[model]))
 		out[model] = s

--- a/coordinator/registry/warm_pool_controller_test.go
+++ b/coordinator/registry/warm_pool_controller_test.go
@@ -418,7 +418,13 @@ func TestWarmPoolPressureLoadsBeforeMinWarmFloor(t *testing.T) {
 	}
 }
 
-func TestWarmPoolFleetSnapshotUsesObservedSlotTPS(t *testing.T) {
+// TestWarmPoolFleetSnapshotSplitsSoloAndServiceRates: the snapshot's
+// soloDecodeTPS must come from the quality-cap solo resolver (static solo
+// rate — here the registration benchmark, since no solo samples or seed
+// exist), NOT the under-load slot EWMA, so warm targets use the same quality
+// math as the admission cap. The EWMA still feeds serviceDecodeTPS/prefillTPS,
+// which size E[S] (a request's actually-observed rates).
+func TestWarmPoolFleetSnapshotSplitsSoloAndServiceRates(t *testing.T) {
 	reg := New(testLogger())
 	model := "warm-pool-observed-tps"
 	p := makeSchedulerProvider(t, reg, "warm", model, 23)
@@ -429,8 +435,11 @@ func TestWarmPoolFleetSnapshotUsesObservedSlotTPS(t *testing.T) {
 
 	snap := reg.warmPoolFleetSnapshot(time.Now())[model]
 
-	if snap.soloDecodeTPS != 73 {
-		t.Fatalf("soloDecodeTPS = %v, want observed slot TPS 73", snap.soloDecodeTPS)
+	if snap.soloDecodeTPS != 23 {
+		t.Fatalf("soloDecodeTPS = %v, want static solo rate 23 (observed EWMA must not feed quality concurrency)", snap.soloDecodeTPS)
+	}
+	if snap.serviceDecodeTPS != 73 {
+		t.Fatalf("serviceDecodeTPS = %v, want observed slot TPS 73", snap.serviceDecodeTPS)
 	}
 	if snap.prefillTPS != 1000 {
 		t.Fatalf("prefillTPS = %v, want observed slot prefill TPS 1000", snap.prefillTPS)
@@ -452,7 +461,13 @@ func TestWarmPoolFleetSnapshotFallsBackToStaticTPS(t *testing.T) {
 	}
 }
 
-func TestWarmPoolDiagnosticsReflectObservedTPS(t *testing.T) {
+// TestWarmPoolDiagnosticsSplitObservedAndSoloRates: E[S] (ServiceTime) still
+// reflects the observed load-inclusive rates, while QualityConcurrency
+// deliberately does NOT read the under-load EWMA — it is computed from the
+// same static solo rate as the admission cap (postmortem layer 6: EWMA-fed
+// planning and static-fed admission used to disagree). Static 23 tok/s at
+// floor 15 → quality batch 1, no matter how high the current EWMA reads.
+func TestWarmPoolDiagnosticsSplitObservedAndSoloRates(t *testing.T) {
 	reg := New(testLogger())
 	model := "warm-pool-observed-diagnostics"
 	p := makeSchedulerProvider(t, reg, "warm", model, 23)
@@ -473,11 +488,11 @@ func TestWarmPoolDiagnosticsReflectObservedTPS(t *testing.T) {
 		t.Fatalf("snapshots = %d, want 1", len(snaps))
 	}
 	snap := snaps[0]
-	if snap.QualityConcurrency <= 2 {
-		t.Fatalf("QualityConcurrency = %d, want observed TPS to raise it above stale value 2", snap.QualityConcurrency)
+	if snap.QualityConcurrency != 1 {
+		t.Fatalf("QualityConcurrency = %d, want 1 from the static solo rate 23 (observed EWMA 73 must not inflate the quality batch)", snap.QualityConcurrency)
 	}
 	if snap.ServiceTime >= 10*time.Second {
-		t.Fatalf("ServiceTime = %v, want observed TPS to keep it below stale 12.8s", snap.ServiceTime)
+		t.Fatalf("ServiceTime = %v, want observed rates to keep it below stale 12.8s", snap.ServiceTime)
 	}
 }
 

--- a/docs/operations/coordinator-deploy.md
+++ b/docs/operations/coordinator-deploy.md
@@ -234,6 +234,9 @@ semantics is the code (`coordinator/registry/`, `coordinator/api/`); the highlig
 | `EIGENINFERENCE_QUEUE_BEFORE_SHED`, `_QUEUE_MAX_DEPTH`, `_QUEUE_MAX_WAIT` | Capacity queueing (dedicated pools included) |
 | `EIGENINFERENCE_HEALTH_EJECTION` | Stable-identity ejection kill switch — **`on` in prod**; `off` disables black-hole ejection entirely |
 | `EIGENINFERENCE_QUALITY_CONCURRENCY_OVERCOMMIT`, `_BY_MODEL` | Per-box admission density (default 1.2) |
+| `EIGENINFERENCE_QUALITY_CAP_PER_MODEL_TPS` | Quality cap reads each model's own solo decode rate (default `true`; `false` restores the provider-level benchmark) |
+| `EIGENINFERENCE_QUALITY_CAP_SOLO_MIN_SAMPLES` | Solo samples required before a per-(model, chip) median is trusted (default 5) |
+| `EIGENINFERENCE_MODEL_SOLO_TPS_SEED` | Cold-start solo rates, `build-id=tok/s` CSV (e.g. `gemma-4-26b-qat-4bit=14,gpt-oss-20b=30`); the in-memory TPS registry is restart-wiped |
 | `EIGENINFERENCE_WARM_POOL_*` | Warm-pool controller (active; `OBSERVE_ONLY=false`) |
 | `EIGENINFERENCE_DEDICATED_MODELS` | Static dedicated-box partition (`gemma-4`) |
 | `EIGENINFERENCE_IPAPI_KEY` | ip-api.com PRO key; unset falls back to the free 45 req/min tier |


### PR DESCRIPTION
# Per-model solo-TPS quality caps and pooled KV admission

> **Base:** `master`
> **Final head:** `85817ad2` - 17 commits, 12 files, 2,600 additions, 104 deletions
> **Release role:** **Merge group A only. Do not deploy the coordinator from this PR by itself.**

## Problem

The 2026-07-06 Gemma serving incident exposed two coordinator-side admission failures.

First, the quality-concurrency cap used `resolvedDecodeTPS(p)`, the provider-level registration benchmark, for every model on a mixed-model box. A box benchmarked on gpt-oss at 58-93 tok/s therefore granted Gemma caps of 12-23 even though Gemma's own 10-18 tok/s solo rate warrants approximately 1-2 concurrent decodes. The coordinator concentrated 8-11 Gemma requests on boxes that collapse beyond small batches.

Second, `freeMemoryAdmits` treated each model slot's token budget as private and counted only same-model pending work. In reality, every slot exposes its own committed tokens plus the same physical KV-cache headroom. Co-resident models could spend that shared pool twice during the heartbeat gap, and token-only accounting could not compare models with different KV bytes per token.

Review of the accumulated byte and chip-class follow-ups found three final gaps:

- A cold model with no resident slot was priced only from resident KV rates. A large-KV cold model could therefore be undercharged both as the incoming request and later as coordinator-pending work.
- For an unsampled chip class, organic samples from a faster class were consulted before the operator seed. Fast-class data could override a deliberately conservative cold-start seed and widen the slow class's hard cap.
- Engine V2 can truthfully report a positive KV rate with a zero token budget after its live fleet clamp. The coordinator treated that model-local zero as an omitted legacy budget, so co-resident pooled headroom could admit and advertise a model the provider had declared full.

## What changed

### Per-model quality caps

- Added a solo-gated store to `TPSRegistry`. Heartbeats record a solo sample only when the whole provider has at most one running-or-waiting request, and only for the slot that has an actual running decode. Idle slots and queued-only slots cannot repeatedly contribute retained EWMA values.
- Keyed solo samples by chip class (`ChipFamily|ChipTier`) so an M4 Max rate is not treated as an M4 Pro rate. Cross-class transfer uses the minimum per-class median rather than a sample-weighted fleet median.
- Added `resolvedSoloModelTPSLocked` as the static rate source for quality caps. The final resolver order is: trusted same-class median; minimum cross-class median bounded above by the configured seed when one exists; the seed when no cross-class median is trusted; then the prior provider-level benchmark behavior. Same-class organic evidence still supersedes the seed, while faster-class data cannot widen an unsampled class above its configured cold-start estimate.
- Kept load-inclusive TPS observations separate. They still feed TTFT and service-time estimation; they never feed the hard quality cap.
- Applied the same resolved cap at routing snapshot selection, quick-capacity preflight, final reservation re-check, public model-capacity snapshots, warm-pool saturation, and warm-target quality math.
- Rejected malformed, non-positive, `NaN`, and infinite values in the shared per-model float-map parser.
- Preserved `EIGENINFERENCE_QUALITY_CAP_PER_MODEL_TPS=false` as the kill switch that restores the provider-level benchmark behavior.

### Shared KV-pool admission

- Added `providerPooledTokenBudget` to reconstruct one provider-wide pool from all backend slots. Live used capacity adds across slots; shared free headroom is counted once; committed potential is retained only as the pending de-duplication baseline.
- Normalized the pool and charges into bytes whenever the provider reports KV bytes per token. Per-token rates are clamped before multiplication to prevent malformed heartbeat values from overflowing `int64` accounting.
- Added all-model pending totals to both routing snapshot builders. `pooledBudgetAdmits` now charges every coordinator-pending model before admitting a new request.
- Kept the existing per-slot check for model context limits, then required the request to fit the provider-wide pool as a second condition.
- Applied the pooled check to cold requests as well as resident-slot requests.
- The final readiness fix routes every pooled byte charge through `resolvedPooledKVBytesPerToken`. A resident model keeps its clamped reported rate; a cold model with no resident slot uses `max(400,000 B/token coordinator default, highest resident rate)`, clamped by the existing 16 MiB/token overflow ceiling. The same policy prices both the incoming cold request and already-pending cold work, so an unknown large-KV model cannot borrow a smaller resident model's rate or disable byte accounting.
- Added saturating pending-byte accumulation with `addPooledKVByteCharge`, and division-based admission comparisons, so a large pending or incoming charge rejects instead of wrapping an `int64` product.
- Distinguished authoritative Engine V2 zero budgets from legacy omission. A positive KV rate preserves a zero maximum as model-local known-full capacity in both `freeMemoryAdmits` and `ModelCapacitySnapshot`; another model's pooled headroom cannot widen it. Positive-budget co-residents remain usable, and zero-budget slot rates remain available for pending and capacity math.
- Added `pooledRemainingTokens` so `/v1/models` and `/v1/models/capacity` expose the same byte-aware pooled headroom that admission enforces.
- Preserved legacy behavior for providers reporting neither token budgets nor KV rates, and preserved the arithmetic boundary for single-model providers.

### Commit history

| Commit | Change |
|---|---|
| `9b69fee7` | Per-model solo-TPS quality caps |
| `c397dc46` | Provider-wide pooled KV admission |
| `ac482fe0` | Reject non-finite per-model tunable values |
| `ef179d08` | Sample only the slot that owns the active request |
| `3ba518cc` | Normalize heterogeneous co-resident KV use into bytes |
| `ba8ad368` | Charge the shared pool on the cold-model path |
| `5edbe165` | Clamp public capacity by the pooled admission budget |
| `942429fa` | Merge the then-current `master` into the branch |
| `cd7039cc` | Align byte snapshots, running-decode gating, and live-used pool totals |
| `1ddb69db` | Clamp KV byte rates before byte multiplication |
| `34b73308` | Key solo caps by chip class and make cross-class transfer conservative |
| `8f0a28b8` | Keep cold unknown-KV requests in byte accounting |
| `1a4d25e8` | Correct cold-path documentation |
| `96b3dc29` | Bound cross-class solo-rate transfer by the operator seed |
| `8872e744` | Keep incoming and pending cold pooled-KV accounting in bytes |
| `5e5024f8` | Merge current `master`, including #527 capacity-rate accounting |
| `85817ad2` | Honor authoritative zero Engine V2 KV budgets |

The final merge preserves #527's capacity-rate lifecycle accounting and this PR's pooled-admission and capacity-snapshot behavior without conflicts.

## Behavior: Before and after

```mermaid
flowchart TB
  subgraph Before["Before"]
    A1["Gemma request reaches mixed-model provider"] --> B1["Cap uses provider-level gpt-oss benchmark"]
    B1 --> C1["Gemma receives an over-wide concurrency cap"]
    C1 --> D1["Batch grows and per-request decode collapses"]

    E1["Co-resident model requests"] --> F1["Per-slot token checks count same-model pending only"]
    F1 --> G1["Both models spend the same KV headroom"]

    H1["Cold large-KV model has no resident slot"] --> I1["Request and pending work borrow resident KV rates"]
    I1 --> J1["Shared pool is undercharged"]

    K1["Slow chip class has no samples"] --> L1["Fast-class samples run before conservative seed"]
    L1 --> M1["Slow class can receive a fast-class cap"]

    N1["V2 model reports positive KV rate and zero budget"] --> O1["Zero is treated as legacy omission"]
    O1 --> P1["Co-resident pooled headroom admits a known-full model"]
  end

  subgraph After["After"]
    A2["Gemma request reaches mixed-model provider"] --> B2["Cap uses static model and chip-class solo rate"]
    B2 --> C2["Concurrency stays near the model quality floor"]

    E2["Co-resident model requests"] --> F2["Per-slot limit plus provider-wide byte pool"]
    F2 --> G2["All-model pending work is charged once"]

    H2["Cold model has no resident slot"] --> I2["Resolve conservative cold-model KV rate"]
    I2 --> J2["Use the same rate for incoming and pending work"]

    K2["Chip class has no trusted same-class median"] --> L2["Bound cross-class transfer by the operator seed"]
    L2 --> M2["Fallback remains conservative until local samples exist"]

    N2["V2 model reports positive KV rate and zero budget"] --> O2["Treat zero as authoritative model-local capacity"]
    O2 --> P2["Admission and capacity reject it without blocking positive-budget models"]
  end
```

## Code: Before and after

```mermaid
flowchart LR
  subgraph BeforeCode["Before"]
    H1["Heartbeat"] --> R1["Record load-inclusive TPS"]
    R1 --> D1["resolvedDecodeTPS provider rate"]
    D1 --> C1["effectiveMaxConcurrencyForModelLocked"]

    S1["snapshotProviderLockedEx or quickCapacityCheck"] --> F1["freeMemoryAdmits"]
    F1 --> P1["Per-slot budget plus same-model pending"]
    Z1["Positive KV rate plus zero max"] --> U1["Falls through as budget unavailable"]
    U1 --> F1
  end

  subgraph AfterCode["After"]
    H2["Heartbeat"] --> G2["soloSampleEligible plus NumRunning"]
    G2 --> R2["TPSRegistry.RecordSolo by model and chip class"]
    R2 --> D2["resolvedSoloModelTPSLocked"]
    D2 --> C2["hasConcurrencyHeadroomForModelCapResolvedLocked"]
    C2 --> W2["routing, preflight, final admit, capacity feed, warm pool"]

    S2["snapshotProviderLockedEx or quickCapacityCheck"] --> A2["fillSnapshotPendingAndPool"]
    A2 --> B2["providerPooledTokenBudget"]
    A2 --> K2["resolvedPooledKVBytesPerToken"]
    K2 --> O2["addPooledKVByteCharge saturates pending bytes"]
    B2 --> F2["freeMemoryAdmits plus pooledBudgetAdmits"]
    K2 --> F2
    B2 --> P2["pooledRemainingTokens"]
    K2 --> P2
    P2 --> M2["ModelCapacitySnapshot"]
    Z2["Positive KV rate plus zero max"] --> Q2["knownZeroTokenBudget"]
    Q2 --> F2
    Q2 --> M2
  end
```

## Configuration

| Environment variable | Default | Meaning |
|---|---|---|
| `EIGENINFERENCE_QUALITY_CAP_PER_MODEL_TPS` | `true` | Use each model's static solo rate for hard quality caps. `false` restores the provider-level rate at every cap site. |
| `EIGENINFERENCE_QUALITY_CAP_SOLO_MIN_SAMPLES` | `5` | Same-class solo samples required before a median is trusted. |
| `EIGENINFERENCE_MODEL_SOLO_TPS_SEED` | empty | Cold-start `build-id=tok/s` values, matched case-insensitively. For an unsampled class, broader organic data is capped at this seed; trusted same-class samples still take precedence. |

These settings are parsed at coordinator startup. Pooled admission has no feature flag.

At the single integrated coordinator deployment, the planned seed remains:

```text
gemma-4-26b-qat-4bit=14,gpt-oss-20b=30
```

Remove the interim `EIGENINFERENCE_QUALITY_CONCURRENCY_OVERCOMMIT_BY_MODEL=gemma-4-26b-qat-4bit=0.15` at that same integrated deployment; this PR supersedes it.

## Test coverage

The current diff contains focused regression coverage for:

- The exact mixed-box postmortem case: provider benchmark 93, Gemma solo rate 14, quality floor 15, Gemma cap 2, and gpt-oss cap 23.
- Kill-switch restoration and model-specific capping without a registration benchmark.
- Whole-box solo gating, owner-slot-only recording, running-decode-only recording, chip-class keying, conservative cross-class medians, seed cold start, and sample floors.
- Shared-pool reconstruction, single-model equivalence, legacy-provider behavior, heterogeneous KV rates, live-used byte totals, rate clamping, cold admission, and real reservation-path double-spend prevention.
- Admission and `ModelCapacitySnapshot` equivalence in token and byte modes.
- Warm-pool separation between static solo rates and load-inclusive service rates.

Readiness regressions added to the final head:

- `TestPooledFirstColdRequestUsesConservativeDefault`: an incoming cold large-KV request uses `max(400,000 B/token default, highest resident rate)` rather than the maximum resident rate alone; public pooled remaining uses the same policy.
- `TestPooledPendingColdRequestKeepsByteAccounting`: already-pending cold work is normalized with the same conservative default policy and cannot force token-mode or optimistic resident-rate accounting for the next request.
- `TestQualityCapSeedBoundsCrossClassTransfer`: an unsampled slow chip class remains capped by the operator seed even when a faster class has enough organic samples.
- `TestResolvedSoloModelTPSFallbackChain`: trusted same-class organic samples still supersede the cold-start seed after reaching the sample floor.
- `TestPooledKnownZeroBudgetRejects`: a single Engine V2 positive-rate/zero-max slot is known-full, while a true legacy slot remains unconstrained.
- `TestPooledZeroBudgetResidentRateStaysSymmetric`: a mixed provider retains the zero-budget resident's reported rate across pending, admission, and capacity; that model rejects even with abundant pooled headroom while its positive-budget co-resident still admits.

Final verification:

- **PASS** focused merged regression lane under `-race`
- **PASS** `go test ./... -race -count=1`
- **PASS** `go vet ./...`
- **PASS** `go build ./cmd/coordinator`
- **PASS** `gofmt -l` on changed Go files and `git diff --check`
- **PASS** all required GitHub checks on the final PR head: Coordinator Tests, Coordinator Lint, Provider Tests, and Console UI Lint & Build
- **NON-BLOCKING INFRA FAILURE** the optional E2E workflow hit the known Qwen3.5 MLX concurrent-batching crash (`broadcast_shapes`: incompatible `(5,1)` / `(20,1)` and `(3,1)` / `(6,1)` shapes). Current `master` at `9b1d3b02` failed the same test with the same MLX fatal error in [run 29045836408](https://github.com/Layr-Labs/d-inference/actions/runs/29045836408); the PR run is [29048151439](https://github.com/Layr-Labs/d-inference/actions/runs/29048151439). This coordinator-only PR does not modify the provider, MLX submodules, or E2E tests.

## Merge and release sequence

This PR is **merge group A**, not a coordinator deployment unit.

1. Merge #524 after its readiness fixes, latest-`master` sync, review threads, and final checks are complete.
2. Prepare and merge the next stacked coordinator PRs in order: #525, then #526.
3. Run the integrated release gates against the complete coordinator and provider set.
4. Publish and validate the complete one-engine v0.7.5 provider release, including full legacy-engine removal.
5. Canary that complete v0.7.5 release and confirm inference, capacity, upgrade, and rollback gates.
6. Only after the provider canary passes, deploy the complete coordinator once.

**Do not partially deploy #524, #525, or #526. Do not deploy the new coordinator before the complete one-engine v0.7.5 provider release has been published, validated, and canaried.**

At the eventual integrated deployment, verify mixed-box Gemma caps, per-chip-class sample counts, pooled-budget rejection reasons, public capacity/admission symmetry, and gpt-oss TTFT/TPS. The quality-cap rollback is `EIGENINFERENCE_QUALITY_CAP_PER_MODEL_TPS=false`; pooled admission requires rolling back the integrated coordinator artifact.

## Review notes

- The cold-model KV-rate, seed-precedence, and Engine V2 known-zero findings are fixed with fails-before-fix regressions and an independent final PASS.
- Current `master`, including #527, is merged at `5e5024f8`; final verification ran on descendant `85817ad2`.
- This PR must merge before the stacked warm/open-pool and version-floor/TTFT work that depends on these registry seams.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/524"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786081379&installation_id=133247490&pr_number=524&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F524&signature=a80c4b1474597fc2f510779c410dac2733236762457724ade96d23a45f97abab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
