### PR TITLE
feat(provider): add opt-in fan control

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,11 @@ jobs:
         working-directory: provider-swift
         # Build the TEST bundle too, so the .xctest bundle exists before we
         # place the metallib next to its runner binary (see next step).
-        run: swift build --build-tests
+        run: |
+          swift build --build-tests
+          # The root helper is a separately packaged executable product and is
+          # not guaranteed to be linked merely because the test bundle builds.
+          swift build --product darkbloom-fan-helper
       - name: Extract mlx.metallib
         working-directory: provider-swift
         run: |
@@ -149,7 +153,9 @@ jobs:
             spm-v2-${{ runner.os }}-
       - name: Build provider-swift
         working-directory: provider-swift
-        run: swift build -c release --product darkbloom
+        run: |
+          swift build -c release --product darkbloom
+          swift build -c release --product darkbloom-fan-helper
       - name: Build nested mlx-swift-lm tests (warms nested cache)
         working-directory: libs/mlx-swift-lm
         # The test-provider job runs CBv2PagedSafetyTests from this nested

--- a/.github/workflows/release-swift.yml
+++ b/.github/workflows/release-swift.yml
@@ -6,6 +6,7 @@ name: Release Provider Bundle (Swift)
 #   - bin/darkbloom          (provider CLI)
 #   - bin/darkbloom-enclave  (Secure Enclave attestation/sign helper)
 #   - bin/mlx.metallib       (compiled Metal kernels for the matching MLX)
+#   - Darkbloom.app/Contents/Helpers/darkbloom-fan-helper (dormant opt-in root helper)
 #   - Darkbloom.app/Contents/Resources/*.bundle (SwiftPM resources)
 #
 # install.sh creates a backward-compatibility symlink from the legacy
@@ -61,6 +62,8 @@ env:
   APPLE_TEAM_ID: 'SLDQ2GJ6TL'
   CLI_NAME: 'darkbloom'
   ENCLAVE_NAME: 'darkbloom-enclave'
+  FAN_HELPER_NAME: 'darkbloom-fan-helper'
+  FAN_HELPER_ID: 'io.darkbloom.fan-helper'
   MIN_MACOS: '14.0'
   # The mlx.metallib (compiled Metal GPU kernels) is BUILT FROM SOURCE from the
   # MLX fork pinned at libs/mlx-swift/Source/Cmlx/mlx — NOT fetched from a PyPI
@@ -321,9 +324,11 @@ jobs:
           set -euo pipefail
           swift build -c release --product darkbloom
           swift build -c release --product darkbloom-enclave
+          swift build -c release --product darkbloom-fan-helper
           BIN_DIR=$(swift build -c release --show-bin-path)
           test -x "$BIN_DIR/$CLI_NAME"
           test -x "$BIN_DIR/$ENCLAVE_NAME"
+          test -x "$BIN_DIR/$FAN_HELPER_NAME"
           echo "BIN_DIR=$BIN_DIR" >> "$GITHUB_ENV"
           ls -la "$BIN_DIR" | head -50
 
@@ -440,11 +445,19 @@ jobs:
           # Wrap the CLI in a minimal .app bundle so the provisioning profile
           # authorizes keychain-access-groups for the persistent SE key.
           APP="$STAGE/Darkbloom.app"
-          mkdir -p "$APP/Contents/MacOS"
+          mkdir -p \
+            "$APP/Contents/MacOS" \
+            "$APP/Contents/Helpers" \
+            "$APP/Contents/Resources/darkbloom-runtime-capabilities"
 
           cp "$BIN_DIR/$CLI_NAME" "$APP/Contents/MacOS/"
           cp "$BIN_DIR/$ENCLAVE_NAME" "$APP/Contents/MacOS/"
           cp "${{ steps.metallib.outputs.metallib }}" "$APP/Contents/MacOS/mlx.metallib"
+          install -m 0755 \
+            "$BIN_DIR/$FAN_HELPER_NAME" \
+            "$APP/Contents/Helpers/$FAN_HELPER_NAME"
+          printf '1\n' \
+            > "$APP/Contents/Resources/darkbloom-runtime-capabilities/fan-helper-v1"
 
           cat > "$APP/Contents/Info.plist" << PLIST
           <?xml version="1.0" encoding="UTF-8"?>
@@ -495,6 +508,17 @@ jobs:
           # Hardened-runtime sign each binary and resource, then the bundle.
           # mlx.metallib must be signed before the bundle or codesign rejects
           # it as an unsigned subcomponent.
+          # The fan helper runs as root only after a separate, explicit sudo
+          # command. Give it its own identity and no provider APNs/keychain
+          # entitlements; ordinary installation leaves it sealed and dormant.
+          codesign --force --options runtime --timestamp \
+            --identifier "$FAN_HELPER_ID" \
+            --keychain "$KEYCHAIN_PATH" \
+            --sign "$DEVELOPER_ID" "$APP/Contents/Helpers/$FAN_HELPER_NAME"
+          FAN_HELPER_REQUIREMENT="anchor apple generic and identifier \"$FAN_HELPER_ID\" and certificate leaf[subject.OU] = \"$APPLE_TEAM_ID\""
+          codesign --verify --strict --verbose=2 \
+            "-R=$FAN_HELPER_REQUIREMENT" \
+            "$APP/Contents/Helpers/$FAN_HELPER_NAME"
           codesign --force --options runtime --timestamp \
             --keychain "$KEYCHAIN_PATH" \
             --sign "$DEVELOPER_ID" "$APP/Contents/MacOS/mlx.metallib"
@@ -650,6 +674,16 @@ jobs:
           grep -qx './bin/darkbloom' /tmp/darkbloom-bundle-files.txt
           grep -qx './bin/darkbloom-enclave' /tmp/darkbloom-bundle-files.txt
           grep -qx './bin/mlx.metallib' /tmp/darkbloom-bundle-files.txt
+          if grep -qx './bin/darkbloom-fan-helper' /tmp/darkbloom-bundle-files.txt; then
+            echo "::error::fan helper must not be present in the flat verifier layout"
+            exit 1
+          fi
+          grep -qx \
+            './Darkbloom.app/Contents/Helpers/darkbloom-fan-helper' \
+            /tmp/darkbloom-bundle-files.txt
+          grep -qx \
+            './Darkbloom.app/Contents/Resources/darkbloom-runtime-capabilities/fan-helper-v1' \
+            /tmp/darkbloom-bundle-files.txt
           while IFS= read -r bundle_name; do
             grep -qx \
               "./Darkbloom.app/Contents/Resources/${bundle_name}/" \
@@ -669,6 +703,22 @@ jobs:
           rm -rf "$SMOKE_ROOT"
           mkdir -p "$SMOKE_ROOT"
           tar xzf /tmp/darkbloom-bundle-macos-arm64.tar.gz -C "$SMOKE_ROOT"
+          FINAL_FAN_HELPER="$SMOKE_ROOT/Darkbloom.app/Contents/Helpers/$FAN_HELPER_NAME"
+          FINAL_FAN_MARKER="$SMOKE_ROOT/Darkbloom.app/Contents/Resources/darkbloom-runtime-capabilities/fan-helper-v1"
+          test -f "$FINAL_FAN_HELPER"
+          test ! -L "$FINAL_FAN_HELPER"
+          test -x "$FINAL_FAN_HELPER"
+          test "$(stat -f '%Lp' "$FINAL_FAN_HELPER")" = "755"
+          test -f "$FINAL_FAN_MARKER"
+          test ! -L "$FINAL_FAN_MARKER"
+          test "$(tr -d '[:space:]' < "$FINAL_FAN_MARKER")" = "1"
+          LC_ALL=C grep -a -q -F 'darkbloom-fan-helper-v1' \
+            "$SMOKE_ROOT/Darkbloom.app/Contents/MacOS/$CLI_NAME"
+          FAN_HELPER_REQUIREMENT="anchor apple generic and identifier \"$FAN_HELPER_ID\" and certificate leaf[subject.OU] = \"$APPLE_TEAM_ID\""
+          codesign --verify --strict --verbose=2 \
+            "-R=$FAN_HELPER_REQUIREMENT" "$FINAL_FAN_HELPER"
+          codesign --verify --deep --strict --verbose=2 \
+            "$SMOKE_ROOT/Darkbloom.app"
           DARKBLOOM_NO_UPDATE_CHECK=1 \
             "$SMOKE_ROOT/Darkbloom.app/Contents/MacOS/$CLI_NAME" runtime-smoke
 

--- a/coordinator/api/install.sh
+++ b/coordinator/api/install.sh
@@ -26,6 +26,8 @@ COORD_URL="${COORD_URL:-__DARKBLOOM_COORD_URL__}"
 INSTALL_DIR="$HOME/.darkbloom"
 BIN_DIR="$INSTALL_DIR/bin"
 DARKBLOOM_DESIGNATED_REQUIREMENT='anchor apple generic and identifier "io.darkbloom.provider" and certificate leaf[subject.OU] = "SLDQ2GJ6TL"'
+DARKBLOOM_FAN_HELPER_REQUIREMENT='anchor apple generic and identifier "io.darkbloom.fan-helper" and certificate leaf[subject.OU] = "SLDQ2GJ6TL"'
+FAN_HELPER_REQUIREMENT="$DARKBLOOM_FAN_HELPER_REQUIREMENT"
 INSTALL_TEST_MODE=0
 
 fail_install() {
@@ -74,6 +76,45 @@ binary_contains_paged_code() {
     LC_ALL=C grep -a -q -F 'engine_v2_kv_backend' "$binary"
 }
 
+verify_fan_helper_capability() {
+    local app=$1
+    local executable="$app/Contents/MacOS/darkbloom"
+    local marker="$app/Contents/Resources/darkbloom-runtime-capabilities/fan-helper-v1"
+    local helper="$app/Contents/Helpers/darkbloom-fan-helper"
+    local code_present=0
+    local marker_present=0
+    local helper_present=0
+
+    LC_ALL=C grep -a -q -F 'darkbloom-fan-helper-v1' "$executable" \
+        && code_present=1
+    if [ -e "$marker" ] || [ -L "$marker" ]; then marker_present=1; fi
+    if [ -e "$helper" ] || [ -L "$helper" ]; then helper_present=1; fi
+    [ "$code_present" -eq "$marker_present" ] \
+        && [ "$marker_present" -eq "$helper_present" ] || {
+        fail_install "Fan-helper CLI capability, marker, and nested helper must be present together."
+        return 1
+    }
+    [ "$marker_present" -eq 1 ] || return 0
+
+    [ -f "$marker" ] && [ ! -L "$marker" ] \
+        && [ "$(tr -d '[:space:]' < "$marker")" = "1" ] || {
+        fail_install "Fan-helper capability marker is invalid."
+        return 1
+    }
+    [ -f "$helper" ] && [ ! -L "$helper" ] && [ -x "$helper" ] || {
+        fail_install "Bundled fan helper must be a regular executable, not a symlink."
+        return 1
+    }
+    [ "$(stat -f '%Lp' "$helper" 2>/dev/null || true)" = "755" ] || {
+        fail_install "Bundled fan helper must have mode 0755."
+        return 1
+    }
+    verify_code_requirement "$helper" 0 "$FAN_HELPER_REQUIREMENT" || {
+        fail_install "Bundled fan helper does not satisfy the pinned helper signature requirement."
+        return 1
+    }
+}
+
 verify_staged_app() {
     local app=$1
     local executable="$app/Contents/MacOS/darkbloom"
@@ -87,6 +128,7 @@ verify_staged_app() {
     else
         verify_staged_app_signature "$app" || return 1
     fi
+    verify_fan_helper_capability "$app" || return 1
 
     local code_has_paged=0
     local marker_present=0
@@ -279,11 +321,12 @@ if [ "${1:-}" = "--verify-staged-app-signature-test" ]; then
 fi
 
 if [ "${1:-}" = "--install-bundle-test" ]; then
-    [ "$#" -eq 5 ] || {
-        echo "usage: $0 --install-bundle-test <archive> <install-dir> <binary-hash> <metallib-hash>" >&2
+    { [ "$#" -eq 5 ] || [ "$#" -eq 6 ]; } || {
+        echo "usage: $0 --install-bundle-test <archive> <install-dir> <binary-hash> <metallib-hash> [fan-helper-requirement]" >&2
         exit 64
     }
     INSTALL_TEST_MODE=1
+    if [ "$#" -eq 6 ]; then FAN_HELPER_REQUIREMENT=$6; fi
     install_bundle_atomically "$2" "$3" "$4" "$5"
     exit $?
 fi

--- a/coordinator/api/install_sh_test.go
+++ b/coordinator/api/install_sh_test.go
@@ -107,6 +107,33 @@ func TestInstallScriptTemplating(t *testing.T) {
 			t.Error("install.sh does not install the Secure Enclave helper")
 		}
 	})
+
+	t.Run("fan helper is verified but never privileged-installed", func(t *testing.T) {
+		srv := newTestServerWithBaseURL(t, "https://api.dev.darkbloom.xyz")
+		defer srv.Close()
+
+		body := fetchInstallScript(t, srv.URL)
+		for _, required := range []string{
+			"fan-helper-v1",
+			"Contents/Helpers/darkbloom-fan-helper",
+			`identifier "io.darkbloom.fan-helper"`,
+			`certificate leaf[subject.OU] = "SLDQ2GJ6TL"`,
+		} {
+			if !strings.Contains(body, required) {
+				t.Errorf("install.sh is missing fan-helper verification %q", required)
+			}
+		}
+		for _, forbidden := range []string{
+			"sudo ",
+			"launchctl",
+			"/Library/PrivilegedHelperTools",
+			"/Library/LaunchDaemons",
+		} {
+			if strings.Contains(body, forbidden) {
+				t.Errorf("ordinary install.sh performs privileged fan activation via %q", forbidden)
+			}
+		}
+	})
 }
 
 func newTestServerWithBaseURL(t *testing.T, baseURL string) *httptest.Server {

--- a/coordinator/api/server.go
+++ b/coordinator/api/server.go
@@ -144,7 +144,7 @@ func keyLimitResetFromContext(ctx context.Context) string {
 // 0.6.0 is the APNs code-identity / VLM-routing / graceful-update release.
 // Keep this fallback in sync with ProviderCore.version so dev/in-memory
 // coordinators advertise the same floor as the Swift binary they expect.
-var LatestProviderVersion = "0.7.8"
+var LatestProviderVersion = "0.7.9"
 
 // minProviderVersionForDesiredModels is the first provider version whose Swift
 // runtime understands the desired_models message. The coordinator must NOT send

--- a/docs/architecture/components/provider.md
+++ b/docs/architecture/components/provider.md
@@ -1,6 +1,6 @@
 # Provider
 
-The provider is the Apple Silicon Mac node that runs inference. It is implemented in Swift as the `darkbloom` CLI, with shared logic in `ProviderCore` and a small `darkbloom-enclave` helper for attestation/signing operations. The provider connects outbound to the coordinator over WebSocket, decrypts prompts in-process, runs inference via `mlx-swift-lm`, and encrypts responses back to the coordinator.
+The provider is the Apple Silicon Mac node that runs inference. It is implemented in Swift as the `darkbloom` CLI, with shared logic in `ProviderCore`, a small `darkbloom-enclave` helper for attestation/signing operations, and an optional minimal root helper for experimental fan control. The provider connects outbound to the coordinator over WebSocket, decrypts prompts in-process, runs inference via `mlx-swift-lm`, and encrypts responses back to the coordinator.
 
 The provider is the decryption endpoint for prompts. Its hardened process and Secure Enclave-bound identity are the core privacy guarantee.
 
@@ -18,12 +18,13 @@ The provider is the decryption endpoint for prompts. Its hardened process and Se
 | Crypto: NaCl Box, node keypair, response encryption | `provider-swift/Sources/ProviderCore/Crypto/NodeKeyPair.swift`, `X25519ChaChaPoly.swift` |
 | KV cache, prefix caching, disk accounting | `provider-swift/Sources/ProviderCore/KVCache/` |
 | Security hardening: anti-debug, env scrub, SIP checks | `provider-swift/Sources/ProviderCore/Security/SecurityHardening.swift`, `EnvironmentScrubber.swift`, `AntiDebug.swift` |
+| Opt-in fan policy, AppleSMC access, signed provider lease | `provider-swift/Sources/DarkbloomFanCore/`, `DarkbloomFanHelper/`, `darkbloom/FanActivityLease.swift` |
 
 ## Key modules
 
 ### CLI (`provider-swift/Sources/darkbloom/`)
 
-`main.swift` is the entry point. Long-running serve modes (`start --foreground`, `start --local`) are hosted under an `NSApplication(.accessory)` run loop so the process can receive APNs code-identity pushes; other commands run through ArgumentParser's async dispatch. `Darkbloom.swift` declares the top-level `AsyncParsableCommand` with subcommands: `start`, `stop`, `restart`, `status`, `doctor`, `models`, `login`, `logout`, `benchmark`, `update`, `verify`, `enroll`, `unenroll`, `logs`, `report`, `autoupdate`, `watchdog`, and `local`.
+`main.swift` is the entry point. Long-running serve modes (`start --foreground`, `start --local`) are hosted under an `NSApplication(.accessory)` run loop so the process can receive APNs code-identity pushes; other commands run through ArgumentParser's async dispatch. `Darkbloom.swift` declares the top-level `AsyncParsableCommand`, including the opt-in experimental `fan` command.
 
 ### ProviderCore
 
@@ -46,6 +47,21 @@ APNs code-identity attestation (v0.6.0+) is implemented in `ProviderCore/Apns/AP
 
 `provider-swift/Sources/darkbloom-enclave-cli/` is a small executable that wraps Secure Enclave attestation/signing helpers. It is used by `install.sh` to render an attestation blob before the main provider daemon is running. Subcommands include `attest`, `sign`, `info`, and `wallet-address`.
 
+### Experimental fan helper
+
+`provider-swift/Sources/DarkbloomFanHelper/` is a separate root LaunchDaemon that
+can write only the fan-related AppleSMC keys exposed by `DarkbloomFanCore`. It is
+not installed during ordinary provider setup. Explicit `sudo darkbloom fan
+enable` copies the independently signed executable to
+`/Library/PrivilegedHelperTools` and binds it to one provider UID.
+
+The helper accepts an activity lease only from the exact Darkbloom Developer ID
+team and provider signing identifier. It receives no prompts, model data,
+credentials, or network access. Lease expiry, XPC invalidation, sleep, thermal
+pressure, and write failures restore macOS automatic fan mode. The boundary is
+defined in `DarkbloomFanProtocol/FanIPC.swift`, `DarkbloomFanService/`, and
+`DarkbloomFanHelper/FanXPCService.swift`.
+
 ## Privacy-relevant boundaries
 
 - **Provider as decryption endpoint**: The provider's X25519 private key is generated in-process and never leaves the Mac. Only this process can open the coordinator's per-request NaCl Box. See `Crypto/NodeKeyPair.swift` and the decryption path in `ProviderLoop.swift`.
@@ -53,6 +69,7 @@ APNs code-identity attestation (v0.6.0+) is implemented in `ProviderCore/Apns/AP
 - **Secure Enclave binding**: The SE P-256 identity and the X25519 node key are bound to the provider binary and machine. Attestation challenges prove liveness and fresh SIP/Secure Boot status.
 - **Memory and disk**: Model weights and live KV use unified memory. The default prefix-cache tier stores encrypted blocks on SSD with a Secure-Enclave-wrapped KEK and leaves serving RAM for live KV. See `KVCacheSSD/SSDPrefixCache.swift`, `KVCache/EncryptedKVStore.swift`, and `KVCache/SecureEnclaveKeyWrappingService.swift`.
 - **No prompt logging**: The provider decrypts prompts only to feed the inference engine. It does not log prompt content; logs contain request IDs, model IDs, and token counts.
+- **Fan-helper IPC**: Optional fan control adds a semantic local XPC lease, not an inference IPC path. The root helper cannot receive prompt or key material and exposes no arbitrary SMC operation.
 
 For the hop-by-hop encryption model, see [`../security/encryption.md`](../security/encryption.md) and the coordinator-side description in [`coordinator.md`](coordinator.md).
 

--- a/docs/developer/release.md
+++ b/docs/developer/release.md
@@ -7,8 +7,8 @@ The provider bundle is built and signed in CI via
 
 High-level flow:
 
-1. Build the `darkbloom` and `darkbloom-enclave` binaries.
-2. Sign with the Developer ID Application certificate.
+1. Build `darkbloom`, `darkbloom-enclave`, and `darkbloom-fan-helper`.
+2. Sign each nested executable with its own identifier, then sign the outer app with the Developer ID Application certificate.
 3. Notarize with Apple.
 4. Compute SHA-256 hashes **after** code signing.
 5. Upload to R2.
@@ -17,11 +17,16 @@ High-level flow:
 > **Important:** hashes must be computed after code signing, not before.
 > Providers verify the hash of the signed binary during install.
 
-Scripts:
+Bundle creation, resource staging, helper signing, notarization, and final
+archive checks live inline in `.github/workflows/release-swift.yml`; there are no
+standalone bundle scripts. `scripts/install.sh` is the end-user installer served
+by the coordinator.
 
-- `scripts/build-bundle.sh` — bundle creation.
-- `scripts/bundle-app.sh` — .app bundle + DMG creation.
-- `scripts/install.sh` — end-user installer (served by coordinator).
+For v0.7.9+, the workflow places the fan helper only at
+`Darkbloom.app/Contents/Helpers/darkbloom-fan-helper`, signs it as
+`io.darkbloom.fan-helper` without provider APNs/keychain entitlements, and seals
+the `fan-helper-v1` capability marker. It must never appear in the flat `bin/`
+verifier layout or be privileged-installed by CI/the ordinary installer.
 
 ## Coordinator release
 
@@ -61,8 +66,9 @@ make ui-build
 
 ## Release-sensitive sync points
 
-- Provider bundle semantics: keep `scripts/build-bundle.sh`,
-  `scripts/install.sh`, and `LatestProviderVersion` in sync.
+- Provider bundle semantics: keep `.github/workflows/release-swift.yml`, both
+  installer copies, updater capability verification, and `LatestProviderVersion`
+  in sync.
 - Install paths or process invocation changes must update both the CLI and the
   install flow.
 - Model registry changes span coordinator registry, provider manifest code,

--- a/docs/provider/cli-reference.md
+++ b/docs/provider/cli-reference.md
@@ -227,6 +227,27 @@ darkbloom beta disable <feature>    # turn off
 is required. See [Beta Features](beta-features.md) for the full guide. `darkbloom
 beta list` also accepts `--json`.
 
+## `darkbloom fan` (experimental)
+
+Inspect or opt into provider-only temperature-based fan control.
+
+```bash
+darkbloom fan status [--json]
+darkbloom fan diagnose [--json]
+sudo darkbloom fan enable [--speed 80] [--temperature 45]
+sudo darkbloom fan configure [--speed 60...90] [--temperature C]
+sudo darkbloom fan disable
+sudo darkbloom fan uninstall
+```
+
+Ordinary Darkbloom installation leaves the bundled helper dormant. State changes
+require explicit `sudo`; read-only status and diagnostics do not. The helper
+applies a target only while a signed provider holds an activity lease and a
+validated GPU sensor exceeds the threshold. Defaults are 80% of each fan's
+reported maximum, engage at 45 C, and release below 40 C. See
+[Experimental Fan Control](fan-control.md) for hardware gates and recovery
+behavior.
+
 ## `darkbloom login`
 
 Link this machine to a Darkbloom account via RFC 8628 device-code flow.

--- a/docs/provider/fan-control.md
+++ b/docs/provider/fan-control.md
@@ -1,0 +1,143 @@
+# Experimental Fan Control
+
+`darkbloom fan` is an opt-in cooling controller for Apple Silicon provider Macs.
+It ships dormant: installing or updating Darkbloom does not request `sudo`, create
+root files, register a background service, or write to AppleSMC.
+
+This feature uses undocumented AppleSMC interfaces and is experimental. A Mac is
+eligible only when Darkbloom detects at least one fan and a known GPU-temperature
+sensor for its M1-M5 chip family. Fanless and unknown hardware remains under macOS
+automatic control.
+
+## Commands
+
+```bash
+# Read-only; no sudo required
+darkbloom fan status
+darkbloom fan diagnose --json
+
+# Explicit opt-in with defaults: 80% at 45 C
+sudo darkbloom fan enable
+
+# Normal targets are restricted to 60-90% of each fan's reported maximum
+sudo darkbloom fan configure --speed 70 --temperature 50
+
+# Both commands restore and verify macOS automatic control
+sudo darkbloom fan disable
+sudo darkbloom fan uninstall
+```
+
+`enable` must be run through `sudo` from the account that runs the provider. The
+numeric `SUDO_UID` and the account's directory-service `GeneratedUID` bind the
+system helper to that account; `$HOME` and `SUDO_USER` are not trusted for this decision
+(`provider-swift/Sources/darkbloom/Fan/FanServiceManager.swift`).
+
+## Control Policy
+
+The default policy is:
+
+| Setting | Default |
+|---|---|
+| Engage | Hottest validated GPU sensor at or above 45 C for 3 samples |
+| Release | All validated GPU readings at or below 40 C for 30 samples |
+| Target | 80% of each fan's reported maximum RPM |
+| User range | 60-90% |
+| Poll interval | 1 second |
+
+Darkbloom first captures each fan's actual, target, minimum, and maximum RPM. It
+never lowers the target present at takeover. If macOS already requests more than
+the configured percentage, that higher target is retained. Multi-fan changes are
+transactional: a partial mode or target failure restores every touched fan.
+
+The policy state machine is in
+`provider-swift/Sources/DarkbloomFanCore/FanPolicy.swift`; AppleSMC capability
+detection and writes are in `DarkbloomFanCore/FanHardware.swift` and
+`DarkbloomFanCore/FanController.swift`.
+
+## Provider-Only Lease
+
+Enabling the helper does not make it control every GPU workload. The signed
+provider opens an authenticated XPC session only while a Darkbloom serving loop
+is active:
+
+- Public and unified serving acquire a lease around `ProviderLoop.run()`.
+- Standalone local serving acquires a lease only after its HTTP socket binds.
+- A scheduled provider has no lease outside its availability window.
+- Benchmarks and unrelated applications do not acquire a lease.
+
+The provider renews every 5 seconds and the helper expires the lease after 15
+seconds. Provider stop, crash, schedule cancellation, XPC interruption, or a
+downgrade to a version without lease support restores automatic control. See
+`provider-swift/Sources/darkbloom/FanActivityLease.swift` and the call sites in
+`StartCommand+Modes.swift`.
+
+Both XPC peers pin the exact Developer ID team and signing identifiers using
+macOS code-signing requirements. The helper also requires the configured user ID.
+The interface exposes only lease, status, and root-only automatic restoration; it
+does not expose arbitrary SMC reads or writes
+(`DarkbloomFanProtocol/FanIPC.swift`, `DarkbloomFanHelper/FanXPCService.swift`).
+
+## Safety And Recovery
+
+The helper restores macOS automatic mode when:
+
+- the provider lease ends or expires;
+- GPU sensors disappear or return invalid data;
+- macOS reports serious or critical thermal pressure;
+- a mode, target, or verification write fails;
+- the machine sleeps or the helper receives a termination signal;
+- the administrator disables or uninstalls the feature.
+
+Before the first possible manual-mode write, the helper durably records the fan
+indices it may touch. A launchd restart after `SIGKILL` reads this root-owned
+journal and restores those fans before accepting a new lease. `Ftst` is cleared
+only when Darkbloom recorded possible ownership. The journal implementation is in
+`DarkbloomFanService/FanDurableFile.swift` and `FanOwnershipRecovery.swift`.
+
+Darkbloom refuses to take over a fan or global `Ftst` gate already held by
+another fan-control application. Stop that application and restore its Auto mode
+before enabling Darkbloom.
+
+## Privileged Files
+
+Explicit enablement creates only these root-owned files:
+
+| Path | Purpose |
+|---|---|
+| `/Library/PrivilegedHelperTools/io.darkbloom.fan-helper` | Minimal signed SMC helper |
+| `/Library/LaunchDaemons/io.darkbloom.fan.plist` | System launchd job |
+| `/Library/Application Support/Darkbloom/fan-policy.json` | Validated policy and provider UID |
+| `/Library/Application Support/Darkbloom/fan-session.json` | Crash-recovery ownership journal, present only while control may be active |
+
+The helper links only the fan core, XPC protocol, Foundation, IOKit, and Security.
+It has no coordinator client, network code, provider credentials, model access,
+or prompt access.
+
+## Updates And Rollback
+
+The signed application bundle contains a dormant helper, but the unprivileged
+self-updater never replaces the root-installed copy. A compatible helper keeps
+working; a protocol mismatch grants no lease and leaves the fans in Auto. Run
+`sudo darkbloom fan enable` again to install a newer bundled helper.
+
+The release workflow, installer, and self-updater require agreement between the
+CLI capability string, sealed `fan-helper-v1` marker, nested executable mode, and
+the helper's exact Developer ID signature. Pre-v0.7.9 bundles with none of these
+remain valid rollback targets.
+
+## Hardware Coverage
+
+The command is distributed to all supported Apple Silicon providers, but active
+control is capability-gated. GPU sensor names are private and change between chip
+families. `darkbloom fan diagnose --json` reports exactly which sensors and fans
+were detected. Do not describe a machine family as validated until a real-device
+test has covered engage, release, provider stop, sleep/wake, helper restart, and
+uninstall restoration.
+
+Current v0.7.9 evidence:
+
+| Hardware | Validation |
+|---|---|
+| M3 Max MacBook Pro (`Mac15,9`, macOS 26.4) | Active control validated: eight GPU sensors, per-fan 80% targets, provider-lease restoration, forced helper `SIGKILL` recovery, reconnect, and uninstall Auto verification |
+| M4 Max MacBook Pro (`Mac16,5`) | Read-only discovery validated; active control not yet exercised |
+| Other M1-M5 models | Catalog support is implemented but remains unvalidated; `enable` fails closed when required keys or plausible GPU sensors are absent |

--- a/docs/provider/hardware-requirements.md
+++ b/docs/provider/hardware-requirements.md
@@ -92,6 +92,9 @@ default).
 - Use `darkbloom status` and `darkbloom doctor` to check thermal state.
 - The provider calls `ProcessLifecycle.preventSystemSleep()` while serving so
   in-flight requests are not interrupted.
+- v0.7.9 adds optional experimental fan control. It requires a Mac that reports
+  at least one fan and a validated GPU sensor; fanless and unknown hardware stays
+  under macOS control. See [Experimental Fan Control](fan-control.md).
 
 ## macOS version support
 

--- a/docs/provider/installation.md
+++ b/docs/provider/installation.md
@@ -35,6 +35,12 @@ No `sudo` is required. The installer will try to create `/usr/local/bin/darkbloo
 as a convenience symlink, but it falls back to the shell `PATH` update if that
 fails.
 
+The v0.7.9+ app also contains a separately signed experimental fan helper under
+`Darkbloom.app/Contents/Helpers`. The installer verifies and preserves it but
+does not copy it into `/Library`, register launchd, request administrator access,
+or write AppleSMC. Only `sudo darkbloom fan enable` performs that separate opt-in
+step; see [Experimental Fan Control](fan-control.md).
+
 ## Manual install
 
 If you cannot run the curl installer:
@@ -122,6 +128,9 @@ Auto-update is controlled by `provider.auto_update` in `provider.toml`
 ## Uninstalling
 
 ```bash
+# If experimental fan control was enabled, restore Auto and remove it first
+sudo darkbloom fan uninstall
+
 # Stop the daemon and remove the launchd plist
 darkbloom stop --uninstall
 
@@ -135,6 +144,8 @@ rm -rf ~/.config/darkbloom
 
 `darkbloom stop --uninstall` (`provider-swift/Sources/darkbloom/StopCommand.swift`)
 disarms the crash-recovery watchdog and removes the launchd user agent.
+It deliberately does not remove the separately opted-in root fan helper; use the
+fan-specific uninstall command above.
 `darkbloom unenroll` opens System Settings → Device Management so you can remove
 the profile.
 

--- a/docs/threat-model.yaml
+++ b/docs/threat-model.yaml
@@ -18,6 +18,7 @@ scope:
     - Coordinator → Apple MDM / MDA trust services
     - Admin → Coordinator admin API
     - Provider in-process MLX inference engine
+    - Optional provider → privileged fan-helper XPC boundary and AppleSMC writes
     - Coordinator → Solana payment network
     - Apple attestation trust chain (cross-cutting)
   out_of_scope:
@@ -156,6 +157,16 @@ assets:
       Compromise lets an attacker sign profiles (and binaries) macOS treats as coming
       from the registered developer. Optional — when unset the coordinator serves
       profiles unsigned.
+
+  - id: A-014
+    name: provider_fan_control_authority
+    description: >
+      Root authority to place Apple Silicon fans into manual mode, set bounded
+      RPM targets, and temporarily assert the global Ftst fan-control gate.
+    sensitivity: high
+    notes: >
+      Dormant unless the operator explicitly runs sudo darkbloom fan enable.
+      Misuse can reduce cooling or interfere with macOS thermal management.
 
 # ─────────────────────────────────────────────────────────────
 # TRUST BOUNDARIES
@@ -727,6 +738,36 @@ trust_boundaries:
       - "The entire MDM→MDA trust upgrade path is asynchronous and runs in a background
         goroutine. A provider is routable at TrustSelfSigned during the window between
         registration and completion of the full verification chain."
+
+  - id: TB-010
+    name: provider_to_privileged_fan_helper
+    description: >
+      An optional root LaunchDaemon owns the AppleSMC fan-write connection. The
+      unprivileged provider may only renew a bounded activity lease or read status;
+      root may additionally request automatic restoration. The helper is outside
+      the user-writable provider install tree.
+    how_it_works: >
+      Explicit sudo enable verifies the separately signed nested helper and atomically
+      copies it to /Library/PrivilegedHelperTools/io.darkbloom.fan-helper, with a
+      root-owned LaunchDaemon plist and validated JSON policy. Both XPC peers use
+      NSXPCConnection code-signing requirements that pin Team SLDQ2GJ6TL and the
+      io.darkbloom.provider / io.darkbloom.fan-helper identifiers. The helper also
+      requires the configured numeric provider UID. The provider renews every five
+      seconds; expiry after fifteen seconds restores automatic mode. The root helper
+      exposes no arbitrary key/value SMC API and has no network, model, credential,
+      or prompt dependency. Before any manual-mode write it fsyncs a root-owned
+      ownership journal; launchd restart restores those fan indices before accepting
+      another lease.
+    current_limitations:
+      - "Apple does not publish stable GPU sensor names or fan-write semantics. Active
+        support is capability-gated by an explicit M1-M5 catalog and requires real-device
+        validation for each model family."
+      - "No process can catch SIGKILL. Safety after SIGKILL depends on launchd KeepAlive
+        restart plus the durable ownership journal; simultaneous helper death and
+        launchd disablement can leave manual state until reboot or administrator repair."
+      - "The root-installed helper is not replaced by the unprivileged self-updater.
+        Protocol mismatch intentionally leaves it dormant until the operator reruns
+        sudo darkbloom fan enable."
 
 # ─────────────────────────────────────────────────────────────
 # THREATS
@@ -2233,3 +2274,152 @@ threats:
       designated-requirement pin to structural codesign validity, or move the
       candidate-hung timeout below the operator's configured
       startup_preload_timeout_secs plus margin.
+
+  # ── TB-010: Provider → privileged fan helper ─────────────────
+
+  - id: T-044
+    trust_boundary: TB-010
+    stride: Elevation_of_Privilege
+    title: Untrusted local process impersonates the provider to the root fan helper
+    description: >
+      A local process that can acquire or renew a helper lease can cause root-owned
+      AppleSMC writes whenever the configured temperature threshold is met.
+    adversaries: [ADV-001]
+    affected_assets: [A-014]
+    affected_files:
+      - provider-swift/Sources/DarkbloomFanService/FanPeerAuthentication.swift
+      - provider-swift/Sources/DarkbloomFanHelper/FanXPCService.swift
+      - provider-swift/Sources/darkbloom/FanActivityLease.swift
+    mitigations:
+      - description: >
+          Production XPC connections mutually pin exact signing identifiers and
+          Developer ID Team SLDQ2GJ6TL using NSXPCConnection requirements; the
+          helper separately restricts peers to root or the configured numeric UID
+          whose directory-service GeneratedUID still matches the opt-in account.
+        status: implemented
+      - description: >
+          The exported protocol contains only lease, status, and root-only Auto
+          restoration operations; no arbitrary SMC write primitive exists.
+        status: implemented
+    open_findings: []
+    severity: high
+    detection_hint: >
+      Reopens if production accepts identifier-only/ad-hoc peers, trusts a PID or
+      user-controlled name instead of XPC credentials, or adds a generic SMC method.
+
+  - id: T-045
+    trust_boundary: TB-010
+    stride: Tampering
+    title: User-writable helper, plist, or policy turns launchd into root execution
+    description: >
+      A system LaunchDaemon that executes a binary or parses executable paths from a
+      provider-owned home directory would convert ordinary account access into root.
+    adversaries: [ADV-001]
+    affected_assets: [A-014]
+    affected_files:
+      - provider-swift/Sources/darkbloom/Fan/FanServiceManager.swift
+      - provider-swift/Sources/DarkbloomFanService/FanDurableFile.swift
+      - provider-swift/Sources/ProviderCore/Update/FanHelperCapabilityVerifier.swift
+    mitigations:
+      - description: >
+          The helper is copied to a fixed root:wheel 0755 path after exact signature
+          verification; plist and policy are fixed-path, root-owned, non-symlink files.
+        status: implemented
+      - description: >
+          Writes use same-directory temporary files, fchmod/fchown, fsync, atomic
+          rename, and parent-directory fsync. The helper rejects unsafe file metadata.
+        status: implemented
+    open_findings: []
+    severity: critical
+    detection_hint: >
+      Reopens if ProgramArguments points into ~/.darkbloom, a user supplies a path,
+      signature/ownership checks weaken, or config grows command/path fields.
+
+  - id: T-046
+    trust_boundary: TB-010
+    stride: Denial_of_Service
+    title: Helper crash or partial SMC write strands fans in manual mode
+    description: >
+      Manual mode and Ftst can outlive the process that asserted them. A failure
+      between multi-fan writes can also leave inconsistent fan state.
+    adversaries: [ADV-001]
+    affected_assets: [A-014]
+    affected_files:
+      - provider-swift/Sources/DarkbloomFanCore/FanController.swift
+      - provider-swift/Sources/DarkbloomFanHelper/FanDaemon.swift
+      - provider-swift/Sources/DarkbloomFanService/FanOwnershipRecovery.swift
+    mitigations:
+      - description: >
+          Controller writes are verified and transactional; any partial failure
+          restores every possibly touched fan and clears only possibly owned Ftst.
+        status: implemented
+      - description: >
+          A durable ownership journal is committed before the first possible SMC
+          mutation; KeepAlive restart reconciles it before XPC activation.
+        status: implemented
+      - description: >
+          Signal shutdown, sleep, administrator disable, and uninstall restore and
+          verify Auto. Uninstall refuses to delete recovery state if restoration fails.
+        status: implemented
+    open_findings: []
+    severity: high
+    detection_hint: >
+      Reopens if journal persistence moves after an SMC write, rollback stops after
+      the first fan error, or shutdown/uninstall deletes an unresolved journal.
+
+  - id: T-047
+    trust_boundary: TB-010
+    stride: Tampering
+    title: Stale provider or downgrade keeps privileged fan control active
+    description: >
+      Provider stop, schedule closure, update, rollback, or a hung process must not
+      leave a permanent root-authorized manual policy.
+    adversaries: [ADV-001]
+    affected_assets: [A-014]
+    affected_files:
+      - provider-swift/Sources/darkbloom/FanActivityLease.swift
+      - provider-swift/Sources/darkbloom/StartCommand+Modes.swift
+      - provider-swift/Sources/DarkbloomFanHelper/FanDaemon.swift
+    mitigations:
+      - description: >
+          Connection-scoped leases renew every five seconds and expire after fifteen;
+          invalidation and task cancellation request immediate restoration.
+        status: implemented
+      - description: >
+          Sleep revokes the lease and wake requires a fresh renewal. Protocol mismatch
+          and rollback to pre-lease versions leave the helper dormant in Auto.
+        status: implemented
+    open_findings: []
+    severity: medium
+    detection_hint: >
+      Reopens if a lease becomes persistent, cancellation stops releasing it, or an
+      incompatible provider can trigger manual mode.
+
+  - id: T-048
+    trust_boundary: TB-010
+    stride: Denial_of_Service
+    title: Incorrect private GPU sensor mapping applies an unsafe fan policy
+    description: >
+      Apple changes private SMC sensor names by chip family. A wrong or stale mapping
+      can engage too early, fail to cool, or hold a manual ceiling while another
+      component overheats.
+    adversaries: []
+    affected_assets: [A-014]
+    affected_files:
+      - provider-swift/Sources/DarkbloomFanCore/FanHardware.swift
+      - provider-swift/Sources/DarkbloomFanCore/FanPolicy.swift
+      - provider-swift/Sources/DarkbloomFanHelper/FanDaemon.swift
+    mitigations:
+      - description: >
+          Explicit M1-M5 allowlists, runtime key/type probing, finite plausible-value
+          checks, missing-sensor fail-safe, and read-only diagnose output.
+        status: implemented
+      - description: >
+          Takeover never lowers the existing target; serious/critical macOS thermal
+          pressure, invalid readings, or control failures restore system Auto.
+        status: implemented
+    open_findings: []
+    severity: medium
+    detection_hint: >
+      Every new chip/model or macOS release needs GPU-load correlation and full
+      engage/release/restore hardware validation before support is claimed.

--- a/provider-swift/Package.swift
+++ b/provider-swift/Package.swift
@@ -10,7 +10,11 @@ let package = Package(
     products: [
         .library(name: "ProviderCoreFoundation", targets: ["ProviderCoreFoundation"]),
         .library(name: "ProviderCore", targets: ["ProviderCore"]),
+        .library(name: "DarkbloomFanCore", targets: ["DarkbloomFanCore"]),
+        .library(name: "DarkbloomFanProtocol", targets: ["DarkbloomFanProtocol"]),
+        .library(name: "DarkbloomFanService", targets: ["DarkbloomFanService"]),
         .executable(name: "darkbloom", targets: ["darkbloom"]),
+        .executable(name: "darkbloom-fan-helper", targets: ["DarkbloomFanHelper"]),
         .executable(name: "darkbloom-enclave", targets: ["DarkbloomEnclaveCLI"]),
         .executable(name: "darkbloom-publish", targets: ["darkbloom-publish"]),
     ],
@@ -50,6 +54,31 @@ let package = Package(
         .package(url: "https://github.com/hummingbird-project/hummingbird-websocket.git", exact: "2.6.0"),
     ],
     targets: [
+        .target(
+            name: "DarkbloomFanCore",
+            path: "Sources/DarkbloomFanCore",
+            linkerSettings: [.linkedFramework("IOKit")]
+        ),
+        .target(
+            name: "DarkbloomFanProtocol",
+            path: "Sources/DarkbloomFanProtocol"
+        ),
+        .target(
+            name: "DarkbloomFanService",
+            dependencies: ["DarkbloomFanCore", "DarkbloomFanProtocol"],
+            path: "Sources/DarkbloomFanService",
+            linkerSettings: [.linkedFramework("Security")]
+        ),
+        .executableTarget(
+            name: "DarkbloomFanHelper",
+            dependencies: [
+                "DarkbloomFanCore",
+                "DarkbloomFanProtocol",
+                "DarkbloomFanService",
+            ],
+            path: "Sources/DarkbloomFanHelper"
+        ),
+
         // ----------------------------------------------------------------
         // ProviderCoreFoundation: Linux-buildable subset containing the
         // model hashing primitives (ModelScanner file discovery,
@@ -125,6 +154,9 @@ let package = Package(
         .executableTarget(
             name: "darkbloom",
             dependencies: [
+                "DarkbloomFanCore",
+                "DarkbloomFanProtocol",
+                "DarkbloomFanService",
                 "ProviderCore",
                 "ProviderBenchmark",
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
@@ -192,6 +224,31 @@ let package = Package(
             name: "ProviderCoreFoundationTests",
             dependencies: ["ProviderCoreFoundation"],
             path: "Tests/ProviderCoreFoundationTests"
+        ),
+
+        .testTarget(
+            name: "DarkbloomFanCoreTests",
+            dependencies: ["DarkbloomFanCore"],
+            path: "Tests/DarkbloomFanCoreTests"
+        ),
+        .testTarget(
+            name: "DarkbloomFanServiceTests",
+            dependencies: [
+                "DarkbloomFanCore",
+                "DarkbloomFanProtocol",
+                "DarkbloomFanService",
+            ],
+            path: "Tests/DarkbloomFanServiceTests"
+        ),
+        .testTarget(
+            name: "DarkbloomFanHelperTests",
+            dependencies: [
+                "DarkbloomFanCore",
+                "DarkbloomFanHelper",
+                "DarkbloomFanProtocol",
+                "DarkbloomFanService",
+            ],
+            path: "Tests/DarkbloomFanHelperTests"
         ),
 
         // ----------------------------------------------------------------

--- a/provider-swift/Sources/DarkbloomFanCore/FanController.swift
+++ b/provider-swift/Sources/DarkbloomFanCore/FanController.swift
@@ -173,7 +173,11 @@ public actor TransactionalFanController {
     }
 
     @discardableResult
-    public func engage(speedPercent: Double) throws -> FanControlSession {
+    public func engage(
+        speedPercent: Double,
+        beforeFanWrite: @Sendable () throws -> Void = {},
+        beforeFtstWrite: @Sendable () throws -> Void = {}
+    ) throws -> FanControlSession {
         let allowedSpeed = FanPolicyConfiguration.minimumSpeedPercent...FanPolicyConfiguration.maximumSpeedPercent
         guard speedPercent.isFinite,
               allowedSpeed.contains(speedPercent)
@@ -237,6 +241,10 @@ public actor TransactionalFanController {
         }
 
         do {
+            // All foreign-ownership and capability checks are complete. Record
+            // possible ownership immediately before the first fan-mode write,
+            // which may land even if the backend reports an error.
+            try beforeFanWrite()
             for reading in readings {
                 let fan = reading.capability
                 // Mark intent before the first mode write. A backend can fail
@@ -250,7 +258,7 @@ public actor TransactionalFanController {
                     guard shouldAttemptFtst(after: directFailure) else {
                         throw directFailure
                     }
-                    try acquireFtstIfNeeded()
+                    try acquireFtstIfNeeded(beforeFtstWrite: beforeFtstWrite)
                     try retryManualMode(fan)
                 }
                 guard let target = targets[fan.index] else {
@@ -260,7 +268,9 @@ public actor TransactionalFanController {
                 targetRPMByFan[fan.index] = target
             }
 
-            try verifyFtstOwnershipAtTransactionEnd()
+            try verifyFtstOwnershipAtTransactionEnd(
+                beforeFtstWrite: beforeFtstWrite
+            )
 
             return FanControlSession(
                 targetRPMByFan: targetRPMByFan,
@@ -294,7 +304,9 @@ public actor TransactionalFanController {
     /// with engage/restore. Any failure restores every tracked fan to automatic
     /// control rather than leaving a partially repaired session active.
     @discardableResult
-    public func maintain() throws -> FanControlSession {
+    public func maintain(
+        beforeFtstWrite: @Sendable () throws -> Void = {}
+    ) throws -> FanControlSession {
         guard isControlling else {
             throw FanControllerError.notControlling
         }
@@ -317,7 +329,7 @@ public actor TransactionalFanController {
             // Reassert a gate that this session already owns before touching
             // individual modes.
             if mayOwnFtst {
-                try acquireFtstIfNeeded()
+                try acquireFtstIfNeeded(beforeFtstWrite: beforeFtstWrite)
             }
 
             for fan in possiblyControlledFans.values.sorted(by: { $0.index < $1.index }) {
@@ -334,7 +346,7 @@ public actor TransactionalFanController {
                         guard shouldAttemptFtst(after: directFailure) else {
                             throw directFailure
                         }
-                        try acquireFtstIfNeeded()
+                        try acquireFtstIfNeeded(beforeFtstWrite: beforeFtstWrite)
                         try retryManualMode(fan)
                     }
                 case .unknown(let value):
@@ -345,7 +357,9 @@ public actor TransactionalFanController {
                 }
                 try writeAndVerifyTarget(fan, rpm: target)
             }
-            try verifyFtstOwnershipAtTransactionEnd()
+            try verifyFtstOwnershipAtTransactionEnd(
+                beforeFtstWrite: beforeFtstWrite
+            )
 
             return FanControlSession(
                 targetRPMByFan: targetRPMByFan,
@@ -412,7 +426,9 @@ public actor TransactionalFanController {
         )
     }
 
-    private func acquireFtstIfNeeded() throws {
+    private func acquireFtstIfNeeded(
+        beforeFtstWrite: @Sendable () throws -> Void
+    ) throws {
         guard let ftstKey = inventory.ftstKey else {
             throw FanControllerError.smc(.keyNotFound("Ftst"))
         }
@@ -424,8 +440,10 @@ public actor TransactionalFanController {
             throw FanControllerError.foreignFtst(rawValue: initial)
         }
 
-        // From this point onward a thrown write may still have landed. Mark the
-        // gate as ours before issuing it so rollback always attempts to clear it.
+        // The caller durably records possible ownership only after we know the
+        // gate is free, immediately before the first write that may still land
+        // despite throwing. Then mirror that intent in memory for rollback.
+        try beforeFtstWrite()
         mayOwnFtst = true
         do {
             try backend.write(ftstKey, bytes: [1])
@@ -446,7 +464,9 @@ public actor TransactionalFanController {
         }
     }
 
-    private func verifyFtstOwnershipAtTransactionEnd() throws {
+    private func verifyFtstOwnershipAtTransactionEnd(
+        beforeFtstWrite: @Sendable () throws -> Void
+    ) throws {
         guard let ftstKey = inventory.ftstKey else { return }
         if mayOwnFtst {
             let current = try readUI8(ftstKey)
@@ -454,6 +474,7 @@ public actor TransactionalFanController {
                 throw FanControllerError.foreignFtst(rawValue: current)
             }
             if current == 0 {
+                try beforeFtstWrite()
                 try backend.write(ftstKey, bytes: [1])
                 timing.sleep(timing.ftstSettleSeconds)
                 let refreshed = try readUI8(ftstKey)

--- a/provider-swift/Sources/DarkbloomFanCore/FanController.swift
+++ b/provider-swift/Sources/DarkbloomFanCore/FanController.swift
@@ -55,6 +55,7 @@ public struct FanControlOwnership: Equatable, Sendable {
 public enum FanRollbackStep: String, Equatable, Codable, Sendable {
     case restoreMode
     case clearFtst
+    case persistOwnership
 }
 
 public enum FanRollbackError: Error, Equatable, Sendable, CustomStringConvertible {
@@ -62,6 +63,7 @@ public enum FanRollbackError: Error, Equatable, Sendable, CustomStringConvertibl
     case hardware(FanHardwareError)
     case modeNotAutomatic(rawValue: UInt8)
     case ftstStillSet(rawValue: UInt8)
+    case persistence(String)
 
     public var description: String {
         switch self {
@@ -69,6 +71,7 @@ public enum FanRollbackError: Error, Equatable, Sendable, CustomStringConvertibl
         case .hardware(let error): return error.description
         case .modeNotAutomatic(let value): return "fan mode remained \(value)"
         case .ftstStillSet(let value): return "Ftst remained \(value)"
+        case .persistence(let detail): return detail
         }
     }
 }
@@ -281,11 +284,33 @@ public actor TransactionalFanController {
                     try acquireFtstIfNeeded(recordOwnership: recordOwnership)
                     try retryManualMode(fan)
                 }
-                guard let target = targets[fan.index] else {
+                guard let precomputedTarget = targets[fan.index] else {
                     throw FanControllerError.incompleteSession(index: fan.index)
                 }
-                try writeAndVerifyTarget(fan, rpm: target)
-                targetRPMByFan[fan.index] = target
+                // Re-read the takeover floor after manual mode is verified.
+                // The OS or another controller may have raised actual/target
+                // RPM since the initial snapshot; never write an older floor.
+                let liveActual = try readRPM(
+                    fan.actualKey,
+                    fanIndex: fan.index
+                )
+                let liveTarget = try readRPM(
+                    fan.targetKey,
+                    fanIndex: fan.index
+                )
+                let finalTarget = max(
+                    precomputedTarget,
+                    max(liveActual, liveTarget)
+                )
+                guard finalTarget <= reading.maximumRPM else {
+                    throw FanControllerError.takeoverFloorExceedsMaximum(
+                        index: fan.index,
+                        floor: finalTarget,
+                        maximum: reading.maximumRPM
+                    )
+                }
+                try writeAndVerifyTarget(fan, rpm: finalTarget)
+                targetRPMByFan[fan.index] = finalTarget
             }
 
             try verifyFtstOwnershipAtTransactionEnd(
@@ -298,7 +323,7 @@ public actor TransactionalFanController {
             )
         } catch {
             let primary = normalize(error)
-            let failures = restoreTrackedState()
+            let failures = restoreTrackedState(recordOwnership: recordOwnership)
             if !failures.isEmpty {
                 throw FanControllerError.rollbackFailed(
                     primary: primary,
@@ -309,8 +334,10 @@ public actor TransactionalFanController {
         }
     }
 
-    public func restoreAutomatic() throws {
-        let failures = restoreTrackedState()
+    public func restoreAutomatic(
+        recordOwnership: @Sendable (FanControlOwnership) throws -> Void = { _ in }
+    ) throws {
+        let failures = restoreTrackedState(recordOwnership: recordOwnership)
         if !failures.isEmpty {
             throw FanControllerError.rollbackFailed(
                 primary: .smc(.injectedFailure("explicit automatic restore")),
@@ -331,7 +358,7 @@ public actor TransactionalFanController {
             throw FanControllerError.notControlling
         }
         guard !possiblyControlledFans.isEmpty else {
-            let failures = restoreTrackedState()
+            let failures = restoreTrackedState(recordOwnership: recordOwnership)
             if !failures.isEmpty {
                 throw FanControllerError.rollbackFailed(
                     primary: .notControlling,
@@ -404,7 +431,7 @@ public actor TransactionalFanController {
             )
         } catch {
             let primary = normalize(error)
-            let failures = restoreTrackedState()
+            let failures = restoreTrackedState(recordOwnership: recordOwnership)
             if !failures.isEmpty {
                 throw FanControllerError.rollbackFailed(
                     primary: primary,
@@ -586,7 +613,9 @@ public actor TransactionalFanController {
         )
     }
 
-    private func restoreTrackedState() -> [FanRollbackFailure] {
+    private func restoreTrackedState(
+        recordOwnership: @Sendable (FanControlOwnership) throws -> Void = { _ in }
+    ) -> [FanRollbackFailure] {
         var failures: [FanRollbackFailure] = []
         var stillUncertain: [Int: FanCapability] = [:]
 
@@ -639,6 +668,21 @@ public actor TransactionalFanController {
             ftstStillUncertain = true
         }
 
+        do {
+            try recordOwnership(FanControlOwnership(
+                fanIndices: Array(stillUncertain.keys),
+                ownsFtst: ftstStillUncertain
+            ))
+        } catch {
+            failures.append(FanRollbackFailure(
+                fanIndex: nil,
+                step: .persistOwnership,
+                error: .persistence(String(describing: error))
+            ))
+            // Disk still describes the broader pre-rollback ownership. Keep
+            // memory equally conservative so the next retry cannot omit it.
+            return failures
+        }
         possiblyControlledFans = stillUncertain
         targetRPMByFan = targetRPMByFan.filter { stillUncertain[$0.key] != nil }
         mayOwnFtst = ftstStillUncertain

--- a/provider-swift/Sources/DarkbloomFanCore/FanController.swift
+++ b/provider-swift/Sources/DarkbloomFanCore/FanController.swift
@@ -1,0 +1,609 @@
+import Foundation
+
+public struct FanControlTiming: Sendable {
+    public let ftstSettleSeconds: TimeInterval
+    public let retryDelaySeconds: TimeInterval
+    public let manualModeAttempts: Int
+    public let verificationAttempts: Int
+    public let sleep: @Sendable (TimeInterval) -> Void
+
+    public init(
+        ftstSettleSeconds: TimeInterval = 0.5,
+        retryDelaySeconds: TimeInterval = 0.1,
+        manualModeAttempts: Int = 100,
+        verificationAttempts: Int = 3,
+        sleep: @escaping @Sendable (TimeInterval) -> Void = {
+            Thread.sleep(forTimeInterval: $0)
+        }
+    ) {
+        precondition(ftstSettleSeconds >= 0)
+        precondition(retryDelaySeconds >= 0)
+        precondition(manualModeAttempts > 0)
+        precondition(verificationAttempts > 0)
+        self.ftstSettleSeconds = ftstSettleSeconds
+        self.retryDelaySeconds = retryDelaySeconds
+        self.manualModeAttempts = manualModeAttempts
+        self.verificationAttempts = verificationAttempts
+        self.sleep = sleep
+    }
+
+    public static let production = FanControlTiming()
+}
+
+public struct FanControlSession: Equatable, Codable, Sendable {
+    public let targetRPMByFan: [Int: Double]
+    public let ownsFtst: Bool
+
+    public init(targetRPMByFan: [Int: Double], ownsFtst: Bool) {
+        self.targetRPMByFan = targetRPMByFan
+        self.ownsFtst = ownsFtst
+    }
+}
+
+public enum FanRollbackStep: String, Equatable, Codable, Sendable {
+    case restoreMode
+    case clearFtst
+}
+
+public enum FanRollbackError: Error, Equatable, Sendable, CustomStringConvertible {
+    case smc(SMCError)
+    case hardware(FanHardwareError)
+    case modeNotAutomatic(rawValue: UInt8)
+    case ftstStillSet(rawValue: UInt8)
+
+    public var description: String {
+        switch self {
+        case .smc(let error): return error.description
+        case .hardware(let error): return error.description
+        case .modeNotAutomatic(let value): return "fan mode remained \(value)"
+        case .ftstStillSet(let value): return "Ftst remained \(value)"
+        }
+    }
+}
+
+public struct FanRollbackFailure: Error, Equatable, Sendable, CustomStringConvertible {
+    public let fanIndex: Int?
+    public let step: FanRollbackStep
+    public let error: FanRollbackError
+
+    public init(fanIndex: Int?, step: FanRollbackStep, error: FanRollbackError) {
+        self.fanIndex = fanIndex
+        self.step = step
+        self.error = error
+    }
+
+    public var description: String {
+        "\(step.rawValue) \(fanIndex.map { "fan \($0)" } ?? "global"): \(error)"
+    }
+}
+
+public indirect enum FanControllerError: Error, Equatable, Sendable,
+    CustomStringConvertible
+{
+    case noFans
+    case invalidSpeedPercent(Double)
+    case alreadyControlling
+    case notControlling
+    case incompleteSession(index: Int)
+    case duplicateFanIndex(Int)
+    case foreignManualControl(indices: [Int])
+    case unknownFanMode(index: Int, rawValue: UInt8)
+    case foreignFtst(rawValue: UInt8)
+    case takeoverFloorExceedsMaximum(index: Int, floor: Double, maximum: Double)
+    case modeVerificationFailed(index: Int, rawValue: UInt8)
+    case targetVerificationFailed(index: Int, expected: Double, actual: Double)
+    case manualModeTimeout(index: Int, lastError: SMCError?)
+    case hardware(FanHardwareError)
+    case smc(SMCError)
+    case rollbackFailed(primary: FanControllerError, failures: [FanRollbackFailure])
+
+    public var description: String {
+        switch self {
+        case .noFans:
+            return "this Mac reports no controllable fans"
+        case .invalidSpeedPercent(let speed):
+            return "fan speed must be between 60 and 90 percent (got \(speed))"
+        case .alreadyControlling:
+            return "Darkbloom already owns a manual fan session"
+        case .notControlling:
+            return "Darkbloom does not own a manual fan session"
+        case .incompleteSession(let index):
+            return "Darkbloom has no stored target for tracked fan \(index)"
+        case .duplicateFanIndex(let index):
+            return "fan inventory contains duplicate index \(index)"
+        case .foreignManualControl(let indices):
+            return "refusing to replace foreign manual control of fans \(indices)"
+        case .unknownFanMode(let index, let rawValue):
+            return "fan \(index) reported unknown mode \(rawValue)"
+        case .foreignFtst(let rawValue):
+            return "refusing to claim pre-existing Ftst value \(rawValue)"
+        case .takeoverFloorExceedsMaximum(let index, let floor, let maximum):
+            return "fan \(index) takeover floor \(floor) exceeds maximum \(maximum)"
+        case .modeVerificationFailed(let index, let rawValue):
+            return "fan \(index) did not enter manual mode (read \(rawValue))"
+        case .targetVerificationFailed(let index, let expected, let actual):
+            return "fan \(index) target verification failed (expected \(expected), read \(actual))"
+        case .manualModeTimeout(let index, let lastError):
+            return "fan \(index) did not enter manual mode before timeout: \(lastError?.description ?? "no error")"
+        case .hardware(let error):
+            return error.description
+        case .smc(let error):
+            return error.description
+        case .rollbackFailed(let primary, let failures):
+            return "fan operation failed (\(primary)); rollback also failed: \(failures.map(\.description).joined(separator: "; "))"
+        }
+    }
+}
+
+public actor TransactionalFanController {
+    private static let targetToleranceRPM = 1.0
+
+    private let backend: any SMCBackend
+    private let inventory: FanInventory
+    private let reader: FanHardwareReader
+    private let timing: FanControlTiming
+
+    // A fan enters this map before its first possible mode write. Retaining it
+    // after a failed rollback lets a later restore retry repair uncertain state.
+    private var possiblyControlledFans: [Int: FanCapability] = [:]
+    private var targetRPMByFan: [Int: Double] = [:]
+    private var mayOwnFtst = false
+
+    public init(
+        backend: any SMCBackend,
+        inventory: FanInventory,
+        timing: FanControlTiming = .production
+    ) {
+        self.backend = backend
+        self.inventory = inventory
+        self.reader = FanHardwareReader(backend: backend)
+        self.timing = timing
+    }
+
+    public var isControlling: Bool {
+        !possiblyControlledFans.isEmpty || mayOwnFtst
+    }
+
+    public func currentSession() -> FanControlSession? {
+        guard isControlling else { return nil }
+        return FanControlSession(
+            targetRPMByFan: targetRPMByFan,
+            ownsFtst: mayOwnFtst
+        )
+    }
+
+    @discardableResult
+    public func engage(speedPercent: Double) throws -> FanControlSession {
+        let allowedSpeed = FanPolicyConfiguration.minimumSpeedPercent...FanPolicyConfiguration.maximumSpeedPercent
+        guard speedPercent.isFinite,
+              allowedSpeed.contains(speedPercent)
+        else {
+            throw FanControllerError.invalidSpeedPercent(speedPercent)
+        }
+        guard !isControlling else {
+            throw FanControllerError.alreadyControlling
+        }
+        guard !inventory.fans.isEmpty else {
+            throw FanControllerError.noFans
+        }
+
+        let readings: [FanReading]
+        do {
+            readings = try reader.fanReadings(in: inventory)
+        } catch {
+            throw normalize(error)
+        }
+        let foreign = readings.compactMap { $0.mode == .manual ? $0.capability.index : nil }
+        guard foreign.isEmpty else {
+            throw FanControllerError.foreignManualControl(indices: foreign.sorted())
+        }
+        for reading in readings {
+            if case .unknown(let rawValue) = reading.mode {
+                throw FanControllerError.unknownFanMode(
+                    index: reading.capability.index,
+                    rawValue: rawValue
+                )
+            }
+        }
+        var seenFanIndices = Set<Int>()
+        for reading in readings where !seenFanIndices.insert(reading.capability.index).inserted {
+            throw FanControllerError.duplicateFanIndex(reading.capability.index)
+        }
+        if let ftstKey = inventory.ftstKey {
+            let rawFtst = try readUI8(ftstKey)
+            guard rawFtst == 0 else {
+                throw FanControllerError.foreignFtst(rawValue: rawFtst)
+            }
+        }
+
+        var targets: [Int: Double] = [:]
+        for reading in readings {
+            let takeoverFloor = max(
+                reading.minimumRPM,
+                max(reading.actualRPM, reading.targetRPM)
+            )
+            guard takeoverFloor <= reading.maximumRPM else {
+                throw FanControllerError.takeoverFloorExceedsMaximum(
+                    index: reading.capability.index,
+                    floor: takeoverFloor,
+                    maximum: reading.maximumRPM
+                )
+            }
+            let requested = reading.maximumRPM * speedPercent / 100.0
+            targets[reading.capability.index] = min(
+                reading.maximumRPM,
+                max(requested, takeoverFloor)
+            )
+        }
+
+        do {
+            for reading in readings {
+                let fan = reading.capability
+                // Mark intent before the first mode write. A backend can fail
+                // after the kernel accepted a write, so "threw" is not proof
+                // that the fan stayed automatic.
+                possiblyControlledFans[fan.index] = fan
+                do {
+                    try writeAndVerifyManualMode(fan)
+                } catch {
+                    let directFailure = normalize(error)
+                    guard shouldAttemptFtst(after: directFailure) else {
+                        throw directFailure
+                    }
+                    try acquireFtstIfNeeded()
+                    try retryManualMode(fan)
+                }
+                guard let target = targets[fan.index] else {
+                    throw FanControllerError.incompleteSession(index: fan.index)
+                }
+                try writeAndVerifyTarget(fan, rpm: target)
+                targetRPMByFan[fan.index] = target
+            }
+
+            try verifyFtstOwnershipAtTransactionEnd()
+
+            return FanControlSession(
+                targetRPMByFan: targetRPMByFan,
+                ownsFtst: mayOwnFtst
+            )
+        } catch {
+            let primary = normalize(error)
+            let failures = restoreTrackedState()
+            if !failures.isEmpty {
+                throw FanControllerError.rollbackFailed(
+                    primary: primary,
+                    failures: failures
+                )
+            }
+            throw primary
+        }
+    }
+
+    public func restoreAutomatic() throws {
+        let failures = restoreTrackedState()
+        if !failures.isEmpty {
+            throw FanControllerError.rollbackFailed(
+                primary: .smc(.injectedFailure("explicit automatic restore")),
+                failures: failures
+            )
+        }
+    }
+
+    /// Reconcile a live session after firmware or thermalmonitord reclaimed a
+    /// fan mode/target (commonly across sleep/wake). Calls are actor-serialized
+    /// with engage/restore. Any failure restores every tracked fan to automatic
+    /// control rather than leaving a partially repaired session active.
+    @discardableResult
+    public func maintain() throws -> FanControlSession {
+        guard isControlling else {
+            throw FanControllerError.notControlling
+        }
+        guard !possiblyControlledFans.isEmpty else {
+            let failures = restoreTrackedState()
+            if !failures.isEmpty {
+                throw FanControllerError.rollbackFailed(
+                    primary: .notControlling,
+                    failures: failures
+                )
+            }
+            throw FanControllerError.notControlling
+        }
+
+        do {
+            for fan in possiblyControlledFans.values where targetRPMByFan[fan.index] == nil {
+                throw FanControllerError.incompleteSession(index: fan.index)
+            }
+            // Sleep can reset Ftst even before the per-fan mode read changes.
+            // Reassert a gate that this session already owns before touching
+            // individual modes.
+            if mayOwnFtst {
+                try acquireFtstIfNeeded()
+            }
+
+            for fan in possiblyControlledFans.values.sorted(by: { $0.index < $1.index }) {
+                let target = targetRPMByFan[fan.index]!
+                let rawMode = try readUI8(fan.modeKey)
+                switch FanMode(rawValue: rawMode) {
+                case .manual:
+                    break
+                case .automatic, .system:
+                    do {
+                        try writeAndVerifyManualMode(fan)
+                    } catch {
+                        let directFailure = normalize(error)
+                        guard shouldAttemptFtst(after: directFailure) else {
+                            throw directFailure
+                        }
+                        try acquireFtstIfNeeded()
+                        try retryManualMode(fan)
+                    }
+                case .unknown(let value):
+                    throw FanControllerError.unknownFanMode(
+                        index: fan.index,
+                        rawValue: value
+                    )
+                }
+                try writeAndVerifyTarget(fan, rpm: target)
+            }
+            try verifyFtstOwnershipAtTransactionEnd()
+
+            return FanControlSession(
+                targetRPMByFan: targetRPMByFan,
+                ownsFtst: mayOwnFtst
+            )
+        } catch {
+            let primary = normalize(error)
+            let failures = restoreTrackedState()
+            if !failures.isEmpty {
+                throw FanControllerError.rollbackFailed(
+                    primary: primary,
+                    failures: failures
+                )
+            }
+            throw primary
+        }
+    }
+
+    @discardableResult
+    public func reassert() throws -> FanControlSession {
+        try maintain()
+    }
+
+    private func writeAndVerifyManualMode(_ fan: FanCapability) throws {
+        do {
+            try backend.write(fan.modeKey, bytes: [FanMode.manual.rawValue])
+            let raw = try readUI8(fan.modeKey)
+            guard raw == FanMode.manual.rawValue else {
+                throw FanControllerError.modeVerificationFailed(
+                    index: fan.index,
+                    rawValue: raw
+                )
+            }
+        } catch {
+            throw normalize(error)
+        }
+    }
+
+    private func retryManualMode(_ fan: FanCapability) throws {
+        var lastError: SMCError?
+        for attempt in 0..<timing.manualModeAttempts {
+            do {
+                try writeAndVerifyManualMode(fan)
+                return
+            } catch let error as FanControllerError {
+                if case .smc(let smcError) = error {
+                    lastError = smcError
+                    if smcError.isNotPrivileged || smcError.isKeyNotFound {
+                        throw error
+                    }
+                } else if case .modeVerificationFailed = error {
+                    lastError = nil
+                } else {
+                    throw error
+                }
+            }
+            if attempt + 1 < timing.manualModeAttempts {
+                timing.sleep(timing.retryDelaySeconds)
+            }
+        }
+        throw FanControllerError.manualModeTimeout(
+            index: fan.index,
+            lastError: lastError
+        )
+    }
+
+    private func acquireFtstIfNeeded() throws {
+        guard let ftstKey = inventory.ftstKey else {
+            throw FanControllerError.smc(.keyNotFound("Ftst"))
+        }
+        let initial = try readUI8(ftstKey)
+        if mayOwnFtst, initial == 1 {
+            return
+        }
+        if initial != 0 {
+            throw FanControllerError.foreignFtst(rawValue: initial)
+        }
+
+        // From this point onward a thrown write may still have landed. Mark the
+        // gate as ours before issuing it so rollback always attempts to clear it.
+        mayOwnFtst = true
+        do {
+            try backend.write(ftstKey, bytes: [1])
+            // M3-class firmware applies Ftst asynchronously (and some builds
+            // expose it as an edge-trigger that still reads zero). The ensuing
+            // verified manual-mode transition is the authoritative proof.
+            timing.sleep(timing.ftstSettleSeconds)
+            let actual = try readUI8(ftstKey)
+            guard actual == 0 || actual == 1 else {
+                throw SMCError.firmwareRejected(
+                    operation: .writeBytes,
+                    key: ftstKey,
+                    result: actual
+                )
+            }
+        } catch {
+            throw normalize(error)
+        }
+    }
+
+    private func verifyFtstOwnershipAtTransactionEnd() throws {
+        guard let ftstKey = inventory.ftstKey else { return }
+        if mayOwnFtst {
+            let current = try readUI8(ftstKey)
+            guard current == 0 || current == 1 else {
+                throw FanControllerError.foreignFtst(rawValue: current)
+            }
+            if current == 0 {
+                try backend.write(ftstKey, bytes: [1])
+                timing.sleep(timing.ftstSettleSeconds)
+                let refreshed = try readUI8(ftstKey)
+                guard refreshed == 0 || refreshed == 1 else {
+                    throw FanControllerError.foreignFtst(rawValue: refreshed)
+                }
+            }
+            return
+        }
+        let rawFtst = try readUI8(ftstKey)
+        guard rawFtst == 0 else {
+            throw FanControllerError.foreignFtst(rawValue: rawFtst)
+        }
+    }
+
+    private func writeAndVerifyTarget(_ fan: FanCapability, rpm: Double) throws {
+        let bytes: [UInt8]
+        do {
+            bytes = try SMCValue.float32Bytes(rpm, key: fan.targetKey)
+            try backend.write(fan.targetKey, bytes: bytes)
+        } catch {
+            throw normalize(error)
+        }
+
+        var actual = Double.nan
+        for attempt in 0..<timing.verificationAttempts {
+            do {
+                actual = try backend.read(fan.targetKey).float32()
+            } catch {
+                throw normalize(error)
+            }
+            if abs(actual - rpm) <= Self.targetToleranceRPM {
+                return
+            }
+            if attempt + 1 < timing.verificationAttempts {
+                timing.sleep(timing.retryDelaySeconds)
+            }
+        }
+        throw FanControllerError.targetVerificationFailed(
+            index: fan.index,
+            expected: rpm,
+            actual: actual
+        )
+    }
+
+    private func restoreTrackedState() -> [FanRollbackFailure] {
+        var failures: [FanRollbackFailure] = []
+        var stillUncertain: [Int: FanCapability] = [:]
+
+        for fan in possiblyControlledFans.values.sorted(by: { $0.index < $1.index }) {
+            do {
+                try backend.write(fan.modeKey, bytes: [FanMode.automatic.rawValue])
+                let raw = try readUI8(fan.modeKey)
+                guard FanMode(rawValue: raw).isAutomatic else {
+                    throw FanRollbackError.modeNotAutomatic(rawValue: raw)
+                }
+                // Auto mode is authoritative. Clearing the stale manual target
+                // is best-effort defense against a later accidental mode toggle;
+                // failure here must not turn a verified Auto restore into error.
+                if let zero = try? SMCValue.float32Bytes(0, key: fan.targetKey) {
+                    try? backend.write(fan.targetKey, bytes: zero)
+                }
+            } catch {
+                let rollbackError = normalizeRollback(error)
+                failures.append(FanRollbackFailure(
+                    fanIndex: fan.index,
+                    step: .restoreMode,
+                    error: rollbackError
+                ))
+                stillUncertain[fan.index] = fan
+            }
+        }
+
+        var ftstStillUncertain = false
+        if mayOwnFtst, let ftstKey = inventory.ftstKey {
+            do {
+                try backend.write(ftstKey, bytes: [0])
+                let raw = try readUI8(ftstKey)
+                guard raw == 0 else {
+                    throw FanRollbackError.ftstStillSet(rawValue: raw)
+                }
+            } catch {
+                failures.append(FanRollbackFailure(
+                    fanIndex: nil,
+                    step: .clearFtst,
+                    error: normalizeRollback(error)
+                ))
+                ftstStillUncertain = true
+            }
+        } else if mayOwnFtst {
+            failures.append(FanRollbackFailure(
+                fanIndex: nil,
+                step: .clearFtst,
+                error: .smc(.keyNotFound("Ftst"))
+            ))
+            ftstStillUncertain = true
+        }
+
+        possiblyControlledFans = stillUncertain
+        targetRPMByFan = targetRPMByFan.filter { stillUncertain[$0.key] != nil }
+        mayOwnFtst = ftstStillUncertain
+        return failures
+    }
+
+    private func readUI8(_ key: SMCKey) throws -> UInt8 {
+        do {
+            return try backend.read(key).uint8()
+        } catch {
+            throw normalize(error)
+        }
+    }
+
+    private func shouldAttemptFtst(after error: FanControllerError) -> Bool {
+        switch error {
+        case .modeVerificationFailed:
+            return inventory.ftstKey != nil
+        case .smc(let smcError):
+            guard inventory.ftstKey != nil else { return false }
+            switch smcError {
+            case .firmwareRejected, .callFailed, .injectedFailure:
+                return true
+            default:
+                return false
+            }
+        default:
+            return false
+        }
+    }
+
+    private func normalize(_ error: Error) -> FanControllerError {
+        if let error = error as? FanControllerError { return error }
+        if let error = error as? FanHardwareError { return .hardware(error) }
+        if let error = error as? SMCError { return .smc(error) }
+        if let error = error as? FanRollbackError {
+            return .smc(.injectedFailure(error.description))
+        }
+        return .smc(.injectedFailure(String(describing: error)))
+    }
+
+    private func normalizeRollback(_ error: Error) -> FanRollbackError {
+        if let error = error as? FanRollbackError { return error }
+        if let error = error as? FanControllerError {
+            switch error {
+            case .smc(let smcError): return .smc(smcError)
+            case .hardware(let hardwareError): return .hardware(hardwareError)
+            default: return .smc(.injectedFailure(error.description))
+            }
+        }
+        if let error = error as? FanHardwareError { return .hardware(error) }
+        if let error = error as? SMCError { return .smc(error) }
+        return .smc(.injectedFailure(String(describing: error)))
+    }
+}

--- a/provider-swift/Sources/DarkbloomFanCore/FanController.swift
+++ b/provider-swift/Sources/DarkbloomFanCore/FanController.swift
@@ -353,7 +353,7 @@ public actor TransactionalFanController {
             }
 
             for fan in possiblyControlledFans.values.sorted(by: { $0.index < $1.index }) {
-                let target = targetRPMByFan[fan.index]!
+                let savedTarget = targetRPMByFan[fan.index]!
                 let rawMode = try readUI8(fan.modeKey)
                 switch FanMode(rawValue: rawMode) {
                 case .manual:
@@ -375,7 +375,24 @@ public actor TransactionalFanController {
                         rawValue: value
                     )
                 }
-                try writeAndVerifyTarget(fan, rpm: target)
+
+                // Never reduce cooling during maintenance. Firmware or an
+                // operator may have raised the live target while this session
+                // remained manual; adopt that higher value as the new floor.
+                let liveTarget = try readRPM(fan.targetKey, fanIndex: fan.index)
+                let maximum = try maximumRPM(for: fan)
+                guard liveTarget <= maximum else {
+                    throw FanControllerError.takeoverFloorExceedsMaximum(
+                        index: fan.index,
+                        floor: liveTarget,
+                        maximum: maximum
+                    )
+                }
+                let maintainedTarget = max(savedTarget, liveTarget)
+                targetRPMByFan[fan.index] = maintainedTarget
+                if abs(liveTarget - maintainedTarget) > Self.targetToleranceRPM {
+                    try writeAndVerifyTarget(fan, rpm: maintainedTarget)
+                }
             }
             try verifyFtstOwnershipAtTransactionEnd(
                 recordOwnership: recordOwnership
@@ -631,6 +648,29 @@ public actor TransactionalFanController {
     private func readUI8(_ key: SMCKey) throws -> UInt8 {
         do {
             return try backend.read(key).uint8()
+        } catch {
+            throw normalize(error)
+        }
+    }
+
+    private func maximumRPM(for fan: FanCapability) throws -> Double {
+        if let cached = inventory.fanLimits[fan.index]?.maximumRPM {
+            return cached
+        }
+        return try readRPM(fan.maximumKey, fanIndex: fan.index)
+    }
+
+    private func readRPM(_ key: SMCKey, fanIndex: Int) throws -> Double {
+        do {
+            let rpm = try backend.read(key).float32()
+            guard rpm.isFinite, rpm >= 0 else {
+                throw FanHardwareError.invalidFanRPM(
+                    index: fanIndex,
+                    field: key.rawValue,
+                    value: rpm
+                )
+            }
+            return rpm
         } catch {
             throw normalize(error)
         }

--- a/provider-swift/Sources/DarkbloomFanCore/FanController.swift
+++ b/provider-swift/Sources/DarkbloomFanCore/FanController.swift
@@ -40,6 +40,18 @@ public struct FanControlSession: Equatable, Codable, Sendable {
     }
 }
 
+/// Durable ownership boundary recorded immediately before a write that may
+/// still land despite returning an error.
+public struct FanControlOwnership: Equatable, Sendable {
+    public let fanIndices: [Int]
+    public let ownsFtst: Bool
+
+    public init(fanIndices: [Int], ownsFtst: Bool) {
+        self.fanIndices = Array(Set(fanIndices)).sorted()
+        self.ownsFtst = ownsFtst
+    }
+}
+
 public enum FanRollbackStep: String, Equatable, Codable, Sendable {
     case restoreMode
     case clearFtst
@@ -175,8 +187,7 @@ public actor TransactionalFanController {
     @discardableResult
     public func engage(
         speedPercent: Double,
-        beforeFanWrite: @Sendable () throws -> Void = {},
-        beforeFtstWrite: @Sendable () throws -> Void = {}
+        recordOwnership: @Sendable (FanControlOwnership) throws -> Void = { _ in }
     ) throws -> FanControlSession {
         let allowedSpeed = FanPolicyConfiguration.minimumSpeedPercent...FanPolicyConfiguration.maximumSpeedPercent
         guard speedPercent.isFinite,
@@ -241,14 +252,23 @@ public actor TransactionalFanController {
         }
 
         do {
-            // All foreign-ownership and capability checks are complete. Record
-            // possible ownership immediately before the first fan-mode write,
-            // which may land even if the backend reports an error.
-            try beforeFanWrite()
             for reading in readings {
                 let fan = reading.capability
-                // Mark intent before the first mode write. A backend can fail
-                // after the kernel accepted a write, so "threw" is not proof
+                // Close the initial-scan race, then durably widen ownership only
+                // for this fan. Recheck after the journal fsync so a foreign
+                // claimant that arrived during the write is not overwritten.
+                try verifyAvailableForTakeover(fan)
+                let priorOwnership = currentOwnership()
+                try recordOwnership(currentOwnership(including: fan.index))
+                do {
+                    try verifyAvailableForTakeover(fan)
+                } catch {
+                    try recordOwnership(priorOwnership)
+                    throw error
+                }
+
+                // Mark in-memory intent before the first mode write. A backend
+                // can fail after the kernel accepted it, so "threw" is not proof
                 // that the fan stayed automatic.
                 possiblyControlledFans[fan.index] = fan
                 do {
@@ -258,7 +278,7 @@ public actor TransactionalFanController {
                     guard shouldAttemptFtst(after: directFailure) else {
                         throw directFailure
                     }
-                    try acquireFtstIfNeeded(beforeFtstWrite: beforeFtstWrite)
+                    try acquireFtstIfNeeded(recordOwnership: recordOwnership)
                     try retryManualMode(fan)
                 }
                 guard let target = targets[fan.index] else {
@@ -269,7 +289,7 @@ public actor TransactionalFanController {
             }
 
             try verifyFtstOwnershipAtTransactionEnd(
-                beforeFtstWrite: beforeFtstWrite
+                recordOwnership: recordOwnership
             )
 
             return FanControlSession(
@@ -305,7 +325,7 @@ public actor TransactionalFanController {
     /// control rather than leaving a partially repaired session active.
     @discardableResult
     public func maintain(
-        beforeFtstWrite: @Sendable () throws -> Void = {}
+        recordOwnership: @Sendable (FanControlOwnership) throws -> Void = { _ in }
     ) throws -> FanControlSession {
         guard isControlling else {
             throw FanControllerError.notControlling
@@ -329,7 +349,7 @@ public actor TransactionalFanController {
             // Reassert a gate that this session already owns before touching
             // individual modes.
             if mayOwnFtst {
-                try acquireFtstIfNeeded(beforeFtstWrite: beforeFtstWrite)
+                try acquireFtstIfNeeded(recordOwnership: recordOwnership)
             }
 
             for fan in possiblyControlledFans.values.sorted(by: { $0.index < $1.index }) {
@@ -346,7 +366,7 @@ public actor TransactionalFanController {
                         guard shouldAttemptFtst(after: directFailure) else {
                             throw directFailure
                         }
-                        try acquireFtstIfNeeded(beforeFtstWrite: beforeFtstWrite)
+                        try acquireFtstIfNeeded(recordOwnership: recordOwnership)
                         try retryManualMode(fan)
                     }
                 case .unknown(let value):
@@ -358,7 +378,7 @@ public actor TransactionalFanController {
                 try writeAndVerifyTarget(fan, rpm: target)
             }
             try verifyFtstOwnershipAtTransactionEnd(
-                beforeFtstWrite: beforeFtstWrite
+                recordOwnership: recordOwnership
             )
 
             return FanControlSession(
@@ -427,7 +447,7 @@ public actor TransactionalFanController {
     }
 
     private func acquireFtstIfNeeded(
-        beforeFtstWrite: @Sendable () throws -> Void
+        recordOwnership: @Sendable (FanControlOwnership) throws -> Void
     ) throws {
         guard let ftstKey = inventory.ftstKey else {
             throw FanControllerError.smc(.keyNotFound("Ftst"))
@@ -443,7 +463,7 @@ public actor TransactionalFanController {
         // The caller durably records possible ownership only after we know the
         // gate is free, immediately before the first write that may still land
         // despite throwing. Then mirror that intent in memory for rollback.
-        try beforeFtstWrite()
+        try recordOwnership(currentOwnership(ownsFtst: true))
         mayOwnFtst = true
         do {
             try backend.write(ftstKey, bytes: [1])
@@ -465,7 +485,7 @@ public actor TransactionalFanController {
     }
 
     private func verifyFtstOwnershipAtTransactionEnd(
-        beforeFtstWrite: @Sendable () throws -> Void
+        recordOwnership: @Sendable (FanControlOwnership) throws -> Void
     ) throws {
         guard let ftstKey = inventory.ftstKey else { return }
         if mayOwnFtst {
@@ -474,7 +494,7 @@ public actor TransactionalFanController {
                 throw FanControllerError.foreignFtst(rawValue: current)
             }
             if current == 0 {
-                try beforeFtstWrite()
+                try recordOwnership(currentOwnership(ownsFtst: true))
                 try backend.write(ftstKey, bytes: [1])
                 timing.sleep(timing.ftstSettleSeconds)
                 let refreshed = try readUI8(ftstKey)
@@ -488,6 +508,35 @@ public actor TransactionalFanController {
         guard rawFtst == 0 else {
             throw FanControllerError.foreignFtst(rawValue: rawFtst)
         }
+    }
+
+    private func verifyAvailableForTakeover(_ fan: FanCapability) throws {
+        let rawMode = try readUI8(fan.modeKey)
+        switch FanMode(rawValue: rawMode) {
+        case .automatic, .system:
+            return
+        case .manual:
+            throw FanControllerError.foreignManualControl(indices: [fan.index])
+        case .unknown(let value):
+            throw FanControllerError.unknownFanMode(
+                index: fan.index,
+                rawValue: value
+            )
+        }
+    }
+
+    private func currentOwnership(
+        including fanIndex: Int? = nil,
+        ownsFtst: Bool? = nil
+    ) -> FanControlOwnership {
+        var fanIndices = Set(possiblyControlledFans.keys)
+        if let fanIndex {
+            fanIndices.insert(fanIndex)
+        }
+        return FanControlOwnership(
+            fanIndices: Array(fanIndices),
+            ownsFtst: ownsFtst ?? mayOwnFtst
+        )
     }
 
     private func writeAndVerifyTarget(_ fan: FanCapability, rpm: Double) throws {

--- a/provider-swift/Sources/DarkbloomFanCore/FanHardware.swift
+++ b/provider-swift/Sources/DarkbloomFanCore/FanHardware.swift
@@ -1,0 +1,459 @@
+import Foundation
+
+#if canImport(Darwin)
+import Darwin
+#endif
+
+public enum FanChipFamily: String, Codable, CaseIterable, Sendable {
+    case m1 = "M1"
+    case m2 = "M2"
+    case m3 = "M3"
+    case m4 = "M4"
+    case m5 = "M5"
+    case unknown = "Unknown"
+
+    public init(brandString: String) {
+        let tokens = brandString.uppercased().split {
+            !$0.isLetter && !$0.isNumber
+        }
+        if tokens.contains("M5") {
+            self = .m5
+        } else if tokens.contains("M4") {
+            self = .m4
+        } else if tokens.contains("M3") {
+            self = .m3
+        } else if tokens.contains("M2") {
+            self = .m2
+        } else if tokens.contains("M1") {
+            self = .m1
+        } else {
+            self = .unknown
+        }
+    }
+}
+
+public enum FanMode: Equatable, Codable, Sendable {
+    case automatic
+    case manual
+    case system
+    case unknown(UInt8)
+
+    public init(rawValue: UInt8) {
+        switch rawValue {
+        case 0: self = .automatic
+        case 1: self = .manual
+        case 3: self = .system
+        default: self = .unknown(rawValue)
+        }
+    }
+
+    public var rawValue: UInt8 {
+        switch self {
+        case .automatic: return 0
+        case .manual: return 1
+        case .system: return 3
+        case .unknown(let value): return value
+        }
+    }
+
+    public var isAutomatic: Bool {
+        self == .automatic || self == .system
+    }
+}
+
+public struct FanCapability: Equatable, Codable, Sendable {
+    public let index: Int
+    public let actualKey: SMCKey
+    public let minimumKey: SMCKey
+    public let maximumKey: SMCKey
+    public let targetKey: SMCKey
+    public let modeKey: SMCKey
+
+    public init(
+        index: Int,
+        actualKey: SMCKey,
+        minimumKey: SMCKey,
+        maximumKey: SMCKey,
+        targetKey: SMCKey,
+        modeKey: SMCKey
+    ) {
+        self.index = index
+        self.actualKey = actualKey
+        self.minimumKey = minimumKey
+        self.maximumKey = maximumKey
+        self.targetKey = targetKey
+        self.modeKey = modeKey
+    }
+}
+
+public struct FanInventory: Equatable, Codable, Sendable {
+    public let chipFamily: FanChipFamily
+    public let fans: [FanCapability]
+    public let gpuTemperatureKeys: [SMCKey]
+    public let ftstKey: SMCKey?
+    public let fanLimits: [Int: FanLimits]
+
+    public init(
+        chipFamily: FanChipFamily,
+        fans: [FanCapability],
+        gpuTemperatureKeys: [SMCKey],
+        ftstKey: SMCKey?,
+        fanLimits: [Int: FanLimits] = [:]
+    ) {
+        self.chipFamily = chipFamily
+        self.fans = fans
+        self.gpuTemperatureKeys = gpuTemperatureKeys
+        self.ftstKey = ftstKey
+        self.fanLimits = fanLimits
+    }
+}
+
+public struct FanLimits: Equatable, Codable, Sendable {
+    public let minimumRPM: Double
+    public let maximumRPM: Double
+
+    public init(minimumRPM: Double, maximumRPM: Double) {
+        self.minimumRPM = minimumRPM
+        self.maximumRPM = maximumRPM
+    }
+}
+
+public struct FanReading: Equatable, Codable, Sendable {
+    public let capability: FanCapability
+    public let actualRPM: Double
+    public let minimumRPM: Double
+    public let maximumRPM: Double
+    public let targetRPM: Double
+    public let mode: FanMode
+
+    public init(
+        capability: FanCapability,
+        actualRPM: Double,
+        minimumRPM: Double,
+        maximumRPM: Double,
+        targetRPM: Double,
+        mode: FanMode
+    ) {
+        self.capability = capability
+        self.actualRPM = actualRPM
+        self.minimumRPM = minimumRPM
+        self.maximumRPM = maximumRPM
+        self.targetRPM = targetRPM
+        self.mode = mode
+    }
+}
+
+public struct GPUTemperatureReading: Equatable, Codable, Sendable {
+    public let key: SMCKey
+    public let celsius: Double
+
+    public init(key: SMCKey, celsius: Double) {
+        self.key = key
+        self.celsius = celsius
+    }
+}
+
+public enum FanHardwareError: Error, Equatable, Sendable, CustomStringConvertible {
+    case invalidFanCount(Int)
+    case missingFanKey(index: Int, key: SMCKey)
+    case missingModeKey(index: Int)
+    case unsupportedRPMKey(key: SMCKey, info: SMCKeyInfo)
+    case unsupportedModeKey(key: SMCKey, info: SMCKeyInfo)
+    case invalidFanLimits(index: Int, minimum: Double, maximum: Double)
+    case invalidFanRPM(index: Int, field: String, value: Double)
+    case invalidTemperature(key: SMCKey, value: Double)
+    case backend(SMCError)
+
+    public var description: String {
+        switch self {
+        case .invalidFanCount(let count):
+            return "invalid fan count \(count)"
+        case .missingFanKey(let index, let key):
+            return "fan \(index) is missing required key \(key)"
+        case .missingModeKey(let index):
+            return "fan \(index) exposes neither F\(index)Md nor F\(index)md"
+        case .unsupportedRPMKey(let key, let info):
+            return "fan RPM key \(key) must be flt/4, got \(info.dataType)/\(info.dataSize)"
+        case .unsupportedModeKey(let key, let info):
+            return "fan mode key \(key) must be ui8/1, got \(info.dataType)/\(info.dataSize)"
+        case .invalidFanLimits(let index, let minimum, let maximum):
+            return "fan \(index) reported invalid limits \(minimum)...\(maximum) RPM"
+        case .invalidFanRPM(let index, let field, let value):
+            return "fan \(index) reported invalid \(field) RPM \(value)"
+        case .invalidTemperature(let key, let value):
+            return "GPU sensor \(key) reported implausible temperature \(value) C"
+        case .backend(let error):
+            return error.description
+        }
+    }
+}
+
+public enum GPUTemperatureCatalog {
+    public static func keys(for family: FanChipFamily) -> [SMCKey] {
+        switch family {
+        case .m1:
+            return ["Tg05", "Tg0D", "Tg0L", "Tg0T"]
+        case .m2:
+            return ["Tg0f", "Tg0j"]
+        case .m3:
+            return ["Tf14", "Tf18", "Tf19", "Tf1A", "Tf24", "Tf28", "Tf29", "Tf2A"]
+        case .m4:
+            return [
+                "Tg0G", "Tg0H", "Tg1U", "Tg1k", "Tg0K",
+                "Tg0L", "Tg0d", "Tg0e", "Tg0j", "Tg0k",
+            ]
+        case .m5:
+            return ["Tg0U", "Tg0X", "Tg0d", "Tg0g", "Tg0j", "Tg1Y", "Tg1c", "Tg1g"]
+        case .unknown:
+            return []
+        }
+    }
+}
+
+public enum FanChipIdentity {
+    public static func currentBrandString() throws -> String {
+        #if canImport(Darwin)
+        var size = 0
+        guard sysctlbyname("machdep.cpu.brand_string", nil, &size, nil, 0) == 0,
+              size > 1
+        else {
+            throw SMCError.systemQueryFailed("machdep.cpu.brand_string size")
+        }
+        var buffer = [CChar](repeating: 0, count: size)
+        guard sysctlbyname("machdep.cpu.brand_string", &buffer, &size, nil, 0) == 0 else {
+            throw SMCError.systemQueryFailed("machdep.cpu.brand_string value")
+        }
+        let bytes = buffer.prefix { $0 != 0 }.map { UInt8(bitPattern: $0) }
+        return String(decoding: bytes, as: UTF8.self)
+        #else
+        throw SMCError.unsupportedPlatform
+        #endif
+    }
+}
+
+public struct FanHardwareReader: Sendable {
+    public static let maximumSupportedFans = 8
+    public static let plausibleTemperatureRange = 10.0...125.0
+
+    private let backend: any SMCBackend
+
+    public init(backend: any SMCBackend) {
+        self.backend = backend
+    }
+
+    public func discover(brandString: String? = nil) throws -> FanInventory {
+        let recoveryInventory = try discoverForRecovery(brandString: brandString)
+        let family = recoveryInventory.chipFamily
+        let fans = recoveryInventory.fans
+        let ftstKey = recoveryInventory.ftstKey
+        let limits = try Dictionary(uniqueKeysWithValues: fans.map { fan in
+            let minimum = try readRPM(fan.minimumKey)
+            let maximum = try readRPM(fan.maximumKey)
+            guard minimum > 0, maximum >= minimum else {
+                throw FanHardwareError.invalidFanLimits(
+                    index: fan.index,
+                    minimum: minimum,
+                    maximum: maximum
+                )
+            }
+            return (
+                fan.index,
+                FanLimits(minimumRPM: minimum, maximumRPM: maximum)
+            )
+        })
+        let gpuKeys: [SMCKey] = try GPUTemperatureCatalog.keys(for: family).compactMap { key in
+            guard let info = try probeKey(key) else { return nil }
+            guard isTemperatureType(info) else { return nil }
+            let value = try mapBackend { try backend.read(key) }
+            guard let temperature = try? value.number(),
+                  Self.plausibleTemperatureRange.contains(temperature)
+            else {
+                return nil
+            }
+            return key
+        }
+
+        return FanInventory(
+            chipFamily: family,
+            fans: fans,
+            gpuTemperatureKeys: gpuKeys,
+            ftstKey: ftstKey,
+            fanLimits: limits
+        )
+    }
+
+    /// Minimal discovery for crash repair. It intentionally reads no fan-limit
+    /// values or GPU sensors because affected firmware can report F?Mx=0 while
+    /// manual mode is stranded and a sensor failure must never block Auto repair.
+    public func discoverForRecovery(brandString: String? = nil) throws -> FanInventory {
+        let brand = try brandString ?? FanChipIdentity.currentBrandString()
+        let family = FanChipFamily(brandString: brand)
+        let countValue = try mapBackend { try backend.read("FNum") }
+        let fanCount: Int
+        do {
+            fanCount = Int(try countValue.uint8())
+        } catch let error as SMCError {
+            throw FanHardwareError.backend(error)
+        }
+        guard (0...Self.maximumSupportedFans).contains(fanCount) else {
+            throw FanHardwareError.invalidFanCount(fanCount)
+        }
+
+        let fans = try (0..<fanCount).map(discoverFan)
+        let ftstKey = try probeUI8Key("Ftst")
+        return FanInventory(
+            chipFamily: family,
+            fans: fans,
+            gpuTemperatureKeys: [],
+            ftstKey: ftstKey
+        )
+    }
+
+    public func fanReadings(in inventory: FanInventory) throws -> [FanReading] {
+        try inventory.fans.map { fan in
+            let actual = try readRPM(fan.actualKey)
+            let cachedLimits = inventory.fanLimits[fan.index]
+            let minimum = try cachedLimits?.minimumRPM ?? readRPM(fan.minimumKey)
+            let maximum = try cachedLimits?.maximumRPM ?? readRPM(fan.maximumKey)
+            let target = try readRPM(fan.targetKey)
+            let modeValue = try mapBackend { try backend.read(fan.modeKey) }
+            let mode: FanMode
+            do {
+                mode = FanMode(rawValue: try modeValue.uint8())
+            } catch let error as SMCError {
+                throw FanHardwareError.backend(error)
+            }
+
+            guard minimum > 0, maximum >= minimum else {
+                throw FanHardwareError.invalidFanLimits(
+                    index: fan.index,
+                    minimum: minimum,
+                    maximum: maximum
+                )
+            }
+            guard actual >= 0 else {
+                throw FanHardwareError.invalidFanRPM(
+                    index: fan.index,
+                    field: "actual",
+                    value: actual
+                )
+            }
+            guard target >= 0 else {
+                throw FanHardwareError.invalidFanRPM(
+                    index: fan.index,
+                    field: "target",
+                    value: target
+                )
+            }
+            return FanReading(
+                capability: fan,
+                actualRPM: actual,
+                minimumRPM: minimum,
+                maximumRPM: maximum,
+                targetRPM: target,
+                mode: mode
+            )
+        }
+    }
+
+    public func gpuTemperatures(in inventory: FanInventory) throws -> [GPUTemperatureReading] {
+        try inventory.gpuTemperatureKeys.map { key in
+            let value = try mapBackend { try backend.read(key) }
+            let temperature: Double
+            do {
+                temperature = try value.number()
+            } catch let error as SMCError {
+                throw FanHardwareError.backend(error)
+            }
+            guard Self.plausibleTemperatureRange.contains(temperature) else {
+                throw FanHardwareError.invalidTemperature(key: key, value: temperature)
+            }
+            return GPUTemperatureReading(key: key, celsius: temperature)
+        }
+    }
+
+    private func discoverFan(index: Int) throws -> FanCapability {
+        let actual = try SMCKey("F\(index)Ac")
+        let minimum = try SMCKey("F\(index)Mn")
+        let maximum = try SMCKey("F\(index)Mx")
+        let target = try SMCKey("F\(index)Tg")
+        for key in [actual, minimum, maximum, target] {
+            guard let info = try probeKey(key) else {
+                throw FanHardwareError.missingFanKey(index: index, key: key)
+            }
+            guard info.dataType.rawValue == "flt ", info.dataSize == 4 else {
+                throw FanHardwareError.unsupportedRPMKey(key: key, info: info)
+            }
+        }
+
+        var modeKey: SMCKey?
+        for candidate in [try SMCKey("F\(index)md"), try SMCKey("F\(index)Md")] {
+            guard let info = try probeKey(candidate) else { continue }
+            guard info.dataType.rawValue == "ui8 ", info.dataSize == 1 else {
+                throw FanHardwareError.unsupportedModeKey(key: candidate, info: info)
+            }
+            modeKey = candidate
+            break
+        }
+        guard let modeKey else {
+            throw FanHardwareError.missingModeKey(index: index)
+        }
+        return FanCapability(
+            index: index,
+            actualKey: actual,
+            minimumKey: minimum,
+            maximumKey: maximum,
+            targetKey: target,
+            modeKey: modeKey
+        )
+    }
+
+    private func readRPM(_ key: SMCKey) throws -> Double {
+        let value = try mapBackend { try backend.read(key) }
+        do {
+            return try value.float32()
+        } catch let error as SMCError {
+            throw FanHardwareError.backend(error)
+        }
+    }
+
+    private func probeUI8Key(_ key: SMCKey) throws -> SMCKey? {
+        guard let info = try probeKey(key) else { return nil }
+        guard info.dataType.rawValue == "ui8 ", info.dataSize == 1 else {
+            throw FanHardwareError.unsupportedModeKey(key: key, info: info)
+        }
+        return key
+    }
+
+    private func probeKey(_ key: SMCKey) throws -> SMCKeyInfo? {
+        do {
+            return try backend.keyInfo(for: key)
+        } catch let error as SMCError where error.isKeyNotFound {
+            return nil
+        } catch let error as SMCError {
+            throw FanHardwareError.backend(error)
+        } catch {
+            throw FanHardwareError.backend(.injectedFailure(String(describing: error)))
+        }
+    }
+
+    private func isTemperatureType(_ info: SMCKeyInfo) -> Bool {
+        switch info.dataType.rawValue {
+        case "flt ": return info.dataSize == 4
+        case "sp78", "sp1e": return info.dataSize == 2
+        default: return false
+        }
+    }
+
+    private func mapBackend<T>(_ body: () throws -> T) throws -> T {
+        do {
+            return try body()
+        } catch let error as FanHardwareError {
+            throw error
+        } catch let error as SMCError {
+            throw FanHardwareError.backend(error)
+        } catch {
+            throw FanHardwareError.backend(.injectedFailure(String(describing: error)))
+        }
+    }
+}

--- a/provider-swift/Sources/DarkbloomFanCore/FanPolicy.swift
+++ b/provider-swift/Sources/DarkbloomFanCore/FanPolicy.swift
@@ -1,0 +1,256 @@
+import Foundation
+
+public struct FanPolicyConfiguration: Equatable, Codable, Sendable {
+    public static let minimumSpeedPercent = 60.0
+    public static let maximumSpeedPercent = 90.0
+
+    public let triggerCelsius: Double
+    public let releaseCelsius: Double
+    public let speedPercent: Double
+    public let engageSampleCount: Int
+    public let releaseSampleCount: Int
+
+    public static let defaults = FanPolicyConfiguration(
+        knownValidTrigger: 45,
+        release: 40,
+        speed: 80,
+        engageSamples: 3,
+        releaseSamples: 30
+    )
+
+    private init(
+        knownValidTrigger trigger: Double,
+        release: Double,
+        speed: Double,
+        engageSamples: Int,
+        releaseSamples: Int
+    ) {
+        self.triggerCelsius = trigger
+        self.releaseCelsius = release
+        self.speedPercent = speed
+        self.engageSampleCount = engageSamples
+        self.releaseSampleCount = releaseSamples
+    }
+
+    public init(
+        triggerCelsius: Double = 45,
+        releaseCelsius: Double = 40,
+        speedPercent: Double = 80,
+        engageSampleCount: Int = 3,
+        releaseSampleCount: Int = 30
+    ) throws {
+        guard triggerCelsius.isFinite, releaseCelsius.isFinite,
+              FanHardwareReader.plausibleTemperatureRange.contains(triggerCelsius),
+              FanHardwareReader.plausibleTemperatureRange.contains(releaseCelsius),
+              releaseCelsius < triggerCelsius
+        else {
+            throw FanPolicyConfigurationError.invalidTemperatureThresholds(
+                trigger: triggerCelsius,
+                release: releaseCelsius
+            )
+        }
+        guard speedPercent.isFinite,
+              (Self.minimumSpeedPercent...Self.maximumSpeedPercent).contains(speedPercent)
+        else {
+            throw FanPolicyConfigurationError.invalidSpeedPercent(speedPercent)
+        }
+        guard engageSampleCount > 0, releaseSampleCount > 0 else {
+            throw FanPolicyConfigurationError.invalidDebounceCounts(
+                engage: engageSampleCount,
+                release: releaseSampleCount
+            )
+        }
+        self.triggerCelsius = triggerCelsius
+        self.releaseCelsius = releaseCelsius
+        self.speedPercent = speedPercent
+        self.engageSampleCount = engageSampleCount
+        self.releaseSampleCount = releaseSampleCount
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case triggerCelsius
+        case releaseCelsius
+        case speedPercent
+        case engageSampleCount
+        case releaseSampleCount
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        try self.init(
+            triggerCelsius: try container.decodeIfPresent(
+                Double.self,
+                forKey: .triggerCelsius
+            ) ?? 45,
+            releaseCelsius: try container.decodeIfPresent(
+                Double.self,
+                forKey: .releaseCelsius
+            ) ?? 40,
+            speedPercent: try container.decodeIfPresent(
+                Double.self,
+                forKey: .speedPercent
+            ) ?? 80,
+            engageSampleCount: try container.decodeIfPresent(
+                Int.self,
+                forKey: .engageSampleCount
+            ) ?? 3,
+            releaseSampleCount: try container.decodeIfPresent(
+                Int.self,
+                forKey: .releaseSampleCount
+            ) ?? 30
+        )
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(triggerCelsius, forKey: .triggerCelsius)
+        try container.encode(releaseCelsius, forKey: .releaseCelsius)
+        try container.encode(speedPercent, forKey: .speedPercent)
+        try container.encode(engageSampleCount, forKey: .engageSampleCount)
+        try container.encode(releaseSampleCount, forKey: .releaseSampleCount)
+    }
+}
+
+public enum FanPolicyConfigurationError: Error, Equatable, Sendable,
+    CustomStringConvertible
+{
+    case invalidTemperatureThresholds(trigger: Double, release: Double)
+    case invalidSpeedPercent(Double)
+    case invalidDebounceCounts(engage: Int, release: Int)
+
+    public var description: String {
+        switch self {
+        case .invalidTemperatureThresholds(let trigger, let release):
+            return "fan release temperature must be plausible and below trigger (trigger=\(trigger), release=\(release))"
+        case .invalidSpeedPercent(let speed):
+            return "fan speed must be between 60 and 90 percent (got \(speed))"
+        case .invalidDebounceCounts(let engage, let release):
+            return "fan debounce counts must be positive (engage=\(engage), release=\(release))"
+        }
+    }
+}
+
+public enum FanPolicyMode: String, Equatable, Codable, Sendable {
+    case automatic
+    case manual
+}
+
+public enum FanPolicyReason: Equatable, Codable, Sendable {
+    case providerInactive
+    case sensorUnavailable
+    case invalidSensorValue
+    case controlFailure
+    case waitingForTrigger(samples: Int, required: Int)
+    case belowTrigger
+    case releaseReached
+}
+
+public enum FanPolicyAction: Equatable, Codable, Sendable {
+    case stayAutomatic(reason: FanPolicyReason)
+    case engage(speedPercent: Double, hottestGPUCelsius: Double)
+    case maintain(speedPercent: Double, hottestGPUCelsius: Double)
+    case restoreAutomatic(reason: FanPolicyReason)
+}
+
+public struct FanPolicyInput: Equatable, Sendable {
+    public let providerLeaseActive: Bool
+    public let gpuTemperaturesCelsius: [Double]?
+    public let controlHealthy: Bool
+
+    public init(
+        providerLeaseActive: Bool,
+        gpuTemperaturesCelsius: [Double]?,
+        controlHealthy: Bool = true
+    ) {
+        self.providerLeaseActive = providerLeaseActive
+        self.gpuTemperaturesCelsius = gpuTemperaturesCelsius
+        self.controlHealthy = controlHealthy
+    }
+}
+
+public struct FanPolicyStateMachine: Equatable, Sendable {
+    public let configuration: FanPolicyConfiguration
+    public private(set) var mode: FanPolicyMode = .automatic
+    public private(set) var consecutiveHotSamples = 0
+    public private(set) var consecutiveCoolSamples = 0
+
+    public init(configuration: FanPolicyConfiguration = .defaults) {
+        self.configuration = configuration
+    }
+
+    public mutating func evaluate(_ input: FanPolicyInput) -> FanPolicyAction {
+        guard input.providerLeaseActive else {
+            return forceAutomatic(reason: .providerInactive)
+        }
+        guard input.controlHealthy else {
+            return forceAutomatic(reason: .controlFailure)
+        }
+        guard let temperatures = input.gpuTemperaturesCelsius, !temperatures.isEmpty else {
+            return forceAutomatic(reason: .sensorUnavailable)
+        }
+        guard temperatures.allSatisfy({
+            $0.isFinite && FanHardwareReader.plausibleTemperatureRange.contains($0)
+        }) else {
+            return forceAutomatic(reason: .invalidSensorValue)
+        }
+
+        guard let hottest = temperatures.max() else {
+            return forceAutomatic(reason: .sensorUnavailable)
+        }
+        switch mode {
+        case .automatic:
+            consecutiveCoolSamples = 0
+            guard hottest >= configuration.triggerCelsius else {
+                consecutiveHotSamples = 0
+                return .stayAutomatic(reason: .belowTrigger)
+            }
+            consecutiveHotSamples += 1
+            guard consecutiveHotSamples >= configuration.engageSampleCount else {
+                return .stayAutomatic(reason: .waitingForTrigger(
+                    samples: consecutiveHotSamples,
+                    required: configuration.engageSampleCount
+                ))
+            }
+            mode = .manual
+            consecutiveHotSamples = 0
+            return .engage(
+                speedPercent: configuration.speedPercent,
+                hottestGPUCelsius: hottest
+            )
+
+        case .manual:
+            consecutiveHotSamples = 0
+            guard hottest <= configuration.releaseCelsius else {
+                consecutiveCoolSamples = 0
+                return .maintain(
+                    speedPercent: configuration.speedPercent,
+                    hottestGPUCelsius: hottest
+                )
+            }
+            consecutiveCoolSamples += 1
+            guard consecutiveCoolSamples >= configuration.releaseSampleCount else {
+                return .maintain(
+                    speedPercent: configuration.speedPercent,
+                    hottestGPUCelsius: hottest
+                )
+            }
+            mode = .automatic
+            consecutiveCoolSamples = 0
+            return .restoreAutomatic(reason: .releaseReached)
+        }
+    }
+
+    public mutating func reset() -> FanPolicyAction {
+        forceAutomatic(reason: .providerInactive)
+    }
+
+    private mutating func forceAutomatic(reason: FanPolicyReason) -> FanPolicyAction {
+        consecutiveHotSamples = 0
+        consecutiveCoolSamples = 0
+        if mode == .manual {
+            mode = .automatic
+            return .restoreAutomatic(reason: reason)
+        }
+        return .stayAutomatic(reason: reason)
+    }
+}

--- a/provider-swift/Sources/DarkbloomFanCore/SMCBackend.swift
+++ b/provider-swift/Sources/DarkbloomFanCore/SMCBackend.swift
@@ -1,0 +1,308 @@
+import Foundation
+
+#if os(macOS)
+import Darwin
+import IOKit
+#endif
+
+public protocol SMCBackend: Sendable {
+    func keyInfo(for key: SMCKey) throws -> SMCKeyInfo
+    func read(_ key: SMCKey) throws -> SMCValue
+    func write(_ key: SMCKey, bytes: [UInt8]) throws
+}
+
+#if os(macOS)
+private let smcKernelSelector: UInt32 = 2
+private let smcReadBytesCommand: UInt8 = 5
+private let smcWriteBytesCommand: UInt8 = 6
+private let smcReadKeyInfoCommand: UInt8 = 9
+private let smcKeyNotFoundResult: UInt8 = 0x84
+
+private struct SMCRawVersion {
+    var major: UInt8 = 0
+    var minor: UInt8 = 0
+    var build: UInt8 = 0
+    var reserved: UInt8 = 0
+    var release: UInt16 = 0
+}
+
+private struct SMCRawPLimitData {
+    var version: UInt16 = 0
+    var length: UInt16 = 0
+    var cpuPLimit: UInt32 = 0
+    var gpuPLimit: UInt32 = 0
+    var memPLimit: UInt32 = 0
+}
+
+private struct SMCRawKeyInfo {
+    var dataSize: UInt32 = 0
+    var dataType: UInt32 = 0
+    var dataAttributes: UInt8 = 0
+    // C's SMCKeyData_keyInfo_t has 4-byte alignment and therefore three
+    // trailing padding bytes. Swift embeds a nested struct using its size,
+    // not its stride, so the padding must be explicit to keep the following
+    // result/status/data fields at the AppleSMC ABI offsets.
+    var padding0: UInt8 = 0
+    var padding1: UInt8 = 0
+    var padding2: UInt8 = 0
+}
+
+private struct SMCRawBytes {
+    var b00: UInt8 = 0
+    var b01: UInt8 = 0
+    var b02: UInt8 = 0
+    var b03: UInt8 = 0
+    var b04: UInt8 = 0
+    var b05: UInt8 = 0
+    var b06: UInt8 = 0
+    var b07: UInt8 = 0
+    var b08: UInt8 = 0
+    var b09: UInt8 = 0
+    var b10: UInt8 = 0
+    var b11: UInt8 = 0
+    var b12: UInt8 = 0
+    var b13: UInt8 = 0
+    var b14: UInt8 = 0
+    var b15: UInt8 = 0
+    var b16: UInt8 = 0
+    var b17: UInt8 = 0
+    var b18: UInt8 = 0
+    var b19: UInt8 = 0
+    var b20: UInt8 = 0
+    var b21: UInt8 = 0
+    var b22: UInt8 = 0
+    var b23: UInt8 = 0
+    var b24: UInt8 = 0
+    var b25: UInt8 = 0
+    var b26: UInt8 = 0
+    var b27: UInt8 = 0
+    var b28: UInt8 = 0
+    var b29: UInt8 = 0
+    var b30: UInt8 = 0
+    var b31: UInt8 = 0
+
+    mutating func store(_ source: [UInt8]) {
+        withUnsafeMutableBytes(of: &self) { destination in
+            destination.initializeMemory(as: UInt8.self, repeating: 0)
+            destination.copyBytes(from: source)
+        }
+    }
+
+    func load(count: Int) -> [UInt8] {
+        withUnsafeBytes(of: self) { Array($0.prefix(count)) }
+    }
+}
+
+private struct SMCRawKeyData {
+    var key: UInt32 = 0
+    var version = SMCRawVersion()
+    var pLimitData = SMCRawPLimitData()
+    var keyInfo = SMCRawKeyInfo()
+    var result: UInt8 = 0
+    var status: UInt8 = 0
+    var data8: UInt8 = 0
+    var data32: UInt32 = 0
+    var bytes = SMCRawBytes()
+}
+
+public final class AppleSMCBackend: SMCBackend, @unchecked Sendable {
+    public static let expectedABISize = 80
+    public static var abiStride: Int { MemoryLayout<SMCRawKeyData>.stride }
+    public static var abiOffsets: [String: Int] {
+        [
+            "key": MemoryLayout<SMCRawKeyData>.offset(of: \.key) ?? -1,
+            "version": MemoryLayout<SMCRawKeyData>.offset(of: \.version) ?? -1,
+            "pLimitData": MemoryLayout<SMCRawKeyData>.offset(of: \.pLimitData) ?? -1,
+            "keyInfo": MemoryLayout<SMCRawKeyData>.offset(of: \.keyInfo) ?? -1,
+            "result": MemoryLayout<SMCRawKeyData>.offset(of: \.result) ?? -1,
+            "status": MemoryLayout<SMCRawKeyData>.offset(of: \.status) ?? -1,
+            "data8": MemoryLayout<SMCRawKeyData>.offset(of: \.data8) ?? -1,
+            "data32": MemoryLayout<SMCRawKeyData>.offset(of: \.data32) ?? -1,
+            "bytes": MemoryLayout<SMCRawKeyData>.offset(of: \.bytes) ?? -1,
+        ]
+    }
+
+    private let lock = NSLock()
+    private var connection: io_connect_t
+
+    public init() throws {
+        let actualSize = MemoryLayout<SMCRawKeyData>.stride
+        guard actualSize == Self.expectedABISize else {
+            throw SMCError.invalidStructLayout(
+                expected: Self.expectedABISize,
+                actual: actualSize
+            )
+        }
+
+        guard let matching = IOServiceMatching("AppleSMC") else {
+            throw SMCError.serviceNotFound
+        }
+        let service = IOServiceGetMatchingService(kIOMainPortDefault, matching)
+        guard service != 0 else {
+            throw SMCError.serviceNotFound
+        }
+        defer { IOObjectRelease(service) }
+
+        var opened: io_connect_t = 0
+        let result = IOServiceOpen(service, mach_task_self_, 0, &opened)
+        guard result == kIOReturnSuccess else {
+            throw Self.mapIOError(result, operation: .open, key: nil)
+        }
+        connection = opened
+    }
+
+    deinit {
+        if connection != 0 {
+            IOServiceClose(connection)
+        }
+    }
+
+    public func keyInfo(for key: SMCKey) throws -> SMCKeyInfo {
+        try lock.withLock {
+            try readKeyInfoLocked(key)
+        }
+    }
+
+    public func read(_ key: SMCKey) throws -> SMCValue {
+        try lock.withLock {
+            let info = try readKeyInfoLocked(key)
+            var input = SMCRawKeyData()
+            input.key = key.code
+            input.keyInfo.dataSize = UInt32(info.dataSize)
+            input.data8 = smcReadBytesCommand
+            let output = try callLocked(input, operation: .readBytes, key: key)
+            return try SMCValue(
+                key: key,
+                info: info,
+                bytes: output.bytes.load(count: info.dataSize)
+            )
+        }
+    }
+
+    public func write(_ key: SMCKey, bytes: [UInt8]) throws {
+        try lock.withLock {
+            let info = try readKeyInfoLocked(key)
+            guard info.dataSize <= 32 else {
+                throw SMCError.invalidDataSize(key: key, size: info.dataSize)
+            }
+            guard bytes.count == info.dataSize else {
+                throw SMCError.dataLengthMismatch(
+                    key: key,
+                    expected: info.dataSize,
+                    actual: bytes.count
+                )
+            }
+
+            var input = SMCRawKeyData()
+            input.key = key.code
+            input.keyInfo.dataSize = UInt32(info.dataSize)
+            input.keyInfo.dataType = info.dataType.code
+            input.data8 = smcWriteBytesCommand
+            input.bytes.store(bytes)
+            _ = try callLocked(input, operation: .writeBytes, key: key)
+        }
+    }
+
+    private func readKeyInfoLocked(_ key: SMCKey) throws -> SMCKeyInfo {
+        var input = SMCRawKeyData()
+        input.key = key.code
+        input.data8 = smcReadKeyInfoCommand
+        let output = try callLocked(input, operation: .readKeyInfo, key: key)
+        let size = Int(output.keyInfo.dataSize)
+        guard (0...32).contains(size) else {
+            throw SMCError.invalidDataSize(key: key, size: size)
+        }
+        return SMCKeyInfo(
+            dataSize: size,
+            dataType: SMCDataType(code: output.keyInfo.dataType),
+            attributes: output.keyInfo.dataAttributes
+        )
+    }
+
+    private func callLocked(
+        _ input: SMCRawKeyData,
+        operation: SMCOperation,
+        key: SMCKey?
+    ) throws -> SMCRawKeyData {
+        var input = input
+        var output = SMCRawKeyData()
+        var outputSize = MemoryLayout<SMCRawKeyData>.stride
+        let result = withUnsafePointer(to: &input) { inputPointer in
+            withUnsafeMutablePointer(to: &output) { outputPointer in
+                IOConnectCallStructMethod(
+                    connection,
+                    smcKernelSelector,
+                    inputPointer,
+                    MemoryLayout<SMCRawKeyData>.stride,
+                    outputPointer,
+                    &outputSize
+                )
+            }
+        }
+        guard result == kIOReturnSuccess else {
+            throw Self.mapIOError(result, operation: operation, key: key)
+        }
+        guard outputSize == MemoryLayout<SMCRawKeyData>.stride else {
+            throw SMCError.invalidStructLayout(
+                expected: MemoryLayout<SMCRawKeyData>.stride,
+                actual: outputSize
+            )
+        }
+        guard output.result == 0 else {
+            if output.result == smcKeyNotFoundResult, let key {
+                throw SMCError.keyNotFound(key)
+            }
+            throw SMCError.firmwareRejected(
+                operation: operation,
+                key: key ?? "????",
+                result: output.result
+            )
+        }
+        return output
+    }
+
+    private static func mapIOError(
+        _ result: kern_return_t,
+        operation: SMCOperation,
+        key: SMCKey?
+    ) -> SMCError {
+        if result == kIOReturnNotPrivileged {
+            return .notPrivileged(operation: operation, key: key)
+        }
+        if operation == .open {
+            return .openFailed(code: Int32(result))
+        }
+        return .callFailed(operation: operation, key: key, code: Int32(result))
+    }
+}
+
+#else
+
+public final class AppleSMCBackend: SMCBackend, @unchecked Sendable {
+    public static let expectedABISize = 80
+    public static var abiStride: Int { expectedABISize }
+    public static var abiOffsets: [String: Int] {
+        [
+            "key": 0, "version": 4, "pLimitData": 12, "keyInfo": 28,
+            "result": 40, "status": 41, "data8": 42, "data32": 44, "bytes": 48,
+        ]
+    }
+
+    public init() throws {
+        throw SMCError.unsupportedPlatform
+    }
+
+    public func keyInfo(for _: SMCKey) throws -> SMCKeyInfo {
+        throw SMCError.unsupportedPlatform
+    }
+
+    public func read(_: SMCKey) throws -> SMCValue {
+        throw SMCError.unsupportedPlatform
+    }
+
+    public func write(_: SMCKey, bytes _: [UInt8]) throws {
+        throw SMCError.unsupportedPlatform
+    }
+}
+
+#endif

--- a/provider-swift/Sources/DarkbloomFanCore/SMCTypes.swift
+++ b/provider-swift/Sources/DarkbloomFanCore/SMCTypes.swift
@@ -1,0 +1,291 @@
+import Foundation
+
+public struct SMCKey: Hashable, Codable, Sendable, CustomStringConvertible,
+    ExpressibleByStringLiteral
+{
+    public let rawValue: String
+
+    public init(_ rawValue: String) throws {
+        let bytes = Array(rawValue.utf8)
+        guard bytes.count == 4, bytes.allSatisfy({ $0 >= 0x20 && $0 <= 0x7e }) else {
+            throw SMCError.invalidKey(rawValue)
+        }
+        self.rawValue = rawValue
+    }
+
+    public init(stringLiteral value: String) {
+        guard let key = try? SMCKey(value) else {
+            preconditionFailure("SMC keys must contain exactly four printable ASCII bytes")
+        }
+        self = key
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case rawValue
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        try self.init(container.decode(String.self, forKey: .rawValue))
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(rawValue, forKey: .rawValue)
+    }
+
+    init(code: UInt32) {
+        let bytes = [
+            UInt8((code >> 24) & 0xff),
+            UInt8((code >> 16) & 0xff),
+            UInt8((code >> 8) & 0xff),
+            UInt8(code & 0xff),
+        ]
+        self.rawValue = String(bytes: bytes, encoding: .ascii) ?? "????"
+    }
+
+    var code: UInt32 {
+        rawValue.utf8.reduce(0) { ($0 << 8) | UInt32($1) }
+    }
+
+    public var description: String { rawValue }
+}
+
+public struct SMCDataType: Hashable, Codable, Sendable, CustomStringConvertible {
+    public let rawValue: String
+
+    public init(_ rawValue: String) throws {
+        guard rawValue.utf8.count == 4 else {
+            throw SMCError.invalidDataType(rawValue)
+        }
+        self.rawValue = rawValue
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case rawValue
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        try self.init(container.decode(String.self, forKey: .rawValue))
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(rawValue, forKey: .rawValue)
+    }
+
+    init(code: UInt32) {
+        let bytes = [
+            UInt8((code >> 24) & 0xff),
+            UInt8((code >> 16) & 0xff),
+            UInt8((code >> 8) & 0xff),
+            UInt8(code & 0xff),
+        ]
+        self.rawValue = String(bytes: bytes, encoding: .ascii) ?? "????"
+    }
+
+    var code: UInt32 {
+        rawValue.utf8.reduce(0) { ($0 << 8) | UInt32($1) }
+    }
+
+    public var description: String { rawValue }
+}
+
+public struct SMCKeyInfo: Hashable, Codable, Sendable {
+    public let dataSize: Int
+    public let dataType: SMCDataType
+    public let attributes: UInt8
+
+    public init(dataSize: Int, dataType: SMCDataType, attributes: UInt8 = 0) {
+        self.dataSize = dataSize
+        self.dataType = dataType
+        self.attributes = attributes
+    }
+}
+
+public struct SMCValue: Hashable, Codable, Sendable {
+    public let key: SMCKey
+    public let info: SMCKeyInfo
+    public let bytes: [UInt8]
+
+    public init(key: SMCKey, info: SMCKeyInfo, bytes: [UInt8]) throws {
+        guard info.dataSize >= 0, info.dataSize <= 32 else {
+            throw SMCError.invalidDataSize(key: key, size: info.dataSize)
+        }
+        guard bytes.count == info.dataSize else {
+            throw SMCError.dataLengthMismatch(
+                key: key,
+                expected: info.dataSize,
+                actual: bytes.count
+            )
+        }
+        self.key = key
+        self.info = info
+        self.bytes = bytes
+    }
+
+    public func float32() throws -> Double {
+        try require(type: "flt ", size: 4)
+        let bits = UInt32(bytes[0])
+            | (UInt32(bytes[1]) << 8)
+            | (UInt32(bytes[2]) << 16)
+            | (UInt32(bytes[3]) << 24)
+        let value = Double(Float(bitPattern: bits))
+        guard value.isFinite else {
+            throw SMCError.nonFiniteValue(key: key)
+        }
+        return value
+    }
+
+    public func uint8() throws -> UInt8 {
+        try require(type: "ui8 ", size: 1)
+        return bytes[0]
+    }
+
+    public func number() throws -> Double {
+        switch info.dataType.rawValue {
+        case "flt ":
+            return try float32()
+        case "ui8 ":
+            return Double(try uint8())
+        case "ui16":
+            try require(type: "ui16", size: 2)
+            return Double(bigEndianUInt16())
+        case "ui32":
+            try require(type: "ui32", size: 4)
+            return Double(bigEndianUInt32())
+        case "fpe2":
+            try require(type: "fpe2", size: 2)
+            return Double(bigEndianUInt16()) / 4.0
+        case "sp78":
+            try require(type: "sp78", size: 2)
+            return Double(Int16(bitPattern: bigEndianUInt16())) / 256.0
+        case "sp1e":
+            try require(type: "sp1e", size: 2)
+            return Double(Int16(bitPattern: bigEndianUInt16())) / 16_384.0
+        default:
+            throw SMCError.unsupportedDataType(key: key, type: info.dataType)
+        }
+    }
+
+    public static func float32Bytes(_ value: Double, key: SMCKey) throws -> [UInt8] {
+        guard value.isFinite, value >= -Double(Float.greatestFiniteMagnitude),
+              value <= Double(Float.greatestFiniteMagnitude)
+        else {
+            throw SMCError.nonFiniteValue(key: key)
+        }
+        let bits = Float(value).bitPattern
+        return [
+            UInt8(bits & 0xff),
+            UInt8((bits >> 8) & 0xff),
+            UInt8((bits >> 16) & 0xff),
+            UInt8((bits >> 24) & 0xff),
+        ]
+    }
+
+    private func require(type: String, size: Int) throws {
+        guard info.dataType.rawValue == type else {
+            throw SMCError.typeMismatch(
+                key: key,
+                expected: type,
+                actual: info.dataType.rawValue
+            )
+        }
+        guard info.dataSize == size else {
+            throw SMCError.invalidDataSize(key: key, size: info.dataSize)
+        }
+    }
+
+    private func bigEndianUInt16() -> UInt16 {
+        (UInt16(bytes[0]) << 8) | UInt16(bytes[1])
+    }
+
+    private func bigEndianUInt32() -> UInt32 {
+        (UInt32(bytes[0]) << 24)
+            | (UInt32(bytes[1]) << 16)
+            | (UInt32(bytes[2]) << 8)
+            | UInt32(bytes[3])
+    }
+}
+
+public enum SMCOperation: String, Codable, Sendable {
+    case open
+    case readKeyInfo
+    case readBytes
+    case writeBytes
+}
+
+public enum SMCError: Error, Equatable, Sendable, CustomStringConvertible {
+    case unsupportedPlatform
+    case invalidKey(String)
+    case invalidDataType(String)
+    case invalidStructLayout(expected: Int, actual: Int)
+    case serviceNotFound
+    case openFailed(code: Int32)
+    case callFailed(operation: SMCOperation, key: SMCKey?, code: Int32)
+    case notPrivileged(operation: SMCOperation, key: SMCKey?)
+    case keyNotFound(SMCKey)
+    case firmwareRejected(operation: SMCOperation, key: SMCKey, result: UInt8)
+    case invalidDataSize(key: SMCKey, size: Int)
+    case dataLengthMismatch(key: SMCKey, expected: Int, actual: Int)
+    case typeMismatch(key: SMCKey, expected: String, actual: String)
+    case unsupportedDataType(key: SMCKey, type: SMCDataType)
+    case nonFiniteValue(key: SMCKey)
+    case systemQueryFailed(String)
+    case injectedFailure(String)
+
+    public var isNotPrivileged: Bool {
+        if case .notPrivileged = self { return true }
+        return false
+    }
+
+    public var isKeyNotFound: Bool {
+        if case .keyNotFound = self { return true }
+        return false
+    }
+
+    public var description: String {
+        switch self {
+        case .unsupportedPlatform:
+            return "AppleSMC is available only on macOS"
+        case .invalidKey(let key):
+            return "invalid four-byte SMC key: \(key)"
+        case .invalidDataType(let type):
+            return "invalid four-byte SMC data type: \(type)"
+        case .invalidStructLayout(let expected, let actual):
+            return "AppleSMC ABI layout mismatch: expected \(expected) bytes, got \(actual)"
+        case .serviceNotFound:
+            return "AppleSMC service was not found"
+        case .openFailed(let code):
+            return "could not open AppleSMC (IOReturn \(code))"
+        case .callFailed(let operation, let key, let code):
+            return "AppleSMC \(operation.rawValue) failed for \(key?.rawValue ?? "<none>") (IOReturn \(code))"
+        case .notPrivileged(let operation, let key):
+            return "AppleSMC \(operation.rawValue) is not privileged for \(key?.rawValue ?? "<none>")"
+        case .keyNotFound(let key):
+            return "SMC key \(key) was not found"
+        case .firmwareRejected(let operation, let key, let result):
+            return String(
+                format: "SMC firmware rejected %@ for %@ (0x%02x)",
+                operation.rawValue,
+                key.rawValue,
+                result
+            )
+        case .invalidDataSize(let key, let size):
+            return "SMC key \(key) reported invalid data size \(size)"
+        case .dataLengthMismatch(let key, let expected, let actual):
+            return "SMC key \(key) expected \(expected) bytes, got \(actual)"
+        case .typeMismatch(let key, let expected, let actual):
+            return "SMC key \(key) expected type \(expected), got \(actual)"
+        case .unsupportedDataType(let key, let type):
+            return "SMC key \(key) uses unsupported type \(type)"
+        case .nonFiniteValue(let key):
+            return "SMC key \(key) produced a non-finite value"
+        case .systemQueryFailed(let query):
+            return "system query failed: \(query)"
+        case .injectedFailure(let message):
+            return message
+        }
+    }
+}

--- a/provider-swift/Sources/DarkbloomFanHelper/FanDaemon.swift
+++ b/provider-swift/Sources/DarkbloomFanHelper/FanDaemon.swift
@@ -26,8 +26,7 @@ actor FanDaemon {
     private let uptime: Uptime
     private let journalOwner: (uid: uid_t, gid: gid_t)?
     private let requireRootJournalOwnership: Bool
-    private let recordFanOwnership: @Sendable () throws -> Void
-    private let recordFtstOwnership: @Sendable () throws -> Void
+    private let recordOwnership: @Sendable (FanControlOwnership) throws -> Void
 
     private var policy: FanPolicyStateMachine
     private var pollTask: Task<Void, Never>?
@@ -62,23 +61,16 @@ actor FanDaemon {
         self.journalOwner = journalOwner
         self.requireRootJournalOwnership = requireRootJournalOwnership
         let journalURL = paths.sessionJournal
-        let fanIndices = inventory.fans.map(\.index)
-        let recordOwnership: @Sendable (Bool) throws -> Void = { ownsFtst in
+        self.recordOwnership = { ownership in
             try FanDurableFile.writeJSON(
                 FanSessionJournal(
-                    fanIndices: fanIndices,
-                    ownsFtst: ownsFtst
+                    fanIndices: ownership.fanIndices,
+                    ownsFtst: ownership.ownsFtst
                 ),
                 to: journalURL,
                 permissions: 0o600,
                 owner: journalOwner
             )
-        }
-        self.recordFanOwnership = {
-            try recordOwnership(false)
-        }
-        self.recordFtstOwnership = {
-            try recordOwnership(true)
         }
         self.policy = FanPolicyStateMachine(configuration: configuration.policy)
         self.mode = configuration.enabled ? .waitingForProvider : .disabled
@@ -265,8 +257,7 @@ actor FanDaemon {
             do {
                 let session = try await controller.engage(
                     speedPercent: speedPercent,
-                    beforeFanWrite: recordFanOwnership,
-                    beforeFtstWrite: recordFtstOwnership
+                    recordOwnership: recordOwnership
                 )
                 try persistOwnership(session)
                 lastMaintenanceAt = uptime()
@@ -286,7 +277,7 @@ actor FanDaemon {
                     try persistOwnership(currentSession)
                 }
                 let session = try await controller.maintain(
-                    beforeFtstWrite: recordFtstOwnership
+                    recordOwnership: recordOwnership
                 )
                 try persistOwnership(session)
                 lastMaintenanceAt = uptime()

--- a/provider-swift/Sources/DarkbloomFanHelper/FanDaemon.swift
+++ b/provider-swift/Sources/DarkbloomFanHelper/FanDaemon.swift
@@ -26,6 +26,8 @@ actor FanDaemon {
     private let uptime: Uptime
     private let journalOwner: (uid: uid_t, gid: gid_t)?
     private let requireRootJournalOwnership: Bool
+    private let recordFanOwnership: @Sendable () throws -> Void
+    private let recordFtstOwnership: @Sendable () throws -> Void
 
     private var policy: FanPolicyStateMachine
     private var pollTask: Task<Void, Never>?
@@ -59,6 +61,25 @@ actor FanDaemon {
         self.uptime = uptime
         self.journalOwner = journalOwner
         self.requireRootJournalOwnership = requireRootJournalOwnership
+        let journalURL = paths.sessionJournal
+        let fanIndices = inventory.fans.map(\.index)
+        let recordOwnership: @Sendable (Bool) throws -> Void = { ownsFtst in
+            try FanDurableFile.writeJSON(
+                FanSessionJournal(
+                    fanIndices: fanIndices,
+                    ownsFtst: ownsFtst
+                ),
+                to: journalURL,
+                permissions: 0o600,
+                owner: journalOwner
+            )
+        }
+        self.recordFanOwnership = {
+            try recordOwnership(false)
+        }
+        self.recordFtstOwnership = {
+            try recordOwnership(true)
+        }
         self.policy = FanPolicyStateMachine(configuration: configuration.policy)
         self.mode = configuration.enabled ? .waitingForProvider : .disabled
     }
@@ -241,10 +262,12 @@ actor FanDaemon {
         case .stayAutomatic(let reason):
             mode = serviceMode(for: reason)
         case .engage(let speedPercent, _):
-            try preflightForControl()
-            try persistOwnershipIntent()
             do {
-                let session = try await controller.engage(speedPercent: speedPercent)
+                let session = try await controller.engage(
+                    speedPercent: speedPercent,
+                    beforeFanWrite: recordFanOwnership,
+                    beforeFtstWrite: recordFtstOwnership
+                )
                 try persistOwnership(session)
                 lastMaintenanceAt = uptime()
                 mode = .manual
@@ -256,11 +279,15 @@ actor FanDaemon {
             }
         case .maintain:
             if uptime() - lastMaintenanceAt >= Self.maintenanceIntervalSeconds {
-                // Maintenance can newly need Ftst after firmware reclaims mode.
-                // Widen the crash journal before that possible write, then narrow
-                // it to the controller's actual ownership on success.
-                try persistOwnershipIntent()
-                let session = try await controller.maintain()
+                // Refresh the journal with current ownership. The controller
+                // widens Ftst ownership only after it observes the gate free,
+                // immediately before a possible write.
+                if let currentSession = await controller.currentSession() {
+                    try persistOwnership(currentSession)
+                }
+                let session = try await controller.maintain(
+                    beforeFtstWrite: recordFtstOwnership
+                )
                 try persistOwnership(session)
                 lastMaintenanceAt = uptime()
             }
@@ -271,32 +298,6 @@ actor FanDaemon {
             }
             mode = serviceMode(for: reason)
         }
-    }
-
-    private func preflightForControl() throws {
-        let readings = try reader.fanReadings(in: inventory)
-        let foreign = readings.filter { $0.mode == .manual }.map { $0.capability.index }
-        guard foreign.isEmpty else {
-            throw FanControllerError.foreignManualControl(indices: foreign)
-        }
-        if let ftstKey = inventory.ftstKey {
-            let value = try readerValue(ftstKey)
-            guard value == 0 else {
-                throw FanControllerError.foreignFtst(rawValue: value)
-            }
-        }
-    }
-
-    private func persistOwnershipIntent() throws {
-        try FanDurableFile.writeJSON(
-            FanSessionJournal(
-                fanIndices: inventory.fans.map(\.index),
-                ownsFtst: inventory.ftstKey != nil
-            ),
-            to: paths.sessionJournal,
-            permissions: 0o600,
-            owner: journalOwner
-        )
     }
 
     private func persistOwnership(_ session: FanControlSession) throws {
@@ -352,10 +353,6 @@ actor FanDaemon {
             await controller.isControlling
                 || FileManager.default.fileExists(atPath: paths.sessionJournal.path)
         }
-    }
-
-    private func readerValue(_ key: SMCKey) throws -> UInt8 {
-        try backend.read(key).uint8()
     }
 
     private func serviceMode(for reason: FanPolicyReason) -> FanServiceMode {

--- a/provider-swift/Sources/DarkbloomFanHelper/FanDaemon.swift
+++ b/provider-swift/Sources/DarkbloomFanHelper/FanDaemon.swift
@@ -315,7 +315,9 @@ actor FanDaemon {
         }
         do {
             if await controller.isControlling {
-                try await controller.restoreAutomatic()
+                try await controller.restoreAutomatic(
+                    recordOwnership: recordOwnership
+                )
             } else {
                 try FanOwnershipRecovery.reconcile(
                     backend: backend,

--- a/provider-swift/Sources/DarkbloomFanHelper/FanDaemon.swift
+++ b/provider-swift/Sources/DarkbloomFanHelper/FanDaemon.swift
@@ -1,0 +1,378 @@
+import DarkbloomFanCore
+import DarkbloomFanProtocol
+import DarkbloomFanService
+import Foundation
+import OSLog
+
+#if canImport(Darwin)
+import Darwin
+#endif
+
+private enum FanDaemonError: Error {
+    case automaticRestoreFailed
+}
+
+actor FanDaemon {
+    typealias Uptime = @Sendable () -> TimeInterval
+    private static let maintenanceIntervalSeconds: TimeInterval = 5
+
+    private let logger = Logger(subsystem: "io.darkbloom.fan", category: "daemon")
+    private let configuration: FanServiceConfiguration
+    private let paths: FanServicePaths
+    private let backend: any SMCBackend
+    private let inventory: FanInventory
+    private let reader: FanHardwareReader
+    private let controller: TransactionalFanController
+    private let uptime: Uptime
+    private let journalOwner: (uid: uid_t, gid: gid_t)?
+    private let requireRootJournalOwnership: Bool
+
+    private var policy: FanPolicyStateMachine
+    private var pollTask: Task<Void, Never>?
+    private var leaseSessionID: UUID?
+    private var leaseExpiresAt: TimeInterval = 0
+    private var powerSuspended = false
+    private var administrativelyDisabled = false
+    private var mode: FanServiceMode
+    private var gpuTemperatureC: Double?
+    private var fanReadings: [FanReading] = []
+    private var lastError: String?
+    private var lastMaintenanceAt: TimeInterval = 0
+
+    init(
+        configuration: FanServiceConfiguration,
+        paths: FanServicePaths,
+        backend: any SMCBackend,
+        inventory: FanInventory,
+        reader: FanHardwareReader,
+        controller: TransactionalFanController,
+        uptime: @escaping Uptime = { ProcessInfo.processInfo.systemUptime },
+        journalOwner: (uid: uid_t, gid: gid_t)? = (0, 0),
+        requireRootJournalOwnership: Bool = true
+    ) {
+        self.configuration = configuration
+        self.paths = paths
+        self.backend = backend
+        self.inventory = inventory
+        self.reader = reader
+        self.controller = controller
+        self.uptime = uptime
+        self.journalOwner = journalOwner
+        self.requireRootJournalOwnership = requireRootJournalOwnership
+        self.policy = FanPolicyStateMachine(configuration: configuration.policy)
+        self.mode = configuration.enabled ? .waitingForProvider : .disabled
+    }
+
+    func start() {
+        guard pollTask == nil else { return }
+        pollTask = Task { [weak self] in
+            while !Task.isCancelled {
+                await self?.tick()
+                do {
+                    try await Task.sleep(nanoseconds: 1_000_000_000)
+                } catch {
+                    return
+                }
+            }
+        }
+    }
+
+    func renewLease(
+        sessionID: UUID,
+        protocolVersion: Int,
+        providerVersion: String
+    ) -> FanIPCReply {
+        guard effectiveEnabled else {
+            return FanIPCReply(ok: false, message: "fan control is disabled")
+        }
+        guard !powerSuspended else {
+            return FanIPCReply(ok: false, message: "system sleep is in progress")
+        }
+        guard protocolVersion == FanIPC.protocolVersion else {
+            return FanIPCReply(
+                ok: false,
+                message: "helper upgrade required (provider protocol \(protocolVersion), helper protocol \(FanIPC.protocolVersion))"
+            )
+        }
+        guard providerVersion.utf8.count <= 64 else {
+            return FanIPCReply(ok: false, message: "provider version is invalid")
+        }
+        leaseSessionID = sessionID
+        leaseExpiresAt = uptime() + FanIPC.leaseDurationSeconds
+        return FanIPCReply(ok: true)
+    }
+
+    func releaseLease(sessionID: UUID) async -> FanIPCReply {
+        if leaseSessionID == sessionID {
+            leaseSessionID = nil
+            leaseExpiresAt = 0
+            let restored = await restoreAutomatic(reason: "provider lease released")
+            return FanIPCReply(
+                ok: restored,
+                message: restored ? nil : lastError
+            )
+        }
+        return FanIPCReply(ok: true)
+    }
+
+    func sessionInvalidated(_ sessionID: UUID) async {
+        guard leaseSessionID == sessionID else { return }
+        leaseSessionID = nil
+        leaseExpiresAt = 0
+        _ = await restoreAutomatic(reason: "provider XPC session ended")
+    }
+
+    func emergencyRestore() async -> FanIPCReply {
+        administrativelyDisabled = true
+        leaseSessionID = nil
+        leaseExpiresAt = 0
+        let restored = await restoreAutomatic(reason: "administrator requested Auto")
+        return FanIPCReply(ok: restored, message: restored ? nil : lastError)
+    }
+
+    func status() -> FanServiceStatus {
+        FanServiceStatus(
+            enabled: effectiveEnabled,
+            configuredUID: configuration.configuredUID,
+            providerActive: providerLeaseActive,
+            mode: mode,
+            chip: inventory.chipFamily.rawValue,
+            gpuSensorKeys: inventory.gpuTemperatureKeys.map(\.rawValue),
+            gpuTemperatureC: gpuTemperatureC,
+            triggerTemperatureC: configuration.policy.triggerCelsius,
+            releaseTemperatureC: configuration.policy.releaseCelsius,
+            speedPercent: configuration.policy.speedPercent,
+            fans: fanReadings.map { reading in
+                FanServiceFanStatus(
+                    index: reading.capability.index,
+                    actualRPM: reading.actualRPM,
+                    targetRPM: reading.targetRPM,
+                    minimumRPM: reading.minimumRPM,
+                    maximumRPM: reading.maximumRPM,
+                    mode: describe(reading.mode)
+                )
+            },
+            lastError: lastError
+        )
+    }
+
+    func shutdown() async {
+        pollTask?.cancel()
+        pollTask = nil
+        leaseSessionID = nil
+        leaseExpiresAt = 0
+        _ = await restoreAutomatic(reason: "fan helper shutting down")
+    }
+
+    func prepareForSleep() async {
+        powerSuspended = true
+        leaseSessionID = nil
+        leaseExpiresAt = 0
+        _ = await restoreAutomatic(reason: "system will sleep")
+    }
+
+    func didWake() {
+        // A fresh provider renewal is required after wake. This prevents a
+        // stale pre-sleep lease from reasserting manual mode on resumed hardware.
+        powerSuspended = false
+        leaseSessionID = nil
+        leaseExpiresAt = 0
+        mode = effectiveEnabled ? .waitingForProvider : .disabled
+    }
+
+    private var providerLeaseActive: Bool {
+        !powerSuspended && leaseSessionID != nil && uptime() < leaseExpiresAt
+    }
+
+    private var effectiveEnabled: Bool {
+        configuration.enabled && !administrativelyDisabled
+    }
+
+    func tick() async {
+        guard effectiveEnabled else {
+            mode = await restoreAutomatic(reason: "fan control disabled")
+                ? .disabled : .error
+            return
+        }
+        guard !inventory.fans.isEmpty, !inventory.gpuTemperatureKeys.isEmpty else {
+            mode = await restoreAutomatic(
+                reason: "fan hardware or GPU sensors unavailable"
+            ) ? .unsupported : .error
+            return
+        }
+        if (!providerLeaseActive || mode == .error), await hasPossibleOwnership {
+            mode = await restoreAutomatic(reason: "retrying automatic restoration")
+                ? (providerLeaseActive ? .waitingForTemperature : .waitingForProvider)
+                : .error
+            return
+        }
+
+        do {
+            fanReadings = try reader.fanReadings(in: inventory)
+            let temperatures = try reader.gpuTemperatures(in: inventory)
+            gpuTemperatureC = temperatures.map(\.celsius).max()
+
+            if ProcessInfo.processInfo.thermalState == .serious
+                || ProcessInfo.processInfo.thermalState == .critical
+            {
+                mode = await restoreAutomatic(
+                    reason: "macOS reported serious thermal pressure"
+                ) ? .safetyOverride : .error
+                return
+            }
+
+            let action = policy.evaluate(FanPolicyInput(
+                providerLeaseActive: providerLeaseActive,
+                gpuTemperaturesCelsius: temperatures.map(\.celsius),
+                controlHealthy: true
+            ))
+            try await apply(action)
+            lastError = nil
+        } catch {
+            lastError = String(describing: error)
+            logger.error("fan policy tick failed: \(String(describing: error), privacy: .public)")
+            _ = await restoreAutomatic(reason: "fan policy failure")
+            mode = .error
+        }
+    }
+
+    private func apply(_ action: FanPolicyAction) async throws {
+        switch action {
+        case .stayAutomatic(let reason):
+            mode = serviceMode(for: reason)
+        case .engage(let speedPercent, _):
+            try preflightForControl()
+            try persistOwnershipIntent()
+            do {
+                let session = try await controller.engage(speedPercent: speedPercent)
+                try persistOwnership(session)
+                lastMaintenanceAt = uptime()
+                mode = .manual
+            } catch {
+                if !(await controller.isControlling) {
+                    try? FanDurableFile.remove(paths.sessionJournal)
+                }
+                throw error
+            }
+        case .maintain:
+            if uptime() - lastMaintenanceAt >= Self.maintenanceIntervalSeconds {
+                // Maintenance can newly need Ftst after firmware reclaims mode.
+                // Widen the crash journal before that possible write, then narrow
+                // it to the controller's actual ownership on success.
+                try persistOwnershipIntent()
+                let session = try await controller.maintain()
+                try persistOwnership(session)
+                lastMaintenanceAt = uptime()
+            }
+            mode = .manual
+        case .restoreAutomatic(let reason):
+            guard await restoreAutomatic(reason: String(describing: reason)) else {
+                throw FanDaemonError.automaticRestoreFailed
+            }
+            mode = serviceMode(for: reason)
+        }
+    }
+
+    private func preflightForControl() throws {
+        let readings = try reader.fanReadings(in: inventory)
+        let foreign = readings.filter { $0.mode == .manual }.map { $0.capability.index }
+        guard foreign.isEmpty else {
+            throw FanControllerError.foreignManualControl(indices: foreign)
+        }
+        if let ftstKey = inventory.ftstKey {
+            let value = try readerValue(ftstKey)
+            guard value == 0 else {
+                throw FanControllerError.foreignFtst(rawValue: value)
+            }
+        }
+    }
+
+    private func persistOwnershipIntent() throws {
+        try FanDurableFile.writeJSON(
+            FanSessionJournal(
+                fanIndices: inventory.fans.map(\.index),
+                ownsFtst: inventory.ftstKey != nil
+            ),
+            to: paths.sessionJournal,
+            permissions: 0o600,
+            owner: journalOwner
+        )
+    }
+
+    private func persistOwnership(_ session: FanControlSession) throws {
+        try FanDurableFile.writeJSON(
+            FanSessionJournal(
+                fanIndices: session.targetRPMByFan.keys.map { $0 },
+                ownsFtst: session.ownsFtst
+            ),
+            to: paths.sessionJournal,
+            permissions: 0o600,
+            owner: journalOwner
+        )
+    }
+
+    private func restoreAutomatic(reason: String) async -> Bool {
+        guard await controller.isControlling
+            || FileManager.default.fileExists(atPath: paths.sessionJournal.path)
+        else {
+            _ = policy.reset()
+            if !providerLeaseActive {
+                mode = effectiveEnabled ? .waitingForProvider : .disabled
+            }
+            return true
+        }
+        do {
+            if await controller.isControlling {
+                try await controller.restoreAutomatic()
+            } else {
+                try FanOwnershipRecovery.reconcile(
+                    backend: backend,
+                    inventory: inventory,
+                    journalURL: paths.sessionJournal,
+                    requireRootOwnership: requireRootJournalOwnership,
+                    journalOwner: journalOwner
+                )
+            }
+            try FanDurableFile.remove(paths.sessionJournal)
+            _ = policy.reset()
+            mode = effectiveEnabled
+                ? (providerLeaseActive ? .waitingForTemperature : .waitingForProvider)
+                : .disabled
+            logger.info("restored automatic fan control: \(reason, privacy: .public)")
+            return true
+        } catch {
+            lastError = "automatic restore failed: \(error)"
+            logger.fault("automatic fan restore failed: \(String(describing: error), privacy: .public)")
+            return false
+        }
+    }
+
+    private var hasPossibleOwnership: Bool {
+        get async {
+            await controller.isControlling
+                || FileManager.default.fileExists(atPath: paths.sessionJournal.path)
+        }
+    }
+
+    private func readerValue(_ key: SMCKey) throws -> UInt8 {
+        try backend.read(key).uint8()
+    }
+
+    private func serviceMode(for reason: FanPolicyReason) -> FanServiceMode {
+        switch reason {
+        case .providerInactive: return .waitingForProvider
+        case .sensorUnavailable, .invalidSensorValue: return .unsupported
+        case .controlFailure: return .error
+        default: return .waitingForTemperature
+        }
+    }
+
+    private func describe(_ mode: FanMode) -> String {
+        switch mode {
+        case .automatic: return "auto"
+        case .manual: return "manual"
+        case .system: return "system"
+        case .unknown(let value): return "unknown(\(value))"
+        }
+    }
+}

--- a/provider-swift/Sources/DarkbloomFanHelper/FanPowerMonitor.swift
+++ b/provider-swift/Sources/DarkbloomFanHelper/FanPowerMonitor.swift
@@ -1,0 +1,67 @@
+import Foundation
+import IOKit.pwr_mgt
+
+private let messageCanSystemSleep = natural_t(0xe000_0270)
+private let messageSystemWillSleep = natural_t(0xe000_0280)
+private let messageSystemHasPoweredOn = natural_t(0xe000_0300)
+
+enum FanPowerMonitorError: Error {
+    case registrationFailed
+}
+
+final class FanPowerMonitor {
+    private var rootPort: io_connect_t = 0
+    private var notificationPort: IONotificationPortRef?
+    private var notifier: io_object_t = 0
+    private let daemon: FanDaemon
+
+    init(daemon: FanDaemon) throws {
+        self.daemon = daemon
+        rootPort = IORegisterForSystemPower(
+            Unmanaged.passUnretained(self).toOpaque(),
+            &notificationPort,
+            fanPowerCallback,
+            &notifier
+        )
+        guard rootPort != 0,
+              let notificationPort,
+              let source = IONotificationPortGetRunLoopSource(notificationPort)?
+                .takeUnretainedValue()
+        else {
+            throw FanPowerMonitorError.registrationFailed
+        }
+        CFRunLoopAddSource(CFRunLoopGetMain(), source, .defaultMode)
+    }
+
+    deinit {
+        if notifier != 0 { IODeregisterForSystemPower(&notifier) }
+        if let notificationPort { IONotificationPortDestroy(notificationPort) }
+        if rootPort != 0 { IOServiceClose(rootPort) }
+    }
+
+    fileprivate func handle(message: natural_t, argument: UnsafeMutableRawPointer?) {
+        let token = Int(bitPattern: argument)
+        switch message {
+        case messageCanSystemSleep:
+            IOAllowPowerChange(rootPort, token)
+        case messageSystemWillSleep:
+            Task { [daemon, rootPort] in
+                await daemon.prepareForSleep()
+                IOAllowPowerChange(rootPort, token)
+            }
+        case messageSystemHasPoweredOn:
+            Task { [daemon] in await daemon.didWake() }
+        default:
+            break
+        }
+    }
+}
+
+private let fanPowerCallback: IOServiceInterestCallback = {
+    reference, _, messageType, messageArgument in
+    guard let reference else { return }
+    let monitor = Unmanaged<FanPowerMonitor>
+        .fromOpaque(reference)
+        .takeUnretainedValue()
+    monitor.handle(message: messageType, argument: messageArgument)
+}

--- a/provider-swift/Sources/DarkbloomFanHelper/FanXPCService.swift
+++ b/provider-swift/Sources/DarkbloomFanHelper/FanXPCService.swift
@@ -1,0 +1,130 @@
+import DarkbloomFanProtocol
+import DarkbloomFanService
+import Foundation
+import OSLog
+
+final class FanXPCService: NSObject, NSXPCListenerDelegate, @unchecked Sendable {
+    private let logger = Logger(subsystem: "io.darkbloom.fan", category: "xpc")
+    private let listener: NSXPCListener
+    private let daemon: FanDaemon
+    private let authorization: FanPeerAuthorizationPolicy
+
+    init(
+        daemon: FanDaemon,
+        configuredUID: UInt32,
+        configuredUserUUID: String
+    ) {
+        self.daemon = daemon
+        self.authorization = FanPeerAuthorizationPolicy(
+            configuredUID: configuredUID,
+            configuredUserUUID: configuredUserUUID
+        )
+        self.listener = NSXPCListener(machServiceName: FanIPC.machServiceName)
+        super.init()
+        listener.delegate = self
+        listener.setConnectionCodeSigningRequirement(
+            FanCodeRequirements.providerRequirement()
+        )
+    }
+
+    func start() {
+        listener.resume()
+    }
+
+    func listener(
+        _: NSXPCListener,
+        shouldAcceptNewConnection connection: NSXPCConnection
+    ) -> Bool {
+        let uid = UInt32(connection.effectiveUserIdentifier)
+        let currentUserUUID = uid == 0
+            ? nil
+            : try? FanUserIdentity.generatedUID(for: uid)
+        guard authorization.allows(
+            effectiveUID: uid,
+            currentUserUUID: currentUserUUID
+        ) else {
+            logger.error("rejected fan XPC peer uid=\(uid, privacy: .public)")
+            return false
+        }
+
+        let session = FanXPCSession(
+            daemon: daemon,
+            sessionID: UUID(),
+            effectiveUID: uid
+        )
+        connection.exportedInterface = NSXPCInterface(
+            with: DarkbloomFanHelperProtocol.self
+        )
+        connection.exportedObject = session
+        connection.invalidationHandler = { [daemon, sessionID = session.sessionID] in
+            Task { await daemon.sessionInvalidated(sessionID) }
+        }
+        connection.interruptionHandler = { [daemon, sessionID = session.sessionID] in
+            Task { await daemon.sessionInvalidated(sessionID) }
+        }
+        connection.resume()
+        return true
+    }
+}
+
+final class FanXPCSession: NSObject, DarkbloomFanHelperProtocol, @unchecked Sendable {
+    let sessionID: UUID
+    private let daemon: FanDaemon
+    private let effectiveUID: UInt32
+
+    init(daemon: FanDaemon, sessionID: UUID, effectiveUID: UInt32) {
+        self.daemon = daemon
+        self.sessionID = sessionID
+        self.effectiveUID = effectiveUID
+    }
+
+    func renewProviderActivity(
+        protocolVersion: Int,
+        providerVersion: String,
+        withReply reply: @escaping @Sendable (Data) -> Void
+    ) {
+        Task {
+            let result = await daemon.renewLease(
+                sessionID: sessionID,
+                protocolVersion: protocolVersion,
+                providerVersion: providerVersion
+            )
+            reply(encode(result))
+        }
+    }
+
+    func releaseProviderActivity(withReply reply: @escaping @Sendable (Data) -> Void) {
+        Task {
+            reply(encode(await daemon.releaseLease(sessionID: sessionID)))
+        }
+    }
+
+    func status(withReply reply: @escaping @Sendable (Data) -> Void) {
+        Task {
+            reply(encode(await daemon.status()))
+        }
+    }
+
+    func restoreAutomatic(withReply reply: @escaping @Sendable (Data) -> Void) {
+        guard effectiveUID == 0 else {
+            reply(encode(FanIPCReply(
+                ok: false,
+                message: "automatic restore requires root"
+            )))
+            return
+        }
+        Task {
+            reply(encode(await daemon.emergencyRestore()))
+        }
+    }
+
+    private func encode<T: Encodable>(_ value: T) -> Data {
+        do {
+            return try FanIPCCoding.encode(value)
+        } catch {
+            return Data(
+                #"{"ok":false,"message":"fan helper encoding failure","helperVersion":"1","protocolVersion":1}"#.utf8
+            )
+        }
+    }
+}

--- a/provider-swift/Sources/DarkbloomFanHelper/main.swift
+++ b/provider-swift/Sources/DarkbloomFanHelper/main.swift
@@ -1,0 +1,104 @@
+import DarkbloomFanCore
+import DarkbloomFanService
+import Foundation
+import OSLog
+
+#if canImport(Darwin)
+import Darwin
+#endif
+
+private let logger = Logger(subsystem: "io.darkbloom.fan", category: "main")
+
+guard geteuid() == 0 else {
+    logger.fault("fan helper must run as root")
+    exit(77)
+}
+
+guard FanCodeRequirements.ownIdentityIsProduction else {
+    logger.fault("fan helper does not have the expected Darkbloom Developer ID identity")
+    exit(78)
+}
+
+let paths = FanServicePaths.production
+do {
+    let backend = try AppleSMCBackend()
+    let reader = FanHardwareReader(backend: backend)
+    let recoveryInventory = try reader.discoverForRecovery()
+
+    try FanOwnershipRecovery.reconcile(
+        backend: backend,
+        inventory: recoveryInventory,
+        journalURL: paths.sessionJournal
+    )
+    let inventory = try reader.discover()
+
+    let configuration: FanServiceConfiguration
+    do {
+        let loaded = try FanDurableFile.readJSON(
+            FanServiceConfiguration.self,
+            from: paths.configuration
+        )
+        guard loaded.configuredUID != 0,
+              try FanUserIdentity.generatedUID(for: loaded.configuredUID)
+                == loaded.configuredUserUUID
+        else {
+            throw FanDurableFileError.unsafeFile("configured provider UID is invalid")
+        }
+        configuration = loaded
+    } catch {
+        // Recovery is deliberately complete before policy parsing. A corrupt
+        // config can disable control, but must never strand a prior manual mode.
+        logger.fault("cannot load root fan policy; running disabled: \(String(describing: error), privacy: .public)")
+        configuration = FanServiceConfiguration(
+            enabled: false,
+            configuredUID: UInt32.max,
+            configuredUserUUID: "00000000-0000-0000-0000-000000000000",
+            policy: .defaults
+        )
+    }
+
+    let controller = TransactionalFanController(
+        backend: backend,
+        inventory: inventory
+    )
+    let daemon = FanDaemon(
+        configuration: configuration,
+        paths: paths,
+        backend: backend,
+        inventory: inventory,
+        reader: reader,
+        controller: controller
+    )
+    let xpcService = FanXPCService(
+        daemon: daemon,
+        configuredUID: configuration.configuredUID,
+        configuredUserUUID: configuration.configuredUserUUID
+    )
+    let powerMonitor = try FanPowerMonitor(daemon: daemon)
+
+    Task { await daemon.start() }
+    xpcService.start()
+
+    signal(SIGTERM, SIG_IGN)
+    signal(SIGINT, SIG_IGN)
+    let termSource = DispatchSource.makeSignalSource(signal: SIGTERM, queue: .main)
+    let interruptSource = DispatchSource.makeSignalSource(signal: SIGINT, queue: .main)
+    let stop: @Sendable () -> Void = {
+        Task {
+            await daemon.shutdown()
+            exit(0)
+        }
+    }
+    termSource.setEventHandler(handler: stop)
+    interruptSource.setEventHandler(handler: stop)
+    termSource.resume()
+    interruptSource.resume()
+
+    logger.notice("fan helper started")
+    withExtendedLifetime((xpcService, powerMonitor, termSource, interruptSource)) {
+        RunLoop.main.run()
+    }
+} catch {
+    logger.fault("fan helper startup failed: \(String(describing: error), privacy: .public)")
+    exit(1)
+}

--- a/provider-swift/Sources/DarkbloomFanProtocol/FanIPC.swift
+++ b/provider-swift/Sources/DarkbloomFanProtocol/FanIPC.swift
@@ -1,0 +1,144 @@
+import Foundation
+
+public enum FanIPC {
+    public static let machServiceName = "io.darkbloom.fan"
+    public static let protocolVersion = 1
+    public static let helperVersion = "1"
+    public static let helperIdentifier = "io.darkbloom.fan-helper"
+    public static let providerIdentifier = "io.darkbloom.provider"
+    public static let teamID = "SLDQ2GJ6TL"
+    public static let leaseDurationSeconds: TimeInterval = 15
+    public static let renewalIntervalSeconds: TimeInterval = 5
+}
+
+@objc public protocol DarkbloomFanHelperProtocol {
+    func renewProviderActivity(
+        protocolVersion: Int,
+        providerVersion: String,
+        withReply reply: @escaping @Sendable (Data) -> Void
+    )
+
+    func releaseProviderActivity(withReply reply: @escaping @Sendable (Data) -> Void)
+
+    func status(withReply reply: @escaping @Sendable (Data) -> Void)
+
+    /// Emergency recovery for the root CLI. The helper independently verifies
+    /// that the XPC peer is both Darkbloom-signed and running as root.
+    func restoreAutomatic(withReply reply: @escaping @Sendable (Data) -> Void)
+}
+
+public struct FanIPCReply: Codable, Equatable, Sendable {
+    public let ok: Bool
+    public let message: String?
+    public let helperVersion: String
+    public let protocolVersion: Int
+
+    public init(
+        ok: Bool,
+        message: String? = nil,
+        helperVersion: String = FanIPC.helperVersion,
+        protocolVersion: Int = FanIPC.protocolVersion
+    ) {
+        self.ok = ok
+        self.message = message
+        self.helperVersion = helperVersion
+        self.protocolVersion = protocolVersion
+    }
+}
+
+public enum FanServiceMode: String, Codable, Equatable, Sendable {
+    case disabled
+    case waitingForProvider = "waiting_for_provider"
+    case waitingForTemperature = "waiting_for_temperature"
+    case manual
+    case safetyOverride = "safety_override"
+    case unsupported
+    case error
+}
+
+public struct FanServiceFanStatus: Codable, Equatable, Sendable {
+    public let index: Int
+    public let actualRPM: Double?
+    public let targetRPM: Double?
+    public let minimumRPM: Double?
+    public let maximumRPM: Double?
+    public let mode: String?
+
+    public init(
+        index: Int,
+        actualRPM: Double?,
+        targetRPM: Double?,
+        minimumRPM: Double?,
+        maximumRPM: Double?,
+        mode: String?
+    ) {
+        self.index = index
+        self.actualRPM = actualRPM
+        self.targetRPM = targetRPM
+        self.minimumRPM = minimumRPM
+        self.maximumRPM = maximumRPM
+        self.mode = mode
+    }
+}
+
+public struct FanServiceStatus: Codable, Equatable, Sendable {
+    public let helperVersion: String
+    public let protocolVersion: Int
+    public let enabled: Bool
+    public let configuredUID: UInt32
+    public let providerActive: Bool
+    public let mode: FanServiceMode
+    public let chip: String
+    public let gpuSensorKeys: [String]
+    public let gpuTemperatureC: Double?
+    public let triggerTemperatureC: Double
+    public let releaseTemperatureC: Double
+    public let speedPercent: Double
+    public let fans: [FanServiceFanStatus]
+    public let lastError: String?
+    public let updatedAt: Date
+
+    public init(
+        helperVersion: String = FanIPC.helperVersion,
+        protocolVersion: Int = FanIPC.protocolVersion,
+        enabled: Bool,
+        configuredUID: UInt32,
+        providerActive: Bool,
+        mode: FanServiceMode,
+        chip: String,
+        gpuSensorKeys: [String],
+        gpuTemperatureC: Double?,
+        triggerTemperatureC: Double,
+        releaseTemperatureC: Double,
+        speedPercent: Double,
+        fans: [FanServiceFanStatus],
+        lastError: String?,
+        updatedAt: Date = Date()
+    ) {
+        self.helperVersion = helperVersion
+        self.protocolVersion = protocolVersion
+        self.enabled = enabled
+        self.configuredUID = configuredUID
+        self.providerActive = providerActive
+        self.mode = mode
+        self.chip = chip
+        self.gpuSensorKeys = gpuSensorKeys
+        self.gpuTemperatureC = gpuTemperatureC
+        self.triggerTemperatureC = triggerTemperatureC
+        self.releaseTemperatureC = releaseTemperatureC
+        self.speedPercent = speedPercent
+        self.fans = fans
+        self.lastError = lastError
+        self.updatedAt = updatedAt
+    }
+}
+
+public enum FanIPCCoding {
+    public static func encode<T: Encodable>(_ value: T) throws -> Data {
+        try JSONEncoder().encode(value)
+    }
+
+    public static func decode<T: Decodable>(_ type: T.Type, from data: Data) throws -> T {
+        try JSONDecoder().decode(type, from: data)
+    }
+}

--- a/provider-swift/Sources/DarkbloomFanService/FanDurableFile.swift
+++ b/provider-swift/Sources/DarkbloomFanService/FanDurableFile.swift
@@ -1,0 +1,270 @@
+import Foundation
+
+#if canImport(Darwin)
+import Darwin
+#endif
+
+public enum FanDurableFileError: Error, CustomStringConvertible {
+    case unsafeFile(String)
+    case tooLarge(String)
+    case systemCall(String, Int32)
+
+    public var description: String {
+        switch self {
+        case .unsafeFile(let detail): return detail
+        case .tooLarge(let path): return "fan state file is too large: \(path)"
+        case .systemCall(let call, let code): return "\(call) failed (errno \(code))"
+        }
+    }
+}
+
+public enum FanDurableFile {
+    private static let maximumBytes = 64 * 1024
+
+    public static func readJSON<T: Decodable>(
+        _ type: T.Type,
+        from url: URL,
+        requireRootOwnership: Bool = true
+    ) throws -> T {
+        #if canImport(Darwin)
+        let directory = url.deletingLastPathComponent()
+        let directoryDescriptor = Darwin.open(
+            directory.path,
+            O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC
+        )
+        guard directoryDescriptor >= 0 else {
+            throw FanDurableFileError.systemCall("open state directory", errno)
+        }
+        defer { Darwin.close(directoryDescriptor) }
+        let descriptor = openat(
+            directoryDescriptor,
+            url.lastPathComponent,
+            O_RDONLY | O_NOFOLLOW | O_CLOEXEC
+        )
+        guard descriptor >= 0 else {
+            throw FanDurableFileError.systemCall("open state file", errno)
+        }
+        var metadata = stat()
+        guard fstat(descriptor, &metadata) == 0 else {
+            Darwin.close(descriptor)
+            throw FanDurableFileError.systemCall("fstat", errno)
+        }
+        guard metadata.st_mode & S_IFMT == S_IFREG else {
+            Darwin.close(descriptor)
+            throw FanDurableFileError.unsafeFile(
+                "fan state must be a regular file: \(url.path)"
+            )
+        }
+        if requireRootOwnership {
+            guard metadata.st_uid == 0 else {
+                Darwin.close(descriptor)
+                throw FanDurableFileError.unsafeFile(
+                    "fan state is not root-owned: \(url.path)"
+                )
+            }
+            guard metadata.st_mode & (S_IWGRP | S_IWOTH) == 0 else {
+                Darwin.close(descriptor)
+                throw FanDurableFileError.unsafeFile(
+                    "fan state is group/world-writable: \(url.path)"
+                )
+            }
+        }
+        guard metadata.st_size <= maximumBytes else {
+            Darwin.close(descriptor)
+            throw FanDurableFileError.tooLarge(url.path)
+        }
+        let handle = FileHandle(fileDescriptor: descriptor, closeOnDealloc: true)
+        let data = try handle.read(upToCount: maximumBytes + 1) ?? Data()
+        try handle.close()
+        guard data.count <= maximumBytes else {
+            throw FanDurableFileError.tooLarge(url.path)
+        }
+        #else
+        let data = try Data(contentsOf: url, options: [.mappedIfSafe])
+        #endif
+        guard data.count <= maximumBytes else {
+            throw FanDurableFileError.tooLarge(url.path)
+        }
+        return try JSONDecoder().decode(type, from: data)
+    }
+
+    public static func writeJSON<T: Encodable>(
+        _ value: T,
+        to url: URL,
+        permissions: mode_t,
+        owner: (uid: uid_t, gid: gid_t)? = (0, 0)
+    ) throws {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let data = try encoder.encode(value)
+        guard data.count <= maximumBytes else {
+            throw FanDurableFileError.tooLarge(url.path)
+        }
+        try write(
+            data,
+            to: url,
+            permissions: permissions,
+            owner: owner
+        )
+    }
+
+    public static func writeData(
+        _ data: Data,
+        to url: URL,
+        permissions: mode_t,
+        owner: (uid: uid_t, gid: gid_t)? = (0, 0)
+    ) throws {
+        guard data.count <= maximumBytes else {
+            throw FanDurableFileError.tooLarge(url.path)
+        }
+        try write(
+            data,
+            to: url,
+            permissions: permissions,
+            owner: owner
+        )
+    }
+
+    public static func remove(_ url: URL) throws {
+        #if canImport(Darwin)
+        let directory = url.deletingLastPathComponent()
+        let descriptor = Darwin.open(
+            directory.path,
+            O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC
+        )
+        if descriptor < 0, errno == ENOENT { return }
+        guard descriptor >= 0 else {
+            throw FanDurableFileError.systemCall("open remove directory", errno)
+        }
+        defer { Darwin.close(descriptor) }
+        if unlinkat(descriptor, url.lastPathComponent, 0) != 0, errno != ENOENT {
+            throw FanDurableFileError.systemCall("unlinkat", errno)
+        }
+        guard fsync(descriptor) == 0 else {
+            throw FanDurableFileError.systemCall("fsync directory", errno)
+        }
+        #else
+        try? FileManager.default.removeItem(at: url)
+        #endif
+    }
+
+    private static func write(
+        _ data: Data,
+        to url: URL,
+        permissions: mode_t,
+        owner: (uid: uid_t, gid: gid_t)?
+    ) throws {
+        let directory = url.deletingLastPathComponent()
+
+        #if canImport(Darwin)
+        var directoryMetadata = stat()
+        if lstat(directory.path, &directoryMetadata) != 0 {
+            guard errno == ENOENT else {
+                throw FanDurableFileError.systemCall("lstat directory", errno)
+            }
+            try FileManager.default.createDirectory(
+                at: directory,
+                withIntermediateDirectories: true
+            )
+        } else if directoryMetadata.st_mode & S_IFMT != S_IFDIR {
+            throw FanDurableFileError.unsafeFile(
+                "fan state parent must be a non-symlink directory: \(directory.path)"
+            )
+        }
+        guard lstat(directory.path, &directoryMetadata) == 0,
+              directoryMetadata.st_mode & S_IFMT == S_IFDIR
+        else {
+            throw FanDurableFileError.unsafeFile(
+                "fan state parent is unsafe: \(directory.path)"
+            )
+        }
+        if owner != nil {
+            guard directoryMetadata.st_uid == 0,
+                  directoryMetadata.st_mode & (S_IWGRP | S_IWOTH) == 0
+            else {
+                throw FanDurableFileError.unsafeFile(
+                    "fan state parent is not a root-only directory: \(directory.path)"
+                )
+            }
+        }
+        let directoryDescriptor = Darwin.open(
+            directory.path,
+            O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC
+        )
+        guard directoryDescriptor >= 0 else {
+            throw FanDurableFileError.systemCall("open state directory", errno)
+        }
+        defer { Darwin.close(directoryDescriptor) }
+        guard fstat(directoryDescriptor, &directoryMetadata) == 0,
+              directoryMetadata.st_mode & S_IFMT == S_IFDIR
+        else {
+            throw FanDurableFileError.unsafeFile(
+                "fan state directory changed during validation: \(directory.path)"
+            )
+        }
+        let temporaryName = ".\(url.lastPathComponent).\(UUID().uuidString).tmp"
+        let descriptor = openat(
+            directoryDescriptor,
+            temporaryName,
+            O_WRONLY | O_CREAT | O_EXCL | O_NOFOLLOW | O_CLOEXEC,
+            permissions
+        )
+        guard descriptor >= 0 else {
+            throw FanDurableFileError.systemCall("open", errno)
+        }
+        var shouldRemoveTemporary = true
+        defer {
+            Darwin.close(descriptor)
+            if shouldRemoveTemporary {
+                _ = unlinkat(directoryDescriptor, temporaryName, 0)
+            }
+        }
+
+        try data.withUnsafeBytes { rawBuffer in
+            var offset = 0
+            while offset < rawBuffer.count {
+                let written = Darwin.write(
+                    descriptor,
+                    rawBuffer.baseAddress!.advanced(by: offset),
+                    rawBuffer.count - offset
+                )
+                if written < 0, errno == EINTR { continue }
+                guard written > 0 else {
+                    throw FanDurableFileError.systemCall("write", errno)
+                }
+                offset += written
+            }
+        }
+        guard fchmod(descriptor, permissions) == 0 else {
+            throw FanDurableFileError.systemCall("fchmod", errno)
+        }
+        if let owner {
+            guard fchown(descriptor, owner.uid, owner.gid) == 0 else {
+                throw FanDurableFileError.systemCall("fchown", errno)
+            }
+        }
+        guard fsync(descriptor) == 0 else {
+            throw FanDurableFileError.systemCall("fsync", errno)
+        }
+        guard renameat(
+            directoryDescriptor,
+            temporaryName,
+            directoryDescriptor,
+            url.lastPathComponent
+        ) == 0 else {
+            throw FanDurableFileError.systemCall("renameat", errno)
+        }
+        shouldRemoveTemporary = false
+        guard fsync(directoryDescriptor) == 0 else {
+            throw FanDurableFileError.systemCall("fsync directory", errno)
+        }
+        #else
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true
+        )
+        try data.write(to: url, options: .atomic)
+        #endif
+    }
+
+}

--- a/provider-swift/Sources/DarkbloomFanService/FanLaunchDaemon.swift
+++ b/provider-swift/Sources/DarkbloomFanService/FanLaunchDaemon.swift
@@ -1,0 +1,16 @@
+import DarkbloomFanProtocol
+import Foundation
+
+public enum FanLaunchDaemon {
+    public static func propertyList(paths: FanServicePaths) -> [String: Any] {
+        [
+            "Label": FanIPC.machServiceName,
+            "ProgramArguments": [paths.helper.path],
+            "MachServices": [FanIPC.machServiceName: true],
+            "RunAtLoad": true,
+            "KeepAlive": true,
+            "ThrottleInterval": 10,
+            "ProcessType": "Background",
+        ]
+    }
+}

--- a/provider-swift/Sources/DarkbloomFanService/FanOwnershipRecovery.swift
+++ b/provider-swift/Sources/DarkbloomFanService/FanOwnershipRecovery.swift
@@ -1,0 +1,113 @@
+import DarkbloomFanCore
+import Foundation
+
+#if canImport(Darwin)
+import Darwin
+#endif
+
+public struct FanOwnershipRecoveryError: Error, CustomStringConvertible {
+    public let failures: [FanRollbackFailure]
+
+    public var description: String {
+        "fan ownership recovery failed: "
+            + failures.map(\.description).joined(separator: "; ")
+    }
+}
+
+public enum FanOwnershipRecovery {
+    public static func reconcile(
+        backend: any SMCBackend,
+        inventory: FanInventory,
+        journalURL: URL,
+        requireRootOwnership: Bool = true,
+        journalOwner: (uid: uid_t, gid: gid_t)? = (0, 0)
+    ) throws {
+        guard FileManager.default.fileExists(atPath: journalURL.path) else {
+            return
+        }
+        let journal = try FanDurableFile.readJSON(
+            FanSessionJournal.self,
+            from: journalURL,
+            requireRootOwnership: requireRootOwnership
+        )
+
+        var failures: [FanRollbackFailure] = []
+        var unresolvedFans: [Int] = []
+        for index in journal.fanIndices {
+            do {
+                guard let fan = inventory.fans.first(where: { $0.index == index }) else {
+                    throw FanControllerError.noFans
+                }
+                try backend.write(fan.modeKey, bytes: [FanMode.automatic.rawValue])
+                let rawMode = try backend.read(fan.modeKey).uint8()
+                guard FanMode(rawValue: rawMode).isAutomatic else {
+                    throw FanRollbackError.modeNotAutomatic(rawValue: rawMode)
+                }
+                if let zero = try? SMCValue.float32Bytes(0, key: fan.targetKey) {
+                    try? backend.write(fan.targetKey, bytes: zero)
+                }
+            } catch {
+                unresolvedFans.append(index)
+                failures.append(FanRollbackFailure(
+                    fanIndex: index,
+                    step: .restoreMode,
+                    error: recoveryError(error)
+                ))
+            }
+        }
+
+        var unresolvedFtst = false
+        if journal.ownsFtst, let ftstKey = inventory.ftstKey {
+            do {
+                try backend.write(ftstKey, bytes: [0])
+                let value = try backend.read(ftstKey).uint8()
+                guard value == 0 else {
+                    throw FanRollbackError.ftstStillSet(rawValue: value)
+                }
+            } catch {
+                unresolvedFtst = true
+                failures.append(FanRollbackFailure(
+                    fanIndex: nil,
+                    step: .clearFtst,
+                    error: recoveryError(error)
+                ))
+            }
+        } else if journal.ownsFtst {
+            unresolvedFtst = true
+            failures.append(FanRollbackFailure(
+                fanIndex: nil,
+                step: .clearFtst,
+                error: .smc(.keyNotFound("Ftst"))
+            ))
+        }
+
+        guard !failures.isEmpty else {
+            try FanDurableFile.remove(journalURL)
+            return
+        }
+        try FanDurableFile.writeJSON(
+            FanSessionJournal(
+                fanIndices: unresolvedFans,
+                ownsFtst: unresolvedFtst
+            ),
+            to: journalURL,
+            permissions: 0o600,
+            owner: journalOwner
+        )
+        throw FanOwnershipRecoveryError(failures: failures)
+    }
+
+    private static func recoveryError(_ error: Error) -> FanRollbackError {
+        if let error = error as? FanRollbackError { return error }
+        if let error = error as? FanHardwareError { return .hardware(error) }
+        if let error = error as? SMCError { return .smc(error) }
+        if let error = error as? FanControllerError {
+            switch error {
+            case .hardware(let hardware): return .hardware(hardware)
+            case .smc(let smc): return .smc(smc)
+            default: return .smc(.injectedFailure(error.description))
+            }
+        }
+        return .smc(.injectedFailure(String(describing: error)))
+    }
+}

--- a/provider-swift/Sources/DarkbloomFanService/FanPeerAuthentication.swift
+++ b/provider-swift/Sources/DarkbloomFanService/FanPeerAuthentication.swift
@@ -1,0 +1,86 @@
+import DarkbloomFanProtocol
+import Foundation
+import Security
+
+public struct FanPeerAuthorizationPolicy: Equatable, Sendable {
+    public let configuredUID: UInt32
+    public let configuredUserUUID: String
+
+    public init(configuredUID: UInt32, configuredUserUUID: String) {
+        self.configuredUID = configuredUID
+        self.configuredUserUUID = configuredUserUUID
+    }
+
+    public func allows(
+        effectiveUID: UInt32,
+        currentUserUUID: String?,
+        rootOnly: Bool = false
+    ) -> Bool {
+        if rootOnly {
+            return effectiveUID == 0
+        }
+        if effectiveUID == 0 { return true }
+        guard effectiveUID == configuredUID,
+              let currentUserUUID,
+              let current = UUID(uuidString: currentUserUUID),
+              let configured = UUID(uuidString: configuredUserUUID)
+        else {
+            return false
+        }
+        return current == configured
+    }
+}
+
+public enum FanCodeRequirements {
+    public static func ownTeamID() -> String? {
+        var code: SecCode?
+        guard SecCodeCopySelf([], &code) == errSecSuccess, let code else {
+            return nil
+        }
+        var staticCode: SecStaticCode?
+        guard SecCodeCopyStaticCode(code, [], &staticCode) == errSecSuccess,
+              let staticCode
+        else {
+            return nil
+        }
+        var information: CFDictionary?
+        guard SecCodeCopySigningInformation(
+            staticCode,
+            SecCSFlags(rawValue: kSecCSSigningInformation),
+            &information
+        ) == errSecSuccess,
+            let dictionary = information as? [String: Any]
+        else {
+            return nil
+        }
+        return dictionary[kSecCodeInfoTeamIdentifier as String] as? String
+    }
+
+    public static func requirement(identifier: String, teamID: String?) -> String {
+        guard let teamID, !teamID.isEmpty else {
+            // Local ad-hoc builds have no Team ID. NSXPCConnection still
+            // validates the peer's signature and exact signing identifier.
+            return "identifier \"\(identifier)\""
+        }
+        return "anchor apple generic and identifier \"\(identifier)\" "
+            + "and certificate leaf[subject.OU] = \"\(teamID)\""
+    }
+
+    public static var ownIdentityIsProduction: Bool {
+        ownTeamID() == FanIPC.teamID
+    }
+
+    public static func providerRequirement() -> String {
+        return requirement(
+            identifier: FanIPC.providerIdentifier,
+            teamID: FanIPC.teamID
+        )
+    }
+
+    public static func helperRequirement() -> String {
+        return requirement(
+            identifier: FanIPC.helperIdentifier,
+            teamID: FanIPC.teamID
+        )
+    }
+}

--- a/provider-swift/Sources/DarkbloomFanService/FanServiceConfiguration.swift
+++ b/provider-swift/Sources/DarkbloomFanService/FanServiceConfiguration.swift
@@ -1,0 +1,111 @@
+import DarkbloomFanCore
+import Foundation
+
+public struct FanServiceConfiguration: Equatable, Codable, Sendable {
+    public static let schemaVersion = 1
+
+    public let schema: Int
+    public let enabled: Bool
+    public let configuredUID: UInt32
+    public let configuredUserUUID: String
+    public let policy: FanPolicyConfiguration
+
+    public init(
+        enabled: Bool,
+        configuredUID: UInt32,
+        configuredUserUUID: String,
+        policy: FanPolicyConfiguration = .defaults
+    ) {
+        self.schema = Self.schemaVersion
+        self.enabled = enabled
+        self.configuredUID = configuredUID
+        self.configuredUserUUID = configuredUserUUID
+        self.policy = policy
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case schema
+        case enabled
+        case configuredUID = "configured_uid"
+        case configuredUserUUID = "configured_user_uuid"
+        case policy
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let schema = try container.decode(Int.self, forKey: .schema)
+        guard schema == Self.schemaVersion else {
+            throw DecodingError.dataCorruptedError(
+                forKey: .schema,
+                in: container,
+                debugDescription: "unsupported fan configuration schema \(schema)"
+            )
+        }
+        let enabled = try container.decode(Bool.self, forKey: .enabled)
+        let configuredUID = try container.decode(UInt32.self, forKey: .configuredUID)
+        let configuredUserUUID = try container.decode(
+            String.self,
+            forKey: .configuredUserUUID
+        )
+        guard UUID(uuidString: configuredUserUUID) != nil else {
+            throw DecodingError.dataCorruptedError(
+                forKey: .configuredUserUUID,
+                in: container,
+                debugDescription: "configured user UUID is invalid"
+            )
+        }
+        let decodedPolicy = try container.decode(
+            FanPolicyConfiguration.self,
+            forKey: .policy
+        )
+        let policy = try FanPolicyConfiguration(
+            triggerCelsius: decodedPolicy.triggerCelsius,
+            releaseCelsius: decodedPolicy.releaseCelsius,
+            speedPercent: decodedPolicy.speedPercent,
+            engageSampleCount: decodedPolicy.engageSampleCount,
+            releaseSampleCount: decodedPolicy.releaseSampleCount
+        )
+
+        self.schema = schema
+        self.enabled = enabled
+        self.configuredUID = configuredUID
+        self.configuredUserUUID = configuredUserUUID
+        self.policy = policy
+    }
+}
+
+public struct FanServicePaths: Equatable, Sendable {
+    public let helper: URL
+    public let launchDaemonPlist: URL
+    public let configuration: URL
+    public let sessionJournal: URL
+
+    public init(
+        helper: URL,
+        launchDaemonPlist: URL,
+        configuration: URL,
+        sessionJournal: URL
+    ) {
+        self.helper = helper
+        self.launchDaemonPlist = launchDaemonPlist
+        self.configuration = configuration
+        self.sessionJournal = sessionJournal
+    }
+
+    public static let production = FanServicePaths(
+        helper: URL(fileURLWithPath: "/Library/PrivilegedHelperTools/io.darkbloom.fan-helper"),
+        launchDaemonPlist: URL(fileURLWithPath: "/Library/LaunchDaemons/io.darkbloom.fan.plist"),
+        configuration: URL(fileURLWithPath: "/Library/Application Support/Darkbloom/fan-policy.json"),
+        sessionJournal: URL(fileURLWithPath: "/Library/Application Support/Darkbloom/fan-session.json")
+    )
+}
+
+public struct FanSessionJournal: Equatable, Codable, Sendable {
+    public let fanIndices: [Int]
+    public let ownsFtst: Bool
+
+    public init(fanIndices: [Int], ownsFtst: Bool) {
+        self.fanIndices = Array(Set(fanIndices)).sorted()
+        self.ownsFtst = ownsFtst
+    }
+}

--- a/provider-swift/Sources/DarkbloomFanService/FanUserIdentity.swift
+++ b/provider-swift/Sources/DarkbloomFanService/FanUserIdentity.swift
@@ -1,0 +1,84 @@
+import Foundation
+
+#if canImport(Darwin)
+import Darwin
+#endif
+
+public enum FanUserIdentityError: Error, CustomStringConvertible {
+    case unknownUID(UInt32)
+    case invalidUsername
+    case directoryQueryFailed
+    case invalidGeneratedUID
+
+    public var description: String {
+        switch self {
+        case .unknownUID(let uid): return "no local account exists for UID \(uid)"
+        case .invalidUsername: return "local account name is invalid"
+        case .directoryQueryFailed: return "could not query the account GeneratedUID"
+        case .invalidGeneratedUID: return "the account has no valid GeneratedUID"
+        }
+    }
+}
+
+public enum FanUserIdentity {
+    public static func generatedUID(for uid: UInt32) throws -> String {
+        let username = try username(for: uid)
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/dscl")
+        process.arguments = [".", "-read", "/Users/\(username)", "GeneratedUID"]
+        process.standardInput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+        let output = Pipe()
+        process.standardOutput = output
+        let finished = DispatchSemaphore(value: 0)
+        process.terminationHandler = { _ in finished.signal() }
+        try process.run()
+        guard finished.wait(timeout: .now() + 3) == .success else {
+            process.terminate()
+            throw FanUserIdentityError.directoryQueryFailed
+        }
+        guard process.terminationStatus == 0 else {
+            throw FanUserIdentityError.directoryQueryFailed
+        }
+        let text = String(
+            decoding: output.fileHandleForReading.readDataToEndOfFile(),
+            as: UTF8.self
+        )
+        guard let raw = text.split(separator: ":", maxSplits: 1).last?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+              let uuid = UUID(uuidString: raw)
+        else {
+            throw FanUserIdentityError.invalidGeneratedUID
+        }
+        return uuid.uuidString
+    }
+
+    private static func username(for uid: UInt32) throws -> String {
+        #if canImport(Darwin)
+        var record = passwd()
+        var result: UnsafeMutablePointer<passwd>?
+        var buffer = [CChar](repeating: 0, count: 16 * 1024)
+        let status = getpwuid_r(
+            uid_t(uid),
+            &record,
+            &buffer,
+            buffer.count,
+            &result
+        )
+        guard status == 0, result != nil, let name = record.pw_name else {
+            throw FanUserIdentityError.unknownUID(uid)
+        }
+        let username = String(cString: name)
+        let allowed = CharacterSet.alphanumerics
+            .union(CharacterSet(charactersIn: "._-"))
+        guard !username.isEmpty,
+              username.unicodeScalars.allSatisfy(allowed.contains)
+        else {
+            throw FanUserIdentityError.invalidUsername
+        }
+        return username
+        #else
+        throw FanUserIdentityError.unknownUID(uid)
+        #endif
+    }
+}

--- a/provider-swift/Sources/ProviderCore/ProviderCore.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderCore.swift
@@ -143,5 +143,5 @@ public enum ProviderCore {
     // eagerly commit only an independently capped physical plan, report pool
     // truth through existing heartbeat fields, and map terminal exhaustion to
     // retryable capacity. VLM and kv-quant slots stay contiguous.
-    public static let version = "0.7.8"
+    public static let version = "0.7.9"
 }

--- a/provider-swift/Sources/ProviderCore/Server/StandaloneServer.swift
+++ b/provider-swift/Sources/ProviderCore/Server/StandaloneServer.swift
@@ -283,6 +283,13 @@ public actor StandaloneServer {
         return didBind
     }
 
+    /// Wait for the Hummingbird service task to exit. Local mode uses this as
+    /// its serving lifetime so optional fan control ends with the HTTP server.
+    public func waitUntilStopped() async {
+        let task = serverTask
+        _ = await task?.value
+    }
+
     /// Stop the server.
     public func stop() {
         serverTask?.cancel()

--- a/provider-swift/Sources/ProviderCore/Update/DarkbloomCodeSignature.swift
+++ b/provider-swift/Sources/ProviderCore/Update/DarkbloomCodeSignature.swift
@@ -6,9 +6,14 @@ enum DarkbloomCodeSignature {
     static let designatedRequirement =
         "anchor apple generic and identifier \"\(bundleIdentifier)\" "
         + "and certificate leaf[subject.OU] = \"\(teamID)\""
+    static let fanHelperIdentifier = "io.darkbloom.fan-helper"
+    static let fanHelperDesignatedRequirement =
+        "anchor apple generic and identifier \"\(fanHelperIdentifier)\" "
+        + "and certificate leaf[subject.OU] = \"\(teamID)\""
 
     enum Policy: Sendable, Equatable {
         case darkbloomProduction
+        case darkbloomFanHelper
         case structuralForIsolatedTest
     }
 
@@ -22,6 +27,8 @@ enum DarkbloomCodeSignature {
         if deep { arguments.append("--deep") }
         if policy == .darkbloomProduction {
             arguments.append("-R=\(designatedRequirement)")
+        } else if policy == .darkbloomFanHelper {
+            arguments.append("-R=\(fanHelperDesignatedRequirement)")
         }
         arguments.append(target.path)
         try BoundedProcess.run(

--- a/provider-swift/Sources/ProviderCore/Update/FanHelperCapabilityVerifier.swift
+++ b/provider-swift/Sources/ProviderCore/Update/FanHelperCapabilityVerifier.swift
@@ -1,0 +1,95 @@
+import Foundation
+
+#if canImport(Darwin)
+import Darwin
+#endif
+
+enum FanHelperCapabilityVerifier {
+    static let binaryCapability = "darkbloom-fan-helper-v1"
+    static let markerRelativePath =
+        "Contents/Resources/darkbloom-runtime-capabilities/fan-helper-v1"
+    static let helperRelativePath = "Contents/Helpers/darkbloom-fan-helper"
+
+    static func binaryContainsCapability(_ executable: URL) throws -> Bool {
+        let data = try Data(contentsOf: executable, options: [.mappedIfSafe])
+        return data.range(of: Data(binaryCapability.utf8)) != nil
+    }
+
+    static func verify(
+        app: URL,
+        executable: URL,
+        signaturePolicy: DarkbloomCodeSignature.Policy?
+    ) throws {
+        let fileManager = FileManager.default
+        let codePresent = try binaryContainsCapability(executable)
+        let marker = app.appendingPathComponent(markerRelativePath)
+        let helper = app.appendingPathComponent(helperRelativePath)
+        let markerPresent = fileManager.fileExists(atPath: marker.path)
+        let helperPresent = fileManager.fileExists(atPath: helper.path)
+
+        guard codePresent || markerPresent || helperPresent else {
+            return // pre-fan release compatibility
+        }
+        guard codePresent, markerPresent, helperPresent else {
+            throw UpdateError.replaceFailed(
+                "fan-capable artifact requires matching CLI code, signed marker, and nested helper"
+            )
+        }
+        try requireRegularFile(marker, executable: false, label: "fan capability marker")
+        try requireRegularFile(helper, executable: true, label: "fan helper")
+        guard
+            let markerValue = try? String(contentsOf: marker, encoding: .utf8),
+            markerValue.trimmingCharacters(in: .whitespacesAndNewlines) == "1"
+        else {
+            throw UpdateError.replaceFailed("fan helper capability marker is invalid")
+        }
+
+        guard let signaturePolicy else { return }
+        let helperPolicy: DarkbloomCodeSignature.Policy =
+            signaturePolicy == .structuralForIsolatedTest
+            ? .structuralForIsolatedTest
+            : .darkbloomFanHelper
+        do {
+            try DarkbloomCodeSignature.verify(
+                helper,
+                deep: false,
+                policy: helperPolicy
+            )
+        } catch {
+            throw UpdateError.replaceFailed(
+                "fan helper code signature verification failed: \(error.localizedDescription)"
+            )
+        }
+    }
+
+    static func rejectFanCapableFlatExecutable(_ executable: URL) throws {
+        guard try binaryContainsCapability(executable) else { return }
+        throw UpdateError.replaceFailed(
+            "fan-capable releases require the signed Darkbloom.app layout"
+        )
+    }
+
+    private static func requireRegularFile(
+        _ url: URL,
+        executable: Bool,
+        label: String
+    ) throws {
+        #if canImport(Darwin)
+        var metadata = stat()
+        guard lstat(url.path, &metadata) == 0,
+              metadata.st_mode & S_IFMT == S_IFREG
+        else {
+            throw UpdateError.replaceFailed("\(label) must be a regular non-symlink file")
+        }
+        if executable,
+           metadata.st_mode & (S_IXUSR | S_IXGRP | S_IXOTH) == 0
+        {
+            throw UpdateError.replaceFailed("\(label) is not executable")
+        }
+        #else
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            throw UpdateError.replaceFailed("\(label) is missing")
+        }
+        #endif
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Update/SelfUpdater.swift
+++ b/provider-swift/Sources/ProviderCore/Update/SelfUpdater.swift
@@ -596,9 +596,15 @@ public struct SelfUpdater: Sendable {
                         try verifyRuntimeCapabilities(
                             app: extractedApp,
                             executable: appDarkbloom,
-                            fileManager: fm)
+                            fileManager: fm,
+                            signaturePolicy: signaturePolicy)
                     }
                 } else {
+                    if verification.verifyRuntimeCapabilities {
+                        try FanHelperCapabilityVerifier.rejectFanCapableFlatExecutable(
+                            flatDarkbloom
+                        )
+                    }
                     try verifyCodeSignature(
                         file: flatDarkbloom,
                         label: "darkbloom",
@@ -659,6 +665,13 @@ public struct SelfUpdater: Sendable {
                         file: app,
                         label: "Darkbloom.app",
                         deep: true
+                    )
+                    try FanHelperCapabilityVerifier.verify(
+                        app: app,
+                        executable: app.appendingPathComponent(
+                            "Contents/MacOS/darkbloom"
+                        ),
+                        signaturePolicy: .darkbloomProduction
                     )
                 } else {
                     try verifyCodeSignature(
@@ -1087,8 +1100,14 @@ public struct SelfUpdater: Sendable {
     private func verifyRuntimeCapabilities(
         app: URL,
         executable: URL,
-        fileManager: FileManager
+        fileManager: FileManager,
+        signaturePolicy: DarkbloomCodeSignature.Policy
     ) throws {
+        try FanHelperCapabilityVerifier.verify(
+            app: app,
+            executable: executable,
+            signaturePolicy: signaturePolicy
+        )
         let marker = app.appendingPathComponent(
             PackagedRuntimeSmoke.pagedCapabilityRelativePath)
         let markerPresent = fileManager.fileExists(atPath: marker.path)

--- a/provider-swift/Sources/ProviderCore/Update/UpdateInstallLayout.swift
+++ b/provider-swift/Sources/ProviderCore/Update/UpdateInstallLayout.swift
@@ -352,6 +352,13 @@ extension UpdateRecoveryStore {
                 target,
                 deep: layout == .app
             )
+            if layout == .app {
+                try FanHelperCapabilityVerifier.verify(
+                    app: bundle,
+                    executable: binary,
+                    signaturePolicy: .darkbloomProduction
+                )
+            }
         } catch {
             throw StoreError.predecessorVerificationFailed(
                 "\(target.lastPathComponent) does not satisfy the pinned Darkbloom "

--- a/provider-swift/Sources/darkbloom/Darkbloom.swift
+++ b/provider-swift/Sources/darkbloom/Darkbloom.swift
@@ -45,6 +45,7 @@ struct Darkbloom: AsyncParsableCommand {
             Report.self,
             AutoUpdate.self,
             Beta.self,
+            Fan.self,
             Watchdog.self,
             RuntimeSmoke.self,
         ]

--- a/provider-swift/Sources/darkbloom/Fan/FanCommand.swift
+++ b/provider-swift/Sources/darkbloom/Fan/FanCommand.swift
@@ -1,0 +1,351 @@
+import ArgumentParser
+import DarkbloomFanCore
+import DarkbloomFanProtocol
+import DarkbloomFanService
+import Foundation
+import ProviderCore
+
+struct Fan: AsyncParsableCommand {
+    static let packagedCapability = "darkbloom-fan-helper-v1"
+    private static var commandTypes: [ParsableCommand.Type] {
+        var commands: [ParsableCommand.Type] = [
+            Status.self, Diagnose.self, Enable.self, Configure.self,
+            Disable.self, Uninstall.self,
+        ]
+        #if DEBUG
+        commands.append(TestLease.self)
+        #endif
+        return commands
+    }
+
+    static let configuration = CommandConfiguration(
+        commandName: "fan",
+        abstract: "Experimental temperature-based fan control for providers.",
+        discussion: """
+        Fan control is disabled by default. Enabling it installs a narrowly
+        scoped root helper; manual fan targets are applied only while a signed
+        Darkbloom provider is active and a validated GPU sensor is hot enough.
+        """,
+        subcommands: commandTypes,
+        defaultSubcommand: Status.self
+    )
+}
+
+extension Fan {
+    struct Status: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            abstract: "Show fan hardware, policy, and helper state."
+        )
+
+        @Flag(help: "Emit JSON instead of text.")
+        var json = false
+
+        mutating func run() async throws {
+            let manager = FanServiceManager()
+            let diagnostic = Self.diagnosticReport()
+            let loaded = manager.isLoaded()
+            let helper: FanServiceStatus?
+            let helperError: String?
+            if loaded {
+                do {
+                    helper = try FanHelperClient().status()
+                    helperError = nil
+                } catch {
+                    helper = nil
+                    helperError = String(describing: error)
+                }
+            } else {
+                helper = nil
+                helperError = nil
+            }
+            let report = FanStatusReport(
+                capability: Fan.packagedCapability,
+                installed: manager.isInstalled(),
+                loaded: loaded,
+                helper: helper,
+                helperError: helperError,
+                diagnostic: diagnostic
+            )
+            if json {
+                try printJSON(report)
+                return
+            }
+            Self.print(report)
+        }
+
+        static func diagnosticReport() -> FanDiagnosticReport {
+            do {
+                let backend = try AppleSMCBackend()
+                let reader = FanHardwareReader(backend: backend)
+                let inventory = try reader.discover()
+                let fans = try reader.fanReadings(in: inventory)
+                let temperatures = try reader.gpuTemperatures(in: inventory)
+                return FanDiagnosticReport(
+                    chip: inventory.chipFamily.rawValue,
+                    supported: !inventory.fans.isEmpty && !inventory.gpuTemperatureKeys.isEmpty,
+                    gpuTemperatures: temperatures.map {
+                        FanTemperatureStatus(key: $0.key.rawValue, celsius: $0.celsius)
+                    },
+                    fans: fans.map(Self.fanStatus),
+                    error: nil
+                )
+            } catch {
+                return FanDiagnosticReport(
+                    chip: "Unknown",
+                    supported: false,
+                    gpuTemperatures: [],
+                    fans: [],
+                    error: String(describing: error)
+                )
+            }
+        }
+
+        static func fanStatus(_ reading: FanReading) -> FanServiceFanStatus {
+            FanServiceFanStatus(
+                index: reading.capability.index,
+                actualRPM: reading.actualRPM,
+                targetRPM: reading.targetRPM,
+                minimumRPM: reading.minimumRPM,
+                maximumRPM: reading.maximumRPM,
+                mode: describe(reading.mode)
+            )
+        }
+
+        static func describe(_ mode: FanMode) -> String {
+            switch mode {
+            case .automatic: return "auto"
+            case .manual: return "manual"
+            case .system: return "system"
+            case .unknown(let raw): return "unknown(\(raw))"
+            }
+        }
+
+        static func print(_ report: FanStatusReport) {
+            Swift.print("Darkbloom fan control (experimental)")
+            Swift.print("Installed: \(report.installed ? "yes" : "no")")
+            Swift.print("Service: \(report.loaded ? "running" : "stopped")")
+            if let helper = report.helper {
+                Swift.print("Mode: \(helper.mode.rawValue)")
+                Swift.print("Provider active: \(helper.providerActive ? "yes" : "no")")
+                Swift.print(
+                    "Policy: \(format(helper.speedPercent))% at \(format(helper.triggerTemperatureC)) C "
+                        + "(release below \(format(helper.releaseTemperatureC)) C)"
+                )
+                if let temperature = helper.gpuTemperatureC {
+                    Swift.print("GPU: \(format(temperature)) C")
+                }
+                if let error = helper.lastError {
+                    Swift.print("Last error: \(error)")
+                }
+            } else {
+                Swift.print(
+                    report.loaded
+                        ? "Mode: unknown (helper status unavailable)"
+                        : "Mode: macOS automatic"
+                )
+                if let helperError = report.helperError {
+                    Swift.print("Helper error: \(helperError)")
+                }
+            }
+
+            Swift.print("Hardware: \(report.diagnostic.chip)")
+            if let error = report.diagnostic.error {
+                Swift.print("Compatibility: unavailable (\(error))")
+            } else {
+                Swift.print("Compatibility: \(report.diagnostic.supported ? "supported" : "unsupported")")
+            }
+            for fan in report.diagnostic.fans {
+                Swift.print(
+                    "  Fan \(fan.index): actual \(rpm(fan.actualRPM)), target \(rpm(fan.targetRPM)), "
+                        + "range \(rpm(fan.minimumRPM))-\(rpm(fan.maximumRPM)), \(fan.mode ?? "unknown")"
+                )
+            }
+            if !report.diagnostic.gpuTemperatures.isEmpty {
+                let sensors = report.diagnostic.gpuTemperatures.map {
+                    "\($0.key)=\(format($0.celsius)) C"
+                }.joined(separator: ", ")
+                Swift.print("GPU sensors: \(sensors)")
+            }
+            if !report.installed {
+                Swift.print("Enable with: sudo darkbloom fan enable")
+            }
+        }
+
+        private static func rpm(_ value: Double?) -> String {
+            value.map { String(format: "%.0f", $0) } ?? "n/a"
+        }
+
+        private static func format(_ value: Double) -> String {
+            String(format: "%.1f", value)
+        }
+    }
+
+    struct Diagnose: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            abstract: "Read-only fan and GPU-sensor compatibility report."
+        )
+
+        @Flag(help: "Emit JSON instead of text.")
+        var json = false
+
+        mutating func run() async throws {
+            let report = Status.diagnosticReport()
+            if json {
+                try printJSON(report)
+            } else {
+                Status.print(FanStatusReport(
+                    capability: Fan.packagedCapability,
+                    installed: FanServiceManager().isInstalled(),
+                    loaded: FanServiceManager().isLoaded(),
+                    helper: nil,
+                    helperError: nil,
+                    diagnostic: report
+                ))
+            }
+        }
+    }
+
+    struct Enable: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            abstract: "Install and enable the opt-in root fan helper."
+        )
+
+        @Option(help: "Fan speed as percent of each fan's maximum (60-90).")
+        var speed: Double = 80
+
+        @Option(help: "GPU temperature in Celsius that engages fan control.")
+        var temperature: Double = 45
+
+        mutating func run() async throws {
+            try runMutation {
+                let status = try FanServiceManager().enable(
+                    policy: try makePolicy(speed: speed, temperature: temperature)
+                )
+                Swift.print("Experimental fan control ENABLED.")
+                Swift.print(
+                    "  \(String(format: "%.0f", status.speedPercent))% at "
+                        + "\(String(format: "%.0f", status.triggerTemperatureC)) C"
+                )
+                Swift.print("  Active only while the Darkbloom provider is running.")
+                Swift.print("  Disable with: sudo darkbloom fan disable")
+            }
+        }
+    }
+
+    struct Configure: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            abstract: "Change the enabled fan policy."
+        )
+
+        @Option(help: "Fan speed as percent of each fan's maximum (60-90).")
+        var speed: Double?
+
+        @Option(help: "GPU temperature in Celsius that engages fan control.")
+        var temperature: Double?
+
+        mutating func run() async throws {
+            guard speed != nil || temperature != nil else {
+                throw ValidationError("provide --speed, --temperature, or both")
+            }
+            try runMutation {
+                let manager = FanServiceManager()
+                let current = try manager.configuration()
+                let updated = try makePolicy(
+                    speed: speed ?? current.policy.speedPercent,
+                    temperature: temperature ?? current.policy.triggerCelsius
+                )
+                try manager.configure(policy: updated)
+                Swift.print("Fan policy updated: \(updated.speedPercent)% at \(updated.triggerCelsius) C.")
+            }
+        }
+    }
+
+    struct Disable: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            abstract: "Restore macOS automatic control and disable the helper."
+        )
+
+        mutating func run() async throws {
+            try runMutation {
+                try FanServiceManager().disable()
+                Swift.print("Fan control disabled; macOS automatic control restored.")
+            }
+        }
+    }
+
+    struct Uninstall: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            abstract: "Restore macOS automatic control and remove the helper."
+        )
+
+        mutating func run() async throws {
+            try runMutation {
+                try FanServiceManager().uninstall()
+                Swift.print("Fan helper uninstalled; macOS automatic control restored.")
+            }
+        }
+    }
+
+    #if DEBUG
+    struct TestLease: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "test-lease",
+            abstract: "Internal: hold a provider activity lease for hardware tests.",
+            shouldDisplay: false
+        )
+
+        @Option(help: "Lease duration in seconds (1-300).")
+        var seconds: Int = 30
+
+        mutating func run() async throws {
+            guard (1...300).contains(seconds) else {
+                throw ValidationError("--seconds must be between 1 and 300")
+            }
+            try await withFanActivityLease(providerVersion: ProviderCore.version) {
+                try await Task.sleep(
+                    nanoseconds: UInt64(seconds) * 1_000_000_000
+                )
+            }
+        }
+    }
+    #endif
+}
+
+private func makePolicy(speed: Double, temperature: Double) throws -> FanPolicyConfiguration {
+    try FanPolicyConfiguration(
+        triggerCelsius: temperature,
+        releaseCelsius: temperature - 5,
+        speedPercent: speed
+    )
+}
+
+private func runMutation(_ operation: () throws -> Void) throws {
+    do {
+        try operation()
+    } catch {
+        printError("fan: \(error)")
+        throw ExitCode.failure
+    }
+}
+
+struct FanStatusReport: Encodable {
+    let capability: String
+    let installed: Bool
+    let loaded: Bool
+    let helper: FanServiceStatus?
+    let helperError: String?
+    let diagnostic: FanDiagnosticReport
+}
+
+struct FanDiagnosticReport: Encodable {
+    let chip: String
+    let supported: Bool
+    let gpuTemperatures: [FanTemperatureStatus]
+    let fans: [FanServiceFanStatus]
+    let error: String?
+}
+
+struct FanTemperatureStatus: Encodable {
+    let key: String
+    let celsius: Double
+}

--- a/provider-swift/Sources/darkbloom/Fan/FanHelperClient.swift
+++ b/provider-swift/Sources/darkbloom/Fan/FanHelperClient.swift
@@ -1,0 +1,112 @@
+import DarkbloomFanProtocol
+import DarkbloomFanService
+import Foundation
+
+enum FanHelperClientError: Error, CustomStringConvertible {
+    case unavailable(String)
+    case timedOut
+    case invalidReply(String)
+
+    var description: String {
+        switch self {
+        case .unavailable(let detail): return "fan helper is unavailable: \(detail)"
+        case .timedOut: return "fan helper did not reply within 2 seconds"
+        case .invalidReply(let detail): return "fan helper returned an invalid reply: \(detail)"
+        }
+    }
+}
+
+struct FanHelperClient {
+    func status() throws -> FanServiceStatus {
+        let data = try request { proxy, reply in
+            proxy.status(withReply: reply)
+        }
+        do {
+            return try FanIPCCoding.decode(FanServiceStatus.self, from: data)
+        } catch {
+            throw FanHelperClientError.invalidReply(String(describing: error))
+        }
+    }
+
+    func restoreAutomatic() throws -> FanIPCReply {
+        let data = try request { proxy, reply in
+            proxy.restoreAutomatic(withReply: reply)
+        }
+        do {
+            return try FanIPCCoding.decode(FanIPCReply.self, from: data)
+        } catch {
+            throw FanHelperClientError.invalidReply(String(describing: error))
+        }
+    }
+
+    private func request(
+        _ send: (
+            DarkbloomFanHelperProtocol,
+            @escaping @Sendable (Data) -> Void
+        ) -> Void
+    ) throws -> Data {
+        let connection = NSXPCConnection(
+            machServiceName: FanIPC.machServiceName,
+            options: .privileged
+        )
+        connection.remoteObjectInterface = NSXPCInterface(
+            with: DarkbloomFanHelperProtocol.self
+        )
+        connection.setCodeSigningRequirement(
+            FanCodeRequirements.helperRequirement()
+        )
+
+        let reply = FanXPCReplyBox()
+        connection.interruptionHandler = {
+            reply.finish(.failure(.unavailable("connection interrupted")))
+        }
+        connection.invalidationHandler = {
+            reply.finish(.failure(.unavailable("connection invalidated")))
+        }
+        connection.resume()
+
+        guard let proxy = connection.remoteObjectProxyWithErrorHandler({ error in
+            reply.finish(.failure(.unavailable(error.localizedDescription)))
+        }) as? DarkbloomFanHelperProtocol else {
+            connection.invalidate()
+            throw FanHelperClientError.unavailable("could not create XPC proxy")
+        }
+
+        send(proxy) { data in
+            reply.finish(.success(data))
+        }
+        guard reply.wait(timeout: 2) else {
+            connection.invalidate()
+            throw FanHelperClientError.timedOut
+        }
+        connection.invalidate()
+        return try reply.result().get()
+    }
+}
+
+private final class FanXPCReplyBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private let semaphore = DispatchSemaphore(value: 0)
+    private var value: Result<Data, FanHelperClientError>?
+
+    func finish(_ result: Result<Data, FanHelperClientError>) {
+        lock.lock()
+        guard value == nil else {
+            lock.unlock()
+            return
+        }
+        value = result
+        lock.unlock()
+        semaphore.signal()
+    }
+
+    func wait(timeout: TimeInterval) -> Bool {
+        semaphore.wait(timeout: .now() + timeout) == .success
+    }
+
+    func result() -> Result<Data, FanHelperClientError> {
+        lock.lock()
+        defer { lock.unlock() }
+        return value ?? .failure(.timedOut)
+    }
+}

--- a/provider-swift/Sources/darkbloom/Fan/FanProcessRunner.swift
+++ b/provider-swift/Sources/darkbloom/Fan/FanProcessRunner.swift
@@ -1,0 +1,84 @@
+import Foundation
+
+#if canImport(Darwin)
+import Darwin
+#endif
+
+struct FanProcessResult: Equatable {
+    let status: Int32
+    let output: String
+
+    var succeeded: Bool { status == 0 }
+}
+
+enum FanProcessRunner {
+    static func run(
+        _ executable: String,
+        arguments: [String],
+        timeout: TimeInterval = 15
+    ) -> FanProcessResult {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: executable)
+        process.arguments = arguments
+        process.standardInput = FileHandle.nullDevice
+
+        let pipe = Pipe()
+        let output = FanProcessOutputBox()
+        pipe.fileHandleForReading.readabilityHandler = { handle in
+            output.append(handle.availableData)
+        }
+        process.standardOutput = pipe
+        process.standardError = pipe
+
+        let finished = DispatchSemaphore(value: 0)
+        process.terminationHandler = { _ in finished.signal() }
+        do {
+            try process.run()
+        } catch {
+            pipe.fileHandleForReading.readabilityHandler = nil
+            return FanProcessResult(status: -1, output: error.localizedDescription)
+        }
+
+        if finished.wait(timeout: .now() + timeout) == .timedOut {
+            process.terminate()
+            if finished.wait(timeout: .now() + 2) == .timedOut {
+                #if canImport(Darwin)
+                _ = Darwin.kill(process.processIdentifier, SIGKILL)
+                #endif
+                _ = finished.wait(timeout: .now() + 2)
+            }
+            pipe.fileHandleForReading.readabilityHandler = nil
+            return FanProcessResult(
+                status: -1,
+                output: "command timed out after \(Int(timeout)) seconds"
+            )
+        }
+
+        pipe.fileHandleForReading.readabilityHandler = nil
+        output.append(pipe.fileHandleForReading.readDataToEndOfFile())
+        return FanProcessResult(
+            status: process.terminationStatus,
+            output: output.string
+        )
+    }
+}
+
+private final class FanProcessOutputBox: @unchecked Sendable {
+    private static let maximumBytes = 64 * 1024
+    private let lock = NSLock()
+    private var data = Data()
+
+    func append(_ bytes: Data) {
+        guard !bytes.isEmpty else { return }
+        lock.lock()
+        defer { lock.unlock() }
+        let remaining = max(0, Self.maximumBytes - data.count)
+        data.append(bytes.prefix(remaining))
+    }
+
+    var string: String {
+        lock.lock()
+        defer { lock.unlock() }
+        return String(decoding: data, as: UTF8.self)
+    }
+}

--- a/provider-swift/Sources/darkbloom/Fan/FanServiceManager+Install.swift
+++ b/provider-swift/Sources/darkbloom/Fan/FanServiceManager+Install.swift
@@ -1,0 +1,397 @@
+import DarkbloomFanProtocol
+import DarkbloomFanService
+import CryptoKit
+import Foundation
+
+#if canImport(Darwin)
+import Darwin
+#endif
+
+extension FanServiceManager {
+    func bundledHelperURL() throws -> URL {
+        let executable = try currentExecutableURL()
+        let directory = executable.deletingLastPathComponent()
+        guard directory.lastPathComponent == "MacOS" else {
+            throw FanServiceManagerError.helperNotBundled([
+                "a signed Darkbloom.app/Contents/Helpers installation"
+            ])
+        }
+        let contents = directory.deletingLastPathComponent()
+        let app = contents.deletingLastPathComponent()
+        guard app.pathExtension == "app" else {
+            throw FanServiceManagerError.helperNotBundled([
+                "a signed Darkbloom.app/Contents/Helpers installation"
+            ])
+        }
+        let helper = contents.appendingPathComponent("Helpers/darkbloom-fan-helper")
+        try verifyBundledApp(app: app, executable: executable, helper: helper)
+        return helper
+    }
+
+    func currentExecutableURL() throws -> URL {
+        #if canImport(Darwin)
+        var size: UInt32 = 0
+        _ = _NSGetExecutablePath(nil, &size)
+        var buffer = [CChar](repeating: 0, count: Int(size))
+        guard _NSGetExecutablePath(&buffer, &size) == 0 else {
+            throw FanServiceManagerError.unsafeFile("could not resolve current executable")
+        }
+        let path = String(decoding: buffer.prefix { $0 != 0 }.map(UInt8.init), as: UTF8.self)
+        guard let resolved = realpath(path, nil) else {
+            throw FanServiceManagerError.unsafeFile("could not canonicalize current executable")
+        }
+        defer { free(resolved) }
+        return URL(fileURLWithPath: String(cString: resolved))
+        #else
+        return URL(fileURLWithPath: CommandLine.arguments[0])
+        #endif
+    }
+
+    func verifyRegularExecutable(_ url: URL) throws {
+        var metadata = stat()
+        guard lstat(url.path, &metadata) == 0,
+              metadata.st_mode & S_IFMT == S_IFREG,
+              metadata.st_mode & (S_IXUSR | S_IXGRP | S_IXOTH) != 0
+        else {
+            throw FanServiceManagerError.unsafeFile(
+                "fan helper is not a regular executable: \(url.path)"
+            )
+        }
+    }
+
+    func verifyHelperSignature(_ url: URL) throws {
+        let result = FanProcessRunner.run(
+            "/usr/bin/codesign",
+            arguments: [
+                "--verify", "--strict", "--verbose=2",
+                "-R=\(FanCodeRequirements.helperRequirement())",
+                url.path,
+            ]
+        )
+        guard result.succeeded else {
+            throw FanServiceManagerError.signatureFailed(result.output)
+        }
+    }
+
+    func verifyBundledApp(app: URL, executable: URL, helper: URL) throws {
+        let appRequirement = FanCodeRequirements.requirement(
+            identifier: FanIPC.providerIdentifier,
+            teamID: FanIPC.teamID
+        )
+        let signature = FanProcessRunner.run(
+            "/usr/bin/codesign",
+            arguments: [
+                "--verify", "--deep", "--strict", "--verbose=2",
+                "-R=\(appRequirement)", app.path,
+            ]
+        )
+        guard signature.succeeded else {
+            throw FanServiceManagerError.signatureFailed(
+                "outer Darkbloom.app: \(signature.output)"
+            )
+        }
+
+        let marker = app.appendingPathComponent(
+            "Contents/Resources/darkbloom-runtime-capabilities/fan-helper-v1"
+        )
+        var markerMetadata = stat()
+        guard lstat(marker.path, &markerMetadata) == 0,
+              markerMetadata.st_mode & S_IFMT == S_IFREG,
+              let markerValue = try? String(contentsOf: marker, encoding: .utf8),
+              markerValue.trimmingCharacters(in: .whitespacesAndNewlines) == "1",
+              let binary = try? Data(contentsOf: executable, options: [.mappedIfSafe]),
+              binary.range(of: Data("darkbloom-fan-helper-v1".utf8)) != nil
+        else {
+            throw FanServiceManagerError.unsafeFile(
+                "Darkbloom.app fan capability marker is missing or invalid"
+            )
+        }
+        try verifyRegularExecutable(helper)
+        try verifyHelperSignature(helper)
+    }
+
+    func installHelper(from source: URL) throws {
+        let directory = paths.helper.deletingLastPathComponent()
+        try ensureRootDirectory(directory)
+        let directoryDescriptor = Darwin.open(
+            directory.path,
+            O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC
+        )
+        guard directoryDescriptor >= 0 else {
+            throw FanServiceManagerError.unsafeFile(
+                "could not open helper directory safely (errno \(errno))"
+            )
+        }
+        defer { Darwin.close(directoryDescriptor) }
+
+        let sourceDescriptor = Darwin.open(source.path, O_RDONLY | O_NOFOLLOW | O_CLOEXEC)
+        guard sourceDescriptor >= 0 else {
+            throw FanServiceManagerError.unsafeFile(
+                "could not open bundled helper safely (errno \(errno))"
+            )
+        }
+        defer { Darwin.close(sourceDescriptor) }
+        var sourceMetadata = stat()
+        guard fstat(sourceDescriptor, &sourceMetadata) == 0,
+              sourceMetadata.st_mode & S_IFMT == S_IFREG,
+              sourceMetadata.st_size > 0,
+              sourceMetadata.st_size <= 64 * 1024 * 1024
+        else {
+            throw FanServiceManagerError.unsafeFile(
+                "bundled fan helper has unsafe metadata"
+            )
+        }
+
+        let temporaryName = ".\(paths.helper.lastPathComponent).\(UUID().uuidString).tmp"
+        let temporary = directory.appendingPathComponent(temporaryName)
+        var temporaryDescriptor = openat(
+            directoryDescriptor,
+            temporaryName,
+            O_WRONLY | O_CREAT | O_EXCL | O_NOFOLLOW | O_CLOEXEC,
+            0o755
+        )
+        guard temporaryDescriptor >= 0 else {
+            throw FanServiceManagerError.unsafeFile(
+                "could not create helper staging file (errno \(errno))"
+            )
+        }
+        var removeTemporary = true
+        defer {
+            if temporaryDescriptor >= 0 { Darwin.close(temporaryDescriptor) }
+            if removeTemporary {
+                _ = unlinkat(directoryDescriptor, temporaryName, 0)
+            }
+        }
+        try copy(
+            from: sourceDescriptor,
+            to: temporaryDescriptor,
+            expectedBytes: Int(sourceMetadata.st_size)
+        )
+        guard fchmod(temporaryDescriptor, 0o755) == 0,
+              fchown(temporaryDescriptor, 0, 0) == 0,
+              fsync(temporaryDescriptor) == 0
+        else {
+            throw FanServiceManagerError.unsafeFile(
+                "could not secure installed fan helper (errno \(errno))"
+            )
+        }
+        Darwin.close(temporaryDescriptor)
+        temporaryDescriptor = -1
+        try verifyRegularExecutable(temporary)
+        try verifyHelperSignature(temporary)
+        // Recheck the enclosing seal after copying from the user-owned app.
+        // This catches substitutions racing the initial preflight.
+        let executable = try currentExecutableURL()
+        let contents = executable.deletingLastPathComponent().deletingLastPathComponent()
+        try verifyBundledApp(
+            app: contents.deletingLastPathComponent(),
+            executable: executable,
+            helper: source
+        )
+        guard try fileHash(source) == fileHash(temporary) else {
+            throw FanServiceManagerError.unsafeFile(
+                "bundled fan helper changed while it was being installed"
+            )
+        }
+        guard renameat(
+            directoryDescriptor,
+            temporaryName,
+            directoryDescriptor,
+            paths.helper.lastPathComponent
+        ) == 0 else {
+            throw FanServiceManagerError.unsafeFile(
+                "could not atomically install fan helper (errno \(errno))"
+            )
+        }
+        removeTemporary = false
+        guard fsync(directoryDescriptor) == 0 else {
+            throw FanServiceManagerError.unsafeFile(
+                "could not sync installed helper directory (errno \(errno))"
+            )
+        }
+        try verifyHelperSignature(paths.helper)
+    }
+
+    func writeLaunchDaemonPlist() throws {
+        let data = try PropertyListSerialization.data(
+            fromPropertyList: FanLaunchDaemon.propertyList(paths: paths),
+            format: .xml,
+            options: 0
+        )
+        try ensureRootDirectory(paths.launchDaemonPlist.deletingLastPathComponent())
+        try FanDurableFile.writeData(
+            data,
+            to: paths.launchDaemonPlist,
+            permissions: 0o644
+        )
+    }
+
+    func ensureRootDirectory(_ directory: URL) throws {
+        var metadata = stat()
+        if lstat(directory.path, &metadata) != 0 {
+            guard errno == ENOENT else {
+                throw FanServiceManagerError.unsafeFile(
+                    "could not inspect directory \(directory.path) (errno \(errno))"
+                )
+            }
+            try FileManager.default.createDirectory(
+                at: directory,
+                withIntermediateDirectories: true
+            )
+        } else if metadata.st_mode & S_IFMT != S_IFDIR {
+            throw FanServiceManagerError.unsafeFile(
+                "privileged path is not a directory: \(directory.path)"
+            )
+        }
+        metadata = stat()
+        guard lstat(directory.path, &metadata) == 0,
+              metadata.st_mode & S_IFMT == S_IFDIR,
+              chmod(directory.path, 0o755) == 0,
+              chown(directory.path, 0, 0) == 0
+        else {
+            throw FanServiceManagerError.unsafeFile(
+                "could not secure directory \(directory.path) (errno \(errno))"
+            )
+        }
+    }
+
+    func bootoutIfLoaded() throws {
+        guard isLoaded() else { return }
+        let result = FanProcessRunner.run(
+            "/bin/launchctl",
+            arguments: ["bootout", Self.target]
+        )
+        guard result.succeeded
+            || result.output.contains("3:")
+            || result.output.contains("could not find service")
+        else {
+            throw FanServiceManagerError.launchctlFailed(result.output)
+        }
+    }
+
+    func bootoutWithRetries() throws {
+        var lastError: Error?
+        for _ in 0..<3 {
+            do {
+                try bootoutIfLoaded()
+                return
+            } catch {
+                lastError = error
+                Thread.sleep(forTimeInterval: 0.1)
+            }
+        }
+        throw lastError ?? FanServiceManagerError.launchctlFailed("bootout failed")
+    }
+
+    func restartDisabledHelperForRecovery() throws {
+        try setLabelEnabled(true)
+        if isLoaded() {
+            let result = FanProcessRunner.run(
+                "/bin/launchctl",
+                arguments: ["kickstart", "-k", Self.target]
+            )
+            guard result.succeeded else {
+                throw FanServiceManagerError.launchctlFailed(result.output)
+            }
+        } else {
+            try bootstrap()
+            try kickstart()
+        }
+        guard isLoaded() else {
+            throw FanServiceManagerError.launchctlFailed(
+                "recovery helper did not remain registered"
+            )
+        }
+    }
+
+    func waitForJournalClear() -> Bool {
+        for _ in 0..<30 {
+            if !FileManager.default.fileExists(atPath: paths.sessionJournal.path) {
+                return true
+            }
+            Thread.sleep(forTimeInterval: 0.1)
+        }
+        return !FileManager.default.fileExists(atPath: paths.sessionJournal.path)
+    }
+
+    func setLabelEnabled(_ enabled: Bool) throws {
+        let result = FanProcessRunner.run(
+            "/bin/launchctl",
+            arguments: [enabled ? "enable" : "disable", Self.target]
+        )
+        guard result.succeeded else {
+            throw FanServiceManagerError.launchctlFailed(result.output)
+        }
+    }
+
+    func bootstrap() throws {
+        let result = FanProcessRunner.run(
+            "/bin/launchctl",
+            arguments: ["bootstrap", "system", paths.launchDaemonPlist.path]
+        )
+        guard result.succeeded
+            || result.output.contains("37:")
+            || result.output.contains("already loaded")
+        else {
+            throw FanServiceManagerError.launchctlFailed(result.output)
+        }
+    }
+
+    func kickstart() throws {
+        let result = FanProcessRunner.run(
+            "/bin/launchctl",
+            arguments: ["kickstart", Self.target]
+        )
+        guard result.succeeded else {
+            throw FanServiceManagerError.launchctlFailed(result.output)
+        }
+    }
+
+    private func fileHash(_ url: URL) throws -> SHA256.Digest {
+        SHA256.hash(data: try Data(contentsOf: url, options: [.mappedIfSafe]))
+    }
+
+    private func copy(
+        from source: Int32,
+        to destination: Int32,
+        expectedBytes: Int
+    ) throws {
+        var buffer = [UInt8](repeating: 0, count: 64 * 1024)
+        var copied = 0
+        while true {
+            let count = buffer.withUnsafeMutableBytes { rawBuffer in
+                Darwin.read(source, rawBuffer.baseAddress, rawBuffer.count)
+            }
+            if count < 0, errno == EINTR { continue }
+            guard count >= 0 else {
+                throw FanServiceManagerError.unsafeFile(
+                    "could not read bundled fan helper (errno \(errno))"
+                )
+            }
+            if count == 0 { break }
+            var offset = 0
+            while offset < count {
+                let written = buffer.withUnsafeBytes { rawBuffer in
+                    Darwin.write(
+                        destination,
+                        rawBuffer.baseAddress!.advanced(by: offset),
+                        count - offset
+                    )
+                }
+                if written < 0, errno == EINTR { continue }
+                guard written > 0 else {
+                    throw FanServiceManagerError.unsafeFile(
+                        "could not write staged fan helper (errno \(errno))"
+                    )
+                }
+                offset += written
+                copied += written
+            }
+        }
+        guard copied == expectedBytes else {
+            throw FanServiceManagerError.unsafeFile(
+                "bundled fan helper changed size while being copied"
+            )
+        }
+    }
+}

--- a/provider-swift/Sources/darkbloom/Fan/FanServiceManager+Install.swift
+++ b/provider-swift/Sources/darkbloom/Fan/FanServiceManager+Install.swift
@@ -36,7 +36,7 @@ extension FanServiceManager {
         guard _NSGetExecutablePath(&buffer, &size) == 0 else {
             throw FanServiceManagerError.unsafeFile("could not resolve current executable")
         }
-        let path = String(decoding: buffer.prefix { $0 != 0 }.map(UInt8.init), as: UTF8.self)
+        let path = Self.decodeExecutablePath(buffer)
         guard let resolved = realpath(path, nil) else {
             throw FanServiceManagerError.unsafeFile("could not canonicalize current executable")
         }
@@ -45,6 +45,13 @@ extension FanServiceManager {
         #else
         return URL(fileURLWithPath: CommandLine.arguments[0])
         #endif
+    }
+
+    static func decodeExecutablePath(_ buffer: [CChar]) -> String {
+        String(
+            decoding: buffer.prefix { $0 != 0 }.map { UInt8(bitPattern: $0) },
+            as: UTF8.self
+        )
     }
 
     func verifyRegularExecutable(_ url: URL) throws {

--- a/provider-swift/Sources/darkbloom/Fan/FanServiceManager.swift
+++ b/provider-swift/Sources/darkbloom/Fan/FanServiceManager.swift
@@ -62,15 +62,16 @@ struct FanServiceManager {
         try verifyRegularExecutable(source)
         try verifyHelperSignature(source)
 
-        // An existing helper may own the fans. Restore first, then boot it out
-        // before replacing its executable or policy.
-        _ = try? FanHelperClient().restoreAutomatic()
-        try bootoutIfLoaded()
-        try recoverJournalIfPresent(hardware: recoveryHardware)
-        let hardware = try hardwareForControl()
-        try preflightAutomaticHardware(hardware)
-
         do {
+            // An existing helper may own the fans. Keep this preflight inside
+            // the guarded recovery path so any failure after bootout restarts a
+            // helper that can continue reconciling the durable journal.
+            _ = try? FanHelperClient().restoreAutomatic()
+            try bootoutIfLoaded()
+            try recoverJournalIfPresent(hardware: recoveryHardware)
+            let hardware = try hardwareForControl()
+            try preflightAutomaticHardware(hardware)
+
             try installHelper(from: source)
             try ensureRootDirectory(paths.configuration.deletingLastPathComponent())
             try FanDurableFile.writeJSON(
@@ -119,7 +120,7 @@ struct FanServiceManager {
             }
 
             do {
-                try recoverJournalIfPresent(hardware: hardware)
+                try recoverJournalIfPresent(hardware: recoveryHardware)
             } catch let recoveryError {
                 // Auto is not verified. Keep/restart the helper so startup
                 // reconciliation continues retrying the durable journal.
@@ -149,7 +150,7 @@ struct FanServiceManager {
                 for _ in 0..<20 {
                     Thread.sleep(forTimeInterval: 0.1)
                     do {
-                        try recoverJournalIfPresent(hardware: hardware)
+                        try recoverJournalIfPresent(hardware: recoveryHardware)
                         directRecoverySucceeded = true
                         break
                     } catch {

--- a/provider-swift/Sources/darkbloom/Fan/FanServiceManager.swift
+++ b/provider-swift/Sources/darkbloom/Fan/FanServiceManager.swift
@@ -1,0 +1,401 @@
+import DarkbloomFanCore
+import DarkbloomFanProtocol
+import DarkbloomFanService
+import Foundation
+
+#if canImport(Darwin)
+import Darwin
+#endif
+
+enum FanServiceManagerError: Error, CustomStringConvertible {
+    case rootRequired
+    case sudoUserRequired
+    case invalidInvokingUID(String)
+    case helperNotBundled([String])
+    case unsafeFile(String)
+    case signatureFailed(String)
+    case launchctlFailed(String)
+    case unsupported(String)
+    case restoreFailed(String)
+
+    var description: String {
+        switch self {
+        case .rootRequired:
+            return "this operation requires administrator privileges; rerun it with sudo"
+        case .sudoUserRequired:
+            return "run this command through sudo from the provider account (SUDO_UID is required)"
+        case .invalidInvokingUID(let value):
+            return "invalid invoking user ID: \(value)"
+        case .helperNotBundled(let paths):
+            return "signed fan helper was not found; reinstall Darkbloom (searched: \(paths.joined(separator: ", ")))"
+        case .unsafeFile(let detail): return detail
+        case .signatureFailed(let detail): return "fan helper signature verification failed: \(detail)"
+        case .launchctlFailed(let detail): return "fan launchd operation failed: \(detail)"
+        case .unsupported(let detail): return "fan control is unavailable: \(detail)"
+        case .restoreFailed(let detail): return "could not verify automatic fan control: \(detail)"
+        }
+    }
+}
+
+struct FanServiceManager {
+    static let label = FanIPC.machServiceName
+    static let target = "system/\(label)"
+
+    let paths: FanServicePaths
+    let environment: [String: String]
+
+    init(
+        paths: FanServicePaths = .production,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) {
+        self.paths = paths
+        self.environment = environment
+    }
+
+    func enable(policy: FanPolicyConfiguration) throws -> FanServiceStatus {
+        try requireRoot()
+        let configuredUID = try invokingUID()
+        let configuredUserUUID = try FanUserIdentity.generatedUID(for: configuredUID)
+        let recoveryHardware = try hardwareForRecovery()
+
+        let source = try bundledHelperURL()
+        try verifyRegularExecutable(source)
+        try verifyHelperSignature(source)
+
+        // An existing helper may own the fans. Restore first, then boot it out
+        // before replacing its executable or policy.
+        _ = try? FanHelperClient().restoreAutomatic()
+        try bootoutIfLoaded()
+        try recoverJournalIfPresent(hardware: recoveryHardware)
+        let hardware = try hardwareForControl()
+        try preflightAutomaticHardware(hardware)
+
+        do {
+            try installHelper(from: source)
+            try ensureRootDirectory(paths.configuration.deletingLastPathComponent())
+            try FanDurableFile.writeJSON(
+                FanServiceConfiguration(
+                    enabled: true,
+                    configuredUID: configuredUID,
+                    configuredUserUUID: configuredUserUUID,
+                    policy: policy
+                ),
+                to: paths.configuration,
+                permissions: 0o600
+            )
+            try writeLaunchDaemonPlist()
+            try setLabelEnabled(true)
+            try bootstrap()
+            try kickstart()
+
+            for _ in 0..<30 {
+                if let status = try? FanHelperClient().status() {
+                    guard status.enabled,
+                          status.configuredUID == configuredUID,
+                          status.protocolVersion == FanIPC.protocolVersion
+                    else {
+                        throw FanServiceManagerError.launchctlFailed(
+                            "helper status does not match the installed policy"
+                        )
+                    }
+                    return status
+                }
+                Thread.sleep(forTimeInterval: 0.1)
+            }
+            throw FanServiceManagerError.launchctlFailed(
+                "helper started but did not answer status"
+            )
+        } catch {
+            let enableError = error
+            _ = try? FanHelperClient().restoreAutomatic()
+            do {
+                try bootoutIfLoaded()
+            } catch {
+                // Do not disable KeepAlive when the process could still own the
+                // fans. Its lease expiry and policy loop remain recovery paths.
+                throw FanServiceManagerError.restoreFailed(
+                    "enable failed (\(enableError)); helper could not be stopped safely (\(error))"
+                )
+            }
+
+            do {
+                try recoverJournalIfPresent(hardware: hardware)
+            } catch let recoveryError {
+                // Auto is not verified. Keep/restart the helper so startup
+                // reconciliation continues retrying the durable journal.
+                var restartError: Error?
+                var restarted = false
+                do {
+                    try setLabelEnabled(true)
+                    try bootstrap()
+                    try kickstart()
+                    restarted = isLoaded()
+                    if !restarted {
+                        throw FanServiceManagerError.launchctlFailed(
+                            "recovery helper did not remain loaded"
+                        )
+                    }
+                } catch {
+                    restartError = error
+                }
+                if restarted {
+                    throw FanServiceManagerError.restoreFailed(
+                        "enable failed (\(enableError)); cleanup failed (\(recoveryError)); helper was restarted to keep retrying Auto"
+                    )
+                }
+
+                var directRecoverySucceeded = false
+                var lastRecoveryError: Error = recoveryError
+                for _ in 0..<20 {
+                    Thread.sleep(forTimeInterval: 0.1)
+                    do {
+                        try recoverJournalIfPresent(hardware: hardware)
+                        directRecoverySucceeded = true
+                        break
+                    } catch {
+                        lastRecoveryError = error
+                    }
+                }
+                guard directRecoverySucceeded else {
+                    throw FanServiceManagerError.restoreFailed(
+                        "enable failed (\(enableError)); helper restart failed (\(restartError.map { String(describing: $0) } ?? "unknown")); direct Auto retries failed (\(lastRecoveryError))"
+                    )
+                }
+            }
+
+            var cleanupFailure: Error?
+            do {
+                try FanDurableFile.writeJSON(
+                    FanServiceConfiguration(
+                        enabled: false,
+                        configuredUID: configuredUID,
+                        configuredUserUUID: configuredUserUUID,
+                        policy: policy
+                    ),
+                    to: paths.configuration,
+                    permissions: 0o600
+                )
+            } catch {
+                cleanupFailure = error
+            }
+            do {
+                try setLabelEnabled(false)
+            } catch {
+                cleanupFailure = cleanupFailure ?? error
+            }
+            if let cleanupFailure {
+                throw FanServiceManagerError.restoreFailed(
+                    "enable failed (\(enableError)); disabling failed (\(cleanupFailure))"
+                )
+            }
+            throw enableError
+        }
+    }
+
+    func configure(policy: FanPolicyConfiguration) throws {
+        try requireRoot()
+        let current = try FanDurableFile.readJSON(
+            FanServiceConfiguration.self,
+            from: paths.configuration
+        )
+        try FanDurableFile.writeJSON(
+            FanServiceConfiguration(
+                enabled: current.enabled,
+                configuredUID: current.configuredUID,
+                configuredUserUUID: current.configuredUserUUID,
+                policy: policy
+            ),
+            to: paths.configuration,
+            permissions: 0o600
+        )
+        if isLoaded() {
+            let result = FanProcessRunner.run(
+                "/bin/launchctl",
+                arguments: ["kickstart", "-k", Self.target]
+            )
+            guard result.succeeded else {
+                throw FanServiceManagerError.launchctlFailed(result.output)
+            }
+        }
+    }
+
+    func disable() throws {
+        try requireRoot()
+        let current: FanServiceConfiguration
+        if let loaded = try? FanDurableFile.readJSON(
+            FanServiceConfiguration.self,
+            from: paths.configuration
+        ) {
+            current = loaded
+        } else {
+            let fallbackUID = try invokingUID()
+            current = FanServiceConfiguration(
+                enabled: false,
+                configuredUID: fallbackUID,
+                configuredUserUUID: try FanUserIdentity.generatedUID(
+                    for: fallbackUID
+                ),
+                policy: .defaults
+            )
+        }
+        try ensureRootDirectory(paths.configuration.deletingLastPathComponent())
+        try FanDurableFile.writeJSON(
+            FanServiceConfiguration(
+                enabled: false,
+                configuredUID: current.configuredUID,
+                configuredUserUUID: current.configuredUserUUID,
+                policy: current.policy
+            ),
+            to: paths.configuration,
+            permissions: 0o600
+        )
+
+        // XPC is the fast path, not the only recovery authority. Always boot
+        // out and reconcile the durable journal even if the helper is wedged.
+        if isLoaded() { _ = try? FanHelperClient().restoreAutomatic() }
+        do {
+            try bootoutWithRetries()
+        } catch let bootoutError {
+            // Force a restart into the persisted disabled policy. The new
+            // process repairs the journal before it can accept XPC leases.
+            do {
+                try restartDisabledHelperForRecovery()
+            } catch {
+                throw FanServiceManagerError.restoreFailed(
+                    "could not stop helper (\(bootoutError)) or restart it disabled (\(error))"
+                )
+            }
+            guard waitForJournalClear() else {
+                throw FanServiceManagerError.restoreFailed(
+                    "helper remains loaded and disabled while retrying automatic restoration"
+                )
+            }
+            try bootoutWithRetries()
+            try setLabelEnabled(false)
+            return
+        }
+
+        do {
+            try recoverJournalIfPresent(hardware: try hardwareForRecovery())
+        } catch let recoveryError {
+            do {
+                try restartDisabledHelperForRecovery()
+            } catch {
+                throw FanServiceManagerError.restoreFailed(
+                    "direct Auto failed (\(recoveryError)); recovery helper restart also failed (\(error))"
+                )
+            }
+            guard waitForJournalClear() else {
+                throw FanServiceManagerError.restoreFailed(
+                    "helper remains loaded and disabled while retrying automatic restoration"
+                )
+            }
+            try bootoutWithRetries()
+        }
+        try setLabelEnabled(false)
+    }
+
+    func uninstall() throws {
+        try disable()
+        guard !FileManager.default.fileExists(atPath: paths.sessionJournal.path) else {
+            throw FanServiceManagerError.restoreFailed(
+                "ownership journal remains after restore; refusing to remove recovery material"
+            )
+        }
+        try FanDurableFile.remove(paths.launchDaemonPlist)
+        try FanDurableFile.remove(paths.helper)
+        try FanDurableFile.remove(paths.configuration)
+    }
+
+    func isInstalled() -> Bool {
+        FileManager.default.fileExists(atPath: paths.helper.path)
+            && FileManager.default.fileExists(atPath: paths.launchDaemonPlist.path)
+    }
+
+    func configuration() throws -> FanServiceConfiguration {
+        try FanDurableFile.readJSON(
+            FanServiceConfiguration.self,
+            from: paths.configuration
+        )
+    }
+
+    func isLoaded() -> Bool {
+        FanProcessRunner.run(
+            "/bin/launchctl",
+            arguments: ["print", Self.target],
+            timeout: 5
+        ).succeeded
+    }
+
+    private func requireRoot() throws {
+        guard geteuid() == 0 else { throw FanServiceManagerError.rootRequired }
+    }
+
+    private func invokingUID() throws -> UInt32 {
+        guard let raw = environment["SUDO_UID"], !raw.isEmpty else {
+            throw FanServiceManagerError.sudoUserRequired
+        }
+        guard let uid = UInt32(raw), uid != 0, getpwuid(uid_t(uid)) != nil else {
+            throw FanServiceManagerError.invalidInvokingUID(raw)
+        }
+        return uid
+    }
+
+    private typealias Hardware = (
+        backend: AppleSMCBackend,
+        reader: FanHardwareReader,
+        inventory: FanInventory
+    )
+
+    private func hardwareForControl() throws -> Hardware {
+        let backend = try AppleSMCBackend()
+        let reader = FanHardwareReader(backend: backend)
+        let hardware: Hardware = (backend, reader, try reader.discover())
+        guard !hardware.inventory.fans.isEmpty else {
+            throw FanServiceManagerError.unsupported("this Mac reports no fans")
+        }
+        guard !hardware.inventory.gpuTemperatureKeys.isEmpty else {
+            throw FanServiceManagerError.unsupported(
+                "no validated GPU temperature sensor was found for \(hardware.inventory.chipFamily.rawValue)"
+            )
+        }
+        return hardware
+    }
+
+    private func hardwareForRecovery() throws -> Hardware {
+        let backend = try AppleSMCBackend()
+        let reader = FanHardwareReader(backend: backend)
+        return (backend, reader, try reader.discoverForRecovery())
+    }
+
+    private func preflightAutomaticHardware(_ hardware: Hardware) throws {
+        let readings = try hardware.reader.fanReadings(in: hardware.inventory)
+        let foreign = readings.filter { $0.mode == .manual }.map { $0.capability.index }
+        guard foreign.isEmpty else {
+            throw FanServiceManagerError.unsupported(
+                "another application manually controls fans \(foreign)"
+            )
+        }
+        if let ftst = hardware.inventory.ftstKey {
+            let value = try hardware.backend.read(ftst).uint8()
+            guard value == 0 else {
+                throw FanServiceManagerError.unsupported(
+                    "another application holds the Ftst fan-control gate"
+                )
+            }
+        }
+    }
+
+    private func recoverJournalIfPresent(hardware: Hardware) throws {
+        do {
+            try FanOwnershipRecovery.reconcile(
+                backend: hardware.backend,
+                inventory: hardware.inventory,
+                journalURL: paths.sessionJournal
+            )
+        } catch {
+            throw FanServiceManagerError.restoreFailed(String(describing: error))
+        }
+    }
+
+}

--- a/provider-swift/Sources/darkbloom/FanActivityLease.swift
+++ b/provider-swift/Sources/darkbloom/FanActivityLease.swift
@@ -1,0 +1,161 @@
+import DarkbloomFanProtocol
+import DarkbloomFanService
+import Foundation
+import OSLog
+
+/// Best-effort provider-activity lease for the optional root fan helper.
+/// Absence or failure of the helper must never block inference startup.
+actor FanActivityLease {
+    private let logger = Logger(
+        subsystem: "io.darkbloom.provider",
+        category: "fan-lease"
+    )
+    private let providerVersion: String
+    private var running = false
+    private var connection: FanXPCConnectionBox?
+    private var renewalTask: Task<Void, Never>?
+    private var lastReportedError: String?
+
+    init(providerVersion: String) {
+        self.providerVersion = providerVersion
+    }
+
+    func start() {
+        guard !running else { return }
+        running = true
+        renew()
+        renewalTask = Task { [weak self] in
+            while !Task.isCancelled {
+                do {
+                    try await Task.sleep(
+                        nanoseconds: UInt64(
+                            FanIPC.renewalIntervalSeconds * 1_000_000_000
+                        )
+                    )
+                } catch {
+                    return
+                }
+                await self?.renew()
+            }
+        }
+    }
+
+    func stop() {
+        guard running || connection != nil else { return }
+        running = false
+        renewalTask?.cancel()
+        renewalTask = nil
+
+        if let proxy = proxy() {
+            proxy.releaseProviderActivity { _ in }
+        }
+        // Session invalidation is itself a fail-safe release signal. It covers
+        // a lost reply and makes clean provider shutdown restore Auto promptly.
+        connection?.value.invalidate()
+        connection = nil
+    }
+
+    private func renew() {
+        guard running else { return }
+        guard FileManager.default.fileExists(
+            atPath: FanServicePaths.production.helper.path
+        ) else {
+            connection?.value.invalidate()
+            connection = nil
+            return
+        }
+        if connection == nil {
+            connect()
+        }
+        proxy()?.renewProviderActivity(
+            protocolVersion: FanIPC.protocolVersion,
+            providerVersion: providerVersion
+        ) { [weak self] data in
+            Task { await self?.handleRenewalReply(data) }
+        }
+    }
+
+    private func proxy() -> DarkbloomFanHelperProtocol? {
+        guard let connection else { return nil }
+        return connection.value.remoteObjectProxyWithErrorHandler { [weak self, weak connection] _ in
+            guard let connection else { return }
+            Task { await self?.connectionLost(connection) }
+        } as? DarkbloomFanHelperProtocol
+    }
+
+    private func connect() {
+        let rawConnection = NSXPCConnection(
+            machServiceName: FanIPC.machServiceName,
+            options: .privileged
+        )
+        let newConnection = FanXPCConnectionBox(rawConnection)
+        rawConnection.remoteObjectInterface = NSXPCInterface(
+            with: DarkbloomFanHelperProtocol.self
+        )
+        rawConnection.setCodeSigningRequirement(
+            FanCodeRequirements.helperRequirement()
+        )
+        rawConnection.interruptionHandler = { [weak self, weak newConnection] in
+            guard let newConnection else { return }
+            Task { await self?.connectionLost(newConnection) }
+        }
+        rawConnection.invalidationHandler = { [weak self, weak newConnection] in
+            guard let newConnection else { return }
+            Task { await self?.connectionLost(newConnection) }
+        }
+        rawConnection.resume()
+        connection = newConnection
+    }
+
+    private func connectionLost(_ lostConnection: FanXPCConnectionBox) {
+        guard connection === lostConnection else { return }
+        connection = nil
+    }
+
+    private func handleRenewalReply(_ data: Data) {
+        do {
+            let reply = try FanIPCCoding.decode(FanIPCReply.self, from: data)
+            guard !reply.ok else {
+                lastReportedError = nil
+                return
+            }
+            reportOnce(reply.message ?? "fan helper rejected the provider lease")
+        } catch {
+            reportOnce("invalid fan helper lease reply: \(error)")
+        }
+    }
+
+    private func reportOnce(_ message: String) {
+        guard lastReportedError != message else { return }
+        lastReportedError = message
+        logger.error("\(message, privacy: .public)")
+    }
+}
+
+private final class FanXPCConnectionBox: @unchecked Sendable {
+    let value: NSXPCConnection
+
+    init(_ value: NSXPCConnection) {
+        self.value = value
+    }
+}
+
+func withFanActivityLease<T>(
+    providerVersion: String,
+    operation: () async throws -> T
+) async rethrows -> T {
+    let lease = FanActivityLease(providerVersion: providerVersion)
+    await lease.start()
+    return try await withTaskCancellationHandler {
+        do {
+            let value = try await operation()
+            await lease.stop()
+            return value
+        } catch {
+            await lease.stop()
+            throw error
+        }
+    } onCancel: {
+        Task { await lease.stop() }
+    }
+}

--- a/provider-swift/Sources/darkbloom/StartCommand+Modes.swift
+++ b/provider-swift/Sources/darkbloom/StartCommand+Modes.swift
@@ -124,12 +124,12 @@ extension Start {
         try? LocalEndpoint.writeInfo(info)
         defer { LocalEndpoint.removeInfo() }
 
-        // Wait forever (until SIGINT). The optional fan helper receives a
-        // renewable activity lease only after the server has successfully
-        // bound. A stopped/crashed local server therefore releases fan control.
+        // The optional fan helper receives a renewable activity lease only
+        // after the server has successfully bound, and only for the lifetime
+        // of the actual Hummingbird service task. A stopped/crashed local
+        // server therefore releases fan control.
         await withFanActivityLease(providerVersion: ProviderCore.version) {
-            let waitForever = AsyncStream<Never> { _ in }
-            for await _ in waitForever {}
+            await server.waitUntilStopped()
         }
     }
 

--- a/provider-swift/Sources/darkbloom/StartCommand+Modes.swift
+++ b/provider-swift/Sources/darkbloom/StartCommand+Modes.swift
@@ -124,10 +124,13 @@ extension Start {
         try? LocalEndpoint.writeInfo(info)
         defer { LocalEndpoint.removeInfo() }
 
-        // Wait forever (until SIGINT). In standalone mode we don't have a
-        // coordinator event stream to drive the loop, so we just block.
-        let waitForever = AsyncStream<Never> { _ in }
-        for await _ in waitForever {}
+        // Wait forever (until SIGINT). The optional fan helper receives a
+        // renewable activity lease only after the server has successfully
+        // bound. A stopped/crashed local server therefore releases fan control.
+        await withFanActivityLease(providerVersion: ProviderCore.version) {
+            let waitForever = AsyncStream<Never> { _ in }
+            for await _ in waitForever {}
+        }
     }
 
 
@@ -263,7 +266,7 @@ extension Start {
                 try await runScheduled(loopConfig: loopConfig, schedule: schedule)
             } else {
                 let loop = try ProviderLoop(config: loopConfig)
-                try await loop.run()
+                try await runProviderLoopWithFanLease(loop)
             }
         } catch {
             TelemetryClient.shared.emit(
@@ -348,7 +351,7 @@ extension Start {
             let loop = try ProviderLoop(config: loopConfig)
             try await withThrowingTaskGroup(of: ScheduledLoopResult.self) { group in
                 group.addTask {
-                    try await loop.run()
+                    try await runProviderLoopWithFanLease(loop)
                     return .loopEnded
                 }
                 group.addTask {
@@ -373,6 +376,12 @@ extension Start {
     private func sleepNanoseconds(for interval: TimeInterval) -> UInt64 {
         let seconds = max(1.0, min(interval, Double(UInt64.max) / 1_000_000_000))
         return UInt64(seconds * 1_000_000_000)
+    }
+
+    private func runProviderLoopWithFanLease(_ loop: ProviderLoop) async throws {
+        try await withFanActivityLease(providerVersion: ProviderCore.version) {
+            try await loop.run()
+        }
     }
 
 }

--- a/provider-swift/Tests/DarkbloomCLITests/FanCommandTests.swift
+++ b/provider-swift/Tests/DarkbloomCLITests/FanCommandTests.swift
@@ -1,0 +1,39 @@
+import ArgumentParser
+import Testing
+
+@testable import darkbloom
+
+@Suite("Fan command")
+struct FanCommandTests {
+    @Test("fan is registered and defaults to status")
+    func fanParses() throws {
+        let command = try Darkbloom.parseAsRoot(["fan"])
+        #expect(command is Fan.Status)
+    }
+
+    @Test("enable parses the agreed policy knobs")
+    func enableParses() throws {
+        let command = try Darkbloom.parseAsRoot([
+            "fan", "enable", "--speed", "60", "--temperature", "50",
+        ])
+        guard let enable = command as? Fan.Enable else {
+            Issue.record("expected Fan.Enable")
+            return
+        }
+        #expect(enable.speed == 60)
+        #expect(enable.temperature == 50)
+    }
+
+    @Test("configure accepts either setting independently")
+    func configureParses() throws {
+        let command = try Darkbloom.parseAsRoot([
+            "fan", "configure", "--speed", "90",
+        ])
+        guard let configure = command as? Fan.Configure else {
+            Issue.record("expected Fan.Configure")
+            return
+        }
+        #expect(configure.speed == 90)
+        #expect(configure.temperature == nil)
+    }
+}

--- a/provider-swift/Tests/DarkbloomCLITests/FanCommandTests.swift
+++ b/provider-swift/Tests/DarkbloomCLITests/FanCommandTests.swift
@@ -36,4 +36,12 @@ struct FanCommandTests {
         #expect(configure.speed == 90)
         #expect(configure.temperature == nil)
     }
+
+    @Test("executable path decoding preserves non-ASCII UTF-8 bytes")
+    func executablePathDecodesNonASCII() {
+        let expected = "/Users/José/Darkbloom.app/Contents/MacOS/darkbloom"
+        let buffer = expected.utf8.map { CChar(bitPattern: $0) } + [0, 65]
+
+        #expect(FanServiceManager.decodeExecutablePath(buffer) == expected)
+    }
 }

--- a/provider-swift/Tests/DarkbloomFanCoreTests/FakeSMCBackend.swift
+++ b/provider-swift/Tests/DarkbloomFanCoreTests/FakeSMCBackend.swift
@@ -27,6 +27,8 @@ final class FakeSMCBackend: SMCBackend, @unchecked Sendable {
     private var writeBehaviors: [SMCKey: [WriteBehavior]] = [:]
     private var recordedOperations: [Operation] = []
     private var writeHook: (@Sendable (SMCKey, [UInt8]) -> Void)?
+    private var readHook: (@Sendable (SMCKey, Int) -> Void)?
+    private var readCounts: [SMCKey: Int] = [:]
 
     var operations: [Operation] {
         lock.withLock { recordedOperations }
@@ -38,6 +40,13 @@ final class FakeSMCBackend: SMCBackend, @unchecked Sendable {
 
     func installWriteHook(_ hook: (@Sendable (SMCKey, [UInt8]) -> Void)?) {
         lock.withLock { writeHook = hook }
+    }
+
+    func installReadHook(_ hook: (@Sendable (SMCKey, Int) -> Void)?) {
+        lock.withLock {
+            readHook = hook
+            readCounts.removeAll()
+        }
     }
 
     func queue(_ behaviors: [WriteBehavior], for key: SMCKey) {
@@ -94,12 +103,19 @@ final class FakeSMCBackend: SMCBackend, @unchecked Sendable {
     }
 
     func read(_ key: SMCKey) throws -> SMCValue {
-        let entry: Entry = try lock.withLock {
+        let snapshot: (Entry, Int, (@Sendable (SMCKey, Int) -> Void)?) = try lock.withLock {
             recordedOperations.append(.read(key))
             guard let entry = entries[key] else { throw SMCError.keyNotFound(key) }
-            return entry
+            let count = readCounts[key, default: 0] + 1
+            readCounts[key] = count
+            return (entry, count, readHook)
         }
-        return try SMCValue(key: key, info: entry.info, bytes: entry.bytes)
+        snapshot.2?(key, snapshot.1)
+        return try SMCValue(
+            key: key,
+            info: snapshot.0.info,
+            bytes: snapshot.0.bytes
+        )
     }
 
     func write(_ key: SMCKey, bytes: [UInt8]) throws {

--- a/provider-swift/Tests/DarkbloomFanCoreTests/FakeSMCBackend.swift
+++ b/provider-swift/Tests/DarkbloomFanCoreTests/FakeSMCBackend.swift
@@ -1,0 +1,167 @@
+import Foundation
+
+@testable import DarkbloomFanCore
+
+final class FakeSMCBackend: SMCBackend, @unchecked Sendable {
+    enum Operation: Equatable {
+        case keyInfo(SMCKey)
+        case read(SMCKey)
+        case write(SMCKey, [UInt8])
+    }
+
+    enum WriteBehavior {
+        case succeed
+        case ignore
+        case replace([UInt8])
+        case failBefore(SMCError)
+        case failAfter(SMCError)
+    }
+
+    struct Entry {
+        var info: SMCKeyInfo
+        var bytes: [UInt8]
+    }
+
+    private let lock = NSLock()
+    private var entries: [SMCKey: Entry] = [:]
+    private var writeBehaviors: [SMCKey: [WriteBehavior]] = [:]
+    private var recordedOperations: [Operation] = []
+    private var writeHook: (@Sendable (SMCKey, [UInt8]) -> Void)?
+
+    var operations: [Operation] {
+        lock.withLock { recordedOperations }
+    }
+
+    func resetOperations() {
+        lock.withLock { recordedOperations.removeAll() }
+    }
+
+    func installWriteHook(_ hook: (@Sendable (SMCKey, [UInt8]) -> Void)?) {
+        lock.withLock { writeHook = hook }
+    }
+
+    func queue(_ behaviors: [WriteBehavior], for key: SMCKey) {
+        lock.withLock { writeBehaviors[key, default: []].append(contentsOf: behaviors) }
+    }
+
+    func remove(_ key: SMCKey) {
+        _ = lock.withLock { entries.removeValue(forKey: key) }
+    }
+
+    func setUI8(_ key: SMCKey, _ value: UInt8) {
+        set(
+            key,
+            info: SMCKeyInfo(dataSize: 1, dataType: try! SMCDataType("ui8 ")),
+            bytes: [value]
+        )
+    }
+
+    func setFloat(_ key: SMCKey, _ value: Double) {
+        set(
+            key,
+            info: SMCKeyInfo(dataSize: 4, dataType: try! SMCDataType("flt ")),
+            bytes: try! SMCValue.float32Bytes(value, key: key)
+        )
+    }
+
+    func setFixed(_ key: SMCKey, type: String, raw: UInt16) {
+        set(
+            key,
+            info: SMCKeyInfo(dataSize: 2, dataType: try! SMCDataType(type)),
+            bytes: [UInt8(raw >> 8), UInt8(raw & 0xff)]
+        )
+    }
+
+    func set(_ key: SMCKey, info: SMCKeyInfo, bytes: [UInt8]) {
+        precondition(info.dataSize == bytes.count)
+        lock.withLock { entries[key] = Entry(info: info, bytes: bytes) }
+    }
+
+    func uint8(_ key: SMCKey) throws -> UInt8 {
+        try read(key).uint8()
+    }
+
+    func float(_ key: SMCKey) throws -> Double {
+        try read(key).float32()
+    }
+
+    func keyInfo(for key: SMCKey) throws -> SMCKeyInfo {
+        try lock.withLock {
+            recordedOperations.append(.keyInfo(key))
+            guard let entry = entries[key] else { throw SMCError.keyNotFound(key) }
+            return entry.info
+        }
+    }
+
+    func read(_ key: SMCKey) throws -> SMCValue {
+        let entry: Entry = try lock.withLock {
+            recordedOperations.append(.read(key))
+            guard let entry = entries[key] else { throw SMCError.keyNotFound(key) }
+            return entry
+        }
+        return try SMCValue(key: key, info: entry.info, bytes: entry.bytes)
+    }
+
+    func write(_ key: SMCKey, bytes: [UInt8]) throws {
+        let snapshot: (Entry, WriteBehavior, (@Sendable (SMCKey, [UInt8]) -> Void)?) =
+            try lock.withLock {
+                recordedOperations.append(.write(key, bytes))
+                guard let entry = entries[key] else { throw SMCError.keyNotFound(key) }
+                guard entry.info.dataSize == bytes.count else {
+                    throw SMCError.dataLengthMismatch(
+                        key: key,
+                        expected: entry.info.dataSize,
+                        actual: bytes.count
+                    )
+                }
+                let behavior: WriteBehavior
+                if var queued = writeBehaviors[key], !queued.isEmpty {
+                    behavior = queued.removeFirst()
+                    writeBehaviors[key] = queued
+                } else {
+                    behavior = .succeed
+                }
+                return (entry, behavior, writeHook)
+            }
+
+        snapshot.2?(key, bytes)
+        switch snapshot.1 {
+        case .succeed:
+            lock.withLock { entries[key]?.bytes = bytes }
+        case .ignore:
+            break
+        case .replace(let replacement):
+            lock.withLock { entries[key]?.bytes = replacement }
+        case .failBefore(let error):
+            throw error
+        case .failAfter(let error):
+            lock.withLock { entries[key]?.bytes = bytes }
+            throw error
+        }
+    }
+}
+
+func makeFanBackend(
+    fanCount: Int = 2,
+    lowercaseModeKeys: Bool = false,
+    includeFtst: Bool = true,
+    chipFamily: FanChipFamily = .m4
+) -> FakeSMCBackend {
+    let backend = FakeSMCBackend()
+    backend.setUI8("FNum", UInt8(fanCount))
+    for index in 0..<fanCount {
+        backend.setFloat(try! SMCKey("F\(index)Ac"), 1_500 + Double(index * 100))
+        backend.setFloat(try! SMCKey("F\(index)Mn"), 1_200 + Double(index * 100))
+        backend.setFloat(try! SMCKey("F\(index)Mx"), 5_000 + Double(index * 500))
+        backend.setFloat(try! SMCKey("F\(index)Tg"), 1_400 + Double(index * 100))
+        let suffix = lowercaseModeKeys ? "md" : "Md"
+        backend.setUI8(try! SMCKey("F\(index)\(suffix)"), 0)
+    }
+    if includeFtst {
+        backend.setUI8("Ftst", 0)
+    }
+    for key in GPUTemperatureCatalog.keys(for: chipFamily) {
+        backend.setFloat(key, 50)
+    }
+    return backend
+}

--- a/provider-swift/Tests/DarkbloomFanCoreTests/FanControllerTests.swift
+++ b/provider-swift/Tests/DarkbloomFanCoreTests/FanControllerTests.swift
@@ -59,6 +59,85 @@ struct FanControllerTests {
         try await controller.restoreAutomatic()
     }
 
+    @Test("takeover re-reads a target raised after the initial snapshot")
+    func takeoverRereadsLateTargetRaise() async throws {
+        let backend = makeFanBackend(fanCount: 1, includeFtst: false)
+        let controller = try makeController(backend: backend)
+        backend.installReadHook { key, count in
+            if key == "F0Tg", count == 1 {
+                backend.setFloat("F0Tg", 4_500)
+            }
+        }
+
+        let session = try await controller.engage(speedPercent: 60)
+        #expect(session.targetRPMByFan[0] == 4_500)
+        #expect(abs(try backend.float("F0Tg") - 4_500) < 0.001)
+        try await controller.restoreAutomatic()
+    }
+
+    @Test("takeover re-reads actual RPM raised after the initial snapshot")
+    func takeoverRereadsLateActualRaise() async throws {
+        let backend = makeFanBackend(fanCount: 1, includeFtst: false)
+        let controller = try makeController(backend: backend)
+        backend.installReadHook { key, count in
+            if key == "F0Tg", count == 1 {
+                backend.setFloat("F0Ac", 4_700)
+            }
+        }
+
+        let session = try await controller.engage(speedPercent: 60)
+        #expect(session.targetRPMByFan[0] == 4_700)
+        #expect(abs(try backend.float("F0Tg") - 4_700) < 0.001)
+        try await controller.restoreAutomatic()
+    }
+
+    @Test("Ftst fallback still re-reads the final takeover floor")
+    func ftstFallbackRereadsLateTargetRaise() async throws {
+        let backend = makeFanBackend(fanCount: 1)
+        backend.queue([
+            .failBefore(.firmwareRejected(
+                operation: .writeBytes,
+                key: "F0Md",
+                result: 0x82
+            )),
+            .succeed,
+        ], for: "F0Md")
+        backend.installWriteHook { key, bytes in
+            if key == "Ftst", bytes == [1] {
+                backend.setFloat("F0Tg", 4_600)
+            }
+        }
+        let controller = try makeController(backend: backend)
+
+        let session = try await controller.engage(speedPercent: 60)
+        #expect(session.ownsFtst)
+        #expect(session.targetRPMByFan[0] == 4_600)
+        #expect(abs(try backend.float("F0Tg") - 4_600) < 0.001)
+        try await controller.restoreAutomatic()
+    }
+
+    @Test("a late takeover floor above maximum aborts to Auto")
+    func takeoverRejectsLateFloorAboveMaximum() async throws {
+        let backend = makeFanBackend(fanCount: 1, includeFtst: false)
+        let controller = try makeController(backend: backend)
+        backend.installReadHook { key, count in
+            if key == "F0Tg", count == 1 {
+                backend.setFloat("F0Ac", 5_100)
+            }
+        }
+
+        let error = await captureControllerError {
+            _ = try await controller.engage(speedPercent: 60)
+        }
+        #expect(error == .takeoverFloorExceedsMaximum(
+            index: 0,
+            floor: 5_100,
+            maximum: 5_000
+        ))
+        #expect(try backend.uint8("F0Md") == FanMode.automatic.rawValue)
+        #expect(await controller.currentSession() == nil)
+    }
+
     @Test("an automatic RPM above maximum refuses takeover before writes")
     func invalidTakeoverFloor() async throws {
         let backend = makeFanBackend(fanCount: 1)
@@ -180,6 +259,7 @@ struct FanControllerTests {
         #expect(!backend.operations.contains(.write("F1Md", [1])))
         #expect(recorder.values == [
             FanControlOwnership(fanIndices: [0], ownsFtst: false),
+            FanControlOwnership(fanIndices: [], ownsFtst: false),
         ])
     }
 
@@ -211,6 +291,7 @@ struct FanControllerTests {
             FanControlOwnership(fanIndices: [0], ownsFtst: false),
             FanControlOwnership(fanIndices: [0, 1], ownsFtst: false),
             FanControlOwnership(fanIndices: [0], ownsFtst: false),
+            FanControlOwnership(fanIndices: [], ownsFtst: false),
         ])
     }
 
@@ -482,6 +563,39 @@ struct FanControllerTests {
         #expect(await controller.currentSession() == nil)
     }
 
+    @Test("failed journal narrowing retains conservative in-memory ownership")
+    func journalNarrowingFailureRetainsBroadOwnership() async throws {
+        let backend = makeFanBackend(fanCount: 1, includeFtst: false)
+        backend.queue([
+            .failBefore(.injectedFailure("target failed")),
+        ], for: "F0Tg")
+        let controller = try makeController(backend: backend)
+        let recorder = OwnershipRecorder { ownership in
+            if ownership.fanIndices.isEmpty {
+                throw OwnershipRecorderError.injected
+            }
+        }
+
+        let error = await captureControllerError {
+            _ = try await controller.engage(
+                speedPercent: 80,
+                recordOwnership: recorder.record
+            )
+        }
+        guard let error,
+              case .rollbackFailed(_, let failures) = error
+        else {
+            Issue.record("expected rollback failure, got \(String(describing: error))")
+            return
+        }
+        #expect(failures.contains(where: { $0.step == .persistOwnership }))
+        #expect(await controller.isControlling)
+        #expect(try backend.uint8("F0Md") == FanMode.automatic.rawValue)
+
+        try await controller.restoreAutomatic()
+        #expect(await controller.currentSession() == nil)
+    }
+
     @Test("rollback continues to later fans after an earlier restore fails")
     func rollbackAttemptsEveryFan() async throws {
         let backend = makeFanBackend()
@@ -491,9 +605,13 @@ struct FanControllerTests {
         ], for: "F0Md")
         backend.queue([.failBefore(.injectedFailure("fan one target failed"))], for: "F1Tg")
         let controller = try makeController(backend: backend)
+        let recorder = OwnershipRecorder()
 
         let error = await captureControllerError {
-            _ = try await controller.engage(speedPercent: 80)
+            _ = try await controller.engage(
+                speedPercent: 80,
+                recordOwnership: recorder.record
+            )
         }
         guard let error, case .rollbackFailed(_, let failures) = error else {
             Issue.record("expected rollback failure, got \(String(describing: error))")
@@ -502,6 +620,10 @@ struct FanControllerTests {
         #expect(failures.contains(where: { $0.fanIndex == 0 }))
         #expect(try backend.uint8("F1Md") == 0)
         #expect(backend.operations.contains(.write("F1Md", [0])))
+        #expect(recorder.values.last == FanControlOwnership(
+            fanIndices: [0],
+            ownsFtst: false
+        ))
     }
 
     @Test("rollback verifies automatic mode instead of trusting a successful write")
@@ -549,9 +671,13 @@ struct FanControllerTests {
         ], for: "Ftst")
         backend.queue([.failBefore(.injectedFailure("target failed"))], for: "F0Tg")
         let controller = try makeController(backend: backend)
+        let recorder = OwnershipRecorder()
 
         let error = await captureControllerError {
-            _ = try await controller.engage(speedPercent: 80)
+            _ = try await controller.engage(
+                speedPercent: 80,
+                recordOwnership: recorder.record
+            )
         }
         guard let error, case .rollbackFailed(_, let failures) = error else {
             Issue.record("expected rollback failure, got \(String(describing: error))")
@@ -559,6 +685,10 @@ struct FanControllerTests {
         }
         #expect(failures.contains(where: { $0.step == .clearFtst }))
         #expect((await controller.currentSession())?.ownsFtst == true)
+        #expect(recorder.values.last == FanControlOwnership(
+            fanIndices: [],
+            ownsFtst: true
+        ))
 
         try await controller.restoreAutomatic()
         #expect(try backend.uint8("Ftst") == 0)
@@ -850,9 +980,11 @@ private final class CallbackCounter: @unchecked Sendable {
 private final class OwnershipRecorder: @unchecked Sendable {
     private let lock = NSLock()
     private var recorded: [FanControlOwnership] = []
-    private let onRecord: @Sendable (FanControlOwnership) -> Void
+    private let onRecord: @Sendable (FanControlOwnership) throws -> Void
 
-    init(onRecord: @escaping @Sendable (FanControlOwnership) -> Void = { _ in }) {
+    init(
+        onRecord: @escaping @Sendable (FanControlOwnership) throws -> Void = { _ in }
+    ) {
         self.onRecord = onRecord
     }
 
@@ -862,10 +994,14 @@ private final class OwnershipRecorder: @unchecked Sendable {
         return recorded
     }
 
-    func record(_ ownership: FanControlOwnership) {
+    func record(_ ownership: FanControlOwnership) throws {
         lock.lock()
         recorded.append(ownership)
         lock.unlock()
-        onRecord(ownership)
+        try onRecord(ownership)
     }
+}
+
+private enum OwnershipRecorderError: Error {
+    case injected
 }

--- a/provider-swift/Tests/DarkbloomFanCoreTests/FanControllerTests.swift
+++ b/provider-swift/Tests/DarkbloomFanCoreTests/FanControllerTests.swift
@@ -640,6 +640,88 @@ struct FanControllerTests {
         #expect(!backend.operations.contains(.write("F0Md", [1])))
     }
 
+    @Test("maintain adopts a higher live manual target and never lowers it")
+    func maintainPreservesHigherManualTarget() async throws {
+        let backend = makeFanBackend(fanCount: 1, includeFtst: false)
+        let controller = try makeController(backend: backend)
+        _ = try await controller.engage(speedPercent: 80)
+        backend.setFloat("F0Tg", 4_500)
+        backend.resetOperations()
+
+        let raised = try await controller.maintain()
+        #expect(raised.targetRPMByFan[0] == 4_500)
+        #expect(abs(try backend.float("F0Tg") - 4_500) < 0.001)
+        #expect(!backend.operations.contains(where: {
+            if case .write("F0Tg", _) = $0 { return true }
+            return false
+        }))
+
+        backend.setFloat("F0Tg", 0)
+        backend.resetOperations()
+        let restored = try await controller.maintain()
+        #expect(restored.targetRPMByFan[0] == 4_500)
+        #expect(abs(try backend.float("F0Tg") - 4_500) < 0.001)
+    }
+
+    @Test("maintain preserves a higher target while reclaiming system mode")
+    func maintainPreservesHigherTargetAcrossModeRepair() async throws {
+        let backend = makeFanBackend(fanCount: 1, includeFtst: false)
+        let controller = try makeController(backend: backend)
+        _ = try await controller.engage(speedPercent: 80)
+        backend.setUI8("F0Md", FanMode.system.rawValue)
+        backend.setFloat("F0Tg", 4_500)
+        backend.resetOperations()
+
+        let session = try await controller.maintain()
+        #expect(session.targetRPMByFan[0] == 4_500)
+        #expect(try backend.uint8("F0Md") == FanMode.manual.rawValue)
+        #expect(abs(try backend.float("F0Tg") - 4_500) < 0.001)
+    }
+
+    @Test("an impossible live maintenance target fails safe to Auto")
+    func maintainRejectsTargetAboveMaximum() async throws {
+        let backend = makeFanBackend(fanCount: 1, includeFtst: false)
+        let controller = try makeController(backend: backend)
+        _ = try await controller.engage(speedPercent: 80)
+        backend.setFloat("F0Tg", 5_100)
+
+        let error = await captureControllerError {
+            _ = try await controller.maintain()
+        }
+        #expect(error == .takeoverFloorExceedsMaximum(
+            index: 0,
+            floor: 5_100,
+            maximum: 5_000
+        ))
+        #expect(try backend.uint8("F0Md") == FanMode.automatic.rawValue)
+        #expect(await controller.currentSession() == nil)
+    }
+
+    @Test("a negative live maintenance target fails safe to Auto")
+    func maintainRejectsNegativeTarget() async throws {
+        let backend = makeFanBackend(fanCount: 1, includeFtst: false)
+        let controller = try makeController(backend: backend)
+        _ = try await controller.engage(speedPercent: 80)
+        backend.setFloat("F0Tg", -1)
+
+        let error = await captureControllerError {
+            _ = try await controller.maintain()
+        }
+        guard let error,
+              case .hardware(.invalidFanRPM(
+                  index: 0,
+                  field: "F0Tg",
+                  value: let value
+              )) = error
+        else {
+            Issue.record("expected invalid target error, got \(String(describing: error))")
+            return
+        }
+        #expect(value == -1)
+        #expect(try backend.uint8("F0Md") == FanMode.automatic.rawValue)
+        #expect(await controller.currentSession() == nil)
+    }
+
     @Test("maintain reacquires an owned Ftst gate reset by sleep")
     func reacquiresFtstAfterSleep() async throws {
         let backend = makeFanBackend(fanCount: 1)
@@ -671,6 +753,7 @@ struct FanControllerTests {
         let backend = makeFanBackend()
         let controller = try makeController(backend: backend)
         _ = try await controller.engage(speedPercent: 80)
+        backend.setFloat("F1Tg", 0)
         backend.queue([.failAfter(.injectedFailure("maintenance target failed"))], for: "F1Tg")
 
         let error = await captureControllerError {

--- a/provider-swift/Tests/DarkbloomFanCoreTests/FanControllerTests.swift
+++ b/provider-swift/Tests/DarkbloomFanCoreTests/FanControllerTests.swift
@@ -120,11 +120,16 @@ struct FanControllerTests {
         let backend = makeFanBackend()
         backend.setUI8("F1Md", 1)
         let controller = try makeController(backend: backend)
+        let callback = CallbackCounter()
 
         let error = await captureControllerError {
-            _ = try await controller.engage(speedPercent: 80)
+            _ = try await controller.engage(
+                speedPercent: 80,
+                beforeFanWrite: { callback.increment() }
+            )
         }
         #expect(error == .foreignManualControl(indices: [1]))
+        #expect(callback.value == 0)
         #expect(try backend.uint8("F1Md") == 1)
         #expect(!backend.operations.contains(where: {
             if case .write = $0 { return true }
@@ -635,5 +640,22 @@ private func waitForSemaphore(
         DispatchQueue.global().async {
             continuation.resume(returning: semaphore.wait(timeout: timeout))
         }
+    }
+}
+
+private final class CallbackCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var count = 0
+
+    var value: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return count
+    }
+
+    func increment() {
+        lock.lock()
+        count += 1
+        lock.unlock()
     }
 }

--- a/provider-swift/Tests/DarkbloomFanCoreTests/FanControllerTests.swift
+++ b/provider-swift/Tests/DarkbloomFanCoreTests/FanControllerTests.swift
@@ -1,0 +1,639 @@
+import Foundation
+import Testing
+
+@testable import DarkbloomFanCore
+
+@Suite("Transactional fan controller")
+struct FanControllerTests {
+    private func makeController(
+        backend: FakeSMCBackend,
+        brand: String = "Apple M4 Max",
+        timing: FanControlTiming = FanControlTiming(
+            ftstSettleSeconds: 0,
+            retryDelaySeconds: 0,
+            manualModeAttempts: 3,
+            verificationAttempts: 2,
+            sleep: { _ in }
+        )
+    ) throws -> TransactionalFanController {
+        let inventory = try FanHardwareReader(backend: backend).discover(brandString: brand)
+        backend.resetOperations()
+        return TransactionalFanController(
+            backend: backend,
+            inventory: inventory,
+            timing: timing
+        )
+    }
+
+    @Test("direct mode applies per-fan percentage and explicit restore is idempotent")
+    func directModeAndRestore() async throws {
+        let backend = makeFanBackend()
+        let controller = try makeController(backend: backend)
+        let session = try await controller.engage(speedPercent: 80)
+
+        #expect(session.targetRPMByFan[0] == 4_000)
+        #expect(session.targetRPMByFan[1] == 4_400)
+        #expect(!session.ownsFtst)
+        #expect(try backend.uint8("F0Md") == 1)
+        #expect(try backend.uint8("F1Md") == 1)
+        #expect(abs(try backend.float("F0Tg") - 4_000) < 0.001)
+        #expect(abs(try backend.float("F1Tg") - 4_400) < 0.001)
+
+        try await controller.restoreAutomatic()
+        #expect(try backend.uint8("F0Md") == 0)
+        #expect(try backend.uint8("F1Md") == 0)
+        #expect(await controller.currentSession() == nil)
+        try await controller.restoreAutomatic()
+    }
+
+    @Test("takeover never lowers an existing actual or target RPM")
+    func takeoverFloor() async throws {
+        let backend = makeFanBackend(fanCount: 1)
+        backend.setFloat("F0Ac", 4_100)
+        backend.setFloat("F0Tg", 4_500)
+        let controller = try makeController(backend: backend)
+
+        let session = try await controller.engage(speedPercent: 60)
+        #expect(session.targetRPMByFan[0] == 4_500)
+        #expect(abs(try backend.float("F0Tg") - 4_500) < 0.001)
+        try await controller.restoreAutomatic()
+    }
+
+    @Test("an automatic RPM above maximum refuses takeover before writes")
+    func invalidTakeoverFloor() async throws {
+        let backend = makeFanBackend(fanCount: 1)
+        backend.setFloat("F0Ac", 5_100)
+        let controller = try makeController(backend: backend)
+
+        let error = await captureControllerError {
+            _ = try await controller.engage(speedPercent: 80)
+        }
+        #expect(error == .takeoverFloorExceedsMaximum(
+            index: 0,
+            floor: 5_100,
+            maximum: 5_000
+        ))
+        #expect(!backend.operations.contains(where: {
+            if case .write = $0 { return true }
+            return false
+        }))
+    }
+
+    @Test("duplicate fan indices are rejected without trapping or writing")
+    func duplicateFanInventory() async throws {
+        let backend = makeFanBackend(fanCount: 1)
+        let discovered = try FanHardwareReader(backend: backend).discover(
+            brandString: "Apple M4"
+        )
+        let fan = try #require(discovered.fans.first)
+        let duplicate = FanInventory(
+            chipFamily: discovered.chipFamily,
+            fans: [fan, fan],
+            gpuTemperatureKeys: discovered.gpuTemperatureKeys,
+            ftstKey: discovered.ftstKey
+        )
+        backend.resetOperations()
+        let controller = TransactionalFanController(
+            backend: backend,
+            inventory: duplicate,
+            timing: FanControlTiming(
+                ftstSettleSeconds: 0,
+                retryDelaySeconds: 0,
+                manualModeAttempts: 1,
+                verificationAttempts: 1,
+                sleep: { _ in }
+            )
+        )
+
+        let error = await captureControllerError {
+            _ = try await controller.engage(speedPercent: 80)
+        }
+        #expect(error == .duplicateFanIndex(0))
+        #expect(!backend.operations.contains(where: {
+            if case .write = $0 { return true }
+            return false
+        }))
+    }
+
+    @Test("pre-existing manual mode is foreign and is never overwritten")
+    func foreignManualControl() async throws {
+        let backend = makeFanBackend()
+        backend.setUI8("F1Md", 1)
+        let controller = try makeController(backend: backend)
+
+        let error = await captureControllerError {
+            _ = try await controller.engage(speedPercent: 80)
+        }
+        #expect(error == .foreignManualControl(indices: [1]))
+        #expect(try backend.uint8("F1Md") == 1)
+        #expect(!backend.operations.contains(where: {
+            if case .write = $0 { return true }
+            return false
+        }))
+    }
+
+    @Test("controller independently enforces the 60 through 90 percent range")
+    func controllerSpeedBounds() async throws {
+        for invalid in [59.9, 90.1, Double.nan] {
+            let backend = makeFanBackend(fanCount: 1)
+            let controller = try makeController(backend: backend)
+            let error = await captureControllerError {
+                _ = try await controller.engage(speedPercent: invalid)
+            }
+            guard let error, case .invalidSpeedPercent(let value) = error else {
+                Issue.record("expected invalid speed error, got \(String(describing: error))")
+                continue
+            }
+            if invalid.isNaN {
+                #expect(value.isNaN)
+            } else {
+                #expect(value == invalid)
+            }
+            #expect(!backend.operations.contains(where: {
+                if case .write = $0 { return true }
+                return false
+            }))
+        }
+    }
+
+    @Test("firmware rejection uses owned Ftst fallback and clears it on restore")
+    func ftstFallback() async throws {
+        let backend = makeFanBackend(fanCount: 1)
+        backend.queue([
+            .failBefore(.firmwareRejected(
+                operation: .writeBytes,
+                key: "F0Md",
+                result: 0x82
+            )),
+            .succeed,
+        ], for: "F0Md")
+        let controller = try makeController(backend: backend)
+
+        let session = try await controller.engage(speedPercent: 80)
+        #expect(session.ownsFtst)
+        #expect(try backend.uint8("Ftst") == 1)
+        #expect(try backend.uint8("F0Md") == 1)
+
+        try await controller.restoreAutomatic()
+        #expect(try backend.uint8("F0Md") == 0)
+        #expect(try backend.uint8("Ftst") == 0)
+    }
+
+    @Test("owned Ftst reset during setup is reasserted before success returns")
+    func ftstIsVerifiedAtTransactionEnd() async throws {
+        let backend = makeFanBackend(fanCount: 1)
+        backend.queue([
+            .failBefore(.firmwareRejected(
+                operation: .writeBytes,
+                key: "F0Md",
+                result: 0x82
+            )),
+            .succeed,
+        ], for: "F0Md")
+        backend.installWriteHook { key, _ in
+            if key == "F0Tg" {
+                backend.setUI8("Ftst", 0)
+            }
+        }
+        let controller = try makeController(backend: backend)
+
+        let session = try await controller.engage(speedPercent: 80)
+        #expect(session.ownsFtst)
+        #expect(try backend.uint8("Ftst") == 1)
+        #expect(backend.operations.filter { $0 == .write("Ftst", [1]) }.count == 2)
+        try await controller.restoreAutomatic()
+    }
+
+    @Test("pre-existing Ftst is never claimed or cleared")
+    func foreignFtst() async throws {
+        let backend = makeFanBackend(fanCount: 1)
+        backend.setUI8("Ftst", 1)
+        backend.queue([.failBefore(.firmwareRejected(
+            operation: .writeBytes,
+            key: "F0Md",
+            result: 0x82
+        ))], for: "F0Md")
+        let controller = try makeController(backend: backend)
+
+        let error = await captureControllerError {
+            _ = try await controller.engage(speedPercent: 80)
+        }
+        #expect(error == .foreignFtst(rawValue: 1))
+        #expect(try backend.uint8("Ftst") == 1)
+        #expect(try backend.uint8("F0Md") == 0)
+        #expect(!backend.operations.contains(.write("Ftst", [0])))
+    }
+
+    @Test("Ftst acquired concurrently during direct setup aborts and preserves foreign ownership")
+    func concurrentForeignFtstIsDetected() async throws {
+        let backend = makeFanBackend(fanCount: 1)
+        backend.installWriteHook { key, bytes in
+            if key == "F0Md", bytes == [1] {
+                backend.setUI8("Ftst", 1)
+            }
+        }
+        let controller = try makeController(backend: backend)
+
+        let error = await captureControllerError {
+            _ = try await controller.engage(speedPercent: 80)
+        }
+        #expect(error == .foreignFtst(rawValue: 1))
+        #expect(try backend.uint8("F0Md") == 0)
+        #expect(try backend.uint8("Ftst") == 1)
+        #expect(!backend.operations.contains(.write("Ftst", [0])))
+    }
+
+    @Test("permission denial never attempts the Ftst bypass")
+    func permissionFailureDoesNotUseFtst() async throws {
+        let backend = makeFanBackend(fanCount: 1)
+        backend.queue([.failBefore(.notPrivileged(
+            operation: .writeBytes,
+            key: "F0Md"
+        ))], for: "F0Md")
+        let controller = try makeController(backend: backend)
+
+        let error = await captureControllerError {
+            _ = try await controller.engage(speedPercent: 80)
+        }
+        #expect(error == .smc(.notPrivileged(operation: .writeBytes, key: "F0Md")))
+        #expect(!backend.operations.contains(.write("Ftst", [1])))
+        #expect(try backend.uint8("Ftst") == 0)
+    }
+
+    @Test("a mode write that mutates then throws is still rolled back")
+    func uncertainModeWriteRollsBack() async throws {
+        let backend = makeFanBackend(fanCount: 1, includeFtst: false)
+        backend.queue([
+            .failAfter(.injectedFailure("mode accepted then failed")),
+            .succeed,
+        ], for: "F0Md")
+        let controller = try makeController(backend: backend)
+
+        let error = await captureControllerError {
+            _ = try await controller.engage(speedPercent: 80)
+        }
+        #expect(error == .smc(.injectedFailure("mode accepted then failed")))
+        #expect(try backend.uint8("F0Md") == 0)
+        #expect(await controller.currentSession() == nil)
+    }
+
+    @Test("silent manual-mode rejection is detected without Ftst and restored")
+    func modeReadbackVerification() async throws {
+        let backend = makeFanBackend(fanCount: 1, includeFtst: false)
+        backend.queue([.ignore, .succeed], for: "F0Md")
+        let controller = try makeController(backend: backend)
+
+        let error = await captureControllerError {
+            _ = try await controller.engage(speedPercent: 80)
+        }
+        #expect(error == .modeVerificationFailed(index: 0, rawValue: 0))
+        #expect(try backend.uint8("F0Md") == 0)
+    }
+
+    @Test("an uncertain Ftst write is always cleared during rollback")
+    func uncertainFtstWriteRollsBack() async throws {
+        let backend = makeFanBackend(fanCount: 1)
+        backend.queue([.failBefore(.firmwareRejected(
+            operation: .writeBytes,
+            key: "F0Md",
+            result: 0x82
+        ))], for: "F0Md")
+        backend.queue([
+            .failAfter(.injectedFailure("Ftst accepted then failed")),
+            .succeed,
+        ], for: "Ftst")
+        let controller = try makeController(backend: backend)
+
+        let error = await captureControllerError {
+            _ = try await controller.engage(speedPercent: 80)
+        }
+        #expect(error == .smc(.injectedFailure("Ftst accepted then failed")))
+        #expect(try backend.uint8("F0Md") == 0)
+        #expect(try backend.uint8("Ftst") == 0)
+        #expect(await controller.currentSession() == nil)
+    }
+
+    @Test("a target failure after mutation restores every touched fan")
+    func targetFailureRollsBackAllFans() async throws {
+        let backend = makeFanBackend()
+        backend.queue([.failAfter(.injectedFailure("target accepted then failed"))], for: "F1Tg")
+        let controller = try makeController(backend: backend)
+
+        let error = await captureControllerError {
+            _ = try await controller.engage(speedPercent: 80)
+        }
+        #expect(error == .smc(.injectedFailure("target accepted then failed")))
+        #expect(try backend.uint8("F0Md") == 0)
+        #expect(try backend.uint8("F1Md") == 0)
+        #expect(await controller.currentSession() == nil)
+    }
+
+    @Test("silent target rejection is detected and restored")
+    func targetReadbackVerification() async throws {
+        let backend = makeFanBackend(fanCount: 1)
+        backend.queue([.ignore], for: "F0Tg")
+        let controller = try makeController(backend: backend)
+
+        let error = await captureControllerError {
+            _ = try await controller.engage(speedPercent: 80)
+        }
+        #expect(error == .targetVerificationFailed(
+            index: 0,
+            expected: 4_000,
+            actual: 1_400
+        ))
+        #expect(try backend.uint8("F0Md") == 0)
+    }
+
+    @Test("failed rollback retains uncertain fan state for a later retry")
+    func rollbackFailureCanBeRetried() async throws {
+        let backend = makeFanBackend(fanCount: 1, includeFtst: false)
+        backend.queue([
+            .succeed,
+            .failBefore(.injectedFailure("first automatic restore failed")),
+            .succeed,
+        ], for: "F0Md")
+        backend.queue([.failBefore(.injectedFailure("target write failed"))], for: "F0Tg")
+        let controller = try makeController(backend: backend)
+
+        let error = await captureControllerError {
+            _ = try await controller.engage(speedPercent: 80)
+        }
+        guard let error, case .rollbackFailed(let primary, let failures) = error else {
+            Issue.record("expected rollback failure, got \(String(describing: error))")
+            return
+        }
+        #expect(primary == .smc(.injectedFailure("target write failed")))
+        #expect(failures.count == 1)
+        #expect(failures[0].fanIndex == 0)
+        #expect(await controller.currentSession() != nil)
+
+        try await controller.restoreAutomatic()
+        #expect(try backend.uint8("F0Md") == 0)
+        #expect(await controller.currentSession() == nil)
+    }
+
+    @Test("rollback continues to later fans after an earlier restore fails")
+    func rollbackAttemptsEveryFan() async throws {
+        let backend = makeFanBackend()
+        backend.queue([
+            .succeed,
+            .failBefore(.injectedFailure("fan zero restore failed")),
+        ], for: "F0Md")
+        backend.queue([.failBefore(.injectedFailure("fan one target failed"))], for: "F1Tg")
+        let controller = try makeController(backend: backend)
+
+        let error = await captureControllerError {
+            _ = try await controller.engage(speedPercent: 80)
+        }
+        guard let error, case .rollbackFailed(_, let failures) = error else {
+            Issue.record("expected rollback failure, got \(String(describing: error))")
+            return
+        }
+        #expect(failures.contains(where: { $0.fanIndex == 0 }))
+        #expect(try backend.uint8("F1Md") == 0)
+        #expect(backend.operations.contains(.write("F1Md", [0])))
+    }
+
+    @Test("rollback verifies automatic mode instead of trusting a successful write")
+    func rollbackModeReadbackFailureCanBeRetried() async throws {
+        let backend = makeFanBackend(fanCount: 1, includeFtst: false)
+        backend.queue([
+            .succeed,
+            .replace([1]),
+            .succeed,
+        ], for: "F0Md")
+        backend.queue([.failBefore(.injectedFailure("target failed"))], for: "F0Tg")
+        let controller = try makeController(backend: backend)
+
+        let error = await captureControllerError {
+            _ = try await controller.engage(speedPercent: 80)
+        }
+        guard let error, case .rollbackFailed(_, let failures) = error else {
+            Issue.record("expected rollback failure, got \(String(describing: error))")
+            return
+        }
+        #expect(failures == [FanRollbackFailure(
+            fanIndex: 0,
+            step: .restoreMode,
+            error: .modeNotAutomatic(rawValue: 1)
+        )])
+        #expect((await controller.currentSession()) != nil)
+
+        try await controller.restoreAutomatic()
+        #expect(try backend.uint8("F0Md") == 0)
+        #expect(await controller.currentSession() == nil)
+    }
+
+    @Test("uncertain Ftst ownership survives failed clear and can be retried")
+    func ftstRollbackRetry() async throws {
+        let backend = makeFanBackend(fanCount: 1)
+        backend.queue([
+            .failBefore(.firmwareRejected(operation: .writeBytes, key: "F0Md", result: 0x82)),
+            .succeed,
+            .succeed,
+        ], for: "F0Md")
+        backend.queue([
+            .succeed,
+            .failBefore(.injectedFailure("Ftst clear failed")),
+            .succeed,
+        ], for: "Ftst")
+        backend.queue([.failBefore(.injectedFailure("target failed"))], for: "F0Tg")
+        let controller = try makeController(backend: backend)
+
+        let error = await captureControllerError {
+            _ = try await controller.engage(speedPercent: 80)
+        }
+        guard let error, case .rollbackFailed(_, let failures) = error else {
+            Issue.record("expected rollback failure, got \(String(describing: error))")
+            return
+        }
+        #expect(failures.contains(where: { $0.step == .clearFtst }))
+        #expect((await controller.currentSession())?.ownsFtst == true)
+
+        try await controller.restoreAutomatic()
+        #expect(try backend.uint8("Ftst") == 0)
+        #expect(await controller.currentSession() == nil)
+    }
+
+    @Test("maintain never treats orphaned Ftst uncertainty as a healthy session")
+    func maintainClearsOrphanedFtst() async throws {
+        let backend = makeFanBackend(fanCount: 1)
+        backend.queue([
+            .failBefore(.firmwareRejected(operation: .writeBytes, key: "F0Md", result: 0x82)),
+            .succeed,
+            .succeed,
+        ], for: "F0Md")
+        backend.queue([
+            .succeed,
+            .failBefore(.injectedFailure("first Ftst clear failed")),
+            .succeed,
+        ], for: "Ftst")
+        backend.queue([.failBefore(.injectedFailure("target failed"))], for: "F0Tg")
+        let controller = try makeController(backend: backend)
+        _ = await captureControllerError {
+            _ = try await controller.engage(speedPercent: 80)
+        }
+        #expect((await controller.currentSession())?.ownsFtst == true)
+
+        let maintainError = await captureControllerError {
+            _ = try await controller.maintain()
+        }
+        #expect(maintainError == .notControlling)
+        #expect(try backend.uint8("Ftst") == 0)
+        #expect(await controller.currentSession() == nil)
+    }
+
+    @Test("maintain requires an existing owned session")
+    func maintainRequiresSession() async throws {
+        let backend = makeFanBackend(fanCount: 1)
+        let controller = try makeController(backend: backend)
+        let error = await captureControllerError {
+            _ = try await controller.maintain()
+        }
+        #expect(error == .notControlling)
+        #expect(!backend.operations.contains(where: {
+            if case .write = $0 { return true }
+            return false
+        }))
+    }
+
+    @Test("reassert recovers a firmware-reclaimed mode and target")
+    func reassertsReclaimedSession() async throws {
+        let backend = makeFanBackend(fanCount: 1, includeFtst: false)
+        let controller = try makeController(backend: backend)
+        _ = try await controller.engage(speedPercent: 80)
+        backend.setUI8("F0Md", 3)
+        backend.setFloat("F0Tg", 0)
+        backend.resetOperations()
+
+        let session = try await controller.reassert()
+        #expect(session.targetRPMByFan[0] == 4_000)
+        #expect(try backend.uint8("F0Md") == 1)
+        #expect(abs(try backend.float("F0Tg") - 4_000) < 0.001)
+        #expect(backend.operations.contains(.write("F0Md", [1])))
+        #expect(backend.operations.contains(.write(
+            "F0Tg",
+            try SMCValue.float32Bytes(4_000, key: "F0Tg")
+        )))
+    }
+
+    @Test("maintain rewrites a reclaimed target without toggling a valid mode")
+    func rewritesOnlyReclaimedTarget() async throws {
+        let backend = makeFanBackend(fanCount: 1, includeFtst: false)
+        let controller = try makeController(backend: backend)
+        _ = try await controller.engage(speedPercent: 80)
+        backend.setFloat("F0Tg", 0)
+        backend.resetOperations()
+
+        _ = try await controller.maintain()
+        #expect(abs(try backend.float("F0Tg") - 4_000) < 0.001)
+        #expect(!backend.operations.contains(.write("F0Md", [1])))
+    }
+
+    @Test("maintain reacquires an owned Ftst gate reset by sleep")
+    func reacquiresFtstAfterSleep() async throws {
+        let backend = makeFanBackend(fanCount: 1)
+        backend.queue([
+            .failBefore(.firmwareRejected(
+                operation: .writeBytes,
+                key: "F0Md",
+                result: 0x82
+            )),
+            .succeed,
+        ], for: "F0Md")
+        let controller = try makeController(backend: backend)
+        _ = try await controller.engage(speedPercent: 80)
+        backend.setUI8("Ftst", 0)
+        backend.setUI8("F0Md", 3)
+        backend.setFloat("F0Tg", 0)
+        backend.resetOperations()
+
+        let session = try await controller.maintain()
+        #expect(session.ownsFtst)
+        #expect(try backend.uint8("Ftst") == 1)
+        #expect(try backend.uint8("F0Md") == 1)
+        #expect(abs(try backend.float("F0Tg") - 4_000) < 0.001)
+        #expect(backend.operations.contains(.write("Ftst", [1])))
+    }
+
+    @Test("maintain failure restores the whole session instead of leaving it partial")
+    func maintainFailureRestoresSession() async throws {
+        let backend = makeFanBackend()
+        let controller = try makeController(backend: backend)
+        _ = try await controller.engage(speedPercent: 80)
+        backend.queue([.failAfter(.injectedFailure("maintenance target failed"))], for: "F1Tg")
+
+        let error = await captureControllerError {
+            _ = try await controller.maintain()
+        }
+        #expect(error == .smc(.injectedFailure("maintenance target failed")))
+        #expect(try backend.uint8("F0Md") == 0)
+        #expect(try backend.uint8("F1Md") == 0)
+        #expect(await controller.currentSession() == nil)
+    }
+
+    @Test("actor serialization prevents restore from interleaving with engage")
+    func concurrentCallsSerialize() async throws {
+        let backend = makeFanBackend(fanCount: 1, includeFtst: false)
+        let entered = DispatchSemaphore(value: 0)
+        let release = DispatchSemaphore(value: 0)
+        backend.installWriteHook { key, bytes in
+            if key == "F0Md", bytes == [1] {
+                entered.signal()
+                release.wait()
+            }
+        }
+        let controller = try makeController(backend: backend)
+
+        let engage = Task.detached {
+            try await controller.engage(speedPercent: 80)
+        }
+        #expect(await waitForSemaphore(entered, timeout: .now() + 2) == .success)
+        let restore = Task.detached {
+            try await controller.restoreAutomatic()
+        }
+        release.signal()
+        _ = try await engage.value
+        try await restore.value
+
+        let writes = backend.operations.compactMap { operation -> (SMCKey, [UInt8])? in
+            if case .write(let key, let bytes) = operation { return (key, bytes) }
+            return nil
+        }
+        let targetWriteIndex = writes.firstIndex { pair in pair.0 == "F0Tg" }
+        let automaticWriteIndex = writes.firstIndex { pair in
+            pair.0 == "F0Md" && pair.1 == [0]
+        }
+        let targetWrite = try #require(targetWriteIndex)
+        let automaticWrite = try #require(automaticWriteIndex)
+        #expect(automaticWrite > targetWrite)
+        #expect(await controller.currentSession() == nil)
+    }
+}
+
+private func captureControllerError(
+    _ operation: () async throws -> Void
+) async -> FanControllerError? {
+    do {
+        try await operation()
+        Issue.record("expected fan controller operation to fail")
+        return nil
+    } catch let error as FanControllerError {
+        return error
+    } catch {
+        Issue.record("unexpected error type: \(error)")
+        return nil
+    }
+}
+
+private func waitForSemaphore(
+    _ semaphore: DispatchSemaphore,
+    timeout: DispatchTime
+) async -> DispatchTimeoutResult {
+    await withCheckedContinuation { continuation in
+        DispatchQueue.global().async {
+            continuation.resume(returning: semaphore.wait(timeout: timeout))
+        }
+    }
+}

--- a/provider-swift/Tests/DarkbloomFanCoreTests/FanControllerTests.swift
+++ b/provider-swift/Tests/DarkbloomFanCoreTests/FanControllerTests.swift
@@ -125,7 +125,7 @@ struct FanControllerTests {
         let error = await captureControllerError {
             _ = try await controller.engage(
                 speedPercent: 80,
-                beforeFanWrite: { callback.increment() }
+                recordOwnership: { _ in callback.increment() }
             )
         }
         #expect(error == .foreignManualControl(indices: [1]))
@@ -135,6 +135,83 @@ struct FanControllerTests {
             if case .write = $0 { return true }
             return false
         }))
+    }
+
+    @Test("ownership journal expands one fan immediately before each takeover")
+    func ownershipExpandsPerFan() async throws {
+        let backend = makeFanBackend(includeFtst: false)
+        let controller = try makeController(backend: backend)
+        let recorder = OwnershipRecorder()
+
+        let session = try await controller.engage(
+            speedPercent: 80,
+            recordOwnership: recorder.record
+        )
+
+        #expect(session.targetRPMByFan.keys.sorted() == [0, 1])
+        #expect(recorder.values == [
+            FanControlOwnership(fanIndices: [0], ownsFtst: false),
+            FanControlOwnership(fanIndices: [0, 1], ownsFtst: false),
+        ])
+        try await controller.restoreAutomatic()
+    }
+
+    @Test("a foreign manual claim after the initial scan is never overwritten")
+    func concurrentForeignFanIsRechecked() async throws {
+        let backend = makeFanBackend(includeFtst: false)
+        let controller = try makeController(backend: backend)
+        let recorder = OwnershipRecorder()
+        backend.installReadHook { key, count in
+            if key == "F1Md", count == 1 {
+                backend.setUI8("F1Md", 1)
+            }
+        }
+
+        let error = await captureControllerError {
+            _ = try await controller.engage(
+                speedPercent: 80,
+                recordOwnership: recorder.record
+            )
+        }
+
+        #expect(error == .foreignManualControl(indices: [1]))
+        #expect(try backend.uint8("F0Md") == 0)
+        #expect(try backend.uint8("F1Md") == 1)
+        #expect(!backend.operations.contains(.write("F1Md", [1])))
+        #expect(recorder.values == [
+            FanControlOwnership(fanIndices: [0], ownsFtst: false),
+        ])
+    }
+
+    @Test("a foreign claim during journal fsync narrows ownership before aborting")
+    func foreignFanDuringJournalWriteIsPreserved() async throws {
+        let backend = makeFanBackend(includeFtst: false)
+        let controller = try makeController(backend: backend)
+        let recorder = OwnershipRecorder { ownership in
+            if ownership == FanControlOwnership(
+                fanIndices: [0, 1],
+                ownsFtst: false
+            ) {
+                backend.setUI8("F1Md", 1)
+            }
+        }
+
+        let error = await captureControllerError {
+            _ = try await controller.engage(
+                speedPercent: 80,
+                recordOwnership: recorder.record
+            )
+        }
+
+        #expect(error == .foreignManualControl(indices: [1]))
+        #expect(try backend.uint8("F0Md") == 0)
+        #expect(try backend.uint8("F1Md") == 1)
+        #expect(!backend.operations.contains(.write("F1Md", [1])))
+        #expect(recorder.values == [
+            FanControlOwnership(fanIndices: [0], ownsFtst: false),
+            FanControlOwnership(fanIndices: [0, 1], ownsFtst: false),
+            FanControlOwnership(fanIndices: [0], ownsFtst: false),
+        ])
     }
 
     @Test("controller independently enforces the 60 through 90 percent range")
@@ -182,6 +259,33 @@ struct FanControllerTests {
         try await controller.restoreAutomatic()
         #expect(try backend.uint8("F0Md") == 0)
         #expect(try backend.uint8("Ftst") == 0)
+    }
+
+    @Test("Ftst journal preserves only fans already at a possible write boundary")
+    func ftstJournalPreservesExactFanSet() async throws {
+        let backend = makeFanBackend()
+        backend.queue([
+            .failBefore(.firmwareRejected(
+                operation: .writeBytes,
+                key: "F0Md",
+                result: 0x82
+            )),
+            .succeed,
+        ], for: "F0Md")
+        let controller = try makeController(backend: backend)
+        let recorder = OwnershipRecorder()
+
+        let session = try await controller.engage(
+            speedPercent: 80,
+            recordOwnership: recorder.record
+        )
+
+        #expect(session.ownsFtst)
+        let ftstIntent = try #require(
+            recorder.values.first(where: { $0.ownsFtst })
+        )
+        #expect(ftstIntent.fanIndices == [0])
+        try await controller.restoreAutomatic()
     }
 
     @Test("owned Ftst reset during setup is reasserted before success returns")
@@ -657,5 +761,28 @@ private final class CallbackCounter: @unchecked Sendable {
         lock.lock()
         count += 1
         lock.unlock()
+    }
+}
+
+private final class OwnershipRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var recorded: [FanControlOwnership] = []
+    private let onRecord: @Sendable (FanControlOwnership) -> Void
+
+    init(onRecord: @escaping @Sendable (FanControlOwnership) -> Void = { _ in }) {
+        self.onRecord = onRecord
+    }
+
+    var values: [FanControlOwnership] {
+        lock.lock()
+        defer { lock.unlock() }
+        return recorded
+    }
+
+    func record(_ ownership: FanControlOwnership) {
+        lock.lock()
+        recorded.append(ownership)
+        lock.unlock()
+        onRecord(ownership)
     }
 }

--- a/provider-swift/Tests/DarkbloomFanCoreTests/FanHardwareTests.swift
+++ b/provider-swift/Tests/DarkbloomFanCoreTests/FanHardwareTests.swift
@@ -1,0 +1,145 @@
+import Testing
+
+@testable import DarkbloomFanCore
+
+@Suite("Fan hardware discovery")
+struct FanHardwareTests {
+    @Test("chip identity selects explicit M1 through M5 sensor catalogs")
+    func sensorCatalogs() {
+        #expect(FanChipFamily(brandString: "Apple M1 Max") == .m1)
+        #expect(FanChipFamily(brandString: "Apple M2 Ultra") == .m2)
+        #expect(FanChipFamily(brandString: "Apple M3 Pro") == .m3)
+        #expect(FanChipFamily(brandString: "Apple M4 Max") == .m4)
+        #expect(FanChipFamily(brandString: "Apple M5") == .m5)
+        #expect(FanChipFamily(brandString: "Apple M10") == .unknown)
+        #expect(FanChipFamily(brandString: "Unknown") == .unknown)
+
+        #expect(GPUTemperatureCatalog.keys(for: .m1) == ["Tg05", "Tg0D", "Tg0L", "Tg0T"])
+        #expect(GPUTemperatureCatalog.keys(for: .m2) == ["Tg0f", "Tg0j"])
+        #expect(GPUTemperatureCatalog.keys(for: .m3).contains("Tf2A"))
+        #expect(GPUTemperatureCatalog.keys(for: .m4).contains("Tg1U"))
+        #expect(GPUTemperatureCatalog.keys(for: .m5).contains("Tg1g"))
+        #expect(GPUTemperatureCatalog.keys(for: .unknown).isEmpty)
+    }
+
+    @Test("discovers all required fan keys and uppercase mode keys")
+    func uppercaseModeDiscovery() throws {
+        let backend = makeFanBackend()
+        let inventory = try FanHardwareReader(backend: backend).discover(
+            brandString: "Apple M4 Max"
+        )
+
+        #expect(inventory.chipFamily == .m4)
+        #expect(inventory.fans.count == 2)
+        #expect(inventory.fans[0].modeKey == "F0Md")
+        #expect(inventory.fans[1].targetKey == "F1Tg")
+        #expect(inventory.ftstKey == "Ftst")
+        #expect(!inventory.gpuTemperatureKeys.isEmpty)
+    }
+
+    @Test("lowercase M5 mode keys are preferred when present")
+    func lowercaseModeDiscovery() throws {
+        let backend = makeFanBackend(lowercaseModeKeys: true, chipFamily: .m5)
+        // If both variants exist, lowercase remains the selected key.
+        backend.setUI8("F0Md", 0)
+        let inventory = try FanHardwareReader(backend: backend).discover(
+            brandString: "Apple M5 Max"
+        )
+        #expect(inventory.fans[0].modeKey == "F0md")
+        #expect(inventory.chipFamily == .m5)
+    }
+
+    @Test("fanless machines are represented without inventing controls")
+    func fanlessMachine() throws {
+        let backend = makeFanBackend(fanCount: 0)
+        let inventory = try FanHardwareReader(backend: backend).discover(
+            brandString: "Apple M4"
+        )
+        #expect(inventory.fans.isEmpty)
+    }
+
+    @Test("missing per-fan mode key fails capability discovery")
+    func missingModeKey() {
+        let backend = makeFanBackend(fanCount: 1)
+        backend.remove("F0Md")
+        #expect(throws: FanHardwareError.missingModeKey(index: 0)) {
+            _ = try FanHardwareReader(backend: backend).discover(
+                brandString: "Apple M4"
+            )
+        }
+    }
+
+    @Test("only present plausible GPU sensors enter the inventory")
+    func filtersGPUKeys() throws {
+        let backend = makeFanBackend(chipFamily: .m4)
+        backend.remove("Tg0G")
+        backend.setFloat("Tg0H", 2)
+        let inventory = try FanHardwareReader(backend: backend).discover(
+            brandString: "Apple M4 Max"
+        )
+        #expect(!inventory.gpuTemperatureKeys.contains("Tg0G"))
+        #expect(!inventory.gpuTemperatureKeys.contains("Tg0H"))
+        #expect(inventory.gpuTemperatureKeys.contains("Tg1U"))
+    }
+
+    @Test("sp78 GPU sensors decode while implausible later samples fail safe")
+    func fixedPointTemperatureAndFailure() throws {
+        let backend = makeFanBackend(chipFamily: .m1)
+        backend.setFixed("Tg05", type: "sp78", raw: 0x2d80)
+        let reader = FanHardwareReader(backend: backend)
+        let inventory = try reader.discover(brandString: "Apple M1 Max")
+        let initial = try reader.gpuTemperatures(in: inventory)
+        #expect(initial.first(where: { $0.key == "Tg05" })?.celsius == 45.5)
+
+        backend.setFixed("Tg05", type: "sp78", raw: 0x7f00)
+        #expect(throws: FanHardwareError.invalidTemperature(key: "Tg05", value: 127)) {
+            _ = try reader.gpuTemperatures(in: inventory)
+        }
+    }
+
+    @Test("snapshots validate limits before a controller can write")
+    func invalidLimits() {
+        let backend = makeFanBackend(fanCount: 1)
+        backend.setFloat("F0Mn", 5_500)
+        backend.setFloat("F0Mx", 5_000)
+        #expect(throws: FanHardwareError.invalidFanLimits(
+            index: 0,
+            minimum: 5_500,
+            maximum: 5_000
+        )) {
+            _ = try FanHardwareReader(backend: backend).discover(
+                brandString: "Apple M4"
+            )
+        }
+    }
+
+    @Test("manual-mode polling uses limits captured before takeover")
+    func cachedLimitsSurviveFirmwareZero() throws {
+        let backend = makeFanBackend(fanCount: 1)
+        let reader = FanHardwareReader(backend: backend)
+        let inventory = try reader.discover(brandString: "Apple M4")
+        backend.setFloat("F0Mx", 0)
+
+        let reading = try #require(reader.fanReadings(in: inventory).first)
+        #expect(reading.maximumRPM == 5_000)
+        #expect(reading.minimumRPM == 1_200)
+    }
+
+    @Test("crash-recovery discovery ignores zero live limits and GPU failures")
+    func recoveryDiscoveryIsMinimal() throws {
+        let backend = makeFanBackend(fanCount: 1)
+        backend.setFloat("F0Mx", 0)
+        for key in GPUTemperatureCatalog.keys(for: .m4) {
+            backend.remove(key)
+        }
+
+        let reader = FanHardwareReader(backend: backend)
+        let recovery = try reader.discoverForRecovery(brandString: "Apple M4")
+        #expect(recovery.fans.count == 1)
+        #expect(recovery.gpuTemperatureKeys.isEmpty)
+        #expect(recovery.fanLimits.isEmpty)
+        #expect(throws: FanHardwareError.self) {
+            _ = try reader.discover(brandString: "Apple M4")
+        }
+    }
+}

--- a/provider-swift/Tests/DarkbloomFanCoreTests/FanPolicyTests.swift
+++ b/provider-swift/Tests/DarkbloomFanCoreTests/FanPolicyTests.swift
@@ -1,0 +1,180 @@
+import Foundation
+import Testing
+
+@testable import DarkbloomFanCore
+
+@Suite("Fan temperature policy")
+struct FanPolicyTests {
+    @Test("defaults pin the agreed trigger, release, speed, and debounce")
+    func defaults() {
+        let config = FanPolicyConfiguration.defaults
+        #expect(config.triggerCelsius == 45)
+        #expect(config.releaseCelsius == 40)
+        #expect(config.speedPercent == 80)
+        #expect(config.engageSampleCount == 3)
+        #expect(config.releaseSampleCount == 30)
+    }
+
+    @Test("normal speed is restricted to 60 through 90 percent")
+    func speedValidation() throws {
+        #expect(try FanPolicyConfiguration(speedPercent: 60).speedPercent == 60)
+        #expect(try FanPolicyConfiguration(speedPercent: 90).speedPercent == 90)
+        #expect(throws: FanPolicyConfigurationError.invalidSpeedPercent(59.9)) {
+            _ = try FanPolicyConfiguration(speedPercent: 59.9)
+        }
+        #expect(throws: FanPolicyConfigurationError.invalidSpeedPercent(90.1)) {
+            _ = try FanPolicyConfiguration(speedPercent: 90.1)
+        }
+    }
+
+    @Test("decoded root policy is validated instead of bypassing invariants")
+    func decodedConfigurationValidation() throws {
+        let decoder = JSONDecoder()
+        let defaults = try decoder.decode(
+            FanPolicyConfiguration.self,
+            from: Data("{}".utf8)
+        )
+        #expect(defaults == .defaults)
+
+        for malicious in [
+            #"{"speedPercent":10}"#,
+            #"{"triggerCelsius":45,"releaseCelsius":50}"#,
+            #"{"engageSampleCount":0}"#,
+            #"{"releaseSampleCount":-1}"#,
+        ] {
+            #expect(throws: (any Error).self) {
+                _ = try decoder.decode(
+                    FanPolicyConfiguration.self,
+                    from: Data(malicious.utf8)
+                )
+            }
+        }
+    }
+
+    @Test("provider lease gates engagement and resets hot debounce")
+    func providerLeaseGate() throws {
+        var policy = FanPolicyStateMachine(configuration: try FanPolicyConfiguration(
+            engageSampleCount: 2,
+            releaseSampleCount: 2
+        ))
+        #expect(policy.evaluate(FanPolicyInput(
+            providerLeaseActive: true,
+            gpuTemperaturesCelsius: [50]
+        )) == .stayAutomatic(reason: .waitingForTrigger(samples: 1, required: 2)))
+
+        #expect(policy.evaluate(FanPolicyInput(
+            providerLeaseActive: false,
+            gpuTemperaturesCelsius: [50]
+        )) == .stayAutomatic(reason: .providerInactive))
+        #expect(policy.consecutiveHotSamples == 0)
+
+        #expect(policy.evaluate(FanPolicyInput(
+            providerLeaseActive: true,
+            gpuTemperaturesCelsius: [50]
+        )) == .stayAutomatic(reason: .waitingForTrigger(samples: 1, required: 2)))
+    }
+
+    @Test("hottest validated GPU sensor drives debounced engagement")
+    func hottestSensorEngages() throws {
+        var policy = FanPolicyStateMachine(configuration: try FanPolicyConfiguration(
+            speedPercent: 75,
+            engageSampleCount: 3,
+            releaseSampleCount: 2
+        ))
+        for sample in 1...2 {
+            #expect(policy.evaluate(FanPolicyInput(
+                providerLeaseActive: true,
+                gpuTemperaturesCelsius: [41, 45, 44]
+            )) == .stayAutomatic(reason: .waitingForTrigger(samples: sample, required: 3)))
+        }
+        #expect(policy.evaluate(FanPolicyInput(
+            providerLeaseActive: true,
+            gpuTemperaturesCelsius: [42, 47, 43]
+        )) == .engage(speedPercent: 75, hottestGPUCelsius: 47))
+        #expect(policy.mode == .manual)
+    }
+
+    @Test("a cool interruption resets engagement debounce")
+    func hotDebounceMustBeConsecutive() throws {
+        var policy = FanPolicyStateMachine(configuration: try FanPolicyConfiguration(
+            engageSampleCount: 2,
+            releaseSampleCount: 2
+        ))
+        _ = policy.evaluate(FanPolicyInput(
+            providerLeaseActive: true,
+            gpuTemperaturesCelsius: [46]
+        ))
+        #expect(policy.evaluate(FanPolicyInput(
+            providerLeaseActive: true,
+            gpuTemperaturesCelsius: [44.9]
+        )) == .stayAutomatic(reason: .belowTrigger))
+        #expect(policy.consecutiveHotSamples == 0)
+    }
+
+    @Test("40 C release uses consecutive samples and the 40-45 band holds")
+    func releaseHysteresis() throws {
+        var policy = FanPolicyStateMachine(configuration: try FanPolicyConfiguration(
+            speedPercent: 80,
+            engageSampleCount: 1,
+            releaseSampleCount: 2
+        ))
+        _ = policy.evaluate(FanPolicyInput(
+            providerLeaseActive: true,
+            gpuTemperaturesCelsius: [45]
+        ))
+        #expect(policy.mode == .manual)
+
+        #expect(policy.evaluate(FanPolicyInput(
+            providerLeaseActive: true,
+            gpuTemperaturesCelsius: [42]
+        )) == .maintain(speedPercent: 80, hottestGPUCelsius: 42))
+        #expect(policy.consecutiveCoolSamples == 0)
+
+        #expect(policy.evaluate(FanPolicyInput(
+            providerLeaseActive: true,
+            gpuTemperaturesCelsius: [40]
+        )) == .maintain(speedPercent: 80, hottestGPUCelsius: 40))
+        #expect(policy.consecutiveCoolSamples == 1)
+        #expect(policy.evaluate(FanPolicyInput(
+            providerLeaseActive: true,
+            gpuTemperaturesCelsius: [39]
+        )) == .restoreAutomatic(reason: .releaseReached))
+        #expect(policy.mode == .automatic)
+    }
+
+    @Test("lease loss, sensor loss, invalid data, and control failure all restore")
+    func failSafeRestoration() throws {
+        let failureInputs = [
+            FanPolicyInput(providerLeaseActive: false, gpuTemperaturesCelsius: [50]),
+            FanPolicyInput(providerLeaseActive: true, gpuTemperaturesCelsius: nil),
+            FanPolicyInput(providerLeaseActive: true, gpuTemperaturesCelsius: []),
+            FanPolicyInput(providerLeaseActive: true, gpuTemperaturesCelsius: [.nan]),
+            FanPolicyInput(
+                providerLeaseActive: true,
+                gpuTemperaturesCelsius: [50],
+                controlHealthy: false
+            ),
+        ]
+        let expectedReasons: [FanPolicyReason] = [
+            .providerInactive,
+            .sensorUnavailable,
+            .sensorUnavailable,
+            .invalidSensorValue,
+            .controlFailure,
+        ]
+
+        for (input, reason) in zip(failureInputs, expectedReasons) {
+            var policy = FanPolicyStateMachine(configuration: try FanPolicyConfiguration(
+                engageSampleCount: 1,
+                releaseSampleCount: 1
+            ))
+            _ = policy.evaluate(FanPolicyInput(
+                providerLeaseActive: true,
+                gpuTemperaturesCelsius: [50]
+            ))
+            #expect(policy.mode == .manual)
+            #expect(policy.evaluate(input) == .restoreAutomatic(reason: reason))
+            #expect(policy.mode == .automatic)
+        }
+    }
+}

--- a/provider-swift/Tests/DarkbloomFanCoreTests/SMCCodecTests.swift
+++ b/provider-swift/Tests/DarkbloomFanCoreTests/SMCCodecTests.swift
@@ -1,0 +1,127 @@
+import Foundation
+import Testing
+
+@testable import DarkbloomFanCore
+
+@Suite("SMC value codecs")
+struct SMCCodecTests {
+    @Test("AppleSMC parameter ABI remains exactly 80 bytes")
+    func abiLayout() {
+        #expect(AppleSMCBackend.abiStride == AppleSMCBackend.expectedABISize)
+        #expect(AppleSMCBackend.expectedABISize == 80)
+        #expect(AppleSMCBackend.abiOffsets == [
+            "key": 0,
+            "version": 4,
+            "pLimitData": 12,
+            "keyInfo": 28,
+            "result": 40,
+            "status": 41,
+            "data8": 42,
+            "data32": 44,
+            "bytes": 48,
+        ])
+    }
+
+    @Test("SMC keys require four printable ASCII bytes")
+    func keyValidation() throws {
+        let valid = "F0Tg"
+        let key = try SMCKey(valid)
+        #expect(key.rawValue == "F0Tg")
+        #expect(SMCKey(code: key.code) == key)
+
+        let tooShort = "F0"
+        #expect(throws: SMCError.invalidKey("F0")) {
+            _ = try SMCKey(tooShort)
+        }
+        let nonPrintable = "F0\nX"
+        #expect(throws: SMCError.invalidKey("F0\nX")) {
+            _ = try SMCKey(nonPrintable)
+        }
+    }
+
+    @Test("decoded SMC keys and types cannot bypass four-byte validation")
+    func codableValidation() throws {
+        let decoder = JSONDecoder()
+        let key = try decoder.decode(
+            SMCKey.self,
+            from: Data(#"{"rawValue":"F0Tg"}"#.utf8)
+        )
+        #expect(key == "F0Tg")
+        #expect(throws: SMCError.invalidKey("F0")) {
+            _ = try decoder.decode(
+                SMCKey.self,
+                from: Data(#"{"rawValue":"F0"}"#.utf8)
+            )
+        }
+        #expect(throws: SMCError.invalidDataType("flt")) {
+            _ = try decoder.decode(
+                SMCDataType.self,
+                from: Data(#"{"rawValue":"flt"}"#.utf8)
+            )
+        }
+    }
+
+    @Test("little-endian flt values round trip")
+    func floatRoundTrip() throws {
+        let key: SMCKey = "F0Tg"
+        let info = SMCKeyInfo(dataSize: 4, dataType: try SMCDataType("flt "))
+        let bytes = try SMCValue.float32Bytes(4_621.5, key: key)
+        #expect(bytes == [0x00, 0x6c, 0x90, 0x45])
+        let value = try SMCValue(key: key, info: info, bytes: bytes)
+        #expect(abs(try value.float32() - 4_621.5) < 0.001)
+        #expect(abs(try value.number() - 4_621.5) < 0.001)
+    }
+
+    @Test("ui8 and fixed-point read codecs are big-endian where required")
+    func integerAndFixedPointCodecs() throws {
+        let count = try SMCValue(
+            key: "FNum",
+            info: SMCKeyInfo(dataSize: 1, dataType: try SMCDataType("ui8 ")),
+            bytes: [2]
+        )
+        #expect(try count.uint8() == 2)
+        #expect(try count.number() == 2)
+
+        let fpe2 = try SMCValue(
+            key: "F0Ac",
+            info: SMCKeyInfo(dataSize: 2, dataType: try SMCDataType("fpe2")),
+            bytes: [0x3e, 0x80]
+        )
+        #expect(try fpe2.number() == 4_000)
+
+        let sp78 = try SMCValue(
+            key: "TG0D",
+            info: SMCKeyInfo(dataSize: 2, dataType: try SMCDataType("sp78")),
+            bytes: [0x2d, 0x80]
+        )
+        #expect(try sp78.number() == 45.5)
+
+        let sp1e = try SMCValue(
+            key: "TEST",
+            info: SMCKeyInfo(dataSize: 2, dataType: try SMCDataType("sp1e")),
+            bytes: [0x60, 0x00]
+        )
+        #expect(try sp1e.number() == 1.5)
+    }
+
+    @Test("type and length mismatches fail closed")
+    func mismatches() throws {
+        let key: SMCKey = "F0Tg"
+        #expect(throws: SMCError.dataLengthMismatch(key: key, expected: 4, actual: 1)) {
+            _ = try SMCValue(
+                key: key,
+                info: SMCKeyInfo(dataSize: 4, dataType: try SMCDataType("flt ")),
+                bytes: [0]
+            )
+        }
+
+        let value = try SMCValue(
+            key: key,
+            info: SMCKeyInfo(dataSize: 1, dataType: try SMCDataType("ui8 ")),
+            bytes: [1]
+        )
+        #expect(throws: SMCError.typeMismatch(key: key, expected: "flt ", actual: "ui8 ")) {
+            _ = try value.float32()
+        }
+    }
+}

--- a/provider-swift/Tests/DarkbloomFanHelperTests/FanDaemonTests.swift
+++ b/provider-swift/Tests/DarkbloomFanHelperTests/FanDaemonTests.swift
@@ -1,0 +1,335 @@
+import DarkbloomFanCore
+import DarkbloomFanProtocol
+import DarkbloomFanService
+import Foundation
+import Testing
+
+@testable import DarkbloomFanHelper
+
+@Suite("Fan helper daemon")
+struct FanDaemonTests {
+    @Test("provider lease is required and disconnect restores Auto")
+    func providerLeaseLifecycle() async throws {
+        let harness = try makeHarness()
+        defer { try? FileManager.default.removeItem(at: harness.root) }
+        await harness.daemon.tick()
+        #expect((await harness.daemon.status()).mode == .waitingForProvider)
+        #expect(harness.backend.byte("F0Md") == 0)
+
+        let session = UUID()
+        let reply = await harness.daemon.renewLease(
+            sessionID: session,
+            protocolVersion: FanIPC.protocolVersion,
+            providerVersion: "0.7.9"
+        )
+        #expect(reply.ok)
+        await harness.daemon.tick()
+
+        let active = await harness.daemon.status()
+        #expect(active.mode == .manual)
+        #expect(active.providerActive)
+        #expect(harness.backend.byte("F0Md") == 1)
+        #expect(harness.backend.journalExistedBeforeFirstManualWrite)
+        #expect(FileManager.default.fileExists(atPath: harness.paths.sessionJournal.path))
+        let journal = try FanDurableFile.readJSON(
+            FanSessionJournal.self,
+            from: harness.paths.sessionJournal,
+            requireRootOwnership: false
+        )
+        #expect(!journal.ownsFtst)
+
+        await harness.daemon.sessionInvalidated(session)
+        #expect(harness.backend.byte("F0Md") == 0)
+        #expect(!FileManager.default.fileExists(atPath: harness.paths.sessionJournal.path))
+        #expect((await harness.daemon.status()).mode == .waitingForProvider)
+
+        _ = await harness.daemon.renewLease(
+            sessionID: UUID(),
+            protocolVersion: FanIPC.protocolVersion,
+            providerVersion: "0.7.9"
+        )
+        await harness.daemon.tick()
+        #expect(harness.backend.byte("F0Md") == 1)
+    }
+
+    @Test("expired lease restores Auto without a disconnect callback")
+    func leaseExpiry() async throws {
+        let harness = try makeHarness()
+        defer { try? FileManager.default.removeItem(at: harness.root) }
+        let session = UUID()
+        _ = await harness.daemon.renewLease(
+            sessionID: session,
+            protocolVersion: FanIPC.protocolVersion,
+            providerVersion: "0.7.9"
+        )
+        await harness.daemon.tick()
+        #expect(harness.backend.byte("F0Md") == 1)
+
+        harness.clock.advance(by: FanIPC.leaseDurationSeconds + 1)
+        await harness.daemon.tick()
+        #expect(harness.backend.byte("F0Md") == 0)
+        #expect(!(await harness.daemon.status()).providerActive)
+    }
+
+    @Test("protocol mismatch never grants a lease")
+    func protocolMismatch() async throws {
+        let harness = try makeHarness()
+        defer { try? FileManager.default.removeItem(at: harness.root) }
+        let reply = await harness.daemon.renewLease(
+            sessionID: UUID(),
+            protocolVersion: FanIPC.protocolVersion + 1,
+            providerVersion: "0.7.9"
+        )
+        #expect(!reply.ok)
+        await harness.daemon.tick()
+        #expect(harness.backend.byte("F0Md") == 0)
+        #expect((await harness.daemon.status()).mode == .waitingForProvider)
+    }
+
+    @Test("sleep restores Auto and requires a fresh provider renewal")
+    func sleepRecovery() async throws {
+        let harness = try makeHarness()
+        defer { try? FileManager.default.removeItem(at: harness.root) }
+        _ = await harness.daemon.renewLease(
+            sessionID: UUID(),
+            protocolVersion: FanIPC.protocolVersion,
+            providerVersion: "0.7.9"
+        )
+        await harness.daemon.tick()
+        #expect(harness.backend.byte("F0Md") == 1)
+
+        await harness.daemon.prepareForSleep()
+        #expect(harness.backend.byte("F0Md") == 0)
+        let sleepingRenewal = await harness.daemon.renewLease(
+            sessionID: UUID(),
+            protocolVersion: FanIPC.protocolVersion,
+            providerVersion: "0.7.9"
+        )
+        #expect(!sleepingRenewal.ok)
+        await harness.daemon.didWake()
+        let status = await harness.daemon.status()
+        #expect(!status.providerActive)
+        #expect(status.mode == .waitingForProvider)
+    }
+
+    @Test("transient Auto failure is retried while ownership remains")
+    func restoreRetry() async throws {
+        let harness = try makeHarness()
+        defer { try? FileManager.default.removeItem(at: harness.root) }
+        let session = UUID()
+        _ = await harness.daemon.renewLease(
+            sessionID: session,
+            protocolVersion: FanIPC.protocolVersion,
+            providerVersion: "0.7.9"
+        )
+        await harness.daemon.tick()
+        #expect(harness.backend.byte("F0Md") == 1)
+
+        harness.backend.failNextAutomaticRestore()
+        await harness.daemon.sessionInvalidated(session)
+        #expect(harness.backend.byte("F0Md") == 1)
+        #expect(FileManager.default.fileExists(atPath: harness.paths.sessionJournal.path))
+
+        await harness.daemon.tick()
+        #expect(harness.backend.byte("F0Md") == 0)
+        #expect(!FileManager.default.fileExists(atPath: harness.paths.sessionJournal.path))
+    }
+
+    @Test("administrator restore latches leases off until helper restart")
+    func administrativeDisableLatch() async throws {
+        let harness = try makeHarness()
+        defer { try? FileManager.default.removeItem(at: harness.root) }
+        _ = await harness.daemon.renewLease(
+            sessionID: UUID(),
+            protocolVersion: FanIPC.protocolVersion,
+            providerVersion: "0.7.9"
+        )
+        await harness.daemon.tick()
+        #expect(harness.backend.byte("F0Md") == 1)
+
+        let restored = await harness.daemon.emergencyRestore()
+        #expect(restored.ok)
+        #expect(harness.backend.byte("F0Md") == 0)
+        let renewal = await harness.daemon.renewLease(
+            sessionID: UUID(),
+            protocolVersion: FanIPC.protocolVersion,
+            providerVersion: "0.7.9"
+        )
+        #expect(!renewal.ok)
+        #expect(!(await harness.daemon.status()).enabled)
+    }
+}
+
+private struct FanDaemonHarness {
+    let root: URL
+    let daemon: FanDaemon
+    let backend: DaemonBackend
+    let paths: FanServicePaths
+    let clock: TestUptime
+}
+
+private func makeHarness() throws -> FanDaemonHarness {
+    let root = FileManager.default.temporaryDirectory
+        .appendingPathComponent("fan-daemon-test-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    let paths = FanServicePaths(
+        helper: root.appendingPathComponent("helper"),
+        launchDaemonPlist: root.appendingPathComponent("fan.plist"),
+        configuration: root.appendingPathComponent("policy.json"),
+        sessionJournal: root.appendingPathComponent("session.json")
+    )
+    let backend = DaemonBackend(journalURL: paths.sessionJournal)
+    let inventory = FanInventory(
+        chipFamily: .m4,
+        fans: [FanCapability(
+            index: 0,
+            actualKey: "F0Ac",
+            minimumKey: "F0Mn",
+            maximumKey: "F0Mx",
+            targetKey: "F0Tg",
+            modeKey: "F0Md"
+        )],
+        gpuTemperatureKeys: ["Tg1U"],
+        ftstKey: "Ftst"
+    )
+    let reader = FanHardwareReader(backend: backend)
+    let controller = TransactionalFanController(
+        backend: backend,
+        inventory: inventory,
+        timing: FanControlTiming(
+            ftstSettleSeconds: 0,
+            retryDelaySeconds: 0,
+            manualModeAttempts: 2,
+            verificationAttempts: 1,
+            sleep: { _ in }
+        )
+    )
+    let clock = TestUptime()
+    let configuration = FanServiceConfiguration(
+        enabled: true,
+        configuredUID: 502,
+        configuredUserUUID: "11111111-1111-1111-1111-111111111111",
+        policy: try FanPolicyConfiguration(
+            triggerCelsius: 45,
+            releaseCelsius: 40,
+            speedPercent: 80,
+            engageSampleCount: 1,
+            releaseSampleCount: 1
+        )
+    )
+    let daemon = FanDaemon(
+        configuration: configuration,
+        paths: paths,
+        backend: backend,
+        inventory: inventory,
+        reader: reader,
+        controller: controller,
+        uptime: { clock.value },
+        journalOwner: nil,
+        requireRootJournalOwnership: false
+    )
+    return FanDaemonHarness(
+        root: root,
+        daemon: daemon,
+        backend: backend,
+        paths: paths,
+        clock: clock
+    )
+}
+
+private final class TestUptime: @unchecked Sendable {
+    private let lock = NSLock()
+    private var current: TimeInterval = 100
+
+    var value: TimeInterval {
+        lock.lock()
+        defer { lock.unlock() }
+        return current
+    }
+
+    func advance(by seconds: TimeInterval) {
+        lock.lock()
+        current += seconds
+        lock.unlock()
+    }
+}
+
+private final class DaemonBackend: SMCBackend, @unchecked Sendable {
+    private let lock = NSLock()
+    private let journalURL: URL
+    private var numbers: [SMCKey: Double] = [
+        "F0Ac": 0,
+        "F0Mn": 1_350,
+        "F0Mx": 5_000,
+        "F0Tg": 0,
+        "Tg1U": 50,
+    ]
+    private var bytes: [SMCKey: UInt8] = ["F0Md": 0, "Ftst": 0]
+    private(set) var journalExistedBeforeFirstManualWrite = false
+    private var failAutomaticRestore = false
+
+    init(journalURL: URL) {
+        self.journalURL = journalURL
+    }
+
+    func keyInfo(for key: SMCKey) throws -> SMCKeyInfo {
+        if bytes[key] != nil {
+            return SMCKeyInfo(dataSize: 1, dataType: try SMCDataType("ui8 "))
+        }
+        return SMCKeyInfo(dataSize: 4, dataType: try SMCDataType("flt "))
+    }
+
+    func read(_ key: SMCKey) throws -> SMCValue {
+        lock.lock()
+        defer { lock.unlock() }
+        if let byte = bytes[key] {
+            return try SMCValue(
+                key: key,
+                info: SMCKeyInfo(dataSize: 1, dataType: try SMCDataType("ui8 ")),
+                bytes: [byte]
+            )
+        }
+        let value = numbers[key] ?? 0
+        return try SMCValue(
+            key: key,
+            info: SMCKeyInfo(dataSize: 4, dataType: try SMCDataType("flt ")),
+            bytes: SMCValue.float32Bytes(value, key: key)
+        )
+    }
+
+    func write(_ key: SMCKey, bytes raw: [UInt8]) throws {
+        lock.lock()
+        defer { lock.unlock() }
+        if bytes[key] != nil {
+            if key == "F0Md", raw[0] == 0, failAutomaticRestore {
+                failAutomaticRestore = false
+                throw SMCError.injectedFailure("transient automatic restore failure")
+            }
+            if key == "F0Md", raw[0] == 1, !journalExistedBeforeFirstManualWrite {
+                journalExistedBeforeFirstManualWrite = FileManager.default.fileExists(
+                    atPath: journalURL.path
+                )
+            }
+            bytes[key] = raw[0]
+            return
+        }
+        let value = try SMCValue(
+            key: key,
+            info: SMCKeyInfo(dataSize: 4, dataType: try SMCDataType("flt ")),
+            bytes: raw
+        ).float32()
+        numbers[key] = value
+    }
+
+    func byte(_ key: SMCKey) -> UInt8? {
+        lock.lock()
+        defer { lock.unlock() }
+        return bytes[key]
+    }
+
+    func failNextAutomaticRestore() {
+        lock.lock()
+        failAutomaticRestore = true
+        lock.unlock()
+    }
+}

--- a/provider-swift/Tests/DarkbloomFanHelperTests/FanDaemonTests.swift
+++ b/provider-swift/Tests/DarkbloomFanHelperTests/FanDaemonTests.swift
@@ -158,6 +158,52 @@ struct FanDaemonTests {
         #expect(!renewal.ok)
         #expect(!(await harness.daemon.status()).enabled)
     }
+
+    @Test("Ftst ownership is journaled immediately before the first write")
+    func ftstIntentPrecedesWrite() async throws {
+        let harness = try makeHarness()
+        defer { try? FileManager.default.removeItem(at: harness.root) }
+        harness.backend.rejectNextManualWrite()
+
+        _ = await harness.daemon.renewLease(
+            sessionID: UUID(),
+            protocolVersion: FanIPC.protocolVersion,
+            providerVersion: "0.7.9"
+        )
+        await harness.daemon.tick()
+
+        #expect(harness.backend.byte("Ftst") == 1)
+        #expect(harness.backend.journalClaimedFtstBeforeFirstFtstWrite)
+        let journal = try FanDurableFile.readJSON(
+            FanSessionJournal.self,
+            from: harness.paths.sessionJournal,
+            requireRootOwnership: false
+        )
+        #expect(journal.ownsFtst)
+    }
+
+    @Test("maintenance never journals or clears a foreign Ftst gate")
+    func maintenancePreservesForeignFtst() async throws {
+        let harness = try makeHarness()
+        defer { try? FileManager.default.removeItem(at: harness.root) }
+
+        _ = await harness.daemon.renewLease(
+            sessionID: UUID(),
+            protocolVersion: FanIPC.protocolVersion,
+            providerVersion: "0.7.9"
+        )
+        await harness.daemon.tick()
+        #expect(harness.backend.byte("F0Md") == 1)
+
+        harness.clock.advance(by: 6)
+        harness.backend.setByte("F0Md", to: FanMode.system.rawValue)
+        harness.backend.rejectNextManualWrite(claimingFtst: true)
+        await harness.daemon.tick()
+
+        #expect(harness.backend.byte("F0Md") == 0)
+        #expect(harness.backend.byte("Ftst") == 1)
+        #expect(!FileManager.default.fileExists(atPath: harness.paths.sessionJournal.path))
+    }
 }
 
 private struct FanDaemonHarness {
@@ -266,7 +312,10 @@ private final class DaemonBackend: SMCBackend, @unchecked Sendable {
     ]
     private var bytes: [SMCKey: UInt8] = ["F0Md": 0, "Ftst": 0]
     private(set) var journalExistedBeforeFirstManualWrite = false
+    private(set) var journalClaimedFtstBeforeFirstFtstWrite = false
     private var failAutomaticRestore = false
+    private var rejectManualWrite = false
+    private var claimFtstOnManualRejection = false
 
     init(journalURL: URL) {
         self.journalURL = journalURL
@@ -301,6 +350,18 @@ private final class DaemonBackend: SMCBackend, @unchecked Sendable {
         lock.lock()
         defer { lock.unlock() }
         if bytes[key] != nil {
+            if key == "F0Md", raw[0] == 1, rejectManualWrite {
+                rejectManualWrite = false
+                if claimFtstOnManualRejection {
+                    bytes["Ftst"] = 1
+                    claimFtstOnManualRejection = false
+                }
+                throw SMCError.firmwareRejected(
+                    operation: .writeBytes,
+                    key: key,
+                    result: 0x82
+                )
+            }
             if key == "F0Md", raw[0] == 0, failAutomaticRestore {
                 failAutomaticRestore = false
                 throw SMCError.injectedFailure("transient automatic restore failure")
@@ -309,6 +370,16 @@ private final class DaemonBackend: SMCBackend, @unchecked Sendable {
                 journalExistedBeforeFirstManualWrite = FileManager.default.fileExists(
                     atPath: journalURL.path
                 )
+            }
+            if key == "Ftst", raw[0] == 1,
+               !journalClaimedFtstBeforeFirstFtstWrite
+            {
+                let journal = try? FanDurableFile.readJSON(
+                    FanSessionJournal.self,
+                    from: journalURL,
+                    requireRootOwnership: false
+                )
+                journalClaimedFtstBeforeFirstFtstWrite = journal?.ownsFtst == true
             }
             bytes[key] = raw[0]
             return
@@ -330,6 +401,19 @@ private final class DaemonBackend: SMCBackend, @unchecked Sendable {
     func failNextAutomaticRestore() {
         lock.lock()
         failAutomaticRestore = true
+        lock.unlock()
+    }
+
+    func setByte(_ key: SMCKey, to value: UInt8) {
+        lock.lock()
+        bytes[key] = value
+        lock.unlock()
+    }
+
+    func rejectNextManualWrite(claimingFtst: Bool = false) {
+        lock.lock()
+        rejectManualWrite = true
+        claimFtstOnManualRejection = claimingFtst
         lock.unlock()
     }
 }

--- a/provider-swift/Tests/DarkbloomFanServiceTests/FanServiceTests.swift
+++ b/provider-swift/Tests/DarkbloomFanServiceTests/FanServiceTests.swift
@@ -1,0 +1,260 @@
+import DarkbloomFanCore
+import DarkbloomFanProtocol
+import DarkbloomFanService
+import Foundation
+import Testing
+
+#if canImport(Darwin)
+import Darwin
+#endif
+
+@Suite("Fan service boundary")
+struct FanServiceTests {
+    @Test("configured provider and root are the only allowed UIDs")
+    func uidAuthorization() {
+        let uuid = "11111111-1111-1111-1111-111111111111"
+        let policy = FanPeerAuthorizationPolicy(
+            configuredUID: 502,
+            configuredUserUUID: uuid
+        )
+        #expect(policy.allows(effectiveUID: 502, currentUserUUID: uuid))
+        #expect(policy.allows(effectiveUID: 0, currentUserUUID: nil))
+        #expect(!policy.allows(effectiveUID: 501, currentUserUUID: uuid))
+        #expect(!policy.allows(
+            effectiveUID: 502,
+            currentUserUUID: "22222222-2222-2222-2222-222222222222"
+        ))
+        #expect(policy.allows(effectiveUID: 0, currentUserUUID: nil, rootOnly: true))
+        #expect(!policy.allows(effectiveUID: 502, currentUserUUID: uuid, rootOnly: true))
+    }
+
+    @Test("local account GeneratedUID resolves to a stable UUID")
+    func generatedUIDResolution() throws {
+        let first = try FanUserIdentity.generatedUID(for: UInt32(getuid()))
+        let second = try FanUserIdentity.generatedUID(for: UInt32(getuid()))
+        #expect(UUID(uuidString: first) != nil)
+        #expect(first == second)
+    }
+
+    @Test("production code requirements pin identifiers and Team ID")
+    func exactRequirements() {
+        #expect(
+            FanCodeRequirements.requirement(
+                identifier: FanIPC.helperIdentifier,
+                teamID: FanIPC.teamID
+            )
+                == "anchor apple generic and identifier \"io.darkbloom.fan-helper\" "
+                    + "and certificate leaf[subject.OU] = \"SLDQ2GJ6TL\""
+        )
+        #expect(
+            FanCodeRequirements.requirement(
+                identifier: FanIPC.providerIdentifier,
+                teamID: nil
+            ) == "identifier \"io.darkbloom.provider\""
+        )
+        #expect(FanCodeRequirements.providerRequirement().contains("SLDQ2GJ6TL"))
+        #expect(FanCodeRequirements.helperRequirement().contains("SLDQ2GJ6TL"))
+    }
+
+    @Test("root configuration rejects a policy outside safety bounds")
+    func configurationDecodeValidatesPolicy() {
+        let data = Data(#"{"schema":1,"enabled":true,"configured_uid":502,"configured_user_uuid":"11111111-1111-1111-1111-111111111111","policy":{"triggerCelsius":45,"releaseCelsius":40,"speedPercent":20,"engageSampleCount":3,"releaseSampleCount":30}}"#.utf8)
+        #expect(throws: (any Error).self) {
+            _ = try JSONDecoder().decode(FanServiceConfiguration.self, from: data)
+        }
+    }
+
+    @Test("system LaunchDaemon points only at the root-owned helper")
+    func launchDaemonShape() {
+        let root = URL(fileURLWithPath: "/tmp/fan-test")
+        let paths = FanServicePaths(
+            helper: root.appendingPathComponent("helper"),
+            launchDaemonPlist: root.appendingPathComponent("fan.plist"),
+            configuration: root.appendingPathComponent("policy.json"),
+            sessionJournal: root.appendingPathComponent("session.json")
+        )
+        let plist = FanLaunchDaemon.propertyList(paths: paths)
+        #expect(plist["Label"] as? String == FanIPC.machServiceName)
+        #expect(plist["ProgramArguments"] as? [String] == [paths.helper.path])
+        #expect((plist["MachServices"] as? [String: Bool])?[FanIPC.machServiceName] == true)
+        #expect(plist["RunAtLoad"] as? Bool == true)
+        #expect(plist["KeepAlive"] as? Bool == true)
+    }
+
+    @Test("durable state reader rejects symlinks")
+    func durableStateRejectsSymlink() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("fan-service-test-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let target = directory.appendingPathComponent("target.json")
+        let link = directory.appendingPathComponent("link.json")
+        try FanDurableFile.writeJSON(
+            FanSessionJournal(fanIndices: [0], ownsFtst: false),
+            to: target,
+            permissions: 0o600,
+            owner: nil
+        )
+        try FileManager.default.createSymbolicLink(
+            atPath: link.path,
+            withDestinationPath: target.path
+        )
+        #expect(throws: FanDurableFileError.self) {
+            _ = try FanDurableFile.readJSON(
+                FanSessionJournal.self,
+                from: link,
+                requireRootOwnership: false
+            )
+        }
+    }
+
+    @Test("startup reconciliation restores only journaled fans and Ftst")
+    func journalRecovery() throws {
+        let backend = RecoveryBackend()
+        let inventory = recoveryInventory()
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("fan-recovery-test-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let journal = directory.appendingPathComponent("session.json")
+        try FanDurableFile.writeJSON(
+            FanSessionJournal(fanIndices: [0], ownsFtst: true),
+            to: journal,
+            permissions: 0o600,
+            owner: nil
+        )
+
+        try FanOwnershipRecovery.reconcile(
+            backend: backend,
+            inventory: inventory,
+            journalURL: journal,
+            requireRootOwnership: false
+        )
+
+        #expect(backend.byte(for: "F0Md") == 0)
+        #expect(backend.byte(for: "F1Md") == 1)
+        #expect(backend.byte(for: "Ftst") == 0)
+        #expect(!FileManager.default.fileExists(atPath: journal.path))
+    }
+
+    @Test("durable writer rejects a symlink parent directory")
+    func durableWriterRejectsSymlinkParent() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("fan-parent-test-\(UUID().uuidString)")
+        let realDirectory = root.appendingPathComponent("real")
+        let linkedDirectory = root.appendingPathComponent("linked")
+        try FileManager.default.createDirectory(
+            at: realDirectory,
+            withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: root) }
+        try FileManager.default.createSymbolicLink(
+            atPath: linkedDirectory.path,
+            withDestinationPath: realDirectory.path
+        )
+
+        #expect(throws: FanDurableFileError.self) {
+            try FanDurableFile.writeJSON(
+                FanSessionJournal(fanIndices: [0], ownsFtst: false),
+                to: linkedDirectory.appendingPathComponent("session.json"),
+                permissions: 0o600,
+                owner: nil
+            )
+        }
+    }
+
+    @Test("recovery continues after one fan fails and narrows the journal")
+    func recoveryAggregatesFailures() throws {
+        let backend = RecoveryBackend(failFanZeroRestore: true)
+        let inventory = recoveryInventory()
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("fan-recovery-partial-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let journal = directory.appendingPathComponent("session.json")
+        try FanDurableFile.writeJSON(
+            FanSessionJournal(fanIndices: [0, 1], ownsFtst: true),
+            to: journal,
+            permissions: 0o600,
+            owner: nil
+        )
+
+        #expect(throws: FanOwnershipRecoveryError.self) {
+            try FanOwnershipRecovery.reconcile(
+                backend: backend,
+                inventory: inventory,
+                journalURL: journal,
+                requireRootOwnership: false,
+                journalOwner: nil
+            )
+        }
+        #expect(backend.byte(for: "F0Md") == 1)
+        #expect(backend.byte(for: "F1Md") == 0)
+        #expect(backend.byte(for: "Ftst") == 0)
+        let unresolved = try FanDurableFile.readJSON(
+            FanSessionJournal.self,
+            from: journal,
+            requireRootOwnership: false
+        )
+        #expect(unresolved.fanIndices == [0])
+        #expect(!unresolved.ownsFtst)
+    }
+}
+
+private func recoveryInventory() -> FanInventory {
+    FanInventory(
+        chipFamily: .m4,
+        fans: [0, 1].map { index in
+            FanCapability(
+                index: index,
+                actualKey: try! SMCKey("F\(index)Ac"),
+                minimumKey: try! SMCKey("F\(index)Mn"),
+                maximumKey: try! SMCKey("F\(index)Mx"),
+                targetKey: try! SMCKey("F\(index)Tg"),
+                modeKey: try! SMCKey("F\(index)Md")
+            )
+        },
+        gpuTemperatureKeys: ["Tg1U"],
+        ftstKey: "Ftst"
+    )
+}
+
+private final class RecoveryBackend: SMCBackend, @unchecked Sendable {
+    private let lock = NSLock()
+    private var values: [SMCKey: UInt8] = ["F0Md": 1, "F1Md": 1, "Ftst": 1]
+    private let failFanZeroRestore: Bool
+
+    init(failFanZeroRestore: Bool = false) {
+        self.failFanZeroRestore = failFanZeroRestore
+    }
+
+    func keyInfo(for _: SMCKey) throws -> SMCKeyInfo {
+        SMCKeyInfo(dataSize: 1, dataType: try SMCDataType("ui8 "))
+    }
+
+    func read(_ key: SMCKey) throws -> SMCValue {
+        lock.lock()
+        defer { lock.unlock() }
+        return try SMCValue(
+            key: key,
+            info: SMCKeyInfo(dataSize: 1, dataType: try SMCDataType("ui8 ")),
+            bytes: [values[key] ?? 0]
+        )
+    }
+
+    func write(_ key: SMCKey, bytes: [UInt8]) throws {
+        lock.lock()
+        if failFanZeroRestore, key == "F0Md", bytes[0] == 0 {
+            lock.unlock()
+            throw SMCError.injectedFailure("fan zero restore failed")
+        }
+        values[key] = bytes[0]
+        lock.unlock()
+    }
+
+    func byte(for key: SMCKey) -> UInt8? {
+        lock.lock()
+        defer { lock.unlock() }
+        return values[key]
+    }
+}

--- a/provider-swift/Tests/ProviderCoreTests/SelfUpdaterTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/SelfUpdaterTests.swift
@@ -234,8 +234,10 @@ struct SelfUpdaterTests {
 
         // Create an .app bundle layout inside the staging area.
         let appMacOS = stage.appendingPathComponent("Darkbloom.app/Contents/MacOS")
+        let appHelpers = stage.appendingPathComponent("Darkbloom.app/Contents/Helpers")
         let binFlat = stage.appendingPathComponent("bin")
         try FileManager.default.createDirectory(at: appMacOS, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: appHelpers, withIntermediateDirectories: true)
         try FileManager.default.createDirectory(at: binFlat, withIntermediateDirectories: true)
         try FileManager.default.createDirectory(at: install, withIntermediateDirectories: true)
         let oldAppBin = install.appendingPathComponent("Darkbloom.app/Contents/MacOS")
@@ -252,6 +254,11 @@ struct SelfUpdaterTests {
         try Data("app darkbloom".utf8).write(to: appMacOS.appendingPathComponent("darkbloom"))
         try Data("app enclave".utf8).write(to: appMacOS.appendingPathComponent("darkbloom-enclave"))
         try Data("app metallib".utf8).write(to: appMacOS.appendingPathComponent("mlx.metallib"))
+        let fanHelper = appHelpers.appendingPathComponent("darkbloom-fan-helper")
+        try Data("app fan helper".utf8).write(to: fanHelper)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755],
+            ofItemAtPath: fanHelper.path)
         let resourceBundle = stage.appendingPathComponent(
             "Darkbloom.app/Contents/Resources/mlx-swift-lm_MLXLMCommon.bundle",
             isDirectory: true)
@@ -299,6 +306,17 @@ struct SelfUpdaterTests {
         #expect(
             (try String(contentsOf: installedPagedResource, encoding: .utf8))
                 == "paged kernel source")
+        let installedFanHelper = install.appendingPathComponent(
+            "Darkbloom.app/Contents/Helpers/darkbloom-fan-helper"
+        )
+        #expect(
+            try String(contentsOf: installedFanHelper, encoding: .utf8)
+                == "app fan helper"
+        )
+        let helperAttributes = try FileManager.default.attributesOfItem(
+            atPath: installedFanHelper.path
+        )
+        #expect((helperAttributes[.posixPermissions] as? NSNumber)?.intValue == 0o755)
 
         // bin/ should contain symlinks to the .app bundle, not flat copies.
         let installedBin = install.appendingPathComponent("bin")
@@ -386,21 +404,25 @@ struct SelfUpdaterTests {
 
     private func makeSignedRuntimeFixture(
         root: URL,
-        includeResource: Bool
+        includeResource: Bool,
+        includeFanHelper: Bool = true
     ) throws -> (URL, ReleaseInfo, URL) {
         let fm = FileManager.default
         let stage = root.appendingPathComponent("signed-src", isDirectory: true)
         let app = stage.appendingPathComponent("Darkbloom.app", isDirectory: true)
         let appMacOS = app.appendingPathComponent("Contents/MacOS", isDirectory: true)
+        let helpers = app.appendingPathComponent("Contents/Helpers", isDirectory: true)
         let resources = app.appendingPathComponent("Contents/Resources", isDirectory: true)
         let bin = stage.appendingPathComponent("bin", isDirectory: true)
         let install = root.appendingPathComponent("install", isDirectory: true)
         try fm.createDirectory(at: appMacOS, withIntermediateDirectories: true)
+        try fm.createDirectory(at: helpers, withIntermediateDirectories: true)
         try fm.createDirectory(at: resources, withIntermediateDirectories: true)
         try fm.createDirectory(at: bin, withIntermediateDirectories: true)
         try fm.createDirectory(at: install, withIntermediateDirectories: true)
 
         let darkbloom = try debugBuildProduct("darkbloom")
+        let fanHelper = try debugBuildProduct("darkbloom-fan-helper")
         let metallib = try debugBuildProduct("mlx.metallib")
         try fm.copyItem(
             at: darkbloom,
@@ -411,6 +433,13 @@ struct SelfUpdaterTests {
         try fm.copyItem(
             at: metallib,
             to: appMacOS.appendingPathComponent("mlx.metallib"))
+        let stagedFanHelper = helpers.appendingPathComponent("darkbloom-fan-helper")
+        if includeFanHelper {
+            try fm.copyItem(at: fanHelper, to: stagedFanHelper)
+            try fm.setAttributes(
+                [.posixPermissions: 0o755],
+                ofItemAtPath: stagedFanHelper.path)
+        }
         let info: [String: Any] = [
             "CFBundleIdentifier": "io.darkbloom.selfupdater-test",
             "CFBundleExecutable": "darkbloom",
@@ -428,6 +457,8 @@ struct SelfUpdaterTests {
         try fm.createDirectory(at: capability, withIntermediateDirectories: true)
         try Data("1\n".utf8).write(
             to: capability.appendingPathComponent("paged-kernel-v1"))
+        try Data("1\n".utf8).write(
+            to: capability.appendingPathComponent("fan-helper-v1"))
         if includeResource {
             let builtBundle = try debugBuildProduct(
                 PackagedRuntimeSmoke.mlxLMCommonBundleName)
@@ -438,6 +469,11 @@ struct SelfUpdaterTests {
                     isDirectory: true))
         }
 
+        if includeFanHelper {
+            try runTestProcess(
+                "/usr/bin/codesign",
+                ["--force", "--sign", "-", "--identifier", "io.darkbloom.fan-helper", stagedFanHelper.path])
+        }
         try runTestProcess(
             "/usr/bin/codesign",
             ["--force", "--sign", "-", appMacOS.appendingPathComponent("mlx.metallib").path])
@@ -515,6 +551,114 @@ struct SelfUpdaterTests {
         #expect(
             !FileManager.default.fileExists(
                 atPath: missingInstall.appendingPathComponent("Darkbloom.app").path))
+    }
+
+    @Test("fan-capable signed app without its helper is rejected")
+    func signedAppRequiresFanHelper() throws {
+        _ = LiveInferenceFixtures.ensureMetallibColocated()
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(
+                "self-updater-fan-helper-test-\(UUID().uuidString)",
+                isDirectory: true
+            )
+        defer { try? FileManager.default.removeItem(at: root) }
+        let updater = SelfUpdater(coordinatorBaseURL: "https://api.example.test")
+        let (tarball, release, install) = try makeSignedRuntimeFixture(
+            root: root,
+            includeResource: true,
+            includeFanHelper: false
+        )
+
+        guard case .failure(let error) = updater.stageSignedBundleForTesting(
+            from: tarball,
+            release: release,
+            installDir: install
+        ) else {
+            Issue.record("fan-capable app without its helper unexpectedly staged")
+            return
+        }
+        #expect("\(error)".contains("fan-capable artifact"))
+    }
+
+    @Test("fan capability verifier requires a regular executable helper")
+    func fanCapabilityRequiresExecutableHelper() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("fan-capability-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: root) }
+        let (app, executable, helper) = try makeFanCapabilityFixture(root: root)
+
+        try FanHelperCapabilityVerifier.verify(
+            app: app,
+            executable: executable,
+            signaturePolicy: nil
+        )
+
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o644],
+            ofItemAtPath: helper.path
+        )
+        #expect(throws: (any Error).self) {
+            try FanHelperCapabilityVerifier.verify(
+                app: app,
+                executable: executable,
+                signaturePolicy: nil
+            )
+        }
+    }
+
+    @Test("fan capability verifier rejects a symlink helper")
+    func fanCapabilityRejectsSymlinkHelper() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("fan-capability-link-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: root) }
+        let (app, executable, helper) = try makeFanCapabilityFixture(root: root)
+        let payload = helper.deletingLastPathComponent().appendingPathComponent("payload")
+        try FileManager.default.moveItem(at: helper, to: payload)
+        try FileManager.default.createSymbolicLink(
+            atPath: helper.path,
+            withDestinationPath: payload.path
+        )
+
+        #expect(throws: (any Error).self) {
+            try FanHelperCapabilityVerifier.verify(
+                app: app,
+                executable: executable,
+                signaturePolicy: nil
+            )
+        }
+    }
+
+    private func makeFanCapabilityFixture(
+        root: URL
+    ) throws -> (app: URL, executable: URL, helper: URL) {
+        let app = root.appendingPathComponent("Darkbloom.app")
+        let executable = app.appendingPathComponent("Contents/MacOS/darkbloom")
+        let helper = app.appendingPathComponent(
+            FanHelperCapabilityVerifier.helperRelativePath
+        )
+        let marker = app.appendingPathComponent(
+            FanHelperCapabilityVerifier.markerRelativePath
+        )
+        try FileManager.default.createDirectory(
+            at: executable.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try FileManager.default.createDirectory(
+            at: helper.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try FileManager.default.createDirectory(
+            at: marker.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try Data(FanHelperCapabilityVerifier.binaryCapability.utf8).write(to: executable)
+        try Data("helper".utf8).write(to: helper)
+        try Data("1\n".utf8).write(to: marker)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755],
+            ofItemAtPath: helper.path
+        )
+        return (app, executable, helper)
     }
 
     @Test("staging extracts and verifies WITHOUT touching the live layout")

--- a/provider-swift/Tests/ProviderCoreTests/StandaloneServerTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/StandaloneServerTests.swift
@@ -156,7 +156,9 @@ import Testing
 @Test func standaloneServerWaitTracksServiceLifetime() async throws {
     let server = StandaloneServer(config: StandaloneServerConfig(port: 0))
     try await server.start()
-    #expect(await server.waitUntilBound(timeoutSeconds: 2))
+    // The full Swift suite runs more than a thousand tests concurrently on CI;
+    // allow scheduler contention without weakening the lifetime assertion.
+    #expect(await server.waitUntilBound(timeoutSeconds: 10))
 
     let completion = StandaloneServerCompletion()
     let waiter = Task {

--- a/provider-swift/Tests/ProviderCoreTests/StandaloneServerTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/StandaloneServerTests.swift
@@ -153,10 +153,30 @@ import Testing
     #expect(StandaloneServer.schedulerErrorStatus(for: "unexpected backend failure") == .internalServerError)
 }
 
-@Test func standaloneServerStartsAndStops() async throws {
-    let server = standaloneTestServer()
+@Test func standaloneServerWaitTracksServiceLifetime() async throws {
+    let server = StandaloneServer(config: StandaloneServerConfig(port: 0))
     try await server.start()
-    await server.stopAndWait()
+    #expect(await server.waitUntilBound(timeoutSeconds: 2))
+
+    let completion = StandaloneServerCompletion()
+    let waiter = Task {
+        await server.waitUntilStopped()
+        await completion.markComplete()
+    }
+    try await Task.sleep(nanoseconds: 100_000_000)
+    #expect(!(await completion.isComplete))
+
+    await server.stop()
+    await waiter.value
+    #expect(await completion.isComplete)
+}
+
+private actor StandaloneServerCompletion {
+    private(set) var isComplete = false
+
+    func markComplete() {
+        isComplete = true
+    }
 }
 
 // MARK: - Direct/local mode: bearer-token auth

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -25,6 +25,8 @@ COORD_URL="${COORD_URL:-https://api.darkbloom.dev}"
 INSTALL_DIR="$HOME/.darkbloom"
 BIN_DIR="$INSTALL_DIR/bin"
 DARKBLOOM_DESIGNATED_REQUIREMENT='anchor apple generic and identifier "io.darkbloom.provider" and certificate leaf[subject.OU] = "SLDQ2GJ6TL"'
+DARKBLOOM_FAN_HELPER_REQUIREMENT='anchor apple generic and identifier "io.darkbloom.fan-helper" and certificate leaf[subject.OU] = "SLDQ2GJ6TL"'
+FAN_HELPER_REQUIREMENT="$DARKBLOOM_FAN_HELPER_REQUIREMENT"
 INSTALL_TEST_MODE=0
 
 fail_install() {
@@ -73,6 +75,45 @@ binary_contains_paged_code() {
     LC_ALL=C grep -a -q -F 'engine_v2_kv_backend' "$binary"
 }
 
+verify_fan_helper_capability() {
+    local app=$1
+    local executable="$app/Contents/MacOS/darkbloom"
+    local marker="$app/Contents/Resources/darkbloom-runtime-capabilities/fan-helper-v1"
+    local helper="$app/Contents/Helpers/darkbloom-fan-helper"
+    local code_present=0
+    local marker_present=0
+    local helper_present=0
+
+    LC_ALL=C grep -a -q -F 'darkbloom-fan-helper-v1' "$executable" \
+        && code_present=1
+    if [ -e "$marker" ] || [ -L "$marker" ]; then marker_present=1; fi
+    if [ -e "$helper" ] || [ -L "$helper" ]; then helper_present=1; fi
+    [ "$code_present" -eq "$marker_present" ] \
+        && [ "$marker_present" -eq "$helper_present" ] || {
+        fail_install "Fan-helper CLI capability, marker, and nested helper must be present together."
+        return 1
+    }
+    [ "$marker_present" -eq 1 ] || return 0
+
+    [ -f "$marker" ] && [ ! -L "$marker" ] \
+        && [ "$(tr -d '[:space:]' < "$marker")" = "1" ] || {
+        fail_install "Fan-helper capability marker is invalid."
+        return 1
+    }
+    [ -f "$helper" ] && [ ! -L "$helper" ] && [ -x "$helper" ] || {
+        fail_install "Bundled fan helper must be a regular executable, not a symlink."
+        return 1
+    }
+    [ "$(stat -f '%Lp' "$helper" 2>/dev/null || true)" = "755" ] || {
+        fail_install "Bundled fan helper must have mode 0755."
+        return 1
+    }
+    verify_code_requirement "$helper" 0 "$FAN_HELPER_REQUIREMENT" || {
+        fail_install "Bundled fan helper does not satisfy the pinned helper signature requirement."
+        return 1
+    }
+}
+
 verify_staged_app() {
     local app=$1
     local executable="$app/Contents/MacOS/darkbloom"
@@ -86,6 +127,7 @@ verify_staged_app() {
     else
         verify_staged_app_signature "$app" || return 1
     fi
+    verify_fan_helper_capability "$app" || return 1
 
     local code_has_paged=0
     local marker_present=0
@@ -278,11 +320,12 @@ if [ "${1:-}" = "--verify-staged-app-signature-test" ]; then
 fi
 
 if [ "${1:-}" = "--install-bundle-test" ]; then
-    [ "$#" -eq 5 ] || {
-        echo "usage: $0 --install-bundle-test <archive> <install-dir> <binary-hash> <metallib-hash>" >&2
+    { [ "$#" -eq 5 ] || [ "$#" -eq 6 ]; } || {
+        echo "usage: $0 --install-bundle-test <archive> <install-dir> <binary-hash> <metallib-hash> [fan-helper-requirement]" >&2
         exit 64
     }
     INSTALL_TEST_MODE=1
+    if [ "$#" -eq 6 ]; then FAN_HELPER_REQUIREMENT=$6; fi
     install_bundle_atomically "$2" "$3" "$4" "$5"
     exit $?
 fi

--- a/scripts/test-install-atomic.sh
+++ b/scripts/test-install-atomic.sh
@@ -15,10 +15,12 @@ cat > "$ROOT/paged.c" <<'C'
 #include <unistd.h>
 
 static const char *capability = "engine_v2_kv_backend";
+static const char *fan_capability = "darkbloom-fan-helper-v1";
 
 int main(int argc, char **argv) {
     if (argc < 2 || strcmp(argv[1], "runtime-smoke") != 0) {
         fputs(capability, stderr);
+        fputs(fan_capability, stderr);
         return 0;
     }
     char resolved[PATH_MAX];
@@ -41,8 +43,13 @@ cat > "$ROOT/legacy.c" <<'C'
 int main(void) { return 0; }
 C
 
+cat > "$ROOT/fan-helper.c" <<'C'
+int main(void) { return 0; }
+C
+
 clang -Os "$ROOT/paged.c" -o "$ROOT/paged"
 clang -Os "$ROOT/legacy.c" -o "$ROOT/legacy"
+clang -Os "$ROOT/fan-helper.c" -o "$ROOT/fan-helper"
 
 # A pristine Mac has no Xcode Command Line Tools: /usr/bin/strings, otool,
 # nm, etc. are shims that prompt/fail. Prove the installers never need them
@@ -51,7 +58,7 @@ clang -Os "$ROOT/legacy.c" -o "$ROOT/legacy"
 # CLT shims first on PATH, so any hidden invocation aborts the install.
 CLT_SHIMS="$ROOT/clt-shims"
 mkdir -p "$CLT_SHIMS"
-for tool in strings otool nm xcrun swift swiftc clang gcc ld libtool lipo; do
+for tool in strings otool nm xcrun swift swiftc clang gcc ld libtool lipo sudo launchctl; do
     cat > "$CLT_SHIMS/$tool" <<SHIM
 #!/bin/bash
 echo "xcode-select: note: no developer tools were found ($tool shim)" >&2
@@ -75,10 +82,26 @@ assert_no_clt_tools() {
 assert_no_clt_tools "$REPO_ROOT/scripts/install.sh"
 assert_no_clt_tools "$REPO_ROOT/coordinator/api/install.sh"
 
+assert_no_privileged_install() {
+    local script=$1
+    local offending
+    offending=$(sed 's/#.*$//' "$script" \
+        | grep -nE '(^|[^[:alnum:]_])(sudo|launchctl)([^[:alnum:]_]|$)|/Library/PrivilegedHelperTools' \
+        || true)
+    if [ -n "$offending" ]; then
+        echo "ordinary installer contains privileged activation in $script:" >&2
+        echo "$offending" >&2
+        exit 1
+    fi
+}
+assert_no_privileged_install "$REPO_ROOT/scripts/install.sh"
+assert_no_privileged_install "$REPO_ROOT/coordinator/api/install.sh"
+
 make_artifact() {
     local output=$1
     local capability=$2
     local include_resource=$3
+    local include_fan=${4:-no}
     local stage="$ROOT/stage-$RANDOM"
     local app="$stage/Darkbloom.app"
     local binary="$ROOT/$capability"
@@ -106,6 +129,20 @@ PLIST
             printf 'kernel\n' \
                 > "$app/Contents/Resources/mlx-swift-lm_MLXLMCommon.bundle/pagedattention.metal"
         fi
+    fi
+
+    if [ "$include_fan" = "yes" ]; then
+        mkdir -p \
+            "$app/Contents/Helpers" \
+            "$app/Contents/Resources/darkbloom-runtime-capabilities"
+        install -m 0755 \
+            "$ROOT/fan-helper" \
+            "$app/Contents/Helpers/darkbloom-fan-helper"
+        printf '1\n' \
+            > "$app/Contents/Resources/darkbloom-runtime-capabilities/fan-helper-v1"
+        codesign --force --sign - \
+            --identifier io.darkbloom.fan-helper \
+            "$app/Contents/Helpers/darkbloom-fan-helper"
     fi
 
     codesign --force --sign - "$app/Contents/MacOS/mlx.metallib"
@@ -140,20 +177,21 @@ run_install() {
     local install_dir=$2
     artifact_hashes "$archive"
     PATH="$CLT_SHIMS:$PATH" bash "$INSTALLER" --install-bundle-test \
-        "$archive" "$install_dir" "$BINARY_HASH" "$METALLIB_HASH"
+        "$archive" "$install_dir" "$BINARY_HASH" "$METALLIB_HASH" \
+        "$FAN_HELPER_REQUIREMENT"
 }
 
 run_install_without_hashes() {
     PATH="$CLT_SHIMS:$PATH" bash "$INSTALLER" --install-bundle-test \
-        "$1" "$2" "" ""
+        "$1" "$2" "" "" "$FAN_HELPER_REQUIREMENT"
 }
 
 VALID="$ROOT/valid.tar.gz"
 MISSING="$ROOT/missing.tar.gz"
 LEGACY="$ROOT/legacy.tar.gz"
-make_artifact "$VALID" paged yes
-make_artifact "$MISSING" paged no
-make_artifact "$LEGACY" legacy no
+make_artifact "$VALID" paged yes yes
+make_artifact "$MISSING" paged no yes
+make_artifact "$LEGACY" legacy no no
 
 # The designated requirement must be applied to the complete app target,
 # whose main-executable signature seals Contents/Resources.
@@ -164,13 +202,21 @@ APP_REQUIREMENT=$(codesign -d -r- \
     "$SIGNATURE_ROOT/Darkbloom.app" 2>&1 \
     | awk -F' => ' '/designated/{print $2; exit}')
 [ -n "$APP_REQUIREMENT" ]
+FAN_HELPER_REQUIREMENT=$(codesign -d -r- \
+    "$SIGNATURE_ROOT/Darkbloom.app/Contents/Helpers/darkbloom-fan-helper" 2>&1 \
+    | awk -F' => ' '/designated/{print $2; exit}')
+[ -n "$FAN_HELPER_REQUIREMENT" ]
 PRODUCTION_REQUIREMENT='anchor apple generic and identifier "io.darkbloom.provider" and certificate leaf[subject.OU] = "SLDQ2GJ6TL"'
+PRODUCTION_FAN_REQUIREMENT='anchor apple generic and identifier "io.darkbloom.fan-helper" and certificate leaf[subject.OU] = "SLDQ2GJ6TL"'
 for installer in \
     "$REPO_ROOT/scripts/install.sh" \
     "$REPO_ROOT/coordinator/api/install.sh"
 do
     grep -Fqx \
         "DARKBLOOM_DESIGNATED_REQUIREMENT='$PRODUCTION_REQUIREMENT'" \
+        "$installer"
+    grep -Fqx \
+        "DARKBLOOM_FAN_HELPER_REQUIREMENT='$PRODUCTION_FAN_REQUIREMENT'" \
         "$installer"
     bash "$installer" --verify-staged-app-signature-test \
         "$SIGNATURE_ROOT/Darkbloom.app" "$APP_REQUIREMENT"
@@ -181,6 +227,88 @@ do
         exit 1
     fi
 done
+
+make_fan_variant() {
+    local output=$1
+    local mutation=$2
+    local stage="$ROOT/fan-variant-$mutation-$RANDOM"
+    local app="$stage/Darkbloom.app"
+    local helper="$app/Contents/Helpers/darkbloom-fan-helper"
+    local marker="$app/Contents/Resources/darkbloom-runtime-capabilities/fan-helper-v1"
+    mkdir -p "$stage"
+    tar xzf "$VALID" -C "$stage"
+
+    case "$mutation" in
+        missing-helper)
+            rm -f "$helper"
+            ;;
+        missing-marker)
+            rm -f "$marker"
+            ;;
+        non-executable)
+            chmod 0644 "$helper"
+            ;;
+        symlink)
+            rm -f "$helper"
+            ln -s ../MacOS/darkbloom "$helper"
+            ;;
+        wrong-identifier)
+            codesign --force --sign - \
+                --identifier not.darkbloom.fan-helper "$helper"
+            ;;
+        tampered)
+            printf 'tampered\n' >> "$helper"
+            ;;
+        *)
+            echo "unknown fan variant: $mutation" >&2
+            exit 1
+            ;;
+    esac
+
+    # Keep the outer app structurally valid except for the intentional tamper,
+    # so each negative case exercises the dedicated fan-helper checks.
+    if [ "$mutation" != "tampered" ]; then
+        codesign --force --sign - "$app"
+        # Re-signing the outer app may update its main executable signature.
+        # Keep the release verifier's flat payload byte-identical so rejection
+        # reaches the dedicated fan-helper invariant under test.
+        cp "$app/Contents/MacOS/darkbloom" "$stage/bin/darkbloom"
+        cp "$app/Contents/MacOS/darkbloom-enclave" "$stage/bin/darkbloom-enclave"
+        cp "$app/Contents/MacOS/mlx.metallib" "$stage/bin/mlx.metallib"
+    fi
+    tar czf "$output" -C "$stage" .
+    rm -rf "$stage"
+}
+
+FAN_MISSING_HELPER="$ROOT/fan-missing-helper.tar.gz"
+FAN_MISSING_MARKER="$ROOT/fan-missing-marker.tar.gz"
+FAN_NON_EXECUTABLE="$ROOT/fan-non-executable.tar.gz"
+FAN_SYMLINK="$ROOT/fan-symlink.tar.gz"
+FAN_WRONG_ID="$ROOT/fan-wrong-id.tar.gz"
+FAN_TAMPERED="$ROOT/fan-tampered.tar.gz"
+make_fan_variant "$FAN_MISSING_HELPER" missing-helper
+make_fan_variant "$FAN_MISSING_MARKER" missing-marker
+make_fan_variant "$FAN_NON_EXECUTABLE" non-executable
+make_fan_variant "$FAN_SYMLINK" symlink
+make_fan_variant "$FAN_WRONG_ID" wrong-identifier
+make_fan_variant "$FAN_TAMPERED" tampered
+
+assert_fan_variants_rejected() {
+    local install_dir=$1
+    for archive in \
+        "$FAN_MISSING_HELPER" \
+        "$FAN_MISSING_MARKER" \
+        "$FAN_NON_EXECUTABLE" \
+        "$FAN_SYMLINK" \
+        "$FAN_WRONG_ID" \
+        "$FAN_TAMPERED"
+    do
+        if run_install "$archive" "$install_dir"; then
+            echo "invalid fan-helper artifact unexpectedly installed: $archive" >&2
+            exit 1
+        fi
+    done
+}
 
 # Make the registered flat metallib differ from the signed app payload.
 # Structural app verification alone must not admit it.
@@ -196,6 +324,8 @@ INSTALL="$ROOT/install"
 mkdir -p "$INSTALL/Darkbloom.app"
 printf 'old\n' > "$INSTALL/Darkbloom.app/sentinel"
 
+assert_fan_variants_rejected "$INSTALL"
+test -f "$INSTALL/Darkbloom.app/sentinel"
 if run_install_without_hashes "$VALID" "$INSTALL"; then
     echo "app release without payload hashes unexpectedly installed" >&2
     exit 1
@@ -215,10 +345,19 @@ test -f "$INSTALL/Darkbloom.app/sentinel"
 run_install "$VALID" "$INSTALL"
 test ! -f "$INSTALL/Darkbloom.app/sentinel"
 DARKBLOOM_NO_UPDATE_CHECK=1 "$INSTALL/bin/darkbloom" runtime-smoke
+INSTALLED_FAN_HELPER="$INSTALL/Darkbloom.app/Contents/Helpers/darkbloom-fan-helper"
+INSTALLED_FAN_MARKER="$INSTALL/Darkbloom.app/Contents/Resources/darkbloom-runtime-capabilities/fan-helper-v1"
+test -f "$INSTALLED_FAN_HELPER"
+test ! -L "$INSTALLED_FAN_HELPER"
+test -x "$INSTALLED_FAN_HELPER"
+test "$(stat -f '%Lp' "$INSTALLED_FAN_HELPER")" = "755"
+test "$(tr -d '[:space:]' < "$INSTALLED_FAN_MARKER")" = "1"
+codesign --verify --strict "-R=$FAN_HELPER_REQUIREMENT" "$INSTALLED_FAN_HELPER"
 
 LEGACY_INSTALL="$ROOT/legacy-install"
 run_install "$LEGACY" "$LEGACY_INSTALL"
 test -x "$LEGACY_INSTALL/bin/darkbloom"
+test ! -e "$LEGACY_INSTALL/Darkbloom.app/Contents/Helpers/darkbloom-fan-helper"
 
 TAMPER_ROOT="$ROOT/tamper"
 mkdir -p "$TAMPER_ROOT"
@@ -237,6 +376,8 @@ INSTALLER="$REPO_ROOT/coordinator/api/install.sh"
 COORD_INSTALL="$ROOT/coordinator-install"
 mkdir -p "$COORD_INSTALL/Darkbloom.app"
 printf 'coordinator-old\n' > "$COORD_INSTALL/Darkbloom.app/sentinel"
+assert_fan_variants_rejected "$COORD_INSTALL"
+test -f "$COORD_INSTALL/Darkbloom.app/sentinel"
 if run_install_without_hashes "$VALID" "$COORD_INSTALL"; then
     echo "coordinator installer accepted an app without payload hashes" >&2
     exit 1
@@ -254,5 +395,12 @@ fi
 test -f "$COORD_INSTALL/Darkbloom.app/sentinel"
 run_install "$VALID" "$COORD_INSTALL"
 test ! -f "$COORD_INSTALL/Darkbloom.app/sentinel"
+test -x "$COORD_INSTALL/Darkbloom.app/Contents/Helpers/darkbloom-fan-helper"
+test "$(stat -f '%Lp' "$COORD_INSTALL/Darkbloom.app/Contents/Helpers/darkbloom-fan-helper")" = "755"
+
+COORD_LEGACY_INSTALL="$ROOT/coordinator-legacy-install"
+run_install "$LEGACY" "$COORD_LEGACY_INSTALL"
+test -x "$COORD_LEGACY_INSTALL/bin/darkbloom"
+test ! -e "$COORD_LEGACY_INSTALL/Darkbloom.app/Contents/Helpers/darkbloom-fan-helper"
 
 echo "atomic installer tests passed"


### PR DESCRIPTION
## Summary

Adds experimental, opt-in `darkbloom fan` control for v0.7.9. The command ships dormant to Apple Silicon providers; explicit `sudo darkbloom fan enable` installs a narrowly scoped signed root helper that applies a 60-90% target only while a signed Darkbloom provider lease is active and validated GPU sensors exceed the configured threshold.

The implementation includes transactional AppleSMC writes, M1-M5 sensor catalogs, crash/sleep/thermal recovery, exact XPC and helper code-signing requirements, UID plus GeneratedUID account binding, release/installer/updater capability verification, and operator documentation.

## Behavior diagrams

### Before

```mermaid
flowchart LR
  A[Darkbloom provider runs] --> B[macOS owns fan policy]
  B --> C[No Darkbloom fan status or controls]
```

### After

```mermaid
flowchart LR
  A[v0.7.9 installs] --> B[Bundled helper remains dormant]
  B --> C{Operator runs sudo darkbloom fan enable?}
  C -- No --> D[macOS automatic control]
  C -- Yes --> E[Signed root helper waits for provider]
  E --> F{Signed lease active and GPU above threshold?}
  F -- No --> D
  F -- Yes --> G[Apply configured 60-90% targets]
  G --> H{Lease loss, sleep, thermal pressure, or write failure?}
  H -- Yes --> D
  H -- No --> G
```

## Code diagrams

### Before

```mermaid
flowchart LR
  A[darkbloom CLI] --> B[ProviderCore serving loop]
  C[SelfUpdater and install.sh] --> D[Signed Darkbloom.app]
```

### After

```mermaid
flowchart LR
  A[FanCommand] --> B[FanServiceManager]
  B --> C[Root-owned signed helper]
  D[StartCommand serve lifetime] --> E[FanActivityLease]
  E -->|mutually authenticated XPC| F[FanDaemon]
  F --> G[FanPolicyStateMachine]
  G --> H[TransactionalFanController]
  H --> I[AppleSMC fan keys]
  J[Release workflow, installer, SelfUpdater] --> K[FanHelperCapabilityVerifier]
  K --> C
```

## Linked issue

Requested directly; no linked issue.

## Test plan

- [x] `swift test --filter 'DarkbloomFanCoreTests|FanServiceTests|FanDaemonTests|FanCommandTests|SelfUpdaterTests.fan'` - 71 focused tests pass.
- [x] `swift test` - 1,227 tests across 136 suites completed; one pre-existing parallel EngineV2 liveness timing test failed two assertions and passed immediately with `swift test --filter reWedgeOutsideCooldownRecoversAgain`.
- [x] `go test ./...` under `coordinator/` passes.
- [x] `swift build -c release --product darkbloom` and `swift build -c release --product darkbloom-fan-helper` pass.
- [x] `bash scripts/test-install-atomic.sh` passes missing, symlinked, non-executable, tampered, wrong-identifier, legacy, and valid helper cases.
- [x] Shell syntax, threat-model YAML parsing, and `git diff --check` pass.
- [x] Developer ID-signed live test on an M3 Max (`Mac15,9`, macOS 26.4): eight GPU sensors detected; exact 80% targets reached (4279/4622 RPM); lease-before-enable pickup, forced helper `SIGKILL` Auto recovery, launchd reconnect, lease-end Auto, GeneratedUID binding, and uninstall cleanup verified.
- [x] Final independent security and correctness reviews report no remaining P1/P2 blockers.

## Components touched

- [x] coordinator (Go)
- [ ] provider (Rust, legacy)
- [x] provider-swift (Swift CLI)
- [ ] console-ui (Next.js)
- [ ] enclave (Swift)
- [x] infra / CI / release
- [x] docs

## Protocol / interface changes

- [ ] No protocol/interface changes
- [x] Yes - adds the `darkbloom fan` CLI and a local, versioned XPC lease/status interface. There is no coordinator WebSocket protocol change. Release artifacts, both installer copies, updater verification, and `LatestProviderVersion` are synchronized at v0.7.9.

## Notes for reviewers

- Ordinary installation and automatic updates never request `sudo`, create root files, register launchd, or write AppleSMC.
- The helper has no coordinator client, network, model, credential, or prompt access and exposes no arbitrary SMC operation.
- The root-installed helper is upgraded only through explicit `sudo darkbloom fan enable`; incompatible or downgraded providers cannot renew the lease and leave fans in Auto.
- Active writes are live-validated on M3 Max. M4 Max read-only discovery is validated. Other M1-M5 families remain capability-gated and are not claimed as live-write validated.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/536"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786420838&installation_id=133247490&pr_number=536&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F536&signature=c65219480aa45c8186496b7e8712d3af5d4f06a105bad88a3c0bf3304c9b025b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->