### PR TITLE
fix(cache): harden routing and cache lifecycle

### DIFF
--- a/coordinator/api/cache_dispatch_test.go
+++ b/coordinator/api/cache_dispatch_test.go
@@ -1,0 +1,100 @@
+package api
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/registry"
+)
+
+func TestLegacyProviderBodiesReceiveUniqueCacheBusters(t *testing.T) {
+	reg := registry.New(quietLogger())
+	if err := reg.ConfigureCacheRouting(registry.CacheRoutingConfig{
+		Mode: registry.CacheRoutingConversation, TTL: time.Minute, MaxHolders: 4,
+		MaxDiscountMs: 1000, MaxCostFraction: .35,
+		MasterKey: base64.RawURLEncoding.EncodeToString([]byte("0123456789abcdef0123456789abcdef")),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	legacy := &registry.Provider{ID: "legacy", PrefixCacheProtocol: 0}
+	bodies := map[string][]byte{
+		"chat":        []byte(`{"model":"m","prompt_cache_key":"caller","seed":9007199254740993,"messages":[{"role":"user","content":"<hi>&"}]}`),
+		"responses":   []byte(`{"model":"m","prompt_cache_key":"caller","input":"hi"}`),
+		"anthropic":   []byte(`{"model":"m","prompt_cache_key":"caller","messages":[{"role":"user","content":"hi"}]}`),
+		"completions": []byte(`{"model":"m","prompt_cache_key":"caller","prompt":"hi"}`),
+		"generic":     []byte(`{"model":"m","prompt_cache_key":"caller","messages":[{"role":"user","content":"hi"}]}`),
+	}
+	seen := make(map[string]struct{}, len(bodies))
+	for name, raw := range bodies {
+		t.Run(name, func(t *testing.T) {
+			original := append([]byte(nil), raw...)
+			pr := &registry.PendingRequest{
+				RequestID: "attempt-" + name, Attempt: len(seen), Model: "m", ConsumerKey: "account",
+				CacheRoute: registry.CacheRoute{ExactKey: "exact-" + name, ScopeNamespace: "namespace"},
+			}
+			if err := reg.PrepareCacheAttempt(pr, legacy); err != nil {
+				t.Fatal(err)
+			}
+			sealed, err := bodyForCacheAttempt(raw, false, legacy, pr)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(raw) != string(original) {
+				t.Fatal("caller-visible source body was mutated")
+			}
+			if name == "chat" && !strings.Contains(string(sealed), `"seed":9007199254740993`) {
+				t.Fatalf("legacy isolation changed an exact JSON number: %s", sealed)
+			}
+			if name == "chat" && (!strings.Contains(string(sealed), `"content":"<hi>&"`) || strings.Contains(string(sealed), `\u003c`)) {
+				t.Fatalf("legacy isolation HTML-escaped the provider body: %s", sealed)
+			}
+			var decoded map[string]any
+			if err := json.Unmarshal(sealed, &decoded); err != nil {
+				t.Fatal(err)
+			}
+			key, _ := decoded["prompt_cache_key"].(string)
+			if key == "" || key == "caller" || key != pr.LegacyCacheBustKey {
+				t.Fatalf("sealed prompt_cache_key = %q, prepared = %q", key, pr.LegacyCacheBustKey)
+			}
+			if _, duplicate := seen[key]; duplicate {
+				t.Fatalf("legacy cache buster reused across attempts: %q", key)
+			}
+			seen[key] = struct{}{}
+		})
+	}
+}
+
+func TestProtocolV1BodyDoesNotReceiveLegacyCacheBuster(t *testing.T) {
+	raw := []byte(`{"model":"m","prompt_cache_key":"caller","messages":[]}`)
+	sealed, err := bodyForCacheAttempt(raw, false, &registry.Provider{PrefixCacheProtocol: 1}, &registry.PendingRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(sealed) != string(raw) {
+		t.Fatalf("protocol-v1 body changed: %s", sealed)
+	}
+}
+
+func TestCacheRoutingOffStillBustsLegacyProviderBody(t *testing.T) {
+	reg := registry.New(quietLogger())
+	legacy := &registry.Provider{ID: "legacy", PrefixCacheProtocol: 0}
+	pr := &registry.PendingRequest{RequestID: "off-attempt", Model: "m", ConsumerKey: "account"}
+	if err := reg.PrepareCacheAttempt(pr, legacy); err != nil {
+		t.Fatal(err)
+	}
+	raw := []byte(`{"model":"m","prompt_cache_key":"caller","messages":[]}`)
+	sealed, err := bodyForCacheAttempt(raw, false, legacy, pr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(sealed, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if got := decoded["prompt_cache_key"]; got != pr.LegacyCacheBustKey || got == "caller" {
+		t.Fatalf("off-mode sealed prompt_cache_key = %v, prepared = %q", got, pr.LegacyCacheBustKey)
+	}
+}

--- a/coordinator/api/cache_selection_telemetry_test.go
+++ b/coordinator/api/cache_selection_telemetry_test.go
@@ -1,0 +1,84 @@
+package api
+
+import (
+	"math"
+	"strings"
+	"testing"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+	"github.com/eigeninference/d-inference/coordinator/registry"
+)
+
+func TestCacheSelectionTTFTSampleActiveNonHit(t *testing.T) {
+	pr := &registry.PendingRequest{
+		RequestID:          "must-not-be-tagged",
+		CacheRoute:         registry.CacheRoute{ExactKey: "must-not-be-tagged-route"},
+		CacheSelectionMode: "active", CacheSelectionKind: "exact", CacheSelectionTier: "ssd",
+		CacheSelectionSelected: true,
+	}
+	usage := protocol.UsageInfo{CacheOutcome: "miss_absent"}
+	value, tags, ok := cacheSelectionTTFTSample(pr, usage, true, 321.5)
+	if !ok || value != 321.5 {
+		t.Fatalf("sample = %v tags=%v ok=%t, want 321.5", value, tags, ok)
+	}
+	joined := strings.Join(tags, ",")
+	for _, want := range []string{"mode:active", "kind:exact", "tier:ssd", "selected:true", "result:non_hit"} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("TTFT tags %q missing %q", joined, want)
+		}
+	}
+	for _, secret := range []string{pr.RequestID, pr.CacheRoute.ExactKey} {
+		if strings.Contains(joined, secret) {
+			t.Fatalf("TTFT tags leaked identifier %q: %q", secret, joined)
+		}
+	}
+}
+
+func TestCacheSelectionTTFTSampleRejectsUnauthoritativeInputs(t *testing.T) {
+	pr := &registry.PendingRequest{CacheSelectionMode: "active", CacheSelectionSelected: true}
+	usage := protocol.UsageInfo{CacheOutcome: "miss_absent"}
+	for _, tc := range []struct {
+		name  string
+		valid bool
+		ttft  float64
+	}{
+		{name: "invalid_usage", valid: false, ttft: 100},
+		{name: "missing_timing", valid: true, ttft: 0},
+		{name: "negative_timing", valid: true, ttft: -1},
+		{name: "nan_timing", valid: true, ttft: math.NaN()},
+		{name: "infinite_timing", valid: true, ttft: math.Inf(1)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, _, ok := cacheSelectionTTFTSample(pr, usage, tc.valid, tc.ttft); ok {
+				t.Fatal("emitted unauthoritative TTFT sample")
+			}
+		})
+	}
+}
+
+func TestObserveCacheSelectionTTFTIsBaselineNotPrecision(t *testing.T) {
+	collector := newUDPCollector(t)
+	defer collector.Close()
+	ddClient := newTestDD(t, collector)
+	defer ddClient.Close()
+	srv := &Server{}
+	srv.SetDatadog(ddClient)
+
+	pr := &registry.PendingRequest{
+		CacheRoute:         registry.CacheRoute{ExactKey: "secret"},
+		CacheSelectionMode: "observe", CacheSelectionKind: "conversation_explicit", CacheSelectionTier: "memory",
+		CacheSelectionSelected: true, CacheSelectionWouldChange: true,
+	}
+	usage := protocol.UsageInfo{CacheOutcome: "miss_absent"}
+	srv.emitCacheSelectionTerminal(pr, usage, true, true)
+	srv.emitCacheSelectionTTFT(pr, usage, true, 250)
+	_ = ddClient.Statsd.Flush()
+	packets := collector.drain()
+
+	if !hasMetric(packets, "routing.cache_selection_ttft_ms:250") || !hasMetric(packets, "selected:false") || !hasMetric(packets, "result:non_hit") {
+		t.Fatalf("observe TTFT was not emitted as baseline-only: %v", packets)
+	}
+	if hasMetric(packets, "routing.cache_selection_precision") {
+		t.Fatalf("observe hypothetical candidate emitted a precision metric: %v", packets)
+	}
+}

--- a/coordinator/api/cache_terminal_idempotence_test.go
+++ b/coordinator/api/cache_terminal_idempotence_test.go
@@ -1,0 +1,62 @@
+package api
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+	"github.com/eigeninference/d-inference/coordinator/registry"
+)
+
+func cacheTelemetryPending(id string) *registry.PendingRequest {
+	return &registry.PendingRequest{
+		RequestID:          id,
+		CacheRoute:         registry.CacheRoute{ExactKey: "secret-route-" + id},
+		CacheSelectionMode: "active", CacheSelectionKind: "exact", CacheSelectionTier: "memory",
+		CacheSelectionSelected: true,
+	}
+}
+
+func TestCacheTerminalTelemetryIsIdempotentAcrossTerminalSeams(t *testing.T) {
+	collector := newUDPCollector(t)
+	defer collector.Close()
+	ddClient := newTestDD(t, collector)
+	defer ddClient.Close()
+	srv := &Server{}
+	srv.SetDatadog(ddClient)
+
+	// Models a synthetic WebSocket disconnect consumed through ErrorCh: the
+	// consumer's final route outcome is the only terminal seam.
+	disconnected := cacheTelemetryPending("disconnect-secret")
+	srv.updateInferenceRouteOutcomeForPending(disconnected, pendingRouteOutcome(disconnected, finalStatusError, "provider_disconnect_pre_commit", 502))
+	// A racing provider error or late duplicate consumer update must not count it again.
+	srv.emitCacheSelectionTerminal(disconnected, protocol.UsageInfo{}, false, false)
+	srv.updateInferenceRouteOutcomeForPending(disconnected, pendingRouteOutcome(disconnected, finalStatusError, "provider_disconnect_pre_commit", 502))
+
+	// A post-commit parked request has no final consumer outcome before its
+	// provider completion. The validated completion must therefore still count.
+	parked := cacheTelemetryPending("parked-secret")
+	srv.updateInferenceRouteOutcomeForPending(parked, committedRouteOutcome(parked))
+	validHit := protocol.UsageInfo{
+		PromptTokens: 10, CacheOutcome: "hit", CacheTier: "memory",
+		CachedTokens: 4, PrefillTokensSaved: 3,
+	}
+	srv.emitCacheSelectionTerminal(parked, validHit, true, true)
+	srv.emitCacheSelectionTerminal(parked, validHit, true, true)
+
+	_ = ddClient.Statsd.Flush()
+	packets := collector.drain()
+	terminal := findMetrics(packets, "routing.cache_selection_terminal")
+	if len(terminal) != 2 {
+		t.Fatalf("terminal cache metrics = %d, want one disconnect + one parked completion: %v", len(terminal), packets)
+	}
+	if !hasMetric(terminal, "result:unreported") || !hasMetric(terminal, "result:hit") {
+		t.Fatalf("terminal outcomes missing disconnect or parked completion: %v", terminal)
+	}
+	joined := strings.Join(terminal, "\n")
+	for _, secret := range []string{disconnected.RequestID, disconnected.CacheRoute.ExactKey, parked.RequestID, parked.CacheRoute.ExactKey} {
+		if strings.Contains(joined, secret) {
+			t.Fatalf("terminal cache metric leaked identifier %q: %s", secret, joined)
+		}
+	}
+}

--- a/coordinator/api/cache_usage_test.go
+++ b/coordinator/api/cache_usage_test.go
@@ -52,22 +52,89 @@ func TestCacheUsagePropagatesToOpenAIResponses(t *testing.T) {
 		t.Fatalf("Responses cached usage = %+v", responses.Usage)
 	}
 
-	obj := map[string]any{"usage": map[string]any{"prompt_tokens": 100}, "choices": []any{}}
+	obj := map[string]any{"usage": map[string]any{
+		"prompt_tokens":         100,
+		"prompt_tokens_details": map[string]any{"cached_tokens": 999, "audio_tokens": 3},
+	}, "choices": []any{}}
 	line := finalizeUsageChunk(obj, usage, &registry.PendingRequest{Model: "model", PublicModel: "model"})
 	var decoded map[string]any
 	if err := json.Unmarshal([]byte(strings.TrimPrefix(line, "data: ")), &decoded); err != nil {
 		t.Fatal(err)
 	}
 	details := decoded["usage"].(map[string]any)["prompt_tokens_details"].(map[string]any)
-	if details["cached_tokens"] != float64(80) {
+	if details["cached_tokens"] != float64(80) || details["audio_tokens"] != float64(3) {
 		t.Fatalf("stream cached usage = %+v", details)
 	}
 
-	raw := map[string]any{"usage": map[string]any{"prompt_tokens": 100}}
+	raw := map[string]any{"usage": map[string]any{"prompt_tokens": 100, "prompt_tokens_details": map[string]any{"cached_tokens": 999, "audio_tokens": 3}}}
 	injectCacheDetailIntoRawUsage(raw, usage)
 	rawDetails := raw["usage"].(map[string]any)["prompt_tokens_details"].(map[string]any)
-	if rawDetails["cached_tokens"] != 80 {
+	if rawDetails["cached_tokens"] != 80 || rawDetails["audio_tokens"] != 3 {
 		t.Fatalf("raw complete cached usage = %+v", rawDetails)
+	}
+}
+
+func TestTerminalCacheUsageRemovesUntrustedRawDetails(t *testing.T) {
+	zero := protocol.UsageInfo{PromptTokens: 100, CompletionTokens: 2}
+
+	chat := map[string]any{"usage": map[string]any{
+		"prompt_tokens_details": map[string]any{"cached_tokens": 999, "audio_tokens": 3},
+	}}
+	injectCacheDetailIntoRawUsage(chat, zero)
+	chatDetails := chat["usage"].(map[string]any)["prompt_tokens_details"].(map[string]any)
+	if _, exists := chatDetails["cached_tokens"]; exists || chatDetails["audio_tokens"] != 3 {
+		t.Fatalf("raw chat details were not selectively sanitized: %+v", chatDetails)
+	}
+
+	streamObj := map[string]any{
+		"choices": []any{},
+		"usage":   map[string]any{"prompt_tokens_details": map[string]any{"cached_tokens": 999, "audio_tokens": 3}},
+	}
+	line := finalizeUsageChunk(streamObj, zero, &registry.PendingRequest{Model: "model"})
+	var streamed map[string]any
+	if err := json.Unmarshal([]byte(strings.TrimPrefix(line, "data: ")), &streamed); err != nil {
+		t.Fatal(err)
+	}
+	streamDetails := streamed["usage"].(map[string]any)["prompt_tokens_details"].(map[string]any)
+	if _, exists := streamDetails["cached_tokens"]; exists || streamDetails["audio_tokens"] != float64(3) {
+		t.Fatalf("held streaming details were not sanitized: %+v", streamDetails)
+	}
+
+	responses := map[string]any{"usage": map[string]any{
+		"input_tokens_details": map[string]any{"cached_tokens": 999, "audio_tokens": 3},
+	}}
+	sanitizeCacheDetailIntoRawResponsesUsage(responses, zero)
+	responseDetails := responses["usage"].(map[string]any)["input_tokens_details"].(map[string]any)
+	if _, exists := responseDetails["cached_tokens"]; exists || responseDetails["audio_tokens"] != 3 {
+		t.Fatalf("native Responses details were not sanitized: %+v", responseDetails)
+	}
+
+	valid := protocol.UsageInfo{PromptTokens: 100, CacheOutcome: "hit", CacheTier: "memory", CachedTokens: 40, PrefillTokensSaved: 35}
+	sanitizeCacheDetailIntoRawResponsesUsage(responses, valid)
+	if got := responseDetails["cached_tokens"]; got != 40 {
+		t.Fatalf("native Responses cached_tokens = %v, want authoritative 40", got)
+	}
+}
+
+func TestCacheSelectionTerminalTagsAreLowCardinalityAndCorrelated(t *testing.T) {
+	pr := &registry.PendingRequest{
+		CacheRoute:         registry.CacheRoute{ExactKey: "secret-route-key"},
+		CacheSelectionMode: "observe", CacheSelectionKind: "exact", CacheSelectionTier: "ssd",
+		CacheSelectionDiscountMs: 42, CacheSelectionWouldChange: true,
+	}
+	tags := cacheSelectionTerminalTags(pr, protocol.UsageInfo{CacheOutcome: "miss_absent"}, true, true)
+	joined := strings.Join(tags, ",")
+	for _, want := range []string{"mode:observe", "kind:exact", "tier:ssd", "selected:false", "would_change:true", "result:non_hit"} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("terminal selection tags %q missing %q", joined, want)
+		}
+	}
+	if strings.Contains(joined, "secret-route-key") {
+		t.Fatalf("terminal selection tags leaked a route key: %q", joined)
+	}
+	invalid := strings.Join(cacheSelectionTerminalTags(pr, protocol.UsageInfo{}, false, true), ",")
+	if !strings.Contains(invalid, "result:invalid") {
+		t.Fatalf("invalid terminal usage was not correlated: %q", invalid)
 	}
 }
 

--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -866,11 +866,25 @@ func (s *Server) dispatchOneProvider(
 		return nil, nil, decision, "failed to generate session keys", http.StatusInternalServerError
 	}
 
+	if err := s.registry.PrepareCacheAttempt(pr, provider); err != nil {
+		s.registry.ForgetCacheAttempt(pr)
+		refundExtra()
+		cleanupPending()
+		return nil, nil, decision, "failed to prepare cache-safe request", http.StatusInternalServerError
+	}
 	// Pre-fix providers crash on a vision request carrying sampling penalties;
-	// strip them for those providers only (see bodyForProvider).
-	sealedBody := bodyForProvider(rawBody, requiresVision, provider)
+	// strip them for those providers only. Protocol-0 providers additionally get
+	// a coordinator-authored prompt_cache_key only inside this sealed body.
+	sealedBody, err := bodyForCacheAttempt(rawBody, requiresVision, provider, pr)
+	if err != nil {
+		s.registry.ForgetCacheAttempt(pr)
+		refundExtra()
+		cleanupPending()
+		return nil, nil, decision, "failed to prepare provider request", http.StatusInternalServerError
+	}
 	encrypted, err := e2e.Encrypt(sealedBody, providerPubKey, sessionKeys)
 	if err != nil {
+		s.registry.ForgetCacheAttempt(pr)
 		refundExtra()
 		cleanupPending()
 		return nil, nil, decision, "failed to encrypt request", http.StatusInternalServerError
@@ -878,12 +892,6 @@ func (s *Server) dispatchOneProvider(
 	if pr.Timing != nil {
 		pr.Timing.EncryptedAt = time.Now()
 	}
-	if err := s.registry.PrepareCacheAttempt(pr, provider); err != nil {
-		s.registry.ForgetCacheAttempt(pr)
-		s.ddIncr("routing.cache_prepare_error", nil)
-		s.logger.Warn("cache routing attempt disabled", "request_id", requestID, "provider_id", provider.ID, "error", err)
-	}
-
 	wireMsg := map[string]any{
 		"type":       protocol.TypeInferenceRequest,
 		"request_id": requestID,
@@ -963,6 +971,30 @@ func bodyForProvider(rawBody []byte, requiresVision bool, provider *registry.Pro
 		return stripped
 	}
 	return rawBody
+}
+
+func bodyForCacheAttempt(rawBody []byte, requiresVision bool, provider *registry.Provider, pr *registry.PendingRequest) ([]byte, error) {
+	body := bodyForProvider(rawBody, requiresVision, provider)
+	if pr == nil || pr.LegacyCacheBustKey == "" {
+		return body, nil
+	}
+	var parsed map[string]json.RawMessage
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return nil, err
+	}
+	keyJSON, err := json.Marshal(pr.LegacyCacheBustKey)
+	if err != nil {
+		return nil, err
+	}
+	parsed["prompt_cache_key"] = keyJSON
+	sealed, err := marshalForwardBody(parsed)
+	if err != nil {
+		return nil, err
+	}
+	if len(sealed) > maxInferenceBodyBytes {
+		return nil, fmt.Errorf("provider request body exceeds the %d-byte limit after cache isolation", maxInferenceBodyBytes)
+	}
+	return sealed, nil
 }
 
 // defaultMaxOutputTokens is the ceiling injected into requests that don't set
@@ -1645,6 +1677,7 @@ func (s *Server) handleStreamingResponseWithFirstChunk(w http.ResponseWriter, r 
 		if firstChunk == "" || isSSEDoneChunk(firstChunk) {
 			continue
 		}
+		firstChunk = sanitizeStreamCacheDetails(firstChunk)
 		if isResponsesAPIEventChunk(firstChunk) {
 			sawResponsesAPI = true
 		}
@@ -1784,6 +1817,7 @@ func (s *Server) handleStreamingResponseWithFirstChunk(w http.ResponseWriter, r 
 					sawResponsesAPI = true
 				}
 			}
+			chunk = sanitizeStreamCacheDetails(chunk)
 			// Swallow the provider's own "data: [DONE]" terminator. The
 			// coordinator appends terminal events of its own (held usage with
 			// the reasoning breakdown, SE signature) and then emits exactly ONE
@@ -1868,7 +1902,7 @@ func (s *Server) handleResponsesStreamingResponseWithFirstChunk(w http.ResponseW
 
 	for _, firstChunk := range firstChunks {
 		if firstChunk != "" {
-			emitter.handleChunk(firstChunk)
+			emitter.handleChunk(sanitizeStreamCacheDetails(firstChunk))
 		}
 	}
 
@@ -1899,7 +1933,7 @@ func (s *Server) handleResponsesStreamingResponseWithFirstChunk(w http.ResponseW
 				emitter.finish(usage)
 				return
 			}
-			emitter.handleChunk(chunk)
+			emitter.handleChunk(sanitizeStreamCacheDetails(chunk))
 			if !timer.Stop() {
 				select {
 				case <-timer.C:
@@ -2034,6 +2068,7 @@ func (s *Server) handleNonStreamingResponseWithFirstChunk(w http.ResponseWriter,
 								// Native passthrough (object=="response"): the provider
 								// echoed the concrete build id; rewrite it to the public
 								// alias so the consumer never sees the quant/build.
+								sanitizeCacheDetailIntoRawResponsesUsage(obj, completeUsage)
 								if pr.PublicModel != "" {
 									obj["model"] = consumerModel(pr)
 								}
@@ -2479,21 +2514,180 @@ func injectReasoningDetailIntoRawUsage(obj map[string]any, usage protocol.UsageI
 }
 
 func injectCacheDetailIntoRawUsage(obj map[string]any, usage protocol.UsageInfo) {
-	if usage.CachedTokens <= 0 {
-		return
-	}
 	usageObj, ok := obj["usage"].(map[string]any)
 	if !ok {
 		return
 	}
-	details, _ := usageObj["prompt_tokens_details"].(map[string]any)
+	details, detailsOK := usageObj["prompt_tokens_details"].(map[string]any)
 	if details == nil {
+		if usage.CachedTokens <= 0 {
+			// A malformed/non-object provider detail cannot be selectively
+			// sanitized, so remove it rather than forwarding untrusted cache data.
+			if !detailsOK {
+				delete(usageObj, "prompt_tokens_details")
+			}
+			return
+		}
 		details = map[string]any{}
 	}
-	if _, exists := details["cached_tokens"]; !exists {
+	if usage.CachedTokens > 0 {
 		details["cached_tokens"] = usage.CachedTokens
+	} else {
+		delete(details, "cached_tokens")
 	}
-	usageObj["prompt_tokens_details"] = details
+	if len(details) == 0 {
+		delete(usageObj, "prompt_tokens_details")
+	} else {
+		usageObj["prompt_tokens_details"] = details
+	}
+}
+
+func sanitizeCacheDetailIntoRawResponsesUsage(obj map[string]any, usage protocol.UsageInfo) {
+	usageObj, ok := obj["usage"].(map[string]any)
+	if !ok {
+		return
+	}
+	details, detailsOK := usageObj["input_tokens_details"].(map[string]any)
+	if details == nil {
+		if usage.CachedTokens <= 0 {
+			if !detailsOK {
+				delete(usageObj, "input_tokens_details")
+			}
+			return
+		}
+		details = map[string]any{}
+	}
+	if usage.CachedTokens > 0 {
+		details["cached_tokens"] = usage.CachedTokens
+	} else {
+		delete(details, "cached_tokens")
+	}
+	if len(details) == 0 {
+		delete(usageObj, "input_tokens_details")
+	} else {
+		usageObj["input_tokens_details"] = details
+	}
+}
+
+func removeCachedTokenDetail(usageObj map[string]any, detailField string) bool {
+	details, ok := usageObj[detailField].(map[string]any)
+	if !ok || details == nil {
+		return false
+	}
+	if _, exists := details["cached_tokens"]; !exists {
+		return false
+	}
+	delete(details, "cached_tokens")
+	if len(details) == 0 {
+		delete(usageObj, detailField)
+	} else {
+		usageObj[detailField] = details
+	}
+	return true
+}
+
+func sanitizeStreamCacheDetailsJSON(raw string) (string, bool) {
+	var obj map[string]any
+	if json.Unmarshal([]byte(raw), &obj) != nil {
+		return raw, false
+	}
+	changed := false
+	if usageObj, ok := obj["usage"].(map[string]any); ok {
+		changed = removeCachedTokenDetail(usageObj, "prompt_tokens_details") || changed
+		changed = removeCachedTokenDetail(usageObj, "input_tokens_details") || changed
+	}
+	if response, ok := obj["response"].(map[string]any); ok {
+		if usageObj, ok := response["usage"].(map[string]any); ok {
+			changed = removeCachedTokenDetail(usageObj, "prompt_tokens_details") || changed
+			changed = removeCachedTokenDetail(usageObj, "input_tokens_details") || changed
+		}
+	}
+	if !changed {
+		return raw, false
+	}
+	b, err := marshalForwardBody(obj)
+	if err != nil {
+		return raw, false
+	}
+	return string(b), true
+}
+
+func sseDataValue(line string) (string, bool) {
+	colon := strings.IndexByte(line, ':')
+	field, value := line, ""
+	if colon >= 0 {
+		field, value = line[:colon], line[colon+1:]
+		if strings.HasPrefix(value, " ") {
+			value = value[1:]
+		}
+	}
+	return value, field == "data"
+}
+
+func sanitizeStreamCacheEventGroup(group string) (string, bool) {
+	lines := strings.Split(group, "\n")
+	data := make([]string, 0, len(lines))
+	firstData := -1
+	for i, line := range lines {
+		if value, ok := sseDataValue(line); ok {
+			if firstData < 0 {
+				firstData = i
+			}
+			data = append(data, value)
+		}
+	}
+	if firstData < 0 {
+		if len(lines) == 1 {
+			if sanitized, ok := sanitizeStreamCacheDetailsJSON(strings.TrimSpace(group)); ok {
+				return sanitized, true
+			}
+		}
+		return group, false
+	}
+	sanitized, changed := sanitizeStreamCacheDetailsJSON(strings.Join(data, "\n"))
+	if !changed {
+		return group, false
+	}
+	out := make([]string, 0, len(lines)-len(data)+1)
+	for i, line := range lines {
+		if _, ok := sseDataValue(line); ok {
+			if i == firstData {
+				out = append(out, "data: "+sanitized)
+			}
+			continue
+		}
+		out = append(out, line)
+	}
+	return strings.Join(out, "\n"), true
+}
+
+// sanitizeStreamCacheDetails removes provider-supplied cached_tokens from any
+// streamed frame before it can reach the consumer. SSE data fields are joined
+// per the specification across each blank-line-delimited event, then a changed
+// payload is emitted as one safe data line while event/id/comments are retained.
+// Terminal usage is validated independently and re-added only to the held usage
+// frame at stream completion.
+func sanitizeStreamCacheDetails(chunk string) string {
+	// A normal field takes the literal fast path. A disguised equivalent must use
+	// a JSON Unicode escape (for example cached\u005ftokens); no other valid JSON
+	// escape can encode an ASCII letter or underscore. Parse those frames too,
+	// while leaving the overwhelmingly common escape-free content frame untouched.
+	if !strings.Contains(chunk, `"cached_tokens"`) && !strings.Contains(chunk, `\u`) {
+		return chunk
+	}
+	normalized := strings.ReplaceAll(strings.ReplaceAll(chunk, "\r\n", "\n"), "\r", "\n")
+	groups := strings.Split(normalized, "\n\n")
+	changed := false
+	for i, group := range groups {
+		if sanitized, ok := sanitizeStreamCacheEventGroup(group); ok {
+			groups[i] = sanitized
+			changed = true
+		}
+	}
+	if changed {
+		return strings.Join(groups, "\n\n")
+	}
+	return chunk
 }
 
 // parseUsageOnlyStreamChunk decodes a terminal include_usage chunk (empty choices
@@ -3779,11 +3973,31 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 		return
 	}
 
+	if err := s.registry.PrepareCacheAttempt(pr, provider); err != nil {
+		s.registry.ForgetCacheAttempt(pr)
+		cleanupPending()
+		refundExtra()
+		refundReservation()
+		s.ddIncr("routing.cache_prepare_error", nil)
+		s.updateInferenceRouteOutcomeForPending(pr, dispatchFailedPendingRouteOutcome(pr, "provider_error", http.StatusInternalServerError))
+		writeJSON(w, http.StatusInternalServerError, errorResponse("internal_error", "failed to prepare cache-safe request"))
+		return
+	}
 	// Version-gated penalty strip for vision requests (Anthropic /v1/messages
 	// carries image blocks); this handler seals separately from dispatchOneProvider.
-	inferenceBody = bodyForProvider(inferenceBody, requiresVision, provider)
+	inferenceBody, err = bodyForCacheAttempt(inferenceBody, requiresVision, provider, pr)
+	if err != nil {
+		s.registry.ForgetCacheAttempt(pr)
+		cleanupPending()
+		refundExtra()
+		refundReservation()
+		s.updateInferenceRouteOutcomeForPending(pr, dispatchFailedPendingRouteOutcome(pr, "provider_error", http.StatusInternalServerError))
+		writeJSON(w, http.StatusInternalServerError, errorResponse("internal_error", "failed to prepare provider request"))
+		return
+	}
 	encrypted, err := e2e.Encrypt(inferenceBody, providerPubKey, sessionKeys)
 	if err != nil {
+		s.registry.ForgetCacheAttempt(pr)
 		cleanupPending()
 		refundExtra()
 		refundReservation()
@@ -3792,12 +4006,6 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 		return
 	}
 	timing.EncryptedAt = time.Now()
-	if err := s.registry.PrepareCacheAttempt(pr, provider); err != nil {
-		s.registry.ForgetCacheAttempt(pr)
-		s.ddIncr("routing.cache_prepare_error", nil)
-		s.logger.Warn("cache routing attempt disabled", "request_id", requestID, "provider_id", provider.ID, "error", err)
-	}
-
 	wireMsg := map[string]any{
 		"type":       protocol.TypeInferenceRequest,
 		"request_id": requestID,

--- a/coordinator/api/consumer_streaming_usage_test.go
+++ b/coordinator/api/consumer_streaming_usage_test.go
@@ -89,6 +89,90 @@ func TestStreamingChatReasoningTokensInUsage(t *testing.T) {
 	}
 }
 
+func TestStreamingFramesCannotForwardUnvalidatedCachedTokens(t *testing.T) {
+	logger := quietLogger()
+	srv := NewServer(registry.New(logger), store.NewMemory(store.Config{}), ServerConfig{}, logger)
+	pr := &registry.PendingRequest{
+		RequestID:  "cache-stream",
+		Model:      "model",
+		ChunkCh:    make(chan string, 4),
+		ErrorCh:    make(chan protocol.InferenceErrorMessage, 1),
+		CompleteCh: make(chan protocol.UsageInfo, 1),
+	}
+	pr.ChunkCh <- `data: {"object":"chat.completion.chunk","choices":[{"delta":{"content":"hi"},"finish_reason":null}],"usage":{"prompt_tokens_details":{"cached\u005ftokens":999,"audio_tokens":3}}}`
+	pr.ChunkCh <- `data: {"object":"chat.completion.chunk","choices":[{"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens_details":{"\u0063ached_tokens":888,"audio_tokens":4}}}`
+	pr.ChunkCh <- `data: {"object":"chat.completion.chunk","choices":[],"usage":{"prompt_tokens":10,"completion_tokens":2,"total_tokens":12,"prompt_tokens_details":{"cached_\u0074okens":777,"audio_tokens":5}}}`
+	close(pr.ChunkCh)
+	pr.CompleteCh <- protocol.UsageInfo{
+		PromptTokens: 10, CompletionTokens: 2,
+		CacheOutcome: "hit", CacheTier: "memory", CachedTokens: 4, PrefillTokensSaved: 3,
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	srv.handleStreamingResponseWithFirstChunk(rec, req, pr, nil, false)
+	body := rec.Body.String()
+	for _, untrusted := range []string{"999", "888", "777"} {
+		if strings.Contains(body, untrusted) {
+			t.Fatalf("stream forwarded unvalidated cache detail %s: %s", untrusted, body)
+		}
+	}
+	if strings.Count(body, `"cached_tokens":4`) != 1 {
+		t.Fatalf("authoritative terminal cached_tokens not emitted exactly once: %s", body)
+	}
+	for _, preserved := range []string{`"audio_tokens":3`, `"audio_tokens":4`, `"audio_tokens":5`} {
+		if !strings.Contains(body, preserved) {
+			t.Fatalf("stream sanitization removed unrelated detail %s: %s", preserved, body)
+		}
+	}
+}
+
+func TestSanitizeNestedResponsesStreamCacheDetails(t *testing.T) {
+	chunk := "event: response.completed\n" +
+		"id: response-7\n" +
+		": retain this comment\n" +
+		`data: {"type":"response.completed","response":{"usage":{` + "\n" +
+		`data: "input_tokens_details":{"cached\u005ftokens":99,"audio_tokens":7}}}}` + "\n\n"
+	got := sanitizeStreamCacheDetails(chunk)
+	if strings.Contains(got, `"cached_tokens"`) || strings.Contains(got, `cached\u005ftokens`) || strings.Contains(got, "99") {
+		t.Fatalf("nested Responses cached_tokens survived: %s", got)
+	}
+	if !strings.Contains(got, `"audio_tokens":7`) || !strings.Contains(got, "event: response.completed") ||
+		!strings.Contains(got, "id: response-7") || !strings.Contains(got, ": retain this comment") || strings.Count(got, "data:") != 1 {
+		t.Fatalf("nested Responses sanitization removed unrelated content: %s", got)
+	}
+}
+
+func TestSanitizeSplitMultilineChatStreamCacheDetails(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		choices string
+	}{
+		{name: "content", choices: `[{"delta":{"content":"hi"},"finish_reason":null}]`},
+		{name: "finish", choices: `[{"delta":{},"finish_reason":"stop"}]`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			chunk := "event: message\n" +
+				"id: chat-9\n" +
+				": keepalive\n" +
+				`data: {"object":"chat.completion.chunk","choices":` + tc.choices + `,` + "\n" +
+				`data: "usage":{"prompt_tokens_details":{"cached\u005ftokens":123,"audio_tokens":6}}}` + "\n\n"
+			got := sanitizeStreamCacheDetails(chunk)
+			if strings.Contains(got, "123") || strings.Contains(got, `cached\u005ftokens`) || strings.Contains(got, `"cached_tokens"`) {
+				t.Fatalf("split %s frame retained cached_tokens: %s", tc.name, got)
+			}
+			for _, preserved := range []string{`"audio_tokens":6`, "event: message", "id: chat-9", ": keepalive"} {
+				if !strings.Contains(got, preserved) {
+					t.Fatalf("split %s frame lost %q: %s", tc.name, preserved, got)
+				}
+			}
+			if strings.Count(got, "data:") != 1 || !strings.HasSuffix(got, "\n\n") {
+				t.Fatalf("split %s frame was not re-emitted as one data line/event: %q", tc.name, got)
+			}
+		})
+	}
+}
+
 // TestStreamingChatUsageOnlyFirstChunk covers the zero-delta case: a completion
 // that streams no content/reasoning deltas, so the include_usage frame is the very
 // FIRST chunk handed to the handler. It must still be held and have the reasoning

--- a/coordinator/api/dispatch.go
+++ b/coordinator/api/dispatch.go
@@ -445,18 +445,26 @@ func (d *dispatchState) commitFirstContent(pr *registry.PendingRequest, chunk st
 // only known when the provider later sends complete/error; handleComplete or
 // post-commit response handlers update them.
 func (d *dispatchState) successRoutingOutcome() *store.InferenceRouteOutcome {
-	return committedRouteOutcome(d.pr)
+	return d.successRoutingOutcomeFor(d.pr)
+}
+
+func (d *dispatchState) successRoutingOutcomeFor(pr *registry.PendingRequest) *store.InferenceRouteOutcome {
+	return committedRouteOutcome(pr)
 }
 
 // errorRoutingOutcome builds an error / timeout / cancelled outcome.
 func (d *dispatchState) errorRoutingOutcome(status, class string, code int) *store.InferenceRouteOutcome {
+	return d.errorRoutingOutcomeFor(d.pr, status, class, code)
+}
+
+func (d *dispatchState) errorRoutingOutcomeFor(pr *registry.PendingRequest, status, class string, code int) *store.InferenceRouteOutcome {
 	providerReason, errorText := "", ""
 	if routeOutcomeUsesProviderErrorText(class) {
 		providerReason = d.lastErrReason
 		errorText = d.lastErr
 	}
 	out := routeOutcomeWithReason(status, class, code, providerReason, errorText)
-	applyPendingRouteTelemetry(out, d.pr)
+	applyPendingRouteTelemetry(out, pr)
 	return out
 }
 
@@ -509,17 +517,21 @@ func providerReportedBudget(provider *registry.Provider, model string) int64 {
 // pre-dispatch failures (queue reservation DB error, invalid key, keygen, send
 // failure) and coordinator-side timeouts are NOT flagged.
 func (d *dispatchState) providerFailedRoutingOutcome() *store.InferenceRouteOutcome {
+	return d.providerFailedRoutingOutcomeFor(d.pr)
+}
+
+func (d *dispatchState) providerFailedRoutingOutcomeFor(pr *registry.PendingRequest) *store.InferenceRouteOutcome {
 	if isTerminalClientErrorCode(d.lastErrCode) {
 		// Deterministic client-shape 4xx: a malformed/unservable-by-shape request,
 		// not a provider fault. Record as client_error WITHOUT AdmittedButFailed so
 		// it stays out of the admission-mismatch gauge.
-		return d.errorRoutingOutcome("error", errorClassClientError, d.lastErrCode)
+		return d.errorRoutingOutcomeFor(pr, "error", errorClassClientError, d.lastErrCode)
 	}
 	class := "provider_error"
 	if providerDisconnectedError(d.lastErr, d.lastErrCode) {
 		class = "provider_disconnect_pre_commit"
 	}
-	out := d.errorRoutingOutcome("error", class, d.lastErrCode)
+	out := d.errorRoutingOutcomeFor(pr, "error", class, d.lastErrCode)
 	out.AdmittedButFailed = true
 	return out
 }
@@ -604,8 +616,42 @@ func (d *dispatchState) rejectionInfoWithDecision(stage, reason string, status, 
 	return info
 }
 
-// updateRoutingOutcome writes a final outcome update for the current attempt
-// asynchronously. It is a no-op when there is no request ID to correlate.
+// dispatchRoutingAttempt is immutable identity captured before a wait path can
+// clear or promote mutable dispatchState provider/request fields.
+type dispatchRoutingAttempt struct {
+	provider  *registry.Provider
+	pending   *registry.PendingRequest
+	requestID string
+	attempt   int
+}
+
+func routingAttempt(provider *registry.Provider, pr *registry.PendingRequest, requestID string, attempt int) dispatchRoutingAttempt {
+	return dispatchRoutingAttempt{provider: provider, pending: pr, requestID: requestID, attempt: attempt}
+}
+
+func (d *dispatchState) currentOrCapturedRoutingAttempt(captured dispatchRoutingAttempt) dispatchRoutingAttempt {
+	if d.pr == nil {
+		return captured
+	}
+	return routingAttempt(d.provider, d.pr, d.routingOutcomeKey(), d.attempt)
+}
+
+func (d *dispatchState) updateRoutingOutcomeForAttempt(target dispatchRoutingAttempt, outcome *store.InferenceRouteOutcome) {
+	requestID, attempt := target.requestID, target.attempt
+	if requestID == "" {
+		return
+	}
+	providerMatches := target.provider == nil ||
+		(target.pending != nil && target.pending.ProviderID != "" && target.pending.ProviderID == target.provider.ID)
+	if target.pending != nil && target.pending.RequestID == requestID && target.pending.Attempt == attempt && providerMatches {
+		d.s.updateInferenceRouteOutcomeForPending(target.pending, outcome)
+		return
+	}
+	d.s.updateInferenceRouteOutcomeWithModel(requestID, attempt, d.model, outcome)
+}
+
+// updateRoutingOutcome writes an outcome update for the current attempt. It is
+// a no-op when there is no request ID to correlate.
 func (d *dispatchState) updateRoutingOutcome(outcome *store.InferenceRouteOutcome) {
 	requestID := d.routingOutcomeKey()
 	if requestID == "" {
@@ -614,7 +660,7 @@ func (d *dispatchState) updateRoutingOutcome(outcome *store.InferenceRouteOutcom
 	// Capture attempt on the dispatch goroutine: the closure runs on a telemetry
 	// sink worker, while run()'s retry loop concurrently advances d.attempt.
 	attempt := d.attempt
-	d.s.updateInferenceRouteOutcomeWithModel(requestID, attempt, d.model, outcome)
+	d.updateRoutingOutcomeForAttempt(routingAttempt(d.provider, d.pr, requestID, attempt), outcome)
 }
 
 func (d *dispatchState) markSpeculativeLoser(pr *registry.PendingRequest) {
@@ -962,11 +1008,30 @@ func (d *dispatchState) dispatchPrimary() dispatchOutcome {
 			d.updateRoutingOutcome(d.errorRoutingOutcome("error", "provider_error", 0))
 			return outcomeRetry
 		}
-		// Version-gated penalty strip (see bodyForProvider). The queued path seals
-		// here, separately from dispatchOneProvider.
-		sealedBody := bodyForProvider(d.rawBody, d.requiresVision, d.provider)
+		if err := s.registry.PrepareCacheAttempt(d.pr, d.provider); err != nil {
+			s.registry.ForgetCacheAttempt(d.pr)
+			d.provider.RemovePending(d.requestID)
+			s.registry.SetProviderIdle(d.provider.ID)
+			s.refundProviderExtra(d.pr)
+			d.setLastError("failed to prepare cache-safe request", http.StatusInternalServerError)
+			d.updateRoutingOutcome(d.errorRoutingOutcome("error", "provider_error", http.StatusInternalServerError))
+			return outcomeRetry
+		}
+		// Version-gated penalty strip plus protocol-0 cache isolation. The queued
+		// path seals here, separately from dispatchOneProvider.
+		sealedBody, err := bodyForCacheAttempt(d.rawBody, d.requiresVision, d.provider, d.pr)
+		if err != nil {
+			s.registry.ForgetCacheAttempt(d.pr)
+			d.provider.RemovePending(d.requestID)
+			s.registry.SetProviderIdle(d.provider.ID)
+			s.refundProviderExtra(d.pr)
+			d.setLastError("failed to prepare provider request", http.StatusInternalServerError)
+			d.updateRoutingOutcome(d.errorRoutingOutcome("error", "provider_error", http.StatusInternalServerError))
+			return outcomeRetry
+		}
 		encrypted, err := e2e.Encrypt(sealedBody, providerPubKey, sessionKeys)
 		if err != nil {
+			s.registry.ForgetCacheAttempt(d.pr)
 			d.provider.RemovePending(d.requestID)
 			s.registry.SetProviderIdle(d.provider.ID)
 			s.refundProviderExtra(d.pr)
@@ -975,11 +1040,6 @@ func (d *dispatchState) dispatchPrimary() dispatchOutcome {
 			return outcomeRetry
 		}
 		d.timing.EncryptedAt = time.Now()
-		if err := s.registry.PrepareCacheAttempt(d.pr, d.provider); err != nil {
-			s.registry.ForgetCacheAttempt(d.pr)
-			s.ddIncr("routing.cache_prepare_error", nil)
-			s.logger.Warn("cache routing attempt disabled", "request_id", d.requestID, "provider_id", d.provider.ID, "error", err)
-		}
 		wireMsg := map[string]any{
 			"type":       protocol.TypeInferenceRequest,
 			"request_id": d.requestID,
@@ -1143,21 +1203,23 @@ func (d *dispatchState) waitFirstChunk() (outcome dispatchOutcome) {
 	s := d.s
 	r := d.r
 	provider, pr := d.provider, d.pr
+	captured := routingAttempt(provider, pr, pr.RequestID, pr.Attempt)
 
 	defer func() {
+		target := d.currentOrCapturedRoutingAttempt(captured)
 		switch outcome {
 		case outcomeCommitted:
-			d.updateRoutingOutcome(d.successRoutingOutcome())
+			d.updateRoutingOutcomeForAttempt(target, d.successRoutingOutcomeFor(target.pending))
 		case outcomeRetry:
 			if d.lastErrCode == http.StatusGatewayTimeout {
-				d.updateRoutingOutcome(d.errorRoutingOutcome("timeout", "first_chunk_timeout", d.lastErrCode))
+				d.updateRoutingOutcomeForAttempt(target, d.errorRoutingOutcomeFor(target.pending, "timeout", "first_chunk_timeout", d.lastErrCode))
 			} else {
 				// Post-dispatch provider failure (incl. OOM/model-load): admitted but failed.
-				d.updateRoutingOutcome(d.providerFailedRoutingOutcome())
+				d.updateRoutingOutcomeForAttempt(target, d.providerFailedRoutingOutcomeFor(target.pending))
 			}
 		case outcomeClientGone:
 			d.emitClientGone(phaseBeforeFirstToken)
-			d.updateRoutingOutcome(d.errorRoutingOutcome("cancelled", "client_gone", 0))
+			d.updateRoutingOutcomeForAttempt(target, d.errorRoutingOutcomeFor(target.pending, "cancelled", "client_gone", 0))
 		}
 	}()
 
@@ -1965,25 +2027,27 @@ func (d *dispatchState) waitAccepted() (outcome dispatchOutcome) {
 	s := d.s
 	r := d.r
 	provider, pr := d.provider, d.pr
+	captured := routingAttempt(provider, pr, pr.RequestID, pr.Attempt)
 
 	defer func() {
+		target := d.currentOrCapturedRoutingAttempt(captured)
 		switch outcome {
 		case outcomeCommitted:
-			d.updateRoutingOutcome(d.successRoutingOutcome())
+			d.updateRoutingOutcomeForAttempt(target, d.successRoutingOutcomeFor(target.pending))
 		case outcomeRetry:
 			if d.lastErrCode == http.StatusGatewayTimeout {
 				if d.preambleLiveness {
-					d.updateRoutingOutcome(d.errorRoutingOutcome("timeout", "preamble_liveness_timeout", d.lastErrCode))
+					d.updateRoutingOutcomeForAttempt(target, d.errorRoutingOutcomeFor(target.pending, "timeout", "preamble_liveness_timeout", d.lastErrCode))
 				} else {
-					d.updateRoutingOutcome(d.errorRoutingOutcome("timeout", "accepted_timeout", d.lastErrCode))
+					d.updateRoutingOutcomeForAttempt(target, d.errorRoutingOutcomeFor(target.pending, "timeout", "accepted_timeout", d.lastErrCode))
 				}
 			} else {
 				// Post-dispatch provider failure (incl. OOM/model-load): admitted but failed.
-				d.updateRoutingOutcome(d.providerFailedRoutingOutcome())
+				d.updateRoutingOutcomeForAttempt(target, d.providerFailedRoutingOutcomeFor(target.pending))
 			}
 		case outcomeClientGone:
 			d.emitClientGone(phaseBeforeFirstToken)
-			d.updateRoutingOutcome(d.errorRoutingOutcome("cancelled", "client_gone", 0))
+			d.updateRoutingOutcomeForAttempt(target, d.errorRoutingOutcomeFor(target.pending, "cancelled", "client_gone", 0))
 		}
 	}()
 
@@ -2393,6 +2457,10 @@ func adjustLatencyForPrefill(raw time.Duration, promptTokens int, prefillTPS flo
 	return raw
 }
 
+func shouldRecordReputationLatency(pr *registry.PendingRequest, firstChunk string) bool {
+	return pr != nil && pr.Timing != nil && firstChunk != "" && !pr.CacheRoutingParticipates()
+}
+
 func (d *dispatchState) writeCommittedResponse() {
 	s := d.s
 	w, r := d.w, d.r
@@ -2414,7 +2482,7 @@ func (d *dispatchState) writeCommittedResponse() {
 	// prompt-size prefill is removed using the coordinator-side prompt estimate
 	// (known up front, adequate for normalization) and the provider's benchmarked
 	// PrefillTPS (set once at registration, read-only thereafter).
-	if pr.Timing != nil && d.firstChunk != "" {
+	if shouldRecordReputationLatency(pr, d.firstChunk) {
 		// FirstContentAt was already stamped at the content-commit site
 		// (commitFirstContent), earlier in THIS goroutine, so contentLatency reads
 		// a set value here. No re-stamp needed; just read it for the reputation

--- a/coordinator/api/dispatch.go
+++ b/coordinator/api/dispatch.go
@@ -440,14 +440,6 @@ func (d *dispatchState) commitFirstContent(pr *registry.PendingRequest, chunk st
 	}
 }
 
-// successRoutingOutcome builds a success outcome for the committed attempt.
-// Token counts and final_status are left empty because the final terminal is
-// only known when the provider later sends complete/error; handleComplete or
-// post-commit response handlers update them.
-func (d *dispatchState) successRoutingOutcome() *store.InferenceRouteOutcome {
-	return d.successRoutingOutcomeFor(d.pr)
-}
-
 func (d *dispatchState) successRoutingOutcomeFor(pr *registry.PendingRequest) *store.InferenceRouteOutcome {
 	return committedRouteOutcome(pr)
 }

--- a/coordinator/api/dispatch_cache_terminal_test.go
+++ b/coordinator/api/dispatch_cache_terminal_test.go
@@ -1,0 +1,78 @@
+package api
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+	"github.com/eigeninference/d-inference/coordinator/registry"
+	"github.com/eigeninference/d-inference/coordinator/store"
+)
+
+func TestWaitFirstChunkDeferredRetryUsesCapturedCacheTerminal(t *testing.T) {
+	collector := newUDPCollector(t)
+	defer collector.Close()
+	ddClient := newTestDD(t, collector)
+	defer ddClient.Close()
+	logger := quietLogger()
+	reg := registry.New(logger)
+	srv := NewServer(reg, store.NewMemory(store.Config{}), ServerConfig{}, logger)
+	srv.SetDatadog(ddClient)
+	provider := reg.Register("disconnect-provider", nil, &protocol.RegisterMessage{
+		Models: []protocol.ModelInfo{{ID: "model", ModelType: "chat"}},
+	})
+
+	pr := &registry.PendingRequest{
+		RequestID: "disconnect-request", Attempt: 2, ProviderID: provider.ID, Model: "model",
+		CacheRoute:         registry.CacheRoute{ExactKey: "secret-route"},
+		CacheSelectionMode: "active", CacheSelectionKind: "exact", CacheSelectionTier: "memory",
+		CacheSelectionSelected: true,
+		AcceptedCh:             make(chan struct{}, 1),
+		ChunkCh:                make(chan string, 1),
+		CompleteCh:             make(chan protocol.UsageInfo, 1),
+		ErrorCh:                make(chan protocol.InferenceErrorMessage, 1),
+	}
+	provider.AddPending(pr)
+	pr.ErrorCh <- protocol.InferenceErrorMessage{
+		Type: protocol.TypeInferenceError, RequestID: pr.RequestID,
+		Error: "provider disconnected", StatusCode: 502,
+	}
+	d := &dispatchState{
+		s: srv, r: httptest.NewRequest("POST", "/v1/chat/completions", nil),
+		model: pr.Model, provider: provider, pr: pr, requestID: pr.RequestID, attempt: pr.Attempt,
+		speculativeAt: time.Hour, deadline: time.Hour,
+		excludeProviders: make(map[string]struct{}),
+	}
+	if outcome := d.waitFirstChunk(); outcome != outcomeRetry || d.pr != nil || d.provider != nil {
+		t.Fatalf("waitFirstChunk outcome=%v pr=%v provider=%v, want retry with mutable state cleared", outcome, d.pr, d.provider)
+	}
+	// A duplicate provider terminal racing afterward must not emit again.
+	srv.emitCacheSelectionTerminal(pr, protocol.UsageInfo{
+		PromptTokens: 10, CacheOutcome: "hit", CacheTier: "memory",
+		CachedTokens: 4, PrefillTokensSaved: 3,
+	}, true, true)
+
+	_ = ddClient.Statsd.Flush()
+	packets := collector.drain()
+	terminal := findMetrics(packets, "routing.cache_selection_terminal")
+	if len(terminal) != 1 || !hasMetric(terminal, "result:unreported") {
+		t.Fatalf("synthetic disconnect terminal metrics = %v, want one unreported", terminal)
+	}
+	if strings.Contains(strings.Join(terminal, "\n"), pr.RequestID) || strings.Contains(strings.Join(terminal, "\n"), pr.CacheRoute.ExactKey) {
+		t.Fatalf("synthetic disconnect metric leaked identifiers: %v", terminal)
+	}
+}
+
+func TestDispatchRoutingOutcomePreservesMismatchedPendingFallback(t *testing.T) {
+	pr := cacheTelemetryPending("other-request")
+	d := &dispatchState{
+		s: &Server{}, model: "model", pr: pr,
+		requestID: "current-request", attempt: pr.Attempt + 1,
+	}
+	d.updateRoutingOutcome(routeOutcome(finalStatusError, "provider_error", 502))
+	if !pr.MarkCacheTerminalTelemetryEmitted() {
+		t.Fatal("mismatched pending request incorrectly consumed cache terminal hook")
+	}
+}

--- a/coordinator/api/provider.go
+++ b/coordinator/api/provider.go
@@ -655,6 +655,90 @@ func hasCacheUsage(usage protocol.UsageInfo) bool {
 		usage.PrefillTokensSaved != 0 || usage.CacheStageMs != 0
 }
 
+func lowCardinalityCacheSelectionKind(kind string) string {
+	switch kind {
+	case "exact", "conversation_explicit", "conversation_derived":
+		return kind
+	default:
+		return "none"
+	}
+}
+
+func cacheSelectionTerminalTags(pr *registry.PendingRequest, usage protocol.UsageInfo, usageValid, usagePresent bool) []string {
+	mode := "none"
+	if pr != nil && (pr.CacheSelectionMode == "active" || pr.CacheSelectionMode == "observe") {
+		mode = pr.CacheSelectionMode
+	}
+	result := "unreported"
+	if usagePresent && !usageValid {
+		result = "invalid"
+	} else if usageValid {
+		if usage.CacheOutcome == "hit" {
+			result = "hit"
+		} else {
+			result = "non_hit"
+		}
+	}
+	kind, tier := "none", "none"
+	selected, wouldChange := false, false
+	if pr != nil {
+		kind = lowCardinalityCacheSelectionKind(pr.CacheSelectionKind)
+		tier = lowCardinalityCacheTier(pr.CacheSelectionTier)
+		selected = pr.CacheSelectionSelected
+		wouldChange = pr.CacheSelectionWouldChange
+		// Observe mode never dispatches its hypothetical cache winner. Keep its
+		// terminal correlation explicitly baseline-only even if malformed metadata
+		// claims otherwise, so it cannot be read as hypothetical-provider precision.
+		if mode == "observe" {
+			selected = false
+		}
+	}
+	return []string{
+		"mode:" + mode,
+		"kind:" + kind,
+		"tier:" + tier,
+		"selected:" + strconv.FormatBool(selected),
+		"would_change:" + strconv.FormatBool(wouldChange),
+		"result:" + result,
+	}
+}
+
+func (s *Server) emitCacheSelectionTerminal(pr *registry.PendingRequest, usage protocol.UsageInfo, usageValid, usagePresent bool) bool {
+	if pr == nil || (!pr.CacheRoutingParticipates() && pr.CacheSelectionKind == "") {
+		return false
+	}
+	if !pr.MarkCacheTerminalTelemetryEmitted() {
+		return false
+	}
+	tags := cacheSelectionTerminalTags(pr, usage, usageValid, usagePresent)
+	s.ddIncr("routing.cache_selection_terminal", tags)
+	if pr.CacheSelectionKind != "" {
+		s.ddHistogram("routing.cache_selection_discount_ms", pr.CacheSelectionDiscountMs, tags[:len(tags)-1])
+		if pr.CacheSelectionMode == "active" && pr.CacheSelectionSelected {
+			s.ddIncr("routing.cache_selection_precision", tags)
+		}
+	}
+	return true
+}
+
+func cacheSelectionTTFTSample(pr *registry.PendingRequest, usage protocol.UsageInfo, usageValid bool, actualTTFTMs float64) (float64, []string, bool) {
+	if pr == nil || !usageValid || actualTTFTMs <= 0 || math.IsNaN(actualTTFTMs) || math.IsInf(actualTTFTMs, 0) {
+		return 0, nil, false
+	}
+	if pr.CacheSelectionMode != "active" && pr.CacheSelectionMode != "observe" {
+		return 0, nil, false
+	}
+	return actualTTFTMs, cacheSelectionTerminalTags(pr, usage, true, true), true
+}
+
+func (s *Server) emitCacheSelectionTTFT(pr *registry.PendingRequest, usage protocol.UsageInfo, usageValid bool, actualTTFTMs float64) {
+	value, tags, ok := cacheSelectionTTFTSample(pr, usage, usageValid, actualTTFTMs)
+	if !ok {
+		return
+	}
+	s.ddHistogram("routing.cache_selection_ttft_ms", value, tags)
+}
+
 // CodeAttestResponseTimeout bounds how long the coordinator will accept a
 // provider's WebSocket reply to an APNs code-identity challenge after the push.
 // It is no longer a blocking wait (Fix 1): verification happens in the read-loop
@@ -1683,8 +1767,9 @@ func (s *Server) handleComplete(providerID string, provider *registry.Provider, 
 			"prompt_tokens", msg.Usage.PromptTokens,
 		)
 	}
+	cacheUsagePresent := hasCacheUsage(msg.Usage)
 	cacheUsageValid := validCacheUsage(msg.Usage)
-	if hasCacheUsage(msg.Usage) && !cacheUsageValid {
+	if cacheUsagePresent && !cacheUsageValid {
 		s.ddIncr("routing.cache_usage_rejected", nil)
 		clearCacheUsage(&msg.Usage)
 	}
@@ -1695,6 +1780,7 @@ func (s *Server) handleComplete(providerID string, provider *registry.Provider, 
 		s.ddCount("routing.cache_prefill_tokens_saved", int64(msg.Usage.PrefillTokensSaved), tags)
 		s.ddHistogram("routing.cache_stage_ms", msg.Usage.CacheStageMs, tags)
 	}
+	cacheTerminalClaimed := s.emitCacheSelectionTerminal(pr, msg.Usage, cacheUsageValid, cacheUsagePresent)
 	s.reconcileOutputAdmission(pr, msg.Usage.CompletionTokens)
 
 	// Record job success and usage BEFORE closing ChunkCh. Closing
@@ -1985,6 +2071,13 @@ func (s *Server) handleComplete(providerID string, provider *registry.Provider, 
 		// the provider completed and billing settled, but the client did not receive
 		// the full response.
 		outcome := completeRouteOutcome(pr, msg.Usage, totalCost, consumerGone)
+		// Join only after both inputs are authoritative: cacheUsageValid was
+		// established from the terminal usage above, and completeRouteOutcome read
+		// the committed attempt's mutex-guarded first-content timestamp after the
+		// fallback stamp. No request, provider, route, or scope identifier is tagged.
+		if cacheTerminalClaimed {
+			s.emitCacheSelectionTTFT(pr, msg.Usage, cacheUsageValid, outcome.ActualTTFTMs)
+		}
 		if pr.Timing != nil {
 			// completeRouteOutcome already applied the per-attempt timing via
 			// applyPendingRouteTelemetry — actual_ttft_ms (from FirstContentAt),
@@ -2161,6 +2254,9 @@ func (s *Server) handleInferenceError(providerID string, provider *registry.Prov
 	// The request is terminal — drop its memoized chunk-decryption key.
 	s.chunkKeys.forget(pr.SessionPrivKey)
 	consumerGone := parked != nil
+	// Provider errors carry no validated cache usage, but still close the
+	// selection/outcome correlation denominator as an unreported result.
+	s.emitCacheSelectionTerminal(pr, protocol.UsageInfo{}, false, false)
 
 	// Record a job failure, but not for capacity rejections or consumer
 	// cancellations — neither is a provider fault. Capacity = load shedding the

--- a/coordinator/api/reputation_latency_test.go
+++ b/coordinator/api/reputation_latency_test.go
@@ -95,3 +95,17 @@ func TestAdjustLatencyForPrefill(t *testing.T) {
 		}
 	}
 }
+
+func TestCacheParticipationSuppressesReputationLatency(t *testing.T) {
+	plain := &registry.PendingRequest{Timing: &registry.RequestTiming{}}
+	if !shouldRecordReputationLatency(plain, "data: content") {
+		t.Fatal("ordinary content attempt should record reputation latency")
+	}
+	cached := &registry.PendingRequest{
+		Timing:     &registry.RequestTiming{},
+		CacheRoute: registry.CacheRoute{ExactKey: "coordinator-only-route"},
+	}
+	if shouldRecordReputationLatency(cached, "data: content") {
+		t.Fatal("cache-participating attempt recorded full-prefill reputation latency")
+	}
+}

--- a/coordinator/api/route_outcome.go
+++ b/coordinator/api/route_outcome.go
@@ -102,8 +102,19 @@ func (s *Server) updateInferenceRouteOutcomeForPending(pr *registry.PendingReque
 	if pr == nil {
 		return
 	}
-	if outcome != nil && outcome.FinalStatus != "" && !pr.MarkRouteOutcomeFinalized() {
-		return
+	terminal := outcome != nil && outcome.FinalStatus != ""
+	if terminal {
+		if !pr.MarkRouteOutcomeFinalized() {
+			return
+		}
+		// Consumer-side synthetic terminals (notably registry.Disconnect's
+		// ErrorCh delivery, local timeout, and grace expiry) do not pass through a
+		// provider terminal handler. Close their cache-selection denominator as
+		// unreported; the per-attempt claim makes this idempotent with provider
+		// complete/error races.
+		if s != nil {
+			s.emitCacheSelectionTerminal(pr, protocol.UsageInfo{}, false, false)
+		}
 	}
 	s.updateInferenceRouteOutcomeWithModel(pr.RequestID, pr.Attempt, pr.Model, outcome)
 }

--- a/coordinator/api/settlement.go
+++ b/coordinator/api/settlement.go
@@ -144,7 +144,7 @@ func (s *Server) claimSettlement(requestID string) *registry.PendingRequest {
 // pending prediction (cold dispatches, providers without BackendCapacity,
 // retries whose prediction expired) are ignored by the calibrator itself.
 func (s *Server) observeTTFTCalibration(pr *registry.PendingRequest) {
-	if pr == nil || pr.Timing == nil || pr.UsedBackup {
+	if pr == nil || pr.Timing == nil || pr.UsedBackup || pr.CacheRoutingParticipates() {
 		return
 	}
 	firstContent := pr.FirstContentAtSafe()

--- a/coordinator/api/ttft_first_content_test.go
+++ b/coordinator/api/ttft_first_content_test.go
@@ -25,6 +25,11 @@ import (
 // (ActualTTFTMs == 0).
 func TestFastCompletionStampsActualTTFT(t *testing.T) {
 	srv, st, _ := billingTestServer(t)
+	collector := newUDPCollector(t)
+	defer collector.Close()
+	ddClient := newTestDD(t, collector)
+	defer ddClient.Close()
+	srv.SetDatadog(ddClient)
 
 	model := "fast-ttft-model"
 	provider := srv.registry.Register("fast-ttft-provider", nil, &protocol.RegisterMessage{
@@ -35,13 +40,18 @@ func TestFastCompletionStampsActualTTFT(t *testing.T) {
 	// chunk the dispatch goroutine has NOT yet stamped (FirstContentAt zero) —
 	// exactly the fast-completion race the fix closes.
 	pr := &registry.PendingRequest{
-		RequestID:        "fast-ttft-req",
-		Model:            model,
-		ConsumerKey:      testConsumerID,
-		ReservedMicroUSD: 10_000_000,
-		ChunkCh:          make(chan string, 1),
-		CompleteCh:       make(chan protocol.UsageInfo, 1),
-		ErrorCh:          make(chan protocol.InferenceErrorMessage, 1),
+		RequestID:              "fast-ttft-req",
+		Model:                  model,
+		ConsumerKey:            testConsumerID,
+		ReservedMicroUSD:       10_000_000,
+		ChunkCh:                make(chan string, 1),
+		CompleteCh:             make(chan protocol.UsageInfo, 1),
+		ErrorCh:                make(chan protocol.InferenceErrorMessage, 1),
+		CacheRoute:             registry.CacheRoute{ExactKey: "coordinator-only"},
+		CacheSelectionMode:     "active",
+		CacheSelectionKind:     "exact",
+		CacheSelectionTier:     "memory",
+		CacheSelectionSelected: true,
 		Timing: &registry.RequestTiming{
 			ReceivedAt:   time.Now().Add(-60 * time.Millisecond),
 			DispatchedAt: time.Now().Add(-50 * time.Millisecond),
@@ -66,8 +76,16 @@ func TestFastCompletionStampsActualTTFT(t *testing.T) {
 	srv.handleComplete(provider.ID, provider, &protocol.InferenceCompleteMessage{
 		Type:      protocol.TypeInferenceComplete,
 		RequestID: pr.RequestID,
-		Usage:     protocol.UsageInfo{PromptTokens: 1000, CompletionTokens: 1},
+		Usage: protocol.UsageInfo{
+			PromptTokens: 1000, CompletionTokens: 1,
+			CacheOutcome: "miss_absent",
+		},
 	})
+	_ = ddClient.Statsd.Flush()
+	packets := collector.drain()
+	if !hasMetric(packets, "routing.cache_selection_ttft_ms:") || !hasMetric(packets, "selected:true") || !hasMetric(packets, "result:non_hit") {
+		t.Fatalf("cache-selected non-hit TTFT was not emitted after authoritative fallback timing: %v", packets)
+	}
 
 	// The outcome write is best-effort async (telemetry sink), so poll for it.
 	deadline := time.Now().Add(2 * time.Second)

--- a/coordinator/protocol/messages.go
+++ b/coordinator/protocol/messages.go
@@ -339,13 +339,14 @@ type PrefixCacheLookupMessage struct {
 // PrefixCacheReadyMessage confirms that reusable prefix state is ready after
 // an inference attempt. Ready receipts may arrive after inference_complete.
 type PrefixCacheReadyMessage struct {
-	Type                       string `json:"type"`
-	RequestID                  string `json:"request_id"`
-	CacheReceiptNonce          string `json:"cache_receipt_nonce"`
-	ReadyTokens                int    `json:"ready_tokens"`
-	RequiredRecomputeTokens    int    `json:"required_recompute_tokens,omitempty"`
-	ExpectedPrefillTokensSaved int    `json:"expected_prefill_tokens_saved,omitempty"`
-	Tier                       string `json:"tier,omitempty"`
+	Type                       string  `json:"type"`
+	RequestID                  string  `json:"request_id"`
+	CacheReceiptNonce          string  `json:"cache_receipt_nonce"`
+	ReadyTokens                int     `json:"ready_tokens"`
+	RequiredRecomputeTokens    int     `json:"required_recompute_tokens,omitempty"`
+	ExpectedPrefillTokensSaved int     `json:"expected_prefill_tokens_saved,omitempty"`
+	Tier                       string  `json:"tier,omitempty"`
+	StageMs                    float64 `json:"stage_ms,omitempty"`
 }
 
 // InferenceCompleteMessage signals the provider finished generating.

--- a/coordinator/protocol/messages_inference_test.go
+++ b/coordinator/protocol/messages_inference_test.go
@@ -180,7 +180,7 @@ func TestPrefixCacheReceiptsDecode(t *testing.T) {
 		want any
 	}{
 		{`{"type":"prefix_cache_lookup","request_id":"r","cache_receipt_nonce":"n","outcome":"hit","tier":"ssd","cached_tokens":256,"prefill_tokens_saved":240,"stage_ms":3.5}`, &PrefixCacheLookupMessage{}},
-		{`{"type":"prefix_cache_ready","request_id":"r","cache_receipt_nonce":"n","ready_tokens":512,"required_recompute_tokens":16,"expected_prefill_tokens_saved":496,"tier":"memory"}`, &PrefixCacheReadyMessage{}},
+		{`{"type":"prefix_cache_ready","request_id":"r","cache_receipt_nonce":"n","ready_tokens":512,"required_recompute_tokens":16,"expected_prefill_tokens_saved":496,"tier":"ssd","stage_ms":12.25}`, &PrefixCacheReadyMessage{}},
 	} {
 		var decoded ProviderMessage
 		if err := json.Unmarshal([]byte(tc.wire), &decoded); err != nil {
@@ -194,7 +194,7 @@ func TestPrefixCacheReceiptsDecode(t *testing.T) {
 			}
 		case *PrefixCacheReadyMessage:
 			msg, ok := decoded.Payload.(*PrefixCacheReadyMessage)
-			if !ok || msg.CacheReceiptNonce != "n" || msg.ReadyTokens != 512 {
+			if !ok || msg.CacheReceiptNonce != "n" || msg.ReadyTokens != 512 || msg.StageMs != 12.25 {
 				t.Fatalf("ready payload = %#v", decoded.Payload)
 			}
 		}

--- a/coordinator/registry/cache_receipts.go
+++ b/coordinator/registry/cache_receipts.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"math"
+	"strings"
 	"time"
 
 	"github.com/eigeninference/d-inference/coordinator/protocol"
@@ -19,30 +20,62 @@ func newCacheReceiptNonce() (string, error) {
 }
 
 // PrepareCacheAttempt creates the provider-visible opaque scope and nonce only
-// for protocol-v1 providers and catalog builds with an immutable expected hash.
-// All registry/provider locks are released before HMAC and tracker mutation.
+// for protocol-v1 providers whose advertised weight hash matches the catalog.
+// Protocol-0 providers instead receive an encrypted-body-only, unique cache
+// buster so old code cannot derive a caller-controlled remote namespace.
 func (r *Registry) PrepareCacheAttempt(pr *PendingRequest, provider *Provider) error {
-	if r == nil || pr == nil || provider == nil || (pr.CacheRoute.ExactKey == "" && pr.CacheRoute.ConversationKey == "") {
+	if r == nil || pr == nil || provider == nil {
 		return nil
 	}
+	// A PendingRequest can be reused by a queued retry. Never carry cache fields
+	// from its previous selected provider into the next attempt.
+	r.ForgetCacheAttempt(pr)
 	provider.mu.Lock()
 	protocolVersion := provider.PrefixCacheProtocol
 	providerID := provider.ID
+	providerWeightHash := ""
+	for _, model := range provider.Models {
+		if model.ID == pr.Model {
+			providerWeightHash = strings.TrimSpace(model.WeightHash)
+			break
+		}
+	}
 	provider.mu.Unlock()
 	if protocolVersion < 1 {
+		bust, err := newCacheReceiptNonce()
+		if err != nil {
+			return err
+		}
+		pr.LegacyCacheBustKey = "darkbloom-uncached-" + bust
 		return nil
 	}
-	expectedHash := r.CatalogWeightHash(pr.Model)
-	if expectedHash == "" {
+	if !pr.CacheRoute.present() {
+		return nil
+	}
+	r.mu.RLock()
+	tracker := r.cacheRouting
+	mode := r.cacheRoutingMode
+	expectedHash := ""
+	if entry, ok := r.modelCatalog[pr.Model]; ok {
+		expectedHash = strings.TrimSpace(entry.WeightHash)
+	}
+	r.mu.RUnlock()
+	if mode == CacheRoutingOff || tracker == nil {
+		return nil
+	}
+	if expectedHash == "" || providerWeightHash == "" || !strings.EqualFold(providerWeightHash, expectedHash) {
 		return nil
 	}
 	scope := r.ProviderCacheScope(pr.ConsumerKey, pr.Model, expectedHash, pr.CacheRoute.ScopeNamespace)
 	if scope == "" {
 		return nil
 	}
-	nonce, err := r.cacheRouting.registerAttempt(pr.RequestID, providerID, pr.Model, pr.CacheRoute, time.Now())
+	nonce, err := tracker.registerAttempt(pr.RequestID, providerID, pr.Model, pr.CacheRoute, time.Now())
 	if err != nil {
 		return err
+	}
+	if nonce == "" {
+		return nil
 	}
 	pr.CacheReceiptNonce = nonce
 	pr.CacheScope = scope
@@ -53,9 +86,15 @@ func (r *Registry) ForgetCacheAttempt(pr *PendingRequest) {
 	if r == nil || pr == nil {
 		return
 	}
-	r.cacheRouting.forgetAttempt(pr.CacheReceiptNonce)
+	r.mu.RLock()
+	tracker := r.cacheRouting
+	r.mu.RUnlock()
+	if tracker != nil {
+		tracker.forgetAttempt(pr.CacheReceiptNonce)
+	}
 	pr.CacheReceiptNonce = ""
 	pr.CacheScope = ""
+	pr.LegacyCacheBustKey = ""
 }
 
 func (r *Registry) ApplyPrefixCacheLookup(providerID string, msg *protocol.PrefixCacheLookupMessage) bool {
@@ -122,7 +161,12 @@ func (r *Registry) MarkCacheAttemptTerminal(pr *PendingRequest) {
 	if r == nil || pr == nil {
 		return
 	}
-	r.cacheRouting.markAttemptTerminal(pr.CacheReceiptNonce, time.Now())
+	r.mu.RLock()
+	tracker := r.cacheRouting
+	r.mu.RUnlock()
+	if tracker != nil {
+		tracker.markAttemptTerminal(pr.CacheReceiptNonce, time.Now())
+	}
 }
 
 func validCacheOutcome(outcome string) bool {
@@ -170,6 +214,13 @@ func (t *cacheRoutingTracker) applyLookup(providerID string, msg *protocol.Prefi
 			if key == "" {
 				continue
 			}
+			ref := cacheHolderRef{key: key, providerID: providerID}
+			if watermark, exists := t.activeWatermarkLocked(ref, now); exists {
+				if attempt.Sequence < watermark.Sequence {
+					continue
+				}
+				t.advanceWatermarkLocked(ref, attempt.Sequence, now)
+			}
 			holder, _ := t.activeHolderLocked(key, providerID, now)
 			holder.ProviderID = providerID
 			if attempt.Sequence > holder.EvidenceSequence {
@@ -195,6 +246,14 @@ func (t *cacheRoutingTracker) applyLookup(providerID string, msg *protocol.Prefi
 			break
 		}
 		for _, key := range keys {
+			if key == "" {
+				continue
+			}
+			ref := cacheHolderRef{key: key, providerID: providerID}
+			if watermark, exists := t.activeWatermarkLocked(ref, now); exists && attempt.Sequence < watermark.Sequence {
+				continue
+			}
+			t.advanceWatermarkLocked(ref, attempt.Sequence, now)
 			holder, exists := t.activeHolderLocked(key, providerID, now)
 			if exists && holder.EvidenceSequence > attempt.Sequence {
 				continue
@@ -209,6 +268,14 @@ func (t *cacheRoutingTracker) applyLookup(providerID string, msg *protocol.Prefi
 			break
 		}
 		for _, key := range keys {
+			if key == "" {
+				continue
+			}
+			ref := cacheHolderRef{key: key, providerID: providerID}
+			if watermark, exists := t.activeWatermarkLocked(ref, now); exists && attempt.Sequence < watermark.Sequence {
+				continue
+			}
+			t.advanceWatermarkLocked(ref, attempt.Sequence, now)
 			holder, exists := t.activeHolderLocked(key, providerID, now)
 			if !exists || holder.EvidenceSequence > attempt.Sequence {
 				continue
@@ -226,8 +293,12 @@ func (t *cacheRoutingTracker) applyLookup(providerID string, msg *protocol.Prefi
 }
 
 func (t *cacheRoutingTracker) applyReady(providerID string, msg *protocol.PrefixCacheReadyMessage, now time.Time) bool {
-	if t == nil || msg == nil || msg.Tier == "" || !validCacheTier(msg.Tier) || !validReceiptNumbers(msg.ReadyTokens, msg.ExpectedPrefillTokensSaved, 0) || msg.ReadyTokens <= 0 || msg.RequiredRecomputeTokens < 0 || msg.RequiredRecomputeTokens > cacheRoutingMaxReceiptTokens || msg.ReadyTokens < msg.RequiredRecomputeTokens || msg.ExpectedPrefillTokensSaved != msg.ReadyTokens-msg.RequiredRecomputeTokens {
+	if t == nil || msg == nil || msg.Tier == "" || !validCacheTier(msg.Tier) || !validReceiptNumbers(msg.ReadyTokens, msg.ExpectedPrefillTokensSaved, msg.StageMs) || msg.ReadyTokens <= 0 || msg.RequiredRecomputeTokens < 0 || msg.RequiredRecomputeTokens > cacheRoutingMaxReceiptTokens || msg.ReadyTokens < msg.RequiredRecomputeTokens || msg.ExpectedPrefillTokensSaved != msg.ReadyTokens-msg.RequiredRecomputeTokens {
 		return false
+	}
+	stageMs := msg.StageMs
+	if msg.Tier == "ssd" && stageMs == 0 {
+		stageMs = cacheRoutingUnmeasuredSSDStageMs
 	}
 	t.mu.Lock()
 	defer t.mu.Unlock()
@@ -246,15 +317,33 @@ func (t *cacheRoutingTracker) applyReady(providerID string, msg *protocol.Prefix
 		if key == "" {
 			continue
 		}
-		current, _ := t.activeHolderLocked(key, providerID, now)
+		ref := cacheHolderRef{key: key, providerID: providerID}
+		current, currentExists := t.activeHolderLocked(key, providerID, now)
 		if current.ProviderID != "" && !now.Before(current.ExpiresAt) {
 			t.removeHolderLocked(key, providerID)
 			current = cacheHolder{}
+			currentExists = false
 		}
-		authoritativeReady := attempt.Sequence >= current.EvidenceSequence
-		sequenceAdvanced := attempt.Sequence > current.EvidenceSequence
+		watermark, watermarkExists := t.activeWatermarkLocked(ref, now)
+		// Physical ready evidence from an older attempt may still extend a live
+		// holder's prefix, but it must never recreate a holder removed/suppressed
+		// by newer negative evidence.
+		if watermarkExists && attempt.Sequence < watermark.Sequence && !currentExists {
+			continue
+		}
+		latestSequence := current.EvidenceSequence
+		if watermark.Sequence > latestSequence {
+			latestSequence = watermark.Sequence
+		}
+		authoritativeReady := attempt.Sequence >= latestSequence
+		sequenceAdvanced := attempt.Sequence > latestSequence
+		if authoritativeReady && watermarkExists {
+			t.advanceWatermarkLocked(ref, attempt.Sequence, now)
+		}
 		if sequenceAdvanced {
 			current.EvidenceSequence = attempt.Sequence
+		} else if watermark.Sequence > current.EvidenceSequence {
+			current.EvidenceSequence = watermark.Sequence
 		}
 		if authoritativeReady {
 			current.SuppressedUntil = time.Time{}
@@ -270,6 +359,7 @@ func (t *cacheRoutingTracker) applyReady(providerID string, msg *protocol.Prefix
 			if authoritativeReady && current.ReadyTokens == msg.ReadyTokens {
 				current.RequiredRecomputeTokens = msg.RequiredRecomputeTokens
 				current.PrefillTokensSaved = msg.ExpectedPrefillTokensSaved
+				current.StageMs = stageMs
 				current.Tier = msg.Tier
 			}
 			if authoritativeReady || sequenceAdvanced {
@@ -284,12 +374,16 @@ func (t *cacheRoutingTracker) applyReady(providerID string, msg *protocol.Prefix
 		current.ReadyTokens = msg.ReadyTokens
 		current.RequiredRecomputeTokens = msg.RequiredRecomputeTokens
 		current.PrefillTokensSaved = msg.ExpectedPrefillTokensSaved
+		current.StageMs = stageMs
 		current.Tier = msg.Tier
 		current.Outcome = "ready"
 		current.Confirmed = true
 		current.UpdatedAt = now
 		current.ExpiresAt = now.Add(t.ttl)
 		t.upsertHolderLocked(key, current)
+		if !authoritativeReady && watermarkExists {
+			t.advanceWatermarkLocked(ref, watermark.Sequence, now)
+		}
 	}
 	return true
 }
@@ -303,6 +397,10 @@ func (t *cacheRoutingTracker) resetLocked(now time.Time) {
 	t.holderOrderByRef = make(map[cacheHolderRef]*cacheHolderOrderEntry)
 	t.attemptOrder = nil
 	t.attemptOrderByNonce = make(map[string]*cacheAttemptOrderEntry)
+	t.watermarks = make(map[cacheHolderRef]cacheEvidenceWatermark)
+	t.watermarkOrder = nil
+	t.watermarkOrderByRef = make(map[cacheHolderRef]*cacheWatermarkOrderEntry)
+	t.activeAttemptRefs = make(map[cacheHolderRef]*cacheActiveAttemptRefState)
 	t.nextAttemptSequence = 0
 }
 
@@ -322,10 +420,19 @@ func (t *cacheRoutingTracker) disconnect(providerID string) {
 			t.removeAttemptLocked(nonce)
 		}
 	}
+	for ref := range t.watermarks {
+		if ref.providerID == providerID {
+			t.removeWatermarkLocked(ref)
+		}
+	}
 }
 
 func (t *cacheRoutingTracker) storeAttemptLocked(nonce string, attempt cacheAttempt) {
+	if previous, exists := t.attempts[nonce]; exists {
+		t.removeActiveAttemptRefsLocked(nonce, previous)
+	}
 	t.attempts[nonce] = attempt
+	t.addActiveAttemptRefsLocked(nonce, attempt)
 	if entry := t.attemptOrderByNonce[nonce]; entry != nil {
 		entry.createdAt = attempt.CreatedAt
 		heap.Fix(&t.attemptOrder, entry.index)
@@ -337,6 +444,9 @@ func (t *cacheRoutingTracker) storeAttemptLocked(nonce string, attempt cacheAtte
 }
 
 func (t *cacheRoutingTracker) removeAttemptLocked(nonce string) {
+	if attempt, exists := t.attempts[nonce]; exists {
+		t.removeActiveAttemptRefsLocked(nonce, attempt)
+	}
 	delete(t.attempts, nonce)
 	if entry := t.attemptOrderByNonce[nonce]; entry != nil {
 		heap.Remove(&t.attemptOrder, entry.index)
@@ -439,6 +549,11 @@ func (t *cacheRoutingTracker) sweepLocked(now time.Time) {
 	for nonce, attempt := range t.attempts {
 		if !now.Before(attempt.ExpiresAt) {
 			t.removeAttemptLocked(nonce)
+		}
+	}
+	for ref, watermark := range t.watermarks {
+		if !now.Before(watermark.ExpiresAt) {
+			t.removeWatermarkLocked(ref)
 		}
 	}
 }

--- a/coordinator/registry/cache_route_keys.go
+++ b/coordinator/registry/cache_route_keys.go
@@ -82,10 +82,18 @@ func (r *Registry) DeriveCacheRoute(account, model, endpoint string, finalBody [
 		return CacheRoute{}
 	}
 	exactDigest := sha256.Sum256(canonicalBytes)
-	exactKey := opaqueHMAC(keys.route, "exact-v2", account, endpoint, model, string(exactDigest[:]))
+	explicit, hasExplicit := explicitCacheNamespace(body, sessionHeader)
+	// The header is not part of the sealed JSON body, so bind the effective
+	// explicit namespace (including its source prefix) into exact identity.
+	// Body session_id and prompt_cache_key retain their existing precedence.
+	exactNamespace := ""
+	if hasExplicit {
+		exactNamespace = explicit
+	}
+	exactKey := opaqueHMAC(keys.route, "exact-v2", account, endpoint, model, string(exactDigest[:]), exactNamespace)
 	route := CacheRoute{ExactKey: exactKey, ScopeNamespace: base64.RawURLEncoding.EncodeToString(exactDigest[:])}
 
-	if explicit, ok := explicitCacheNamespace(body, sessionHeader); ok {
+	if hasExplicit {
 		route.ConversationKey = opaqueHMAC(keys.route, "conversation-explicit-v2", account, endpoint, model, explicit)
 		route.ConversationKind = "explicit"
 		route.ScopeNamespace = explicit

--- a/coordinator/registry/cache_routing.go
+++ b/coordinator/registry/cache_routing.go
@@ -21,8 +21,16 @@ const (
 	cacheRoutingSweepInterval          = 30 * time.Second
 	cacheRoutingMaxEntries             = 10_000
 	cacheRoutingMaxAttempts            = 50_000
-	cacheRoutingMaxReceiptTokens       = 1_000_000
-	cacheRoutingMaxStageMs             = 10 * 60 * 1000.0
+	// Each attempt can carry both an exact and conversation route key. Keeping
+	// two watermarks per live attempt prevents cap eviction from reopening a
+	// delayed-receipt resurrection window while remaining strictly bounded.
+	cacheRoutingMaxWatermarks    = 2 * cacheRoutingMaxAttempts
+	cacheRoutingMaxReceiptTokens = 1_000_000
+	cacheRoutingMaxStageMs       = 10 * 60 * 1000.0
+	// Older protocol-v1 providers omit stage_ms on durable SSD-ready receipts.
+	// Treat that cost as unknown and maximally conservative until a measured hit
+	// replaces it, rather than granting SSD evidence a zero-cost discount.
+	cacheRoutingUnmeasuredSSDStageMs = cacheRoutingMaxStageMs
 )
 
 type CacheRoute struct {
@@ -30,6 +38,17 @@ type CacheRoute struct {
 	ConversationKey  string
 	ConversationKind string
 	ScopeNamespace   string
+}
+
+func (r CacheRoute) present() bool {
+	return r.ExactKey != "" || r.ConversationKey != ""
+}
+
+// CacheRoutingParticipates reports whether this request was derived while a
+// cache rollout mode was enabled. Callers use it only to suppress feedback that
+// assumes a full prefill; route keys themselves remain registry-private.
+func (pr *PendingRequest) CacheRoutingParticipates() bool {
+	return pr != nil && pr.CacheRoute.present()
 }
 
 type cacheRouteKeys struct {
@@ -121,6 +140,50 @@ type cacheHolderRef struct {
 	providerID string
 }
 
+type cacheEvidenceWatermark struct {
+	Sequence  uint64
+	UpdatedAt time.Time
+	ExpiresAt time.Time
+}
+
+type cacheWatermarkOrderEntry struct {
+	ref       cacheHolderRef
+	updatedAt time.Time
+	index     int
+}
+
+type cacheWatermarkOrderHeap []*cacheWatermarkOrderEntry
+
+func (h cacheWatermarkOrderHeap) Len() int { return len(h) }
+func (h cacheWatermarkOrderHeap) Less(i, j int) bool {
+	if !h[i].updatedAt.Equal(h[j].updatedAt) {
+		return h[i].updatedAt.Before(h[j].updatedAt)
+	}
+	if h[i].ref.key != h[j].ref.key {
+		return h[i].ref.key < h[j].ref.key
+	}
+	return h[i].ref.providerID < h[j].ref.providerID
+}
+func (h cacheWatermarkOrderHeap) Swap(i, j int) {
+	h[i], h[j] = h[j], h[i]
+	h[i].index = i
+	h[j].index = j
+}
+func (h *cacheWatermarkOrderHeap) Push(value any) {
+	entry := value.(*cacheWatermarkOrderEntry)
+	entry.index = len(*h)
+	*h = append(*h, entry)
+}
+func (h *cacheWatermarkOrderHeap) Pop() any {
+	old := *h
+	last := len(old) - 1
+	entry := old[last]
+	old[last] = nil
+	entry.index = -1
+	*h = old[:last]
+	return entry
+}
+
 type cacheHolderOrderEntry struct {
 	ref       cacheHolderRef
 	updatedAt time.Time
@@ -169,6 +232,7 @@ type cacheRoutingTracker struct {
 	maxHolders          int
 	maxEntries          int
 	maxAttempts         int
+	maxWatermarks       int
 	holderCount         int
 	lastSweep           time.Time
 	holders             map[string]map[string]cacheHolder
@@ -177,6 +241,10 @@ type cacheRoutingTracker struct {
 	holderOrderByRef    map[cacheHolderRef]*cacheHolderOrderEntry
 	attemptOrder        cacheAttemptOrderHeap
 	attemptOrderByNonce map[string]*cacheAttemptOrderEntry
+	watermarks          map[cacheHolderRef]cacheEvidenceWatermark
+	watermarkOrder      cacheWatermarkOrderHeap
+	watermarkOrderByRef map[cacheHolderRef]*cacheWatermarkOrderEntry
+	activeAttemptRefs   map[cacheHolderRef]*cacheActiveAttemptRefState
 	nextAttemptSequence uint64
 }
 
@@ -188,8 +256,10 @@ func newCacheRoutingTracker(ttl time.Duration, maxHolders int) *cacheRoutingTrac
 		maxHolders = defaultCacheRoutingMaxHolders
 	}
 	return &cacheRoutingTracker{
-		ttl: ttl, maxHolders: maxHolders, maxEntries: cacheRoutingMaxEntries, maxAttempts: cacheRoutingMaxAttempts,
+		ttl: ttl, maxHolders: maxHolders, maxEntries: cacheRoutingMaxEntries, maxAttempts: cacheRoutingMaxAttempts, maxWatermarks: cacheRoutingMaxWatermarks,
 		holders: make(map[string]map[string]cacheHolder), attempts: make(map[string]cacheAttempt),
 		holderOrderByRef: make(map[cacheHolderRef]*cacheHolderOrderEntry), attemptOrderByNonce: make(map[string]*cacheAttemptOrderEntry),
+		watermarks: make(map[cacheHolderRef]cacheEvidenceWatermark), watermarkOrderByRef: make(map[cacheHolderRef]*cacheWatermarkOrderEntry),
+		activeAttemptRefs: make(map[cacheHolderRef]*cacheActiveAttemptRefState),
 	}
 }

--- a/coordinator/registry/cache_routing_test.go
+++ b/coordinator/registry/cache_routing_test.go
@@ -3,6 +3,7 @@ package registry
 import (
 	"encoding/base64"
 	"fmt"
+	"math"
 	"strings"
 	"sync"
 	"testing"
@@ -50,6 +51,15 @@ func TestCacheRouteDerivationIsolationAndPrecedence(t *testing.T) {
 	if !strings.HasPrefix(withoutHeader.ScopeNamespace, "prompt_cache_key:") {
 		t.Fatalf("scope namespace %q did not use prompt key", withoutHeader.ScopeNamespace)
 	}
+	otherHeader := reg.DeriveCacheRoute("acct-a", "build-a", "/v1/chat/completions", deleteSession, "other-header-session", false)
+	if header.ExactKey == otherHeader.ExactKey {
+		t.Fatal("different X-Session-Id namespaces shared exact evidence")
+	}
+	bodySessionA := reg.DeriveCacheRoute("acct-a", "build-a", "/v1/chat/completions", body, "header-a", false)
+	bodySessionB := reg.DeriveCacheRoute("acct-a", "build-a", "/v1/chat/completions", body, "header-b", false)
+	if bodySessionA.ExactKey != bodySessionB.ExactKey || bodySessionA.ScopeNamespace != bodySessionB.ScopeNamespace {
+		t.Fatal("X-Session-Id overrode body session_id precedence")
+	}
 }
 
 func TestCacheRoutingOffDerivesNothing(t *testing.T) {
@@ -57,6 +67,18 @@ func TestCacheRoutingOffDerivesNothing(t *testing.T) {
 	route := reg.DeriveCacheRoute("account", "model", "/v1/chat/completions", []byte(`{"messages":[{"role":"user","content":"hello"}]}`), "session", false)
 	if route != (CacheRoute{}) {
 		t.Fatalf("off mode derived route keys: %+v", route)
+	}
+}
+
+func TestCacheRoutingOffStillIsolatesLegacyProviderBody(t *testing.T) {
+	reg := New(testLogger())
+	pr := &PendingRequest{RequestID: "request", Model: "model", ConsumerKey: "account"}
+	legacy := &Provider{ID: "legacy", PrefixCacheProtocol: 0}
+	if err := reg.PrepareCacheAttempt(pr, legacy); err != nil {
+		t.Fatal(err)
+	}
+	if pr.LegacyCacheBustKey == "" || pr.CacheReceiptNonce != "" || pr.CacheScope != "" {
+		t.Fatalf("off-mode legacy preparation = bust %q nonce %q scope %q", pr.LegacyCacheBustKey, pr.CacheReceiptNonce, pr.CacheScope)
 	}
 }
 
@@ -131,11 +153,37 @@ func TestPrepareCacheAttemptVersionAndExpectedHashGates(t *testing.T) {
 	if err := reg.PrepareCacheAttempt(pr, provider); err != nil {
 		t.Fatal(err)
 	}
-	if pr.CacheScope != "" || pr.CacheReceiptNonce != "" {
-		t.Fatal("legacy provider received cache fields")
+	if pr.CacheScope != "" || pr.CacheReceiptNonce != "" || pr.LegacyCacheBustKey == "" {
+		t.Fatal("legacy provider did not receive only an encrypted-body cache buster")
+	}
+	firstBust := pr.LegacyCacheBustKey
+	if err := reg.PrepareCacheAttempt(pr, provider); err != nil {
+		t.Fatal(err)
+	}
+	if pr.LegacyCacheBustKey == "" || pr.LegacyCacheBustKey == firstBust {
+		t.Fatal("legacy retry reused its prior cache buster")
 	}
 	provider.mu.Lock()
 	provider.PrefixCacheProtocol = 1
+	provider.Models = []protocol.ModelInfo{{ID: "model"}}
+	provider.mu.Unlock()
+	if err := reg.PrepareCacheAttempt(pr, provider); err != nil {
+		t.Fatal(err)
+	}
+	if pr.CacheScope != "" || pr.CacheReceiptNonce != "" || pr.LegacyCacheBustKey != "" {
+		t.Fatal("protocol-v1 provider without a weight hash received cache fields")
+	}
+	provider.mu.Lock()
+	provider.Models = []protocol.ModelInfo{{ID: "model", WeightHash: "mismatched-hash"}}
+	provider.mu.Unlock()
+	if err := reg.PrepareCacheAttempt(pr, provider); err != nil {
+		t.Fatal(err)
+	}
+	if pr.CacheScope != "" || pr.CacheReceiptNonce != "" {
+		t.Fatal("protocol-v1 provider with a mismatched weight hash received cache fields")
+	}
+	provider.mu.Lock()
+	provider.Models = []protocol.ModelInfo{{ID: "model", WeightHash: "EXPECTED-HASH"}}
 	provider.mu.Unlock()
 	if err := reg.PrepareCacheAttempt(pr, provider); err != nil {
 		t.Fatal(err)
@@ -154,6 +202,42 @@ func TestPrepareCacheAttemptVersionAndExpectedHashGates(t *testing.T) {
 	}
 	if withoutHash.CacheScope != "" || withoutHash.CacheReceiptNonce != "" {
 		t.Fatal("build without expected immutable hash received cache fields")
+	}
+}
+
+func TestNegativeWatermarkBlocksDelayedPositiveResurrection(t *testing.T) {
+	for _, negative := range []string{"miss_absent", "miss_corrupt", "skipped_capacity"} {
+		for _, positive := range []string{"hit", "ready"} {
+			t.Run(negative+"_then_older_"+positive, func(t *testing.T) {
+				tracker := newCacheRoutingTracker(time.Minute, 4)
+				now := time.Unix(140, 0)
+				route := CacheRoute{ExactKey: "exact", ConversationKey: "conversation"}
+				olderNonce, _ := tracker.registerAttempt("older", "provider", "model", route, now)
+				newerNonce, _ := tracker.registerAttempt("newer", "provider", "model", route, now.Add(time.Second))
+				if !tracker.applyLookup("provider", &protocol.PrefixCacheLookupMessage{
+					RequestID: "newer", CacheReceiptNonce: newerNonce, Outcome: negative,
+				}, now.Add(2*time.Second)) {
+					t.Fatal("newer negative receipt rejected")
+				}
+				delayedAt := now.Add(2 * time.Minute)
+				if positive == "hit" {
+					if !tracker.applyLookup("provider", &protocol.PrefixCacheLookupMessage{
+						RequestID: "older", CacheReceiptNonce: olderNonce, Outcome: "hit",
+						Tier: "memory", CachedTokens: 1000, PrefillTokensSaved: 900,
+					}, delayedAt) {
+						t.Fatal("delayed older hit receipt rejected")
+					}
+				} else if !tracker.applyReady("provider", &protocol.PrefixCacheReadyMessage{
+					RequestID: "older", CacheReceiptNonce: olderNonce, ReadyTokens: 1000,
+					RequiredRecomputeTokens: 100, ExpectedPrefillTokensSaved: 900, Tier: "memory",
+				}, delayedAt) {
+					t.Fatal("delayed older ready receipt rejected")
+				}
+				if hints := tracker.hints(route, CacheRoutingConversation, delayedAt.Add(time.Second)); len(hints) != 0 {
+					t.Fatalf("%s resurrected evidence after newer %s: %+v", positive, negative, hints)
+				}
+			})
+		}
 	}
 }
 
@@ -187,6 +271,49 @@ func TestCacheReceiptNonceLifecycleAndReadyAfterTerminal(t *testing.T) {
 	}
 	if got := tracker.hints(route, CacheRoutingConversation, terminalAt.Add(time.Minute))["provider"]; got.ReadyTokens != 768 || got.RecomputeTokens != 32 {
 		t.Fatalf("ready hint = %+v", got)
+	}
+}
+
+func TestSSDReadyStageCostIsMeasuredOrConservative(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		stageMs float64
+		want    float64
+	}{
+		{name: "measured", stageMs: 17.5, want: 17.5},
+		{name: "omitted", stageMs: 0, want: cacheRoutingUnmeasuredSSDStageMs},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tracker := newCacheRoutingTracker(time.Minute, 4)
+			now := time.Unix(125, 0)
+			route := CacheRoute{ExactKey: "exact"}
+			nonce, _ := tracker.registerAttempt("request", "provider", "model", route, now)
+			if !tracker.applyReady("provider", &protocol.PrefixCacheReadyMessage{
+				RequestID: "request", CacheReceiptNonce: nonce, ReadyTokens: 1000,
+				RequiredRecomputeTokens: 100, ExpectedPrefillTokensSaved: 900,
+				Tier: "ssd", StageMs: tc.stageMs,
+			}, now.Add(time.Second)) {
+				t.Fatal("ready receipt rejected")
+			}
+			if got := tracker.hints(route, CacheRoutingExact, now.Add(2*time.Second))["provider"].StageMs; got != tc.want {
+				t.Fatalf("ready stage = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSSDReadyStageCostRejectsInvalidNumbers(t *testing.T) {
+	for _, stageMs := range []float64{-1, cacheRoutingMaxStageMs + 1, math.NaN(), math.Inf(1), math.Inf(-1)} {
+		tracker := newCacheRoutingTracker(time.Minute, 4)
+		now := time.Unix(130, 0)
+		nonce, _ := tracker.registerAttempt("request", "provider", "model", CacheRoute{ExactKey: "exact"}, now)
+		if tracker.applyReady("provider", &protocol.PrefixCacheReadyMessage{
+			RequestID: "request", CacheReceiptNonce: nonce, ReadyTokens: 1000,
+			RequiredRecomputeTokens: 100, ExpectedPrefillTokensSaved: 900,
+			Tier: "ssd", StageMs: stageMs,
+		}, now.Add(time.Second)) {
+			t.Fatalf("accepted invalid SSD ready stage_ms %v", stageMs)
+		}
 	}
 }
 
@@ -428,6 +555,14 @@ func TestOlderReadyCannotClearNewerCapacitySuppression(t *testing.T) {
 	if hints := tracker.hints(route, CacheRoutingExact, now.Add(4*time.Second)); len(hints) != 0 {
 		t.Fatalf("older ready cleared newer capacity suppression: %+v", hints)
 	}
+	tracker.mu.Lock()
+	holder := tracker.holders[route.ExactKey]["provider"]
+	newerSequence := tracker.attempts[newerNonce].Sequence
+	watermark := tracker.watermarks[cacheHolderRef{key: route.ExactKey, providerID: "provider"}]
+	tracker.mu.Unlock()
+	if holder.ReadyTokens != 1500 || holder.EvidenceSequence != newerSequence || holder.SuppressedUntil.IsZero() || watermark.Sequence != newerSequence {
+		t.Fatalf("older physical extension regressed newer negative ordering: holder=%+v watermark=%+v newer_sequence=%d", holder, watermark, newerSequence)
+	}
 }
 
 func TestEqualNewerReadyRefreshesHolderLifetime(t *testing.T) {
@@ -466,6 +601,7 @@ func TestCacheAttemptSequenceWrapClearsOldEvidence(t *testing.T) {
 	tracker.upsertForTest("old", "provider", now, 1000)
 	oldNonce, _ := tracker.registerAttempt("old", "provider", "model", CacheRoute{ExactKey: "old"}, now)
 	tracker.mu.Lock()
+	tracker.advanceWatermarkLocked(cacheHolderRef{key: "old", providerID: "provider"}, 1, now)
 	tracker.nextAttemptSequence = ^uint64(0)
 	tracker.mu.Unlock()
 	newNonce, _ := tracker.registerAttempt("new", "provider", "model", CacheRoute{ExactKey: "new"}, now.Add(time.Second))
@@ -473,6 +609,12 @@ func TestCacheAttemptSequenceWrapClearsOldEvidence(t *testing.T) {
 	defer tracker.mu.Unlock()
 	if len(tracker.holders) != 0 {
 		t.Fatalf("sequence wrap retained old holders: %+v", tracker.holders)
+	}
+	if len(tracker.watermarks) != 0 || len(tracker.watermarkOrder) != 0 || len(tracker.watermarkOrderByRef) != 0 {
+		t.Fatal("sequence wrap retained old evidence watermarks")
+	}
+	if _, retained := tracker.activeAttemptRefs[cacheHolderRef{key: "old", providerID: "provider"}]; retained || len(tracker.activeAttemptRefs) != 1 {
+		t.Fatalf("sequence wrap retained old active-attempt refs: %+v", tracker.activeAttemptRefs)
 	}
 	if _, exists := tracker.attempts[oldNonce]; exists {
 		t.Fatal("sequence wrap retained old attempt")
@@ -590,11 +732,155 @@ func TestCacheReceiptValidationAndDisconnect(t *testing.T) {
 		t.Fatal("valid receipt rejected after invalid receipt")
 	}
 	tracker.disconnect("provider")
-	if len(tracker.hints(route, CacheRoutingExact, now)) != 0 || len(tracker.attempts) != 0 {
-		t.Fatal("disconnect retained holder or attempt")
+	if len(tracker.hints(route, CacheRoutingExact, now)) != 0 || len(tracker.attempts) != 0 || len(tracker.watermarks) != 0 {
+		t.Fatal("disconnect retained holder, attempt, or watermark")
 	}
-	if len(tracker.holderOrder) != 0 || len(tracker.holderOrderByRef) != 0 || len(tracker.attemptOrder) != 0 || len(tracker.attemptOrderByNonce) != 0 {
+	if len(tracker.holderOrder) != 0 || len(tracker.holderOrderByRef) != 0 || len(tracker.attemptOrder) != 0 || len(tracker.attemptOrderByNonce) != 0 || len(tracker.watermarkOrder) != 0 || len(tracker.watermarkOrderByRef) != 0 || len(tracker.activeAttemptRefs) != 0 {
 		t.Fatal("disconnect retained cap ordering metadata")
+	}
+}
+
+func TestCacheEvidenceWatermarksRemainBounded(t *testing.T) {
+	tracker := newCacheRoutingTracker(time.Minute, 4)
+	if tracker.maxWatermarks < 2*tracker.maxAttempts {
+		t.Fatalf("default watermark cap %d cannot cover two keys for %d live attempts", tracker.maxWatermarks, tracker.maxAttempts)
+	}
+	tracker.maxWatermarks = 2
+	now := time.Unix(225, 0)
+	for i, key := range []string{"route-a", "route-b", "route-c"} {
+		requestID := fmt.Sprintf("request-%d", i)
+		nonce, _ := tracker.registerAttempt(requestID, "provider", "model", CacheRoute{ExactKey: key}, now.Add(time.Duration(i)*time.Second))
+		if !tracker.applyLookup("provider", &protocol.PrefixCacheLookupMessage{
+			RequestID: requestID, CacheReceiptNonce: nonce, Outcome: "miss_absent",
+		}, now.Add(time.Duration(i)*time.Second)) {
+			t.Fatalf("negative receipt %d rejected", i)
+		}
+	}
+	tracker.mu.Lock()
+	defer tracker.mu.Unlock()
+	if len(tracker.watermarks) != 2 || len(tracker.watermarkOrder) != 2 || len(tracker.watermarkOrderByRef) != 2 {
+		t.Fatalf("watermark cap mismatch: live=%d heap=%d index=%d", len(tracker.watermarks), len(tracker.watermarkOrder), len(tracker.watermarkOrderByRef))
+	}
+	if _, oldestRetained := tracker.watermarks[cacheHolderRef{key: "route-a", providerID: "provider"}]; oldestRetained {
+		t.Fatal("watermark cap retained oldest evidence")
+	}
+}
+
+func TestCacheWatermarkCapPreservesActiveDelayedAttempt(t *testing.T) {
+	tracker := newCacheRoutingTracker(time.Minute, 4)
+	tracker.maxWatermarks = 2
+	now := time.Unix(235, 0)
+	protectedRoute := CacheRoute{ExactKey: "protected"}
+	olderNonce, _ := tracker.registerAttempt("older", "provider", "model", protectedRoute, now)
+	newerNonce, _ := tracker.registerAttempt("newer", "provider", "model", protectedRoute, now.Add(time.Second))
+	if !tracker.applyLookup("provider", &protocol.PrefixCacheLookupMessage{
+		RequestID: "newer", CacheReceiptNonce: newerNonce, Outcome: "miss_absent",
+	}, now.Add(2*time.Second)) {
+		t.Fatal("newer negative receipt rejected")
+	}
+	tracker.forgetAttempt(newerNonce)
+
+	for i, key := range []string{"completed-a", "completed-b"} {
+		requestID := fmt.Sprintf("completed-%d", i)
+		nonce, _ := tracker.registerAttempt(requestID, "provider", "model", CacheRoute{ExactKey: key}, now.Add(time.Duration(3+i)*time.Second))
+		if !tracker.applyLookup("provider", &protocol.PrefixCacheLookupMessage{
+			RequestID: requestID, CacheReceiptNonce: nonce, Outcome: "miss_absent",
+		}, now.Add(time.Duration(3+i)*time.Second)) {
+			t.Fatalf("completed tombstone %d rejected", i)
+		}
+		tracker.forgetAttempt(nonce)
+	}
+
+	protectedRef := cacheHolderRef{key: protectedRoute.ExactKey, providerID: "provider"}
+	tracker.mu.Lock()
+	_, retained := tracker.watermarks[protectedRef]
+	bounded := len(tracker.watermarks) == tracker.maxWatermarks
+	tracker.mu.Unlock()
+	if !retained || !bounded {
+		t.Fatalf("overflow evicted protected watermark or exceeded cap: retained=%t count=%d", retained, len(tracker.watermarks))
+	}
+	if !tracker.applyLookup("provider", &protocol.PrefixCacheLookupMessage{
+		RequestID: "older", CacheReceiptNonce: olderNonce, Outcome: "hit",
+		Tier: "memory", CachedTokens: 100, PrefillTokensSaved: 90,
+	}, now.Add(10*time.Second)) {
+		t.Fatal("delayed older hit receipt rejected")
+	}
+	if hints := tracker.hints(protectedRoute, CacheRoutingExact, now.Add(11*time.Second)); len(hints) != 0 {
+		t.Fatalf("delayed older hit resurrected evidence after cap churn: %+v", hints)
+	}
+	tracker.forgetAttempt(olderNonce)
+	tracker.mu.Lock()
+	_, stillActive := tracker.activeAttemptRefs[protectedRef]
+	_, nowEvictable := tracker.watermarkOrderByRef[protectedRef]
+	tracker.mu.Unlock()
+	if stillActive || !nowEvictable {
+		t.Fatalf("attempt removal did not release indexed protection: active=%t evictable=%t", stillActive, nowEvictable)
+	}
+}
+
+func TestCacheWatermarkCapIndexedMetadataUnderChurn(t *testing.T) {
+	tracker := newCacheRoutingTracker(time.Minute, 4)
+	tracker.maxWatermarks = 32
+	now := time.Unix(238, 0)
+	protectedRoute := CacheRoute{ExactKey: "protected"}
+	olderNonce, _ := tracker.registerAttempt("older", "provider", "model", protectedRoute, now)
+	newerNonce, _ := tracker.registerAttempt("newer", "provider", "model", protectedRoute, now.Add(time.Millisecond))
+	if !tracker.applyLookup("provider", &protocol.PrefixCacheLookupMessage{
+		RequestID: "newer", CacheReceiptNonce: newerNonce, Outcome: "miss_absent",
+	}, now.Add(2*time.Millisecond)) {
+		t.Fatal("protected tombstone rejected")
+	}
+	tracker.forgetAttempt(newerNonce)
+
+	for i := 0; i < 5000; i++ {
+		requestID := fmt.Sprintf("churn-%d", i)
+		key := fmt.Sprintf("route-%d", i)
+		at := now.Add(time.Duration(i+3) * time.Millisecond)
+		nonce, _ := tracker.registerAttempt(requestID, "provider", "model", CacheRoute{ExactKey: key}, at)
+		if !tracker.applyLookup("provider", &protocol.PrefixCacheLookupMessage{
+			RequestID: requestID, CacheReceiptNonce: nonce, Outcome: "miss_absent",
+		}, at) {
+			t.Fatalf("churn receipt %d rejected", i)
+		}
+		tracker.forgetAttempt(nonce)
+	}
+
+	protectedRef := cacheHolderRef{key: protectedRoute.ExactKey, providerID: "provider"}
+	tracker.mu.Lock()
+	defer tracker.mu.Unlock()
+	if len(tracker.watermarks) != tracker.maxWatermarks {
+		t.Fatalf("watermarks=%d, want cap %d", len(tracker.watermarks), tracker.maxWatermarks)
+	}
+	if _, retained := tracker.watermarks[protectedRef]; !retained {
+		t.Fatal("indexed cap churn evicted protected watermark")
+	}
+	if _, evictable := tracker.watermarkOrderByRef[protectedRef]; evictable {
+		t.Fatal("protected watermark remained in eviction heap")
+	}
+	if state := tracker.activeAttemptRefs[protectedRef]; state == nil || len(state.order) != 1 || state.order[0].nonce != olderNonce {
+		t.Fatalf("active-attempt protection metadata = %+v", state)
+	}
+	if len(tracker.watermarkOrder) != tracker.maxWatermarks-1 || len(tracker.watermarkOrderByRef) != len(tracker.watermarkOrder) {
+		t.Fatalf("eviction metadata mismatch: heap=%d index=%d", len(tracker.watermarkOrder), len(tracker.watermarkOrderByRef))
+	}
+	for index, entry := range tracker.watermarkOrder {
+		if entry.index != index || tracker.watermarkOrderByRef[entry.ref] != entry {
+			t.Fatalf("eviction heap index %d is inconsistent: %+v", index, entry)
+		}
+	}
+}
+
+func TestCacheEvidenceWatermarkExpiresAfterReceiptWindow(t *testing.T) {
+	tracker := newCacheRoutingTracker(time.Minute, 4)
+	now := time.Unix(240, 0)
+	ref := cacheHolderRef{key: "route", providerID: "provider"}
+	tracker.mu.Lock()
+	tracker.advanceWatermarkLocked(ref, 1, now)
+	tracker.sweepLocked(now.Add(cacheRoutingInFlightAttemptTTL))
+	_, retained := tracker.watermarks[ref]
+	tracker.mu.Unlock()
+	if retained {
+		t.Fatal("watermark survived the full delayed-receipt window")
 	}
 }
 
@@ -711,14 +997,14 @@ func TestCacheCapOrderMetadataRemainsBounded(t *testing.T) {
 	tracker.forgetAttempt(nonce)
 	tracker.mu.Lock()
 	tracker.removeHolderLocked("exact", "provider")
-	if len(tracker.holderOrder) != 0 || len(tracker.holderOrderByRef) != 0 || len(tracker.attemptOrder) != 0 || len(tracker.attemptOrderByNonce) != 0 {
+	if len(tracker.holderOrder) != 0 || len(tracker.holderOrderByRef) != 0 || len(tracker.attemptOrder) != 0 || len(tracker.attemptOrderByNonce) != 0 || len(tracker.activeAttemptRefs) != 0 {
 		tracker.mu.Unlock()
 		t.Fatal("forget/remove retained cap ordering metadata")
 	}
 	tracker.upsertHolderLocked("expired", cacheHolder{ProviderID: "provider", UpdatedAt: now, ExpiresAt: now})
 	tracker.storeAttemptLocked("expired", cacheAttempt{CreatedAt: now, ExpiresAt: now})
 	tracker.sweepLocked(now)
-	if len(tracker.holderOrder) != 0 || len(tracker.holderOrderByRef) != 0 || len(tracker.attemptOrder) != 0 || len(tracker.attemptOrderByNonce) != 0 {
+	if len(tracker.holderOrder) != 0 || len(tracker.holderOrderByRef) != 0 || len(tracker.attemptOrder) != 0 || len(tracker.attemptOrderByNonce) != 0 || len(tracker.activeAttemptRefs) != 0 {
 		tracker.mu.Unlock()
 		t.Fatal("sweep retained expired cap ordering metadata")
 	}
@@ -811,9 +1097,13 @@ func TestCacheRoutingAppliesBoundedExactDiscount(t *testing.T) {
 	provider := makeSchedulerProvider(t, reg, "provider", model, 100)
 	route := CacheRoute{ExactKey: "exact", ConversationKey: "conversation", ConversationKind: "explicit"}
 	reg.cacheRouting.upsertForTest(route.ExactKey, provider.ID, time.Now(), 4096)
-	selected, decision := reg.ReserveProviderEx(model, &PendingRequest{RequestID: "request", Model: model, EstimatedPromptTokens: 4096, RequestedMaxTokens: 128, CacheRoute: route})
+	pr := &PendingRequest{RequestID: "request", Model: model, EstimatedPromptTokens: 4096, RequestedMaxTokens: 128, CacheRoute: route}
+	selected, decision := reg.ReserveProviderEx(model, pr)
 	if selected == nil || decision.CacheKind != "exact" || decision.CacheDiscountMs <= 0 || decision.CacheDiscountMs > 1000 || decision.CacheDiscountMs > (decision.CostMs+decision.CacheDiscountMs)*.35+1 {
 		t.Fatalf("invalid exact discount: selected=%v decision=%+v", selected, decision)
+	}
+	if pr.CacheSelectionMode != "active" || pr.CacheSelectionKind != "exact" || pr.CacheSelectionTier != "memory" || !pr.CacheSelectionSelected || pr.CacheSelectionWouldChange || pr.CacheSelectionDiscountMs != decision.CacheDiscountMs {
+		t.Fatalf("pending cache selection metadata = %+v", pr)
 	}
 }
 
@@ -883,15 +1173,19 @@ func TestCacheRoutingObserveReportsChangedWinner(t *testing.T) {
 	route := CacheRoute{ExactKey: "exact"}
 	reg.cacheRouting.upsertForTest(route.ExactKey, cached.ID, time.Now(), 4096)
 
-	selected, decision := reg.ReserveProviderEx(model, &PendingRequest{
+	pr := &PendingRequest{
 		RequestID: "request", Model: model, EstimatedPromptTokens: 4096,
 		RequestedMaxTokens: 128, CacheRoute: route,
-	})
+	}
+	selected, decision := reg.ReserveProviderEx(model, pr)
 	if selected == nil || selected.ID != baseline.ID {
 		t.Fatalf("observe mode selected %v, want baseline provider %q; decision=%+v", selected, baseline.ID, decision)
 	}
 	if !decision.CacheWouldChange || decision.CacheKind != "observe_exact" || decision.CacheDiscountMs <= 0 {
 		t.Fatalf("cache discount did not change shadow winner: %+v", decision)
+	}
+	if pr.CacheSelectionMode != "observe" || pr.CacheSelectionKind != "exact" || pr.CacheSelectionSelected || !pr.CacheSelectionWouldChange || pr.CacheSelectionDiscountMs != decision.CacheDiscountMs {
+		t.Fatalf("pending observe metadata = %+v", pr)
 	}
 }
 

--- a/coordinator/registry/cache_watermarks.go
+++ b/coordinator/registry/cache_watermarks.go
@@ -1,0 +1,173 @@
+package registry
+
+import (
+	"container/heap"
+	"time"
+)
+
+type cacheActiveAttemptRefEntry struct {
+	nonce    string
+	sequence uint64
+	index    int
+}
+
+type cacheActiveAttemptRefHeap []*cacheActiveAttemptRefEntry
+
+func (h cacheActiveAttemptRefHeap) Len() int { return len(h) }
+func (h cacheActiveAttemptRefHeap) Less(i, j int) bool {
+	if h[i].sequence != h[j].sequence {
+		return h[i].sequence < h[j].sequence
+	}
+	return h[i].nonce < h[j].nonce
+}
+func (h cacheActiveAttemptRefHeap) Swap(i, j int) {
+	h[i], h[j] = h[j], h[i]
+	h[i].index = i
+	h[j].index = j
+}
+func (h *cacheActiveAttemptRefHeap) Push(value any) {
+	entry := value.(*cacheActiveAttemptRefEntry)
+	entry.index = len(*h)
+	*h = append(*h, entry)
+}
+func (h *cacheActiveAttemptRefHeap) Pop() any {
+	old := *h
+	last := len(old) - 1
+	entry := old[last]
+	old[last] = nil
+	entry.index = -1
+	*h = old[:last]
+	return entry
+}
+
+type cacheActiveAttemptRefState struct {
+	order   cacheActiveAttemptRefHeap
+	byNonce map[string]*cacheActiveAttemptRefEntry
+}
+
+func cacheAttemptHolderRefs(attempt cacheAttempt) []cacheHolderRef {
+	refs := make([]cacheHolderRef, 0, 2)
+	if attempt.ExactKey != "" {
+		refs = append(refs, cacheHolderRef{key: attempt.ExactKey, providerID: attempt.ProviderID})
+	}
+	if attempt.ConversationKey != "" && attempt.ConversationKey != attempt.ExactKey {
+		refs = append(refs, cacheHolderRef{key: attempt.ConversationKey, providerID: attempt.ProviderID})
+	}
+	return refs
+}
+
+func (t *cacheRoutingTracker) addActiveAttemptRefsLocked(nonce string, attempt cacheAttempt) {
+	for _, ref := range cacheAttemptHolderRefs(attempt) {
+		state := t.activeAttemptRefs[ref]
+		if state == nil {
+			state = &cacheActiveAttemptRefState{byNonce: make(map[string]*cacheActiveAttemptRefEntry)}
+			t.activeAttemptRefs[ref] = state
+		}
+		entry := &cacheActiveAttemptRefEntry{nonce: nonce, sequence: attempt.Sequence}
+		heap.Push(&state.order, entry)
+		state.byNonce[nonce] = entry
+		t.syncWatermarkEvictabilityLocked(ref)
+	}
+}
+
+func (t *cacheRoutingTracker) removeActiveAttemptRefsLocked(nonce string, attempt cacheAttempt) {
+	for _, ref := range cacheAttemptHolderRefs(attempt) {
+		state := t.activeAttemptRefs[ref]
+		if state == nil {
+			continue
+		}
+		if entry := state.byNonce[nonce]; entry != nil {
+			heap.Remove(&state.order, entry.index)
+			delete(state.byNonce, nonce)
+		}
+		if len(state.order) == 0 {
+			delete(t.activeAttemptRefs, ref)
+		}
+		t.syncWatermarkEvictabilityLocked(ref)
+	}
+	t.enforceWatermarkCapLocked()
+}
+
+func (t *cacheRoutingTracker) watermarkProtectedLocked(ref cacheHolderRef, sequence uint64) bool {
+	state := t.activeAttemptRefs[ref]
+	return state != nil && len(state.order) > 0 && state.order[0].sequence < sequence
+}
+
+func (t *cacheRoutingTracker) syncWatermarkEvictabilityLocked(ref cacheHolderRef) {
+	watermark, exists := t.watermarks[ref]
+	entry := t.watermarkOrderByRef[ref]
+	if !exists || t.watermarkProtectedLocked(ref, watermark.Sequence) {
+		if entry != nil {
+			heap.Remove(&t.watermarkOrder, entry.index)
+			delete(t.watermarkOrderByRef, ref)
+		}
+		return
+	}
+	if entry != nil {
+		entry.updatedAt = watermark.UpdatedAt
+		heap.Fix(&t.watermarkOrder, entry.index)
+		return
+	}
+	entry = &cacheWatermarkOrderEntry{ref: ref, updatedAt: watermark.UpdatedAt}
+	heap.Push(&t.watermarkOrder, entry)
+	t.watermarkOrderByRef[ref] = entry
+}
+
+// activeWatermarkLocked returns the live sequence watermark for one route and
+// provider. Watermarks outlive holders so delayed positive receipts cannot
+// resurrect evidence invalidated by a newer miss or capacity result.
+func (t *cacheRoutingTracker) activeWatermarkLocked(ref cacheHolderRef, now time.Time) (cacheEvidenceWatermark, bool) {
+	watermark, ok := t.watermarks[ref]
+	if !ok {
+		return cacheEvidenceWatermark{}, false
+	}
+	if now.Before(watermark.ExpiresAt) {
+		return watermark, true
+	}
+	t.removeWatermarkLocked(ref)
+	return cacheEvidenceWatermark{}, false
+}
+
+func (t *cacheRoutingTracker) advanceWatermarkLocked(ref cacheHolderRef, sequence uint64, now time.Time) {
+	if ref.key == "" || ref.providerID == "" || sequence == 0 {
+		return
+	}
+	watermark, ok := t.activeWatermarkLocked(ref, now)
+	if ok && sequence < watermark.Sequence {
+		return
+	}
+	if sequence > watermark.Sequence {
+		watermark.Sequence = sequence
+	}
+	watermark.UpdatedAt = now
+	watermarkTTL := t.ttl
+	if watermarkTTL < cacheRoutingInFlightAttemptTTL {
+		watermarkTTL = cacheRoutingInFlightAttemptTTL
+	}
+	watermark.ExpiresAt = now.Add(watermarkTTL)
+	t.watermarks[ref] = watermark
+	t.syncWatermarkEvictabilityLocked(ref)
+	t.enforceWatermarkCapLocked()
+}
+
+func (t *cacheRoutingTracker) removeWatermarkLocked(ref cacheHolderRef) {
+	delete(t.watermarks, ref)
+	if entry := t.watermarkOrderByRef[ref]; entry != nil {
+		heap.Remove(&t.watermarkOrder, entry.index)
+		delete(t.watermarkOrderByRef, ref)
+	}
+}
+
+// enforceWatermarkCapLocked evicts the oldest unprotected watermark in O(log n).
+// activeAttemptRefs keeps protected refs out of watermarkOrder, so completed
+// tombstone churn cannot evict ordering evidence needed by a delayed receipt.
+func (t *cacheRoutingTracker) enforceWatermarkCapLocked() {
+	for len(t.watermarks) > t.maxWatermarks {
+		if len(t.watermarkOrder) == 0 {
+			// Defensive only: the 2*maxAttempts sizing invariant makes this
+			// unreachable while attempt and route-key caps hold.
+			return
+		}
+		t.removeWatermarkLocked(t.watermarkOrder[0].ref)
+	}
+}

--- a/coordinator/registry/config.go
+++ b/coordinator/registry/config.go
@@ -2,6 +2,7 @@ package registry
 
 import (
 	"fmt"
+	"math"
 	"os"
 	"strconv"
 	"strings"
@@ -201,10 +202,10 @@ func (c CacheRoutingConfig) Check() error {
 	if c.MaxHolders < 1 || c.MaxHolders > 32 {
 		return fmt.Errorf("registry: cache routing max holders must be between 1 and 32")
 	}
-	if c.MaxDiscountMs < 0 || c.MaxDiscountMs > 10_000 {
+	if math.IsNaN(c.MaxDiscountMs) || math.IsInf(c.MaxDiscountMs, 0) || c.MaxDiscountMs < 0 || c.MaxDiscountMs > 10_000 {
 		return fmt.Errorf("registry: cache routing max discount must be between 0 and 10000ms")
 	}
-	if c.MaxCostFraction < 0 || c.MaxCostFraction > 1 {
+	if math.IsNaN(c.MaxCostFraction) || math.IsInf(c.MaxCostFraction, 0) || c.MaxCostFraction < 0 || c.MaxCostFraction > 1 {
 		return fmt.Errorf("registry: cache routing max cost fraction must be between 0 and 1")
 	}
 	if mode != CacheRoutingOff {

--- a/coordinator/registry/config_test.go
+++ b/coordinator/registry/config_test.go
@@ -1,6 +1,7 @@
 package registry
 
 import (
+	"math"
 	"testing"
 	"time"
 
@@ -122,5 +123,33 @@ func TestReadConfigCacheRoutingDefaultsOff(t *testing.T) {
 	cfg := ReadConfig().CacheRouting
 	if cfg.Mode != "" || cfg.TTL != 10*time.Minute || cfg.MaxHolders != 4 || cfg.MaxDiscountMs != 1000 || cfg.MaxCostFraction != .35 || cfg.Dedicated {
 		t.Fatalf("cache routing defaults = %+v", cfg)
+	}
+}
+
+func TestCacheRoutingConfigRejectsNonFiniteDiscounts(t *testing.T) {
+	base := CacheRoutingConfig{
+		Mode: CacheRoutingOff, TTL: time.Minute, MaxHolders: 4,
+		MaxDiscountMs: 1000, MaxCostFraction: .35,
+	}
+	for _, tc := range []struct {
+		name       string
+		discountMs float64
+		fraction   float64
+	}{
+		{name: "discount_nan", discountMs: math.NaN(), fraction: .35},
+		{name: "discount_pos_inf", discountMs: math.Inf(1), fraction: .35},
+		{name: "discount_neg_inf", discountMs: math.Inf(-1), fraction: .35},
+		{name: "fraction_nan", discountMs: 1000, fraction: math.NaN()},
+		{name: "fraction_pos_inf", discountMs: 1000, fraction: math.Inf(1)},
+		{name: "fraction_neg_inf", discountMs: 1000, fraction: math.Inf(-1)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := base
+			cfg.MaxDiscountMs = tc.discountMs
+			cfg.MaxCostFraction = tc.fraction
+			if err := cfg.Check(); err == nil {
+				t.Fatalf("accepted non-finite cache routing config: %+v", cfg)
+			}
+		})
 	}
 }

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -156,11 +156,22 @@ type PendingRequest struct {
 	MinDecodeTPS float64
 	// CacheRoute contains coordinator-only HMAC route keys. They are never sent
 	// to providers, logged, or persisted.
-	CacheRoute          CacheRoute
-	CacheReceiptNonce   string
-	CacheScope          string
-	cacheRoutingHints   map[string]cacheRoutingHint
-	cacheRoutingObserve bool
+	CacheRoute        CacheRoute
+	CacheReceiptNonce string
+	CacheScope        string
+	// LegacyCacheBustKey is injected only into the encrypted provider-bound
+	// request body for protocol-0 providers. It is never reflected to the caller.
+	LegacyCacheBustKey string
+	// Cache selection fields are low-cardinality terminal-correlation metadata.
+	// They contain no route keys, scopes, account identifiers, or provider IDs.
+	CacheSelectionMode        string
+	CacheSelectionKind        string
+	CacheSelectionTier        string
+	CacheSelectionDiscountMs  float64
+	CacheSelectionSelected    bool
+	CacheSelectionWouldChange bool
+	cacheRoutingHints         map[string]cacheRoutingHint
+	cacheRoutingObserve       bool
 	// TokenAdmission records the output-token charge admitted at request time so
 	// successful completion can reconcile any positive actual-output delta.
 	TokenAdmission TokenAdmission
@@ -194,6 +205,7 @@ type PendingRequest struct {
 	reservationFinalized  bool
 	routeOutcomeMu        sync.Mutex
 	routeOutcomeFinalized bool
+	cacheTerminalEmitted  bool
 
 	// Timing fields for latency decomposition. Written and read by the
 	// consumer/dispatch goroutine that owns the request. The reputation latency
@@ -227,6 +239,22 @@ type PendingRequest struct {
 	// the first reject so event ordering cannot distort the five-minute rate.
 	// Guarded by timingMu like contentCommitted (same writer/reader goroutines).
 	rateOutcomeCounted bool
+}
+
+// MarkCacheTerminalTelemetryEmitted claims the single terminal cache-selection
+// metric for this attempt. Provider terminals and consumer-side synthetic
+// disconnect/timeout paths can race; only the first terminal seam emits.
+func (pr *PendingRequest) MarkCacheTerminalTelemetryEmitted() bool {
+	if pr == nil {
+		return false
+	}
+	pr.routeOutcomeMu.Lock()
+	defer pr.routeOutcomeMu.Unlock()
+	if pr.cacheTerminalEmitted {
+		return false
+	}
+	pr.cacheTerminalEmitted = true
+	return true
 }
 
 // MarkFirstChunkArrived stamps Timing.FirstChunkAt to now exactly once, under

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -3,6 +3,7 @@ package registry
 import (
 	"math"
 	"math/rand"
+	"strings"
 	"time"
 
 	"github.com/eigeninference/d-inference/coordinator/env"
@@ -345,6 +346,18 @@ func (r *Registry) ReserveProviderEx(model string, pr *PendingRequest, excludeID
 		pr.cacheRoutingHints = cacheTracker.hints(pr.CacheRoute, cacheMode, time.Now())
 		pr.cacheRoutingObserve = cacheMode == CacheRoutingObserve
 	}
+	pr.CacheSelectionMode = ""
+	pr.CacheSelectionKind = ""
+	pr.CacheSelectionTier = ""
+	pr.CacheSelectionDiscountMs = 0
+	pr.CacheSelectionSelected = false
+	pr.CacheSelectionWouldChange = false
+	if pr.CacheRoutingParticipates() && cacheMode != CacheRoutingOff {
+		pr.CacheSelectionMode = "active"
+		if cacheMode == CacheRoutingObserve {
+			pr.CacheSelectionMode = "observe"
+		}
+	}
 
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -421,6 +434,19 @@ func (r *Registry) ReserveProviderEx(model string, pr *PendingRequest, excludeID
 		}
 	}
 
+	bd := selected.breakdown
+	if selected.cacheKind != "" {
+		pr.CacheSelectionMode = "active"
+		pr.CacheSelectionKind = selected.cacheKind
+		if strings.HasPrefix(pr.CacheSelectionKind, "observe_") {
+			pr.CacheSelectionMode = "observe"
+			pr.CacheSelectionKind = strings.TrimPrefix(pr.CacheSelectionKind, "observe_")
+		}
+		pr.CacheSelectionTier = selected.cacheTier
+		pr.CacheSelectionDiscountMs = bd.CacheDiscountMs
+		pr.CacheSelectionSelected = pr.CacheSelectionMode == "active"
+		pr.CacheSelectionWouldChange = selected.cacheWouldChange
+	}
 	pr.ProviderID = p.ID
 	p.addPendingLocked(pr)
 	// If this pair's capacity-reject cooldown just EXPIRED, this reservation is
@@ -437,13 +463,12 @@ func (r *Registry) ReserveProviderEx(model string, pr *PendingRequest, excludeID
 		r.RecordWarmPoolColdDispatch(model)
 	}
 
-	bd := selected.breakdown
 	// Register the RAW estimate with the calibrator so the first-content
 	// observation (API layer, RecordTTFTObservation) can be joined to it.
 	// Warm-slot winners only (StateMs == 0): a cold dispatch's actual includes
 	// model-load time the flow estimate does not model, which would poison the
 	// ratio sample.
-	if bd.RawTTFTMs > 0 && bd.StateMs == 0 {
+	if bd.RawTTFTMs > 0 && bd.StateMs == 0 && !pr.CacheRoutingParticipates() {
 		ttftCalibration.notePrediction(pr.RequestID, pr.Attempt, model, selected.snapshot.chipFamily, bd.RawTTFTMs)
 	}
 	decision := RoutingDecision{

--- a/coordinator/registry/ttft_calibration_scheduler_test.go
+++ b/coordinator/registry/ttft_calibration_scheduler_test.go
@@ -189,3 +189,45 @@ func TestTTFTCalibrationSkipsColdPredictions(t *testing.T) {
 		t.Fatal("cold-slot prediction must not be joinable")
 	}
 }
+
+func TestTTFTCalibrationSkipsCacheParticipatingRequests(t *testing.T) {
+	resetCalibrator(t)
+	reg := New(testLogger())
+	model := "calib-cache-model"
+	calibrationTestProvider(t, reg, "cache-box", model, 100, 100)
+	const promptTokens = 1000
+	const rawEstimateMs = 10_010.0
+
+	for i := 0; i < ttftCalibrationWarmupObs; i++ {
+		req := &PendingRequest{
+			RequestID:             fmt.Sprintf("cache-calib-%d", i),
+			Model:                 model,
+			EstimatedPromptTokens: promptTokens,
+			RequestedMaxTokens:    128,
+			CacheRoute:            CacheRoute{ExactKey: "cache-route"},
+		}
+		selected, decision := reg.ReserveProviderEx(model, req)
+		if selected == nil {
+			t.Fatalf("cache reserve %d failed: %+v", i, decision)
+		}
+		if _, ok := RecordTTFTObservation(req.RequestID, req.Attempt, rawEstimateMs*0.1); ok {
+			t.Fatal("cache-participating request produced a calibration sample")
+		}
+		selected.RemovePending(req.RequestID)
+		reg.SetProviderIdle(selected.ID)
+	}
+	if got := TTFTCalibrationRatio(model, "M3"); got != 1 {
+		t.Fatalf("cache requests lowered calibrator ratio to %v", got)
+	}
+
+	gated := &PendingRequest{
+		RequestID:             "cache-gated",
+		Model:                 model,
+		EstimatedPromptTokens: promptTokens,
+		RequestedMaxTokens:    128,
+		MaxTTFTMs:             5000,
+	}
+	if selected, decision := reg.ReserveProviderEx(model, gated); selected != nil || decision.TTFTRejections != 1 {
+		t.Fatalf("cache samples weakened hard gate: selected=%v decision=%+v", selected, decision)
+	}
+}

--- a/coordinator/store/postgres.go
+++ b/coordinator/store/postgres.go
@@ -104,7 +104,16 @@ RETURNS trigger LANGUAGE plpgsql AS $$ BEGIN
 END $$`
 
 const legacyCacheAffinityGuardTrigger = `DO $$ BEGIN
-	IF NOT EXISTS (SELECT 1 FROM pg_trigger WHERE tgname = 'clear_legacy_cache_affinity_key') THEN
+	IF NOT EXISTS (
+		SELECT 1
+		FROM pg_trigger tg
+		JOIN pg_class target ON target.oid = tg.tgrelid
+		JOIN pg_namespace ns ON ns.oid = target.relnamespace
+		WHERE tg.tgname = 'clear_legacy_cache_affinity_key'
+		  AND NOT tg.tgisinternal
+		  AND target.relname = 'inference_routes'
+		  AND ns.nspname = current_schema()
+	) THEN
 		CREATE TRIGGER clear_legacy_cache_affinity_key
 		BEFORE INSERT OR UPDATE OF cache_affinity_key ON inference_routes
 		FOR EACH ROW EXECUTE FUNCTION clear_legacy_cache_affinity_key();

--- a/coordinator/store/route_telemetry_test.go
+++ b/coordinator/store/route_telemetry_test.go
@@ -21,6 +21,15 @@ func TestLegacyCacheAffinityScrubMigration(t *testing.T) {
 		!strings.Contains(legacyCacheAffinityGuardTrigger, "BEFORE INSERT OR UPDATE OF cache_affinity_key") {
 		t.Fatal("legacy cache-affinity write guard is incomplete")
 	}
+	for _, required := range []string{
+		"tg.tgrelid",
+		"target.relname = 'inference_routes'",
+		"ns.nspname = current_schema()",
+	} {
+		if !strings.Contains(legacyCacheAffinityGuardTrigger, required) {
+			t.Fatalf("legacy cache-affinity trigger existence check missing %q", required)
+		}
+	}
 }
 
 func TestInferenceRoute_Memory(t *testing.T) {

--- a/docs/architecture/cache-aware-routing.md
+++ b/docs/architecture/cache-aware-routing.md
@@ -125,7 +125,8 @@ After asynchronous donation settles, the provider may send:
   "ready_tokens": 8192,
   "required_recompute_tokens": 1536,
   "expected_prefill_tokens_saved": 6656,
-  "tier": "ssd"
+  "tier": "ssd",
+  "stage_ms": 420
 }
 ```
 
@@ -133,11 +134,15 @@ SSD ready means encryption, atomic rename, index insertion, global budget enforc
 contiguous readability all completed. Queue drops, rate limits, low disk, ENOSPC, write
 failure, corruption, shutdown, and immediate eviction do not produce ready. A partial
 leading run can report readiness only when it independently clears the benefit floor.
-Receipt emission never delays chunks or `inference_complete`.
+`stage_ms` is the conservative predicted cost to read and decrypt that durable run on a
+future request, not donation-write latency. Receipt emission never delays chunks or
+`inference_complete`.
 
 New protocol and usage fields are optional. Old providers remain eligible but serve
-uncached. New providers receiving an old-coordinator request serve it uncached rather than
-falling back to a shared remote scope. Go and Swift wire shapes live in
+uncached: the coordinator overwrites their encrypted-body `prompt_cache_key` with a fresh
+per-attempt buster, including while cache routing is off, so legacy caller-derived or empty
+namespaces cannot reuse state. New providers receiving an old-coordinator request serve it
+uncached rather than falling back to a shared remote scope. Go and Swift wire shapes live in
 `coordinator/protocol/messages.go` and
 `provider-swift/Sources/ProviderCore/Protocol/Messages.swift`.
 
@@ -153,7 +158,13 @@ tokens must increase monotonically. Attempt records survive terminal inference f
 minutes because SSD writes complete asynchronously. Attempts also receive a coordinator-
 local monotonic sequence: a delayed negative receipt from an older attempt cannot remove
 or suppress holder evidence established by a newer attempt, while a newer miss can still
-invalidate older evidence.
+invalidate older evidence. A separately bounded evidence watermark survives holder removal,
+so delayed older hit or ready receipts cannot resurrect state after that newer negative.
+Watermarks cover both exact and conversation references for every live delayed attempt and
+expire only after the longer of holder TTL and in-flight attempt TTL. Active-attempt
+sequence heaps keep protected tombstones out of the eviction heap, so capped steady-state
+maintenance remains logarithmic and completed-attempt churn cannot evict evidence required
+by an older live receipt.
 
 Attempt and holder caps use indexed oldest-first heaps, so steady-state insertion at the
 50,000-attempt and 10,000-holder global bounds remains logarithmic. Expiry sweeps are
@@ -176,7 +187,9 @@ cooldown state, loaded-slot state, memory, concurrency, queues, pooled KV, full 
 budget, and TTFT admission.
 
 Reservations continue to use the full prompt and requested output. A stale receipt or
-staging refusal must safely fall back to cold prefill without overcommitment.
+staging refusal must safely fall back to cold prefill without overcommitment. If optional
+SSD staging consumes the last shared headroom, the provider abandons and releases staging,
+retries the full cold reservation, and rejects only if that cold request itself cannot fit.
 
 For an eligible holder:
 
@@ -192,9 +205,11 @@ adjusted_cost = baseline_cost - discount
 ```
 
 Prefill rate must come from cache-miss measurements or a safe benchmark fallback, never an
-EWMA contaminated by cache hits. Exact and conversation discounts do not stack. There is
-no hard affinity override. A busy holder whose adjusted cost is still worse loses to an
-idle provider without a cache.
+EWMA contaminated by cache hits. Cache-participating requests are also excluded from the
+coordinator's full-prefill TTFT calibration and reputation samples because their cache
+outcome is not authoritative at first-content time. Exact and conversation discounts do
+not stack. There is no hard affinity override. A busy holder whose adjusted cost is still
+worse loses to an idle provider without a cache.
 
 Modes are `off`, `observe`, `exact`, and `conversation`. Observe calculates hypothetical
 selection without changing the winner. Dedicated models require their separate enable
@@ -218,6 +233,14 @@ malformed. `off` starts without a secret and disables remote cache participation
 The encrypted SSD tier retains current token-chain, weight, layout, block-size, media, and
 lossless-snapshot checks in
 `provider-swift/Sources/ProviderCore/KVCacheSSD/SSDPrefixCache.swift`.
+The tier is constructed only with a nonempty verified live weight hash, and the coordinator
+sends a remote scope only when the selected provider advertises that same catalog hash.
+The cache-eligible hash requires independently successful cryptographic hashes immediately
+before and after model load, and those hashes must match exactly. Size/mtime fingerprints
+remain a change detector for attestation bookkeeping but cannot authorize reusable KV. A
+failed or mismatched bracket disables reusable SSD cache even if an older hash remains
+available for operator-visible attestation state. Standalone mode performs the same bracket
+before enabling its local SSD tier. There is no model-ID fallback for reusable KV.
 
 Startup and periodic maintenance account for every owned model directory under the `kv2`
 root, including unloaded models. Sliding TTL and the box-wide byte budget therefore do not
@@ -231,7 +254,24 @@ use the writer's canonical uppercase spelling. Young temporary files are treated
 their bytes count toward the global budget, but neither TTL nor budget maintenance deletes
 them. Only exact owned temporary files at least one hour old are crash-orphan candidates.
 Deletion-sensitive traversal also rejects a maintenance root reached through a symlinked
-path component, in addition to rejecting symlinked model and fanout descendants.
+path component, in addition to rejecting symlinked model and fanout descendants. The same
+root/model/fanout checks apply to active scan, read, write, attribute, rename, and deletion
+paths; unsafe cache roots disable the tier rather than following them. On Darwin, active
+file operations open every directory component with `O_NOFOLLOW` and perform read, write,
+rename, touch, and deletion relative to verified directory descriptors, so a concurrent
+fanout-to-symlink replacement cannot redirect I/O outside `kv2`.
+
+SSD staging tickets are keyed by the submission-unique `prefixCacheReceiptID`. The engine
+passes that identity through request-aware lookup and `endAdoption`, so concurrent identical
+prefixes cannot consume each other's pins or let one terminal backstop retire a slower peer.
+Ticket and reservation keys also include a cache-instance namespace, preventing identical
+per-bridge receipt counters from colliding in the process-wide KV budget.
+Every cache-enabled attempt with a receipt nonce finalizes exactly one lookup result,
+including outer-handler drain/admission/load/media/encryption failures, pre-engine capacity
+rejection, submit rejection, and terminal-less teardown. Lookup and ready receipts are
+enqueued synchronously through the thread-safe control sender before a terminal error or
+completion, while the transport itself remains asynchronous; terminal cleanup therefore
+cannot overtake or lose the request's sole receipt.
 
 Natural completion remains the first donation path. Early prompt-only donation occurs
 after full prefill and the first sampled token, behind `DARKBLOOM_EARLY_PROMPT_DONATION`
@@ -247,19 +287,31 @@ deterministic sampler request ID. See
 `provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge.swift`. Completion clears the
 request's exact pending-job identity; later cancellation or preemption therefore releases
 immediately instead of waiting behind unrelated donation-queue work. A request whose own
-donation is still materializing remains charged until that job completes.
+donation is still materializing remains charged until that job completes. Each early job is
+bound to the exact source sequence rows that produced its snapshot; replacement rows from a
+preempted/requeued request release independently. Graceful drain waits for every early or
+terminal donation obligation that still owns backend state, subject to the existing bounded
+shutdown timeout.
 
 ## Telemetry and billing
 
 Low-cardinality telemetry records source kind, holder availability, hypothetical and
 actual selection, baseline and adjusted cost, discount, outcome, tier, cached tokens,
-prefill tokens saved, and stage time. It never records keys or client identifiers. Cold
-prefill, memory hit, SSD staging, and post-adoption prefill remain separate measurements.
+prefill tokens saved, and stage time. Selection metadata is carried on the pending attempt
+and joined to terminal outcome, making per-kind hit precision and non-hit performance
+measurable without request IDs, keys, or client identifiers. Provider completion, provider
+error, consumer timeout, and synthetic WebSocket-disconnect terminals share one idempotent
+per-attempt metric claim. Cold prefill, memory hit, SSD staging, and post-adoption prefill
+remain separate measurements; any request with matched, adopted, or saved cache tokens is
+excluded from the cold-prefill EWMA even if later preemption changes its terminal outcome.
 
 Cached tokens remain part of prompt-token billing in this release. Provider terminal usage
 reports cache details for calibration. OpenAI chat and Responses output now fills the
-existing standard `cached_tokens` usage detail when a validated hit occurs; totals and
-prices do not change. Anthropic billing and usage totals remain unchanged.
+existing standard `cached_tokens` usage detail when a validated hit occurs; sanitized
+terminal usage always overwrites or removes any raw provider-supplied cache detail in
+complete, held-stream, native Responses, content-bearing, and finish-bearing stream payloads.
+Totals and prices do not change.
+Anthropic billing and usage totals remain unchanged.
 
 ## Rollout and rollback
 
@@ -273,7 +325,8 @@ prices do not change. Anthropic billing and usage totals remain unchanged.
 5. Enable exact routing for a narrow canary.
 6. Enable explicit conversation routing, then derived anchors.
 7. Canary dedicated models independently.
-8. Enable early prompt donation independently after contiguous and paged safety tests.
+8. Enable contiguous early prompt donation independently after cancellation, preemption,
+   drain, and retained-state gates; paged early donation remains disabled.
 
 Rollback sets routing to `observe` or `off`, then independently disables receipts or early
 donation. Rollback never restores caller-controlled or unscoped remote namespaces.

--- a/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClientCodec.swift
+++ b/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClientCodec.swift
@@ -186,7 +186,7 @@ public enum CoordinatorClientCodec {
 
         case .prefixCacheReady(
             let requestId, let nonce, let readyTokens,
-            let requiredRecomputeTokens, let expectedPrefillTokensSaved, let tier
+            let requiredRecomputeTokens, let expectedPrefillTokensSaved, let tier, let stageMs
         ):
             return .prefixCacheReady(ProviderMessage.PrefixCacheReady(
                 requestId: requestId,
@@ -194,7 +194,8 @@ public enum CoordinatorClientCodec {
                 readyTokens: readyTokens,
                 requiredRecomputeTokens: requiredRecomputeTokens,
                 expectedPrefillTokensSaved: expectedPrefillTokensSaved,
-                tier: tier
+                tier: tier,
+                stageMs: stageMs
             ))
         }
     }

--- a/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClientTypes.swift
+++ b/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClientTypes.swift
@@ -159,7 +159,8 @@ public enum OutboundMessage: Sendable {
         readyTokens: UInt64,
         requiredRecomputeTokens: UInt64,
         expectedPrefillTokensSaved: UInt64,
-        tier: PrefixCacheTier
+        tier: PrefixCacheTier,
+        stageMs: Double?
     )
 }
 

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge+PrefixCache.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge+PrefixCache.swift
@@ -31,12 +31,11 @@ import os
 // MARK: - Per-request usage signal
 
 /// Thread-safe, set-once-read-late box for a request's terminal usage
-/// detail. One instance per inference request (created by the coordinator
-/// inference handler only when the slot serves via the v2 engine); written
-/// by the bridge pump at the engine terminal, read by the frames loop when
-/// the trailing usage chunk arrives. The pump records BEFORE yielding the
-/// terminal events, and the usage SSE frame is only encoded downstream of
-/// those events, so the read always observes the write.
+/// detail and final lookup receipt. One instance per inference request
+/// (created by the coordinator inference handler only when the slot serves
+/// via the v2 engine); finalized by terminal usage or by the precise
+/// pre-terminal failure path. On success the pump records BEFORE yielding
+/// terminal events, so the trailing usage frame always observes the write.
 public final class EngineV2RequestUsageSignal: @unchecked Sendable {
     private let lock = NSLock()
     private var _prefixCacheHitTokens: Int?
@@ -122,6 +121,23 @@ public final class EngineV2RequestUsageSignal: @unchecked Sendable {
 
     func record(stageResult: SSDPrefixCacheStageResult) {
         lock.withLock { _stageResult = stageResult }
+    }
+
+    func finalizeLookup(
+        failure: PrefixCacheLookupFailureClass,
+        fallbackTier: PrefixCacheTier
+    ) {
+        let resolved: PrefixCacheLookupResult? = lock.withLock {
+            guard !didEmitLookup else { return nil }
+            let result = _stageResult?.resolved(failure: failure)
+                ?? PrefixCacheLookupResult(
+                    outcome: failure == .capacity ? .skippedCapacity : .skippedPolicy,
+                    tier: fallbackTier)
+            _lookupResult = result
+            didEmitLookup = true
+            return result
+        }
+        if let resolved { onLookupResolved?(resolved) }
     }
 
     func recordCacheDisabled(tier: PrefixCacheTier?) {

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge.swift
@@ -180,9 +180,10 @@ public actor EngineV2Bridge {
     var wedgeMonitor = WedgeMonitor()
     var observedDecodeTpsEwma: Double = 0
     var ewmaInitialized = false
-    /// Cold-prefill EWMA (`observed_prefill_tps` heartbeat field), fed per
-    /// successful finish from the bridge's own timing: prefill window =
-    /// first-token time − submit; rate = prompt tokens / window. Absorbs
+    /// Cold-prefill EWMA (`observed_prefill_tps` heartbeat field), fed only by
+    /// successful requests whose terminal usage confirms that no prefix KV was
+    /// adopted. The bridge's timing window is first-token time − submit and
+    /// the rate is prompt tokens / window. Absorbs
     /// PR #454's measurement approach for the v2 engine (that PR added an
     /// engine prefill-start marker for the LEGACY engine; the v2 bridge
     /// already owns both timestamps, so no engine change is needed) with
@@ -336,9 +337,30 @@ public actor EngineV2Bridge {
         // the two pumps would corrupt each other's teardown. Same canonical
         // message → `.requestRejected` (a deterministic client fault).
         guard active[id] == nil else {
+            usageSignal?.finalizeLookup(
+                failure: .policy,
+                fallbackTier: ssdPrefixCache == nil ? .memory : .ssd)
             continuation.yield(.error("token_budget_exhausted: duplicate request ID"))
             continuation.finish()
             return stream
+        }
+
+        // The SSD staging ticket must be submission-unique even when seeded
+        // sampling intentionally reuses a deterministic engine request id.
+        // Mint it before staging and pass the same identity through
+        // CBv2Request.prefixCacheReceiptID so the engine's request-aware
+        // lookup/endAdoption calls balance this exact ticket.
+        let prefixCacheReceiptID: CBv2RequestID?
+        var readyReceiptRegistered = false
+        if cacheEnabled, multimodal == nil, let ssd = ssdPrefixCache {
+            let receiptID = mintPrefixCacheReceiptID()
+            prefixCacheReceiptID = receiptID
+            if let callback = usageSignal?.onCacheReady {
+                ssd.registerReadyReceipt(requestID: receiptID, callback: callback)
+                readyReceiptRegistered = true
+            }
+        } else {
+            prefixCacheReceiptID = nil
         }
 
         // PRE-SUBMIT SSD STAGING (v0.7.5 read-through adoption): probe the
@@ -356,15 +378,25 @@ public actor EngineV2Bridge {
         var ssdStaged = false
         if !cacheEnabled {
             usageSignal?.recordCacheDisabled(tier: ssdPrefixCache == nil ? .memory : .ssd)
-        } else if let ssd = ssdPrefixCache, multimodal == nil {
+        } else if multimodal != nil {
+            usageSignal?.finalizeLookup(
+                failure: .policy,
+                fallbackTier: ssdPrefixCache == nil ? .memory : .ssd)
+        } else if let ssd = ssdPrefixCache, let prefixCacheReceiptID {
             let stageResult = await ssd.stage(
-                requestID: id, promptTokens: promptTokens, cacheScope: cacheScope)
+                requestID: prefixCacheReceiptID,
+                promptTokens: promptTokens,
+                cacheScope: cacheScope)
             usageSignal?.record(stageResult: stageResult)
             ssdStaged = stageResult.staged
             // `stage` suspended this actor — re-check the duplicate guard
             // (same discipline as the shared-budget gate below).
             guard active[id] == nil else {
-                if ssdStaged { ssd.completeStaging(requestID: id) }
+                if ssdStaged { await ssd.abandonStaging(requestID: prefixCacheReceiptID) }
+                if readyReceiptRegistered {
+                    ssd.discardReadyReceipt(requestID: prefixCacheReceiptID)
+                }
+                usageSignal?.finalizeLookup(failure: .policy, fallbackTier: .ssd)
                 continuation.yield(.error("token_budget_exhausted: duplicate request ID"))
                 continuation.finish()
                 return stream
@@ -387,6 +419,7 @@ public actor EngineV2Bridge {
             cacheEnabled: cacheEnabled,
             multimodal: multimodal
         )
+        cbv2Request.prefixCacheReceiptID = prefixCacheReceiptID
 
         // SHARED-BUDGET ADMISSION GATE: reserve this request's worst-case KV
         // footprint (prompt + maxTokens at the fp16 rate — the caches v2
@@ -424,8 +457,28 @@ public actor EngineV2Bridge {
         {
             sharedKVReserved = await kvBudget.reserve(
                 requestID: id, kvBytesPerToken: kvBytesPerToken, tokenCount: worstCaseTokens)
+            if !sharedKVReserved, ssdStaged, let prefixCacheReceiptID {
+                // Optional adoption may be the only reason R no longer fits:
+                // retire S synchronously, then retry the full cold request R.
+                await ssdPrefixCache?.abandonStaging(requestID: prefixCacheReceiptID)
+                ssdStaged = false
+                sharedKVReserved = await kvBudget.reserve(
+                    requestID: id,
+                    kvBytesPerToken: kvBytesPerToken,
+                    tokenCount: worstCaseTokens)
+            }
             guard sharedKVReserved else {
-                if ssdStaged { ssdPrefixCache?.completeStaging(requestID: id) }
+                if let prefixCacheReceiptID {
+                    if ssdStaged {
+                        await ssdPrefixCache?.abandonStaging(requestID: prefixCacheReceiptID)
+                    }
+                    if readyReceiptRegistered {
+                        ssdPrefixCache?.discardReadyReceipt(requestID: prefixCacheReceiptID)
+                    }
+                }
+                usageSignal?.finalizeLookup(
+                    failure: .capacity,
+                    fallbackTier: ssdPrefixCache == nil ? .memory : .ssd)
                 continuation.yield(.error(
                     "token_budget_exhausted: request requires \(worstCaseTokens) tokens "
                         + "but the shared KV budget has no headroom"))
@@ -441,7 +494,17 @@ public actor EngineV2Bridge {
             // on this id's existing entry.)
             guard active[id] == nil else {
                 await kvBudget.release(requestID: id)
-                if ssdStaged { ssdPrefixCache?.completeStaging(requestID: id) }
+                if let prefixCacheReceiptID {
+                    if ssdStaged {
+                        await ssdPrefixCache?.abandonStaging(requestID: prefixCacheReceiptID)
+                    }
+                    if readyReceiptRegistered {
+                        ssdPrefixCache?.discardReadyReceipt(requestID: prefixCacheReceiptID)
+                    }
+                }
+                usageSignal?.finalizeLookup(
+                    failure: .policy,
+                    fallbackTier: ssdPrefixCache == nil ? .memory : .ssd)
                 continuation.yield(.error("token_budget_exhausted: duplicate request ID"))
                 continuation.finish()
                 return stream
@@ -458,18 +521,6 @@ public actor EngineV2Bridge {
         let cbv2Id = mintEngineRequestId(
             seed: cbv2Request.sampling.seed, promptTokens: promptTokens)
         cbv2Request.id = cbv2Id
-        let readyReceiptRequestID: CBv2RequestID?
-        if cacheEnabled, multimodal == nil,
-            let ssd = ssdPrefixCache,
-            let callback = usageSignal?.onCacheReady
-        {
-            let receiptID = mintPrefixCacheReceiptID()
-            cbv2Request.prefixCacheReceiptID = receiptID
-            ssd.registerReadyReceipt(requestID: receiptID, callback: callback)
-            readyReceiptRequestID = receiptID
-        } else {
-            readyReceiptRequestID = nil
-        }
 
         let events: AsyncStream<CBv2Event>
         do {
@@ -488,10 +539,17 @@ public actor EngineV2Bridge {
             // A rejected submit also never ran the prefix-cache lookup, so
             // the engine can never balance the staging ticket — backstop it.
             if sharedKVReserved { await kvBudget?.release(requestID: id) }
-            if ssdStaged { ssdPrefixCache?.completeStaging(requestID: id) }
-            if let readyReceiptRequestID {
-                ssdPrefixCache?.discardReadyReceipt(requestID: readyReceiptRequestID)
+            if let prefixCacheReceiptID {
+                if ssdStaged {
+                    await ssdPrefixCache?.abandonStaging(requestID: prefixCacheReceiptID)
+                }
+                if readyReceiptRegistered {
+                    ssdPrefixCache?.discardReadyReceipt(requestID: prefixCacheReceiptID)
+                }
             }
+            usageSignal?.finalizeLookup(
+                failure: Self.prefixCacheFailureClass(for: error),
+                fallbackTier: ssdPrefixCache == nil ? .memory : .ssd)
             // Admission failure. The message keeps the canonical
             // `token_budget_exhausted:` prefix contract so
             // `fromSchedulerMessage` classifies it as a retryable capacity
@@ -524,7 +582,8 @@ public actor EngineV2Bridge {
             holdsSharedReservation: sharedKVReserved,
             logprobsChannel: logprobsChannel,
             usageSignal: usageSignal,
-            readyReceiptRequestID: readyReceiptRequestID
+            prefixCacheReceiptID: prefixCacheReceiptID,
+            readyReceiptRegistered: readyReceiptRegistered
         )
 
         let bridge = self
@@ -640,7 +699,8 @@ public actor EngineV2Bridge {
         holdsSharedReservation: Bool,
         logprobsChannel: EngineV2LogprobsChannel? = nil,
         usageSignal: EngineV2RequestUsageSignal? = nil,
-        readyReceiptRequestID: CBv2RequestID? = nil
+        prefixCacheReceiptID: CBv2RequestID? = nil,
+        readyReceiptRegistered: Bool = false
     ) {
         let bridge = self
         let task = Task {
@@ -649,7 +709,8 @@ public actor EngineV2Bridge {
                 holdsSharedReservation: holdsSharedReservation,
                 logprobsChannel: logprobsChannel,
                 usageSignal: usageSignal,
-                readyReceiptRequestID: readyReceiptRequestID
+                prefixCacheReceiptID: prefixCacheReceiptID,
+                readyReceiptRegistered: readyReceiptRegistered
             )
             await bridge.clearPumpTask(id: id)
         }
@@ -669,7 +730,8 @@ public actor EngineV2Bridge {
         holdsSharedReservation: Bool,
         logprobsChannel: EngineV2LogprobsChannel? = nil,
         usageSignal: EngineV2RequestUsageSignal? = nil,
-        readyReceiptRequestID: CBv2RequestID? = nil
+        prefixCacheReceiptID: CBv2RequestID? = nil,
+        readyReceiptRegistered: Bool = false
     ) async {
         // NOTE: the shared-budget KV reservation is taken in `submitTokenized`
         // (the pre-engine admission gate), NOT here — the pump only RELEASES
@@ -733,10 +795,12 @@ public actor EngineV2Bridge {
                 // SSD staging backstop: usually a no-op (the engine's
                 // endAdoption already balanced the ticket at adoption
                 // time); covers the lookup-missed corner. Idempotent.
-                ssdPrefixCache?.completeStaging(requestID: id)
-                if let readyReceiptRequestID {
+                if let prefixCacheReceiptID {
+                    ssdPrefixCache?.completeStaging(requestID: prefixCacheReceiptID)
+                }
+                if readyReceiptRegistered, let prefixCacheReceiptID {
                     ssdPrefixCache?.markReadyReceiptTerminal(
-                        requestID: readyReceiptRequestID)
+                        requestID: prefixCacheReceiptID)
                 }
                 continuation.finish()
                 return
@@ -754,13 +818,24 @@ public actor EngineV2Bridge {
             if holdsSharedReservation {
                 await kvBudget?.release(requestID: id)
             }
-            ssdPrefixCache?.completeStaging(requestID: id)
-            if let readyReceiptRequestID {
+            if let prefixCacheReceiptID {
+                ssdPrefixCache?.completeStaging(requestID: prefixCacheReceiptID)
+            }
+            usageSignal?.finalizeLookup(
+                failure: .policy,
+                fallbackTier: ssdPrefixCache == nil ? .memory : .ssd)
+            if readyReceiptRegistered, let prefixCacheReceiptID {
                 ssdPrefixCache?.markReadyReceiptTerminal(
-                    requestID: readyReceiptRequestID)
+                    requestID: prefixCacheReceiptID)
             }
             continuation.finish()
         }
+    }
+
+    private static func prefixCacheFailureClass(
+        for error: Error
+    ) -> PrefixCacheLookupFailureClass {
+        error is CBv2KVError ? .capacity : .policy
     }
 
     /// Terminal framing — mirrors `BatchScheduler+EngineBridge` exactly.
@@ -869,6 +944,7 @@ public actor EngineV2Bridge {
         if success {
             recordPrefillSample(
                 promptTokens: prompt,
+                usage: usage,
                 submittedAt: state.submittedAt,
                 firstTokenAt: state.firstTokenAt)
         }
@@ -907,14 +983,16 @@ public actor EngineV2Bridge {
     }
 
     /// Feed the prefill EWMA (α = 0.3, mirroring the decode EWMA) from a
-    /// successful request's timing. The v2 production engine runs with the
-    /// prefix cache OFF, so every sample is a genuine cold prefill; the
-    /// bounds above still reject degenerate windows.
+    /// successful request's timing only when terminal engine usage proves the
+    /// request performed a cold prefill. Cache hits have a different latency
+    /// distribution and must never calibrate the coordinator's cold TTFT model.
     private func recordPrefillSample(
         promptTokens: Int,
+        usage: CBv2Usage,
         submittedAt: ContinuousClock.Instant,
         firstTokenAt: ContinuousClock.Instant?
     ) {
+        guard Self.isColdPrefillSample(usage: usage) else { return }
         guard let firstTokenAt else { return }
         let prefillSeconds = WedgeMonitor.seconds(firstTokenAt - submittedAt)
         guard
@@ -928,6 +1006,15 @@ public actor EngineV2Bridge {
             observedPrefillTpsEwma = tps
             prefillEwmaInitialized = true
         }
+    }
+
+    static func isColdPrefillSample(usage: CBv2Usage) -> Bool {
+        guard usage.prefixCacheOutcome != .hit else { return false }
+        return max(
+            usage.prefixCacheHitTokens,
+            usage.prefixCacheMatchedTokens,
+            usage.prefixCachePrefillTokensSaved
+        ) <= 0
     }
 
     /// Stream torn down without a terminal event — drop local state.

--- a/provider-swift/Sources/ProviderCore/Inference/PrefixCacheReceipts.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/PrefixCacheReceipts.swift
@@ -25,21 +25,76 @@ public struct PrefixCacheLookupResult: Sendable, Equatable {
 }
 
 public struct PrefixCacheReadyResult: Sendable, Equatable {
+    public static let maxStageMs = 600_000.0
+
     public let readyTokens: Int
     public let requiredRecomputeTokens: Int
     public let expectedPrefillTokensSaved: Int
     public let tier: PrefixCacheTier
+    public let stageMs: Double?
 
     public init(
         readyTokens: Int,
         requiredRecomputeTokens: Int,
         expectedPrefillTokensSaved: Int,
-        tier: PrefixCacheTier = .ssd
+        tier: PrefixCacheTier = .ssd,
+        stageMs: Double? = nil
     ) {
         self.readyTokens = max(0, readyTokens)
         self.requiredRecomputeTokens = max(0, requiredRecomputeTokens)
         self.expectedPrefillTokensSaved = max(0, expectedPrefillTokensSaved)
         self.tier = tier
+        if let stageMs, stageMs.isFinite {
+            self.stageMs = min(Self.maxStageMs, max(0, stageMs))
+        } else {
+            self.stageMs = nil
+        }
+    }
+}
+
+/// One receipt resolver shared by the outer provider handler and the engine
+/// bridge. The outer path owns it until the detached inference task is spawned;
+/// bridge usage or an early failure may resolve it, and every later attempt is
+/// a no-op.
+final class PrefixCacheLookupReceiptFinalizer: @unchecked Sendable {
+    private let lock = NSLock()
+    private var resolved = false
+    private let callback: (@Sendable (PrefixCacheLookupResult) -> Void)?
+
+    init(callback: (@Sendable (PrefixCacheLookupResult) -> Void)?) {
+        self.callback = callback
+    }
+
+    func resolve(_ result: PrefixCacheLookupResult) {
+        let shouldDeliver = lock.withLock { () -> Bool in
+            guard !resolved else { return false }
+            resolved = true
+            return true
+        }
+        if shouldDeliver { callback?(result) }
+    }
+
+    func finalize(
+        failure: PrefixCacheLookupFailureClass,
+        tier: PrefixCacheTier? = nil
+    ) {
+        resolve(PrefixCacheLookupResult(
+            outcome: failure == .capacity ? .skippedCapacity : .skippedPolicy,
+            tier: tier))
+    }
+
+    /// Queue the final lookup receipt before the terminal inference message.
+    /// `SendHandle.send` is synchronous/nonblocking, so this establishes
+    /// outbound ordering without a task hop. A bridge-resolved receipt makes
+    /// the fallback finalization a no-op.
+    func sendTerminal(
+        _ message: OutboundMessage,
+        fallbackFailure: PrefixCacheLookupFailureClass,
+        tier: PrefixCacheTier? = nil,
+        send: SendHandle
+    ) {
+        finalize(failure: fallbackFailure, tier: tier)
+        send.send(message)
     }
 }
 
@@ -82,7 +137,7 @@ enum PrefixCacheReceiptEmitter {
                 prefillTokensSaved: result.prefillTokensSaved > 0
                     ? UInt64(result.prefillTokensSaved) : nil,
                 stageMs: result.stageMs)
-            Task.detached { send.send(message) }
+            send.send(message)
         }
         let ready: @Sendable (PrefixCacheReadyResult) -> Void = { result in
             let message = OutboundMessage.prefixCacheReady(
@@ -91,8 +146,9 @@ enum PrefixCacheReceiptEmitter {
                 readyTokens: UInt64(result.readyTokens),
                 requiredRecomputeTokens: UInt64(result.requiredRecomputeTokens),
                 expectedPrefillTokensSaved: UInt64(result.expectedPrefillTokensSaved),
-                tier: result.tier)
-            Task.detached { send.send(message) }
+                tier: result.tier,
+                stageMs: result.stageMs)
+            send.send(message)
         }
         return (lookup, ready)
     }
@@ -105,6 +161,11 @@ enum SSDPrefixCacheStageDisposition: Sendable, Equatable {
     case skippedCapacity
     case skippedCost
     case skippedPolicy
+}
+
+enum PrefixCacheLookupFailureClass: Sendable {
+    case capacity
+    case policy
 }
 
 struct SSDPrefixCacheStageResult: Sendable, Equatable {
@@ -152,5 +213,15 @@ struct SSDPrefixCacheStageResult: Sendable, Equatable {
             outcome = .skippedPolicy
         }
         return PrefixCacheLookupResult(outcome: outcome, tier: .ssd, stageMs: stageMs)
+    }
+
+    func resolved(failure: PrefixCacheLookupFailureClass) -> PrefixCacheLookupResult {
+        if case .staged = disposition {
+            return PrefixCacheLookupResult(
+                outcome: failure == .capacity ? .skippedCapacity : .skippedPolicy,
+                tier: .ssd,
+                stageMs: stageMs)
+        }
+        return resolved(actualCachedTokens: 0)
     }
 }

--- a/provider-swift/Sources/ProviderCore/KVCacheSSD/SSDBlockPathGuard.swift
+++ b/provider-swift/Sources/ProviderCore/KVCacheSSD/SSDBlockPathGuard.swift
@@ -1,0 +1,114 @@
+// Copyright © 2026 Eigen Labs.
+
+import Foundation
+
+extension SSDBlockStore {
+    /// Create and validate the production `<dedicatedRoot>/<modelKey>` pair
+    /// without accepting a symlinked existing component. The model root must
+    /// be a direct child of the dedicated cache hierarchy.
+    static func prepareModelRoot(dedicatedRoot: URL, modelRoot: URL) throws {
+        let dedicated = dedicatedRoot.standardizedFileURL
+        let model = modelRoot.standardizedFileURL
+        guard model.deletingLastPathComponent().path == dedicated.path,
+            pathResolvesToItself(dedicated), pathResolvesToItself(model)
+        else { throw SSDBlockStoreError.ioFailure("unsafe cache root") }
+
+        let fm = FileManager.default
+        if !fm.fileExists(atPath: dedicated.path) {
+            try fm.createDirectory(at: dedicated, withIntermediateDirectories: true)
+        }
+        guard isRealDirectory(dedicated), pathResolvesToItself(dedicated) else {
+            throw SSDBlockStoreError.ioFailure("dedicated cache root is symlinked")
+        }
+        if !fm.fileExists(atPath: model.path) {
+            try fm.createDirectory(at: model, withIntermediateDirectories: false)
+        }
+        guard isSafeModelRoot(model, dedicatedRoot: dedicated) else {
+            throw SSDBlockStoreError.ioFailure("model cache root is symlinked or escaped")
+        }
+    }
+
+    static func isSafeModelRoot(_ modelRoot: URL, dedicatedRoot: URL) -> Bool {
+        let model = modelRoot.standardizedFileURL
+        let dedicated = dedicatedRoot.standardizedFileURL
+        return model.deletingLastPathComponent().path == dedicated.path
+            && pathResolvesToItself(dedicated)
+            && pathResolvesToItself(model)
+            && isRealDirectory(dedicated)
+            && isRealDirectory(model)
+    }
+
+    static func isSafeBlockURL(_ url: URL, modelRoot: URL? = nil) -> Bool {
+        let file = url.standardizedFileURL
+        let root = (modelRoot ?? file.deletingLastPathComponent().deletingLastPathComponent())
+            .standardizedFileURL
+        let fanout = file.deletingLastPathComponent()
+        let stem = file.deletingPathExtension().lastPathComponent
+        guard file.pathExtension == fileExtension,
+            isLowerHex(stem, count: 32),
+            isLowerHex(fanout.lastPathComponent, count: 2),
+            stem.hasPrefix(fanout.lastPathComponent),
+            fanout.deletingLastPathComponent().path == root.path,
+            isSafeModelRoot(root, dedicatedRoot: root.deletingLastPathComponent()),
+            pathResolvesToItself(fanout), pathResolvesToItself(file)
+        else { return false }
+        if FileManager.default.fileExists(atPath: fanout.path), !isRealDirectory(fanout) {
+            return false
+        }
+        return true
+    }
+
+    @discardableResult
+    static func removeItemIfSafe(
+        at url: URL,
+        under root: URL,
+        beforeOperation: (@Sendable (SSDActiveIOOperation) -> Void)? = nil
+    ) -> Bool {
+        guard isSafeDescendant(url, under: root), isRealRegularFile(url) else { return false }
+        return SSDNoFollowIO.unlinkRegularFile(
+            at: url, beforeOperation: beforeOperation)
+    }
+
+    static func setAttributesIfSafe(
+        _ attributes: [FileAttributeKey: Any],
+        at url: URL,
+        under root: URL,
+        beforeOperation: (@Sendable (SSDActiveIOOperation) -> Void)? = nil
+    ) {
+        guard isSafeDescendant(url, under: root), isRealRegularFile(url),
+            let modificationDate = attributes[.modificationDate] as? Date
+        else { return }
+        SSDNoFollowIO.touchRegularFile(
+            at: url,
+            modificationDate: modificationDate,
+            beforeOperation: beforeOperation)
+    }
+
+    static func isSafeDescendant(_ url: URL, under root: URL) -> Bool {
+        let candidate = url.standardizedFileURL
+        let canonicalRoot = root.standardizedFileURL
+        let prefix = canonicalRoot.path.hasSuffix("/") ? canonicalRoot.path : canonicalRoot.path + "/"
+        return candidate.path.hasPrefix(prefix)
+            && pathResolvesToItself(canonicalRoot)
+            && pathResolvesToItself(candidate)
+    }
+
+    static func pathResolvesToItself(_ url: URL) -> Bool {
+        let standardized = url.standardizedFileURL
+        return standardized.path
+            == standardized.resolvingSymlinksInPath().standardizedFileURL.path
+    }
+
+    static func isRealDirectory(_ url: URL) -> Bool {
+        guard let values = try? url.resourceValues(forKeys: [.isDirectoryKey, .isSymbolicLinkKey])
+        else { return false }
+        return values.isDirectory == true && values.isSymbolicLink != true
+    }
+
+    static func isRealRegularFile(_ url: URL) -> Bool {
+        guard let values = try? url.resourceValues(forKeys: [.isRegularFileKey, .isSymbolicLinkKey])
+        else { return false }
+        return values.isRegularFile == true && values.isSymbolicLink != true
+            && pathResolvesToItself(url)
+    }
+}

--- a/provider-swift/Sources/ProviderCore/KVCacheSSD/SSDBlockStore.swift
+++ b/provider-swift/Sources/ProviderCore/KVCacheSSD/SSDBlockStore.swift
@@ -183,8 +183,13 @@ enum SSDBlockStore {
         metadata: SSDBlockMetadata,
         chunks: [Data],
         kekKey: SymmetricKey,
-        strictFsync: Bool = false
-    ) throws {
+        strictFsync: Bool = false,
+        beforeOperation: (@Sendable (SSDActiveIOOperation) -> Void)? = nil
+    ) throws -> Int {
+        let modelRoot = url.deletingLastPathComponent().deletingLastPathComponent()
+        guard isSafeBlockURL(url, modelRoot: modelRoot) else {
+            throw SSDBlockStoreError.ioFailure("unsafe block path")
+        }
         guard chunks.count == metadata.chunkPlaintextSizes.count,
             chunks.count == metadata.chunks.count
         else {
@@ -202,33 +207,17 @@ enum SSDBlockStore {
         let header = try assembleHeader(
             fileIV: fileIV, wrappedDEK: wrappedDEK, metadataJSON: metadataJSON)
 
-        let dir = url.deletingLastPathComponent()
-        try ensureDirectory(dir)
-        let tmpURL = temporaryFileURL(for: url)
         do {
-            FileManager.default.createFile(atPath: tmpURL.path, contents: nil)
-            let handle = try FileHandle(forWritingTo: tmpURL)
-            defer { try? handle.close() }
+            return try SSDNoFollowIO.writeAtomically(
+                to: url,
+                strictFsync: strictFsync,
+                beforeOperation: beforeOperation
+            ) { handle in
             try handle.write(contentsOf: header)
             try writeEncryptedBody(handle, chunks: chunks, dek: dek, fileIV: fileIV, aad: metadataJSON)
-            if strictFsync { try handle.synchronize() }
-        } catch {
-            try? FileManager.default.removeItem(at: tmpURL)
-            throw SSDBlockStoreError.ioFailure("write tmp: \(error)")
-        }
-        do {
-            if FileManager.default.fileExists(atPath: url.path) {
-                _ = try FileManager.default.replaceItemAt(url, withItemAt: tmpURL)
-            } else {
-                do {
-                    try FileManager.default.moveItem(at: tmpURL, to: url)
-                } catch {
-                    _ = try FileManager.default.replaceItemAt(url, withItemAt: tmpURL)
-                }
             }
         } catch {
-            try? FileManager.default.removeItem(at: tmpURL)
-            throw SSDBlockStoreError.ioFailure("atomic rename: \(error)")
+            throw SSDBlockStoreError.ioFailure("descriptor-relative write: \(error)")
         }
     }
 
@@ -237,12 +226,20 @@ enum SSDBlockStore {
     /// Read + authenticate one block file. Any auth/binding failure throws;
     /// the caller deletes the file and falls back to recompute.
     static func read(
-        from url: URL, kekKey: SymmetricKey
+        from url: URL,
+        kekKey: SymmetricKey,
+        beforeOperation: (@Sendable (SSDActiveIOOperation) -> Void)? = nil
     ) throws -> (SSDBlockMetadata, [Data]) {
-        let header = try readHeader(at: url)
+        guard isSafeBlockURL(url), isRealRegularFile(url) else {
+            throw SSDBlockStoreError.ioFailure("unsafe block path")
+        }
+        let handle = try SSDNoFollowIO.openRegularFileForReading(
+            at: url, beforeOperation: beforeOperation)
+        defer { try? handle.close() }
+        let header = try readHeader(from: handle)
         let dek = try unwrapDEK(
             wrapped: header.wrappedDEK, kekKey: kekKey, aad: header.metadataBytes)
-        let plaintexts = try decryptChunks(at: url, header: header, dek: dek)
+        let plaintexts = try decryptChunks(from: handle, header: header, dek: dek)
         return (header.metadata, plaintexts)
     }
 
@@ -250,8 +247,17 @@ enum SSDBlockStore {
     /// chunk decrypt. NOTE: an unauthenticated read (the AAD is only
     /// verified when chunks are opened); scan decisions made on it are
     /// re-verified at adoption time by the full authenticated `read`.
-    static func readMetadataOnly(from url: URL) throws -> SSDBlockMetadata {
-        try readHeader(at: url).metadata
+    static func readMetadataOnly(
+        from url: URL,
+        beforeOperation: (@Sendable (SSDActiveIOOperation) -> Void)? = nil
+    ) throws -> SSDBlockMetadata {
+        guard isSafeBlockURL(url), isRealRegularFile(url) else {
+            throw SSDBlockStoreError.ioFailure("unsafe block path")
+        }
+        let handle = try SSDNoFollowIO.openRegularFileForReading(
+            at: url, beforeOperation: beforeOperation)
+        defer { try? handle.close() }
+        return try readHeader(from: handle).metadata
     }
 
     // MARK: Temp sweep
@@ -290,9 +296,7 @@ enum SSDBlockStore {
     /// Maintenance performs deletion, so following a caller-controlled root
     /// outside the dedicated cache hierarchy is never acceptable.
     static func isSafeMaintenanceRoot(_ root: URL) -> Bool {
-        let standardized = root.standardizedFileURL
-        return standardized.path
-            == standardized.resolvingSymlinksInPath().standardizedFileURL.path
+        pathResolvesToItself(root)
     }
 
     static func isStaleTempFile(modifiedAt: Int64?, nowSeconds: Int64) -> Bool {
@@ -342,7 +346,7 @@ enum SSDBlockStore {
                         },
                         nowSeconds: nowSeconds)
                 else { continue }
-                if (try? fm.removeItem(at: url)) != nil {
+                if removeItemIfSafe(at: url, under: root) {
                     removed += 1
                 }
             }
@@ -406,16 +410,13 @@ enum SSDBlockStore {
     }
 
     private static func decryptChunks(
-        at url: URL, header: ParsedHeader, dek: SymmetricKey
+        from handle: FileHandle, header: ParsedHeader, dek: SymmetricKey
     ) throws -> [Data] {
-        let handle: FileHandle
         do {
-            handle = try FileHandle(forReadingFrom: url)
             try handle.seek(toOffset: header.bodyOffset)
         } catch {
-            throw SSDBlockStoreError.ioFailure("open/seek \(url.lastPathComponent): \(error)")
+            throw SSDBlockStoreError.ioFailure("seek encrypted body: \(error)")
         }
-        defer { try? handle.close() }
 
         let countBytes = try readExactly(4, from: handle, what: "chunk count")
         let chunkCount = readUInt32LE(countBytes, at: 0)
@@ -466,15 +467,8 @@ enum SSDBlockStore {
         let bodyOffset: UInt64
     }
 
-    private static func readHeader(at url: URL) throws -> ParsedHeader {
-        let handle: FileHandle
-        do {
-            handle = try FileHandle(forReadingFrom: url)
-        } catch {
-            throw SSDBlockStoreError.ioFailure("open \(url.lastPathComponent): \(error)")
-        }
-        defer { try? handle.close() }
-
+    private static func readHeader(from handle: FileHandle) throws -> ParsedHeader {
+        try handle.seek(toOffset: 0)
         let prefix = try readExactly(24, from: handle, what: "header prefix")
         guard Array(prefix.prefix(4)) == magic else {
             throw SSDBlockStoreError.malformedHeader("magic mismatch")
@@ -616,14 +610,4 @@ enum SSDBlockStore {
         return Data(buf)
     }
 
-    private static func ensureDirectory(_ url: URL) throws {
-        if !FileManager.default.fileExists(atPath: url.path) {
-            do {
-                try FileManager.default.createDirectory(
-                    at: url, withIntermediateDirectories: true)
-            } catch {
-                throw SSDBlockStoreError.ioFailure("mkdir \(url.path): \(error)")
-            }
-        }
-    }
 }

--- a/provider-swift/Sources/ProviderCore/KVCacheSSD/SSDNoFollowIO.swift
+++ b/provider-swift/Sources/ProviderCore/KVCacheSSD/SSDNoFollowIO.swift
@@ -1,0 +1,293 @@
+// Copyright © 2026 Eigen Labs.
+
+import Foundation
+#if canImport(Darwin)
+import Darwin
+#endif
+
+enum SSDActiveIOOperation: Sendable {
+    case read
+    case write
+    case touch
+    case delete
+}
+
+/// Descriptor-relative active I/O for the SSD cache. On Darwin every absolute
+/// directory component is opened with `O_NOFOLLOW`, then file operations stay
+/// relative to the verified parent descriptor. A concurrent pathname swap can
+/// detach that directory, but can never redirect I/O through a replacement
+/// symlink.
+enum SSDNoFollowIO {
+    #if canImport(Darwin)
+    static func openRegularFileForReading(
+        at url: URL,
+        beforeOperation: (@Sendable (SSDActiveIOOperation) -> Void)? = nil
+    ) throws -> FileHandle {
+        let (parentFD, name) = try openVerifiedParent(of: url)
+        defer { Darwin.close(parentFD) }
+        beforeOperation?(.read)
+        let fd = name.withCString {
+            openat(parentFD, $0, O_RDONLY | O_CLOEXEC | O_NOFOLLOW)
+        }
+        guard fd >= 0 else { throw posixError("openat read", url: url) }
+        guard isRegularFile(fd) else {
+            Darwin.close(fd)
+            throw SSDBlockStoreError.ioFailure("read target is not a regular file")
+        }
+        return FileHandle(fileDescriptor: fd, closeOnDealloc: true)
+    }
+
+    static func writeAtomically(
+        to url: URL,
+        strictFsync: Bool,
+        beforeOperation: (@Sendable (SSDActiveIOOperation) -> Void)? = nil,
+        writer: (FileHandle) throws -> Void
+    ) throws -> Int {
+        let (parentFD, name) = try openVerifiedBlockParentForWrite(of: url)
+        defer { Darwin.close(parentFD) }
+        beforeOperation?(.write)
+
+        var existing = stat()
+        let existingResult = name.withCString {
+            fstatat(parentFD, $0, &existing, AT_SYMLINK_NOFOLLOW)
+        }
+        if existingResult == 0, (existing.st_mode & S_IFMT) != S_IFREG {
+            throw SSDBlockStoreError.ioFailure("write target is not a regular file")
+        }
+        if existingResult != 0, errno != ENOENT {
+            throw posixError("fstatat write target", url: url)
+        }
+
+        let tempName = "\(name).\(SSDBlockStore.tempMarker).\(UUID().uuidString)"
+        let fd = tempName.withCString {
+            openat(
+                parentFD,
+                $0,
+                O_WRONLY | O_CREAT | O_EXCL | O_CLOEXEC | O_NOFOLLOW,
+                S_IRUSR | S_IWUSR)
+        }
+        guard fd >= 0 else { throw posixError("openat temp", url: url) }
+        var renamed = false
+        defer {
+            if !renamed {
+                tempName.withCString { _ = unlinkat(parentFD, $0, 0) }
+            }
+        }
+
+        let handle = FileHandle(fileDescriptor: fd, closeOnDealloc: true)
+        do {
+            try writer(handle)
+            if strictFsync { try handle.synchronize() }
+            var info = stat()
+            guard fstat(fd, &info) == 0, (info.st_mode & S_IFMT) == S_IFREG else {
+                throw posixError("fstat temp", url: url)
+            }
+            let fileBytes = info.st_size > off_t(Int.max) ? Int.max : Int(info.st_size)
+            try handle.close()
+            let renameResult = tempName.withCString { tempPtr in
+                name.withCString { namePtr in
+                    renameat(parentFD, tempPtr, parentFD, namePtr)
+                }
+            }
+            guard renameResult == 0 else { throw posixError("renameat", url: url) }
+            renamed = true
+            return max(0, fileBytes)
+        } catch {
+            try? handle.close()
+            throw error
+        }
+    }
+
+    @discardableResult
+    static func unlinkRegularFile(
+        at url: URL,
+        beforeOperation: (@Sendable (SSDActiveIOOperation) -> Void)? = nil
+    ) -> Bool {
+        guard let (parentFD, name) = try? openVerifiedParent(of: url) else { return false }
+        defer { Darwin.close(parentFD) }
+        beforeOperation?(.delete)
+        var info = stat()
+        let statResult = name.withCString {
+            fstatat(parentFD, $0, &info, AT_SYMLINK_NOFOLLOW)
+        }
+        guard statResult == 0, (info.st_mode & S_IFMT) == S_IFREG else { return false }
+        return name.withCString { unlinkat(parentFD, $0, 0) == 0 }
+    }
+
+    static func touchRegularFile(
+        at url: URL,
+        modificationDate: Date,
+        beforeOperation: (@Sendable (SSDActiveIOOperation) -> Void)? = nil
+    ) {
+        guard let (parentFD, name) = try? openVerifiedParent(of: url) else { return }
+        defer { Darwin.close(parentFD) }
+        beforeOperation?(.touch)
+        let fd = name.withCString {
+            openat(parentFD, $0, O_RDONLY | O_CLOEXEC | O_NOFOLLOW)
+        }
+        guard fd >= 0 else { return }
+        defer { Darwin.close(fd) }
+        guard isRegularFile(fd) else { return }
+        let interval = modificationDate.timeIntervalSince1970
+        let seconds = time_t(interval.rounded(.down))
+        let nanoseconds = Int((interval - Double(seconds)) * 1_000_000_000)
+        var times = [
+            timespec(tv_sec: seconds, tv_nsec: nanoseconds),
+            timespec(tv_sec: seconds, tv_nsec: nanoseconds),
+        ]
+        _ = futimens(fd, &times)
+    }
+
+    private static func openVerifiedParent(of url: URL) throws -> (Int32, String) {
+        let parent = url.deletingLastPathComponent().standardizedFileURL
+        let name = url.lastPathComponent
+        guard !name.isEmpty, name != ".", name != "..", !name.contains("/") else {
+            throw SSDBlockStoreError.ioFailure("invalid cache filename")
+        }
+        return (try openDirectoryChain(parent), name)
+    }
+
+    private static func openVerifiedBlockParentForWrite(
+        of url: URL
+    ) throws -> (Int32, String) {
+        let fanoutURL = url.deletingLastPathComponent().standardizedFileURL
+        let modelURL = fanoutURL.deletingLastPathComponent()
+        let fanout = fanoutURL.lastPathComponent
+        let name = url.lastPathComponent
+        guard SSDBlockStore.isLowerHex(fanout, count: 2),
+            !name.isEmpty, !name.contains("/")
+        else { throw SSDBlockStoreError.ioFailure("invalid block path") }
+        let modelFD = try openDirectoryChain(modelURL)
+        defer { Darwin.close(modelFD) }
+        let mkdirResult = fanout.withCString {
+            mkdirat(modelFD, $0, S_IRWXU)
+        }
+        guard mkdirResult == 0 || errno == EEXIST else {
+            throw posixError("mkdirat fanout", url: fanoutURL)
+        }
+        let fanoutFD = fanout.withCString {
+            openat(modelFD, $0, O_RDONLY | O_DIRECTORY | O_CLOEXEC | O_NOFOLLOW)
+        }
+        guard fanoutFD >= 0 else {
+            throw posixError("openat fanout", url: fanoutURL)
+        }
+        return (fanoutFD, name)
+    }
+
+    private static func openDirectoryChain(_ directory: URL) throws -> Int32 {
+        let rawPath = directory.path
+        // macOS exposes these immutable system aliases as symlinks. Normalize
+        // only those known aliases textually; never resolve a cache-controlled
+        // component before the O_NOFOLLOW descriptor walk.
+        let canonicalPath: String
+        if rawPath == "/var" || rawPath.hasPrefix("/var/") {
+            canonicalPath = "/private" + rawPath
+        } else if rawPath == "/tmp" || rawPath.hasPrefix("/tmp/") {
+            canonicalPath = "/private" + rawPath
+        } else {
+            canonicalPath = rawPath
+        }
+        guard canonicalPath.hasPrefix("/") else {
+            throw SSDBlockStoreError.ioFailure("cache path is not absolute")
+        }
+        var current = Darwin.open("/", O_RDONLY | O_DIRECTORY | O_CLOEXEC | O_NOFOLLOW)
+        guard current >= 0 else { throw posixError("open root", url: directory) }
+        do {
+            for component in URL(fileURLWithPath: canonicalPath).pathComponents.dropFirst() {
+                guard !component.isEmpty, component != ".", component != "..", component != "/"
+                else { throw SSDBlockStoreError.ioFailure("unsafe cache path component") }
+                let next = component.withCString {
+                    openat(current, $0, O_RDONLY | O_DIRECTORY | O_CLOEXEC | O_NOFOLLOW)
+                }
+                guard next >= 0 else {
+                    throw SSDBlockStoreError.ioFailure(
+                        "openat directory \(component) under \(canonicalPath): "
+                            + String(cString: strerror(errno)))
+                }
+                Darwin.close(current)
+                current = next
+            }
+            return current
+        } catch {
+            Darwin.close(current)
+            throw error
+        }
+    }
+
+    private static func isRegularFile(_ fd: Int32) -> Bool {
+        var info = stat()
+        return fstat(fd, &info) == 0 && (info.st_mode & S_IFMT) == S_IFREG
+    }
+
+    private static func posixError(_ operation: String, url: URL) -> SSDBlockStoreError {
+        SSDBlockStoreError.ioFailure(
+            "\(operation) \(url.lastPathComponent): \(String(cString: strerror(errno)))")
+    }
+    #else
+    static func openRegularFileForReading(
+        at url: URL,
+        beforeOperation: (@Sendable (SSDActiveIOOperation) -> Void)? = nil
+    ) throws -> FileHandle {
+        beforeOperation?(.read)
+        guard SSDBlockStore.isSafeBlockURL(url) else {
+            throw SSDBlockStoreError.ioFailure("unsafe block path")
+        }
+        return try FileHandle(forReadingFrom: url)
+    }
+
+    static func writeAtomically(
+        to url: URL,
+        strictFsync: Bool,
+        beforeOperation: (@Sendable (SSDActiveIOOperation) -> Void)? = nil,
+        writer: (FileHandle) throws -> Void
+    ) throws -> Int {
+        beforeOperation?(.write)
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        guard SSDBlockStore.isSafeBlockURL(url) else {
+            throw SSDBlockStoreError.ioFailure("unsafe block path")
+        }
+        let temp = SSDBlockStore.temporaryFileURL(for: url)
+        guard FileManager.default.createFile(atPath: temp.path, contents: nil) else {
+            throw SSDBlockStoreError.ioFailure("create tmp failed")
+        }
+        let handle = try FileHandle(forWritingTo: temp)
+        do {
+            try writer(handle)
+            if strictFsync { try handle.synchronize() }
+            try handle.close()
+            if FileManager.default.fileExists(atPath: url.path) {
+                _ = try FileManager.default.replaceItemAt(url, withItemAt: temp)
+            } else {
+                try FileManager.default.moveItem(at: temp, to: url)
+            }
+            return (try? url.resourceValues(forKeys: [.fileSizeKey]).fileSize) ?? 0
+        } catch {
+            try? handle.close()
+            try? FileManager.default.removeItem(at: temp)
+            throw error
+        }
+    }
+
+    static func unlinkRegularFile(
+        at url: URL,
+        beforeOperation: (@Sendable (SSDActiveIOOperation) -> Void)? = nil
+    ) -> Bool {
+        beforeOperation?(.delete)
+        guard SSDBlockStore.isSafeDescendant(
+            url, under: url.deletingLastPathComponent().deletingLastPathComponent())
+        else { return false }
+        return (try? FileManager.default.removeItem(at: url)) != nil
+    }
+
+    static func touchRegularFile(
+        at url: URL,
+        modificationDate: Date,
+        beforeOperation: (@Sendable (SSDActiveIOOperation) -> Void)? = nil
+    ) {
+        beforeOperation?(.touch)
+        try? FileManager.default.setAttributes(
+            [.modificationDate: modificationDate], ofItemAtPath: url.path)
+    }
+    #endif
+}

--- a/provider-swift/Sources/ProviderCore/KVCacheSSD/SSDPrefixCache.swift
+++ b/provider-swift/Sources/ProviderCore/KVCacheSSD/SSDPrefixCache.swift
@@ -103,8 +103,8 @@ public final class SSDPrefixCache: CBv2PrefixCache, SSDEvictableStore, @unchecke
 
     struct Config: Sendable {
         let modelId: String
-        /// Weight root hash (MB-1 binding); falls back to the model id
-        /// when no hash is known — same degradation as the legacy tier.
+        /// Verified live weight root hash (MB-1 binding). Production
+        /// construction refuses to create this reusable tier without it.
         let weightHash: String
         let blockSize: Int
         /// `windowCount × maxWindow` — the engine's recompute bound; the
@@ -115,16 +115,52 @@ public final class SSDPrefixCache: CBv2PrefixCache, SSDEvictableStore, @unchecke
         /// the SSD tier's OWN root (never under the legacy `kv/` root the
         /// upgrade sweeper sheds).
         let root: URL
+        /// Canonical `…/darkbloom/kv2` parent. Production construction pins
+        /// the model directory as a direct child; direct test construction
+        /// defaults to `root`'s parent.
+        let dedicatedRoot: URL
         let ttlSeconds: Int64
         let minEffectiveTokens: Int
         let maxStageBytes: Int
         let maxStageMillis: Int
         let nowSeconds: @Sendable () -> Int64
+
+        init(
+            modelId: String,
+            weightHash: String,
+            blockSize: Int,
+            adoptionBoundTokens: Int,
+            layoutEpoch: String,
+            root: URL,
+            dedicatedRoot: URL? = nil,
+            ttlSeconds: Int64,
+            minEffectiveTokens: Int,
+            maxStageBytes: Int,
+            maxStageMillis: Int,
+            nowSeconds: @escaping @Sendable () -> Int64
+        ) {
+            self.modelId = modelId
+            self.weightHash = weightHash
+            self.blockSize = blockSize
+            self.adoptionBoundTokens = adoptionBoundTokens
+            self.layoutEpoch = layoutEpoch
+            self.root = root
+            self.dedicatedRoot = dedicatedRoot ?? root.deletingLastPathComponent()
+            self.ttlSeconds = ttlSeconds
+            self.minEffectiveTokens = minEffectiveTokens
+            self.maxStageBytes = maxStageBytes
+            self.maxStageMillis = maxStageMillis
+            self.nowSeconds = nowSeconds
+        }
     }
 
     let config: Config
     private let kekKey: SymmetricKey
     private let lookupKeys: SSDLookupKeys
+    /// Process-unique namespace for staging tickets and the process-global KV
+    /// reservation ledger. Per-bridge receipt counters intentionally restart at
+    /// one, so their raw values are not globally unique.
+    private let cacheInstanceNamespace: String
     let index: SSDBlockIndex
     private let kvBudget: GlobalKVCacheBudget?
     private let diskBudget: SSDDiskBudget
@@ -136,16 +172,16 @@ public final class SSDPrefixCache: CBv2PrefixCache, SSDEvictableStore, @unchecke
         let matched: Int
         let prefix: [(keys: MLXArray, values: MLXArray, offset: Int)?]
         let deviceBytes: Int
-        /// Requests attached to this entry that have not yet been balanced
-        /// (endAdoption drops one per balanced hit; the bridge backstop
-        /// closes stragglers). PURE residency accounting — the shared-KV
+        /// Requests attached to this entry that have not yet been balanced.
+        /// PURE residency accounting — the shared-KV
         /// reservation is per-ENTRY (`reservationKey`), not per-ticket, so
         /// dropping an arbitrary ticket here can never strand another
         /// request's reservation.
         var openTickets: Set<String>
-        /// Lookup hits not yet balanced by endAdoption — the entry's
-        /// arrays stay parked while an adoption is in flight.
-        var pinsInUse = 0
+        /// Exact request tickets whose lookup hit has not yet been balanced by
+        /// endAdoption. A peer can never consume or retire another request's
+        /// ticket while its adoption is in flight.
+        var pinnedTickets: Set<String> = []
         /// The ONE shared-KV-budget reservation covering this entry's
         /// `deviceBytes` (the CREATING request's key). Attaching requests
         /// release their redundant provisional reservation; this one is
@@ -204,11 +240,13 @@ public final class SSDPrefixCache: CBv2PrefixCache, SSDEvictableStore, @unchecke
         maxWriteBytesPerDay: Int = SSDPrefixCachePolicy.defaultMaxWriteBytesPerDay,
         strictFsync: Bool = false,
         diskBudgetBytes: @escaping @Sendable () -> Int,
-        maintainWholeRoot: (@Sendable () -> Void)? = nil
+        maintainWholeRoot: (@Sendable () -> Void)? = nil,
+        cacheInstanceNamespace: String = UUID().uuidString
     ) {
         self.config = config
         self.kekKey = kekKey
         self.lookupKeys = SSDLookupKeys(kek: kekKey)
+        self.cacheInstanceNamespace = cacheInstanceNamespace
         self.index = SSDBlockIndex()
         self.kvBudget = kvBudget
         self.diskBudget = diskBudget
@@ -251,6 +289,7 @@ public final class SSDPrefixCache: CBv2PrefixCache, SSDEvictableStore, @unchecke
     /// Start the startup directory scan (async — lookups before it
     /// finishes just miss) and the low-frequency periodic TTL sweep.
     func startBackgroundTasks(sweepIntervalSeconds: Int = 60) {
+        guard hasSafeRoot else { return }
         scanTask = Task.detached(priority: .utility) { [weak self] in
             self?.scanOnDisk()
         }
@@ -301,11 +340,33 @@ public final class SSDPrefixCache: CBv2PrefixCache, SSDEvictableStore, @unchecke
     public func lookup(
         tokens: [Int], layerKinds: [CBv2LayerKind]
     ) -> (matched: Int, prefix: [(keys: MLXArray, values: MLXArray, offset: Int)?])? {
-        lookup(tokens: tokens, layerKinds: layerKinds, cacheSalt: nil)
+        lookup(ticket: nil, tokens: tokens, layerKinds: layerKinds, cacheSalt: nil)
     }
 
     public func lookup(
         tokens: [Int], layerKinds: [CBv2LayerKind], cacheSalt: String?
+    ) -> (matched: Int, prefix: [(keys: MLXArray, values: MLXArray, offset: Int)?])? {
+        lookup(ticket: nil, tokens: tokens, layerKinds: layerKinds, cacheSalt: cacheSalt)
+    }
+
+    public func lookup(
+        requestID: CBv2RequestID,
+        tokens: [Int],
+        layerKinds: [CBv2LayerKind],
+        cacheSalt: String?
+    ) -> (matched: Int, prefix: [(keys: MLXArray, values: MLXArray, offset: Int)?])? {
+        lookup(
+            ticket: ticketKey(requestID),
+            tokens: tokens,
+            layerKinds: layerKinds,
+            cacheSalt: cacheSalt)
+    }
+
+    private func lookup(
+        ticket: String?,
+        tokens: [Int],
+        layerKinds: [CBv2LayerKind],
+        cacheSalt: String?
     ) -> (matched: Int, prefix: [(keys: MLXArray, values: MLXArray, offset: Int)?])? {
         // SYNCHRONOUS + RAM-ONLY by contract: the engine calls this on the
         // submit thread — never any disk I/O here. All I/O happened in the
@@ -339,7 +400,22 @@ public final class SSDPrefixCache: CBv2PrefixCache, SSDEvictableStore, @unchecke
                     let cacheable = Self.isCacheable(kind)
                     guard (staged.prefix[i] != nil) == cacheable else { return nil }
                 }
-                staged.pinsInUse += 1
+                let claimedTicket: String
+                if let ticket {
+                    guard tickets[ticket] == tag16,
+                        staged.openTickets.contains(ticket),
+                        !staged.pinnedTickets.contains(ticket)
+                    else { return nil }
+                    claimedTicket = ticket
+                } else {
+                    // Backwards-compatible uncorrelated callers are safe only
+                    // when there is exactly one possible ticket. Never choose
+                    // arbitrarily between concurrent same-prefix requests.
+                    let available = staged.openTickets.subtracting(staged.pinnedTickets)
+                    guard available.count == 1, let only = available.first else { return nil }
+                    claimedTicket = only
+                }
+                staged.pinnedTickets.insert(claimedTicket)
                 return (staged.matched, staged.prefix)
             }
             if let (matched, prefix) = hit {
@@ -354,10 +430,32 @@ public final class SSDPrefixCache: CBv2PrefixCache, SSDEvictableStore, @unchecke
     // MARK: - CBv2PrefixCache: endAdoption (the staging release hook)
 
     public func endAdoption(tokens: [Int], matched: Int) {
-        endAdoption(tokens: tokens, matched: matched, cacheSalt: nil)
+        endAdoption(ticket: nil, tokens: tokens, matched: matched, cacheSalt: nil)
     }
 
     public func endAdoption(tokens: [Int], matched: Int, cacheSalt: String?) {
+        endAdoption(ticket: nil, tokens: tokens, matched: matched, cacheSalt: cacheSalt)
+    }
+
+    public func endAdoption(
+        requestID: CBv2RequestID,
+        tokens: [Int],
+        matched: Int,
+        cacheSalt: String?
+    ) {
+        endAdoption(
+            ticket: ticketKey(requestID),
+            tokens: tokens,
+            matched: matched,
+            cacheSalt: cacheSalt)
+    }
+
+    private func endAdoption(
+        ticket: String?,
+        tokens: [Int],
+        matched: Int,
+        cacheSalt: String?
+    ) {
         guard matched > 0, matched % config.blockSize == 0 else { return }
         let blocks = matched / config.blockSize
         guard blocks * config.blockSize <= tokens.count else { return }
@@ -369,16 +467,20 @@ public final class SSDPrefixCache: CBv2PrefixCache, SSDEvictableStore, @unchecke
         var releaseKey: String?
         lock.withLock {
             guard let staged = stagedEntries[tag16] else { return }
-            staged.pinsInUse = max(0, staged.pinsInUse - 1)
-            // Drop ONE residency ticket per balanced hit. Tickets no longer
-            // map 1:1 to reservations (the entry carries a single per-entry
-            // reservation), so popping an arbitrary one is pure attached-
-            // request accounting — it can't release a still-pinned
-            // concurrent request's budget. The entry's reservation is
-            // released only when the entry itself retires (below).
-            if let ticket = staged.openTickets.popFirst() {
-                tickets.removeValue(forKey: ticket)
+            let claimedTicket: String
+            if let ticket {
+                guard tickets[ticket] == tag16, staged.pinnedTickets.contains(ticket)
+                else { return }
+                claimedTicket = ticket
+            } else {
+                guard staged.pinnedTickets.count == 1,
+                    let only = staged.pinnedTickets.first
+                else { return }
+                claimedTicket = only
             }
+            staged.pinnedTickets.remove(claimedTicket)
+            staged.openTickets.remove(claimedTicket)
+            tickets.removeValue(forKey: claimedTicket)
             releaseKey = removeStagedEntryIfDoneLocked(tag16)
         }
         if let releaseKey, let kvBudget {
@@ -590,8 +692,8 @@ public final class SSDPrefixCache: CBv2PrefixCache, SSDEvictableStore, @unchecke
             guard index.contains(tag16: tag16) else { continue }
             let url = SSDBlockStore.fileURL(
                 root: config.root, tag16Hex: SSDLookupKeys.hex(tag16))
-            try? FileManager.default.setAttributes(
-                [.modificationDate: touchDate], ofItemAtPath: url.path)
+            SSDBlockStore.setAttributesIfSafe(
+                [.modificationDate: touchDate], at: url, under: config.root)
         }
         guard !newBlockIndices.isEmpty else {
             // An all-deduped donation is already durable, but still pass it
@@ -723,7 +825,7 @@ public final class SSDPrefixCache: CBv2PrefixCache, SSDEvictableStore, @unchecke
             return SSDPrefixCacheStageResult(
                 disposition: disposition, stageMs: max(0, milliseconds))
         }
-        guard !isClosed else { return finish(.skippedPolicy) }
+        guard !isClosed, hasSafeRoot else { return finish(.skippedPolicy) }
         guard index.count > 0 else { return finish(.missAbsent) }
         let salt = cacheScope
         let hasher = hasher(cacheSalt: salt)
@@ -782,7 +884,7 @@ public final class SSDPrefixCache: CBv2PrefixCache, SSDEvictableStore, @unchecke
         // build the entry — on attach it is redundant with the entry's own
         // reservation and released immediately.
         let terminalTag = tags16[k - 1]
-        let reservationKey = Self.reservationKey(forRequestID: requestID)
+        let reservationKey = reservationKey(forRequestID: requestID)
         if let kvBudget {
             guard await kvBudget.reserveBytes(requestID: reservationKey, bytes: UInt64(runBytes))
             else { return finish(.skippedCapacity) }
@@ -833,7 +935,7 @@ public final class SSDPrefixCache: CBv2PrefixCache, SSDEvictableStore, @unchecke
                 // Corrupt / torn / stale-binding block: delete, drop from
                 // the index, fall back to the shorter run (or recompute).
                 statsBox.add(corruptDropped: 1)
-                try? FileManager.default.removeItem(at: url)
+                _ = SSDBlockStore.removeItemIfSafe(at: url, under: config.root)
                 index.remove(tag16: tags16[i])
                 #if canImport(os)
                 Self.logger.warning(
@@ -936,8 +1038,8 @@ public final class SSDPrefixCache: CBv2PrefixCache, SSDEvictableStore, @unchecke
         for i in 0 ..< usableBlocks {
             let url = SSDBlockStore.fileURL(
                 root: config.root, tag16Hex: SSDLookupKeys.hex(tags16[i]))
-            try? FileManager.default.setAttributes(
-                [.modificationDate: touchDate], ofItemAtPath: url.path)
+            SSDBlockStore.setAttributesIfSafe(
+                [.modificationDate: touchDate], at: url, under: config.root)
         }
         return finish(.staged(
             matchedTokens: matched,
@@ -945,23 +1047,49 @@ public final class SSDPrefixCache: CBv2PrefixCache, SSDEvictableStore, @unchecke
             shortenedByCorruption: shortenedByCorruption))
     }
 
+    func stage(
+        requestID: CBv2RequestID, promptTokens: [Int], cacheScope: String
+    ) async -> SSDPrefixCacheStageResult {
+        await stage(
+            requestID: ticketKey(requestID),
+            promptTokens: promptTokens,
+            cacheScope: cacheScope)
+    }
+
     /// Bridge backstop: release a request's staging ticket on every
     /// terminal path the engine's `endAdoption` did not already balance
     /// (submit failure before lookup, teardown, defensive). Idempotent.
     func completeStaging(requestID: String) {
-        var releaseKey: String?
-        lock.withLock {
-            guard let tag = tickets.removeValue(forKey: requestID) else { return }
-            guard let staged = stagedEntries[tag] else { return }
-            staged.openTickets.remove(requestID)
-            // Only the entry's own (per-entry) reservation is released, and
-            // only when this was the last user — a request terminating while
-            // a concurrent same-prefix request still pins the shared entry
-            // leaves the reservation in place (residency stays covered).
-            releaseKey = removeStagedEntryIfDoneLocked(tag)
-        }
+        let releaseKey = detachStagingTicket(requestID)
         if let releaseKey, let kvBudget {
             Task { await kvBudget.release(requestID: releaseKey) }
+        }
+    }
+
+
+    func completeStaging(requestID: CBv2RequestID) {
+        completeStaging(requestID: ticketKey(requestID))
+    }
+
+    /// Pre-submit abandonment used by the shared-budget fallback. The release
+    /// is awaited before admission is retried, so optional staging can never
+    /// consume the headroom needed by a request that fits cold.
+    func abandonStaging(requestID: CBv2RequestID) async {
+        guard let releaseKey = detachStagingTicket(ticketKey(requestID)) else { return }
+        await releaseReservation(releaseKey)
+    }
+
+    private func detachStagingTicket(_ requestID: String) -> String? {
+        lock.withLock {
+            guard let tag = tickets.removeValue(forKey: requestID),
+                let staged = stagedEntries[tag]
+            else { return nil }
+            staged.openTickets.remove(requestID)
+            staged.pinnedTickets.remove(requestID)
+            // Only the entry's own (per-entry) reservation is released, and
+            // only when this was the last user. A concurrent peer keeps the
+            // shared entry resident and reservation-accounted.
+            return removeStagedEntryIfDoneLocked(tag)
         }
     }
 
@@ -973,16 +1101,18 @@ public final class SSDPrefixCache: CBv2PrefixCache, SSDEvictableStore, @unchecke
 
     /// Unlink the LRU entry (box-wide budget enforcement).
     func evictOldestEntry() -> Int {
+        guard hasSafeRoot else { return 0 }
         guard let victim = index.oldest() else { return 0 }
         let url = SSDBlockStore.fileURL(
             root: config.root, tag16Hex: SSDLookupKeys.hex(victim.tag16))
-        try? FileManager.default.removeItem(at: url)
+        guard SSDBlockStore.removeItemIfSafe(at: url, under: config.root) else { return 0 }
         let bytes = index.remove(tag16: victim.tag16)
         statsBox.add(evictions: 1)
         return bytes
     }
 
     func reconcileExternalRemovals() {
+        guard hasSafeRoot else { return }
         for tag16 in index.allTags() {
             let url = SSDBlockStore.fileURL(
                 root: config.root, tag16Hex: SSDLookupKeys.hex(tag16))
@@ -996,13 +1126,15 @@ public final class SSDPrefixCache: CBv2PrefixCache, SSDEvictableStore, @unchecke
     /// the periodic low-frequency task): unlink entries whose last hit is
     /// older than the sliding TTL.
     func sweepExpiredEntries() {
+        guard hasSafeRoot else { return }
         let expired = index.expired(now: config.nowSeconds(), ttlSeconds: config.ttlSeconds)
         guard !expired.isEmpty else { return }
         for tag16 in expired {
             let url = SSDBlockStore.fileURL(
                 root: config.root, tag16Hex: SSDLookupKeys.hex(tag16))
-            try? FileManager.default.removeItem(at: url)
-            index.remove(tag16: tag16)
+            if SSDBlockStore.removeItemIfSafe(at: url, under: config.root) {
+                index.remove(tag16: tag16)
+            }
         }
         statsBox.add(ttlExpired: expired.count)
     }
@@ -1014,6 +1146,10 @@ public final class SSDPrefixCache: CBv2PrefixCache, SSDEvictableStore, @unchecke
     /// (weightHash / layoutEpoch / blockSize) and TTL-expired files are
     /// deleted; everything else is indexed with mtime as lastAccess.
     func scanOnDisk() {
+        guard hasSafeRoot else {
+            index.removeAll()
+            return
+        }
         SSDBlockStore.sweepStaleTempFiles(under: config.root)
         let fm = FileManager.default
         let now = config.nowSeconds()
@@ -1024,13 +1160,36 @@ public final class SSDPrefixCache: CBv2PrefixCache, SSDEvictableStore, @unchecke
         var indexed = 0
         var dropped = 0
         var expired = 0
-        for dir in fanouts where (try? dir.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory == true {
+        // A recognized fanout symlink invalidates the whole scan. Skipping it
+        // would leave active cache I/O able to follow the same path later.
+        for dir in fanouts where SSDBlockStore.isLowerHex(dir.lastPathComponent, count: 2) {
+            guard let dirValues = try? dir.resourceValues(
+                forKeys: [.isDirectoryKey, .isSymbolicLinkKey]),
+                dirValues.isDirectory == true, dirValues.isSymbolicLink != true,
+                dir.standardizedFileURL.path
+                    == dir.resolvingSymlinksInPath().standardizedFileURL.path
+            else {
+                index.removeAll()
+                return
+            }
             guard let files = try? fm.contentsOfDirectory(
-                at: dir, includingPropertiesForKeys: [.fileSizeKey, .contentModificationDateKey],
+                at: dir,
+                includingPropertiesForKeys: [
+                    .fileSizeKey, .contentModificationDateKey, .isRegularFileKey,
+                    .isSymbolicLinkKey,
+                ],
                 options: [.skipsHiddenFiles])
             else { continue }
             for url in files where url.pathExtension == SSDBlockStore.fileExtension {
                 if isClosed { return }
+                guard let fileValues = try? url.resourceValues(
+                    forKeys: [.isRegularFileKey, .isSymbolicLinkKey]),
+                    fileValues.isRegularFile == true, fileValues.isSymbolicLink != true,
+                    SSDBlockStore.isSafeBlockURL(url, modelRoot: config.root)
+                else {
+                    index.removeAll()
+                    return
+                }
                 let name = url.deletingPathExtension().lastPathComponent
                 guard let tag16 = Self.hexDecode(name),
                     tag16.count == SSDLookupKeys.truncatedTagLength,
@@ -1040,7 +1199,7 @@ public final class SSDPrefixCache: CBv2PrefixCache, SSDEvictableStore, @unchecke
                     metadata.blockSize == config.blockSize,
                     metadata.lookupTag.hasPrefix(name)
                 else {
-                    try? fm.removeItem(at: url)
+                    _ = SSDBlockStore.removeItemIfSafe(at: url, under: config.root)
                     dropped += 1
                     continue
                 }
@@ -1048,7 +1207,7 @@ public final class SSDPrefixCache: CBv2PrefixCache, SSDEvictableStore, @unchecke
                     forKeys: [.fileSizeKey, .contentModificationDateKey])
                 let mtime = Int64(values?.contentModificationDate?.timeIntervalSince1970 ?? 0)
                 if config.ttlSeconds > 0, now - mtime >= config.ttlSeconds {
-                    try? fm.removeItem(at: url)
+                    _ = SSDBlockStore.removeItemIfSafe(at: url, under: config.root)
                     expired += 1
                     continue
                 }
@@ -1080,7 +1239,17 @@ public final class SSDPrefixCache: CBv2PrefixCache, SSDEvictableStore, @unchecke
             blockSize: config.blockSize, modelName: config.modelId, cacheSalt: cacheSalt)
     }
 
-    static func reservationKey(forRequestID id: String) -> String { "ssd-stage-\(id)" }
+    private var hasSafeRoot: Bool {
+        SSDBlockStore.isSafeModelRoot(config.root, dedicatedRoot: config.dedicatedRoot)
+    }
+
+    private func reservationKey(forRequestID id: String) -> String {
+        "ssd-stage:\(cacheInstanceNamespace):\(id)"
+    }
+
+    private func ticketKey(_ requestID: CBv2RequestID) -> String {
+        "\(cacheInstanceNamespace):\(requestID.raw)"
+    }
 
     private func releaseReservation(_ key: String) async {
         guard let kvBudget else { return }
@@ -1122,6 +1291,13 @@ public final class SSDPrefixCache: CBv2PrefixCache, SSDEvictableStore, @unchecke
         let recompute = min(config.adoptionBoundTokens, readyTokens)
         let expectedSaved = max(0, readyTokens - recompute)
         guard expectedSaved >= config.minEffectiveTokens else { return }
+        guard let durableSizes = index.fileBytes(tags16: tags16.prefix(readableBlocks))
+        else { return }
+        let durableBytes = durableSizes.reduce(0) { total, next in
+            let (sum, overflow) = total.addingReportingOverflow(max(0, next))
+            return overflow ? Int.max : sum
+        }
+        let stageMs = SSDPrefixCachePolicy.estimatedStageMillisDouble(bytes: durableBytes)
 
         let delivery: ((@Sendable (PrefixCacheReadyResult) -> Void), PrefixCacheReadyResult)? =
             lock.withLock {
@@ -1135,7 +1311,8 @@ public final class SSDPrefixCache: CBv2PrefixCache, SSDEvictableStore, @unchecke
                         readyTokens: readyTokens,
                         requiredRecomputeTokens: recompute,
                         expectedPrefillTokensSaved: expectedSaved,
-                        tier: .ssd))
+                        tier: .ssd,
+                        stageMs: stageMs))
             }
         if let delivery { delivery.0(delivery.1) }
     }
@@ -1147,7 +1324,7 @@ public final class SSDPrefixCache: CBv2PrefixCache, SSDEvictableStore, @unchecke
     @discardableResult
     private func removeStagedEntryIfDoneLocked(_ tag16: Data) -> String? {
         guard let staged = stagedEntries[tag16],
-            staged.openTickets.isEmpty, staged.pinsInUse <= 0
+            staged.openTickets.isEmpty, staged.pinnedTickets.isEmpty
         else { return nil }
         stagedEntries.removeValue(forKey: tag16)
         statsBox.add(stagedBytesDelta: -staged.deviceBytes)

--- a/provider-swift/Sources/ProviderCore/KVCacheSSD/SSDPrefixCacheFactory.swift
+++ b/provider-swift/Sources/ProviderCore/KVCacheSSD/SSDPrefixCacheFactory.swift
@@ -77,8 +77,10 @@ enum SSDPrefixCacheFactory {
         SSDWholeRootMaintainer.shared.stopPeriodicMaintenance(root: cacheRootDirectory())
     }
 
-    /// Build the SSD tier for a supported model slot. `weightHash` nil falls
-    /// back to the model id (same binding degradation as the legacy tier).
+    /// Build the SSD tier for a supported model slot. Reusable ciphertext is
+    /// permitted only when it can be bound to the verified hash of the live
+    /// weights. A missing/blank hash disables the tier instead of degrading to
+    /// a model-id binding that could survive a weight replacement.
     static func make(
         modelId: String,
         weightHash: String?,
@@ -86,6 +88,26 @@ enum SSDPrefixCacheFactory {
         kvBudget: GlobalKVCacheBudget?,
         environment: [String: String] = ProcessInfo.processInfo.environment
     ) async -> SSDPrefixCache? {
+        guard let weightHash = verifiedWeightHash(weightHash) else {
+            #if canImport(os)
+            logger.warning(
+                "ssd prefix cache disabled for \(modelId, privacy: .public): verified live weight hash unavailable")
+            #endif
+            return nil
+        }
+        let wholeRoot = cacheRootDirectory()
+        let dir = cacheDirectory(modelId: modelId)
+        do {
+            try SSDBlockStore.prepareModelRoot(
+                dedicatedRoot: wholeRoot,
+                modelRoot: dir)
+        } catch {
+            #if canImport(os)
+            logger.warning(
+                "ssd prefix cache disabled for \(modelId, privacy: .public): unsafe cache path (\(String(describing: error), privacy: .public))")
+            #endif
+            return nil
+        }
         // KEK: SE-wrapped + Keychain-persisted (files must survive restart
         // — restart warmth is the feature). Same construction + escape
         // hatch as the legacy tier.
@@ -119,18 +141,15 @@ enum SSDPrefixCacheFactory {
             kekKey = ephKey
         }
 
-        let dir = cacheDirectory(modelId: modelId)
-        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-        let wholeRoot = cacheRootDirectory()
-
         let blockSize = PrefixCachePolicy.blockSize
         let config = SSDPrefixCache.Config(
             modelId: modelId,
-            weightHash: (weightHash?.isEmpty == false) ? weightHash! : modelId,
+            weightHash: weightHash,
             blockSize: blockSize,
             adoptionBoundTokens: PrefixCachePolicy.adoptionBoundTokens(layerKinds: layerKinds),
             layoutEpoch: SSDBlockStore.layoutEpoch(blockSize: blockSize, layerKinds: layerKinds),
             root: dir,
+            dedicatedRoot: wholeRoot,
             ttlSeconds: SSDPrefixCachePolicy.ttlSeconds(environment: environment),
             minEffectiveTokens: SSDPrefixCachePolicy.minEffectiveTokens(environment: environment),
             maxStageBytes: SSDPrefixCachePolicy.maxStageBytes(environment: environment),
@@ -164,5 +183,11 @@ enum SSDPrefixCacheFactory {
             "ssd prefix cache active for \(modelId, privacy: .public) at \(dir.path, privacy: .public): ttl \(config.ttlSeconds)s sliding, box-wide disk budget \(PrefixCachePolicy.ssdDiskBudgetBytes(environment: environment, freeBytes: PrefixCachePolicy.volumeFreeBytes(at: dir))) B, adoption bound \(config.adoptionBoundTokens) tok — HMAC-keyed names (T-041 leak #2 closed), no memory carve")
         #endif
         return cache
+    }
+
+    static func verifiedWeightHash(_ value: String?) -> String? {
+        guard let value else { return nil }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
     }
 }

--- a/provider-swift/Sources/ProviderCore/KVCacheSSD/SSDPrefixCachePolicy.swift
+++ b/provider-swift/Sources/ProviderCore/KVCacheSSD/SSDPrefixCachePolicy.swift
@@ -114,8 +114,17 @@ enum SSDPrefixCachePolicy {
 
     /// Estimated stage time for `bytes` at the conservative rate.
     static func estimatedStageMillis(bytes: Int) -> Int {
+        Int(estimatedStageMillisDouble(bytes: bytes))
+    }
+
+    /// Wire/scoring estimate for a future read of the durable leading run.
+    /// Positive durable bytes always carry a positive cost, and hostile sizes
+    /// are bounded to the protocol's ten-minute ceiling.
+    static func estimatedStageMillisDouble(bytes: Int) -> Double {
         guard bytes > 0 else { return 0 }
-        return Int((Double(bytes) / conservativeStageBytesPerSecond) * 1000.0)
+        let estimate = (Double(bytes) / conservativeStageBytesPerSecond) * 1000.0
+        guard estimate.isFinite else { return PrefixCacheReadyResult.maxStageMs }
+        return min(PrefixCacheReadyResult.maxStageMs, max(1, estimate.rounded(.up)))
     }
 
     // MARK: - Low-disk guard

--- a/provider-swift/Sources/ProviderCore/KVCacheSSD/SSDWholeRootMaintainer.swift
+++ b/provider-swift/Sources/ProviderCore/KVCacheSSD/SSDWholeRootMaintainer.swift
@@ -76,7 +76,7 @@ final class SSDWholeRootMaintainer: @unchecked Sendable {
             for file in contents.tempFiles {
                 if SSDBlockStore.isStaleTempFile(
                     modifiedAt: file.modifiedAt, nowSeconds: nowSeconds),
-                    (try? FileManager.default.removeItem(at: file.url)) != nil
+                    SSDBlockStore.removeItemIfSafe(at: file.url, under: root)
                 {
                     result.tempFilesRemoved += 1
                 } else {
@@ -94,7 +94,7 @@ final class SSDWholeRootMaintainer: @unchecked Sendable {
                 for file in files {
                     if nowSeconds - file.modifiedAt >= ttlSeconds
                     {
-                        if (try? FileManager.default.removeItem(at: file.url)) != nil {
+                        if SSDBlockStore.removeItemIfSafe(at: file.url, under: root) {
                             result.ttlExpired += 1
                         } else {
                             survivors.append(file)
@@ -114,7 +114,8 @@ final class SSDWholeRootMaintainer: @unchecked Sendable {
                     return $0.url.path < $1.url.path
                 }
                 for file in files where total > limit {
-                    guard (try? FileManager.default.removeItem(at: file.url)) != nil else { continue }
+                    guard SSDBlockStore.removeItemIfSafe(at: file.url, under: root)
+                    else { continue }
                     total = max(0, total - file.bytes)
                     result.budgetEvicted += 1
                 }

--- a/provider-swift/Sources/ProviderCore/KVCacheSSD/SSDWriteBehind.swift
+++ b/provider-swift/Sources/ProviderCore/KVCacheSSD/SSDWriteBehind.swift
@@ -275,15 +275,20 @@ final class SSDWriteBehind: @unchecked Sendable {
                 continue
             }
             let url = SSDBlockStore.fileURL(root: config.root, tag16Hex: block.tag16Hex)
+            guard SSDBlockStore.isSafeBlockURL(url, modelRoot: config.root) else {
+                stats.add(donationsDropped: 1)
+                continue
+            }
+            let fileBytes: Int
             do {
                 if let writeBlock = config.writeBlock {
-                    let fileBytes = try writeBlock(block, url)
+                    fileBytes = try writeBlock(block, url)
                     index.insert(tag16: block.tag16, fileBytes: fileBytes, lastAccess: now)
                     stats.add(blocksWritten: 1, bytesWritten: fileBytes)
                     maySettleDurable = true
                     continue
                 }
-                try SSDBlockStore.write(
+                fileBytes = try SSDBlockStore.write(
                     to: url, metadata: block.metadata, chunks: block.chunks,
                     kekKey: config.kekKey, strictFsync: config.strictFsync)
             } catch {
@@ -299,8 +304,6 @@ final class SSDWriteBehind: @unchecked Sendable {
                 }
                 continue
             }
-            let fileBytes = (try? url.resourceValues(forKeys: [.fileSizeKey]).fileSize)
-                ?? block.plaintextBytes
             // Index LAST, after the durable rename (spec §3.2 step 7).
             index.insert(tag16: block.tag16, fileBytes: fileBytes, lastAccess: now)
             stats.add(blocksWritten: 1, bytesWritten: fileBytes)

--- a/provider-swift/Sources/ProviderCore/Protocol/Messages.swift
+++ b/provider-swift/Sources/ProviderCore/Protocol/Messages.swift
@@ -211,6 +211,7 @@ public enum ProviderMessage: Sendable, Equatable {
         public var requiredRecomputeTokens: UInt64
         public var expectedPrefillTokensSaved: UInt64
         public var tier: PrefixCacheTier
+        public var stageMs: Double?
 
         public init(
             requestId: String,
@@ -218,7 +219,8 @@ public enum ProviderMessage: Sendable, Equatable {
             readyTokens: UInt64,
             requiredRecomputeTokens: UInt64,
             expectedPrefillTokensSaved: UInt64,
-            tier: PrefixCacheTier
+            tier: PrefixCacheTier,
+            stageMs: Double? = nil
         ) {
             self.requestId = requestId
             self.cacheReceiptNonce = cacheReceiptNonce
@@ -226,6 +228,11 @@ public enum ProviderMessage: Sendable, Equatable {
             self.requiredRecomputeTokens = requiredRecomputeTokens
             self.expectedPrefillTokensSaved = expectedPrefillTokensSaved
             self.tier = tier
+            if let stageMs, stageMs.isFinite {
+                self.stageMs = min(PrefixCacheReadyResult.maxStageMs, max(0, stageMs))
+            } else {
+                self.stageMs = nil
+            }
         }
     }
 
@@ -587,6 +594,7 @@ extension ProviderMessage: Codable {
             try container.encode(receipt.requiredRecomputeTokens, forKey: .requiredRecomputeTokens)
             try container.encode(receipt.expectedPrefillTokensSaved, forKey: .expectedPrefillTokensSaved)
             try container.encode(receipt.tier, forKey: .tier)
+            try container.encodeIfPresent(receipt.stageMs, forKey: .stageMs)
         }
     }
 
@@ -736,7 +744,8 @@ extension ProviderMessage: Codable {
                 readyTokens: try container.decode(UInt64.self, forKey: .readyTokens),
                 requiredRecomputeTokens: try container.decode(UInt64.self, forKey: .requiredRecomputeTokens),
                 expectedPrefillTokensSaved: try container.decode(UInt64.self, forKey: .expectedPrefillTokensSaved),
-                tier: try container.decode(PrefixCacheTier.self, forKey: .tier)
+                tier: try container.decode(PrefixCacheTier.self, forKey: .tier),
+                stageMs: try container.decodeIfPresent(Double.self, forKey: .stageMs)
             ))
         }
     }

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+EngineV2.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+EngineV2.swift
@@ -233,7 +233,8 @@ extension ProviderLoop {
         modelDirectory: URL?,
         newcomer newcomerBox: EngineV2NewcomerBox,
         tokenizer: TokenizerHandle,
-        sizing: SlotSizingSnapshot
+        sizing: SlotSizingSnapshot,
+        cacheEligibleWeightHash: String? = nil
     ) async throws -> EngineV2Bridge {
         let existing = await existingSlotGrants(excludingModelId: modelId)
         let newcomer = EngineV2KVSizing.ResliceSlot(
@@ -310,7 +311,8 @@ extension ProviderLoop {
                 container: newcomerBox.borrow(),
                 tokenizer: tokenizer,
                 sizing: sizing,
-                kvBytesCapacity: targets[modelId] ?? 0)
+                kvBytesCapacity: targets[modelId] ?? 0,
+                cacheEligibleWeightHash: cacheEligibleWeightHash)
         } catch {
             newcomerBox.release()
             MLX.Memory.clearCache()
@@ -409,7 +411,8 @@ extension ProviderLoop {
         container: ModelContainer,
         tokenizer: TokenizerHandle,
         sizing: SlotSizingSnapshot,
-        kvBytesCapacity: Int
+        kvBytesCapacity: Int,
+        cacheEligibleWeightHash: String? = nil
     ) async throws -> EngineV2Bridge {
         let maxConcurrent = engineV2MaxConcurrent(forModel: modelId)
 
@@ -489,8 +492,8 @@ extension ProviderLoop {
                 kvBackendConfig: loopConfig.config.backend.engineV2KVBackend,
                 kvBackendConfigByModel: loopConfig.config.backend.engineV2KVBackendByModel,
                 // SSD-tier metadata binding: the verified hash for the bytes
-                // this slot loaded (nil ⇒ model-id binding degradation).
-                weightHash: liveModelHashes[modelId],
+                // this slot loaded (nil/blank disables reusable SSD caching).
+                weightHash: cacheEligibleWeightHash,
                 logInfo: { slotLogger.info($0) },
                 logWarning: { slotLogger.warning($0) })
         }

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+EngineV2Liveness.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+EngineV2Liveness.swift
@@ -183,7 +183,8 @@ extension ProviderLoop {
                 container: slot.container,
                 tokenizer: slot.tokenizer,
                 sizing: slot.sizing,
-                kvBytesCapacity: grant)
+                kvBytesCapacity: grant,
+                cacheEligibleWeightHash: slot.cacheEligibleWeightHash)
             // makeEngineV2BridgeForSlot re-registered `newBridge` in
             // engineV2Runtime (replacing the old bridge's entry).
 
@@ -214,6 +215,7 @@ extension ProviderLoop {
                 container: slot.container,
                 tokenizer: slot.tokenizer,
                 sizing: slot.sizing,
+                cacheEligibleWeightHash: slot.cacheEligibleWeightHash,
                 isVLM: slot.isVLM,
                 modelType: slot.modelType,
                 lastInferenceAt: .now

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+InferenceHandler.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+InferenceHandler.swift
@@ -34,14 +34,20 @@ extension ProviderLoop {
 
     /// Coordinator admission: sends the 503 reroute and returns true if the
     /// request must be dropped because we're draining.
-    private func rejectIfDrainingForUpdate(requestId: String, send: SendHandle) -> Bool {
+    private func rejectIfDrainingForUpdate(
+        requestId: String,
+        send: SendHandle,
+        lookupReceiptFinalizer: PrefixCacheLookupReceiptFinalizer
+    ) -> Bool {
         guard isDrainingForUpdate else { return false }
-        send.send(.inferenceError(
-            requestId: requestId,
-            error: providerDrainingForUpdateReason,
-            statusCode: 503,
-            errorReason: nil
-        ))
+        lookupReceiptFinalizer.sendTerminal(
+            .inferenceError(
+                requestId: requestId,
+                error: providerDrainingForUpdateReason,
+                statusCode: 503,
+                errorReason: nil),
+            fallbackFailure: .capacity,
+            send: send)
         return true
     }
 
@@ -96,31 +102,60 @@ extension ProviderLoop {
     ) async {
         logger.info("Processing inference request: \(requestId)")
 
+        // Cache receipt ownership begins before any admission/decrypt/load work.
+        // A valid nonce must settle exactly once even when the request never
+        // reaches EngineV2Bridge.submitTokenized.
+        let remoteCache = RemotePrefixCacheContext(
+            cacheScope: authenticatedCacheScope,
+            cacheReceiptNonce: cacheReceiptNonce)
+        let receiptCallbacks = PrefixCacheReceiptEmitter.callbacks(
+            requestID: requestId,
+            nonce: remoteCache.receiptNonce,
+            send: send)
+        let lookupReceiptFinalizer = PrefixCacheLookupReceiptFinalizer(
+            callback: receiptCallbacks.lookup)
+        var receiptTransferredToTask = false
+        defer {
+            if !receiptTransferredToTask {
+                lookupReceiptFinalizer.finalize(failure: .policy)
+            }
+        }
+
         if isShuttingDown {
-            send.send(.inferenceError(
-                requestId: requestId,
-                error: "provider is shutting down",
-                statusCode: 503,
-                errorReason: nil
-            ))
+            lookupReceiptFinalizer.sendTerminal(
+                .inferenceError(
+                    requestId: requestId,
+                    error: "provider is shutting down",
+                    statusCode: 503,
+                    errorReason: nil),
+                fallbackFailure: .capacity,
+                send: send)
             return
         }
 
         // Fast-path drain reject (skips decrypt/parse work). Re-checked
         // authoritatively at step 4. See `rejectIfDrainingForUpdate`.
-        if rejectIfDrainingForUpdate(requestId: requestId, send: send) { return }
+        if rejectIfDrainingForUpdate(
+            requestId: requestId,
+            send: send,
+            lookupReceiptFinalizer: lookupReceiptFinalizer)
+        {
+            return
+        }
 
         // 1. Decrypt the request body. Both `ciphertext` and
         // `senderPublicKey` are already base64-decoded by CoordinatorClient,
         // so we hand the raw bytes straight to NodeKeyPair.decrypt.
         guard let senderKey = senderPublicKey, senderKey.count == 32 else {
             logger.error("[\(requestId)] missing or malformed sender public key")
-            send.send(.inferenceError(
-                requestId: requestId,
-                error: "missing or malformed ephemeral_public_key",
-                statusCode: 400,
-                errorReason: nil
-            ))
+            lookupReceiptFinalizer.sendTerminal(
+                .inferenceError(
+                    requestId: requestId,
+                    error: "missing or malformed ephemeral_public_key",
+                    statusCode: 400,
+                    errorReason: nil),
+                fallbackFailure: .policy,
+                send: send)
             return
         }
 
@@ -132,12 +167,14 @@ extension ProviderLoop {
             )
         } catch {
             logger.error("[\(requestId)] decryption failed: \(error)")
-            send.send(.inferenceError(
-                requestId: requestId,
-                error: "decryption failed",
-                statusCode: 400,
-                errorReason: nil
-            ))
+            lookupReceiptFinalizer.sendTerminal(
+                .inferenceError(
+                    requestId: requestId,
+                    error: "decryption failed",
+                    statusCode: 400,
+                    errorReason: nil),
+                fallbackFailure: .policy,
+                send: send)
             return
         }
 
@@ -161,7 +198,14 @@ extension ProviderLoop {
             // the raw error could resurface a prompt fragment in coordinator logs
             // (defense-in-depth for the "coordinator never sees plaintext" invariant).
             logger.error("[\(requestId)] Failed to parse chat request (\(type(of: error)))")
-            send.send(.inferenceError(requestId: requestId, error: "invalid request body", statusCode: 400, errorReason: nil))
+            lookupReceiptFinalizer.sendTerminal(
+                .inferenceError(
+                    requestId: requestId,
+                    error: "invalid request body",
+                    statusCode: 400,
+                    errorReason: nil),
+                fallbackFailure: .policy,
+                send: send)
             return
         }
 
@@ -176,9 +220,6 @@ extension ProviderLoop {
         // sealed OpenAI body. Never trust caller-controlled prompt_cache_key/user
         // for remote cache partitioning. Legacy coordinators omit the outer
         // scope; those requests still serve, but with caching disabled.
-        let remoteCache = RemotePrefixCacheContext(
-            cacheScope: authenticatedCacheScope,
-            cacheReceiptNonce: cacheReceiptNonce)
         let cacheScope = remoteCache.scope ?? ""
         // OpenAI `logprobs` / `top_logprobs` (also absent from the upstream
         // request shape). Non-nil only when the request asked for logprobs;
@@ -199,12 +240,14 @@ extension ProviderLoop {
         let modelId = chatRequest.model
         if await fastAdmissionReject(modelId: modelId) {
             logger.warning("[\(requestId)] Pre-accept reject for '\(modelId)': insufficient capacity to load")
-            send.send(.inferenceError(
-                requestId: requestId,
-                error: "insufficient memory to load model '\(modelId)'",
-                statusCode: 503,
-                errorReason: nil
-            ))
+            lookupReceiptFinalizer.sendTerminal(
+                .inferenceError(
+                    requestId: requestId,
+                    error: "insufficient memory to load model '\(modelId)'",
+                    statusCode: 503,
+                    errorReason: nil),
+                fallbackFailure: .capacity,
+                send: send)
             return
         }
 
@@ -215,7 +258,13 @@ extension ProviderLoop {
         // registration below, so on the actor it is atomic: either we reject now,
         // or the request is counted in `hasInflightWork` before any drain
         // snapshot can miss it.
-        if rejectIfDrainingForUpdate(requestId: requestId, send: send) { return }
+        if rejectIfDrainingForUpdate(
+            requestId: requestId,
+            send: send,
+            lookupReceiptFinalizer: lookupReceiptFinalizer)
+        {
+            return
+        }
 
         // 5. Send inference_accepted
         send.send(.inferenceAccepted(requestId: requestId))
@@ -243,7 +292,14 @@ extension ProviderLoop {
             await cancellationRegistry.finish(requestId: requestId)
             logger.error("[\(requestId)] Failed to load model '\(modelId)': \(error)")
             let statusCode = Self.loadErrorStatusCode(for: error)
-            send.send(.inferenceError(requestId: requestId, error: "model load failed: \(error.localizedDescription)", statusCode: statusCode, errorReason: "model_load"))
+            lookupReceiptFinalizer.sendTerminal(
+                .inferenceError(
+                    requestId: requestId,
+                    error: "model load failed: \(error.localizedDescription)",
+                    statusCode: statusCode,
+                    errorReason: "model_load"),
+                fallbackFailure: statusCode == 503 ? .capacity : .policy,
+                send: send)
             return
         }
 
@@ -261,7 +317,14 @@ extension ProviderLoop {
             }
             await cancellationRegistry.finish(requestId: requestId)
             logger.error("[\(requestId)] Model '\(modelId)' disappeared after load")
-            send.send(.inferenceError(requestId: requestId, error: "model unavailable", statusCode: 500, errorReason: nil))
+            lookupReceiptFinalizer.sendTerminal(
+                .inferenceError(
+                    requestId: requestId,
+                    error: "model unavailable",
+                    statusCode: 500,
+                    errorReason: nil),
+                fallbackFailure: .policy,
+                send: send)
             return
         }
 
@@ -307,8 +370,10 @@ extension ProviderLoop {
         // the assembled assistant text, extracted by parsing each emitted
         // chunk back from its JSON delta.
         let me = self
+        receiptTransferredToTask = true
         let task = Task.detached {
             defer {
+                lookupReceiptFinalizer.finalize(failure: .policy)
                 Task {
                     await registry.finish(requestId: requestId)
                     await me.finishInflightRequest(requestId: requestId)
@@ -329,12 +394,14 @@ extension ProviderLoop {
             } catch {
                 log.error("[\(requestId)] Shared key precomputation failed: \(error)")
                 providerStats.incrementChunkEncryptionErrors()
-                send.send(.inferenceError(
-                    requestId: requestId,
-                    error: "response encryption failed",
-                    statusCode: 500,
-                    errorReason: nil
-                ))
+                lookupReceiptFinalizer.sendTerminal(
+                    .inferenceError(
+                        requestId: requestId,
+                        error: "response encryption failed",
+                        statusCode: 500,
+                        errorReason: nil),
+                    fallbackFailure: .policy,
+                    send: send)
                 return
             }
 
@@ -352,12 +419,14 @@ extension ProviderLoop {
                 } catch {
                     log.error("[\(requestId)] Chunk encryption failed: \(error)")
                     providerStats.incrementChunkEncryptionErrors()
-                    send.send(.inferenceError(
-                        requestId: requestId,
-                        error: "response encryption failed",
-                        statusCode: 500,
-                        errorReason: nil
-                    ))
+                    lookupReceiptFinalizer.sendTerminal(
+                        .inferenceError(
+                            requestId: requestId,
+                            error: "response encryption failed",
+                            statusCode: 500,
+                            errorReason: nil),
+                        fallbackFailure: .policy,
+                        send: send)
                     return false
                 }
 
@@ -383,12 +452,8 @@ extension ProviderLoop {
             // the signal always exists.
             // Best-effort detached delivery: callbacks never hold a cache lock
             // or delay inference terminal messages.
-            let receiptCallbacks = PrefixCacheReceiptEmitter.callbacks(
-                requestID: requestId,
-                nonce: remoteCache.receiptNonce,
-                send: send)
             let v2UsageSignal = EngineV2RequestUsageSignal(
-                onLookupResolved: receiptCallbacks.lookup,
+                onLookupResolved: lookupReceiptFinalizer.resolve,
                 onCacheReady: receiptCallbacks.ready)
 
             // Build a single-model engine view bound to the scheduler we
@@ -469,12 +534,14 @@ extension ProviderLoop {
                 if error is CancellationError || token.isCancelled {
                     log.info("[\(requestId)] Request cancelled while starting the stream")
                     providerStats.incrementCancellationsBeforeOutput()
-                    send.send(.inferenceError(
-                        requestId: requestId,
-                        error: "request cancelled",
-                        statusCode: 499,
-                        errorReason: nil
-                    ))
+                    lookupReceiptFinalizer.sendTerminal(
+                        .inferenceError(
+                            requestId: requestId,
+                            error: "request cancelled",
+                            statusCode: 499,
+                            errorReason: nil),
+                        fallbackFailure: .policy,
+                        send: send)
                     return
                 }
                 log.error("[\(requestId)] Failed to start stream: \(error)")
@@ -507,12 +574,14 @@ extension ProviderLoop {
                         )
                     }
                 }
-                send.send(.inferenceError(
-                    requestId: requestId,
-                    error: error.localizedDescription,
-                    statusCode: statusCode,
-                    errorReason: reason
-                ))
+                lookupReceiptFinalizer.sendTerminal(
+                    .inferenceError(
+                        requestId: requestId,
+                        error: error.localizedDescription,
+                        statusCode: statusCode,
+                        errorReason: reason),
+                    fallbackFailure: statusCode == 503 ? .capacity : .policy,
+                    send: send)
                 return
             }
 
@@ -705,12 +774,14 @@ extension ProviderLoop {
                     // Mid-stream generation error. Left unclassified (nil): the
                     // Harmony channel-tags / null-bridge template failures surface
                     // at stream START (see the catch below), not here.
-                    send.send(.inferenceError(
-                        requestId: requestId,
-                        error: error.localizedDescription,
-                        statusCode: statusCode,
-                        errorReason: nil
-                    ))
+                    lookupReceiptFinalizer.sendTerminal(
+                        .inferenceError(
+                            requestId: requestId,
+                            error: error.localizedDescription,
+                            statusCode: statusCode,
+                            errorReason: nil),
+                        fallbackFailure: statusCode == 503 ? .capacity : .policy,
+                        send: send)
                     return
                 }
             }
@@ -759,12 +830,14 @@ extension ProviderLoop {
                 guard case .complete(let settledUsage) = terminal else {
                     // Cancelled with nothing delivered: 499 so the coordinator refunds.
                     providerStats.incrementCancellationsBeforeOutput()
-                    send.send(.inferenceError(
-                        requestId: requestId,
-                        error: "request cancelled",
-                        statusCode: 499,
-                        errorReason: nil
-                    ))
+                    lookupReceiptFinalizer.sendTerminal(
+                        .inferenceError(
+                            requestId: requestId,
+                            error: "request cancelled",
+                            statusCode: 499,
+                            errorReason: nil),
+                        fallbackFailure: .policy,
+                        send: send)
                     return
                 }
                 if completionTokens == 0 {
@@ -867,12 +940,14 @@ extension ProviderLoop {
                 prefillTokensSaved: cacheResult.map { UInt64(max(0, $0.prefillTokensSaved)) },
                 cacheStageMs: cacheResult?.stageMs
             )
-            send.send(.inferenceComplete(
-                requestId: requestId,
-                usage: usageInfo,
-                seSignature: attestation.signature,
-                responseHash: attestation.hash
-            ))
+            lookupReceiptFinalizer.sendTerminal(
+                .inferenceComplete(
+                    requestId: requestId,
+                    usage: usageInfo,
+                    seSignature: attestation.signature,
+                    responseHash: attestation.hash),
+                fallbackFailure: .policy,
+                send: send)
 
             log.info(
                 "[\(requestId)] Complete\(cancelledMidStream ? " (cancelled mid-stream, partial settle)" : ""): "

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+ModelLoading.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+ModelLoading.swift
@@ -23,10 +23,15 @@ extension ProviderLoop {
     /// `liveModelHashes` entry now reflects bytes on disk. `effectiveFingerprint`
     /// is what the after-load TOCTOU check compares against to decide whether the
     /// bytes drifted between hashing and loading.
-    private struct WeightHashRefreshResult {
+    struct WeightHashRefreshResult: Sendable {
+        /// Fingerprint observed by this attempt, even when hashing failed.
+        let observedFingerprint: String?
         /// Fingerprint that `liveModelHashes[modelId]` now corresponds to, or nil
         /// if we have no trustworthy fingerprint (stat failed / recompute failed).
         let effectiveFingerprint: String?
+        /// Hash eligible to bind reusable cache state during this load. Unlike
+        /// `liveModelHashes`, this is nil after a failed recomputation.
+        let cacheEligibleWeightHash: String?
     }
 
     /// Re-hash the weights for `modelId` and update `liveModelHashes` /
@@ -41,16 +46,32 @@ extension ProviderLoop {
     /// a stale hash would make the coordinator hard-untrust this provider for a
     /// "model swap" even though the disk is correct. Returns the fingerprint the
     /// recorded hash now corresponds to so the caller can detect a post-load drift.
-    private func refreshWeightHash(modelId: String, modelPath: URL) async throws -> WeightHashRefreshResult {
+    func refreshWeightHash(
+        modelId: String,
+        modelPath: URL,
+        requireFreshCryptographicHash: Bool = false
+    ) async throws -> WeightHashRefreshResult {
         let priorFingerprint = modelHashFingerprints[modelId]
-        let hasPriorHash = liveModelHashes[modelId] != nil
+        let priorHash = SSDPrefixCacheFactory.verifiedWeightHash(liveModelHashes[modelId])
+        let fingerprintOverride = weightHashFingerprintOverride
+        let hashOverride = weightHashComputeOverride
         let refresh = await Task.detached(priority: .utility) {
             () -> (fingerprint: String?, hash: String?, skipped: Bool) in
-            let fingerprint = WeightHasher.snapshotFingerprint(snapshotDir: modelPath)
-            if let fingerprint, fingerprint == priorFingerprint, hasPriorHash {
+            let fingerprint = fingerprintOverride != nil
+                ? fingerprintOverride!(modelPath)
+                : WeightHasher.snapshotFingerprint(snapshotDir: modelPath)
+            if !requireFreshCryptographicHash,
+                let fingerprint, fingerprint == priorFingerprint, priorHash != nil
+            {
                 return (fingerprint, nil, true)  // unchanged — keep cached hash
             }
-            return (fingerprint, WeightHasher.computeHash(snapshotDir: modelPath, modelID: modelId), false)
+            let hash = hashOverride != nil
+                ? hashOverride!(modelPath, modelId)
+                : WeightHasher.computeHash(snapshotDir: modelPath, modelID: modelId)
+            return (
+                fingerprint,
+                SSDPrefixCacheFactory.verifiedWeightHash(hash),
+                false)
         }.value
         try Task.checkCancellation()
         if isShuttingDown { throw CancellationError() }
@@ -60,7 +81,8 @@ extension ProviderLoop {
         // the next reload fingerprint-match against the stale hash and silently
         // skip the retry — turning a transient read failure into a persistently
         // stale report.
-        let haveTrustworthyHash = refresh.hash != nil || refresh.skipped
+        let cacheEligibleWeightHash = refresh.hash ?? (refresh.skipped ? priorHash : nil)
+        let haveTrustworthyHash = refresh.fingerprint != nil && cacheEligibleWeightHash != nil
         if let fingerprint = refresh.fingerprint, haveTrustworthyHash {
             modelHashFingerprints[modelId] = fingerprint
         }
@@ -86,8 +108,40 @@ extension ProviderLoop {
         // nil when we couldn't establish a trustworthy hash/fingerprint pair, in
         // which case the after-load check should re-hash (safe direction).
         return WeightHashRefreshResult(
-            effectiveFingerprint: haveTrustworthyHash ? refresh.fingerprint : nil
+            observedFingerprint: refresh.fingerprint,
+            effectiveFingerprint: haveTrustworthyHash ? refresh.fingerprint : nil,
+            cacheEligibleWeightHash: haveTrustworthyHash ? cacheEligibleWeightHash : nil
         )
+    }
+
+    /// Resolve the only hash safe to bind to the loaded container. Fingerprint
+    /// drift makes the exact bytes consumed by the loader ambiguous, so the SSD
+    /// tier remains disabled even if a later disk re-hash succeeds.
+    static func cacheEligibleWeightHash(
+        preLoad: WeightHashRefreshResult,
+        postLoadFingerprint: String?,
+        postLoadRefresh: WeightHashRefreshResult?
+    ) -> String? {
+        guard let postLoadFingerprint else { return nil }
+        if preLoad.effectiveFingerprint == postLoadFingerprint {
+            return preLoad.cacheEligibleWeightHash
+        }
+        // A failed pre-load hash can be retried after load only when the same
+        // observed fingerprint brackets the entire load.
+        guard preLoad.observedFingerprint == postLoadFingerprint,
+            postLoadRefresh?.effectiveFingerprint == postLoadFingerprint
+        else { return nil }
+        return postLoadRefresh?.cacheEligibleWeightHash
+    }
+
+    static func cryptographicallyBracketedCacheHash(
+        preLoadHash: String?, postLoadHash: String?
+    ) -> String? {
+        guard let preLoadHash = SSDPrefixCacheFactory.verifiedWeightHash(preLoadHash),
+            let postLoadHash = SSDPrefixCacheFactory.verifiedWeightHash(postLoadHash),
+            preLoadHash == postLoadHash
+        else { return nil }
+        return preLoadHash
     }
 
     /// Load `modelId` if it is not already resident.
@@ -235,7 +289,14 @@ extension ProviderLoop {
             // goes active guarantees a challenge arriving mid-serve reports the
             // hash of the bytes actually loaded — not the disk state at daemon
             // start. (See `refreshWeightHash` for the full rationale.)
-            let preLoadRefresh = try await refreshWeightHash(modelId: modelId, modelPath: modelPath)
+            let reusableSSDRequested: Bool = {
+                if case .ssd = PrefixCachePolicy.mode() { return true }
+                return false
+            }()
+            let preLoadRefresh = try await refreshWeightHash(
+                modelId: modelId,
+                modelPath: modelPath,
+                requireFreshCryptographicHash: reusableSSDRequested)
 
             if let beforeModelLoad {
                 await beforeModelLoad(modelId)
@@ -262,13 +323,30 @@ extension ProviderLoop {
             // fingerprint and no re-read. A nil pre-load fingerprint also forces a
             // re-hash here — we never recorded a trustworthy hash, so re-deriving
             // it post-load is the safe direction.
-            let postLoadFingerprint = WeightHasher.snapshotFingerprint(snapshotDir: modelPath)
-            if preLoadRefresh.effectiveFingerprint == nil
+            let postLoadFingerprint = weightHashFingerprintOverride != nil
+                ? weightHashFingerprintOverride!(modelPath)
+                : WeightHasher.snapshotFingerprint(snapshotDir: modelPath)
+            var postLoadRefresh: WeightHashRefreshResult?
+            if reusableSSDRequested {
+                // A size/mtime fingerprint cannot prove exact bytes. Re-hash
+                // cryptographically after every reusable-cache load and require
+                // equality with the independently-computed pre-load hash.
+                postLoadRefresh = try await refreshWeightHash(
+                    modelId: modelId,
+                    modelPath: modelPath,
+                    requireFreshCryptographicHash: true)
+            } else if preLoadRefresh.effectiveFingerprint == nil
                 || postLoadFingerprint != preLoadRefresh.effectiveFingerprint {
                 logger.warning(
                     "Snapshot fingerprint drifted between hash and load for \(modelId) — recomputing weight hash for the bytes actually loaded")
-                _ = try await refreshWeightHash(modelId: modelId, modelPath: modelPath)
+                postLoadRefresh = try await refreshWeightHash(
+                    modelId: modelId, modelPath: modelPath)
             }
+            let cacheEligibleWeightHash = reusableSSDRequested
+                ? Self.cryptographicallyBracketedCacheHash(
+                    preLoadHash: preLoadRefresh.cacheEligibleWeightHash,
+                    postLoadHash: postLoadRefresh?.cacheEligibleWeightHash)
+                : nil
             // Hard-fail without Metal (moved from the legacy scheduler's
             // loadModel): CPU inference is not acceptable, and with no
             // legacy engine left this is a load failure, not a log line.
@@ -367,7 +445,8 @@ extension ProviderLoop {
                     modelDirectory: modelPath,
                     newcomer: newcomer,
                     tokenizer: tokenizer,
-                    sizing: sizing
+                    sizing: sizing,
+                    cacheEligibleWeightHash: cacheEligibleWeightHash
                 )
             } catch let error as InferenceError {
                 // Already shaped (e.g. the re-slice floor refusal) — record +
@@ -444,6 +523,7 @@ extension ProviderLoop {
                 container: installContainer,
                 tokenizer: tokenizer,
                 sizing: sizing,
+                cacheEligibleWeightHash: cacheEligibleWeightHash,
                 isVLM: slotIsVLM,
                 modelType: modelInfo.modelType,
                 lastInferenceAt: .now

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+Testing.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+Testing.swift
@@ -25,6 +25,27 @@ extension ProviderLoop {
     /// Test seam: recorded weight hash for a model (nil when unknown).
     func modelHashForTesting(_ id: String) -> String? { modelHashes[id] }
 
+    func liveModelHashForTesting(_ id: String) -> String? { liveModelHashes[id] }
+
+    func setWeightHashOperationsForTesting(
+        fingerprint: (@Sendable (URL) -> String?)?,
+        computeHash: (@Sendable (URL, String) -> String?)?
+    ) {
+        weightHashFingerprintOverride = fingerprint
+        weightHashComputeOverride = computeHash
+    }
+
+    func refreshWeightHashForTesting(
+        modelId: String,
+        modelPath: URL,
+        requireFreshCryptographicHash: Bool = false
+    ) async throws -> WeightHashRefreshResult {
+        try await refreshWeightHash(
+            modelId: modelId,
+            modelPath: modelPath,
+            requireFreshCryptographicHash: requireFreshCryptographicHash)
+    }
+
     /// Test seam: exposes the prefetch pre-check decision.
     func prefetchPreCheckForTesting(_ id: String) -> PrefetchPreCheck { prefetchPreCheck(modelId: id) }
 
@@ -267,6 +288,7 @@ extension ProviderLoop {
                 container: try newcomer.borrow(),
                 tokenizer: tokenizer,
                 sizing: sizing,
+                cacheEligibleWeightHash: nil,
                 isVLM: false,
                 modelType: modelType,
                 lastInferenceAt: .now
@@ -297,6 +319,7 @@ extension ProviderLoop {
             container: container,
             tokenizer: tokenizer,
             sizing: sizing,
+            cacheEligibleWeightHash: nil,
             isVLM: false,
             modelType: modelType,
             lastInferenceAt: .now

--- a/provider-swift/Sources/ProviderCore/ProviderLoop.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop.swift
@@ -166,6 +166,10 @@ public actor ProviderLoop {
     internal let powerAssertion: InferencePowerAssertion
     internal let preloadTaskStarted: (@Sendable (String) -> Void)?
     internal let beforeModelLoad: (@Sendable (String) async -> Void)?
+    /// Test-only overrides for weight-hash disk operations. Production leaves
+    /// these nil and calls `WeightHasher` directly.
+    internal var weightHashFingerprintOverride: (@Sendable (URL) -> String?)?
+    internal var weightHashComputeOverride: (@Sendable (URL, String) -> String?)?
 
     /// Per-model inference slots. Each loaded model gets one EngineV2Bridge.
     /// Keyed by model ID.
@@ -582,6 +586,9 @@ public actor ProviderLoop {
         /// Scheduler-free sizing facts (weights, fp16 KV rate, context) —
         /// feeds re-slicing, heartbeat fleet context, and the vision gate.
         let sizing: SlotSizingSnapshot
+        /// Hash verified for the exact bytes bracketed around this slot's load.
+        /// Reused only when rebuilding the engine over the retained container.
+        let cacheEligibleWeightHash: String?
         /// Vision-language model (config has `vision_config`). The container
         /// supplies vision preprocessing before multimodal EngineV2 prefill.
         let isVLM: Bool

--- a/provider-swift/Sources/ProviderCore/Server/StandaloneServer.swift
+++ b/provider-swift/Sources/ProviderCore/Server/StandaloneServer.swift
@@ -134,17 +134,23 @@ public actor StandaloneServer {
         let physicalMemoryBytes: UInt64?
         let emitTelemetry: (@Sendable (TelemetryEvent) -> Void)?
         let beforeWeightLoad: (@Sendable (String) async throws -> Void)?
+        let computeWeightHash: (@Sendable (URL, String) -> String?)?
+        let onCacheEligibleWeightHash: (@Sendable (String?) -> Void)?
         let makeEngine: @Sendable (String, Int) throws -> any CBv2Engine
 
         init(
             physicalMemoryBytes: UInt64? = nil,
             emitTelemetry: (@Sendable (TelemetryEvent) -> Void)? = nil,
             beforeWeightLoad: (@Sendable (String) async throws -> Void)? = nil,
+            computeWeightHash: (@Sendable (URL, String) -> String?)? = nil,
+            onCacheEligibleWeightHash: (@Sendable (String?) -> Void)? = nil,
             makeEngine: @escaping @Sendable (String, Int) throws -> any CBv2Engine
         ) {
             self.physicalMemoryBytes = physicalMemoryBytes
             self.emitTelemetry = emitTelemetry
             self.beforeWeightLoad = beforeWeightLoad
+            self.computeWeightHash = computeWeightHash
+            self.onCacheEligibleWeightHash = onCacheEligibleWeightHash
             self.makeEngine = makeEngine
         }
     }
@@ -372,7 +378,8 @@ public actor StandaloneServer {
         container: MLXLMCommon.ModelContainer,
         tokenizer: TokenizerHandle,
         sizing: SlotSizingSnapshot,
-        isVLM: Bool = false
+        isVLM: Bool = false,
+        cacheEligibleWeightHash: String? = nil
     ) async throws -> EngineV2Bridge {
         // Convenience shape: box the container the way loadModel does (the
         // caller also holds its own reference, so unwind-ordering assertions
@@ -385,7 +392,8 @@ public actor StandaloneServer {
             modelDirectory: nil,
             newcomer: newcomer,
             tokenizer: tokenizer,
-            sizing: sizing)
+            sizing: sizing,
+            cacheEligibleWeightHash: cacheEligibleWeightHash)
         guard let installContainer = newcomer.container else {
             throw StandaloneServerError.capacityUnavailable(
                 "internal: newcomer container missing at install for '\(modelId)'")
@@ -412,7 +420,8 @@ public actor StandaloneServer {
         modelDirectory: URL? = nil,
         newcomer: EngineV2NewcomerBox,
         tokenizer: TokenizerHandle,
-        sizing: SlotSizingSnapshot
+        sizing: SlotSizingSnapshot,
+        cacheEligibleWeightHash: String? = nil
     ) async throws -> EngineV2Bridge {
         try await resliceAndBuildSlot(
             modelId: modelId,
@@ -421,7 +430,8 @@ public actor StandaloneServer {
             modelDirectory: modelDirectory,
             newcomer: newcomer,
             tokenizer: tokenizer,
-            sizing: sizing)
+            sizing: sizing,
+            cacheEligibleWeightHash: cacheEligibleWeightHash)
     }
 
     /// Test seam: the post-bridge-guard failure unwind (retire bridge →
@@ -524,7 +534,8 @@ public actor StandaloneServer {
         modelDirectory: URL?,
         newcomer newcomerBox: EngineV2NewcomerBox,
         tokenizer: TokenizerHandle,
-        sizing: SlotSizingSnapshot
+        sizing: SlotSizingSnapshot,
+        cacheEligibleWeightHash: String? = nil
     ) async throws -> EngineV2Bridge {
         let existing = await existingSlotGrants(excludingModelId: modelId)
         let newcomer = EngineV2KVSizing.ResliceSlot(
@@ -586,6 +597,7 @@ public actor StandaloneServer {
         // last strong reference and `release()` frees the weights.
         let bridge: EngineV2Bridge
         do {
+            v2TestHooks?.onCacheEligibleWeightHash?(cacheEligibleWeightHash)
             bridge = try await EngineV2SlotFactory.makeProductionBridge(
                 modelId: modelId,
                 modelType: modelType,
@@ -600,6 +612,7 @@ public actor StandaloneServer {
                 kvQuantConfigured: config.kvQuant,
                 kvBackendConfig: config.engineV2KVBackend,
                 kvBackendConfigByModel: config.engineV2KVBackendByModel,
+                weightHash: cacheEligibleWeightHash,
                 emitTelemetry: v2TestHooks?.emitTelemetry,
                 makeEngineOverride: v2TestHooks?.makeEngine,
                 logInfo: { standaloneLogger.info("\($0)") },
@@ -895,6 +908,18 @@ public actor StandaloneServer {
         models.map { $0.id }.sorted()
     }
 
+    private func computeStandaloneWeightHash(
+        modelPath: URL, modelId: String
+    ) async -> String? {
+        let override = v2TestHooks?.computeWeightHash
+        return await Task.detached(priority: .utility) {
+            let hash = override != nil
+                ? override!(modelPath, modelId)
+                : WeightHasher.computeHash(snapshotDir: modelPath, modelID: modelId)
+            return SSDPrefixCacheFactory.verifiedWeightHash(hash)
+        }.value
+    }
+
     /// Lazy-load a model if it isn't already resident. Serializes loads and
     /// applies LRU + memory-headroom eviction, then builds the v2 slot
     /// through the shared sizing → re-slice → bridge path.
@@ -975,6 +1000,13 @@ public actor StandaloneServer {
                 requestID: pendingLoadID, bytes: pendingLoadBytes)
 
             try await v2TestHooks?.beforeWeightLoad?(modelId)
+            let reusableSSDRequested: Bool = {
+                if case .ssd = PrefixCachePolicy.mode() { return true }
+                return false
+            }()
+            let preLoadCacheHash = reusableSSDRequested
+                ? await computeStandaloneWeightHash(modelPath: modelPath, modelId: modelId)
+                : nil
             // Hard-fail without Metal: CPU inference is not acceptable, and
             // with no legacy engine left this is a load failure, not a log
             // line (mirrors ProviderLoop.ensureModelLoaded).
@@ -989,6 +1021,12 @@ public actor StandaloneServer {
             let newcomer = EngineV2NewcomerBox(
                 try await ModelContainerLoading.loadContainer(from: modelPath))
             try Task.checkCancellation()
+            let postLoadCacheHash = reusableSSDRequested
+                ? await computeStandaloneWeightHash(modelPath: modelPath, modelId: modelId)
+                : nil
+            let cacheEligibleWeightHash = ProviderLoop.cryptographicallyBracketedCacheHash(
+                preLoadHash: preLoadCacheHash,
+                postLoadHash: postLoadCacheHash)
 
             // Scheduler-free sizing snapshot: weight bytes + the engine-truth
             // fp16 KV rate + context window — everything the re-slice and
@@ -1049,7 +1087,8 @@ public actor StandaloneServer {
                     modelDirectory: modelPath,
                     newcomer: newcomer,
                     tokenizer: tokenizer,
-                    sizing: sizing)
+                    sizing: sizing,
+                    cacheEligibleWeightHash: cacheEligibleWeightHash)
             } catch let error as StandaloneServerError {
                 MLX.Memory.clearCache()
                 throw error

--- a/provider-swift/Tests/ProviderCoreTests/CoordinatorClientTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/CoordinatorClientTests.swift
@@ -171,8 +171,10 @@ import Testing
         readyTokens: 1024,
         requiredRecomputeTokens: 256,
         expectedPrefillTokensSaved: 768,
-        tier: .ssd))
+        tier: .ssd,
+        stageMs: 3.5))
     #expect(ready.contains(#""type":"prefix_cache_ready""#))
+    #expect(ready.contains(#""stage_ms":3.5"#))
 }
 
 @Test func coordinatorHeartbeatConstructionOmitRulesMatchProtocol() throws {

--- a/provider-swift/Tests/ProviderCoreTests/EngineV2BridgeTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/EngineV2BridgeTests.swift
@@ -268,6 +268,60 @@ private func makeRequest(
     )
 }
 
+private func makeBridgeStagedCache(
+    parent: URL,
+    budget: GlobalKVCacheBudget
+) async throws -> (cache: SSDPrefixCache, prompt: [Int]) {
+    _ = LiveInferenceFixtures.ensureMetallibColocated()
+    let root = parent.appendingPathComponent("aaaaaaaaaaaa", isDirectory: true)
+    try SSDBlockStore.prepareModelRoot(dedicatedRoot: parent, modelRoot: root)
+    let layerKinds = [
+        CBv2LayerKind(attention: .full, headDim: 4, kvHeads: 1, queryHeads: 1)
+    ]
+    let cache = SSDPrefixCache(
+        config: .init(
+            modelId: "bridge-stage-model",
+            weightHash: "bridge-stage-weight",
+            blockSize: 8,
+            adoptionBoundTokens: 0,
+            layoutEpoch: SSDBlockStore.layoutEpoch(blockSize: 8, layerKinds: layerKinds),
+            root: root,
+            dedicatedRoot: parent,
+            ttlSeconds: 900,
+            minEffectiveTokens: 8,
+            maxStageBytes: 1 << 20,
+            maxStageMillis: 10_000,
+            nowSeconds: { 10_000 }),
+        kekKey: SymmetricKey(size: .bits256),
+        kvBudget: budget,
+        diskBudget: SSDDiskBudget(),
+        maxWriteBytesPerDay: 0,
+        diskBudgetBytes: { 1 << 20 })
+    let tokenCount = 64
+    let shape = [1, 1, tokenCount, 4]
+    let keys = MLXArray(0 ..< shape.reduce(1, *)).reshaped(shape).asType(.float16)
+    let values = keys + 1
+    eval(keys, values)
+    cache.donate(
+        tokens: Array(0 ..< tokenCount),
+        snapshots: [(keys: keys, values: values, offset: tokenCount)],
+        layerKinds: layerKinds,
+        cacheSalt: "scope")
+    let deadline = ContinuousClock.now + .seconds(10)
+    while ContinuousClock.now < deadline, cache.index.count < 8 {
+        try? await Task.sleep(for: .milliseconds(20))
+    }
+    guard cache.index.count == 8 else {
+        cache.close()
+        throw BridgeFixtureError.cacheDidNotPersist
+    }
+    return (cache, Array(0 ..< tokenCount) + [999])
+}
+
+private enum BridgeFixtureError: Error {
+    case cacheDidNotPersist
+}
+
 // MARK: - Translation
 
 @Suite("EngineV2 translation: ChatCompletionRequest → CBv2Request")
@@ -1578,6 +1632,151 @@ struct EngineV2SharedBudgetTests {
         // …and the shared reservation taken by the gate was rolled back, so
         // a rejected request can never pin shared headroom.
         #expect(await budget.outstandingReservedBytes() == 0)
+    }
+
+    @Test("SSD staging never false-rejects a request that fits cold at the exact boundary")
+    func stagingFallsBackToColdReservation() async throws {
+        let parent = FileManager.default.temporaryDirectory.resolvingSymlinksInPath()
+            .appendingPathComponent("bridge-stage-boundary-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: parent, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: parent) }
+
+        let kvBytesPerToken = 1_000_000
+        let worstCaseTokens = 66  // 65 prompt + 1 completion
+        let coldBytes = UInt64(kvBytesPerToken * worstCaseTokens)
+        let gib: UInt64 = 1_073_741_824
+        let budget = GlobalKVCacheBudget(
+            capFraction: 1.0,
+            activationReserveBytes: 0,
+            memorySnapshot: {
+                .init(
+                    total: 3 * gib,
+                    active: gib - coldBytes,
+                    cache: 0,
+                    systemAvailable: coldBytes)
+            })
+        let fixture = try await makeBridgeStagedCache(parent: parent, budget: budget)
+        defer { fixture.cache.close() }
+        let engine = ScriptedCBv2Engine(script: .manual)
+        let bridge = makeBridge(
+            engine: engine,
+            kvBytesPerToken: kvBytesPerToken,
+            kvBudget: budget,
+            ssdPrefixCache: fixture.cache)
+        let signal = EngineV2RequestUsageSignal()
+
+        let stream = await bridge.submitTokenized(
+            promptTokens: fixture.prompt,
+            request: makeRequest(maxTokens: 1),
+            requestId: "req-stage-boundary",
+            cacheScope: "scope",
+            usageSignal: signal)
+
+        #expect(engine.submitted.count == 1, "cold-fit request must reach the engine")
+        #expect(engine.submitted.first?.prefixCacheReceiptID != nil)
+        #expect(fixture.cache.bytesInUse == 0, "optional staging must be abandoned before retry")
+        #expect(await budget.outstandingReservedBytes() == coldBytes)
+
+        let consumer = Task { await record(stream) }
+        engine.manualContinuation?.yield(.finished(
+            reason: .stop,
+            usage: CBv2Usage(
+                promptTokens: fixture.prompt.count,
+                completionTokens: 0,
+                prefixCacheOutcome: .miss)))
+        engine.manualContinuation?.finish()
+        _ = await consumer.value
+        #expect(await budget.outstandingReservedBytes() == 0)
+    }
+}
+
+@Suite("EngineV2 lookup receipt terminal coverage")
+struct EngineV2LookupReceiptCoverageTests {
+    private final class Box: @unchecked Sendable {
+        private let lock = NSLock()
+        private var values: [PrefixCacheLookupResult] = []
+
+        func append(_ value: PrefixCacheLookupResult) {
+            lock.withLock { values.append(value) }
+        }
+
+        var snapshot: [PrefixCacheLookupResult] { lock.withLock { values } }
+    }
+
+    private func signal(_ box: Box) -> EngineV2RequestUsageSignal {
+        EngineV2RequestUsageSignal(onLookupResolved: box.append)
+    }
+
+    @Test("shared-budget rejection emits exactly one final lookup receipt")
+    func sharedBudgetRejection() async {
+        let box = Box()
+        let engine = ScriptedCBv2Engine(script: .manual)
+        let bridge = makeBridge(
+            engine: engine,
+            kvBytesPerToken: 4_000,
+            kvBudget: TestBudgets.exhausted())
+        _ = await record(await bridge.submitTokenized(
+            promptTokens: [1, 2, 3],
+            request: makeRequest(maxTokens: 8),
+            requestId: "receipt-shared-reject",
+            cacheEnabled: true,
+            usageSignal: signal(box)))
+        #expect(box.snapshot.count == 1)
+        #expect(box.snapshot.first?.outcome == .skippedCapacity)
+        #expect(box.snapshot.first?.tier == .memory)
+        #expect(engine.submitted.isEmpty)
+    }
+
+    @Test("engine submit rejection emits exactly one final lookup receipt")
+    func engineSubmitRejection() async {
+        let box = Box()
+        let engine = ScriptedCBv2Engine(script: .throwOnSubmit(
+            CBv2KVError.capacityExhausted(needed: 10, available: 1)))
+        let bridge = makeBridge(engine: engine)
+        _ = await record(await bridge.submitTokenized(
+            promptTokens: [1, 2, 3],
+            request: makeRequest(maxTokens: 8),
+            requestId: "receipt-engine-reject",
+            cacheEnabled: true,
+            usageSignal: signal(box)))
+        #expect(box.snapshot.count == 1)
+        #expect(box.snapshot.first?.outcome == .skippedCapacity)
+    }
+
+    @Test("teardown without finished emits exactly one final lookup receipt")
+    func teardownWithoutFinished() async {
+        let box = Box()
+        let engine = ScriptedCBv2Engine(script: .stream([
+            .delta(text: "partial", tokens: [1], logprobs: nil)
+        ]))
+        let bridge = makeBridge(engine: engine)
+        _ = await record(await bridge.submitTokenized(
+            promptTokens: [1, 2, 3],
+            request: makeRequest(maxTokens: 8),
+            requestId: "receipt-teardown",
+            cacheEnabled: true,
+            usageSignal: signal(box)))
+        #expect(box.snapshot.count == 1)
+        #expect(box.snapshot.first?.outcome == .skippedPolicy)
+    }
+
+    @Test("cache-disabled path emits once even when terminal usage follows")
+    func cacheDisabled() async {
+        let box = Box()
+        let engine = ScriptedCBv2Engine(script: .stream([
+            .finished(
+                reason: .stop,
+                usage: CBv2Usage(promptTokens: 3, completionTokens: 0))
+        ]))
+        let bridge = makeBridge(engine: engine)
+        _ = await record(await bridge.submitTokenized(
+            promptTokens: [1, 2, 3],
+            request: makeRequest(maxTokens: 8),
+            requestId: "receipt-disabled",
+            cacheEnabled: false,
+            usageSignal: signal(box)))
+        #expect(box.snapshot.count == 1)
+        #expect(box.snapshot.first?.outcome == .skippedPolicy)
     }
 }
 

--- a/provider-swift/Tests/ProviderCoreTests/EngineV2LivenessRecoveryTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/EngineV2LivenessRecoveryTests.swift
@@ -223,10 +223,11 @@ private func makeSizing(
         defaultMaxTokens: 4096)
 }
 
-private func makeChatRequest(model: String) -> ChatCompletionRequest {
+private func makeChatRequest(model: String, maxTokens: Int? = nil) -> ChatCompletionRequest {
     ChatCompletionRequest(
         model: model,
-        messages: [ChatMessage(role: "user", content: "hi")])
+        messages: [ChatMessage(role: "user", content: "hi")],
+        max_tokens: maxTokens)
 }
 
 /// Install a v2 slot through the REAL load path (re-slice + factory +
@@ -245,17 +246,17 @@ private func loadSlot(
 /// Drive a wedge: one hanging admit (engine accepts, never yields) plus a
 /// step-counter baseline sample at `t0`. The engine's steps never advance,
 /// so any later verdict ≥ the stall window sees the full flatline.
-@discardableResult
 private func injectWedge(
     bridge: EngineV2Bridge, modelId: String, at t0: ContinuousClock.Instant
-) async -> AsyncStream<GenerationEvent> {
-    let stream = await bridge.submitTokenized(
+) async {
+    _ = await bridge.submitTokenized(
         promptTokens: [1, 2, 3],
-        request: makeChatRequest(model: modelId),
+        // Liveness tests exercise the engine state machine, not the
+        // process-wide KV budget shared by parallel test suites.
+        request: makeChatRequest(model: modelId, maxTokens: 0),
         requestId: "req-wedge-\(modelId)")
     // Baseline step sample (the heartbeat normally does this).
     _ = await bridge.backendSlotCapacity(now: t0)
-    return stream
 }
 
 // MARK: - Bridge-level verdict + heartbeat state
@@ -571,8 +572,7 @@ struct EngineV2LivenessRecoveryTests {
         let engine = factory.built[0].engine
 
         let t0 = ContinuousClock.Instant.now
-        let firstWedgeStream = await injectWedge(
-            bridge: bridge, modelId: Self.modelA, at: t0)
+        await injectWedge(bridge: bridge, modelId: Self.modelA, at: t0)
         // A recovery attempt happened 60s ago (inside the 120s cooldown).
         let tWedge = t0.advanced(by: .seconds(130))
         await loop.setEngineV2LastRecoveryAtForTesting(
@@ -594,7 +594,6 @@ struct EngineV2LivenessRecoveryTests {
         // No restart/complete events fired.
         #expect(!telemetry.operations().contains("engine_v2_self_restart"))
         #expect(!telemetry.operations().contains("engine_v2_self_restart_complete"))
-        withExtendedLifetime(firstWedgeStream) {}
     }
 
     @Test("outside the cooldown a re-wedge recovers again (cooldown anchored on the attempt)")
@@ -607,8 +606,7 @@ struct EngineV2LivenessRecoveryTests {
 
         // First recovery.
         let t0 = ContinuousClock.Instant.now
-        let firstWedgeStream = await injectWedge(
-            bridge: bridge, modelId: Self.modelA, at: t0)
+        await injectWedge(bridge: bridge, modelId: Self.modelA, at: t0)
         let firstAttempt = t0.advanced(by: .seconds(130))
         await loop.recoverWedgedEngineV2SlotsForTesting(now: firstAttempt)
         #expect(factory.built.count == 2)
@@ -616,16 +614,13 @@ struct EngineV2LivenessRecoveryTests {
 
         // The rebuilt engine wedges again, but the second confirmation
         // lands AFTER the cooldown expired — recover again, don't unload.
-        let secondWedgeStream = await injectWedge(
-            bridge: secondBridge, modelId: Self.modelA, at: firstAttempt)
+        await injectWedge(bridge: secondBridge, modelId: Self.modelA, at: firstAttempt)
         let secondAttempt = firstAttempt.advanced(by: .seconds(130))
         await loop.recoverWedgedEngineV2SlotsForTesting(now: secondAttempt)
         #expect(factory.built.count == 3)
         #expect(await loop.slotBridgeForTesting(modelId: Self.modelA) != nil)
         #expect(await runtime.bridge(forModel: Self.modelA) != nil)
         #expect(await loop.engineV2LastRecoveryAtForTesting(modelId: Self.modelA) == secondAttempt)
-        withExtendedLifetime(firstWedgeStream) {}
-        withExtendedLifetime(secondWedgeStream) {}
     }
 
     @Test("rebuild failure: refusal + slot unload — never a half-alive slot")

--- a/provider-swift/Tests/ProviderCoreTests/EngineV2LivenessRecoveryTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/EngineV2LivenessRecoveryTests.swift
@@ -245,15 +245,17 @@ private func loadSlot(
 /// Drive a wedge: one hanging admit (engine accepts, never yields) plus a
 /// step-counter baseline sample at `t0`. The engine's steps never advance,
 /// so any later verdict ≥ the stall window sees the full flatline.
+@discardableResult
 private func injectWedge(
     bridge: EngineV2Bridge, modelId: String, at t0: ContinuousClock.Instant
-) async {
-    _ = await bridge.submitTokenized(
+) async -> AsyncStream<GenerationEvent> {
+    let stream = await bridge.submitTokenized(
         promptTokens: [1, 2, 3],
         request: makeChatRequest(model: modelId),
         requestId: "req-wedge-\(modelId)")
     // Baseline step sample (the heartbeat normally does this).
     _ = await bridge.backendSlotCapacity(now: t0)
+    return stream
 }
 
 // MARK: - Bridge-level verdict + heartbeat state
@@ -569,7 +571,8 @@ struct EngineV2LivenessRecoveryTests {
         let engine = factory.built[0].engine
 
         let t0 = ContinuousClock.Instant.now
-        await injectWedge(bridge: bridge, modelId: Self.modelA, at: t0)
+        let firstWedgeStream = await injectWedge(
+            bridge: bridge, modelId: Self.modelA, at: t0)
         // A recovery attempt happened 60s ago (inside the 120s cooldown).
         let tWedge = t0.advanced(by: .seconds(130))
         await loop.setEngineV2LastRecoveryAtForTesting(
@@ -591,6 +594,7 @@ struct EngineV2LivenessRecoveryTests {
         // No restart/complete events fired.
         #expect(!telemetry.operations().contains("engine_v2_self_restart"))
         #expect(!telemetry.operations().contains("engine_v2_self_restart_complete"))
+        withExtendedLifetime(firstWedgeStream) {}
     }
 
     @Test("outside the cooldown a re-wedge recovers again (cooldown anchored on the attempt)")
@@ -603,7 +607,8 @@ struct EngineV2LivenessRecoveryTests {
 
         // First recovery.
         let t0 = ContinuousClock.Instant.now
-        await injectWedge(bridge: bridge, modelId: Self.modelA, at: t0)
+        let firstWedgeStream = await injectWedge(
+            bridge: bridge, modelId: Self.modelA, at: t0)
         let firstAttempt = t0.advanced(by: .seconds(130))
         await loop.recoverWedgedEngineV2SlotsForTesting(now: firstAttempt)
         #expect(factory.built.count == 2)
@@ -611,13 +616,16 @@ struct EngineV2LivenessRecoveryTests {
 
         // The rebuilt engine wedges again, but the second confirmation
         // lands AFTER the cooldown expired — recover again, don't unload.
-        await injectWedge(bridge: secondBridge, modelId: Self.modelA, at: firstAttempt)
+        let secondWedgeStream = await injectWedge(
+            bridge: secondBridge, modelId: Self.modelA, at: firstAttempt)
         let secondAttempt = firstAttempt.advanced(by: .seconds(130))
         await loop.recoverWedgedEngineV2SlotsForTesting(now: secondAttempt)
         #expect(factory.built.count == 3)
         #expect(await loop.slotBridgeForTesting(modelId: Self.modelA) != nil)
         #expect(await runtime.bridge(forModel: Self.modelA) != nil)
         #expect(await loop.engineV2LastRecoveryAtForTesting(modelId: Self.modelA) == secondAttempt)
+        withExtendedLifetime(firstWedgeStream) {}
+        withExtendedLifetime(secondWedgeStream) {}
     }
 
     @Test("rebuild failure: refusal + slot unload — never a half-alive slot")

--- a/provider-swift/Tests/ProviderCoreTests/EngineV2PrefillSamplingTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/EngineV2PrefillSamplingTests.swift
@@ -75,6 +75,41 @@ struct EngineV2PrefillSamplingTests {
         #expect(tps == 500)
     }
 
+    @Test("terminal cache outcome admits only genuinely cold prefills")
+    func coldOutcomeClassifier() {
+        for outcome in [
+            CBv2PrefixCacheOutcome.disabled, .miss, .skippedPolicy,
+            .skippedCapacity, .adoptionFailed,
+        ] {
+            #expect(EngineV2Bridge.isColdPrefillSample(usage: CBv2Usage(
+                promptTokens: 100,
+                completionTokens: 1,
+                prefixCacheOutcome: outcome)))
+        }
+        #expect(!EngineV2Bridge.isColdPrefillSample(usage: CBv2Usage(
+            promptTokens: 100,
+            completionTokens: 1,
+            prefixCacheOutcome: .hit,
+            prefixCacheMatchedTokens: 64,
+            prefixCachePrefillTokensSaved: 48)))
+        // Saved-token truth is authoritative even if an older/malformed
+        // engine reports a non-hit enum.
+        #expect(!EngineV2Bridge.isColdPrefillSample(usage: CBv2Usage(
+            promptTokens: 100,
+            completionTokens: 1,
+            prefixCacheOutcome: .miss,
+            prefixCachePrefillTokensSaved: 48)))
+        // A real hit can be invalidated by preemption before terminal usage.
+        // The engine then reports adoptionFailed/saved=0 but retains the raw
+        // matched prefix. It is not a trustworthy cold-prefill sample.
+        #expect(!EngineV2Bridge.isColdPrefillSample(usage: CBv2Usage(
+            promptTokens: 100,
+            completionTokens: 1,
+            prefixCacheOutcome: .adoptionFailed,
+            prefixCacheMatchedTokens: 64,
+            prefixCachePrefillTokensSaved: 0)))
+    }
+
     @Test("successful finish feeds the EWMA from submit→first-token timing")
     func ewmaPopulatedFromRealTiming() async throws {
         let engine = PrefillScriptEngine()
@@ -134,6 +169,39 @@ struct EngineV2PrefillSamplingTests {
         continuation.yield(.delta(text: "x", tokens: [11], logprobs: nil))
         continuation.yield(.finished(
             reason: .cancelled, usage: CBv2Usage(promptTokens: 200, completionTokens: 1)))
+        continuation.finish()
+        _ = await consumer.value
+
+        #expect(await bridge.backendSlotCapacity().observedPrefillTps == 0)
+    }
+
+    @Test("cache-hit submit-to-first-token timing never feeds the cold prefill EWMA")
+    func cacheHitsDoNotSample() async throws {
+        let engine = PrefillScriptEngine()
+        let bridge = EngineV2Bridge(
+            engine: engine,
+            modelId: "gpt-oss-20b",
+            tokenizer: TokenizerHandle(PrefillStubTokenizer()),
+            eosTokenIds: [])
+        let stream = await bridge.submitTokenized(
+            promptTokens: Array(repeating: 7, count: 200),
+            request: ChatCompletionRequest(
+                model: "gpt-oss-20b",
+                messages: [ChatMessage(role: "user", content: "hi")]),
+            requestId: "req-prefill-hit")
+        let consumer = Task { for await _ in stream {} }
+        try await Task.sleep(for: .milliseconds(50))
+        let continuation = try #require(engine.continuations.first)
+        continuation.yield(.delta(text: "x", tokens: [11], logprobs: nil))
+        continuation.yield(.finished(
+            reason: .stop,
+            usage: CBv2Usage(
+                promptTokens: 200,
+                completionTokens: 1,
+                prefixCacheHitTokens: 128,
+                prefixCacheOutcome: .hit,
+                prefixCacheMatchedTokens: 160,
+                prefixCachePrefillTokensSaved: 128)))
         continuation.finish()
         _ = await consumer.value
 

--- a/provider-swift/Tests/ProviderCoreTests/OuterPrefixCacheReceiptTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/OuterPrefixCacheReceiptTests.swift
@@ -1,0 +1,156 @@
+import Foundation
+import Testing
+
+@testable import ProviderCore
+
+@Suite("Outer inference-handler prefix cache receipts")
+struct OuterPrefixCacheReceiptTests {
+    private final class Recorder: @unchecked Sendable {
+        private let lock = NSLock()
+        private var messages: [OutboundMessage] = []
+
+        func append(_ message: OutboundMessage) {
+            lock.withLock { messages.append(message) }
+        }
+
+        var lookups: [(outcome: PrefixCacheLookupOutcome, tier: PrefixCacheTier?)] {
+            lock.withLock {
+                messages.compactMap {
+                    guard case .prefixCacheLookup(
+                        _, _, let outcome, let tier, _, _, _
+                    ) = $0 else { return nil }
+                    return (outcome, tier)
+                }
+            }
+        }
+
+        var kinds: [String] {
+            lock.withLock {
+                messages.compactMap {
+                    switch $0 {
+                    case .prefixCacheLookup: return "lookup"
+                    case .inferenceError: return "error"
+                    case .inferenceComplete: return "complete"
+                    default: return nil
+                    }
+                }
+            }
+        }
+
+        func waitForLookup() async {
+            let deadline = ContinuousClock.now + .seconds(2)
+            while ContinuousClock.now < deadline, lookups.isEmpty {
+                try? await Task.sleep(for: .milliseconds(10))
+            }
+        }
+    }
+
+    private func makeLoop() throws -> ProviderLoop {
+        let config = ProviderLoopConfig(
+            coordinatorURL: "ws://127.0.0.1:0/ignored",
+            hardware: HardwareInfo(
+                machineModel: "Mac16,5",
+                chipName: "Apple M4 Max",
+                chipFamily: .m4,
+                chipTier: .max,
+                memoryGb: 128,
+                memoryAvailableGb: 124,
+                cpuCores: CpuCores(total: 16, performance: 12, efficiency: 4),
+                gpuCores: 40,
+                memoryBandwidthGbs: 546),
+            models: [],
+            config: ProviderConfig(
+                provider: ProviderSettings(name: "outer-receipt-test", memoryReserveGB: 1),
+                backend: BackendSettings(idleTimeoutMins: 0, maxModelSlots: 1),
+                coordinator: CoordinatorSettings(heartbeatIntervalSecs: 60)))
+        return try ProviderLoop(
+            config: config,
+            purgeLegacyFiles: false,
+            attestationSigner: nil)
+    }
+
+    @Test("pre-decrypt policy failure emits exactly one lookup receipt")
+    func malformedResponseKeyFinalizesPolicy() async throws {
+        let loop = try makeLoop()
+        let recorder = Recorder()
+        await loop.handleInferenceRequest(
+            requestId: "outer-policy",
+            ciphertext: Data(),
+            senderPublicKey: nil,
+            cacheReceiptNonce: "nonce-policy",
+            authenticatedCacheScope: "scope-policy",
+            send: SendHandle(recorder.append))
+        await recorder.waitForLookup()
+
+        #expect(recorder.lookups.count == 1)
+        #expect(recorder.lookups.first?.outcome == .skippedPolicy)
+        #expect(recorder.kinds == ["lookup", "error"])
+    }
+
+    @Test("pre-decrypt shutdown admission emits exactly one capacity receipt")
+    func shutdownFinalizesCapacity() async throws {
+        let loop = try makeLoop()
+        await loop.beginShutdownForTesting()
+        let recorder = Recorder()
+        await loop.handleInferenceRequest(
+            requestId: "outer-capacity",
+            ciphertext: Data(),
+            senderPublicKey: nil,
+            cacheReceiptNonce: "nonce-capacity",
+            authenticatedCacheScope: "scope-capacity",
+            send: SendHandle(recorder.append))
+        await recorder.waitForLookup()
+
+        #expect(recorder.lookups.count == 1)
+        #expect(recorder.lookups.first?.outcome == .skippedCapacity)
+        #expect(recorder.kinds == ["lookup", "error"])
+    }
+
+    @Test("bridge resolution wins over the outer policy backstop without duplication")
+    func bridgeResolutionIsSetOnce() {
+        final class Box: @unchecked Sendable {
+            let lock = NSLock()
+            var values: [PrefixCacheLookupResult] = []
+        }
+        let box = Box()
+        let finalizer = PrefixCacheLookupReceiptFinalizer(callback: { value in
+            box.lock.withLock { box.values.append(value) }
+        })
+        finalizer.resolve(PrefixCacheLookupResult(
+            outcome: .hit,
+            tier: .ssd,
+            cachedTokens: 64,
+            prefillTokensSaved: 48))
+        finalizer.finalize(failure: .policy)
+        #expect(box.lock.withLock { box.values.count } == 1)
+        #expect(box.lock.withLock { box.values.first?.outcome } == .hit)
+    }
+
+    @Test("detached terminal helper queues lookup before error without duplicate")
+    func detachedFailureOrdering() async throws {
+        let recorder = Recorder()
+        let send = SendHandle(recorder.append)
+        let callbacks = PrefixCacheReceiptEmitter.callbacks(
+            requestID: "detached-order",
+            nonce: "detached-nonce",
+            send: send)
+        let finalizer = PrefixCacheLookupReceiptFinalizer(
+            callback: callbacks.lookup)
+
+        await Task.detached {
+            finalizer.sendTerminal(
+                .inferenceError(
+                    requestId: "detached-order",
+                    error: "template/media/encryption failure",
+                    statusCode: 500,
+                    errorReason: nil),
+                fallbackFailure: .policy,
+                send: send)
+            // Detached-task defer fallback after the terminal must be a no-op.
+            finalizer.finalize(failure: .policy)
+        }.value
+
+        #expect(recorder.lookups.count == 1)
+        #expect(recorder.kinds == ["lookup", "error"])
+    }
+}

--- a/provider-swift/Tests/ProviderCoreTests/PrefixCacheReceiptTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/PrefixCacheReceiptTests.swift
@@ -121,6 +121,124 @@ struct PrefixCacheReceiptTests {
         #expect(signal.lookupResult?.cachedTokens == 64)
     }
 
+    @Test("failure finalization uses known stage result and remains exactly once")
+    func failureFinalization() throws {
+        final class Box: @unchecked Sendable {
+            let lock = NSLock()
+            var values: [PrefixCacheLookupResult] = []
+        }
+        let cases: [(SSDPrefixCacheStageDisposition, PrefixCacheLookupFailureClass,
+            PrefixCacheLookupOutcome)] = [
+            (.missAbsent, .capacity, .missAbsent),
+            (.missCorrupt, .policy, .missCorrupt),
+            (.skippedCost, .capacity, .skippedCost),
+            (.skippedCapacity, .policy, .skippedCapacity),
+            (.skippedPolicy, .capacity, .skippedPolicy),
+            (.staged(
+                matchedTokens: 64,
+                expectedPrefillTokensSaved: 48,
+                shortenedByCorruption: false), .capacity, .skippedCapacity),
+            (.staged(
+                matchedTokens: 64,
+                expectedPrefillTokensSaved: 48,
+                shortenedByCorruption: false), .policy, .skippedPolicy),
+        ]
+        for (stage, failure, expected) in cases {
+            let box = Box()
+            let signal = EngineV2RequestUsageSignal { result in
+                box.lock.withLock { box.values.append(result) }
+            }
+            signal.record(stageResult: SSDPrefixCacheStageResult(
+                disposition: stage, stageMs: 2.5))
+            signal.finalizeLookup(failure: failure, fallbackTier: .memory)
+            signal.finalizeLookup(failure: failure, fallbackTier: .memory)
+            signal.record(usage: CBv2Usage(
+                promptTokens: 10,
+                completionTokens: 0,
+                prefixCacheOutcome: .miss))
+            let values = box.lock.withLock { box.values }
+            #expect(values.count == 1)
+            #expect(try #require(values.first).outcome == expected)
+            #expect(values.first?.tier == .ssd)
+            #expect(values.first?.stageMs == 2.5)
+        }
+    }
+
+    @Test("missing-stage and cache-disabled attempts finalize once")
+    func missingStageFinalization() {
+        final class Box: @unchecked Sendable {
+            let lock = NSLock()
+            var values: [PrefixCacheLookupResult] = []
+        }
+        let box = Box()
+        let signal = EngineV2RequestUsageSignal { result in
+            box.lock.withLock { box.values.append(result) }
+        }
+        signal.finalizeLookup(failure: .capacity, fallbackTier: .memory)
+        signal.recordCacheDisabled(tier: .memory)
+        signal.record(usage: CBv2Usage(promptTokens: 1, completionTokens: 0))
+        let values = box.lock.withLock { box.values }
+        #expect(values.count == 1)
+        #expect(values.first?.outcome == .skippedCapacity)
+        #expect(values.first?.tier == .memory)
+    }
+
+    @Test("ready stage cost is optional, finite, and bounded")
+    func readyStageCostBounds() {
+        func result(_ stageMs: Double?) -> PrefixCacheReadyResult {
+            PrefixCacheReadyResult(
+                readyTokens: 8,
+                requiredRecomputeTokens: 0,
+                expectedPrefillTokensSaved: 8,
+                stageMs: stageMs)
+        }
+        #expect(result(nil).stageMs == nil)
+        #expect(result(.nan).stageMs == nil)
+        #expect(result(.infinity).stageMs == nil)
+        #expect(result(-1).stageMs == 0)
+        #expect(result(PrefixCacheReadyResult.maxStageMs + 1).stageMs
+            == PrefixCacheReadyResult.maxStageMs)
+    }
+
+    @Test("lookup and ready receipts are synchronously queued before terminal error")
+    func receiptOrderingBeforeTerminal() throws {
+        final class Sequence: @unchecked Sendable {
+            let lock = NSLock()
+            var values: [String] = []
+        }
+        let sequence = Sequence()
+        let send = SendHandle { message in
+            let kind: String
+            switch message {
+            case .prefixCacheLookup: kind = "lookup"
+            case .prefixCacheReady: kind = "ready"
+            case .inferenceError: kind = "error"
+            default: kind = "other"
+            }
+            sequence.lock.withLock { sequence.values.append(kind) }
+        }
+        let callbacks = PrefixCacheReceiptEmitter.callbacks(
+            requestID: "ordered-request",
+            nonce: "ordered-nonce",
+            send: send)
+        let lookup = try #require(callbacks.lookup)
+        let ready = try #require(callbacks.ready)
+
+        lookup(PrefixCacheLookupResult(outcome: .missAbsent, tier: .ssd))
+        ready(PrefixCacheReadyResult(
+            readyTokens: 64,
+            requiredRecomputeTokens: 0,
+            expectedPrefillTokensSaved: 64,
+            stageMs: 1))
+        send.send(.inferenceError(
+            requestId: "ordered-request",
+            error: "terminal",
+            statusCode: 500,
+            errorReason: nil))
+
+        #expect(sequence.lock.withLock { sequence.values } == ["lookup", "ready", "error"])
+    }
+
     @Test("early prompt donation is opt-in and parses explicit affirmative values")
     func earlyDonationFlag() {
         #expect(!EngineV2Factory.earlyPrefixDonationEnabled(environment: [:]))

--- a/provider-swift/Tests/ProviderCoreTests/ProtocolTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ProtocolTests.swift
@@ -929,7 +929,8 @@ import Testing
         readyTokens: 8192,
         requiredRecomputeTokens: 1536,
         expectedPrefillTokensSaved: 6656,
-        tier: .ssd))
+        tier: .ssd,
+        stageMs: 18.75))
     for message in [lookup, ready] {
         let data = try ProviderProtocolCodec.encodeProviderMessage(message)
         #expect(try ProviderProtocolCodec.decodeProviderMessage(from: data) == message)
@@ -944,6 +945,13 @@ import Testing
     #expect(readyObject["type"] as? String == "prefix_cache_ready")
     #expect(readyObject["ready_tokens"] as? Int == 8192)
     #expect(readyObject["required_recompute_tokens"] as? Int == 1536)
+    #expect(readyObject["stage_ms"] as? Double == 18.75)
+
+    let legacyReadyJSON = #"{"type":"prefix_cache_ready","request_id":"r","cache_receipt_nonce":"n","ready_tokens":8,"required_recompute_tokens":0,"expected_prefill_tokens_saved":8,"tier":"ssd"}"#
+    guard case .prefixCacheReady(let legacyReady) = try ProviderProtocolCodec.decodeProviderMessage(
+        from: Data(legacyReadyJSON.utf8))
+    else { throw TestFailure.unexpectedMessage }
+    #expect(legacyReady.stageMs == nil)
 }
 
 @Test func usageInfoCacheFieldsAreOptionalAndBackwardCompatible() throws {

--- a/provider-swift/Tests/ProviderCoreTests/SSDPrefixCacheTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/SSDPrefixCacheTests.swift
@@ -2003,12 +2003,6 @@ struct SSDWholeRootMaintenanceTests {
         }
         #expect(!FileManager.default.fileExists(atPath: temp.path))
         SSDWholeRootMaintainer.shared.stopPeriodicMaintenance(root: root)
-        SSDWholeRootMaintainer.shared.startPeriodicMaintenance(
-            root: root,
-            ttlSeconds: 900,
-            intervalSeconds: 3600,
-            nowSeconds: { 10_000 },
-            budgetBytes: { 1 << 20 })
 
         let restartedTemp = SSDBlockStore.temporaryFileURL(
             for: destination,
@@ -2018,6 +2012,12 @@ struct SSDWholeRootMaintenanceTests {
             [.modificationDate: Date(timeIntervalSince1970:
                 TimeInterval(10_000 - SSDBlockStore.crashTempTTLSeconds))],
             ofItemAtPath: restartedTemp.path)
+        SSDWholeRootMaintainer.shared.startPeriodicMaintenance(
+            root: root,
+            ttlSeconds: 900,
+            intervalSeconds: 3600,
+            nowSeconds: { 10_000 },
+            budgetBytes: { 1 << 20 })
         let restartDeadline = ContinuousClock.now + .seconds(2)
         while ContinuousClock.now < restartDeadline,
             FileManager.default.fileExists(atPath: restartedTemp.path)

--- a/provider-swift/Tests/ProviderCoreTests/SSDPrefixCacheTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/SSDPrefixCacheTests.swift
@@ -351,6 +351,162 @@ struct SSDBlockStoreTests {
         #expect(!FileManager.default.fileExists(atPath: stale.path))
         #expect(FileManager.default.fileExists(atPath: young.path))
     }
+
+    @Test("active cache I/O rejects symlinked root, model, and fanout paths")
+    func activeSymlinkIOFailsClosed() throws {
+        let parent = tempDir("active-symlinks")
+        defer { try? FileManager.default.removeItem(at: parent) }
+        let fm = FileManager.default
+
+        let realDedicated = parent.appendingPathComponent("real", isDirectory: true)
+        let linkedDedicated = parent.appendingPathComponent("linked", isDirectory: true)
+        try fm.createDirectory(at: realDedicated, withIntermediateDirectories: true)
+        try fm.createSymbolicLink(at: linkedDedicated, withDestinationURL: realDedicated)
+        #expect(throws: (any Error).self) {
+            try SSDBlockStore.prepareModelRoot(
+                dedicatedRoot: linkedDedicated,
+                modelRoot: linkedDedicated.appendingPathComponent("aaaaaaaaaaaa"))
+        }
+
+        let outsideModel = parent.appendingPathComponent("outside-model", isDirectory: true)
+        try fm.createDirectory(at: outsideModel, withIntermediateDirectories: true)
+        let modelLink = realDedicated.appendingPathComponent("aaaaaaaaaaaa", isDirectory: true)
+        try fm.createSymbolicLink(at: modelLink, withDestinationURL: outsideModel)
+        #expect(throws: (any Error).self) {
+            try SSDBlockStore.prepareModelRoot(
+                dedicatedRoot: realDedicated,
+                modelRoot: modelLink)
+        }
+        try fm.removeItem(at: modelLink)
+
+        let modelRoot = realDedicated.appendingPathComponent("bbbbbbbbbbbb", isDirectory: true)
+        try SSDBlockStore.prepareModelRoot(
+            dedicatedRoot: realDedicated,
+            modelRoot: modelRoot)
+        let outsideFanout = parent.appendingPathComponent("outside-fanout", isDirectory: true)
+        try fm.createDirectory(at: outsideFanout, withIntermediateDirectories: true)
+        let fanoutLink = modelRoot.appendingPathComponent("aa", isDirectory: true)
+        try fm.createSymbolicLink(at: fanoutLink, withDestinationURL: outsideFanout)
+        let url = SSDBlockStore.fileURL(
+            root: modelRoot,
+            tag16Hex: "aabbccdd00112233445566778899eeff")
+        #expect(throws: (any Error).self) {
+            try SSDBlockStore.write(
+                to: url,
+                metadata: fixtureMetadata(sizes: [32]),
+                chunks: [Data(repeating: 1, count: 32)],
+                kekKey: SymmetricKey(size: .bits256))
+        }
+        #expect((try fm.contentsOfDirectory(atPath: outsideFanout.path)).isEmpty)
+
+        let cache = makeCache(
+            dir: modelRoot,
+            kek: SymmetricKey(size: .bits256),
+            clock: ClockBox(10_000))
+        defer { cache.close() }
+        cache.scanOnDisk()
+        #expect(cache.index.count == 0)
+        let escapedFile = outsideFanout.appendingPathComponent(
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.dbk2")
+        try Data("must-survive".utf8).write(to: escapedFile)
+        cache.index.insert(
+            tag16: Data(repeating: 0xaa, count: 16),
+            fileBytes: 32,
+            lastAccess: 0)
+        cache.sweepExpiredEntries()
+        #expect(cache.index.count == 1, "unsafe fanout must block destructive cleanup")
+        #expect(fm.fileExists(atPath: escapedFile.path))
+    }
+
+    @Test("descriptor-relative active I/O cannot be redirected by a fanout symlink race")
+    func activeIORenameToSymlinkRace() throws {
+        struct Fixture {
+            let parent: URL
+            let modelRoot: URL
+            let file: URL
+            let outsideFile: URL
+            let hook: @Sendable (SSDActiveIOOperation) -> Void
+        }
+        var parents: [URL] = []
+        defer { for parent in parents { try? FileManager.default.removeItem(at: parent) } }
+        let kek = SymmetricKey(size: .bits256)
+        let tag = "aabbccdd00112233445566778899eeff"
+        let originalChunk = Data(repeating: 3, count: 32)
+        let outsideSentinel = Data("outside-must-remain-untouched".utf8)
+
+        func makeFixture(_ label: String) throws -> Fixture {
+            let parent = tempDir("nofollow-\(label)")
+            parents.append(parent)
+            let dedicated = parent.appendingPathComponent("cache", isDirectory: true)
+            let modelRoot = dedicated.appendingPathComponent("aaaaaaaaaaaa", isDirectory: true)
+            try SSDBlockStore.prepareModelRoot(
+                dedicatedRoot: dedicated, modelRoot: modelRoot)
+            let file = SSDBlockStore.fileURL(root: modelRoot, tag16Hex: tag)
+            _ = try SSDBlockStore.write(
+                to: file,
+                metadata: fixtureMetadata(sizes: [originalChunk.count]),
+                chunks: [originalChunk],
+                kekKey: kek)
+
+            let fanout = file.deletingLastPathComponent()
+            let detachedFanout = modelRoot.appendingPathComponent("detached-aa")
+            let outsideFanout = parent.appendingPathComponent("outside-aa", isDirectory: true)
+            try FileManager.default.createDirectory(
+                at: outsideFanout, withIntermediateDirectories: true)
+            let outsideFile = outsideFanout.appendingPathComponent(file.lastPathComponent)
+            try outsideSentinel.write(to: outsideFile)
+            let hook: @Sendable (SSDActiveIOOperation) -> Void = { _ in
+                try! FileManager.default.moveItem(at: fanout, to: detachedFanout)
+                try! FileManager.default.createSymbolicLink(
+                    at: fanout, withDestinationURL: outsideFanout)
+            }
+            return Fixture(
+                parent: parent,
+                modelRoot: modelRoot,
+                file: file,
+                outsideFile: outsideFile,
+                hook: hook)
+        }
+
+        let readFixture = try makeFixture("read")
+        let (readMetadata, readChunks) = try SSDBlockStore.read(
+            from: readFixture.file,
+            kekKey: kek,
+            beforeOperation: readFixture.hook)
+        #expect(readMetadata.weightHash == "w-hash")
+        #expect(readChunks == [originalChunk])
+        #expect(try Data(contentsOf: readFixture.outsideFile) == outsideSentinel)
+
+        let writeFixture = try makeFixture("write")
+        _ = try SSDBlockStore.write(
+            to: writeFixture.file,
+            metadata: fixtureMetadata(sizes: [48]),
+            chunks: [Data(repeating: 9, count: 48)],
+            kekKey: kek,
+            beforeOperation: writeFixture.hook)
+        #expect(try Data(contentsOf: writeFixture.outsideFile) == outsideSentinel)
+
+        let touchFixture = try makeFixture("touch")
+        let outsideDate = Date(timeIntervalSince1970: 1_000)
+        try FileManager.default.setAttributes(
+            [.modificationDate: outsideDate],
+            ofItemAtPath: touchFixture.outsideFile.path)
+        SSDBlockStore.setAttributesIfSafe(
+            [.modificationDate: Date(timeIntervalSince1970: 9_000)],
+            at: touchFixture.file,
+            under: touchFixture.modelRoot,
+            beforeOperation: touchFixture.hook)
+        let untouchedDate = try touchFixture.outsideFile.resourceValues(
+            forKeys: [.contentModificationDateKey]).contentModificationDate
+        #expect(untouchedDate == outsideDate)
+
+        let deleteFixture = try makeFixture("delete")
+        #expect(SSDBlockStore.removeItemIfSafe(
+            at: deleteFixture.file,
+            under: deleteFixture.modelRoot,
+            beforeOperation: deleteFixture.hook))
+        #expect(try Data(contentsOf: deleteFixture.outsideFile) == outsideSentinel)
+    }
 }
 
 // MARK: - Mode selection + no-carve
@@ -404,6 +560,22 @@ struct SSDPrefixCacheModeTests {
             slotKVBytesCapacity: slot, requestedBudgetBytes: 0, kvBytesPerToken: 24_576)
         #expect(carve.engineKVBytesCapacity == slot)
         #expect(carve.prefixCacheBudgetBytes == 0)
+    }
+
+    @Test("reusable SSD cache requires a verified non-empty live weight hash")
+    func verifiedWeightBindingRequired() {
+        #expect(SSDPrefixCacheFactory.verifiedWeightHash(nil) == nil)
+        #expect(SSDPrefixCacheFactory.verifiedWeightHash("") == nil)
+        #expect(SSDPrefixCacheFactory.verifiedWeightHash(" \n\t ") == nil)
+        #expect(SSDPrefixCacheFactory.verifiedWeightHash("  abcd1234  ") == "abcd1234")
+    }
+
+    @Test("durable-byte stage estimate is positive, conservative, and wire-bounded")
+    func durableStageEstimate() {
+        #expect(SSDPrefixCachePolicy.estimatedStageMillis(bytes: 1) == 1)
+        #expect(SSDPrefixCachePolicy.estimatedStageMillisDouble(bytes: 1) > 0)
+        #expect(SSDPrefixCachePolicy.estimatedStageMillisDouble(bytes: Int.max)
+            == PrefixCacheReadyResult.maxStageMs)
     }
 
     @Test("box-wide disk budget: env override wins; default = min(20 GiB, free/2)")
@@ -840,10 +1012,11 @@ struct SSDPrefixCacheReadyReceiptTests {
 
         correlatedDonate(cache, requestID: requestID, tokenCount: 64)
         #expect(await box.waitForCount(1))
-        #expect(box.snapshot[0] == PrefixCacheReadyResult(
-            readyTokens: 64,
-            requiredRecomputeTokens: 0,
-            expectedPrefillTokensSaved: 64))
+        #expect(box.snapshot[0].readyTokens == 64)
+        #expect(box.snapshot[0].requiredRecomputeTokens == 0)
+        #expect(box.snapshot[0].expectedPrefillTokensSaved == 64)
+        #expect(try #require(box.snapshot[0].stageMs) > 0)
+        #expect(try #require(box.snapshot[0].stageMs) <= PrefixCacheReadyResult.maxStageMs)
 
         correlatedDonate(cache, requestID: requestID, tokenCount: 72)
         #expect(await box.waitForCount(2))
@@ -1330,7 +1503,7 @@ struct SSDPrefixCacheReservationTests {
         #expect(!dbk2Files(under: dir).isEmpty)
     }
 
-    @Test("two same-prefix requests share ONE entry reservation — no double-charge, no orphaned residency")
+    @Test("concurrent same-prefix requests bind exact tickets to one reserved entry")
     func sharedEntryReservedExactlyOnce() async throws {
         // Regression (Codex, v0.7.5 SSD review — SSDPrefixCache staging
         // ticket accounting): when two concurrent same-prefix requests
@@ -1352,38 +1525,106 @@ struct SSDPrefixCacheReservationTests {
         defer { cache.close() }
 
         let prompt = Array(0 ..< tokenCount) + [1]
-        // A creates the staged entry; B attaches to the SAME entry.
-        #expect((await cache.stage(requestID: "req-A", promptTokens: prompt, cacheScope: "")).staged)
-        let afterA = await budget.outstandingReservedBytes()
-        #expect(afterA > 0)
-        #expect((await cache.stage(requestID: "req-B", promptTokens: prompt, cacheScope: "")).staged)
+        let requestA = CBv2RequestID(101)
+        let requestB = CBv2RequestID(102)
+        // Race both stages. One creates the entry and the other attaches,
+        // regardless of which disk read wins.
+        async let stageA = cache.stage(
+            requestID: requestA, promptTokens: prompt, cacheScope: "")
+        async let stageB = cache.stage(
+            requestID: requestB, promptTokens: prompt, cacheScope: "")
+        let (resultA, resultB) = await (stageA, stageB)
+        #expect(resultA.staged)
+        #expect(resultB.staged)
+        let sharedReservation = await budget.outstandingReservedBytes()
+        #expect(sharedReservation > 0)
         // Charged ONCE: attaching adds a residency ticket, not a reservation.
         // (Pre-fix this was 2 × afterA.)
         #expect(
-            await budget.outstandingReservedBytes() == afterA,
+            sharedReservation == UInt64(cache.bytesInUse),
             "attaching to a staged entry must not add a second reservation")
-        #expect(cache.bytesInUse == Int(afterA))
+        #expect(cache.bytesInUse == Int(sharedReservation))
 
-        // Both engines look up the shared arrays (two live pins).
-        let hit = try #require(
-            cache.lookup(tokens: prompt, layerKinds: fixtureLayerKinds, cacheSalt: nil))
-        _ = try #require(
-            cache.lookup(tokens: prompt, layerKinds: fixtureLayerKinds, cacheSalt: nil))
-        // A fully completes (adoption + terminal backstop) while B is STILL
-        // pinned and the entry is STILL resident. Its reservation must NOT
-        // be released here — residency stays covered.
-        cache.endAdoption(tokens: prompt, matched: hit.matched, cacheSalt: nil)
-        cache.completeStaging(requestID: "req-A")
+        // An unrelated request cannot consume either staged ticket. B can
+        // finish while A's lookup is still delayed without stealing A's pin.
+        #expect(cache.lookup(
+            requestID: CBv2RequestID(999),
+            tokens: prompt,
+            layerKinds: fixtureLayerKinds,
+            cacheSalt: nil) == nil)
+        let hitB = try #require(cache.lookup(
+            requestID: requestB,
+            tokens: prompt,
+            layerKinds: fixtureLayerKinds,
+            cacheSalt: nil))
+        cache.endAdoption(
+            requestID: requestB,
+            tokens: prompt,
+            matched: hitB.matched,
+            cacheSalt: nil)
+        cache.completeStaging(requestID: requestB)
         #expect(
-            await budget.outstandingReservedBytes() == afterA,
+            await budget.outstandingReservedBytes() == sharedReservation,
             "a resident shared entry must stay reserved until its LAST user leaves")
-        #expect(cache.bytesInUse == Int(afterA))
+        #expect(cache.bytesInUse == Int(sharedReservation))
 
-        // B finishes; the entry retires and the single reservation drains.
-        cache.endAdoption(tokens: prompt, matched: hit.matched, cacheSalt: nil)
-        cache.completeStaging(requestID: "req-B")
+        // A's slower lookup remains valid after B's terminal backstop. Only
+        // A can balance A's ticket; then the shared reservation drains.
+        let hitA = try #require(cache.lookup(
+            requestID: requestA,
+            tokens: prompt,
+            layerKinds: fixtureLayerKinds,
+            cacheSalt: nil))
+        cache.endAdoption(
+            requestID: requestA,
+            tokens: prompt,
+            matched: hitA.matched,
+            cacheSalt: nil)
+        cache.completeStaging(requestID: requestA)
         #expect(await waitForZeroOutstanding(budget), "the last user must drain the entry reservation")
         #expect(cache.bytesInUse == 0)
+    }
+
+    @Test("two cache instances may reserve the same raw receipt id independently")
+    func instanceNamespacesPreventGlobalReservationCollisions() async throws {
+        let parent = tempDir("res-instance-namespace")
+        defer { try? FileManager.default.removeItem(at: parent) }
+        let budget = makeBudget()
+        let clock = ClockBox(10_000)
+        try FileManager.default.createDirectory(
+            at: parent.appendingPathComponent("aaaaaaaaaaaa"),
+            withIntermediateDirectories: false)
+        try FileManager.default.createDirectory(
+            at: parent.appendingPathComponent("bbbbbbbbbbbb"),
+            withIntermediateDirectories: false)
+        let cacheA = await makeStagedCache(
+            dir: parent.appendingPathComponent("aaaaaaaaaaaa"),
+            kek: SymmetricKey(size: .bits256),
+            clock: clock,
+            kvBudget: budget)
+        let cacheB = await makeStagedCache(
+            dir: parent.appendingPathComponent("bbbbbbbbbbbb"),
+            kek: SymmetricKey(size: .bits256),
+            clock: clock,
+            kvBudget: budget)
+        defer { cacheA.close(); cacheB.close() }
+
+        let requestID = CBv2RequestID(1)
+        let prompt = Array(0 ..< tokenCount) + [1]
+        let resultA = await cacheA.stage(
+            requestID: requestID, promptTokens: prompt, cacheScope: "")
+        let resultB = await cacheB.stage(
+            requestID: requestID, promptTokens: prompt, cacheScope: "")
+
+        #expect(resultA.staged)
+        #expect(resultB.staged)
+        #expect(await budget.outstandingReservedBytes()
+            == UInt64(cacheA.bytesInUse + cacheB.bytesInUse))
+        #expect((await budget.reservationIDsForTesting()).count == 2)
+
+        await cacheA.abandonStaging(requestID: requestID)
+        await cacheB.abandonStaging(requestID: requestID)
+        #expect(await budget.outstandingReservedBytes() == 0)
     }
 }
 
@@ -1466,6 +1707,9 @@ struct SSDWholeRootMaintenanceTests {
         payloadBytes: Int = 128
     ) throws -> URL {
         let modelRoot = root.appendingPathComponent(modelKey, isDirectory: true)
+        try SSDBlockStore.prepareModelRoot(
+            dedicatedRoot: root,
+            modelRoot: modelRoot)
         let url = SSDBlockStore.fileURL(root: modelRoot, tag16Hex: tagHex)
         let chunk = Data(repeating: 7, count: payloadBytes)
         let metadata = SSDBlockMetadata(

--- a/provider-swift/Tests/ProviderCoreTests/StandaloneServerTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/StandaloneServerTests.swift
@@ -535,6 +535,13 @@ private struct StandalonePendingLoadObservation: Error {
     let reservedBytes: UInt64
 }
 
+private final class StandaloneHashRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var values: [String?] = []
+    func record(_ value: String?) { lock.withLock { values.append(value) } }
+    var snapshot: [String?] { lock.withLock { values } }
+}
+
 private func makeStandaloneFakeHFSnapshot(modelId: String) throws -> URL {
     let cacheDir = FileManager.default.homeDirectoryForCurrentUser
         .appendingPathComponent(".cache/huggingface/hub", isDirectory: true)
@@ -620,6 +627,27 @@ private func makeStandaloneFakeHFSnapshot(modelId: String) throws -> URL {
         residentWeightBytes: UInt64(standaloneSizing(weightsGiB: 15).weightsBytes),
         configReserveBytes: 0)
     #expect(recorder.entries.map(\.grant) == [Int(expected)])
+}
+
+@Test func standaloneFactoryReceivesVerifiedCacheWeightHash() async throws {
+    let server = standaloneTestServer()
+    let hashes = StandaloneHashRecorder()
+    await server.setV2TestHooksForTesting(
+        StandaloneServer.V2TestHooks(
+            physicalMemoryBytes: standalonePhysicalBytes,
+            onCacheEligibleWeightHash: hashes.record,
+            makeEngine: { _, grant in InertStubEngine(kvBytesCapacity: grant) }))
+
+    _ = try await server.buildSlotForTesting(
+        modelId: "gpt-oss-20b",
+        modelType: "gpt_oss",
+        container: makeStandaloneStubContainer(),
+        tokenizer: TokenizerHandle(StubBridgeTokenizer()),
+        sizing: standaloneSizing(weightsGiB: 15),
+        cacheEligibleWeightHash: "verified-standalone-hash")
+
+    #expect(hashes.snapshot == ["verified-standalone-hash"])
+    #expect(SSDPrefixCacheFactory.verifiedWeightHash(hashes.snapshot[0]) != nil)
 }
 
 @Test func standaloneSecondLoadReslicesAndEvictionRegrows() async throws {

--- a/provider-swift/Tests/ProviderCoreTests/WeightHashCacheEligibilityTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/WeightHashCacheEligibilityTests.swift
@@ -1,0 +1,137 @@
+import Foundation
+import MLXLMCommon
+import Testing
+
+@testable import ProviderCore
+
+@Suite("SSD cache weight-hash eligibility")
+struct WeightHashCacheEligibilityTests {
+    private func makeLoop() throws -> ProviderLoop {
+        let modelID = "test/cache-hash-model"
+        let config = ProviderLoopConfig(
+            coordinatorURL: "ws://127.0.0.1:0/ignored",
+            hardware: HardwareInfo(
+                machineModel: "Mac16,5",
+                chipName: "Apple M4 Max",
+                chipFamily: .m4,
+                chipTier: .max,
+                memoryGb: 128,
+                memoryAvailableGb: 124,
+                cpuCores: CpuCores(total: 16, performance: 12, efficiency: 4),
+                gpuCores: 40,
+                memoryBandwidthGbs: 546),
+            models: [ModelInfo(
+                id: modelID,
+                modelType: "gpt_oss",
+                sizeBytes: 1,
+                estimatedMemoryGb: 1,
+                weightHash: "stale-observable-hash")],
+            config: ProviderConfig(
+                provider: ProviderSettings(name: "cache-hash-test", memoryReserveGB: 1),
+                backend: BackendSettings(idleTimeoutMins: 0, maxModelSlots: 1),
+                coordinator: CoordinatorSettings(heartbeatIntervalSecs: 60)),
+            modelHashes: [modelID: "stale-observable-hash"],
+            modelHashFingerprints: [modelID: "old-fingerprint"])
+        return try ProviderLoop(
+            config: config,
+            purgeLegacyFiles: false,
+            attestationSigner: nil)
+    }
+
+    @Test("changed fingerprint plus both failed rehashes keeps stale observable hash but disables SSD")
+    func failedRehashesDisableReusableCache() async throws {
+        let modelID = "test/cache-hash-model"
+        let loop = try makeLoop()
+        await loop.setWeightHashOperationsForTesting(
+            fingerprint: { _ in "new-fingerprint" },
+            computeHash: { _, _ in nil })
+        let modelPath = URL(fileURLWithPath: "/nonexistent/cache-hash-fixture")
+
+        let preLoad = try await loop.refreshWeightHashForTesting(
+            modelId: modelID,
+            modelPath: modelPath,
+            requireFreshCryptographicHash: true)
+        let postLoad = try await loop.refreshWeightHashForTesting(
+            modelId: modelID,
+            modelPath: modelPath,
+            requireFreshCryptographicHash: true)
+        let eligible = ProviderLoop.cryptographicallyBracketedCacheHash(
+            preLoadHash: preLoad.cacheEligibleWeightHash,
+            postLoadHash: postLoad.cacheEligibleWeightHash)
+
+        #expect(preLoad.effectiveFingerprint == nil)
+        #expect(postLoad.effectiveFingerprint == nil)
+        #expect(eligible == nil)
+        #expect(await loop.liveModelHashForTesting(modelID) == "stale-observable-hash")
+
+        let cache = await SSDPrefixCacheFactory.make(
+            modelId: modelID,
+            weightHash: eligible,
+            layerKinds: [CBv2LayerKind(
+                attention: .full,
+                headDim: 8,
+                kvHeads: 1,
+                queryHeads: 1)],
+            kvBudget: nil,
+            environment: ["DARKBLOOM_PREFIX_CACHE_ALLOW_EPHEMERAL": "1"])
+        #expect(cache == nil)
+    }
+
+    @Test("fingerprint drift across load disables cache even after a successful post-load hash")
+    func loadWindowDriftDisablesCache() {
+        let pre = ProviderLoop.WeightHashRefreshResult(
+            observedFingerprint: "before",
+            effectiveFingerprint: "before",
+            cacheEligibleWeightHash: "before-hash")
+        let post = ProviderLoop.WeightHashRefreshResult(
+            observedFingerprint: "after",
+            effectiveFingerprint: "after",
+            cacheEligibleWeightHash: "after-hash")
+        #expect(ProviderLoop.cacheEligibleWeightHash(
+            preLoad: pre,
+            postLoadFingerprint: "after",
+            postLoadRefresh: post) == nil)
+    }
+
+    @Test("same fingerprint with changed cryptographic hash disables SSD")
+    func preservedMetadataReplacementIsDetected() async throws {
+        final class HashSequence: @unchecked Sendable {
+            private let lock = NSLock()
+            private var hashes = ["hash-before", "hash-after"]
+            func next() -> String? {
+                lock.withLock { hashes.isEmpty ? nil : hashes.removeFirst() }
+            }
+        }
+        let sequence = HashSequence()
+        let loop = try makeLoop()
+        await loop.setWeightHashOperationsForTesting(
+            fingerprint: { _ in "same-size-same-mtime" },
+            computeHash: { _, _ in sequence.next() })
+        let path = URL(fileURLWithPath: "/nonexistent/preserved-metadata-fixture")
+        let pre = try await loop.refreshWeightHashForTesting(
+            modelId: "test/cache-hash-model",
+            modelPath: path,
+            requireFreshCryptographicHash: true)
+        let post = try await loop.refreshWeightHashForTesting(
+            modelId: "test/cache-hash-model",
+            modelPath: path,
+            requireFreshCryptographicHash: true)
+
+        #expect(pre.observedFingerprint == post.observedFingerprint)
+        #expect(pre.cacheEligibleWeightHash == "hash-before")
+        #expect(post.cacheEligibleWeightHash == "hash-after")
+        #expect(ProviderLoop.cryptographicallyBracketedCacheHash(
+            preLoadHash: pre.cacheEligibleWeightHash,
+            postLoadHash: post.cacheEligibleWeightHash) == nil)
+    }
+
+    @Test("missing either cryptographic bracket disables SSD")
+    func missingHashDisablesCache() {
+        #expect(ProviderLoop.cryptographicallyBracketedCacheHash(
+            preLoadHash: nil, postLoadHash: "hash") == nil)
+        #expect(ProviderLoop.cryptographicallyBracketedCacheHash(
+            preLoadHash: "hash", postLoadHash: nil) == nil)
+        #expect(ProviderLoop.cryptographicallyBracketedCacheHash(
+            preLoadHash: "hash", postLoadHash: "hash") == "hash")
+    }
+}


### PR DESCRIPTION
## Summary

- closes every validated post-merge cache-routing review finding across the coordinator and Swift provider
- pins engine hardening from Layr-Labs/mlx-swift-lm#73
- keeps cache routing and early prompt donation disabled by default

## Before

### Behavior

```mermaid
flowchart LR
  A[Consumer request] --> B[Coordinator dispatch]
  B --> C{Provider protocol}
  C -->|v0| D[Caller-derived or shared cache namespace]
  C -->|v1| E[Cache route without mandatory provider hash match]
  D --> F[Provider inference]
  E --> F
  F --> G[SSD staging reserves shared headroom]
  G -->|staging refuses| H[Capacity error even when cold request fits]
  F --> I[Cache hit latency enters cold prefill and TTFT calibration]
  F --> J[Terminal message can overtake or omit lookup receipt]
  F --> K[Raw provider cache details can escape in streamed payloads]
```

### Code

```mermaid
flowchart LR
  A[registry cache evidence] --> B[scheduler discount]
  B --> C[api dispatch]
  C --> D[ProviderLoop inference handler]
  D --> E[EngineV2Bridge]
  E --> F[SSDPrefixCache path-based I/O]
  D --> G[independent receipt and terminal sends]
  D --> H[prefill EWMA]
  C --> I[TTFT and reputation samples]
```

## After

### Behavior

```mermaid
flowchart LR
  A[Consumer request] --> B[Coordinator creates isolated attempt]
  B --> C{Remote cache eligible?}
  C -->|protocol v0 or routing off| D[Fresh per-attempt cache buster]
  C -->|v1 and exact provider/catalog hash match| E[Scoped cache route]
  C -->|no hash match| F[Cold unscoped-disabled request]
  E --> G[Provider performs pre/post cryptographic load-hash bracket]
  G -->|verified match| H[Memory or encrypted SSD cache]
  G -->|missing or changed| F
  H --> I{SSD staging fits?}
  I -->|yes| J[Stage and serve]
  I -->|no| K[Release staging and retry full cold reservation]
  J --> L[Receipt queued before exactly one terminal]
  K --> L
  F --> L
  L --> M[Sanitized usage and correlated terminal telemetry]
  M --> N[Cache participants excluded from cold-prefill calibration]
```

### Code

```mermaid
flowchart LR
  A[cache_receipts.go] --> B[cache_watermarks.go]
  B --> C[cache_routing.go and scheduler.go]
  C --> D[api dispatch.go immutable attempt identity]
  D --> E[ProviderLoop InferenceHandler and ModelLoading]
  E --> F[PrefixCacheReceipts ordered finalizer]
  E --> G[EngineV2Bridge request-aware receipt identity]
  G --> H[SSDPrefixCache namespaced tickets]
  H --> I[SSDNoFollowIO descriptor-relative operations]
  G --> J[mlx-swift-lm donation lifecycle hardening]
  F --> K[api provider.go idempotent outcome metrics]
  K --> L[consumer.go cache-detail sanitization]
```

## Details

- isolates protocol-0 and routing-off requests from reusable remote cache namespaces
- requires matching catalog and provider weight hashes before remote cache participation
- requires matching pre-load and post-load cryptographic hashes before reusable SSD cache construction, including standalone mode
- prevents stale evidence resurrection with bounded watermarks protected by active-attempt heaps
- includes `X-Session-Id` in exact route identity and rejects non-finite routing configuration
- retries cold capacity admission after optional SSD staging abandonment
- binds staging tickets to request correlation IDs and namespaces process-wide reservations per cache instance
- performs active Darwin SSD reads, writes, touches, renames, and deletes through descriptor-relative no-follow operations
- finalizes exactly one lookup receipt before terminal completion or error across outer and bridge failure paths
- sanitizes raw cache-token details from complete, Responses, content, finish, escaped-key, and multiline SSE payloads
- joins selection and terminal telemetry without recording client identifiers or cache keys
- excludes cache-participating latency from provider cold-prefill EWMA and coordinator TTFT/reputation calibration
- binds early donations to their source state and includes donation-owned state in graceful drain readiness; paged early donation remains disabled

## Verification

- `cd coordinator && go test ./...`
- `cd coordinator && go test -race ./registry`
- final focused coordinator API, registry, store, dispatch, sanitization, calibration, and telemetry tests passed
- `cd provider-swift && swift test --parallel` passed 1,309 tests in 145 suites
- liveness-recovery and whole-root-maintenance fixtures pass in CI parallel mode without shared-budget or asynchronous-start races
- final provider receipt/hash selection passed 8/8
- final SSD selection passed 57/57
- engine early-donation selection passed 16/16
- engine prefix-cache selection passed 37/37
- engine scheduler, end-to-end, multimodal, and quantized selection passed 119/119
- final integrated engine selection passed 72/72
- the full engine suite built successfully but exceeded the 30-minute runner timeout without failure output; focused affected suites passed
- `git diff --check`

## Dependency

- engine PR: Layr-Labs/mlx-swift-lm#73
- parent gitlink: `89aa0eeab`

## Rollout

No release or deploy is included. Cache routing and early prompt donation remain default-off.
