### PR TITLE
release(provider): v0.7.10 — bump provider version

### DIFF
--- a/coordinator/api/server.go
+++ b/coordinator/api/server.go
@@ -144,7 +144,7 @@ func keyLimitResetFromContext(ctx context.Context) string {
 // 0.6.0 is the APNs code-identity / VLM-routing / graceful-update release.
 // Keep this fallback in sync with ProviderCore.version so dev/in-memory
 // coordinators advertise the same floor as the Swift binary they expect.
-var LatestProviderVersion = "0.7.9"
+var LatestProviderVersion = "0.7.10"
 
 // minProviderVersionForDesiredModels is the first provider version whose Swift
 // runtime understands the desired_models message. The coordinator must NOT send

--- a/provider-swift/Sources/ProviderCore/ProviderCore.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderCore.swift
@@ -143,5 +143,5 @@ public enum ProviderCore {
     // eagerly commit only an independently capped physical plan, report pool
     // truth through existing heartbeat fields, and map terminal exhaustion to
     // retryable capacity. VLM and kv-quant slots stay contiguous.
-    public static let version = "0.7.9"
+    public static let version = "0.7.10"
 }


### PR DESCRIPTION
## Summary

- bump the Swift provider version from `0.7.9` to `0.7.10`
- keep the coordinator's no-release-row fallback synchronized at `0.7.10`
- prepare current master (PRs #536 and #538) for the next provider release

This PR does not create a tag or publish a release.

## Before

```mermaid
flowchart LR
  subgraph BeforeBehavior[Behavior]
    A[Build current master] --> B[darkbloom reports 0.7.9]
    C[Coordinator without a release row] --> D[Advertises fallback 0.7.9]
  end

  subgraph BeforeCode[Code]
    E[ProviderCore.version = 0.7.9] --> F[CLI and provider registration version]
    G[LatestProviderVersion = 0.7.9] --> H[Coordinator fallback version response]
  end
```

## After

```mermaid
flowchart LR
  subgraph AfterBehavior[Behavior]
    A2[Build current master] --> B2[darkbloom reports 0.7.10]
    C2[Coordinator without a release row] --> D2[Advertises fallback 0.7.10]
    B2 --> E2[Ready for a separately authorized v0.7.10 tag and release]
  end

  subgraph AfterCode[Code]
    F2[ProviderCore.version = 0.7.10] --> G2[CLI and provider registration version]
    H2[LatestProviderVersion = 0.7.10] --> I2[Coordinator fallback version response]
  end
```

## Verification

- `go test ./coordinator/api`
- `swift build --product darkbloom`
- `.build/debug/darkbloom --version` prints `0.7.10`
- `git diff --check`

## Release Scope

Based on current `master` at `5c33a32a`, including merged PR #536 (fan control) and PR #538 (Gemma reasoning/tool-choice fixes). Open PR #537 is intentionally excluded.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/540"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786503949&installation_id=133247490&pr_number=540&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F540&signature=b69ff511e8c9efcf311edfba50ce0dccef881d327e8888f22d5d02d70a3e8933"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->