### PR TITLE
feat(provider): watchdog-owned updates + automatic predecessor rollback

### DIFF
--- a/docs/threat-model.yaml
+++ b/docs/threat-model.yaml
@@ -2161,3 +2161,75 @@ threats:
       authorization, (b) carries code_challenge in an alert-rendering payload, or
       (c) logs the push payload. The closed-verification scope is current macOS
       (min target is 15); re-verify on a version bump.
+
+  # ── TB-003: watchdog-owned update / rollback recovery authority ──
+
+  - id: T-043
+    trust_boundary: TB-003
+    stride: Denial of Service
+    title: Watchdog rollback authority is the same replaceable provider binary
+    description: >
+      The crash-recovery watchdog (`io.darkbloom.watchdog`) and the automatic
+      predecessor rollback it performs run the SAME installed `darkbloom`
+      binary that updates replace. This is a deliberate, documented limitation
+      set, not an oversight. (1) Rollback protection depends on the pre-update
+      watchdog PROCESS surviving a candidate's stabilization window: launchd
+      KeepAlive keeps the old process alive across the install, but if that
+      process dies (reboot, logout, crash) launchd relaunches the watchdog
+      FROM the candidate binary. (2) Rollback therefore does NOT survive a
+      reboot into a candidate broken at the binary level (dyld failure,
+      code-signature rejection, eager crash before command dispatch) — such a
+      host stays down until a manual reinstall. (3) The failed-version
+      quarantine is intentionally single-slot and exact-version:
+      quarantining v3 OVERWRITES the v2 quarantine record, and only normal
+      monotonic version ordering (a quarantined version is never strictly
+      newer than the rolled-back-to predecessor's successor) prevents v2 from
+      reinstalling. No component may claim multi-version quarantine.
+      (4) Rollback/replay verification is fail-closed on the pinned Darkbloom
+      designated requirement (Team SLDQ2GJ6TL): legacy flat/ad-hoc or locally
+      re-signed installs are NOT rollback-eligible; the watchdog logs an
+      actionable refusal and preserves the live install, and the remedy is a
+      signed reinstall via install.sh. This is an accepted fleet-impact
+      decision — hosts on unsigned installs keep restart recovery but not
+      rollback.
+    adversaries: [ADV-001]
+    affected_assets: [A-010]
+    affected_files:
+      - provider-swift/Sources/ProviderCore/Service/WatchdogAgent.swift
+      - provider-swift/Sources/ProviderCore/Service/WatchdogRecoveryService.swift
+      - provider-swift/Sources/ProviderCore/Update/UpdateRecoveryStore.swift
+      - provider-swift/Sources/ProviderCore/Update/UpdateInstallLayout.swift
+      - provider-swift/Sources/ProviderCore/Update/DarkbloomCodeSignature.swift
+    mitigations:
+      - description: >
+          Persistent KeepAlive watchdog process with an internal monotonic
+          scheduler (GUI StartInterval one-shots are stranded by launchd
+          on-demand-only mode), so the pre-update process normally survives
+          the whole stabilization window without respawning.
+        status: implemented
+      - description: >
+          Journaled, fsync-fail-closed install/rollback transactions with
+          crash replay, so every power-loss boundary converges to a fully
+          verified install; predecessor material is hash+signature verified
+          against the pinned designated requirement before any restore.
+        status: implemented
+      - description: >
+          Bounded watchdog network I/O (URLSession request/resource timeouts)
+          plus a safe-point per-tick budget so a stalled download or wedged
+          tick cannot hold the cross-process update lock forever; the budget
+          is only consulted between complete operations and can never
+          interrupt a journaled commit.
+        status: implemented
+      - description: >
+          A separately installed, independently signed minimal bootstrap
+          executable outside the replaceable install tree, giving recovery
+          authority that survives reboot into a binary-level-broken candidate.
+        status: open
+    open_findings: []
+    severity: medium
+    detection_hint: >
+      Reopens if any code or docs claim rollback survives a reboot into a
+      non-launchable candidate, claim multi-version quarantine, weaken the
+      designated-requirement pin to structural codesign validity, or move the
+      candidate-hung timeout below the operator's configured
+      startup_preload_timeout_secs plus margin.

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+AutoUpdate.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+AutoUpdate.swift
@@ -84,9 +84,14 @@ extension ProviderLoop {
         let jitterMaxSeconds = loopConfig.config.provider.updateJitterSeconds
 
         let deps = AutoUpdateController.Dependencies(
-            claimStart: { await me.claimUpdateStart() },
+            claimStart: { await me.claimUpdateStart(updater: updater) },
             resumeServing: { await me.resumeServingAfterUpdate() },
-            check: { await updater.checkForUpdate() },
+            check: {
+                guard let session = await me.activeUpdateSession() else {
+                    return .checkFailed(reason: "cross-process update lease was lost")
+                }
+                return await updater.checkForUpdate(session: session)
+            },
             downloadVerifyStage: { release in
                 await me.stageUpdateBundle(release: release, updater: updater)
             },
@@ -112,7 +117,14 @@ extension ProviderLoop {
             // the engine, which we no longer wait on past the timeout).
             forceCancelInflight: { await me.cancelAllInflight() },
             commitInstall: { await me.commitStagedUpdateBundle(updater: updater) },
+            prepareInstalledRestart: {
+                await me.prepareInstalledCandidateRestart(updater: updater)
+            },
             restart: { try ProcessLifecycle.restartAfterUpdate() },
+            restartDidFail: {
+                try? updater.cancelPendingCandidateAttempt(
+                    operation: "background-restart-failure")
+            },
             log: { logger.info("\($0)") }
         )
 
@@ -125,6 +137,8 @@ extension ProviderLoop {
             logger.info("Auto-update: cycle cancelled during the pre-install wait; nothing installed")
         case .upToDate:
             logger.info("Auto-update: already running latest version")
+        case .quarantined(let version):
+            logger.warning("Auto-update: v\(version) is quarantined after failed starts")
         case .checkFailed(let reason):
             logger.warning("Auto-update: check failed: \(reason)")
         case .stageFailed(let reason):
@@ -144,10 +158,25 @@ extension ProviderLoop {
     /// underway (re-entrancy guard for overlapping monitor ticks). On `true`,
     /// enter the `.installing` phase — still serving while the new bundle
     /// downloads and stages.
-    private func claimUpdateStart() -> Bool {
+    private func claimUpdateStart(updater: SelfUpdater) -> Bool {
         guard updatePhase == .idle, !isShuttingDown else { return false }
+        do {
+            let session = try updater.beginUpdateSession(
+                operation: "background-auto-update",
+                timeout: 0
+            )
+            try session.recover()
+            updateSession = session
+        } catch {
+            logger.info("Auto-update: cross-process lease unavailable: \(error)")
+            return false
+        }
         updatePhase = .installing
         return true
+    }
+
+    private func activeUpdateSession() -> SelfUpdater.UpdateSession? {
+        updateSession
     }
 
     /// Return to normal serving after an update cycle that did not restart
@@ -162,6 +191,8 @@ extension ProviderLoop {
             stagedUpdateBundle = nil
             staged.discard()
         }
+        updateSession?.release()
+        updateSession = nil
 
         if let entries = deferredDesiredModels {
             deferredDesiredModels = nil
@@ -191,7 +222,14 @@ extension ProviderLoop {
             return .failed("\(error)")
         case .success(let tempFile):
             defer { try? FileManager.default.removeItem(at: tempFile) }
-            switch updater.stageBundle(from: tempFile, release: release) {
+            guard let session = updateSession else {
+                return .failed("cross-process update lease was lost before staging")
+            }
+            switch updater.stageBundle(
+                from: tempFile,
+                release: release,
+                session: session
+            ) {
             case .success(let staged):
                 stagedUpdateBundle = staged
                 return .completed
@@ -208,11 +246,33 @@ extension ProviderLoop {
         guard let staged = stagedUpdateBundle else {
             return .failed("no staged update bundle to install")
         }
+        guard let session = updateSession else {
+            return .failed("cross-process update lease was lost before commit")
+        }
         stagedUpdateBundle = nil
-        switch updater.commitStagedBundle(staged) {
+        let result = updater.commitStagedBundle(staged, session: session)
+        session.release()
+        updateSession = nil
+        switch result {
         case .success:
             return .completed
         case .failure(let error):
+            return .failed("\(error)")
+        }
+    }
+
+    private func prepareInstalledCandidateRestart(
+        updater: SelfUpdater
+    ) -> AutoUpdateController.StepOutcome {
+        guard let session = updateSession else {
+            return .failed("cross-process update lease was lost before candidate restart")
+        }
+        do {
+            try updater.armPendingCandidateAttempt(session: session)
+            session.release()
+            updateSession = nil
+            return .completed
+        } catch {
             return .failed("\(error)")
         }
     }

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+AutoUpdate.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+AutoUpdate.swift
@@ -251,8 +251,6 @@ extension ProviderLoop {
         }
         stagedUpdateBundle = nil
         let result = updater.commitStagedBundle(staged, session: session)
-        session.release()
-        updateSession = nil
         switch result {
         case .success:
             return .completed
@@ -268,7 +266,10 @@ extension ProviderLoop {
             return .failed("cross-process update lease was lost before candidate restart")
         }
         do {
-            try updater.armPendingCandidateAttempt(session: session)
+            try updater.prepareCandidateLaunch(
+                session: session,
+                baseline: LaunchAgent.launchSnapshot()
+            )
             session.release()
             updateSession = nil
             return .completed

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+Serve.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+Serve.swift
@@ -103,9 +103,14 @@ extension ProviderLoop {
         // Stamp a minimal daemon state FIRST: a freshly installed candidate
         // spends its whole preload window with no heartbeat otherwise, and
         // the watchdog would misread a long (operator-raised) preload as a
-        // hung launch and charge a false start failure.
+        // hung launch and charge a false start failure. The refresh task keeps
+        // that stamp fresh for the WHOLE preload (a single stamp goes stale
+        // after 90s, but the gate may defer for startup_preload_timeout_secs);
+        // it is cancelled once the gate returns and the capacity loop takes over.
         writeDaemonState()
+        let preloadLivenessRefresh = startPreloadLivenessRefresh()
         await runStartupPreloadGate()
+        preloadLivenessRefresh.cancel()
 
         // 2. Build attestation blob for registration
         let attestation = buildRegistrationAttestation()

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+Serve.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+Serve.swift
@@ -99,6 +99,12 @@ extension ProviderLoop {
         // models it hasn't warmed (the v0.6.30 first_chunk_timeout storm).
         // Bounded by startup_preload_timeout_secs — on timeout we register
         // anyway and the remaining loads continue in the background.
+        //
+        // Stamp a minimal daemon state FIRST: a freshly installed candidate
+        // spends its whole preload window with no heartbeat otherwise, and
+        // the watchdog would misread a long (operator-raised) preload as a
+        // hung launch and charge a false start failure.
+        writeDaemonState()
         await runStartupPreloadGate()
 
         // 2. Build attestation blob for registration

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+StartupPreload.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+StartupPreload.swift
@@ -53,6 +53,35 @@ extension ProviderLoop {
     /// warmup) indefinitely.
     internal static let startupSelfTestTimeout: Duration = .seconds(180)
 
+    /// Cadence for refreshing the daemon-state liveness stamp while the startup
+    /// preload gate defers registration. Comfortably under the daemon-state
+    /// staleness window (90s) so a slow preload never reads as a wedged/down
+    /// process to the crash-recovery watchdog.
+    internal static let preloadLivenessRefreshInterval: Duration = .seconds(30)
+
+    /// While the startup preload gate defers registration (up to
+    /// `startup_preload_timeout_secs`, which an operator may raise well past the
+    /// 90s daemon-state staleness window), keep refreshing the liveness stamp
+    /// so the crash-recovery watchdog sees the slow-but-healthy candidate as
+    /// alive — and does NOT take the down-grace restart path and charge a false
+    /// failed start toward rollback/quarantine. The post-registration
+    /// capacity-refresh loop takes over once the gate returns; the caller
+    /// cancels this task then.
+    internal func startPreloadLivenessRefresh() -> Task<Void, Never> {
+        let me = self
+        return Task.detached(priority: .utility) {
+            while !Task.isCancelled {
+                do {
+                    try await taskSleep(Self.preloadLivenessRefreshInterval)
+                } catch {
+                    return  // cancelled
+                }
+                if Task.isCancelled { return }
+                await me.writeDaemonState()
+            }
+        }
+    }
+
     // MARK: - Loaded-model set persistence
 
     internal func loadedModelsFileURL() -> URL {

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+Trust.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+Trust.swift
@@ -28,6 +28,7 @@ extension ProviderLoop {
         let cap = state.backendCapacity
         let snapshot = DaemonState(
             pid: getpid(),
+            processIdentity: ProcessIdentity.current(),
             version: ProviderCore.version,
             writtenAt: Date().timeIntervalSince1970,
             startedAt: startedAtEpoch,

--- a/provider-swift/Sources/ProviderCore/ProviderLoop.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop.swift
@@ -245,6 +245,11 @@ public actor ProviderLoop {
     /// request can never observe a half-replaced bundle. Consumed by
     /// `commitStagedUpdateBundle`; discarded by `resumeServingAfterUpdate`.
     internal var stagedUpdateBundle: SelfUpdater.StagedBundle?
+    /// Kernel-owned cross-process lease held from update check through commit.
+    /// It serializes this actor with watchdog, startup, and manual updater
+    /// processes; released on every non-restart exit and immediately after a
+    /// durable commit.
+    internal var updateSession: SelfUpdater.UpdateSession?
 
     /// Latest `desired_models` push received while update-draining. Normally
     /// the restart makes it moot (registration gets fresh desired state), but

--- a/provider-swift/Sources/ProviderCore/Service/DaemonStateFile.swift
+++ b/provider-swift/Sources/ProviderCore/Service/DaemonStateFile.swift
@@ -19,6 +19,13 @@ public struct DaemonState: Codable, Sendable, Equatable {
 
     public var schema: Int
     public var pid: Int32
+    /// The provider's kernel process identity (pid + start time) at the moment
+    /// this state was written. The watchdog cross-checks a live PID's start
+    /// time against this before treating it as the provider — a PID the kernel
+    /// has since reused (e.g. by a manual `darkbloom update`) must NOT be
+    /// force-killed as a stale lock owner. Optional for backward compatibility
+    /// with state files written before this field existed.
+    public var processIdentity: ProcessIdentity?
     public var version: String
     public var writtenAt: Double // epoch seconds; staleness check
     public var startedAt: Double // epoch seconds; uptime
@@ -106,6 +113,7 @@ public struct DaemonState: Codable, Sendable, Equatable {
     public init(
         schema: Int = DaemonState.currentSchema,
         pid: Int32,
+        processIdentity: ProcessIdentity? = nil,
         version: String,
         writtenAt: Double,
         startedAt: Double,
@@ -121,6 +129,7 @@ public struct DaemonState: Codable, Sendable, Equatable {
     ) {
         self.schema = schema
         self.pid = pid
+        self.processIdentity = processIdentity
         self.version = version
         self.writtenAt = writtenAt
         self.startedAt = startedAt

--- a/provider-swift/Sources/ProviderCore/Service/ProcessIdentity.swift
+++ b/provider-swift/Sources/ProviderCore/Service/ProcessIdentity.swift
@@ -1,0 +1,47 @@
+import Foundation
+#if canImport(Darwin)
+import Darwin
+#endif
+
+/// PID plus kernel-recorded process start time, preventing PID-reuse mistakes.
+public struct ProcessIdentity: Codable, Sendable, Equatable {
+    public let pid: Int32
+    public let startTimeMicros: UInt64
+
+    public init(pid: Int32, startTimeMicros: UInt64) {
+        self.pid = pid
+        self.startTimeMicros = startTimeMicros
+    }
+
+    public static func current() -> ProcessIdentity? {
+        read(pid: getpid())
+    }
+
+    public static func read(pid: Int32) -> ProcessIdentity? {
+        #if canImport(Darwin)
+        guard pid > 0 else { return nil }
+        var info = proc_bsdinfo()
+        let size = withUnsafeMutablePointer(to: &info) {
+            proc_pidinfo(
+                pid,
+                PROC_PIDTBSDINFO,
+                0,
+                $0,
+                Int32(MemoryLayout<proc_bsdinfo>.size)
+            )
+        }
+        guard size == Int32(MemoryLayout<proc_bsdinfo>.size) else {
+            return nil
+        }
+        let micros = UInt64(info.pbi_start_tvsec) * 1_000_000
+            + UInt64(info.pbi_start_tvusec)
+        return ProcessIdentity(pid: pid, startTimeMicros: micros)
+        #else
+        return nil
+        #endif
+    }
+
+    public func isCurrent() -> Bool {
+        Self.read(pid: pid) == self
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Service/ProcessIdentity.swift
+++ b/provider-swift/Sources/ProviderCore/Service/ProcessIdentity.swift
@@ -21,16 +21,23 @@ public struct ProcessIdentity: Codable, Sendable, Equatable {
         #if canImport(Darwin)
         guard pid > 0 else { return nil }
         var info = proc_bsdinfo()
+        let expectedSize = Int32(MemoryLayout<proc_bsdinfo>.size)
         let size = withUnsafeMutablePointer(to: &info) {
             proc_pidinfo(
                 pid,
                 PROC_PIDTBSDINFO,
                 0,
                 $0,
-                Int32(MemoryLayout<proc_bsdinfo>.size)
+                expectedSize
             )
         }
-        guard size == Int32(MemoryLayout<proc_bsdinfo>.size) else {
+        // proc_pidinfo returns the number of bytes actually written: 0 for a
+        // dead/nonexistent PID, a negative value on error, or a short count on
+        // a partial read. Require the FULL struct before reading the start-time
+        // fields — otherwise a dead PID would yield a zeroed identity
+        // (startTimeMicros == 0) that could spuriously match another zeroed
+        // identity during stale-lock-owner attribution.
+        guard size == expectedSize else {
             return nil
         }
         let micros = UInt64(info.pbi_start_tvsec) * 1_000_000

--- a/provider-swift/Sources/ProviderCore/Service/ProcessLifecycle.swift
+++ b/provider-swift/Sources/ProviderCore/Service/ProcessLifecycle.swift
@@ -160,6 +160,28 @@ public enum ProcessLifecycle {
         }
     }
 
+    /// Terminate only the exact kernel process identity supplied by the caller.
+    /// PID reuse can never redirect the signal to an unrelated process.
+    public static func terminate(
+        _ identity: ProcessIdentity,
+        gracePeriod: TimeInterval = 2
+    ) -> Bool {
+        guard identity.isCurrent() else { return false }
+        _ = kill(identity.pid, SIGTERM)
+        let deadline = Date().addingTimeInterval(gracePeriod)
+        while Date() < deadline, identity.isCurrent() {
+            Thread.sleep(forTimeInterval: 0.05)
+        }
+        if identity.isCurrent() {
+            _ = kill(identity.pid, SIGKILL)
+        }
+        let killDeadline = Date().addingTimeInterval(1)
+        while Date() < killDeadline, identity.isCurrent() {
+            Thread.sleep(forTimeInterval: 0.02)
+        }
+        return !identity.isCurrent()
+    }
+
     // MARK: - Internals
 
     private static func readPID(at url: URL) -> Int32? {

--- a/provider-swift/Sources/ProviderCore/Service/ProviderLaunchSnapshot.swift
+++ b/provider-swift/Sources/ProviderCore/Service/ProviderLaunchSnapshot.swift
@@ -1,0 +1,70 @@
+import Foundation
+
+public struct ProviderLaunchSnapshot: Codable, Sendable, Equatable {
+    public let label: String
+    public let runs: UInt64?
+    public let process: ProcessIdentity?
+
+    public init(label: String, runs: UInt64?, process: ProcessIdentity?) {
+        self.label = label
+        self.runs = runs
+        self.process = process
+    }
+
+    public func provesLaunch(after baseline: ProviderLaunchSnapshot?) -> Bool {
+        guard let baseline else {
+            return runs != nil || process != nil
+        }
+        if let runs, let previous = baseline.runs, runs > previous {
+            return true
+        }
+        if let process, process != baseline.process {
+            return true
+        }
+        return false
+    }
+}
+
+extension LaunchAgent {
+    public static func launchSnapshot() -> ProviderLaunchSnapshot? {
+        for label in supportedLabels {
+            let output = LaunchctlControl.printOutput(label: label)
+            guard output.succeeded else { continue }
+            return parseLaunchSnapshot(label: label, output: output.stdout)
+        }
+        return nil
+    }
+
+    static func parseLaunchSnapshot(
+        label: String,
+        output: String,
+        identityReader: (Int32) -> ProcessIdentity? = ProcessIdentity.read
+    ) -> ProviderLaunchSnapshot {
+        let runs = captureInteger(#"\bruns\s*=\s*([0-9]+)"#, in: output)
+            .flatMap(UInt64.init)
+        let pid = captureInteger(#"\bpid\s*=\s*([1-9][0-9]*)"#, in: output)
+            .flatMap(Int32.init)
+        return ProviderLaunchSnapshot(
+            label: label,
+            runs: runs,
+            process: pid.flatMap(identityReader)
+        )
+    }
+
+    private static func captureInteger(
+        _ pattern: String,
+        in output: String
+    ) -> String? {
+        guard let expression = try? NSRegularExpression(pattern: pattern),
+              let match = expression.firstMatch(
+                in: output,
+                range: NSRange(output.startIndex..., in: output)
+              ),
+              match.numberOfRanges == 2,
+              let range = Range(match.range(at: 1), in: output)
+        else {
+            return nil
+        }
+        return String(output[range])
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Service/WatchdogAgent.swift
+++ b/provider-swift/Sources/ProviderCore/Service/WatchdogAgent.swift
@@ -1,9 +1,9 @@
 /// The crash-recovery watchdog's launchd agent (`io.darkbloom.watchdog`),
-/// separate from the provider service. Runs `darkbloom watchdog` once a minute
-/// (`StartInterval`) as a check-and-exit one-shot, so a wedged tick can't stall
-/// recovery. Lifecycle mirrors the provider agent: `start` installs+loads it
+/// separate from the provider service. It keeps one lightweight
+/// `darkbloom watchdog` process alive; that process owns a monotonic timer.
+/// Lifecycle mirrors the provider agent: `start` installs+loads it
 /// (re-enabling any persistent disable), `stop` bootouts it AND persistently
-/// disables it so RunAtLoad/StartInterval can't resurrect it at the next
+/// disables it so KeepAlive/RunAtLoad can't resurrect it at the next
 /// login/reboot (plist stays on disk), `stop --uninstall` deletes it.
 
 import Foundation
@@ -34,12 +34,19 @@ public enum WatchdogAgent: Sendable {
     }
 
     /// Write the plist and (re)load it; idempotent.
-    public static func installAndStart() throws {
+    public static func installAndStart(
+        configPath: URL? = nil,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) throws {
         if isLoaded() {
             try bootout()
             Thread.sleep(forTimeInterval: 0.2)
         }
-        try writePlist(binaryPath: LaunchctlControl.currentExecutablePath())
+        try writePlist(
+            binaryPath: LaunchctlControl.currentExecutablePath(),
+            configPath: configPath,
+            environment: environment
+        )
         try loadService()
     }
 
@@ -63,32 +70,65 @@ public enum WatchdogAgent: Sendable {
         }
     }
 
-    private static func writePlist(binaryPath: String) throws {
+    private static func writePlist(
+        binaryPath: String,
+        configPath: URL?,
+        environment: [String: String]
+    ) throws {
         let plist = plistPath()
         try FileManager.default.createDirectory(at: plist.deletingLastPathComponent(), withIntermediateDirectories: true)
+        var arguments = [binaryPath, "watchdog"]
+        if let configPath {
+            arguments.append(contentsOf: ["--config", configPath.path])
+        }
         let dict = makeWatchdogPlist(
             label: label,
-            programArguments: [binaryPath, "watchdog"],
+            programArguments: arguments,
             logPath: logPath().path,
-            intervalSeconds: checkIntervalSeconds
+            environment: environment
         )
         let data = try PropertyListSerialization.data(fromPropertyList: dict, format: .xml, options: 0)
         try data.write(to: plist, options: .atomic)
     }
 
-    /// Pure plist builder (testable). KeepAlive=false (cadence is StartInterval's
-    /// job); RunAtLoad=true (guard immediately + at login); Background priority.
-    static func makeWatchdogPlist(label: String, programArguments: [String], logPath: String, intervalSeconds: Int) -> [String: Any] {
-        [
+    static let passthroughEnvKeys = [
+        "DARKBLOOM_NO_UPDATE_CHECK",
+        "DARKBLOOM_STATE_FILE",
+        "DARKBLOOM_WATCHDOG_STATE",
+    ]
+
+    static func passthroughEnvironment(
+        from environment: [String: String]
+    ) -> [String: String] {
+        Dictionary(uniqueKeysWithValues: passthroughEnvKeys.compactMap { key in
+            guard let value = environment[key], !value.isEmpty else { return nil }
+            return (key, value)
+        })
+    }
+
+    /// Persistent job: launchd starts it at login and keeps it alive. This
+    /// avoids StartInterval jobs being stranded by GUI on-demand-only mode.
+    static func makeWatchdogPlist(
+        label: String,
+        programArguments: [String],
+        logPath: String,
+        environment: [String: String] = [:]
+    ) -> [String: Any] {
+        var plist: [String: Any] = [
             "Label": label,
             "ProgramArguments": programArguments,
-            "StartInterval": intervalSeconds,
             "RunAtLoad": true,
-            "KeepAlive": false,
+            "KeepAlive": true,
+            "ThrottleInterval": 10,
             "StandardOutPath": logPath,
             "StandardErrorPath": logPath,
             "ProcessType": "Background",
         ]
+        let passed = passthroughEnvironment(from: environment)
+        if !passed.isEmpty {
+            plist["EnvironmentVariables"] = passed
+        }
+        return plist
     }
 
     private static func loadService() throws {

--- a/provider-swift/Sources/ProviderCore/Service/WatchdogAgent.swift
+++ b/provider-swift/Sources/ProviderCore/Service/WatchdogAgent.swift
@@ -79,6 +79,24 @@ public enum WatchdogAgent: Sendable {
         return installed
     }
 
+    public enum RearmAction: Sendable, Equatable {
+        case arm
+        case disarm
+    }
+
+    /// What an arming site (`start`, `restart`) should do with the watchdog
+    /// job. `auto_restart = false` DISARMS a previously loaded watchdog rather
+    /// than leaving it running on its old plist config — otherwise a host
+    /// whose operator switched to an opted-out config would still get
+    /// watchdog-driven relaunches from the stale job.
+    public static func rearmAction(
+        autoRestartEnabled: Bool,
+        isLoaded: Bool
+    ) -> RearmAction? {
+        if autoRestartEnabled { return .arm }
+        return isLoaded ? .disarm : nil
+    }
+
     public static func isLoaded() -> Bool {
         LaunchctlControl.printSucceeds(label: label)
     }

--- a/provider-swift/Sources/ProviderCore/Service/WatchdogAgent.swift
+++ b/provider-swift/Sources/ProviderCore/Service/WatchdogAgent.swift
@@ -5,6 +5,15 @@
 /// (re-enabling any persistent disable), `stop` bootouts it AND persistently
 /// disables it so KeepAlive/RunAtLoad can't resurrect it at the next
 /// login/reboot (plist stays on disk), `stop --uninstall` deletes it.
+///
+/// KNOWN LIMITATION (threat model T-043): the agent runs the SAME replaceable
+/// `darkbloom` binary it recovers. Rollback protection therefore depends on
+/// the pre-update watchdog process surviving a candidate's stabilization
+/// window; after a reboot, launchd relaunches the watchdog FROM the candidate
+/// binary, so a candidate broken at the binary level (dyld/codesign/eager
+/// crash before command dispatch) cannot be rolled back by this mechanism.
+/// A truly independent recovery authority requires a separately installed
+/// bootstrap executable outside the replaceable install tree.
 
 import Foundation
 
@@ -27,6 +36,47 @@ public enum WatchdogAgent: Sendable {
 
     public static func isInstalled() -> Bool {
         FileManager.default.fileExists(atPath: plistPath().path)
+    }
+
+    /// The `--config` path recorded in the installed watchdog plist, if any.
+    /// Re-arm paths (`darkbloom restart`) use this so rewriting the plist
+    /// cannot silently drop a custom config the operator installed with.
+    public static func installedConfigPath() -> URL? {
+        guard let data = try? Data(contentsOf: plistPath()),
+              let plist = try? PropertyListSerialization.propertyList(
+                from: data,
+                options: [],
+                format: nil
+              ) as? [String: Any],
+              let arguments = plist["ProgramArguments"] as? [String]
+        else {
+            return nil
+        }
+        return configPathArgument(in: arguments)
+    }
+
+    /// Pure parser for the watchdog `ProgramArguments` config flag.
+    static func configPathArgument(in arguments: [String]) -> URL? {
+        for (index, argument) in arguments.enumerated()
+        where argument == "--config" || argument == "-c" {
+            guard index + 1 < arguments.count else { return nil }
+            return URL(fileURLWithPath: arguments[index + 1])
+        }
+        return nil
+    }
+
+    /// The config path a re-arm should install with: an explicit override
+    /// wins; otherwise the already-installed plist's config is preserved.
+    public static func rearmConfigPath(
+        explicit: String?,
+        installed: URL?
+    ) -> URL? {
+        if let explicit {
+            return URL(
+                fileURLWithPath: (explicit as NSString).expandingTildeInPath
+            )
+        }
+        return installed
     }
 
     public static func isLoaded() -> Bool {

--- a/provider-swift/Sources/ProviderCore/Service/WatchdogDecision.swift
+++ b/provider-swift/Sources/ProviderCore/Service/WatchdogDecision.swift
@@ -13,7 +13,7 @@ import Foundation
 public enum WatchdogDecision: Equatable, Sendable {
     case disabled                    // auto_restart = false
     case notManaged                  // unloaded: stopped/uninstalled, not a crash
-    case healthy                     // running
+    case healthy                     // running with no attributable stale heartbeat
     case startGrace                  // first tick down: arm the window
     case waiting(remaining: Double)  // down, inside the grace window
     case restart                     // down >= grace

--- a/provider-swift/Sources/ProviderCore/Service/WatchdogProbe.swift
+++ b/provider-swift/Sources/ProviderCore/Service/WatchdogProbe.swift
@@ -55,6 +55,28 @@ public enum WatchdogProbe {
         return !daemonState.isStale(now: now)
     }
 
+    /// The provider's process identity for stale-lock-owner attribution.
+    ///
+    /// A daemon-state PID is trusted ONLY when the currently-live process at
+    /// that PID has the SAME kernel start time the daemon recorded. If the PID
+    /// was reused (the recorded process died and the kernel handed its PID to
+    /// an unrelated process — e.g. a manual `darkbloom update` that now holds
+    /// the update lock), the start times differ and we fall back to the launchd
+    /// snapshot's process. This prevents the watchdog from force-killing a live,
+    /// unrelated process that merely inherited the provider's old PID.
+    public static func providerIdentity(
+        daemonState: DaemonState?,
+        launchSnapshotProcess: ProcessIdentity?,
+        readIdentity: (Int32) -> ProcessIdentity? = ProcessIdentity.read
+    ) -> ProcessIdentity? {
+        if let recorded = daemonState?.processIdentity,
+           let live = readIdentity(recorded.pid),
+           live == recorded {
+            return live
+        }
+        return launchSnapshotProcess
+    }
+
     /// Parse `launchctl print` for a live process: `state = running` or a
     /// non-zero `pid` (and not `state = not running`). Pure, for testing.
     static func parseRunning(_ output: String) -> Bool {

--- a/provider-swift/Sources/ProviderCore/Service/WatchdogProbe.swift
+++ b/provider-swift/Sources/ProviderCore/Service/WatchdogProbe.swift
@@ -32,7 +32,7 @@ public enum WatchdogProbe {
         if !running,
            let state = DaemonStateFile.read(),
            !state.isStale(now: now),
-           daemonProcessAlive(pid: state.pid) {
+           recordBelongsToLiveProcess(state) {
             running = true
         }
         return ProviderLiveness(loaded: loaded, running: running)
@@ -46,13 +46,40 @@ public enum WatchdogProbe {
         processRunning: Bool,
         daemonState: DaemonState?,
         now: Double,
-        processAlive: (Int32) -> Bool = daemonProcessAlive
+        processAlive: (Int32) -> Bool = daemonProcessAlive,
+        readIdentity: (Int32) -> ProcessIdentity? = ProcessIdentity.read
     ) -> Bool {
         guard processRunning else { return false }
-        guard let daemonState, processAlive(daemonState.pid) else {
+        guard let daemonState,
+              recordBelongsToLiveProcess(
+                daemonState,
+                processAlive: processAlive,
+                readIdentity: readIdentity
+              )
+        else {
             return true
         }
         return !daemonState.isStale(now: now)
+    }
+
+    /// Whether a daemon-state record is attributable to a currently-live
+    /// process. With a recorded kernel identity the live process at that PID
+    /// must have the SAME start time — a PID the kernel has since reused
+    /// belongs to an unrelated process, so the record came from a DEAD
+    /// provider and must not demote (or add) liveness. Records written before
+    /// `ProcessIdentity` existed keep the PID-alive check.
+    static func recordBelongsToLiveProcess(
+        _ state: DaemonState,
+        processAlive: (Int32) -> Bool = daemonProcessAlive,
+        readIdentity: (Int32) -> ProcessIdentity? = ProcessIdentity.read
+    ) -> Bool {
+        if let recorded = state.processIdentity {
+            guard let live = readIdentity(recorded.pid), live == recorded else {
+                return false
+            }
+            return true
+        }
+        return processAlive(state.pid)
     }
 
     /// The provider's process identity for stale-lock-owner attribution.

--- a/provider-swift/Sources/ProviderCore/Service/WatchdogProbe.swift
+++ b/provider-swift/Sources/ProviderCore/Service/WatchdogProbe.swift
@@ -38,6 +38,23 @@ public enum WatchdogProbe {
         return ProviderLiveness(loaded: loaded, running: running)
     }
 
+    /// A live launchd process becomes inactive only when a daemon-state record
+    /// attributable to that still-live PID has gone stale. No state (normal
+    /// during initial model preload) or a state record from a dead prior PID
+    /// does not override launchd liveness.
+    public static func providerActive(
+        processRunning: Bool,
+        daemonState: DaemonState?,
+        now: Double,
+        processAlive: (Int32) -> Bool = daemonProcessAlive
+    ) -> Bool {
+        guard processRunning else { return false }
+        guard let daemonState, processAlive(daemonState.pid) else {
+            return true
+        }
+        return !daemonState.isStale(now: now)
+    }
+
     /// Parse `launchctl print` for a live process: `state = running` or a
     /// non-zero `pid` (and not `state = not running`). Pure, for testing.
     static func parseRunning(_ output: String) -> Bool {

--- a/provider-swift/Sources/ProviderCore/Service/WatchdogRecoveryService.swift
+++ b/provider-swift/Sources/ProviderCore/Service/WatchdogRecoveryService.swift
@@ -317,28 +317,46 @@ public struct WatchdogRecoveryService: Sendable {
             // Launch stamps use the CURRENT time, not the tick-entry `now`:
             // everything the startup window measures begins here, after any
             // slow download/install above has already elapsed.
+            //
+            // Every write below is gated on an ACTUAL state mutation. With no
+            // candidate, all of the launch bookkeeping is a no-op, and an
+            // ordinary crashed provider must be restartable even when the
+            // recovery state has become unwritable (full disk, permissions) —
+            // a vacuous write must never gate the bare kickstart.
             let launchNow = freshNow()
+            func writeIfChanged(
+                _ state: UpdateRecoveryState,
+                before: UpdateRecoveryState
+            ) throws {
+                if state != before {
+                    try session.writeState(state)
+                }
+            }
             if state.candidate?.pendingAttemptID == nil,
                state.candidate?.launchIntent == nil {
+                let before = state
                 _ = state.prepareLaunchIntent(
                     now: launchNow,
                     baseline: deps.launchSnapshot()
                 )
-                try session.writeState(state)
+                try writeIfChanged(state, before: before)
             }
 
             do {
                 let started = try deps.kickstartIfLoaded()
                 guard started else {
+                    let before = state
                     state.cancelPendingAttempt()
-                    try session.writeState(state)
+                    try writeIfChanged(state, before: before)
                     return .noLongerLoaded
                 }
+                let before = state
                 _ = state.markLaunchIssued(now: launchNow)
-                try session.writeState(state)
+                try writeIfChanged(state, before: before)
             } catch {
+                let before = state
                 state.cancelPendingAttempt()
-                try session.writeState(state)
+                try writeIfChanged(state, before: before)
                 throw error
             }
             return .restartIssued(updatedTo: updatedTo, rolledBackTo: rolledBackTo)

--- a/provider-swift/Sources/ProviderCore/Service/WatchdogRecoveryService.swift
+++ b/provider-swift/Sources/ProviderCore/Service/WatchdogRecoveryService.swift
@@ -61,6 +61,10 @@ public struct WatchdogRecoveryService: Sendable {
         case noCandidate
         case stabilizing(since: Double?)
         case inactiveCandidate(attemptStartedAt: Double)
+        /// A candidate whose rollback was refused (blocked) has passed its
+        /// retry backoff without producing a heartbeat; the caller must
+        /// re-enter the recovery path to honor the retry.
+        case blockedCandidateRetry(reason: String)
         case promoted(version: String)
         case lockBusy
         case failed(String)
@@ -420,6 +424,23 @@ public struct WatchdogRecoveryService: Sendable {
                now - attemptStartedAt >= candidateStartupTimeoutSeconds
             {
                 return .inactiveCandidate(attemptStartedAt: attemptStartedAt)
+            }
+            // A refused rollback clears `pendingAttemptID`, so the branch
+            // above can never fire again for that candidate — and a hung-but-
+            // alive process keeps launchd reporting "running", so the down
+            // path never fires either. Without this bridge, the expiry of
+            // `retryNotBefore` is never honored and the host stays wedged on
+            // a hung candidate forever. (A pending fresh install without a
+            // blocked reason is deliberately NOT bridged: the provider's own
+            // update loop restarts into it; the watchdog must never kill a
+            // serving provider to force an update.)
+            if !freshMatchingHeartbeat,
+               providerRunning,
+               candidate.pendingAttemptID == nil,
+               let blockedReason = candidate.rollbackBlockedReason,
+               !state.isCandidateRetryBackedOff(now: now)
+            {
+                return .blockedCandidateRetry(reason: blockedReason)
             }
             return .stabilizing(since: state.candidate?.healthySince)
         } catch {

--- a/provider-swift/Sources/ProviderCore/Service/WatchdogRecoveryService.swift
+++ b/provider-swift/Sources/ProviderCore/Service/WatchdogRecoveryService.swift
@@ -6,19 +6,29 @@ import Foundation
 public struct WatchdogRecoveryService: Sendable {
     public struct Dependencies: Sendable {
         public var kickstartIfLoaded: @Sendable () throws -> Bool
+        public var launchSnapshot: @Sendable () -> ProviderLaunchSnapshot?
         public var providerStillLoaded: @Sendable () -> Bool
         public var processAlive: @Sendable (Int32) -> Bool
+        public var terminateStaleLockOwner:
+            @Sendable (UpdateProcessLock.Owner) -> Bool
         public var log: @Sendable (String) -> Void
 
         public init(
             kickstartIfLoaded: @escaping @Sendable () throws -> Bool,
+            launchSnapshot: @escaping @Sendable () -> ProviderLaunchSnapshot? = {
+                LaunchAgent.launchSnapshot()
+            },
             providerStillLoaded: @escaping @Sendable () -> Bool = { true },
             processAlive: @escaping @Sendable (Int32) -> Bool = daemonProcessAlive,
+            terminateStaleLockOwner:
+                @escaping @Sendable (UpdateProcessLock.Owner) -> Bool = { _ in false },
             log: @escaping @Sendable (String) -> Void
         ) {
             self.kickstartIfLoaded = kickstartIfLoaded
+            self.launchSnapshot = launchSnapshot
             self.providerStillLoaded = providerStillLoaded
             self.processAlive = processAlive
+            self.terminateStaleLockOwner = terminateStaleLockOwner
             self.log = log
         }
     }
@@ -62,16 +72,33 @@ public struct WatchdogRecoveryService: Sendable {
     /// failure, then an allowed newer release is installed before kickstart.
     public func recoverDownProvider(
         autoUpdateEnabled: Bool,
+        inactiveProviderIdentity: ProcessIdentity? = nil,
         now: Double
     ) async -> DownOutcome {
         let session: SelfUpdater.UpdateSession
         do {
-            session = try updater.beginUpdateSession(
-                operation: "watchdog-recovery",
-                timeout: 0
-            )
+            do {
+                session = try updater.beginUpdateSession(
+                    operation: "watchdog-recovery",
+                    timeout: 1
+                )
+            } catch UpdateError.lockBusy(let reason, let owner) {
+                guard let owner,
+                      owner.processIdentity == inactiveProviderIdentity,
+                      deps.terminateStaleLockOwner(owner)
+                else {
+                    throw UpdateError.lockBusy(
+                        reason: reason,
+                        owner: owner
+                    )
+                }
+                session = try updater.beginUpdateSession(
+                    operation: "watchdog-recovery-after-stale-owner",
+                    timeout: 3
+                )
+            }
             try session.recover(now: now)
-        } catch UpdateError.busy(let reason) {
+        } catch UpdateError.lockBusy(let reason, _) {
             deps.log("update/recovery lock busy: \(reason)")
             return .lockBusy(reason)
         } catch {
@@ -87,6 +114,10 @@ public struct WatchdogRecoveryService: Sendable {
         var rolledBackTo: String?
         do {
             var state = try session.readState()
+            _ = state.reconcileLaunchIntent(
+                snapshot: deps.launchSnapshot(),
+                now: now
+            )
             if let count = state.recordPendingAttemptFailure(now: now) {
                 try session.writeState(state)
                 deps.log(
@@ -172,8 +203,12 @@ public struct WatchdogRecoveryService: Sendable {
 
         do {
             var state = try session.readState()
-            if state.candidate?.pendingAttemptID == nil {
-                _ = state.armCandidateAttempt(now: now)
+            if state.candidate?.pendingAttemptID == nil,
+               state.candidate?.launchIntent == nil {
+                _ = state.prepareLaunchIntent(
+                    now: now,
+                    baseline: deps.launchSnapshot()
+                )
                 try session.writeState(state)
             }
 
@@ -184,6 +219,8 @@ public struct WatchdogRecoveryService: Sendable {
                     try session.writeState(state)
                     return .noLongerLoaded
                 }
+                _ = state.markLaunchIssued(now: now)
+                try session.writeState(state)
             } catch {
                 state.cancelPendingAttempt()
                 try session.writeState(state)
@@ -212,7 +249,7 @@ public struct WatchdogRecoveryService: Sendable {
                 timeout: 0
             )
             try session.recover(now: now)
-        } catch UpdateError.busy {
+        } catch UpdateError.lockBusy {
             return .lockBusy
         } catch {
             return .failed("\(error)")

--- a/provider-swift/Sources/ProviderCore/Service/WatchdogRecoveryService.swift
+++ b/provider-swift/Sources/ProviderCore/Service/WatchdogRecoveryService.swift
@@ -109,6 +109,18 @@ public struct WatchdogRecoveryService: Sendable {
         providerProcessAlive: Bool = false,
         now: Double
     ) async -> DownOutcome {
+        // Monotonic anchor for re-deriving the epoch time later in this call.
+        // The awaited update/download below may legally take minutes (bounded
+        // by the watchdog URLSession's 600s resource timeout); stamping the
+        // candidate launch with the entry `now` would let a slow-but-successful
+        // download consume the candidate's startup window before it even
+        // launched, and the next tick would charge a false failed start.
+        let entered = ContinuousClock.now
+        func freshNow() -> Double {
+            let elapsed = entered.duration(to: ContinuousClock.now)
+            return now + Double(elapsed.components.seconds)
+                + Double(elapsed.components.attoseconds) * 1e-18
+        }
         let session: SelfUpdater.UpdateSession
         do {
             do {
@@ -269,10 +281,14 @@ public struct WatchdogRecoveryService: Sendable {
 
         do {
             var state = try session.readState()
+            // Launch stamps use the CURRENT time, not the tick-entry `now`:
+            // everything the startup window measures begins here, after any
+            // slow download/install above has already elapsed.
+            let launchNow = freshNow()
             if state.candidate?.pendingAttemptID == nil,
                state.candidate?.launchIntent == nil {
                 _ = state.prepareLaunchIntent(
-                    now: now,
+                    now: launchNow,
                     baseline: deps.launchSnapshot()
                 )
                 try session.writeState(state)
@@ -285,7 +301,7 @@ public struct WatchdogRecoveryService: Sendable {
                     try session.writeState(state)
                     return .noLongerLoaded
                 }
-                _ = state.markLaunchIssued(now: now)
+                _ = state.markLaunchIssued(now: launchNow)
                 try session.writeState(state)
             } catch {
                 state.cancelPendingAttempt()

--- a/provider-swift/Sources/ProviderCore/Service/WatchdogRecoveryService.swift
+++ b/provider-swift/Sources/ProviderCore/Service/WatchdogRecoveryService.swift
@@ -143,16 +143,31 @@ public struct WatchdogRecoveryService: Sendable {
                     timeout: 3
                 )
             }
-            try session.recover(now: now)
         } catch UpdateError.lockBusy(let reason, _) {
+            // A LIVE process holds the update lease (flock auto-releases on
+            // owner death) — it owns the provider lifecycle; defer to it.
             deps.log("update/recovery lock busy: \(reason)")
             return .lockBusy(reason)
         } catch {
-            let reason = "could not open recovery state: \(error)"
+            // Session infrastructure is unavailable (recovery dir or lock
+            // file unopenable — full disk, permissions). Update and rollback
+            // are impossible without it, but a plain launchd kickstart needs
+            // none of that state: a degraded filesystem must not disable
+            // basic crash recovery for an auto_restart provider.
+            return restartWithoutRecovery(
+                reason: "update recovery unavailable: \(error)"
+            )
+        }
+        defer { session.release() }
+        do {
+            try session.recover(now: now)
+        } catch {
+            // An unreplayable journaled transaction: do NOT kickstart what
+            // may be an unfinalized install tree. The next tick retries.
+            let reason = "could not recover update state: \(error)"
             deps.log(reason)
             return .failed(reason)
         }
-        defer { session.release() }
         guard deps.providerStillLoaded() else {
             return .noLongerLoaded
         }
@@ -276,6 +291,20 @@ public struct WatchdogRecoveryService: Sendable {
                     "update artifact refused (bundle hash expected \(expected), got \(got)); restarting current install")
             case .replaceFailed(let reason):
                 deps.log("update install refused; restarting current install: \(reason)")
+                // The refusal may have stranded a journaled transaction that
+                // already exchanged the live layout (e.g. a state-write
+                // failure after the rename). Replay it NOW: kickstarting an
+                // unfinalized tree would launch a candidate with no pending
+                // attempt recorded, so its crash would never be charged
+                // toward the rollback threshold.
+                do {
+                    try session.recover(now: freshNow())
+                } catch {
+                    let recoveryReason =
+                        "post-refusal update recovery failed: \(error)"
+                    deps.log(recoveryReason)
+                    return .failed(recoveryReason)
+                }
             }
         }
 
@@ -313,6 +342,24 @@ public struct WatchdogRecoveryService: Sendable {
             let reason = "provider kickstart failed: \(error)"
             deps.log(reason)
             return .failed(reason)
+        }
+    }
+
+    /// Degraded-mode restart when the update/recovery session cannot even be
+    /// opened: no state is read or written (it is unreachable), no failure is
+    /// attributed, only the launchd kickstart runs. Provider availability
+    /// outranks update bookkeeping when the filesystem is failing.
+    private func restartWithoutRecovery(reason: String) -> DownOutcome {
+        deps.log(reason + "; issuing restart-only kickstart without update recovery")
+        guard deps.providerStillLoaded() else { return .noLongerLoaded }
+        do {
+            let started = try deps.kickstartIfLoaded()
+            guard started else { return .noLongerLoaded }
+            return .restartIssued(updatedTo: nil, rolledBackTo: nil)
+        } catch {
+            let kickstartReason = "provider kickstart failed: \(error)"
+            deps.log(kickstartReason)
+            return .failed(kickstartReason)
         }
     }
 

--- a/provider-swift/Sources/ProviderCore/Service/WatchdogRecoveryService.swift
+++ b/provider-swift/Sources/ProviderCore/Service/WatchdogRecoveryService.swift
@@ -1,0 +1,263 @@
+import Foundation
+
+/// Recovery authority used by the one-shot watchdog command. Update,
+/// predecessor rollback, failure attribution, and launch attempt persistence
+/// all execute while the same cross-process update lease is held.
+public struct WatchdogRecoveryService: Sendable {
+    public struct Dependencies: Sendable {
+        public var kickstartIfLoaded: @Sendable () throws -> Bool
+        public var providerStillLoaded: @Sendable () -> Bool
+        public var processAlive: @Sendable (Int32) -> Bool
+        public var log: @Sendable (String) -> Void
+
+        public init(
+            kickstartIfLoaded: @escaping @Sendable () throws -> Bool,
+            providerStillLoaded: @escaping @Sendable () -> Bool = { true },
+            processAlive: @escaping @Sendable (Int32) -> Bool = daemonProcessAlive,
+            log: @escaping @Sendable (String) -> Void
+        ) {
+            self.kickstartIfLoaded = kickstartIfLoaded
+            self.providerStillLoaded = providerStillLoaded
+            self.processAlive = processAlive
+            self.log = log
+        }
+    }
+
+    public enum DownOutcome: Sendable, Equatable {
+        case restartIssued(updatedTo: String?, rolledBackTo: String?)
+        case noLongerLoaded
+        case retryBackoff(until: Double, reason: String)
+        case lockBusy(String)
+        case failed(String)
+    }
+
+    public enum HealthOutcome: Sendable, Equatable {
+        case noCandidate
+        case stabilizing(since: Double?)
+        case inactiveCandidate(attemptStartedAt: Double)
+        case promoted(version: String)
+        case lockBusy
+        case failed(String)
+    }
+
+    private let updater: SelfUpdater
+    private let deps: Dependencies
+    private let stabilizationSeconds: Double
+    private let candidateStartupTimeoutSeconds: Double
+
+    public init(
+        updater: SelfUpdater,
+        dependencies: Dependencies,
+        stabilizationSeconds: Double = UpdateRecoveryState.defaultStabilizationSeconds,
+        candidateStartupTimeoutSeconds: Double = 300
+    ) {
+        self.updater = updater
+        self.deps = dependencies
+        self.stabilizationSeconds = stabilizationSeconds
+        self.candidateStartupTimeoutSeconds = candidateStartupTimeoutSeconds
+    }
+
+    /// Called only after the watchdog's outage grace expires. A pending
+    /// candidate attempt is charged once, rollback is attempted at the third
+    /// failure, then an allowed newer release is installed before kickstart.
+    public func recoverDownProvider(
+        autoUpdateEnabled: Bool,
+        now: Double
+    ) async -> DownOutcome {
+        let session: SelfUpdater.UpdateSession
+        do {
+            session = try updater.beginUpdateSession(
+                operation: "watchdog-recovery",
+                timeout: 0
+            )
+            try session.recover(now: now)
+        } catch UpdateError.busy(let reason) {
+            deps.log("update/recovery lock busy: \(reason)")
+            return .lockBusy(reason)
+        } catch {
+            let reason = "could not open recovery state: \(error)"
+            deps.log(reason)
+            return .failed(reason)
+        }
+        defer { session.release() }
+        guard deps.providerStillLoaded() else {
+            return .noLongerLoaded
+        }
+
+        var rolledBackTo: String?
+        do {
+            var state = try session.readState()
+            if let count = state.recordPendingAttemptFailure(now: now) {
+                try session.writeState(state)
+                deps.log(
+                    "v\(state.candidate?.release.version ?? "unknown") failed start \(count)/\(UpdateRecoveryState.rollbackThreshold)")
+            }
+
+            if state.isCandidateRetryBackedOff(now: now) {
+                return .retryBackoff(
+                    until: state.candidate?.retryNotBefore ?? now,
+                    reason: state.candidate?.rollbackBlockedReason
+                        ?? "rollback retry backoff"
+                )
+            }
+
+            // Once rollback has been refused, the expiry of its backoff permits
+            // one more launch of the still-intact current install. A subsequent
+            // failure increments the attempt counter and retries rollback with
+            // a longer delay; the provider is not trapped permanently down.
+            let retryCurrentAfterRollbackRefusal =
+                state.candidate?.rollbackBlockedReason != nil
+            if let candidate = state.candidate,
+               candidate.failureCount >= UpdateRecoveryState.rollbackThreshold,
+               !retryCurrentAfterRollbackRefusal
+            {
+                do {
+                    let restored = try session.rollback(
+                        now: now,
+                        reason: "automatic rollback after \(candidate.failureCount) failed starts"
+                    )
+                    rolledBackTo = restored
+                    deps.log(
+                        "quarantined v\(candidate.release.version) and restored verified predecessor v\(restored)")
+                    state = try session.readState()
+                } catch {
+                    let reason = "\(error)"
+                    state.deferRetryAfterRollbackFailure(now: now, reason: reason)
+                    try session.writeState(state)
+                    let until = state.candidate?.retryNotBefore ?? (now + 300)
+                    deps.log(
+                        "rollback refused; current install preserved; retry after \(Int(max(0, until - now)))s: \(reason)")
+                    return .retryBackoff(until: until, reason: reason)
+                }
+            }
+        } catch {
+            let reason = "could not attribute candidate failure: \(error)"
+            deps.log(reason)
+            return .failed(reason)
+        }
+
+        var updatedTo: String?
+        if autoUpdateEnabled {
+            let result = await updater.update(
+                session: session,
+                beforeInstall: deps.providerStillLoaded
+            )
+            switch result {
+            case .updated(_, let to):
+                updatedTo = to
+                deps.log("installed signed v\(to) before restart")
+            case .restartRequired(_, let to):
+                updatedTo = to
+                deps.log("v\(to) is already installed; retrying its pending restart")
+            case .alreadyUpToDate:
+                break
+            case .quarantined(let version, let reason):
+                deps.log("v\(version) remains quarantined; not reinstalling it: \(reason)")
+            case .busy(let reason):
+                // Impossible while this session owns the lock, but fail safe if
+                // a future updater implementation changes session semantics.
+                deps.log("update skipped because lock became busy: \(reason)")
+            case .cancelled(let reason):
+                deps.log("watchdog update cancelled: \(reason)")
+                return .noLongerLoaded
+            case .downloadFailed(let reason):
+                deps.log("update check/download failed; restarting current install: \(reason)")
+            case .hashMismatch(let expected, let got):
+                deps.log(
+                    "update artifact refused (bundle hash expected \(expected), got \(got)); restarting current install")
+            case .replaceFailed(let reason):
+                deps.log("update install refused; restarting current install: \(reason)")
+            }
+        }
+
+        do {
+            var state = try session.readState()
+            if state.candidate?.pendingAttemptID == nil {
+                _ = state.armCandidateAttempt(now: now)
+                try session.writeState(state)
+            }
+
+            do {
+                let started = try deps.kickstartIfLoaded()
+                guard started else {
+                    state.cancelPendingAttempt()
+                    try session.writeState(state)
+                    return .noLongerLoaded
+                }
+            } catch {
+                state.cancelPendingAttempt()
+                try session.writeState(state)
+                throw error
+            }
+            return .restartIssued(updatedTo: updatedTo, rolledBackTo: rolledBackTo)
+        } catch {
+            let reason = "provider kickstart failed: \(error)"
+            deps.log(reason)
+            return .failed(reason)
+        }
+    }
+
+    /// Promote a candidate only after launchd says it is running and a daemon
+    /// state heartbeat from that exact version remains fresh for the full
+    /// stabilization window.
+    public func observeHealthyProvider(
+        providerRunning: Bool,
+        daemonState: DaemonState?,
+        now: Double
+    ) -> HealthOutcome {
+        let session: SelfUpdater.UpdateSession
+        do {
+            session = try updater.beginUpdateSession(
+                operation: "watchdog-health",
+                timeout: 0
+            )
+            try session.recover(now: now)
+        } catch UpdateError.busy {
+            return .lockBusy
+        } catch {
+            return .failed("\(error)")
+        }
+        defer { session.release() }
+
+        do {
+            var state = try session.readState()
+            guard let candidate = state.candidate else { return .noCandidate }
+            let freshMatchingHeartbeat: Bool
+            if let daemonState {
+                freshMatchingHeartbeat = providerRunning
+                    && daemonState.version == candidate.release.version
+                    && !daemonState.isStale(now: now)
+                    && deps.processAlive(daemonState.pid)
+            } else {
+                freshMatchingHeartbeat = false
+            }
+
+            let before = state
+            let promoted = state.observeCandidateHealth(
+                healthySignal: freshMatchingHeartbeat,
+                processStartedAt: daemonState?.startedAt,
+                now: now,
+                stabilizationSeconds: stabilizationSeconds
+            )
+            if state != before {
+                try session.writeState(state)
+            }
+            if promoted {
+                deps.log(
+                    "v\(candidate.release.version) passed \(Int(stabilizationSeconds))s stabilization; promoted")
+                return .promoted(version: candidate.release.version)
+            }
+            if !freshMatchingHeartbeat,
+               providerRunning,
+               candidate.pendingAttemptID != nil,
+               let attemptStartedAt = candidate.attemptStartedAt,
+               now - attemptStartedAt >= candidateStartupTimeoutSeconds
+            {
+                return .inactiveCandidate(attemptStartedAt: attemptStartedAt)
+            }
+            return .stabilizing(since: state.candidate?.healthySince)
+        } catch {
+            return .failed("\(error)")
+        }
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Service/WatchdogRecoveryService.swift
+++ b/provider-swift/Sources/ProviderCore/Service/WatchdogRecoveryService.swift
@@ -1,8 +1,17 @@
 import Foundation
 
-/// Recovery authority used by the one-shot watchdog command. Update,
-/// predecessor rollback, failure attribution, and launch attempt persistence
-/// all execute while the same cross-process update lease is held.
+/// Recovery authority driven by the persistent watchdog process's ticks.
+/// Update, predecessor rollback, failure attribution, and launch attempt
+/// persistence all execute while the same cross-process update lease is held.
+///
+/// KNOWN LIMITATIONS (see threat model T-043): the watchdog runs the SAME
+/// replaceable `darkbloom` binary it protects, so rollback protection depends
+/// on the pre-update watchdog process staying alive through a candidate's
+/// stabilization window. Rollback does NOT survive a reboot into a candidate
+/// whose binary cannot start at all (launchd relaunches the broken candidate
+/// as the watchdog too). Quarantine is intentionally single-slot and
+/// exact-version: quarantining v3 after v2 overwrites the v2 record, and only
+/// normal monotonic version ordering keeps v2 from reinstalling.
 public struct WatchdogRecoveryService: Sendable {
     public struct Dependencies: Sendable {
         public var kickstartIfLoaded: @Sendable () throws -> Bool
@@ -11,6 +20,11 @@ public struct WatchdogRecoveryService: Sendable {
         public var processAlive: @Sendable (Int32) -> Bool
         public var terminateStaleLockOwner:
             @Sendable (UpdateProcessLock.Owner) -> Bool
+        /// Safe-point tick budget check. Consulted ONLY between complete
+        /// operations (never mid-journal, mid-rename, or mid-commit), so an
+        /// exceeded budget can defer work but can never corrupt an in-flight
+        /// journaled transaction.
+        public var isPastTickDeadline: @Sendable () -> Bool
         public var log: @Sendable (String) -> Void
 
         public init(
@@ -22,6 +36,7 @@ public struct WatchdogRecoveryService: Sendable {
             processAlive: @escaping @Sendable (Int32) -> Bool = daemonProcessAlive,
             terminateStaleLockOwner:
                 @escaping @Sendable (UpdateProcessLock.Owner) -> Bool = { _ in false },
+            isPastTickDeadline: @escaping @Sendable () -> Bool = { false },
             log: @escaping @Sendable (String) -> Void
         ) {
             self.kickstartIfLoaded = kickstartIfLoaded
@@ -29,6 +44,7 @@ public struct WatchdogRecoveryService: Sendable {
             self.providerStillLoaded = providerStillLoaded
             self.processAlive = processAlive
             self.terminateStaleLockOwner = terminateStaleLockOwner
+            self.isPastTickDeadline = isPastTickDeadline
             self.log = log
         }
     }
@@ -55,11 +71,28 @@ public struct WatchdogRecoveryService: Sendable {
     private let stabilizationSeconds: Double
     private let candidateStartupTimeoutSeconds: Double
 
+    /// A candidate is judged hung only after the operator's configured
+    /// startup preload window plus a safety margin. A raised
+    /// `startup_preload_timeout_secs` must never make a healthy-but-slow
+    /// new version charge false start failures and roll back.
+    public static let candidateStartupSafetyMarginSeconds: Double = 180
+    public static let candidateStartupTimeoutFloorSeconds: Double = 300
+
+    public static func candidateStartupTimeout(
+        preloadTimeoutSecs: UInt64
+    ) -> Double {
+        max(
+            candidateStartupTimeoutFloorSeconds,
+            Double(preloadTimeoutSecs) + candidateStartupSafetyMarginSeconds
+        )
+    }
+
     public init(
         updater: SelfUpdater,
         dependencies: Dependencies,
         stabilizationSeconds: Double = UpdateRecoveryState.defaultStabilizationSeconds,
-        candidateStartupTimeoutSeconds: Double = 300
+        candidateStartupTimeoutSeconds: Double =
+            WatchdogRecoveryService.candidateStartupTimeout(preloadTimeoutSecs: 120)
     ) {
         self.updater = updater
         self.deps = dependencies
@@ -168,7 +201,14 @@ public struct WatchdogRecoveryService: Sendable {
         }
 
         var updatedTo: String?
-        if autoUpdateEnabled {
+        // Safe point: rollback (if any) is fully committed and the journal is
+        // clean. Skipping the network update here can never leave a partial
+        // install; the restart below still proceeds on the current binary and
+        // the next tick retries the update.
+        if autoUpdateEnabled, deps.isPastTickDeadline() {
+            deps.log(
+                "tick budget exhausted before the update check; restarting the current install now and deferring the update to the next tick")
+        } else if autoUpdateEnabled {
             let result = await updater.update(
                 session: session,
                 beforeInstall: deps.providerStillLoaded

--- a/provider-swift/Sources/ProviderCore/Service/WatchdogRecoveryService.swift
+++ b/provider-swift/Sources/ProviderCore/Service/WatchdogRecoveryService.swift
@@ -106,6 +106,7 @@ public struct WatchdogRecoveryService: Sendable {
     public func recoverDownProvider(
         autoUpdateEnabled: Bool,
         inactiveProviderIdentity: ProcessIdentity? = nil,
+        providerProcessAlive: Bool = false,
         now: Double
     ) async -> DownOutcome {
         let session: SelfUpdater.UpdateSession
@@ -147,10 +148,35 @@ public struct WatchdogRecoveryService: Sendable {
         var rolledBackTo: String?
         do {
             var state = try session.readState()
+            let beforeReconcile = state
             _ = state.reconcileLaunchIntent(
                 snapshot: deps.launchSnapshot(),
                 now: now
             )
+
+            // A candidate that is still ALIVE and inside its config-derived
+            // startup window (max(300, startup_preload_timeout_secs + 180)) is a
+            // legitimately slow start (a long model preload writes no heartbeat
+            // yet), NOT a failed launch. The generic down-grace must defer to
+            // that window: do not charge a failed start and do not restart the
+            // candidate. A DEAD candidate (providerProcessAlive == false) is
+            // still charged and restarted so a real crash-loop rolls back.
+            if providerProcessAlive,
+               let candidate = state.candidate,
+               let attemptStartedAt = candidate.attemptStartedAt,
+               now - attemptStartedAt < candidateStartupTimeoutSeconds
+            {
+                if state != beforeReconcile { try session.writeState(state) }
+                let until = attemptStartedAt + candidateStartupTimeoutSeconds
+                deps.log(
+                    "v\(candidate.release.version) is alive and within its "
+                        + "\(Int(candidateStartupTimeoutSeconds))s startup window; deferring restart")
+                return .retryBackoff(
+                    until: until,
+                    reason: "candidate still within startup window"
+                )
+            }
+
             if let count = state.recordPendingAttemptFailure(now: now) {
                 try session.writeState(state)
                 deps.log(

--- a/provider-swift/Sources/ProviderCore/Service/WatchdogScheduler.swift
+++ b/provider-swift/Sources/ProviderCore/Service/WatchdogScheduler.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+/// Monotonic in-process cadence for the persistent watchdog LaunchAgent.
+public struct WatchdogScheduler: Sendable {
+    public let interval: Duration
+
+    public init(interval: Duration = .seconds(60)) {
+        precondition(interval > .zero)
+        self.interval = interval
+    }
+
+    /// Ticks immediately, then sleeps on Swift's monotonic `ContinuousClock`.
+    /// Cancellation always exits through the sleep boundary instead of spinning.
+    public func run(
+        tick: @escaping @Sendable () async -> Void
+    ) async {
+        while !Task.isCancelled {
+            await tick()
+            do {
+                try await Task.sleep(for: interval)
+            } catch {
+                return
+            }
+        }
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Service/WatchdogState.swift
+++ b/provider-swift/Sources/ProviderCore/Service/WatchdogState.swift
@@ -1,6 +1,7 @@
 /// The watchdog's cross-tick timer, persisted at
 /// `~/.darkbloom/watchdog-state.json` (override `DARKBLOOM_WATCHDOG_STATE`).
-/// The watchdog is the only writer — launchd never overlaps ticks.
+/// The single persistent watchdog process is the only writer, and its
+/// scheduler runs ticks strictly sequentially — ticks never overlap.
 
 import Foundation
 

--- a/provider-swift/Sources/ProviderCore/Update/AutoUpdateController.swift
+++ b/provider-swift/Sources/ProviderCore/Update/AutoUpdateController.swift
@@ -246,6 +246,13 @@ public struct AutoUpdateController: Sendable {
 
                 case .completed:
                     deps.log("auto-update: restarting into v\(release.version)")
+                    switch await deps.prepareInstalledRestart() {
+                    case .failed(let reason):
+                        await deps.resumeServing()
+                        return .restartFailed(reason)
+                    case .completed:
+                        break
+                    }
                     do {
                         try deps.restart()
                     } catch {

--- a/provider-swift/Sources/ProviderCore/Update/AutoUpdateController.swift
+++ b/provider-swift/Sources/ProviderCore/Update/AutoUpdateController.swift
@@ -74,9 +74,14 @@ public struct AutoUpdateController: Sendable {
         /// Swap the staged bundle into the live layout. Runs only after the
         /// drain (admission closed, in-flight work finished or cancelled).
         public var commitInstall: @Sendable () async -> StepOutcome
+        /// Arm the already-installed candidate before retrying a restart after
+        /// a prior restart command or process died.
+        public var prepareInstalledRestart: @Sendable () async -> StepOutcome
         /// Restart the process into the new binary. In production this does not
         /// return (the process is replaced/relaunched by launchd).
         public var restart: @Sendable () throws -> Void
+        /// Undo the pending-attempt marker if `restart` throws before launch.
+        public var restartDidFail: @Sendable () async -> Void
         /// Emit a human-readable progress line.
         public var log: @Sendable (String) -> Void
 
@@ -90,7 +95,9 @@ public struct AutoUpdateController: Sendable {
             waitForDrain: @escaping @Sendable (Duration) async -> Bool,
             forceCancelInflight: @escaping @Sendable () async -> Void,
             commitInstall: @escaping @Sendable () async -> StepOutcome,
+            prepareInstalledRestart: @escaping @Sendable () async -> StepOutcome = { .completed },
             restart: @escaping @Sendable () throws -> Void,
+            restartDidFail: @escaping @Sendable () async -> Void = {},
             log: @escaping @Sendable (String) -> Void
         ) {
             self.claimStart = claimStart
@@ -102,7 +109,9 @@ public struct AutoUpdateController: Sendable {
             self.waitForDrain = waitForDrain
             self.forceCancelInflight = forceCancelInflight
             self.commitInstall = commitInstall
+            self.prepareInstalledRestart = prepareInstalledRestart
             self.restart = restart
+            self.restartDidFail = restartDidFail
             self.log = log
         }
     }
@@ -118,6 +127,8 @@ public struct AutoUpdateController: Sendable {
         case cancelled
         /// Already on the latest version.
         case upToDate
+        /// Latest release is the exact locally quarantined failed version.
+        case quarantined(String)
         /// The version check failed.
         case checkFailed(String)
         /// Download/verify/stage failed; the provider kept serving the old
@@ -155,6 +166,34 @@ public struct AutoUpdateController: Sendable {
         case .upToDate:
             await deps.resumeServing()
             return .upToDate
+
+        case .quarantined(let version, let reason):
+            deps.log("auto-update: v\(version) is quarantined locally: \(reason)")
+            await deps.resumeServing()
+            return .quarantined(version)
+
+        case .restartRequired(let current, let installed):
+            deps.log(
+                "auto-update: v\(installed) is already installed but not running; draining before restart")
+            await deps.beginDraining()
+            let drained = await deps.waitForDrain(drainTimeout)
+            if !drained {
+                await deps.forceCancelInflight()
+            }
+            switch await deps.prepareInstalledRestart() {
+            case .failed(let reason):
+                await deps.resumeServing()
+                return .restartFailed(reason)
+            case .completed:
+                do {
+                    try deps.restart()
+                    return .restarted(from: current, to: installed, drained: drained)
+                } catch {
+                    await deps.restartDidFail()
+                    await deps.resumeServing()
+                    return .restartFailed("\(error)")
+                }
+            }
 
         case .checkFailed(let reason):
             deps.log("auto-update: check failed: \(reason)")
@@ -213,6 +252,7 @@ public struct AutoUpdateController: Sendable {
                         // Restart failed but the binary is already installed; resume
                         // serving (on the old in-memory binary) so we aren't wedged.
                         deps.log("auto-update: restart failed: \(error.localizedDescription)")
+                        await deps.restartDidFail()
                         await deps.resumeServing()
                         return .restartFailed("\(error)")
                     }

--- a/provider-swift/Sources/ProviderCore/Update/DarkbloomCodeSignature.swift
+++ b/provider-swift/Sources/ProviderCore/Update/DarkbloomCodeSignature.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+enum DarkbloomCodeSignature {
+    static let teamID = "SLDQ2GJ6TL"
+    static let bundleIdentifier = "io.darkbloom.provider"
+    static let designatedRequirement =
+        "anchor apple generic and identifier \"\(bundleIdentifier)\" "
+        + "and certificate leaf[subject.OU] = \"\(teamID)\""
+
+    enum Policy: Sendable, Equatable {
+        case darkbloomProduction
+        case structuralForIsolatedTest
+    }
+
+    static func verify(
+        _ target: URL,
+        deep: Bool,
+        policy: Policy = .darkbloomProduction
+    ) throws {
+        #if canImport(Darwin)
+        var arguments = ["--verify", "--strict", "--verbose=2"]
+        if deep { arguments.append("--deep") }
+        if policy == .darkbloomProduction {
+            arguments.append("-R=\(designatedRequirement)")
+        }
+        arguments.append(target.path)
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/codesign")
+        process.arguments = arguments
+        let stderr = Pipe()
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = stderr
+        try process.run()
+        process.waitUntilExit()
+        guard process.terminationStatus == 0 else {
+            let detail = String(
+                data: stderr.fileHandleForReading.readDataToEndOfFile(),
+                encoding: .utf8
+            )?.trimmingCharacters(in: .whitespacesAndNewlines)
+                ?? "codesign exited \(process.terminationStatus)"
+            throw NSError(
+                domain: "DarkbloomCodeSignature",
+                code: Int(process.terminationStatus),
+                userInfo: [NSLocalizedDescriptionKey: detail]
+            )
+        }
+        #endif
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Update/SelfUpdater.swift
+++ b/provider-swift/Sources/ProviderCore/Update/SelfUpdater.swift
@@ -63,6 +63,16 @@ public struct SelfUpdater: Sendable {
     private let urlSession: URLSession
     private let now: @Sendable () -> Double
 
+    /// Whether this updater verifies the pinned Darkbloom code signature on
+    /// staged/committed/installed artifacts. Always `true` for the public
+    /// production initializer; `false` is reachable ONLY through the internal
+    /// test seam (the `verifyCodeSignatures:` overload used by the `*ForTesting`
+    /// helpers and fixtures, which stage synthetic unsigned binaries). Exposed
+    /// so a test can assert the production path never selects the unsigned path.
+    internal var verifiesCodeSignatures: Bool { verifyCodeSignatures }
+
+    /// Production initializer: signature verification is ALWAYS on. There is no
+    /// public way to construct a `SelfUpdater` that skips signature checks.
     public init(coordinatorBaseURL: String, urlSession: URLSession = .shared) {
         self.init(
             coordinatorBaseURL: coordinatorBaseURL,
@@ -93,6 +103,11 @@ public struct SelfUpdater: Sendable {
         return URLSession(configuration: configuration)
     }
 
+    /// Test-only seam. Passing `verifyCodeSignatures: false` disables the
+    /// signature pin so tests can stage synthetic unsigned binaries; NO
+    /// production call site does this (the public init hard-codes `true`, and
+    /// the only `verifyCodeSignatures: false` callers are the `*ForTesting`
+    /// helpers below). Do not add a production caller that passes `false`.
     internal init(
         coordinatorBaseURL: String,
         installRoot: URL?,
@@ -314,6 +329,10 @@ public struct SelfUpdater: Sendable {
         )
     }
 
+    /// TEST-ONLY. Stages without signature verification so tests can use
+    /// synthetic unsigned binaries. Never call from production — the production
+    /// path is `stageBundle(from:release:session:)`, which derives verification
+    /// from the session's store (always `true` for a production session).
     internal func stageBundleForTesting(
         from downloadedFile: URL,
         release: ReleaseInfo,
@@ -527,6 +546,8 @@ public struct SelfUpdater: Sendable {
         }
     }
 
+    /// TEST-ONLY. Commits without signature verification. Never call from
+    /// production — the production path is `commitStagedBundle(_:session:)`.
     internal func commitStagedBundleForTesting(
         _ staged: StagedBundle
     ) -> Result<Void, UpdateError> {
@@ -756,6 +777,9 @@ public struct SelfUpdater: Sendable {
         }
     }
 
+    /// TEST-ONLY. Installs without signature verification. Never call from
+    /// production — production installs go through `update(session:...)` or
+    /// `installBundle(from:release:session:)` with a signed session.
     internal func installBundleForTesting(
         from downloadedFile: URL,
         release: ReleaseInfo,

--- a/provider-swift/Sources/ProviderCore/Update/SelfUpdater.swift
+++ b/provider-swift/Sources/ProviderCore/Update/SelfUpdater.swift
@@ -63,15 +63,34 @@ public struct SelfUpdater: Sendable {
     private let urlSession: URLSession
     private let now: @Sendable () -> Double
 
-    public init(coordinatorBaseURL: String) {
+    public init(coordinatorBaseURL: String, urlSession: URLSession = .shared) {
         self.init(
             coordinatorBaseURL: coordinatorBaseURL,
             installRoot: nil,
             verifyCodeSignatures: true,
             currentVersion: ProviderCore.version,
-            urlSession: .shared,
+            urlSession: urlSession,
             now: { Date().timeIntervalSince1970 }
         )
+    }
+
+    /// Per-request handshake/idle bound for watchdog-owned network calls.
+    public static let watchdogRequestTimeoutSeconds: TimeInterval = 30
+    /// Whole-transfer bound: generously covers a ~170 MB bundle on a slow
+    /// link, but guarantees a stalled download can never wedge a watchdog
+    /// tick (and the update lock it holds) forever.
+    public static let watchdogResourceTimeoutSeconds: TimeInterval = 600
+
+    /// Bounded session for the persistent watchdog. The default `.shared`
+    /// session has a 7-day resource timeout — a stalled release download
+    /// would block the recovery loop indefinitely while holding the
+    /// cross-process update lock.
+    public static func watchdogURLSession() -> URLSession {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.timeoutIntervalForRequest = watchdogRequestTimeoutSeconds
+        configuration.timeoutIntervalForResource = watchdogResourceTimeoutSeconds
+        configuration.waitsForConnectivity = false
+        return URLSession(configuration: configuration)
     }
 
     internal init(

--- a/provider-swift/Sources/ProviderCore/Update/SelfUpdater.swift
+++ b/provider-swift/Sources/ProviderCore/Update/SelfUpdater.swift
@@ -35,13 +35,19 @@ public struct ReleaseInfo: Sendable {
 public enum UpdateCheckResult: Sendable {
     case upToDate(currentVersion: String)
     case updateAvailable(current: String, latest: ReleaseInfo)
+    case restartRequired(current: String, installed: String)
+    case quarantined(version: String, reason: String)
     case checkFailed(reason: String)
 }
 
 /// Result of an update attempt.
 public enum UpdateResult: Sendable {
     case updated(from: String, to: String)
+    case restartRequired(from: String, to: String)
     case alreadyUpToDate(version: String)
+    case quarantined(version: String, reason: String)
+    case busy(reason: String)
+    case cancelled(reason: String)
     case downloadFailed(reason: String)
     case hashMismatch(expected: String, got: String)
     case replaceFailed(reason: String)
@@ -51,8 +57,33 @@ public enum UpdateResult: Sendable {
 public struct SelfUpdater: Sendable {
 
     private let coordinatorBaseURL: String
+    private let installRootOverride: URL?
+    private let verifyCodeSignatures: Bool
+    private let currentVersion: String
+    private let urlSession: URLSession
+    private let now: @Sendable () -> Double
 
     public init(coordinatorBaseURL: String) {
+        self.init(
+            coordinatorBaseURL: coordinatorBaseURL,
+            installRoot: nil,
+            verifyCodeSignatures: true,
+            currentVersion: ProviderCore.version,
+            urlSession: .shared,
+            now: { Date().timeIntervalSince1970 }
+        )
+    }
+
+    internal init(
+        coordinatorBaseURL: String,
+        installRoot: URL?,
+        verifyCodeSignatures: Bool,
+        currentVersion: String,
+        urlSession: URLSession = .shared,
+        now: @escaping @Sendable () -> Double = {
+            Date().timeIntervalSince1970
+        }
+    ) {
         // Convert WebSocket URL to HTTP if needed
         var base = WebSocketURLScheme.toHTTP(coordinatorBaseURL)
         // Strip trailing path components (e.g. /ws/provider)
@@ -61,13 +92,41 @@ public struct SelfUpdater: Sendable {
             base = "\(scheme)://\(host)\(port)"
         }
         self.coordinatorBaseURL = base
+        self.installRootOverride = installRoot
+        self.verifyCodeSignatures = verifyCodeSignatures
+        self.currentVersion = currentVersion
+        self.urlSession = urlSession
+        self.now = now
     }
 
     // MARK: - Version Check
 
     /// Check the coordinator for the latest release.
-    public func checkForUpdate() async -> UpdateCheckResult {
-        let currentVersion = ProviderCore.version
+    public func checkForUpdate(
+        manualOverride: Bool = false,
+        session: UpdateSession? = nil
+    ) async -> UpdateCheckResult {
+        let recoveryState: UpdateRecoveryState
+        do {
+            if let session {
+                recoveryState = try session.readState()
+            } else if let store = recoveryStore() {
+                recoveryState = try store.loadState()
+            } else {
+                recoveryState = UpdateRecoveryState()
+            }
+        } catch {
+            return .checkFailed(reason: "could not read update recovery state: \(error)")
+        }
+        if let candidate = recoveryState.candidate,
+           candidate.release.version != currentVersion
+        {
+            return .restartRequired(
+                current: currentVersion,
+                installed: candidate.release.version
+            )
+        }
+
         let endpoint = "\(coordinatorBaseURL)/v1/releases/latest?platform=macos-arm64"
 
         guard let url = URL(string: endpoint) else {
@@ -75,7 +134,7 @@ public struct SelfUpdater: Sendable {
         }
 
         do {
-            let (data, response) = try await URLSession.shared.data(from: url)
+            let (data, response) = try await urlSession.data(from: url)
 
             guard let httpResponse = response as? HTTPURLResponse else {
                 return .checkFailed(reason: "unexpected response type")
@@ -97,6 +156,10 @@ public struct SelfUpdater: Sendable {
             else {
                 return .checkFailed(reason: "missing required fields in release response")
             }
+            guard platform == "macos-arm64" else {
+                return .checkFailed(
+                    reason: "coordinator returned unsupported release platform \(platform)")
+            }
             guard let bundleHash = (json["bundle_hash"] as? String)
                     ?? (json["sha256"] as? String)
                     ?? (json["binary_hash"] as? String)
@@ -112,6 +175,13 @@ public struct SelfUpdater: Sendable {
                 binaryHash: json["binary_hash"] as? String,
                 metallibHash: json["metallib_hash"] as? String
             )
+
+            if recoveryState.quarantineBlocks(version: version, manualOverride: manualOverride) {
+                return .quarantined(
+                    version: version,
+                    reason: recoveryState.quarantine?.reason ?? "release failed local startup validation"
+                )
+            }
 
             if isNewer(latest: version, current: currentVersion) {
                 return .updateAvailable(current: currentVersion, latest: release)
@@ -132,7 +202,7 @@ public struct SelfUpdater: Sendable {
         }
 
         do {
-            let (tempFileURL, response) = try await URLSession.shared.download(from: downloadURL)
+            let (tempFileURL, response) = try await urlSession.download(from: downloadURL)
 
             guard let httpResponse = response as? HTTPURLResponse,
                   httpResponse.statusCode == 200
@@ -162,7 +232,6 @@ public struct SelfUpdater: Sendable {
     /// the darkbloom root. Dot-prefixed so they stay out of the visible
     /// layout; cleaned up on the next staging pass if a crash orphans them.
     private static let stagingDirPrefix = ".update-staging-"
-    private static let backupDirPrefix = ".update-backup-"
 
     /// A release bundle that has been extracted and fully verified (hashes and
     /// code signature) but NOT yet installed into the live layout.
@@ -185,6 +254,10 @@ public struct SelfUpdater: Sendable {
         let flatMetallib: URL
         /// The darkbloom root directory the commit will write into.
         let installDir: URL
+        let release: ReleaseInfo
+        /// Full extracted-tree digest captured after stage verification and
+        /// checked again immediately before commit.
+        let stagedTreeHash: String
 
         /// Remove the staged contents from disk (failure/abort cleanup).
         public func discard() {
@@ -199,15 +272,20 @@ public struct SelfUpdater: Sendable {
     /// flat `bin/` copies. The .app bundle is the canonical signed artifact;
     /// older flat-only tarballs (no .app bundle) are staged for the legacy
     /// direct-file install.
-    public func stageBundle(from downloadedFile: URL, release: ReleaseInfo) -> Result<StagedBundle, UpdateError> {
-        guard let installDir = liveInstallDir() else {
-            return .failure(.replaceFailed("could not determine current executable path"))
+    public func stageBundle(
+        from downloadedFile: URL,
+        release: ReleaseInfo,
+        session: UpdateSession
+    ) -> Result<StagedBundle, UpdateError> {
+        let installDir = session.store.installRoot
+        guard installDir == resolvedInstallRoot() else {
+            return .failure(.replaceFailed("update session belongs to a different install root"))
         }
         return stageBundle(
             from: downloadedFile,
             release: release,
             installDir: installDir,
-            verifyCodeSignatures: true
+            verifyCodeSignatures: session.store.verifyCodeSignatures
         )
     }
 
@@ -216,7 +294,21 @@ public struct SelfUpdater: Sendable {
         release: ReleaseInfo,
         installDir: URL
     ) -> Result<StagedBundle, UpdateError> {
-        stageBundle(
+        guard let session = try? beginUpdateSession(
+            operation: "test-stage",
+            timeout: 0,
+            installRoot: installDir,
+            verifyCodeSignatures: false
+        ) else {
+            return .failure(.replaceFailed("could not acquire test update lock"))
+        }
+        defer { session.release() }
+        do {
+            try session.recover()
+        } catch {
+            return .failure(.replaceFailed("\(error)"))
+        }
+        return stageBundle(
             from: downloadedFile,
             release: release,
             installDir: installDir,
@@ -276,19 +368,45 @@ public struct SelfUpdater: Sendable {
                 if hasAppBundle {
                     let appDarkbloom = extractedApp
                         .appendingPathComponent("Contents/MacOS/darkbloom")
+                    let appMetallib = extractedApp
+                        .appendingPathComponent("Contents/MacOS/mlx.metallib")
+                    if let binaryHash = release.binaryHash {
+                        try verifyHash(
+                            file: appDarkbloom,
+                            expected: binaryHash,
+                            label: "Darkbloom.app darkbloom"
+                        )
+                    }
+                    if let metallibHash = release.metallibHash {
+                        try verifyHash(
+                            file: appMetallib,
+                            expected: metallibHash,
+                            label: "Darkbloom.app mlx.metallib"
+                        )
+                    }
                     try verifyCodeSignature(file: appDarkbloom, label: "darkbloom")
+                    try verifyCodeSignature(
+                        file: extractedApp,
+                        label: "Darkbloom.app",
+                        deep: true
+                    )
                 } else {
                     try verifyCodeSignature(file: flatDarkbloom, label: "darkbloom")
                 }
             }
 
+            let stagedTreeHash = try UpdateAtomicFilesystem.treeHash(
+                root: hasAppBundle ? extractedApp : stagingRoot
+            )
             return .success(StagedBundle(
                 stagingRoot: stagingRoot,
                 extractedApp: hasAppBundle ? extractedApp : nil,
                 flatDarkbloom: flatDarkbloom,
                 flatEnclave: flatEnclave,
                 flatMetallib: flatMetallib,
-                installDir: installDir
+                installDir: installDir,
+                release: release,
+                stagedTreeHash: stagedTreeHash
             ))
         } catch let error as UpdateError {
             try? fm.removeItem(at: stagingRoot)
@@ -307,150 +425,147 @@ public struct SelfUpdater: Sendable {
     ///
     /// The staging directory is consumed (moved or removed) regardless of
     /// outcome; on failure the previous layout is restored from the backup.
-    public func commitStagedBundle(_ staged: StagedBundle) -> Result<Void, UpdateError> {
-        let fm = FileManager.default
-        let backupRoot = staged.installDir.appendingPathComponent(
-            "\(Self.backupDirPrefix)\(UUID().uuidString)", isDirectory: true)
-        defer {
-            try? fm.removeItem(at: staged.stagingRoot)
-            try? fm.removeItem(at: backupRoot)
+    public func commitStagedBundle(
+        _ staged: StagedBundle,
+        session: UpdateSession
+    ) -> Result<Void, UpdateError> {
+        guard staged.installDir.standardizedFileURL == session.store.installRoot else {
+            return .failure(.replaceFailed("staged bundle belongs to a different install root"))
         }
-
         do {
-            try fm.createDirectory(at: backupRoot, withIntermediateDirectories: true)
-            if let extractedApp = staged.extractedApp {
-                return try commitAppBundle(
-                    extractedApp: extractedApp,
-                    installDir: staged.installDir,
-                    backupRoot: backupRoot
-                )
+            let stagedRoot = staged.extractedApp ?? staged.stagingRoot
+            let currentTreeHash = try UpdateAtomicFilesystem.treeHash(root: stagedRoot)
+            guard currentTreeHash == staged.stagedTreeHash else {
+                return .failure(.replaceFailed(
+                    "staged bundle changed after verification; refusing commit"))
             }
-            return try commitFlatBundle(staged, backupRoot: backupRoot)
-        } catch let error as UpdateError {
-            return .failure(error)
-        } catch {
-            return .failure(.replaceFailed(error.localizedDescription))
-        }
-    }
-
-    /// Commit a signed .app bundle and create bin/ symlinks.
-    ///
-    /// This mirrors the install.sh layout:
-    ///   installDir/Darkbloom.app/Contents/MacOS/{darkbloom,darkbloom-enclave,mlx.metallib}
-    ///   installDir/bin/darkbloom          -> ../Darkbloom.app/Contents/MacOS/darkbloom
-    ///   installDir/bin/darkbloom-enclave  -> ../Darkbloom.app/Contents/MacOS/darkbloom-enclave
-    ///   installDir/bin/mlx.metallib       -> ../Darkbloom.app/Contents/MacOS/mlx.metallib
-    private func commitAppBundle(
-        extractedApp: URL,
-        installDir: URL,
-        backupRoot: URL
-    ) throws -> Result<Void, UpdateError> {
-        let fm = FileManager.default
-
-        let destinationApp = installDir.appendingPathComponent("Darkbloom.app")
-        let backupApp = backupRoot.appendingPathComponent("Darkbloom.app")
-
-        // Move (rename) the existing .app bundle aside.
-        if fm.fileExists(atPath: destinationApp.path) {
-            try fm.moveItem(at: destinationApp, to: backupApp)
-        }
-
-        do {
-            // Move the staged .app bundle into place (same-volume rename).
-            try fm.moveItem(at: extractedApp, to: destinationApp)
-
-            let appBin = "Darkbloom.app/Contents/MacOS"
-            let binDir = installDir.appendingPathComponent("bin")
-            try fm.createDirectory(at: binDir, withIntermediateDirectories: true)
-
-            // Create symlinks from bin/ into the .app bundle, matching install.sh.
-            // Use relative paths ("../Darkbloom.app/Contents/MacOS/X") so the
-            // layout is relocatable.
-            let symlinks = [
-                ("darkbloom", "../\(appBin)/darkbloom"),
-                ("darkbloom-enclave", "../\(appBin)/darkbloom-enclave"),
-                ("mlx.metallib", "../\(appBin)/mlx.metallib"),
-                ("eigeninference-enclave", "darkbloom-enclave"),
-            ]
-            for (name, target) in symlinks {
-                let link = binDir.appendingPathComponent(name)
-                // Remove existing file/symlink.
-                if itemExistsIncludingSymlink(link) {
-                    try fm.removeItem(at: link)
+            if session.store.verifyCodeSignatures {
+                if let app = staged.extractedApp {
+                    try verifyCodeSignature(
+                        file: app,
+                        label: "Darkbloom.app",
+                        deep: true
+                    )
+                } else {
+                    try verifyCodeSignature(
+                        file: staged.flatDarkbloom,
+                        label: "darkbloom"
+                    )
                 }
-                try fm.createSymbolicLink(atPath: link.path, withDestinationPath: target)
             }
-
+            try session.store.commit(
+                staged: staged,
+                currentVersion: currentVersion,
+                now: now()
+            )
             return .success(())
         } catch {
-            // Rollback: restore the backed-up .app bundle.
-            try? fm.removeItem(at: destinationApp)
-            if fm.fileExists(atPath: backupApp.path) {
-                try? fm.moveItem(at: backupApp, to: destinationApp)
-            }
-            throw error
+            return .failure(.replaceFailed("\(error)"))
         }
     }
 
-    /// Commit a legacy flat-only bundle: move the staged binaries directly
-    /// into bin/ (no .app bundle in the tarball).
-    private func commitFlatBundle(
-        _ staged: StagedBundle,
-        backupRoot: URL
-    ) throws -> Result<Void, UpdateError> {
-        let fm = FileManager.default
-        let binDir = staged.installDir.appendingPathComponent("bin")
-        try fm.createDirectory(at: binDir, withIntermediateDirectories: true)
-        let targets = [
-            ("darkbloom", staged.flatDarkbloom, 0o755),
-            ("darkbloom-enclave", staged.flatEnclave, 0o755),
-            ("mlx.metallib", staged.flatMetallib, 0o644),
-        ] as [(String, URL, Int)]
-
-        var installed: [URL] = []
-        var backups: [URL: URL] = [:]
+    internal func commitStagedBundleForTesting(
+        _ staged: StagedBundle
+    ) -> Result<Void, UpdateError> {
         do {
-            for (name, source, mode) in targets {
-                let destination = binDir.appendingPathComponent(name)
-                let backup = backupRoot.appendingPathComponent(name)
-                if fm.fileExists(atPath: destination.path) {
-                    try fm.moveItem(at: destination, to: backup)
-                    backups[destination] = backup
-                }
-                try fm.moveItem(at: source, to: destination)
-                try fm.setAttributes([.posixPermissions: mode], ofItemAtPath: destination.path)
-                installed.append(destination)
-            }
-
-            let legacyLink = binDir.appendingPathComponent("eigeninference-enclave")
-            let legacyBackup = backupRoot.appendingPathComponent("eigeninference-enclave")
-            if itemExistsIncludingSymlink(legacyLink) {
-                try fm.moveItem(at: legacyLink, to: legacyBackup)
-                backups[legacyLink] = legacyBackup
-            }
-            try fm.createSymbolicLink(atPath: legacyLink.path, withDestinationPath: "darkbloom-enclave")
-            installed.append(legacyLink)
+            let session = try beginUpdateSession(
+                operation: "test-commit",
+                timeout: 0,
+                installRoot: staged.installDir,
+                verifyCodeSignatures: false
+            )
+            defer { session.release() }
+            try session.recover()
+            return commitStagedBundle(staged, session: session)
         } catch {
-            let destinations = Set(installed + Array(backups.keys))
-            for destination in destinations {
-                try? fm.removeItem(at: destination)
-                if let backup = backups[destination], itemExistsIncludingSymlink(backup) {
-                    try? fm.moveItem(at: backup, to: destination)
-                }
-            }
-            throw error
+            return .failure(.replaceFailed("\(error)"))
         }
-
-        return .success(())
     }
 
     /// The darkbloom root (~/.darkbloom/) of the running install. Must resolve
     /// symlinks first: invoked as plain `darkbloom`, `executablePath` is the
     /// /usr/local/bin/darkbloom PATH symlink, which would derive root=/usr/local
     /// and fail staging with EPERM ("can't save .update-staging-… in 'local'").
-    private func liveInstallDir() -> URL? {
+    private func resolvedInstallRoot() -> URL? {
+        if let installRootOverride {
+            return installRootOverride.standardizedFileURL
+        }
         guard let executablePath = Bundle.main.executablePath else { return nil }
         return Self.installRoot(forExecutablePath: executablePath)
+    }
+
+    private func recoveryStore() -> UpdateRecoveryStore? {
+        guard let root = resolvedInstallRoot() else { return nil }
+        return UpdateRecoveryStore(
+            installRoot: root,
+            verifyCodeSignatures: verifyCodeSignatures
+        )
+    }
+
+    public func beginUpdateSession(
+        operation: String,
+        timeout: TimeInterval = 0
+    ) throws -> UpdateSession {
+        guard let root = resolvedInstallRoot() else {
+            throw UpdateError.replaceFailed("could not determine current executable path")
+        }
+        return try beginUpdateSession(
+            operation: operation,
+            timeout: timeout,
+            installRoot: root,
+            verifyCodeSignatures: verifyCodeSignatures
+        )
+    }
+
+    private func beginUpdateSession(
+        operation: String,
+        timeout: TimeInterval,
+        installRoot: URL,
+        verifyCodeSignatures: Bool
+    ) throws -> UpdateSession {
+        let store = UpdateRecoveryStore(
+            installRoot: installRoot,
+            verifyCodeSignatures: verifyCodeSignatures
+        )
+        do {
+            let processLock = try UpdateProcessLock.acquire(
+                at: store.lockPath,
+                operation: operation,
+                timeout: timeout
+            )
+            return UpdateSession(processLock: processLock, store: store)
+        } catch let error as UpdateProcessLock.LockError {
+            throw UpdateError.busy(error.description)
+        }
+    }
+
+    /// Clear the candidate's pending launch marker when a restart command
+    /// itself failed. No failed start is charged because no process was
+    /// actually launched.
+    public func cancelPendingCandidateAttempt(
+        operation: String = "restart-failure-cleanup"
+    ) throws {
+        let session = try beginUpdateSession(operation: operation, timeout: 1)
+        defer { session.release() }
+        try session.recover()
+        var state = try session.readState()
+        let before = state
+        state.cancelPendingAttempt()
+        if state != before {
+            try session.writeState(state)
+        }
+    }
+
+    public func armPendingCandidateAttempt(
+        session: UpdateSession,
+        now: Double = Date().timeIntervalSince1970
+    ) throws {
+        var state = try session.readState()
+        let before = state
+        _ = state.armCandidateAttempt(now: now)
+        if state != before {
+            try session.writeState(state)
+        }
     }
 
     /// Pure path derivation behind `liveInstallDir` (separated for tests).
@@ -468,18 +583,15 @@ public struct SelfUpdater: Sendable {
         return parentDir.deletingLastPathComponent()
     }
 
-    /// Minimum age before a staging/backup directory is considered orphaned.
+    /// Minimum age before a staging directory is considered orphaned.
     /// A LIVE staging dir only exists between stage and commit, a window
     /// bounded by the drain timeout (minutes) — an hour-old dir can only be
     /// left over from a crashed cycle.
     private static let staleUpdateDirAge: TimeInterval = 60 * 60
 
-    /// Best-effort cleanup of staging/backup directories left behind by a
-    /// crashed update cycle. Within one process, `claimStart` serializes
-    /// cycles, but ANOTHER process may hold a live staged bundle (e.g. a
-    /// foreground `darkbloom update` running while the serving daemon is
-    /// mid-cycle) — the age gate ensures we never delete a staging directory
-    /// an active cycle is still about to commit.
+    /// Best-effort cleanup of old staging directories. The process lock
+    /// serializes every stage and commit; the age gate remains defensive
+    /// against directories from binaries that predate the shared lock.
     private func removeStaleUpdateDirs(in installDir: URL) {
         let fm = FileManager.default
         guard let entries = try? fm.contentsOfDirectory(
@@ -491,7 +603,10 @@ public struct SelfUpdater: Sendable {
         let cutoff = Date().addingTimeInterval(-Self.staleUpdateDirAge)
         for entry in entries {
             let name = entry.lastPathComponent
-            guard name.hasPrefix(Self.stagingDirPrefix) || name.hasPrefix(Self.backupDirPrefix) else {
+            guard name.hasPrefix(Self.stagingDirPrefix)
+                    || name.hasPrefix(".rollback-staging-")
+                    || name.hasPrefix(".recovery-restore-")
+            else {
                 continue
             }
             let modified = (try? entry.resourceValues(forKeys: [.contentModificationDateKey]))?
@@ -511,15 +626,16 @@ public struct SelfUpdater: Sendable {
     /// `stageBundle` / `commitStagedBundle` separately so the live swap only
     /// happens after admission is closed and in-flight work has drained.
     public func installBundle(from downloadedFile: URL, release: ReleaseInfo) -> Result<Void, UpdateError> {
-        guard let installDir = liveInstallDir() else {
-            return .failure(.replaceFailed("could not determine current executable path"))
+        do {
+            let session = try beginUpdateSession(operation: "manual-install", timeout: 0)
+            defer { session.release() }
+            try session.recover()
+            return installBundle(from: downloadedFile, release: release, session: session)
+        } catch let error as UpdateError {
+            return .failure(error)
+        } catch {
+            return .failure(.replaceFailed("\(error)"))
         }
-        return installBundle(
-            from: downloadedFile,
-            release: release,
-            installDir: installDir,
-            verifyCodeSignatures: true
-        )
     }
 
     internal func installBundleForTesting(
@@ -527,42 +643,83 @@ public struct SelfUpdater: Sendable {
         release: ReleaseInfo,
         installDir: URL
     ) -> Result<Void, UpdateError> {
-        installBundle(
-            from: downloadedFile,
-            release: release,
-            installDir: installDir,
-            verifyCodeSignatures: false
-        )
+        do {
+            let session = try beginUpdateSession(
+                operation: "test-install",
+                timeout: 0,
+                installRoot: installDir,
+                verifyCodeSignatures: false
+            )
+            defer { session.release() }
+            try session.recover()
+            return installBundle(from: downloadedFile, release: release, session: session)
+        } catch let error as UpdateError {
+            return .failure(error)
+        } catch {
+            return .failure(.replaceFailed("\(error)"))
+        }
     }
 
     private func installBundle(
         from downloadedFile: URL,
         release: ReleaseInfo,
-        installDir: URL,
-        verifyCodeSignatures: Bool
+        session: UpdateSession
     ) -> Result<Void, UpdateError> {
         switch stageBundle(
             from: downloadedFile,
             release: release,
-            installDir: installDir,
-            verifyCodeSignatures: verifyCodeSignatures
+            installDir: session.store.installRoot,
+            verifyCodeSignatures: session.store.verifyCodeSignatures
         ) {
         case .failure(let error):
             return .failure(error)
         case .success(let staged):
-            return commitStagedBundle(staged)
+            return commitStagedBundle(staged, session: session)
         }
     }
 
     // MARK: - Full Update Flow
 
     /// Check for updates and apply if available.
-    public func update() async -> UpdateResult {
-        let checkResult = await checkForUpdate()
+    public func update(manualOverride: Bool = false) async -> UpdateResult {
+        let session: UpdateSession
+        do {
+            session = try beginUpdateSession(operation: "update", timeout: 0)
+            try session.recover()
+        } catch UpdateError.busy(let reason) {
+            return .busy(reason: reason)
+        } catch {
+            return .replaceFailed(reason: "update recovery failed: \(error)")
+        }
+        defer { session.release() }
+        return await update(session: session, manualOverride: manualOverride)
+    }
+
+    public func update(
+        session: UpdateSession,
+        manualOverride: Bool = false,
+        beforeInstall: @Sendable () -> Bool = { true }
+    ) async -> UpdateResult {
+        let checkResult = await checkForUpdate(
+            manualOverride: manualOverride,
+            session: session
+        )
 
         switch checkResult {
         case .upToDate(let version):
             return .alreadyUpToDate(version: version)
+
+        case .restartRequired(let current, let installed):
+            do {
+                try armPendingCandidateAttempt(session: session)
+            } catch {
+                return .replaceFailed(
+                    reason: "could not persist candidate restart attempt: \(error)")
+            }
+            return .restartRequired(from: current, to: installed)
+
+        case .quarantined(let version, let reason):
+            return .quarantined(version: version, reason: reason)
 
         case .checkFailed(let reason):
             return .downloadFailed(reason: "update check failed: \(reason)")
@@ -581,10 +738,21 @@ public struct SelfUpdater: Sendable {
                     return .downloadFailed(reason: "invalid download URL: \(url)")
                 case .replaceFailed(let reason):
                     return .replaceFailed(reason: reason)
+                case .busy(let reason):
+                    return .busy(reason: reason)
                 }
 
             case .success(let tempFile):
-                let replaceResult = installBundle(from: tempFile, release: release)
+                guard beforeInstall() else {
+                    try? FileManager.default.removeItem(at: tempFile)
+                    return .cancelled(
+                        reason: "provider was intentionally stopped before install")
+                }
+                let replaceResult = installBundle(
+                    from: tempFile,
+                    release: release,
+                    session: session
+                )
                 // Clean up the downloaded tarball regardless of install outcome.
                 try? FileManager.default.removeItem(at: tempFile)
                 switch replaceResult {
@@ -592,7 +760,7 @@ public struct SelfUpdater: Sendable {
                     return .updated(from: current, to: release.version)
                 case .failure(let error):
                     switch error {
-                    case .replaceFailed(let reason):
+                    case .replaceFailed(let reason), .busy(let reason):
                         return .replaceFailed(reason: reason)
                     default:
                         return .replaceFailed(reason: "\(error)")
@@ -642,12 +810,6 @@ public struct SelfUpdater: Sendable {
         throw UpdateError.replaceFailed("release bundle missing \(names[0])")
     }
 
-    private func itemExistsIncludingSymlink(_ url: URL) -> Bool {
-        let fm = FileManager.default
-        return fm.fileExists(atPath: url.path)
-            || (try? fm.destinationOfSymbolicLink(atPath: url.path)) != nil
-    }
-
     private func verifyHash(file: URL, expected: String, label: String) throws {
         let data = try Data(contentsOf: file)
         let digest = SHA256.hash(data: data)
@@ -657,15 +819,23 @@ public struct SelfUpdater: Sendable {
         }
     }
 
-    private func verifyCodeSignature(file: URL, label: String) throws {
+    private func verifyCodeSignature(
+        file: URL,
+        label: String,
+        deep: Bool = false
+    ) throws {
         #if canImport(Darwin)
         do {
-            try runProcess("/usr/bin/codesign", arguments: [
+            var arguments = [
                 "--verify",
                 "--strict",
                 "--verbose=2",
-                file.path,
-            ])
+            ]
+            if deep {
+                arguments.append("--deep")
+            }
+            arguments.append(file.path)
+            try runProcess("/usr/bin/codesign", arguments: arguments)
         } catch {
             throw UpdateError.replaceFailed("\(label) code signature verification failed: \(error.localizedDescription)")
         }
@@ -696,4 +866,5 @@ public enum UpdateError: Error, Sendable {
     case downloadFailed(String)
     case hashMismatch(expected: String, got: String)
     case replaceFailed(String)
+    case busy(String)
 }

--- a/provider-swift/Sources/ProviderCore/Update/SelfUpdater.swift
+++ b/provider-swift/Sources/ProviderCore/Update/SelfUpdater.swift
@@ -152,84 +152,162 @@ public struct SelfUpdater: Sendable {
         } catch {
             return .checkFailed(reason: "could not read update recovery state: \(error)")
         }
-        if let candidate = recoveryState.candidate,
-           candidate.release.version != currentVersion
-        {
-            return .restartRequired(
+
+        // Compare against the version installed ON DISK, not this process's
+        // version. The persistent watchdog outlives the binary it replaces:
+        // after it installs and promotes v2, its own `ProviderCore.version`
+        // is still v1, and a process-version compare would re-download the
+        // already-installed release and re-arm it as an unproven candidate
+        // (a later unrelated crash could then quarantine a good release).
+        // SemVer-max also keeps manual reinstalls, which bypass recovery
+        // state, from re-candidatizing.
+        let installedVersion = Self.effectiveInstalledVersion(
+            processVersion: currentVersion,
+            recorded: recoveryState.current?.version
+        )
+        let pendingCandidate = recoveryState.candidate.flatMap {
+            $0.release.version != currentVersion ? $0 : nil
+        }
+        func restartPendingCandidate(
+            _ candidate: PendingReleaseCandidate
+        ) -> UpdateCheckResult {
+            .restartRequired(
                 current: currentVersion,
                 installed: candidate.release.version
             )
         }
 
+        let release: ReleaseInfo
+        switch await fetchLatestRelease() {
+        case .release(let fetched):
+            release = fetched
+        case .failed(let reason):
+            // A pending candidate must still restart when the coordinator is
+            // unreachable — only DISCOVERY of a superseding release needs the
+            // network, never the restart/rollback path itself.
+            if let pendingCandidate {
+                return restartPendingCandidate(pendingCandidate)
+            }
+            return .checkFailed(reason: reason)
+        }
+
+        guard SemanticVersion(release.version) != nil,
+              SemanticVersion(installedVersion) != nil
+        else {
+            if let pendingCandidate {
+                return restartPendingCandidate(pendingCandidate)
+            }
+            return .checkFailed(
+                reason: "release or current version is not valid SemVer")
+        }
+
+        if let pendingCandidate {
+            // A strictly newer, non-quarantined release supersedes a pending
+            // (possibly stuck) candidate: `installCandidate` quarantines a
+            // superseded candidate that already failed starts. Without this,
+            // a host wedged on a broken candidate whose rollback is blocked
+            // could never be rescued by publishing a fixed release.
+            if !recoveryState.quarantineBlocks(
+                version: release.version,
+                manualOverride: manualOverride
+            ),
+               isNewer(
+                latest: release.version,
+                current: pendingCandidate.release.version
+               )
+            {
+                return .updateAvailable(current: installedVersion, latest: release)
+            }
+            return restartPendingCandidate(pendingCandidate)
+        }
+
+        if recoveryState.quarantineBlocks(
+            version: release.version,
+            manualOverride: manualOverride
+        ) {
+            return .quarantined(
+                version: release.version,
+                reason: recoveryState.quarantine?.reason ?? "release failed local startup validation"
+            )
+        }
+
+        if isNewer(latest: release.version, current: installedVersion) {
+            return .updateAvailable(current: installedVersion, latest: release)
+        } else {
+            return .upToDate(currentVersion: installedVersion)
+        }
+    }
+
+    /// The version installed on disk: the SemVer-newer of this process's
+    /// compiled version and the recovery state's durable installed record.
+    /// Falls back to the process version when the record is absent or not
+    /// valid SemVer.
+    internal static func effectiveInstalledVersion(
+        processVersion: String,
+        recorded: String?
+    ) -> String {
+        guard let recorded, SemanticVersion(recorded) != nil else {
+            return processVersion
+        }
+        guard SemanticVersion(processVersion) != nil else { return recorded }
+        return isNewer(latest: recorded, current: processVersion)
+            ? recorded
+            : processVersion
+    }
+
+    private enum LatestReleaseFetch {
+        case release(ReleaseInfo)
+        case failed(String)
+    }
+
+    private func fetchLatestRelease() async -> LatestReleaseFetch {
         let endpoint = "\(coordinatorBaseURL)/v1/releases/latest?platform=macos-arm64"
 
         guard let url = URL(string: endpoint) else {
-            return .checkFailed(reason: "invalid coordinator URL: \(endpoint)")
+            return .failed("invalid coordinator URL: \(endpoint)")
         }
 
         do {
             let (data, response) = try await urlSession.data(from: url)
 
             guard let httpResponse = response as? HTTPURLResponse else {
-                return .checkFailed(reason: "unexpected response type")
+                return .failed("unexpected response type")
             }
 
             guard httpResponse.statusCode == 200 else {
-                return .checkFailed(
-                    reason: "coordinator returned HTTP \(httpResponse.statusCode)"
-                )
+                return .failed("coordinator returned HTTP \(httpResponse.statusCode)")
             }
 
             guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
-                return .checkFailed(reason: "invalid JSON response")
+                return .failed("invalid JSON response")
             }
 
             guard let version = json["version"] as? String,
                   let platform = json["platform"] as? String,
                   let downloadURL = json["url"] as? String
             else {
-                return .checkFailed(reason: "missing required fields in release response")
+                return .failed("missing required fields in release response")
             }
             guard platform == "macos-arm64" else {
-                return .checkFailed(
-                    reason: "coordinator returned unsupported release platform \(platform)")
+                return .failed("coordinator returned unsupported release platform \(platform)")
             }
             guard let bundleHash = (json["bundle_hash"] as? String)
                     ?? (json["sha256"] as? String)
                     ?? (json["binary_hash"] as? String)
             else {
-                return .checkFailed(reason: "missing release hash field")
+                return .failed("missing release hash field")
             }
 
-            let release = ReleaseInfo(
+            return .release(ReleaseInfo(
                 version: version,
                 platform: platform,
                 url: downloadURL,
                 bundleHash: bundleHash,
                 binaryHash: json["binary_hash"] as? String,
                 metallibHash: json["metallib_hash"] as? String
-            )
-            guard SemanticVersion(version) != nil,
-                  SemanticVersion(currentVersion) != nil
-            else {
-                return .checkFailed(
-                    reason: "release or current version is not valid SemVer")
-            }
-
-            if recoveryState.quarantineBlocks(version: version, manualOverride: manualOverride) {
-                return .quarantined(
-                    version: version,
-                    reason: recoveryState.quarantine?.reason ?? "release failed local startup validation"
-                )
-            }
-
-            if isNewer(latest: version, current: currentVersion) {
-                return .updateAvailable(current: currentVersion, latest: release)
-            } else {
-                return .upToDate(currentVersion: currentVersion)
-            }
+            ))
         } catch {
-            return .checkFailed(reason: error.localizedDescription)
+            return .failed(error.localizedDescription)
         }
     }
 

--- a/provider-swift/Sources/ProviderCore/Update/SelfUpdater.swift
+++ b/provider-swift/Sources/ProviderCore/Update/SelfUpdater.swift
@@ -62,6 +62,10 @@ public struct SelfUpdater: Sendable {
     private let currentVersion: String
     private let urlSession: URLSession
     private let now: @Sendable () -> Double
+    /// Test seam threaded into every `UpdateRecoveryStore` this updater
+    /// constructs; production always uses the no-op default.
+    private let recoveryFaultInjector:
+        @Sendable (UpdateRecoveryStore.FaultPoint) throws -> Void
 
     /// Whether this updater verifies the pinned Darkbloom code signature on
     /// staged/committed/installed artifacts. Always `true` for the public
@@ -116,7 +120,9 @@ public struct SelfUpdater: Sendable {
         urlSession: URLSession = .shared,
         now: @escaping @Sendable () -> Double = {
             Date().timeIntervalSince1970
-        }
+        },
+        recoveryFaultInjector:
+            @escaping @Sendable (UpdateRecoveryStore.FaultPoint) throws -> Void = { _ in }
     ) {
         // Convert WebSocket URL to HTTP if needed
         var base = WebSocketURLScheme.toHTTP(coordinatorBaseURL)
@@ -131,6 +137,7 @@ public struct SelfUpdater: Sendable {
         self.currentVersion = currentVersion
         self.urlSession = urlSession
         self.now = now
+        self.recoveryFaultInjector = recoveryFaultInjector
     }
 
     // MARK: - Version Check
@@ -660,7 +667,8 @@ public struct SelfUpdater: Sendable {
         guard let root = resolvedInstallRoot() else { return nil }
         return UpdateRecoveryStore(
             installRoot: root,
-            verifyCodeSignatures: verifyCodeSignatures
+            verifyCodeSignatures: verifyCodeSignatures,
+            faultInjector: recoveryFaultInjector
         )
     }
 
@@ -687,7 +695,8 @@ public struct SelfUpdater: Sendable {
     ) throws -> UpdateSession {
         let store = UpdateRecoveryStore(
             installRoot: installRoot,
-            verifyCodeSignatures: verifyCodeSignatures
+            verifyCodeSignatures: verifyCodeSignatures,
+            faultInjector: recoveryFaultInjector
         )
         do {
             let processLock = try UpdateProcessLock.acquire(
@@ -697,16 +706,18 @@ public struct SelfUpdater: Sendable {
             )
             return UpdateSession(processLock: processLock, store: store)
         } catch let error as UpdateProcessLock.LockError {
-            let owner: UpdateProcessLock.Owner?
+            // Only real contention is `lockBusy` — flock is kernel-owned and
+            // auto-releases on owner death, so `.busy` always means a LIVE
+            // process holds the lease. An unopenable recovery dir or lock
+            // file (full disk, permissions) is an infrastructure failure, not
+            // contention: callers must not wait for a nonexistent owner.
             if case .busy(let recorded) = error {
-                owner = recorded
-            } else {
-                owner = nil
+                throw UpdateError.lockBusy(
+                    reason: error.description,
+                    owner: recorded
+                )
             }
-            throw UpdateError.lockBusy(
-                reason: error.description,
-                owner: owner
-            )
+            throw UpdateError.replaceFailed(error.description)
         }
     }
 

--- a/provider-swift/Sources/ProviderCore/Update/SelfUpdater.swift
+++ b/provider-swift/Sources/ProviderCore/Update/SelfUpdater.swift
@@ -175,6 +175,12 @@ public struct SelfUpdater: Sendable {
                 binaryHash: json["binary_hash"] as? String,
                 metallibHash: json["metallib_hash"] as? String
             )
+            guard SemanticVersion(version) != nil,
+                  SemanticVersion(currentVersion) != nil
+            else {
+                return .checkFailed(
+                    reason: "release or current version is not valid SemVer")
+            }
 
             if recoveryState.quarantineBlocks(version: version, manualOverride: manualOverride) {
                 return .quarantined(
@@ -337,15 +343,15 @@ public struct SelfUpdater: Sendable {
 
             // Use the flat bin/ copies for hash verification (release hashes
             // are computed from the flat layout).
-            let flatDarkbloom = try requiredBundleFile(
+            var flatDarkbloom = try requiredBundleFile(
                 names: ["bin/darkbloom", "darkbloom"],
                 root: stagingRoot
             )
-            let flatEnclave = try requiredBundleFile(
+            var flatEnclave = try requiredBundleFile(
                 names: ["bin/darkbloom-enclave", "darkbloom-enclave", "bin/eigeninference-enclave", "eigeninference-enclave"],
                 root: stagingRoot
             )
-            let flatMetallib = try requiredBundleFile(
+            var flatMetallib = try requiredBundleFile(
                 names: ["bin/mlx.metallib", "mlx.metallib"],
                 root: stagingRoot
             )
@@ -364,6 +370,41 @@ public struct SelfUpdater: Sendable {
             // to SIGKILL the process.
             let extractedApp = stagingRoot.appendingPathComponent("Darkbloom.app")
             let hasAppBundle = fm.fileExists(atPath: extractedApp.path)
+            if !hasAppBundle {
+                let canonicalBin = stagingRoot.appendingPathComponent("bin")
+                try fm.createDirectory(
+                    at: canonicalBin,
+                    withIntermediateDirectories: true
+                )
+                func canonicalize(_ source: URL, name: String) throws -> URL {
+                    let destination = canonicalBin.appendingPathComponent(name)
+                    if source.standardizedFileURL != destination.standardizedFileURL {
+                        try fm.moveItem(at: source, to: destination)
+                    }
+                    return destination
+                }
+                flatDarkbloom = try canonicalize(
+                    flatDarkbloom,
+                    name: "darkbloom"
+                )
+                flatEnclave = try canonicalize(
+                    flatEnclave,
+                    name: "darkbloom-enclave"
+                )
+                flatMetallib = try canonicalize(
+                    flatMetallib,
+                    name: "mlx.metallib"
+                )
+                let legacy = canonicalBin.appendingPathComponent(
+                    "eigeninference-enclave"
+                )
+                if !UpdateAtomicFilesystem.itemExists(legacy) {
+                    try fm.createSymbolicLink(
+                        atPath: legacy.path,
+                        withDestinationPath: "darkbloom-enclave"
+                    )
+                }
+            }
             if verifyCodeSignatures {
                 if hasAppBundle {
                     let appDarkbloom = extractedApp
@@ -396,7 +437,9 @@ public struct SelfUpdater: Sendable {
             }
 
             let stagedTreeHash = try UpdateAtomicFilesystem.treeHash(
-                root: hasAppBundle ? extractedApp : stagingRoot
+                root: hasAppBundle
+                    ? extractedApp
+                    : stagingRoot.appendingPathComponent("bin")
             )
             return .success(StagedBundle(
                 stagingRoot: stagingRoot,
@@ -433,7 +476,8 @@ public struct SelfUpdater: Sendable {
             return .failure(.replaceFailed("staged bundle belongs to a different install root"))
         }
         do {
-            let stagedRoot = staged.extractedApp ?? staged.stagingRoot
+            let stagedRoot = staged.extractedApp
+                ?? staged.stagingRoot.appendingPathComponent("bin")
             let currentTreeHash = try UpdateAtomicFilesystem.treeHash(root: stagedRoot)
             guard currentTreeHash == staged.stagedTreeHash else {
                 return .failure(.replaceFailed(
@@ -535,7 +579,16 @@ public struct SelfUpdater: Sendable {
             )
             return UpdateSession(processLock: processLock, store: store)
         } catch let error as UpdateProcessLock.LockError {
-            throw UpdateError.busy(error.description)
+            let owner: UpdateProcessLock.Owner?
+            if case .busy(let recorded) = error {
+                owner = recorded
+            } else {
+                owner = nil
+            }
+            throw UpdateError.lockBusy(
+                reason: error.description,
+                owner: owner
+            )
         }
     }
 
@@ -556,13 +609,59 @@ public struct SelfUpdater: Sendable {
         }
     }
 
-    public func armPendingCandidateAttempt(
+    public func prepareCandidateLaunch(
+        session: UpdateSession,
+        baseline: ProviderLaunchSnapshot?,
+        now: Double = Date().timeIntervalSince1970
+    ) throws {
+        var state = try session.readState()
+        let before = state
+        _ = state.prepareLaunchIntent(now: now, baseline: baseline)
+        if state != before {
+            try session.writeState(state)
+        }
+    }
+
+    public func prepareCandidateLaunch(
+        operation: String,
+        baseline: ProviderLaunchSnapshot? = LaunchAgent.launchSnapshot()
+    ) throws {
+        let session = try beginUpdateSession(operation: operation, timeout: 1)
+        defer { session.release() }
+        try session.recover()
+        try prepareCandidateLaunch(
+            session: session,
+            baseline: baseline,
+            now: now()
+        )
+    }
+
+    public func markCandidateLaunchIssued(
         session: UpdateSession,
         now: Double = Date().timeIntervalSince1970
     ) throws {
         var state = try session.readState()
         let before = state
-        _ = state.armCandidateAttempt(now: now)
+        _ = state.markLaunchIssued(now: now)
+        if state != before {
+            try session.writeState(state)
+        }
+    }
+
+    public func confirmRunningCandidateLaunch(
+        processStartedAt: Double,
+        operation: String = "candidate-process-confirmation"
+    ) throws {
+        let session = try beginUpdateSession(operation: operation, timeout: 1)
+        defer { session.release() }
+        try session.recover()
+        var state = try session.readState()
+        let before = state
+        _ = state.confirmRunningCandidate(
+            version: currentVersion,
+            processStartedAt: processStartedAt,
+            now: now()
+        )
         if state != before {
             try session.writeState(state)
         }
@@ -686,7 +785,7 @@ public struct SelfUpdater: Sendable {
         do {
             session = try beginUpdateSession(operation: "update", timeout: 0)
             try session.recover()
-        } catch UpdateError.busy(let reason) {
+        } catch UpdateError.lockBusy(let reason, _) {
             return .busy(reason: reason)
         } catch {
             return .replaceFailed(reason: "update recovery failed: \(error)")
@@ -710,12 +809,6 @@ public struct SelfUpdater: Sendable {
             return .alreadyUpToDate(version: version)
 
         case .restartRequired(let current, let installed):
-            do {
-                try armPendingCandidateAttempt(session: session)
-            } catch {
-                return .replaceFailed(
-                    reason: "could not persist candidate restart attempt: \(error)")
-            }
             return .restartRequired(from: current, to: installed)
 
         case .quarantined(let version, let reason):
@@ -738,7 +831,7 @@ public struct SelfUpdater: Sendable {
                     return .downloadFailed(reason: "invalid download URL: \(url)")
                 case .replaceFailed(let reason):
                     return .replaceFailed(reason: reason)
-                case .busy(let reason):
+                case .lockBusy(let reason, _):
                     return .busy(reason: reason)
                 }
 
@@ -760,7 +853,8 @@ public struct SelfUpdater: Sendable {
                     return .updated(from: current, to: release.version)
                 case .failure(let error):
                     switch error {
-                    case .replaceFailed(let reason), .busy(let reason):
+                    case .replaceFailed(let reason),
+                         .lockBusy(let reason, _):
                         return .replaceFailed(reason: reason)
                     default:
                         return .replaceFailed(reason: "\(error)")
@@ -777,22 +871,12 @@ public struct SelfUpdater: Sendable {
     /// Handles versions like "0.4.0-swift", "0.4.1", etc. The suffix after '-' is
     /// stripped for comparison (pre-release suffixes are ignored for ordering).
     internal static func isNewer(latest: String, current: String) -> Bool {
-        let latestParts = parseVersion(latest)
-        let currentParts = parseVersion(current)
-
-        for i in 0..<max(latestParts.count, currentParts.count) {
-            let l = i < latestParts.count ? latestParts[i] : 0
-            let c = i < currentParts.count ? currentParts[i] : 0
-            if l > c { return true }
-            if l < c { return false }
+        guard let latest = SemanticVersion(latest),
+              let current = SemanticVersion(current)
+        else {
+            return false
         }
-        return false
-    }
-
-    private static func parseVersion(_ version: String) -> [Int] {
-        // Strip pre-release suffix (e.g. "-swift", "-beta1")
-        let base = version.split(separator: "-").first ?? Substring(version)
-        return base.split(separator: ".").compactMap { Int($0) }
+        return latest > current
     }
 
     private func isNewer(latest: String, current: String) -> Bool {
@@ -826,16 +910,7 @@ public struct SelfUpdater: Sendable {
     ) throws {
         #if canImport(Darwin)
         do {
-            var arguments = [
-                "--verify",
-                "--strict",
-                "--verbose=2",
-            ]
-            if deep {
-                arguments.append("--deep")
-            }
-            arguments.append(file.path)
-            try runProcess("/usr/bin/codesign", arguments: arguments)
+            try DarkbloomCodeSignature.verify(file, deep: deep)
         } catch {
             throw UpdateError.replaceFailed("\(label) code signature verification failed: \(error.localizedDescription)")
         }
@@ -866,5 +941,5 @@ public enum UpdateError: Error, Sendable {
     case downloadFailed(String)
     case hashMismatch(expected: String, got: String)
     case replaceFailed(String)
-    case busy(String)
+    case lockBusy(reason: String, owner: UpdateProcessLock.Owner?)
 }

--- a/provider-swift/Sources/ProviderCore/Update/SemanticVersion.swift
+++ b/provider-swift/Sources/ProviderCore/Update/SemanticVersion.swift
@@ -1,0 +1,101 @@
+import Foundation
+
+struct SemanticVersion: Comparable, Sendable, Equatable {
+    enum Identifier: Sendable, Equatable {
+        case numeric(UInt64)
+        case text(String)
+    }
+
+    let major: UInt64
+    let minor: UInt64
+    let patch: UInt64
+    let prerelease: [Identifier]
+
+    init?(_ raw: String) {
+        var value = raw
+        if value.first == "v" { value.removeFirst() }
+        let withoutBuild = value.split(
+            separator: "+",
+            maxSplits: 1,
+            omittingEmptySubsequences: false
+        )[0]
+        let pieces = withoutBuild.split(
+            separator: "-",
+            maxSplits: 1,
+            omittingEmptySubsequences: false
+        )
+        let core = pieces[0].split(
+            separator: ".",
+            omittingEmptySubsequences: false
+        )
+        guard core.count == 3,
+              let major = Self.parseCore(core[0]),
+              let minor = Self.parseCore(core[1]),
+              let patch = Self.parseCore(core[2])
+        else {
+            return nil
+        }
+        var prerelease: [Identifier] = []
+        if pieces.count == 2 {
+            let identifiers = pieces[1].split(
+                separator: ".",
+                omittingEmptySubsequences: false
+            )
+            guard !identifiers.isEmpty else { return nil }
+            for identifier in identifiers {
+                guard !identifier.isEmpty,
+                      identifier.allSatisfy({
+                          $0.isASCII
+                              && ($0.isLetter || $0.isNumber || $0 == "-")
+                      })
+                else {
+                    return nil
+                }
+                if identifier.allSatisfy(\.isNumber) {
+                    guard identifier == "0" || identifier.first != "0",
+                          let number = UInt64(identifier)
+                    else {
+                        return nil
+                    }
+                    prerelease.append(.numeric(number))
+                } else {
+                    prerelease.append(.text(String(identifier)))
+                }
+            }
+        }
+        self.major = major
+        self.minor = minor
+        self.patch = patch
+        self.prerelease = prerelease
+    }
+
+    static func < (lhs: SemanticVersion, rhs: SemanticVersion) -> Bool {
+        let leftCore = [lhs.major, lhs.minor, lhs.patch]
+        let rightCore = [rhs.major, rhs.minor, rhs.patch]
+        if leftCore != rightCore {
+            return leftCore.lexicographicallyPrecedes(rightCore)
+        }
+        if lhs.prerelease.isEmpty { return false }
+        if rhs.prerelease.isEmpty { return true }
+        for (left, right) in zip(lhs.prerelease, rhs.prerelease) {
+            if left == right { continue }
+            switch (left, right) {
+            case (.numeric(let a), .numeric(let b)): return a < b
+            case (.numeric, .text): return true
+            case (.text, .numeric): return false
+            case (.text(let a), .text(let b)): return a < b
+            }
+        }
+        return lhs.prerelease.count < rhs.prerelease.count
+    }
+
+    private static func parseCore(_ raw: Substring) -> UInt64? {
+        guard !raw.isEmpty,
+              raw.allSatisfy(\.isNumber),
+              raw == "0" || raw.first != "0"
+        else {
+            return nil
+        }
+        return UInt64(raw)
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Update/UpdateAtomicFilesystem.swift
+++ b/provider-swift/Sources/ProviderCore/Update/UpdateAtomicFilesystem.swift
@@ -109,6 +109,25 @@ enum UpdateAtomicFilesystem {
         try syncDirectory(parent)
     }
 
+    /// Remove a file/tree so the ORIGINAL path vanishes atomically. The path is
+    /// first renamed to a sibling `asidePrefix<uuid>` (a single atomic rename,
+    /// then the parent is fsync'd), and only afterwards is the renamed copy
+    /// deleted. A crash mid-delete can never leave the original path partially
+    /// populated — it is already gone — it only leaves an orphaned sibling for
+    /// the caller to sweep. Used to retire a stale `Darkbloom.app` during a flat
+    /// install/rollback without a window where a half-deleted app could be
+    /// mistaken for a valid install.
+    static func atomicRemove(_ url: URL, asidePrefix: String) throws {
+        guard itemExists(url) else { return }
+        let parent = url.deletingLastPathComponent()
+        let aside = parent.appendingPathComponent("\(asidePrefix)\(UUID().uuidString)")
+        guard rename(url.path, aside.path) == 0 else {
+            throw filesystemError("rename \(url.path) aside for removal")
+        }
+        try syncDirectory(parent)
+        try? FileManager.default.removeItem(at: aside)
+    }
+
     static func createDirectoryDurably(_ directory: URL) throws {
         let fm = FileManager.default
         if fm.fileExists(atPath: directory.path) {

--- a/provider-swift/Sources/ProviderCore/Update/UpdateAtomicFilesystem.swift
+++ b/provider-swift/Sources/ProviderCore/Update/UpdateAtomicFilesystem.swift
@@ -17,7 +17,7 @@ enum UpdateAtomicFilesystem {
     static func write(_ data: Data, to destination: URL) throws {
         let fm = FileManager.default
         let directory = destination.deletingLastPathComponent()
-        try fm.createDirectory(at: directory, withIntermediateDirectories: true)
+        try createDirectoryDurably(directory)
         let temporary = directory.appendingPathComponent(
             ".\(destination.lastPathComponent).tmp-\(UUID().uuidString)")
 
@@ -51,7 +51,7 @@ enum UpdateAtomicFilesystem {
             throw filesystemError("rename \(temporary.path) -> \(destination.path)")
         }
         shouldRemove = false
-        syncDirectory(directory)
+        try syncDirectory(directory)
     }
 
     /// Atomically exchange two same-volume paths. Both names always reference
@@ -68,9 +68,9 @@ enum UpdateAtomicFilesystem {
         guard result == 0 else {
             throw filesystemError("exchange \(first.path) <-> \(second.path)")
         }
-        syncDirectory(first.deletingLastPathComponent())
+        try syncDirectory(first.deletingLastPathComponent())
         if first.deletingLastPathComponent() != second.deletingLastPathComponent() {
-            syncDirectory(second.deletingLastPathComponent())
+            try syncDirectory(second.deletingLastPathComponent())
         }
         #else
         throw CocoaError(.featureUnsupported)
@@ -84,7 +84,7 @@ enum UpdateAtomicFilesystem {
             guard rename(source.path, destination.path) == 0 else {
                 throw filesystemError("rename \(source.path) -> \(destination.path)")
             }
-            syncDirectory(destination.deletingLastPathComponent())
+            try syncDirectory(destination.deletingLastPathComponent())
         }
     }
 
@@ -99,7 +99,27 @@ enum UpdateAtomicFilesystem {
         guard rename(temporary.path, destination.path) == 0 else {
             throw filesystemError("replace symlink \(destination.path)")
         }
-        syncDirectory(directory)
+        try syncDirectory(directory)
+    }
+
+    static func removeDurably(_ url: URL) throws {
+        guard itemExists(url) else { return }
+        let parent = url.deletingLastPathComponent()
+        try FileManager.default.removeItem(at: url)
+        try syncDirectory(parent)
+    }
+
+    static func createDirectoryDurably(_ directory: URL) throws {
+        let fm = FileManager.default
+        if fm.fileExists(atPath: directory.path) {
+            return
+        }
+        try fm.createDirectory(at: directory, withIntermediateDirectories: true)
+        try syncDirectory(directory)
+        let parent = directory.deletingLastPathComponent()
+        if parent.path != directory.path {
+            try syncDirectory(parent)
+        }
     }
 
     static func sha256(file: URL) throws -> String {
@@ -187,7 +207,7 @@ enum UpdateAtomicFilesystem {
             }
         }
         for directory in directories.reversed() {
-            syncDirectory(directory)
+            try syncDirectory(directory)
         }
     }
 
@@ -213,11 +233,18 @@ enum UpdateAtomicFilesystem {
         hasher.update(data: Data((line + "\n").utf8))
     }
 
-    private static func syncDirectory(_ directory: URL) {
+    static func syncDirectory(_ directory: URL) throws {
         let descriptor = open(directory.path, O_RDONLY | O_CLOEXEC)
-        guard descriptor >= 0 else { return }
-        _ = fsync(descriptor)
+        guard descriptor >= 0 else {
+            throw filesystemError("open directory \(directory.path)")
+        }
+        let result = fsync(descriptor)
+        let code = errno
         _ = close(descriptor)
+        guard result == 0 else {
+            errno = code
+            throw filesystemError("fsync directory \(directory.path)")
+        }
     }
 
     private static func filesystemError(_ operation: String) -> Error {

--- a/provider-swift/Sources/ProviderCore/Update/UpdateAtomicFilesystem.swift
+++ b/provider-swift/Sources/ProviderCore/Update/UpdateAtomicFilesystem.swift
@@ -1,0 +1,243 @@
+import CryptoKit
+import Foundation
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
+
+enum UpdateAtomicFilesystem {
+    static func writeJSON<T: Encodable>(_ value: T, to destination: URL) throws {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let data = try encoder.encode(value)
+        try write(data, to: destination)
+    }
+
+    static func write(_ data: Data, to destination: URL) throws {
+        let fm = FileManager.default
+        let directory = destination.deletingLastPathComponent()
+        try fm.createDirectory(at: directory, withIntermediateDirectories: true)
+        let temporary = directory.appendingPathComponent(
+            ".\(destination.lastPathComponent).tmp-\(UUID().uuidString)")
+
+        let descriptor = open(temporary.path, O_WRONLY | O_CREAT | O_EXCL | O_CLOEXEC, 0o600)
+        guard descriptor >= 0 else {
+            throw filesystemError("open \(temporary.path)")
+        }
+        var shouldRemove = true
+        defer {
+            _ = close(descriptor)
+            if shouldRemove { try? fm.removeItem(at: temporary) }
+        }
+
+        try data.withUnsafeBytes { rawBuffer in
+            guard var pointer = rawBuffer.baseAddress else { return }
+            var remaining = rawBuffer.count
+            while remaining > 0 {
+                let count = DarwinOrGlibcWrite(descriptor, pointer, remaining)
+                if count < 0, errno == EINTR { continue }
+                guard count > 0 else {
+                    throw filesystemError("write \(temporary.path)")
+                }
+                remaining -= count
+                pointer = pointer.advanced(by: count)
+            }
+        }
+        guard fsync(descriptor) == 0 else {
+            throw filesystemError("fsync \(temporary.path)")
+        }
+        guard rename(temporary.path, destination.path) == 0 else {
+            throw filesystemError("rename \(temporary.path) -> \(destination.path)")
+        }
+        shouldRemove = false
+        syncDirectory(directory)
+    }
+
+    /// Atomically exchange two same-volume paths. Both names always reference
+    /// a complete tree; there is no interval where the live app path is absent.
+    static func exchange(_ first: URL, _ second: URL) throws {
+        #if canImport(Darwin)
+        let result = renameatx_np(
+            AT_FDCWD,
+            first.path,
+            AT_FDCWD,
+            second.path,
+            UInt32(RENAME_SWAP)
+        )
+        guard result == 0 else {
+            throw filesystemError("exchange \(first.path) <-> \(second.path)")
+        }
+        syncDirectory(first.deletingLastPathComponent())
+        if first.deletingLastPathComponent() != second.deletingLastPathComponent() {
+            syncDirectory(second.deletingLastPathComponent())
+        }
+        #else
+        throw CocoaError(.featureUnsupported)
+        #endif
+    }
+
+    static func replace(_ source: URL, at destination: URL) throws {
+        if itemExists(destination) {
+            try exchange(source, destination)
+        } else {
+            guard rename(source.path, destination.path) == 0 else {
+                throw filesystemError("rename \(source.path) -> \(destination.path)")
+            }
+            syncDirectory(destination.deletingLastPathComponent())
+        }
+    }
+
+    static func replaceSymlink(at destination: URL, target: String) throws {
+        let fm = FileManager.default
+        let directory = destination.deletingLastPathComponent()
+        try fm.createDirectory(at: directory, withIntermediateDirectories: true)
+        let temporary = directory.appendingPathComponent(
+            ".\(destination.lastPathComponent).link-\(UUID().uuidString)")
+        try fm.createSymbolicLink(atPath: temporary.path, withDestinationPath: target)
+        defer { try? fm.removeItem(at: temporary) }
+        guard rename(temporary.path, destination.path) == 0 else {
+            throw filesystemError("replace symlink \(destination.path)")
+        }
+        syncDirectory(directory)
+    }
+
+    static func sha256(file: URL) throws -> String {
+        let handle = try FileHandle(forReadingFrom: file)
+        defer { try? handle.close() }
+        var hasher = SHA256()
+        while true {
+            let chunk = try handle.read(upToCount: 1024 * 1024) ?? Data()
+            if chunk.isEmpty { break }
+            hasher.update(data: chunk)
+        }
+        return hasher.finalize().map { String(format: "%02x", $0) }.joined()
+    }
+
+    /// Content-address the complete backup tree. File paths, node kinds,
+    /// symlink targets, and regular-file bytes are included in sorted order.
+    static func treeHash(root: URL) throws -> String {
+        let fm = FileManager.default
+        let keys: [URLResourceKey] = [.isRegularFileKey, .isDirectoryKey, .isSymbolicLinkKey]
+        guard let enumerator = fm.enumerator(
+            at: root,
+            includingPropertiesForKeys: keys,
+            options: [],
+            errorHandler: { _, _ in false }
+        ) else {
+            throw CocoaError(.fileReadUnknown)
+        }
+
+        var entries: [URL] = []
+        while let entry = enumerator.nextObject() as? URL {
+            entries.append(entry)
+        }
+        entries.sort { relativePath($0, under: root) < relativePath($1, under: root) }
+
+        var hasher = SHA256()
+        for entry in entries {
+            let relative = relativePath(entry, under: root)
+            let values = try entry.resourceValues(forKeys: Set(keys))
+            if values.isSymbolicLink == true {
+                let target = try fm.destinationOfSymbolicLink(atPath: entry.path)
+                hashLine("L \(relative) \(target)", into: &hasher)
+            } else if values.isDirectory == true {
+                hashLine("D \(relative)", into: &hasher)
+            } else if values.isRegularFile == true {
+                hashLine("F \(relative)", into: &hasher)
+                let handle = try FileHandle(forReadingFrom: entry)
+                do {
+                    while true {
+                        let chunk = try handle.read(upToCount: 1024 * 1024) ?? Data()
+                        if chunk.isEmpty { break }
+                        hasher.update(data: chunk)
+                    }
+                    try handle.close()
+                } catch {
+                    try? handle.close()
+                    throw error
+                }
+                hashLine("", into: &hasher)
+            } else {
+                throw CocoaError(.fileReadUnsupportedScheme)
+            }
+        }
+        return hasher.finalize().map { String(format: "%02x", $0) }.joined()
+    }
+
+    static func fsyncTree(_ root: URL) throws {
+        let fm = FileManager.default
+        guard let enumerator = fm.enumerator(
+            at: root,
+            includingPropertiesForKeys: [.isRegularFileKey, .isDirectoryKey]
+        ) else {
+            throw CocoaError(.fileReadUnknown)
+        }
+        var directories = [root]
+        while let entry = enumerator.nextObject() as? URL {
+            let values = try entry.resourceValues(forKeys: [.isRegularFileKey, .isDirectoryKey])
+            if values.isRegularFile == true {
+                let descriptor = open(entry.path, O_RDONLY | O_CLOEXEC)
+                guard descriptor >= 0 else { throw filesystemError("open \(entry.path)") }
+                let result = fsync(descriptor)
+                _ = close(descriptor)
+                guard result == 0 else { throw filesystemError("fsync \(entry.path)") }
+            } else if values.isDirectory == true {
+                directories.append(entry)
+            }
+        }
+        for directory in directories.reversed() {
+            syncDirectory(directory)
+        }
+    }
+
+    static func itemExists(_ url: URL) -> Bool {
+        FileManager.default.fileExists(atPath: url.path)
+            || (try? FileManager.default.destinationOfSymbolicLink(atPath: url.path)) != nil
+    }
+
+    static func isDescendant(_ candidate: URL, of root: URL) -> Bool {
+        let rootPath = root.standardizedFileURL.path
+        let candidatePath = candidate.standardizedFileURL.path
+        return candidatePath == rootPath || candidatePath.hasPrefix(rootPath + "/")
+    }
+
+    private static func relativePath(_ url: URL, under root: URL) -> String {
+        let rootPath = root.standardizedFileURL.path
+        let path = url.standardizedFileURL.path
+        guard path.hasPrefix(rootPath + "/") else { return path }
+        return String(path.dropFirst(rootPath.count + 1))
+    }
+
+    private static func hashLine(_ line: String, into hasher: inout SHA256) {
+        hasher.update(data: Data((line + "\n").utf8))
+    }
+
+    private static func syncDirectory(_ directory: URL) {
+        let descriptor = open(directory.path, O_RDONLY | O_CLOEXEC)
+        guard descriptor >= 0 else { return }
+        _ = fsync(descriptor)
+        _ = close(descriptor)
+    }
+
+    private static func filesystemError(_ operation: String) -> Error {
+        NSError(
+            domain: NSPOSIXErrorDomain,
+            code: Int(errno),
+            userInfo: [NSLocalizedDescriptionKey: "\(operation): \(String(cString: strerror(errno)))"]
+        )
+    }
+}
+
+@inline(__always)
+private func DarwinOrGlibcWrite(
+    _ descriptor: Int32,
+    _ pointer: UnsafeRawPointer,
+    _ count: Int
+) -> Int {
+    #if canImport(Darwin)
+    Darwin.write(descriptor, pointer, count)
+    #else
+    Glibc.write(descriptor, pointer, count)
+    #endif
+}

--- a/provider-swift/Sources/ProviderCore/Update/UpdateInstallLayout.swift
+++ b/provider-swift/Sources/ProviderCore/Update/UpdateInstallLayout.swift
@@ -1,0 +1,397 @@
+import Foundation
+
+/// Concrete app/flat-layout operations used by the journaled recovery store.
+/// Kept separate from transaction/state orchestration so rename ordering and
+/// artifact verification remain independently auditable.
+extension UpdateRecoveryStore {
+    func snapshotLiveAsPredecessor(
+        version: String,
+        releaseBundleHash: String?,
+        installGeneration: UInt64,
+        now: Double
+    ) throws -> VerifiedPredecessor {
+        let layout = try liveLayout()
+        let nextRoot = recoveryRoot.appendingPathComponent(
+            ".predecessor-next-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        try fm.createDirectory(at: recoveryRoot, withIntermediateDirectories: true)
+        try? fm.removeItem(at: nextRoot)
+        try fm.createDirectory(at: nextRoot, withIntermediateDirectories: true)
+
+        let copiedBundle: URL
+        let copiedBinary: URL
+        let copiedMetallib: URL
+        switch layout {
+        case .app:
+            let source = installRoot.appendingPathComponent("Darkbloom.app")
+            copiedBundle = nextRoot.appendingPathComponent("Darkbloom.app")
+            try fm.copyItem(at: source, to: copiedBundle)
+            copiedBinary = copiedBundle.appendingPathComponent("Contents/MacOS/darkbloom")
+            copiedMetallib = copiedBundle.appendingPathComponent("Contents/MacOS/mlx.metallib")
+        case .flat:
+            let sourceBin = installRoot.appendingPathComponent("bin")
+            copiedBundle = nextRoot.appendingPathComponent("bin")
+            try fm.createDirectory(at: copiedBundle, withIntermediateDirectories: true)
+            for name in ["darkbloom", "darkbloom-enclave", "mlx.metallib"] {
+                try fm.copyItem(
+                    at: sourceBin.appendingPathComponent(name),
+                    to: copiedBundle.appendingPathComponent(name)
+                )
+            }
+            copiedBinary = copiedBundle.appendingPathComponent("darkbloom")
+            copiedMetallib = copiedBundle.appendingPathComponent("mlx.metallib")
+        }
+
+        try verifySignature(layout: layout, bundle: copiedBundle, binary: copiedBinary)
+        let release = InstalledReleaseRecord(
+            version: version,
+            releaseBundleHash: releaseBundleHash,
+            installedBundleHash: try UpdateAtomicFilesystem.treeHash(root: copiedBundle),
+            binaryHash: try UpdateAtomicFilesystem.sha256(file: copiedBinary),
+            metallibHash: try UpdateAtomicFilesystem.sha256(file: copiedMetallib),
+            installGeneration: installGeneration,
+            installedAt: stateInstallDateFallback(now)
+        )
+        let manifest = VerifiedPredecessor(
+            release: release,
+            layout: layout,
+            bundlePath: layout == .app
+                ? "predecessor/Darkbloom.app"
+                : "predecessor/bin",
+            binaryPath: layout == .app
+                ? "predecessor/Darkbloom.app/Contents/MacOS/darkbloom"
+                : "predecessor/bin/darkbloom",
+            metallibPath: layout == .app
+                ? "predecessor/Darkbloom.app/Contents/MacOS/mlx.metallib"
+                : "predecessor/bin/mlx.metallib",
+            verifiedAt: now
+        )
+        try UpdateAtomicFilesystem.writeJSON(
+            manifest,
+            to: nextRoot.appendingPathComponent("manifest.json")
+        )
+        try UpdateAtomicFilesystem.fsyncTree(nextRoot)
+
+        if fm.fileExists(atPath: predecessorRoot.path) {
+            try UpdateAtomicFilesystem.exchange(nextRoot, predecessorRoot)
+            try? fm.removeItem(at: nextRoot)
+        } else {
+            try UpdateAtomicFilesystem.replace(nextRoot, at: predecessorRoot)
+        }
+        try faultInjector(.predecessorPromoted)
+        return manifest
+    }
+
+    func recordForStagedBundle(
+        _ staged: SelfUpdater.StagedBundle,
+        generation: UInt64,
+        now: Double
+    ) throws -> InstalledReleaseRecord {
+        let bundle: URL
+        let binary: URL
+        let metallib: URL
+        if let app = staged.extractedApp {
+            bundle = app
+            binary = app.appendingPathComponent("Contents/MacOS/darkbloom")
+            metallib = app.appendingPathComponent("Contents/MacOS/mlx.metallib")
+        } else {
+            bundle = staged.stagingRoot.appendingPathComponent("bin")
+            binary = staged.flatDarkbloom
+            metallib = staged.flatMetallib
+        }
+        return InstalledReleaseRecord(
+            version: staged.release.version,
+            releaseBundleHash: staged.release.bundleHash,
+            installedBundleHash: try UpdateAtomicFilesystem.treeHash(root: bundle),
+            binaryHash: try UpdateAtomicFilesystem.sha256(file: binary),
+            metallibHash: try UpdateAtomicFilesystem.sha256(file: metallib),
+            installGeneration: generation,
+            installedAt: now
+        )
+    }
+
+    func installStagedBundle(_ staged: SelfUpdater.StagedBundle) throws {
+        if let app = staged.extractedApp {
+            try installApp(from: app)
+        } else {
+            try installFlat(
+                darkbloom: staged.flatDarkbloom,
+                enclave: staged.flatEnclave,
+                metallib: staged.flatMetallib
+            )
+        }
+        try ensureCanonicalLinks()
+    }
+
+    func installFromStaging(
+        _ stagingRoot: URL,
+        layout: VerifiedPredecessor.Layout
+    ) throws {
+        switch layout {
+        case .app:
+            try installApp(from: stagingRoot.appendingPathComponent("Darkbloom.app"))
+        case .flat:
+            let bin = stagingRoot.appendingPathComponent("bin")
+            try installFlat(
+                darkbloom: bin.appendingPathComponent("darkbloom"),
+                enclave: bin.appendingPathComponent("darkbloom-enclave"),
+                metallib: bin.appendingPathComponent("mlx.metallib")
+            )
+        }
+    }
+
+    func ensureCanonicalLinks() throws {
+        guard fm.fileExists(atPath: installRoot.appendingPathComponent("Darkbloom.app").path) else {
+            let legacy = installRoot.appendingPathComponent("bin/eigeninference-enclave")
+            try UpdateAtomicFilesystem.replaceSymlink(at: legacy, target: "darkbloom-enclave")
+            return
+        }
+        let bin = installRoot.appendingPathComponent("bin")
+        try fm.createDirectory(at: bin, withIntermediateDirectories: true)
+        let appBin = "../Darkbloom.app/Contents/MacOS"
+        for (name, target) in [
+            ("mlx.metallib", "\(appBin)/mlx.metallib"),
+            ("darkbloom-enclave", "\(appBin)/darkbloom-enclave"),
+            ("eigeninference-enclave", "darkbloom-enclave"),
+            ("darkbloom", "\(appBin)/darkbloom"),
+        ] {
+            try UpdateAtomicFilesystem.replaceSymlink(
+                at: bin.appendingPathComponent(name),
+                target: target
+            )
+        }
+    }
+
+    func liveMatches(
+        _ record: InstalledReleaseRecord,
+        layout: VerifiedPredecessor.Layout
+    ) throws -> Bool {
+        let (binary, metallib) = livePaths(layout: layout)
+        guard fm.fileExists(atPath: binary.path), fm.fileExists(atPath: metallib.path) else {
+            return false
+        }
+        guard try UpdateAtomicFilesystem.sha256(file: binary) == record.binaryHash,
+              try UpdateAtomicFilesystem.sha256(file: metallib) == record.metallibHash
+        else {
+            return false
+        }
+        if layout == .app {
+            let app = installRoot.appendingPathComponent("Darkbloom.app")
+            guard try UpdateAtomicFilesystem.treeHash(root: app)
+                    == record.installedBundleHash
+            else {
+                return false
+            }
+            try verifySignature(layout: .app, bundle: app, binary: binary)
+            return true
+        }
+        try verifySignature(
+            layout: .flat,
+            bundle: installRoot.appendingPathComponent("bin"),
+            binary: binary
+        )
+        return true
+    }
+
+    func stagingContainsTarget(
+        _ stagingRoot: URL,
+        target: InstalledReleaseRecord,
+        layout: VerifiedPredecessor.Layout
+    ) throws -> Bool {
+        let binary: URL
+        let metallib: URL
+        switch layout {
+        case .app:
+            let app = stagingRoot.appendingPathComponent("Darkbloom.app/Contents/MacOS")
+            binary = app.appendingPathComponent("darkbloom")
+            metallib = app.appendingPathComponent("mlx.metallib")
+        case .flat:
+            let bin = stagingRoot.appendingPathComponent("bin")
+            binary = bin.appendingPathComponent("darkbloom")
+            metallib = bin.appendingPathComponent("mlx.metallib")
+        }
+        guard fm.fileExists(atPath: binary.path), fm.fileExists(atPath: metallib.path) else {
+            return false
+        }
+        return try UpdateAtomicFilesystem.sha256(file: binary) == target.binaryHash
+            && UpdateAtomicFilesystem.sha256(file: metallib) == target.metallibHash
+    }
+
+    func copyPredecessor(
+        _ predecessor: VerifiedPredecessor,
+        to stagingRoot: URL
+    ) throws {
+        try? fm.removeItem(at: stagingRoot)
+        try fm.createDirectory(at: stagingRoot, withIntermediateDirectories: true)
+        switch predecessor.layout {
+        case .app:
+            let source = try resolvedRecoveryPath(predecessor.bundlePath)
+            try fm.copyItem(
+                at: source,
+                to: stagingRoot.appendingPathComponent("Darkbloom.app")
+            )
+        case .flat:
+            let source = try resolvedRecoveryPath(predecessor.bundlePath)
+            try fm.copyItem(at: source, to: stagingRoot.appendingPathComponent("bin"))
+        }
+        try UpdateAtomicFilesystem.fsyncTree(stagingRoot)
+    }
+
+    func verifyStagedPredecessor(
+        _ predecessor: VerifiedPredecessor,
+        at stagingRoot: URL
+    ) throws {
+        let bundle: URL
+        let binary: URL
+        let metallib: URL
+        switch predecessor.layout {
+        case .app:
+            bundle = stagingRoot.appendingPathComponent("Darkbloom.app")
+            binary = bundle.appendingPathComponent("Contents/MacOS/darkbloom")
+            metallib = bundle.appendingPathComponent("Contents/MacOS/mlx.metallib")
+        case .flat:
+            bundle = stagingRoot.appendingPathComponent("bin")
+            binary = bundle.appendingPathComponent("darkbloom")
+            metallib = bundle.appendingPathComponent("mlx.metallib")
+        }
+        guard try UpdateAtomicFilesystem.treeHash(root: bundle)
+                == predecessor.release.installedBundleHash,
+              try UpdateAtomicFilesystem.sha256(file: binary) == predecessor.release.binaryHash,
+              try UpdateAtomicFilesystem.sha256(file: metallib) == predecessor.release.metallibHash
+        else {
+            throw StoreError.predecessorVerificationFailed(
+                "rollback staging copy changed during copy")
+        }
+        try verifySignature(layout: predecessor.layout, bundle: bundle, binary: binary)
+    }
+
+    func restorePredecessorCopy(
+        _ predecessor: VerifiedPredecessor,
+        stagingName: String
+    ) throws {
+        let staging = installRoot.appendingPathComponent(stagingName, isDirectory: true)
+        try copyPredecessor(predecessor, to: staging)
+        try verifyStagedPredecessor(predecessor, at: staging)
+        try installFromStaging(staging, layout: predecessor.layout)
+        try ensureCanonicalLinks()
+        try? fm.removeItem(at: staging)
+    }
+
+    func verifySignature(
+        layout: VerifiedPredecessor.Layout,
+        bundle: URL,
+        binary: URL
+    ) throws {
+        guard verifyCodeSignatures else { return }
+        #if canImport(Darwin)
+        let target = layout == .app ? bundle : binary
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/codesign")
+        process.arguments = layout == .app
+            ? ["--verify", "--deep", "--strict", "--verbose=2", target.path]
+            : ["--verify", "--strict", "--verbose=2", target.path]
+        let stderr = Pipe()
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = stderr
+        do {
+            try process.run()
+            process.waitUntilExit()
+        } catch {
+            throw StoreError.predecessorVerificationFailed(
+                "could not run codesign: \(error.localizedDescription)")
+        }
+        guard process.terminationStatus == 0 else {
+            let detail = String(
+                data: stderr.fileHandleForReading.readDataToEndOfFile(),
+                encoding: .utf8
+            )?.trimmingCharacters(in: .whitespacesAndNewlines) ?? "codesign exited non-zero"
+            throw StoreError.predecessorVerificationFailed(detail)
+        }
+        #endif
+    }
+
+    func resolvedRecoveryPath(_ relativePath: String) throws -> URL {
+        guard !relativePath.hasPrefix("/") else {
+            throw StoreError.corruptState("absolute predecessor path is forbidden")
+        }
+        let resolved = recoveryRoot.appendingPathComponent(relativePath).standardizedFileURL
+        guard UpdateAtomicFilesystem.isDescendant(resolved, of: recoveryRoot) else {
+            throw StoreError.corruptState("predecessor path escapes recovery root")
+        }
+        return resolved
+    }
+
+    private func installApp(from sourceApp: URL) throws {
+        guard fm.fileExists(atPath: sourceApp.path) else {
+            throw StoreError.filesystem("staged app bundle is missing")
+        }
+        let liveApp = installRoot.appendingPathComponent("Darkbloom.app")
+        try UpdateAtomicFilesystem.replace(sourceApp, at: liveApp)
+    }
+
+    private func installFlat(darkbloom: URL, enclave: URL, metallib: URL) throws {
+        let liveBin = installRoot.appendingPathComponent("bin")
+        try fm.createDirectory(at: liveBin, withIntermediateDirectories: true)
+        // Switch the executable last. If power is lost midway, the old
+        // watchdog binary can replay the journal and converge the layout.
+        for (source, name, mode) in [
+            (metallib, "mlx.metallib", 0o644),
+            (enclave, "darkbloom-enclave", 0o755),
+            (darkbloom, "darkbloom", 0o755),
+        ] {
+            guard fm.fileExists(atPath: source.path) else {
+                throw StoreError.filesystem("staged \(name) is missing")
+            }
+            let destination = liveBin.appendingPathComponent(name)
+            try UpdateAtomicFilesystem.replace(source, at: destination)
+            try fm.setAttributes([.posixPermissions: mode], ofItemAtPath: destination.path)
+        }
+    }
+
+    private func liveLayout() throws -> VerifiedPredecessor.Layout {
+        let app = installRoot.appendingPathComponent("Darkbloom.app")
+        if fm.fileExists(atPath: app.appendingPathComponent("Contents/MacOS/darkbloom").path),
+           fm.fileExists(atPath: app.appendingPathComponent("Contents/MacOS/mlx.metallib").path)
+        {
+            return .app
+        }
+        let bin = installRoot.appendingPathComponent("bin")
+        if fm.fileExists(atPath: bin.appendingPathComponent("darkbloom").path),
+           fm.fileExists(atPath: bin.appendingPathComponent("darkbloom-enclave").path),
+           fm.fileExists(atPath: bin.appendingPathComponent("mlx.metallib").path)
+        {
+            return .flat
+        }
+        throw StoreError.missingLiveInstall
+    }
+
+    private func livePaths(
+        layout: VerifiedPredecessor.Layout
+    ) -> (binary: URL, metallib: URL) {
+        switch layout {
+        case .app:
+            let app = installRoot.appendingPathComponent("Darkbloom.app/Contents/MacOS")
+            return (
+                app.appendingPathComponent("darkbloom"),
+                app.appendingPathComponent("mlx.metallib")
+            )
+        case .flat:
+            let bin = installRoot.appendingPathComponent("bin")
+            return (
+                bin.appendingPathComponent("darkbloom"),
+                bin.appendingPathComponent("mlx.metallib")
+            )
+        }
+    }
+
+    private func stateInstallDateFallback(_ now: Double) -> Double {
+        guard let attributes = try? fm.attributesOfItem(
+            atPath: installRoot.appendingPathComponent("Darkbloom.app").path
+        ), let created = attributes[.creationDate] as? Date
+        else {
+            return now
+        }
+        return created.timeIntervalSince1970
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Update/UpdateInstallLayout.swift
+++ b/provider-swift/Sources/ProviderCore/Update/UpdateInstallLayout.swift
@@ -279,6 +279,14 @@ extension UpdateRecoveryStore {
         try UpdateAtomicFilesystem.removeDurably(staging)
     }
 
+    /// INTENTIONALLY FAIL-CLOSED for legacy flat/ad-hoc installs: an install
+    /// whose live binary does not satisfy the pinned Darkbloom designated
+    /// requirement (Team SLDQ2GJ6TL) is not eligible as rollback material and
+    /// its replay/rollback verification refuses. Accepting a structurally
+    /// valid but unpinned signature would let any locally re-signed binary
+    /// become "verified" recovery state. Fleet impact and the recorded
+    /// decision live in the threat model (T-043); the remedy for an affected
+    /// host is a signed reinstall via install.sh.
     func verifySignature(
         layout: VerifiedPredecessor.Layout,
         bundle: URL,
@@ -294,7 +302,11 @@ extension UpdateRecoveryStore {
             )
         } catch {
             throw StoreError.predecessorVerificationFailed(
-                "Darkbloom designated requirement failed: \(error.localizedDescription)")
+                "\(target.lastPathComponent) does not satisfy the pinned Darkbloom "
+                    + "designated requirement (Team \(DarkbloomCodeSignature.teamID)). "
+                    + "Legacy ad-hoc or re-signed installs are intentionally not "
+                    + "rollback-eligible (fail-closed); reinstall via install.sh to "
+                    + "restore signed rollback material. codesign: \(error.localizedDescription)")
         }
         #endif
     }

--- a/provider-swift/Sources/ProviderCore/Update/UpdateInstallLayout.swift
+++ b/provider-swift/Sources/ProviderCore/Update/UpdateInstallLayout.swift
@@ -41,6 +41,16 @@ extension UpdateRecoveryStore {
                     to: copiedBundle.appendingPathComponent(name)
                 )
             }
+            // The snapshot must hash the EXACT tree a restore produces.
+            // Every flat restore runs `ensureCanonicalLinks(.flat)`, which
+            // (re)creates the legacy `eigeninference-enclave` symlink, and
+            // `treeHash` includes symlink entries — a record without it would
+            // fail the post-restore `liveMatches` verification forever and
+            // wedge interrupted-transaction recovery on flat hosts.
+            try UpdateAtomicFilesystem.replaceSymlink(
+                at: copiedBundle.appendingPathComponent("eigeninference-enclave"),
+                target: "darkbloom-enclave"
+            )
             copiedBinary = copiedBundle.appendingPathComponent("darkbloom")
             copiedEnclave = copiedBundle.appendingPathComponent("darkbloom-enclave")
             copiedMetallib = copiedBundle.appendingPathComponent("mlx.metallib")

--- a/provider-swift/Sources/ProviderCore/Update/UpdateInstallLayout.swift
+++ b/provider-swift/Sources/ProviderCore/Update/UpdateInstallLayout.swift
@@ -125,12 +125,13 @@ extension UpdateRecoveryStore {
     func installStagedBundle(_ staged: SelfUpdater.StagedBundle) throws {
         if let app = staged.extractedApp {
             try installApp(from: app)
+            try ensureCanonicalLinks(layout: .app)
         } else {
             try installFlatDirectory(
                 from: staged.stagingRoot.appendingPathComponent("bin")
             )
+            try ensureCanonicalLinks(layout: .flat)
         }
-        try ensureCanonicalLinks()
     }
 
     func installFromStaging(
@@ -147,27 +148,68 @@ extension UpdateRecoveryStore {
         }
     }
 
-    func ensureCanonicalLinks() throws {
-        guard fm.fileExists(atPath: installRoot.appendingPathComponent("Darkbloom.app").path) else {
+    /// Point the canonical `bin/` entries at the just-installed layout.
+    ///
+    /// The intended layout is passed EXPLICITLY rather than inferred from
+    /// whether `Darkbloom.app` happens to exist: after a flat rollback that
+    /// followed a `.app` candidate, a stale `Darkbloom.app` is still on disk,
+    /// and inferring `.app` would re-point `bin/darkbloom` back into the
+    /// quarantined candidate (and let `liveLayout()` later re-adopt it as a
+    /// predecessor). For a `.flat` layout we therefore first retire any stale
+    /// `Darkbloom.app` and leave `bin/`'s real flat binaries in place.
+    func ensureCanonicalLinks(layout: VerifiedPredecessor.Layout) throws {
+        switch layout {
+        case .flat:
+            try removeStaleAppBundle()
             let legacy = installRoot.appendingPathComponent("bin/eigeninference-enclave")
             try UpdateAtomicFilesystem.replaceSymlink(at: legacy, target: "darkbloom-enclave")
-            return
-        }
-        let bin = installRoot.appendingPathComponent("bin")
-        try fm.createDirectory(at: bin, withIntermediateDirectories: true)
-        let appBin = "../Darkbloom.app/Contents/MacOS"
-        for (name, target) in [
-            ("mlx.metallib", "\(appBin)/mlx.metallib"),
-            ("darkbloom-enclave", "\(appBin)/darkbloom-enclave"),
-            ("eigeninference-enclave", "darkbloom-enclave"),
-            ("darkbloom", "\(appBin)/darkbloom"),
-        ] {
-            try UpdateAtomicFilesystem.replaceSymlink(
-                at: bin.appendingPathComponent(name),
-                target: target
-            )
+        case .app:
+            guard fm.fileExists(
+                atPath: installRoot.appendingPathComponent("Darkbloom.app").path
+            ) else {
+                throw StoreError.filesystem(
+                    "app layout requested for canonical links but Darkbloom.app is missing")
+            }
+            let bin = installRoot.appendingPathComponent("bin")
+            try fm.createDirectory(at: bin, withIntermediateDirectories: true)
+            let appBin = "../Darkbloom.app/Contents/MacOS"
+            for (name, target) in [
+                ("mlx.metallib", "\(appBin)/mlx.metallib"),
+                ("darkbloom-enclave", "\(appBin)/darkbloom-enclave"),
+                ("eigeninference-enclave", "darkbloom-enclave"),
+                ("darkbloom", "\(appBin)/darkbloom"),
+            ] {
+                try UpdateAtomicFilesystem.replaceSymlink(
+                    at: bin.appendingPathComponent(name),
+                    target: target
+                )
+            }
         }
     }
+
+    /// Retire a `Darkbloom.app` left over from a prior `.app` candidate before
+    /// a flat install/rollback links or snapshots the tree. Orphaned aside
+    /// copies from an interrupted prior removal are swept first (the whole
+    /// operation runs under the update lock, so the sweep is race-free).
+    private func removeStaleAppBundle() throws {
+        if let entries = try? fm.contentsOfDirectory(
+            at: installRoot,
+            includingPropertiesForKeys: nil
+        ) {
+            for entry in entries
+            where entry.lastPathComponent.hasPrefix(Self.staleAppAsidePrefix) {
+                try? fm.removeItem(at: entry)
+            }
+        }
+        let app = installRoot.appendingPathComponent("Darkbloom.app")
+        guard UpdateAtomicFilesystem.itemExists(app) else { return }
+        try UpdateAtomicFilesystem.atomicRemove(
+            app,
+            asidePrefix: Self.staleAppAsidePrefix
+        )
+    }
+
+    static let staleAppAsidePrefix = ".stale-app-"
 
     func liveMatches(
         _ record: InstalledReleaseRecord,
@@ -275,7 +317,7 @@ extension UpdateRecoveryStore {
         try copyPredecessor(predecessor, to: staging)
         try verifyStagedPredecessor(predecessor, at: staging)
         try installFromStaging(staging, layout: predecessor.layout)
-        try ensureCanonicalLinks()
+        try ensureCanonicalLinks(layout: predecessor.layout)
         try UpdateAtomicFilesystem.removeDurably(staging)
     }
 

--- a/provider-swift/Sources/ProviderCore/Update/UpdateInstallLayout.swift
+++ b/provider-swift/Sources/ProviderCore/Update/UpdateInstallLayout.swift
@@ -15,12 +15,13 @@ extension UpdateRecoveryStore {
             ".predecessor-next-\(UUID().uuidString)",
             isDirectory: true
         )
-        try fm.createDirectory(at: recoveryRoot, withIntermediateDirectories: true)
-        try? fm.removeItem(at: nextRoot)
-        try fm.createDirectory(at: nextRoot, withIntermediateDirectories: true)
+        try UpdateAtomicFilesystem.createDirectoryDurably(recoveryRoot)
+        try UpdateAtomicFilesystem.removeDurably(nextRoot)
+        try UpdateAtomicFilesystem.createDirectoryDurably(nextRoot)
 
         let copiedBundle: URL
         let copiedBinary: URL
+        let copiedEnclave: URL
         let copiedMetallib: URL
         switch layout {
         case .app:
@@ -28,6 +29,7 @@ extension UpdateRecoveryStore {
             copiedBundle = nextRoot.appendingPathComponent("Darkbloom.app")
             try fm.copyItem(at: source, to: copiedBundle)
             copiedBinary = copiedBundle.appendingPathComponent("Contents/MacOS/darkbloom")
+            copiedEnclave = copiedBundle.appendingPathComponent("Contents/MacOS/darkbloom-enclave")
             copiedMetallib = copiedBundle.appendingPathComponent("Contents/MacOS/mlx.metallib")
         case .flat:
             let sourceBin = installRoot.appendingPathComponent("bin")
@@ -40,6 +42,7 @@ extension UpdateRecoveryStore {
                 )
             }
             copiedBinary = copiedBundle.appendingPathComponent("darkbloom")
+            copiedEnclave = copiedBundle.appendingPathComponent("darkbloom-enclave")
             copiedMetallib = copiedBundle.appendingPathComponent("mlx.metallib")
         }
 
@@ -49,6 +52,7 @@ extension UpdateRecoveryStore {
             releaseBundleHash: releaseBundleHash,
             installedBundleHash: try UpdateAtomicFilesystem.treeHash(root: copiedBundle),
             binaryHash: try UpdateAtomicFilesystem.sha256(file: copiedBinary),
+            enclaveHash: try UpdateAtomicFilesystem.sha256(file: copiedEnclave),
             metallibHash: try UpdateAtomicFilesystem.sha256(file: copiedMetallib),
             installGeneration: installGeneration,
             installedAt: stateInstallDateFallback(now)
@@ -62,6 +66,9 @@ extension UpdateRecoveryStore {
             binaryPath: layout == .app
                 ? "predecessor/Darkbloom.app/Contents/MacOS/darkbloom"
                 : "predecessor/bin/darkbloom",
+            enclavePath: layout == .app
+                ? "predecessor/Darkbloom.app/Contents/MacOS/darkbloom-enclave"
+                : "predecessor/bin/darkbloom-enclave",
             metallibPath: layout == .app
                 ? "predecessor/Darkbloom.app/Contents/MacOS/mlx.metallib"
                 : "predecessor/bin/mlx.metallib",
@@ -75,7 +82,7 @@ extension UpdateRecoveryStore {
 
         if fm.fileExists(atPath: predecessorRoot.path) {
             try UpdateAtomicFilesystem.exchange(nextRoot, predecessorRoot)
-            try? fm.removeItem(at: nextRoot)
+            try UpdateAtomicFilesystem.removeDurably(nextRoot)
         } else {
             try UpdateAtomicFilesystem.replace(nextRoot, at: predecessorRoot)
         }
@@ -90,14 +97,17 @@ extension UpdateRecoveryStore {
     ) throws -> InstalledReleaseRecord {
         let bundle: URL
         let binary: URL
+        let enclave: URL
         let metallib: URL
         if let app = staged.extractedApp {
             bundle = app
             binary = app.appendingPathComponent("Contents/MacOS/darkbloom")
+            enclave = app.appendingPathComponent("Contents/MacOS/darkbloom-enclave")
             metallib = app.appendingPathComponent("Contents/MacOS/mlx.metallib")
         } else {
             bundle = staged.stagingRoot.appendingPathComponent("bin")
             binary = staged.flatDarkbloom
+            enclave = staged.flatEnclave
             metallib = staged.flatMetallib
         }
         return InstalledReleaseRecord(
@@ -105,6 +115,7 @@ extension UpdateRecoveryStore {
             releaseBundleHash: staged.release.bundleHash,
             installedBundleHash: try UpdateAtomicFilesystem.treeHash(root: bundle),
             binaryHash: try UpdateAtomicFilesystem.sha256(file: binary),
+            enclaveHash: try UpdateAtomicFilesystem.sha256(file: enclave),
             metallibHash: try UpdateAtomicFilesystem.sha256(file: metallib),
             installGeneration: generation,
             installedAt: now
@@ -115,10 +126,8 @@ extension UpdateRecoveryStore {
         if let app = staged.extractedApp {
             try installApp(from: app)
         } else {
-            try installFlat(
-                darkbloom: staged.flatDarkbloom,
-                enclave: staged.flatEnclave,
-                metallib: staged.flatMetallib
+            try installFlatDirectory(
+                from: staged.stagingRoot.appendingPathComponent("bin")
             )
         }
         try ensureCanonicalLinks()
@@ -132,11 +141,8 @@ extension UpdateRecoveryStore {
         case .app:
             try installApp(from: stagingRoot.appendingPathComponent("Darkbloom.app"))
         case .flat:
-            let bin = stagingRoot.appendingPathComponent("bin")
-            try installFlat(
-                darkbloom: bin.appendingPathComponent("darkbloom"),
-                enclave: bin.appendingPathComponent("darkbloom-enclave"),
-                metallib: bin.appendingPathComponent("mlx.metallib")
+            try installFlatDirectory(
+                from: stagingRoot.appendingPathComponent("bin")
             )
         }
     }
@@ -167,29 +173,25 @@ extension UpdateRecoveryStore {
         _ record: InstalledReleaseRecord,
         layout: VerifiedPredecessor.Layout
     ) throws -> Bool {
-        let (binary, metallib) = livePaths(layout: layout)
-        guard fm.fileExists(atPath: binary.path), fm.fileExists(atPath: metallib.path) else {
-            return false
-        }
-        guard try UpdateAtomicFilesystem.sha256(file: binary) == record.binaryHash,
-              try UpdateAtomicFilesystem.sha256(file: metallib) == record.metallibHash
+        let paths = artifactPaths(root: installRoot, layout: layout)
+        guard fm.fileExists(atPath: paths.binary.path),
+              fm.fileExists(atPath: paths.enclave.path),
+              fm.fileExists(atPath: paths.metallib.path)
         else {
             return false
         }
-        if layout == .app {
-            let app = installRoot.appendingPathComponent("Darkbloom.app")
-            guard try UpdateAtomicFilesystem.treeHash(root: app)
-                    == record.installedBundleHash
-            else {
-                return false
-            }
-            try verifySignature(layout: .app, bundle: app, binary: binary)
-            return true
+        guard try UpdateAtomicFilesystem.sha256(file: paths.binary) == record.binaryHash,
+              try UpdateAtomicFilesystem.sha256(file: paths.enclave) == record.enclaveHash,
+              try UpdateAtomicFilesystem.sha256(file: paths.metallib) == record.metallibHash,
+              try UpdateAtomicFilesystem.treeHash(root: paths.bundle)
+                == record.installedBundleHash
+        else {
+            return false
         }
         try verifySignature(
-            layout: .flat,
-            bundle: installRoot.appendingPathComponent("bin"),
-            binary: binary
+            layout: layout,
+            bundle: paths.bundle,
+            binary: paths.binary
         )
         return true
     }
@@ -199,31 +201,26 @@ extension UpdateRecoveryStore {
         target: InstalledReleaseRecord,
         layout: VerifiedPredecessor.Layout
     ) throws -> Bool {
-        let binary: URL
-        let metallib: URL
-        switch layout {
-        case .app:
-            let app = stagingRoot.appendingPathComponent("Darkbloom.app/Contents/MacOS")
-            binary = app.appendingPathComponent("darkbloom")
-            metallib = app.appendingPathComponent("mlx.metallib")
-        case .flat:
-            let bin = stagingRoot.appendingPathComponent("bin")
-            binary = bin.appendingPathComponent("darkbloom")
-            metallib = bin.appendingPathComponent("mlx.metallib")
-        }
-        guard fm.fileExists(atPath: binary.path), fm.fileExists(atPath: metallib.path) else {
+        let paths = artifactPaths(root: stagingRoot, layout: layout)
+        guard fm.fileExists(atPath: paths.binary.path),
+              fm.fileExists(atPath: paths.enclave.path),
+              fm.fileExists(atPath: paths.metallib.path)
+        else {
             return false
         }
-        return try UpdateAtomicFilesystem.sha256(file: binary) == target.binaryHash
-            && UpdateAtomicFilesystem.sha256(file: metallib) == target.metallibHash
+        return try UpdateAtomicFilesystem.sha256(file: paths.binary) == target.binaryHash
+            && UpdateAtomicFilesystem.sha256(file: paths.enclave) == target.enclaveHash
+            && UpdateAtomicFilesystem.sha256(file: paths.metallib) == target.metallibHash
+            && UpdateAtomicFilesystem.treeHash(root: paths.bundle)
+                == target.installedBundleHash
     }
 
     func copyPredecessor(
         _ predecessor: VerifiedPredecessor,
         to stagingRoot: URL
     ) throws {
-        try? fm.removeItem(at: stagingRoot)
-        try fm.createDirectory(at: stagingRoot, withIntermediateDirectories: true)
+        try UpdateAtomicFilesystem.removeDurably(stagingRoot)
+        try UpdateAtomicFilesystem.createDirectoryDurably(stagingRoot)
         switch predecessor.layout {
         case .app:
             let source = try resolvedRecoveryPath(predecessor.bundlePath)
@@ -244,20 +241,24 @@ extension UpdateRecoveryStore {
     ) throws {
         let bundle: URL
         let binary: URL
+        let enclave: URL
         let metallib: URL
         switch predecessor.layout {
         case .app:
             bundle = stagingRoot.appendingPathComponent("Darkbloom.app")
             binary = bundle.appendingPathComponent("Contents/MacOS/darkbloom")
+            enclave = bundle.appendingPathComponent("Contents/MacOS/darkbloom-enclave")
             metallib = bundle.appendingPathComponent("Contents/MacOS/mlx.metallib")
         case .flat:
             bundle = stagingRoot.appendingPathComponent("bin")
             binary = bundle.appendingPathComponent("darkbloom")
+            enclave = bundle.appendingPathComponent("darkbloom-enclave")
             metallib = bundle.appendingPathComponent("mlx.metallib")
         }
         guard try UpdateAtomicFilesystem.treeHash(root: bundle)
                 == predecessor.release.installedBundleHash,
               try UpdateAtomicFilesystem.sha256(file: binary) == predecessor.release.binaryHash,
+              try UpdateAtomicFilesystem.sha256(file: enclave) == predecessor.release.enclaveHash,
               try UpdateAtomicFilesystem.sha256(file: metallib) == predecessor.release.metallibHash
         else {
             throw StoreError.predecessorVerificationFailed(
@@ -275,7 +276,7 @@ extension UpdateRecoveryStore {
         try verifyStagedPredecessor(predecessor, at: staging)
         try installFromStaging(staging, layout: predecessor.layout)
         try ensureCanonicalLinks()
-        try? fm.removeItem(at: staging)
+        try UpdateAtomicFilesystem.removeDurably(staging)
     }
 
     func verifySignature(
@@ -286,27 +287,14 @@ extension UpdateRecoveryStore {
         guard verifyCodeSignatures else { return }
         #if canImport(Darwin)
         let target = layout == .app ? bundle : binary
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/usr/bin/codesign")
-        process.arguments = layout == .app
-            ? ["--verify", "--deep", "--strict", "--verbose=2", target.path]
-            : ["--verify", "--strict", "--verbose=2", target.path]
-        let stderr = Pipe()
-        process.standardOutput = FileHandle.nullDevice
-        process.standardError = stderr
         do {
-            try process.run()
-            process.waitUntilExit()
+            try DarkbloomCodeSignature.verify(
+                target,
+                deep: layout == .app
+            )
         } catch {
             throw StoreError.predecessorVerificationFailed(
-                "could not run codesign: \(error.localizedDescription)")
-        }
-        guard process.terminationStatus == 0 else {
-            let detail = String(
-                data: stderr.fileHandleForReading.readDataToEndOfFile(),
-                encoding: .utf8
-            )?.trimmingCharacters(in: .whitespacesAndNewlines) ?? "codesign exited non-zero"
-            throw StoreError.predecessorVerificationFailed(detail)
+                "Darkbloom designated requirement failed: \(error.localizedDescription)")
         }
         #endif
     }
@@ -330,23 +318,16 @@ extension UpdateRecoveryStore {
         try UpdateAtomicFilesystem.replace(sourceApp, at: liveApp)
     }
 
-    private func installFlat(darkbloom: URL, enclave: URL, metallib: URL) throws {
+    private func installFlatDirectory(from stagedBin: URL) throws {
         let liveBin = installRoot.appendingPathComponent("bin")
-        try fm.createDirectory(at: liveBin, withIntermediateDirectories: true)
-        // Switch the executable last. If power is lost midway, the old
-        // watchdog binary can replay the journal and converge the layout.
-        for (source, name, mode) in [
-            (metallib, "mlx.metallib", 0o644),
-            (enclave, "darkbloom-enclave", 0o755),
-            (darkbloom, "darkbloom", 0o755),
-        ] {
-            guard fm.fileExists(atPath: source.path) else {
+        for name in ["darkbloom", "darkbloom-enclave", "mlx.metallib"] {
+            guard fm.fileExists(
+                atPath: stagedBin.appendingPathComponent(name).path
+            ) else {
                 throw StoreError.filesystem("staged \(name) is missing")
             }
-            let destination = liveBin.appendingPathComponent(name)
-            try UpdateAtomicFilesystem.replace(source, at: destination)
-            try fm.setAttributes([.posixPermissions: mode], ofItemAtPath: destination.path)
         }
+        try UpdateAtomicFilesystem.replace(stagedBin, at: liveBin)
     }
 
     private func liveLayout() throws -> VerifiedPredecessor.Layout {
@@ -366,20 +347,26 @@ extension UpdateRecoveryStore {
         throw StoreError.missingLiveInstall
     }
 
-    private func livePaths(
+    private func artifactPaths(
+        root: URL,
         layout: VerifiedPredecessor.Layout
-    ) -> (binary: URL, metallib: URL) {
+    ) -> (bundle: URL, binary: URL, enclave: URL, metallib: URL) {
         switch layout {
         case .app:
-            let app = installRoot.appendingPathComponent("Darkbloom.app/Contents/MacOS")
+            let bundle = root.appendingPathComponent("Darkbloom.app")
+            let app = bundle.appendingPathComponent("Contents/MacOS")
             return (
+                bundle,
                 app.appendingPathComponent("darkbloom"),
+                app.appendingPathComponent("darkbloom-enclave"),
                 app.appendingPathComponent("mlx.metallib")
             )
         case .flat:
-            let bin = installRoot.appendingPathComponent("bin")
+            let bin = root.appendingPathComponent("bin")
             return (
+                bin,
                 bin.appendingPathComponent("darkbloom"),
+                bin.appendingPathComponent("darkbloom-enclave"),
                 bin.appendingPathComponent("mlx.metallib")
             )
         }

--- a/provider-swift/Sources/ProviderCore/Update/UpdateProcessLock.swift
+++ b/provider-swift/Sources/ProviderCore/Update/UpdateProcessLock.swift
@@ -1,0 +1,175 @@
+import Foundation
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
+
+/// One kernel-owned lock for every process that can mutate the provider install.
+///
+/// `flock(2)` ownership is attached to the open file description, so the kernel
+/// releases the lock if an updater is killed or crashes. The descriptor is also
+/// close-on-exec: a successful provider restart cannot accidentally inherit the
+/// updater lock and deadlock the next watchdog tick.
+public final class UpdateProcessLock: @unchecked Sendable {
+    public struct Owner: Codable, Sendable, Equatable {
+        public let pid: Int32
+        public let operation: String
+        public let acquiredAt: Double
+
+        enum CodingKeys: String, CodingKey {
+            case pid
+            case operation
+            case acquiredAt = "acquired_at"
+        }
+    }
+
+    public enum LockError: Error, CustomStringConvertible, Sendable {
+        case busy(owner: Owner?)
+        case openFailed(String)
+        case lockFailed(String)
+
+        public var description: String {
+            switch self {
+            case .busy(let owner):
+                if let owner {
+                    return "another update operation owns the lock (pid \(owner.pid), \(owner.operation))"
+                }
+                return "another update operation owns the lock"
+            case .openFailed(let reason):
+                return "could not open update lock: \(reason)"
+            case .lockFailed(let reason):
+                return "could not acquire update lock: \(reason)"
+            }
+        }
+    }
+
+    private let descriptor: Int32
+    public let path: URL
+    public let owner: Owner
+    private let releaseMutex = NSLock()
+    private var released = false
+
+    private init(descriptor: Int32, path: URL, owner: Owner) {
+        self.descriptor = descriptor
+        self.path = path
+        self.owner = owner
+    }
+
+    deinit {
+        release()
+    }
+
+    public static func acquire(
+        at path: URL,
+        operation: String,
+        timeout: TimeInterval = 0
+    ) throws -> UpdateProcessLock {
+        let fm = FileManager.default
+        do {
+            try fm.createDirectory(
+                at: path.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+        } catch {
+            throw LockError.openFailed(error.localizedDescription)
+        }
+
+        let descriptor = open(path.path, O_RDWR | O_CREAT | O_CLOEXEC, 0o600)
+        guard descriptor >= 0 else {
+            throw LockError.openFailed(posixMessage())
+        }
+
+        let deadline = Date().addingTimeInterval(max(0, timeout))
+        while flock(descriptor, LOCK_EX | LOCK_NB) != 0 {
+            let code = errno
+            if code == EINTR {
+                continue
+            }
+            if code == EWOULDBLOCK || code == EAGAIN {
+                if timeout > 0, Date() < deadline {
+                    Thread.sleep(forTimeInterval: min(0.05, deadline.timeIntervalSinceNow))
+                    continue
+                }
+                let owner = readOwner(from: descriptor)
+                close(descriptor)
+                throw LockError.busy(owner: owner)
+            }
+            let reason = String(cString: strerror(code))
+            close(descriptor)
+            throw LockError.lockFailed(reason)
+        }
+
+        let owner = Owner(
+            pid: getpid(),
+            operation: operation,
+            acquiredAt: Date().timeIntervalSince1970
+        )
+        do {
+            try writeOwner(owner, to: descriptor)
+        } catch {
+            flock(descriptor, LOCK_UN)
+            close(descriptor)
+            throw LockError.lockFailed(error.localizedDescription)
+        }
+        return UpdateProcessLock(descriptor: descriptor, path: path, owner: owner)
+    }
+
+    public func release() {
+        releaseMutex.lock()
+        defer { releaseMutex.unlock() }
+        guard !released else { return }
+        released = true
+        _ = flock(descriptor, LOCK_UN)
+        _ = close(descriptor)
+    }
+
+    private static func writeOwner(_ owner: Owner, to descriptor: Int32) throws {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        var data = try encoder.encode(owner)
+        data.append(0x0A)
+
+        guard ftruncate(descriptor, 0) == 0 else {
+            throw CocoaError(.fileWriteUnknown, userInfo: [
+                NSUnderlyingErrorKey: String(cString: strerror(errno)),
+            ])
+        }
+        guard lseek(descriptor, 0, SEEK_SET) >= 0 else {
+            throw CocoaError(.fileWriteUnknown)
+        }
+
+        try data.withUnsafeBytes { rawBuffer in
+            guard var base = rawBuffer.baseAddress else { return }
+            var remaining = rawBuffer.count
+            while remaining > 0 {
+                let count = write(descriptor, base, remaining)
+                if count < 0, errno == EINTR {
+                    continue
+                }
+                guard count > 0 else {
+                    throw CocoaError(.fileWriteUnknown, userInfo: [
+                        NSUnderlyingErrorKey: String(cString: strerror(errno)),
+                    ])
+                }
+                remaining -= count
+                base = base.advanced(by: count)
+            }
+        }
+        guard fsync(descriptor) == 0 else {
+            throw CocoaError(.fileWriteUnknown)
+        }
+    }
+
+    private static func readOwner(from descriptor: Int32) -> Owner? {
+        guard lseek(descriptor, 0, SEEK_SET) >= 0 else { return nil }
+        var bytes = [UInt8](repeating: 0, count: 4096)
+        let count = read(descriptor, &bytes, bytes.count)
+        guard count > 0 else { return nil }
+        return try? JSONDecoder().decode(Owner.self, from: Data(bytes.prefix(count)))
+    }
+
+    private static func posixMessage() -> String {
+        String(cString: strerror(errno))
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Update/UpdateProcessLock.swift
+++ b/provider-swift/Sources/ProviderCore/Update/UpdateProcessLock.swift
@@ -14,11 +14,25 @@ import Glibc
 public final class UpdateProcessLock: @unchecked Sendable {
     public struct Owner: Codable, Sendable, Equatable {
         public let pid: Int32
+        public let processIdentity: ProcessIdentity?
         public let operation: String
         public let acquiredAt: Double
 
+        public init(
+            pid: Int32,
+            processIdentity: ProcessIdentity?,
+            operation: String,
+            acquiredAt: Double
+        ) {
+            self.pid = pid
+            self.processIdentity = processIdentity
+            self.operation = operation
+            self.acquiredAt = acquiredAt
+        }
+
         enum CodingKeys: String, CodingKey {
             case pid
+            case processIdentity = "process_identity"
             case operation
             case acquiredAt = "acquired_at"
         }
@@ -65,11 +79,9 @@ public final class UpdateProcessLock: @unchecked Sendable {
         operation: String,
         timeout: TimeInterval = 0
     ) throws -> UpdateProcessLock {
-        let fm = FileManager.default
         do {
-            try fm.createDirectory(
-                at: path.deletingLastPathComponent(),
-                withIntermediateDirectories: true
+            try UpdateAtomicFilesystem.createDirectoryDurably(
+                path.deletingLastPathComponent()
             )
         } catch {
             throw LockError.openFailed(error.localizedDescription)
@@ -102,6 +114,7 @@ public final class UpdateProcessLock: @unchecked Sendable {
 
         let owner = Owner(
             pid: getpid(),
+            processIdentity: ProcessIdentity.current(),
             operation: operation,
             acquiredAt: Date().timeIntervalSince1970
         )

--- a/provider-swift/Sources/ProviderCore/Update/UpdateRecoveryState.swift
+++ b/provider-swift/Sources/ProviderCore/Update/UpdateRecoveryState.swift
@@ -329,9 +329,14 @@ public struct UpdateRecoveryState: Codable, Sendable, Equatable {
         return now < retryNotBefore
     }
 
-    /// Quarantine is narrow: it blocks only the exact failed version. Normal
-    /// monotonic version comparison still applies, so a strictly newer release
+    /// Quarantine is narrow AND single-slot: it blocks only the exact failed
+    /// version, and quarantining a newer failed version (v3) OVERWRITES the
+    /// previous record (v2) — there is deliberately no multi-version
+    /// quarantine list. After the overwrite, only normal monotonic version
+    /// comparison keeps v2 from reinstalling (it is never strictly newer than
+    /// the restored predecessor's successor). A strictly newer release
     /// escapes automatically without weakening anti-downgrade policy.
+    /// Documented in threat model T-043.
     public func quarantineBlocks(version: String, manualOverride: Bool) -> Bool {
         guard !manualOverride, let quarantine else { return false }
         return quarantine.version == version

--- a/provider-swift/Sources/ProviderCore/Update/UpdateRecoveryState.swift
+++ b/provider-swift/Sources/ProviderCore/Update/UpdateRecoveryState.swift
@@ -1,0 +1,276 @@
+import Foundation
+
+public struct InstalledReleaseRecord: Codable, Sendable, Equatable {
+    public var version: String
+    public var releaseBundleHash: String?
+    public var installedBundleHash: String
+    public var binaryHash: String
+    public var metallibHash: String
+    public var installGeneration: UInt64
+    public var installedAt: Double
+
+    enum CodingKeys: String, CodingKey {
+        case version
+        case releaseBundleHash = "release_bundle_hash"
+        case installedBundleHash = "installed_bundle_hash"
+        case binaryHash = "binary_hash"
+        case metallibHash = "metallib_hash"
+        case installGeneration = "install_generation"
+        case installedAt = "installed_at"
+    }
+}
+
+public struct VerifiedPredecessor: Codable, Sendable, Equatable {
+    public enum Layout: String, Codable, Sendable {
+        case app
+        case flat
+    }
+
+    public var release: InstalledReleaseRecord
+    public var layout: Layout
+    /// Paths are relative to the recovery root and validated before use.
+    public var bundlePath: String
+    public var binaryPath: String
+    public var metallibPath: String
+    public var verifiedAt: Double
+
+    enum CodingKeys: String, CodingKey {
+        case release
+        case layout
+        case bundlePath = "bundle_path"
+        case binaryPath = "binary_path"
+        case metallibPath = "metallib_path"
+        case verifiedAt = "verified_at"
+    }
+}
+
+public struct PendingReleaseCandidate: Codable, Sendable, Equatable {
+    public var release: InstalledReleaseRecord
+    public var failureCount: Int
+    public var pendingAttemptID: String?
+    public var attemptStartedAt: Double?
+    public var healthySince: Double?
+    public var healthyProcessStartedAt: Double?
+    public var retryNotBefore: Double?
+    public var rollbackBlockedReason: String?
+
+    enum CodingKeys: String, CodingKey {
+        case release
+        case failureCount = "failure_count"
+        case pendingAttemptID = "pending_attempt_id"
+        case attemptStartedAt = "attempt_started_at"
+        case healthySince = "healthy_since"
+        case healthyProcessStartedAt = "healthy_process_started_at"
+        case retryNotBefore = "retry_not_before"
+        case rollbackBlockedReason = "rollback_blocked_reason"
+    }
+}
+
+public struct FailedReleaseQuarantine: Codable, Sendable, Equatable {
+    public var version: String
+    public var failureCount: Int
+    public var quarantinedAt: Double
+    public var reason: String
+
+    enum CodingKeys: String, CodingKey {
+        case version
+        case failureCount = "failure_count"
+        case quarantinedAt = "quarantined_at"
+        case reason
+    }
+}
+
+/// Durable update state. Filesystem effects are deliberately absent: these
+/// transitions are deterministic and exhaustively testable.
+public struct UpdateRecoveryState: Codable, Sendable, Equatable {
+    public static let currentSchema = 1
+    public static let rollbackThreshold = 3
+    public static let defaultStabilizationSeconds: Double = 600
+
+    public var schema: Int
+    public var installGeneration: UInt64
+    public var current: InstalledReleaseRecord?
+    public var candidate: PendingReleaseCandidate?
+    public var predecessor: VerifiedPredecessor?
+    public var quarantine: FailedReleaseQuarantine?
+
+    public init(
+        schema: Int = UpdateRecoveryState.currentSchema,
+        installGeneration: UInt64 = 0,
+        current: InstalledReleaseRecord? = nil,
+        candidate: PendingReleaseCandidate? = nil,
+        predecessor: VerifiedPredecessor? = nil,
+        quarantine: FailedReleaseQuarantine? = nil
+    ) {
+        self.schema = schema
+        self.installGeneration = installGeneration
+        self.current = current
+        self.candidate = candidate
+        self.predecessor = predecessor
+        self.quarantine = quarantine
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case schema
+        case installGeneration = "install_generation"
+        case current
+        case candidate
+        case predecessor
+        case quarantine
+    }
+
+    public mutating func installCandidate(
+        _ release: InstalledReleaseRecord,
+        predecessor: VerifiedPredecessor,
+        now: Double
+    ) {
+        if let superseded = candidate, superseded.failureCount > 0 {
+            quarantine = FailedReleaseQuarantine(
+                version: superseded.release.version,
+                failureCount: superseded.failureCount,
+                quarantinedAt: now,
+                reason: "superseded by newer release \(release.version) after failed starts"
+            )
+        }
+        installGeneration = release.installGeneration
+        self.predecessor = predecessor
+        candidate = PendingReleaseCandidate(
+            release: release,
+            failureCount: 0,
+            pendingAttemptID: UUID().uuidString,
+            attemptStartedAt: now,
+            healthySince: nil,
+            healthyProcessStartedAt: nil,
+            retryNotBefore: nil,
+            rollbackBlockedReason: nil
+        )
+        if quarantine?.version == release.version {
+            quarantine = nil
+        }
+    }
+
+    /// Count a failed launch exactly once. Repeated watchdog ticks cannot
+    /// increment the counter because the pending attempt identifier is cleared.
+    @discardableResult
+    public mutating func recordPendingAttemptFailure(now: Double) -> Int? {
+        guard var candidate, candidate.pendingAttemptID != nil else { return nil }
+        if candidate.failureCount < Int.max {
+            candidate.failureCount += 1
+        }
+        candidate.pendingAttemptID = nil
+        candidate.attemptStartedAt = nil
+        candidate.healthySince = nil
+        candidate.healthyProcessStartedAt = nil
+        candidate.retryNotBefore = nil
+        candidate.rollbackBlockedReason = nil
+        self.candidate = candidate
+        return candidate.failureCount
+    }
+
+    /// Arm one launch attempt. Returns false when an attempt is already pending
+    /// or the candidate is still inside rollback-failure backoff.
+    @discardableResult
+    public mutating func armCandidateAttempt(now: Double) -> Bool {
+        guard var candidate, candidate.pendingAttemptID == nil else { return false }
+        if let retryNotBefore = candidate.retryNotBefore, now < retryNotBefore {
+            return false
+        }
+        candidate.pendingAttemptID = UUID().uuidString
+        candidate.attemptStartedAt = now
+        candidate.healthySince = nil
+        candidate.healthyProcessStartedAt = nil
+        candidate.retryNotBefore = nil
+        candidate.rollbackBlockedReason = nil
+        self.candidate = candidate
+        return true
+    }
+
+    public mutating func cancelPendingAttempt() {
+        guard var candidate else { return }
+        candidate.pendingAttemptID = nil
+        candidate.attemptStartedAt = nil
+        self.candidate = candidate
+    }
+
+    /// Observe the candidate's health signal. A candidate is promoted only
+    /// after the signal remains continuously true for the stabilization window.
+    /// Returns true exactly when promotion occurs.
+    @discardableResult
+    public mutating func observeCandidateHealth(
+        healthySignal: Bool,
+        processStartedAt: Double?,
+        now: Double,
+        stabilizationSeconds: Double = UpdateRecoveryState.defaultStabilizationSeconds
+    ) -> Bool {
+        guard var candidate else { return false }
+        guard healthySignal else {
+            candidate.healthySince = nil
+            candidate.healthyProcessStartedAt = nil
+            self.candidate = candidate
+            return false
+        }
+
+        if candidate.healthySince == nil
+            || candidate.healthyProcessStartedAt != processStartedAt
+        {
+            candidate.healthySince = now
+            candidate.healthyProcessStartedAt = processStartedAt
+            self.candidate = candidate
+            return stabilizationSeconds <= 0
+                ? promoteCandidate()
+                : false
+        }
+        guard now - (candidate.healthySince ?? now) >= stabilizationSeconds else {
+            self.candidate = candidate
+            return false
+        }
+        self.candidate = candidate
+        return promoteCandidate()
+    }
+
+    @discardableResult
+    public mutating func promoteCandidate() -> Bool {
+        guard let candidate else { return false }
+        current = candidate.release
+        self.candidate = nil
+        return true
+    }
+
+    public mutating func completeRollback(now: Double, reason: String) {
+        guard let failed = candidate, let predecessor else { return }
+        current = predecessor.release
+        quarantine = FailedReleaseQuarantine(
+            version: failed.release.version,
+            failureCount: failed.failureCount,
+            quarantinedAt: now,
+            reason: reason
+        )
+        candidate = nil
+    }
+
+    public mutating func deferRetryAfterRollbackFailure(now: Double, reason: String) {
+        guard var candidate else { return }
+        let exponent = max(0, min(candidate.failureCount - Self.rollbackThreshold, 4))
+        let delay = min(3600.0, 300.0 * pow(2.0, Double(exponent)))
+        candidate.pendingAttemptID = nil
+        candidate.attemptStartedAt = nil
+        candidate.healthySince = nil
+        candidate.healthyProcessStartedAt = nil
+        candidate.retryNotBefore = now + delay
+        candidate.rollbackBlockedReason = reason
+        self.candidate = candidate
+    }
+
+    public func isCandidateRetryBackedOff(now: Double) -> Bool {
+        guard let retryNotBefore = candidate?.retryNotBefore else { return false }
+        return now < retryNotBefore
+    }
+
+    /// Quarantine is narrow: it blocks only the exact failed version. Normal
+    /// monotonic version comparison still applies, so a strictly newer release
+    /// escapes automatically without weakening anti-downgrade policy.
+    public func quarantineBlocks(version: String, manualOverride: Bool) -> Bool {
+        guard !manualOverride, let quarantine else { return false }
+        return quarantine.version == version
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Update/UpdateRecoveryState.swift
+++ b/provider-swift/Sources/ProviderCore/Update/UpdateRecoveryState.swift
@@ -5,6 +5,7 @@ public struct InstalledReleaseRecord: Codable, Sendable, Equatable {
     public var releaseBundleHash: String?
     public var installedBundleHash: String
     public var binaryHash: String
+    public var enclaveHash: String
     public var metallibHash: String
     public var installGeneration: UInt64
     public var installedAt: Double
@@ -14,6 +15,7 @@ public struct InstalledReleaseRecord: Codable, Sendable, Equatable {
         case releaseBundleHash = "release_bundle_hash"
         case installedBundleHash = "installed_bundle_hash"
         case binaryHash = "binary_hash"
+        case enclaveHash = "enclave_hash"
         case metallibHash = "metallib_hash"
         case installGeneration = "install_generation"
         case installedAt = "installed_at"
@@ -31,6 +33,7 @@ public struct VerifiedPredecessor: Codable, Sendable, Equatable {
     /// Paths are relative to the recovery root and validated before use.
     public var bundlePath: String
     public var binaryPath: String
+    public var enclavePath: String
     public var metallibPath: String
     public var verifiedAt: Double
 
@@ -39,14 +42,22 @@ public struct VerifiedPredecessor: Codable, Sendable, Equatable {
         case layout
         case bundlePath = "bundle_path"
         case binaryPath = "binary_path"
+        case enclavePath = "enclave_path"
         case metallibPath = "metallib_path"
         case verifiedAt = "verified_at"
     }
 }
 
 public struct PendingReleaseCandidate: Codable, Sendable, Equatable {
+    public struct LaunchIntent: Codable, Sendable, Equatable {
+        public var id: String
+        public var preparedAt: Double
+        public var baseline: ProviderLaunchSnapshot?
+    }
+
     public var release: InstalledReleaseRecord
     public var failureCount: Int
+    public var launchIntent: LaunchIntent?
     public var pendingAttemptID: String?
     public var attemptStartedAt: Double?
     public var healthySince: Double?
@@ -57,6 +68,7 @@ public struct PendingReleaseCandidate: Codable, Sendable, Equatable {
     enum CodingKeys: String, CodingKey {
         case release
         case failureCount = "failure_count"
+        case launchIntent = "launch_intent"
         case pendingAttemptID = "pending_attempt_id"
         case attemptStartedAt = "attempt_started_at"
         case healthySince = "healthy_since"
@@ -137,8 +149,9 @@ public struct UpdateRecoveryState: Codable, Sendable, Equatable {
         candidate = PendingReleaseCandidate(
             release: release,
             failureCount: 0,
-            pendingAttemptID: UUID().uuidString,
-            attemptStartedAt: now,
+            launchIntent: nil,
+            pendingAttemptID: nil,
+            attemptStartedAt: nil,
             healthySince: nil,
             healthyProcessStartedAt: nil,
             retryNotBefore: nil,
@@ -147,6 +160,72 @@ public struct UpdateRecoveryState: Codable, Sendable, Equatable {
         if quarantine?.version == release.version {
             quarantine = nil
         }
+    }
+
+    public mutating func prepareLaunchIntent(
+        now: Double,
+        baseline: ProviderLaunchSnapshot?
+    ) -> Bool {
+        guard var candidate, candidate.pendingAttemptID == nil else {
+            return false
+        }
+        if let retryNotBefore = candidate.retryNotBefore,
+           now < retryNotBefore {
+            return false
+        }
+        candidate.launchIntent = PendingReleaseCandidate.LaunchIntent(
+            id: UUID().uuidString,
+            preparedAt: now,
+            baseline: baseline
+        )
+        candidate.retryNotBefore = nil
+        candidate.rollbackBlockedReason = nil
+        self.candidate = candidate
+        return true
+    }
+
+    public mutating func markLaunchIssued(now: Double) -> Bool {
+        guard var candidate, candidate.launchIntent != nil else { return false }
+        candidate.pendingAttemptID = candidate.launchIntent?.id
+        candidate.attemptStartedAt = now
+        candidate.launchIntent = nil
+        candidate.healthySince = nil
+        candidate.healthyProcessStartedAt = nil
+        self.candidate = candidate
+        return true
+    }
+
+    public mutating func reconcileLaunchIntent(
+        snapshot: ProviderLaunchSnapshot?,
+        now: Double
+    ) -> Bool {
+        guard let intent = candidate?.launchIntent else { return false }
+        if snapshot?.provesLaunch(after: intent.baseline) == true {
+            return markLaunchIssued(now: now)
+        }
+        candidate?.launchIntent = nil
+        return false
+    }
+
+    public mutating func confirmRunningCandidate(
+        version: String,
+        processStartedAt: Double,
+        now: Double
+    ) -> Bool {
+        guard var candidate,
+              candidate.release.version == version,
+              candidate.pendingAttemptID == nil
+        else {
+            return false
+        }
+        candidate.pendingAttemptID = candidate.launchIntent?.id
+            ?? UUID().uuidString
+        candidate.attemptStartedAt = now
+        candidate.launchIntent = nil
+        candidate.healthySince = now
+        candidate.healthyProcessStartedAt = processStartedAt
+        self.candidate = candidate
+        return true
     }
 
     /// Count a failed launch exactly once. Repeated watchdog ticks cannot
@@ -159,6 +238,7 @@ public struct UpdateRecoveryState: Codable, Sendable, Equatable {
         }
         candidate.pendingAttemptID = nil
         candidate.attemptStartedAt = nil
+        candidate.launchIntent = nil
         candidate.healthySince = nil
         candidate.healthyProcessStartedAt = nil
         candidate.retryNotBefore = nil
@@ -167,26 +247,9 @@ public struct UpdateRecoveryState: Codable, Sendable, Equatable {
         return candidate.failureCount
     }
 
-    /// Arm one launch attempt. Returns false when an attempt is already pending
-    /// or the candidate is still inside rollback-failure backoff.
-    @discardableResult
-    public mutating func armCandidateAttempt(now: Double) -> Bool {
-        guard var candidate, candidate.pendingAttemptID == nil else { return false }
-        if let retryNotBefore = candidate.retryNotBefore, now < retryNotBefore {
-            return false
-        }
-        candidate.pendingAttemptID = UUID().uuidString
-        candidate.attemptStartedAt = now
-        candidate.healthySince = nil
-        candidate.healthyProcessStartedAt = nil
-        candidate.retryNotBefore = nil
-        candidate.rollbackBlockedReason = nil
-        self.candidate = candidate
-        return true
-    }
-
     public mutating func cancelPendingAttempt() {
         guard var candidate else { return }
+        candidate.launchIntent = nil
         candidate.pendingAttemptID = nil
         candidate.attemptStartedAt = nil
         self.candidate = candidate

--- a/provider-swift/Sources/ProviderCore/Update/UpdateRecoveryStore.swift
+++ b/provider-swift/Sources/ProviderCore/Update/UpdateRecoveryStore.swift
@@ -1,0 +1,471 @@
+import Foundation
+
+/// Journal and state authority for update commit, interrupted-transaction
+/// recovery, and rollback. Concrete install-layout operations live in
+/// `UpdateInstallLayout`; callers must hold `UpdateProcessLock`.
+final class UpdateRecoveryStore: @unchecked Sendable {
+    enum FaultPoint: Sendable, Equatable {
+        case predecessorPromoted
+        case transactionPersisted
+        case liveLayoutReplaced
+        case statePersisted
+    }
+
+    enum StoreError: Error, CustomStringConvertible {
+        case corruptState(String)
+        case corruptTransaction(String)
+        case missingLiveInstall
+        case missingPredecessor(String)
+        case predecessorVerificationFailed(String)
+        case interruptedRecoveryFailed(String)
+        case filesystem(String)
+
+        var description: String {
+            switch self {
+            case .corruptState(let reason):
+                return "update recovery state is unreadable: \(reason)"
+            case .corruptTransaction(let reason):
+                return "update transaction journal is unreadable: \(reason)"
+            case .missingLiveInstall:
+                return "current provider install is incomplete; no signed app or flat binary layout found"
+            case .missingPredecessor(let reason):
+                return "verified predecessor unavailable: \(reason)"
+            case .predecessorVerificationFailed(let reason):
+                return "verified predecessor refused: \(reason)"
+            case .interruptedRecoveryFailed(let reason):
+                return "interrupted update recovery failed: \(reason)"
+            case .filesystem(let reason):
+                return reason
+            }
+        }
+    }
+
+    private enum TransactionKind: String, Codable {
+        case install
+        case rollback
+    }
+
+    private enum TransactionPhase: String, Codable {
+        case prepared
+        case liveReplaced = "live_replaced"
+    }
+
+    private struct Transaction: Codable {
+        var schema: Int
+        var kind: TransactionKind
+        var phase: TransactionPhase
+        var target: InstalledReleaseRecord
+        var layout: VerifiedPredecessor.Layout
+        var stagingRoot: String
+        var createdAt: Double
+
+        enum CodingKeys: String, CodingKey {
+            case schema
+            case kind
+            case phase
+            case target
+            case layout
+            case stagingRoot = "staging_root"
+            case createdAt = "created_at"
+        }
+    }
+
+    let installRoot: URL
+    let recoveryRoot: URL
+    let lockPath: URL
+    let verifyCodeSignatures: Bool
+    let faultInjector: @Sendable (FaultPoint) throws -> Void
+    let fm = FileManager.default
+
+    private var statePath: URL {
+        recoveryRoot.appendingPathComponent("state.json")
+    }
+    private var transactionPath: URL {
+        recoveryRoot.appendingPathComponent("transaction.json")
+    }
+    var predecessorRoot: URL {
+        recoveryRoot.appendingPathComponent("predecessor", isDirectory: true)
+    }
+    private var predecessorManifestPath: URL {
+        predecessorRoot.appendingPathComponent("manifest.json")
+    }
+
+    init(
+        installRoot: URL,
+        verifyCodeSignatures: Bool,
+        faultInjector: @escaping @Sendable (FaultPoint) throws -> Void = { _ in }
+    ) {
+        self.installRoot = installRoot.standardizedFileURL
+        self.recoveryRoot = installRoot
+            .appendingPathComponent("recovery", isDirectory: true)
+            .standardizedFileURL
+        self.lockPath = recoveryRoot.appendingPathComponent("update.lock")
+        self.verifyCodeSignatures = verifyCodeSignatures
+        self.faultInjector = faultInjector
+    }
+
+    func loadState() throws -> UpdateRecoveryState {
+        var state: UpdateRecoveryState
+        if fm.fileExists(atPath: statePath.path) {
+            do {
+                state = try JSONDecoder().decode(
+                    UpdateRecoveryState.self,
+                    from: Data(contentsOf: statePath)
+                )
+            } catch {
+                throw StoreError.corruptState(error.localizedDescription)
+            }
+            guard state.schema == UpdateRecoveryState.currentSchema else {
+                throw StoreError.corruptState("unsupported schema \(state.schema)")
+            }
+            if let failures = state.candidate?.failureCount, failures < 0 {
+                throw StoreError.corruptState("negative candidate failure count")
+            }
+            if let failures = state.quarantine?.failureCount, failures < 0 {
+                throw StoreError.corruptState("negative quarantine failure count")
+            }
+        } else {
+            state = UpdateRecoveryState()
+        }
+
+        // The manifest is inside the atomically-promoted predecessor tree, so
+        // it wins if death occurred after promotion but before state replace.
+        if fm.fileExists(atPath: predecessorManifestPath.path) {
+            let diskManifest: VerifiedPredecessor
+            do {
+                diskManifest = try JSONDecoder().decode(
+                    VerifiedPredecessor.self,
+                    from: Data(contentsOf: predecessorManifestPath)
+                )
+            } catch {
+                throw StoreError.corruptState(
+                    "predecessor manifest: \(error.localizedDescription)")
+            }
+            state.predecessor = diskManifest
+        } else if state.predecessor != nil {
+            throw StoreError.corruptState(
+                "state references a missing predecessor directory")
+        }
+        return state
+    }
+
+    func writeState(_ state: UpdateRecoveryState) throws {
+        try UpdateAtomicFilesystem.writeJSON(state, to: statePath)
+    }
+
+    func recoverInterruptedTransaction(now: Double) throws {
+        guard fm.fileExists(atPath: transactionPath.path) else {
+            cleanupOrphanedRecoveryTemps()
+            return
+        }
+        let transaction = try readTransaction()
+        var state = try loadState()
+
+        if try liveMatches(transaction.target, layout: transaction.layout) {
+            try ensureCanonicalLinks()
+            try finalizeRecovered(transaction, state: &state, now: now)
+            cleanupTransaction(transaction)
+            return
+        }
+
+        let stagingRoot = URL(
+            fileURLWithPath: transaction.stagingRoot
+        ).standardizedFileURL
+        guard UpdateAtomicFilesystem.isDescendant(stagingRoot, of: installRoot) else {
+            throw StoreError.corruptTransaction("staging path escapes install root")
+        }
+
+        if try stagingContainsTarget(
+            stagingRoot,
+            target: transaction.target,
+            layout: transaction.layout
+        ) {
+            try installFromStaging(stagingRoot, layout: transaction.layout)
+            guard try liveMatches(transaction.target, layout: transaction.layout) else {
+                throw StoreError.interruptedRecoveryFailed(
+                    "target hashes do not match after replay")
+            }
+            try ensureCanonicalLinks()
+            try finalizeRecovered(transaction, state: &state, now: now)
+            cleanupTransaction(transaction)
+            return
+        }
+
+        guard let predecessor = state.predecessor else {
+            throw StoreError.interruptedRecoveryFailed(
+                "neither target staging nor a predecessor is available; live install left untouched")
+        }
+        try verifyPredecessor(predecessor)
+        try restorePredecessorCopy(
+            predecessor,
+            stagingName: ".recovery-restore-\(UUID().uuidString)"
+        )
+        guard try liveMatches(predecessor.release, layout: predecessor.layout) else {
+            throw StoreError.interruptedRecoveryFailed(
+                "predecessor hashes do not match after restore")
+        }
+        if transaction.kind == .install {
+            state.candidate = nil
+            state.current = predecessor.release
+        } else {
+            state.completeRollback(
+                now: now,
+                reason: "recovered an interrupted rollback of \(transaction.target.version)"
+            )
+        }
+        try writeState(state)
+        cleanupTransaction(transaction)
+    }
+
+    func commit(
+        staged: SelfUpdater.StagedBundle,
+        currentVersion: String,
+        now: Double
+    ) throws {
+        try recoverInterruptedTransaction(now: now)
+        var state = try loadState()
+        let predecessor = try preparePredecessor(
+            state: &state,
+            currentVersion: currentVersion,
+            now: now
+        )
+
+        let layout: VerifiedPredecessor.Layout =
+            staged.extractedApp == nil ? .flat : .app
+        let (nextGeneration, overflow) =
+            state.installGeneration.addingReportingOverflow(1)
+        guard !overflow else {
+            throw StoreError.corruptState("install generation overflow")
+        }
+        let candidate = try recordForStagedBundle(
+            staged,
+            generation: nextGeneration,
+            now: now
+        )
+        var transaction = Transaction(
+            schema: 1,
+            kind: .install,
+            phase: .prepared,
+            target: candidate,
+            layout: layout,
+            stagingRoot: staged.stagingRoot.standardizedFileURL.path,
+            createdAt: now
+        )
+        try persist(transaction)
+        try faultInjector(.transactionPersisted)
+
+        try installStagedBundle(staged)
+        transaction.phase = .liveReplaced
+        try persist(transaction)
+        try faultInjector(.liveLayoutReplaced)
+
+        state.installCandidate(candidate, predecessor: predecessor, now: now)
+        try writeState(state)
+        try faultInjector(.statePersisted)
+        finish(remove: staged.stagingRoot)
+    }
+
+    func rollback(now: Double, reason: String) throws -> String {
+        try recoverInterruptedTransaction(now: now)
+        var state = try loadState()
+        guard let candidate = state.candidate else {
+            throw StoreError.missingPredecessor(
+                "there is no pending release candidate to roll back")
+        }
+        guard let predecessor = state.predecessor else {
+            throw StoreError.missingPredecessor(
+                "v\(candidate.release.version) has no recorded predecessor")
+        }
+        try verifyPredecessor(predecessor)
+        let (rollbackGeneration, overflow) =
+            state.installGeneration.addingReportingOverflow(1)
+        guard !overflow else {
+            throw StoreError.corruptState("install generation overflow")
+        }
+
+        let stagingRoot = installRoot.appendingPathComponent(
+            ".rollback-staging-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        try copyPredecessor(predecessor, to: stagingRoot)
+        try verifyStagedPredecessor(predecessor, at: stagingRoot)
+
+        var transaction = Transaction(
+            schema: 1,
+            kind: .rollback,
+            phase: .prepared,
+            target: predecessor.release,
+            layout: predecessor.layout,
+            stagingRoot: stagingRoot.path,
+            createdAt: now
+        )
+        try persist(transaction)
+        try faultInjector(.transactionPersisted)
+
+        try installFromStaging(stagingRoot, layout: predecessor.layout)
+        try ensureCanonicalLinks()
+        transaction.phase = .liveReplaced
+        try persist(transaction)
+        try faultInjector(.liveLayoutReplaced)
+
+        state.installGeneration = rollbackGeneration
+        state.completeRollback(now: now, reason: reason)
+        try writeState(state)
+        try faultInjector(.statePersisted)
+        finish(remove: stagingRoot)
+        return predecessor.release.version
+    }
+
+    func verifyPredecessor(_ predecessor: VerifiedPredecessor) throws {
+        let bundle = try resolvedRecoveryPath(predecessor.bundlePath)
+        let binary = try resolvedRecoveryPath(predecessor.binaryPath)
+        let metallib = try resolvedRecoveryPath(predecessor.metallibPath)
+        guard fm.fileExists(atPath: bundle.path),
+              fm.fileExists(atPath: binary.path),
+              fm.fileExists(atPath: metallib.path)
+        else {
+            throw StoreError.predecessorVerificationFailed(
+                "recorded files are missing")
+        }
+        do {
+            let bundleHash = try UpdateAtomicFilesystem.treeHash(root: bundle)
+            guard bundleHash == predecessor.release.installedBundleHash else {
+                throw StoreError.predecessorVerificationFailed(
+                    "bundle hash mismatch (expected \(predecessor.release.installedBundleHash), got \(bundleHash))")
+            }
+            let binaryHash = try UpdateAtomicFilesystem.sha256(file: binary)
+            guard binaryHash == predecessor.release.binaryHash else {
+                throw StoreError.predecessorVerificationFailed(
+                    "binary hash mismatch (expected \(predecessor.release.binaryHash), got \(binaryHash))")
+            }
+            let metallibHash = try UpdateAtomicFilesystem.sha256(file: metallib)
+            guard metallibHash == predecessor.release.metallibHash else {
+                throw StoreError.predecessorVerificationFailed(
+                    "metallib hash mismatch (expected \(predecessor.release.metallibHash), got \(metallibHash))")
+            }
+            try verifySignature(
+                layout: predecessor.layout,
+                bundle: bundle,
+                binary: binary
+            )
+        } catch let error as StoreError {
+            throw error
+        } catch {
+            throw StoreError.predecessorVerificationFailed(
+                error.localizedDescription)
+        }
+    }
+
+    private func preparePredecessor(
+        state: inout UpdateRecoveryState,
+        currentVersion: String,
+        now: Double
+    ) throws -> VerifiedPredecessor {
+        if state.candidate != nil {
+            guard let predecessor = state.predecessor else {
+                throw StoreError.missingPredecessor(
+                    "an unproven installed candidate exists without rollback material")
+            }
+            try verifyPredecessor(predecessor)
+            return predecessor
+        }
+
+        let predecessor = try snapshotLiveAsPredecessor(
+            version: state.current?.version ?? currentVersion,
+            releaseBundleHash: state.current?.releaseBundleHash,
+            installGeneration: state.current?.installGeneration
+                ?? state.installGeneration,
+            now: now
+        )
+        state.predecessor = predecessor
+        if state.current == nil {
+            state.current = predecessor.release
+        }
+        try writeState(state)
+        return predecessor
+    }
+
+    private func finalizeRecovered(
+        _ transaction: Transaction,
+        state: inout UpdateRecoveryState,
+        now: Double
+    ) throws {
+        guard let predecessor = state.predecessor else {
+            throw StoreError.interruptedRecoveryFailed(
+                "predecessor metadata is missing")
+        }
+        switch transaction.kind {
+        case .install:
+            if state.candidate?.release != transaction.target {
+                state.installCandidate(
+                    transaction.target,
+                    predecessor: predecessor,
+                    now: now
+                )
+            }
+        case .rollback:
+            let (generation, overflow) =
+                state.installGeneration.addingReportingOverflow(1)
+            guard !overflow else {
+                throw StoreError.corruptState("install generation overflow")
+            }
+            state.installGeneration = generation
+            state.completeRollback(
+                now: now,
+                reason: "recovered rollback after \(state.candidate?.failureCount ?? 0) failed starts"
+            )
+        }
+        try writeState(state)
+    }
+
+    private func readTransaction() throws -> Transaction {
+        let transaction: Transaction
+        do {
+            transaction = try JSONDecoder().decode(
+                Transaction.self,
+                from: Data(contentsOf: transactionPath)
+            )
+        } catch {
+            throw StoreError.corruptTransaction(error.localizedDescription)
+        }
+        guard transaction.schema == 1 else {
+            throw StoreError.corruptTransaction(
+                "unsupported schema \(transaction.schema)")
+        }
+        return transaction
+    }
+
+    private func persist(_ transaction: Transaction) throws {
+        try UpdateAtomicFilesystem.writeJSON(transaction, to: transactionPath)
+    }
+
+    private func finish(remove staging: URL) {
+        try? fm.removeItem(at: transactionPath)
+        try? fm.removeItem(at: staging)
+        cleanupOrphanedRecoveryTemps()
+    }
+
+    private func cleanupTransaction(_ transaction: Transaction) {
+        try? fm.removeItem(at: transactionPath)
+        let staging = URL(
+            fileURLWithPath: transaction.stagingRoot
+        ).standardizedFileURL
+        if UpdateAtomicFilesystem.isDescendant(staging, of: installRoot) {
+            try? fm.removeItem(at: staging)
+        }
+        cleanupOrphanedRecoveryTemps()
+    }
+
+    private func cleanupOrphanedRecoveryTemps() {
+        guard let entries = try? fm.contentsOfDirectory(
+            at: recoveryRoot,
+            includingPropertiesForKeys: nil
+        ) else {
+            return
+        }
+        for entry in entries
+        where entry.lastPathComponent.hasPrefix(".predecessor-next-") {
+            try? fm.removeItem(at: entry)
+        }
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Update/UpdateRecoveryStore.swift
+++ b/provider-swift/Sources/ProviderCore/Update/UpdateRecoveryStore.swift
@@ -164,7 +164,7 @@ final class UpdateRecoveryStore: @unchecked Sendable {
         var state = try loadState()
 
         if try liveMatches(transaction.target, layout: transaction.layout) {
-            try ensureCanonicalLinks()
+            try ensureCanonicalLinks(layout: transaction.layout)
             try finalizeRecovered(transaction, state: &state, now: now)
             try cleanupTransaction(transaction)
             return
@@ -187,7 +187,7 @@ final class UpdateRecoveryStore: @unchecked Sendable {
                 throw StoreError.interruptedRecoveryFailed(
                     "target hashes do not match after replay")
             }
-            try ensureCanonicalLinks()
+            try ensureCanonicalLinks(layout: transaction.layout)
             try finalizeRecovered(transaction, state: &state, now: now)
             try cleanupTransaction(transaction)
             return
@@ -306,7 +306,7 @@ final class UpdateRecoveryStore: @unchecked Sendable {
         try faultInjector(.transactionPersisted)
 
         try installFromStaging(stagingRoot, layout: predecessor.layout)
-        try ensureCanonicalLinks()
+        try ensureCanonicalLinks(layout: predecessor.layout)
         try faultInjector(.liveLayoutExchanged)
         transaction.phase = .liveReplaced
         try persist(transaction)

--- a/provider-swift/Sources/ProviderCore/Update/UpdateRecoveryStore.swift
+++ b/provider-swift/Sources/ProviderCore/Update/UpdateRecoveryStore.swift
@@ -4,11 +4,13 @@ import Foundation
 /// recovery, and rollback. Concrete install-layout operations live in
 /// `UpdateInstallLayout`; callers must hold `UpdateProcessLock`.
 final class UpdateRecoveryStore: @unchecked Sendable {
-    enum FaultPoint: Sendable, Equatable {
+    enum FaultPoint: Sendable, Equatable, CaseIterable {
         case predecessorPromoted
         case transactionPersisted
+        case liveLayoutExchanged
         case liveLayoutReplaced
         case statePersisted
+        case transactionRemoved
     }
 
     enum StoreError: Error, CustomStringConvertible {
@@ -164,7 +166,7 @@ final class UpdateRecoveryStore: @unchecked Sendable {
         if try liveMatches(transaction.target, layout: transaction.layout) {
             try ensureCanonicalLinks()
             try finalizeRecovered(transaction, state: &state, now: now)
-            cleanupTransaction(transaction)
+            try cleanupTransaction(transaction)
             return
         }
 
@@ -187,7 +189,7 @@ final class UpdateRecoveryStore: @unchecked Sendable {
             }
             try ensureCanonicalLinks()
             try finalizeRecovered(transaction, state: &state, now: now)
-            cleanupTransaction(transaction)
+            try cleanupTransaction(transaction)
             return
         }
 
@@ -214,7 +216,7 @@ final class UpdateRecoveryStore: @unchecked Sendable {
             )
         }
         try writeState(state)
-        cleanupTransaction(transaction)
+        try cleanupTransaction(transaction)
     }
 
     func commit(
@@ -255,6 +257,7 @@ final class UpdateRecoveryStore: @unchecked Sendable {
         try faultInjector(.transactionPersisted)
 
         try installStagedBundle(staged)
+        try faultInjector(.liveLayoutExchanged)
         transaction.phase = .liveReplaced
         try persist(transaction)
         try faultInjector(.liveLayoutReplaced)
@@ -262,7 +265,7 @@ final class UpdateRecoveryStore: @unchecked Sendable {
         state.installCandidate(candidate, predecessor: predecessor, now: now)
         try writeState(state)
         try faultInjector(.statePersisted)
-        finish(remove: staged.stagingRoot)
+        try finish(remove: staged.stagingRoot)
     }
 
     func rollback(now: Double, reason: String) throws -> String {
@@ -304,6 +307,7 @@ final class UpdateRecoveryStore: @unchecked Sendable {
 
         try installFromStaging(stagingRoot, layout: predecessor.layout)
         try ensureCanonicalLinks()
+        try faultInjector(.liveLayoutExchanged)
         transaction.phase = .liveReplaced
         try persist(transaction)
         try faultInjector(.liveLayoutReplaced)
@@ -312,16 +316,18 @@ final class UpdateRecoveryStore: @unchecked Sendable {
         state.completeRollback(now: now, reason: reason)
         try writeState(state)
         try faultInjector(.statePersisted)
-        finish(remove: stagingRoot)
+        try finish(remove: stagingRoot)
         return predecessor.release.version
     }
 
     func verifyPredecessor(_ predecessor: VerifiedPredecessor) throws {
         let bundle = try resolvedRecoveryPath(predecessor.bundlePath)
         let binary = try resolvedRecoveryPath(predecessor.binaryPath)
+        let enclave = try resolvedRecoveryPath(predecessor.enclavePath)
         let metallib = try resolvedRecoveryPath(predecessor.metallibPath)
         guard fm.fileExists(atPath: bundle.path),
               fm.fileExists(atPath: binary.path),
+              fm.fileExists(atPath: enclave.path),
               fm.fileExists(atPath: metallib.path)
         else {
             throw StoreError.predecessorVerificationFailed(
@@ -337,6 +343,11 @@ final class UpdateRecoveryStore: @unchecked Sendable {
             guard binaryHash == predecessor.release.binaryHash else {
                 throw StoreError.predecessorVerificationFailed(
                     "binary hash mismatch (expected \(predecessor.release.binaryHash), got \(binaryHash))")
+            }
+            let enclaveHash = try UpdateAtomicFilesystem.sha256(file: enclave)
+            guard enclaveHash == predecessor.release.enclaveHash else {
+                throw StoreError.predecessorVerificationFailed(
+                    "enclave hash mismatch (expected \(predecessor.release.enclaveHash), got \(enclaveHash))")
             }
             let metallibHash = try UpdateAtomicFilesystem.sha256(file: metallib)
             guard metallibHash == predecessor.release.metallibHash else {
@@ -439,19 +450,20 @@ final class UpdateRecoveryStore: @unchecked Sendable {
         try UpdateAtomicFilesystem.writeJSON(transaction, to: transactionPath)
     }
 
-    private func finish(remove staging: URL) {
-        try? fm.removeItem(at: transactionPath)
-        try? fm.removeItem(at: staging)
+    private func finish(remove staging: URL) throws {
+        try UpdateAtomicFilesystem.removeDurably(transactionPath)
+        try faultInjector(.transactionRemoved)
+        try UpdateAtomicFilesystem.removeDurably(staging)
         cleanupOrphanedRecoveryTemps()
     }
 
-    private func cleanupTransaction(_ transaction: Transaction) {
-        try? fm.removeItem(at: transactionPath)
+    private func cleanupTransaction(_ transaction: Transaction) throws {
+        try UpdateAtomicFilesystem.removeDurably(transactionPath)
         let staging = URL(
             fileURLWithPath: transaction.stagingRoot
         ).standardizedFileURL
         if UpdateAtomicFilesystem.isDescendant(staging, of: installRoot) {
-            try? fm.removeItem(at: staging)
+            try UpdateAtomicFilesystem.removeDurably(staging)
         }
         cleanupOrphanedRecoveryTemps()
     }

--- a/provider-swift/Sources/ProviderCore/Update/UpdateSession.swift
+++ b/provider-swift/Sources/ProviderCore/Update/UpdateSession.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+extension SelfUpdater {
+    /// A cross-process update lease. Holding a session is mandatory for every
+    /// stage, commit, recovery, or rollback mutation.
+    public final class UpdateSession: @unchecked Sendable {
+        let processLock: UpdateProcessLock
+        let store: UpdateRecoveryStore
+        private let releaseMutex = NSLock()
+        private var released = false
+
+        init(processLock: UpdateProcessLock, store: UpdateRecoveryStore) {
+            self.processLock = processLock
+            self.store = store
+        }
+
+        deinit {
+            release()
+        }
+
+        public func release() {
+            releaseMutex.lock()
+            defer { releaseMutex.unlock() }
+            guard !released else { return }
+            released = true
+            processLock.release()
+        }
+
+        func recover(now: Double = Date().timeIntervalSince1970) throws {
+            try store.recoverInterruptedTransaction(now: now)
+        }
+
+        func readState() throws -> UpdateRecoveryState {
+            try store.loadState()
+        }
+
+        func writeState(_ state: UpdateRecoveryState) throws {
+            try store.writeState(state)
+        }
+
+        @discardableResult
+        func rollback(now: Double, reason: String) throws -> String {
+            try store.rollback(now: now, reason: reason)
+        }
+    }
+}

--- a/provider-swift/Sources/darkbloom/Diagnostics/DoctorRunner.swift
+++ b/provider-swift/Sources/darkbloom/Diagnostics/DoctorRunner.swift
@@ -164,8 +164,20 @@ enum DoctorRunner {
         switch await updater.checkForUpdate() {
         case .updateAvailable(let current, let latest):
             out.append(VersionDiagnostic.diagnose(current: current, minimum: nil, latest: latest.version))
+        case .restartRequired(let current, let installed):
+            out.append(VersionDiagnostic.diagnose(
+                current: current,
+                minimum: nil,
+                latest: installed
+            ))
         case .upToDate(let current):
             out.append(VersionDiagnostic.diagnose(current: current, minimum: nil, latest: current))
+        case .quarantined(let version, _):
+            out.append(VersionDiagnostic.diagnose(
+                current: ProviderCore.version,
+                minimum: nil,
+                latest: version
+            ))
         case .checkFailed:
             break // network section already covers coordinator reachability
         }

--- a/provider-swift/Sources/darkbloom/RestartCommand.swift
+++ b/provider-swift/Sources/darkbloom/RestartCommand.swift
@@ -15,6 +15,8 @@ struct Restart: AsyncParsableCommand {
         """
     )
 
+    @OptionGroup var configOptions: ConfigOptions
+
     mutating func run() async throws {
         let wasLoaded = LaunchAgent.isLoaded()
         do {
@@ -30,9 +32,15 @@ struct Restart: AsyncParsableCommand {
         }
 
         // Re-arm the watchdog (re-enables it after a prior `stop`, or installs it
-        // on a provider upgraded from a pre-watchdog build).
-        if Watchdog.autoRestartEnabled(configPath: nil) {
-            try? WatchdogAgent.installAndStart()
+        // on a provider upgraded from a pre-watchdog build). The rewrite must
+        // not drop a custom config: an explicit --config wins, otherwise the
+        // installed plist's recorded config path is preserved.
+        let watchdogConfig = WatchdogAgent.rearmConfigPath(
+            explicit: configOptions.config,
+            installed: WatchdogAgent.installedConfigPath()
+        )
+        if Watchdog.autoRestartEnabled(configPath: watchdogConfig?.path) {
+            try? WatchdogAgent.installAndStart(configPath: watchdogConfig)
         }
 
         print("  darkbloom status  Check status")

--- a/provider-swift/Sources/darkbloom/RestartCommand.swift
+++ b/provider-swift/Sources/darkbloom/RestartCommand.swift
@@ -34,13 +34,23 @@ struct Restart: AsyncParsableCommand {
         // Re-arm the watchdog (re-enables it after a prior `stop`, or installs it
         // on a provider upgraded from a pre-watchdog build). The rewrite must
         // not drop a custom config: an explicit --config wins, otherwise the
-        // installed plist's recorded config path is preserved.
+        // installed plist's recorded config path is preserved. An opted-out
+        // config (`auto_restart = false`) DISARMS a still-loaded watchdog
+        // instead of leaving the stale job running.
         let watchdogConfig = WatchdogAgent.rearmConfigPath(
             explicit: configOptions.config,
             installed: WatchdogAgent.installedConfigPath()
         )
-        if Watchdog.autoRestartEnabled(configPath: watchdogConfig?.path) {
+        switch WatchdogAgent.rearmAction(
+            autoRestartEnabled: Watchdog.autoRestartEnabled(configPath: watchdogConfig?.path),
+            isLoaded: WatchdogAgent.isLoaded()
+        ) {
+        case .arm:
             try? WatchdogAgent.installAndStart(configPath: watchdogConfig)
+        case .disarm:
+            try? WatchdogAgent.stop()
+        case nil:
+            break
         }
 
         print("  darkbloom status  Check status")

--- a/provider-swift/Sources/darkbloom/StartCommand+Daemon.swift
+++ b/provider-swift/Sources/darkbloom/StartCommand+Daemon.swift
@@ -50,9 +50,15 @@ extension Start {
         )
 
         // Arm the crash-recovery watchdog (relaunches ~5 min after a crash;
-        // `stop` disarms, `auto_restart = false` opts out). Best-effort.
+        // `stop` disarms, `auto_restart = false` opts out — including
+        // disarming a watchdog left loaded by a previous opted-in config).
+        // Best-effort.
         let autoRestartOn = config.provider.autoRestart
-        if autoRestartOn {
+        switch WatchdogAgent.rearmAction(
+            autoRestartEnabled: autoRestartOn,
+            isLoaded: WatchdogAgent.isLoaded()
+        ) {
+        case .arm:
             do {
                 try WatchdogAgent.installAndStart(
                     configPath: snapshot.configPath
@@ -60,6 +66,10 @@ extension Start {
             } catch {
                 printError("note: could not install crash-recovery watchdog: \(error)")
             }
+        case .disarm:
+            try? WatchdogAgent.stop()
+        case nil:
+            break
         }
 
         let logPath = LaunchAgent.logPath().path

--- a/provider-swift/Sources/darkbloom/StartCommand+Daemon.swift
+++ b/provider-swift/Sources/darkbloom/StartCommand+Daemon.swift
@@ -54,7 +54,9 @@ extension Start {
         let autoRestartOn = config.provider.autoRestart
         if autoRestartOn {
             do {
-                try WatchdogAgent.installAndStart()
+                try WatchdogAgent.installAndStart(
+                    configPath: snapshot.configPath
+                )
             } catch {
                 printError("note: could not install crash-recovery watchdog: \(error)")
             }

--- a/provider-swift/Sources/darkbloom/StartCommand+Modes.swift
+++ b/provider-swift/Sources/darkbloom/StartCommand+Modes.swift
@@ -156,6 +156,13 @@ extension Start {
         let (models, modelHashes, modelHashFingerprints) = attachWeightHashes(to: selectedModels)
         let runtimeHashes = (try? RuntimeHashReporter().report().coordinatorRuntimeHashes)
         let authToken = AuthTokenStore.load()
+        if let identity = ProcessIdentity.current() {
+            try? SelfUpdater(
+                coordinatorBaseURL: coordinatorURL
+            ).confirmRunningCandidateLaunch(
+                processStartedAt: Double(identity.startTimeMicros) / 1_000_000
+            )
+        }
 
         if config.provider.autoUpdate {
             try await runStartupAutoUpdate(coordinatorURL: coordinatorURL)
@@ -174,7 +181,9 @@ extension Start {
         // (manual start, login, or auto-update relaunch). Idempotent (skip when
         // already loaded → no churn on restarts) + best-effort.
         if config.provider.autoRestart, !WatchdogAgent.isLoaded() {
-            try? WatchdogAgent.installAndStart()
+            try? WatchdogAgent.installAndStart(
+                configPath: snapshot.configPath
+            )
         }
 
         // ----- Telemetry: configure now so reconnect/inference/panic events flow. -----
@@ -280,6 +289,9 @@ extension Start {
         case .updated(let from, let to):
             print("Updated provider: v\(from) -> v\(to). Restarting into new binary...")
             do {
+                try updater.prepareCandidateLaunch(
+                    operation: "startup-update-exec"
+                )
                 try ProcessLifecycle.execCurrentProcess()
             } catch {
                 try? updater.cancelPendingCandidateAttempt(
@@ -289,6 +301,9 @@ extension Start {
         case .restartRequired(let from, let to):
             print("Provider v\(to) is already installed (running v\(from)); restarting into it...")
             do {
+                try updater.prepareCandidateLaunch(
+                    operation: "startup-candidate-exec"
+                )
                 try ProcessLifecycle.execCurrentProcess()
             } catch {
                 try? updater.cancelPendingCandidateAttempt(

--- a/provider-swift/Sources/darkbloom/StartCommand+Modes.swift
+++ b/provider-swift/Sources/darkbloom/StartCommand+Modes.swift
@@ -279,7 +279,28 @@ extension Start {
             return
         case .updated(let from, let to):
             print("Updated provider: v\(from) -> v\(to). Restarting into new binary...")
-            try ProcessLifecycle.execCurrentProcess()
+            do {
+                try ProcessLifecycle.execCurrentProcess()
+            } catch {
+                try? updater.cancelPendingCandidateAttempt(
+                    operation: "startup-exec-failure")
+                throw error
+            }
+        case .restartRequired(let from, let to):
+            print("Provider v\(to) is already installed (running v\(from)); restarting into it...")
+            do {
+                try ProcessLifecycle.execCurrentProcess()
+            } catch {
+                try? updater.cancelPendingCandidateAttempt(
+                    operation: "startup-exec-failure")
+                throw error
+            }
+        case .quarantined(let version, let reason):
+            printError("auto-update skipped: v\(version) is quarantined after failed starts (\(reason))")
+        case .busy(let reason):
+            printError("auto-update skipped: another update/recovery operation is active (\(reason))")
+        case .cancelled(let reason):
+            printError("auto-update cancelled: \(reason)")
         case .downloadFailed(let reason):
             printError("auto-update skipped: \(reason)")
         case .hashMismatch(let expected, let got):

--- a/provider-swift/Sources/darkbloom/UpdateCommand.swift
+++ b/provider-swift/Sources/darkbloom/UpdateCommand.swift
@@ -15,6 +15,12 @@ struct Update: AsyncParsableCommand {
     @Flag(help: "Only check for updates without installing.")
     var checkOnly = false
 
+    @Flag(
+        name: .long,
+        help: "Explicitly reinstall a locally quarantined failed version."
+    )
+    var overrideQuarantine = false
+
     mutating func run() async throws {
         let config: ProviderConfig
         do {
@@ -32,7 +38,9 @@ struct Update: AsyncParsableCommand {
         let updater = SelfUpdater(coordinatorBaseURL: coordinatorURL)
 
         if checkOnly {
-            let result = await updater.checkForUpdate()
+            let result = await updater.checkForUpdate(
+                manualOverride: overrideQuarantine
+            )
             switch result {
             case .upToDate(let version):
                 print("Up to date (v\(version)).")
@@ -50,6 +58,16 @@ struct Update: AsyncParsableCommand {
                 print("")
                 print("Run 'darkbloom update' to install.")
 
+            case .restartRequired(let current, let installed):
+                print("v\(installed) is already installed on disk but this process is v\(current).")
+                print("Restart the provider to activate the installed version.")
+
+            case .quarantined(let version, let reason):
+                print("Latest release v\(version) is quarantined on this machine.")
+                print("Reason: \(reason)")
+                print("A strictly newer release remains eligible automatically.")
+                print("Use --override-quarantine only for an explicit operator retry.")
+
             case .checkFailed(let reason):
                 printError("update check failed: \(reason)")
                 throw ExitCode.failure
@@ -57,8 +75,12 @@ struct Update: AsyncParsableCommand {
             return
         }
 
+        if overrideQuarantine {
+            printError("WARNING: overriding local failed-version quarantine by explicit request.")
+            printError("The failed release may crash this provider again.")
+        }
         print("Checking for updates...")
-        let result = await updater.update()
+        let result = await updater.update(manualOverride: overrideQuarantine)
 
         switch result {
         case .alreadyUpToDate(let version):
@@ -68,10 +90,45 @@ struct Update: AsyncParsableCommand {
             print("Updated: v\(from) -> v\(to)")
             if LaunchAgent.isLoaded() {
                 print("Restarting provider via launchd...")
-                try ProcessLifecycle.restartAfterUpdate()
+                do {
+                    try ProcessLifecycle.restartAfterUpdate()
+                } catch {
+                    try? updater.cancelPendingCandidateAttempt(
+                        operation: "manual-restart-failure")
+                    throw error
+                }
             } else {
                 print("Restart the provider for the new version to take effect.")
             }
+
+        case .restartRequired(let from, let to):
+            print("v\(to) is already installed (current process: v\(from)).")
+            if LaunchAgent.isLoaded() {
+                print("Restarting provider via launchd...")
+                do {
+                    try ProcessLifecycle.restartAfterUpdate()
+                } catch {
+                    try? updater.cancelPendingCandidateAttempt(
+                        operation: "manual-restart-failure")
+                    throw error
+                }
+            } else {
+                print("Restart the provider for v\(to) to take effect.")
+            }
+
+        case .quarantined(let version, let reason):
+            printError("v\(version) is quarantined after failed starts: \(reason)")
+            printError("A strictly newer release will install automatically.")
+            printError("Use --override-quarantine for an explicit operator retry.")
+            throw ExitCode.failure
+
+        case .busy(let reason):
+            printError("another update/recovery operation is active: \(reason)")
+            throw ExitCode.failure
+
+        case .cancelled(let reason):
+            printError("update cancelled: \(reason)")
+            throw ExitCode.failure
 
         case .downloadFailed(let reason):
             printError("download failed: \(reason)")

--- a/provider-swift/Sources/darkbloom/UpdateCommand.swift
+++ b/provider-swift/Sources/darkbloom/UpdateCommand.swift
@@ -91,6 +91,9 @@ struct Update: AsyncParsableCommand {
             if LaunchAgent.isLoaded() {
                 print("Restarting provider via launchd...")
                 do {
+                    try updater.prepareCandidateLaunch(
+                        operation: "manual-update-restart"
+                    )
                     try ProcessLifecycle.restartAfterUpdate()
                 } catch {
                     try? updater.cancelPendingCandidateAttempt(
@@ -106,6 +109,9 @@ struct Update: AsyncParsableCommand {
             if LaunchAgent.isLoaded() {
                 print("Restarting provider via launchd...")
                 do {
+                    try updater.prepareCandidateLaunch(
+                        operation: "manual-candidate-restart"
+                    )
                     try ProcessLifecycle.restartAfterUpdate()
                 } catch {
                     try? updater.cancelPendingCandidateAttempt(

--- a/provider-swift/Sources/darkbloom/WatchdogCommand.swift
+++ b/provider-swift/Sources/darkbloom/WatchdogCommand.swift
@@ -49,9 +49,14 @@ struct Watchdog: AsyncParsableCommand {
             daemonState: daemonState,
             now: now
         )
-        let providerIdentity = daemonState.flatMap {
-            ProcessIdentity.read(pid: $0.pid)
-        } ?? LaunchAgent.launchSnapshot()?.process
+        // Only trust the daemon-state PID when its live kernel start time still
+        // matches what the daemon recorded; a reused PID (e.g. a manual
+        // `darkbloom update` holding the lock) falls back to the launchd
+        // snapshot so the watchdog never force-kills an unrelated live process.
+        let providerIdentity = WatchdogProbe.providerIdentity(
+            daemonState: daemonState,
+            launchSnapshotProcess: LaunchAgent.launchSnapshot()?.process
+        )
         let state = WatchdogStateStore.read()
         // Ignore a downSince left over from a previous boot (fresh window per outage).
         let bootTime = now - ProcessInfo.processInfo.systemUptime
@@ -96,6 +101,7 @@ struct Watchdog: AsyncParsableCommand {
             let outcome = await recovery.recoverDownProvider(
                 autoUpdateEnabled: settings.autoUpdate,
                 inactiveProviderIdentity: providerIdentity,
+                providerProcessAlive: liveness.running,
                 now: now
             )
             persistenceDecision = Self.recordRecoveryOutcome(
@@ -116,9 +122,13 @@ struct Watchdog: AsyncParsableCommand {
             if case .inactiveCandidate(let attemptStartedAt) = health {
                 Self.log(
                     "new version has no fresh heartbeat \(Int(now - attemptStartedAt))s after launch — treating it as a failed start")
+                // The candidate is already past its startup window here (that is
+                // exactly what .inactiveCandidate means), so the process-alive
+                // grace below is a no-op; passed for call-site consistency.
                 let outcome = await recovery.recoverDownProvider(
                     autoUpdateEnabled: settings.autoUpdate,
                     inactiveProviderIdentity: providerIdentity,
+                    providerProcessAlive: liveness.running,
                     now: now
                 )
                 _ = Self.recordRecoveryOutcome(

--- a/provider-swift/Sources/darkbloom/WatchdogCommand.swift
+++ b/provider-swift/Sources/darkbloom/WatchdogCommand.swift
@@ -119,7 +119,8 @@ struct Watchdog: AsyncParsableCommand {
                 daemonState: daemonState,
                 now: now
             )
-            if case .inactiveCandidate(let attemptStartedAt) = health {
+            switch health {
+            case .inactiveCandidate(let attemptStartedAt):
                 Self.log(
                     "new version has no fresh heartbeat \(Int(now - attemptStartedAt))s after launch — treating it as a failed start")
                 // The candidate is already past its startup window here (that is
@@ -136,8 +137,24 @@ struct Watchdog: AsyncParsableCommand {
                     grace: grace,
                     now: now
                 )
-            } else if case .failed(let reason) = health {
+            case .blockedCandidateRetry(let reason):
+                Self.log(
+                    "blocked-rollback candidate's retry backoff expired with no heartbeat — retrying restart/rollback (\(reason))")
+                let outcome = await recovery.recoverDownProvider(
+                    autoUpdateEnabled: settings.autoUpdate,
+                    inactiveProviderIdentity: providerIdentity,
+                    providerProcessAlive: liveness.running,
+                    now: now
+                )
+                _ = Self.recordRecoveryOutcome(
+                    outcome,
+                    grace: grace,
+                    now: now
+                )
+            case .failed(let reason):
                 Self.log("candidate health persistence failed: \(reason)")
+            case .noCandidate, .stabilizing, .promoted, .lockBusy:
+                break
             }
             if downSince != nil { Self.log("provider recovered — cancelling pending restart") }
         case .disabled, .notManaged:

--- a/provider-swift/Sources/darkbloom/WatchdogCommand.swift
+++ b/provider-swift/Sources/darkbloom/WatchdogCommand.swift
@@ -2,13 +2,13 @@ import Foundation
 import ArgumentParser
 import ProviderCore
 
-/// `darkbloom watchdog` — one crash-recovery check, then exit. Run every minute
-/// by `WatchdogAgent` (launchd StartInterval). Hidden: machine-invoked, not a
-/// user verb. The thin I/O shell around `WatchdogPolicy`.
+/// Persistent launchd watchdog. Cadence is owned by a monotonic in-process
+/// scheduler because GUI-domain StartInterval jobs can become permanently
+/// stranded in launchd's on-demand-only mode.
 struct Watchdog: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "watchdog",
-        abstract: "Internal: one provider crash-recovery check (run by launchd).",
+        abstract: "Internal: persistent provider recovery watchdog.",
         shouldDisplay: false
     )
 
@@ -16,9 +16,22 @@ struct Watchdog: AsyncParsableCommand {
 
     mutating func run() async throws {
         Darkbloom.ensureLogging()
+        let configPath = configOptions.config
+        let scheduler = Task {
+            await WatchdogScheduler(
+                interval: .seconds(WatchdogAgent.checkIntervalSeconds)
+            ).run {
+                await Self.runTick(configPath: configPath)
+            }
+        }
+        await WatchdogSignalTrap.waitForTermination()
+        scheduler.cancel()
+        await scheduler.value
+    }
 
+    static func runTick(configPath: String?) async {
         let now = Date().timeIntervalSince1970
-        let settings = Self.settings(configPath: configOptions.config)
+        let settings = Self.settings(configPath: configPath)
         let liveness = WatchdogProbe.probeProvider(now: now)
         let daemonState = DaemonStateFile.read()
         let providerActive = WatchdogProbe.providerActive(
@@ -26,6 +39,9 @@ struct Watchdog: AsyncParsableCommand {
             daemonState: daemonState,
             now: now
         )
+        let providerIdentity = daemonState.flatMap {
+            ProcessIdentity.read(pid: $0.pid)
+        } ?? LaunchAgent.launchSnapshot()?.process
         let state = WatchdogStateStore.read()
         // Ignore a downSince left over from a previous boot (fresh window per outage).
         let bootTime = now - ProcessInfo.processInfo.systemUptime
@@ -46,6 +62,14 @@ struct Watchdog: AsyncParsableCommand {
                 providerStillLoaded: {
                     LaunchAgent.isAnySupportedLabelLoaded()
                 },
+                terminateStaleLockOwner: { owner in
+                    guard owner.processIdentity == providerIdentity,
+                          let identity = owner.processIdentity
+                    else {
+                        return false
+                    }
+                    return ProcessLifecycle.terminate(identity)
+                },
                 log: { Self.log($0) }
             )
         )
@@ -56,6 +80,7 @@ struct Watchdog: AsyncParsableCommand {
         case .restart:
             let outcome = await recovery.recoverDownProvider(
                 autoUpdateEnabled: settings.autoUpdate,
+                inactiveProviderIdentity: providerIdentity,
                 now: now
             )
             persistenceDecision = Self.recordRecoveryOutcome(
@@ -78,6 +103,7 @@ struct Watchdog: AsyncParsableCommand {
                     "new version has no fresh heartbeat \(Int(now - attemptStartedAt))s after launch — treating it as a failed start")
                 let outcome = await recovery.recoverDownProvider(
                     autoUpdateEnabled: settings.autoUpdate,
+                    inactiveProviderIdentity: providerIdentity,
                     now: now
                 )
                 _ = Self.recordRecoveryOutcome(
@@ -105,21 +131,26 @@ struct Watchdog: AsyncParsableCommand {
         let coordinatorURL: String
     }
 
-    static func settings(configPath: String?) -> Settings {
+    static func settings(
+        configPath: String?,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> Settings {
         if let configPath {
             let path = URL(fileURLWithPath: (configPath as NSString).expandingTildeInPath)
             let config = (try? ConfigManager.load(from: path))
                 ?? ProviderConfig(provider: ProviderSettings(name: "darkbloom"))
             return Settings(
                 autoRestart: config.provider.autoRestart,
-                autoUpdate: config.provider.autoUpdate,
+                autoUpdate: config.provider.autoUpdate
+                    && environment["DARKBLOOM_NO_UPDATE_CHECK"] == nil,
                 coordinatorURL: config.coordinator.url
             )
         }
         let config = ConfigManager.loadDefault()
         return Settings(
             autoRestart: config.provider.autoRestart,
-            autoUpdate: config.provider.autoUpdate,
+            autoUpdate: config.provider.autoUpdate
+                && environment["DARKBLOOM_NO_UPDATE_CHECK"] == nil,
             coordinatorURL: config.coordinator.url
         )
     }

--- a/provider-swift/Sources/darkbloom/WatchdogCommand.swift
+++ b/provider-swift/Sources/darkbloom/WatchdogCommand.swift
@@ -29,8 +29,18 @@ struct Watchdog: AsyncParsableCommand {
         await scheduler.value
     }
 
+    /// Safe-point tick budget. Larger than the bounded URLSession's
+    /// whole-transfer timeout so a normal (slow) download completes; a tick
+    /// that exceeds it skips further network work at the next safe point and
+    /// proceeds straight to the restart action. Never interrupts a journaled
+    /// commit mid-flight.
+    static let tickDeadlineSeconds: Double =
+        SelfUpdater.watchdogResourceTimeoutSeconds + 120
+
     static func runTick(configPath: String?) async {
         let now = Date().timeIntervalSince1970
+        let tickDeadline = ContinuousClock.now
+            + .seconds(Int64(Self.tickDeadlineSeconds))
         let settings = Self.settings(configPath: configPath)
         let liveness = WatchdogProbe.probeProvider(now: now)
         let daemonState = DaemonStateFile.read()
@@ -54,7 +64,10 @@ struct Watchdog: AsyncParsableCommand {
             downSince: downSince,
             now: now
         )
-        let updater = SelfUpdater(coordinatorBaseURL: settings.coordinatorURL)
+        let updater = SelfUpdater(
+            coordinatorBaseURL: settings.coordinatorURL,
+            urlSession: SelfUpdater.watchdogURLSession()
+        )
         let recovery = WatchdogRecoveryService(
             updater: updater,
             dependencies: .init(
@@ -70,8 +83,10 @@ struct Watchdog: AsyncParsableCommand {
                     }
                     return ProcessLifecycle.terminate(identity)
                 },
+                isPastTickDeadline: { ContinuousClock.now > tickDeadline },
                 log: { Self.log($0) }
-            )
+            ),
+            candidateStartupTimeoutSeconds: settings.candidateStartupTimeoutSeconds
         )
 
         let grace = Int(WatchdogPolicy.defaultGraceSeconds)
@@ -129,29 +144,32 @@ struct Watchdog: AsyncParsableCommand {
         let autoRestart: Bool
         let autoUpdate: Bool
         let coordinatorURL: String
+        /// Derived from the operator's `startup_preload_timeout_secs` so a
+        /// raised preload window never reads as a hung candidate launch.
+        let candidateStartupTimeoutSeconds: Double
     }
 
     static func settings(
         configPath: String?,
         environment: [String: String] = ProcessInfo.processInfo.environment
     ) -> Settings {
+        let config: ProviderConfig
         if let configPath {
             let path = URL(fileURLWithPath: (configPath as NSString).expandingTildeInPath)
-            let config = (try? ConfigManager.load(from: path))
+            config = (try? ConfigManager.load(from: path))
                 ?? ProviderConfig(provider: ProviderSettings(name: "darkbloom"))
-            return Settings(
-                autoRestart: config.provider.autoRestart,
-                autoUpdate: config.provider.autoUpdate
-                    && environment["DARKBLOOM_NO_UPDATE_CHECK"] == nil,
-                coordinatorURL: config.coordinator.url
-            )
+        } else {
+            config = ConfigManager.loadDefault()
         }
-        let config = ConfigManager.loadDefault()
         return Settings(
             autoRestart: config.provider.autoRestart,
             autoUpdate: config.provider.autoUpdate
                 && environment["DARKBLOOM_NO_UPDATE_CHECK"] == nil,
-            coordinatorURL: config.coordinator.url
+            coordinatorURL: config.coordinator.url,
+            candidateStartupTimeoutSeconds:
+                WatchdogRecoveryService.candidateStartupTimeout(
+                    preloadTimeoutSecs: config.backend.startupPreloadTimeoutSecs
+                )
         )
     }
 

--- a/provider-swift/Sources/darkbloom/WatchdogCommand.swift
+++ b/provider-swift/Sources/darkbloom/WatchdogCommand.swift
@@ -18,66 +18,149 @@ struct Watchdog: AsyncParsableCommand {
         Darkbloom.ensureLogging()
 
         let now = Date().timeIntervalSince1970
-        let enabled = Self.autoRestartEnabled(configPath: configOptions.config)
+        let settings = Self.settings(configPath: configOptions.config)
         let liveness = WatchdogProbe.probeProvider(now: now)
+        let daemonState = DaemonStateFile.read()
+        let providerActive = WatchdogProbe.providerActive(
+            processRunning: liveness.running,
+            daemonState: daemonState,
+            now: now
+        )
         let state = WatchdogStateStore.read()
         // Ignore a downSince left over from a previous boot (fresh window per outage).
         let bootTime = now - ProcessInfo.processInfo.systemUptime
         let downSince = WatchdogPolicy.effectiveDownSince(state.downSince, bootTime: bootTime)
 
         let decision = WatchdogPolicy.decide(
-            autoRestartEnabled: enabled,
+            autoRestartEnabled: settings.autoRestart,
             providerLoaded: liveness.loaded,
-            providerRunning: liveness.running,
+            providerRunning: providerActive,
             downSince: downSince,
             now: now
         )
+        let updater = SelfUpdater(coordinatorBaseURL: settings.coordinatorURL)
+        let recovery = WatchdogRecoveryService(
+            updater: updater,
+            dependencies: .init(
+                kickstartIfLoaded: { try LaunchAgent.kickstartIfLoaded() },
+                providerStillLoaded: {
+                    LaunchAgent.isAnySupportedLabelLoaded()
+                },
+                log: { Self.log($0) }
+            )
+        )
 
         let grace = Int(WatchdogPolicy.defaultGraceSeconds)
+        var persistenceDecision = decision
         switch decision {
         case .restart:
-            // kickstartIfLoaded re-checks loaded, so a `stop` racing the probe is a no-op.
-            do {
-                let restarted = try LaunchAgent.kickstartIfLoaded()
-                log(restarted ? "provider down > \(grace)s — restart issued"
-                              : "provider no longer loaded — skipping restart")
-            } catch {
-                log("restart failed: \(error)")
-            }
+            let outcome = await recovery.recoverDownProvider(
+                autoUpdateEnabled: settings.autoUpdate,
+                now: now
+            )
+            persistenceDecision = Self.recordRecoveryOutcome(
+                outcome,
+                grace: grace,
+                now: now
+            )
         case .startGrace:
-            log("provider appears down — will restart in \(grace)s if it stays down")
+            Self.log("provider appears down — will restart in \(grace)s if it stays down")
         case .waiting(let remaining):
-            log("provider still down — restart in ~\(Int(remaining))s")
+            Self.log("provider still down — restart in ~\(Int(remaining))s")
         case .healthy:
-            if downSince != nil { log("provider recovered — cancelling pending restart") }
+            let health = recovery.observeHealthyProvider(
+                providerRunning: liveness.running,
+                daemonState: daemonState,
+                now: now
+            )
+            if case .inactiveCandidate(let attemptStartedAt) = health {
+                Self.log(
+                    "new version has no fresh heartbeat \(Int(now - attemptStartedAt))s after launch — treating it as a failed start")
+                let outcome = await recovery.recoverDownProvider(
+                    autoUpdateEnabled: settings.autoUpdate,
+                    now: now
+                )
+                _ = Self.recordRecoveryOutcome(
+                    outcome,
+                    grace: grace,
+                    now: now
+                )
+            } else if case .failed(let reason) = health {
+                Self.log("candidate health persistence failed: \(reason)")
+            }
+            if downSince != nil { Self.log("provider recovered — cancelling pending restart") }
         case .disabled, .notManaged:
             break
         }
 
-        if let newState = WatchdogPolicy.nextState(for: decision, current: state, now: now),
+        if let newState = WatchdogPolicy.nextState(for: persistenceDecision, current: state, now: now),
            !WatchdogStateStore.write(newState) {
-            log("warning: could not persist watchdog state (check ~/.darkbloom)")
+            Self.log("warning: could not persist watchdog state (check ~/.darkbloom)")
         }
+    }
+
+    struct Settings: Equatable {
+        let autoRestart: Bool
+        let autoUpdate: Bool
+        let coordinatorURL: String
+    }
+
+    static func settings(configPath: String?) -> Settings {
+        if let configPath {
+            let path = URL(fileURLWithPath: (configPath as NSString).expandingTildeInPath)
+            let config = (try? ConfigManager.load(from: path))
+                ?? ProviderConfig(provider: ProviderSettings(name: "darkbloom"))
+            return Settings(
+                autoRestart: config.provider.autoRestart,
+                autoUpdate: config.provider.autoUpdate,
+                coordinatorURL: config.coordinator.url
+            )
+        }
+        let config = ConfigManager.loadDefault()
+        return Settings(
+            autoRestart: config.provider.autoRestart,
+            autoUpdate: config.provider.autoUpdate,
+            coordinatorURL: config.coordinator.url
+        )
     }
 
     /// Read just `auto_restart` cheaply; fail open to enabled so a missing or
     /// malformed config never silently disables recovery.
     static func autoRestartEnabled(configPath: String?) -> Bool {
-        let path: URL
-        if let configPath {
-            path = URL(fileURLWithPath: (configPath as NSString).expandingTildeInPath)
-        } else if let resolved = try? ConfigManager.defaultConfigPath() {
-            path = resolved
-        } else {
-            return true
+        settings(configPath: configPath).autoRestart
+    }
+
+    private static func recordRecoveryOutcome(
+        _ outcome: WatchdogRecoveryService.DownOutcome,
+        grace: Int,
+        now: Double
+    ) -> WatchdogDecision {
+        switch outcome {
+        case .restartIssued(let updatedTo, let rolledBackTo):
+            var details: [String] = []
+            if let updatedTo { details.append("updated to v\(updatedTo)") }
+            if let rolledBackTo { details.append("rolled back to v\(rolledBackTo)") }
+            let suffix = details.isEmpty ? "" : " (\(details.joined(separator: ", ")))"
+            log("provider down > \(grace)s — restart issued\(suffix)")
+            return .restart
+        case .noLongerLoaded:
+            log("provider no longer loaded — skipping restart")
+            return .restart
+        case .retryBackoff(let until, let reason):
+            log(
+                "restart deferred for rollback safety until \(ISO8601DateFormatter().string(from: Date(timeIntervalSince1970: until))): \(reason)")
+            return .waiting(remaining: max(0, until - now))
+        case .lockBusy(let reason):
+            log("restart deferred while another update operation finishes: \(reason)")
+            return .waiting(remaining: 0)
+        case .failed(let reason):
+            log("restart recovery failed: \(reason)")
+            return .waiting(remaining: 0)
         }
-        guard FileManager.default.fileExists(atPath: path.path),
-              let config = try? ConfigManager.load(from: path) else { return true }
-        return config.provider.autoRestart
     }
 
     /// launchd routes stdout to ~/.darkbloom/watchdog.log; healthy ticks log nothing.
-    private func log(_ message: String) {
+    private static func log(_ message: String) {
         print("[\(ISO8601DateFormatter().string(from: Date()))] watchdog: \(message)")
     }
 }

--- a/provider-swift/Sources/darkbloom/WatchdogSignalTrap.swift
+++ b/provider-swift/Sources/darkbloom/WatchdogSignalTrap.swift
@@ -1,0 +1,61 @@
+import Dispatch
+import Foundation
+#if canImport(Darwin)
+import Darwin
+#endif
+
+enum WatchdogSignalTrap {
+    static func waitForTermination() async {
+        #if canImport(Darwin)
+        signal(SIGTERM, SIG_IGN)
+        signal(SIGINT, SIG_IGN)
+        await withCheckedContinuation { continuation in
+            let state = ResumeOnce(continuation)
+            let term = DispatchSource.makeSignalSource(
+                signal: SIGTERM,
+                queue: .global(qos: .utility)
+            )
+            let interrupt = DispatchSource.makeSignalSource(
+                signal: SIGINT,
+                queue: .global(qos: .utility)
+            )
+            term.setEventHandler { state.resume() }
+            interrupt.setEventHandler { state.resume() }
+            term.resume()
+            interrupt.resume()
+            state.retain(term, interrupt)
+        }
+        #else
+        while !Task.isCancelled {
+            try? await Task.sleep(for: .seconds(60))
+        }
+        #endif
+    }
+
+    private final class ResumeOnce: @unchecked Sendable {
+        private let lock = NSLock()
+        private var continuation: CheckedContinuation<Void, Never>?
+        private var sources: [DispatchSourceSignal] = []
+
+        init(_ continuation: CheckedContinuation<Void, Never>) {
+            self.continuation = continuation
+        }
+
+        func retain(_ sources: DispatchSourceSignal...) {
+            lock.withLock {
+                self.sources = sources
+            }
+        }
+
+        func resume() {
+            let pending: CheckedContinuation<Void, Never>? = lock.withLock {
+                let pending = continuation
+                continuation = nil
+                sources.forEach { $0.cancel() }
+                sources.removeAll()
+                return pending
+            }
+            pending?.resume()
+        }
+    }
+}

--- a/provider-swift/Tests/DarkbloomCLITests/WatchdogCommandTests.swift
+++ b/provider-swift/Tests/DarkbloomCLITests/WatchdogCommandTests.swift
@@ -73,6 +73,23 @@ struct WatchdogCommandTests {
         #expect(!settings.autoUpdate)
     }
 
+    @Test("DARKBLOOM_NO_UPDATE_CHECK disables only watchdog updates")
+    func environmentUpdateOptOut() {
+        let url = writeTempConfig("""
+        [provider]
+        name = "x"
+        auto_update = true
+        auto_restart = true
+        """)
+        defer { try? FileManager.default.removeItem(at: url) }
+        let settings = Watchdog.settings(
+            configPath: url.path,
+            environment: ["DARKBLOOM_NO_UPDATE_CHECK": "1"]
+        )
+        #expect(settings.autoRestart)
+        #expect(!settings.autoUpdate)
+    }
+
     @Test("manual quarantine override is explicit and parseable")
     func manualOverrideParses() throws {
         let command = try Darkbloom.parseAsRoot([

--- a/provider-swift/Tests/DarkbloomCLITests/WatchdogCommandTests.swift
+++ b/provider-swift/Tests/DarkbloomCLITests/WatchdogCommandTests.swift
@@ -1,5 +1,6 @@
 import ArgumentParser
 import Foundation
+import ProviderCore
 import Testing
 
 @testable import darkbloom
@@ -88,6 +89,51 @@ struct WatchdogCommandTests {
         )
         #expect(settings.autoRestart)
         #expect(!settings.autoUpdate)
+    }
+
+    @Test("raised startup_preload_timeout_secs raises the candidate timeout")
+    func derivesCandidateTimeoutFromPreloadConfig() {
+        let url = writeTempConfig("""
+        [provider]
+        name = "x"
+
+        [backend]
+        startup_preload_timeout_secs = 420
+        """)
+        defer { try? FileManager.default.removeItem(at: url) }
+        let settings = Watchdog.settings(configPath: url.path)
+        #expect(settings.candidateStartupTimeoutSeconds == 600)
+
+        let defaults = writeTempConfig("""
+        [provider]
+        name = "x"
+        """)
+        defer { try? FileManager.default.removeItem(at: defaults) }
+        #expect(Watchdog.settings(
+            configPath: defaults.path
+        ).candidateStartupTimeoutSeconds == 300)
+    }
+
+    @Test("tick budget exceeds the bounded network whole-transfer timeout")
+    func tickBudgetCoversBoundedDownload() {
+        #expect(
+            Watchdog.tickDeadlineSeconds
+                > SelfUpdater.watchdogResourceTimeoutSeconds
+        )
+    }
+
+    @Test("restart accepts --config for the watchdog re-arm")
+    func restartParsesConfig() throws {
+        let command = try Darkbloom.parseAsRoot([
+            "restart",
+            "--config",
+            "/tmp/custom.toml",
+        ])
+        guard let restart = command as? Restart else {
+            Issue.record("expected Restart command")
+            return
+        }
+        #expect(restart.configOptions.config == "/tmp/custom.toml")
     }
 
     @Test("manual quarantine override is explicit and parseable")

--- a/provider-swift/Tests/DarkbloomCLITests/WatchdogCommandTests.swift
+++ b/provider-swift/Tests/DarkbloomCLITests/WatchdogCommandTests.swift
@@ -57,5 +57,32 @@ struct WatchdogCommandTests {
         let missing = FileManager.default.temporaryDirectory
             .appendingPathComponent("watchdog-missing-\(UUID().uuidString).toml")
         #expect(Watchdog.autoRestartEnabled(configPath: missing.path) == true)
+        #expect(Watchdog.settings(configPath: missing.path).autoUpdate == true)
+    }
+
+    @Test("auto_update = false disables watchdog-owned update checks")
+    func honoursAutoUpdateDisable() {
+        let url = writeTempConfig("""
+        [provider]
+        name = "x"
+        auto_update = false
+        """)
+        defer { try? FileManager.default.removeItem(at: url) }
+        let settings = Watchdog.settings(configPath: url.path)
+        #expect(settings.autoRestart)
+        #expect(!settings.autoUpdate)
+    }
+
+    @Test("manual quarantine override is explicit and parseable")
+    func manualOverrideParses() throws {
+        let command = try Darkbloom.parseAsRoot([
+            "update",
+            "--override-quarantine",
+        ])
+        guard let update = command as? Update else {
+            Issue.record("expected Update command")
+            return
+        }
+        #expect(update.overrideQuarantine)
     }
 }

--- a/provider-swift/Tests/ProviderCoreTests/AutoUpdateControllerTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/AutoUpdateControllerTests.swift
@@ -30,6 +30,7 @@ struct AutoUpdateControllerTests {
         var checkResult: UpdateCheckResult
         var stageResult: AutoUpdateController.StepOutcome = .completed
         var commitResult: AutoUpdateController.StepOutcome = .completed
+        var prepareRestartResult: AutoUpdateController.StepOutcome = .completed
         var drainReturns = true
         var restartThrows = false
     }
@@ -55,6 +56,10 @@ struct AutoUpdateControllerTests {
             waitForDrain: { _ in recorder.record("waitForDrain"); return fakes.drainReturns },
             forceCancelInflight: { recorder.record("forceCancel") },
             commitInstall: { recorder.record("commit"); return fakes.commitResult },
+            prepareInstalledRestart: {
+                recorder.record("prepareRestart")
+                return fakes.prepareRestartResult
+            },
             restart: {
                 recorder.record("restart")
                 if fakes.restartThrows { throw FakeError.restart }
@@ -148,6 +153,34 @@ struct AutoUpdateControllerTests {
         #expect(recorder.events == ["claim", "check", "stage", "beginDraining", "waitForDrain", "commit", "restart"])
         #expect(!recorder.events.contains("forceCancel"))
         #expect(!recorder.events.contains("resume")) // restart succeeded → no resume
+    }
+
+    @Test("already-installed candidate drains and restarts without staging or commit")
+    func installedCandidateRestartsWithoutReinstall() async {
+        let recorder = Recorder()
+        let controller = makeController(
+            Fakes(checkResult: .restartRequired(
+                current: "1.0.0",
+                installed: "2.0.0"
+            )),
+            recorder: recorder
+        )
+
+        let outcome = await controller.run()
+
+        #expect(outcome == .restarted(
+            from: "1.0.0",
+            to: "2.0.0",
+            drained: true
+        ))
+        #expect(recorder.events == [
+            "claim",
+            "check",
+            "beginDraining",
+            "waitForDrain",
+            "prepareRestart",
+            "restart",
+        ])
     }
 
     @Test("drain timeout: force-cancels stragglers, then commits and restarts anyway")

--- a/provider-swift/Tests/ProviderCoreTests/AutoUpdateControllerTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/AutoUpdateControllerTests.swift
@@ -150,7 +150,7 @@ struct AutoUpdateControllerTests {
         // Strict order: download/stage happens BEFORE we stop accepting work,
         // and the live-layout commit happens strictly AFTER the drain so no
         // request can observe a half-replaced bundle.
-        #expect(recorder.events == ["claim", "check", "stage", "beginDraining", "waitForDrain", "commit", "restart"])
+        #expect(recorder.events == ["claim", "check", "stage", "beginDraining", "waitForDrain", "commit", "prepareRestart", "restart"])
         #expect(!recorder.events.contains("forceCancel"))
         #expect(!recorder.events.contains("resume")) // restart succeeded → no resume
     }
@@ -193,7 +193,7 @@ struct AutoUpdateControllerTests {
         let outcome = await controller.run()
 
         #expect(outcome == .restarted(from: "1.0.0", to: "2.0.0", drained: false))
-        #expect(recorder.events == ["claim", "check", "stage", "beginDraining", "waitForDrain", "forceCancel", "commit", "restart"])
+        #expect(recorder.events == ["claim", "check", "stage", "beginDraining", "waitForDrain", "forceCancel", "commit", "prepareRestart", "restart"])
     }
 
     @Test("commit failure: resumes serving on the old binary, never restarts")
@@ -223,6 +223,6 @@ struct AutoUpdateControllerTests {
             Issue.record("expected .restartFailed, got \(outcome)")
             return
         }
-        #expect(recorder.events == ["claim", "check", "stage", "beginDraining", "waitForDrain", "commit", "restart", "resume"])
+        #expect(recorder.events == ["claim", "check", "stage", "beginDraining", "waitForDrain", "commit", "prepareRestart", "restart", "resume"])
     }
 }

--- a/provider-swift/Tests/ProviderCoreTests/Helpers/MockCoordinator.swift
+++ b/provider-swift/Tests/ProviderCoreTests/Helpers/MockCoordinator.swift
@@ -160,6 +160,7 @@ public final class MockCoordinator: @unchecked Sendable {
 
     public let catalog: [CatalogModel]
     public let release: MockReleaseFixture
+    public let releaseArtifact: Data?
     public let version: MockVersionFixture
     public let mobileConfig: Data
     public let deviceCode: MockDeviceCodeFixture
@@ -188,12 +189,14 @@ public final class MockCoordinator: @unchecked Sendable {
     public init(
         catalog: [CatalogModel] = MockCoordinator.defaultCatalog,
         release: MockReleaseFixture = MockReleaseFixture(),
+        releaseArtifact: Data? = nil,
         version: MockVersionFixture = MockVersionFixture(version: "0.5.0"),
         mobileConfig: Data = MockCoordinator.defaultMobileConfig,
         deviceCode: MockDeviceCodeFixture = MockDeviceCodeFixture()
     ) {
         self.catalog = catalog
         self.release = release
+        self.releaseArtifact = releaseArtifact
         self.version = version
         self.mobileConfig = mobileConfig
         self.deviceCode = deviceCode
@@ -443,15 +446,39 @@ public final class MockCoordinator: @unchecked Sendable {
                     body: ["error": "mock dead"], status: .internalServerError
                 )
             }
+            let releaseURL: String
+            if self.release.url == "mock://release-artifact" {
+                releaseURL = self.lock.withLock {
+                    self.bound?.baseURL
+                        .appendingPathComponent("mock-release-artifact")
+                        .absoluteString
+                } ?? self.release.url
+            } else {
+                releaseURL = self.release.url
+            }
             let body = ReleaseLatestPayload(
                 version: self.release.version,
                 platform: self.release.platform,
-                url: self.release.url,
+                url: releaseURL,
                 bundle_hash: self.release.bundleHash,
                 binary_hash: self.release.binaryHash,
                 metallib_hash: self.release.metallibHash
             )
             return MockCoordinator.makeJSONResponse(body: body)
+        }
+
+        router.get("/mock-release-artifact") { [weak self] _, _ -> Response in
+            guard let artifact = self?.releaseArtifact else {
+                return MockCoordinator.makeJSONResponse(
+                    body: ["error": "release artifact missing"],
+                    status: .notFound
+                )
+            }
+            return Response(
+                status: .ok,
+                headers: [.contentType: "application/gzip"],
+                body: .init(byteBuffer: ByteBuffer(bytes: artifact))
+            )
         }
 
         // ----- HTTP: /api/version (UpdateBanner) -----

--- a/provider-swift/Tests/ProviderCoreTests/Helpers/UpdateRecoveryFixture.swift
+++ b/provider-swift/Tests/ProviderCoreTests/Helpers/UpdateRecoveryFixture.swift
@@ -10,6 +10,7 @@ struct UpdateRecoveryFixture {
     let release: ReleaseInfo
     let oldVersion: String
     let newVersion: String
+    let layout: VerifiedPredecessor.Layout
     private let preservedFiles: [String: String] = [
         "provider.toml": "provider-config",
         "auth-token": "provider-token",
@@ -18,7 +19,11 @@ struct UpdateRecoveryFixture {
         "io.darkbloom.provider.plist": "launchd-selection",
     ]
 
-    init(oldVersion: String = "1.0.0", newVersion: String = "2.0.0") throws {
+    init(
+        oldVersion: String = "1.0.0",
+        newVersion: String = "2.0.0",
+        layout: VerifiedPredecessor.Layout = .app
+    ) throws {
         let fm = FileManager.default
         root = fm.temporaryDirectory.appendingPathComponent(
             "update-recovery-\(UUID().uuidString)",
@@ -28,9 +33,14 @@ struct UpdateRecoveryFixture {
         tarball = root.appendingPathComponent("release.tar.gz")
         self.oldVersion = oldVersion
         self.newVersion = newVersion
+        self.layout = layout
 
-        try Self.writeApp(version: oldVersion, root: installRoot)
-        try Self.writeCanonicalLinks(root: installRoot)
+        if layout == .app {
+            try Self.writeApp(version: oldVersion, root: installRoot)
+            try Self.writeCanonicalLinks(root: installRoot)
+        } else {
+            try Self.writeFlat(version: oldVersion, root: installRoot)
+        }
         for (relativePath, contents) in preservedFiles {
             let file = installRoot.appendingPathComponent(relativePath)
             try fm.createDirectory(
@@ -41,15 +51,19 @@ struct UpdateRecoveryFixture {
         }
 
         let releaseSource = root.appendingPathComponent("release-source", isDirectory: true)
-        try Self.writeApp(version: newVersion, root: releaseSource)
         let flatBin = releaseSource.appendingPathComponent("bin", isDirectory: true)
-        try fm.createDirectory(at: flatBin, withIntermediateDirectories: true)
-        let appBin = releaseSource.appendingPathComponent("Darkbloom.app/Contents/MacOS")
-        for name in ["darkbloom", "darkbloom-enclave", "mlx.metallib"] {
-            try fm.copyItem(
-                at: appBin.appendingPathComponent(name),
-                to: flatBin.appendingPathComponent(name)
-            )
+        if layout == .app {
+            try Self.writeApp(version: newVersion, root: releaseSource)
+            try fm.createDirectory(at: flatBin, withIntermediateDirectories: true)
+            let appBin = releaseSource.appendingPathComponent("Darkbloom.app/Contents/MacOS")
+            for name in ["darkbloom", "darkbloom-enclave", "mlx.metallib"] {
+                try fm.copyItem(
+                    at: appBin.appendingPathComponent(name),
+                    to: flatBin.appendingPathComponent(name)
+                )
+            }
+        } else {
+            try Self.writeFlat(version: newVersion, root: releaseSource)
         }
 
         try Self.runTar(source: releaseSource, destination: tarball)
@@ -90,9 +104,11 @@ struct UpdateRecoveryFixture {
     }
 
     func liveBinaryContents() throws -> String {
-        try String(
-            contentsOf: installRoot
-                .appendingPathComponent("Darkbloom.app/Contents/MacOS/darkbloom"),
+        let relative = layout == .app
+            ? "Darkbloom.app/Contents/MacOS/darkbloom"
+            : "bin/darkbloom"
+        return try String(
+            contentsOf: installRoot.appendingPathComponent(relative),
             encoding: .utf8
         )
     }
@@ -134,6 +150,25 @@ struct UpdateRecoveryFixture {
         try fm.createSymbolicLink(
             atPath: bin.appendingPathComponent("mlx.metallib").path,
             withDestinationPath: "../Darkbloom.app/Contents/MacOS/mlx.metallib"
+        )
+        try fm.createSymbolicLink(
+            atPath: bin.appendingPathComponent("eigeninference-enclave").path,
+            withDestinationPath: "darkbloom-enclave"
+        )
+    }
+
+    static func writeFlat(version: String, root: URL) throws {
+        let fm = FileManager.default
+        let bin = root.appendingPathComponent("bin")
+        try fm.createDirectory(at: bin, withIntermediateDirectories: true)
+        try Data("\(version)-darkbloom".utf8).write(
+            to: bin.appendingPathComponent("darkbloom")
+        )
+        try Data("\(version)-enclave".utf8).write(
+            to: bin.appendingPathComponent("darkbloom-enclave")
+        )
+        try Data("\(version)-metallib".utf8).write(
+            to: bin.appendingPathComponent("mlx.metallib")
         )
         try fm.createSymbolicLink(
             atPath: bin.appendingPathComponent("eigeninference-enclave").path,

--- a/provider-swift/Tests/ProviderCoreTests/Helpers/UpdateRecoveryFixture.swift
+++ b/provider-swift/Tests/ProviderCoreTests/Helpers/UpdateRecoveryFixture.swift
@@ -212,6 +212,21 @@ struct UpdateRecoveryFixture {
     }
 }
 
+/// One-shot latch for fault injectors: the first `claim()` wins, replays
+/// (e.g. transaction recovery through the same store) do not re-fire.
+final class OneShotFault: @unchecked Sendable {
+    private let lock = NSLock()
+    private var fired = false
+
+    func claim() -> Bool {
+        lock.withLock {
+            guard !fired else { return false }
+            fired = true
+            return true
+        }
+    }
+}
+
 final class RecoveryRestartCounter: @unchecked Sendable {
     private let lock = NSLock()
     private var storage = 0

--- a/provider-swift/Tests/ProviderCoreTests/Helpers/UpdateRecoveryFixture.swift
+++ b/provider-swift/Tests/ProviderCoreTests/Helpers/UpdateRecoveryFixture.swift
@@ -10,7 +10,12 @@ struct UpdateRecoveryFixture {
     let release: ReleaseInfo
     let oldVersion: String
     let newVersion: String
+    /// Layout of the initially-installed (predecessor) tree.
     let layout: VerifiedPredecessor.Layout
+    /// Layout of the release the update installs. Defaults to `layout`; set it
+    /// differently to model a legacy flat install updating to an .app candidate
+    /// (the flat→app→rollback path).
+    let candidateLayout: VerifiedPredecessor.Layout
     private let preservedFiles: [String: String] = [
         "provider.toml": "provider-config",
         "auth-token": "provider-token",
@@ -22,7 +27,8 @@ struct UpdateRecoveryFixture {
     init(
         oldVersion: String = "1.0.0",
         newVersion: String = "2.0.0",
-        layout: VerifiedPredecessor.Layout = .app
+        layout: VerifiedPredecessor.Layout = .app,
+        candidateLayout: VerifiedPredecessor.Layout? = nil
     ) throws {
         let fm = FileManager.default
         root = fm.temporaryDirectory.appendingPathComponent(
@@ -34,6 +40,7 @@ struct UpdateRecoveryFixture {
         self.oldVersion = oldVersion
         self.newVersion = newVersion
         self.layout = layout
+        self.candidateLayout = candidateLayout ?? layout
 
         if layout == .app {
             try Self.writeApp(version: oldVersion, root: installRoot)
@@ -52,7 +59,7 @@ struct UpdateRecoveryFixture {
 
         let releaseSource = root.appendingPathComponent("release-source", isDirectory: true)
         let flatBin = releaseSource.appendingPathComponent("bin", isDirectory: true)
-        if layout == .app {
+        if self.candidateLayout == .app {
             try Self.writeApp(version: newVersion, root: releaseSource)
             try fm.createDirectory(at: flatBin, withIntermediateDirectories: true)
             let appBin = releaseSource.appendingPathComponent("Darkbloom.app/Contents/MacOS")
@@ -110,6 +117,23 @@ struct UpdateRecoveryFixture {
         return try String(
             contentsOf: installRoot.appendingPathComponent(relative),
             encoding: .utf8
+        )
+    }
+
+    /// Contents that `bin/darkbloom` RESOLVES to (following any symlink into a
+    /// Darkbloom.app). After a flat rollback this must be the flat predecessor's
+    /// real binary, not a symlink pointing back into a leftover candidate app.
+    func liveFlatBinaryResolvedContents() throws -> String {
+        try String(
+            contentsOf: installRoot.appendingPathComponent("bin/darkbloom"),
+            encoding: .utf8
+        )
+    }
+
+    /// Whether a `Darkbloom.app` bundle is present at the install root.
+    func appBundleExists() -> Bool {
+        FileManager.default.fileExists(
+            atPath: installRoot.appendingPathComponent("Darkbloom.app").path
         )
     }
 

--- a/provider-swift/Tests/ProviderCoreTests/Helpers/UpdateRecoveryFixture.swift
+++ b/provider-swift/Tests/ProviderCoreTests/Helpers/UpdateRecoveryFixture.swift
@@ -1,0 +1,171 @@
+import Foundation
+import Testing
+@testable import ProviderCore
+
+struct UpdateRecoveryFixture {
+    let root: URL
+    let installRoot: URL
+    let tarball: URL
+    let artifact: Data
+    let release: ReleaseInfo
+    let oldVersion: String
+    let newVersion: String
+    private let preservedFiles: [String: String] = [
+        "provider.toml": "provider-config",
+        "auth-token": "provider-token",
+        "loaded-models.json": "[\"model-a\"]",
+        "models/model-a/cache.bin": "model-cache",
+        "io.darkbloom.provider.plist": "launchd-selection",
+    ]
+
+    init(oldVersion: String = "1.0.0", newVersion: String = "2.0.0") throws {
+        let fm = FileManager.default
+        root = fm.temporaryDirectory.appendingPathComponent(
+            "update-recovery-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        installRoot = root.appendingPathComponent("install", isDirectory: true)
+        tarball = root.appendingPathComponent("release.tar.gz")
+        self.oldVersion = oldVersion
+        self.newVersion = newVersion
+
+        try Self.writeApp(version: oldVersion, root: installRoot)
+        try Self.writeCanonicalLinks(root: installRoot)
+        for (relativePath, contents) in preservedFiles {
+            let file = installRoot.appendingPathComponent(relativePath)
+            try fm.createDirectory(
+                at: file.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try Data(contents.utf8).write(to: file)
+        }
+
+        let releaseSource = root.appendingPathComponent("release-source", isDirectory: true)
+        try Self.writeApp(version: newVersion, root: releaseSource)
+        let flatBin = releaseSource.appendingPathComponent("bin", isDirectory: true)
+        try fm.createDirectory(at: flatBin, withIntermediateDirectories: true)
+        let appBin = releaseSource.appendingPathComponent("Darkbloom.app/Contents/MacOS")
+        for name in ["darkbloom", "darkbloom-enclave", "mlx.metallib"] {
+            try fm.copyItem(
+                at: appBin.appendingPathComponent(name),
+                to: flatBin.appendingPathComponent(name)
+            )
+        }
+
+        try Self.runTar(source: releaseSource, destination: tarball)
+        artifact = try Data(contentsOf: tarball)
+        release = ReleaseInfo(
+            version: newVersion,
+            platform: "macos-arm64",
+            url: "mock://release-artifact",
+            bundleHash: sha256Hex(artifact),
+            binaryHash: sha256Hex(try Data(contentsOf: flatBin.appendingPathComponent("darkbloom"))),
+            metallibHash: sha256Hex(try Data(contentsOf: flatBin.appendingPathComponent("mlx.metallib")))
+        )
+    }
+
+    func cleanup() {
+        try? FileManager.default.removeItem(at: root)
+    }
+
+    func updater(baseURL: URL) -> SelfUpdater {
+        SelfUpdater(
+            coordinatorBaseURL: baseURL.absoluteString,
+            installRoot: installRoot,
+            verifyCodeSignatures: false,
+            currentVersion: oldVersion,
+            now: { 100 }
+        )
+    }
+
+    func mockReleaseFixture() -> MockReleaseFixture {
+        MockReleaseFixture(
+            version: release.version,
+            platform: release.platform,
+            url: release.url,
+            bundleHash: release.bundleHash,
+            binaryHash: release.binaryHash,
+            metallibHash: release.metallibHash
+        )
+    }
+
+    func liveBinaryContents() throws -> String {
+        try String(
+            contentsOf: installRoot
+                .appendingPathComponent("Darkbloom.app/Contents/MacOS/darkbloom"),
+            encoding: .utf8
+        )
+    }
+
+    func persistentStateIsIntact() throws -> Bool {
+        for (relativePath, expected) in preservedFiles {
+            let contents = try String(
+                contentsOf: installRoot.appendingPathComponent(relativePath),
+                encoding: .utf8
+            )
+            if contents != expected { return false }
+        }
+        return true
+    }
+
+    static func writeApp(version: String, root: URL) throws {
+        let fm = FileManager.default
+        let contents = root.appendingPathComponent("Darkbloom.app/Contents")
+        let appBin = contents.appendingPathComponent("MacOS")
+        try fm.createDirectory(at: appBin, withIntermediateDirectories: true)
+        try Data("<plist/>".utf8).write(to: contents.appendingPathComponent("Info.plist"))
+        try Data("\(version)-darkbloom".utf8).write(to: appBin.appendingPathComponent("darkbloom"))
+        try Data("\(version)-enclave".utf8).write(to: appBin.appendingPathComponent("darkbloom-enclave"))
+        try Data("\(version)-metallib".utf8).write(to: appBin.appendingPathComponent("mlx.metallib"))
+    }
+
+    static func writeCanonicalLinks(root: URL) throws {
+        let fm = FileManager.default
+        let bin = root.appendingPathComponent("bin")
+        try fm.createDirectory(at: bin, withIntermediateDirectories: true)
+        try fm.createSymbolicLink(
+            atPath: bin.appendingPathComponent("darkbloom").path,
+            withDestinationPath: "../Darkbloom.app/Contents/MacOS/darkbloom"
+        )
+        try fm.createSymbolicLink(
+            atPath: bin.appendingPathComponent("darkbloom-enclave").path,
+            withDestinationPath: "../Darkbloom.app/Contents/MacOS/darkbloom-enclave"
+        )
+        try fm.createSymbolicLink(
+            atPath: bin.appendingPathComponent("mlx.metallib").path,
+            withDestinationPath: "../Darkbloom.app/Contents/MacOS/mlx.metallib"
+        )
+        try fm.createSymbolicLink(
+            atPath: bin.appendingPathComponent("eigeninference-enclave").path,
+            withDestinationPath: "darkbloom-enclave"
+        )
+    }
+
+    private static func runTar(source: URL, destination: URL) throws {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/tar")
+        process.arguments = ["czf", destination.path, "-C", source.path, "."]
+        try process.run()
+        process.waitUntilExit()
+        guard process.terminationStatus == 0 else {
+            throw CocoaError(.fileWriteUnknown)
+        }
+    }
+}
+
+final class RecoveryRestartCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage = 0
+
+    var value: Int {
+        lock.withLock { storage }
+    }
+
+    @discardableResult
+    func increment() -> Int {
+        lock.withLock {
+            storage += 1
+            return storage
+        }
+    }
+}

--- a/provider-swift/Tests/ProviderCoreTests/SelfUpdaterTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/SelfUpdaterTests.swift
@@ -4,6 +4,74 @@ import Testing
 
 @Suite("SelfUpdater")
 struct SelfUpdaterTests {
+    @Test("SemVer prerelease ordering is exact")
+    func semverPrereleaseOrdering() {
+        #expect(SelfUpdater.isNewer(
+            latest: "0.8.0-dev.2",
+            current: "0.8.0-dev.1"
+        ))
+        #expect(SelfUpdater.isNewer(
+            latest: "0.8.0",
+            current: "0.8.0-dev.9"
+        ))
+        #expect(!SelfUpdater.isNewer(
+            latest: "0.8.0-dev.1",
+            current: "0.8.0"
+        ))
+        #expect(SelfUpdater.isNewer(
+            latest: "0.8.0-rc.1",
+            current: "0.8.0-beta.11"
+        ))
+        #expect(!SelfUpdater.isNewer(
+            latest: "0.8.0-dev.01",
+            current: "0.8.0-dev.1"
+        ))
+    }
+
+    #if canImport(Darwin)
+    @Test("real packaged code signature is verified and production pin rejects ad hoc signer")
+    func realPackagedSignatureVerification() throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "codesign-fixture-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        defer { try? FileManager.default.removeItem(at: root) }
+        let app = root.appendingPathComponent("Darkbloom.app")
+        let contents = app.appendingPathComponent("Contents")
+        let bin = contents.appendingPathComponent("MacOS")
+        try FileManager.default.createDirectory(
+            at: bin,
+            withIntermediateDirectories: true
+        )
+        let plist = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <plist version="1.0"><dict>
+        <key>CFBundleIdentifier</key><string>io.darkbloom.provider</string>
+        <key>CFBundleExecutable</key><string>darkbloom</string>
+        <key>CFBundlePackageType</key><string>APPL</string>
+        </dict></plist>
+        """
+        try Data(plist.utf8).write(
+            to: contents.appendingPathComponent("Info.plist")
+        )
+        for name in ["darkbloom", "darkbloom-enclave", "mlx.metallib"] {
+            try FileManager.default.copyItem(
+                at: URL(fileURLWithPath: "/usr/bin/true"),
+                to: bin.appendingPathComponent(name)
+            )
+        }
+        try runCodesign(["--force", "--deep", "--sign", "-", app.path])
+
+        try DarkbloomCodeSignature.verify(
+            app,
+            deep: true,
+            policy: .structuralForIsolatedTest
+        )
+        #expect(throws: (any Error).self) {
+            try DarkbloomCodeSignature.verify(app, deep: true)
+        }
+    }
+    #endif
 
     @Test("release endpoint preserves bundle, binary, and metallib hashes")
     func releaseEndpointPreservesAllHashes() async throws {
@@ -381,6 +449,17 @@ private func runTarCreate(sourceDir: URL, tarball: URL) throws {
     try process.run()
     process.waitUntilExit()
     #expect(process.terminationStatus == 0)
+}
+
+private func runCodesign(_ arguments: [String]) throws {
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/usr/bin/codesign")
+    process.arguments = arguments
+    try process.run()
+    process.waitUntilExit()
+    guard process.terminationStatus == 0 else {
+        throw CocoaError(.fileWriteUnknown)
+    }
 }
 
 // MARK: - installRoot derivation (symlink regression)

--- a/provider-swift/Tests/ProviderCoreTests/SelfUpdaterTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/SelfUpdaterTests.swift
@@ -4,6 +4,20 @@ import Testing
 
 @Suite("SelfUpdater")
 struct SelfUpdaterTests {
+    @Test("production public init always verifies code signatures")
+    func productionInitVerifiesSignatures() {
+        // The only way to disable the signature pin is the internal
+        // `verifyCodeSignatures:` seam used by tests/fixtures; the public
+        // production initializer must never select the unsigned path.
+        #expect(SelfUpdater(coordinatorBaseURL: "https://api.example").verifiesCodeSignatures)
+        #expect(
+            SelfUpdater(
+                coordinatorBaseURL: "https://api.example",
+                urlSession: SelfUpdater.watchdogURLSession()
+            ).verifiesCodeSignatures
+        )
+    }
+
     @Test("SemVer prerelease ordering is exact")
     func semverPrereleaseOrdering() {
         #expect(SelfUpdater.isNewer(

--- a/provider-swift/Tests/ProviderCoreTests/SelfUpdaterTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/SelfUpdaterTests.swift
@@ -28,6 +28,25 @@ struct SelfUpdaterTests {
         #expect(latest.metallibHash == String(repeating: "c", count: 64))
     }
 
+    @Test("release endpoint refuses a mismatched platform")
+    func releaseEndpointRefusesWrongPlatform() async throws {
+        let mock = MockCoordinator(release: MockReleaseFixture(
+            version: "99.0.0",
+            platform: "linux-amd64"
+        ))
+        let baseURL = try await mock.start()
+        defer { Task { await mock.shutdown() } }
+
+        let result = await SelfUpdater(
+            coordinatorBaseURL: baseURL.absoluteString
+        ).checkForUpdate()
+        guard case .checkFailed(let reason) = result else {
+            Issue.record("wrong-platform release was accepted")
+            return
+        }
+        #expect(reason.contains("unsupported release platform"))
+    }
+
     @Test("ReleaseInfo sha256 compatibility returns bundle hash")
     func releaseInfoShaCompatibility() {
         let hash = String(repeating: "d", count: 64)
@@ -52,6 +71,11 @@ struct SelfUpdaterTests {
 
         try FileManager.default.createDirectory(at: bin, withIntermediateDirectories: true)
         try FileManager.default.createDirectory(at: install, withIntermediateDirectories: true)
+        let oldBin = install.appendingPathComponent("bin")
+        try FileManager.default.createDirectory(at: oldBin, withIntermediateDirectories: true)
+        try Data("old darkbloom".utf8).write(to: oldBin.appendingPathComponent("darkbloom"))
+        try Data("old enclave".utf8).write(to: oldBin.appendingPathComponent("darkbloom-enclave"))
+        try Data("old metallib".utf8).write(to: oldBin.appendingPathComponent("mlx.metallib"))
         let darkbloom = bin.appendingPathComponent("darkbloom")
         let enclave = bin.appendingPathComponent("darkbloom-enclave")
         let metallib = bin.appendingPathComponent("mlx.metallib")
@@ -103,6 +127,11 @@ struct SelfUpdaterTests {
         try FileManager.default.createDirectory(at: appMacOS, withIntermediateDirectories: true)
         try FileManager.default.createDirectory(at: binFlat, withIntermediateDirectories: true)
         try FileManager.default.createDirectory(at: install, withIntermediateDirectories: true)
+        let oldAppBin = install.appendingPathComponent("Darkbloom.app/Contents/MacOS")
+        try FileManager.default.createDirectory(at: oldAppBin, withIntermediateDirectories: true)
+        try Data("old app darkbloom".utf8).write(to: oldAppBin.appendingPathComponent("darkbloom"))
+        try Data("old app enclave".utf8).write(to: oldAppBin.appendingPathComponent("darkbloom-enclave"))
+        try Data("old app metallib".utf8).write(to: oldAppBin.appendingPathComponent("mlx.metallib"))
 
         // Write Info.plist for the .app bundle.
         let infoDir = stage.appendingPathComponent("Darkbloom.app/Contents")
@@ -192,6 +221,7 @@ struct SelfUpdaterTests {
         try fm.createDirectory(at: liveMacOS, withIntermediateDirectories: true)
         try fm.createDirectory(at: liveBin, withIntermediateDirectories: true)
         try Data("old darkbloom".utf8).write(to: liveMacOS.appendingPathComponent("darkbloom"))
+        try Data("old enclave".utf8).write(to: liveMacOS.appendingPathComponent("darkbloom-enclave"))
         try Data("old metallib".utf8).write(to: liveMacOS.appendingPathComponent("mlx.metallib"))
         try fm.createSymbolicLink(
             atPath: liveBin.appendingPathComponent("mlx.metallib").path,
@@ -256,7 +286,7 @@ struct SelfUpdaterTests {
             return
         }
 
-        let result = updater.commitStagedBundle(staged)
+        let result = updater.commitStagedBundleForTesting(staged)
         guard case .success = result else {
             Issue.record("commitStagedBundle failed: \(result)")
             return
@@ -271,6 +301,41 @@ struct SelfUpdaterTests {
         let leftovers = try FileManager.default.contentsOfDirectory(atPath: install.path)
             .filter { $0.hasPrefix(".update-staging-") || $0.hasPrefix(".update-backup-") }
         #expect(leftovers.isEmpty)
+    }
+
+    @Test("commit refuses a staged tree changed after verification")
+    func commitRefusesPostStageMutation() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(
+                "self-updater-stage-mutation-\(UUID().uuidString)",
+                isDirectory: true
+            )
+        defer { try? FileManager.default.removeItem(at: root) }
+        let (tarball, release, install) = try makeAppBundleFixture(root: root)
+        let updater = SelfUpdater(coordinatorBaseURL: "https://api.example.test")
+        guard case .success(let staged) = updater.stageBundleForTesting(
+            from: tarball,
+            release: release,
+            installDir: install
+        ) else {
+            Issue.record("stageBundleForTesting failed")
+            return
+        }
+        try Data("post-verification tamper".utf8).write(
+            to: staged.stagingRoot
+                .appendingPathComponent("Darkbloom.app/Contents/Info.plist")
+        )
+
+        guard case .failure(let error) = updater.commitStagedBundleForTesting(staged) else {
+            Issue.record("mutated staging tree was installed")
+            return
+        }
+        #expect("\(error)".contains("changed after verification"))
+        #expect(try String(
+            contentsOf: install.appendingPathComponent(
+                "Darkbloom.app/Contents/MacOS/darkbloom"),
+            encoding: .utf8
+        ) == "old darkbloom")
     }
 
     @Test("a later staging pass removes OLD orphaned staging dirs but spares young (possibly live) ones")

--- a/provider-swift/Tests/ProviderCoreTests/SelfUpdaterTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/SelfUpdaterTests.swift
@@ -18,6 +18,35 @@ struct SelfUpdaterTests {
         )
     }
 
+    @Test("effective installed version prefers the newer of process and durable record")
+    func effectiveInstalledVersionSelection() {
+        // Surviving watchdog: process is older than the promoted disk install.
+        #expect(SelfUpdater.effectiveInstalledVersion(
+            processVersion: "1.0.0",
+            recorded: "2.0.0"
+        ) == "2.0.0")
+        // Manual reinstall bypassed recovery state: process is newer.
+        #expect(SelfUpdater.effectiveInstalledVersion(
+            processVersion: "3.0.0",
+            recorded: "1.0.0"
+        ) == "3.0.0")
+        // No durable record (fresh install) → process version.
+        #expect(SelfUpdater.effectiveInstalledVersion(
+            processVersion: "1.0.0",
+            recorded: nil
+        ) == "1.0.0")
+        // Invalid durable record → process version.
+        #expect(SelfUpdater.effectiveInstalledVersion(
+            processVersion: "1.0.0",
+            recorded: "not-a-version"
+        ) == "1.0.0")
+        // Invalid process version → durable record.
+        #expect(SelfUpdater.effectiveInstalledVersion(
+            processVersion: "dev",
+            recorded: "2.0.0"
+        ) == "2.0.0")
+    }
+
     @Test("SemVer prerelease ordering is exact")
     func semverPrereleaseOrdering() {
         #expect(SelfUpdater.isNewer(

--- a/provider-swift/Tests/ProviderCoreTests/UpdateProcessLockTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/UpdateProcessLockTests.swift
@@ -24,6 +24,7 @@ struct UpdateProcessLockTests {
         } catch UpdateProcessLock.LockError.busy(let owner) {
             #expect(owner?.operation == "first")
             #expect(owner?.pid == getpid())
+            #expect(owner?.processIdentity == ProcessIdentity.current())
         }
     }
 
@@ -82,6 +83,100 @@ struct UpdateProcessLockTests {
             timeout: 1
         )
         recovered.release()
+    }
+
+    @Test("watchdog kills only matching stale provider lock owner")
+    func watchdogRecoversWedgedProviderOwner() async throws {
+        let fixture = try UpdateRecoveryFixture()
+        defer { fixture.cleanup() }
+        let store = UpdateRecoveryStore(
+            installRoot: fixture.installRoot,
+            verifyCodeSignatures: false
+        )
+        try FileManager.default.createDirectory(
+            at: store.recoveryRoot,
+            withIntermediateDirectories: true
+        )
+        let child = Process()
+        child.executableURL = URL(fileURLWithPath: "/usr/bin/perl")
+        child.arguments = [
+            "-e",
+            """
+            use Fcntl qw(:flock);
+            $| = 1;
+            open(my $fh, '>>', $ARGV[0]) or die $!;
+            flock($fh, LOCK_EX) or die $!;
+            print '1';
+            sleep 30;
+            """,
+            store.lockPath.path,
+        ]
+        let output = Pipe()
+        child.standardOutput = output
+        child.standardError = FileHandle.nullDevice
+        try child.run()
+        defer {
+            if child.isRunning {
+                _ = kill(child.processIdentifier, SIGKILL)
+                child.waitUntilExit()
+            }
+        }
+        #expect(
+            output.fileHandleForReading.readData(ofLength: 1)
+                == Data("1".utf8)
+        )
+        guard let identity = ProcessIdentity.read(
+            pid: child.processIdentifier
+        ) else {
+            Issue.record("could not read child process identity")
+            return
+        }
+        let owner = UpdateProcessLock.Owner(
+            pid: child.processIdentifier,
+            processIdentity: identity,
+            operation: "wedged-provider-update",
+            acquiredAt: 1
+        )
+        let ownerData = try JSONEncoder().encode(owner)
+        let handle = try FileHandle(forWritingTo: store.lockPath)
+        try handle.truncate(atOffset: 0)
+        try handle.write(contentsOf: ownerData)
+        try handle.synchronize()
+        try handle.close()
+
+        let updater = SelfUpdater(
+            coordinatorBaseURL: "http://127.0.0.1:1",
+            installRoot: fixture.installRoot,
+            verifyCodeSignatures: false,
+            currentVersion: fixture.oldVersion
+        )
+        let service = WatchdogRecoveryService(
+            updater: updater,
+            dependencies: .init(
+                kickstartIfLoaded: { true },
+                providerStillLoaded: { true },
+                terminateStaleLockOwner: { candidate in
+                    guard candidate.processIdentity == identity,
+                          identity.isCurrent()
+                    else {
+                        return false
+                    }
+                    _ = kill(identity.pid, SIGKILL)
+                    child.waitUntilExit()
+                    return !identity.isCurrent()
+                },
+                log: { _ in }
+            )
+        )
+        let result = await service.recoverDownProvider(
+            autoUpdateEnabled: false,
+            inactiveProviderIdentity: identity,
+            now: 100
+        )
+        #expect(result == .restartIssued(
+            updatedTo: nil,
+            rolledBackTo: nil
+        ))
     }
     #endif
 }

--- a/provider-swift/Tests/ProviderCoreTests/UpdateProcessLockTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/UpdateProcessLockTests.swift
@@ -1,0 +1,87 @@
+import Foundation
+import Testing
+@testable import ProviderCore
+#if canImport(Darwin)
+import Darwin
+#endif
+
+@Suite("Cross-process update lock", .serialized)
+struct UpdateProcessLockTests {
+    @Test("concurrent owner is refused")
+    func contention() throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "update-lock-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        let path = root.appendingPathComponent("update.lock")
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let first = try UpdateProcessLock.acquire(at: path, operation: "first")
+        defer { first.release() }
+        do {
+            _ = try UpdateProcessLock.acquire(at: path, operation: "second")
+            Issue.record("second owner acquired an already-held lock")
+        } catch UpdateProcessLock.LockError.busy(let owner) {
+            #expect(owner?.operation == "first")
+            #expect(owner?.pid == getpid())
+        }
+    }
+
+    #if canImport(Darwin)
+    @Test("kernel releases lock after owner is killed")
+    func crashedOwnerRecovery() throws {
+        let fm = FileManager.default
+        let root = fm.temporaryDirectory.appendingPathComponent(
+            "update-lock-crash-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        let path = root.appendingPathComponent("update.lock")
+        try fm.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? fm.removeItem(at: root) }
+
+        let child = Process()
+        child.executableURL = URL(fileURLWithPath: "/usr/bin/perl")
+        child.arguments = [
+            "-e",
+            """
+            use Fcntl qw(:flock);
+            $| = 1;
+            open(my $fh, '>>', $ARGV[0]) or die $!;
+            flock($fh, LOCK_EX) or die $!;
+            print '1';
+            sleep 30;
+            """,
+            path.path,
+        ]
+        let output = Pipe()
+        child.standardOutput = output
+        child.standardError = FileHandle.nullDevice
+        try child.run()
+        defer {
+            if child.isRunning {
+                _ = kill(child.processIdentifier, SIGKILL)
+                child.waitUntilExit()
+            }
+        }
+        let ready = output.fileHandleForReading.readData(ofLength: 1)
+        #expect(ready == Data("1".utf8))
+
+        do {
+            _ = try UpdateProcessLock.acquire(at: path, operation: "parent")
+            Issue.record("parent acquired child-owned lock")
+        } catch UpdateProcessLock.LockError.busy {
+            // Expected.
+        }
+
+        _ = kill(child.processIdentifier, SIGKILL)
+        child.waitUntilExit()
+
+        let recovered = try UpdateProcessLock.acquire(
+            at: path,
+            operation: "recovered",
+            timeout: 1
+        )
+        recovered.release()
+    }
+    #endif
+}

--- a/provider-swift/Tests/ProviderCoreTests/UpdateProcessLockTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/UpdateProcessLockTests.swift
@@ -154,6 +154,7 @@ struct UpdateProcessLockTests {
             updater: updater,
             dependencies: .init(
                 kickstartIfLoaded: { true },
+                launchSnapshot: { nil },
                 providerStillLoaded: { true },
                 terminateStaleLockOwner: { candidate in
                     guard candidate.processIdentity == identity,

--- a/provider-swift/Tests/ProviderCoreTests/UpdateRecoveryStateTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/UpdateRecoveryStateTests.swift
@@ -1,0 +1,160 @@
+import Foundation
+import Testing
+@testable import ProviderCore
+
+@Suite("Update recovery state")
+struct UpdateRecoveryStateTests {
+    @Test("failed start is counted once per armed attempt")
+    func countsOneFailurePerAttempt() {
+        var state = makeCandidateState()
+        let firstFailure = state.recordPendingAttemptFailure(now: 100)
+        let duplicateTick = state.recordPendingAttemptFailure(now: 101)
+        #expect(firstFailure == 1)
+        #expect(duplicateTick == nil)
+        #expect(state.candidate?.failureCount == 1)
+
+        let armed = state.armCandidateAttempt(now: 200)
+        let secondFailure = state.recordPendingAttemptFailure(now: 201)
+        let secondDuplicate = state.recordPendingAttemptFailure(now: 202)
+        #expect(armed)
+        #expect(secondFailure == 2)
+        #expect(secondDuplicate == nil)
+    }
+
+    @Test("continuous healthy heartbeat promotes and clears failure state")
+    func successfulStartPromotes() {
+        var state = makeCandidateState(failures: 2)
+        let first = state.observeCandidateHealth(
+            healthySignal: true,
+            processStartedAt: 10,
+            now: 100,
+            stabilizationSeconds: 60
+        )
+        let stale = state.observeCandidateHealth(
+            healthySignal: false,
+            processStartedAt: nil,
+            now: 130,
+            stabilizationSeconds: 60
+        )
+        let restarted = state.observeCandidateHealth(
+            healthySignal: true,
+            processStartedAt: 20,
+            now: 200,
+            stabilizationSeconds: 60
+        )
+        let promoted = state.observeCandidateHealth(
+            healthySignal: true,
+            processStartedAt: 20,
+            now: 261,
+            stabilizationSeconds: 60
+        )
+        #expect(!first)
+        #expect(!stale)
+        #expect(!restarted)
+        #expect(promoted)
+        #expect(state.candidate == nil)
+        #expect(state.current?.version == "2.0.0")
+        #expect(state.predecessor?.release.version == "1.0.0")
+    }
+
+    @Test("new daemon process restarts stabilization window")
+    func processIdentityRestartsWindow() {
+        var state = makeCandidateState()
+        _ = state.observeCandidateHealth(
+            healthySignal: true,
+            processStartedAt: 10,
+            now: 100,
+            stabilizationSeconds: 60
+        )
+        let newProcess = state.observeCandidateHealth(
+            healthySignal: true,
+            processStartedAt: 150,
+            now: 159,
+            stabilizationSeconds: 60
+        )
+        let tooSoon = state.observeCandidateHealth(
+            healthySignal: true,
+            processStartedAt: 150,
+            now: 218,
+            stabilizationSeconds: 60
+        )
+        let promoted = state.observeCandidateHealth(
+            healthySignal: true,
+            processStartedAt: 150,
+            now: 220,
+            stabilizationSeconds: 60
+        )
+        #expect(!newProcess)
+        #expect(!tooSoon)
+        #expect(promoted)
+    }
+
+    @Test("quarantine blocks exact bad version but not a newer release")
+    func quarantineAllowsNewerEscape() {
+        var state = makeCandidateState(failures: 3)
+        state.completeRollback(now: 500, reason: "three failed starts")
+
+        #expect(state.quarantineBlocks(version: "2.0.0", manualOverride: false))
+        #expect(!state.quarantineBlocks(version: "3.0.0", manualOverride: false))
+        #expect(!state.quarantineBlocks(version: "2.0.0", manualOverride: true))
+        #expect(state.current?.version == "1.0.0")
+        #expect(state.candidate == nil)
+    }
+
+    @Test("rollback failure uses bounded exponential retry")
+    func rollbackFailureBackoff() {
+        var state = makeCandidateState(failures: 3)
+        state.deferRetryAfterRollbackFailure(now: 1_000, reason: "corrupt predecessor")
+        #expect(state.candidate?.retryNotBefore == 1_300)
+        #expect(state.isCandidateRetryBackedOff(now: 1_299))
+        #expect(!state.isCandidateRetryBackedOff(now: 1_300))
+
+        state.candidate?.failureCount = 7
+        state.deferRetryAfterRollbackFailure(now: 2_000, reason: "still corrupt")
+        #expect(state.candidate?.retryNotBefore == 5_600)
+    }
+
+    private func makeCandidateState(failures: Int = 0) -> UpdateRecoveryState {
+        let predecessorRecord = InstalledReleaseRecord(
+            version: "1.0.0",
+            releaseBundleHash: "release-old",
+            installedBundleHash: "bundle-old",
+            binaryHash: "binary-old",
+            metallibHash: "metallib-old",
+            installGeneration: 0,
+            installedAt: 1
+        )
+        let predecessor = VerifiedPredecessor(
+            release: predecessorRecord,
+            layout: .app,
+            bundlePath: "predecessor/Darkbloom.app",
+            binaryPath: "predecessor/Darkbloom.app/Contents/MacOS/darkbloom",
+            metallibPath: "predecessor/Darkbloom.app/Contents/MacOS/mlx.metallib",
+            verifiedAt: 2
+        )
+        let candidateRecord = InstalledReleaseRecord(
+            version: "2.0.0",
+            releaseBundleHash: "release-new",
+            installedBundleHash: "bundle-new",
+            binaryHash: "binary-new",
+            metallibHash: "metallib-new",
+            installGeneration: 1,
+            installedAt: 3
+        )
+        return UpdateRecoveryState(
+            installGeneration: 1,
+            current: predecessorRecord,
+            candidate: PendingReleaseCandidate(
+                release: candidateRecord,
+                failureCount: failures,
+                pendingAttemptID: "attempt",
+                attemptStartedAt: 4,
+                healthySince: nil,
+                healthyProcessStartedAt: nil,
+                retryNotBefore: nil,
+                rollbackBlockedReason: nil
+            ),
+            predecessor: predecessor
+        )
+    }
+}

--- a/provider-swift/Tests/ProviderCoreTests/UpdateRecoveryStateTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/UpdateRecoveryStateTests.swift
@@ -4,6 +4,63 @@ import Testing
 
 @Suite("Update recovery state")
 struct UpdateRecoveryStateTests {
+    @Test("directory durability failures are surfaced")
+    func directoryFsyncFailsClosed() {
+        #expect(throws: (any Error).self) {
+            try UpdateAtomicFilesystem.syncDirectory(
+                URL(fileURLWithPath: "/dev/null/not-a-directory")
+            )
+        }
+    }
+
+    @Test("installation and pre-launch power loss do not count a start")
+    func installDoesNotCountBeforeLaunch() {
+        var state = makeCandidateState()
+        state.candidate?.pendingAttemptID = nil
+        state.candidate?.attemptStartedAt = nil
+        let baseline = ProviderLaunchSnapshot(
+            label: "io.darkbloom.provider",
+            runs: 10,
+            process: nil
+        )
+        let prepared = state.prepareLaunchIntent(now: 100, baseline: baseline)
+        let noFailure = state.recordPendingAttemptFailure(now: 101)
+        let reconciled = state.reconcileLaunchIntent(
+            snapshot: baseline,
+            now: 102
+        )
+        #expect(prepared)
+        #expect(noFailure == nil)
+        #expect(!reconciled)
+        #expect(state.candidate?.failureCount == 0)
+        #expect(state.candidate?.pendingAttemptID == nil)
+    }
+
+    @Test("launchd run-count advancement proves issuance after crash")
+    func launchReceiptReconcilesAfterCrash() {
+        var state = makeCandidateState()
+        state.candidate?.pendingAttemptID = nil
+        state.candidate?.attemptStartedAt = nil
+        let baseline = ProviderLaunchSnapshot(
+            label: "io.darkbloom.provider",
+            runs: 10,
+            process: nil
+        )
+        _ = state.prepareLaunchIntent(now: 100, baseline: baseline)
+        let launched = ProviderLaunchSnapshot(
+            label: "io.darkbloom.provider",
+            runs: 11,
+            process: nil
+        )
+        let reconciled = state.reconcileLaunchIntent(
+            snapshot: launched,
+            now: 105
+        )
+        let failure = state.recordPendingAttemptFailure(now: 106)
+        #expect(reconciled)
+        #expect(failure == 1)
+    }
+
     @Test("failed start is counted once per armed attempt")
     func countsOneFailurePerAttempt() {
         var state = makeCandidateState()
@@ -13,10 +70,11 @@ struct UpdateRecoveryStateTests {
         #expect(duplicateTick == nil)
         #expect(state.candidate?.failureCount == 1)
 
-        let armed = state.armCandidateAttempt(now: 200)
+        let prepared = state.prepareLaunchIntent(now: 199, baseline: nil)
+        let armed = state.markLaunchIssued(now: 200)
         let secondFailure = state.recordPendingAttemptFailure(now: 201)
         let secondDuplicate = state.recordPendingAttemptFailure(now: 202)
-        #expect(armed)
+        #expect(prepared && armed)
         #expect(secondFailure == 2)
         #expect(secondDuplicate == nil)
     }
@@ -120,6 +178,7 @@ struct UpdateRecoveryStateTests {
             releaseBundleHash: "release-old",
             installedBundleHash: "bundle-old",
             binaryHash: "binary-old",
+            enclaveHash: "enclave-old",
             metallibHash: "metallib-old",
             installGeneration: 0,
             installedAt: 1
@@ -129,6 +188,7 @@ struct UpdateRecoveryStateTests {
             layout: .app,
             bundlePath: "predecessor/Darkbloom.app",
             binaryPath: "predecessor/Darkbloom.app/Contents/MacOS/darkbloom",
+            enclavePath: "predecessor/Darkbloom.app/Contents/MacOS/darkbloom-enclave",
             metallibPath: "predecessor/Darkbloom.app/Contents/MacOS/mlx.metallib",
             verifiedAt: 2
         )
@@ -137,6 +197,7 @@ struct UpdateRecoveryStateTests {
             releaseBundleHash: "release-new",
             installedBundleHash: "bundle-new",
             binaryHash: "binary-new",
+            enclaveHash: "enclave-new",
             metallibHash: "metallib-new",
             installGeneration: 1,
             installedAt: 3
@@ -147,6 +208,7 @@ struct UpdateRecoveryStateTests {
             candidate: PendingReleaseCandidate(
                 release: candidateRecord,
                 failureCount: failures,
+                launchIntent: nil,
                 pendingAttemptID: "attempt",
                 attemptStartedAt: 4,
                 healthySince: nil,

--- a/provider-swift/Tests/ProviderCoreTests/WatchdogRecoveryIntegrationTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/WatchdogRecoveryIntegrationTests.swift
@@ -615,6 +615,121 @@ struct WatchdogRecoveryIntegrationTests {
         #expect(try store.loadState().candidate?.failureCount == 4)
     }
 
+    @Test("install refusal after layout exchange is recovered before kickstart")
+    func replaceFailedRecoversTransactionBeforeKickstart() async throws {
+        enum InjectedFault: Error { case afterExchange }
+        let fixture = try UpdateRecoveryFixture()
+        defer { fixture.cleanup() }
+        let mock = MockCoordinator(
+            release: fixture.mockReleaseFixture(),
+            releaseArtifact: fixture.artifact
+        )
+        let baseURL = try await mock.start()
+        defer { Task { await mock.shutdown() } }
+
+        // The commit exchanges the live layout, then fails before finalizing
+        // (models a state-write/fsync failure after the rename). One-shot:
+        // the recovery replay through the same store must not re-fire.
+        let fault = OneShotFault()
+        let updater = SelfUpdater(
+            coordinatorBaseURL: baseURL.absoluteString,
+            installRoot: fixture.installRoot,
+            verifyCodeSignatures: false,
+            currentVersion: fixture.oldVersion,
+            now: { 100 },
+            recoveryFaultInjector: { point in
+                if point == .liveLayoutReplaced, fault.claim() {
+                    throw InjectedFault.afterExchange
+                }
+            }
+        )
+        let restarts = RecoveryRestartCounter()
+        let service = makeService(updater: updater, restarts: restarts)
+        let outcome = await service.recoverDownProvider(
+            autoUpdateEnabled: true,
+            now: 100
+        )
+
+        // The refused install stranded a journaled transaction with the live
+        // layout already exchanged. Pre-fix, the tick kickstarted that
+        // unfinalized tree with NO candidate attempt recorded — a crash of
+        // the new binary would never be charged toward rollback. The fix
+        // replays the journal before kickstart.
+        #expect(outcome == .restartIssued(updatedTo: nil, rolledBackTo: nil))
+        #expect(restarts.value == 1)
+        let store = recoveryStore(fixture)
+        #expect(!FileManager.default.fileExists(
+            atPath: store.recoveryRoot
+                .appendingPathComponent("transaction.json").path
+        ))
+        let state = try store.loadState()
+        #expect(state.candidate?.release.version == "2.0.0")
+        #expect(state.candidate?.pendingAttemptID != nil)
+        #expect(try fixture.liveBinaryContents() == "2.0.0-darkbloom")
+    }
+
+    @Test("unopenable recovery infrastructure still restarts the provider")
+    func degradedRecoveryInfraStillRestarts() async throws {
+        let fixture = try UpdateRecoveryFixture()
+        defer { fixture.cleanup() }
+        // Occupy the recovery root with a regular FILE so the lock directory
+        // can never be created — the full-disk / permissions failure class.
+        try Data("not a directory".utf8).write(
+            to: fixture.installRoot.appendingPathComponent("recovery")
+        )
+
+        let restarts = RecoveryRestartCounter()
+        let updater = SelfUpdater(
+            coordinatorBaseURL: "http://127.0.0.1:1",
+            installRoot: fixture.installRoot,
+            verifyCodeSignatures: false,
+            currentVersion: fixture.oldVersion
+        )
+        let service = makeService(updater: updater, restarts: restarts)
+        let outcome = await service.recoverDownProvider(
+            autoUpdateEnabled: true,
+            now: 100
+        )
+
+        // Pre-fix this surfaced as a nil-owner lock-busy wait and the
+        // provider stayed down forever, even though the plain launchd
+        // kickstart needs no update recovery state at all.
+        #expect(outcome == .restartIssued(updatedTo: nil, rolledBackTo: nil))
+        #expect(restarts.value == 1)
+        #expect(try fixture.liveBinaryContents() == "1.0.0-darkbloom")
+    }
+
+    @Test("live lock owner still defers the watchdog — degraded fallback never fires past contention")
+    func liveLockOwnerStillDefers() async throws {
+        let fixture = try UpdateRecoveryFixture()
+        defer { fixture.cleanup() }
+        let store = recoveryStore(fixture)
+        let held = try UpdateProcessLock.acquire(
+            at: store.lockPath,
+            operation: "live-manual-update"
+        )
+        defer { held.release() }
+
+        let restarts = RecoveryRestartCounter()
+        let updater = SelfUpdater(
+            coordinatorBaseURL: "http://127.0.0.1:1",
+            installRoot: fixture.installRoot,
+            verifyCodeSignatures: false,
+            currentVersion: fixture.oldVersion
+        )
+        let service = makeService(updater: updater, restarts: restarts)
+        let outcome = await service.recoverDownProvider(
+            autoUpdateEnabled: true,
+            now: 100
+        )
+        guard case .lockBusy(let reason) = outcome else {
+            Issue.record("expected deferral to the live lock owner, got \(outcome)")
+            return
+        }
+        #expect(reason.contains("live-manual-update"))
+        #expect(restarts.value == 0)
+    }
+
     @Test("candidate launch is stamped when kickstart happens, not at tick entry")
     func launchStampUsesFreshTimeAfterSlowDownload() async throws {
         let fixture = try UpdateRecoveryFixture()

--- a/provider-swift/Tests/ProviderCoreTests/WatchdogRecoveryIntegrationTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/WatchdogRecoveryIntegrationTests.swift
@@ -1,0 +1,602 @@
+import Foundation
+import Testing
+@testable import ProviderCore
+
+@Suite("Watchdog update and rollback integration", .serialized)
+struct WatchdogRecoveryIntegrationTests {
+    @Test("down provider installs signed release before restart")
+    func forwardUpdateWhileDown() async throws {
+        let fixture = try UpdateRecoveryFixture()
+        defer { fixture.cleanup() }
+        let mock = MockCoordinator(
+            release: fixture.mockReleaseFixture(),
+            releaseArtifact: fixture.artifact
+        )
+        let baseURL = try await mock.start()
+        defer { Task { await mock.shutdown() } }
+
+        let restarts = RecoveryRestartCounter()
+        let service = makeService(
+            updater: fixture.updater(baseURL: baseURL),
+            restarts: restarts
+        )
+        let outcome = await service.recoverDownProvider(
+            autoUpdateEnabled: true,
+            now: 100
+        )
+
+        #expect(outcome == .restartIssued(updatedTo: "2.0.0", rolledBackTo: nil))
+        #expect(restarts.value == 1)
+        #expect(try fixture.liveBinaryContents() == "2.0.0-darkbloom")
+        #expect(try fixture.persistentStateIsIntact())
+
+        let state = try recoveryStore(fixture).loadState()
+        #expect(state.candidate?.release.version == "2.0.0")
+        #expect(state.candidate?.failureCount == 0)
+        #expect(state.candidate?.pendingAttemptID != nil)
+        #expect(state.predecessor?.release.version == "1.0.0")
+        #expect(state.predecessor?.release.binaryHash.isEmpty == false)
+        #expect(state.predecessor?.release.installedBundleHash.isEmpty == false)
+        #expect(state.predecessor?.release.metallibHash.isEmpty == false)
+    }
+
+    @Test("third failed start restores predecessor and quarantines candidate")
+    func threeFailureRollback() async throws {
+        let context = try await installedCandidate()
+        defer { context.fixture.cleanup() }
+        defer { Task { await context.mock.shutdown() } }
+
+        let first = await context.service.recoverDownProvider(
+            autoUpdateEnabled: false,
+            now: 200
+        )
+        let second = await context.service.recoverDownProvider(
+            autoUpdateEnabled: false,
+            now: 300
+        )
+        let third = await context.service.recoverDownProvider(
+            autoUpdateEnabled: false,
+            now: 400
+        )
+
+        #expect(first == .restartIssued(updatedTo: nil, rolledBackTo: nil))
+        #expect(second == .restartIssued(updatedTo: nil, rolledBackTo: nil))
+        #expect(third == .restartIssued(updatedTo: nil, rolledBackTo: "1.0.0"))
+        #expect(try context.fixture.liveBinaryContents() == "1.0.0-darkbloom")
+        #expect(try context.fixture.persistentStateIsIntact())
+
+        let state = try recoveryStore(context.fixture).loadState()
+        #expect(state.candidate == nil)
+        #expect(state.current?.version == "1.0.0")
+        #expect(state.quarantine?.version == "2.0.0")
+        #expect(state.quarantine?.failureCount == 3)
+        #expect(state.predecessor?.release.version == "1.0.0")
+    }
+
+    @Test("fresh matching heartbeat promotes after stabilization")
+    func successfulStartReset() async throws {
+        let context = try await installedCandidate(stabilizationSeconds: 60)
+        defer { context.fixture.cleanup() }
+        defer { Task { await context.mock.shutdown() } }
+
+        let firstHeartbeat = DaemonState(
+            pid: 4242,
+            version: "2.0.0",
+            writtenAt: 200,
+            startedAt: 150
+        )
+        let first = context.service.observeHealthyProvider(
+            providerRunning: true,
+            daemonState: firstHeartbeat,
+            now: 200
+        )
+        let secondHeartbeat = DaemonState(
+            pid: 4242,
+            version: "2.0.0",
+            writtenAt: 261,
+            startedAt: 150
+        )
+        let second = context.service.observeHealthyProvider(
+            providerRunning: true,
+            daemonState: secondHeartbeat,
+            now: 261
+        )
+
+        #expect(first == .stabilizing(since: 200))
+        #expect(second == .promoted(version: "2.0.0"))
+        let state = try recoveryStore(context.fixture).loadState()
+        #expect(state.candidate == nil)
+        #expect(state.current?.version == "2.0.0")
+        #expect(state.predecessor?.release.version == "1.0.0")
+    }
+
+    @Test("installed candidate retries restart without reinstalling")
+    func installedCandidateRestartOnly() async throws {
+        let context = try await installedCandidate()
+        defer { context.fixture.cleanup() }
+        defer { Task { await context.mock.shutdown() } }
+
+        guard case .restartRequired(let current, let installed)
+                = await context.updater.checkForUpdate()
+        else {
+            Issue.record("expected installed candidate restart requirement")
+            return
+        }
+        #expect(current == "1.0.0")
+        #expect(installed == "2.0.0")
+
+        let predecessorBefore = try recoveryStore(context.fixture)
+            .loadState().predecessor
+        let outcome = await context.service.recoverDownProvider(
+            autoUpdateEnabled: true,
+            now: 200
+        )
+        #expect(outcome == .restartIssued(updatedTo: "2.0.0", rolledBackTo: nil))
+        #expect(try fixturePredecessorCount(context.fixture) == 1)
+        #expect(try recoveryStore(context.fixture).loadState().predecessor == predecessorBefore)
+    }
+
+    @Test("new version without heartbeat is a failed start, even if process lives")
+    func hungCandidateCountsAsFailedStart() async throws {
+        let context = try await installedCandidate()
+        defer { context.fixture.cleanup() }
+        defer { Task { await context.mock.shutdown() } }
+
+        let health = context.service.observeHealthyProvider(
+            providerRunning: true,
+            daemonState: nil,
+            now: 401
+        )
+        #expect(health == .inactiveCandidate(attemptStartedAt: 100))
+
+        let recovery = await context.service.recoverDownProvider(
+            autoUpdateEnabled: false,
+            now: 401
+        )
+        #expect(recovery == .restartIssued(updatedTo: nil, rolledBackTo: nil))
+        #expect(try recoveryStore(context.fixture)
+            .loadState().candidate?.failureCount == 1)
+    }
+
+    @Test("process death after atomic app exchange is recovered")
+    func crashBetweenRenameAndMetadata() throws {
+        enum InjectedCrash: Error { case afterExchange }
+
+        let fixture = try UpdateRecoveryFixture()
+        defer { fixture.cleanup() }
+        let updater = SelfUpdater(
+            coordinatorBaseURL: "http://127.0.0.1:1",
+            installRoot: fixture.installRoot,
+            verifyCodeSignatures: false,
+            currentVersion: fixture.oldVersion
+        )
+        guard case .success(let staged) = updater.stageBundleForTesting(
+            from: fixture.tarball,
+            release: fixture.release,
+            installDir: fixture.installRoot
+        ) else {
+            Issue.record("failed to stage fixture")
+            return
+        }
+
+        let crashingStore = UpdateRecoveryStore(
+            installRoot: fixture.installRoot,
+            verifyCodeSignatures: false,
+            faultInjector: { point in
+                if point == .liveLayoutReplaced { throw InjectedCrash.afterExchange }
+            }
+        )
+        let firstLock = try UpdateProcessLock.acquire(
+            at: crashingStore.lockPath,
+            operation: "crashing-commit"
+        )
+        #expect(throws: InjectedCrash.self) {
+            try crashingStore.commit(
+                staged: staged,
+                currentVersion: fixture.oldVersion,
+                now: 100
+            )
+        }
+        firstLock.release()
+        #expect(try fixture.liveBinaryContents() == "2.0.0-darkbloom")
+
+        let recoveredStore = recoveryStore(fixture)
+        let recoveryLock = try UpdateProcessLock.acquire(
+            at: recoveredStore.lockPath,
+            operation: "post-crash-recovery"
+        )
+        defer { recoveryLock.release() }
+        try recoveredStore.recoverInterruptedTransaction(now: 101)
+
+        let state = try recoveredStore.loadState()
+        #expect(state.candidate?.release.version == "2.0.0")
+        #expect(state.predecessor?.release.version == "1.0.0")
+        #expect(!FileManager.default.fileExists(
+            atPath: recoveredStore.recoveryRoot
+                .appendingPathComponent("transaction.json").path
+        ))
+    }
+
+    @Test("corrupt predecessor is refused without touching current install")
+    func corruptPredecessorRefused() async throws {
+        let context = try await installedCandidate()
+        defer { context.fixture.cleanup() }
+        defer { Task { await context.mock.shutdown() } }
+
+        let predecessorBinary = context.fixture.installRoot
+            .appendingPathComponent(
+                "recovery/predecessor/Darkbloom.app/Contents/MacOS/darkbloom")
+        try Data("tampered predecessor".utf8).write(to: predecessorBinary)
+
+        _ = await context.service.recoverDownProvider(
+            autoUpdateEnabled: false,
+            now: 200
+        )
+        _ = await context.service.recoverDownProvider(
+            autoUpdateEnabled: false,
+            now: 300
+        )
+        let third = await context.service.recoverDownProvider(
+            autoUpdateEnabled: false,
+            now: 400
+        )
+
+        guard case .retryBackoff(_, let reason) = third else {
+            Issue.record("expected rollback safety backoff, got \(third)")
+            return
+        }
+        #expect(reason.contains("hash mismatch"))
+        #expect(try context.fixture.liveBinaryContents() == "2.0.0-darkbloom")
+        let state = try recoveryStore(context.fixture).loadState()
+        #expect(state.candidate?.failureCount == 3)
+        #expect(state.candidate?.retryNotBefore == 700)
+        #expect(state.quarantine == nil)
+    }
+
+    @Test("missing predecessor enters retry backoff without touching live install")
+    func missingPredecessorBackoff() async throws {
+        let fixture = try UpdateRecoveryFixture()
+        defer { fixture.cleanup() }
+        let app = fixture.installRoot.appendingPathComponent("Darkbloom.app")
+        let appBin = app.appendingPathComponent("Contents/MacOS")
+        let record = InstalledReleaseRecord(
+            version: "1.0.0",
+            releaseBundleHash: nil,
+            installedBundleHash: try UpdateAtomicFilesystem.treeHash(root: app),
+            binaryHash: try UpdateAtomicFilesystem.sha256(
+                file: appBin.appendingPathComponent("darkbloom")),
+            metallibHash: try UpdateAtomicFilesystem.sha256(
+                file: appBin.appendingPathComponent("mlx.metallib")),
+            installGeneration: 1,
+            installedAt: 1
+        )
+        var state = UpdateRecoveryState(
+            installGeneration: 1,
+            candidate: PendingReleaseCandidate(
+                release: record,
+                failureCount: 2,
+                pendingAttemptID: "third-attempt",
+                attemptStartedAt: 50,
+                healthySince: nil,
+                healthyProcessStartedAt: nil,
+                retryNotBefore: nil,
+                rollbackBlockedReason: nil
+            )
+        )
+        let store = recoveryStore(fixture)
+        try store.writeState(state)
+
+        let restarts = RecoveryRestartCounter()
+        let updater = SelfUpdater(
+            coordinatorBaseURL: "http://127.0.0.1:1",
+            installRoot: fixture.installRoot,
+            verifyCodeSignatures: false,
+            currentVersion: fixture.oldVersion
+        )
+        let service = makeService(updater: updater, restarts: restarts)
+        let outcome = await service.recoverDownProvider(
+            autoUpdateEnabled: false,
+            now: 100
+        )
+
+        guard case .retryBackoff(let until, let reason) = outcome else {
+            Issue.record("expected missing-predecessor backoff, got \(outcome)")
+            return
+        }
+        #expect(until == 400)
+        #expect(reason.contains("no recorded predecessor"))
+        #expect(restarts.value == 0)
+        #expect(try fixture.liveBinaryContents() == "1.0.0-darkbloom")
+        state = try store.loadState()
+        #expect(state.candidate?.failureCount == 3)
+        #expect(state.candidate?.retryNotBefore == 400)
+
+        let stillWaiting = await service.recoverDownProvider(
+            autoUpdateEnabled: false,
+            now: 399
+        )
+        guard case .retryBackoff(let waitingUntil, _) = stillWaiting else {
+            Issue.record("expected active backoff, got \(stillWaiting)")
+            return
+        }
+        #expect(waitingUntil == 400)
+        #expect(restarts.value == 0)
+
+        let retried = await service.recoverDownProvider(
+            autoUpdateEnabled: false,
+            now: 400
+        )
+        #expect(retried == .restartIssued(updatedTo: nil, rolledBackTo: nil))
+        #expect(restarts.value == 1)
+
+        let fourthFailure = await service.recoverDownProvider(
+            autoUpdateEnabled: false,
+            now: 500
+        )
+        guard case .retryBackoff(let nextUntil, _) = fourthFailure else {
+            Issue.record("expected longer second backoff, got \(fourthFailure)")
+            return
+        }
+        #expect(nextUntil == 1_100)
+        #expect(try store.loadState().candidate?.failureCount == 4)
+    }
+
+    @Test("quarantine blocks bad version and strictly newer release escapes")
+    func quarantineAndNewerEscape() async throws {
+        let context = try await installedCandidate()
+        defer { context.fixture.cleanup() }
+        defer { Task { await context.mock.shutdown() } }
+        _ = await context.service.recoverDownProvider(autoUpdateEnabled: false, now: 200)
+        _ = await context.service.recoverDownProvider(autoUpdateEnabled: false, now: 300)
+        _ = await context.service.recoverDownProvider(autoUpdateEnabled: false, now: 400)
+
+        let blocked = await context.updater.checkForUpdate()
+        guard case .quarantined(let version, _) = blocked else {
+            Issue.record("expected v2 quarantine, got \(blocked)")
+            return
+        }
+        #expect(version == "2.0.0")
+
+        let newer = try UpdateRecoveryFixture(oldVersion: "1.0.0", newVersion: "3.0.0")
+        defer { newer.cleanup() }
+        let newerMock = MockCoordinator(
+            release: newer.mockReleaseFixture(),
+            releaseArtifact: newer.artifact
+        )
+        let newerBase = try await newerMock.start()
+        defer { Task { await newerMock.shutdown() } }
+        let updater = SelfUpdater(
+            coordinatorBaseURL: newerBase.absoluteString,
+            installRoot: context.fixture.installRoot,
+            verifyCodeSignatures: false,
+            currentVersion: "1.0.0"
+        )
+        let service = makeService(updater: updater, restarts: context.restarts)
+        let outcome = await service.recoverDownProvider(
+            autoUpdateEnabled: true,
+            now: 500
+        )
+        #expect(outcome == .restartIssued(updatedTo: "3.0.0", rolledBackTo: nil))
+        #expect(try context.fixture.liveBinaryContents() == "3.0.0-darkbloom")
+    }
+
+    @Test("auto-update disabled restarts without querying or replacing")
+    func autoUpdateDisabled() async throws {
+        let fixture = try UpdateRecoveryFixture()
+        defer { fixture.cleanup() }
+        let updater = SelfUpdater(
+            coordinatorBaseURL: "http://127.0.0.1:1",
+            installRoot: fixture.installRoot,
+            verifyCodeSignatures: false,
+            currentVersion: fixture.oldVersion
+        )
+        let restarts = RecoveryRestartCounter()
+        let service = makeService(updater: updater, restarts: restarts)
+
+        let outcome = await service.recoverDownProvider(
+            autoUpdateEnabled: false,
+            now: 100
+        )
+        #expect(outcome == .restartIssued(updatedTo: nil, rolledBackTo: nil))
+        #expect(restarts.value == 1)
+        #expect(try fixture.liveBinaryContents() == "1.0.0-darkbloom")
+        #expect(try recoveryStore(fixture).loadState().candidate == nil)
+    }
+
+    @Test("watchdog defers while another process owns update lock")
+    func watchdogLockContention() async throws {
+        let fixture = try UpdateRecoveryFixture()
+        defer { fixture.cleanup() }
+        let store = recoveryStore(fixture)
+        let held = try UpdateProcessLock.acquire(
+            at: store.lockPath,
+            operation: "manual-update"
+        )
+        defer { held.release() }
+
+        let restarts = RecoveryRestartCounter()
+        let updater = SelfUpdater(
+            coordinatorBaseURL: "http://127.0.0.1:1",
+            installRoot: fixture.installRoot,
+            verifyCodeSignatures: false,
+            currentVersion: fixture.oldVersion
+        )
+        let service = makeService(updater: updater, restarts: restarts)
+        let outcome = await service.recoverDownProvider(
+            autoUpdateEnabled: true,
+            now: 100
+        )
+        guard case .lockBusy(let reason) = outcome else {
+            Issue.record("expected lock contention, got \(outcome)")
+            return
+        }
+        #expect(reason.contains("manual-update"))
+        #expect(restarts.value == 0)
+    }
+
+    @Test("intentional stop racing download cancels install")
+    func intentionalStopDuringDownload() async throws {
+        let fixture = try UpdateRecoveryFixture()
+        defer { fixture.cleanup() }
+        let mock = MockCoordinator(
+            release: fixture.mockReleaseFixture(),
+            releaseArtifact: fixture.artifact
+        )
+        let baseURL = try await mock.start()
+        defer { Task { await mock.shutdown() } }
+        let updater = fixture.updater(baseURL: baseURL)
+        let session = try updater.beginUpdateSession(
+            operation: "watchdog-stop-race"
+        )
+        defer { session.release() }
+        try session.recover(now: 100)
+
+        let result = await updater.update(
+            session: session,
+            beforeInstall: { false }
+        )
+        guard case .cancelled(let reason) = result else {
+            Issue.record("expected stop-race cancellation, got \(result)")
+            return
+        }
+        #expect(reason.contains("intentionally stopped"))
+        #expect(try fixture.liveBinaryContents() == "1.0.0-darkbloom")
+        #expect(try recoveryStore(fixture).loadState().candidate == nil)
+    }
+
+    @Test("explicit manual override reinstalls quarantined version")
+    func manualOverride() async throws {
+        let fixture = try UpdateRecoveryFixture()
+        defer { fixture.cleanup() }
+        let store = recoveryStore(fixture)
+        var state = UpdateRecoveryState()
+        state.quarantine = FailedReleaseQuarantine(
+            version: "2.0.0",
+            failureCount: 3,
+            quarantinedAt: 10,
+            reason: "three failed starts"
+        )
+        try store.writeState(state)
+
+        let mock = MockCoordinator(
+            release: fixture.mockReleaseFixture(),
+            releaseArtifact: fixture.artifact
+        )
+        let baseURL = try await mock.start()
+        defer { Task { await mock.shutdown() } }
+        let updater = fixture.updater(baseURL: baseURL)
+
+        guard case .quarantined = await updater.checkForUpdate() else {
+            Issue.record("non-override check did not honor quarantine")
+            return
+        }
+        let result = await updater.update(manualOverride: true)
+        #expect(result.isUpdated(to: "2.0.0"))
+        #expect(try fixture.liveBinaryContents() == "2.0.0-darkbloom")
+        #expect(try store.loadState().quarantine == nil)
+    }
+
+    @Test("intentional stop remains unmanaged")
+    func intentionalStop() {
+        let decision = WatchdogPolicy.decide(
+            autoRestartEnabled: true,
+            providerLoaded: false,
+            providerRunning: false,
+            downSince: 1,
+            now: 1_000
+        )
+        #expect(decision == .notManaged)
+    }
+
+    private struct InstalledContext {
+        let fixture: UpdateRecoveryFixture
+        let mock: MockCoordinator
+        let updater: SelfUpdater
+        let service: WatchdogRecoveryService
+        let restarts: RecoveryRestartCounter
+    }
+
+    private func installedCandidate(
+        stabilizationSeconds: Double = 180
+    ) async throws -> InstalledContext {
+        let fixture = try UpdateRecoveryFixture()
+        let mock = MockCoordinator(
+            release: fixture.mockReleaseFixture(),
+            releaseArtifact: fixture.artifact
+        )
+        let baseURL = try await mock.start()
+        let updater = fixture.updater(baseURL: baseURL)
+        let restarts = RecoveryRestartCounter()
+        let service = makeService(
+            updater: updater,
+            restarts: restarts,
+            stabilizationSeconds: stabilizationSeconds
+        )
+        let outcome = await service.recoverDownProvider(
+            autoUpdateEnabled: true,
+            now: 100
+        )
+        guard outcome == .restartIssued(updatedTo: "2.0.0", rolledBackTo: nil) else {
+            await mock.shutdown()
+            fixture.cleanup()
+            throw TestSetupError.initialUpdateFailed("\(outcome)")
+        }
+        return InstalledContext(
+            fixture: fixture,
+            mock: mock,
+            updater: updater,
+            service: service,
+            restarts: restarts
+        )
+    }
+
+    private func makeService(
+        updater: SelfUpdater,
+        restarts: RecoveryRestartCounter,
+        stabilizationSeconds: Double = 180
+    ) -> WatchdogRecoveryService {
+        WatchdogRecoveryService(
+            updater: updater,
+            dependencies: .init(
+                kickstartIfLoaded: {
+                    restarts.increment()
+                    return true
+                },
+                processAlive: { _ in true },
+                log: { _ in }
+            ),
+            stabilizationSeconds: stabilizationSeconds
+        )
+    }
+
+    private func recoveryStore(
+        _ fixture: UpdateRecoveryFixture
+    ) -> UpdateRecoveryStore {
+        UpdateRecoveryStore(
+            installRoot: fixture.installRoot,
+            verifyCodeSignatures: false
+        )
+    }
+
+    private func fixturePredecessorCount(
+        _ fixture: UpdateRecoveryFixture
+    ) throws -> Int {
+        let recovery = fixture.installRoot.appendingPathComponent("recovery")
+        return try FileManager.default.contentsOfDirectory(atPath: recovery.path)
+            .filter { $0 == "predecessor" }
+            .count
+    }
+
+    private enum TestSetupError: Error {
+        case initialUpdateFailed(String)
+    }
+}
+
+private extension UpdateResult {
+    func isUpdated(to version: String) -> Bool {
+        if case .updated(_, let installed) = self {
+            return installed == version
+        }
+        return false
+    }
+}

--- a/provider-swift/Tests/ProviderCoreTests/WatchdogRecoveryIntegrationTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/WatchdogRecoveryIntegrationTests.swift
@@ -217,6 +217,74 @@ struct WatchdogRecoveryIntegrationTests {
         ))
     }
 
+    @Test("every app and flat transaction boundary is restart-safe")
+    func allPowerLossBoundaries() throws {
+        enum PowerLoss: Error { case injected }
+
+        for layout in [
+            VerifiedPredecessor.Layout.app,
+            VerifiedPredecessor.Layout.flat,
+        ] {
+            for point in UpdateRecoveryStore.FaultPoint.allCases {
+                let fixture = try UpdateRecoveryFixture(layout: layout)
+                defer { fixture.cleanup() }
+                let updater = SelfUpdater(
+                    coordinatorBaseURL: "http://127.0.0.1:1",
+                    installRoot: fixture.installRoot,
+                    verifyCodeSignatures: false,
+                    currentVersion: fixture.oldVersion
+                )
+                guard case .success(let staged) = updater.stageBundleForTesting(
+                    from: fixture.tarball,
+                    release: fixture.release,
+                    installDir: fixture.installRoot
+                ) else {
+                    Issue.record("failed to stage \(layout) at \(point)")
+                    continue
+                }
+                let store = UpdateRecoveryStore(
+                    installRoot: fixture.installRoot,
+                    verifyCodeSignatures: false,
+                    faultInjector: { hit in
+                        if hit == point { throw PowerLoss.injected }
+                    }
+                )
+                let lock = try UpdateProcessLock.acquire(
+                    at: store.lockPath,
+                    operation: "power-loss-\(point)"
+                )
+                do {
+                    try store.commit(
+                        staged: staged,
+                        currentVersion: fixture.oldVersion,
+                        now: 100
+                    )
+                    Issue.record("fault \(point) did not interrupt commit")
+                } catch PowerLoss.injected {
+                    // Expected process-death boundary.
+                }
+                lock.release()
+
+                let recovered = UpdateRecoveryStore(
+                    installRoot: fixture.installRoot,
+                    verifyCodeSignatures: false
+                )
+                let recoveryLock = try UpdateProcessLock.acquire(
+                    at: recovered.lockPath,
+                    operation: "power-loss-recovery"
+                )
+                try recovered.recoverInterruptedTransaction(now: 101)
+                recoveryLock.release()
+
+                let expected = point == .predecessorPromoted
+                    ? "1.0.0-darkbloom"
+                    : "2.0.0-darkbloom"
+                #expect(try fixture.liveBinaryContents() == expected)
+                #expect(try fixture.persistentStateIsIntact())
+            }
+        }
+    }
+
     @Test("corrupt predecessor is refused without touching current install")
     func corruptPredecessorRefused() async throws {
         let context = try await installedCandidate()
@@ -253,6 +321,27 @@ struct WatchdogRecoveryIntegrationTests {
         #expect(state.quarantine == nil)
     }
 
+    @Test("flat predecessor enclave and full tree are verified")
+    func flatPredecessorEnclaveVerification() async throws {
+        let context = try await installedCandidate(layout: .flat)
+        defer { context.fixture.cleanup() }
+        defer { Task { await context.mock.shutdown() } }
+        let store = recoveryStore(context.fixture)
+        let state = try store.loadState()
+        guard let predecessor = state.predecessor else {
+            Issue.record("missing flat predecessor")
+            return
+        }
+        try Data("tampered enclave".utf8).write(
+            to: context.fixture.installRoot.appendingPathComponent(
+                "recovery/predecessor/bin/darkbloom-enclave"
+            )
+        )
+        #expect(throws: (any Error).self) {
+            try store.verifyPredecessor(predecessor)
+        }
+    }
+
     @Test("missing predecessor enters retry backoff without touching live install")
     func missingPredecessorBackoff() async throws {
         let fixture = try UpdateRecoveryFixture()
@@ -265,6 +354,8 @@ struct WatchdogRecoveryIntegrationTests {
             installedBundleHash: try UpdateAtomicFilesystem.treeHash(root: app),
             binaryHash: try UpdateAtomicFilesystem.sha256(
                 file: appBin.appendingPathComponent("darkbloom")),
+            enclaveHash: try UpdateAtomicFilesystem.sha256(
+                file: appBin.appendingPathComponent("darkbloom-enclave")),
             metallibHash: try UpdateAtomicFilesystem.sha256(
                 file: appBin.appendingPathComponent("mlx.metallib")),
             installGeneration: 1,
@@ -275,6 +366,7 @@ struct WatchdogRecoveryIntegrationTests {
             candidate: PendingReleaseCandidate(
                 release: record,
                 failureCount: 2,
+                launchIntent: nil,
                 pendingAttemptID: "third-attempt",
                 attemptStartedAt: 50,
                 healthySince: nil,
@@ -493,7 +585,10 @@ struct WatchdogRecoveryIntegrationTests {
         let result = await updater.update(manualOverride: true)
         #expect(result.isUpdated(to: "2.0.0"))
         #expect(try fixture.liveBinaryContents() == "2.0.0-darkbloom")
-        #expect(try store.loadState().quarantine == nil)
+        let installed = try store.loadState()
+        #expect(installed.quarantine == nil)
+        #expect(installed.candidate?.pendingAttemptID == nil)
+        #expect(installed.candidate?.attemptStartedAt == nil)
     }
 
     @Test("intentional stop remains unmanaged")
@@ -517,9 +612,10 @@ struct WatchdogRecoveryIntegrationTests {
     }
 
     private func installedCandidate(
-        stabilizationSeconds: Double = 180
+        stabilizationSeconds: Double = 180,
+        layout: VerifiedPredecessor.Layout = .app
     ) async throws -> InstalledContext {
-        let fixture = try UpdateRecoveryFixture()
+        let fixture = try UpdateRecoveryFixture(layout: layout)
         let mock = MockCoordinator(
             release: fixture.mockReleaseFixture(),
             releaseArtifact: fixture.artifact

--- a/provider-swift/Tests/ProviderCoreTests/WatchdogRecoveryIntegrationTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/WatchdogRecoveryIntegrationTests.swift
@@ -195,7 +195,10 @@ struct WatchdogRecoveryIntegrationTests {
             Issue.record("expected startup-window backoff, got \(outcome)")
             return
         }
-        #expect(until == 700)  // attemptStartedAt(100) + window(600)
+        // attemptStartedAt(100 + real ms elapsed inside the install call)
+        // + window(600). The stamp intentionally includes real elapsed time
+        // (slow-download fix), so allow the sub-second test-run epsilon.
+        #expect(until >= 700 && until < 701)
         #expect(reason.contains("startup window"))
         #expect(context.restarts.value == restartsBefore)  // no restart issued
 
@@ -320,7 +323,13 @@ struct WatchdogRecoveryIntegrationTests {
             daemonState: nil,
             now: 401
         )
-        #expect(health == .inactiveCandidate(attemptStartedAt: 100))
+        // The launch stamp includes the real ms elapsed inside the install
+        // call (slow-download fix), so range-check rather than exact-match.
+        guard case .inactiveCandidate(let attemptStartedAt) = health else {
+            Issue.record("expected inactive candidate, got \(health)")
+            return
+        }
+        #expect(attemptStartedAt >= 100 && attemptStartedAt < 101)
 
         let recovery = await context.service.recoverDownProvider(
             autoUpdateEnabled: false,
@@ -604,6 +613,188 @@ struct WatchdogRecoveryIntegrationTests {
         }
         #expect(nextUntil == 1_100)
         #expect(try store.loadState().candidate?.failureCount == 4)
+    }
+
+    @Test("candidate launch is stamped when kickstart happens, not at tick entry")
+    func launchStampUsesFreshTimeAfterSlowDownload() async throws {
+        let fixture = try UpdateRecoveryFixture()
+        defer { fixture.cleanup() }
+        let mock = MockCoordinator(
+            release: fixture.mockReleaseFixture(),
+            releaseArtifact: fixture.artifact
+        )
+        let baseURL = try await mock.start()
+        defer { Task { await mock.shutdown() } }
+
+        let restarts = RecoveryRestartCounter()
+        let service = WatchdogRecoveryService(
+            updater: fixture.updater(baseURL: baseURL),
+            dependencies: .init(
+                kickstartIfLoaded: {
+                    restarts.increment()
+                    return true
+                },
+                launchSnapshot: { nil },
+                // Models a slow-but-successful release download (the watchdog
+                // URLSession allows up to 600s): each call injects real
+                // elapsed time between tick entry and the kickstart, exactly
+                // where a long download sits in production.
+                providerStillLoaded: {
+                    Thread.sleep(forTimeInterval: 0.8)
+                    return true
+                },
+                processAlive: { _ in true },
+                log: { _ in }
+            )
+        )
+        let outcome = await service.recoverDownProvider(
+            autoUpdateEnabled: true,
+            now: 100
+        )
+        #expect(outcome == .restartIssued(updatedTo: "2.0.0", rolledBackTo: nil))
+
+        // ≥1.6s of real time elapsed inside the call before the kickstart.
+        // Pre-fix, the launch was stamped with the tick-entry `now` (exactly
+        // 100), so a download longer than the startup window would have eaten
+        // the whole window before the candidate even launched, and the next
+        // tick would charge a false failed start.
+        let state = try recoveryStore(fixture).loadState()
+        guard let stamp = state.candidate?.attemptStartedAt else {
+            Issue.record("expected an armed candidate launch attempt")
+            return
+        }
+        #expect(stamp >= 101.5)
+        #expect(stamp < 160)  // derived from `now` + elapsed, not the wall clock
+    }
+
+    @Test("surviving watchdog does not re-candidatize the promoted release")
+    func promotedReleaseNotReinstalledByStaleWatchdogVersion() async throws {
+        // stabilization 0 → the first fresh matching heartbeat promotes.
+        let context = try await installedCandidate(stabilizationSeconds: 0)
+        defer { context.fixture.cleanup() }
+        defer { Task { await context.mock.shutdown() } }
+
+        let heartbeat = DaemonState(
+            pid: 4242,
+            version: "2.0.0",
+            writtenAt: 200,
+            startedAt: 150
+        )
+        let health = context.service.observeHealthyProvider(
+            providerRunning: true,
+            daemonState: heartbeat,
+            now: 200
+        )
+        #expect(health == .promoted(version: "2.0.0"))
+
+        // The persistent watchdog process still runs the OLD binary, so its
+        // compiled version is 1.0.0 while 2.0.0 is installed and promoted on
+        // disk. Pre-fix, checkForUpdate compared latest against the process
+        // version, re-downloaded 2.0.0, and re-armed it as an UNPROVEN
+        // candidate — a later unrelated crash could then quarantine it.
+        guard case .upToDate(let version) = await context.updater.checkForUpdate() else {
+            Issue.record("expected upToDate for the already-promoted release")
+            return
+        }
+        #expect(version == "2.0.0")
+
+        let outcome = await context.service.recoverDownProvider(
+            autoUpdateEnabled: true,
+            now: 300
+        )
+        #expect(outcome == .restartIssued(updatedTo: nil, rolledBackTo: nil))
+        let state = try recoveryStore(context.fixture).loadState()
+        #expect(state.candidate == nil)
+        #expect(state.current?.version == "2.0.0")
+    }
+
+    @Test("newer release supersedes a stuck failing candidate")
+    func newerReleaseSupersedesStuckCandidate() async throws {
+        let context = try await installedCandidate()
+        defer { context.fixture.cleanup() }
+        defer { Task { await context.mock.shutdown() } }
+
+        // v2 fails a start; the coordinator then publishes v3 as the fix.
+        _ = await context.service.recoverDownProvider(
+            autoUpdateEnabled: false,
+            now: 200
+        )
+        #expect(try recoveryStore(context.fixture)
+            .loadState().candidate?.failureCount == 1)
+
+        let newer = try UpdateRecoveryFixture(oldVersion: "1.0.0", newVersion: "3.0.0")
+        defer { newer.cleanup() }
+        let newerMock = MockCoordinator(
+            release: newer.mockReleaseFixture(),
+            releaseArtifact: newer.artifact
+        )
+        let newerBase = try await newerMock.start()
+        defer { Task { await newerMock.shutdown() } }
+        let updater = SelfUpdater(
+            coordinatorBaseURL: newerBase.absoluteString,
+            installRoot: context.fixture.installRoot,
+            verifyCodeSignatures: false,
+            currentVersion: "1.0.0"
+        )
+
+        // Pre-fix, a pending candidate short-circuited to .restartRequired
+        // before ever contacting /v1/releases/latest, so a host wedged on a
+        // failing candidate could never discover the fixed release.
+        guard case .updateAvailable(_, let latest) = await updater.checkForUpdate() else {
+            Issue.record("expected v3 to supersede the pending v2 candidate")
+            return
+        }
+        #expect(latest.version == "3.0.0")
+
+        let service = makeService(updater: updater, restarts: context.restarts)
+        let outcome = await service.recoverDownProvider(
+            autoUpdateEnabled: true,
+            now: 300
+        )
+        #expect(outcome == .restartIssued(updatedTo: "3.0.0", rolledBackTo: nil))
+        #expect(try context.fixture.liveBinaryContents() == "3.0.0-darkbloom")
+
+        let state = try recoveryStore(context.fixture).loadState()
+        #expect(state.candidate?.release.version == "3.0.0")
+        // The superseded, already-failing v2 is quarantined by installCandidate.
+        #expect(state.quarantine?.version == "2.0.0")
+        #expect(state.predecessor?.release.version == "1.0.0")
+    }
+
+    @Test("pending candidate still restarts when the coordinator is unreachable")
+    func pendingCandidateRestartsOffline() async throws {
+        let context = try await installedCandidate()
+        defer { context.fixture.cleanup() }
+        defer { Task { await context.mock.shutdown() } }
+
+        // The supersede check adds a network fetch to the pending-candidate
+        // path; an unreachable coordinator must never block the restart.
+        let offline = SelfUpdater(
+            coordinatorBaseURL: "http://127.0.0.1:1",
+            installRoot: context.fixture.installRoot,
+            verifyCodeSignatures: false,
+            currentVersion: "1.0.0"
+        )
+        guard case .restartRequired(let current, let installed)
+                = await offline.checkForUpdate()
+        else {
+            Issue.record("offline pending candidate must still require restart")
+            return
+        }
+        #expect(current == "1.0.0")
+        #expect(installed == "2.0.0")
+
+        let service = makeService(updater: offline, restarts: context.restarts)
+        let outcome = await service.recoverDownProvider(
+            autoUpdateEnabled: true,
+            now: 300
+        )
+        guard case .restartIssued(let updatedTo, _) = outcome else {
+            Issue.record("expected offline restart, got \(outcome)")
+            return
+        }
+        #expect(updatedTo == "2.0.0")
+        #expect(try context.fixture.liveBinaryContents() == "2.0.0-darkbloom")
     }
 
     @Test("quarantine blocks bad version and strictly newer release escapes")

--- a/provider-swift/Tests/ProviderCoreTests/WatchdogRecoveryIntegrationTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/WatchdogRecoveryIntegrationTests.swift
@@ -168,6 +168,102 @@ struct WatchdogRecoveryIntegrationTests {
         #expect(state.candidate?.failureCount == 0)
     }
 
+    @Test("alive candidate within startup window defers the down-grace restart path — no false failure")
+    func slowPreloadCandidateDefersRestartPath() async throws {
+        // preload=420s → candidate startup window = max(300, 420+180) = 600s.
+        // installedCandidate arms attemptStartedAt=100 via the install at now=100.
+        let window = WatchdogRecoveryService.candidateStartupTimeout(
+            preloadTimeoutSecs: 420
+        )
+        let context = try await installedCandidate(
+            candidateStartupTimeoutSeconds: window
+        )
+        defer { context.fixture.cleanup() }
+        defer { Task { await context.mock.shutdown() } }
+
+        let restartsBefore = context.restarts.value  // 1 from the install
+
+        // now=550: well past the 300s generic down-grace, but within the 600s
+        // candidate window; the process is still ALIVE (legitimately preloading).
+        // The pre-fix down-grace path charged a failed start here and restarted.
+        let outcome = await context.service.recoverDownProvider(
+            autoUpdateEnabled: false,
+            providerProcessAlive: true,
+            now: 550
+        )
+        guard case .retryBackoff(let until, let reason) = outcome else {
+            Issue.record("expected startup-window backoff, got \(outcome)")
+            return
+        }
+        #expect(until == 700)  // attemptStartedAt(100) + window(600)
+        #expect(reason.contains("startup window"))
+        #expect(context.restarts.value == restartsBefore)  // no restart issued
+
+        let state = try recoveryStore(context.fixture).loadState()
+        #expect(state.candidate?.failureCount == 0)         // no failed start charged
+        #expect(state.candidate?.pendingAttemptID != nil)   // attempt still pending
+        #expect(state.quarantine == nil)                    // no quarantine
+        #expect(try context.fixture.liveBinaryContents() == "2.0.0-darkbloom")  // no rollback
+
+        // Contrast: a DEAD candidate at the same instant IS charged a failed
+        // start — proving the defer is gated on the process being alive.
+        let dead = await context.service.recoverDownProvider(
+            autoUpdateEnabled: false,
+            providerProcessAlive: false,
+            now: 560
+        )
+        #expect(dead == .restartIssued(updatedTo: nil, rolledBackTo: nil))
+        #expect(try recoveryStore(context.fixture)
+            .loadState().candidate?.failureCount == 1)
+    }
+
+    @Test("flat rollback after an app candidate runs the flat predecessor, not the quarantined app")
+    func flatToAppRollbackRunsFlatPredecessor() async throws {
+        // Legacy .flat install updates to an .app candidate (leaves Darkbloom.app
+        // in installRoot); the candidate fails 3x and rolls back to the flat
+        // predecessor. The live bin/darkbloom must resolve to the flat
+        // predecessor binary — NOT a symlink back into the quarantined app.
+        let fixture = try UpdateRecoveryFixture(layout: .flat, candidateLayout: .app)
+        defer { fixture.cleanup() }
+        let mock = MockCoordinator(
+            release: fixture.mockReleaseFixture(),
+            releaseArtifact: fixture.artifact
+        )
+        let baseURL = try await mock.start()
+        defer { Task { await mock.shutdown() } }
+
+        let restarts = RecoveryRestartCounter()
+        let service = makeService(
+            updater: fixture.updater(baseURL: baseURL),
+            restarts: restarts
+        )
+
+        let install = await service.recoverDownProvider(
+            autoUpdateEnabled: true,
+            now: 100
+        )
+        #expect(install == .restartIssued(updatedTo: "2.0.0", rolledBackTo: nil))
+        #expect(fixture.appBundleExists())  // candidate app is now on disk
+        #expect(try fixture.liveFlatBinaryResolvedContents() == "2.0.0-darkbloom")
+
+        _ = await service.recoverDownProvider(autoUpdateEnabled: false, now: 200)
+        _ = await service.recoverDownProvider(autoUpdateEnabled: false, now: 300)
+        let third = await service.recoverDownProvider(autoUpdateEnabled: false, now: 400)
+        #expect(third == .restartIssued(updatedTo: nil, rolledBackTo: "1.0.0"))
+
+        // The fix: stale Darkbloom.app is retired and bin/darkbloom is the real
+        // flat predecessor. Without it, ensureCanonicalLinks would re-point
+        // bin/darkbloom into the leftover candidate app (→ "2.0.0-darkbloom").
+        #expect(try fixture.liveFlatBinaryResolvedContents() == "1.0.0-darkbloom")
+        #expect(!fixture.appBundleExists())
+        #expect(try fixture.persistentStateIsIntact())
+
+        let state = try recoveryStore(fixture).loadState()
+        #expect(state.candidate == nil)
+        #expect(state.current?.version == "1.0.0")
+        #expect(state.quarantine?.version == "2.0.0")
+    }
+
     @Test("exhausted tick budget skips the update at a safe point but still restarts")
     func tickDeadlineSkipsUpdateSafely() async throws {
         let fixture = try UpdateRecoveryFixture()

--- a/provider-swift/Tests/ProviderCoreTests/WatchdogRecoveryIntegrationTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/WatchdogRecoveryIntegrationTests.swift
@@ -503,6 +503,174 @@ struct WatchdogRecoveryIntegrationTests {
         #expect(state.quarantine == nil)
     }
 
+    @Test("blocked-rollback candidate retries from the healthy path once its backoff expires")
+    func blockedCandidateRetriesFromHealthyPath() async throws {
+        let context = try await installedCandidate()
+        defer { context.fixture.cleanup() }
+        defer { Task { await context.mock.shutdown() } }
+
+        // Corrupt the rollback material so the third failure REFUSES rollback
+        // and parks the candidate in retry backoff (clearing pendingAttemptID).
+        let predecessorBinary = context.fixture.installRoot
+            .appendingPathComponent(
+                "recovery/predecessor/Darkbloom.app/Contents/MacOS/darkbloom")
+        try Data("tampered predecessor".utf8).write(to: predecessorBinary)
+        _ = await context.service.recoverDownProvider(autoUpdateEnabled: false, now: 200)
+        _ = await context.service.recoverDownProvider(autoUpdateEnabled: false, now: 300)
+        guard case .retryBackoff = await context.service.recoverDownProvider(
+            autoUpdateEnabled: false,
+            now: 400
+        ) else {
+            Issue.record("expected refused rollback to enter retry backoff")
+            return
+        }
+        let parked = try recoveryStore(context.fixture).loadState()
+        #expect(parked.candidate?.pendingAttemptID == nil)
+        #expect(parked.candidate?.retryNotBefore == 700)
+        #expect(parked.candidate?.rollbackBlockedReason != nil)
+
+        // Hung-but-alive candidate: launchd says running, no heartbeat. While
+        // the backoff is active the healthy path must keep waiting…
+        let waiting = context.service.observeHealthyProvider(
+            providerRunning: true,
+            daemonState: nil,
+            now: 650
+        )
+        #expect(waiting == .stabilizing(since: nil))
+
+        // …but once it expires, the healthy path must bridge back into
+        // recovery. Pre-fix this returned .stabilizing forever: with
+        // pendingAttemptID cleared, .inactiveCandidate could never fire again
+        // and the launchd-running hung candidate kept the down path away —
+        // the host stayed wedged indefinitely.
+        let health = context.service.observeHealthyProvider(
+            providerRunning: true,
+            daemonState: nil,
+            now: 701
+        )
+        guard case .blockedCandidateRetry(let reason) = health else {
+            Issue.record("expected blocked-candidate retry bridge, got \(health)")
+            return
+        }
+        #expect(reason.contains("hash mismatch"))
+
+        // The bridged recovery call retries the candidate launch (rollback
+        // stays refused, so the still-intact current install is relaunched
+        // and the attempt is re-armed for future failure attribution).
+        let outcome = await context.service.recoverDownProvider(
+            autoUpdateEnabled: false,
+            providerProcessAlive: true,
+            now: 701
+        )
+        #expect(outcome == .restartIssued(updatedTo: nil, rolledBackTo: nil))
+        let state = try recoveryStore(context.fixture).loadState()
+        #expect(state.candidate?.pendingAttemptID != nil)
+        #expect(state.candidate?.rollbackBlockedReason == nil)
+        #expect(try context.fixture.liveBinaryContents() == "2.0.0-darkbloom")
+    }
+
+    @Test("pending fresh candidate without a blocked rollback is not bridged from the healthy path")
+    func freshPendingCandidateIsNotBridged() async throws {
+        let context = try await installedCandidate()
+        defer { context.fixture.cleanup() }
+        defer { Task { await context.mock.shutdown() } }
+
+        // A candidate awaiting its (provider-owned) restart: pendingAttemptID
+        // cleared, but NO refused rollback. The watchdog must not kill a
+        // serving provider to force an update.
+        let store = recoveryStore(context.fixture)
+        var state = try store.loadState()
+        state.cancelPendingAttempt()
+        try store.writeState(state)
+
+        let oldProviderHeartbeat = DaemonState(
+            pid: 4242,
+            version: "1.0.0",  // serving OLD version — not the candidate
+            writtenAt: 200,
+            startedAt: 150
+        )
+        let health = context.service.observeHealthyProvider(
+            providerRunning: true,
+            daemonState: oldProviderHeartbeat,
+            now: 200
+        )
+        #expect(health == .stabilizing(since: nil))
+    }
+
+    @Test("interrupted flat rollback recovers — predecessor hash covers the legacy symlink")
+    func interruptedFlatRollbackRecovers() async throws {
+        enum InjectedFault: Error { case midRollback }
+        let fixture = try UpdateRecoveryFixture(layout: .flat)
+        defer { fixture.cleanup() }
+        let mock = MockCoordinator(
+            release: fixture.mockReleaseFixture(),
+            releaseArtifact: fixture.artifact
+        )
+        let baseURL = try await mock.start()
+        defer { Task { await mock.shutdown() } }
+
+        // Forward-install v2 with a clean updater.
+        let restarts = RecoveryRestartCounter()
+        let installService = makeService(
+            updater: fixture.updater(baseURL: baseURL),
+            restarts: restarts
+        )
+        let install = await installService.recoverDownProvider(
+            autoUpdateEnabled: true,
+            now: 100
+        )
+        #expect(install == .restartIssued(updatedTo: "2.0.0", rolledBackTo: nil))
+
+        // Fail v2 three times with an updater that dies mid-ROLLBACK, right
+        // after the live layout was replaced (transaction journaled, staging
+        // already consumed by the rename).
+        let fault = OneShotFault()
+        let faultingUpdater = SelfUpdater(
+            coordinatorBaseURL: "http://127.0.0.1:1",
+            installRoot: fixture.installRoot,
+            verifyCodeSignatures: false,
+            currentVersion: fixture.oldVersion,
+            recoveryFaultInjector: { point in
+                if point == .liveLayoutReplaced, fault.claim() {
+                    throw InjectedFault.midRollback
+                }
+            }
+        )
+        let service = makeService(updater: faultingUpdater, restarts: restarts)
+        _ = await service.recoverDownProvider(autoUpdateEnabled: false, now: 200)
+        _ = await service.recoverDownProvider(autoUpdateEnabled: false, now: 300)
+        guard case .retryBackoff = await service.recoverDownProvider(
+            autoUpdateEnabled: false,
+            now: 400
+        ) else {
+            Issue.record("expected the injected mid-rollback fault to defer")
+            return
+        }
+
+        // The next tick must REPLAY the stranded rollback and restart.
+        // Pre-fix, the flat predecessor record hashed only the three regular
+        // files, but every flat restore re-adds the legacy
+        // `eigeninference-enclave` symlink (which treeHash includes), so the
+        // recovery pass failed `liveMatches` on every tick — a permanently
+        // wedged host.
+        let outcome = await service.recoverDownProvider(
+            autoUpdateEnabled: false,
+            now: 500
+        )
+        #expect(outcome == .restartIssued(updatedTo: nil, rolledBackTo: nil))
+        #expect(try fixture.liveBinaryContents() == "1.0.0-darkbloom")
+        let state = try recoveryStore(fixture).loadState()
+        #expect(state.candidate == nil)
+        #expect(state.current?.version == "1.0.0")
+        #expect(state.quarantine?.version == "2.0.0")
+        // The restored live tree keeps the legacy symlink.
+        let legacy = fixture.installRoot.appendingPathComponent("bin/eigeninference-enclave")
+        #expect(
+            (try? FileManager.default.destinationOfSymbolicLink(atPath: legacy.path))
+                == "darkbloom-enclave"
+        )
+    }
+
     @Test("flat predecessor enclave and full tree are verified")
     func flatPredecessorEnclaveVerification() async throws {
         let context = try await installedCandidate(layout: .flat)

--- a/provider-swift/Tests/ProviderCoreTests/WatchdogRecoveryIntegrationTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/WatchdogRecoveryIntegrationTests.swift
@@ -136,6 +136,83 @@ struct WatchdogRecoveryIntegrationTests {
         #expect(try recoveryStore(context.fixture).loadState().predecessor == predecessorBefore)
     }
 
+    @Test("raised preload timeout raises the hung-candidate threshold — no false failure")
+    func raisedPreloadTimeoutAvoidsFalseFailure() async throws {
+        // Operator raised startup_preload_timeout_secs to 420s; the derived
+        // hung-candidate threshold must exceed it (420 + 180 = 600).
+        let derived = WatchdogRecoveryService.candidateStartupTimeout(
+            preloadTimeoutSecs: 420
+        )
+        #expect(derived == 600)
+        #expect(WatchdogRecoveryService.candidateStartupTimeout(
+            preloadTimeoutSecs: 60
+        ) == 300)
+
+        let context = try await installedCandidate(
+            candidateStartupTimeoutSeconds: derived
+        )
+        defer { context.fixture.cleanup() }
+        defer { Task { await context.mock.shutdown() } }
+
+        // 400s into a legitimate 420s preload: process alive, heartbeat not
+        // yet written. The fixed 300s threshold would flag this healthy-but-
+        // slow candidate as hung and charge a false start failure.
+        let health = context.service.observeHealthyProvider(
+            providerRunning: true,
+            daemonState: nil,
+            now: 100 + 400
+        )
+        #expect(health == .stabilizing(since: nil))
+
+        let state = try recoveryStore(context.fixture).loadState()
+        #expect(state.candidate?.failureCount == 0)
+    }
+
+    @Test("exhausted tick budget skips the update at a safe point but still restarts")
+    func tickDeadlineSkipsUpdateSafely() async throws {
+        let fixture = try UpdateRecoveryFixture()
+        defer { fixture.cleanup() }
+        let mock = MockCoordinator(
+            release: fixture.mockReleaseFixture(),
+            releaseArtifact: fixture.artifact
+        )
+        let baseURL = try await mock.start()
+        defer { Task { await mock.shutdown() } }
+
+        let restarts = RecoveryRestartCounter()
+        let service = makeService(
+            updater: fixture.updater(baseURL: baseURL),
+            restarts: restarts,
+            isPastTickDeadline: { true }
+        )
+        let outcome = await service.recoverDownProvider(
+            autoUpdateEnabled: true,
+            now: 100
+        )
+
+        // The newer release was available but the exhausted budget defers it;
+        // the restart action still fires and the live install is untouched.
+        #expect(outcome == .restartIssued(updatedTo: nil, rolledBackTo: nil))
+        #expect(restarts.value == 1)
+        #expect(try fixture.liveBinaryContents() == "1.0.0-darkbloom")
+        let state = try recoveryStore(fixture).loadState()
+        #expect(state.candidate == nil)
+    }
+
+    @Test("watchdog network session is bounded")
+    func watchdogSessionIsBounded() {
+        let session = SelfUpdater.watchdogURLSession()
+        #expect(
+            session.configuration.timeoutIntervalForRequest
+                == SelfUpdater.watchdogRequestTimeoutSeconds
+        )
+        #expect(
+            session.configuration.timeoutIntervalForResource
+                == SelfUpdater.watchdogResourceTimeoutSeconds
+        )
+        #expect(!session.configuration.waitsForConnectivity)
+    }
+
     @Test("new version without heartbeat is a failed start, even if process lives")
     func hungCandidateCountsAsFailedStart() async throws {
         let context = try await installedCandidate()
@@ -613,6 +690,7 @@ struct WatchdogRecoveryIntegrationTests {
 
     private func installedCandidate(
         stabilizationSeconds: Double = 180,
+        candidateStartupTimeoutSeconds: Double = 300,
         layout: VerifiedPredecessor.Layout = .app
     ) async throws -> InstalledContext {
         let fixture = try UpdateRecoveryFixture(layout: layout)
@@ -626,7 +704,8 @@ struct WatchdogRecoveryIntegrationTests {
         let service = makeService(
             updater: updater,
             restarts: restarts,
-            stabilizationSeconds: stabilizationSeconds
+            stabilizationSeconds: stabilizationSeconds,
+            candidateStartupTimeoutSeconds: candidateStartupTimeoutSeconds
         )
         let outcome = await service.recoverDownProvider(
             autoUpdateEnabled: true,
@@ -649,7 +728,9 @@ struct WatchdogRecoveryIntegrationTests {
     private func makeService(
         updater: SelfUpdater,
         restarts: RecoveryRestartCounter,
-        stabilizationSeconds: Double = 180
+        stabilizationSeconds: Double = 180,
+        candidateStartupTimeoutSeconds: Double = 300,
+        isPastTickDeadline: @escaping @Sendable () -> Bool = { false }
     ) -> WatchdogRecoveryService {
         WatchdogRecoveryService(
             updater: updater,
@@ -658,10 +739,15 @@ struct WatchdogRecoveryIntegrationTests {
                     restarts.increment()
                     return true
                 },
+                // Injected: tests must never shell out to the real
+                // `launchctl print` for the host's provider job.
+                launchSnapshot: { nil },
                 processAlive: { _ in true },
+                isPastTickDeadline: isPastTickDeadline,
                 log: { _ in }
             ),
-            stabilizationSeconds: stabilizationSeconds
+            stabilizationSeconds: stabilizationSeconds,
+            candidateStartupTimeoutSeconds: candidateStartupTimeoutSeconds
         )
     }
 

--- a/provider-swift/Tests/ProviderCoreTests/WatchdogRecoveryIntegrationTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/WatchdogRecoveryIntegrationTests.swift
@@ -867,6 +867,55 @@ struct WatchdogRecoveryIntegrationTests {
         #expect(try fixture.liveBinaryContents() == "1.0.0-darkbloom")
     }
 
+    @Test("no-candidate restart survives an unwritable recovery state")
+    func noCandidateRestartSurvivesUnwritableState() async throws {
+        let fixture = try UpdateRecoveryFixture()
+        defer { fixture.cleanup() }
+        let store = recoveryStore(fixture)
+
+        // Materialize the recovery dir + lock file while the dir is still
+        // writable (the session open only needs to reopen the existing lock).
+        try UpdateProcessLock.acquire(
+            at: store.lockPath,
+            operation: "seed-lock"
+        ).release()
+
+        // Then the recovery dir becomes unwritable (full-disk/permissions
+        // class). No candidate exists, so ALL launch bookkeeping is vacuous —
+        // the plain restart must still go through.
+        let fm = FileManager.default
+        try fm.setAttributes(
+            [.posixPermissions: 0o555],
+            ofItemAtPath: store.recoveryRoot.path
+        )
+        defer {
+            try? fm.setAttributes(
+                [.posixPermissions: 0o755],
+                ofItemAtPath: store.recoveryRoot.path
+            )
+        }
+
+        let restarts = RecoveryRestartCounter()
+        let updater = SelfUpdater(
+            coordinatorBaseURL: "http://127.0.0.1:1",
+            installRoot: fixture.installRoot,
+            verifyCodeSignatures: false,
+            currentVersion: fixture.oldVersion
+        )
+        let service = makeService(updater: updater, restarts: restarts)
+        let outcome = await service.recoverDownProvider(
+            autoUpdateEnabled: false,
+            now: 100
+        )
+
+        // Pre-fix, the vacuous prepareLaunchIntent write threw on the
+        // read-only dir and the watchdog returned .failed without ever
+        // kickstarting — a host that needed nothing but `launchctl
+        // kickstart` stayed down for as long as the disk stayed full.
+        #expect(outcome == .restartIssued(updatedTo: nil, rolledBackTo: nil))
+        #expect(restarts.value == 1)
+    }
+
     @Test("live lock owner still defers the watchdog — degraded fallback never fires past contention")
     func liveLockOwnerStillDefers() async throws {
         let fixture = try UpdateRecoveryFixture()

--- a/provider-swift/Tests/ProviderCoreTests/WatchdogTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/WatchdogTests.swift
@@ -171,6 +171,44 @@ struct WatchdogProbeParseTests {
         #expect(!WatchdogProbe.parseRunning("\tpid = 0"))
         #expect(!WatchdogProbe.parseRunning(""))
     }
+
+    @Test("stale heartbeat from the live daemon marks it inactive")
+    func staleLiveDaemonIsInactive() {
+        let state = DaemonState(
+            pid: 42,
+            version: "1.0.0",
+            writtenAt: 100,
+            startedAt: 10
+        )
+        #expect(!WatchdogProbe.providerActive(
+            processRunning: true,
+            daemonState: state,
+            now: 500,
+            processAlive: { $0 == 42 }
+        ))
+    }
+
+    @Test("fresh heartbeat or unrelated old state preserves activity")
+    func freshOrUnrelatedState() {
+        let state = DaemonState(
+            pid: 42,
+            version: "1.0.0",
+            writtenAt: 480,
+            startedAt: 10
+        )
+        #expect(WatchdogProbe.providerActive(
+            processRunning: true,
+            daemonState: state,
+            now: 500,
+            processAlive: { $0 == 42 }
+        ))
+        #expect(WatchdogProbe.providerActive(
+            processRunning: true,
+            daemonState: state,
+            now: 1_000,
+            processAlive: { _ in false }
+        ))
+    }
 }
 
 /// The watchdog launchd plist shape.

--- a/provider-swift/Tests/ProviderCoreTests/WatchdogTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/WatchdogTests.swift
@@ -254,6 +254,46 @@ struct WatchdogAgentPlistTests {
         #expect(plist["StandardErrorPath"] as? String == "/tmp/watchdog.log")
     }
 
+    @Test("re-arm preserves the installed plist config when no override is given")
+    func rearmPreservesInstalledConfig() {
+        let installedArguments = [
+            "/opt/darkbloom",
+            "watchdog",
+            "--config",
+            "/tmp/custom-provider.toml",
+        ]
+        let installed = WatchdogAgent.configPathArgument(in: installedArguments)
+        #expect(installed?.path == "/tmp/custom-provider.toml")
+
+        // No explicit --config on `darkbloom restart`: the previously
+        // installed custom config MUST survive the plist rewrite.
+        let preserved = WatchdogAgent.rearmConfigPath(
+            explicit: nil,
+            installed: installed
+        )
+        #expect(preserved?.path == "/tmp/custom-provider.toml")
+
+        // An explicit override wins over the installed value.
+        let overridden = WatchdogAgent.rearmConfigPath(
+            explicit: "/tmp/other.toml",
+            installed: installed
+        )
+        #expect(overridden?.path == "/tmp/other.toml")
+
+        // Short flag parses too; missing value or absent flag yields nil.
+        #expect(
+            WatchdogAgent.configPathArgument(
+                in: ["/opt/darkbloom", "watchdog", "-c", "/tmp/short.toml"]
+            )?.path == "/tmp/short.toml"
+        )
+        #expect(WatchdogAgent.configPathArgument(
+            in: ["/opt/darkbloom", "watchdog", "--config"]
+        ) == nil)
+        #expect(WatchdogAgent.configPathArgument(
+            in: ["/opt/darkbloom", "watchdog"]
+        ) == nil)
+    }
+
     @Test("plist propagates custom config and update opt-out environment")
     func configAndEnvironment() {
         let arguments = [

--- a/provider-swift/Tests/ProviderCoreTests/WatchdogTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/WatchdogTests.swift
@@ -251,6 +251,28 @@ struct WatchdogProbeParseTests {
     }
 }
 
+@Suite("Watchdog re-arm action")
+struct WatchdogRearmActionTests {
+    @Test("auto_restart=true always arms")
+    func armWhenEnabled() {
+        #expect(WatchdogAgent.rearmAction(autoRestartEnabled: true, isLoaded: false) == .arm)
+        #expect(WatchdogAgent.rearmAction(autoRestartEnabled: true, isLoaded: true) == .arm)
+    }
+
+    @Test("auto_restart=false disarms a loaded watchdog instead of leaving the stale job")
+    func disarmWhenOptedOutAndLoaded() {
+        // Pre-fix, an opted-out config left a previously armed watchdog
+        // running on its OLD plist config, which could keep relaunching the
+        // provider after crashes despite the opt-out.
+        #expect(WatchdogAgent.rearmAction(autoRestartEnabled: false, isLoaded: true) == .disarm)
+    }
+
+    @Test("auto_restart=false with nothing loaded does nothing")
+    func noopWhenOptedOutAndUnloaded() {
+        #expect(WatchdogAgent.rearmAction(autoRestartEnabled: false, isLoaded: false) == nil)
+    }
+}
+
 @Suite("Provider launch receipt")
 struct ProviderLaunchSnapshotTests {
     @Test("launchctl runs and PID produce crash-safe launch proof")

--- a/provider-swift/Tests/ProviderCoreTests/WatchdogTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/WatchdogTests.swift
@@ -233,6 +233,87 @@ struct ProviderLaunchSnapshotTests {
     }
 }
 
+@Suite("Watchdog provider identity (PID reuse)")
+struct WatchdogProviderIdentityTests {
+    private func stateWithIdentity(_ identity: ProcessIdentity?) -> DaemonState {
+        DaemonState(
+            pid: 4242,
+            processIdentity: identity,
+            version: "2.0.0",
+            writtenAt: 100,
+            startedAt: 50
+        )
+    }
+
+    @Test("a reused daemon-state PID whose start time differs is NOT the provider identity")
+    func reusedPidIsNotProviderIdentity() {
+        let recorded = ProcessIdentity(pid: 4242, startTimeMicros: 111)
+        let state = stateWithIdentity(recorded)
+        // The PID is live again but with a DIFFERENT start time — the kernel
+        // reused it (e.g. for a manual `darkbloom update` holding the lock). It
+        // must NOT be treated as the provider (which would force-kill it); we
+        // fall back to the launchd snapshot (nil here).
+        let reused = ProcessIdentity(pid: 4242, startTimeMicros: 999)
+        #expect(
+            WatchdogProbe.providerIdentity(
+                daemonState: state,
+                launchSnapshotProcess: nil,
+                readIdentity: { _ in reused }
+            ) == nil
+        )
+        // A MATCHING live start time IS trusted.
+        #expect(
+            WatchdogProbe.providerIdentity(
+                daemonState: state,
+                launchSnapshotProcess: nil,
+                readIdentity: { _ in recorded }
+            ) == recorded
+        )
+    }
+
+    @Test("a dead daemon-state PID falls back to the launchd snapshot")
+    func deadPidFallsBackToSnapshot() {
+        let state = stateWithIdentity(ProcessIdentity(pid: 4242, startTimeMicros: 111))
+        let fallback = ProcessIdentity(pid: 77, startTimeMicros: 3)
+        #expect(
+            WatchdogProbe.providerIdentity(
+                daemonState: state,
+                launchSnapshotProcess: fallback,
+                readIdentity: { _ in nil }
+            ) == fallback
+        )
+    }
+
+    @Test("a daemon-state without a recorded identity uses the launchd snapshot")
+    func missingRecordedIdentityUsesSnapshot() {
+        let state = stateWithIdentity(nil)
+        let fallback = ProcessIdentity(pid: 77, startTimeMicros: 3)
+        #expect(
+            WatchdogProbe.providerIdentity(
+                daemonState: state,
+                launchSnapshotProcess: fallback,
+                readIdentity: { _ in ProcessIdentity(pid: 4242, startTimeMicros: 5) }
+            ) == fallback
+        )
+    }
+
+    @Test("ProcessIdentity.read returns nil for a nonexistent pid")
+    func readReturnsNilForDeadPid() throws {
+        // Deterministic: PIDs never reach Int32.max on macOS; proc_pidinfo
+        // returns a zero-length read, which the size guard rejects.
+        #expect(ProcessIdentity.read(pid: Int32.max) == nil)
+        #expect(ProcessIdentity.read(pid: 0) == nil)
+        #expect(ProcessIdentity.read(pid: -1) == nil)
+
+        // A real, reaped process is the realistic "nonexistent pid" case.
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/true")
+        try process.run()
+        process.waitUntilExit()
+        #expect(ProcessIdentity.read(pid: process.processIdentifier) == nil)
+    }
+}
+
 /// The watchdog launchd plist shape.
 @Suite("Watchdog agent plist")
 struct WatchdogAgentPlistTests {

--- a/provider-swift/Tests/ProviderCoreTests/WatchdogTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/WatchdogTests.swift
@@ -211,32 +211,101 @@ struct WatchdogProbeParseTests {
     }
 }
 
+@Suite("Provider launch receipt")
+struct ProviderLaunchSnapshotTests {
+    @Test("launchctl runs and PID produce crash-safe launch proof")
+    func parsesAndCompares() {
+        let identity = ProcessIdentity(pid: 42, startTimeMicros: 7)
+        let baseline = LaunchAgent.parseLaunchSnapshot(
+            label: LaunchAgent.label,
+            output: "runs = 10\npid = 42",
+            identityReader: { _ in identity }
+        )
+        let advanced = LaunchAgent.parseLaunchSnapshot(
+            label: LaunchAgent.label,
+            output: "runs = 11\npid = 42",
+            identityReader: { _ in identity }
+        )
+        #expect(baseline.runs == 10)
+        #expect(baseline.process == identity)
+        #expect(advanced.provesLaunch(after: baseline))
+        #expect(!baseline.provesLaunch(after: baseline))
+    }
+}
+
 /// The watchdog launchd plist shape.
 @Suite("Watchdog agent plist")
 struct WatchdogAgentPlistTests {
-    @Test("plist runs `darkbloom watchdog` on a one-minute interval at load")
+    @Test("plist keeps one persistent watchdog alive and delegates cadence internally")
     func plistShape() {
         let plist = WatchdogAgent.makeWatchdogPlist(
             label: "io.darkbloom.watchdog",
             programArguments: ["/usr/local/bin/darkbloom", "watchdog"],
-            logPath: "/tmp/watchdog.log",
-            intervalSeconds: 60
+            logPath: "/tmp/watchdog.log"
         )
         #expect(plist["Label"] as? String == "io.darkbloom.watchdog")
         #expect(plist["ProgramArguments"] as? [String] == ["/usr/local/bin/darkbloom", "watchdog"])
-        #expect(plist["StartInterval"] as? Int == 60)
+        #expect(plist["StartInterval"] == nil)
         #expect(plist["RunAtLoad"] as? Bool == true)
-        // Cadence is StartInterval's job; the watchdog must not KeepAlive.
-        #expect(plist["KeepAlive"] as? Bool == false)
+        #expect(plist["KeepAlive"] as? Bool == true)
+        #expect(plist["ThrottleInterval"] as? Int == 10)
         #expect(plist["ProcessType"] as? String == "Background")
         #expect(plist["StandardOutPath"] as? String == "/tmp/watchdog.log")
         #expect(plist["StandardErrorPath"] as? String == "/tmp/watchdog.log")
+    }
+
+    @Test("plist propagates custom config and update opt-out environment")
+    func configAndEnvironment() {
+        let arguments = [
+            "/opt/darkbloom",
+            "watchdog",
+            "--config",
+            "/tmp/provider.toml",
+        ]
+        let plist = WatchdogAgent.makeWatchdogPlist(
+            label: "io.darkbloom.watchdog",
+            programArguments: arguments,
+            logPath: "/tmp/watchdog.log",
+            environment: [
+                "DARKBLOOM_NO_UPDATE_CHECK": "1",
+                "UNRELATED_SECRET": "no",
+            ]
+        )
+        #expect(plist["ProgramArguments"] as? [String] == arguments)
+        let environment = plist["EnvironmentVariables"] as? [String: String]
+        #expect(environment == ["DARKBLOOM_NO_UPDATE_CHECK": "1"])
     }
 
     @Test("the watchdog label is distinct from the provider label")
     func distinctLabel() {
         #expect(WatchdogAgent.label != LaunchAgent.label)
         #expect(LaunchAgent.supportedLabels.contains(LaunchAgent.label))
+    }
+}
+
+@Suite("Watchdog persistent cadence", .serialized)
+struct WatchdogSchedulerTests {
+    @Test("real monotonic timer repeats and cancels without spinning")
+    func cadenceAndCancellation() async throws {
+        let (stream, continuation) = AsyncStream<Double>.makeStream()
+        let task = Task {
+            await WatchdogScheduler(interval: .milliseconds(20)).run {
+                continuation.yield(ProcessInfo.processInfo.systemUptime)
+            }
+        }
+        var times: [Double] = []
+        for await time in stream {
+            times.append(time)
+            if times.count == 3 { break }
+        }
+        task.cancel()
+        await task.value
+        continuation.finish()
+
+        #expect(times.count == 3)
+        for pair in zip(times, times.dropFirst()) {
+            #expect(pair.1 - pair.0 >= 0.012)
+        }
     }
 }
 

--- a/provider-swift/Tests/ProviderCoreTests/WatchdogTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/WatchdogTests.swift
@@ -209,6 +209,46 @@ struct WatchdogProbeParseTests {
             processAlive: { _ in false }
         ))
     }
+
+    @Test("stale record whose PID the kernel reused cannot demote launchd liveness")
+    func pidReuseCannotDemoteLiveness() {
+        let recorded = ProcessIdentity(pid: 42, startTimeMicros: 7)
+        let state = DaemonState(
+            pid: 42,
+            processIdentity: recorded,
+            version: "1.0.0",
+            writtenAt: 100,
+            startedAt: 10
+        )
+        // PID 42 is alive but belongs to a DIFFERENT process (start time
+        // differs): the record came from a dead provider, so the stale
+        // heartbeat must not override launchd's "running" — pre-fix this
+        // returned false and the watchdog could restart or charge a candidate
+        // failure against a healthy provider.
+        #expect(WatchdogProbe.providerActive(
+            processRunning: true,
+            daemonState: state,
+            now: 500,
+            processAlive: { $0 == 42 },
+            readIdentity: { _ in ProcessIdentity(pid: 42, startTimeMicros: 99) }
+        ))
+        // Same kernel identity → the stale record demotes, as before.
+        #expect(!WatchdogProbe.providerActive(
+            processRunning: true,
+            daemonState: state,
+            now: 500,
+            processAlive: { $0 == 42 },
+            readIdentity: { _ in recorded }
+        ))
+        // Fresh record from the matching identity stays active.
+        #expect(WatchdogProbe.providerActive(
+            processRunning: true,
+            daemonState: state,
+            now: 150,
+            processAlive: { $0 == 42 },
+            readIdentity: { _ in recorded }
+        ))
+    }
 }
 
 @Suite("Provider launch receipt")


### PR DESCRIPTION
## Summary

Incident follow-up for the v0.7.6 fleet outage (2026-07-10): crashed providers could not self-recover because the watchdog LaunchAgent's one-shot `StartInterval` timer never re-fired (launchd left the GUI domain in on-demand-only mode; observed live: `pending spawn, domain in on-demand-only mode`, `runs = 1`), and the background updater only starts after coordinator registration — so a provider that crashes before registering never sees a fixed release.

This PR makes the watchdog the recovery authority when the provider is down:

- **Persistent watchdog process** (`RunAtLoad` + `KeepAlive`, no `StartInterval`): internal monotonic cadence with clean cancellation, replacing the proven-broken one-shot timer.
- **Update-before-restart**: when the provider is loaded-but-down, the watchdog checks the coordinator for a newer signed release, downloads, verifies (Team ID + designated requirement pinned), atomically installs, then kickstarts. Respects `auto_update=false`, custom `--config`, and `DARKBLOOM_NO_UPDATE_CHECK`.
- **Automatic rollback**: one durable, signature+hash-verified predecessor is retained across updates. Failures are attributed only to proven launches (launchd receipt reconciliation). After **3 failed starts of a newly installed version**, the watchdog atomically restores the predecessor and quarantines the exact failed version; strictly newer releases escape quarantine, and `darkbloom update --override-quarantine` is the loud manual escape.
- **Crash-safe throughout**: journaled two-phase installs with `renameatx_np` swap, fail-closed directory fsync, replay across power loss at every rename boundary, kernel `flock` update lock with PID+start-time stale-owner takeover, full SemVer 2.0 comparison, bounded per-tick network/time budgets that can only defer at safe points.
- **Documented residual** (threat model T-043): the watchdog is still the same replaceable binary — a reboot into a binary-level-broken candidate remains unrecoverable without a future independent bootstrap executable.

## Before

```mermaid
flowchart LR
  subgraph Behavior_Before[Behavior before]
    A1[Provider crashes on bad release] --> B1[Watchdog StartInterval tick]
    B1 -- "launchd on-demand-only: never fires again" --> C1[No restart, no update]
    C1 --> D1[Machine offline until manual darkbloom update]
  end
  subgraph Code_Before[Code before]
    E1[WatchdogAgent plist StartInterval=60 KeepAlive=false] --> F1[WatchdogCommand one-shot tick]
    F1 --> G1[kickstartIfLoaded only - no update, no rollback]
  end
```

## After

```mermaid
flowchart LR
  subgraph Behavior_After[Behavior after]
    A2[Provider crashes on bad release] --> B2[Persistent watchdog monotonic tick]
    B2 --> C2{Newer signed release?}
    C2 -- yes --> D2[Verify + atomic install + kickstart]
    C2 -- no --> E2[Kickstart current]
    D2 --> F2{3 failed starts of new version?}
    F2 -- yes --> G2[Verified rollback to predecessor + quarantine exact version]
    F2 -- no --> H2[Stabilize 10 min -> promote]
  end
  subgraph Code_After[Code after]
    I2[WatchdogAgent plist RunAtLoad+KeepAlive] --> J2[WatchdogScheduler ContinuousClock loop]
    J2 --> K2[WatchdogRecoveryService: flock lease, launch receipts, journaled installs]
    K2 --> L2[UpdateRecoveryState: attempts, quarantine, predecessor rotation]
  end
```

## Test plan
- [x] 97 watchdog/update/recovery tests (16 suites), incl. fails-without-fix regressions for every review finding
- [x] Full provider/CLI suite: 1,120 tests / 125 suites, clean from-scratch build
- [x] Clean release build; threat-model YAML parses
- [x] Real-artifact integration tests: local HTTP release server, journaled install, power-loss replay at all 6 boundaries × both layouts, killed lock owners, ad-hoc signature rejection
- [x] Three adversarial review rounds (2 independent reviewers); all P0/P1 findings fixed with tests
- [ ] Signed canary: one real update + forced-crash rollback on a real install; watchdog across logout/login/reboot

Co-developed during the v0.7.6 incident response; see JOURNAL for the full forensic record.

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/534"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786326278&installation_id=133247490&pr_number=534&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F534&signature=08ff61d492b8b945c15376c477738ad755c8596bef49f73182ae3994e185d581"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->