### PR TITLE
feat(release): add opt-in beta provider cohort

### DIFF
--- a/.github/workflows/release-swift.yml
+++ b/.github/workflows/release-swift.yml
@@ -18,6 +18,7 @@ name: Release Provider Bundle (Swift)
 #
 # Swift cutover tag conventions:
 #   - vX.Y.Z           -> prod Swift release (reviewer approval required)
+#   - vX.Y.Z-beta.N    -> prod beta-cohort release (reviewer approval required)
 #   - vX.Y.Z-dev.N     -> dev Swift release
 #   - vX.Y.Z-swift     -> accepted alias while the migration is in progress
 #   - vX.Y.Z-swift.N   -> accepted alias while the migration is in progress
@@ -52,6 +53,12 @@ on:
         description: 'Optional version string when running manually (otherwise derived from tag)'
         required: false
         type: string
+      release_channel:
+        description: 'Release cohort (tagged *-beta.* versions infer beta)'
+        required: false
+        type: choice
+        options: [stable, beta]
+        default: stable
 
 permissions:
   contents: write   # gh release create
@@ -78,27 +85,55 @@ jobs:
     outputs:
       environment: ${{ steps.pick.outputs.environment }}
       version: ${{ steps.pick.outputs.version }}
+      channel: ${{ steps.pick.outputs.channel }}
     steps:
       - id: pick
