### PR TITLE
fix(release): fail closed on Apple notarization

### DIFF
--- a/.github/workflows/release-swift.yml
+++ b/.github/workflows/release-swift.yml
@@ -21,8 +21,9 @@ name: Release Provider Bundle (Swift)
 #   - vX.Y.Z-swift     -> accepted alias while the migration is in progress
 #   - vX.Y.Z-swift.N   -> accepted alias while the migration is in progress
 #
-# Repo secrets use DEV_/PROD_ prefixes so both environments live at repo
-# level without needing GitHub environments:
+# Repo secrets use DEV_/PROD_ prefixes so both environments can remain at
+# repo level. The release job still binds the resolved GitHub environment so
+# production tags must pass the environment's deployment protection rules:
 #   DEV_R2_ACCESS_KEY_ID  / PROD_R2_ACCESS_KEY_ID
 #   DEV_R2_SECRET_ACCESS_KEY / PROD_R2_SECRET_ACCESS_KEY
 #   DEV_R2_ENDPOINT       / PROD_R2_ENDPOINT
@@ -102,6 +103,7 @@ jobs:
     name: Build, sign, notarize, upload, register
     needs: [resolve-env]
     runs-on: blacksmith-12vcpu-macos-latest
+    environment: ${{ needs.resolve-env.outputs.environment }}
 
     env:
       VERSION: ${{ needs.resolve-env.outputs.version }}
@@ -556,8 +558,14 @@ jobs:
           cp "$APP/Contents/MacOS/$ENCLAVE_NAME" "$STAGE/bin/$ENCLAVE_NAME"
           cp "$APP/Contents/MacOS/mlx.metallib" "$STAGE/bin/mlx.metallib"
 
-          # Two artifact shapes: zip for notarization, tar.gz for distribution.
-          ditto -c -k --keepParent "$STAGE" /tmp/darkbloom-notarize.zip
+          # Notarize only the canonical app. The flat bin/ copies exist solely
+          # for coordinator artifact verification and inherit signatures that
+          # are valid only in the app-bundle context, so they are not valid
+          # notarization inputs on their own.
+          ditto -c -k --keepParent "$APP" /tmp/darkbloom-notarize.zip
+
+          # The distribution tar retains both shapes: install.sh uses the app,
+          # while the coordinator hashes the regular file at bin/darkbloom.
           tar czf /tmp/darkbloom-bundle-macos-arm64.tar.gz -C "$STAGE" .
           tar tzf /tmp/darkbloom-bundle-macos-arm64.tar.gz | sort | tee /tmp/darkbloom-bundle-files.txt
           echo "stage=$STAGE" >> "$GITHUB_OUTPUT"
@@ -573,20 +581,48 @@ jobs:
             --apple-id "$APPLE_ID" \
             --password "$APPLE_APP_PASSWORD" \
             --team-id "$APPLE_TEAM_ID" \
-            --wait --timeout 15m
+            --wait --timeout 15m \
+            --output-format json | tee /tmp/notary-result.json
 
-          # Staple per Mach-O. Re-tar after stapling so the distribution
-          # tarball ships stapled binaries (avoids a network round trip on
-          # first launch with strict Gatekeeper). Staple both the flat bin/
-          # layout AND the .app bundle copies — both are independent files
-          # now (no symlinks) so each needs its own ticket.
+          read -r NOTARY_ID NOTARY_STATUS < <(python3 - <<'PY'
+          import json
+
+          with open('/tmp/notary-result.json', encoding='utf-8') as result_file:
+              result = json.load(result_file)
+
+          submission_id = result.get('id')
+          status = result.get('status')
+          if not submission_id or not status:
+              raise SystemExit('notarytool result is missing id or status')
+          print(submission_id, status)
+          PY
+          )
+
+          if [ "$NOTARY_STATUS" != "Accepted" ]; then
+            echo "::error::Apple notarization $NOTARY_ID finished with status $NOTARY_STATUS (expected Accepted)"
+            if ! xcrun notarytool log "$NOTARY_ID" \
+              --apple-id "$APPLE_ID" \
+              --password "$APPLE_APP_PASSWORD" \
+              --team-id "$APPLE_TEAM_ID"; then
+              echo "::warning::Could not retrieve Apple's rejection log for $NOTARY_ID"
+            fi
+            exit 1
+          fi
+
+          # Stapler supports executable bundles, not individual Mach-O files.
+          # Require an attached ticket and a local Gatekeeper acceptance before
+          # the distribution artifact can be rebuilt or uploaded.
           STAGE="${{ steps.bundle.outputs.stage }}"
           APP="$STAGE/Darkbloom.app"
