### PR TITLE
fix(provider): make paged KV opt-in, resource-safe, and physically bounded

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,7 @@ jobs:
             ~/Library/Caches/org.swift.swiftpm
             ~/Library/org.swift.swiftpm
             provider-swift/.build
+            libs/mlx-swift-lm/.build
           key: spm-v1-${{ runner.os }}-${{ hashFiles('provider-swift/Package.resolved', 'libs/mlx-swift/Package.swift', 'libs/mlx-swift-lm/Package.swift') }}
           restore-keys: |
             spm-v1-${{ runner.os }}-
@@ -89,6 +90,7 @@ jobs:
           # runner. Place it in both locations to cover `swift run`/built-binary
           # paths and the test runner. Fail loudly if the source isn't there.
           test -f "$metallib" || { echo "::error::mlx.metallib not found at $metallib"; exit 1; }
+          cp "$metallib" "$RUNNER_TEMP/mlx.metallib"
           cp "$metallib" .build/debug/mlx.metallib
           for bundle in .build/debug/*PackageTests.xctest; do
             macos="$bundle/Contents/MacOS"
@@ -102,6 +104,26 @@ jobs:
         # NOTE: do NOT pass --build-tests-relinking flags; the bundle is already
         # built above, so `swift test` reuses it (and our colocated metallib).
         run: swift test
+      - name: Build nested paged safety tests
+        working-directory: libs/mlx-swift-lm
+        timeout-minutes: 5
+        run: swift build --build-tests
+      - name: Run nested paged safety tests directly
+        working-directory: libs/mlx-swift-lm
+        timeout-minutes: 2
+        run: |
+          set -euo pipefail
+          cp "$RUNNER_TEMP/mlx.metallib" .build/debug/mlx.metallib
+          for bundle in .build/debug/*PackageTests.xctest; do
+            macos="$bundle/Contents/MacOS"
+            if [ -d "$macos" ]; then
+              cp "$RUNNER_TEMP/mlx.metallib" "$macos/mlx.metallib"
+            fi
+          done
+          swift test --skip-build --filter CBv2PagedSafetyTests
+      - name: Run atomic installer artifact tests
+        timeout-minutes: 2
+        run: ./scripts/test-install-atomic.sh
 
   cache-swift:
     name: Swift Build + Cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,9 +69,9 @@ jobs:
             ~/Library/org.swift.swiftpm
             provider-swift/.build
             libs/mlx-swift-lm/.build
-          key: spm-v1-${{ runner.os }}-${{ hashFiles('provider-swift/Package.resolved', 'libs/mlx-swift/Package.swift', 'libs/mlx-swift-lm/Package.swift') }}
+          key: spm-v2-${{ runner.os }}-${{ hashFiles('provider-swift/Package.resolved', 'libs/mlx-swift/Package.swift', 'libs/mlx-swift-lm/Package.swift') }}
           restore-keys: |
-            spm-v1-${{ runner.os }}-
+            spm-v2-${{ runner.os }}-
       - name: Build provider-swift (incl. tests)
         working-directory: provider-swift
         # Build the TEST bundle too, so the .xctest bundle exists before we
@@ -106,11 +106,14 @@ jobs:
         run: swift test
       - name: Build nested paged safety tests
         working-directory: libs/mlx-swift-lm
-        timeout-minutes: 5
+        # Cold builds compile the full Cmlx C++/Metal tree (~20 min on the
+        # 12-vcpu runner); warm runs restore libs/mlx-swift-lm/.build from
+        # the SwiftPM cache and finish in ~1 min.
+        timeout-minutes: 35
         run: swift build --build-tests
       - name: Run nested paged safety tests directly
         working-directory: libs/mlx-swift-lm
-        timeout-minutes: 2
+        timeout-minutes: 10
         run: |
           set -euo pipefail
           cp "$RUNNER_TEMP/mlx.metallib" .build/debug/mlx.metallib
@@ -140,12 +143,19 @@ jobs:
             ~/Library/Caches/org.swift.swiftpm
             ~/Library/org.swift.swiftpm
             provider-swift/.build
-          key: spm-v1-${{ runner.os }}-${{ hashFiles('provider-swift/Package.resolved', 'libs/mlx-swift/Package.swift', 'libs/mlx-swift-lm/Package.swift') }}
+            libs/mlx-swift-lm/.build
+          key: spm-v2-${{ runner.os }}-${{ hashFiles('provider-swift/Package.resolved', 'libs/mlx-swift/Package.swift', 'libs/mlx-swift-lm/Package.swift') }}
           restore-keys: |
-            spm-v1-${{ runner.os }}-
+            spm-v2-${{ runner.os }}-
       - name: Build provider-swift
         working-directory: provider-swift
         run: swift build -c release --product darkbloom
+      - name: Build nested mlx-swift-lm tests (warms nested cache)
+        working-directory: libs/mlx-swift-lm
+        # The test-provider job runs CBv2PagedSafetyTests from this nested
+        # .build; saving it here keeps that lane warm across PRs.
+        timeout-minutes: 35
+        run: swift build --build-tests
       - name: Save SwiftPM cache
         uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
@@ -153,7 +163,8 @@ jobs:
             ~/Library/Caches/org.swift.swiftpm
             ~/Library/org.swift.swiftpm
             provider-swift/.build
-          key: spm-v1-${{ runner.os }}-${{ hashFiles('provider-swift/Package.resolved', 'libs/mlx-swift/Package.swift', 'libs/mlx-swift-lm/Package.swift') }}
+            libs/mlx-swift-lm/.build
+          key: spm-v2-${{ runner.os }}-${{ hashFiles('provider-swift/Package.resolved', 'libs/mlx-swift/Package.swift', 'libs/mlx-swift-lm/Package.swift') }}
 
   lint-console:
     name: Console UI Lint & Build

--- a/.github/workflows/release-swift.yml
+++ b/.github/workflows/release-swift.yml
@@ -6,6 +6,7 @@ name: Release Provider Bundle (Swift)
 #   - bin/darkbloom          (provider CLI)
 #   - bin/darkbloom-enclave  (Secure Enclave attestation/sign helper)
 #   - bin/mlx.metallib       (compiled Metal kernels for the matching MLX)
+#   - Darkbloom.app/Contents/Resources/*.bundle (SwiftPM resources)
 #
 # install.sh creates a backward-compatibility symlink from the legacy
 # `eigeninference-enclave` name to `darkbloom-enclave` for existing
@@ -340,7 +341,7 @@ jobs:
       # blocking signed releases on CI hardware timing differences.
 
       # ----------------------------------------------------------------------
-      # Stage the bundle: bin/darkbloom, bin/darkbloom-enclave, bin/mlx.metallib
+      # Stage the app, every SwiftPM runtime bundle, and flat verifier files.
       # ----------------------------------------------------------------------
 
       - name: Embed provisioning profile
@@ -471,6 +472,23 @@ jobs:
             echo "Provisioning profile embedded in app bundle"
           fi
 
+          # Copy every product resource bundle into the canonical signed-app
+          # resource directory before signing/notarizing. PagedAttention uses
+          # a catchable locator instead of SwiftPM's fatal Bundle.module
+          # accessor and searches this sealed location. This includes
+          # mlx-swift-lm_MLXLMCommon.bundle/pagedattention.metal and future
+          # dependency resource bundles.
+          RESOURCE_MANIFEST=/tmp/darkbloom-swiftpm-resource-bundles.txt
+          scripts/stage-swiftpm-resource-bundles.sh \
+            "$BIN_DIR" "$APP" "$RESOURCE_MANIFEST"
+
+          # Package-real runtime gate. This invokes the staged executable,
+          # resolves the resource from the installed app layout, JIT-compiles
+          # the paged bulk-write kernel, and executes a tiny dispatch. The
+          # v0.7.6 artifact fails here because its bundle is absent.
+          DARKBLOOM_NO_UPDATE_CHECK=1 \
+            "$APP/Contents/MacOS/$CLI_NAME" runtime-smoke
+
           # Hardened-runtime sign each binary and resource, then the bundle.
           # mlx.metallib must be signed before the bundle or codesign rejects
           # it as an unsigned subcomponent.
@@ -494,7 +512,7 @@ jobs:
             --keychain "$KEYCHAIN_PATH" \
             --sign "$DEVELOPER_ID" "$APP"
 
-          codesign --verify --verbose=2 "$APP"
+          codesign --verify --deep --strict --verbose=2 "$APP"
           codesign --verify --verbose=2 "$APP/Contents/MacOS/$CLI_NAME"
 
           # Persistent Secure Enclave key requires keychain-access-groups
@@ -629,6 +647,24 @@ jobs:
           grep -qx './bin/darkbloom' /tmp/darkbloom-bundle-files.txt
           grep -qx './bin/darkbloom-enclave' /tmp/darkbloom-bundle-files.txt
           grep -qx './bin/mlx.metallib' /tmp/darkbloom-bundle-files.txt
+          while IFS= read -r bundle_name; do
+            grep -qx \
+              "./Darkbloom.app/Contents/Resources/${bundle_name}/" \
+              /tmp/darkbloom-bundle-files.txt
+          done < /tmp/darkbloom-swiftpm-resource-bundles.txt
+          grep -qx \
+            './Darkbloom.app/Contents/Resources/mlx-swift-lm_MLXLMCommon.bundle/pagedattention.metal' \
+            /tmp/darkbloom-bundle-files.txt
+
+          # Verify the FINAL archived layout, not merely the staging tree.
+          # This runs after signing, notarization, stapling, and tar rebuild,
+          # and before any upload or coordinator registration.
+          SMOKE_ROOT=/tmp/darkbloom-final-artifact-smoke
+          rm -rf "$SMOKE_ROOT"
+          mkdir -p "$SMOKE_ROOT"
+          tar xzf /tmp/darkbloom-bundle-macos-arm64.tar.gz -C "$SMOKE_ROOT"
+          DARKBLOOM_NO_UPDATE_CHECK=1 \
+            "$SMOKE_ROOT/Darkbloom.app/Contents/MacOS/$CLI_NAME" runtime-smoke
 
           BINARY_HASH=$(shasum -a 256 "${{ steps.bundle.outputs.stage }}/bin/$CLI_NAME" | cut -d' ' -f1)
           BUNDLE_HASH=$(shasum -a 256 /tmp/darkbloom-bundle-macos-arm64.tar.gz | cut -d' ' -f1)

--- a/.github/workflows/release-swift.yml
+++ b/.github/workflows/release-swift.yml
@@ -483,9 +483,10 @@ jobs:
             "$BIN_DIR" "$APP" "$RESOURCE_MANIFEST"
 
           # Package-real runtime gate. This invokes the staged executable,
-          # resolves the resource from the installed app layout, JIT-compiles
-          # the paged bulk-write kernel, and executes a tiny dispatch. The
-          # v0.7.6 artifact fails here because its bundle is absent.
+          # resolves the resource from the installed app layout, then
+          # JIT-compiles and executes GPT-OSS bulk-write, decode-part, and
+          # decode-merge variants. The v0.7.6 artifact fails here because
+          # its bundle is absent.
           DARKBLOOM_NO_UPDATE_CHECK=1 \
             "$APP/Contents/MacOS/$CLI_NAME" runtime-smoke
 
@@ -654,6 +655,9 @@ jobs:
           done < /tmp/darkbloom-swiftpm-resource-bundles.txt
           grep -qx \
             './Darkbloom.app/Contents/Resources/mlx-swift-lm_MLXLMCommon.bundle/pagedattention.metal' \
+            /tmp/darkbloom-bundle-files.txt
+          grep -qx \
+            './Darkbloom.app/Contents/Resources/darkbloom-runtime-capabilities/paged-kernel-v1' \
             /tmp/darkbloom-bundle-files.txt
 
           # Verify the FINAL archived layout, not merely the staging tree.

--- a/.github/workflows/release-swift.yml
+++ b/.github/workflows/release-swift.yml
@@ -209,9 +209,10 @@ jobs:
             ~/Library/Caches/org.swift.swiftpm
             ~/Library/org.swift.swiftpm
             provider-swift/.build
-          key: spm-v1-${{ runner.os }}-${{ hashFiles('provider-swift/Package.resolved', 'libs/mlx-swift/Package.swift', 'libs/mlx-swift-lm/Package.swift') }}
+            libs/mlx-swift-lm/.build
+          key: spm-v2-${{ runner.os }}-${{ hashFiles('provider-swift/Package.resolved', 'libs/mlx-swift/Package.swift', 'libs/mlx-swift-lm/Package.swift') }}
           restore-keys: |
-            spm-v1-${{ runner.os }}-
+            spm-v2-${{ runner.os }}-
 
       # ----------------------------------------------------------------------
       # Build mlx.metallib (compiled Metal GPU kernels) FROM SOURCE.
@@ -334,7 +335,8 @@ jobs:
             ~/Library/Caches/org.swift.swiftpm
             ~/Library/org.swift.swiftpm
             provider-swift/.build
-          key: spm-v1-${{ runner.os }}-${{ hashFiles('provider-swift/Package.resolved', 'libs/mlx-swift/Package.swift', 'libs/mlx-swift-lm/Package.swift') }}
+            libs/mlx-swift-lm/.build
+          key: spm-v2-${{ runner.os }}-${{ hashFiles('provider-swift/Package.resolved', 'libs/mlx-swift/Package.swift', 'libs/mlx-swift-lm/Package.swift') }}
 
       # Unit tests are run by CI (ci.yml + integration.yml) on push to
       # master. Skipped here to avoid flaky live MLX inference tests

--- a/coordinator/api/install.sh
+++ b/coordinator/api/install.sh
@@ -25,6 +25,227 @@ set -euo pipefail
 COORD_URL="${COORD_URL:-__DARKBLOOM_COORD_URL__}"
 INSTALL_DIR="$HOME/.darkbloom"
 BIN_DIR="$INSTALL_DIR/bin"
+EXPECTED_TEAM_ID="SLDQ2GJ6TL"
+INSTALL_TEST_MODE=0
+
+fail_install() {
+    echo "  ✗ $*" >&2
+    return 1
+}
+
+verify_file_hash() {
+    local file=$1
+    local expected=$2
+    local label=$3
+    [ -z "$expected" ] && return 0
+    local actual
+    actual=$(shasum -a 256 "$file" | cut -d' ' -f1)
+    [ "$actual" = "$expected" ] \
+        || fail_install "$label hash mismatch (expected $expected, got $actual)."
+}
+
+binary_contains_paged_code() {
+    local binary=$1
+    local count
+    count=$(strings "$binary" | grep -c 'engine_v2_kv_backend' || true)
+    [ "$count" -gt 0 ]
+}
+
+verify_staged_app() {
+    local app=$1
+    local executable="$app/Contents/MacOS/darkbloom"
+    local marker="$app/Contents/Resources/darkbloom-runtime-capabilities/paged-kernel-v1"
+
+    codesign --verify --deep --strict --verbose=2 "$app" >/dev/null 2>&1 \
+        || {
+            fail_install "Strict code-signature verification failed for staged Darkbloom.app."
+            return 1
+        }
+
+    if [ "$INSTALL_TEST_MODE" != "1" ]; then
+        local team
+        team=$(codesign -dvv "$executable" 2>&1 \
+            | awk -F= '/^TeamIdentifier=/{print $2; exit}')
+        [ "$team" = "$EXPECTED_TEAM_ID" ] || {
+            fail_install "Staged app signer mismatch (expected team $EXPECTED_TEAM_ID, got ${team:-none})."
+            return 1
+        }
+    fi
+
+    local code_has_paged=0
+    local marker_present=0
+    binary_contains_paged_code "$executable" && code_has_paged=1
+    [ -f "$marker" ] && marker_present=1
+    [ "$code_has_paged" -eq "$marker_present" ] || {
+        if [ "$code_has_paged" -eq 1 ]; then
+            fail_install "Paged-capable staged app is missing its signed capability marker."
+        else
+            fail_install "Staged app advertises paged capability without paged runtime code."
+        fi
+        return 1
+    }
+    [ "$marker_present" -eq 1 ] || return 0
+    [ "$(tr -d '[:space:]' < "$marker")" = "1" ] || {
+        fail_install "Paged runtime capability marker is invalid."
+        return 1
+    }
+
+    shopt -s nullglob
+    local paged_resources=(
+        "$app/Contents/Resources"/*.bundle/pagedattention.metal
+    )
+    local expected_resource="$app/Contents/Resources/mlx-swift-lm_MLXLMCommon.bundle/pagedattention.metal"
+    [ "${#paged_resources[@]}" -eq 1 ] \
+        && [ "${paged_resources[0]}" = "$expected_resource" ] \
+        && [ -s "$expected_resource" ] \
+        || {
+            fail_install "Paged-capable staged app requires exactly one sealed MLXLMCommon pagedattention.metal."
+            return 1
+        }
+
+    DARKBLOOM_NO_UPDATE_CHECK=1 "$executable" runtime-smoke >/dev/null \
+        || {
+            fail_install "Packaged paged-kernel runtime smoke failed."
+            return 1
+        }
+}
+
+commit_staged_app() {
+    local staged_app=$1
+    local install_dir=$2
+    local backup="$install_dir/.install-backup-$$-$RANDOM"
+    local destination="$install_dir/Darkbloom.app"
+    local had_previous=0
+    mkdir -p "$backup" "$install_dir/bin"
+
+    if [ -d "$destination" ]; then
+        mv "$destination" "$backup/Darkbloom.app" || {
+            rm -rf "$backup"
+            return 1
+        }
+        had_previous=1
+    fi
+    if ! mv "$staged_app" "$destination"; then
+        [ "$had_previous" -eq 1 ] \
+            && mv "$backup/Darkbloom.app" "$destination" 2>/dev/null || true
+        rm -rf "$backup"
+        return 1
+    fi
+
+    local app_bin="$destination/Contents/MacOS"
+    if ! ln -sfn "../Darkbloom.app/Contents/MacOS/darkbloom" "$install_dir/bin/darkbloom" \
+        || ! ln -sfn "../Darkbloom.app/Contents/MacOS/darkbloom-enclave" "$install_dir/bin/darkbloom-enclave" \
+        || ! ln -sfn "../Darkbloom.app/Contents/MacOS/mlx.metallib" "$install_dir/bin/mlx.metallib" \
+        || ! ln -sfn "darkbloom-enclave" "$install_dir/bin/eigeninference-enclave"
+    then
+        rm -rf "$destination"
+        [ "$had_previous" -eq 1 ] \
+            && mv "$backup/Darkbloom.app" "$destination" 2>/dev/null || true
+        rm -rf "$backup"
+        return 1
+    fi
+    chmod +x "$app_bin/darkbloom" "$app_bin/darkbloom-enclave"
+    rm -rf "$backup"
+}
+
+commit_staged_flat_bundle() {
+    local staged_bin=$1
+    local install_dir=$2
+    local backup="$install_dir/.install-backup-$$-$RANDOM"
+    local destination="$install_dir/bin"
+    mkdir -p "$backup"
+    if [ -d "$destination" ]; then
+        mv "$destination" "$backup/bin" || {
+            rm -rf "$backup"
+            return 1
+        }
+    fi
+    if ! mv "$staged_bin" "$destination"; then
+        [ -d "$backup/bin" ] && mv "$backup/bin" "$destination" 2>/dev/null || true
+        rm -rf "$backup"
+        return 1
+    fi
+    chmod +x "$destination/darkbloom" "$destination/darkbloom-enclave"
+    ln -sfn "darkbloom-enclave" "$destination/eigeninference-enclave"
+    rm -rf "$backup"
+}
+
+install_bundle_atomically() {
+    local archive=$1
+    local install_dir=$2
+    local binary_hash=${3:-}
+    local metallib_hash=${4:-}
+    local stage="$install_dir/.install-staging-$$-$RANDOM"
+    rm -rf "$stage"
+    mkdir -p "$stage"
+    if ! tar xzf "$archive" -C "$stage"; then
+        rm -rf "$stage"
+        return 1
+    fi
+
+    local flat_bin="$stage/bin"
+    [ -f "$flat_bin/darkbloom" ] \
+        && [ -f "$flat_bin/darkbloom-enclave" ] \
+        && [ -f "$flat_bin/mlx.metallib" ] \
+        || {
+            rm -rf "$stage"
+            fail_install "Release bundle is missing required flat verifier files."
+            return 1
+        }
+    verify_file_hash "$flat_bin/darkbloom" "$binary_hash" "Binary" || {
+        rm -rf "$stage"
+        return 1
+    }
+    verify_file_hash "$flat_bin/mlx.metallib" "$metallib_hash" "Metallib" || {
+        rm -rf "$stage"
+        return 1
+    }
+
+    if [ -d "$stage/Darkbloom.app" ]; then
+        verify_staged_app "$stage/Darkbloom.app" || {
+            rm -rf "$stage"
+            return 1
+        }
+        commit_staged_app "$stage/Darkbloom.app" "$install_dir" || {
+            rm -rf "$stage"
+            fail_install "Atomic app swap failed; previous install was restored."
+            return 1
+        }
+    else
+        codesign --verify --strict --verbose=2 "$flat_bin/darkbloom" >/dev/null 2>&1 \
+            || {
+                rm -rf "$stage"
+                fail_install "Strict signature verification failed for legacy flat artifact."
+                return 1
+            }
+        if [ "$INSTALL_TEST_MODE" != "1" ]; then
+            local flat_team
+            flat_team=$(codesign -dvv "$flat_bin/darkbloom" 2>&1 \
+                | awk -F= '/^TeamIdentifier=/{print $2; exit}')
+            [ "$flat_team" = "$EXPECTED_TEAM_ID" ] || {
+                rm -rf "$stage"
+                fail_install "Legacy flat artifact signer mismatch."
+                return 1
+            }
+        fi
+        commit_staged_flat_bundle "$flat_bin" "$install_dir" || {
+            rm -rf "$stage"
+            fail_install "Atomic flat-bundle swap failed; previous install was restored."
+            return 1
+        }
+    fi
+    rm -rf "$stage"
+}
+
+if [ "${1:-}" = "--install-bundle-test" ]; then
+    [ "$#" -eq 5 ] || {
+        echo "usage: $0 --install-bundle-test <archive> <install-dir> <binary-hash> <metallib-hash>" >&2
+        exit 64
+    }
+    INSTALL_TEST_MODE=1
+    install_bundle_atomically "$2" "$3" "$4" "$5"
+    exit $?
+fi
 
 # Detect interactive vs piped (curl | bash).
 if [ -t 0 ]; then
@@ -103,88 +324,14 @@ if [ "$ACTUAL_HASH" != "$BUNDLE_HASH" ]; then
 fi
 echo "  Bundle hash verified ✓"
 
-echo "  Installing into $INSTALL_DIR ..."
-# The bundle ships as Darkbloom.app/ (contains provisioning profile for
-# keychain-access-groups) with bin/ symlinks for backward compatibility.
-# Older flat bundles (bin/darkbloom directly) are also handled.
-tar xzf "$TARBALL" -C "$INSTALL_DIR"
-
-# New .app bundle layout: Darkbloom.app/Contents/MacOS/{darkbloom,darkbloom-enclave,mlx.metallib}
-if [ -d "$INSTALL_DIR/Darkbloom.app" ]; then
-    APP_BIN="$INSTALL_DIR/Darkbloom.app/Contents/MacOS"
-    chmod +x "$APP_BIN/darkbloom" "$APP_BIN/darkbloom-enclave" 2>/dev/null || true
-    # bin/ gets symlinks pointing into the .app bundle
-    mkdir -p "$BIN_DIR"
-    ln -sfn "$APP_BIN/darkbloom" "$BIN_DIR/darkbloom"
-    ln -sfn "$APP_BIN/darkbloom-enclave" "$BIN_DIR/darkbloom-enclave"
-    ln -sfn "$APP_BIN/mlx.metallib" "$BIN_DIR/mlx.metallib" 2>/dev/null || true
-    echo "  Installed .app bundle with provisioning profile"
-else
-    # Legacy flat layout fallback
-    [ -f "$INSTALL_DIR/darkbloom" ]               && mv -f "$INSTALL_DIR/darkbloom" "$BIN_DIR/darkbloom"
-    [ -f "$INSTALL_DIR/darkbloom-enclave" ]       && mv -f "$INSTALL_DIR/darkbloom-enclave" "$BIN_DIR/darkbloom-enclave"
-    if [ -f "$INSTALL_DIR/eigeninference-enclave" ] && [ ! -f "$BIN_DIR/darkbloom-enclave" ]; then
-        mv -f "$INSTALL_DIR/eigeninference-enclave" "$BIN_DIR/darkbloom-enclave"
-    fi
-    [ -f "$INSTALL_DIR/mlx.metallib" ]            && mv -f "$INSTALL_DIR/mlx.metallib" "$BIN_DIR/mlx.metallib"
-    chmod +x "$BIN_DIR/darkbloom" "$BIN_DIR/darkbloom-enclave" 2>/dev/null || true
-fi
-
-ln -sfn "$BIN_DIR/darkbloom-enclave" "$BIN_DIR/eigeninference-enclave" 2>/dev/null || true
-rm -f "$TARBALL"
-
-# Verify per-binary SHA matches what the coordinator registered. The bundle
-# hash above proves the tarball matches; this also proves codesign + notary
-# didn't quietly mutate the binary.
-if [ -n "${BINARY_HASH:-}" ]; then
-    ACTUAL_BIN=$(shasum -a 256 "$BIN_DIR/darkbloom" | cut -d' ' -f1)
-    if [ "$ACTUAL_BIN" != "$BINARY_HASH" ]; then
-        echo "  ✗ Binary hash mismatch (expected $BINARY_HASH, got $ACTUAL_BIN)."
-        rm -rf "$BIN_DIR"
-        exit 1
-    fi
-    echo "  Binary hash verified ✓"
-fi
-if [ -n "$METALLIB_HASH" ] && [ -f "$BIN_DIR/mlx.metallib" ]; then
-    ACTUAL_LIB=$(shasum -a 256 "$BIN_DIR/mlx.metallib" | cut -d' ' -f1)
-    if [ "$ACTUAL_LIB" != "$METALLIB_HASH" ]; then
-        echo "  ✗ mlx.metallib hash mismatch (expected $METALLIB_HASH, got $ACTUAL_LIB)."
-        rm -rf "$BIN_DIR"
-        exit 1
-    fi
-    echo "  Metallib hash verified ✓"
-fi
-
-# Verify the whole app when present so its sealed SwiftPM resources are
-# covered, not only the main executable.
-SIGNATURE_TARGET="$BIN_DIR/darkbloom"
-if [ -d "$INSTALL_DIR/Darkbloom.app" ]; then
-    SIGNATURE_TARGET="$INSTALL_DIR/Darkbloom.app"
-fi
-if codesign --verify --deep --strict --verbose "$SIGNATURE_TARGET" 2>/dev/null; then
-    TEAM=$(codesign -dvv "$BIN_DIR/darkbloom" 2>&1 | grep "TeamIdentifier=" | cut -d= -f2)
-    echo "  Code signature verified ✓ (Team: $TEAM)"
-else
-    echo "  ⚠ Code signature could not be verified — proceed with caution."
-fi
-
-# Execute the same installed-layout paged-kernel gate release CI ran. This
-# catches a missing/corrupt SwiftPM bundle before the provider service starts.
-shopt -s nullglob
-PAGED_RESOURCES=(
-    "$INSTALL_DIR/Darkbloom.app/Contents/Resources"/*.bundle/pagedattention.metal
-)
-if [ "${#PAGED_RESOURCES[@]}" -gt 1 ]; then
-    echo "  ✗ Multiple pagedattention.metal resources found — refusing ambiguous package."
+echo "  Staging and verifying the complete app before touching the live install ..."
+if ! install_bundle_atomically "$TARBALL" "$INSTALL_DIR" "$BINARY_HASH" "$METALLIB_HASH"; then
+    rm -f "$TARBALL"
+    echo "  Existing installation was left unchanged."
     exit 1
 fi
-if [ "${#PAGED_RESOURCES[@]}" -eq 1 ]; then
-    if ! DARKBLOOM_NO_UPDATE_CHECK=1 "$BIN_DIR/darkbloom" runtime-smoke >/dev/null; then
-        echo "  ✗ Packaged runtime smoke failed — refusing to start this provider build."
-        exit 1
-    fi
-    echo "  Runtime resource smoke verified ✓"
-fi
+rm -f "$TARBALL"
+echo "  Strict signature, runtime resources, and atomic swap verified ✓"
 
 # Make available in PATH. Try /usr/local/bin symlink, fall back to shell rc.
 if ln -sf "$BIN_DIR/darkbloom" /usr/local/bin/darkbloom 2>/dev/null; then

--- a/coordinator/api/install.sh
+++ b/coordinator/api/install.sh
@@ -44,11 +44,12 @@ verify_file_hash() {
         || fail_install "$label hash mismatch (expected $expected, got $actual)."
 }
 
+# Stock-macOS binary capability probe. `strings` is an Xcode CLT shim on a
+# pristine Mac (it prompts/fails without developer tools), so scan the file
+# directly with BSD grep's binary-as-text mode — grep ships in base macOS.
 binary_contains_paged_code() {
     local binary=$1
-    local count
-    count=$(strings "$binary" | grep -c 'engine_v2_kv_backend' || true)
-    [ "$count" -gt 0 ]
+    LC_ALL=C grep -a -q -F 'engine_v2_kv_backend' "$binary"
 }
 
 verify_staged_app() {

--- a/coordinator/api/install.sh
+++ b/coordinator/api/install.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 #
 # This script:
 #   1. Fetches the latest signed release from the coordinator
-#   2. Downloads the provider bundle (darkbloom + darkbloom-enclave + mlx.metallib)
+#   2. Downloads the provider app (binaries, metallib, SwiftPM resources)
 #   3. Verifies bundle SHA-256 + Apple Developer ID code signature
 #   4. Sets up the Secure Enclave identity
 #   5. Optionally enrolls in MDM (device attestation)
@@ -155,12 +155,35 @@ if [ -n "$METALLIB_HASH" ] && [ -f "$BIN_DIR/mlx.metallib" ]; then
     echo "  Metallib hash verified ✓"
 fi
 
-# Verify code signature (codesign is base macOS, no CLT prompt).
-if codesign --verify --verbose "$BIN_DIR/darkbloom" 2>/dev/null; then
+# Verify the whole app when present so its sealed SwiftPM resources are
+# covered, not only the main executable.
+SIGNATURE_TARGET="$BIN_DIR/darkbloom"
+if [ -d "$INSTALL_DIR/Darkbloom.app" ]; then
+    SIGNATURE_TARGET="$INSTALL_DIR/Darkbloom.app"
+fi
+if codesign --verify --deep --strict --verbose "$SIGNATURE_TARGET" 2>/dev/null; then
     TEAM=$(codesign -dvv "$BIN_DIR/darkbloom" 2>&1 | grep "TeamIdentifier=" | cut -d= -f2)
     echo "  Code signature verified ✓ (Team: $TEAM)"
 else
     echo "  ⚠ Code signature could not be verified — proceed with caution."
+fi
+
+# Execute the same installed-layout paged-kernel gate release CI ran. This
+# catches a missing/corrupt SwiftPM bundle before the provider service starts.
+shopt -s nullglob
+PAGED_RESOURCES=(
+    "$INSTALL_DIR/Darkbloom.app/Contents/Resources"/*.bundle/pagedattention.metal
+)
+if [ "${#PAGED_RESOURCES[@]}" -gt 1 ]; then
+    echo "  ✗ Multiple pagedattention.metal resources found — refusing ambiguous package."
+    exit 1
+fi
+if [ "${#PAGED_RESOURCES[@]}" -eq 1 ]; then
+    if ! DARKBLOOM_NO_UPDATE_CHECK=1 "$BIN_DIR/darkbloom" runtime-smoke >/dev/null; then
+        echo "  ✗ Packaged runtime smoke failed — refusing to start this provider build."
+        exit 1
+    fi
+    echo "  Runtime resource smoke verified ✓"
 fi
 
 # Make available in PATH. Try /usr/local/bin symlink, fall back to shell rc.

--- a/coordinator/api/install.sh
+++ b/coordinator/api/install.sh
@@ -25,7 +25,7 @@ set -euo pipefail
 COORD_URL="${COORD_URL:-__DARKBLOOM_COORD_URL__}"
 INSTALL_DIR="$HOME/.darkbloom"
 BIN_DIR="$INSTALL_DIR/bin"
-EXPECTED_TEAM_ID="SLDQ2GJ6TL"
+DARKBLOOM_DESIGNATED_REQUIREMENT='anchor apple generic and identifier "io.darkbloom.provider" and certificate leaf[subject.OU] = "SLDQ2GJ6TL"'
 INSTALL_TEST_MODE=0
 
 fail_install() {
@@ -44,6 +44,28 @@ verify_file_hash() {
         || fail_install "$label hash mismatch (expected $expected, got $actual)."
 }
 
+verify_code_requirement() {
+    local target=$1
+    local deep=$2
+    local requirement=$3
+    if [ "$deep" = "1" ]; then
+        codesign --verify --deep --strict --verbose=2 \
+            "-R=$requirement" "$target" >/dev/null 2>&1
+    else
+        codesign --verify --strict --verbose=2 \
+            "-R=$requirement" "$target" >/dev/null 2>&1
+    fi
+}
+
+verify_staged_app_signature() {
+    local app=$1
+    local requirement=${2:-$DARKBLOOM_DESIGNATED_REQUIREMENT}
+    verify_code_requirement "$app" 1 "$requirement" || {
+        fail_install "Staged Darkbloom.app does not satisfy the pinned signature requirement."
+        return 1
+    }
+}
+
 # Stock-macOS binary capability probe. `strings` is an Xcode CLT shim on a
 # pristine Mac (it prompts/fails without developer tools), so scan the file
 # directly with BSD grep's binary-as-text mode — grep ships in base macOS.
@@ -57,20 +79,13 @@ verify_staged_app() {
     local executable="$app/Contents/MacOS/darkbloom"
     local marker="$app/Contents/Resources/darkbloom-runtime-capabilities/paged-kernel-v1"
 
-    codesign --verify --deep --strict --verbose=2 "$app" >/dev/null 2>&1 \
-        || {
+    if [ "$INSTALL_TEST_MODE" = "1" ]; then
+        codesign --verify --deep --strict --verbose=2 "$app" >/dev/null 2>&1 || {
             fail_install "Strict code-signature verification failed for staged Darkbloom.app."
             return 1
         }
-
-    if [ "$INSTALL_TEST_MODE" != "1" ]; then
-        local team
-        team=$(codesign -dvv "$executable" 2>&1 \
-            | awk -F= '/^TeamIdentifier=/{print $2; exit}')
-        [ "$team" = "$EXPECTED_TEAM_ID" ] || {
-            fail_install "Staged app signer mismatch (expected team $EXPECTED_TEAM_ID, got ${team:-none})."
-            return 1
-        }
+    else
+        verify_staged_app_signature "$app" || return 1
     fi
 
     local code_has_paged=0
@@ -109,6 +124,19 @@ verify_staged_app() {
             fail_install "Packaged paged-kernel runtime smoke failed."
             return 1
         }
+}
+
+verify_staged_app_payload() {
+    local app=$1
+    local binary_hash=$2
+    local metallib_hash=$3
+    local app_bin="$app/Contents/MacOS"
+    [ -n "$binary_hash" ] && [ -n "$metallib_hash" ] || {
+        fail_install "App releases require binary_hash and metallib_hash."
+        return 1
+    }
+    verify_file_hash "$app_bin/darkbloom" "$binary_hash" "App binary" \
+        && verify_file_hash "$app_bin/mlx.metallib" "$metallib_hash" "App metallib"
 }
 
 commit_staged_app() {
@@ -203,6 +231,11 @@ install_bundle_atomically() {
     }
 
     if [ -d "$stage/Darkbloom.app" ]; then
+        verify_staged_app_payload \
+            "$stage/Darkbloom.app" "$binary_hash" "$metallib_hash" || {
+            rm -rf "$stage"
+            return 1
+        }
         verify_staged_app "$stage/Darkbloom.app" || {
             rm -rf "$stage"
             return 1
@@ -213,19 +246,17 @@ install_bundle_atomically() {
             return 1
         }
     else
-        codesign --verify --strict --verbose=2 "$flat_bin/darkbloom" >/dev/null 2>&1 \
-            || {
+        if [ "$INSTALL_TEST_MODE" = "1" ]; then
+            codesign --verify --strict --verbose=2 "$flat_bin/darkbloom" >/dev/null 2>&1 || {
                 rm -rf "$stage"
                 fail_install "Strict signature verification failed for legacy flat artifact."
                 return 1
             }
-        if [ "$INSTALL_TEST_MODE" != "1" ]; then
-            local flat_team
-            flat_team=$(codesign -dvv "$flat_bin/darkbloom" 2>&1 \
-                | awk -F= '/^TeamIdentifier=/{print $2; exit}')
-            [ "$flat_team" = "$EXPECTED_TEAM_ID" ] || {
+        else
+            verify_code_requirement \
+                "$flat_bin/darkbloom" 0 "$DARKBLOOM_DESIGNATED_REQUIREMENT" || {
                 rm -rf "$stage"
-                fail_install "Legacy flat artifact signer mismatch."
+                fail_install "Legacy flat artifact does not satisfy the pinned signature requirement."
                 return 1
             }
         fi
@@ -237,6 +268,15 @@ install_bundle_atomically() {
     fi
     rm -rf "$stage"
 }
+
+if [ "${1:-}" = "--verify-staged-app-signature-test" ]; then
+    [ "$#" -eq 3 ] || {
+        echo "usage: $0 --verify-staged-app-signature-test <app> <requirement>" >&2
+        exit 64
+    }
+    verify_staged_app_signature "$2" "$3"
+    exit $?
+fi
 
 if [ "${1:-}" = "--install-bundle-test" ]; then
     [ "$#" -eq 5 ] || {

--- a/docs/provider/quickstart.md
+++ b/docs/provider/quickstart.md
@@ -138,15 +138,16 @@ end = "08:00"
   fp16-only KV. Setting it logs a warning and does not enable quantization. See
   [Beta Features](beta-features.md).
 - `backend.engine_v2_kv_backend` — KV-cache backend for the inference engine:
-  `"auto"` (default — PagedAttention for GPT-OSS text models, contiguous
-  otherwise), `"paged"`, or `"contiguous"`. Vision models and `kv_quant`
+  `"auto"` (default — contiguous for every model), experimental `"paged"`,
+  or `"contiguous"`. Vision models and `kv_quant`
   configurations always serve contiguous; models the paged kernel cannot
   serve fall back to contiguous automatically. Per-model overrides:
   `engine_v2_kv_backend_by_model` (TOML table of model id → value). Fleet
   kill switch: launch with `DARKBLOOM_CBV2_PAGED_KV=0` (survives restarts —
-  it is forwarded into the launchd service environment). Note: a paged model
-  commits its whole KV grant in memory at load (the pool is preallocated),
-  where a contiguous model grows its KV usage with traffic.
+  it is forwarded into the launchd service environment). An explicit paged
+  model eagerly commits a separately capped physical pool derived from useful
+  concurrent context demand, live memory, machine size, and Metal buffer
+  limits; it never preallocates the full logical admission grant.
 - `coordinator.private_only` — serve only your own self-route traffic; never
   join the public fleet.
 

--- a/provider-swift/Sources/ProviderCore/Config/ProviderConfig.swift
+++ b/provider-swift/Sources/ProviderCore/Config/ProviderConfig.swift
@@ -101,8 +101,8 @@ public struct BackendSettings: Sendable, Equatable, Codable {
     /// `engineV2MaxConcurrent`.
     public var engineV2MaxConcurrentByModel: [String: UInt64]
     /// CBv2 KV-backend selection (`engine_v2_kv_backend` under
-    /// `[backend]`): "auto" (default — paged for GPT-OSS text slots,
-    /// contiguous otherwise), "paged", or "contiguous". VLM slots and
+    /// `[backend]`): "auto" (default — contiguous for every current and
+    /// future model), experimental "paged", or "contiguous". VLM slots and
     /// `kv_quant = true` always force contiguous; kernel-ineligible models
     /// fall back to contiguous with an INFO telemetry event. Fleet kill
     /// switch: `DARKBLOOM_CBV2_PAGED_KV=0`. See `EngineV2KVBackendPolicy`.

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge+PrefixCache.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge+PrefixCache.swift
@@ -64,13 +64,28 @@ extension EngineV2Bridge {
         subsystem: "com.darkbloom.provider", category: "prefix_cache")
     #endif
 
-    /// The slot's TOTAL KV byte claim: the engine's construction-fixed
-    /// admission ceiling PLUS the prefix-cache budget carved out of it.
+    /// The slot's TOTAL KV byte claim: for contiguous, the engine admission
+    /// ceiling; for paged, the immutable PHYSICAL backend capacity; then
+    /// PLUS the prefix-cache budget carved out of the slot grant.
     /// Fleet sizing (`makeEngineV2BridgeForSlot`) and the heartbeat clamp
     /// (`EngineV2Runtime.capacitySummary`) subtract THIS — not the bare
     /// engine capacity — for co-resident slots, so Σ(engine ceilings +
     /// cache budgets) never exceeds the unified-memory KV budget.
     public func slotKVBytesClaim() -> Int {
+        let snapshot = engine.capacity()
+        let engineClaim =
+            kvBackendKind == .paged && snapshot.kvBytesBackendCapacity > 0
+            ? snapshot.kvBytesBackendCapacity
+            : snapshot.kvBytesCapacity
+        let (sum, overflow) = engineClaim
+            .addingReportingOverflow(prefixCacheBudgetBytes)
+        return overflow ? Int.max : sum
+    }
+
+    /// Current logical admission target plus the fixed prefix carve. Re-slice
+    /// rollback uses this exact value; unlike `slotKVBytesClaim()`, it does
+    /// not replace a shrunk paged ledger with the larger immutable pool.
+    func resliceAdmissionBytesClaim() -> Int {
         let (sum, overflow) = engine.capacity().kvBytesCapacity
             .addingReportingOverflow(prefixCacheBudgetBytes)
         return overflow ? Int.max : sum

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge.swift
@@ -542,22 +542,22 @@ public actor EngineV2Bridge {
     /// (`resliceMeetsServiceabilityFloor(_:fixedCarveBytes:)`), so the
     /// `max(0, …)` clamp is defensive only.
     ///
-    /// PAGED slots (`kvBackendKind == .paged`): the resize moves the
-    /// ADMISSION ledger only — the physically preallocated page pool
-    /// neither shrinks nor grows (`updateBytesCapacity` is a no-op on a
-    /// construction-fixed pool). This is safe by design: a SHRINK tightens
-    /// admissions immediately while the slabs stay resident, and whether a
-    /// newcomer physically fits is arbitrated by the post-load headroom
-    /// guards against TRUE residency (slabs are materialized eagerly at
-    /// construction) — an over-tight box fails the newcomer's load and
-    /// restores, it never jetsams. A GROW past pool truth is bound back
-    /// down in the heartbeat (`backendSlotCapacity` min-binds the
-    /// advertised capacity to `kvBytesBackendCapacity`), so the
-    /// coordinator never routes tokens the pool cannot place. Reclaiming
-    /// or adding physical pool bytes requires an engine rebuild (unload →
-    /// load), or the future pool-resize follow-up.
+    /// PAGED slots (`kvBackendKind == .paged`): the physically preallocated
+    /// page pool neither shrinks nor grows (`updateBytesCapacity` is a no-op
+    /// on the backend). The admission ledger is clamped to that immutable
+    /// physical capacity on every resize, so logical admission, heartbeat
+    /// reporting, and page placement agree. A SHRINK tightens admission but
+    /// does NOT reclaim physical memory; callers must never count it as
+    /// freed. A later GROW can restore admission only up to the same pool.
+    /// Reclaiming or adding physical bytes requires an unload/rebuild.
     public func updateKVBytesCapacity(_ bytes: Int) {
-        engine.updateKVBytesCapacity(max(0, bytes - prefixCacheBudgetBytes))
+        let requested = max(0, bytes - prefixCacheBudgetBytes)
+        if kvBackendKind == .paged {
+            let physical = max(0, engine.capacity().kvBytesBackendCapacity)
+            engine.updateKVBytesCapacity(min(requested, physical))
+        } else {
+            engine.updateKVBytesCapacity(requested)
+        }
     }
 
     /// Record the slot's cold-start load time for heartbeat reporting

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Factory+Production.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Factory+Production.swift
@@ -152,8 +152,7 @@ extension EngineV2Factory {
         maxConcurrentRequests: Int = EngineV2Factory.productionMaxConcurrentRequests,
         kvBackend: EngineV2KVBackendSelection = .auto,
         maxContextLength: Int? = nil,
-        environment: [String: String] = ProcessInfo.processInfo.environment,
-        pagedResourceSearchRoots: [URL]? = nil
+        environment: [String: String] = ProcessInfo.processInfo.environment
     ) throws -> any CBv2Engine {
         try makeProductionBuild(
             model: model,
@@ -163,8 +162,7 @@ extension EngineV2Factory {
             maxConcurrentRequests: maxConcurrentRequests,
             kvBackend: kvBackend,
             maxContextLength: maxContextLength,
-            environment: environment,
-            pagedResourceSearchRoots: pagedResourceSearchRoots
+            environment: environment
         ).engine
     }
 
@@ -203,7 +201,7 @@ extension EngineV2Factory {
         kvBackend: EngineV2KVBackendSelection = .auto,
         maxContextLength: Int? = nil,
         environment: [String: String] = ProcessInfo.processInfo.environment,
-        pagedResourceSearchRoots: [URL]? = nil
+        pagedPreflightOverride: (([CBv2LayerKind]) throws -> Void)? = nil
     ) throws -> ProductionBuild {
         guard kvBytesCapacity > 0 else {
             throw EngineV2ProductionError.noKVHeadroom
@@ -269,6 +267,19 @@ extension EngineV2Factory {
         }
 
         if resolvedKind == .paged {
+            do {
+                if let pagedPreflightOverride {
+                    try pagedPreflightOverride(layerKinds)
+                } else {
+                    try PagedKernelPreflight.run(layerKinds: layerKinds)
+                }
+            } catch {
+                resolvedKind = .contiguous
+                fallbackReason = "kernel_preflight: \(error)"
+            }
+        }
+
+        if resolvedKind == .paged {
             let maxBufferLength = MLX.GPU.deviceInfo().maxBufferSize
             let rate = PagedKVPhysicalCapacityPolicy.fp16BytesPerToken(
                 layerKinds: layerKinds) ?? 0
@@ -298,8 +309,7 @@ extension EngineV2Factory {
                             maxPrefillChunk: schedulerConfig.prefillChunkSize,
                             nominalMaxSequenceLength: max(
                                 1, maxContextLength ?? 8192),
-                            maxBufferLength: maxBufferLength,
-                            resourceSearchRoots: pagedResourceSearchRoots))
+                            maxBufferLength: maxBufferLength))
                     let pagedCaches = paged.makeLayerCaches()
                     let caches = newCaches { index, _ in pagedCaches[index] }
                     // Commit only the independently-capped PHYSICAL pool.

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Factory+Production.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Factory+Production.swift
@@ -14,12 +14,11 @@
 //     `cbv2LayerKinds` / `newCacheV2` (Gemma 4 text, GPT-OSS — the two
 //     families the engine is correct-by-construction for; GPT-OSS's
 //     `newCacheV2` also primes its sinks-activation probe at build time),
-//   * a KV backend sized from the unified-memory KV budget — the PAGED
-//     `PagedKVBackend` for GPT-OSS slots by default (slabs physically
-//     committed at construction via `materializeSlabs`; see
-//     `EngineV2KVBackendPolicy` for the gate/kill-switch/fallback layers)
-//     or `CBv2ContiguousKVBackend` (admission ceiling only — nothing is
-//     preallocated),
+//   * a KV backend sized from the unified-memory KV budget —
+//     `CBv2ContiguousKVBackend` for production "auto" (admission ceiling
+//     only — nothing is preallocated), or the explicitly experimental
+//     `PagedKVBackend`, whose physical slabs are independently capped by
+//     `PagedKVPhysicalCapacityPolicy` before eager materialization,
 //   * `CBv2LayerCacheBank` over the model-built caches,
 //   * `CBv2DefaultSampler` + `CBv2TextDetokenizerFactory` (real incremental
 //     detokenization with stop-string holdback).
@@ -30,6 +29,7 @@
 // legacy engine to fall back to.
 
 import Foundation
+import MLX
 import MLXLLM
 import MLXLMCommon
 
@@ -152,7 +152,8 @@ extension EngineV2Factory {
         maxConcurrentRequests: Int = EngineV2Factory.productionMaxConcurrentRequests,
         kvBackend: EngineV2KVBackendSelection = .auto,
         maxContextLength: Int? = nil,
-        environment: [String: String] = ProcessInfo.processInfo.environment
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        pagedResourceSearchRoots: [URL]? = nil
     ) throws -> any CBv2Engine {
         try makeProductionBuild(
             model: model,
@@ -162,7 +163,8 @@ extension EngineV2Factory {
             maxConcurrentRequests: maxConcurrentRequests,
             kvBackend: kvBackend,
             maxContextLength: maxContextLength,
-            environment: environment
+            environment: environment,
+            pagedResourceSearchRoots: pagedResourceSearchRoots
         ).engine
     }
 
@@ -185,10 +187,8 @@ extension EngineV2Factory {
     ///
     /// KV-backend gate (see `EngineV2KVBackendPolicy` for the full layer
     /// order): the caller passes the operator selection with slot vetoes
-    /// (VLM, kv-quant) already applied; `.auto` resolves per family HERE —
-    /// next to the authoritative family switch so the two can never drift —
-    /// GPT-OSS → paged (default-ON, 2026-07-10 decision), Gemma-4 →
-    /// contiguous (KV arrives bf16; fp16 pages stay an explicit opt-in).
+    /// (VLM, kv-quant) already applied; `.auto` is always contiguous.
+    /// Paged remains an explicit experimental selection.
     /// The `DARKBLOOM_CBV2_PAGED_KV=0` fleet kill switch is enforced at
     /// THIS deepest layer so no call path (benchmarks included) bypasses
     /// it. Paged construction throwing `CBv2KVError` (kernel ineligibility,
@@ -202,7 +202,8 @@ extension EngineV2Factory {
         maxConcurrentRequests: Int = EngineV2Factory.productionMaxConcurrentRequests,
         kvBackend: EngineV2KVBackendSelection = .auto,
         maxContextLength: Int? = nil,
-        environment: [String: String] = ProcessInfo.processInfo.environment
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        pagedResourceSearchRoots: [URL]? = nil
     ) throws -> ProductionBuild {
         guard kvBytesCapacity > 0 else {
             throw EngineV2ProductionError.noKVHeadroom
@@ -225,18 +226,15 @@ extension EngineV2Factory {
         // sinks-activation probe inside it (one host readback per layer,
         // at build time — never on the step path).
         let layerKinds: [CBv2LayerKind]
-        let autoKind: EngineV2KVBackendKind
         let newCaches:
             ((Int, CBv2LayerKind) -> any CBv2AttendingLayerCache)
                 -> [any CBv2AttendingLayerCache]
         switch model {
         case let gemma as Gemma4TextModel:
             layerKinds = gemma.cbv2LayerKinds
-            autoKind = .contiguous
             newCaches = { make in gemma.newCacheV2(makeLayerCache: make) }
         case let gptoss as GPTOSSModel:
             layerKinds = gptoss.cbv2LayerKinds
-            autoKind = .paged
             newCaches = { make in gptoss.newCacheV2(makeLayerCache: make) }
         default:
             throw EngineV2ProductionError.unsupportedModel(
@@ -247,7 +245,7 @@ extension EngineV2Factory {
         switch kvBackend {
         case .contiguous: resolvedKind = .contiguous
         case .paged: resolvedKind = .paged
-        case .auto: resolvedKind = autoKind
+        case .auto: resolvedKind = .contiguous
         }
         var fallbackReason: String?
         if resolvedKind == .paged,
@@ -271,42 +269,61 @@ extension EngineV2Factory {
         }
 
         if resolvedKind == .paged {
-            do {
-                let paged = try PagedKVBackend(
-                    layerKinds: layerKinds,
-                    config: PagedKVPoolConfig(
-                        capacityBytes: cappedCapacity,
-                        // LOCKSTEP: a windowed-layer update larger than the
-                        // ring's provision traps the process
-                        // (PagedSequenceKV precondition) — size the pool to
-                        // the scheduler's REAL chunk, never a parallel
-                        // constant.
-                        maxPrefillChunk: schedulerConfig.prefillChunkSize,
-                        nominalMaxSequenceLength: max(1, maxContextLength ?? 8192)))
-                let pagedCaches = paged.makeLayerCaches()
-                let caches = newCaches { index, _ in pagedCaches[index] }
-                // Commit the slabs NOW (fail fast + measure honestly): the
-                // post-load headroom guards must see the pool's true
-                // residency — first traffic must never discover the
-                // allocation (that is the v0.7.2 "pinned black hole" shape).
-                paged.pool.materializeSlabs()
-                return ProductionBuild(
-                    engine: makeEngineV2(
-                        model: model, tokenizer: tokenizer, layerKinds: layerKinds,
-                        backend: paged, caches: caches,
-                        schedulerConfig: schedulerConfig, prefixCache: prefixCache),
-                    kvBackendKind: .paged,
-                    kvBackendFallbackReason: nil)
-            } catch let error as CBv2KVError {
-                // Paged ineligibility/capacity is a supported degradation:
-                // fall back to the contiguous backend (INFO telemetry at the
-                // bridge — never the engine_v2_refusal path).
-                switch error {
-                case .backendIneligible(let reason):
-                    fallbackReason = "ineligible: \(reason)"
-                case .capacityExhausted(let needed, let available):
-                    fallbackReason =
-                        "pool_construction_capacity: needed \(needed), available \(available)"
+            let maxBufferLength = MLX.GPU.deviceInfo().maxBufferSize
+            let rate = PagedKVPhysicalCapacityPolicy.fp16BytesPerToken(
+                layerKinds: layerKinds) ?? 0
+            let decision = PagedKVPhysicalCapacityPolicy.decide(
+                logicalGrantBytes: cappedCapacity,
+                fp16BytesPerToken: rate,
+                maxContextLength: maxContextLength,
+                maxConcurrentRequests: schedulerConfig.maxConcurrentRequests,
+                inputs: .init(
+                    physicalMemoryBytes: ProcessInfo.processInfo.physicalMemory,
+                    liveKVHeadroomBytes: KVHeadroomProbe.measuredLiveKVHeadroomBytes,
+                    maxBufferLength: maxBufferLength))
+            switch decision {
+            case .contiguous(let reason):
+                fallbackReason = reason
+            case .paged(let plan):
+                do {
+                    let paged = try PagedKVBackend(
+                        layerKinds: layerKinds,
+                        config: PagedKVPoolConfig(
+                            capacityBytes: plan.capacityBytes,
+                            // LOCKSTEP: a windowed-layer update larger than the
+                            // ring's provision traps the process
+                            // (PagedSequenceKV precondition) — size the pool to
+                            // the scheduler's REAL chunk, never a parallel
+                            // constant.
+                            maxPrefillChunk: schedulerConfig.prefillChunkSize,
+                            nominalMaxSequenceLength: max(
+                                1, maxContextLength ?? 8192),
+                            maxBufferLength: maxBufferLength,
+                            resourceSearchRoots: pagedResourceSearchRoots))
+                    let pagedCaches = paged.makeLayerCaches()
+                    let caches = newCaches { index, _ in pagedCaches[index] }
+                    // Commit only the independently-capped PHYSICAL pool.
+                    // Resource and size eligibility has already thrown
+                    // catchably; first traffic cannot discover either.
+                    paged.pool.materializeSlabs()
+                    return ProductionBuild(
+                        engine: makeEngineV2(
+                            model: model, tokenizer: tokenizer, layerKinds: layerKinds,
+                            backend: paged, caches: caches,
+                            schedulerConfig: schedulerConfig, prefixCache: prefixCache),
+                        kvBackendKind: .paged,
+                        kvBackendFallbackReason: nil)
+                } catch let error as CBv2KVError {
+                    // Paged ineligibility/capacity is a supported degradation:
+                    // fall back to the contiguous backend (INFO telemetry at the
+                    // bridge — never the engine_v2_refusal path).
+                    switch error {
+                    case .backendIneligible(let reason):
+                        fallbackReason = "ineligible: \(reason)"
+                    case .capacityExhausted(let needed, let available):
+                        fallbackReason =
+                            "pool_construction_capacity: needed \(needed), available \(available)"
+                    }
                 }
             }
         }

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2KVBackendPolicy.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2KVBackendPolicy.swift
@@ -22,11 +22,10 @@
 //      no call path can bypass it. Forwarded through the launchd plist
 //      (`LaunchAgent.passthroughEnvKeys`) so an operator kill survives
 //      install/restart — the same rationale as the SSD tier's switch.
-//   4. Family resolution for "auto", kept NEXT TO the authoritative family
-//      switch in `makeProductionEngine` so the two can never drift:
-//      GPT-OSS → paged (default-ON, 2026-07-10 decision); Gemma-4 →
-//      contiguous (its KV arrives bf16; fp16 pages are a numerics delta
-//      that stays opt-in via an explicit "paged").
+//   4. "auto" is production-safe and permanently resolves CONTIGUOUS.
+//      Paged is experimental and requires the explicit "paged" selection.
+//      This is intentionally not a family table: adding a future model
+//      family cannot silently turn a stale/default config into paged.
 //   5. Eligibility fallback: `PagedKVBackend` construction throwing
 //      `backendIneligible` falls back to contiguous — a paged-ineligible
 //      model must load and serve, never refuse.
@@ -41,7 +40,7 @@ public enum EngineV2KVBackendKind: String, Sendable, Equatable {
 
 /// Operator-facing backend selection (`engine_v2_kv_backend`).
 public enum EngineV2KVBackendSelection: String, Sendable, Equatable, CaseIterable {
-    /// Family default: paged for GPT-OSS text slots, contiguous otherwise.
+    /// Production default: contiguous for every current and future model.
     case auto
     /// Force paged where structurally possible (VLM/kv-quant slots and
     /// kernel-ineligible models still fall back to contiguous).
@@ -59,8 +58,7 @@ public enum EngineV2KVBackendPolicy {
     /// Parse the operator selection for `modelID` (per-model override
     /// wins over the global value). `unrecognized` carries a raw value
     /// that failed to parse so the caller can WARN once; the returned
-    /// selection is then `.auto` (the shipped default — still safe: every
-    /// auto path passes the VLM/kv-quant vetoes and eligibility fallback).
+    /// selection is then `.auto` (the shipped contiguous default).
     public static func parseSelection(
         global: String,
         byModel: [String: String],

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Runtime.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Runtime.swift
@@ -92,9 +92,10 @@ public actor EngineV2Runtime {
     public func capacitySummary(fleetKV: FleetKVContext? = nil) async -> CapacitySummary {
         consultCount += 1
         guard !bridges.isEmpty else { return .empty }
-        // Snapshot every bridge's current grant + prefix-cache budget
-        // first: bridge i's clamp subtracts the OTHER bridges' figures, so
-        // all must be read before any slot is built.
+        // Snapshot every bridge's current admission grant, physical total
+        // claim, and prefix-cache budget first: bridge i's clamp subtracts
+        // the OTHER bridges' physical claims, so all must be read before
+        // any slot is built.
         //
         // Prefix-cache accounting (T-041): a RAM-tier bridge's engine grant is
         // reduced by its cache budget, but the cache's bytes
@@ -104,10 +105,12 @@ public actor EngineV2Runtime {
         // reduction as fleet reality changes, and the coordinator is never
         // told about bytes any prefix cache will consume.
         var grants: [String: Int] = [:]
+        var totalClaims: [String: Int] = [:]
         var prefixBudgets: [String: Int] = [:]
         if fleetKV != nil {
             for (modelId, bridge) in bridges {
                 grants[modelId] = await bridge.engineKVBytesCapacity()
+                totalClaims[modelId] = await bridge.slotKVBytesClaim()
                 prefixBudgets[modelId] = bridge.prefixCacheBudgetBytes
             }
         }
@@ -117,13 +120,9 @@ public actor EngineV2Runtime {
             guard let bridge = bridges[modelId] else { continue }
             var clamp: Int?
             if let fleetKV, let grant = grants[modelId] {
-                var otherClaims = grants.filter { $0.key != modelId }.map {
-                    // Overflow-safe like `slotKVBytesClaim()`: saturate
-                    // rather than trap on absurd inputs.
-                    let (sum, overflow) = $0.value
-                        .addingReportingOverflow(prefixBudgets[$0.key] ?? 0)
-                    return overflow ? Int.max : sum
-                }
+                var otherClaims = totalClaims
+                    .filter { $0.key != modelId }
+                    .map(\.value)
                 // Own cache budget: carved out of the fleet budget but not
                 // visible in the engine's own (already-reduced) grant, so it
                 // rides the subtraction list like a co-resident claim.

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2SlotFactory.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2SlotFactory.swift
@@ -224,9 +224,9 @@ enum EngineV2SlotFactory {
         // parse the operator selection (per-model override wins; typo →
         // WARN + auto), then force contiguous for slots the paged cache
         // cannot serve — VLM (span masks unsupported: media would 4xx at
-        // submit) and kv_quant intent (fp16 pages only). Family
-        // resolution for `auto` + the fleet kill switch + eligibility
-        // fallback live in `makeProductionBuild`.
+        // submit) and kv_quant intent (fp16 pages only). `auto` resolves
+        // contiguous; the fleet kill switch, physical-capacity planning,
+        // and eligibility fallback live in `makeProductionBuild`.
         let parsedKVBackend = EngineV2KVBackendPolicy.parseSelection(
             global: kvBackendConfig, byModel: kvBackendConfigByModel, modelID: modelId)
         if let unrecognized = parsedKVBackend.unrecognized {

--- a/provider-swift/Sources/ProviderCore/Inference/KVHeadroomProbe.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/KVHeadroomProbe.swift
@@ -45,15 +45,15 @@ public enum KVHeadroomProbe {
     ///
     ///   * CONTIGUOUS: KV allocates lazily from free headroom, so measure
     ///     live headroom (the classic guard).
-    ///   * PAGED: the slot physically committed its serveable KV at
-    ///     construction (`materializeSlabs` — the pool consumed the very
-    ///     budget the measurement looks for), so measuring the residue
-    ///     would reject EVERY paged slot by design. Hold the SAME floor
-    ///     against the committed pool instead.
+    ///   * PAGED: require BOTH a serveable committed pool and the same
+    ///     minimum residual whole-machine headroom. Physical sizing uses
+    ///     only a conservative fraction of the pre-build live headroom, so
+    ///     the residual check catches unaccounted engine/JIT residency or
+    ///     concurrent OS pressure without rejecting every valid pool.
     ///
     /// Pure over its inputs (the live measurement is a defaulted
-    /// autoclosure, never evaluated on the paged arm) so the matrix is
-    /// unit-testable without touching MLX counters.
+    /// autoclosure) so the matrix is unit-testable without touching MLX
+    /// counters.
     public static func postBuildServeable(
         kvBackendKind: EngineV2KVBackendKind,
         pagedPoolBytes: UInt64,
@@ -63,6 +63,8 @@ public enum KVHeadroomProbe {
         switch kvBackendKind {
         case .paged:
             return pagedPoolBytes >= UnifiedMemoryCap.minimumLoadKVBytes
+                && UnifiedMemoryCap.loadIsServeable(
+                    measuredLiveKVHeadroomBytes: measuredHeadroomBytes())
         case .contiguous:
             return UnifiedMemoryCap.loadIsServeable(
                 measuredLiveKVHeadroomBytes: measuredHeadroomBytes())

--- a/provider-swift/Sources/ProviderCore/Inference/PackagedRuntimeSmoke.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/PackagedRuntimeSmoke.swift
@@ -6,19 +6,22 @@ import MLXLMCommon
 /// Runtime gate for the installed provider artifact. Release packaging runs
 /// this through the staged app executable before publication.
 public enum PackagedRuntimeSmoke {
-    public static func runPagedKernel() throws {
-        // Strictly inspect the installed app. Development search roots are
-        // intentionally excluded so CI cannot pass by finding the build
-        // directory after forgetting to package the bundle.
-        var roots = [Bundle.main.bundleURL]
-        roots.append(
-            Bundle.main.bundleURL.appendingPathComponent(
-                "Contents/Resources",
-                isDirectory: true))
-        if let resourceURL = Bundle.main.resourceURL {
-            roots.append(resourceURL)
-        }
-        try PagedAttentionKernel.runtimeSmoke(
-            searchRoots: roots)
+    public static let pagedCapabilityRelativePath =
+        "Contents/Resources/darkbloom-runtime-capabilities/paged-kernel-v1"
+    public static let mlxLMCommonBundleName =
+        "mlx-swift-lm_MLXLMCommon.bundle"
+
+    public static func runPagedKernel(
+        shapes: [PagedAttentionKernelSmokeShape] =
+            PagedAttentionKernel.gptOSSRuntimeSmokeShapes
+    ) throws {
+        try PagedAttentionKernel.runtimeSmoke(shapes: shapes)
+    }
+
+    public static func runPagedKernel(arguments: [String]) throws {
+        let shapes = try arguments.isEmpty
+            ? PagedAttentionKernel.gptOSSRuntimeSmokeShapes
+            : arguments.map(PagedAttentionKernelSmokeShape.init(argumentValue:))
+        try runPagedKernel(shapes: shapes)
     }
 }

--- a/provider-swift/Sources/ProviderCore/Inference/PackagedRuntimeSmoke.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/PackagedRuntimeSmoke.swift
@@ -1,0 +1,24 @@
+// Copyright © 2026 Eigen Labs.
+
+import Foundation
+import MLXLMCommon
+
+/// Runtime gate for the installed provider artifact. Release packaging runs
+/// this through the staged app executable before publication.
+public enum PackagedRuntimeSmoke {
+    public static func runPagedKernel() throws {
+        // Strictly inspect the installed app. Development search roots are
+        // intentionally excluded so CI cannot pass by finding the build
+        // directory after forgetting to package the bundle.
+        var roots = [Bundle.main.bundleURL]
+        roots.append(
+            Bundle.main.bundleURL.appendingPathComponent(
+                "Contents/Resources",
+                isDirectory: true))
+        if let resourceURL = Bundle.main.resourceURL {
+            roots.append(resourceURL)
+        }
+        try PagedAttentionKernel.runtimeSmoke(
+            searchRoots: roots)
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Inference/PagedKVPhysicalCapacityPolicy.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/PagedKVPhysicalCapacityPolicy.swift
@@ -1,0 +1,140 @@
+// Copyright © 2026 Eigen Labs.
+//
+// Physical-capacity policy for the experimental paged KV backend.
+//
+// A slot's logical unified-memory grant is an admission ceiling, not an
+// instruction to preallocate that many bytes. Paged slabs are physically
+// materialized at engine construction, so their budget is independently
+// bounded by useful concurrent context, live OS/MLX headroom, machine size,
+// and Metal's per-buffer limit.
+
+import Foundation
+import MLXLMCommon
+
+enum PagedKVPhysicalCapacityPolicy {
+    static let gib = 1 << 30
+    static let mib = 1 << 20
+
+    /// Beyond 32K tokens per running row, reserving eager physical pages has
+    /// sharply diminishing value. Longer requests remain admissible only
+    /// when the finite pool can reserve them; otherwise they retry on a
+    /// contiguous provider.
+    static let usefulContextTokensPerRequest = 32_768
+    /// A paged slot may eagerly own at most 1/16 of physical RAM.
+    static let physicalMemoryDivisor = 16
+    /// Never eagerly materialize more than 8 GiB for one model.
+    static let absoluteHardCapBytes = 8 * gib
+    /// Use at most one quarter of currently safe live KV headroom. The
+    /// remainder absorbs co-resident loads, non-MLX processes, and sampling
+    /// drift between the preflight and Metal allocation.
+    static let liveHeadroomDivisor = 4
+    /// Production grants must still leave a useful pool; otherwise explicit
+    /// paged selection degrades to contiguous before allocation.
+    static let minimumProductionPoolBytes = 1 * gib
+
+    struct Inputs: Sendable, Equatable {
+        let physicalMemoryBytes: UInt64
+        let liveKVHeadroomBytes: UInt64
+        let maxBufferLength: Int
+    }
+
+    struct Plan: Sendable, Equatable {
+        let capacityBytes: Int
+        let usefulDemandBytes: UInt64
+        let liveAllocationLimitBytes: UInt64
+        let machineHardCapBytes: UInt64
+    }
+
+    enum Decision: Sendable, Equatable {
+        case paged(Plan)
+        case contiguous(reason: String)
+    }
+
+    static func fp16BytesPerToken(layerKinds: [CBv2LayerKind]) -> Int? {
+        var total = 0
+        for kind in layerKinds where kind.sharesKVWithLayer == nil {
+            guard kind.kvHeads > 0, kind.headDim > 0 else { return nil }
+            var layer = 2
+            for factor in [kind.kvHeads, kind.headDim, MemoryLayout<Float16>.size] {
+                let (next, overflow) = layer.multipliedReportingOverflow(by: factor)
+                guard !overflow else { return nil }
+                layer = next
+            }
+            let (nextTotal, overflow) = total.addingReportingOverflow(layer)
+            guard !overflow else { return nil }
+            total = nextTotal
+        }
+        return total > 0 ? total : nil
+    }
+
+    static func decide(
+        logicalGrantBytes: Int,
+        fp16BytesPerToken: Int,
+        maxContextLength: Int?,
+        maxConcurrentRequests: Int,
+        inputs: Inputs
+    ) -> Decision {
+        guard logicalGrantBytes > 0 else {
+            return .contiguous(reason: "physical_capacity: zero logical grant")
+        }
+        guard fp16BytesPerToken > 0 else {
+            return .contiguous(reason: "physical_capacity: unknown KV byte rate")
+        }
+        guard maxConcurrentRequests > 0 else {
+            return .contiguous(reason: "physical_capacity: invalid concurrency")
+        }
+        guard inputs.maxBufferLength > 0 else {
+            return .contiguous(reason: "physical_capacity: Metal maxBufferLength unavailable")
+        }
+
+        let context = UInt64(max(
+            1,
+            min(
+                maxContextLength ?? usefulContextTokensPerRequest,
+                usefulContextTokensPerRequest)))
+        let usefulTokens = saturatingMultiply(context, UInt64(maxConcurrentRequests))
+        let usefulDemand = saturatingMultiply(
+            usefulTokens, UInt64(fp16BytesPerToken))
+        let machineCap = min(
+            UInt64(absoluteHardCapBytes),
+            inputs.physicalMemoryBytes / UInt64(physicalMemoryDivisor))
+        let liveLimit = inputs.liveKVHeadroomBytes / UInt64(liveHeadroomDivisor)
+        let twoBufferLimit = saturatingMultiply(
+            UInt64(inputs.maxBufferLength), 2)
+        let planned = min(
+            UInt64(logicalGrantBytes),
+            usefulDemand,
+            machineCap,
+            liveLimit,
+            twoBufferLimit,
+            UInt64(Int.max))
+        let rounded = planned / UInt64(mib) * UInt64(mib)
+
+        // Tiny-model unit/benchmark builds intentionally use sub-GiB logical
+        // grants. Production re-slicing already enforces a ≥1 GiB grant, so
+        // apply the serving floor exactly where it is meaningful.
+        let minimum = logicalGrantBytes >= minimumProductionPoolBytes
+            ? UInt64(minimumProductionPoolBytes)
+            : UInt64(mib)
+        guard rounded >= minimum else {
+            return .contiguous(
+                reason: "physical_capacity: safe pool \(rounded) B is below "
+                    + "the \(minimum) B serviceability floor")
+        }
+
+        return .paged(
+            Plan(
+                capacityBytes: Int(rounded),
+                usefulDemandBytes: usefulDemand,
+                liveAllocationLimitBytes: liveLimit,
+                machineHardCapBytes: machineCap))
+    }
+
+    private static func saturatingMultiply(
+        _ lhs: UInt64,
+        _ rhs: UInt64
+    ) -> UInt64 {
+        let (product, overflow) = lhs.multipliedReportingOverflow(by: rhs)
+        return overflow ? .max : product
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Inference/PagedKernelPreflight.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/PagedKernelPreflight.swift
@@ -34,7 +34,10 @@ enum PagedKernelPreflight {
         let shapes = PagedAttentionKernel.smokeShapes(layerKinds: layerKinds)
         if let childRunner {
             try childRunner(shapes)
-        } else if let executableURL,
+        } else if
+            // Resolve bin/ (or operator-added) symlinks before deriving the
+            // packaged context — same rule as PagedAttentionResources.
+            let executableURL = executableURL?.resolvingSymlinksInPath(),
             executableURL.lastPathComponent == "darkbloom",
             FileManager.default.isExecutableFile(atPath: executableURL.path)
         {

--- a/provider-swift/Sources/ProviderCore/Inference/PagedKernelPreflight.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/PagedKernelPreflight.swift
@@ -1,0 +1,80 @@
+// Copyright © 2026 Eigen Labs.
+//
+// Catchable pre-JIT gate for explicit paged engines. MLX custom-kernel
+// compilation failures can terminate the process rather than throw, so a
+// packaged provider probes every model-specific specialization in a child
+// process first. The parent then runs the same smoke to populate its own
+// kernel cache before allocating the physical slabs.
+
+import Foundation
+import MLXLMCommon
+
+enum PagedKernelPreflightError: Error, CustomStringConvertible {
+    case childFailed(status: Int32, output: String)
+    case childSignalled(signal: Int32, output: String)
+
+    var description: String {
+        switch self {
+        case .childFailed(let status, let output):
+            return "paged kernel preflight child exited \(status): \(output)"
+        case .childSignalled(let signal, let output):
+            return "paged kernel preflight child terminated by signal \(signal): \(output)"
+        }
+    }
+}
+
+enum PagedKernelPreflight {
+    typealias ChildRunner = ([PagedAttentionKernelSmokeShape]) throws -> Void
+
+    static func run(
+        layerKinds: [CBv2LayerKind],
+        executableURL: URL? = Bundle.main.executableURL,
+        childRunner: ChildRunner? = nil
+    ) throws {
+        let shapes = PagedAttentionKernel.smokeShapes(layerKinds: layerKinds)
+        if let childRunner {
+            try childRunner(shapes)
+        } else if let executableURL,
+            executableURL.lastPathComponent == "darkbloom",
+            FileManager.default.isExecutableFile(atPath: executableURL.path)
+        {
+            try runChild(executableURL: executableURL, shapes: shapes)
+        }
+
+        // The child makes fatal compiler/driver failures catchable. Repeat
+        // in the parent to populate its process-local MLXFast kernel cache,
+        // so the first request compiles or dispatches no new paged variant.
+        try PagedAttentionKernel.runtimeSmoke(shapes: shapes)
+    }
+
+    private static func runChild(
+        executableURL: URL,
+        shapes: [PagedAttentionKernelSmokeShape]
+    ) throws {
+        let process = Process()
+        process.executableURL = executableURL
+        process.arguments = ["runtime-smoke"] + shapes.map(\.argumentValue)
+        process.environment = ProcessInfo.processInfo.environment.merging(
+            ["DARKBLOOM_NO_UPDATE_CHECK": "1"],
+            uniquingKeysWith: { _, override in override })
+        let output = Pipe()
+        process.standardOutput = output
+        process.standardError = output
+        try process.run()
+        process.waitUntilExit()
+        let text = String(
+            data: output.fileHandleForReading.readDataToEndOfFile(),
+            encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        guard process.terminationReason == .exit else {
+            throw PagedKernelPreflightError.childSignalled(
+                signal: process.terminationStatus,
+                output: text)
+        }
+        guard process.terminationStatus == 0 else {
+            throw PagedKernelPreflightError.childFailed(
+                status: process.terminationStatus,
+                output: text)
+        }
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Inference/PagedKernelPreflight.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/PagedKernelPreflight.swift
@@ -10,25 +10,34 @@ import Foundation
 import MLXLMCommon
 
 enum PagedKernelPreflightError: Error, CustomStringConvertible {
-    case childFailed(status: Int32, output: String)
-    case childSignalled(signal: Int32, output: String)
+    case childFailed(status: Int32)
+    case childSignalled(signal: Int32)
+    case childTimedOut(seconds: TimeInterval)
+    case childWouldNotTerminate
 
     var description: String {
         switch self {
-        case .childFailed(let status, let output):
-            return "paged kernel preflight child exited \(status): \(output)"
-        case .childSignalled(let signal, let output):
-            return "paged kernel preflight child terminated by signal \(signal): \(output)"
+        case .childFailed(let status):
+            return "paged kernel preflight child exited \(status)"
+        case .childSignalled(let signal):
+            return "paged kernel preflight child terminated by signal \(signal)"
+        case .childTimedOut(let seconds):
+            return "paged kernel preflight child exceeded \(seconds) seconds"
+        case .childWouldNotTerminate:
+            return "paged kernel preflight child survived SIGKILL"
         }
     }
 }
 
 enum PagedKernelPreflight {
+    static let defaultChildTimeout: TimeInterval = 120
+
     typealias ChildRunner = ([PagedAttentionKernelSmokeShape]) throws -> Void
 
     static func run(
         layerKinds: [CBv2LayerKind],
         executableURL: URL? = Bundle.main.executableURL,
+        childTimeout: TimeInterval = defaultChildTimeout,
         childRunner: ChildRunner? = nil
     ) throws {
         let shapes = PagedAttentionKernel.smokeShapes(layerKinds: layerKinds)
@@ -41,7 +50,10 @@ enum PagedKernelPreflight {
             executableURL.lastPathComponent == "darkbloom",
             FileManager.default.isExecutableFile(atPath: executableURL.path)
         {
-            try runChild(executableURL: executableURL, shapes: shapes)
+            try runChild(
+                executableURL: executableURL,
+                shapes: shapes,
+                timeout: childTimeout)
         }
 
         // The child makes fatal compiler/driver failures catchable. Repeat
@@ -52,32 +64,23 @@ enum PagedKernelPreflight {
 
     private static func runChild(
         executableURL: URL,
-        shapes: [PagedAttentionKernelSmokeShape]
+        shapes: [PagedAttentionKernelSmokeShape],
+        timeout: TimeInterval
     ) throws {
-        let process = Process()
-        process.executableURL = executableURL
-        process.arguments = ["runtime-smoke"] + shapes.map(\.argumentValue)
-        process.environment = ProcessInfo.processInfo.environment.merging(
-            ["DARKBLOOM_NO_UPDATE_CHECK": "1"],
-            uniquingKeysWith: { _, override in override })
-        let output = Pipe()
-        process.standardOutput = output
-        process.standardError = output
-        try process.run()
-        process.waitUntilExit()
-        let text = String(
-            data: output.fileHandleForReading.readDataToEndOfFile(),
-            encoding: .utf8)?
-            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        guard process.terminationReason == .exit else {
-            throw PagedKernelPreflightError.childSignalled(
-                signal: process.terminationStatus,
-                output: text)
-        }
-        guard process.terminationStatus == 0 else {
-            throw PagedKernelPreflightError.childFailed(
-                status: process.terminationStatus,
-                output: text)
+        do {
+            try BoundedProcess.run(
+                executableURL,
+                arguments: ["runtime-smoke"] + shapes.map(\.argumentValue),
+                environment: ["DARKBLOOM_NO_UPDATE_CHECK": "1"],
+                timeout: timeout)
+        } catch BoundedProcess.Failure.exited(let status) {
+            throw PagedKernelPreflightError.childFailed(status: status)
+        } catch BoundedProcess.Failure.signalled(let signal) {
+            throw PagedKernelPreflightError.childSignalled(signal: signal)
+        } catch BoundedProcess.Failure.timedOut(let seconds) {
+            throw PagedKernelPreflightError.childTimedOut(seconds: seconds)
+        } catch BoundedProcess.Failure.wouldNotTerminate {
+            throw PagedKernelPreflightError.childWouldNotTerminate
         }
     }
 }

--- a/provider-swift/Sources/ProviderCore/Process/BoundedProcess.swift
+++ b/provider-swift/Sources/ProviderCore/Process/BoundedProcess.swift
@@ -1,0 +1,88 @@
+import Foundation
+#if canImport(Darwin)
+import Darwin
+#endif
+
+enum BoundedProcess {
+    enum Failure: Error, LocalizedError, CustomStringConvertible {
+        case exited(status: Int32)
+        case signalled(signal: Int32)
+        case timedOut(seconds: TimeInterval)
+        case wouldNotTerminate
+
+        var description: String {
+            switch self {
+            case .exited(let status):
+                return "process exited \(status)"
+            case .signalled(let signal):
+                return "process terminated by signal \(signal)"
+            case .timedOut(let seconds):
+                return "process exceeded \(seconds) seconds"
+            case .wouldNotTerminate:
+                return "process did not terminate after SIGKILL"
+            }
+        }
+
+        var errorDescription: String? { description }
+    }
+
+    static func run(
+        _ executable: URL,
+        arguments: [String],
+        environment: [String: String]? = nil,
+        timeout: TimeInterval
+    ) throws {
+        let process = Process()
+        process.executableURL = executable
+        process.arguments = arguments
+        if let environment {
+            process.environment = ProcessInfo.processInfo.environment.merging(
+                environment,
+                uniquingKeysWith: { _, override in override })
+        }
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+        try process.run()
+
+        guard waitForExit(process, timeout: timeout) else {
+            process.terminate()
+            if !waitForExit(process, timeout: 2) {
+                forceKill(process)
+                guard waitForExit(process, timeout: 2) else {
+                    throw Failure.wouldNotTerminate
+                }
+            }
+            process.waitUntilExit()
+            throw Failure.timedOut(seconds: timeout)
+        }
+        process.waitUntilExit()
+
+        guard process.terminationReason == .exit else {
+            throw Failure.signalled(signal: process.terminationStatus)
+        }
+        guard process.terminationStatus == 0 else {
+            throw Failure.exited(status: process.terminationStatus)
+        }
+    }
+
+    private static func waitForExit(
+        _ process: Process,
+        timeout: TimeInterval
+    ) -> Bool {
+        let deadline = ProcessInfo.processInfo.systemUptime + max(0, timeout)
+        while process.isRunning,
+              ProcessInfo.processInfo.systemUptime < deadline
+        {
+            Thread.sleep(forTimeInterval: 0.05)
+        }
+        return !process.isRunning
+    }
+
+    private static func forceKill(_ process: Process) {
+        #if canImport(Darwin)
+        _ = Darwin.kill(process.processIdentifier, SIGKILL)
+        #else
+        process.terminate()
+        #endif
+    }
+}

--- a/provider-swift/Sources/ProviderCore/ProviderCore.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderCore.swift
@@ -138,10 +138,10 @@ public enum ProviderCore {
     // WebSocket message types, same BackendSlotCapacity wire shape;
     // max_concurrency now truthfully reports the engine cap (≤ 8, default
     // 4) instead of legacy's 24.
-    // 0.7.6 enables the production PagedAttention KV backend for GPT-OSS text
-    // slots. The backend eagerly commits its pool, reports physical pool truth
-    // through existing heartbeat fields, and maps terminal pool exhaustion to
-    // retryable capacity. Gemma-4 VLM and kv-quant slots stay contiguous; an
-    // operator can force contiguous with DARKBLOOM_CBV2_PAGED_KV=0.
+    // 0.7.6 introduced PagedAttention for GPT-OSS; the safety follow-up keeps
+    // "auto" contiguous and leaves paged explicit/experimental. Explicit pools
+    // eagerly commit only an independently capped physical plan, report pool
+    // truth through existing heartbeat fields, and map terminal exhaustion to
+    // retryable capacity. VLM and kv-quant slots stay contiguous.
     public static let version = "0.7.6"
 }

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+EngineV2.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+EngineV2.swift
@@ -156,17 +156,16 @@ extension ProviderLoop {
     /// Existing v2 slots eligible for re-slicing: live (not mid-unload)
     /// slots other than `excludingModelId` (a same-id slot present during a
     /// reload is excluded so its weights/grant are not double-counted).
-    /// Reads each slot's CURRENT TOTAL claim (post-any-earlier-resize):
-    /// engine admission ceiling PLUS the slot's fixed prefix-cache budget
-    /// (`slotKVBytesClaim`, T-041) — counting only the engine ceiling would
-    /// re-grant the cache's bytes to a newcomer. Grants flowing back down
-    /// (`updateKVBytesCapacity`) are totals too; the bridge nets out its
-    /// own cache budget before touching the engine.
+    /// Reads each slot's CURRENT logical admission target PLUS the fixed
+    /// prefix-cache budget. This is the exact rollback value after a failed
+    /// load. Paged physical claims are tracked separately by
+    /// `slotKVBytesClaim()` for fleet accounting and never shrink when this
+    /// logical target is re-sliced.
     private func existingSlotGrants(excludingModelId: String) async -> [ExistingSlotGrant] {
         var existing: [ExistingSlotGrant] = []
         for (slotModelId, slot) in modelSlots
         where slotModelId != excludingModelId && !modelsUnloading.contains(slotModelId) {
-            let currentGrant = await slot.engineV2.slotKVBytesClaim()
+            let currentGrant = await slot.engineV2.resliceAdmissionBytesClaim()
             existing.append(
                 ExistingSlotGrant(
                     slot: EngineV2KVSizing.ResliceSlot(

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+EngineV2.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+EngineV2.swift
@@ -98,6 +98,13 @@ extension ProviderLoop {
         /// Machine-memory override for the re-slice fleet budget (nil ⇒
         /// real physical memory).
         let physicalMemoryBytes: UInt64?
+        /// Backend kind the hook-built bridge reports per model (default
+        /// `.contiguous`). A `.paged` entry makes the bridge apply the
+        /// production paged semantics — resize clamps to the scripted
+        /// engine's physical `kvBytesBackendCapacity`, no per-request
+        /// shared-gate reserve — so mixed paged+contiguous re-slice
+        /// orchestration is testable without weights.
+        let kvBackendKindByModel: [String: EngineV2KVBackendKind]
         /// Scripted engine builder: (modelId, kvBytesCapacity) — the second
         /// argument is the RE-SLICED, POST-CARVE admission ceiling the
         /// production path would hand `makeProductionEngine`, exposed so
@@ -111,6 +118,7 @@ extension ProviderLoop {
             extraEOSTokens: [String] = [],
             emitTelemetry: (@Sendable (TelemetryEvent) -> Void)? = nil,
             physicalMemoryBytes: UInt64? = nil,
+            kvBackendKindByModel: [String: EngineV2KVBackendKind] = [:],
             makeEngine: @escaping @Sendable (String, Int) throws -> any CBv2Engine
         ) {
             self.environment = environment
@@ -118,6 +126,7 @@ extension ProviderLoop {
             self.extraEOSTokens = extraEOSTokens
             self.emitTelemetry = emitTelemetry
             self.physicalMemoryBytes = physicalMemoryBytes
+            self.kvBackendKindByModel = kvBackendKindByModel
             self.makeEngine = makeEngine
         }
     }
@@ -447,12 +456,14 @@ extension ProviderLoop {
                 prefixCacheBudgetBytes: carve.prefixCacheBudgetBytes,
                 emitTelemetry: hooks.emitTelemetry,
                 makeEngine: {
-                    // Scripted hook engines are backend-less stubs:
-                    // contiguous semantics (per-request shared-gate
-                    // reserves, resize-in-place re-slice).
+                    // Scripted hook engines default to contiguous semantics
+                    // (per-request shared-gate reserves, resize-in-place
+                    // re-slice); a per-model `.paged` entry opts into the
+                    // production paged bridge semantics for mixed-backend
+                    // re-slice tests.
                     EngineV2Factory.ProductionBuild(
                         engine: try hookBuilder(modelId, carve.engineKVBytesCapacity),
-                        kvBackendKind: .contiguous,
+                        kvBackendKind: hooks.kvBackendKindByModel[modelId] ?? .contiguous,
                         kvBackendFallbackReason: nil)
                 })
             // WARN once (per load) that kv_quant is ignored on the v2 path

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+ModelLoading.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+ModelLoading.swift
@@ -397,11 +397,12 @@ extension ProviderLoop {
             // whose full load-time footprint leaves no serveable KV unloads
             // and 503s instead of advertising a model whose every request
             // the shared KV gate rejects — the v0.7.2 black-hole shape.
-            // BACKEND-AWARE (PR #531 Codex P1): a PAGED slot commits its
-            // whole grant as the pool at construction, so measuring the
-            // residue would unload every paged slot by design — the floor
-            // is held against the committed pool instead
-            // (`KVHeadroomProbe.postBuildServeable`).
+            // BACKEND-AWARE: a PAGED slot commits its independently-capped
+            // physical pool at construction. The guard requires BOTH a
+            // serveable pool and residual whole-machine headroom; this
+            // catches unaccounted build/JIT residency while the conservative
+            // physical-capacity policy prevents the pool from consuming the
+            // full logical grant.
             MLX.Memory.clearCache()
             let postBridgeServeable = KVHeadroomProbe.postBuildServeable(
                 kvBackendKind: engineV2Bridge.kvBackendKind,

--- a/provider-swift/Sources/ProviderCore/Server/StandaloneServer.swift
+++ b/provider-swift/Sources/ProviderCore/Server/StandaloneServer.swift
@@ -478,10 +478,11 @@ public actor StandaloneServer {
         var existing: [ExistingSlotGrant] = []
         for (modelId, slot) in slots
         where modelId != excludingModelId && !evictingModels.contains(modelId) {
-            // TOTAL claim (engine ceiling + prefix-cache budget, T-041):
-            // grants flowing back down through `updateKVBytesCapacity` are
-            // totals too — the bridge nets out its own cache budget.
-            let currentGrant = await slot.bridge.slotKVBytesClaim()
+            // Exact logical admission target + prefix carve for rollback.
+            // A paged slot's larger immutable physical claim is tracked by
+            // slotKVBytesClaim(), but must not replace a previously-shrunk
+            // logical restore point.
+            let currentGrant = await slot.bridge.resliceAdmissionBytesClaim()
             existing.append(
                 ExistingSlotGrant(
                     slot: EngineV2KVSizing.ResliceSlot(
@@ -1057,9 +1058,9 @@ public actor StandaloneServer {
             // memory beyond the weights. Re-measure so a box whose full
             // load-time footprint leaves no serveable KV tears down instead
             // of publishing a model whose every request the KV gate rejects.
-            // BACKEND-AWARE (PR #531 Codex P1): a PAGED slot commits its
-            // whole grant as the pool at construction — the floor is held
-            // against the committed pool, not the residue it consumed.
+            // BACKEND-AWARE: a PAGED slot commits only its conservative
+            // physical plan. Require both a useful pool and residual
+            // whole-machine headroom after the build.
             MLX.Memory.clearCache()
             let postBridgeServeable = KVHeadroomProbe.postBuildServeable(
                 kvBackendKind: bridge.kvBackendKind,

--- a/provider-swift/Sources/ProviderCore/Update/DarkbloomCodeSignature.swift
+++ b/provider-swift/Sources/ProviderCore/Update/DarkbloomCodeSignature.swift
@@ -24,27 +24,10 @@ enum DarkbloomCodeSignature {
             arguments.append("-R=\(designatedRequirement)")
         }
         arguments.append(target.path)
-
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/usr/bin/codesign")
-        process.arguments = arguments
-        let stderr = Pipe()
-        process.standardOutput = FileHandle.nullDevice
-        process.standardError = stderr
-        try process.run()
-        process.waitUntilExit()
-        guard process.terminationStatus == 0 else {
-            let detail = String(
-                data: stderr.fileHandleForReading.readDataToEndOfFile(),
-                encoding: .utf8
-            )?.trimmingCharacters(in: .whitespacesAndNewlines)
-                ?? "codesign exited \(process.terminationStatus)"
-            throw NSError(
-                domain: "DarkbloomCodeSignature",
-                code: Int(process.terminationStatus),
-                userInfo: [NSLocalizedDescriptionKey: detail]
-            )
-        }
+        try BoundedProcess.run(
+            URL(fileURLWithPath: "/usr/bin/codesign"),
+            arguments: arguments,
+            timeout: 120)
         #endif
     }
 }

--- a/provider-swift/Sources/ProviderCore/Update/SelfUpdater.swift
+++ b/provider-swift/Sources/ProviderCore/Update/SelfUpdater.swift
@@ -554,6 +554,19 @@ public struct SelfUpdater: Sendable {
                         label: "Darkbloom.app",
                         deep: true
                     )
+                    let pagedResources = try stagedPagedResources(
+                        app: extractedApp,
+                        fileManager: fm)
+                    guard pagedResources.count <= 1 else {
+                        throw UpdateError.replaceFailed(
+                            "ambiguous package: multiple pagedattention.metal resources")
+                    }
+                    if pagedResources.count == 1 {
+                        try runProcess(
+                            appDarkbloom.path,
+                            arguments: ["runtime-smoke"],
+                            environment: ["DARKBLOOM_NO_UPDATE_CHECK": "1"])
+                    }
                 } else {
                     try verifyCodeSignature(file: flatDarkbloom, label: "darkbloom")
                 }
@@ -1035,6 +1048,25 @@ public struct SelfUpdater: Sendable {
         }
     }
 
+    private func stagedPagedResources(
+        app: URL,
+        fileManager: FileManager
+    ) throws -> [URL] {
+        let resourceRoot = app.appendingPathComponent(
+            "Contents/Resources",
+            isDirectory: true)
+        guard fileManager.fileExists(atPath: resourceRoot.path) else {
+            return []
+        }
+        return try fileManager.contentsOfDirectory(
+            at: resourceRoot,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: [.skipsHiddenFiles])
+            .filter { $0.pathExtension == "bundle" }
+            .map { $0.appendingPathComponent("pagedattention.metal") }
+            .filter { fileManager.isReadableFile(atPath: $0.path) }
+    }
+
     private func verifyCodeSignature(
         file: URL,
         label: String,
@@ -1049,10 +1081,19 @@ public struct SelfUpdater: Sendable {
         #endif
     }
 
-    private func runProcess(_ executable: String, arguments: [String]) throws {
+    private func runProcess(
+        _ executable: String,
+        arguments: [String],
+        environment: [String: String]? = nil
+    ) throws {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: executable)
         process.arguments = arguments
+        if let environment {
+            process.environment = ProcessInfo.processInfo.environment.merging(
+                environment,
+                uniquingKeysWith: { _, override in override })
+        }
         let stderr = Pipe()
         process.standardError = stderr
         try process.run()

--- a/provider-swift/Sources/ProviderCore/Update/SelfUpdater.swift
+++ b/provider-swift/Sources/ProviderCore/Update/SelfUpdater.swift
@@ -358,6 +358,21 @@ public struct SelfUpdater: Sendable {
     /// layout; cleaned up on the next staging pass if a crash orphans them.
     private static let stagingDirPrefix = ".update-staging-"
 
+    private struct ArtifactVerificationPolicy {
+        let codeSignaturePolicy: DarkbloomCodeSignature.Policy?
+        let verifyRuntimeCapabilities: Bool
+
+        static let production = ArtifactVerificationPolicy(
+            codeSignaturePolicy: .darkbloomProduction,
+            verifyRuntimeCapabilities: true)
+        static let unverifiedTestFixture = ArtifactVerificationPolicy(
+            codeSignaturePolicy: nil,
+            verifyRuntimeCapabilities: false)
+        static let signedTestFixture = ArtifactVerificationPolicy(
+            codeSignaturePolicy: .structuralForIsolatedTest,
+            verifyRuntimeCapabilities: true)
+    }
+
     /// A release bundle that has been extracted and fully verified (hashes and
     /// code signature) but NOT yet installed into the live layout.
     ///
@@ -410,7 +425,9 @@ public struct SelfUpdater: Sendable {
             from: downloadedFile,
             release: release,
             installDir: installDir,
-            verifyCodeSignatures: session.store.verifyCodeSignatures
+            verification: session.store.verifyCodeSignatures
+                ? .production
+                : .unverifiedTestFixture
         )
     }
 
@@ -441,15 +458,27 @@ public struct SelfUpdater: Sendable {
             from: downloadedFile,
             release: release,
             installDir: installDir,
-            verifyCodeSignatures: false
+            verification: .unverifiedTestFixture
         )
+    }
+
+    internal func stageSignedBundleForTesting(
+        from downloadedFile: URL,
+        release: ReleaseInfo,
+        installDir: URL
+    ) -> Result<StagedBundle, UpdateError> {
+        stageBundle(
+            from: downloadedFile,
+            release: release,
+            installDir: installDir,
+            verification: .signedTestFixture)
     }
 
     private func stageBundle(
         from downloadedFile: URL,
         release: ReleaseInfo,
         installDir: URL,
-        verifyCodeSignatures: Bool
+        verification: ArtifactVerificationPolicy
     ) -> Result<StagedBundle, UpdateError> {
         let fm = FileManager.default
         let stagingRoot = installDir.appendingPathComponent(
@@ -528,7 +557,7 @@ public struct SelfUpdater: Sendable {
                     )
                 }
             }
-            if verifyCodeSignatures {
+            if let signaturePolicy = verification.codeSignaturePolicy {
                 if hasAppBundle {
                     let appDarkbloom = extractedApp
                         .appendingPathComponent("Contents/MacOS/darkbloom")
@@ -548,27 +577,28 @@ public struct SelfUpdater: Sendable {
                             label: "Darkbloom.app mlx.metallib"
                         )
                     }
-                    try verifyCodeSignature(file: appDarkbloom, label: "darkbloom")
+                    try verifyCodeSignature(
+                        file: appDarkbloom,
+                        label: "darkbloom",
+                        policy: signaturePolicy
+                    )
                     try verifyCodeSignature(
                         file: extractedApp,
                         label: "Darkbloom.app",
-                        deep: true
+                        deep: true,
+                        policy: signaturePolicy
                     )
-                    let pagedResources = try stagedPagedResources(
-                        app: extractedApp,
-                        fileManager: fm)
-                    guard pagedResources.count <= 1 else {
-                        throw UpdateError.replaceFailed(
-                            "ambiguous package: multiple pagedattention.metal resources")
-                    }
-                    if pagedResources.count == 1 {
-                        try runProcess(
-                            appDarkbloom.path,
-                            arguments: ["runtime-smoke"],
-                            environment: ["DARKBLOOM_NO_UPDATE_CHECK": "1"])
+                    if verification.verifyRuntimeCapabilities {
+                        try verifyRuntimeCapabilities(
+                            app: extractedApp,
+                            executable: appDarkbloom,
+                            fileManager: fm)
                     }
                 } else {
-                    try verifyCodeSignature(file: flatDarkbloom, label: "darkbloom")
+                    try verifyCodeSignature(
+                        file: flatDarkbloom,
+                        label: "darkbloom",
+                        policy: signaturePolicy)
                 }
             }
 
@@ -913,7 +943,9 @@ public struct SelfUpdater: Sendable {
             from: downloadedFile,
             release: release,
             installDir: session.store.installRoot,
-            verifyCodeSignatures: session.store.verifyCodeSignatures
+            verification: session.store.verifyCodeSignatures
+                ? .production
+                : .unverifiedTestFixture
         ) {
         case .failure(let error):
             return .failure(error)
@@ -1048,33 +1080,72 @@ public struct SelfUpdater: Sendable {
         }
     }
 
-    private func stagedPagedResources(
+    private func verifyRuntimeCapabilities(
         app: URL,
+        executable: URL,
         fileManager: FileManager
-    ) throws -> [URL] {
+    ) throws {
+        let marker = app.appendingPathComponent(
+            PackagedRuntimeSmoke.pagedCapabilityRelativePath)
+        let markerPresent = fileManager.fileExists(atPath: marker.path)
+        let binary = try Data(contentsOf: executable, options: [.mappedIfSafe])
+        let pagedCodePresent = binary.range(
+            of: Data("engine_v2_kv_backend".utf8)) != nil
+
+        guard markerPresent == pagedCodePresent else {
+            throw UpdateError.replaceFailed(
+                pagedCodePresent
+                    ? "paged-capable artifact is missing its signed capability marker"
+                    : "artifact advertises paged capability without paged runtime code")
+        }
+        guard markerPresent else {
+            return // pre-paged v0.7.5/v0.7.7 compatibility
+        }
+        guard
+            let markerValue = try? String(contentsOf: marker, encoding: .utf8),
+            markerValue.trimmingCharacters(in: .whitespacesAndNewlines) == "1"
+        else {
+            throw UpdateError.replaceFailed(
+                "paged runtime capability marker is invalid")
+        }
+
         let resourceRoot = app.appendingPathComponent(
             "Contents/Resources",
             isDirectory: true)
-        guard fileManager.fileExists(atPath: resourceRoot.path) else {
-            return []
-        }
-        return try fileManager.contentsOfDirectory(
+        let bundles = try fileManager.contentsOfDirectory(
             at: resourceRoot,
             includingPropertiesForKeys: [.isDirectoryKey],
             options: [.skipsHiddenFiles])
-            .filter { $0.pathExtension == "bundle" }
+            .filter {
+                $0.lastPathComponent == PackagedRuntimeSmoke.mlxLMCommonBundleName
+            }
             .map { $0.appendingPathComponent("pagedattention.metal") }
             .filter { fileManager.isReadableFile(atPath: $0.path) }
+        guard bundles.count == 1 else {
+            throw UpdateError.replaceFailed(
+                "paged-capable artifact requires exactly one sealed "
+                    + "\(PackagedRuntimeSmoke.mlxLMCommonBundleName)/pagedattention.metal "
+                    + "(found \(bundles.count))")
+        }
+        try runProcess(
+            executable.path,
+            arguments: ["runtime-smoke"],
+            environment: ["DARKBLOOM_NO_UPDATE_CHECK": "1"])
     }
 
     private func verifyCodeSignature(
         file: URL,
         label: String,
-        deep: Bool = false
+        deep: Bool = false,
+        policy: DarkbloomCodeSignature.Policy = .darkbloomProduction
     ) throws {
         #if canImport(Darwin)
         do {
-            try DarkbloomCodeSignature.verify(file, deep: deep)
+            try DarkbloomCodeSignature.verify(
+                file,
+                deep: deep,
+                policy: policy
+            )
         } catch {
             throw UpdateError.replaceFailed("\(label) code signature verification failed: \(error.localizedDescription)")
         }
@@ -1105,6 +1176,7 @@ public struct SelfUpdater: Sendable {
             throw UpdateError.replaceFailed(message?.isEmpty == false ? message! : "\(executable) exited \(process.terminationStatus)")
         }
     }
+
 }
 
 // MARK: - Errors

--- a/provider-swift/Sources/ProviderCore/Update/SelfUpdater.swift
+++ b/provider-swift/Sources/ProviderCore/Update/SelfUpdater.swift
@@ -357,6 +357,7 @@ public struct SelfUpdater: Sendable {
     /// the darkbloom root. Dot-prefixed so they stay out of the visible
     /// layout; cleaned up on the next staging pass if a crash orphans them.
     private static let stagingDirPrefix = ".update-staging-"
+    private static let artifactVerificationTimeout: TimeInterval = 120
 
     private struct ArtifactVerificationPolicy {
         let codeSignaturePolicy: DarkbloomCodeSignature.Policy?
@@ -491,7 +492,10 @@ public struct SelfUpdater: Sendable {
             removeStaleUpdateDirs(in: installDir)
 
             try fm.createDirectory(at: stagingRoot, withIntermediateDirectories: true)
-            try runProcess("/usr/bin/tar", arguments: ["xzf", downloadedFile.path, "-C", stagingRoot.path])
+            try BoundedProcess.run(
+                URL(fileURLWithPath: "/usr/bin/tar"),
+                arguments: ["xzf", downloadedFile.path, "-C", stagingRoot.path],
+                timeout: Self.artifactVerificationTimeout)
 
             // Use the flat bin/ copies for hash verification (release hashes
             // are computed from the flat layout).
@@ -1127,10 +1131,11 @@ public struct SelfUpdater: Sendable {
                     + "\(PackagedRuntimeSmoke.mlxLMCommonBundleName)/pagedattention.metal "
                     + "(found \(bundles.count))")
         }
-        try runProcess(
-            executable.path,
+        try BoundedProcess.run(
+            executable,
             arguments: ["runtime-smoke"],
-            environment: ["DARKBLOOM_NO_UPDATE_CHECK": "1"])
+            environment: ["DARKBLOOM_NO_UPDATE_CHECK": "1"],
+            timeout: Self.artifactVerificationTimeout)
     }
 
     private func verifyCodeSignature(
@@ -1150,31 +1155,6 @@ public struct SelfUpdater: Sendable {
             throw UpdateError.replaceFailed("\(label) code signature verification failed: \(error.localizedDescription)")
         }
         #endif
-    }
-
-    private func runProcess(
-        _ executable: String,
-        arguments: [String],
-        environment: [String: String]? = nil
-    ) throws {
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: executable)
-        process.arguments = arguments
-        if let environment {
-            process.environment = ProcessInfo.processInfo.environment.merging(
-                environment,
-                uniquingKeysWith: { _, override in override })
-        }
-        let stderr = Pipe()
-        process.standardError = stderr
-        try process.run()
-        process.waitUntilExit()
-        guard process.terminationStatus == 0 else {
-            let data = stderr.fileHandleForReading.readDataToEndOfFile()
-            let message = String(data: data, encoding: .utf8)?
-                .trimmingCharacters(in: .whitespacesAndNewlines)
-            throw UpdateError.replaceFailed(message?.isEmpty == false ? message! : "\(executable) exited \(process.terminationStatus)")
-        }
     }
 
 }

--- a/provider-swift/Sources/darkbloom/Darkbloom.swift
+++ b/provider-swift/Sources/darkbloom/Darkbloom.swift
@@ -46,6 +46,7 @@ struct Darkbloom: AsyncParsableCommand {
             AutoUpdate.self,
             Beta.self,
             Watchdog.self,
+            RuntimeSmoke.self,
         ]
     )
 

--- a/provider-swift/Sources/darkbloom/RuntimeSmokeCommand.swift
+++ b/provider-swift/Sources/darkbloom/RuntimeSmokeCommand.swift
@@ -1,0 +1,16 @@
+import ArgumentParser
+import ProviderCore
+
+/// Package-real release gate. Hidden because it is invoked by CI against the
+/// staged/extracted app, not by operators.
+struct RuntimeSmoke: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "runtime-smoke",
+        abstract: "Internal: validate packaged runtime resources and kernels.",
+        shouldDisplay: false)
+
+    mutating func run() throws {
+        try PackagedRuntimeSmoke.runPagedKernel()
+        print("paged-kernel-runtime-smoke: ok")
+    }
+}

--- a/provider-swift/Sources/darkbloom/RuntimeSmokeCommand.swift
+++ b/provider-swift/Sources/darkbloom/RuntimeSmokeCommand.swift
@@ -9,8 +9,11 @@ struct RuntimeSmoke: ParsableCommand {
         abstract: "Internal: validate packaged runtime resources and kernels.",
         shouldDisplay: false)
 
+    @Argument(help: "Internal encoded kernel shapes.")
+    var shapes: [String] = []
+
     mutating func run() throws {
-        try PackagedRuntimeSmoke.runPagedKernel()
+        try PackagedRuntimeSmoke.runPagedKernel(arguments: shapes)
         print("paged-kernel-runtime-smoke: ok")
     }
 }

--- a/provider-swift/Tests/ProviderCoreTests/EngineV2BridgeTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/EngineV2BridgeTests.swift
@@ -101,6 +101,12 @@ private final class ScriptedCBv2Engine: CBv2Engine, @unchecked Sendable {
         lock.withLock { capacitySnapshot }
     }
 
+    func updateKVBytesCapacity(_ bytes: Int) {
+        lock.withLock {
+            capacitySnapshot.kvBytesCapacity = max(0, bytes)
+        }
+    }
+
     func shutdown() async {
         lock.withLock { _shutdownCalls += 1 }
     }
@@ -1911,6 +1917,33 @@ struct EngineV2BridgePagedKVTests {
         #expect(
             await bridge.backendSlotCapacity(kvBytesBudgetClamp: 40_000)
                 .activeTokenBudgetMax == 40)
+    }
+
+    @Test("ledger-only reslice never claims physical reclaim or grows past the pool")
+    func pagedResliceKeepsPhysicalTruth() async {
+        let engine = ScriptedCBv2Engine(
+            script: .manual,
+            capacity: CBv2CapacitySnapshot(
+                activeRequests: 0, waitingRequests: 0, kvBytesInUse: 0,
+                kvBytesCapacity: 60_000, kvBytesBackendCapacity: 60_000,
+                activeTokens: 0))
+        let bridge = makeBridge(
+            engine: engine,
+            kvBytesPerToken: 1_000,
+            kvBackendKind: .paged)
+
+        await bridge.updateKVBytesCapacity(20_000)
+        #expect(engine.capacity().kvBytesCapacity == 20_000)
+        #expect(engine.capacity().kvBytesBackendCapacity == 60_000)
+        #expect(await bridge.kvBackendPoolBytes() == 60_000)
+        #expect(await bridge.slotKVBytesClaim() == 60_000)
+        #expect(await bridge.resliceAdmissionBytesClaim() == 20_000)
+
+        // Growing the logical target cannot mint physical pages.
+        await bridge.updateKVBytesCapacity(100_000)
+        #expect(engine.capacity().kvBytesCapacity == 60_000)
+        #expect(engine.capacity().kvBytesBackendCapacity == 60_000)
+        #expect(await bridge.backendSlotCapacity().activeTokenBudgetMax == 60)
     }
 
     @Test("unknown backend capacity (0) does not bind")

--- a/provider-swift/Tests/ProviderCoreTests/EngineV2KVBackendGateTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/EngineV2KVBackendGateTests.swift
@@ -74,7 +74,7 @@ private func makeBuild(
     model: any LanguageModel,
     kvBackend: EngineV2KVBackendSelection,
     environment: [String: String] = [:],
-    pagedResourceSearchRoots: [URL]? = nil
+    pagedPreflightOverride: (([CBv2LayerKind]) throws -> Void)? = nil
 ) throws -> EngineV2Factory.ProductionBuild {
     _ = LiveInferenceFixtures.ensureMetallibColocated()
     return try EngineV2Factory.makeProductionBuild(
@@ -86,7 +86,7 @@ private func makeBuild(
         kvBackend: kvBackend,
         maxContextLength: 2048,
         environment: environment,
-        pagedResourceSearchRoots: pagedResourceSearchRoots)
+        pagedPreflightOverride: pagedPreflightOverride)
 }
 
 // MARK: - Tests
@@ -160,23 +160,19 @@ struct EngineV2KVBackendGateTests {
         // headDim 80 is outside the paged kernel's {64,128,256,512}.
         let build = try makeBuild(model: try tinyGPTOSS(headDim: 80), kvBackend: .paged)
         #expect(build.kvBackendKind == .contiguous)
-        #expect(build.kvBackendFallbackReason?.hasPrefix("ineligible:") == true)
+        #expect(build.kvBackendFallbackReason?.hasPrefix("kernel_preflight:") == true)
         await build.engine.shutdown()
     }
 
-    @Test("missing packaged resource falls back to contiguous before any request")
-    func missingResourceFallsBack() async throws {
-        let empty = FileManager.default.temporaryDirectory
-            .appendingPathComponent("paged-gate-missing-\(UUID().uuidString)", isDirectory: true)
-        try FileManager.default.createDirectory(at: empty, withIntermediateDirectories: true)
-        defer { try? FileManager.default.removeItem(at: empty) }
-
+    @Test("failed kernel preflight falls back to contiguous before slab construction")
+    func failedPreflightFallsBack() async throws {
+        struct PreflightFailure: Error {}
         let build = try makeBuild(
             model: try tinyGPTOSS(),
             kvBackend: .paged,
-            pagedResourceSearchRoots: [empty])
+            pagedPreflightOverride: { _ in throw PreflightFailure() })
         #expect(build.kvBackendKind == .contiguous)
-        #expect(build.kvBackendFallbackReason?.contains("runtime resource unavailable") == true)
+        #expect(build.kvBackendFallbackReason?.hasPrefix("kernel_preflight:") == true)
         await build.engine.shutdown()
     }
 }

--- a/provider-swift/Tests/ProviderCoreTests/EngineV2KVBackendGateTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/EngineV2KVBackendGateTests.swift
@@ -2,8 +2,8 @@
 //
 // KV-backend GATE tests over the REAL `EngineV2Factory.makeProductionBuild`
 // with tiny real-family models (JSON-decoded configs, random-init weights,
-// no downloads): family resolution for `auto` (GPT-OSS → paged, Gemma-4 →
-// contiguous), the fleet kill switch at the deepest layer, explicit
+// no downloads): production-safe `auto` (always contiguous), the fleet
+// kill switch at the deepest layer, explicit
 // selections, and the eligibility fallback (ineligible head dim → paged
 // selection degrades to contiguous, never a refusal).
 //
@@ -73,9 +73,11 @@ private let gateTestCapacity = 8 << 20  // 8 MiB pool — tiny but constructible
 private func makeBuild(
     model: any LanguageModel,
     kvBackend: EngineV2KVBackendSelection,
-    environment: [String: String] = [:]
+    environment: [String: String] = [:],
+    pagedResourceSearchRoots: [URL]? = nil
 ) throws -> EngineV2Factory.ProductionBuild {
-    try EngineV2Factory.makeProductionBuild(
+    _ = LiveInferenceFixtures.ensureMetallibColocated()
+    return try EngineV2Factory.makeProductionBuild(
         model: model,
         tokenizer: StubBridgeTokenizer(),
         kvBytesCapacity: gateTestCapacity,
@@ -83,23 +85,25 @@ private func makeBuild(
         maxConcurrentRequests: 2,
         kvBackend: kvBackend,
         maxContextLength: 2048,
-        environment: environment)
+        environment: environment,
+        pagedResourceSearchRoots: pagedResourceSearchRoots)
 }
 
 // MARK: - Tests
 
 @Suite("EngineV2 KV-backend gate (real tiny models)", .serialized)
 struct EngineV2KVBackendGateTests {
+    init() {
+        _ = LiveInferenceFixtures.ensureMetallibColocated()
+    }
 
-    @Test("auto resolves paged for GPT-OSS text slots")
-    func autoServesPagedForGPTOSS() async throws {
+    @Test("auto is contiguous for GPT-OSS and cannot drift with family defaults")
+    func autoServesContiguousForGPTOSS() async throws {
         let build = try makeBuild(model: try tinyGPTOSS(), kvBackend: .auto)
-        #expect(build.kvBackendKind == .paged)
+        #expect(build.kvBackendKind == .contiguous)
         #expect(build.kvBackendFallbackReason == nil)
-        // Pool truth surfaces through the engine's capacity snapshot.
         let snapshot = build.engine.capacity()
-        #expect(snapshot.kvBytesBackendCapacity > 0)
-        #expect(snapshot.kvBytesBackendCapacity <= gateTestCapacity)
+        #expect(snapshot.kvBytesBackendCapacity == gateTestCapacity)
         await build.engine.shutdown()
     }
 
@@ -119,6 +123,19 @@ struct EngineV2KVBackendGateTests {
         await build.engine.shutdown()
     }
 
+    @Test("explicit paged GPT-OSS preflights packaged resources and physical pool truth")
+    func explicitPagedGPTOSS() async throws {
+        try PagedAttentionKernel.validateRuntimeResources()
+        let build = try makeBuild(model: try tinyGPTOSS(), kvBackend: .paged)
+        #expect(build.kvBackendKind == .paged)
+        #expect(build.kvBackendFallbackReason == nil)
+        let snapshot = build.engine.capacity()
+        #expect(snapshot.kvBytesCapacity > 0)
+        #expect(snapshot.kvBytesCapacity == snapshot.kvBytesBackendCapacity)
+        #expect(snapshot.kvBytesCapacity < gateTestCapacity)
+        await build.engine.shutdown()
+    }
+
     @Test("explicit paged serves Gemma-4 TEXT (eligible shapes, opt-in)")
     func explicitPagedGemmaText() async throws {
         let build = try makeBuild(model: try tinyGemma4Text(), kvBackend: .paged)
@@ -127,11 +144,11 @@ struct EngineV2KVBackendGateTests {
         await build.engine.shutdown()
     }
 
-    @Test("fleet kill switch forces contiguous at the deepest layer")
+    @Test("fleet kill switch forces explicit paged to contiguous at the deepest layer")
     func killSwitchForcesContiguous() async throws {
         let build = try makeBuild(
             model: try tinyGPTOSS(),
-            kvBackend: .auto,
+            kvBackend: .paged,
             environment: [EngineV2KVBackendPolicy.killSwitchEnvKey: "0"])
         #expect(build.kvBackendKind == .contiguous)
         #expect(build.kvBackendFallbackReason == "kill_switch")
@@ -144,6 +161,22 @@ struct EngineV2KVBackendGateTests {
         let build = try makeBuild(model: try tinyGPTOSS(headDim: 80), kvBackend: .paged)
         #expect(build.kvBackendKind == .contiguous)
         #expect(build.kvBackendFallbackReason?.hasPrefix("ineligible:") == true)
+        await build.engine.shutdown()
+    }
+
+    @Test("missing packaged resource falls back to contiguous before any request")
+    func missingResourceFallsBack() async throws {
+        let empty = FileManager.default.temporaryDirectory
+            .appendingPathComponent("paged-gate-missing-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: empty, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: empty) }
+
+        let build = try makeBuild(
+            model: try tinyGPTOSS(),
+            kvBackend: .paged,
+            pagedResourceSearchRoots: [empty])
+        #expect(build.kvBackendKind == .contiguous)
+        #expect(build.kvBackendFallbackReason?.contains("runtime resource unavailable") == true)
         await build.engine.shutdown()
     }
 }

--- a/provider-swift/Tests/ProviderCoreTests/EngineV2KVBackendPolicyTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/EngineV2KVBackendPolicyTests.swift
@@ -78,8 +78,8 @@ struct EngineV2KVBackendPolicyTests {
                 EngineV2KVBackendPolicy.killSwitchDisabled(environment: [key: negative]),
                 "\(negative) must kill")
         }
-        // Affirmatives and typos leave the default ON — a typo must not
-        // flip the fleet.
+        // Affirmatives and typos leave explicit paged eligibility enabled;
+        // auto still resolves contiguous independently.
         for benign in ["1", "true", "yes", "on", "junk", ""] {
             #expect(
                 !EngineV2KVBackendPolicy.killSwitchDisabled(environment: [key: benign]),
@@ -131,25 +131,30 @@ struct EngineV2KVBackendPolicyTests {
 
     // MARK: post-build serveable-KV guard (PR #531 Codex P1)
 
-    @Test("post-build guard: paged holds the floor against the pool, contiguous against headroom")
+    @Test("post-build guard: paged requires pool and whole-machine headroom")
     func postBuildServeableMatrix() {
         let gib: UInt64 = 1 << 30
-        // Paged: the committed pool answers the guard — the live headroom
-        // measurement must not even be consulted (the slab consumed it by
-        // design). measured=0 while the pool clears the floor.
+        // Paged requires BOTH a useful committed pool and safe residual
+        // whole-machine headroom.
         #expect(
             KVHeadroomProbe.postBuildServeable(
-                kvBackendKind: .paged, pagedPoolBytes: 8 * gib, measuredHeadroomBytes: 0))
-        // A paged pool under the floor is genuinely unserveable.
+                kvBackendKind: .paged,
+                pagedPoolBytes: 8 * gib,
+                measuredHeadroomBytes: 2 * gib))
+        #expect(
+            !KVHeadroomProbe.postBuildServeable(
+                kvBackendKind: .paged,
+                pagedPoolBytes: 8 * gib,
+                measuredHeadroomBytes: 0))
         #expect(
             !KVHeadroomProbe.postBuildServeable(
                 kvBackendKind: .paged, pagedPoolBytes: gib / 2, measuredHeadroomBytes: 100 * gib))
-        // Exactly at the floor serves (>= comparator, mirrors loadIsServeable).
+        // Exactly at both floors serves (>= comparator).
         #expect(
             KVHeadroomProbe.postBuildServeable(
                 kvBackendKind: .paged,
                 pagedPoolBytes: UnifiedMemoryCap.minimumLoadKVBytes,
-                measuredHeadroomBytes: 0))
+                measuredHeadroomBytes: UnifiedMemoryCap.minimumLoadKVBytes))
         // Contiguous: classic measured-headroom semantics, pool ignored.
         #expect(
             KVHeadroomProbe.postBuildServeable(

--- a/provider-swift/Tests/ProviderCoreTests/EngineV2PagedParityLiveTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/EngineV2PagedParityLiveTests.swift
@@ -6,10 +6,10 @@
 // ProviderLoop/slot-factory string threading is covered by the gate and
 // policy suites). The repo's batching lesson (ragged-NaN, resource-count
 // leak): solo-vs-batched output invariance is THE oracle that catches
-// batch-composition corruption — so it gates the paged default before any
-// fleet exposure.
+// batch-composition corruption — so it gates explicit paged canaries before
+// any future default reconsideration.
 //
-//   1. `.auto` resolves PAGED for GPT-OSS through the real family gate
+//   1. explicit `.paged` resolves PAGED for GPT-OSS
 //      (build reports kvBackendKind == .paged; pool truth on the idle
 //      capacity snapshot);
 //   2. greedy SOLO baselines (3 mixed-length prompts) == the SAME requests
@@ -27,9 +27,9 @@
 // and the engine repo's BenchCBv2RealModel --engines v2-paged runs).
 //
 // Gated like every multi-GB suite: DARKBLOOM_LIVE_MLX_TESTS=1 + the
-// checkpoint in the local HF cache; skips cleanly otherwise. The pool is
-// sized explicitly (8 GiB) so the eager slab commit stays trivially inside
-// the test memory budget regardless of box state.
+// checkpoint in the local HF cache; skips cleanly otherwise. The logical
+// grant is 8 GiB; the physical pool is independently capped by production
+// policy.
 
 import Foundation
 import MLX
@@ -87,8 +87,7 @@ struct EngineV2PagedParityLiveTests {
     }
 
     /// Production engine + bridge over the loaded weights with an explicit
-    /// backend selection. 8 GiB pool: the eager slab commit stays trivially
-    /// inside the test budget, and admission comfortably fits the workload.
+    /// backend selection and an 8 GiB logical grant.
     private func makeBridge(
         _ live: LiveModel, kvBackend: EngineV2KVBackendSelection
     ) throws -> (bridge: EngineV2Bridge, kind: EngineV2KVBackendKind) {
@@ -145,17 +144,17 @@ struct EngineV2PagedParityLiveTests {
         ),
     ]
 
-    @Test("gpt-oss .auto serves PAGED; solo == concurrent, token-exact")
+    @Test("explicit paged GPT-OSS: solo == concurrent, token-exact")
     func pagedBatchCompositionInvariance() async throws {
         guard LiveInferenceFixtures.liveTestsEnabled else { return }
         let live = try await loadGptOss()
-        let (bridge, kind) = try makeBridge(live, kvBackend: .auto)
+        let (bridge, kind) = try makeBridge(live, kvBackend: .paged)
         defer { Task { await bridge.shutdown(); MLX.Memory.clearCache() } }
 
-        // 1. The real family gate served PAGED (the default-ON path), and
+        // 1. The explicit canary gate served PAGED, and
         // pool truth rides the IDLE capacity snapshot (heartbeats fire
         // before the first request).
-        #expect(kind == .paged, ".auto must resolve paged for gpt-oss")
+        #expect(kind == .paged, "explicit paged must resolve for eligible gpt-oss")
         #expect(await bridge.kvBackendKind == .paged)
         let snapshot = await bridge.engine.capacity()
         #expect(snapshot.kvBytesBackendCapacity > 0)
@@ -247,16 +246,15 @@ struct EngineV2PagedParityLiveTests {
     /// The LOOP-PATH drill this suite originally lost (PR #531 Codex P1):
     /// load gpt-oss through the REAL `ProviderLoop.ensureModelLoaded` —
     /// pre-load estimate gate, weights, re-slice, engine build with the
-    /// eager slab commit, and BOTH measured-headroom guards — and require
-    /// the slot to come up PAGED and serve. Before the backend-aware
-    /// post-bridge guard, this failed deterministically: the slab consumed
-    /// the entire KV budget and the 1 GiB floor unloaded every paged slot.
+    /// independently-capped eager slab commit, and BOTH measured-headroom
+    /// guards — and require the slot to come up PAGED and serve. Startup
+    /// preload and cold first-request loads share this exact construction
+    /// path.
     ///
-    /// The operator reserve (40 GiB) sizes the slab to ~43 GiB on a 128 GB
-    /// box so the drill is safe under concurrent dev load, while leaving
-    /// the pre-load free-memory gate (`availableBytes − reserve ≥ weights
-    /// estimate`) ~22 GiB of margin on a typically-loaded box — the test
-    /// skips (not fails) if the box is too busy, like every live suite.
+    /// The operator reserve keeps the live drill safe under concurrent
+    /// developer load. Physical capacity no longer scales with the remaining
+    /// logical grant; production policy caps it from useful context demand,
+    /// live headroom, machine size, and Metal buffer limits.
     @Test("loop path: paged gpt-oss survives the load guards and serves")
     func pagedSlotSurvivesLoadGuardsThroughProviderLoop() async throws {
         guard LiveInferenceFixtures.liveTestsEnabled else { return }
@@ -287,7 +285,10 @@ struct EngineV2PagedParityLiveTests {
             config: ProviderConfig(
                 provider: ProviderSettings(
                     name: "paged-loop-live", memoryReserveGB: reserveGiB),
-                backend: BackendSettings(idleTimeoutMins: 0, maxModelSlots: 1),
+                backend: BackendSettings(
+                    idleTimeoutMins: 0,
+                    maxModelSlots: 1,
+                    engineV2KVBackend: "paged"),
                 coordinator: CoordinatorSettings(heartbeatIntervalSecs: 60)
             )
         )

--- a/provider-swift/Tests/ProviderCoreTests/EngineV2ProductionWiringTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/EngineV2ProductionWiringTests.swift
@@ -48,10 +48,14 @@ private final class WiringScriptedEngine: CBv2Engine, @unchecked Sendable {
     private var _manualContinuation: AsyncStream<CBv2Event>.Continuation?
     private var _kvBytesCapacity: Int
     private var _capacityUpdates: [Int] = []
+    /// Construction-fixed physical backend capacity (paged contract: the
+    /// preallocated pool never resizes; 0 = unknown/contiguous stub).
+    private let kvBytesBackendCapacity: Int
 
-    init(script: Script, kvBytesCapacity: Int = 0) {
+    init(script: Script, kvBytesCapacity: Int = 0, kvBytesBackendCapacity: Int = 0) {
         self.script = script
         self._kvBytesCapacity = kvBytesCapacity
+        self.kvBytesBackendCapacity = kvBytesBackendCapacity
     }
 
     var submitted: [CBv2Request] { lock.withLock { _submitted } }
@@ -92,7 +96,8 @@ private final class WiringScriptedEngine: CBv2Engine, @unchecked Sendable {
             CBv2CapacitySnapshot(
                 activeRequests: max(0, _submitted.count - _cancelled.count),
                 waitingRequests: 0,
-                kvBytesInUse: 0, kvBytesCapacity: _kvBytesCapacity, activeTokens: 0)
+                kvBytesInUse: 0, kvBytesCapacity: _kvBytesCapacity,
+                kvBytesBackendCapacity: kvBytesBackendCapacity, activeTokens: 0)
         }
     }
 
@@ -666,6 +671,121 @@ struct EngineV2ReslicingWiringTests {
         #expect(grownA == Int(fullBudget))
         #expect(grownA > shrunkA)
         #expect(engineA.capacityUpdates.last == grownA)
+    }
+
+    @Test("mixed paged+contiguous: re-slice moves ledgers only; the paged pool never resizes and bounds every regrow")
+    func mixedPagedContiguousResliceIsLedgerOnly() async throws {
+        // Slot A is PAGED with a demand-capped physical pool SMALLER than
+        // its logical grant (the production shape after the v0.7.6 fix:
+        // physical capacity is designed from demand, never the full
+        // logical grant). Slot B is contiguous. The ProviderLoop-driven
+        // load/unload re-slice must:
+        //   * shrink/grow ONLY admission ledgers,
+        //   * keep A's physical pool byte-for-byte constant, and
+        //   * clamp A's regrow to pool truth — a ledger-only re-slice can
+        //     never "restore" physical bytes the pool does not hold.
+        let loop = try makeWiringLoop()
+        let runtime = EngineV2Runtime()
+        let recorder = GrantRecorder()
+        let enginesBox = EngineBox()
+        await loop.setEngineV2RuntimeForTesting(runtime)
+        await loop.setEngineV2SlotHooksForTesting(
+            ProviderLoop.EngineV2SlotHooks(
+                eosTokenIds: [2],
+                physicalMemoryBytes: wiringPhysicalBytes,
+                kvBackendKindByModel: ["gemma-4-26b-qat-4bit": .paged],
+                makeEngine: { modelId, grant in
+                    recorder.record(grant)
+                    let engine = WiringScriptedEngine(
+                        script: .manual,
+                        kvBytesCapacity: grant,
+                        // Paged slot: pool capped below the logical grant.
+                        kvBytesBackendCapacity: modelId == "gemma-4-26b-qat-4bit"
+                            ? grant * 3 / 5 : 0)
+                    enginesBox.append(engine)
+                    return engine
+                }))
+
+        let sizingA = makeSizing(weightsGiB: 15, kvRate: 20_480, maxContext: 262_144)
+        let bridgeA = try await loop.resliceAndBuildEngineV2SlotForTesting(
+            modelId: "gemma-4-26b-qat-4bit",
+            modelType: "gemma4",
+            container: makeStubContainer(),
+            tokenizer: TokenizerHandle(WiringStubTokenizer()),
+            sizing: sizingA)
+        await loop.installModelSlotForTesting(
+            modelId: "gemma-4-26b-qat-4bit",
+            container: makeStubContainer(),
+            tokenizer: TokenizerHandle(WiringStubTokenizer()),
+            engineV2: bridgeA,
+            sizing: sizingA,
+            modelType: "gemma4")
+        let engineA = enginesBox.all[0]
+        let grantA0 = recorder.granted[0]
+        let poolA = UInt64(grantA0 * 3 / 5)
+        #expect(await bridgeA.kvBackendKind == .paged)
+        #expect(await bridgeA.kvBackendPoolBytes() == poolA)
+        // Fleet accounting reads pool truth for the paged slot, not the
+        // (larger) logical ledger.
+        #expect(await bridgeA.slotKVBytesClaim() == Int(poolA))
+
+        // Load contiguous B: A's admission ledger shrinks to its fair
+        // share; the physical pool is untouched.
+        let sizingB = makeSizing(weightsGiB: 12, kvRate: 24_576, maxContext: 131_072)
+        let bridgeB = try await loop.resliceAndBuildEngineV2SlotForTesting(
+            modelId: "gpt-oss-20b",
+            modelType: "gpt_oss",
+            container: makeStubContainer(),
+            tokenizer: TokenizerHandle(WiringStubTokenizer()),
+            sizing: sizingB)
+        await loop.installModelSlotForTesting(
+            modelId: "gpt-oss-20b",
+            container: makeStubContainer(),
+            tokenizer: TokenizerHandle(WiringStubTokenizer()),
+            engineV2: bridgeB,
+            sizing: sizingB,
+            modelType: "gpt_oss")
+        #expect(await bridgeB.kvBackendKind == .contiguous)
+
+        let fleetBudget2 = UnifiedMemoryCap.kvBudgetBytes(
+            physicalBytes: wiringPhysicalBytes,
+            residentWeightBytes: UInt64(sizingA.weightsBytes + sizingB.weightsBytes),
+            configReserveBytes: wiringReserveBytes)
+        let targets = EngineV2KVSizing.resliceGrants(
+            existing: [
+                .init(
+                    modelId: "gemma-4-26b-qat-4bit",
+                    fp16KVBytesPerToken: sizingA.fp16KVBytesPerToken,
+                    maxContextLength: sizingA.maxContextLength)
+            ],
+            newcomer: .init(
+                modelId: "gpt-oss-20b",
+                fp16KVBytesPerToken: sizingB.fp16KVBytesPerToken,
+                maxContextLength: sizingB.maxContextLength),
+            fleetKVBudgetBytes: fleetBudget2)
+        let targetA = try #require(targets["gemma-4-26b-qat-4bit"])
+        // The two-model fair share sits below the pool here, so the shrink
+        // reaches the engine unclamped — and the pool still never moved.
+        #expect(UInt64(targetA) < poolA)
+        #expect(engineA.capacityUpdates.last == targetA)
+        #expect(await bridgeA.engineKVBytesCapacity() == targetA)
+        #expect(await bridgeA.kvBackendPoolBytes() == poolA)
+        #expect(await bridgeB.engineKVBytesCapacity() == targets["gpt-oss-20b"])
+
+        // Unload B: the regrow's single-survivor target is the FULL fleet
+        // budget (> pool), but the paged bridge clamps the restore to pool
+        // truth — admission can never advertise physical bytes the slabs
+        // do not hold, and the pool itself is byte-for-byte unchanged.
+        await loop.unloadModel("gpt-oss-20b")
+        let regrowTarget = UnifiedMemoryCap.kvBudgetBytes(
+            physicalBytes: wiringPhysicalBytes,
+            residentWeightBytes: UInt64(sizingA.weightsBytes),
+            configReserveBytes: wiringReserveBytes)
+        #expect(regrowTarget > poolA)
+        #expect(engineA.capacityUpdates.last == Int(poolA))
+        #expect(await bridgeA.engineKVBytesCapacity() == Int(poolA))
+        #expect(await bridgeA.kvBackendPoolBytes() == poolA)
+        #expect(await bridgeA.slotKVBytesClaim() == Int(poolA))
     }
 
     @Test("restore-on-throw: B's construction failure restores A's grant EXACTLY")

--- a/provider-swift/Tests/ProviderCoreTests/LiveInferenceFixtures.swift
+++ b/provider-swift/Tests/ProviderCoreTests/LiveInferenceFixtures.swift
@@ -226,7 +226,8 @@ enum LiveInferenceFixtures {
         modelType: String? = nil,
         maxConcurrentRequests: Int = 4,
         memoryBudgetBytes: Int? = nil,
-        defaultMaxTokens: Int = 256
+        defaultMaxTokens: Int = 256,
+        kvBackendConfig: String = "auto"
     ) async throws -> LoadedBridge {
         guard ensureMetallibColocated() != nil else {
             throw LiveFixtureSkip.missingMetallib
@@ -275,6 +276,7 @@ enum LiveInferenceFixtures {
             maxConcurrentRequests: maxConcurrentRequests,
             kvBudget: nil,
             kvQuantConfigured: false,
+            kvBackendConfig: kvBackendConfig,
             // Hermetic tests: master-kill EVERY prefix-cache tier. An empty
             // environment is no longer dormant — the SSD tier (v0.7.5) is
             // default-on and would write real files under the user's

--- a/provider-swift/Tests/ProviderCoreTests/PagedKVPhysicalCapacityPolicyTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/PagedKVPhysicalCapacityPolicyTests.swift
@@ -1,0 +1,102 @@
+// Copyright © 2026 Eigen Labs.
+
+import Testing
+
+@testable import ProviderCore
+
+@Suite("PagedKV physical capacity policy")
+struct PagedKVPhysicalCapacityPolicyTests {
+    private let gib = 1 << 30
+
+    private func decision(
+        physicalGiB: Int,
+        liveGiB: Int,
+        logicalGiB: Int = 200,
+        rate: Int = 48 * 1024,
+        context: Int = 131_072,
+        concurrency: Int = 4,
+        maxBufferGiB: Int = 32
+    ) -> PagedKVPhysicalCapacityPolicy.Decision {
+        PagedKVPhysicalCapacityPolicy.decide(
+            logicalGrantBytes: logicalGiB * gib,
+            fp16BytesPerToken: rate,
+            maxContextLength: context,
+            maxConcurrentRequests: concurrency,
+            inputs: .init(
+                physicalMemoryBytes: UInt64(physicalGiB * gib),
+                liveKVHeadroomBytes: UInt64(liveGiB * gib),
+                maxBufferLength: maxBufferGiB * gib))
+    }
+
+    @Test("32/64/128/256 GiB hosts stay useful without scaling to the logical grant")
+    func machineSizingMatrix() {
+        let cases = [
+            (physical: 32, live: 16, expectedGiB: 2),
+            (physical: 64, live: 32, expectedGiB: 4),
+            (physical: 128, live: 64, expectedGiB: 6),
+            (physical: 256, live: 128, expectedGiB: 6),
+        ]
+        for item in cases {
+            guard case .paged(let plan) = decision(
+                physicalGiB: item.physical,
+                liveGiB: item.live)
+            else {
+                Issue.record("\(item.physical) GiB host unexpectedly fell back")
+                continue
+            }
+            #expect(plan.capacityBytes == item.expectedGiB * gib)
+            #expect(plan.capacityBytes < 200 * gib)
+            #expect(plan.capacityBytes <= PagedKVPhysicalCapacityPolicy.absoluteHardCapBytes)
+        }
+    }
+
+    @Test("live memory and maxBufferLength can force a pre-allocation contiguous fallback")
+    func resourceLimitsFailClosed() {
+        #expect(
+            decision(physicalGiB: 128, liveGiB: 3)
+                == .contiguous(
+                    reason: "physical_capacity: safe pool 805306368 B is below "
+                        + "the 1073741824 B serviceability floor"))
+        #expect(
+            decision(
+                physicalGiB: 128,
+                liveGiB: 64,
+                maxBufferGiB: 0)
+                == .contiguous(
+                    reason: "physical_capacity: Metal maxBufferLength unavailable"))
+    }
+
+    @Test("mixed-model load order remains bounded by live and machine caps")
+    func mixedModelLoadOrders() {
+        let rates = [48 * 1024, 32 * 1024]
+
+        func loadOrder(_ order: [Int]) -> [Int] {
+            var live = 40 * gib
+            var pools: [Int] = []
+            for index in order {
+                let result = PagedKVPhysicalCapacityPolicy.decide(
+                    logicalGrantBytes: 40 * gib,
+                    fp16BytesPerToken: rates[index],
+                    maxContextLength: 131_072,
+                    maxConcurrentRequests: 4,
+                    inputs: .init(
+                        physicalMemoryBytes: UInt64(64 * gib),
+                        liveKVHeadroomBytes: UInt64(live),
+                        maxBufferLength: 32 * gib))
+                guard case .paged(let plan) = result else {
+                    Issue.record("mixed-model load \(index) unexpectedly fell back")
+                    continue
+                }
+                pools.append(plan.capacityBytes)
+                live -= plan.capacityBytes
+            }
+            return pools
+        }
+
+        let gptThenGemma = loadOrder([0, 1])
+        let gemmaThenGPT = loadOrder([1, 0])
+        #expect(gptThenGemma.reduce(0, +) == 8 * gib)
+        #expect(gemmaThenGPT.reduce(0, +) == 8 * gib)
+        #expect((gptThenGemma + gemmaThenGPT).allSatisfy { $0 <= 4 * gib })
+    }
+}

--- a/provider-swift/Tests/ProviderCoreTests/PagedKernelPreflightTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/PagedKernelPreflightTests.swift
@@ -1,7 +1,11 @@
 // Copyright © 2026 Eigen Labs.
 
+import Foundation
 import MLXLMCommon
 import Testing
+#if canImport(Darwin)
+import Darwin
+#endif
 
 @testable import ProviderCore
 
@@ -49,5 +53,94 @@ struct PagedKernelPreflightTests {
                 executableURL: nil,
                 childRunner: { _ in throw ChildFailure() })
         }
+    }
+
+    @Test("large child diagnostics cannot block the preflight")
+    func noisyChildCannotDeadlock() throws {
+        let child = try makeChild(
+            """
+            #!/bin/bash
+            i=0
+            while [ "$i" -lt 20000 ]; do
+                printf 'paged-kernel-compiler-diagnostic-0123456789\\n' >&2
+                i=$((i + 1))
+            done
+            exit 9
+            """)
+        defer { try? FileManager.default.removeItem(at: child.directory) }
+
+        do {
+            try PagedKernelPreflight.run(
+                layerKinds: [layerKind()],
+                executableURL: child.executable,
+                childTimeout: 5)
+            Issue.record("noisy failing child unexpectedly passed")
+        } catch PagedKernelPreflightError.childFailed(let status) {
+            #expect(status == 9)
+        } catch {
+            Issue.record("unexpected preflight error: \(error)")
+        }
+    }
+
+    @Test("hung child is terminated at the preflight deadline")
+    func hungChildTimesOut() throws {
+        let pidFile = FileManager.default.temporaryDirectory
+            .appendingPathComponent("paged-preflight-\(UUID().uuidString).pid")
+        defer { try? FileManager.default.removeItem(at: pidFile) }
+        let child = try makeChild(
+            """
+            #!/bin/bash
+            trap '' TERM
+            printf '%s\\n' "$$" > "\(pidFile.path)"
+            while :; do :; done
+            """)
+        defer { try? FileManager.default.removeItem(at: child.directory) }
+        let started = ProcessInfo.processInfo.systemUptime
+
+        do {
+            try PagedKernelPreflight.run(
+                layerKinds: [layerKind()],
+                executableURL: child.executable,
+                childTimeout: 0.5)
+            Issue.record("hung child unexpectedly passed")
+        } catch PagedKernelPreflightError.childTimedOut(let seconds) {
+            #expect(seconds == 0.5)
+            #expect(ProcessInfo.processInfo.systemUptime - started < 4)
+            #if canImport(Darwin)
+            let pidText = try String(contentsOf: pidFile, encoding: .utf8)
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            let pid = try #require(Int32(pidText))
+            #expect(Darwin.kill(pid, 0) == -1)
+            #endif
+        } catch {
+            Issue.record("unexpected preflight error: \(error)")
+        }
+    }
+
+    private func layerKind() -> CBv2LayerKind {
+        CBv2LayerKind(
+            attention: .full,
+            hasSinks: true,
+            headDim: 64,
+            kvHeads: 8,
+            queryHeads: 64)
+    }
+
+    private func makeChild(
+        _ script: String
+    ) throws -> (directory: URL, executable: URL) {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(
+                "paged-preflight-\(UUID().uuidString)",
+                isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true)
+        let executable = directory.appendingPathComponent("darkbloom")
+        try Data(script.utf8).write(to: executable)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755],
+            ofItemAtPath: executable.path)
+        return (directory, executable)
     }
 }

--- a/provider-swift/Tests/ProviderCoreTests/PagedKernelPreflightTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/PagedKernelPreflightTests.swift
@@ -1,0 +1,53 @@
+// Copyright © 2026 Eigen Labs.
+
+import MLXLMCommon
+import Testing
+
+@testable import ProviderCore
+
+@Suite("Paged kernel process preflight", .serialized)
+struct PagedKernelPreflightTests {
+    init() {
+        _ = LiveInferenceFixtures.ensureMetallibColocated()
+    }
+
+    @Test("child probe sees every model-specific variant before parent pre-JIT")
+    func modelSpecificVariants() throws {
+        let owner = CBv2LayerKind(
+            attention: .full,
+            hasSinks: true,
+            headDim: 64,
+            kvHeads: 8,
+            queryHeads: 64)
+        var borrower = owner
+        borrower.sharesKVWithLayer = 0
+        var observed: [PagedAttentionKernelSmokeShape] = []
+
+        try PagedKernelPreflight.run(
+            layerKinds: [owner, borrower],
+            executableURL: nil,
+            childRunner: { observed = $0 })
+
+        #expect(observed.count == 2)
+        #expect(observed.contains { $0.hasWrite })
+        #expect(observed.contains { !$0.hasWrite })
+        #expect(observed.allSatisfy { $0.hasSinks })
+    }
+
+    @Test("child crash/failure is catchable and blocks parent construction")
+    func childFailureIsCatchable() {
+        struct ChildFailure: Error {}
+        let kind = CBv2LayerKind(
+            attention: .full,
+            hasSinks: true,
+            headDim: 64,
+            kvHeads: 8,
+            queryHeads: 64)
+        #expect(throws: ChildFailure.self) {
+            try PagedKernelPreflight.run(
+                layerKinds: [kind],
+                executableURL: nil,
+                childRunner: { _ in throw ChildFailure() })
+        }
+    }
+}

--- a/provider-swift/Tests/ProviderCoreTests/SelfUpdaterTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/SelfUpdaterTests.swift
@@ -252,6 +252,14 @@ struct SelfUpdaterTests {
         try Data("app darkbloom".utf8).write(to: appMacOS.appendingPathComponent("darkbloom"))
         try Data("app enclave".utf8).write(to: appMacOS.appendingPathComponent("darkbloom-enclave"))
         try Data("app metallib".utf8).write(to: appMacOS.appendingPathComponent("mlx.metallib"))
+        let resourceBundle = stage.appendingPathComponent(
+            "Darkbloom.app/Contents/Resources/mlx-swift-lm_MLXLMCommon.bundle",
+            isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: resourceBundle,
+            withIntermediateDirectories: true)
+        try Data("paged kernel source".utf8).write(
+            to: resourceBundle.appendingPathComponent("pagedattention.metal"))
 
         // Also create flat copies in bin/ (as the real tarball does).
         try Data("flat darkbloom".utf8).write(to: binFlat.appendingPathComponent("darkbloom"))
@@ -285,6 +293,12 @@ struct SelfUpdaterTests {
         // .app bundle should be installed at the root.
         let installedAppBin = install.appendingPathComponent("Darkbloom.app/Contents/MacOS")
         #expect((try String(contentsOf: installedAppBin.appendingPathComponent("darkbloom"), encoding: .utf8)) == "app darkbloom")
+        let installedPagedResource = install.appendingPathComponent(
+            "Darkbloom.app/Contents/Resources/mlx-swift-lm_MLXLMCommon.bundle/"
+                + "pagedattention.metal")
+        #expect(
+            (try String(contentsOf: installedPagedResource, encoding: .utf8))
+                == "paged kernel source")
 
         // bin/ should contain symlinks to the .app bundle, not flat copies.
         let installedBin = install.appendingPathComponent("bin")

--- a/provider-swift/Tests/ProviderCoreTests/SelfUpdaterTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/SelfUpdaterTests.swift
@@ -366,6 +366,157 @@ struct SelfUpdaterTests {
         return (tarball, release, install)
     }
 
+    private func debugBuildProduct(_ name: String) throws -> URL {
+        var packageRoot = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+        while !FileManager.default.fileExists(
+            atPath: packageRoot.appendingPathComponent("Package.swift").path)
+        {
+            let parent = packageRoot.deletingLastPathComponent()
+            guard parent.path != packageRoot.path else {
+                throw CocoaError(.fileNoSuchFile)
+            }
+            packageRoot = parent
+        }
+        let product = packageRoot.appendingPathComponent(".build/debug/\(name)")
+        guard FileManager.default.fileExists(atPath: product.path) else {
+            throw CocoaError(.fileNoSuchFile)
+        }
+        return product
+    }
+
+    private func makeSignedRuntimeFixture(
+        root: URL,
+        includeResource: Bool
+    ) throws -> (URL, ReleaseInfo, URL) {
+        let fm = FileManager.default
+        let stage = root.appendingPathComponent("signed-src", isDirectory: true)
+        let app = stage.appendingPathComponent("Darkbloom.app", isDirectory: true)
+        let appMacOS = app.appendingPathComponent("Contents/MacOS", isDirectory: true)
+        let resources = app.appendingPathComponent("Contents/Resources", isDirectory: true)
+        let bin = stage.appendingPathComponent("bin", isDirectory: true)
+        let install = root.appendingPathComponent("install", isDirectory: true)
+        try fm.createDirectory(at: appMacOS, withIntermediateDirectories: true)
+        try fm.createDirectory(at: resources, withIntermediateDirectories: true)
+        try fm.createDirectory(at: bin, withIntermediateDirectories: true)
+        try fm.createDirectory(at: install, withIntermediateDirectories: true)
+
+        let darkbloom = try debugBuildProduct("darkbloom")
+        let metallib = try debugBuildProduct("mlx.metallib")
+        try fm.copyItem(
+            at: darkbloom,
+            to: appMacOS.appendingPathComponent("darkbloom"))
+        try fm.copyItem(
+            at: darkbloom,
+            to: appMacOS.appendingPathComponent("darkbloom-enclave"))
+        try fm.copyItem(
+            at: metallib,
+            to: appMacOS.appendingPathComponent("mlx.metallib"))
+        let info: [String: Any] = [
+            "CFBundleIdentifier": "io.darkbloom.selfupdater-test",
+            "CFBundleExecutable": "darkbloom",
+            "CFBundlePackageType": "APPL",
+            "CFBundleVersion": "1",
+        ]
+        try PropertyListSerialization.data(
+            fromPropertyList: info,
+            format: .xml,
+            options: 0)
+            .write(to: app.appendingPathComponent("Contents/Info.plist"))
+        let capability = resources.appendingPathComponent(
+            "darkbloom-runtime-capabilities",
+            isDirectory: true)
+        try fm.createDirectory(at: capability, withIntermediateDirectories: true)
+        try Data("1\n".utf8).write(
+            to: capability.appendingPathComponent("paged-kernel-v1"))
+        if includeResource {
+            let builtBundle = try debugBuildProduct(
+                PackagedRuntimeSmoke.mlxLMCommonBundleName)
+            try fm.copyItem(
+                at: builtBundle,
+                to: resources.appendingPathComponent(
+                    PackagedRuntimeSmoke.mlxLMCommonBundleName,
+                    isDirectory: true))
+        }
+
+        try runTestProcess(
+            "/usr/bin/codesign",
+            ["--force", "--sign", "-", appMacOS.appendingPathComponent("mlx.metallib").path])
+        try runTestProcess(
+            "/usr/bin/codesign",
+            ["--force", "--sign", "-", appMacOS.appendingPathComponent("darkbloom-enclave").path])
+        try runTestProcess(
+            "/usr/bin/codesign",
+            ["--force", "--sign", "-", appMacOS.appendingPathComponent("darkbloom").path])
+        try runTestProcess(
+            "/usr/bin/codesign",
+            ["--force", "--sign", "-", app.path])
+        try runTestProcess(
+            "/usr/bin/codesign",
+            ["--verify", "--deep", "--strict", app.path])
+
+        try fm.copyItem(
+            at: appMacOS.appendingPathComponent("darkbloom"),
+            to: bin.appendingPathComponent("darkbloom"))
+        try fm.copyItem(
+            at: appMacOS.appendingPathComponent("darkbloom-enclave"),
+            to: bin.appendingPathComponent("darkbloom-enclave"))
+        try fm.copyItem(
+            at: appMacOS.appendingPathComponent("mlx.metallib"),
+            to: bin.appendingPathComponent("mlx.metallib"))
+        let tarball = root.appendingPathComponent(
+            includeResource ? "signed-valid.tar.gz" : "signed-missing.tar.gz")
+        try runTarCreate(sourceDir: stage, tarball: tarball)
+        let release = ReleaseInfo(
+            version: "test",
+            platform: "macos-arm64",
+            url: "file://unused",
+            bundleHash: sha256Hex(try Data(contentsOf: tarball)),
+            binaryHash: sha256Hex(
+                try Data(contentsOf: bin.appendingPathComponent("darkbloom"))),
+            metallibHash: sha256Hex(
+                try Data(contentsOf: bin.appendingPathComponent("mlx.metallib"))))
+        return (tarball, release, install)
+    }
+
+    @Test("signed extracted app runs real packaged verification before staging succeeds")
+    func signedAppRunsRealVerification() throws {
+        _ = LiveInferenceFixtures.ensureMetallibColocated()
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(
+                "self-updater-signed-test-\(UUID().uuidString)",
+                isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let updater = SelfUpdater(coordinatorBaseURL: "https://api.example.test")
+
+        let (validTar, validRelease, install) = try makeSignedRuntimeFixture(
+            root: root.appendingPathComponent("valid", isDirectory: true),
+            includeResource: true)
+        guard case .success(let staged) = updater.stageSignedBundleForTesting(
+            from: validTar,
+            release: validRelease,
+            installDir: install)
+        else {
+            Issue.record("real signed/runtime-verified staging failed")
+            return
+        }
+        staged.discard()
+
+        let (missingTar, missingRelease, missingInstall) = try makeSignedRuntimeFixture(
+            root: root.appendingPathComponent("missing", isDirectory: true),
+            includeResource: false)
+        guard case .failure = updater.stageSignedBundleForTesting(
+            from: missingTar,
+            release: missingRelease,
+            installDir: missingInstall)
+        else {
+            Issue.record("paged-capable app without its resource unexpectedly staged")
+            return
+        }
+        #expect(
+            !FileManager.default.fileExists(
+                atPath: missingInstall.appendingPathComponent("Darkbloom.app").path))
+    }
+
     @Test("staging extracts and verifies WITHOUT touching the live layout")
     func stagingDoesNotTouchLiveLayout() throws {
         let root = FileManager.default.temporaryDirectory
@@ -516,6 +667,28 @@ private func runCodesign(_ arguments: [String]) throws {
     process.waitUntilExit()
     guard process.terminationStatus == 0 else {
         throw CocoaError(.fileWriteUnknown)
+    }
+}
+
+private func runTestProcess(
+    _ executable: String,
+    _ arguments: [String]
+) throws {
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: executable)
+    process.arguments = arguments
+    let output = Pipe()
+    process.standardOutput = output
+    process.standardError = output
+    try process.run()
+    process.waitUntilExit()
+    guard process.terminationStatus == 0 else {
+        let message = String(
+            data: output.fileHandleForReading.readDataToEndOfFile(),
+            encoding: .utf8) ?? ""
+        throw CocoaError(
+            .fileWriteUnknown,
+            userInfo: [NSLocalizedDescriptionKey: message])
     }
 }
 

--- a/provider-swift/Tests/ProviderCoreTests/StartupSelfTestDecodeLiveTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/StartupSelfTestDecodeLiveTests.swift
@@ -46,7 +46,8 @@ struct StartupSelfTestDecodeLiveTests {
         try await LiveInferenceFixtures.loadBridge(
             modelID: Self.modelID,
             maxConcurrentRequests: 4,
-            memoryBudgetBytes: 24 * 1024 * 1024 * 1024
+            memoryBudgetBytes: 24 * 1024 * 1024 * 1024,
+            kvBackendConfig: "paged"
         )
     }
 
@@ -105,6 +106,7 @@ struct StartupSelfTestDecodeLiveTests {
             return
         }
         let bridge = loaded.bridge
+        #expect(await bridge.kvBackendKind == .paged)
         defer {
             Task {
                 await bridge.shutdown()

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # NOTE: This file is also embedded in the coordinator binary via go:embed.
-# The copy at coordinator/internal/api/install.sh must be kept in sync.
+# The copy at coordinator/api/install.sh must be kept in sync.
 set -euo pipefail
 
 # Darkbloom Provider Installer (Swift CLI release v0.5.0+)
@@ -24,6 +24,227 @@ set -euo pipefail
 COORD_URL="${COORD_URL:-https://api.darkbloom.dev}"
 INSTALL_DIR="$HOME/.darkbloom"
 BIN_DIR="$INSTALL_DIR/bin"
+EXPECTED_TEAM_ID="SLDQ2GJ6TL"
+INSTALL_TEST_MODE=0
+
+fail_install() {
+    echo "  ✗ $*" >&2
+    return 1
+}
+
+verify_file_hash() {
+    local file=$1
+    local expected=$2
+    local label=$3
+    [ -z "$expected" ] && return 0
+    local actual
+    actual=$(shasum -a 256 "$file" | cut -d' ' -f1)
+    [ "$actual" = "$expected" ] \
+        || fail_install "$label hash mismatch (expected $expected, got $actual)."
+}
+
+binary_contains_paged_code() {
+    local binary=$1
+    local count
+    count=$(strings "$binary" | grep -c 'engine_v2_kv_backend' || true)
+    [ "$count" -gt 0 ]
+}
+
+verify_staged_app() {
+    local app=$1
+    local executable="$app/Contents/MacOS/darkbloom"
+    local marker="$app/Contents/Resources/darkbloom-runtime-capabilities/paged-kernel-v1"
+
+    codesign --verify --deep --strict --verbose=2 "$app" >/dev/null 2>&1 \
+        || {
+            fail_install "Strict code-signature verification failed for staged Darkbloom.app."
+            return 1
+        }
+
+    if [ "$INSTALL_TEST_MODE" != "1" ]; then
+        local team
+        team=$(codesign -dvv "$executable" 2>&1 \
+            | awk -F= '/^TeamIdentifier=/{print $2; exit}')
+        [ "$team" = "$EXPECTED_TEAM_ID" ] || {
+            fail_install "Staged app signer mismatch (expected team $EXPECTED_TEAM_ID, got ${team:-none})."
+            return 1
+        }
+    fi
+
+    local code_has_paged=0
+    local marker_present=0
+    binary_contains_paged_code "$executable" && code_has_paged=1
+    [ -f "$marker" ] && marker_present=1
+    [ "$code_has_paged" -eq "$marker_present" ] || {
+        if [ "$code_has_paged" -eq 1 ]; then
+            fail_install "Paged-capable staged app is missing its signed capability marker."
+        else
+            fail_install "Staged app advertises paged capability without paged runtime code."
+        fi
+        return 1
+    }
+    [ "$marker_present" -eq 1 ] || return 0
+    [ "$(tr -d '[:space:]' < "$marker")" = "1" ] || {
+        fail_install "Paged runtime capability marker is invalid."
+        return 1
+    }
+
+    shopt -s nullglob
+    local paged_resources=(
+        "$app/Contents/Resources"/*.bundle/pagedattention.metal
+    )
+    local expected_resource="$app/Contents/Resources/mlx-swift-lm_MLXLMCommon.bundle/pagedattention.metal"
+    [ "${#paged_resources[@]}" -eq 1 ] \
+        && [ "${paged_resources[0]}" = "$expected_resource" ] \
+        && [ -s "$expected_resource" ] \
+        || {
+            fail_install "Paged-capable staged app requires exactly one sealed MLXLMCommon pagedattention.metal."
+            return 1
+        }
+
+    DARKBLOOM_NO_UPDATE_CHECK=1 "$executable" runtime-smoke >/dev/null \
+        || {
+            fail_install "Packaged paged-kernel runtime smoke failed."
+            return 1
+        }
+}
+
+commit_staged_app() {
+    local staged_app=$1
+    local install_dir=$2
+    local backup="$install_dir/.install-backup-$$-$RANDOM"
+    local destination="$install_dir/Darkbloom.app"
+    local had_previous=0
+    mkdir -p "$backup" "$install_dir/bin"
+
+    if [ -d "$destination" ]; then
+        mv "$destination" "$backup/Darkbloom.app" || {
+            rm -rf "$backup"
+            return 1
+        }
+        had_previous=1
+    fi
+    if ! mv "$staged_app" "$destination"; then
+        [ "$had_previous" -eq 1 ] \
+            && mv "$backup/Darkbloom.app" "$destination" 2>/dev/null || true
+        rm -rf "$backup"
+        return 1
+    fi
+
+    local app_bin="$destination/Contents/MacOS"
+    if ! ln -sfn "../Darkbloom.app/Contents/MacOS/darkbloom" "$install_dir/bin/darkbloom" \
+        || ! ln -sfn "../Darkbloom.app/Contents/MacOS/darkbloom-enclave" "$install_dir/bin/darkbloom-enclave" \
+        || ! ln -sfn "../Darkbloom.app/Contents/MacOS/mlx.metallib" "$install_dir/bin/mlx.metallib" \
+        || ! ln -sfn "darkbloom-enclave" "$install_dir/bin/eigeninference-enclave"
+    then
+        rm -rf "$destination"
+        [ "$had_previous" -eq 1 ] \
+            && mv "$backup/Darkbloom.app" "$destination" 2>/dev/null || true
+        rm -rf "$backup"
+        return 1
+    fi
+    chmod +x "$app_bin/darkbloom" "$app_bin/darkbloom-enclave"
+    rm -rf "$backup"
+}
+
+commit_staged_flat_bundle() {
+    local staged_bin=$1
+    local install_dir=$2
+    local backup="$install_dir/.install-backup-$$-$RANDOM"
+    local destination="$install_dir/bin"
+    mkdir -p "$backup"
+    if [ -d "$destination" ]; then
+        mv "$destination" "$backup/bin" || {
+            rm -rf "$backup"
+            return 1
+        }
+    fi
+    if ! mv "$staged_bin" "$destination"; then
+        [ -d "$backup/bin" ] && mv "$backup/bin" "$destination" 2>/dev/null || true
+        rm -rf "$backup"
+        return 1
+    fi
+    chmod +x "$destination/darkbloom" "$destination/darkbloom-enclave"
+    ln -sfn "darkbloom-enclave" "$destination/eigeninference-enclave"
+    rm -rf "$backup"
+}
+
+install_bundle_atomically() {
+    local archive=$1
+    local install_dir=$2
+    local binary_hash=${3:-}
+    local metallib_hash=${4:-}
+    local stage="$install_dir/.install-staging-$$-$RANDOM"
+    rm -rf "$stage"
+    mkdir -p "$stage"
+    if ! tar xzf "$archive" -C "$stage"; then
+        rm -rf "$stage"
+        return 1
+    fi
+
+    local flat_bin="$stage/bin"
+    [ -f "$flat_bin/darkbloom" ] \
+        && [ -f "$flat_bin/darkbloom-enclave" ] \
+        && [ -f "$flat_bin/mlx.metallib" ] \
+        || {
+            rm -rf "$stage"
+            fail_install "Release bundle is missing required flat verifier files."
+            return 1
+        }
+    verify_file_hash "$flat_bin/darkbloom" "$binary_hash" "Binary" || {
+        rm -rf "$stage"
+        return 1
+    }
+    verify_file_hash "$flat_bin/mlx.metallib" "$metallib_hash" "Metallib" || {
+        rm -rf "$stage"
+        return 1
+    }
+
+    if [ -d "$stage/Darkbloom.app" ]; then
+        verify_staged_app "$stage/Darkbloom.app" || {
+            rm -rf "$stage"
+            return 1
+        }
+        commit_staged_app "$stage/Darkbloom.app" "$install_dir" || {
+            rm -rf "$stage"
+            fail_install "Atomic app swap failed; previous install was restored."
+            return 1
+        }
+    else
+        codesign --verify --strict --verbose=2 "$flat_bin/darkbloom" >/dev/null 2>&1 \
+            || {
+                rm -rf "$stage"
+                fail_install "Strict signature verification failed for legacy flat artifact."
+                return 1
+            }
+        if [ "$INSTALL_TEST_MODE" != "1" ]; then
+            local flat_team
+            flat_team=$(codesign -dvv "$flat_bin/darkbloom" 2>&1 \
+                | awk -F= '/^TeamIdentifier=/{print $2; exit}')
+            [ "$flat_team" = "$EXPECTED_TEAM_ID" ] || {
+                rm -rf "$stage"
+                fail_install "Legacy flat artifact signer mismatch."
+                return 1
+            }
+        fi
+        commit_staged_flat_bundle "$flat_bin" "$install_dir" || {
+            rm -rf "$stage"
+            fail_install "Atomic flat-bundle swap failed; previous install was restored."
+            return 1
+        }
+    fi
+    rm -rf "$stage"
+}
+
+if [ "${1:-}" = "--install-bundle-test" ]; then
+    [ "$#" -eq 5 ] || {
+        echo "usage: $0 --install-bundle-test <archive> <install-dir> <binary-hash> <metallib-hash>" >&2
+        exit 64
+    }
+    INSTALL_TEST_MODE=1
+    install_bundle_atomically "$2" "$3" "$4" "$5"
+    exit $?
+fi
 
 # Detect interactive vs piped (curl | bash).
 if [ -t 0 ]; then
@@ -102,88 +323,14 @@ if [ "$ACTUAL_HASH" != "$BUNDLE_HASH" ]; then
 fi
 echo "  Bundle hash verified ✓"
 
-echo "  Installing into $INSTALL_DIR ..."
-# The bundle ships as Darkbloom.app/ (contains provisioning profile for
-# keychain-access-groups) with bin/ symlinks for backward compatibility.
-# Older flat bundles (bin/darkbloom directly) are also handled.
-tar xzf "$TARBALL" -C "$INSTALL_DIR"
-
-# New .app bundle layout: Darkbloom.app/Contents/MacOS/{darkbloom,darkbloom-enclave,mlx.metallib}
-if [ -d "$INSTALL_DIR/Darkbloom.app" ]; then
-    APP_BIN="$INSTALL_DIR/Darkbloom.app/Contents/MacOS"
-    chmod +x "$APP_BIN/darkbloom" "$APP_BIN/darkbloom-enclave" 2>/dev/null || true
-    # bin/ gets symlinks pointing into the .app bundle
-    mkdir -p "$BIN_DIR"
-    ln -sfn "$APP_BIN/darkbloom" "$BIN_DIR/darkbloom"
-    ln -sfn "$APP_BIN/darkbloom-enclave" "$BIN_DIR/darkbloom-enclave"
-    ln -sfn "$APP_BIN/mlx.metallib" "$BIN_DIR/mlx.metallib" 2>/dev/null || true
-    echo "  Installed .app bundle with provisioning profile"
-else
-    # Legacy flat layout fallback
-    [ -f "$INSTALL_DIR/darkbloom" ]               && mv -f "$INSTALL_DIR/darkbloom" "$BIN_DIR/darkbloom"
-    [ -f "$INSTALL_DIR/darkbloom-enclave" ]       && mv -f "$INSTALL_DIR/darkbloom-enclave" "$BIN_DIR/darkbloom-enclave"
-    if [ -f "$INSTALL_DIR/eigeninference-enclave" ] && [ ! -f "$BIN_DIR/darkbloom-enclave" ]; then
-        mv -f "$INSTALL_DIR/eigeninference-enclave" "$BIN_DIR/darkbloom-enclave"
-    fi
-    [ -f "$INSTALL_DIR/mlx.metallib" ]            && mv -f "$INSTALL_DIR/mlx.metallib" "$BIN_DIR/mlx.metallib"
-    chmod +x "$BIN_DIR/darkbloom" "$BIN_DIR/darkbloom-enclave" 2>/dev/null || true
-fi
-
-ln -sfn "$BIN_DIR/darkbloom-enclave" "$BIN_DIR/eigeninference-enclave" 2>/dev/null || true
-rm -f "$TARBALL"
-
-# Verify per-binary SHA matches what the coordinator registered. The bundle
-# hash above proves the tarball matches; this also proves codesign + notary
-# didn't quietly mutate the binary.
-if [ -n "${BINARY_HASH:-}" ]; then
-    ACTUAL_BIN=$(shasum -a 256 "$BIN_DIR/darkbloom" | cut -d' ' -f1)
-    if [ "$ACTUAL_BIN" != "$BINARY_HASH" ]; then
-        echo "  ✗ Binary hash mismatch (expected $BINARY_HASH, got $ACTUAL_BIN)."
-        rm -rf "$BIN_DIR"
-        exit 1
-    fi
-    echo "  Binary hash verified ✓"
-fi
-if [ -n "$METALLIB_HASH" ] && [ -f "$BIN_DIR/mlx.metallib" ]; then
-    ACTUAL_LIB=$(shasum -a 256 "$BIN_DIR/mlx.metallib" | cut -d' ' -f1)
-    if [ "$ACTUAL_LIB" != "$METALLIB_HASH" ]; then
-        echo "  ✗ mlx.metallib hash mismatch (expected $METALLIB_HASH, got $ACTUAL_LIB)."
-        rm -rf "$BIN_DIR"
-        exit 1
-    fi
-    echo "  Metallib hash verified ✓"
-fi
-
-# Verify the whole app when present so its sealed SwiftPM resources are
-# covered, not only the main executable.
-SIGNATURE_TARGET="$BIN_DIR/darkbloom"
-if [ -d "$INSTALL_DIR/Darkbloom.app" ]; then
-    SIGNATURE_TARGET="$INSTALL_DIR/Darkbloom.app"
-fi
-if codesign --verify --deep --strict --verbose "$SIGNATURE_TARGET" 2>/dev/null; then
-    TEAM=$(codesign -dvv "$BIN_DIR/darkbloom" 2>&1 | grep "TeamIdentifier=" | cut -d= -f2)
-    echo "  Code signature verified ✓ (Team: $TEAM)"
-else
-    echo "  ⚠ Code signature could not be verified — proceed with caution."
-fi
-
-# Execute the same installed-layout paged-kernel gate release CI ran. This
-# catches a missing/corrupt SwiftPM bundle before the provider service starts.
-shopt -s nullglob
-PAGED_RESOURCES=(
-    "$INSTALL_DIR/Darkbloom.app/Contents/Resources"/*.bundle/pagedattention.metal
-)
-if [ "${#PAGED_RESOURCES[@]}" -gt 1 ]; then
-    echo "  ✗ Multiple pagedattention.metal resources found — refusing ambiguous package."
+echo "  Staging and verifying the complete app before touching the live install ..."
+if ! install_bundle_atomically "$TARBALL" "$INSTALL_DIR" "$BINARY_HASH" "$METALLIB_HASH"; then
+    rm -f "$TARBALL"
+    echo "  Existing installation was left unchanged."
     exit 1
 fi
-if [ "${#PAGED_RESOURCES[@]}" -eq 1 ]; then
-    if ! DARKBLOOM_NO_UPDATE_CHECK=1 "$BIN_DIR/darkbloom" runtime-smoke >/dev/null; then
-        echo "  ✗ Packaged runtime smoke failed — refusing to start this provider build."
-        exit 1
-    fi
-    echo "  Runtime resource smoke verified ✓"
-fi
+rm -f "$TARBALL"
+echo "  Strict signature, runtime resources, and atomic swap verified ✓"
 
 # Make available in PATH. Try /usr/local/bin symlink, fall back to shell rc.
 if ln -sf "$BIN_DIR/darkbloom" /usr/local/bin/darkbloom 2>/dev/null; then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -24,7 +24,7 @@ set -euo pipefail
 COORD_URL="${COORD_URL:-https://api.darkbloom.dev}"
 INSTALL_DIR="$HOME/.darkbloom"
 BIN_DIR="$INSTALL_DIR/bin"
-EXPECTED_TEAM_ID="SLDQ2GJ6TL"
+DARKBLOOM_DESIGNATED_REQUIREMENT='anchor apple generic and identifier "io.darkbloom.provider" and certificate leaf[subject.OU] = "SLDQ2GJ6TL"'
 INSTALL_TEST_MODE=0
 
 fail_install() {
@@ -43,6 +43,28 @@ verify_file_hash() {
         || fail_install "$label hash mismatch (expected $expected, got $actual)."
 }
 
+verify_code_requirement() {
+    local target=$1
+    local deep=$2
+    local requirement=$3
+    if [ "$deep" = "1" ]; then
+        codesign --verify --deep --strict --verbose=2 \
+            "-R=$requirement" "$target" >/dev/null 2>&1
+    else
+        codesign --verify --strict --verbose=2 \
+            "-R=$requirement" "$target" >/dev/null 2>&1
+    fi
+}
+
+verify_staged_app_signature() {
+    local app=$1
+    local requirement=${2:-$DARKBLOOM_DESIGNATED_REQUIREMENT}
+    verify_code_requirement "$app" 1 "$requirement" || {
+        fail_install "Staged Darkbloom.app does not satisfy the pinned signature requirement."
+        return 1
+    }
+}
+
 # Stock-macOS binary capability probe. `strings` is an Xcode CLT shim on a
 # pristine Mac (it prompts/fails without developer tools), so scan the file
 # directly with BSD grep's binary-as-text mode — grep ships in base macOS.
@@ -56,20 +78,13 @@ verify_staged_app() {
     local executable="$app/Contents/MacOS/darkbloom"
     local marker="$app/Contents/Resources/darkbloom-runtime-capabilities/paged-kernel-v1"
 
-    codesign --verify --deep --strict --verbose=2 "$app" >/dev/null 2>&1 \
-        || {
+    if [ "$INSTALL_TEST_MODE" = "1" ]; then
+        codesign --verify --deep --strict --verbose=2 "$app" >/dev/null 2>&1 || {
             fail_install "Strict code-signature verification failed for staged Darkbloom.app."
             return 1
         }
-
-    if [ "$INSTALL_TEST_MODE" != "1" ]; then
-        local team
-        team=$(codesign -dvv "$executable" 2>&1 \
-            | awk -F= '/^TeamIdentifier=/{print $2; exit}')
-        [ "$team" = "$EXPECTED_TEAM_ID" ] || {
-            fail_install "Staged app signer mismatch (expected team $EXPECTED_TEAM_ID, got ${team:-none})."
-            return 1
-        }
+    else
+        verify_staged_app_signature "$app" || return 1
     fi
 
     local code_has_paged=0
@@ -108,6 +123,19 @@ verify_staged_app() {
             fail_install "Packaged paged-kernel runtime smoke failed."
             return 1
         }
+}
+
+verify_staged_app_payload() {
+    local app=$1
+    local binary_hash=$2
+    local metallib_hash=$3
+    local app_bin="$app/Contents/MacOS"
+    [ -n "$binary_hash" ] && [ -n "$metallib_hash" ] || {
+        fail_install "App releases require binary_hash and metallib_hash."
+        return 1
+    }
+    verify_file_hash "$app_bin/darkbloom" "$binary_hash" "App binary" \
+        && verify_file_hash "$app_bin/mlx.metallib" "$metallib_hash" "App metallib"
 }
 
 commit_staged_app() {
@@ -202,6 +230,11 @@ install_bundle_atomically() {
     }
 
     if [ -d "$stage/Darkbloom.app" ]; then
+        verify_staged_app_payload \
+            "$stage/Darkbloom.app" "$binary_hash" "$metallib_hash" || {
+            rm -rf "$stage"
+            return 1
+        }
         verify_staged_app "$stage/Darkbloom.app" || {
             rm -rf "$stage"
             return 1
@@ -212,19 +245,17 @@ install_bundle_atomically() {
             return 1
         }
     else
-        codesign --verify --strict --verbose=2 "$flat_bin/darkbloom" >/dev/null 2>&1 \
-            || {
+        if [ "$INSTALL_TEST_MODE" = "1" ]; then
+            codesign --verify --strict --verbose=2 "$flat_bin/darkbloom" >/dev/null 2>&1 || {
                 rm -rf "$stage"
                 fail_install "Strict signature verification failed for legacy flat artifact."
                 return 1
             }
-        if [ "$INSTALL_TEST_MODE" != "1" ]; then
-            local flat_team
-            flat_team=$(codesign -dvv "$flat_bin/darkbloom" 2>&1 \
-                | awk -F= '/^TeamIdentifier=/{print $2; exit}')
-            [ "$flat_team" = "$EXPECTED_TEAM_ID" ] || {
+        else
+            verify_code_requirement \
+                "$flat_bin/darkbloom" 0 "$DARKBLOOM_DESIGNATED_REQUIREMENT" || {
                 rm -rf "$stage"
-                fail_install "Legacy flat artifact signer mismatch."
+                fail_install "Legacy flat artifact does not satisfy the pinned signature requirement."
                 return 1
             }
         fi
@@ -236,6 +267,15 @@ install_bundle_atomically() {
     fi
     rm -rf "$stage"
 }
+
+if [ "${1:-}" = "--verify-staged-app-signature-test" ]; then
+    [ "$#" -eq 3 ] || {
+        echo "usage: $0 --verify-staged-app-signature-test <app> <requirement>" >&2
+        exit 64
+    }
+    verify_staged_app_signature "$2" "$3"
+    exit $?
+fi
 
 if [ "${1:-}" = "--install-bundle-test" ]; then
     [ "$#" -eq 5 ] || {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -43,11 +43,12 @@ verify_file_hash() {
         || fail_install "$label hash mismatch (expected $expected, got $actual)."
 }
 
+# Stock-macOS binary capability probe. `strings` is an Xcode CLT shim on a
+# pristine Mac (it prompts/fails without developer tools), so scan the file
+# directly with BSD grep's binary-as-text mode — grep ships in base macOS.
 binary_contains_paged_code() {
     local binary=$1
-    local count
-    count=$(strings "$binary" | grep -c 'engine_v2_kv_backend' || true)
-    [ "$count" -gt 0 ]
+    LC_ALL=C grep -a -q -F 'engine_v2_kv_backend' "$binary"
 }
 
 verify_staged_app() {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 #
 # This script:
 #   1. Fetches the latest signed release from the coordinator
-#   2. Downloads the provider bundle (darkbloom + darkbloom-enclave + mlx.metallib)
+#   2. Downloads the provider app (binaries, metallib, SwiftPM resources)
 #   3. Verifies bundle SHA-256 + Apple Developer ID code signature
 #   4. Sets up the Secure Enclave identity
 #   5. Kicks off MDM enrollment (non-blocking)
@@ -154,12 +154,35 @@ if [ -n "$METALLIB_HASH" ] && [ -f "$BIN_DIR/mlx.metallib" ]; then
     echo "  Metallib hash verified ✓"
 fi
 
-# Verify code signature (codesign is base macOS, no CLT prompt).
-if codesign --verify --verbose "$BIN_DIR/darkbloom" 2>/dev/null; then
+# Verify the whole app when present so its sealed SwiftPM resources are
+# covered, not only the main executable.
+SIGNATURE_TARGET="$BIN_DIR/darkbloom"
+if [ -d "$INSTALL_DIR/Darkbloom.app" ]; then
+    SIGNATURE_TARGET="$INSTALL_DIR/Darkbloom.app"
+fi
+if codesign --verify --deep --strict --verbose "$SIGNATURE_TARGET" 2>/dev/null; then
     TEAM=$(codesign -dvv "$BIN_DIR/darkbloom" 2>&1 | grep "TeamIdentifier=" | cut -d= -f2)
     echo "  Code signature verified ✓ (Team: $TEAM)"
 else
     echo "  ⚠ Code signature could not be verified — proceed with caution."
+fi
+
+# Execute the same installed-layout paged-kernel gate release CI ran. This
+# catches a missing/corrupt SwiftPM bundle before the provider service starts.
+shopt -s nullglob
+PAGED_RESOURCES=(
+    "$INSTALL_DIR/Darkbloom.app/Contents/Resources"/*.bundle/pagedattention.metal
+)
+if [ "${#PAGED_RESOURCES[@]}" -gt 1 ]; then
+    echo "  ✗ Multiple pagedattention.metal resources found — refusing ambiguous package."
+    exit 1
+fi
+if [ "${#PAGED_RESOURCES[@]}" -eq 1 ]; then
+    if ! DARKBLOOM_NO_UPDATE_CHECK=1 "$BIN_DIR/darkbloom" runtime-smoke >/dev/null; then
+        echo "  ✗ Packaged runtime smoke failed — refusing to start this provider build."
+        exit 1
+    fi
+    echo "  Runtime resource smoke verified ✓"
 fi
 
 # Make available in PATH. Try /usr/local/bin symlink, fall back to shell rc.

--- a/scripts/stage-swiftpm-resource-bundles.sh
+++ b/scripts/stage-swiftpm-resource-bundles.sh
@@ -49,5 +49,9 @@ paged_resources=("$resource_root"/*.bundle/pagedattention.metal)
   exit 1
 }
 
+capability_dir="$resource_root/darkbloom-runtime-capabilities"
+mkdir -p "$capability_dir"
+printf '1\n' > "$capability_dir/paged-kernel-v1"
+
 LC_ALL=C sort -u "$manifest" -o "$manifest"
 echo "Staged ${#bundles[@]} SwiftPM resource bundle(s) in Contents/Resources"

--- a/scripts/stage-swiftpm-resource-bundles.sh
+++ b/scripts/stage-swiftpm-resource-bundles.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 3 ]]; then
+  echo "usage: $0 <swift-bin-dir> <app-bundle> <manifest-output>" >&2
+  exit 64
+fi
+
+bin_dir=$1
+app_bundle=$2
+manifest=$3
+
+[[ -d "$bin_dir" ]] || { echo "Swift bin directory does not exist: $bin_dir" >&2; exit 1; }
+[[ -d "$app_bundle" ]] || { echo "App bundle does not exist: $app_bundle" >&2; exit 1; }
+resource_root="$app_bundle/Contents/Resources"
+mkdir -p "$resource_root"
+
+shopt -s nullglob
+bundles=("$bin_dir"/*.bundle)
+(( ${#bundles[@]} > 0 )) || {
+  echo "No SwiftPM resource bundles found beside the built executable: $bin_dir" >&2
+  exit 1
+}
+
+: > "$manifest"
+for source_bundle in "${bundles[@]}"; do
+  [[ -d "$source_bundle" && ! -L "$source_bundle" ]] || {
+    echo "SwiftPM resource bundle must be a real directory: $source_bundle" >&2
+    exit 1
+  }
+  bundle_name=$(basename "$source_bundle")
+  destination="$resource_root/$bundle_name"
+  rm -rf "$destination"
+  /usr/bin/ditto "$source_bundle" "$destination"
+  [[ -d "$destination" ]] || {
+    echo "Failed to stage SwiftPM resource bundle: $bundle_name" >&2
+    exit 1
+  }
+  printf '%s\n' "$bundle_name" >> "$manifest"
+done
+
+paged_resources=("$resource_root"/*.bundle/pagedattention.metal)
+(( ${#paged_resources[@]} == 1 )) || {
+  echo "Expected exactly one staged pagedattention.metal, found ${#paged_resources[@]}" >&2
+  exit 1
+}
+[[ -s "${paged_resources[0]}" ]] || {
+  echo "Staged pagedattention.metal is empty: ${paged_resources[0]}" >&2
+  exit 1
+}
+
+LC_ALL=C sort -u "$manifest" -o "$manifest"
+echo "Staged ${#bundles[@]} SwiftPM resource bundle(s) in Contents/Resources"

--- a/scripts/test-install-atomic.sh
+++ b/scripts/test-install-atomic.sh
@@ -1,0 +1,165 @@
+#!/bin/bash
+set -euo pipefail
+
+ROOT=$(mktemp -d "${TMPDIR:-/tmp}/darkbloom-install-test.XXXXXX")
+trap 'rm -rf "$ROOT"' EXIT
+REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd)
+INSTALLER="$REPO_ROOT/scripts/install.sh"
+
+cat > "$ROOT/paged.c" <<'C'
+#include <libgen.h>
+#include <limits.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+static const char *capability = "engine_v2_kv_backend";
+
+int main(int argc, char **argv) {
+    if (argc < 2 || strcmp(argv[1], "runtime-smoke") != 0) {
+        fputs(capability, stderr);
+        return 0;
+    }
+    char resolved[PATH_MAX];
+    if (realpath(argv[0], resolved) == NULL) return 2;
+    char first[PATH_MAX], second[PATH_MAX], third[PATH_MAX];
+    snprintf(first, sizeof(first), "%s", resolved);
+    snprintf(second, sizeof(second), "%s", dirname(first));
+    snprintf(third, sizeof(third), "%s", dirname(second));
+    char *app = dirname(third);
+    char resource[PATH_MAX];
+    snprintf(
+        resource, sizeof(resource),
+        "%s/Contents/Resources/mlx-swift-lm_MLXLMCommon.bundle/pagedattention.metal",
+        app);
+    return access(resource, R_OK) == 0 ? 0 : 3;
+}
+C
+
+cat > "$ROOT/legacy.c" <<'C'
+int main(void) { return 0; }
+C
+
+clang -Os "$ROOT/paged.c" -o "$ROOT/paged"
+clang -Os "$ROOT/legacy.c" -o "$ROOT/legacy"
+
+make_artifact() {
+    local output=$1
+    local capability=$2
+    local include_resource=$3
+    local stage="$ROOT/stage-$RANDOM"
+    local app="$stage/Darkbloom.app"
+    local binary="$ROOT/$capability"
+    mkdir -p "$app/Contents/MacOS" "$stage/bin"
+    cp "$binary" "$app/Contents/MacOS/darkbloom"
+    cp "$binary" "$app/Contents/MacOS/darkbloom-enclave"
+    cp "$binary" "$app/Contents/MacOS/mlx.metallib"
+    cat > "$app/Contents/Info.plist" <<'PLIST'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+<key>CFBundleIdentifier</key><string>io.darkbloom.install-test</string>
+<key>CFBundleExecutable</key><string>darkbloom</string>
+<key>CFBundlePackageType</key><string>APPL</string>
+<key>CFBundleVersion</key><string>1</string>
+</dict></plist>
+PLIST
+
+    if [ "$capability" = "paged" ]; then
+        mkdir -p "$app/Contents/Resources/darkbloom-runtime-capabilities"
+        printf '1\n' \
+            > "$app/Contents/Resources/darkbloom-runtime-capabilities/paged-kernel-v1"
+        if [ "$include_resource" = "yes" ]; then
+            mkdir -p "$app/Contents/Resources/mlx-swift-lm_MLXLMCommon.bundle"
+            printf 'kernel\n' \
+                > "$app/Contents/Resources/mlx-swift-lm_MLXLMCommon.bundle/pagedattention.metal"
+        fi
+    fi
+
+    codesign --force --sign - "$app/Contents/MacOS/mlx.metallib"
+    codesign --force --sign - "$app/Contents/MacOS/darkbloom-enclave"
+    codesign --force --sign - "$app/Contents/MacOS/darkbloom"
+    codesign --force --sign - "$app"
+    codesign --verify --deep --strict "$app"
+
+    cp "$app/Contents/MacOS/darkbloom" "$stage/bin/darkbloom"
+    cp "$app/Contents/MacOS/darkbloom-enclave" "$stage/bin/darkbloom-enclave"
+    cp "$app/Contents/MacOS/mlx.metallib" "$stage/bin/mlx.metallib"
+    tar czf "$output" -C "$stage" .
+    rm -rf "$stage"
+}
+
+hash_file() {
+    shasum -a 256 "$1" | cut -d' ' -f1
+}
+
+artifact_hashes() {
+    local archive=$1
+    local extracted="$ROOT/hash-$RANDOM"
+    mkdir -p "$extracted"
+    tar xzf "$archive" -C "$extracted"
+    BINARY_HASH=$(hash_file "$extracted/bin/darkbloom")
+    METALLIB_HASH=$(hash_file "$extracted/bin/mlx.metallib")
+    rm -rf "$extracted"
+}
+
+run_install() {
+    local archive=$1
+    local install_dir=$2
+    artifact_hashes "$archive"
+    bash "$INSTALLER" --install-bundle-test \
+        "$archive" "$install_dir" "$BINARY_HASH" "$METALLIB_HASH"
+}
+
+VALID="$ROOT/valid.tar.gz"
+MISSING="$ROOT/missing.tar.gz"
+LEGACY="$ROOT/legacy.tar.gz"
+make_artifact "$VALID" paged yes
+make_artifact "$MISSING" paged no
+make_artifact "$LEGACY" legacy no
+
+INSTALL="$ROOT/install"
+mkdir -p "$INSTALL/Darkbloom.app"
+printf 'old\n' > "$INSTALL/Darkbloom.app/sentinel"
+
+if run_install "$MISSING" "$INSTALL"; then
+    echo "missing paged resource unexpectedly installed" >&2
+    exit 1
+fi
+test -f "$INSTALL/Darkbloom.app/sentinel"
+
+run_install "$VALID" "$INSTALL"
+test ! -f "$INSTALL/Darkbloom.app/sentinel"
+DARKBLOOM_NO_UPDATE_CHECK=1 "$INSTALL/bin/darkbloom" runtime-smoke
+
+LEGACY_INSTALL="$ROOT/legacy-install"
+run_install "$LEGACY" "$LEGACY_INSTALL"
+test -x "$LEGACY_INSTALL/bin/darkbloom"
+
+TAMPER_ROOT="$ROOT/tamper"
+mkdir -p "$TAMPER_ROOT"
+tar xzf "$VALID" -C "$TAMPER_ROOT"
+printf 'tampered\n' \
+    >> "$TAMPER_ROOT/Darkbloom.app/Contents/Resources/mlx-swift-lm_MLXLMCommon.bundle/pagedattention.metal"
+TAMPERED="$ROOT/tampered.tar.gz"
+tar czf "$TAMPERED" -C "$TAMPER_ROOT" .
+if run_install "$TAMPERED" "$INSTALL"; then
+    echo "tampered signed app unexpectedly installed" >&2
+    exit 1
+fi
+DARKBLOOM_NO_UPDATE_CHECK=1 "$INSTALL/bin/darkbloom" runtime-smoke
+
+INSTALLER="$REPO_ROOT/coordinator/api/install.sh"
+COORD_INSTALL="$ROOT/coordinator-install"
+mkdir -p "$COORD_INSTALL/Darkbloom.app"
+printf 'coordinator-old\n' > "$COORD_INSTALL/Darkbloom.app/sentinel"
+if run_install "$MISSING" "$COORD_INSTALL"; then
+    echo "coordinator installer accepted missing paged resource" >&2
+    exit 1
+fi
+test -f "$COORD_INSTALL/Darkbloom.app/sentinel"
+run_install "$VALID" "$COORD_INSTALL"
+test ! -f "$COORD_INSTALL/Darkbloom.app/sentinel"
+
+echo "atomic installer tests passed"

--- a/scripts/test-install-atomic.sh
+++ b/scripts/test-install-atomic.sh
@@ -143,6 +143,11 @@ run_install() {
         "$archive" "$install_dir" "$BINARY_HASH" "$METALLIB_HASH"
 }
 
+run_install_without_hashes() {
+    PATH="$CLT_SHIMS:$PATH" bash "$INSTALLER" --install-bundle-test \
+        "$1" "$2" "" ""
+}
+
 VALID="$ROOT/valid.tar.gz"
 MISSING="$ROOT/missing.tar.gz"
 LEGACY="$ROOT/legacy.tar.gz"
@@ -150,12 +155,59 @@ make_artifact "$VALID" paged yes
 make_artifact "$MISSING" paged no
 make_artifact "$LEGACY" legacy no
 
+# The designated requirement must be applied to the complete app target,
+# whose main-executable signature seals Contents/Resources.
+SIGNATURE_ROOT="$ROOT/signature"
+mkdir -p "$SIGNATURE_ROOT"
+tar xzf "$VALID" -C "$SIGNATURE_ROOT"
+APP_REQUIREMENT=$(codesign -d -r- \
+    "$SIGNATURE_ROOT/Darkbloom.app" 2>&1 \
+    | awk -F' => ' '/designated/{print $2; exit}')
+[ -n "$APP_REQUIREMENT" ]
+PRODUCTION_REQUIREMENT='anchor apple generic and identifier "io.darkbloom.provider" and certificate leaf[subject.OU] = "SLDQ2GJ6TL"'
+for installer in \
+    "$REPO_ROOT/scripts/install.sh" \
+    "$REPO_ROOT/coordinator/api/install.sh"
+do
+    grep -Fqx \
+        "DARKBLOOM_DESIGNATED_REQUIREMENT='$PRODUCTION_REQUIREMENT'" \
+        "$installer"
+    bash "$installer" --verify-staged-app-signature-test \
+        "$SIGNATURE_ROOT/Darkbloom.app" "$APP_REQUIREMENT"
+    if bash "$installer" --verify-staged-app-signature-test \
+        "$SIGNATURE_ROOT/Darkbloom.app" 'identifier "not.darkbloom"'
+    then
+        echo "$installer accepted an app outside the required identity" >&2
+        exit 1
+    fi
+done
+
+# Make the registered flat metallib differ from the signed app payload.
+# Structural app verification alone must not admit it.
+DIVERGED_ROOT="$ROOT/diverged"
+mkdir -p "$DIVERGED_ROOT"
+tar xzf "$VALID" -C "$DIVERGED_ROOT"
+printf 'diverged\n' \
+    >> "$DIVERGED_ROOT/bin/mlx.metallib"
+DIVERGED="$ROOT/diverged.tar.gz"
+tar czf "$DIVERGED" -C "$DIVERGED_ROOT" .
+
 INSTALL="$ROOT/install"
 mkdir -p "$INSTALL/Darkbloom.app"
 printf 'old\n' > "$INSTALL/Darkbloom.app/sentinel"
 
+if run_install_without_hashes "$VALID" "$INSTALL"; then
+    echo "app release without payload hashes unexpectedly installed" >&2
+    exit 1
+fi
+test -f "$INSTALL/Darkbloom.app/sentinel"
 if run_install "$MISSING" "$INSTALL"; then
     echo "missing paged resource unexpectedly installed" >&2
+    exit 1
+fi
+test -f "$INSTALL/Darkbloom.app/sentinel"
+if run_install "$DIVERGED" "$INSTALL"; then
+    echo "divergent app payload unexpectedly installed" >&2
     exit 1
 fi
 test -f "$INSTALL/Darkbloom.app/sentinel"
@@ -185,8 +237,18 @@ INSTALLER="$REPO_ROOT/coordinator/api/install.sh"
 COORD_INSTALL="$ROOT/coordinator-install"
 mkdir -p "$COORD_INSTALL/Darkbloom.app"
 printf 'coordinator-old\n' > "$COORD_INSTALL/Darkbloom.app/sentinel"
+if run_install_without_hashes "$VALID" "$COORD_INSTALL"; then
+    echo "coordinator installer accepted an app without payload hashes" >&2
+    exit 1
+fi
+test -f "$COORD_INSTALL/Darkbloom.app/sentinel"
 if run_install "$MISSING" "$COORD_INSTALL"; then
     echo "coordinator installer accepted missing paged resource" >&2
+    exit 1
+fi
+test -f "$COORD_INSTALL/Darkbloom.app/sentinel"
+if run_install "$DIVERGED" "$COORD_INSTALL"; then
+    echo "coordinator installer accepted a divergent app payload" >&2
     exit 1
 fi
 test -f "$COORD_INSTALL/Darkbloom.app/sentinel"

--- a/scripts/test-install-atomic.sh
+++ b/scripts/test-install-atomic.sh
@@ -44,6 +44,37 @@ C
 clang -Os "$ROOT/paged.c" -o "$ROOT/paged"
 clang -Os "$ROOT/legacy.c" -o "$ROOT/legacy"
 
+# A pristine Mac has no Xcode Command Line Tools: /usr/bin/strings, otool,
+# nm, etc. are shims that prompt/fail. Prove the installers never need them
+# two ways: (1) statically — no CLT tool is referenced outside comments in
+# either installer; (2) behaviorally — every install below runs with failing
+# CLT shims first on PATH, so any hidden invocation aborts the install.
+CLT_SHIMS="$ROOT/clt-shims"
+mkdir -p "$CLT_SHIMS"
+for tool in strings otool nm xcrun swift swiftc clang gcc ld libtool lipo; do
+    cat > "$CLT_SHIMS/$tool" <<SHIM
+#!/bin/bash
+echo "xcode-select: note: no developer tools were found ($tool shim)" >&2
+exit 72
+SHIM
+    chmod +x "$CLT_SHIMS/$tool"
+done
+
+assert_no_clt_tools() {
+    local script=$1
+    local offending
+    offending=$(sed 's/#.*$//' "$script" \
+        | grep -nEw 'strings|otool|nm|xcrun|swiftc|libtool|lipo' \
+        || true)
+    if [ -n "$offending" ]; then
+        echo "CLT-dependent tool referenced in $script:" >&2
+        echo "$offending" >&2
+        exit 1
+    fi
+}
+assert_no_clt_tools "$REPO_ROOT/scripts/install.sh"
+assert_no_clt_tools "$REPO_ROOT/coordinator/api/install.sh"
+
 make_artifact() {
     local output=$1
     local capability=$2
@@ -108,7 +139,7 @@ run_install() {
     local archive=$1
     local install_dir=$2
     artifact_hashes "$archive"
-    bash "$INSTALLER" --install-bundle-test \
+    PATH="$CLT_SHIMS:$PATH" bash "$INSTALLER" --install-bundle-test \
         "$archive" "$install_dir" "$BINARY_HASH" "$METALLIB_HASH"
 }
 


### PR DESCRIPTION
## Summary

Root-cause fix for the v0.7.6 fleet outage (2026-07-10, ~305 → ~190 providers in 40 minutes). Two defects shipped together:

1. **Missing runtime resource**: the release archive omitted `mlx-swift-lm_MLXLMCommon.bundle` (contains `pagedattention.metal`). `Bundle.module` hit a Swift `fatalError` (SIGTRAP, confirmed on a live host) on first GPT-OSS paged access — during pre-registration startup preload on machines with GPT persisted, so they crash-looped invisibly.
2. **Unsafe physical sizing**: the paged pool was sized from the full logical KV grant (~0.90×RAM − weights − 3 GiB) and synchronously `materializeSlabs()`-ed before registration, ignoring live OS memory and Metal `maxBufferLength` (two ~50 GiB slabs on a 128 GB box vs a ~43 GiB device limit).

This PR (parent + nested `mlx-swift-lm` branch `fix/pagedattention-safety-sol`, pin `e718c2d`):

- **`auto` resolves contiguous, permanently.** Paged requires explicit opt-in (`engine_v2_kv_backend = "paged"`) and stays experimental until real-weight host canaries pass.
- **Sealed resources or refuse-and-fallback**: SwiftPM bundles are staged under `Contents/Resources`, sealed by app signing, and lookup is restricted to the sealed app (symlink-resolving; unsigned external bundles rejected). Missing/corrupt resources throw catchable `CBv2KVError` → contiguous fallback before any request. No `fatalError` path remains reachable from packaging.
- **Every paged traffic kernel is pre-JITed** (bulk-write, decode part, merge — all layer-kind variants) in a child-process preflight before slab materialization; any failure falls back contiguous.
- **Physically bounded pools**: capacity = min(useful concurrent context demand, live free memory share, RAM/16, 8 GiB), every slab validated against `MTLDevice.maxBufferLength`, overflow-safe arithmetic. Heartbeats report pool truth; ledger-only reslices can never claim physical reclaim (pinned by a new ProviderLoop-level mixed paged+contiguous test).
- **Release/install gates now execute the artifact**: staged atomic installs (no more extract-over-live), strict Team-ID-pinned codesign fail-closed, signed capability marker distinguishes paged-capable from legacy artifacts, and a packaged runtime smoke runs from the installed layout in the release workflow, both installers, and SelfUpdater — the exact v0.7.6 failure now fails the pipeline instead of the fleet. Installer probes use only stock-macOS tools (verified with poisoned CLT shims on PATH).
- **CI**: nested paged safety suites run directly; SwiftPM cache includes `libs/mlx-swift-lm/.build` (key bumped to `spm-v2`), realistic timeouts.

## Before

```mermaid
flowchart LR
  subgraph Behavior_Before[Behavior before]
    A1[v0.7.6 installs] --> B1[GPT slot auto-selects paged]
    B1 --> C1[Bundle.module: bundle missing from archive]
    C1 --> D1[fatalError SIGTRAP pre-registration]
    D1 --> E1[Crash loop, fleet 305 to 190]
    B1 --> F1[materializeSlabs: full logical grant]
    F1 --> G1[Ignores live memory + maxBufferLength]
  end
  subgraph Code_Before[Code before]
    H1[Release workflow: stages 3 binaries only] --> I1[Structural tar checks pass]
    J1[EngineV2KVBackendPolicy auto=paged for GPT] --> K1[PagedKVPool capacity = full grant]
  end
```

## After

```mermaid
flowchart LR
  subgraph Behavior_After[Behavior after]
    A2[Install/update] --> B2[Staged + strict-signed + capability check]
    B2 --> C2[Packaged runtime smoke executes paged kernels]
    C2 -- pass --> D2[Atomic swap live]
    C2 -- fail --> E2[Refuse install, live install untouched]
    F2[GPT slot: auto] --> G2[Contiguous always]
    H2[Explicit paged opt-in] --> I2[Preflight kernels + bounded pool <= 8GiB, <= maxBufferLength]
    I2 -- any failure --> G2
  end
  subgraph Code_After[Code after]
    J2[Release workflow + installers + SelfUpdater share smoke gate] --> K2[PagedAttentionResources: sealed-app-only lookup]
    L2[EngineV2KVBackendPolicy: auto=contiguous] --> M2[PagedKVPool: demand/live-memory/8GiB/maxBufferLength caps]
  end
```

## Test plan
- [x] 50 nested paged tests (6 suites) incl. missing-bundle, tamper, symlink, external-bundle rejection — fail without the fix
- [x] Provider suite: 1,083 tests / 122 suites, three consecutive green runs
- [x] Coordinator API tests (embed the installer) green
- [x] Installer scenarios under stock bash 3.2 with poisoned CLT shims; shellcheck delta vs master = zero
- [x] Release builds; strict ad-hoc signed staged-app + extracted-archive smokes
- [x] Three adversarial review rounds; all P0/P1 findings closed with regression tests
- [ ] Real-weight live-host canary for explicit paged (tag must be strictly above 0.7.7)

Nested PR branch: `Layr-Labs/mlx-swift-lm` `fix/pagedattention-safety-sol` (d72ce57 → e718c2d). Paged-by-default remains off until canaries pass.

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/535"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786327363&installation_id=133247490&pr_number=535&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F535&signature=caa2215a960d71fc4d87fde5b0f5c1924135b7a4aaca770fc8ba8a43c9586928"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->