+        env:
+          INPUT_ENVIRONMENT: ${{ inputs.environment }}
+          INPUT_VERSION_OVERRIDE: ${{ inputs.version_override }}
+          INPUT_RELEASE_CHANNEL: ${{ inputs.release_channel }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
           set -euo pipefail
-          if [ -n "${{ inputs.environment }}" ]; then
-            ENV="${{ inputs.environment }}"
-          elif [[ "${{ github.ref_name }}" == *-dev.* ]]; then
+          if [ -n "$INPUT_ENVIRONMENT" ]; then
+            ENV="$INPUT_ENVIRONMENT"
+          elif [[ "$REF_NAME" == *-dev.* ]]; then
             ENV="dev"
           else
             ENV="prod"
           fi
           echo "environment=$ENV" >> "$GITHUB_OUTPUT"
 
-          if [ -n "${{ inputs.version_override }}" ]; then
-            VERSION="${{ inputs.version_override }}"
+          if [ -n "$INPUT_VERSION_OVERRIDE" ]; then
+            VERSION="$INPUT_VERSION_OVERRIDE"
           else
             REF="${GITHUB_REF_NAME#v}"
             VERSION="${REF%-swift*}"
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "Resolved env=$ENV version=$VERSION"
+
+          if [ -n "$INPUT_RELEASE_CHANNEL" ]; then
+            CHANNEL="$INPUT_RELEASE_CHANNEL"
+          elif [[ "$VERSION" == *-beta.* ]]; then
+            CHANNEL="beta"
+          else
+            CHANNEL="stable"
+          fi
+          if [[ "$VERSION" == *-beta || "$VERSION" == *-beta.* ]]; then
+            IS_BETA_VERSION=true
+          else
+            IS_BETA_VERSION=false
+          fi
+          if [ "$CHANNEL" = "beta" ] && [ "$IS_BETA_VERSION" != true ]; then
+            echo "::error::Beta releases must use a -beta SemVer prerelease (for example 0.8.0-beta.1)"
+            exit 1
+          fi
+          if [ "$CHANNEL" = "stable" ] && [ "$IS_BETA_VERSION" = true ]; then
+            echo "::error::A -beta SemVer prerelease cannot be published on the stable channel"
+            exit 1
+          fi
+          echo "channel=$CHANNEL" >> "$GITHUB_OUTPUT"
+          echo "Resolved env=$ENV version=$VERSION channel=$CHANNEL"
 
   build-and-release:
     name: Build, sign, notarize, upload, register
@@ -108,6 +143,7 @@ jobs:
 
     env:
       VERSION: ${{ needs.resolve-env.outputs.version }}
+      RELEASE_CHANNEL: ${{ needs.resolve-env.outputs.channel }}
       ENV_PREFIX: ${{ needs.resolve-env.outputs.environment }}
 
     steps:
@@ -695,15 +731,23 @@ jobs:
             "${PREFIX}/darkbloom-bundle-macos-arm64.tar.gz" \
             --endpoint-url "$R2_ENDPOINT" --only-show-errors
 
-          # Latest pointer for `install.sh` discovery. Publish under both
+          # Stable and beta pointers are separate so a beta publication can
+          # never replace the anonymous installer's stable latest artifact.
+          if [ "$RELEASE_CHANNEL" = "beta" ]; then
+            LATEST_PREFIX="s3://${R2_BUCKET}/releases/beta/latest"
+          else
+            LATEST_PREFIX="s3://${R2_BUCKET}/releases/latest"
+          fi
+
+          # Publish under both
           # the canonical `darkbloom-bundle` name and the legacy
           # `eigeninference-bundle` name for backward compatibility with
           # any caller that hardcoded the old filename.
           aws s3 cp /tmp/darkbloom-bundle-macos-arm64.tar.gz \
-            "s3://${R2_BUCKET}/releases/latest/darkbloom-bundle-macos-arm64.tar.gz" \
+            "${LATEST_PREFIX}/darkbloom-bundle-macos-arm64.tar.gz" \
             --endpoint-url "$R2_ENDPOINT" --only-show-errors
           aws s3 cp /tmp/darkbloom-bundle-macos-arm64.tar.gz \
-            "s3://${R2_BUCKET}/releases/latest/eigeninference-bundle-macos-arm64.tar.gz" \
+            "${LATEST_PREFIX}/eigeninference-bundle-macos-arm64.tar.gz" \
             --endpoint-url "$R2_ENDPOINT" --only-show-errors
 
       - name: Compute template hashes
@@ -744,6 +788,7 @@ jobs:
           payload = {
               "version":         os.environ["VERSION"],
               "platform":        "macos-arm64",
+              "channel":         os.environ["RELEASE_CHANNEL"],
               "backend":         "mlx-swift",
               "binary_hash":     os.environ["BINARY_HASH"],
               "bundle_hash":     os.environ["BUNDLE_HASH"],
@@ -759,13 +804,20 @@ jobs:
             -H "Content-Type: application/json" \
             -d @/tmp/release-payload.json
           echo
-          echo "Release v${VERSION} registered with coordinator"
+          echo "Release v${VERSION} registered with coordinator on ${RELEASE_CHANNEL} channel"
 
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
+          if [ "$RELEASE_CHANNEL" = "beta" ]; then
+            INSTALL_GUIDE="Join with \`darkbloom beta enable\`, restart, then use the normal automatic or manual update path."
+            RELEASE_FLAGS=(--prerelease --latest=false)
+          else
+            INSTALL_GUIDE="\`curl -fsSL ${{ env.coordinator_url }}/install.sh | bash\`"
+            RELEASE_FLAGS=()
+          fi
           cat > /tmp/release-notes.md <<NOTES
           ## Provider v${VERSION} (Swift CLI)
 
@@ -778,15 +830,14 @@ jobs:
 
           ### Install
 
-          \`\`\`bash
-          curl -fsSL ${{ env.coordinator_url }}/install.sh | bash
-          \`\`\`
+          ${INSTALL_GUIDE}
 
           NOTES
           gh release create "${{ github.ref_name }}" \
             /tmp/darkbloom-bundle-macos-arm64.tar.gz \
             --title "${{ github.ref_name }}" \
             --notes-file /tmp/release-notes.md \
+            "${RELEASE_FLAGS[@]}" \
             --generate-notes
 
       - name: Cleanup keychain

--- a/console-ui/src/app/providers/dashboard/ProviderDashboard.tsx
+++ b/console-ui/src/app/providers/dashboard/ProviderDashboard.tsx
@@ -52,9 +52,15 @@ export function ProviderDashboard() {
   const updateAvailable = useMemo(
     () =>
       providers.some(
-        (p) => p.version && ctx.latest_provider_version && semverLess(p.version, ctx.latest_provider_version)
+        (p) => {
+          const latest =
+            p.release_channel === "beta"
+              ? ctx.latest_beta_provider_version || ctx.latest_provider_version
+              : ctx.latest_provider_version;
+          return Boolean(p.version && latest && semverLess(p.version, latest));
+        }
       ),
-    [providers, ctx.latest_provider_version]
+    [providers, ctx.latest_beta_provider_version, ctx.latest_provider_version]
   );
 
   if (!ready) return <Shell><LoadingState /></Shell>;

--- a/console-ui/src/app/providers/dashboard/routing.ts
+++ b/console-ui/src/app/providers/dashboard/routing.ts
@@ -19,6 +19,7 @@ export type RoutingState = "routable" | "degraded" | "blocked" | "offline";
 export type RoutingCtx = Pick<
   MyProvidersResponse,
   | "latest_provider_version"
+  | "latest_beta_provider_version"
   | "min_provider_version"
   | "heartbeat_timeout_seconds"
   | "challenge_max_age_seconds"
@@ -27,6 +28,7 @@ export type RoutingCtx = Pick<
 /** Default ctx so callers (and tests) never pass undefined fields. */
 export const DEFAULT_CTX: RoutingCtx = {
   latest_provider_version: "",
+  latest_beta_provider_version: "",
   min_provider_version: "",
   heartbeat_timeout_seconds: 90,
   challenge_max_age_seconds: 360,

--- a/console-ui/src/app/providers/dashboard/useFleetData.ts
+++ b/console-ui/src/app/providers/dashboard/useFleetData.ts
@@ -39,6 +39,7 @@ export interface FleetData {
 
 const DEFAULT_CTX_FROM = (resp: MyProvidersResponse | null): RoutingCtx => ({
   latest_provider_version: resp?.latest_provider_version ?? "",
+  latest_beta_provider_version: resp?.latest_beta_provider_version ?? "",
   min_provider_version: resp?.min_provider_version ?? "",
   heartbeat_timeout_seconds: resp?.heartbeat_timeout_seconds ?? 90,
   challenge_max_age_seconds: resp?.challenge_max_age_seconds ?? 360,

--- a/console-ui/src/app/providers/semver.test.ts
+++ b/console-ui/src/app/providers/semver.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { semverLess } from "./semver";
+
+describe("semverLess", () => {
+  it("orders beta increments and stable promotion", () => {
+    expect(semverLess("0.8.0-beta.1", "0.8.0-beta.2")).toBe(true);
+    expect(semverLess("0.8.0-beta.9", "0.8.0")).toBe(true);
+    expect(semverLess("0.8.0", "0.8.0-beta.9")).toBe(false);
+  });
+
+  it("uses numeric core and prerelease identifiers", () => {
+    expect(semverLess("0.9.10", "0.10.0")).toBe(true);
+    expect(semverLess("1.0.0-beta.10", "1.0.0-beta.2")).toBe(false);
+  });
+});

--- a/console-ui/src/app/providers/semver.ts
+++ b/console-ui/src/app/providers/semver.ts
@@ -1,0 +1,49 @@
+interface ParsedSemver {
+  major: number;
+  minor: number;
+  patch: number;
+  prerelease: string[];
+}
+
+function parseSemver(value: string): ParsedSemver | null {
+  const [withoutBuild] = value.replace(/^v/, "").split("+", 1);
+  const [core, prerelease] = withoutBuild.split("-", 2);
+  const parts = core.split(".");
+  if (parts.length !== 3) return null;
+  const [major, minor, patch] = parts.map(Number);
+  if (![major, minor, patch].every(Number.isInteger)) return null;
+  return { major, minor, patch, prerelease: prerelease?.split(".") ?? [] };
+}
+
+function comparePrereleaseIdentifier(left: string, right: string): number {
+  const leftNumber = /^\d+$/.test(left) ? Number(left) : null;
+  const rightNumber = /^\d+$/.test(right) ? Number(right) : null;
+  if (leftNumber !== null && rightNumber !== null) return leftNumber - rightNumber;
+  if (leftNumber !== null) return -1;
+  if (rightNumber !== null) return 1;
+  return left.localeCompare(right);
+}
+
+function prereleaseIsLess(left: string[], right: string[]): boolean {
+  if (left.length === 0) return false;
+  if (right.length === 0) return true;
+  for (const [index, leftPart] of left.entries()) {
+    const rightPart = right.at(index);
+    if (rightPart === undefined) return false;
+    const comparison = comparePrereleaseIdentifier(leftPart, rightPart);
+    if (comparison !== 0) return comparison < 0;
+  }
+  return left.length < right.length;
+}
+
+export function semverLess(leftVersion: string, rightVersion: string): boolean {
+  if (!leftVersion) return Boolean(rightVersion);
+  if (!rightVersion) return false;
+  const left = parseSemver(leftVersion);
+  const right = parseSemver(rightVersion);
+  if (!left || !right) return false;
+  if (left.major !== right.major) return left.major < right.major;
+  if (left.minor !== right.minor) return left.minor < right.minor;
+  if (left.patch !== right.patch) return left.patch < right.patch;
+  return prereleaseIsLess(left.prerelease, right.prerelease);
+}

--- a/console-ui/src/app/providers/types.ts
+++ b/console-ui/src/app/providers/types.ts
@@ -74,6 +74,7 @@ export interface MyProvider {
   models: MyModelInfo[];
   backend?: string;
   version?: string;
+  release_channel?: "stable" | "beta";
   serial_number?: string;
 
   trust_level: "hardware" | "self_signed" | "none" | string;
@@ -125,6 +126,7 @@ export interface MyProvider {
 export interface MyProvidersResponse {
   providers: MyProvider[];
   latest_provider_version: string;
+  latest_beta_provider_version?: string;
   min_provider_version: string;
   heartbeat_timeout_seconds: number;
   challenge_max_age_seconds: number;
@@ -161,5 +163,6 @@ export interface MySummaryResponse {
   last_7d_jobs: number;
   counts: MyFleetCounts;
   latest_provider_version: string;
+  latest_beta_provider_version?: string;
   min_provider_version: string;
 }

--- a/console-ui/src/app/providers/warnings.ts
+++ b/console-ui/src/app/providers/warnings.ts
@@ -10,6 +10,9 @@
 // rules and FindProviderWithTrust exclusion checks.
 
 import type { MyProvider, MyProvidersResponse } from "./types";
+import { semverLess } from "./semver";
+
+export { semverLess } from "./semver";
 
 export type WarningSeverity = "blocking" | "degrading" | "info";
 
@@ -20,26 +23,12 @@ export interface Warning {
   detail: string;
 }
 
-export function semverLess(a: string, b: string): boolean {
-  if (!a) return Boolean(b);
-  if (!b) return false;
-  const ap = a.split(".").map((n) => parseInt(n, 10) || 0);
-  const bp = b.split(".").map((n) => parseInt(n, 10) || 0);
-  const len = Math.max(ap.length, bp.length);
-  for (let i = 0; i < len; i++) {
-    const av = ap[i] ?? 0;
-    const bv = bp[i] ?? 0;
-    if (av < bv) return true;
-    if (av > bv) return false;
-  }
-  return false;
-}
-
 export function computeWarnings(
   p: MyProvider,
   ctx: Pick<
     MyProvidersResponse,
     | "latest_provider_version"
+    | "latest_beta_provider_version"
     | "min_provider_version"
     | "heartbeat_timeout_seconds"
     | "challenge_max_age_seconds"
@@ -271,10 +260,15 @@ export function computeWarnings(
     });
   }
 
+  const releaseChannel = p.release_channel ?? "stable";
+  const latestVersion =
+    releaseChannel === "beta"
+      ? ctx.latest_beta_provider_version || ctx.latest_provider_version
+      : ctx.latest_provider_version;
   if (
-    ctx.latest_provider_version &&
+    latestVersion &&
     p.version &&
-    semverLess(p.version, ctx.latest_provider_version) &&
+    semverLess(p.version, latestVersion) &&
     !out.some((w) => w.id === "version_below_min")
   ) {
     const isOffline = p.status === "offline" || p.status === "never_seen";
@@ -285,8 +279,8 @@ export function computeWarnings(
         ? "Version may be outdated"
         : "Newer provider version available",
       detail: isOffline
-        ? `Last seen on v${p.version}. Latest is v${ctx.latest_provider_version}. Start the provider to verify — if already updated, the version will refresh automatically.`
-        : `Running v${p.version}. Latest is v${ctx.latest_provider_version}. Update via the installer when convenient.`,
+        ? `Last seen on v${p.version}. Latest for the ${releaseChannel} channel is v${latestVersion}. Start the provider to verify — if already updated, the version will refresh automatically.`
+        : `Running v${p.version}. Latest for the ${releaseChannel} channel is v${latestVersion}. Update via the provider CLI when convenient.`,
     });
   }
 

--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -2998,7 +2998,7 @@ func (s *Server) handleVersion(w http.ResponseWriter, r *http.Request) {
 
 	var resp types.VersionResponse
 	// Try release table first.
-	if release := s.store.GetLatestRelease("macos-arm64"); release != nil {
+	if release := s.store.GetLatestRelease("macos-arm64", store.ReleaseChannelStable); release != nil {
 		resp = types.VersionResponse{
 			Version:      release.Version,
 			Platform:     release.Platform,

--- a/coordinator/api/edge_release_test.go
+++ b/coordinator/api/edge_release_test.go
@@ -18,6 +18,9 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/store"
 )
 
 func TestEdge_ReleaseLatestNoReleases(t *testing.T) {
@@ -29,6 +32,62 @@ func TestEdge_ReleaseLatestNoReleases(t *testing.T) {
 
 	if w.Code != http.StatusNotFound {
 		t.Errorf("latest with no releases: status = %d, want 404", w.Code)
+	}
+}
+
+func TestEdge_ReleaseLatestSeparatesStableAndBetaChannels(t *testing.T) {
+	srv, st := testServer(t)
+	for _, release := range []*store.Release{
+		{Version: "1.0.0", Platform: "macos-arm64", Channel: store.ReleaseChannelStable, CreatedAt: time.Now()},
+		{Version: "1.1.0-beta.1", Platform: "macos-arm64", Channel: store.ReleaseChannelBeta, CreatedAt: time.Now().Add(time.Second)},
+	} {
+		if err := st.SetRelease(release); err != nil {
+			t.Fatalf("SetRelease(%s): %v", release.Version, err)
+		}
+	}
+
+	for _, tc := range []struct {
+		path string
+		want string
+	}{
+		{path: "/v1/releases/latest?platform=macos-arm64", want: "1.0.0"},
+		{path: "/v1/releases/latest?platform=macos-arm64&channel=stable", want: "1.0.0"},
+		{path: "/v1/releases/latest?platform=macos-arm64&channel=beta", want: "1.1.0-beta.1"},
+	} {
+		req := httptest.NewRequest(http.MethodGet, tc.path, nil)
+		w := httptest.NewRecorder()
+		srv.Handler().ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("GET %s: status = %d, body = %s", tc.path, w.Code, w.Body.String())
+		}
+		var got store.Release
+		if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+			t.Fatalf("decode %s: %v", tc.path, err)
+		}
+		if got.Version != tc.want {
+			t.Errorf("GET %s: version = %q, want %q", tc.path, got.Version, tc.want)
+		}
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/releases/latest?channel=canary", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("unknown channel status = %d, want 400", w.Code)
+	}
+}
+
+func TestInvalidateLatestReleaseCacheClearsBothChannels(t *testing.T) {
+	srv, _ := testServer(t)
+	platform := "macos-arm64"
+	for _, channel := range []string{store.ReleaseChannelStable, store.ReleaseChannelBeta} {
+		srv.readCache.Set(latestReleaseCacheKey(platform, channel), []byte(`{}`), time.Minute)
+	}
+	srv.invalidateLatestReleaseCache(platform)
+	for _, channel := range []string{store.ReleaseChannelStable, store.ReleaseChannelBeta} {
+		if _, ok := srv.readCache.Get(latestReleaseCacheKey(platform, channel)); ok {
+			t.Fatalf("cache entry for %s channel survived invalidation", channel)
+		}
 	}
 }
 
@@ -78,6 +137,9 @@ func TestEdge_ReleaseRegisterMissingFields(t *testing.T) {
 		{"missing_url", fmt.Sprintf(`{"version":"1.0.0","platform":"macos-arm64","binary_hash":%q,"bundle_hash":%q}`, strings.Repeat("a", 64), strings.Repeat("b", 64))},
 		{"invalid_hash", `{"version":"1.0.0","platform":"macos-arm64","binary_hash":"abc","bundle_hash":"def","url":"http://example.com/b.tar.gz"}`},
 		{"missing_swift_metallib", fmt.Sprintf(`{"version":"1.0.0","platform":"macos-arm64","backend":"mlx-swift","binary_hash":%q,"bundle_hash":%q,"url":"http://example.com/b.tar.gz"}`, strings.Repeat("a", 64), strings.Repeat("b", 64))},
+		{"invalid_channel", fmt.Sprintf(`{"version":"1.0.0","platform":"macos-arm64","channel":"canary","binary_hash":%q,"bundle_hash":%q,"url":"http://example.com/b.tar.gz"}`, strings.Repeat("a", 64), strings.Repeat("b", 64))},
+		{"beta_version_on_stable", fmt.Sprintf(`{"version":"1.1.0-beta.1","platform":"macos-arm64","channel":"stable","binary_hash":%q,"bundle_hash":%q,"url":"http://example.com/b.tar.gz"}`, strings.Repeat("a", 64), strings.Repeat("b", 64))},
+		{"stable_version_on_beta", fmt.Sprintf(`{"version":"1.1.0","platform":"macos-arm64","channel":"beta","binary_hash":%q,"bundle_hash":%q,"url":"http://example.com/b.tar.gz"}`, strings.Repeat("a", 64), strings.Repeat("b", 64))},
 	}
 
 	for _, tc := range cases {
@@ -98,9 +160,12 @@ func TestEdge_ReleaseRegisterAndRetrieve(t *testing.T) {
 	srv, st := testServer(t)
 	srv.SetReleaseKey("release-key")
 
-	bundle, binaryHash, bundleHash := buildReleaseBundleForTest(t, []byte("provider-binary"))
+	bundle, binaryHash, metallibHash, bundleHash := buildSwiftReleaseBundleForTest(
+		t, []byte("provider-binary"), []byte("metal-library"),
+	)
 	cdn := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/releases/v1.0.0/darkbloom-bundle-macos-arm64.tar.gz" {
+		if r.URL.Path != "/releases/v1.0.0/darkbloom-bundle-macos-arm64.tar.gz" &&
+			r.URL.Path != "/releases/v1.1.0-beta.1/darkbloom-bundle-macos-arm64.tar.gz" {
 			http.NotFound(w, r)
 			return
 		}
@@ -109,7 +174,7 @@ func TestEdge_ReleaseRegisterAndRetrieve(t *testing.T) {
 	defer cdn.Close()
 	srv.SetR2CDNURL(cdn.URL + "/")
 
-	body := fmt.Sprintf(`{"version":"1.0.0","platform":"macos-arm64","backend":"mlx-swift","binary_hash":%q,"bundle_hash":%q,"metallib_hash":%q,"url":%q,"changelog":"First release"}`, binaryHash, bundleHash, strings.Repeat("c", 64), cdn.URL+"/releases/v1.0.0/darkbloom-bundle-macos-arm64.tar.gz")
+	body := fmt.Sprintf(`{"version":"1.0.0","platform":"macos-arm64","backend":"mlx-swift","binary_hash":%q,"bundle_hash":%q,"metallib_hash":%q,"url":%q,"changelog":"First release"}`, binaryHash, bundleHash, metallibHash, cdn.URL+"/releases/v1.0.0/darkbloom-bundle-macos-arm64.tar.gz")
 	req := httptest.NewRequest(http.MethodPost, "/v1/releases", strings.NewReader(body))
 	req.Header.Set("Authorization", "Bearer release-key")
 	w := httptest.NewRecorder()
@@ -134,10 +199,38 @@ func TestEdge_ReleaseRegisterAndRetrieve(t *testing.T) {
 		t.Errorf("latest version = %v, want 1.0.0", latest["version"])
 	}
 
+	// Register a beta after stable latest is cached. Registration must clear
+	// both channel keys without exposing the beta through stable discovery.
+	betaBody := fmt.Sprintf(`{"version":"1.1.0-beta.1","platform":"macos-arm64","channel":"beta","backend":"mlx-swift","binary_hash":%q,"bundle_hash":%q,"metallib_hash":%q,"url":%q}`,
+		binaryHash, bundleHash, metallibHash, cdn.URL+"/releases/v1.1.0-beta.1/darkbloom-bundle-macos-arm64.tar.gz")
+	req = httptest.NewRequest(http.MethodPost, "/v1/releases", strings.NewReader(betaBody))
+	req.Header.Set("Authorization", "Bearer release-key")
+	w = httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("register beta release: status = %d, body = %s", w.Code, w.Body.String())
+	}
+
+	for _, tc := range []struct {
+		channel string
+		want    string
+	}{{"stable", "1.0.0"}, {"beta", "1.1.0-beta.1"}} {
+		req = httptest.NewRequest(http.MethodGet, "/v1/releases/latest?platform=macos-arm64&channel="+tc.channel, nil)
+		w = httptest.NewRecorder()
+		srv.Handler().ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("get %s latest: status = %d, body = %s", tc.channel, w.Code, w.Body.String())
+		}
+		var got store.Release
+		if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil || got.Version != tc.want {
+			t.Fatalf("get %s latest = %+v (err %v), want %s", tc.channel, got, err, tc.want)
+		}
+	}
+
 	// Verify binary hashes were synced
 	releases := st.ListReleases()
-	if len(releases) == 0 {
-		t.Error("expected at least one release in store")
+	if len(releases) != 2 {
+		t.Errorf("expected two releases in store, got %d", len(releases))
 	}
 }
 
@@ -314,6 +407,31 @@ func TestEdge_ReleaseRegisterRejectsBundledBinaryHashMismatch(t *testing.T) {
 	}
 }
 
+func TestEdge_ReleaseRegisterRejectsBundledMetallibHashMismatch(t *testing.T) {
+	srv, _ := testServer(t)
+	srv.SetReleaseKey("release-key")
+
+	bundle, binaryHash, _, bundleHash := buildSwiftReleaseBundleForTest(
+		t, []byte("provider-binary"), []byte("metal-library"),
+	)
+	cdn := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(bundle)
+	}))
+	defer cdn.Close()
+	srv.SetR2CDNURL(cdn.URL)
+
+	body := fmt.Sprintf(`{"version":"1.0.0","platform":"macos-arm64","backend":"mlx-swift","binary_hash":%q,"bundle_hash":%q,"metallib_hash":%q,"url":%q}`,
+		binaryHash, bundleHash, strings.Repeat("f", 64), cdn.URL+"/releases/v1.0.0/darkbloom-bundle-macos-arm64.tar.gz")
+	req := httptest.NewRequest(http.MethodPost, "/v1/releases", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer release-key")
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest || !strings.Contains(w.Body.String(), "metallib_hash") {
+		t.Fatalf("metallib mismatch: status = %d, body = %s", w.Code, w.Body.String())
+	}
+}
+
 func TestEdge_ReleaseRegisterRejectsOversizedBundledBinary(t *testing.T) {
 	srv, _ := testServer(t)
 	srv.SetReleaseKey("release-key")
@@ -425,6 +543,33 @@ func buildReleaseBundleForTest(t *testing.T, binary []byte) ([]byte, string, str
 	t.Helper()
 
 	return buildReleaseBundleWithEntryForTest(t, "bin/darkbloom", tar.TypeReg, binary, "")
+}
+
+func buildSwiftReleaseBundleForTest(t *testing.T, binary, metallib []byte) ([]byte, string, string, string) {
+	t.Helper()
+
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	for name, content := range map[string][]byte{
+		"bin/darkbloom":    binary,
+		"bin/mlx.metallib": metallib,
+	} {
+		if err := tw.WriteHeader(&tar.Header{Name: name, Mode: 0o755, Size: int64(len(content)), Typeflag: tar.TypeReg}); err != nil {
+			t.Fatalf("write %s tar header: %v", name, err)
+		}
+		if _, err := tw.Write(content); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("close tar: %v", err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatalf("close gzip: %v", err)
+	}
+
+	return buf.Bytes(), sha256HexBytesForReleaseTest(binary), sha256HexBytesForReleaseTest(metallib), sha256HexBytesForReleaseTest(buf.Bytes())
 }
 
 func buildReleaseBundleWithEntryForTest(t *testing.T, name string, typeflag byte, binary []byte, linkname string) ([]byte, string, string) {

--- a/coordinator/api/me_handlers.go
+++ b/coordinator/api/me_handlers.go
@@ -52,11 +52,12 @@ type myProvider struct {
 	LastHeartbeat *time.Time `json:"last_heartbeat,omitempty"`
 
 	// Identity / hardware
-	Hardware     protocol.Hardware    `json:"hardware"`
-	Models       []protocol.ModelInfo `json:"models"`
-	Backend      string               `json:"backend,omitempty"`
-	Version      string               `json:"version,omitempty"`
-	SerialNumber string               `json:"serial_number,omitempty"`
+	Hardware       protocol.Hardware    `json:"hardware"`
+	Models         []protocol.ModelInfo `json:"models"`
+	Backend        string               `json:"backend,omitempty"`
+	Version        string               `json:"version,omitempty"`
+	ReleaseChannel string               `json:"release_channel"`
+	SerialNumber   string               `json:"serial_number,omitempty"`
 
 	// Trust & attestation
 	TrustLevel  string `json:"trust_level"`
@@ -117,11 +118,12 @@ type myProvider struct {
 }
 
 type myProvidersResponse struct {
-	Providers             []myProvider `json:"providers"`
-	LatestProviderVersion string       `json:"latest_provider_version"`
-	MinProviderVersion    string       `json:"min_provider_version"`
-	HeartbeatTimeoutSec   int          `json:"heartbeat_timeout_seconds"`
-	ChallengeMaxAgeSec    int          `json:"challenge_max_age_seconds"`
+	Providers                 []myProvider `json:"providers"`
+	LatestProviderVersion     string       `json:"latest_provider_version"`
+	LatestBetaProviderVersion string       `json:"latest_beta_provider_version"`
+	MinProviderVersion        string       `json:"min_provider_version"`
+	HeartbeatTimeoutSec       int          `json:"heartbeat_timeout_seconds"`
+	ChallengeMaxAgeSec        int          `json:"challenge_max_age_seconds"`
 }
 
 // myFleetCounts aggregates machine counts by status for the dashboard header.
@@ -149,6 +151,7 @@ type mySummaryResponse struct {
 	Last7dJobs                  int64         `json:"last_7d_jobs"`
 	Counts                      myFleetCounts `json:"counts"`
 	LatestProviderVersion       string        `json:"latest_provider_version"`
+	LatestBetaProviderVersion   string        `json:"latest_beta_provider_version"`
 	MinProviderVersion          string        `json:"min_provider_version"`
 }
 
@@ -213,6 +216,7 @@ func (s *Server) handleMySummary(w http.ResponseWriter, r *http.Request) {
 		Last7dJobs:                  last7dJobs,
 		Counts:                      counts,
 		LatestProviderVersion:       s.latestReleasedVersion(),
+		LatestBetaProviderVersion:   s.latestReleasedVersionForChannel(store.ReleaseChannelBeta),
 		MinProviderVersion:          s.minProviderVersion,
 	}
 	writeJSON(w, http.StatusOK, resp)
@@ -342,11 +346,12 @@ func (s *Server) handleMyProviders(w http.ResponseWriter, r *http.Request) {
 	}
 
 	resp := myProvidersResponse{
-		Providers:             fleet,
-		LatestProviderVersion: s.latestReleasedVersion(),
-		MinProviderVersion:    s.minProviderVersion,
-		HeartbeatTimeoutSec:   90,
-		ChallengeMaxAgeSec:    int((6 * time.Minute).Seconds()),
+		Providers:                 fleet,
+		LatestProviderVersion:     s.latestReleasedVersion(),
+		LatestBetaProviderVersion: s.latestReleasedVersionForChannel(store.ReleaseChannelBeta),
+		MinProviderVersion:        s.minProviderVersion,
+		HeartbeatTimeoutSec:       90,
+		ChallengeMaxAgeSec:        int((6 * time.Minute).Seconds()),
 	}
 	writeJSON(w, http.StatusOK, resp)
 }
@@ -467,6 +472,7 @@ func buildMyProvider(rec *store.ProviderRecord, live *registry.Provider) myProvi
 		mp.AccountID = rec.AccountID
 		mp.Backend = rec.Backend
 		mp.Version = rec.Version
+		mp.ReleaseChannel = rec.ReleaseChannel
 		mp.SerialNumber = rec.SerialNumber
 		mp.TrustLevel = rec.TrustLevel
 		mp.Attested = rec.Attested
@@ -547,6 +553,7 @@ func buildMyProvider(rec *store.ProviderRecord, live *registry.Provider) myProvi
 		mp.Models = append([]protocol.ModelInfo{}, live.Models...)
 		mp.Backend = live.Backend
 		mp.Version = live.Version
+		mp.ReleaseChannel = live.ReleaseChannel
 		mp.TrustLevel = string(live.TrustLevel)
 		mp.Attested = live.Attested
 		mp.MDAVerified = live.MDAVerified
@@ -620,6 +627,9 @@ func buildMyProvider(rec *store.ProviderRecord, live *registry.Provider) myProvi
 		// Concurrency limit lookup acquires its own lock.
 		mp.PendingRequests = live.PendingCount()
 		mp.MaxConcurrency = live.MaxConcurrency()
+	}
+	if mp.ReleaseChannel == "" {
+		mp.ReleaseChannel = store.ReleaseChannelStable
 	}
 
 	return mp

--- a/coordinator/api/provider_registration_test.go
+++ b/coordinator/api/provider_registration_test.go
@@ -311,7 +311,7 @@ func TestAdminDeleteReleaseBlocksActiveBinaryHashWhenEnforced(t *testing.T) {
 	if w.Code != http.StatusConflict {
 		t.Fatalf("delete without force status = %d, want %d; body=%s", w.Code, http.StatusConflict, w.Body.String())
 	}
-	if latest := st.GetLatestRelease("macos-arm64"); latest == nil || !latest.Active {
+	if latest := st.GetLatestRelease("macos-arm64", store.ReleaseChannelStable); latest == nil || !latest.Active {
 		t.Fatal("release should remain active after protected delete")
 	}
 
@@ -322,7 +322,7 @@ func TestAdminDeleteReleaseBlocksActiveBinaryHashWhenEnforced(t *testing.T) {
 	if forceW.Code != http.StatusOK {
 		t.Fatalf("force delete status = %d, want %d; body=%s", forceW.Code, http.StatusOK, forceW.Body.String())
 	}
-	if latest := st.GetLatestRelease("macos-arm64"); latest != nil {
+	if latest := st.GetLatestRelease("macos-arm64", store.ReleaseChannelStable); latest != nil {
 		t.Fatal("release should be inactive after forced delete")
 	}
 }

--- a/coordinator/api/release_handlers.go
+++ b/coordinator/api/release_handlers.go
@@ -21,12 +21,14 @@ import (
 
 	"github.com/eigeninference/d-inference/coordinator/auth"
 	"github.com/eigeninference/d-inference/coordinator/store"
+	"golang.org/x/mod/semver"
 )
 
 const (
 	maxReleaseRegisterBodyBytes = 64 * 1024
 	maxReleaseArtifactBytes     = 2 << 30 // 2 GiB
 	maxReleaseProviderBinBytes  = 512 << 20
+	maxReleaseMetallibBytes     = 512 << 20
 	releaseArtifactTimeout      = 2 * time.Minute
 )
 
@@ -39,6 +41,7 @@ var (
 type registerReleaseRequest struct {
 	Version        string `json:"version"`
 	Platform       string `json:"platform"`
+	Channel        string `json:"channel,omitempty"`
 	Backend        string `json:"backend,omitempty"`
 	BinaryHash     string `json:"binary_hash"`
 	BundleHash     string `json:"bundle_hash"`
@@ -54,6 +57,7 @@ func (req registerReleaseRequest) toRelease() store.Release {
 	return store.Release{
 		Version:        req.Version,
 		Platform:       req.Platform,
+		Channel:        req.Channel,
 		Backend:        req.Backend,
 		BinaryHash:     req.BinaryHash,
 		BundleHash:     req.BundleHash,
@@ -98,6 +102,13 @@ func (s *Server) handleRegisterRelease(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request_error", err.Error()))
 		return
 	}
+	if existing, ok := findRelease(s.store.ListReleases(), release.Version, release.Platform); ok && existing.Channel != release.Channel {
+		writeJSON(w, http.StatusConflict, errorResponse(
+			"release_channel_conflict",
+			fmt.Sprintf("release %s/%s is already registered on channel %s", release.Version, release.Platform, existing.Channel),
+		))
+		return
+	}
 
 	if s.r2CDNURL == "" {
 		s.logger.Error("release: artifact verification unavailable because R2 CDN URL is not configured",
@@ -135,11 +146,12 @@ func (s *Server) handleRegisterRelease(w http.ResponseWriter, r *http.Request) {
 	// out the TTL.
 	s.readCache.Invalidate("api_version:v1")
 	s.readCache.Invalidate("runtime_manifest:v1")
-	s.readCache.Invalidate("latest_release:v1")
+	s.invalidateLatestReleaseCache(release.Platform)
 
 	s.logger.Info("release registered",
 		"version", release.Version,
 		"platform", release.Platform,
+		"channel", release.Channel,
 		"binary_hash", release.BinaryHash[:min(16, len(release.BinaryHash))]+"...",
 	)
 
@@ -159,6 +171,10 @@ func (s *Server) releaseKeyAuthorized(token string) bool {
 func (s *Server) validateReleaseMetadata(release *store.Release) error {
 	release.Version = strings.TrimSpace(release.Version)
 	release.Platform = strings.TrimSpace(release.Platform)
+	release.Channel = strings.ToLower(strings.TrimSpace(release.Channel))
+	if release.Channel == "" {
+		release.Channel = store.ReleaseChannelStable
+	}
 	release.Backend = strings.TrimSpace(release.Backend)
 	release.BinaryHash = strings.TrimSpace(release.BinaryHash)
 	release.BundleHash = strings.TrimSpace(release.BundleHash)
@@ -174,11 +190,26 @@ func (s *Server) validateReleaseMetadata(release *store.Release) error {
 	if !releaseVersionPattern.MatchString(release.Version) {
 		return fmt.Errorf("version must be semver, e.g. 1.2.3 or 1.2.3-dev.1")
 	}
+	canonicalVersion := "v" + strings.TrimPrefix(release.Version, "v")
+	if !semver.IsValid(canonicalVersion) {
+		return fmt.Errorf("version must be valid semver")
+	}
 	if release.Platform == "" {
 		return fmt.Errorf("platform is required")
 	}
 	if !releasePlatformPattern.MatchString(release.Platform) {
 		return fmt.Errorf("platform contains invalid characters")
+	}
+	if release.Channel != store.ReleaseChannelStable && release.Channel != store.ReleaseChannelBeta {
+		return fmt.Errorf("channel must be stable or beta")
+	}
+	prerelease := semver.Prerelease(canonicalVersion)
+	isBetaVersion := prerelease == "-beta" || strings.HasPrefix(prerelease, "-beta.")
+	if release.Channel == store.ReleaseChannelBeta && !isBetaVersion {
+		return fmt.Errorf("beta channel requires a -beta prerelease version")
+	}
+	if release.Channel == store.ReleaseChannelStable && isBetaVersion {
+		return fmt.Errorf("a -beta prerelease version cannot be registered on the stable channel")
 	}
 
 	var err error
@@ -394,7 +425,9 @@ func (s *Server) verifyReleaseArtifact(ctx context.Context, release *store.Relea
 
 	tarReader := tar.NewReader(gz)
 	binaryHash := sha256.New()
+	metallibHash := sha256.New()
 	foundBinary := false
+	foundMetallib := false
 	for {
 		header, err := tarReader.Next()
 		if err == io.EOF {
@@ -407,26 +440,44 @@ func (s *Server) verifyReleaseArtifact(ctx context.Context, release *store.Relea
 		if err != nil {
 			return err
 		}
-		if cleanName != "bin/darkbloom" {
-			continue
+		switch cleanName {
+		case "bin/darkbloom":
+			if header.Typeflag != tar.TypeReg && header.Typeflag != tar.TypeRegA {
+				return fmt.Errorf("bundled provider binary is not a regular file")
+			}
+			if foundBinary {
+				return fmt.Errorf("bundle contains multiple provider binaries")
+			}
+			if header.Size < 0 || header.Size > maxReleaseProviderBinBytes {
+				return fmt.Errorf("provider binary exceeds maximum size")
+			}
+			n, err := io.Copy(binaryHash, io.LimitReader(tarReader, maxReleaseProviderBinBytes+1))
+			if err != nil {
+				return fmt.Errorf("read provider binary: %w", err)
+			}
+			if n > maxReleaseProviderBinBytes {
+				return fmt.Errorf("provider binary exceeds maximum size")
+			}
+			foundBinary = true
+		case "bin/mlx.metallib":
+			if header.Typeflag != tar.TypeReg && header.Typeflag != tar.TypeRegA {
+				return fmt.Errorf("bundled mlx.metallib is not a regular file")
+			}
+			if foundMetallib {
+				return fmt.Errorf("bundle contains multiple mlx.metallib files")
+			}
+			if header.Size < 0 || header.Size > maxReleaseMetallibBytes {
+				return fmt.Errorf("mlx.metallib exceeds maximum size")
+			}
+			n, err := io.Copy(metallibHash, io.LimitReader(tarReader, maxReleaseMetallibBytes+1))
+			if err != nil {
+				return fmt.Errorf("read mlx.metallib: %w", err)
+			}
+			if n > maxReleaseMetallibBytes {
+				return fmt.Errorf("mlx.metallib exceeds maximum size")
+			}
+			foundMetallib = true
 		}
-		if header.Typeflag != tar.TypeReg && header.Typeflag != tar.TypeRegA {
-			return fmt.Errorf("bundled provider binary is not a regular file")
-		}
-		if foundBinary {
-			return fmt.Errorf("bundle contains multiple provider binaries")
-		}
-		if header.Size < 0 || header.Size > maxReleaseProviderBinBytes {
-			return fmt.Errorf("provider binary exceeds maximum size")
-		}
-		n, err := io.Copy(binaryHash, io.LimitReader(tarReader, maxReleaseProviderBinBytes+1))
-		if err != nil {
-			return fmt.Errorf("read provider binary: %w", err)
-		}
-		if n > maxReleaseProviderBinBytes {
-			return fmt.Errorf("provider binary exceeds maximum size")
-		}
-		foundBinary = true
 	}
 	if !foundBinary {
 		return fmt.Errorf("bundle is missing bin/darkbloom")
@@ -435,6 +486,15 @@ func (s *Server) verifyReleaseArtifact(ctx context.Context, release *store.Relea
 	actualBinaryHash := hex.EncodeToString(binaryHash.Sum(nil))
 	if actualBinaryHash != release.BinaryHash {
 		return fmt.Errorf("binary_hash does not match bundled provider binary")
+	}
+	if release.MetallibHash != "" {
+		if !foundMetallib {
+			return fmt.Errorf("bundle is missing bin/mlx.metallib")
+		}
+		actualMetallibHash := hex.EncodeToString(metallibHash.Sum(nil))
+		if actualMetallibHash != release.MetallibHash {
+			return fmt.Errorf("metallib_hash does not match bundled mlx.metallib")
+		}
 	}
 	return nil
 }
@@ -452,21 +512,30 @@ func cleanReleaseTarPath(name string) (string, error) {
 }
 
 // handleLatestRelease handles GET /v1/releases/latest.
-// Public endpoint — returns the latest active release for a platform.
-// Used by install.sh to get the download URL and expected hash.
+// Public endpoint — returns the latest active release for a platform/channel.
+// The omitted/default channel is stable for install.sh; beta is an explicit
+// provider opt-in and includes stable releases for final-version promotion.
 func (s *Server) handleLatestRelease(w http.ResponseWriter, r *http.Request) {
 	platform := r.URL.Query().Get("platform")
 	if platform == "" {
 		platform = "macos-arm64"
 	}
+	channel := strings.ToLower(strings.TrimSpace(r.URL.Query().Get("channel")))
+	if channel == "" {
+		channel = store.ReleaseChannelStable
+	}
+	if channel != store.ReleaseChannelStable && channel != store.ReleaseChannelBeta {
+		writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request_error", "channel must be stable or beta"))
+		return
+	}
 
-	cacheKey := "latest_release:v1:" + platform
+	cacheKey := latestReleaseCacheKey(platform, channel)
 	if cached, ok := s.readCache.Get(cacheKey); ok {
 		writeCachedJSON(w, cached)
 		return
 	}
 
-	release := s.store.GetLatestRelease(platform)
+	release := s.store.GetLatestRelease(platform, channel)
 	if release == nil {
 		writeJSON(w, http.StatusNotFound, errorResponse("not_found", "no active release for platform "+platform))
 		return
@@ -479,6 +548,15 @@ func (s *Server) handleLatestRelease(w http.ResponseWriter, r *http.Request) {
 	}
 	s.readCache.Set(cacheKey, body, time.Minute)
 	writeCachedJSON(w, body)
+}
+
+func latestReleaseCacheKey(platform, channel string) string {
+	return "latest_release:v1:" + platform + ":" + channel
+}
+
+func (s *Server) invalidateLatestReleaseCache(platform string) {
+	s.readCache.Invalidate(latestReleaseCacheKey(platform, store.ReleaseChannelStable))
+	s.readCache.Invalidate(latestReleaseCacheKey(platform, store.ReleaseChannelBeta))
 }
 
 // handleAdminListReleases handles GET /v1/admin/releases.
@@ -518,7 +596,7 @@ func (s *Server) handleAdminDeleteRelease(w http.ResponseWriter, r *http.Request
 	if req.Platform == "" {
 		req.Platform = "macos-arm64"
 	}
-	if s.binaryHashEnforce && !req.Force {
+	if !req.Force {
 		if release, ok := findReleaseForDeactivation(s.store.ListReleases(), req.Version, req.Platform); ok {
 			if activeProviders := s.registry.CountProvidersByBinaryHash(release.BinaryHash); activeProviders > 0 {
 				writeJSON(w, http.StatusConflict, errorResponse(
@@ -538,6 +616,9 @@ func (s *Server) handleAdminDeleteRelease(w http.ResponseWriter, r *http.Request
 	// Re-sync known hashes after deactivation.
 	s.SyncBinaryHashes()
 	s.SyncRuntimeManifest()
+	s.readCache.Invalidate("api_version:v1")
+	s.readCache.Invalidate("runtime_manifest:v1")
+	s.invalidateLatestReleaseCache(req.Platform)
 
 	s.logger.Info("admin: release deactivated", "version", req.Version, "platform", req.Platform)
 	writeJSON(w, http.StatusOK, map[string]any{
@@ -548,8 +629,13 @@ func (s *Server) handleAdminDeleteRelease(w http.ResponseWriter, r *http.Request
 }
 
 func findReleaseForDeactivation(releases []store.Release, version, platform string) (store.Release, bool) {
+	release, ok := findRelease(releases, version, platform)
+	return release, ok && release.Active
+}
+
+func findRelease(releases []store.Release, version, platform string) (store.Release, bool) {
 	for _, release := range releases {
-		if release.Version == version && release.Platform == platform && release.Active {
+		if release.Version == version && release.Platform == platform {
 			return release, true
 		}
 	}

--- a/coordinator/api/runtime_manifest_test.go
+++ b/coordinator/api/runtime_manifest_test.go
@@ -48,6 +48,59 @@ func TestSyncRuntimeManifestIncludesSwiftMetallibHash(t *testing.T) {
 	}
 }
 
+func TestSyncRuntimeManifestAcceptsStableAndBetaMetallibs(t *testing.T) {
+	srv, st := runtimeManifestTestServer(t)
+	stableHash := strings.Repeat("a", 64)
+	betaHash := strings.Repeat("b", 64)
+	for _, release := range []*store.Release{
+		{
+			Version: "0.7.8", Platform: "macos-arm64", Channel: store.ReleaseChannelStable,
+			Backend: "mlx-swift", BinaryHash: strings.Repeat("c", 64), BundleHash: strings.Repeat("d", 64),
+			MetallibHash: stableHash,
+		},
+		{
+			Version: "0.7.9-beta.1", Platform: "macos-arm64", Channel: store.ReleaseChannelBeta,
+			Backend: "mlx-swift", BinaryHash: strings.Repeat("e", 64), BundleHash: strings.Repeat("f", 64),
+			MetallibHash: betaHash,
+		},
+	} {
+		if err := st.SetRelease(release); err != nil {
+			t.Fatalf("SetRelease(%s): %v", release.Version, err)
+		}
+	}
+
+	srv.SyncRuntimeManifest()
+	if srv.knownRuntimeManifest == nil {
+		t.Fatal("knownRuntimeManifest = nil")
+	}
+	if !srv.knownRuntimeManifest.MetallibHashes[stableHash] || !srv.knownRuntimeManifest.MetallibHashes[betaHash] {
+		t.Fatalf("metallib hashes = %#v, want stable and beta", srv.knownRuntimeManifest.MetallibHashes)
+	}
+	for _, hash := range []string{stableHash, betaHash} {
+		if ok, mismatches := srv.verifyRuntimeHashesForBackend("mlx-swift", "", "", map[string]string{"mlx_metallib": hash}); !ok {
+			t.Errorf("metallib %q rejected: %#v", hash, mismatches)
+		}
+	}
+}
+
+func TestMergeRuntimeManifestPreservesReleaseDerivedMetallibs(t *testing.T) {
+	srv, _ := runtimeManifestTestServer(t)
+	releaseHash := strings.Repeat("a", 64)
+	overrideHash := strings.Repeat("b", 64)
+	srv.SetRuntimeManifest(&RuntimeManifest{
+		TemplateHashes: map[string]string{"mlx_metallib": releaseHash},
+		MetallibHashes: map[string]bool{releaseHash: true},
+	})
+	srv.MergeRuntimeManifest(&RuntimeManifest{
+		TemplateHashes: map[string]string{"mlx_metallib": overrideHash},
+		MetallibHashes: map[string]bool{overrideHash: true},
+	})
+
+	if !srv.knownRuntimeManifest.MetallibHashes[releaseHash] || !srv.knownRuntimeManifest.MetallibHashes[overrideHash] {
+		t.Fatalf("metallib hashes = %#v, want release and override", srv.knownRuntimeManifest.MetallibHashes)
+	}
+}
+
 func TestVerifyRuntimeHashesForSwiftRequiresMetallibButNotLegacyRuntime(t *testing.T) {
 	srv, _ := runtimeManifestTestServer(t)
 	metallibHash := strings.Repeat("a", 64)

--- a/coordinator/api/server.go
+++ b/coordinator/api/server.go
@@ -49,6 +49,7 @@ import (
 	"github.com/eigeninference/d-inference/coordinator/saferun"
 	"github.com/eigeninference/d-inference/coordinator/store"
 	"github.com/eigeninference/d-inference/coordinator/telemetry"
+	"golang.org/x/mod/semver"
 )
 
 // apiKeyCacheEntry stores the authenticated key record for a single raw API
@@ -158,7 +159,11 @@ const minProviderVersionForDesiredModels = "0.5.17"
 // the store, falling back to the hardcoded LatestProviderVersion when
 // no release record exists.
 func (s *Server) latestReleasedVersion() string {
-	if release := s.store.GetLatestRelease("macos-arm64"); release != nil {
+	return s.latestReleasedVersionForChannel(store.ReleaseChannelStable)
+}
+
+func (s *Server) latestReleasedVersionForChannel(channel string) string {
+	if release := s.store.GetLatestRelease("macos-arm64", channel); release != nil {
 		return release.Version
 	}
 	return LatestProviderVersion
@@ -1254,6 +1259,7 @@ func (s *Server) SyncRuntimeManifest() {
 		PythonHashes:   make(map[string]bool),
 		RuntimeHashes:  make(map[string]bool),
 		TemplateHashes: make(map[string]string),
+		MetallibHashes: make(map[string]bool),
 	}
 
 	// Sort releases ascending by version so newer releases' template hashes
@@ -1296,6 +1302,7 @@ func (s *Server) SyncRuntimeManifest() {
 					"error", err,
 				)
 			} else {
+				manifest.MetallibHashes[normalized] = true
 				manifest.TemplateHashes["mlx_metallib"] = normalized
 				hasAny = true
 			}
@@ -1308,6 +1315,7 @@ func (s *Server) SyncRuntimeManifest() {
 			"python_hashes", len(manifest.PythonHashes),
 			"runtime_hashes", len(manifest.RuntimeHashes),
 			"template_hashes", len(manifest.TemplateHashes),
+			"metallib_hashes", len(manifest.MetallibHashes),
 		)
 	} else if len(releases) > 0 {
 		// Explicit empty: releases exist but none have hashes. Clear manifest.
@@ -1380,6 +1388,7 @@ type RuntimeManifest struct {
 	PythonHashes   map[string]bool   `json:"python_hashes"`   // set of accepted Python runtime hashes
 	RuntimeHashes  map[string]bool   `json:"runtime_hashes"`  // set of accepted inference runtime hashes
 	TemplateHashes map[string]string `json:"template_hashes"` // template_name -> expected hash
+	MetallibHashes map[string]bool   `json:"metallib_hashes"` // accepted mlx.metallib hashes across stable and beta releases
 }
 
 // SetRuntimeManifest configures the known-good runtime manifest for provider
@@ -1393,24 +1402,7 @@ func semverGreater(a, b string) bool {
 	if b == "" {
 		return true
 	}
-	aParts := strings.Split(a, ".")
-	bParts := strings.Split(b, ".")
-	for i := 0; i < len(aParts) || i < len(bParts); i++ {
-		var ai, bi int
-		if i < len(aParts) {
-			fmt.Sscanf(aParts[i], "%d", &ai)
-		}
-		if i < len(bParts) {
-			fmt.Sscanf(bParts[i], "%d", &bi)
-		}
-		if ai > bi {
-			return true
-		}
-		if ai < bi {
-			return false
-		}
-	}
-	return false // equal
+	return semver.Compare("v"+strings.TrimPrefix(a, "v"), "v"+strings.TrimPrefix(b, "v")) > 0
 }
 
 // semverLess returns true if version a is less than version b.
@@ -1420,6 +1412,43 @@ func semverLess(a, b string) bool {
 
 func (s *Server) SetRuntimeManifest(m *RuntimeManifest) {
 	s.knownRuntimeManifest = m
+}
+
+// MergeRuntimeManifest adds operator-supplied accepted hashes without removing
+// release-derived stable or beta hashes. Environment overrides are an additive
+// emergency control, not a way to silently deroute another active cohort.
+func (s *Server) MergeRuntimeManifest(m *RuntimeManifest) {
+	if m == nil {
+		return
+	}
+	if s.knownRuntimeManifest == nil {
+		s.knownRuntimeManifest = &RuntimeManifest{}
+	}
+	dst := s.knownRuntimeManifest
+	if dst.PythonHashes == nil {
+		dst.PythonHashes = make(map[string]bool)
+	}
+	if dst.RuntimeHashes == nil {
+		dst.RuntimeHashes = make(map[string]bool)
+	}
+	if dst.TemplateHashes == nil {
+		dst.TemplateHashes = make(map[string]string)
+	}
+	if dst.MetallibHashes == nil {
+		dst.MetallibHashes = make(map[string]bool)
+	}
+	for hash := range m.PythonHashes {
+		dst.PythonHashes[hash] = true
+	}
+	for hash := range m.RuntimeHashes {
+		dst.RuntimeHashes[hash] = true
+	}
+	for name, hash := range m.TemplateHashes {
+		dst.TemplateHashes[name] = hash
+	}
+	for hash := range m.MetallibHashes {
+		dst.MetallibHashes[hash] = true
+	}
 }
 
 func (s *Server) verifyRuntimeHashesForBackend(backend, pythonHash, runtimeHash string, templateHashes map[string]string) (bool, []protocol.RuntimeMismatch) {
@@ -1438,6 +1467,32 @@ func (s *Server) verifyRuntimeHashesForBackend(backend, pythonHash, runtimeHash 
 	}
 
 	manifest := s.knownRuntimeManifest
+	acceptedMetallibHashes := manifest.MetallibHashes
+	if len(acceptedMetallibHashes) == 0 {
+		acceptedMetallibHashes = map[string]bool{}
+		if expected := manifest.TemplateHashes["mlx_metallib"]; expected != "" {
+			acceptedMetallibHashes[expected] = true
+		}
+	}
+	if len(acceptedMetallibHashes) > 0 {
+		got := templateHashes["mlx_metallib"]
+		if got == "" {
+			return false, []protocol.RuntimeMismatch{{
+				Component: "template:mlx_metallib",
+				Expected:  "reported hash matching one of known-good values",
+				Got:       "(missing)",
+			}}
+		}
+		if !acceptedMetallibHashes[got] {
+			return false, []protocol.RuntimeMismatch{{
+				Component: "template:mlx_metallib",
+				Expected:  "one of known-good hashes",
+				Got:       got,
+			}}
+		}
+		return true, nil
+	}
+
 	scoped := &RuntimeManifest{
 		PythonHashes:   map[string]bool{},
 		RuntimeHashes:  map[string]bool{},
@@ -1536,6 +1591,7 @@ func (s *Server) handleRuntimeManifest(w http.ResponseWriter, r *http.Request) {
 			"python_hashes":   s.knownRuntimeManifest.PythonHashes,
 			"runtime_hashes":  s.knownRuntimeManifest.RuntimeHashes,
 			"template_hashes": s.knownRuntimeManifest.TemplateHashes,
+			"metallib_hashes": s.knownRuntimeManifest.MetallibHashes,
 		}
 	}
 	body, err := json.Marshal(resp)

--- a/coordinator/cmd/coordinator/main.go
+++ b/coordinator/cmd/coordinator/main.go
@@ -576,16 +576,23 @@ func main() {
 			PythonHashes:   make(map[string]bool),
 			RuntimeHashes:  make(map[string]bool),
 			TemplateHashes: make(map[string]string),
+			MetallibHashes: make(map[string]bool),
 		}
 		for _, pair := range strings.Split(templateHashes, ",") {
 			parts := strings.SplitN(strings.TrimSpace(pair), "=", 2)
 			if len(parts) == 2 {
-				manifest.TemplateHashes[strings.TrimSpace(parts[0])] = strings.TrimSpace(parts[1])
+				name := strings.TrimSpace(parts[0])
+				hash := strings.TrimSpace(parts[1])
+				manifest.TemplateHashes[name] = hash
+				if name == "mlx_metallib" {
+					manifest.MetallibHashes[hash] = true
+				}
 			}
 		}
-		srv.SetRuntimeManifest(manifest)
+		srv.MergeRuntimeManifest(manifest)
 		logger.Info("runtime manifest configured from env",
 			"template_hashes", len(manifest.TemplateHashes),
+			"metallib_hashes", len(manifest.MetallibHashes),
 		)
 	}
 

--- a/coordinator/protocol/messages.go
+++ b/coordinator/protocol/messages.go
@@ -152,6 +152,7 @@ type RegisterMessage struct {
 	DecodeTPS               float64         `json:"decode_tps,omitempty"`                // benchmark: decode tokens per second
 	AuthToken               string          `json:"auth_token,omitempty"`                // device-linked provider token (from darkbloom login)
 	PrivateOnly             bool            `json:"private_only,omitempty"`              // when true, this machine serves only its owner's self-route requests, never the public fleet
+	ReleaseChannel          string          `json:"release_channel,omitempty"`           // "beta" for opt-in prerelease updates; omitted means stable
 
 	// APNs code-identity attestation (v0.6.0): the device token the coordinator
 	// pushes the E_K(nonce) code-identity challenge to, and which APNs environment

--- a/coordinator/protocol/messages_register_heartbeat_test.go
+++ b/coordinator/protocol/messages_register_heartbeat_test.go
@@ -109,6 +109,25 @@ func TestRegisterMessagePrivateOnlySymmetry(t *testing.T) {
 	}
 }
 
+func TestRegisterMessageReleaseChannelSymmetry(t *testing.T) {
+	swiftJSON := `{"type":"register","hardware":{},"models":[],"backend":"mlx-swift","release_channel":"beta"}`
+	var decoded RegisterMessage
+	if err := json.Unmarshal([]byte(swiftJSON), &decoded); err != nil {
+		t.Fatalf("unmarshal swift payload: %v", err)
+	}
+	if decoded.ReleaseChannel != "beta" {
+		t.Fatalf("release_channel = %q, want beta", decoded.ReleaseChannel)
+	}
+
+	data, err := json.Marshal(RegisterMessage{Type: TypeRegister})
+	if err != nil {
+		t.Fatalf("marshal stable payload: %v", err)
+	}
+	if strings.Contains(string(data), "release_channel") {
+		t.Fatalf("empty stable release channel should be omitted, got %s", data)
+	}
+}
+
 func TestRegisterMessageAPNsFieldsSymmetry(t *testing.T) {
 	// A register payload exactly as the Swift ProviderMessage encoder emits it
 	// with the v0.6.0 APNs code-identity fields present.

--- a/coordinator/registry/persistence.go
+++ b/coordinator/registry/persistence.go
@@ -284,6 +284,7 @@ func (r *Registry) persistProviderNow(p *Provider) {
 			MDAVerified:                p.MDAVerified,
 			MDACertChain:               mdaCertJSON,
 			Version:                    p.Version,
+			ReleaseChannel:             p.ReleaseChannel,
 			RuntimeVerified:            p.RuntimeVerified,
 			PythonHash:                 p.PythonHash,
 			RuntimeHash:                p.RuntimeHash,

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -465,6 +465,10 @@ type Provider struct {
 	// PrivateOnly excludes this machine from the public fleet entirely: it
 	// serves only its owner's self-route requests. Reported at registration.
 	PrivateOnly bool
+	// ReleaseChannel is the provider's persisted updater cohort. It is
+	// observational only and never gates routing: beta providers serve the same
+	// traffic as stable providers.
+	ReleaseChannel string
 
 	// APNs code-identity attestation (v0.6.0). The device token the coordinator
 	// pushes the E_K(nonce) code-identity challenge to, bound 1:1 to PublicKey (K).
@@ -2532,6 +2536,10 @@ func (r *Registry) Register(id string, conn *websocket.Conn, msg *protocol.Regis
 			pubKey = "" // clear so provider can register but won't receive encrypted requests
 		}
 	}
+	releaseChannel := store.ReleaseChannelStable
+	if msg.ReleaseChannel == store.ReleaseChannelBeta {
+		releaseChannel = store.ReleaseChannelBeta
+	}
 
 	p := &Provider{
 		ID:                      id,
@@ -2541,6 +2549,7 @@ func (r *Registry) Register(id string, conn *websocket.Conn, msg *protocol.Regis
 		PublicKey:               pubKey,
 		EncryptedResponseChunks: msg.EncryptedResponseChunks,
 		PrivateOnly:             msg.PrivateOnly,
+		ReleaseChannel:          releaseChannel,
 		APNsDeviceToken:         msg.APNsDeviceToken,
 		APNsEnvironment:         msg.APNsEnvironment,
 		PrefillTPS:              msg.PrefillTPS,

--- a/coordinator/registry/registry_lifecycle_test.go
+++ b/coordinator/registry/registry_lifecycle_test.go
@@ -32,6 +32,36 @@ func TestDisconnectUnknown(t *testing.T) {
 	reg.Disconnect("nonexistent")
 }
 
+func TestBetaProviderRemainsPubliclyRoutable(t *testing.T) {
+	registrationRegistry := New(testLogger())
+	msg := testRegisterMessage()
+	msg.ReleaseChannel = "beta"
+	registered := registrationRegistry.Register("registered-beta", nil, msg)
+	if registered.ReleaseChannel != "beta" {
+		t.Fatalf("registered release channel = %q, want beta", registered.ReleaseChannel)
+	}
+
+	reg := New(testLogger())
+	model := "beta-routing-model"
+	p := makeSchedulerProvider(t, reg, "beta-provider", model, 80)
+	p.mu.Lock()
+	p.ReleaseChannel = "beta"
+	p.mu.Unlock()
+
+	if p.ReleaseChannel != "beta" {
+		t.Fatalf("release channel = %q, want beta", p.ReleaseChannel)
+	}
+	if p.PrivateOnly {
+		t.Fatal("beta cohort must not make a provider private-only")
+	}
+	selected, decision := reg.ReserveProviderEx(model, &PendingRequest{
+		RequestID: "beta-request", Model: model, RequestedMaxTokens: 64,
+	})
+	if selected == nil || selected.ID != p.ID {
+		t.Fatalf("beta provider was not selected: selected=%v decision=%+v", selected, decision)
+	}
+}
+
 func TestSetProviderIdle(t *testing.T) {
 	reg := New(testLogger())
 	msg := testRegisterMessage()

--- a/coordinator/store/harness_test.go
+++ b/coordinator/store/harness_test.go
@@ -52,6 +52,7 @@ func testPostgresStore(t *testing.T) *PostgresStore {
 		"provider_trust_reuse",
 		"provider_floor_draws",
 		"code_attestations",
+		"releases",
 	} {
 		if _, err := s.pool.Exec(ctx, "TRUNCATE "+table+" CASCADE"); err != nil {
 			t.Fatalf("truncate %s: %v", table, err)

--- a/coordinator/store/interface.go
+++ b/coordinator/store/interface.go
@@ -719,6 +719,7 @@ type PublishingAPIKey struct {
 type Release struct {
 	Version        string    `json:"version"`                   // semver, e.g. "0.5.0"
 	Platform       string    `json:"platform"`                  // "macos-arm64"
+	Channel        string    `json:"channel"`                   // "stable" or "beta"
 	Backend        string    `json:"backend,omitempty"`         // "mlx-swift" (post-cutover) or "vllm-mlx" (legacy)
 	BinaryHash     string    `json:"binary_hash"`               // SHA-256 of darkbloom binary (attestation verification)
 	BundleHash     string    `json:"bundle_hash"`               // SHA-256 of the bundle tarball (install.sh download verification)
@@ -857,6 +858,7 @@ type ProviderRecord struct {
 	MDAVerified                bool            `json:"mda_verified"`
 	MDACertChain               json.RawMessage `json:"mda_cert_chain,omitempty"`
 	Version                    string          `json:"version,omitempty"`
+	ReleaseChannel             string          `json:"release_channel,omitempty"`
 	RuntimeVerified            bool            `json:"runtime_verified"`
 	PythonHash                 string          `json:"python_hash,omitempty"`
 	RuntimeHash                string          `json:"runtime_hash,omitempty"`

--- a/coordinator/store/interface_domains.go
+++ b/coordinator/store/interface_domains.go
@@ -396,8 +396,10 @@ type ReleaseStore interface {
 	// ListReleases returns all releases, ordered by created_at descending.
 	ListReleases() []Release
 
-	// GetLatestRelease returns the latest active release for a platform.
-	GetLatestRelease(platform string) *Release
+	// GetLatestRelease returns the latest active release visible to a channel.
+	// The beta channel includes stable releases so beta providers naturally
+	// converge onto a final stable build when it supersedes a prerelease.
+	GetLatestRelease(platform, channel string) *Release
 
 	// DeleteRelease deactivates a release by version and platform.
 	DeleteRelease(version, platform string) error

--- a/coordinator/store/memory.go
+++ b/coordinator/store/memory.go
@@ -2827,12 +2827,27 @@ func (s *MemoryStore) SetRelease(release *Release) error {
 	if release.Version == "" || release.Platform == "" {
 		return errors.New("version and platform are required")
 	}
+	if !validReleaseVersion(release.Version) {
+		return fmt.Errorf("invalid release version %q", release.Version)
+	}
 	r := *release
+	channel, ok := normalizeReleaseChannel(r.Channel)
+	if !ok {
+		return fmt.Errorf("invalid release channel %q", r.Channel)
+	}
+	r.Channel = channel
+	key := releaseKey(r.Version, r.Platform)
+	if existing, exists := s.releases[key]; exists {
+		existingChannel, _ := normalizeReleaseChannel(existing.Channel)
+		if existingChannel != r.Channel {
+			return fmt.Errorf("release %s/%s is already registered on channel %s", r.Version, r.Platform, existingChannel)
+		}
+	}
 	if r.CreatedAt.IsZero() {
 		r.CreatedAt = time.Now()
 	}
 	r.Active = true
-	s.releases[releaseKey(r.Version, r.Platform)] = &r
+	s.releases[key] = &r
 	return nil
 }
 
@@ -2849,12 +2864,15 @@ func (s *MemoryStore) ListReleases() []Release {
 	return releases
 }
 
-func (s *MemoryStore) GetLatestRelease(platform string) *Release {
+func (s *MemoryStore) GetLatestRelease(platform, channel string) *Release {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
+	if _, ok := normalizeReleaseChannel(channel); !ok {
+		return nil
+	}
 	var latest *Release
 	for _, r := range s.releases {
-		if r.Platform != platform || !r.Active {
+		if r.Platform != platform || !r.Active || !releaseVisibleToChannel(r.Channel, channel) {
 			continue
 		}
 		if latest == nil ||
@@ -2887,6 +2905,11 @@ func (s *MemoryStore) DeleteRelease(version, platform string) error {
 func (s *MemoryStore) UpsertProvider(_ context.Context, p ProviderRecord) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if channel, ok := normalizeReleaseChannel(p.ReleaseChannel); ok {
+		p.ReleaseChannel = channel
+	} else {
+		p.ReleaseChannel = ReleaseChannelStable
+	}
 
 	// Update serial index
 	if p.SerialNumber != "" {

--- a/coordinator/store/postgres.go
+++ b/coordinator/store/postgres.go
@@ -126,6 +126,7 @@ func (s *PostgresStore) migrate(ctx context.Context) error {
 			mda_verified BOOLEAN NOT NULL DEFAULT FALSE,
 			mda_cert_chain JSONB,
 			version TEXT NOT NULL DEFAULT '',
+			release_channel TEXT NOT NULL DEFAULT 'stable',
 			runtime_verified BOOLEAN NOT NULL DEFAULT FALSE,
 			python_hash TEXT NOT NULL DEFAULT '',
 			runtime_hash TEXT NOT NULL DEFAULT '',
@@ -150,6 +151,12 @@ func (s *PostgresStore) migrate(ctx context.Context) error {
 		`DO $$ BEGIN ALTER TABLE providers ADD COLUMN IF NOT EXISTS mda_verified BOOLEAN NOT NULL DEFAULT FALSE; EXCEPTION WHEN others THEN NULL; END $$`,
 		`DO $$ BEGIN ALTER TABLE providers ADD COLUMN IF NOT EXISTS mda_cert_chain JSONB; EXCEPTION WHEN others THEN NULL; END $$`,
 		`DO $$ BEGIN ALTER TABLE providers ADD COLUMN IF NOT EXISTS version TEXT NOT NULL DEFAULT ''; EXCEPTION WHEN others THEN NULL; END $$`,
+		`DO $$ BEGIN ALTER TABLE providers ADD COLUMN IF NOT EXISTS release_channel TEXT NOT NULL DEFAULT 'stable'; EXCEPTION WHEN others THEN NULL; END $$`,
+		`DO $$ BEGIN
+			IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'providers_release_channel_check') THEN
+				ALTER TABLE providers ADD CONSTRAINT providers_release_channel_check CHECK (release_channel IN ('stable', 'beta'));
+			END IF;
+		END $$`,
 		`DO $$ BEGIN ALTER TABLE providers ADD COLUMN IF NOT EXISTS runtime_verified BOOLEAN NOT NULL DEFAULT FALSE; EXCEPTION WHEN others THEN NULL; END $$`,
 		`DO $$ BEGIN ALTER TABLE providers ADD COLUMN IF NOT EXISTS python_hash TEXT NOT NULL DEFAULT ''; EXCEPTION WHEN others THEN NULL; END $$`,
 		`DO $$ BEGIN ALTER TABLE providers ADD COLUMN IF NOT EXISTS runtime_hash TEXT NOT NULL DEFAULT ''; EXCEPTION WHEN others THEN NULL; END $$`,
@@ -484,6 +491,7 @@ func (s *PostgresStore) migrate(ctx context.Context) error {
 		`CREATE TABLE IF NOT EXISTS releases (
 			version TEXT NOT NULL,
 			platform TEXT NOT NULL,
+			channel TEXT NOT NULL DEFAULT 'stable',
 			backend TEXT NOT NULL DEFAULT '',
 			binary_hash TEXT NOT NULL DEFAULT '',
 			bundle_hash TEXT NOT NULL DEFAULT '',
@@ -498,6 +506,15 @@ func (s *PostgresStore) migrate(ctx context.Context) error {
 			created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
 			PRIMARY KEY (version, platform)
 		)`,
+		`DO $$ BEGIN
+			ALTER TABLE releases ADD COLUMN IF NOT EXISTS channel TEXT NOT NULL DEFAULT 'stable';
+		EXCEPTION WHEN others THEN NULL;
+		END $$`,
+		`DO $$ BEGIN
+			IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'releases_channel_check') THEN
+				ALTER TABLE releases ADD CONSTRAINT releases_channel_check CHECK (channel IN ('stable', 'beta'));
+			END IF;
+		END $$`,
 		`DO $$ BEGIN
 			ALTER TABLE releases ADD COLUMN IF NOT EXISTS backend TEXT NOT NULL DEFAULT '';
 		EXCEPTION WHEN others THEN NULL;
@@ -3680,18 +3697,30 @@ func (s *PostgresStore) ListStripeWithdrawalsForStripeAccount(stripeAccountID, s
 func (s *PostgresStore) SetRelease(release *Release) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
+	if !validReleaseVersion(release.Version) || release.Platform == "" {
+		return fmt.Errorf("version and platform must be valid")
+	}
+	channel, ok := normalizeReleaseChannel(release.Channel)
+	if !ok {
+		return fmt.Errorf("invalid release channel %q", release.Channel)
+	}
+	release.Channel = channel
 
-	_, err := s.pool.Exec(ctx,
-		`INSERT INTO releases (version, platform, backend, binary_hash, bundle_hash, metallib_hash, python_hash, runtime_hash, template_hashes, url, changelog, active, created_at)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, TRUE, NOW())
+	tag, err := s.pool.Exec(ctx,
+		`INSERT INTO releases (version, platform, backend, binary_hash, bundle_hash, metallib_hash, python_hash, runtime_hash, template_hashes, url, changelog, channel, active, created_at)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, TRUE, NOW())
 		 ON CONFLICT (version, platform) DO UPDATE SET
-		   backend = $3, binary_hash = $4, bundle_hash = $5, metallib_hash = $6, python_hash = $7, runtime_hash = $8, template_hashes = $9, url = $10, changelog = $11, active = TRUE`,
+		   backend = $3, binary_hash = $4, bundle_hash = $5, metallib_hash = $6, python_hash = $7, runtime_hash = $8, template_hashes = $9, url = $10, changelog = $11, active = TRUE
+		 WHERE releases.channel = EXCLUDED.channel`,
 		release.Version, release.Platform, release.Backend, release.BinaryHash, release.BundleHash,
 		release.MetallibHash, release.PythonHash, release.RuntimeHash, release.TemplateHashes,
-		release.URL, release.Changelog,
+		release.URL, release.Changelog, release.Channel,
 	)
 	if err != nil {
 		return fmt.Errorf("store: set release: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("release %s/%s is already registered on a different channel", release.Version, release.Platform)
 	}
 	return nil
 }
@@ -3701,7 +3730,7 @@ func (s *PostgresStore) ListReleases() []Release {
 	defer cancel()
 
 	rows, err := s.pool.Query(ctx,
-		`SELECT version, platform, COALESCE(backend, ''), binary_hash, bundle_hash, COALESCE(metallib_hash, ''),
+		`SELECT version, platform, COALESCE(channel, 'stable'), COALESCE(backend, ''), binary_hash, bundle_hash, COALESCE(metallib_hash, ''),
 		        COALESCE(python_hash, ''), COALESCE(runtime_hash, ''), COALESCE(template_hashes, ''),
 		        url, changelog, active, created_at
 		 FROM releases ORDER BY created_at DESC`,
@@ -3714,7 +3743,7 @@ func (s *PostgresStore) ListReleases() []Release {
 	var releases []Release
 	for rows.Next() {
 		var r Release
-		if err := rows.Scan(&r.Version, &r.Platform, &r.Backend, &r.BinaryHash, &r.BundleHash, &r.MetallibHash,
+		if err := rows.Scan(&r.Version, &r.Platform, &r.Channel, &r.Backend, &r.BinaryHash, &r.BundleHash, &r.MetallibHash,
 			&r.PythonHash, &r.RuntimeHash, &r.TemplateHashes,
 			&r.URL, &r.Changelog, &r.Active, &r.CreatedAt); err != nil {
 			continue
@@ -3724,12 +3753,15 @@ func (s *PostgresStore) ListReleases() []Release {
 	return releases
 }
 
-func (s *PostgresStore) GetLatestRelease(platform string) *Release {
+func (s *PostgresStore) GetLatestRelease(platform, channel string) *Release {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
+	if _, ok := normalizeReleaseChannel(channel); !ok {
+		return nil
+	}
 
 	rows, err := s.pool.Query(ctx,
-		`SELECT version, platform, COALESCE(backend, ''), binary_hash, bundle_hash, COALESCE(metallib_hash, ''),
+		`SELECT version, platform, COALESCE(channel, 'stable'), COALESCE(backend, ''), binary_hash, bundle_hash, COALESCE(metallib_hash, ''),
 		        COALESCE(python_hash, ''), COALESCE(runtime_hash, ''), COALESCE(template_hashes, ''),
 		        url, changelog, active, created_at
 		 FROM releases WHERE platform = $1 AND active = TRUE`, platform,
@@ -3742,10 +3774,13 @@ func (s *PostgresStore) GetLatestRelease(platform string) *Release {
 	var latest *Release
 	for rows.Next() {
 		var r Release
-		if err := rows.Scan(&r.Version, &r.Platform, &r.Backend, &r.BinaryHash, &r.BundleHash, &r.MetallibHash,
+		if err := rows.Scan(&r.Version, &r.Platform, &r.Channel, &r.Backend, &r.BinaryHash, &r.BundleHash, &r.MetallibHash,
 			&r.PythonHash, &r.RuntimeHash, &r.TemplateHashes,
 			&r.URL, &r.Changelog, &r.Active, &r.CreatedAt); err != nil {
 			return nil
+		}
+		if !releaseVisibleToChannel(r.Channel, channel) {
+			continue
 		}
 		if latest == nil ||
 			releaseVersionGreater(r.Version, latest.Version) ||
@@ -4393,6 +4428,11 @@ func providerStatsJSON(raw json.RawMessage) json.RawMessage {
 func (s *PostgresStore) UpsertProvider(ctx context.Context, p ProviderRecord) error {
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
+	if channel, ok := normalizeReleaseChannel(p.ReleaseChannel); ok {
+		p.ReleaseChannel = channel
+	} else {
+		p.ReleaseChannel = ReleaseChannelStable
+	}
 
 	_, err := s.pool.Exec(ctx,
 		`INSERT INTO providers (
@@ -4404,7 +4444,7 @@ func (s *PostgresStore) UpsertProvider(ctx context.Context, p ProviderRecord) er
 			lifetime_requests_served, lifetime_tokens_generated,
 			last_session_requests_served, last_session_tokens_generated,
 			lifetime_stats, last_session_stats,
-			registered_at, last_seen, public_key
+			registered_at, last_seen, public_key, release_channel
 		) VALUES (
 			$1, $2, $3, $4, $5, $6, $7,
 			$8, $9, $10,
@@ -4413,7 +4453,7 @@ func (s *PostgresStore) UpsertProvider(ctx context.Context, p ProviderRecord) er
 			$17, $18, $19,
 			$20, $21, $22, $23,
 			$24, $25,
-			$26, $27, $28
+			$26, $27, $28, $29
 		)
 		ON CONFLICT (id) DO UPDATE SET
 			hardware = $2, models = $3, backend = $4, location = $5,
@@ -4425,7 +4465,7 @@ func (s *PostgresStore) UpsertProvider(ctx context.Context, p ProviderRecord) er
 			lifetime_requests_served = $20, lifetime_tokens_generated = $21,
 			last_session_requests_served = $22, last_session_tokens_generated = $23,
 			lifetime_stats = $24, last_session_stats = $25,
-			last_seen = $27, public_key = $28`,
+			last_seen = $27, public_key = $28, release_channel = $29`,
 		p.ID, p.Hardware, p.Models, p.Backend,
 		marshalProviderLocation(p.Location),
 		p.TrustLevel, p.Attested,
@@ -4436,7 +4476,7 @@ func (s *PostgresStore) UpsertProvider(ctx context.Context, p ProviderRecord) er
 		p.LifetimeRequestsServed, p.LifetimeTokensGenerated,
 		p.LastSessionRequestsServed, p.LastSessionTokensGenerated,
 		providerStatsJSON(p.LifetimeStats), providerStatsJSON(p.LastSessionStats),
-		p.RegisteredAt, p.LastSeen, p.PublicKey,
+		p.RegisteredAt, p.LastSeen, p.PublicKey, p.ReleaseChannel,
 	)
 	if err != nil {
 		return fmt.Errorf("store: upsert provider: %w", err)
@@ -4459,7 +4499,7 @@ func (s *PostgresStore) GetProviderRecord(ctx context.Context, id string) (*Prov
 			lifetime_requests_served, lifetime_tokens_generated,
 			last_session_requests_served, last_session_tokens_generated,
 			lifetime_stats, last_session_stats,
-			registered_at, last_seen, public_key
+			registered_at, last_seen, public_key, release_channel
 		 FROM providers WHERE id = $1`, id,
 	).Scan(
 		&p.ID, &p.Hardware, &p.Models, &p.Backend,
@@ -4472,7 +4512,7 @@ func (s *PostgresStore) GetProviderRecord(ctx context.Context, id string) (*Prov
 		&p.LifetimeRequestsServed, &p.LifetimeTokensGenerated,
 		&p.LastSessionRequestsServed, &p.LastSessionTokensGenerated,
 		&p.LifetimeStats, &p.LastSessionStats,
-		&p.RegisteredAt, &p.LastSeen, &p.PublicKey,
+		&p.RegisteredAt, &p.LastSeen, &p.PublicKey, &p.ReleaseChannel,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("store: provider not found: %w", err)
@@ -4496,7 +4536,7 @@ func (s *PostgresStore) GetProviderBySerial(ctx context.Context, serial string) 
 			lifetime_requests_served, lifetime_tokens_generated,
 			last_session_requests_served, last_session_tokens_generated,
 			lifetime_stats, last_session_stats,
-			registered_at, last_seen, public_key
+			registered_at, last_seen, public_key, release_channel
 		 FROM providers WHERE serial_number = $1 AND serial_number != ''
 		 ORDER BY last_seen DESC LIMIT 1`, serial,
 	).Scan(
@@ -4510,7 +4550,7 @@ func (s *PostgresStore) GetProviderBySerial(ctx context.Context, serial string) 
 		&p.LifetimeRequestsServed, &p.LifetimeTokensGenerated,
 		&p.LastSessionRequestsServed, &p.LastSessionTokensGenerated,
 		&p.LifetimeStats, &p.LastSessionStats,
-		&p.RegisteredAt, &p.LastSeen, &p.PublicKey,
+		&p.RegisteredAt, &p.LastSeen, &p.PublicKey, &p.ReleaseChannel,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("store: provider with serial not found: %w", err)
@@ -4556,7 +4596,7 @@ func (s *PostgresStore) ListProviderRecords(ctx context.Context) ([]ProviderReco
 			lifetime_requests_served, lifetime_tokens_generated,
 			last_session_requests_served, last_session_tokens_generated,
 			lifetime_stats, last_session_stats,
-			registered_at, last_seen, public_key
+			registered_at, last_seen, public_key, release_channel
 		 FROM providers ORDER BY last_seen DESC`,
 	)
 	if err != nil {
@@ -4579,7 +4619,7 @@ func (s *PostgresStore) ListProviderRecords(ctx context.Context) ([]ProviderReco
 			&p.LifetimeRequestsServed, &p.LifetimeTokensGenerated,
 			&p.LastSessionRequestsServed, &p.LastSessionTokensGenerated,
 			&p.LifetimeStats, &p.LastSessionStats,
-			&p.RegisteredAt, &p.LastSeen, &p.PublicKey,
+			&p.RegisteredAt, &p.LastSeen, &p.PublicKey, &p.ReleaseChannel,
 		); err != nil {
 			continue
 		}
@@ -4618,7 +4658,7 @@ func (s *PostgresStore) ListProvidersByAccount(ctx context.Context, accountID st
 			lifetime_requests_served, lifetime_tokens_generated,
 			last_session_requests_served, last_session_tokens_generated,
 			lifetime_stats, last_session_stats,
-			registered_at, last_seen, public_key
+			registered_at, last_seen, public_key, release_channel
 		 FROM providers
 		 WHERE account_id = $1
 		 ORDER BY COALESCE(NULLIF(serial_number, ''),
@@ -4647,7 +4687,7 @@ func (s *PostgresStore) ListProvidersByAccount(ctx context.Context, accountID st
 			&p.LifetimeRequestsServed, &p.LifetimeTokensGenerated,
 			&p.LastSessionRequestsServed, &p.LastSessionTokensGenerated,
 			&p.LifetimeStats, &p.LastSessionStats,
-			&p.RegisteredAt, &p.LastSeen, &p.PublicKey,
+			&p.RegisteredAt, &p.LastSeen, &p.PublicKey, &p.ReleaseChannel,
 		); err != nil {
 			continue
 		}

--- a/coordinator/store/postgres_test.go
+++ b/coordinator/store/postgres_test.go
@@ -57,6 +57,7 @@ func TestPostgresProviderRecordStatsPersisted(t *testing.T) {
 		Attested:                   true,
 		SEPublicKey:                "se-key",
 		SerialNumber:               "serial-1",
+		ReleaseChannel:             ReleaseChannelBeta,
 		LifetimeRequestsServed:     42,
 		LifetimeTokensGenerated:    1234,
 		LastSessionRequestsServed:  7,
@@ -85,6 +86,9 @@ func TestPostgresProviderRecordStatsPersisted(t *testing.T) {
 	}
 	if got.LastSessionTokensGenerated != rec.LastSessionTokensGenerated {
 		t.Errorf("last_session_tokens_generated = %d, want %d", got.LastSessionTokensGenerated, rec.LastSessionTokensGenerated)
+	}
+	if got.ReleaseChannel != ReleaseChannelBeta {
+		t.Errorf("release_channel = %q, want %q", got.ReleaseChannel, ReleaseChannelBeta)
 	}
 }
 

--- a/coordinator/store/provider_records_test.go
+++ b/coordinator/store/provider_records_test.go
@@ -7,6 +7,26 @@ import (
 	"time"
 )
 
+func TestMemoryProviderReleaseChannelPersistence(t *testing.T) {
+	st := NewMemory(Config{})
+	ctx := context.Background()
+	if err := st.UpsertProvider(ctx, ProviderRecord{ID: "beta", ReleaseChannel: ReleaseChannelBeta}); err != nil {
+		t.Fatalf("UpsertProvider(beta): %v", err)
+	}
+	if err := st.UpsertProvider(ctx, ProviderRecord{ID: "stable"}); err != nil {
+		t.Fatalf("UpsertProvider(stable): %v", err)
+	}
+	for id, want := range map[string]string{"beta": ReleaseChannelBeta, "stable": ReleaseChannelStable} {
+		got, err := st.GetProviderRecord(ctx, id)
+		if err != nil {
+			t.Fatalf("GetProviderRecord(%s): %v", id, err)
+		}
+		if got.ReleaseChannel != want {
+			t.Errorf("GetProviderRecord(%s).ReleaseChannel = %q, want %q", id, got.ReleaseChannel, want)
+		}
+	}
+}
+
 // TestMemoryGetMDAChainBySerial_NotShadowedByNewerEmptyRow is the durability fix
 // for the MDA-reuse race: a reconnect creates a new row (fresh provider id) that
 // can be persisted with an empty chain before the chain is reattached. A plain

--- a/coordinator/store/release_version.go
+++ b/coordinator/store/release_version.go
@@ -1,9 +1,39 @@
 package store
 
 import (
-	"fmt"
 	"strings"
+
+	"golang.org/x/mod/semver"
 )
+
+const (
+	ReleaseChannelStable = "stable"
+	ReleaseChannelBeta   = "beta"
+)
+
+func normalizeReleaseChannel(channel string) (string, bool) {
+	switch strings.ToLower(strings.TrimSpace(channel)) {
+	case "", ReleaseChannelStable:
+		return ReleaseChannelStable, true
+	case ReleaseChannelBeta:
+		return ReleaseChannelBeta, true
+	default:
+		return "", false
+	}
+}
+
+func releaseVisibleToChannel(releaseChannel, requestedChannel string) bool {
+	releaseChannel, releaseOK := normalizeReleaseChannel(releaseChannel)
+	requestedChannel, requestedOK := normalizeReleaseChannel(requestedChannel)
+	if !releaseOK || !requestedOK {
+		return false
+	}
+	return releaseChannel == ReleaseChannelStable || requestedChannel == ReleaseChannelBeta
+}
+
+func validReleaseVersion(version string) bool {
+	return semver.IsValid("v" + strings.TrimPrefix(strings.TrimSpace(version), "v"))
+}
 
 func releaseVersionGreater(a, b string) bool {
 	if a == "" {
@@ -12,22 +42,5 @@ func releaseVersionGreater(a, b string) bool {
 	if b == "" {
 		return true
 	}
-	aParts := strings.Split(a, ".")
-	bParts := strings.Split(b, ".")
-	for i := 0; i < len(aParts) || i < len(bParts); i++ {
-		var ai, bi int
-		if i < len(aParts) {
-			fmt.Sscanf(aParts[i], "%d", &ai)
-		}
-		if i < len(bParts) {
-			fmt.Sscanf(bParts[i], "%d", &bi)
-		}
-		if ai > bi {
-			return true
-		}
-		if ai < bi {
-			return false
-		}
-	}
-	return false
+	return semver.Compare("v"+strings.TrimPrefix(a, "v"), "v"+strings.TrimPrefix(b, "v")) > 0
 }

--- a/coordinator/store/releases_test.go
+++ b/coordinator/store/releases_test.go
@@ -13,7 +13,7 @@ func TestReleases(t *testing.T) {
 	if len(releases) != 0 {
 		t.Fatalf("expected 0 releases, got %d", len(releases))
 	}
-	if r := s.GetLatestRelease("macos-arm64"); r != nil {
+	if r := s.GetLatestRelease("macos-arm64", ReleaseChannelStable); r != nil {
 		t.Fatal("expected nil latest release")
 	}
 
@@ -49,7 +49,7 @@ func TestReleases(t *testing.T) {
 	}
 
 	// Latest should be r2.
-	latest := s.GetLatestRelease("macos-arm64")
+	latest := s.GetLatestRelease("macos-arm64", ReleaseChannelStable)
 	if latest == nil {
 		t.Fatal("expected non-nil latest release")
 	}
@@ -67,7 +67,7 @@ func TestReleases(t *testing.T) {
 	}
 
 	// Unknown platform returns nil.
-	if r := s.GetLatestRelease("linux-amd64"); r != nil {
+	if r := s.GetLatestRelease("linux-amd64", ReleaseChannelStable); r != nil {
 		t.Error("expected nil for unknown platform")
 	}
 
@@ -77,7 +77,7 @@ func TestReleases(t *testing.T) {
 	}
 
 	// Latest should now be r1.
-	latest = s.GetLatestRelease("macos-arm64")
+	latest = s.GetLatestRelease("macos-arm64", ReleaseChannelStable)
 	if latest == nil {
 		t.Fatal("expected non-nil latest after deactivation")
 	}
@@ -121,11 +121,58 @@ func TestGetLatestReleasePrefersHigherSemverOverNewerTimestamp(t *testing.T) {
 		t.Fatalf("SetRelease 0.3.8: %v", err)
 	}
 
-	latest := s.GetLatestRelease("macos-arm64")
+	latest := s.GetLatestRelease("macos-arm64", ReleaseChannelStable)
 	if latest == nil {
 		t.Fatal("expected non-nil latest release")
 	}
 	if latest.Version != "0.3.9" {
 		t.Fatalf("latest version = %q, want %q", latest.Version, "0.3.9")
+	}
+}
+
+func TestReleaseChannelsIsolateStableAndAdvanceBetaToFinal(t *testing.T) {
+	for name, s := range storeBackends(t) {
+		t.Run(name, func(t *testing.T) {
+			for _, release := range []*Release{
+				{Version: "0.7.8", Platform: "macos-arm64", Channel: ReleaseChannelStable},
+				{Version: "0.7.9-beta.1", Platform: "macos-arm64", Channel: ReleaseChannelBeta},
+			} {
+				if err := s.SetRelease(release); err != nil {
+					t.Fatalf("SetRelease(%s): %v", release.Version, err)
+				}
+			}
+
+			if got := s.GetLatestRelease("macos-arm64", ReleaseChannelStable); got == nil || got.Version != "0.7.8" {
+				t.Fatalf("stable latest = %#v, want 0.7.8", got)
+			}
+			if got := s.GetLatestRelease("macos-arm64", ReleaseChannelBeta); got == nil || got.Version != "0.7.9-beta.1" {
+				t.Fatalf("beta latest = %#v, want 0.7.9-beta.1", got)
+			}
+
+			if err := s.SetRelease(&Release{
+				Version: "0.7.9", Platform: "macos-arm64", Channel: ReleaseChannelStable,
+			}); err != nil {
+				t.Fatalf("SetRelease(final): %v", err)
+			}
+			if got := s.GetLatestRelease("macos-arm64", ReleaseChannelBeta); got == nil || got.Version != "0.7.9" {
+				t.Fatalf("beta latest after final = %#v, want 0.7.9", got)
+			}
+		})
+	}
+}
+
+func TestSetReleaseDefaultsChannelAndRejectsUnknown(t *testing.T) {
+	s := NewMemory(Config{})
+	if err := s.SetRelease(&Release{Version: "1.0.0", Platform: "macos-arm64"}); err != nil {
+		t.Fatalf("SetRelease(default): %v", err)
+	}
+	if got := s.GetLatestRelease("macos-arm64", ReleaseChannelStable); got == nil || got.Channel != ReleaseChannelStable {
+		t.Fatalf("default channel release = %#v, want stable", got)
+	}
+	if err := s.SetRelease(&Release{Version: "1.0.1", Platform: "macos-arm64", Channel: "canary"}); err == nil {
+		t.Fatal("SetRelease accepted unknown channel")
+	}
+	if err := s.SetRelease(&Release{Version: "1.0.0", Platform: "macos-arm64", Channel: ReleaseChannelBeta}); err == nil {
+		t.Fatal("SetRelease allowed an existing release to change channels")
 	}
 }

--- a/docs/operations/coordinator-deploy.md
+++ b/docs/operations/coordinator-deploy.md
@@ -164,7 +164,8 @@ Provider releases are built and shipped by `.github/workflows/release-swift.yml`
 3. Embeds the provisioning profile and signs with Developer ID Application.
 4. Notarizes with Apple.
 5. Computes SHA-256 hashes **after** signing/notarization.
-6. Uploads the tarball to R2 under `releases/v${VERSION}` and `releases/latest`.
+6. Uploads the tarball to R2 under `releases/v${VERSION}` and the matching
+   channel pointer (`releases/latest` for stable or `releases/beta/latest` for beta).
 7. Registers the release with `POST /v1/releases` using `RELEASE_KEY`.
 8. Creates a GitHub release.
 
@@ -177,6 +178,7 @@ Tag conventions:
 | Tag shape | Environment |
 |---|---|
 | `vX.Y.Z` | Prod (requires GitHub Environment approval if configured) |
+| `vX.Y.Z-beta.N` | Prod beta cohort; registered as `channel=beta`, does not replace stable latest |
 | `vX.Y.Z-dev.N` | Dev |
 | `vX.Y.Z-swift` or `vX.Y.Z-swift.N` | Accepted aliases during migration |
 
@@ -189,6 +191,22 @@ exists** — fixed by registering the release, not by bumping code.
 git tag -a v0.7.4 -m "Release v0.7.4"
 git push origin master --tags
 ```
+
+### First beta rollout
+
+1. Deploy the coordinator schema/API changes before publishing any beta release.
+2. Ship these CLI changes in a stable provider release so existing machines can
+   run `darkbloom beta enable` and restart.
+3. Confirm opted-in machines register with `release_channel=beta` and remain in
+   normal routing before publishing a beta artifact.
+4. Publish the first beta with a strictly newer SemVer core than the bootstrap
+   stable release. For example, after stable `0.7.9`, use `0.7.10-beta.1`, not
+   `0.7.9-beta.1` (which SemVer orders below `0.7.9`).
+5. Verify stable discovery still returns the stable release and beta discovery
+   returns the beta release with `scripts/admin.sh releases latest macos-arm64 stable`
+   and `scripts/admin.sh releases latest macos-arm64 beta`.
+6. Do not raise the global minimum provider version to a beta version. Wait for
+   the promoted stable release and fleet convergence.
 
 ### Required GitHub secrets
 

--- a/docs/provider/beta-features.md
+++ b/docs/provider/beta-features.md
@@ -1,6 +1,32 @@
-# Beta Features
+# Beta Releases And Features
 
-Beta features are experimental provider capabilities that are **off by default**.
+The beta release cohort is opt-in and receives signed prereleases through the
+same automatic update, rollback, and traffic-serving path as stable providers.
+Joining beta does not remove the provider from public traffic.
+
+```bash
+darkbloom beta enable
+darkbloom restart
+```
+
+This writes `provider.release_channel = "beta"` to
+`~/.config/darkbloom/provider.toml`. The provider reports the cohort when it
+registers, and manual, startup, background, and watchdog update checks request
+the beta channel. Joining also enables `provider.auto_update` so the machine
+stays on the beta track. Beta discovery includes stable releases, so a final `X.Y.Z`
+naturally supersedes `X.Y.Z-beta.N`.
+
+To stop receiving future beta releases:
+
+```bash
+darkbloom beta disable
+darkbloom restart
+```
+
+Leaving beta does not downgrade an already-installed prerelease. It remains in
+place until a newer stable version is published.
+
+Individual beta features are experimental provider capabilities that are **off by default**.
 They are validated enough to try in production but may change, carry caveats, or
 only apply to specific model families. Enable them per provider when you want to
 opt in.
@@ -23,6 +49,8 @@ The registry of available features lives in
 ```bash
 darkbloom beta list                 # show all beta features and whether each is on (default)
 darkbloom beta status [feature]     # show details for all features, or one
+darkbloom beta enable               # join the beta release cohort
+darkbloom beta disable              # return to stable release discovery
 darkbloom beta enable <feature>     # turn a feature on
 darkbloom beta disable <feature>    # turn a feature off
 ```
@@ -36,8 +64,8 @@ darkbloom beta enable kv-quant
 darkbloom restart
 ```
 
-You can also see which beta features are active in `darkbloom status` (the
-`Beta features:` line), or edit the TOML directly.
+You can also see the release channel and active beta features in `darkbloom
+status`, or edit the TOML directly.
 
 ## Available features
 

--- a/docs/provider/cli-reference.md
+++ b/docs/provider/cli-reference.md
@@ -208,13 +208,15 @@ This toggles `provider.auto_update` in `provider.toml`.
 
 ## `darkbloom beta`
 
-Manage opt-in beta features. Beta features are off by default and config-backed
-(a TOML field), so they apply to the launchd daemon too — unlike environment
-variables, which the daemon does not inherit.
+Join the opt-in beta release cohort or manage individual beta features. Cohort
+membership is config-backed and uses the normal signed automatic update,
+rollback, and traffic-serving path.
 
 ```bash
-darkbloom beta list                 # all features + on/off (default subcommand)
+darkbloom beta list                 # release cohort and feature states
 darkbloom beta status [feature]     # details for all features, or one
+darkbloom beta enable               # receive beta releases (then restart)
+darkbloom beta disable              # stop future beta releases (then restart)
 darkbloom beta enable <feature>     # turn on (then: darkbloom restart)
 darkbloom beta disable <feature>    # turn off
 ```
@@ -223,9 +225,10 @@ darkbloom beta disable <feature>    # turn off
 |---------|--------|
 | `kv-quant` | Forward-compatibility toggle; v0.7.5 warns and continues with fp16 KV |
 
-`enable`/`disable` read-modify-write the TOML config and report whether a restart
-is required. See [Beta Features](beta-features.md) for the full guide. `darkbloom
-beta list` also accepts `--json`.
+Without a feature argument, `enable`/`disable` write
+`provider.release_channel`. With a feature argument, they retain the existing
+per-feature behavior. See [Beta Releases And Features](beta-features.md) for the
+full guide. `darkbloom beta list` also accepts `--json`.
 
 ## `darkbloom login`
 

--- a/docs/provider/installation.md
+++ b/docs/provider/installation.md
@@ -78,6 +78,7 @@ name = "darkbloom-mac16-1"
 memory_reserve_gb = 4
 auto_update = true
 auto_restart = true
+release_channel = "stable"
 
 [backend]
 enabled_models = []
@@ -118,6 +119,13 @@ darkbloom autoupdate disable
 
 Auto-update is controlled by `provider.auto_update` in `provider.toml`
 (`provider-swift/Sources/darkbloom/AutoUpdateCommand.swift`).
+
+To opt into signed beta releases through the same update and rollback path:
+
+```bash
+darkbloom beta enable
+darkbloom restart
+```
 
 ## Uninstalling
 

--- a/docs/provider/quickstart.md
+++ b/docs/provider/quickstart.md
@@ -110,6 +110,7 @@ name = "darkbloom-mac16-1"
 memory_reserve_gb = 4
 auto_update = true
 auto_restart = true
+release_channel = "stable"
 
 [backend]
 model = ""
@@ -131,6 +132,9 @@ end = "08:00"
 ```
 
 - `backend.enabled_models` — if non-empty, only these models are advertised.
+- `provider.release_channel` — `"stable"` by default; use `darkbloom beta
+  enable` and restart to opt into signed beta releases while continuing to
+  serve normal traffic.
 - `backend.idle_timeout_mins` — minutes of inactivity before an idle model is
   unloaded (default 60; 0 disables eviction).
 - `backend.max_model_slots` — maximum resident models at once (default 3).

--- a/docs/reference/protocol-messages.md
+++ b/docs/reference/protocol-messages.md
@@ -30,6 +30,7 @@ Sent on WebSocket connect. Go: [`RegisterMessage`](../../coordinator/protocol/me
 | `prefill_tps` / `decode_tps` | number | no | Benchmark throughput |
 | `auth_token` | string | no | Device-linked provider token from `darkbloom login` |
 | `private_only` | bool | no | `true` ⇒ only owner's self-route requests |
+| `release_channel` | string | no | `"beta"` for the opt-in beta updater cohort; omitted means stable and never changes traffic eligibility |
 | `apns_device_token` / `apns_environment` | string | no | APNs code-identity attestation (v0.6.0+) |
 | `python_hash` / `runtime_hash` | string | no | Runtime integrity hashes |
 | `template_hashes` | object | no | `name → SHA-256` |

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	go.etcd.io/bbolt v1.4.3
 	golang.org/x/crypto v0.51.0
+	golang.org/x/mod v0.35.0
 	golang.org/x/time v0.15.0
 	gopkg.in/DataDog/dd-trace-go.v1 v1.74.8
 	nhooyr.io/websocket v1.8.17
@@ -92,7 +93,6 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
 	golang.org/x/exp v0.0.0-20250606033433-dcc06ee1d476 // indirect
-	golang.org/x/mod v0.35.0 // indirect
 	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect

--- a/provider-swift/Sources/ProviderCore/Config/BetaFeatures.swift
+++ b/provider-swift/Sources/ProviderCore/Config/BetaFeatures.swift
@@ -57,6 +57,10 @@ public struct BetaFeature: Sendable, Identifiable {
 
 /// The registry of opt-in beta features.
 ///
+/// These are local experimental overrides, not release-cohort gates. A beta
+/// release must ship its intended behavior in the build itself; joining the
+/// beta release channel must never require enabling every entry here by hand.
+///
 /// Adding a beta toggle = adding one ``BetaFeature`` entry here (and its backing
 /// `ProviderConfig` field). The `darkbloom beta` command and `darkbloom status`
 /// are driven entirely off this list, so they need no per-feature code.

--- a/provider-swift/Sources/ProviderCore/Config/ProviderConfig.swift
+++ b/provider-swift/Sources/ProviderCore/Config/ProviderConfig.swift
@@ -19,6 +19,11 @@ import TOMLKit
 
 // MARK: - Config structs
 
+public enum ProviderReleaseChannel: String, Sendable, Equatable, Codable {
+    case stable
+    case beta
+}
+
 public struct ProviderSettings: Sendable, Equatable, Codable {
     public var name: String
     public var memoryReserveGB: UInt64
@@ -26,6 +31,9 @@ public struct ProviderSettings: Sendable, Equatable, Codable {
     /// When true (default), the watchdog relaunches the provider ~5 min after a
     /// crash. `false` opts out while keeping the provider installed.
     public var autoRestart: Bool
+    /// Signed release cohort used by every manual and automatic update check.
+    /// Beta remains fully routable; this only changes release discovery.
+    public var releaseChannel: ProviderReleaseChannel
     /// Maximum random delay (seconds) inserted between staging a verified
     /// background auto-update bundle and beginning the drain+restart. Staggers
     /// fleet restarts after a release so every provider is not cold at once (the
@@ -40,13 +48,15 @@ public struct ProviderSettings: Sendable, Equatable, Codable {
         memoryReserveGB: UInt64 = 4,
         autoUpdate: Bool = true,
         autoRestart: Bool = true,
-        updateJitterSeconds: UInt64 = 300
+        updateJitterSeconds: UInt64 = 300,
+        releaseChannel: ProviderReleaseChannel = .stable
     ) {
         self.name = name
         self.memoryReserveGB = memoryReserveGB
         self.autoUpdate = autoUpdate
         self.autoRestart = autoRestart
         self.updateJitterSeconds = updateJitterSeconds
+        self.releaseChannel = releaseChannel
     }
 
     enum CodingKeys: String, CodingKey {
@@ -55,6 +65,7 @@ public struct ProviderSettings: Sendable, Equatable, Codable {
         case autoUpdate = "auto_update"
         case autoRestart = "auto_restart"
         case updateJitterSeconds = "update_jitter_seconds"
+        case releaseChannel = "release_channel"
     }
 
     public init(from decoder: Decoder) throws {
@@ -64,6 +75,8 @@ public struct ProviderSettings: Sendable, Equatable, Codable {
         self.autoUpdate = try container.decodeIfPresent(Bool.self, forKey: .autoUpdate) ?? true
         self.autoRestart = try container.decodeIfPresent(Bool.self, forKey: .autoRestart) ?? true
         self.updateJitterSeconds = try container.decodeIfPresent(UInt64.self, forKey: .updateJitterSeconds) ?? 300
+        let rawReleaseChannel = try container.decodeIfPresent(String.self, forKey: .releaseChannel)
+        self.releaseChannel = rawReleaseChannel.flatMap(ProviderReleaseChannel.init(rawValue:)) ?? .stable
     }
 }
 

--- a/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClientCodec.swift
+++ b/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClientCodec.swift
@@ -52,6 +52,7 @@ public enum CoordinatorClientCodec {
             templateHashes: config.runtimeHashes?.templateHashes ?? [:],
             privacyCapabilities: privacyCapabilities,
             privateOnly: config.privateOnly,
+            releaseChannel: config.releaseChannel,
             apnsDeviceToken: effectiveToken,
             apnsEnvironment: effectiveEnv
         ))

--- a/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClientTypes.swift
+++ b/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClientTypes.swift
@@ -59,6 +59,7 @@ public struct CoordinatorClientConfig: Sendable {
     /// serves it exclusively to its owner's self-route requests, never the
     /// public fleet.
     public let privateOnly: Bool
+    public let releaseChannel: ProviderReleaseChannel
     /// APNs code-identity (v0.6.0): the device token to push the E_K(nonce)
     /// code-identity challenge to, and which APNs environment it belongs to.
     /// nil on headless/no-GUI boxes (no token) — those register un-attested.
@@ -79,6 +80,7 @@ public struct CoordinatorClientConfig: Sendable {
         modelHashes: [String: String] = [:],
         privacyCapabilities: PrivacyCapabilities? = nil,
         privateOnly: Bool = false,
+        releaseChannel: ProviderReleaseChannel = .stable,
         apnsDeviceToken: String? = nil,
         apnsEnvironment: String? = nil
     ) {
@@ -95,6 +97,7 @@ public struct CoordinatorClientConfig: Sendable {
         self.modelHashes = modelHashes
         self.privacyCapabilities = privacyCapabilities
         self.privateOnly = privateOnly
+        self.releaseChannel = releaseChannel
         self.apnsDeviceToken = apnsDeviceToken
         self.apnsEnvironment = apnsEnvironment
     }
@@ -206,4 +209,3 @@ public enum CoordinatorError: Error, CustomStringConvertible {
         }
     }
 }
-

--- a/provider-swift/Sources/ProviderCore/Protocol/Messages.swift
+++ b/provider-swift/Sources/ProviderCore/Protocol/Messages.swift
@@ -34,6 +34,9 @@ public enum ProviderMessage: Sendable, Equatable {
         /// When true, this machine serves only its owner's self-route requests,
         /// never the public fleet. Mirrors RegisterMessage.PrivateOnly (Go).
         public var privateOnly: Bool
+        /// Persisted automatic-update cohort. Stable is omitted on the wire for
+        /// compatibility; beta providers remain normal public traffic workers.
+        public var releaseChannel: ProviderReleaseChannel
         /// APNs code-identity attestation (v0.6.0). Device token the coordinator
         /// pushes the E_K(nonce) challenge to + which APNs environment it belongs
         /// to. Mirrors RegisterMessage.APNsDeviceToken/APNsEnvironment (Go).
@@ -57,6 +60,7 @@ public enum ProviderMessage: Sendable, Equatable {
             templateHashes: [String: String] = [:],
             privacyCapabilities: PrivacyCapabilities? = nil,
             privateOnly: Bool = false,
+            releaseChannel: ProviderReleaseChannel = .stable,
             apnsDeviceToken: String? = nil,
             apnsEnvironment: String? = nil
         ) {
@@ -76,6 +80,7 @@ public enum ProviderMessage: Sendable, Equatable {
             self.templateHashes = templateHashes
             self.privacyCapabilities = privacyCapabilities
             self.privateOnly = privateOnly
+            self.releaseChannel = releaseChannel
             self.apnsDeviceToken = apnsDeviceToken
             self.apnsEnvironment = apnsEnvironment
         }
@@ -336,6 +341,7 @@ extension ProviderMessage: Codable {
         case templateHashes = "template_hashes"
         case privacyCapabilities = "privacy_capabilities"
         case privateOnly = "private_only"
+        case releaseChannel = "release_channel"
         case apnsDeviceToken = "apns_device_token"
         case apnsEnvironment = "apns_environment"
         // Heartbeat
@@ -401,6 +407,9 @@ extension ProviderMessage: Codable {
             try container.encodeIfPresent(r.privacyCapabilities, forKey: .privacyCapabilities)
             if r.privateOnly {
                 try container.encode(true, forKey: .privateOnly)
+            }
+            if r.releaseChannel != .stable {
+                try container.encode(r.releaseChannel, forKey: .releaseChannel)
             }
             try container.encodeIfPresent(r.apnsDeviceToken, forKey: .apnsDeviceToken)
             try container.encodeIfPresent(r.apnsEnvironment, forKey: .apnsEnvironment)
@@ -519,6 +528,7 @@ extension ProviderMessage: Codable {
                 templateHashes: try container.decodeIfPresent([String: String].self, forKey: .templateHashes) ?? [:],
                 privacyCapabilities: try container.decodeIfPresent(PrivacyCapabilities.self, forKey: .privacyCapabilities),
                 privateOnly: try container.decodeIfPresent(Bool.self, forKey: .privateOnly) ?? false,
+                releaseChannel: try container.decodeIfPresent(ProviderReleaseChannel.self, forKey: .releaseChannel) ?? .stable,
                 apnsDeviceToken: try container.decodeIfPresent(String.self, forKey: .apnsDeviceToken),
                 apnsEnvironment: try container.decodeIfPresent(String.self, forKey: .apnsEnvironment)
             ))

--- a/provider-swift/Sources/ProviderCore/Protocol/ProtocolCodec.swift
+++ b/provider-swift/Sources/ProviderCore/Protocol/ProtocolCodec.swift
@@ -119,6 +119,9 @@ public enum ProviderProtocolCodec {
         if register.privateOnly {
             try fields.append(("private_only", encodeValue(true)))
         }
+        if register.releaseChannel != .stable {
+            try fields.append(("release_channel", encodeValue(register.releaseChannel)))
+        }
         try appendIfPresent(register.apnsDeviceToken, key: "apns_device_token", to: &fields)
         try appendIfPresent(register.apnsEnvironment, key: "apns_environment", to: &fields)
 

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+AutoUpdate.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+AutoUpdate.swift
@@ -78,7 +78,10 @@ extension ProviderLoop {
     /// the phase transitions, staged-bundle handoff, and drain bookkeeping
     /// stay race-free.
     private func performAutoUpdateCheck(coordinatorURL: String) async {
-        let updater = SelfUpdater(coordinatorBaseURL: coordinatorURL)
+        let updater = SelfUpdater(
+            coordinatorBaseURL: coordinatorURL,
+            releaseChannel: loopConfig.config.provider.releaseChannel
+        )
         let me = self
         let logger = self.logger
         let jitterMaxSeconds = loopConfig.config.provider.updateJitterSeconds

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+Serve.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+Serve.swift
@@ -158,6 +158,7 @@ extension ProviderLoop {
             modelHashes: loopConfig.modelHashes,
             privacyCapabilities: privacyCapabilitiesForRegistration(),
             privateOnly: loopConfig.config.coordinator.privateOnly,
+            releaseChannel: loopConfig.config.provider.releaseChannel,
             apnsDeviceToken: apnsDeviceToken,
             apnsEnvironment: apnsDeviceToken != nil ? "production" : nil
         )

--- a/provider-swift/Sources/ProviderCore/Update/SelfUpdater.swift
+++ b/provider-swift/Sources/ProviderCore/Update/SelfUpdater.swift
@@ -5,6 +5,7 @@ import CryptoKit
 public struct ReleaseInfo: Sendable {
     public let version: String
     public let platform: String
+    public let channel: ProviderReleaseChannel
     public let url: String
     public let bundleHash: String
     public let binaryHash: String?
@@ -13,6 +14,7 @@ public struct ReleaseInfo: Sendable {
     public init(
         version: String,
         platform: String,
+        channel: ProviderReleaseChannel = .stable,
         url: String,
         bundleHash: String,
         binaryHash: String? = nil,
@@ -20,6 +22,7 @@ public struct ReleaseInfo: Sendable {
     ) {
         self.version = version
         self.platform = platform
+        self.channel = channel
         self.url = url
         self.bundleHash = bundleHash
         self.binaryHash = binaryHash
@@ -60,6 +63,7 @@ public struct SelfUpdater: Sendable {
     private let installRootOverride: URL?
     private let verifyCodeSignatures: Bool
     private let currentVersion: String
+    private let releaseChannel: ProviderReleaseChannel
     private let urlSession: URLSession
     private let now: @Sendable () -> Double
     /// Test seam threaded into every `UpdateRecoveryStore` this updater
@@ -77,12 +81,17 @@ public struct SelfUpdater: Sendable {
 
     /// Production initializer: signature verification is ALWAYS on. There is no
     /// public way to construct a `SelfUpdater` that skips signature checks.
-    public init(coordinatorBaseURL: String, urlSession: URLSession = .shared) {
+    public init(
+        coordinatorBaseURL: String,
+        releaseChannel: ProviderReleaseChannel = .stable,
+        urlSession: URLSession = .shared
+    ) {
         self.init(
             coordinatorBaseURL: coordinatorBaseURL,
             installRoot: nil,
             verifyCodeSignatures: true,
             currentVersion: ProviderCore.version,
+            releaseChannel: releaseChannel,
             urlSession: urlSession,
             now: { Date().timeIntervalSince1970 }
         )
@@ -117,6 +126,7 @@ public struct SelfUpdater: Sendable {
         installRoot: URL?,
         verifyCodeSignatures: Bool,
         currentVersion: String,
+        releaseChannel: ProviderReleaseChannel = .stable,
         urlSession: URLSession = .shared,
         now: @escaping @Sendable () -> Double = {
             Date().timeIntervalSince1970
@@ -135,6 +145,7 @@ public struct SelfUpdater: Sendable {
         self.installRootOverride = installRoot
         self.verifyCodeSignatures = verifyCodeSignatures
         self.currentVersion = currentVersion
+        self.releaseChannel = releaseChannel
         self.urlSession = urlSession
         self.now = now
         self.recoveryFaultInjector = recoveryFaultInjector
@@ -268,7 +279,7 @@ public struct SelfUpdater: Sendable {
     }
 
     private func fetchLatestRelease() async -> LatestReleaseFetch {
-        let endpoint = "\(coordinatorBaseURL)/v1/releases/latest?platform=macos-arm64"
+        let endpoint = "\(coordinatorBaseURL)/v1/releases/latest?platform=macos-arm64&channel=\(releaseChannel.rawValue)"
 
         guard let url = URL(string: endpoint) else {
             return .failed("invalid coordinator URL: \(endpoint)")
@@ -298,6 +309,23 @@ public struct SelfUpdater: Sendable {
             guard platform == "macos-arm64" else {
                 return .failed("coordinator returned unsupported release platform \(platform)")
             }
+            let responseChannel: ProviderReleaseChannel
+            if let rawChannel = json["channel"] as? String {
+                guard let parsed = ProviderReleaseChannel(rawValue: rawChannel) else {
+                    return .failed("coordinator returned unsupported release channel \(rawChannel)")
+                }
+                responseChannel = parsed
+            } else {
+                responseChannel = .stable
+            }
+            if releaseChannel == .stable && responseChannel != .stable {
+                return .failed("coordinator returned a beta release to the stable channel")
+            }
+            if releaseChannel == .stable,
+               let parsedVersion = SemanticVersion(version),
+               parsedVersion.prerelease.first == .text("beta") {
+                return .failed("coordinator returned a beta version to the stable channel")
+            }
             guard let bundleHash = (json["bundle_hash"] as? String)
                     ?? (json["sha256"] as? String)
                     ?? (json["binary_hash"] as? String)
@@ -308,6 +336,7 @@ public struct SelfUpdater: Sendable {
             return .release(ReleaseInfo(
                 version: version,
                 platform: platform,
+                channel: responseChannel,
                 url: downloadURL,
                 bundleHash: bundleHash,
                 binaryHash: json["binary_hash"] as? String,

--- a/provider-swift/Sources/ProviderCore/Update/UpdateBanner.swift
+++ b/provider-swift/Sources/ProviderCore/Update/UpdateBanner.swift
@@ -13,11 +13,15 @@ public enum UpdateBanner: Sendable {
     /// thing has a configurable hard timeout. Errors are never propagated.
     public static func run(
         coordinatorURL: String,
+        releaseChannel: ProviderReleaseChannel = .stable,
         currentVersion: String = ProviderCore.version,
         timeout: TimeInterval = 2.0
     ) async {
         let baseURL = coordinatorHTTPBase(coordinatorURL)
-        guard let url = URL(string: "\(baseURL)/api/version") else { return }
+        let endpoint = releaseChannel == .beta
+            ? "\(baseURL)/v1/releases/latest?platform=macos-arm64&channel=beta"
+            : "\(baseURL)/api/version"
+        guard let url = URL(string: endpoint) else { return }
 
         var request = URLRequest(url: url)
         request.timeoutInterval = timeout
@@ -50,27 +54,14 @@ public enum UpdateBanner: Sendable {
         let changelog: String?
     }
 
-    /// Return true if `lhs` is strictly newer than `rhs` under the rules:
-    ///   - both are split on '.', non-numeric pre-release tags compared
-    ///     lexicographically.
-    ///   - "0.5.0" > "0.4.10" (numeric comparison, not lexicographic).
+    /// Return true if `lhs` is strictly newer than `rhs` under SemVer,
+    /// including prerelease precedence and final-release promotion.
     /// Internal so we can unit-test without a network.
     static func isNewerSemver(_ lhs: String, than rhs: String) -> Bool {
-        let l = parts(lhs)
-        let r = parts(rhs)
-        let count = max(l.count, r.count)
-        for i in 0..<count {
-            let a = i < l.count ? l[i] : 0
-            let b = i < r.count ? r[i] : 0
-            if a != b { return a > b }
+        guard let left = SemanticVersion(lhs), let right = SemanticVersion(rhs) else {
+            return false
         }
-        return false
-    }
-
-    private static func parts(_ version: String) -> [Int] {
-        // Strip pre-release / build metadata (e.g. "0.5.0-rc1" -> "0.5.0").
-        let stripped = version.split(separator: "-", maxSplits: 1).first.map(String.init) ?? version
-        return stripped.split(separator: ".").map { Int($0) ?? 0 }
+        return left > right
     }
 
     private static func printBanner(current: String, latest: String, changelog: String) {

--- a/provider-swift/Sources/darkbloom/BetaCommand.swift
+++ b/provider-swift/Sources/darkbloom/BetaCommand.swift
@@ -5,20 +5,27 @@ import ProviderCore
 struct Beta: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "beta",
-        abstract: "Manage opt-in beta features.",
+        abstract: "Join the beta release cohort or manage beta features.",
         discussion: """
-        Beta features are experimental and off by default. Toggling one writes a
-        field in your provider TOML config, so the change also applies to the
-        launchd daemon (unlike environment variables, which the daemon does not
-        inherit).
+        The beta release cohort receives signed prereleases through the same
+        automatic update, rollback, and traffic-serving path as stable providers.
+        Cohort membership is persisted in provider.toml and reported to the
+        coordinator at registration. Individual beta feature toggles remain
+        available separately.
 
         Subcommands:
-          list                 Show all beta features and whether each is on (default).
-          enable <feature>     Turn a beta feature on.
-          disable <feature>    Turn a beta feature off.
+          list                 Show release cohort and feature states (default).
+          enable               Join the beta release cohort.
+          disable              Return to stable release discovery.
+          enable <feature>     Turn an individual beta feature on.
+          disable <feature>    Turn an individual beta feature off.
           status [feature]     Show details for all features, or one.
 
-        Most changes require a restart to take effect:
+        Cohort changes require a restart to update registration and background checks:
+          darkbloom beta enable
+          darkbloom restart
+
+        Individual features use the existing form:
           darkbloom beta enable kv-quant
           darkbloom restart
         """,
@@ -55,7 +62,7 @@ extension Beta {
             let config = snapshot.config
 
             if json {
-                let payload = BetaFeatures.all.map { feature in
+                let features = BetaFeatures.all.map { feature in
                     BetaFeatureReport(
                         id: feature.id,
                         title: feature.title,
@@ -64,12 +71,24 @@ extension Beta {
                         summary: feature.summary
                     )
                 }
-                try printJSON(payload)
+                let releaseCohort = BetaFeatureReport(
+                    id: "release-channel",
+                    title: "Beta releases",
+                    enabled: config.provider.releaseChannel == .beta,
+                    requiresRestart: true,
+                    summary: "Use `darkbloom beta enable` without a feature id to opt in."
+                )
+                try printJSON([releaseCohort] + features)
                 return
             }
 
-            print("Beta features (config: \(describeConfigPath(snapshot)))")
+            print("Beta releases: \(config.provider.releaseChannel == .beta ? "ENABLED" : "disabled")")
+            print("Release channel: \(config.provider.releaseChannel.rawValue)")
+            print("Config: \(describeConfigPath(snapshot))")
+            print("Beta providers continue serving normal network traffic.")
+            print("Change with: darkbloom beta \(config.provider.releaseChannel == .beta ? "disable" : "enable")  (then: darkbloom restart)")
             print("")
+            print("Individual beta features:")
             if BetaFeatures.all.isEmpty {
                 print("  (none available in this build)")
             } else {
@@ -79,7 +98,7 @@ extension Beta {
                 }
             }
             print("")
-            print("Enable with:  darkbloom beta enable <feature>   (then: darkbloom restart)")
+            print("Enable a feature with: darkbloom beta enable <feature>  (then: darkbloom restart)")
             print("Details with: darkbloom beta status <feature>")
         }
     }
@@ -110,6 +129,10 @@ extension Beta {
                 features = [match]
             } else {
                 features = BetaFeatures.all
+                print("Beta releases: \(config.provider.releaseChannel == .beta ? "ENABLED" : "disabled")")
+                print("  Release channel: \(config.provider.releaseChannel.rawValue)")
+                print("  Prereleases use the normal signed update, rollback, and traffic-serving path.")
+                print("  Requires `darkbloom restart` after a cohort change.")
             }
 
             print("Config: \(describeConfigPath(snapshot))")
@@ -135,11 +158,15 @@ extension Beta {
 
         @OptionGroup var configOptions: ConfigOptions
 
-        @Argument(help: "Beta feature id (see `darkbloom beta list`).")
-        var feature: String
+        @Argument(help: "Optional beta feature id. Omit it to join the beta release cohort.")
+        var feature: String?
 
         mutating func run() async throws {
-            try setBetaFeature(feature, enabled: true, configOptions: configOptions)
+            if let feature {
+                try setBetaFeature(feature, enabled: true, configOptions: configOptions)
+            } else {
+                try setBetaReleaseChannel(.beta, configOptions: configOptions)
+            }
         }
     }
 
@@ -150,11 +177,15 @@ extension Beta {
 
         @OptionGroup var configOptions: ConfigOptions
 
-        @Argument(help: "Beta feature id (see `darkbloom beta list`).")
-        var feature: String
+        @Argument(help: "Optional beta feature id. Omit it to leave the beta release cohort.")
+        var feature: String?
 
         mutating func run() async throws {
-            try setBetaFeature(feature, enabled: false, configOptions: configOptions)
+            if let feature {
+                try setBetaFeature(feature, enabled: false, configOptions: configOptions)
+            } else {
+                try setBetaReleaseChannel(.stable, configOptions: configOptions)
+            }
         }
     }
 }
@@ -186,12 +217,7 @@ private func setBetaFeature(
     // the launchd daemon resolve that canonical path first, so writing back to
     // the (legacy) snapshot.configPath would leave the restarted daemon on the
     // stale value. Re-resolving the default returns the post-migration canonical.
-    let savePath: URL
-    if configOptions.config != nil {
-        savePath = snapshot.configPath
-    } else {
-        savePath = try ConfigManager.defaultConfigPath()
-    }
+    let savePath = try betaConfigSavePath(snapshot: snapshot, configOptions: configOptions)
 
     // Already in the desired state and the target file exists — no-op.
     if feature.isEnabled(in: config) == enabled
@@ -209,4 +235,47 @@ private func setBetaFeature(
         print("  Restart to apply:  darkbloom restart")
     }
     print("  Config: \(savePath.path)")
+}
+
+private func setBetaReleaseChannel(
+    _ channel: ProviderReleaseChannel,
+    configOptions: ConfigOptions
+) throws {
+    let snapshot = try loadRuntimeSnapshot(configOptions: configOptions)
+    var config = snapshot.config
+    let savePath = try betaConfigSavePath(snapshot: snapshot, configOptions: configOptions)
+
+    if config.provider.releaseChannel == channel
+        && (channel != .beta || config.provider.autoUpdate)
+        && FileManager.default.fileExists(atPath: savePath.path) {
+        print("Release channel is already \(channel.rawValue).")
+        return
+    }
+
+    config.provider.releaseChannel = channel
+    if channel == .beta {
+        config.provider.autoUpdate = true
+    }
+    try ConfigManager.save(config, to: savePath)
+
+    if channel == .beta {
+        print("Beta release cohort ENABLED.")
+        print("  This provider will receive signed beta releases and continue serving normal traffic.")
+        print("  Automatic updates are enabled so the provider stays on the beta track.")
+    } else {
+        print("Beta release cohort disabled; release channel is stable.")
+        print("  An installed beta is not downgraded; the provider stays on it until a newer stable release exists.")
+    }
+    print("  Restart to apply: darkbloom restart")
+    print("  Config: \(savePath.path)")
+}
+
+private func betaConfigSavePath(
+    snapshot: RuntimeSnapshot,
+    configOptions: ConfigOptions
+) throws -> URL {
+    if configOptions.config != nil {
+        return snapshot.configPath
+    }
+    return try ConfigManager.defaultConfigPath()
 }

--- a/provider-swift/Sources/darkbloom/Darkbloom.swift
+++ b/provider-swift/Sources/darkbloom/Darkbloom.swift
@@ -78,12 +78,18 @@ public func runUpdateBannerIfEnabled() async {
     // wrapper is uninitialized outside ArgumentParser's decoding lifecycle
     // and accessing it causes a fatal error. Pass nil to use defaults.
     let coordinatorURL: String
+    let releaseChannel: ProviderReleaseChannel
     if let snapshot = try? loadRuntimeSnapshot(configPath: nil) {
         coordinatorURL = snapshot.config.coordinator.url
+        releaseChannel = snapshot.config.provider.releaseChannel
     } else {
         coordinatorURL = "https://api.darkbloom.dev"
+        releaseChannel = .stable
     }
-    await UpdateBanner.run(coordinatorURL: coordinatorURL)
+    await UpdateBanner.run(
+        coordinatorURL: coordinatorURL,
+        releaseChannel: releaseChannel
+    )
 }
 
 // MARK: - Shared Options

--- a/provider-swift/Sources/darkbloom/Diagnostics/DoctorRunner.swift
+++ b/provider-swift/Sources/darkbloom/Diagnostics/DoctorRunner.swift
@@ -160,7 +160,10 @@ enum DoctorRunner {
         // as a follow-up. Below-min providers are still flagged indirectly: the
         // coordinator marks them RuntimeVerified=false and the trust section
         // above reports the resulting "not earning" state.
-        let updater = SelfUpdater(coordinatorBaseURL: coordinatorURL)
+        let updater = SelfUpdater(
+            coordinatorBaseURL: coordinatorURL,
+            releaseChannel: snapshot.config.provider.releaseChannel
+        )
         switch await updater.checkForUpdate() {
         case .updateAvailable(let current, let latest):
             out.append(VersionDiagnostic.diagnose(current: current, minimum: nil, latest: latest.version))

--- a/provider-swift/Sources/darkbloom/StartCommand+Modes.swift
+++ b/provider-swift/Sources/darkbloom/StartCommand+Modes.swift
@@ -158,14 +158,18 @@ extension Start {
         let authToken = AuthTokenStore.load()
         if let identity = ProcessIdentity.current() {
             try? SelfUpdater(
-                coordinatorBaseURL: coordinatorURL
+                coordinatorBaseURL: coordinatorURL,
+                releaseChannel: config.provider.releaseChannel
             ).confirmRunningCandidateLaunch(
                 processStartedAt: Double(identity.startTimeMicros) / 1_000_000
             )
         }
 
         if config.provider.autoUpdate {
-            try await runStartupAutoUpdate(coordinatorURL: coordinatorURL)
+            try await runStartupAutoUpdate(
+                coordinatorURL: coordinatorURL,
+                releaseChannel: config.provider.releaseChannel
+            )
         }
 
         // ----- Process-level lifecycle: PID lock + caffeinate. -----
@@ -277,12 +281,18 @@ extension Start {
         await TelemetryClient.shared.shutdown()
     }
 
-    private func runStartupAutoUpdate(coordinatorURL: String) async throws {
+    private func runStartupAutoUpdate(
+        coordinatorURL: String,
+        releaseChannel: ProviderReleaseChannel
+    ) async throws {
         if ProcessInfo.processInfo.environment["DARKBLOOM_NO_UPDATE_CHECK"] != nil {
             return
         }
         print("Checking for provider update...")
-        let updater = SelfUpdater(coordinatorBaseURL: coordinatorURL)
+        let updater = SelfUpdater(
+            coordinatorBaseURL: coordinatorURL,
+            releaseChannel: releaseChannel
+        )
         switch await updater.update() {
         case .alreadyUpToDate:
             return

--- a/provider-swift/Sources/darkbloom/StatusCommand.swift
+++ b/provider-swift/Sources/darkbloom/StatusCommand.swift
@@ -25,6 +25,7 @@ struct Status: AsyncParsableCommand {
         print("Backend port: \(config.backend.port)")
         print("Configured model: \(config.backend.model ?? "auto-select")")
         print("Idle timeout: \(config.backend.idleTimeoutMins == 0 ? "disabled" : "\(config.backend.idleTimeoutMins)m")")
+        print("Release channel: \(config.provider.releaseChannel.rawValue) (manage with `darkbloom beta`)")
         let enabledBeta = BetaFeatures.enabledIDs(in: config)
         print("Beta features: \(enabledBeta.isEmpty ? "none" : enabledBeta.joined(separator: ", ")) (manage with `darkbloom beta`)")
         print("Auto-restart: \(autoRestartStatus(config: config))")

--- a/provider-swift/Sources/darkbloom/UpdateCommand.swift
+++ b/provider-swift/Sources/darkbloom/UpdateCommand.swift
@@ -35,7 +35,10 @@ struct Update: AsyncParsableCommand {
         print("")
 
         let coordinatorURL = coordinator ?? config.coordinator.url
-        let updater = SelfUpdater(coordinatorBaseURL: coordinatorURL)
+        let updater = SelfUpdater(
+            coordinatorBaseURL: coordinatorURL,
+            releaseChannel: config.provider.releaseChannel
+        )
 
         if checkOnly {
             let result = await updater.checkForUpdate(

--- a/provider-swift/Sources/darkbloom/WatchdogCommand.swift
+++ b/provider-swift/Sources/darkbloom/WatchdogCommand.swift
@@ -71,6 +71,7 @@ struct Watchdog: AsyncParsableCommand {
         )
         let updater = SelfUpdater(
             coordinatorBaseURL: settings.coordinatorURL,
+            releaseChannel: settings.releaseChannel,
             urlSession: SelfUpdater.watchdogURLSession()
         )
         let recovery = WatchdogRecoveryService(
@@ -171,6 +172,7 @@ struct Watchdog: AsyncParsableCommand {
         let autoRestart: Bool
         let autoUpdate: Bool
         let coordinatorURL: String
+        let releaseChannel: ProviderReleaseChannel
         /// Derived from the operator's `startup_preload_timeout_secs` so a
         /// raised preload window never reads as a hung candidate launch.
         let candidateStartupTimeoutSeconds: Double
@@ -193,6 +195,7 @@ struct Watchdog: AsyncParsableCommand {
             autoUpdate: config.provider.autoUpdate
                 && environment["DARKBLOOM_NO_UPDATE_CHECK"] == nil,
             coordinatorURL: config.coordinator.url,
+            releaseChannel: config.provider.releaseChannel,
             candidateStartupTimeoutSeconds:
                 WatchdogRecoveryService.candidateStartupTimeout(
                     preloadTimeoutSecs: config.backend.startupPreloadTimeoutSecs

--- a/provider-swift/Tests/DarkbloomCLITests/BetaCommandTests.swift
+++ b/provider-swift/Tests/DarkbloomCLITests/BetaCommandTests.swift
@@ -1,0 +1,52 @@
+import Foundation
+import Testing
+@testable import ProviderCore
+@testable import darkbloom
+
+@Suite("Beta command")
+struct BetaCommandTests {
+    @Test("cohort enable and disable persist release channel")
+    func cohortPersistence() async throws {
+        let path = try temporaryConfig(autoUpdate: false)
+        defer { try? FileManager.default.removeItem(at: path.deletingLastPathComponent()) }
+
+        var enable = try Beta.Enable.parse(["--config", path.path])
+        try await enable.run()
+        var config = try ConfigManager.load(from: path)
+        #expect(config.provider.releaseChannel == .beta)
+        #expect(config.provider.autoUpdate)
+
+        var disable = try Beta.Disable.parse(["--config", path.path])
+        try await disable.run()
+        config = try ConfigManager.load(from: path)
+        #expect(config.provider.releaseChannel == .stable)
+        #expect(config.provider.autoUpdate)
+    }
+
+    @Test("feature argument keeps existing beta feature behavior")
+    func featureCompatibility() async throws {
+        let path = try temporaryConfig(autoUpdate: true)
+        defer { try? FileManager.default.removeItem(at: path.deletingLastPathComponent()) }
+
+        var enable = try Beta.Enable.parse(["kv-quant", "--config", path.path])
+        try await enable.run()
+        let config = try ConfigManager.load(from: path)
+        #expect(config.backend.kvQuant)
+        #expect(config.provider.releaseChannel == .stable)
+    }
+
+    private func temporaryConfig(autoUpdate: Bool) throws -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("beta-command-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let path = root.appendingPathComponent("provider.toml")
+        try ConfigManager.save(
+            ProviderConfig(provider: ProviderSettings(
+                name: "test-provider",
+                autoUpdate: autoUpdate
+            )),
+            to: path
+        )
+        return path
+    }
+}

--- a/provider-swift/Tests/DarkbloomCLITests/WatchdogCommandTests.swift
+++ b/provider-swift/Tests/DarkbloomCLITests/WatchdogCommandTests.swift
@@ -74,6 +74,17 @@ struct WatchdogCommandTests {
         #expect(!settings.autoUpdate)
     }
 
+    @Test("watchdog uses the persisted beta release channel")
+    func honoursReleaseChannel() {
+        let url = writeTempConfig("""
+        [provider]
+        name = "x"
+        release_channel = "beta"
+        """)
+        defer { try? FileManager.default.removeItem(at: url) }
+        #expect(Watchdog.settings(configPath: url.path).releaseChannel == .beta)
+    }
+
     @Test("DARKBLOOM_NO_UPDATE_CHECK disables only watchdog updates")
     func environmentUpdateOptOut() {
         let url = writeTempConfig("""

--- a/provider-swift/Tests/ProviderCoreTests/ConfigTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ConfigTests.swift
@@ -1,6 +1,28 @@
 import Testing
 @testable import ProviderCore
 
+@Test func configReleaseChannelDefaultsStableAndRoundTripsBeta() throws {
+    let defaults = ConfigManager.parse("""
+    [provider]
+    name = "test-provider"
+    """)
+    #expect(defaults.provider.releaseChannel == .stable)
+
+    let original = ProviderConfig(
+        provider: ProviderSettings(name: "test-provider", releaseChannel: .beta)
+    )
+    let toml = ConfigManager.serialize(original)
+    #expect(toml.contains("release_channel"))
+    #expect(ConfigManager.parse(toml).provider.releaseChannel == .beta)
+
+    let unknown = ConfigManager.parse("""
+    [provider]
+    name = "test-provider"
+    release_channel = "canary"
+    """)
+    #expect(unknown.provider.releaseChannel == .stable)
+}
+
 @Test func configParsingDefaultsMaxModelSlotsWhenMissing() throws {
     let config = ConfigManager.parse("""
     [provider]

--- a/provider-swift/Tests/ProviderCoreTests/Helpers/MockCoordinator.swift
+++ b/provider-swift/Tests/ProviderCoreTests/Helpers/MockCoordinator.swift
@@ -96,6 +96,7 @@ public struct MockDeviceCodeFixture: Sendable {
 public struct MockReleaseFixture: Sendable {
     public var version: String
     public var platform: String
+    public var channel: ProviderReleaseChannel
     public var url: String
     public var bundleHash: String
     public var binaryHash: String?
@@ -104,6 +105,7 @@ public struct MockReleaseFixture: Sendable {
     public init(
         version: String = "0.99.0",
         platform: String = "macos-arm64",
+        channel: ProviderReleaseChannel = .stable,
         url: String = "https://example.test/darkbloom-bundle-macos-arm64.tar.gz",
         bundleHash: String = String(repeating: "a", count: 64),
         binaryHash: String? = nil,
@@ -111,6 +113,7 @@ public struct MockReleaseFixture: Sendable {
     ) {
         self.version = version
         self.platform = platform
+        self.channel = channel
         self.url = url
         self.bundleHash = bundleHash
         self.binaryHash = binaryHash
@@ -459,6 +462,7 @@ public final class MockCoordinator: @unchecked Sendable {
             let body = ReleaseLatestPayload(
                 version: self.release.version,
                 platform: self.release.platform,
+                channel: self.release.channel,
                 url: releaseURL,
                 bundle_hash: self.release.bundleHash,
                 binary_hash: self.release.binaryHash,
@@ -683,6 +687,7 @@ private final class PortBox: @unchecked Sendable {
 private struct ReleaseLatestPayload: Encodable {
     let version: String
     let platform: String
+    let channel: ProviderReleaseChannel
     let url: String
     let bundle_hash: String
     let binary_hash: String?

--- a/provider-swift/Tests/ProviderCoreTests/ProtocolTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ProtocolTests.swift
@@ -67,6 +67,31 @@ import Testing
     #expect(register.privateOnly == true)
 }
 
+@Test func registerEncodesBetaReleaseChannelOnlyWhenOptedIn() throws {
+    let stable = ProviderMessage.register(ProviderMessage.Register(
+        hardware: sampleHardware(),
+        models: [sampleModel()],
+        backend: "mlx_swift_lm"
+    ))
+    let stableObject = try jsonObject(try ProviderProtocolCodec.encodeProviderMessage(stable))
+    #expect(stableObject["release_channel"] == nil)
+
+    let beta = ProviderMessage.register(ProviderMessage.Register(
+        hardware: sampleHardware(),
+        models: [sampleModel()],
+        backend: "mlx_swift_lm",
+        releaseChannel: .beta
+    ))
+    let betaData = try ProviderProtocolCodec.encodeProviderMessage(beta)
+    let betaObject = try jsonObject(betaData)
+    #expect(betaObject["release_channel"] as? String == "beta")
+
+    guard case .register(let decoded) = try ProviderProtocolCodec.decodeProviderMessage(from: betaData) else {
+        throw TestFailure.unexpectedMessage
+    }
+    #expect(decoded.releaseChannel == .beta)
+}
+
 @Test func registerEncodesAPNsFieldsOnlyWhenPresent() throws {
     // Omitted when nil (mirrors Go `omitempty`).
     let off = ProviderMessage.register(ProviderMessage.Register(
@@ -111,6 +136,7 @@ import Testing
         backend: "mlx_swift_lm",
         attestation: RawJSON(rawBytes: Data(raw.utf8)),
         privateOnly: true,
+        releaseChannel: .beta,
         apnsDeviceToken: "cb1ceb489ec9",
         apnsEnvironment: "production"
     ))
@@ -119,6 +145,7 @@ import Testing
     #expect(object["apns_device_token"] as? String == "cb1ceb489ec9")
     #expect(object["apns_environment"] as? String == "production")
     #expect(object["private_only"] as? Bool == true)
+    #expect(object["release_channel"] as? String == "beta")
     // Raw attestation bytes preserved verbatim (the reason this path exists).
     let json = String(data: data, encoding: .utf8) ?? ""
     #expect(json.contains(#""attestation":\#(raw)"#))
@@ -128,6 +155,7 @@ import Testing
     #expect(r.apnsDeviceToken == "cb1ceb489ec9")
     #expect(r.apnsEnvironment == "production")
     #expect(r.privateOnly == true)
+    #expect(r.releaseChannel == .beta)
 }
 
 @Test func codeAttestationResponseEncodesSnakeCaseAndRoundTrips() throws {

--- a/provider-swift/Tests/ProviderCoreTests/SelfUpdaterTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/SelfUpdaterTests.swift
@@ -158,6 +158,76 @@ struct SelfUpdaterTests {
         #expect(reason.contains("unsupported release platform"))
     }
 
+    @Test("beta updater accepts beta releases while stable updater rejects them")
+    func releaseChannelSelectionIsFailClosed() async throws {
+        let mock = MockCoordinator(release: MockReleaseFixture(
+            version: "99.0.0-beta.1",
+            channel: .beta
+        ))
+        let baseURL = try await mock.start()
+        defer { Task { await mock.shutdown() } }
+
+        let betaResult = await SelfUpdater(
+            coordinatorBaseURL: baseURL.absoluteString,
+            releaseChannel: .beta
+        ).checkForUpdate()
+        guard case .updateAvailable(_, let betaRelease) = betaResult else {
+            Issue.record("beta updater did not accept beta release: \(betaResult)")
+            return
+        }
+        #expect(betaRelease.channel == .beta)
+
+        let stableResult = await SelfUpdater(
+            coordinatorBaseURL: baseURL.absoluteString,
+            releaseChannel: .stable
+        ).checkForUpdate()
+        guard case .checkFailed(let reason) = stableResult else {
+            Issue.record("stable updater accepted beta release: \(stableResult)")
+            return
+        }
+        #expect(reason.contains("beta release"))
+    }
+
+    @Test("stable updater rejects a beta version mislabeled as stable")
+    func stableUpdaterRejectsMislabeledBetaVersion() async throws {
+        let mock = MockCoordinator(release: MockReleaseFixture(
+            version: "99.0.0-beta.1",
+            channel: .stable
+        ))
+        let baseURL = try await mock.start()
+        defer { Task { await mock.shutdown() } }
+
+        let result = await SelfUpdater(
+            coordinatorBaseURL: baseURL.absoluteString,
+            releaseChannel: .stable
+        ).checkForUpdate()
+        guard case .checkFailed(let reason) = result else {
+            Issue.record("stable updater accepted mislabeled beta version: \(result)")
+            return
+        }
+        #expect(reason.contains("beta version"))
+    }
+
+    @Test("beta updater accepts a newer promoted stable release")
+    func betaUpdaterAcceptsStablePromotion() async throws {
+        let mock = MockCoordinator(release: MockReleaseFixture(
+            version: "99.0.0",
+            channel: .stable
+        ))
+        let baseURL = try await mock.start()
+        defer { Task { await mock.shutdown() } }
+
+        let result = await SelfUpdater(
+            coordinatorBaseURL: baseURL.absoluteString,
+            releaseChannel: .beta
+        ).checkForUpdate()
+        guard case .updateAvailable(_, let release) = result else {
+            Issue.record("beta updater rejected stable promotion: \(result)")
+            return
+        }
+        #expect(release.channel == .stable)
+    }
+
     @Test("ReleaseInfo sha256 compatibility returns bundle hash")
     func releaseInfoShaCompatibility() {
         let hash = String(repeating: "d", count: 64)

--- a/provider-swift/Tests/ProviderCoreTests/UpdateBannerTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/UpdateBannerTests.swift
@@ -29,16 +29,17 @@ struct UpdateBannerTests {
         #expect(!UpdateBanner.isNewerSemver("0.99.99", than: "1.0.0"))
     }
 
-    @Test("pre-release suffix is stripped before comparison")
-    func preReleaseSuffixStripped() {
+    @Test("pre-release ordering follows SemVer")
+    func preReleaseOrdering() {
         #expect(!UpdateBanner.isNewerSemver("0.5.0-rc1", than: "0.5.0"))
         #expect(UpdateBanner.isNewerSemver("0.5.1-rc1", than: "0.5.0"))
+        #expect(UpdateBanner.isNewerSemver("0.5.0-beta.2", than: "0.5.0-beta.1"))
+        #expect(UpdateBanner.isNewerSemver("0.5.0", than: "0.5.0-beta.9"))
     }
 
-    @Test("missing parts default to zero")
-    func missingPartsDefaultToZero() {
-        // "0.5" parses to [0, 5] which expands to [0, 5, 0] for comparison.
+    @Test("invalid abbreviated versions are rejected")
+    func abbreviatedVersionsRejected() {
         #expect(!UpdateBanner.isNewerSemver("0.5", than: "0.5.0"))
-        #expect(UpdateBanner.isNewerSemver("0.5.1", than: "0.5"))
+        #expect(!UpdateBanner.isNewerSemver("0.5.1", than: "0.5"))
     }
 }

--- a/scripts/admin.sh
+++ b/scripts/admin.sh
@@ -102,7 +102,8 @@ cmd_releases_deactivate() {
 
 cmd_releases_latest() {
     local platform="${1:-macos-arm64}"
-    curl -fsSL "$COORDINATOR_URL/v1/releases/latest?platform=$platform" | python3 -m json.tool
+    local channel="${2:-stable}"
+    curl -fsSL "$COORDINATOR_URL/v1/releases/latest?platform=$platform&channel=$channel" | python3 -m json.tool
 }
 
 cmd_models_list() {
@@ -138,7 +139,7 @@ case "${1:-help}" in
         case "${2:-list}" in
             list) cmd_releases_list ;;
             deactivate) cmd_releases_deactivate "${3:-}" "${4:-}" ;;
-            latest) cmd_releases_latest "${3:-}" ;;
+            latest) cmd_releases_latest "${3:-}" "${4:-}" ;;
             *) echo "Usage: $0 releases [list|deactivate|latest]" ;;
         esac
         ;;
@@ -158,7 +159,7 @@ case "${1:-help}" in
         echo "  login                          Authenticate with Privy (email OTP)"
         echo "  logout                         Remove stored token"
         echo "  releases list                  List all releases"
-        echo "  releases latest [platform]     Show latest active release"
+        echo "  releases latest [platform] [stable|beta]  Show latest release for a channel"
         echo "  releases deactivate <version>  Deactivate a release"
         echo "  models list                    List model catalog"
         echo "  raw <METHOD> <path> [body]     Raw API call with auth"


### PR DESCRIPTION
## Summary

- add an opt-in per-provider beta release cohort through `darkbloom beta enable` / `disable`, persisted in `provider.toml` and mirrored into coordinator provider records
- route manual, startup, background, watchdog, doctor, and banner update discovery through the selected release channel while leaving beta providers in the normal traffic pool
- introduce stable/beta release persistence, exact SemVer selection, channel-isolated caches and dashboard version reporting, plus strict release/channel validation
- make beta publication safe: separate R2 pointers, GitHub prereleases that cannot become latest, immutable channel assignment, and verified bundle/binary/metallib hashes
- keep the old `darkbloom beta enable <feature>` form for independent local experiments; beta release builds carry their intended defaults instead of requiring fleet operators to toggle every feature

## Before

```mermaid
flowchart LR
  subgraph BeforeBehavior[Behavior]
    O[Provider operator] --> F[Enable each beta feature manually]
    F --> R[Restart provider]
    P[Every auto-updating provider] --> L[One global latest release]
    L --> U[Same update target for whole fleet]
    B[Prerelease rollout] --> M[Manual feature flags or global latest replacement]
  end

  subgraph BeforeCode[Code]
    BC[BetaCommand] --> BF[BetaFeatures config fields]
    SU[SelfUpdater call sites] --> EP[GET /v1/releases/latest]
    EP --> GS[GetLatestRelease platform]
    RW[release-swift workflow] --> RP[releases/latest pointer]
  end
```

## After

```mermaid
flowchart LR
  subgraph AfterBehavior[Behavior]
    O2[Provider operator] --> BE[darkbloom beta enable]
    BE --> CFG[Persist beta channel and enable auto-update]
    CFG --> BP[Beta provider checks beta channel]
    SP[Stable provider] --> SL[Stable-only latest]
    BP --> BL[Highest stable or beta SemVer]
    BL --> V[Existing verify, stage, drain, restart, quarantine and rollback path]
    SL --> V
    V --> T[Provider continues serving normal traffic]
  end

  subgraph AfterCode[Code]
    BC2[BetaCommand] --> PS[ProviderSettings.releaseChannel]
    PS --> SU2[All SelfUpdater constructors]
    PS --> REG[RegisterMessage.release_channel]
    SU2 --> API[handleLatestRelease platform plus channel]
    API --> STORE[ReleaseStore channel-aware selection]
    REG --> PREC[ProviderRecord.release_channel]
    STORE --> HASH[Binary and accepted metallib hash policies]
    WF2[release-swift workflow] --> PTR[Separate stable and beta R2 pointers]
  end
```

## Safeguards

- the public/default release channel remains `stable`; beta discovery must be explicit
- beta discovery includes stable releases so a final `X.Y.Z` supersedes `X.Y.Z-beta.N`
- `-beta` versions cannot be registered as stable, stable versions cannot be registered as beta, and a stored release cannot change channels
- active stable and beta binary/metallib hashes remain simultaneously trusted, so registering a beta cannot deroute stable providers
- release deactivation refuses binaries still used by connected providers unless explicitly forced
- leaving beta stops future beta discovery without attempting an unsafe downgrade

## Verification

- `go test ./coordinator/...`
- `npm test -- src/app/providers` (21 tests)
- `npx eslint src/` (0 errors; existing warnings only)
- `swift build --product darkbloom`
- focused Swift beta/config/protocol/updater/watchdog/CLI suite (27 tests)
- `bash -n scripts/admin.sh`
- `actionlint .github/workflows/release-swift.yml` with the repository's established custom-runner/baseline ShellCheck warnings ignored
- `git diff --check`

## Rollout

Deploy the coordinator first, then ship this capability in one stable provider release. The first beta must use a newer SemVer core than that bootstrap stable release, for example stable `0.7.9` followed by `0.7.10-beta.1`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/537"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786422619&installation_id=133247490&pr_number=537&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F537&signature=f88f4ccc05962a8b0c857245e409ec1bfd8d2bdcbbed3969ca7a786d2b055339"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->