-          xcrun stapler staple "$STAGE/bin/$CLI_NAME" || true
-          xcrun stapler staple "$STAGE/bin/$ENCLAVE_NAME" || true
-          xcrun stapler staple "$APP/Contents/MacOS/$CLI_NAME" || true
-          xcrun stapler staple "$APP/Contents/MacOS/$ENCLAVE_NAME" || true
-          xcrun stapler staple "$APP" || true
+          xcrun stapler staple "$APP"
+          xcrun stapler validate "$APP"
+          spctl --assess --type execute --verbose=4 "$APP"
+          codesign --verify --deep --strict --verbose=2 "$APP"
+
+          # Stapling the bundle must not change the executable bytes registered
+          # with the coordinator and verified by provider self-update.
+          cmp "$STAGE/bin/$CLI_NAME" "$APP/Contents/MacOS/$CLI_NAME"
+          cmp "$STAGE/bin/$ENCLAVE_NAME" "$APP/Contents/MacOS/$ENCLAVE_NAME"
 
           tar czf /tmp/darkbloom-bundle-macos-arm64.tar.gz -C "${{ steps.bundle.outputs.stage }}" .
           tar tzf /tmp/darkbloom-bundle-macos-arm64.tar.gz | sort | tee /tmp/darkbloom-bundle-files.txt


### PR DESCRIPTION
## Summary

- notarize only the canonical `Darkbloom.app`, not the context-invalid flat verification copies
- require Apple `status == Accepted`, then staple, validate, assess with Gatekeeper, and re-verify the signature before upload
- bind releases to the resolved GitHub environment so production tags require approval

## Root cause

The `v0.7.4` release workflow received Apple notarization status `Invalid`, but `notarytool submit --wait` still exited successfully. The workflow never parsed the returned status, and every stapler command used `|| true`, so it uploaded and registered an unnotarized artifact and published release notes claiming `Notarized: yes`.

The submitted ZIP also contained `bin/darkbloom`, a byte-identical copy of the app executable whose signature is valid only inside `Darkbloom.app`. The installer executes the app-bundled binary; the flat copy exists only because the coordinator requires a regular file for hash verification.

## Before

```mermaid
flowchart TD
  subgraph Behavior
    B1[Push production tag] --> B2[Apple returns Invalid]
    B2 --> B3[Stapling fails]
    B3 --> B4[Artifact uploads and registers]
    B4 --> B5[Providers receive unnotarized release]
  end
  subgraph Code
    C1[Archive entire staging tree] --> C2[notarytool submit --wait]
    C2 --> C3[Status not inspected]
    C3 --> C4[stapler commands use or-true]
    C4 --> C5[Upload and SetRelease]
  end
```

## After

```mermaid
flowchart TD
  subgraph Behavior
    B1[Push production tag] --> B2[Production reviewer approval]
    B2 --> B3[Apple notarizes canonical app]
    B3 -->|Accepted| B4[Ticket and Gatekeeper checks pass]
    B3 -->|Any other result| B5[Release stops before upload]
    B4 --> B6[Artifact uploads and registers]
  end
  subgraph Code
    C1[Archive Darkbloom.app only] --> C2[notarytool JSON result]
    C2 --> C3{status exactly Accepted}
    C3 -->|No| C4[Fetch rejection log and exit 1]
    C3 -->|Yes| C5[staple and validate app]
    C5 --> C6[spctl and codesign checks]
    C6 --> C7[Compare executable bytes]
    C7 --> C8[Rebuild, upload, and SetRelease]
  end
```

## Validation

- `actionlint` passed for workflow syntax and expressions after excluding only the repository's known custom Blacksmith labels
- YAML parsing, extracted-step `bash -n`, and warning-level `shellcheck` passed
- simulated `Invalid`, missing-status, and malformed-JSON responses all stopped the job; simulated `Accepted` completed the gated artifact path
- app-only notarization ZIP and dual-layout distribution tar contents were verified
- a synthetic notarization extended attribute survived the same macOS tar round trip
- `git diff --check` passed
- two independent release reviews returned PASS

The live `prod` environment now permits `v*` tags and still requires a non-self reviewer. No release or tag is created by this PR. Actual Apple acceptance can only be proven by the first credentialed release run; importantly, any rejection now fails before upload or coordinator activation.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/529"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786240727&installation_id=133247490&pr_number=529&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F529&signature=d6b29be9c497415fe994bd4198c71e413beb42360fa670e1fc8b83dbc1ae97d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->