### PR TITLE
feat(registry): v2 version floors + tripwire, prefill-honest TTFT (absorbs #453), satisficing utilization band [stacked on per-model caps]

### DIFF
--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -679,8 +679,17 @@ func (s *Server) dispatchOneProvider(
 	// dispatch serves the best-available provider instead of re-rejecting an
 	// over-threshold request the preflight already chose to soft-serve. (Mirrors
 	// queueMaxTTFTMs, which already returns 0 in soft mode.)
-	if !policy.enabled && !policy.prefer && s.ttftHardReject {
-		pr.MaxTTFTMs = float64(ttftDeadline(estimatedPromptTokens).Milliseconds())
+	if !policy.enabled && !policy.prefer {
+		// Advisory public TTFT target — stamped in BOTH gate modes. In hard mode
+		// it also becomes the enforced MaxTTFTMs ceiling; in soft mode MaxTTFTMs
+		// stays 0 (dispatch serves the best-available provider) but the target
+		// still bounds the satisficing band so it can't spread onto an
+		// over-target box. Self-route / prefer-owner routes leave both 0.
+		target := float64(ttftDeadline(estimatedPromptTokens).Milliseconds())
+		pr.TTFTTargetMs = target
+		if s.ttftHardReject {
+			pr.MaxTTFTMs = target
+		}
 	}
 	// Routing v2 W2: soft per-request decode floor (0 = off). Applies to all
 	// routes; it only ranks providers, never rejects.
@@ -3337,8 +3346,14 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 	// TTFT is above the threshold.
 	// Routing v2 (P1 fix): enforce the TTFT ceiling only in HARD mode; soft mode
 	// leaves MaxTTFTMs 0 so dispatch serves the best-available provider.
-	if !policy.enabled && !policy.prefer && s.ttftHardReject {
-		pr.MaxTTFTMs = float64(genericDeadline.Milliseconds())
+	if !policy.enabled && !policy.prefer {
+		// Advisory public TTFT target (see the primary dispatch path): stamped in
+		// both gate modes; only becomes the enforced ceiling in hard mode.
+		target := float64(genericDeadline.Milliseconds())
+		pr.TTFTTargetMs = target
+		if s.ttftHardReject {
+			pr.MaxTTFTMs = target
+		}
 	}
 	// Routing v2 W2: soft per-request decode floor (0 = off).
 	pr.MinDecodeTPS = s.minDecodeTPS

--- a/coordinator/api/dispatch.go
+++ b/coordinator/api/dispatch.go
@@ -217,6 +217,18 @@ func queueMaxTTFTMs(policy selfRoutePolicy, deadline time.Duration, hardReject b
 	return float64(deadline.Milliseconds())
 }
 
+// queueTTFTTargetMs returns the ADVISORY public TTFT target for queued requests.
+// Unlike queueMaxTTFTMs it is stamped in BOTH gate modes (it never drives hard
+// scheduler rejection); it only bounds the satisficing band so a soft-mode
+// queue drain can't spread onto an over-target box. Self-route / prefer-owner
+// routes get 0 (no public target).
+func queueTTFTTargetMs(policy selfRoutePolicy, deadline time.Duration) float64 {
+	if policy.enabled || policy.prefer {
+		return 0
+	}
+	return float64(deadline.Milliseconds())
+}
+
 // routingOutcomeKey returns a stable requestID + attempt identifier used for
 // telemetry updates. It prefers the explicit dispatch requestID, falling back
 // to the pending request's ID when the dispatch requestID has not been set yet.
@@ -772,6 +784,7 @@ func (d *dispatchState) dispatchPrimary() dispatchOutcome {
 			OwnerAccountID:         d.policy.ownerAccountID,
 			FreeSelfRoute:          d.policy.enabled,
 			MaxTTFTMs:              queueMaxTTFTMs(d.policy, d.deadline, d.s.ttftHardReject),
+			TTFTTargetMs:           queueTTFTTargetMs(d.policy, d.deadline),
 			MinDecodeTPS:           d.s.minDecodeTPS,
 			AcceptedCh:             make(chan struct{}, 1),
 			ChunkCh:                make(chan string, chunkBufferSize),

--- a/coordinator/api/inference_admission.go
+++ b/coordinator/api/inference_admission.go
@@ -383,6 +383,14 @@ func (s *Server) runInferenceAdmission(w http.ResponseWriter, r *http.Request, p
 		}
 	}
 	if ttftTooSlow(bestTTFT, hasTTFT, ttftThreshold) {
+		// Prefill-fallback shadow: live routing still runs on the legacy fallback
+		// here, but measure whether the recalibrated fallback would have cleared the
+		// SAME deadline — i.e. the projected ttft_429 recovery the enforce flip
+		// delivers. Extra scan paid only in shadow mode.
+		if registry.PrefillFallbackModeValue() == registry.PrefillFallbackShadow {
+			recalTTFT, recalHas := s.registry.QuickCapacityCheckRecalibratedTTFT(model, p.estimatedPromptTokens, p.requestedMaxTokens, registry.RequestTraits{HasTools: p.hasTools}, p.requiresVision, p.allowedProviderSerials...)
+			s.emitPrefillFallbackShadow(model, !ttftTooSlow(recalTTFT, recalHas, ttftThreshold))
+		}
 		if !s.ttftHardReject {
 			// Soft TTFT gate (default): a provider passed every routing and
 			// capacity gate, and pr.MaxTTFTMs is left 0 in soft mode, so the

--- a/coordinator/api/inference_admission.go
+++ b/coordinator/api/inference_admission.go
@@ -389,7 +389,10 @@ func (s *Server) runInferenceAdmission(w http.ResponseWriter, r *http.Request, p
 		// delivers. Extra scan paid only in shadow mode.
 		if registry.PrefillFallbackModeValue() == registry.PrefillFallbackShadow {
 			recalTTFT, recalHas := s.registry.QuickCapacityCheckRecalibratedTTFT(model, p.estimatedPromptTokens, p.requestedMaxTokens, registry.RequestTraits{HasTools: p.hasTools}, p.requiresVision, p.allowedProviderSerials...)
-			s.emitPrefillFallbackShadow(model, !ttftTooSlow(recalTTFT, recalHas, ttftThreshold))
+			// gate = whether this legacy ttft_too_slow actually sheds: hard gate =
+			// a real 429 the enforce flip would recover; soft gate (default) =
+			// the request is served anyway, so it is a near-miss, not a recovery.
+			s.emitPrefillFallbackShadow(model, !ttftTooSlow(recalTTFT, recalHas, ttftThreshold), s.ttftHardReject)
 		}
 		if !s.ttftHardReject {
 			// Soft TTFT gate (default): a provider passed every routing and

--- a/coordinator/api/prefill_fallback_metrics.go
+++ b/coordinator/api/prefill_fallback_metrics.go
@@ -1,0 +1,41 @@
+package api
+
+// Prefill-fallback shadow telemetry (DogStatsD + the in-process /v1/admin/metrics
+// registry). Pure observability — emitted only when
+// EIGENINFERENCE_PREFILL_FALLBACK_MODE=shadow, where live routing is unchanged
+// (still on the legacy ~280 tok/s fallback) and we measure how many of today's
+// long-prompt ttft_429s the recalibrated fallback (~6500 tok/s) WOULD recover
+// before flipping enforce.
+//
+//   - routing.prefill_fallback{decision:would_admit} — the live (legacy) estimate
+//     sheds this request on TTFT, but the recalibrated estimate clears the same
+//     deadline: a 429 the enforce flip would convert to a served request.
+//   - routing.prefill_fallback{decision:would_shed} — even the recalibrated
+//     estimate is over the deadline (genuinely too slow; enforce would not help).
+//
+// The caller invokes this only for requests the live estimate already flagged
+// ttft_too_slow, so the would_admit / would_shed split is exactly the projected
+// recovery vs. residual.
+func (s *Server) emitPrefillFallbackShadow(model string, recalibratedAdmits bool) {
+	if s == nil {
+		return
+	}
+	decision := "would_shed"
+	if recalibratedAdmits {
+		decision = "would_admit"
+	}
+	s.ddIncr("routing.prefill_fallback", []string{"model:" + model, "decision:" + decision, "mode:shadow"})
+	if s.metrics != nil {
+		s.metrics.IncCounter("routing.prefill_fallback",
+			MetricLabel{Name: "model", Value: model},
+			MetricLabel{Name: "decision", Value: decision},
+			MetricLabel{Name: "mode", Value: "shadow"},
+		)
+	}
+	if s.logger != nil {
+		s.logger.Debug("prefill fallback shadow",
+			"model", model,
+			"decision", decision,
+		)
+	}
+}

--- a/coordinator/api/prefill_fallback_metrics.go
+++ b/coordinator/api/prefill_fallback_metrics.go
@@ -14,9 +14,17 @@ package api
 //     estimate is over the deadline (genuinely too slow; enforce would not help).
 //
 // The caller invokes this only for requests the live estimate already flagged
-// ttft_too_slow, so the would_admit / would_shed split is exactly the projected
-// recovery vs. residual.
-func (s *Server) emitPrefillFallbackShadow(model string, recalibratedAdmits bool) {
+// ttft_too_slow. The extra `gate` tag records whether that flag actually sheds:
+//
+//   - gate:hard — the hard TTFT gate is on, so a legacy ttft_too_slow becomes a
+//     real 429. Here would_admit is the genuine projected ttft_429 RECOVERY the
+//     enforce flip delivers.
+//   - gate:soft — the default soft gate serves the request anyway (no 429), so a
+//     would_admit here is a soft near-miss the enforce flip would stop treating
+//     as a TTFT miss (warm-pool signal), NOT a recovered shed. Tagging it
+//     separately keeps the recovery signal (gate:hard) from being inflated by
+//     already-served traffic in the default deployment (Codex review).
+func (s *Server) emitPrefillFallbackShadow(model string, recalibratedAdmits, hardGate bool) {
 	if s == nil {
 		return
 	}
@@ -24,11 +32,16 @@ func (s *Server) emitPrefillFallbackShadow(model string, recalibratedAdmits bool
 	if recalibratedAdmits {
 		decision = "would_admit"
 	}
-	s.ddIncr("routing.prefill_fallback", []string{"model:" + model, "decision:" + decision, "mode:shadow"})
+	gate := "soft"
+	if hardGate {
+		gate = "hard"
+	}
+	s.ddIncr("routing.prefill_fallback", []string{"model:" + model, "decision:" + decision, "gate:" + gate, "mode:shadow"})
 	if s.metrics != nil {
 		s.metrics.IncCounter("routing.prefill_fallback",
 			MetricLabel{Name: "model", Value: model},
 			MetricLabel{Name: "decision", Value: decision},
+			MetricLabel{Name: "gate", Value: gate},
 			MetricLabel{Name: "mode", Value: "shadow"},
 		)
 	}
@@ -36,6 +49,7 @@ func (s *Server) emitPrefillFallbackShadow(model string, recalibratedAdmits bool
 		s.logger.Debug("prefill fallback shadow",
 			"model", model,
 			"decision", decision,
+			"gate", gate,
 		)
 	}
 }

--- a/coordinator/api/prefill_fallback_metrics_test.go
+++ b/coordinator/api/prefill_fallback_metrics_test.go
@@ -1,0 +1,26 @@
+package api
+
+import "testing"
+
+// TestEmitPrefillFallbackShadowWouldAdmit asserts the shadow counter is tagged
+// would_admit when the recalibrated fallback clears the TTFT deadline a live
+// (legacy) estimate sheds — the projected ttft_429 recovery the enforce flip buys.
+func TestEmitPrefillFallbackShadowWouldAdmit(t *testing.T) {
+	srv := newTTFTTestServer(t)
+	srv.emitPrefillFallbackShadow("gpt-oss-20b", true)
+	counters := srv.metrics.Snapshot().Counters
+	if !counterMatches(counters, "routing.prefill_fallback", "decision=would_admit", "model=gpt-oss-20b", "mode=shadow") {
+		t.Fatalf("missing routing.prefill_fallback{would_admit}; counters=%v", counters)
+	}
+}
+
+// TestEmitPrefillFallbackShadowWouldShed covers the residual: even recalibrated,
+// the request is over the deadline (enforce would not recover it).
+func TestEmitPrefillFallbackShadowWouldShed(t *testing.T) {
+	srv := newTTFTTestServer(t)
+	srv.emitPrefillFallbackShadow("gpt-oss-20b", false)
+	counters := srv.metrics.Snapshot().Counters
+	if !counterMatches(counters, "routing.prefill_fallback", "decision=would_shed", "model=gpt-oss-20b", "mode=shadow") {
+		t.Fatalf("missing routing.prefill_fallback{would_shed}; counters=%v", counters)
+	}
+}

--- a/coordinator/api/prefill_fallback_metrics_test.go
+++ b/coordinator/api/prefill_fallback_metrics_test.go
@@ -7,7 +7,7 @@ import "testing"
 // (legacy) estimate sheds — the projected ttft_429 recovery the enforce flip buys.
 func TestEmitPrefillFallbackShadowWouldAdmit(t *testing.T) {
 	srv := newTTFTTestServer(t)
-	srv.emitPrefillFallbackShadow("gpt-oss-20b", true)
+	srv.emitPrefillFallbackShadow("gpt-oss-20b", true, true)
 	counters := srv.metrics.Snapshot().Counters
 	if !counterMatches(counters, "routing.prefill_fallback", "decision=would_admit", "model=gpt-oss-20b", "mode=shadow") {
 		t.Fatalf("missing routing.prefill_fallback{would_admit}; counters=%v", counters)
@@ -18,9 +18,36 @@ func TestEmitPrefillFallbackShadowWouldAdmit(t *testing.T) {
 // the request is over the deadline (enforce would not recover it).
 func TestEmitPrefillFallbackShadowWouldShed(t *testing.T) {
 	srv := newTTFTTestServer(t)
-	srv.emitPrefillFallbackShadow("gpt-oss-20b", false)
+	srv.emitPrefillFallbackShadow("gpt-oss-20b", false, true)
 	counters := srv.metrics.Snapshot().Counters
 	if !counterMatches(counters, "routing.prefill_fallback", "decision=would_shed", "model=gpt-oss-20b", "mode=shadow") {
 		t.Fatalf("missing routing.prefill_fallback{would_shed}; counters=%v", counters)
+	}
+}
+
+// TestEmitPrefillFallbackShadowGateTag is the regression for the Codex finding:
+// under the default SOFT gate a legacy ttft_too_slow is served anyway (no 429),
+// so a would_admit there is a near-miss, not a recovered shed. The gate tag must
+// distinguish the two so the recovery signal (gate:hard) is not inflated by
+// already-served soft traffic. Fails without the gate tag (the pre-fix emitter
+// tagged both identically).
+func TestEmitPrefillFallbackShadowGateTag(t *testing.T) {
+	srv := newTTFTTestServer(t)
+	// Soft gate: a would_admit near-miss must carry gate=soft, NOT gate=hard.
+	srv.emitPrefillFallbackShadow("gpt-oss-20b", true, false)
+	counters := srv.metrics.Snapshot().Counters
+	if !counterMatches(counters, "routing.prefill_fallback", "decision=would_admit", "gate=soft", "mode=shadow") {
+		t.Fatalf("missing soft-gate near-miss tag routing.prefill_fallback{would_admit,gate=soft}; counters=%v", counters)
+	}
+	if counterMatches(counters, "routing.prefill_fallback", "decision=would_admit", "gate=hard") {
+		t.Fatalf("soft-gate near-miss must not be counted as a hard-gate recovery; counters=%v", counters)
+	}
+
+	// Hard gate: the genuine projected ttft_429 recovery carries gate=hard.
+	srv2 := newTTFTTestServer(t)
+	srv2.emitPrefillFallbackShadow("gpt-oss-20b", true, true)
+	counters2 := srv2.metrics.Snapshot().Counters
+	if !counterMatches(counters2, "routing.prefill_fallback", "decision=would_admit", "gate=hard", "mode=shadow") {
+		t.Fatalf("missing hard-gate recovery tag routing.prefill_fallback{would_admit,gate=hard}; counters=%v", counters2)
 	}
 }

--- a/coordinator/api/server.go
+++ b/coordinator/api/server.go
@@ -702,6 +702,12 @@ func NewServer(reg *registry.Registry, st store.Store, cfg ServerConfig, logger 
 	s.registerDefaultGauges()
 	s.routes()
 
+	// v2 silent-legacy-fallback tripwire: the registry's version-keyed heartbeat
+	// clamp (registry/v2_capacity_clamp.go) reports every corrected slot here so
+	// the Datadog counter fires. Inert until EIGENINFERENCE_V2_VERSION_FLOOR is
+	// set.
+	reg.SetV2ClampTripwireHook(s.emitV2ClampTripwire)
+
 	// Load stored provider records into a lookup table for matching
 	// reconnecting providers to their persisted state.
 	s.storedProviders = reg.LoadStoredProviders()

--- a/coordinator/api/v2_clamp_metrics.go
+++ b/coordinator/api/v2_clamp_metrics.go
@@ -1,0 +1,31 @@
+package api
+
+// v2 silent-legacy-fallback tripwire telemetry (DogStatsD + the in-process
+// /v1/admin/metrics registry). The registry's version-keyed heartbeat clamp
+// (registry/v2_capacity_clamp.go) fires this hook whenever a provider at or
+// above the EIGENINFERENCE_V2_VERSION_FLOOR heartbeats a chat-slot
+// max_concurrency above the v2 ceiling — on a >=floor box that report means
+// the silent-legacy-fallback bug (2026-07-06 gemma postmortem) has resurfaced,
+// so the counter is a PERMANENT audit of the v0.7.5 fail-loud promise, not a
+// transient rollout metric. Tags are low-cardinality (model + binary version);
+// the provider id is in the registry's ERROR log, never a tag.
+func (s *Server) emitV2ClampTripwire(providerID, version, model string, reported int) {
+	if s == nil {
+		return
+	}
+	s.ddIncr("provider.v2_concurrency_tripwire", []string{"model:" + model, "version:" + version})
+	if s.metrics != nil {
+		s.metrics.IncCounter("provider.v2_concurrency_tripwire",
+			MetricLabel{Name: "model", Value: model},
+			MetricLabel{Name: "version", Value: version},
+		)
+	}
+	if s.logger != nil {
+		s.logger.Error("v2 max_concurrency tripwire fired — silent legacy fallback suspected",
+			"provider_id", providerID,
+			"provider_version", version,
+			"model", model,
+			"reported_max_concurrency", reported,
+		)
+	}
+}

--- a/coordinator/cmd/coordinator/main.go
+++ b/coordinator/cmd/coordinator/main.go
@@ -201,6 +201,51 @@ func main() {
 		"decode_floor_tps", cfg.RegistryCfg.WarmPool.DecodeFloorTPS,
 	)
 
+	// Mixed-fleet migration defense (v0.7.5 rollout; registry/v2_capacity_clamp.go
+	// and registry/model_version_floors.go). Both are inert at their defaults:
+	//
+	//   - EIGENINFERENCE_V2_VERSION_FLOOR (version string, default empty = off):
+	//     providers at/above this binary version are engine-v2-only by
+	//     construction, so a heartbeat chat-slot max_concurrency above the v2
+	//     ceiling means the silent-legacy-fallback bug resurfaced — the slot is
+	//     clamped, logged at ERROR, and counted on the
+	//     provider.v2_concurrency_tripwire Datadog tripwire. Below-floor
+	//     providers keep the legacy 24-ceiling clamp exactly.
+	//   - EIGENINFERENCE_V2_MAX_CONCURRENCY_CEILING (int, default 4): the v2
+	//     engine's box-wide concurrency cap (productionMaxConcurrentRequests).
+	//   - EIGENINFERENCE_MODEL_VERSION_FLOORS ("pattern=version" CSV, default
+	//     empty = off): per-model routing floor — a model whose resolved build id
+	//     contains a pattern (case-insensitive substring, same matching as
+	//     EIGENINFERENCE_DEDICATED_MODELS) routes and pre-warms ONLY onto
+	//     providers at/above the paired version; empty-version providers fail
+	//     every floor. During the v0.7.5 migration this keeps gemma off boxes
+	//     that would legacy-serve it; retire the env after fleet convergence
+	//     (gauge adoption on ONLINE boxes, not seen-3d).
+	v2Floor := strings.TrimSpace(os.Getenv("EIGENINFERENCE_V2_VERSION_FLOOR"))
+	v2Ceiling := 4
+	if v := os.Getenv("EIGENINFERENCE_V2_MAX_CONCURRENCY_CEILING"); v != "" {
+		if n, err := strconv.Atoi(strings.TrimSpace(v)); err == nil && n >= 1 {
+			v2Ceiling = n
+		} else {
+			logger.Warn("invalid EIGENINFERENCE_V2_MAX_CONCURRENCY_CEILING; keeping default 4", "value", v)
+		}
+	}
+	registry.SetV2ConcurrencyClamp(v2Floor, v2Ceiling)
+	if v2Floor != "" {
+		logger.Warn("v2 heartbeat concurrency clamp ENABLED (EIGENINFERENCE_V2_VERSION_FLOOR)",
+			"version_floor", v2Floor, "ceiling", v2Ceiling)
+	}
+	if v := os.Getenv("EIGENINFERENCE_MODEL_VERSION_FLOORS"); strings.TrimSpace(v) != "" {
+		floors := registry.ParseModelVersionFloors(v)
+		reg.SetModelVersionFloors(floors)
+		if len(floors) > 0 {
+			logger.Warn("per-model provider-version routing floors ENABLED (EIGENINFERENCE_MODEL_VERSION_FLOORS)",
+				"floors", registry.FormatModelVersionFloors(floors))
+		} else {
+			logger.Warn("EIGENINFERENCE_MODEL_VERSION_FLOORS set but no valid entries parsed; floors disabled", "value", v)
+		}
+	}
+
 	reg.ConfigureCacheAffinity(cfg.RegistryCfg.CacheAffinity)
 	cacheAffinityCfg := reg.CacheAffinityConfigSnapshot()
 	logger.Info("cache affinity configured", "ttl", cacheAffinityCfg.TTL.String(), "bonus_ms", cacheAffinityCfg.BonusMs, "enabled", cacheAffinityCfg.BonusMs > 0)

--- a/coordinator/cmd/coordinator/main.go
+++ b/coordinator/cmd/coordinator/main.go
@@ -390,6 +390,52 @@ func main() {
 		}
 	}
 
+	// Routing: prefill-fallback recalibration (coordinator-side, ship-now fix for
+	// the live ~41% long-prompt ttft_429 over-shed). The mode is behavior-neutral
+	// at its default (off); the ceiling raise is also behavior-neutral on today's
+	// fleet (0 of 313 warm slots report observed_prefill_tps, so nothing is being
+	// zeroed/capped near the old 5000 ceiling).
+	//
+	//   - EIGENINFERENCE_PREFILL_FALLBACK_MODE (off|shadow|enforce, default off):
+	//     off => resolvePrefillTPS keeps the legacy sqrt(bandwidth)×ratio fallback
+	//     (~280 tok/s); shadow => routing unchanged but the preflight emits
+	//     routing.prefill_fallback{would_admit|would_shed} so the projected
+	//     ttft_429 recovery is measured BEFORE enforcing; enforce => routing uses
+	//     the data-derived fallback (~6500 tok/s, the measured prefill p50) when no
+	//     provider measurement exists.
+	//   - EIGENINFERENCE_PREFILL_FALLBACK_TPS (float, default 6500): the fallback
+	//     value, the measured empirical idle prefill p50.
+	//   - EIGENINFERENCE_MAX_PREFILL_TPS (float, default 20000): the prefill sanity
+	//     ceiling, raised above the measured p90 (17,707) so a correctly-measured
+	//     value from a fixed provider is neither zeroed at ingest nor capped in
+	//     routing. Tunable down for instant rollback.
+	if v := os.Getenv("EIGENINFERENCE_MAX_PREFILL_TPS"); v != "" {
+		if ceil, err := strconv.ParseFloat(v, 64); err == nil && ceil > 0 {
+			registry.SetMaxPrefillTPS(ceil)
+			logger.Info("max prefill TPS override via EIGENINFERENCE_MAX_PREFILL_TPS", "tps", ceil)
+		} else {
+			logger.Warn("invalid EIGENINFERENCE_MAX_PREFILL_TPS; keeping default", "value", v, "default", registry.MaxPrefillTPS())
+		}
+	}
+	if v := os.Getenv("EIGENINFERENCE_PREFILL_FALLBACK_TPS"); v != "" {
+		if tps, err := strconv.ParseFloat(v, 64); err == nil && tps > 0 {
+			registry.SetPrefillFallbackTPS(tps)
+			logger.Info("prefill fallback TPS override via EIGENINFERENCE_PREFILL_FALLBACK_TPS", "tps", tps)
+		} else {
+			logger.Warn("invalid EIGENINFERENCE_PREFILL_FALLBACK_TPS; keeping default", "value", v, "default", registry.PrefillFallbackTPS())
+		}
+	}
+	if v := os.Getenv("EIGENINFERENCE_PREFILL_FALLBACK_MODE"); v != "" {
+		mode := registry.ParsePrefillFallbackMode(v)
+		registry.SetPrefillFallbackMode(mode)
+		if mode == registry.PrefillFallbackOff {
+			logger.Info("prefill-fallback recalibration OFF (EIGENINFERENCE_PREFILL_FALLBACK_MODE)", "value", v)
+		} else {
+			logger.Warn("prefill-fallback recalibration ENABLED (EIGENINFERENCE_PREFILL_FALLBACK_MODE)",
+				"mode", mode.String(), "fallback_tps", registry.PrefillFallbackTPS(), "max_prefill_tps", registry.MaxPrefillTPS())
+		}
+	}
+
 	// Routing (Phase-0 TTFT-contention, shadow + measurement slice). All three
 	// knobs are behavior-neutral at their defaults:
 	//

--- a/coordinator/registry/concurrency_cap.go
+++ b/coordinator/registry/concurrency_cap.go
@@ -136,8 +136,12 @@ func (r *Registry) QualityCapOvercommit() float64 {
 // parseModelFloatMap parses the "model=value,..." CSV form (mirroring
 // envModelIntMap for EIGENINFERENCE_WARM_POOL_MIN_WARM, with float values).
 // Keys are lowercased so lookups on resolved build ids match
-// case-insensitively. Malformed entries and non-positive values are skipped;
-// an empty or all-invalid input yields nil (no entries). Shared by the
+// case-insensitively. Malformed, non-positive, and non-finite values are all
+// skipped — strconv.ParseFloat happily yields NaN and ±Inf ("m=NaN" passes a
+// naive v <= 0 filter because NaN comparisons are always false), and either
+// one flows into int(math.Ceil(...)) / qualityConcurrency as an
+// implementation-defined integer, silently strangling the model to cap 1.
+// An empty or all-invalid input yields nil (no entries). Shared by the
 // per-model overcommit overrides (qualityCapOvercommitByModelEnv) and the
 // solo-TPS seed (modelSoloTPSSeedEnv).
 func parseModelFloatMap(raw string) map[string]float64 {
@@ -160,7 +164,7 @@ func parseModelFloatMap(raw string) map[string]float64 {
 			continue
 		}
 		v, err := strconv.ParseFloat(strings.TrimSpace(value), 64)
-		if err != nil || v <= 0 {
+		if err != nil || math.IsNaN(v) || math.IsInf(v, 0) || v <= 0 {
 			continue
 		}
 		out[model] = v

--- a/coordinator/registry/concurrency_cap.go
+++ b/coordinator/registry/concurrency_cap.go
@@ -200,10 +200,12 @@ type soloModelTPS struct {
 // resolvedSoloModelTPSLocked resolves the static solo decode rate the quality
 // cap should use for (p, model). Fallback chain, most- to least-specific:
 //
-//  1. per-(model, chip) solo median — gated samples only (solo_tps.go) — once
-//     it has ≥ qualityCapSoloMinSamples samples;
-//  2. model-wide solo median pooled across chip families (conservative
-//     cross-chip transfer), same sample floor;
+//  1. per-(model, chip CLASS) solo median — gated samples only (solo_tps.go),
+//     keyed by chipClassKey (family+tier) so a fast tier never lends its rate
+//     to a slow one — once it has ≥ qualityCapSoloMinSamples samples;
+//  2. the MIN of the per-class solo medians across chip classes (conservative
+//     cross-class transfer, SoloMedianAllChips), same total-sample floor — can
+//     never exceed the slowest class's rate, so it never over-caps a slow box;
 //  3. the modelSoloTPSSeedEnv seed (cold-start answer — the TPS registry is
 //     in-memory and restart-wiped);
 //  4. the provider-level resolvedDecodeTPS(p) — exactly the pre-per-model
@@ -219,7 +221,7 @@ type soloModelTPS struct {
 // r.mu and p.mu.
 func (r *Registry) resolvedSoloModelTPSLocked(p *Provider, model string) soloModelTPS {
 	if qualityCapPerModelTPS {
-		if tps, n := r.tpsRegistry.SoloMedian(model, p.Hardware.ChipFamily); n >= qualityCapSoloMinSamples && tps > 0 {
+		if tps, n := r.tpsRegistry.SoloMedian(model, chipClassKey(p.Hardware)); n >= qualityCapSoloMinSamples && tps > 0 {
 			return soloModelTPS{tps: tps, perModel: true}
 		}
 		if tps, n := r.tpsRegistry.SoloMedianAllChips(model); n >= qualityCapSoloMinSamples && tps > 0 {

--- a/coordinator/registry/concurrency_cap.go
+++ b/coordinator/registry/concurrency_cap.go
@@ -46,11 +46,44 @@ const defaultQualityCapOvercommit = 1.2
 // the global overcommit.
 const qualityCapOvercommitByModelEnv = env.EnvPrefix + "_QUALITY_CONCURRENCY_OVERCOMMIT_BY_MODEL"
 
+// Per-model solo-TPS source for the quality cap (the postmortem layer-6 root
+// fix — see resolvedSoloModelTPSLocked):
+//
+//   - qualityCapPerModelTPSEnv is the kill switch (bool, default TRUE). false
+//     restores the provider-level resolvedDecodeTPS(p) rate at every quality-cap
+//     site exactly.
+//   - qualityCapSoloMinSamplesEnv is the minimum solo sample count (per chip,
+//     or pooled across chips) before a solo median is trusted (int, default 5).
+//   - modelSoloTPSSeedEnv is the cold-start seed, a "model=tok/s" CSV keyed by
+//     concrete resolved build id (matched case-insensitively), e.g.
+//     "gemma-4-26b-qat-4bit=14,gpt-oss-20b=30". The TPS registry is in-memory
+//     and restart-wiped, so the seed is the answer until gated solo samples
+//     accumulate (e.g. while a model warms behind a shed).
+const (
+	qualityCapPerModelTPSEnv    = env.EnvPrefix + "_QUALITY_CAP_PER_MODEL_TPS"
+	qualityCapSoloMinSamplesEnv = env.EnvPrefix + "_QUALITY_CAP_SOLO_MIN_SAMPLES"
+	modelSoloTPSSeedEnv         = env.EnvPrefix + "_MODEL_SOLO_TPS_SEED"
+)
+
+// defaultQualityCapSoloMinSamples is the solo-median trust floor when
+// EIGENINFERENCE_QUALITY_CAP_SOLO_MIN_SAMPLES is unset.
+const defaultQualityCapSoloMinSamples = 5
+
 // qualityCapOvercommitByModel holds the parsed per-model overrides. Like the
 // package's other startup-configured routing knobs (prefillToDecodeRatio,
 // ttftOccupancyAlpha), it is written once by SetQualityConcurrencyCap before
 // the coordinator serves and only read on routing paths thereafter.
 var qualityCapOvercommitByModel map[string]float64
+
+// qualityCapPerModelTPS / qualityCapSoloMinSamples / modelSoloTPSSeed are the
+// parsed per-model solo-TPS knobs. Same lifecycle as
+// qualityCapOvercommitByModel: written once by SetQualityConcurrencyCap before
+// serving, read-only on routing paths.
+var (
+	qualityCapPerModelTPS    = true
+	qualityCapSoloMinSamples = defaultQualityCapSoloMinSamples
+	modelSoloTPSSeed         map[string]float64
+)
 
 // SetQualityConcurrencyCap configures the per-provider quality-concurrency
 // admission cap. enabled=false leaves the legacy flat cap unchanged. floorTPS
@@ -76,7 +109,13 @@ func (r *Registry) SetQualityConcurrencyCap(enabled bool, overcommit, floorTPS f
 	if fallback < 1 {
 		fallback = 1
 	}
-	qualityCapOvercommitByModel = parseQualityCapOvercommitByModel(os.Getenv(qualityCapOvercommitByModelEnv))
+	qualityCapOvercommitByModel = parseModelFloatMap(os.Getenv(qualityCapOvercommitByModelEnv))
+	qualityCapPerModelTPS = env.EnvBool(qualityCapPerModelTPSEnv, true)
+	qualityCapSoloMinSamples = env.EnvInt(qualityCapSoloMinSamplesEnv, defaultQualityCapSoloMinSamples)
+	if qualityCapSoloMinSamples < 1 {
+		qualityCapSoloMinSamples = 1
+	}
+	modelSoloTPSSeed = parseModelFloatMap(os.Getenv(modelSoloTPSSeedEnv))
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.qualityCapEnabled = enabled
@@ -94,11 +133,14 @@ func (r *Registry) QualityCapOvercommit() float64 {
 	return r.qualityCapOvercommit
 }
 
-// parseQualityCapOvercommitByModel parses the "model=overcommit,..." CSV form
-// (mirroring envModelIntMap for EIGENINFERENCE_WARM_POOL_MIN_WARM, with float
-// values). Malformed entries and non-positive values are skipped; an empty or
-// all-invalid input yields nil (no overrides).
-func parseQualityCapOvercommitByModel(raw string) map[string]float64 {
+// parseModelFloatMap parses the "model=value,..." CSV form (mirroring
+// envModelIntMap for EIGENINFERENCE_WARM_POOL_MIN_WARM, with float values).
+// Keys are lowercased so lookups on resolved build ids match
+// case-insensitively. Malformed entries and non-positive values are skipped;
+// an empty or all-invalid input yields nil (no entries). Shared by the
+// per-model overcommit overrides (qualityCapOvercommitByModelEnv) and the
+// solo-TPS seed (modelSoloTPSSeedEnv).
+func parseModelFloatMap(raw string) map[string]float64 {
 	raw = strings.TrimSpace(raw)
 	if raw == "" {
 		return nil
@@ -139,17 +181,83 @@ func (r *Registry) qualityCapOvercommitForModelLocked(model string) float64 {
 	return r.qualityCapOvercommit
 }
 
+// soloModelTPS is a static single-stream decode rate for a (provider, model)
+// pair plus its provenance. perModel is true when the rate came from a
+// model-specific source — a gated solo median or the seed env — which is
+// trustworthy for capping even when the provider never reported a registration
+// benchmark; false means the rate is the provider-level resolvedDecodeTPS
+// chain (registration benchmark, or the model-agnostic sqrt-bandwidth proxy
+// that only dedicated models may be capped from).
+type soloModelTPS struct {
+	tps      float64
+	perModel bool
+}
+
+// resolvedSoloModelTPSLocked resolves the static solo decode rate the quality
+// cap should use for (p, model). Fallback chain, most- to least-specific:
+//
+//  1. per-(model, chip) solo median — gated samples only (solo_tps.go) — once
+//     it has ≥ qualityCapSoloMinSamples samples;
+//  2. model-wide solo median pooled across chip families (conservative
+//     cross-chip transfer), same sample floor;
+//  3. the modelSoloTPSSeedEnv seed (cold-start answer — the TPS registry is
+//     in-memory and restart-wiped);
+//  4. the provider-level resolvedDecodeTPS(p) — exactly the pre-per-model
+//     behavior, including its sqrt-bandwidth fallback semantics.
+//
+// The rate is deliberately STATIC (never an under-load EWMA): an observed rate
+// collapses under the very overload the cap exists to prevent, which would
+// drive the cap to 1 in a feedback loop. Solo medians preserve that property
+// because ingest is gated on a fully uncontended box.
+//
+// The qualityCapPerModelTPSEnv kill switch (false) short-circuits to (4),
+// restoring resolvedDecodeTPS(p) at every wired site exactly. Caller holds
+// r.mu and p.mu.
+func (r *Registry) resolvedSoloModelTPSLocked(p *Provider, model string) soloModelTPS {
+	if qualityCapPerModelTPS {
+		if tps, n := r.tpsRegistry.SoloMedian(model, p.Hardware.ChipFamily); n >= qualityCapSoloMinSamples && tps > 0 {
+			return soloModelTPS{tps: tps, perModel: true}
+		}
+		if tps, n := r.tpsRegistry.SoloMedianAllChips(model); n >= qualityCapSoloMinSamples && tps > 0 {
+			return soloModelTPS{tps: tps, perModel: true}
+		}
+		if tps, ok := modelSoloTPSSeed[strings.ToLower(model)]; ok {
+			return soloModelTPS{tps: tps, perModel: true}
+		}
+	}
+	return soloModelTPS{tps: resolvedDecodeTPS(p), perModel: false}
+}
+
 // effectiveMaxConcurrencyForModelLocked returns the per-provider admission
+// concurrency cap for model from an explicit provider-level static rate
+// (resolvedDecodeTPS). Kept for callers/tests that already resolved the rate;
+// production admission paths use effectiveMaxConcurrencyForModelResolvedLocked
+// so the cap consumes the per-model solo rate. Caller holds r.mu and p.mu.
+func (r *Registry) effectiveMaxConcurrencyForModelLocked(p *Provider, model string, staticDecodeTPS float64) int {
+	return r.effectiveMaxConcurrencyForModelRateLocked(p, model, soloModelTPS{tps: staticDecodeTPS})
+}
+
+// effectiveMaxConcurrencyForModelResolvedLocked is the per-model admission cap
+// with the static solo rate resolved internally (resolvedSoloModelTPSLocked).
+// This is what fixes the postmortem layer-6 failure: a mixed box benchmarked
+// on gpt-oss (58–93 tok/s) no longer lends gemma its provider-level rate — the
+// gemma cap is computed from gemma's own solo median (10–18 tok/s → cap 1–2).
+// Caller holds r.mu and p.mu.
+func (r *Registry) effectiveMaxConcurrencyForModelResolvedLocked(p *Provider, model string) int {
+	return r.effectiveMaxConcurrencyForModelRateLocked(p, model, r.resolvedSoloModelTPSLocked(p, model))
+}
+
+// effectiveMaxConcurrencyForModelRateLocked returns the per-provider admission
 // concurrency cap for model: the MINIMUM of the legacy cap
 // (p.maxConcurrencyForModelLocked — a provider-reported per-slot MaxConcurrency
 // if set, else the flat fallback) and quality_concurrency × overcommit. Taking
 // the min means a provider that self-reports a TIGHTER cap still binds (it knows
 // its backend best), while a provider that reports a looser cap — or none — is
-// still held to the quality bar, so neither path can over-admit. staticDecodeTPS
-// must be the provider's single-stream (static) decode rate for the model
-// (resolvedDecodeTPS), not the observed-under-load value (which collapses under
-// the overload this cap exists to prevent). Caller holds r.mu and p.mu.
-func (r *Registry) effectiveMaxConcurrencyForModelLocked(p *Provider, model string, staticDecodeTPS float64) int {
+// still held to the quality bar, so neither path can over-admit. rate must be a
+// single-stream (static) decode rate for the model, not the observed-under-load
+// value (which collapses under the overload this cap exists to prevent).
+// Caller holds r.mu and p.mu.
+func (r *Registry) effectiveMaxConcurrencyForModelRateLocked(p *Provider, model string, rate soloModelTPS) int {
 	base := p.maxConcurrencyForModelLocked(model)
 	if !r.qualityCapEnabled {
 		return base
@@ -161,13 +269,16 @@ func (r *Registry) effectiveMaxConcurrencyForModelLocked(p *Provider, model stri
 	// a fast non-dedicated model from it could shed healthy traffic. Only cap from
 	// the bandwidth fallback for DEDICATED models, which are known-slow and urgently
 	// need it; a non-dedicated model without a real benchmark keeps the legacy flat
-	// cap until its provider reports decode_tps.
-	if p.DecodeTPS <= 0 {
+	// cap until its provider reports decode_tps. A PER-MODEL rate (solo median or
+	// seed — rate.perModel) is model-specific by construction, so the guard does
+	// not apply to it: those models are capped even without a registration
+	// benchmark.
+	if p.DecodeTPS <= 0 && !rate.perModel {
 		if _, dedicated := r.dedicatedPatternForLocked(model); !dedicated {
 			return base
 		}
 	}
-	qc := qualityConcurrency(staticDecodeTPS, r.qualityCapFloorTPS, effectiveTPSLoadFactor, base, r.qualityCapFallback)
+	qc := qualityConcurrency(rate.tps, r.qualityCapFloorTPS, effectiveTPSLoadFactor, base, r.qualityCapFallback)
 	capped := int(math.Ceil(float64(qc) * r.qualityCapOvercommitForModelLocked(model)))
 	if capped < 1 {
 		capped = 1
@@ -178,22 +289,18 @@ func (r *Registry) effectiveMaxConcurrencyForModelLocked(p *Provider, model stri
 	return base
 }
 
-// hasConcurrencyHeadroomForModelCapLocked mirrors
+// hasConcurrencyHeadroomForModelCapResolvedLocked mirrors
 // Provider.hasConcurrencyHeadroomForModelLocked but applies the registry's
-// quality-concurrency cap to the per-model limit. staticDecodeTPS is the
-// provider's single-stream decode rate for the model. Caller holds r.mu and
-// p.mu.
-func (r *Registry) hasConcurrencyHeadroomForModelCapLocked(p *Provider, model string, staticDecodeTPS float64) bool {
-	return p.pendingLoadForModelLocked(model) < r.effectiveMaxConcurrencyForModelLocked(p, model, staticDecodeTPS) &&
-		p.pendingCount() < p.maxConcurrency()
-}
-
-// hasConcurrencyHeadroomForModelCapResolvedLocked is hasConcurrencyHeadroomForModelCapLocked
-// with the provider's static single-stream decode rate resolved internally. Used
-// by the public capacity feeds (ModelCapacitySnapshot) so /v1/models[/capacity]
-// report the SAME headroom the routing path enforces — otherwise a capped box is
+// quality-concurrency cap to the per-model limit, with the static single-stream
+// decode rate resolved internally — per-model (solo median / seed) when
+// available, else the provider-level rate. It is the single production entry
+// point: the routing snapshot, the queue-drain preflight, the final admit
+// re-check, the warm-pool saturation gate, and the public capacity feeds
+// (ModelCapacitySnapshot) all consume it, so /v1/models[/capacity] report the
+// SAME headroom the routing path enforces — otherwise a capped box is
 // advertised as routable and upstream routers keep sending requests it 429s.
 // Caller holds r.mu and p.mu.
 func (r *Registry) hasConcurrencyHeadroomForModelCapResolvedLocked(p *Provider, model string) bool {
-	return r.hasConcurrencyHeadroomForModelCapLocked(p, model, resolvedDecodeTPS(p))
+	return p.pendingLoadForModelLocked(model) < r.effectiveMaxConcurrencyForModelResolvedLocked(p, model) &&
+		p.pendingCount() < p.maxConcurrency()
 }

--- a/coordinator/registry/concurrency_cap_test.go
+++ b/coordinator/registry/concurrency_cap_test.go
@@ -380,6 +380,102 @@ func TestQualityCapProjectedDecodeTPSAtDefaultHoldsNearFloor(t *testing.T) {
 	}
 }
 
+// TestQualityCapPerModelTPSPostmortemRegression is THE 2026-07-06 gemma
+// postmortem layer-6 scenario: a mixed box whose registration benchmark was
+// taken on gpt-oss (93 tok/s) hosts a gemma slot that actually decodes ~14
+// tok/s solo. The old cap consumed the provider-LEVEL rate for every model, so
+// gemma got cap ceil(qc 19 × 1.2) = 23 — and the coordinator marched 8–11
+// concurrent gemma requests onto exactly the boxes that collapse past batch 3.
+// With the per-model solo source, gemma's cap must come from gemma's own solo
+// median (14 ≤ floor 15 → qc 1 → cap 2) while gpt-oss keeps its wide cap from
+// the benchmark. Reverting the resolver wiring makes the gemma assertion fail
+// (cap becomes 23 again).
+func TestQualityCapPerModelTPSPostmortemRegression(t *testing.T) {
+	run := func(t *testing.T, seedGemma func(reg *Registry)) {
+		reg := New(testLogger())
+		enablePerModelQualityCap(t, reg, "", "", "")
+		seedGemma(reg)
+		p := mixedBoxProvider(t, reg, "mixed-93", 93)
+
+		if got := effCapResolved(reg, p, gemmaBuild); got != 2 {
+			t.Fatalf("gemma cap on the mixed box = %d, want 2 (solo 14 ≤ floor 15 → qc 1 × overcommit 1.2; NOT the benchmark-derived 23)", got)
+		}
+		if got := effCapResolved(reg, p, gptossBuild); got != 23 {
+			t.Fatalf("gpt-oss cap on the mixed box = %d, want 23 (its own 93 tok/s benchmark stays wide)", got)
+		}
+	}
+
+	t.Run("solo_median_recorded", func(t *testing.T) {
+		run(t, func(reg *Registry) {
+			for _, v := range []float64{12, 13, 14, 15, 16} {
+				reg.tpsRegistry.RecordSolo(gemmaBuild, "M3", v)
+			}
+		})
+	})
+	t.Run("seed_env_cold_start", func(t *testing.T) {
+		run(t, func(reg *Registry) {
+			t.Setenv(modelSoloTPSSeedEnv, gemmaBuild+"=14")
+			// Re-parse with the seed present (startup order: env → setter).
+			enableQualityCap(t, reg, "")
+		})
+	})
+}
+
+// TestQualityCapPerModelTPSKillSwitchRestoresOldBehavior pins the kill switch:
+// EIGENINFERENCE_QUALITY_CAP_PER_MODEL_TPS=false must restore the provider-
+// level resolvedDecodeTPS(p) at the cap exactly — reproducing the postmortem's
+// buggy wide gemma cap (23 from the gpt-oss benchmark) even though a trusted
+// gemma solo median exists. This doubles as the proof that the regression test
+// above fails without the fix: the old code path IS the switch-off path.
+func TestQualityCapPerModelTPSKillSwitchRestoresOldBehavior(t *testing.T) {
+	reg := New(testLogger())
+	enablePerModelQualityCap(t, reg, gemmaBuild+"=14", "false", "")
+	for i := 0; i < 10; i++ {
+		reg.tpsRegistry.RecordSolo(gemmaBuild, "M3", 14)
+	}
+	p := mixedBoxProvider(t, reg, "mixed-93", 93)
+
+	if got := effCapResolved(reg, p, gemmaBuild); got != 23 {
+		t.Fatalf("kill switch off: gemma cap = %d, want the old provider-level 23 (byte-for-byte legacy behavior)", got)
+	}
+	// And it must match the explicit provider-level path exactly.
+	if resolved, legacy := effCapResolved(reg, p, gemmaBuild), effCap(reg, p, gemmaBuild); resolved != legacy {
+		t.Fatalf("kill switch off: resolved cap %d != legacy explicit-rate cap %d", resolved, legacy)
+	}
+}
+
+// TestQualityCapPerModelRateCapsWithoutRegistrationBenchmark: the DecodeTPS<=0
+// guard exists because the sqrt-bandwidth fallback is model-agnostic — but a
+// PER-MODEL rate (solo median / seed) is trustworthy by construction, so a
+// non-dedicated model on a benchmark-less box is still capped from it. Without
+// any per-model source the old guard semantics hold (flat cap).
+func TestQualityCapPerModelRateCapsWithoutRegistrationBenchmark(t *testing.T) {
+	reg := New(testLogger())
+	enablePerModelQualityCap(t, reg, "", "", "")
+	for i := 0; i < 5; i++ {
+		reg.tpsRegistry.RecordSolo(gemmaBuild, "M3", 14)
+	}
+
+	mkNoBenchmark := func(id string) *Provider {
+		p := mixedBoxProvider(t, reg, id, 0) // DecodeTPS unset
+		p.mu.Lock()
+		p.Hardware.MemoryBandwidthGBs = 800 // sqrt(800) ≈ 28 fallback
+		p.mu.Unlock()
+		return p
+	}
+
+	// Solo median present → capped even without a registration benchmark.
+	p := mkNoBenchmark("no-bench")
+	if got := effCapResolved(reg, p, gemmaBuild); got != 2 {
+		t.Fatalf("no-benchmark box with solo median: gemma cap = %d, want 2", got)
+	}
+	// No per-model source (gpt-oss): non-dedicated + bandwidth fallback → the
+	// old guard keeps the flat cap (don't shed a fast model on a coarse proxy).
+	if got := effCapResolved(reg, p, gptossBuild); got != 24 {
+		t.Fatalf("no-benchmark box without per-model source: gpt-oss cap = %d, want flat 24", got)
+	}
+}
+
 // TestWarmTargetDedicatedWholePool: for a dedicated model UNDER DEMAND the
 // warm-pool target is the entire eligible pool (warm + eligibleCold), so idle
 // dedicated boxes get warmed. With NO demand for that build it is left at the

--- a/coordinator/registry/model_capacity_snapshot_composition_test.go
+++ b/coordinator/registry/model_capacity_snapshot_composition_test.go
@@ -1,0 +1,70 @@
+package registry
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+)
+
+// Guard: PR #524 (byte-aware pooled ModelCapacitySnapshot) and PR #526
+// (per-model version-floor gating) both edit ModelCapacitySnapshot; this pins
+// that they compose — below-floor boxes dropped AND byte-aware pooled remaining.
+func TestModelCapacitySnapshotFlooredByteModeComposition(t *testing.T) {
+	reg := New(testLogger())
+	reg.SetModelVersionFloors(ParseModelVersionFloors("gemma-4=0.7.5"))
+
+	// Below-floor box (0.7.4) serving ONLY the floored model, with a large solo
+	// token budget: if the floor gate regressed it would surface as a second
+	// routable gemma provider AND add ~50k of remaining budget to the aggregate.
+	old := makeSchedulerProvider(t, reg, "old-box", gemmaBuild, 30)
+	old.mu.Lock()
+	old.BackendCapacity.Slots[0].ActiveTokenBudgetMax = 50_000
+	old.mu.Unlock()
+	setProviderVersion(old, "0.7.4")
+
+	// At-floor box (0.7.5): mixed-KV byte pool shared by the floored big-KV model
+	// (gemma, 100 kB/token → 10k-token view) and an unfloored small-KV co-resident
+	// (gpt-oss, 10 kB/token → 100k-token view), both over the SAME 1 GB pool.
+	newp := makeSchedulerProvider(t, reg, "new-box", gemmaBuild, 93)
+	addAdvertisedModel(newp, gptossBuild)
+	newp.mu.Lock()
+	newp.BackendCapacity.Slots[0].ActiveTokenBudgetMax = 10_000
+	newp.BackendCapacity.Slots[0].KVBytesPerToken = 100_000
+	newp.BackendCapacity.Slots = append(newp.BackendCapacity.Slots, protocol.BackendSlotCapacity{
+		Model:                gptossBuild,
+		State:                "running",
+		ActiveTokenBudgetMax: 100_000,
+		KVBytesPerToken:      10_000,
+	})
+	newp.mu.Unlock()
+	setProviderVersion(newp, "0.7.5")
+
+	// Burst gpt-oss on new-box (old-box does not serve it, so every reservation
+	// lands here): nine × 10k tokens = 90k tokens = 0.9 GB pending inside one
+	// heartbeat gap, leaving 0.1 GB of the shared 1 GB pool.
+	for i := 0; i < 9; i++ {
+		if got := reg.ReserveProvider(gptossBuild, &PendingRequest{
+			RequestID: fmt.Sprintf("burst-%d", i), Model: gptossBuild, EstimatedPromptTokens: 500, RequestedMaxTokens: 9_500,
+		}); got == nil {
+			t.Fatalf("burst request %d rejected; 0.9 GB must fit the 1 GB pool", i)
+		}
+	}
+
+	gemma := findModelCapacity(reg.ModelCapacitySnapshot(), gemmaBuild)
+	if gemma == nil {
+		t.Fatalf("gemma missing from capacity snapshot (the at-floor box should still count)")
+	}
+	// Floor property: only the at-floor box counts; the 0.7.4 box is dropped.
+	if gemma.RoutableProviders != 1 {
+		t.Fatalf("gemma RoutableProviders = %d, want 1 (only the >=0.7.5 box; the below-floor box must be dropped)", gemma.RoutableProviders)
+	}
+	// Byte + floor together: 0.1 GB byte headroom on the at-floor box ÷
+	// 100 kB/token = 1_000 gemma tokens. Token-mode accounting over-advertises
+	// (~10k on new-box alone); a leaked below-floor box adds its 50k solo budget
+	// (~51k total). Only byte-aware per-model remaining on the floor-included box
+	// alone yields exactly 1_000.
+	if gemma.TokenBudgetRemaining != 1_000 {
+		t.Fatalf("gemma token_budget_remaining = %d, want 1_000 (0.1 GB byte headroom on the at-floor box only)", gemma.TokenBudgetRemaining)
+	}
+}

--- a/coordinator/registry/model_version_floors.go
+++ b/coordinator/registry/model_version_floors.go
@@ -17,12 +17,21 @@ import "strings"
 // (dedicatedPatternForLocked) — and the version comparison is CompareVersions,
 // the same tolerant dotted-numeric compare the capability version floors use.
 //
-// Enforcement points (both, so we never pre-warm a box we won't route to):
+// Enforcement points (all four, so alias resolution, routing, and warming can
+// never disagree about who serves a floored model):
 //   - the single routing gate providerPassesRoutingGatesLockedEx (shared by the
 //     dispatch hot path, the capacity preflight, and the final admit re-check),
 //     beside the trait version floors;
+//   - alias routability providerCanRouteBuildLocked (ResolveModel /
+//     ResolveModelConstrained / RoutableProviderIDsForBuild), so a below-floor
+//     box advertising the Desired build cannot make an alias resolve to a build
+//     the routing gate then rejects — resolution falls back to Previous;
 //   - the warm-pool candidate gate warmPoolCandidateReasonLocked (reason
-//     warmColdBelowVersionFloor).
+//     warmColdBelowVersionFloor);
+//   - the queue-driven swap planner: providerHasWarmModelLocked (a below-floor
+//     warm box must not suppress loading the model onto a routable node) and
+//     modelLoadCandidatePendingLocked (never send load_model to a box routing
+//     won't use).
 //
 // Providers with an EMPTY version fail every floor (same rule as the trait
 // floors: a binary too old to report a version is below any floor). An empty

--- a/coordinator/registry/model_version_floors.go
+++ b/coordinator/registry/model_version_floors.go
@@ -65,12 +65,44 @@ func ParseModelVersionFloors(csv string) []ModelVersionFloor {
 		}
 		pattern = strings.ToLower(strings.TrimSpace(pattern))
 		version = strings.TrimSpace(version)
-		if pattern == "" || version == "" {
+		if pattern == "" || !validFloorVersion(version) {
 			continue
 		}
 		out = append(out, ModelVersionFloor{Pattern: pattern, Version: version})
 	}
 	return out
+}
+
+// validFloorVersion reports whether v is a usable dotted-numeric version — a
+// non-empty sequence of dot-separated segments that each parse as a
+// non-negative integer (an optional leading v/V is tolerated, matching
+// CompareVersions). A malformed floor version (e.g. "foo", "0.7.x") is REJECTED
+// at parse time rather than installed, because CompareVersions silently treats
+// an unparseable segment as 0 — so "gemma-4=foo" would install an all-zero
+// floor that every real version clears (fence defeated) and "gemma-4=0.7.x"
+// would install 0.7.0 (a 0.7.4 box wrongly passes a 0.7.5 fence). Dropping the
+// entry degrades to "no floor for that pattern" (the fail-open contract), never
+// to a wrong floor.
+func validFloorVersion(v string) bool {
+	v = strings.TrimSpace(v)
+	if len(v) > 0 && (v[0] == 'v' || v[0] == 'V') {
+		v = v[1:]
+	}
+	if v == "" {
+		return false
+	}
+	for _, part := range strings.Split(v, ".") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			return false
+		}
+		for _, ch := range part {
+			if ch < '0' || ch > '9' {
+				return false
+			}
+		}
+	}
+	return true
 }
 
 // FormatModelVersionFloors renders floors back to the "pattern=version" CSV
@@ -92,7 +124,7 @@ func (r *Registry) SetModelVersionFloors(floors []ModelVersionFloor) {
 	for _, f := range floors {
 		pattern := strings.ToLower(strings.TrimSpace(f.Pattern))
 		version := strings.TrimSpace(f.Version)
-		if pattern == "" || version == "" {
+		if pattern == "" || !validFloorVersion(version) {
 			continue
 		}
 		normalized = append(normalized, ModelVersionFloor{Pattern: pattern, Version: version})

--- a/coordinator/registry/model_version_floors.go
+++ b/coordinator/registry/model_version_floors.go
@@ -1,0 +1,133 @@
+package registry
+
+import "strings"
+
+// Per-model provider-version routing floors — the second half of the
+// mixed-fleet migration defense (beside the version-keyed heartbeat clamp in
+// v2_capacity_clamp.go).
+//
+// During the v0.7.5 rollout a model that NEEDS the re-slice-capable v2 engine
+// (e.g. gemma-4: multi-model co-residency, honest per-engine KV grants) must
+// never route to an older binary, no matter what that binary advertises — an
+// old mixed box would silently legacy-serve it at collapsed batch throughput.
+// EIGENINFERENCE_MODEL_VERSION_FLOORS maps model patterns to minimum provider
+// binary versions ("pattern=version" CSV, e.g. "gemma-4=0.7.5"). A pattern is
+// matched as a case-insensitive substring of the resolved build id — the same
+// matching semantics as EIGENINFERENCE_DEDICATED_MODELS
+// (dedicatedPatternForLocked) — and the version comparison is CompareVersions,
+// the same tolerant dotted-numeric compare the capability version floors use.
+//
+// Enforcement points (both, so we never pre-warm a box we won't route to):
+//   - the single routing gate providerPassesRoutingGatesLockedEx (shared by the
+//     dispatch hot path, the capacity preflight, and the final admit re-check),
+//     beside the trait version floors;
+//   - the warm-pool candidate gate warmPoolCandidateReasonLocked (reason
+//     warmColdBelowVersionFloor).
+//
+// Providers with an EMPTY version fail every floor (same rule as the trait
+// floors: a binary too old to report a version is below any floor). An empty
+// env — the default — disables the feature entirely: zero behavior change.
+// The env is expected to RETIRE (empty again) after fleet convergence.
+
+// ModelVersionFloor pairs a build-id substring pattern with the minimum
+// provider binary version able to serve matching models.
+type ModelVersionFloor struct {
+	Pattern string // lowercased, non-empty substring of the resolved build id
+	Version string // minimum provider binary version (CompareVersions semantics)
+}
+
+// ParseModelVersionFloors parses a "pattern=version" CSV into normalized
+// floors. Patterns are trimmed + lowercased; versions are trimmed. Entries
+// with an empty pattern or empty version (or no '=') are skipped — a malformed
+// entry must degrade to "no floor for that pattern", never to a floor that
+// blocks or admits the wrong providers. An empty or all-invalid input yields
+// nil (feature disabled). Entry order is preserved: like the dedicated-model
+// patterns, the FIRST matching pattern wins.
+func ParseModelVersionFloors(csv string) []ModelVersionFloor {
+	var out []ModelVersionFloor
+	for _, entry := range strings.Split(csv, ",") {
+		entry = strings.TrimSpace(entry)
+		if entry == "" {
+			continue
+		}
+		pattern, version, ok := strings.Cut(entry, "=")
+		if !ok {
+			continue
+		}
+		pattern = strings.ToLower(strings.TrimSpace(pattern))
+		version = strings.TrimSpace(version)
+		if pattern == "" || version == "" {
+			continue
+		}
+		out = append(out, ModelVersionFloor{Pattern: pattern, Version: version})
+	}
+	return out
+}
+
+// FormatModelVersionFloors renders floors back to the "pattern=version" CSV
+// form for startup logging.
+func FormatModelVersionFloors(floors []ModelVersionFloor) string {
+	parts := make([]string, 0, len(floors))
+	for _, f := range floors {
+		parts = append(parts, f.Pattern+"="+f.Version)
+	}
+	return strings.Join(parts, ",")
+}
+
+// SetModelVersionFloors configures the per-model provider-version routing
+// floors. Entries are re-normalized defensively (SetDedicatedModels does the
+// same); invalid entries are dropped. An empty (or all-invalid) list disables
+// the feature. Called once at startup before the coordinator begins serving.
+func (r *Registry) SetModelVersionFloors(floors []ModelVersionFloor) {
+	normalized := make([]ModelVersionFloor, 0, len(floors))
+	for _, f := range floors {
+		pattern := strings.ToLower(strings.TrimSpace(f.Pattern))
+		version := strings.TrimSpace(f.Version)
+		if pattern == "" || version == "" {
+			continue
+		}
+		normalized = append(normalized, ModelVersionFloor{Pattern: pattern, Version: version})
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if len(normalized) == 0 {
+		r.modelVersionFloors = nil
+		return
+	}
+	r.modelVersionFloors = normalized
+}
+
+// modelVersionFloorForLocked returns the minimum provider version for the
+// resolved build id, or "", false when no configured pattern matches (or the
+// feature is disabled). First matching pattern wins, mirroring
+// dedicatedPatternForLocked. Caller holds r.mu.
+func (r *Registry) modelVersionFloorForLocked(model string) (string, bool) {
+	if len(r.modelVersionFloors) == 0 {
+		return "", false
+	}
+	m := strings.ToLower(model)
+	for _, f := range r.modelVersionFloors {
+		if strings.Contains(m, f.Pattern) {
+			return f.Version, true
+		}
+	}
+	return "", false
+}
+
+// providerBelowModelVersionFloorLocked reports whether the per-model version
+// floor EXCLUDES this provider for the model: a floor is configured for the
+// model AND the provider's binary version is below it (an empty version is
+// below any floor). false when no floor matches the model — the common case
+// and the whole-feature-disabled case. Applied to self-route too: unlike the
+// dedicated-box rule (a routing-policy partition owners may opt out of), the
+// floor exists because a below-floor binary would MIS-SERVE the model, which
+// is just as true on the owner's own machine. Caller holds r.mu and p.mu
+// (p.Version is guarded by p.mu — same discipline as
+// providerMeetsTraitFloorsLocked).
+func (r *Registry) providerBelowModelVersionFloorLocked(p *Provider, model string) bool {
+	floor, ok := r.modelVersionFloorForLocked(model)
+	if !ok {
+		return false
+	}
+	return p.Version == "" || CompareVersions(p.Version, floor) < 0
+}

--- a/coordinator/registry/model_version_floors_test.go
+++ b/coordinator/registry/model_version_floors_test.go
@@ -1,0 +1,161 @@
+package registry
+
+import (
+	"testing"
+	"time"
+)
+
+// floorProvider registers a routable provider advertising BOTH gemma and
+// gpt-oss builds (a mixed box) running the given binary version.
+func floorProvider(t *testing.T, reg *Registry, id, version string) *Provider {
+	t.Helper()
+	p := makeSchedulerProvider(t, reg, id, gemmaBuild, 30)
+	addAdvertisedModel(p, gptossBuild)
+	if version != "" {
+		setProviderVersion(p, version)
+	}
+	return p
+}
+
+func TestParseModelVersionFloors(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+		want []ModelVersionFloor
+	}{
+		{"empty", "", nil},
+		{"single", "gemma-4=0.7.5", []ModelVersionFloor{{Pattern: "gemma-4", Version: "0.7.5"}}},
+		{"multi_with_spaces", " gemma-4 = 0.7.5 , gpt-oss = 0.8.0 ", []ModelVersionFloor{{Pattern: "gemma-4", Version: "0.7.5"}, {Pattern: "gpt-oss", Version: "0.8.0"}}},
+		{"uppercase_pattern_lowered", "GEMMA-4=0.7.5", []ModelVersionFloor{{Pattern: "gemma-4", Version: "0.7.5"}}},
+		// Malformed entries degrade to "no floor", never to a bad floor.
+		{"bad_entries_skipped", "bogus,=0.7.5,gemma-4=,x", nil},
+		{"mixed_valid_invalid", "bogus,gemma-4=0.7.5,=1", []ModelVersionFloor{{Pattern: "gemma-4", Version: "0.7.5"}}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ParseModelVersionFloors(tc.raw)
+			if len(got) != len(tc.want) {
+				t.Fatalf("ParseModelVersionFloors(%q) = %v, want %v", tc.raw, got, tc.want)
+			}
+			for i := range tc.want {
+				if got[i] != tc.want[i] {
+					t.Fatalf("ParseModelVersionFloors(%q)[%d] = %v, want %v", tc.raw, i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}
+
+// TestModelVersionFloorRoutingGate is the migration regression: with
+// gemma-4=0.7.5 configured, gemma routes ONLY to >=0.7.5 providers — a 0.7.4
+// box and a version-less box advertising the same build are excluded — while
+// gpt-oss (no floor) still routes to every box. Fails without the routing-gate
+// check (all three boxes would serve gemma).
+func TestModelVersionFloorRoutingGate(t *testing.T) {
+	reg := New(testLogger())
+	reg.SetModelVersionFloors(ParseModelVersionFloors("gemma-4=0.7.5"))
+
+	floorProvider(t, reg, "old-box", "0.7.4")
+	floorProvider(t, reg, "no-version-box", "")
+
+	// Below-floor and version-less boxes must not serve the floored model...
+	if p := findRoutableProvider(reg, gemmaBuild); p != nil {
+		t.Fatalf("gemma routed to %s, want no provider (both boxes below the 0.7.5 floor)", p.ID)
+	}
+	// ...but still serve unfloored models (only gemma is fenced).
+	if p := findRoutableProvider(reg, gptossBuild); p == nil {
+		t.Fatalf("gpt-oss unroutable — the floor must fence only matching models")
+	}
+
+	// A >=floor box serves the floored model; the substring match covers any
+	// build id containing the pattern (same semantics as dedicated models).
+	floorProvider(t, reg, "new-box", "0.7.5")
+	p := findRoutableProvider(reg, gemmaBuild)
+	if p == nil || p.ID != "new-box" {
+		t.Fatalf("gemma routed to %v, want new-box (the only >=0.7.5 provider)", p)
+	}
+}
+
+// TestModelVersionFloorPreflightConsistency: the capacity preflight
+// (QuickCapacityCheck) funnels through the same routing gate, so a below-floor
+// box is structurally absent there too — no phantom capacity that routing then
+// refuses.
+func TestModelVersionFloorPreflightConsistency(t *testing.T) {
+	reg := New(testLogger())
+	reg.SetModelVersionFloors(ParseModelVersionFloors("gemma-4=0.7.5"))
+	floorProvider(t, reg, "old-box", "0.7.4")
+
+	candidates, capacityRejects, tooLarge := reg.QuickCapacityCheck(gemmaBuild, 500, 128, RequestTraits{})
+	if candidates != 0 || capacityRejects != 0 || tooLarge != 0 {
+		t.Fatalf("preflight for floored gemma = (%d, %d, %d), want (0, 0, 0): a below-floor box is structural absence, not capacity", candidates, capacityRejects, tooLarge)
+	}
+	if candidates, _, _ := reg.QuickCapacityCheck(gptossBuild, 500, 128, RequestTraits{}); candidates != 1 {
+		t.Fatalf("preflight for unfloored gpt-oss = %d candidates, want 1", candidates)
+	}
+}
+
+// TestModelVersionFloorDisabledByDefault pins the flag-off contract: with no
+// floors configured (the default), below-floor and version-less providers
+// route exactly as today.
+func TestModelVersionFloorDisabledByDefault(t *testing.T) {
+	reg := New(testLogger())
+	floorProvider(t, reg, "old-box", "0.7.4")
+	if p := findRoutableProvider(reg, gemmaBuild); p == nil {
+		t.Fatalf("gemma unroutable with no floors configured — empty env must be zero behavior change")
+	}
+
+	// Setting then clearing the floors restores the default entirely.
+	reg.SetModelVersionFloors(ParseModelVersionFloors("gemma-4=0.7.5"))
+	if p := findRoutableProvider(reg, gemmaBuild); p != nil {
+		t.Fatalf("floor set: gemma routed to %s, want none", p.ID)
+	}
+	reg.SetModelVersionFloors(nil)
+	if p := findRoutableProvider(reg, gemmaBuild); p == nil {
+		t.Fatalf("floors cleared: gemma unroutable, want routable again")
+	}
+}
+
+// TestModelVersionFloorWarmPoolCandidacy: the warm-pool candidate gate applies
+// the same floor with its own disqualification reason, so the controller never
+// pre-warms a box routing won't use — and the reason tally exposes why.
+func TestModelVersionFloorWarmPoolCandidacy(t *testing.T) {
+	reg := New(testLogger())
+	reg.SetModelVersionFloors(ParseModelVersionFloors("gemma-4=0.7.5"))
+
+	oldBox := floorProvider(t, reg, "old-box", "0.7.4")
+	newBox := floorProvider(t, reg, "new-box", "0.7.5")
+	// Make both boxes COLD for gemma (no gemma slot in backend capacity) so they
+	// are warm-pool candidates rather than already-warm providers.
+	for _, p := range []*Provider{oldBox, newBox} {
+		p.mu.Lock()
+		p.BackendCapacity.Slots = nil
+		p.mu.Unlock()
+	}
+
+	now := time.Now()
+	reg.mu.RLock()
+	oldBox.mu.Lock()
+	_, oldReason := reg.warmPoolCandidateReasonLocked(oldBox, gemmaBuild, now)
+	oldBox.mu.Unlock()
+	newBox.mu.Lock()
+	_, newReason := reg.warmPoolCandidateReasonLocked(newBox, gemmaBuild, now)
+	newBox.mu.Unlock()
+	reg.mu.RUnlock()
+
+	if oldReason != warmColdBelowVersionFloor {
+		t.Fatalf("below-floor cold box reason = %q, want %q", oldReason, warmColdBelowVersionFloor)
+	}
+	if newReason != warmColdEligible {
+		t.Fatalf(">=floor cold box reason = %q, want eligible", newReason)
+	}
+
+	// The fleet snapshot surfaces the tally under the exported reason string, so
+	// "why is eligible_cold 0" is a dashboard, not a grep.
+	snap := reg.warmPoolFleetSnapshot(now)[gemmaBuild]
+	if len(snap.eligibleCold) != 1 || snap.eligibleCold[0].providerID != "new-box" {
+		t.Fatalf("eligibleCold = %+v, want exactly new-box", snap.eligibleCold)
+	}
+	if snap.coldDisq[warmColdBelowVersionFloor] != 1 {
+		t.Fatalf("coldDisq = %v, want %q: 1", snap.coldDisq, warmColdBelowVersionFloor)
+	}
+}

--- a/coordinator/registry/model_version_floors_test.go
+++ b/coordinator/registry/model_version_floors_test.go
@@ -30,6 +30,18 @@ func TestParseModelVersionFloors(t *testing.T) {
 		// Malformed entries degrade to "no floor", never to a bad floor.
 		{"bad_entries_skipped", "bogus,=0.7.5,gemma-4=,x", nil},
 		{"mixed_valid_invalid", "bogus,gemma-4=0.7.5,=1", []ModelVersionFloor{{Pattern: "gemma-4", Version: "0.7.5"}}},
+		// A NON-NUMERIC version must be dropped: CompareVersions treats an
+		// unparseable segment as 0, so installing "gemma-4=foo" would fence
+		// against an all-zero floor that every real version clears (the fence
+		// silently defeated). Regression for the Codex finding.
+		{"nonnumeric_version_dropped", "gemma-4=foo", nil},
+		// A partially-numeric version ("0.7.x") would install 0.7.0 and let a
+		// 0.7.4 box wrongly pass a 0.7.5-intended fence — dropped too.
+		{"partial_numeric_version_dropped", "gemma-4=0.7.x", nil},
+		// A valid entry survives alongside a dropped malformed one.
+		{"valid_kept_bad_version_dropped", "gemma-4=0.7.5,gpt-oss=vNext", []ModelVersionFloor{{Pattern: "gemma-4", Version: "0.7.5"}}},
+		// A leading v is tolerated (matches CompareVersions).
+		{"v_prefix_ok", "gemma-4=v0.7.5", []ModelVersionFloor{{Pattern: "gemma-4", Version: "v0.7.5"}}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -282,5 +294,72 @@ func TestModelVersionFloorSwapPlannerNeverTargetsBelowFloorBox(t *testing.T) {
 	// unfloored model it advertises.
 	if actions := reg.planModelLoadActions([]string{gptossBuild}, time.Now()); len(actions) != 1 || actions[0].providerID != "old-cold-box" {
 		t.Fatalf("planModelLoadActions(gpt-oss) = %+v, want one load onto old-cold-box (only gemma is floored)", actions)
+	}
+}
+
+// findModelCapacity returns the ModelCapacity snapshot entry for a build id.
+func findModelCapacity(caps []ModelCapacity, modelID string) *ModelCapacity {
+	for i := range caps {
+		if caps[i].ModelID == modelID {
+			return &caps[i]
+		}
+	}
+	return nil
+}
+
+// TestModelVersionFloorCapacitySnapshot is the Codex regression: the public
+// /v1/models/capacity feed must apply the per-model version floor too. A
+// below-floor box advertising a floored model is unroutable, so counting its
+// slot as a RoutableProvider would advertise capacity the preflight immediately
+// 429s — luring upstream routers into undeliverable traffic. Fails without the
+// floor gate inside ModelCapacitySnapshot (gemma RoutableProviders would be 2).
+func TestModelVersionFloorCapacitySnapshot(t *testing.T) {
+	reg := New(testLogger())
+	reg.SetModelVersionFloors(ParseModelVersionFloors("gemma-4=0.7.5"))
+	floorProvider(t, reg, "old-box", "0.7.4") // below floor: advertises gemma + gpt-oss
+	floorProvider(t, reg, "new-box", "0.7.5") // at floor
+
+	caps := reg.ModelCapacitySnapshot()
+
+	gemma := findModelCapacity(caps, gemmaBuild)
+	if gemma == nil {
+		t.Fatalf("gemma missing from capacity snapshot (the at-floor box should still count)")
+	}
+	if gemma.RoutableProviders != 1 {
+		t.Fatalf("gemma RoutableProviders = %d, want 1 (only the >=0.7.5 box; the 0.7.4 box is floored out)", gemma.RoutableProviders)
+	}
+	// gpt-oss has no floor: both boxes count.
+	gptoss := findModelCapacity(caps, gptossBuild)
+	if gptoss == nil || gptoss.RoutableProviders != 2 {
+		t.Fatalf("gpt-oss RoutableProviders = %v, want 2 (unfloored — both boxes)", gptoss)
+	}
+}
+
+// TestModelVersionFloorDesiredModelsGate is the Codex regression: a below-floor
+// box must NOT be steered toward the Desired build of a floored alias — routing
+// will never use it there, so a desired_models command only makes it swap away
+// from a still-usable previous build into one it cannot serve. Fails without the
+// floor gate in DesiredModelsForProvider (the old box is told to converge to QAT).
+func TestModelVersionFloorDesiredModelsGate(t *testing.T) {
+	reg := New(testLogger())
+	reg.SetModelAliases(map[string]AliasTarget{
+		"gemma-4-26b": {Desired: aliasQAT, Previous: aliasFP8},
+	})
+	reg.SetModelVersionFloors(ParseModelVersionFloors("gemma-4=0.7.5"))
+
+	// Below-floor box advertising the previous build: must not be told to
+	// converge to the floored desired build.
+	old := registerProviderWithModel(reg, "p-old", aliasFP8)
+	setProviderVersion(old, "0.7.4")
+	if got := reg.DesiredModelsForProvider("p-old"); len(got) != 0 {
+		t.Fatalf("below-floor box steered toward floored desired build, got %+v", got)
+	}
+
+	// At-floor box advertising the previous build: still told to converge.
+	newp := registerProviderWithModel(reg, "p-new", aliasFP8)
+	setProviderVersion(newp, "0.7.5")
+	got := reg.DesiredModelsForProvider("p-new")
+	if len(got) != 1 || got[0].DesiredBuild != aliasQAT {
+		t.Fatalf("at-floor box should be told the desired build, got %+v", got)
 	}
 }

--- a/coordinator/registry/model_version_floors_test.go
+++ b/coordinator/registry/model_version_floors_test.go
@@ -192,3 +192,95 @@ func TestModelVersionFloorOwnedSummaryConsistency(t *testing.T) {
 		t.Fatalf("with a >=floor owned box: OwnedProviderSummary = (online %d, serves %d), want (2, 1)", online, serves)
 	}
 }
+
+// TestModelVersionFloorAliasResolutionFallsBackToPrevious (review fix): alias
+// routability (providerCanRouteBuildLocked) must apply the same per-model
+// version floor as the dispatch gate. Without it, a below-floor box advertising
+// the alias's Desired build makes ResolveModel resolve to Desired, the
+// candidate scan then finds ZERO eligible providers, and the request
+// queues/dies against a build the fleet cannot serve — instead of falling back
+// to the routable Previous build. Fails without the floor check in
+// providerCanRouteBuildLocked.
+func TestModelVersionFloorAliasResolutionFallsBackToPrevious(t *testing.T) {
+	reg := New(testLogger())
+	// aliasQAT contains "qat"; aliasFP8 does not — the floor fences ONLY the
+	// Desired build.
+	reg.SetModelVersionFloors(ParseModelVersionFloors("qat=0.7.5"))
+	reg.SetModelAliases(map[string]AliasTarget{
+		"gemma-4-26b": {Desired: aliasQAT, Previous: aliasFP8},
+	})
+
+	// The ONLY box advertising Desired is below the floor; Previous has a
+	// routable box.
+	oldBox := registerProviderWithModel(reg, "old-desired-box", aliasQAT)
+	makeProviderRoutable(oldBox)
+	setProviderVersion(oldBox, "0.7.4")
+	makeProviderRoutable(registerProviderWithModel(reg, "prev-box", aliasFP8))
+
+	build, isAlias, ok := reg.ResolveModel("gemma-4-26b")
+	if !ok || !isAlias || build != aliasFP8 {
+		t.Fatalf("ResolveModel = (%q, %v, %v), want the Previous build %q — a below-floor box must not make Desired look routable", build, isAlias, ok, aliasFP8)
+	}
+	// RoutableProviderIDsForBuild shares the same predicate, so rollout/drop
+	// measurement agrees with resolution: the floored Desired build has zero
+	// routable providers.
+	if ids := reg.RoutableProviderIDsForBuild(aliasQAT); len(ids) != 0 {
+		t.Fatalf("RoutableProviderIDsForBuild(%q) = %v, want none (only provider is below floor)", aliasQAT, ids)
+	}
+
+	// Upgrading the box restores Desired-first resolution.
+	setProviderVersion(oldBox, "0.7.5")
+	if build, _, _ := reg.ResolveModel("gemma-4-26b"); build != aliasQAT {
+		t.Fatalf("after upgrade: ResolveModel = %q, want Desired %q", build, aliasQAT)
+	}
+}
+
+// TestModelVersionFloorSwapPlannerIgnoresBelowFloorWarmBox (review fix): the
+// queue-driven swap path must mirror the floor. A below-floor box holding the
+// model WARM must not suppress load planning (providerHasWarmModelLocked) —
+// routing will never use its warm slot — and the planner must pick a >=floor
+// cold box as the load_model target. Fails without the floor check in
+// providerHasWarmModelLocked (no action is planned at all).
+func TestModelVersionFloorSwapPlannerIgnoresBelowFloorWarmBox(t *testing.T) {
+	reg := New(testLogger())
+	reg.SetModelVersionFloors(ParseModelVersionFloors("gemma-4=0.7.5"))
+
+	// Below-floor box WARM for gemma (running slot from the fixture).
+	floorProvider(t, reg, "old-warm-box", "0.7.4")
+	// >=floor box COLD for gemma (advertises it, no slot).
+	newBox := floorProvider(t, reg, "new-cold-box", "0.7.5")
+	newBox.mu.Lock()
+	newBox.BackendCapacity.Slots = nil
+	newBox.mu.Unlock()
+
+	actions := reg.planModelLoadActions([]string{gemmaBuild}, time.Now())
+	if len(actions) != 1 || actions[0].providerID != "new-cold-box" || actions[0].modelID != gemmaBuild {
+		t.Fatalf("planModelLoadActions = %+v, want exactly one load of %s onto new-cold-box — the below-floor warm box must not suppress it", actions, gemmaBuild)
+	}
+}
+
+// TestModelVersionFloorSwapPlannerNeverTargetsBelowFloorBox (review fix): the
+// load planner (modelLoadCandidatePendingLocked) must never send load_model to
+// a below-floor box — routing would never use the resulting warm slot, so the
+// load burns GPU memory while queued demand keeps waiting. Fails without the
+// floor check in modelLoadCandidatePendingLocked (the idle below-floor box is
+// picked as the target).
+func TestModelVersionFloorSwapPlannerNeverTargetsBelowFloorBox(t *testing.T) {
+	reg := New(testLogger())
+	reg.SetModelVersionFloors(ParseModelVersionFloors("gemma-4=0.7.5"))
+
+	// The only box is idle, COLD for gemma, and below the floor.
+	oldBox := floorProvider(t, reg, "old-cold-box", "0.7.4")
+	oldBox.mu.Lock()
+	oldBox.BackendCapacity.Slots = nil
+	oldBox.mu.Unlock()
+
+	if actions := reg.planModelLoadActions([]string{gemmaBuild}, time.Now()); len(actions) != 0 {
+		t.Fatalf("planModelLoadActions = %+v, want none — a below-floor box must never receive load_model for a floored model", actions)
+	}
+	// The floor is model-scoped: the same box is still a valid target for an
+	// unfloored model it advertises.
+	if actions := reg.planModelLoadActions([]string{gptossBuild}, time.Now()); len(actions) != 1 || actions[0].providerID != "old-cold-box" {
+		t.Fatalf("planModelLoadActions(gpt-oss) = %+v, want one load onto old-cold-box (only gemma is floored)", actions)
+	}
+}

--- a/coordinator/registry/model_version_floors_test.go
+++ b/coordinator/registry/model_version_floors_test.go
@@ -159,3 +159,36 @@ func TestModelVersionFloorWarmPoolCandidacy(t *testing.T) {
 		t.Fatalf("coldDisq = %v, want %q: 1", snap.coldDisq, warmColdBelowVersionFloor)
 	}
 }
+
+// TestModelVersionFloorOwnedSummaryConsistency (review fix): the self-route
+// preflight summary must apply the same per-model version floor as the
+// dispatch gate — otherwise a below-floor OWNED box reads as "serves model",
+// passes the self-route preflight, queues for up to 120s, and dies as
+// machine_busy instead of failing fast with the real cause. Fails without the
+// providerBelowModelVersionFloorLocked check in OwnedProviderSummary.
+func TestModelVersionFloorOwnedSummaryConsistency(t *testing.T) {
+	reg := New(testLogger())
+	reg.SetModelVersionFloors(ParseModelVersionFloors("gemma-4=0.7.5"))
+
+	oldBox := floorProvider(t, reg, "owned-old", "0.7.4")
+	oldBox.mu.Lock()
+	oldBox.AccountID = "acct-1"
+	oldBox.mu.Unlock()
+
+	online, serves := reg.OwnedProviderSummary("acct-1", gemmaBuild, RequestTraits{}, false)
+	if online != 1 || serves != 0 {
+		t.Fatalf("below-floor owned box: OwnedProviderSummary = (online %d, serves %d), want (1, 0) — the summary must mirror the dispatch floor", online, serves)
+	}
+	// The floor is model-scoped: the same box still serves unfloored models.
+	if _, serves := reg.OwnedProviderSummary("acct-1", gptossBuild, RequestTraits{}, false); serves != 1 {
+		t.Fatalf("below-floor owned box: gpt-oss serves = %d, want 1 (only gemma is floored)", serves)
+	}
+
+	newBox := floorProvider(t, reg, "owned-new", "0.7.5")
+	newBox.mu.Lock()
+	newBox.AccountID = "acct-1"
+	newBox.mu.Unlock()
+	if online, serves := reg.OwnedProviderSummary("acct-1", gemmaBuild, RequestTraits{}, false); online != 2 || serves != 1 {
+		t.Fatalf("with a >=floor owned box: OwnedProviderSummary = (online %d, serves %d), want (2, 1)", online, serves)
+	}
+}

--- a/coordinator/registry/pooled_admission.go
+++ b/coordinator/registry/pooled_admission.go
@@ -113,7 +113,13 @@ func providerPooledTokenBudget(slots []protocol.BackendSlotCapacity) pooledToken
 	if budgetSlots == 0 {
 		pool.byteMode = false
 	}
-	pool.totalBytes = pool.committedBytes + sharedFreeBytes
+	// totalBytes mirrors the token path's total (providerTokenBudget: LIVE
+	// used + shared free), NOT committed+potential. committedBytes carries
+	// MaxTokensPotential only as the pending de-dup baseline (subtracted in
+	// pooledBudgetAdmits' extra); adding it into the pool total too would
+	// double-count a co-resident slot's not-yet-materialized future growth as
+	// extra physical KV capacity, letting an in-gap burst overcommit the box.
+	pool.totalBytes = pool.usedBytes + sharedFreeBytes
 	return pool
 }
 
@@ -148,4 +154,42 @@ func pooledBudgetAdmits(snap routingSnapshot, requestTokens int64) bool {
 		extra = 0
 	}
 	return pool.used+extra+requestTokens <= pool.total
+}
+
+// pooledRemainingTokens is the capacity-snapshot analog of pooledBudgetAdmits:
+// how many tokens of a model whose per-token KV rate is modelRate still fit the
+// shared pool once every model's coordinator-pending tokens are charged.
+// pooledBudgetAdmits(snap, n) admits iff n <= pooledRemainingTokens(pool, …,
+// snap.kvBytesPerToken) with the same inputs, so the public capacity feed
+// (/v1/models[/capacity]) cannot advertise pooled headroom the admission gate
+// refuses. Both branch identically: BYTES when the pool is byte-reconstructable
+// (byteMode), every pending charge normalized (pendingBytesKnown), and THIS
+// model's KV rate is known (modelRate > 0 — its resident slot; 0 for a
+// cold/absent slot, matching the gate's cold path); token accounting otherwise.
+// Returns -1 when the provider reports no pooled budget (total <= 0) — the "no
+// pooled constraint" sentinel that leaves the per-slot numbers unclamped.
+func pooledRemainingTokens(pool pooledTokenBudget, pendingTokensAllModels int, pendingBytesAllModels int64, pendingBytesKnown bool, modelRate int64) int64 {
+	if pool.total <= 0 {
+		return -1
+	}
+	if pool.byteMode && pendingBytesKnown && modelRate > 0 {
+		extra := pendingBytesAllModels - pool.committedBytes
+		if extra < 0 {
+			extra = 0
+		}
+		remBytes := pool.totalBytes - pool.usedBytes - extra
+		if remBytes < 0 {
+			remBytes = 0
+		}
+		return remBytes / modelRate
+	}
+	extra := int64(pendingTokensAllModels) - pool.committed
+	if extra < 0 {
+		extra = 0
+	}
+	rem := pool.total - pool.used - extra
+	if rem < 0 {
+		rem = 0
+	}
+	return rem
 }

--- a/coordinator/registry/pooled_admission.go
+++ b/coordinator/registry/pooled_admission.go
@@ -87,6 +87,13 @@ type pooledTokenBudget struct {
 	// KV rate, for normalizing coordinator-pending charges into bytes. Nil
 	// when no budget slot reports a rate.
 	kvBytesPerToken map[string]int64
+	// maxKVBytesPerToken is the largest clamped per-token KV rate across the
+	// budget slots. Only meaningful in byteMode (where every budget slot reports
+	// a positive rate, so it is > 0). It is the conservative rate used to price
+	// a COLD/absent request (one whose own model has no resident slot, so its
+	// rate is 0) in bytes rather than collapsing the whole byte-reconstructable
+	// pool to token accounting and under-charging a large-KV cold burst.
+	maxKVBytesPerToken int64
 }
 
 // providerPooledTokenBudget reconstructs the provider's pooled budget from its
@@ -129,6 +136,9 @@ func providerPooledTokenBudget(slots []protocol.BackendSlotCapacity) pooledToken
 			pool.kvBytesPerToken = make(map[string]int64, len(slots))
 		}
 		pool.kvBytesPerToken[slot.Model] = rate
+		if rate > pool.maxKVBytesPerToken {
+			pool.maxKVBytesPerToken = rate
+		}
 		pool.usedBytes += slotUsed * rate
 		pool.committedBytes += c * rate
 		// Per-slot free headroom in bytes; all slots see the same shared byte
@@ -159,22 +169,36 @@ func providerPooledTokenBudget(slots []protocol.BackendSlotCapacity) pooledToken
 // reported no pooled budget (legacy provider, or a snapshot built without
 // backend capacity) — no pooled constraint, the caller's other gates decide.
 //
-// The check runs in BYTES when the pool is byte-reconstructable (byteMode),
-// every pending charge was normalizable (snap.pendingBytesKnown), and the
-// incoming request's own KV rate is known (snap.kvBytesPerToken — this
-// model's slot; 0 for a cold/absent slot). Any gap falls back to token
-// accounting, which is byte-for-byte the legacy-provider behavior.
+// The check runs in BYTES when the pool is byte-reconstructable (byteMode) and
+// every pending charge was normalizable (snap.pendingBytesKnown). The incoming
+// request's own KV rate (snap.kvBytesPerToken — this model's slot) prices it;
+// when that is 0 (a cold/absent slot) the request is priced CONSERVATIVELY at
+// the box's max resident rate (pool.maxKVBytesPerToken) rather than collapsing
+// to token accounting, so a large-KV cold request on a mixed-KV box is not
+// under-charged against a token view of a byte-reconstructable pool. Token
+// accounting is used ONLY when the pool is not byte-reconstructable
+// (!byteMode) or a pending charge could not be normalized (!pendingBytesKnown)
+// — byte-for-byte the legacy-provider behavior.
 func pooledBudgetAdmits(snap routingSnapshot, requestTokens int64) bool {
 	pool := snap.pooledTokenBudget
 	if pool.total <= 0 {
 		return true
 	}
-	if pool.byteMode && snap.pendingBytesKnown && snap.kvBytesPerToken > 0 {
-		extra := snap.pendingMaxBytesAllModels - pool.committedBytes
-		if extra < 0 {
-			extra = 0
+	if pool.byteMode && snap.pendingBytesKnown {
+		reqRate := snap.kvBytesPerToken
+		if reqRate <= 0 {
+			// Cold/absent slot: price at the box's max resident rate. Guaranteed
+			// > 0 in byteMode; the guard covers the impossible 0 case by falling
+			// through to token accounting.
+			reqRate = pool.maxKVBytesPerToken
 		}
-		return pool.usedBytes+extra+requestTokens*snap.kvBytesPerToken <= pool.totalBytes
+		if reqRate > 0 {
+			extra := snap.pendingMaxBytesAllModels - pool.committedBytes
+			if extra < 0 {
+				extra = 0
+			}
+			return pool.usedBytes+extra+requestTokens*reqRate <= pool.totalBytes
+		}
 	}
 	extra := int64(snap.pendingMaxTokensAllModels) - pool.committed
 	if extra < 0 {
@@ -190,25 +214,34 @@ func pooledBudgetAdmits(snap routingSnapshot, requestTokens int64) bool {
 // snap.kvBytesPerToken) with the same inputs, so the public capacity feed
 // (/v1/models[/capacity]) cannot advertise pooled headroom the admission gate
 // refuses. Both branch identically: BYTES when the pool is byte-reconstructable
-// (byteMode), every pending charge normalized (pendingBytesKnown), and THIS
-// model's KV rate is known (modelRate > 0 — its resident slot; 0 for a
-// cold/absent slot, matching the gate's cold path); token accounting otherwise.
-// Returns -1 when the provider reports no pooled budget (total <= 0) — the "no
-// pooled constraint" sentinel that leaves the per-slot numbers unclamped.
+// (byteMode) and every pending charge normalized (pendingBytesKnown), pricing
+// this model at modelRate when its resident slot reports one (> 0) and at the
+// box's max resident rate (pool.maxKVBytesPerToken) for a cold/absent slot
+// (modelRate == 0) — the SAME cold-rate substitution pooledBudgetAdmits uses,
+// so the two stay equivalent. Token accounting ONLY when !byteMode or
+// !pendingBytesKnown. Returns -1 when the provider reports no pooled budget
+// (total <= 0) — the "no pooled constraint" sentinel that leaves the per-slot
+// numbers unclamped.
 func pooledRemainingTokens(pool pooledTokenBudget, pendingTokensAllModels int, pendingBytesAllModels int64, pendingBytesKnown bool, modelRate int64) int64 {
 	if pool.total <= 0 {
 		return -1
 	}
-	if pool.byteMode && pendingBytesKnown && modelRate > 0 {
-		extra := pendingBytesAllModels - pool.committedBytes
-		if extra < 0 {
-			extra = 0
+	if pool.byteMode && pendingBytesKnown {
+		rate := modelRate
+		if rate <= 0 {
+			rate = pool.maxKVBytesPerToken // cold/absent slot: box's max rate
 		}
-		remBytes := pool.totalBytes - pool.usedBytes - extra
-		if remBytes < 0 {
-			remBytes = 0
+		if rate > 0 {
+			extra := pendingBytesAllModels - pool.committedBytes
+			if extra < 0 {
+				extra = 0
+			}
+			remBytes := pool.totalBytes - pool.usedBytes - extra
+			if remBytes < 0 {
+				remBytes = 0
+			}
+			return remBytes / rate
 		}
-		return remBytes / modelRate
 	}
 	extra := int64(pendingTokensAllModels) - pool.committed
 	if extra < 0 {

--- a/coordinator/registry/pooled_admission.go
+++ b/coordinator/registry/pooled_admission.go
@@ -30,6 +30,30 @@ import "github.com/eigeninference/d-inference/coordinator/protocol"
 // against it — the byte form is what makes a small-KV model's burst visible
 // to a big-KV co-resident and vice versa.
 
+// maxKVBytesPerToken bounds a slot's reported per-token KV cost before it enters
+// byte-pool math. Heartbeat token counts are clamped to ~10B upstream, but
+// slot.KVBytesPerToken is UNBOUNDED — a garbage or malicious rate multiplied by
+// a large token count overflows int64 to a negative usedBytes/totalBytes, which
+// silently breaks admission (a negative pool total either rejects everything or,
+// with a negative left side, admits everything). 16 MiB/token is ~160× gemma's
+// real ~100 kB/token, so every legitimate rate passes untouched; the product
+// with the 10B-token clamp is 1.68e17, and the per-slot sums stay far below
+// int64max (9.2e18).
+const maxKVBytesPerToken = 1 << 24 // 16 MiB per token
+
+// clampKVBytesPerToken floors a per-token KV rate at 0 and caps it at
+// maxKVBytesPerToken so byte-pool products cannot overflow. A negative rate is
+// treated as absent (0), matching the pool's "no byte rate" handling.
+func clampKVBytesPerToken(r int64) int64 {
+	if r < 0 {
+		return 0
+	}
+	if r > maxKVBytesPerToken {
+		return maxKVBytesPerToken
+	}
+	return r
+}
+
 // pooledTokenBudget is a provider's reconstructed whole-box token budget,
 // carried in token units always and additionally in byte units when every
 // budget slot reports KVBytesPerToken (byteMode).
@@ -92,7 +116,10 @@ func providerPooledTokenBudget(slots []protocol.BackendSlotCapacity) pooledToken
 			c = 0
 		}
 		pool.committed += c
-		if slot.KVBytesPerToken <= 0 {
+		// Clamp the raw rate ONCE (overflow guard, see maxKVBytesPerToken) and
+		// use the clamped value for the map store and every byte product below.
+		rate := clampKVBytesPerToken(slot.KVBytesPerToken)
+		if rate <= 0 {
 			// A budget slot without a KV rate makes byte reconstruction
 			// impossible for the whole pool (legacy provider build).
 			pool.byteMode = false
@@ -101,12 +128,12 @@ func providerPooledTokenBudget(slots []protocol.BackendSlotCapacity) pooledToken
 		if pool.kvBytesPerToken == nil {
 			pool.kvBytesPerToken = make(map[string]int64, len(slots))
 		}
-		pool.kvBytesPerToken[slot.Model] = slot.KVBytesPerToken
-		pool.usedBytes += slotUsed * slot.KVBytesPerToken
-		pool.committedBytes += c * slot.KVBytesPerToken
+		pool.kvBytesPerToken[slot.Model] = rate
+		pool.usedBytes += slotUsed * rate
+		pool.committedBytes += c * rate
 		// Per-slot free headroom in bytes; all slots see the same shared byte
 		// pool, so the largest is the live shared headroom (counted once).
-		if free := (slot.ActiveTokenBudgetMax - slotUsed) * slot.KVBytesPerToken; free > sharedFreeBytes {
+		if free := (slot.ActiveTokenBudgetMax - slotUsed) * rate; free > sharedFreeBytes {
 			sharedFreeBytes = free
 		}
 	}

--- a/coordinator/registry/pooled_admission.go
+++ b/coordinator/registry/pooled_admission.go
@@ -16,8 +16,23 @@ import "github.com/eigeninference/d-inference/coordinator/protocol"
 // pool reduces to the slot's own budget and the arithmetic matches the
 // per-slot check exactly) and for legacy providers that report no token
 // budget (total = 0).
+//
+// Units: the shared pool is physically BYTES of unified memory, and
+// co-resident models spend it at different per-token rates
+// (BackendSlotCapacity.KVBytesPerToken — a 26B model's token costs ~10× a
+// small model's), so tokens are not a common unit across slots. When every
+// budget slot reports its KV rate, the pool and all charges against it are
+// normalized into bytes; otherwise (any legacy slot, or a pending/incoming
+// request whose model has no reported rate) the check falls back to token
+// accounting, which is exactly the pre-byte behavior. Token accounting
+// denominates the pool in the LARGEST per-slot free-token view (the
+// smallest-KV model's), so a big-KV model's pending burst is under-charged
+// against it — the byte form is what makes a small-KV model's burst visible
+// to a big-KV co-resident and vice versa.
 
-// pooledTokenBudget is a provider's reconstructed whole-box token budget.
+// pooledTokenBudget is a provider's reconstructed whole-box token budget,
+// carried in token units always and additionally in byte units when every
+// budget slot reports KVBytesPerToken (byteMode).
 type pooledTokenBudget struct {
 	// used is Σ (ActiveTokenBudgetUsed + QueuedTokenBudget) across budget
 	// slots — reservations the provider itself reports as live.
@@ -31,6 +46,23 @@ type pooledTokenBudget struct {
 	// (which add across slots) plus the shared free headroom counted exactly
 	// once (per-slot maxes are NOT additive).
 	total int64
+
+	// usedBytes / committedBytes / totalBytes are the byte-normalized analogs
+	// of used / committed / total: each slot's token quantities × that slot's
+	// KVBytesPerToken, with the shared free headroom again counted once (the
+	// largest per-slot free BYTE view — in byte space every slot observes the
+	// same shared pool). Only meaningful when byteMode is true.
+	usedBytes      int64
+	committedBytes int64
+	totalBytes     int64
+	// byteMode is true when there is at least one budget slot and EVERY budget
+	// slot reports KVBytesPerToken > 0, i.e. the pool can be reconstructed in
+	// bytes. False ⇒ pooledBudgetAdmits uses token accounting exactly.
+	byteMode bool
+	// kvBytesPerToken maps each budget slot's model to its reported per-token
+	// KV rate, for normalizing coordinator-pending charges into bytes. Nil
+	// when no budget slot reports a rate.
+	kvBytesPerToken map[string]int64
 }
 
 // providerPooledTokenBudget reconstructs the provider's pooled budget from its
@@ -40,10 +72,17 @@ type pooledTokenBudget struct {
 // pooledBudgetAdmits treats as "no pooled constraint".
 func providerPooledTokenBudget(slots []protocol.BackendSlotCapacity) pooledTokenBudget {
 	used, total := providerTokenBudget(slots)
-	var committed int64
+	pool := pooledTokenBudget{used: used, total: total, byteMode: true}
+	budgetSlots := 0
+	var sharedFreeBytes int64
 	for _, slot := range slots {
 		if slot.ActiveTokenBudgetMax <= 0 {
 			continue
+		}
+		budgetSlots++
+		slotUsed := slot.ActiveTokenBudgetUsed + slot.QueuedTokenBudget
+		if slotUsed < 0 {
+			slotUsed = 0
 		}
 		c := slot.ActiveTokenBudgetUsed + slot.QueuedTokenBudget
 		if slot.MaxTokensPotential > c {
@@ -52,24 +91,59 @@ func providerPooledTokenBudget(slots []protocol.BackendSlotCapacity) pooledToken
 		if c < 0 {
 			c = 0
 		}
-		committed += c
+		pool.committed += c
+		if slot.KVBytesPerToken <= 0 {
+			// A budget slot without a KV rate makes byte reconstruction
+			// impossible for the whole pool (legacy provider build).
+			pool.byteMode = false
+			continue
+		}
+		if pool.kvBytesPerToken == nil {
+			pool.kvBytesPerToken = make(map[string]int64, len(slots))
+		}
+		pool.kvBytesPerToken[slot.Model] = slot.KVBytesPerToken
+		pool.usedBytes += slotUsed * slot.KVBytesPerToken
+		pool.committedBytes += c * slot.KVBytesPerToken
+		// Per-slot free headroom in bytes; all slots see the same shared byte
+		// pool, so the largest is the live shared headroom (counted once).
+		if free := (slot.ActiveTokenBudgetMax - slotUsed) * slot.KVBytesPerToken; free > sharedFreeBytes {
+			sharedFreeBytes = free
+		}
 	}
-	return pooledTokenBudget{used: used, committed: committed, total: total}
+	if budgetSlots == 0 {
+		pool.byteMode = false
+	}
+	pool.totalBytes = pool.committedBytes + sharedFreeBytes
+	return pool
 }
 
 // pooledBudgetAdmits reports whether a request of requestTokens fits the
 // provider's shared pool once every model's coordinator-side pending tokens
-// (pendingMaxTokensAllModels) are charged against it. The subtraction of
-// pool.committed mirrors the per-slot check's committedTokenBudget subtraction
-// (avoid double-counting requests the heartbeat already reflects), floored at
-// zero. total <= 0 means the provider reported no pooled budget (legacy
-// provider, or a snapshot built without backend capacity) — no pooled
-// constraint, the caller's other gates decide.
-func pooledBudgetAdmits(pool pooledTokenBudget, pendingMaxTokensAllModels int, requestTokens int64) bool {
+// (snap.pendingMaxTokensAllModels / snap.pendingMaxBytesAllModels) are charged
+// against it. The subtraction of the committed baseline mirrors the per-slot
+// check's committedTokenBudget subtraction (avoid double-counting requests the
+// heartbeat already reflects), floored at zero. total <= 0 means the provider
+// reported no pooled budget (legacy provider, or a snapshot built without
+// backend capacity) — no pooled constraint, the caller's other gates decide.
+//
+// The check runs in BYTES when the pool is byte-reconstructable (byteMode),
+// every pending charge was normalizable (snap.pendingBytesKnown), and the
+// incoming request's own KV rate is known (snap.kvBytesPerToken — this
+// model's slot; 0 for a cold/absent slot). Any gap falls back to token
+// accounting, which is byte-for-byte the legacy-provider behavior.
+func pooledBudgetAdmits(snap routingSnapshot, requestTokens int64) bool {
+	pool := snap.pooledTokenBudget
 	if pool.total <= 0 {
 		return true
 	}
-	extra := int64(pendingMaxTokensAllModels) - pool.committed
+	if pool.byteMode && snap.pendingBytesKnown && snap.kvBytesPerToken > 0 {
+		extra := snap.pendingMaxBytesAllModels - pool.committedBytes
+		if extra < 0 {
+			extra = 0
+		}
+		return pool.usedBytes+extra+requestTokens*snap.kvBytesPerToken <= pool.totalBytes
+	}
+	extra := int64(snap.pendingMaxTokensAllModels) - pool.committed
 	if extra < 0 {
 		extra = 0
 	}

--- a/coordinator/registry/pooled_admission.go
+++ b/coordinator/registry/pooled_admission.go
@@ -1,0 +1,77 @@
+package registry
+
+import "github.com/eigeninference/d-inference/coordinator/protocol"
+
+// pooled_admission.go — provider-level (all-models) token-budget admission.
+//
+// A provider's per-model slots do NOT own private KV budgets: each slot's
+// ActiveTokenBudgetMax is (that slot's committed tokens) + the box's ONE
+// shared live KV headroom (see providerTokenBudget, utilization.go). The
+// per-slot admission check in freeMemoryAdmits therefore lets two co-resident
+// models double-spend the shared pool inside the ~30s heartbeat gap: a burst
+// admitted against model A's slot max is invisible to model B's slot max
+// until the next heartbeat re-reports both. The pooled check here closes that
+// gap by admitting against the reconstructed whole-box pool with ALL models'
+// coordinator-pending tokens counted. Inert for single-model providers (the
+// pool reduces to the slot's own budget and the arithmetic matches the
+// per-slot check exactly) and for legacy providers that report no token
+// budget (total = 0).
+
+// pooledTokenBudget is a provider's reconstructed whole-box token budget.
+type pooledTokenBudget struct {
+	// used is Σ (ActiveTokenBudgetUsed + QueuedTokenBudget) across budget
+	// slots — reservations the provider itself reports as live.
+	used int64
+	// committed is the all-slots analog of committedTokenBudget: Σ per slot of
+	// max(used+queued, MaxTokensPotential). It is the heartbeat-visible
+	// commitment baseline subtracted from coordinator-pending tokens so
+	// requests the provider already accounts for are not double-counted.
+	committed int64
+	// total is the pooled capacity from providerTokenBudget: committed tokens
+	// (which add across slots) plus the shared free headroom counted exactly
+	// once (per-slot maxes are NOT additive).
+	total int64
+}
+
+// providerPooledTokenBudget reconstructs the provider's pooled budget from its
+// backend slots. Slots without a token budget (ActiveTokenBudgetMax <= 0) are
+// ignored and negative per-slot values floored, mirroring providerTokenBudget.
+// A nil/empty slice (or no budget slots at all) yields the zero value, which
+// pooledBudgetAdmits treats as "no pooled constraint".
+func providerPooledTokenBudget(slots []protocol.BackendSlotCapacity) pooledTokenBudget {
+	used, total := providerTokenBudget(slots)
+	var committed int64
+	for _, slot := range slots {
+		if slot.ActiveTokenBudgetMax <= 0 {
+			continue
+		}
+		c := slot.ActiveTokenBudgetUsed + slot.QueuedTokenBudget
+		if slot.MaxTokensPotential > c {
+			c = slot.MaxTokensPotential
+		}
+		if c < 0 {
+			c = 0
+		}
+		committed += c
+	}
+	return pooledTokenBudget{used: used, committed: committed, total: total}
+}
+
+// pooledBudgetAdmits reports whether a request of requestTokens fits the
+// provider's shared pool once every model's coordinator-side pending tokens
+// (pendingMaxTokensAllModels) are charged against it. The subtraction of
+// pool.committed mirrors the per-slot check's committedTokenBudget subtraction
+// (avoid double-counting requests the heartbeat already reflects), floored at
+// zero. total <= 0 means the provider reported no pooled budget (legacy
+// provider, or a snapshot built without backend capacity) — no pooled
+// constraint, the caller's other gates decide.
+func pooledBudgetAdmits(pool pooledTokenBudget, pendingMaxTokensAllModels int, requestTokens int64) bool {
+	if pool.total <= 0 {
+		return true
+	}
+	extra := int64(pendingMaxTokensAllModels) - pool.committed
+	if extra < 0 {
+		extra = 0
+	}
+	return pool.used+extra+requestTokens <= pool.total
+}

--- a/coordinator/registry/pooled_admission_test.go
+++ b/coordinator/registry/pooled_admission_test.go
@@ -1,0 +1,222 @@
+package registry
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+)
+
+func TestProviderPooledTokenBudget(t *testing.T) {
+	cases := []struct {
+		name      string
+		slots     []protocol.BackendSlotCapacity
+		used      int64
+		committed int64
+		total     int64
+	}{
+		{name: "nil_slots"},
+		{
+			name: "single_slot",
+			slots: []protocol.BackendSlotCapacity{
+				{Model: "a", ActiveTokenBudgetMax: 10_000, ActiveTokenBudgetUsed: 1_000, QueuedTokenBudget: 500, MaxTokensPotential: 3_000},
+			},
+			used:      1_500,
+			committed: 3_000, // potential dominates used+queued
+			total:     10_000,
+		},
+		{
+			name: "two_slots_shared_headroom_counted_once",
+			// Both slots see the same 8k shared free headroom:
+			// maxA = 2k committed + 8k, maxB = 1k committed + 8k.
+			slots: []protocol.BackendSlotCapacity{
+				{Model: "a", ActiveTokenBudgetMax: 10_000, ActiveTokenBudgetUsed: 2_000},
+				{Model: "b", ActiveTokenBudgetMax: 9_000, ActiveTokenBudgetUsed: 1_000},
+			},
+			used:      3_000,
+			committed: 3_000,
+			total:     11_000, // 3k committed + 8k shared free ONCE (not 19k)
+		},
+		{
+			name: "budgetless_slot_ignored_negatives_floored",
+			slots: []protocol.BackendSlotCapacity{
+				{Model: "a", ActiveTokenBudgetMax: 10_000, ActiveTokenBudgetUsed: -50, MaxTokensPotential: -10},
+				{Model: "legacy", ActiveTokenBudgetMax: 0, ActiveTokenBudgetUsed: 5_000},
+			},
+			used:      0,
+			committed: 0,
+			total:     10_000,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := providerPooledTokenBudget(tc.slots)
+			if got.used != tc.used || got.committed != tc.committed || got.total != tc.total {
+				t.Fatalf("providerPooledTokenBudget = %+v, want {used:%d committed:%d total:%d}",
+					got, tc.used, tc.committed, tc.total)
+			}
+		})
+	}
+}
+
+// TestPooledAdmissionCoResidencyDoubleSpend is the heartbeat-gap regression,
+// driven through the REAL reservation path: two co-resident models report
+// per-slot maxes that each equal the ONE shared 10k KV pool. A burst to model
+// A consumes the whole pool coordinator-side while the provider's heartbeat
+// still reads used=0 — the old per-slot check (same-model pending only) then
+// happily admitted model B against ITS stale slot max, double-spending the
+// pool. The pooled check must reject B. Fails without the
+// pooledBudgetAdmits call in freeMemoryAdmits.
+func TestPooledAdmissionCoResidencyDoubleSpend(t *testing.T) {
+	reg := New(testLogger())
+	p := makeSchedulerProvider(t, reg, "shared-box", gptossBuild, 93)
+	addAdvertisedModel(p, gemmaBuild)
+	p.mu.Lock()
+	p.BackendCapacity.Slots[0].ActiveTokenBudgetMax = 10_000
+	p.BackendCapacity.Slots = append(p.BackendCapacity.Slots, protocol.BackendSlotCapacity{
+		Model:                gemmaBuild,
+		State:                "running",
+		ActiveTokenBudgetMax: 10_000,
+	})
+	p.mu.Unlock()
+
+	// Burst model A (gpt-oss): five requests × (100 prompt + 1_900 max) =
+	// 10_000 tokens — exactly the pool — all inside one heartbeat gap.
+	for i := 0; i < 5; i++ {
+		pr := &PendingRequest{
+			RequestID:             fmt.Sprintf("burst-%d", i),
+			Model:                 gptossBuild,
+			EstimatedPromptTokens: 100,
+			RequestedMaxTokens:    1_900,
+		}
+		if got := reg.ReserveProvider(gptossBuild, pr); got == nil {
+			t.Fatalf("burst request %d rejected; 5×2k must fit the 10k pool", i)
+		}
+	}
+	// A sixth same-model request must be rejected (slot and pool both full) —
+	// the pre-existing per-slot behavior, unchanged.
+	if got := reg.ReserveProvider(gptossBuild, &PendingRequest{
+		RequestID: "burst-overflow", Model: gptossBuild, EstimatedPromptTokens: 100, RequestedMaxTokens: 1_900,
+	}); got != nil {
+		t.Fatalf("6th same-model request admitted past the slot budget on %q", got.ID)
+	}
+
+	// Model B (gemma) within the same gap: B's slot still reads max 10_000 /
+	// used 0, so the old check admits — but the shared pool is already fully
+	// pending to A. Must be rejected.
+	if got := reg.ReserveProvider(gemmaBuild, &PendingRequest{
+		RequestID: "victim", Model: gemmaBuild, EstimatedPromptTokens: 100, RequestedMaxTokens: 1_900,
+	}); got != nil {
+		t.Fatalf("gemma admitted during the heartbeat gap — co-resident double-spend of the shared KV pool (provider %q)", got.ID)
+	}
+}
+
+// TestPooledAdmissionAllowsCoResidentWithinPool is the non-regression control:
+// when the pool has real headroom left, a co-resident model's request IS
+// admitted — the pooled gate only charges what is actually pending.
+func TestPooledAdmissionAllowsCoResidentWithinPool(t *testing.T) {
+	reg := New(testLogger())
+	p := makeSchedulerProvider(t, reg, "shared-box", gptossBuild, 93)
+	addAdvertisedModel(p, gemmaBuild)
+	p.mu.Lock()
+	p.BackendCapacity.Slots[0].ActiveTokenBudgetMax = 10_000
+	p.BackendCapacity.Slots = append(p.BackendCapacity.Slots, protocol.BackendSlotCapacity{
+		Model:                gemmaBuild,
+		State:                "running",
+		ActiveTokenBudgetMax: 10_000,
+	})
+	p.mu.Unlock()
+
+	for i := 0; i < 2; i++ { // 4k of the 10k pool
+		pr := &PendingRequest{
+			RequestID:             fmt.Sprintf("burst-%d", i),
+			Model:                 gptossBuild,
+			EstimatedPromptTokens: 100,
+			RequestedMaxTokens:    1_900,
+		}
+		if got := reg.ReserveProvider(gptossBuild, pr); got == nil {
+			t.Fatalf("burst request %d rejected with pool mostly free", i)
+		}
+	}
+	if got := reg.ReserveProvider(gemmaBuild, &PendingRequest{
+		RequestID: "fits", Model: gemmaBuild, EstimatedPromptTokens: 100, RequestedMaxTokens: 1_900,
+	}); got == nil {
+		t.Fatal("gemma rejected although the pool has 6k headroom (pooled gate over-rejecting)")
+	}
+}
+
+// TestFreeMemoryAdmitsSingleModelUnchanged pins that the pooled check is
+// arithmetically inert for single-model providers: for one budget slot the
+// pool reduces to that slot's own budget and the admission boundary is
+// byte-for-byte the old per-slot one — including the case where
+// MaxTokensPotential dominates used+queued in the committed baseline.
+func TestFreeMemoryAdmitsSingleModelUnchanged(t *testing.T) {
+	slot := protocol.BackendSlotCapacity{
+		Model:                 "m",
+		ActiveTokenBudgetMax:  10_000,
+		ActiveTokenBudgetUsed: 3_000,
+		QueuedTokenBudget:     500,
+		MaxTokensPotential:    6_000,
+	}
+	// Old per-slot formula: used+queued + max(0, pending − max(used+queued,
+	// potential)) + req ≤ max → 3_500 + 1_000 + req ≤ 10_000 → req ≤ 5_500.
+	mkSnap := func(pending int) routingSnapshot {
+		return routingSnapshot{
+			pendingMaxTokens:          pending,
+			pendingMaxTokensAllModels: pending, // single model: identical
+			activeTokenBudgetUsed:     slot.ActiveTokenBudgetUsed,
+			activeTokenBudgetMax:      slot.ActiveTokenBudgetMax,
+			queuedTokenBudget:         slot.QueuedTokenBudget,
+			maxTokensPotential:        slot.MaxTokensPotential,
+			pooledTokenBudget:         providerPooledTokenBudget([]protocol.BackendSlotCapacity{slot}),
+		}
+	}
+	if !freeMemoryAdmits(mkSnap(7_000), 0, 5_500) {
+		t.Fatal("request at the exact old boundary (5_500) rejected — pooled check changed single-model behavior")
+	}
+	if freeMemoryAdmits(mkSnap(7_000), 0, 5_501) {
+		t.Fatal("request past the old boundary (5_501) admitted — budget admission loosened")
+	}
+}
+
+// TestFreeMemoryAdmitsPooledRejectsGapDoubleSpend is the pure-function version
+// of the double-spend regression (fails without the pooledBudgetAdmits call):
+// model B's own slot budget admits, but the all-models pending has consumed
+// the pool.
+func TestFreeMemoryAdmitsPooledRejectsGapDoubleSpend(t *testing.T) {
+	slots := []protocol.BackendSlotCapacity{
+		{Model: "a", ActiveTokenBudgetMax: 10_000},
+		{Model: "b", ActiveTokenBudgetMax: 10_000},
+	}
+	snap := routingSnapshot{
+		// Snapshot for model B: no same-model pending, stale heartbeat (used 0).
+		pendingMaxTokens:          0,
+		pendingMaxTokensAllModels: 10_000, // model A's in-gap burst
+		activeTokenBudgetMax:      10_000,
+		pooledTokenBudget:         providerPooledTokenBudget(slots),
+	}
+	if freeMemoryAdmits(snap, 100, 1_900) {
+		t.Fatal("admitted 2k tokens into a pool with 10k already pending to a co-resident model (per-slot double-spend)")
+	}
+	// Same snapshot with only 4k pending across models → admits.
+	snap.pendingMaxTokensAllModels = 4_000
+	if !freeMemoryAdmits(snap, 100, 1_900) {
+		t.Fatal("rejected 2k tokens although the pool has 6k of headroom")
+	}
+}
+
+// TestFreeMemoryAdmitsLegacyProviderUnchanged: providers that report no token
+// budget (ActiveTokenBudgetMax == 0) never reach the budget branch — the
+// legacy memory-estimation path is untouched by the pooled fields.
+func TestFreeMemoryAdmitsLegacyProviderUnchanged(t *testing.T) {
+	snap := routingSnapshot{
+		modelLoaded:               true,
+		totalMemoryGB:             64,
+		gpuMemoryActiveGB:         10,
+		modelSizeGB:               14,
+		pendingMaxTokensAllModels: 1 << 30, // must be ignored on the legacy path
+	}
+	if !freeMemoryAdmits(snap, 100, 1_900) {
+		t.Fatal("legacy (budget-less) admission changed: loaded model with free memory must admit")
+	}
+}

--- a/coordinator/registry/pooled_admission_test.go
+++ b/coordinator/registry/pooled_admission_test.go
@@ -346,6 +346,88 @@ func TestPooledAdmissionByteDoubleSpendRealPath(t *testing.T) {
 	}
 }
 
+// TestFreeMemoryAdmitsColdModelChargesPool is the cold-slot pooled-gate
+// regression (pure-function form): the target model reports NO budget slot
+// (activeTokenBudgetMax == 0, not loaded here), so it skips the budget branch
+// entirely — but a resident co-model's slot reports the shared pool, and the
+// in-gap pending burst has already consumed it. The cold request must be
+// charged against the pool too, or it double-spends the same KV the resident
+// pending will occupy. Fails without the cold-path pooledBudgetAdmits call.
+func TestFreeMemoryAdmitsColdModelChargesPool(t *testing.T) {
+	slots := []protocol.BackendSlotCapacity{
+		{Model: "resident", ActiveTokenBudgetMax: 10_000},
+	}
+	mkSnap := func(pendingAllModels int) routingSnapshot {
+		return routingSnapshot{
+			// Snapshot for a COLD model: no slot, no budget, model not loaded.
+			pendingMaxTokensAllModels: pendingAllModels,
+			pooledTokenBudget:         providerPooledTokenBudget(slots),
+		}
+	}
+	if freeMemoryAdmits(mkSnap(10_000), 100, 1_900) {
+		t.Fatal("cold request admitted into a pool fully pending to a resident model (cold path skipped the pooled gate)")
+	}
+	// Control: with 4k of the 10k pool pending, the 2k cold request fits.
+	if !freeMemoryAdmits(mkSnap(4_000), 100, 1_900) {
+		t.Fatal("cold request rejected although the pool has 6k of headroom")
+	}
+}
+
+// TestPooledAdmissionColdModelDoubleSpendRealPath mirrors
+// TestPooledAdmissionCoResidencyDoubleSpend with the target model COLD: gemma
+// is advertised but has no backend slot, so its requests take the
+// non-budget admission path. An in-gap burst to the resident gpt-oss slot
+// consumes the whole shared pool; the cold gemma request must still be
+// rejected. Fails without the cold-path pooled gate in freeMemoryAdmits.
+func TestPooledAdmissionColdModelDoubleSpendRealPath(t *testing.T) {
+	reg := New(testLogger())
+	p := makeSchedulerProvider(t, reg, "shared-box", gptossBuild, 93)
+	addAdvertisedModel(p, gemmaBuild) // advertised, NOT loaded: no gemma slot
+	p.mu.Lock()
+	p.BackendCapacity.Slots[0].ActiveTokenBudgetMax = 10_000
+	p.mu.Unlock()
+
+	// Burst the resident model: five requests × 2k tokens = the whole pool.
+	for i := 0; i < 5; i++ {
+		pr := &PendingRequest{
+			RequestID:             fmt.Sprintf("burst-%d", i),
+			Model:                 gptossBuild,
+			EstimatedPromptTokens: 100,
+			RequestedMaxTokens:    1_900,
+		}
+		if got := reg.ReserveProvider(gptossBuild, pr); got == nil {
+			t.Fatalf("burst request %d rejected; 5×2k must fit the 10k pool", i)
+		}
+	}
+	// Cold gemma within the same gap: no slot to check, but the pool is fully
+	// pending to gpt-oss — the post-load KV for this request does not exist.
+	if got := reg.ReserveProvider(gemmaBuild, &PendingRequest{
+		RequestID: "victim", Model: gemmaBuild, EstimatedPromptTokens: 100, RequestedMaxTokens: 1_900,
+	}); got != nil {
+		t.Fatalf("cold gemma admitted during the heartbeat gap — pool double-spend via the budget-less path (provider %q)", got.ID)
+	}
+
+	// Control: on a fresh box with only 4k pending, the cold request admits.
+	reg2 := New(testLogger())
+	p2 := makeSchedulerProvider(t, reg2, "shared-box-2", gptossBuild, 93)
+	addAdvertisedModel(p2, gemmaBuild)
+	p2.mu.Lock()
+	p2.BackendCapacity.Slots[0].ActiveTokenBudgetMax = 10_000
+	p2.mu.Unlock()
+	for i := 0; i < 2; i++ {
+		if got := reg2.ReserveProvider(gptossBuild, &PendingRequest{
+			RequestID: fmt.Sprintf("light-%d", i), Model: gptossBuild, EstimatedPromptTokens: 100, RequestedMaxTokens: 1_900,
+		}); got == nil {
+			t.Fatalf("light burst request %d rejected", i)
+		}
+	}
+	if got := reg2.ReserveProvider(gemmaBuild, &PendingRequest{
+		RequestID: "fits", Model: gemmaBuild, EstimatedPromptTokens: 100, RequestedMaxTokens: 1_900,
+	}); got == nil {
+		t.Fatal("cold gemma rejected although the pool has 6k of headroom (cold pooled gate over-rejecting)")
+	}
+}
+
 // TestFreeMemoryAdmitsLegacyProviderUnchanged: providers that report no token
 // budget (ActiveTokenBudgetMax == 0) never reach the budget branch — the
 // legacy memory-estimation path is untouched by the pooled fields.

--- a/coordinator/registry/pooled_admission_test.go
+++ b/coordinator/registry/pooled_admission_test.go
@@ -205,6 +205,147 @@ func TestFreeMemoryAdmitsPooledRejectsGapDoubleSpend(t *testing.T) {
 	}
 }
 
+// TestProviderPooledTokenBudgetByteNormalization pins the byte-space
+// reconstruction: per-slot token quantities scale by that slot's own
+// KVBytesPerToken, the shared free headroom is the largest per-slot free BYTE
+// view counted once, and a single budget slot without a KV rate disables byte
+// mode for the whole pool (legacy provider build).
+func TestProviderPooledTokenBudgetByteNormalization(t *testing.T) {
+	// Big-KV model A: 10k tokens × 100kB/token headroom = 1 GB.
+	// Small-KV model B: 100k tokens × 10kB/token = the SAME 1 GB pool.
+	slots := []protocol.BackendSlotCapacity{
+		{Model: "a", ActiveTokenBudgetMax: 10_000, KVBytesPerToken: 100_000},
+		{Model: "b", ActiveTokenBudgetMax: 100_000, KVBytesPerToken: 10_000},
+	}
+	pool := providerPooledTokenBudget(slots)
+	if !pool.byteMode {
+		t.Fatal("byteMode = false with every budget slot reporting a KV rate")
+	}
+	if pool.totalBytes != 1_000_000_000 || pool.usedBytes != 0 || pool.committedBytes != 0 {
+		t.Fatalf("byte pool = {used:%d committed:%d total:%d}, want {0 0 1e9} (shared free bytes counted once)",
+			pool.usedBytes, pool.committedBytes, pool.totalBytes)
+	}
+	// Token space is denominated by the LARGEST free-token view (B's 100k) —
+	// the very distortion byte mode exists to correct.
+	if pool.total != 100_000 {
+		t.Fatalf("token pool total = %d, want 100_000", pool.total)
+	}
+
+	// One budget slot without a rate → byte reconstruction impossible.
+	mixed := providerPooledTokenBudget([]protocol.BackendSlotCapacity{
+		{Model: "a", ActiveTokenBudgetMax: 10_000, KVBytesPerToken: 100_000},
+		{Model: "legacy", ActiveTokenBudgetMax: 9_000},
+	})
+	if mixed.byteMode {
+		t.Fatal("byteMode = true although a budget slot reports no KVBytesPerToken")
+	}
+}
+
+// TestFreeMemoryAdmitsByteNormalizedHeterogeneousKV is the X-unit regression:
+// co-resident slots with different KVBytesPerToken share ONE byte pool, so
+// token counts are not a common unit. A 90k-token pending burst on the
+// small-KV model (10 kB/token = 0.9 GB) leaves only 0.1 GB of the 1 GB pool,
+// so a 3k-token request to the big-KV model (100 kB/token = 0.3 GB) must be
+// rejected — token accounting (93k ≤ 100k) would admit it and the box OOMs.
+// Fails without the byte-normalized branch in pooledBudgetAdmits.
+func TestFreeMemoryAdmitsByteNormalizedHeterogeneousKV(t *testing.T) {
+	slots := []protocol.BackendSlotCapacity{
+		{Model: "big-kv", ActiveTokenBudgetMax: 10_000, KVBytesPerToken: 100_000},
+		{Model: "small-kv", ActiveTokenBudgetMax: 100_000, KVBytesPerToken: 10_000},
+	}
+	mkSnap := func(pendingSmallKVTokens int64) routingSnapshot {
+		return routingSnapshot{
+			// Snapshot for the big-KV model: no same-model pending, stale
+			// heartbeat (used 0), all pending is the small-KV burst.
+			activeTokenBudgetMax:      10_000,
+			kvBytesPerToken:           100_000,
+			pendingMaxTokensAllModels: int(pendingSmallKVTokens),
+			pendingMaxBytesAllModels:  pendingSmallKVTokens * 10_000,
+			pendingBytesKnown:         true,
+			pooledTokenBudget:         providerPooledTokenBudget(slots),
+		}
+	}
+	// 90k small-KV tokens pending = 0.9 GB; +0.3 GB request = 1.2 GB > 1 GB.
+	if freeMemoryAdmits(mkSnap(90_000), 100, 2_900) {
+		t.Fatal("admitted 0.3 GB of big-KV request into a byte pool with 0.9 GB already pending (token/byte unit confusion)")
+	}
+	// Control: 40k small-KV tokens pending = 0.4 GB; +0.3 GB = 0.7 GB ≤ 1 GB.
+	if !freeMemoryAdmits(mkSnap(40_000), 100, 2_900) {
+		t.Fatal("rejected a request although the byte pool has 0.6 GB of headroom (byte gate over-rejecting)")
+	}
+}
+
+// TestFreeMemoryAdmitsByteModeCorrectsTokenOverReject is the reverse sanity
+// case: when heartbeat skew leaves the token pool denominated by a SMALLER
+// free view than the true byte pool, token accounting over-rejects small-KV
+// work that genuinely fits in bytes. With the fix the byte check admits;
+// without it the token check (61k > 50k) wrongly rejects.
+func TestFreeMemoryAdmitsByteModeCorrectsTokenOverReject(t *testing.T) {
+	slots := []protocol.BackendSlotCapacity{
+		// Big-KV slot sees 1 GB free (10k × 100 kB); small-KV slot's staler
+		// view reports only 0.5 GB (50k × 10 kB). Token total = max(10k, 50k)
+		// = 50k tokens; byte total = max(1 GB, 0.5 GB) = 1 GB.
+		{Model: "big-kv", ActiveTokenBudgetMax: 10_000, KVBytesPerToken: 100_000},
+		{Model: "small-kv", ActiveTokenBudgetMax: 50_000, KVBytesPerToken: 10_000},
+	}
+	snap := routingSnapshot{
+		// Snapshot for the small-KV model with a 60k-token (0.6 GB) small-KV
+		// burst pending elsewhere on the box and a 1k-token (10 MB) request.
+		activeTokenBudgetMax:      50_000,
+		kvBytesPerToken:           10_000,
+		pendingMaxTokensAllModels: 60_000,
+		pendingMaxBytesAllModels:  600_000_000,
+		pendingBytesKnown:         true,
+		pooledTokenBudget:         providerPooledTokenBudget(slots),
+	}
+	if !pooledBudgetAdmits(snap, 1_000) {
+		t.Fatal("rejected 10 MB into a 1 GB byte pool holding 0.6 GB (token-unit over-rejection not corrected)")
+	}
+}
+
+// TestPooledAdmissionByteDoubleSpendRealPath drives the heterogeneous-KV
+// double-spend through the REAL reservation path: a small-KV burst that fits
+// the pool token-wise exhausts it byte-wise, so a big-KV co-resident request
+// inside the same heartbeat gap must be rejected. Fails without byte
+// normalization (token accounting reads 93k ≤ 100k and admits).
+func TestPooledAdmissionByteDoubleSpendRealPath(t *testing.T) {
+	reg := New(testLogger())
+	p := makeSchedulerProvider(t, reg, "shared-box", gptossBuild, 93)
+	addAdvertisedModel(p, gemmaBuild)
+	p.mu.Lock()
+	// gpt-oss: 10 kB/token → 100k-token view of the 1 GB shared pool.
+	p.BackendCapacity.Slots[0].ActiveTokenBudgetMax = 100_000
+	p.BackendCapacity.Slots[0].KVBytesPerToken = 10_000
+	// gemma: 100 kB/token → 10k-token view of the SAME 1 GB pool.
+	p.BackendCapacity.Slots = append(p.BackendCapacity.Slots, protocol.BackendSlotCapacity{
+		Model:                gemmaBuild,
+		State:                "running",
+		ActiveTokenBudgetMax: 10_000,
+		KVBytesPerToken:      100_000,
+	})
+	p.mu.Unlock()
+
+	// Burst gpt-oss: nine requests × 10k tokens = 90k tokens = 0.9 GB pending.
+	for i := 0; i < 9; i++ {
+		pr := &PendingRequest{
+			RequestID:             fmt.Sprintf("burst-%d", i),
+			Model:                 gptossBuild,
+			EstimatedPromptTokens: 500,
+			RequestedMaxTokens:    9_500,
+		}
+		if got := reg.ReserveProvider(gptossBuild, pr); got == nil {
+			t.Fatalf("burst request %d rejected; 9×10k tokens (0.9 GB) must fit the 1 GB pool", i)
+		}
+	}
+	// Gemma within the same gap: 3k tokens ≤ its 10k slot view and 93k ≤ 100k
+	// in token space — but 0.3 GB does NOT fit the 0.1 GB of byte headroom.
+	if got := reg.ReserveProvider(gemmaBuild, &PendingRequest{
+		RequestID: "victim", Model: gemmaBuild, EstimatedPromptTokens: 100, RequestedMaxTokens: 2_900,
+	}); got != nil {
+		t.Fatalf("gemma admitted during the heartbeat gap — token-unit accounting double-spent the byte pool (provider %q)", got.ID)
+	}
+}
+
 // TestFreeMemoryAdmitsLegacyProviderUnchanged: providers that report no token
 // budget (ActiveTokenBudgetMax == 0) never reach the budget branch — the
 // legacy memory-estimation path is untouched by the pooled fields.

--- a/coordinator/registry/pooled_admission_test.go
+++ b/coordinator/registry/pooled_admission_test.go
@@ -491,6 +491,113 @@ func TestModelCapacitySnapshotPooledBudgetClamp(t *testing.T) {
 	}
 }
 
+// TestPooledByteTotalFromLiveUsedNotCommitted is the double-count regression
+// (Finding 3): the byte pool total must be built from LIVE used bytes plus the
+// shared free headroom — mirroring the token path (providerTokenBudget uses
+// used+sharedFree) — NOT from committedBytes, which carries MaxTokensPotential
+// as the pending de-dup baseline. A co-resident slot whose potential (0.4 GB)
+// far exceeds its used (0) would otherwise inflate the 1 GB physical pool to
+// 1.4 GB, letting an in-gap burst overcommit the box's real KV. Fails without
+// the pool.usedBytes+sharedFreeBytes total in providerPooledTokenBudget.
+func TestPooledByteTotalFromLiveUsedNotCommitted(t *testing.T) {
+	slots := []protocol.BackendSlotCapacity{
+		// Big-KV slot with an active request whose POTENTIAL growth (4k tokens =
+		// 0.4 GB) dwarfs its live used (0). Shared free = 10k × 100 kB = 1 GB.
+		{Model: "big-kv", ActiveTokenBudgetMax: 10_000, KVBytesPerToken: 100_000, MaxTokensPotential: 4_000},
+		// Small-KV co-resident sees the SAME 1 GB pool (100k × 10 kB).
+		{Model: "small-kv", ActiveTokenBudgetMax: 100_000, KVBytesPerToken: 10_000},
+	}
+	pool := providerPooledTokenBudget(slots)
+	if !pool.byteMode {
+		t.Fatal("byteMode = false with every budget slot reporting a KV rate")
+	}
+	if pool.usedBytes != 0 {
+		t.Fatalf("usedBytes = %d, want 0 (no live used/queued on either slot)", pool.usedBytes)
+	}
+	if pool.committedBytes != 400_000_000 {
+		t.Fatalf("committedBytes = %d, want 4e8 (0.4 GB de-dup baseline from MaxTokensPotential)", pool.committedBytes)
+	}
+	if pool.totalBytes != 1_000_000_000 {
+		t.Fatalf("totalBytes = %d, want 1e9 (live used + shared free); committed potential must NOT inflate the pool total", pool.totalBytes)
+	}
+
+	// The admission gate must charge against the 1 GB physical pool, not the
+	// inflated 1.4 GB. A 12k-token big-KV request is 1.2 GB — slot A's 0.4 GB of
+	// potential is a de-dup baseline, not spare capacity, so it must be rejected.
+	snap := routingSnapshot{
+		activeTokenBudgetMax:      10_000,
+		kvBytesPerToken:           100_000,
+		pendingMaxBytesAllModels:  0,
+		pendingMaxTokensAllModels: 0,
+		pendingBytesKnown:         true,
+		pooledTokenBudget:         pool,
+	}
+	if pooledBudgetAdmits(snap, 12_000) {
+		t.Fatal("admitted 1.2 GB into a 1 GB byte pool — MaxTokensPotential double-counted as physical KV capacity")
+	}
+	// Control: 8k tokens = 0.8 GB genuinely fits the 1 GB pool.
+	if !pooledBudgetAdmits(snap, 8_000) {
+		t.Fatal("rejected 0.8 GB that fits the 1 GB byte pool (byte total under-counted)")
+	}
+}
+
+// TestModelCapacitySnapshotByteModePooledClamp is the byte-unit capacity-feed
+// regression (Finding 1): on a mixed-KV provider the public snapshot must
+// clamp advertised budget in BYTES, matching pooledBudgetAdmits, not in tokens.
+// A 0.9 GB small-KV burst leaves only 0.1 GB of the 1 GB pool — ~1k tokens for
+// the 100 kB/token big-KV model — but token accounting reads 90k << the 100k
+// token pool and would advertise ~10k gemma tokens the admission gate refuses.
+// Fails without routing the snapshot through the byte-aware pooledRemainingTokens.
+func TestModelCapacitySnapshotByteModePooledClamp(t *testing.T) {
+	reg := New(testLogger())
+	p := makeSchedulerProvider(t, reg, "shared-box", gptossBuild, 93)
+	addAdvertisedModel(p, gemmaBuild)
+	p.mu.Lock()
+	// gpt-oss small-KV: 10 kB/token → 100k-token view of the 1 GB pool.
+	p.BackendCapacity.Slots[0].ActiveTokenBudgetMax = 100_000
+	p.BackendCapacity.Slots[0].KVBytesPerToken = 10_000
+	// gemma big-KV: 100 kB/token → 10k-token view of the SAME 1 GB pool.
+	p.BackendCapacity.Slots = append(p.BackendCapacity.Slots, protocol.BackendSlotCapacity{
+		Model:                gemmaBuild,
+		State:                "running",
+		ActiveTokenBudgetMax: 10_000,
+		KVBytesPerToken:      100_000,
+	})
+	p.mu.Unlock()
+
+	// Burst gpt-oss: nine × 10k tokens = 90k tokens = 0.9 GB pending, all inside
+	// one heartbeat gap (slot used stays 0).
+	for i := 0; i < 9; i++ {
+		if got := reg.ReserveProvider(gptossBuild, &PendingRequest{
+			RequestID: fmt.Sprintf("burst-%d", i), Model: gptossBuild, EstimatedPromptTokens: 500, RequestedMaxTokens: 9_500,
+		}); got == nil {
+			t.Fatalf("burst request %d rejected; 0.9 GB must fit the 1 GB pool", i)
+		}
+	}
+
+	caps := make(map[string]ModelCapacity)
+	for _, c := range reg.ModelCapacitySnapshot() {
+		caps[c.ModelID] = c
+	}
+	gemma, ok := caps[gemmaBuild]
+	if !ok {
+		t.Fatalf("missing capacity row for %s", gemmaBuild)
+	}
+	// Byte-accurate: 0.1 GB remaining ÷ 100 kB/token = 1_000 gemma tokens.
+	// Token-mode (the bug) reports 100k pool − 90k pending = 10_000.
+	if gemma.TokenBudgetRemaining != 1_000 {
+		t.Fatalf("gemma token_budget_remaining = %d, want 1_000 (0.1 GB byte headroom); token-mode over-advertised the pool", gemma.TokenBudgetRemaining)
+	}
+
+	// Snapshot verdict must match the admission gate: a 3k-token (0.3 GB) gemma
+	// request does NOT fit the 0.1 GB byte headroom, so ReserveProvider rejects.
+	if got := reg.ReserveProvider(gemmaBuild, &PendingRequest{
+		RequestID: "probe", Model: gemmaBuild, EstimatedPromptTokens: 100, RequestedMaxTokens: 2_900,
+	}); got != nil {
+		t.Fatalf("gemma admitted 0.3 GB into 0.1 GB byte headroom (snapshot/gate disagree; provider %q)", got.ID)
+	}
+}
+
 // TestFreeMemoryAdmitsLegacyProviderUnchanged: providers that report no token
 // budget (ActiveTokenBudgetMax == 0) never reach the budget branch — the
 // legacy memory-estimation path is untouched by the pooled fields.

--- a/coordinator/registry/pooled_admission_test.go
+++ b/coordinator/registry/pooled_admission_test.go
@@ -642,6 +642,114 @@ func TestModelCapacitySnapshotByteModePooledClamp(t *testing.T) {
 	}
 }
 
+// TestPooledColdUnknownKVChargedInBytes is the cold unknown-KV regression: on a
+// byte-reconstructable mixed-KV box, a COLD request (its own model has no
+// resident slot, so snap.kvBytesPerToken == 0) must be priced CONSERVATIVELY in
+// bytes at the box's max resident rate, NOT collapse to token accounting that
+// under-charges a large-KV burst against the small-KV token view of the pool.
+// Fails without the maxKVBytesPerToken cold-rate substitution.
+func TestPooledColdUnknownKVChargedInBytes(t *testing.T) {
+	t.Run("mixed_kv_cold_priced_at_max_rate", func(t *testing.T) {
+		slots := []protocol.BackendSlotCapacity{
+			{Model: "big-kv", ActiveTokenBudgetMax: 10_000, KVBytesPerToken: 100_000},   // 1 GB view
+			{Model: "small-kv", ActiveTokenBudgetMax: 100_000, KVBytesPerToken: 10_000}, // same 1 GB
+		}
+		pool := providerPooledTokenBudget(slots)
+		if !pool.byteMode || pool.maxKVBytesPerToken != 100_000 {
+			t.Fatalf("pool byteMode=%v maxKVBytesPerToken=%d, want true / 100000", pool.byteMode, pool.maxKVBytesPerToken)
+		}
+		cold := routingSnapshot{
+			kvBytesPerToken:   0, // cold/absent slot
+			pendingBytesKnown: true,
+			pooledTokenBudget: pool,
+		}
+		// 50k tokens: token fallback would admit (50k ≤ 100k token pool); byte
+		// pricing at the 100 kB/token max rate = 5 GB ≫ 1 GB pool → reject.
+		if pooledBudgetAdmits(cold, 50_000) {
+			t.Fatal("cold large-KV request admitted via token fallback (5 GB into a 1 GB byte pool)")
+		}
+		// Control: 8k tokens = 0.8 GB fits the 1 GB byte pool.
+		if !pooledBudgetAdmits(cold, 8_000) {
+			t.Fatal("cold request rejected although 0.8 GB fits the 1 GB byte pool")
+		}
+		// Capacity feed mirrors the gate: 1 GB ÷ 100 kB/token = 10k tokens.
+		if rem := pooledRemainingTokens(pool, 0, 0, true, 0); rem != 10_000 {
+			t.Fatalf("cold pooledRemainingTokens = %d, want 10_000 (byte pool ÷ max rate)", rem)
+		}
+	})
+
+	// Single-KV byteMode box: a cold request priced at the sole resident rate is
+	// arithmetically identical to token accounting, so the boundary is unchanged.
+	t.Run("single_kv_cold_equals_token_boundary", func(t *testing.T) {
+		pool := providerPooledTokenBudget([]protocol.BackendSlotCapacity{
+			{Model: "m", ActiveTokenBudgetMax: 10_000, KVBytesPerToken: 50_000},
+		})
+		cold := routingSnapshot{kvBytesPerToken: 0, pendingBytesKnown: true, pooledTokenBudget: pool}
+		if !pooledBudgetAdmits(cold, 10_000) {
+			t.Fatal("cold request at the exact 10k boundary rejected (single-KV byte pricing changed the boundary)")
+		}
+		if pooledBudgetAdmits(cold, 10_001) {
+			t.Fatal("cold request past the 10k boundary admitted (single-KV budget loosened)")
+		}
+	})
+}
+
+// TestPooledRemainingTokensMatchesAdmits pins the equivalence the capacity feed
+// relies on: pooledBudgetAdmits(snap, n) admits IFF n <= pooledRemainingTokens(
+// pool, …, snap.kvBytesPerToken), across the byte path (known rate), the byte
+// COLD path (rate 0 → max resident rate substitution), token mode, and the
+// pending-unknown fall-through. Both must apply the SAME cold-rate substitution.
+func TestPooledRemainingTokensMatchesAdmits(t *testing.T) {
+	bytePool := providerPooledTokenBudget([]protocol.BackendSlotCapacity{
+		{Model: "big-kv", ActiveTokenBudgetMax: 10_000, KVBytesPerToken: 100_000},
+		{Model: "small-kv", ActiveTokenBudgetMax: 100_000, KVBytesPerToken: 10_000},
+	})
+	tokenPool := providerPooledTokenBudget([]protocol.BackendSlotCapacity{
+		{Model: "a", ActiveTokenBudgetMax: 10_000},
+		{Model: "b", ActiveTokenBudgetMax: 10_000},
+	})
+	cases := []struct {
+		name string
+		snap routingSnapshot
+	}{
+		{"byte_known_rate", routingSnapshot{
+			kvBytesPerToken: 100_000, pendingBytesKnown: true,
+			pendingMaxTokensAllModels: 20_000, pendingMaxBytesAllModels: 20_000 * 10_000,
+			pooledTokenBudget: bytePool,
+		}},
+		{"byte_cold_rate", routingSnapshot{
+			kvBytesPerToken: 0, pendingBytesKnown: true,
+			pendingMaxTokensAllModels: 10_000, pendingMaxBytesAllModels: 10_000 * 10_000,
+			pooledTokenBudget: bytePool,
+		}},
+		{"token_mode", routingSnapshot{
+			pendingMaxTokensAllModels: 4_000,
+			pooledTokenBudget:         tokenPool,
+		}},
+		{"byte_pending_unknown_falls_to_token", routingSnapshot{
+			kvBytesPerToken: 100_000, pendingBytesKnown: false,
+			pendingMaxTokensAllModels: 5_000,
+			pooledTokenBudget:         bytePool,
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rem := pooledRemainingTokens(
+				tc.snap.pooledTokenBudget,
+				tc.snap.pendingMaxTokensAllModels,
+				tc.snap.pendingMaxBytesAllModels,
+				tc.snap.pendingBytesKnown,
+				tc.snap.kvBytesPerToken,
+			)
+			for n := int64(1); n <= rem+50; n++ {
+				if admits, want := pooledBudgetAdmits(tc.snap, n), n <= rem; admits != want {
+					t.Fatalf("n=%d: pooledBudgetAdmits=%v, but (n<=rem=%d)=%v", n, admits, rem, want)
+				}
+			}
+		})
+	}
+}
+
 // TestFreeMemoryAdmitsLegacyProviderUnchanged: providers that report no token
 // budget (ActiveTokenBudgetMax == 0) never reach the budget branch — the
 // legacy memory-estimation path is untouched by the pooled fields.

--- a/coordinator/registry/pooled_admission_test.go
+++ b/coordinator/registry/pooled_admission_test.go
@@ -2,10 +2,54 @@ package registry
 
 import (
 	"fmt"
+	"math"
 	"testing"
 
 	"github.com/eigeninference/d-inference/coordinator/protocol"
 )
+
+// TestProviderPooledTokenBudgetClampsKVByteRate is the overflow regression: a
+// slot reporting an absurd (unbounded) KVBytesPerToken multiplied by a normal
+// token count wraps int64 to a NEGATIVE usedBytes/totalBytes, which breaks the
+// byte-pool admission (a negative total either rejects everything or, with a
+// negative left side, admits everything). The clamp caps the rate at
+// maxKVBytesPerToken so all products and sums stay positive and admission fails
+// closed. Fails without clampKVBytesPerToken in providerPooledTokenBudget.
+func TestProviderPooledTokenBudgetClampsKVByteRate(t *testing.T) {
+	const normalMax = 400_000
+	slots := []protocol.BackendSlotCapacity{
+		{Model: "a", ActiveTokenBudgetMax: normalMax, ActiveTokenBudgetUsed: 200_000, KVBytesPerToken: math.MaxInt64 / 2},
+	}
+	pool := providerPooledTokenBudget(slots)
+	if !pool.byteMode {
+		t.Fatal("byteMode = false with a (clamped) positive KV rate")
+	}
+	if pool.usedBytes < 0 || pool.committedBytes < 0 || pool.totalBytes < 0 {
+		t.Fatalf("byte pool overflowed to negative: used=%d committed=%d total=%d (KV rate not clamped)",
+			pool.usedBytes, pool.committedBytes, pool.totalBytes)
+	}
+	if pool.totalBytes < pool.usedBytes {
+		t.Fatalf("totalBytes %d < usedBytes %d (overflow)", pool.totalBytes, pool.usedBytes)
+	}
+	if got := pool.kvBytesPerToken["a"]; got != maxKVBytesPerToken {
+		t.Fatalf("stored KV rate = %d, want clamp %d (raw absurd rate not clamped)", got, maxKVBytesPerToken)
+	}
+	// Admission must fail-closed for a request that overflows the pool, not
+	// admit-everything off a wrapped negative total. Free headroom is
+	// (400k − 200k) = 200k tokens at the clamped rate.
+	snap := routingSnapshot{
+		activeTokenBudgetMax: normalMax,
+		kvBytesPerToken:      maxKVBytesPerToken,
+		pendingBytesKnown:    true,
+		pooledTokenBudget:    pool,
+	}
+	if pooledBudgetAdmits(snap, 10_000_000_000) {
+		t.Fatal("admitted a 10B-token request into a finite byte pool (overflow admitted-everything)")
+	}
+	if !pooledBudgetAdmits(snap, 100_000) {
+		t.Fatal("rejected a 100k-token request that fits the 200k-token byte headroom")
+	}
+}
 
 func TestProviderPooledTokenBudget(t *testing.T) {
 	cases := []struct {

--- a/coordinator/registry/pooled_admission_test.go
+++ b/coordinator/registry/pooled_admission_test.go
@@ -428,6 +428,69 @@ func TestPooledAdmissionColdModelDoubleSpendRealPath(t *testing.T) {
 	}
 }
 
+// TestModelCapacitySnapshotPooledBudgetClamp: the public capacity feed
+// (/v1/models[/capacity]) must not advertise per-slot budget headroom the
+// pooled admission gate would reject. Co-resident slots each re-report the
+// ONE shared 10k pool; after an in-gap 10k burst to gpt-oss, gemma's slot
+// fields still read used=0/max=10k — but a gemma request would be rejected
+// (pooledBudgetAdmits), so its row must report zero remaining budget and not
+// be Ready. Fails without the pooledBudgetRemaining clamp in
+// ModelCapacitySnapshot.
+func TestModelCapacitySnapshotPooledBudgetClamp(t *testing.T) {
+	build := func(pendingTokens int) *Registry {
+		reg := New(testLogger())
+		p := makeSchedulerProvider(t, reg, "shared-box", gptossBuild, 93)
+		addAdvertisedModel(p, gemmaBuild)
+		p.mu.Lock()
+		p.BackendCapacity.Slots[0].ActiveTokenBudgetMax = 10_000
+		p.BackendCapacity.Slots = append(p.BackendCapacity.Slots, protocol.BackendSlotCapacity{
+			Model:                gemmaBuild,
+			State:                "running",
+			ActiveTokenBudgetMax: 10_000,
+		})
+		p.mu.Unlock()
+		for i := 0; i < pendingTokens/2_000; i++ {
+			if got := reg.ReserveProvider(gptossBuild, &PendingRequest{
+				RequestID: fmt.Sprintf("burst-%d", i), Model: gptossBuild, EstimatedPromptTokens: 100, RequestedMaxTokens: 1_900,
+			}); got == nil {
+				t.Fatalf("burst request %d rejected", i)
+			}
+		}
+		return reg
+	}
+	capsByModel := func(reg *Registry) map[string]ModelCapacity {
+		out := make(map[string]ModelCapacity)
+		for _, c := range reg.ModelCapacitySnapshot() {
+			out[c.ModelID] = c
+		}
+		return out
+	}
+
+	// Pool fully pending to gpt-oss: gemma's stale slot (used 0 / max 10k)
+	// must not surface as remaining budget or readiness.
+	full := capsByModel(build(10_000))
+	gemma, ok := full[gemmaBuild]
+	if !ok {
+		t.Fatalf("missing capacity row for %s", gemmaBuild)
+	}
+	if gemma.TokenBudgetRemaining != 0 {
+		t.Fatalf("gemma token_budget_remaining = %d, want 0 (pool fully pending to co-resident gpt-oss)", gemma.TokenBudgetRemaining)
+	}
+	if gemma.Ready || gemma.CanAccept || gemma.RoutableProviders != 0 {
+		t.Fatalf("gemma row = %+v, want not ready/routable with the shared pool exhausted", gemma)
+	}
+
+	// Control: 4k of the 10k pool pending → 6k remaining, still routable.
+	part := capsByModel(build(4_000))
+	gemma = part[gemmaBuild]
+	if gemma.TokenBudgetRemaining != 6_000 {
+		t.Fatalf("gemma token_budget_remaining = %d, want 6_000 (10k pool − 4k pending)", gemma.TokenBudgetRemaining)
+	}
+	if !gemma.Ready || gemma.RoutableProviders != 1 {
+		t.Fatalf("gemma row = %+v, want ready/routable with 6k pooled headroom", gemma)
+	}
+}
+
 // TestFreeMemoryAdmitsLegacyProviderUnchanged: providers that report no token
 // budget (ActiveTokenBudgetMax == 0) never reach the budget branch — the
 // legacy memory-estimation path is untouched by the pooled fields.

--- a/coordinator/registry/prefill_fallback.go
+++ b/coordinator/registry/prefill_fallback.go
@@ -1,0 +1,176 @@
+package registry
+
+import (
+	"math"
+	"strings"
+	"time"
+)
+
+// Prefill-fallback recalibration — the coordinator-side, ship-now mitigation for
+// the live 41% long-prompt ttft_429 over-shed. No provider release required.
+//
+// Root cause (docs/reports/2026-06-22-live-prefill-tps-check.md): no provider in
+// the fleet reports a usable observed_prefill_tps (0 of 313 warm slots, 100% of
+// clean warm routing decisions resolved prefill to exactly the fallback). So
+// resolvePrefillTPS falls back to resolvedPrefillTPS(p) =
+// sqrt(MemoryBandwidthGBs) × prefillToDecodeRatio ≈ 280 tok/s p50 — ~23× below
+// the measured real prefill (empirical idle p50 6,523 tok/s, p90 17,707 tok/s,
+// recovered EXACTLY by inverting the stored ttft_ms). That pessimistic estimate
+// makes the TTFT gate reject every prompt above ~550 tokens.
+//
+// This file adds a data-derived fallback (defaultPrefillFallbackTPS ≈ the
+// measured p50) that REPLACES the sqrt(bandwidth)×ratio estimate when no
+// measurement exists, gated behind EIGENINFERENCE_PREFILL_FALLBACK_MODE so it can
+// be staged shadow→enforce. It is orthogonal to the durable provider-side
+// measurement fix (which makes observed_prefill_tps non-zero): once a provider
+// reports a real value, resolvePrefillTPS prefers that measured value and this
+// fallback is never consulted. It also raises maxPrefillTPS above the measured
+// p90 so a correctly-measured value is not discarded at ingest or capped at
+// routing time.
+
+// PrefillFallbackMode selects how the recalibrated prefill fallback is applied.
+type PrefillFallbackMode int
+
+const (
+	// PrefillFallbackOff is the default: resolvePrefillTPS returns the legacy
+	// sqrt(bandwidth)×ratio fallback, byte-for-byte the pre-recalibration value.
+	PrefillFallbackOff PrefillFallbackMode = iota
+	// PrefillFallbackShadow leaves live routing on the legacy fallback but lets
+	// the API layer emit routing.prefill_fallback{would_admit|would_shed} so the
+	// projected ttft_429 recovery can be measured before enforcing.
+	PrefillFallbackShadow
+	// PrefillFallbackEnforce applies the recalibrated fallback to live routing:
+	// resolvePrefillTPS uses max(static, prefillFallbackTPS) when no measured
+	// prefill exists, capped at maxPrefillTPS.
+	PrefillFallbackEnforce
+)
+
+func (m PrefillFallbackMode) String() string {
+	switch m {
+	case PrefillFallbackShadow:
+		return "shadow"
+	case PrefillFallbackEnforce:
+		return "enforce"
+	default:
+		return "off"
+	}
+}
+
+// ParsePrefillFallbackMode maps an env string to a mode. Anything unrecognized
+// (including empty) is OFF — the safe, behavior-neutral default.
+func ParsePrefillFallbackMode(s string) PrefillFallbackMode {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "shadow":
+		return PrefillFallbackShadow
+	case "enforce":
+		return PrefillFallbackEnforce
+	default:
+		return PrefillFallbackOff
+	}
+}
+
+// defaultPrefillFallbackTPS is the data-derived prefill fallback (tok/s): the
+// measured empirical idle prefill p50 = 6,523 tok/s (lower bound, recovered by
+// inverting the router's own stored ttft_ms on prompts ≥800 tok;
+// docs/reports/2026-06-22-live-prefill-tps-check.md). Rounded to 6500. It is
+// CONSERVATIVE on purpose: the regression slope implies a true asymptotic rate of
+// 7,500–10,500 tok/s, so anchoring on the p50 will not over-admit, while still
+// being ~23× the broken ~280 tok/s estimate that drives the 41% over-shed. Prefill
+// on Apple-Silicon MLX is a parallel/compute-bound pass, so a flat anchor (not the
+// bandwidth-scaled decode proxy) is the honest representation of the fleet-aggregate
+// data; tune per-deployment via EIGENINFERENCE_PREFILL_FALLBACK_TPS.
+const defaultPrefillFallbackTPS = 6500.0
+
+// defaultMaxPrefillTPS is the sanity ceiling (tok/s) on resolved/ingested prefill
+// rates. Raised from the legacy 5000 to sit comfortably above the measured p90
+// (17,707 tok/s) so (a) the recalibrated fallback (6500) is not capped back down
+// and (b) a correctly-measured cold-prefill value from a fixed provider is neither
+// zeroed at ingest (clampBackendCapacity) nor capped at routing time
+// (resolvePrefillTPS) — while still rejecting the "billions of tok/s" overflow a
+// collapsed admitted→first-token window produces. Tunable for rollback via
+// EIGENINFERENCE_MAX_PREFILL_TPS.
+const defaultMaxPrefillTPS = 20000.0
+
+// All three are configured once at startup (from main.go env wiring) and read-only
+// on routing/ingest paths thereafter, mirroring prefillToDecodeRatio /
+// ttftAdmissionMode.
+var (
+	prefillFallbackMode = PrefillFallbackOff
+	prefillFallbackTPS  = defaultPrefillFallbackTPS
+	// maxPrefillTPS is the prefill sanity ceiling shared by clampBackendCapacity
+	// (ingest zeroing of out-of-range observed_prefill_tps), the registration
+	// prefill_tps clamp, and resolvePrefillTPS (routing cap). Declared here rather
+	// than in registry.go's const block so the prefill ceiling lives next to the
+	// fallback it must clear.
+	maxPrefillTPS = defaultMaxPrefillTPS
+)
+
+// SetPrefillFallbackMode sets the recalibration mode. Must be called before
+// serving starts (read-only on routing paths thereafter).
+func SetPrefillFallbackMode(mode PrefillFallbackMode) { prefillFallbackMode = mode }
+
+// PrefillFallbackModeValue returns the configured recalibration mode.
+func PrefillFallbackModeValue() PrefillFallbackMode { return prefillFallbackMode }
+
+// SetPrefillFallbackTPS overrides the data-derived fallback (tok/s). Values <= 0
+// are ignored. Must be called before serving starts.
+func SetPrefillFallbackTPS(tps float64) {
+	if tps > 0 {
+		prefillFallbackTPS = tps
+	}
+}
+
+// PrefillFallbackTPS returns the configured prefill fallback (tok/s).
+func PrefillFallbackTPS() float64 { return prefillFallbackTPS }
+
+// SetMaxPrefillTPS overrides the prefill sanity ceiling (tok/s). Values <= 0 are
+// ignored. Must be called before serving starts.
+func SetMaxPrefillTPS(tps float64) {
+	if tps > 0 {
+		maxPrefillTPS = tps
+	}
+}
+
+// MaxPrefillTPS returns the configured prefill sanity ceiling (tok/s).
+func MaxPrefillTPS() float64 { return maxPrefillTPS }
+
+// prefillTPSForSnapshot resolves the prefill TPS for a snapshot. The measured
+// per-slot observed prefill EWMA always wins when present (>0). Otherwise, when
+// recalibrate is true and the provider reports BackendCapacity (so its TTFT
+// estimate is actually consulted by the gate), the data-derived fallback lifts the
+// pessimistic sqrt(bandwidth)×ratio static estimate — never lowering it, so a
+// (hypothetical) higher static prefill_tps is preserved. The result is always
+// capped at maxPrefillTPS.
+func prefillTPSForSnapshot(snap routingSnapshot, recalibrate bool) float64 {
+	tps := snap.prefillTPS
+	if snap.observedPrefillTPS > 0 {
+		tps = snap.observedPrefillTPS
+	} else if recalibrate && snap.hasBackendCapacity {
+		if prefillFallbackTPS > tps {
+			tps = prefillFallbackTPS
+		}
+	}
+	if tps > maxPrefillTPS {
+		tps = maxPrefillTPS
+	}
+	return tps
+}
+
+// recalibratedTTFTMsFromSnapshot is the TTFT estimate computed with the
+// recalibrated prefill fallback FORCED on, regardless of mode. Used only by the
+// shadow path to measure the projected admission recovery WITHOUT changing the
+// live decision (which, in shadow mode, still runs on the legacy fallback).
+func recalibratedTTFTMsFromSnapshot(snap routingSnapshot, reqPromptTokens int) float64 {
+	return ttftMsFromSnapshotWithPrefill(snap, reqPromptTokens, prefillTPSForSnapshot(snap, true))
+}
+
+// estimatedRecalibratedTTFTFromSnapshot mirrors estimatedTTFTFromSnapshot but with
+// the recalibrated prefill fallback forced on. Returns 0 for an invalid estimate
+// (no BackendCapacity, NaN/Inf), matching the live preflight contract.
+func estimatedRecalibratedTTFTFromSnapshot(snap routingSnapshot, reqPromptTokens int) time.Duration {
+	ttftMs := recalibratedTTFTMsFromSnapshot(snap, reqPromptTokens)
+	if ttftMs <= 0 || math.IsNaN(ttftMs) || math.IsInf(ttftMs, 0) {
+		return 0
+	}
+	return time.Duration(ttftMs * float64(time.Millisecond))
+}

--- a/coordinator/registry/prefill_fallback.go
+++ b/coordinator/registry/prefill_fallback.go
@@ -183,11 +183,17 @@ func recalibratedTTFTMsFromSnapshot(snap routingSnapshot, reqPromptTokens int) f
 
 // estimatedRecalibratedTTFTFromSnapshot mirrors estimatedTTFTFromSnapshot but with
 // the recalibrated prefill fallback forced on. Returns 0 for an invalid estimate
-// (no BackendCapacity, NaN/Inf), matching the live preflight contract.
+// (no BackendCapacity, NaN/Inf), matching the live preflight contract. The #512
+// online calibration is applied exactly like the live path applies it: an
+// enforce flip would gate on calibrate(recalibrated-raw), so the shadow
+// would_admit/would_shed split must compare calibrated-vs-calibrated — without
+// this, a learned ratio < 1 (the norm on the over-predicting legacy chain)
+// makes the shadow under-report the projected recovery.
 func estimatedRecalibratedTTFTFromSnapshot(snap routingSnapshot, reqPromptTokens int) time.Duration {
 	ttftMs := recalibratedTTFTMsFromSnapshot(snap, reqPromptTokens)
 	if ttftMs <= 0 || math.IsNaN(ttftMs) || math.IsInf(ttftMs, 0) {
 		return 0
 	}
+	ttftMs = calibratedTTFTMs(snap, ttftMs)
 	return time.Duration(ttftMs * float64(time.Millisecond))
 }

--- a/coordinator/registry/prefill_fallback.go
+++ b/coordinator/registry/prefill_fallback.go
@@ -134,18 +134,35 @@ func SetMaxPrefillTPS(tps float64) {
 // MaxPrefillTPS returns the configured prefill sanity ceiling (tok/s).
 func MaxPrefillTPS() float64 { return maxPrefillTPS }
 
-// prefillTPSForSnapshot resolves the prefill TPS for a snapshot. The measured
-// per-slot observed prefill EWMA always wins when present (>0). Otherwise, when
-// recalibrate is true and the provider reports BackendCapacity (so its TTFT
-// estimate is actually consulted by the gate), the data-derived fallback lifts the
-// pessimistic sqrt(bandwidth)×ratio static estimate — never lowering it, so a
-// (hypothetical) higher static prefill_tps is preserved. The result is always
-// capped at maxPrefillTPS.
+// prefillTPSForSnapshot resolves the prefill TPS for a snapshot, most- to
+// least-specific:
+//
+//  1. the box's OWN measured per-slot observed prefill EWMA (>0) always wins;
+//  2. the per-(model, chip family) fleet prefill MEDIAN (prefill_tps.go) when
+//     it has >= EIGENINFERENCE_TTFT_PREFILL_MIN_SAMPLES samples and the
+//     medians layer is enabled (EIGENINFERENCE_TTFT_PREFILL_MEDIANS, default
+//     true): a real measurement of THIS model on THIS chip class, transferred
+//     to boxes that don't (yet) report their own. Unlike the anchor below it
+//     REPLACES the static estimate in either direction — a measured median may
+//     honestly be lower than an optimistic static rate;
+//  3. when recalibrate is true and the provider reports BackendCapacity (so
+//     its TTFT estimate is actually consulted by the gate), the data-derived
+//     fleet-wide fallback anchor LIFTS the pessimistic sqrt(bandwidth)×ratio
+//     static estimate — never lowering it, so a (hypothetical) higher static
+//     prefill_tps is preserved;
+//  4. the static snap.prefillTPS chain (registration benchmark →
+//     decode×prefillToDecodeRatio).
+//
+// The result is always capped at maxPrefillTPS.
 func prefillTPSForSnapshot(snap routingSnapshot, recalibrate bool) float64 {
 	tps := snap.prefillTPS
-	if snap.observedPrefillTPS > 0 {
+	switch {
+	case snap.observedPrefillTPS > 0:
 		tps = snap.observedPrefillTPS
-	} else if recalibrate && snap.hasBackendCapacity {
+	case ttftPrefillMediansEnabled() && snap.prefillMedianTPS > 0 &&
+		snap.prefillMedianSamples >= ttftPrefillMinSamples():
+		tps = snap.prefillMedianTPS
+	case recalibrate && snap.hasBackendCapacity:
 		if prefillFallbackTPS > tps {
 			tps = prefillFallbackTPS
 		}

--- a/coordinator/registry/prefill_fallback_test.go
+++ b/coordinator/registry/prefill_fallback_test.go
@@ -1,0 +1,280 @@
+package registry
+
+import (
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+)
+
+// withPrefillFallbackState snapshots and restores the package-level prefill
+// fallback knobs so a test that flips mode/value/ceiling cannot leak into the
+// rest of the (sequential) package suite.
+func withPrefillFallbackState(t *testing.T) {
+	t.Helper()
+	mode, fb, ceil := prefillFallbackMode, prefillFallbackTPS, maxPrefillTPS
+	t.Cleanup(func() {
+		prefillFallbackMode, prefillFallbackTPS, maxPrefillTPS = mode, fb, ceil
+	})
+}
+
+func TestParsePrefillFallbackMode(t *testing.T) {
+	cases := map[string]PrefillFallbackMode{
+		"":         PrefillFallbackOff,
+		"off":      PrefillFallbackOff,
+		"garbage":  PrefillFallbackOff,
+		"shadow":   PrefillFallbackShadow,
+		"  SHADOW": PrefillFallbackShadow,
+		"enforce":  PrefillFallbackEnforce,
+		"Enforce ": PrefillFallbackEnforce,
+	}
+	for in, want := range cases {
+		if got := ParsePrefillFallbackMode(in); got != want {
+			t.Errorf("ParsePrefillFallbackMode(%q) = %v, want %v", in, got, want)
+		}
+		if got := want.String(); ParsePrefillFallbackMode(got) != want {
+			t.Errorf("round-trip String()/Parse for %v gave %q", want, got)
+		}
+	}
+}
+
+func TestPrefillFallbackDefaultsAndSetters(t *testing.T) {
+	withPrefillFallbackState(t)
+
+	// Defaults are the data-derived values and the safe (off) mode.
+	if prefillFallbackMode != PrefillFallbackOff {
+		t.Fatalf("default mode = %v, want off (behavior-neutral)", prefillFallbackMode)
+	}
+	if defaultPrefillFallbackTPS != 6500.0 {
+		t.Fatalf("defaultPrefillFallbackTPS = %v, want 6500 (measured p50)", defaultPrefillFallbackTPS)
+	}
+	if defaultMaxPrefillTPS != 20000.0 {
+		t.Fatalf("defaultMaxPrefillTPS = %v, want 20000 (above measured p90 17,707)", defaultMaxPrefillTPS)
+	}
+
+	SetPrefillFallbackTPS(7200)
+	if PrefillFallbackTPS() != 7200 {
+		t.Fatalf("PrefillFallbackTPS = %v, want 7200", PrefillFallbackTPS())
+	}
+	SetPrefillFallbackTPS(0) // ignored
+	SetPrefillFallbackTPS(-1)
+	if PrefillFallbackTPS() != 7200 {
+		t.Fatalf("PrefillFallbackTPS = %v, want 7200 after ignored non-positive sets", PrefillFallbackTPS())
+	}
+
+	SetMaxPrefillTPS(18000)
+	if MaxPrefillTPS() != 18000 {
+		t.Fatalf("MaxPrefillTPS = %v, want 18000", MaxPrefillTPS())
+	}
+	SetMaxPrefillTPS(0) // ignored
+	if MaxPrefillTPS() != 18000 {
+		t.Fatalf("MaxPrefillTPS = %v, want 18000 after ignored zero set", MaxPrefillTPS())
+	}
+
+	SetPrefillFallbackMode(PrefillFallbackEnforce)
+	if PrefillFallbackModeValue() != PrefillFallbackEnforce {
+		t.Fatalf("mode = %v, want enforce", PrefillFallbackModeValue())
+	}
+}
+
+// TestPrefillTPSForSnapshotRecalibration pins the core resolution helper: measured
+// always wins; the recalibration only lifts (never lowers) the static estimate and
+// only when BackendCapacity is present; the ceiling always caps.
+func TestPrefillTPSForSnapshotRecalibration(t *testing.T) {
+	withPrefillFallbackState(t)
+	prefillFallbackTPS = 6500
+	maxPrefillTPS = 20000
+
+	// Measured observed prefill always wins, regardless of recalibrate.
+	obs := routingSnapshot{prefillTPS: 240, observedPrefillTPS: 1800, hasBackendCapacity: true}
+	if got := prefillTPSForSnapshot(obs, false); got != 1800 {
+		t.Fatalf("observed (off) = %v, want 1800", got)
+	}
+	if got := prefillTPSForSnapshot(obs, true); got != 1800 {
+		t.Fatalf("observed (recalibrate) = %v, want 1800 (measured wins)", got)
+	}
+
+	// No measurement, recalibrate OFF → legacy static estimate (the ~280 chain).
+	legacy := routingSnapshot{prefillTPS: 240, hasBackendCapacity: true}
+	if got := prefillTPSForSnapshot(legacy, false); got != 240 {
+		t.Fatalf("legacy (off) = %v, want 240", got)
+	}
+	// No measurement, recalibrate ON → lifted to the data-derived fallback.
+	if got := prefillTPSForSnapshot(legacy, true); got != 6500 {
+		t.Fatalf("recalibrated = %v, want 6500", got)
+	}
+
+	// Recalibration is gated on BackendCapacity (a legacy provider whose TTFT is
+	// never gated keeps its static estimate).
+	noBC := routingSnapshot{prefillTPS: 240, hasBackendCapacity: false}
+	if got := prefillTPSForSnapshot(noBC, true); got != 240 {
+		t.Fatalf("recalibrate without BackendCapacity = %v, want 240 (gated)", got)
+	}
+
+	// Never LOWER a higher static estimate to the fallback.
+	high := routingSnapshot{prefillTPS: 9000, hasBackendCapacity: true}
+	if got := prefillTPSForSnapshot(high, true); got != 9000 {
+		t.Fatalf("recalibrate with higher static = %v, want 9000 (max, never lowered)", got)
+	}
+
+	// The ceiling caps everything (e.g. an observed value above the ceiling).
+	over := routingSnapshot{observedPrefillTPS: 25000, hasBackendCapacity: true}
+	if got := prefillTPSForSnapshot(over, true); got != 20000 {
+		t.Fatalf("over-ceiling observed = %v, want capped to 20000", got)
+	}
+}
+
+// TestMaxPrefillCeilingRaiseKeepsHighObserved proves the ceiling raise: a
+// genuinely-fast cold-prefill measurement that sits BETWEEN the legacy 5000 and the
+// measured p90 (17,707) is now KEPT at ingest instead of being zeroed, while a true
+// overflow above the new ceiling is still dropped.
+func TestMaxPrefillCeilingRaiseKeepsHighObserved(t *testing.T) {
+	withPrefillFallbackState(t)
+	maxPrefillTPS = defaultMaxPrefillTPS // 20000
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	bc := &protocol.BackendCapacity{
+		Slots: []protocol.BackendSlotCapacity{
+			{Model: "p50", ObservedPrefillTPS: 6500},   // measured p50 — kept (was kept before too)
+			{Model: "p90", ObservedPrefillTPS: 15000},  // between old 5000 and new ceiling — NOW kept
+			{Model: "fast", ObservedPrefillTPS: 17700}, // ~p90 — NOW kept
+			{Model: "overflow", ObservedPrefillTPS: 25000},
+		},
+	}
+	clampBackendCapacity(logger, "p1", bc)
+
+	if bc.Slots[0].ObservedPrefillTPS != 6500 {
+		t.Errorf("p50 ObservedPrefillTPS = %v, want 6500 (kept)", bc.Slots[0].ObservedPrefillTPS)
+	}
+	if bc.Slots[1].ObservedPrefillTPS != 15000 {
+		t.Errorf("p90-ish ObservedPrefillTPS = %v, want 15000 (kept under raised ceiling; was zeroed at 5000)", bc.Slots[1].ObservedPrefillTPS)
+	}
+	if bc.Slots[2].ObservedPrefillTPS != 17700 {
+		t.Errorf("fast ObservedPrefillTPS = %v, want 17700 (kept)", bc.Slots[2].ObservedPrefillTPS)
+	}
+	if bc.Slots[3].ObservedPrefillTPS != 0 {
+		t.Errorf("overflow ObservedPrefillTPS = %v, want 0 (above new ceiling, dropped)", bc.Slots[3].ObservedPrefillTPS)
+	}
+}
+
+// makeBrokenPrefillProvider builds a healthy, model-resident provider whose static
+// prefill estimate is the broken ~fleet fallback (240 tok/s), so a long prompt's
+// TTFT estimate blows the gate under the legacy fallback but clears it once the
+// recalibrated fallback is applied. Decode is fast so the first-decode term is
+// negligible and the prefill term dominates (matching the live pathology).
+func makeBrokenPrefillProvider(t *testing.T, reg *Registry, id, model string) *Provider {
+	t.Helper()
+	p := makeSchedulerProvider(t, reg, id, model, 100) // decode 100 tok/s → 10ms first-decode
+	p.mu.Lock()
+	p.PrefillTPS = 240 // the broken sqrt(bandwidth)×12 ≈ fleet fallback
+	p.mu.Unlock()
+	return p
+}
+
+// TestLongPromptAdmittedUnderEnforceFallback is THE required regression: a
+// long-prompt request that the TTFT hard gate 429s under the legacy fallback is
+// ADMITTED once the recalibrated fallback is enforced — with cancels-flat safety,
+// because the recalibrated estimate (~615ms prefill for 4k tokens) is well within
+// the deadline rather than the legacy ~16.7s that over-shed it.
+func TestLongPromptAdmittedUnderEnforceFallback(t *testing.T) {
+	withPrefillFallbackState(t)
+	prefillFallbackTPS = defaultPrefillFallbackTPS // 6500
+	maxPrefillTPS = defaultMaxPrefillTPS           // 20000
+
+	const (
+		model     = "prefill-fallback-admit-model"
+		reqPrompt = 4_000 // ≈ the live 429'd long-prompt p50 (4,009 tok)
+		// Hard TTFT gate ≈ consumer ttftDeadline(4000) = 5000 + 1ms·4000.
+		maxTTFTMs = 9_000.0
+	)
+	newReq := func(id string) *PendingRequest {
+		return &PendingRequest{
+			RequestID:             id,
+			Model:                 model,
+			EstimatedPromptTokens: reqPrompt,
+			RequestedMaxTokens:    128,
+			MaxTTFTMs:             maxTTFTMs,
+		}
+	}
+
+	// OFF (legacy fallback ≈240 tok/s): 4000/240*1000 ≈ 16.7s ≫ 9s → 429.
+	prefillFallbackMode = PrefillFallbackOff
+	{
+		reg := New(testLogger())
+		makeBrokenPrefillProvider(t, reg, "p-off", model)
+		sel, dec := reg.ReserveProviderEx(model, newReq("off"))
+		if sel != nil {
+			t.Fatalf("OFF: expected TTFT 429 (nil provider), got %q; decision=%+v", sel.ID, dec)
+		}
+		if dec.TTFTRejections != 1 {
+			t.Fatalf("OFF: TTFTRejections = %d, want 1 (the only blocker is the prefill-driven TTFT gate); decision=%+v", dec.TTFTRejections, dec)
+		}
+		if dec.BestTTFTMs <= maxTTFTMs {
+			t.Fatalf("OFF: BestTTFTMs = %v, want > %v (legacy fallback over-estimates TTFT)", dec.BestTTFTMs, maxTTFTMs)
+		}
+	}
+
+	// ENFORCE (recalibrated fallback 6500 tok/s): 4000/6500*1000 ≈ 615ms ≪ 9s → admit.
+	prefillFallbackMode = PrefillFallbackEnforce
+	{
+		reg := New(testLogger())
+		p := makeBrokenPrefillProvider(t, reg, "p-enforce", model)
+		sel, dec := reg.ReserveProviderEx(model, newReq("enforce"))
+		if sel == nil {
+			t.Fatalf("ENFORCE: expected admission, got nil; decision=%+v", dec)
+		}
+		if sel.ID != p.ID {
+			t.Fatalf("ENFORCE: selected %q, want %q", sel.ID, p.ID)
+		}
+		if dec.TTFTRejections != 0 {
+			t.Fatalf("ENFORCE: TTFTRejections = %d, want 0 (recalibrated prefill clears the gate)", dec.TTFTRejections)
+		}
+		if dec.TTFTMs > maxTTFTMs {
+			t.Fatalf("ENFORCE: winning TTFTMs = %v, want <= %v", dec.TTFTMs, maxTTFTMs)
+		}
+	}
+}
+
+// TestPrefillFallbackShadowIsBehaviorNeutral proves shadow mode does NOT change the
+// live routing decision (the same long prompt is still 429'd, byte-for-byte with
+// OFF), while the recalibrated estimate the shadow measures WOULD have cleared the
+// gate — exactly the projected-recovery signal the API emits before enforcing.
+func TestPrefillFallbackShadowIsBehaviorNeutral(t *testing.T) {
+	withPrefillFallbackState(t)
+	prefillFallbackTPS = defaultPrefillFallbackTPS
+	maxPrefillTPS = defaultMaxPrefillTPS
+
+	const (
+		model     = "prefill-fallback-shadow-model"
+		reqPrompt = 4_000
+		maxTTFTMs = 9_000.0
+	)
+	req := func(id string) *PendingRequest {
+		return &PendingRequest{RequestID: id, Model: model, EstimatedPromptTokens: reqPrompt, RequestedMaxTokens: 128, MaxTTFTMs: maxTTFTMs}
+	}
+
+	prefillFallbackMode = PrefillFallbackShadow
+	reg := New(testLogger())
+	makeBrokenPrefillProvider(t, reg, "p-shadow", model)
+
+	// Live routing in shadow mode is unchanged → still 429 (behavior-neutral).
+	sel, dec := reg.ReserveProviderEx(model, req("shadow-live"))
+	if sel != nil {
+		t.Fatalf("SHADOW: live routing must stay 429 (behavior-neutral), got %q; decision=%+v", sel.ID, dec)
+	}
+	if dec.TTFTRejections != 1 {
+		t.Fatalf("SHADOW: TTFTRejections = %d, want 1 (live still on legacy fallback)", dec.TTFTRejections)
+	}
+
+	// The shadow measurement (recalibration forced on) would have ADMITTED it:
+	// the preflight's recalibrated best-TTFT clears the same deadline.
+	recalTTFT, hasTTFT := reg.QuickCapacityCheckRecalibratedTTFT(model, reqPrompt, 128, RequestTraits{}, false)
+	if !hasTTFT {
+		t.Fatalf("SHADOW: recalibrated preflight produced no TTFT estimate")
+	}
+	if float64(recalTTFT.Milliseconds()) > maxTTFTMs {
+		t.Fatalf("SHADOW: recalibrated best-TTFT = %v, want <= %v (would_admit)", recalTTFT, time.Duration(maxTTFTMs)*time.Millisecond)
+	}
+}

--- a/coordinator/registry/prefill_tps.go
+++ b/coordinator/registry/prefill_tps.go
@@ -1,6 +1,9 @@
 package registry
 
-import "github.com/eigeninference/d-inference/coordinator/env"
+import (
+	"github.com/eigeninference/d-inference/coordinator/env"
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+)
 
 // prefill_tps.go is the observed-prefill half of TPSRegistry: per-(model, chip
 // family) medians of the prefill EWMAs providers report in heartbeats
@@ -82,18 +85,43 @@ func ttftPrefillMinSamples() int {
 	return n
 }
 
+// prefillChipClass keys the prefill-median ring at a FINER grain than the
+// decode/solo rings' chip FAMILY. Prefill is compute-bound and spreads 3–4×
+// across the tiers WITHIN a family (e.g. M4 base vs M4 Max/Ultra), so keying by
+// family alone would let a few fast-tier samples satisfy the min-sample trust
+// floor and then admit a long prompt on a slower same-family tier at the HARD
+// TTFT gate — exactly the over-admit this ring's no-cross-chip-pooling rule
+// exists to avoid (Codex review). Family+tier is the normalized grain the
+// heartbeat carries (Hardware.ChipFamily + ChipTier); the base chip (empty
+// tier) maps to "<family>|", distinct from "<family>|Max". Falls back to the
+// raw ChipName when the family is absent, matching the decode ring's
+// empty-family key ("" stays "").
+//
+// NOTE: the decode (Record/Median) and solo (RecordSolo/SoloMedian) rings still
+// key by ChipFamily on the base branch; they face the same family-vs-tier
+// coarseness but a lower blast radius (they feed cost estimation / the quality
+// cap, not the hard TTFT admit) and the solo ring has SoloMedianAllChips as a
+// deliberate conservative cross-chip fallback. Moving those to tier grain is a
+// separate follow-up on that branch — not changed here.
+func prefillChipClass(hw protocol.Hardware) string {
+	if hw.ChipFamily == "" {
+		return hw.ChipName
+	}
+	return hw.ChipFamily + "|" + hw.ChipTier
+}
+
 // RecordPrefill adds an observed prefill TPS sample for the given model and
-// chip family. Called from heartbeat processing when a provider reports
-// slot.ObservedPrefillTPS > 0 (post-clamp, so out-of-range garbage was already
-// zeroed and never reaches the ring) AND the value changed since the
-// connection's last recorded sample (the heartbeat-side re-report dedup —
-// Provider.lastRecordedPrefillTPS). Load-inclusive like Record — see the file
-// comment for why prefill samples are not solo-gated.
-func (r *TPSRegistry) RecordPrefill(model, chipFamily string, tps float64) {
+// chip CLASS (family+tier, see prefillChipClass). Called from heartbeat
+// processing when a provider reports slot.ObservedPrefillTPS > 0 (post-clamp, so
+// out-of-range garbage was already zeroed and never reaches the ring) AND the
+// value changed since the connection's last recorded sample (the heartbeat-side
+// re-report dedup — Provider.lastRecordedPrefillTPS). Load-inclusive like Record
+// — see the file comment for why prefill samples are not solo-gated.
+func (r *TPSRegistry) RecordPrefill(model, chipClass string, tps float64) {
 	if tps <= 0 || model == "" {
 		return
 	}
-	key := tpsKey{Model: model, ChipFamily: chipFamily}
+	key := tpsKey{Model: model, ChipFamily: chipClass}
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	samples := r.prefillSamples[key]
@@ -105,10 +133,11 @@ func (r *TPSRegistry) RecordPrefill(model, chipFamily string, tps float64) {
 }
 
 // PrefillMedian returns the median observed prefill TPS for the given model
-// and chip family plus the number of samples behind it. (0, 0) when no samples
-// exist. The count lets the TTFT estimate apply the min-sample trust floor.
-func (r *TPSRegistry) PrefillMedian(model, chipFamily string) (float64, int) {
-	key := tpsKey{Model: model, ChipFamily: chipFamily}
+// and chip CLASS (family+tier, see prefillChipClass) plus the number of samples
+// behind it. (0, 0) when no samples exist. The count lets the TTFT estimate
+// apply the min-sample trust floor.
+func (r *TPSRegistry) PrefillMedian(model, chipClass string) (float64, int) {
+	key := tpsKey{Model: model, ChipFamily: chipClass}
 	r.mu.RLock()
 	samples := r.prefillSamples[key]
 	sorted := make([]float64, len(samples))

--- a/coordinator/registry/prefill_tps.go
+++ b/coordinator/registry/prefill_tps.go
@@ -29,12 +29,17 @@ import "github.com/eigeninference/d-inference/coordinator/env"
 //     measured p90 so REAL measurements survive ingest), and the provider-side
 //     fix samples cold prefills only — so samples reaching RecordPrefill are
 //     already sanity-bounded.
-//   - Residual contamination (an idle box re-reporting one EWMA every
-//     heartbeat, mild under-load smear) is absorbed by the same defenses the
-//     decode rings rely on: per-(model, chip) keying makes same-chip samples
-//     roughly exchangeable, the median is rank-robust, the min-sample floor
-//     delays trust, and the #512 online TTFT calibrator remains downstream as
-//     the corrector for any residual bias.
+//   - Re-reports are deduplicated at the heartbeat ingest, not here: the slot
+//     EWMA is persistent and resent every 30s, so Heartbeat records a sample
+//     only when the reported value CHANGED since the connection's last recorded
+//     one (Provider.lastRecordedPrefillTPS) — otherwise one idle box's single
+//     cold-prefill measurement would satisfy the min-sample floor below after
+//     five ticks of the same value. Residual contamination (mild under-load
+//     smear) is absorbed by the same defenses the decode rings rely on:
+//     per-(model, chip) keying makes same-chip samples roughly exchangeable,
+//     the median is rank-robust, the min-sample floor delays trust, and the
+//     #512 online TTFT calibrator remains downstream as the corrector for any
+//     residual bias.
 //
 // Two knobs, both live-read (no restart, mirroring decodeFloorUseFleetMedian):
 //
@@ -80,9 +85,10 @@ func ttftPrefillMinSamples() int {
 // RecordPrefill adds an observed prefill TPS sample for the given model and
 // chip family. Called from heartbeat processing when a provider reports
 // slot.ObservedPrefillTPS > 0 (post-clamp, so out-of-range garbage was already
-// zeroed and never reaches the ring). Mirrors Record's unconditional,
-// load-inclusive ingest — see the file comment for why prefill samples are not
-// solo-gated.
+// zeroed and never reaches the ring) AND the value changed since the
+// connection's last recorded sample (the heartbeat-side re-report dedup —
+// Provider.lastRecordedPrefillTPS). Load-inclusive like Record — see the file
+// comment for why prefill samples are not solo-gated.
 func (r *TPSRegistry) RecordPrefill(model, chipFamily string, tps float64) {
 	if tps <= 0 || model == "" {
 		return

--- a/coordinator/registry/prefill_tps.go
+++ b/coordinator/registry/prefill_tps.go
@@ -1,0 +1,112 @@
+package registry
+
+import "github.com/eigeninference/d-inference/coordinator/env"
+
+// prefill_tps.go is the observed-prefill half of TPSRegistry: per-(model, chip
+// family) medians of the prefill EWMAs providers report in heartbeats
+// (BackendSlotCapacity.ObservedPrefillTPS, populated by v0.7.5's bridge usage
+// timings). These medians are the prefill-honest input to the TTFT estimate
+// (prefillTPSForSnapshot, prefill_fallback.go): today an unmeasured provider's
+// prefill is estimated as decode×EIGENINFERENCE_PREFILL_DECODE_RATIO
+// (sqrt-bandwidth×12 ≈ 280 tok/s) — ~23× below the measured fleet reality
+// (p50 6,523 tok/s) — so gpt-oss's 13.7k-token p90 prompts predict ~38s TTFT
+// against a 5s deadline and 18.2k requests/day die on ttft_too_slow
+// mispredictions. A per-(model, chip) median of REAL measurements replaces
+// that guess for every box of the same chip family, including boxes that
+// haven't (or can't yet) report their own measurement.
+//
+// Ingest gating — decided against solo-gating, differing from the solo decode
+// ring on purpose:
+//
+//   - Prefill throughput is per-request compute-bound work (a parallel batched
+//     pass over the prompt), not the shared-decode-loop rate the solo gate
+//     protects; co-resident decode steals some GPU time but does not collapse
+//     the measurement the way batching collapses per-request decode.
+//   - The known garbage mode (PR #453's analysis): the admitted→first-token
+//     window collapsing on a prefix-cache hit inflates the EWMA to absurd
+//     values. That is handled upstream of this ring — clampBackendCapacity
+//     zeroes out-of-range values (> maxPrefillTPS, raised to 20,000 above the
+//     measured p90 so REAL measurements survive ingest), and the provider-side
+//     fix samples cold prefills only — so samples reaching RecordPrefill are
+//     already sanity-bounded.
+//   - Residual contamination (an idle box re-reporting one EWMA every
+//     heartbeat, mild under-load smear) is absorbed by the same defenses the
+//     decode rings rely on: per-(model, chip) keying makes same-chip samples
+//     roughly exchangeable, the median is rank-robust, the min-sample floor
+//     delays trust, and the #512 online TTFT calibrator remains downstream as
+//     the corrector for any residual bias.
+//
+// Two knobs, both live-read (no restart, mirroring decodeFloorUseFleetMedian):
+//
+//   - EIGENINFERENCE_TTFT_PREFILL_MEDIANS (bool, default true): kill switch;
+//     false removes the median layer and restores the pure ratio-derived path
+//     (plus the #453 fallback anchor, whose own mode env governs it).
+//   - EIGENINFERENCE_TTFT_PREFILL_MIN_SAMPLES (int, default 5): samples
+//     required before a (model, chip) median is trusted by the TTFT estimate.
+//
+// There is deliberately NO cross-chip pooled fallback (unlike the solo-cap
+// resolver): prefill is compute-bound and spreads 3–4× across chip tiers, so a
+// cross-chip transfer could over-admit a slow tier at the hard TTFT gate. With
+// too few same-chip samples the estimate falls back to the ratio chain / #453
+// anchor instead.
+
+const (
+	ttftPrefillMediansEnv    = env.EnvPrefix + "_TTFT_PREFILL_MEDIANS"
+	ttftPrefillMinSamplesEnv = env.EnvPrefix + "_TTFT_PREFILL_MIN_SAMPLES"
+)
+
+// defaultTTFTPrefillMinSamples is the trust floor when
+// EIGENINFERENCE_TTFT_PREFILL_MIN_SAMPLES is unset.
+const defaultTTFTPrefillMinSamples = 5
+
+// ttftPrefillMediansEnabled gates the per-(model, chip) prefill-median layer of
+// the TTFT prefill estimate. Read LIVE (no restart); default ON. Set
+// EIGENINFERENCE_TTFT_PREFILL_MEDIANS=false to restore the pure ratio-derived
+// path exactly.
+func ttftPrefillMediansEnabled() bool {
+	return env.EnvBool(ttftPrefillMediansEnv, true)
+}
+
+// ttftPrefillMinSamples returns the minimum sample count before a prefill
+// median is trusted. Read live; values < 1 are floored to 1.
+func ttftPrefillMinSamples() int {
+	n := env.EnvInt(ttftPrefillMinSamplesEnv, defaultTTFTPrefillMinSamples)
+	if n < 1 {
+		n = 1
+	}
+	return n
+}
+
+// RecordPrefill adds an observed prefill TPS sample for the given model and
+// chip family. Called from heartbeat processing when a provider reports
+// slot.ObservedPrefillTPS > 0 (post-clamp, so out-of-range garbage was already
+// zeroed and never reaches the ring). Mirrors Record's unconditional,
+// load-inclusive ingest — see the file comment for why prefill samples are not
+// solo-gated.
+func (r *TPSRegistry) RecordPrefill(model, chipFamily string, tps float64) {
+	if tps <= 0 || model == "" {
+		return
+	}
+	key := tpsKey{Model: model, ChipFamily: chipFamily}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	samples := r.prefillSamples[key]
+	if len(samples) >= r.maxSamples {
+		// Drop oldest sample (FIFO ring), same shape as Record/RecordSolo.
+		samples = samples[1:]
+	}
+	r.prefillSamples[key] = append(samples, tps)
+}
+
+// PrefillMedian returns the median observed prefill TPS for the given model
+// and chip family plus the number of samples behind it. (0, 0) when no samples
+// exist. The count lets the TTFT estimate apply the min-sample trust floor.
+func (r *TPSRegistry) PrefillMedian(model, chipFamily string) (float64, int) {
+	key := tpsKey{Model: model, ChipFamily: chipFamily}
+	r.mu.RLock()
+	samples := r.prefillSamples[key]
+	sorted := make([]float64, len(samples))
+	copy(sorted, samples)
+	r.mu.RUnlock()
+	return medianOfCopied(sorted), len(sorted)
+}

--- a/coordinator/registry/prefill_tps_test.go
+++ b/coordinator/registry/prefill_tps_test.go
@@ -107,6 +107,66 @@ func TestPrefillRecordingThroughHeartbeat(t *testing.T) {
 	}
 }
 
+// TestPrefillHeartbeatDedupsResentEWMA (review fix): the per-slot prefill EWMA
+// is PERSISTENT provider state resent on every 30s heartbeat, so an idle box
+// re-reporting one cold-prefill measurement must count as ONE sample — not one
+// per tick, which would satisfy EIGENINFERENCE_TTFT_PREFILL_MIN_SAMPLES=5 with
+// a single real observation after five idle ticks. Only a CHANGED value (a new
+// measurement folded into the EWMA) records; per-model tracking keeps
+// co-resident slots independent. Fails without the lastRecordedPrefillTPS gate
+// in Heartbeat (the resent value records 5 samples).
+func TestPrefillHeartbeatDedupsResentEWMA(t *testing.T) {
+	reg := New(testLogger())
+	makeSchedulerProvider(t, reg, "box", gptossBuild, 30)
+
+	hb := func(slots []protocol.BackendSlotCapacity) {
+		reg.Heartbeat("box", &protocol.HeartbeatMessage{
+			Type:   protocol.TypeHeartbeat,
+			Status: "serving",
+			BackendCapacity: &protocol.BackendCapacity{
+				TotalMemoryGB: 64,
+				Slots:         slots,
+			},
+		})
+	}
+
+	// Five idle ticks resending the SAME EWMA = one measurement, one sample.
+	for i := 0; i < 5; i++ {
+		hb([]protocol.BackendSlotCapacity{
+			{Model: gptossBuild, State: "idle", ObservedPrefillTPS: 6500},
+		})
+	}
+	if _, n := reg.tpsRegistry.PrefillMedian(gptossBuild, "M3"); n != 1 {
+		t.Fatalf("prefill samples after 5 identical heartbeats = %d, want 1 (a resent EWMA is not a new observation)", n)
+	}
+
+	// A changed value IS a new observation — recorded. And a change BACK to a
+	// previously seen value is also new (the gate compares against the last
+	// recorded value, not a history).
+	hb([]protocol.BackendSlotCapacity{
+		{Model: gptossBuild, State: "running", ObservedPrefillTPS: 7000},
+	})
+	hb([]protocol.BackendSlotCapacity{
+		{Model: gptossBuild, State: "running", ObservedPrefillTPS: 6500},
+	})
+	if _, n := reg.tpsRegistry.PrefillMedian(gptossBuild, "M3"); n != 3 {
+		t.Fatalf("prefill samples after two genuine changes = %d, want 3", n)
+	}
+
+	// Per-model independence: a co-resident slot reporting the same NUMBER for a
+	// different model is that model's first observation.
+	hb([]protocol.BackendSlotCapacity{
+		{Model: gptossBuild, State: "running", ObservedPrefillTPS: 6500},
+		{Model: gemmaBuild, State: "running", ObservedPrefillTPS: 6500},
+	})
+	if _, n := reg.tpsRegistry.PrefillMedian(gptossBuild, "M3"); n != 3 {
+		t.Fatalf("gpt-oss samples after unchanged resend = %d, want 3", n)
+	}
+	if _, n := reg.tpsRegistry.PrefillMedian(gemmaBuild, "M3"); n != 1 {
+		t.Fatalf("gemma samples = %d, want 1 (per-model tracking)", n)
+	}
+}
+
 // TestPrefillIngestZeroedUnderOldCeiling documents the ceiling interaction the
 // absorbed #453 change fixes: with the ceiling back at the legacy 5000, a REAL
 // p50-scale measurement (6500) is zeroed at ingest and the median ring starves.

--- a/coordinator/registry/prefill_tps_test.go
+++ b/coordinator/registry/prefill_tps_test.go
@@ -1,0 +1,308 @@
+package registry
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+)
+
+// --- Prefill sample ring ---
+
+func TestPrefillMedianReturnsMedianAndCount(t *testing.T) {
+	r := NewTPSRegistry()
+	for _, v := range []float64{9000, 5000, 6500, 6000, 7000} {
+		r.RecordPrefill("model-a", "m4", v)
+	}
+	tps, n := r.PrefillMedian("model-a", "m4")
+	if tps != 6500 || n != 5 {
+		t.Fatalf("PrefillMedian = (%v, %d), want (6500, 5)", tps, n)
+	}
+	// The decode stores must be untouched by prefill recording.
+	if got := r.Median("model-a", "m4"); got != 0 {
+		t.Fatalf("Median = %v, want 0 (RecordPrefill must not feed the decode store)", got)
+	}
+	if _, n := r.SoloMedian("model-a", "m4"); n != 0 {
+		t.Fatalf("SoloMedian count = %d, want 0", n)
+	}
+}
+
+func TestPrefillMedianEmptyInvalidAndFIFO(t *testing.T) {
+	r := NewTPSRegistry()
+	if tps, n := r.PrefillMedian("missing", "m4"); tps != 0 || n != 0 {
+		t.Fatalf("PrefillMedian(empty) = (%v, %d), want (0, 0)", tps, n)
+	}
+	r.RecordPrefill("model", "m4", 0)
+	r.RecordPrefill("model", "m4", -3)
+	r.RecordPrefill("", "m4", 5000)
+	if tps, n := r.PrefillMedian("model", "m4"); tps != 0 || n != 0 {
+		t.Fatalf("PrefillMedian(after invalid samples) = (%v, %d), want (0, 0)", tps, n)
+	}
+	for i := 0; i < 50; i++ {
+		r.RecordPrefill("model", "m4", 1000)
+	}
+	for i := 0; i < 10; i++ {
+		r.RecordPrefill("model", "m4", 2000)
+	}
+	// 40 × 1000 + 10 × 2000 after FIFO eviction → median 1000, count capped at 50.
+	if tps, n := r.PrefillMedian("model", "m4"); tps != 1000 || n != 50 {
+		t.Fatalf("PrefillMedian = (%v, %d), want (1000, 50) after FIFO eviction", tps, n)
+	}
+}
+
+// --- Heartbeat ingest ---
+
+// TestPrefillRecordingThroughHeartbeat drives the REAL heartbeat ingest path:
+// observed_prefill_tps > 0 feeds the prefill ring UNCONDITIONALLY (no solo
+// gating — prefill is per-request compute-bound; the ingest-gating rationale is
+// in prefill_tps.go), while out-of-range values are zeroed by
+// clampBackendCapacity and never reach the ring.
+func TestPrefillRecordingThroughHeartbeat(t *testing.T) {
+	reg := New(testLogger())
+	makeSchedulerProvider(t, reg, "box", gptossBuild, 30)
+
+	hb := func(slots []protocol.BackendSlotCapacity) {
+		reg.Heartbeat("box", &protocol.HeartbeatMessage{
+			Type:   protocol.TypeHeartbeat,
+			Status: "serving",
+			BackendCapacity: &protocol.BackendCapacity{
+				TotalMemoryGB: 64,
+				Slots:         slots,
+			},
+		})
+	}
+
+	// A real measurement above the OLD 5000 ceiling (the fleet p50 is 6,523)
+	// must survive ingest and land in the ring — this is exactly why the #453
+	// ceiling raise (maxPrefillTPS 5000 → 20000) is a prerequisite for the
+	// medians: under the old ceiling this sample would have been zeroed.
+	hb([]protocol.BackendSlotCapacity{
+		{Model: gptossBuild, State: "running", NumRunning: 1, ObservedPrefillTPS: 6500},
+	})
+	if tps, n := reg.tpsRegistry.PrefillMedian(gptossBuild, "M3"); tps != 6500 || n != 1 {
+		t.Fatalf("PrefillMedian after heartbeat = (%v, %d), want (6500, 1)", tps, n)
+	}
+
+	// A CONTENDED box still records (deliberately un-gated, unlike RecordSolo):
+	// co-resident decode does not invalidate a compute-bound prefill EWMA.
+	hb([]protocol.BackendSlotCapacity{
+		{Model: gptossBuild, State: "running", NumRunning: 2, NumWaiting: 1, ObservedPrefillTPS: 7000},
+		{Model: gemmaBuild, State: "running", NumRunning: 3, ObservedDecodeTPS: 4},
+	})
+	if _, n := reg.tpsRegistry.PrefillMedian(gptossBuild, "M3"); n != 2 {
+		t.Fatalf("prefill samples after contended heartbeat = %d, want 2 (no solo gating)", n)
+	}
+
+	// Out-of-range garbage (the prefix-cache-hit EWMA overflow) is zeroed at
+	// the clamp and must NOT be recorded; an unreported slot (0) records nothing.
+	hb([]protocol.BackendSlotCapacity{
+		{Model: gptossBuild, State: "running", ObservedPrefillTPS: 25_000},
+	})
+	hb([]protocol.BackendSlotCapacity{
+		{Model: gptossBuild, State: "running", ObservedPrefillTPS: 0},
+	})
+	if _, n := reg.tpsRegistry.PrefillMedian(gptossBuild, "M3"); n != 2 {
+		t.Fatalf("prefill samples after garbage/zero heartbeats = %d, want 2", n)
+	}
+}
+
+// TestPrefillIngestZeroedUnderOldCeiling documents the ceiling interaction the
+// absorbed #453 change fixes: with the ceiling back at the legacy 5000, a REAL
+// p50-scale measurement (6500) is zeroed at ingest and the median ring starves.
+func TestPrefillIngestZeroedUnderOldCeiling(t *testing.T) {
+	t.Cleanup(func() { SetMaxPrefillTPS(defaultMaxPrefillTPS) })
+	SetMaxPrefillTPS(5000)
+	reg := New(testLogger())
+	makeSchedulerProvider(t, reg, "box", gptossBuild, 30)
+	reg.Heartbeat("box", &protocol.HeartbeatMessage{
+		Type:   protocol.TypeHeartbeat,
+		Status: "serving",
+		BackendCapacity: &protocol.BackendCapacity{
+			TotalMemoryGB: 64,
+			Slots: []protocol.BackendSlotCapacity{
+				{Model: gptossBuild, State: "running", ObservedPrefillTPS: 6500},
+			},
+		},
+	})
+	if _, n := reg.tpsRegistry.PrefillMedian(gptossBuild, "M3"); n != 0 {
+		t.Fatalf("prefill samples under the old 5000 ceiling = %d, want 0 (zeroed at ingest)", n)
+	}
+}
+
+// --- TTFT estimation ---
+
+// longPromptRequest is the production overshoot shape: gpt-oss's p90 prompt of
+// 13,711 tokens against the 5s hard TTFT deadline.
+func longPromptRequest(id string) *PendingRequest {
+	return &PendingRequest{
+		RequestID:             id,
+		Model:                 gptossBuild,
+		EstimatedPromptTokens: 13_711,
+		RequestedMaxTokens:    256,
+		MaxTTFTMs:             5_000,
+	}
+}
+
+// seedPrefillMedian records n gated samples for (model, chip M3).
+func seedPrefillMedian(reg *Registry, model string, n int, tps float64) {
+	for i := 0; i < n; i++ {
+		reg.tpsRegistry.RecordPrefill(model, "M3", tps)
+	}
+}
+
+// TestPrefillMedianLongPromptRegression replicates the production overshoot:
+// a 13.7k-token prompt on a warm box whose real (fleet-measured) prefill is
+// 6,500 tok/s. The ratio-derived estimate (decode 30 × 12 = 360 tok/s → ~38s
+// "TTFT") rejects it at the 5s deadline — the ttft_too_slow misprediction class
+// killing 18.2k requests/day — while the trusted per-(model, chip) median
+// admits it (13,711 / 6,500 ≈ 2.1s). Fails without the median layer in
+// prefillTPSForSnapshot.
+func TestPrefillMedianLongPromptRegression(t *testing.T) {
+	reg := New(testLogger())
+	makeSchedulerProvider(t, reg, "warm-box", gptossBuild, 30)
+	seedPrefillMedian(reg, gptossBuild, 5, 6500)
+
+	p, decision := reg.ReserveProviderEx(gptossBuild, longPromptRequest("long-prompt-1"))
+	if p == nil {
+		t.Fatalf("long prompt rejected (TTFTRejections=%d, bestTTFT=%.0fms) — the trusted prefill median must admit it", decision.TTFTRejections, decision.BestTTFTMs)
+	}
+	if decision.TTFTMs <= 0 || decision.TTFTMs >= 5_000 {
+		t.Fatalf("median-based TTFT estimate = %.0fms, want ~2100ms (well under the 5s deadline)", decision.TTFTMs)
+	}
+	p.RemovePending("long-prompt-1")
+	reg.SetProviderIdle(p.ID)
+
+	// Kill switch: EIGENINFERENCE_TTFT_PREFILL_MEDIANS=false restores the pure
+	// ratio path — the same request is rejected on the ~38s misprediction.
+	t.Setenv(ttftPrefillMediansEnv, "false")
+	if p, decision := reg.ReserveProviderEx(gptossBuild, longPromptRequest("long-prompt-2")); p != nil {
+		t.Fatalf("kill switch off: long prompt admitted with TTFT %.0fms — must reject on the ratio-derived estimate", decision.TTFTMs)
+	} else if decision.TTFTRejections != 1 {
+		t.Fatalf("kill switch off: TTFTRejections = %d, want 1", decision.TTFTRejections)
+	}
+}
+
+// TestPrefillMedianMinSampleFloor: below EIGENINFERENCE_TTFT_PREFILL_MIN_SAMPLES
+// the median is not trusted (ratio path → reject); at the floor it is.
+func TestPrefillMedianMinSampleFloor(t *testing.T) {
+	reg := New(testLogger())
+	makeSchedulerProvider(t, reg, "warm-box", gptossBuild, 30)
+
+	seedPrefillMedian(reg, gptossBuild, 4, 6500)
+	if p, _ := reg.ReserveProviderEx(gptossBuild, longPromptRequest("below-floor")); p != nil {
+		t.Fatalf("4 samples (< default floor 5): median must not be trusted yet")
+	}
+	seedPrefillMedian(reg, gptossBuild, 1, 6500)
+	p, _ := reg.ReserveProviderEx(gptossBuild, longPromptRequest("at-floor"))
+	if p == nil {
+		t.Fatalf("5 samples (= default floor): median must be trusted")
+	}
+	p.RemovePending("at-floor")
+	reg.SetProviderIdle(p.ID)
+
+	// A raised floor un-trusts the same median again (live-read env).
+	t.Setenv(ttftPrefillMinSamplesEnv, "6")
+	if p, _ := reg.ReserveProviderEx(gptossBuild, longPromptRequest("raised-floor")); p != nil {
+		t.Fatalf("floor raised to 6: 5 samples must no longer be trusted")
+	}
+}
+
+// TestPrefillMedianPreflightConsistency: the capacity preflight's bestTTFT uses
+// the same estimate, so the shed decision and Retry-After agree with dispatch.
+func TestPrefillMedianPreflightConsistency(t *testing.T) {
+	reg := New(testLogger())
+	makeSchedulerProvider(t, reg, "warm-box", gptossBuild, 30)
+
+	_, _, _, bestTTFT, hasTTFT := reg.QuickCapacityCheckWithTTFTForRequest(gptossBuild, 13_711, 256, RequestTraits{}, false)
+	if !hasTTFT || bestTTFT < 30*time.Second {
+		t.Fatalf("ratio-path preflight bestTTFT = (%v, %v), want ~38s (the overshoot)", bestTTFT, hasTTFT)
+	}
+	seedPrefillMedian(reg, gptossBuild, 5, 6500)
+	_, _, _, bestTTFT, hasTTFT = reg.QuickCapacityCheckWithTTFTForRequest(gptossBuild, 13_711, 256, RequestTraits{}, false)
+	if !hasTTFT || bestTTFT > 4*time.Second {
+		t.Fatalf("median preflight bestTTFT = (%v, %v), want ~2.1s", bestTTFT, hasTTFT)
+	}
+}
+
+// TestPrefillTPSForSnapshotResolutionOrder pins the full resolution chain of
+// prefillTPSForSnapshot: own observed EWMA → trusted median → (enforce-only)
+// fallback anchor → static ratio chain, with the maxPrefillTPS cap on top.
+func TestPrefillTPSForSnapshotResolutionOrder(t *testing.T) {
+	base := routingSnapshot{prefillTPS: 360, hasBackendCapacity: true}
+	median := func(tps float64, n int) routingSnapshot {
+		s := base
+		s.prefillMedianTPS = tps
+		s.prefillMedianSamples = n
+		return s
+	}
+	cases := []struct {
+		name        string
+		snap        routingSnapshot
+		recalibrate bool
+		want        float64
+	}{
+		{"static_ratio_chain", base, false, 360},
+		{"own_observation_wins", func() routingSnapshot {
+			s := median(6500, 50)
+			s.observedPrefillTPS = 9000
+			return s
+		}(), true, 9000},
+		{"trusted_median_replaces_static", median(6500, 5), false, 6500},
+		// The median is a real measurement: unlike the anchor it may honestly
+		// LOWER an optimistic static estimate.
+		{"trusted_median_lowers_static", func() routingSnapshot {
+			s := median(2000, 5)
+			s.prefillTPS = 4000
+			return s
+		}(), true, 2000},
+		{"untrusted_median_falls_to_anchor", median(6500, 4), true, defaultPrefillFallbackTPS},
+		{"untrusted_median_falls_to_static_when_off", median(6500, 4), false, 360},
+		{"anchor_never_lowers_static", func() routingSnapshot {
+			s := base
+			s.prefillTPS = 9000
+			return s
+		}(), true, 9000},
+		{"cap_applies_to_median", median(30_000, 5), false, defaultMaxPrefillTPS},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := prefillTPSForSnapshot(tc.snap, tc.recalibrate); got != tc.want {
+				t.Fatalf("prefillTPSForSnapshot = %v, want %v", got, tc.want)
+			}
+		})
+	}
+
+	// Kill switch: the median layer vanishes; everything else is unchanged.
+	t.Setenv(ttftPrefillMediansEnv, "false")
+	if got := prefillTPSForSnapshot(median(6500, 50), false); got != 360 {
+		t.Fatalf("kill switch off: prefillTPSForSnapshot = %v, want the static 360 exactly", got)
+	}
+	if got := prefillTPSForSnapshot(median(6500, 50), true); got != defaultPrefillFallbackTPS {
+		t.Fatalf("kill switch off + enforce: prefillTPSForSnapshot = %v, want the anchor %v", got, defaultPrefillFallbackTPS)
+	}
+}
+
+// TestPrefillMedianConvergesAcrossBoxes: several same-chip boxes that never
+// reported their own measurement all estimate from the SAME fleet median — the
+// transfer property that routes long prompts to (and admits them on) boxes the
+// static chain would have shed.
+func TestPrefillMedianConvergesAcrossBoxes(t *testing.T) {
+	reg := New(testLogger())
+	seedPrefillMedian(reg, gptossBuild, 5, 6500)
+	for i, decodeTPS := range []float64{20, 30, 90} {
+		id := fmt.Sprintf("box-%d", i)
+		makeSchedulerProvider(t, reg, id, gptossBuild, decodeTPS)
+		reqID := fmt.Sprintf("req-%d", i)
+		pr := longPromptRequest(reqID)
+		p, decision := reg.ReserveProviderEx(gptossBuild, pr)
+		if p == nil {
+			t.Fatalf("box with decode %v: long prompt rejected, want admitted via the shared median", decodeTPS)
+		}
+		if decision.TTFTMs >= 5_000 {
+			t.Fatalf("box with decode %v: TTFT estimate %.0fms, want ~2.1s", decodeTPS, decision.TTFTMs)
+		}
+		p.RemovePending(reqID)
+		reg.SetProviderIdle(p.ID)
+	}
+}

--- a/coordinator/registry/prefill_tps_test.go
+++ b/coordinator/registry/prefill_tps_test.go
@@ -80,7 +80,7 @@ func TestPrefillRecordingThroughHeartbeat(t *testing.T) {
 	hb([]protocol.BackendSlotCapacity{
 		{Model: gptossBuild, State: "running", NumRunning: 1, ObservedPrefillTPS: 6500},
 	})
-	if tps, n := reg.tpsRegistry.PrefillMedian(gptossBuild, "M3"); tps != 6500 || n != 1 {
+	if tps, n := reg.tpsRegistry.PrefillMedian(gptossBuild, "M3|Max"); tps != 6500 || n != 1 {
 		t.Fatalf("PrefillMedian after heartbeat = (%v, %d), want (6500, 1)", tps, n)
 	}
 
@@ -90,7 +90,7 @@ func TestPrefillRecordingThroughHeartbeat(t *testing.T) {
 		{Model: gptossBuild, State: "running", NumRunning: 2, NumWaiting: 1, ObservedPrefillTPS: 7000},
 		{Model: gemmaBuild, State: "running", NumRunning: 3, ObservedDecodeTPS: 4},
 	})
-	if _, n := reg.tpsRegistry.PrefillMedian(gptossBuild, "M3"); n != 2 {
+	if _, n := reg.tpsRegistry.PrefillMedian(gptossBuild, "M3|Max"); n != 2 {
 		t.Fatalf("prefill samples after contended heartbeat = %d, want 2 (no solo gating)", n)
 	}
 
@@ -102,7 +102,7 @@ func TestPrefillRecordingThroughHeartbeat(t *testing.T) {
 	hb([]protocol.BackendSlotCapacity{
 		{Model: gptossBuild, State: "running", ObservedPrefillTPS: 0},
 	})
-	if _, n := reg.tpsRegistry.PrefillMedian(gptossBuild, "M3"); n != 2 {
+	if _, n := reg.tpsRegistry.PrefillMedian(gptossBuild, "M3|Max"); n != 2 {
 		t.Fatalf("prefill samples after garbage/zero heartbeats = %d, want 2", n)
 	}
 }
@@ -136,7 +136,7 @@ func TestPrefillHeartbeatDedupsResentEWMA(t *testing.T) {
 			{Model: gptossBuild, State: "idle", ObservedPrefillTPS: 6500},
 		})
 	}
-	if _, n := reg.tpsRegistry.PrefillMedian(gptossBuild, "M3"); n != 1 {
+	if _, n := reg.tpsRegistry.PrefillMedian(gptossBuild, "M3|Max"); n != 1 {
 		t.Fatalf("prefill samples after 5 identical heartbeats = %d, want 1 (a resent EWMA is not a new observation)", n)
 	}
 
@@ -149,7 +149,7 @@ func TestPrefillHeartbeatDedupsResentEWMA(t *testing.T) {
 	hb([]protocol.BackendSlotCapacity{
 		{Model: gptossBuild, State: "running", ObservedPrefillTPS: 6500},
 	})
-	if _, n := reg.tpsRegistry.PrefillMedian(gptossBuild, "M3"); n != 3 {
+	if _, n := reg.tpsRegistry.PrefillMedian(gptossBuild, "M3|Max"); n != 3 {
 		t.Fatalf("prefill samples after two genuine changes = %d, want 3", n)
 	}
 
@@ -159,10 +159,10 @@ func TestPrefillHeartbeatDedupsResentEWMA(t *testing.T) {
 		{Model: gptossBuild, State: "running", ObservedPrefillTPS: 6500},
 		{Model: gemmaBuild, State: "running", ObservedPrefillTPS: 6500},
 	})
-	if _, n := reg.tpsRegistry.PrefillMedian(gptossBuild, "M3"); n != 3 {
+	if _, n := reg.tpsRegistry.PrefillMedian(gptossBuild, "M3|Max"); n != 3 {
 		t.Fatalf("gpt-oss samples after unchanged resend = %d, want 3", n)
 	}
-	if _, n := reg.tpsRegistry.PrefillMedian(gemmaBuild, "M3"); n != 1 {
+	if _, n := reg.tpsRegistry.PrefillMedian(gemmaBuild, "M3|Max"); n != 1 {
 		t.Fatalf("gemma samples = %d, want 1 (per-model tracking)", n)
 	}
 }
@@ -185,7 +185,7 @@ func TestPrefillIngestZeroedUnderOldCeiling(t *testing.T) {
 			},
 		},
 	})
-	if _, n := reg.tpsRegistry.PrefillMedian(gptossBuild, "M3"); n != 0 {
+	if _, n := reg.tpsRegistry.PrefillMedian(gptossBuild, "M3|Max"); n != 0 {
 		t.Fatalf("prefill samples under the old 5000 ceiling = %d, want 0 (zeroed at ingest)", n)
 	}
 }
@@ -204,10 +204,11 @@ func longPromptRequest(id string) *PendingRequest {
 	}
 }
 
-// seedPrefillMedian records n gated samples for (model, chip M3).
+// seedPrefillMedian records n gated samples for (model, chip class "M3|Max" —
+// the family+tier key prefillChipClass derives from the test provider hardware).
 func seedPrefillMedian(reg *Registry, model string, n int, tps float64) {
 	for i := 0; i < n; i++ {
-		reg.tpsRegistry.RecordPrefill(model, "M3", tps)
+		reg.tpsRegistry.RecordPrefill(model, "M3|Max", tps)
 	}
 }
 
@@ -242,6 +243,71 @@ func TestPrefillMedianLongPromptRegression(t *testing.T) {
 		t.Fatalf("kill switch off: long prompt admitted with TTFT %.0fms — must reject on the ratio-derived estimate", decision.TTFTMs)
 	} else if decision.TTFTRejections != 1 {
 		t.Fatalf("kill switch off: TTFTRejections = %d, want 1", decision.TTFTRejections)
+	}
+}
+
+// TestPrefillMedianNotBorrowedAcrossChipTier is the regression for the Codex
+// chip-tier finding: prefill spreads 3–4× across tiers within a family, so a
+// median seeded by fast M3 Max boxes must NOT be trusted for an M3 base/Pro box
+// that never reported its own measurement — otherwise the base box's long
+// prompt is admitted at the hard TTFT gate on a rate it cannot sustain. With
+// the pre-fix family keying ("M3") the base box would borrow the Max median and
+// be admitted; with class keying ("M3|Max" vs "M3|") it correctly falls back to
+// the ratio path and is shed.
+func TestPrefillMedianNotBorrowedAcrossChipTier(t *testing.T) {
+	t.Setenv(ttftPrefillMediansEnv, "true")
+	t.Setenv(ttftPrefillMinSamplesEnv, "5")
+	reg := New(testLogger())
+
+	// Seed the median through the REAL heartbeat ingest from an M3 MAX box (5
+	// changing values → 5 samples, dedup-safe), so the samples land under
+	// whatever key the ingest actually uses. Under the fix that is "M3|Max";
+	// under the pre-fix family keying it would be "M3" — which is exactly what
+	// lets a base box wrongly borrow them.
+	makeSchedulerProvider(t, reg, "m3-max-seed", gptossBuild, 30) // testRegisterMessage = M3 Max
+	for _, v := range []float64{6400, 6450, 6500, 6550, 6600} {
+		reg.Heartbeat("m3-max-seed", &protocol.HeartbeatMessage{
+			Type:   protocol.TypeHeartbeat,
+			Status: "serving",
+			BackendCapacity: &protocol.BackendCapacity{
+				TotalMemoryGB: 64,
+				Slots:         []protocol.BackendSlotCapacity{{Model: gptossBuild, State: "running", NumRunning: 1, ObservedPrefillTPS: v}},
+			},
+		})
+	}
+	if _, n := reg.tpsRegistry.PrefillMedian(gptossBuild, "M3|Max"); n != 5 {
+		t.Fatalf("seed samples under M3|Max = %d, want 5", n)
+	}
+	// Remove the seed box from routing; the median ring is registry-global and
+	// persists, so only the base box below is evaluated for the long prompt.
+	reg.RemoveProviderBySerial("m3-max-seed", true)
+
+	// A same-FAMILY but different-TIER box (M3 base, empty ChipTier) that never
+	// reported its own prefill: its class key is "M3|", so the Max samples must
+	// NOT apply and the long prompt is shed on the ratio estimate. With the
+	// pre-fix family keying (ingest + lookup both "M3") it would find the median
+	// and be admitted.
+	base := makeSchedulerProvider(t, reg, "m3-base", gptossBuild, 30)
+	base.mu.Lock()
+	base.Hardware.ChipTier = "" // base chip → prefillChipClass "M3|"
+	base.Hardware.ChipName = "Apple M3"
+	base.mu.Unlock()
+	if got := prefillChipClass(base.Hardware); got != "M3|" {
+		t.Fatalf("prefillChipClass(base M3) = %q, want %q", got, "M3|")
+	}
+	if p, decision := reg.ReserveProviderEx(gptossBuild, longPromptRequest("cross-tier")); p != nil {
+		t.Fatalf("base-tier box admitted the long prompt (TTFT %.0fms) — the M3 Max median must not transfer across tiers", decision.TTFTMs)
+	} else if decision.TTFTRejections != 1 {
+		t.Fatalf("TTFTRejections = %d, want 1 (ratio-path shed, median not borrowed across tiers)", decision.TTFTRejections)
+	}
+
+	// Control: a same-tier M3 MAX box with no own measurement DOES trust the
+	// seeded median and is admitted — the transfer still works within a tier.
+	reg2 := New(testLogger())
+	seedPrefillMedian(reg2, gptossBuild, 5, 6500) // keys "M3|Max"
+	makeSchedulerProvider(t, reg2, "m3-max", gptossBuild, 30)
+	if p, _ := reg2.ReserveProviderEx(gptossBuild, longPromptRequest("same-tier")); p == nil {
+		t.Fatalf("same-tier (M3 Max) box shed the long prompt — the median must transfer within a tier")
 	}
 }
 

--- a/coordinator/registry/prefill_tps_test.go
+++ b/coordinator/registry/prefill_tps_test.go
@@ -159,6 +159,8 @@ func seedPrefillMedian(reg *Registry, model string, n int, tps float64) {
 // admits it (13,711 / 6,500 ≈ 2.1s). Fails without the median layer in
 // prefillTPSForSnapshot.
 func TestPrefillMedianLongPromptRegression(t *testing.T) {
+	t.Setenv(ttftPrefillMediansEnv, "true") // pin the default against ambient operator env
+	t.Setenv(ttftPrefillMinSamplesEnv, "5")
 	reg := New(testLogger())
 	makeSchedulerProvider(t, reg, "warm-box", gptossBuild, 30)
 	seedPrefillMedian(reg, gptossBuild, 5, 6500)
@@ -186,6 +188,8 @@ func TestPrefillMedianLongPromptRegression(t *testing.T) {
 // TestPrefillMedianMinSampleFloor: below EIGENINFERENCE_TTFT_PREFILL_MIN_SAMPLES
 // the median is not trusted (ratio path → reject); at the floor it is.
 func TestPrefillMedianMinSampleFloor(t *testing.T) {
+	t.Setenv(ttftPrefillMediansEnv, "true")
+	t.Setenv(ttftPrefillMinSamplesEnv, "5")
 	reg := New(testLogger())
 	makeSchedulerProvider(t, reg, "warm-box", gptossBuild, 30)
 
@@ -211,6 +215,8 @@ func TestPrefillMedianMinSampleFloor(t *testing.T) {
 // TestPrefillMedianPreflightConsistency: the capacity preflight's bestTTFT uses
 // the same estimate, so the shed decision and Retry-After agree with dispatch.
 func TestPrefillMedianPreflightConsistency(t *testing.T) {
+	t.Setenv(ttftPrefillMediansEnv, "true")
+	t.Setenv(ttftPrefillMinSamplesEnv, "5")
 	reg := New(testLogger())
 	makeSchedulerProvider(t, reg, "warm-box", gptossBuild, 30)
 
@@ -288,6 +294,8 @@ func TestPrefillTPSForSnapshotResolutionOrder(t *testing.T) {
 // transfer property that routes long prompts to (and admits them on) boxes the
 // static chain would have shed.
 func TestPrefillMedianConvergesAcrossBoxes(t *testing.T) {
+	t.Setenv(ttftPrefillMediansEnv, "true")
+	t.Setenv(ttftPrefillMinSamplesEnv, "5")
 	reg := New(testLogger())
 	seedPrefillMedian(reg, gptossBuild, 5, 6500)
 	for i, decodeTPS := range []float64{20, 30, 90} {

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -1067,7 +1067,34 @@ func (p *Provider) ReportedTokenBudgetMaxForModel(model string) int64 {
 	return 0
 }
 
-// maxConcurrency is the lock-free version (caller must hold p.mu).
+// maxConcurrency is the lock-free version (caller must hold p.mu; p.Version is
+// p.mu-guarded): the legacy cap chain, bounded by the v2 box-wide ceiling for
+// >=v2-floor providers.
+func (p *Provider) maxConcurrency() int {
+	return v2BoxCeilingClamp(p.Version, p.legacyMaxConcurrency())
+}
+
+// v2BoxCeilingClamp bounds a provider-level concurrency cap by the v2 box-wide
+// ceiling for >=EIGENINFERENCE_V2_VERSION_FLOOR providers. Engine V2 runs ONE
+// engine with a BOX-WIDE concurrent-request cap (productionMaxConcurrentRequests,
+// the v2 ceiling — see v2_capacity_clamp.go). The heartbeat clamp bounds each
+// SLOT's max_concurrency, but the provider-LEVEL valve (pendingCount() <
+// maxConcurrency(), aggregated across ALL models) is what enforces the box-wide
+// total: without this clamp, a >=floor box with multiple warm models admits
+// slots × ceiling in aggregate under the legacy token-budget valve of 24 —
+// exactly the over-admission the tripwire exists to prevent. Tightening only
+// (min, never a raise: a small box's hardware-derived cap of 2 stays 2), and a
+// no-op when the floor env is unset or the provider is below it
+// (providerAtOrAboveV2Floor is false for both).
+func v2BoxCeilingClamp(version string, cap int) int {
+	if providerAtOrAboveV2Floor(version) && cap > v2MaxConcurrencyCeiling {
+		return v2MaxConcurrencyCeiling
+	}
+	return cap
+}
+
+// legacyMaxConcurrency is the pre-v2 provider-level cap chain (token-budget
+// safety valve → hardware tiers). Callers must hold p.mu.
 //
 // Tier values were lowered in Phase 2 of the routing-algorithm rework
 // (was 4/8/16/24/32). The old caps were derived from "how many
@@ -1076,7 +1103,7 @@ func (p *Provider) ReportedTokenBudgetMaxForModel(model string) int64 {
 // per-request TPS collapses". Empirically this is much smaller than
 // the memory-derived ceiling. Pushing past it makes each request slow
 // without increasing fleet throughput.
-func (p *Provider) maxConcurrency() int {
+func (p *Provider) legacyMaxConcurrency() int {
 	if p.BackendCapacity == nil {
 		return DefaultMaxConcurrent
 	}

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -4421,6 +4421,15 @@ type providerCapSnap struct {
 	activeTokenBudgetMax  int64
 	activeTokenBudgetUsed int64
 	queuedTokenBudget     int64
+	// pooledBudgetRemaining is the provider's whole-box pooled token budget
+	// left after charging ALL models' coordinator-pending tokens — the same
+	// pool the admission gate (pooledBudgetAdmits) enforces, so this public
+	// capacity feed cannot advertise per-slot headroom dispatch would reject:
+	// co-resident slots each re-report the ONE shared KV headroom, and an
+	// in-gap burst to model A is invisible to model B's slot fields until the
+	// next heartbeat. -1 = provider reports no pooled budget (legacy), which
+	// leaves the per-slot numbers unclamped.
+	pooledBudgetRemaining int64
 }
 
 // publiclyRoutableLocked reports whether a provider passes the public routing
@@ -4459,6 +4468,29 @@ func (r *Registry) ModelCapacitySnapshot() []ModelCapacity {
 		decodeTPS := resolvedDecodeTPS(p)
 		prefillTPS := resolvedPrefillTPS(p)
 
+		// Reconstruct the whole-box pooled budget remaining after charging
+		// every model's coordinator-pending tokens (mirrors pooledBudgetAdmits'
+		// token accounting: pending beyond the heartbeat-visible committed
+		// baseline spends the pool). Token units — this surface reports token
+		// budgets; byte normalization stays an admission-gate concern.
+		pooledRemaining := int64(-1)
+		if p.BackendCapacity != nil {
+			if pool := providerPooledTokenBudget(p.BackendCapacity.Slots); pool.total > 0 {
+				pendingAll := 0
+				for _, pr := range p.pendingReqs {
+					pendingAll += pendingTokenBudget(pr)
+				}
+				extra := int64(pendingAll) - pool.committed
+				if extra < 0 {
+					extra = 0
+				}
+				pooledRemaining = pool.total - pool.used - extra
+				if pooledRemaining < 0 {
+					pooledRemaining = 0
+				}
+			}
+		}
+
 		// Enumerate every model this provider serves.
 		for _, m := range p.Models {
 			if !r.modelAllowedByCatalogLocked(m) {
@@ -4480,11 +4512,12 @@ func (r *Registry) ModelCapacitySnapshot() []ModelCapacity {
 			}
 
 			snap := providerCapSnap{
-				model:          m.ID,
-				hasHeadroom:    hasHeadroom,
-				effectiveTPS:   decodeTPS,
-				prefillTPS:     prefillTPS,
-				activeRequests: modelPending,
+				model:                 m.ID,
+				hasHeadroom:           hasHeadroom,
+				effectiveTPS:          decodeTPS,
+				prefillTPS:            prefillTPS,
+				activeRequests:        modelPending,
+				pooledBudgetRemaining: pooledRemaining,
 			}
 
 			// Check backend capacity for this model's slot.
@@ -4561,14 +4594,25 @@ func (r *Registry) ModelCapacitySnapshot() []ModelCapacity {
 			if headroom < 0 {
 				headroom = 0
 			}
+			// Per-slot headroom cannot exceed the provider's pooled remaining:
+			// each co-resident slot re-reports the ONE shared KV headroom, so
+			// in-gap pending to another model already spent it. Without the
+			// clamp this surface advertises capacity pooledBudgetAdmits rejects.
+			if s.pooledBudgetRemaining >= 0 && headroom > s.pooledBudgetRemaining {
+				headroom = s.pooledBudgetRemaining
+			}
 			a.budgetRemaining += headroom
 			a.budgetTotal += s.activeTokenBudgetMax
 		}
 		// Routable providers require both concurrency headroom AND token-budget
 		// headroom. A provider with exhausted token budget should not make the
-		// model appear immediately ready.
-		hasBudgetHeadroom := s.activeTokenBudgetMax <= 0 ||
-			s.activeTokenBudgetUsed+s.queuedTokenBudget < s.activeTokenBudgetMax
+		// model appear immediately ready. An exhausted POOLED budget (0 — not
+		// the -1 no-budget sentinel) counts as exhausted for every model on the
+		// box, cold ones included: the admission gate charges those against the
+		// shared pool too (freeMemoryAdmits' cold-slot pooled gate).
+		hasBudgetHeadroom := (s.activeTokenBudgetMax <= 0 ||
+			s.activeTokenBudgetUsed+s.queuedTokenBudget < s.activeTokenBudgetMax) &&
+			s.pooledBudgetRemaining != 0
 		if s.hasHeadroom && hasBudgetHeadroom {
 			a.routable++
 			a.anyImmediateSlot = true

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -451,6 +451,21 @@ type Provider struct {
 	// Live backend capacity from heartbeats (nil for providers without capacity reporting)
 	BackendCapacity *protocol.BackendCapacity
 
+	// lastRecordedPrefillTPS tracks, per model, the last observed_prefill_tps
+	// value this connection fed into the fleet prefill-median ring
+	// (tpsRegistry.RecordPrefill). Providers resend a PERSISTENT per-slot EWMA
+	// on every 30s heartbeat, so without this gate one cold-prefill measurement
+	// re-recorded five times would satisfy the ring's min-sample trust floor
+	// (EIGENINFERENCE_TTFT_PREFILL_MIN_SAMPLES) with a single real observation.
+	// A sample is recorded only when the reported value CHANGES — the honest
+	// "a new measurement folded into the EWMA" signal available on the wire
+	// (per-slot first-token counters advance on prefix-cache hits too, which
+	// the provider deliberately does not sample, so they over-count). Lazily
+	// allocated; per-connection like BackendCapacity (a reconnect records one
+	// fresh sample — bounded, and the ring's FIFO + median absorb it). Guarded
+	// by p.mu.
+	lastRecordedPrefillTPS map[string]float64
+
 	// Reputation tracking
 	Reputation Reputation
 
@@ -2773,8 +2788,18 @@ func (r *Registry) Heartbeat(id string, msg *protocol.HeartbeatMessage) {
 			// Deliberately NOT solo-gated (prefill is per-request compute-bound;
 			// see prefill_tps.go for the full ingest-gating rationale). The value
 			// is post-clamp, so out-of-range garbage (the prefix-cache-hit EWMA
-			// overflow) was already zeroed and never reaches the ring.
-			if slot.ObservedPrefillTPS > 0 {
+			// overflow) was already zeroed and never reaches the ring. Gated on
+			// the value CHANGING since this connection's last recorded sample:
+			// the slot EWMA is persistent and resent every heartbeat, so an
+			// unchanged value is a re-report of an already-counted measurement,
+			// not a new observation — recording it would let one measurement
+			// satisfy the ring's min-sample floor after five idle ticks (see
+			// lastRecordedPrefillTPS).
+			if slot.ObservedPrefillTPS > 0 && p.lastRecordedPrefillTPS[slot.Model] != slot.ObservedPrefillTPS {
+				if p.lastRecordedPrefillTPS == nil {
+					p.lastRecordedPrefillTPS = make(map[string]float64)
+				}
+				p.lastRecordedPrefillTPS[slot.Model] = slot.ObservedPrefillTPS
 				r.tpsRegistry.RecordPrefill(slot.Model, chipFamily, slot.ObservedPrefillTPS)
 			}
 		}

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -147,6 +147,16 @@ type PendingRequest struct {
 	// <= MaxTTFTMs. Used by public inference routes to honor the public
 	// TTFT target. Self-route / prefer-owner requests leave this at 0.
 	MaxTTFTMs float64
+	// TTFTTargetMs is the ADVISORY public TTFT target in milliseconds. Unlike
+	// MaxTTFTMs it never drives hard scheduler rejection — it is stamped on
+	// public routes in BOTH gate modes (in hard mode it equals MaxTTFTMs; in the
+	// default soft mode MaxTTFTMs stays 0 but this carries the same deadline).
+	// Consumed only by the satisficing band (dormant by default) so that, in
+	// soft mode, a warm slow-prefill/long-prompt box already over the target is
+	// kept out of the load-spread band instead of weighted-randomly beating a
+	// fast box. 0 (self-route / prefer-owner / queue drains) = no target, and
+	// the band falls back to its cold-exclusion proxy. See satisficing_band.go.
+	TTFTTargetMs float64
 	// MinDecodeTPS is an optional per-request sustained-decode floor in tokens/sec
 	// (Routing v2 W2). When > 0, the scheduler PREFERS providers that would still
 	// deliver >= MinDecodeTPS to a newly admitted request (i.e. not overpack a
@@ -2806,7 +2816,9 @@ func (r *Registry) Heartbeat(id string, msg *protocol.HeartbeatMessage) {
 					p.lastRecordedPrefillTPS = make(map[string]float64)
 				}
 				p.lastRecordedPrefillTPS[slot.Model] = slot.ObservedPrefillTPS
-				r.tpsRegistry.RecordPrefill(slot.Model, chipFamily, slot.ObservedPrefillTPS)
+				// Keyed by chip CLASS (family+tier), NOT family — prefill spreads
+				// 3–4× across same-family tiers; see prefillChipClass.
+				r.tpsRegistry.RecordPrefill(slot.Model, prefillChipClass(p.Hardware), slot.ObservedPrefillTPS)
 			}
 		}
 	}
@@ -3021,12 +3033,26 @@ func (r *Registry) DesiredModelsForProvider(providerID string) []protocol.Desire
 			advertised[m.ID] = struct{}{}
 		}
 	}
+	version := p.Version // captured under p.mu for the version-floor check below
 	p.mu.Unlock()
 
 	var entries []protocol.DesiredModelEntry
 	for alias, t := range r.modelAliases {
 		if t.Desired == "" {
 			continue
+		}
+		// Per-model provider-version floor: do NOT steer a below-floor box toward
+		// the Desired build of a floored alias (e.g. gemma-4=0.7.5 during the v2
+		// migration). Routing will never use that box for the floored model, so a
+		// desired_models command would only make it prefetch/hard-swap away from a
+		// still-usable previous build into one it can't serve — wasting memory and
+		// removing fallback capacity (Codex review). Empty-version boxes fail every
+		// floor. No-op when the floor env is unset. Mirrors the routing/warm-pool
+		// enforcement points in model_version_floors.go.
+		if floor, ok := r.modelVersionFloorForLocked(t.Desired); ok {
+			if version == "" || CompareVersions(version, floor) < 0 {
+				continue
+			}
 		}
 		_, hasDesired := advertised[t.Desired]
 		_, hasPrevious := advertised[t.Previous]
@@ -4630,6 +4656,16 @@ func (r *Registry) ModelCapacitySnapshot() []ModelCapacity {
 		// Enumerate every model this provider serves.
 		for _, m := range p.Models {
 			if !r.modelAllowedByCatalogLocked(m) {
+				continue
+			}
+			// Apply the per-model provider-version floor here too: a below-floor
+			// box is unroutable for a floored model (providerPassesRoutingGates
+			// rejects it), so counting its slot in the public capacity feed would
+			// advertise RoutableProviders/CanAccept from boxes the preflight
+			// immediately 429s — luring upstream routers into traffic this
+			// coordinator cannot serve (Codex review). No-op when the floor env is
+			// unset. Holds r.mu (RLock) and p.mu, as the helper requires.
+			if r.providerBelowModelVersionFloorLocked(p, m.ID) {
 				continue
 			}
 			// Use the SAME quality-concurrency-capped headroom the routing/preflight

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -4582,10 +4582,12 @@ func (r *Registry) ModelCapacitySnapshot() []ModelCapacity {
 			}
 
 			// Per-model pooled remaining: byte-aware when the box is byte-
-			// reconstructable and this model's slot reports a KV rate, else token
-			// accounting — exactly pooledBudgetAdmits' branch. Cold/absent slots
-			// have no rate (map miss ⇒ 0), which lands on the token path just like
-			// the gate's cold-model path. Inert for single-KV/legacy boxes.
+			// reconstructable, else token accounting — exactly pooledBudgetAdmits'
+			// branch. Cold/absent slots have no rate (map miss ⇒ 0); on a byte-
+			// reconstructable pool they are priced at the box's max resident rate
+			// (the same cold-rate substitution the gate uses), so this feed stays
+			// equivalent to the gate on the cold path too. Inert for single-KV/
+			// legacy boxes.
 			pooledRemaining := pooledRemainingTokens(
 				poolSnap.pooledTokenBudget,
 				poolSnap.pendingMaxTokensAllModels,

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -2732,13 +2732,18 @@ func (r *Registry) Heartbeat(id string, msg *protocol.HeartbeatMessage) {
 		// Solo gate: a slot EWMA is additionally recorded as a SOLO sample only
 		// when the whole box is uncontended at heartbeat time (Σ running+waiting
 		// ≤ 1 across ALL slots — the one allowance is the sample-generating
-		// request itself) AND the slot is the one that OWNS that request
-		// (running+waiting > 0). Both halves matter: without the second, every
-		// co-resident slot with a nonzero (stale, decayed) EWMA would be
-		// re-recorded as a fresh solo observation on each ~30s heartbeat,
-		// contaminating OTHER models' medians with samples no request produced —
-		// a fully idle box records nothing, because there is no fresh
-		// observation to record. The unconditional Record keeps its
+		// request itself) AND the slot has an actual RUNNING decode
+		// (NumRunning > 0). Both halves matter. Requiring NumRunning (not
+		// running+waiting) excludes a purely-QUEUED box: the provider reports
+		// NumWaiting from its pending set while ObservedDecodeTPS is a retained
+		// EWMA (BatchScheduler+Telemetry.swift), so a box with one queued-but-
+		// not-yet-decoding request would otherwise mint that stale EWMA as a
+		// fresh solo sample every ~30s heartbeat and, once the min-sample floor
+		// is reached, base the model's quality cap on traffic no running request
+		// produced. It also keeps the prior round's owner-slot-only rule: an
+		// idle co-resident slot with a decayed EWMA is NumRunning == 0, so it is
+		// never re-sampled, and a fully idle box records nothing. The
+		// unconditional Record keeps its
 		// load-inclusive semantics for TTFT estimation (fleetMedianTPS); the
 		// gated RecordSolo feeds the quality-concurrency cap's per-model static
 		// rate (resolvedSoloModelTPSLocked). See solo_tps.go.
@@ -2746,7 +2751,7 @@ func (r *Registry) Heartbeat(id string, msg *protocol.HeartbeatMessage) {
 		for _, slot := range p.BackendCapacity.Slots {
 			if slot.ObservedDecodeTPS > 0 {
 				r.tpsRegistry.Record(slot.Model, chipFamily, slot.ObservedDecodeTPS)
-				if soloEligible && slot.NumRunning+slot.NumWaiting > 0 {
+				if soloEligible && slot.NumRunning > 0 {
 					r.tpsRegistry.RecordSolo(slot.Model, chipFamily, slot.ObservedDecodeTPS)
 				}
 			}
@@ -4537,27 +4542,19 @@ func (r *Registry) ModelCapacitySnapshot() []ModelCapacity {
 		decodeTPS := resolvedDecodeTPS(p)
 		prefillTPS := resolvedPrefillTPS(p)
 
-		// Reconstruct the whole-box pooled budget remaining after charging
-		// every model's coordinator-pending tokens (mirrors pooledBudgetAdmits'
-		// token accounting: pending beyond the heartbeat-visible committed
-		// baseline spends the pool). Token units — this surface reports token
-		// budgets; byte normalization stays an admission-gate concern.
-		pooledRemaining := int64(-1)
+		// Reconstruct the whole-box pooled budget and its all-models
+		// coordinator-pending charges (token and, when every pending request
+		// normalizes, byte) ONCE per provider — the SAME accumulation the
+		// admission gate uses (fillSnapshotPendingAndPool). The per-model
+		// remaining differs only by that model's KV rate in byte mode, so it is
+		// finalized inside the model loop via pooledRemainingTokens, keeping this
+		// feed's verdict identical to pooledBudgetAdmits' on a mixed-KV box (a
+		// pool exhausted in BYTES by a small-KV burst must not surface token
+		// headroom for a big-KV co-resident). Token units out; byte
+		// normalization stays internal.
+		var poolSnap routingSnapshot
 		if p.BackendCapacity != nil {
-			if pool := providerPooledTokenBudget(p.BackendCapacity.Slots); pool.total > 0 {
-				pendingAll := 0
-				for _, pr := range p.pendingReqs {
-					pendingAll += pendingTokenBudget(pr)
-				}
-				extra := int64(pendingAll) - pool.committed
-				if extra < 0 {
-					extra = 0
-				}
-				pooledRemaining = pool.total - pool.used - extra
-				if pooledRemaining < 0 {
-					pooledRemaining = 0
-				}
-			}
+			fillSnapshotPendingAndPool(&poolSnap, p, "")
 		}
 
 		// Enumerate every model this provider serves.
@@ -4579,6 +4576,19 @@ func (r *Registry) ModelCapacitySnapshot() []ModelCapacity {
 					modelPending++
 				}
 			}
+
+			// Per-model pooled remaining: byte-aware when the box is byte-
+			// reconstructable and this model's slot reports a KV rate, else token
+			// accounting — exactly pooledBudgetAdmits' branch. Cold/absent slots
+			// have no rate (map miss ⇒ 0), which lands on the token path just like
+			// the gate's cold-model path. Inert for single-KV/legacy boxes.
+			pooledRemaining := pooledRemainingTokens(
+				poolSnap.pooledTokenBudget,
+				poolSnap.pendingMaxTokensAllModels,
+				poolSnap.pendingMaxBytesAllModels,
+				poolSnap.pendingBytesKnown,
+				poolSnap.pooledTokenBudget.kvBytesPerToken[m.ID],
+			)
 
 			snap := providerCapSnap{
 				model:                 m.ID,

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -1185,6 +1185,17 @@ type Registry struct {
 	// SetDedicatedModels and dedicated_models.go. Guarded by r.mu.
 	dedicatedModels []string
 
+	// modelVersionFloors holds the per-model provider-version routing floors
+	// (pattern → minimum binary version; same substring matching as
+	// dedicatedModels). A model whose resolved build id matches a pattern routes
+	// and pre-warms ONLY onto providers at/above the paired version — the
+	// v0.7.5-migration defense that keeps re-slice-dependent models off binaries
+	// that would silently legacy-serve them. Empty = feature disabled (the
+	// default; retires to empty after fleet convergence). Configured once at
+	// startup from EIGENINFERENCE_MODEL_VERSION_FLOORS; see
+	// model_version_floors.go. Guarded by r.mu.
+	modelVersionFloors []ModelVersionFloor
+
 	// Quality-concurrency admission cap (see concurrency_cap.go). When enabled,
 	// the per-provider concurrency cap for a model is tightened from the flat
 	// fallback to quality_concurrency × overcommit, computed from the provider's
@@ -1375,6 +1386,13 @@ type Registry struct {
 	// restarts. Keyed by the device's Secure Enclave public key. Set once at
 	// startup; nil = no-op. Guarded by r.mu (set + read).
 	onHardUntrust func(seKey string)
+
+	// onV2ClampTrip is an optional hook fired (off the registry locks) whenever
+	// the version-keyed heartbeat sanity clamp corrects a >=v2-floor provider's
+	// reported slot max_concurrency (see v2_capacity_clamp.go). The api layer
+	// wires it to the Datadog silent-legacy-fallback tripwire counter. Set once
+	// at startup; nil = no-op. Guarded by r.mu (set + read).
+	onV2ClampTrip func(providerID, version, model string, reported int)
 }
 
 // pendingModelLoadTTL bounds how long an outstanding (or failed) load_model
@@ -2652,10 +2670,24 @@ func (r *Registry) Heartbeat(id string, msg *protocol.HeartbeatMessage) {
 		return
 	}
 
+	// Version-keyed v2 concurrency clamp FIRST (so the tripwire records the
+	// provider's original report), then the general sanity clamp. A >=v2-floor
+	// provider heartbeating a legacy-scale chat-slot max_concurrency means the
+	// silent-legacy-fallback bug resurfaced: clamp to the v2 ceiling, log at
+	// ERROR, and fire the Datadog tripwire (hook invoked off the locks, below).
+	// Below-floor providers skip this pass entirely and keep today's behavior.
+	// providerVersion takes p.mu briefly (p.Version is set by the api layer
+	// post-registration under p.mu).
+	version := providerVersion(p)
+	v2Trips := clampV2MaxConcurrency(r.logger, id, version, msg.BackendCapacity)
+
 	// Clamp heartbeat-reported capacity and metrics so a malicious provider
 	// can't skew routing by reporting absurd values (e.g. TotalMemoryGB=1e9
 	// would drive gpuUtil to 0 and sidestep health penalties).
 	clampBackendCapacity(r.logger, id, msg.BackendCapacity)
+	// Tripwire counter for any v2-clamped slots — no locks held here (the hook
+	// may do I/O; same contract as the hard-untrust hook).
+	r.fireV2ClampTrips(id, version, v2Trips)
 	if v, changed := clampNonNeg(msg.SystemMetrics.MemoryPressure, 1.0); changed {
 		msg.SystemMetrics.MemoryPressure = v
 	}

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -2285,9 +2285,13 @@ func (r *Registry) SetQueue(q *RequestQueue) {
 // ~3-4x current hardware ceilings (M2 Ultra is ~800 GB/s, MLX decode is ~120
 // tok/s, max Mac Studio RAM is 512 GB) so legitimate future hardware isn't
 // clamped unnecessarily.
+//
+// maxPrefillTPS (the prefill sanity ceiling) is declared as a var in
+// prefill_fallback.go (default defaultMaxPrefillTPS = 20000, above the measured
+// p90 17,707) so the ingest zeroing here, the registration clamp below, and the
+// routing cap in resolvePrefillTPS share one tunable ceiling.
 const (
 	maxDecodeTPS                    = 500.0
-	maxPrefillTPS                   = 5000.0
 	maxMemoryBandwidthGBs           = 2000.0
 	maxMemoryGB                     = 1024
 	maxMemoryGBFloat                = 1024.0
@@ -2384,7 +2388,9 @@ func clampBackendCapacity(logger *slog.Logger, providerID string, bc *protocol.B
 		// would make the TTFT estimate over-optimistic (prefill looks instant) and
 		// the hard gate over-accept; zeroing it makes resolvePrefillTPS fall back to
 		// the conservative decode×ratio estimate until the provider reports a sane
-		// value (provider fix: only sample cold prefills).
+		// value (provider fix: only sample cold prefills). The ceiling now sits
+		// above the measured p90 (17,707 tok/s; see defaultMaxPrefillTPS) so a
+		// genuinely-fast cold prefill from a fixed provider survives ingest.
 		if math.IsNaN(s.ObservedPrefillTPS) || s.ObservedPrefillTPS < 0 || s.ObservedPrefillTPS > maxPrefillTPS {
 			logger.Warn("provider slot observed_prefill_tps out of range; ignoring (fall back to estimate)",
 				"provider_id", providerID, "model", s.Model, "reported", s.ObservedPrefillTPS)

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -2729,6 +2729,10 @@ func (r *Registry) Heartbeat(id string, msg *protocol.HeartbeatMessage) {
 	p.BackendCapacity = msg.BackendCapacity
 	if p.BackendCapacity != nil {
 		chipFamily := p.Hardware.ChipFamily
+		// Solo samples are keyed by chip CLASS (family+tier, chipClassKey) so a
+		// fast tier (M4 Max) never lends its rate to a slow one (M4 Pro); the
+		// load-inclusive Record stays family-keyed (fleetMedianTPS semantics).
+		chipClass := chipClassKey(p.Hardware)
 		// Solo gate: a slot EWMA is additionally recorded as a SOLO sample only
 		// when the whole box is uncontended at heartbeat time (Σ running+waiting
 		// ≤ 1 across ALL slots — the one allowance is the sample-generating
@@ -2752,7 +2756,7 @@ func (r *Registry) Heartbeat(id string, msg *protocol.HeartbeatMessage) {
 			if slot.ObservedDecodeTPS > 0 {
 				r.tpsRegistry.Record(slot.Model, chipFamily, slot.ObservedDecodeTPS)
 				if soloEligible && slot.NumRunning > 0 {
-					r.tpsRegistry.RecordSolo(slot.Model, chipFamily, slot.ObservedDecodeTPS)
+					r.tpsRegistry.RecordSolo(slot.Model, chipClass, slot.ObservedDecodeTPS)
 				}
 			}
 		}

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -1376,6 +1376,11 @@ type Registry struct {
 	cacheAffinity        *cacheAffinityTracker
 	cacheAffinityBonusMs float64
 	warmPool             *warmPoolController
+	// serveCounter is the decaying per-provider recent-serve counter behind
+	// the satisficing band's inverse-recent-serves selection weight
+	// (satisficing_band.go). Fed on every successful reservation (flag-
+	// independent, so weights are warm when the band flips on); own lock.
+	serveCounter *recentServeCounter
 	// loadModelSender is a test seam for SendLoadModel. Nil uses the provider WebSocket.
 	loadModelSender func(providerID, modelID string) error
 
@@ -1460,6 +1465,7 @@ func New(logger *slog.Logger) *Registry {
 		evictStrikes:                   make(map[string]int),
 		cacheAffinity:                  newCacheAffinityTracker(cacheAffinityTTL),
 		cacheAffinityBonusMs:           defaultCacheAffinityBonusMs,
+		serveCounter:                   newRecentServeCounter(),
 		logger:                         logger,
 	}
 }

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -2669,9 +2669,20 @@ func (r *Registry) Heartbeat(id string, msg *protocol.HeartbeatMessage) {
 	p.BackendCapacity = msg.BackendCapacity
 	if p.BackendCapacity != nil {
 		chipFamily := p.Hardware.ChipFamily
+		// Solo gate: a slot EWMA is additionally recorded as a SOLO sample only
+		// when the whole box is uncontended at heartbeat time (Σ running+waiting
+		// ≤ 1 across ALL slots — the one allowance is the sample-generating
+		// request itself). The unconditional Record keeps its load-inclusive
+		// semantics for TTFT estimation (fleetMedianTPS); the gated RecordSolo
+		// feeds the quality-concurrency cap's per-model static rate
+		// (resolvedSoloModelTPSLocked). See solo_tps.go.
+		soloEligible := soloSampleEligible(p.BackendCapacity)
 		for _, slot := range p.BackendCapacity.Slots {
 			if slot.ObservedDecodeTPS > 0 {
 				r.tpsRegistry.Record(slot.Model, chipFamily, slot.ObservedDecodeTPS)
+				if soloEligible {
+					r.tpsRegistry.RecordSolo(slot.Model, chipFamily, slot.ObservedDecodeTPS)
+				}
 			}
 		}
 	}

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -2672,15 +2672,21 @@ func (r *Registry) Heartbeat(id string, msg *protocol.HeartbeatMessage) {
 		// Solo gate: a slot EWMA is additionally recorded as a SOLO sample only
 		// when the whole box is uncontended at heartbeat time (Σ running+waiting
 		// ≤ 1 across ALL slots — the one allowance is the sample-generating
-		// request itself). The unconditional Record keeps its load-inclusive
-		// semantics for TTFT estimation (fleetMedianTPS); the gated RecordSolo
-		// feeds the quality-concurrency cap's per-model static rate
-		// (resolvedSoloModelTPSLocked). See solo_tps.go.
+		// request itself) AND the slot is the one that OWNS that request
+		// (running+waiting > 0). Both halves matter: without the second, every
+		// co-resident slot with a nonzero (stale, decayed) EWMA would be
+		// re-recorded as a fresh solo observation on each ~30s heartbeat,
+		// contaminating OTHER models' medians with samples no request produced —
+		// a fully idle box records nothing, because there is no fresh
+		// observation to record. The unconditional Record keeps its
+		// load-inclusive semantics for TTFT estimation (fleetMedianTPS); the
+		// gated RecordSolo feeds the quality-concurrency cap's per-model static
+		// rate (resolvedSoloModelTPSLocked). See solo_tps.go.
 		soloEligible := soloSampleEligible(p.BackendCapacity)
 		for _, slot := range p.BackendCapacity.Slots {
 			if slot.ObservedDecodeTPS > 0 {
 				r.tpsRegistry.Record(slot.Model, chipFamily, slot.ObservedDecodeTPS)
-				if soloEligible {
+				if soloEligible && slot.NumRunning+slot.NumWaiting > 0 {
 					r.tpsRegistry.RecordSolo(slot.Model, chipFamily, slot.ObservedDecodeTPS)
 				}
 			}

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -1794,6 +1794,19 @@ func (r *Registry) providerCanRouteBuildLocked(p *Provider, buildID string, minT
 	if !r.providerServesRoutableModelLocked(p, buildID, allowPrivate) {
 		return false
 	}
+	// Per-model provider-version floor (EIGENINFERENCE_MODEL_VERSION_FLOORS):
+	// alias routability must apply the same floor as the dispatch gate
+	// (providerPassesRoutingGatesLockedEx → providerBelowModelVersionFloorLocked)
+	// — otherwise a below-floor box advertising the Desired build makes
+	// ResolveModel/ResolveModelConstrained resolve to Desired, the candidate scan
+	// then finds ZERO eligible providers, and the request queues/dies against a
+	// build the fleet cannot serve instead of falling back to the alias's
+	// Previous build. Applied unconditionally — self-route included — matching
+	// the dispatch gate (a below-floor binary would MIS-SERVE the model, owner's
+	// box or not; model_version_floors.go).
+	if r.providerBelowModelVersionFloorLocked(p, buildID) {
+		return false
+	}
 	if r.dispatchLoadCooldownActiveLocked(p.ID, buildID, now) {
 		return false
 	}
@@ -3081,6 +3094,15 @@ func (r *Registry) providerHasWarmModelLocked(p *Provider, model string, now tim
 	if !r.providerServesRoutableModelLocked(p, model, false) {
 		return false
 	}
+	// Per-model provider-version floor: routing will never send the model to a
+	// below-floor (or version-less) box (providerPassesRoutingGatesLockedEx), so
+	// its warm slot must not suppress swap planning — otherwise one below-floor
+	// warm box makes the planner believe the model is covered and skip
+	// load_model to an eligible >=floor node, stranding queued requests until
+	// timeout. Mirrors the routing gate (model_version_floors.go).
+	if r.providerBelowModelVersionFloorLocked(p, model) {
+		return false
+	}
 	if p.BackendCapacity != nil {
 		for _, slot := range p.BackendCapacity.Slots {
 			if slot.Model == model {
@@ -3148,6 +3170,15 @@ func (r *Registry) modelLoadCandidatePendingLocked(p *Provider, model string, no
 		return 0, false
 	}
 	if !r.providerServesRoutableModelLocked(p, model, false) {
+		return 0, false
+	}
+	// Per-model provider-version floor: never pick a below-floor (or
+	// version-less) box as a load_model target — routing will never send the
+	// model there (providerPassesRoutingGatesLockedEx), so the load would burn
+	// GPU memory on an unroutable warm slot while the queued demand keeps
+	// waiting. Mirrors providerHasWarmModelLocked and the warm-pool candidate
+	// gate (warmColdBelowVersionFloor).
+	if r.providerBelowModelVersionFloorLocked(p, model) {
 		return 0, false
 	}
 

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -2722,6 +2722,15 @@ func (r *Registry) Heartbeat(id string, msg *protocol.HeartbeatMessage) {
 					r.tpsRegistry.RecordSolo(slot.Model, chipFamily, slot.ObservedDecodeTPS)
 				}
 			}
+			// Observed prefill feeds the per-(model, chip) prefill-median ring
+			// (prefill_tps.go) — the prefill-honest input to the TTFT estimate.
+			// Deliberately NOT solo-gated (prefill is per-request compute-bound;
+			// see prefill_tps.go for the full ingest-gating rationale). The value
+			// is post-clamp, so out-of-range garbage (the prefix-cache-hit EWMA
+			// overflow) was already zeroed and never reaches the ring.
+			if slot.ObservedPrefillTPS > 0 {
+				r.tpsRegistry.RecordPrefill(slot.Model, chipFamily, slot.ObservedPrefillTPS)
+			}
 		}
 	}
 	// Credit wall-clock time since the previous heartbeat as uptime, so an

--- a/coordinator/registry/satisficing_band.go
+++ b/coordinator/registry/satisficing_band.go
@@ -1,0 +1,252 @@
+package registry
+
+import (
+	"math"
+	"math/rand"
+	"sync"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/env"
+)
+
+// Satisficing utilization band — activate the idle 70% (plan §2.8).
+//
+// Candidate selection today is strictly cheapest-cost with near-tie
+// randomization, so the fastest boxes win everything: the top-10% of boxes
+// take 79% of traffic, the median gpt-oss box serves 9 requests/day, ~70% of
+// online boxes serve nothing in a given hour, and 41 online 24GB boxes
+// advertising gpt-oss served 0 — while their solo 19 tok/s decode comfortably
+// clears the 15 tok/s quality floor. Consumers don't experience "cheapest
+// cost"; they experience "met the SLO or not". So among candidates PREDICTED
+// to meet the SLO (the band), selection becomes weighted-random with an
+// inverse-recent-serves weight instead of cost-ranked — spreading traffic
+// across every box that would satisfy the consumer, favoring the ones that
+// served least recently.
+//
+// Band membership reuses the EXACT predicates admission already computes — no
+// new estimators:
+//
+//   - predicted TTFT: the candidate's calibrated breakdown.TTFTMs — the same
+//     value the hard TTFT ceiling (pr.MaxTTFTMs) gates on — must clear the
+//     deadline minus EIGENINFERENCE_SATISFICING_TTFT_MARGIN_MS (default
+//     1000ms; the margin buys prediction error). Candidates without
+//     BackendCapacity have no reliable TTFT estimate and are excluded from
+//     the band when a deadline exists (they stay selectable via the
+//     cheapest-cost fallback, exactly as today). Requests without a deadline
+//     (pr.MaxTTFTMs <= 0, e.g. soft-gate mode or queue drains) satisfy the
+//     TTFT criterion vacuously.
+//   - predicted decode: projectedPerRequestDecodeTPS(snapshot) >=
+//     pr.MinDecodeTPS — the same projection the decode-floor quality
+//     preference uses. Vacuous when no floor is stamped.
+//
+// Selection within the band is weighted random, weight = 1/(1+recentServes),
+// where recentServes is a registry-local in-memory exponentially-decaying
+// per-provider serve counter (half-life 5 minutes ≈ the "sliding ~10-minute
+// window" shape; chosen over a bucketed window for simplicity and exact
+// testability — decay is a pure function of elapsed time). The counter is fed
+// on EVERY successful reservation regardless of the flag, so weights are
+// already warm when the flag flips on; it is restart-wiped like the TPS
+// registries (acceptable: it converges within minutes).
+//
+// Cache affinity keeps its pin WITHIN the band: if the affinity provider is a
+// band member it wins, preserving prefix-cache TTFT for repeat-prefix
+// consumers (their turns are serial, so pinning them costs no utilization
+// spread; evicting them from their cached box would regress TTFT p90 — the
+// rollout guard metric).
+//
+// Everything else is unchanged: candidates OUTSIDE the band never displace
+// the cheapest-cost path (when the band is empty — or the flag is off, the
+// default — selection is byte-for-byte today's), and speculative/backup
+// dispatch, queueing, retries, and admission gates are untouched. The band
+// only reorders WHICH eligible candidate is picked first.
+
+const (
+	satisficingBandEnv       = env.EnvPrefix + "_SATISFICING_BAND"
+	satisficingTTFTMarginEnv = env.EnvPrefix + "_SATISFICING_TTFT_MARGIN_MS"
+)
+
+// defaultSatisficingTTFTMarginMs is the TTFT safety margin (ms) subtracted
+// from the request deadline for band membership when
+// EIGENINFERENCE_SATISFICING_TTFT_MARGIN_MS is unset.
+const defaultSatisficingTTFTMarginMs = 1000.0
+
+// satisficingBandEnabled gates the whole feature. Read LIVE (no restart,
+// mirroring decodeFloorUseFleetMedian); default FALSE — dormant until the
+// staged canary after gemma re-enable stabilizes.
+func satisficingBandEnabled() bool {
+	return env.EnvBool(satisficingBandEnv, false)
+}
+
+// satisficingTTFTMarginMs returns the band's TTFT safety margin. Read live;
+// negative values are clamped to 0 (band boundary = the raw deadline).
+func satisficingTTFTMarginMs() float64 {
+	m := env.EnvFloat(satisficingTTFTMarginEnv, defaultSatisficingTTFTMarginMs)
+	if m < 0 || math.IsNaN(m) {
+		m = 0
+	}
+	return m
+}
+
+// candidateInSatisficingBand reports whether a cost-eligible candidate is
+// predicted to satisfy the request's SLO with margin to spare. It reuses the
+// candidate's already-computed gate inputs — breakdown.TTFTMs (the calibrated
+// estimate the hard MaxTTFTMs ceiling consumes) and
+// projectedPerRequestDecodeTPS (the decode-floor preference's projection) —
+// so band membership can never disagree with admission about what "fast
+// enough" means.
+func candidateInSatisficingBand(c *routingCandidate, pr *PendingRequest, marginMs float64) bool {
+	if c == nil {
+		return false
+	}
+	if pr.MaxTTFTMs > 0 {
+		// A deadline exists: require a RELIABLE estimate that clears it with
+		// margin. No BackendCapacity means no reliable TTFT estimate — not a
+		// band member (still reachable via the cheapest-cost fallback).
+		if !c.snapshot.hasBackendCapacity {
+			return false
+		}
+		if c.breakdown.TTFTMs > pr.MaxTTFTMs-marginMs {
+			return false
+		}
+	}
+	if pr.MinDecodeTPS > 0 && projectedPerRequestDecodeTPS(c.snapshot) < pr.MinDecodeTPS {
+		return false
+	}
+	return true
+}
+
+// satisficingBandMembers filters the eligible pool down to band members.
+func satisficingBandMembers(pool []*routingCandidate, pr *PendingRequest) []*routingCandidate {
+	marginMs := satisficingTTFTMarginMs()
+	band := make([]*routingCandidate, 0, len(pool))
+	for _, c := range pool {
+		if candidateInSatisficingBand(c, pr, marginMs) {
+			band = append(band, c)
+		}
+	}
+	return band
+}
+
+// pickSatisficingBandLocked selects a band member by weighted random with
+// weight = 1/(1+recentServes). A provider that just served a burst decays
+// toward weight 1 within a few half-lives; a box that served nothing holds
+// weight 1 — so the idle majority absorbs new load first while every member
+// keeps a nonzero chance (no starvation, no hard round-robin). Caller holds
+// r.mu (band candidates borrow registry state); the serve counter has its own
+// lock.
+func (r *Registry) pickSatisficingBandLocked(band []*routingCandidate) *routingCandidate {
+	if len(band) == 0 {
+		return nil
+	}
+	if len(band) == 1 {
+		return band[0]
+	}
+	weights := make([]float64, len(band))
+	total := 0.0
+	for i, c := range band {
+		w := 1.0 / (1.0 + r.serveCounter.recentServes(c.provider.ID))
+		weights[i] = w
+		total += w
+	}
+	x := rand.Float64() * total
+	for i, c := range band {
+		x -= weights[i]
+		if x < 0 {
+			return c
+		}
+	}
+	return band[len(band)-1] // float underflow backstop
+}
+
+// --- Recent-serve counter ---
+
+const (
+	// recentServeHalfLife is the exponential-decay half-life of the serve
+	// counter: a serve contributes 1.0 immediately, 0.5 after 5 minutes, ~0.25
+	// after 10 — approximating a sliding ~10-minute window of "how much has
+	// this box served lately" with O(1) state per provider.
+	recentServeHalfLife = 5 * time.Minute
+	// recentServePruneBelow: entries decayed to negligible weight-impact are
+	// pruned opportunistically (weight 1/(1+0.01) ≈ 0.99, indistinguishable
+	// from never-served).
+	recentServePruneBelow = 0.01
+	// recentServePruneScanThreshold bounds map growth on long-lived
+	// registries with heavy session-ID churn: once the map exceeds this size,
+	// each record() sweeps out decayed entries.
+	recentServePruneScanThreshold = 4096
+)
+
+// recentServeCounter is the registry-local decaying per-provider serve
+// counter behind the band's inverse-recent-serves weight. Keyed by provider
+// session ID (a reconnect starts fresh at weight 1 — acceptable: the counter
+// is a fairness heuristic, not an accounting ledger). nowFunc is injectable
+// for deterministic decay tests.
+type recentServeCounter struct {
+	mu      sync.Mutex
+	nowFunc func() time.Time
+	entries map[string]*recentServeEntry
+}
+
+type recentServeEntry struct {
+	count float64   // decayed serve count as of last
+	last  time.Time // when count was last materialized
+}
+
+func newRecentServeCounter() *recentServeCounter {
+	return &recentServeCounter{
+		nowFunc: time.Now,
+		entries: make(map[string]*recentServeEntry),
+	}
+}
+
+// decayedLocked returns e's count decayed to now. Caller holds c.mu.
+func decayedLocked(e *recentServeEntry, now time.Time) float64 {
+	dt := now.Sub(e.last)
+	if dt <= 0 {
+		return e.count
+	}
+	return e.count * math.Exp2(-float64(dt)/float64(recentServeHalfLife))
+}
+
+// record adds one serve for the provider (called on every successful
+// reservation — flag-independent so the weights are warm when the band is
+// enabled).
+func (c *recentServeCounter) record(providerID string) {
+	if c == nil || providerID == "" {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	now := c.nowFunc()
+	if e, ok := c.entries[providerID]; ok {
+		e.count = decayedLocked(e, now) + 1
+		e.last = now
+	} else {
+		c.entries[providerID] = &recentServeEntry{count: 1, last: now}
+	}
+	if len(c.entries) > recentServePruneScanThreshold {
+		for id, e := range c.entries {
+			if id == providerID {
+				continue
+			}
+			if decayedLocked(e, now) < recentServePruneBelow {
+				delete(c.entries, id)
+			}
+		}
+	}
+}
+
+// recentServes returns the provider's decayed serve count (0 for unknown
+// providers).
+func (c *recentServeCounter) recentServes(providerID string) float64 {
+	if c == nil {
+		return 0
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	e, ok := c.entries[providerID]
+	if !ok {
+		return 0
+	}
+	return decayedLocked(e, c.nowFunc())
+}

--- a/coordinator/registry/satisficing_band.go
+++ b/coordinator/registry/satisficing_band.go
@@ -32,15 +32,19 @@ import (
 //     1000ms; the margin buys prediction error). Candidates without
 //     BackendCapacity have no reliable TTFT estimate and are excluded from
 //     the band when a deadline exists (they stay selectable via the
-//     cheapest-cost fallback, exactly as today). Requests without a deadline
-//     (pr.MaxTTFTMs <= 0 — soft-gate mode, the production default, and queue
-//     drains) have no TTFT criterion to predict against, so the band is
-//     restricted to WARM (weights-resident) candidates instead: without that,
-//     a cold box passing the decode floor would weighted-randomly beat a warm
-//     one and force an avoidable 15–60s model load the deadline branch would
-//     have priced in via the slot-state penalty. Cold candidates stay
-//     selectable via the cheapest-cost fallback, where statePenalty already
-//     makes them a last resort.
+//     cheapest-cost fallback, exactly as today). In the default soft-gate mode
+//     pr.MaxTTFTMs is 0, but public routes still stamp the ADVISORY
+//     pr.TTFTTargetMs (the same prompt-scaled deadline the preflight uses), so
+//     the band gates on that target too — a warm slow-prefill/long-prompt box
+//     already over the target is kept out of the band instead of
+//     weighted-randomly beating a fast box and regressing TTFT p90. Only when
+//     there is neither a ceiling nor a target (self-route / prefer-owner /
+//     queue drains) does the band fall back to a WARM-only proxy: without it a
+//     cold box passing the decode floor would weighted-randomly beat a warm one
+//     and force an avoidable 15–60s model load the deadline branch would have
+//     priced in via the slot-state penalty. Cold candidates stay selectable via
+//     the cheapest-cost fallback, where statePenalty already makes them a last
+//     resort.
 //   - predicted decode: projectedPerRequestDecodeTPS(snapshot) >=
 //     pr.MinDecodeTPS — the same projection the decode-floor quality
 //     preference uses. Vacuous when no floor is stamped.
@@ -104,26 +108,39 @@ func candidateInSatisficingBand(c *routingCandidate, pr *PendingRequest, marginM
 	if c == nil {
 		return false
 	}
-	if pr.MaxTTFTMs > 0 {
-		// A deadline exists: require a RELIABLE estimate that clears it with
-		// margin. No BackendCapacity means no reliable TTFT estimate — not a
-		// band member (still reachable via the cheapest-cost fallback).
+	// Effective TTFT deadline the band gates on: the HARD per-request ceiling
+	// when set (hard-reject mode), else the ADVISORY public target stamped in
+	// soft mode (pr.TTFTTargetMs). Both bound band membership identically; only
+	// MaxTTFTMs drives hard scheduler rejection, so using the soft target here
+	// changes no admission decision — it just keeps an over-target box out of
+	// the load-spread band.
+	deadline := pr.MaxTTFTMs
+	if deadline <= 0 {
+		deadline = pr.TTFTTargetMs
+	}
+	if deadline > 0 {
+		// A deadline/target exists: require a RELIABLE estimate that clears it
+		// with margin. No BackendCapacity means no reliable TTFT estimate — not
+		// a band member (still reachable via the cheapest-cost fallback). This
+		// is what keeps a WARM slow-prefill/long-prompt box that the preflight
+		// already marked over the (soft) deadline from weighted-randomly beating
+		// the fast candidate and regressing TTFT p90 (Codex review).
 		if !c.snapshot.hasBackendCapacity {
 			return false
 		}
-		if c.breakdown.TTFTMs > pr.MaxTTFTMs-marginMs {
+		if c.breakdown.TTFTMs > deadline-marginMs {
 			return false
 		}
 	} else if !c.snapshot.modelLoaded {
-		// No deadline (soft TTFT mode — the production default — or a queue
-		// drain): there is no TTFT criterion to predict against, so the band
-		// must not treat a COLD candidate as "satisfying" — a cold pick forces
-		// a 15–60s model load the deadline branch above would have priced in
-		// via the slot-state penalty inside breakdown.TTFTMs. Restrict the
-		// band to WARM (weights-resident) candidates; cold boxes stay
-		// reachable via the cheapest-cost fallback, whose statePenalty already
-		// makes them a last resort — exactly today's behavior. Growing warm
-		// capacity is the warm-pool controller's job, not the band's.
+		// No deadline AND no target (self-route / prefer-owner / a queue drain):
+		// there is no TTFT criterion to predict against, so the band must not
+		// treat a COLD candidate as "satisfying" — a cold pick forces a 15–60s
+		// model load the deadline branch above would have priced in via the
+		// slot-state penalty inside breakdown.TTFTMs. Restrict the band to WARM
+		// (weights-resident) candidates; cold boxes stay reachable via the
+		// cheapest-cost fallback, whose statePenalty already makes them a last
+		// resort — exactly today's behavior. Growing warm capacity is the
+		// warm-pool controller's job, not the band's.
 		return false
 	}
 	if pr.MinDecodeTPS > 0 && projectedPerRequestDecodeTPS(c.snapshot) < pr.MinDecodeTPS {

--- a/coordinator/registry/satisficing_band.go
+++ b/coordinator/registry/satisficing_band.go
@@ -33,8 +33,14 @@ import (
 //     BackendCapacity have no reliable TTFT estimate and are excluded from
 //     the band when a deadline exists (they stay selectable via the
 //     cheapest-cost fallback, exactly as today). Requests without a deadline
-//     (pr.MaxTTFTMs <= 0, e.g. soft-gate mode or queue drains) satisfy the
-//     TTFT criterion vacuously.
+//     (pr.MaxTTFTMs <= 0 — soft-gate mode, the production default, and queue
+//     drains) have no TTFT criterion to predict against, so the band is
+//     restricted to WARM (weights-resident) candidates instead: without that,
+//     a cold box passing the decode floor would weighted-randomly beat a warm
+//     one and force an avoidable 15–60s model load the deadline branch would
+//     have priced in via the slot-state penalty. Cold candidates stay
+//     selectable via the cheapest-cost fallback, where statePenalty already
+//     makes them a last resort.
 //   - predicted decode: projectedPerRequestDecodeTPS(snapshot) >=
 //     pr.MinDecodeTPS — the same projection the decode-floor quality
 //     preference uses. Vacuous when no floor is stamped.
@@ -108,6 +114,17 @@ func candidateInSatisficingBand(c *routingCandidate, pr *PendingRequest, marginM
 		if c.breakdown.TTFTMs > pr.MaxTTFTMs-marginMs {
 			return false
 		}
+	} else if !c.snapshot.modelLoaded {
+		// No deadline (soft TTFT mode — the production default — or a queue
+		// drain): there is no TTFT criterion to predict against, so the band
+		// must not treat a COLD candidate as "satisfying" — a cold pick forces
+		// a 15–60s model load the deadline branch above would have priced in
+		// via the slot-state penalty inside breakdown.TTFTMs. Restrict the
+		// band to WARM (weights-resident) candidates; cold boxes stay
+		// reachable via the cheapest-cost fallback, whose statePenalty already
+		// makes them a last resort — exactly today's behavior. Growing warm
+		// capacity is the warm-pool controller's job, not the band's.
+		return false
 	}
 	if pr.MinDecodeTPS > 0 && projectedPerRequestDecodeTPS(c.snapshot) < pr.MinDecodeTPS {
 		return false
@@ -148,6 +165,13 @@ func (r *Registry) pickSatisficingBandLocked(band []*routingCandidate) *routingC
 		weights[i] = w
 		total += w
 	}
+	// math/rand on purpose: this is load-spreading jitter among candidates that
+	// ALL already passed every security/trust/admission gate — not a security
+	// boundary — matching the near-tie randomization in
+	// selectBestCandidateScanLocked (scheduler.go, rand.Intn). An adversary who
+	// could predict the stream gains nothing (they cannot steer a request to a
+	// provider the gates would not have admitted), and crypto/rand would add a
+	// syscall per selection on the routing hot path.
 	x := rand.Float64() * total
 	for i, c := range band {
 		x -= weights[i]

--- a/coordinator/registry/satisficing_band_test.go
+++ b/coordinator/registry/satisficing_band_test.go
@@ -33,10 +33,10 @@ func bandRequest(id string) *PendingRequest {
 	}
 }
 
-// reserveOnce runs one production selection and releases the reservation so
+// bandReserveOnce runs one production selection and releases the reservation so
 // per-trial registry state (pending counts, costs, band membership) is
 // identical across trials. Returns the winner's ID.
-func reserveOnce(t *testing.T, reg *Registry, pr *PendingRequest) string {
+func bandReserveOnce(t *testing.T, reg *Registry, pr *PendingRequest) string {
 	t.Helper()
 	p, _ := reg.ReserveProviderEx(pr.Model, pr)
 	if p == nil {
@@ -56,7 +56,7 @@ func TestSatisficingBandOffSelectionPinned(t *testing.T) {
 	reg := New(testLogger())
 	bandFixture(t, reg)
 	for i := 0; i < 50; i++ {
-		if id := reserveOnce(t, reg, bandRequest(fmt.Sprintf("off-%d", i))); id != "fast-box" {
+		if id := bandReserveOnce(t, reg, bandRequest(fmt.Sprintf("off-%d", i))); id != "fast-box" {
 			t.Fatalf("flag off, trial %d: selected %s, want fast-box every time (deterministic cheapest-cost)", i, id)
 		}
 	}
@@ -76,7 +76,7 @@ func TestSatisficingBandSpreadsAcrossMembers(t *testing.T) {
 	const trials = 300
 	counts := map[string]int{}
 	for i := 0; i < trials; i++ {
-		counts[reserveOnce(t, reg, bandRequest(fmt.Sprintf("on-%d", i)))]++
+		counts[bandReserveOnce(t, reg, bandRequest(fmt.Sprintf("on-%d", i)))]++
 	}
 	for _, id := range []string{"fast-box", "mid-box", "slow-box"} {
 		if counts[id] == 0 {
@@ -112,7 +112,7 @@ func TestSatisficingBandNonMembersOnlyWhenBandEmpty(t *testing.T) {
 		}
 	}
 	for i := 0; i < 30; i++ {
-		if id := reserveOnce(t, reg, pr(i)); id != "fast-box" {
+		if id := bandReserveOnce(t, reg, pr(i)); id != "fast-box" {
 			t.Fatalf("empty band, trial %d: selected %s, want fast-box (exact cheapest-cost fallback)", i, id)
 		}
 	}
@@ -146,7 +146,7 @@ func TestSatisficingBandExcludesColdWhenNoDeadline(t *testing.T) {
 			MaxTTFTMs:    0,
 			MinDecodeTPS: 15,
 		}
-		if id := reserveOnce(t, reg, pr); id != "warm-box" {
+		if id := bandReserveOnce(t, reg, pr); id != "warm-box" {
 			t.Fatalf("trial %d: selected %s, want warm-box — a cold candidate must not enter the band when no deadline exists", i, id)
 		}
 	}
@@ -186,7 +186,7 @@ func TestSatisficingBandServeCounterFedOnRealPath(t *testing.T) {
 	t.Setenv(satisficingBandEnv, "false") // recording must be flag-independent
 	reg := New(testLogger())
 	bandFixture(t, reg)
-	winner := reserveOnce(t, reg, bandRequest("feed-1"))
+	winner := bandReserveOnce(t, reg, bandRequest("feed-1"))
 	if got := reg.serveCounter.recentServes(winner); got < 0.99 {
 		t.Fatalf("recentServes(%s) = %v after a real reservation, want ~1", winner, got)
 	}
@@ -232,7 +232,7 @@ func TestSatisficingBandCacheAffinityPinnedWithinBand(t *testing.T) {
 		pr := bandRequest(fmt.Sprintf("aff-%d", i))
 		pr.ConsumerKey = "consumer-1"
 		pr.CacheAffinityKey = "prefix-abc"
-		if id := reserveOnce(t, reg, pr); id != "mid-box" {
+		if id := bandReserveOnce(t, reg, pr); id != "mid-box" {
 			t.Fatalf("trial %d: selected %s, want the affinity-pinned band member mid-box", i, id)
 		}
 	}

--- a/coordinator/registry/satisficing_band_test.go
+++ b/coordinator/registry/satisficing_band_test.go
@@ -118,6 +118,40 @@ func TestSatisficingBandNonMembersOnlyWhenBandEmpty(t *testing.T) {
 	}
 }
 
+// TestSatisficingBandExcludesColdWhenNoDeadline (review fix): with the default
+// soft TTFT mode, public requests carry MaxTTFTMs == 0, so the band has no TTFT
+// criterion — without the warm-only restriction, a COLD (slotState "unknown")
+// candidate passing the decode floor enters the band and weighted-randomly
+// beats the warm provider, forcing avoidable 15–60s model loads. The cold box
+// stays reachable via the cheapest-cost fallback only (where statePenalty makes
+// it a last resort). Fails without the modelLoaded check in
+// candidateInSatisficingBand (the cold box wins ~half of the trials).
+func TestSatisficingBandExcludesColdWhenNoDeadline(t *testing.T) {
+	t.Setenv(satisficingBandEnv, "true")
+	reg := New(testLogger())
+	makeSchedulerProvider(t, reg, "warm-box", gptossBuild, 20)
+	cold := makeSchedulerProvider(t, reg, "cold-box", gptossBuild, 100)
+	// Make the fast box COLD for gpt-oss: advertises it, no backend slot.
+	cold.mu.Lock()
+	cold.BackendCapacity.Slots = nil
+	cold.mu.Unlock()
+
+	for i := 0; i < 100; i++ {
+		pr := &PendingRequest{
+			RequestID:             fmt.Sprintf("no-deadline-%d", i),
+			Model:                 gptossBuild,
+			EstimatedPromptTokens: 500,
+			RequestedMaxTokens:    2000,
+			// Soft TTFT mode: no per-request deadline stamped.
+			MaxTTFTMs:    0,
+			MinDecodeTPS: 15,
+		}
+		if id := reserveOnce(t, reg, pr); id != "warm-box" {
+			t.Fatalf("trial %d: selected %s, want warm-box — a cold candidate must not enter the band when no deadline exists", i, id)
+		}
+	}
+}
+
 // TestSatisficingBandWeightsShiftWithRecentServes: weight = 1/(1+recentServes).
 // A provider seeded with ~9 recent serves (weight ≈ 0.1) is picked ~10× less
 // often than never-served peers (weight 1). Expected share 0.1/2.1 ≈ 4.8% of

--- a/coordinator/registry/satisficing_band_test.go
+++ b/coordinator/registry/satisficing_band_test.go
@@ -1,0 +1,203 @@
+package registry
+
+import (
+	"fmt"
+	"math"
+	"testing"
+	"time"
+)
+
+// bandFixture registers three warm gpt-oss boxes with well-separated costs
+// (cost gaps >> the 3s near-tie window, so flag-off selection is
+// deterministic): fast (decode 100), mid (40), slow (20). With the default
+// EIGENINFERENCE_MIN_DECODE_TPS-style floor of 15 all three project above the
+// floor at batch 1 (100/1.27, 40/1.27, 20/1.27 = 78.7/31.5/15.7), and with a
+// 10s deadline all three TTFT estimates (~0.4s/1.1s/2.1s) clear the band
+// margin — so all three are band members.
+func bandFixture(t *testing.T, reg *Registry) (fast, mid, slow *Provider) {
+	t.Helper()
+	fast = makeSchedulerProvider(t, reg, "fast-box", gptossBuild, 100)
+	mid = makeSchedulerProvider(t, reg, "mid-box", gptossBuild, 40)
+	slow = makeSchedulerProvider(t, reg, "slow-box", gptossBuild, 20)
+	return fast, mid, slow
+}
+
+func bandRequest(id string) *PendingRequest {
+	return &PendingRequest{
+		RequestID:             id,
+		Model:                 gptossBuild,
+		EstimatedPromptTokens: 500,
+		RequestedMaxTokens:    2000,
+		MaxTTFTMs:             10_000,
+		MinDecodeTPS:          15,
+	}
+}
+
+// reserveOnce runs one production selection and releases the reservation so
+// per-trial registry state (pending counts, costs, band membership) is
+// identical across trials. Returns the winner's ID.
+func reserveOnce(t *testing.T, reg *Registry, pr *PendingRequest) string {
+	t.Helper()
+	p, _ := reg.ReserveProviderEx(pr.Model, pr)
+	if p == nil {
+		t.Fatalf("no provider selected for %s", pr.RequestID)
+	}
+	p.RemovePending(pr.RequestID)
+	reg.SetProviderIdle(p.ID)
+	return p.ID
+}
+
+// TestSatisficingBandOffSelectionPinned is the flag-off contract: with the
+// band dormant (the default), selection is byte-for-byte today's cheapest-cost
+// path — the fast box wins EVERY trial (its cost is ~30s below the next
+// candidate, far outside the near-tie window, so there is no randomization).
+func TestSatisficingBandOffSelectionPinned(t *testing.T) {
+	reg := New(testLogger())
+	bandFixture(t, reg)
+	for i := 0; i < 50; i++ {
+		if id := reserveOnce(t, reg, bandRequest(fmt.Sprintf("off-%d", i))); id != "fast-box" {
+			t.Fatalf("flag off, trial %d: selected %s, want fast-box every time (deterministic cheapest-cost)", i, id)
+		}
+	}
+}
+
+// TestSatisficingBandSpreadsAcrossMembers: flag on, every band member gets
+// selected across repeated trials and the cheapest no longer monopolizes —
+// the anti-concentration property the band exists for (top-10% boxes take
+// 79% of traffic today). Statistical: with all weights starting at 1 and the
+// winner's weight decaying after each serve, P(any member never chosen in 300
+// trials) < (2/3)^300 ≈ 10^-53.
+func TestSatisficingBandSpreadsAcrossMembers(t *testing.T) {
+	t.Setenv(satisficingBandEnv, "true")
+	reg := New(testLogger())
+	bandFixture(t, reg)
+
+	const trials = 300
+	counts := map[string]int{}
+	for i := 0; i < trials; i++ {
+		counts[reserveOnce(t, reg, bandRequest(fmt.Sprintf("on-%d", i)))]++
+	}
+	for _, id := range []string{"fast-box", "mid-box", "slow-box"} {
+		if counts[id] == 0 {
+			t.Fatalf("band member %s never selected across %d trials; counts=%v", id, trials, counts)
+		}
+	}
+	if counts["fast-box"] == trials {
+		t.Fatalf("cheapest candidate selected in all %d trials — band selection must not reduce to cheapest-cost; counts=%v", trials, counts)
+	}
+}
+
+// TestSatisficingBandNonMembersOnlyWhenBandEmpty: candidates outside the band
+// are selected ONLY when the band is empty — and then via exactly today's
+// cheapest-cost path. All three boxes pass the 3s HARD TTFT gate (~0.7s/1.4s/
+// 2.8s estimates) but miss the band boundary (deadline − 2.5s margin = 0.5s),
+// so with the flag on the band is empty and the fast box wins deterministically
+// (cost gaps >> the near-tie window).
+func TestSatisficingBandNonMembersOnlyWhenBandEmpty(t *testing.T) {
+	t.Setenv(satisficingBandEnv, "true")
+	t.Setenv(satisficingTTFTMarginEnv, "2500")
+	reg := New(testLogger())
+	makeSchedulerProvider(t, reg, "fast-box", gptossBuild, 60)
+	makeSchedulerProvider(t, reg, "mid-box", gptossBuild, 30)
+	makeSchedulerProvider(t, reg, "slow-box", gptossBuild, 15)
+
+	pr := func(i int) *PendingRequest {
+		return &PendingRequest{
+			RequestID:             fmt.Sprintf("empty-band-%d", i),
+			Model:                 gptossBuild,
+			EstimatedPromptTokens: 500,
+			RequestedMaxTokens:    2000,
+			MaxTTFTMs:             3_000,
+		}
+	}
+	for i := 0; i < 30; i++ {
+		if id := reserveOnce(t, reg, pr(i)); id != "fast-box" {
+			t.Fatalf("empty band, trial %d: selected %s, want fast-box (exact cheapest-cost fallback)", i, id)
+		}
+	}
+}
+
+// TestSatisficingBandWeightsShiftWithRecentServes: weight = 1/(1+recentServes).
+// A provider seeded with ~9 recent serves (weight ≈ 0.1) is picked ~10× less
+// often than never-served peers (weight 1). Expected share 0.1/2.1 ≈ 4.8% of
+// 2100 picks ≈ 100; asserting < a quarter of each peer's count puts the
+// threshold ~15 standard deviations from the mean.
+func TestSatisficingBandWeightsShiftWithRecentServes(t *testing.T) {
+	reg := New(testLogger())
+	hot := makeSchedulerProvider(t, reg, "hot-box", gptossBuild, 30)
+	cold1 := makeSchedulerProvider(t, reg, "cold-1", gptossBuild, 30)
+	cold2 := makeSchedulerProvider(t, reg, "cold-2", gptossBuild, 30)
+	for i := 0; i < 9; i++ {
+		reg.serveCounter.record("hot-box")
+	}
+
+	band := []*routingCandidate{{provider: hot}, {provider: cold1}, {provider: cold2}}
+	counts := map[string]int{}
+	for i := 0; i < 2100; i++ {
+		counts[reg.pickSatisficingBandLocked(band).provider.ID]++
+	}
+	if counts["hot-box"]*4 >= counts["cold-1"] || counts["hot-box"]*4 >= counts["cold-2"] {
+		t.Fatalf("recently-served provider not deprioritized: counts=%v (want hot-box ≈ 1/10 of each cold)", counts)
+	}
+	if counts["hot-box"] == 0 {
+		t.Fatalf("recently-served provider fully starved: counts=%v (weights must stay nonzero)", counts)
+	}
+}
+
+// TestSatisficingBandServeCounterFedOnRealPath: the counter is fed by every
+// successful reservation even with the flag OFF, so weights are warm the
+// moment the band is enabled.
+func TestSatisficingBandServeCounterFedOnRealPath(t *testing.T) {
+	reg := New(testLogger())
+	bandFixture(t, reg)
+	winner := reserveOnce(t, reg, bandRequest("feed-1"))
+	if got := reg.serveCounter.recentServes(winner); got < 0.99 {
+		t.Fatalf("recentServes(%s) = %v after a real reservation, want ~1", winner, got)
+	}
+}
+
+// TestRecentServeCounterDecay pins the exponential half-life: 2 serves decay
+// to ~1 after one half-life and to noise after ten.
+func TestRecentServeCounterDecay(t *testing.T) {
+	c := newRecentServeCounter()
+	base := time.Now()
+	now := base
+	c.nowFunc = func() time.Time { return now }
+
+	c.record("p")
+	c.record("p")
+	if got := c.recentServes("p"); got != 2 {
+		t.Fatalf("recentServes = %v, want 2 (no decay at t=0)", got)
+	}
+	now = base.Add(recentServeHalfLife)
+	if got := c.recentServes("p"); math.Abs(got-1) > 1e-9 {
+		t.Fatalf("recentServes after one half-life = %v, want 1", got)
+	}
+	now = base.Add(10 * recentServeHalfLife)
+	if got := c.recentServes("p"); got >= recentServePruneBelow {
+		t.Fatalf("recentServes after ten half-lives = %v, want < %v (decayed to noise)", got, recentServePruneBelow)
+	}
+	if got := c.recentServes("never-served"); got != 0 {
+		t.Fatalf("recentServes(unknown) = %v, want 0", got)
+	}
+}
+
+// TestSatisficingBandCacheAffinityPinnedWithinBand: an affinity-pinned
+// provider that is a band member wins every trial — the prefix-cache TTFT win
+// is preserved under the band (a pinned consumer's turns are serial, so the
+// pin costs no utilization spread).
+func TestSatisficingBandCacheAffinityPinnedWithinBand(t *testing.T) {
+	t.Setenv(satisficingBandEnv, "true")
+	reg := New(testLogger())
+	bandFixture(t, reg)
+	reg.RecordCacheAffinity("consumer-1", gptossBuild, "prefix-abc", "mid-box")
+
+	for i := 0; i < 40; i++ {
+		pr := bandRequest(fmt.Sprintf("aff-%d", i))
+		pr.ConsumerKey = "consumer-1"
+		pr.CacheAffinityKey = "prefix-abc"
+		if id := reserveOnce(t, reg, pr); id != "mid-box" {
+			t.Fatalf("trial %d: selected %s, want the affinity-pinned band member mid-box", i, id)
+		}
+	}
+}

--- a/coordinator/registry/satisficing_band_test.go
+++ b/coordinator/registry/satisficing_band_test.go
@@ -237,3 +237,36 @@ func TestSatisficingBandCacheAffinityPinnedWithinBand(t *testing.T) {
 		}
 	}
 }
+
+// TestSatisficingBandExcludesOverTargetWarmInSoftMode is the Codex regression:
+// in the default SOFT TTFT mode public requests carry MaxTTFTMs == 0 but still
+// stamp the advisory pr.TTFTTargetMs, so a WARM box whose TTFT estimate is over
+// that target (slow prefill / long prompt, but fine decode) must be kept OUT of
+// the load-spread band — otherwise it weighted-randomly beats the fast box and
+// regresses TTFT p90. Here fast-box (~0.4s TTFT) clears the 1000ms target and
+// slow-box (~2.1s) does not, so the band is {fast-box} and it wins every trial.
+// Fails without the effective-deadline (TTFTTargetMs) gate in
+// candidateInSatisficingBand: slow-box passes the decode floor (20/1.27 ≈ 15.7 >
+// 15) and, with no TTFT check in the soft branch, would win ~half the trials.
+func TestSatisficingBandExcludesOverTargetWarmInSoftMode(t *testing.T) {
+	t.Setenv(satisficingBandEnv, "true")
+	t.Setenv(satisficingTTFTMarginEnv, "0") // band boundary = the raw target
+	reg := New(testLogger())
+	makeSchedulerProvider(t, reg, "fast-box", gptossBuild, 100) // TTFT ~0.4s
+	makeSchedulerProvider(t, reg, "slow-box", gptossBuild, 20)  // TTFT ~2.1s (over target)
+
+	for i := 0; i < 100; i++ {
+		pr := &PendingRequest{
+			RequestID:             fmt.Sprintf("soft-target-%d", i),
+			Model:                 gptossBuild,
+			EstimatedPromptTokens: 500,
+			RequestedMaxTokens:    2000,
+			MaxTTFTMs:             0,    // soft mode: no hard ceiling
+			TTFTTargetMs:          1000, // advisory public target the band gates on
+			MinDecodeTPS:          15,
+		}
+		if id := bandReserveOnce(t, reg, pr); id != "fast-box" {
+			t.Fatalf("trial %d: selected %s, want fast-box — an over-target warm box must be excluded from the soft-mode band", i, id)
+		}
+	}
+}

--- a/coordinator/registry/satisficing_band_test.go
+++ b/coordinator/registry/satisficing_band_test.go
@@ -52,6 +52,7 @@ func reserveOnce(t *testing.T, reg *Registry, pr *PendingRequest) string {
 // path — the fast box wins EVERY trial (its cost is ~30s below the next
 // candidate, far outside the near-tie window, so there is no randomization).
 func TestSatisficingBandOffSelectionPinned(t *testing.T) {
+	t.Setenv(satisficingBandEnv, "false") // pin the default against ambient operator env
 	reg := New(testLogger())
 	bandFixture(t, reg)
 	for i := 0; i < 50; i++ {
@@ -148,6 +149,7 @@ func TestSatisficingBandWeightsShiftWithRecentServes(t *testing.T) {
 // successful reservation even with the flag OFF, so weights are warm the
 // moment the band is enabled.
 func TestSatisficingBandServeCounterFedOnRealPath(t *testing.T) {
+	t.Setenv(satisficingBandEnv, "false") // recording must be flag-independent
 	reg := New(testLogger())
 	bandFixture(t, reg)
 	winner := reserveOnce(t, reg, bandRequest("feed-1"))

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -917,6 +917,13 @@ func (r *Registry) OwnedProviderSummary(accountID, model string, traits RequestT
 		// instead of proceeding into a dispatch that can only be rejected.
 		serves := r.providerServesOwnedRoutableModelLocked(p, model) &&
 			r.providerEligibleForTraitsLocked(p, model, traits) &&
+			// Per-model version floor: the dispatch gate applies it to
+			// self-route too (a below-floor binary would MIS-SERVE the model,
+			// owner's box or not — model_version_floors.go), so the preflight
+			// summary must agree or a below-floor owned box reads as
+			// "serves model", queues, and dies as machine_busy instead of
+			// failing fast with the real cause.
+			!r.providerBelowModelVersionFloorLocked(p, model) &&
 			(!requiresVision || r.providerServesVisionModelLocked(p, model, true)) &&
 			p.RuntimeVerified &&
 			r.providerSupportsPrivateTextLocked(p) &&

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -1264,9 +1264,11 @@ func freeMemoryAdmits(snap routingSnapshot, reqPromptTokens, reqMaxTokens int) b
 	// load — so in-gap pending on a resident model must not be double-spendable
 	// by a cold request that skips the budget branch above. The reconstructed
 	// pool charges all-models coordinator pending plus this request; a cold
-	// model has no reported KV rate (snap.kvBytesPerToken == 0), so the check
-	// runs in token units. No-op for legacy providers with no budget slots at
-	// all (pool.total == 0).
+	// model has no reported KV rate (snap.kvBytesPerToken == 0), so on a
+	// byte-reconstructable pool it is priced conservatively in bytes at the
+	// box's max resident rate (pooledBudgetAdmits' cold-rate substitution),
+	// falling to token units only when the pool is not byte-reconstructable.
+	// No-op for legacy providers with no budget slots at all (pool.total == 0).
 	if !pooledBudgetAdmits(snap, requestTokens) {
 		return false
 	}

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -376,6 +376,11 @@ func (r *Registry) ReserveProviderEx(model string, pr *PendingRequest, excludeID
 
 	pr.ProviderID = p.ID
 	p.addPendingLocked(pr)
+	// Feed the satisficing band's recent-serve counter on EVERY successful
+	// reservation (flag-independent): weights are already warm the moment the
+	// band flips on, and recording is selection-neutral while it's off. The
+	// counter has its own leaf lock; see satisficing_band.go.
+	r.serveCounter.record(p.ID)
 	// If this pair's capacity-reject cooldown just EXPIRED, this reservation is
 	// its single half-open probe: claim it here (r.mu write lock is held for the
 	// whole selection+reservation, so concurrent reservations serialize) so the
@@ -749,6 +754,33 @@ func (r *Registry) selectBestCandidateScanLocked(model string, pr *PendingReques
 	pool := scan.pool
 	affinityProviderID := scan.affinityProviderID
 	candidateCount := scan.candidateCount
+
+	// Satisficing utilization band (EIGENINFERENCE_SATISFICING_BAND, default
+	// OFF — this block is dormant and selection below is byte-for-byte
+	// today's). Among candidates predicted to meet the request's SLO with
+	// margin (the band — the same TTFT/decode predicates the hard gates
+	// compute; see satisficing_band.go), pick weighted-random by inverse
+	// recent serves instead of cheapest-cost, so the idle majority of SLO-
+	// meeting boxes absorbs load the fastest tier otherwise monopolizes.
+	// Candidates outside the band never displace the cost path: an empty band
+	// falls through to the exact selection below. Cache affinity keeps its
+	// pin WITHIN the band (prefix-cache TTFT for repeat prefixes; a pinned
+	// consumer's turns are serial, so honoring the pin costs no spread).
+	if satisficingBandEnabled() {
+		if band := satisficingBandMembers(pool, pr); len(band) > 0 {
+			winner := r.pickSatisficingBandLocked(band)
+			if affinityProviderID != "" {
+				for _, c := range band {
+					if c.provider.ID == affinityProviderID {
+						winner = c
+						break
+					}
+				}
+			}
+			r.logRoutingDecision(model, pr, winner, candidateCount)
+			return winner, candidateCount, scan.capacityRejections, scan.tooLargeRejections, scan.visionRejections, scan.ttftRejections, scan.bestTTFTMs, scan.breakerRejected
+		}
+	}
 
 	var best *routingCandidate
 	for _, c := range pool {

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -113,9 +113,18 @@ type routingSnapshot struct {
 	// (callers fall back to the kvCacheBytesPerToken default). Used by the
 	// servability predictor to estimate a cold provider's post-load token budget
 	// the same way the provider does, instead of the fixed default.
-	kvBytesPerToken    int64
-	fleetMedianTPS     float64
-	hasBackendCapacity bool // provider reports BackendCapacity; TTFT estimates are reliable
+	kvBytesPerToken int64
+	fleetMedianTPS  float64
+	// prefillMedianTPS / prefillMedianSamples are the per-(model, chip family)
+	// median of fleet-observed prefill EWMAs and its sample count
+	// (TPSRegistry.PrefillMedian, prefill_tps.go). When trusted (>= the
+	// min-sample floor) it replaces the static decode×ratio prefill estimate in
+	// prefillTPSForSnapshot for providers that don't report their own
+	// measurement — the prefill-honest TTFT input. 0/0 when no fleet samples
+	// exist for this (model, chip).
+	prefillMedianTPS     float64
+	prefillMedianSamples int
+	hasBackendCapacity   bool // provider reports BackendCapacity; TTFT estimates are reliable
 
 	// Engine-health (first-token wedge) signals, decoded from the slot's
 	// BackendSlotCapacity (see docs/reports/2026-06-22-cancel-root-cause-and-fix.md
@@ -1141,6 +1150,7 @@ func (r *Registry) snapshotProviderLockedEx(p *Provider, model string, traits Re
 	snap.modelLoaded = slotStateModelLoaded(snap.slotState)
 	snap.availableOnDisk = !snap.modelLoaded
 	snap.fleetMedianTPS = r.tpsRegistry.Median(model, p.Hardware.ChipFamily)
+	snap.prefillMedianTPS, snap.prefillMedianSamples = r.tpsRegistry.PrefillMedian(model, p.Hardware.ChipFamily)
 
 	return snap, true
 }
@@ -1490,17 +1500,20 @@ func resolveEffectiveTPS(snap routingSnapshot) float64 {
 }
 
 // resolvePrefillTPS returns the best available prefill TPS estimate for TTFT.
-// Preference order: measured per-slot observed prefill EWMA → (in
-// PrefillFallbackEnforce mode) the data-derived fleet fallback → snap.prefillTPS
-// (the resolvedPrefillTPS chain: registration benchmark → decode×
-// prefillToDecodeRatio). This mirrors how resolveEffectiveTPS prefers the measured
-// decode rate over the static estimate. The result is clamped to maxPrefillTPS so
-// a single outlier heartbeat cannot collapse the TTFT estimate.
+// Preference order: measured per-slot observed prefill EWMA → the trusted
+// per-(model, chip) fleet prefill median (prefill_tps.go; the prefill-honest
+// transfer of REAL v0.7.5 measurements to boxes that don't report their own) →
+// (in PrefillFallbackEnforce mode) the data-derived fleet fallback anchor →
+// snap.prefillTPS (the resolvedPrefillTPS chain: registration benchmark →
+// decode×prefillToDecodeRatio). This mirrors how resolveEffectiveTPS prefers
+// measured decode rates over static estimates. The result is clamped to
+// maxPrefillTPS so a single outlier heartbeat cannot collapse the TTFT estimate.
 //
-// observedPrefillTPS stays 0 until providers ship the durable measurement fix, so
-// on today's fleet the OFF default returns the legacy sqrt(bandwidth)×ratio value
-// (~280 tok/s) and ENFORCE returns the recalibrated fallback (~6500 tok/s, the
-// measured prefill p50) — see prefill_fallback.go (prefillTPSForSnapshot).
+// Until v0.7.5 providers populate observed_prefill_tps the medians stay empty,
+// so today's fleet sees: OFF default → the legacy sqrt(bandwidth)×ratio value
+// (~280 tok/s); ENFORCE → the recalibrated fallback (~6500 tok/s, the measured
+// prefill p50). As adoption ramps, per-(model, chip) medians take over — see
+// prefill_fallback.go (prefillTPSForSnapshot) for the full resolution order.
 func resolvePrefillTPS(snap routingSnapshot) float64 {
 	return prefillTPSForSnapshot(snap, prefillFallbackMode == PrefillFallbackEnforce)
 }
@@ -2082,6 +2095,7 @@ func (r *Registry) quickCapacityCheck(model string, estimatedPromptTokens, reque
 		snap.modelLoaded = slotStateModelLoaded(snap.slotState)
 		snap.availableOnDisk = !snap.modelLoaded
 		snap.fleetMedianTPS = r.tpsRegistry.Median(model, p.Hardware.ChipFamily)
+		snap.prefillMedianTPS, snap.prefillMedianSamples = r.tpsRegistry.PrefillMedian(model, p.Hardware.ChipFamily)
 
 		p.mu.Unlock()
 

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -66,22 +66,28 @@ const (
 )
 
 type routingSnapshot struct {
-	provider           *Provider
-	model              string
-	chipFamily         string // hardware chip family (e.g. "M3"); keys the TTFT calibrator
-	slotState          string
-	hasHeadroom        bool
-	totalPending       int
-	pendingForModel    int
-	pendingMaxTokens   int
-	backendRunning     int
-	backendWaiting     int
-	maxTokensPotential int64
-	decodeTPS          float64
-	prefillTPS         float64
-	systemMetrics      protocol.SystemMetrics
-	gpuMemoryActiveGB  float64
-	totalMemoryGB      float64
+	provider         *Provider
+	model            string
+	chipFamily       string // hardware chip family (e.g. "M3"); keys the TTFT calibrator
+	slotState        string
+	hasHeadroom      bool
+	totalPending     int
+	pendingForModel  int
+	pendingMaxTokens int
+	// pendingMaxTokensAllModels is pendingMaxTokens WITHOUT the model filter:
+	// the token budgets of every coordinator-pending request on this provider,
+	// any model. Feeds the pooled-budget admission check (pooledBudgetAdmits)
+	// so co-resident models cannot double-spend the one shared KV pool inside
+	// the heartbeat gap.
+	pendingMaxTokensAllModels int
+	backendRunning            int
+	backendWaiting            int
+	maxTokensPotential        int64
+	decodeTPS                 float64
+	prefillTPS                float64
+	systemMetrics             protocol.SystemMetrics
+	gpuMemoryActiveGB         float64
+	totalMemoryGB             float64
 	// freeForLoadGB is the provider-reported max additional model-weight (GB) it
 	// can load right now (net of cap/reserve/headroom, idle models reclaimed).
 	// When non-nil it is the authoritative cold-load gate; nil = legacy provider
@@ -97,6 +103,11 @@ type routingSnapshot struct {
 	activeTokenBudgetUsed int64
 	activeTokenBudgetMax  int64
 	queuedTokenBudget     int64
+	// pooledTokenBudget is the provider's reconstructed whole-box token budget
+	// (all budget slots; shared headroom counted once — providerPooledTokenBudget).
+	// Zero value when the provider reports no backend capacity / no budget
+	// slots, which disables the pooled admission check.
+	pooledTokenBudget pooledTokenBudget
 	// kvBytesPerToken is the provider-reported per-token KV-cache cost (bytes)
 	// for THIS model's slot (BackendSlotCapacity.KVBytesPerToken). 0 = unreported
 	// (callers fall back to the kvCacheBytesPerToken default). Used by the
@@ -1068,11 +1079,13 @@ func (r *Registry) snapshotProviderLockedEx(p *Provider, model string, traits Re
 	}
 
 	for _, pr := range p.pendingReqs {
+		tokens := pendingTokenBudget(pr)
+		snap.pendingMaxTokensAllModels += tokens
 		if pr.Model != model {
 			continue
 		}
 		snap.pendingForModel++
-		snap.pendingMaxTokens += pendingTokenBudget(pr)
+		snap.pendingMaxTokens += tokens
 	}
 	// Concurrency headroom with the quality-concurrency cap: a slow model whose
 	// quality batch is below the flat fallback (e.g. Gemma at ~14 tok/s solo →
@@ -1091,6 +1104,7 @@ func (r *Registry) snapshotProviderLockedEx(p *Provider, model string, traits Re
 		if p.BackendCapacity.TotalMemoryGB > 0 {
 			snap.totalMemoryGB = p.BackendCapacity.TotalMemoryGB
 		}
+		snap.pooledTokenBudget = providerPooledTokenBudget(p.BackendCapacity.Slots)
 		for _, slot := range p.BackendCapacity.Slots {
 			if slot.Model != model {
 				continue
@@ -1173,7 +1187,18 @@ func freeMemoryAdmits(snap routingSnapshot, reqPromptTokens, reqMaxTokens int) b
 		if coordinatorExtra < 0 {
 			coordinatorExtra = 0
 		}
-		return snap.activeTokenBudgetUsed+snap.queuedTokenBudget+coordinatorExtra+requestTokens <= snap.activeTokenBudgetMax
+		if snap.activeTokenBudgetUsed+snap.queuedTokenBudget+coordinatorExtra+requestTokens > snap.activeTokenBudgetMax {
+			return false
+		}
+		// The per-slot max still encodes this model's own context/KV ceiling, but
+		// it is NOT a private budget: co-resident slots share the box's ONE KV
+		// pool (each slot's max = own committed + the SAME shared headroom), so a
+		// burst admitted against model A within the heartbeat gap is invisible to
+		// model B's slot max until the next heartbeat. The request must therefore
+		// also fit the reconstructed whole-box pool with EVERY model's
+		// coordinator-pending tokens charged (see pooled_admission.go). Reduces
+		// exactly to the per-slot check for single-model providers.
+		return pooledBudgetAdmits(snap.pooledTokenBudget, snap.pendingMaxTokensAllModels, requestTokens)
 	}
 
 	if !snap.modelLoaded {
@@ -1994,11 +2019,13 @@ func (r *Registry) quickCapacityCheck(model string, estimatedPromptTokens, reque
 			hasBackendCapacity: p.BackendCapacity != nil,
 		}
 		for _, pending := range p.pendingReqs {
+			tokens := pendingTokenBudget(pending)
+			snap.pendingMaxTokensAllModels += tokens
 			if pending.Model != model {
 				continue
 			}
 			snap.pendingForModel++
-			snap.pendingMaxTokens += pendingTokenBudget(pending)
+			snap.pendingMaxTokens += tokens
 		}
 		if snap.hasBackendCapacity {
 			snap.gpuMemoryActiveGB = p.BackendCapacity.GPUMemoryActiveGB
@@ -2006,6 +2033,7 @@ func (r *Registry) quickCapacityCheck(model string, estimatedPromptTokens, reque
 			if p.BackendCapacity.TotalMemoryGB > 0 {
 				snap.totalMemoryGB = p.BackendCapacity.TotalMemoryGB
 			}
+			snap.pooledTokenBudget = providerPooledTokenBudget(p.BackendCapacity.Slots)
 			for _, slot := range p.BackendCapacity.Slots {
 				if slot.Model != model {
 					continue

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -1075,12 +1075,14 @@ func (r *Registry) snapshotProviderLockedEx(p *Provider, model string, traits Re
 		snap.pendingMaxTokens += pendingTokenBudget(pr)
 	}
 	// Concurrency headroom with the quality-concurrency cap: a slow model whose
-	// quality batch is below the flat fallback (e.g. Gemma at ~23 tok/s solo →
+	// quality batch is below the flat fallback (e.g. Gemma at ~14 tok/s solo →
 	// batch 1-2) stops being admittable once it is at its quality cap, so load
-	// spreads across boxes instead of collapsing a few. Uses the static
-	// single-stream decode rate (snap.decodeTPS = resolvedDecodeTPS), not the
-	// observed-under-load value. No-op (legacy flat cap) when the cap is disabled.
-	snap.hasHeadroom = r.hasConcurrencyHeadroomForModelCapLocked(p, model, snap.decodeTPS)
+	// spreads across boxes instead of collapsing a few. The cap resolves the
+	// model's own static solo rate internally (solo median / seed → provider
+	// benchmark fallback) — NOT snap.decodeTPS, which stays the provider-level
+	// rate for TTFT/cost estimation, and NOT the observed-under-load value.
+	// No-op (legacy flat cap) when the cap is disabled.
+	snap.hasHeadroom = r.hasConcurrencyHeadroomForModelCapResolvedLocked(p, model)
 	snap.hasBackendCapacity = p.BackendCapacity != nil
 
 	if p.BackendCapacity != nil {
@@ -1967,10 +1969,10 @@ func (r *Registry) quickCapacityCheck(model string, estimatedPromptTokens, reque
 		}
 
 		// Concurrency gate (with the quality-concurrency cap, same as the dispatch
-		// snapshot — uses the static single-stream decode rate so routing and the
-		// shed preflight stay consistent and a slow model's quality cap counts a
-		// saturated box as a capacity rejection here too).
-		if !r.hasConcurrencyHeadroomForModelCapLocked(p, model, resolvedDecodeTPS(p)) {
+		// snapshot — resolves the model's own static solo rate internally so
+		// routing and the shed preflight stay consistent and a slow model's
+		// quality cap counts a saturated box as a capacity rejection here too).
+		if !r.hasConcurrencyHeadroomForModelCapResolvedLocked(p, model) {
 			p.mu.Unlock()
 			capacityRejections++
 			continue

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -1482,23 +1482,19 @@ func resolveEffectiveTPS(snap routingSnapshot) float64 {
 }
 
 // resolvePrefillTPS returns the best available prefill TPS estimate for TTFT.
-// Fallback chain: measured per-slot observed prefill EWMA → snap.prefillTPS (the
-// resolvedPrefillTPS chain: registration benchmark → decode×prefillToDecodeRatio
-// ×12 fallback). This mirrors how resolveEffectiveTPS prefers the measured
-// decode rate over the static estimate. The result is clamped to maxPrefillTPS
-// so a single outlier heartbeat cannot collapse the TTFT estimate.
+// Preference order: measured per-slot observed prefill EWMA → (in
+// PrefillFallbackEnforce mode) the data-derived fleet fallback → snap.prefillTPS
+// (the resolvedPrefillTPS chain: registration benchmark → decode×
+// prefillToDecodeRatio). This mirrors how resolveEffectiveTPS prefers the measured
+// decode rate over the static estimate. The result is clamped to maxPrefillTPS so
+// a single outlier heartbeat cannot collapse the TTFT estimate.
 //
-// observedPrefillTPS stays 0 until providers ship the W1 measurement, so on
-// today's fleet this is a no-op that returns the existing ×12-chain value.
+// observedPrefillTPS stays 0 until providers ship the durable measurement fix, so
+// on today's fleet the OFF default returns the legacy sqrt(bandwidth)×ratio value
+// (~280 tok/s) and ENFORCE returns the recalibrated fallback (~6500 tok/s, the
+// measured prefill p50) — see prefill_fallback.go (prefillTPSForSnapshot).
 func resolvePrefillTPS(snap routingSnapshot) float64 {
-	tps := snap.prefillTPS
-	if snap.observedPrefillTPS > 0 {
-		tps = snap.observedPrefillTPS
-	}
-	if tps > maxPrefillTPS {
-		tps = maxPrefillTPS
-	}
-	return tps
+	return prefillTPSForSnapshot(snap, prefillFallbackMode == PrefillFallbackEnforce)
 }
 
 // effectiveDecodeTPS scales the static decode TPS down by current
@@ -1591,7 +1587,11 @@ func resolvedModelTPSLocked(p *Provider, model string) (decodeTPS, prefillTPS fl
 // with the 5s+1ms/token TTFT deadline it estimated ~100 tok/s prefill (vs the
 // ~1000 tok/s the deadline implicitly assumes), so the TTFT gate wrongly
 // rejected warm, capable providers on any prompt above ~550 tokens. No provider
-// currently reports prefill_tps, so this fallback is the production path.
+// currently reports prefill_tps, so this fallback is the production path. Even 12×
+// is far too low against the MEASURED reality (real prefill p50 ≈ 6,500 tok/s vs
+// this chain's ~280 tok/s) — the data-derived replacement lives in
+// prefill_fallback.go (defaultPrefillFallbackTPS) and supersedes this chain when
+// PrefillFallbackEnforce is set.
 const defaultPrefillToDecodeRatio = 12.0
 
 // prefillToDecodeRatio is configured once at startup (via SetPrefillToDecodeRatio,
@@ -1876,20 +1876,32 @@ func (r *Registry) providerCanAdmitLockedEx(p *Provider, model string, traits Re
 //     a model that will never fit (the client would retry forever) — it should
 //     surface model_too_large / 503 instead.
 func (r *Registry) QuickCapacityCheck(model string, estimatedPromptTokens, requestedMaxTokens int, traits RequestTraits, allowedSerials ...string) (candidateCount, capacityRejections, modelTooLarge int) {
-	candidateCount, capacityRejections, modelTooLarge, _, _ = r.quickCapacityCheck(model, estimatedPromptTokens, requestedMaxTokens, traits, false, allowedSerials...)
+	candidateCount, capacityRejections, modelTooLarge, _, _ = r.quickCapacityCheck(model, estimatedPromptTokens, requestedMaxTokens, traits, false, false, allowedSerials...)
 	return candidateCount, capacityRejections, modelTooLarge
 }
 
 func (r *Registry) QuickCapacityCheckForRequest(model string, estimatedPromptTokens, requestedMaxTokens int, traits RequestTraits, requiresVision bool, allowedSerials ...string) (candidateCount, capacityRejections, modelTooLarge int) {
-	candidateCount, capacityRejections, modelTooLarge, _, _ = r.quickCapacityCheck(model, estimatedPromptTokens, requestedMaxTokens, traits, requiresVision, allowedSerials...)
+	candidateCount, capacityRejections, modelTooLarge, _, _ = r.quickCapacityCheck(model, estimatedPromptTokens, requestedMaxTokens, traits, requiresVision, false, allowedSerials...)
 	return candidateCount, capacityRejections, modelTooLarge
 }
 
 func (r *Registry) QuickCapacityCheckWithTTFTForRequest(model string, estimatedPromptTokens, requestedMaxTokens int, traits RequestTraits, requiresVision bool, allowedSerials ...string) (candidateCount, capacityRejections, modelTooLarge int, bestTTFT time.Duration, hasTTFT bool) {
-	return r.quickCapacityCheck(model, estimatedPromptTokens, requestedMaxTokens, traits, requiresVision, allowedSerials...)
+	return r.quickCapacityCheck(model, estimatedPromptTokens, requestedMaxTokens, traits, requiresVision, false, allowedSerials...)
 }
 
-func (r *Registry) quickCapacityCheck(model string, estimatedPromptTokens, requestedMaxTokens int, traits RequestTraits, requiresVision bool, allowedSerials ...string) (candidateCount, capacityRejections, modelTooLarge int, bestTTFT time.Duration, hasTTFT bool) {
+// QuickCapacityCheckRecalibratedTTFT runs the preflight TTFT scan with the
+// prefill-fallback recalibration FORCED on (regardless of mode), returning the
+// best estimated TTFT and whether any candidate produced a reliable estimate. Used
+// ONLY by the prefill-fallback shadow path to measure projected ttft_429 recovery
+// WITHOUT changing live routing; callers gate it on
+// PrefillFallbackModeValue() == PrefillFallbackShadow, so the extra scan is paid
+// only during a staging window.
+func (r *Registry) QuickCapacityCheckRecalibratedTTFT(model string, estimatedPromptTokens, requestedMaxTokens int, traits RequestTraits, requiresVision bool, allowedSerials ...string) (bestTTFT time.Duration, hasTTFT bool) {
+	_, _, _, bestTTFT, hasTTFT = r.quickCapacityCheck(model, estimatedPromptTokens, requestedMaxTokens, traits, requiresVision, true, allowedSerials...)
+	return bestTTFT, hasTTFT
+}
+
+func (r *Registry) quickCapacityCheck(model string, estimatedPromptTokens, requestedMaxTokens int, traits RequestTraits, requiresVision bool, recalibratePrefill bool, allowedSerials ...string) (candidateCount, capacityRejections, modelTooLarge int, bestTTFT time.Duration, hasTTFT bool) {
 	// Use a dummy PendingRequest with the caller's actual token estimates
 	// for the admission gate (freeMemoryAdmits).
 	if estimatedPromptTokens <= 0 {
@@ -2089,6 +2101,9 @@ func (r *Registry) quickCapacityCheck(model string, estimatedPromptTokens, reque
 		candidateCount++
 		if snap.hasBackendCapacity {
 			ttft := estimatedTTFTFromSnapshot(snap, estimatedPromptTokens)
+			if recalibratePrefill {
+				ttft = estimatedRecalibratedTTFTFromSnapshot(snap, estimatedPromptTokens)
+			}
 			if !hasTTFT || ttft < bestTTFT {
 				bestTTFT = ttft
 				hasTTFT = true
@@ -2128,6 +2143,14 @@ func estimatedTTFTFromSnapshot(snap routingSnapshot, reqPromptTokens int) time.D
 // and this request's own prefill instead of treating active_token_budget_used as
 // a serial decode backlog.
 func ttftMsFromSnapshot(snap routingSnapshot, reqPromptTokens int) float64 {
+	return ttftMsFromSnapshotWithPrefill(snap, reqPromptTokens, resolvePrefillTPS(snap))
+}
+
+// ttftMsFromSnapshotWithPrefill is ttftMsFromSnapshot parametrized by the prefill
+// TPS to use, so the prefill-fallback shadow path (recalibratedTTFTMsFromSnapshot)
+// can compute the recalibrated estimate without changing the live prefill
+// resolution. prefillTPS <= 0 is floored to 1 tok/s.
+func ttftMsFromSnapshotWithPrefill(snap routingSnapshot, reqPromptTokens int, prefillTPS float64) float64 {
 	if !snap.hasBackendCapacity {
 		return 0
 	}
@@ -2135,7 +2158,6 @@ func ttftMsFromSnapshot(snap routingSnapshot, reqPromptTokens int) float64 {
 	if reqPromptTokens < 0 {
 		reqPromptTokens = 0
 	}
-	prefillTPS := resolvePrefillTPS(snap)
 	if prefillTPS <= 0 {
 		prefillTPS = 1.0
 	}

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -1147,7 +1147,7 @@ func (r *Registry) snapshotProviderLockedEx(p *Provider, model string, traits Re
 			snap.activeTokenBudgetUsed = slot.ActiveTokenBudgetUsed
 			snap.activeTokenBudgetMax = slot.ActiveTokenBudgetMax
 			snap.queuedTokenBudget = slot.QueuedTokenBudget
-			snap.kvBytesPerToken = slot.KVBytesPerToken
+			snap.kvBytesPerToken = clampKVBytesPerToken(slot.KVBytesPerToken)
 			snap.stepsExecuted = slot.StepsExecuted
 			snap.admits = slot.Admits
 			snap.firstTokensEmitted = slot.FirstTokensEmitted
@@ -2152,7 +2152,7 @@ func (r *Registry) quickCapacityCheck(model string, estimatedPromptTokens, reque
 				snap.activeTokenBudgetMax = slot.ActiveTokenBudgetMax
 				snap.queuedTokenBudget = slot.QueuedTokenBudget
 				snap.maxTokensPotential = slot.MaxTokensPotential
-				snap.kvBytesPerToken = slot.KVBytesPerToken
+				snap.kvBytesPerToken = clampKVBytesPerToken(slot.KVBytesPerToken)
 				snap.stepsExecuted = slot.StepsExecuted
 				snap.admits = slot.Admits
 				snap.firstTokensEmitted = slot.FirstTokensEmitted

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -80,14 +80,22 @@ type routingSnapshot struct {
 	// so co-resident models cannot double-spend the one shared KV pool inside
 	// the heartbeat gap.
 	pendingMaxTokensAllModels int
-	backendRunning            int
-	backendWaiting            int
-	maxTokensPotential        int64
-	decodeTPS                 float64
-	prefillTPS                float64
-	systemMetrics             protocol.SystemMetrics
-	gpuMemoryActiveGB         float64
-	totalMemoryGB             float64
+	// pendingMaxBytesAllModels is the byte-normalized analog: each pending
+	// request's token budget × its model's reported KVBytesPerToken. Valid
+	// only when pendingBytesKnown — every pending request's model had a
+	// reported KV rate (see fillSnapshotPendingAndPool). Co-resident models
+	// spend the ONE shared pool at different per-token byte rates, so tokens
+	// are not a common unit across models (pooled_admission.go).
+	pendingMaxBytesAllModels int64
+	pendingBytesKnown        bool
+	backendRunning           int
+	backendWaiting           int
+	maxTokensPotential       int64
+	decodeTPS                float64
+	prefillTPS               float64
+	systemMetrics            protocol.SystemMetrics
+	gpuMemoryActiveGB        float64
+	totalMemoryGB            float64
 	// freeForLoadGB is the provider-reported max additional model-weight (GB) it
 	// can load right now (net of cap/reserve/headroom, idle models reclaimed).
 	// When non-nil it is the authoritative cold-load gate; nil = legacy provider
@@ -1078,15 +1086,7 @@ func (r *Registry) snapshotProviderLockedEx(p *Provider, model string, traits Re
 		minRAMGb:      r.catalogMinRAMGbLocked(model),
 	}
 
-	for _, pr := range p.pendingReqs {
-		tokens := pendingTokenBudget(pr)
-		snap.pendingMaxTokensAllModels += tokens
-		if pr.Model != model {
-			continue
-		}
-		snap.pendingForModel++
-		snap.pendingMaxTokens += tokens
-	}
+	fillSnapshotPendingAndPool(&snap, p, model)
 	// Concurrency headroom with the quality-concurrency cap: a slow model whose
 	// quality batch is below the flat fallback (e.g. Gemma at ~14 tok/s solo →
 	// batch 1-2) stops being admittable once it is at its quality cap, so load
@@ -1104,7 +1104,6 @@ func (r *Registry) snapshotProviderLockedEx(p *Provider, model string, traits Re
 		if p.BackendCapacity.TotalMemoryGB > 0 {
 			snap.totalMemoryGB = p.BackendCapacity.TotalMemoryGB
 		}
-		snap.pooledTokenBudget = providerPooledTokenBudget(p.BackendCapacity.Slots)
 		for _, slot := range p.BackendCapacity.Slots {
 			if slot.Model != model {
 				continue
@@ -1196,9 +1195,11 @@ func freeMemoryAdmits(snap routingSnapshot, reqPromptTokens, reqMaxTokens int) b
 		// burst admitted against model A within the heartbeat gap is invisible to
 		// model B's slot max until the next heartbeat. The request must therefore
 		// also fit the reconstructed whole-box pool with EVERY model's
-		// coordinator-pending tokens charged (see pooled_admission.go). Reduces
-		// exactly to the per-slot check for single-model providers.
-		return pooledBudgetAdmits(snap.pooledTokenBudget, snap.pendingMaxTokensAllModels, requestTokens)
+		// coordinator-pending tokens charged — byte-normalized per slot KV rate
+		// when reported, since co-resident models spend the pool at different
+		// bytes/token (see pooled_admission.go). Reduces exactly to the per-slot
+		// check for single-model providers.
+		return pooledBudgetAdmits(snap, requestTokens)
 	}
 
 	if !snap.modelLoaded {
@@ -1254,6 +1255,41 @@ func freeMemoryAdmits(snap routingSnapshot, reqPromptTokens, reqMaxTokens int) b
 
 	free := snap.totalMemoryGB - snap.gpuMemoryActiveGB
 	return free >= required
+}
+
+// fillSnapshotPendingAndPool populates snap's reconstructed pooled budget and
+// its coordinator-pending aggregates — the per-model filtered pair
+// (pendingForModel / pendingMaxTokens) and the all-models totals in token and,
+// when normalizable, byte units. Byte normalization needs each pending
+// request's model to have a reported KVBytesPerToken (a budget slot in the
+// pool); any pending request that can't be normalized — e.g. for a cold model
+// with no resident slot — flips pendingBytesKnown off and pooledBudgetAdmits
+// falls back to token accounting for the whole check. Shared by the dispatch
+// snapshot (snapshotProviderLockedEx) and the queue preflight
+// (QuickCapacityCheck…) so the two admission paths cannot drift. Caller holds
+// p.mu.
+func fillSnapshotPendingAndPool(snap *routingSnapshot, p *Provider, model string) {
+	if p.BackendCapacity != nil {
+		snap.pooledTokenBudget = providerPooledTokenBudget(p.BackendCapacity.Slots)
+	}
+	bytesKnown := snap.pooledTokenBudget.byteMode
+	for _, pr := range p.pendingReqs {
+		tokens := pendingTokenBudget(pr)
+		snap.pendingMaxTokensAllModels += tokens
+		if bytesKnown {
+			if rate := snap.pooledTokenBudget.kvBytesPerToken[pr.Model]; rate > 0 {
+				snap.pendingMaxBytesAllModels += int64(tokens) * rate
+			} else {
+				bytesKnown = false
+			}
+		}
+		if pr.Model != model {
+			continue
+		}
+		snap.pendingForModel++
+		snap.pendingMaxTokens += tokens
+	}
+	snap.pendingBytesKnown = bytesKnown
 }
 
 func pendingTokenBudget(pr *PendingRequest) int {
@@ -2018,22 +2054,13 @@ func (r *Registry) quickCapacityCheck(model string, estimatedPromptTokens, reque
 			minRAMGb:           r.catalogMinRAMGbLocked(model),
 			hasBackendCapacity: p.BackendCapacity != nil,
 		}
-		for _, pending := range p.pendingReqs {
-			tokens := pendingTokenBudget(pending)
-			snap.pendingMaxTokensAllModels += tokens
-			if pending.Model != model {
-				continue
-			}
-			snap.pendingForModel++
-			snap.pendingMaxTokens += tokens
-		}
+		fillSnapshotPendingAndPool(&snap, p, model)
 		if snap.hasBackendCapacity {
 			snap.gpuMemoryActiveGB = p.BackendCapacity.GPUMemoryActiveGB
 			snap.freeForLoadGB = p.BackendCapacity.FreeForLoadGB
 			if p.BackendCapacity.TotalMemoryGB > 0 {
 				snap.totalMemoryGB = p.BackendCapacity.TotalMemoryGB
 			}
-			snap.pooledTokenBudget = providerPooledTokenBudget(p.BackendCapacity.Slots)
 			for _, slot := range p.BackendCapacity.Slots {
 				if slot.Model != model {
 					continue

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -1176,8 +1176,8 @@ func reportedFreeForLoadAdmits(catalogSizeGB float64, freeForLoadGB *float64) (a
 // Providers that report a token budget use budget-based admission;
 // legacy providers fall back to memory-based estimation.
 func freeMemoryAdmits(snap routingSnapshot, reqPromptTokens, reqMaxTokens int) bool {
+	requestTokens := int64(reqPromptTokens) + int64(reqMaxTokens)
 	if snap.activeTokenBudgetMax > 0 {
-		requestTokens := int64(reqPromptTokens) + int64(reqMaxTokens)
 		// Include coordinator-side pending tokens not yet reflected in the
 		// provider's heartbeat. Avoid double-counting active/queued backend
 		// budgets that are still present in the coordinator pending set until
@@ -1200,6 +1200,19 @@ func freeMemoryAdmits(snap routingSnapshot, reqPromptTokens, reqMaxTokens int) b
 		// bytes/token (see pooled_admission.go). Reduces exactly to the per-slot
 		// check for single-model providers.
 		return pooledBudgetAdmits(snap, requestTokens)
+	}
+
+	// Cold-slot pooled gate: this model reports no budget slot (not loaded
+	// here), but when ANY resident slot reports a token budget the box still
+	// has its ONE shared KV pool, and this request lands in it after the
+	// load — so in-gap pending on a resident model must not be double-spendable
+	// by a cold request that skips the budget branch above. The reconstructed
+	// pool charges all-models coordinator pending plus this request; a cold
+	// model has no reported KV rate (snap.kvBytesPerToken == 0), so the check
+	// runs in token units. No-op for legacy providers with no budget slots at
+	// all (pool.total == 0).
+	if !pooledBudgetAdmits(snap, requestTokens) {
+		return false
 	}
 
 	if !snap.modelLoaded {

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -1188,7 +1188,10 @@ func (r *Registry) snapshotProviderLockedEx(p *Provider, model string, traits Re
 	snap.modelLoaded = slotStateModelLoaded(snap.slotState)
 	snap.availableOnDisk = !snap.modelLoaded
 	snap.fleetMedianTPS = r.tpsRegistry.Median(model, p.Hardware.ChipFamily)
-	snap.prefillMedianTPS, snap.prefillMedianSamples = r.tpsRegistry.PrefillMedian(model, p.Hardware.ChipFamily)
+	// Prefill medians are keyed by chip CLASS (family+tier), not family — prefill
+	// throughput spreads 3–4× across same-family tiers, so pooling them would
+	// over-admit a slow tier at the hard TTFT gate (see prefillChipClass).
+	snap.prefillMedianTPS, snap.prefillMedianSamples = r.tpsRegistry.PrefillMedian(model, prefillChipClass(p.Hardware))
 
 	return snap, true
 }
@@ -2174,7 +2177,10 @@ func (r *Registry) quickCapacityCheck(model string, estimatedPromptTokens, reque
 		snap.modelLoaded = slotStateModelLoaded(snap.slotState)
 		snap.availableOnDisk = !snap.modelLoaded
 		snap.fleetMedianTPS = r.tpsRegistry.Median(model, p.Hardware.ChipFamily)
-		snap.prefillMedianTPS, snap.prefillMedianSamples = r.tpsRegistry.PrefillMedian(model, p.Hardware.ChipFamily)
+		// Prefill medians are keyed by chip CLASS (family+tier), not family — must
+		// match the ingest + dispatch-snapshot key or the preflight bestTTFT would
+		// diverge from dispatch (see prefillChipClass).
+		snap.prefillMedianTPS, snap.prefillMedianSamples = r.tpsRegistry.PrefillMedian(model, prefillChipClass(p.Hardware))
 
 		p.mu.Unlock()
 

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -1031,6 +1031,14 @@ func (r *Registry) providerPassesRoutingGatesLockedEx(p *Provider, model string,
 	if !r.providerEligibleForTraitsLocked(p, model, traits) {
 		return false
 	}
+	// Per-model provider-version floor (EIGENINFERENCE_MODEL_VERSION_FLOORS):
+	// the model-scoped sibling of the trait floors above — a floored model
+	// (e.g. gemma-4=0.7.5 during the v2 migration) may only route to providers
+	// at/above the paired binary version; empty-version providers fail every
+	// floor. No-op when the env is unset. See model_version_floors.go.
+	if r.providerBelowModelVersionFloorLocked(p, model) {
+		return false
+	}
 	return true
 }
 

--- a/coordinator/registry/solo_tps.go
+++ b/coordinator/registry/solo_tps.go
@@ -1,0 +1,107 @@
+package registry
+
+import (
+	"sort"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+)
+
+// solo_tps.go is the solo-gated half of TPSRegistry: per-(model, chip) decode
+// rates sampled ONLY while the reporting box was uncontended, so a mixed box's
+// gemma sample is never smeared by a concurrent gpt-oss batch. These medians
+// are the per-model static rate the quality-concurrency cap consumes
+// (resolvedSoloModelTPSLocked, concurrency_cap.go) — the root fix for the
+// 2026-07-06 gemma postmortem layer 6, where the cap read the provider-LEVEL
+// registration benchmark (gpt-oss 58–93 tok/s) and granted gemma caps of
+// 12–23 on boxes where gemma actually decodes 10–18 solo.
+//
+// The load-inclusive store (Record/Median, tps_registry.go) is untouched: its
+// consumers (fleetMedianTPS → TTFT estimation) want under-load samples.
+
+// RecordSolo adds a solo (uncontended-box) decode TPS sample for the given
+// model and chip family. Callers must pre-gate on soloSampleEligible — this
+// method itself only validates the sample value, mirroring Record.
+func (r *TPSRegistry) RecordSolo(model, chipFamily string, tps float64) {
+	if tps <= 0 || model == "" {
+		return
+	}
+	key := tpsKey{Model: model, ChipFamily: chipFamily}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	samples := r.soloSamples[key]
+	if len(samples) >= r.maxSamples {
+		// Drop oldest sample (FIFO ring), same shape as Record.
+		samples = samples[1:]
+	}
+	r.soloSamples[key] = append(samples, tps)
+}
+
+// SoloMedian returns the median solo decode TPS for the given model and chip
+// family plus the number of samples behind it. (0, 0) when no solo samples
+// exist. The count lets callers apply a min-sample trust floor before using
+// the median for admission decisions.
+func (r *TPSRegistry) SoloMedian(model, chipFamily string) (float64, int) {
+	key := tpsKey{Model: model, ChipFamily: chipFamily}
+	r.mu.RLock()
+	samples := r.soloSamples[key]
+	sorted := make([]float64, len(samples))
+	copy(sorted, samples)
+	r.mu.RUnlock()
+	return medianOfCopied(sorted), len(sorted)
+}
+
+// SoloMedianAllChips returns the model-wide solo median pooled across every
+// chip family that has at least one solo sample, plus the total sample count.
+// It is the conservative cross-chip transfer used when a specific (model,
+// chip) pair has too few samples: some real solo measurement of the model
+// beats a provider-level benchmark taken on a different model.
+func (r *TPSRegistry) SoloMedianAllChips(model string) (float64, int) {
+	r.mu.RLock()
+	var pooled []float64
+	for key, samples := range r.soloSamples {
+		if key.Model != model {
+			continue
+		}
+		pooled = append(pooled, samples...)
+	}
+	r.mu.RUnlock()
+	return medianOfCopied(pooled), len(pooled)
+}
+
+// medianOfCopied returns the median of samples, sorting in place (callers pass
+// a private copy). 0 for an empty slice.
+func medianOfCopied(sorted []float64) float64 {
+	if len(sorted) == 0 {
+		return 0
+	}
+	sort.Float64s(sorted)
+	mid := len(sorted) / 2
+	if len(sorted)%2 == 0 {
+		return (sorted[mid-1] + sorted[mid]) / 2
+	}
+	return sorted[mid]
+}
+
+// soloSampleEligible reports whether a heartbeat's capacity snapshot qualifies
+// its slot EWMAs as SOLO samples: the whole box — every slot, every co-resident
+// model — has at most one running-or-waiting request. The ≤1 allowance is the
+// request that produced the EWMA itself; ANY other activity anywhere on the
+// box disqualifies, which is exactly what keeps mixed-box samples honest
+// (a gemma EWMA measured while gpt-oss batches on the same GPU is a contended
+// rate, not a solo one). Negative counts (already clamped upstream by
+// clampBackendCapacity) are defensively ignored.
+func soloSampleEligible(bc *protocol.BackendCapacity) bool {
+	if bc == nil {
+		return false
+	}
+	load := 0
+	for _, slot := range bc.Slots {
+		if n := slot.NumRunning + slot.NumWaiting; n > 0 {
+			load += n
+		}
+		if load > 1 {
+			return false
+		}
+	}
+	return true
+}

--- a/coordinator/registry/solo_tps.go
+++ b/coordinator/registry/solo_tps.go
@@ -19,8 +19,10 @@ import (
 // consumers (fleetMedianTPS → TTFT estimation) want under-load samples.
 
 // RecordSolo adds a solo (uncontended-box) decode TPS sample for the given
-// model and chip family. Callers must pre-gate on soloSampleEligible — this
-// method itself only validates the sample value, mirroring Record.
+// model and chip family. Callers must pre-gate on soloSampleEligible AND on
+// the slot owning the box's one active request (NumRunning+NumWaiting > 0,
+// see the heartbeat ingest in registry.go) — this method itself only
+// validates the sample value, mirroring Record.
 func (r *TPSRegistry) RecordSolo(model, chipFamily string, tps float64) {
 	if tps <= 0 || model == "" {
 		return
@@ -83,13 +85,16 @@ func medianOfCopied(sorted []float64) float64 {
 }
 
 // soloSampleEligible reports whether a heartbeat's capacity snapshot qualifies
-// its slot EWMAs as SOLO samples: the whole box — every slot, every co-resident
-// model — has at most one running-or-waiting request. The ≤1 allowance is the
-// request that produced the EWMA itself; ANY other activity anywhere on the
-// box disqualifies, which is exactly what keeps mixed-box samples honest
-// (a gemma EWMA measured while gpt-oss batches on the same GPU is a contended
-// rate, not a solo one). Negative counts (already clamped upstream by
-// clampBackendCapacity) are defensively ignored.
+// as an uncontended box for SOLO sampling: the whole box — every slot, every
+// co-resident model — has at most one running-or-waiting request. The ≤1
+// allowance is the request that produced the EWMA itself; ANY other activity
+// anywhere on the box disqualifies, which is exactly what keeps mixed-box
+// samples honest (a gemma EWMA measured while gpt-oss batches on the same GPU
+// is a contended rate, not a solo one). This is the BOX-level half of the
+// gate; the heartbeat ingest additionally records only the slot that owns the
+// one active request, so idle co-resident slots cannot re-report a stale
+// decayed EWMA as a fresh solo observation every heartbeat. Negative counts
+// (already clamped upstream by clampBackendCapacity) are defensively ignored.
 func soloSampleEligible(bc *protocol.BackendCapacity) bool {
 	if bc == nil {
 		return false

--- a/coordinator/registry/solo_tps.go
+++ b/coordinator/registry/solo_tps.go
@@ -20,9 +20,10 @@ import (
 
 // RecordSolo adds a solo (uncontended-box) decode TPS sample for the given
 // model and chip family. Callers must pre-gate on soloSampleEligible AND on
-// the slot owning the box's one active request (NumRunning+NumWaiting > 0,
-// see the heartbeat ingest in registry.go) — this method itself only
-// validates the sample value, mirroring Record.
+// the slot having an actual running decode (NumRunning > 0, see the heartbeat
+// ingest in registry.go) so a purely-queued box's retained EWMA is not
+// sampled — this method itself only validates the sample value, mirroring
+// Record.
 func (r *TPSRegistry) RecordSolo(model, chipFamily string, tps float64) {
 	if tps <= 0 || model == "" {
 		return
@@ -91,10 +92,11 @@ func medianOfCopied(sorted []float64) float64 {
 // anywhere on the box disqualifies, which is exactly what keeps mixed-box
 // samples honest (a gemma EWMA measured while gpt-oss batches on the same GPU
 // is a contended rate, not a solo one). This is the BOX-level half of the
-// gate; the heartbeat ingest additionally records only the slot that owns the
-// one active request, so idle co-resident slots cannot re-report a stale
-// decayed EWMA as a fresh solo observation every heartbeat. Negative counts
-// (already clamped upstream by clampBackendCapacity) are defensively ignored.
+// gate; the heartbeat ingest additionally records only a slot with an actual
+// running decode (NumRunning > 0), so neither an idle co-resident slot nor a
+// purely-queued box can re-report a stale decayed EWMA as a fresh solo
+// observation every heartbeat. Negative counts (already clamped upstream by
+// clampBackendCapacity) are defensively ignored.
 func soloSampleEligible(bc *protocol.BackendCapacity) bool {
 	if bc == nil {
 		return false

--- a/coordinator/registry/solo_tps.go
+++ b/coordinator/registry/solo_tps.go
@@ -18,17 +18,32 @@ import (
 // The load-inclusive store (Record/Median, tps_registry.go) is untouched: its
 // consumers (fleetMedianTPS → TTFT estimation) want under-load samples.
 
+// chipClassKey keys the solo-sample store at a FINER grain than ChipFamily
+// alone: an M4 Max and an M4 Pro are the same family but 3–4× apart in decode
+// throughput, so pooling them by family lets a fast tier's rate raise a slow
+// tier's quality cap — the exact over-admission this cap exists to prevent.
+// The class is ChipFamily|ChipTier (e.g. "M4|Max"); the raw ChipName is the
+// fallback when the family is absent. Byte-for-byte the form #526's
+// prefillChipClass uses, so the solo and prefill rings key identically.
+func chipClassKey(hw protocol.Hardware) string {
+	if hw.ChipFamily == "" {
+		return hw.ChipName
+	}
+	return hw.ChipFamily + "|" + hw.ChipTier
+}
+
 // RecordSolo adds a solo (uncontended-box) decode TPS sample for the given
-// model and chip family. Callers must pre-gate on soloSampleEligible AND on
-// the slot having an actual running decode (NumRunning > 0, see the heartbeat
-// ingest in registry.go) so a purely-queued box's retained EWMA is not
-// sampled — this method itself only validates the sample value, mirroring
-// Record.
-func (r *TPSRegistry) RecordSolo(model, chipFamily string, tps float64) {
+// model and chip CLASS (chipClassKey — family+tier, not family alone). Callers
+// must pre-gate on soloSampleEligible AND on the slot having an actual running
+// decode (NumRunning > 0, see the heartbeat ingest in registry.go) so a
+// purely-queued box's retained EWMA is not sampled — this method itself only
+// validates the sample value, mirroring Record. The tpsKey.ChipFamily field
+// carries the chip-class string for solo entries.
+func (r *TPSRegistry) RecordSolo(model, chipClass string, tps float64) {
 	if tps <= 0 || model == "" {
 		return
 	}
-	key := tpsKey{Model: model, ChipFamily: chipFamily}
+	key := tpsKey{Model: model, ChipFamily: chipClass}
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	samples := r.soloSamples[key]
@@ -40,11 +55,11 @@ func (r *TPSRegistry) RecordSolo(model, chipFamily string, tps float64) {
 }
 
 // SoloMedian returns the median solo decode TPS for the given model and chip
-// family plus the number of samples behind it. (0, 0) when no solo samples
-// exist. The count lets callers apply a min-sample trust floor before using
-// the median for admission decisions.
-func (r *TPSRegistry) SoloMedian(model, chipFamily string) (float64, int) {
-	key := tpsKey{Model: model, ChipFamily: chipFamily}
+// CLASS (chipClassKey) plus the number of samples behind it. (0, 0) when no
+// solo samples exist. The count lets callers apply a min-sample trust floor
+// before using the median for admission decisions.
+func (r *TPSRegistry) SoloMedian(model, chipClass string) (float64, int) {
+	key := tpsKey{Model: model, ChipFamily: chipClass}
 	r.mu.RLock()
 	samples := r.soloSamples[key]
 	sorted := make([]float64, len(samples))
@@ -53,22 +68,49 @@ func (r *TPSRegistry) SoloMedian(model, chipFamily string) (float64, int) {
 	return medianOfCopied(sorted), len(sorted)
 }
 
-// SoloMedianAllChips returns the model-wide solo median pooled across every
-// chip family that has at least one solo sample, plus the total sample count.
-// It is the conservative cross-chip transfer used when a specific (model,
-// chip) pair has too few samples: some real solo measurement of the model
-// beats a provider-level benchmark taken on a different model.
+// SoloMedianAllChips is the CONSERVATIVE cross-class transfer used when a
+// provider's own chip class has too few solo samples: it returns the MINIMUM
+// of the per-class medians across every chip class that has at least one solo
+// sample for the model, plus the TOTAL sample count across those classes.
+//
+// SAFETY INVARIANT: the resolver must never hand a slow box a rate faster than
+// its own class demonstrated. Pooling every sample into one median (the old
+// behavior) lets a fast, sample-heavy class dominate and return a rate above a
+// slow box's real capability — over-capping it into the very quality collapse
+// this cap prevents. Taking the min of per-class medians instead can never
+// exceed the slowest class's typical rate: worst case it UNDER-caps a fast box
+// (safe, quality-protective), never over-caps a slower one.
+//
+// The returned int is the total sample count across classes, so the resolver's
+// existing >= qualityCapSoloMinSamples trust floor is unchanged. The
+// tpsKey.ChipFamily field carries the chip-class string for solo entries, so
+// grouping by key.Model + key.ChipFamily groups by class.
 func (r *TPSRegistry) SoloMedianAllChips(model string) (float64, int) {
 	r.mu.RLock()
-	var pooled []float64
+	perClass := make(map[string][]float64)
 	for key, samples := range r.soloSamples {
-		if key.Model != model {
+		if key.Model != model || len(samples) == 0 {
 			continue
 		}
-		pooled = append(pooled, samples...)
+		// append copies the values, so perClass is safe to sort after RUnlock.
+		perClass[key.ChipFamily] = append(perClass[key.ChipFamily], samples...)
 	}
 	r.mu.RUnlock()
-	return medianOfCopied(pooled), len(pooled)
+
+	minMedian, total := 0.0, 0
+	have := false
+	for _, samples := range perClass {
+		// samples is a private copy; medianOfCopied sorts it in place.
+		m := medianOfCopied(samples)
+		total += len(samples)
+		if m <= 0 {
+			continue
+		}
+		if !have || m < minMedian {
+			minMedian, have = m, true
+		}
+	}
+	return minMedian, total
 }
 
 // medianOfCopied returns the median of samples, sorting in place (callers pass

--- a/coordinator/registry/solo_tps_test.go
+++ b/coordinator/registry/solo_tps_test.go
@@ -1,0 +1,351 @@
+package registry
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+)
+
+const gptossBuild = "gpt-oss-20b"
+
+// enablePerModelQualityCap enables the quality cap exactly like
+// enableQualityCap (floor 15, fallback 4, default overcommit) and pins the
+// per-model solo-TPS envs — seed CSV, kill switch, min-sample floor — so
+// ambient operator settings can't leak in. Package-level knobs are restored to
+// defaults on cleanup so tests that never call SetQualityConcurrencyCap can't
+// observe leftovers.
+func enablePerModelQualityCap(t *testing.T, reg *Registry, seed, killSwitch, minSamples string) {
+	t.Helper()
+	t.Cleanup(func() {
+		qualityCapPerModelTPS = true
+		qualityCapSoloMinSamples = defaultQualityCapSoloMinSamples
+		modelSoloTPSSeed = nil
+		qualityCapOvercommitByModel = nil
+	})
+	t.Setenv(modelSoloTPSSeedEnv, seed)
+	t.Setenv(qualityCapPerModelTPSEnv, killSwitch)
+	t.Setenv(qualityCapSoloMinSamplesEnv, minSamples)
+	enableQualityCap(t, reg, "")
+}
+
+// resolveSolo evaluates the quality-cap solo-rate resolver under the locks the
+// routing path holds.
+func resolveSolo(reg *Registry, p *Provider, model string) soloModelTPS {
+	reg.mu.RLock()
+	defer reg.mu.RUnlock()
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return reg.resolvedSoloModelTPSLocked(p, model)
+}
+
+// effCapResolved evaluates the production per-model admission cap (solo rate
+// resolved internally) under the routing-path locks — the value every
+// production admission site now consumes via
+// hasConcurrencyHeadroomForModelCapResolvedLocked.
+func effCapResolved(reg *Registry, p *Provider, model string) int {
+	reg.mu.RLock()
+	defer reg.mu.RUnlock()
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return reg.effectiveMaxConcurrencyForModelResolvedLocked(p, model)
+}
+
+// mixedBoxProvider builds the postmortem's mixed box: registration benchmark
+// taken on gpt-oss (fast), with BOTH a gpt-oss and a gemma token-budget slot.
+func mixedBoxProvider(t *testing.T, reg *Registry, id string, decodeTPS float64) *Provider {
+	t.Helper()
+	p := makeSchedulerProvider(t, reg, id, gptossBuild, decodeTPS)
+	addAdvertisedModel(p, gemmaBuild)
+	p.mu.Lock()
+	p.BackendCapacity.Slots[0].ActiveTokenBudgetMax = 500_000
+	p.BackendCapacity.Slots = append(p.BackendCapacity.Slots, protocol.BackendSlotCapacity{
+		Model:                gemmaBuild,
+		State:                "running",
+		ActiveTokenBudgetMax: 400_000,
+	})
+	p.mu.Unlock()
+	return p
+}
+
+// --- Solo sample store ---
+
+func TestSoloMedianReturnsMedianAndCount(t *testing.T) {
+	r := NewTPSRegistry()
+	for _, v := range []float64{18, 10, 14, 12, 16} {
+		r.RecordSolo("model-a", "m4", v)
+	}
+	tps, n := r.SoloMedian("model-a", "m4")
+	if tps != 14 || n != 5 {
+		t.Fatalf("SoloMedian = (%v, %d), want (14, 5)", tps, n)
+	}
+	// The load-inclusive store must be untouched by solo recording.
+	if got := r.Median("model-a", "m4"); got != 0 {
+		t.Fatalf("Median = %v, want 0 (RecordSolo must not feed the load-inclusive store)", got)
+	}
+}
+
+func TestSoloMedianEmptyAndInvalidSamples(t *testing.T) {
+	r := NewTPSRegistry()
+	if tps, n := r.SoloMedian("missing", "m4"); tps != 0 || n != 0 {
+		t.Fatalf("SoloMedian(empty) = (%v, %d), want (0, 0)", tps, n)
+	}
+	r.RecordSolo("model", "m4", 0)
+	r.RecordSolo("model", "m4", -3)
+	r.RecordSolo("", "m4", 50)
+	if tps, n := r.SoloMedian("model", "m4"); tps != 0 || n != 0 {
+		t.Fatalf("SoloMedian(after invalid samples) = (%v, %d), want (0, 0)", tps, n)
+	}
+}
+
+func TestSoloMedianFIFOCap(t *testing.T) {
+	r := NewTPSRegistry()
+	for i := 0; i < 50; i++ {
+		r.RecordSolo("model", "chip", 100)
+	}
+	for i := 0; i < 10; i++ {
+		r.RecordSolo("model", "chip", 200)
+	}
+	// 40 × 100 + 10 × 200 after FIFO eviction → median 100, count capped at 50.
+	tps, n := r.SoloMedian("model", "chip")
+	if tps != 100 || n != 50 {
+		t.Fatalf("SoloMedian = (%v, %d), want (100, 50) after FIFO eviction", tps, n)
+	}
+}
+
+func TestSoloMedianAllChipsPoolsAcrossFamilies(t *testing.T) {
+	r := NewTPSRegistry()
+	r.RecordSolo("model", "m1", 20)
+	r.RecordSolo("model", "m1", 20)
+	r.RecordSolo("model", "m4", 30)
+	r.RecordSolo("model", "m4", 30)
+	r.RecordSolo("model", "m4", 30)
+	r.RecordSolo("other-model", "m4", 999) // different model must not pollute
+	tps, n := r.SoloMedianAllChips("model")
+	if tps != 30 || n != 5 {
+		t.Fatalf("SoloMedianAllChips = (%v, %d), want (30, 5)", tps, n)
+	}
+}
+
+// --- Heartbeat ingest gating ---
+
+func soloHeartbeat(slots []protocol.BackendSlotCapacity) *protocol.HeartbeatMessage {
+	return &protocol.HeartbeatMessage{
+		Type:   protocol.TypeHeartbeat,
+		Status: "serving",
+		BackendCapacity: &protocol.BackendCapacity{
+			TotalMemoryGB: 64,
+			Slots:         slots,
+		},
+	}
+}
+
+// TestSoloRecordingGatedOnUncontendedBox drives the REAL heartbeat ingest
+// path: a slot EWMA becomes a solo sample only when the whole box has at most
+// one running-or-waiting request (the sample-generating request itself). Any
+// co-resident activity — another model running, or waiting queue depth —
+// disqualifies the sample; the load-inclusive store records regardless.
+func TestSoloRecordingGatedOnUncontendedBox(t *testing.T) {
+	reg := New(testLogger())
+	makeSchedulerProvider(t, reg, "box", gemmaBuild, 93)
+
+	// Uncontended: gemma serving exactly the sample-generating request.
+	reg.Heartbeat("box", soloHeartbeat([]protocol.BackendSlotCapacity{
+		{Model: gemmaBuild, State: "running", NumRunning: 1, ObservedDecodeTPS: 14},
+		{Model: gptossBuild, State: "idle", NumRunning: 0, NumWaiting: 0},
+	}))
+	if _, n := reg.tpsRegistry.SoloMedian(gemmaBuild, "M3"); n != 1 {
+		t.Fatalf("solo samples after uncontended heartbeat = %d, want 1", n)
+	}
+
+	// Fully idle box reporting a (decayed) EWMA also qualifies.
+	reg.Heartbeat("box", soloHeartbeat([]protocol.BackendSlotCapacity{
+		{Model: gemmaBuild, State: "idle", ObservedDecodeTPS: 15},
+	}))
+	if _, n := reg.tpsRegistry.SoloMedian(gemmaBuild, "M3"); n != 2 {
+		t.Fatalf("solo samples after idle heartbeat = %d, want 2", n)
+	}
+
+	// Co-resident model busy → gemma's EWMA is a contended rate: NOT solo.
+	reg.Heartbeat("box", soloHeartbeat([]protocol.BackendSlotCapacity{
+		{Model: gemmaBuild, State: "running", NumRunning: 1, ObservedDecodeTPS: 5},
+		{Model: gptossBuild, State: "running", NumRunning: 1, ObservedDecodeTPS: 40},
+	}))
+	// Same-slot queue depth also disqualifies (batch of 2 on one model).
+	reg.Heartbeat("box", soloHeartbeat([]protocol.BackendSlotCapacity{
+		{Model: gemmaBuild, State: "running", NumRunning: 1, NumWaiting: 1, ObservedDecodeTPS: 6},
+	}))
+	if _, n := reg.tpsRegistry.SoloMedian(gemmaBuild, "M3"); n != 2 {
+		t.Fatalf("solo samples after contended heartbeats = %d, want 2 (contended samples must be rejected)", n)
+	}
+	// The load-inclusive store keeps EVERY sample (TTFT estimation semantics).
+	if got := reg.tpsRegistry.Median(gemmaBuild, "M3"); got != (6+14)/2.0 {
+		t.Fatalf("load-inclusive median = %v, want 10 (all four gemma samples recorded: 14,15,5,6)", got)
+	}
+}
+
+// --- Resolver fallback chain ---
+
+func TestResolvedSoloModelTPSFallbackChain(t *testing.T) {
+	reg := New(testLogger())
+	enablePerModelQualityCap(t, reg, gemmaBuild+"=14", "", "")
+	p := mixedBoxProvider(t, reg, "mixed", 93) // ChipFamily "M3"
+
+	// (c) seed only — no solo samples anywhere.
+	if got := resolveSolo(reg, p, gemmaBuild); got.tps != 14 || !got.perModel {
+		t.Fatalf("seed fallback = %+v, want tps 14, perModel true", got)
+	}
+
+	// (b) cross-chip pooled median once total n ≥ floor (5), even though the
+	// provider's own chip family (M3) has no samples yet.
+	for i, v := range []float64{16, 16, 16, 20, 20} {
+		chip := "M1"
+		if i >= 3 {
+			chip = "M2"
+		}
+		reg.tpsRegistry.RecordSolo(gemmaBuild, chip, v)
+	}
+	if got := resolveSolo(reg, p, gemmaBuild); got.tps != 16 || !got.perModel {
+		t.Fatalf("cross-chip fallback = %+v, want tps 16 (pooled median), perModel true", got)
+	}
+
+	// (a) per-(model, chip) median wins over cross-chip and seed once trusted.
+	for _, v := range []float64{10, 12, 12, 12, 30} {
+		reg.tpsRegistry.RecordSolo(gemmaBuild, "M3", v)
+	}
+	if got := resolveSolo(reg, p, gemmaBuild); got.tps != 12 || !got.perModel {
+		t.Fatalf("per-chip solo median = %+v, want tps 12, perModel true", got)
+	}
+
+	// (d) a model with no solo data and no seed falls back to the provider-level
+	// rate (the registration benchmark).
+	if got := resolveSolo(reg, p, gptossBuild); got.tps != 93 || got.perModel {
+		t.Fatalf("provider-level fallback = %+v, want tps 93, perModel false", got)
+	}
+}
+
+func TestResolvedSoloModelTPSMinSampleFloor(t *testing.T) {
+	reg := New(testLogger())
+	// Floor raised to 6: five per-chip samples are NOT yet trusted.
+	enablePerModelQualityCap(t, reg, "", "", "6")
+	p := mixedBoxProvider(t, reg, "mixed", 93)
+	for i := 0; i < 5; i++ {
+		reg.tpsRegistry.RecordSolo(gemmaBuild, "M3", 14)
+	}
+	if got := resolveSolo(reg, p, gemmaBuild); got.tps != 93 || got.perModel {
+		t.Fatalf("below min samples = %+v, want provider-level (93, perModel false)", got)
+	}
+	reg.tpsRegistry.RecordSolo(gemmaBuild, "M3", 14)
+	if got := resolveSolo(reg, p, gemmaBuild); got.tps != 14 || !got.perModel {
+		t.Fatalf("at min samples = %+v, want (14, perModel true)", got)
+	}
+}
+
+func TestResolvedSoloModelTPSKillSwitch(t *testing.T) {
+	reg := New(testLogger())
+	// Kill switch OFF: solo medians and seed present but must be ignored —
+	// resolvedDecodeTPS(p) exactly, at every consumer.
+	enablePerModelQualityCap(t, reg, gemmaBuild+"=14", "false", "")
+	p := mixedBoxProvider(t, reg, "mixed", 93)
+	for i := 0; i < 10; i++ {
+		reg.tpsRegistry.RecordSolo(gemmaBuild, "M3", 14)
+	}
+	if got := resolveSolo(reg, p, gemmaBuild); got.tps != 93 || got.perModel {
+		t.Fatalf("kill switch off: resolver = %+v, want provider-level (93, perModel false)", got)
+	}
+}
+
+// --- Seed parsing ---
+
+func TestParseModelFloatMapSeedEntries(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+		want map[string]float64
+	}{
+		{"empty", "", nil},
+		{"single", "gemma-4-26b-qat-4bit=14", map[string]float64{"gemma-4-26b-qat-4bit": 14}},
+		{"multi_with_spaces", " gemma-4-26b-qat-4bit=14 , gpt-oss-20b=30 ", map[string]float64{"gemma-4-26b-qat-4bit": 14, "gpt-oss-20b": 30}},
+		{"uppercase_key_lowered", "GPT-OSS-20B=30", map[string]float64{"gpt-oss-20b": 30}},
+		{"bad_entries_skipped", "bogus,=3,x=,gemma=abc,gemma=0,gemma=-2,good=14.5", map[string]float64{"good": 14.5}},
+		{"all_invalid", "bogus,=3,x=abc", nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseModelFloatMap(tc.raw)
+			if len(got) != len(tc.want) {
+				t.Fatalf("parseModelFloatMap(%q) = %v, want %v", tc.raw, got, tc.want)
+			}
+			for k, v := range tc.want {
+				if got[k] != v {
+					t.Fatalf("parseModelFloatMap(%q)[%q] = %v, want %v", tc.raw, k, got[k], v)
+				}
+			}
+		})
+	}
+}
+
+// TestSoloSeedColdStart is the restart scenario: the TPS registry is in-memory
+// and wiped by a coordinator restart, so on a fresh registry the seed env must
+// carry the per-model cap alone (gemma-qat solo ≈ 14 from prod data → cap 2)
+// until gated solo samples re-accumulate.
+func TestSoloSeedColdStart(t *testing.T) {
+	reg := New(testLogger()) // fresh registry == post-restart state
+	enablePerModelQualityCap(t, reg, "gemma-4-26b-qat-4bit=14,gpt-oss-20b=30", "", "")
+	p := mixedBoxProvider(t, reg, "mixed", 93)
+
+	if got := effCapResolved(reg, p, gemmaBuild); got != 2 {
+		t.Fatalf("cold-start gemma cap = %d, want 2 (seed 14 ≤ floor 15 → qc 1 × 1.2)", got)
+	}
+	if got := effCapResolved(reg, p, gptossBuild); got != 4 {
+		t.Fatalf("cold-start gpt-oss cap = %d, want 4 (seed 30 → qc 3 → ceil(3.6))", got)
+	}
+}
+
+// --- Warm-pool consistency ---
+
+// TestWarmPoolSnapshotDecodeSampleUsesSoloResolver: the warm-pool fleet
+// snapshot's decode samples (→ soloDecodeTPS → warm-target quality
+// concurrency) must come from the SAME solo resolver as the admission cap —
+// here the gemma solo median (14) — not the collapsed under-load slot EWMA
+// (2.6) and not the provider-level benchmark (93). Otherwise admission would
+// cap a box at 2 while the warm-pool controller plans capacity as if it could
+// take 19.
+func TestWarmPoolSnapshotDecodeSampleUsesSoloResolver(t *testing.T) {
+	reg := New(testLogger())
+	enablePerModelQualityCap(t, reg, "", "", "")
+	p := makeSchedulerProvider(t, reg, "gemma-box", gemmaBuild, 93)
+	p.mu.Lock()
+	p.BackendCapacity.Slots[0].ObservedDecodeTPS = 2.6 // collapsed contended EWMA
+	p.mu.Unlock()
+	for i := 0; i < 5; i++ {
+		reg.tpsRegistry.RecordSolo(gemmaBuild, "M3", 14)
+	}
+
+	snap := reg.warmPoolFleetSnapshot(time.Now())[gemmaBuild]
+	if snap.soloDecodeTPS != 14 {
+		t.Fatalf("warm-pool soloDecodeTPS = %v, want 14 (solo median; EWMA 2.6 and benchmark 93 must not feed the warm target)", snap.soloDecodeTPS)
+	}
+	if snap.serviceDecodeTPS != 2.6 {
+		t.Fatalf("warm-pool serviceDecodeTPS = %v, want observed 2.6 (E[S] keeps load-inclusive semantics)", snap.serviceDecodeTPS)
+	}
+}
+
+// TestSoloResolverConvergesAcrossManyBoxes is a small sanity spread: several
+// mixed boxes with different provider-level benchmarks all resolve the SAME
+// per-model rate once the solo median is trusted — the property that makes
+// caps chip-honest instead of benchmark-inherited.
+func TestSoloResolverConvergesAcrossManyBoxes(t *testing.T) {
+	reg := New(testLogger())
+	enablePerModelQualityCap(t, reg, "", "", "")
+	for i := 0; i < 5; i++ {
+		reg.tpsRegistry.RecordSolo(gemmaBuild, "M3", 14)
+	}
+	for i, bench := range []float64{58, 73, 93} {
+		p := mixedBoxProvider(t, reg, fmt.Sprintf("box-%d", i), bench)
+		if got := effCapResolved(reg, p, gemmaBuild); got != 2 {
+			t.Fatalf("box benchmarked %v tok/s: gemma cap = %d, want 2 regardless of the provider-level benchmark", bench, got)
+		}
+	}
+}

--- a/coordinator/registry/solo_tps_test.go
+++ b/coordinator/registry/solo_tps_test.go
@@ -218,6 +218,41 @@ func TestSoloRecordingOnlySamplesActiveSlot(t *testing.T) {
 	}
 }
 
+// TestSoloRecordingRequiresRunningDecode is the queued-but-not-running
+// regression (Finding 3 of the final round): a box with one QUEUED request and
+// no running decode is box-wide uncontended (soloEligible), and the owning slot
+// has NumWaiting > 0 — but its ObservedDecodeTPS is a retained EWMA with no
+// running decode behind it. The prior round's NumRunning+NumWaiting > 0 gate
+// would mint that stale EWMA as a fresh solo sample every heartbeat; the
+// tightened NumRunning > 0 gate must not. A running-and-uncontended heartbeat
+// still records. Fails without the NumRunning > 0 gate in the heartbeat ingest.
+func TestSoloRecordingRequiresRunningDecode(t *testing.T) {
+	reg := New(testLogger())
+	makeSchedulerProvider(t, reg, "box", gemmaBuild, 93)
+
+	// Queued but NOT decoding: NumRunning 0 / NumWaiting 1. Box-wide load = 1
+	// (uncontended), but observed_decode_tps is a stale retained EWMA — no
+	// running request produced it, so it must NOT be sampled.
+	reg.Heartbeat("box", soloHeartbeat([]protocol.BackendSlotCapacity{
+		{Model: gemmaBuild, State: "running", NumRunning: 0, NumWaiting: 1, ObservedDecodeTPS: 14},
+	}))
+	if _, n := reg.tpsRegistry.SoloMedian(gemmaBuild, "M3"); n != 0 {
+		t.Fatalf("solo samples after queued-but-not-running heartbeat = %d, want 0 (stale EWMA, no running decode)", n)
+	}
+
+	// Running and uncontended: NumRunning 1 / NumWaiting 0 → a real solo sample.
+	reg.Heartbeat("box", soloHeartbeat([]protocol.BackendSlotCapacity{
+		{Model: gemmaBuild, State: "running", NumRunning: 1, NumWaiting: 0, ObservedDecodeTPS: 12},
+	}))
+	if _, n := reg.tpsRegistry.SoloMedian(gemmaBuild, "M3"); n != 1 {
+		t.Fatalf("solo samples after running-uncontended heartbeat = %d, want 1", n)
+	}
+	// The load-inclusive store records BOTH heartbeats' EWMAs regardless.
+	if got := reg.tpsRegistry.Median(gemmaBuild, "M3"); got != (12+14)/2.0 {
+		t.Fatalf("load-inclusive median = %v, want 13 (both EWMAs recorded: 14, 12)", got)
+	}
+}
+
 // --- Resolver fallback chain ---
 
 func TestResolvedSoloModelTPSFallbackChain(t *testing.T) {

--- a/coordinator/registry/solo_tps_test.go
+++ b/coordinator/registry/solo_tps_test.go
@@ -114,7 +114,13 @@ func TestSoloMedianFIFOCap(t *testing.T) {
 	}
 }
 
-func TestSoloMedianAllChipsPoolsAcrossFamilies(t *testing.T) {
+// TestSoloMedianAllChipsMinOfClassMedians pins the CONSERVATIVE cross-class
+// transfer: SoloMedianAllChips returns the MINIMUM of the per-class medians
+// (never the pooled median, which a fast, sample-heavy class can dominate) plus
+// the TOTAL sample count. A slow class (m1, median 20) and a fast class (m4,
+// median 30) → the min (20), so the rate can never exceed the slowest class's
+// typical rate and can never over-cap a slow box.
+func TestSoloMedianAllChipsMinOfClassMedians(t *testing.T) {
 	r := NewTPSRegistry()
 	r.RecordSolo("model", "m1", 20)
 	r.RecordSolo("model", "m1", 20)
@@ -123,8 +129,19 @@ func TestSoloMedianAllChipsPoolsAcrossFamilies(t *testing.T) {
 	r.RecordSolo("model", "m4", 30)
 	r.RecordSolo("other-model", "m4", 999) // different model must not pollute
 	tps, n := r.SoloMedianAllChips("model")
-	if tps != 30 || n != 5 {
-		t.Fatalf("SoloMedianAllChips = (%v, %d), want (30, 5)", tps, n)
+	if tps != 20 || n != 5 {
+		t.Fatalf("SoloMedianAllChips = (%v, %d), want (20, 5) — min of class medians, total count", tps, n)
+	}
+
+	// A fast class with MANY samples must not drag the min up: the pooled median
+	// would be 30, but the slow class's median (12) is what a slow box can do.
+	r2 := NewTPSRegistry()
+	for i := 0; i < 20; i++ {
+		r2.RecordSolo("m", "M4|Max", 30) // fast, sample-heavy
+	}
+	r2.RecordSolo("m", "M1", 12) // slow, one sample
+	if tps, n := r2.SoloMedianAllChips("m"); tps != 12 || n != 21 {
+		t.Fatalf("SoloMedianAllChips = (%v, %d), want (12, 21) — fast class must not dominate the min", tps, n)
 	}
 }
 
@@ -153,11 +170,12 @@ func TestSoloRecordingGatedOnUncontendedBox(t *testing.T) {
 	makeSchedulerProvider(t, reg, "box", gemmaBuild, 93)
 
 	// Uncontended: gemma serving exactly the sample-generating request.
+	// Solo samples are keyed by chip CLASS ("M3|Max"), not family ("M3").
 	reg.Heartbeat("box", soloHeartbeat([]protocol.BackendSlotCapacity{
 		{Model: gemmaBuild, State: "running", NumRunning: 1, ObservedDecodeTPS: 14},
 		{Model: gptossBuild, State: "idle", NumRunning: 0, NumWaiting: 0},
 	}))
-	if _, n := reg.tpsRegistry.SoloMedian(gemmaBuild, "M3"); n != 1 {
+	if _, n := reg.tpsRegistry.SoloMedian(gemmaBuild, "M3|Max"); n != 1 {
 		t.Fatalf("solo samples after uncontended heartbeat = %d, want 1", n)
 	}
 
@@ -167,7 +185,7 @@ func TestSoloRecordingGatedOnUncontendedBox(t *testing.T) {
 	reg.Heartbeat("box", soloHeartbeat([]protocol.BackendSlotCapacity{
 		{Model: gemmaBuild, State: "idle", ObservedDecodeTPS: 15},
 	}))
-	if _, n := reg.tpsRegistry.SoloMedian(gemmaBuild, "M3"); n != 1 {
+	if _, n := reg.tpsRegistry.SoloMedian(gemmaBuild, "M3|Max"); n != 1 {
 		t.Fatalf("solo samples after idle heartbeat = %d, want 1 (idle EWMA must not be recorded)", n)
 	}
 
@@ -180,7 +198,7 @@ func TestSoloRecordingGatedOnUncontendedBox(t *testing.T) {
 	reg.Heartbeat("box", soloHeartbeat([]protocol.BackendSlotCapacity{
 		{Model: gemmaBuild, State: "running", NumRunning: 1, NumWaiting: 1, ObservedDecodeTPS: 6},
 	}))
-	if _, n := reg.tpsRegistry.SoloMedian(gemmaBuild, "M3"); n != 1 {
+	if _, n := reg.tpsRegistry.SoloMedian(gemmaBuild, "M3|Max"); n != 1 {
 		t.Fatalf("solo samples after contended heartbeats = %d, want 1 (contended samples must be rejected)", n)
 	}
 	// The load-inclusive store keeps EVERY sample (TTFT estimation semantics).
@@ -206,10 +224,10 @@ func TestSoloRecordingOnlySamplesActiveSlot(t *testing.T) {
 			{Model: gptossBuild, State: "idle", ObservedDecodeTPS: 60}, // stale EWMA, no request
 		}))
 	}
-	if _, n := reg.tpsRegistry.SoloMedian(gemmaBuild, "M3"); n != 5 {
+	if _, n := reg.tpsRegistry.SoloMedian(gemmaBuild, "M3|Max"); n != 5 {
 		t.Fatalf("active-slot solo samples = %d, want 5", n)
 	}
-	if _, n := reg.tpsRegistry.SoloMedian(gptossBuild, "M3"); n != 0 {
+	if _, n := reg.tpsRegistry.SoloMedian(gptossBuild, "M3|Max"); n != 0 {
 		t.Fatalf("idle co-resident slot recorded %d solo samples, want 0 (stale EWMA contamination)", n)
 	}
 	// The load-inclusive store still sees both slots' EWMAs.
@@ -236,7 +254,7 @@ func TestSoloRecordingRequiresRunningDecode(t *testing.T) {
 	reg.Heartbeat("box", soloHeartbeat([]protocol.BackendSlotCapacity{
 		{Model: gemmaBuild, State: "running", NumRunning: 0, NumWaiting: 1, ObservedDecodeTPS: 14},
 	}))
-	if _, n := reg.tpsRegistry.SoloMedian(gemmaBuild, "M3"); n != 0 {
+	if _, n := reg.tpsRegistry.SoloMedian(gemmaBuild, "M3|Max"); n != 0 {
 		t.Fatalf("solo samples after queued-but-not-running heartbeat = %d, want 0 (stale EWMA, no running decode)", n)
 	}
 
@@ -244,7 +262,7 @@ func TestSoloRecordingRequiresRunningDecode(t *testing.T) {
 	reg.Heartbeat("box", soloHeartbeat([]protocol.BackendSlotCapacity{
 		{Model: gemmaBuild, State: "running", NumRunning: 1, NumWaiting: 0, ObservedDecodeTPS: 12},
 	}))
-	if _, n := reg.tpsRegistry.SoloMedian(gemmaBuild, "M3"); n != 1 {
+	if _, n := reg.tpsRegistry.SoloMedian(gemmaBuild, "M3|Max"); n != 1 {
 		t.Fatalf("solo samples after running-uncontended heartbeat = %d, want 1", n)
 	}
 	// The load-inclusive store records BOTH heartbeats' EWMAs regardless.
@@ -290,6 +308,137 @@ func TestResolvedSoloModelTPSFallbackChain(t *testing.T) {
 	// rate (the registration benchmark).
 	if got := resolveSolo(reg, p, gptossBuild); got.tps != 93 || got.perModel {
 		t.Fatalf("provider-level fallback = %+v, want tps 93, perModel false", got)
+	}
+}
+
+// setChipClass overrides a provider's chip family/tier so tests can drive the
+// class-keyed solo resolver (chipClassKey = family|tier).
+func setChipClass(p *Provider, family, tier string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.Hardware.ChipFamily = family
+	p.Hardware.ChipTier = tier
+}
+
+// TestSoloResolverChipClassKeying is the correctness-critical safety test for
+// Fix 2: solo caps are keyed by chip CLASS (family+tier), and the cross-class
+// fallback is the MIN of per-class medians. Together these guarantee the
+// resolver never hands a slow box a rate faster than its own class demonstrated
+// — the over-admission that collapses a slow box under load.
+func TestSoloResolverChipClassKeying(t *testing.T) {
+	// (a) same-class primary lookup applies: an M3|Max box uses M3|Max samples.
+	t.Run("same_class_primary", func(t *testing.T) {
+		reg := New(testLogger())
+		enablePerModelQualityCap(t, reg, "", "", "")
+		p := mixedBoxProvider(t, reg, "m3max", 93)
+		setChipClass(p, "M3", "Max")
+		for _, v := range []float64{10, 12, 12, 12, 30} { // median 12
+			reg.tpsRegistry.RecordSolo(gemmaBuild, "M3|Max", v)
+		}
+		if got := resolveSolo(reg, p, gemmaBuild); got.tps != 12 || !got.perModel {
+			t.Fatalf("same-class resolver = %+v, want tps 12, perModel true", got)
+		}
+	})
+
+	// (b) cross-tier isolation: an M4|Pro box must NOT inherit the fast M4|Max
+	// tier's rate. With family-only keying both tiers pooled under "M4" and the
+	// Pro box got the Max rate; class keying keeps them separate, so the Pro box
+	// resolves to its OWN slower median.
+	t.Run("cross_tier_isolation", func(t *testing.T) {
+		reg := New(testLogger())
+		enablePerModelQualityCap(t, reg, "", "", "")
+		p := mixedBoxProvider(t, reg, "m4pro", 93)
+		setChipClass(p, "M4", "Pro")
+		for i := 0; i < 5; i++ {
+			reg.tpsRegistry.RecordSolo(gemmaBuild, "M4|Max", 40) // fast tier
+		}
+		for _, v := range []float64{14, 15, 15, 15, 16} { // slow tier, median 15
+			reg.tpsRegistry.RecordSolo(gemmaBuild, "M4|Pro", v)
+		}
+		if got := resolveSolo(reg, p, gemmaBuild); got.tps != 15 {
+			t.Fatalf("M4|Pro resolved %v, want 15 (its own class median), NOT the M4|Max 40", got.tps)
+		}
+	})
+
+	// (c) conservative cross-class fallback: a box whose own class has no samples
+	// falls to SoloMedianAllChips, which returns the MIN of class medians — the
+	// slow class (10), never the fast one (40). A slow box can never be over-capped.
+	t.Run("conservative_cross_class_fallback", func(t *testing.T) {
+		reg := New(testLogger())
+		enablePerModelQualityCap(t, reg, "", "", "")
+		p := mixedBoxProvider(t, reg, "m2max", 93)
+		setChipClass(p, "M2", "Max") // no M2|Max samples exist
+		for i := 0; i < 5; i++ {
+			reg.tpsRegistry.RecordSolo(gemmaBuild, "M4|Max", 40) // fast class
+		}
+		for i := 0; i < 5; i++ {
+			reg.tpsRegistry.RecordSolo(gemmaBuild, "M1", 10) // slow class
+		}
+		if got := resolveSolo(reg, p, gemmaBuild); got.tps != 10 || !got.perModel {
+			t.Fatalf("cross-class fallback = %+v, want tps 10 (min of class medians), NOT the fast 40", got)
+		}
+	})
+
+	// (d) cold-start safety: a cold-class box with only FASTER classes present
+	// still gets the conservative min of those class medians (25, the slower of
+	// the two), never the fastest (40).
+	t.Run("cold_class_conservative_min", func(t *testing.T) {
+		reg := New(testLogger())
+		enablePerModelQualityCap(t, reg, "", "", "")
+		p := mixedBoxProvider(t, reg, "m2ultra", 93)
+		setChipClass(p, "M2", "Ultra") // no M2|Ultra samples exist
+		for i := 0; i < 5; i++ {
+			reg.tpsRegistry.RecordSolo(gemmaBuild, "M4|Max", 40) // fastest
+		}
+		for i := 0; i < 5; i++ {
+			reg.tpsRegistry.RecordSolo(gemmaBuild, "M3|Max", 25) // slower of the two
+		}
+		if got := resolveSolo(reg, p, gemmaBuild); got.tps != 25 {
+			t.Fatalf("cold-class resolver = %v, want 25 (conservative min), never the fastest 40", got.tps)
+		}
+	})
+}
+
+// TestSoloClassKeyingEndToEndNoCrossTierOverCap drives the REAL heartbeat
+// ingest so both the ingest key (registry.go) and the resolver key
+// (concurrency_cap.go) are exercised: two same-family boxes of different tiers
+// (M4 Max fast, M4 Pro slow) serving gemma solo. With chip-CLASS keying the
+// slow box's cap comes from its OWN 14 tok/s (→ cap 2) while the fast box keeps
+// its wide cap from 40 tok/s. With family-only keying both tiers pool under
+// "M4" and the slow box's cap inflates from the fast box's samples — the exact
+// cross-tier over-admission this fix prevents. Reverting either the ingest or
+// the resolver keying trips one of the two assertions.
+func TestSoloClassKeyingEndToEndNoCrossTierOverCap(t *testing.T) {
+	reg := New(testLogger())
+	enablePerModelQualityCap(t, reg, "", "", "5")
+
+	mk := func(id, family, tier string) *Provider {
+		p := makeSchedulerProvider(t, reg, id, gemmaBuild, 93)
+		p.mu.Lock()
+		p.Hardware.ChipFamily = family
+		p.Hardware.ChipTier = tier
+		p.mu.Unlock()
+		return p
+	}
+	fast := mk("fast", "M4", "Max")
+	slow := mk("slow", "M4", "Pro")
+
+	// Five uncontended solo heartbeats each: fast decodes gemma at 40, slow at
+	// 14. One running gemma request per heartbeat gates the sample in.
+	for i := 0; i < 5; i++ {
+		reg.Heartbeat("fast", soloHeartbeat([]protocol.BackendSlotCapacity{
+			{Model: gemmaBuild, State: "running", NumRunning: 1, ObservedDecodeTPS: 40},
+		}))
+		reg.Heartbeat("slow", soloHeartbeat([]protocol.BackendSlotCapacity{
+			{Model: gemmaBuild, State: "running", NumRunning: 1, ObservedDecodeTPS: 14},
+		}))
+	}
+
+	if got := effCapResolved(reg, slow, gemmaBuild); got != 2 {
+		t.Fatalf("slow (M4|Pro) gemma cap = %d, want 2 (its own 14 tok/s); family keying inflates it from the fast M4|Max box", got)
+	}
+	if got := effCapResolved(reg, fast, gemmaBuild); got <= 2 {
+		t.Fatalf("fast (M4|Max) gemma cap = %d, want wide (its own 40 tok/s), not dragged down cross-tier", got)
 	}
 }
 

--- a/coordinator/registry/solo_tps_test.go
+++ b/coordinator/registry/solo_tps_test.go
@@ -269,6 +269,10 @@ func TestParseModelFloatMapSeedEntries(t *testing.T) {
 		{"multi_with_spaces", " gemma-4-26b-qat-4bit=14 , gpt-oss-20b=30 ", map[string]float64{"gemma-4-26b-qat-4bit": 14, "gpt-oss-20b": 30}},
 		{"uppercase_key_lowered", "GPT-OSS-20B=30", map[string]float64{"gpt-oss-20b": 30}},
 		{"bad_entries_skipped", "bogus,=3,x=,gemma=abc,gemma=0,gemma=-2,good=14.5", map[string]float64{"good": 14.5}},
+		// strconv.ParseFloat accepts NaN/±Inf spellings; NaN in particular
+		// slips past a naive v <= 0 filter (NaN comparisons are always false)
+		// and would drive the cap math to an implementation-defined integer.
+		{"non_finite_skipped", "a=NaN,b=+Inf,c=Inf,d=-Inf,e=Infinity,good=2", map[string]float64{"good": 2}},
 		{"all_invalid", "bogus,=3,x=abc", nil},
 	}
 	for _, tc := range cases {

--- a/coordinator/registry/solo_tps_test.go
+++ b/coordinator/registry/solo_tps_test.go
@@ -143,9 +143,11 @@ func soloHeartbeat(slots []protocol.BackendSlotCapacity) *protocol.HeartbeatMess
 
 // TestSoloRecordingGatedOnUncontendedBox drives the REAL heartbeat ingest
 // path: a slot EWMA becomes a solo sample only when the whole box has at most
-// one running-or-waiting request (the sample-generating request itself). Any
-// co-resident activity — another model running, or waiting queue depth —
-// disqualifies the sample; the load-inclusive store records regardless.
+// one running-or-waiting request (the sample-generating request itself) AND
+// the slot is the one running it. Any co-resident activity — another model
+// running, or waiting queue depth — disqualifies the sample, and a fully idle
+// box records nothing (a decayed EWMA with no active request is not a fresh
+// observation); the load-inclusive store records regardless.
 func TestSoloRecordingGatedOnUncontendedBox(t *testing.T) {
 	reg := New(testLogger())
 	makeSchedulerProvider(t, reg, "box", gemmaBuild, 93)
@@ -159,12 +161,14 @@ func TestSoloRecordingGatedOnUncontendedBox(t *testing.T) {
 		t.Fatalf("solo samples after uncontended heartbeat = %d, want 1", n)
 	}
 
-	// Fully idle box reporting a (decayed) EWMA also qualifies.
+	// Fully idle box: the reported EWMA is a stale decayed value with no
+	// request behind it — NOT a fresh solo observation. Recording it would let
+	// an idle box mint one bogus sample per heartbeat.
 	reg.Heartbeat("box", soloHeartbeat([]protocol.BackendSlotCapacity{
 		{Model: gemmaBuild, State: "idle", ObservedDecodeTPS: 15},
 	}))
-	if _, n := reg.tpsRegistry.SoloMedian(gemmaBuild, "M3"); n != 2 {
-		t.Fatalf("solo samples after idle heartbeat = %d, want 2", n)
+	if _, n := reg.tpsRegistry.SoloMedian(gemmaBuild, "M3"); n != 1 {
+		t.Fatalf("solo samples after idle heartbeat = %d, want 1 (idle EWMA must not be recorded)", n)
 	}
 
 	// Co-resident model busy → gemma's EWMA is a contended rate: NOT solo.
@@ -176,12 +180,41 @@ func TestSoloRecordingGatedOnUncontendedBox(t *testing.T) {
 	reg.Heartbeat("box", soloHeartbeat([]protocol.BackendSlotCapacity{
 		{Model: gemmaBuild, State: "running", NumRunning: 1, NumWaiting: 1, ObservedDecodeTPS: 6},
 	}))
-	if _, n := reg.tpsRegistry.SoloMedian(gemmaBuild, "M3"); n != 2 {
-		t.Fatalf("solo samples after contended heartbeats = %d, want 2 (contended samples must be rejected)", n)
+	if _, n := reg.tpsRegistry.SoloMedian(gemmaBuild, "M3"); n != 1 {
+		t.Fatalf("solo samples after contended heartbeats = %d, want 1 (contended samples must be rejected)", n)
 	}
 	// The load-inclusive store keeps EVERY sample (TTFT estimation semantics).
 	if got := reg.tpsRegistry.Median(gemmaBuild, "M3"); got != (6+14)/2.0 {
 		t.Fatalf("load-inclusive median = %v, want 10 (all four gemma samples recorded: 14,15,5,6)", got)
+	}
+}
+
+// TestSoloRecordingOnlySamplesActiveSlot is the idle-co-resident contamination
+// regression: with model A running the box's ONE active request, model B's
+// idle slot keeps re-reporting its stale decayed EWMA in every heartbeat.
+// Only A may be sampled — otherwise B accumulates one duplicate "solo"
+// sample per ~30s heartbeat from a single long-past observation, reaches the
+// min-sample trust floor without any real measurement, and B's quality cap is
+// then derived from a rate no request produced.
+func TestSoloRecordingOnlySamplesActiveSlot(t *testing.T) {
+	reg := New(testLogger())
+	makeSchedulerProvider(t, reg, "box", gemmaBuild, 93)
+
+	for i := 0; i < 5; i++ {
+		reg.Heartbeat("box", soloHeartbeat([]protocol.BackendSlotCapacity{
+			{Model: gemmaBuild, State: "running", NumRunning: 1, ObservedDecodeTPS: 14},
+			{Model: gptossBuild, State: "idle", ObservedDecodeTPS: 60}, // stale EWMA, no request
+		}))
+	}
+	if _, n := reg.tpsRegistry.SoloMedian(gemmaBuild, "M3"); n != 5 {
+		t.Fatalf("active-slot solo samples = %d, want 5", n)
+	}
+	if _, n := reg.tpsRegistry.SoloMedian(gptossBuild, "M3"); n != 0 {
+		t.Fatalf("idle co-resident slot recorded %d solo samples, want 0 (stale EWMA contamination)", n)
+	}
+	// The load-inclusive store still sees both slots' EWMAs.
+	if got := reg.tpsRegistry.Median(gptossBuild, "M3"); got != 60 {
+		t.Fatalf("load-inclusive median for idle slot = %v, want 60", got)
 	}
 }
 

--- a/coordinator/registry/tps_registry.go
+++ b/coordinator/registry/tps_registry.go
@@ -19,11 +19,16 @@ import (
 //     while the WHOLE box was uncontended. Feeds the quality-concurrency cap,
 //     which needs a static solo rate that cannot collapse under the very
 //     overload the cap exists to prevent.
+//   - prefillSamples (RecordPrefill/PrefillMedian, prefill_tps.go): observed
+//     per-request prefill EWMAs. Feeds the TTFT estimate's prefill rate for
+//     providers that don't (yet) report their own measurement — the
+//     prefill-honest replacement for the static decode×ratio chain.
 type TPSRegistry struct {
-	mu          sync.RWMutex
-	samples     map[tpsKey][]float64
-	soloSamples map[tpsKey][]float64
-	maxSamples  int
+	mu             sync.RWMutex
+	samples        map[tpsKey][]float64
+	soloSamples    map[tpsKey][]float64
+	prefillSamples map[tpsKey][]float64
+	maxSamples     int
 }
 
 type tpsKey struct {
@@ -33,9 +38,10 @@ type tpsKey struct {
 
 func NewTPSRegistry() *TPSRegistry {
 	return &TPSRegistry{
-		samples:     make(map[tpsKey][]float64),
-		soloSamples: make(map[tpsKey][]float64),
-		maxSamples:  50, // keep last 50 observations per model+chip
+		samples:        make(map[tpsKey][]float64),
+		soloSamples:    make(map[tpsKey][]float64),
+		prefillSamples: make(map[tpsKey][]float64),
+		maxSamples:     50, // keep last 50 observations per model+chip
 	}
 }
 

--- a/coordinator/registry/tps_registry.go
+++ b/coordinator/registry/tps_registry.go
@@ -8,10 +8,22 @@ import (
 // TPSRegistry aggregates observed decode TPS values from heartbeats,
 // keyed by model and chip family. Used to provide fleet-calibrated
 // estimates for providers that haven't reported observed TPS yet.
+//
+// It holds two independent sample stores with the same 50-sample FIFO+median
+// shape but deliberately different ingest semantics:
+//
+//   - samples (Record/Median): EVERY reported EWMA, including under-load ones.
+//     Feeds fleetMedianTPS → TTFT estimation, whose load-inclusive semantics
+//     are intentional (an estimate of what a request will actually see).
+//   - soloSamples (RecordSolo/SoloMedian, solo_tps.go): only samples taken
+//     while the WHOLE box was uncontended. Feeds the quality-concurrency cap,
+//     which needs a static solo rate that cannot collapse under the very
+//     overload the cap exists to prevent.
 type TPSRegistry struct {
-	mu         sync.RWMutex
-	samples    map[tpsKey][]float64
-	maxSamples int
+	mu          sync.RWMutex
+	samples     map[tpsKey][]float64
+	soloSamples map[tpsKey][]float64
+	maxSamples  int
 }
 
 type tpsKey struct {
@@ -21,8 +33,9 @@ type tpsKey struct {
 
 func NewTPSRegistry() *TPSRegistry {
 	return &TPSRegistry{
-		samples:    make(map[tpsKey][]float64),
-		maxSamples: 50, // keep last 50 observations per model+chip
+		samples:     make(map[tpsKey][]float64),
+		soloSamples: make(map[tpsKey][]float64),
+		maxSamples:  50, // keep last 50 observations per model+chip
 	}
 }
 

--- a/coordinator/registry/v2_capacity_clamp.go
+++ b/coordinator/registry/v2_capacity_clamp.go
@@ -27,6 +27,13 @@ import (
 // and they keep today's clampBackendCapacity 24-ceiling behavior exactly.
 // An empty EIGENINFERENCE_V2_VERSION_FLOOR disables the audit entirely
 // (zero behavior change); an empty provider version is below any floor.
+//
+// The ceiling is BOX-WIDE, not per-slot: the v2 engine runs one scheduler for
+// the whole box. So beside this per-slot ingest clamp, the provider-LEVEL
+// admission valve (Provider.maxConcurrency → v2BoxCeilingClamp, registry.go)
+// observes the same ceiling for >=floor providers — otherwise a v2 box with
+// multiple warm models would admit slots × ceiling in aggregate under the
+// legacy token-budget valve of 24.
 
 // defaultV2MaxConcurrencyCeiling is the ceiling applied to >=floor providers
 // when EIGENINFERENCE_V2_MAX_CONCURRENCY_CEILING is unset. Matches the engine's

--- a/coordinator/registry/v2_capacity_clamp.go
+++ b/coordinator/registry/v2_capacity_clamp.go
@@ -55,8 +55,8 @@ func SetV2ConcurrencyClamp(floor string, ceiling int) {
 	v2MaxConcurrencyCeiling = ceiling
 }
 
-// V2ConcurrencyClampConfig returns the configured (floor, ceiling) pair.
-// Exposed for startup logging.
+// V2ConcurrencyClampConfig returns the configured (floor, ceiling) pair
+// (tests pin the setter's sanitization through it).
 func V2ConcurrencyClampConfig() (string, int) {
 	return v2VersionFloor, v2MaxConcurrencyCeiling
 }

--- a/coordinator/registry/v2_capacity_clamp.go
+++ b/coordinator/registry/v2_capacity_clamp.go
@@ -1,0 +1,144 @@
+package registry
+
+import (
+	"log/slog"
+	"strings"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+)
+
+// Version-keyed heartbeat sanity clamp — the permanent mixed-fleet audit of the
+// v0.7.5 "one engine, fail loud" promise.
+//
+// Engine V2 providers (>= EIGENINFERENCE_V2_VERSION_FLOOR) truthfully report
+// their engine concurrency cap (<= 4 by construction; the legacy scheduler and
+// its silent-fallback cap of 24 are DELETED in v0.7.5). If a >=floor box ever
+// heartbeats a chat-slot max_concurrency above the v2 ceiling again, the
+// silent-legacy-fallback bug (2026-07-06 gemma postmortem, layers 5-6: first
+// engine claims the whole KV budget -> later models fall back to the legacy
+// scheduler -> cap 24, 2-3 tok/s at batch >=4) has RESURFACED in some form.
+// This clamp (a) refuses to route on the bogus capacity by clamping the slot
+// down to the ceiling, (b) logs at ERROR, and (c) fires a Datadog tripwire
+// counter (via the api-layer hook) so the regression pages a dashboard instead
+// of resurfacing as a throughput collapse.
+//
+// Below-floor providers are UNTOUCHED: their reported 24 is a real legacy
+// cap (the per-model quality-concurrency caps are what actually bind them),
+// and they keep today's clampBackendCapacity 24-ceiling behavior exactly.
+// An empty EIGENINFERENCE_V2_VERSION_FLOOR disables the audit entirely
+// (zero behavior change); an empty provider version is below any floor.
+
+// defaultV2MaxConcurrencyCeiling is the ceiling applied to >=floor providers
+// when EIGENINFERENCE_V2_MAX_CONCURRENCY_CEILING is unset. Matches the engine's
+// productionMaxConcurrentRequests (4) — the v0.7.5 default box-wide cap.
+const defaultV2MaxConcurrencyCeiling = 4
+
+// v2VersionFloor / v2MaxConcurrencyCeiling are configured once at startup via
+// SetV2ConcurrencyClamp (from EIGENINFERENCE_V2_VERSION_FLOOR /
+// _V2_MAX_CONCURRENCY_CEILING) before the coordinator serves, then only read on
+// the heartbeat ingest path — same lifecycle as prefillToDecodeRatio.
+var (
+	v2VersionFloor          = ""
+	v2MaxConcurrencyCeiling = defaultV2MaxConcurrencyCeiling
+)
+
+// SetV2ConcurrencyClamp configures the version-keyed heartbeat concurrency
+// clamp. An empty (or all-blank) floor disables it — today's behavior for the
+// whole fleet. Ceilings < 1 are reset to the default (a ceiling of 0 would
+// clamp every v2 slot to "unreported", disabling admission math). Must be
+// called before serving starts (read-only on ingest paths thereafter).
+func SetV2ConcurrencyClamp(floor string, ceiling int) {
+	v2VersionFloor = strings.TrimSpace(floor)
+	if ceiling < 1 {
+		ceiling = defaultV2MaxConcurrencyCeiling
+	}
+	v2MaxConcurrencyCeiling = ceiling
+}
+
+// V2ConcurrencyClampConfig returns the configured (floor, ceiling) pair.
+// Exposed for startup logging.
+func V2ConcurrencyClampConfig() (string, int) {
+	return v2VersionFloor, v2MaxConcurrencyCeiling
+}
+
+// providerAtOrAboveV2Floor reports whether a provider binary version is at or
+// above the configured v2 floor. False when the floor is unset (feature
+// disabled) and for an EMPTY provider version — a non-reporting binary is below
+// any floor (same convention as the capability version floors), even a floor
+// that parses as all-zeros.
+func providerAtOrAboveV2Floor(version string) bool {
+	if v2VersionFloor == "" || version == "" {
+		return false
+	}
+	return CompareVersions(version, v2VersionFloor) >= 0
+}
+
+// v2ConcurrencyTrip records one slot the v2 clamp had to correct: the model and
+// the max_concurrency the provider actually reported (pre-clamp). Surfaced to
+// the api layer through the tripwire hook for the Datadog counter.
+type v2ConcurrencyTrip struct {
+	Model    string
+	Reported int
+}
+
+// clampV2MaxConcurrency applies the version-keyed ceiling to every slot of a
+// >=floor provider's reported backend capacity, returning one trip per clamped
+// slot. It runs BEFORE the general clampBackendCapacity pass so the trip
+// carries the provider's original report (not the 24-clamped value); the
+// general pass then still normalizes negatives and below-floor providers
+// exactly as today. MaxConcurrency == 0 means "not reported" (omitempty) and is
+// never touched. No-op (nil) when the floor is unset or the provider is below
+// it.
+func clampV2MaxConcurrency(logger *slog.Logger, providerID, version string, bc *protocol.BackendCapacity) []v2ConcurrencyTrip {
+	if bc == nil || !providerAtOrAboveV2Floor(version) {
+		return nil
+	}
+	var trips []v2ConcurrencyTrip
+	for i := range bc.Slots {
+		s := &bc.Slots[i]
+		if s.MaxConcurrency <= v2MaxConcurrencyCeiling {
+			continue
+		}
+		trips = append(trips, v2ConcurrencyTrip{Model: s.Model, Reported: s.MaxConcurrency})
+		if logger != nil {
+			logger.Error("v2 provider reported legacy-scale max_concurrency — silent-legacy-fallback tripwire",
+				"provider_id", providerID,
+				"provider_version", version,
+				"model", s.Model,
+				"reported", s.MaxConcurrency,
+				"clamped", v2MaxConcurrencyCeiling,
+				"v2_version_floor", v2VersionFloor,
+			)
+		}
+		s.MaxConcurrency = v2MaxConcurrencyCeiling
+	}
+	return trips
+}
+
+// SetV2ClampTripwireHook registers an optional callback fired (off the registry
+// locks) whenever the version-keyed heartbeat clamp corrects a slot. The api
+// layer uses it to emit the Datadog tripwire counter. Set once at startup
+// before providers connect; nil clears it. Thread-safe.
+func (r *Registry) SetV2ClampTripwireHook(fn func(providerID, version, model string, reported int)) {
+	r.mu.Lock()
+	r.onV2ClampTrip = fn
+	r.mu.Unlock()
+}
+
+// fireV2ClampTrips invokes the tripwire hook for each clamped slot. Called from
+// Heartbeat with NO locks held (the hook may do I/O — mirror of the
+// hard-untrust hook contract).
+func (r *Registry) fireV2ClampTrips(providerID, version string, trips []v2ConcurrencyTrip) {
+	if len(trips) == 0 {
+		return
+	}
+	r.mu.RLock()
+	hook := r.onV2ClampTrip
+	r.mu.RUnlock()
+	if hook == nil {
+		return
+	}
+	for _, trip := range trips {
+		hook(providerID, version, trip.Model, trip.Reported)
+	}
+}

--- a/coordinator/registry/v2_capacity_clamp_test.go
+++ b/coordinator/registry/v2_capacity_clamp_test.go
@@ -1,0 +1,210 @@
+package registry
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+)
+
+// enableV2ConcurrencyClamp configures the version-keyed heartbeat clamp for a
+// test and restores the package defaults on cleanup (the knobs are
+// startup-configured package vars, mirroring enablePerModelQualityCap's
+// hygiene).
+func enableV2ConcurrencyClamp(t *testing.T, floor string, ceiling int) {
+	t.Helper()
+	t.Cleanup(func() {
+		v2VersionFloor = ""
+		v2MaxConcurrencyCeiling = defaultV2MaxConcurrencyCeiling
+	})
+	SetV2ConcurrencyClamp(floor, ceiling)
+}
+
+// v2TripRecorder captures tripwire hook invocations.
+type v2TripRecorder struct {
+	mu    sync.Mutex
+	trips []struct {
+		providerID, version, model string
+		reported                   int
+	}
+}
+
+func (rec *v2TripRecorder) hook(providerID, version, model string, reported int) {
+	rec.mu.Lock()
+	defer rec.mu.Unlock()
+	rec.trips = append(rec.trips, struct {
+		providerID, version, model string
+		reported                   int
+	}{providerID, version, model, reported})
+}
+
+func (rec *v2TripRecorder) count() int {
+	rec.mu.Lock()
+	defer rec.mu.Unlock()
+	return len(rec.trips)
+}
+
+// v2ClampHeartbeat drives the REAL heartbeat ingest path with a single slot
+// reporting the given max_concurrency and returns the post-ingest value.
+func v2ClampHeartbeat(t *testing.T, reg *Registry, id, model string, reportedMaxConcurrency int) int {
+	t.Helper()
+	reg.Heartbeat(id, &protocol.HeartbeatMessage{
+		Type:   protocol.TypeHeartbeat,
+		Status: "serving",
+		BackendCapacity: &protocol.BackendCapacity{
+			TotalMemoryGB: 64,
+			Slots: []protocol.BackendSlotCapacity{
+				{Model: model, State: "running", MaxConcurrency: reportedMaxConcurrency},
+			},
+		},
+	})
+	reg.mu.RLock()
+	p := reg.providers[id]
+	reg.mu.RUnlock()
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.BackendCapacity.Slots[0].MaxConcurrency
+}
+
+// TestV2ClampAtOrAboveFloorClampsAndTrips is the core tripwire regression: a
+// >=floor provider heartbeating the legacy max_concurrency of 24 (the
+// silent-legacy-fallback signature) is clamped to the v2 ceiling and the
+// tripwire hook fires with the original report. Fails without the fix (the
+// legacy clamp keeps any value <= 24 untouched for every provider).
+func TestV2ClampAtOrAboveFloorClampsAndTrips(t *testing.T) {
+	enableV2ConcurrencyClamp(t, "0.7.5", 4)
+	reg := New(testLogger())
+	rec := &v2TripRecorder{}
+	reg.SetV2ClampTripwireHook(rec.hook)
+	p := makeSchedulerProvider(t, reg, "v2-box", gptossBuild, 30)
+	setProviderVersion(p, "0.7.5")
+
+	if got := v2ClampHeartbeat(t, reg, "v2-box", gptossBuild, 24); got != 4 {
+		t.Fatalf("post-heartbeat max_concurrency = %d, want 4 (clamped to the v2 ceiling)", got)
+	}
+	if rec.count() != 1 {
+		t.Fatalf("tripwire fired %d times, want 1", rec.count())
+	}
+	trip := rec.trips[0]
+	if trip.providerID != "v2-box" || trip.version != "0.7.5" || trip.model != gptossBuild || trip.reported != 24 {
+		t.Fatalf("trip = %+v, want (v2-box, 0.7.5, %s, 24)", trip, gptossBuild)
+	}
+
+	// Above the floor (0.7.6 > 0.7.5) trips too.
+	setProviderVersion(p, "0.7.6")
+	if got := v2ClampHeartbeat(t, reg, "v2-box", gptossBuild, 24); got != 4 {
+		t.Fatalf("0.7.6 post-heartbeat max_concurrency = %d, want 4", got)
+	}
+	if rec.count() != 2 {
+		t.Fatalf("tripwire fired %d times, want 2", rec.count())
+	}
+}
+
+// TestV2ClampOriginalReportSurvivesLegacyClamp: a >=floor provider reporting an
+// out-of-range 30 is clamped straight to the v2 ceiling with the trip carrying
+// the ORIGINAL 30 — not the 24 the legacy sanity clamp would have produced
+// first.
+func TestV2ClampOriginalReportSurvivesLegacyClamp(t *testing.T) {
+	enableV2ConcurrencyClamp(t, "0.7.5", 4)
+	reg := New(testLogger())
+	rec := &v2TripRecorder{}
+	reg.SetV2ClampTripwireHook(rec.hook)
+	setProviderVersion(makeSchedulerProvider(t, reg, "v2-box", gptossBuild, 30), "0.7.5")
+
+	if got := v2ClampHeartbeat(t, reg, "v2-box", gptossBuild, 30); got != 4 {
+		t.Fatalf("post-heartbeat max_concurrency = %d, want 4", got)
+	}
+	if rec.count() != 1 || rec.trips[0].reported != 30 {
+		t.Fatalf("trips = %+v, want one trip with reported=30", rec.trips)
+	}
+}
+
+// TestV2ClampBelowFloorKeepsLegacyBehavior: below-floor providers keep today's
+// clamp exactly — 24 passes through, out-of-range 30 clamps to the legacy 24
+// (not the v2 ceiling), and the tripwire never fires.
+func TestV2ClampBelowFloorKeepsLegacyBehavior(t *testing.T) {
+	enableV2ConcurrencyClamp(t, "0.7.5", 4)
+	reg := New(testLogger())
+	rec := &v2TripRecorder{}
+	reg.SetV2ClampTripwireHook(rec.hook)
+	setProviderVersion(makeSchedulerProvider(t, reg, "legacy-box", gptossBuild, 30), "0.7.4")
+
+	if got := v2ClampHeartbeat(t, reg, "legacy-box", gptossBuild, 24); got != 24 {
+		t.Fatalf("below-floor max_concurrency = %d, want 24 (legacy report is real)", got)
+	}
+	if got := v2ClampHeartbeat(t, reg, "legacy-box", gptossBuild, 30); got != maxReportedMaxConcurrency {
+		t.Fatalf("below-floor out-of-range report = %d, want the legacy ceiling %d", got, maxReportedMaxConcurrency)
+	}
+	if rec.count() != 0 {
+		t.Fatalf("tripwire fired %d times for a below-floor provider, want 0", rec.count())
+	}
+}
+
+// TestV2ClampEmptyVersionIsBelowFloor: a provider that reports no version at
+// all sits below any floor (the trait-floor convention), so its 24 is treated
+// as legacy — clamped only by the legacy 24 ceiling, no tripwire.
+func TestV2ClampEmptyVersionIsBelowFloor(t *testing.T) {
+	enableV2ConcurrencyClamp(t, "0.7.5", 4)
+	reg := New(testLogger())
+	rec := &v2TripRecorder{}
+	reg.SetV2ClampTripwireHook(rec.hook)
+	makeSchedulerProvider(t, reg, "versionless", gptossBuild, 30)
+
+	if got := v2ClampHeartbeat(t, reg, "versionless", gptossBuild, 24); got != 24 {
+		t.Fatalf("empty-version max_concurrency = %d, want 24", got)
+	}
+	if rec.count() != 0 {
+		t.Fatalf("tripwire fired %d times for an empty-version provider, want 0", rec.count())
+	}
+}
+
+// TestV2ClampDisabledWhenFloorEmpty: the default (empty floor env) is zero
+// behavior change even for a v2-version provider reporting 24.
+func TestV2ClampDisabledWhenFloorEmpty(t *testing.T) {
+	enableV2ConcurrencyClamp(t, "", 4)
+	reg := New(testLogger())
+	rec := &v2TripRecorder{}
+	reg.SetV2ClampTripwireHook(rec.hook)
+	setProviderVersion(makeSchedulerProvider(t, reg, "v2-box", gptossBuild, 30), "0.7.5")
+
+	if got := v2ClampHeartbeat(t, reg, "v2-box", gptossBuild, 24); got != 24 {
+		t.Fatalf("floor-disabled max_concurrency = %d, want 24 (no behavior change)", got)
+	}
+	if rec.count() != 0 {
+		t.Fatalf("tripwire fired %d times with the floor disabled, want 0", rec.count())
+	}
+}
+
+// TestV2ClampAtOrBelowCeilingUntouched: a >=floor provider truthfully reporting
+// at/below the ceiling (or omitting the field) is never clamped or counted.
+func TestV2ClampAtOrBelowCeilingUntouched(t *testing.T) {
+	enableV2ConcurrencyClamp(t, "0.7.5", 4)
+	reg := New(testLogger())
+	rec := &v2TripRecorder{}
+	reg.SetV2ClampTripwireHook(rec.hook)
+	setProviderVersion(makeSchedulerProvider(t, reg, "v2-box", gptossBuild, 30), "0.7.5")
+
+	if got := v2ClampHeartbeat(t, reg, "v2-box", gptossBuild, 4); got != 4 {
+		t.Fatalf("honest report = %d, want 4 untouched", got)
+	}
+	if got := v2ClampHeartbeat(t, reg, "v2-box", gptossBuild, 0); got != 0 {
+		t.Fatalf("unreported (0) = %d, want 0 untouched", got)
+	}
+	if rec.count() != 0 {
+		t.Fatalf("tripwire fired %d times for honest reports, want 0", rec.count())
+	}
+}
+
+// TestSetV2ConcurrencyClampSanitizes: ceilings < 1 reset to the default and the
+// floor is trimmed.
+func TestSetV2ConcurrencyClampSanitizes(t *testing.T) {
+	t.Cleanup(func() {
+		v2VersionFloor = ""
+		v2MaxConcurrencyCeiling = defaultV2MaxConcurrencyCeiling
+	})
+	SetV2ConcurrencyClamp("  0.7.5  ", 0)
+	floor, ceiling := V2ConcurrencyClampConfig()
+	if floor != "0.7.5" || ceiling != defaultV2MaxConcurrencyCeiling {
+		t.Fatalf("config = (%q, %d), want (0.7.5, %d)", floor, ceiling, defaultV2MaxConcurrencyCeiling)
+	}
+}

--- a/coordinator/registry/v2_capacity_clamp_test.go
+++ b/coordinator/registry/v2_capacity_clamp_test.go
@@ -1,6 +1,7 @@
 package registry
 
 import (
+	"fmt"
 	"sync"
 	"testing"
 
@@ -192,6 +193,89 @@ func TestV2ClampAtOrBelowCeilingUntouched(t *testing.T) {
 	}
 	if rec.count() != 0 {
 		t.Fatalf("tripwire fired %d times for honest reports, want 0", rec.count())
+	}
+}
+
+// TestV2ProviderLevelCapObservesBoxCeiling (review fix): the v2 ceiling is
+// BOX-WIDE (one engine per box), so the provider-LEVEL admission valve
+// (pendingCount < maxConcurrency, aggregated across ALL models) must observe it
+// too — the per-slot ingest clamp alone lets a >=floor box with two warm models
+// admit slots × ceiling in aggregate under the legacy token-budget valve of 24.
+// Fails without v2BoxCeilingClamp in Provider.maxConcurrency (MaxConcurrency
+// returns 24 and the aggregate admission check stays open at 4 pending).
+func TestV2ProviderLevelCapObservesBoxCeiling(t *testing.T) {
+	enableV2ConcurrencyClamp(t, "0.7.5", 4)
+	reg := New(testLogger())
+	p := makeSchedulerProvider(t, reg, "v2-box", gptossBuild, 30)
+	setProviderVersion(p, "0.7.5")
+
+	// Two warm token-budget slots (multi-model co-residency), each honestly at
+	// the per-slot ceiling — nothing for the ingest clamp to correct.
+	reg.Heartbeat("v2-box", &protocol.HeartbeatMessage{
+		Type:   protocol.TypeHeartbeat,
+		Status: "serving",
+		BackendCapacity: &protocol.BackendCapacity{
+			TotalMemoryGB: 64,
+			Slots: []protocol.BackendSlotCapacity{
+				{Model: gptossBuild, State: "running", MaxConcurrency: 4, ActiveTokenBudgetMax: 100_000},
+				{Model: gemmaBuild, State: "running", MaxConcurrency: 4, ActiveTokenBudgetMax: 100_000},
+			},
+		},
+	})
+
+	if got := p.MaxConcurrency(); got != 4 {
+		t.Fatalf("v2 provider-level MaxConcurrency = %d, want the box-wide ceiling 4 (not the legacy token-budget valve of 24)", got)
+	}
+
+	// Aggregate admission: with the box-wide ceiling reached across BOTH models,
+	// no model has headroom — regardless of its own slot's occupancy.
+	for i := 0; i < 2; i++ {
+		p.AddPending(&PendingRequest{RequestID: fmt.Sprintf("oss-%d", i), Model: gptossBuild})
+		p.AddPending(&PendingRequest{RequestID: fmt.Sprintf("gemma-%d", i), Model: gemmaBuild})
+	}
+	reg.mu.RLock()
+	p.mu.Lock()
+	ossHeadroom := reg.hasConcurrencyHeadroomForModelCapResolvedLocked(p, gptossBuild)
+	gemmaHeadroom := reg.hasConcurrencyHeadroomForModelCapResolvedLocked(p, gemmaBuild)
+	p.mu.Unlock()
+	reg.mu.RUnlock()
+	if ossHeadroom || gemmaHeadroom {
+		t.Fatalf("headroom at box-wide capacity = (gptoss %v, gemma %v), want (false, false): 2+2 pending must saturate the aggregate v2 ceiling of 4", ossHeadroom, gemmaHeadroom)
+	}
+}
+
+// TestV2ProviderLevelCapUntouchedBelowFloorOrDisabled pins the no-behavior-
+// change contract of the provider-level clamp: a below-floor token-budget
+// provider keeps the legacy 24 valve, and so does a v2-version provider when
+// the floor env is unset. The clamp also never RAISES a cap — a small box's
+// hardware-derived cap of 2 stays 2 at/above the floor.
+func TestV2ProviderLevelCapUntouchedBelowFloorOrDisabled(t *testing.T) {
+	enableV2ConcurrencyClamp(t, "0.7.5", 4)
+	reg := New(testLogger())
+
+	legacy := makeTokenBudgetProvider(t, reg, "legacy-box", gptossBuild, 30, 0, 100_000, 0)
+	setProviderVersion(legacy, "0.7.4")
+	if got := legacy.MaxConcurrency(); got != 24 {
+		t.Fatalf("below-floor token-budget MaxConcurrency = %d, want the legacy 24", got)
+	}
+
+	// Tightening only: a >=floor box whose hardware tier is BELOW the ceiling
+	// keeps its smaller cap (24GB tier → 2).
+	small := makeSchedulerProvider(t, reg, "small-v2-box", gptossBuild, 30)
+	setProviderVersion(small, "0.7.5")
+	small.mu.Lock()
+	small.BackendCapacity.TotalMemoryGB = 24
+	small.mu.Unlock()
+	if got := small.MaxConcurrency(); got != 2 {
+		t.Fatalf(">=floor small-box MaxConcurrency = %d, want 2 (the clamp must never raise a cap)", got)
+	}
+
+	// Floor disabled: zero behavior change even for a v2-version provider.
+	SetV2ConcurrencyClamp("", 4)
+	v2 := makeTokenBudgetProvider(t, reg, "v2-box", gptossBuild, 30, 0, 100_000, 0)
+	setProviderVersion(v2, "0.7.5")
+	if got := v2.MaxConcurrency(); got != 24 {
+		t.Fatalf("floor-disabled v2 MaxConcurrency = %d, want 24 (no behavior change)", got)
 	}
 }
 

--- a/coordinator/registry/warm_pool_controller.go
+++ b/coordinator/registry/warm_pool_controller.go
@@ -87,13 +87,20 @@ type warmPoolModelSnapshot struct {
 	// backend slots for this model (the observable L in Little's Law).
 	running int
 	waiting int
-	// soloDecodeTPS / prefillTPS / maxProviderConc are representative (median)
-	// rates and the per-provider concurrency cap across providers serving the
-	// model, used for quality concurrency and the E[S] service-time estimate.
-	soloDecodeTPS   float64
-	prefillTPS      float64
-	maxProviderConc int
-	eligibleCold    []warmPoolCandidate
+	// soloDecodeTPS / serviceDecodeTPS / prefillTPS / maxProviderConc are
+	// representative (median) rates and the per-provider concurrency cap across
+	// providers serving the model. soloDecodeTPS is the STATIC solo rate from
+	// the quality-cap resolver (resolvedSoloModelTPSLocked) and feeds quality
+	// concurrency, so warm targets and admission caps use the same math and
+	// cannot disagree. serviceDecodeTPS keeps the observed-EWMA-preferring
+	// chain (resolvedModelTPSLocked) and feeds only the E[S] service-time
+	// estimate, which deliberately wants the load-inclusive rate a request
+	// actually sees.
+	soloDecodeTPS    float64
+	serviceDecodeTPS float64
+	prefillTPS       float64
+	maxProviderConc  int
+	eligibleCold     []warmPoolCandidate
 	// coldIneligible / coldDisq tally cold (on-disk, not-warm) providers that
 	// FAILED the warm-pool candidate gate, by reason — diagnostics for why
 	// eligibleCold is smaller than the raw cold count.
@@ -327,7 +334,16 @@ func (c *warmPoolController) planObserveOnly(now time.Time, reserve func([]model
 		p := pressure[model]
 		q := queue[model]
 		f := fleet[model]
-		svc := estimateServiceTime(f.prefillTPS, f.soloDecodeTPS, params)
+		// E[S] from the load-inclusive service rate (what a request actually
+		// sees); quality concurrency below from the solo rate (the admission
+		// cap's math). Falls back to the solo rate when no service samples
+		// exist (both medians share the same provider set, so this only guards
+		// the degenerate empty case).
+		serviceTPS := f.serviceDecodeTPS
+		if serviceTPS <= 0 {
+			serviceTPS = f.soloDecodeTPS
+		}
+		svc := estimateServiceTime(f.prefillTPS, serviceTPS, params)
 		target := c.targetWarm(f, p, q, params, svc, now)
 
 		gap := target - f.warm
@@ -524,7 +540,10 @@ func (r *Registry) warmPoolFleetSnapshot(now time.Time) map[string]warmPoolModel
 	out := make(map[string]warmPoolModelSnapshot)
 	// Per-model rate samples (from every eligible provider serving the model,
 	// warm or warmable) collapsed to a representative median at the end.
+	// decodeSamples carries the quality-cap solo rate (→ qualityConcurrency);
+	// serviceSamples the observed-EWMA service rate (→ E[S]).
 	decodeSamples := make(map[string][]float64)
+	serviceSamples := make(map[string][]float64)
 	prefillSamples := make(map[string][]float64)
 	concSamples := make(map[string][]float64)
 	for _, p := range r.providers {
@@ -548,8 +567,17 @@ func (r *Registry) warmPoolFleetSnapshot(now time.Time) map[string]warmPoolModel
 					s.warmSaturated++
 				}
 				out[model] = s
-				decodeTPS, prefillTPS := resolvedModelTPSLocked(p, model)
-				decodeSamples[model] = append(decodeSamples[model], decodeTPS)
+				// decodeSamples feed soloDecodeTPS → qualityConcurrency in the
+				// warm target. Use the SAME solo resolver as the admission cap
+				// (solo median / seed → provider benchmark), NOT the per-slot
+				// observed EWMA: the EWMA is a contended rate, and planning warm
+				// targets from it while admission caps from the solo rate would
+				// let the two disagree. The observed-EWMA chain
+				// (resolvedModelTPSLocked) still feeds serviceSamples/prefill —
+				// E[S] wants the load-inclusive rate a request actually sees.
+				serviceTPS, prefillTPS := resolvedModelTPSLocked(p, model)
+				decodeSamples[model] = append(decodeSamples[model], r.resolvedSoloModelTPSLocked(p, model).tps)
+				serviceSamples[model] = append(serviceSamples[model], serviceTPS)
 				prefillSamples[model] = append(prefillSamples[model], prefillTPS)
 				concSamples[model] = append(concSamples[model], float64(p.maxConcurrencyForModelLocked(model)))
 				continue
@@ -560,8 +588,10 @@ func (r *Registry) warmPoolFleetSnapshot(now time.Time) map[string]warmPoolModel
 			if reason == warmColdEligible {
 				s.eligibleCold = append(s.eligibleCold, candidate)
 				out[model] = s
-				decodeTPS, prefillTPS := resolvedModelTPSLocked(p, model)
-				decodeSamples[model] = append(decodeSamples[model], decodeTPS)
+				// Same solo-resolver / service-rate split as the warm branch above.
+				serviceTPS, prefillTPS := resolvedModelTPSLocked(p, model)
+				decodeSamples[model] = append(decodeSamples[model], r.resolvedSoloModelTPSLocked(p, model).tps)
+				serviceSamples[model] = append(serviceSamples[model], serviceTPS)
 				prefillSamples[model] = append(prefillSamples[model], prefillTPS)
 				concSamples[model] = append(concSamples[model], float64(p.maxConcurrencyForModelLocked(model)))
 			} else {
@@ -578,6 +608,7 @@ func (r *Registry) warmPoolFleetSnapshot(now time.Time) map[string]warmPoolModel
 	for model, s := range out {
 		sort.Slice(s.eligibleCold, func(i, j int) bool { return s.eligibleCold[i].score > s.eligibleCold[j].score })
 		s.soloDecodeTPS = medianFloat(decodeSamples[model])
+		s.serviceDecodeTPS = medianFloat(serviceSamples[model])
 		s.prefillTPS = medianFloat(prefillSamples[model])
 		s.maxProviderConc = int(medianFloat(concSamples[model]))
 		out[model] = s

--- a/coordinator/registry/warm_pool_controller.go
+++ b/coordinator/registry/warm_pool_controller.go
@@ -648,8 +648,14 @@ const (
 	warmColdStaleChallenge warmColdReason = "stale_challenge"
 	warmColdNotServing     warmColdReason = "not_serving_catalog"
 	warmColdDedicated      warmColdReason = "dedicated_excluded"
-	warmColdTooLarge       warmColdReason = "model_too_large"
-	warmColdNoFreeForLoad  warmColdReason = "no_free_for_load"
+	// warmColdBelowVersionFloor: the model carries a per-model provider-version
+	// routing floor (EIGENINFERENCE_MODEL_VERSION_FLOORS) and this provider's
+	// binary is below it (or reports no version). Routing would never send the
+	// model here, so warming it would waste GPU memory and mislead the demand
+	// calc — mirrors the routing gate exactly (model_version_floors.go).
+	warmColdBelowVersionFloor warmColdReason = "below_model_version_floor"
+	warmColdTooLarge          warmColdReason = "model_too_large"
+	warmColdNoFreeForLoad     warmColdReason = "no_free_for_load"
 )
 
 // warmColdReasonStrings converts a reason tally to a string-keyed map for
@@ -712,6 +718,13 @@ func (r *Registry) warmPoolCandidateReasonLocked(p *Provider, model string, now 
 	// the model is already covered. Mirrors the routing/preflight gate.
 	if r.providerExcludedByDedicatedRuleLocked(p, model) {
 		return warmPoolCandidate{}, warmColdDedicated
+	}
+	// Same never-warm-what-we-won't-route rule for the per-model provider-version
+	// floors: a below-floor (or version-less) box can't be routed the model, so
+	// it must not be warmed for it either. Mirrors the routing gate
+	// (providerPassesRoutingGatesLockedEx → providerBelowModelVersionFloorLocked).
+	if r.providerBelowModelVersionFloorLocked(p, model) {
+		return warmPoolCandidate{}, warmColdBelowVersionFloor
 	}
 	totalMemoryGB := float64(p.Hardware.MemoryGB)
 	gpuActiveGB := 0.0

--- a/coordinator/registry/warm_pool_controller_test.go
+++ b/coordinator/registry/warm_pool_controller_test.go
@@ -418,7 +418,13 @@ func TestWarmPoolPressureLoadsBeforeMinWarmFloor(t *testing.T) {
 	}
 }
 
-func TestWarmPoolFleetSnapshotUsesObservedSlotTPS(t *testing.T) {
+// TestWarmPoolFleetSnapshotSplitsSoloAndServiceRates: the snapshot's
+// soloDecodeTPS must come from the quality-cap solo resolver (static solo
+// rate — here the registration benchmark, since no solo samples or seed
+// exist), NOT the under-load slot EWMA, so warm targets use the same quality
+// math as the admission cap. The EWMA still feeds serviceDecodeTPS/prefillTPS,
+// which size E[S] (a request's actually-observed rates).
+func TestWarmPoolFleetSnapshotSplitsSoloAndServiceRates(t *testing.T) {
 	reg := New(testLogger())
 	model := "warm-pool-observed-tps"
 	p := makeSchedulerProvider(t, reg, "warm", model, 23)
@@ -429,8 +435,11 @@ func TestWarmPoolFleetSnapshotUsesObservedSlotTPS(t *testing.T) {
 
 	snap := reg.warmPoolFleetSnapshot(time.Now())[model]
 
-	if snap.soloDecodeTPS != 73 {
-		t.Fatalf("soloDecodeTPS = %v, want observed slot TPS 73", snap.soloDecodeTPS)
+	if snap.soloDecodeTPS != 23 {
+		t.Fatalf("soloDecodeTPS = %v, want static solo rate 23 (observed EWMA must not feed quality concurrency)", snap.soloDecodeTPS)
+	}
+	if snap.serviceDecodeTPS != 73 {
+		t.Fatalf("serviceDecodeTPS = %v, want observed slot TPS 73", snap.serviceDecodeTPS)
 	}
 	if snap.prefillTPS != 1000 {
 		t.Fatalf("prefillTPS = %v, want observed slot prefill TPS 1000", snap.prefillTPS)
@@ -452,7 +461,13 @@ func TestWarmPoolFleetSnapshotFallsBackToStaticTPS(t *testing.T) {
 	}
 }
 
-func TestWarmPoolDiagnosticsReflectObservedTPS(t *testing.T) {
+// TestWarmPoolDiagnosticsSplitObservedAndSoloRates: E[S] (ServiceTime) still
+// reflects the observed load-inclusive rates, while QualityConcurrency
+// deliberately does NOT read the under-load EWMA — it is computed from the
+// same static solo rate as the admission cap (postmortem layer 6: EWMA-fed
+// planning and static-fed admission used to disagree). Static 23 tok/s at
+// floor 15 → quality batch 1, no matter how high the current EWMA reads.
+func TestWarmPoolDiagnosticsSplitObservedAndSoloRates(t *testing.T) {
 	reg := New(testLogger())
 	model := "warm-pool-observed-diagnostics"
 	p := makeSchedulerProvider(t, reg, "warm", model, 23)
@@ -473,11 +488,11 @@ func TestWarmPoolDiagnosticsReflectObservedTPS(t *testing.T) {
 		t.Fatalf("snapshots = %d, want 1", len(snaps))
 	}
 	snap := snaps[0]
-	if snap.QualityConcurrency <= 2 {
-		t.Fatalf("QualityConcurrency = %d, want observed TPS to raise it above stale value 2", snap.QualityConcurrency)
+	if snap.QualityConcurrency != 1 {
+		t.Fatalf("QualityConcurrency = %d, want 1 from the static solo rate 23 (observed EWMA 73 must not inflate the quality batch)", snap.QualityConcurrency)
 	}
 	if snap.ServiceTime >= 10*time.Second {
-		t.Fatalf("ServiceTime = %v, want observed TPS to keep it below stale 12.8s", snap.ServiceTime)
+		t.Fatalf("ServiceTime = %v, want observed rates to keep it below stale 12.8s", snap.ServiceTime)
 	}
 }
 

--- a/docs/operations/coordinator-deploy.md
+++ b/docs/operations/coordinator-deploy.md
@@ -234,6 +234,9 @@ semantics is the code (`coordinator/registry/`, `coordinator/api/`); the highlig
 | `EIGENINFERENCE_QUEUE_BEFORE_SHED`, `_QUEUE_MAX_DEPTH`, `_QUEUE_MAX_WAIT` | Capacity queueing (dedicated pools included) |
 | `EIGENINFERENCE_HEALTH_EJECTION` | Stable-identity ejection kill switch — **`on` in prod**; `off` disables black-hole ejection entirely |
 | `EIGENINFERENCE_QUALITY_CONCURRENCY_OVERCOMMIT`, `_BY_MODEL` | Per-box admission density (default 1.2) |
+| `EIGENINFERENCE_QUALITY_CAP_PER_MODEL_TPS` | Quality cap reads each model's own solo decode rate (default `true`; `false` restores the provider-level benchmark) |
+| `EIGENINFERENCE_QUALITY_CAP_SOLO_MIN_SAMPLES` | Solo samples required before a per-(model, chip) median is trusted (default 5) |
+| `EIGENINFERENCE_MODEL_SOLO_TPS_SEED` | Cold-start solo rates, `build-id=tok/s` CSV (e.g. `gemma-4-26b-qat-4bit=14,gpt-oss-20b=30`); the in-memory TPS registry is restart-wiped |
 | `EIGENINFERENCE_WARM_POOL_*` | Warm-pool controller (active; `OBSERVE_ONLY=false`) |
 | `EIGENINFERENCE_DEDICATED_MODELS` | Static dedicated-box partition (`gemma-4`) |
 | `EIGENINFERENCE_IPAPI_KEY` | ip-api.com PRO key; unset falls back to the free 45 req/min tier |

--- a/docs/operations/coordinator-deploy.md
+++ b/docs/operations/coordinator-deploy.md
@@ -239,6 +239,9 @@ semantics is the code (`coordinator/registry/`, `coordinator/api/`); the highlig
 | `EIGENINFERENCE_MODEL_SOLO_TPS_SEED` | Cold-start solo rates, `build-id=tok/s` CSV (e.g. `gemma-4-26b-qat-4bit=14,gpt-oss-20b=30`); the in-memory TPS registry is restart-wiped |
 | `EIGENINFERENCE_WARM_POOL_*` | Warm-pool controller (active; `OBSERVE_ONLY=false`) |
 | `EIGENINFERENCE_DEDICATED_MODELS` | Static dedicated-box partition (`gemma-4`) |
+| `EIGENINFERENCE_V2_VERSION_FLOOR` | v0.7.5-migration audit: providers at/above this version are engine-v2-only, so a heartbeat `max_concurrency` above the v2 ceiling is clamped + counted on the `provider.v2_concurrency_tripwire` Datadog tripwire (silent-legacy-fallback resurfaced). Default empty = off; set to `0.7.5` with deploy batch B; permanent audit thereafter |
+| `EIGENINFERENCE_V2_MAX_CONCURRENCY_CEILING` | Chat-slot concurrency ceiling for ≥floor providers (default 4 = the v2 engine's box-wide cap) |
+| `EIGENINFERENCE_MODEL_VERSION_FLOORS` | Per-model provider-version routing floors, `pattern=version` CSV (e.g. `gemma-4=0.7.5`; substring match like `_DEDICATED_MODELS`). Floored models route/pre-warm only onto ≥floor providers; empty-version providers fail every floor. Default empty = off; set at ≥70% online-fleet v0.7.5 adoption, retire after convergence |
 | `EIGENINFERENCE_IPAPI_KEY` | ip-api.com PRO key; unset falls back to the free 45 req/min tier |
 
 ## Troubleshooting

--- a/docs/operations/coordinator-deploy.md
+++ b/docs/operations/coordinator-deploy.md
@@ -242,6 +242,11 @@ semantics is the code (`coordinator/registry/`, `coordinator/api/`); the highlig
 | `EIGENINFERENCE_V2_VERSION_FLOOR` | v0.7.5-migration audit: providers at/above this version are engine-v2-only, so a heartbeat `max_concurrency` above the v2 ceiling is clamped + counted on the `provider.v2_concurrency_tripwire` Datadog tripwire (silent-legacy-fallback resurfaced). Default empty = off; set to `0.7.5` with deploy batch B; permanent audit thereafter |
 | `EIGENINFERENCE_V2_MAX_CONCURRENCY_CEILING` | Chat-slot concurrency ceiling for ≥floor providers (default 4 = the v2 engine's box-wide cap) |
 | `EIGENINFERENCE_MODEL_VERSION_FLOORS` | Per-model provider-version routing floors, `pattern=version` CSV (e.g. `gemma-4=0.7.5`; substring match like `_DEDICATED_MODELS`). Floored models route/pre-warm only onto ≥floor providers; empty-version providers fail every floor. Default empty = off; set at ≥70% online-fleet v0.7.5 adoption, retire after convergence |
+| `EIGENINFERENCE_TTFT_PREFILL_MEDIANS` | Prefill-honest TTFT: use the per-(model, chip) median of fleet-observed `observed_prefill_tps` in the TTFT estimate once trusted (default `true`; `false` restores the pure ratio-derived path). Live-read, no restart |
+| `EIGENINFERENCE_TTFT_PREFILL_MIN_SAMPLES` | Prefill samples required before a per-(model, chip) median is trusted by the TTFT estimate (default 5). Live-read |
+| `EIGENINFERENCE_PREFILL_FALLBACK_MODE` | Data-derived prefill fallback anchor for UNMEASURED fleets (`off`\|`shadow`\|`enforce`, default `off`): `shadow` emits `routing.prefill_fallback{would_admit\|would_shed}` without changing routing; `enforce` lifts the static sqrt(bandwidth)×ratio estimate (~280 tok/s) to the fallback anchor when neither a slot measurement nor a trusted median exists |
+| `EIGENINFERENCE_PREFILL_FALLBACK_TPS` | The fallback anchor (default 6500 = measured fleet prefill p50, 2026-06-22 live check) |
+| `EIGENINFERENCE_MAX_PREFILL_TPS` | Prefill sanity ceiling shared by heartbeat ingest zeroing and routing caps (default 20000, above the measured p90 17,707 so real v0.7.5 `observed_prefill_tps` reports survive ingest; the old 5000 would zero the majority of them) |
 | `EIGENINFERENCE_IPAPI_KEY` | ip-api.com PRO key; unset falls back to the free 45 req/min tier |
 
 ## Troubleshooting

--- a/docs/operations/coordinator-deploy.md
+++ b/docs/operations/coordinator-deploy.md
@@ -247,6 +247,8 @@ semantics is the code (`coordinator/registry/`, `coordinator/api/`); the highlig
 | `EIGENINFERENCE_PREFILL_FALLBACK_MODE` | Data-derived prefill fallback anchor for UNMEASURED fleets (`off`\|`shadow`\|`enforce`, default `off`): `shadow` emits `routing.prefill_fallback{would_admit\|would_shed}` without changing routing; `enforce` lifts the static sqrt(bandwidth)×ratio estimate (~280 tok/s) to the fallback anchor when neither a slot measurement nor a trusted median exists |
 | `EIGENINFERENCE_PREFILL_FALLBACK_TPS` | The fallback anchor (default 6500 = measured fleet prefill p50, 2026-06-22 live check) |
 | `EIGENINFERENCE_MAX_PREFILL_TPS` | Prefill sanity ceiling shared by heartbeat ingest zeroing and routing caps (default 20000, above the measured p90 17,707 so real v0.7.5 `observed_prefill_tps` reports survive ingest; the old 5000 would zero the majority of them) |
+| `EIGENINFERENCE_SATISFICING_BAND` | Utilization band (default `false` = dormant): among candidates predicted to meet the request's TTFT deadline (with margin) and decode floor, select weighted-random by inverse recent serves instead of cheapest-cost — spreads load off the top-10% boxes onto the idle SLO-meeting majority. Canary AFTER gemma re-enable stabilizes; guard: TTFT p90 within ±10% of pre-band baseline. Live-read |
+| `EIGENINFERENCE_SATISFICING_TTFT_MARGIN_MS` | Band TTFT safety margin subtracted from the request deadline (default 1000). Live-read |
 | `EIGENINFERENCE_IPAPI_KEY` | ip-api.com PRO key; unset falls back to the free 45 req/min tier |
 
 ## Troubleshooting


### PR DESCRIPTION
# PR body — `fix/version-floors-ttft-band` @ `083279ba`

> **Suggested title:** `feat(registry): mixed-fleet version floors, prefill-honest TTFT, satisficing band (+ absorbed PR #453)`
> **Base:** ⚠️ **STACKED PR — set base = `fix/per-model-quality-caps` (coord-a)**, NOT master. This branch contains coord-a's 2 commits plus 5 of its own; merge coord-a first, then rebase-or-retarget this PR onto master. The review diff below refers only to the 5 stacked commits (`c397dc46..083279ba`, i.e. `81bba621` through `083279ba`).
> ⚠️ **Close open PR #453 (`prefill-fallback-recalibration`) in favor of this PR** — its content is absorbed as commit `81bba621` (see below); do not merge #453 separately.
> Worktree `.worktrees/coord-c` · **Deploy batch B** (all new behavior inert/dormant at deploy)

## Problem

Three problems, one migration-defense stack:

1. **Mixed-fleet migration risk (audits postmortem layer 5's provider fix):** v0.7.5 deletes the provider's legacy scheduler — a ≥0.7.5 box can never silently legacy-serve at cap 24 again. But the fleet converges over hours-to-days, and the postmortem (`docs/reports/2026-07-06-gemma4-serving-failure-postmortem.md` §3.1) showed what silently-degraded boxes do to a model pool: 54% of open-pool gemma traffic ran on the legacy engine at 2–3 tok/s. The coordinator needs (a) a permanent tripwire that catches the silent-legacy signature (a ≥0.7.5 box heartbeating `max_concurrency` 24) and (b) a way to fence gemma onto re-slice-capable binaries during the migration.
2. **Consumer latency — false TTFT sheds:** the TTFT estimate derives unmeasured prefill from `sqrt(bandwidth) × EIGENINFERENCE_PREFILL_DECODE_RATIO(12)` ≈ **280 tok/s**, ~23× below measured reality (fleet p50 6,523 tok/s, p90 17,707 — recovered from the router's own stored `ttft_ms`). gpt-oss's p90 prompt is **13,711 tokens**, so predicted TTFT ≈ 38s against a 5s deadline and **18.2k requests/day die on `ttft_too_slow` mispredictions** (~41% long-prompt over-shed) while the fleet idles.
3. **Utilization concentration:** selection is strictly cheapest-cost with near-tie randomization — top-10% of boxes take 79% of traffic, the median gpt-oss box serves 9 req/day, ~70% of online boxes serve nothing in a given hour, 41 online 24GB boxes serving gpt-oss served 0.

## What changed (per commit)

1. **`81bba621` — absorbed PR #453: prefill-TPS fallback recalibration** (`registry/prefill_fallback.go`, `api/prefill_fallback_metrics.go`): env-gated, data-derived prefill fallback anchor — `EIGENINFERENCE_PREFILL_FALLBACK_MODE` `off|shadow|enforce` (default **off**, behavior-neutral), `EIGENINFERENCE_PREFILL_FALLBACK_TPS` (default 6500 = measured p50). `shadow` emits `routing.prefill_fallback{would_admit|would_shed}` from the preflight so the projected `ttft_429` recovery is measured before enforcing. Also raises the prefill sanity ceiling `maxPrefillTPS` from the hardcoded constant 5000 to env-tunable `EIGENINFERENCE_MAX_PREFILL_TPS` (default **20000**, above measured p90) — a **hard prerequisite** for commit 3: the old 5000 ingest clamp would zero the majority of real v0.7.5 `observed_prefill_tps` reports (p50 6,523 > 5,000) before they could ever feed a median. Cost ranking untouched; only the TTFT admission gate moves.
2. **`66f12329` — mixed-fleet defense** (plan 2.4): **(a)** version-keyed heartbeat sanity clamp (`registry/v2_capacity_clamp.go`, `api/v2_clamp_metrics.go`): providers at/above `EIGENINFERENCE_V2_VERSION_FLOOR` (default empty = off) heartbeating a chat-slot `max_concurrency` above `EIGENINFERENCE_V2_MAX_CONCURRENCY_CEILING` (default 4) are clamped, logged at ERROR, and counted on the **`provider.v2_concurrency_tripwire`** Datadog counter — on a ≥floor box that report means the silent-legacy bug *resurfaced*; this is a **permanent audit of the release's fail-loud promise**, not a rollout metric. The v2 pass runs BEFORE the general `clampBackendCapacity` pass so the tripwire records the original report; below-floor and empty-version providers keep today's clamp-24 behavior byte-for-byte. **(b)** per-model provider-version routing floors (`registry/model_version_floors.go`): `EIGENINFERENCE_MODEL_VERSION_FLOORS="gemma-4=0.7.5"` (pattern=version CSV, case-insensitive substring like `DEDICATED_MODELS`) enforced in the single routing gate (`providerPassesRoutingGatesLockedEx` — dispatch, preflight, and final admit re-check all agree) AND the warm-pool candidate gate (new `warmColdBelowVersionFloor` reason) AND self-route. Empty-version providers fail every floor; malformed CSV degrades to no-floor, never a wrong floor.
3. **`b97c32ce` — prefill-honest TTFT** (plan 2.7; `registry/prefill_tps.go`): a **third TPSRegistry ring** (`RecordPrefill`/`PrefillMedian`, same 50-sample FIFO shape) of the `observed_prefill_tps` EWMAs v0.7.5 providers report in heartbeats. TTFT prefill resolution (`prefillTPSForSnapshot`, consumed by `resolvePrefillTPS`) becomes, most- to least-specific: **own slot measurement → trusted per-(model, chip) median (≥ `EIGENINFERENCE_TTFT_PREFILL_MIN_SAMPLES`, default 5) → (enforce mode) the #453 anchor → static decode×ratio chain**, applied in BOTH the dispatch snapshot and the capacity preflight, with the #512 online calibrator kept downstream as corrector. Deliberately NO cross-chip pooling (prefill is compute-bound, spreads 3–4× across tiers) and NOT solo-gated (prefill is per-request compute work; garbage EWMAs are zeroed at ingest by the clamp). Kill switch `EIGENINFERENCE_TTFT_PREFILL_MEDIANS` (default **true**, live-read) — false restores the pure ratio path exactly.
4. **`87d045c1` — satisficing utilization band** (plan 2.8; `registry/satisficing_band.go`), behind `EIGENINFERENCE_SATISFICING_BAND` (default **FALSE — fully dormant**, flag-off selection byte-identical and pinned by test): band = candidates whose calibrated `breakdown.TTFTMs` clears the request deadline minus `EIGENINFERENCE_SATISFICING_TTFT_MARGIN_MS` (default 1000) AND whose `projectedPerRequestDecodeTPS` clears the decode floor — the exact predicates admission already computes, no new estimators. Within the band: weighted-random, weight `1/(1+recentServes)` from a registry-local exponentially-decaying per-provider counter (half-life 5 min), **fed on every successful reservation regardless of the flag** so weights are warm at flip time. Cache affinity keeps its pin within the band; an empty band falls through to exactly today's cheapest-cost path; speculative dispatch/queueing/retries untouched. Hooked in `selectBestCandidateScanLocked`.
5. **`083279ba` — quality-gate review fixes:** `OwnedProviderSummary` now applies the model version floor (a below-floor OWNED box previously read "serves model" in the self-route preflight, queued 120s, died as `machine_busy`); the prefill-fallback SHADOW estimate now applies #512 online calibration so `would_admit|would_shed` compares calibrated-vs-calibrated (an enforce flip gates on calibrated values; the uncalibrated shadow under-reported the projected recovery); tests pin env defaults via `t.Setenv`. Documented-not-changed reviewer note: with `EIGENINFERENCE_LONG_PROMPT_TOKENS > 0` (default 0 = off), a trusted median/anchor also shifts long-prompt cost ranking via `longPromptPenalty` — intentional per that knob's design.

## Before / After

```mermaid
flowchart TB
  subgraph Before["Before — trusting heartbeats, static prefill guess, winner-takes-all"]
    A1["0.7.4 mixed box, silent legacy fallback<br/>heartbeats max_concurrency 24"] --> B1[clampBackendCapacity accepts ≤24] --> C1[coordinator trusts it<br/>→ traffic marched into the trap]
    D1[13.7k-token gpt-oss prompt] --> E1["resolvePrefillTPS: no measurement →<br/>sqrt(bandwidth)×12 ≈ 280 tok/s"] --> F1["predicted TTFT ~38s > 5s deadline<br/>→ ttft_too_slow 429 (18.2k/day false)"]
    G1[selection] --> H1[strict cheapest-cost + near-tie<br/>→ top-10% boxes take 79%]
  end
  subgraph After["After — floors + tripwire, measured prefill, SLO band (dormant)"]
    A2["box ≥ V2_VERSION_FLOOR<br/>heartbeats max_concurrency 24"] --> B2["clampV2MaxConcurrency FIRST:<br/>clamp→4, ERROR log,<br/>provider.v2_concurrency_tripwire"] --> C2[general clamp pass second]
    A3[gemma request] --> B3{"MODEL_VERSION_FLOORS<br/>gemma-4=0.7.5: provider ≥ floor?"} -- no --> C3[not routed, not warmed, not self-routed<br/>warmColdBelowVersionFloor tallied]
    B3 -- yes --> D3[normal gates]
    D2[13.7k-token prompt] --> E2["prefillTPSForSnapshot:<br/>own slot → (model,chip) median n≥5<br/>→ enforce? 6500 anchor → ratio chain"] --> F2["honest TTFT → routes to<br/>high-prefill boxes instead of shed"]
    G2[selection] --> H2{SATISFICING_BAND=true?}
    H2 -- "off (default)" --> I2[byte-identical cheapest-cost]
    H2 -- on --> J2["band = deadline−margin & decode-floor<br/>members → weighted random 1/(1+recentServes),<br/>affinity pin kept; empty band → cheapest-cost"]
  end
```

## New envs

| Env | Default | Semantics | Runbook flip |
|---|---|---|---|
| `EIGENINFERENCE_V2_VERSION_FLOOR` | *(empty = off)* | ≥floor providers are v2-only by construction; a chat-slot `max_concurrency` above the ceiling is clamped + tripwired (`provider.v2_concurrency_tripwire`) | Set `0.7.5` at Deploy B once ≥70% of online ≥36GB boxes run 0.7.5; **permanent audit thereafter** |
| `EIGENINFERENCE_V2_MAX_CONCURRENCY_CEILING` | `4` | The v2 engine's box-wide cap (`productionMaxConcurrentRequests`); must be ≥1 | Leave default |
| `EIGENINFERENCE_MODEL_VERSION_FLOORS` | *(empty = off)* | `pattern=version` CSV; floored models route/warm/self-route only onto ≥floor providers | Set `gemma-4=0.7.5` with the V2 floor; **retire after fleet convergence** |
| `EIGENINFERENCE_TTFT_PREFILL_MEDIANS` | `true` (live-read) | Per-(model, chip) observed-prefill medians in the TTFT estimate | No flip needed — activates itself as v0.7.5 boxes report `observed_prefill_tps`; kill switch if misbehaving |
| `EIGENINFERENCE_TTFT_PREFILL_MIN_SAMPLES` | `5` (live-read) | Median trust floor | Leave default |
| `EIGENINFERENCE_PREFILL_FALLBACK_MODE` | `off` | `off\|shadow\|enforce` — the #453 anchor for UNMEASURED (model, chip) pairs; shadow = metrics only | `shadow` at Deploy B; `enforce` at runbook step 7 after shadow validates |
| `EIGENINFERENCE_PREFILL_FALLBACK_TPS` | `6500` | The anchor (measured fleet prefill p50, 2026-06-22 live check) | Leave default |
| `EIGENINFERENCE_MAX_PREFILL_TPS` | `20000` (was hardcoded 5000) | Prefill sanity ceiling shared by ingest zeroing + routing cap | Active at deploy (behavior-neutral today: 0/313 warm slots report prefill); tune down for instant rollback |
| `EIGENINFERENCE_SATISFICING_BAND` | `false` (live-read) | The utilization band; dormant, flag-off selection byte-identical | Canary at step 7, only after gemma re-enable stabilizes; guard TTFT p90 ±10% |
| `EIGENINFERENCE_SATISFICING_TTFT_MARGIN_MS` | `1000` (live-read) | Band TTFT safety margin under the deadline | Leave default |

## Test evidence

- **`TestPrefillMedianLongPromptRegression`** (`prefill_tps_test.go`) — **the production overshoot**: a **13,711-token** prompt on a warm box whose fleet-measured prefill is ~6,500 tok/s is admitted with medians on and shed with them off (fails with the median layer neutralized).
- **`TestPrefillIngestZeroedUnderOldCeiling`** — pins why the #453 ceiling raise is a prerequisite: real reports (6,523 tok/s) are zeroed at ingest under the old 5000 cap.
- V2 tripwire: `TestV2ClampAtOrAboveFloorClampsAndTrips` (incl. a 30-report that bypasses the legacy-24 stage), `TestV2ClampOriginalReportSurvivesLegacyClamp` (ordering), `TestV2ClampBelowFloorKeepsLegacyBehavior` + `TestV2ClampEmptyVersionIsBelowFloor` + `TestV2ClampDisabledWhenFloorEmpty` (flag-off/below-floor byte-identical pins).
- Version floors: `TestModelVersionFloorRoutingGate`, `TestModelVersionFloorPreflightConsistency` (shed/Retry-After agree with routing), `TestModelVersionFloorWarmPoolCandidacy`, `TestModelVersionFloorOwnedSummaryConsistency` (the 083279ba review fix — fails without it), `TestModelVersionFloorDisabledByDefault`, `TestParseModelVersionFloors`.
- #453 pieces: `TestLongPromptAdmittedUnderEnforceFallback`, **`TestPrefillFallbackShadowIsBehaviorNeutral`** (shadow = byte-identical routing), `TestEmitPrefillFallbackShadowWouldAdmit`/`WouldShed`, `TestMaxPrefillCeilingRaiseKeepsHighObserved`, `TestPrefillTPSForSnapshotResolutionOrder`, `TestPrefillTPSForSnapshotRecalibration` (calibrated shadow, the other 083279ba fix).
- Band: **`TestSatisficingBandOffSelectionPinned`** (50 trials, flag-off deterministic-cheapest — the byte-identical pin), `TestSatisficingBandSpreadsAcrossMembers` (300 trials through the REAL `ReserveProviderEx` path), `TestSatisficingBandNonMembersOnlyWhenBandEmpty`, `TestSatisficingBandWeightsShiftWithRecentServes` (~9 recent serves → ~1/10 the picks, no starvation), `TestRecentServeCounterDecay` (injected clock), `TestSatisficingBandServeCounterFedOnRealPath` (flag off), `TestSatisficingBandCacheAffinityPinnedWithinBand`.

Suite status: **re-verified 2026-07-07 by ship-prep: `go test ./registry/... ./api/...` ok in the worktree.**

## Review status

**Codex rescue: FAIL → fixed in `083279ba`** (self-route preflight missing the version floor; uncalibrated shadow TTFT), then **independent reviewer: PASS** on the fixed stack (dual-reviewed per JOURNAL.md Foundry row).

## Rollout notes

- **Deploy batch B.** At deploy, everything is inert or self-limiting: V2 floor + model floors empty (off), band off, fallback mode off; the medians layer is on by default but has no samples until v0.7.5 boxes report `observed_prefill_tps`; the `MAX_PREFILL_TPS` ceiling raise is behavior-neutral on today's non-reporting fleet.
- Flip sequence (see runbook): `PREFILL_FALLBACK_MODE=shadow` at Deploy B → floors (`V2_VERSION_FLOOR=0.7.5`, `MODEL_VERSION_FLOORS=gemma-4=0.7.5`) at ≥70% online adoption → `enforce` at step 7 if shadow numbers validate → `SATISFICING_BAND=true` canary last, after gemma stabilizes.
- **Close PR #453** when this merges; note it on #453 with a pointer here.
- Retirement: `MODEL_VERSION_FLOORS` retires after fleet convergence; `V2_VERSION_FLOOR` stays (permanent fail-loud audit). The #453 anchor and the ratio chain both retire naturally per (model, chip) pair as real measurements take over.
- Merge-order note: **stacked on coord-a** — merge coord-a first; GitHub retargets this PR's base to master when the coord-a branch merges. Conflicts with coord-b (`cmd/coordinator/main.go`, `registry/concurrency_cap.go`, `registry/warm_pool_controller.go`, docs): whichever of coord-b/coord-c merges second takes the rebase.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/526"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786081383&installation_id=133247490&pr_number=526&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F526&signature=392f9137c5b7eb80c4d03c2de97169e76e90ae64b1e0137b9d07d2f084a5e4ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->