### PR TITLE
release(provider): v0.7.6 — enable paged KV for GPT-OSS

### DIFF
--- a/coordinator/api/server.go
+++ b/coordinator/api/server.go
@@ -144,7 +144,7 @@ func keyLimitResetFromContext(ctx context.Context) string {
 // 0.6.0 is the APNs code-identity / VLM-routing / graceful-update release.
 // Keep this fallback in sync with ProviderCore.version so dev/in-memory
 // coordinators advertise the same floor as the Swift binary they expect.
-var LatestProviderVersion = "0.7.5"
+var LatestProviderVersion = "0.7.6"
 
 // minProviderVersionForDesiredModels is the first provider version whose Swift
 // runtime understands the desired_models message. The coordinator must NOT send

--- a/provider-swift/Sources/ProviderCore/ProviderCore.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderCore.swift
@@ -138,5 +138,10 @@ public enum ProviderCore {
     // WebSocket message types, same BackendSlotCapacity wire shape;
     // max_concurrency now truthfully reports the engine cap (≤ 8, default
     // 4) instead of legacy's 24.
-    public static let version = "0.7.5"
+    // 0.7.6 enables the production PagedAttention KV backend for GPT-OSS text
+    // slots. The backend eagerly commits its pool, reports physical pool truth
+    // through existing heartbeat fields, and maps terminal pool exhaustion to
+    // retryable capacity. Gemma-4 VLM and kv-quant slots stay contiguous; an
+    // operator can force contiguous with DARKBLOOM_CBV2_PAGED_KV=0.
+    public static let version = "0.7.6"
 }


### PR DESCRIPTION
## Summary
- bump the Swift provider runtime version to 0.7.6 for the merged PagedAttention rollout
- keep the coordinator's no-release-row fallback version synchronized
- document that GPT-OSS text slots use paged KV while Gemma-4 VLM and KV-quantized slots remain contiguous

## Before
```mermaid
flowchart LR
  subgraph Behavior
    A1[Provider with merged paged KV] --> B1[Reports version 0.7.5]
  end
  subgraph Code
    C1[ProviderCore.version 0.7.5] --> D1[Coordinator fallback 0.7.5]
  end
```

## After
```mermaid
flowchart LR
  subgraph Behavior
    A2[v0.7.6 provider] --> B2[GPT-OSS text uses paged KV]
    A2 --> C2[Gemma-4 VLM and KV-quant use contiguous KV]
  end
  subgraph Code
    D2[ProviderCore.version 0.7.6] --> E2[Coordinator fallback 0.7.6]
    D2 --> F2[Annotated v0.7.6 release tag]
  end
```

## Test plan
- [x] `cd coordinator && go test ./api/...`
- [x] `swift test` — 1,073 tests passed with the pinned MLX metallib colocated in the XCTest bundle
- [x] two independent release-readiness reviews passed

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/533"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786310658&installation_id=133247490&pr_number=533&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F533&signature=8279d5b42fac7399c0abf5f87fb52430b93fdb1cecbe5f4d02b4e90c6299aab2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->