### PR TITLE
fix(console): stats page map overflow on phones + two-column whitespace

### DIFF
--- a/console-ui/src/app/stats/ProviderDashboard.tsx
+++ b/console-ui/src/app/stats/ProviderDashboard.tsx
@@ -286,7 +286,9 @@ export function ProviderDashboard({ providers }: { providers: ProviderStats[] })
           </div>
         ) : (
           <div className="grid items-start gap-3 md:grid-cols-[minmax(235px,0.78fr)_minmax(0,1.22fr)]">
-            <div className="space-y-2 md:max-h-[760px] md:overflow-y-auto md:pr-1">
+            {/* h-0 + min-h-full: the detail panel defines the row height and
+                the fleet list scrolls to match, instead of trailing whitespace. */}
+            <div className="space-y-2 md:h-0 md:min-h-full md:overflow-y-auto md:pr-1">
               {filteredProviders.map((provider) => (
                 <ProviderRow key={provider.id} provider={provider} selected={provider.id === selectedProvider?.id} onSelect={() => setSelectedProviderId(provider.id)} />
               ))}

--- a/console-ui/src/app/stats/page.tsx
+++ b/console-ui/src/app/stats/page.tsx
@@ -867,7 +867,9 @@ function ProviderGeography({ stats }: { stats: PlatformStats }) {
 
       <div className="grid grid-cols-1 items-start gap-5 lg:grid-cols-[minmax(0,1fr)_340px]">
         <ZoomableMapViewport
-          className="relative aspect-[2/1] min-h-[260px] overflow-hidden rounded-xl border border-border-dim shadow-inner"
+          // min-h only from sm up: with aspect-ratio, a base min-height would
+          // transfer into a 520px min-width and overflow narrow viewports.
+          className="relative aspect-[2/1] overflow-hidden rounded-xl border border-border-dim shadow-inner sm:min-h-[260px]"
           style={{
             background:
               "radial-gradient(115% 78% at 50% -10%, color-mix(in srgb, var(--accent-brand) 11%, transparent), transparent 55%), radial-gradient(85% 70% at 50% 118%, color-mix(in srgb, var(--accent-green) 7%, transparent), transparent 52%), linear-gradient(180deg, var(--bg-primary), var(--bg-secondary))",
@@ -1025,7 +1027,9 @@ function ProviderGeography({ stats }: { stats: PlatformStats }) {
           )}
         </ZoomableMapViewport>
 
-        <div className="space-y-4">
+        {/* h-0 + min-h-full: the map defines the row height and this side
+            scrolls, instead of stretching the section with whitespace. */}
+        <div className="space-y-4 lg:h-0 lg:min-h-full lg:overflow-y-auto lg:pr-1">
           <div className="grid grid-cols-2 gap-3">
             <FlowMetric label="30m requests" value={formatNumber(recentRequests)} sub={`${formatNumber(peakRequests)} peak/min`} />
             <FlowMetric label="30m tokens" value={formatNumber(recentTokens)} sub={`${formatNumber(Math.round(recentTokens / recentBuckets.length))}/min avg`} />
@@ -1205,7 +1209,7 @@ function RequestGeography({ stats }: { stats: PlatformStats }) {
 
       <div className="grid grid-cols-1 lg:grid-cols-[minmax(0,1fr)_320px] gap-5">
         <div
-          className="relative aspect-[2/1] min-h-[260px] overflow-hidden rounded-lg border border-border-dim shadow-inner"
+          className="relative aspect-[2/1] overflow-hidden rounded-lg border border-border-dim shadow-inner sm:min-h-[260px]"
           style={{
             background:
               "radial-gradient(110% 80% at 50% -8%, color-mix(in srgb, var(--accent-green) 9%, transparent), transparent 55%), linear-gradient(180deg, var(--bg-primary), var(--bg-secondary))",
@@ -1272,7 +1276,9 @@ function RequestGeography({ stats }: { stats: PlatformStats }) {
           )}
         </div>
 
-        <div className="space-y-5">
+        {/* Same height-cap trick as Live Network Flow: the map sets the row
+            height and the origin/region lists scroll within it. */}
+        <div className="space-y-5 lg:h-0 lg:min-h-full lg:overflow-y-auto lg:pr-1">
           <div>
             <h3 className="text-xs font-mono text-text-tertiary uppercase tracking-wider mb-3">
               Top Origins

--- a/console-ui/src/app/stats/page.tsx
+++ b/console-ui/src/app/stats/page.tsx
@@ -310,6 +310,7 @@ function providerServesGemmaRollout(provider: ProviderStats): boolean {
   return provider.models?.some((model) => GEMMA_ROLLOUT_IDS.has(model)) ?? false;
 }
 
+
 function gemmaRolloutProviders(providers: ProviderStats[]): ProviderStats[] {
   return providers.filter(providerServesGemmaRollout);
 }


### PR DESCRIPTION
## What changed

Two small layout fixes on the network stats page. No behavior or data changes — CSS classes only (2 files, +13/−5).

**1. Maps no longer overflow narrow browsers.**
The two world maps (Live Network Flow, Request Geography) had `aspect-[2/1] min-h-[260px]`. CSS transfers that min-height through the aspect ratio into a **min-width of 520px**, so on phone-width viewports the maps forced the whole page to scroll sideways. The min-height now only applies from the `sm` breakpoint up; below that the maps just follow the 2:1 aspect ratio and fit the screen.

**2. Two-column sections no longer trail huge whitespace.**
In Live Network Flow, Request Geography, and the Provider fleet, one side of the widget (metrics list, top-origins list, node list) often grows much taller than the other (map, detail panel), leaving a large blank area beside it. Now the shorter "anchor" side defines the section height and the longer list scrolls inside it (`h-0 + min-h-full + overflow-y-auto`, applied only at `lg`/`md` widths — mobile stacking is unchanged).

## Before / After

```mermaid
flowchart LR
  subgraph Before
    A1[phone viewport 390px] --> B1[map min-width 520px → page scrolls sideways]
    C1[two-column widget] --> D1[long list stretches section → whitespace next to map/detail]
  end
  subgraph After
    A2[phone viewport 390px] --> B2[map fits width, 2:1 aspect]
    C2[two-column widget] --> D2[map/detail sets height → long list scrolls inside]
  end
```

## Verification

- `npx eslint src/` and `npm run build` pass.
- Verified in a real browser at 390px: page scroll width is exactly the viewport (no horizontal overflow, zero overflowing elements found by a DOM scan).
- Verified at 1280px: Live Network Flow, Request Geography, and Provider fleet sections are compact, long sides scroll.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/544"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786550576&installation_id=133247490&pr_number=544&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F544&signature=e767d3ebe6c779f602acf4e115552fdcda949e1004a81e845f214a17629658f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->