### PR TITLE
fix(routing): correct capacity-rate window accounting

### DIFF
--- a/coordinator/api/capacity_cooldown_followups_test.go
+++ b/coordinator/api/capacity_cooldown_followups_test.go
@@ -231,14 +231,10 @@ func TestGrayBoxClassificationTrustsStructuredReason(t *testing.T) {
 	}
 }
 
-// After-commit client-gone regression (Codex review of #523): a stream that
-// commits BEFORE the pair's first windowed reject, then the consumer
-// disconnects and the provider completes into the PARKED settlement path
-// (handleComplete, consumerGone=true), must still enter the capacity-503 rate
-// denominator. noteInferenceSuccess — which re-offers the outcome on clean
-// completion — never runs on this path, so without the handleComplete re-offer
-// the served completion vanishes and a few later 503s overstate a healthy
-// pair's reject rate.
+// After-commit client-gone regression: a stream that commits before the pair's
+// first windowed reject records its accept immediately. If the consumer then
+// disconnects and the provider completes into the parked settlement path,
+// handleComplete must observe the commit-time stamp and avoid counting it again.
 func TestCapacityRateParkedCompletionCountsAtHandleComplete(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	st := store.NewMemory(store.Config{AdminKey: "test-key"})
@@ -251,22 +247,22 @@ func TestCapacityRateParkedCompletionCountsAtHandleComplete(t *testing.T) {
 	pr := capacityTestPending(model, p.ID, 1)
 	pr.ConsumerKey = "test-key"
 
-	// Commit first content while the pair is healthy (no reject in-window yet):
-	// mirrors commitFirstContent — the offer records nothing, so the request
-	// still owes its one rate outcome (RateOutcomeCountedSafe stays false).
-	if reg.RecordCapacityAccept(pr.ProviderID, model) {
-		t.Fatal("commit-time accept with an empty reject window must not record a rate outcome")
+	// Commit first content while the pair is healthy (no reject in-window yet),
+	// mirroring commitFirstContent and its request-local exactly-once stamp.
+	if !reg.RecordCapacityAccept(pr.ProviderID, model) {
+		t.Fatal("commit-time accept must be retained before the first reject")
 	}
+	pr.MarkRateOutcomeCounted()
 
 	// The pair goes gray while the (now client-gone) stream is still serving.
 	reg.RecordCapacityReject(pr.ProviderID, model)
-	if _, samples := reg.CapacityRejectRate(pr.ProviderID, model); samples != 1 {
-		t.Fatalf("setup: samples=%d after one reject, want 1", samples)
+	if _, samples := reg.CapacityRejectRate(pr.ProviderID, model); samples != 2 {
+		t.Fatalf("setup: samples=%d after one accept and one reject, want 2", samples)
 	}
 
 	// Consumer disconnected mid-stream: the request is parked (no reader), then
 	// the provider completes. handleComplete claims the parked record
-	// (consumerGone=true) and must re-offer the served completion.
+	// (consumerGone=true) and must not re-offer the already recorded accept.
 	srv.holdForSettlement(pr)
 	srv.handleComplete(p.ID, p, &protocol.InferenceCompleteMessage{
 		Type:      protocol.TypeInferenceComplete,
@@ -276,7 +272,7 @@ func TestCapacityRateParkedCompletionCountsAtHandleComplete(t *testing.T) {
 
 	rate, samples := reg.CapacityRejectRate(pr.ProviderID, model)
 	if samples != 2 {
-		t.Fatalf("samples=%d after the parked completion, want 2 (1 reject + the served client-gone stream) — the parked completion never entered the denominator", samples)
+		t.Fatalf("samples=%d after parked completion, want 2 — completion double-counted the commit", samples)
 	}
 	if rate != 0.5 {
 		t.Fatalf("rate=%.2f, want 0.5 (1 reject / 2 outcomes)", rate)

--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -406,12 +406,9 @@ func (s *Server) noteInferenceSuccess(pr *registry.PendingRequest) {
 	// count exactly ONE outcome, so this completion-time accept re-offers the
 	// outcome only when the commit-time accept did not actually RECORD one
 	// (RateOutcomeCountedSafe — stamped from RecordCapacityAccept's return at
-	// every commit site). Keying on the recorded outcome rather than on
-	// ContentCommittedSafe covers the stream that committed BEFORE the pair's
-	// first windowed reject (nothing recorded then — accepts only store while
-	// a reject is in-window) but was still serving during the rejects: it
-	// enters the denominator here instead of vanishing and letting a few
-	// later 503s overstate a healthy pair's reject rate.
+	// every commit site). With rate tracking enabled, commit-time accepts are
+	// retained even before the first reject; paths that never commit content
+	// record their sole outcome here instead.
 	s.registry.RecordCapacityAcceptOutcome(pr.ProviderID, pr.Model, !pr.RateOutcomeCountedSafe())
 	// A clean completion proves the node is healthy — close its node-health
 	// breaker (and reset the exponential backoff) if it had tripped.

--- a/coordinator/api/dispatch.go
+++ b/coordinator/api/dispatch.go
@@ -419,10 +419,9 @@ func (d *dispatchState) commitFirstContent(pr *registry.PendingRequest, chunk st
 	// legitimately sheds concurrent dispatches — waiting for the completion
 	// accept (noteInferenceSuccess) would let transient fullness masquerade as
 	// the zero-accepts black-hole signature. See registry/capacity_cooldown.go.
-	// The return says whether the pair's capacity-503 RATE window actually
-	// stored this accept (only while a reject is in-window) — stamp it so the
-	// completion-time accept knows whether the request still owes its one
-	// denominator outcome (noteInferenceSuccess).
+	// The return says whether the pair's capacity-503 RATE window stored this
+	// accept. The enabled tracker retains it even before the first reject; stamp
+	// the request so completion cannot add the same denominator outcome twice.
 	if d.s.registry.RecordCapacityAccept(pr.ProviderID, pr.Model) {
 		pr.MarkRateOutcomeCounted()
 	}

--- a/coordinator/api/provider.go
+++ b/coordinator/api/provider.go
@@ -1595,13 +1595,11 @@ func (s *Server) handleComplete(providerID string, provider *registry.Provider, 
 		// (capacity_rate.go denominator). On the clean-completion path
 		// noteInferenceSuccess re-offers it, but that never runs here — the
 		// consumer handler already returned. Re-offer it now, keyed on the
-		// recorded outcome exactly as noteInferenceSuccess does: a stream that
-		// committed BEFORE the pair's first windowed reject recorded nothing at
-		// commit (RateOutcomeCountedSafe=false), so without this it would vanish
-		// from the denominator and a few later 503s would overstate a healthy
-		// pair's reject rate. A commit that already recorded passes
-		// countRateOutcome=false and cannot double-count. Uses pr.ProviderID
-		// (the committed attempt's provider) to match the commit-time key.
+		// recorded outcome exactly as noteInferenceSuccess does. Commit-time
+		// accepts are retained even before the first reject; a commit that already
+		// recorded passes countRateOutcome=false and cannot double-count. A path
+		// without a recorded commit contributes its sole outcome here. Uses
+		// pr.ProviderID (the committed attempt's provider) to match the commit key.
 		s.registry.RecordCapacityAcceptOutcome(pr.ProviderID, pr.Model, !pr.RateOutcomeCountedSafe())
 	}
 

--- a/coordinator/registry/capacity_cooldown.go
+++ b/coordinator/registry/capacity_cooldown.go
@@ -357,10 +357,10 @@ func (r *Registry) claimCapacityProbeLocked(providerID, modelID string, now time
 // is also left untouched: ejection doesn't cancel in-flight work, so content
 // can flow from an ejected node, and lifting the quarantine early on it would
 // defeat the cooldown — recovery goes through the half-open success probe.
-// It returns whether a capacity-503 RATE outcome was actually recorded for
-// this accept (see RecordCapacityAcceptOutcome) so commit-time callers can
-// stamp the request (MarkRateOutcomeCounted) and the completion-time accept
-// can decide whether the request still owes its one rate outcome.
+// It returns whether a capacity-503 RATE outcome was recorded for this accept
+// (see RecordCapacityAcceptOutcome) so commit-time callers can stamp the request
+// (MarkRateOutcomeCounted) and the completion-time accept can decide whether the
+// request still owes its one rate outcome.
 func (r *Registry) RecordCapacityAccept(providerID, modelID string) (rateOutcomeRecorded bool) {
 	return r.RecordCapacityAcceptOutcome(providerID, modelID, true)
 }
@@ -368,46 +368,42 @@ func (r *Registry) RecordCapacityAccept(providerID, modelID string) (rateOutcome
 // RecordCapacityAcceptOutcome is RecordCapacityAccept with explicit control
 // over the capacity-503 RATE window's denominator (capacity_rate.go).
 // countRateOutcome=true OFFERS one served-dispatch outcome; whether it was
-// actually RECORDED is the return value — the rate window only stores accepts
-// while the pair has a reject in-window (recordCapacityRateAcceptLocked), so a
-// commit that lands before any reject is an offer that records nothing. The
-// api layer offers at the commit point (first content chunk) and stamps the
-// request when the offer recorded (MarkRateOutcomeCounted); the completion-
-// time accept re-offers ONLY when the commit-time offer did not record
-// (!RateOutcomeCountedSafe) — so a long stream that committed pre-reject and
-// completed during the reject window still enters the denominator exactly
-// once, and a request whose commit already recorded cannot double-count and
-// dilute the reject rate. The cooldown/streak/clamp accept semantics below
-// are identical for both values (belt-and-braces accepts stay harmless there).
+// actually RECORDED is the return value. While the tracker is enabled, accepts
+// are retained even before the first reject so the five-minute denominator is
+// independent of event order. The api layer offers at the commit point (first
+// content chunk) and stamps the request when the offer recorded
+// (MarkRateOutcomeCounted); the completion-time accept re-offers ONLY when the
+// commit-time offer did not record (!RateOutcomeCountedSafe), covering paths
+// that never commit content without double-counting streamed requests. The
+// cooldown/streak/clamp accept semantics below are identical for both values
+// (belt-and-braces accepts stay harmless there).
 func (r *Registry) RecordCapacityAcceptOutcome(providerID, modelID string, countRateOutcome bool) (rateOutcomeRecorded bool) {
 	if providerID == "" || modelID == "" {
 		return false
 	}
-	// Fast path: this runs once per served request, and for a healthy pair all
-	// the maps are empty — check under the read lock so the serving hot path
-	// does not serialize on r.mu write acquisition. A rate-outcome accept only
-	// needs the write lock when the pair has rejects in its rate window
-	// (recordCapacityRateAcceptLocked is what builds the denominator, and a
-	// zero-reject pair's rate is 0 regardless — capacityRatePenaltyLocked
-	// fast-exits on rejects==0 — so skipping the append loses nothing).
-	r.mu.RLock()
-	key := capacityRejectKey{ProviderID: r.faultKeyLocked(providerID), ModelID: modelID}
-	_, hasStrikes := r.capacityRejectStrikes[key]
-	_, hasCooldown := r.capacityCooldowns[key]
-	_, hasTrips := r.capacityCooldownTrips[key]
-	_, hasClamp := r.budgetClamps[key]
-	hasRateRejects := len(r.capacityRateRejects[key]) > 0
-	_, hasNodeStreak := r.healthEjectionCapacityStreaks[key.ProviderID]
-	capacityTripped := r.healthEjectionLastTripCapacity[key.ProviderID]
-	r.mu.RUnlock()
-	if !hasStrikes && !hasCooldown && !hasTrips && !hasClamp && !hasRateRejects && !hasNodeStreak && !capacityTripped {
-		// Nothing recorded: with no reject in the rate window the accept
-		// would not be stored anyway (see recordCapacityRateAcceptLocked).
-		return false
+	// The rate config is immutable after Registry construction. An enabled
+	// offered outcome is the common path and already requires the write lock, so
+	// skip a redundant read-lock probe. Completion calls that already counted
+	// their rate outcome retain the old healthy fast path: use the read lock to
+	// avoid write acquisition when there is no cooldown/clamp state to clear.
+	shouldRecordRate := countRateOutcome && r.capacityRateCfg.PenaltyMs > 0
+	if !shouldRecordRate {
+		r.mu.RLock()
+		key := capacityRejectKey{ProviderID: r.faultKeyLocked(providerID), ModelID: modelID}
+		_, hasStrikes := r.capacityRejectStrikes[key]
+		_, hasCooldown := r.capacityCooldowns[key]
+		_, hasTrips := r.capacityCooldownTrips[key]
+		_, hasClamp := r.budgetClamps[key]
+		_, hasNodeStreak := r.healthEjectionCapacityStreaks[key.ProviderID]
+		capacityTripped := r.healthEjectionLastTripCapacity[key.ProviderID]
+		r.mu.RUnlock()
+		if !hasStrikes && !hasCooldown && !hasTrips && !hasClamp && !hasNodeStreak && !capacityTripped {
+			return false
+		}
 	}
 	r.mu.Lock()
 	now := time.Now()
-	key = capacityRejectKey{ProviderID: r.faultKeyLocked(providerID), ModelID: modelID}
+	key := capacityRejectKey{ProviderID: r.faultKeyLocked(providerID), ModelID: modelID}
 	delete(r.capacityRejectStrikes, key)
 	delete(r.capacityCooldowns, key)
 	delete(r.capacityCooldownTrips, key)
@@ -420,8 +416,10 @@ func (r *Registry) RecordCapacityAcceptOutcome(providerID, modelID string, count
 	// a lingering inactive entry would keep every later accept for the pair off
 	// the read-lock fast path above and would re-block the identity's next
 	// budgetless reconnect window.
-	r.noteBudgetClampAcceptLocked(key)
-	r.dropInactiveBudgetClampLocked(providerID, modelID, now)
+	if _, hasClamp := r.budgetClamps[key]; hasClamp {
+		r.noteBudgetClampAcceptLocked(key)
+		r.dropInactiveBudgetClampLocked(providerID, modelID, now)
+	}
 	if countRateOutcome {
 		rateOutcomeRecorded = r.recordCapacityRateAcceptLocked(key, now)
 	}

--- a/coordinator/registry/capacity_rate.go
+++ b/coordinator/registry/capacity_rate.go
@@ -1,6 +1,7 @@
 package registry
 
 import (
+	"sort"
 	"time"
 
 	"github.com/eigeninference/d-inference/coordinator/env"
@@ -34,15 +35,12 @@ import (
 //
 // One served request counts as ONE accept outcome: the api layer OFFERS the
 // accept at the commit point (first content chunk) and stamps the request when
-// the offer actually recorded (accepts are only stored while a reject is in
-// the window — see recordCapacityRateAcceptLocked); at clean completion it
-// re-offers only when the commit-time offer did not record
-// (!RateOutcomeCountedSafe), which covers both paths that never commit content
-// AND streams that committed BEFORE the pair's first windowed reject but were
-// still serving during it — without the re-offer those served requests would
-// vanish from the denominator and a few later rejects would overstate a
-// healthy pair's rate. Commit-recorded XOR completion-recorded, so the
-// denominator is per-dispatch honest.
+// the offer records; at clean completion it re-offers only when the commit-time
+// offer did not record (!RateOutcomeCountedSafe), which covers paths that never
+// commit content. Accepts are retained even before the first reject so a later
+// reject burst is measured against every recent served dispatch, not against an
+// artificially reject-only window. Commit-recorded XOR completion-recorded, so
+// the denominator is per-dispatch honest.
 // Rejects are recorded once per failed dispatch attempt by
 // RecordCapacityReject.
 //
@@ -91,51 +89,76 @@ func (r *Registry) recordCapacityRateRejectLocked(key capacityRejectKey, now tim
 	if r.capacityRateCfg.PenaltyMs <= 0 {
 		return
 	}
-	sweepCapacityRateMapLocked(r.capacityRateRejects, now)
+	_, existed := r.capacityRateRejects[key]
 	r.capacityRateRejects[key] = appendWindowedOutcome(r.capacityRateRejects[key], now)
+	if !existed {
+		sweepCapacityRateMapLocked(r.capacityRateRejects, now)
+	}
+
+	// A pair may have gone quiet long enough for its accept-only history to
+	// expire before this first/new reject. Prune it now so repeated routing reads
+	// do not keep scanning stale timestamps and the first rate uses only the same
+	// five-minute window as the reject side.
+	if accepts, ok := r.capacityRateAccepts[key]; ok {
+		accepts = pruneWindowedOutcomes(accepts, now)
+		if len(accepts) == 0 {
+			delete(r.capacityRateAccepts, key)
+		} else {
+			r.capacityRateAccepts[key] = accepts
+		}
+	}
 }
 
 // recordCapacityRateAcceptLocked appends one served-dispatch outcome for the
-// pair and prunes the window. Accepts are recorded only while the pair has a
-// capacity-503 inside the window: the penalty math fast-exits at rejects==0
-// regardless, so pre-reject accepts add nothing, and skipping them keeps
-// RecordCapacityAccept's healthy-pair read-lock fast path intact (a served
-// request on a never-rejecting pair never takes the write lock for this).
-// Once the reject side has fully decayed, the pair's slices are dropped
-// instead — state returns to empty and the fast path is restored. Returns
-// whether the accept was actually stored, so the api layer can stamp the
-// request (MarkRateOutcomeCounted) and let its completion re-offer when the
-// commit-time offer recorded nothing. Caller holds the r.mu write lock
-// (called from RecordCapacityAccept with countRateOutcome=true).
+// pair and prunes the window. Accepts are retained before, during, and after a
+// reject window: a first reject must be divided by all recent dispatch outcomes,
+// and accepts that outlive the last reject must remain available to a new burst.
+// The rate/penalty read paths still return zero while no reject is in-window, so
+// this healthy history is observationally dormant. Returns whether the accept
+// was stored so the api layer can stamp the request (MarkRateOutcomeCounted)
+// and prevent completion from double-counting it. Caller holds r.mu for write.
 func (r *Registry) recordCapacityRateAcceptLocked(key capacityRejectKey, now time.Time) (recorded bool) {
 	if r.capacityRateCfg.PenaltyMs <= 0 {
 		return false
 	}
-	if countInWindow(r.capacityRateRejects[key], now) == 0 {
-		delete(r.capacityRateRejects, key)
-		delete(r.capacityRateAccepts, key)
-		return false
-	}
-	sweepCapacityRateMapLocked(r.capacityRateAccepts, now)
+	_, existed := r.capacityRateAccepts[key]
 	r.capacityRateAccepts[key] = appendWindowedOutcome(r.capacityRateAccepts[key], now)
+	if !existed {
+		sweepCapacityRateMapLocked(r.capacityRateAccepts, now)
+	}
 	return true
 }
 
-// appendWindowedOutcome slides the window (keeps only in-window timestamps)
-// and appends the new outcome, reusing the backing array.
-func appendWindowedOutcome(outcomes []time.Time, now time.Time) []time.Time {
-	kept := outcomes[:0]
-	for _, ts := range outcomes {
-		if now.Sub(ts) < capacityRateWindow {
-			kept = append(kept, ts)
-		}
+// pruneWindowedOutcomes keeps only timestamps strictly inside the sliding
+// window. Outcome histories are chronological, so binary search avoids scanning
+// a hot pair's whole five-minute history on every accept. Reslicing instead of
+// compacting makes steady-state expiry amortized O(1); append occasionally grows
+// the backing array and releases the skipped prefix.
+func pruneWindowedOutcomes(outcomes []time.Time, now time.Time) []time.Time {
+	cutoff := now.Add(-capacityRateWindow)
+	first := sort.Search(len(outcomes), func(i int) bool {
+		return outcomes[i].After(cutoff)
+	})
+	if first == 0 {
+		return outcomes
 	}
-	return append(kept, now)
+	if first == len(outcomes) {
+		return outcomes[:0]
+	}
+	return outcomes[first:]
+}
+
+// appendWindowedOutcome slides the chronological window and appends the new
+// outcome, reusing the backing array.
+func appendWindowedOutcome(outcomes []time.Time, now time.Time) []time.Time {
+	return append(pruneWindowedOutcomes(outcomes, now), now)
 }
 
 // sweepCapacityRateMapLocked bounds a rate map by dropping pairs whose newest
 // outcome has aged out of the window, once the map grows (mirrors the sibling
 // cooldown sweeps — churned session-keyed identities are never re-keyed).
+// Histories must remain chronological because this deliberately uses the tail
+// for an O(1) newest check while holding the registry lock.
 func sweepCapacityRateMapLocked(m map[capacityRejectKey][]time.Time, now time.Time) {
 	if len(m) <= 1024 {
 		return
@@ -148,15 +171,13 @@ func sweepCapacityRateMapLocked(m map[capacityRejectKey][]time.Time, now time.Ti
 }
 
 // countInWindow counts timestamps still inside the window without mutating the
-// slice, so read paths stay safe under r.mu.RLock.
+// chronological slice, so read paths stay safe under r.mu.RLock.
 func countInWindow(outcomes []time.Time, now time.Time) int {
-	n := 0
-	for _, ts := range outcomes {
-		if now.Sub(ts) < capacityRateWindow {
-			n++
-		}
-	}
-	return n
+	cutoff := now.Add(-capacityRateWindow)
+	first := sort.Search(len(outcomes), func(i int) bool {
+		return outcomes[i].After(cutoff)
+	})
+	return len(outcomes) - first
 }
 
 // capacityRatePenaltyLocked returns the cost penalty (ms) and the measured
@@ -191,6 +212,9 @@ func (r *Registry) CapacityRejectRate(providerID, modelID string) (rate float64,
 	now := time.Now()
 	key := capacityRejectKey{ProviderID: r.faultKeyLocked(providerID), ModelID: modelID}
 	rejects := countInWindow(r.capacityRateRejects[key], now)
+	if rejects == 0 {
+		return 0, 0
+	}
 	accepts := countInWindow(r.capacityRateAccepts[key], now)
 	total := rejects + accepts
 	if total == 0 {

--- a/coordinator/registry/capacity_rate_followup_test.go
+++ b/coordinator/registry/capacity_rate_followup_test.go
@@ -1,0 +1,228 @@
+package registry
+
+import (
+	"fmt"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/attestation"
+)
+
+// Recent accepts must already be in the denominator when a pair records its
+// first capacity reject. Otherwise a short reject burst after sustained healthy
+// traffic reads as a 100% reject rate and applies the maximum derating penalty.
+func TestCapacityRateFirstRejectIncludesRecentAccepts(t *testing.T) {
+	r := New(testLogger())
+	const provider, model = "prov-pre-reject-accepts", "gemma-4-26b-qat-4bit"
+
+	for i := 0; i < 100; i++ {
+		if recorded := r.RecordCapacityAccept(provider, model); !recorded {
+			t.Fatalf("healthy accept %d was not retained for a later reject window", i+1)
+		}
+	}
+	if rate, samples := r.CapacityRejectRate(provider, model); rate != 0 || samples != 0 {
+		t.Fatalf("accept-only history must stay observationally inactive: rate=%v samples=%d, want 0/0", rate, samples)
+	}
+
+	for i := 0; i < capacityRateMinSample; i++ {
+		r.RecordCapacityReject(provider, model)
+	}
+
+	rate, samples := r.CapacityRejectRate(provider, model)
+	wantRate := float64(capacityRateMinSample) / float64(100+capacityRateMinSample)
+	if samples != 100+capacityRateMinSample {
+		t.Fatalf("samples = %d, want %d recent accepts + rejects", samples, 100+capacityRateMinSample)
+	}
+	if math.Abs(rate-wantRate) > 1e-12 {
+		t.Fatalf("rate = %v, want %v", rate, wantRate)
+	}
+	if penalty, _ := capacityRatePenaltyOf(r, provider, model); penalty != 0 {
+		t.Fatalf("penalty = %v at healthy-window rate %v, want 0", penalty, rate)
+	}
+}
+
+// The first reject prunes accept-only history against the same strict window
+// boundary: exactly-window-old outcomes are excluded, while a newer outcome is
+// retained. Use a fixed clock so nanosecond boundary behavior is deterministic.
+func TestCapacityRateFirstRejectPrunesExpiredAccepts(t *testing.T) {
+	r := New(testLogger())
+	const provider, model = "prov-accept-window", "gemma-4-26b-qat-4bit"
+	now := time.Now()
+	key := capacityRejectKey{ProviderID: provider, ModelID: model}
+
+	r.mu.Lock()
+	r.capacityRateAccepts[key] = []time.Time{
+		now.Add(-capacityRateWindow - time.Nanosecond),
+		now.Add(-capacityRateWindow),
+		now.Add(-capacityRateWindow + time.Nanosecond),
+	}
+	r.recordCapacityRateRejectLocked(key, now)
+	rejects := countInWindow(r.capacityRateRejects[key], now)
+	accepts := countInWindow(r.capacityRateAccepts[key], now)
+	r.mu.Unlock()
+
+	if rejects != 1 || accepts != 1 {
+		t.Fatalf("windowed outcomes = rejects %d accepts %d, want 1/1", rejects, accepts)
+	}
+}
+
+// Pruning runs while the global registry lock is held. Once a hot pair reaches
+// the five-minute horizon, an expired prefix is normal on nearly every accept;
+// the helper must advance the slice rather than copy the whole live window back
+// to index zero each time.
+func TestPruneWindowedOutcomesDropsPrefixWithoutCompaction(t *testing.T) {
+	now := time.Now()
+	outcomes := []time.Time{
+		now.Add(-capacityRateWindow - time.Second),
+		now.Add(-time.Minute),
+		now,
+	}
+	pruned := pruneWindowedOutcomes(outcomes, now)
+	if len(pruned) != 2 {
+		t.Fatalf("pruned length = %d, want 2", len(pruned))
+	}
+	if &pruned[0] != &outcomes[1] {
+		t.Fatal("pruning compacted the live window instead of advancing the expired prefix")
+	}
+}
+
+func TestMergeChronologicalTimestampsPreservesEqualOutcomes(t *testing.T) {
+	ts := time.Now()
+	merged := mergeChronologicalTimestamps([]time.Time{ts}, []time.Time{ts})
+	if len(merged) != 2 || merged[0] != ts || merged[1] != ts {
+		t.Fatalf("equal timestamp merge = %v, want two distinct outcomes", merged)
+	}
+}
+
+// Rate calculation must depend only on the five-minute multiset, not whether
+// the healthy traffic came before, after, or between the rejects.
+func TestCapacityRateIsIndependentOfOutcomeOrder(t *testing.T) {
+	const model = "gemma-4-26b-qat-4bit"
+	for _, tc := range []struct {
+		name   string
+		record func(r *Registry, provider string)
+	}{
+		{
+			name: "accepts first",
+			record: func(r *Registry, provider string) {
+				seedRateOutcomes(r, provider, model, 0, 12)
+				seedRateOutcomes(r, provider, model, 4, 0)
+			},
+		},
+		{
+			name: "rejects first",
+			record: func(r *Registry, provider string) {
+				seedRateOutcomes(r, provider, model, 4, 12)
+			},
+		},
+		{
+			name: "interleaved",
+			record: func(r *Registry, provider string) {
+				for i := 0; i < 4; i++ {
+					r.RecordCapacityReject(provider, model)
+					for j := 0; j < 3; j++ {
+						r.RecordCapacityAccept(provider, model)
+					}
+				}
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			r := New(testLogger())
+			provider := "prov-order-" + tc.name
+			tc.record(r, provider)
+			rate, samples := r.CapacityRejectRate(provider, model)
+			if samples != 16 || math.Abs(rate-0.25) > 1e-12 {
+				t.Fatalf("rate window = (%v, %d), want (0.25, 16)", rate, samples)
+			}
+		})
+	}
+}
+
+// Identity enrichment can merge a stale source history into a destination
+// that already has fresh state from a previous connection. Every timestamp
+// history must remain oldest-to-newest because the bounded-map sweeps use the
+// tail as the newest outcome. This exercises the real sekey -> serial rebind
+// and the >1024 cleanup consequence for both rate maps.
+func TestFaultTimestampHistoriesStayOrderedAcrossIdentityRebind(t *testing.T) {
+	r := New(testLogger())
+	const (
+		provider  = "rate-rebind-session"
+		model     = "gemma-4-26b-qat-4bit"
+		publicKey = "PK-RATE-REBIND"
+		serial    = "SER-RATE-REBIND"
+	)
+
+	p := makeSchedulerProvider(t, r, provider, model, 100)
+	p.SetAttestationResult(&attestation.VerificationResult{Valid: true, PublicKey: publicKey})
+	oldID := "sekey:" + publicKey
+	newID := "serial:" + serial
+	if got := faultKeyOf(r, provider); got != oldID {
+		t.Fatalf("initial fault key = %q, want %q", got, oldID)
+	}
+
+	now := time.Now()
+	expired := now.Add(-capacityRateWindow - time.Minute)
+	fresh := now.Add(-time.Minute)
+	oldRateKey := capacityRejectKey{ProviderID: oldID, ModelID: model}
+	newRateKey := capacityRejectKey{ProviderID: newID, ModelID: model}
+	oldInferenceKey := inferenceErrorKey{ProviderID: oldID, ModelID: model, Shape: "base"}
+	newInferenceKey := inferenceErrorKey{ProviderID: newID, ModelID: model, Shape: "base"}
+
+	r.mu.Lock()
+	r.inferenceErrorStrikes[oldInferenceKey] = []time.Time{expired}
+	r.inferenceErrorStrikes[newInferenceKey] = []time.Time{fresh}
+	r.capacityRejectStrikes[oldRateKey] = []time.Time{expired}
+	r.capacityRejectStrikes[newRateKey] = []time.Time{fresh}
+	r.capacityRateRejects[oldRateKey] = []time.Time{expired}
+	r.capacityRateRejects[newRateKey] = []time.Time{fresh}
+	r.capacityRateAccepts[oldRateKey] = []time.Time{expired}
+	r.capacityRateAccepts[newRateKey] = []time.Time{fresh}
+	for i := 0; i < 1024; i++ {
+		key := capacityRejectKey{ProviderID: fmt.Sprintf("expired-rate-%d", i), ModelID: model}
+		r.capacityRateRejects[key] = []time.Time{expired}
+		r.capacityRateAccepts[key] = []time.Time{expired}
+	}
+	r.mu.Unlock()
+
+	p.SetAttestationResult(&attestation.VerificationResult{
+		Valid: true, PublicKey: publicKey, SerialNumber: serial,
+	})
+	if got := faultKeyOf(r, provider); got != newID {
+		t.Fatalf("enriched fault key = %q, want %q", got, newID)
+	}
+
+	r.mu.Lock()
+	mergedInference := append([]time.Time(nil), r.inferenceErrorStrikes[newInferenceKey]...)
+	mergedCapacity := append([]time.Time(nil), r.capacityRejectStrikes[newRateKey]...)
+	mergedRejects := append([]time.Time(nil), r.capacityRateRejects[newRateKey]...)
+	mergedAccepts := append([]time.Time(nil), r.capacityRateAccepts[newRateKey]...)
+	_, oldInferenceRemains := r.inferenceErrorStrikes[oldInferenceKey]
+	_, oldCapacityRemains := r.capacityRejectStrikes[oldRateKey]
+	_, oldRejectsRemain := r.capacityRateRejects[oldRateKey]
+	_, oldAcceptsRemain := r.capacityRateAccepts[oldRateKey]
+	sweepCapacityRateMapLocked(r.capacityRateRejects, now)
+	sweepCapacityRateMapLocked(r.capacityRateAccepts, now)
+	freshRejects := countInWindow(r.capacityRateRejects[newRateKey], now)
+	freshAccepts := countInWindow(r.capacityRateAccepts[newRateKey], now)
+	r.mu.Unlock()
+
+	for name, history := range map[string][]time.Time{
+		"inference strikes": mergedInference,
+		"capacity strikes":  mergedCapacity,
+		"rate rejects":      mergedRejects,
+		"rate accepts":      mergedAccepts,
+	} {
+		if len(history) != 2 || history[0] != expired || history[1] != fresh {
+			t.Errorf("%s after rebind = %v, want [expired, fresh]", name, history)
+		}
+	}
+	if oldInferenceRemains || oldCapacityRemains || oldRejectsRemain || oldAcceptsRemain {
+		t.Fatalf("source identity retained timestamp state: inference=%v capacity=%v rejects=%v accepts=%v",
+			oldInferenceRemains, oldCapacityRemains, oldRejectsRemain, oldAcceptsRemain)
+	}
+	if freshRejects != 1 || freshAccepts != 1 {
+		t.Fatalf("fresh migrated rate history was lost by bounded sweep: rejects=%d accepts=%d, want 1/1", freshRejects, freshAccepts)
+	}
+}

--- a/coordinator/registry/capacity_rate_test.go
+++ b/coordinator/registry/capacity_rate_test.go
@@ -21,9 +21,8 @@ func capacityRatePenaltyOf(r *Registry, providerID, model string) (penaltyMs, ra
 	return r.capacityRatePenaltyLocked(providerID, model, time.Now())
 }
 
-// seedRateOutcomes drives the real entry points: rejects first (accepts only
-// count into the window while a reject is present — see
-// recordCapacityRateAcceptLocked), then accepts.
+// seedRateOutcomes drives the real entry points in reject-first order. Other
+// tests cover accept-first and interleaved ordering explicitly.
 func seedRateOutcomes(r *Registry, providerID, model string, rejects, accepts int) {
 	for i := 0; i < rejects; i++ {
 		r.RecordCapacityReject(providerID, model)
@@ -118,8 +117,8 @@ func TestCapacityRateAtThresholdNoPenalty(t *testing.T) {
 }
 
 // Outcomes age out of the window naturally — no reset event required. Once the
-// rejects decay the penalty is gone, and the next accept clears the residual
-// state entirely (restoring the healthy-pair fast path).
+// rejects decay the penalty is gone, while still-recent accepts remain hidden
+// but available to the next reject window.
 func TestCapacityRateDecays(t *testing.T) {
 	r := New(testLogger())
 	const provider, model = "prov-decay", "gemma-4-26b-qat-4bit"
@@ -132,15 +131,16 @@ func TestCapacityRateDecays(t *testing.T) {
 	if penalty, rate := capacityRatePenaltyOf(r, provider, model); penalty != 0 || rate != 0 {
 		t.Fatalf("penalty=%v rate=%v after the rejects aged out, want 0/0", penalty, rate)
 	}
-	// An accept on the fully-decayed pair clears the residual slices.
+	// A later accept keeps the recent denominator warm. The stale reject slice is
+	// observationally inert; accept history must not be deleted just because the
+	// last reject expired.
 	r.RecordCapacityAcceptOutcome(provider, model, true)
 	r.mu.RLock()
 	key := capacityRejectKey{ProviderID: provider, ModelID: model}
-	_, hasRejects := r.capacityRateRejects[key]
-	_, hasAccepts := r.capacityRateAccepts[key]
+	accepts := countInWindow(r.capacityRateAccepts[key], time.Now())
 	r.mu.RUnlock()
-	if hasRejects || hasAccepts {
-		t.Fatal("decayed rate state must be dropped on the next accept")
+	if accepts != 7 {
+		t.Fatalf("recent accept history = %d, want 7 after the new accept", accepts)
 	}
 }
 
@@ -298,22 +298,18 @@ func TestCapacityRateNeverClosesRouting(t *testing.T) {
 	}
 }
 
-// A stream that commits BEFORE the pair's first windowed reject must still
-// enter the rate denominator when it is serving THROUGH the rejects: the
-// commit-time offer records nothing (accepts only store while a reject is
-// in-window), so the completion-time accept — keyed on the RECORDED outcome
-// (RateOutcomeCountedSafe), not on ContentCommittedSafe — re-offers it. Codex
-// review of #523: without this, a healthy pair serving long streams looked
-// like a 100%-reject gray box after a few later 503s.
-func TestCapacityRatePreRejectCommitCountsAtCompletion(t *testing.T) {
+// A stream that commits BEFORE the pair's first windowed reject is retained at
+// commit, so later rejects see it immediately and completion must not count it
+// again. This is the exactly-once contract behind RateOutcomeCountedSafe.
+func TestCapacityRatePreRejectCommitCountsExactlyOnce(t *testing.T) {
 	r := New(testLogger())
 	const model = "gemma-4-26b-qat-4bit"
 	p := makeTokenBudgetProvider(t, r, "pre-reject-commit", model, 100, grayBoxBudgetUsed, grayBoxBudgetMax, 100)
 
-	// Long stream commits first content while the pair is healthy: the offer
-	// must report NOT recorded (nothing in the reject window yet).
-	if recorded := r.RecordCapacityAccept(p.ID, model); recorded {
-		t.Fatal("commit-time accept with an empty reject window must not record a rate outcome")
+	// Long stream commits first content while the pair is healthy. Its accept is
+	// dormant until a reject arrives, but it is already retained and stamped.
+	if recorded := r.RecordCapacityAccept(p.ID, model); !recorded {
+		t.Fatal("commit-time accept must be retained before the first reject")
 	}
 
 	// The box goes gray while the stream is still serving: 8 capacity-503s.
@@ -321,11 +317,10 @@ func TestCapacityRatePreRejectCommitCountsAtCompletion(t *testing.T) {
 		r.RecordCapacityReject(p.ID, model)
 	}
 
-	// Completion: the api layer re-offers because the commit-time offer did
-	// not record (this is the noteInferenceSuccess wiring:
-	// countRateOutcome = !RateOutcomeCountedSafe → true here).
-	if recorded := r.RecordCapacityAcceptOutcome(p.ID, model, true); !recorded {
-		t.Fatal("completion-time re-offer during the reject window must record the request's one outcome")
+	// Completion sees RateOutcomeCountedSafe=true and passes false, so it cannot
+	// add the request a second time.
+	if recorded := r.RecordCapacityAcceptOutcome(p.ID, model, false); recorded {
+		t.Fatal("completion after a pre-reject commit must not record a second outcome")
 	}
 
 	rate, samples := r.CapacityRejectRate(p.ID, model)

--- a/coordinator/registry/health_ejection.go
+++ b/coordinator/registry/health_ejection.go
@@ -201,10 +201,10 @@ func (r *Registry) bindStableFaultKey(sessionID, stableID string) {
 // migrateFaultStateLocked re-keys every fault-tracking map entry from oldKey to
 // newKey so accumulated history follows an identity rebind. Merge policy where
 // both keys hold state: expiries and streak recency take the max, trip counts
-// take the max, strike slices are unioned (window pruning re-normalizes them on
-// the next record), and health windows are merged in timestamp order bounded by
-// the ring size (providerHealthWindow.merge) so an in-progress consecutive-fault
-// streak survives the rebind. Caller holds r.mu.
+// take the max, timestamp histories merge chronologically (their bounded-map
+// sweeps use the tail as the newest entry), and health windows are merged in
+// timestamp order bounded by the ring size (providerHealthWindow.merge) so an
+// in-progress consecutive-fault streak survives the rebind. Caller holds r.mu.
 func (r *Registry) migrateFaultStateLocked(oldKey, newKey string) {
 	if oldKey == "" || newKey == "" || oldKey == newKey {
 		return
@@ -227,7 +227,7 @@ func (r *Registry) migrateFaultStateLocked(oldKey, newKey string) {
 		if k.ProviderID == oldKey {
 			nk := k
 			nk.ProviderID = newKey
-			r.inferenceErrorStrikes[nk] = append(r.inferenceErrorStrikes[nk], strikes...)
+			r.inferenceErrorStrikes[nk] = mergeChronologicalTimestamps(r.inferenceErrorStrikes[nk], strikes)
 			delete(r.inferenceErrorStrikes, k)
 		}
 	}
@@ -269,7 +269,7 @@ func (r *Registry) migrateFaultStateLocked(oldKey, newKey string) {
 		if k.ProviderID == oldKey {
 			nk := k
 			nk.ProviderID = newKey
-			r.capacityRejectStrikes[nk] = append(r.capacityRejectStrikes[nk], strikes...)
+			r.capacityRejectStrikes[nk] = mergeChronologicalTimestamps(r.capacityRejectStrikes[nk], strikes)
 			delete(r.capacityRejectStrikes, k)
 		}
 	}
@@ -308,13 +308,14 @@ func (r *Registry) migrateFaultStateLocked(oldKey, newKey string) {
 		}
 	}
 
-	// Capacity-503 rate windows: union the outcome slices (window pruning
-	// re-normalizes them on the next record / read), like the strike slices.
+	// Capacity-503 rate windows: union the outcome slices chronologically. The
+	// large-map sweep uses the tail as the newest timestamp, so appending an older
+	// source history after a fresh destination would otherwise delete live state.
 	for k, outcomes := range r.capacityRateRejects {
 		if k.ProviderID == oldKey {
 			nk := k
 			nk.ProviderID = newKey
-			r.capacityRateRejects[nk] = append(r.capacityRateRejects[nk], outcomes...)
+			r.capacityRateRejects[nk] = mergeChronologicalTimestamps(r.capacityRateRejects[nk], outcomes)
 			delete(r.capacityRateRejects, k)
 		}
 	}
@@ -322,7 +323,7 @@ func (r *Registry) migrateFaultStateLocked(oldKey, newKey string) {
 		if k.ProviderID == oldKey {
 			nk := k
 			nk.ProviderID = newKey
-			r.capacityRateAccepts[nk] = append(r.capacityRateAccepts[nk], outcomes...)
+			r.capacityRateAccepts[nk] = mergeChronologicalTimestamps(r.capacityRateAccepts[nk], outcomes)
 			delete(r.capacityRateAccepts, k)
 		}
 	}
@@ -360,6 +361,34 @@ func (r *Registry) migrateFaultStateLocked(oldKey, newKey string) {
 		}
 		delete(r.healthEjectionLastTripCapacity, oldKey)
 	}
+}
+
+// mergeChronologicalTimestamps returns the oldest-to-newest union of two
+// already-ordered histories. Identity migration is rare, so allocate only when
+// both identities already hold state; the common move-to-empty case reuses the
+// source slice. Equal timestamps remain distinct outcomes.
+func mergeChronologicalTimestamps(dst, src []time.Time) []time.Time {
+	if len(dst) == 0 {
+		return src
+	}
+	if len(src) == 0 {
+		return dst
+	}
+
+	merged := make([]time.Time, 0, len(dst)+len(src))
+	i, j := 0, 0
+	for i < len(dst) && j < len(src) {
+		if !dst[i].After(src[j]) {
+			merged = append(merged, dst[i])
+			i++
+		} else {
+			merged = append(merged, src[j])
+			j++
+		}
+	}
+	merged = append(merged, dst[i:]...)
+	merged = append(merged, src[j:]...)
+	return merged
 }
 
 // faultKeyLocked resolves a session provider id to the key its fault state

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -219,10 +219,10 @@ type PendingRequest struct {
 	// outcome (capacity_rate.go denominator) was recorded by the commit-time
 	// accept — RecordCapacityAccept returned rateOutcomeRecorded=true. The
 	// completion-time accept (noteInferenceSuccess) re-offers the outcome only
-	// when this is false, so a stream that committed BEFORE the pair's first
-	// windowed reject but was still serving during it still counts, and a
-	// commit-recorded request cannot double-count. Guarded by timingMu like
-	// contentCommitted (same writer/reader goroutines).
+	// when this is false, covering requests that never commit content while a
+	// commit-recorded request cannot double-count. Accepts are retained before
+	// the first reject so event ordering cannot distort the five-minute rate.
+	// Guarded by timingMu like contentCommitted (same writer/reader goroutines).
 	rateOutcomeCounted bool
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #523. This corrects two capacity-rate accounting defects before the v0.7.5 coordinator stack is merged:

- retain every served dispatch for the five-minute denominator, including accepts before the first capacity reject;
- merge timestamp histories chronologically when a provider's stable identity is rebound, so bounded cleanup cannot discard fresh state;
- keep the new accept path bounded with binary-search window pruning, amortized prefix reslicing, new-key-only map sweeps, and clamp snapshot work only for pairs with a live clamp.

The same chronological merge helper is applied to inference-error and capacity-cooldown strike histories because they had the identical migration and tail-sweep invariant.

## Before

```mermaid
flowchart LR
  subgraph Behavior["Behavior before"]
    A[Recent successful dispatches] --> B[Accept history discarded]
    C[First capacity 503 burst] --> D[Reject-only rate]
    D --> E[False high routing penalty]
    F[Identity rebind with destination history] --> G[Older source appended last]
    G --> H[Large-map sweep can delete fresh state]
  end

  subgraph Code["Code before"]
    I[RecordCapacityAcceptOutcome] --> J{Reject already present}
    J -- No --> K[Return without rate outcome]
    J -- Yes --> L[Append accept]
    M[migrateFaultStateLocked] --> N[Append destination and source]
    N --> O[Sweep trusts final timestamp]
  end
```

## After

```mermaid
flowchart LR
  subgraph Behavior["Behavior after"]
    A[Every served dispatch] --> B[Retained for five-minute window]
    C[Capacity 503 burst] --> D[Rejects divided by all recent outcomes]
    D --> E[Penalty only above sample and rate thresholds]
    F[Identity rebind] --> G[Histories merged oldest to newest]
    G --> H[Large-map sweep preserves fresh state]
  end

  subgraph Code["Code after"]
    I[RecordCapacityAcceptOutcome] --> J[Append and reslice accept history]
    K[recordCapacityRateRejectLocked] --> L[Prune accepts and append reject]
    J --> M[Binary-search window counts]
    L --> M
    N[migrateFaultStateLocked] --> O[mergeChronologicalTimestamps]
    O --> P[Newest timestamp remains at tail]
  end
```

## Regression coverage

- 100 accepts followed by eight rejects reports `8/108`, not `8/8`.
- Accept-first, reject-first, and interleaved outcomes produce the same rate.
- Exact five-minute boundary behavior and accept-only history pruning.
- Commit, clean completion, and parked completion count each served dispatch once.
- SE-key to serial rebind preserves chronological histories for all four timestamp maps.
- A map larger than 1,024 entries retains fresh migrated rate state during cleanup.
- Equal timestamps remain distinct outcomes.
- Window pruning advances the expired prefix instead of compacting the live history under the registry lock.

The two principal regressions were verified failing against `3220bd9e` before the implementation.

## Verification

- `go test ./... -race -count=1` (28 packages)
- `go vet ./...`
- `go build -o /tmp/d-inference-coordinator-capacity-rate-fast-follow ./coordinator/cmd/coordinator`
- `gofmt -l` on every changed Go file
- `git diff --check`

The race suite emitted only the recurring macOS `LC_DYSYMTAB` linker warnings and exited successfully.

## Rollout

Merge this before rebasing and completing #524. Per the v0.7.5 release policy, merging this PR does not authorize a partial coordinator deployment; it becomes part of the single complete coordinator release candidate.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/527"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786217271&installation_id=133247490&pr_number=527&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F527&signature=574680cc8cfe9b6ef1b98dda3c6997e22f1e5607a84e74eea45df267132f0278"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->