### PR TITLE
feat(provider): ship Gemma 4 MTP on CBv2

### DIFF
--- a/docs/architecture/gemma4-cbv2-mtp.md
+++ b/docs/architecture/gemma4-cbv2-mtp.md
@@ -1,8 +1,10 @@
 # Gemma 4 Frozen-KV MTP on Continuous Batching V2
 
-**Status:** implemented and locally validated on parent `c77d38523` with
-`libs/mlx-swift-lm` based at `9ec146e49`. Not pushed, released, registered, or
-deployed.
+**Status:** implemented and under review in d-inference PR
+[#547](https://github.com/Layr-Labs/d-inference/pull/547), which pins the engine
+implementation in mlx-swift-lm PR
+[#74](https://github.com/Layr-Labs/mlx-swift-lm/pull/74). Default-off; not
+released, registered, or deployed.
 
 This document is the implementation contract for production Gemma 4
 multi-token prediction (MTP) in Darkbloom. It records the code-grounded local
@@ -525,6 +527,721 @@ recording their paths, revisions, configs, byte sizes, and hashes.
 - `darkbloom` product build.
 - Targeted production-factory HTTP test.
 - Independent correctness, lifecycle, memory, and security review.
+
+## Future Engine Design
+
+This section is an implementation specification for work after the current
+greedy release. Everything in it is **proposed** unless a paragraph begins
+with **Current**. The implemented contracts remain [Correctness
+Invariants](#correctness-invariants), [Memory Accounting](#memory-accounting),
+[Depth Control](#depth-control), and [Verification Matrix](#verification-matrix).
+The proposals below extend those contracts; they do not reinterpret completed
+validation as evidence for functionality that does not exist yet.
+
+The future design remains a linear Gemma 4 frozen-KV drafter. Stochastic
+sampling, paged-window transactions, and hardware certification are independent
+capabilities with independent fail-open gates. Enabling one must not imply that
+the others are ready.
+
+### Current Greedy-Only Boundary
+
+**Current.** CBv2 MTP is not a generic sampler fast path. Its verifier takes
+raw target argmaxes and bypasses `CBv2DefaultSampler`. The engine therefore
+constructs an MTP driver only for `CBv2DefaultSampler` and
+`CBv2GreedySampler`; an unknown sampler disables MTP for the entire engine
+(`Libraries/MLXLMCommon/ContinuousBatchingV2/EngineV2.swift:247-281`). The
+drafter returns only greedy token IDs, not its logits or proposal
+probabilities (`Libraries/MLXLMCommon/ContinuousBatchingV2/MTP/
+MTPContractsV2.swift:126-149` and `Libraries/MLXLLM/Models/
+Gemma4CBv2MTPDrafter.swift:104-122`). Target verification similarly reduces
+`[B, 1+k, vocab]` to argmax IDs before the one finalize readback
+(`Libraries/MLXLMCommon/ContinuousBatchingV2/MTP/
+EngineLoopV2+MTPExecution.swift:249-291`).
+
+The exact per-row request gate is in `mtpBasicEligible`
+(`Libraries/MLXLMCommon/ContinuousBatchingV2/MTP/
+EngineLoopV2+MTPPlanning.swift:7-23`):
+
+- `temperature` must equal zero.
+- `topLogprobs` must be zero.
+- `logitBias` must be empty.
+- Repetition, frequency, and presence penalties must be at their no-op values.
+- Stop strings must be absent. Stop-token IDs remain supported.
+- The token being processed must not be inside a multimodal embedding span.
+
+`topP`, `topK`, `minP`, and `seed` alone do not make a temperature-zero row
+ineligible. The current logits pipeline deliberately treats those filters as
+irrelevant for greedy rows, while bias and penalties can change the argmax
+(`Libraries/MLXLMCommon/ContinuousBatchingV2/LogitsPipelineV2.swift:163-202,
+265-313`).
+
+**Exact fallback.** If a row is non-greedy or trips any request gate, it is not
+partially speculated and it does not fail. The step-global planner selects
+depth zero when the decode cohort cannot speculate together, invalidates stale
+MTP carry for those rows, and leaves SchedulerV2 with ordinary one-token work
+(`EngineLoopV2+MTPPlanning.swift:84-170`). `executeMixed` then calls the normal
+`CBv2DefaultSampler`, which applies bias, penalties, temperature, top-k,
+top-p, and min-p before keyed Gumbel-max sampling
+(`DefaultSamplerV2.swift:49-97`; `LogitsPipelineV2.swift:1-28`;
+`SamplerV2.swift:82-115`). Requested raw target logprobs are gathered and
+materialized at the existing finalize boundary. The assistant may remain
+resident, but it performs no work for that plan and the consumer sees the
+same target-only behavior it would see with MTP disabled.
+
+This distinction must remain visible in metrics. A request-level sampling
+gate is an ordinary target-only selection, not an assistant load failure and
+not a provider 503. Paged-window storage is a separate current fallback: its
+destructive ring cannot roll back exactly, so it returns
+`supportsSpeculativeWrites == false` and the same planner selects target-only
+decode (`Paged/PagedSequenceKV.swift:107-135`).
+
+### Distribution-Preserving Stochastic Linear MTP
+
+#### Probability Contract
+
+**Proposed.** For one row and draft position `i`, let `h_i` be the confirmed
+output history followed by already proposed draft tokens for this round. Let
+`F(raw, params, h_i, grammar_i)` be the one canonical logits-processing
+function. Define:
+
+```text
+p_i(x) = softmax(F(target_logits_i, params, h_i, grammar_i))[x]
+q_i(x) = softmax(F(draft_logits_i,  params, h_i, grammar_i))[x]
+```
+
+The assistant samples proposal `y_i ~ q_i`. With an independent uniform
+`u_i`, accept it when:
+
+```text
+u_i < alpha_i, where alpha_i = min(1, p_i(y_i) / q_i(y_i)).
+```
+
+Because `y_i` was sampled from `q_i`, its probability is nonzero except for a
+numerical or implementation fault. At the first rejection, emit exactly one
+correction sampled from:
+
+```text
+r_i(x) = max(p_i(x) - q_i(x), 0)
+         / sum_z max(p_i(z) - q_i(z), 0).
+```
+
+Then stop the round. If every one of the `k` proposals is accepted, emit one
+target bonus sampled from `p_k`, the target distribution after the full draft
+prefix. Thus a round still commits `accepted + 1` output tokens. At one
+position, the accepted contribution and rejected residual contribution sum to
+the target distribution because
+`min(p(x), q(x)) + max(p(x) - q(x), 0) = p(x)`.
+
+The zero residual-mass case is not an alternate algorithm. In exact arithmetic
+it cannot coincide with a rejection when `p == q`, because acceptance is one.
+The device implementation must count it as a numerical fault and sample from
+`p_i` for availability, while the rollout gate requires the counter to remain
+zero in certification and canaries. NaN, negative, or non-normalizable `p` or
+`q` fails that row to an ordinary target sample before any output or KV commit;
+it must never silently switch to greedy.
+
+The single-stream helper `gemma4SpeculativeSampleRound` already demonstrates
+the mathematical accept/residual/bonus rule
+(`Libraries/MLXLLM/Models/Gemma4MTP.swift:796-875`), but it calls `.item()` for
+each acceptance decision and sampled token. It is evidence for the formula,
+not an implementation to reuse in CBv2. The CBv2 design below keeps the whole
+batch on device until the existing finalize boundary.
+
+#### Worked Example
+
+Suppose one processed position has:
+
+```text
+token       A     B     C
+p         0.4   0.4   0.2
+q         0.5   0.3   0.2
+```
+
+The drafter samples `A`. Its acceptance probability is
+`min(1, 0.4 / 0.5) = 0.8`. If the acceptance draw is `0.7`, `A` is accepted
+and the round continues. If the draw is `0.9`, `A` is rejected. The positive
+residual is `(p-q)+ = (0, 0.1, 0)`, its normalization is `0.1`, and the
+correction distribution is `(0, 1, 0)`, so the engine emits `B` and ends the
+round. If all draft positions are accepted, the extra emitted token is drawn
+from the target distribution after the entire draft prefix, never from the
+assistant.
+
+#### One Processing Function For `p` And `q`
+
+Correctness requires the same operation order, parameter values, history, and
+constraint state on both raw-logit tensors. "Same processing" does not mean
+the resulting values or support are equal; target and assistant raw logits are
+different. It means both pass through the same implementation of:
+
+1. Capture target raw logprobs for reporting, without changing the sampling
+   tensor. Drafter logprobs are never reported to consumers.
+2. Apply additive logit bias.
+3. Apply repetition, frequency, and presence penalties using the same
+   `confirmed history + earlier drafts` prefix.
+4. Apply the same grammar/allowed-token mask for that prefix.
+5. Divide by the same temperature.
+6. Apply top-k, top-p, and min-p in the same canonical order.
+7. Normalize in float32 and sample.
+
+This is an extension of the current production order in
+`LogitsPipelineV2.process` (`LogitsPipelineV2.swift:265-313`), not a second MTP
+filter implementation. In particular, applying top-p to `p` but not `q`, or
+advancing penalties/grammar with different prefixes, invalidates the ratio and
+residual proof.
+
+Current ProviderCore already translates temperature, top-p, top-k,
+repetition/frequency/presence penalties, seed, bias, and logprobs into
+`CBv2SamplingParams` (`provider-swift/Sources/ProviderCore/Inference/
+EngineV2Bridge+Translation.swift:72-101`). It does not currently implement a
+grammar engine: `response_format` is a pass-through request field
+(`provider-swift/Sources/ProviderCore/Inference/ChatRequest.swift:21-26,
+212-216`). Grammar rows therefore remain target-only until a constraint
+implementation supplies a cloneable, device-resident automaton. A CPU grammar
+that needs draft IDs before producing the next mask would add a mid-round
+readback and is not eligible for stochastic MTP.
+
+#### RNG, Logprobs, Batching, And State
+
+The stochastic contract is distribution identity, not token-for-token identity
+with MTP disabled. Greedy requests retain their stronger exact-token contract.
+For stochastic requests:
+
+- Every random draw is a pure key of `(seed, requestID, absolute output index,
+  lane)`. Lanes are `draftProposal`, `acceptance`, `residual`, and
+  `targetBonus`. No global engine-step number or batch row number participates.
+- A fixed request, seed, engine build, MTP depth schedule, and logits sequence
+  is replay-deterministic and invariant to batchmates, joins, and leaves.
+  Turning MTP on can consume different logical lanes than target-only sampling,
+  so identical seeded tokens across those two algorithms are not promised.
+- Draws for truncated common-width suffixes do not advance mutable RNG state.
+  Output-position keys make unused speculative work irrelevant to later output.
+- Logprobs for an accepted proposal are the target logprobs at that position.
+  A residual correction reports its target `p_i` logprob, not its `r_i`
+  logprob. A bonus reports the target bonus-position logprob. Until the public
+  contract changes, `topLogprobs` retains current raw, pre-transform semantics
+  (`CBv2Contracts.swift:35-53`; `LogitsPipelineV2.swift:276-284`).
+- The step keeps one uniform `k` for all speculating rows. Per-row sampling
+  parameters may differ, but all decode rows in the synchronized target cohort
+  must support the speculative processor; otherwise the entire cohort uses
+  depth zero. Chunked-prefill neighbors remain separate `[1, chunk]` forwards.
+- Rows may naturally accept different lengths. The first implementation keeps
+  the existing common committed width used for quantized-MoE shape parity
+  (`EngineLoopV2+MTPFinalize.swift:45-102`). Truncating a longer valid prefix is
+  distribution-safe; its uncommitted KV, sampler state, logprobs, and RNG lanes
+  are discarded.
+- The canonical penalty and grammar state commits only consumer-visible
+  tokens. It never commits an unaccepted proposal or a naturally accepted
+  suffix truncated by the common width.
+- Target KV still commits the verified input prefix, rolls back the rejected
+  suffix, and stores the next carry from the target hidden column that predicts
+  the newest emitted-but-unfed token. Sampling changes token selection, not the
+  frozen-KV or carry geometry defined above.
+- Stop token, stop string, EOS, max-token, cancellation, and deadline handling
+  walk the emitted prefix in order. Any suffix beyond the first terminal is
+  rolled back before stream completion.
+
+#### Swift Interface Changes
+
+The implementation should change the narrow MTP and sampler seams rather than
+teach `EngineLoopV2` a parallel sampling stack:
+
+1. In `MTPContractsV2.swift`, replace the drafter result `(tokens, hidden)`
+   with `CBv2MTPDraftStep { rawLogits: MLXArray, hidden: MLXArray }`. Greedy
+   token selection then belongs to the same transaction used for stochastic
+   proposals. `Gemma4CBv2MTPDrafter.draftStep` returns its full logits and no
+   longer calls `argMax`.
+2. Extend `CBv2StepSampler` (`EngineLoopV2.swift:59-108`) with an explicit
+   `mtpCapability` and `beginMTPTransaction(rows:draftDepth:rowContext:)`.
+   Remove the concrete-type test in `EngineV2.init`; unknown/custom samplers
+   advertise `.unsupported` and retain the current target-only fallback.
+3. Add engine-thread-confined `CBv2MTPSamplingTransaction`. Its graph-only
+   methods are `sampleDraft(rawLogits:position:)`,
+   `buildAcceptance(targetRawLogits:drafts:)`, `commit(outcomes:)`, and
+   `abort()`. The associated fixed-shape `CBv2MTPAcceptanceGraph` contains
+   device arrays for natural emitted counts, emitted token IDs, accepted
+   counts, target logprob gathers, and numerical-fallback flags.
+4. Refactor `LogitsPipelineV2` so ordinary sampling and an MTP transaction
+   call one pure transform function. A transaction owns two forks initialized
+   from the same confirmed state. The `q` fork advances with each sampled
+   proposal; after rectangular target inference, the `p` fork processes target
+   positions sequentially and advances with those same proposal IDs. Add
+   `commitMany` so canonical penalty state incorporates only finalized output.
+5. Add `CBv2SpeculativeRNGKey` and a stable lane enum beside `SamplerV2.mix`
+   (`SamplerV2.swift:117-155`). Preserve the current ordinary sampler keying;
+   a versioned key derivation prevents a future lane reorder from changing
+   existing seeded output.
+6. Add `CBv2TokenConstraint` only when structured output is implemented. It
+   must provide immutable device transition/mask tables, a forkable per-row
+   state, graph-only `advance(token:)`, and finalize-time `commit`/`abort`.
+   Until then `mtpCapability` returns an explicit `constraint_unsupported` for
+   grammar rows.
+7. Replace `CBv2MTPRoundInFlight.Verify.acceptancePacket` with the typed
+   acceptance graph. `EngineLoopV2+MTPExecution` appends every result and
+   logprob tensor to the same `asyncEval`; `EngineLoopV2+MTPFinalize` performs
+   one readback, commits sampler/KV state, and emits the retained prefix.
+8. Extend `CBv2MTPMetrics` and `ProviderMTPStatusSnapshot`
+   (`MTPContractsV2.swift:240-291` and
+   `provider-swift/Sources/ProviderCore/Inference/ProviderEngineBundle.swift:
+   5-45`) with stochastic rounds, residual samples, target bonuses, processor
+   fallbacks, and numerical faults. Metrics remain content-free.
+
+Artifact resolution, assistant ownership, and memory sizing do not change.
+The provider continues to pass the bound drafter and `CBv2MTPConfig` through
+the single production factory (`EngineV2SlotFactory.swift:317-440` and
+`EngineV2Factory+Production.swift:365-394`). A new stochastic mode flag belongs
+in that config and defaults off independently of the existing MTP beta switch.
+
+#### Device And Host-Sync Plan
+
+Draft forwards remain sequential graph construction because each consumes the
+previous proposal and recurrent hidden. No draft step evaluates or reads a
+token on the host. Proposal sampling, both logits-pipeline forks, acceptance
+coins, residual normalization, residual/bonus sampling, accepted-count
+selection, and logprob gathers are MLX graph operations. The target still runs
+once on `[B, 1+k]`.
+
+The graph emits one fixed-size packet per row: natural count, accepted count,
+`k+1` token slots, terminal/numerical flags, and logprob gather indices. It
+rides the step's existing `asyncEval` list. Finalize performs the only
+`asArray`, in the same place where current MTP reads draft/target argmaxes
+(`EngineLoopV2+MTPFinalize.swift:10-34`). `CBv2CoreInstrumentation.hostSyncs`
+and a new MTP packet-read counter must prove that stochastic `k > 0` adds no
+host synchronization relative to greedy MTP. Device grammar tables are a hard
+requirement for the same reason.
+
+#### Stochastic Test Gates
+
+Deterministic tests must include:
+
+- The worked three-token example with forced proposal and uniform draws for
+  accept, reject, and all-accepted bonus paths.
+- `p == q`, disjoint/partial supports after filtering, `q(y) > p(y)`,
+  `q(y) < p(y)`, top-k one, and the zero-residual numerical guard.
+- A processor-symmetry spy proving both sides receive the same bias,
+  penalties, temperature, top-k/top-p/min-p parameters, proposal prefix, and
+  grammar state at every position.
+- Repetition/frequency/presence state after rejection, common-width
+  truncation, stop token/string, cancellation, preemption, and request-ID
+  reuse.
+- Seed replay and batch-composition invariance at B=1/2/4/8 with joins,
+  leaves, chunked-prefill neighbors, mixed parameter values, and depth zero.
+- Chosen and top logprobs gathered from target raw logits for every accepted,
+  residual, and bonus token; no drafter or residual-distribution logprob leaks.
+- Full, quantized, contiguous-window, and later paged-window KV equality with
+  the direct target path after every accepted length `0...k`.
+- Exactly one finalize packet read and zero `.item()`/blocking `eval` calls in
+  graph construction.
+
+Statistical tests must use fixed synthetic `p != q` distributions and enough
+independent request keys for a chi-square goodness-of-fit test after merging
+low-expected-count bins. Cover `k=1,3,7`, temperature `0.6` and `1.0`, top-k,
+top-p, bias, each penalty family, and a small device grammar. Test both the
+first marginal and a two-position conditional distribution; checking only
+token validity or sequence diversity is insufficient. The CUDA-side vLLM test
+at `tests/v1/spec_decode/test_rejection_sampler_utils.py` is a useful test
+shape, but Darkbloom needs the same evidence on MLX and Apple Silicon.
+
+Real-model gates compare stochastic MTP samples with direct target samples,
+not individual token strings. For each certified target/assistant/chip tuple,
+record a predeclared goodness-of-fit statistic over opaque token-count bins,
+acceptance by position, residual/bonus counts, and zero numerical faults. The
+same suite runs with MTP off, fixed depths, and adaptive depth. Greedy parity
+matrices remain mandatory and separate.
+
+Rollout is blocked until all deterministic and statistical tests pass in a
+release build, no extra host sync is measured, MTP-off fallback handles every
+unsupported processor, and the content-free counters are live. Ship behind a
+new default-off stochastic kill switch, canary only on already-certified
+pre-M5 tuples, and default-enable no tuple until target-distribution tests and
+workload-weighted goodput both pass. Any distribution, NaN, RNG replay,
+logprob, or state-leak failure turns stochastic MTP off without disabling
+greedy MTP or target serving.
+
+### Paged-Window Speculative Staging
+
+#### Current Failure
+
+**Current.** A paged full-attention row is rollback-safe: reads are bounded by
+`absoluteOffset`, and pages beyond a rolled-back frontier can be freed. A
+paged sliding-window row maps logical page `j` to
+`table[j % ringPages]`. A multi-token verify can therefore overwrite the
+physical page still holding the oldest committed in-window entries. Moving
+the frontier backward cannot reconstruct those values. The implementation
+documents that destructive alias and deliberately returns false from
+`supportsSpeculativeWrites` for windowed rows
+(`Paged/PagedSequenceKV.swift:10-16,107-135,187-203`).
+
+The contiguous window backend solves the same problem by holding the entire
+speculative K/V tile outside its ring until finalize
+(`SequenceKV/WindowedSequenceKV.swift:43-53,182-263`). Reusing that tensor
+strategy for paged storage would defeat paging and add a window-sized copy.
+Paged staging instead needs page-level copy-on-write.
+
+#### Transaction Model
+
+**Proposed.** Each `PagedSequenceKV` exposes two views while a verify is in
+flight:
+
+- The **committed table** and `committedOffset`, which are the only state
+  visible to donation, preemption, cancellation cleanup, and the next engine
+  step.
+- A **provisional table** and `provisionalOffset`, used only by the current
+  target verify graph. It begins as a logical copy of the committed mapping
+  and replaces every destructively touched ring page with a temporary physical
+  page.
+
+The engine first reserves the worst-case temporary pages for every
+storage-owning layer and every participating row. Reservation is atomic by
+`PagedKVGroupKey`: if any group lacks pages, release all temporary holds,
+refund the speculative token reservation, clear round marks, and execute the
+whole synchronized cohort at depth zero. No committed table or frontier may
+change before all reservations succeed.
+
+For each touched logical page:
+
+1. A full-attention append that begins on a fresh page can write a new
+   provisional page directly. An append into the unused suffix of the current
+   full page may keep the committed page because it cannot destroy confirmed
+   slots, but it remains hidden beyond `committedOffset`.
+2. A sliding-window destination whose ring slot currently owns committed live
+   history gets a temporary page. If the write is partial, copy the source
+   page first, then overlay provisional slots. If it is a whole-page overwrite
+   and every old slot is outside the post-commit window, the initial copy is
+   unnecessary.
+3. Verification attention receives the provisional tables and provisional
+   frontier. Frozen assistant snapshots continue to use the committed
+   pre-round tables; this preserves the current target-KV snapshot ordering.
+4. Finalize computes the retained token count. A wholly accepted temporary
+   page is remapped into the committed table in O(1), and the displaced page
+   is released after its last read fence. At a partially accepted boundary,
+   remap is legal only when rejected slots cannot represent still-live old
+   history. Otherwise copy only accepted slots into the committed destination
+   and keep its untouched slots. Rejected temporary pages are freed.
+5. After every layer has a non-failing commit plan, publish table versions and
+   the row's committed frontier together on the serial engine queue. Scheduler
+   computed tokens and pending samples update only after this publication.
+
+The commit path cannot allocate or throw. All pages, copy destinations, table
+capacity, and copy descriptors are prepared during reservation. Copy/remap
+kernels participate in the pool's existing write-fence chain
+(`Paged/PagedKVPool.swift:484-552`). If a row is discarded after launch, its
+transaction aborts after the step's host fence; the ordinary deferred-release
+rule then returns committed and temporary pages safely.
+
+#### Full-To-SWA Mapping
+
+Gemma 4 full and sliding layers have different head dimensions and may live in
+different `PagedKVGroupKey` pools (`LayerKindDerivation.swift:79-121`). Page
+IDs are group-local and must never be assumed equal. The transaction therefore
+uses one canonical logical token range but records a per-layer mapping:
+
+```text
+(layerIndex, logicalPage) -> (groupKey, committedSlot, provisionalPage)
+```
+
+If a future scheduler adopts a canonical full-attention token-location table,
+it must also maintain an explicit `fullToSWA` mapping for every provisional,
+remapped, copied, and freed page. Allocation, accepted-path compaction, abort,
+and prefix donation update both mappings in one engine-queue transaction.
+Inferring the SWA page from a full page number is forbidden. This is the same
+class of requirement made explicit by SGLang's separate target pool and typed
+physical-layer mapping, but the Swift representation remains per layer rather
+than importing its global token-slot model.
+
+KV-shared Gemma layers continue to own no pages. They borrow the source
+layer's provisional table during target verification and the committed table
+everywhere else, matching the current `sharesKVWithLayer` contract
+(`Paged/PagedLayerCache.swift:79-107,156-178`).
+
+#### Swift Interface Changes
+
+Replace the implicit arm/rollback/commit sequence in `CBv2SequenceKV`
+(`CBv2Contracts.swift:267-324`) with an explicit transaction contract:
+
+```swift
+public protocol CBv2SpeculativeKVTransaction: AnyObject {
+    var reservedBytes: Int { get }
+    func commit(keepingTokens: Int)
+    func abort()
+}
+
+public protocol CBv2SequenceKV: AnyObject {
+    // New requirement; existing update/snapshot/accounting requirements remain.
+    func beginSpeculativeWrite(maxTokens: Int) throws
+        -> any CBv2SpeculativeKVTransaction
+}
+```
+
+`commit` transitions a pending transaction exactly once and asserts on a
+second normal commit. `abort` transitions pending to aborted and is a no-op
+after either terminal state so teardown can call it defensively. Full and
+quantized contiguous rows return a zero-reservation transaction over their
+existing offset rollback. Contiguous window rows wrap their current staged
+tensors. Paged rows return
+`PagedSpeculativeWrite`, containing `baseOffset`, provisional table entries,
+temporary pages, partial-page copy plans, and the exact reserved-page charge.
+
+Add `PagedKVPool.reserveTemporary`, `commitTemporary`, and `abortTemporary`.
+`pagesReserved` and `bytesReserved` include both request-lifetime and temporary
+holds, while new gauges expose temporary reserved/in-use pages separately.
+The slabs are already physically resident, so temporary pages do not add slab
+resident bytes; they consume allocatable pool capacity and must reduce
+admission headroom. For contiguous staging, actual extra MLX arrays continue
+to appear in `byteCount` as they do today
+(`WindowedSequenceKV.swift:113-118`).
+
+Add a row-level `CBv2SpeculativeKVBatch` coordinator. It reserves every
+storage owner, aborts the prefix on any failure, supplies provisional cache
+views to the target forward, and commits all layers with one per-row retained
+count. `CBv2MTPRoundInFlight.VerifyRow` owns this coordinator rather than an
+untyped `[CBv2SequenceKV]` list
+(`MTP/CBv2MTPRoundDriver.swift:47-70`). `EngineLoopV2+MTPFinalize` no longer
+calls `rollback` and `commitSpeculativeWrite` separately; it invokes exactly
+one batch `commit(keepingTokens:)` or `abort()`.
+
+`PagedLayerCache.deviceTables` must fingerprint which view it cached
+(`committed` or a unique transaction serial) in addition to row serial and
+table version (`Paged/PagedLayerCache.swift:48-57,281-305`). A committed-table
+cache must never be returned to a verify graph, and a provisional device table
+must die with its transaction.
+
+#### Lifecycle And Prefix Rules
+
+- Cancellation before launch aborts reservations immediately. Cancellation
+  after launch marks the row discarded, waits for the existing in-flight
+  fence, aborts provisional pages, then releases committed storage.
+- Preemption first aborts or finalizes the transaction. Requeued state contains
+  only a committed table/frontier; request-ID reuse cannot reach a transaction
+  because the in-flight step owns it by object identity.
+- Drain and shutdown abort every uncommitted transaction before pool teardown.
+  Pool assertions require temporary reserved/in-use counts to reach zero.
+- `snapshot()` and prefix donation expose committed state only. An early
+  donation scheduled while a transaction exists is delayed behind finalize or
+  cancelled; it never pins provisional page IDs. The current paged snapshot
+  materialization requirement remains in force
+  (`provider-swift/Sources/ProviderCore/Inference/
+  EngineV2Factory+Production.swift:187-208` describes the paged production
+  boundary; `PagedKVBackend.swift:201-208` owns the snapshot rule).
+- Prefix adoption creates committed tables only. A fast-forwarded SWA row may
+  begin a later transaction, but its partial ring and full-to-SWA mapping must
+  pass the same boundary tests as a cold row.
+- Rejected bytes may remain in a hidden full-page suffix, but no table/frontier
+  combination may make them attendable, donatable, or visible to another row.
+  A recycled temporary page is not read until its new owner writes every slot
+  it exposes.
+
+#### Exact Paged Test Matrix
+
+Every row in this matrix runs both the paged transaction and the contiguous
+window reference, then compares retained K/V values, attention output, emitted
+tokens, tables, frontiers, and accounting:
+
+| Axis | Required cases | Required assertion |
+|---|---|---|
+| Page geometry | production page size 16; test page size 4; frontier modulo page at `0`, `1`, `S-1` | Correct destination slots and no read of rejected suffix |
+| Window geometry | below first wrap; exactly full; first wrap; multiple wraps; `window < page`, `window == page`, `window = page+1`; prefix fast-forward | Exact oldest-to-newest committed window |
+| Draft geometry | `k=1,2,7`; keep `0...1+k`; full accept, first reject, middle reject, terminal truncation | Value-exact state for every retained width |
+| Page outcome | fresh full page; existing partial page; whole SWA replacement; partial SWA replacement with live old slots | Legal remap when whole-safe, accepted-slot copy otherwise |
+| Layer layout | full only; SWA only; Gemma mixed full/SWA; KV-shared borrowers; distinct group page IDs | Per-layer mapping correct; no full/SWA ID alias assumption |
+| Batch | B=1/2/4/8; equal and mixed natural accept lengths; common-width truncation | Row isolation and synchronized committed width |
+| Capacity | exact temporary-page fit; short by one page in each group; reservation race after planner preflight | All-or-nothing reserve and target-only demotion before mutation |
+| Lifecycle | cancel before write, after write, after eval, and before finalize; deadline; preemption; ID reuse; drain; shutdown | No leak, double free, stale table, or provisional donation |
+| Prefix cache | cold row; adopted partial page; adopted window tail; donation requested during verify | Only committed pages/offset are adopted or donated |
+| Device-table cache | no page change; provisional remap; abort; commit; row serial reuse attempt | Correct table rebuild count and transaction-view fingerprint |
+| Accounting | remap, copy, abort, capacity fallback, terminal release | `temporaryReserved == temporaryInUse == 0` at quiescence; pool totals conserved |
+| Fences and reuse | immediate page reuse by another row after commit/abort | New owner cannot race the prior verify read or copy |
+
+Add randomized state-machine tests over allocate, write, begin, keep/abort,
+snapshot, preempt, donate, and release, with a simple host K/V model as the
+oracle. Run at least 10,000 deterministic operations for page sizes 4 and 16.
+Real-model gates must cross a Gemma sliding-window boundary at B=1/2/4/8 and
+compare paged MTP tokens and target logits with contiguous MTP and paged
+target-only. Paged-window activation remains separately default-off until the
+matrix, randomized oracle, full engine suites, and release goodput measurement
+pass with zero temporary-page leaks.
+
+### M5 Rectangular Kernel Certification
+
+#### Current Veto And Evidence
+
+**Current.** Ordinary decode uses `[B,1]`; an MTP verification uses
+`[B,1+k]`. Remote M5 Max testing found repeatable target-argmax drift between
+those shapes in synthetic B1/B2 cases and in the real production QAT/QAT
+matrix at B8/L6. The evidence and excluded scheduler/cache/order hypotheses
+are recorded in the M5 follow-up on engine PR
+[#74](https://github.com/Layr-Labs/mlx-swift-lm/pull/74#issuecomment-4974224001).
+This is target-kernel evidence, not evidence against the accept-walk.
+
+The engine now denies any chip name containing the token `M5` before it builds
+the MTP driver (`Libraries/MLXLMCommon/MLXHardwareInfo.swift:31-60` and
+`ContinuousBatchingV2/EngineV2.swift:247-287`). It exposes the stable inactive
+reason and serves target-only. The gate test proves M5/M5 Max denial and M4
+allowance (`Tests/MLXLMTests/CBv2MTPEngineParityTests.swift:365-417`). The
+provider benchmark schema has an explicit expected-inactive M5 mode and rejects
+unexpected work or reasons
+(`provider-swift/Sources/ProviderBenchmark/MTPBenchmarkReport.swift:29-75`;
+`provider-swift/Tests/ProviderCoreTests/MTPBenchmarkTests.swift:183-273`).
+
+At parent commit `0b08e76d8`, the remote M5 Max expected-inactive QAT matrix
+completed 40/40 target parity cases, 36/36 requested MTP cases inactive, 150
+rows, zero speculative work, and the exact hardware reason. That proves the
+veto and fallback, not rectangular correctness. The report SHA-256 is
+`b197fc3aa4b27706024057ec201a9015f5dd8b392d196f6998880b5b2419391d`.
+
+The current gate is a negative M5 denylist, not a certification database. At
+the engine's pinned MLX Swift revision
+`df1fdc5f7821a1fabe921fdefbc42ac74dcfb6bc`
+(`Package.resolved:31-38`), the truthful capability table is:
+
+| Chip family | Current code gate | Evidence recorded for this branch | Proposed certified state |
+|---|---|---|---|
+| M1 | allowed | No complete per-chip rectangular artifact recorded | Deny until exact tuple is certified |
+| M2 | allowed | No complete per-chip rectangular artifact recorded | Deny until exact tuple is certified |
+| M3 | allowed | No complete per-chip rectangular artifact recorded | Deny until exact tuple is certified |
+| M4 | allowed | Local bounded MTP suites and production matrices passed | Allow only listed M4/MLX/model tuples |
+| M5 | denied | Repeatable synthetic and real QAT argmax drift; fail-open matrix passed | Deny until kernel fix and full recertification |
+| Unknown/future | currently allowed | None | Deny by default |
+
+This table deliberately distinguishes "the code does not veto it" from
+"certified". MTP remains default-off while the current coarse gate exists.
+
+#### Investigation And Certification Plan
+
+1. Build a release diagnostic that starts from byte-identical committed KV and
+   feeds the same fixed token continuations through serial `[B,1]` target
+   calls and one `[B,L]` call. Compare raw logits, argmax, pre-norm hidden,
+   each storage-owning layer's committed K/V, and attention output before any
+   sampler or accept logic.
+2. Run B=1/2/4/8 and L=1...8 for production QAT-4bit, available 8bit, and BF16
+   targets at short context, immediately before/after SWA wrap, and long
+   context. Add L=9 diagnostic cases because the known MLX SDPA dispatch
+   boundary sits at 8/9; keep L=9 outside the production capability range.
+3. Bisect the first divergent layer and operation. Compare embedding, Q/K/V
+   projection, RoPE, SDPA/composed attention, quantized dense matmul, MoE gate
+   and expert output, residual, norm, and LM head. Force available reference
+   versus optimized MLX paths one operator at a time. Record Metal kernel
+   names and tensor shapes, not just final token IDs.
+4. Repeat every case in fresh processes and with wide-margin as well as
+   near-tie logits. Report max absolute/relative drift, argmax margin, first
+   divergent tensor, selected kernel, macOS build, exact chip identifier/GPU
+   cores, compiler, mlx-swift-lm SHA, and MLX Swift SHA.
+5. When the root cause is in MLX/Metal, land or pin the upstream fix first.
+   Re-run the complete matrix on every M5 variant intended for the fleet; an
+   M5 Max result does not certify base M5, Pro, or a later stepping.
+6. Re-run the real provider QAT/QAT raw-parity matrix, repeated rejection
+   regressions, mixed continuous batching, KV rollback, and release performance
+   on the exact fixed dependency. No synthetic-only certification is valid.
+
+The load-time API becomes a positive capability lookup, for example
+`CBv2MTPKernelCertification.lookup(key:)`, keyed at minimum by exact chip
+identifier, macOS build range, MLX Swift revision, target model build/hash,
+target quantization, batch ceiling, and verification-width range. The
+provider passes the resulting immutable certificate ID through
+`CBv2MTPConfig`; `EngineV2` constructs the driver only when the requested
+`B,L` range is covered. Missing, unknown, expired, or mismatched entries select
+target-only and surface a stable `kernel_uncertified` reason.
+
+Normal model load must not self-certify by running unsafe rectangular work.
+Certification is an offline/release process that produces a reviewed table;
+load only verifies the exact tuple. The process kill switch remains a final
+override.
+
+The blanket M5 veto can be narrowed only when all of these are true:
+
+- A first-divergence root cause is understood and fixed at a pinned dependency
+  or an explicitly safe engine path.
+- Every supported M5 chip variant passes the full deterministic tensor matrix
+  repeatedly in clean release processes with zero argmax divergence.
+- Real QAT, 8bit where offered, and BF16 matrices pass B=1/2/4/8 and L=1...8,
+  including sliding boundaries and mixed batches.
+- Greedy, stochastic if enabled, KV, cancellation, and provider fail-open
+  suites pass at the exact parent and engine SHAs.
+- The capability entry, reports, and dependency pin receive independent
+  review, and a default-off owned-box canary shows no drift or kernel fault.
+
+Passing those gates adds narrow positive entries. It does not delete hardware
+certification or make unknown future chips eligible.
+
+### Audited Runtime Comparison
+
+This is a source audit, not a portability claim. vLLM and SGLang target CUDA/
+ROCm-style paged runtimes; their algorithms inform contracts, while Swift/MLX
+needs its own memory, synchronization, and kernel evidence.
+
+| Capability | Darkbloom current PR | vLLM `8b8af2caf739a7537b9ca848b836733c6533bf20` | SGLang `cfc3d0555e6d56a382ed6eb40e993cd2c10c9ef8` |
+|---|---|---|---|
+| Gemma 4 drafter | Dedicated linear frozen-KV adapter; constant position; target embedding/hidden | Dedicated `Gemma4Speculator`; Q-only, constant position, typed target-layer sharing | Dedicated `FROZEN_KV_MTP`; target pool is read-only to the drafter with logical-to-physical layer mapping |
+| Stochastic support | CBv2: no; exact target-only fallback. A separate single-stream helper has host-synced rejection sampling and is not production CBv2 | Generic probabilistic draft plus rejection/residual sampler supports target processing and distribution tests; Gemma-specific E2E in this revision is greedy, so Gemma stochastic remains less directly evidenced | Generic linear rejection kernel exists, but startup explicitly rejects it for `FROZEN_KV_MTP`; current Frozen-KV path is not stochastic-certified |
+| Paged provisional KV | Paged full rows roll back; paged SWA rows are disabled because ring writes are destructive | Scheduler allocates new plus lookahead blocks; unverified drafts are included in allocation but excluded from cache publication, and rejected counts move the computed frontier back | Verify uses overallocated target slots/pages, moves the accepted tree path into committed target locations, and tracks allocated versus committed lengths |
+| Tree/top-k | No; one proposal per position and one linear verify | Gemma 4 speculator is linear, one token per step; other speculators have separate tree/block modes | Frozen-KV reuses EAGLE tree machinery and tests top-k 1 and 3; top-k > 1 is backend-restricted |
+| Sliding-window attention | Contiguous SWA staging is exact; paged SWA speculation disabled | KV manager accounts for sliding-window block removal against processed/in-flight tokens; Gemma shares the last non-shared layer of each attention type | Frozen draft resolves typed physical target layers and participates in SWA eviction/pool resolution; page/tree backend combinations are restricted |
+| Adaptive depth | Online batch-bucketed measured-goodput controller including depth zero | Optional configured batch-size-to-k schedule; it is not online measured goodput and is disabled with data parallelism | Generic adaptive runtime exists, but `FrozenKVMTPWorkerV2` asserts that adaptive mode is unsupported |
+| Tests and limits | Greedy token parity across real QAT/8bit pairings; no stochastic CBv2 or paged-SWA proof; M5 denied | Generic chi-square rejection tests, processor/constraint tests, dynamic-depth unit tests, and Gemma E4B correctness/acceptance E2E. Gemma E2E allows partial token agreement and does not directly certify Apple kernels | Frozen-KV E4B GSM8K/acceptance E2E for top-k 1/3 and SWA-pool resolver tests. No Frozen stochastic/adaptive test; mixed chunking is disabled for speculative mode |
+
+Primary audited paths:
+
+- vLLM Gemma binding:
+  [`vllm/v1/worker/gpu/spec_decode/gemma4/speculator.py`](https://github.com/vllm-project/vllm/blob/8b8af2caf739a7537b9ca848b836733c6533bf20/vllm/v1/worker/gpu/spec_decode/gemma4/speculator.py)
+  and the already referenced [vLLM PR
+  #41745](https://github.com/vllm-project/vllm/pull/41745).
+- vLLM stochastic verifier:
+  [`rejection_sampler.py`](https://github.com/vllm-project/vllm/blob/8b8af2caf739a7537b9ca848b836733c6533bf20/vllm/v1/worker/gpu/spec_decode/rejection_sampler.py),
+  [`rejection_sampler_utils.py`](https://github.com/vllm-project/vllm/blob/8b8af2caf739a7537b9ca848b836733c6533bf20/vllm/v1/worker/gpu/spec_decode/rejection_sampler_utils.py),
+  and
+  [`tests/v1/spec_decode/test_rejection_sampler_utils.py`](https://github.com/vllm-project/vllm/blob/8b8af2caf739a7537b9ca848b836733c6533bf20/tests/v1/spec_decode/test_rejection_sampler_utils.py).
+- vLLM block lifecycle and depth schedule:
+  [`vllm/v1/core/kv_cache_manager.py`](https://github.com/vllm-project/vllm/blob/8b8af2caf739a7537b9ca848b836733c6533bf20/vllm/v1/core/kv_cache_manager.py),
+  [`vllm/v1/core/sched/scheduler.py`](https://github.com/vllm-project/vllm/blob/8b8af2caf739a7537b9ca848b836733c6533bf20/vllm/v1/core/sched/scheduler.py),
+  and
+  [`tests/v1/spec_decode/test_dynamic_sd.py`](https://github.com/vllm-project/vllm/blob/8b8af2caf739a7537b9ca848b836733c6533bf20/tests/v1/spec_decode/test_dynamic_sd.py).
+- SGLang Frozen-KV worker and mapping:
+  [`frozen_kv_mtp_worker_v2.py`](https://github.com/sgl-project/sglang/blob/cfc3d0555e6d56a382ed6eb40e993cd2c10c9ef8/python/sglang/srt/speculative/frozen_kv_mtp_worker_v2.py),
+  [`frozen_kv_mtp_info.py`](https://github.com/sgl-project/sglang/blob/cfc3d0555e6d56a382ed6eb40e993cd2c10c9ef8/python/sglang/srt/speculative/frozen_kv_mtp_info.py),
+  [`models/gemma4_mtp.py`](https://github.com/sgl-project/sglang/blob/cfc3d0555e6d56a382ed6eb40e993cd2c10c9ef8/python/sglang/srt/models/gemma4_mtp.py),
+  and the already referenced [SGLang PR
+  #24436](https://github.com/sgl-project/sglang/pull/24436).
+- SGLang verify allocation/commit and stochastic exclusion:
+  [`eagle_utils.py`](https://github.com/sgl-project/sglang/blob/cfc3d0555e6d56a382ed6eb40e993cd2c10c9ef8/python/sglang/srt/speculative/eagle_utils.py),
+  [`spec_utils.py`](https://github.com/sgl-project/sglang/blob/cfc3d0555e6d56a382ed6eb40e993cd2c10c9ef8/python/sglang/srt/speculative/spec_utils.py),
+  and
+  [`arg_groups/speculative_hook.py`](https://github.com/sgl-project/sglang/blob/cfc3d0555e6d56a382ed6eb40e993cd2c10c9ef8/python/sglang/srt/arg_groups/speculative_hook.py).
+- SGLang tests:
+  [`test/registered/spec/test_frozen_kv_mtp.py`](https://github.com/sgl-project/sglang/blob/cfc3d0555e6d56a382ed6eb40e993cd2c10c9ef8/test/registered/spec/test_frozen_kv_mtp.py)
+  and
+  [`test/registered/unit/spec/test_resolve_swa_kv_pool.py`](https://github.com/sgl-project/sglang/blob/cfc3d0555e6d56a382ed6eb40e993cd2c10c9ef8/test/registered/unit/spec/test_resolve_swa_kv_pool.py).
+
+### Prioritized Delivery Phases
+
+These phases extend, rather than replace, the current [Rollout
+Gates](#rollout-gates). A later phase cannot weaken an earlier target-only
+fallback.
+
+| Priority | Dependencies | Deliverable | Definition of done |
+|---|---|---|---|
+| F0: capability foundations | Current greedy PRs | Positive kernel-certificate type; sampler capability marker; explicit KV transaction protocol; no feature enabled | Current greedy matrices and full suites unchanged; every new capability defaults unsupported; no provider behavior change |
+| F1: stochastic linear MTP on current safe storage | F0; pre-M5 certified rectangular tuple | Device-only `p/q` processing, rejection/residual/bonus packet, RNG lanes, target logprobs; contiguous full/quantized/window staging only | Deterministic and chi-square matrices pass; one finalize readback; all unsupported sampler/constraint rows fall back; release goodput non-regressing where enabled |
+| F2: paged-window greedy staging | F0 | Temporary page reservation, committed/provisional tables, remap/copy commit, full-to-SWA mapping, lifecycle/accounting | Exact matrix and 10,000-operation state model pass; real Gemma boundary parity passes; zero page/accounting leaks; stochastic remains off on paged rows |
+| F3: compose stochastic and paged staging | F1 and F2 | Same stochastic transaction over paged full/SWA rows | Cross-product sampling, KV, logprob, cancellation, prefix, and capacity tests pass; no extra sync or distribution drift |
+| F4: per-chip certification and M5 recovery | F0; upstream/root-cause fix for M5 | Reviewed positive entries for exact chip/OS/MLX/model tuples | All removal criteria above pass; unknown tuples stay target-only; M5 canary remains default-off until separately approved |
+| F5: controlled rollout | Relevant capability phases | Independent stochastic, paged-window, and chip allowlists plus kill switches and content-free telemetry | Owned-box canaries, production-duration replay, memory/energy/TTFT/goodput gates, rollback drill, and operator documentation complete |
+
+The future engine work is complete only when every enabled tuple is positively
+certified, stochastic output matches the target distribution, paged state is
+value-exact after every lifecycle exit, no new host synchronization appears,
+provider accounting includes all temporary work, and disabling any new
+capability returns immediately to the already-validated greedy or target-only
+path.
+
+### Explicit Non-Goals
+
+The exclusions in [Scope](#scope) continue to apply. In particular, these
+phases do **not** add EAGLE/EAGLE-2/EAGLE-3, Medusa, tree verification,
+top-k branching, relaxed/block acceptance, online assistant training, beam
+search, or per-row variable verification depth. SGLang's tree implementation
+is comparison evidence only. They also do not move speculation into the
+coordinator, change assistant artifact trust/ownership, promise bitwise
+stochastic equality between MTP-on and MTP-off, or default-enable MTP on an
+uncertified chip. Those are separate designs and reviews.
 
 ## Rollout Gates
 

--- a/docs/architecture/gemma4-cbv2-mtp.md
+++ b/docs/architecture/gemma4-cbv2-mtp.md
@@ -20,6 +20,9 @@ Continuous Batching V2 (CBv2).
 The production branch now includes:
 
 - Native CBv2 seed/draft/verify rounds with target-authoritative acceptance.
+- A chip-independent serial target verifier that keeps MTP active from M1
+  through M5; rectangular verification is explicit opt-in rather than a
+  hardware denylist.
 - Step-global eligibility and commit cadence for quantized MoE parity.
 - Exact full, quantized, and staged-window KV rollback.
 - Strict absolute-position assistant sliding masks.
@@ -66,6 +69,8 @@ Review-driven correctness defects found and fixed during implementation:
 | QAT target + BF16 assistant raw matrix | 40/40 parity, same matrix |
 | 8bit target + BF16 assistant raw matrix | 40/40 parity, same matrix |
 | Real provider paths | load/bind, fail-open assistant failure, tool-templated VLM, and image-prefill paths passed |
+| M4 Max serial-target QAT/QAT matrix | 40/40 parity, 36/36 requested speculative cases active, 714 rounds, 2,175 proposals, 1,179 accepted, zero mismatch rows; report records `serial_target`; SHA-256 `b90e7f6671f409d11e621ede4040e8e18060a17dfe7bbbcd555efe1e968bdd15` |
+| M5 Max serial-target QAT/QAT matrix | 40/40 parity, 36/36 requested speculative cases active, 630 rounds, 1,827 proposals, 1,189 accepted, zero mismatch rows; report records `serial_target`; SHA-256 `53d2bd99e6a21c7745d73a4ab617b2855d57c2199ec2a90357bf1c7faf2aa2a5` |
 | Products | `ProviderCore`, `ProviderBenchmark` debug/release, and `darkbloom` build passed |
 | Diff checks | parent and nested diffs clean |
 
@@ -127,7 +132,9 @@ Build the official Gemma 4 assistant path:
 - Frozen K/V from the last storage-owning full-attention and
   sliding-attention target layers.
 - Constant assistant position within a draft round.
-- Linear draft proposals followed by one rectangular target verification.
+- Linear draft proposals followed by chip-independent serial target
+  verification by default; rectangular target verification remains an
+  explicit optimization.
 - Target-authoritative greedy acceptance.
 - Exact per-row KV commit or rollback.
 - Continuous batching with ordinary decode and chunked-prefill neighbors.
@@ -213,7 +220,7 @@ flowchart LR
   Controller --> Scheduler[SchedulerV2 plan]
   Scheduler --> Seed[Seed hidden and bonus]
   Seed --> Draft[Sequential frozen-KV drafts]
-  Draft --> Verify[One rectangular target verify]
+  Draft --> Verify[Serial target-authority verify by default]
   Verify --> Accept[Target-authoritative accept walk]
   Accept --> Commit[KV commit or rollback]
   Commit --> Stream[Consumer token stream]
@@ -295,11 +302,15 @@ Full acceptance emits the target bonus token.
 The assistant may affect performance and availability, but never accepted
 content.
 
-### One Finalize Boundary
+### Evaluation Boundaries
 
-Draft IDs, target argmaxes, and target hidden state remain device-resident
-until the existing CBv2 finalize boundary. A round introduces no second host
-synchronization.
+Rectangular verification keeps draft IDs, target argmaxes, and target hidden
+state device-resident until the existing CBv2 finalize boundary. The default
+serial target mode instead materializes every `[B,1]` target column and its KV
+inner state before constructing the next column. This adds device
+synchronization but prevents lazy mutable-cache versions from crossing the
+canonical target step boundary. Token IDs still reach the host only at the
+existing finalize acceptance readback.
 
 ### Frozen Assistant State
 
@@ -316,10 +327,13 @@ not decided by comments or inherited code; tensor parity decides it.
 
 ### Speculative KV Transaction
 
-Target verification may compute `1+k` provisional positions. After acceptance:
+Target verification computes `1+k` provisional positions either through
+serial `[B,1]` target calls or an explicitly selected `[B,1+k]` call. After
+acceptance:
 
 - Full and quantized contiguous KV roll back the rejected suffix exactly.
-- Windowed rings stage writes so rejected tokens never destroy live history.
+- Windowed rings accumulate one or more staged writes so rejected tokens never
+  destroy live history.
 - Shared-KV views for the next round contain confirmed tokens only.
 - Scheduler computed-token and pending-sample counts match confirmed KV.
 - Admission refunds exactly the rejected token reservation.
@@ -340,8 +354,8 @@ sampling rows, and chunked-prefill neighbors. MTP work must not:
 - Enter compiled decode with `L > 1`.
 - Become a chained-step base.
 
-The first release uses one uniform depth for all speculating rows in a
-rectangular verification batch.
+The first release uses one uniform depth for all speculating rows in a target
+verification cohort.
 
 ### Lifecycle
 
@@ -539,9 +553,9 @@ The proposals below extend those contracts; they do not reinterpret completed
 validation as evidence for functionality that does not exist yet.
 
 The future design remains a linear Gemma 4 frozen-KV drafter. Stochastic
-sampling, paged-window transactions, and hardware certification are independent
-capabilities with independent fail-open gates. Enabling one must not imply that
-the others are ready.
+sampling, paged-window transactions, and rectangular-kernel certification are
+independent capabilities with independent fail-open gates. Enabling one must
+not imply that the others are ready.
 
 ### Current Greedy-Only Boundary
 
@@ -553,10 +567,12 @@ constructs an MTP driver only for `CBv2DefaultSampler` and
 drafter returns only greedy token IDs, not its logits or proposal
 probabilities (`Libraries/MLXLMCommon/ContinuousBatchingV2/MTP/
 MTPContractsV2.swift:126-149` and `Libraries/MLXLLM/Models/
-Gemma4CBv2MTPDrafter.swift:104-122`). Target verification similarly reduces
-`[B, 1+k, vocab]` to argmax IDs before the one finalize readback
+Gemma4CBv2MTPDrafter.swift:104-122`). Target verification reduces each target
+column to argmax IDs before the finalize acceptance readback. The default
+serial mode materializes `[B,1]` target/KV state between columns; explicit
+rectangular mode uses one `[B,1+k,vocab]` result
 (`Libraries/MLXLMCommon/ContinuousBatchingV2/MTP/
-EngineLoopV2+MTPExecution.swift:249-291`).
+EngineLoopV2+MTPTargetVerification.swift`).
 
 The exact per-row request gate is in `mtpBasicEligible`
 (`Libraries/MLXLMCommon/ContinuousBatchingV2/MTP/
@@ -829,8 +845,9 @@ Deterministic tests must include:
   residual, and bonus token; no drafter or residual-distribution logprob leaks.
 - Full, quantized, contiguous-window, and later paged-window KV equality with
   the direct target path after every accepted length `0...k`.
-- Exactly one finalize packet read and zero `.item()`/blocking `eval` calls in
-  graph construction.
+- For the accelerated rectangular stochastic path, exactly one finalize packet
+  read and zero `.item()`/blocking `eval` calls in graph construction. A future
+  serial stochastic mode must specify its separate evaluation contract.
 
 Statistical tests must use fixed synthetic `p != q` distributions and enough
 independent request keys for a chi-square goodness-of-fit test after merging
@@ -849,10 +866,11 @@ same suite runs with MTP off, fixed depths, and adaptive depth. Greedy parity
 matrices remain mandatory and separate.
 
 Rollout is blocked until all deterministic and statistical tests pass in a
-release build, no extra host sync is measured, MTP-off fallback handles every
-unsupported processor, and the content-free counters are live. Ship behind a
-new default-off stochastic kill switch, canary only on already-certified
-pre-M5 tuples, and default-enable no tuple until target-distribution tests and
+release build, no extra host sync is measured in rectangular mode, MTP-off
+fallback handles every unsupported processor, and the content-free counters
+are live. Ship behind a new default-off stochastic kill switch, canary only on
+already-certified rectangular tuples, and default-enable no tuple until
+target-distribution tests and
 workload-weighted goodput both pass. Any distribution, NaN, RNG replay,
 logprob, or state-leak failure turns stochastic MTP off without disabling
 greedy MTP or target serving.
@@ -1060,107 +1078,74 @@ target-only. Paged-window activation remains separately default-off until the
 matrix, randomized oracle, full engine suites, and release goodput measurement
 pass with zero temporary-page leaks.
 
-### M5 Rectangular Kernel Certification
+### Universal Serial Verification And Rectangular Certification
 
-#### Current Veto And Evidence
+#### Current Default And Evidence
 
-**Current.** Ordinary decode uses `[B,1]`; an MTP verification uses
-`[B,1+k]`. Remote M5 Max testing found repeatable target-argmax drift between
-those shapes in synthetic B1/B2 cases and in the real production QAT/QAT
-matrix at B8/L6. The evidence and excluded scheduler/cache/order hypotheses
-are recorded in the M5 follow-up on engine PR
+**Current.** MTP construction no longer reads a chip name or denies a hardware
+family. `CBv2MTPConfig.verificationMode` defaults to `serial_target`, and the
+engine scores every known target column through the same eager `[B,1]` target
+forward used by ordinary decode
+(`Libraries/MLXLMCommon/ContinuousBatchingV2/MTP/MTPContractsV2.swift` and
+`EngineLoopV2+MTPTargetVerification.swift`). Each column and its KV inner state
+are materialized before the next target column is constructed. The assistant
+still drafts `k` tokens, target authority still accepts or corrects them, and
+one KV transaction commits only the confirmed prefix.
+
+Windowed storage now accumulates multiple serial speculative updates before
+one rollback/commit. KV-shared decode layers borrow the staged source view only
+while that transaction is active; ordinary decode continues using the retained
+ring. Bit-exact storage tests cover full, quantized, and windowed rows, including
+full rollback, partial rollback, repeated serial updates, and post-wrap sharing
+(`CBv2MTPKVStagingTests.swift`). Engine tests cover perfect, fully adversarial,
+and repeatedly partial rejection, mixed batches, stop/length tails,
+cancellation, request-ID reuse, and compiled/eager transitions.
+
+The earlier rectangular result remains important: remote M5 Max testing found
+repeatable target-argmax drift between serial `[B,1]` and `[B,1+k]`, including
+the production QAT pair at B8/L6. That evidence is recorded on engine PR
 [#74](https://github.com/Layr-Labs/mlx-swift-lm/pull/74#issuecomment-4974224001).
-This is target-kernel evidence, not evidence against the accept-walk.
+It justifies keeping rectangular mode explicit; it no longer justifies denying
+MTP on M5.
 
-The engine now denies any chip name containing the token `M5` before it builds
-the MTP driver (`Libraries/MLXLMCommon/MLXHardwareInfo.swift:31-60` and
-`ContinuousBatchingV2/EngineV2.swift:247-287`). It exposes the stable inactive
-reason and serves target-only. The gate test proves M5/M5 Max denial and M4
-allowance (`Tests/MLXLMTests/CBv2MTPEngineParityTests.swift:365-417`). The
-provider benchmark schema has an explicit expected-inactive M5 mode and rejects
-unexpected work or reasons
-(`provider-swift/Sources/ProviderBenchmark/MTPBenchmarkReport.swift:29-75`;
-`provider-swift/Tests/ProviderCoreTests/MTPBenchmarkTests.swift:183-273`).
+The current capability table is:
 
-At parent commit `0b08e76d8`, the remote M5 Max expected-inactive QAT matrix
-completed 40/40 target parity cases, 36/36 requested MTP cases inactive, 150
-rows, zero speculative work, and the exact hardware reason. That proves the
-veto and fallback, not rectangular correctness. The report SHA-256 is
-`b197fc3aa4b27706024057ec201a9015f5dd8b392d196f6998880b5b2419391d`.
-
-The current gate is a negative M5 denylist, not a certification database. At
-the engine's pinned MLX Swift revision
-`df1fdc5f7821a1fabe921fdefbc42ac74dcfb6bc`
-(`Package.resolved:31-38`), the truthful capability table is:
-
-| Chip family | Current code gate | Evidence recorded for this branch | Proposed certified state |
+| Chip family | Default MTP mode | Current evidence | Rectangular optimization |
 |---|---|---|---|
-| M1 | allowed | No complete per-chip rectangular artifact recorded | Deny until exact tuple is certified |
-| M2 | allowed | No complete per-chip rectangular artifact recorded | Deny until exact tuple is certified |
-| M3 | allowed | No complete per-chip rectangular artifact recorded | Deny until exact tuple is certified |
-| M4 | allowed | Local bounded MTP suites and production matrices passed | Allow only listed M4/MLX/model tuples |
-| M5 | denied | Repeatable synthetic and real QAT argmax drift; fail-open matrix passed | Deny until kernel fix and full recertification |
-| Unknown/future | currently allowed | None | Deny by default |
+| M1 | Serial target | Same chip-independent `[B,1]` path as ordinary CBv2 decode; no dedicated physical MTP artifact in this branch | Explicit opt-in only after tuple certification |
+| M2 | Serial target | Same chip-independent `[B,1]` path as ordinary CBv2 decode; no dedicated physical MTP artifact in this branch | Explicit opt-in only after tuple certification |
+| M3 | Serial target | Same chip-independent `[B,1]` path as ordinary CBv2 decode; no dedicated physical MTP artifact in this branch | Explicit opt-in only after tuple certification |
+| M4 | Serial target | M4 Max real QAT matrix: 40/40 parity, all 36 speculative cases active, zero mismatch rows | Available only by explicit config; prior bounded rectangular matrices passed |
+| M5 | Serial target | M5 Max real QAT matrix: 40/40 parity, all 36 speculative cases active, zero mismatch rows | Uncertified; prior rectangular QAT B8/L6 drift remains reproducible evidence |
+| Unknown/future | Serial target | Structural authority comes from the ordinary eager decode path | Explicit opt-in only after tuple certification |
 
-This table deliberately distinguishes "the code does not veto it" from
-"certified". MTP remains default-off while the current coarse gate exists.
+The serial default makes MTP functional across Apple Silicon; it does not claim
+a speedup over target-only. The measured-goodput controller may select depth
+zero when drafter plus serial target work is unprofitable. Rectangular mode is
+the acceleration optimization and requires independent evidence.
 
-#### Investigation And Certification Plan
+#### Rectangular Optimization Plan
 
-1. Build a release diagnostic that starts from byte-identical committed KV and
-   feeds the same fixed token continuations through serial `[B,1]` target
-   calls and one `[B,L]` call. Compare raw logits, argmax, pre-norm hidden,
-   each storage-owning layer's committed K/V, and attention output before any
-   sampler or accept logic.
+1. Start from byte-identical committed KV and compare serial `[B,1]` target
+   calls with one `[B,L]` call. Compare logits, argmax, pre-norm hidden,
+   storage-owning K/V, and attention output before acceptance logic.
 2. Run B=1/2/4/8 and L=1...8 for production QAT-4bit, available 8bit, and BF16
-   targets at short context, immediately before/after SWA wrap, and long
-   context. Add L=9 diagnostic cases because the known MLX SDPA dispatch
-   boundary sits at 8/9; keep L=9 outside the production capability range.
-3. Bisect the first divergent layer and operation. Compare embedding, Q/K/V
-   projection, RoPE, SDPA/composed attention, quantized dense matmul, MoE gate
-   and expert output, residual, norm, and LM head. Force available reference
-   versus optimized MLX paths one operator at a time. Record Metal kernel
-   names and tensor shapes, not just final token IDs.
-4. Repeat every case in fresh processes and with wide-margin as well as
-   near-tie logits. Report max absolute/relative drift, argmax margin, first
-   divergent tensor, selected kernel, macOS build, exact chip identifier/GPU
-   cores, compiler, mlx-swift-lm SHA, and MLX Swift SHA.
-5. When the root cause is in MLX/Metal, land or pin the upstream fix first.
-   Re-run the complete matrix on every M5 variant intended for the fleet; an
-   M5 Max result does not certify base M5, Pro, or a later stepping.
-6. Re-run the real provider QAT/QAT raw-parity matrix, repeated rejection
-   regressions, mixed continuous batching, KV rollback, and release performance
-   on the exact fixed dependency. No synthetic-only certification is valid.
+   targets around SWA boundaries and long context. Keep L=9 as a diagnostic
+   for the known MLX SDPA dispatch boundary.
+3. Bisect the first divergent operation across projections, RoPE, attention,
+   quantized matmul, MoE, residuals, norms, and LM head. Record selected Metal
+   kernels and exact tensor geometry.
+4. Force reference and optimized paths one operation at a time. If the root
+   cause is in MLX/Metal, land or pin the narrow fix before enabling the mode.
+5. Re-run real QAT matrices, repeated rejection, mixed batching, KV rollback,
+   lifecycle, and release performance on every exact chip/OS/MLX/model tuple
+   intended for rectangular use.
 
-The load-time API becomes a positive capability lookup, for example
-`CBv2MTPKernelCertification.lookup(key:)`, keyed at minimum by exact chip
-identifier, macOS build range, MLX Swift revision, target model build/hash,
-target quantization, batch ceiling, and verification-width range. The
-provider passes the resulting immutable certificate ID through
-`CBv2MTPConfig`; `EngineV2` constructs the driver only when the requested
-`B,L` range is covered. Missing, unknown, expired, or mismatched entries select
-target-only and surface a stable `kernel_uncertified` reason.
-
-Normal model load must not self-certify by running unsafe rectangular work.
-Certification is an offline/release process that produces a reviewed table;
-load only verifies the exact tuple. The process kill switch remains a final
-override.
-
-The blanket M5 veto can be narrowed only when all of these are true:
-
-- A first-divergence root cause is understood and fixed at a pinned dependency
-  or an explicitly safe engine path.
-- Every supported M5 chip variant passes the full deterministic tensor matrix
-  repeatedly in clean release processes with zero argmax divergence.
-- Real QAT, 8bit where offered, and BF16 matrices pass B=1/2/4/8 and L=1...8,
-  including sliding boundaries and mixed batches.
-- Greedy, stochastic if enabled, KV, cancellation, and provider fail-open
-  suites pass at the exact parent and engine SHAs.
-- The capability entry, reports, and dependency pin receive independent
-  review, and a default-off owned-box canary shows no drift or kernel fault.
-
-Passing those gates adds narrow positive entries. It does not delete hardware
-certification or make unknown future chips eligible.
+Normal model load does not self-certify by running rectangular work. A future
+positive capability lookup may key on exact chip identifier, macOS range, MLX
+revision, model hash, quantization, batch ceiling, and verification width.
+Missing entries continue using serial target verification, not target-only and
+not an inactive MTP driver.
 
 ### Audited Runtime Comparison
 
@@ -1176,7 +1161,7 @@ needs its own memory, synchronization, and kernel evidence.
 | Tree/top-k | No; one proposal per position and one linear verify | Gemma 4 speculator is linear, one token per step; other speculators have separate tree/block modes | Frozen-KV reuses EAGLE tree machinery and tests top-k 1 and 3; top-k > 1 is backend-restricted |
 | Sliding-window attention | Contiguous SWA staging is exact; paged SWA speculation disabled | KV manager accounts for sliding-window block removal against processed/in-flight tokens; Gemma shares the last non-shared layer of each attention type | Frozen draft resolves typed physical target layers and participates in SWA eviction/pool resolution; page/tree backend combinations are restricted |
 | Adaptive depth | Online batch-bucketed measured-goodput controller including depth zero | Optional configured batch-size-to-k schedule; it is not online measured goodput and is disabled with data parallelism | Generic adaptive runtime exists, but `FrozenKVMTPWorkerV2` asserts that adaptive mode is unsupported |
-| Tests and limits | Greedy token parity across real QAT/8bit pairings; no stochastic CBv2 or paged-SWA proof; M5 denied | Generic chi-square rejection tests, processor/constraint tests, dynamic-depth unit tests, and Gemma E4B correctness/acceptance E2E. Gemma E2E allows partial token agreement and does not directly certify Apple kernels | Frozen-KV E4B GSM8K/acceptance E2E for top-k 1/3 and SWA-pool resolver tests. No Frozen stochastic/adaptive test; mixed chunking is disabled for speculative mode |
+| Tests and limits | Greedy token parity across real QAT/8bit pairings; serial-target M4/M5 QAT matrices active and exact; no stochastic CBv2 or paged-SWA proof; rectangular mode remains tuple-certified only | Generic chi-square rejection tests, processor/constraint tests, dynamic-depth unit tests, and Gemma E4B correctness/acceptance E2E. Gemma E2E allows partial token agreement and does not directly certify Apple kernels | Frozen-KV E4B GSM8K/acceptance E2E for top-k 1/3 and SWA-pool resolver tests. No Frozen stochastic/adaptive test; mixed chunking is disabled for speculative mode |
 
 Primary audited paths:
 
@@ -1219,18 +1204,18 @@ fallback.
 | Priority | Dependencies | Deliverable | Definition of done |
 |---|---|---|---|
 | F0: capability foundations | Current greedy PRs | Positive kernel-certificate type; sampler capability marker; explicit KV transaction protocol; no feature enabled | Current greedy matrices and full suites unchanged; every new capability defaults unsupported; no provider behavior change |
-| F1: stochastic linear MTP on current safe storage | F0; pre-M5 certified rectangular tuple | Device-only `p/q` processing, rejection/residual/bonus packet, RNG lanes, target logprobs; contiguous full/quantized/window staging only | Deterministic and chi-square matrices pass; one finalize readback; all unsupported sampler/constraint rows fall back; release goodput non-regressing where enabled |
+| F1: stochastic linear MTP on current safe storage | F0; certified rectangular tuple or separately specified serial stochastic path | Device-only `p/q` processing, rejection/residual/bonus packet, RNG lanes, target logprobs; contiguous full/quantized/window staging only | Deterministic and chi-square matrices pass; target-authoritative readback; all unsupported sampler/constraint rows fall back; release goodput non-regressing where enabled |
 | F2: paged-window greedy staging | F0 | Temporary page reservation, committed/provisional tables, remap/copy commit, full-to-SWA mapping, lifecycle/accounting | Exact matrix and 10,000-operation state model pass; real Gemma boundary parity passes; zero page/accounting leaks; stochastic remains off on paged rows |
 | F3: compose stochastic and paged staging | F1 and F2 | Same stochastic transaction over paged full/SWA rows | Cross-product sampling, KV, logprob, cancellation, prefix, and capacity tests pass; no extra sync or distribution drift |
-| F4: per-chip certification and M5 recovery | F0; upstream/root-cause fix for M5 | Reviewed positive entries for exact chip/OS/MLX/model tuples | All removal criteria above pass; unknown tuples stay target-only; M5 canary remains default-off until separately approved |
+| F4: rectangular optimization certification | F0; first-divergence root cause or invariant target kernel | Reviewed positive entries for exact chip/OS/MLX/model tuples | Exact rectangular entries pass all comparison gates; missing tuples remain on serial target MTP; optimization canaries stay default-off until separately approved |
 | F5: controlled rollout | Relevant capability phases | Independent stochastic, paged-window, and chip allowlists plus kill switches and content-free telemetry | Owned-box canaries, production-duration replay, memory/energy/TTFT/goodput gates, rollback drill, and operator documentation complete |
 
 The future engine work is complete only when every enabled tuple is positively
 certified, stochastic output matches the target distribution, paged state is
 value-exact after every lifecycle exit, no new host synchronization appears,
 provider accounting includes all temporary work, and disabling any new
-capability returns immediately to the already-validated greedy or target-only
-path.
+capability returns immediately to the already-validated serial-target greedy
+MTP or target-only path.
 
 ### Explicit Non-Goals
 
@@ -1240,8 +1225,8 @@ top-k branching, relaxed/block acceptance, online assistant training, beam
 search, or per-row variable verification depth. SGLang's tree implementation
 is comparison evidence only. They also do not move speculation into the
 coordinator, change assistant artifact trust/ownership, promise bitwise
-stochastic equality between MTP-on and MTP-off, or default-enable MTP on an
-uncertified chip. Those are separate designs and reviews.
+stochastic equality between MTP-on and MTP-off, or default-enable rectangular
+verification on an uncertified tuple. Those are separate designs and reviews.
 
 ## Rollout Gates
 

--- a/docs/architecture/gemma4-cbv2-mtp.md
+++ b/docs/architecture/gemma4-cbv2-mtp.md
@@ -24,10 +24,18 @@ The production branch now includes:
 - Native CBv2 seed/draft/verify rounds with target-authoritative acceptance.
 - An exact automatic verifier that accelerates certified rectangular work on
   M1 through M5 and clamps to ordinary target-only decode before drafting when
-  no positive safe depth fits. Serial target verification remains explicit.
+  no positive safe depth fits
+  (`libs/mlx-swift-lm/Libraries/MLXLMCommon/ContinuousBatchingV2/MTP/CBv2MTPRoundDriver.swift`
+  `maximumAutomaticDepth`/`verificationLimitedDecision`;
+  `EngineLoopV2+MTPPlanning.swift` `mtpWantsStep`). Serial target verification
+  remains explicit
+  (`EngineLoopV2+MTPTargetVerification.swift` `mtpVerifyTargets`).
 - Decode-shaped rectangular attention: projections and feed-forward work stay
   batched, while every provisional query uses canonical `L=1` attention over
-  its exact visible KV prefix.
+  its exact visible KV prefix
+  (`libs/mlx-swift-lm/Libraries/MLXLMCommon/ContinuousBatchingV2/AttentionV1.swift`
+  `attendSerialQueries`; scoped per verify by
+  `CBv2LayerCache.mtpSerializesRectangularAttention` in `LayerCacheV2.swift`).
 - Step-global eligibility and commit cadence for quantized MoE parity.
 - Exact full, quantized, and staged-window KV rollback.
 - Strict absolute-position assistant sliding masks.
@@ -125,10 +133,14 @@ unchanged, but an exact post-fix performance rerun was interrupted and is not
 claimed as complete. The schema-v4 raw parity matrices were rerun after the
 final engine/config hardening.
 
-The production repair uses fixed `k=1`, not an untrained adaptive controller.
-Its automatic work cap is `batch * (1+k) <= 4` on M1/M2/unknown hardware and
-`<= 8` on M3/M4/M5. The operator override may only tighten that certified
-maximum. M5 exactness was measured across the full safe envelope: B1/L2...L8,
+The production repair uses fixed `k=1`, not an untrained adaptive controller
+(`provider-swift/Sources/ProviderCore/Inference/EngineV2SlotFactory.swift`
+`makeProductionBundle` MTP config). Its automatic work cap is
+`batch * (1+k) <= 4` on M1/M2/unknown hardware and `<= 8` on M3/M4/M5. The
+operator override (`DARKBLOOM_MTP_MAX_RECTANGULAR_TOKENS`, preserved across
+service installs by `Service/LaunchAgent.swift` `passthroughEnvKeys`) may only
+tighten that certified maximum
+(`provider-swift/Sources/ProviderCore/Inference/MTPAutomaticVerificationPolicy.swift`). M5 exactness was measured across the full safe envelope: B1/L2...L8,
 B2/L2...L4, B4/L2, final logits, every decoder layer, storage-owning K/V, and
 partial rollback. M4 was checked at B1/L3, B2/L2, and B4/L2. M1 through M3
 were not physically available; their conservative limits follow the pinned

--- a/docs/architecture/gemma4-cbv2-mtp.md
+++ b/docs/architecture/gemma4-cbv2-mtp.md
@@ -1,0 +1,563 @@
+# Gemma 4 Frozen-KV MTP on Continuous Batching V2
+
+**Status:** implemented and locally validated on parent `c77d38523` with
+`libs/mlx-swift-lm` based at `9ec146e49`. Not pushed, released, registered, or
+deployed.
+
+This document is the implementation contract for production Gemma 4
+multi-token prediction (MTP) in Darkbloom. It records the code-grounded local
+findings, current upstream evidence, correctness invariants, ownership
+boundaries, stable interfaces, validation gates, and rollout sequence.
+
+Historical d-inference PR #306 is deliberately excluded. It targeted the
+deleted legacy batching engine. The only current implementation target is
+Continuous Batching V2 (CBv2).
+
+## Implementation Result
+
+The production branch now includes:
+
+- Native CBv2 seed/draft/verify rounds with target-authoritative acceptance.
+- Step-global eligibility and commit cadence for quantized MoE parity.
+- Exact full, quantized, and staged-window KV rollback.
+- Strict absolute-position assistant sliding masks.
+- A depth-zero, batch-bucketed goodput controller with isolated target-only
+  probes, conditional acceptance, bounded exploration, hysteresis, and exact
+  seed-cost attribution.
+- Safe hybrid prefix-cache policy: full replay whenever a storage-owning full
+  layer follows sliding attention.
+- Provider local/catalog resolution, mandatory immutable catalog anchors,
+  bounded nonblocking prefetch, assistant-owned quantization, exact target
+  binding, fail-open target-only fallback, memory accounting, slot lifetime,
+  rebuild posture preservation, metrics, and kill switch.
+- A production-backed cache-only validation and benchmark harness with process
+  supervision, raw-token parity, release performance mode, bounded inventory,
+  secure output handling, and explicit coverage labels.
+
+Review-driven correctness defects found and fixed during implementation:
+
+- Rejected draft emitted instead of the target correction (deliberate mutation
+  proved the parity gate has teeth).
+- Mixed terminal depths changed quantized MoE target batch cadence.
+- Mixed eligible/ineligible rows split one target decode batch into different
+  shapes.
+- Hybrid prefix-cache partial replay permanently cached polluted activations.
+- The oldest retained sliding key at `anchor-window` was incorrectly visible
+  to the assistant.
+- Depth-zero timing included chained neighbor work while MTP timing did not.
+- Seed cost and exploration backoff could attach to work at another depth.
+- Assistant-only memory pressure could unload an otherwise valid target.
+- Rebuild could activate or reload unreserved assistant memory.
+- Warm/local artifact mutation, coalesced cancellation, and shutdown races.
+- Validation could accept inactive/error runs or report non-production timing.
+
+### Final Local Verification
+
+| Gate | Result |
+|---|---|
+| Engine focused MTP suites | 75/75 passed after modular split |
+| Broader engine scheduler/KV/cache suites | 77/77 passed |
+| Controller review-fix suites | 63/63 passed |
+| Provider focused final suites | 72/72 passed; prior combined provider pass 173/173 |
+| Full provider suite | Near-final run executed 1,393 tests; all MTP behavior tests passed. Under full-suite contention, the documented `reWedgeOutsideCooldownRecoversAgain` timing case and the catalog-prewarm wall-clock assertion failed; both 11-test suites passed in isolation. The final rotary-preflight and benchmark-sizing deltas then passed their focused tests |
+| QAT target + QAT-4bit assistant raw matrix | 40/40 parity, B=1/2/4/8, fixed L=1...8 plus adaptive |
+| QAT target + BF16 assistant raw matrix | 40/40 parity, same matrix |
+| 8bit target + BF16 assistant raw matrix | 40/40 parity, same matrix |
+| Real provider paths | load/bind, fail-open assistant failure, tool-templated VLM, and image-prefill paths passed |
+| Products | `ProviderCore`, `ProviderBenchmark` debug/release, and `darkbloom` build passed |
+| Diff checks | parent and nested diffs clean |
+
+Schema-v4 raw-parity reports contain neither timing fields nor token IDs. The
+exact-final QAT/QAT report is under `tmp/mtp-20260714T030020Z-...run/`, the
+QAT/BF16 report under `tmp/mtp-20260714T030152Z-...run/`, and the 8bit/BF16
+report under `tmp/mtp-20260714T030313Z-...run/`.
+
+### Production-Target Drafter Comparison
+
+Release sweeps used the production QAT-4bit target, production EOS handling,
+32 output tokens, one warmup, three repetitions, real prompt categories, and
+median aggregate decode TPS. Values are within-run comparisons; target-only
+baselines varied across processes, so absolute TPS must not be compared across
+the two assistant runs.
+
+| Assistant | B=1 best | B=2 best | B=4 best | B=8 best |
+|---|---:|---:|---:|---:|
+| QAT-4bit, 236 MB | L3: +23% | L6: +6% | L6: +17% | k=0; best MTP -2% |
+| BF16, 839 MB | L4: +10% | k=0; best positive-depth MTP -11% | L2: +18% | L2: +6% |
+
+The QAT-4bit assistant is the production recommendation: it is 3.6 times
+smaller and produces profitable regions at B=1, B=2, and B=4. The BF16
+assistant improves B=1, B=4, and B=8 in this short sweep but is less
+consistent, regresses B=2, and is more expensive. Both need depth zero at
+unprofitable shapes.
+
+The short adaptive cases begin with an untrained controller and mostly select
+depth zero. They validate safe exploration and fallback, not convergence.
+Production-duration traffic replay remains required before setting controller
+seeds or enabling MTP by default.
+
+The sanitized schema-v4 release reports are stored in the gitignored run
+directories beginning `tmp/mtp-20260714T030432Z-` (QAT-4bit assistant) and
+`tmp/mtp-20260714T031303Z-` (BF16 assistant).
+
+Those short-context release sweeps predate the final benchmark-only correction
+that charges assistant residency as model weight rather than an OS reserve.
+The cases were far below the KV ceiling, so the measured decode path is
+unchanged, but an exact post-fix performance rerun was interrupted and is not
+claimed as complete. The schema-v4 raw parity matrices were rerun after the
+final engine/config hardening.
+
+Residual engineering risks are explicit: Swift cannot cancel synchronous MLX
+construction inside the process, so live validation relies on the process-group
+supervisor; same-user mutation after catalog verification remains a general
+path/fd TOCTOU concern; official cross-runtime tensor fixtures, real
+long-prefix validation, video, structured output, and production-duration
+controller convergence remain unimplemented. These do not weaken the completed
+target-authority matrices, but they block a default-on production rollout.
+
+## Scope
+
+Build the official Gemma 4 assistant path:
+
+- A separate four-layer autoregressive Q-only assistant.
+- Target input-embedding reuse.
+- Target hidden-state conditioning.
+- Frozen K/V from the last storage-owning full-attention and
+  sliding-attention target layers.
+- Constant assistant position within a draft round.
+- Linear draft proposals followed by one rectangular target verification.
+- Target-authoritative greedy acceptance.
+- Exact per-row KV commit or rollback.
+- Continuous batching with ordinary decode and chunked-prefill neighbors.
+- Provider-side artifact resolution, loading, memory accounting, lifecycle,
+  observability, fail-open fallback, and real-model validation.
+- A measured, batch-aware speculation-depth controller with depth zero.
+
+Explicitly out of scope for this release:
+
+- EAGLE, EAGLE-2, or EAGLE-3.
+- Medusa, Hydra, ReDrafter, or newly trained draft heads.
+- Top-k or beam/tree verification.
+- Relaxed acceptance.
+- Stochastic speculative sampling.
+- Paged-window speculative staging.
+- Online drafter training.
+
+## Why This Architecture
+
+Gemma 4 calls the feature MTP, but the published assistant is not the
+independent multi-head architecture described by Gloeckle et al. at ICML
+2024. It is a sequential autoregressive drafter conditioned on target state.
+Google documents the same four properties that the local model code exposes:
+target embeddings, previous target hidden state, frozen target KV, and
+constant positions.
+
+Current production implementations independently converge on a dedicated
+Gemma path:
+
+| Runtime | Audited revision | Relevant design |
+|---|---|---|
+| vLLM | `8b8af2caf739a7537b9ca848b836733c6533bf20` | Dedicated `Gemma4Speculator`, paged provisional KV, batch-size depth schedule, generic acceptance and metrics |
+| SGLang | `cfc3d0555e6d56a382ed6eb40e993cd2c10c9ef8` | Dedicated `FROZEN_KV_MTP`, direct typed-layer KV binding, temporary verification pages |
+| Ollama MLX | `4f7786d0baa9085e568c5d48135b5347daaddd8f` | One target forward, one host sync, transactional cache handling, measured depth-zero controller |
+
+Primary external sources:
+
+- [Gemma 4 MTP overview](https://ai.google.dev/gemma/docs/mtp/overview)
+- [Gemma 4 MTP usage](https://ai.google.dev/gemma/docs/mtp/mtp)
+- [Gemma 4 technical report](https://arxiv.org/abs/2607.02770)
+- [vLLM Gemma 4 MTP PR #41745](https://github.com/vllm-project/vllm/pull/41745)
+- [SGLang Frozen-KV MTP PR #24436](https://github.com/sgl-project/sglang/pull/24436)
+- [Ollama adaptive MLX speculation PR #16791](https://github.com/ollama/ollama/pull/16791)
+- [TurboSpec/SmartSpec](https://arxiv.org/abs/2406.14066)
+- [Speculative Decoding: Performance or Illusion?](https://arxiv.org/abs/2601.11580)
+
+The local engine work already follows the correct model shape. The task is to
+finish, harden, measure, and ship it rather than replace it.
+
+## Current Local Inventory
+
+The clean source implementation is split across five local commits in the
+read-only source worktree `.worktrees/mtp-build`:
+
+| Commit | Responsibility |
+|---|---|
+| engine `13a726e` | Scheduler `1+k` planning, speculative KV contracts, window staging, rectangular attention, Gemma model and drafter seams |
+| engine `e11a108` | Seed/draft/verify step, finalize-time accept walk, lifecycle integration, metrics |
+| parent `c228c257` | `spec_dec` R2 artifact resolver and store |
+| parent `37f785b0` | Provider config, beta switch, assistant advertisement exclusion |
+| parent `5040e86b` | Drafter memory-accounting and slot-lifetime scaffolding |
+
+Those commits were based on older parent and engine revisions. They are
+source material, not merge-ready output. The production branches must port
+their behavior onto the exact bases named at the top of this document.
+
+The source worktree also contains an intentional uncommitted parity mutation
+that emits a rejected draft token. It must never be copied. Correct behavior
+always emits the target correction at the first divergence.
+
+## End-to-End Architecture
+
+```mermaid
+flowchart LR
+  Catalog[Target catalog metadata] --> Resolver[SpecDecResolver]
+  Resolver --> Store[Verified assistant store]
+  Store --> Loader[Assistant loader]
+  Target[Loaded Gemma target] --> Binder[Gemma4CBv2MTPDrafter]
+  Loader --> Binder
+  Binder --> Factory[EngineV2 factory]
+  Factory --> Engine[CBv2 EngineV2]
+  Engine --> Controller[Depth controller k >= 0]
+  Controller --> Scheduler[SchedulerV2 plan]
+  Scheduler --> Seed[Seed hidden and bonus]
+  Seed --> Draft[Sequential frozen-KV drafts]
+  Draft --> Verify[One rectangular target verify]
+  Verify --> Accept[Target-authoritative accept walk]
+  Accept --> Commit[KV commit or rollback]
+  Commit --> Stream[Consumer token stream]
+```
+
+The coordinator performs no speculation. Existing free-form catalog metadata
+provides an immutable pointer to an assistant artifact. Old providers ignore
+that metadata and continue target-only serving.
+
+## Stable Interfaces
+
+Parallel work converges through these interfaces. Owners may extend them only
+after notifying the other workstreams.
+
+### Engine Construction
+
+`EngineV2` accepts:
+
+- `mtpDrafter: (any CBv2MTPDrafter)?`
+- `mtpConfig: CBv2MTPConfig`
+
+Nil drafter or disabled config is behaviorally identical to target-only
+CBv2. Provider code must not reach into engine-loop state.
+
+### Provider Engine Bundle
+
+Production construction returns a bundle containing:
+
+- The `EngineV2Bridge`.
+- An opaque slot-owned assistant handle.
+- Assistant resident-byte estimate used for admission and sizing.
+- Activation status and a stable fallback reason.
+
+The slot owns the assistant for exactly the same lifetime as the target. The
+assistant must be released before the post-unload MLX cache purge and before
+survivor KV grants regrow.
+
+### Speculation Metrics
+
+The engine exposes a lock-safe snapshot with at least:
+
+- Seed row count.
+- Proposed tokens.
+- Accepted draft tokens.
+- Committed emitted tokens.
+- Acceptance count by draft position.
+- Skip and fallback counts by stable reason.
+- Selected depth.
+- Planned decode rows.
+- Round wall time or committed-token goodput inputs.
+
+Provider observability consumes snapshots. It does not mutate controller or
+engine state.
+
+### Artifact Resolution
+
+Resolution returns either a verified local assistant directory plus manifest
+facts, or nil. It never throws into target model loading. Required metadata:
+
+- Immutable R2 prefix.
+- Manifest SHA-256.
+- Expected total bytes.
+- Maximum file count and allowed file types.
+- Assistant configuration or family digest.
+
+Failure is observable and falls back to target-only decode.
+
+## Correctness Invariants
+
+These invariants are release blockers.
+
+### Target Authority
+
+For greedy requests, every emitted token is a target argmax after all
+supported target-side processing. A drafter token is emitted only when it
+equals that target result. The first disagreement emits the target correction.
+Full acceptance emits the target bonus token.
+
+The assistant may affect performance and availability, but never accepted
+content.
+
+### One Finalize Boundary
+
+Draft IDs, target argmaxes, and target hidden state remain device-resident
+until the existing CBv2 finalize boundary. A round introduces no second host
+synchronization.
+
+### Frozen Assistant State
+
+The assistant writes no KV. Each draft step in one round uses:
+
+- The same frozen target KV views.
+- The same absolute query position.
+- The preceding draft token.
+- The recurrent hidden returned by the preceding assistant step.
+
+Target and assistant tensor semantics must match official Google/Hugging Face
+fixtures. In particular, pre-final-norm versus post-final-norm hidden state is
+not decided by comments or inherited code; tensor parity decides it.
+
+### Speculative KV Transaction
+
+Target verification may compute `1+k` provisional positions. After acceptance:
+
+- Full and quantized contiguous KV roll back the rejected suffix exactly.
+- Windowed rings stage writes so rejected tokens never destroy live history.
+- Shared-KV views for the next round contain confirmed tokens only.
+- Scheduler computed-token and pending-sample counts match confirmed KV.
+- Admission refunds exactly the rejected token reservation.
+- Paged-window rows remain target-only until a transactional implementation
+  is proven.
+
+Transient staged KV memory must be charged or bounded separately from the
+steady retained-token estimate.
+
+### Continuous Batching
+
+One plan may contain MTP rows, seed rows, ordinary decode rows, logprob or
+sampling rows, and chunked-prefill neighbors. MTP work must not:
+
+- Preempt a request merely to reserve speculative slack.
+- Block waiting admission through leaked pending samples.
+- Change ordinary-row output or logprobs.
+- Enter compiled decode with `L > 1`.
+- Become a chained-step base.
+
+The first release uses one uniform depth for all speculating rows in a
+rectangular verification batch.
+
+### Lifecycle
+
+Carry, plan marks, provisional KV, and assistant ownership are cleared on:
+
+- Normal completion.
+- Stop token or stop string.
+- Length completion.
+- Cancellation or deadline.
+- Preemption and capacity requeue.
+- Request-ID reuse.
+- Engine rebuild, slot unload, drain, and shutdown.
+
+### Fail-Open Availability
+
+Missing metadata, download failure, corrupt assistant, incompatible geometry,
+assistant load failure, unsupported KV backend, unprofitable depth, or disabled
+kill switch all select ordinary target decode. A drafter failure must not turn
+a loadable target into a provider 503.
+
+## Memory Accounting
+
+Assistant memory exists outside the target snapshot. Its bytes must be added
+before every decision that assumes resident model size:
+
+- Cold-load admission.
+- Pending-load reservation.
+- `SlotSizingSnapshot.weightsBytes`.
+- Fleet KV-budget derivation.
+- Co-resident KV re-slicing.
+- Heartbeat capacity clamps.
+- Standalone-server mirrored budgets.
+- Post-engine-build headroom guard.
+
+Use manifest bytes and a measured/conservative resident multiplier before
+load. Report measured resident deltas during validation. Loading order is:
+
+1. Resolve and size assistant metadata.
+2. Admit target plus assistant plus required headroom.
+3. Load target.
+4. Extract the exact serving text target.
+5. Load and bind assistant.
+6. Construct engine and bridge.
+7. Run the measured post-build headroom guard.
+8. Install the slot atomically.
+
+Every failure unwinds assistant, bridge, target, pending reservation, and
+re-slice state in reverse order.
+
+## Depth Control
+
+Static `k=2` is a bring-up value, not a fleet policy. Google warns that the
+26B-A4B MoE can lose at batch one on Apple Silicon because broader target
+verification activates more experts. External Apple measurements show that
+the profitable region may begin at batch two and peak at batch four to eight.
+
+Before default-on, the controller must choose a step-global depth from
+`0...K` by expected committed tokens divided by measured round cost.
+
+Controller state is keyed by:
+
+- Model build and assistant revision.
+- Chip class.
+- Target and assistant quantization.
+- Planned decode-row bucket.
+- Verification-width or relevant context regime.
+
+Required behavior:
+
+- Depth zero is always available.
+- Track conditional acceptance per draft position.
+- Track outlier-clamped wall-cost EWMAs per tested depth.
+- Explore one deeper depth at a bounded, backing-off cadence.
+- Use hysteresis before changing the active depth.
+- Persist safe warm estimates across requests.
+- Clamp selection to numerically and operationally validated MLX shapes.
+
+The first correctness milestone may use fixed `k=2`. The first production
+default-on milestone may not.
+
+## MLX Measurement Requirements
+
+The pinned MLX already contains small-batch QMV, small-sequence SDPA, and
+split-K quantized matmul improvements. Kernel absence must not be assumed.
+
+Known evidence requires explicit shape testing:
+
+- [MLX issue #3553](https://github.com/ml-explore/mlx/issues/3553) reports a
+  quantized-matmul cost ramp around verification `M=3...9`.
+- [MLX issue #3573](https://github.com/ml-explore/mlx/issues/3573) reports a
+  causal SDPA numerical change across the query-length 8/9 dispatch boundary.
+
+Benchmark and parity-test target verification widths `L=1...8` on every
+supported chip and quantization. Record target verify time, assistant time,
+total round time, committed tokens, acceptance by position, and logit-margin
+drift versus serial target decode.
+
+## Workstream Ownership
+
+Parallel implementation uses disjoint file ownership.
+
+### Engine Workstream
+
+Owns only `libs/mlx-swift-lm` MTP engine/model/tests/docs. Responsibilities:
+
+- Port clean engine commits onto `9ec146e49`.
+- Reconcile current paged/cache lifecycle.
+- Land parity and mixed-plan suites.
+- Add a modular step-global depth controller and engine metrics.
+- Preserve target-only behavior when inactive.
+
+### Provider Workstream
+
+Owns ProviderCore production source and ProviderCore unit tests, excluding
+benchmark products. Responsibilities:
+
+- Port resolver/config/capacity work onto `c77d38523`.
+- Harden artifact verification.
+- Load, bind, pass, retain, account, and unload the assistant.
+- Unify production, local, and rebuild construction through one funnel.
+- Add observable stable fallback reasons.
+
+### Validation Workstream
+
+Owns benchmark products, validation scripts, live/integration test files, and
+cache discovery. It does not edit engine or provider production source.
+Responsibilities:
+
+- Locate and validate cached target and assistant artifacts.
+- Build reproducible official-reference fixture and live parity runners.
+- Wire production-factory performance sweeps.
+- Produce B=1/2/4/8 and L=1...8 reports.
+
+The root integrator owns this document, cross-layer interface reconciliation,
+full-suite verification, independent review, and final refactor.
+
+## Verification Matrix
+
+### Deterministic Unit And Engine Tests
+
+- No drafter/config off is behaviorally identical to current main.
+- Perfect drafter accepts all positions and counters are exact.
+- Adversarial drafter accepts none and cannot alter output.
+- B=1, B=2, and B=4 ragged batches match target-only tokens.
+- Mixed MTP, ordinary decode, top-logprobs, and chunked prefill remain exact.
+- Window wrap, full rollback, quantized rollback, and unsupported paged-window
+  fallback are exact.
+- Tight speculative reservation falls back without preemption.
+- Stop token, stop string, EOS, length, cancellation, deadline, preemption,
+  ID reuse, resize, drain, and shutdown leave no pending state.
+- Compiled ordinary decode remains usable beside eager MTP rounds.
+- Prefix-cache adoption and donation observe confirmed state only.
+
+### Provider Tests
+
+- Config absent, present, invalid, beta toggle, and serialization.
+- Local assistant path precedence.
+- Catalog metadata resolution and shared-prefix reuse.
+- Manifest digest, size, file-count, path, and hash rejection.
+- Download failure and assistant incompatibility fall back to target-only.
+- Assistant bytes affect every load and KV-budget consumer exactly once.
+- Slot unload and rebuild release the assistant before cache purge/regrow.
+- Non-Gemma targets never load an assistant.
+
+### Real Cached-Model Tests
+
+Use the exact cached Gemma 4 26B-A4B target and matching assistant after
+recording their paths, revisions, configs, byte sizes, and hashes.
+
+- Official tensor fixture parity for hidden state, typed K/V, first assistant
+  logits, recurrent hidden, and draft IDs.
+- Target-only versus MTP greedy token identity on real prompts.
+- QAT-4bit and available 8bit target pairings.
+- BF16 and available quantized assistant pairings.
+- Text, tools, structured output, reasoning, and image/video-prefill cases.
+- Short, sliding-window-crossing, and long-prefix-cache contexts.
+- B=1/2/4/8 and verified widths L=1...8.
+
+### Full Gates
+
+- Full `mlx-swift-lm` test suite.
+- Full provider Swift test suite.
+- `darkbloom` product build.
+- Targeted production-factory HTTP test.
+- Independent correctness, lifecycle, memory, and security review.
+
+## Rollout Gates
+
+No push, registry write, release, or production mutation is part of the build
+phase.
+
+When implementation is review-ready:
+
+1. Open the engine PR with before/after behavior and code diagrams.
+2. Pin its exact commit in the parent provider PR.
+3. Ship provider support default-off.
+4. Publish one immutable verified assistant artifact.
+5. Attach `spec_dec` metadata to existing target builds.
+6. Run owned-box HTTP and routed canaries.
+7. Verify activation, fallback, acceptance, depth, committed goodput, memory,
+   energy, TTFT, and lifecycle telemetry.
+8. Pass the emergency kill switch through launchd.
+9. Default-on only where the controller selects profitable nonzero depth and
+   workload-weighted goodput shows no regression.
+10. Refresh routing solo-TPS seeds only from stable post-rollout measurements.
+
+## Definition Of Done
+
+The feature is done only when:
+
+- The parent checkout reproducibly pins the reviewed engine implementation.
+- Provider MTP configuration creates a bound, accounted, slot-owned assistant
+  through the real production funnel.
+- Every failure mode demonstrably falls back to target-only serving.
+- Greedy output is target-authoritative across the full deterministic and
+  real-model matrix.
+- Continuous batching, cache lifecycle, and memory accounting invariants hold.
+- Measured Apple Silicon results determine depth; no static assumption is
+  promoted to policy.
+- Full suites and independent review pass.
+- No EAGLE/tree code was added.

--- a/docs/architecture/gemma4-cbv2-mtp.md
+++ b/docs/architecture/gemma4-cbv2-mtp.md
@@ -80,6 +80,8 @@ Review-driven correctness defects found and fixed during implementation:
 | M5 Max exact rollback | B4/L2 with one accepted and one rejected position: final logits byte-equal, `kvMismatches=0` after rollback |
 | M5 Max production k=1 TPS | B1 `139.73` vs `119.67` target-only (`+16.76%`); B2 `187.43` vs `173.97` (`+7.73%`); B4 `222.02` vs `180.77` (`+22.82%`); B8 safely performed zero draft/verification rounds and measured `306.65` vs `306.77` (`-0.04%`) |
 | M4 Max production k=1 TPS | B1 `+11.4%`; B2 `+0.3%`; B4 `+8.3%`; all measured MTP rounds used rectangular verification and zero serial rounds |
+| M4 Max automatic raw-parity matrix | 40/40 byte token parity, zero mismatch rows, 380 rounds, 537 proposed / 442 accepted (repeated partial rejections), zero serial rounds, 144 rectangular rounds, every positive cost input within the cap; report SHA-256 `27e2072c6a70cc50d1a2867f7d67a4091080dc9495fc259ff93c16adf8e1b167` |
+| M5 Max automatic raw-parity matrix | 40/40 byte token parity, zero mismatch rows, 348 rounds, 479 proposed / 438 accepted, zero serial rounds, 133 rectangular rounds, every positive cost input within the cap; report SHA-256 `0605bb9650ebbe4968fc0d909cac4b9394a7e8e2b87b6b92187234b4a0037a40` |
 | Products | `ProviderCore`, `ProviderBenchmark` debug/release, and `darkbloom` build passed |
 | Diff checks | parent and nested diffs clean |
 

--- a/docs/architecture/gemma4-cbv2-mtp.md
+++ b/docs/architecture/gemma4-cbv2-mtp.md
@@ -3,7 +3,9 @@
 **Status:** implemented and under review in d-inference PR
 [#547](https://github.com/Layr-Labs/d-inference/pull/547), which pins the engine
 implementation in mlx-swift-lm PR
-[#74](https://github.com/Layr-Labs/mlx-swift-lm/pull/74). Default-off; not
+[#74](https://github.com/Layr-Labs/mlx-swift-lm/pull/74), plus the exact
+automatic-verifier repair in mlx-swift-lm PR
+[#75](https://github.com/Layr-Labs/mlx-swift-lm/pull/75). Default-off; not
 released, registered, or deployed.
 
 This document is the implementation contract for production Gemma 4
@@ -20,9 +22,12 @@ Continuous Batching V2 (CBv2).
 The production branch now includes:
 
 - Native CBv2 seed/draft/verify rounds with target-authoritative acceptance.
-- A chip-independent serial target verifier that keeps MTP active from M1
-  through M5; rectangular verification is explicit opt-in rather than a
-  hardware denylist.
+- An exact automatic verifier that accelerates certified rectangular work on
+  M1 through M5 and clamps to ordinary target-only decode before drafting when
+  no positive safe depth fits. Serial target verification remains explicit.
+- Decode-shaped rectangular attention: projections and feed-forward work stay
+  batched, while every provisional query uses canonical `L=1` attention over
+  its exact visible KV prefix.
 - Step-global eligibility and commit cadence for quantized MoE parity.
 - Exact full, quantized, and staged-window KV rollback.
 - Strict absolute-position assistant sliding masks.
@@ -71,6 +76,10 @@ Review-driven correctness defects found and fixed during implementation:
 | Real provider paths | load/bind, fail-open assistant failure, tool-templated VLM, and image-prefill paths passed |
 | M4 Max serial-target QAT/QAT matrix | 40/40 parity, 36/36 requested speculative cases active, 714 rounds, 2,175 proposals, 1,179 accepted, zero mismatch rows; report records `serial_target`; SHA-256 `b90e7f6671f409d11e621ede4040e8e18060a17dfe7bbbcd555efe1e968bdd15` |
 | M5 Max serial-target QAT/QAT matrix | 40/40 parity, 36/36 requested speculative cases active, 630 rounds, 1,827 proposals, 1,189 accepted, zero mismatch rows; report records `serial_target`; SHA-256 `53d2bd99e6a21c7745d73a4ab617b2855d57c2199ec2a90357bf1c7faf2aa2a5` |
+| M5 Max first-divergence diagnostic | Rectangular B8/L6 first diverged in layer-0 quantized Q/K projection because target-only and rectangular shapes selected different quantized matmul reductions; B1/L2 also exposed shape-dependent SDPA. Decode-shaped attention plus a bounded projection work envelope produced exact layer states, final logits, and storage-owning K/V |
+| M5 Max exact rollback | B4/L2 with one accepted and one rejected position: final logits byte-equal, `kvMismatches=0` after rollback |
+| M5 Max production k=1 TPS | B1 `139.73` vs `119.67` target-only (`+16.76%`); B2 `187.43` vs `173.97` (`+7.73%`); B4 `222.02` vs `180.77` (`+22.82%`); B8 safely performed zero draft/verification rounds and measured `306.65` vs `306.77` (`-0.04%`) |
+| M4 Max production k=1 TPS | B1 `+11.4%`; B2 `+0.3%`; B4 `+8.3%`; all measured MTP rounds used rectangular verification and zero serial rounds |
 | Products | `ProviderCore`, `ProviderBenchmark` debug/release, and `darkbloom` build passed |
 | Diff checks | parent and nested diffs clean |
 
@@ -114,6 +123,16 @@ unchanged, but an exact post-fix performance rerun was interrupted and is not
 claimed as complete. The schema-v4 raw parity matrices were rerun after the
 final engine/config hardening.
 
+The production repair uses fixed `k=1`, not an untrained adaptive controller.
+Its automatic work cap is `batch * (1+k) <= 4` on M1/M2/unknown hardware and
+`<= 8` on M3/M4/M5. The operator override may only tighten that certified
+maximum. M5 exactness was measured across the full safe envelope: B1/L2...L8,
+B2/L2...L4, B4/L2, final logits, every decoder layer, storage-owning K/V, and
+partial rollback. M4 was checked at B1/L3, B2/L2, and B4/L2. M1 through M3
+were not physically available; their conservative limits follow the pinned
+MLX quantized-kernel dispatch bounds and must not be expanded without physical
+parity and TPS evidence.
+
 Residual engineering risks are explicit: Swift cannot cancel synchronous MLX
 construction inside the process, so live validation relies on the process-group
 supervisor; same-user mutation after catalog verification remains a general
@@ -132,9 +151,9 @@ Build the official Gemma 4 assistant path:
 - Frozen K/V from the last storage-owning full-attention and
   sliding-attention target layers.
 - Constant assistant position within a draft round.
-- Linear draft proposals followed by chip-independent serial target
-  verification by default; rectangular target verification remains an
-  explicit optimization.
+- Linear draft proposals followed by automatic exact rectangular verification
+  within a chip-certified work envelope, with pre-draft target-only fallback
+  and explicit serial target verification retained as a diagnostic oracle.
 - Target-authoritative greedy acceptance.
 - Exact per-row KV commit or rollback.
 - Continuous batching with ordinary decode and chunked-prefill neighbors.
@@ -220,7 +239,7 @@ flowchart LR
   Controller --> Scheduler[SchedulerV2 plan]
   Scheduler --> Seed[Seed hidden and bonus]
   Seed --> Draft[Sequential frozen-KV drafts]
-  Draft --> Verify[Serial target-authority verify by default]
+  Draft --> Verify[Automatic exact target-authority verify]
   Verify --> Accept[Target-authoritative accept walk]
   Accept --> Commit[KV commit or rollback]
   Commit --> Stream[Consumer token stream]
@@ -270,6 +289,7 @@ The engine exposes a lock-safe snapshot with at least:
 - Skip and fallback counts by stable reason.
 - Selected depth.
 - Planned decode rows.
+- Configured rectangular work cap and actual rectangular/serial round counts.
 - Round wall time or committed-token goodput inputs.
 
 Provider observability consumes snapshots. It does not mutate controller or
@@ -304,13 +324,14 @@ content.
 
 ### Evaluation Boundaries
 
-Rectangular verification keeps draft IDs, target argmaxes, and target hidden
-state device-resident until the existing CBv2 finalize boundary. The default
-serial target mode instead materializes every `[B,1]` target column and its KV
-inner state before constructing the next column. This adds device
-synchronization but prevents lazy mutable-cache versions from crossing the
-canonical target step boundary. Token IDs still reach the host only at the
-existing finalize acceptance readback.
+Automatic rectangular verification keeps draft IDs, target argmaxes, and
+target hidden state device-resident until the existing CBv2 finalize boundary.
+Projection and feed-forward tensors retain `[B,L]` shape only inside the
+certified work envelope. Attention evaluates each query through canonical
+`L=1` SDPA with its exact visible staged KV prefix. Explicit `serial_target`
+instead materializes every `[B,1]` target column and its KV inner state before
+constructing the next column. Token IDs reach the host only at the existing
+finalize acceptance readback.
 
 ### Frozen Assistant State
 
@@ -328,8 +349,9 @@ not decided by comments or inherited code; tensor parity decides it.
 ### Speculative KV Transaction
 
 Target verification computes `1+k` provisional positions either through
-serial `[B,1]` target calls or an explicitly selected `[B,1+k]` call. After
-acceptance:
+automatic bounded `[B,1+k]` scoring or explicit serial `[B,1]` target calls.
+The automatic planner clamps depth before seed or draft work; if no positive
+depth fits, ordinary target-only chaining continues. After acceptance:
 
 - Full and quantized contiguous KV roll back the rejected suffix exactly.
 - Windowed rings accumulate one or more staged writes so rejected tokens never
@@ -569,8 +591,9 @@ probabilities (`Libraries/MLXLMCommon/ContinuousBatchingV2/MTP/
 MTPContractsV2.swift:126-149` and `Libraries/MLXLLM/Models/
 Gemma4CBv2MTPDrafter.swift:104-122`). Target verification reduces each target
 column to argmax IDs before the finalize acceptance readback. The default
-serial mode materializes `[B,1]` target/KV state between columns; explicit
-rectangular mode uses one `[B,1+k,vocab]` result
+automatic mode uses bounded `[B,1+k,vocab]` scoring with decode-shaped
+attention; explicit serial mode materializes `[B,1]` target/KV state between
+columns
 (`Libraries/MLXLMCommon/ContinuousBatchingV2/MTP/
 EngineLoopV2+MTPTargetVerification.swift`).
 
@@ -1078,19 +1101,33 @@ target-only. Paged-window activation remains separately default-off until the
 matrix, randomized oracle, full engine suites, and release goodput measurement
 pass with zero temporary-page leaks.
 
-### Universal Serial Verification And Rectangular Certification
+### Automatic Exact Verification And Serial Fallback
 
 #### Current Default And Evidence
 
-**Current.** MTP construction no longer reads a chip name or denies a hardware
-family. `CBv2MTPConfig.verificationMode` defaults to `serial_target`, and the
-engine scores every known target column through the same eager `[B,1]` target
-forward used by ordinary decode
-(`Libraries/MLXLMCommon/ContinuousBatchingV2/MTP/MTPContractsV2.swift` and
-`EngineLoopV2+MTPTargetVerification.swift`). Each column and its KV inner state
-are materialized before the next target column is constructed. The assistant
-still drafts `k` tokens, target authority still accepts or corrects them, and
-one KV transaction commits only the confirmed prefix.
+**Current.** MTP construction no longer denies a hardware family.
+`CBv2MTPConfig.verificationMode` defaults to `automatic`, with a conservative
+work cap of four target rows when no provider policy is supplied
+(`Libraries/MLXLMCommon/ContinuousBatchingV2/MTP/MTPContractsV2.swift`). The
+provider selects a certified maximum of four on M1/M2/unknown hardware and
+eight on M3/M4/M5, and starts production at fixed `k=1`
+(`provider-swift/Sources/ProviderCore/Inference/
+MTPAutomaticVerificationPolicy.swift` and `EngineV2SlotFactory.swift`). An
+environment override can only reduce, never expand, the hardware maximum.
+
+Before seed or draft work, `CBv2MTPRoundDriver` limits `k` so
+`batch * (1+k)` stays inside that envelope. A zero limit returns to ordinary
+target-only chaining with no assistant seed, proposal, rectangular verify, or
+serial verify. Positive depths use one rectangular target pass. Projections
+and feed-forward layers remain batched; `CBv2AttentionV1` evaluates each query
+through the canonical `L=1` attention dispatch with only the KV prefix visible
+at that provisional position. The target argmax still accepts or corrects each
+proposal, and one KV transaction commits only the confirmed prefix.
+
+`serial_target` remains an explicit correctness oracle and defensive fallback.
+It scores each column through the same eager `[B,1]` target forward as ordinary
+decode, materializing the column and KV state before constructing the next.
+It is exact but structurally unable to provide the production acceleration.
 
 Windowed storage now accumulates multiple serial speculative updates before
 one rollback/commit. KV-shared decode layers borrow the staged source view only
@@ -1101,30 +1138,33 @@ full rollback, partial rollback, repeated serial updates, and post-wrap sharing
 and repeatedly partial rejection, mixed batches, stop/length tails,
 cancellation, request-ID reuse, and compiled/eager transitions.
 
-The earlier rectangular result remains important: remote M5 Max testing found
-repeatable target-argmax drift between serial `[B,1]` and `[B,1+k]`, including
-the production QAT pair at B8/L6. That evidence is recorded on engine PR
-[#74](https://github.com/Layr-Labs/mlx-swift-lm/pull/74#issuecomment-4974224001).
-It justifies keeping rectangular mode explicit; it no longer justifies denying
-MTP on M5.
+The first-divergence harness explained the earlier M5 failure. Production QAT
+B8/L6 first diverged in layer-0 Q/K quantized projections: serial and
+rectangular shapes selected different MLX reduction paths. B1/L2 additionally
+diverged in shape-dependent SDPA. The repaired path does not assume a chip is
+safe. It bounds projection geometry to the exact tested kernel regime and
+makes attention dispatch identical to canonical decode. On M5, the complete
+exact envelope is `B * L <= 8`; B8 therefore has no positive safe depth. On M4,
+the measured safe shapes include B1/L3, B2/L2, and B4/L2. The production cap is
+intentionally smaller than some individually measured shapes because one
+simple invariant is easier to audit and enforce.
 
 The current capability table is:
 
-| Chip family | Default MTP mode | Current evidence | Rectangular optimization |
+| Chip family | Automatic work cap | Current evidence | Fallback |
 |---|---|---|---|
-| M1 | Serial target | Same chip-independent `[B,1]` path as ordinary CBv2 decode; no dedicated physical MTP artifact in this branch | Explicit opt-in only after tuple certification |
-| M2 | Serial target | Same chip-independent `[B,1]` path as ordinary CBv2 decode; no dedicated physical MTP artifact in this branch | Explicit opt-in only after tuple certification |
-| M3 | Serial target | Same chip-independent `[B,1]` path as ordinary CBv2 decode; no dedicated physical MTP artifact in this branch | Explicit opt-in only after tuple certification |
-| M4 | Serial target | M4 Max real QAT matrix: 40/40 parity, all 36 speculative cases active, zero mismatch rows | Available only by explicit config; prior bounded rectangular matrices passed |
-| M5 | Serial target | M5 Max real QAT matrix: 40/40 parity, all 36 speculative cases active, zero mismatch rows | Uncertified; prior rectangular QAT B8/L6 drift remains reproducible evidence |
-| Unknown/future | Serial target | Structural authority comes from the ordinary eager decode path | Explicit opt-in only after tuple certification |
+| M1 | `B * L <= 4` | Conservative pinned-MLX kernel bound; no physical matrix in this branch | Pre-draft target-only when no positive depth fits; explicit serial remains available |
+| M2 | `B * L <= 4` | Conservative pinned-MLX kernel bound; no physical matrix in this branch | Same |
+| M3 | `B * L <= 8` | Pinned-MLX kernel bound; no physical matrix in this branch | Same |
+| M4 | `B * L <= 8` | Real QAT exact shapes and partial rollback; fixed k=1 TPS non-regressing at B1/B2/B4 | Same |
+| M5 | `B * L <= 8` | Every safe-envelope shape exact through final logits and committed K/V; fixed k=1 TPS `+16.76%/+7.73%/+22.82%` at B1/B2/B4 | B8 target-only: zero draft/verify rounds, `-0.04%` TPS |
+| Unknown/future | `B * L <= 4` | Conservative floor only | Same |
 
-The serial default makes MTP functional across Apple Silicon; it does not claim
-a speedup over target-only. The measured-goodput controller may select depth
-zero when drafter plus serial target work is unprofitable. Rectangular mode is
-the acceleration optimization and requires independent evidence.
+Physical M1/M2/M3 parity and performance matrices remain required before
+raising their bounds. The lack of those machines is not converted into an
+unsafe optimistic assumption.
 
-#### Rectangular Optimization Plan
+#### Expanding The Exact Envelope
 
 1. Start from byte-identical committed KV and compare serial `[B,1]` target
    calls with one `[B,L]` call. Compare logits, argmax, pre-norm hidden,
@@ -1135,8 +1175,9 @@ the acceleration optimization and requires independent evidence.
 3. Bisect the first divergent operation across projections, RoPE, attention,
    quantized matmul, MoE, residuals, norms, and LM head. Record selected Metal
    kernels and exact tensor geometry.
-4. Force reference and optimized paths one operation at a time. If the root
-   cause is in MLX/Metal, land or pin the narrow fix before enabling the mode.
+4. Force reference and optimized paths one operation at a time. If a larger
+   shape crosses an MLX/Metal reduction boundary, keep the lower cap or land
+   and pin a narrow exact kernel fix before expanding it.
 5. Re-run real QAT matrices, repeated rejection, mixed batching, KV rollback,
    lifecycle, and release performance on every exact chip/OS/MLX/model tuple
    intended for rectangular use.
@@ -1144,8 +1185,8 @@ the acceleration optimization and requires independent evidence.
 Normal model load does not self-certify by running rectangular work. A future
 positive capability lookup may key on exact chip identifier, macOS range, MLX
 revision, model hash, quantization, batch ceiling, and verification width.
-Missing entries continue using serial target verification, not target-only and
-not an inactive MTP driver.
+Missing or oversized entries clamp before drafting and continue target-only;
+they do not deactivate the loaded target or silently run serial speculation.
 
 ### Audited Runtime Comparison
 
@@ -1161,7 +1202,7 @@ needs its own memory, synchronization, and kernel evidence.
 | Tree/top-k | No; one proposal per position and one linear verify | Gemma 4 speculator is linear, one token per step; other speculators have separate tree/block modes | Frozen-KV reuses EAGLE tree machinery and tests top-k 1 and 3; top-k > 1 is backend-restricted |
 | Sliding-window attention | Contiguous SWA staging is exact; paged SWA speculation disabled | KV manager accounts for sliding-window block removal against processed/in-flight tokens; Gemma shares the last non-shared layer of each attention type | Frozen draft resolves typed physical target layers and participates in SWA eviction/pool resolution; page/tree backend combinations are restricted |
 | Adaptive depth | Online batch-bucketed measured-goodput controller including depth zero | Optional configured batch-size-to-k schedule; it is not online measured goodput and is disabled with data parallelism | Generic adaptive runtime exists, but `FrozenKVMTPWorkerV2` asserts that adaptive mode is unsupported |
-| Tests and limits | Greedy token parity across real QAT/8bit pairings; serial-target M4/M5 QAT matrices active and exact; no stochastic CBv2 or paged-SWA proof; rectangular mode remains tuple-certified only | Generic chi-square rejection tests, processor/constraint tests, dynamic-depth unit tests, and Gemma E4B correctness/acceptance E2E. Gemma E2E allows partial token agreement and does not directly certify Apple kernels | Frozen-KV E4B GSM8K/acceptance E2E for top-k 1/3 and SWA-pool resolver tests. No Frozen stochastic/adaptive test; mixed chunking is disabled for speculative mode |
+| Tests and limits | Greedy token parity across real QAT/8bit pairings; serial-target M4/M5 matrices; exact automatic M4/M5 shape, rollback, and TPS evidence; conservative M1-M3 kernel bounds without physical matrices; no stochastic CBv2 or paged-SWA proof | Generic chi-square rejection tests, processor/constraint tests, dynamic-depth unit tests, and Gemma E4B correctness/acceptance E2E. Gemma E2E allows partial token agreement and does not directly certify Apple kernels | Frozen-KV E4B GSM8K/acceptance E2E for top-k 1/3 and SWA-pool resolver tests. No Frozen stochastic/adaptive test; mixed chunking is disabled for speculative mode |
 
 Primary audited paths:
 
@@ -1207,15 +1248,15 @@ fallback.
 | F1: stochastic linear MTP on current safe storage | F0; certified rectangular tuple or separately specified serial stochastic path | Device-only `p/q` processing, rejection/residual/bonus packet, RNG lanes, target logprobs; contiguous full/quantized/window staging only | Deterministic and chi-square matrices pass; target-authoritative readback; all unsupported sampler/constraint rows fall back; release goodput non-regressing where enabled |
 | F2: paged-window greedy staging | F0 | Temporary page reservation, committed/provisional tables, remap/copy commit, full-to-SWA mapping, lifecycle/accounting | Exact matrix and 10,000-operation state model pass; real Gemma boundary parity passes; zero page/accounting leaks; stochastic remains off on paged rows |
 | F3: compose stochastic and paged staging | F1 and F2 | Same stochastic transaction over paged full/SWA rows | Cross-product sampling, KV, logprob, cancellation, prefix, and capacity tests pass; no extra sync or distribution drift |
-| F4: rectangular optimization certification | F0; first-divergence root cause or invariant target kernel | Reviewed positive entries for exact chip/OS/MLX/model tuples | Exact rectangular entries pass all comparison gates; missing tuples remain on serial target MTP; optimization canaries stay default-off until separately approved |
+| F4: exact-envelope expansion | F0; first-divergence root cause or invariant target kernel | Reviewed larger positive bounds for exact chip/OS/MLX/model tuples | Larger shapes pass all comparison and TPS gates; missing tuples retain their existing conservative cap; oversized work clamps to target-only before drafting |
 | F5: controlled rollout | Relevant capability phases | Independent stochastic, paged-window, and chip allowlists plus kill switches and content-free telemetry | Owned-box canaries, production-duration replay, memory/energy/TTFT/goodput gates, rollback drill, and operator documentation complete |
 
 The future engine work is complete only when every enabled tuple is positively
 certified, stochastic output matches the target distribution, paged state is
 value-exact after every lifecycle exit, no new host synchronization appears,
 provider accounting includes all temporary work, and disabling any new
-capability returns immediately to the already-validated serial-target greedy
-MTP or target-only path.
+capability returns immediately to the already-validated automatic greedy MTP,
+explicit serial oracle, or target-only path.
 
 ### Explicit Non-Goals
 
@@ -1225,8 +1266,9 @@ top-k branching, relaxed/block acceptance, online assistant training, beam
 search, or per-row variable verification depth. SGLang's tree implementation
 is comparison evidence only. They also do not move speculation into the
 coordinator, change assistant artifact trust/ownership, promise bitwise
-stochastic equality between MTP-on and MTP-off, or default-enable rectangular
-verification on an uncertified tuple. Those are separate designs and reviews.
+stochastic equality between MTP-on and MTP-off, or expand the automatic
+rectangular envelope beyond a certified bound. Those are separate designs and
+reviews.
 
 ## Rollout Gates
 

--- a/provider-swift/Sources/ProviderBenchmark/MTPBenchmarkDigest.swift
+++ b/provider-swift/Sources/ProviderBenchmark/MTPBenchmarkDigest.swift
@@ -1,0 +1,78 @@
+import CryptoKit
+import Foundation
+
+enum MTPBenchmarkDigest {
+    private static let artifactDomain = Data(
+        "darkbloom.mtp.artifact-fingerprint.v1".utf8)
+    private static let tokenDomain = Data(
+        "darkbloom.mtp.generated-token-sequence.v1".utf8)
+
+    static func sha256(_ data: Data) -> String {
+        hex(SHA256.hash(data: data))
+    }
+
+    static func sha256(file: URL) throws -> String {
+        let handle = try FileHandle(forReadingFrom: file)
+        defer { try? handle.close() }
+        var hasher = SHA256()
+        while let chunk = try handle.read(upToCount: 1024 * 1024), !chunk.isEmpty {
+            hasher.update(data: chunk)
+        }
+        return hex(hasher.finalize())
+    }
+
+    static func artifactFingerprint(
+        modelID: String,
+        revision: String?,
+        configSizeBytes: Int64,
+        configSHA256: String,
+        weightFiles: [MTPBenchmarkArtifactFacts.WeightFile]
+    ) -> String {
+        var payload = artifactDomain
+        append(modelID, to: &payload)
+        append(revision ?? "", to: &payload)
+        append(String(configSizeBytes), to: &payload)
+        append(configSHA256, to: &payload)
+        for weight in weightFiles.sorted(by: { $0.name < $1.name }) {
+            append(weight.name, to: &payload)
+            append(String(weight.sizeBytes), to: &payload)
+            append(weight.identityKind.rawValue, to: &payload)
+            append(weight.contentIdentity, to: &payload)
+        }
+        return sha256(payload)
+    }
+
+    /// The salt is intentionally never persisted. Digests compare sequences
+    /// inside one report without creating a reusable token-sequence oracle.
+    static func opaqueTokenDigest(tokenIDs: [Int], salt: Data) -> String {
+        var payload = tokenDomain
+        append(salt, to: &payload)
+        append(String(tokenIDs.count), to: &payload)
+        for tokenID in tokenIDs {
+            var encoded = Int64(tokenID).bigEndian
+            withUnsafeBytes(of: &encoded) { payload.append(contentsOf: $0) }
+        }
+        return sha256(payload)
+    }
+
+    static func randomSalt() -> Data {
+        var generator = SystemRandomNumberGenerator()
+        return Data((0..<32).map { _ in
+            UInt8.random(in: UInt8.min...UInt8.max, using: &generator)
+        })
+    }
+
+    private static func append(_ value: String, to data: inout Data) {
+        append(Data(value.utf8), to: &data)
+    }
+
+    private static func append(_ value: Data, to data: inout Data) {
+        var count = UInt64(value.count).bigEndian
+        withUnsafeBytes(of: &count) { data.append(contentsOf: $0) }
+        data.append(value)
+    }
+
+    private static func hex<D: Sequence>(_ digest: D) -> String where D.Element == UInt8 {
+        digest.map { String(format: "%02x", $0) }.joined()
+    }
+}

--- a/provider-swift/Sources/ProviderBenchmark/MTPBenchmarkMetrics+Engine.swift
+++ b/provider-swift/Sources/ProviderBenchmark/MTPBenchmarkMetrics+Engine.swift
@@ -6,6 +6,7 @@ extension MTPBenchmarkMetrics {
     public init(engineMetrics value: CBv2MTPMetrics) {
         self.init(
             active: value.active,
+            verificationMode: value.verificationMode.rawValue,
             selectedDepth: value.selectedDepth,
             decodeRowBucket: value.decodeRowBucket,
             rounds: value.rounds,

--- a/provider-swift/Sources/ProviderBenchmark/MTPBenchmarkMetrics+Engine.swift
+++ b/provider-swift/Sources/ProviderBenchmark/MTPBenchmarkMetrics+Engine.swift
@@ -33,9 +33,12 @@ extension MTPBenchmarkMetrics {
 
 public enum MTPBenchmarkEngineMetrics {
     public static func snapshot(engine: any CBv2Engine) -> MTPBenchmarkMetrics {
-        guard let engine = engine as? EngineV2,
-              let metrics = engine.mtpMetricsSnapshot()
-        else { return .inactive }
+        guard let engine = engine as? EngineV2 else { return .inactive }
+        guard let metrics = engine.mtpMetricsSnapshot() else {
+            return MTPBenchmarkMetrics(
+                active: false,
+                inactiveReason: engine.mtpInactiveReason)
+        }
         return MTPBenchmarkMetrics(engineMetrics: metrics)
     }
 }

--- a/provider-swift/Sources/ProviderBenchmark/MTPBenchmarkMetrics+Engine.swift
+++ b/provider-swift/Sources/ProviderBenchmark/MTPBenchmarkMetrics+Engine.swift
@@ -7,6 +7,9 @@ extension MTPBenchmarkMetrics {
         self.init(
             active: value.active,
             verificationMode: value.verificationMode.rawValue,
+            maxAutomaticRectangularTokens: value.maxAutomaticRectangularTokens,
+            rectangularVerificationRounds: value.rectangularVerificationRounds,
+            serialVerificationRounds: value.serialVerificationRounds,
             selectedDepth: value.selectedDepth,
             decodeRowBucket: value.decodeRowBucket,
             rounds: value.rounds,

--- a/provider-swift/Sources/ProviderBenchmark/MTPBenchmarkMetrics+Engine.swift
+++ b/provider-swift/Sources/ProviderBenchmark/MTPBenchmarkMetrics+Engine.swift
@@ -1,0 +1,41 @@
+import MLXLMCommon
+
+extension MTPBenchmarkMetrics {
+    /// Project only metrics the engine actually exposes. Assistant/target
+    /// timing stays nil rather than being estimated from aggregate wall time.
+    public init(engineMetrics value: CBv2MTPMetrics) {
+        self.init(
+            active: value.active,
+            selectedDepth: value.selectedDepth,
+            decodeRowBucket: value.decodeRowBucket,
+            rounds: value.rounds,
+            seedRows: value.seedSteps,
+            proposedTokens: value.proposedTokens,
+            acceptedDraftTokens: value.acceptedTokens,
+            committedTokens: value.emittedTokens,
+            acceptanceByPosition: value.perPositionAccepted,
+            conditionalAcceptance: value.conditionalAcceptance,
+            skippedRows: value.skippedRows,
+            depthSelections: Dictionary(
+                uniqueKeysWithValues: value.depthSelections.map { (String($0.key), $0.value) }),
+            controllerFallbacks: value.controllerFallbacks,
+            costInputs: value.costInputs.map {
+                CostInput(
+                    decodeRowBucket: $0.decodeRowBucket,
+                    draftDepth: $0.depth,
+                    sampleCount: $0.samples,
+                    ewmaRoundWallTimeNanos: $0.ewmaWallTimeNanos,
+                    totalRoundWallTimeNanos: $0.totalWallTimeNanos)
+            },
+            totalRoundWallTimeNanos: value.totalRoundWallTimeNanos)
+    }
+}
+
+public enum MTPBenchmarkEngineMetrics {
+    public static func snapshot(engine: any CBv2Engine) -> MTPBenchmarkMetrics {
+        guard let engine = engine as? EngineV2,
+              let metrics = engine.mtpMetricsSnapshot()
+        else { return .inactive }
+        return MTPBenchmarkMetrics(engineMetrics: metrics)
+    }
+}

--- a/provider-swift/Sources/ProviderBenchmark/MTPBenchmarkModelFacts.swift
+++ b/provider-swift/Sources/ProviderBenchmark/MTPBenchmarkModelFacts.swift
@@ -1,0 +1,199 @@
+import Foundation
+import ProviderCore
+
+public enum MTPBenchmarkModelFacts {
+    public static func inspect(
+        modelID: String?,
+        directory: URL
+    ) throws -> MTPBenchmarkArtifactFacts {
+        let resolved = directory.resolvingSymlinksInPath().standardizedFileURL
+        let inferredID = huggingFaceModelID(snapshot: resolved)
+        if let modelID, let inferredID, modelID != inferredID {
+            throw MTPBenchmarkError.artifactIdentity(
+                "model ID does not match the Hugging Face snapshot path")
+        }
+        guard let effectiveModelID = modelID ?? inferredID, !effectiveModelID.isEmpty else {
+            throw MTPBenchmarkError.artifactIdentity(
+                "model ID is required when it cannot be inferred from the snapshot path")
+        }
+
+        let configURL = resolved.appendingPathComponent("config.json")
+        let data = try Data(contentsOf: configURL)
+        let configSize = try regularFileSize(configURL.resolvingSymlinksInPath())
+        let configSHA256 = MTPBenchmarkDigest.sha256(data)
+        let object = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+
+        let quantization = (object?["quantization"] as? [String: Any])
+            ?? (object?["quantization_config"] as? [String: Any])
+        let quantizationFacts = quantization.map {
+            var overrides: [String: Int] = [:]
+            for value in $0.values {
+                collectNestedBitOverrides(value, into: &overrides)
+            }
+            return MTPBenchmarkArtifactFacts.Quantization(
+                bits: integer($0["bits"]),
+                groupSize: integer($0["group_size"]),
+                mode: $0["mode"] as? String,
+                perLayerOverridesByBits: overrides)
+        }
+
+        let entries = try FileManager.default.contentsOfDirectory(
+            at: resolved,
+            includingPropertiesForKeys: [.isRegularFileKey, .isSymbolicLinkKey, .fileSizeKey],
+            options: [.skipsHiddenFiles])
+        let weights = try entries
+            .filter { $0.pathExtension == "safetensors" }
+            .map { url -> MTPBenchmarkArtifactFacts.WeightFile in
+                let resolvedWeight = url.resolvingSymlinksInPath().standardizedFileURL
+                let bytes = try regularFileSize(resolvedWeight)
+                let identity = try weightIdentity(
+                    snapshotEntry: url,
+                    resolvedWeight: resolvedWeight,
+                    snapshot: resolved)
+                return .init(
+                    name: url.lastPathComponent,
+                    sizeBytes: bytes,
+                    identityKind: identity.kind,
+                    contentIdentity: identity.value)
+            }
+            .sorted { $0.name < $1.name }
+        guard !weights.isEmpty else {
+            throw MTPBenchmarkError.artifactIdentity("artifact has no safetensors weights")
+        }
+
+        let revision = revision(from: resolved)
+        let fingerprint = MTPBenchmarkDigest.artifactFingerprint(
+            modelID: effectiveModelID,
+            revision: revision,
+            configSizeBytes: configSize,
+            configSHA256: configSHA256,
+            weightFiles: weights)
+        let architectures = object?["architectures"] as? [String]
+        return MTPBenchmarkArtifactFacts(
+            modelID: effectiveModelID,
+            resolvedPath: resolved.path,
+            revision: revision,
+            modelType: object?["model_type"] as? String,
+            architecture: architectures?.first,
+            dtype: object?["dtype"] as? String,
+            quantization: quantizationFacts,
+            configSizeBytes: configSize,
+            configSHA256: configSHA256,
+            weightFiles: weights,
+            artifactFingerprint: fingerprint)
+    }
+
+    public static func validateUnchanged(
+        _ expected: MTPBenchmarkArtifactFacts,
+        label: String
+    ) throws {
+        guard expected.hasVerifiableProvenance else {
+            throw MTPBenchmarkError.artifactIdentity("\(label) lacks immutable provenance")
+        }
+        let refreshed: MTPBenchmarkArtifactFacts
+        do {
+            refreshed = try inspect(
+                modelID: expected.modelID,
+                directory: URL(fileURLWithPath: expected.resolvedPath, isDirectory: true))
+        } catch {
+            throw MTPBenchmarkError.artifactDrift(label)
+        }
+        guard refreshed.resolvedPath == expected.resolvedPath,
+              refreshed.configSHA256 == expected.configSHA256,
+              refreshed.weightFiles == expected.weightFiles,
+              refreshed.artifactFingerprint == expected.artifactFingerprint
+        else {
+            throw MTPBenchmarkError.artifactDrift(label)
+        }
+    }
+
+    public static func hardware() throws -> MTPBenchmarkHardware {
+        let value = try HardwareDetector.detect()
+        return MTPBenchmarkHardware(
+            machineModel: value.machineModel,
+            chipName: value.chipName,
+            chipFamily: value.chipFamily.rawValue,
+            chipTier: value.chipTier.rawValue,
+            memoryGB: value.memoryGb,
+            gpuCores: value.gpuCores,
+            memoryBandwidthGBps: value.memoryBandwidthGbs)
+    }
+
+    private static func regularFileSize(_ url: URL) throws -> Int64 {
+        let values = try url.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
+        guard values.isRegularFile == true, let size = values.fileSize, size > 0 else {
+            throw MTPBenchmarkError.artifactIdentity("artifact member is not a nonempty file")
+        }
+        return Int64(size)
+    }
+
+    private static func weightIdentity(
+        snapshotEntry: URL,
+        resolvedWeight: URL,
+        snapshot: URL
+    ) throws -> (
+        kind: MTPBenchmarkArtifactFacts.WeightFile.IdentityKind,
+        value: String
+    ) {
+        let values = try snapshotEntry.resourceValues(forKeys: [.isSymbolicLinkKey])
+        if values.isSymbolicLink == true,
+           snapshot.deletingLastPathComponent().lastPathComponent == "snapshots"
+        {
+            let repository = snapshot.deletingLastPathComponent().deletingLastPathComponent()
+            let blobRoot = repository.appendingPathComponent("blobs", isDirectory: true)
+                .standardizedFileURL
+            let candidate = resolvedWeight.lastPathComponent.lowercased()
+            if resolvedWeight.deletingLastPathComponent() == blobRoot,
+               candidate.allSatisfy(\.isHexDigit)
+            {
+                if candidate.count == 64 {
+                    return (.hfBlobSHA256, candidate)
+                }
+                if candidate.count == 40 {
+                    return (.hfBlobGitSHA1, candidate)
+                }
+            }
+        }
+        return (.sha256, try MTPBenchmarkDigest.sha256(file: resolvedWeight))
+    }
+
+    private static func huggingFaceModelID(snapshot: URL) -> String? {
+        let snapshots = snapshot.deletingLastPathComponent()
+        guard snapshots.lastPathComponent == "snapshots" else { return nil }
+        let repositoryName = snapshots.deletingLastPathComponent().lastPathComponent
+        guard repositoryName.hasPrefix("models--") else { return nil }
+        let encoded = repositoryName.dropFirst("models--".count)
+        let components = encoded.components(separatedBy: "--")
+        guard components.count >= 2, components.allSatisfy({ !$0.isEmpty }) else { return nil }
+        return components.joined(separator: "/")
+    }
+
+    private static func integer(_ value: Any?) -> Int? {
+        if let value = value as? Int { return value }
+        return (value as? NSNumber)?.intValue
+    }
+
+    private static func collectNestedBitOverrides(
+        _ value: Any,
+        into counts: inout [String: Int]
+    ) {
+        if let object = value as? [String: Any] {
+            if let bits = integer(object["bits"]) {
+                counts[String(bits), default: 0] += 1
+            }
+            for child in object.values {
+                collectNestedBitOverrides(child, into: &counts)
+            }
+        } else if let values = value as? [Any] {
+            for child in values {
+                collectNestedBitOverrides(child, into: &counts)
+            }
+        }
+    }
+
+    private static func revision(from directory: URL) -> String? {
+        let name = directory.lastPathComponent
+        guard name.count == 40, name.allSatisfy(\.isHexDigit) else { return nil }
+        return name.lowercased()
+    }
+}

--- a/provider-swift/Sources/ProviderBenchmark/MTPBenchmarkReport.swift
+++ b/provider-swift/Sources/ProviderBenchmark/MTPBenchmarkReport.swift
@@ -334,6 +334,9 @@ public struct MTPBenchmarkMetrics: Codable, Sendable {
 
     public let active: Bool
     public let verificationMode: String?
+    public let maxAutomaticRectangularTokens: Int?
+    public let rectangularVerificationRounds: Int?
+    public let serialVerificationRounds: Int?
     public let inactiveReason: String?
     public let selectedDepth: Int?
     public let decodeRowBucket: Int?
@@ -355,6 +358,9 @@ public struct MTPBenchmarkMetrics: Codable, Sendable {
     public init(
         active: Bool,
         verificationMode: String? = nil,
+        maxAutomaticRectangularTokens: Int? = nil,
+        rectangularVerificationRounds: Int? = nil,
+        serialVerificationRounds: Int? = nil,
         inactiveReason: String? = nil,
         selectedDepth: Int? = nil,
         decodeRowBucket: Int? = nil,
@@ -375,6 +381,9 @@ public struct MTPBenchmarkMetrics: Codable, Sendable {
     ) {
         self.active = active
         self.verificationMode = verificationMode
+        self.maxAutomaticRectangularTokens = maxAutomaticRectangularTokens
+        self.rectangularVerificationRounds = rectangularVerificationRounds
+        self.serialVerificationRounds = serialVerificationRounds
         self.inactiveReason = inactiveReason
         self.selectedDepth = selectedDepth
         self.decodeRowBucket = decodeRowBucket
@@ -400,6 +409,9 @@ public struct MTPBenchmarkMetrics: Codable, Sendable {
         MTPBenchmarkMetrics(
             active: active,
             verificationMode: verificationMode,
+            maxAutomaticRectangularTokens: maxAutomaticRectangularTokens,
+            rectangularVerificationRounds: rectangularVerificationRounds,
+            serialVerificationRounds: serialVerificationRounds,
             inactiveReason: inactiveReason,
             selectedDepth: selectedDepth,
             decodeRowBucket: decodeRowBucket,

--- a/provider-swift/Sources/ProviderBenchmark/MTPBenchmarkReport.swift
+++ b/provider-swift/Sources/ProviderBenchmark/MTPBenchmarkReport.swift
@@ -26,6 +26,66 @@ public enum MTPBenchmarkPurpose: String, Codable, Sendable {
     public var performanceEligible: Bool { self == .productionPerformance }
 }
 
+/// Declares whether requested fixed/adaptive cases must exercise MTP or must
+/// prove a specific fail-open safety gate. Inactive validation is never
+/// inferred from the machine or the engine result.
+public struct MTPBenchmarkMTPExpectation: Codable, Equatable, Sendable {
+    public enum Kind: String, Codable, Sendable {
+        case active
+        case expectedInactive = "expected_inactive"
+    }
+
+    public static let m5HardwareSafetyGate = MTPBenchmarkMTPExpectation(
+        kind: .expectedInactive,
+        allowedInactiveReasonPrefixes: [
+            "rectangular MTP verification is disabled on Apple M5"
+        ])
+
+    public let kind: Kind
+    public let allowedInactiveReasonValues: [String]
+    public let allowedInactiveReasonPrefixes: [String]
+
+    public static let active = MTPBenchmarkMTPExpectation(kind: .active)
+
+    public static func expectedInactive(
+        allowedReasonValues: [String] = [],
+        allowedReasonPrefixes: [String] = []
+    ) -> MTPBenchmarkMTPExpectation {
+        MTPBenchmarkMTPExpectation(
+            kind: .expectedInactive,
+            allowedInactiveReasonValues: allowedReasonValues,
+            allowedInactiveReasonPrefixes: allowedReasonPrefixes)
+    }
+
+    public init(
+        kind: Kind,
+        allowedInactiveReasonValues: [String] = [],
+        allowedInactiveReasonPrefixes: [String] = []
+    ) {
+        self.kind = kind
+        self.allowedInactiveReasonValues = allowedInactiveReasonValues.sorted()
+        self.allowedInactiveReasonPrefixes = allowedInactiveReasonPrefixes.sorted()
+    }
+
+    public var expectsInactive: Bool { kind == .expectedInactive }
+
+    public func matchesInactiveReason(_ reason: String?) -> Bool {
+        guard let reason, !reason.isEmpty else { return false }
+        return allowedInactiveReasonValues.contains(reason)
+            || allowedInactiveReasonPrefixes.contains { reason.hasPrefix($0) }
+    }
+
+    var isWellFormed: Bool {
+        let values = allowedInactiveReasonValues + allowedInactiveReasonPrefixes
+        switch kind {
+        case .active:
+            return values.isEmpty
+        case .expectedInactive:
+            return !values.isEmpty && values.allSatisfy { !$0.isEmpty }
+        }
+    }
+}
+
 public struct MTPBenchmarkStopPolicy: Equatable, Sendable {
     public enum Kind: String, Codable, Sendable {
         case rawFixedLengthNoStop = "raw_fixed_length_no_stop"
@@ -271,6 +331,7 @@ public struct MTPBenchmarkMetrics: Codable, Sendable {
     }
 
     public let active: Bool
+    public let inactiveReason: String?
     public let selectedDepth: Int?
     public let decodeRowBucket: Int?
     public let rounds: Int
@@ -290,6 +351,7 @@ public struct MTPBenchmarkMetrics: Codable, Sendable {
 
     public init(
         active: Bool,
+        inactiveReason: String? = nil,
         selectedDepth: Int? = nil,
         decodeRowBucket: Int? = nil,
         rounds: Int = 0,
@@ -308,6 +370,7 @@ public struct MTPBenchmarkMetrics: Codable, Sendable {
         targetVerifyTimeNanos: UInt64? = nil
     ) {
         self.active = active
+        self.inactiveReason = inactiveReason
         self.selectedDepth = selectedDepth
         self.decodeRowBucket = decodeRowBucket
         self.rounds = rounds
@@ -331,6 +394,7 @@ public struct MTPBenchmarkMetrics: Codable, Sendable {
     fileprivate func withoutPerformanceMeasurements() -> MTPBenchmarkMetrics {
         MTPBenchmarkMetrics(
             active: active,
+            inactiveReason: inactiveReason,
             selectedDepth: selectedDepth,
             decodeRowBucket: decodeRowBucket,
             rounds: rounds,
@@ -556,12 +620,13 @@ public struct MTPBenchmarkCoverage: Codable, Sendable {
 }
 
 public struct MTPBenchmarkReport: Codable, Sendable {
-    public static let currentSchemaVersion = 4
+    public static let currentSchemaVersion = 5
 
     public let schemaVersion: Int
     public let runFingerprint: String
     public let buildConfiguration: MTPBenchmarkBuildConfiguration
     public let purpose: MTPBenchmarkPurpose
+    public let mtpExpectation: MTPBenchmarkMTPExpectation
     public let stopPolicy: MTPBenchmarkStopPolicySummary
     public let startedAt: Date
     public let generatedAt: Date
@@ -581,9 +646,10 @@ public struct MTPBenchmarkReport: Codable, Sendable {
 
     public static func buildBoundFingerprint(
         _ launchFingerprint: String,
-        buildConfiguration: MTPBenchmarkBuildConfiguration
+        buildConfiguration: MTPBenchmarkBuildConfiguration,
+        mtpExpectation: MTPBenchmarkMTPExpectation = .active
     ) -> String {
-        "\(buildConfiguration.rawValue):\(launchFingerprint)"
+        "\(buildConfiguration.rawValue):\(mtpExpectation.kind.rawValue):\(launchFingerprint)"
     }
 
     public init(
@@ -591,6 +657,7 @@ public struct MTPBenchmarkReport: Codable, Sendable {
         runFingerprint: String,
         buildConfiguration: MTPBenchmarkBuildConfiguration = .current,
         purpose: MTPBenchmarkPurpose,
+        mtpExpectation: MTPBenchmarkMTPExpectation = .active,
         stopPolicy: MTPBenchmarkStopPolicy,
         startedAt: Date,
         generatedAt: Date = Date(),
@@ -611,9 +678,11 @@ public struct MTPBenchmarkReport: Codable, Sendable {
         self.schemaVersion = schemaVersion
         self.runFingerprint = Self.buildBoundFingerprint(
             runFingerprint,
-            buildConfiguration: buildConfiguration)
+            buildConfiguration: buildConfiguration,
+            mtpExpectation: mtpExpectation)
         self.buildConfiguration = buildConfiguration
         self.purpose = purpose
+        self.mtpExpectation = mtpExpectation
         self.stopPolicy = MTPBenchmarkStopPolicySummary(stopPolicy)
         self.startedAt = startedAt
         self.generatedAt = generatedAt
@@ -844,6 +913,7 @@ public enum MTPBenchmarkError: Error, CustomStringConvertible, Sendable {
     case emptyPromptCorpus
     case missingTargetOnlyBaseline
     case invalidStopPolicy(String)
+    case invalidMTPExpectation(String)
     case mtpRequestedButInactive(String)
     case productionMTPSeamUnavailable
     case missingTerminalEvent(row: Int)
@@ -876,6 +946,8 @@ public enum MTPBenchmarkError: Error, CustomStringConvertible, Sendable {
             return "MTP benchmark modes must include a target-only parity baseline"
         case .invalidStopPolicy(let detail):
             return "invalid MTP benchmark stop policy: \(detail)"
+        case .invalidMTPExpectation(let detail):
+            return "invalid MTP benchmark activation expectation: \(detail)"
         case .mtpRequestedButInactive(let mode):
             return "MTP was requested for \(mode), but the production engine reported it inactive"
         case .productionMTPSeamUnavailable:

--- a/provider-swift/Sources/ProviderBenchmark/MTPBenchmarkReport.swift
+++ b/provider-swift/Sources/ProviderBenchmark/MTPBenchmarkReport.swift
@@ -1,0 +1,911 @@
+import Darwin
+import Foundation
+
+public enum MTPBenchmarkBuildConfiguration: String, Codable, Sendable {
+    case debug
+    case release
+
+    public static var current: MTPBenchmarkBuildConfiguration {
+        #if DEBUG
+        .debug
+        #else
+        .release
+        #endif
+    }
+}
+
+public enum MTPBenchmarkPurpose: String, Codable, Sendable {
+    /// Fixed-length, no-stop correctness stress. Performance fields are
+    /// deliberately omitted because this is not production serving behavior.
+    case rawParityStress = "raw_parity_stress"
+    /// Production-shaped correctness using the target's exact stop-token set.
+    case productionCorrectness = "production_correctness"
+    /// Production-shaped performance using the target's exact stop-token set.
+    case productionPerformance = "production_performance"
+
+    public var performanceEligible: Bool { self == .productionPerformance }
+}
+
+public struct MTPBenchmarkStopPolicy: Equatable, Sendable {
+    public enum Kind: String, Codable, Sendable {
+        case rawFixedLengthNoStop = "raw_fixed_length_no_stop"
+        case productionTargetEOS = "production_target_eos"
+    }
+
+    public let kind: Kind
+    let stopTokenIDs: [Int]
+
+    public var configuredTokenCount: Int { stopTokenIDs.count }
+
+    public static let rawFixedLength = MTPBenchmarkStopPolicy(
+        kind: .rawFixedLengthNoStop, stopTokenIDs: [])
+
+    public static func production(tokenIDs: Set<Int>) -> MTPBenchmarkStopPolicy {
+        MTPBenchmarkStopPolicy(
+            kind: .productionTargetEOS, stopTokenIDs: tokenIDs.sorted())
+    }
+
+    public init(kind: Kind, stopTokenIDs: [Int]) {
+        self.kind = kind
+        self.stopTokenIDs = stopTokenIDs
+    }
+}
+
+/// Persisted stop-policy evidence deliberately records only cardinality. The
+/// runtime IDs remain in memory and are validated against every stop event.
+public struct MTPBenchmarkStopPolicySummary: Codable, Equatable, Sendable {
+    public let kind: MTPBenchmarkStopPolicy.Kind
+    public let configuredTokenCount: Int
+
+    init(_ policy: MTPBenchmarkStopPolicy) {
+        kind = policy.kind
+        configuredTokenCount = policy.configuredTokenCount
+    }
+}
+
+public struct MTPBenchmarkMode: Codable, Hashable, Sendable {
+    public enum Kind: String, Codable, Sendable {
+        case targetOnly = "target_only"
+        case fixed
+        case adaptive
+    }
+
+    public let kind: Kind
+    /// Target verification width L. Fixed modes cover L=1...8, where draft
+    /// depth k=L-1. Nil for target-only and adaptive modes.
+    public let verificationWidth: Int?
+
+    public static let targetOnly = MTPBenchmarkMode(kind: .targetOnly)
+    public static let adaptive = MTPBenchmarkMode(kind: .adaptive)
+
+    public static func fixed(verificationWidth: Int) throws -> MTPBenchmarkMode {
+        guard (1...8).contains(verificationWidth) else {
+            throw MTPBenchmarkError.invalidVerificationWidth(verificationWidth)
+        }
+        return MTPBenchmarkMode(kind: .fixed, verificationWidth: verificationWidth)
+    }
+
+    public init(kind: Kind, verificationWidth: Int? = nil) {
+        self.kind = kind
+        self.verificationWidth = verificationWidth
+    }
+
+    public var requestsMTP: Bool { kind != .targetOnly }
+    public var fixedDraftTokens: Int? {
+        guard kind == .fixed, let verificationWidth else { return nil }
+        return verificationWidth - 1
+    }
+
+    public var label: String {
+        switch kind {
+        case .targetOnly: return "target-only"
+        case .fixed: return "fixed-L\(verificationWidth ?? -1)"
+        case .adaptive: return "adaptive"
+        }
+    }
+}
+
+public struct MTPBenchmarkArtifactFacts: Codable, Equatable, Sendable {
+    public struct Quantization: Codable, Equatable, Sendable {
+        public let bits: Int?
+        public let groupSize: Int?
+        public let mode: String?
+        public let perLayerOverridesByBits: [String: Int]
+
+        public init(
+            bits: Int?,
+            groupSize: Int?,
+            mode: String?,
+            perLayerOverridesByBits: [String: Int] = [:]
+        ) {
+            self.bits = bits
+            self.groupSize = groupSize
+            self.mode = mode
+            self.perLayerOverridesByBits = perLayerOverridesByBits
+        }
+    }
+
+    public struct WeightFile: Codable, Equatable, Sendable {
+        public enum IdentityKind: String, Codable, Sendable {
+            case hfBlobSHA256 = "hf_blob_sha256"
+            case hfBlobGitSHA1 = "hf_blob_git_sha1"
+            case sha256
+        }
+
+        public let name: String
+        public let sizeBytes: Int64
+        public let identityKind: IdentityKind
+        public let contentIdentity: String
+
+        public init(
+            name: String,
+            sizeBytes: Int64,
+            identityKind: IdentityKind = .sha256,
+            contentIdentity: String = ""
+        ) {
+            self.name = name
+            self.sizeBytes = sizeBytes
+            self.identityKind = identityKind
+            self.contentIdentity = contentIdentity
+        }
+    }
+
+    public let modelID: String
+    public let resolvedPath: String
+    public let revision: String?
+    public let modelType: String?
+    public let architecture: String?
+    public let dtype: String?
+    public let quantization: Quantization?
+    public let configSizeBytes: Int64
+    public let configSHA256: String
+    public let weightFiles: [WeightFile]
+    public let artifactFingerprint: String
+
+    public var weightFileCount: Int { weightFiles.count }
+    public var weightBytes: Int64 { weightFiles.reduce(0) { $0 + $1.sizeBytes } }
+    public var artifactBytes: Int64 {
+        let (total, overflow) = configSizeBytes.addingReportingOverflow(weightBytes)
+        return overflow ? Int64.max : total
+    }
+    public var hasVerifiableProvenance: Bool {
+        Self.isSHA256(configSHA256)
+            && Self.isSHA256(artifactFingerprint)
+            && !weightFiles.isEmpty
+            && weightFiles.allSatisfy {
+                !$0.contentIdentity.isEmpty
+                    && ($0.identityKind != .sha256 || Self.isSHA256($0.contentIdentity))
+            }
+    }
+
+    public init(
+        modelID: String,
+        resolvedPath: String,
+        revision: String?,
+        modelType: String?,
+        architecture: String?,
+        dtype: String?,
+        quantization: Quantization?,
+        configSizeBytes: Int64 = 0,
+        configSHA256: String = "",
+        weightFiles: [WeightFile],
+        artifactFingerprint: String = ""
+    ) {
+        self.modelID = modelID
+        self.resolvedPath = resolvedPath
+        self.revision = revision
+        self.modelType = modelType
+        self.architecture = architecture
+        self.dtype = dtype
+        self.quantization = quantization
+        self.configSizeBytes = configSizeBytes
+        self.configSHA256 = configSHA256
+        self.weightFiles = weightFiles
+        self.artifactFingerprint = artifactFingerprint
+    }
+
+    private static func isSHA256(_ value: String) -> Bool {
+        value.count == 64 && value.allSatisfy(\.isHexDigit)
+    }
+}
+
+public struct MTPBenchmarkHardware: Codable, Sendable {
+    public let machineModel: String
+    public let chipName: String
+    public let chipFamily: String
+    public let chipTier: String
+    public let memoryGB: UInt64
+    public let gpuCores: UInt32
+    public let memoryBandwidthGBps: UInt32
+
+    public init(
+        machineModel: String,
+        chipName: String,
+        chipFamily: String,
+        chipTier: String,
+        memoryGB: UInt64,
+        gpuCores: UInt32,
+        memoryBandwidthGBps: UInt32
+    ) {
+        self.machineModel = machineModel
+        self.chipName = chipName
+        self.chipFamily = chipFamily
+        self.chipTier = chipTier
+        self.memoryGB = memoryGB
+        self.gpuCores = gpuCores
+        self.memoryBandwidthGBps = memoryBandwidthGBps
+    }
+}
+
+/// Stable benchmark-side projection of the engine's lock-safe MTP metrics.
+/// Optional timing/controller fields remain nil until the production engine
+/// exposes them; the report never invents values.
+public struct MTPBenchmarkMetrics: Codable, Sendable {
+    public struct CostInput: Codable, Sendable {
+        public let decodeRowBucket: Int
+        public let draftDepth: Int
+        public let sampleCount: Int
+        public let ewmaRoundWallTimeNanos: UInt64?
+        public let totalRoundWallTimeNanos: UInt64?
+
+        public init(
+            decodeRowBucket: Int,
+            draftDepth: Int,
+            sampleCount: Int,
+            ewmaRoundWallTimeNanos: UInt64? = nil,
+            totalRoundWallTimeNanos: UInt64? = nil
+        ) {
+            self.decodeRowBucket = decodeRowBucket
+            self.draftDepth = draftDepth
+            self.sampleCount = sampleCount
+            self.ewmaRoundWallTimeNanos = ewmaRoundWallTimeNanos
+            self.totalRoundWallTimeNanos = totalRoundWallTimeNanos
+        }
+
+        fileprivate func withoutPerformanceMeasurements() -> CostInput {
+            CostInput(
+                decodeRowBucket: decodeRowBucket,
+                draftDepth: draftDepth,
+                sampleCount: sampleCount)
+        }
+    }
+
+    public let active: Bool
+    public let selectedDepth: Int?
+    public let decodeRowBucket: Int?
+    public let rounds: Int
+    public let seedRows: Int
+    public let proposedTokens: Int
+    public let acceptedDraftTokens: Int
+    public let committedTokens: Int
+    public let acceptanceByPosition: [Int]
+    public let conditionalAcceptance: [Double]
+    public let skippedRows: [String: Int]
+    public let depthSelections: [String: Int]
+    public let controllerFallbacks: [String: Int]
+    public let costInputs: [CostInput]
+    public let totalRoundWallTimeNanos: UInt64?
+    public let assistantTimeNanos: UInt64?
+    public let targetVerifyTimeNanos: UInt64?
+
+    public init(
+        active: Bool,
+        selectedDepth: Int? = nil,
+        decodeRowBucket: Int? = nil,
+        rounds: Int = 0,
+        seedRows: Int = 0,
+        proposedTokens: Int = 0,
+        acceptedDraftTokens: Int = 0,
+        committedTokens: Int = 0,
+        acceptanceByPosition: [Int] = [],
+        conditionalAcceptance: [Double] = [],
+        skippedRows: [String: Int] = [:],
+        depthSelections: [String: Int] = [:],
+        controllerFallbacks: [String: Int] = [:],
+        costInputs: [CostInput] = [],
+        totalRoundWallTimeNanos: UInt64? = nil,
+        assistantTimeNanos: UInt64? = nil,
+        targetVerifyTimeNanos: UInt64? = nil
+    ) {
+        self.active = active
+        self.selectedDepth = selectedDepth
+        self.decodeRowBucket = decodeRowBucket
+        self.rounds = rounds
+        self.seedRows = seedRows
+        self.proposedTokens = proposedTokens
+        self.acceptedDraftTokens = acceptedDraftTokens
+        self.committedTokens = committedTokens
+        self.acceptanceByPosition = acceptanceByPosition
+        self.conditionalAcceptance = conditionalAcceptance
+        self.skippedRows = skippedRows
+        self.depthSelections = depthSelections
+        self.controllerFallbacks = controllerFallbacks
+        self.costInputs = costInputs
+        self.totalRoundWallTimeNanos = totalRoundWallTimeNanos
+        self.assistantTimeNanos = assistantTimeNanos
+        self.targetVerifyTimeNanos = targetVerifyTimeNanos
+    }
+
+    public static let inactive = MTPBenchmarkMetrics(active: false)
+
+    fileprivate func withoutPerformanceMeasurements() -> MTPBenchmarkMetrics {
+        MTPBenchmarkMetrics(
+            active: active,
+            selectedDepth: selectedDepth,
+            decodeRowBucket: decodeRowBucket,
+            rounds: rounds,
+            seedRows: seedRows,
+            proposedTokens: proposedTokens,
+            acceptedDraftTokens: acceptedDraftTokens,
+            committedTokens: committedTokens,
+            acceptanceByPosition: acceptanceByPosition,
+            conditionalAcceptance: conditionalAcceptance,
+            skippedRows: skippedRows,
+            depthSelections: depthSelections,
+            controllerFallbacks: controllerFallbacks,
+            costInputs: costInputs.map { $0.withoutPerformanceMeasurements() })
+    }
+}
+
+public struct MTPBenchmarkRowResult: Codable, Sendable {
+    public let promptName: String
+    public let tokenCount: Int
+    public let opaqueTokenDigest: String
+    /// Median production-performance timings. These are nil for raw parity
+    /// and production-correctness reports so they cannot be quoted as TPS.
+    public let timeToFirstTokenMs: Double?
+    public let interTokenLatencyMs: Double?
+    public let decodeTokensPerSecond: Double?
+    /// Submission to last token. Terminal-event delivery is excluded.
+    public let lastTokenLatencyMs: Double?
+    public let finishReason: String
+
+    public init(
+        promptName: String,
+        tokenCount: Int,
+        opaqueTokenDigest: String,
+        timeToFirstTokenMs: Double?,
+        interTokenLatencyMs: Double?,
+        decodeTokensPerSecond: Double?,
+        lastTokenLatencyMs: Double?,
+        finishReason: String
+    ) {
+        self.promptName = promptName
+        self.tokenCount = tokenCount
+        self.opaqueTokenDigest = opaqueTokenDigest
+        self.timeToFirstTokenMs = timeToFirstTokenMs
+        self.interTokenLatencyMs = interTokenLatencyMs
+        self.decodeTokensPerSecond = decodeTokensPerSecond
+        self.lastTokenLatencyMs = lastTokenLatencyMs
+        self.finishReason = finishReason
+    }
+
+    fileprivate func withoutPerformanceMeasurements() -> MTPBenchmarkRowResult {
+        MTPBenchmarkRowResult(
+            promptName: promptName,
+            tokenCount: tokenCount,
+            opaqueTokenDigest: opaqueTokenDigest,
+            timeToFirstTokenMs: nil,
+            interTokenLatencyMs: nil,
+            decodeTokensPerSecond: nil,
+            lastTokenLatencyMs: nil,
+            finishReason: finishReason)
+    }
+}
+
+public struct MTPBenchmarkCaseResult: Codable, Sendable {
+    public let mode: MTPBenchmarkMode
+    public let batchSize: Int
+    public let measurementRepetitions: Int
+    /// Median over repetitions, using sum(N-1) decode intervals over one
+    /// common earliest-first-token to latest-last-token batch interval.
+    /// Nil unless the entire report is production-performance eligible.
+    public let medianAggregateDecodeTokensPerSecond: Double?
+    public let tokenParity: Bool
+    public let parityMismatchRows: [Int]
+    public let rows: [MTPBenchmarkRowResult]
+    public let metrics: MTPBenchmarkMetrics
+
+    public init(
+        mode: MTPBenchmarkMode,
+        batchSize: Int,
+        measurementRepetitions: Int,
+        medianAggregateDecodeTokensPerSecond: Double?,
+        tokenParity: Bool,
+        parityMismatchRows: [Int],
+        rows: [MTPBenchmarkRowResult],
+        metrics: MTPBenchmarkMetrics
+    ) {
+        self.mode = mode
+        self.batchSize = batchSize
+        self.measurementRepetitions = measurementRepetitions
+        self.medianAggregateDecodeTokensPerSecond = medianAggregateDecodeTokensPerSecond
+        self.tokenParity = tokenParity
+        self.parityMismatchRows = parityMismatchRows
+        self.rows = rows
+        self.metrics = metrics
+    }
+
+    fileprivate func withoutPerformanceMeasurements() -> MTPBenchmarkCaseResult {
+        MTPBenchmarkCaseResult(
+            mode: mode,
+            batchSize: batchSize,
+            measurementRepetitions: measurementRepetitions,
+            medianAggregateDecodeTokensPerSecond: nil,
+            tokenParity: tokenParity,
+            parityMismatchRows: parityMismatchRows,
+            rows: rows.map { $0.withoutPerformanceMeasurements() },
+            metrics: metrics.withoutPerformanceMeasurements())
+    }
+}
+
+public enum MTPBenchmarkGateStatus: String, Codable, Sendable {
+    case covered
+    case notRun = "not_run"
+    case notImplemented = "not_implemented"
+    case notInThisReport = "not_in_this_report"
+}
+
+/// Honest scope labels for gates that a short cached-model matrix does not
+/// implement. These fields intentionally prevent a QAT smoke from standing in
+/// for quantization, fixture, modality, or long-context coverage.
+public struct MTPBenchmarkCoverage: Codable, Sendable {
+    public let qat4BitShortContextSmoke: MTPBenchmarkGateStatus
+    public let eightBitTargetPairing: MTPBenchmarkGateStatus
+    public let bf16AssistantPairing: MTPBenchmarkGateStatus
+    public let officialTensorFixtures: MTPBenchmarkGateStatus
+    public let toolTemplateDecodeParity: MTPBenchmarkGateStatus
+    public let structuredOutput: MTPBenchmarkGateStatus
+    public let imagePrefill: MTPBenchmarkGateStatus
+    public let videoPrefill: MTPBenchmarkGateStatus
+    public let longSlidingAndPrefixContexts: MTPBenchmarkGateStatus
+    public let opaqueTokenEvidence: MTPBenchmarkGateStatus
+    public let productionServingStopPolicy: MTPBenchmarkGateStatus
+    public let artifactProvenanceAndDrift: MTPBenchmarkGateStatus
+    public let conservativeAssistantSizing: MTPBenchmarkGateStatus
+    public let scopeNote: String
+
+    public static func shortContextMatrix(
+        target: MTPBenchmarkArtifactFacts,
+        assistant: MTPBenchmarkArtifactFacts,
+        purpose: MTPBenchmarkPurpose = .rawParityStress
+    ) -> MTPBenchmarkCoverage {
+        let targetName = target.modelID.lowercased()
+        let assistantName = assistant.modelID.lowercased()
+        let isQAT4 = targetName.contains("qat") && assistantName.contains("qat")
+            && effectiveQuantizationBits(target) == 4
+            && effectiveQuantizationBits(assistant) == 4
+        let isEightBitTarget = target.modelType == "gemma4"
+            && effectiveQuantizationBits(target) == 8
+        let normalizedAssistantDType = assistant.dtype?
+            .lowercased()
+            .replacingOccurrences(of: "_", with: "")
+            .replacingOccurrences(of: "-", with: "")
+        let isBF16Assistant = assistant.modelType == "gemma4_assistant"
+            && (normalizedAssistantDType == "bfloat16" || normalizedAssistantDType == "bf16")
+            && assistant.quantization == nil
+        let coveredPairings = [
+            isEightBitTarget ? "8-bit target" : nil,
+            isBF16Assistant ? "BF16 assistant" : nil,
+        ].compactMap { $0 }
+        let pairingNote = coveredPairings.isEmpty
+            ? "No 8-bit-target or BF16-assistant pairing is represented."
+            : "Artifact inspection identifies: \(coveredPairings.joined(separator: ", "))."
+        return MTPBenchmarkCoverage(
+            qat4BitShortContextSmoke: isQAT4 ? .covered : .notRun,
+            eightBitTargetPairing: isEightBitTarget ? .covered : .notRun,
+            bf16AssistantPairing: isBF16Assistant ? .covered : .notRun,
+            officialTensorFixtures: .notImplemented,
+            toolTemplateDecodeParity: .notInThisReport,
+            structuredOutput: .notImplemented,
+            imagePrefill: .notInThisReport,
+            videoPrefill: .notImplemented,
+            longSlidingAndPrefixContexts: .notImplemented,
+            opaqueTokenEvidence: .covered,
+            productionServingStopPolicy: purpose == .rawParityStress
+                ? .notInThisReport : .covered,
+            artifactProvenanceAndDrift:
+                target.hasVerifiableProvenance && assistant.hasVerifiableProvenance
+                    ? .covered : .notRun,
+            conservativeAssistantSizing: .covered,
+            scopeNote: "Short-context text matrix only. \(pairingNote) Generated token arrays are never persisted. Official-tensor, structured-output, video, and long/prefix-context gates are not implemented here.")
+    }
+
+    public init(
+        qat4BitShortContextSmoke: MTPBenchmarkGateStatus,
+        eightBitTargetPairing: MTPBenchmarkGateStatus,
+        bf16AssistantPairing: MTPBenchmarkGateStatus,
+        officialTensorFixtures: MTPBenchmarkGateStatus,
+        toolTemplateDecodeParity: MTPBenchmarkGateStatus,
+        structuredOutput: MTPBenchmarkGateStatus,
+        imagePrefill: MTPBenchmarkGateStatus,
+        videoPrefill: MTPBenchmarkGateStatus,
+        longSlidingAndPrefixContexts: MTPBenchmarkGateStatus,
+        opaqueTokenEvidence: MTPBenchmarkGateStatus,
+        productionServingStopPolicy: MTPBenchmarkGateStatus,
+        artifactProvenanceAndDrift: MTPBenchmarkGateStatus,
+        conservativeAssistantSizing: MTPBenchmarkGateStatus,
+        scopeNote: String
+    ) {
+        self.qat4BitShortContextSmoke = qat4BitShortContextSmoke
+        self.eightBitTargetPairing = eightBitTargetPairing
+        self.bf16AssistantPairing = bf16AssistantPairing
+        self.officialTensorFixtures = officialTensorFixtures
+        self.toolTemplateDecodeParity = toolTemplateDecodeParity
+        self.structuredOutput = structuredOutput
+        self.imagePrefill = imagePrefill
+        self.videoPrefill = videoPrefill
+        self.longSlidingAndPrefixContexts = longSlidingAndPrefixContexts
+        self.opaqueTokenEvidence = opaqueTokenEvidence
+        self.productionServingStopPolicy = productionServingStopPolicy
+        self.artifactProvenanceAndDrift = artifactProvenanceAndDrift
+        self.conservativeAssistantSizing = conservativeAssistantSizing
+        self.scopeNote = scopeNote
+    }
+
+    private static func effectiveQuantizationBits(
+        _ artifact: MTPBenchmarkArtifactFacts
+    ) -> Int? {
+        guard let quantization = artifact.quantization else { return nil }
+        if let bits = quantization.bits { return bits }
+        let overrideBits = Set(quantization.perLayerOverridesByBits.compactMap { key, count in
+            count > 0 ? Int(key) : nil
+        })
+        return overrideBits.count == 1 ? overrideBits.first : nil
+    }
+}
+
+public struct MTPBenchmarkReport: Codable, Sendable {
+    public static let currentSchemaVersion = 4
+
+    public let schemaVersion: Int
+    public let runFingerprint: String
+    public let buildConfiguration: MTPBenchmarkBuildConfiguration
+    public let purpose: MTPBenchmarkPurpose
+    public let stopPolicy: MTPBenchmarkStopPolicySummary
+    public let startedAt: Date
+    public let generatedAt: Date
+    public let completedAt: Date?
+    public let complete: Bool
+    public let expectedCaseCount: Int
+    public let target: MTPBenchmarkArtifactFacts
+    public let assistant: MTPBenchmarkArtifactFacts
+    public let hardware: MTPBenchmarkHardware
+    public let maxTokensPerRow: Int
+    public let warmupIterations: Int
+    public let measurementRepetitions: Int
+    public let modeOrderSeed: UInt64
+    public let coverage: MTPBenchmarkCoverage
+    public let elapsedMs: Double?
+    public let cases: [MTPBenchmarkCaseResult]
+
+    public static func buildBoundFingerprint(
+        _ launchFingerprint: String,
+        buildConfiguration: MTPBenchmarkBuildConfiguration
+    ) -> String {
+        "\(buildConfiguration.rawValue):\(launchFingerprint)"
+    }
+
+    public init(
+        schemaVersion: Int = MTPBenchmarkReport.currentSchemaVersion,
+        runFingerprint: String,
+        buildConfiguration: MTPBenchmarkBuildConfiguration = .current,
+        purpose: MTPBenchmarkPurpose,
+        stopPolicy: MTPBenchmarkStopPolicy,
+        startedAt: Date,
+        generatedAt: Date = Date(),
+        completedAt: Date?,
+        complete: Bool,
+        expectedCaseCount: Int,
+        target: MTPBenchmarkArtifactFacts,
+        assistant: MTPBenchmarkArtifactFacts,
+        hardware: MTPBenchmarkHardware,
+        maxTokensPerRow: Int,
+        warmupIterations: Int,
+        measurementRepetitions: Int,
+        modeOrderSeed: UInt64,
+        coverage: MTPBenchmarkCoverage,
+        elapsedMs: Double?,
+        cases: [MTPBenchmarkCaseResult]
+    ) {
+        self.schemaVersion = schemaVersion
+        self.runFingerprint = Self.buildBoundFingerprint(
+            runFingerprint,
+            buildConfiguration: buildConfiguration)
+        self.buildConfiguration = buildConfiguration
+        self.purpose = purpose
+        self.stopPolicy = MTPBenchmarkStopPolicySummary(stopPolicy)
+        self.startedAt = startedAt
+        self.generatedAt = generatedAt
+        self.completedAt = completedAt
+        self.complete = complete
+        self.expectedCaseCount = expectedCaseCount
+        self.target = target
+        self.assistant = assistant
+        self.hardware = hardware
+        self.maxTokensPerRow = maxTokensPerRow
+        self.warmupIterations = warmupIterations
+        self.measurementRepetitions = measurementRepetitions
+        self.modeOrderSeed = modeOrderSeed
+        self.coverage = coverage
+        self.elapsedMs = purpose.performanceEligible ? elapsedMs : nil
+        self.cases = purpose.performanceEligible
+            ? cases
+            : cases.map { $0.withoutPerformanceMeasurements() }
+    }
+
+    public func jsonData(prettyPrinted: Bool = true) throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = prettyPrinted
+            ? [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+            : [.sortedKeys, .withoutEscapingSlashes]
+        return try encoder.encode(self)
+    }
+
+    public func write(to destination: MTPBenchmarkReportDestination) throws {
+        try destination.write(jsonData())
+    }
+}
+
+/// Descriptor-relative destination for benchmark checkpoints. The directory is
+/// opened once without following its final path component; every temporary
+/// write and rename remains anchored to that descriptor even if the visible
+/// directory path is replaced while the benchmark is running.
+public final class MTPBenchmarkReportDestination: @unchecked Sendable {
+    public let directoryURL: URL
+    public let fileName: String
+
+    private let directoryFileDescriptor: Int32
+    private let directoryDevice: UInt64
+    private let directoryInode: UInt64
+
+    public var url: URL { directoryURL.appendingPathComponent(fileName) }
+
+    public static func open(
+        directoryURL: URL,
+        fileName: String,
+        expectedDevice: UInt64? = nil,
+        expectedInode: UInt64? = nil
+    ) throws -> MTPBenchmarkReportDestination {
+        guard !fileName.isEmpty,
+              fileName != ".",
+              fileName != "..",
+              !fileName.contains("/")
+        else {
+            throw MTPBenchmarkError.unsafeReportDestination("invalid report filename")
+        }
+        let descriptor = Darwin.open(
+            directoryURL.path,
+            O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC)
+        guard descriptor >= 0 else {
+            throw posixError("open benchmark report directory")
+        }
+        do {
+            var metadata = stat()
+            guard Darwin.fstat(descriptor, &metadata) == 0 else {
+                throw posixError("stat benchmark report directory")
+            }
+            guard (metadata.st_mode & mode_t(S_IFMT)) == mode_t(S_IFDIR) else {
+                throw MTPBenchmarkError.unsafeReportDestination(
+                    "report parent is not a directory")
+            }
+            if expectedDevice != nil || expectedInode != nil {
+                guard (metadata.st_mode & mode_t(0o777)) == mode_t(0o700),
+                      metadata.st_uid == Darwin.geteuid()
+                else {
+                    throw MTPBenchmarkError.unsafeReportDestination(
+                        "supervised report parent is not private and process-owned")
+                }
+            }
+            let device = UInt64(metadata.st_dev)
+            let inode = UInt64(metadata.st_ino)
+            if let expectedDevice, expectedDevice != device {
+                throw MTPBenchmarkError.unsafeReportDestination(
+                    "report parent device changed")
+            }
+            if let expectedInode, expectedInode != inode {
+                throw MTPBenchmarkError.unsafeReportDestination(
+                    "report parent inode changed")
+            }
+            return MTPBenchmarkReportDestination(
+                directoryURL: directoryURL.standardizedFileURL,
+                fileName: fileName,
+                directoryFileDescriptor: descriptor,
+                directoryDevice: device,
+                directoryInode: inode)
+        } catch {
+            Darwin.close(descriptor)
+            throw error
+        }
+    }
+
+    private init(
+        directoryURL: URL,
+        fileName: String,
+        directoryFileDescriptor: Int32,
+        directoryDevice: UInt64,
+        directoryInode: UInt64
+    ) {
+        self.directoryURL = directoryURL
+        self.fileName = fileName
+        self.directoryFileDescriptor = directoryFileDescriptor
+        self.directoryDevice = directoryDevice
+        self.directoryInode = directoryInode
+    }
+
+    deinit {
+        Darwin.close(directoryFileDescriptor)
+    }
+
+    fileprivate func write(_ data: Data) throws {
+        try validateOpenDirectory()
+        let temporaryName = ".\(fileName).\(UUID().uuidString).tmp"
+        let descriptor = Darwin.openat(
+            directoryFileDescriptor,
+            temporaryName,
+            O_WRONLY | O_CREAT | O_EXCL | O_NOFOLLOW | O_CLOEXEC,
+            mode_t(S_IRUSR | S_IWUSR))
+        guard descriptor >= 0 else { throw posixError("create benchmark checkpoint") }
+
+        var temporaryMetadata = stat()
+        do {
+            try data.withUnsafeBytes { bytes in
+                var offset = 0
+                while offset < bytes.count {
+                    let count = Darwin.write(
+                        descriptor,
+                        bytes.baseAddress!.advanced(by: offset),
+                        bytes.count - offset)
+                    if count < 0, errno == EINTR { continue }
+                    guard count > 0 else { throw posixError("write benchmark checkpoint") }
+                    offset += count
+                }
+            }
+            guard Darwin.fsync(descriptor) == 0 else {
+                throw posixError("sync benchmark checkpoint")
+            }
+            guard Darwin.fstat(descriptor, &temporaryMetadata) == 0 else {
+                throw posixError("stat benchmark checkpoint")
+            }
+            guard (temporaryMetadata.st_mode & mode_t(S_IFMT)) == mode_t(S_IFREG) else {
+                throw MTPBenchmarkError.unsafeReportDestination(
+                    "checkpoint temporary is not a regular file")
+            }
+        } catch {
+            Darwin.close(descriptor)
+            Darwin.unlinkat(directoryFileDescriptor, temporaryName, 0)
+            throw error
+        }
+        Darwin.close(descriptor)
+
+        guard Darwin.renameat(
+            directoryFileDescriptor,
+            temporaryName,
+            directoryFileDescriptor,
+            fileName) == 0
+        else {
+            Darwin.unlinkat(directoryFileDescriptor, temporaryName, 0)
+            throw posixError("publish benchmark checkpoint")
+        }
+
+        let finalDescriptor = Darwin.openat(
+            directoryFileDescriptor,
+            fileName,
+            O_RDONLY | O_NOFOLLOW | O_CLOEXEC)
+        guard finalDescriptor >= 0 else {
+            throw posixError("reopen benchmark checkpoint")
+        }
+        defer { Darwin.close(finalDescriptor) }
+        var finalMetadata = stat()
+        guard Darwin.fstat(finalDescriptor, &finalMetadata) == 0 else {
+            throw posixError("stat published benchmark checkpoint")
+        }
+        guard (finalMetadata.st_mode & mode_t(S_IFMT)) == mode_t(S_IFREG),
+              finalMetadata.st_dev == temporaryMetadata.st_dev,
+              finalMetadata.st_ino == temporaryMetadata.st_ino
+        else {
+            throw MTPBenchmarkError.unsafeReportDestination(
+                "published checkpoint inode changed")
+        }
+        guard Darwin.fsync(directoryFileDescriptor) == 0 else {
+            throw posixError("sync benchmark report directory")
+        }
+        try validateOpenDirectory()
+    }
+
+    private func validateOpenDirectory() throws {
+        var metadata = stat()
+        guard Darwin.fstat(directoryFileDescriptor, &metadata) == 0 else {
+            throw posixError("stat open benchmark report directory")
+        }
+        guard (metadata.st_mode & mode_t(S_IFMT)) == mode_t(S_IFDIR),
+              UInt64(metadata.st_dev) == directoryDevice,
+              UInt64(metadata.st_ino) == directoryInode
+        else {
+            throw MTPBenchmarkError.unsafeReportDestination(
+                "open report parent identity changed")
+        }
+    }
+}
+
+private func posixError(_ operation: String) -> NSError {
+    NSError(
+        domain: NSPOSIXErrorDomain,
+        code: Int(errno),
+        userInfo: [NSLocalizedDescriptionKey: "\(operation): \(String(cString: strerror(errno)))"])
+}
+
+public enum MTPBenchmarkError: Error, CustomStringConvertible, Sendable {
+    case invalidVerificationWidth(Int)
+    case invalidBatchSize(Int)
+    case invalidWarmupIterations(Int)
+    case invalidMeasurementRepetitions(Int)
+    case emptyPromptCorpus
+    case missingTargetOnlyBaseline
+    case invalidStopPolicy(String)
+    case mtpRequestedButInactive(String)
+    case productionMTPSeamUnavailable
+    case missingTerminalEvent(row: Int)
+    case unsuccessfulTerminal(row: Int, reason: String)
+    case unexpectedTerminal(row: Int, condition: String)
+    case emptyTokenStream(row: Int)
+    case invalidTokenTimeline(String)
+    case invalidMetrics(String)
+    case inconsistentRepetition(String)
+    case tokenParityMismatch(mode: String, batchSize: Int, rows: [Int])
+    case invalidBuildConfiguration(String)
+    case artifactIdentity(String)
+    case artifactDrift(String)
+    case unsafeReportDestination(String)
+    case deadlineExceeded
+
+    public var description: String {
+        switch self {
+        case .invalidVerificationWidth(let width):
+            return "MTP verification width must be in 1...8, got \(width)"
+        case .invalidBatchSize(let size):
+            return "MTP benchmark batch size must be positive, got \(size)"
+        case .invalidWarmupIterations(let count):
+            return "MTP benchmark warmup iterations must be nonnegative, got \(count)"
+        case .invalidMeasurementRepetitions(let count):
+            return "MTP benchmark measurement repetitions must be positive, got \(count)"
+        case .emptyPromptCorpus:
+            return "MTP benchmark prompt corpus is empty"
+        case .missingTargetOnlyBaseline:
+            return "MTP benchmark modes must include a target-only parity baseline"
+        case .invalidStopPolicy(let detail):
+            return "invalid MTP benchmark stop policy: \(detail)"
+        case .mtpRequestedButInactive(let mode):
+            return "MTP was requested for \(mode), but the production engine reported it inactive"
+        case .productionMTPSeamUnavailable:
+            return "production EngineV2 construction has not exposed the MTP drafter/config seam"
+        case .missingTerminalEvent(let row):
+            return "MTP benchmark row \(row) ended without a terminal event"
+        case .unsuccessfulTerminal(let row, let reason):
+            return "MTP benchmark row \(row) failed with terminal reason \(reason)"
+        case .unexpectedTerminal(let row, let condition):
+            return "MTP benchmark row \(row) violated \(condition)"
+        case .emptyTokenStream(let row):
+            return "MTP benchmark row \(row) completed without a sampled token"
+        case .invalidTokenTimeline(let detail):
+            return "invalid MTP benchmark token timeline: \(detail)"
+        case .invalidMetrics(let detail):
+            return "invalid MTP benchmark engine metrics: \(detail)"
+        case .inconsistentRepetition(let detail):
+            return "inconsistent MTP benchmark repetition: \(detail)"
+        case .tokenParityMismatch(let mode, let batchSize, let rows):
+            return "MTP token parity failed for \(mode), B=\(batchSize), rows=\(rows)"
+        case .invalidBuildConfiguration(let detail):
+            return "invalid MTP benchmark build configuration: \(detail)"
+        case .artifactIdentity(let detail):
+            return "invalid MTP benchmark artifact identity: \(detail)"
+        case .artifactDrift(let label):
+            return "MTP benchmark \(label) artifact changed during the run"
+        case .unsafeReportDestination(let detail):
+            return "unsafe MTP benchmark report destination: \(detail)"
+        case .deadlineExceeded:
+            return "MTP benchmark deadline exceeded"
+        }
+    }
+}

--- a/provider-swift/Sources/ProviderBenchmark/MTPBenchmarkReport.swift
+++ b/provider-swift/Sources/ProviderBenchmark/MTPBenchmarkReport.swift
@@ -557,7 +557,10 @@ public struct MTPBenchmarkCoverage: Codable, Sendable {
         let isQAT4 = targetName.contains("qat") && assistantName.contains("qat")
             && effectiveQuantizationBits(target) == 4
             && effectiveQuantizationBits(assistant) == 4
-        let isEightBitTarget = target.modelType == "gemma4"
+        // Both official Gemma 4 target config types count: multimodal
+        // checkpoints report "gemma4" and text-only checkpoints report
+        // "gemma4_text" (mirrors EngineV2SupportedModels.isGemma4Target).
+        let isEightBitTarget = (target.modelType == "gemma4" || target.modelType == "gemma4_text")
             && effectiveQuantizationBits(target) == 8
         let normalizedAssistantDType = assistant.dtype?
             .lowercased()

--- a/provider-swift/Sources/ProviderBenchmark/MTPBenchmarkReport.swift
+++ b/provider-swift/Sources/ProviderBenchmark/MTPBenchmarkReport.swift
@@ -35,7 +35,9 @@ public struct MTPBenchmarkMTPExpectation: Codable, Equatable, Sendable {
         case expectedInactive = "expected_inactive"
     }
 
-    public static let m5HardwareSafetyGate = MTPBenchmarkMTPExpectation(
+    /// Backward-compatible validator for reports created before the
+    /// chip-independent serial target verifier replaced the M5 denylist.
+    public static let legacyM5HardwareSafetyGate = MTPBenchmarkMTPExpectation(
         kind: .expectedInactive,
         allowedInactiveReasonPrefixes: [
             "rectangular MTP verification is disabled on Apple M5"
@@ -331,6 +333,7 @@ public struct MTPBenchmarkMetrics: Codable, Sendable {
     }
 
     public let active: Bool
+    public let verificationMode: String?
     public let inactiveReason: String?
     public let selectedDepth: Int?
     public let decodeRowBucket: Int?
@@ -351,6 +354,7 @@ public struct MTPBenchmarkMetrics: Codable, Sendable {
 
     public init(
         active: Bool,
+        verificationMode: String? = nil,
         inactiveReason: String? = nil,
         selectedDepth: Int? = nil,
         decodeRowBucket: Int? = nil,
@@ -370,6 +374,7 @@ public struct MTPBenchmarkMetrics: Codable, Sendable {
         targetVerifyTimeNanos: UInt64? = nil
     ) {
         self.active = active
+        self.verificationMode = verificationMode
         self.inactiveReason = inactiveReason
         self.selectedDepth = selectedDepth
         self.decodeRowBucket = decodeRowBucket
@@ -394,6 +399,7 @@ public struct MTPBenchmarkMetrics: Codable, Sendable {
     fileprivate func withoutPerformanceMeasurements() -> MTPBenchmarkMetrics {
         MTPBenchmarkMetrics(
             active: active,
+            verificationMode: verificationMode,
             inactiveReason: inactiveReason,
             selectedDepth: selectedDepth,
             decodeRowBucket: decodeRowBucket,

--- a/provider-swift/Sources/ProviderBenchmark/MTPBenchmarkRunner.swift
+++ b/provider-swift/Sources/ProviderBenchmark/MTPBenchmarkRunner.swift
@@ -442,6 +442,9 @@ public enum MTPBenchmarkRunner {
                     "adaptive B=\(batchSize) never observed decode-row bucket \(expectedBucket)")
             }
             if adaptiveDraftingExpected {
+                if try validateAutomaticAdaptiveWithinCap(metrics, batchSize: batchSize) {
+                    return
+                }
                 guard metrics.rounds > 0, metrics.proposedTokens > 0 else {
                     throw MTPBenchmarkError.invalidMetrics(
                         "adaptive B=\(batchSize) was expected to draft but did not")
@@ -482,7 +485,6 @@ public enum MTPBenchmarkRunner {
             $0.decodeRowBucket * ($0.draftDepth + 1) <= maxRectangularTokens
         }
         guard metrics.controllerFallbacks["automatic_rectangular_limit", default: 0] > 0,
-              metrics.depthSelections["0", default: 0] > 0,
               costsStayWithinLimit,
               (metrics.serialVerificationRounds ?? 0) == 0
         else {
@@ -501,6 +503,7 @@ public enum MTPBenchmarkRunner {
             return true
         }
         guard metrics.selectedDepth == 0,
+              metrics.depthSelections["0", default: 0] > 0,
               metrics.rounds == 0,
               metrics.seedRows == 0,
               metrics.proposedTokens == 0,
@@ -517,6 +520,34 @@ public enum MTPBenchmarkRunner {
         else {
             throw MTPBenchmarkError.invalidMetrics(
                 "automatic fixed-depth fallback B=\(batchSize) reported uncategorized work")
+        }
+        return true
+    }
+
+    /// Adaptive drafting cannot be demanded when even depth one exceeds the
+    /// automatic rectangular work cap at the submitted batch size. Any
+    /// drafting that does happen (for example after tail rows drain) must
+    /// stay rectangular and inside the cap.
+    private static func validateAutomaticAdaptiveWithinCap(
+        _ metrics: MTPBenchmarkMetrics,
+        batchSize: Int
+    ) throws -> Bool {
+        guard metrics.verificationMode == "automatic",
+              let maxRectangularTokens = metrics.maxAutomaticRectangularTokens,
+              batchSize * 2 > maxRectangularTokens
+        else { return false }
+
+        let positiveCosts = metrics.costInputs.filter { $0.draftDepth > 0 && $0.sampleCount > 0 }
+        let costsStayWithinLimit = positiveCosts.allSatisfy {
+            $0.decodeRowBucket * ($0.draftDepth + 1) <= maxRectangularTokens
+        }
+        guard costsStayWithinLimit,
+              (metrics.serialVerificationRounds ?? 0) == 0,
+              metrics.rounds == 0 || metrics.proposedTokens > 0,
+              metrics.rounds > 0 || (metrics.rectangularVerificationRounds ?? 0) == 0
+        else {
+            throw MTPBenchmarkError.invalidMetrics(
+                "adaptive B=\(batchSize) escaped its automatic rectangular limit")
         }
         return true
     }

--- a/provider-swift/Sources/ProviderBenchmark/MTPBenchmarkRunner.swift
+++ b/provider-swift/Sources/ProviderBenchmark/MTPBenchmarkRunner.swift
@@ -810,6 +810,17 @@ public enum MTPBenchmarkRunner {
                         condition: "production stop membership")
                 }
             }
+            // A "length" terminal certifies the decode ran to the token budget.
+            // Fewer tokens means the engine truncated early; rejecting it here
+            // keeps identical premature truncation in both sessions from
+            // passing token parity and the gates.
+            if finishReason == "length" {
+                guard tokens.count == maxTokens else {
+                    throw MTPBenchmarkError.unexpectedTerminal(
+                        row: row,
+                        condition: "production length terminal reached maxTokens")
+                }
+            }
         }
         let timing = try MTPBenchmarkTiming.stream(
             submittedAtNanoseconds: submittedAtNanoseconds,

--- a/provider-swift/Sources/ProviderBenchmark/MTPBenchmarkRunner.swift
+++ b/provider-swift/Sources/ProviderBenchmark/MTPBenchmarkRunner.swift
@@ -492,13 +492,15 @@ public enum MTPBenchmarkRunner {
                 "automatic fixed-depth fallback B=\(batchSize) escaped its rectangular limit")
         }
         if hasPositiveDepth {
+            // The depth controller intentionally refuses cost attribution
+            // when the finalized depth differs from its requested depth, so
+            // clamped rounds may record no positive cost inputs at all.
             guard metrics.rounds > 0,
                   metrics.proposedTokens > 0,
-                  !positiveCosts.isEmpty,
                   (metrics.rectangularVerificationRounds ?? 0) > 0
             else {
                 throw MTPBenchmarkError.invalidMetrics(
-                    "automatic fixed-depth fallback B=\(batchSize) lacks safe smaller-batch evidence")
+                    "automatic fixed-depth fallback B=\(batchSize) lacks clamped-depth evidence")
             }
             return true
         }

--- a/provider-swift/Sources/ProviderBenchmark/MTPBenchmarkRunner.swift
+++ b/provider-swift/Sources/ProviderBenchmark/MTPBenchmarkRunner.swift
@@ -405,6 +405,11 @@ public enum MTPBenchmarkRunner {
                 return
             }
             let expectedDepth = (mode.verificationWidth ?? 1) - 1
+            if try validateAutomaticDepthLimitFallback(
+                metrics, batchSize: batchSize, requestedDepth: expectedDepth)
+            {
+                return
+            }
             guard observedBucket(metrics, expectedBucket: expectedBucket) else {
                 throw MTPBenchmarkError.invalidMetrics(
                     "\(mode.label), B=\(batchSize) never observed decode-row bucket \(expectedBucket)")
@@ -457,6 +462,63 @@ public enum MTPBenchmarkRunner {
                 }
             }
         }
+    }
+
+    private static func validateAutomaticDepthLimitFallback(
+        _ metrics: MTPBenchmarkMetrics,
+        batchSize: Int,
+        requestedDepth: Int
+    ) throws -> Bool {
+        guard metrics.verificationMode == "automatic",
+              let maxRectangularTokens = metrics.maxAutomaticRectangularTokens,
+              batchSize * (requestedDepth + 1) > maxRectangularTokens
+        else { return false }
+
+        let hasPositiveDepth = metrics.depthSelections.contains {
+            (Int($0.key) ?? 0) > 0 && $0.value > 0
+        }
+        let positiveCosts = metrics.costInputs.filter { $0.draftDepth > 0 && $0.sampleCount > 0 }
+        let costsStayWithinLimit = positiveCosts.allSatisfy {
+            $0.decodeRowBucket * ($0.draftDepth + 1) <= maxRectangularTokens
+        }
+        guard metrics.controllerFallbacks["automatic_rectangular_limit", default: 0] > 0,
+              metrics.depthSelections["0", default: 0] > 0,
+              costsStayWithinLimit,
+              (metrics.serialVerificationRounds ?? 0) == 0
+        else {
+            throw MTPBenchmarkError.invalidMetrics(
+                "automatic fixed-depth fallback B=\(batchSize) escaped its rectangular limit")
+        }
+        if hasPositiveDepth {
+            guard metrics.rounds > 0,
+                  metrics.proposedTokens > 0,
+                  !positiveCosts.isEmpty,
+                  (metrics.rectangularVerificationRounds ?? 0) > 0
+            else {
+                throw MTPBenchmarkError.invalidMetrics(
+                    "automatic fixed-depth fallback B=\(batchSize) lacks safe smaller-batch evidence")
+            }
+            return true
+        }
+        guard metrics.selectedDepth == 0,
+              metrics.rounds == 0,
+              metrics.seedRows == 0,
+              metrics.proposedTokens == 0,
+              metrics.acceptedDraftTokens == 0,
+              metrics.committedTokens == 0,
+              metrics.acceptanceByPosition.isEmpty,
+              metrics.conditionalAcceptance.isEmpty,
+              metrics.skippedRows.isEmpty,
+              metrics.costInputs.isEmpty,
+              (metrics.totalRoundWallTimeNanos ?? 0) == 0,
+              metrics.assistantTimeNanos == nil,
+              metrics.targetVerifyTimeNanos == nil,
+              (metrics.rectangularVerificationRounds ?? 0) == 0
+        else {
+            throw MTPBenchmarkError.invalidMetrics(
+                "automatic fixed-depth fallback B=\(batchSize) reported uncategorized work")
+        }
+        return true
     }
 
     private static func validateActivation(

--- a/provider-swift/Sources/ProviderBenchmark/MTPBenchmarkRunner.swift
+++ b/provider-swift/Sources/ProviderBenchmark/MTPBenchmarkRunner.swift
@@ -150,6 +150,7 @@ public enum MTPBenchmarkRunner {
         let tokenEvidenceSalt = MTPBenchmarkDigest.randomSalt()
         var results: [MTPBenchmarkCaseResult] = []
         var baselineTokens: [Int: [[Int]]] = [:]
+        var baselineFinishReasons: [Int: [String]] = [:]
 
         func report(complete: Bool) -> MTPBenchmarkReport {
             MTPBenchmarkReport(
@@ -194,11 +195,15 @@ public enum MTPBenchmarkRunner {
             try validateRepetitionConsistency(samples, key: key)
 
             let sampleTokens = samples.map { $0.batch.rows.map(\.tokenIDs) }
+            let sampleReasons = samples.map { $0.batch.rows.map(\.finishReason) }
             let canonicalTokens = sampleTokens[0]
             if key.mode.kind == .targetOnly {
                 baselineTokens[key.batchSize] = canonicalTokens
+                baselineFinishReasons[key.batchSize] = sampleReasons[0]
             } else {
-                guard let baseline = baselineTokens[key.batchSize] else {
+                guard let baseline = baselineTokens[key.batchSize],
+                      let baselineReasons = baselineFinishReasons[key.batchSize]
+                else {
                     throw MTPBenchmarkError.missingTargetOnlyBaseline
                 }
                 for tokens in sampleTokens {
@@ -209,6 +214,18 @@ public enum MTPBenchmarkRunner {
                             batchSize: key.batchSize,
                             rows: mismatches)
                     }
+                }
+                // Identical tokens with a different terminal reason is still
+                // an OpenAI-visible behavior divergence (for example EOS
+                // exactly at the budget reported as "stop" by target-only but
+                // "length" by MTP). Parity certifies both.
+                for reasons in sampleReasons where reasons != baselineReasons {
+                    let rows = zip(reasons, baselineReasons).enumerated()
+                        .filter { $0.element.0 != $0.element.1 }
+                        .map(\.offset)
+                    throw MTPBenchmarkError.invalidMetrics(
+                        "\(key.mode.label), B=\(key.batchSize) finish reasons diverge "
+                            + "from the target-only baseline at rows \(rows)")
                 }
             }
 
@@ -544,12 +561,39 @@ public enum MTPBenchmarkRunner {
             $0.decodeRowBucket * ($0.draftDepth + 1) <= maxRectangularTokens
         }
         guard costsStayWithinLimit,
-              (metrics.serialVerificationRounds ?? 0) == 0,
-              metrics.rounds == 0 || metrics.proposedTokens > 0,
-              metrics.rounds > 0 || (metrics.rectangularVerificationRounds ?? 0) == 0
+              (metrics.serialVerificationRounds ?? 0) == 0
         else {
             throw MTPBenchmarkError.invalidMetrics(
                 "adaptive B=\(batchSize) escaped its automatic rectangular limit")
+        }
+        if metrics.rounds > 0 {
+            // Drafting after tail rows drained inside the cap: every row-round
+            // proposes at least one token and is scored by at least one
+            // rectangular batch verification (rounds count per-row finalizes;
+            // verifier counters count per-batch passes, so equality is NOT
+            // the invariant here).
+            guard metrics.proposedTokens > 0,
+                  (metrics.rectangularVerificationRounds ?? 0) > 0
+            else {
+                throw MTPBenchmarkError.invalidMetrics(
+                    "adaptive B=\(batchSize) drafted without rectangular verification evidence")
+            }
+            return true
+        }
+        // Zero rounds: nothing may have been proposed, accepted, committed,
+        // or verified. Seed steps alone remain legitimate — they are recorded
+        // at step launch, and a seed's own emitted token can terminate the
+        // request (production EOS) or the adaptive depth can drop before the
+        // planned round ever runs.
+        guard metrics.proposedTokens == 0,
+              metrics.acceptedDraftTokens == 0,
+              metrics.committedTokens == 0,
+              (metrics.rectangularVerificationRounds ?? 0) == 0,
+              metrics.acceptanceByPosition.allSatisfy({ $0 == 0 }),
+              metrics.costInputs.allSatisfy({ $0.draftDepth == 0 })
+        else {
+            throw MTPBenchmarkError.invalidMetrics(
+                "adaptive B=\(batchSize) reported speculative counters without rounds")
         }
         return true
     }
@@ -600,6 +644,11 @@ public enum MTPBenchmarkRunner {
               metrics.proposedTokens == 0,
               metrics.acceptedDraftTokens == 0,
               metrics.committedTokens == 0,
+              // Target verification with zero claimed rounds is still
+              // speculative work: an engine regression must not verify while
+              // reporting inactivity.
+              (metrics.rectangularVerificationRounds ?? 0) == 0,
+              (metrics.serialVerificationRounds ?? 0) == 0,
               metrics.acceptanceByPosition.isEmpty,
               metrics.conditionalAcceptance.isEmpty,
               metrics.skippedRows.isEmpty,

--- a/provider-swift/Sources/ProviderBenchmark/MTPBenchmarkRunner.swift
+++ b/provider-swift/Sources/ProviderBenchmark/MTPBenchmarkRunner.swift
@@ -377,7 +377,8 @@ public enum MTPBenchmarkRunner {
                 adaptiveDraftingExpected: configuration.adaptiveDraftingBatchSizes.contains(
                     key.batchSize),
                 allowedSkipReasons: configuration.allowedSkipReasons,
-                expectation: configuration.mtpExpectation)
+                expectation: configuration.mtpExpectation,
+                requireAutomaticVerification: configuration.purpose != .rawParityStress)
             await session.engine.shutdown()
             didShutdown = true
             try requireBeforeDeadline(deadlineAt)
@@ -400,13 +401,30 @@ public enum MTPBenchmarkRunner {
         batchSize: Int,
         adaptiveDraftingExpected: Bool,
         allowedSkipReasons: Set<String>,
-        expectation: MTPBenchmarkMTPExpectation = .active
+        expectation: MTPBenchmarkMTPExpectation = .active,
+        requireAutomaticVerification: Bool = false
     ) throws {
         try validateActivation(
             metrics: metrics,
             mode: mode,
             expectation: expectation,
             beforeRun: false)
+        // Production evidence certifies the PRODUCTION mechanism: every
+        // active MTP case must have run the automatic verifier with zero
+        // serial rounds (a stray DARKBLOOM_MTP_VERIFICATION_MODE in the
+        // launching shell must not certify the serial oracle). Raw parity
+        // stays mode-agnostic — it is the serial/rectangular diagnostic
+        // vehicle. Target-authoritative token/finish-reason parity against
+        // the target-only baseline is enforced unconditionally in `run`.
+        if requireAutomaticVerification, mode.requestsMTP, !expectation.expectsInactive {
+            guard metrics.verificationMode == "automatic",
+                  (metrics.serialVerificationRounds ?? 0) == 0
+            else {
+                throw MTPBenchmarkError.invalidMetrics(
+                    "\(mode.label), B=\(batchSize) production evidence requires the "
+                        + "automatic verifier (mode=\(metrics.verificationMode ?? "nil"))")
+            }
+        }
         let unexpectedSkips = Set(metrics.skippedRows.keys).subtracting(allowedSkipReasons)
         guard unexpectedSkips.isEmpty else {
             throw MTPBenchmarkError.invalidMetrics(

--- a/provider-swift/Sources/ProviderBenchmark/MTPBenchmarkRunner.swift
+++ b/provider-swift/Sources/ProviderBenchmark/MTPBenchmarkRunner.swift
@@ -43,6 +43,7 @@ public struct MTPBenchmarkConfiguration: Sendable {
     public let modes: [MTPBenchmarkMode]
     public let maxTokensPerRow: Int
     public let purpose: MTPBenchmarkPurpose
+    public let mtpExpectation: MTPBenchmarkMTPExpectation
     public let stopPolicy: MTPBenchmarkStopPolicy
     public let warmupIterations: Int
     public let measurementRepetitions: Int
@@ -63,6 +64,7 @@ public struct MTPBenchmarkConfiguration: Sendable {
         modes: [MTPBenchmarkMode] = MTPBenchmarkRunner.standardModes,
         maxTokensPerRow: Int = 64,
         purpose: MTPBenchmarkPurpose,
+        mtpExpectation: MTPBenchmarkMTPExpectation = .active,
         stopPolicy: MTPBenchmarkStopPolicy,
         warmupIterations: Int = 0,
         measurementRepetitions: Int = 1,
@@ -78,6 +80,7 @@ public struct MTPBenchmarkConfiguration: Sendable {
         self.modes = modes
         self.maxTokensPerRow = max(1, maxTokensPerRow)
         self.purpose = purpose
+        self.mtpExpectation = mtpExpectation
         self.stopPolicy = stopPolicy
         self.warmupIterations = warmupIterations
         self.measurementRepetitions = measurementRepetitions
@@ -153,6 +156,7 @@ public enum MTPBenchmarkRunner {
                 runFingerprint: configuration.runFingerprint,
                 buildConfiguration: .current,
                 purpose: configuration.purpose,
+                mtpExpectation: configuration.mtpExpectation,
                 stopPolicy: configuration.stopPolicy,
                 startedAt: startedDate,
                 completedAt: complete ? Date() : nil,
@@ -246,6 +250,16 @@ public enum MTPBenchmarkRunner {
         guard !configuration.runFingerprint.isEmpty else {
             throw MTPBenchmarkError.invalidStopPolicy("run fingerprint is empty")
         }
+        guard configuration.mtpExpectation.isWellFormed else {
+            throw MTPBenchmarkError.invalidMTPExpectation(
+                "expected-inactive mode requires a nonempty exact reason or prefix; active mode must not carry inactive reasons")
+        }
+        if configuration.purpose == .productionPerformance,
+           configuration.mtpExpectation.expectsInactive
+        {
+            throw MTPBenchmarkError.invalidMTPExpectation(
+                "production performance cannot certify expected-inactive target-only fallback")
+        }
         if configuration.purpose == .productionPerformance,
            MTPBenchmarkBuildConfiguration.current == .debug
         {
@@ -325,7 +339,11 @@ public enum MTPBenchmarkRunner {
         do {
             let before = await session.metrics()
             try requireBeforeDeadline(deadlineAt)
-            try validateActivation(metrics: before, mode: key.mode, beforeRun: true)
+            try validateActivation(
+                metrics: before,
+                mode: key.mode,
+                expectation: configuration.mtpExpectation,
+                beforeRun: true)
             let batch = try await runBatch(
                 engine: session.engine,
                 prompts: configuration.prompts,
@@ -341,7 +359,8 @@ public enum MTPBenchmarkRunner {
                 batchSize: key.batchSize,
                 adaptiveDraftingExpected: configuration.adaptiveDraftingBatchSizes.contains(
                     key.batchSize),
-                allowedSkipReasons: configuration.allowedSkipReasons)
+                allowedSkipReasons: configuration.allowedSkipReasons,
+                expectation: configuration.mtpExpectation)
             await session.engine.shutdown()
             didShutdown = true
             try requireBeforeDeadline(deadlineAt)
@@ -363,9 +382,14 @@ public enum MTPBenchmarkRunner {
         mode: MTPBenchmarkMode,
         batchSize: Int,
         adaptiveDraftingExpected: Bool,
-        allowedSkipReasons: Set<String>
+        allowedSkipReasons: Set<String>,
+        expectation: MTPBenchmarkMTPExpectation = .active
     ) throws {
-        try validateActivation(metrics: metrics, mode: mode, beforeRun: false)
+        try validateActivation(
+            metrics: metrics,
+            mode: mode,
+            expectation: expectation,
+            beforeRun: false)
         let unexpectedSkips = Set(metrics.skippedRows.keys).subtracting(allowedSkipReasons)
         guard unexpectedSkips.isEmpty else {
             throw MTPBenchmarkError.invalidMetrics(
@@ -374,11 +398,12 @@ public enum MTPBenchmarkRunner {
         let expectedBucket = decodeRowBucket(batchSize)
         switch mode.kind {
         case .targetOnly:
-            guard metrics.rounds == 0, metrics.proposedTokens == 0 else {
-                throw MTPBenchmarkError.invalidMetrics(
-                    "target-only baseline reported speculative work")
-            }
+            try validateNoSpeculativeWork(metrics, context: "target-only baseline")
         case .fixed:
+            if expectation.expectsInactive {
+                try validateNoSpeculativeWork(metrics, context: "\(mode.label), B=\(batchSize)")
+                return
+            }
             let expectedDepth = (mode.verificationWidth ?? 1) - 1
             guard observedBucket(metrics, expectedBucket: expectedBucket) else {
                 throw MTPBenchmarkError.invalidMetrics(
@@ -403,6 +428,10 @@ public enum MTPBenchmarkRunner {
                 }
             }
         case .adaptive:
+            if expectation.expectsInactive {
+                try validateNoSpeculativeWork(metrics, context: "adaptive B=\(batchSize)")
+                return
+            }
             guard observedBucket(metrics, expectedBucket: expectedBucket) else {
                 throw MTPBenchmarkError.invalidMetrics(
                     "adaptive B=\(batchSize) never observed decode-row bucket \(expectedBucket)")
@@ -433,14 +462,61 @@ public enum MTPBenchmarkRunner {
     private static func validateActivation(
         metrics: MTPBenchmarkMetrics,
         mode: MTPBenchmarkMode,
+        expectation: MTPBenchmarkMTPExpectation,
         beforeRun: Bool
     ) throws {
-        if mode.requestsMTP, !metrics.active {
-            throw MTPBenchmarkError.mtpRequestedButInactive(mode.label)
-        }
         if !mode.requestsMTP, metrics.active {
             throw MTPBenchmarkError.invalidMetrics(
                 "target-only baseline unexpectedly reported MTP active\(beforeRun ? " before execution" : "")")
+        }
+        guard mode.requestsMTP else { return }
+
+        if expectation.expectsInactive {
+            guard !metrics.active else {
+                throw MTPBenchmarkError.invalidMetrics(
+                    "\(mode.label) unexpectedly reported MTP active in expected-inactive mode\(beforeRun ? " before execution" : "")")
+            }
+            guard expectation.matchesInactiveReason(metrics.inactiveReason) else {
+                throw MTPBenchmarkError.invalidMetrics(
+                    "\(mode.label) inactive reason did not match the declared exact value or prefix")
+            }
+            try validateNoSpeculativeWork(
+                metrics,
+                context: "\(mode.label) expected-inactive metrics\(beforeRun ? " before execution" : "")")
+        } else {
+            guard metrics.active else {
+                let detail = metrics.inactiveReason ?? "missing inactive reason"
+                throw MTPBenchmarkError.mtpRequestedButInactive(
+                    "\(mode.label) (\(detail))")
+            }
+            guard metrics.inactiveReason == nil else {
+                throw MTPBenchmarkError.invalidMetrics(
+                    "\(mode.label) reported active MTP with an inactive reason")
+            }
+        }
+    }
+
+    private static func validateNoSpeculativeWork(
+        _ metrics: MTPBenchmarkMetrics,
+        context: String
+    ) throws {
+        guard metrics.rounds == 0,
+              metrics.seedRows == 0,
+              metrics.proposedTokens == 0,
+              metrics.acceptedDraftTokens == 0,
+              metrics.committedTokens == 0,
+              metrics.acceptanceByPosition.isEmpty,
+              metrics.conditionalAcceptance.isEmpty,
+              metrics.skippedRows.isEmpty,
+              metrics.depthSelections.isEmpty,
+              metrics.controllerFallbacks.isEmpty,
+              metrics.costInputs.isEmpty,
+              metrics.totalRoundWallTimeNanos == nil,
+              metrics.assistantTimeNanos == nil,
+              metrics.targetVerifyTimeNanos == nil
+        else {
+            throw MTPBenchmarkError.invalidMetrics(
+                "\(context) reported speculative work")
         }
     }
 

--- a/provider-swift/Sources/ProviderBenchmark/MTPBenchmarkRunner.swift
+++ b/provider-swift/Sources/ProviderBenchmark/MTPBenchmarkRunner.swift
@@ -1,0 +1,792 @@
+import Foundation
+import MLXLMCommon
+import ProviderCore
+
+public struct MTPBenchmarkPrompt: Sendable {
+    public let name: String
+    public let tokenIDs: [Int]
+
+    public init(name: String, tokenIDs: [Int]) {
+        self.name = name
+        self.tokenIDs = tokenIDs
+    }
+}
+
+public struct MTPBenchmarkSession: Sendable {
+    public let engine: any CBv2Engine
+    private let metricsProvider: @Sendable () async -> MTPBenchmarkMetrics
+
+    public init(
+        engine: any CBv2Engine,
+        metrics: @escaping @Sendable () async -> MTPBenchmarkMetrics
+    ) {
+        self.engine = engine
+        self.metricsProvider = metrics
+    }
+
+    public func metrics() async -> MTPBenchmarkMetrics { await metricsProvider() }
+}
+
+public struct MTPBenchmarkSessionFactory: Sendable {
+    public let make: @Sendable (MTPBenchmarkMode, Int) async throws -> MTPBenchmarkSession
+
+    public init(
+        make: @escaping @Sendable (MTPBenchmarkMode, Int) async throws -> MTPBenchmarkSession
+    ) {
+        self.make = make
+    }
+}
+
+public struct MTPBenchmarkConfiguration: Sendable {
+    public let prompts: [MTPBenchmarkPrompt]
+    public let batchSizes: [Int]
+    public let modes: [MTPBenchmarkMode]
+    public let maxTokensPerRow: Int
+    public let purpose: MTPBenchmarkPurpose
+    public let stopPolicy: MTPBenchmarkStopPolicy
+    public let warmupIterations: Int
+    public let measurementRepetitions: Int
+    public let modeOrderSeed: UInt64
+    public let adaptiveDraftingBatchSizes: Set<Int>
+    public let allowedSkipReasons: Set<String>
+    public let runFingerprint: String
+    public let checkpointDestination: MTPBenchmarkReportDestination?
+    /// Elapsed run budget checked around factory creation, submission,
+    /// consumption, and shutdown. Synchronous MLX calls are not safely
+    /// preemptible, so env-gated live tests additionally require the external
+    /// process-group supervisor in scripts/run-mtp-benchmark.py.
+    public let deadline: Duration
+
+    public init(
+        prompts: [MTPBenchmarkPrompt],
+        batchSizes: [Int] = [1, 2, 4, 8],
+        modes: [MTPBenchmarkMode] = MTPBenchmarkRunner.standardModes,
+        maxTokensPerRow: Int = 64,
+        purpose: MTPBenchmarkPurpose,
+        stopPolicy: MTPBenchmarkStopPolicy,
+        warmupIterations: Int = 0,
+        measurementRepetitions: Int = 1,
+        modeOrderSeed: UInt64 = 0x4d545032,
+        adaptiveDraftingBatchSizes: Set<Int>? = nil,
+        allowedSkipReasons: Set<String> = [],
+        runFingerprint: String = UUID().uuidString,
+        checkpointDestination: MTPBenchmarkReportDestination? = nil,
+        deadline: Duration = .seconds(3600)
+    ) {
+        self.prompts = prompts
+        self.batchSizes = batchSizes
+        self.modes = modes
+        self.maxTokensPerRow = max(1, maxTokensPerRow)
+        self.purpose = purpose
+        self.stopPolicy = stopPolicy
+        self.warmupIterations = warmupIterations
+        self.measurementRepetitions = measurementRepetitions
+        self.modeOrderSeed = modeOrderSeed
+        self.adaptiveDraftingBatchSizes = adaptiveDraftingBatchSizes ?? Set(batchSizes)
+        self.allowedSkipReasons = allowedSkipReasons
+        self.runFingerprint = runFingerprint
+        self.checkpointDestination = checkpointDestination
+        self.deadline = deadline
+    }
+}
+
+public enum MTPBenchmarkRunner {
+    public static let standardModes: [MTPBenchmarkMode] = {
+        var modes: [MTPBenchmarkMode] = [.targetOnly]
+        modes.append(contentsOf: (1...8).map {
+            MTPBenchmarkMode(kind: .fixed, verificationWidth: $0)
+        })
+        modes.append(.adaptive)
+        return modes
+    }()
+
+    private struct CaseKey: Hashable, Sendable {
+        let mode: MTPBenchmarkMode
+        let batchSize: Int
+    }
+
+    private struct MeasuredRow: Sendable {
+        let promptName: String
+        let tokenIDs: [Int]
+        let tokenTimestampsNanoseconds: [UInt64]
+        let timing: MTPBenchmarkStreamTiming
+        let finishReason: String
+    }
+
+    private struct BatchMeasurement: Sendable {
+        let rows: [MeasuredRow]
+        let aggregateDecodeTokensPerSecond: Double
+    }
+
+    private struct CaseSample: Sendable {
+        let batch: BatchMeasurement
+        let metrics: MTPBenchmarkMetrics
+    }
+
+    private enum BatchTaskResult: Sendable {
+        case row(Int, MeasuredRow)
+    }
+
+    public static func run(
+        target: MTPBenchmarkArtifactFacts,
+        assistant: MTPBenchmarkArtifactFacts,
+        hardware: MTPBenchmarkHardware,
+        configuration: MTPBenchmarkConfiguration,
+        sessions: MTPBenchmarkSessionFactory
+    ) async throws -> MTPBenchmarkReport {
+        let startedAt = ContinuousClock.now
+        let startedDate = Date()
+        try validate(configuration)
+        try validateArtifactBoundary(target, label: "target")
+        try validateArtifactBoundary(assistant, label: "assistant")
+
+        let deadlineAt = startedAt + configuration.deadline
+        let coverage = MTPBenchmarkCoverage.shortContextMatrix(
+            target: target, assistant: assistant, purpose: configuration.purpose)
+        let orderedCases = caseOrder(configuration: configuration)
+        let tokenEvidenceSalt = MTPBenchmarkDigest.randomSalt()
+        var results: [MTPBenchmarkCaseResult] = []
+        var baselineTokens: [Int: [[Int]]] = [:]
+
+        func report(complete: Bool) -> MTPBenchmarkReport {
+            MTPBenchmarkReport(
+                runFingerprint: configuration.runFingerprint,
+                buildConfiguration: .current,
+                purpose: configuration.purpose,
+                stopPolicy: configuration.stopPolicy,
+                startedAt: startedDate,
+                completedAt: complete ? Date() : nil,
+                complete: complete,
+                expectedCaseCount: orderedCases.count,
+                target: target,
+                assistant: assistant,
+                hardware: hardware,
+                maxTokensPerRow: configuration.maxTokensPerRow,
+                warmupIterations: configuration.warmupIterations,
+                measurementRepetitions: configuration.measurementRepetitions,
+                modeOrderSeed: configuration.modeOrderSeed,
+                coverage: coverage,
+                elapsedMs: milliseconds(ContinuousClock.now - startedAt),
+                cases: results)
+        }
+
+        for key in orderedCases {
+            try requireBeforeDeadline(deadlineAt)
+            for _ in 0..<configuration.warmupIterations {
+                _ = try await runSample(
+                    key: key,
+                    configuration: configuration,
+                    deadlineAt: deadlineAt,
+                    sessions: sessions)
+            }
+            var samples: [CaseSample] = []
+            for _ in 0..<configuration.measurementRepetitions {
+                samples.append(try await runSample(
+                    key: key,
+                    configuration: configuration,
+                    deadlineAt: deadlineAt,
+                    sessions: sessions))
+            }
+            try validateRepetitionConsistency(samples, key: key)
+
+            let sampleTokens = samples.map { $0.batch.rows.map(\.tokenIDs) }
+            let canonicalTokens = sampleTokens[0]
+            if key.mode.kind == .targetOnly {
+                baselineTokens[key.batchSize] = canonicalTokens
+            } else {
+                guard let baseline = baselineTokens[key.batchSize] else {
+                    throw MTPBenchmarkError.missingTargetOnlyBaseline
+                }
+                for tokens in sampleTokens {
+                    let mismatches = parityMismatches(baseline: baseline, candidate: tokens)
+                    guard mismatches.isEmpty, baseline.count == tokens.count else {
+                        throw MTPBenchmarkError.tokenParityMismatch(
+                            mode: key.mode.label,
+                            batchSize: key.batchSize,
+                            rows: mismatches)
+                    }
+                }
+            }
+
+            results.append(aggregate(
+                samples: samples,
+                key: key,
+                performanceEligible: configuration.purpose.performanceEligible,
+                tokenEvidenceSalt: tokenEvidenceSalt))
+            if let checkpointDestination = configuration.checkpointDestination {
+                try requireBeforeDeadline(deadlineAt)
+                try report(complete: false).write(to: checkpointDestination)
+                try requireBeforeDeadline(deadlineAt)
+            }
+        }
+
+        try requireBeforeDeadline(deadlineAt)
+        try validateArtifactBoundary(target, label: "target")
+        try validateArtifactBoundary(assistant, label: "assistant")
+        let final = report(complete: true)
+        if let checkpointDestination = configuration.checkpointDestination {
+            try final.write(to: checkpointDestination)
+            try requireBeforeDeadline(deadlineAt)
+        }
+        return final
+    }
+
+    private static func validate(_ configuration: MTPBenchmarkConfiguration) throws {
+        guard !configuration.prompts.isEmpty else { throw MTPBenchmarkError.emptyPromptCorpus }
+        guard configuration.modes.contains(.targetOnly) else {
+            throw MTPBenchmarkError.missingTargetOnlyBaseline
+        }
+        guard configuration.warmupIterations >= 0 else {
+            throw MTPBenchmarkError.invalidWarmupIterations(configuration.warmupIterations)
+        }
+        guard configuration.measurementRepetitions > 0 else {
+            throw MTPBenchmarkError.invalidMeasurementRepetitions(
+                configuration.measurementRepetitions)
+        }
+        guard !configuration.runFingerprint.isEmpty else {
+            throw MTPBenchmarkError.invalidStopPolicy("run fingerprint is empty")
+        }
+        if configuration.purpose == .productionPerformance,
+           MTPBenchmarkBuildConfiguration.current == .debug
+        {
+            throw MTPBenchmarkError.invalidBuildConfiguration(
+                "production performance requires a release build")
+        }
+        for batchSize in configuration.batchSizes where batchSize <= 0 {
+            throw MTPBenchmarkError.invalidBatchSize(batchSize)
+        }
+        guard Set(configuration.batchSizes).count == configuration.batchSizes.count else {
+            throw MTPBenchmarkError.invalidBatchSize(-1)
+        }
+        guard Set(configuration.modes).count == configuration.modes.count else {
+            throw MTPBenchmarkError.invalidVerificationWidth(-1)
+        }
+        for mode in configuration.modes where mode.kind == .fixed {
+            guard let width = mode.verificationWidth, (1...8).contains(width) else {
+                throw MTPBenchmarkError.invalidVerificationWidth(mode.verificationWidth ?? -1)
+            }
+        }
+        switch (configuration.purpose, configuration.stopPolicy.kind) {
+        case (.rawParityStress, .rawFixedLengthNoStop):
+            guard configuration.stopPolicy.stopTokenIDs.isEmpty else {
+                throw MTPBenchmarkError.invalidStopPolicy(
+                    "raw parity must not carry stop token IDs")
+            }
+        case (.productionCorrectness, .productionTargetEOS),
+             (.productionPerformance, .productionTargetEOS):
+            guard !configuration.stopPolicy.stopTokenIDs.isEmpty else {
+                throw MTPBenchmarkError.invalidStopPolicy(
+                    "production runs require the target EOS/stop token IDs")
+            }
+        default:
+            throw MTPBenchmarkError.invalidStopPolicy(
+                "purpose \(configuration.purpose.rawValue) does not match \(configuration.stopPolicy.kind.rawValue)")
+        }
+    }
+
+    private static func caseOrder(
+        configuration: MTPBenchmarkConfiguration
+    ) -> [CaseKey] {
+        var generator = SeededGenerator(seed: configuration.modeOrderSeed)
+        var baselines = configuration.batchSizes.map {
+            CaseKey(mode: .targetOnly, batchSize: $0)
+        }
+        baselines.seededShuffle(using: &generator)
+        var candidates = configuration.modes
+            .filter { $0.kind != .targetOnly }
+            .flatMap { mode in
+                configuration.batchSizes.map { CaseKey(mode: mode, batchSize: $0) }
+            }
+        candidates.seededShuffle(using: &generator)
+        return baselines + candidates
+    }
+
+    private static func runSample(
+        key: CaseKey,
+        configuration: MTPBenchmarkConfiguration,
+        deadlineAt: ContinuousClock.Instant,
+        sessions: MTPBenchmarkSessionFactory
+    ) async throws -> CaseSample {
+        try requireBeforeDeadline(deadlineAt)
+        let session: MTPBenchmarkSession
+        do {
+            session = try await sessions.make(key.mode, key.batchSize)
+        } catch {
+            if ContinuousClock.now >= deadlineAt {
+                throw MTPBenchmarkError.deadlineExceeded
+            }
+            throw error
+        }
+        if ContinuousClock.now >= deadlineAt {
+            await session.engine.shutdown()
+            throw MTPBenchmarkError.deadlineExceeded
+        }
+        var didShutdown = false
+        do {
+            let before = await session.metrics()
+            try requireBeforeDeadline(deadlineAt)
+            try validateActivation(metrics: before, mode: key.mode, beforeRun: true)
+            let batch = try await runBatch(
+                engine: session.engine,
+                prompts: configuration.prompts,
+                batchSize: key.batchSize,
+                maxTokens: configuration.maxTokensPerRow,
+                stopPolicy: configuration.stopPolicy,
+                deadlineAt: deadlineAt)
+            let metrics = await session.metrics()
+            try requireBeforeDeadline(deadlineAt)
+            try validateMetrics(
+                metrics,
+                mode: key.mode,
+                batchSize: key.batchSize,
+                adaptiveDraftingExpected: configuration.adaptiveDraftingBatchSizes.contains(
+                    key.batchSize),
+                allowedSkipReasons: configuration.allowedSkipReasons)
+            await session.engine.shutdown()
+            didShutdown = true
+            try requireBeforeDeadline(deadlineAt)
+            return CaseSample(batch: batch, metrics: metrics)
+        } catch {
+            let primaryError = error
+            if !didShutdown {
+                await session.engine.shutdown()
+            }
+            if ContinuousClock.now >= deadlineAt {
+                throw MTPBenchmarkError.deadlineExceeded
+            }
+            throw primaryError
+        }
+    }
+
+    static func validateMetrics(
+        _ metrics: MTPBenchmarkMetrics,
+        mode: MTPBenchmarkMode,
+        batchSize: Int,
+        adaptiveDraftingExpected: Bool,
+        allowedSkipReasons: Set<String>
+    ) throws {
+        try validateActivation(metrics: metrics, mode: mode, beforeRun: false)
+        let unexpectedSkips = Set(metrics.skippedRows.keys).subtracting(allowedSkipReasons)
+        guard unexpectedSkips.isEmpty else {
+            throw MTPBenchmarkError.invalidMetrics(
+                "\(mode.label), B=\(batchSize) reported unapproved skips \(unexpectedSkips.sorted())")
+        }
+        let expectedBucket = decodeRowBucket(batchSize)
+        switch mode.kind {
+        case .targetOnly:
+            guard metrics.rounds == 0, metrics.proposedTokens == 0 else {
+                throw MTPBenchmarkError.invalidMetrics(
+                    "target-only baseline reported speculative work")
+            }
+        case .fixed:
+            let expectedDepth = (mode.verificationWidth ?? 1) - 1
+            guard observedBucket(metrics, expectedBucket: expectedBucket) else {
+                throw MTPBenchmarkError.invalidMetrics(
+                    "\(mode.label), B=\(batchSize) never observed decode-row bucket \(expectedBucket)")
+            }
+            guard metrics.depthSelections[String(expectedDepth), default: 0] > 0 else {
+                throw MTPBenchmarkError.invalidMetrics(
+                    "\(mode.label), B=\(batchSize) never selected requested depth \(expectedDepth)")
+            }
+            if expectedDepth > 0 {
+                guard metrics.rounds > 0, metrics.proposedTokens > 0 else {
+                    throw MTPBenchmarkError.invalidMetrics(
+                        "\(mode.label), B=\(batchSize) did not execute active draft rounds")
+                }
+                guard metrics.costInputs.contains(where: {
+                    $0.decodeRowBucket == expectedBucket
+                        && $0.draftDepth == expectedDepth
+                        && $0.sampleCount > 0
+                }) else {
+                    throw MTPBenchmarkError.invalidMetrics(
+                        "\(mode.label), B=\(batchSize) did not measure requested depth/bucket")
+                }
+            }
+        case .adaptive:
+            guard observedBucket(metrics, expectedBucket: expectedBucket) else {
+                throw MTPBenchmarkError.invalidMetrics(
+                    "adaptive B=\(batchSize) never observed decode-row bucket \(expectedBucket)")
+            }
+            if adaptiveDraftingExpected {
+                guard metrics.rounds > 0, metrics.proposedTokens > 0 else {
+                    throw MTPBenchmarkError.invalidMetrics(
+                        "adaptive B=\(batchSize) was expected to draft but did not")
+                }
+                guard metrics.depthSelections.contains(where: {
+                    (Int($0.key) ?? 0) > 0 && $0.value > 0
+                }) else {
+                    throw MTPBenchmarkError.invalidMetrics(
+                        "adaptive B=\(batchSize) never selected a nonzero depth")
+                }
+                guard metrics.costInputs.contains(where: {
+                    $0.decodeRowBucket == expectedBucket
+                        && $0.draftDepth > 0
+                        && $0.sampleCount > 0
+                }) else {
+                    throw MTPBenchmarkError.invalidMetrics(
+                        "adaptive B=\(batchSize) lacks positive-depth cost evidence for requested bucket \(expectedBucket)")
+                }
+            }
+        }
+    }
+
+    private static func validateActivation(
+        metrics: MTPBenchmarkMetrics,
+        mode: MTPBenchmarkMode,
+        beforeRun: Bool
+    ) throws {
+        if mode.requestsMTP, !metrics.active {
+            throw MTPBenchmarkError.mtpRequestedButInactive(mode.label)
+        }
+        if !mode.requestsMTP, metrics.active {
+            throw MTPBenchmarkError.invalidMetrics(
+                "target-only baseline unexpectedly reported MTP active\(beforeRun ? " before execution" : "")")
+        }
+    }
+
+    private static func observedBucket(
+        _ metrics: MTPBenchmarkMetrics,
+        expectedBucket: Int
+    ) -> Bool {
+        metrics.decodeRowBucket == expectedBucket
+            || metrics.costInputs.contains { $0.decodeRowBucket == expectedBucket }
+    }
+
+    private static func decodeRowBucket(_ rows: Int) -> Int {
+        var bucket = 1
+        while bucket < rows { bucket *= 2 }
+        return bucket
+    }
+
+    private static func runBatch(
+        engine: any CBv2Engine,
+        prompts: [MTPBenchmarkPrompt],
+        batchSize: Int,
+        maxTokens: Int,
+        stopPolicy: MTPBenchmarkStopPolicy,
+        deadlineAt: ContinuousClock.Instant
+    ) async throws -> BatchMeasurement {
+        let origin = ContinuousClock.now
+        var submissions: [(
+            row: Int,
+            requestID: UInt64,
+            prompt: MTPBenchmarkPrompt,
+            submittedAtNanoseconds: UInt64,
+            stream: AsyncStream<CBv2Event>
+        )] = []
+        do {
+            // Submit every stream before starting any consumer so scheduler
+            // membership and decode-row buckets are reproducible.
+            for row in 0..<batchSize {
+                try requireBeforeDeadline(deadlineAt)
+                let prompt = prompts[row % prompts.count]
+                let requestID = UInt64(row + 1)
+                let submittedAt = ContinuousClock.now
+                let stream = try engine.submit(CBv2Request(
+                    id: CBv2RequestID(requestID),
+                    promptTokens: prompt.tokenIDs,
+                    sampling: CBv2SamplingParams(temperature: 0),
+                    maxTokens: maxTokens,
+                    stopTokens: Set(stopPolicy.stopTokenIDs)))
+                submissions.append((
+                    row: row,
+                    requestID: requestID,
+                    prompt: prompt,
+                    submittedAtNanoseconds: nanoseconds(submittedAt - origin),
+                    stream: stream))
+                try requireBeforeDeadline(deadlineAt)
+            }
+        } catch {
+            for submission in submissions {
+                engine.cancel(CBv2RequestID(submission.requestID))
+            }
+            if ContinuousClock.now >= deadlineAt {
+                throw MTPBenchmarkError.deadlineExceeded
+            }
+            throw error
+        }
+
+        let requestIDs = submissions.map(\.requestID)
+        do {
+            let rows = try await withThrowingTaskGroup(
+                of: BatchTaskResult.self,
+                returning: [MeasuredRow].self
+            ) { group in
+                for submission in submissions {
+                    group.addTask {
+                        .row(submission.row, try await consume(
+                            stream: submission.stream,
+                            row: submission.row,
+                            prompt: submission.prompt,
+                            submittedAtNanoseconds: submission.submittedAtNanoseconds,
+                            origin: origin,
+                            maxTokens: maxTokens,
+                            stopPolicy: stopPolicy))
+                    }
+                }
+                group.addTask {
+                    let now = ContinuousClock.now
+                    if now < deadlineAt {
+                        try await taskSleep(deadlineAt - now)
+                    }
+                    for requestID in requestIDs {
+                        engine.cancel(CBv2RequestID(requestID))
+                    }
+                    throw MTPBenchmarkError.deadlineExceeded
+                }
+
+                var ordered = Array<MeasuredRow?>(repeating: nil, count: batchSize)
+                var received = 0
+                while received < batchSize, let result = try await group.next() {
+                    switch result {
+                    case .row(let row, let value):
+                        ordered[row] = value
+                        received += 1
+                    }
+                }
+                group.cancelAll()
+                return ordered.compactMap { $0 }
+            }
+            guard rows.count == batchSize else {
+                throw MTPBenchmarkError.inconsistentRepetition(
+                    "received \(rows.count) rows for B=\(batchSize)")
+            }
+            return BatchMeasurement(
+                rows: rows,
+                aggregateDecodeTokensPerSecond:
+                    try MTPBenchmarkTiming.aggregateDecodeTokensPerSecond(
+                        tokenTimestampsNanoseconds: rows.map(\.tokenTimestampsNanoseconds)))
+        } catch {
+            for submission in submissions {
+                engine.cancel(CBv2RequestID(submission.requestID))
+            }
+            if ContinuousClock.now >= deadlineAt {
+                throw MTPBenchmarkError.deadlineExceeded
+            }
+            throw error
+        }
+    }
+
+    private static func consume(
+        stream: AsyncStream<CBv2Event>,
+        row: Int,
+        prompt: MTPBenchmarkPrompt,
+        submittedAtNanoseconds: UInt64,
+        origin: ContinuousClock.Instant,
+        maxTokens: Int,
+        stopPolicy: MTPBenchmarkStopPolicy
+    ) async throws -> MeasuredRow {
+        var tokens: [Int] = []
+        var tokenTimestamps: [UInt64] = []
+        var finishReason: String?
+        for await event in stream {
+            switch event {
+            case .delta(_, let emitted, _):
+                guard finishReason == nil else {
+                    throw MTPBenchmarkError.unsuccessfulTerminal(
+                        row: row, reason: "delta_after_terminal")
+                }
+                let timestamp = nanoseconds(ContinuousClock.now - origin)
+                tokens.append(contentsOf: emitted)
+                tokenTimestamps.append(
+                    contentsOf: repeatElement(timestamp, count: emitted.count))
+            case .finished(let reason, let usage):
+                guard finishReason == nil else {
+                    throw MTPBenchmarkError.unsuccessfulTerminal(
+                        row: row, reason: "duplicate_terminal")
+                }
+                guard usage.completionTokens == tokens.count else {
+                    throw MTPBenchmarkError.unsuccessfulTerminal(
+                        row: row, reason: "usage_count_mismatch")
+                }
+                switch reason {
+                case .cancelled:
+                    throw MTPBenchmarkError.unsuccessfulTerminal(
+                        row: row, reason: "cancelled")
+                case .error:
+                    throw MTPBenchmarkError.unsuccessfulTerminal(
+                        row: row, reason: "engine_error")
+                case .stop:
+                    finishReason = "stop"
+                case .length:
+                    finishReason = "length"
+                }
+            }
+        }
+        guard let finishReason else {
+            throw MTPBenchmarkError.missingTerminalEvent(row: row)
+        }
+        guard !tokens.isEmpty else { throw MTPBenchmarkError.emptyTokenStream(row: row) }
+        switch stopPolicy.kind {
+        case .rawFixedLengthNoStop:
+            guard finishReason == "length", tokens.count == maxTokens else {
+                throw MTPBenchmarkError.unexpectedTerminal(
+                    row: row,
+                    condition: "raw fixed-length completion")
+            }
+        case .productionTargetEOS:
+            guard finishReason == "stop" || finishReason == "length" else {
+                throw MTPBenchmarkError.unexpectedTerminal(
+                    row: row,
+                    condition: "production terminal reason")
+            }
+            if finishReason == "stop" {
+                guard let finalToken = tokens.last,
+                      stopPolicy.stopTokenIDs.contains(finalToken)
+                else {
+                    throw MTPBenchmarkError.unexpectedTerminal(
+                        row: row,
+                        condition: "production stop membership")
+                }
+            }
+        }
+        let timing = try MTPBenchmarkTiming.stream(
+            submittedAtNanoseconds: submittedAtNanoseconds,
+            tokenTimestampsNanoseconds: tokenTimestamps)
+        return MeasuredRow(
+            promptName: prompt.name,
+            tokenIDs: tokens,
+            tokenTimestampsNanoseconds: tokenTimestamps,
+            timing: timing,
+            finishReason: finishReason)
+    }
+
+    private static func validateRepetitionConsistency(
+        _ samples: [CaseSample],
+        key: CaseKey
+    ) throws {
+        guard let first = samples.first else {
+            throw MTPBenchmarkError.invalidMeasurementRepetitions(0)
+        }
+        let expected = first.batch.rows.map { ($0.promptName, $0.tokenIDs, $0.finishReason) }
+        for sample in samples.dropFirst() {
+            let actual = sample.batch.rows.map { ($0.promptName, $0.tokenIDs, $0.finishReason) }
+            guard actual.elementsEqual(expected, by: {
+                $0.0 == $1.0 && $0.1 == $1.1 && $0.2 == $1.2
+            }) else {
+                throw MTPBenchmarkError.inconsistentRepetition(
+                    "\(key.mode.label), B=\(key.batchSize) changed tokens, prompts, or terminal reason")
+            }
+        }
+    }
+
+    private static func aggregate(
+        samples: [CaseSample],
+        key: CaseKey,
+        performanceEligible: Bool,
+        tokenEvidenceSalt: Data
+    ) -> MTPBenchmarkCaseResult {
+        let sortedSamples = samples.sorted {
+            $0.batch.aggregateDecodeTokensPerSecond < $1.batch.aggregateDecodeTokensPerSecond
+        }
+        let representative = sortedSamples[(sortedSamples.count - 1) / 2]
+        let rowCount = representative.batch.rows.count
+        let rows = (0..<rowCount).map { row -> MTPBenchmarkRowResult in
+            let source = representative.batch.rows[row]
+            return MTPBenchmarkRowResult(
+                promptName: source.promptName,
+                tokenCount: source.tokenIDs.count,
+                opaqueTokenDigest: MTPBenchmarkDigest.opaqueTokenDigest(
+                    tokenIDs: source.tokenIDs,
+                    salt: tokenEvidenceSalt),
+                timeToFirstTokenMs: performanceEligible
+                    ? median(samples.map { $0.batch.rows[row].timing.timeToFirstTokenMs })
+                    : nil,
+                interTokenLatencyMs: performanceEligible
+                    ? median(samples.map { $0.batch.rows[row].timing.interTokenLatencyMs })
+                    : nil,
+                decodeTokensPerSecond: performanceEligible
+                    ? median(samples.map { $0.batch.rows[row].timing.decodeTokensPerSecond })
+                    : nil,
+                lastTokenLatencyMs: performanceEligible
+                    ? median(samples.map { $0.batch.rows[row].timing.lastTokenLatencyMs })
+                    : nil,
+                finishReason: source.finishReason)
+        }
+        return MTPBenchmarkCaseResult(
+            mode: key.mode,
+            batchSize: key.batchSize,
+            measurementRepetitions: samples.count,
+            medianAggregateDecodeTokensPerSecond: performanceEligible
+                ? median(samples.map { $0.batch.aggregateDecodeTokensPerSecond })
+                : nil,
+            tokenParity: true,
+            parityMismatchRows: [],
+            rows: rows,
+            metrics: representative.metrics)
+    }
+
+    private static func parityMismatches(
+        baseline: [[Int]], candidate: [[Int]]
+    ) -> [Int] {
+        let count = max(baseline.count, candidate.count)
+        return (0..<count).filter { row in
+            guard row < baseline.count, row < candidate.count else { return true }
+            return baseline[row] != candidate[row]
+        }
+    }
+
+    private static func validateArtifactBoundary(
+        _ artifact: MTPBenchmarkArtifactFacts,
+        label: String
+    ) throws {
+        guard artifact.hasVerifiableProvenance else { return }
+        try MTPBenchmarkModelFacts.validateUnchanged(artifact, label: label)
+    }
+
+    private static func median(_ values: [Double]) -> Double {
+        let sorted = values.sorted()
+        let middle = sorted.count / 2
+        if sorted.count.isMultiple(of: 2) {
+            return (sorted[middle - 1] + sorted[middle]) / 2
+        }
+        return sorted[middle]
+    }
+
+    static func milliseconds(_ duration: Duration) -> Double {
+        Double(duration.components.seconds) * 1000
+            + Double(duration.components.attoseconds) / 1e15
+    }
+
+    private static func requireBeforeDeadline(
+        _ deadlineAt: ContinuousClock.Instant
+    ) throws {
+        guard ContinuousClock.now < deadlineAt else {
+            throw MTPBenchmarkError.deadlineExceeded
+        }
+    }
+
+    private static func nanoseconds(_ duration: Duration) -> UInt64 {
+        let components = duration.components
+        guard components.seconds >= 0, components.attoseconds >= 0 else { return 0 }
+        let seconds = UInt64(components.seconds)
+        let nanos = UInt64(components.attoseconds / 1_000_000_000)
+        return seconds.multipliedReportingOverflow(by: 1_000_000_000).partialValue &+ nanos
+    }
+}
+
+private struct SeededGenerator: RandomNumberGenerator {
+    private var state: UInt64
+
+    init(seed: UInt64) {
+        state = seed &+ 0x9e3779b97f4a7c15
+    }
+
+    mutating func next() -> UInt64 {
+        state &+= 0x9e3779b97f4a7c15
+        var value = state
+        value = (value ^ (value >> 30)) &* 0xbf58476d1ce4e5b9
+        value = (value ^ (value >> 27)) &* 0x94d049bb133111eb
+        return value ^ (value >> 31)
+    }
+}
+
+private extension Array {
+    mutating func seededShuffle(using generator: inout SeededGenerator) {
+        guard count > 1 else { return }
+        for index in stride(from: count - 1, through: 1, by: -1) {
+            let other = Int(generator.next() % UInt64(index + 1))
+            if index != other { swapAt(index, other) }
+        }
+    }
+}

--- a/provider-swift/Sources/ProviderBenchmark/MTPBenchmarkRunner.swift
+++ b/provider-swift/Sources/ProviderBenchmark/MTPBenchmarkRunner.swift
@@ -850,6 +850,14 @@ public enum MTPBenchmarkRunner {
                     row: row,
                     condition: "production terminal reason")
             }
+            // No terminal may exceed the requested budget: an engine that
+            // overshoots maxTokens before its EOS violates the OpenAI-visible
+            // limit even when both sessions overshoot identically.
+            guard tokens.count <= maxTokens else {
+                throw MTPBenchmarkError.unexpectedTerminal(
+                    row: row,
+                    condition: "production terminal within maxTokens")
+            }
             if finishReason == "stop" {
                 guard let finalToken = tokens.last,
                       stopPolicy.stopTokenIDs.contains(finalToken)

--- a/provider-swift/Sources/ProviderBenchmark/MTPBenchmarkSizing.swift
+++ b/provider-swift/Sources/ProviderBenchmark/MTPBenchmarkSizing.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+/// Exact benchmark-side mirror of SpecDecLimits.residentEstimate. ProviderCore
+/// does not expose that helper publicly, so a drift test pins the two formulas.
+public enum MTPBenchmarkSizing {
+    public static let assistantResidentMultiplier = 1.20
+
+    public static func assistantResidentBytes(artifactBytes: UInt64) -> UInt64 {
+        guard artifactBytes > 0 else { return 0 }
+        let estimate = (Double(artifactBytes) * assistantResidentMultiplier).rounded(.up)
+        guard estimate.isFinite, estimate < Double(UInt64.max) else { return .max }
+        return UInt64(estimate)
+    }
+
+    public static func assistantResidentBytes(
+        artifact: MTPBenchmarkArtifactFacts
+    ) -> UInt64 {
+        assistantResidentBytes(artifactBytes: UInt64(max(0, artifact.artifactBytes)))
+    }
+
+    /// Total resident model weights handed to `UnifiedMemoryCap`. Assistant
+    /// memory is model residency, not an operator/OS reserve.
+    public static func totalResidentWeightBytes(
+        targetWeightBytes: Int,
+        assistant: MTPBenchmarkArtifactFacts
+    ) -> UInt64 {
+        let target = UInt64(max(0, targetWeightBytes))
+        let value = target.addingReportingOverflow(assistantResidentBytes(artifact: assistant))
+        return value.overflow ? .max : value.partialValue
+    }
+}

--- a/provider-swift/Sources/ProviderBenchmark/MTPBenchmarkTiming.swift
+++ b/provider-swift/Sources/ProviderBenchmark/MTPBenchmarkTiming.swift
@@ -1,0 +1,84 @@
+import Foundation
+
+public struct MTPBenchmarkStreamTiming: Equatable, Sendable {
+    public let timeToFirstTokenMs: Double
+    public let interTokenLatencyMs: Double
+    public let decodeTokensPerSecond: Double
+    public let lastTokenLatencyMs: Double
+
+    public init(
+        timeToFirstTokenMs: Double,
+        interTokenLatencyMs: Double,
+        decodeTokensPerSecond: Double,
+        lastTokenLatencyMs: Double
+    ) {
+        self.timeToFirstTokenMs = timeToFirstTokenMs
+        self.interTokenLatencyMs = interTokenLatencyMs
+        self.decodeTokensPerSecond = decodeTokensPerSecond
+        self.lastTokenLatencyMs = lastTokenLatencyMs
+    }
+}
+
+public enum MTPBenchmarkTiming {
+    /// Pure nanosecond-based timing used by both the live runner and
+    /// deterministic unit tests. Throughput uses N-1 decode intervals and the
+    /// last token timestamp, never terminal-event delivery.
+    public static func stream(
+        submittedAtNanoseconds: UInt64,
+        tokenTimestampsNanoseconds: [UInt64]
+    ) throws -> MTPBenchmarkStreamTiming {
+        guard let first = tokenTimestampsNanoseconds.first,
+              let last = tokenTimestampsNanoseconds.last
+        else { throw MTPBenchmarkError.invalidTokenTimeline("no token timestamps") }
+        guard first >= submittedAtNanoseconds else {
+            throw MTPBenchmarkError.invalidTokenTimeline("first token predates submission")
+        }
+        for (previous, next) in zip(
+            tokenTimestampsNanoseconds, tokenTimestampsNanoseconds.dropFirst())
+        where next < previous {
+            throw MTPBenchmarkError.invalidTokenTimeline(
+                "token timestamps are not monotonic: \(previous) then \(next)")
+        }
+
+        let decodeIntervals = tokenTimestampsNanoseconds.count - 1
+        let decodeNanoseconds = last - first
+        let itlMs = decodeIntervals > 0
+            ? milliseconds(decodeNanoseconds) / Double(decodeIntervals)
+            : 0
+        let decodeTPS = decodeIntervals > 0 && decodeNanoseconds > 0
+            ? Double(decodeIntervals) / (Double(decodeNanoseconds) / 1_000_000_000)
+            : 0
+        return MTPBenchmarkStreamTiming(
+            timeToFirstTokenMs: milliseconds(first - submittedAtNanoseconds),
+            interTokenLatencyMs: itlMs,
+            decodeTokensPerSecond: decodeTPS,
+            lastTokenLatencyMs: milliseconds(last - submittedAtNanoseconds))
+    }
+
+    /// Aggregate batch throughput shares one interval across every stream:
+    /// earliest first token through latest last token. The numerator is the
+    /// sum of each stream's N-1 decode intervals.
+    public static func aggregateDecodeTokensPerSecond(
+        tokenTimestampsNanoseconds streams: [[UInt64]]
+    ) throws -> Double {
+        guard !streams.isEmpty, streams.allSatisfy({ !$0.isEmpty }) else {
+            throw MTPBenchmarkError.invalidTokenTimeline(
+                "aggregate timing requires at least one token per stream")
+        }
+        for timestamps in streams {
+            _ = try stream(
+                submittedAtNanoseconds: timestamps[0],
+                tokenTimestampsNanoseconds: timestamps)
+        }
+        let first = streams.compactMap(\.first).min()!
+        let last = streams.compactMap(\.last).max()!
+        let intervals = streams.reduce(0) { $0 + max(0, $1.count - 1) }
+        let elapsed = last - first
+        guard intervals > 0, elapsed > 0 else { return 0 }
+        return Double(intervals) / (Double(elapsed) / 1_000_000_000)
+    }
+
+    private static func milliseconds(_ nanoseconds: UInt64) -> Double {
+        Double(nanoseconds) / 1_000_000
+    }
+}

--- a/provider-swift/Sources/ProviderBenchmark/MTPProductionSession.swift
+++ b/provider-swift/Sources/ProviderBenchmark/MTPProductionSession.swift
@@ -163,6 +163,14 @@ public final class MTPProductionModelBundle: @unchecked Sendable {
         mode: MTPBenchmarkMode,
         batchSize: Int
     ) async throws -> MTPBenchmarkSession {
+        let verificationMode: CBv2MTPVerificationMode = {
+            switch ProcessInfo.processInfo.environment["DARKBLOOM_MTP_VERIFICATION_MODE"] {
+            case "rectangular": return .rectangular
+            case "serial", "serial_target": return .serialTarget
+            default: return .automatic
+            }
+        }()
+        let automaticRectangularTokens = MTPAutomaticVerificationPolicy.maxRectangularTokens()
         let mtpDrafter: (any CBv2MTPDrafter)?
         let mtpConfig: CBv2MTPConfig
         switch mode.kind {
@@ -179,14 +187,18 @@ public final class MTPProductionModelBundle: @unchecked Sendable {
                 enabled: true,
                 maxDraftTokens: CBv2MTPConfig.testedMaxDraftTokens,
                 maxSpeculativeBatch: 8,
-                fixedDraftTokens: fixedDraftTokens)
+                fixedDraftTokens: fixedDraftTokens,
+                verificationMode: verificationMode,
+                maxAutomaticRectangularTokens: automaticRectangularTokens)
         case .adaptive:
             mtpDrafter = drafter
             mtpConfig = CBv2MTPConfig(
                 enabled: true,
                 maxDraftTokens: CBv2MTPConfig.testedMaxDraftTokens,
                 maxSpeculativeBatch: 8,
-                fixedDraftTokens: nil)
+                fixedDraftTokens: nil,
+                verificationMode: verificationMode,
+                maxAutomaticRectangularTokens: automaticRectangularTokens)
         }
         let engine = try EngineV2Factory.makeProductionEngine(
             model: servingModel,

--- a/provider-swift/Sources/ProviderBenchmark/MTPProductionSession.swift
+++ b/provider-swift/Sources/ProviderBenchmark/MTPProductionSession.swift
@@ -1,0 +1,242 @@
+import Foundation
+import MLXLLM
+import MLXLMCommon
+import MLXVLM
+import ProviderCore
+
+/// Cache-only model bundle for MTP validation. It loads the target through the
+/// same model factories as serving, resolves the exact VLM text model through
+/// ProviderCore's production extraction seam, and loads/binds the real Gemma 4
+/// assistant. It never downloads and never contains a decoder implementation.
+public final class MTPProductionModelBundle: @unchecked Sendable {
+    public let targetID: String
+    public let assistantID: String
+    public let targetDirectory: URL
+    public let assistantDirectory: URL
+    public let targetFacts: MTPBenchmarkArtifactFacts
+    public let assistantFacts: MTPBenchmarkArtifactFacts
+
+    private let container: ModelContainer
+    private let servingModel: any LanguageModel
+    private let tokenizer: any MLXLMCommon.Tokenizer
+    private let eosTokenIDs: Set<Int>
+    private let drafter: Gemma4CBv2MTPDrafter
+    private let kvBytesCapacity: Int
+
+    public var targetContainer: ModelContainer { container }
+    /// Exact target EOS set captured from the same loaded configuration used
+    /// to construct production sessions. Performance/correctness validation
+    /// must pass this set to every request; raw parity deliberately passes none.
+    public var productionStopTokenIDs: Set<Int> { eosTokenIDs }
+
+    private init(
+        targetID: String,
+        assistantID: String,
+        targetDirectory: URL,
+        assistantDirectory: URL,
+        targetFacts: MTPBenchmarkArtifactFacts,
+        assistantFacts: MTPBenchmarkArtifactFacts,
+        container: ModelContainer,
+        servingModel: any LanguageModel,
+        tokenizer: any MLXLMCommon.Tokenizer,
+        eosTokenIDs: Set<Int>,
+        drafter: Gemma4CBv2MTPDrafter,
+        kvBytesCapacity: Int
+    ) {
+        self.targetID = targetID
+        self.assistantID = assistantID
+        self.targetDirectory = targetDirectory
+        self.assistantDirectory = assistantDirectory
+        self.targetFacts = targetFacts
+        self.assistantFacts = assistantFacts
+        self.container = container
+        self.servingModel = servingModel
+        self.tokenizer = tokenizer
+        self.eosTokenIDs = eosTokenIDs
+        self.drafter = drafter
+        self.kvBytesCapacity = kvBytesCapacity
+    }
+
+    public static func load(
+        targetID: String,
+        targetDirectory: URL,
+        assistantID: String,
+        assistantDirectory: URL
+    ) async throws -> MTPProductionModelBundle {
+        let targetFacts = try MTPBenchmarkModelFacts.inspect(
+            modelID: targetID, directory: targetDirectory)
+        let assistantFacts = try MTPBenchmarkModelFacts.inspect(
+            modelID: assistantID, directory: assistantDirectory)
+        let isVLM = hasVisionConfig(directory: targetDirectory)
+        let container: ModelContainer
+        if isVLM {
+            container = try await VLMModelFactory.shared.loadContainer(
+                from: targetDirectory, using: LocalTokenizerLoader())
+        } else {
+            container = try await LLMModelFactory.shared.loadContainer(
+                from: targetDirectory, using: LocalTokenizerLoader())
+        }
+
+        struct Snapshot: @unchecked Sendable {
+            let model: any LanguageModel
+            let tokenizer: any MLXLMCommon.Tokenizer
+            let baseEOSTokenIDs: Set<Int>
+            let tokenizerEOSTokenID: Int?
+            let extraEOSTokens: [String]
+            let weightBytes: Int
+        }
+        let snapshot = await container.perform { context -> Snapshot in
+            let weightBytes = context.model.parameters().flattened().reduce(0) {
+                $0 + $1.1.nbytes
+            }
+            return Snapshot(
+                model: context.model,
+                tokenizer: context.tokenizer,
+                baseEOSTokenIDs: context.configuration.eosTokenIds,
+                tokenizerEOSTokenID: context.tokenizer.eosTokenId,
+                extraEOSTokens: context.configuration.extraEOSTokens.sorted(),
+                weightBytes: weightBytes)
+        }
+        let eosTokenIDs = MTPBenchmarkProductionPolicy.stopTokenIDs(
+            modelID: targetID,
+            modelType: targetFacts.modelType,
+            baseConfigTokenIDs: snapshot.baseEOSTokenIDs,
+            tokenizerEOSTokenID: snapshot.tokenizerEOSTokenID,
+            extraEOSTokens: snapshot.extraEOSTokens,
+            convertTokenToID: { snapshot.tokenizer.convertTokenToId($0) })
+        let servingModel = try EngineV2Factory.benchmarkServingModel(
+            model: snapshot.model,
+            isVLM: isVLM,
+            modelDirectory: targetDirectory)
+        guard let target = servingModel as? any Gemma4MTPTarget else {
+            throw MTPBenchmarkError.mtpRequestedButInactive(
+                "target model \(type(of: servingModel)) is not Gemma4MTPTarget")
+        }
+        let assistant = try await Gemma4AssistantDraftModel.load(from: assistantDirectory)
+        let drafter = try Gemma4CBv2MTPDrafter(drafter: assistant, target: target)
+        let residentWeightBytes = MTPBenchmarkSizing.totalResidentWeightBytes(
+            targetWeightBytes: snapshot.weightBytes,
+            assistant: assistantFacts)
+        let kvBytesCapacity = Int(min(
+            UnifiedMemoryCap.kvBudgetBytes(
+                physicalBytes: ProcessInfo.processInfo.physicalMemory,
+                residentWeightBytes: residentWeightBytes),
+            UInt64(Int.max)))
+
+        return MTPProductionModelBundle(
+            targetID: targetID,
+            assistantID: assistantID,
+            targetDirectory: targetDirectory,
+            assistantDirectory: assistantDirectory,
+            targetFacts: targetFacts,
+            assistantFacts: assistantFacts,
+            container: container,
+            servingModel: servingModel,
+            tokenizer: snapshot.tokenizer,
+            eosTokenIDs: eosTokenIDs,
+            drafter: drafter,
+            kvBytesCapacity: kvBytesCapacity)
+    }
+
+    public func tokenizeChat(name: String, userPrompt: String) throws -> MTPBenchmarkPrompt {
+        let messages: [[String: any Sendable]] = [["role": "user", "content": userPrompt]]
+        return try tokenize(name: name, messages: messages)
+    }
+
+    public func tokenize(
+        name: String,
+        messages: [[String: any Sendable]],
+        tools: [[String: any Sendable]]? = nil
+    ) throws -> MTPBenchmarkPrompt {
+        let tokens = try tokenizer.applyChatTemplate(
+            messages: messages, tools: tools, additionalContext: nil)
+        return MTPBenchmarkPrompt(name: name, tokenIDs: tokens)
+    }
+
+    public func makeSessionFactory() -> MTPBenchmarkSessionFactory {
+        MTPBenchmarkSessionFactory { [self] mode, batchSize in
+            try await self.makeSession(mode: mode, batchSize: batchSize)
+        }
+    }
+
+    private func makeSession(
+        mode: MTPBenchmarkMode,
+        batchSize: Int
+    ) async throws -> MTPBenchmarkSession {
+        let mtpDrafter: (any CBv2MTPDrafter)?
+        let mtpConfig: CBv2MTPConfig
+        switch mode.kind {
+        case .targetOnly:
+            mtpDrafter = nil
+            mtpConfig = CBv2MTPConfig(enabled: false)
+        case .fixed:
+            guard let fixedDraftTokens = mode.fixedDraftTokens else {
+                throw MTPBenchmarkError.invalidVerificationWidth(
+                    mode.verificationWidth ?? -1)
+            }
+            mtpDrafter = drafter
+            mtpConfig = CBv2MTPConfig(
+                enabled: true,
+                maxDraftTokens: CBv2MTPConfig.testedMaxDraftTokens,
+                maxSpeculativeBatch: 8,
+                fixedDraftTokens: fixedDraftTokens)
+        case .adaptive:
+            mtpDrafter = drafter
+            mtpConfig = CBv2MTPConfig(
+                enabled: true,
+                maxDraftTokens: CBv2MTPConfig.testedMaxDraftTokens,
+                maxSpeculativeBatch: 8,
+                fixedDraftTokens: nil)
+        }
+        let engine = try EngineV2Factory.makeProductionEngine(
+            model: servingModel,
+            tokenizer: tokenizer,
+            kvBytesCapacity: kvBytesCapacity,
+            maxConcurrentRequests: batchSize,
+            mtpDrafter: mtpDrafter,
+            mtpConfig: mtpConfig,
+            environment: [
+                "DARKBLOOM_PREFIX_CACHE": "0",
+            ])
+        return MTPBenchmarkSession(engine: engine) {
+            MTPBenchmarkEngineMetrics.snapshot(engine: engine)
+        }
+    }
+
+    private static func hasVisionConfig(directory: URL) -> Bool {
+        let config = directory.appendingPathComponent("config.json")
+        guard let data = try? Data(contentsOf: config),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else { return false }
+        return object["vision_config"] != nil
+    }
+}
+
+public enum MTPBenchmarkProductionPolicy {
+    /// Exact serving stop policy: loader config, model-family augmentation,
+    /// tokenizer EOS, and every configuration extra converted by that same
+    /// loaded tokenizer.
+    public static func stopTokenIDs(
+        modelID: String,
+        modelType: String?,
+        baseConfigTokenIDs: Set<Int>,
+        tokenizerEOSTokenID: Int?,
+        extraEOSTokens: [String],
+        convertTokenToID: (String) -> Int?
+    ) -> Set<Int> {
+        var result = ModelEOSPolicy.effectiveEOSTokenIds(
+            modelId: modelID,
+            modelType: modelType,
+            base: baseConfigTokenIDs,
+            tokenToId: convertTokenToID)
+        if let tokenizerEOSTokenID {
+            result.insert(tokenizerEOSTokenID)
+        }
+        for token in extraEOSTokens {
+            if let tokenID = convertTokenToID(token) {
+                result.insert(tokenID)
+            }
+        }
+        return result
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Config/BetaFeatures.swift
+++ b/provider-swift/Sources/ProviderCore/Config/BetaFeatures.swift
@@ -76,7 +76,23 @@ public enum BetaFeatures {
             requiresRestart: true,
             read: { $0.backend.kvQuant },
             write: { enabled, config in config.backend.kvQuant = enabled }
-        )
+        ),
+        BetaFeature(
+            id: "mtp",
+            title: "Multi-token prediction (speculative decoding)",
+            summary: "Gemma 4 drafter-assisted decode on CBv2 — faster greedy decode, token-identical output.",
+            details: """
+            Binds a small drafter model to Gemma 4 slots so greedy \
+            (temperature-0) requests decode several tokens per step. Output \
+            is token-identical to MTP-off; drafter resolution and load are \
+            fail-open (any problem falls back to plain decode). The drafter \
+            comes from the catalog's spec_dec pointer, or set \
+            mtp_drafter_path under [backend] to a local drafter directory.
+            """,
+            requiresRestart: true,
+            read: { $0.backend.mtp },
+            write: { enabled, config in config.backend.mtp = enabled }
+        ),
         // (adaptive-prefill was retired with the legacy engine, v0.7.5 —
         // CBv2 chunks prefill engine-internally.)
     ]

--- a/provider-swift/Sources/ProviderCore/Config/ProviderConfig.swift
+++ b/provider-swift/Sources/ProviderCore/Config/ProviderConfig.swift
@@ -142,6 +142,18 @@ public struct BackendSettings: Sendable, Equatable, Codable {
     /// false: availability beats perfection — a self-test failure may be
     /// transient and the model can still serve via the lazy-load path.
     public var startupSelftestFailClosed: Bool
+    /// MTP (multi-token prediction / speculative decoding) opt-in for CBv2
+    /// (`mtp` under `[backend]`, default false — beta id `mtp`). When enabled,
+    /// slot build resolves a Gemma drafter (`mtp_drafter_path` if set, else the
+    /// catalog entry's `spec_dec` download) and binds it to the engine. Drafter
+    /// resolution/load is fail-open: any failure means plain decode, never a
+    /// slot failure. `DARKBLOOM_CBV2_MTP` remains the engine-side kill switch.
+    public var mtp: Bool
+    /// Optional local drafter directory override (`mtp_drafter_path` under
+    /// `[backend]`) — the canary path: `config.json` + `*.safetensors`, no R2
+    /// involved. Takes precedence over the `spec_dec` download when set. nil
+    /// (default) = resolve via the catalog's `spec_dec` pointer.
+    public var mtpDrafterPath: String?
     /// RETIRED `[backend]` keys found in the decoded provider.toml
     /// (`engine_v2`, `continuous_batching`, `adaptive_prefill`,
     /// `legacy_compiled_decode`). The keys parse cleanly — an old config
@@ -165,7 +177,9 @@ public struct BackendSettings: Sendable, Equatable, Codable {
         preloadModels: [String] = [],
         startupPreloadTimeoutSecs: UInt64 = 120,
         startupSelftest: Bool = true,
-        startupSelftestFailClosed: Bool = false
+        startupSelftestFailClosed: Bool = false,
+        mtp: Bool = false,
+        mtpDrafterPath: String? = nil
     ) {
         self.port = port
         self.model = model
@@ -182,6 +196,8 @@ public struct BackendSettings: Sendable, Equatable, Codable {
         self.startupPreloadTimeoutSecs = startupPreloadTimeoutSecs
         self.startupSelftest = startupSelftest
         self.startupSelftestFailClosed = startupSelftestFailClosed
+        self.mtp = mtp
+        self.mtpDrafterPath = mtpDrafterPath
     }
 
     enum CodingKeys: String, CodingKey {
@@ -200,6 +216,8 @@ public struct BackendSettings: Sendable, Equatable, Codable {
         case startupPreloadTimeoutSecs = "startup_preload_timeout_secs"
         case startupSelftest = "startup_selftest"
         case startupSelftestFailClosed = "startup_selftest_fail_closed"
+        case mtp
+        case mtpDrafterPath = "mtp_drafter_path"
     }
 
     /// RETIRED `[backend]` keys (v0.7.5 one-engine): parsed for presence
@@ -236,6 +254,8 @@ public struct BackendSettings: Sendable, Equatable, Codable {
         self.startupSelftest = try container.decodeIfPresent(Bool.self, forKey: .startupSelftest) ?? true
         self.startupSelftestFailClosed =
             try container.decodeIfPresent(Bool.self, forKey: .startupSelftestFailClosed) ?? false
+        self.mtp = try container.decodeIfPresent(Bool.self, forKey: .mtp) ?? false
+        self.mtpDrafterPath = try container.decodeIfPresent(String.self, forKey: .mtpDrafterPath)
         // Retired keys: presence-only scan so startup can WARN (values are
         // ignored; an old provider.toml must keep loading cleanly).
         let retired = try decoder.container(keyedBy: RetiredCodingKeys.self)

--- a/provider-swift/Sources/ProviderCore/Hardware/HardwareDetector.swift
+++ b/provider-swift/Sources/ProviderCore/Hardware/HardwareDetector.swift
@@ -65,7 +65,7 @@ public enum HardwareDetector: Sendable {
 
 // MARK: - sysctl Helpers
 
-private func sysctlString(_ key: String) throws -> String {
+func sysctlString(_ key: String) throws -> String {
     var size: Int = 0
     guard sysctlbyname(key, nil, &size, nil, 0) == 0, size > 0 else {
         throw HardwareError.sysctlFailed(key)

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge+Capacity.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge+Capacity.swift
@@ -42,7 +42,7 @@ extension EngineV2Bridge {
         now: ContinuousClock.Instant = .now,
         kvBytesBudgetClamp: Int? = nil
     ) -> BackendSlotCapacity {
-        let snapshot = engine.capacity()
+        let snapshot = capacitySnapshot()
 
         // Sample loop progress into the wedge monitor on the heartbeat
         // cadence (mirrors `sampleEngineSteps`), then emit the step_wedge
@@ -178,7 +178,7 @@ extension EngineV2Bridge {
     /// cache budget — so Σ(engine ceilings + cache budgets) stays within
     /// the process-wide KV budget (`EngineV2KVSizing.engineKVBytesCapacity`).
     public func engineKVBytesCapacity() -> Int {
-        engine.capacity().kvBytesCapacity
+        capacitySnapshot().kvBytesCapacity
     }
 
     // MARK: - engine_v2.step_wedge

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge+Liveness.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge+Liveness.swift
@@ -47,8 +47,8 @@ extension EngineV2Bridge {
     /// verdict never depends on heartbeat cadence. Never fires while a
     /// recovery is already in flight for this bridge.
     func confirmedWedgeForRecovery(now: ContinuousClock.Instant = .now) -> Bool {
-        guard !recoveryReloading else { return false }
-        wedgeMonitor.sampleSteps(engine.capacity().stepsExecuted, now: now)
+        guard !recoveryReloading, ownedEngine != nil else { return false }
+        wedgeMonitor.sampleSteps(capacitySnapshot().stepsExecuted, now: now)
         return wedgeMonitor.consecutiveAdmitsWithoutFirstToken >= 1
             && wedgeMonitor.dryStreakSeconds(now: now) >= Self.recoveryStallSeconds
             && wedgeMonitor.secondsSinceLastStep(now: now) >= Self.recoveryStallSeconds

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge+MTP.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge+MTP.swift
@@ -1,0 +1,54 @@
+import Foundation
+import MLXLMCommon
+#if canImport(os)
+import os
+#endif
+
+extension EngineV2Bridge {
+    #if canImport(os)
+    private static let mtpLogger = Logger(
+        subsystem: "com.darkbloom.provider", category: "engine_v2_mtp")
+    #endif
+
+    func configureMTPStatus(
+        _ status: MTPActivationStatus,
+        metricsInterval: Duration = .seconds(60)
+    ) {
+        mtpActivationStatus = status
+        mtpMetricsTask?.cancel()
+        mtpMetricsTask = nil
+        guard status.active, metricsInterval > .zero else { return }
+        let bridge = self
+        mtpMetricsTask = Task { [weak bridge] in
+            while !Task.isCancelled {
+                try? await taskSleep(metricsInterval)
+                if Task.isCancelled { return }
+                guard let bridge else { return }
+                await bridge.logMTPSnapshot()
+            }
+        }
+    }
+
+    /// Public/test-visible lock-safe snapshot. `EngineV2.mtpMetricsSnapshot()`
+    /// takes the engine's metrics lock; this adapter never reaches controller
+    /// mutation or the inference loop.
+    public func mtpStatusSnapshot() -> ProviderMTPStatusSnapshot {
+        let metrics = (ownedEngine as? EngineV2)?.mtpMetricsSnapshot()
+        return ProviderMTPStatusSnapshot(status: mtpActivationStatus, metrics: metrics)
+    }
+
+    private func logMTPSnapshot() {
+        let snapshot = mtpStatusSnapshot()
+        #if canImport(os)
+        let reason = snapshot.fallbackReason?.rawValue ?? "none"
+        let revision = snapshot.assistantRevision ?? "none"
+        let skipped = snapshot.skippedRows.sorted { $0.key < $1.key }
+            .map { "\($0.key)=\($0.value)" }.joined(separator: ",")
+        let controller = snapshot.controllerFallbacks.sorted { $0.key < $1.key }
+            .map { "\($0.key)=\($0.value)" }.joined(separator: ",")
+        Self.mtpLogger.info(
+            "mtp metrics model=\(self.modelId, privacy: .public) configured=\(snapshot.configured) active=\(snapshot.active) reason=\(reason, privacy: .public) revision=\(revision, privacy: .public) assistant_bytes=\(snapshot.assistantResidentBytes) depth=\(snapshot.selectedDepth) decode_bucket=\(snapshot.decodeRowBucket) rounds=\(snapshot.rounds) seeds=\(snapshot.seedRows) proposed=\(snapshot.proposedTokens) accepted=\(snapshot.acceptedDraftTokens) emitted=\(snapshot.committedEmittedTokens) skipped=\(skipped, privacy: .public) controller=\(controller, privacy: .public)"
+        )
+        #endif
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge+PrefixCache.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge+PrefixCache.swift
@@ -168,7 +168,7 @@ extension EngineV2Bridge {
     /// engine capacity — for co-resident slots, so Σ(engine ceilings +
     /// cache budgets) never exceeds the unified-memory KV budget.
     public func slotKVBytesClaim() -> Int {
-        let snapshot = engine.capacity()
+        let snapshot = capacitySnapshot()
         let engineClaim =
             kvBackendKind == .paged && snapshot.kvBytesBackendCapacity > 0
             ? snapshot.kvBytesBackendCapacity
@@ -182,7 +182,7 @@ extension EngineV2Bridge {
     /// rollback uses this exact value; unlike `slotKVBytesClaim()`, it does
     /// not replace a shrunk paged ledger with the larger immutable pool.
     func resliceAdmissionBytesClaim() -> Int {
-        let (sum, overflow) = engine.capacity().kvBytesCapacity
+        let (sum, overflow) = capacitySnapshot().kvBytesCapacity
             .addingReportingOverflow(prefixCacheBudgetBytes)
         return overflow ? Int.max : sum
     }

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge.swift
@@ -56,7 +56,28 @@ public actor EngineV2Bridge {
     /// bridge actor holds and calls it directly. The former
     /// `@unchecked Sendable` box workaround (CONTRACT-ISSUES-H-provider.md
     /// §1) is resolved.
-    let engine: any CBv2Engine
+    /// Mutable ownership is intentional: `shutdown()` nils the engine after
+    /// drain so its target and MTP drafter references are released before the
+    /// slot owner purges MLX cache and regrows survivor grants.
+    var ownedEngine: (any CBv2Engine)?
+    var engine: any CBv2Engine {
+        guard let ownedEngine else {
+            preconditionFailure("EngineV2Bridge engine accessed after shutdown")
+        }
+        return ownedEngine
+    }
+    func capacitySnapshot() -> CBv2CapacitySnapshot {
+        ownedEngine?.capacity()
+            ?? CBv2CapacitySnapshot(
+                activeRequests: 0,
+                waitingRequests: 0,
+                kvBytesInUse: 0,
+                kvBytesCapacity: 0,
+                kvBytesBackendCapacity: 0,
+                kvBytesReserved: 0,
+                activeTokens: 0,
+                stepsExecuted: wedgeMonitor.lastStepsSample)
+    }
     public let modelId: String
     /// Which KV backend the engine was built with. Keys the bridge's
     /// shared-gate accounting (paged pools are construction-committed —
@@ -113,6 +134,10 @@ public actor EngineV2Bridge {
     /// checkpoint-tier logger). Started by the slot factory when an active
     /// cache exists; cancelled in `shutdown()`.
     var prefixCacheStatsTask: Task<Void, Never>?
+    /// Periodic content-free MTP metrics logger, cancelled by `shutdown()`.
+    var mtpMetricsTask: Task<Void, Never>?
+    var mtpActivationStatus = MTPActivationStatus.disabled(
+        .configDisabled, configured: false)
     /// Injectable telemetry sink (tests); nil ⇒ `TelemetryClient.shared`.
     let emitTelemetry: (@Sendable (TelemetryEvent) -> Void)?
 
@@ -220,7 +245,7 @@ public actor EngineV2Bridge {
         kvBackendKind: EngineV2KVBackendKind = .contiguous,
         emitTelemetry: (@Sendable (TelemetryEvent) -> Void)? = nil
     ) {
-        self.engine = engine
+        self.ownedEngine = engine
         self.modelId = modelId
         self.tokenizer = tokenizer
         self.kvBackendKind = kvBackendKind
@@ -472,6 +497,16 @@ public actor EngineV2Bridge {
         }
 
         let events: AsyncStream<CBv2Event>
+        guard let engine = ownedEngine else {
+            if sharedKVReserved { await kvBudget?.release(requestID: id) }
+            if ssdStaged { ssdPrefixCache?.completeStaging(requestID: id) }
+            if let readyReceiptRequestID {
+                ssdPrefixCache?.discardReadyReceipt(requestID: readyReceiptRequestID)
+            }
+            continuation.yield(.error("request queue full: engine is shutting down"))
+            continuation.finish()
+            return stream
+        }
         do {
             // `engine.submit` is an O(1) non-blocking ENQUEUE by contract
             // (`CBv2Engine.submit`: "Cancel promptly … row is dropped O(1)";
@@ -544,7 +579,7 @@ public actor EngineV2Bridge {
     /// which drives the normal bookkeeping/teardown in the pump.
     public func cancel(requestId: String) {
         guard let cbv2Id = idMap[requestId] else { return }
-        engine.cancel(cbv2Id)
+        ownedEngine?.cancel(cbv2Id)
     }
 
     // MARK: - Runtime KV re-slicing / slot bookkeeping
@@ -578,6 +613,7 @@ public actor EngineV2Bridge {
     /// Reclaiming or adding physical bytes requires an unload/rebuild.
     public func updateKVBytesCapacity(_ bytes: Int) {
         let requested = max(0, bytes - prefixCacheBudgetBytes)
+        guard let engine = ownedEngine else { return }
         if kvBackendKind == .paged {
             let physical = max(0, engine.capacity().kvBytesBackendCapacity)
             engine.updateKVBytesCapacity(min(requested, physical))
@@ -597,12 +633,12 @@ public actor EngineV2Bridge {
     /// contiguous: the admission ceiling). Input to the post-build
     /// serveable-KV guard (`KVHeadroomProbe.postBuildServeable`).
     public func kvBackendPoolBytes() -> UInt64 {
-        UInt64(max(0, engine.capacity().kvBytesBackendCapacity))
+        UInt64(max(0, capacitySnapshot().kvBytesBackendCapacity))
     }
 
     /// Runtime fan-out helper: cancel iff this bridge owns the request-id.
     func cancelIfOwned(requestId: String) -> Bool {
-        guard let cbv2Id = idMap[requestId] else { return false }
+        guard let cbv2Id = idMap[requestId], let engine = ownedEngine else { return false }
         engine.cancel(cbv2Id)
         return true
     }
@@ -621,10 +657,17 @@ public actor EngineV2Bridge {
     public func shutdown() async {
         prefixCacheStatsTask?.cancel()
         prefixCacheStatsTask = nil
+        mtpMetricsTask?.cancel()
+        mtpMetricsTask = nil
         let live = pumpTasks
         pumpTasks.removeAll()
         for task in live.values { task.cancel() }
-        await engine.shutdown()
+        if let engine = ownedEngine {
+            await engine.shutdown()
+        }
+        // The bridge may remain in a local teardown variable; explicitly drop
+        // the concrete engine so target and assistant ownership does not.
+        ownedEngine = nil
         // SSD tier teardown AFTER the engine drain: queued donation writes
         // are dropped, staging pins/reservations released, on-disk files
         // KEPT — durable warmth across unload/restart is the feature.

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Factory+Production.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Factory+Production.swift
@@ -150,6 +150,8 @@ extension EngineV2Factory {
         kvBytesCapacity: Int,
         prefixCache: (any CBv2PrefixCache)? = nil,
         maxConcurrentRequests: Int = EngineV2Factory.productionMaxConcurrentRequests,
+        mtpDrafter: (any CBv2MTPDrafter)? = nil,
+        mtpConfig: CBv2MTPConfig = CBv2MTPConfig(),
         kvBackend: EngineV2KVBackendSelection = .auto,
         maxContextLength: Int? = nil,
         environment: [String: String] = ProcessInfo.processInfo.environment
@@ -160,6 +162,8 @@ extension EngineV2Factory {
             kvBytesCapacity: kvBytesCapacity,
             prefixCache: prefixCache,
             maxConcurrentRequests: maxConcurrentRequests,
+            mtpDrafter: mtpDrafter,
+            mtpConfig: mtpConfig,
             kvBackend: kvBackend,
             maxContextLength: maxContextLength,
             environment: environment
@@ -198,6 +202,8 @@ extension EngineV2Factory {
         kvBytesCapacity: Int,
         prefixCache: (any CBv2PrefixCache)? = nil,
         maxConcurrentRequests: Int = EngineV2Factory.productionMaxConcurrentRequests,
+        mtpDrafter: (any CBv2MTPDrafter)? = nil,
+        mtpConfig: CBv2MTPConfig = CBv2MTPConfig(),
         kvBackend: EngineV2KVBackendSelection = .auto,
         maxContextLength: Int? = nil,
         environment: [String: String] = ProcessInfo.processInfo.environment,
@@ -323,7 +329,9 @@ extension EngineV2Factory {
                             backend: paged, caches: caches,
                             schedulerConfig: schedulerConfig,
                             prefixCache: prefixCache,
-                            loopConfig: engineLoopConfig),
+                            loopConfig: engineLoopConfig,
+                            mtpDrafter: mtpDrafter,
+                            mtpConfig: mtpConfig),
                         kvBackendKind: .paged,
                         kvBackendFallbackReason: nil)
                 } catch let error as CBv2KVError {
@@ -347,7 +355,9 @@ extension EngineV2Factory {
                 backend: backend, caches: caches,
                 schedulerConfig: schedulerConfig,
                 prefixCache: prefixCache,
-                loopConfig: engineLoopConfig),
+                loopConfig: engineLoopConfig,
+                mtpDrafter: mtpDrafter,
+                mtpConfig: mtpConfig),
             kvBackendKind: .contiguous,
             kvBackendFallbackReason: fallbackReason)
     }
@@ -361,7 +371,9 @@ extension EngineV2Factory {
         caches: [any CBv2AttendingLayerCache],
         schedulerConfig: CBv2SchedulerConfig,
         prefixCache: (any CBv2PrefixCache)?,
-        loopConfig: CBv2EngineLoopConfig
+        loopConfig: CBv2EngineLoopConfig,
+        mtpDrafter: (any CBv2MTPDrafter)?,
+        mtpConfig: CBv2MTPConfig
     ) -> EngineV2 {
         EngineV2(
             model: CBv2SteppableLanguageModelAdapter(model),
@@ -376,7 +388,9 @@ extension EngineV2Factory {
             // default-on encrypted SSD tier or the opt-in RAM PrefixCacheV2
             // tier. Both use per-request cacheSalt scoping; selection and
             // budgets live in PrefixCachePolicy.
-            prefixCache: prefixCache
+            prefixCache: prefixCache,
+            mtpDrafter: mtpDrafter,
+            mtpConfig: mtpConfig
         )
     }
 

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2MTPAssistant.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2MTPAssistant.swift
@@ -1,0 +1,61 @@
+import Foundation
+import MLXLLM
+import MLXLMCommon
+
+enum ProviderMTPAssistantLoadError: Error, CustomStringConvertible {
+    case targetIncompatible(String)
+    case loadFailed(String)
+    case bindFailed(String)
+
+    var reason: MTPFallbackReason {
+        switch self {
+        case .targetIncompatible, .bindFailed: .assistantTargetIncompatible
+        case .loadFailed: .assistantLoadFailed
+        }
+    }
+
+    var description: String {
+        switch self {
+        case .targetIncompatible(let detail): "target incompatible: \(detail)"
+        case .loadFailed(let detail): "assistant load failed: \(detail)"
+        case .bindFailed(let detail): "assistant bind failed: \(detail)"
+        }
+    }
+}
+
+protocol ProviderMTPAssistantLoading: Sendable {
+    func loadAndBind(
+        artifact: SpecDecArtifact,
+        target: any LanguageModel
+    ) async throws -> ProviderMTPAssistantHandle
+}
+
+/// The sole production assistant loader. `Gemma4AssistantDraftModel.load`
+/// decodes the assistant's own `config.json`, applies its own per-layer
+/// quantization table, loads its own safetensors, and verifies all parameters.
+struct Gemma4ProviderMTPAssistantLoader: ProviderMTPAssistantLoading {
+    func loadAndBind(
+        artifact: SpecDecArtifact,
+        target: any LanguageModel
+    ) async throws -> ProviderMTPAssistantHandle {
+        guard let gemmaTarget = target as? Gemma4TextModel else {
+            throw ProviderMTPAssistantLoadError.targetIncompatible(
+                String(describing: type(of: target)))
+        }
+
+        let assistant: Gemma4AssistantDraftModel
+        do {
+            assistant = try await Gemma4AssistantDraftModel.load(
+                from: artifact.directory)
+        } catch {
+            throw ProviderMTPAssistantLoadError.loadFailed(String(describing: error))
+        }
+        do {
+            let drafter = try Gemma4CBv2MTPDrafter(
+                drafter: assistant, target: gemmaTarget)
+            return ProviderMTPAssistantHandle(owner: assistant, drafter: drafter)
+        } catch {
+            throw ProviderMTPAssistantLoadError.bindFailed(String(describing: error))
+        }
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2SlotFactory+MTP.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2SlotFactory+MTP.swift
@@ -1,0 +1,222 @@
+import Foundation
+import MLXLMCommon
+
+/// Model handle + EOS config snapshot pulled out of `ModelContainer.perform`.
+/// The module crosses container isolation once and is then engine-thread owned.
+struct EngineV2ModelSnapshot: @unchecked Sendable {
+    let model: any LanguageModel
+    let eosTokenIds: Set<Int>
+    let extraEOSTokens: [String]
+}
+
+/// Target extraction plus fail-open assistant preparation, completed before KV
+/// re-slicing so final sizing uses retained assistant bytes.
+struct EngineV2PreparedModel: @unchecked Sendable {
+    let snapshot: EngineV2ModelSnapshot
+    let servingModel: any LanguageModel
+    let assistant: ProviderMTPAssistantHandle?
+    let mtpStatus: MTPActivationStatus
+    let mtpArtifact: SpecDecArtifact?
+
+    var assistantBytes: UInt64 { mtpStatus.assistantBytes }
+
+    func fallingBack(_ reason: MTPFallbackReason) -> Self {
+        Self(
+            snapshot: snapshot,
+            servingModel: servingModel,
+            assistant: nil,
+            mtpStatus: mtpStatus.fallingBack(reason),
+            mtpArtifact: nil)
+    }
+}
+
+extension EngineV2SlotFactory {
+    private static func modelSnapshot(
+        container: ModelContainer
+    ) async -> EngineV2ModelSnapshot {
+        await container.perform { ctx in
+            EngineV2ModelSnapshot(
+                model: ctx.model,
+                eosTokenIds: ctx.configuration.eosTokenIds,
+                extraEOSTokens: ctx.configuration.extraEOSTokens.sorted())
+        }
+    }
+
+    private static func servingModel(
+        modelId: String,
+        isVLM: Bool,
+        modelDirectory: URL?,
+        snapshot: EngineV2ModelSnapshot,
+        emitTelemetry: (@Sendable (TelemetryEvent) -> Void)?,
+        logInfo: @escaping @Sendable (String) -> Void
+    ) throws -> any LanguageModel {
+        guard isVLM else { return snapshot.model }
+        guard let modelDirectory else {
+            let error = EngineV2VLMTextExtractionError.missingModelDirectory
+            EngineV2Factory.emitRefusalTelemetry(
+                modelId: modelId,
+                reason: .vlmExtractionFailed,
+                error: error,
+                emitTelemetry: emitTelemetry)
+            throw error
+        }
+        let extraction: EngineV2VLMTextExtraction.Extraction
+        do {
+            extraction = try EngineV2VLMTextExtraction.extractTextModel(
+                from: snapshot.model, modelDirectory: modelDirectory)
+        } catch {
+            EngineV2Factory.emitRefusalTelemetry(
+                modelId: modelId,
+                reason: .vlmExtractionFailed,
+                error: error,
+                emitTelemetry: emitTelemetry)
+            throw error
+        }
+        if let parityDiff = extraction.parityMaxAbsLogitDiff {
+            logInfo(
+                "engine_v2: \(modelId) VLM text-model extraction passed the "
+                    + "load-time forward parity gate (max |Δlogit| \(parityDiff))")
+        }
+        return extraction.model
+    }
+
+    static func prepareProductionModel(
+        modelId: String,
+        isVLM: Bool,
+        modelDirectory: URL?,
+        container: ModelContainer,
+        specDecPreparation: SpecDecPreparation,
+        assistantLoader: any ProviderMTPAssistantLoading = Gemma4ProviderMTPAssistantLoader(),
+        emitTelemetry: (@Sendable (TelemetryEvent) -> Void)? = nil,
+        logInfo: @escaping @Sendable (String) -> Void = { _ in },
+        logWarning: @escaping @Sendable (String) -> Void = { _ in }
+    ) async throws -> EngineV2PreparedModel {
+        let snapshot = await modelSnapshot(container: container)
+        let servingModel = try servingModel(
+            modelId: modelId,
+            isVLM: isVLM,
+            modelDirectory: modelDirectory,
+            snapshot: snapshot,
+            emitTelemetry: emitTelemetry,
+            logInfo: logInfo)
+
+        var assistant: ProviderMTPAssistantHandle?
+        var mtpStatus = specDecPreparation.status
+        var retainedArtifact: SpecDecArtifact?
+        if let candidate = specDecPreparation.artifact {
+            let artifact: SpecDecArtifact
+            let revalidation = SpecDecStore.revalidateForLoad(candidate)
+            if let verified = revalidation.artifact {
+                artifact = verified
+                mtpStatus = .candidate(verified)
+            } else {
+                let reason = revalidation.reason ?? .warmArtifactCorrupt
+                mtpStatus = mtpStatus.fallingBack(reason)
+                logWarning(
+                    "mtp: model=\(modelId) fallback reason=\(reason.rawValue) detail="
+                        + (revalidation.detail ?? "artifact revalidation failed"))
+                return EngineV2PreparedModel(
+                    snapshot: snapshot,
+                    servingModel: servingModel,
+                    assistant: nil,
+                    mtpStatus: mtpStatus,
+                    mtpArtifact: nil)
+            }
+            do {
+                assistant = try await assistantLoader.loadAndBind(
+                    artifact: artifact, target: servingModel)
+                assistant?.bind(
+                    sourceTarget: snapshot.model, servingTarget: servingModel)
+                mtpStatus = mtpStatus.activated(assistantBytes: artifact.residentBytes)
+                retainedArtifact = artifact
+            } catch let error as ProviderMTPAssistantLoadError {
+                mtpStatus = mtpStatus.fallingBack(error.reason)
+                logWarning(
+                    "mtp: model=\(modelId) fallback reason=\(error.reason.rawValue) detail=\(error)")
+            } catch {
+                mtpStatus = mtpStatus.fallingBack(.assistantLoadFailed)
+                logWarning(
+                    "mtp: model=\(modelId) fallback reason=\(MTPFallbackReason.assistantLoadFailed.rawValue) detail=\(error)")
+            }
+        }
+        return EngineV2PreparedModel(
+            snapshot: snapshot,
+            servingModel: servingModel,
+            assistant: assistant,
+            mtpStatus: mtpStatus,
+            mtpArtifact: retainedArtifact)
+    }
+
+    /// Recovery may reuse already-accounted assistant residency, but it must
+    /// never call an assistant loader. Invalid or structurally stale ownership
+    /// falls back to a fresh target-only engine over the retained container.
+    static func prepareRecoveryModel(
+        modelId: String,
+        isVLM: Bool,
+        modelDirectory: URL?,
+        container: ModelContainer,
+        previousArtifact: SpecDecArtifact?,
+        previousStatus: MTPActivationStatus,
+        assistant: ProviderMTPAssistantHandle?,
+        emitTelemetry: (@Sendable (TelemetryEvent) -> Void)? = nil,
+        logInfo: @escaping @Sendable (String) -> Void = { _ in },
+        logWarning: @escaping @Sendable (String) -> Void = { _ in }
+    ) async throws -> EngineV2PreparedModel {
+        let snapshot = await modelSnapshot(container: container)
+
+        if previousStatus.active,
+            let previousArtifact,
+            let assistant,
+            previousStatus.source == previousArtifact.source,
+            previousStatus.revision == previousArtifact.revision,
+            previousStatus.artifactBytes == previousArtifact.artifactBytes,
+            previousStatus.assistantBytes == previousArtifact.residentBytes
+        {
+            let revalidation = SpecDecStore.revalidateForLoad(previousArtifact)
+            if let artifact = revalidation.artifact,
+                let reusedTarget = assistant.recoveryServingTarget(
+                    for: snapshot.model)
+            {
+                return EngineV2PreparedModel(
+                    snapshot: snapshot,
+                    servingModel: reusedTarget,
+                    assistant: assistant,
+                    mtpStatus: MTPActivationStatus.candidate(artifact).activated(
+                        assistantBytes: artifact.residentBytes),
+                    mtpArtifact: artifact)
+            }
+            let reason = revalidation.reason ?? .assistantTargetIncompatible
+            logWarning(
+                "mtp: model=\(modelId) recovery fallback reason=\(reason.rawValue) detail="
+                    + (revalidation.detail ?? "installed assistant binding is not reusable"))
+            let target = try servingModel(
+                modelId: modelId,
+                isVLM: isVLM,
+                modelDirectory: modelDirectory,
+                snapshot: snapshot,
+                emitTelemetry: emitTelemetry,
+                logInfo: logInfo)
+            return EngineV2PreparedModel(
+                snapshot: snapshot,
+                servingModel: target,
+                assistant: nil,
+                mtpStatus: previousStatus.fallingBack(reason),
+                mtpArtifact: nil)
+        }
+
+        let reason: MTPFallbackReason? = previousStatus.active ? .engineInactive : nil
+        let target = try servingModel(
+            modelId: modelId,
+            isVLM: isVLM,
+            modelDirectory: modelDirectory,
+            snapshot: snapshot,
+            emitTelemetry: emitTelemetry,
+            logInfo: logInfo)
+        return EngineV2PreparedModel(
+            snapshot: snapshot,
+            servingModel: target,
+            assistant: nil,
+            mtpStatus: reason.map(previousStatus.fallingBack) ?? previousStatus,
+            mtpArtifact: nil)
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2SlotFactory.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2SlotFactory.swift
@@ -23,17 +23,6 @@
 import Foundation
 import MLXLMCommon
 
-/// Model handle + EOS config snapshot pulled out of `ModelContainer.perform`.
-///
-/// `@unchecked Sendable` justification: the module reference crosses the
-/// container's isolation exactly once, at load time, to be handed to the v2
-/// engine — which serializes every use on its own engine thread.
-struct EngineV2ModelSnapshot: @unchecked Sendable {
-    let model: any LanguageModel
-    let eosTokenIds: Set<Int>
-    let extraEOSTokens: [String]
-}
-
 enum EngineV2SlotFactory {
 
     // MARK: - Prefix-cache carve (T-041, v0.7.5)
@@ -220,6 +209,59 @@ enum EngineV2SlotFactory {
         logInfo: @escaping @Sendable (String) -> Void = { _ in },
         logWarning: @escaping @Sendable (String) -> Void = { _ in }
     ) async throws -> EngineV2Bridge {
+        try await makeProductionBundle(
+            modelId: modelId,
+            modelType: modelType,
+            isVLM: isVLM,
+            modelDirectory: modelDirectory,
+            container: container,
+            tokenizer: tokenizer,
+            sizing: sizing,
+            kvBytesCapacity: kvBytesCapacity,
+            maxConcurrentRequests: maxConcurrentRequests,
+            kvBudget: kvBudget,
+            kvQuantConfigured: kvQuantConfigured,
+            kvBackendConfig: kvBackendConfig,
+            kvBackendConfigByModel: kvBackendConfigByModel,
+            weightHash: weightHash,
+            specDecPreparation: SpecDecPreparation(
+                artifact: nil,
+                status: .disabled(.configDisabled, configured: false)),
+            environment: environment,
+            emitTelemetry: emitTelemetry,
+            makeEngineOverride: makeEngineOverride,
+            logInfo: logInfo,
+            logWarning: logWarning
+        ).bridge
+    }
+
+    /// Production bundle assembly. Assistant preparation is deliberately
+    /// fail-open; target extraction/engine construction retain their existing
+    /// fail-loud semantics.
+    static func makeProductionBundle(
+        modelId: String,
+        modelType: String?,
+        isVLM: Bool,
+        modelDirectory: URL?,
+        container: ModelContainer,
+        tokenizer: TokenizerHandle,
+        sizing: SlotSizingSnapshot,
+        kvBytesCapacity: Int,
+        maxConcurrentRequests: Int,
+        kvBudget: GlobalKVCacheBudget?,
+        kvQuantConfigured: Bool,
+        kvBackendConfig: String = "auto",
+        kvBackendConfigByModel: [String: String] = [:],
+        weightHash: String? = nil,
+        specDecPreparation: SpecDecPreparation,
+        preparedModel: EngineV2PreparedModel? = nil,
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        emitTelemetry: (@Sendable (TelemetryEvent) -> Void)? = nil,
+        makeEngineOverride: (@Sendable (String, Int) throws -> any CBv2Engine)? = nil,
+        assistantLoader: any ProviderMTPAssistantLoading = Gemma4ProviderMTPAssistantLoader(),
+        logInfo: @escaping @Sendable (String) -> Void = { _ in },
+        logWarning: @escaping @Sendable (String) -> Void = { _ in }
+    ) async throws -> ProviderEngineBundle {
         // KV-backend gate, slot-veto layer (`EngineV2KVBackendPolicy`):
         // parse the operator selection (per-model override wins; typo →
         // WARN + auto), then force contiguous for slots the paged cache
@@ -244,17 +286,41 @@ enum EngineV2SlotFactory {
                 "engine_v2: \(modelId) paged KV backend forced to contiguous "
                     + "(\(veto))")
         }
-        // Snapshot the model handle + EOS config out of the container.
-        // Handing the module reference to the v2 engine serializes all
-        // forward passes on the engine's own step thread. Taken BEFORE the
-        // carve because the per-model funding gate needs the model's layer
-        // shape.
-        let snapshot = await container.perform { ctx in
-            EngineV2ModelSnapshot(
-                model: ctx.model,
-                eosTokenIds: ctx.configuration.eosTokenIds,
-                extraEOSTokens: ctx.configuration.extraEOSTokens.sorted())
+        let prepared: EngineV2PreparedModel
+        if let preparedModel {
+            prepared = preparedModel
+        } else if makeEngineOverride != nil {
+            // Scripted engines intentionally do not construct real assistants.
+            prepared = try await prepareProductionModel(
+                modelId: modelId,
+                isVLM: isVLM,
+                modelDirectory: modelDirectory,
+                container: container,
+                specDecPreparation: SpecDecPreparation(
+                    artifact: nil, status: specDecPreparation.status),
+                assistantLoader: assistantLoader,
+                emitTelemetry: emitTelemetry,
+                logInfo: logInfo,
+                logWarning: logWarning)
+        } else {
+            prepared = try await prepareProductionModel(
+                modelId: modelId,
+                isVLM: isVLM,
+                modelDirectory: modelDirectory,
+                container: container,
+                specDecPreparation: specDecPreparation,
+                assistantLoader: assistantLoader,
+                emitTelemetry: emitTelemetry,
+                logInfo: logInfo,
+                logWarning: logWarning)
         }
+        let snapshot = prepared.snapshot
+        let servingModel = prepared.servingModel
+        let assistantHandle = prepared.assistant
+        let mtpStatus = prepared.mtpStatus
+        let mtpConfig = CBv2MTPConfig(
+            enabled: assistantHandle != nil,
+            fixedDraftTokens: nil)
         // Same model-specific EOS augmentation as always (GPT-OSS/Harmony
         // adds its generation-config action stops) — from the
         // scheduler-free policy home.
@@ -274,7 +340,7 @@ enum EngineV2SlotFactory {
             modelId: modelId,
             isVLM: isVLM,
             modelDirectory: modelDirectory,
-            model: snapshot.model,
+            model: servingModel,
             slotKVBytesCapacity: kvBytesCapacity,
             kvBytesPerToken: sizing.fp16KVBytesPerToken,
             environment: environment)
@@ -318,13 +384,7 @@ enum EngineV2SlotFactory {
                         + "this slot; tiers do not compose in v1")
             }
             let ssdLayerKinds: [CBv2LayerKind]?
-            if isVLM {
-                ssdLayerKinds = modelDirectory.flatMap {
-                    EngineV2VLMTextExtraction.cbv2LayerKinds(modelDirectory: $0)
-                }
-            } else {
-                ssdLayerKinds = EngineV2Factory.cbv2LayerKinds(model: snapshot.model)
-            }
+            ssdLayerKinds = EngineV2Factory.cbv2LayerKinds(model: servingModel)
             if let ssdLayerKinds {
                 ssdPrefixCache = await SSDPrefixCacheFactory.make(
                     modelId: modelId,
@@ -363,32 +423,14 @@ enum EngineV2SlotFactory {
             }
         } else {
             makeEngine = {
-                // VLM slot: extract the CBv2-adapted MLXLLM text model over
-                // the SAME weight arrays (zero extra weight memory) and
-                // build the engine on that; any extraction/verify/parity
-                // failure throws into the factory's engine_v2_refusal ERROR.
-                let servingModel: any LanguageModel
-                if isVLM {
-                    guard let modelDirectory else {
-                        throw EngineV2VLMTextExtractionError.missingModelDirectory
-                    }
-                    let extraction = try EngineV2VLMTextExtraction.extractTextModel(
-                        from: snapshot.model, modelDirectory: modelDirectory)
-                    if let parityDiff = extraction.parityMaxAbsLogitDiff {
-                        logInfo(
-                            "engine_v2: \(modelId) VLM text-model extraction passed the "
-                                + "load-time forward parity gate (max |Δlogit| \(parityDiff))")
-                    }
-                    servingModel = extraction.model
-                } else {
-                    servingModel = snapshot.model
-                }
                 return try EngineV2Factory.makeProductionBuild(
                     model: servingModel,
                     tokenizer: tokenizer.inner,
                     kvBytesCapacity: engineKVBytesCapacity,
                     prefixCache: enginePrefixCache,
                     maxConcurrentRequests: maxConcurrentRequests,
+                    mtpDrafter: assistantHandle?.drafter,
+                    mtpConfig: mtpConfig,
                     kvBackend: kvBackendSelection,
                     // Sizes the paged pool's per-group split
                     // (`nominalMaxSequenceLength`); 0/unknown → factory
@@ -430,6 +472,7 @@ enum EngineV2SlotFactory {
         if let ssdPrefixCache {
             await bridge.startSSDPrefixCacheStatsLogger(cache: ssdPrefixCache)
         }
+        await bridge.configureMTPStatus(mtpStatus)
         logInfo(
             "engine_v2: \(modelId) prefix cache "
                 + prefixCacheStateDescription(
@@ -443,6 +486,18 @@ enum EngineV2SlotFactory {
             EngineV2Factory.emitKVQuantUnsupportedTelemetry(
                 modelId: modelId, emitTelemetry: emitTelemetry)
         }
-        return bridge
+        let reason = mtpStatus.reason?.rawValue ?? "none"
+        let revision = mtpStatus.revision ?? "none"
+        logInfo(
+            "mtp: model=\(modelId) configured=\(mtpStatus.configured) active=\(mtpStatus.active) "
+                + "reason=\(reason) source=\(mtpStatus.source?.rawValue ?? "none") "
+                + "revision=\(revision) artifact_bytes=\(mtpStatus.artifactBytes) "
+                + "assistant_bytes=\(mtpStatus.assistantBytes)")
+        return ProviderEngineBundle(
+            bridge: bridge,
+            assistant: assistantHandle,
+            assistantBytes: mtpStatus.assistantBytes,
+            mtpArtifact: prepared.mtpArtifact,
+            mtpStatus: mtpStatus)
     }
 }

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2SlotFactory.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2SlotFactory.swift
@@ -318,9 +318,13 @@ enum EngineV2SlotFactory {
         let servingModel = prepared.servingModel
         let assistantHandle = prepared.assistant
         let mtpStatus = prepared.mtpStatus
+        let automaticRectangularTokens = MTPAutomaticVerificationPolicy.maxRectangularTokens(
+            environment: environment)
         let mtpConfig = CBv2MTPConfig(
             enabled: assistantHandle != nil,
-            fixedDraftTokens: nil)
+            fixedDraftTokens: MTPAutomaticVerificationPolicy.initialDraftTokens,
+            verificationMode: .automatic,
+            maxAutomaticRectangularTokens: automaticRectangularTokens)
         // Same model-specific EOS augmentation as always (GPT-OSS/Harmony
         // adds its generation-config action stops) — from the
         // scheduler-free policy home.

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2SupportedModels.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2SupportedModels.swift
@@ -32,6 +32,14 @@ public enum EngineV2SupportedModels {
             !raw.isEmpty
         else { return false }
         if raw == "gpt_oss" { return true }
+        // `gemma4_assistant` is the KV-less MTP drafter checkpoint, NOT a
+        // servable chat model (no standalone forward — it attends a frozen
+        // snapshot of the target's KV). Without this carve-out the gemma4
+        // prefix match below would advertise a hand-downloaded drafter in
+        // the HF cache as a chat model and the coordinator could route to
+        // it. Drafters bind engine-side only (spec-dec dir / mtp_drafter_path),
+        // never scanned, advertised, or attested.
+        if raw == "gemma4_assistant" { return false }
         // Gemma 4 family: `gemma4` (VLM wrapper), `gemma4_text`, and any
         // future gemma4-suffixed text/VLM variant. Deliberately a prefix so
         // `gemma3`/`gemma2` (no CBv2 adapter) can never match.

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2SupportedModels.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2SupportedModels.swift
@@ -10,7 +10,8 @@
 // declares (the value `ModelScanner.parseModelInfo` stamps on `ModelInfo`):
 //
 //   * `gpt_oss`      — GPT-OSS (GPTOSSModel)
-//   * `gemma4…`      — Gemma 4 text (`gemma4_text`) AND the Gemma 4 VLM
+//   * `gemma4`       — Gemma 4 VLM wrapper
+//   * `gemma4_text`  — Gemma 4 text target
 //                      wrapper (`gemma4`, served via the weight-sharing
 //                      text-model extraction + vision prefill)
 //
@@ -25,26 +26,22 @@
 import Foundation
 
 public enum EngineV2SupportedModels {
+    /// Exact config namespaces registered by the official Gemma 4 target
+    /// factories. Keep this closed: assistant checkpoints intentionally share
+    /// the `gemma4` prefix and must never become advertised chat targets.
+    private static let gemma4TargetTypes: Set<String> = ["gemma4", "gemma4_text"]
+
+    static func isGemma4Target(modelType: String?) -> Bool {
+        guard let raw = normalized(modelType) else { return false }
+        return gemma4TargetTypes.contains(raw)
+    }
+
     /// Whether the v2 engine can serve this `model_type` (config.json).
     /// nil/unknown types are unsupported — fail closed.
     public static func isSupported(modelType: String?) -> Bool {
-        guard let raw = modelType?.trimmingCharacters(in: .whitespaces).lowercased(),
-            !raw.isEmpty
-        else { return false }
+        guard let raw = normalized(modelType) else { return false }
         if raw == "gpt_oss" { return true }
-        // `gemma4_assistant` is the KV-less MTP drafter checkpoint, NOT a
-        // servable chat model (no standalone forward — it attends a frozen
-        // snapshot of the target's KV). Without this carve-out the gemma4
-        // prefix match below would advertise a hand-downloaded drafter in
-        // the HF cache as a chat model and the coordinator could route to
-        // it. Drafters bind engine-side only (spec-dec dir / mtp_drafter_path),
-        // never scanned, advertised, or attested.
-        if raw == "gemma4_assistant" { return false }
-        // Gemma 4 family: `gemma4` (VLM wrapper), `gemma4_text`, and any
-        // future gemma4-suffixed text/VLM variant. Deliberately a prefix so
-        // `gemma3`/`gemma2` (no CBv2 adapter) can never match.
-        if raw.hasPrefix("gemma4") { return true }
-        return false
+        return gemma4TargetTypes.contains(raw)
     }
 
     /// Split an advertised-model list into (supported, unsupported) by the
@@ -62,5 +59,12 @@ public enum EngineV2SupportedModels {
             }
         }
         return (supported, unsupported)
+    }
+
+    private static func normalized(_ modelType: String?) -> String? {
+        guard let raw = modelType?.trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased(), !raw.isEmpty
+        else { return nil }
+        return raw
     }
 }

--- a/provider-swift/Sources/ProviderCore/Inference/GlobalKVCacheBudget.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/GlobalKVCacheBudget.swift
@@ -220,6 +220,26 @@ public actor GlobalKVCacheBudget {
         reservations[requestID] = Reservation(bytes: bytes, createdAt: .now)
     }
 
+    /// Atomically replace the in-flight load reservation when target weights
+    /// become live but an optional assistant is still pending. Zero removes it.
+    public func replacePendingLoadReservation(requestID: String, bytes: UInt64) {
+        let previous = reservations[requestID]?.bytes
+        if bytes == 0 {
+            reservations.removeValue(forKey: requestID)
+        } else if let createdAt = reservations[requestID]?.createdAt {
+            reservations[requestID] = Reservation(bytes: bytes, createdAt: createdAt)
+        } else {
+            reservations[requestID] = Reservation(bytes: bytes, createdAt: .now)
+        }
+        // Removing or shrinking a real pending-load promise proves the ledger
+        // is making progress, exactly like `release`. Do not let a rejection
+        // streak armed against the larger footprint audit live reservations.
+        if let previous, bytes < previous {
+            rejectionStreakStart = nil
+            lastRejectionAt = nil
+        }
+    }
+
     /// Atomically shrink an existing reservation to a smaller byte count,
     /// freeing the difference. `reserve`/`release` cannot express a shrink:
     /// `reserve` refuses when an entry already exists for the id, and a
@@ -415,6 +435,10 @@ public actor GlobalKVCacheBudget {
     /// deterministically (they run the injected `clearCache` synchronously on the
     /// reclaimer actor) instead of racing the fire-and-forget signal tasks.
     var reclaimerForTesting: KVPoolReclaimer { reclaimer }
+
+    func rejectionStreakArmedForTesting() -> Bool {
+        rejectionStreakStart != nil || lastRejectionAt != nil
+    }
 
     /// Current reservation ids, so tests can assert the ledger is empty (or
     /// holds exactly the expected live entries) after a load/audit sequence.

--- a/provider-swift/Sources/ProviderCore/Inference/MTPAutomaticVerificationPolicy.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/MTPAutomaticVerificationPolicy.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+public enum MTPAutomaticVerificationPolicy {
+    public static let initialDraftTokens = 1
+
+    public static func maxRectangularTokens(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        chipName: String? = nil
+    ) -> Int {
+        let resolvedChipName = chipName
+            ?? (try? sysctlString("machdep.cpu.brand_string"))
+            ?? "Unknown"
+        let certifiedMaximum = maxRectangularTokens(chipName: resolvedChipName)
+        if let value = environment["DARKBLOOM_MTP_MAX_RECTANGULAR_TOKENS"].flatMap(Int.init) {
+            return min(max(value, 0), certifiedMaximum)
+        }
+        return certifiedMaximum
+    }
+
+    public static func maxRectangularTokens(chipName: String) -> Int {
+        switch parseChipIdentity(chipName).0 {
+        case .m3, .m4, .m5:
+            return 8
+        case .m1, .m2, .unknown:
+            return 4
+        }
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Inference/ProviderEngineBundle.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/ProviderEngineBundle.swift
@@ -1,0 +1,151 @@
+import Foundation
+import MLXLLM
+import MLXLMCommon
+
+/// Read-only provider view of MTP activation and cumulative engine metrics.
+/// It deliberately contains no model, prompt, token-id, or controller state.
+public struct ProviderMTPStatusSnapshot: Sendable, Equatable {
+    public let configured: Bool
+    public let active: Bool
+    public let fallbackReason: MTPFallbackReason?
+    public let assistantSource: SpecDecArtifactSource?
+    public let assistantRevision: String?
+    public let assistantArtifactBytes: UInt64
+    public let assistantResidentBytes: UInt64
+    public let selectedDepth: Int
+    public let decodeRowBucket: Int
+    public let rounds: Int
+    public let seedRows: Int
+    public let proposedTokens: Int
+    public let acceptedDraftTokens: Int
+    public let committedEmittedTokens: Int
+    public let acceptanceByPosition: [Int]
+    public let skippedRows: [String: Int]
+    public let controllerFallbacks: [String: Int]
+
+    init(status: MTPActivationStatus, metrics: CBv2MTPMetrics?) {
+        let engineActive = metrics?.active == true
+        self.configured = status.configured
+        self.active = status.active && engineActive
+        self.fallbackReason = status.active && !engineActive ? .engineInactive : status.reason
+        self.assistantSource = status.source
+        self.assistantRevision = status.revision
+        self.assistantArtifactBytes = status.artifactBytes
+        self.assistantResidentBytes = status.assistantBytes
+        self.selectedDepth = metrics?.selectedDepth ?? 0
+        self.decodeRowBucket = metrics?.decodeRowBucket ?? 0
+        self.rounds = metrics?.rounds ?? 0
+        self.seedRows = metrics?.seedSteps ?? 0
+        self.proposedTokens = metrics?.proposedTokens ?? 0
+        self.acceptedDraftTokens = metrics?.acceptedTokens ?? 0
+        self.committedEmittedTokens = metrics?.emittedTokens ?? 0
+        self.acceptanceByPosition = metrics?.perPositionAccepted ?? []
+        self.skippedRows = metrics?.skippedRows ?? [:]
+        self.controllerFallbacks = metrics?.controllerFallbacks ?? [:]
+    }
+}
+
+/// Opaque slot-owned assistant lifetime handle. The concrete owner is the
+/// loaded `Gemma4AssistantDraftModel`; the adapter is what `EngineV2` calls.
+final class ProviderMTPAssistantHandle: @unchecked Sendable {
+    private let lock = NSLock()
+    private var owner: AnyObject?
+    private var storedDrafter: (any CBv2MTPDrafter)?
+    private var sourceTargetID: ObjectIdentifier?
+    private var servingTarget: (any LanguageModel)?
+
+    var drafter: (any CBv2MTPDrafter)? { lock.withLock { storedDrafter } }
+
+    init(owner: AnyObject, drafter: any CBv2MTPDrafter) {
+        self.owner = owner
+        self.storedDrafter = drafter
+    }
+
+    func bind(sourceTarget: any LanguageModel, servingTarget: any LanguageModel) {
+        lock.withLock {
+            sourceTargetID = ObjectIdentifier(sourceTarget)
+            self.servingTarget = servingTarget
+        }
+    }
+
+    func recoveryServingTarget(for sourceTarget: any LanguageModel) -> (any LanguageModel)? {
+        lock.withLock {
+            guard owner != nil, storedDrafter != nil,
+                sourceTargetID == ObjectIdentifier(sourceTarget)
+            else { return nil }
+            return servingTarget
+        }
+    }
+
+    func release() {
+        lock.withLock {
+            storedDrafter = nil
+            servingTarget = nil
+            sourceTargetID = nil
+            owner = nil
+        }
+    }
+}
+
+/// One slot's engine and auxiliary ownership. `releaseAssistant()` is explicit
+/// so teardown order is observable and cannot depend on struct temporary scope.
+final class ProviderEngineBundle: @unchecked Sendable {
+    let bridge: EngineV2Bridge
+    let mtpArtifact: SpecDecArtifact?
+    let mtpStatus: MTPActivationStatus
+    let assistantBytes: UInt64
+
+    private let lock = NSLock()
+    private var assistant: ProviderMTPAssistantHandle?
+    private var pinnedAssistant: (any AnyObject & Sendable)?
+
+    init(
+        bridge: EngineV2Bridge,
+        assistant: ProviderMTPAssistantHandle?,
+        assistantBytes: UInt64,
+        mtpArtifact: SpecDecArtifact?,
+        mtpStatus: MTPActivationStatus,
+        pinnedAssistant: (any AnyObject & Sendable)? = nil
+    ) {
+        self.bridge = bridge
+        self.assistant = assistant
+        self.assistantBytes = assistantBytes
+        self.mtpArtifact = mtpArtifact
+        self.mtpStatus = mtpStatus
+        self.pinnedAssistant = pinnedAssistant
+    }
+
+    convenience init(targetOnly bridge: EngineV2Bridge) {
+        self.init(
+            bridge: bridge, assistant: nil, assistantBytes: 0, mtpArtifact: nil,
+            mtpStatus: .disabled(.configDisabled, configured: false))
+    }
+
+    var hasAssistant: Bool {
+        lock.withLock { assistant != nil || pinnedAssistant != nil }
+    }
+
+    /// Move the slot-owned assistant into a liveness rebuild. The old bundle
+    /// must not release a handle that the replacement engine is reusing.
+    func takeAssistantForRecovery() -> ProviderMTPAssistantHandle? {
+        lock.withLock {
+            let current = assistant
+            assistant = nil
+            return current
+        }
+    }
+
+    func releaseAssistant() {
+        let handle = lock.withLock { () -> ProviderMTPAssistantHandle? in
+            let current = assistant
+            assistant = nil
+            pinnedAssistant = nil
+            return current
+        }
+        handle?.release()
+    }
+
+    deinit {
+        releaseAssistant()
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Inference/ProviderEngineBundle.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/ProviderEngineBundle.swift
@@ -7,6 +7,7 @@ import MLXLMCommon
 public struct ProviderMTPStatusSnapshot: Sendable, Equatable {
     public let configured: Bool
     public let active: Bool
+    public let verificationMode: String?
     public let fallbackReason: MTPFallbackReason?
     public let assistantSource: SpecDecArtifactSource?
     public let assistantRevision: String?
@@ -27,6 +28,7 @@ public struct ProviderMTPStatusSnapshot: Sendable, Equatable {
         let engineActive = metrics?.active == true
         self.configured = status.configured
         self.active = status.active && engineActive
+        self.verificationMode = metrics?.verificationMode.rawValue
         self.fallbackReason = status.active && !engineActive ? .engineInactive : status.reason
         self.assistantSource = status.source
         self.assistantRevision = status.revision

--- a/provider-swift/Sources/ProviderCore/Inference/ProviderEngineBundle.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/ProviderEngineBundle.swift
@@ -8,6 +8,8 @@ public struct ProviderMTPStatusSnapshot: Sendable, Equatable {
     public let configured: Bool
     public let active: Bool
     public let verificationMode: String?
+    public let rectangularVerificationRounds: Int
+    public let serialVerificationRounds: Int
     public let fallbackReason: MTPFallbackReason?
     public let assistantSource: SpecDecArtifactSource?
     public let assistantRevision: String?
@@ -29,6 +31,8 @@ public struct ProviderMTPStatusSnapshot: Sendable, Equatable {
         self.configured = status.configured
         self.active = status.active && engineActive
         self.verificationMode = metrics?.verificationMode.rawValue
+        self.rectangularVerificationRounds = metrics?.rectangularVerificationRounds ?? 0
+        self.serialVerificationRounds = metrics?.serialVerificationRounds ?? 0
         self.fallbackReason = status.active && !engineActive ? .engineInactive : status.reason
         self.assistantSource = status.source
         self.assistantRevision = status.revision

--- a/provider-swift/Sources/ProviderCore/Inference/SlotSizingSnapshot.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/SlotSizingSnapshot.swift
@@ -33,8 +33,13 @@ import MLXVLM
 /// Immutable sizing facts for one loaded model slot.
 public struct SlotSizingSnapshot: Sendable, Equatable {
     /// Σ parameter nbytes over the loaded container (same figure the legacy
-    /// `snapshotContainer` measured). Feeds the fleet KV budget
-    /// (`UnifiedMemoryCap.kvBudgetBytes(residentWeightBytes:)`).
+    /// `snapshotContainer` measured), PLUS any `auxiliaryWeightBytes` folded
+    /// in at construction (the MTP drafter's resident footprint — plan D5
+    /// capacity truthfulness). Feeds the fleet KV budget
+    /// (`UnifiedMemoryCap.kvBudgetBytes(residentWeightBytes:)`), re-slice
+    /// grants, the heartbeat clamp, and StandaloneServer's mirrored budget:
+    /// folding at construction means every consumer sees the sum with zero
+    /// consumer-site changes.
     public let weightsBytes: Int
     /// fp16 per-token KV cost (bytes/token), engine-truth marginal rate —
     /// see the header. 0 = unknown (non-CBv2 family; such models are not
@@ -48,13 +53,19 @@ public struct SlotSizingSnapshot: Sendable, Equatable {
     /// legacy `applyPostLoadBudgets` policy).
     public let defaultMaxTokens: Int
 
+    /// `auxiliaryWeightBytes`: resident weight bytes that live OUTSIDE the
+    /// model container (the MTP drafter — never scanned, advertised, or
+    /// attested), folded into `weightsBytes` here so all downstream memory
+    /// accounting is truthful. Deliberately NOT an input to any KV-rate
+    /// figure: the drafter writes no KV.
     public init(
         weightsBytes: Int,
+        auxiliaryWeightBytes: Int = 0,
         fp16KVBytesPerToken: Int,
         maxContextLength: Int,
         defaultMaxTokens: Int
     ) {
-        self.weightsBytes = weightsBytes
+        self.weightsBytes = weightsBytes + max(0, auxiliaryWeightBytes)
         self.fp16KVBytesPerToken = fp16KVBytesPerToken
         self.maxContextLength = maxContextLength
         self.defaultMaxTokens = defaultMaxTokens
@@ -71,10 +82,15 @@ public struct SlotSizingSnapshot: Sendable, Equatable {
     ///   - modelPath: the checkpoint directory (for `config.json`).
     ///   - fallbackDefaultMaxTokens: the provider-wide default max-token
     ///     budget used when the model's context window is unknown.
+    ///   - auxiliaryWeightBytes: non-snapshot resident weight bytes (the MTP
+    ///     drafter estimate: file bytes × the standard 1.2 factor — sizing
+    ///     runs before the drafter loads). Folded into `weightsBytes`; never
+    ///     touches the KV-rate derivation below.
     public static func build(
         container: ModelContainer,
         modelPath: URL?,
-        fallbackDefaultMaxTokens: Int
+        fallbackDefaultMaxTokens: Int,
+        auxiliaryWeightBytes: Int = 0
     ) async -> SlotSizingSnapshot {
         struct ModuleFacts: @unchecked Sendable {
             let bytes: Int
@@ -137,6 +153,7 @@ public struct SlotSizingSnapshot: Sendable, Equatable {
 
         return SlotSizingSnapshot(
             weightsBytes: facts.bytes,
+            auxiliaryWeightBytes: auxiliaryWeightBytes,
             fp16KVBytesPerToken: kvRate,
             maxContextLength: maxContext,
             defaultMaxTokens: defaultMaxTokens

--- a/provider-swift/Sources/ProviderCore/Inference/SlotSizingSnapshot.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/SlotSizingSnapshot.swift
@@ -41,6 +41,11 @@ public struct SlotSizingSnapshot: Sendable, Equatable {
     /// folding at construction means every consumer sees the sum with zero
     /// consumer-site changes.
     public let weightsBytes: Int
+    /// Target container bytes only. Kept separately so a fail-open assistant
+    /// load can remove its prospective charge before final re-slicing.
+    public let targetWeightsBytes: Int
+    /// Resident assistant estimate. Zero for target-only/fallback slots.
+    public let auxiliaryWeightBytes: Int
     /// fp16 per-token KV cost (bytes/token), engine-truth marginal rate —
     /// see the header. 0 = unknown (non-CBv2 family; such models are not
     /// advertised and cannot serve, but the snapshot itself never fails).
@@ -65,10 +70,26 @@ public struct SlotSizingSnapshot: Sendable, Equatable {
         maxContextLength: Int,
         defaultMaxTokens: Int
     ) {
-        self.weightsBytes = weightsBytes + max(0, auxiliaryWeightBytes)
+        self.targetWeightsBytes = max(0, weightsBytes)
+        self.auxiliaryWeightBytes = max(0, auxiliaryWeightBytes)
+        let (total, overflow) = self.targetWeightsBytes.addingReportingOverflow(
+            self.auxiliaryWeightBytes)
+        self.weightsBytes = overflow ? Int.max : total
         self.fp16KVBytesPerToken = fp16KVBytesPerToken
         self.maxContextLength = maxContextLength
         self.defaultMaxTokens = defaultMaxTokens
+    }
+
+    /// Replace, rather than add to, the auxiliary charge. This is the only
+    /// legal transition from a pre-admission candidate estimate to the bytes
+    /// of an actually retained assistant.
+    public func replacingAuxiliaryWeightBytes(_ bytes: UInt64) -> SlotSizingSnapshot {
+        SlotSizingSnapshot(
+            weightsBytes: targetWeightsBytes,
+            auxiliaryWeightBytes: Int(min(bytes, UInt64(Int.max))),
+            fp16KVBytesPerToken: fp16KVBytesPerToken,
+            maxContextLength: maxContextLength,
+            defaultMaxTokens: defaultMaxTokens)
     }
 
     // MARK: - Builder

--- a/provider-swift/Sources/ProviderCore/Models/ModelCatalogClient.swift
+++ b/provider-swift/Sources/ProviderCore/Models/ModelCatalogClient.swift
@@ -10,6 +10,15 @@ import Foundation
 
 public struct ModelCatalogClient: Sendable {
 
+    static let maximumCatalogResponseBytes = 4 * 1024 * 1024
+    static let maximumManifestResponseBytes = 1 * 1024 * 1024
+    static let maximumCatalogModelCount = 4_096
+    static let maximumCatalogAliasCount = 4_096
+    private static let maximumManifestFileCount = 16_384
+    private static let maximumJSONNestingDepth = 32
+    private static let maximumJSONStringBytes = 256 * 1024
+    private static let maximumJSONCollectionCount = 4_096
+
     private let coordinatorURL: String
     private let urlSession: URLSession
 
@@ -46,7 +55,12 @@ public struct ModelCatalogClient: Sendable {
         let data: Data
         let response: URLResponse
         do {
-            (data, response) = try await urlSession.data(for: request)
+            (data, response) = try await boundedData(
+                for: request,
+                maximumBytes: Self.maximumCatalogResponseBytes,
+                responseName: "catalog response")
+        } catch let error as ModelCatalogError {
+            throw error
         } catch {
             throw ModelCatalogError.unreachable(error.localizedDescription)
         }
@@ -56,8 +70,12 @@ public struct ModelCatalogClient: Sendable {
         }
 
         do {
+            try Self.validateJSONLexicalBounds(data, responseName: "catalog response")
             let decoded = try JSONDecoder().decode(CatalogResponse.self, from: data)
+            try Self.validateCatalogBounds(decoded)
             return CatalogSnapshot(models: decoded.models, aliases: decoded.aliases ?? [])
+        } catch let error as ModelCatalogError {
+            throw error
         } catch {
             throw ModelCatalogError.decodeFailed(error.localizedDescription)
         }
@@ -80,7 +98,12 @@ public struct ModelCatalogClient: Sendable {
         let data: Data
         let response: URLResponse
         do {
-            (data, response) = try await urlSession.data(for: request)
+            (data, response) = try await boundedData(
+                for: request,
+                maximumBytes: Self.maximumManifestResponseBytes,
+                responseName: "manifest response")
+        } catch let error as ModelCatalogError {
+            throw error
         } catch {
             throw ModelCatalogError.unreachable(error.localizedDescription)
         }
@@ -90,7 +113,12 @@ public struct ModelCatalogClient: Sendable {
         }
 
         do {
-            return try Self.manifestDecoder.decode(ModelManifest.self, from: data)
+            try Self.validateJSONLexicalBounds(data, responseName: "manifest response")
+            let manifest = try Self.manifestDecoder.decode(ModelManifest.self, from: data)
+            try Self.validateManifestBounds(manifest)
+            return manifest
+        } catch let error as ModelCatalogError {
+            throw error
         } catch {
             throw ModelCatalogError.decodeFailed(error.localizedDescription)
         }
@@ -107,5 +135,173 @@ public struct ModelCatalogClient: Sendable {
         allowed.remove(charactersIn: "/")
         return modelID.addingPercentEncoding(withAllowedCharacters: allowed)
     }
-}
 
+    /// `URLSession.data(for:)` buffers without an application byte ceiling.
+    /// Consume the response stream directly so a missing or dishonest
+    /// Content-Length cannot make catalog JSON an unbounded allocation.
+    private func boundedData(
+        for request: URLRequest,
+        maximumBytes: Int,
+        responseName: String
+    ) async throws -> (Data, URLResponse) {
+        let (bytes, response) = try await urlSession.bytes(for: request)
+        if response.expectedContentLength > Int64(maximumBytes) {
+            throw ModelCatalogError.decodeFailed("\(responseName) exceeds \(maximumBytes)-byte bound")
+        }
+
+        var data = Data()
+        if response.expectedContentLength > 0 {
+            data.reserveCapacity(min(Int(response.expectedContentLength), maximumBytes))
+        }
+        do {
+            for try await byte in bytes {
+                guard data.count < maximumBytes else {
+                    throw ModelCatalogError.decodeFailed(
+                        "\(responseName) exceeds \(maximumBytes)-byte bound")
+                }
+                data.append(byte)
+            }
+        } catch let error as ModelCatalogError {
+            throw error
+        }
+        return (data, response)
+    }
+
+    /// Cheap lexical limits run before recursive Codable decoding. They are
+    /// deliberately not a JSON parser; malformed syntax still belongs to
+    /// JSONDecoder, while depth and individual string size are bounded here.
+    private static func validateJSONLexicalBounds(
+        _ data: Data,
+        responseName: String
+    ) throws {
+        var depth = 0
+        var inString = false
+        var escaped = false
+        var stringBytes = 0
+
+        for byte in data {
+            if inString {
+                if escaped {
+                    escaped = false
+                } else if byte == 0x5c {
+                    escaped = true
+                } else if byte == 0x22 {
+                    inString = false
+                    stringBytes = 0
+                } else {
+                    stringBytes += 1
+                    if stringBytes > maximumJSONStringBytes {
+                        throw ModelCatalogError.decodeFailed(
+                            "\(responseName) contains an oversized JSON string")
+                    }
+                }
+                continue
+            }
+
+            switch byte {
+            case 0x22:
+                inString = true
+                stringBytes = 0
+            case 0x7b, 0x5b:
+                depth += 1
+                if depth > maximumJSONNestingDepth {
+                    throw ModelCatalogError.decodeFailed(
+                        "\(responseName) exceeds JSON nesting bound")
+                }
+            case 0x7d, 0x5d:
+                depth = max(0, depth - 1)
+            default:
+                break
+            }
+        }
+    }
+
+    private static func validateCatalogBounds(_ response: CatalogResponse) throws {
+        guard response.models.count <= maximumCatalogModelCount else {
+            throw ModelCatalogError.decodeFailed("catalog model count exceeds provider bound")
+        }
+        let aliases = response.aliases ?? []
+        guard aliases.count <= maximumCatalogAliasCount else {
+            throw ModelCatalogError.decodeFailed("catalog alias count exceeds provider bound")
+        }
+        guard response.models.allSatisfy(modelWithinBounds),
+            aliases.allSatisfy(aliasWithinBounds)
+        else {
+            throw ModelCatalogError.decodeFailed("catalog field exceeds provider structural bound")
+        }
+    }
+
+    private static func modelWithinBounds(_ model: CatalogModel) -> Bool {
+        let strings = [
+            model.id, model.s3Name, model.displayName, model.modelType,
+            model.architecture, model.description, model.weightHash, model.version,
+            model.r2Prefix, model.aggregateSHA256, model.family, model.quantization,
+        ].compactMap { $0 }
+        guard strings.allSatisfy({ $0.utf8.count <= maximumJSONStringBytes }),
+            (model.capabilities?.count ?? 0) <= maximumJSONCollectionCount,
+            model.capabilities?.allSatisfy({ $0.utf8.count <= maximumJSONStringBytes }) ?? true,
+            jsonDictionaryWithinBounds(model.runtimeParameters),
+            jsonDictionaryWithinBounds(model.metadata)
+        else { return false }
+        return true
+    }
+
+    private static func aliasWithinBounds(_ alias: CatalogAlias) -> Bool {
+        let strings = [
+            alias.id, alias.displayName, alias.desiredBuild,
+            alias.previousBuild, alias.primaryBuild,
+        ].compactMap { $0 }
+        return strings.allSatisfy { $0.utf8.count <= maximumJSONStringBytes }
+            && (alias.retiredBuilds?.count ?? 0) <= maximumJSONCollectionCount
+            && (alias.retiredBuilds?.allSatisfy {
+                $0.utf8.count <= maximumJSONStringBytes
+            } ?? true)
+    }
+
+    private static func jsonDictionaryWithinBounds(
+        _ dictionary: [String: JSONValue]?
+    ) -> Bool {
+        guard let dictionary else { return true }
+        guard dictionary.count <= maximumJSONCollectionCount else { return false }
+        return dictionary.allSatisfy {
+            $0.key.utf8.count <= maximumJSONStringBytes
+                && jsonValueWithinBounds($0.value, depth: 1)
+        }
+    }
+
+    private static func jsonValueWithinBounds(_ value: JSONValue, depth: Int) -> Bool {
+        guard depth <= maximumJSONNestingDepth else { return false }
+        switch value {
+        case .null, .bool, .int, .double:
+            return true
+        case .string(let string):
+            return string.utf8.count <= maximumJSONStringBytes
+        case .array(let values):
+            return values.count <= maximumJSONCollectionCount
+                && values.allSatisfy { jsonValueWithinBounds($0, depth: depth + 1) }
+        case .object(let pairs):
+            return pairs.count <= maximumJSONCollectionCount
+                && pairs.allSatisfy {
+                    $0.0.utf8.count <= maximumJSONStringBytes
+                        && jsonValueWithinBounds($0.1, depth: depth + 1)
+                }
+        }
+    }
+
+    private static func validateManifestBounds(_ manifest: ModelManifest) throws {
+        let strings = [
+            manifest.modelID, manifest.version, manifest.r2Prefix,
+            manifest.aggregateSHA256,
+        ]
+        guard manifest.files.count <= maximumManifestFileCount,
+            strings.allSatisfy({ $0.utf8.count <= maximumJSONStringBytes }),
+            manifest.files.allSatisfy({ file in
+                file.path.utf8.count <= maximumJSONStringBytes
+                    && file.sha256.utf8.count <= maximumJSONStringBytes
+                    && file.role.utf8.count <= maximumJSONStringBytes
+            })
+        else {
+            throw ModelCatalogError.decodeFailed("manifest exceeds provider structural bound")
+        }
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Models/ModelDownloader+Download.swift
+++ b/provider-swift/Sources/ProviderCore/Models/ModelDownloader+Download.swift
@@ -36,6 +36,7 @@ extension ModelDownloader {
             onProgress: nil,
             required: true,
             expectedSHA256: job.file.sha256.lowercased(),
+            maximumBytes: job.file.sizeBytes,
             onChunk: onChunk
         )
         guard ok else {

--- a/provider-swift/Sources/ProviderCore/Models/ModelDownloader+HTTP.swift
+++ b/provider-swift/Sources/ProviderCore/Models/ModelDownloader+HTTP.swift
@@ -42,6 +42,7 @@ extension ModelDownloader {
         onProgress: (@Sendable (ProgressEvent) -> Void)?,
         required: Bool,
         expectedSHA256: String? = nil,
+        maximumBytes: Int64? = nil,
         onChunk: (@Sendable (Int64) -> Void)? = nil
     ) async throws -> Bool {
         guard let url = URL(string: urlString) else {
@@ -66,6 +67,7 @@ extension ModelDownloader {
                     to: partial,
                     label: label,
                     required: required,
+                    maximumBytes: maximumBytes,
                     onChunk: onChunk
                 )
                 guard ok else {
@@ -127,6 +129,7 @@ extension ModelDownloader {
         to partial: URL,
         label: String,
         required: Bool,
+        maximumBytes: Int64?,
         onChunk: (@Sendable (Int64) -> Void)? = nil
     ) async throws -> Bool {
         let existingBytes = fileSize(partial)
@@ -145,6 +148,7 @@ extension ModelDownloader {
             partial: partial,
             existingBytes: existingBytes,
             label: label,
+            maximumTotalBytes: maximumBytes,
             onChunk: onChunk
         )
         let task = urlSession.dataTask(with: request)

--- a/provider-swift/Sources/ProviderCore/Models/StreamingFileDownloadDelegate.swift
+++ b/provider-swift/Sources/ProviderCore/Models/StreamingFileDownloadDelegate.swift
@@ -45,6 +45,7 @@ final class StreamingFileDownloadDelegate: NSObject, URLSessionDataDelegate, @un
     private let partial: URL
     private let existingBytes: Int64
     private let label: String
+    private let maximumTotalBytes: Int64?
     private let onChunk: (@Sendable (Int64) -> Void)?
     private let fm = FileManager.default
 
@@ -64,11 +65,13 @@ final class StreamingFileDownloadDelegate: NSObject, URLSessionDataDelegate, @un
         partial: URL,
         existingBytes: Int64,
         label: String,
+        maximumTotalBytes: Int64? = nil,
         onChunk: (@Sendable (Int64) -> Void)?
     ) {
         self.partial = partial
         self.existingBytes = existingBytes
         self.label = label
+        self.maximumTotalBytes = maximumTotalBytes
         self.onChunk = onChunk
         super.init()
     }
@@ -149,6 +152,14 @@ final class StreamingFileDownloadDelegate: NSObject, URLSessionDataDelegate, @un
             completionHandler(.cancel)
             return
         }
+        if let maximumTotalBytes, maximumTotalBytes >= 0,
+            http.expectedContentLength > maximumTotalBytes
+        {
+            setupError = ModelCatalogError.downloadFailed(
+                "\(label): response exceeds manifest size bound")
+            completionHandler(.cancel)
+            return
+        }
 
         // Append only when the server confirms it resumed at our exact offset.
         var append = false
@@ -183,6 +194,16 @@ final class StreamingFileDownloadDelegate: NSObject, URLSessionDataDelegate, @un
 
     func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
         guard setupError == nil, let writer else { return }
+        if let maximumTotalBytes {
+            let (received, overflow) = baseline.addingReportingOverflow(written)
+            let (next, nextOverflow) = received.addingReportingOverflow(Int64(data.count))
+            if overflow || nextOverflow || next > maximumTotalBytes {
+                setupError = ModelCatalogError.downloadFailed(
+                    "\(label): response exceeds manifest size bound")
+                dataTask.cancel()
+                return
+            }
+        }
         do {
             // Synchronous write == backpressure: the next didReceive(data:) is
             // not delivered until this returns, throttling the socket to disk.

--- a/provider-swift/Sources/ProviderCore/Models/StreamingFileDownloadDelegate.swift
+++ b/provider-swift/Sources/ProviderCore/Models/StreamingFileDownloadDelegate.swift
@@ -169,6 +169,21 @@ final class StreamingFileDownloadDelegate: NSObject, URLSessionDataDelegate, @un
             start == UInt64(existingBytes) {
             append = true
         }
+        // Any OTHER 206 body is some partial suffix we cannot place: a
+        // mismatched or unparseable Content-Range (or a 206 we never asked
+        // for) written from byte 0 would silently corrupt the file, and only
+        // hash-checked callers would ever notice. Discard the .part and
+        // surface a RETRYABLE error so `downloadFile`'s loop re-runs from
+        // byte 0 with a full GET (same contract as the untrustworthy-416
+        // branch above; must NOT be a CancellationError).
+        if status == 206, !append {
+            try? fm.removeItem(at: partial)
+            setupError = ModelCatalogError.downloadFailed(
+                "\(label): 206 resume did not match .part offset \(existingBytes); "
+                    + "discarded for clean re-download")
+            completionHandler(.cancel)
+            return
+        }
 
         do {
             if !append { try? fm.removeItem(at: partial) }

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+EngineV2.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+EngineV2.swift
@@ -72,6 +72,11 @@ final class EngineV2NewcomerBox: @unchecked Sendable {
 
 extension ProviderLoop {
 
+    struct EngineV2SlotBuild {
+        let bundle: ProviderEngineBundle
+        let sizing: SlotSizingSnapshot
+    }
+
     /// Whether any live slot exists. Every slot serves through the v2
     /// engine as of v0.7.5, so this is a plain occupancy check — the
     /// capacity/cancellation hooks use it to skip the runtime actor hop
@@ -105,6 +110,7 @@ extension ProviderLoop {
         /// shared-gate reserve — so mixed paged+contiguous re-slice
         /// orchestration is testable without weights.
         let kvBackendKindByModel: [String: EngineV2KVBackendKind]
+        let assistantLoader: (any ProviderMTPAssistantLoading)?
         /// Scripted engine builder: (modelId, kvBytesCapacity) — the second
         /// argument is the RE-SLICED, POST-CARVE admission ceiling the
         /// production path would hand `makeProductionEngine`, exposed so
@@ -119,6 +125,7 @@ extension ProviderLoop {
             emitTelemetry: (@Sendable (TelemetryEvent) -> Void)? = nil,
             physicalMemoryBytes: UInt64? = nil,
             kvBackendKindByModel: [String: EngineV2KVBackendKind] = [:],
+            assistantLoader: (any ProviderMTPAssistantLoading)? = nil,
             makeEngine: @escaping @Sendable (String, Int) throws -> any CBv2Engine
         ) {
             self.environment = environment
@@ -127,6 +134,7 @@ extension ProviderLoop {
             self.emitTelemetry = emitTelemetry
             self.physicalMemoryBytes = physicalMemoryBytes
             self.kvBackendKindByModel = kvBackendKindByModel
+            self.assistantLoader = assistantLoader
             self.makeEngine = makeEngine
         }
     }
@@ -235,13 +243,61 @@ extension ProviderLoop {
         tokenizer: TokenizerHandle,
         sizing: SlotSizingSnapshot
     ) async throws -> EngineV2Bridge {
+        let build = try await resliceAndBuildEngineV2Bundle(
+            modelId: modelId,
+            modelType: modelType,
+            isVLM: isVLM,
+            modelDirectory: modelDirectory,
+            newcomer: newcomerBox,
+            tokenizer: tokenizer,
+            targetSizing: sizing,
+            specDecPreparation: SpecDecPreparation(
+                artifact: nil,
+                status: .disabled(.configDisabled, configured: false)))
+        return build.bundle.bridge
+    }
+
+    /// MTP-aware load funnel. Target extraction and assistant load/bind complete
+    /// before final sizing and re-slicing, so fallback removes the prospective
+    /// assistant charge and active MTP adds it exactly once.
+    internal func resliceAndBuildEngineV2Bundle(
+        modelId: String,
+        modelType: String?,
+        isVLM: Bool,
+        modelDirectory: URL?,
+        newcomer newcomerBox: EngineV2NewcomerBox,
+        tokenizer: TokenizerHandle,
+        targetSizing: SlotSizingSnapshot,
+        specDecPreparation: SpecDecPreparation
+    ) async throws -> EngineV2SlotBuild {
+        var prepared: EngineV2PreparedModel
+        do {
+            let slotLogger = logger
+            prepared = try await EngineV2SlotFactory.prepareProductionModel(
+                modelId: modelId,
+                isVLM: isVLM,
+                modelDirectory: modelDirectory,
+                container: newcomerBox.borrow(),
+                specDecPreparation: specDecPreparation,
+                assistantLoader: engineV2SlotHooks?.assistantLoader
+                    ?? Gemma4ProviderMTPAssistantLoader(),
+                emitTelemetry: engineV2SlotHooks?.emitTelemetry,
+                logInfo: { slotLogger.info($0) },
+                logWarning: { slotLogger.warning($0) })
+        } catch {
+            newcomerBox.release()
+            MLX.Memory.clearCache()
+            throw error
+        }
+        var sizing = targetSizing.replacingAuxiliaryWeightBytes(
+            prepared.assistantBytes)
         let existing = await existingSlotGrants(excludingModelId: modelId)
         let newcomer = EngineV2KVSizing.ResliceSlot(
             modelId: modelId,
             fp16KVBytesPerToken: sizing.fp16KVBytesPerToken,
             maxContextLength: sizing.maxContextLength)
-        let fleetBudget = fleetKVBudgetBytes(extraWeightBytes: sizing.weightsBytes)
-        let targets = EngineV2KVSizing.resliceGrants(
+        var fleetBudget = fleetKVBudgetBytes(extraWeightBytes: sizing.weightsBytes)
+        var targets = EngineV2KVSizing.resliceGrants(
             existing: existing.map(\.slot),
             newcomer: newcomer,
             fleetKVBudgetBytes: fleetBudget)
@@ -259,9 +315,27 @@ extension ProviderLoop {
         for entry in existing where entry.bridge.prefixCacheBudgetBytes > 0 {
             fixedCarveBytes[entry.slot.modelId] = entry.bridge.prefixCacheBudgetBytes
         }
-        guard
-            EngineV2KVSizing.resliceMeetsServiceabilityFloor(
-                targets, fixedCarveBytes: fixedCarveBytes)
+        if !EngineV2KVSizing.resliceMeetsServiceabilityFloor(
+            targets, fixedCarveBytes: fixedCarveBytes), prepared.assistant != nil
+        {
+            logger.warning(
+                "mtp: model=\(modelId) fallback reason="
+                    + "\(MTPFallbackReason.assistantResliceFloor.rawValue); "
+                    + "retrying target-only before refusing the load")
+            prepared.assistant?.release()
+            prepared = prepared.fallingBack(.assistantResliceFloor)
+            sizing = targetSizing.replacingAuxiliaryWeightBytes(0)
+            await kvBudget.replacePendingLoadReservation(
+                requestID: "pending-load:\(modelId)", bytes: 0)
+            MLX.Memory.clearCache()
+            fleetBudget = fleetKVBudgetBytes(extraWeightBytes: sizing.weightsBytes)
+            targets = EngineV2KVSizing.resliceGrants(
+                existing: existing.map(\.slot),
+                newcomer: newcomer,
+                fleetKVBudgetBytes: fleetBudget)
+        }
+        guard EngineV2KVSizing.resliceMeetsServiceabilityFloor(
+            targets, fixedCarveBytes: fixedCarveBytes)
         else {
             let floorGb = String(
                 format: "%.1f",
@@ -277,6 +351,7 @@ extension ProviderLoop {
             // Pre-shrink refusal: no grants were mutated, but drop the
             // newcomer's weights promptly so live residency reflects the
             // refusal before the caller's error handling runs.
+            prepared.assistant?.release()
             newcomerBox.release()
             MLX.Memory.clearCache()
             throw InferenceError.modelLoadFailed(message)
@@ -300,9 +375,9 @@ extension ProviderLoop {
         // `borrow()` is evaluated inline so the container reference lives
         // only for the duration of the call — by the time this catch runs,
         // the box holds the last strong reference and `release()` frees it.
-        let bridge: EngineV2Bridge
+        let bundle: ProviderEngineBundle
         do {
-            bridge = try await makeEngineV2BridgeForSlot(
+            bundle = try await makeEngineV2BundleForSlot(
                 modelId: modelId,
                 modelType: modelType,
                 isVLM: isVLM,
@@ -310,8 +385,11 @@ extension ProviderLoop {
                 container: newcomerBox.borrow(),
                 tokenizer: tokenizer,
                 sizing: sizing,
-                kvBytesCapacity: targets[modelId] ?? 0)
+                kvBytesCapacity: targets[modelId] ?? 0,
+                specDecPreparation: specDecPreparation,
+                preparedModel: prepared)
         } catch {
+            prepared.assistant?.release()
             newcomerBox.release()
             MLX.Memory.clearCache()
             for entry in existing {
@@ -328,7 +406,7 @@ extension ProviderLoop {
                 await entry.bridge.updateKVBytesCapacity(target)
             }
         }
-        return bridge
+        return EngineV2SlotBuild(bundle: bundle, sizing: sizing)
     }
 
     /// Failure unwind AFTER a successful bridge build (the post-bridge
@@ -338,14 +416,27 @@ extension ProviderLoop {
     /// Σ(grants) never exceeds it. Caller holds the re-slice gate.
     internal func unwindBuiltSlotAndRegrow(
         modelId: String,
-        bridge: EngineV2Bridge,
+        bundle: ProviderEngineBundle,
         newcomer: EngineV2NewcomerBox
     ) async {
         await engineV2Runtime.unregister(modelId: modelId)
-        await bridge.shutdown()
+        await bundle.bridge.shutdown()
+        bundle.releaseAssistant()
         newcomer.release()
         MLX.Memory.clearCache()
         await resliceGrowSurvivorsLocked()
+    }
+
+    /// Compatibility overload for target-only tests.
+    internal func unwindBuiltSlotAndRegrow(
+        modelId: String,
+        bridge: EngineV2Bridge,
+        newcomer: EngineV2NewcomerBox
+    ) async {
+        await unwindBuiltSlotAndRegrow(
+            modelId: modelId,
+            bundle: ProviderEngineBundle(targetOnly: bridge),
+            newcomer: newcomer)
     }
 
     /// Grow the surviving slots back to their re-sliced shares after an
@@ -411,6 +502,34 @@ extension ProviderLoop {
         sizing: SlotSizingSnapshot,
         kvBytesCapacity: Int
     ) async throws -> EngineV2Bridge {
+        try await makeEngineV2BundleForSlot(
+            modelId: modelId,
+            modelType: modelType,
+            isVLM: isVLM,
+            modelDirectory: modelDirectory,
+            container: container,
+            tokenizer: tokenizer,
+            sizing: sizing,
+            kvBytesCapacity: kvBytesCapacity,
+            specDecPreparation: SpecDecPreparation(
+                artifact: nil,
+                status: .disabled(.configDisabled, configured: false)),
+            preparedModel: nil
+        ).bridge
+    }
+
+    internal func makeEngineV2BundleForSlot(
+        modelId: String,
+        modelType: String?,
+        isVLM: Bool = false,
+        modelDirectory: URL? = nil,
+        container: ModelContainer,
+        tokenizer: TokenizerHandle,
+        sizing: SlotSizingSnapshot,
+        kvBytesCapacity: Int,
+        specDecPreparation: SpecDecPreparation,
+        preparedModel: EngineV2PreparedModel?
+    ) async throws -> ProviderEngineBundle {
         let maxConcurrent = engineV2MaxConcurrent(forModel: modelId)
 
         // Assembly is shared with the standalone server via
@@ -432,7 +551,7 @@ extension ProviderLoop {
         // and hands the builder the REDUCED capacity, and the bridge the
         // budget bookkeeping, so the claim/heartbeat math is testable
         // without a real engine (no cache INSTANCE exists under hooks).
-        let bridge: EngineV2Bridge
+        let bundle: ProviderEngineBundle
         if let hooks = engineV2SlotHooks {
             let carve = EngineV2SlotFactory.resolvePrefixCarve(
                 modelId: modelId,
@@ -444,7 +563,7 @@ extension ProviderLoop {
                 environment: hooks.environment
             ).carve
             let hookBuilder = hooks.makeEngine
-            bridge = try EngineV2Factory.makeBridge(
+            let bridge = try EngineV2Factory.makeBridge(
                 modelId: modelId,
                 tokenizer: tokenizer,
                 eosTokenIds: hooks.eosTokenIds,
@@ -466,6 +585,14 @@ extension ProviderLoop {
                         kvBackendKind: hooks.kvBackendKindByModel[modelId] ?? .contiguous,
                         kvBackendFallbackReason: nil)
                 })
+            let status = preparedModel?.mtpStatus ?? specDecPreparation.status
+            await bridge.configureMTPStatus(status)
+            bundle = ProviderEngineBundle(
+                bridge: bridge,
+                assistant: preparedModel?.assistant,
+                assistantBytes: status.assistantBytes,
+                mtpArtifact: preparedModel?.mtpArtifact,
+                mtpStatus: status)
             // WARN once (per load) that kv_quant is ignored on the v2 path
             // (fp16 caches are what the engine builds).
             if loopConfig.config.backend.kvQuant {
@@ -474,7 +601,7 @@ extension ProviderLoop {
             }
         } else {
             let slotLogger = logger
-            bridge = try await EngineV2SlotFactory.makeProductionBridge(
+            bundle = try await EngineV2SlotFactory.makeProductionBundle(
                 modelId: modelId,
                 modelType: modelType,
                 isVLM: isVLM,
@@ -491,9 +618,12 @@ extension ProviderLoop {
                 // SSD-tier metadata binding: the verified hash for the bytes
                 // this slot loaded (nil ⇒ model-id binding degradation).
                 weightHash: liveModelHashes[modelId],
+                specDecPreparation: specDecPreparation,
+                preparedModel: preparedModel,
                 logInfo: { slotLogger.info($0) },
                 logWarning: { slotLogger.warning($0) })
         }
+        let bridge = bundle.bridge
 
         // Register before the slot goes live so capacity heartbeats and
         // cancellation fan-out see the bridge from the first request.
@@ -512,6 +642,6 @@ extension ProviderLoop {
                 "engine_v2: serving \(modelId) via ContinuousBatchingV2 "
                     + "[kv=\(bridge.kvBackendKind.rawValue)]")
         }
-        return bridge
+        return bundle
     }
 }

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+EngineV2.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+EngineV2.swift
@@ -289,6 +289,16 @@ extension ProviderLoop {
             MLX.Memory.clearCache()
             throw error
         }
+        // Prepare-stage fail-open (artifact revalidation, assistant load, or
+        // bind failure): the drafter never became resident, so drop its share
+        // of the caller's pending-load reservation NOW instead of holding
+        // phantom bytes against co-resident admission through the re-slice
+        // and engine build. The re-slice floor fallback below already does
+        // exactly this for its own fail-open.
+        if prepared.assistant == nil, specDecPreparation.artifact != nil {
+            await kvBudget.replacePendingLoadReservation(
+                requestID: "pending-load:\(modelId)", bytes: 0)
+        }
         var sizing = targetSizing.replacingAuxiliaryWeightBytes(
             prepared.assistantBytes)
         let existing = await existingSlotGrants(excludingModelId: modelId)

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+EngineV2Liveness.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+EngineV2Liveness.swift
@@ -17,9 +17,10 @@
 ///     recovering: telemetry `engine_v2_self_restart` (ERROR)
 ///                 → old bridge marked "reloading" (heartbeat honesty)
 ///                 → drain: cancel pumps + bounded engine drain
-///                 → rebuild engine+bridge over the SAME container with the
-///                   slot's CURRENT grant (no re-slice) via the existing
-///                   factory path (re-registers in `EngineV2Runtime`)
+///                 → rebuild engine+bridge over the SAME container, preserving
+///                   target-only posture or moving the already-bound assistant
+///                 → if assistant revalidation fails, atomically install
+///                   target-only sizing/status and re-slice the freed bytes
 ///                 → swap the ModelSlot's bridge → serving
 ///     recovering ──rebuild throws──▶ unload (fail loud: slot gone, the
 ///                 coordinator's heartbeat view drops it and routes around)
@@ -156,7 +157,7 @@ extension ProviderLoop {
         // bridge stays registered in the runtime for exactly that reason).
         await bridge.beginRecoveryReload()
 
-        // The recovered engine keeps the slot's CURRENT TOTAL grant
+        // An unchanged posture keeps the slot's CURRENT TOTAL grant
         // (engine ceiling + prefix-cache budget, `slotKVBytesClaim` —
         // T-041) — recovery is not a re-slice; co-resident slots' grants
         // are untouched and Σ(claims) ≤ fleet budget is preserved by
@@ -165,6 +166,12 @@ extension ProviderLoop {
         // the rebuilt slot reproduces grant + carve; the cache itself
         // restarts empty (its KV died with the wedged engine).
         let grant = await bridge.slotKVBytesClaim()
+
+        // Move, never duplicate, the slot-owned assistant. A target-only slot
+        // yields nil and cannot discover or activate an artifact during recovery.
+        // If rebuilding fails, this local remains the sole owner and is released
+        // on the failure path below.
+        var recoveryAssistant = slot.engineBundle.takeAssistantForRecovery()
 
         // Drain: cancel the bridge's pump tasks (in-flight requests get
         // their teardown terminal + shared-KV release) and drain the
@@ -175,17 +182,96 @@ extension ProviderLoop {
 
         let rebuildStartedAt = ContinuousClock.now
         do {
-            let newBridge = try await makeEngineV2BridgeForSlot(
+            let slotLogger = logger
+            let modelDirectory = ModelScanner.resolveLocalPath(modelID: modelId)
+            var prepared = try await EngineV2SlotFactory.prepareRecoveryModel(
+                modelId: modelId,
+                isVLM: slot.isVLM,
+                modelDirectory: modelDirectory,
+                container: slot.container,
+                previousArtifact: slot.engineBundle.mtpArtifact,
+                previousStatus: slot.engineBundle.mtpStatus,
+                assistant: recoveryAssistant,
+                emitTelemetry: engineV2SlotHooks?.emitTelemetry,
+                logInfo: { slotLogger.info($0) },
+                logWarning: { slotLogger.warning($0) })
+            if prepared.assistant == nil {
+                recoveryAssistant?.release()
+                recoveryAssistant = nil
+            }
+            var rebuiltSizing = slot.sizing.replacingAuxiliaryWeightBytes(
+                prepared.assistantBytes)
+            var rebuildPreparation = SpecDecPreparation(
+                artifact: prepared.mtpArtifact, status: prepared.mtpStatus)
+            var newBundle = try await makeEngineV2BundleForSlot(
                 modelId: modelId,
                 modelType: slot.modelType,
                 isVLM: slot.isVLM,
-                modelDirectory: ModelScanner.resolveLocalPath(modelID: modelId),
+                modelDirectory: modelDirectory,
                 container: slot.container,
                 tokenizer: slot.tokenizer,
-                sizing: slot.sizing,
-                kvBytesCapacity: grant)
+                sizing: rebuiltSizing,
+                kvBytesCapacity: grant,
+                specDecPreparation: rebuildPreparation,
+                preparedModel: prepared)
+            // The replacement bundle now owns the moved handle.
+            recoveryAssistant = nil
+            var newBridge = newBundle.bridge
             // makeEngineV2BridgeForSlot re-registered `newBridge` in
             // engineV2Runtime (replacing the old bridge's entry).
+
+            MLX.Memory.clearCache()
+            var postBuildServeable = KVHeadroomProbe.postBuildServeable(
+                kvBackendKind: newBridge.kvBackendKind,
+                pagedPoolBytes: await newBridge.kvBackendPoolBytes())
+            // Scripted hook engines are not concrete EngineV2 instances and
+            // cannot expose MTP metrics; their prepared bundle status is the
+            // test seam's runtime truth. Production still requires live metrics.
+            let runtimeMTPActive: Bool
+            if engineV2SlotHooks != nil {
+                runtimeMTPActive = newBundle.mtpStatus.active
+            } else {
+                runtimeMTPActive = await newBridge.mtpStatusSnapshot().active
+            }
+            if newBundle.mtpStatus.active,
+                !postBuildServeable || !runtimeMTPActive
+            {
+                let reason: MTPFallbackReason = runtimeMTPActive
+                    ? .assistantPostBuildHeadroom : .engineInactive
+                logger.warning(
+                    "mtp: model=\(modelId) recovery fallback reason=\(reason.rawValue); rebuilding target-only")
+                await engineV2Runtime.unregister(modelId: modelId)
+                await newBridge.shutdown()
+                newBundle.releaseAssistant()
+                MLX.Memory.clearCache()
+                rebuildPreparation = rebuildPreparation.fallingBack(reason)
+                prepared = prepared.fallingBack(reason)
+                rebuiltSizing = slot.sizing.replacingAuxiliaryWeightBytes(0)
+                newBundle = try await makeEngineV2BundleForSlot(
+                    modelId: modelId,
+                    modelType: slot.modelType,
+                    isVLM: slot.isVLM,
+                    modelDirectory: modelDirectory,
+                    container: slot.container,
+                    tokenizer: slot.tokenizer,
+                    sizing: rebuiltSizing,
+                    kvBytesCapacity: grant,
+                    specDecPreparation: rebuildPreparation,
+                    preparedModel: prepared)
+                newBridge = newBundle.bridge
+                MLX.Memory.clearCache()
+                postBuildServeable = KVHeadroomProbe.postBuildServeable(
+                    kvBackendKind: newBridge.kvBackendKind,
+                    pagedPoolBytes: await newBridge.kvBackendPoolBytes())
+            }
+            if !postBuildServeable {
+                await engineV2Runtime.unregister(modelId: modelId)
+                await newBridge.shutdown()
+                newBundle.releaseAssistant()
+                MLX.Memory.clearCache()
+                throw InferenceError.modelLoadFailed(
+                    "engine_v2 self-restart of '\(modelId)' left insufficient KV headroom")
+            }
 
             let rebuildElapsed = ContinuousClock.now - rebuildStartedAt
             let rebuildMs = Int64(
@@ -202,22 +288,30 @@ extension ProviderLoop {
                 // happen under the gate, so this ordering can never strip a
                 // successor load's fresh registration by model id.
                 await engineV2Runtime.unregister(modelId: modelId)
-                releaseResliceGate()
                 await newBridge.shutdown()
+                newBundle.releaseAssistant()
+                MLX.Memory.clearCache()
+                releaseResliceGate()
                 logger.warning(
                     "engine_v2 liveness: \(modelId) was unloaded mid-recovery — rebuilt engine discarded")
                 return
             }
 
             modelSlots[modelId] = ModelSlot(
-                engineV2: newBridge,
+                engineBundle: newBundle,
                 container: slot.container,
                 tokenizer: slot.tokenizer,
-                sizing: slot.sizing,
+                sizing: rebuiltSizing,
                 isVLM: slot.isVLM,
                 modelType: slot.modelType,
                 lastInferenceAt: .now
             )
+            if rebuiltSizing.auxiliaryWeightBytes != slot.sizing.auxiliaryWeightBytes {
+                // The assistant bytes just left residency. Publish the new
+                // target-only posture and recompute every live grant while the
+                // same re-slice gate still excludes loads and unload regrows.
+                await resliceGrowSurvivorsLocked()
+            }
             releaseResliceGate()
 
             await newBridge.emitSelfRestartTelemetry(
@@ -231,6 +325,7 @@ extension ProviderLoop {
             syncWarmModelState()
             await updateAggregateCapacity()
         } catch {
+            recoveryAssistant?.release()
             // Rebuild failed (refusal telemetry already fired inside the
             // factory). The slot cannot serve — fail loud: unload it so
             // heartbeats stop advertising and the coordinator reroutes.

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+MTP.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+MTP.swift
@@ -1,0 +1,89 @@
+import Foundation
+
+extension ProviderLoop {
+    static let specDecCatalogPrewarmTimeout: Duration = .seconds(2)
+
+    /// Warm the in-process target-to-assistant metadata map before any startup
+    /// preload or unified-local request can construct a target slot. This does
+    /// not download assistant bytes and is bounded/fail-open; every ordinary
+    /// load remains a local-only catalog-cache/artifact-cache consultation.
+    func prewarmSpecDecCatalog() async {
+        let backend = loopConfig.config.backend
+        guard backend.mtp,
+            backend.mtpDrafterPath?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty != false,
+            SpecDecArtifactFunnel.killSwitchEnabled(
+                environment: ProcessInfo.processInfo.environment),
+            let modelId = advertisedModels.values
+                .filter({ EngineV2SupportedModels.isGemma4Target(modelType: $0.modelType) })
+                .map(\.id)
+                .sorted()
+                .first
+        else { return }
+
+        let warmed = await specDecFunnel.prewarmCatalog(
+            modelId: modelId,
+            timeout: Self.specDecCatalogPrewarmTimeout)
+        if warmed {
+            logger.info("mtp: catalog metadata prewarm complete")
+        } else {
+            logger.warning(
+                "mtp: catalog metadata prewarm failed or exceeded deadline; "
+                    + "startup continues target-only until a later full slot load")
+        }
+    }
+
+    func specDecPreparation(
+        modelId: String,
+        modelInfo: ModelInfo,
+        allowDownload: Bool = true
+    ) async -> SpecDecPreparation {
+        let prepared = await specDecFunnel.prepare(
+            .init(
+                modelId: modelId,
+                modelType: modelInfo.modelType,
+                enabled: loopConfig.config.backend.mtp,
+                localPath: loopConfig.config.backend.mtpDrafterPath,
+                allowDownload: allowDownload,
+                environment: ProcessInfo.processInfo.environment))
+        let reason = prepared.status.reason?.rawValue ?? "ready"
+        logger.info(
+            "mtp: model=\(modelId) configured=\(prepared.status.configured) "
+                + "artifact_ready=\(prepared.artifact != nil) reason=\(reason) "
+                + "revision=\(prepared.status.revision ?? "none") "
+                + "artifact_bytes=\(prepared.status.artifactBytes)")
+        return prepared
+    }
+
+    /// Assistant memory is optional: if it does not fit after target admission,
+    /// preserve target loadability and record a stable target-only fallback.
+    func admitSpecDecIfMemoryAllows(
+        _ preparation: SpecDecPreparation,
+        targetRequiredGb: Double
+    ) async -> SpecDecPreparation {
+        guard let artifact = preparation.artifact else { return preparation }
+        guard Self.assistantMemoryFits(
+            availableGb: await availableMemoryGb(),
+            targetRequiredGb: targetRequiredGb,
+            assistantBytes: artifact.residentBytes)
+        else {
+            logger.warning(
+                "mtp: model assistant skipped reason=\(MTPFallbackReason.assistantMemoryUnavailable.rawValue) "
+                    + "assistant_bytes=\(artifact.residentBytes)")
+            return preparation.fallingBack(.assistantMemoryUnavailable)
+        }
+        return preparation
+    }
+
+    static func assistantMemoryFits(
+        availableGb: Double,
+        targetRequiredGb: Double,
+        assistantBytes: UInt64
+    ) -> Bool {
+        guard availableGb.isFinite, targetRequiredGb.isFinite,
+            availableGb >= 0, targetRequiredGb >= 0
+        else { return false }
+        let assistantGb = Double(assistantBytes) / 1_073_741_824.0
+        let required = targetRequiredGb + assistantGb
+        return required.isFinite && availableGb >= required
+    }
+}

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+ModelLoading.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+ModelLoading.swift
@@ -100,7 +100,17 @@ extension ProviderLoop {
     /// checks run INSIDE the `isLoadingAny` critical section, so an
     /// interleaved local-endpoint load cannot make the no-evict verdict
     /// stale.
-    internal func ensureModelLoaded(modelId: String, allowEviction: Bool = true) async throws {
+    ///
+    /// `extraWeightBytes` (default 0): resident weight bytes this load will
+    /// add BEYOND the model snapshot — the MTP drafter estimate (file bytes ×
+    /// the standard 1.2 factor, plan D5). The drafter lives outside the HF
+    /// snapshot on every path, so `modelInfo.estimatedMemoryGb` (scan-time,
+    /// snapshot-derived) can never include it; the load gate, the
+    /// pending-load reservation, and the sizing snapshot each add it
+    /// explicitly here instead.
+    internal func ensureModelLoaded(
+        modelId: String, allowEviction: Bool = true, extraWeightBytes: UInt64 = 0
+    ) async throws {
         if isShuttingDown {
             throw CancellationError()
         }
@@ -125,7 +135,8 @@ extension ProviderLoop {
                 if isShuttingDown { throw CancellationError() }
             }
             if modelSlots[modelId] != nil { return }
-            try await ensureModelLoaded(modelId: modelId, allowEviction: allowEviction)
+            try await ensureModelLoaded(
+                modelId: modelId, allowEviction: allowEviction, extraWeightBytes: extraWeightBytes)
             return
         }
 
@@ -201,7 +212,9 @@ extension ProviderLoop {
             // clamps to real OS-available memory and subtracts in-flight KV
             // reservations, so dropping the multiplier here is still OOM-safe.
             let requiredGb = ModelLoadAdmission.requiredToLoadGb(
-                weightsGb: modelInfo.estimatedMemoryGb,
+                weightsGb: Self.loadGateWeightsGb(
+                    estimatedWeightsGb: modelInfo.estimatedMemoryGb,
+                    extraWeightBytes: extraWeightBytes),
                 headroomGb: Self.loadHeadroomGb)
             do {
                 try await evictUntilAvailable(requiredGb: requiredGb, allowEviction: allowEviction)
@@ -218,11 +231,11 @@ extension ProviderLoop {
             // a concurrent KV reservation on an already-loaded model can't grant
             // headroom that, plus these incoming (not-yet-in-mlxUsed) weights,
             // blows the unified-memory cap. Released once the weights are resident.
-            let pendingLoadGiB = modelInfo.estimatedMemoryGb * 1_073_741_824
-            let pendingLoadBytes: UInt64 =
-                pendingLoadGiB.isFinite && pendingLoadGiB > 0
-                ? (pendingLoadGiB >= Double(UInt64.max) ? .max : UInt64(pendingLoadGiB))
-                : 0
+            // Includes `extraWeightBytes` (the drafter): those bytes land in
+            // mlxUsed during this load window just like the target's.
+            let pendingLoadBytes = Self.pendingLoadReservationBytes(
+                estimatedWeightsGb: modelInfo.estimatedMemoryGb,
+                extraWeightBytes: extraWeightBytes)
             await kvBudget.reservePendingLoad(requestID: pendingLoadID, bytes: pendingLoadBytes)
 
             logger.info("Loading model: \(modelId) from \(modelPath.path)")
@@ -289,11 +302,15 @@ extension ProviderLoop {
 
             // Scheduler-free sizing snapshot (v0.7.5): weight bytes + the
             // engine-truth fp16 KV rate + context window — everything the
-            // re-slice, bridge, heartbeat, and vision gate need.
+            // re-slice, bridge, heartbeat, and vision gate need. The drafter
+            // estimate folds into weightsBytes here (single source of truth
+            // with the gate/reservation above), so every downstream consumer
+            // of `.weightsBytes` accounts for it automatically.
             let sizing = try await SlotSizingSnapshot.build(
                 container: newcomer.borrow(),
                 modelPath: modelPath,
-                fallbackDefaultMaxTokens: Self.schedulerDefaultMaxTokens)
+                fallbackDefaultMaxTokens: Self.schedulerDefaultMaxTokens,
+                auxiliaryWeightBytes: Int(min(extraWeightBytes, UInt64(Int.max))))
 
             // Weights are resident now (reflected in MLX active/cache), so hand
             // off from the pending-load reservation to the live mlxUsed view —
@@ -480,6 +497,32 @@ extension ProviderLoop {
         }
     }
 
+    // MARK: - Load-gate arithmetic (pure, unit-tested by SpecDecCapacityTests)
+
+    /// The load gate's weight figure (GB): the scan-time snapshot estimate
+    /// plus any auxiliary weight bytes the load will make resident OUTSIDE
+    /// the snapshot (the MTP drafter — plan D5: scan-time estimates never
+    /// include it, so the gate must add it explicitly).
+    internal static func loadGateWeightsGb(
+        estimatedWeightsGb: Double, extraWeightBytes: UInt64
+    ) -> Double {
+        estimatedWeightsGb + Double(extraWeightBytes) / 1_073_741_824.0
+    }
+
+    /// The pending-load reservation (bytes) for an in-flight load: the
+    /// estimated snapshot footprint plus auxiliary weight bytes, saturating.
+    /// A non-finite/non-positive estimate contributes nothing (the pre-MTP
+    /// behavior), leaving just the auxiliary bytes.
+    internal static func pendingLoadReservationBytes(
+        estimatedWeightsGb: Double, extraWeightBytes: UInt64
+    ) -> UInt64 {
+        let weightBytes = estimatedWeightsGb * 1_073_741_824
+        guard weightBytes.isFinite, weightBytes > 0 else { return extraWeightBytes }
+        if weightBytes >= Double(UInt64.max) { return .max }
+        let (sum, overflow) = UInt64(weightBytes).addingReportingOverflow(extraWeightBytes)
+        return overflow ? .max : sum
+    }
+
     internal func releaseLoadGateWaiters() {
         let waiters = loadGateWaiters
         loadGateWaiters.removeAll()
@@ -495,13 +538,21 @@ extension ProviderLoop {
     }
 
     internal func unloadModel(_ modelId: String) async {
-        guard let slot = modelSlots[modelId], !modelsUnloading.contains(modelId) else { return }
+        // Bind ONLY the bridge, never the whole slot: the slot value is the
+        // last owner of the container AND the opaque MTP drafter handle, and
+        // both must be released at `removeValue` below — BEFORE the cache
+        // purge — not kept alive by a local until this function returns.
+        guard let engineV2 = modelSlots[modelId]?.engineV2,
+            !modelsUnloading.contains(modelId)
+        else { return }
         modelsUnloading.insert(modelId)
         // Retire the slot's v2 bridge: unregister so heartbeats/cancellation
         // stop fanning out to it, then drain the engine gracefully (running
         // requests finish, new submissions are rejected).
         await engineV2Runtime.unregister(modelId: modelId)
-        await slot.engineV2.shutdown()
+        await engineV2.shutdown()
+        // Drops the slot's container and MTP drafter references with the
+        // target (the drafter is slot-owned — plan D5 teardown).
         modelSlots.removeValue(forKey: modelId)
         modelsUnloading.remove(modelId)
         // Mandatory: freed weights linger in MLX's pool (GPU.cacheMemory), which

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+ModelLoading.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+ModelLoading.swift
@@ -150,6 +150,24 @@ extension ProviderLoop {
         var mtpPreparation = await specDecPreparation(
             modelId: modelId, modelInfo: modelInfo)
 
+        // Re-check residency and in-flight loads after the preparation await:
+        // a concurrent request for the same cold model can pass the checks
+        // above, complete its ENTIRE load (returning `isLoadingAny` to false),
+        // and install the slot while this task was suspended. Without this
+        // recheck the continuation would start a second load of a resident
+        // model — double pending-load reservation, possible eviction of the
+        // warm slot, and a leaked bridge.
+        while modelsUnloading.contains(modelId) {
+            await waitForModelUnload(modelId)
+            if isShuttingDown { throw CancellationError() }
+        }
+        if modelSlots[modelId] != nil { return }
+        if modelsLoading.contains(modelId) {
+            try await ensureModelLoaded(
+                modelId: modelId, allowEviction: allowEviction)
+            return
+        }
+
         // Serialize loads so concurrent eviction decisions don't interleave
         while isLoadingAny {
             await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
@@ -778,10 +796,13 @@ extension ProviderLoop {
         guard let modelInfo = advertisedModels[modelId] else {
             return false
         }
-        // Resolve/size the optional assistant before the load decision, but do
-        // not let it participate in a fast rejection: a target that fits must
-        // remain loadable and can fall back to plain decode.
-        _ = await specDecPreparation(modelId: modelId, modelInfo: modelInfo)
+        // The optional assistant deliberately plays NO role here: it cannot
+        // cause a fast rejection (a target that fits must remain loadable and
+        // can fall back to plain decode), and this pre-accept path must not
+        // touch the spec-dec funnel at all — admission is non-mutating and
+        // must not schedule catalog or artifact prefetch work for requests
+        // that may be rejected. The accepted load path performs the real
+        // preparation (and any prefetch) itself.
         let requiredGb = ModelLoadAdmission.requiredToLoadGb(
             weightsGb: modelInfo.estimatedMemoryGb,
             headroomGb: Self.loadHeadroomGb)

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+ModelLoading.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+ModelLoading.swift
@@ -101,15 +101,11 @@ extension ProviderLoop {
     /// interleaved local-endpoint load cannot make the no-evict verdict
     /// stale.
     ///
-    /// `extraWeightBytes` (default 0): resident weight bytes this load will
-    /// add BEYOND the model snapshot — the MTP drafter estimate (file bytes ×
-    /// the standard 1.2 factor, plan D5). The drafter lives outside the HF
-    /// snapshot on every path, so `modelInfo.estimatedMemoryGb` (scan-time,
-    /// snapshot-derived) can never include it; the load gate, the
-    /// pending-load reservation, and the sizing snapshot each add it
-    /// explicitly here instead.
+    /// When MTP is configured, the shared spec-dec funnel resolves and sizes
+    /// the assistant before admission. The target remains independently
+    /// loadable: assistant headroom failure selects target-only decode.
     internal func ensureModelLoaded(
-        modelId: String, allowEviction: Bool = true, extraWeightBytes: UInt64 = 0
+        modelId: String, allowEviction: Bool = true
     ) async throws {
         if isShuttingDown {
             throw CancellationError()
@@ -136,7 +132,7 @@ extension ProviderLoop {
             }
             if modelSlots[modelId] != nil { return }
             try await ensureModelLoaded(
-                modelId: modelId, allowEviction: allowEviction, extraWeightBytes: extraWeightBytes)
+                modelId: modelId, allowEviction: allowEviction)
             return
         }
 
@@ -151,6 +147,8 @@ extension ProviderLoop {
                 "Model '\(modelId)' not in advertised model list"
             )
         }
+        var mtpPreparation = await specDecPreparation(
+            modelId: modelId, modelInfo: modelInfo)
 
         // Serialize loads so concurrent eviction decisions don't interleave
         while isLoadingAny {
@@ -211,10 +209,11 @@ extension ProviderLoop {
             // load a model it could actually serve. `availableMemoryGb` now
             // clamps to real OS-available memory and subtracts in-flight KV
             // reservations, so dropping the multiplier here is still OOM-safe.
+            let targetWeightsGb = Self.loadGateWeightsGb(
+                estimatedWeightsGb: modelInfo.estimatedMemoryGb,
+                extraWeightBytes: 0)
             let requiredGb = ModelLoadAdmission.requiredToLoadGb(
-                weightsGb: Self.loadGateWeightsGb(
-                    estimatedWeightsGb: modelInfo.estimatedMemoryGb,
-                    extraWeightBytes: extraWeightBytes),
+                weightsGb: targetWeightsGb,
                 headroomGb: Self.loadHeadroomGb)
             do {
                 try await evictUntilAvailable(requiredGb: requiredGb, allowEviction: allowEviction)
@@ -224,6 +223,12 @@ extension ProviderLoop {
                 recordModelLoadError(model: modelId, message: message)
                 throw InferenceError.modelLoadFailed(message)
             }
+            // The assistant is optional and must never make an otherwise
+            // loadable target fail. It is charged before allocation when it
+            // fits; otherwise this load continues target-only.
+            mtpPreparation = await admitSpecDecIfMemoryAllows(
+                mtpPreparation, targetRequiredGb: requiredGb)
+            let extraWeightBytes = mtpPreparation.artifact?.residentBytes ?? 0
             try Task.checkCancellation()
             if isShuttingDown { throw CancellationError() }
 
@@ -300,23 +305,20 @@ extension ProviderLoop {
                 ))
             })
 
-            // Scheduler-free sizing snapshot (v0.7.5): weight bytes + the
-            // engine-truth fp16 KV rate + context window — everything the
-            // re-slice, bridge, heartbeat, and vision gate need. The drafter
-            // estimate folds into weightsBytes here (single source of truth
-            // with the gate/reservation above), so every downstream consumer
-            // of `.weightsBytes` accounts for it automatically.
-            let sizing = try await SlotSizingSnapshot.build(
+            // Target-only sizing snapshot. After assistant load/bind, the slot
+            // factory replaces its auxiliary component with the bytes actually
+            // retained before final re-slicing and installation.
+            let targetSizing = try await SlotSizingSnapshot.build(
                 container: newcomer.borrow(),
                 modelPath: modelPath,
-                fallbackDefaultMaxTokens: Self.schedulerDefaultMaxTokens,
-                auxiliaryWeightBytes: Int(min(extraWeightBytes, UInt64(Int.max))))
+                fallbackDefaultMaxTokens: Self.schedulerDefaultMaxTokens)
 
             // Weights are resident now (reflected in MLX active/cache), so hand
             // off from the pending-load reservation to the live mlxUsed view —
             // concurrent KV reservations see the weights from here on. (Also
             // released in catch for the error paths above.)
-            await kvBudget.release(requestID: pendingLoadID)
+            await kvBudget.replacePendingLoadReservation(
+                requestID: pendingLoadID, bytes: extraWeightBytes)
             if isShuttingDown || Task.isCancelled {
                 newcomer.release()
                 MLX.Memory.clearCache()
@@ -375,16 +377,17 @@ extension ProviderLoop {
             // appearing in `modelSlots` — it would recompute without the
             // newcomer and re-inflate survivors past the fleet budget.
             await acquireResliceGate()
-            let engineV2Bridge: EngineV2Bridge
+            var slotBuild: EngineV2SlotBuild
             do {
-                engineV2Bridge = try await resliceAndBuildEngineV2Slot(
+                slotBuild = try await resliceAndBuildEngineV2Bundle(
                     modelId: modelId,
                     modelType: modelInfo.modelType,
                     isVLM: slotIsVLM,
                     modelDirectory: modelPath,
                     newcomer: newcomer,
                     tokenizer: tokenizer,
-                    sizing: sizing
+                    targetSizing: targetSizing,
+                    specDecPreparation: mtpPreparation
                 )
             } catch let error as InferenceError {
                 // Already shaped (e.g. the re-slice floor refusal) — record +
@@ -406,6 +409,12 @@ extension ProviderLoop {
                 recordModelLoadError(model: modelId, message: message)
                 throw InferenceError.modelLoadFailed(message)
             }
+            // Assistant construction has completed. Its bytes are now either
+            // live and reflected in MLX, or fully released on fallback.
+            await kvBudget.release(requestID: pendingLoadID)
+            var engineBundle = slotBuild.bundle
+            var sizing = slotBuild.sizing
+            var engineV2Bridge = engineBundle.bridge
 
             // Post-BRIDGE measured-headroom re-guard (v0.7.3, kept): the
             // engine build (and, for VLM slots, the text-model extraction +
@@ -421,9 +430,50 @@ extension ProviderLoop {
             // physical-capacity policy prevents the pool from consuming the
             // full logical grant.
             MLX.Memory.clearCache()
-            let postBridgeServeable = KVHeadroomProbe.postBuildServeable(
+            var postBridgeServeable = KVHeadroomProbe.postBuildServeable(
                 kvBackendKind: engineV2Bridge.kvBackendKind,
                 pagedPoolBytes: await engineV2Bridge.kvBackendPoolBytes())
+            let runtimeMTPActive = await engineV2Bridge.mtpStatusSnapshot().active
+            if engineBundle.mtpStatus.active,
+                !postBridgeServeable || !runtimeMTPActive
+            {
+                let reason: MTPFallbackReason = runtimeMTPActive
+                    ? .assistantPostBuildHeadroom : .engineInactive
+                logger.warning(
+                    "mtp: model=\(modelId) fallback reason=\(reason.rawValue); rebuilding target-only")
+                await engineV2Runtime.unregister(modelId: modelId)
+                await engineV2Bridge.shutdown()
+                engineBundle.releaseAssistant()
+                MLX.Memory.clearCache()
+                do {
+                    slotBuild = try await resliceAndBuildEngineV2Bundle(
+                        modelId: modelId,
+                        modelType: modelInfo.modelType,
+                        isVLM: slotIsVLM,
+                        modelDirectory: modelPath,
+                        newcomer: newcomer,
+                        tokenizer: tokenizer,
+                        targetSizing: targetSizing,
+                        specDecPreparation: mtpPreparation.fallingBack(reason))
+                } catch {
+                    // The retry released the target on failure. Recompute from
+                    // actual survivor residency, not the first attempt's
+                    // assistant-conservative grants.
+                    await resliceGrowSurvivorsLocked()
+                    releaseResliceGate()
+                    MLX.Memory.clearCache()
+                    let message = "Model '\(modelId)' MTP fallback engine construction failed: \(error) — unloaded"
+                    recordModelLoadError(model: modelId, message: message)
+                    throw InferenceError.modelLoadFailed(message)
+                }
+                engineBundle = slotBuild.bundle
+                sizing = slotBuild.sizing
+                engineV2Bridge = engineBundle.bridge
+                MLX.Memory.clearCache()
+                postBridgeServeable = KVHeadroomProbe.postBuildServeable(
+                    kvBackendKind: engineV2Bridge.kvBackendKind,
+                    pagedPoolBytes: await engineV2Bridge.kvBackendPoolBytes())
+            }
             if !postBridgeServeable {
                 let headroomGb = String(
                     format: "%.1f",
@@ -434,7 +484,7 @@ extension ProviderLoop {
                 // would let Σ(grants) exceed the true fleet budget. Still
                 // holding the re-slice gate; release only after.
                 await unwindBuiltSlotAndRegrow(
-                    modelId: modelId, bridge: engineV2Bridge, newcomer: newcomer)
+                    modelId: modelId, bundle: engineBundle, newcomer: newcomer)
                 releaseResliceGate()
                 let message = "Model '\(modelId)' loaded but its engine build left insufficient "
                     + "KV headroom under the memory cap (\(headroomGb) GB free) — unloaded"
@@ -452,12 +502,14 @@ extension ProviderLoop {
                 // Unreachable (the box is drained only on failure paths) —
                 // defensive so a wiring bug can never leak the re-slice gate
                 // and wedge every future load.
+                await unwindBuiltSlotAndRegrow(
+                    modelId: modelId, bundle: engineBundle, newcomer: newcomer)
                 releaseResliceGate()
                 throw InferenceError.modelLoadFailed(
                     "internal: newcomer container missing at install for '\(modelId)'")
             }
             modelSlots[modelId] = ModelSlot(
-                engineV2: engineV2Bridge,
+                engineBundle: engineBundle,
                 container: installContainer,
                 tokenizer: tokenizer,
                 sizing: sizing,
@@ -542,15 +594,17 @@ extension ProviderLoop {
         // last owner of the container AND the opaque MTP drafter handle, and
         // both must be released at `removeValue` below — BEFORE the cache
         // purge — not kept alive by a local until this function returns.
-        guard let engineV2 = modelSlots[modelId]?.engineV2,
+        guard let engineBundle = modelSlots[modelId]?.engineBundle,
             !modelsUnloading.contains(modelId)
         else { return }
+        let engineV2 = engineBundle.bridge
         modelsUnloading.insert(modelId)
         // Retire the slot's v2 bridge: unregister so heartbeats/cancellation
         // stop fanning out to it, then drain the engine gracefully (running
         // requests finish, new submissions are rejected).
         await engineV2Runtime.unregister(modelId: modelId)
         await engineV2.shutdown()
+        engineBundle.releaseAssistant()
         // Drops the slot's container and MTP drafter references with the
         // target (the drafter is slot-owned — plan D5 teardown).
         modelSlots.removeValue(forKey: modelId)
@@ -724,6 +778,10 @@ extension ProviderLoop {
         guard let modelInfo = advertisedModels[modelId] else {
             return false
         }
+        // Resolve/size the optional assistant before the load decision, but do
+        // not let it participate in a fast rejection: a target that fits must
+        // remain loadable and can fall back to plain decode.
+        _ = await specDecPreparation(modelId: modelId, modelInfo: modelInfo)
         let requiredGb = ModelLoadAdmission.requiredToLoadGb(
             weightsGb: modelInfo.estimatedMemoryGb,
             headroomGb: Self.loadHeadroomGb)

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+Serve.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+Serve.swift
@@ -83,16 +83,23 @@ extension ProviderLoop {
             OOMDetector.clearMarker()
         }
 
+        // 1. Apply security hardening
+        try await applySecurityHardening()
+
+        // MTP catalog metadata is process-local. Give it one short, owned
+        // prewarm before either startup preloads or the unified local endpoint
+        // can perform the first normal cold target load. This never downloads
+        // assistant bytes and fails open on timeout.
+        await prewarmSpecDecCatalog()
+
         // Unified mode: also expose a local OpenAI endpoint off the same loaded
-        // models. Started before the coordinator connection so local clients can
-        // serve immediately; torn down on shutdown.
+        // models. It starts after the bounded metadata prewarm, but still before
+        // the coordinator connection, so local serving keeps coordinator
+        // independence while a cached assistant can join the first target load.
         if let localEndpoint = loopConfig.localEndpoint {
             startLocalEndpoint(localEndpoint)
         }
         defer { stopLocalEndpoint() }
-
-        // 1. Apply security hardening
-        try await applySecurityHardening()
 
         // Arm the loaded-models persistence now that this loop is actually
         // serving (test instances never flip this, so their unload paths
@@ -320,6 +327,7 @@ extension ProviderLoop {
         for task in desiredPrefetchRetryTasks.values { task.cancel() }
         desiredPrefetchRetryTasks.removeAll()
         desiredPrefetchRetryAttempts.removeAll()
+        await specDecFunnel.shutdown()
         // Cancel background prefetch downloads (no GPU slot, but they hold a
         // network connection and disk staging we want to release promptly).
         if let prefetchCoordinator {

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+Testing.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+Testing.swift
@@ -300,6 +300,12 @@ extension ProviderLoop {
         return bridge
     }
 
+    /// Test seam: swap the spec-dec funnel so lifecycle tests can gate the
+    /// MTP preparation await deterministically.
+    func setSpecDecFunnelForTesting(_ funnel: SpecDecArtifactFunnel) {
+        specDecFunnel = funnel
+    }
+
     /// Test seam: install a fully-formed v2 model slot so capacity/
     /// cancellation/re-slice tests can exercise the slot-dependent paths
     /// without loading weights.

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+Testing.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+Testing.swift
@@ -185,6 +185,27 @@ extension ProviderLoop {
         )
     }
 
+    /// MTP-aware variant of the production re-slice seam. The returned sizing
+    /// and bundle expose whether an optional assistant survived admission.
+    func resliceAndBuildEngineV2BundleForTesting(
+        modelId: String,
+        modelType: String?,
+        newcomer: EngineV2NewcomerBox,
+        tokenizer: TokenizerHandle,
+        sizing: SlotSizingSnapshot,
+        specDecPreparation: SpecDecPreparation
+    ) async throws -> EngineV2SlotBuild {
+        try await resliceAndBuildEngineV2Bundle(
+            modelId: modelId,
+            modelType: modelType,
+            isVLM: false,
+            modelDirectory: nil,
+            newcomer: newcomer,
+            tokenizer: tokenizer,
+            targetSizing: sizing,
+            specDecPreparation: specDecPreparation)
+    }
+
     /// Box variant: the caller hands over container OWNERSHIP, so the
     /// unwind-ordering regression tests can observe (via a weak reference)
     /// that a failed build releases the newcomer's weights BEFORE survivor
@@ -303,6 +324,24 @@ extension ProviderLoop {
         )
     }
 
+    func installModelBundleForTesting(
+        modelId: String,
+        bundle: ProviderEngineBundle,
+        container: MLXLMCommon.ModelContainer,
+        tokenizer: TokenizerHandle,
+        sizing: SlotSizingSnapshot,
+        modelType: String?
+    ) {
+        modelSlots[modelId] = ModelSlot(
+            engineBundle: bundle,
+            container: container,
+            tokenizer: tokenizer,
+            sizing: sizing,
+            isVLM: false,
+            modelType: modelType,
+            lastInferenceAt: .now)
+    }
+
     /// Test seam: remove an installed slot without the unload machinery.
     func removeModelSlotForTesting(modelId: String) {
         modelSlots.removeValue(forKey: modelId)
@@ -312,6 +351,10 @@ extension ProviderLoop {
     /// recompute the fleet KV budget from real slot weights).
     func slotSizingForTesting(modelId: String) -> SlotSizingSnapshot? {
         modelSlots[modelId]?.sizing
+    }
+
+    func slotMTPStatusForTesting(modelId: String) -> MTPActivationStatus? {
+        modelSlots[modelId]?.engineBundle.mtpStatus
     }
 
     /// Test seam: the live bridge for a loaded slot.
@@ -325,6 +368,16 @@ extension ProviderLoop {
 
     /// Test seam: the current aggregate backend capacity snapshot.
     func backendCapacityForTesting() -> BackendCapacity? { state.backendCapacity }
+
+    func reservePendingLoadForTesting(requestID: String, bytes: UInt64) async {
+        await kvBudget.reservePendingLoad(requestID: requestID, bytes: bytes)
+    }
+
+    func outstandingKVReservationBytesForTesting() async -> UInt64 {
+        await kvBudget.outstandingReservedBytes()
+    }
+
+    func kvBudgetForTesting() -> GlobalKVCacheBudget { kvBudget }
 
     // MARK: - Wedge self-recovery seams
 

--- a/provider-swift/Sources/ProviderCore/ProviderLoop.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop.swift
@@ -591,6 +591,19 @@ public actor ProviderLoop {
         /// drop window while the slot is still resident (a Gemma build would
         /// otherwise fall back to the qwen3 parser and leak <think> tokens).
         let modelType: String?
+        /// Opaque MTP drafter handle bound to this slot's engine, nil when
+        /// speculative decoding is off or no drafter resolved. Type-erased on
+        /// purpose: the concrete drafter type lives in MLXLLM and ProviderCore
+        /// must not depend on it (wrap a non-Sendable drafter in a small
+        /// `@unchecked Sendable` holder — the handle exists ONLY to pin
+        /// lifetime; nothing ever calls through it). Sendable-constrained so
+        /// `ModelSlot` keeps its implicit Sendable conformance. The SLOT owns
+        /// the drafter (plan D5): it is released with the target in
+        /// `unloadModel` (before the cache purge), and it is never scanned,
+        /// advertised, weight-hashed, or attested — its resident footprint is
+        /// accounted via the sizing snapshot's `auxiliaryWeightBytes` fold
+        /// instead.
+        var mtpDrafter: (any AnyObject & Sendable)? = nil
         var lastInferenceAt: ContinuousClock.Instant
 
         /// Per-slot memory gate for VLM media decode and generation KV against

--- a/provider-swift/Sources/ProviderCore/ProviderLoop.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop.swift
@@ -166,6 +166,7 @@ public actor ProviderLoop {
     internal let powerAssertion: InferencePowerAssertion
     internal let preloadTaskStarted: (@Sendable (String) -> Void)?
     internal let beforeModelLoad: (@Sendable (String) async -> Void)?
+    internal var specDecFunnel: SpecDecArtifactFunnel
 
     /// Per-model inference slots. Each loaded model gets one EngineV2Bridge.
     /// Keyed by model ID.
@@ -483,6 +484,9 @@ public actor ProviderLoop {
         beforeModelLoad: (@Sendable (String) async -> Void)? = nil
     ) throws {
         self.loopConfig = config
+        self.specDecFunnel = SpecDecArtifactFunnel(
+            resolver: SpecDecResolver(),
+            catalog: SpecDecCatalogLookup(coordinatorURL: config.coordinatorURL))
         // Architecture-derived supported set (v0.7.5 fail-loud): the v2
         // engine is the ONLY engine, so a model whose family has no CBv2
         // adapter can never serve — advertising it would invite requests
@@ -574,7 +578,8 @@ public actor ProviderLoop {
         /// through (v0.7.5): every chat request routes here; there is no
         /// legacy scheduler on the slot anymore. Construction failure means
         /// the slot never exists (`ensureModelLoaded` unloads + 503s).
-        let engineV2: EngineV2Bridge
+        let engineBundle: ProviderEngineBundle
+        var engineV2: EngineV2Bridge { engineBundle.bridge }
         /// Retained for VLM vision preprocessing (the tower shares weights
         /// with the extracted text model) and for liveness rebuilds.
         let container: MLXLMCommon.ModelContainer
@@ -603,8 +608,55 @@ public actor ProviderLoop {
         /// advertised, weight-hashed, or attested — its resident footprint is
         /// accounted via the sizing snapshot's `auxiliaryWeightBytes` fold
         /// instead.
-        var mtpDrafter: (any AnyObject & Sendable)? = nil
+        var mtpDrafter: (any AnyObject & Sendable)? {
+            engineBundle.hasAssistant ? engineBundle : nil
+        }
         var lastInferenceAt: ContinuousClock.Instant
+
+        init(
+            engineBundle: ProviderEngineBundle,
+            container: MLXLMCommon.ModelContainer,
+            tokenizer: TokenizerHandle,
+            sizing: SlotSizingSnapshot,
+            isVLM: Bool,
+            modelType: String?,
+            lastInferenceAt: ContinuousClock.Instant
+        ) {
+            self.engineBundle = engineBundle
+            self.container = container
+            self.tokenizer = tokenizer
+            self.sizing = sizing
+            self.isVLM = isVLM
+            self.modelType = modelType
+            self.lastInferenceAt = lastInferenceAt
+        }
+
+        /// Compatibility initializer for existing target-only test seams.
+        init(
+            engineV2: EngineV2Bridge,
+            container: MLXLMCommon.ModelContainer,
+            tokenizer: TokenizerHandle,
+            sizing: SlotSizingSnapshot,
+            isVLM: Bool,
+            modelType: String?,
+            mtpDrafter: (any AnyObject & Sendable)? = nil,
+            lastInferenceAt: ContinuousClock.Instant
+        ) {
+            self.init(
+                engineBundle: ProviderEngineBundle(
+                    bridge: engineV2,
+                    assistant: nil,
+                    assistantBytes: 0,
+                    mtpArtifact: nil,
+                    mtpStatus: .disabled(.configDisabled, configured: false),
+                    pinnedAssistant: mtpDrafter),
+                container: container,
+                tokenizer: tokenizer,
+                sizing: sizing,
+                isVLM: isVLM,
+                modelType: modelType,
+                lastInferenceAt: lastInferenceAt)
+        }
 
         /// Per-slot memory gate for VLM media decode and generation KV against
         /// the shared `GlobalKVCacheBudget`.

--- a/provider-swift/Sources/ProviderCore/Server/StandaloneServer+MTP.swift
+++ b/provider-swift/Sources/ProviderCore/Server/StandaloneServer+MTP.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+extension StandaloneServer {
+    func specDecPreparation(
+        modelId: String, modelInfo: ModelInfo
+    ) async -> SpecDecPreparation {
+        await specDecFunnel.prepare(
+            .init(
+                modelId: modelId,
+                modelType: modelInfo.modelType,
+                enabled: config.mtp,
+                localPath: config.mtpDrafterPath,
+                // `darkbloom start --local` is coordinator-independent. Only an
+                // explicit operator-provided path may activate MTP here.
+                allowDownload: false,
+                environment: ProcessInfo.processInfo.environment))
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Server/StandaloneServer.swift
+++ b/provider-swift/Sources/ProviderCore/Server/StandaloneServer.swift
@@ -399,6 +399,12 @@ public actor StandaloneServer {
     }
 
     /// Install test hooks (scripted engine + deterministic memory).
+    /// Test seam: swap the spec-dec funnel so lifecycle tests can gate the
+    /// MTP preparation await deterministically.
+    func setSpecDecFunnelForTesting(_ funnel: SpecDecArtifactFunnel) {
+        specDecFunnel = funnel
+    }
+
     func setV2TestHooksForTesting(_ hooks: V2TestHooks?) {
         v2TestHooks = hooks
     }
@@ -1097,6 +1103,21 @@ public actor StandaloneServer {
         }
         var mtpPreparation = await specDecPreparation(
             modelId: modelId, modelInfo: modelInfo)
+
+        // Re-check residency and in-flight loads after the preparation await:
+        // a concurrent request for the same cold model can pass the checks
+        // above, complete its ENTIRE load (returning `isLoadingAny` to false)
+        // and install the slot while this task was suspended. Without this
+        // recheck the continuation would skip the load gate's residency check
+        // and start a second load of an already-resident model.
+        if slots[modelId] != nil, !evictingModels.contains(modelId) {
+            touchSlot(modelId)
+            return
+        }
+        if modelsLoading.contains(modelId) {
+            try await ensureModelLoaded(modelId)
+            return
+        }
 
         // Serialize loads so concurrent requests for different models don't
         // interleave and overcommit unified memory.

--- a/provider-swift/Sources/ProviderCore/Server/StandaloneServer.swift
+++ b/provider-swift/Sources/ProviderCore/Server/StandaloneServer.swift
@@ -80,6 +80,10 @@ public struct StandaloneServerConfig: Sendable {
     public let engineV2KVBackend: String
     /// Per-model overrides (`engine_v2_kv_backend_by_model`).
     public let engineV2KVBackendByModel: [String: String]
+    /// MTP beta configuration. Defaults off; the CLI/config owner passes these
+    /// through when standalone MTP is intentionally enabled.
+    public let mtp: Bool
+    public let mtpDrafterPath: String?
 
     public init(
         port: UInt16 = 8000,
@@ -91,7 +95,9 @@ public struct StandaloneServerConfig: Sendable {
         engineV2MaxConcurrent: UInt64 = 4,
         engineV2MaxConcurrentByModel: [String: UInt64] = [:],
         engineV2KVBackend: String = "auto",
-        engineV2KVBackendByModel: [String: String] = [:]
+        engineV2KVBackendByModel: [String: String] = [:],
+        mtp: Bool = false,
+        mtpDrafterPath: String? = nil
     ) {
         self.port = port
         self.host = host
@@ -103,6 +109,8 @@ public struct StandaloneServerConfig: Sendable {
         self.engineV2MaxConcurrentByModel = engineV2MaxConcurrentByModel
         self.engineV2KVBackend = engineV2KVBackend
         self.engineV2KVBackendByModel = engineV2KVBackendByModel
+        self.mtp = mtp
+        self.mtpDrafterPath = mtpDrafterPath
     }
 }
 
@@ -118,13 +126,51 @@ public actor StandaloneServer {
     /// weights with the extracted text model), and the sizing facts the KV
     /// re-slice needs. Mirrors `ProviderLoop.ModelSlot`.
     struct CachedSlot {
-        let bridge: EngineV2Bridge
+        let bundle: ProviderEngineBundle
+        var bridge: EngineV2Bridge { bundle.bridge }
         let container: MLXLMCommon.ModelContainer
         let tokenizer: TokenizerHandle
         let modelType: String?
         let isVLM: Bool
         let sizing: SlotSizingSnapshot
         var lastUsedAt: ContinuousClock.Instant
+
+        init(
+            bundle: ProviderEngineBundle,
+            container: MLXLMCommon.ModelContainer,
+            tokenizer: TokenizerHandle,
+            modelType: String?,
+            isVLM: Bool,
+            sizing: SlotSizingSnapshot,
+            lastUsedAt: ContinuousClock.Instant
+        ) {
+            self.bundle = bundle
+            self.container = container
+            self.tokenizer = tokenizer
+            self.modelType = modelType
+            self.isVLM = isVLM
+            self.sizing = sizing
+            self.lastUsedAt = lastUsedAt
+        }
+
+        init(
+            bridge: EngineV2Bridge,
+            container: MLXLMCommon.ModelContainer,
+            tokenizer: TokenizerHandle,
+            modelType: String?,
+            isVLM: Bool,
+            sizing: SlotSizingSnapshot,
+            lastUsedAt: ContinuousClock.Instant
+        ) {
+            self.init(
+                bundle: ProviderEngineBundle(targetOnly: bridge),
+                container: container,
+                tokenizer: tokenizer,
+                modelType: modelType,
+                isVLM: isVLM,
+                sizing: sizing,
+                lastUsedAt: lastUsedAt)
+        }
     }
 
     /// Test hooks: scripted engine builder + deterministic machine memory
@@ -134,17 +180,20 @@ public actor StandaloneServer {
         let physicalMemoryBytes: UInt64?
         let emitTelemetry: (@Sendable (TelemetryEvent) -> Void)?
         let beforeWeightLoad: (@Sendable (String) async throws -> Void)?
+        let assistantLoader: (any ProviderMTPAssistantLoading)?
         let makeEngine: @Sendable (String, Int) throws -> any CBv2Engine
 
         init(
             physicalMemoryBytes: UInt64? = nil,
             emitTelemetry: (@Sendable (TelemetryEvent) -> Void)? = nil,
             beforeWeightLoad: (@Sendable (String) async throws -> Void)? = nil,
+            assistantLoader: (any ProviderMTPAssistantLoading)? = nil,
             makeEngine: @escaping @Sendable (String, Int) throws -> any CBv2Engine
         ) {
             self.physicalMemoryBytes = physicalMemoryBytes
             self.emitTelemetry = emitTelemetry
             self.beforeWeightLoad = beforeWeightLoad
+            self.assistantLoader = assistantLoader
             self.makeEngine = makeEngine
         }
     }
@@ -162,6 +211,7 @@ public actor StandaloneServer {
     private var models: [ModelInfo]
     private var serverTask: Task<Void, Never>?
     private let kvBudget: GlobalKVCacheBudget
+    var specDecFunnel: SpecDecArtifactFunnel
     /// Phase 3: global disk accountant (process-wide, shared across models).
     /// Kept on the v2 path for its crash-sweep of stale on-disk KV from
     /// older (legacy-engine) versions; the v2 engine itself never persists.
@@ -187,6 +237,9 @@ public actor StandaloneServer {
         // operator-facing error and refuses to start when nothing remains.
         self.models = Self.filterSupported(models)
         self.kvBudget = GlobalKVCacheBudget()
+        self.specDecFunnel = SpecDecArtifactFunnel(
+            resolver: SpecDecResolver(),
+            catalog: nil)
         // Sweep only the retired checkpoint tier's `darkbloom/kv` directory.
         // EngineV2 SSD data lives under the separate `darkbloom/kv2` root.
         LegacyKVCacheSweeper.sweep()
@@ -291,9 +344,10 @@ public actor StandaloneServer {
     }
 
     /// Stop the server.
-    public func stop() {
+    public func stop() async {
         serverTask?.cancel()
         serverTask = nil
+        await specDecFunnel.shutdown()
         // Phase 3: shutdown the global disk accountant.
     }
 
@@ -304,8 +358,10 @@ public actor StandaloneServer {
         serverTask = nil
         task?.cancel()
         _ = await task?.value
+        await specDecFunnel.shutdown()
         for slot in slots.values {
             await slot.bridge.shutdown()
+            slot.bundle.releaseAssistant()
         }
         // Return the freed weights to the OS so a later StandaloneServer in the
         // same process (e.g. across tests) sees real free memory.
@@ -330,6 +386,10 @@ public actor StandaloneServer {
 
     func debugOutstandingKVReservationBytes() async -> UInt64 {
         await kvBudget.outstandingReservedBytes()
+    }
+
+    func reservePendingLoadForTesting(requestID: String, bytes: UInt64) async {
+        await kvBudget.reservePendingLoad(requestID: requestID, bytes: bytes)
     }
 
     /// The resident slot's engine KV grant in bytes (re-slice assertions).
@@ -424,6 +484,29 @@ public actor StandaloneServer {
             sizing: sizing)
     }
 
+    /// MTP-aware variant of the standalone re-slice seam. It drives the same
+    /// assistant load, floor fallback, sizing, and engine construction as a
+    /// real local load without publishing the resulting slot.
+    func resliceAndBuildMTPBundleForTesting(
+        modelId: String,
+        modelType: String?,
+        newcomer: EngineV2NewcomerBox,
+        tokenizer: TokenizerHandle,
+        sizing: SlotSizingSnapshot,
+        specDecPreparation: SpecDecPreparation
+    ) async throws -> (bundle: ProviderEngineBundle, sizing: SlotSizingSnapshot) {
+        let build = try await resliceAndBuildBundle(
+            modelId: modelId,
+            modelType: modelType,
+            isVLM: false,
+            modelDirectory: nil,
+            newcomer: newcomer,
+            tokenizer: tokenizer,
+            targetSizing: sizing,
+            specDecPreparation: specDecPreparation)
+        return (build.bundle, build.sizing)
+    }
+
     /// Test seam: the post-bridge-guard failure unwind (retire bridge →
     /// release newcomer weights → regrow survivors, in that order).
     func unwindBuiltSlotAndRegrowForTesting(
@@ -481,6 +564,11 @@ public actor StandaloneServer {
         let bridge: EngineV2Bridge
     }
 
+    private struct SlotBuild {
+        let bundle: ProviderEngineBundle
+        let sizing: SlotSizingSnapshot
+    }
+
     private func existingSlotGrants(excludingModelId: String) async -> [ExistingSlotGrant] {
         var existing: [ExistingSlotGrant] = []
         for (modelId, slot) in slots
@@ -526,13 +614,57 @@ public actor StandaloneServer {
         tokenizer: TokenizerHandle,
         sizing: SlotSizingSnapshot
     ) async throws -> EngineV2Bridge {
+        let build = try await resliceAndBuildBundle(
+            modelId: modelId,
+            modelType: modelType,
+            isVLM: isVLM,
+            modelDirectory: modelDirectory,
+            newcomer: newcomerBox,
+            tokenizer: tokenizer,
+            targetSizing: sizing,
+            specDecPreparation: SpecDecPreparation(
+                artifact: nil,
+                status: .disabled(.configDisabled, configured: false)))
+        return build.bundle.bridge
+    }
+
+    private func resliceAndBuildBundle(
+        modelId: String,
+        modelType: String?,
+        isVLM: Bool,
+        modelDirectory: URL?,
+        newcomer newcomerBox: EngineV2NewcomerBox,
+        tokenizer: TokenizerHandle,
+        targetSizing: SlotSizingSnapshot,
+        specDecPreparation: SpecDecPreparation
+    ) async throws -> SlotBuild {
+        var prepared: EngineV2PreparedModel
+        do {
+            prepared = try await EngineV2SlotFactory.prepareProductionModel(
+                modelId: modelId,
+                isVLM: isVLM,
+                modelDirectory: modelDirectory,
+                container: newcomerBox.borrow(),
+                specDecPreparation: specDecPreparation,
+                assistantLoader: v2TestHooks?.assistantLoader
+                    ?? Gemma4ProviderMTPAssistantLoader(),
+                emitTelemetry: v2TestHooks?.emitTelemetry,
+                logInfo: { standaloneLogger.info("\($0)") },
+                logWarning: { standaloneLogger.warning("\($0)") })
+        } catch {
+            newcomerBox.release()
+            MLX.Memory.clearCache()
+            throw error
+        }
+        var sizing = targetSizing.replacingAuxiliaryWeightBytes(
+            prepared.assistantBytes)
         let existing = await existingSlotGrants(excludingModelId: modelId)
         let newcomer = EngineV2KVSizing.ResliceSlot(
             modelId: modelId,
             fp16KVBytesPerToken: sizing.fp16KVBytesPerToken,
             maxContextLength: sizing.maxContextLength)
-        let fleetBudget = fleetKVBudgetBytes(extraWeightBytes: sizing.weightsBytes)
-        let targets = EngineV2KVSizing.resliceGrants(
+        var fleetBudget = fleetKVBudgetBytes(extraWeightBytes: sizing.weightsBytes)
+        var targets = EngineV2KVSizing.resliceGrants(
             existing: existing.map(\.slot),
             newcomer: newcomer,
             fleetKVBudgetBytes: fleetBudget)
@@ -546,9 +678,25 @@ public actor StandaloneServer {
         for entry in existing where entry.bridge.prefixCacheBudgetBytes > 0 {
             fixedCarveBytes[entry.slot.modelId] = entry.bridge.prefixCacheBudgetBytes
         }
-        guard
-            EngineV2KVSizing.resliceMeetsServiceabilityFloor(
-                targets, fixedCarveBytes: fixedCarveBytes)
+        if !EngineV2KVSizing.resliceMeetsServiceabilityFloor(
+            targets, fixedCarveBytes: fixedCarveBytes), prepared.assistant != nil
+        {
+            standaloneLogger.warning(
+                "mtp: model=\(modelId) fallback reason=\(MTPFallbackReason.assistantResliceFloor.rawValue); retrying target-only before refusing the load")
+            prepared.assistant?.release()
+            prepared = prepared.fallingBack(.assistantResliceFloor)
+            sizing = targetSizing.replacingAuxiliaryWeightBytes(0)
+            await kvBudget.replacePendingLoadReservation(
+                requestID: "pending-load:\(modelId)", bytes: 0)
+            MLX.Memory.clearCache()
+            fleetBudget = fleetKVBudgetBytes(extraWeightBytes: sizing.weightsBytes)
+            targets = EngineV2KVSizing.resliceGrants(
+                existing: existing.map(\.slot),
+                newcomer: newcomer,
+                fleetKVBudgetBytes: fleetBudget)
+        }
+        guard EngineV2KVSizing.resliceMeetsServiceabilityFloor(
+            targets, fixedCarveBytes: fixedCarveBytes)
         else {
             let floorGb = String(
                 format: "%.1f",
@@ -562,6 +710,7 @@ public actor StandaloneServer {
             // newcomer's weights promptly (mirrors ProviderLoop) so live
             // residency reflects the refusal before the caller's error
             // handling runs.
+            prepared.assistant?.release()
             newcomerBox.release()
             MLX.Memory.clearCache()
             throw StandaloneServerError.capacityUnavailable(
@@ -584,9 +733,9 @@ public actor StandaloneServer {
         // `try`) so the container reference lives only for the duration of
         // the build call — by the time the catch runs, the box holds the
         // last strong reference and `release()` frees the weights.
-        let bridge: EngineV2Bridge
+        let bundle: ProviderEngineBundle
         do {
-            bridge = try await EngineV2SlotFactory.makeProductionBridge(
+            bundle = try await EngineV2SlotFactory.makeProductionBundle(
                 modelId: modelId,
                 modelType: modelType,
                 isVLM: isVLM,
@@ -600,6 +749,8 @@ public actor StandaloneServer {
                 kvQuantConfigured: config.kvQuant,
                 kvBackendConfig: config.engineV2KVBackend,
                 kvBackendConfigByModel: config.engineV2KVBackendByModel,
+                specDecPreparation: specDecPreparation,
+                preparedModel: prepared,
                 emitTelemetry: v2TestHooks?.emitTelemetry,
                 makeEngineOverride: v2TestHooks?.makeEngine,
                 logInfo: { standaloneLogger.info("\($0)") },
@@ -611,6 +762,7 @@ public actor StandaloneServer {
             // Restoring before the weights are gone would let Σ(grants)
             // exceed the true fleet budget while the failed container was
             // still resident.
+            prepared.assistant?.release()
             newcomerBox.release()
             MLX.Memory.clearCache()
             for entry in existing {
@@ -627,7 +779,7 @@ public actor StandaloneServer {
             }
         }
 
-        return bridge
+        return SlotBuild(bundle: bundle, sizing: sizing)
     }
 
     /// Post-bridge-guard failure unwind (mirrors
@@ -636,12 +788,20 @@ public actor StandaloneServer {
     /// survivors — in that order, so the regrow's fleet budget reflects true
     /// residency and Σ(grants) never exceeds it. Caller holds `isLoadingAny`.
     private func unwindBuiltSlotAndRegrow(
-        bridge: EngineV2Bridge, newcomer: EngineV2NewcomerBox
+        bundle: ProviderEngineBundle, newcomer: EngineV2NewcomerBox
     ) async {
-        await bridge.shutdown()
+        await bundle.bridge.shutdown()
+        bundle.releaseAssistant()
         newcomer.release()
         MLX.Memory.clearCache()
         await resliceGrowSurvivors()
+    }
+
+    private func unwindBuiltSlotAndRegrow(
+        bridge: EngineV2Bridge, newcomer: EngineV2NewcomerBox
+    ) async {
+        await unwindBuiltSlotAndRegrow(
+            bundle: ProviderEngineBundle(targetOnly: bridge), newcomer: newcomer)
     }
 
     /// Grow the surviving slots back to their re-sliced shares after an
@@ -709,6 +869,7 @@ public actor StandaloneServer {
         // Drain the v2 bridge (running requests finish, new submissions are
         // rejected by the engine), then release the container reference.
         await evicted.bridge.shutdown()
+        evicted.bundle.releaseAssistant()
         if slots[evictKey]?.bridge === evicted.bridge {
             slots.removeValue(forKey: evictKey)
         }
@@ -934,6 +1095,8 @@ public actor StandaloneServer {
         guard let modelPath = ModelScanner.resolveLocalPath(modelID: modelId) else {
             throw StandaloneServerError.modelNotFound(modelId)
         }
+        var mtpPreparation = await specDecPreparation(
+            modelId: modelId, modelInfo: modelInfo)
 
         // Serialize loads so concurrent requests for different models don't
         // interleave and overcommit unified memory.
@@ -954,23 +1117,33 @@ public actor StandaloneServer {
         do {
             try Task.checkCancellation()
             try await evictIfNeededForLoad()
-            try await ensureMemoryHeadroomForLoad(
-                requiredGb: ModelLoadAdmission.requiredToLoadGb(
+            let targetRequiredGb = ModelLoadAdmission.requiredToLoadGb(
                     weightsGb: modelInfo.estimatedMemoryGb,
                     // Cap-aware: activation reserve + min serveable KV, so a model
                     // that loads can actually serve (matches the runtime KV gate).
                     headroomGb: Double(UnifiedMemoryCap.loadHeadroomBytes()) / (1024.0 * 1024.0 * 1024.0))
-            )
+            try await ensureMemoryHeadroomForLoad(requiredGb: targetRequiredGb)
+            if let artifact = mtpPreparation.artifact {
+                if !ProviderLoop.assistantMemoryFits(
+                    availableGb: await availableMemoryGb(),
+                    targetRequiredGb: targetRequiredGb,
+                    assistantBytes: artifact.residentBytes)
+                {
+                    mtpPreparation = mtpPreparation.fallingBack(
+                        .assistantMemoryUnavailable)
+                    standaloneLogger.warning(
+                        "mtp: model=\(modelId) fallback reason=\(MTPFallbackReason.assistantMemoryUnavailable.rawValue) assistant_bytes=\(artifact.residentBytes)")
+                }
+            }
+            let extraWeightBytes = mtpPreparation.artifact?.residentBytes ?? 0
             try Task.checkCancellation()
 
             // Keep incoming weights visible to the process-wide KV ledger while
             // loadContainer is suspended. Existing-model requests continue to
             // serve during this await and must not reserve the same headroom.
-            let pendingLoadGiB = modelInfo.estimatedMemoryGb * 1_073_741_824
-            let pendingLoadBytes: UInt64 =
-                pendingLoadGiB.isFinite && pendingLoadGiB > 0
-                ? (pendingLoadGiB >= Double(UInt64.max) ? .max : UInt64(pendingLoadGiB))
-                : 0
+            let pendingLoadBytes = ProviderLoop.pendingLoadReservationBytes(
+                estimatedWeightsGb: modelInfo.estimatedMemoryGb,
+                extraWeightBytes: extraWeightBytes)
             await kvBudget.reservePendingLoad(
                 requestID: pendingLoadID, bytes: pendingLoadBytes)
 
@@ -993,13 +1166,14 @@ public actor StandaloneServer {
             // Scheduler-free sizing snapshot: weight bytes + the engine-truth
             // fp16 KV rate + context window — everything the re-slice and
             // bridge need.
-            let sizing = try await SlotSizingSnapshot.build(
+            let targetSizing = try await SlotSizingSnapshot.build(
                 container: newcomer.borrow(),
                 modelPath: modelPath,
                 fallbackDefaultMaxTokens: Self.slotDefaultMaxTokens)
             // The loaded weights are now reflected in MLX memory, so transfer
             // accounting from the pending estimate to the live memory snapshot.
-            await kvBudget.release(requestID: pendingLoadID)
+            await kvBudget.replacePendingLoadReservation(
+                requestID: pendingLoadID, bytes: extraWeightBytes)
             let tokenizer: TokenizerHandle = try await newcomer.borrow().perform { ctx in
                 TokenizerHandle(ctx.tokenizer)
             }
@@ -1040,16 +1214,17 @@ public actor StandaloneServer {
             // + existing grants restored inside the catch (unwind ordering)
             // — the catch below just surfaces it as a 503-shaped capacity
             // error.
-            let bridge: EngineV2Bridge
+            var slotBuild: SlotBuild
             do {
-                bridge = try await resliceAndBuildSlot(
+                slotBuild = try await resliceAndBuildBundle(
                     modelId: modelId,
                     modelType: modelInfo.modelType,
                     isVLM: slotIsVLM,
                     modelDirectory: modelPath,
                     newcomer: newcomer,
                     tokenizer: tokenizer,
-                    sizing: sizing)
+                    targetSizing: targetSizing,
+                    specDecPreparation: mtpPreparation)
             } catch let error as StandaloneServerError {
                 MLX.Memory.clearCache()
                 throw error
@@ -1058,6 +1233,10 @@ public actor StandaloneServer {
                 throw StandaloneServerError.capacityUnavailable(
                     "Model '\(modelId)' loaded but its v2 engine construction failed: \(error) — unloaded")
             }
+            await kvBudget.release(requestID: pendingLoadID)
+            var bundle = slotBuild.bundle
+            var sizing = slotBuild.sizing
+            var bridge = bundle.bridge
 
             // Post-BRIDGE measured-headroom re-guard (mirrors ProviderLoop):
             // the engine build (and, for VLM slots, the text-model
@@ -1069,9 +1248,44 @@ public actor StandaloneServer {
             // physical plan. Require both a useful pool and residual
             // whole-machine headroom after the build.
             MLX.Memory.clearCache()
-            let postBridgeServeable = KVHeadroomProbe.postBuildServeable(
+            var postBridgeServeable = KVHeadroomProbe.postBuildServeable(
                 kvBackendKind: bridge.kvBackendKind,
                 pagedPoolBytes: await bridge.kvBackendPoolBytes())
+            let runtimeMTPActive = await bridge.mtpStatusSnapshot().active
+            if bundle.mtpStatus.active,
+                !postBridgeServeable || !runtimeMTPActive
+            {
+                let reason: MTPFallbackReason = runtimeMTPActive
+                    ? .assistantPostBuildHeadroom : .engineInactive
+                standaloneLogger.warning(
+                    "mtp: model=\(modelId) fallback reason=\(reason.rawValue); rebuilding target-only")
+                await bridge.shutdown()
+                bundle.releaseAssistant()
+                MLX.Memory.clearCache()
+                do {
+                    slotBuild = try await resliceAndBuildBundle(
+                        modelId: modelId,
+                        modelType: modelInfo.modelType,
+                        isVLM: slotIsVLM,
+                        modelDirectory: modelPath,
+                        newcomer: newcomer,
+                        tokenizer: tokenizer,
+                        targetSizing: targetSizing,
+                        specDecPreparation: mtpPreparation.fallingBack(reason))
+                } catch {
+                    await resliceGrowSurvivors()
+                    MLX.Memory.clearCache()
+                    throw StandaloneServerError.capacityUnavailable(
+                        "Model '\(modelId)' MTP fallback engine construction failed: \(error) — unloaded")
+                }
+                bundle = slotBuild.bundle
+                sizing = slotBuild.sizing
+                bridge = bundle.bridge
+                MLX.Memory.clearCache()
+                postBridgeServeable = KVHeadroomProbe.postBuildServeable(
+                    kvBackendKind: bridge.kvBackendKind,
+                    pagedPoolBytes: await bridge.kvBackendPoolBytes())
+            }
             if !postBridgeServeable {
                 let headroomGb = String(
                     format: "%.1f",
@@ -1080,7 +1294,7 @@ public actor StandaloneServer {
                 // regrow survivors — in that order (Codex review): regrowing
                 // while the aborted newcomer's weights are still resident
                 // would let Σ(grants) exceed the true fleet budget.
-                await unwindBuiltSlotAndRegrow(bridge: bridge, newcomer: newcomer)
+                await unwindBuiltSlotAndRegrow(bundle: bundle, newcomer: newcomer)
                 throw StandaloneServerError.capacityUnavailable(
                     "Model '\(modelId)' loaded but its engine build left insufficient "
                     + "KV headroom under the memory cap (\(headroomGb) GB free) — unloaded")
@@ -1091,11 +1305,12 @@ public actor StandaloneServer {
                 // Unreachable (the box is drained only on failure paths) —
                 // defensive so a wiring bug can never publish a slot with no
                 // container.
+                await unwindBuiltSlotAndRegrow(bundle: bundle, newcomer: newcomer)
                 throw StandaloneServerError.capacityUnavailable(
                     "internal: newcomer container missing at install for '\(modelId)'")
             }
             slots[modelId] = CachedSlot(
-                bridge: bridge,
+                bundle: bundle,
                 container: installContainer,
                 tokenizer: tokenizer,
                 modelType: modelInfo.modelType,

--- a/provider-swift/Sources/ProviderCore/Server/StandaloneServer.swift
+++ b/provider-swift/Sources/ProviderCore/Server/StandaloneServer.swift
@@ -662,6 +662,14 @@ public actor StandaloneServer {
             MLX.Memory.clearCache()
             throw error
         }
+        // Prepare-stage fail-open: the drafter never became resident, so drop
+        // its share of the pending-load reservation now instead of holding
+        // phantom bytes through the re-slice and engine build (mirrors
+        // ProviderLoop.resliceAndBuildEngineV2Bundle).
+        if prepared.assistant == nil, specDecPreparation.artifact != nil {
+            await kvBudget.replacePendingLoadReservation(
+                requestID: "pending-load:\(modelId)", bytes: 0)
+        }
         var sizing = targetSizing.replacingAuxiliaryWeightBytes(
             prepared.assistantBytes)
         let existing = await existingSlotGrants(excludingModelId: modelId)

--- a/provider-swift/Sources/ProviderCore/Service/LaunchAgent.swift
+++ b/provider-swift/Sources/ProviderCore/Service/LaunchAgent.swift
@@ -272,6 +272,7 @@ public enum LaunchAgent: Sendable {
     static let passthroughEnvKeys = [
         "DARKBLOOM_PREFIX_CACHE", "DARKBLOOM_PREFIX_CACHE_SSD",
         "DARKBLOOM_MLX_RESOURCE_DEBUG", "DARKBLOOM_CBV2_PAGED_KV",
+        "DARKBLOOM_CBV2_MTP",
     ]
 
     /// Build the daemon `EnvironmentVariables` map from a source environment,

--- a/provider-swift/Sources/ProviderCore/Service/LaunchAgent.swift
+++ b/provider-swift/Sources/ProviderCore/Service/LaunchAgent.swift
@@ -269,10 +269,14 @@ public enum LaunchAgent: Sendable {
     /// next launchd start. `DARKBLOOM_CBV2_PAGED_KV`: same rationale for
     /// the paged KV backend's fleet kill switch (default-ON for GPT-OSS
     /// slots — see `EngineV2KVBackendPolicy`).
+    /// `DARKBLOOM_MTP_MAX_RECTANGULAR_TOKENS`: the tighten-only automatic
+    /// rectangular cap override is the operator's lever to REDUCE speculative
+    /// verification work short of disabling MTP entirely; it must survive
+    /// install/restart like the kill switches.
     static let passthroughEnvKeys = [
         "DARKBLOOM_PREFIX_CACHE", "DARKBLOOM_PREFIX_CACHE_SSD",
         "DARKBLOOM_MLX_RESOURCE_DEBUG", "DARKBLOOM_CBV2_PAGED_KV",
-        "DARKBLOOM_CBV2_MTP",
+        "DARKBLOOM_CBV2_MTP", "DARKBLOOM_MTP_MAX_RECTANGULAR_TOKENS",
     ]
 
     /// Build the daemon `EnvironmentVariables` map from a source environment,

--- a/provider-swift/Sources/ProviderCore/SpecDec/SpecDecArtifactFunnel.swift
+++ b/provider-swift/Sources/ProviderCore/SpecDec/SpecDecArtifactFunnel.swift
@@ -67,7 +67,13 @@ actor SpecDecArtifactFunnel {
     /// loads. The deadline is intentionally short and fail-open; target loads
     /// never await catalog or artifact network I/O themselves.
     @discardableResult
-    func prewarmCatalog(modelId: String, timeout: Duration) async -> Bool {
+    func prewarmCatalog(
+        modelId: String,
+        timeout: Duration,
+        sleep: @escaping @Sendable (Duration) async throws -> Void = { duration in
+            try await taskSleep(duration)
+        }
+    ) async -> Bool {
         guard !isShutdown, let catalog else { return false }
         return await withTaskGroup(of: Bool.self) { group in
             group.addTask {
@@ -80,7 +86,7 @@ actor SpecDecArtifactFunnel {
             }
             group.addTask {
                 do {
-                    try await taskSleep(timeout)
+                    try await sleep(timeout)
                 } catch {
                     return false
                 }

--- a/provider-swift/Sources/ProviderCore/SpecDec/SpecDecArtifactFunnel.swift
+++ b/provider-swift/Sources/ProviderCore/SpecDec/SpecDecArtifactFunnel.swift
@@ -1,0 +1,251 @@
+import Foundation
+
+protocol SpecDecCatalogLooking: Sendable {
+    func cachedModel(id: String) async -> CatalogModel?
+    func model(id: String) async throws -> CatalogModel?
+}
+
+extension SpecDecCatalogLooking {
+    func cachedModel(id: String) async -> CatalogModel? { nil }
+}
+
+actor SpecDecCatalogLookup: SpecDecCatalogLooking {
+    private let client: ModelCatalogClient
+    private var cached: [String: CatalogModel]?
+
+    init(coordinatorURL: String, urlSession: URLSession = .shared) {
+        self.client = ModelCatalogClient(coordinatorURL: coordinatorURL, urlSession: urlSession)
+    }
+
+    func cachedModel(id: String) -> CatalogModel? {
+        cached?[id]
+    }
+
+    func model(id: String) async throws -> CatalogModel? {
+        if let model = cached?[id] { return model }
+        // Refresh on a miss so a provider that stays up across a newly
+        // published desired build can resolve that build's immutable pointer.
+        let models = try await client.fetchCatalog()
+        // ModelCatalogClient rejects oversized/unbounded responses before this
+        // actor can retain them.
+        let indexed = Dictionary(models.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
+        cached = indexed
+        return indexed[id]
+    }
+}
+
+/// One target-independent artifact funnel shared by coordinator-serving and
+/// standalone slots. It never loads model weights and never throws.
+actor SpecDecArtifactFunnel {
+    struct Request: Sendable {
+        let modelId: String
+        let modelType: String?
+        let enabled: Bool
+        let localPath: String?
+        let allowDownload: Bool
+        let environment: [String: String]
+    }
+
+    private let resolver: SpecDecResolver
+    private let catalog: (any SpecDecCatalogLooking)?
+    private struct Prefetch {
+        let id: UUID
+        let task: Task<Void, Never>
+    }
+    private var prefetches: [String: Prefetch] = [:]
+    private var prefetchFailures: [String: MTPFallbackReason] = [:]
+    private let maximumPrefetches = 2
+    private var isShutdown = false
+    private var shutdownTasks: [Task<Void, Never>] = []
+
+    init(resolver: SpecDecResolver, catalog: (any SpecDecCatalogLooking)?) {
+        self.resolver = resolver
+        self.catalog = catalog
+    }
+
+    /// Populate only the small catalog metadata cache before startup model
+    /// loads. The deadline is intentionally short and fail-open; target loads
+    /// never await catalog or artifact network I/O themselves.
+    @discardableResult
+    func prewarmCatalog(modelId: String, timeout: Duration) async -> Bool {
+        guard !isShutdown, let catalog else { return false }
+        return await withTaskGroup(of: Bool.self) { group in
+            group.addTask {
+                do {
+                    _ = try await catalog.model(id: modelId)
+                    return true
+                } catch {
+                    return false
+                }
+            }
+            group.addTask {
+                do {
+                    try await taskSleep(timeout)
+                } catch {
+                    return false
+                }
+                return false
+            }
+            let result = await group.next() ?? false
+            group.cancelAll()
+            return result
+        }
+    }
+
+    func prepare(_ request: Request) async -> SpecDecPreparation {
+        guard !isShutdown else {
+            return .init(
+                artifact: nil,
+                status: .disabled(.catalogUnavailable, configured: request.enabled))
+        }
+        guard request.enabled else {
+            return .init(artifact: nil, status: .disabled(.configDisabled, configured: false))
+        }
+        guard Self.killSwitchEnabled(environment: request.environment) else {
+            return .init(artifact: nil, status: .disabled(.killSwitchDisabled, configured: true))
+        }
+        guard Self.isGemma4Target(modelType: request.modelType) else {
+            return .init(artifact: nil, status: .disabled(.targetUnsupported, configured: true))
+        }
+
+        // An explicitly configured local artifact is authoritative. An invalid
+        // local override falls back to target-only rather than silently fetching
+        // and activating a different assistant from the catalog.
+        if let rawPath = request.localPath?.trimmingCharacters(in: .whitespacesAndNewlines),
+            !rawPath.isEmpty
+        {
+            guard let artifact = SpecDecStore.inspectLocalArtifact(path: rawPath) else {
+                return .init(
+                    artifact: nil,
+                    status: .disabled(.localArtifactInvalid, configured: true))
+            }
+            return .init(artifact: artifact, status: .candidate(artifact))
+        }
+
+        guard let catalog else {
+            return .init(
+                artifact: nil,
+                status: .disabled(.catalogDisabled, configured: true))
+        }
+
+        guard let model = await catalog.cachedModel(id: request.modelId) else {
+            if request.allowDownload {
+                schedulePrefetch(modelId: request.modelId, catalog: catalog)
+            }
+            return .init(
+                artifact: nil,
+                status: .disabled(
+                    prefetchFailures[request.modelId] ?? .artifactNotCached,
+                    configured: true))
+        }
+        // Loading paths only inspect verified local state. Any optional network
+        // work is owned by this funnel so shutdown can cancel it promptly.
+        let resolution = await resolver.resolve(model: model, allowDownload: false)
+        if resolution.reason == .artifactNotCached, request.allowDownload {
+            scheduleArtifactPrefetch(modelId: request.modelId, model: model)
+        }
+        guard let artifact = resolution.artifact else {
+            return .init(
+                artifact: nil,
+                status: .disabled(resolution.reason ?? .publicationFailed, configured: true))
+        }
+        return .init(artifact: artifact, status: .candidate(artifact))
+    }
+
+    func shutdown() async {
+        if isShutdown {
+            for task in shutdownTasks { await task.value }
+            return
+        }
+        // Terminal before the first suspension: reentrant prepare calls and
+        // tasks returning from catalog lookup cannot enqueue successor work.
+        isShutdown = true
+        let tasks = prefetches.values.map(\.task)
+        shutdownTasks = tasks
+        prefetches.removeAll()
+        for task in tasks { task.cancel() }
+        for task in tasks { await task.value }
+        shutdownTasks.removeAll()
+    }
+
+    private func schedulePrefetch(
+        modelId: String,
+        catalog: any SpecDecCatalogLooking
+    ) {
+        guard !isShutdown,
+            prefetches[modelId] == nil,
+            prefetches.count < maximumPrefetches
+        else {
+            return
+        }
+        let id = UUID()
+        let resolver = self.resolver
+        let task = Task {
+            let reason: MTPFallbackReason?
+            do {
+                guard let model = try await catalog.model(id: modelId) else {
+                    self.finishPrefetch(
+                        modelId: modelId, id: id, reason: .catalogModelMissing)
+                    return
+                }
+                guard self.prefetchMayContinue(modelId: modelId, id: id) else {
+                    return
+                }
+                let result = await resolver.prefetch(model: model)
+                reason = result.artifact == nil ? result.reason : nil
+            } catch {
+                reason = .catalogUnavailable
+            }
+            self.finishPrefetch(modelId: modelId, id: id, reason: reason)
+        }
+        prefetches[modelId] = Prefetch(id: id, task: task)
+    }
+
+    private func scheduleArtifactPrefetch(modelId: String, model: CatalogModel) {
+        guard !isShutdown,
+            prefetches[modelId] == nil,
+            prefetches.count < maximumPrefetches
+        else {
+            return
+        }
+        let id = UUID()
+        let resolver = self.resolver
+        let task = Task {
+            let result = await resolver.prefetch(model: model)
+            self.finishPrefetch(
+                modelId: modelId,
+                id: id,
+                reason: result.artifact == nil ? result.reason : nil)
+        }
+        prefetches[modelId] = Prefetch(id: id, task: task)
+    }
+
+    private func prefetchMayContinue(modelId: String, id: UUID) -> Bool {
+        !isShutdown && prefetches[modelId]?.id == id
+    }
+
+    private func finishPrefetch(
+        modelId: String,
+        id: UUID,
+        reason: MTPFallbackReason?
+    ) {
+        guard prefetches[modelId]?.id == id else { return }
+        prefetches.removeValue(forKey: modelId)
+        if let reason {
+            prefetchFailures[modelId] = reason
+        } else {
+            prefetchFailures.removeValue(forKey: modelId)
+        }
+    }
+
+    static func isGemma4Target(modelType: String?) -> Bool {
+        EngineV2SupportedModels.isGemma4Target(modelType: modelType)
+    }
+
+    static func killSwitchEnabled(environment: [String: String]) -> Bool {
+        guard let raw = environment["DARKBLOOM_CBV2_MTP"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines).lowercased(), !raw.isEmpty
+        else { return true }
+        return !["0", "false", "no", "off"].contains(raw)
+    }
+}

--- a/provider-swift/Sources/ProviderCore/SpecDec/SpecDecArtifactFunnel.swift
+++ b/provider-swift/Sources/ProviderCore/SpecDec/SpecDecArtifactFunnel.swift
@@ -3,10 +3,19 @@ import Foundation
 protocol SpecDecCatalogLooking: Sendable {
     func cachedModel(id: String) async -> CatalogModel?
     func model(id: String) async throws -> CatalogModel?
+    /// Bypass the cache and refetch the catalog. Used when a CACHED entry is
+    /// suspected stale (present, but without usable `spec_dec` metadata) so a
+    /// coordinator that adds spec-dec to an existing model id can roll out
+    /// without a provider restart. New builds get new ids and refresh through
+    /// the ordinary `model(id:)` miss path.
+    func freshModel(id: String) async throws -> CatalogModel?
 }
 
 extension SpecDecCatalogLooking {
     func cachedModel(id: String) async -> CatalogModel? { nil }
+    func freshModel(id: String) async throws -> CatalogModel? {
+        try await model(id: id)
+    }
 }
 
 actor SpecDecCatalogLookup: SpecDecCatalogLooking {
@@ -25,6 +34,10 @@ actor SpecDecCatalogLookup: SpecDecCatalogLooking {
         if let model = cached?[id] { return model }
         // Refresh on a miss so a provider that stays up across a newly
         // published desired build can resolve that build's immutable pointer.
+        return try await freshModel(id: id)
+    }
+
+    func freshModel(id: String) async throws -> CatalogModel? {
         let models = try await client.fetchCatalog()
         // ModelCatalogClient rejects oversized/unbounded responses before this
         // actor can retain them.
@@ -57,6 +70,11 @@ actor SpecDecArtifactFunnel {
     private let maximumPrefetches = 2
     private var isShutdown = false
     private var shutdownTasks: [Task<Void, Never>] = []
+    /// Cooldown for stale-entry catalog refreshes so a model that is
+    /// permanently missing spec-dec metadata cannot make every load attempt
+    /// refetch the catalog. Internal-settable for tests.
+    var catalogRefreshCooldown: Duration = .seconds(600)
+    private var catalogRefreshedAt: [String: ContinuousClock.Instant] = [:]
 
     init(resolver: SpecDecResolver, catalog: (any SpecDecCatalogLooking)?) {
         self.resolver = resolver
@@ -149,6 +167,14 @@ actor SpecDecArtifactFunnel {
         let resolution = await resolver.resolve(model: model, allowDownload: false)
         if resolution.reason == .artifactNotCached, request.allowDownload {
             scheduleArtifactPrefetch(modelId: request.modelId, model: model)
+        } else if let reason = resolution.reason,
+            reason == .metadataMissing || reason == .metadataMalformed,
+            request.allowDownload
+        {
+            // The cached catalog entry exists but carries no usable spec_dec.
+            // The coordinator may have added it after this cache filled, so
+            // refresh (cooldown-gated) instead of staying stuck until restart.
+            scheduleCatalogRefresh(modelId: request.modelId, catalog: catalog)
         }
         guard let artifact = resolution.artifact else {
             return .init(
@@ -157,6 +183,9 @@ actor SpecDecArtifactFunnel {
         }
         return .init(artifact: artifact, status: .candidate(artifact))
     }
+
+    /// Number of in-flight prefetch/refresh tasks (test observability).
+    var prefetchInFlightForTesting: Int { prefetches.count }
 
     func shutdown() async {
         if isShutdown {
@@ -190,6 +219,47 @@ actor SpecDecArtifactFunnel {
             let reason: MTPFallbackReason?
             do {
                 guard let model = try await catalog.model(id: modelId) else {
+                    self.finishPrefetch(
+                        modelId: modelId, id: id, reason: .catalogModelMissing)
+                    return
+                }
+                guard self.prefetchMayContinue(modelId: modelId, id: id) else {
+                    return
+                }
+                let result = await resolver.prefetch(model: model)
+                reason = result.artifact == nil ? result.reason : nil
+            } catch {
+                reason = .catalogUnavailable
+            }
+            self.finishPrefetch(modelId: modelId, id: id, reason: reason)
+        }
+        prefetches[modelId] = Prefetch(id: id, task: task)
+    }
+
+    /// Refresh a suspected-stale cached catalog entry, then prefetch the
+    /// artifact if the refreshed metadata now resolves. Reuses the prefetch
+    /// ledger for dedupe/shutdown and is additionally cooldown-gated.
+    private func scheduleCatalogRefresh(
+        modelId: String,
+        catalog: any SpecDecCatalogLooking
+    ) {
+        guard !isShutdown,
+            prefetches[modelId] == nil,
+            prefetches.count < maximumPrefetches
+        else {
+            return
+        }
+        let now = ContinuousClock.now
+        if let last = catalogRefreshedAt[modelId], now - last < catalogRefreshCooldown {
+            return
+        }
+        catalogRefreshedAt[modelId] = now
+        let id = UUID()
+        let resolver = self.resolver
+        let task = Task {
+            let reason: MTPFallbackReason?
+            do {
+                guard let model = try await catalog.freshModel(id: modelId) else {
                     self.finishPrefetch(
                         modelId: modelId, id: id, reason: .catalogModelMissing)
                     return

--- a/provider-swift/Sources/ProviderCore/SpecDec/SpecDecMetadata.swift
+++ b/provider-swift/Sources/ProviderCore/SpecDec/SpecDecMetadata.swift
@@ -1,0 +1,193 @@
+import Foundation
+
+struct SpecDecArtifactReference: Sendable, Equatable, Hashable {
+    let r2Prefix: String
+    let manifestSHA256: String
+    let expectedTotalBytes: UInt64
+    let expectedFileCount: Int
+    let maximumFileCount: Int
+    let allowedFileRoles: Set<String>
+    let configSHA256: String
+    let revision: String
+}
+
+struct SpecDecMetadataError: Error, Sendable, CustomStringConvertible {
+    let reason: MTPFallbackReason
+    let description: String
+}
+
+enum SpecDecMetadata {
+    static func reference(for model: CatalogModel) -> Result<SpecDecArtifactReference, SpecDecMetadataError> {
+        guard let raw = model.metadata?["spec_dec"] else {
+            return .failure(.init(reason: .metadataMissing, description: "spec_dec is absent"))
+        }
+        guard case .object(let pairs) = raw else {
+            return .failure(.init(reason: .metadataMalformed, description: "spec_dec is not an object"))
+        }
+        let keys = pairs.map(\.0)
+        guard Set(keys).count == keys.count else {
+            return .failure(.init(reason: .metadataMalformed, description: "spec_dec has duplicate keys"))
+        }
+        let values = Dictionary(uniqueKeysWithValues: pairs)
+
+        guard case .string(let rawPrefix)? = values["r2_prefix"] else {
+            return .failure(.init(reason: .metadataMalformed, description: "r2_prefix is missing or not a string"))
+        }
+        let prefix = rawPrefix.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard validPrefix(prefix) else {
+            return .failure(.init(reason: .metadataMalformed, description: "r2_prefix is invalid"))
+        }
+
+        func digest(_ key: String) -> Result<String?, SpecDecMetadataError> {
+            guard let value = values[key] else { return .success(nil) }
+            guard case .string(let raw) = value, isSHA256(raw) else {
+                return .failure(.init(reason: .metadataMalformed, description: "\(key) is not a SHA-256 hex digest"))
+            }
+            return .success(raw.lowercased())
+        }
+
+        let manifestDigest: String
+        let configDigest: String
+        switch digest("manifest_sha256") {
+        case .success(let value):
+            guard let value else {
+                return .failure(.init(
+                    reason: .metadataMalformed,
+                    description: "manifest_sha256 is required"))
+            }
+            manifestDigest = value
+        case .failure(let error): return .failure(error)
+        }
+        let configDigestResult = values["config_sha256"] != nil
+            ? digest("config_sha256") : digest("family_digest")
+        switch configDigestResult {
+        case .success(let value):
+            guard let value else {
+                return .failure(.init(
+                    reason: .metadataMalformed,
+                    description: "config_sha256 or family_digest is required"))
+            }
+            configDigest = value
+        case .failure(let error): return .failure(error)
+        }
+
+        let expectedBytes: UInt64
+        switch boundedUInt(values["total_size_bytes"], maximum: SpecDecLimits.maximumArtifactBytes) {
+        case .success(let value):
+            guard let value else {
+                return .failure(.init(
+                    reason: .metadataMalformed,
+                    description: "total_size_bytes is required"))
+            }
+            expectedBytes = value
+        case .failure(let error): return .failure(error)
+        }
+        let expectedCount: Int
+        switch boundedInt(values["file_count"], maximum: SpecDecLimits.maximumFileCount) {
+        case .success(let value):
+            guard let value else {
+                return .failure(.init(
+                    reason: .metadataMalformed,
+                    description: "file_count is required"))
+            }
+            expectedCount = value
+        case .failure(let error): return .failure(error)
+        }
+        let maximumCount: Int
+        switch boundedInt(values["max_file_count"], maximum: SpecDecLimits.maximumFileCount) {
+        case .success(let value):
+            guard let value else {
+                return .failure(.init(
+                    reason: .metadataMalformed,
+                    description: "max_file_count is required"))
+            }
+            maximumCount = value
+        case .failure(let error): return .failure(error)
+        }
+        if expectedCount > maximumCount {
+            return .failure(.init(reason: .metadataMalformed, description: "file_count exceeds max_file_count"))
+        }
+
+        guard let rawRoles = values["allowed_file_types"] ?? values["allowed_file_roles"],
+            case .array(let array) = rawRoles, !array.isEmpty,
+            array.count <= SpecDecLimits.allowedRoles.count
+        else {
+            return .failure(.init(reason: .metadataMalformed, description: "allowed_file_types is required and must be bounded"))
+        }
+        var roles = Set<String>()
+        for item in array {
+            guard case .string(let role) = item, role.utf8.count <= 32,
+                SpecDecLimits.allowedRoles.contains(role), roles.insert(role).inserted
+            else {
+                return .failure(.init(reason: .metadataMalformed, description: "allowed_file_types contains a duplicate or unsupported role"))
+            }
+        }
+        guard roles.contains("config"), roles.contains("weight") else {
+            return .failure(.init(reason: .metadataMalformed, description: "assistant requires config and weight file roles"))
+        }
+
+        guard case .string(let revision)? = values["revision"], !revision.isEmpty,
+            revision.utf8.count <= SpecDecLimits.maximumRevisionBytes,
+            validIdentifier(revision)
+        else {
+            return .failure(.init(reason: .metadataMalformed, description: "revision is required and must be valid"))
+        }
+
+        return .success(
+            SpecDecArtifactReference(
+                r2Prefix: prefix,
+                manifestSHA256: manifestDigest,
+                expectedTotalBytes: expectedBytes,
+                expectedFileCount: expectedCount,
+                maximumFileCount: maximumCount,
+                allowedFileRoles: roles,
+                configSHA256: configDigest,
+                revision: revision))
+    }
+
+    static func validPrefix(_ prefix: String) -> Bool {
+        guard !prefix.isEmpty, prefix.utf8.count <= SpecDecLimits.maximumPrefixBytes,
+            !prefix.hasPrefix("/"), !prefix.contains("\\"),
+            !prefix.contains("?"), !prefix.contains("#")
+        else { return false }
+        let parts = prefix.split(separator: "/", omittingEmptySubsequences: false)
+        return parts.allSatisfy { part in
+            !part.isEmpty && part != "." && part != ".."
+                && part.utf8.count <= SpecDecLimits.maximumFileNameBytes
+                && validIdentifier(String(part))
+        }
+    }
+
+    static func validIdentifier(_ value: String) -> Bool {
+        !value.isEmpty && value.utf8.allSatisfy {
+            (48...57).contains($0) || (65...90).contains($0) || (97...122).contains($0)
+                || $0 == 45 || $0 == 46 || $0 == 95
+        }
+    }
+
+    static func isSHA256(_ value: String) -> Bool {
+        value.utf8.count == 64 && value.utf8.allSatisfy {
+            (48...57).contains($0) || (65...70).contains($0) || (97...102).contains($0)
+        }
+    }
+
+    private static func boundedUInt(
+        _ value: JSONValue?, maximum: UInt64
+    ) -> Result<UInt64?, SpecDecMetadataError> {
+        guard let value else { return .success(nil) }
+        guard case .int(let raw) = value, raw > 0, UInt64(raw) <= maximum else {
+            return .failure(.init(reason: .metadataMalformed, description: "numeric metadata is out of bounds"))
+        }
+        return .success(UInt64(raw))
+    }
+
+    private static func boundedInt(
+        _ value: JSONValue?, maximum: Int
+    ) -> Result<Int?, SpecDecMetadataError> {
+        guard let value else { return .success(nil) }
+        guard case .int(let raw) = value, raw > 0, raw <= Int64(maximum) else {
+            return .failure(.init(reason: .metadataMalformed, description: "count metadata is out of bounds"))
+        }
+        return .success(Int(raw))
+    }
+}

--- a/provider-swift/Sources/ProviderCore/SpecDec/SpecDecResolver.swift
+++ b/provider-swift/Sources/ProviderCore/SpecDec/SpecDecResolver.swift
@@ -1,0 +1,190 @@
+/// SpecDecResolver -- resolves the local drafter directory for a catalog
+/// model that carries a `spec_dec` distribution pointer (plan D2).
+///
+/// The target build's registry entry attaches
+/// `metadata.spec_dec = {"r2_prefix": "v2-specdec/<artifact>/<version>"}`.
+/// This resolver fetches that artifact's `manifest.json` from the model CDN
+/// (same source/env as `ModelDownloader`: `DARKBLOOM_R2_CDN_URL`, default
+/// `https://models.darkbloom.ai`), downloads each listed file with per-file
+/// SHA-256 verification into a staging dir, and atomically publishes it under
+/// `~/.darkbloom/spec-dec/<key>/`.
+///
+/// FAIL-OPEN CONTRACT: every failure -- no metadata pointer, HTTP error, SHA
+/// mismatch after retries, disk full -- returns nil after one WARN log, never
+/// throws. A drafter problem must never become a slot/load failure; the
+/// caller falls back to plain decode (availability beats speculation).
+///
+/// Deliberately absent (plan D3): aggregate-hash enforcement and registry
+/// pinning. Per-file SHA-256 from the artifact's own manifest is the only
+/// integrity gate, because greedy-accept-walk drafter bytes cannot alter
+/// output content.
+
+import Foundation
+import Logging
+import ProviderCoreFoundation
+
+public struct SpecDecResolver: Sendable {
+
+    private let storeRoot: URL
+    private let downloader: ModelDownloader
+
+    private static let logger = Logger(label: "darkbloom.SpecDecResolver")
+
+    /// - Parameters:
+    ///   - storeRoot: drafter store root; defaults to `~/.darkbloom/spec-dec/`
+    ///     (override for tests).
+    ///   - cdnBaseURL: CDN base; defaults to `DARKBLOOM_R2_CDN_URL` /
+    ///     `https://models.darkbloom.ai`, the same resolution `ModelDownloader`
+    ///     uses (override for tests).
+    ///   - urlSession: transport (override for tests).
+    public init(storeRoot: URL? = nil, cdnBaseURL: String? = nil, urlSession: URLSession = .shared) {
+        self.storeRoot = storeRoot ?? SpecDecStore.defaultRoot()
+        self.downloader = ModelDownloader(r2CDNURL: cdnBaseURL, urlSession: urlSession)
+    }
+
+    /// The `metadata.spec_dec.r2_prefix` pointer, when the catalog entry
+    /// carries one. Callers can use this to check for a pointer cheaply
+    /// (without the resolver's fail-open WARN) before resolving.
+    public static func specDecR2Prefix(for model: CatalogModel) -> String? {
+        guard case .string(let prefix)? = model.metadata?["spec_dec"]?["r2_prefix"],
+              !prefix.isEmpty
+        else { return nil }
+        return prefix
+    }
+
+    /// Resolve the local drafter directory for `model`. Returns a directory
+    /// containing the artifact's files + its `manifest.json`, or nil (with one
+    /// WARN log) on any failure. When a complete verified copy is already on
+    /// disk no network traffic happens; otherwise the artifact is downloaded
+    /// iff `allowDownload` is true.
+    public func drafterDirectory(for model: CatalogModel, allowDownload: Bool) async -> URL? {
+        guard let prefix = Self.specDecR2Prefix(for: model) else {
+            Self.logger.warning(
+                "spec-dec: model \(model.id) carries no spec_dec.r2_prefix metadata; no drafter")
+            return nil
+        }
+
+        let artifactDir = SpecDecStore.artifactDirectory(root: storeRoot, r2Prefix: prefix)
+        if SpecDecStore.verifiedManifest(at: artifactDir) != nil {
+            return artifactDir
+        }
+
+        guard allowDownload else {
+            Self.logger.warning(
+                "spec-dec: no verified local copy of \(prefix) for \(model.id) and downloads are disabled; no drafter")
+            return nil
+        }
+
+        do {
+            try await downloadArtifact(r2Prefix: prefix, into: artifactDir)
+        } catch {
+            Self.logger.warning(
+                "spec-dec: fetch of \(prefix) for \(model.id) failed (\(errorDetail(error))); falling back to plain decode")
+            return nil
+        }
+
+        // Re-verify the published copy so a nil here always means "not usable".
+        guard SpecDecStore.verifiedManifest(at: artifactDir) != nil else {
+            Self.logger.warning(
+                "spec-dec: downloaded copy of \(prefix) for \(model.id) failed verification; falling back to plain decode")
+            return nil
+        }
+        return artifactDir
+    }
+
+    // MARK: - Download
+
+    /// Fetch `<cdn>/<r2_prefix>/manifest.json`, download every listed file
+    /// with per-file SHA-256 verification into a stable staging dir (resuming
+    /// already-valid files / `.part` prefixes), stage the manifest bytes as
+    /// the completeness marker, then atomically publish to `artifactDir`.
+    private func downloadArtifact(r2Prefix: String, into artifactDir: URL) async throws {
+        let (manifest, manifestData) = try await fetchManifest(r2Prefix: r2Prefix)
+
+        guard !manifest.files.isEmpty else {
+            throw ModelCatalogError.downloadFailed("manifest contains no files")
+        }
+        guard manifest.files.count == manifest.fileCount else {
+            throw ModelCatalogError.downloadFailed(
+                "manifest file_count \(manifest.fileCount) does not match files array")
+        }
+
+        let fm = FileManager.default
+        let stagingDir = SpecDecStore.stagingDirectory(root: storeRoot, r2Prefix: r2Prefix)
+        try fm.createDirectory(at: stagingDir, withIntermediateDirectories: true)
+
+        // NOTE: URLs are built from the artifact's own manifest prefix
+        // deliberately -- there is no catalog pinning to cross-check (D3).
+        let jobs = try manifest.files.map { file -> (file: ManifestFile, destination: URL, url: String) in
+            let relativePath = try ModelDownloader.validatedManifestRelativePath(file.path)
+            return (
+                file: file,
+                destination: stagingDir.appendingPathComponent(relativePath, isDirectory: false),
+                url: "\(downloader.r2CDNURL)/\(ModelDownloader.escapeR2Path(r2Prefix))/\(ModelDownloader.escapeR2Path(relativePath))"
+            )
+        }
+
+        // Disk pre-check sized to what is actually left to fetch (valid staged
+        // files and `.part` prefixes are credited), same as the model paths.
+        let alreadyValid = jobs.map {
+            ModelDownloader.fileMatches($0.destination, size: $0.file.sizeBytes, sha256: $0.file.sha256)
+        }
+        let partBytes = jobs.map { downloader.fileSize($0.destination.appendingPathExtension("part")) }
+        try ModelDownloader.ensureAvailableCapacity(
+            at: storeRoot,
+            requiredBytes: ModelDownloader.remainingBytesToFetch(
+                sizes: jobs.map(\.file.sizeBytes), alreadyValid: alreadyValid, partBytes: partBytes
+            )
+        )
+
+        // Sequential fetch (drafter artifacts are small -- ~2 files, ~226 MiB);
+        // each file byte-resumes and is size + SHA-256 verified before promotion.
+        for (job, valid) in zip(jobs, alreadyValid) where !valid {
+            try await downloader.downloadManifestFileWithResume(job)
+        }
+
+        // The staged manifest doubles as the store's completeness marker: it is
+        // written only after every file verified, and the publish below is atomic.
+        try manifestData.write(
+            to: stagingDir.appendingPathComponent(SpecDecStore.manifestFileName, isDirectory: false))
+
+        try ModelDownloader.publishStagedSnapshot(stagingDir, to: artifactDir)
+        // Staging was consumed by the publish; best-effort husk cleanup.
+        try? fm.removeItem(at: stagingDir)
+    }
+
+    private func fetchManifest(r2Prefix: String) async throws -> (ModelManifest, Data) {
+        let urlString = "\(downloader.r2CDNURL)/\(ModelDownloader.escapeR2Path(r2Prefix))/manifest.json"
+        guard let url = URL(string: urlString) else {
+            throw ModelCatalogError.downloadFailed("invalid manifest URL: \(urlString)")
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.timeoutInterval = 30
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await downloader.urlSession.data(for: request)
+        } catch {
+            throw ModelCatalogError.downloadFailed("manifest.json: \(error.localizedDescription)")
+        }
+        if let http = response as? HTTPURLResponse, !(200..<300).contains(http.statusCode) {
+            throw ModelCatalogError.downloadFailed("manifest.json: HTTP \(http.statusCode)")
+        }
+
+        do {
+            let manifest = try ModelCatalogClient.manifestDecoder.decode(ModelManifest.self, from: data)
+            return (manifest, data)
+        } catch {
+            throw ModelCatalogError.downloadFailed("manifest.json decode failed: \(error.localizedDescription)")
+        }
+    }
+
+    private func errorDetail(_ error: Error) -> String {
+        if let catalogError = error as? ModelCatalogError { return catalogError.description }
+        return error.localizedDescription
+    }
+}

--- a/provider-swift/Sources/ProviderCore/SpecDec/SpecDecResolver.swift
+++ b/provider-swift/Sources/ProviderCore/SpecDec/SpecDecResolver.swift
@@ -1,190 +1,373 @@
-/// SpecDecResolver -- resolves the local drafter directory for a catalog
-/// model that carries a `spec_dec` distribution pointer (plan D2).
-///
-/// The target build's registry entry attaches
-/// `metadata.spec_dec = {"r2_prefix": "v2-specdec/<artifact>/<version>"}`.
-/// This resolver fetches that artifact's `manifest.json` from the model CDN
-/// (same source/env as `ModelDownloader`: `DARKBLOOM_R2_CDN_URL`, default
-/// `https://models.darkbloom.ai`), downloads each listed file with per-file
-/// SHA-256 verification into a staging dir, and atomically publishes it under
-/// `~/.darkbloom/spec-dec/<key>/`.
-///
-/// FAIL-OPEN CONTRACT: every failure -- no metadata pointer, HTTP error, SHA
-/// mismatch after retries, disk full -- returns nil after one WARN log, never
-/// throws. A drafter problem must never become a slot/load failure; the
-/// caller falls back to plain decode (availability beats speculation).
-///
-/// Deliberately absent (plan D3): aggregate-hash enforcement and registry
-/// pinning. Per-file SHA-256 from the artifact's own manifest is the only
-/// integrity gate, because greedy-accept-walk drafter bytes cannot alter
-/// output content.
-
 import Foundation
 import Logging
 import ProviderCoreFoundation
 
-public struct SpecDecResolver: Sendable {
+private actor SpecDecResolutionCoordinator {
+    static let shared = SpecDecResolutionCoordinator()
 
+    struct Key: Sendable, Hashable {
+        let storeRoot: String
+        let cdnIdentity: String
+        let reference: SpecDecArtifactReference
+        let allowDownload: Bool
+    }
+
+    private struct Inflight {
+        let id: UUID
+        let task: Task<SpecDecResolution, Never>
+        let keepAlive: Bool
+        var waiters: [UUID: CheckedContinuation<SpecDecResolution, Never>]
+    }
+    private var inflight: [Key: Inflight] = [:]
+    private let maximumInflight = 4
+
+    func run(
+        key: Key,
+        operation: @escaping @Sendable () async -> SpecDecResolution
+    ) async -> SpecDecResolution {
+        let inflightID: UUID
+        if let existing = inflight[key] {
+            inflightID = existing.id
+        } else {
+            guard inflight.count < maximumInflight else {
+                return .fallback(.artifactNotCached, detail: "MTP prefetch concurrency limit reached")
+            }
+            let id = UUID()
+            let task = Task {
+                let result = await operation()
+                self.finished(key: key, id: id, result: result)
+                return result
+            }
+            inflight[key] = Inflight(
+                id: id, task: task, keepAlive: false, waiters: [:])
+            inflightID = id
+        }
+        let waiterID = UUID()
+        return await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                guard var current = inflight[key], current.id == inflightID else {
+                    continuation.resume(returning: .fallback(
+                        .fileDownloadFailed,
+                        detail: "MTP prefetch ended before waiter registration"))
+                    return
+                }
+                current.waiters[waiterID] = continuation
+                inflight[key] = current
+            }
+        } onCancel: {
+            Task {
+                await self.cancelWaiter(
+                    key: key, inflightID: inflightID, waiterID: waiterID)
+            }
+        }
+    }
+
+    func schedule(
+        key: Key,
+        operation: @escaping @Sendable () async -> SpecDecResolution
+    ) {
+        guard inflight[key] == nil, inflight.count < maximumInflight else { return }
+        let id = UUID()
+        let task = Task {
+            let result = await operation()
+            self.finished(key: key, id: id, result: result)
+            return result
+        }
+        inflight[key] = Inflight(
+            id: id, task: task, keepAlive: true, waiters: [:])
+    }
+
+    private func cancelWaiter(
+        key: Key,
+        inflightID: UUID,
+        waiterID: UUID
+    ) {
+        guard var current = inflight[key], current.id == inflightID,
+            let continuation = current.waiters.removeValue(forKey: waiterID)
+        else { return }
+        if current.waiters.isEmpty, !current.keepAlive {
+            inflight.removeValue(forKey: key)
+            current.task.cancel()
+        } else {
+            inflight[key] = current
+        }
+        continuation.resume(returning: .fallback(
+            .fileDownloadFailed, detail: "MTP prefetch was cancelled"))
+    }
+
+    private func finished(
+        key: Key,
+        id: UUID,
+        result: SpecDecResolution
+    ) {
+        guard let current = inflight[key], current.id == id else { return }
+        inflight.removeValue(forKey: key)
+        for continuation in current.waiters.values {
+            continuation.resume(returning: result)
+        }
+    }
+}
+
+public struct SpecDecResolver: Sendable {
     private let storeRoot: URL
     private let downloader: ModelDownloader
-
+    private let prefetchTimeout: Duration
     private static let logger = Logger(label: "darkbloom.SpecDecResolver")
 
-    /// - Parameters:
-    ///   - storeRoot: drafter store root; defaults to `~/.darkbloom/spec-dec/`
-    ///     (override for tests).
-    ///   - cdnBaseURL: CDN base; defaults to `DARKBLOOM_R2_CDN_URL` /
-    ///     `https://models.darkbloom.ai`, the same resolution `ModelDownloader`
-    ///     uses (override for tests).
-    ///   - urlSession: transport (override for tests).
-    public init(storeRoot: URL? = nil, cdnBaseURL: String? = nil, urlSession: URLSession = .shared) {
+    public init(
+        storeRoot: URL? = nil,
+        cdnBaseURL: String? = nil,
+        urlSession: URLSession = .shared,
+        prefetchTimeout: Duration = .seconds(120)
+    ) {
         self.storeRoot = storeRoot ?? SpecDecStore.defaultRoot()
         self.downloader = ModelDownloader(r2CDNURL: cdnBaseURL, urlSession: urlSession)
+        self.prefetchTimeout = prefetchTimeout
     }
 
-    /// The `metadata.spec_dec.r2_prefix` pointer, when the catalog entry
-    /// carries one. Callers can use this to check for a pointer cheaply
-    /// (without the resolver's fail-open WARN) before resolving.
     public static func specDecR2Prefix(for model: CatalogModel) -> String? {
-        guard case .string(let prefix)? = model.metadata?["spec_dec"]?["r2_prefix"],
-              !prefix.isEmpty
-        else { return nil }
-        return prefix
+        guard case .success(let reference) = SpecDecMetadata.reference(for: model) else { return nil }
+        return reference.r2Prefix
     }
 
-    /// Resolve the local drafter directory for `model`. Returns a directory
-    /// containing the artifact's files + its `manifest.json`, or nil (with one
-    /// WARN log) on any failure. When a complete verified copy is already on
-    /// disk no network traffic happens; otherwise the artifact is downloaded
-    /// iff `allowDownload` is true.
+    func resolve(model: CatalogModel, allowDownload: Bool) async -> SpecDecResolution {
+        let reference: SpecDecArtifactReference
+        switch SpecDecMetadata.reference(for: model) {
+        case .success(let value): reference = value
+        case .failure(let error): return .fallback(error.reason, detail: error.description)
+        }
+        let cached = resolveCached(reference: reference)
+        guard cached.reason == .artifactNotCached, allowDownload else { return cached }
+
+        let key = resolutionKey(reference: reference, allowDownload: true)
+        await SpecDecResolutionCoordinator.shared.schedule(key: key) {
+            await boundedDownload(reference: reference)
+        }
+        return cached
+    }
+
+    /// Explicit prefetch lifecycle used by the background artifact funnel and
+    /// tests. Callers that are loading a target use `resolve`, which only checks
+    /// verified local state and schedules this work without awaiting it.
+    func prefetch(model: CatalogModel) async -> SpecDecResolution {
+        let reference: SpecDecArtifactReference
+        switch SpecDecMetadata.reference(for: model) {
+        case .success(let value): reference = value
+        case .failure(let error): return .fallback(error.reason, detail: error.description)
+        }
+        let cached = resolveCached(reference: reference)
+        guard cached.reason == .artifactNotCached else { return cached }
+        let key = resolutionKey(reference: reference, allowDownload: true)
+        return await SpecDecResolutionCoordinator.shared.run(key: key) {
+            await boundedDownload(reference: reference)
+        }
+    }
+
+    /// URL-only convenience surface. Cold downloads are scheduled and return
+    /// nil immediately; a later call observes the verified publication.
     public func drafterDirectory(for model: CatalogModel, allowDownload: Bool) async -> URL? {
-        guard let prefix = Self.specDecR2Prefix(for: model) else {
-            Self.logger.warning(
-                "spec-dec: model \(model.id) carries no spec_dec.r2_prefix metadata; no drafter")
-            return nil
+        let result = await resolve(model: model, allowDownload: allowDownload)
+        if let reason = result.reason {
+            let message = "spec-dec: model \(model.id) fallback reason=\(reason.rawValue)"
+                + (result.detail.map { " detail=\($0)" } ?? "")
+            Self.logger.warning("\(message)")
         }
-
-        let artifactDir = SpecDecStore.artifactDirectory(root: storeRoot, r2Prefix: prefix)
-        if SpecDecStore.verifiedManifest(at: artifactDir) != nil {
-            return artifactDir
-        }
-
-        guard allowDownload else {
-            Self.logger.warning(
-                "spec-dec: no verified local copy of \(prefix) for \(model.id) and downloads are disabled; no drafter")
-            return nil
-        }
-
-        do {
-            try await downloadArtifact(r2Prefix: prefix, into: artifactDir)
-        } catch {
-            Self.logger.warning(
-                "spec-dec: fetch of \(prefix) for \(model.id) failed (\(errorDetail(error))); falling back to plain decode")
-            return nil
-        }
-
-        // Re-verify the published copy so a nil here always means "not usable".
-        guard SpecDecStore.verifiedManifest(at: artifactDir) != nil else {
-            Self.logger.warning(
-                "spec-dec: downloaded copy of \(prefix) for \(model.id) failed verification; falling back to plain decode")
-            return nil
-        }
-        return artifactDir
+        return result.artifact?.directory
     }
 
-    // MARK: - Download
-
-    /// Fetch `<cdn>/<r2_prefix>/manifest.json`, download every listed file
-    /// with per-file SHA-256 verification into a stable staging dir (resuming
-    /// already-valid files / `.part` prefixes), stage the manifest bytes as
-    /// the completeness marker, then atomically publish to `artifactDir`.
-    private func downloadArtifact(r2Prefix: String, into artifactDir: URL) async throws {
-        let (manifest, manifestData) = try await fetchManifest(r2Prefix: r2Prefix)
-
-        guard !manifest.files.isEmpty else {
-            throw ModelCatalogError.downloadFailed("manifest contains no files")
+    private func resolveCached(reference: SpecDecArtifactReference) -> SpecDecResolution {
+        let artifactDir = SpecDecStore.artifactDirectory(
+            root: storeRoot, r2Prefix: reference.r2Prefix)
+        if FileManager.default.fileExists(atPath: artifactDir.path) {
+            switch SpecDecStore.verifyPublishedArtifact(at: artifactDir, reference: reference) {
+            case .success(let verification):
+                return .resolved(artifact(from: verification, directory: artifactDir, reference: reference))
+            case .failure(let error):
+                // Immutable publications are never replaced in place. A warm
+                // corruption is observable and target decode remains available.
+                return .fallback(.warmArtifactCorrupt, detail: error.description)
+            }
         }
-        guard manifest.files.count == manifest.fileCount else {
-            throw ModelCatalogError.downloadFailed(
-                "manifest file_count \(manifest.fileCount) does not match files array")
+        return .fallback(.artifactNotCached)
+    }
+
+    private func downloadAndPublish(
+        reference: SpecDecArtifactReference
+    ) async -> SpecDecResolution {
+        let artifactDir = SpecDecStore.artifactDirectory(
+            root: storeRoot, r2Prefix: reference.r2Prefix)
+        // A task can sit behind the bounded coordinator while another process
+        // publishes the artifact. Recheck before opening a network transfer.
+        let cached = resolveCached(reference: reference)
+        guard cached.reason == .artifactNotCached else { return cached }
+        do {
+            try FileManager.default.createDirectory(
+                at: storeRoot, withIntermediateDirectories: true)
+            let staging = SpecDecStore.stagingDirectory(
+                root: storeRoot, r2Prefix: reference.r2Prefix)
+            defer { try? FileManager.default.removeItem(at: staging) }
+            _ = try await downloadArtifact(reference: reference, staging: staging)
+            switch SpecDecStore.publishImmutable(
+                staging: staging, destination: artifactDir, reference: reference)
+            {
+            case .success(let published):
+                return .resolved(artifact(from: published, directory: artifactDir, reference: reference))
+            case .failure(let error):
+                return .fallback(error.reason, detail: error.description)
+            }
+        } catch let failure as ResolverFailure {
+            return .fallback(failure.reason, detail: failure.description)
+        } catch {
+            return .fallback(.fileDownloadFailed, detail: error.localizedDescription)
+        }
+    }
+
+    private func boundedDownload(
+        reference: SpecDecArtifactReference
+    ) async -> SpecDecResolution {
+        await withTaskGroup(of: SpecDecResolution.self) { group in
+            group.addTask {
+                await downloadAndPublish(reference: reference)
+            }
+            group.addTask {
+                do {
+                    try await taskSleep(prefetchTimeout)
+                    return .fallback(
+                        .fileDownloadFailed,
+                        detail: "MTP prefetch exceeded its owned deadline")
+                } catch {
+                    return .fallback(
+                        .fileDownloadFailed,
+                        detail: "MTP prefetch was cancelled")
+                }
+            }
+            let result = await group.next()
+                ?? .fallback(.fileDownloadFailed, detail: "MTP prefetch ended without a result")
+            group.cancelAll()
+            return result
+        }
+    }
+
+    private func resolutionKey(
+        reference: SpecDecArtifactReference,
+        allowDownload: Bool
+    ) -> SpecDecResolutionCoordinator.Key {
+        .init(
+            storeRoot: storeRoot.standardizedFileURL.path,
+            cdnIdentity: downloader.r2CDNURL,
+            reference: reference,
+            allowDownload: allowDownload)
+    }
+
+    private func downloadArtifact(
+        reference: SpecDecArtifactReference,
+        staging: URL
+    ) async throws -> SpecDecStore.Verification {
+        let (manifest, manifestData) = try await fetchManifest(reference: reference)
+        switch SpecDecStore.validateManifest(manifest, data: manifestData, reference: reference) {
+        case .failure(let error): throw ResolverFailure(reason: error.reason, description: error.description)
+        case .success: break
         }
 
         let fm = FileManager.default
-        let stagingDir = SpecDecStore.stagingDirectory(root: storeRoot, r2Prefix: r2Prefix)
-        try fm.createDirectory(at: stagingDir, withIntermediateDirectories: true)
-
-        // NOTE: URLs are built from the artifact's own manifest prefix
-        // deliberately -- there is no catalog pinning to cross-check (D3).
-        let jobs = try manifest.files.map { file -> (file: ManifestFile, destination: URL, url: String) in
-            let relativePath = try ModelDownloader.validatedManifestRelativePath(file.path)
-            return (
+        try fm.createDirectory(at: staging, withIntermediateDirectories: false)
+        let jobs = manifest.files.map { file in
+            (
                 file: file,
-                destination: stagingDir.appendingPathComponent(relativePath, isDirectory: false),
-                url: "\(downloader.r2CDNURL)/\(ModelDownloader.escapeR2Path(r2Prefix))/\(ModelDownloader.escapeR2Path(relativePath))"
+                destination: staging.appendingPathComponent(file.path, isDirectory: false),
+                url: "\(downloader.r2CDNURL)/\(ModelDownloader.escapeR2Path(reference.r2Prefix))/\(ModelDownloader.escapeR2Path(file.path))"
             )
         }
-
-        // Disk pre-check sized to what is actually left to fetch (valid staged
-        // files and `.part` prefixes are credited), same as the model paths.
-        let alreadyValid = jobs.map {
-            ModelDownloader.fileMatches($0.destination, size: $0.file.sizeBytes, sha256: $0.file.sha256)
-        }
-        let partBytes = jobs.map { downloader.fileSize($0.destination.appendingPathExtension("part")) }
         try ModelDownloader.ensureAvailableCapacity(
-            at: storeRoot,
-            requiredBytes: ModelDownloader.remainingBytesToFetch(
-                sizes: jobs.map(\.file.sizeBytes), alreadyValid: alreadyValid, partBytes: partBytes
-            )
-        )
+            at: storeRoot, requiredBytes: manifest.totalSizeBytes)
 
-        // Sequential fetch (drafter artifacts are small -- ~2 files, ~226 MiB);
-        // each file byte-resumes and is size + SHA-256 verified before promotion.
-        for (job, valid) in zip(jobs, alreadyValid) where !valid {
-            try await downloader.downloadManifestFileWithResume(job)
+        for job in jobs {
+            do {
+                try await downloader.downloadManifestFileWithResume(job)
+            } catch {
+                let detail = String(describing: error)
+                let reason: MTPFallbackReason = detail.contains("SHA-256 mismatch")
+                    ? .fileDigestMismatch : .fileDownloadFailed
+                throw ResolverFailure(reason: reason, description: detail)
+            }
         }
-
-        // The staged manifest doubles as the store's completeness marker: it is
-        // written only after every file verified, and the publish below is atomic.
         try manifestData.write(
-            to: stagingDir.appendingPathComponent(SpecDecStore.manifestFileName, isDirectory: false))
-
-        try ModelDownloader.publishStagedSnapshot(stagingDir, to: artifactDir)
-        // Staging was consumed by the publish; best-effort husk cleanup.
-        try? fm.removeItem(at: stagingDir)
+            to: staging.appendingPathComponent(SpecDecStore.manifestFileName),
+            options: [.atomic])
+        switch SpecDecStore.verifyPublishedArtifact(at: staging, reference: reference) {
+        case .success(let verification): return verification
+        case .failure(let error):
+            throw ResolverFailure(reason: error.reason, description: error.description)
+        }
     }
 
-    private func fetchManifest(r2Prefix: String) async throws -> (ModelManifest, Data) {
-        let urlString = "\(downloader.r2CDNURL)/\(ModelDownloader.escapeR2Path(r2Prefix))/manifest.json"
+    private func fetchManifest(
+        reference: SpecDecArtifactReference
+    ) async throws -> (ModelManifest, Data) {
+        let urlString = "\(downloader.r2CDNURL)/\(ModelDownloader.escapeR2Path(reference.r2Prefix))/manifest.json"
         guard let url = URL(string: urlString) else {
-            throw ModelCatalogError.downloadFailed("invalid manifest URL: \(urlString)")
+            throw ResolverFailure(reason: .manifestFetchFailed, description: "invalid manifest URL")
         }
-
         var request = URLRequest(url: url)
         request.httpMethod = "GET"
         request.timeoutInterval = 30
         request.setValue("application/json", forHTTPHeaderField: "Accept")
 
-        let data: Data
+        let bytes: URLSession.AsyncBytes
         let response: URLResponse
         do {
-            (data, response) = try await downloader.urlSession.data(for: request)
+            (bytes, response) = try await downloader.urlSession.bytes(for: request)
         } catch {
-            throw ModelCatalogError.downloadFailed("manifest.json: \(error.localizedDescription)")
+            throw ResolverFailure(reason: .manifestFetchFailed, description: "manifest request failed")
         }
-        if let http = response as? HTTPURLResponse, !(200..<300).contains(http.statusCode) {
-            throw ModelCatalogError.downloadFailed("manifest.json: HTTP \(http.statusCode)")
+        guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
+            throw ResolverFailure(reason: .manifestFetchFailed, description: "manifest returned a non-success status")
         }
-
+        if response.expectedContentLength > Int64(SpecDecLimits.maximumManifestBytes) {
+            throw ResolverFailure(reason: .manifestMalformed, description: "manifest exceeds byte bound")
+        }
+        var data = Data()
+        data.reserveCapacity(min(
+            max(0, Int(response.expectedContentLength)), SpecDecLimits.maximumManifestBytes))
         do {
-            let manifest = try ModelCatalogClient.manifestDecoder.decode(ModelManifest.self, from: data)
-            return (manifest, data)
+            for try await byte in bytes {
+                guard data.count < SpecDecLimits.maximumManifestBytes else {
+                    throw ResolverFailure(reason: .manifestMalformed, description: "manifest exceeds byte bound")
+                }
+                data.append(byte)
+            }
+        } catch let failure as ResolverFailure {
+            throw failure
         } catch {
-            throw ModelCatalogError.downloadFailed("manifest.json decode failed: \(error.localizedDescription)")
+            throw ResolverFailure(reason: .manifestFetchFailed, description: "manifest stream failed")
+        }
+        do {
+            return (
+                try ModelCatalogClient.manifestDecoder.decode(ModelManifest.self, from: data),
+                data)
+        } catch {
+            throw ResolverFailure(reason: .manifestMalformed, description: "manifest JSON decode failed")
         }
     }
 
-    private func errorDetail(_ error: Error) -> String {
-        if let catalogError = error as? ModelCatalogError { return catalogError.description }
-        return error.localizedDescription
+    private func artifact(
+        from verification: SpecDecStore.Verification,
+        directory: URL,
+        reference: SpecDecArtifactReference
+    ) -> SpecDecArtifact {
+        SpecDecArtifact(
+            directory: directory,
+            source: .catalog,
+            revision: reference.revision,
+            artifactBytes: verification.artifactBytes,
+            residentBytes: SpecDecLimits.residentEstimate(
+                artifactBytes: verification.artifactBytes),
+            manifestSHA256: verification.manifestSHA256,
+            catalogReference: reference)
+    }
+
+    private struct ResolverFailure: Error, Sendable, CustomStringConvertible {
+        let reason: MTPFallbackReason
+        let description: String
     }
 }

--- a/provider-swift/Sources/ProviderCore/SpecDec/SpecDecStore.swift
+++ b/provider-swift/Sources/ProviderCore/SpecDec/SpecDecStore.swift
@@ -1,70 +1,383 @@
-/// SpecDecStore -- on-disk layout + completeness verification for the
-/// speculative-decoding drafter store at `~/.darkbloom/spec-dec/`.
-///
-/// This store is deliberately OUTSIDE the HuggingFace cache: drafter
-/// artifacts are never scanned, advertised, weight-hashed, or attested
-/// (plan D3 -- with the greedy accept-walk, drafter bytes can only affect
-/// speed, never output). Artifacts are keyed by a stable hash of their
-/// `r2_prefix`, so multiple catalog builds pointing at one drafter artifact
-/// share a single download.
-
 import CryptoKit
 import Foundation
 import ProviderCoreFoundation
 
 enum SpecDecStore {
-
     static let manifestFileName = "manifest.json"
 
-    /// `~/.darkbloom/spec-dec/` -- sibling of the other provider-owned state
-    /// dirs (device auth, enrollment, logs), never inside the HF cache.
+    struct Verification: Sendable {
+        let manifest: ModelManifest
+        let manifestSHA256: String
+        let artifactBytes: UInt64
+    }
+
+    struct VerificationError: Error, Sendable, CustomStringConvertible {
+        let reason: MTPFallbackReason
+        let description: String
+    }
+
     static func defaultRoot() -> URL {
         FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent(".darkbloom", isDirectory: true)
             .appendingPathComponent("spec-dec", isDirectory: true)
     }
 
-    /// Stable directory key for an artifact prefix: first 16 hex chars of
-    /// SHA-256 over the exact `r2_prefix` string. Both gemma builds carry the
-    /// same prefix, hash to the same key, and share one download. The full
-    /// prefix stays introspectable via the stored manifest's `r2_prefix`.
+    /// Full SHA-256 avoids aliasing two immutable prefixes into one directory.
     static func key(forR2Prefix prefix: String) -> String {
-        let digest = SHA256.hash(data: Data(prefix.utf8))
-        return String(digest.map { String(format: "%02x", $0) }.joined().prefix(16))
+        SHA256.hash(data: Data(prefix.utf8))
+            .map { String(format: "%02x", $0) }.joined()
     }
 
     static func artifactDirectory(root: URL, r2Prefix: String) -> URL {
         root.appendingPathComponent(key(forR2Prefix: r2Prefix), isDirectory: true)
     }
 
-    /// Stable staging dir (keyed like the artifact dir, dot-prefixed) so an
-    /// interrupted download resumes into the same dir -- mirroring the
-    /// ModelDownloader staging convention.
     static func stagingDirectory(root: URL, r2Prefix: String) -> URL {
-        root.appendingPathComponent(".staging-" + key(forR2Prefix: r2Prefix), isDirectory: true)
+        root.appendingPathComponent(
+            ".staging-\(key(forR2Prefix: r2Prefix))-\(UUID().uuidString)",
+            isDirectory: true)
     }
 
-    /// A stored copy is complete when its `manifest.json` decodes and every
-    /// listed file exists with the manifest's exact size. Per-file SHA-256 was
-    /// verified at download time; the warm re-resolve is size-only by design
-    /// (there is no aggregate-hash enforcement for drafters, plan D3).
-    static func verifiedManifest(at directory: URL) -> ModelManifest? {
+    static func verifyPublishedArtifact(
+        at directory: URL,
+        reference: SpecDecArtifactReference
+    ) -> Result<Verification, VerificationError> {
+        let fm = FileManager.default
+        guard !Task.isCancelled else {
+            return .failure(.init(reason: .warmArtifactCorrupt, description: "artifact verification was cancelled"))
+        }
+        guard isDirectoryWithoutSymlink(directory) else {
+            return .failure(.init(reason: .warmArtifactCorrupt, description: "artifact directory is missing or is a symlink"))
+        }
         let manifestURL = directory.appendingPathComponent(manifestFileName, isDirectory: false)
-        guard let data = try? Data(contentsOf: manifestURL),
-              let manifest = try? ModelCatalogClient.manifestDecoder.decode(ModelManifest.self, from: data),
-              !manifest.files.isEmpty
+        guard let manifestSize = regularFileSize(manifestURL),
+            manifestSize > 0, manifestSize <= UInt64(SpecDecLimits.maximumManifestBytes)
+        else {
+            return .failure(.init(reason: .warmArtifactCorrupt, description: "manifest file is missing, non-regular, or oversized"))
+        }
+        let manifestData: Data
+        do {
+            manifestData = try Data(contentsOf: manifestURL)
+        } catch {
+            return .failure(.init(reason: .warmArtifactCorrupt, description: "manifest file is unreadable"))
+        }
+        let manifest: ModelManifest
+        do {
+            manifest = try ModelCatalogClient.manifestDecoder.decode(ModelManifest.self, from: manifestData)
+        } catch {
+            return .failure(.init(reason: .manifestMalformed, description: "manifest JSON is invalid"))
+        }
+        switch validateManifest(manifest, data: manifestData, reference: reference) {
+        case .failure(let error): return .failure(error)
+        case .success: break
+        }
+
+        let expectedNames = Set(manifest.files.map(\.path) + [manifestFileName])
+        guard let actualURLs = try? fm.contentsOfDirectory(
+            at: directory, includingPropertiesForKeys: nil, options: []),
+            Set(actualURLs.map(\.lastPathComponent)) == expectedNames
+        else {
+            return .failure(.init(reason: .warmArtifactCorrupt, description: "artifact contains missing or unexpected files"))
+        }
+
+        var aggregate = SHA256()
+        var configDigest: String?
+        for file in manifest.files.sorted(by: { $0.path < $1.path }) {
+            guard !Task.isCancelled else {
+                return .failure(.init(reason: .warmArtifactCorrupt, description: "artifact verification was cancelled"))
+            }
+            let url = directory.appendingPathComponent(file.path, isDirectory: false)
+            guard let size = regularFileSize(url), size == UInt64(file.sizeBytes) else {
+                return .failure(.init(reason: .warmArtifactCorrupt, description: "stored file size/type mismatch"))
+            }
+            guard let digest = digestRegularFile(at: url), hex(digest) == file.sha256.lowercased() else {
+                return .failure(.init(reason: .fileDigestMismatch, description: "stored file digest mismatch"))
+            }
+            digest.withUnsafeBytes { aggregate.update(bufferPointer: $0) }
+            if file.path == "config.json" {
+                configDigest = hex(digest)
+            }
+        }
+        guard hex(aggregate.finalize()) == manifest.aggregateSHA256.lowercased() else {
+            return .failure(.init(reason: .fileDigestMismatch, description: "stored aggregate digest mismatch"))
+        }
+        guard configDigest == reference.configSHA256 else {
+            return .failure(.init(reason: .fileDigestMismatch, description: "assistant config digest mismatch"))
+        }
+        return .success(
+            Verification(
+                manifest: manifest,
+                manifestSHA256: sha256Hex(manifestData),
+                artifactBytes: UInt64(manifest.totalSizeBytes)))
+    }
+
+    static func validateManifest(
+        _ manifest: ModelManifest,
+        data: Data,
+        reference: SpecDecArtifactReference
+    ) -> Result<Void, VerificationError> {
+        guard data.count <= SpecDecLimits.maximumManifestBytes, manifest.schemaVersion == 1 else {
+            return .failure(.init(reason: .manifestMalformed, description: "unsupported or oversized manifest"))
+        }
+        let manifestDigest = sha256Hex(data)
+        if manifestDigest != reference.manifestSHA256 {
+            return .failure(.init(reason: .manifestDigestMismatch, description: "manifest digest does not match catalog metadata"))
+        }
+        guard manifest.r2Prefix == reference.r2Prefix,
+            reference.revision == manifest.version,
+            !manifest.modelID.isEmpty, manifest.modelID.utf8.count <= 512,
+            !manifest.version.isEmpty,
+            manifest.version.utf8.count <= SpecDecLimits.maximumRevisionBytes,
+            manifest.modelID.split(separator: "/", omittingEmptySubsequences: false)
+                .allSatisfy({ SpecDecMetadata.validIdentifier(String($0)) }),
+            SpecDecMetadata.validIdentifier(manifest.version)
+        else {
+            return .failure(.init(reason: .manifestBindingMismatch, description: "manifest identity does not match metadata"))
+        }
+        guard manifest.fileCount == manifest.files.count,
+            manifest.fileCount > 0,
+            manifest.fileCount <= reference.maximumFileCount,
+            manifest.fileCount <= SpecDecLimits.maximumFileCount,
+            reference.expectedFileCount == manifest.fileCount
+        else {
+            return .failure(.init(reason: .fileCountInvalid, description: "manifest file count is invalid"))
+        }
+        guard manifest.totalSizeBytes > 0,
+            UInt64(manifest.totalSizeBytes) <= SpecDecLimits.maximumArtifactBytes,
+            reference.expectedTotalBytes == UInt64(manifest.totalSizeBytes)
+        else {
+            return .failure(.init(reason: .artifactOversize, description: "manifest total size is invalid"))
+        }
+        guard SpecDecMetadata.isSHA256(manifest.aggregateSHA256) else {
+            return .failure(.init(reason: .manifestMalformed, description: "aggregate digest is invalid"))
+        }
+
+        var names = Set<String>()
+        var total: UInt64 = 0
+        var hasConfig = false
+        var hasWeights = false
+        for file in manifest.files {
+            guard let safe = try? ModelDownloader.validatedManifestRelativePath(file.path),
+                safe == file.path, !safe.contains("/"),
+                safe.utf8.count <= SpecDecLimits.maximumFileNameBytes,
+                SpecDecMetadata.validIdentifier(safe),
+                names.insert(safe).inserted
+            else {
+                return .failure(.init(reason: .pathInvalid, description: "manifest path is unsafe or duplicated"))
+            }
+            guard file.sizeBytes > 0, SpecDecMetadata.isSHA256(file.sha256),
+                file.role.utf8.count <= 32
+            else {
+                return .failure(.init(reason: .manifestMalformed, description: "manifest file facts are invalid"))
+            }
+            guard SpecDecLimits.allowedRoles.contains(file.role),
+                reference.allowedFileRoles.contains(file.role)
+            else {
+                return .failure(.init(reason: .fileTypeDisallowed, description: "manifest file role is disallowed"))
+            }
+            if file.role == "config" {
+                guard file.path == "config.json",
+                    UInt64(file.sizeBytes) <= SpecDecLimits.maximumConfigBytes
+                else {
+                    return .failure(.init(reason: .fileTypeDisallowed, description: "config role must be config.json"))
+                }
+                hasConfig = true
+            } else if file.role == "weight" {
+                guard file.path.hasSuffix(".safetensors") else {
+                    return .failure(.init(reason: .fileTypeDisallowed, description: "weight role must be safetensors"))
+                }
+                hasWeights = true
+            }
+            let (sum, overflow) = total.addingReportingOverflow(UInt64(file.sizeBytes))
+            guard !overflow, sum <= SpecDecLimits.maximumArtifactBytes else {
+                return .failure(.init(reason: .artifactOversize, description: "manifest file sizes overflow the artifact bound"))
+            }
+            total = sum
+        }
+        guard hasConfig, hasWeights, total == UInt64(manifest.totalSizeBytes) else {
+            return .failure(.init(reason: .manifestMalformed, description: "manifest totals or required files are invalid"))
+        }
+        return .success(())
+    }
+
+    /// Inspect an operator-provided local assistant without trusting names or
+    /// directory aggregate size. Only the exact files consumed by the engine
+    /// loader are allowed and charged.
+    static func inspectLocalArtifact(path: String) -> SpecDecArtifact? {
+        guard path.utf8.count <= 4096 else { return nil }
+        let expanded = (path as NSString).expandingTildeInPath
+        let directory = URL(fileURLWithPath: expanded, isDirectory: true).standardizedFileURL
+        let canonicalDirectory = directory.resolvingSymlinksInPath()
+        guard isDirectoryWithoutSymlink(directory),
+            let urls = try? FileManager.default.contentsOfDirectory(
+                at: directory, includingPropertiesForKeys: nil, options: []),
+            !urls.isEmpty, urls.count <= SpecDecLimits.maximumFileCount
         else { return nil }
 
-        let fm = FileManager.default
-        for file in manifest.files {
-            guard let relative = try? ModelDownloader.validatedManifestRelativePath(file.path) else {
+        var total: UInt64 = 0
+        var hasConfig = false
+        var configDigest: String?
+        var weightDigests: [String: String] = [:]
+        for url in urls {
+            guard !Task.isCancelled else { return nil }
+            let name = url.lastPathComponent
+            let standardized = url.standardizedFileURL
+            guard !isSymbolicLink(standardized),
+                standardized.resolvingSymlinksInPath().deletingLastPathComponent()
+                    == canonicalDirectory,
+                let size = regularFileSize(standardized), size > 0,
+                let digest = digestRegularFile(at: standardized)
+            else { return nil }
+            let digestHex = hex(digest)
+            if name == "config.json" {
+                guard size <= SpecDecLimits.maximumConfigBytes else { return nil }
+                hasConfig = true
+                configDigest = digestHex
+            } else if name.hasSuffix(".safetensors") {
+                weightDigests[name] = digestHex
+            } else {
                 return nil
             }
-            let onDisk = directory.appendingPathComponent(relative, isDirectory: false)
-            guard let attrs = try? fm.attributesOfItem(atPath: onDisk.path),
-                  let size = attrs[.size] as? Int64, size == file.sizeBytes
-            else { return nil }
+            let (sum, overflow) = total.addingReportingOverflow(size)
+            guard !overflow, sum <= SpecDecLimits.maximumArtifactBytes else { return nil }
+            total = sum
         }
-        return manifest
+        guard hasConfig, !weightDigests.isEmpty, let configDigest else { return nil }
+        return SpecDecArtifact(
+            directory: directory,
+            source: .local,
+            revision: "local-\(configDigest.prefix(16))",
+            artifactBytes: total,
+            residentBytes: SpecDecLimits.residentEstimate(artifactBytes: total),
+            manifestSHA256: nil,
+            localWeightSHA256: weightDigests,
+            localConfigSHA256: configDigest)
+    }
+
+    /// Re-inspect the exact bytes immediately before assistant construction.
+    /// Catalog artifacts are verified against their retained immutable trust
+    /// reference; mutable local overrides must still match the inspected size
+    /// and config revision used for admission.
+    static func revalidateForLoad(_ artifact: SpecDecArtifact) -> SpecDecResolution {
+        switch artifact.source {
+        case .catalog:
+            guard let reference = artifact.catalogReference else {
+                return .fallback(
+                    .warmArtifactCorrupt,
+                    detail: "catalog artifact has no retained trust reference")
+            }
+            switch verifyPublishedArtifact(at: artifact.directory, reference: reference) {
+            case .failure(let error):
+                return .fallback(.warmArtifactCorrupt, detail: error.description)
+            case .success(let verification):
+                let refreshed = SpecDecArtifact(
+                    directory: artifact.directory,
+                    source: .catalog,
+                    revision: reference.revision,
+                    artifactBytes: verification.artifactBytes,
+                    residentBytes: SpecDecLimits.residentEstimate(
+                        artifactBytes: verification.artifactBytes),
+                    manifestSHA256: verification.manifestSHA256,
+                    catalogReference: reference)
+                guard refreshed.artifactBytes == artifact.artifactBytes,
+                    refreshed.residentBytes == artifact.residentBytes,
+                    refreshed.revision == artifact.revision,
+                    refreshed.manifestSHA256 == artifact.manifestSHA256
+                else {
+                    return .fallback(
+                        .warmArtifactCorrupt,
+                        detail: "catalog artifact facts changed after admission")
+                }
+                return .resolved(refreshed)
+            }
+        case .local:
+            guard let refreshed = inspectLocalArtifact(path: artifact.directory.path),
+                refreshed.directory == artifact.directory,
+                refreshed.artifactBytes == artifact.artifactBytes,
+                refreshed.residentBytes == artifact.residentBytes,
+                refreshed.revision == artifact.revision,
+                refreshed.localWeightSHA256 == artifact.localWeightSHA256,
+                refreshed.localConfigSHA256 == artifact.localConfigSHA256
+            else {
+                return .fallback(
+                    .localArtifactInvalid,
+                    detail: "local assistant changed after admission")
+            }
+            return .resolved(refreshed)
+        }
+    }
+
+    static func publishImmutable(
+        staging: URL,
+        destination: URL,
+        reference: SpecDecArtifactReference
+    ) -> Result<Verification, VerificationError> {
+        let fm = FileManager.default
+        if fm.fileExists(atPath: destination.path) {
+            return verifyPublishedArtifact(at: destination, reference: reference)
+        }
+        do {
+            try fm.moveItem(at: staging, to: destination)
+        } catch {
+            // Another process may have won the immutable publication race.
+            if fm.fileExists(atPath: destination.path) {
+                return verifyPublishedArtifact(at: destination, reference: reference)
+            }
+            return .failure(.init(reason: .publicationFailed, description: "atomic directory publication failed"))
+        }
+        return verifyPublishedArtifact(at: destination, reference: reference)
+    }
+
+    private static func isDirectoryWithoutSymlink(_ url: URL) -> Bool {
+        guard !isSymbolicLink(url),
+            let attrs = try? FileManager.default.attributesOfItem(atPath: url.path),
+            let type = attrs[.type] as? FileAttributeType
+        else { return false }
+        return type == .typeDirectory
+    }
+
+    private static func regularFileSize(_ url: URL) -> UInt64? {
+        guard !isSymbolicLink(url),
+            let attrs = try? FileManager.default.attributesOfItem(atPath: url.path),
+            let type = attrs[.type] as? FileAttributeType, type == .typeRegular,
+            let number = attrs[.size] as? NSNumber
+        else { return nil }
+        return number.uint64Value
+    }
+
+    private static func isSymbolicLink(_ url: URL) -> Bool {
+        (try? url.resourceValues(forKeys: [.isSymbolicLinkKey]).isSymbolicLink) == true
+    }
+
+    /// Hash once per file, in bounded chunks, checking cancellation between
+    /// chunks. The resulting digest serves both the per-file manifest check and
+    /// aggregate digest, avoiding the prior second full artifact read.
+    private static func digestRegularFile(at url: URL) -> SHA256Digest? {
+        guard regularFileSize(url) != nil,
+            let handle = try? FileHandle(forReadingFrom: url)
+        else { return nil }
+        defer { try? handle.close() }
+
+        var hasher = SHA256()
+        while true {
+            guard !Task.isCancelled else { return nil }
+            do {
+                guard let chunk = try handle.read(upToCount: 1024 * 1024) else {
+                    return hasher.finalize()
+                }
+                if chunk.isEmpty { return hasher.finalize() }
+                hasher.update(data: chunk)
+            } catch {
+                return nil
+            }
+        }
+    }
+
+    private static func hex(_ digest: SHA256Digest) -> String {
+        digest.map { String(format: "%02x", $0) }.joined()
+    }
+
+    private static func sha256Hex(_ data: Data) -> String {
+        SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
     }
 }

--- a/provider-swift/Sources/ProviderCore/SpecDec/SpecDecStore.swift
+++ b/provider-swift/Sources/ProviderCore/SpecDec/SpecDecStore.swift
@@ -1,0 +1,70 @@
+/// SpecDecStore -- on-disk layout + completeness verification for the
+/// speculative-decoding drafter store at `~/.darkbloom/spec-dec/`.
+///
+/// This store is deliberately OUTSIDE the HuggingFace cache: drafter
+/// artifacts are never scanned, advertised, weight-hashed, or attested
+/// (plan D3 -- with the greedy accept-walk, drafter bytes can only affect
+/// speed, never output). Artifacts are keyed by a stable hash of their
+/// `r2_prefix`, so multiple catalog builds pointing at one drafter artifact
+/// share a single download.
+
+import CryptoKit
+import Foundation
+import ProviderCoreFoundation
+
+enum SpecDecStore {
+
+    static let manifestFileName = "manifest.json"
+
+    /// `~/.darkbloom/spec-dec/` -- sibling of the other provider-owned state
+    /// dirs (device auth, enrollment, logs), never inside the HF cache.
+    static func defaultRoot() -> URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".darkbloom", isDirectory: true)
+            .appendingPathComponent("spec-dec", isDirectory: true)
+    }
+
+    /// Stable directory key for an artifact prefix: first 16 hex chars of
+    /// SHA-256 over the exact `r2_prefix` string. Both gemma builds carry the
+    /// same prefix, hash to the same key, and share one download. The full
+    /// prefix stays introspectable via the stored manifest's `r2_prefix`.
+    static func key(forR2Prefix prefix: String) -> String {
+        let digest = SHA256.hash(data: Data(prefix.utf8))
+        return String(digest.map { String(format: "%02x", $0) }.joined().prefix(16))
+    }
+
+    static func artifactDirectory(root: URL, r2Prefix: String) -> URL {
+        root.appendingPathComponent(key(forR2Prefix: r2Prefix), isDirectory: true)
+    }
+
+    /// Stable staging dir (keyed like the artifact dir, dot-prefixed) so an
+    /// interrupted download resumes into the same dir -- mirroring the
+    /// ModelDownloader staging convention.
+    static func stagingDirectory(root: URL, r2Prefix: String) -> URL {
+        root.appendingPathComponent(".staging-" + key(forR2Prefix: r2Prefix), isDirectory: true)
+    }
+
+    /// A stored copy is complete when its `manifest.json` decodes and every
+    /// listed file exists with the manifest's exact size. Per-file SHA-256 was
+    /// verified at download time; the warm re-resolve is size-only by design
+    /// (there is no aggregate-hash enforcement for drafters, plan D3).
+    static func verifiedManifest(at directory: URL) -> ModelManifest? {
+        let manifestURL = directory.appendingPathComponent(manifestFileName, isDirectory: false)
+        guard let data = try? Data(contentsOf: manifestURL),
+              let manifest = try? ModelCatalogClient.manifestDecoder.decode(ModelManifest.self, from: data),
+              !manifest.files.isEmpty
+        else { return nil }
+
+        let fm = FileManager.default
+        for file in manifest.files {
+            guard let relative = try? ModelDownloader.validatedManifestRelativePath(file.path) else {
+                return nil
+            }
+            let onDisk = directory.appendingPathComponent(relative, isDirectory: false)
+            guard let attrs = try? fm.attributesOfItem(atPath: onDisk.path),
+                  let size = attrs[.size] as? Int64, size == file.sizeBytes
+            else { return nil }
+        }
+        return manifest
+    }
+}

--- a/provider-swift/Sources/ProviderCore/SpecDec/SpecDecTypes.swift
+++ b/provider-swift/Sources/ProviderCore/SpecDec/SpecDecTypes.swift
@@ -1,0 +1,163 @@
+import Foundation
+
+/// Stable, content-free reasons for MTP not being active. These values are
+/// written to provider logs and are intentionally safe to aggregate.
+public enum MTPFallbackReason: String, Sendable, Equatable {
+    case configDisabled = "config_disabled"
+    case killSwitchDisabled = "kill_switch_disabled"
+    case targetUnsupported = "target_unsupported"
+    case localArtifactInvalid = "local_artifact_invalid"
+    case catalogDisabled = "catalog_disabled"
+    case catalogUnavailable = "catalog_unavailable"
+    case catalogModelMissing = "catalog_model_missing"
+    case metadataMissing = "metadata_missing"
+    case metadataMalformed = "metadata_malformed"
+    case artifactNotCached = "artifact_not_cached"
+    case manifestFetchFailed = "manifest_fetch_failed"
+    case manifestMalformed = "manifest_malformed"
+    case manifestDigestMismatch = "manifest_digest_mismatch"
+    case manifestBindingMismatch = "manifest_binding_mismatch"
+    case artifactOversize = "artifact_oversize"
+    case fileCountInvalid = "file_count_invalid"
+    case fileTypeDisallowed = "file_type_disallowed"
+    case pathInvalid = "path_invalid"
+    case fileDownloadFailed = "file_download_failed"
+    case fileDigestMismatch = "file_digest_mismatch"
+    case warmArtifactCorrupt = "warm_artifact_corrupt"
+    case publicationFailed = "publication_failed"
+    case assistantLoadFailed = "assistant_load_failed"
+    case assistantTargetIncompatible = "assistant_target_incompatible"
+    case assistantMemoryUnavailable = "assistant_memory_unavailable"
+    case assistantResliceFloor = "assistant_reslice_floor"
+    case assistantPostBuildHeadroom = "assistant_post_build_headroom"
+    case engineInactive = "engine_inactive"
+}
+
+public enum SpecDecArtifactSource: String, Sendable, Equatable {
+    case local
+    case catalog
+}
+
+/// A verified assistant directory and the facts used before model admission.
+struct SpecDecArtifact: Sendable, Equatable {
+    let directory: URL
+    let source: SpecDecArtifactSource
+    let revision: String
+    let artifactBytes: UInt64
+    let residentBytes: UInt64
+    let manifestSHA256: String?
+    /// Immutable inspection-time digests for every local weight file. Catalog
+    /// artifacts use their signed manifest instead.
+    let localWeightSHA256: [String: String]?
+    /// Full local config digest retained separately from the display revision;
+    /// the revision intentionally contains only a short, non-secret prefix.
+    let localConfigSHA256: String?
+    /// Catalog artifacts retain the complete immutable trust reference used to
+    /// verify them. Local operator overrides intentionally have no catalog trust.
+    let catalogReference: SpecDecArtifactReference?
+
+    init(
+        directory: URL,
+        source: SpecDecArtifactSource,
+        revision: String,
+        artifactBytes: UInt64,
+        residentBytes: UInt64,
+        manifestSHA256: String?,
+        localWeightSHA256: [String: String]? = nil,
+        localConfigSHA256: String? = nil,
+        catalogReference: SpecDecArtifactReference? = nil
+    ) {
+        self.directory = directory
+        self.source = source
+        self.revision = revision
+        self.artifactBytes = artifactBytes
+        self.residentBytes = residentBytes
+        self.manifestSHA256 = manifestSHA256
+        self.localWeightSHA256 = localWeightSHA256
+        self.localConfigSHA256 = localConfigSHA256
+        self.catalogReference = catalogReference
+    }
+}
+
+struct SpecDecResolution: Sendable, Equatable {
+    let artifact: SpecDecArtifact?
+    let reason: MTPFallbackReason?
+    let detail: String?
+
+    static func resolved(_ artifact: SpecDecArtifact) -> Self {
+        Self(artifact: artifact, reason: nil, detail: nil)
+    }
+
+    static func fallback(_ reason: MTPFallbackReason, detail: String? = nil) -> Self {
+        Self(artifact: nil, reason: reason, detail: detail)
+    }
+}
+
+/// Slot-visible MTP state. `artifactBytes` describes the resolved artifact;
+/// `assistantBytes` is the resident estimate and is zero on every fallback.
+struct MTPActivationStatus: Sendable, Equatable {
+    let configured: Bool
+    let active: Bool
+    let reason: MTPFallbackReason?
+    let source: SpecDecArtifactSource?
+    let revision: String?
+    let artifactBytes: UInt64
+    let assistantBytes: UInt64
+
+    static func disabled(_ reason: MTPFallbackReason, configured: Bool) -> Self {
+        Self(
+            configured: configured, active: false, reason: reason, source: nil,
+            revision: nil, artifactBytes: 0, assistantBytes: 0)
+    }
+
+    static func candidate(_ artifact: SpecDecArtifact) -> Self {
+        Self(
+            configured: true, active: false, reason: nil, source: artifact.source,
+            revision: artifact.revision, artifactBytes: artifact.artifactBytes,
+            assistantBytes: 0)
+    }
+
+    func activated(assistantBytes: UInt64) -> Self {
+        Self(
+            configured: configured, active: true, reason: nil, source: source,
+            revision: revision, artifactBytes: artifactBytes,
+            assistantBytes: assistantBytes)
+    }
+
+    func fallingBack(_ reason: MTPFallbackReason) -> Self {
+        Self(
+            configured: configured, active: false, reason: reason, source: source,
+            revision: revision, artifactBytes: artifactBytes, assistantBytes: 0)
+    }
+}
+
+struct SpecDecPreparation: Sendable, Equatable {
+    let artifact: SpecDecArtifact?
+    let status: MTPActivationStatus
+
+    func fallingBack(_ reason: MTPFallbackReason) -> Self {
+        Self(artifact: nil, status: status.fallingBack(reason))
+    }
+}
+
+enum SpecDecLimits {
+    static let maximumPrefixBytes = 512
+    static let maximumManifestBytes = 1 * 1024 * 1024
+    /// Current Gemma 4 assistants are a few hundred MiB. Two GiB leaves ample
+    /// publication headroom without allowing optional drafting to trigger an
+    /// 8 GiB verification/read workload on a target-serving process.
+    static let maximumArtifactBytes: UInt64 = 2 * 1024 * 1024 * 1024
+    static let maximumConfigBytes: UInt64 = 1 * 1024 * 1024
+    static let maximumFileCount = 64
+    static let maximumFileNameBytes = 255
+    static let maximumRevisionBytes = 256
+    static let residentMultiplier = 1.20
+    static let allowedRoles: Set<String> = ["config", "weight"]
+
+    static func residentEstimate(artifactBytes: UInt64) -> UInt64 {
+        guard artifactBytes > 0 else { return 0 }
+        let estimate = (Double(artifactBytes) * residentMultiplier).rounded(.up)
+        guard estimate.isFinite, estimate < Double(UInt64.max) else { return .max }
+        return UInt64(estimate)
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Update/UpdateBanner.swift
+++ b/provider-swift/Sources/ProviderCore/Update/UpdateBanner.swift
@@ -16,6 +16,19 @@ public enum UpdateBanner: Sendable {
         currentVersion: String = ProviderCore.version,
         timeout: TimeInterval = 2.0
     ) async {
+        await run(
+            coordinatorURL: coordinatorURL,
+            currentVersion: currentVersion,
+            timeout: timeout,
+            write: { FileHandle.standardError.write($0) })
+    }
+
+    static func run(
+        coordinatorURL: String,
+        currentVersion: String,
+        timeout: TimeInterval,
+        write: @Sendable (Data) -> Void
+    ) async {
         let baseURL = coordinatorHTTPBase(coordinatorURL)
         guard let url = URL(string: "\(baseURL)/api/version") else { return }
 
@@ -40,7 +53,11 @@ public enum UpdateBanner: Sendable {
               isNewerSemver(latest, than: currentVersion)
         else { return }
 
-        printBanner(current: currentVersion, latest: latest, changelog: payload.changelog ?? "")
+        printBanner(
+            current: currentVersion,
+            latest: latest,
+            changelog: payload.changelog ?? "",
+            write: write)
     }
 
     // MARK: - Internals
@@ -73,7 +90,12 @@ public enum UpdateBanner: Sendable {
         return stripped.split(separator: ".").map { Int($0) ?? 0 }
     }
 
-    private static func printBanner(current: String, latest: String, changelog: String) {
+    private static func printBanner(
+        current: String,
+        latest: String,
+        changelog: String,
+        write: @Sendable (Data) -> Void
+    ) {
         let header = "Update available: \(current) → \(latest)"
         var lines: [String] = []
         lines.append("")
@@ -92,7 +114,7 @@ public enum UpdateBanner: Sendable {
 
         let banner = lines.joined(separator: "\n") + "\n"
         if let data = banner.data(using: .utf8) {
-            FileHandle.standardError.write(data)
+            write(data)
         }
     }
 

--- a/provider-swift/Sources/darkbloom/StartCommand+Modes.swift
+++ b/provider-swift/Sources/darkbloom/StartCommand+Modes.swift
@@ -91,7 +91,9 @@ extension Start {
                 engineV2MaxConcurrent: config.backend.engineV2MaxConcurrent,
                 engineV2MaxConcurrentByModel: config.backend.engineV2MaxConcurrentByModel,
                 engineV2KVBackend: config.backend.engineV2KVBackend,
-                engineV2KVBackendByModel: config.backend.engineV2KVBackendByModel
+                engineV2KVBackendByModel: config.backend.engineV2KVBackendByModel,
+                mtp: config.backend.mtp,
+                mtpDrafterPath: config.backend.mtpDrafterPath
             ),
             models: advertised
         )

--- a/provider-swift/Tests/ProviderCoreTests/CoordinatorIntegrationTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/CoordinatorIntegrationTests.swift
@@ -576,13 +576,13 @@ struct CoordinatorIntegrationTests {
         let baseURL = try await mock.start()
         defer { Task { await mock.shutdown() } }
 
-        let captured = await captureStderr {
-            await UpdateBanner.run(
-                coordinatorURL: baseURL.absoluteString,
-                currentVersion: ProviderCore.version,
-                timeout: 2.0
-            )
-        }
+        let output = BannerOutputBox()
+        await UpdateBanner.run(
+            coordinatorURL: baseURL.absoluteString,
+            currentVersion: ProviderCore.version,
+            timeout: 2.0,
+            write: { output.append($0) })
+        let captured = output.text
         #expect(captured.isEmpty, "expected no banner; got: \(captured)")
     }
 
@@ -596,13 +596,13 @@ struct CoordinatorIntegrationTests {
         let baseURL = try await mock.start()
         defer { Task { await mock.shutdown() } }
 
-        let captured = await captureStderr {
-            await UpdateBanner.run(
-                coordinatorURL: baseURL.absoluteString,
-                currentVersion: "0.5.0",
-                timeout: 2.0
-            )
-        }
+        let output = BannerOutputBox()
+        await UpdateBanner.run(
+            coordinatorURL: baseURL.absoluteString,
+            currentVersion: "0.5.0",
+            timeout: 2.0,
+            write: { output.append($0) })
+        let captured = output.text
         #expect(captured.contains("Update available"), "stderr: \(captured)")
         #expect(captured.contains("99.0.0"))
         #expect(captured.contains("darkbloom update"))
@@ -722,29 +722,15 @@ private final class LoopStateBox: @unchecked Sendable {
     }
 }
 
-// MARK: Stderr capture
+private final class BannerOutputBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var data = Data()
 
-/// Run the given async closure with stderr (FD 2) redirected into a Pipe and
-/// return the bytes written to it as a UTF-8 string.
-///
-/// This is best-effort: only output that goes through `FileHandle.standardError`
-/// or the C-level `stderr` is captured. swift-log's stderr handler routes
-/// through STDERR_FILENO so the existing UpdateBanner banner (which calls
-/// `FileHandle.standardError.write`) is captured.
-private func captureStderr(_ body: () async -> Void) async -> String {
-    let pipe = Pipe()
-    let originalFD = dup(fileno(stderr))
-    setvbuf(stderr, nil, _IONBF, 0)
-    let pipeFD = pipe.fileHandleForWriting.fileDescriptor
-    dup2(pipeFD, fileno(stderr))
+    func append(_ value: Data) {
+        lock.withLock { data.append(value) }
+    }
 
-    await body()
-
-    fflush(stderr)
-    dup2(originalFD, fileno(stderr))
-    close(originalFD)
-    try? pipe.fileHandleForWriting.close()
-
-    let data = (try? pipe.fileHandleForReading.readToEnd()) ?? Data()
-    return String(data: data, encoding: .utf8) ?? ""
+    var text: String {
+        lock.withLock { String(data: data, encoding: .utf8) ?? "" }
+    }
 }

--- a/provider-swift/Tests/ProviderCoreTests/EngineV2BridgeTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/EngineV2BridgeTests.swift
@@ -1276,6 +1276,8 @@ struct EngineV2FailLoudFactoryTests {
         #expect(EngineV2SupportedModels.isSupported(modelType: "gemma4"))        // VLM wrapper
         #expect(EngineV2SupportedModels.isSupported(modelType: "gemma4_text"))   // text config
         #expect(EngineV2SupportedModels.isSupported(modelType: "GEMMA4_TEXT"))   // case-insensitive
+        #expect(!EngineV2SupportedModels.isSupported(modelType: "gemma4_assistant_v2"))
+        #expect(!EngineV2SupportedModels.isSupported(modelType: "gemma4_text_assistant"))
         // Everything else fails closed — including nil/empty and the
         // near-miss families that must never match by accident.
         #expect(!EngineV2SupportedModels.isSupported(modelType: nil))

--- a/provider-swift/Tests/ProviderCoreTests/EngineV2LivenessRecoveryTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/EngineV2LivenessRecoveryTests.swift
@@ -245,15 +245,17 @@ private func loadSlot(
 /// Drive a wedge: one hanging admit (engine accepts, never yields) plus a
 /// step-counter baseline sample at `t0`. The engine's steps never advance,
 /// so any later verdict ≥ the stall window sees the full flatline.
+@discardableResult
 private func injectWedge(
     bridge: EngineV2Bridge, modelId: String, at t0: ContinuousClock.Instant
-) async {
-    _ = await bridge.submitTokenized(
+) async -> AsyncStream<GenerationEvent> {
+    let stream = await bridge.submitTokenized(
         promptTokens: [1, 2, 3],
         request: makeChatRequest(model: modelId),
         requestId: "req-wedge-\(modelId)")
     // Baseline step sample (the heartbeat normally does this).
     _ = await bridge.backendSlotCapacity(now: t0)
+    return stream
 }
 
 // MARK: - Bridge-level verdict + heartbeat state
@@ -569,7 +571,8 @@ struct EngineV2LivenessRecoveryTests {
         let engine = factory.built[0].engine
 
         let t0 = ContinuousClock.Instant.now
-        await injectWedge(bridge: bridge, modelId: Self.modelA, at: t0)
+        let firstWedgeStream = await injectWedge(
+            bridge: bridge, modelId: Self.modelA, at: t0)
         // A recovery attempt happened 60s ago (inside the 120s cooldown).
         let tWedge = t0.advanced(by: .seconds(130))
         await loop.setEngineV2LastRecoveryAtForTesting(
@@ -591,6 +594,7 @@ struct EngineV2LivenessRecoveryTests {
         // No restart/complete events fired.
         #expect(!telemetry.operations().contains("engine_v2_self_restart"))
         #expect(!telemetry.operations().contains("engine_v2_self_restart_complete"))
+        withExtendedLifetime(firstWedgeStream) {}
     }
 
     @Test("outside the cooldown a re-wedge recovers again (cooldown anchored on the attempt)")
@@ -603,7 +607,8 @@ struct EngineV2LivenessRecoveryTests {
 
         // First recovery.
         let t0 = ContinuousClock.Instant.now
-        await injectWedge(bridge: bridge, modelId: Self.modelA, at: t0)
+        let firstWedgeStream = await injectWedge(
+            bridge: bridge, modelId: Self.modelA, at: t0)
         let firstAttempt = t0.advanced(by: .seconds(130))
         await loop.recoverWedgedEngineV2SlotsForTesting(now: firstAttempt)
         #expect(factory.built.count == 2)
@@ -611,13 +616,16 @@ struct EngineV2LivenessRecoveryTests {
 
         // The rebuilt engine wedges again, but the second confirmation
         // lands AFTER the cooldown expired — recover again, don't unload.
-        await injectWedge(bridge: secondBridge, modelId: Self.modelA, at: firstAttempt)
+        let secondWedgeStream = await injectWedge(
+            bridge: secondBridge, modelId: Self.modelA, at: firstAttempt)
         let secondAttempt = firstAttempt.advanced(by: .seconds(130))
         await loop.recoverWedgedEngineV2SlotsForTesting(now: secondAttempt)
         #expect(factory.built.count == 3)
         #expect(await loop.slotBridgeForTesting(modelId: Self.modelA) != nil)
         #expect(await runtime.bridge(forModel: Self.modelA) != nil)
         #expect(await loop.engineV2LastRecoveryAtForTesting(modelId: Self.modelA) == secondAttempt)
+        withExtendedLifetime(firstWedgeStream) {}
+        withExtendedLifetime(secondWedgeStream) {}
     }
 
     @Test("rebuild failure: refusal + slot unload — never a half-alive slot")

--- a/provider-swift/Tests/ProviderCoreTests/EngineV2LivenessRecoveryTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/EngineV2LivenessRecoveryTests.swift
@@ -223,10 +223,11 @@ private func makeSizing(
         defaultMaxTokens: 4096)
 }
 
-private func makeChatRequest(model: String) -> ChatCompletionRequest {
+private func makeChatRequest(model: String, maxTokens: Int? = nil) -> ChatCompletionRequest {
     ChatCompletionRequest(
         model: model,
-        messages: [ChatMessage(role: "user", content: "hi")])
+        messages: [ChatMessage(role: "user", content: "hi")],
+        max_tokens: maxTokens)
 }
 
 /// Install a v2 slot through the REAL load path (re-slice + factory +
@@ -251,7 +252,9 @@ private func injectWedge(
 ) async -> AsyncStream<GenerationEvent> {
     let stream = await bridge.submitTokenized(
         promptTokens: [1, 2, 3],
-        request: makeChatRequest(model: modelId),
+        // Liveness tests exercise the engine state machine, not the
+        // process-wide KV budget shared by parallel test suites.
+        request: makeChatRequest(model: modelId, maxTokens: 0),
         requestId: "req-wedge-\(modelId)")
     // Baseline step sample (the heartbeat normally does this).
     _ = await bridge.backendSlotCapacity(now: t0)

--- a/provider-swift/Tests/ProviderCoreTests/GemmaMTPPerformanceLiveTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/GemmaMTPPerformanceLiveTests.swift
@@ -14,6 +14,7 @@ struct GemmaMTPPerformanceLiveTests {
         let output = try MTPProductionLiveFixtures.benchmarkOutput()
         let bundle = try await MTPProductionLiveFixtures.loadBundle()
         let purpose = MTPProductionLiveFixtures.benchmarkPurpose
+        let mtpExpectation = MTPProductionLiveFixtures.benchmarkMTPExpectation
         let report = try await MTPBenchmarkRunner.run(
             target: bundle.targetFacts,
             assistant: bundle.assistantFacts,
@@ -24,6 +25,7 @@ struct GemmaMTPPerformanceLiveTests {
                 modes: MTPBenchmarkRunner.standardModes,
                 maxTokensPerRow: MTPProductionLiveFixtures.benchmarkMaxTokens,
                 purpose: purpose,
+                mtpExpectation: mtpExpectation,
                 stopPolicy: MTPProductionLiveFixtures.benchmarkStopPolicy(bundle: bundle),
                 warmupIterations: MTPProductionLiveFixtures.benchmarkWarmupIterations,
                 measurementRepetitions: MTPProductionLiveFixtures.benchmarkRepetitions,
@@ -36,8 +38,20 @@ struct GemmaMTPPerformanceLiveTests {
         #expect(report.cases.count == 40)
         #expect(report.complete)
         #expect(report.purpose == purpose)
+        #expect(report.mtpExpectation == mtpExpectation)
         #expect(report.cases.allSatisfy { $0.tokenParity })
-        #expect(report.cases.filter { $0.mode.requestsMTP }.allSatisfy { $0.metrics.active })
+        let requestedCases = report.cases.filter { $0.mode.requestsMTP }
+        if mtpExpectation.expectsInactive {
+            #expect(requestedCases.allSatisfy {
+                !$0.metrics.active
+                    && mtpExpectation.matchesInactiveReason($0.metrics.inactiveReason)
+                    && $0.metrics.rounds == 0
+                    && $0.metrics.proposedTokens == 0
+                    && $0.metrics.acceptedDraftTokens == 0
+            })
+        } else {
+            #expect(requestedCases.allSatisfy { $0.metrics.active })
+        }
         if purpose == .rawParityStress {
             #expect(report.cases.allSatisfy {
                 $0.medianAggregateDecodeTokensPerSecond == nil

--- a/provider-swift/Tests/ProviderCoreTests/GemmaMTPPerformanceLiveTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/GemmaMTPPerformanceLiveTests.swift
@@ -1,0 +1,50 @@
+import MLX
+import Testing
+
+@testable import ProviderBenchmark
+
+@Suite("Gemma 4 production MTP validation matrix", .serialized)
+struct GemmaMTPPerformanceLiveTests {
+    @Test(
+        "B=1/2/4/8 raw parity or production performance matrix",
+        .enabled(
+            if: MTPProductionLiveFixtures.enabled,
+            MTPProductionLiveFixtures.disabledReason))
+    func fullMatrix() async throws {
+        let output = try MTPProductionLiveFixtures.benchmarkOutput()
+        let bundle = try await MTPProductionLiveFixtures.loadBundle()
+        let purpose = MTPProductionLiveFixtures.benchmarkPurpose
+        let report = try await MTPBenchmarkRunner.run(
+            target: bundle.targetFacts,
+            assistant: bundle.assistantFacts,
+            hardware: try MTPBenchmarkModelFacts.hardware(),
+            configuration: MTPBenchmarkConfiguration(
+                prompts: try MTPProductionLiveFixtures.prompts(bundle: bundle),
+                batchSizes: [1, 2, 4, 8],
+                modes: MTPBenchmarkRunner.standardModes,
+                maxTokensPerRow: MTPProductionLiveFixtures.benchmarkMaxTokens,
+                purpose: purpose,
+                stopPolicy: MTPProductionLiveFixtures.benchmarkStopPolicy(bundle: bundle),
+                warmupIterations: MTPProductionLiveFixtures.benchmarkWarmupIterations,
+                measurementRepetitions: MTPProductionLiveFixtures.benchmarkRepetitions,
+                modeOrderSeed: MTPProductionLiveFixtures.benchmarkModeOrderSeed,
+                runFingerprint: try MTPProductionLiveFixtures.benchmarkRunFingerprint(),
+                checkpointDestination: output,
+                deadline: MTPProductionLiveFixtures.benchmarkDeadline),
+            sessions: bundle.makeSessionFactory())
+
+        #expect(report.cases.count == 40)
+        #expect(report.complete)
+        #expect(report.purpose == purpose)
+        #expect(report.cases.allSatisfy { $0.tokenParity })
+        #expect(report.cases.filter { $0.mode.requestsMTP }.allSatisfy { $0.metrics.active })
+        if purpose == .rawParityStress {
+            #expect(report.cases.allSatisfy {
+                $0.medianAggregateDecodeTokensPerSecond == nil
+                    && $0.rows.allSatisfy { $0.decodeTokensPerSecond == nil }
+            })
+        }
+        print("[mtp-benchmark] wrote \(output.url.path)")
+        MLX.Memory.clearCache()
+    }
+}

--- a/provider-swift/Tests/ProviderCoreTests/GemmaMTPProductionLiveTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/GemmaMTPProductionLiveTests.swift
@@ -85,9 +85,12 @@ struct GemmaMTPProductionLiveTests {
                 $0.lastPathComponent == "config.json" || $0.pathExtension == "safetensors"
             }
         for source in assistantFiles {
-            try FileManager.default.createSymbolicLink(
-                at: localArtifactDirectory.appendingPathComponent(source.lastPathComponent),
-                withDestinationURL: source.resolvingSymlinksInPath())
+            // Copy, never symlink: SpecDecStore.inspectLocalArtifact rejects
+            // any symlinked member, which would fail the #require below
+            // before the loader-failure fallback under test ever runs.
+            try FileManager.default.copyItem(
+                at: source.resolvingSymlinksInPath(),
+                to: localArtifactDirectory.appendingPathComponent(source.lastPathComponent))
         }
         let artifact = try #require(
             SpecDecStore.inspectLocalArtifact(path: localArtifactDirectory.path))

--- a/provider-swift/Tests/ProviderCoreTests/GemmaMTPProductionLiveTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/GemmaMTPProductionLiveTests.swift
@@ -1,0 +1,288 @@
+import Foundation
+import MLX
+import MLXLLM
+import MLXLMCommon
+import MLXLMServer
+import Testing
+
+@testable import ProviderBenchmark
+@testable import ProviderCore
+
+@Suite("Gemma 4 production MTP cached-model correctness", .serialized)
+struct GemmaMTPProductionLiveTests {
+    private static let redPNGDataURI =
+        "data:image/png;base64,"
+        + "iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAFklEQVR42mO4IyJCEmIY"
+        + "1TCqYfhqAAACcQQQFd0BdQAAAABJRU5ErkJggg=="
+
+    @Test(
+        "cached target and assistant load and bind",
+        .enabled(
+            if: MTPProductionLiveFixtures.enabled,
+            MTPProductionLiveFixtures.disabledReason))
+    func targetAndAssistantLoadAndBind() async throws {
+        let bundle = try await MTPProductionLiveFixtures.loadBundle()
+        #expect(bundle.targetFacts.modelType == "gemma4")
+        #expect(bundle.assistantFacts.modelType == "gemma4_assistant")
+        #expect(bundle.targetFacts.weightFileCount > 0)
+        #expect(bundle.assistantFacts.weightFileCount > 0)
+        MLX.Memory.clearCache()
+    }
+
+    @Test(
+        "target-only and production MTP greedy token IDs are identical",
+        .enabled(
+            if: MTPProductionLiveFixtures.enabled,
+            MTPProductionLiveFixtures.disabledReason))
+    func targetOnlyAndMTPGreedyParity() async throws {
+        let bundle = try await MTPProductionLiveFixtures.loadBundle()
+        let fixed = try MTPBenchmarkMode.fixed(verificationWidth: 3)
+        let report = try await MTPBenchmarkRunner.run(
+            target: bundle.targetFacts,
+            assistant: bundle.assistantFacts,
+            hardware: try MTPBenchmarkModelFacts.hardware(),
+            configuration: MTPBenchmarkConfiguration(
+                prompts: try MTPProductionLiveFixtures.prompts(bundle: bundle),
+                batchSizes: [1, 2],
+                modes: [.targetOnly, fixed, .adaptive],
+                maxTokensPerRow: 24,
+                purpose: .productionCorrectness,
+                stopPolicy: .production(tokenIDs: bundle.productionStopTokenIDs),
+                deadline: .seconds(900)),
+            sessions: bundle.makeSessionFactory())
+        #expect(report.cases.filter { $0.mode.requestsMTP }.allSatisfy { $0.tokenParity })
+        #expect(report.cases.filter { $0.mode.requestsMTP }.allSatisfy { $0.metrics.active })
+        MLX.Memory.clearCache()
+    }
+
+    @Test(
+        "assistant load failure leaves the production target bridge usable",
+        .enabled(
+            if: MTPProductionLiveFixtures.enabled,
+            MTPProductionLiveFixtures.disabledReason))
+    func assistantFailureFallsBackToTargetOnly() async throws {
+        guard LiveInferenceFixtures.ensureMetallibColocated() != nil else {
+            throw MTPProductionLivePrerequisiteError.missingMetallib
+        }
+        LiveInferenceFixtures.applyMemoryBudget(maxBytes: 64 * 1024 * 1024 * 1024)
+        let targetDirectory = try MTPProductionLiveFixtures.targetSnapshot()
+        let assistantDirectory = try MTPProductionLiveFixtures.assistantSnapshot()
+        let container = try await ModelContainerLoading.loadContainer(from: targetDirectory)
+        let sizing = await SlotSizingSnapshot.build(
+            container: container,
+            modelPath: targetDirectory,
+            fallbackDefaultMaxTokens: 32)
+        let tokenizer = await container.perform { TokenizerHandle($0.tokenizer) }
+        let localArtifactDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mtp-live-loader-failure-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(
+            at: localArtifactDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: localArtifactDirectory) }
+        let assistantFiles = try FileManager.default.contentsOfDirectory(
+            at: assistantDirectory,
+            includingPropertiesForKeys: nil)
+            .filter {
+                $0.lastPathComponent == "config.json" || $0.pathExtension == "safetensors"
+            }
+        for source in assistantFiles {
+            try FileManager.default.createSymbolicLink(
+                at: localArtifactDirectory.appendingPathComponent(source.lastPathComponent),
+                withDestinationURL: source.resolvingSymlinksInPath())
+        }
+        let artifact = try #require(
+            SpecDecStore.inspectLocalArtifact(path: localArtifactDirectory.path))
+        let preparation = SpecDecPreparation(
+            artifact: artifact,
+            status: .candidate(artifact))
+        let prepared = try await EngineV2SlotFactory.prepareProductionModel(
+            modelId: MTPProductionLiveFixtures.targetID,
+            isVLM: true,
+            modelDirectory: targetDirectory,
+            container: container,
+            specDecPreparation: preparation,
+            assistantLoader: AlwaysFailMTPAssistantLoader())
+        #expect(prepared.assistant == nil)
+        #expect(prepared.mtpStatus.reason == .assistantLoadFailed)
+
+        let grant = Int(min(
+            UnifiedMemoryCap.kvBudgetBytes(
+                physicalBytes: ProcessInfo.processInfo.physicalMemory,
+                residentWeightBytes: UInt64(max(0, sizing.weightsBytes)),
+                configReserveBytes: 0),
+            UInt64(Int.max)))
+        let bundle = try await EngineV2SlotFactory.makeProductionBundle(
+            modelId: MTPProductionLiveFixtures.targetID,
+            modelType: "gemma4",
+            isVLM: true,
+            modelDirectory: targetDirectory,
+            container: container,
+            tokenizer: tokenizer,
+            sizing: sizing,
+            kvBytesCapacity: grant,
+            maxConcurrentRequests: 1,
+            kvBudget: nil,
+            kvQuantConfigured: false,
+            specDecPreparation: preparation,
+            preparedModel: prepared,
+            environment: ["DARKBLOOM_PREFIX_CACHE": "0"])
+        let status = await bundle.bridge.mtpStatusSnapshot()
+        #expect(status.configured)
+        #expect(!status.active)
+        #expect(status.fallbackReason == .assistantLoadFailed)
+
+        let prompt = "What is 9 plus 4? Reply with only the number."
+        let tokens: [Int] = try await container.perform { context in
+            try context.tokenizer.applyChatTemplate(
+                messages: [["role": "user", "content": prompt]],
+                tools: nil,
+                additionalContext: nil)
+        }
+        let result = await collect(
+            from: bundle.bridge,
+            promptTokens: tokens,
+            request: ChatCompletionRequest(
+                model: MTPProductionLiveFixtures.targetID,
+                messages: [ChatMessage(role: "user", content: prompt)],
+                temperature: 0,
+                max_tokens: 32))
+        await bundle.bridge.shutdown()
+        MLX.Memory.clearCache()
+        #expect(!result.didError, "target-only fallback failed: \(result.error ?? "")")
+        #expect(result.info != nil)
+        #expect(result.fullText.contains("13"))
+    }
+
+    @Test(
+        "VLM extraction and tool-templated decode retain greedy parity",
+        .enabled(
+            if: MTPProductionLiveFixtures.enabled,
+            MTPProductionLiveFixtures.disabledReason))
+    func vlmToolPathParity() async throws {
+        let bundle = try await MTPProductionLiveFixtures.loadBundle()
+        let fixed = try MTPBenchmarkMode.fixed(verificationWidth: 3)
+        let report = try await MTPBenchmarkRunner.run(
+            target: bundle.targetFacts,
+            assistant: bundle.assistantFacts,
+            hardware: try MTPBenchmarkModelFacts.hardware(),
+            configuration: MTPBenchmarkConfiguration(
+                prompts: [try MTPProductionLiveFixtures.toolPrompt(bundle: bundle)],
+                batchSizes: [1],
+                modes: [.targetOnly, fixed],
+                maxTokensPerRow: 64,
+                purpose: .productionCorrectness,
+                stopPolicy: .production(tokenIDs: bundle.productionStopTokenIDs),
+                deadline: .seconds(600)),
+            sessions: bundle.makeSessionFactory())
+        let candidate = try #require(report.cases.last)
+        #expect(candidate.tokenParity)
+        #expect(candidate.metrics.active)
+        #expect(candidate.metrics.proposedTokens > 0)
+        #expect(candidate.metrics.rounds > 0)
+        #expect(candidate.rows.allSatisfy { $0.tokenCount > 0 })
+        #expect(report.stopPolicy.configuredTokenCount == bundle.productionStopTokenIDs.count)
+        MLX.Memory.clearCache()
+    }
+
+    @Test(
+        "VLM image-prefill decode retains greedy token parity",
+        .enabled(
+            if: MTPProductionLiveFixtures.enabled,
+            MTPProductionLiveFixtures.disabledReason))
+    func vlmImagePathParity() async throws {
+        let bundle = try await MTPProductionLiveFixtures.loadBundle()
+        let request = OpenAIChatCompletionRequest(
+            model: MTPProductionLiveFixtures.targetID,
+            messages: [OpenAIChatMessage(
+                role: .user,
+                content: .parts([
+                    .text("What color is this image? Reply with one word."),
+                    .imageURL(Self.redPNGDataURI),
+                ]))],
+            temperature: 0,
+            maxTokens: 16)
+        let prepared = try await EngineV2VisionPrefill.prepare(
+            container: bundle.targetContainer,
+            request: request)
+        let factory = bundle.makeSessionFactory()
+
+        let targetSession = try await factory.make(.targetOnly, 1)
+        let baseline = try await rawTokens(
+            engine: targetSession.engine,
+            promptTokens: prepared.promptTokens,
+            maxTokens: 16,
+            stopTokens: bundle.productionStopTokenIDs,
+            multimodal: prepared.multimodalInput())
+        await targetSession.engine.shutdown()
+
+        let fixed = try MTPBenchmarkMode.fixed(verificationWidth: 3)
+        let mtpSession = try await factory.make(fixed, 1)
+        let candidate = try await rawTokens(
+            engine: mtpSession.engine,
+            promptTokens: prepared.promptTokens,
+            maxTokens: 16,
+            stopTokens: bundle.productionStopTokenIDs,
+            multimodal: prepared.multimodalInput())
+        let metrics = await mtpSession.metrics()
+        await mtpSession.engine.shutdown()
+
+        #expect(metrics.active)
+        if candidate != baseline {
+            Issue.record("MTP image parity failed for row 0")
+        }
+        MLX.Memory.clearCache()
+    }
+
+    private func rawTokens(
+        engine: any CBv2Engine,
+        promptTokens: [Int],
+        maxTokens: Int,
+        stopTokens: Set<Int>,
+        multimodal: CBv2MultimodalInput
+    ) async throws -> [Int] {
+        let stream = try engine.submit(CBv2Request(
+            id: CBv2RequestID(1),
+            promptTokens: promptTokens,
+            sampling: CBv2SamplingParams(temperature: 0),
+            maxTokens: maxTokens,
+            stopTokens: stopTokens,
+            multimodal: multimodal))
+        var tokens: [Int] = []
+        var finishReason: CBv2FinishReason?
+        for await event in stream {
+            switch event {
+            case .delta(_, let emitted, _): tokens.append(contentsOf: emitted)
+            case .finished(let reason, _): finishReason = reason
+            }
+        }
+        guard let finishReason else {
+            throw MTPBenchmarkError.missingTerminalEvent(row: 0)
+        }
+        switch finishReason {
+        case .stop:
+            guard let finalToken = tokens.last, stopTokens.contains(finalToken) else {
+                throw MTPBenchmarkError.unexpectedTerminal(
+                    row: 0,
+                    condition: "production stop membership")
+            }
+        case .length:
+            break
+        case .cancelled:
+            throw MTPBenchmarkError.unsuccessfulTerminal(
+                row: 0, reason: "cancelled")
+        case .error:
+            throw MTPBenchmarkError.unsuccessfulTerminal(
+                row: 0, reason: "engine_error")
+        }
+        guard !tokens.isEmpty else { throw MTPBenchmarkError.emptyTokenStream(row: 0) }
+        return tokens
+    }
+}
+
+private struct AlwaysFailMTPAssistantLoader: ProviderMTPAssistantLoading {
+    func loadAndBind(
+        artifact _: SpecDecArtifact,
+        target _: any MLXLMCommon.LanguageModel
+    ) async throws -> ProviderMTPAssistantHandle {
+        throw ProviderMTPAssistantLoadError.loadFailed("injected live fallback probe")
+    }
+}

--- a/provider-swift/Tests/ProviderCoreTests/GemmaMTPSafePerformanceLiveTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/GemmaMTPSafePerformanceLiveTests.swift
@@ -1,0 +1,43 @@
+import Foundation
+import Testing
+
+@testable import ProviderBenchmark
+@testable import ProviderCore
+
+@Suite("Gemma 4 MTP safe verifier performance", .serialized)
+struct GemmaMTPSafePerformanceLiveTests {
+    @Test(
+        "safe automatic verifier performance",
+        .enabled(
+            if: MTPProductionLiveFixtures.enabled
+                && ProcessInfo.processInfo.environment["DARKBLOOM_MTP_SAFE_PERF_DIAGNOSTIC"] == "1",
+            Comment(rawValue: "requires the supervised MTP safe performance environment")))
+    func safeAutomaticPerformance() async throws {
+        let bundle = try await MTPProductionLiveFixtures.loadBundle()
+        let report = try await MTPBenchmarkRunner.run(
+            target: bundle.targetFacts,
+            assistant: bundle.assistantFacts,
+            hardware: try MTPBenchmarkModelFacts.hardware(),
+            configuration: MTPBenchmarkConfiguration(
+                prompts: try MTPProductionLiveFixtures.prompts(bundle: bundle),
+                batchSizes: [1, 2, 4, 8],
+                modes: [.targetOnly, try .fixed(verificationWidth: 2)],
+                maxTokensPerRow: 32,
+                purpose: .productionPerformance,
+                stopPolicy: .production(tokenIDs: bundle.productionStopTokenIDs),
+                warmupIterations: 1,
+                measurementRepetitions: 3,
+                adaptiveDraftingBatchSizes: []),
+            sessions: bundle.makeSessionFactory())
+        for item in report.cases.sorted(by: {
+            ($0.batchSize, $0.mode.label) < ($1.batchSize, $1.mode.label)
+        }) {
+            let tps = item.medianAggregateDecodeTokensPerSecond ?? 0
+            let rectangularRounds = item.metrics.rectangularVerificationRounds ?? 0
+            let serialRounds = item.metrics.serialVerificationRounds ?? 0
+            print(
+                "MTP_SAFE_PERF batch=\(item.batchSize) mode=\(item.mode.label) "
+                    + "tps=\(tps) rect=\(rectangularRounds) serial=\(serialRounds)")
+        }
+    }
+}

--- a/provider-swift/Tests/ProviderCoreTests/LaunchAgentRestartTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/LaunchAgentRestartTests.swift
@@ -81,6 +81,15 @@ struct LaunchAgentEnvironmentTests {
             from: ["DARKBLOOM_CBV2_MTP": "0", "PATH": "/usr/bin"])
         #expect(out == ["DARKBLOOM_CBV2_MTP": "0"])
     }
+
+    @Test func forwardsMTPRectangularCapOverrideToDaemon() {
+        // The tighten-only cap override is the operator's lever to reduce
+        // rectangular verification short of disabling MTP; it must survive
+        // service install/restart.
+        let out = LaunchAgent.passthroughEnvironment(
+            from: ["DARKBLOOM_MTP_MAX_RECTANGULAR_TOKENS": "4", "PATH": "/usr/bin"])
+        #expect(out == ["DARKBLOOM_MTP_MAX_RECTANGULAR_TOKENS": "4"])
+    }
 }
 
 @Suite("LaunchAgent service plist")

--- a/provider-swift/Tests/ProviderCoreTests/LaunchAgentRestartTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/LaunchAgentRestartTests.swift
@@ -75,6 +75,12 @@ struct LaunchAgentEnvironmentTests {
             from: ["DARKBLOOM_MLX_RESOURCE_DEBUG": "0", "PATH": "/usr/bin"])
         #expect(out == ["DARKBLOOM_MLX_RESOURCE_DEBUG": "0"])
     }
+
+    @Test func forwardsMTPKillSwitchToDaemon() {
+        let out = LaunchAgent.passthroughEnvironment(
+            from: ["DARKBLOOM_CBV2_MTP": "0", "PATH": "/usr/bin"])
+        #expect(out == ["DARKBLOOM_CBV2_MTP": "0"])
+    }
 }
 
 @Suite("LaunchAgent service plist")

--- a/provider-swift/Tests/ProviderCoreTests/MTPBenchmarkTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/MTPBenchmarkTests.swift
@@ -167,6 +167,7 @@ struct MTPBenchmarkTests {
         let decoded = try JSONDecoder.withISO8601.decode(MTPBenchmarkReport.self, from: data)
         #expect(decoded.schemaVersion == MTPBenchmarkReport.currentSchemaVersion)
         #expect(decoded.buildConfiguration == .current)
+        #expect(decoded.mtpExpectation == .active)
         #expect(decoded.cases.first?.tokenParity == true)
         #expect(decoded.cases.first?.metrics.selectedDepth == 2)
         #expect(decoded.cases.first?.metrics.totalRoundWallTimeNanos == 1_000)
@@ -177,6 +178,117 @@ struct MTPBenchmarkTests {
         #expect(decoded.stopPolicy.configuredTokenCount == 2)
         let object = try JSONSerialization.jsonObject(with: data)
         #expect(findKeys(in: object, matching: ["tokenIDs"]).isEmpty)
+    }
+
+    @Test("expected-inactive metrics require the declared reason and zero work")
+    func expectedInactiveMetricsValidation() throws {
+        let mode = try MTPBenchmarkMode.fixed(verificationWidth: 3)
+        let reason = "rectangular MTP verification is disabled on Apple M5 Max: target-only and [B, 1+k] target argmax parity is not certified"
+        let exactExpectation = MTPBenchmarkMTPExpectation.expectedInactive(
+            allowedReasonValues: [reason])
+
+        #expect(throws: MTPBenchmarkError.self) {
+            try MTPBenchmarkRunner.validateMetrics(
+                MTPBenchmarkMetrics(active: false, inactiveReason: reason),
+                mode: mode,
+                batchSize: 2,
+                adaptiveDraftingExpected: true,
+                allowedSkipReasons: [])
+        }
+        for invalid in [
+            MTPBenchmarkMetrics(active: false),
+            MTPBenchmarkMetrics(active: false, inactiveReason: "configuration disabled"),
+            MTPBenchmarkMetrics(active: false, inactiveReason: reason, rounds: 1),
+        ] {
+            #expect(throws: MTPBenchmarkError.self) {
+                try MTPBenchmarkRunner.validateMetrics(
+                    invalid,
+                    mode: mode,
+                    batchSize: 2,
+                    adaptiveDraftingExpected: true,
+                    allowedSkipReasons: [],
+                    expectation: exactExpectation)
+            }
+        }
+        #expect(throws: MTPBenchmarkError.self) {
+            try MTPBenchmarkRunner.validateMetrics(
+                MTPBenchmarkMetrics(active: true),
+                mode: mode,
+                batchSize: 2,
+                adaptiveDraftingExpected: true,
+                allowedSkipReasons: [],
+                expectation: exactExpectation)
+        }
+
+        try MTPBenchmarkRunner.validateMetrics(
+            MTPBenchmarkMetrics(active: false, inactiveReason: reason),
+            mode: mode,
+            batchSize: 2,
+            adaptiveDraftingExpected: true,
+            allowedSkipReasons: [],
+            expectation: exactExpectation)
+        #expect(MTPBenchmarkMTPExpectation.m5HardwareSafetyGate
+            .matchesInactiveReason(reason))
+    }
+
+    @Test("expected-inactive raw report preserves reason without raw tokens or timing")
+    func expectedInactiveReportSerialization() throws {
+        let artifact = testArtifact()
+        let reason = "rectangular MTP verification is disabled on Apple M5 Max: target-only and [B, 1+k] target argmax parity is not certified"
+        let expectation = MTPBenchmarkMTPExpectation.m5HardwareSafetyGate
+        let report = MTPBenchmarkReport(
+            runFingerprint: "inactive-unit-test",
+            purpose: .rawParityStress,
+            mtpExpectation: expectation,
+            stopPolicy: .rawFixedLength,
+            startedAt: Date(),
+            completedAt: Date(),
+            complete: true,
+            expectedCaseCount: 1,
+            target: artifact,
+            assistant: artifact,
+            hardware: testHardware(),
+            maxTokensPerRow: 1,
+            warmupIterations: 0,
+            measurementRepetitions: 1,
+            modeOrderSeed: 1,
+            coverage: .shortContextMatrix(target: artifact, assistant: artifact),
+            elapsedMs: 10,
+            cases: [.init(
+                mode: .adaptive,
+                batchSize: 1,
+                measurementRepetitions: 1,
+                medianAggregateDecodeTokensPerSecond: 10,
+                tokenParity: true,
+                parityMismatchRows: [],
+                rows: [.init(
+                    promptName: "p",
+                    tokenCount: 1,
+                    opaqueTokenDigest: String(repeating: "e", count: 64),
+                    timeToFirstTokenMs: 1,
+                    interTokenLatencyMs: 2,
+                    decodeTokensPerSecond: 3,
+                    lastTokenLatencyMs: 4,
+                    finishReason: "length")],
+                metrics: .init(active: false, inactiveReason: reason))])
+
+        let data = try report.jsonData()
+        let decoded = try JSONDecoder.withISO8601.decode(MTPBenchmarkReport.self, from: data)
+        #expect(decoded.mtpExpectation == expectation)
+        #expect(decoded.cases.first?.metrics.inactiveReason == reason)
+        #expect(decoded.runFingerprint.contains(":expected_inactive:"))
+        let object = try JSONSerialization.jsonObject(with: data)
+        #expect(findKeys(in: object, matching: ["inactiveReason"]) == ["inactiveReason"])
+        #expect(findKeys(in: object, matching: ["tokenIDs"]).isEmpty)
+        #expect(findKeys(in: object, matching: [
+            "elapsedMs",
+            "medianAggregateDecodeTokensPerSecond",
+            "timeToFirstTokenMs",
+            "interTokenLatencyMs",
+            "decodeTokensPerSecond",
+            "lastTokenLatencyMs",
+            "totalRoundWallTimeNanos",
+        ]).isEmpty)
     }
 
     @Test("stream and aggregate timing use token timestamps and N-1 intervals")
@@ -400,6 +512,30 @@ struct MTPBenchmarkTests {
         #expect(report.cases.first?.rows.first?.decodeTokensPerSecond == 0)
         #expect(report.elapsedMs != nil)
         #endif
+    }
+
+    @Test("production performance rejects expected-inactive certification")
+    func productionPerformanceRejectsExpectedInactive() async {
+        let artifact = testArtifact()
+        let sessions = MTPBenchmarkSessionFactory { _, _ in
+            MTPBenchmarkSession(engine: SuccessfulLengthEngine()) { .inactive }
+        }
+        await #expect(throws: MTPBenchmarkError.self) {
+            _ = try await MTPBenchmarkRunner.run(
+                target: artifact,
+                assistant: artifact,
+                hardware: testHardware(),
+                configuration: MTPBenchmarkConfiguration(
+                    prompts: [.init(name: "prompt", tokenIDs: [1])],
+                    batchSizes: [1],
+                    modes: [.targetOnly],
+                    maxTokensPerRow: 1,
+                    purpose: .productionPerformance,
+                    mtpExpectation: .m5HardwareSafetyGate,
+                    stopPolicy: .production(tokenIDs: [9]),
+                    deadline: .seconds(2)),
+                sessions: sessions)
+        }
     }
 
     @Test("all non-performance reports recursively omit performance keys")

--- a/provider-swift/Tests/ProviderCoreTests/MTPBenchmarkTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/MTPBenchmarkTests.swift
@@ -1,0 +1,923 @@
+import Foundation
+import MLXLMCommon
+import Testing
+
+@testable import ProviderBenchmark
+@testable import ProviderCore
+
+@Suite("MTP benchmark report and matrix")
+struct MTPBenchmarkTests {
+    @Test("standard matrix is baseline, fixed L=1...8, adaptive")
+    func standardMatrix() throws {
+        let modes = MTPBenchmarkRunner.standardModes
+        #expect(modes.count == 10)
+        #expect(modes.first == .targetOnly)
+        #expect(modes.last == .adaptive)
+        #expect(modes.dropFirst().dropLast().map(\.verificationWidth) == (1...8).map(Optional.some))
+        #expect(modes.dropFirst().dropLast().map(\.fixedDraftTokens) == (0...7).map(Optional.some))
+        #expect(throws: MTPBenchmarkError.self) {
+            try MTPBenchmarkMode.fixed(verificationWidth: 9)
+        }
+    }
+
+    @Test("artifact inspection records immutable config and shard provenance")
+    func artifactInspection() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathComponent(String(repeating: "a", count: 40))
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root.deletingLastPathComponent()) }
+        try Data(#"{"model_type":"gemma4_assistant","architectures":["Gemma4AssistantForCausalLM"],"dtype":"bfloat16","quantization":{"bits":4,"group_size":64,"mode":"affine","layer_overrides":{"head":{"bits":8}}}}"#.utf8)
+            .write(to: root.appendingPathComponent("config.json"))
+        try Data(repeating: 1, count: 17)
+            .write(to: root.appendingPathComponent("model.safetensors"))
+
+        let facts = try MTPBenchmarkModelFacts.inspect(modelID: "assistant", directory: root)
+        #expect(facts.revision == String(repeating: "a", count: 40))
+        #expect(facts.modelType == "gemma4_assistant")
+        #expect(facts.quantization?.bits == 4)
+        #expect(facts.quantization?.groupSize == 64)
+        #expect(facts.quantization?.perLayerOverridesByBits["8"] == 1)
+        #expect(facts.weightFileCount == 1)
+        #expect(facts.weightBytes == 17)
+        #expect(facts.configSizeBytes > 0)
+        #expect(facts.artifactBytes == facts.configSizeBytes + 17)
+        #expect(facts.configSHA256.count == 64)
+        #expect(facts.weightFiles[0].identityKind == .sha256)
+        #expect(facts.weightFiles[0].contentIdentity.count == 64)
+        #expect(facts.artifactFingerprint.count == 64)
+        #expect(facts.hasVerifiableProvenance)
+        try MTPBenchmarkModelFacts.validateUnchanged(facts, label: "assistant")
+    }
+
+    @Test("Hugging Face blob OIDs avoid weight hashing and bind model ID")
+    func huggingFaceBlobIdentityAndDrift() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mtp-hf-\(UUID().uuidString)")
+        let repository = root.appendingPathComponent("models--example--assistant")
+        let revision = String(repeating: "a", count: 40)
+        let snapshot = repository.appendingPathComponent("snapshots/\(revision)")
+        let blobs = repository.appendingPathComponent("blobs")
+        try FileManager.default.createDirectory(at: snapshot, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: blobs, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        try Data(#"{"model_type":"gemma4_assistant"}"#.utf8)
+            .write(to: snapshot.appendingPathComponent("config.json"))
+        let firstOID = String(repeating: "b", count: 64)
+        let secondOID = String(repeating: "c", count: 64)
+        try Data(repeating: 1, count: 11).write(to: blobs.appendingPathComponent(firstOID))
+        try Data(repeating: 2, count: 11).write(to: blobs.appendingPathComponent(secondOID))
+        let weight = snapshot.appendingPathComponent("model.safetensors")
+        try FileManager.default.createSymbolicLink(
+            at: weight, withDestinationURL: blobs.appendingPathComponent(firstOID))
+
+        let facts = try MTPBenchmarkModelFacts.inspect(modelID: nil, directory: snapshot)
+        #expect(facts.modelID == "example/assistant")
+        #expect(facts.weightFiles[0].identityKind == .hfBlobSHA256)
+        #expect(facts.weightFiles[0].contentIdentity == firstOID)
+        #expect(throws: MTPBenchmarkError.self) {
+            try MTPBenchmarkModelFacts.inspect(modelID: "other/assistant", directory: snapshot)
+        }
+
+        try FileManager.default.removeItem(at: weight)
+        try FileManager.default.createSymbolicLink(
+            at: weight, withDestinationURL: blobs.appendingPathComponent(secondOID))
+        #expect(throws: MTPBenchmarkError.self) {
+            try MTPBenchmarkModelFacts.validateUnchanged(facts, label: "assistant")
+        }
+    }
+
+    @Test("benchmark assistant sizing stays identical to production")
+    func assistantResidentSizingDrift() {
+        for bytes: UInt64 in [0, 1, 17, 4_096, 7_999_999_999] {
+            #expect(MTPBenchmarkSizing.assistantResidentBytes(artifactBytes: bytes)
+                == SpecDecLimits.residentEstimate(artifactBytes: bytes))
+        }
+
+        let artifact = MTPBenchmarkArtifactFacts(
+            modelID: "assistant", resolvedPath: "/tmp/assistant", revision: "local",
+            modelType: "gemma4_assistant", architecture: "Gemma4AssistantForCausalLM",
+            dtype: "bfloat16", quantization: nil,
+            weightFiles: [.init(name: "model.safetensors", sizeBytes: 100)])
+        #expect(
+            MTPBenchmarkSizing.totalResidentWeightBytes(
+                targetWeightBytes: 1_000, assistant: artifact)
+                == 1_000 + SpecDecLimits.residentEstimate(artifactBytes: 100))
+        #expect(
+            MTPBenchmarkSizing.totalResidentWeightBytes(
+                targetWeightBytes: Int.max, assistant: artifact)
+                == UInt64(Int.max) + SpecDecLimits.residentEstimate(artifactBytes: 100))
+    }
+
+    @Test("report JSON preserves parity and exposed metrics")
+    func reportJSON() throws {
+        let artifact = MTPBenchmarkArtifactFacts(
+            modelID: "target",
+            resolvedPath: "/tmp/target",
+            revision: String(repeating: "b", count: 40),
+            modelType: "gemma4",
+            architecture: "Gemma4ForConditionalGeneration",
+            dtype: "bfloat16",
+            quantization: .init(bits: 4, groupSize: 64, mode: "affine"),
+            weightFiles: [.init(name: "model.safetensors", sizeBytes: 42)])
+        let mode = try MTPBenchmarkMode.fixed(verificationWidth: 3)
+        let startedAt = Date()
+        let report = MTPBenchmarkReport(
+            runFingerprint: "unit-test-run",
+            purpose: .productionPerformance,
+            stopPolicy: .production(tokenIDs: [1, 2]),
+            startedAt: startedAt,
+            completedAt: startedAt,
+            complete: true,
+            expectedCaseCount: 1,
+            target: artifact,
+            assistant: artifact,
+            hardware: .init(
+                 machineModel: "Mac", chipName: "Apple M4 Max", chipFamily: "m4",
+                 chipTier: "max", memoryGB: 128, gpuCores: 40, memoryBandwidthGBps: 546),
+            maxTokensPerRow: 32,
+            warmupIterations: 1,
+            measurementRepetitions: 3,
+            modeOrderSeed: 42,
+            coverage: .shortContextMatrix(
+                target: artifact, assistant: artifact, purpose: .productionPerformance),
+            elapsedMs: 100,
+            cases: [.init(
+                mode: mode,
+                batchSize: 1,
+                measurementRepetitions: 3,
+                medianAggregateDecodeTokensPerSecond: 50,
+                tokenParity: true,
+                parityMismatchRows: [],
+                rows: [.init(
+                    promptName: "math", tokenCount: 2,
+                    opaqueTokenDigest: String(repeating: "c", count: 64),
+                    timeToFirstTokenMs: 10,
+                    interTokenLatencyMs: 20, decodeTokensPerSecond: 50,
+                    lastTokenLatencyMs: 30, finishReason: "length")],
+                metrics: .init(
+                    active: true, selectedDepth: 2, decodeRowBucket: 1,
+                    rounds: 1, proposedTokens: 2,
+                    acceptedDraftTokens: 1, committedTokens: 2,
+                    acceptanceByPosition: [1, 0], conditionalAcceptance: [1, 0],
+                    totalRoundWallTimeNanos: 1_000))])
+
+        let data = try report.jsonData()
+        let decoded = try JSONDecoder.withISO8601.decode(MTPBenchmarkReport.self, from: data)
+        #expect(decoded.schemaVersion == MTPBenchmarkReport.currentSchemaVersion)
+        #expect(decoded.buildConfiguration == .current)
+        #expect(decoded.cases.first?.tokenParity == true)
+        #expect(decoded.cases.first?.metrics.selectedDepth == 2)
+        #expect(decoded.cases.first?.metrics.totalRoundWallTimeNanos == 1_000)
+        #expect(decoded.runFingerprint == MTPBenchmarkReport.buildBoundFingerprint(
+            "unit-test-run", buildConfiguration: .current))
+        #expect(decoded.complete)
+        #expect(decoded.stopPolicy.kind == .productionTargetEOS)
+        #expect(decoded.stopPolicy.configuredTokenCount == 2)
+        let object = try JSONSerialization.jsonObject(with: data)
+        #expect(findKeys(in: object, matching: ["tokenIDs"]).isEmpty)
+    }
+
+    @Test("stream and aggregate timing use token timestamps and N-1 intervals")
+    func deterministicTokenTiming() throws {
+        let stream = try MTPBenchmarkTiming.stream(
+            submittedAtNanoseconds: 1_000_000_000,
+            tokenTimestampsNanoseconds: [
+                1_100_000_000,
+                1_200_000_000,
+                1_400_000_000,
+            ])
+        #expect(stream.timeToFirstTokenMs == 100)
+        #expect(stream.interTokenLatencyMs == 150)
+        #expect(abs(stream.decodeTokensPerSecond - (2.0 / 0.3)) < 0.000_001)
+        #expect(stream.lastTokenLatencyMs == 400)
+
+        let aggregate = try MTPBenchmarkTiming.aggregateDecodeTokensPerSecond(
+            tokenTimestampsNanoseconds: [
+                [100_000_000, 200_000_000, 300_000_000],
+                [150_000_000, 250_000_000],
+            ])
+        #expect(abs(aggregate - 15) < 0.000_001)
+    }
+
+    @Test("fixed metrics prove requested depth and actual row bucket")
+    func fixedMetricsValidation() throws {
+        let mode = try MTPBenchmarkMode.fixed(verificationWidth: 3)
+        let metrics = MTPBenchmarkMetrics(
+            active: true,
+            selectedDepth: 1,
+            decodeRowBucket: 2,
+            rounds: 8,
+            proposedTokens: 16,
+            skippedRows: [:],
+            depthSelections: ["1": 1, "2": 8],
+            costInputs: [.init(
+                decodeRowBucket: 2,
+                draftDepth: 2,
+                sampleCount: 8,
+                ewmaRoundWallTimeNanos: 10,
+                totalRoundWallTimeNanos: 80)])
+        try MTPBenchmarkRunner.validateMetrics(
+            metrics,
+            mode: mode,
+            batchSize: 2,
+            adaptiveDraftingExpected: true,
+            allowedSkipReasons: [])
+
+        #expect(throws: MTPBenchmarkError.self) {
+            try MTPBenchmarkRunner.validateMetrics(
+                MTPBenchmarkMetrics(
+                    active: true,
+                    selectedDepth: 2,
+                    decodeRowBucket: 2,
+                    rounds: 8,
+                    proposedTokens: 16,
+                    skippedRows: ["planner_clamp": 1],
+                    depthSelections: ["2": 8],
+                    costInputs: metrics.costInputs),
+                mode: mode,
+                batchSize: 2,
+                adaptiveDraftingExpected: true,
+                allowedSkipReasons: [])
+        }
+    }
+
+    @Test("adaptive mode must actually draft where requested")
+    func adaptiveMustDraft() {
+        #expect(throws: MTPBenchmarkError.self) {
+            try MTPBenchmarkRunner.validateMetrics(
+                MTPBenchmarkMetrics(
+                    active: true,
+                    selectedDepth: 0,
+                    decodeRowBucket: 1,
+                    depthSelections: ["0": 2],
+                    costInputs: [.init(
+                        decodeRowBucket: 1,
+                        draftDepth: 0,
+                        sampleCount: 2,
+                        ewmaRoundWallTimeNanos: 10,
+                        totalRoundWallTimeNanos: 20)]),
+                mode: .adaptive,
+                batchSize: 1,
+                adaptiveDraftingExpected: true,
+                allowedSkipReasons: [])
+        }
+
+        #expect(throws: MTPBenchmarkError.self) {
+            try MTPBenchmarkRunner.validateMetrics(
+                MTPBenchmarkMetrics(
+                    active: true,
+                    selectedDepth: 2,
+                    decodeRowBucket: 4,
+                    rounds: 2,
+                    proposedTokens: 4,
+                    depthSelections: ["2": 2],
+                    costInputs: [.init(
+                        decodeRowBucket: 2,
+                        draftDepth: 2,
+                        sampleCount: 2,
+                        ewmaRoundWallTimeNanos: 10,
+                        totalRoundWallTimeNanos: 20)]),
+                mode: .adaptive,
+                batchSize: 4,
+                adaptiveDraftingExpected: true,
+                allowedSkipReasons: [])
+        }
+    }
+
+    @Test("error terminal fails the benchmark run")
+    func errorTerminalFailsRun() async throws {
+        let artifact = testArtifact()
+        let engine = TerminalErrorEngine()
+        let sessions = MTPBenchmarkSessionFactory { _, _ in
+            MTPBenchmarkSession(engine: engine) { .inactive }
+        }
+        do {
+            _ = try await MTPBenchmarkRunner.run(
+                target: artifact,
+                assistant: artifact,
+                hardware: testHardware(),
+                configuration: MTPBenchmarkConfiguration(
+                    prompts: [.init(name: "prompt", tokenIDs: [1, 2])],
+                    batchSizes: [1],
+                    modes: [.targetOnly],
+                    maxTokensPerRow: 1,
+                    purpose: .rawParityStress,
+                    stopPolicy: .rawFixedLength,
+                    deadline: .seconds(2)),
+                sessions: sessions)
+            Issue.record("benchmark accepted an error terminal")
+        } catch let error as MTPBenchmarkError {
+            #expect(error.description.contains("engine_error"))
+            #expect(!error.description.contains("7"))
+        }
+    }
+
+    @Test("raw parity checkpoint is complete and contains no performance fields")
+    func rawParityRedactsPerformance() async throws {
+        let artifact = testArtifact()
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mtp-benchmark-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: false)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let destination = try MTPBenchmarkReportDestination.open(
+            directoryURL: directory,
+            fileName: "report.json")
+        let sessions = MTPBenchmarkSessionFactory { _, _ in
+            MTPBenchmarkSession(engine: SuccessfulLengthEngine()) { .inactive }
+        }
+        let report = try await MTPBenchmarkRunner.run(
+            target: artifact,
+            assistant: artifact,
+            hardware: testHardware(),
+            configuration: MTPBenchmarkConfiguration(
+                prompts: [.init(name: "prompt", tokenIDs: [1, 2])],
+                batchSizes: [1],
+                modes: [.targetOnly],
+                maxTokensPerRow: 1,
+                purpose: .rawParityStress,
+                stopPolicy: .rawFixedLength,
+                checkpointDestination: destination,
+                deadline: .seconds(2)),
+            sessions: sessions)
+        #expect(report.complete)
+        #expect(report.cases.first?.medianAggregateDecodeTokensPerSecond == nil)
+        #expect(report.cases.first?.rows.first?.timeToFirstTokenMs == nil)
+        #expect(report.cases.first?.rows.first?.decodeTokensPerSecond == nil)
+        #expect(report.cases.first?.rows.first?.tokenCount == 1)
+        #expect(report.cases.first?.rows.first?.opaqueTokenDigest.count == 64)
+        #expect(report.elapsedMs == nil)
+
+        let persisted = try JSONDecoder.withISO8601.decode(
+            MTPBenchmarkReport.self, from: Data(contentsOf: destination.url))
+        #expect(persisted.complete)
+        #expect(persisted.cases.count == persisted.expectedCaseCount)
+        let object = try JSONSerialization.jsonObject(with: Data(contentsOf: destination.url))
+        #expect(findKeys(in: object, matching: ["tokenIDs"]).isEmpty)
+    }
+
+    @Test("production performance retains corrected token timing fields")
+    func productionPerformanceTimingFields() async throws {
+        let artifact = testArtifact()
+        let sessions = MTPBenchmarkSessionFactory { _, _ in
+            MTPBenchmarkSession(engine: SuccessfulLengthEngine()) { .inactive }
+        }
+        #if DEBUG
+        await #expect(throws: MTPBenchmarkError.self) {
+            _ = try await MTPBenchmarkRunner.run(
+                target: artifact,
+                assistant: artifact,
+                hardware: testHardware(),
+                configuration: MTPBenchmarkConfiguration(
+                    prompts: [.init(name: "prompt", tokenIDs: [1, 2])],
+                    batchSizes: [1],
+                    modes: [.targetOnly],
+                    maxTokensPerRow: 1,
+                    purpose: .productionPerformance,
+                    stopPolicy: .production(tokenIDs: [9]),
+                    measurementRepetitions: 2,
+                    deadline: .seconds(2)),
+                sessions: sessions)
+        }
+        #else
+        let report = try await MTPBenchmarkRunner.run(
+            target: artifact,
+            assistant: artifact,
+            hardware: testHardware(),
+            configuration: MTPBenchmarkConfiguration(
+                prompts: [.init(name: "prompt", tokenIDs: [1, 2])],
+                batchSizes: [1],
+                modes: [.targetOnly],
+                maxTokensPerRow: 1,
+                purpose: .productionPerformance,
+                stopPolicy: .production(tokenIDs: [9]),
+                measurementRepetitions: 2,
+                deadline: .seconds(2)),
+            sessions: sessions)
+        #expect(report.cases.first?.medianAggregateDecodeTokensPerSecond == 0)
+        #expect(report.cases.first?.rows.first?.timeToFirstTokenMs != nil)
+        #expect(report.cases.first?.rows.first?.decodeTokensPerSecond == 0)
+        #expect(report.elapsedMs != nil)
+        #endif
+    }
+
+    @Test("all non-performance reports recursively omit performance keys")
+    func nonPerformanceReportsRecursivelyRedactPerformance() throws {
+        let artifact = testArtifact()
+        let performanceKeys: Set<String> = [
+            "elapsedMs",
+            "medianAggregateDecodeTokensPerSecond",
+            "timeToFirstTokenMs",
+            "interTokenLatencyMs",
+            "decodeTokensPerSecond",
+            "lastTokenLatencyMs",
+            "ewmaRoundWallTimeNanos",
+            "totalRoundWallTimeNanos",
+            "assistantTimeNanos",
+            "targetVerifyTimeNanos",
+        ]
+        for purpose in [MTPBenchmarkPurpose.rawParityStress, .productionCorrectness] {
+            let stopPolicy: MTPBenchmarkStopPolicy = purpose == .rawParityStress
+                ? .rawFixedLength
+                : .production(tokenIDs: [9])
+            let report = MTPBenchmarkReport(
+                runFingerprint: "redaction-\(purpose.rawValue)",
+                purpose: purpose,
+                stopPolicy: stopPolicy,
+                startedAt: Date(),
+                completedAt: Date(),
+                complete: true,
+                expectedCaseCount: 1,
+                target: artifact,
+                assistant: artifact,
+                hardware: testHardware(),
+                maxTokensPerRow: 1,
+                warmupIterations: 0,
+                measurementRepetitions: 1,
+                modeOrderSeed: 1,
+                coverage: .shortContextMatrix(target: artifact, assistant: artifact),
+                elapsedMs: 123,
+                cases: [.init(
+                    mode: .adaptive,
+                    batchSize: 1,
+                    measurementRepetitions: 1,
+                    medianAggregateDecodeTokensPerSecond: 50,
+                    tokenParity: true,
+                    parityMismatchRows: [],
+                    rows: [.init(
+                        promptName: "p",
+                        tokenCount: 1,
+                        opaqueTokenDigest: String(repeating: "d", count: 64),
+                        timeToFirstTokenMs: 1,
+                        interTokenLatencyMs: 2,
+                        decodeTokensPerSecond: 3,
+                        lastTokenLatencyMs: 4,
+                        finishReason: "stop")],
+                    metrics: .init(
+                        active: true,
+                        selectedDepth: 1,
+                        decodeRowBucket: 1,
+                        rounds: 1,
+                        proposedTokens: 1,
+                        costInputs: [.init(
+                            decodeRowBucket: 1,
+                            draftDepth: 1,
+                            sampleCount: 1,
+                            ewmaRoundWallTimeNanos: 5,
+                            totalRoundWallTimeNanos: 6)],
+                        totalRoundWallTimeNanos: 7,
+                        assistantTimeNanos: 8,
+                        targetVerifyTimeNanos: 9))])
+            let object = try JSONSerialization.jsonObject(with: report.jsonData())
+            #expect(findKeys(in: object, matching: performanceKeys).isEmpty)
+            #expect(findKeys(in: object, matching: ["tokenIDs"]).isEmpty)
+        }
+    }
+
+    @Test("production policy includes tokenizer and extra EOS absent from base")
+    func productionStopPolicyUsesServingUnion() async throws {
+        let policy = MTPBenchmarkProductionPolicy.stopTokenIDs(
+            modelID: "example/gemma4",
+            modelType: "gemma4",
+            baseConfigTokenIDs: [11],
+            tokenizerEOSTokenID: 22,
+            extraEOSTokens: ["<extra-eos>"],
+            convertTokenToID: { $0 == "<extra-eos>" ? 33 : nil })
+        #expect(policy == [11, 22, 33])
+
+        let artifact = testArtifact()
+        let sessions = MTPBenchmarkSessionFactory { _, _ in
+            MTPBenchmarkSession(engine: ConfiguredStopEngine(stopToken: 33)) { .inactive }
+        }
+        let report = try await MTPBenchmarkRunner.run(
+            target: artifact,
+            assistant: artifact,
+            hardware: testHardware(),
+            configuration: MTPBenchmarkConfiguration(
+                prompts: [.init(name: "extra-stop", tokenIDs: [1])],
+                batchSizes: [1],
+                modes: [.targetOnly],
+                maxTokensPerRow: 2,
+                purpose: .productionCorrectness,
+                stopPolicy: .production(tokenIDs: policy),
+                deadline: .seconds(2)),
+            sessions: sessions)
+        #expect(report.cases.first?.rows.first?.finishReason == "stop")
+        #expect(report.stopPolicy.configuredTokenCount == 3)
+    }
+
+    @Test("report destination survives visible parent symlink replacement")
+    func descriptorRelativeReportWrite() throws {
+        let base = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mtp-report-race-\(UUID().uuidString)")
+        let run = base.appendingPathComponent("run")
+        let held = base.appendingPathComponent("held")
+        let outside = base.appendingPathComponent("outside")
+        try FileManager.default.createDirectory(at: run, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: outside, withIntermediateDirectories: false)
+        defer { try? FileManager.default.removeItem(at: base) }
+
+        let destination = try MTPBenchmarkReportDestination.open(
+            directoryURL: run,
+            fileName: "report.json")
+        let outsideFile = outside.appendingPathComponent("victim.json")
+        try Data("sentinel".utf8).write(to: outsideFile)
+        try FileManager.default.createSymbolicLink(
+            at: run.appendingPathComponent("report.json"),
+            withDestinationURL: outsideFile)
+        try FileManager.default.moveItem(at: run, to: held)
+        try FileManager.default.createSymbolicLink(at: run, withDestinationURL: outside)
+        let report = minimalReport(purpose: .rawParityStress)
+        try report.write(to: destination)
+
+        #expect(FileManager.default.fileExists(
+            atPath: held.appendingPathComponent("report.json").path))
+        #expect(!FileManager.default.fileExists(
+            atPath: outside.appendingPathComponent("report.json").path))
+        #expect(try String(contentsOf: outsideFile, encoding: .utf8) == "sentinel")
+    }
+
+    @Test("coverage labels follow inspected target and assistant formats")
+    func dynamicCoverageLabels() {
+        let target = MTPBenchmarkArtifactFacts(
+            modelID: "custom/target",
+            resolvedPath: "/tmp/target",
+            revision: nil,
+            modelType: "gemma4",
+            architecture: nil,
+            dtype: "bfloat16",
+            quantization: .init(
+                bits: nil,
+                groupSize: 64,
+                mode: "affine",
+                perLayerOverridesByBits: ["8": 12]),
+            weightFiles: [])
+        let assistant = MTPBenchmarkArtifactFacts(
+            modelID: "custom/assistant",
+            resolvedPath: "/tmp/assistant",
+            revision: nil,
+            modelType: "gemma4_assistant",
+            architecture: nil,
+            dtype: "bfloat16",
+            quantization: nil,
+            weightFiles: [])
+        let coverage = MTPBenchmarkCoverage.shortContextMatrix(
+            target: target, assistant: assistant)
+        #expect(coverage.eightBitTargetPairing == .covered)
+        #expect(coverage.bf16AssistantPairing == .covered)
+        #expect(coverage.qat4BitShortContextSmoke == .notRun)
+    }
+
+    @Test("production stop requires the final emitted token to be configured")
+    func stopTokenMustBeEmitted() async throws {
+        let artifact = testArtifact()
+        let sessions = MTPBenchmarkSessionFactory { _, _ in
+            MTPBenchmarkSession(engine: InvalidStopEngine()) { .inactive }
+        }
+        await #expect(throws: MTPBenchmarkError.self) {
+            _ = try await MTPBenchmarkRunner.run(
+                target: artifact,
+                assistant: artifact,
+                hardware: testHardware(),
+                configuration: MTPBenchmarkConfiguration(
+                    prompts: [.init(name: "prompt", tokenIDs: [1])],
+                    batchSizes: [1],
+                    modes: [.targetOnly],
+                    maxTokensPerRow: 1,
+                    purpose: .productionCorrectness,
+                    stopPolicy: .production(tokenIDs: [9]),
+                    deadline: .seconds(2)),
+                sessions: sessions)
+        }
+    }
+
+    @Test("deadline includes session construction")
+    func deadlineIncludesSessionConstruction() async throws {
+        let artifact = testArtifact()
+        let sessions = MTPBenchmarkSessionFactory { _, _ in
+            try await Task<Never, Never>.sleep(nanoseconds: 40_000_000)
+            return MTPBenchmarkSession(engine: SuccessfulLengthEngine()) { .inactive }
+        }
+        await expectDeadline(artifact: artifact, deadline: .milliseconds(10), sessions: sessions)
+    }
+
+    @Test("deadline includes synchronous submission")
+    func deadlineIncludesSubmission() async throws {
+        let artifact = testArtifact()
+        let sessions = MTPBenchmarkSessionFactory { _, _ in
+            MTPBenchmarkSession(engine: SlowSubmissionEngine()) { .inactive }
+        }
+        await expectDeadline(artifact: artifact, deadline: .milliseconds(10), sessions: sessions)
+    }
+
+    @Test("deadline includes engine shutdown")
+    func deadlineIncludesShutdown() async throws {
+        let artifact = testArtifact()
+        let sessions = MTPBenchmarkSessionFactory { _, _ in
+            MTPBenchmarkSession(engine: SlowShutdownEngine()) { .inactive }
+        }
+        await expectDeadline(artifact: artifact, deadline: .milliseconds(10), sessions: sessions)
+    }
+
+    @Test("per-case remaining deadline cancels a hanging batch")
+    func remainingDeadlineCancelsBatch() async throws {
+        let artifact = testArtifact()
+        let engine = HangingEngine()
+        let sessions = MTPBenchmarkSessionFactory { _, _ in
+            MTPBenchmarkSession(engine: engine) { .inactive }
+        }
+        do {
+            _ = try await MTPBenchmarkRunner.run(
+                target: artifact,
+                assistant: artifact,
+                hardware: testHardware(),
+                configuration: MTPBenchmarkConfiguration(
+                    prompts: [.init(name: "prompt", tokenIDs: [1, 2])],
+                    batchSizes: [1],
+                    modes: [.targetOnly],
+                    maxTokensPerRow: 1,
+                    purpose: .rawParityStress,
+                    stopPolicy: .rawFixedLength,
+                    deadline: .milliseconds(20)),
+                sessions: sessions)
+            Issue.record("benchmark accepted a batch past its remaining deadline")
+        } catch let error as MTPBenchmarkError {
+            if case .deadlineExceeded = error {
+                #expect(engine.cancelled)
+            } else {
+                Issue.record("unexpected deadline error: \(error)")
+            }
+        }
+    }
+
+    private func testArtifact() -> MTPBenchmarkArtifactFacts {
+        MTPBenchmarkArtifactFacts(
+            modelID: "test",
+            resolvedPath: "/tmp/test",
+            revision: nil,
+            modelType: "gemma4",
+            architecture: nil,
+            dtype: "bfloat16",
+            quantization: nil,
+            weightFiles: [])
+    }
+
+    private func testHardware() -> MTPBenchmarkHardware {
+        MTPBenchmarkHardware(
+            machineModel: "Mac",
+            chipName: "Apple",
+            chipFamily: "m4",
+            chipTier: "max",
+            memoryGB: 64,
+            gpuCores: 40,
+            memoryBandwidthGBps: 500)
+    }
+
+    private func minimalReport(purpose: MTPBenchmarkPurpose) -> MTPBenchmarkReport {
+        let artifact = testArtifact()
+        return MTPBenchmarkReport(
+            runFingerprint: "minimal",
+            purpose: purpose,
+            stopPolicy: purpose == .rawParityStress
+                ? .rawFixedLength
+                : .production(tokenIDs: [9]),
+            startedAt: Date(),
+            completedAt: Date(),
+            complete: true,
+            expectedCaseCount: 0,
+            target: artifact,
+            assistant: artifact,
+            hardware: testHardware(),
+            maxTokensPerRow: 1,
+            warmupIterations: 0,
+            measurementRepetitions: 1,
+            modeOrderSeed: 1,
+            coverage: .shortContextMatrix(target: artifact, assistant: artifact),
+            elapsedMs: 1,
+            cases: [])
+    }
+
+    private func findKeys(in value: Any, matching wanted: Set<String>) -> [String] {
+        if let object = value as? [String: Any] {
+            return object.flatMap { key, child in
+                (wanted.contains(key) ? [key] : []) + findKeys(in: child, matching: wanted)
+            }
+        }
+        if let values = value as? [Any] {
+            return values.flatMap { findKeys(in: $0, matching: wanted) }
+        }
+        return []
+    }
+
+    private func expectDeadline(
+        artifact: MTPBenchmarkArtifactFacts,
+        deadline: Duration,
+        sessions: MTPBenchmarkSessionFactory
+    ) async {
+        do {
+            _ = try await MTPBenchmarkRunner.run(
+                target: artifact,
+                assistant: artifact,
+                hardware: testHardware(),
+                configuration: MTPBenchmarkConfiguration(
+                    prompts: [.init(name: "prompt", tokenIDs: [1])],
+                    batchSizes: [1],
+                    modes: [.targetOnly],
+                    maxTokensPerRow: 1,
+                    purpose: .rawParityStress,
+                    stopPolicy: .rawFixedLength,
+                    deadline: deadline),
+                sessions: sessions)
+            Issue.record("benchmark exceeded its case deadline")
+        } catch let error as MTPBenchmarkError {
+            if case .deadlineExceeded = error {
+                return
+            }
+            Issue.record("unexpected deadline error: \(error)")
+        } catch {
+            Issue.record("unexpected deadline error: \(error)")
+        }
+    }
+}
+
+private final class TerminalErrorEngine: CBv2Engine, @unchecked Sendable {
+    func submit(_ request: CBv2Request) throws -> AsyncStream<CBv2Event> {
+        AsyncStream { continuation in
+            continuation.yield(.delta(text: "x", tokens: [7], logprobs: nil))
+            continuation.yield(.finished(
+                reason: .error("injected"),
+                usage: CBv2Usage(
+                    promptTokens: request.promptTokens.count,
+                    completionTokens: 1)))
+            continuation.finish()
+        }
+    }
+
+    func cancel(_: CBv2RequestID) {}
+
+    func capacity() -> CBv2CapacitySnapshot {
+        CBv2CapacitySnapshot(
+            activeRequests: 0,
+            waitingRequests: 0,
+            kvBytesInUse: 0,
+            kvBytesCapacity: 0,
+            activeTokens: 0)
+    }
+
+    func shutdown() async {}
+}
+
+private final class SuccessfulLengthEngine: CBv2Engine, @unchecked Sendable {
+    func submit(_ request: CBv2Request) throws -> AsyncStream<CBv2Event> {
+        successfulLengthStream(request)
+    }
+
+    func cancel(_: CBv2RequestID) {}
+
+    func capacity() -> CBv2CapacitySnapshot {
+        CBv2CapacitySnapshot(
+            activeRequests: 0,
+            waitingRequests: 0,
+            kvBytesInUse: 0,
+            kvBytesCapacity: 0,
+            activeTokens: 0)
+    }
+
+    func shutdown() async {}
+}
+
+private final class InvalidStopEngine: CBv2Engine, @unchecked Sendable {
+    func submit(_ request: CBv2Request) throws -> AsyncStream<CBv2Event> {
+        AsyncStream { continuation in
+            continuation.yield(.delta(text: "x", tokens: [7], logprobs: nil))
+            continuation.yield(.finished(
+                reason: .stop,
+                usage: CBv2Usage(
+                    promptTokens: request.promptTokens.count,
+                    completionTokens: 1)))
+            continuation.finish()
+        }
+    }
+
+    func cancel(_: CBv2RequestID) {}
+    func capacity() -> CBv2CapacitySnapshot { emptyCapacity() }
+    func shutdown() async {}
+}
+
+private final class ConfiguredStopEngine: CBv2Engine, @unchecked Sendable {
+    private let stopToken: Int
+
+    init(stopToken: Int) {
+        self.stopToken = stopToken
+    }
+
+    func submit(_ request: CBv2Request) throws -> AsyncStream<CBv2Event> {
+        guard request.stopTokens.contains(stopToken) else {
+            throw MTPBenchmarkError.invalidStopPolicy(
+                "fixture request omitted the configured extra EOS")
+        }
+        return AsyncStream { continuation in
+            continuation.yield(.delta(text: "", tokens: [stopToken], logprobs: nil))
+            continuation.yield(.finished(
+                reason: .stop,
+                usage: CBv2Usage(
+                    promptTokens: request.promptTokens.count,
+                    completionTokens: 1)))
+            continuation.finish()
+        }
+    }
+
+    func cancel(_: CBv2RequestID) {}
+    func capacity() -> CBv2CapacitySnapshot { emptyCapacity() }
+    func shutdown() async {}
+}
+
+private final class SlowSubmissionEngine: CBv2Engine, @unchecked Sendable {
+    func submit(_ request: CBv2Request) throws -> AsyncStream<CBv2Event> {
+        Thread.sleep(forTimeInterval: 0.04)
+        return successfulLengthStream(request)
+    }
+
+    func cancel(_: CBv2RequestID) {}
+    func capacity() -> CBv2CapacitySnapshot { emptyCapacity() }
+    func shutdown() async {}
+}
+
+private final class SlowShutdownEngine: CBv2Engine, @unchecked Sendable {
+    func submit(_ request: CBv2Request) throws -> AsyncStream<CBv2Event> {
+        successfulLengthStream(request)
+    }
+
+    func cancel(_: CBv2RequestID) {}
+    func capacity() -> CBv2CapacitySnapshot { emptyCapacity() }
+
+    func shutdown() async {
+        try? await Task<Never, Never>.sleep(nanoseconds: 40_000_000)
+    }
+}
+
+private final class HangingEngine: CBv2Engine, @unchecked Sendable {
+    private let lock = NSLock()
+    private var continuation: AsyncStream<CBv2Event>.Continuation?
+    private var didCancel = false
+
+    var cancelled: Bool { lock.withLock { didCancel } }
+
+    func submit(_: CBv2Request) throws -> AsyncStream<CBv2Event> {
+        AsyncStream { continuation in
+            lock.withLock { self.continuation = continuation }
+        }
+    }
+
+    func cancel(_: CBv2RequestID) {
+        let stream = lock.withLock { () -> AsyncStream<CBv2Event>.Continuation? in
+            didCancel = true
+            return continuation
+        }
+        stream?.yield(.finished(
+            reason: .cancelled,
+            usage: CBv2Usage(promptTokens: 2, completionTokens: 0)))
+        stream?.finish()
+    }
+
+    func capacity() -> CBv2CapacitySnapshot {
+        CBv2CapacitySnapshot(
+            activeRequests: 1,
+            waitingRequests: 0,
+            kvBytesInUse: 0,
+            kvBytesCapacity: 0,
+            activeTokens: 0)
+    }
+
+    func shutdown() async {}
+}
+
+private func successfulLengthStream(_ request: CBv2Request) -> AsyncStream<CBv2Event> {
+    AsyncStream { continuation in
+        continuation.yield(.delta(text: "x", tokens: [7], logprobs: nil))
+        continuation.yield(.finished(
+            reason: .length,
+            usage: CBv2Usage(
+                promptTokens: request.promptTokens.count,
+                completionTokens: 1)))
+        continuation.finish()
+    }
+}
+
+private func emptyCapacity() -> CBv2CapacitySnapshot {
+    CBv2CapacitySnapshot(
+        activeRequests: 0,
+        waitingRequests: 0,
+        kvBytesInUse: 0,
+        kvBytesCapacity: 0,
+        activeTokens: 0)
+}
+
+private extension JSONDecoder {
+    static var withISO8601: JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }
+}

--- a/provider-swift/Tests/ProviderCoreTests/MTPBenchmarkTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/MTPBenchmarkTests.swift
@@ -903,6 +903,41 @@ struct MTPBenchmarkTests {
         }
     }
 
+    @Test("production length terminal must reach maxTokens")
+    func lengthTerminalMustReachMaxTokens() async throws {
+        let artifact = testArtifact()
+        let sessions = MTPBenchmarkSessionFactory { _, _ in
+            MTPBenchmarkSession(engine: SuccessfulLengthEngine()) { .inactive }
+        }
+        func run(maxTokensPerRow: Int) async throws -> MTPBenchmarkReport {
+            try await MTPBenchmarkRunner.run(
+                target: artifact,
+                assistant: artifact,
+                hardware: testHardware(),
+                configuration: MTPBenchmarkConfiguration(
+                    prompts: [.init(name: "prompt", tokenIDs: [1])],
+                    batchSizes: [1],
+                    modes: [.targetOnly],
+                    maxTokensPerRow: maxTokensPerRow,
+                    purpose: .productionCorrectness,
+                    stopPolicy: .production(tokenIDs: [9]),
+                    deadline: .seconds(2)),
+                sessions: sessions)
+        }
+        // The engine emits exactly one token before its "length" terminal, so a
+        // budget of 2 is a premature truncation and must be rejected.
+        do {
+            _ = try await run(maxTokensPerRow: 2)
+            Issue.record("benchmark certified a truncated length terminal")
+        } catch let error as MTPBenchmarkError {
+            #expect(error.description.contains(
+                "production length terminal reached maxTokens"))
+        }
+        // Reaching the budget exactly is a valid production length terminal.
+        let report = try await run(maxTokensPerRow: 1)
+        #expect(report.cases.first?.rows.first?.finishReason == "length")
+    }
+
     @Test("deadline includes session construction")
     func deadlineIncludesSessionConstruction() async throws {
         let artifact = testArtifact()

--- a/provider-swift/Tests/ProviderCoreTests/MTPBenchmarkTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/MTPBenchmarkTests.swift
@@ -24,8 +24,14 @@ struct MTPBenchmarkTests {
     func verificationModeProjection() {
         var engineMetrics = CBv2MTPMetrics()
         engineMetrics.verificationMode = .rectangular
+        engineMetrics.maxAutomaticRectangularTokens = 8
+        engineMetrics.rectangularVerificationRounds = 3
+        engineMetrics.serialVerificationRounds = 1
         let projected = MTPBenchmarkMetrics(engineMetrics: engineMetrics)
         #expect(projected.verificationMode == "rectangular")
+        #expect(projected.maxAutomaticRectangularTokens == 8)
+        #expect(projected.rectangularVerificationRounds == 3)
+        #expect(projected.serialVerificationRounds == 1)
     }
 
     @Test("artifact inspection records immutable config and shard provenance")
@@ -358,6 +364,68 @@ struct MTPBenchmarkTests {
                     costInputs: metrics.costInputs),
                 mode: mode,
                 batchSize: 2,
+                adaptiveDraftingExpected: true,
+                allowedSkipReasons: [])
+        }
+    }
+
+    @Test("automatic fixed depth accepts certified target-only fallback")
+    func automaticFixedDepthFallbackValidation() throws {
+        let mode = try MTPBenchmarkMode.fixed(verificationWidth: 2)
+        let fallback = MTPBenchmarkMetrics(
+            active: true,
+            verificationMode: "automatic",
+            maxAutomaticRectangularTokens: 8,
+            rectangularVerificationRounds: 0,
+            serialVerificationRounds: 0,
+            selectedDepth: 0,
+            decodeRowBucket: 8,
+            depthSelections: ["0": 4],
+            controllerFallbacks: ["automatic_rectangular_limit": 4],
+            totalRoundWallTimeNanos: 0)
+
+        try MTPBenchmarkRunner.validateMetrics(
+            fallback,
+            mode: mode,
+            batchSize: 8,
+            adaptiveDraftingExpected: true,
+            allowedSkipReasons: [])
+
+        let safeAfterBatchShrink = MTPBenchmarkMetrics(
+            active: true,
+            verificationMode: "automatic",
+            maxAutomaticRectangularTokens: 8,
+            rectangularVerificationRounds: 2,
+            serialVerificationRounds: 0,
+            selectedDepth: 1,
+            decodeRowBucket: 4,
+            rounds: 2,
+            proposedTokens: 8,
+            depthSelections: ["0": 2, "1": 2],
+            controllerFallbacks: ["automatic_rectangular_limit": 2],
+            costInputs: [.init(
+                decodeRowBucket: 4,
+                draftDepth: 1,
+                sampleCount: 2)])
+        try MTPBenchmarkRunner.validateMetrics(
+            safeAfterBatchShrink,
+            mode: mode,
+            batchSize: 8,
+            adaptiveDraftingExpected: true,
+            allowedSkipReasons: [])
+
+        #expect(throws: MTPBenchmarkError.self) {
+            try MTPBenchmarkRunner.validateMetrics(
+                MTPBenchmarkMetrics(
+                    active: true,
+                    verificationMode: "automatic",
+                    maxAutomaticRectangularTokens: 8,
+                    selectedDepth: 0,
+                    decodeRowBucket: 4,
+                    depthSelections: ["0": 4],
+                    controllerFallbacks: ["automatic_rectangular_limit": 4]),
+                mode: mode,
+                batchSize: 4,
                 adaptiveDraftingExpected: true,
                 allowedSkipReasons: [])
         }

--- a/provider-swift/Tests/ProviderCoreTests/MTPBenchmarkTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/MTPBenchmarkTests.swift
@@ -596,6 +596,36 @@ struct MTPBenchmarkTests {
         }
     }
 
+    @Test("production evidence pins active cases to the automatic verifier")
+    func productionRequiresAutomaticVerifier() throws {
+        let mode = try MTPBenchmarkMode.fixed(verificationWidth: 1)
+        let serialMetrics = MTPBenchmarkMetrics(
+            active: true,
+            verificationMode: "serial_target",
+            serialVerificationRounds: 3,
+            selectedDepth: 0,
+            decodeRowBucket: 1,
+            depthSelections: ["0": 1])
+        // Raw parity remains mode-agnostic (the serial/rectangular
+        // diagnostic vehicle).
+        try MTPBenchmarkRunner.validateMetrics(
+            serialMetrics,
+            mode: mode,
+            batchSize: 1,
+            adaptiveDraftingExpected: false,
+            allowedSkipReasons: [])
+        // Production evidence must reject the retired serial verifier.
+        #expect(throws: MTPBenchmarkError.self) {
+            try MTPBenchmarkRunner.validateMetrics(
+                serialMetrics,
+                mode: mode,
+                batchSize: 1,
+                adaptiveDraftingExpected: false,
+                allowedSkipReasons: [],
+                requireAutomaticVerification: true)
+        }
+    }
+
     @Test("adaptive mode must actually draft where requested")
     func adaptiveMustDraft() {
         #expect(throws: MTPBenchmarkError.self) {
@@ -1036,6 +1066,58 @@ struct MTPBenchmarkTests {
             Issue.record("benchmark certified a stop terminal past maxTokens")
         } catch let error as MTPBenchmarkError {
             #expect(error.description.contains("production terminal within maxTokens"))
+        }
+    }
+
+    @Test("token parity mismatch and missing baseline cannot certify")
+    func parityMismatchCannotCertify() async throws {
+        let artifact = testArtifact()
+        let fixedMetrics = MTPBenchmarkMetrics(
+            active: true,
+            verificationMode: "automatic",
+            maxAutomaticRectangularTokens: 8,
+            selectedDepth: 0,
+            decodeRowBucket: 1,
+            depthSelections: ["0": 1])
+        // Target-only emits token 9; the MTP session emits a DIFFERENT valid
+        // token 7 — target authority requires this to fail certification.
+        let sessions = MTPBenchmarkSessionFactory { mode, _ in
+            if mode.kind == .targetOnly {
+                return MTPBenchmarkSession(
+                    engine: ConfiguredStopEngine(stopToken: 9)) { .inactive }
+            }
+            return MTPBenchmarkSession(
+                engine: SameTokenLengthEngine(token: 7)) { fixedMetrics }
+        }
+        func configuration(modes: [MTPBenchmarkMode]) -> MTPBenchmarkConfiguration {
+            MTPBenchmarkConfiguration(
+                prompts: [.init(name: "prompt", tokenIDs: [1])],
+                batchSizes: [1],
+                modes: modes,
+                maxTokensPerRow: 1,
+                purpose: .productionCorrectness,
+                stopPolicy: .production(tokenIDs: [9, 7]),
+                deadline: .seconds(2))
+        }
+        do {
+            _ = try await MTPBenchmarkRunner.run(
+                target: artifact, assistant: artifact, hardware: testHardware(),
+                configuration: configuration(
+                    modes: [.targetOnly, try .fixed(verificationWidth: 1)]),
+                sessions: sessions)
+            Issue.record("divergent tokens were certified as parity")
+        } catch MTPBenchmarkError.tokenParityMismatch(let mode, let batchSize, let rows) {
+            #expect(mode == "fixed-L1")
+            #expect(batchSize == 1)
+            #expect(rows == [0])
+        }
+        // A configuration without the target-only baseline cannot even start.
+        await #expect(throws: MTPBenchmarkError.self) {
+            _ = try await MTPBenchmarkRunner.run(
+                target: artifact, assistant: artifact, hardware: testHardware(),
+                configuration: configuration(
+                    modes: [try .fixed(verificationWidth: 1)]),
+                sessions: sessions)
         }
     }
 

--- a/provider-swift/Tests/ProviderCoreTests/MTPBenchmarkTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/MTPBenchmarkTests.swift
@@ -213,6 +213,11 @@ struct MTPBenchmarkTests {
             MTPBenchmarkMetrics(active: false),
             MTPBenchmarkMetrics(active: false, inactiveReason: "configuration disabled"),
             MTPBenchmarkMetrics(active: false, inactiveReason: reason, rounds: 1),
+            // Target verification with zero claimed rounds is still work.
+            MTPBenchmarkMetrics(
+                active: false, rectangularVerificationRounds: 1, inactiveReason: reason),
+            MTPBenchmarkMetrics(
+                active: false, serialVerificationRounds: 1, inactiveReason: reason),
         ] {
             #expect(throws: MTPBenchmarkError.self) {
                 try MTPBenchmarkRunner.validateMetrics(
@@ -502,6 +507,67 @@ struct MTPBenchmarkTests {
             batchSize: 8,
             adaptiveDraftingExpected: true,
             allowedSkipReasons: [])
+
+        // Seed steps alone are legitimate: they are recorded at step launch
+        // and the row can terminate before its round runs.
+        try MTPBenchmarkRunner.validateMetrics(
+            MTPBenchmarkMetrics(
+                active: true,
+                verificationMode: "automatic",
+                maxAutomaticRectangularTokens: 8,
+                rectangularVerificationRounds: 0,
+                serialVerificationRounds: 0,
+                selectedDepth: 0,
+                decodeRowBucket: 8,
+                seedRows: 2,
+                depthSelections: ["0": 3, "1": 1],
+                controllerFallbacks: ["warmup": 4]),
+            mode: .adaptive,
+            batchSize: 8,
+            adaptiveDraftingExpected: true,
+            allowedSkipReasons: [])
+
+        // Zero rounds with nonzero draft counters must fail.
+        #expect(throws: MTPBenchmarkError.self) {
+            try MTPBenchmarkRunner.validateMetrics(
+                MTPBenchmarkMetrics(
+                    active: true,
+                    verificationMode: "automatic",
+                    maxAutomaticRectangularTokens: 8,
+                    rectangularVerificationRounds: 0,
+                    serialVerificationRounds: 0,
+                    selectedDepth: 0,
+                    decodeRowBucket: 8,
+                    proposedTokens: 3,
+                    depthSelections: ["0": 4],
+                    controllerFallbacks: ["warmup": 4]),
+                mode: .adaptive,
+                batchSize: 8,
+                adaptiveDraftingExpected: true,
+                allowedSkipReasons: [])
+        }
+
+        // Positive rounds without any rectangular verification evidence must
+        // fail even when cost inputs are empty.
+        #expect(throws: MTPBenchmarkError.self) {
+            try MTPBenchmarkRunner.validateMetrics(
+                MTPBenchmarkMetrics(
+                    active: true,
+                    verificationMode: "automatic",
+                    maxAutomaticRectangularTokens: 8,
+                    rectangularVerificationRounds: 0,
+                    serialVerificationRounds: 0,
+                    selectedDepth: 1,
+                    decodeRowBucket: 4,
+                    rounds: 2,
+                    proposedTokens: 4,
+                    depthSelections: ["0": 2, "1": 2],
+                    controllerFallbacks: ["automatic_rectangular_limit": 2]),
+                mode: .adaptive,
+                batchSize: 8,
+                adaptiveDraftingExpected: true,
+                allowedSkipReasons: [])
+        }
 
         // Late-drain drafting at a smaller bucket stays acceptable only while
         // rectangular and inside the cap; serial rounds must fail.
@@ -903,6 +969,47 @@ struct MTPBenchmarkTests {
         }
     }
 
+    @Test("parity requires matching finish reasons, not only tokens")
+    func parityComparesFinishReasons() async throws {
+        let artifact = testArtifact()
+        let fixedMetrics = MTPBenchmarkMetrics(
+            active: true,
+            verificationMode: "automatic",
+            maxAutomaticRectangularTokens: 8,
+            selectedDepth: 0,
+            decodeRowBucket: 1,
+            depthSelections: ["0": 1])
+        let sessions = MTPBenchmarkSessionFactory { mode, _ in
+            if mode.kind == .targetOnly {
+                return MTPBenchmarkSession(
+                    engine: ConfiguredStopEngine(stopToken: 9)) { .inactive }
+            }
+            return MTPBenchmarkSession(
+                engine: SameTokenLengthEngine(token: 9)) { fixedMetrics }
+        }
+        // Both engines emit the identical single token 9 at the budget; only
+        // the OpenAI-visible finish reason differs (stop vs length). Token
+        // parity alone would certify this divergence.
+        do {
+            _ = try await MTPBenchmarkRunner.run(
+                target: artifact,
+                assistant: artifact,
+                hardware: testHardware(),
+                configuration: MTPBenchmarkConfiguration(
+                    prompts: [.init(name: "prompt", tokenIDs: [1])],
+                    batchSizes: [1],
+                    modes: [.targetOnly, try .fixed(verificationWidth: 1)],
+                    maxTokensPerRow: 1,
+                    purpose: .productionCorrectness,
+                    stopPolicy: .production(tokenIDs: [9]),
+                    deadline: .seconds(2)),
+                sessions: sessions)
+            Issue.record("identical tokens with divergent finish reasons were certified")
+        } catch let error as MTPBenchmarkError {
+            #expect(error.description.contains("finish reasons diverge"))
+        }
+    }
+
     @Test("production length terminal must reach maxTokens")
     func lengthTerminalMustReachMaxTokens() async throws {
         let artifact = testArtifact()
@@ -1130,6 +1237,32 @@ private final class SuccessfulLengthEngine: CBv2Engine, @unchecked Sendable {
             activeTokens: 0)
     }
 
+    func shutdown() async {}
+}
+
+/// Emits exactly one configurable token and finishes with `.length` — the
+/// finish-reason twin of `ConfiguredStopEngine` for parity divergence tests.
+private final class SameTokenLengthEngine: CBv2Engine, @unchecked Sendable {
+    private let token: Int
+
+    init(token: Int) {
+        self.token = token
+    }
+
+    func submit(_ request: CBv2Request) throws -> AsyncStream<CBv2Event> {
+        AsyncStream { continuation in
+            continuation.yield(.delta(text: "", tokens: [token], logprobs: nil))
+            continuation.yield(.finished(
+                reason: .length,
+                usage: CBv2Usage(
+                    promptTokens: request.promptTokens.count,
+                    completionTokens: 1)))
+            continuation.finish()
+        }
+    }
+
+    func cancel(_: CBv2RequestID) {}
+    func capacity() -> CBv2CapacitySnapshot { emptyCapacity() }
     func shutdown() async {}
 }
 

--- a/provider-swift/Tests/ProviderCoreTests/MTPBenchmarkTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/MTPBenchmarkTests.swift
@@ -688,7 +688,7 @@ struct MTPBenchmarkTests {
                     maxTokensPerRow: 1,
                     purpose: .rawParityStress,
                     stopPolicy: .rawFixedLength,
-                    deadline: .seconds(2)),
+                    deadline: .seconds(60)),
                 sessions: sessions)
             Issue.record("benchmark accepted an error terminal")
         } catch let error as MTPBenchmarkError {
@@ -722,7 +722,7 @@ struct MTPBenchmarkTests {
                 purpose: .rawParityStress,
                 stopPolicy: .rawFixedLength,
                 checkpointDestination: destination,
-                deadline: .seconds(2)),
+                deadline: .seconds(60)),
             sessions: sessions)
         #expect(report.complete)
         #expect(report.cases.first?.medianAggregateDecodeTokensPerSecond == nil)
@@ -760,7 +760,7 @@ struct MTPBenchmarkTests {
                     purpose: .productionPerformance,
                     stopPolicy: .production(tokenIDs: [9]),
                     measurementRepetitions: 2,
-                    deadline: .seconds(2)),
+                    deadline: .seconds(60)),
                 sessions: sessions)
         }
         #else
@@ -776,7 +776,7 @@ struct MTPBenchmarkTests {
                 purpose: .productionPerformance,
                 stopPolicy: .production(tokenIDs: [9]),
                 measurementRepetitions: 2,
-                deadline: .seconds(2)),
+                deadline: .seconds(60)),
             sessions: sessions)
         #expect(report.cases.first?.medianAggregateDecodeTokensPerSecond == 0)
         #expect(report.cases.first?.rows.first?.timeToFirstTokenMs != nil)
@@ -804,7 +804,7 @@ struct MTPBenchmarkTests {
                     purpose: .productionPerformance,
                     mtpExpectation: .legacyM5HardwareSafetyGate,
                     stopPolicy: .production(tokenIDs: [9]),
-                    deadline: .seconds(2)),
+                    deadline: .seconds(60)),
                 sessions: sessions)
         }
     }
@@ -908,7 +908,7 @@ struct MTPBenchmarkTests {
                 maxTokensPerRow: 2,
                 purpose: .productionCorrectness,
                 stopPolicy: .production(tokenIDs: policy),
-                deadline: .seconds(2)),
+                deadline: .seconds(60)),
             sessions: sessions)
         #expect(report.cases.first?.rows.first?.finishReason == "stop")
         #expect(report.stopPolicy.configuredTokenCount == 3)
@@ -994,7 +994,7 @@ struct MTPBenchmarkTests {
                     maxTokensPerRow: 1,
                     purpose: .productionCorrectness,
                     stopPolicy: .production(tokenIDs: [9]),
-                    deadline: .seconds(2)),
+                    deadline: .seconds(60)),
                 sessions: sessions)
         }
     }
@@ -1032,7 +1032,7 @@ struct MTPBenchmarkTests {
                     maxTokensPerRow: 1,
                     purpose: .productionCorrectness,
                     stopPolicy: .production(tokenIDs: [9]),
-                    deadline: .seconds(2)),
+                    deadline: .seconds(60)),
                 sessions: sessions)
             Issue.record("identical tokens with divergent finish reasons were certified")
         } catch let error as MTPBenchmarkError {
@@ -1061,7 +1061,7 @@ struct MTPBenchmarkTests {
                     maxTokensPerRow: 1,
                     purpose: .productionCorrectness,
                     stopPolicy: .production(tokenIDs: [9]),
-                    deadline: .seconds(2)),
+                    deadline: .seconds(60)),
                 sessions: sessions)
             Issue.record("benchmark certified a stop terminal past maxTokens")
         } catch let error as MTPBenchmarkError {
@@ -1097,7 +1097,7 @@ struct MTPBenchmarkTests {
                 maxTokensPerRow: 1,
                 purpose: .productionCorrectness,
                 stopPolicy: .production(tokenIDs: [9, 7]),
-                deadline: .seconds(2))
+                deadline: .seconds(60))
         }
         do {
             _ = try await MTPBenchmarkRunner.run(
@@ -1139,7 +1139,7 @@ struct MTPBenchmarkTests {
                     maxTokensPerRow: maxTokensPerRow,
                     purpose: .productionCorrectness,
                     stopPolicy: .production(tokenIDs: [9]),
-                    deadline: .seconds(2)),
+                    deadline: .seconds(60)),
                 sessions: sessions)
         }
         // The engine emits exactly one token before its "length" terminal, so a

--- a/provider-swift/Tests/ProviderCoreTests/MTPBenchmarkTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/MTPBenchmarkTests.swift
@@ -20,6 +20,14 @@ struct MTPBenchmarkTests {
         }
     }
 
+    @Test("engine metrics preserve the target verification mode")
+    func verificationModeProjection() {
+        var engineMetrics = CBv2MTPMetrics()
+        engineMetrics.verificationMode = .rectangular
+        let projected = MTPBenchmarkMetrics(engineMetrics: engineMetrics)
+        #expect(projected.verificationMode == "rectangular")
+    }
+
     @Test("artifact inspection records immutable config and shard provenance")
     func artifactInspection() throws {
         let root = FileManager.default.temporaryDirectory
@@ -227,7 +235,7 @@ struct MTPBenchmarkTests {
             adaptiveDraftingExpected: true,
             allowedSkipReasons: [],
             expectation: exactExpectation)
-        #expect(MTPBenchmarkMTPExpectation.m5HardwareSafetyGate
+        #expect(MTPBenchmarkMTPExpectation.legacyM5HardwareSafetyGate
             .matchesInactiveReason(reason))
     }
 
@@ -235,7 +243,7 @@ struct MTPBenchmarkTests {
     func expectedInactiveReportSerialization() throws {
         let artifact = testArtifact()
         let reason = "rectangular MTP verification is disabled on Apple M5 Max: target-only and [B, 1+k] target argmax parity is not certified"
-        let expectation = MTPBenchmarkMTPExpectation.m5HardwareSafetyGate
+        let expectation = MTPBenchmarkMTPExpectation.legacyM5HardwareSafetyGate
         let report = MTPBenchmarkReport(
             runFingerprint: "inactive-unit-test",
             purpose: .rawParityStress,
@@ -531,7 +539,7 @@ struct MTPBenchmarkTests {
                     modes: [.targetOnly],
                     maxTokensPerRow: 1,
                     purpose: .productionPerformance,
-                    mtpExpectation: .m5HardwareSafetyGate,
+                    mtpExpectation: .legacyM5HardwareSafetyGate,
                     stopPolicy: .production(tokenIDs: [9]),
                     deadline: .seconds(2)),
                 sessions: sessions)

--- a/provider-swift/Tests/ProviderCoreTests/MTPBenchmarkTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/MTPBenchmarkTests.swift
@@ -414,6 +414,60 @@ struct MTPBenchmarkTests {
             adaptiveDraftingExpected: true,
             allowedSkipReasons: [])
 
+        // Regression: a requested depth clamped to a SMALLER POSITIVE depth
+        // records only positive selections. The validator must not demand
+        // depth-zero selections in that case (found by the real M4 matrix at
+        // B=4 with fixed L=3 clamping to k=1).
+        let positiveClamp = MTPBenchmarkMetrics(
+            active: true,
+            verificationMode: "automatic",
+            maxAutomaticRectangularTokens: 8,
+            rectangularVerificationRounds: 6,
+            serialVerificationRounds: 0,
+            selectedDepth: 1,
+            decodeRowBucket: 4,
+            rounds: 6,
+            proposedTokens: 6,
+            depthSelections: ["1": 6],
+            controllerFallbacks: ["automatic_rectangular_limit": 6],
+            costInputs: [.init(
+                decodeRowBucket: 4,
+                draftDepth: 1,
+                sampleCount: 6)])
+        try MTPBenchmarkRunner.validateMetrics(
+            positiveClamp,
+            mode: try MTPBenchmarkMode.fixed(verificationWidth: 3),
+            batchSize: 4,
+            adaptiveDraftingExpected: true,
+            allowedSkipReasons: [])
+
+        // A positive cost input whose bucket * (depth + 1) exceeds the cap
+        // proves work escaped the envelope and must fail even with the
+        // fallback reason recorded.
+        #expect(throws: MTPBenchmarkError.self) {
+            try MTPBenchmarkRunner.validateMetrics(
+                MTPBenchmarkMetrics(
+                    active: true,
+                    verificationMode: "automatic",
+                    maxAutomaticRectangularTokens: 8,
+                    rectangularVerificationRounds: 2,
+                    serialVerificationRounds: 0,
+                    selectedDepth: 1,
+                    decodeRowBucket: 8,
+                    rounds: 2,
+                    proposedTokens: 2,
+                    depthSelections: ["1": 2],
+                    controllerFallbacks: ["automatic_rectangular_limit": 2],
+                    costInputs: [.init(
+                        decodeRowBucket: 8,
+                        draftDepth: 1,
+                        sampleCount: 2)]),
+                mode: mode,
+                batchSize: 8,
+                adaptiveDraftingExpected: true,
+                allowedSkipReasons: [])
+        }
+
         #expect(throws: MTPBenchmarkError.self) {
             try MTPBenchmarkRunner.validateMetrics(
                 MTPBenchmarkMetrics(
@@ -426,6 +480,53 @@ struct MTPBenchmarkTests {
                     controllerFallbacks: ["automatic_rectangular_limit": 4]),
                 mode: mode,
                 batchSize: 4,
+                adaptiveDraftingExpected: true,
+                allowedSkipReasons: [])
+        }
+    }
+
+    @Test("adaptive accepts certified within-cap behavior when the cap forbids drafting")
+    func adaptiveAutomaticCapValidation() throws {
+        // B=8 with cap 8: even depth one exceeds the cap, so zero drafting
+        // with only depth-zero selections is the correct outcome.
+        try MTPBenchmarkRunner.validateMetrics(
+            MTPBenchmarkMetrics(
+                active: true,
+                verificationMode: "automatic",
+                maxAutomaticRectangularTokens: 8,
+                rectangularVerificationRounds: 0,
+                serialVerificationRounds: 0,
+                selectedDepth: 0,
+                decodeRowBucket: 8,
+                depthSelections: ["0": 4],
+                controllerFallbacks: ["warmup": 4]),
+            mode: .adaptive,
+            batchSize: 8,
+            adaptiveDraftingExpected: true,
+            allowedSkipReasons: [])
+
+        // Late-drain drafting at a smaller bucket stays acceptable only while
+        // rectangular and inside the cap; serial rounds must fail.
+        #expect(throws: MTPBenchmarkError.self) {
+            try MTPBenchmarkRunner.validateMetrics(
+                MTPBenchmarkMetrics(
+                    active: true,
+                    verificationMode: "automatic",
+                    maxAutomaticRectangularTokens: 8,
+                    rectangularVerificationRounds: 1,
+                    serialVerificationRounds: 1,
+                    selectedDepth: 1,
+                    decodeRowBucket: 4,
+                    rounds: 2,
+                    proposedTokens: 2,
+                    depthSelections: ["0": 2, "1": 2],
+                    controllerFallbacks: ["automatic_rectangular_limit": 2],
+                    costInputs: [.init(
+                        decodeRowBucket: 4,
+                        draftDepth: 1,
+                        sampleCount: 2)]),
+                mode: .adaptive,
+                batchSize: 8,
                 adaptiveDraftingExpected: true,
                 allowedSkipReasons: [])
         }

--- a/provider-swift/Tests/ProviderCoreTests/MTPBenchmarkTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/MTPBenchmarkTests.swift
@@ -1010,6 +1010,35 @@ struct MTPBenchmarkTests {
         }
     }
 
+    @Test("production stop terminal must not exceed maxTokens")
+    func stopTerminalMustNotOvershoot() async throws {
+        let artifact = testArtifact()
+        let sessions = MTPBenchmarkSessionFactory { _, _ in
+            MTPBenchmarkSession(engine: OvershootStopEngine(stopToken: 9)) { .inactive }
+        }
+        // The engine emits two tokens (7, then EOS 9) against a budget of 1:
+        // a valid stop membership that still violates the OpenAI-visible
+        // max-token limit and must be rejected.
+        do {
+            _ = try await MTPBenchmarkRunner.run(
+                target: artifact,
+                assistant: artifact,
+                hardware: testHardware(),
+                configuration: MTPBenchmarkConfiguration(
+                    prompts: [.init(name: "prompt", tokenIDs: [1])],
+                    batchSizes: [1],
+                    modes: [.targetOnly],
+                    maxTokensPerRow: 1,
+                    purpose: .productionCorrectness,
+                    stopPolicy: .production(tokenIDs: [9]),
+                    deadline: .seconds(2)),
+                sessions: sessions)
+            Issue.record("benchmark certified a stop terminal past maxTokens")
+        } catch let error as MTPBenchmarkError {
+            #expect(error.description.contains("production terminal within maxTokens"))
+        }
+    }
+
     @Test("production length terminal must reach maxTokens")
     func lengthTerminalMustReachMaxTokens() async throws {
         let artifact = testArtifact()
@@ -1237,6 +1266,32 @@ private final class SuccessfulLengthEngine: CBv2Engine, @unchecked Sendable {
             activeTokens: 0)
     }
 
+    func shutdown() async {}
+}
+
+/// Emits two tokens ending in the configured stop token and finishes with
+/// `.stop` — an overshoot fixture for the production budget bound.
+private final class OvershootStopEngine: CBv2Engine, @unchecked Sendable {
+    private let stopToken: Int
+
+    init(stopToken: Int) {
+        self.stopToken = stopToken
+    }
+
+    func submit(_ request: CBv2Request) throws -> AsyncStream<CBv2Event> {
+        AsyncStream { continuation in
+            continuation.yield(.delta(text: "x", tokens: [7, stopToken], logprobs: nil))
+            continuation.yield(.finished(
+                reason: .stop,
+                usage: CBv2Usage(
+                    promptTokens: request.promptTokens.count,
+                    completionTokens: 2)))
+            continuation.finish()
+        }
+    }
+
+    func cancel(_: CBv2RequestID) {}
+    func capacity() -> CBv2CapacitySnapshot { emptyCapacity() }
     func shutdown() async {}
 }
 

--- a/provider-swift/Tests/ProviderCoreTests/MTPBenchmarkTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/MTPBenchmarkTests.swift
@@ -418,6 +418,8 @@ struct MTPBenchmarkTests {
         // records only positive selections. The validator must not demand
         // depth-zero selections in that case (found by the real M4 matrix at
         // B=4 with fixed L=3 clamping to k=1).
+        // No cost inputs on purpose: the controller refuses attribution when
+        // the finalized depth differs from its requested fixed depth.
         let positiveClamp = MTPBenchmarkMetrics(
             active: true,
             verificationMode: "automatic",
@@ -429,11 +431,7 @@ struct MTPBenchmarkTests {
             rounds: 6,
             proposedTokens: 6,
             depthSelections: ["1": 6],
-            controllerFallbacks: ["automatic_rectangular_limit": 6],
-            costInputs: [.init(
-                decodeRowBucket: 4,
-                draftDepth: 1,
-                sampleCount: 6)])
+            controllerFallbacks: ["automatic_rectangular_limit": 6])
         try MTPBenchmarkRunner.validateMetrics(
             positiveClamp,
             mode: try MTPBenchmarkMode.fixed(verificationWidth: 3),

--- a/provider-swift/Tests/ProviderCoreTests/MTPConfigTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/MTPConfigTests.swift
@@ -1,0 +1,240 @@
+// Copyright © 2026 Eigen Labs.
+//
+// MTP config + hygiene surface (Gemma 4 MTP plan §4 D5): the `[backend]`
+// `mtp` / `mtp_drafter_path` TOML keys, the `mtp` beta-feature registry
+// entry (`darkbloom beta enable mtp` is registry-driven, zero CLI code),
+// and the `gemma4_assistant` supported-set carve-out (a hand-downloaded
+// drafter checkpoint must never be advertised as a servable chat model).
+
+import Testing
+
+@testable import ProviderCore
+
+// MARK: - TOML keys
+
+@Suite("MTP config keys")
+struct MTPConfigKeyTests {
+
+    @Test("absent keys default to mtp=false, no drafter path")
+    func defaultsWhenAbsent() {
+        let config = ConfigManager.parse(
+            """
+            [provider]
+            name = "test-provider"
+
+            [backend]
+            port = 8100
+            """)
+
+        #expect(config.backend.mtp == false)
+        #expect(config.backend.mtpDrafterPath == nil)
+    }
+
+    @Test("present keys decode")
+    func decodesPresentKeys() {
+        let config = ConfigManager.parse(
+            """
+            [provider]
+            name = "test-provider"
+
+            [backend]
+            mtp = true
+            mtp_drafter_path = "/opt/drafters/gemma4-assistant-4bit"
+            """)
+
+        #expect(config.backend.mtp == true)
+        #expect(config.backend.mtpDrafterPath == "/opt/drafters/gemma4-assistant-4bit")
+    }
+
+    @Test("mtp works without a drafter path (fleet spec_dec path)")
+    func mtpWithoutPath() {
+        let config = ConfigManager.parse(
+            """
+            [provider]
+            name = "test-provider"
+
+            [backend]
+            mtp = true
+            """)
+
+        #expect(config.backend.mtp == true)
+        #expect(config.backend.mtpDrafterPath == nil)
+    }
+
+    // ConfigManager.parse falls back to a full default config on any decode
+    // failure (documented behavior: a malformed provider.toml must never
+    // brick a provider) — so a wrongly-typed value yields the safe default
+    // (MTP off), never a crash or a half-parsed config.
+    @Test("wrongly-typed mtp value falls back to defaults (off)")
+    func invalidMTPValueFallsBack() {
+        let config = ConfigManager.parse(
+            """
+            [provider]
+            name = "test-provider"
+
+            [backend]
+            mtp = "yes"
+            """)
+
+        #expect(config.backend.mtp == false)
+        #expect(config.backend.mtpDrafterPath == nil)
+    }
+
+    @Test("wrongly-typed mtp_drafter_path falls back to defaults")
+    func invalidDrafterPathFallsBack() {
+        let config = ConfigManager.parse(
+            """
+            [provider]
+            name = "test-provider"
+
+            [backend]
+            mtp = true
+            mtp_drafter_path = 42
+            """)
+
+        #expect(config.backend.mtp == false)
+        #expect(config.backend.mtpDrafterPath == nil)
+    }
+
+    @Test("serialization round-trips both keys")
+    func serializationRoundTrips() {
+        let original = ProviderConfig(
+            provider: ProviderSettings(name: "test-provider"),
+            backend: BackendSettings(mtp: true, mtpDrafterPath: "/tmp/drafter"),
+            coordinator: CoordinatorSettings()
+        )
+
+        let toml = ConfigManager.serialize(original)
+        let decoded = ConfigManager.parse(toml)
+
+        #expect(toml.contains("mtp = true"))
+        #expect(toml.contains("mtp_drafter_path"))
+        #expect(decoded.backend.mtp == true)
+        #expect(decoded.backend.mtpDrafterPath == "/tmp/drafter")
+    }
+
+    @Test("nil drafter path is not emitted")
+    func nilPathNotEmitted() {
+        let original = ProviderConfig(
+            provider: ProviderSettings(name: "test-provider"),
+            backend: BackendSettings(),
+            coordinator: CoordinatorSettings()
+        )
+
+        let toml = ConfigManager.serialize(original)
+
+        #expect(!toml.contains("mtp_drafter_path"))
+    }
+}
+
+// MARK: - Beta feature
+
+@Suite("MTP beta feature")
+struct MTPBetaFeatureTests {
+
+    private func freshConfig() -> ProviderConfig {
+        ProviderConfig(
+            provider: ProviderSettings(name: "test-provider"),
+            backend: BackendSettings(),
+            coordinator: CoordinatorSettings()
+        )
+    }
+
+    @Test("registry exposes mtp, restart-required, default off")
+    func registryEntry() throws {
+        let feature = try #require(BetaFeatures.feature(id: "mtp"))
+        #expect(feature.id == "mtp")
+        #expect(feature.requiresRestart == true)
+        #expect(feature.isEnabled(in: freshConfig()) == false)
+        // Case-insensitive lookup, like every other beta id.
+        #expect(BetaFeatures.feature(id: "MTP")?.id == "mtp")
+    }
+
+    @Test("apply toggles config.backend.mtp both ways")
+    func applyTogglesField() {
+        let feature = BetaFeatures.feature(id: "mtp")!
+        var config = freshConfig()
+
+        feature.apply(true, to: &config)
+        #expect(config.backend.mtp == true)
+        #expect(feature.isEnabled(in: config) == true)
+        #expect(BetaFeatures.enabledIDs(in: config) == ["mtp"])
+
+        feature.apply(false, to: &config)
+        #expect(config.backend.mtp == false)
+        #expect(feature.isEnabled(in: config) == false)
+        #expect(BetaFeatures.enabledIDs(in: config).isEmpty)
+    }
+
+    @Test("apply only mutates its mapped field")
+    func applyIsScoped() {
+        let feature = BetaFeatures.feature(id: "mtp")!
+        var config = freshConfig()
+        let before = config
+
+        feature.apply(true, to: &config)
+
+        #expect(config.backend.kvQuant == before.backend.kvQuant)
+        #expect(config.backend.mtpDrafterPath == before.backend.mtpDrafterPath)
+        #expect(config.backend.port == before.backend.port)
+        #expect(config.provider == before.provider)
+        #expect(config.coordinator == before.coordinator)
+    }
+
+    // `darkbloom beta enable mtp` = apply(true) + ConfigManager.save; the
+    // daemon reads the TOML back on restart. This round-trip is the whole
+    // enable path, minus the file I/O.
+    @Test("toggle survives a TOML round-trip")
+    func roundTripsThroughTOML() {
+        let feature = BetaFeatures.feature(id: "mtp")!
+        var config = freshConfig()
+        feature.apply(true, to: &config)
+
+        let toml = ConfigManager.serialize(config)
+        let decoded = ConfigManager.parse(toml)
+
+        #expect(toml.contains("mtp = true"))
+        #expect(feature.isEnabled(in: decoded) == true)
+    }
+}
+
+// MARK: - Supported-set drafter carve-out
+
+@Suite("EngineV2 supported set: gemma4_assistant carve-out")
+struct MTPSupportedModelsTests {
+
+    @Test("gemma4_assistant is never a servable chat model")
+    func assistantExcluded() {
+        #expect(EngineV2SupportedModels.isSupported(modelType: "gemma4_assistant") == false)
+        // Same normalization (trim + lowercase) as every other type check.
+        #expect(EngineV2SupportedModels.isSupported(modelType: " GEMMA4_ASSISTANT ") == false)
+    }
+
+    @Test("the rest of the gemma4 prefix family stays supported")
+    func gemma4FamilyStillSupported() {
+        #expect(EngineV2SupportedModels.isSupported(modelType: "gemma4") == true)
+        #expect(EngineV2SupportedModels.isSupported(modelType: "gemma4_text") == true)
+        #expect(EngineV2SupportedModels.isSupported(modelType: "gpt_oss") == true)
+        // Non-CBv2 families still fail closed.
+        #expect(EngineV2SupportedModels.isSupported(modelType: "gemma3") == false)
+        #expect(EngineV2SupportedModels.isSupported(modelType: nil) == false)
+    }
+
+    @Test("partition drops the drafter, keeps its targets")
+    func partitionExcludesDrafter() {
+        let models = [
+            ModelInfo(
+                id: "gemma-4-26b-qat-4bit", modelType: "gemma4",
+                sizeBytes: 1 << 30, estimatedMemoryGb: 1.2),
+            ModelInfo(
+                id: "gemma-4-26b-assistant-4bit", modelType: "gemma4_assistant",
+                sizeBytes: 236_124_704, estimatedMemoryGb: 0.3),
+            ModelInfo(
+                id: "gemma-4-26b-text", modelType: "gemma4_text",
+                sizeBytes: 1 << 30, estimatedMemoryGb: 1.2),
+        ]
+        let split = EngineV2SupportedModels.partition(models)
+        #expect(split.supported.map(\.id) == ["gemma-4-26b-qat-4bit", "gemma-4-26b-text"])
+        #expect(split.unsupported.map(\.id) == ["gemma-4-26b-assistant-4bit"])
+    }
+}

--- a/provider-swift/Tests/ProviderCoreTests/MTPConfigTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/MTPConfigTests.swift
@@ -14,6 +14,22 @@ import Testing
 
 @Suite("MTP config keys")
 struct MTPConfigKeyTests {
+    @Test func automaticVerificationPolicyUsesConservativeGenerationBounds() {
+        #expect(MTPAutomaticVerificationPolicy.maxRectangularTokens(chipName: "Apple M1 Max") == 4)
+        #expect(MTPAutomaticVerificationPolicy.maxRectangularTokens(chipName: "Apple M2 Ultra") == 4)
+        #expect(MTPAutomaticVerificationPolicy.maxRectangularTokens(chipName: "Apple M3 Pro") == 8)
+        #expect(MTPAutomaticVerificationPolicy.maxRectangularTokens(chipName: "Apple M4 Max") == 8)
+        #expect(MTPAutomaticVerificationPolicy.maxRectangularTokens(chipName: "Apple M5") == 8)
+        #expect(MTPAutomaticVerificationPolicy.maxRectangularTokens(chipName: "Unknown") == 4)
+        #expect(MTPAutomaticVerificationPolicy.maxRectangularTokens(
+            environment: ["DARKBLOOM_MTP_MAX_RECTANGULAR_TOKENS": "12"],
+            chipName: "Apple M1 Max") == 4)
+        #expect(MTPAutomaticVerificationPolicy.maxRectangularTokens(
+            environment: ["DARKBLOOM_MTP_MAX_RECTANGULAR_TOKENS": "6"],
+            chipName: "Apple M5 Max") == 6)
+        #expect(MTPAutomaticVerificationPolicy.initialDraftTokens == 1)
+    }
+
 
     @Test("absent keys default to mtp=false, no drafter path")
     func defaultsWhenAbsent() {

--- a/provider-swift/Tests/ProviderCoreTests/MTPConfigTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/MTPConfigTests.swift
@@ -198,22 +198,28 @@ struct MTPBetaFeatureTests {
     }
 }
 
-// MARK: - Supported-set drafter carve-out
+// MARK: - Closed Gemma target namespace
 
-@Suite("EngineV2 supported set: gemma4_assistant carve-out")
+@Suite("EngineV2 supported set: closed Gemma target namespace")
 struct MTPSupportedModelsTests {
 
-    @Test("gemma4_assistant is never a servable chat model")
-    func assistantExcluded() {
-        #expect(EngineV2SupportedModels.isSupported(modelType: "gemma4_assistant") == false)
-        // Same normalization (trim + lowercase) as every other type check.
-        #expect(EngineV2SupportedModels.isSupported(modelType: " GEMMA4_ASSISTANT ") == false)
+    @Test("assistant namespace variants are never servable chat models")
+    func assistantVariantsExcluded() {
+        for type in [
+            "gemma4_assistant", " GEMMA4_ASSISTANT ",
+            "gemma4_assistant_v2", "gemma4_text_assistant",
+            "gemma4_mtp", "gemma4-drafter",
+        ] {
+            #expect(!EngineV2SupportedModels.isSupported(modelType: type), "type=\(type)")
+            #expect(!EngineV2SupportedModels.isGemma4Target(modelType: type), "type=\(type)")
+        }
     }
 
-    @Test("the rest of the gemma4 prefix family stays supported")
-    func gemma4FamilyStillSupported() {
+    @Test("only official Gemma target config types are supported")
+    func officialGemmaTargetsSupported() {
         #expect(EngineV2SupportedModels.isSupported(modelType: "gemma4") == true)
         #expect(EngineV2SupportedModels.isSupported(modelType: "gemma4_text") == true)
+        #expect(EngineV2SupportedModels.isGemma4Target(modelType: " GEMMA4_TEXT "))
         #expect(EngineV2SupportedModels.isSupported(modelType: "gpt_oss") == true)
         // Non-CBv2 families still fail closed.
         #expect(EngineV2SupportedModels.isSupported(modelType: "gemma3") == false)

--- a/provider-swift/Tests/ProviderCoreTests/MTPProductionLiveFixtures.swift
+++ b/provider-swift/Tests/ProviderCoreTests/MTPProductionLiveFixtures.swift
@@ -1,0 +1,241 @@
+import Foundation
+import MLX
+import Testing
+
+@testable import ProviderBenchmark
+@testable import ProviderCore
+
+enum MTPProductionLiveFixtures {
+    static let liveEnvironment = "DARKBLOOM_LIVE_MLX_MTP"
+    static let supervisorEnvironment = "DARKBLOOM_MTP_EXTERNAL_SUPERVISOR"
+    static let supervisorContract = "run-mtp-benchmark-v1"
+    static let defaultTargetID = "mlx-community/gemma-4-26B-A4B-it-qat-4bit"
+    static let defaultAssistantID = "mlx-community/gemma-4-26B-A4B-it-qat-assistant-4bit"
+
+    static var enabled: Bool {
+        LiveInferenceFixtures.gemmaTestsEnabled
+            && truthy(environment[liveEnvironment])
+            && environment[supervisorEnvironment] == supervisorContract
+    }
+
+    static let disabledReason = Comment(
+        rawValue: "run through scripts/run-mtp-benchmark.py; synchronous MLX work cannot be safely cancelled by a Swift task deadline and requires its external process-group timeout")
+
+    static var targetID: String {
+        environment["DARKBLOOM_MTP_TARGET_ID"] ?? defaultTargetID
+    }
+
+    static var assistantID: String {
+        environment["DARKBLOOM_MTP_ASSISTANT_ID"] ?? defaultAssistantID
+    }
+
+    static func loadBundle() async throws -> MTPProductionModelBundle {
+        guard LiveInferenceFixtures.ensureMetallibColocated() != nil else {
+            throw MTPProductionLivePrerequisiteError.missingMetallib
+        }
+        LiveInferenceFixtures.applyMemoryBudget(maxBytes: 64 * 1024 * 1024 * 1024)
+        let target = try targetSnapshot()
+        let assistant = try assistantSnapshot()
+        return try await MTPProductionModelBundle.load(
+            targetID: targetID,
+            targetDirectory: target,
+            assistantID: assistantID,
+            assistantDirectory: assistant)
+    }
+
+    static func targetSnapshot() throws -> URL {
+        try requiredSnapshot(
+            modelID: targetID, pathEnvironment: "DARKBLOOM_MTP_TARGET_PATH")
+    }
+
+    static func assistantSnapshot() throws -> URL {
+        try requiredSnapshot(
+            modelID: assistantID, pathEnvironment: "DARKBLOOM_MTP_ASSISTANT_PATH")
+    }
+
+    static func prompts(bundle: MTPProductionModelBundle) throws -> [MTPBenchmarkPrompt] {
+        try [
+            bundle.tokenizeChat(
+                name: "code",
+                userPrompt: "Write a Swift function that returns the larger of two integers."),
+            bundle.tokenizeChat(
+                name: "reasoning",
+                userPrompt: "A train travels 120 km in 90 minutes. State its average speed in km/h."),
+            bundle.tokenizeChat(
+                name: "arithmetic",
+                userPrompt: "What is 17 multiplied by 23? Reply with only the number."),
+        ]
+    }
+
+    static func toolPrompt(bundle: MTPProductionModelBundle) throws -> MTPBenchmarkPrompt {
+        let tools: [[String: any Sendable]] = [[
+            "type": "function",
+            "function": [
+                "name": "lookup_weather",
+                "description": "Look up current weather for a city.",
+                "parameters": [
+                    "type": "object",
+                    "properties": [
+                        "city": ["type": "string"] as [String: any Sendable]
+                    ] as [String: any Sendable],
+                    "required": ["city"],
+                ] as [String: any Sendable],
+            ] as [String: any Sendable],
+        ]]
+        return try bundle.tokenize(
+            name: "tool",
+            messages: [["role": "user", "content": "What is the weather in Paris? Use the tool."]],
+            tools: tools)
+    }
+
+    static func benchmarkOutput() throws -> MTPBenchmarkReportDestination {
+        guard let value = environment["DARKBLOOM_MTP_BENCHMARK_OUTPUT"], !value.isEmpty else {
+            throw MTPProductionLivePrerequisiteError.missingBenchmarkOutput
+        }
+        guard let runDirectoryValue = environment["DARKBLOOM_MTP_BENCHMARK_RUN_DIRECTORY"],
+              let expectedDeviceValue = environment["DARKBLOOM_MTP_BENCHMARK_RUN_DEVICE"],
+              let expectedInodeValue = environment["DARKBLOOM_MTP_BENCHMARK_RUN_INODE"],
+              let expectedDevice = UInt64(expectedDeviceValue),
+              let expectedInode = UInt64(expectedInodeValue)
+        else {
+            throw MTPProductionLivePrerequisiteError.missingSecureOutputContract
+        }
+        let output = URL(fileURLWithPath: value).standardizedFileURL
+        let runDirectory = URL(fileURLWithPath: runDirectoryValue).standardizedFileURL
+        guard output.deletingLastPathComponent() == runDirectory else {
+            throw MTPProductionLivePrerequisiteError.unsafeBenchmarkOutput(output.path)
+        }
+        let systemTemp = FileManager.default.temporaryDirectory
+            .resolvingSymlinksInPath().standardizedFileURL
+        let package = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+            .standardizedFileURL
+        let repoTemp = package.lastPathComponent == "provider-swift"
+            ? package.deletingLastPathComponent().appendingPathComponent("tmp", isDirectory: true)
+            : package.appendingPathComponent("tmp", isDirectory: true)
+        let resolvedRoots = [systemTemp, repoTemp.resolvingSymlinksInPath().standardizedFileURL]
+        guard resolvedRoots.contains(where: { isDescendant(runDirectory, of: $0) }) else {
+            throw MTPProductionLivePrerequisiteError.unsafeBenchmarkOutput(output.path)
+        }
+        return try MTPBenchmarkReportDestination.open(
+            directoryURL: runDirectory,
+            fileName: output.lastPathComponent,
+            expectedDevice: expectedDevice,
+            expectedInode: expectedInode)
+    }
+
+    static var benchmarkMaxTokens: Int {
+        environment["DARKBLOOM_MTP_BENCHMARK_MAX_TOKENS"].flatMap(Int.init) ?? 64
+    }
+
+    static var benchmarkDeadline: Duration {
+        let seconds = environment["DARKBLOOM_MTP_BENCHMARK_DEADLINE_SECONDS"]
+            .flatMap(Int.init) ?? 3600
+        return .seconds(max(1, seconds))
+    }
+
+    static var benchmarkPurpose: MTPBenchmarkPurpose {
+        switch environment["DARKBLOOM_MTP_BENCHMARK_MODE"] {
+        case "production-performance": return .productionPerformance
+        case "production-correctness": return .productionCorrectness
+        default: return .rawParityStress
+        }
+    }
+
+    static func benchmarkStopPolicy(
+        bundle: MTPProductionModelBundle
+    ) -> MTPBenchmarkStopPolicy {
+        benchmarkPurpose == .rawParityStress
+            ? .rawFixedLength
+            : .production(tokenIDs: bundle.productionStopTokenIDs)
+    }
+
+    static var benchmarkWarmupIterations: Int {
+        max(0, environment["DARKBLOOM_MTP_BENCHMARK_WARMUP"].flatMap(Int.init) ?? 0)
+    }
+
+    static var benchmarkRepetitions: Int {
+        max(1, environment["DARKBLOOM_MTP_BENCHMARK_REPETITIONS"].flatMap(Int.init) ?? 1)
+    }
+
+    static var benchmarkModeOrderSeed: UInt64 {
+        environment["DARKBLOOM_MTP_BENCHMARK_SEED"].flatMap(UInt64.init) ?? 0x4d545032
+    }
+
+    static func benchmarkRunFingerprint() throws -> String {
+        guard let value = environment["DARKBLOOM_MTP_BENCHMARK_RUN_FINGERPRINT"],
+              !value.isEmpty
+        else { throw MTPProductionLivePrerequisiteError.missingRunFingerprint }
+        guard environment["DARKBLOOM_MTP_BENCHMARK_BUILD_CONFIGURATION"]
+                == MTPBenchmarkBuildConfiguration.current.rawValue
+        else { throw MTPProductionLivePrerequisiteError.buildConfigurationMismatch }
+        return value
+    }
+
+    private static var environment: [String: String] {
+        ProcessInfo.processInfo.environment
+    }
+
+    private static func truthy(_ value: String?) -> Bool {
+        guard let value else { return false }
+        return ["1", "true", "yes", "on"].contains(value.lowercased())
+    }
+
+    private static func isDescendant(_ path: URL, of root: URL) -> Bool {
+        let normalizedPath = path.standardizedFileURL.path
+        let normalizedRoot = root.standardizedFileURL.path
+        return normalizedPath == normalizedRoot
+            || normalizedPath.hasPrefix(normalizedRoot + "/")
+    }
+
+    private static func requiredSnapshot(
+        modelID: String,
+        pathEnvironment: String
+    ) throws -> URL {
+        if let path = environment[pathEnvironment], !path.isEmpty {
+            let url = URL(fileURLWithPath: path).resolvingSymlinksInPath()
+            guard FileManager.default.fileExists(
+                atPath: url.appendingPathComponent("config.json").path)
+            else {
+                throw MTPProductionLivePrerequisiteError.incompleteSnapshot(
+                    modelID: modelID, path: url.path)
+            }
+            return url
+        }
+        guard let url = ModelScanner.resolveLocalPath(modelID: modelID) else {
+            throw MTPProductionLivePrerequisiteError.modelNotInCache(modelID)
+        }
+        return url.resolvingSymlinksInPath()
+    }
+}
+
+enum MTPProductionLivePrerequisiteError: Error, CustomStringConvertible {
+    case missingMetallib
+    case modelNotInCache(String)
+    case incompleteSnapshot(modelID: String, path: String)
+    case missingBenchmarkOutput
+    case missingSecureOutputContract
+    case missingRunFingerprint
+    case buildConfigurationMismatch
+    case unsafeBenchmarkOutput(String)
+
+    var description: String {
+        switch self {
+        case .missingMetallib:
+            return "mlx.metallib is unavailable; run scripts/fetch-metallib.sh debug"
+        case .modelNotInCache(let id):
+            return "required cached model is missing: \(id); this test never downloads"
+        case .incompleteSnapshot(let id, let path):
+            return "cached snapshot for \(id) is incomplete at \(path)"
+        case .missingBenchmarkOutput:
+            return "DARKBLOOM_MTP_BENCHMARK_OUTPUT must name the supervised run report"
+        case .missingSecureOutputContract:
+            return "the supervised benchmark run-directory descriptor identity is missing"
+        case .missingRunFingerprint:
+            return "DARKBLOOM_MTP_BENCHMARK_RUN_FINGERPRINT is required"
+        case .buildConfigurationMismatch:
+            return "benchmark build configuration does not match the compiled Swift target"
+        case .unsafeBenchmarkOutput(let path):
+            return "refusing tracked MTP benchmark output path: \(path)"
+        }
+    }
+}

--- a/provider-swift/Tests/ProviderCoreTests/MTPProductionLiveFixtures.swift
+++ b/provider-swift/Tests/ProviderCoreTests/MTPProductionLiveFixtures.swift
@@ -143,7 +143,7 @@ enum MTPProductionLiveFixtures {
 
     static var benchmarkMTPExpectation: MTPBenchmarkMTPExpectation {
         truthy(environment["DARKBLOOM_MTP_BENCHMARK_EXPECT_MTP_INACTIVE"])
-            ? .m5HardwareSafetyGate
+            ? .legacyM5HardwareSafetyGate
             : .active
     }
 

--- a/provider-swift/Tests/ProviderCoreTests/MTPProductionLiveFixtures.swift
+++ b/provider-swift/Tests/ProviderCoreTests/MTPProductionLiveFixtures.swift
@@ -141,6 +141,12 @@ enum MTPProductionLiveFixtures {
         }
     }
 
+    static var benchmarkMTPExpectation: MTPBenchmarkMTPExpectation {
+        truthy(environment["DARKBLOOM_MTP_BENCHMARK_EXPECT_MTP_INACTIVE"])
+            ? .m5HardwareSafetyGate
+            : .active
+    }
+
     static func benchmarkStopPolicy(
         bundle: MTPProductionModelBundle
     ) -> MTPBenchmarkStopPolicy {

--- a/provider-swift/Tests/ProviderCoreTests/MTPResliceFallbackTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/MTPResliceFallbackTests.swift
@@ -1,0 +1,565 @@
+import Foundation
+import Dispatch
+import MLX
+import MLXLMCommon
+import MLXNN
+import Testing
+
+@testable import ProviderCore
+
+private let mtpFloorGiB: UInt64 = 1_073_741_824
+private let mtpFloorPhysical = 64 * mtpFloorGiB
+private let mtpFloorExistingID = "gemma-4-existing"
+private let mtpFloorNewID = "gemma-4-new"
+private let mtpFloorExistingWeightBytes = 15 * mtpFloorGiB
+private let mtpFloorTargetWeightBytes =
+    UnifiedMemoryCap.hardCapBytes(physicalBytes: mtpFloorPhysical)
+    - UnifiedMemoryCap.defaultActivationReserveBytes
+    - (2 * mtpFloorGiB)
+private let mtpFloorNewWeightBytes = mtpFloorTargetWeightBytes - mtpFloorExistingWeightBytes
+
+private struct MTPFloorTokenizer: MLXLMCommon.Tokenizer {
+    func encode(text: String, addSpecialTokens: Bool) -> [Int] { [0] }
+    func decode(tokenIds: [Int], skipSpecialTokens: Bool) -> String { "" }
+    func convertTokenToId(_ token: String) -> Int? { nil }
+    func convertIdToToken(_ id: Int) -> String? { nil }
+    var bosToken: String? { nil }
+    var eosToken: String? { nil }
+    var unknownToken: String? { nil }
+    func applyChatTemplate(
+        messages: [[String: any Sendable]],
+        tools: [[String: any Sendable]]?,
+        additionalContext: [String: any Sendable]?
+    ) throws -> [Int] { [0] }
+}
+
+private final class MTPFloorTarget: Module, LanguageModel {
+    func prepare(_ input: LMInput, cache: [KVCache], windowSize: Int?) throws -> PrepareResult {
+        .tokens(input.text)
+    }
+    func newCache(parameters: GenerateParameters?) -> [KVCache] { [] }
+}
+
+private struct MTPFloorProcessor: UserInputProcessor {
+    func prepare(input: UserInput) async throws -> LMInput { throw CancellationError() }
+}
+
+private func mtpFloorContainer() -> ModelContainer {
+    ModelContainer(context: ModelContext(
+        configuration: ModelConfiguration(id: "test/mtp-floor"),
+        model: MTPFloorTarget(),
+        processor: MTPFloorProcessor(),
+        tokenizer: MTPFloorTokenizer()))
+}
+
+private final class MTPFloorEngine: CBv2Engine, @unchecked Sendable {
+    private let lock = NSLock()
+    private var capacityBytes: Int
+    private var capacityUpdates: [Int] = []
+    private let hangs: Bool
+    private var submitted = 0
+    private var continuations: [AsyncStream<CBv2Event>.Continuation] = []
+
+    init(capacityBytes: Int, hangs: Bool = false) {
+        self.capacityBytes = capacityBytes
+        self.hangs = hangs
+    }
+
+    var updates: [Int] { lock.withLock { capacityUpdates } }
+
+    func submit(_ request: CBv2Request) throws -> AsyncStream<CBv2Event> {
+        let (stream, continuation) = AsyncStream<CBv2Event>.makeStream()
+        lock.withLock {
+            submitted += 1
+            if hangs {
+                continuations.append(continuation)
+            } else {
+                continuation.finish()
+            }
+        }
+        return stream
+    }
+    func cancel(_ id: CBv2RequestID) {}
+    func capacity() -> CBv2CapacitySnapshot {
+        lock.withLock {
+            .init(
+                activeRequests: submitted, waitingRequests: 0, kvBytesInUse: 0,
+                kvBytesCapacity: capacityBytes, activeTokens: 0,
+                stepsExecuted: 0)
+        }
+    }
+    func updateKVBytesCapacity(_ bytes: Int) {
+        lock.withLock {
+            capacityBytes = max(0, bytes)
+            capacityUpdates.append(capacityBytes)
+        }
+    }
+    func shutdown() async {
+        let held = lock.withLock { () -> [AsyncStream<CBv2Event>.Continuation] in
+            let held = continuations
+            continuations.removeAll()
+            return held
+        }
+        for continuation in held { continuation.finish() }
+    }
+}
+
+private final class MTPRecoveryEngineFactory: @unchecked Sendable {
+    private let lock = NSLock()
+    private var count = 0
+    private let blockRecovery: Bool
+    private let recoveryStarted = DispatchSemaphore(value: 0)
+    private let recoveryResume = DispatchSemaphore(value: 0)
+
+    init(blockRecovery: Bool = false) {
+        self.blockRecovery = blockRecovery
+    }
+
+    var buildCount: Int { lock.withLock { count } }
+
+    func make(grant: Int) -> any CBv2Engine {
+        let index = lock.withLock { () -> Int in
+            let index = count
+            count += 1
+            return index
+        }
+        if blockRecovery, index == 1 {
+            recoveryStarted.signal()
+            recoveryResume.wait()
+        }
+        return MTPFloorEngine(capacityBytes: grant, hangs: index == 0)
+    }
+
+    func waitForRecoveryStart() -> Bool {
+        recoveryStarted.wait(timeout: .now() + 2) == .success
+    }
+
+    func resumeRecovery() { recoveryResume.signal() }
+}
+
+private final class MTPFloorPrepared: CBv2MTPPreparedCapture {}
+private final class MTPFloorDrafter: CBv2MTPDrafter, @unchecked Sendable {
+    func prepare(rows: [CBv2MTPRowCapture]) -> CBv2MTPPreparedCapture {
+        MTPFloorPrepared()
+    }
+    func draftStep(
+        tokens: MLXArray,
+        hidden: MLXArray,
+        prepared: CBv2MTPPreparedCapture
+    ) -> (tokens: MLXArray, hidden: MLXArray) {
+        (tokens, hidden)
+    }
+}
+
+private final class MTPFloorAssistantLoadCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value = 0
+    var count: Int { lock.withLock { value } }
+    func increment() { lock.withLock { value += 1 } }
+}
+
+private struct MTPFloorAssistantLoader: ProviderMTPAssistantLoading {
+    let counter: MTPFloorAssistantLoadCounter?
+
+    init(counter: MTPFloorAssistantLoadCounter? = nil) {
+        self.counter = counter
+    }
+
+    func loadAndBind(
+        artifact: SpecDecArtifact,
+        target: any LanguageModel
+    ) async throws -> ProviderMTPAssistantHandle {
+        counter?.increment()
+        return ProviderMTPAssistantHandle(
+            owner: NSObject(), drafter: MTPFloorDrafter())
+    }
+}
+
+private func mtpFloorArtifact() throws -> SpecDecArtifact {
+    let directory = FileManager.default.temporaryDirectory
+        .appendingPathComponent("mtp-floor-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    try Data(#"{"model_type":"gemma4_assistant"}"#.utf8)
+        .write(to: directory.appendingPathComponent("config.json"))
+    let weightURL = directory.appendingPathComponent("model.safetensors")
+    try Data(repeating: 0x5a, count: 4096).write(to: weightURL)
+    return try #require(SpecDecStore.inspectLocalArtifact(path: directory.path))
+}
+
+private func mtpFloorSizing(weightsGiB: UInt64) -> SlotSizingSnapshot {
+    mtpFloorSizing(weightsBytes: weightsGiB * mtpFloorGiB)
+}
+
+private func mtpFloorSizing(weightsBytes: UInt64) -> SlotSizingSnapshot {
+    .init(
+        weightsBytes: Int(weightsBytes),
+        fp16KVBytesPerToken: 20_480,
+        maxContextLength: 131_072,
+        defaultMaxTokens: 4096)
+}
+
+private func mtpFloorLoop(
+    models: [ModelInfo] = [],
+    mtpDrafterPath: String? = nil
+) throws -> ProviderLoop {
+    try ProviderLoop(
+        config: ProviderLoopConfig(
+            coordinatorURL: "ws://127.0.0.1:0/ignored",
+            hardware: HardwareInfo(
+                machineModel: "Mac16,5", chipName: "Apple M4 Max",
+                chipFamily: .m4, chipTier: .max,
+                memoryGb: 64, memoryAvailableGb: 60,
+                cpuCores: .init(total: 16, performance: 12, efficiency: 4),
+                gpuCores: 40, memoryBandwidthGbs: 546),
+            models: models,
+            config: ProviderConfig(
+                provider: .init(name: "mtp-floor", memoryReserveGB: 0),
+                backend: .init(
+                    idleTimeoutMins: 0,
+                    maxModelSlots: 3,
+                    mtp: mtpDrafterPath != nil,
+                    mtpDrafterPath: mtpDrafterPath),
+                coordinator: .init(heartbeatIntervalSecs: 60))),
+        purgeLegacyFiles: false,
+        attestationSigner: nil)
+}
+
+private func mtpFloorTargetOnlyGrants() -> [String: Int] {
+    let existing = mtpFloorSizing(weightsBytes: mtpFloorExistingWeightBytes)
+    let newcomer = mtpFloorSizing(weightsBytes: mtpFloorNewWeightBytes)
+    let budget = UnifiedMemoryCap.kvBudgetBytes(
+        physicalBytes: mtpFloorPhysical,
+        residentWeightBytes: UInt64(existing.weightsBytes + newcomer.weightsBytes),
+        configReserveBytes: 0)
+    return EngineV2KVSizing.resliceGrants(
+        existing: [
+            .init(
+                modelId: mtpFloorExistingID,
+                fp16KVBytesPerToken: existing.fp16KVBytesPerToken,
+                maxContextLength: existing.maxContextLength),
+        ],
+        newcomer: .init(
+            modelId: mtpFloorNewID,
+            fp16KVBytesPerToken: newcomer.fp16KVBytesPerToken,
+            maxContextLength: newcomer.maxContextLength),
+        fleetKVBudgetBytes: budget)
+}
+
+@Suite("MTP assistant-only re-slice fallback", .serialized)
+struct MTPResliceFallbackTests {
+    init() {
+        _ = LiveInferenceFixtures.ensureMetallibColocated()
+    }
+
+    @Test("ProviderLoop retries target-only, transfers accounting, and preserves heartbeat truth")
+    func providerLoopTargetSurvivesAssistantFloor() async throws {
+        let artifact = try mtpFloorArtifact()
+        defer { try? FileManager.default.removeItem(at: artifact.directory) }
+        let loop = try mtpFloorLoop()
+        let runtime = EngineV2Runtime()
+        await loop.setEngineV2RuntimeForTesting(runtime)
+        await loop.setEngineV2SlotHooksForTesting(.init(
+            physicalMemoryBytes: mtpFloorPhysical,
+            assistantLoader: MTPFloorAssistantLoader(),
+            makeEngine: { _, grant in MTPFloorEngine(capacityBytes: grant) }))
+
+        let existingSizing = mtpFloorSizing(weightsBytes: mtpFloorExistingWeightBytes)
+        let existingEngine = MTPFloorEngine(capacityBytes: Int(30 * mtpFloorGiB))
+        let existingBridge = EngineV2Bridge(
+            engine: existingEngine,
+            modelId: mtpFloorExistingID,
+            tokenizer: TokenizerHandle(MTPFloorTokenizer()),
+            eosTokenIds: [])
+        await runtime.register(modelId: mtpFloorExistingID, bridge: existingBridge)
+        await loop.installModelSlotForTesting(
+            modelId: mtpFloorExistingID,
+            container: mtpFloorContainer(),
+            tokenizer: TokenizerHandle(MTPFloorTokenizer()),
+            engineV2: existingBridge,
+            sizing: existingSizing,
+            modelType: "gemma4")
+        await loop.reservePendingLoadForTesting(
+            requestID: "pending-load:\(mtpFloorNewID)", bytes: artifact.residentBytes)
+
+        let newcomer = EngineV2NewcomerBox(mtpFloorContainer())
+        let build = try await loop.resliceAndBuildEngineV2BundleForTesting(
+            modelId: mtpFloorNewID,
+            modelType: "gemma4",
+            newcomer: newcomer,
+            tokenizer: TokenizerHandle(MTPFloorTokenizer()),
+            sizing: mtpFloorSizing(weightsBytes: mtpFloorNewWeightBytes),
+            specDecPreparation: .init(
+                artifact: artifact, status: .candidate(artifact)))
+
+        let expected = mtpFloorTargetOnlyGrants()
+        #expect(build.bundle.mtpStatus.reason == .assistantResliceFloor)
+        #expect(!build.bundle.mtpStatus.active)
+        #expect(build.bundle.assistantBytes == 0)
+        #expect(build.sizing.auxiliaryWeightBytes == 0)
+        #expect(newcomer.container != nil)
+        #expect(await loop.outstandingKVReservationBytesForTesting() == 0)
+        #expect(await existingBridge.engineKVBytesCapacity() == expected[mtpFloorExistingID])
+        #expect(await build.bundle.bridge.engineKVBytesCapacity() == expected[mtpFloorNewID])
+        #expect(existingEngine.updates == [expected[mtpFloorExistingID]!])
+
+        let heartbeat = await build.bundle.bridge.backendSlotCapacity()
+        #expect(heartbeat.activeTokenBudgetMax == Int64(expected[mtpFloorNewID]! / 20_480))
+        let sum = UInt64(expected.values.reduce(0, +))
+        let targetBudget = UnifiedMemoryCap.kvBudgetBytes(
+            physicalBytes: mtpFloorPhysical,
+            residentWeightBytes: mtpFloorTargetWeightBytes,
+            configReserveBytes: 0)
+        #expect(sum <= targetBudget)
+
+        await runtime.unregister(modelId: mtpFloorNewID)
+        await build.bundle.bridge.shutdown()
+        build.bundle.releaseAssistant()
+        await existingBridge.shutdown()
+    }
+
+    @Test("Standalone retries target-only and keeps the valid target resident")
+    func standaloneTargetSurvivesAssistantFloor() async throws {
+        let artifact = try mtpFloorArtifact()
+        defer { try? FileManager.default.removeItem(at: artifact.directory) }
+        let server = StandaloneServer(config: .init(maxCachedModels: 3))
+        await server.setV2TestHooksForTesting(.init(
+            physicalMemoryBytes: mtpFloorPhysical,
+            assistantLoader: MTPFloorAssistantLoader(),
+            makeEngine: { _, grant in MTPFloorEngine(capacityBytes: grant) }))
+
+        let existingSizing = mtpFloorSizing(weightsBytes: mtpFloorExistingWeightBytes)
+        let existingEngine = MTPFloorEngine(capacityBytes: Int(30 * mtpFloorGiB))
+        let existingBridge = EngineV2Bridge(
+            engine: existingEngine,
+            modelId: mtpFloorExistingID,
+            tokenizer: TokenizerHandle(MTPFloorTokenizer()),
+            eosTokenIds: [])
+        await server.installSlotForTesting(
+            modelId: mtpFloorExistingID,
+            bridge: existingBridge,
+            container: mtpFloorContainer(),
+            tokenizer: TokenizerHandle(MTPFloorTokenizer()),
+            sizing: existingSizing,
+            modelType: "gemma4")
+        await server.reservePendingLoadForTesting(
+            requestID: "pending-load:\(mtpFloorNewID)", bytes: artifact.residentBytes)
+
+        let newcomer = EngineV2NewcomerBox(mtpFloorContainer())
+        let build = try await server.resliceAndBuildMTPBundleForTesting(
+            modelId: mtpFloorNewID,
+            modelType: "gemma4",
+            newcomer: newcomer,
+            tokenizer: TokenizerHandle(MTPFloorTokenizer()),
+            sizing: mtpFloorSizing(weightsBytes: mtpFloorNewWeightBytes),
+            specDecPreparation: .init(
+                artifact: artifact, status: .candidate(artifact)))
+
+        let expected = mtpFloorTargetOnlyGrants()
+        #expect(build.bundle.mtpStatus.reason == .assistantResliceFloor)
+        #expect(!build.bundle.mtpStatus.active)
+        #expect(build.sizing.auxiliaryWeightBytes == 0)
+        #expect(newcomer.container != nil)
+        #expect(await server.debugOutstandingKVReservationBytes() == 0)
+        #expect(await existingBridge.engineKVBytesCapacity() == expected[mtpFloorExistingID])
+        #expect(await build.bundle.bridge.engineKVBytesCapacity() == expected[mtpFloorNewID])
+        #expect(existingEngine.updates == [expected[mtpFloorExistingID]!])
+
+        await build.bundle.bridge.shutdown()
+        build.bundle.releaseAssistant()
+        await server.stopAndWait()
+    }
+
+    @Test("liveness rebuild revalidates cached artifact and recovers target-only")
+    func recoveryCorruptionFallsBackWithoutUnloadingTarget() async throws {
+        let artifact = try mtpFloorArtifact()
+        defer { try? FileManager.default.removeItem(at: artifact.directory) }
+        let loop = try mtpFloorLoop()
+        let runtime = EngineV2Runtime()
+        let factory = MTPRecoveryEngineFactory()
+        await loop.setEngineV2RuntimeForTesting(runtime)
+        await loop.setEngineV2SlotHooksForTesting(.init(
+            physicalMemoryBytes: mtpFloorPhysical,
+            assistantLoader: MTPFloorAssistantLoader(),
+            makeEngine: { _, grant in factory.make(grant: grant) }))
+
+        let container = mtpFloorContainer()
+        let newcomer = EngineV2NewcomerBox(container)
+        let initial = try await loop.resliceAndBuildEngineV2BundleForTesting(
+            modelId: mtpFloorNewID,
+            modelType: "gemma4",
+            newcomer: newcomer,
+            tokenizer: TokenizerHandle(MTPFloorTokenizer()),
+            sizing: mtpFloorSizing(weightsGiB: 15),
+            specDecPreparation: .init(
+                artifact: artifact, status: .candidate(artifact)))
+        #expect(initial.bundle.mtpStatus.active)
+        #expect(initial.bundle.hasAssistant)
+        await loop.installModelBundleForTesting(
+            modelId: mtpFloorNewID,
+            bundle: initial.bundle,
+            container: container,
+            tokenizer: TokenizerHandle(MTPFloorTokenizer()),
+            sizing: initial.sizing,
+            modelType: "gemma4")
+
+        let oldBridge = initial.bundle.bridge
+        let t0 = ContinuousClock.now
+        _ = await oldBridge.submitTokenized(
+            promptTokens: [1, 2, 3],
+            request: ChatCompletionRequest(
+                model: mtpFloorNewID,
+                messages: [.init(role: "user", content: "hi")]),
+            requestId: "mtp-recovery-wedge")
+        _ = await oldBridge.backendSlotCapacity(now: t0)
+
+        let weightURL = artifact.directory.appendingPathComponent("model.safetensors")
+        var mutated = try Data(contentsOf: weightURL)
+        mutated[mutated.startIndex] ^= 0xff
+        try mutated.write(to: weightURL)
+
+        await loop.recoverWedgedEngineV2SlotsForTesting(
+            now: t0.advanced(by: .seconds(130)))
+
+        let rebuilt = try #require(await loop.slotBridgeForTesting(modelId: mtpFloorNewID))
+        #expect(rebuilt !== oldBridge)
+        #expect(factory.buildCount == 2)
+        let status = await rebuilt.mtpStatusSnapshot()
+        #expect(!status.active)
+        #expect(status.fallbackReason == .localArtifactInvalid)
+        let sizing = try #require(await loop.slotSizingForTesting(modelId: mtpFloorNewID))
+        #expect(sizing.auxiliaryWeightBytes == 0)
+        #expect(sizing.weightsBytes == sizing.targetWeightsBytes)
+        #expect(await runtime.bridge(forModel: mtpFloorNewID) === rebuilt)
+
+        await loop.unloadModel(mtpFloorNewID)
+    }
+
+    @Test("liveness rebuild reuses active assistant while concurrent KV remains reserved")
+    func recoveryReusesAssistantWithoutNewResidency() async throws {
+        let artifact = try mtpFloorArtifact()
+        defer { try? FileManager.default.removeItem(at: artifact.directory) }
+        let counter = MTPFloorAssistantLoadCounter()
+        let factory = MTPRecoveryEngineFactory(blockRecovery: true)
+        let loop = try mtpFloorLoop()
+        let runtime = EngineV2Runtime()
+        await loop.setEngineV2RuntimeForTesting(runtime)
+        await loop.setEngineV2SlotHooksForTesting(.init(
+            physicalMemoryBytes: mtpFloorPhysical,
+            assistantLoader: MTPFloorAssistantLoader(counter: counter),
+            makeEngine: { _, grant in factory.make(grant: grant) }))
+
+        let container = mtpFloorContainer()
+        let initial = try await loop.resliceAndBuildEngineV2BundleForTesting(
+            modelId: mtpFloorNewID,
+            modelType: "gemma4",
+            newcomer: EngineV2NewcomerBox(container),
+            tokenizer: TokenizerHandle(MTPFloorTokenizer()),
+            sizing: mtpFloorSizing(weightsGiB: 15),
+            specDecPreparation: .init(
+                artifact: artifact, status: .candidate(artifact)))
+        await loop.installModelBundleForTesting(
+            modelId: mtpFloorNewID,
+            bundle: initial.bundle,
+            container: container,
+            tokenizer: TokenizerHandle(MTPFloorTokenizer()),
+            sizing: initial.sizing,
+            modelType: "gemma4")
+        let oldBridge = initial.bundle.bridge
+        let t0 = ContinuousClock.now
+        _ = await oldBridge.submitTokenized(
+            promptTokens: [1, 2, 3],
+            request: ChatCompletionRequest(
+                model: mtpFloorNewID,
+                messages: [.init(role: "user", content: "hi")]),
+            requestId: "mtp-recovery-reuse-wedge")
+        _ = await oldBridge.backendSlotCapacity(now: t0)
+
+        let budget = await loop.kvBudgetForTesting()
+        let recovery = Task {
+            await loop.recoverWedgedEngineV2SlotsForTesting(
+                now: t0.advanced(by: .seconds(130)))
+        }
+        let rebuildStarted = factory.waitForRecoveryStart()
+        let outstandingBeforeConcurrentReserve = await budget.outstandingReservedBytes()
+        let reserved = await budget.reserveBytes(
+            requestID: "mtp-concurrent-kv", bytes: 1)
+        let outstandingDuringRebuild = await budget.outstandingReservedBytes()
+        factory.resumeRecovery()
+        await recovery.value
+
+        #expect(rebuildStarted)
+        #expect(reserved)
+        #expect(outstandingDuringRebuild == outstandingBeforeConcurrentReserve + 1)
+        #expect(counter.count == 1, "recovery must reuse, not reload, the assistant")
+        let rebuilt = try #require(await loop.slotBridgeForTesting(modelId: mtpFloorNewID))
+        #expect(rebuilt !== oldBridge)
+        #expect(await loop.slotMTPStatusForTesting(modelId: mtpFloorNewID)?.active == true)
+        #expect(await loop.slotSizingForTesting(modelId: mtpFloorNewID)?.auxiliaryWeightBytes
+            == initial.sizing.auxiliaryWeightBytes)
+        let outstandingBeforeConcurrentRelease = await budget.outstandingReservedBytes()
+        await budget.release(requestID: "mtp-concurrent-kv")
+        let outstandingAfterConcurrentRelease = await budget.outstandingReservedBytes()
+        #expect(outstandingBeforeConcurrentRelease == outstandingAfterConcurrentRelease + 1)
+        await loop.unloadModel(mtpFloorNewID)
+    }
+
+    @Test("target-only slot cannot activate an available assistant during recovery")
+    func recoveryPreservesTargetOnlyPosture() async throws {
+        let artifact = try mtpFloorArtifact()
+        defer { try? FileManager.default.removeItem(at: artifact.directory) }
+        let counter = MTPFloorAssistantLoadCounter()
+        let factory = MTPRecoveryEngineFactory()
+        let model = ModelInfo(
+            id: mtpFloorNewID,
+            modelType: "gemma4",
+            sizeBytes: 1,
+            estimatedMemoryGb: 1)
+        let loop = try mtpFloorLoop(
+            models: [model], mtpDrafterPath: artifact.directory.path)
+        let runtime = EngineV2Runtime()
+        await loop.setEngineV2RuntimeForTesting(runtime)
+        await loop.setEngineV2SlotHooksForTesting(.init(
+            physicalMemoryBytes: mtpFloorPhysical,
+            assistantLoader: MTPFloorAssistantLoader(counter: counter),
+            makeEngine: { _, grant in factory.make(grant: grant) }))
+
+        let targetOnlyStatus = MTPActivationStatus.disabled(
+            .assistantMemoryUnavailable, configured: true)
+        let container = mtpFloorContainer()
+        let initial = try await loop.resliceAndBuildEngineV2BundleForTesting(
+            modelId: mtpFloorNewID,
+            modelType: "gemma4",
+            newcomer: EngineV2NewcomerBox(container),
+            tokenizer: TokenizerHandle(MTPFloorTokenizer()),
+            sizing: mtpFloorSizing(weightsGiB: 15),
+            specDecPreparation: .init(
+                artifact: nil, status: targetOnlyStatus))
+        await loop.installModelBundleForTesting(
+            modelId: mtpFloorNewID,
+            bundle: initial.bundle,
+            container: container,
+            tokenizer: TokenizerHandle(MTPFloorTokenizer()),
+            sizing: initial.sizing,
+            modelType: "gemma4")
+        let oldBridge = initial.bundle.bridge
+        let t0 = ContinuousClock.now
+        _ = await oldBridge.submitTokenized(
+            promptTokens: [1, 2, 3],
+            request: ChatCompletionRequest(
+                model: mtpFloorNewID,
+                messages: [.init(role: "user", content: "hi")]),
+            requestId: "mtp-recovery-target-only-wedge")
+        _ = await oldBridge.backendSlotCapacity(now: t0)
+
+        await loop.recoverWedgedEngineV2SlotsForTesting(
+            now: t0.advanced(by: .seconds(130)))
+
+        let rebuilt = try #require(await loop.slotBridgeForTesting(modelId: mtpFloorNewID))
+        let status = await rebuilt.mtpStatusSnapshot()
+        #expect(!status.active)
+        #expect(status.fallbackReason == .assistantMemoryUnavailable)
+        #expect(counter.count == 0)
+        #expect(await loop.slotSizingForTesting(modelId: mtpFloorNewID)?.auxiliaryWeightBytes == 0)
+        await loop.unloadModel(mtpFloorNewID)
+    }
+}

--- a/provider-swift/Tests/ProviderCoreTests/MTPResliceFallbackTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/MTPResliceFallbackTests.swift
@@ -7,6 +7,49 @@ import Testing
 
 @testable import ProviderCore
 
+/// Deterministic gate inside the funnel's catalog lookup: `cachedModel`
+/// blocks until released, giving load-lifecycle tests a controllable
+/// suspension point inside the MTP preparation await.
+private actor RaceGateCatalog: SpecDecCatalogLooking {
+    private var entered: CheckedContinuation<Void, Never>?
+    private var release: CheckedContinuation<CatalogModel?, Never>?
+    private(set) var cachedCalls = 0
+
+    func cachedModel(id: String) async -> CatalogModel? {
+        cachedCalls += 1
+        entered?.resume()
+        entered = nil
+        return await withCheckedContinuation { release = $0 }
+    }
+
+    func model(id: String) async throws -> CatalogModel? { nil }
+
+    func waitUntilEntered() async {
+        if cachedCalls > 0 { return }
+        await withCheckedContinuation { entered = $0 }
+    }
+
+    func releaseGate() {
+        release?.resume(returning: nil)
+        release = nil
+    }
+}
+
+/// Minimal fake HF-cache snapshot so `ModelScanner.resolveLocalPath` resolves
+/// the id before the load path reaches the preparation await under test.
+private func makeRaceFakeHFSnapshot(modelId: String) throws -> URL {
+    let cacheDir = FileManager.default.homeDirectoryForCurrentUser
+        .appendingPathComponent(".cache/huggingface/hub", isDirectory: true)
+    let modelDir = cacheDir.appendingPathComponent(
+        "models--\(modelId.replacingOccurrences(of: "/", with: "--"))", isDirectory: true)
+    let snapshot = modelDir
+        .appendingPathComponent("snapshots", isDirectory: true)
+        .appendingPathComponent("main", isDirectory: true)
+    try FileManager.default.createDirectory(at: snapshot, withIntermediateDirectories: true)
+    try Data("{}".utf8).write(to: snapshot.appendingPathComponent("config.json"))
+    return modelDir
+}
+
 private let mtpFloorGiB: UInt64 = 1_073_741_824
 private let mtpFloorPhysical = 64 * mtpFloorGiB
 private let mtpFloorExistingID = "gemma-4-existing"
@@ -366,6 +409,50 @@ struct MTPResliceFallbackTests {
 
         await build.bundle.bridge.shutdown()
         build.bundle.releaseAssistant()
+        await server.stopAndWait()
+    }
+
+    @Test("standalone concurrent same-model load rechecks residency after MTP preparation")
+    func standalonePreparationRaceRechecksResidency() async throws {
+        let fakeId = "darkbloom-tests/standalone-race-\(UUID().uuidString.prefix(8))"
+        let fakeDir = try makeRaceFakeHFSnapshot(modelId: fakeId)
+        defer { try? FileManager.default.removeItem(at: fakeDir) }
+
+        let server = StandaloneServer(
+            config: .init(maxCachedModels: 3, mtp: true),
+            models: [ModelInfo(
+                id: fakeId, modelType: "gemma4", parameters: nil,
+                quantization: nil, sizeBytes: 1, estimatedMemoryGb: 0.01)])
+        let gate = RaceGateCatalog()
+        await server.setSpecDecFunnelForTesting(SpecDecArtifactFunnel(
+            resolver: SpecDecResolver(), catalog: gate))
+
+        let load = Task { try await server.ensureModelLoaded(fakeId) }
+        await gate.waitUntilEntered()
+
+        // The load task is now suspended inside the MTP preparation await,
+        // PAST the initial residency/loading checks. Install the slot exactly
+        // as a concurrent same-model load that ran to completion would.
+        let bridge = EngineV2Bridge(
+            engine: MTPFloorEngine(capacityBytes: 1 << 20),
+            modelId: fakeId,
+            tokenizer: TokenizerHandle(MTPFloorTokenizer()),
+            eosTokenIds: [])
+        await server.installSlotForTesting(
+            modelId: fakeId,
+            bridge: bridge,
+            container: mtpFloorContainer(),
+            tokenizer: TokenizerHandle(MTPFloorTokenizer()),
+            sizing: mtpFloorSizing(weightsBytes: 1),
+            modelType: "gemma4")
+        await gate.releaseGate()
+
+        // Without the post-preparation recheck, the continuation starts a
+        // SECOND load of the resident model and throws on the fake
+        // snapshot's unloadable weights.
+        try await load.value
+        #expect(await server.debugOutstandingKVReservationBytes() == 0)
+        await bridge.shutdown()
         await server.stopAndWait()
     }
 

--- a/provider-swift/Tests/ProviderCoreTests/MTPResliceFallbackTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/MTPResliceFallbackTests.swift
@@ -241,6 +241,17 @@ private func mtpFloorSizing(weightsBytes: UInt64) -> SlotSizingSnapshot {
         defaultMaxTokens: 4096)
 }
 
+private struct MTPFloorFailingAssistantLoader: ProviderMTPAssistantLoading {
+    struct Failure: Error {}
+
+    func loadAndBind(
+        artifact: SpecDecArtifact,
+        target: any LanguageModel
+    ) async throws -> ProviderMTPAssistantHandle {
+        throw Failure()
+    }
+}
+
 private func mtpFloorLoop(
     models: [ModelInfo] = [],
     mtpDrafterPath: String? = nil
@@ -410,6 +421,50 @@ struct MTPResliceFallbackTests {
         await build.bundle.bridge.shutdown()
         build.bundle.releaseAssistant()
         await server.stopAndWait()
+    }
+
+    @Test("prepare-stage assistant fail-open drops the drafter's pending reservation")
+    func prepareFailOpenReleasesPhantomReservation() async throws {
+        let artifact = try mtpFloorArtifact()
+        defer { try? FileManager.default.removeItem(at: artifact.directory) }
+        let loop = try mtpFloorLoop()
+        let runtime = EngineV2Runtime()
+        await loop.setEngineV2RuntimeForTesting(runtime)
+        await loop.setEngineV2SlotHooksForTesting(.init(
+            physicalMemoryBytes: mtpFloorPhysical,
+            assistantLoader: MTPFloorFailingAssistantLoader(),
+            makeEngine: { _, grant in MTPFloorEngine(capacityBytes: grant) }))
+
+        // The load path charged the drafter's bytes at admission; the
+        // assistant then fail-opens INSIDE the bundle build (load failure).
+        await loop.reservePendingLoadForTesting(
+            requestID: "pending-load:\(mtpFloorNewID)", bytes: artifact.residentBytes)
+
+        // Small weights: the re-slice floor must NOT trigger — this test
+        // isolates the prepare-stage fail-open, whose fallback previously
+        // kept the never-resident drafter bytes reserved through the whole
+        // re-slice and engine build.
+        let newcomer = EngineV2NewcomerBox(mtpFloorContainer())
+        let build = try await loop.resliceAndBuildEngineV2BundleForTesting(
+            modelId: mtpFloorNewID,
+            modelType: "gemma4",
+            newcomer: newcomer,
+            tokenizer: TokenizerHandle(MTPFloorTokenizer()),
+            sizing: mtpFloorSizing(weightsGiB: 1),
+            specDecPreparation: .init(
+                artifact: artifact, status: .candidate(artifact)))
+
+        #expect(build.bundle.mtpStatus.reason == MTPFallbackReason.assistantLoadFailed)
+        #expect(!build.bundle.mtpStatus.active)
+        #expect(build.bundle.assistantBytes == 0)
+        #expect(build.sizing.auxiliaryWeightBytes == 0)
+        // The phantom reservation must be gone the moment the fallback is
+        // decided — not only after the caller's post-build release.
+        #expect(await loop.outstandingKVReservationBytesForTesting() == 0)
+
+        await runtime.unregister(modelId: mtpFloorNewID)
+        await build.bundle.bridge.shutdown()
+        build.bundle.releaseAssistant()
     }
 
     @Test("standalone concurrent same-model load rechecks residency after MTP preparation")

--- a/provider-swift/Tests/ProviderCoreTests/MTPResliceFallbackTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/MTPResliceFallbackTests.swift
@@ -467,6 +467,38 @@ struct MTPResliceFallbackTests {
         build.bundle.releaseAssistant()
     }
 
+    @Test("standalone prepare-stage fail-open drops the drafter's pending reservation")
+    func standalonePrepareFailOpenReleasesPhantomReservation() async throws {
+        let artifact = try mtpFloorArtifact()
+        defer { try? FileManager.default.removeItem(at: artifact.directory) }
+        let server = StandaloneServer(config: .init(maxCachedModels: 3))
+        await server.setV2TestHooksForTesting(.init(
+            physicalMemoryBytes: mtpFloorPhysical,
+            assistantLoader: MTPFloorFailingAssistantLoader(),
+            makeEngine: { _, grant in MTPFloorEngine(capacityBytes: grant) }))
+        await server.reservePendingLoadForTesting(
+            requestID: "pending-load:\(mtpFloorNewID)", bytes: artifact.residentBytes)
+
+        let newcomer = EngineV2NewcomerBox(mtpFloorContainer())
+        let build = try await server.resliceAndBuildMTPBundleForTesting(
+            modelId: mtpFloorNewID,
+            modelType: "gemma4",
+            newcomer: newcomer,
+            tokenizer: TokenizerHandle(MTPFloorTokenizer()),
+            sizing: mtpFloorSizing(weightsGiB: 1),
+            specDecPreparation: .init(
+                artifact: artifact, status: .candidate(artifact)))
+
+        #expect(build.bundle.mtpStatus.reason == MTPFallbackReason.assistantLoadFailed)
+        #expect(build.bundle.assistantBytes == 0)
+        // The phantom reservation must be gone the moment the fallback is
+        // decided (mirrors the ProviderLoop regression test).
+        #expect(await server.debugOutstandingKVReservationBytes() == 0)
+        await build.bundle.bridge.shutdown()
+        build.bundle.releaseAssistant()
+        await server.stopAndWait()
+    }
+
     @Test("standalone concurrent same-model load rechecks residency after MTP preparation")
     func standalonePreparationRaceRechecksResidency() async throws {
         let fakeId = "darkbloom-tests/standalone-race-\(UUID().uuidString.prefix(8))"

--- a/provider-swift/Tests/ProviderCoreTests/ModelCatalogTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ModelCatalogTests.swift
@@ -286,6 +286,44 @@ struct ModelCatalogTests {
         #expect(RangeURLProtocol.lastRangeHeader == "bytes=8-")
     }
 
+    @Test("downloadFile discards a 206 resume whose Content-Range mismatches and re-downloads")
+    func downloadFileRejectsMismatched206Resume() async throws {
+        // A misbehaving server/proxy answers our `Range: bytes=8-` with a 206
+        // whose Content-Range starts at byte 4. Writing that suffix from
+        // byte 0 would silently corrupt the file (the legacy path passes no
+        // SHA); the delegate must discard the .part, surface a retryable
+        // failure, and the retry must fetch the whole object from byte 0.
+        let full = Data("0123456789abcdef".utf8)
+        RangeURLProtocol.payload = full
+        RangeURLProtocol.lastRangeHeader = nil
+        RangeURLProtocol.mismatchNextResumeStart = 4
+        defer { RangeURLProtocol.mismatchNextResumeStart = nil }
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [RangeURLProtocol.self]
+        let session = URLSession(configuration: config)
+        let downloader = ModelDownloader(r2CDNURL: "https://cdn.example.test", urlSession: session)
+
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("model-download-test-\(UUID().uuidString)", isDirectory: true)
+        let final = dir.appendingPathComponent("model.safetensors")
+        let partial = final.appendingPathExtension("part")
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try full.prefix(8).write(to: partial)
+
+        let ok = try await downloader.downloadFileForTesting(
+            from: "https://cdn.example.test/model.safetensors",
+            to: final
+        )
+
+        #expect(ok)
+        // The retry fetched the WHOLE object (no Range header) and the final
+        // bytes are exactly the object — not a suffix written from byte 0.
+        #expect(try Data(contentsOf: final) == full)
+        #expect(RangeURLProtocol.lastRangeHeader == nil)
+        #expect(!FileManager.default.fileExists(atPath: partial.path))
+    }
+
     @Test("downloadFile promotes a complete .part on 416 instead of re-downloading")
     func downloadFilePromotesCompletePartOn416() async throws {
         // A prior run received every byte into `.part` but died before promoting
@@ -525,6 +563,10 @@ private final class CatalogBodyURLProtocol: URLProtocol, @unchecked Sendable {
 private final class RangeURLProtocol: URLProtocol, @unchecked Sendable {
     nonisolated(unsafe) static var payload = Data()
     nonisolated(unsafe) static var lastRangeHeader: String?
+    /// When set, the NEXT ranged request is answered with a 206 whose
+    /// Content-Range start is this value (a misbehaving server/proxy); the
+    /// flag then clears so retries see correct behavior again.
+    nonisolated(unsafe) static var mismatchNextResumeStart: Int?
 
     override class func canInit(with request: URLRequest) -> Bool { true }
     override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
@@ -549,6 +591,26 @@ private final class RangeURLProtocol: URLProtocol, @unchecked Sendable {
                 headerFields: ["Content-Range": "bytes */\(Self.payload.count)"]
             )!
             client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocolDidFinishLoading(self)
+            return
+        }
+        if start > 0, let liedStart = Self.mismatchNextResumeStart {
+            // Misbehaving server/proxy: a 206 whose Content-Range does not
+            // match the requested resume offset (body matches the lie).
+            Self.mismatchNextResumeStart = nil
+            let body = Self.payload.dropFirst(liedStart)
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 206,
+                httpVersion: "HTTP/1.1",
+                headerFields: [
+                    "Content-Length": "\(body.count)",
+                    "Content-Range":
+                        "bytes \(liedStart)-\(Self.payload.count - 1)/\(Self.payload.count)",
+                ]
+            )!
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: Data(body))
             client?.urlProtocolDidFinishLoading(self)
             return
         }

--- a/provider-swift/Tests/ProviderCoreTests/ModelCatalogTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ModelCatalogTests.swift
@@ -156,6 +156,87 @@ struct ModelCatalogTests {
         #expect(RegistryURLProtocol.lastPath == "/v1/models/catalog/manifest/org%2Fmodel%2Fwith%2Fslash")
     }
 
+    @Test("catalog streaming accepts the exact response-byte boundary")
+    func catalogResponseExactBoundary() async throws {
+        let base = Data(#"{"models":[]}"#.utf8)
+        var body = base
+        body.append(Data(
+            repeating: UInt8(ascii: " "),
+            count: ModelCatalogClient.maximumCatalogResponseBytes - base.count))
+        CatalogBodyURLProtocol.payload = body
+        CatalogBodyURLProtocol.includeContentLength = false
+
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [CatalogBodyURLProtocol.self]
+        let client = ModelCatalogClient(
+            coordinatorURL: "https://coord.example.test",
+            urlSession: URLSession(configuration: config))
+
+        let models = try await client.fetchCatalog()
+        #expect(models.isEmpty)
+    }
+
+    @Test("catalog streaming rejects one byte beyond the response bound")
+    func catalogResponseOverBoundary() async {
+        let base = Data(#"{"models":[]}"#.utf8)
+        var body = base
+        body.append(Data(
+            repeating: UInt8(ascii: " "),
+            count: ModelCatalogClient.maximumCatalogResponseBytes - base.count + 1))
+        CatalogBodyURLProtocol.payload = body
+        CatalogBodyURLProtocol.includeContentLength = false
+
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [CatalogBodyURLProtocol.self]
+        let client = ModelCatalogClient(
+            coordinatorURL: "https://coord.example.test",
+            urlSession: URLSession(configuration: config))
+
+        await #expect(throws: ModelCatalogError.self) {
+            _ = try await client.fetchCatalog()
+        }
+    }
+
+    @Test("catalog rejects excessive JSON nesting before decode")
+    func catalogNestingBound() async {
+        let nesting = String(repeating: "[", count: 33)
+            + String(repeating: "]", count: 33)
+        CatalogBodyURLProtocol.payload = Data(
+            "{\"models\":[],\"ignored\":\(nesting)}".utf8)
+        CatalogBodyURLProtocol.includeContentLength = true
+
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [CatalogBodyURLProtocol.self]
+        let client = ModelCatalogClient(
+            coordinatorURL: "https://coord.example.test",
+            urlSession: URLSession(configuration: config))
+
+        await #expect(throws: ModelCatalogError.self) {
+            _ = try await client.fetchCatalog()
+        }
+    }
+
+    @Test("catalog rejects model arrays beyond the provider count bound")
+    func catalogModelCountBound() async {
+        let model = #"{"id":"m","s3_name":"m","display_name":"m","model_type":"text","size_gb":1}"#
+        let models = Array(
+            repeating: model,
+            count: ModelCatalogClient.maximumCatalogModelCount + 1
+        ).joined(separator: ",")
+        CatalogBodyURLProtocol.payload = Data("{\"models\":[\(models)]}".utf8)
+        CatalogBodyURLProtocol.includeContentLength = true
+
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [CatalogBodyURLProtocol.self]
+        let client = ModelCatalogClient(
+            coordinatorURL: "https://coord.example.test",
+            urlSession: URLSession(configuration: config))
+
+        await #expect(throws: ModelCatalogError.self) {
+            _ = try await client.fetchCatalog()
+        }
+    }
+
     @Test("downloader honors DARKBLOOM_R2_CDN_URL env override")
     func downloaderEnvOverride() {
         setenv("DARKBLOOM_R2_CDN_URL", "https://example.test/cdn", 1)
@@ -410,6 +491,35 @@ struct ModelCatalogTests {
 // unit-test the wire format without exposing the internal type.
 private struct CatalogResponseShim: Codable {
     let models: [CatalogModel]
+}
+
+private final class CatalogBodyURLProtocol: URLProtocol, @unchecked Sendable {
+    nonisolated(unsafe) static var payload = Data()
+    nonisolated(unsafe) static var includeContentLength = true
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        var headers: [String: String]? = nil
+        if Self.includeContentLength {
+            headers = ["Content-Length": "\(Self.payload.count)"]
+        }
+        let response = HTTPURLResponse(
+            url: request.url!, statusCode: 200, httpVersion: "HTTP/1.1",
+            headerFields: headers)!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        let chunkSize = 16 * 1024
+        var offset = 0
+        while offset < Self.payload.count {
+            let end = min(offset + chunkSize, Self.payload.count)
+            client?.urlProtocol(self, didLoad: Self.payload.subdata(in: offset..<end))
+            offset = end
+        }
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
 }
 
 private final class RangeURLProtocol: URLProtocol, @unchecked Sendable {

--- a/provider-swift/Tests/ProviderCoreTests/ProviderMTPFactoryTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ProviderMTPFactoryTests.swift
@@ -1,0 +1,444 @@
+import Foundation
+import Crypto
+import MLX
+import MLXLMCommon
+import MLXNN
+import Testing
+@testable import ProviderCore
+import ProviderCoreFoundation
+
+private struct MTPFactoryTokenizer: MLXLMCommon.Tokenizer {
+    func encode(text: String, addSpecialTokens: Bool) -> [Int] { [0] }
+    func decode(tokenIds: [Int], skipSpecialTokens: Bool) -> String { "" }
+    func convertTokenToId(_ token: String) -> Int? { nil }
+    func convertIdToToken(_ id: Int) -> String? { nil }
+    var bosToken: String? { nil }
+    var eosToken: String? { nil }
+    var unknownToken: String? { nil }
+    func applyChatTemplate(
+        messages: [[String: any Sendable]],
+        tools: [[String: any Sendable]]?,
+        additionalContext: [String: any Sendable]?
+    ) throws -> [Int] { [0] }
+}
+
+private final class MTPFactoryTarget: Module, LanguageModel {
+    func prepare(_ input: LMInput, cache: [KVCache], windowSize: Int?) throws -> PrepareResult {
+        .tokens(input.text)
+    }
+    func newCache(parameters: GenerateParameters?) -> [KVCache] { [] }
+}
+
+private struct MTPFactoryProcessor: UserInputProcessor {
+    func prepare(input: UserInput) async throws -> LMInput { throw CancellationError() }
+}
+
+private func mtpFactoryContainer(_ target: MTPFactoryTarget = MTPFactoryTarget()) -> ModelContainer {
+    ModelContainer(context: ModelContext(
+        configuration: ModelConfiguration(id: "test/mtp-factory"),
+        model: target,
+        processor: MTPFactoryProcessor(),
+        tokenizer: MTPFactoryTokenizer()))
+}
+
+private func mtpFactoryArtifact() throws -> SpecDecArtifact {
+    let directory = FileManager.default.temporaryDirectory
+        .appendingPathComponent("provider-mtp-test-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    try Data(#"{"model_type":"gemma4_assistant"}"#.utf8)
+        .write(to: directory.appendingPathComponent("config.json"))
+    try Data(repeating: 0x5a, count: 4096)
+        .write(to: directory.appendingPathComponent("model.safetensors"))
+    return try #require(SpecDecStore.inspectLocalArtifact(path: directory.path))
+}
+
+private func mtpSHA256(_ data: Data) -> String {
+    SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+}
+
+private func mtpCatalogArtifact() throws -> SpecDecArtifact {
+    let directory = FileManager.default.temporaryDirectory
+        .appendingPathComponent("provider-mtp-catalog-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    let config = Data(#"{"model_type":"gemma4_assistant"}"#.utf8)
+    let weights = Data(repeating: 0x6b, count: 4096)
+    try config.write(to: directory.appendingPathComponent("config.json"))
+    try weights.write(to: directory.appendingPathComponent("model.safetensors"))
+    var aggregate = SHA256()
+    for data in [config, weights] {
+        SHA256.hash(data: data).withUnsafeBytes { aggregate.update(bufferPointer: $0) }
+    }
+    let prefix = "v2-specdec/provider-factory/v1"
+    let manifest = ModelManifest(
+        schemaVersion: 1,
+        modelID: "darkbloom/gemma4-assistant",
+        version: "v1",
+        r2Prefix: prefix,
+        aggregateSHA256: aggregate.finalize().map { String(format: "%02x", $0) }.joined(),
+        totalSizeBytes: Int64(config.count + weights.count),
+        fileCount: 2,
+        files: [
+            .init(
+                path: "config.json", sizeBytes: Int64(config.count),
+                sha256: mtpSHA256(config), role: "config"),
+            .init(
+                path: "model.safetensors", sizeBytes: Int64(weights.count),
+                sha256: mtpSHA256(weights), role: "weight"),
+        ],
+        createdAt: Date(timeIntervalSince1970: 0))
+    let encoder = JSONEncoder()
+    encoder.dateEncodingStrategy = .iso8601
+    encoder.outputFormatting = [.sortedKeys]
+    let manifestData = try encoder.encode(manifest)
+    try manifestData.write(to: directory.appendingPathComponent("manifest.json"))
+    let reference = SpecDecArtifactReference(
+        r2Prefix: prefix,
+        manifestSHA256: mtpSHA256(manifestData),
+        expectedTotalBytes: UInt64(manifest.totalSizeBytes),
+        expectedFileCount: manifest.fileCount,
+        maximumFileCount: 8,
+        allowedFileRoles: ["config", "weight"],
+        configSHA256: mtpSHA256(config),
+        revision: manifest.version)
+    let verification = try SpecDecStore.verifyPublishedArtifact(
+        at: directory, reference: reference).get()
+    return SpecDecArtifact(
+        directory: directory,
+        source: .catalog,
+        revision: manifest.version,
+        artifactBytes: verification.artifactBytes,
+        residentBytes: SpecDecLimits.residentEstimate(
+            artifactBytes: verification.artifactBytes),
+        manifestSHA256: verification.manifestSHA256,
+        catalogReference: reference)
+}
+
+private final class MTPFactoryPrepared: CBv2MTPPreparedCapture {}
+private final class MTPFactoryDrafter: CBv2MTPDrafter, @unchecked Sendable {
+    func prepare(rows: [CBv2MTPRowCapture]) -> CBv2MTPPreparedCapture {
+        MTPFactoryPrepared()
+    }
+    func draftStep(
+        tokens: MLXArray, hidden: MLXArray, prepared: CBv2MTPPreparedCapture
+    ) -> (tokens: MLXArray, hidden: MLXArray) {
+        (tokens, hidden)
+    }
+}
+
+private final class MTPFactoryIdentityRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value: ObjectIdentifier?
+    private var calls = 0
+    func record(_ target: any LanguageModel) {
+        lock.withLock {
+            value = ObjectIdentifier(target)
+            calls += 1
+        }
+    }
+    var snapshot: (ObjectIdentifier?, Int) { lock.withLock { (value, calls) } }
+}
+
+private struct MTPFactoryRecordingLoader: ProviderMTPAssistantLoading {
+    let recorder: MTPFactoryIdentityRecorder
+    let failure: ProviderMTPAssistantLoadError?
+
+    func loadAndBind(
+        artifact: SpecDecArtifact, target: any LanguageModel
+    ) async throws -> ProviderMTPAssistantHandle {
+        recorder.record(target)
+        if let failure { throw failure }
+        return ProviderMTPAssistantHandle(
+            owner: NSObject(), drafter: MTPFactoryDrafter())
+    }
+}
+
+private actor MTPFreshProcessCatalog: SpecDecCatalogLooking {
+    let modelValue: CatalogModel
+    private var warmed = false
+
+    init(model: CatalogModel) { self.modelValue = model }
+
+    func cachedModel(id: String) -> CatalogModel? { warmed ? modelValue : nil }
+
+    func model(id: String) async throws -> CatalogModel? {
+        warmed = true
+        return modelValue
+    }
+}
+
+@Suite("Provider MTP target/assistant preparation")
+struct ProviderMTPFactoryTests {
+    @Test("fresh-process catalog prewarm activates a verified cached assistant on first load")
+    func freshProcessCachedCatalogAssistantActivates() async throws {
+        let staged = try mtpCatalogArtifact()
+        defer { try? FileManager.default.removeItem(at: staged.directory) }
+        let reference = try #require(staged.catalogReference)
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("provider-mtp-fresh-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let published = SpecDecStore.artifactDirectory(
+            root: root, r2Prefix: reference.r2Prefix)
+        try FileManager.default.moveItem(at: staged.directory, to: published)
+
+        let model = CatalogModel(
+            id: "gemma-4-test", s3Name: "unused", displayName: "Gemma", sizeGb: 1,
+            metadata: ["spec_dec": .object([
+                ("r2_prefix", .string(reference.r2Prefix)),
+                ("manifest_sha256", .string(reference.manifestSHA256)),
+                ("total_size_bytes", .int(Int64(reference.expectedTotalBytes))),
+                ("file_count", .int(Int64(reference.expectedFileCount))),
+                ("max_file_count", .int(Int64(reference.maximumFileCount))),
+                ("allowed_file_types", .array([.string("config"), .string("weight")])),
+                ("config_sha256", .string(reference.configSHA256)),
+                ("revision", .string(reference.revision)),
+            ])])
+        let catalog = MTPFreshProcessCatalog(model: model)
+        let funnel = SpecDecArtifactFunnel(
+            resolver: SpecDecResolver(storeRoot: root), catalog: catalog)
+
+        #expect(await funnel.prewarmCatalog(modelId: model.id, timeout: .seconds(1)))
+        let preparation = await funnel.prepare(.init(
+            modelId: model.id, modelType: "gemma4", enabled: true,
+            localPath: nil, allowDownload: true, environment: [:]))
+        #expect(preparation.artifact?.source == .catalog)
+
+        let recorder = MTPFactoryIdentityRecorder()
+        let prepared = try await EngineV2SlotFactory.prepareProductionModel(
+            modelId: model.id,
+            isVLM: false,
+            modelDirectory: nil,
+            container: mtpFactoryContainer(),
+            specDecPreparation: preparation,
+            assistantLoader: MTPFactoryRecordingLoader(recorder: recorder, failure: nil))
+        #expect(prepared.mtpStatus.active)
+        #expect(prepared.assistant != nil)
+        #expect(recorder.snapshot.1 == 1)
+        prepared.assistant?.release()
+        await funnel.shutdown()
+    }
+
+    @Test("one exact serving target instance is handed to assistant loader")
+    func exactTargetInstance() async throws {
+        let target = MTPFactoryTarget()
+        let recorder = MTPFactoryIdentityRecorder()
+        let artifact = try mtpFactoryArtifact()
+        defer { try? FileManager.default.removeItem(at: artifact.directory) }
+        let prepared = try await EngineV2SlotFactory.prepareProductionModel(
+            modelId: "gemma-4-test",
+            isVLM: false,
+            modelDirectory: nil,
+            container: mtpFactoryContainer(target),
+            specDecPreparation: .init(
+                artifact: artifact, status: .candidate(artifact)),
+            assistantLoader: MTPFactoryRecordingLoader(
+                recorder: recorder, failure: nil))
+        #expect(recorder.snapshot.0 == ObjectIdentifier(target))
+        #expect(recorder.snapshot.1 == 1)
+        #expect(ObjectIdentifier(prepared.servingModel) == ObjectIdentifier(target))
+        #expect(prepared.mtpStatus.active)
+        #expect(prepared.assistantBytes == artifact.residentBytes)
+    }
+
+    @Test("assistant load and bind failures are stable target-only fallbacks")
+    func loadAndBindFallbacks() async throws {
+        for failure in [
+            ProviderMTPAssistantLoadError.loadFailed("fixture"),
+            ProviderMTPAssistantLoadError.bindFailed("fixture"),
+        ] {
+            let recorder = MTPFactoryIdentityRecorder()
+            let artifact = try mtpFactoryArtifact()
+            defer { try? FileManager.default.removeItem(at: artifact.directory) }
+            let prepared = try await EngineV2SlotFactory.prepareProductionModel(
+                modelId: "gemma-4-test",
+                isVLM: false,
+                modelDirectory: nil,
+                container: mtpFactoryContainer(),
+                specDecPreparation: .init(
+                    artifact: artifact, status: .candidate(artifact)),
+                assistantLoader: MTPFactoryRecordingLoader(
+                    recorder: recorder, failure: failure))
+            #expect(prepared.assistant == nil)
+            #expect(prepared.assistantBytes == 0)
+            #expect(prepared.mtpStatus.reason == failure.reason)
+        }
+    }
+
+    @Test("cached catalog bytes are revalidated on every load and rebuild")
+    func cachedCatalogCorruptionFallsBackBeforeLoader() async throws {
+        let artifact = try mtpCatalogArtifact()
+        defer { try? FileManager.default.removeItem(at: artifact.directory) }
+        let firstRecorder = MTPFactoryIdentityRecorder()
+        let first = try await EngineV2SlotFactory.prepareProductionModel(
+            modelId: "gemma-4-test",
+            isVLM: false,
+            modelDirectory: nil,
+            container: mtpFactoryContainer(),
+            specDecPreparation: .init(
+                artifact: artifact, status: .candidate(artifact)),
+            assistantLoader: MTPFactoryRecordingLoader(
+                recorder: firstRecorder, failure: nil))
+        #expect(first.assistant != nil)
+        #expect(firstRecorder.snapshot.1 == 1)
+        first.assistant?.release()
+
+        let weightURL = artifact.directory.appendingPathComponent("model.safetensors")
+        var corrupted = try Data(contentsOf: weightURL)
+        corrupted[corrupted.startIndex] ^= 0xff
+        try corrupted.write(to: weightURL)
+
+        let rebuildRecorder = MTPFactoryIdentityRecorder()
+        let rebuilt = try await EngineV2SlotFactory.prepareProductionModel(
+            modelId: "gemma-4-test",
+            isVLM: false,
+            modelDirectory: nil,
+            container: mtpFactoryContainer(),
+            specDecPreparation: .init(
+                artifact: artifact, status: .candidate(artifact)),
+            assistantLoader: MTPFactoryRecordingLoader(
+                recorder: rebuildRecorder, failure: nil))
+        #expect(rebuilt.assistant == nil)
+        #expect(rebuilt.assistantBytes == 0)
+        #expect(rebuilt.mtpStatus.reason == .warmArtifactCorrupt)
+        #expect(rebuildRecorder.snapshot.1 == 0)
+    }
+
+    @Test("local override growth after admission falls back before loader")
+    func localGrowthFallsBackBeforeLoader() async throws {
+        let artifact = try mtpFactoryArtifact()
+        defer { try? FileManager.default.removeItem(at: artifact.directory) }
+        let weightURL = artifact.directory.appendingPathComponent("model.safetensors")
+        let handle = try FileHandle(forWritingTo: weightURL)
+        try handle.seekToEnd()
+        try handle.write(contentsOf: Data([0xff]))
+        try handle.close()
+
+        let recorder = MTPFactoryIdentityRecorder()
+        let prepared = try await EngineV2SlotFactory.prepareProductionModel(
+            modelId: "gemma-4-test",
+            isVLM: false,
+            modelDirectory: nil,
+            container: mtpFactoryContainer(),
+            specDecPreparation: .init(
+                artifact: artifact, status: .candidate(artifact)),
+            assistantLoader: MTPFactoryRecordingLoader(
+                recorder: recorder, failure: nil))
+        #expect(prepared.assistant == nil)
+        #expect(prepared.assistantBytes == 0)
+        #expect(prepared.mtpStatus.reason == .localArtifactInvalid)
+        #expect(recorder.snapshot.1 == 0)
+    }
+
+    @Test("local override same-size weight mutation falls back before loader")
+    func localSameSizeMutationFallsBackBeforeLoader() async throws {
+        let artifact = try mtpFactoryArtifact()
+        defer { try? FileManager.default.removeItem(at: artifact.directory) }
+        let weightURL = artifact.directory.appendingPathComponent("model.safetensors")
+        var weights = try Data(contentsOf: weightURL)
+        weights[weights.startIndex] ^= 0xff
+        try weights.write(to: weightURL)
+
+        let recorder = MTPFactoryIdentityRecorder()
+        let prepared = try await EngineV2SlotFactory.prepareProductionModel(
+            modelId: "gemma-4-test",
+            isVLM: false,
+            modelDirectory: nil,
+            container: mtpFactoryContainer(),
+            specDecPreparation: .init(
+                artifact: artifact, status: .candidate(artifact)),
+            assistantLoader: MTPFactoryRecordingLoader(
+                recorder: recorder, failure: nil))
+        #expect(prepared.assistant == nil)
+        #expect(prepared.assistantBytes == 0)
+        #expect(prepared.mtpStatus.reason == .localArtifactInvalid)
+        #expect(recorder.snapshot.1 == 0)
+    }
+
+    @Test("real loader rejects non-Gemma target without touching artifact files")
+    func realLoaderTargetMismatchFailsOpen() async throws {
+        let artifact = try mtpFactoryArtifact()
+        defer { try? FileManager.default.removeItem(at: artifact.directory) }
+        let prepared = try await EngineV2SlotFactory.prepareProductionModel(
+            modelId: "gemma-4-test",
+            isVLM: false,
+            modelDirectory: nil,
+            container: mtpFactoryContainer(),
+            specDecPreparation: .init(
+                artifact: artifact, status: .candidate(artifact)))
+        #expect(prepared.assistant == nil)
+        #expect(prepared.mtpStatus.reason == .assistantTargetIncompatible)
+    }
+
+    @Test("default-off preparation is identity and never calls loader")
+    func defaultOffIdentity() async throws {
+        let recorder = MTPFactoryIdentityRecorder()
+        let prepared = try await EngineV2SlotFactory.prepareProductionModel(
+            modelId: "gemma-4-test",
+            isVLM: false,
+            modelDirectory: nil,
+            container: mtpFactoryContainer(),
+            specDecPreparation: .init(
+                artifact: nil,
+                status: .disabled(.configDisabled, configured: false)),
+            assistantLoader: MTPFactoryRecordingLoader(
+                recorder: recorder, failure: nil))
+        #expect(prepared.assistant == nil)
+        #expect(prepared.mtpStatus == .disabled(.configDisabled, configured: false))
+        #expect(recorder.snapshot.1 == 0)
+    }
+
+    @Test("bridge exposes stable read-only activation snapshot")
+    func publicStatusSnapshot() async throws {
+        let bridge = makeInertStubBridge(modelId: "gemma-4-status").bridge
+        let artifact = try mtpFactoryArtifact()
+        defer { try? FileManager.default.removeItem(at: artifact.directory) }
+        await bridge.configureMTPStatus(
+            MTPActivationStatus.candidate(artifact).fallingBack(.assistantLoadFailed),
+            metricsInterval: .zero)
+        let snapshot = await bridge.mtpStatusSnapshot()
+        #expect(snapshot.configured)
+        #expect(!snapshot.active)
+        #expect(snapshot.fallbackReason == .assistantLoadFailed)
+        #expect(snapshot.assistantSource == .local)
+        #expect(snapshot.assistantRevision == artifact.revision)
+        #expect(snapshot.assistantArtifactBytes == artifact.artifactBytes)
+        #expect(snapshot.assistantResidentBytes == 0)
+        #expect(snapshot.selectedDepth == 0)
+        #expect(snapshot.proposedTokens == 0)
+        await bridge.shutdown()
+    }
+
+    @Test("bridge and bundle explicitly release engine and assistant ownership")
+    func explicitLifetimeRelease() async throws {
+        var engine: InertStubEngine? = InertStubEngine()
+        weak var weakEngine = engine
+        let bridge = EngineV2Bridge(
+            engine: try #require(engine),
+            modelId: "gemma-4-lifetime",
+            tokenizer: TokenizerHandle(StubBridgeTokenizer()),
+            eosTokenIds: [])
+        engine = nil
+
+        var owner: NSObject? = NSObject()
+        weak var weakOwner = owner
+        let assistant = ProviderMTPAssistantHandle(
+            owner: try #require(owner), drafter: MTPFactoryDrafter())
+        owner = nil
+        let artifact = try mtpFactoryArtifact()
+        defer { try? FileManager.default.removeItem(at: artifact.directory) }
+        let bundle = ProviderEngineBundle(
+            bridge: bridge,
+            assistant: assistant,
+            assistantBytes: artifact.residentBytes,
+            mtpArtifact: artifact,
+            mtpStatus: .candidate(artifact).activated(
+                assistantBytes: artifact.residentBytes))
+
+        #expect(weakEngine != nil)
+        #expect(weakOwner != nil)
+        await bridge.shutdown()
+        bundle.releaseAssistant()
+        #expect(weakEngine == nil)
+        #expect(weakOwner == nil)
+    }
+}

--- a/provider-swift/Tests/ProviderCoreTests/SSDPrefixCacheTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/SSDPrefixCacheTests.swift
@@ -1759,12 +1759,6 @@ struct SSDWholeRootMaintenanceTests {
         }
         #expect(!FileManager.default.fileExists(atPath: temp.path))
         SSDWholeRootMaintainer.shared.stopPeriodicMaintenance(root: root)
-        SSDWholeRootMaintainer.shared.startPeriodicMaintenance(
-            root: root,
-            ttlSeconds: 900,
-            intervalSeconds: 3600,
-            nowSeconds: { 10_000 },
-            budgetBytes: { 1 << 20 })
 
         let restartedTemp = SSDBlockStore.temporaryFileURL(
             for: destination,
@@ -1774,6 +1768,12 @@ struct SSDWholeRootMaintenanceTests {
             [.modificationDate: Date(timeIntervalSince1970:
                 TimeInterval(10_000 - SSDBlockStore.crashTempTTLSeconds))],
             ofItemAtPath: restartedTemp.path)
+        SSDWholeRootMaintainer.shared.startPeriodicMaintenance(
+            root: root,
+            ttlSeconds: 900,
+            intervalSeconds: 3600,
+            nowSeconds: { 10_000 },
+            budgetBytes: { 1 << 20 })
         let restartDeadline = ContinuousClock.now + .seconds(2)
         while ContinuousClock.now < restartDeadline,
             FileManager.default.fileExists(atPath: restartedTemp.path)

--- a/provider-swift/Tests/ProviderCoreTests/SpecDecArtifactFunnelTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/SpecDecArtifactFunnelTests.swift
@@ -57,6 +57,14 @@ private actor SlowFunnelCatalog: SpecDecCatalogLooking {
     }
 }
 
+private actor FunnelSleepProbe {
+    private(set) var durations: [Duration] = []
+
+    func sleep(_ duration: Duration) {
+        durations.append(duration)
+    }
+}
+
 private func funnelModel(id: String = "gemma-4-target", metadata: [String: JSONValue]? = nil) -> CatalogModel {
     CatalogModel(
         id: id, s3Name: "unused", displayName: id, sizeGb: 1,
@@ -280,18 +288,20 @@ struct SpecDecArtifactFunnelTests {
         #expect(await catalog.cancellations == 1)
     }
 
-    @Test("catalog prewarm has a short fail-open deadline")
+    @Test("catalog prewarm fails open when the short deadline wins")
     func prewarmDeadline() async {
+        let sleepProbe = FunnelSleepProbe()
         let funnel = SpecDecArtifactFunnel(
             resolver: SpecDecResolver(
                 storeRoot: FileManager.default.temporaryDirectory,
                 cdnBaseURL: "http://127.0.0.1:1"),
             catalog: SlowFunnelCatalog())
-        let started = ContinuousClock.now
         let warmed = await funnel.prewarmCatalog(
-            modelId: "gemma-4-target", timeout: .milliseconds(20))
+            modelId: "gemma-4-target",
+            timeout: .milliseconds(20),
+            sleep: { duration in await sleepProbe.sleep(duration) })
         #expect(!warmed)
-        #expect(ContinuousClock.now - started < .milliseconds(250))
+        #expect(await sleepProbe.durations == [.milliseconds(20)])
         await funnel.shutdown()
     }
 }

--- a/provider-swift/Tests/ProviderCoreTests/SpecDecArtifactFunnelTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/SpecDecArtifactFunnelTests.swift
@@ -1,0 +1,297 @@
+import Foundation
+import Testing
+@testable import ProviderCore
+
+private actor FunnelCatalog: SpecDecCatalogLooking {
+    private let value: CatalogModel?
+    private(set) var calls = 0
+
+    init(_ value: CatalogModel?) { self.value = value }
+
+    func cachedModel(id: String) -> CatalogModel? { value }
+
+    func model(id: String) async throws -> CatalogModel? {
+        calls += 1
+        return value
+    }
+}
+
+private actor GatedFunnelCatalog: SpecDecCatalogLooking {
+    private let value: CatalogModel
+    private var continuation: CheckedContinuation<CatalogModel?, any Error>?
+    private(set) var calls = 0
+    private(set) var active = 0
+    private(set) var cancellations = 0
+
+    init(_ value: CatalogModel) { self.value = value }
+
+    func cachedModel(id: String) -> CatalogModel? { nil }
+
+    func model(id: String) async throws -> CatalogModel? {
+        calls += 1
+        active += 1
+        defer { active -= 1 }
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                self.continuation = continuation
+            }
+        } onCancel: {
+            Task { await self.recordCancellation() }
+        }
+    }
+
+    func release() {
+        let pending = continuation
+        continuation = nil
+        pending?.resume(returning: value)
+    }
+
+    private func recordCancellation() { cancellations += 1 }
+}
+
+private actor SlowFunnelCatalog: SpecDecCatalogLooking {
+    func cachedModel(id: String) -> CatalogModel? { nil }
+    func model(id: String) async throws -> CatalogModel? {
+        try await taskSleep(.seconds(5))
+        return nil
+    }
+}
+
+private func funnelModel(id: String = "gemma-4-target", metadata: [String: JSONValue]? = nil) -> CatalogModel {
+    CatalogModel(
+        id: id, s3Name: "unused", displayName: id, sizeGb: 1,
+        metadata: metadata)
+}
+
+private let localAssistantConfig = Data(#"{"model_type":"gemma4_assistant"}"#.utf8)
+
+private func makeLocalAssistant() throws -> URL {
+    let root = FileManager.default.temporaryDirectory
+        .appendingPathComponent("specdec-local-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    try localAssistantConfig.write(to: root.appendingPathComponent("config.json"))
+    try Data(repeating: 0x5a, count: 4096)
+        .write(to: root.appendingPathComponent("model.safetensors"))
+    return root
+}
+
+@Suite("SpecDec production artifact funnel")
+struct SpecDecArtifactFunnelTests {
+    private func funnel(catalog: FunnelCatalog, root: URL) -> SpecDecArtifactFunnel {
+        SpecDecArtifactFunnel(
+            resolver: SpecDecResolver(storeRoot: root, cdnBaseURL: "http://127.0.0.1:1"),
+            catalog: catalog)
+    }
+
+    @Test("local override takes precedence and never reads catalog")
+    func localPrecedence() async throws {
+        let local = try makeLocalAssistant()
+        defer { try? FileManager.default.removeItem(at: local) }
+        let store = FileManager.default.temporaryDirectory
+            .appendingPathComponent("specdec-store-\(UUID().uuidString)")
+        let catalog = FunnelCatalog(nil)
+        let prepared = await funnel(catalog: catalog, root: store).prepare(
+            .init(
+                modelId: "gemma-4-target", modelType: "gemma4", enabled: true,
+                localPath: local.path, allowDownload: true, environment: [:]))
+        let artifact = try #require(prepared.artifact)
+        #expect(artifact.source == .local)
+        #expect(artifact.artifactBytes == UInt64(4096 + localAssistantConfig.count))
+        #expect(artifact.residentBytes == SpecDecLimits.residentEstimate(
+            artifactBytes: artifact.artifactBytes))
+        #expect(await catalog.calls == 0)
+    }
+
+    @Test("invalid local override does not silently activate catalog assistant")
+    func invalidLocalDoesNotFallThrough() async {
+        let catalog = FunnelCatalog(funnelModel(metadata: [
+            "spec_dec": .object([("r2_prefix", .string("v2-specdec/other/v1"))])
+        ]))
+        let prepared = await funnel(
+            catalog: catalog,
+            root: FileManager.default.temporaryDirectory
+        ).prepare(
+            .init(
+                modelId: "gemma-4-target", modelType: "gemma4", enabled: true,
+                localPath: "/definitely/missing", allowDownload: true, environment: [:]))
+        #expect(prepared.artifact == nil)
+        #expect(prepared.status.reason == .localArtifactInvalid)
+        #expect(await catalog.calls == 0)
+    }
+
+    @Test("non-Gemma target never resolves or loads an assistant")
+    func nonGemmaExcludedBeforeCatalog() async {
+        let catalog = FunnelCatalog(funnelModel())
+        let prepared = await funnel(
+            catalog: catalog,
+            root: FileManager.default.temporaryDirectory
+        ).prepare(
+            .init(
+                modelId: "gpt-oss", modelType: "gpt_oss", enabled: true,
+                localPath: nil, allowDownload: true, environment: [:]))
+        #expect(prepared.status.reason == .targetUnsupported)
+        #expect(await catalog.calls == 0)
+    }
+
+    @Test("assistant-like Gemma namespace variants are rejected before catalog")
+    func assistantNamespaceVariantsExcluded() async {
+        let catalog = FunnelCatalog(funnelModel())
+        let artifactFunnel = funnel(
+            catalog: catalog, root: FileManager.default.temporaryDirectory)
+        for type in ["gemma4_assistant_v2", "gemma4_text_assistant", "gemma4_mtp"] {
+            let prepared = await artifactFunnel.prepare(.init(
+                modelId: "gemma", modelType: type, enabled: true,
+                localPath: nil, allowDownload: true, environment: [:]))
+            #expect(prepared.status.reason == .targetUnsupported, "type=\(type)")
+        }
+        #expect(await catalog.calls == 0)
+    }
+
+    @Test("local assistant rejects symlink roots and children")
+    func localSymlinksRejected() throws {
+        let real = try makeLocalAssistant()
+        defer { try? FileManager.default.removeItem(at: real) }
+        let rootLink = real.deletingLastPathComponent()
+            .appendingPathComponent("specdec-root-link-\(UUID().uuidString)")
+        try FileManager.default.createSymbolicLink(at: rootLink, withDestinationURL: real)
+        defer { try? FileManager.default.removeItem(at: rootLink) }
+        #expect(SpecDecStore.inspectLocalArtifact(path: rootLink.path) == nil)
+
+        let childRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("specdec-child-link-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: childRoot, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: childRoot) }
+        try localAssistantConfig.write(to: childRoot.appendingPathComponent("config.json"))
+        try FileManager.default.createSymbolicLink(
+            at: childRoot.appendingPathComponent("model.safetensors"),
+            withDestinationURL: real.appendingPathComponent("model.safetensors"))
+        #expect(SpecDecStore.inspectLocalArtifact(path: childRoot.path) == nil)
+    }
+
+    @Test("local assistant config is capped before loader admission")
+    func localConfigCap() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("specdec-config-cap-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        try Data(repeating: 0x20, count: Int(SpecDecLimits.maximumConfigBytes + 1))
+            .write(to: root.appendingPathComponent("config.json"))
+        try Data([0x01]).write(to: root.appendingPathComponent("model.safetensors"))
+        #expect(SpecDecStore.inspectLocalArtifact(path: root.path) == nil)
+    }
+
+    @Test("default off and kill switch are target-only before catalog lookup")
+    func disabledStates() async {
+        let catalog = FunnelCatalog(funnelModel())
+        let artifactFunnel = funnel(
+            catalog: catalog,
+            root: FileManager.default.temporaryDirectory)
+        let off = await artifactFunnel.prepare(
+            .init(
+                modelId: "gemma", modelType: "gemma4", enabled: false,
+                localPath: nil, allowDownload: true, environment: [:]))
+        let killed = await artifactFunnel.prepare(
+            .init(
+                modelId: "gemma", modelType: "gemma4", enabled: true,
+                localPath: nil, allowDownload: true,
+                environment: ["DARKBLOOM_CBV2_MTP": "off"]))
+        #expect(off.status == .disabled(.configDisabled, configured: false))
+        #expect(killed.status == .disabled(.killSwitchDisabled, configured: true))
+        #expect(await catalog.calls == 0)
+    }
+
+    @Test("missing and malformed metadata return stable fail-open reasons")
+    func metadataReasons() async {
+        let missingCatalog = FunnelCatalog(funnelModel())
+        let missing = await funnel(
+            catalog: missingCatalog,
+            root: FileManager.default.temporaryDirectory
+        ).prepare(
+            .init(
+                modelId: "gemma-4-target", modelType: "gemma4", enabled: true,
+                localPath: nil, allowDownload: true, environment: [:]))
+        #expect(missing.status.reason == .metadataMissing)
+
+        let malformedCatalog = FunnelCatalog(funnelModel(metadata: [
+            "spec_dec": .object([("r2_prefix", .string("../escape"))])
+        ]))
+        let malformed = await funnel(
+            catalog: malformedCatalog,
+            root: FileManager.default.temporaryDirectory
+        ).prepare(
+            .init(
+                modelId: "gemma-4-target", modelType: "gemma4", enabled: true,
+                localPath: nil, allowDownload: true, environment: [:]))
+        #expect(malformed.status.reason == .metadataMalformed)
+    }
+
+    @Test("local-only policy never constructs or queries a coordinator catalog")
+    func localOnlyWithoutPathIsNetworkIndependent() async {
+        let funnel = SpecDecArtifactFunnel(
+            resolver: SpecDecResolver(
+                storeRoot: FileManager.default.temporaryDirectory,
+                cdnBaseURL: "http://127.0.0.1:1"),
+            catalog: nil)
+        let prepared = await funnel.prepare(
+            .init(
+                modelId: "gemma-4-target", modelType: "gemma4", enabled: true,
+                localPath: nil, allowDownload: false, environment: [:]))
+        #expect(prepared.artifact == nil)
+        #expect(prepared.status.reason == .catalogDisabled)
+        await funnel.shutdown()
+    }
+
+    @Test("shutdown is terminal across queued and reentrant prefetch scheduling")
+    func shutdownRejectsReentrantWorkWithoutTaskLeak() async throws {
+        let catalog = GatedFunnelCatalog(funnelModel())
+        let store = FileManager.default.temporaryDirectory
+            .appendingPathComponent("specdec-shutdown-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: store) }
+        let funnel = SpecDecArtifactFunnel(
+            resolver: SpecDecResolver(
+                storeRoot: store, cdnBaseURL: "http://127.0.0.1:1"),
+            catalog: catalog)
+        let request = SpecDecArtifactFunnel.Request(
+            modelId: "gemma-4-target", modelType: "gemma4", enabled: true,
+            localPath: nil, allowDownload: true, environment: [:])
+
+        _ = await funnel.prepare(request)
+        for _ in 0..<100 {
+            if await catalog.calls > 0 { break }
+            try await Task.sleep(nanoseconds: 5_000_000)
+        }
+        let shutdown = Task { await funnel.shutdown() }
+        for _ in 0..<100 {
+            if await catalog.cancellations > 0 { break }
+            try await Task.sleep(nanoseconds: 5_000_000)
+        }
+
+        let reentrant = await funnel.prepare(request)
+        #expect(reentrant.artifact == nil)
+        #expect(reentrant.status.reason == .catalogUnavailable)
+        #expect(await catalog.calls == 1)
+
+        await catalog.release()
+        await shutdown.value
+        let after = await funnel.prepare(request)
+        #expect(after.status.reason == .catalogUnavailable)
+        #expect(await catalog.calls == 1)
+        #expect(await catalog.active == 0)
+        #expect(await catalog.cancellations == 1)
+    }
+
+    @Test("catalog prewarm has a short fail-open deadline")
+    func prewarmDeadline() async {
+        let funnel = SpecDecArtifactFunnel(
+            resolver: SpecDecResolver(
+                storeRoot: FileManager.default.temporaryDirectory,
+                cdnBaseURL: "http://127.0.0.1:1"),
+            catalog: SlowFunnelCatalog())
+        let started = ContinuousClock.now
+        let warmed = await funnel.prewarmCatalog(
+            modelId: "gemma-4-target", timeout: .milliseconds(20))
+        #expect(!warmed)
+        #expect(ContinuousClock.now - started < .milliseconds(250))
+        await funnel.shutdown()
+    }
+}

--- a/provider-swift/Tests/ProviderCoreTests/SpecDecArtifactFunnelTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/SpecDecArtifactFunnelTests.swift
@@ -49,6 +49,30 @@ private actor GatedFunnelCatalog: SpecDecCatalogLooking {
     private func recordCancellation() { cancellations += 1 }
 }
 
+private actor StaleFunnelCatalog: SpecDecCatalogLooking {
+    private let stale: CatalogModel
+    private let fresh: CatalogModel
+    private(set) var cachedCalls = 0
+    private(set) var freshCalls = 0
+
+    init(stale: CatalogModel, fresh: CatalogModel) {
+        self.stale = stale
+        self.fresh = fresh
+    }
+
+    func cachedModel(id: String) -> CatalogModel? {
+        cachedCalls += 1
+        return stale
+    }
+
+    func model(id: String) async throws -> CatalogModel? { stale }
+
+    func freshModel(id: String) async throws -> CatalogModel? {
+        freshCalls += 1
+        return fresh
+    }
+}
+
 private actor SlowFunnelCatalog: SpecDecCatalogLooking {
     func cachedModel(id: String) -> CatalogModel? { nil }
     func model(id: String) async throws -> CatalogModel? {
@@ -211,26 +235,71 @@ struct SpecDecArtifactFunnelTests {
     @Test("missing and malformed metadata return stable fail-open reasons")
     func metadataReasons() async {
         let missingCatalog = FunnelCatalog(funnelModel())
-        let missing = await funnel(
-            catalog: missingCatalog,
-            root: FileManager.default.temporaryDirectory
-        ).prepare(
+        let missingFunnel = funnel(
+            catalog: missingCatalog, root: FileManager.default.temporaryDirectory)
+        let missing = await missingFunnel.prepare(
             .init(
                 modelId: "gemma-4-target", modelType: "gemma4", enabled: true,
                 localPath: nil, allowDownload: true, environment: [:]))
         #expect(missing.status.reason == .metadataMissing)
+        await missingFunnel.shutdown()
 
         let malformedCatalog = FunnelCatalog(funnelModel(metadata: [
             "spec_dec": .object([("r2_prefix", .string("../escape"))])
         ]))
-        let malformed = await funnel(
-            catalog: malformedCatalog,
-            root: FileManager.default.temporaryDirectory
-        ).prepare(
+        let malformedFunnel = funnel(
+            catalog: malformedCatalog, root: FileManager.default.temporaryDirectory)
+        let malformed = await malformedFunnel.prepare(
             .init(
                 modelId: "gemma-4-target", modelType: "gemma4", enabled: true,
                 localPath: nil, allowDownload: true, environment: [:]))
         #expect(malformed.status.reason == .metadataMalformed)
+        await malformedFunnel.shutdown()
+    }
+
+    @Test("stale cached entry without spec_dec triggers one cooldown-gated refresh")
+    func staleCatalogEntryRefreshes() async throws {
+        let catalog = StaleFunnelCatalog(
+            stale: funnelModel(),
+            fresh: funnelModel(metadata: [
+                "spec_dec": .object([("r2_prefix", .string("v2-specdec/gemma/v1"))])
+            ]))
+        let store = FileManager.default.temporaryDirectory
+            .appendingPathComponent("specdec-stale-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: store) }
+        let artifactFunnel = SpecDecArtifactFunnel(
+            resolver: SpecDecResolver(storeRoot: store, cdnBaseURL: "http://127.0.0.1:1"),
+            catalog: catalog)
+        let request = SpecDecArtifactFunnel.Request(
+            modelId: "gemma-4-target", modelType: "gemma4", enabled: true,
+            localPath: nil, allowDownload: true, environment: [:])
+
+        // The cached entry is stale (no spec_dec): the prepare itself stays
+        // fail-open, but a background catalog refresh must be scheduled so a
+        // coordinator that added spec_dec to an existing id can roll out
+        // without a provider restart.
+        let first = await artifactFunnel.prepare(request)
+        #expect(first.status.reason == .metadataMissing)
+        // An immediate second prepare must not schedule a second refresh
+        // (in-flight dedupe now, cooldown stamp afterwards).
+        _ = await artifactFunnel.prepare(request)
+        for _ in 0 ..< 200 {
+            if await catalog.freshCalls > 0 { break }
+            try await Task.sleep(nanoseconds: 5_000_000)
+        }
+        #expect(await catalog.freshCalls == 1)
+
+        // Wait for the refresh task to finish (its prefetch against the dead
+        // CDN fails fast), then verify the cooldown blocks a re-refresh.
+        for _ in 0 ..< 200 {
+            if await artifactFunnel.prefetchInFlightForTesting == 0 { break }
+            try await Task.sleep(nanoseconds: 5_000_000)
+        }
+        _ = await artifactFunnel.prepare(request)
+        await artifactFunnel.shutdown()
+        #expect(await catalog.freshCalls == 1)
+        // A local-only prepare never schedules refreshes at all.
+        #expect(await catalog.cachedCalls > 0)
     }
 
     @Test("local-only policy never constructs or queries a coordinator catalog")

--- a/provider-swift/Tests/ProviderCoreTests/SpecDecCapacityTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/SpecDecCapacityTests.swift
@@ -48,10 +48,11 @@ struct SpecDecSizingSnapshotTests {
         let folded = snapshot(weights: 15_000_000_000, aux: Int(drafterEstimateBytes))
         let direct = snapshot(weights: 15_000_000_000 + Int(drafterEstimateBytes))
         #expect(folded.weightsBytes == 15_000_000_000 + Int(drafterEstimateBytes))
-        // Equatable identity is the "all consumers see the sum" guarantee:
-        // no consumer can distinguish the folded snapshot from one whose
-        // target weights were simply that much larger.
-        #expect(folded == direct)
+        // Downstream capacity consumers read the identical folded total. The
+        // component fields intentionally remain distinct for fail-open rebuilds.
+        #expect(folded.weightsBytes == direct.weightsBytes)
+        #expect(folded.fp16KVBytesPerToken == direct.fp16KVBytesPerToken)
+        #expect(folded.maxContextLength == direct.maxContextLength)
     }
 
     @Test("default (0) and negative auxiliary bytes leave weightsBytes unchanged")
@@ -59,6 +60,26 @@ struct SpecDecSizingSnapshotTests {
         #expect(snapshot(weights: 100).weightsBytes == 100)
         #expect(snapshot(weights: 100, aux: 0).weightsBytes == 100)
         #expect(snapshot(weights: 100, aux: -7).weightsBytes == 100)
+    }
+
+    @Test("weight-byte sum saturates instead of trapping at Int boundary")
+    func sizingSaturates() {
+        let saturated = snapshot(weights: Int.max - 4, aux: 10)
+        #expect(saturated.weightsBytes == Int.max)
+        #expect(saturated.targetWeightsBytes == Int.max - 4)
+        #expect(saturated.auxiliaryWeightBytes == 10)
+    }
+
+    @Test("replacing auxiliary bytes charges active assistant exactly once")
+    func replacingAuxiliaryIsExact() {
+        let candidate = snapshot(weights: 1_000, aux: 200)
+        let active = candidate.replacingAuxiliaryWeightBytes(200)
+        let fallback = candidate.replacingAuxiliaryWeightBytes(0)
+        #expect(active.weightsBytes == 1_200)
+        #expect(active.targetWeightsBytes == 1_000)
+        #expect(active.auxiliaryWeightBytes == 200)
+        #expect(fallback.weightsBytes == 1_000)
+        #expect(fallback.auxiliaryWeightBytes == 0)
     }
 
     @Test("KV-rate fields are untouched by auxiliary bytes (drafter writes no KV)")
@@ -172,6 +193,57 @@ struct SpecDecLoadGateTests {
                 estimatedWeightsGb: Double(UInt64.max) / 1_073_741_824 * 0.999,
                 extraWeightBytes: .max)
                 == .max)
+    }
+
+    @Test("assistant admission boundary is exact and malformed inputs fail closed")
+    func assistantAdmissionBoundary() {
+        let oneGiB: UInt64 = 1_073_741_824
+        #expect(ProviderLoop.assistantMemoryFits(
+            availableGb: 11, targetRequiredGb: 10, assistantBytes: oneGiB))
+        #expect(!ProviderLoop.assistantMemoryFits(
+            availableGb: 10.999, targetRequiredGb: 10,
+            assistantBytes: oneGiB))
+        #expect(!ProviderLoop.assistantMemoryFits(
+            availableGb: .nan, targetRequiredGb: 10, assistantBytes: oneGiB))
+        #expect(!ProviderLoop.assistantMemoryFits(
+            availableGb: 11, targetRequiredGb: .infinity, assistantBytes: oneGiB))
+    }
+
+    @Test("pending reservation atomically transfers from target+assistant to assistant only")
+    func pendingReservationTransfer() async {
+        let budget = GlobalKVCacheBudget(
+            memorySnapshot: {
+                .init(total: 10_000, active: 0, cache: 0, systemAvailable: 10_000)
+            })
+        await budget.reservePendingLoad(requestID: "load", bytes: 1_200)
+        #expect(await budget.outstandingReservedBytes() == 1_200)
+        await budget.replacePendingLoadReservation(requestID: "load", bytes: 200)
+        #expect(await budget.outstandingReservedBytes() == 200)
+        await budget.replacePendingLoadReservation(requestID: "load", bytes: 0)
+        #expect(await budget.outstandingReservedBytes() == 0)
+    }
+
+    @Test("pending reservation shrink and removal reset rejection audit progress")
+    func pendingReservationProgressResetsAuditStreak() async {
+        let unit: UInt64 = 1_073_741_824
+        let budget = GlobalKVCacheBudget(
+            capFraction: 1.0,
+            activationReserveBytes: 0,
+            memorySnapshot: {
+                .init(total: 8 * unit, active: 0, cache: 0, systemAvailable: .max)
+            })
+        await budget.reservePendingLoad(requestID: "load", bytes: 6 * unit)
+        #expect(!(await budget.reserveBytes(requestID: "rejected-1", bytes: unit)))
+        #expect(await budget.rejectionStreakArmedForTesting())
+
+        await budget.replacePendingLoadReservation(requestID: "load", bytes: 5 * unit)
+        #expect(!(await budget.rejectionStreakArmedForTesting()))
+        #expect(!(await budget.reserveBytes(requestID: "rejected-2", bytes: 2 * unit)))
+        #expect(await budget.rejectionStreakArmedForTesting())
+
+        await budget.replacePendingLoadReservation(requestID: "load", bytes: 0)
+        #expect(!(await budget.rejectionStreakArmedForTesting()))
+        #expect(await budget.outstandingReservedBytes() == 0)
     }
 }
 

--- a/provider-swift/Tests/ProviderCoreTests/SpecDecCapacityTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/SpecDecCapacityTests.swift
@@ -1,0 +1,325 @@
+// Copyright © 2026 Eigen Labs.
+//
+// Capacity accounting for Gemma 4 MTP speculative decoding (plan D5):
+//
+//   1. Drafter (auxiliary) weight bytes fold INTO
+//      `SlotSizingSnapshot.weightsBytes` at construction, so every consumer
+//      of `.weightsBytes` — fleet KV budget, re-slice grants, heartbeat
+//      clamp, StandaloneServer's mirrored budget — sees the sum with zero
+//      consumer-site changes. KV-rate math must be untouched (the drafter
+//      writes no KV).
+//   2. The load gate (`ensureModelLoaded`) adds `extraWeightBytes` to BOTH
+//      the required-to-load figure and the pending-load reservation. The
+//      drafter lives outside the model snapshot on every path, so the
+//      scan-time `estimatedMemoryGb` can never include it.
+//   3. The slot's opaque MTP drafter handle is released with the target on
+//      `unloadModel` (the gray-box lesson: no unaccounted residents, no
+//      leaked residents).
+
+import Foundation
+import MLX
+import MLXLMCommon
+import MLXNN
+import Testing
+
+@testable import ProviderCore
+
+private let gib = 1024.0 * 1024.0 * 1024.0
+/// The real drafter figure the bridge passes: model.safetensors
+/// 236,124,704 B × the standard 1.2 load factor.
+private let drafterEstimateBytes = UInt64(236_124_704.0 * 1.2)
+
+// MARK: - Sizing snapshot: auxiliary bytes fold at construction
+
+@Suite("SpecDec capacity: sizing snapshot auxiliary-bytes fold")
+struct SpecDecSizingSnapshotTests {
+
+    private func snapshot(weights: Int, aux: Int = 0) -> SlotSizingSnapshot {
+        SlotSizingSnapshot(
+            weightsBytes: weights,
+            auxiliaryWeightBytes: aux,
+            fp16KVBytesPerToken: 20_480,
+            maxContextLength: 262_144,
+            defaultMaxTokens: 8192)
+    }
+
+    @Test("auxiliary bytes fold into weightsBytes — snapshot is IDENTICAL to a direct-sum one")
+    func auxiliaryFoldsIntoWeights() {
+        let folded = snapshot(weights: 15_000_000_000, aux: Int(drafterEstimateBytes))
+        let direct = snapshot(weights: 15_000_000_000 + Int(drafterEstimateBytes))
+        #expect(folded.weightsBytes == 15_000_000_000 + Int(drafterEstimateBytes))
+        // Equatable identity is the "all consumers see the sum" guarantee:
+        // no consumer can distinguish the folded snapshot from one whose
+        // target weights were simply that much larger.
+        #expect(folded == direct)
+    }
+
+    @Test("default (0) and negative auxiliary bytes leave weightsBytes unchanged")
+    func defaultAndNegativeAreInert() {
+        #expect(snapshot(weights: 100).weightsBytes == 100)
+        #expect(snapshot(weights: 100, aux: 0).weightsBytes == 100)
+        #expect(snapshot(weights: 100, aux: -7).weightsBytes == 100)
+    }
+
+    @Test("KV-rate fields are untouched by auxiliary bytes (drafter writes no KV)")
+    func kvFieldsUntouched() {
+        let folded = snapshot(weights: 100, aux: Int(drafterEstimateBytes))
+        let plain = snapshot(weights: 100)
+        #expect(folded.fp16KVBytesPerToken == plain.fp16KVBytesPerToken)
+        #expect(folded.maxContextLength == plain.maxContextLength)
+        #expect(folded.defaultMaxTokens == plain.defaultMaxTokens)
+    }
+
+    @Test("fleet KV budget consumer: budget shrinks by exactly the auxiliary bytes")
+    func fleetKVBudgetSeesTheSum() {
+        // The fleet-budget consumer reads `.weightsBytes` into
+        // `UnifiedMemoryCap.kvBudgetBytes(residentWeightBytes:)`
+        // (ProviderLoop+EngineV2.fleetKVBudgetBytes and StandaloneServer's
+        // mirror). In the linear (non-clamped) region the drafter bytes must
+        // come straight out of the KV budget.
+        let physical: UInt64 = 64 * 1024 * 1024 * 1024
+        let base = snapshot(weights: 15_000_000_000)
+        let mtp = snapshot(weights: 15_000_000_000, aux: Int(drafterEstimateBytes))
+        let budgetBase = UnifiedMemoryCap.kvBudgetBytes(
+            physicalBytes: physical,
+            residentWeightBytes: UInt64(base.weightsBytes),
+            activationReserveBytes: 3 * 1024 * 1024 * 1024)
+        let budgetMTP = UnifiedMemoryCap.kvBudgetBytes(
+            physicalBytes: physical,
+            residentWeightBytes: UInt64(mtp.weightsBytes),
+            activationReserveBytes: 3 * 1024 * 1024 * 1024)
+        #expect(budgetBase > 0)
+        #expect(budgetBase - budgetMTP == drafterEstimateBytes)
+    }
+
+    @Test("build(): auxiliary bytes fold in; every other field byte-identical")
+    func buildFoldsAuxiliaryBytes() async {
+        // Weight-free stub container (Σ parameter nbytes == 0), so the folded
+        // figure IS the auxiliary figure and the KV-rate/context fields can
+        // be compared field-for-field between the two builds.
+        let plain = await SlotSizingSnapshot.build(
+            container: makeSpecDecStubContainer(),
+            modelPath: nil,
+            fallbackDefaultMaxTokens: 4096)
+        let mtp = await SlotSizingSnapshot.build(
+            container: makeSpecDecStubContainer(),
+            modelPath: nil,
+            fallbackDefaultMaxTokens: 4096,
+            auxiliaryWeightBytes: Int(drafterEstimateBytes))
+        #expect(mtp.weightsBytes == plain.weightsBytes + Int(drafterEstimateBytes))
+        #expect(mtp.fp16KVBytesPerToken == plain.fp16KVBytesPerToken)
+        #expect(mtp.maxContextLength == plain.maxContextLength)
+        #expect(mtp.defaultMaxTokens == plain.defaultMaxTokens)
+    }
+}
+
+// MARK: - Load gate: extraWeightBytes arithmetic
+
+@Suite("SpecDec capacity: load-gate extra-bytes arithmetic")
+struct SpecDecLoadGateTests {
+
+    @Test("loadGateWeightsGb adds exactly extraWeightBytes/GiB; zero is the identity")
+    func loadGateAddsExtraGb() {
+        let base = 21.5
+        #expect(ProviderLoop.loadGateWeightsGb(estimatedWeightsGb: base, extraWeightBytes: 0) == base)
+        let withDrafter = ProviderLoop.loadGateWeightsGb(
+            estimatedWeightsGb: base, extraWeightBytes: drafterEstimateBytes)
+        #expect(withDrafter == base + Double(drafterEstimateBytes) / gib)
+    }
+
+    @Test("requiredToLoadGb over the folded figure == weights + drafter + headroom")
+    func requiredToLoadComposition() {
+        let required = ModelLoadAdmission.requiredToLoadGb(
+            weightsGb: ProviderLoop.loadGateWeightsGb(
+                estimatedWeightsGb: 21.5, extraWeightBytes: drafterEstimateBytes),
+            headroomGb: 5.0)
+        #expect(abs(required - (21.5 + Double(drafterEstimateBytes) / gib + 5.0)) < 1e-9)
+    }
+
+    @Test("pending-load reservation includes the drafter bytes")
+    func pendingReservationIncludesExtra() {
+        let bytes = ProviderLoop.pendingLoadReservationBytes(
+            estimatedWeightsGb: 2.0, extraWeightBytes: drafterEstimateBytes)
+        #expect(bytes == 2 * 1_073_741_824 + drafterEstimateBytes)
+    }
+
+    @Test("pre-MTP behavior preserved: no extra bytes, sane estimate")
+    func pendingReservationBaseline() {
+        #expect(
+            ProviderLoop.pendingLoadReservationBytes(estimatedWeightsGb: 2.0, extraWeightBytes: 0)
+                == 2 * 1_073_741_824)
+    }
+
+    @Test("garbage estimates contribute nothing — the extra bytes still reserve")
+    func pendingReservationGarbageEstimate() {
+        for garbage in [0.0, -3.5, .nan, .infinity, -.infinity] as [Double] {
+            #expect(
+                ProviderLoop.pendingLoadReservationBytes(
+                    estimatedWeightsGb: garbage, extraWeightBytes: drafterEstimateBytes)
+                    == drafterEstimateBytes,
+                "estimate=\(garbage)")
+        }
+    }
+
+    @Test("saturation: huge estimate or overflowing sum clamps to UInt64.max")
+    func pendingReservationSaturates() {
+        #expect(
+            ProviderLoop.pendingLoadReservationBytes(
+                estimatedWeightsGb: 1e30, extraWeightBytes: drafterEstimateBytes)
+                == .max)
+        #expect(
+            ProviderLoop.pendingLoadReservationBytes(
+                estimatedWeightsGb: Double(UInt64.max) / 1_073_741_824 * 0.999,
+                extraWeightBytes: .max)
+                == .max)
+    }
+}
+
+// MARK: - Slot teardown releases the drafter handle
+
+/// Weight-free stubs so a real `ModelSlot` can exist (same pattern as
+/// LoadedModelsStoreTests / EngineV2ProductionWiringTests).
+private struct SpecDecStubTokenizer: MLXLMCommon.Tokenizer {
+    func encode(text: String, addSpecialTokens: Bool) -> [Int] { [0] }
+    func decode(tokenIds: [Int], skipSpecialTokens: Bool) -> String { "" }
+    func convertTokenToId(_ token: String) -> Int? { nil }
+    func convertIdToToken(_ id: Int) -> String? { nil }
+    var bosToken: String? { nil }
+    var eosToken: String? { nil }
+    var unknownToken: String? { nil }
+    func applyChatTemplate(
+        messages: [[String: any Sendable]],
+        tools: [[String: any Sendable]]?,
+        additionalContext: [String: any Sendable]?
+    ) throws -> [Int] { [0] }
+}
+
+private final class SpecDecStubLanguageModel: Module, LanguageModel {
+    func prepare(_ input: LMInput, cache: [KVCache], windowSize: Int?) throws -> PrepareResult {
+        .tokens(input.text)
+    }
+    func newCache(parameters: GenerateParameters?) -> [KVCache] { [] }
+}
+
+private struct SpecDecStubProcessorError: Error {}
+private struct SpecDecStubProcessor: UserInputProcessor {
+    func prepare(input: UserInput) async throws -> LMInput {
+        throw SpecDecStubProcessorError()
+    }
+}
+
+private func makeSpecDecStubContainer() -> ModelContainer {
+    ModelContainer(
+        context: ModelContext(
+            configuration: ModelConfiguration(id: "test/specdec-stub-model"),
+            model: SpecDecStubLanguageModel(),
+            processor: SpecDecStubProcessor(),
+            tokenizer: SpecDecStubTokenizer()
+        ))
+}
+
+private func makeSpecDecLoop() throws -> ProviderLoop {
+    let config = ProviderLoopConfig(
+        coordinatorURL: "ws://127.0.0.1:0/ignored",
+        hardware: HardwareInfo(
+            machineModel: "Mac16,5", chipName: "Apple M4 Max", chipFamily: .m4, chipTier: .max,
+            memoryGb: 128, memoryAvailableGb: 124,
+            cpuCores: CpuCores(total: 16, performance: 12, efficiency: 4),
+            gpuCores: 40, memoryBandwidthGbs: 546
+        ),
+        models: [],
+        config: ProviderConfig(
+            provider: ProviderSettings(name: "specdec-capacity-test", memoryReserveGB: 1),
+            backend: BackendSettings(idleTimeoutMins: 0, maxModelSlots: 2),
+            coordinator: CoordinatorSettings(heartbeatIntervalSecs: 60)
+        )
+    )
+    return try ProviderLoop(config: config, purgeLegacyFiles: false, attestationSigner: nil)
+}
+
+/// Stand-in for the MLXLLM drafter adapter — ProviderCore only ever sees the
+/// type-erased handle, so any (Sendable) class object exercises the
+/// ownership contract.
+private final class SpecDecFakeDrafterHandle: Sendable {}
+
+/// Lock-guarded weak observer (a bare `weak var` local can't cross the
+/// @Sendable/actor boundaries; same shape as EngineV2ResliceUnwindTests).
+private final class WeakHandleRef: @unchecked Sendable {
+    private let lock = NSLock()
+    private weak var _value: AnyObject?
+    init(_ value: AnyObject) { self._value = value }
+    var isAlive: Bool { lock.withLock { _value != nil } }
+}
+
+extension ProviderLoop {
+    /// Test-local seam: install a fully-formed slot CARRYING an opaque MTP
+    /// drafter handle (the shared `installModelSlotForTesting` predates the
+    /// field, and this suite owns the drafter-lifecycle contract). The handle
+    /// is created HERE so the non-Sendable strong reference never crosses the
+    /// actor boundary; the returned weak observer is the release probe (the
+    /// slot holds the only strong reference).
+    fileprivate func installSlotWithDrafterForSpecDecTesting(
+        modelId: String
+    ) -> WeakHandleRef {
+        let drafter = SpecDecFakeDrafterHandle()
+        modelSlots[modelId] = ModelSlot(
+            engineV2: makeInertStubBridge(modelId: modelId).bridge,
+            container: makeSpecDecStubContainer(),
+            tokenizer: TokenizerHandle(SpecDecStubTokenizer()),
+            sizing: SlotSizingSnapshot(
+                weightsBytes: 0, fp16KVBytesPerToken: 0,
+                maxContextLength: 0, defaultMaxTokens: 4096),
+            isVLM: false,
+            modelType: "gemma4",
+            mtpDrafter: drafter,
+            lastInferenceAt: .now
+        )
+        return WeakHandleRef(drafter)
+    }
+
+    fileprivate func hasMTPDrafterForSpecDecTesting(modelId: String) -> Bool {
+        modelSlots[modelId]?.mtpDrafter != nil
+    }
+}
+
+@Suite("SpecDec capacity: slot drafter-handle teardown", .serialized)
+struct SpecDecSlotTeardownTests {
+
+    init() {
+        // unloadModel calls MLX.Memory.clearCache(), which initializes the
+        // MLX device — the metallib must sit next to the test runner.
+        _ = LiveInferenceFixtures.ensureMetallibColocated()
+    }
+
+    @Test("unloadModel releases the slot's drafter handle with the target")
+    func unloadReleasesDrafterHandle() async throws {
+        let loop = try makeSpecDecLoop()
+        let modelId = "gemma-4-26b-it-mtp"
+
+        // The slot is the ONLY strong owner of the handle from birth.
+        let weakDrafter = await loop.installSlotWithDrafterForSpecDecTesting(
+            modelId: modelId)
+        #expect(weakDrafter.isAlive)
+        #expect(await loop.hasMTPDrafterForSpecDecTesting(modelId: modelId))
+
+        await loop.unloadModel(modelId)
+
+        #expect(await loop.hasMTPDrafterForSpecDecTesting(modelId: modelId) == false)
+        #expect(!weakDrafter.isAlive)
+    }
+
+    @Test("slots default to NO drafter handle (existing construction sites unchanged)")
+    func defaultSlotHasNoDrafter() async throws {
+        let loop = try makeSpecDecLoop()
+        let modelId = "gemma-4-26b-it"
+        await loop.installModelSlotForTesting(
+            modelId: modelId,
+            container: makeSpecDecStubContainer(),
+            tokenizer: TokenizerHandle(SpecDecStubTokenizer()),
+            engineV2: makeInertStubBridge(modelId: modelId).bridge
+        )
+        #expect(await loop.hasMTPDrafterForSpecDecTesting(modelId: modelId) == false)
+        await loop.unloadModel(modelId)
+        #expect(await loop.slotSizingForTesting(modelId: modelId) == nil)
+    }
+}

--- a/provider-swift/Tests/ProviderCoreTests/SpecDecResolverTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/SpecDecResolverTests.swift
@@ -24,6 +24,7 @@ private final class SpecDecFileServer: @unchecked Sendable {
     private var files: [String: Data] = [:]
     private var requested: [String] = []
     private var serverTask: Task<Void, Never>?
+    private var responseDelayNanoseconds: UInt64 = 0
 
     func setFiles(_ files: [String: Data]) {
         lock.lock(); self.files = files; lock.unlock()
@@ -37,12 +38,20 @@ private final class SpecDecFileServer: @unchecked Sendable {
         lock.lock(); requested = []; lock.unlock()
     }
 
+    func setResponseDelay(milliseconds: UInt64) {
+        lock.withLock { responseDelayNanoseconds = milliseconds * 1_000_000 }
+    }
+
     private func record(_ path: String) {
         lock.lock(); requested.append(path); lock.unlock()
     }
 
     private func body(for path: String) -> Data? {
         lock.lock(); defer { lock.unlock() }; return files[path]
+    }
+
+    private func responseDelay() -> UInt64 {
+        lock.withLock { responseDelayNanoseconds }
     }
 
     /// Bind 127.0.0.1 on a system-assigned port and return the base URL.
@@ -55,6 +64,8 @@ private final class SpecDecFileServer: @unchecked Sendable {
             guard let self else { return Response(status: .internalServerError) }
             let path = request.uri.path
             self.record(path)
+            let delay = self.responseDelay()
+            if delay > 0 { try? await Task.sleep(nanoseconds: delay) }
             guard let full = self.body(for: path) else {
                 return Response(status: .notFound)
             }
@@ -145,6 +156,15 @@ private func sha256Hex(_ data: Data) -> String {
     return hasher.finalize().map { String(format: "%02x", $0) }.joined()
 }
 
+private func aggregateHex(_ files: [(String, Data)]) -> String {
+    var aggregate = SHA256()
+    for (_, data) in files.sorted(by: { $0.0 < $1.0 }) {
+        let digest = SHA256.hash(data: data)
+        digest.withUnsafeBytes { aggregate.update(bufferPointer: $0) }
+    }
+    return aggregate.finalize().map { String(format: "%02x", $0) }.joined()
+}
+
 /// A tiny two-file drafter artifact (config + weights), deterministic bytes.
 private struct DrafterFixture {
     let prefix: String
@@ -169,9 +189,9 @@ private struct DrafterFixture {
             modelID: "darkbloom/gemma4-drafter-4bit",
             version: "v1",
             r2Prefix: prefix,
-            // Junk aggregate: the resolver performs NO aggregate-hash
-            // enforcement by design (plan D3) -- per-file SHA-256 only.
-            aggregateSHA256: String(repeating: "0", count: 64),
+            aggregateSHA256: aggregateHex([
+                ("config.json", configBytes), ("model.safetensors", weightBytes),
+            ]),
             totalSizeBytes: Int64(configBytes.count + weightBytes.count),
             fileCount: 2,
             files: [
@@ -186,13 +206,18 @@ private struct DrafterFixture {
 
     /// path -> bytes map for the file server (manifest.json + both files).
     func served() throws -> [String: Data] {
-        let encoder = JSONEncoder()
-        encoder.dateEncodingStrategy = .iso8601
         return [
-            "/\(prefix)/manifest.json": try encoder.encode(manifest),
+            "/\(prefix)/manifest.json": try manifestData(),
             "/\(prefix)/config.json": configBytes,
             "/\(prefix)/model.safetensors": weightBytes,
         ]
+    }
+
+    func manifestData() throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.sortedKeys]
+        return try encoder.encode(manifest)
     }
 }
 
@@ -205,6 +230,46 @@ private func makeModel(id: String, specDecPrefix: String?) -> CatalogModel {
         id: id, s3Name: "unused", displayName: id, sizeGb: 15.0,
         r2Prefix: "v2/\(id)/v1", metadata: metadata
     )
+}
+
+private func makePinnedModel(id: String, fixture: DrafterFixture) throws -> CatalogModel {
+    let manifestData = try fixture.manifestData()
+    return makeTrustedModel(
+        id: id,
+        prefix: fixture.prefix,
+        manifestData: manifestData,
+        totalSizeBytes: fixture.manifest.totalSizeBytes,
+        fileCount: fixture.manifest.fileCount,
+        configSHA256: sha256Hex(fixture.configBytes),
+        revision: fixture.manifest.version)
+}
+
+private func makeTrustedModel(
+    id: String,
+    prefix: String,
+    manifestData: Data,
+    totalSizeBytes: Int64,
+    fileCount: Int,
+    configSHA256: String,
+    revision: String,
+    manifestSHA256: String? = nil,
+    maximumFileCount: Int = 64
+) -> CatalogModel {
+    let metadata: [String: JSONValue] = [
+        "spec_dec": .object([
+            ("r2_prefix", .string(prefix)),
+            ("manifest_sha256", .string(manifestSHA256 ?? sha256Hex(manifestData))),
+            ("total_size_bytes", .int(totalSizeBytes)),
+            ("file_count", .int(Int64(fileCount))),
+            ("max_file_count", .int(Int64(maximumFileCount))),
+            ("allowed_file_types", .array([.string("config"), .string("weight")])),
+            ("config_sha256", .string(configSHA256)),
+            ("revision", .string(revision)),
+        ])
+    ]
+    return CatalogModel(
+        id: id, s3Name: "unused", displayName: id, sizeGb: 15,
+        metadata: metadata)
 }
 
 private func makeTempStoreRoot() -> URL {
@@ -230,10 +295,12 @@ struct SpecDecResolverTests {
         let storeRoot = makeTempStoreRoot()
         defer { try? FileManager.default.removeItem(at: storeRoot) }
         let resolver = SpecDecResolver(storeRoot: storeRoot, cdnBaseURL: baseURL.absoluteString)
-        let model = makeModel(id: "gemma-4-26b-qat", specDecPrefix: prefix)
+        let model = try makePinnedModel(id: "gemma-4-26b-qat", fixture: fixture)
 
-        let dir = await resolver.drafterDirectory(for: model, allowDownload: true)
-        let resolved = try #require(dir)
+        let cold = await resolver.resolve(model: model, allowDownload: true)
+        #expect(cold.artifact == nil)
+        #expect(cold.reason == .artifactNotCached)
+        let resolved = try #require(await resolver.prefetch(model: model).artifact?.directory)
 
         // Resolved dir lives under the store root (never the HF cache) and is
         // keyed by the prefix hash.
@@ -246,8 +313,9 @@ struct SpecDecResolverTests {
             ModelManifest.self, from: Data(contentsOf: resolved.appendingPathComponent("manifest.json")))
         #expect(storedManifest == fixture.manifest)
         // Staging was consumed by the atomic publish.
-        let staging = SpecDecStore.stagingDirectory(root: storeRoot, r2Prefix: prefix)
-        #expect(!FileManager.default.fileExists(atPath: staging.path))
+        let remaining = try FileManager.default.contentsOfDirectory(
+            at: storeRoot, includingPropertiesForKeys: nil)
+        #expect(!remaining.contains { $0.lastPathComponent.hasPrefix(".staging-") })
     }
 
     @Test("corrupt file (SHA mismatch after retries) fails open: nil, nothing published")
@@ -263,10 +331,11 @@ struct SpecDecResolverTests {
         let storeRoot = makeTempStoreRoot()
         defer { try? FileManager.default.removeItem(at: storeRoot) }
         let resolver = SpecDecResolver(storeRoot: storeRoot, cdnBaseURL: baseURL.absoluteString)
-        let model = makeModel(id: "gemma-4-26b-qat", specDecPrefix: prefix)
+        let model = try makePinnedModel(id: "gemma-4-26b-qat", fixture: fixture)
 
-        let dir = await resolver.drafterDirectory(for: model, allowDownload: true)
-        #expect(dir == nil)
+        let result = await resolver.prefetch(model: model)
+        #expect(result.artifact == nil)
+        #expect(result.reason == .fileDigestMismatch)
         // Nothing was published: the artifact dir does not exist.
         let artifactDir = SpecDecStore.artifactDirectory(root: storeRoot, r2Prefix: prefix)
         #expect(!FileManager.default.fileExists(atPath: artifactDir.path))
@@ -309,7 +378,7 @@ struct SpecDecResolverTests {
         #expect(server.requestedPaths().isEmpty)
         // And the helper mirrors the same decode.
         #expect(SpecDecResolver.specDecR2Prefix(for: bare) == nil)
-        #expect(SpecDecResolver.specDecR2Prefix(for: makeModel(id: "m", specDecPrefix: "p/q")) == "p/q")
+        #expect(SpecDecResolver.specDecR2Prefix(for: makeModel(id: "m", specDecPrefix: "p/q")) == nil)
     }
 
     @Test("manifest 404 fails open: nil, nothing published")
@@ -322,11 +391,16 @@ struct SpecDecResolverTests {
         let storeRoot = makeTempStoreRoot()
         defer { try? FileManager.default.removeItem(at: storeRoot) }
         let resolver = SpecDecResolver(storeRoot: storeRoot, cdnBaseURL: baseURL.absoluteString)
-        let model = makeModel(id: "gemma-4-26b-qat", specDecPrefix: "v2-specdec/missing/v1")
+        let prefix = "v2-specdec/missing/v1"
+        let model = makeTrustedModel(
+            id: "gemma-4-26b-qat", prefix: prefix,
+            manifestData: Data("missing".utf8), totalSizeBytes: 2,
+            fileCount: 2, configSHA256: String(repeating: "0", count: 64),
+            revision: "v1")
 
-        #expect(await resolver.drafterDirectory(for: model, allowDownload: true) == nil)
+        #expect(await resolver.prefetch(model: model).reason == .manifestFetchFailed)
         #expect(!FileManager.default.fileExists(
-            atPath: SpecDecStore.artifactDirectory(root: storeRoot, r2Prefix: "v2-specdec/missing/v1").path))
+            atPath: SpecDecStore.artifactDirectory(root: storeRoot, r2Prefix: prefix).path))
     }
 
     @Test("warm re-resolve returns the stored copy with zero network traffic")
@@ -342,18 +416,18 @@ struct SpecDecResolverTests {
         let storeRoot = makeTempStoreRoot()
         defer { try? FileManager.default.removeItem(at: storeRoot) }
         let resolver = SpecDecResolver(storeRoot: storeRoot, cdnBaseURL: baseURL.absoluteString)
-        let model = makeModel(id: "gemma-4-26b-qat", specDecPrefix: prefix)
+        let model = try makePinnedModel(id: "gemma-4-26b-qat", fixture: fixture)
 
-        let first = try #require(await resolver.drafterDirectory(for: model, allowDownload: true))
+        let first = try #require(await resolver.prefetch(model: model).artifact?.directory)
         #expect(!server.requestedPaths().isEmpty)
 
         server.clearRequested()
-        let second = try #require(await resolver.drafterDirectory(for: model, allowDownload: true))
+        let second = try #require(await resolver.resolve(model: model, allowDownload: true).artifact?.directory)
         #expect(second == first)
         #expect(server.requestedPaths().isEmpty, "warm re-resolve must not touch the CDN")
 
         // allowDownload: false also resolves a verified stored copy.
-        let third = try #require(await resolver.drafterDirectory(for: model, allowDownload: false))
+        let third = try #require(await resolver.resolve(model: model, allowDownload: false).artifact?.directory)
         #expect(third == first)
         #expect(server.requestedPaths().isEmpty)
     }
@@ -371,9 +445,9 @@ struct SpecDecResolverTests {
         let storeRoot = makeTempStoreRoot()
         defer { try? FileManager.default.removeItem(at: storeRoot) }
         let resolver = SpecDecResolver(storeRoot: storeRoot, cdnBaseURL: baseURL.absoluteString)
-        let model = makeModel(id: "gemma-4-26b-qat", specDecPrefix: prefix)
+        let model = try makePinnedModel(id: "gemma-4-26b-qat", fixture: fixture)
 
-        #expect(await resolver.drafterDirectory(for: model, allowDownload: false) == nil)
+        #expect(await resolver.resolve(model: model, allowDownload: false).reason == .artifactNotCached)
         #expect(server.requestedPaths().isEmpty)
     }
 
@@ -392,14 +466,383 @@ struct SpecDecResolverTests {
         let resolver = SpecDecResolver(storeRoot: storeRoot, cdnBaseURL: baseURL.absoluteString)
 
         // Two DIFFERENT catalog builds (qat + 8bit) point at the same artifact.
-        let qat = makeModel(id: "gemma-4-26b-qat", specDecPrefix: prefix)
-        let eightBit = makeModel(id: "gemma-4-26b-8bit", specDecPrefix: prefix)
+        let qat = try makePinnedModel(id: "gemma-4-26b-qat", fixture: fixture)
+        let eightBit = try makePinnedModel(id: "gemma-4-26b-8bit", fixture: fixture)
 
-        let qatDir = try #require(await resolver.drafterDirectory(for: qat, allowDownload: true))
+        let qatDir = try #require(await resolver.prefetch(model: qat).artifact?.directory)
         server.clearRequested()
 
-        let eightBitDir = try #require(await resolver.drafterDirectory(for: eightBit, allowDownload: true))
+        let eightBitDir = try #require(await resolver.resolve(model: eightBit, allowDownload: true).artifact?.directory)
         #expect(eightBitDir == qatDir, "both builds must resolve to the same stored artifact")
         #expect(server.requestedPaths().isEmpty, "the second build must reuse the first download")
+    }
+
+    @Test("production metadata pins manifest, total bytes, file count, roles, config, and revision")
+    func productionMetadataPinsArtifact() async throws {
+        let server = SpecDecFileServer()
+        let baseURL = try await server.start()
+        defer { Task { await server.shutdown() } }
+        let fixture = DrafterFixture(prefix: "v2-specdec/gemma4-pinned/v1")
+        server.setFiles(try fixture.served())
+        let root = makeTempStoreRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let resolver = SpecDecResolver(storeRoot: root, cdnBaseURL: baseURL.absoluteString)
+
+        let result = await resolver.prefetch(
+            model: try makePinnedModel(id: "gemma-4-26b-qat", fixture: fixture))
+        let artifact = try #require(result.artifact)
+        #expect(result.reason == nil)
+        #expect(artifact.artifactBytes == UInt64(fixture.manifest.totalSizeBytes))
+        #expect(artifact.residentBytes == SpecDecLimits.residentEstimate(
+            artifactBytes: UInt64(fixture.manifest.totalSizeBytes)))
+        #expect(artifact.revision == "v1")
+        #expect(artifact.manifestSHA256 == sha256Hex(try fixture.manifestData()))
+    }
+
+    @Test("catalog manifest digest mismatch is rejected before any file download")
+    func manifestDigestMismatch() async throws {
+        let server = SpecDecFileServer()
+        let baseURL = try await server.start()
+        defer { Task { await server.shutdown() } }
+        let fixture = DrafterFixture(prefix: "v2-specdec/gemma4-manifest-digest/v1")
+        server.setFiles(try fixture.served())
+        let model = makeTrustedModel(
+            id: "gemma-4", prefix: fixture.prefix,
+            manifestData: try fixture.manifestData(),
+            totalSizeBytes: fixture.manifest.totalSizeBytes,
+            fileCount: fixture.manifest.fileCount,
+            configSHA256: sha256Hex(fixture.configBytes),
+            revision: fixture.manifest.version,
+            manifestSHA256: String(repeating: "a", count: 64))
+        let root = makeTempStoreRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let result = await SpecDecResolver(
+            storeRoot: root, cdnBaseURL: baseURL.absoluteString
+        ).prefetch(model: model)
+        #expect(result.reason == .manifestDigestMismatch)
+        #expect(server.requestedPaths() == ["/\(fixture.prefix)/manifest.json"])
+    }
+
+    @Test("path traversal in manifest is rejected")
+    func pathTraversalRejected() async throws {
+        let server = SpecDecFileServer()
+        let baseURL = try await server.start()
+        defer { Task { await server.shutdown() } }
+        let prefix = "v2-specdec/gemma4-traversal/v1"
+        let config = Data("{}".utf8)
+        let manifest = ModelManifest(
+            schemaVersion: 1, modelID: "assistant", version: "v1", r2Prefix: prefix,
+            aggregateSHA256: String(repeating: "0", count: 64),
+            totalSizeBytes: Int64(config.count + 1), fileCount: 2,
+            files: [
+                .init(path: "config.json", sizeBytes: Int64(config.count), sha256: sha256Hex(config), role: "config"),
+                .init(path: "../model.safetensors", sizeBytes: 1, sha256: String(repeating: "0", count: 64), role: "weight"),
+            ], createdAt: Date(timeIntervalSince1970: 0))
+        let encoder = JSONEncoder(); encoder.dateEncodingStrategy = .iso8601
+        let manifestData = try encoder.encode(manifest)
+        server.setFiles(["/\(prefix)/manifest.json": manifestData])
+        let root = makeTempStoreRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let model = makeTrustedModel(
+            id: "gemma-4", prefix: prefix, manifestData: manifestData,
+            totalSizeBytes: manifest.totalSizeBytes, fileCount: manifest.fileCount,
+            configSHA256: sha256Hex(config), revision: manifest.version)
+        let result = await SpecDecResolver(
+            storeRoot: root, cdnBaseURL: baseURL.absoluteString
+        ).prefetch(model: model)
+        #expect(result.reason == .pathInvalid)
+    }
+
+    @Test("artifact total and file count bounds reject hostile manifests")
+    func sizeAndCountBounds() async throws {
+        let server = SpecDecFileServer()
+        let baseURL = try await server.start()
+        defer { Task { await server.shutdown() } }
+        let encoder = JSONEncoder(); encoder.dateEncodingStrategy = .iso8601
+        let oversizedPrefix = "v2-specdec/gemma4-oversize/v1"
+        let oversized = ModelManifest(
+            schemaVersion: 1, modelID: "assistant", version: "v1", r2Prefix: oversizedPrefix,
+            aggregateSHA256: String(repeating: "0", count: 64),
+            totalSizeBytes: Int64(SpecDecLimits.maximumArtifactBytes + 1), fileCount: 2,
+            files: [
+                .init(path: "config.json", sizeBytes: 1, sha256: String(repeating: "0", count: 64), role: "config"),
+                .init(path: "model.safetensors", sizeBytes: 1, sha256: String(repeating: "0", count: 64), role: "weight"),
+            ], createdAt: Date(timeIntervalSince1970: 0))
+        let countPrefix = "v2-specdec/gemma4-count/v1"
+        var files = [ManifestFile(
+            path: "config.json", sizeBytes: 1,
+            sha256: String(repeating: "0", count: 64), role: "config")]
+        for index in 0..<SpecDecLimits.maximumFileCount {
+            files.append(.init(
+                path: "model-\(index).safetensors", sizeBytes: 1,
+                sha256: String(repeating: "0", count: 64), role: "weight"))
+        }
+        let tooMany = ModelManifest(
+            schemaVersion: 1, modelID: "assistant", version: "v1", r2Prefix: countPrefix,
+            aggregateSHA256: String(repeating: "0", count: 64),
+            totalSizeBytes: Int64(files.count), fileCount: files.count,
+            files: files, createdAt: Date(timeIntervalSince1970: 0))
+        let oversizedData = try encoder.encode(oversized)
+        let tooManyData = try encoder.encode(tooMany)
+        server.setFiles([
+            "/\(oversizedPrefix)/manifest.json": oversizedData,
+            "/\(countPrefix)/manifest.json": tooManyData,
+        ])
+        let root = makeTempStoreRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let resolver = SpecDecResolver(storeRoot: root, cdnBaseURL: baseURL.absoluteString)
+        let oversizedModel = makeTrustedModel(
+            id: "gemma-4", prefix: oversizedPrefix, manifestData: oversizedData,
+            totalSizeBytes: 2, fileCount: 2,
+            configSHA256: String(repeating: "0", count: 64), revision: "v1")
+        let countModel = makeTrustedModel(
+            id: "gemma-4", prefix: countPrefix, manifestData: tooManyData,
+            totalSizeBytes: Int64(files.count), fileCount: 2,
+            configSHA256: String(repeating: "0", count: 64), revision: "v1",
+            maximumFileCount: 2)
+        #expect(await resolver.prefetch(model: oversizedModel).reason == .artifactOversize)
+        #expect(await resolver.prefetch(model: countModel).reason == .fileCountInvalid)
+    }
+
+    @Test("concurrent same-prefix resolution publishes and downloads once")
+    func concurrentReuse() async throws {
+        let server = SpecDecFileServer()
+        let baseURL = try await server.start()
+        defer { Task { await server.shutdown() } }
+        let fixture = DrafterFixture(prefix: "v2-specdec/gemma4-concurrent/v1")
+        server.setFiles(try fixture.served())
+        let root = makeTempStoreRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let resolver = SpecDecResolver(storeRoot: root, cdnBaseURL: baseURL.absoluteString)
+        let model = try makePinnedModel(id: "gemma-4", fixture: fixture)
+
+        async let first = resolver.prefetch(model: model)
+        async let second = resolver.prefetch(model: model)
+        let results = await [first, second]
+        #expect(results.allSatisfy { $0.artifact != nil })
+        #expect(results[0].artifact?.directory == results[1].artifact?.directory)
+        let paths = server.requestedPaths()
+        #expect(paths.filter { $0.hasSuffix("manifest.json") }.count == 1)
+        #expect(paths.filter { $0.hasSuffix("config.json") }.count == 1)
+        #expect(paths.filter { $0.hasSuffix("model.safetensors") }.count == 1)
+    }
+
+    @Test("cancelling one of two coalesced waiters preserves the shared transfer")
+    func oneCancelledWaiterDoesNotCancelPeer() async throws {
+        let server = SpecDecFileServer()
+        let baseURL = try await server.start()
+        defer { Task { await server.shutdown() } }
+        server.setResponseDelay(milliseconds: 100)
+        let fixture = DrafterFixture(prefix: "v2-specdec/gemma4-two-waiters/v1")
+        server.setFiles(try fixture.served())
+        let root = makeTempStoreRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let resolver = SpecDecResolver(storeRoot: root, cdnBaseURL: baseURL.absoluteString)
+        let model = try makePinnedModel(id: "gemma-4", fixture: fixture)
+
+        let first = Task { await resolver.prefetch(model: model) }
+        let second = Task { await resolver.prefetch(model: model) }
+        for _ in 0..<100 where server.requestedPaths().isEmpty {
+            try await Task.sleep(nanoseconds: 5_000_000)
+        }
+        first.cancel()
+        let cancelled = await first.value
+        let survivor = await second.value
+
+        #expect(cancelled.artifact == nil)
+        #expect(cancelled.detail == "MTP prefetch was cancelled")
+        #expect(survivor.artifact != nil)
+        let paths = server.requestedPaths()
+        #expect(paths.filter { $0.hasSuffix("manifest.json") }.count == 1)
+        #expect(paths.filter { $0.hasSuffix("config.json") }.count == 1)
+        #expect(paths.filter { $0.hasSuffix("model.safetensors") }.count == 1)
+    }
+
+    @Test("cancelled final waiter cannot cancel a same-key successor")
+    func delayedCancellationCannotCancelSuccessor() async throws {
+        let server = SpecDecFileServer()
+        let baseURL = try await server.start()
+        defer { Task { await server.shutdown() } }
+        server.setResponseDelay(milliseconds: 150)
+        let fixture = DrafterFixture(prefix: "v2-specdec/gemma4-successor/v1")
+        server.setFiles(try fixture.served())
+        let root = makeTempStoreRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let resolver = SpecDecResolver(storeRoot: root, cdnBaseURL: baseURL.absoluteString)
+        let model = try makePinnedModel(id: "gemma-4", fixture: fixture)
+
+        let predecessor = Task { await resolver.prefetch(model: model) }
+        for _ in 0..<100 where server.requestedPaths().isEmpty {
+            try await Task.sleep(nanoseconds: 5_000_000)
+        }
+        predecessor.cancel()
+        let cancelled = await predecessor.value
+        #expect(cancelled.detail == "MTP prefetch was cancelled")
+
+        server.clearRequested()
+        let successor = await resolver.prefetch(model: model)
+        #expect(successor.artifact != nil)
+        let successorPaths = server.requestedPaths()
+        #expect(successorPaths.filter { $0.hasSuffix("manifest.json") }.count == 1)
+        #expect(successorPaths.filter { $0.hasSuffix("config.json") }.count == 1)
+        #expect(successorPaths.filter { $0.hasSuffix("model.safetensors") }.count == 1)
+    }
+
+    @Test("warm same-size corruption is hash-detected and never size-trusted")
+    func warmCorruptionDetected() async throws {
+        let server = SpecDecFileServer()
+        let baseURL = try await server.start()
+        defer { Task { await server.shutdown() } }
+        let fixture = DrafterFixture(prefix: "v2-specdec/gemma4-warm-corrupt/v1")
+        server.setFiles(try fixture.served())
+        let root = makeTempStoreRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let resolver = SpecDecResolver(storeRoot: root, cdnBaseURL: baseURL.absoluteString)
+        let model = try makePinnedModel(id: "gemma-4", fixture: fixture)
+        let first = try #require(await resolver.prefetch(model: model).artifact)
+        var corrupted = fixture.weightBytes
+        corrupted[corrupted.startIndex] ^= 0xff
+        try corrupted.write(to: first.directory.appendingPathComponent("model.safetensors"))
+        server.clearRequested()
+
+        let warm = await resolver.resolve(model: model, allowDownload: true)
+        #expect(warm.artifact == nil)
+        #expect(warm.reason == .warmArtifactCorrupt)
+        #expect(server.requestedPaths().isEmpty)
+    }
+
+    @Test("catalog metadata requires every immutable trust anchor before network")
+    func requiredTrustAnchors() async throws {
+        let server = SpecDecFileServer()
+        let baseURL = try await server.start()
+        defer { Task { await server.shutdown() } }
+        let fixture = DrafterFixture(prefix: "v2-specdec/gemma4-required-anchors/v1")
+        server.setFiles(try fixture.served())
+        let pinned = try makePinnedModel(id: "gemma-4", fixture: fixture)
+        let pairs = try #require({ () -> [(String, JSONValue)]? in
+            guard case .object(let value)? = pinned.metadata?["spec_dec"] else { return nil }
+            return value
+        }())
+        let required = [
+            "manifest_sha256", "total_size_bytes", "file_count", "max_file_count",
+            "allowed_file_types", "config_sha256", "revision",
+        ]
+        let root = makeTempStoreRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let resolver = SpecDecResolver(storeRoot: root, cdnBaseURL: baseURL.absoluteString)
+
+        for omitted in required {
+            let model = CatalogModel(
+                id: "gemma-4-\(omitted)", s3Name: "unused", displayName: "g", sizeGb: 1,
+                metadata: ["spec_dec": .object(pairs.filter { $0.0 != omitted })])
+            let result = await resolver.resolve(model: model, allowDownload: true)
+            #expect(result.artifact == nil)
+            #expect(result.reason == .metadataMalformed, "omitted=\(omitted)")
+        }
+        let prefixOnly = await resolver.resolve(
+            model: makeModel(id: "gemma-4-prefix-only", specDecPrefix: fixture.prefix),
+            allowDownload: true)
+        #expect(prefixOnly.artifact == nil)
+        #expect(prefixOnly.reason == .metadataMalformed)
+        #expect(server.requestedPaths().isEmpty)
+    }
+
+    @Test("cold catalog artifact returns immediately while owned prefetch continues")
+    func coldResolutionIsNonblocking() async throws {
+        let server = SpecDecFileServer()
+        let baseURL = try await server.start()
+        defer { Task { await server.shutdown() } }
+        server.setResponseDelay(milliseconds: 200)
+        let fixture = DrafterFixture(prefix: "v2-specdec/gemma4-nonblocking/v1")
+        server.setFiles(try fixture.served())
+        let root = makeTempStoreRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let resolver = SpecDecResolver(storeRoot: root, cdnBaseURL: baseURL.absoluteString)
+        let model = try makePinnedModel(id: "gemma-4", fixture: fixture)
+
+        let started = ContinuousClock.now
+        let cold = await resolver.resolve(model: model, allowDownload: true)
+        let elapsed = ContinuousClock.now - started
+        #expect(cold.reason == .artifactNotCached)
+        #expect(elapsed < .milliseconds(100), "target load waited for optional artifact network")
+
+        let prefetched = await resolver.prefetch(model: model)
+        #expect(prefetched.artifact != nil)
+    }
+
+    @Test("conflicting trust references never share an in-flight verdict")
+    func conflictingReferencesAreIsolated() async throws {
+        let server = SpecDecFileServer()
+        let baseURL = try await server.start()
+        defer { Task { await server.shutdown() } }
+        let fixture = DrafterFixture(prefix: "v2-specdec/gemma4-conflicting/v1")
+        server.setFiles(try fixture.served())
+        let root = makeTempStoreRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let resolver = SpecDecResolver(storeRoot: root, cdnBaseURL: baseURL.absoluteString)
+        let good = try makePinnedModel(id: "gemma-4-good", fixture: fixture)
+        let bad = makeTrustedModel(
+            id: "gemma-4-bad", prefix: fixture.prefix,
+            manifestData: try fixture.manifestData(),
+            totalSizeBytes: fixture.manifest.totalSizeBytes,
+            fileCount: fixture.manifest.fileCount,
+            configSHA256: sha256Hex(fixture.configBytes), revision: "v1",
+            manifestSHA256: String(repeating: "f", count: 64))
+
+        async let goodResult = resolver.prefetch(model: good)
+        async let badResult = resolver.prefetch(model: bad)
+        let results = await (goodResult, badResult)
+        #expect(results.0.artifact != nil)
+        #expect(results.1.artifact == nil)
+        #expect(results.1.reason == .manifestDigestMismatch)
+        #expect(server.requestedPaths().filter { $0.hasSuffix("manifest.json") }.count == 2)
+    }
+
+    @Test("no-download policy never waits on an in-flight downloading policy")
+    func conflictingPoliciesAreIsolated() async throws {
+        let server = SpecDecFileServer()
+        let baseURL = try await server.start()
+        defer { Task { await server.shutdown() } }
+        server.setResponseDelay(milliseconds: 200)
+        let fixture = DrafterFixture(prefix: "v2-specdec/gemma4-policy/v1")
+        server.setFiles(try fixture.served())
+        let root = makeTempStoreRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let resolver = SpecDecResolver(storeRoot: root, cdnBaseURL: baseURL.absoluteString)
+        let model = try makePinnedModel(id: "gemma-4", fixture: fixture)
+
+        async let prefetch = resolver.prefetch(model: model)
+        try await Task.sleep(nanoseconds: 20_000_000)
+        let started = ContinuousClock.now
+        let noDownload = await resolver.resolve(model: model, allowDownload: false)
+        #expect(ContinuousClock.now - started < .milliseconds(100))
+        #expect(noDownload.reason == .artifactNotCached)
+        let prefetched = await prefetch
+        #expect(prefetched.artifact != nil)
+    }
+
+    @Test("prefetch deadline cancels the transfer and removes staging")
+    func prefetchDeadlineOwnsCancellation() async throws {
+        let server = SpecDecFileServer()
+        let baseURL = try await server.start()
+        defer { Task { await server.shutdown() } }
+        server.setResponseDelay(milliseconds: 500)
+        let fixture = DrafterFixture(prefix: "v2-specdec/gemma4-timeout/v1")
+        server.setFiles(try fixture.served())
+        let root = makeTempStoreRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let resolver = SpecDecResolver(
+            storeRoot: root, cdnBaseURL: baseURL.absoluteString,
+            prefetchTimeout: .milliseconds(50))
+        let model = try makePinnedModel(id: "gemma-4", fixture: fixture)
+
+        let started = ContinuousClock.now
+        let result = await resolver.prefetch(model: model)
+        #expect(ContinuousClock.now - started < .milliseconds(300))
+        #expect(result.artifact == nil)
+        #expect(result.reason == .fileDownloadFailed)
+        let contents = (try? FileManager.default.contentsOfDirectory(
+            at: root, includingPropertiesForKeys: nil)) ?? []
+        #expect(!contents.contains { $0.lastPathComponent.hasPrefix(".staging-") })
     }
 }

--- a/provider-swift/Tests/ProviderCoreTests/SpecDecResolverTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/SpecDecResolverTests.swift
@@ -1,0 +1,405 @@
+/// SpecDecResolverTests -- live-isolated tests for the spec-dec drafter
+/// fetcher (plan D2). A real Hummingbird HTTP server on 127.0.0.1:0 (the
+/// MockCoordinator pattern) plays the model CDN, serving a tiny fake drafter
+/// manifest + files; the resolver runs against a throwaway store root.
+
+import Crypto
+import Foundation
+import HTTPTypes
+import Hummingbird
+import HummingbirdCore
+import Logging
+import NIOCore
+import Testing
+@testable import ProviderCore
+import ProviderCoreFoundation
+
+// MARK: - Local CDN fixture
+
+/// Minimal file-serving HTTP server: path -> bytes, with a request log so
+/// tests can prove which paths were (not) fetched. Honors `Range: bytes=N-`
+/// the way the real CDN does, since the downloader byte-resumes.
+private final class SpecDecFileServer: @unchecked Sendable {
+    private let lock = NSLock()
+    private var files: [String: Data] = [:]
+    private var requested: [String] = []
+    private var serverTask: Task<Void, Never>?
+
+    func setFiles(_ files: [String: Data]) {
+        lock.lock(); self.files = files; lock.unlock()
+    }
+
+    func requestedPaths() -> [String] {
+        lock.lock(); defer { lock.unlock() }; return requested
+    }
+
+    func clearRequested() {
+        lock.lock(); requested = []; lock.unlock()
+    }
+
+    private func record(_ path: String) {
+        lock.lock(); requested.append(path); lock.unlock()
+    }
+
+    private func body(for path: String) -> Data? {
+        lock.lock(); defer { lock.unlock() }; return files[path]
+    }
+
+    /// Bind 127.0.0.1 on a system-assigned port and return the base URL.
+    func start() async throws -> URL {
+        var logger = Logger(label: "SpecDecFileServer")
+        logger.logLevel = .critical
+
+        let router = Router(context: BasicRequestContext.self)
+        router.get("**") { [weak self] request, _ -> Response in
+            guard let self else { return Response(status: .internalServerError) }
+            let path = request.uri.path
+            self.record(path)
+            guard let full = self.body(for: path) else {
+                return Response(status: .notFound)
+            }
+            var data = full
+            var status = HTTPResponse.Status.ok
+            var headers = HTTPFields()
+            if let range = request.headers[.range],
+               range.hasPrefix("bytes="), range.hasSuffix("-"),
+               let start = Int(range.dropFirst("bytes=".count).dropLast()), start <= full.count
+            {
+                data = Data(full.dropFirst(start))
+                status = .partialContent
+                headers[.contentRange] = "bytes \(start)-\(full.count - 1)/\(full.count)"
+            }
+            return Response(status: status, headers: headers, body: .init(byteBuffer: ByteBuffer(bytes: data)))
+        }
+
+        let portBox = OneShotPortBox()
+        let app = Application(
+            router: router,
+            configuration: .init(address: .hostname("127.0.0.1", port: 0), serverName: "SpecDecFileServer"),
+            onServerRunning: { @Sendable channel in
+                portBox.complete(channel.localAddress?.port ?? 0)
+            },
+            logger: logger
+        )
+        let task = Task<Void, Never> {
+            do {
+                try await app.runService(gracefulShutdownSignals: [])
+            } catch {
+                logger.warning("SpecDecFileServer crashed: \(error)")
+            }
+        }
+
+        let port = await portBox.value
+        guard port > 0 else {
+            task.cancel()
+            throw URLError(.cannotConnectToHost)
+        }
+        lock.withLock { serverTask = task }
+        return URL(string: "http://127.0.0.1:\(port)")!
+    }
+
+    func shutdown() async {
+        let task: Task<Void, Never>? = lock.withLock {
+            let t = serverTask
+            serverTask = nil
+            return t
+        }
+        task?.cancel()
+        _ = await task?.value
+    }
+}
+
+/// One-shot async box for the bound port (MockCoordinator's PortBox pattern).
+private final class OneShotPortBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var port: Int?
+    private var continuation: CheckedContinuation<Int, Never>?
+
+    var value: Int {
+        get async {
+            await withCheckedContinuation { (cont: CheckedContinuation<Int, Never>) in
+                lock.withLock {
+                    if let p = port { cont.resume(returning: p) } else { continuation = cont }
+                }
+            }
+        }
+    }
+
+    func complete(_ port: Int) {
+        let cont: CheckedContinuation<Int, Never>? = lock.withLock {
+            if self.port != nil { return nil }
+            self.port = port
+            let cont = continuation
+            continuation = nil
+            return cont
+        }
+        cont?.resume(returning: port)
+    }
+}
+
+// MARK: - Fixture helpers
+
+private func sha256Hex(_ data: Data) -> String {
+    var hasher = SHA256()
+    hasher.update(data: data)
+    return hasher.finalize().map { String(format: "%02x", $0) }.joined()
+}
+
+/// A tiny two-file drafter artifact (config + weights), deterministic bytes.
+private struct DrafterFixture {
+    let prefix: String
+    let configBytes: Data
+    let weightBytes: Data
+    let manifest: ModelManifest
+
+    /// - Parameter corruptWeightSHA: when true, the manifest lists a SHA-256
+    ///   for the weight file that does NOT match the served bytes.
+    init(prefix: String, corruptWeightSHA: Bool = false) {
+        self.prefix = prefix
+        self.configBytes = Data(#"{"model_type": "gemma4_assistant"}"#.utf8)
+        self.weightBytes = Data((0..<4096).map { UInt8(($0 &* 31 &+ 7) & 0xFF) })
+        let weightSHA = corruptWeightSHA
+            ? String(repeating: "d", count: 64)
+            : sha256Hex(weightBytes)
+        self.manifest = ModelManifest(
+            schemaVersion: 1,
+            // Deliberately NOT a catalog model id: the drafter artifact is its
+            // own publish, and the resolver must not pin manifest.model_id to
+            // the target model (plan D3: no registry pinning).
+            modelID: "darkbloom/gemma4-drafter-4bit",
+            version: "v1",
+            r2Prefix: prefix,
+            // Junk aggregate: the resolver performs NO aggregate-hash
+            // enforcement by design (plan D3) -- per-file SHA-256 only.
+            aggregateSHA256: String(repeating: "0", count: 64),
+            totalSizeBytes: Int64(configBytes.count + weightBytes.count),
+            fileCount: 2,
+            files: [
+                ManifestFile(path: "config.json", sizeBytes: Int64(configBytes.count),
+                             sha256: sha256Hex(configBytes), role: "config"),
+                ManifestFile(path: "model.safetensors", sizeBytes: Int64(weightBytes.count),
+                             sha256: weightSHA, role: "weight"),
+            ],
+            createdAt: Date(timeIntervalSince1970: 0)
+        )
+    }
+
+    /// path -> bytes map for the file server (manifest.json + both files).
+    func served() throws -> [String: Data] {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        return [
+            "/\(prefix)/manifest.json": try encoder.encode(manifest),
+            "/\(prefix)/config.json": configBytes,
+            "/\(prefix)/model.safetensors": weightBytes,
+        ]
+    }
+}
+
+private func makeModel(id: String, specDecPrefix: String?) -> CatalogModel {
+    var metadata: [String: JSONValue]?
+    if let specDecPrefix {
+        metadata = ["spec_dec": .object([("r2_prefix", .string(specDecPrefix))])]
+    }
+    return CatalogModel(
+        id: id, s3Name: "unused", displayName: id, sizeGb: 15.0,
+        r2Prefix: "v2/\(id)/v1", metadata: metadata
+    )
+}
+
+private func makeTempStoreRoot() -> URL {
+    FileManager.default.temporaryDirectory
+        .appendingPathComponent("specdec-resolver-tests-\(UUID().uuidString)", isDirectory: true)
+}
+
+// MARK: - Tests
+
+@Suite("SpecDecResolver (drafter fetch + store)", .serialized)
+struct SpecDecResolverTests {
+
+    @Test("happy path: downloads via manifest, verifies per-file SHA, publishes atomically")
+    func happyPathDownloadsAndPublishes() async throws {
+        let server = SpecDecFileServer()
+        let baseURL = try await server.start()
+        defer { Task { await server.shutdown() } }
+
+        let prefix = "v2-specdec/gemma4-26b-assistant-4bit/v1"
+        let fixture = DrafterFixture(prefix: prefix)
+        server.setFiles(try fixture.served())
+
+        let storeRoot = makeTempStoreRoot()
+        defer { try? FileManager.default.removeItem(at: storeRoot) }
+        let resolver = SpecDecResolver(storeRoot: storeRoot, cdnBaseURL: baseURL.absoluteString)
+        let model = makeModel(id: "gemma-4-26b-qat", specDecPrefix: prefix)
+
+        let dir = await resolver.drafterDirectory(for: model, allowDownload: true)
+        let resolved = try #require(dir)
+
+        // Resolved dir lives under the store root (never the HF cache) and is
+        // keyed by the prefix hash.
+        #expect(resolved.path.hasPrefix(storeRoot.path))
+        #expect(resolved.lastPathComponent == SpecDecStore.key(forR2Prefix: prefix))
+        // Contents are byte-exact and the manifest was stored alongside.
+        #expect(try Data(contentsOf: resolved.appendingPathComponent("config.json")) == fixture.configBytes)
+        #expect(try Data(contentsOf: resolved.appendingPathComponent("model.safetensors")) == fixture.weightBytes)
+        let storedManifest = try ModelCatalogClient.manifestDecoder.decode(
+            ModelManifest.self, from: Data(contentsOf: resolved.appendingPathComponent("manifest.json")))
+        #expect(storedManifest == fixture.manifest)
+        // Staging was consumed by the atomic publish.
+        let staging = SpecDecStore.stagingDirectory(root: storeRoot, r2Prefix: prefix)
+        #expect(!FileManager.default.fileExists(atPath: staging.path))
+    }
+
+    @Test("corrupt file (SHA mismatch after retries) fails open: nil, nothing published")
+    func corruptFileReturnsNil() async throws {
+        let server = SpecDecFileServer()
+        let baseURL = try await server.start()
+        defer { Task { await server.shutdown() } }
+
+        let prefix = "v2-specdec/gemma4-corrupt/v1"
+        let fixture = DrafterFixture(prefix: prefix, corruptWeightSHA: true)
+        server.setFiles(try fixture.served())
+
+        let storeRoot = makeTempStoreRoot()
+        defer { try? FileManager.default.removeItem(at: storeRoot) }
+        let resolver = SpecDecResolver(storeRoot: storeRoot, cdnBaseURL: baseURL.absoluteString)
+        let model = makeModel(id: "gemma-4-26b-qat", specDecPrefix: prefix)
+
+        let dir = await resolver.drafterDirectory(for: model, allowDownload: true)
+        #expect(dir == nil)
+        // Nothing was published: the artifact dir does not exist.
+        let artifactDir = SpecDecStore.artifactDirectory(root: storeRoot, r2Prefix: prefix)
+        #expect(!FileManager.default.fileExists(atPath: artifactDir.path))
+    }
+
+    @Test("missing/malformed spec_dec metadata fails open: nil, zero network traffic")
+    func missingMetadataReturnsNil() async throws {
+        let server = SpecDecFileServer()
+        let baseURL = try await server.start()
+        defer { Task { await server.shutdown() } }
+
+        let storeRoot = makeTempStoreRoot()
+        defer { try? FileManager.default.removeItem(at: storeRoot) }
+        let resolver = SpecDecResolver(storeRoot: storeRoot, cdnBaseURL: baseURL.absoluteString)
+
+        // No metadata at all.
+        let bare = makeModel(id: "gemma-4-26b-qat", specDecPrefix: nil)
+        #expect(await resolver.drafterDirectory(for: bare, allowDownload: true) == nil)
+
+        // Metadata present but no spec_dec key.
+        let unrelated = CatalogModel(
+            id: "gemma-4-26b-8bit", s3Name: "unused", displayName: "g", sizeGb: 15.0,
+            metadata: ["other": .string("x")]
+        )
+        #expect(await resolver.drafterDirectory(for: unrelated, allowDownload: true) == nil)
+
+        // spec_dec present but r2_prefix missing / wrong type / empty.
+        let noPrefix = CatalogModel(
+            id: "gemma-4-26b-8bit", s3Name: "unused", displayName: "g", sizeGb: 15.0,
+            metadata: ["spec_dec": .object([("r2_prefix", .int(7))])]
+        )
+        #expect(await resolver.drafterDirectory(for: noPrefix, allowDownload: true) == nil)
+        let emptyPrefix = CatalogModel(
+            id: "gemma-4-26b-8bit", s3Name: "unused", displayName: "g", sizeGb: 15.0,
+            metadata: ["spec_dec": .object([("r2_prefix", .string(""))])]
+        )
+        #expect(await resolver.drafterDirectory(for: emptyPrefix, allowDownload: true) == nil)
+
+        // The CDN was never touched for any of them.
+        #expect(server.requestedPaths().isEmpty)
+        // And the helper mirrors the same decode.
+        #expect(SpecDecResolver.specDecR2Prefix(for: bare) == nil)
+        #expect(SpecDecResolver.specDecR2Prefix(for: makeModel(id: "m", specDecPrefix: "p/q")) == "p/q")
+    }
+
+    @Test("manifest 404 fails open: nil, nothing published")
+    func manifestHTTPErrorReturnsNil() async throws {
+        let server = SpecDecFileServer()
+        let baseURL = try await server.start()
+        defer { Task { await server.shutdown() } }
+        // Serve nothing: manifest.json fetch gets a 404.
+
+        let storeRoot = makeTempStoreRoot()
+        defer { try? FileManager.default.removeItem(at: storeRoot) }
+        let resolver = SpecDecResolver(storeRoot: storeRoot, cdnBaseURL: baseURL.absoluteString)
+        let model = makeModel(id: "gemma-4-26b-qat", specDecPrefix: "v2-specdec/missing/v1")
+
+        #expect(await resolver.drafterDirectory(for: model, allowDownload: true) == nil)
+        #expect(!FileManager.default.fileExists(
+            atPath: SpecDecStore.artifactDirectory(root: storeRoot, r2Prefix: "v2-specdec/missing/v1").path))
+    }
+
+    @Test("warm re-resolve returns the stored copy with zero network traffic")
+    func warmReResolveSkipsDownload() async throws {
+        let server = SpecDecFileServer()
+        let baseURL = try await server.start()
+        defer { Task { await server.shutdown() } }
+
+        let prefix = "v2-specdec/gemma4-warm/v1"
+        let fixture = DrafterFixture(prefix: prefix)
+        server.setFiles(try fixture.served())
+
+        let storeRoot = makeTempStoreRoot()
+        defer { try? FileManager.default.removeItem(at: storeRoot) }
+        let resolver = SpecDecResolver(storeRoot: storeRoot, cdnBaseURL: baseURL.absoluteString)
+        let model = makeModel(id: "gemma-4-26b-qat", specDecPrefix: prefix)
+
+        let first = try #require(await resolver.drafterDirectory(for: model, allowDownload: true))
+        #expect(!server.requestedPaths().isEmpty)
+
+        server.clearRequested()
+        let second = try #require(await resolver.drafterDirectory(for: model, allowDownload: true))
+        #expect(second == first)
+        #expect(server.requestedPaths().isEmpty, "warm re-resolve must not touch the CDN")
+
+        // allowDownload: false also resolves a verified stored copy.
+        let third = try #require(await resolver.drafterDirectory(for: model, allowDownload: false))
+        #expect(third == first)
+        #expect(server.requestedPaths().isEmpty)
+    }
+
+    @Test("allowDownload: false with no stored copy fails open without touching the CDN")
+    func allowDownloadFalseWithoutCopyReturnsNil() async throws {
+        let server = SpecDecFileServer()
+        let baseURL = try await server.start()
+        defer { Task { await server.shutdown() } }
+
+        let prefix = "v2-specdec/gemma4-nodownload/v1"
+        let fixture = DrafterFixture(prefix: prefix)
+        server.setFiles(try fixture.served())
+
+        let storeRoot = makeTempStoreRoot()
+        defer { try? FileManager.default.removeItem(at: storeRoot) }
+        let resolver = SpecDecResolver(storeRoot: storeRoot, cdnBaseURL: baseURL.absoluteString)
+        let model = makeModel(id: "gemma-4-26b-qat", specDecPrefix: prefix)
+
+        #expect(await resolver.drafterDirectory(for: model, allowDownload: false) == nil)
+        #expect(server.requestedPaths().isEmpty)
+    }
+
+    @Test("two builds sharing one spec_dec prefix share one download")
+    func sharedPrefixReusesOneDownload() async throws {
+        let server = SpecDecFileServer()
+        let baseURL = try await server.start()
+        defer { Task { await server.shutdown() } }
+
+        let prefix = "v2-specdec/gemma4-shared/v1"
+        let fixture = DrafterFixture(prefix: prefix)
+        server.setFiles(try fixture.served())
+
+        let storeRoot = makeTempStoreRoot()
+        defer { try? FileManager.default.removeItem(at: storeRoot) }
+        let resolver = SpecDecResolver(storeRoot: storeRoot, cdnBaseURL: baseURL.absoluteString)
+
+        // Two DIFFERENT catalog builds (qat + 8bit) point at the same artifact.
+        let qat = makeModel(id: "gemma-4-26b-qat", specDecPrefix: prefix)
+        let eightBit = makeModel(id: "gemma-4-26b-8bit", specDecPrefix: prefix)
+
+        let qatDir = try #require(await resolver.drafterDirectory(for: qat, allowDownload: true))
+        server.clearRequested()
+
+        let eightBitDir = try #require(await resolver.drafterDirectory(for: eightBit, allowDownload: true))
+        #expect(eightBitDir == qatDir, "both builds must resolve to the same stored artifact")
+        #expect(server.requestedPaths().isEmpty, "the second build must reuse the first download")
+    }
+}

--- a/provider-swift/Tests/ProviderCoreTests/StartupPreloadTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/StartupPreloadTests.swift
@@ -584,6 +584,34 @@ private func makeNoEvictStubContainer() -> ModelContainer {
         ))
 }
 
+/// Deterministic gate inside the funnel's catalog lookup: `cachedModel`
+/// blocks until released, giving load-lifecycle tests a controllable
+/// suspension point inside the MTP preparation await.
+private actor PreloadRaceGateCatalog: SpecDecCatalogLooking {
+    private var entered: CheckedContinuation<Void, Never>?
+    private var release: CheckedContinuation<CatalogModel?, Never>?
+    private(set) var cachedCalls = 0
+
+    func cachedModel(id: String) async -> CatalogModel? {
+        cachedCalls += 1
+        entered?.resume()
+        entered = nil
+        return await withCheckedContinuation { release = $0 }
+    }
+
+    func model(id: String) async throws -> CatalogModel? { nil }
+
+    func waitUntilEntered() async {
+        if cachedCalls > 0 { return }
+        await withCheckedContinuation { entered = $0 }
+    }
+
+    func releaseGate() {
+        release?.resume(returning: nil)
+        release = nil
+    }
+}
+
 /// Create a minimal fake HF-cache snapshot so `ModelScanner.resolveLocalPath`
 /// resolves `modelId` (ensureModelLoaded requires an on-disk snapshot BEFORE
 /// it reaches the admission gates under test). Returns the `models--...`
@@ -611,6 +639,37 @@ struct StartupPreloadNoEvictTests {
             tokenizer: TokenizerHandle(NoEvictStubTokenizer()),
             engineV2: makeInertStubBridge(modelId: id).bridge
         )
+    }
+
+    @Test("provider concurrent same-model load rechecks residency after MTP preparation")
+    func providerPreparationRaceRechecksResidency() async throws {
+        let fakeId = "darkbloom-tests/loop-race-\(UUID().uuidString.prefix(8))"
+        let fakeDir = try makeFakeHFSnapshot(modelId: fakeId)
+        defer { try? FileManager.default.removeItem(at: fakeDir) }
+
+        let loop = try await makePreloadLoop(
+            models: [preloadModelInfo(fakeId, memoryGb: 0.01)],
+            backend: BackendSettings(maxModelSlots: 3, mtp: true))
+        let gate = PreloadRaceGateCatalog()
+        await loop.setSpecDecFunnelForTesting(SpecDecArtifactFunnel(
+            resolver: SpecDecResolver(), catalog: gate))
+
+        let load = Task { try await loop.ensureModelLoaded(modelId: fakeId) }
+        await gate.waitUntilEntered()
+
+        // The load task is now suspended inside the MTP preparation await,
+        // PAST the initial residency/loading checks. Install the slot exactly
+        // as a concurrent same-model load that ran to completion would.
+        await installStubSlot(loop, fakeId)
+        await gate.releaseGate()
+
+        // Without the post-preparation recheck, the continuation starts a
+        // SECOND load of the resident model and throws on the fake
+        // snapshot's unloadable weights.
+        try await load.value
+        #expect(await loop.outstandingKVReservationBytesForTesting() == 0)
+        let resident = await loop.modelSlots.keys.sorted()
+        #expect(resident == [fakeId])
     }
 
     @Test("slot-cap: no-evict load refuses instead of evicting an idle resident model")

--- a/scripts/mtp-cache-inventory.py
+++ b/scripts/mtp-cache-inventory.py
@@ -447,6 +447,8 @@ class SecureInventoryOutput:
             try:
                 os.unlink(temporary, dir_fd=self.directory_fd)
             except FileNotFoundError:
+                # os.replace already moved the temp file into place, so
+                # best-effort cleanup finding nothing is the success case.
                 pass
 
     def close(self) -> None:
@@ -458,6 +460,7 @@ def terminate_process_group(process: subprocess.Popen[Any]) -> None:
     try:
         os.killpg(process.pid, signal.SIGTERM)
     except ProcessLookupError:
+        # The whole group already exited; nothing left to terminate.
         pass
     deadline = time.monotonic() + 2
     while process.poll() is None and time.monotonic() < deadline:
@@ -466,6 +469,7 @@ def terminate_process_group(process: subprocess.Popen[Any]) -> None:
         try:
             os.killpg(process.pid, signal.SIGKILL)
         except ProcessLookupError:
+            # The group exited between the deadline check and the kill.
             pass
     try:
         process.wait(timeout=2)
@@ -500,6 +504,8 @@ def self_test_output_safety() -> int:
         try:
             output.path.unlink()
         except OSError:
+            # Self-test teardown is best-effort; a failed unlink must not
+            # mask the assertion result above.
             pass
         for path in (held, outside):
             try:
@@ -507,6 +513,8 @@ def self_test_output_safety() -> int:
                     child.unlink()
                 path.rmdir()
             except OSError:
+                # Best-effort teardown: the directory may be non-empty or
+                # already gone after the checks above.
                 pass
 
 

--- a/scripts/mtp-cache-inventory.py
+++ b/scripts/mtp-cache-inventory.py
@@ -1,0 +1,563 @@
+#!/usr/bin/env python3
+"""Read-only inventory of cached Gemma 4 26B-A4B targets and assistants."""
+
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timezone
+import hashlib
+import json
+import os
+from pathlib import Path
+import secrets
+import signal
+import stat
+import subprocess
+import sys
+import tempfile
+import time
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+MAX_CONFIG_BYTES = 4 * 1024 * 1024
+MAX_CACHE_ROOT_ENTRIES = 4096
+MAX_MATCHING_REPOSITORIES = 64
+MAX_SNAPSHOTS_PER_REPOSITORY = 32
+MAX_FILES_PER_SNAPSHOT = 256
+MAX_TOTAL_ARTIFACTS = 128
+DEFAULT_TIMEOUT_SECONDS = 30
+KNOWN_MODEL_IDS = (
+    "mlx-community/gemma-4-26B-A4B-it-qat-4bit",
+    "mlx-community/gemma-4-26B-A4B-it-qat-assistant-4bit",
+)
+HEX_DIGITS = frozenset("0123456789abcdef")
+
+
+def cache_roots() -> list[Path]:
+    roots: list[Path] = []
+    if value := os.environ.get("HUGGINGFACE_HUB_CACHE"):
+        roots.append(Path(value).expanduser())
+    if value := os.environ.get("HF_HOME"):
+        roots.append(Path(value).expanduser() / "hub")
+    roots.extend(
+        [
+            Path.home() / ".cache/huggingface/hub",
+            Path.home() / "Library/Caches/huggingface/hub",
+        ]
+    )
+    return list(dict.fromkeys(root.resolve() for root in roots if root.is_dir()))
+
+
+def cache_repository_name(model_id: str) -> str:
+    return "models--" + model_id.replace("/", "--")
+
+
+def integer(value: Any) -> int | None:
+    return value if isinstance(value, int) and not isinstance(value, bool) else None
+
+
+def collect_nested_bit_overrides(value: Any, counts: dict[str, int]) -> None:
+    if isinstance(value, dict):
+        if (bits := integer(value.get("bits"))) is not None:
+            key = str(bits)
+            counts[key] = counts.get(key, 0) + 1
+        for child in value.values():
+            collect_nested_bit_overrides(child, counts)
+    elif isinstance(value, list):
+        for child in value:
+            collect_nested_bit_overrides(child, counts)
+
+
+def bounded_directory_entries(directory: Path, limit: int) -> tuple[list[os.DirEntry[str]], bool]:
+    entries: list[os.DirEntry[str]] = []
+    truncated = False
+    try:
+        with os.scandir(directory) as iterator:
+            for entry in iterator:
+                if len(entries) >= limit:
+                    truncated = True
+                    break
+                entries.append(entry)
+    except OSError:
+        return [], False
+    entries.sort(key=lambda entry: entry.name)
+    return entries, truncated
+
+
+def confined_regular_file(path: Path, allowed_root: Path) -> tuple[Path, os.stat_result]:
+    resolved = path.resolve(strict=True)
+    resolved_root = allowed_root.resolve(strict=True)
+    if resolved != resolved_root and resolved_root not in resolved.parents:
+        raise OSError(f"file escapes cache repository: {path} -> {resolved}")
+    metadata = resolved.stat()
+    if not stat.S_ISREG(metadata.st_mode):
+        raise OSError(f"not a regular file: {path}")
+    return resolved, metadata
+
+
+def read_bounded_regular_file(path: Path, limit: int, allowed_root: Path) -> bytes:
+    resolved, metadata = confined_regular_file(path, allowed_root)
+    if metadata.st_size > limit:
+        raise OSError(f"file exceeds {limit} byte limit: {metadata.st_size}")
+    with resolved.open("rb") as handle:
+        data = handle.read(limit + 1)
+    if len(data) > limit:
+        raise OSError(f"file exceeds {limit} byte limit while reading")
+    return data
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        while chunk := handle.read(1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def append_fingerprint_field(payload: bytearray, value: str) -> None:
+    encoded = value.encode()
+    payload.extend(len(encoded).to_bytes(8, "big"))
+    payload.extend(encoded)
+
+
+def snapshot_facts(
+    repository: Path,
+    snapshot: Path,
+    main_revision: str | None,
+) -> dict[str, Any]:
+    config_path = snapshot / "config.json"
+    config_data: bytes | None = None
+    try:
+        config_data = read_bounded_regular_file(config_path, MAX_CONFIG_BYTES, repository)
+        config = json.loads(config_data)
+        if not isinstance(config, dict):
+            raise json.JSONDecodeError("config root is not an object", "", 0)
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        config = {"_config_error": str(error)}
+
+    quantization = config.get("quantization") or config.get("quantization_config") or {}
+    override_counts: dict[str, int] = {}
+    for value in quantization.values():
+        collect_nested_bit_overrides(value, override_counts)
+    weight_files: list[dict[str, Any]] = []
+    snapshot_entries, files_truncated = bounded_directory_entries(
+        snapshot, MAX_FILES_PER_SNAPSHOT
+    )
+    for entry in snapshot_entries:
+        if not entry.name.endswith(".safetensors"):
+            continue
+        weight = Path(entry.path)
+        try:
+            resolved_weight, metadata = confined_regular_file(weight, repository)
+            candidate = resolved_weight.name.lower()
+            if (
+                entry.is_symlink()
+                and snapshot.parent.name == "snapshots"
+                and resolved_weight.parent == repository / "blobs"
+                and set(candidate) <= HEX_DIGITS
+                and len(candidate) in {40, 64}
+            ):
+                identity_kind = (
+                    "hf_blob_sha256" if len(candidate) == 64 else "hf_blob_git_sha1"
+                )
+                content_identity = candidate
+            else:
+                identity_kind = "sha256"
+                content_identity = sha256_file(resolved_weight)
+            weight_files.append(
+                {
+                    "name": weight.name,
+                    "size_bytes": metadata.st_size,
+                    "identity_kind": identity_kind,
+                    "content_identity": content_identity,
+                }
+            )
+        except OSError as error:
+            weight_files.append({"name": weight.name, "size_error": str(error)})
+
+    text = config.get("text_config") or {}
+    model_type = config.get("model_type")
+    if model_type == "gemma4_assistant":
+        role = "assistant"
+    elif model_type == "gemma4":
+        role = "target"
+    else:
+        role = "other"
+    repository_name = repository.name
+    model_id = (
+        "/".join(repository_name.removeprefix("models--").split("--"))
+        if repository_name.startswith("models--")
+        else None
+    )
+    config_sha256 = hashlib.sha256(config_data).hexdigest() if config_data is not None else None
+    config_size = len(config_data) if config_data is not None else None
+    artifact_fingerprint: str | None = None
+    if model_id and config_sha256 and all("content_identity" in item for item in weight_files):
+        payload = bytearray(b"darkbloom.mtp.artifact-fingerprint.v1")
+        for value in (model_id, snapshot.name, str(config_size), config_sha256):
+            append_fingerprint_field(payload, value)
+        for weight in weight_files:
+            for value in (
+                weight["name"],
+                str(weight["size_bytes"]),
+                weight["identity_kind"],
+                weight["content_identity"],
+            ):
+                append_fingerprint_field(payload, value)
+        artifact_fingerprint = hashlib.sha256(payload).hexdigest()
+    return {
+        "cache_repository": str(repository),
+        "model_id": model_id,
+        "resolved_path": str(snapshot.resolve()),
+        "revision": snapshot.name,
+        "is_main_revision": snapshot.name == main_revision,
+        "role": role,
+        "model_type": model_type,
+        "architectures": config.get("architectures"),
+        "dtype": config.get("dtype"),
+        "quantization": {
+            "bits": integer(quantization.get("bits")),
+            "group_size": integer(quantization.get("group_size")),
+            "mode": quantization.get("mode"),
+            "per_layer_overrides_by_bits": override_counts,
+        }
+        if quantization
+        else None,
+        "geometry": {
+            "backbone_hidden_size": integer(config.get("backbone_hidden_size")),
+            "hidden_size": integer(text.get("hidden_size")),
+            "intermediate_size": integer(text.get("intermediate_size")),
+            "num_hidden_layers": integer(text.get("num_hidden_layers")),
+            "num_attention_heads": integer(text.get("num_attention_heads")),
+            "num_key_value_heads": integer(text.get("num_key_value_heads")),
+            "num_global_key_value_heads": integer(text.get("num_global_key_value_heads")),
+            "num_experts": integer(text.get("num_experts")),
+            "top_k_experts": integer(text.get("top_k_experts")),
+            "max_position_embeddings": integer(text.get("max_position_embeddings")),
+            "sliding_window": integer(text.get("sliding_window")),
+            "layer_types": text.get("layer_types"),
+        },
+        "weight_file_count": len(weight_files),
+        "weight_bytes": sum(
+            entry.get("size_bytes", 0) for entry in weight_files if isinstance(entry, dict)
+        ),
+        "weight_files": weight_files,
+        "config_size_bytes": config_size,
+        "config_sha256": config_sha256,
+        "artifact_fingerprint": artifact_fingerprint,
+        "snapshot_file_scan_truncated": files_truncated,
+        "config_error": config.get("_config_error"),
+    }
+
+
+def inventory() -> dict[str, Any]:
+    artifacts: list[dict[str, Any]] = []
+    warnings: list[str] = []
+    matching_repositories = 0
+    for root in cache_roots():
+        repositories: list[Path] = []
+        for model_id in KNOWN_MODEL_IDS:
+            repository = root / cache_repository_name(model_id)
+            try:
+                metadata = repository.lstat()
+            except OSError:
+                continue
+            if stat.S_ISDIR(metadata.st_mode):
+                repositories.append(repository)
+
+        root_entries, root_truncated = bounded_directory_entries(root, MAX_CACHE_ROOT_ENTRIES)
+        if root_truncated:
+            warnings.append(
+                f"cache root entry scan truncated at {MAX_CACHE_ROOT_ENTRIES}: {root}"
+            )
+        for entry in root_entries:
+            if not entry.name.startswith("models--") or not entry.is_dir(follow_symlinks=False):
+                continue
+            normalized = entry.name.lower()
+            if "gemma-4-26b-a4b" not in normalized:
+                continue
+            repository = Path(entry.path)
+            if repository not in repositories:
+                repositories.append(repository)
+
+        for repository in repositories:
+            matching_repositories += 1
+            if matching_repositories > MAX_MATCHING_REPOSITORIES:
+                warnings.append(
+                    f"matching repository scan truncated at {MAX_MATCHING_REPOSITORIES}"
+                )
+                break
+            main_ref = repository / "refs/main"
+            try:
+                main_revision = read_bounded_regular_file(
+                    main_ref, 256, repository
+                ).decode().strip() or None
+            except (OSError, UnicodeDecodeError):
+                main_revision = None
+            snapshots = repository / "snapshots"
+            try:
+                snapshots_metadata = snapshots.lstat()
+            except OSError:
+                continue
+            if not stat.S_ISDIR(snapshots_metadata.st_mode):
+                continue
+            snapshot_entries, snapshots_truncated = bounded_directory_entries(
+                snapshots, MAX_SNAPSHOTS_PER_REPOSITORY
+            )
+            if snapshots_truncated:
+                warnings.append(
+                    f"snapshot scan truncated at {MAX_SNAPSHOTS_PER_REPOSITORY}: {repository}"
+                )
+            for snapshot_entry in snapshot_entries:
+                if not snapshot_entry.is_dir(follow_symlinks=False):
+                    continue
+                if len(artifacts) >= MAX_TOTAL_ARTIFACTS:
+                    warnings.append(
+                        f"artifact inventory truncated at {MAX_TOTAL_ARTIFACTS}"
+                    )
+                    break
+                snapshot = Path(snapshot_entry.path)
+                artifacts.append(snapshot_facts(repository, snapshot, main_revision))
+            if len(artifacts) >= MAX_TOTAL_ARTIFACTS:
+                break
+        if matching_repositories > MAX_MATCHING_REPOSITORIES \
+                or len(artifacts) >= MAX_TOTAL_ARTIFACTS:
+            break
+
+    extra_roots = [
+        Path.home() / ".cache/mlx",
+        Path.home() / "Library/Caches/mlx",
+        Path.home() / ".darkbloom/spec-dec",
+    ]
+    return {
+        "schema_version": 2,
+        "cache_roots": [str(path) for path in cache_roots()],
+        "additional_roots_checked": [
+            {"path": str(path), "exists": path.exists()} for path in extra_roots
+        ],
+        "artifact_count": len(artifacts),
+        "artifacts": artifacts,
+        "bounds": {
+            "max_config_bytes": MAX_CONFIG_BYTES,
+            "max_cache_root_entries": MAX_CACHE_ROOT_ENTRIES,
+            "max_matching_repositories": MAX_MATCHING_REPOSITORIES,
+            "max_snapshots_per_repository": MAX_SNAPSHOTS_PER_REPOSITORY,
+            "max_files_per_snapshot": MAX_FILES_PER_SNAPSHOT,
+            "max_total_artifacts": MAX_TOTAL_ARTIFACTS,
+        },
+        "warnings": warnings,
+    }
+
+
+class SecureInventoryOutput:
+    def __init__(self, root_fd: int, directory_fd: int, path: Path, name: str) -> None:
+        self.root_fd = root_fd
+        self.directory_fd = directory_fd
+        self.path = path
+        self.name = name
+
+    @classmethod
+    def create(cls, requested: Path) -> "SecureInventoryOutput":
+        expanded = requested.expanduser()
+        absolute = expanded if expanded.is_absolute() else Path.cwd() / expanded
+        lexical = Path(os.path.abspath(absolute))
+        repo_tmp = Path(os.path.abspath(REPO_ROOT / "tmp"))
+        system_tmp = Path(os.path.abspath(tempfile.gettempdir()))
+        if lexical == repo_tmp or repo_tmp in lexical.parents:
+            if not repo_tmp.exists():
+                repo_tmp.mkdir(mode=0o700)
+            if not stat.S_ISDIR(repo_tmp.lstat().st_mode):
+                raise SystemExit(f"repo temp root is not a real directory: {repo_tmp}")
+            selected = repo_tmp
+        elif lexical == system_tmp or system_tmp in lexical.parents:
+            selected = system_tmp
+        else:
+            raise SystemExit(
+                f"refusing tracked result path {lexical}; use {repo_tmp} or {system_tmp}"
+            )
+        output_name = lexical.name or "inventory.json"
+        if output_name in {".", ".."} or "/" in output_name:
+            raise SystemExit("invalid inventory output filename")
+
+        resolved_root = selected.resolve(strict=True)
+        root_fd = os.open(
+            resolved_root, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+        )
+        timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        for _ in range(32):
+            directory_name = (
+                f"mtp-inventory-{timestamp}-{secrets.token_hex(8)}.run"
+            )
+            try:
+                os.mkdir(directory_name, mode=0o700, dir_fd=root_fd)
+            except FileExistsError:
+                continue
+            directory_fd = os.open(
+                directory_name,
+                os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW,
+                dir_fd=root_fd,
+            )
+            metadata = os.fstat(directory_fd)
+            if not stat.S_ISDIR(metadata.st_mode) or stat.S_IMODE(metadata.st_mode) != 0o700:
+                os.close(directory_fd)
+                os.close(root_fd)
+                raise SystemExit("new inventory run directory is not private")
+            return cls(
+                root_fd,
+                directory_fd,
+                resolved_root / directory_name,
+                output_name,
+            )
+        os.close(root_fd)
+        raise SystemExit("could not allocate unique inventory output directory")
+
+    @property
+    def output_path(self) -> Path:
+        return self.path / self.name
+
+    def atomic_write(self, data: str) -> None:
+        temporary = f".{self.name}.{secrets.token_hex(8)}.tmp"
+        descriptor = os.open(
+            temporary,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW,
+            0o600,
+            dir_fd=self.directory_fd,
+        )
+        try:
+            encoded = data.encode()
+            view = memoryview(encoded)
+            while view:
+                count = os.write(descriptor, view)
+                if count <= 0:
+                    raise OSError("short inventory output write")
+                view = view[count:]
+            os.fsync(descriptor)
+        finally:
+            os.close(descriptor)
+        try:
+            os.replace(
+                temporary,
+                self.name,
+                src_dir_fd=self.directory_fd,
+                dst_dir_fd=self.directory_fd,
+            )
+            os.fsync(self.directory_fd)
+        finally:
+            try:
+                os.unlink(temporary, dir_fd=self.directory_fd)
+            except FileNotFoundError:
+                pass
+
+    def close(self) -> None:
+        os.close(self.directory_fd)
+        os.close(self.root_fd)
+
+
+def terminate_process_group(process: subprocess.Popen[Any]) -> None:
+    try:
+        os.killpg(process.pid, signal.SIGTERM)
+    except ProcessLookupError:
+        pass
+    deadline = time.monotonic() + 2
+    while process.poll() is None and time.monotonic() < deadline:
+        time.sleep(0.05)
+    if process.poll() is None:
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+    try:
+        process.wait(timeout=2)
+    except subprocess.TimeoutExpired:
+        process.wait()
+
+
+def self_test_output_safety() -> int:
+    output = SecureInventoryOutput.create(
+        Path(tempfile.gettempdir()) / "mtp-inventory-self-test.json"
+    )
+    held = output.path.with_name(output.path.name + ".held")
+    outside = output.path.with_name(output.path.name + ".outside")
+    try:
+        outside.mkdir(mode=0o700)
+        victim = outside / "victim.json"
+        victim.write_bytes(b"sentinel")
+        os.symlink(victim, output.name, dir_fd=output.directory_fd)
+        output.path.rename(held)
+        output.path.symlink_to(outside, target_is_directory=True)
+        output.atomic_write("{}\n")
+        if (
+            not (held / output.name).is_file()
+            or (outside / output.name).exists()
+            or victim.read_bytes() != b"sentinel"
+        ):
+            raise RuntimeError("inventory write escaped after symlink replacement")
+        print("inventory output symlink-replacement self-test passed")
+        return 0
+    finally:
+        output.close()
+        try:
+            output.path.unlink()
+        except OSError:
+            pass
+        for path in (held, outside):
+            try:
+                for child in path.iterdir():
+                    child.unlink()
+                path.rmdir()
+            except OSError:
+                pass
+
+
+def worker(output_path: Path | None) -> int:
+    data = json.dumps(inventory(), indent=2, sort_keys=True) + "\n"
+    if output_path:
+        output = SecureInventoryOutput.create(output_path)
+        try:
+            output.atomic_write(data)
+            print(output.output_path)
+        finally:
+            output.close()
+    else:
+        print(data, end="")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="optional name under repo tmp/system temp; written in a unique run directory",
+    )
+    parser.add_argument("--timeout-seconds", type=int, default=DEFAULT_TIMEOUT_SECONDS)
+    parser.add_argument("--self-test-output-safety", action="store_true", help=argparse.SUPPRESS)
+    parser.add_argument("--_worker", action="store_true", help=argparse.SUPPRESS)
+    args = parser.parse_args()
+    if args.timeout_seconds <= 0:
+        parser.error("--timeout-seconds must be positive")
+    if args.self_test_output_safety:
+        return self_test_output_safety()
+    if args._worker:
+        return worker(args.output)
+
+    process = subprocess.Popen(
+        [sys.executable, str(Path(__file__).resolve()), *sys.argv[1:], "--_worker"],
+        start_new_session=True,
+    )
+    try:
+        try:
+            return process.wait(timeout=args.timeout_seconds)
+        except subprocess.TimeoutExpired:
+            print(
+                f"cache inventory timed out after {args.timeout_seconds}s",
+                file=sys.stderr,
+            )
+            return 124
+    finally:
+        terminate_process_group(process)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run-mtp-benchmark.py
+++ b/scripts/run-mtp-benchmark.py
@@ -1133,6 +1133,16 @@ def validate_report(
                 continue
             if metrics.get("active") is not True:
                 raise ValueError(f"fixed L{width}/B{batch} did not prove activation")
+            # Production evidence certifies the PRODUCTION mechanism: active
+            # cases must have run the automatic verifier with zero serial
+            # rounds. Raw parity stays mode-agnostic (the serial/rectangular
+            # diagnostic vehicle).
+            if mode != "raw-parity" and (
+                metrics.get("verificationMode") != "automatic"
+                or metrics.get("serialVerificationRounds", 0) not in (None, 0)
+            ):
+                raise ValueError(
+                    f"fixed L{width}/B{batch} production evidence requires the automatic verifier")
             depth = width - 1
             if validate_automatic_fixed_fallback(
                 metrics, batch, depth, f"fixed L{width}/B{batch}"
@@ -1169,6 +1179,12 @@ def validate_report(
                 continue
             if metrics.get("active") is not True or not observed_bucket(metrics, expected_bucket):
                 raise ValueError(f"adaptive B{batch} did not prove activation/bucket")
+            if mode != "raw-parity" and (
+                metrics.get("verificationMode") != "automatic"
+                or metrics.get("serialVerificationRounds", 0) not in (None, 0)
+            ):
+                raise ValueError(
+                    f"adaptive B{batch} production evidence requires the automatic verifier")
             if validate_automatic_adaptive_within_cap(
                 metrics, batch, f"adaptive B{batch}"
             ):

--- a/scripts/run-mtp-benchmark.py
+++ b/scripts/run-mtp-benchmark.py
@@ -28,7 +28,7 @@ REPORT_SCHEMA_VERSION = 5
 REPORT_NAME = "report.json"
 LOG_NAME = "benchmark.log"
 SUPERVISOR_CONTRACT = "run-mtp-benchmark-v1"
-M5_INACTIVE_REASON_PREFIX = (
+LEGACY_M5_INACTIVE_REASON_PREFIX = (
     "rectangular MTP verification is disabled on Apple M5"
 )
 MAX_CACHE_ROOTS = 8
@@ -575,7 +575,7 @@ def expected_mtp_expectation(expect_inactive: bool) -> dict[str, Any]:
         "kind": "expected_inactive" if expect_inactive else "active",
         "allowedInactiveReasonValues": [],
         "allowedInactiveReasonPrefixes": (
-            [M5_INACTIVE_REASON_PREFIX] if expect_inactive else []
+            [LEGACY_M5_INACTIVE_REASON_PREFIX] if expect_inactive else []
         ),
     }
 
@@ -1286,8 +1286,8 @@ def parse_arguments() -> argparse.Namespace:
         "--expect-mtp-inactive",
         action="store_true",
         help=(
-            "require fixed/adaptive cases to match the stable Apple M5 hardware "
-            "safety-veto reason, perform zero speculative work, and retain target-only parity"
+            "legacy pre-serial-target regression mode: require the retired Apple M5 "
+            "hardware-veto reason and zero speculative work"
         ),
     )
     parser.add_argument("--warmup", type=int)

--- a/scripts/run-mtp-benchmark.py
+++ b/scripts/run-mtp-benchmark.py
@@ -1,0 +1,1246 @@
+#!/usr/bin/env python3
+"""Run cache-only MTP live tests under a hard process-group deadline."""
+
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timezone
+import hashlib
+import json
+import os
+from pathlib import Path
+import secrets
+import signal
+import stat
+import subprocess
+import sys
+import tempfile
+import time
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PACKAGE_ROOT = REPO_ROOT / "provider-swift"
+DEFAULT_TARGET_ID = "mlx-community/gemma-4-26B-A4B-it-qat-4bit"
+DEFAULT_ASSISTANT_ID = "mlx-community/gemma-4-26B-A4B-it-qat-assistant-4bit"
+DEFAULT_TEST_FILTER = "GemmaMTPPerformanceLiveTests"
+REPORT_SCHEMA_VERSION = 4
+REPORT_NAME = "report.json"
+LOG_NAME = "benchmark.log"
+SUPERVISOR_CONTRACT = "run-mtp-benchmark-v1"
+MAX_CACHE_ROOTS = 8
+MAX_FALLBACK_REPOSITORY_ENTRIES = 4096
+MAX_FALLBACK_REPOSITORIES = 8
+MAX_SNAPSHOT_ENTRIES = 512
+MAX_REF_BYTES = 256
+MAX_REPORT_BYTES = 100 * 1024 * 1024
+PERFORMANCE_KEYS = {
+    "elapsedMs",
+    "medianAggregateDecodeTokensPerSecond",
+    "timeToFirstTokenMs",
+    "interTokenLatencyMs",
+    "decodeTokensPerSecond",
+    "lastTokenLatencyMs",
+    "ewmaRoundWallTimeNanos",
+    "totalRoundWallTimeNanos",
+    "assistantTimeNanos",
+    "targetVerifyTimeNanos",
+}
+HEX_DIGITS = frozenset("0123456789abcdef")
+
+
+def repo_cache_name(model_id: str) -> str:
+    return "models--" + model_id.replace("/", "--")
+
+
+def bounded_scandir(directory: Path, limit: int) -> tuple[list[os.DirEntry[str]], bool]:
+    entries: list[os.DirEntry[str]] = []
+    with os.scandir(directory) as iterator:
+        for entry in iterator:
+            if len(entries) >= limit:
+                return entries, True
+            entries.append(entry)
+    return entries, False
+
+
+def cache_roots() -> list[Path]:
+    candidates: list[Path] = []
+    if value := os.environ.get("HUGGINGFACE_HUB_CACHE"):
+        candidates.append(Path(value).expanduser())
+    if value := os.environ.get("HF_HOME"):
+        candidates.append(Path(value).expanduser() / "hub")
+    candidates.extend(
+        [
+            Path.home() / ".cache/huggingface/hub",
+            Path.home() / "Library/Caches/huggingface/hub",
+        ]
+    )
+    roots: list[Path] = []
+    for candidate in candidates[:MAX_CACHE_ROOTS]:
+        try:
+            resolved = candidate.resolve(strict=True)
+        except OSError:
+            continue
+        if resolved.is_dir() and resolved not in roots:
+            roots.append(resolved)
+    return roots
+
+
+def confined_regular_file(path: Path, repository: Path) -> Path:
+    resolved = path.resolve(strict=True)
+    resolved_repository = repository.resolve(strict=True)
+    if resolved != resolved_repository and resolved_repository not in resolved.parents:
+        raise OSError(f"file escapes cache repository: {path}")
+    metadata = resolved.stat()
+    if not stat.S_ISREG(metadata.st_mode):
+        raise OSError(f"not a regular file: {path}")
+    return resolved
+
+
+def repository_snapshot(repository: Path) -> Path | None:
+    try:
+        repository_metadata = repository.lstat()
+        if not stat.S_ISDIR(repository_metadata.st_mode):
+            return None
+        ref = confined_regular_file(repository / "refs/main", repository)
+        if ref.stat().st_size > MAX_REF_BYTES:
+            return None
+        revision = ref.read_bytes()[: MAX_REF_BYTES + 1].decode().strip()
+        if (
+            not revision
+            or len(revision) > 128
+            or revision in {".", ".."}
+            or "/" in revision
+        ):
+            return None
+        snapshot = repository / "snapshots" / revision
+        snapshot_metadata = snapshot.lstat()
+        if not stat.S_ISDIR(snapshot_metadata.st_mode):
+            return None
+        confined_regular_file(snapshot / "config.json", repository)
+        entries, truncated = bounded_scandir(snapshot, MAX_SNAPSHOT_ENTRIES)
+        if truncated:
+            raise OSError(
+                f"snapshot entry scan exceeds {MAX_SNAPSHOT_ENTRIES}: {snapshot}"
+            )
+        if not any(
+            entry.name.endswith(".safetensors")
+            and stat.S_ISREG(
+                confined_regular_file(Path(entry.path), repository).stat().st_mode
+            )
+            for entry in entries
+        ):
+            return None
+        return snapshot.resolve(strict=True)
+    except (OSError, UnicodeDecodeError):
+        return None
+
+
+def resolve_cached_snapshot(model_id: str) -> Path:
+    wanted_name = repo_cache_name(model_id)
+    roots = cache_roots()
+
+    # Hugging Face repository directory names are deterministic. Resolve the
+    # exact path first so the normal path never scans an entire cache root.
+    for root in roots:
+        if snapshot := repository_snapshot(root / wanted_name):
+            return snapshot
+
+    fallback_repositories = 0
+    for root in roots:
+        try:
+            entries, truncated = bounded_scandir(
+                root, MAX_FALLBACK_REPOSITORY_ENTRIES
+            )
+        except OSError:
+            continue
+        if truncated:
+            raise SystemExit(
+                "exact cache repository was absent and bounded fallback scan "
+                f"exceeded {MAX_FALLBACK_REPOSITORY_ENTRIES} entries at {root}"
+            )
+        for entry in entries:
+            if entry.name.lower() != wanted_name.lower():
+                continue
+            if not entry.is_dir(follow_symlinks=False):
+                continue
+            fallback_repositories += 1
+            if fallback_repositories > MAX_FALLBACK_REPOSITORIES:
+                raise SystemExit(
+                    f"fallback cache resolution exceeded {MAX_FALLBACK_REPOSITORIES} repositories"
+                )
+            if snapshot := repository_snapshot(Path(entry.path)):
+                return snapshot
+    raise SystemExit(f"cached main snapshot not found for {model_id}; downloads are forbidden")
+
+
+def validate_snapshot(path: Path, label: str) -> Path:
+    resolved = path.expanduser().resolve(strict=True)
+    metadata = resolved.lstat()
+    if not stat.S_ISDIR(metadata.st_mode):
+        raise SystemExit(f"{label} path is not a real snapshot directory: {resolved}")
+    repository = resolved.parent.parent
+    try:
+        confined_regular_file(resolved / "config.json", repository)
+        entries, truncated = bounded_scandir(resolved, MAX_SNAPSHOT_ENTRIES)
+        if truncated:
+            raise OSError(f"snapshot contains over {MAX_SNAPSHOT_ENTRIES} entries")
+        if not any(
+            entry.name.endswith(".safetensors")
+            and confined_regular_file(Path(entry.path), repository)
+            for entry in entries
+        ):
+            raise OSError("no safetensors weights")
+    except OSError as error:
+        raise SystemExit(f"{label} path is not a complete cached snapshot: {error}")
+    return resolved
+
+
+def infer_huggingface_model_id(snapshot: Path) -> str | None:
+    if snapshot.parent.name != "snapshots":
+        return None
+    repository_name = snapshot.parent.parent.name
+    if not repository_name.startswith("models--"):
+        return None
+    components = repository_name.removeprefix("models--").split("--")
+    if len(components) < 2 or not all(components):
+        return None
+    return "/".join(components)
+
+
+def resolve_model_snapshot(
+    explicit_id: str | None,
+    explicit_path: Path | None,
+    default_id: str,
+    label: str,
+) -> tuple[str, Path]:
+    if explicit_path is None:
+        model_id = explicit_id or default_id
+        return model_id, validate_snapshot(resolve_cached_snapshot(model_id), label)
+    snapshot = validate_snapshot(explicit_path, label)
+    inferred_id = infer_huggingface_model_id(snapshot)
+    if explicit_id is not None and inferred_id is not None and explicit_id != inferred_id:
+        raise SystemExit(f"{label} model ID does not match its Hugging Face snapshot path")
+    if explicit_id is None and inferred_id is None:
+        raise SystemExit(f"--{label}-id is required for a non-Hugging-Face explicit path")
+    return explicit_id or inferred_id or default_id, snapshot
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        while chunk := handle.read(1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def append_fingerprint_field(payload: bytearray, value: str) -> None:
+    encoded = value.encode()
+    payload.extend(len(encoded).to_bytes(8, "big"))
+    payload.extend(encoded)
+
+
+def artifact_facts(model_id: str, snapshot: Path) -> dict[str, Any]:
+    repository = snapshot.parent.parent
+    config = confined_regular_file(snapshot / "config.json", repository)
+    config_size = config.stat().st_size
+    config_digest = sha256_file(config)
+    entries, truncated = bounded_scandir(snapshot, MAX_SNAPSHOT_ENTRIES)
+    if truncated:
+        raise ValueError(f"snapshot entry scan exceeds {MAX_SNAPSHOT_ENTRIES}")
+    weights: list[dict[str, Any]] = []
+    for entry in sorted(entries, key=lambda value: value.name):
+        if not entry.name.endswith(".safetensors"):
+            continue
+        source = Path(entry.path)
+        resolved = confined_regular_file(source, repository)
+        candidate = resolved.name.lower()
+        if (
+            entry.is_symlink()
+            and snapshot.parent.name == "snapshots"
+            and resolved.parent == repository / "blobs"
+            and set(candidate) <= HEX_DIGITS
+            and len(candidate) in {40, 64}
+        ):
+            kind = "hf_blob_sha256" if len(candidate) == 64 else "hf_blob_git_sha1"
+            identity = candidate
+        else:
+            kind = "sha256"
+            identity = sha256_file(resolved)
+        weights.append(
+            {
+                "name": entry.name,
+                "sizeBytes": resolved.stat().st_size,
+                "identityKind": kind,
+                "contentIdentity": identity,
+            }
+        )
+    if not weights:
+        raise ValueError("artifact has no safetensors weights")
+    revision = (
+        snapshot.name.lower()
+        if len(snapshot.name) == 40 and set(snapshot.name.lower()) <= HEX_DIGITS
+        else None
+    )
+    payload = bytearray(b"darkbloom.mtp.artifact-fingerprint.v1")
+    for value in (model_id, revision or "", str(config_size), config_digest):
+        append_fingerprint_field(payload, value)
+    for weight in weights:
+        for value in (
+            weight["name"],
+            str(weight["sizeBytes"]),
+            weight["identityKind"],
+            weight["contentIdentity"],
+        ):
+            append_fingerprint_field(payload, value)
+    return {
+        "modelID": model_id,
+        "resolvedPath": str(snapshot),
+        "revision": revision,
+        "configSizeBytes": config_size,
+        "configSHA256": config_digest,
+        "weightFiles": weights,
+        "artifactFingerprint": hashlib.sha256(payload).hexdigest(),
+    }
+
+
+def open_directory(path: Path) -> int:
+    return os.open(path, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
+
+
+class SecureRunDirectory:
+    def __init__(
+        self,
+        *,
+        root_fd: int,
+        directory_fd: int,
+        path: Path,
+        device: int,
+        inode: int,
+    ) -> None:
+        self.root_fd = root_fd
+        self.directory_fd = directory_fd
+        self.path = path
+        self.device = device
+        self.inode = inode
+
+    @classmethod
+    def create(cls, requested: Path) -> "SecureRunDirectory":
+        expanded = requested.expanduser()
+        absolute = expanded if expanded.is_absolute() else Path.cwd() / expanded
+        lexical = Path(os.path.abspath(absolute))
+        repo_tmp = Path(os.path.abspath(REPO_ROOT / "tmp"))
+        system_tmp = Path(os.path.abspath(tempfile.gettempdir()))
+        if lexical == repo_tmp or repo_tmp in lexical.parents:
+            if not repo_tmp.exists():
+                repo_tmp.mkdir(mode=0o700)
+            if not stat.S_ISDIR(repo_tmp.lstat().st_mode):
+                raise SystemExit(f"repo temp root is not a real directory: {repo_tmp}")
+            selected = repo_tmp
+        elif lexical == system_tmp or system_tmp in lexical.parents:
+            selected = system_tmp
+        else:
+            raise SystemExit(
+                f"refusing tracked result path {lexical}; use {repo_tmp} or {system_tmp}"
+            )
+
+        resolved_root = selected.resolve(strict=True)
+        root_fd = open_directory(resolved_root)
+        root_metadata = os.fstat(root_fd)
+        if not stat.S_ISDIR(root_metadata.st_mode):
+            os.close(root_fd)
+            raise SystemExit(f"approved output root is not a directory: {resolved_root}")
+
+        stem = "".join(
+            character if character.isalnum() or character in "-_" else "-"
+            for character in lexical.stem
+        )[:48] or "mtp"
+        timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        for _ in range(32):
+            name = f"{stem}-{timestamp}-{secrets.token_hex(8)}.run"
+            try:
+                os.mkdir(name, mode=0o700, dir_fd=root_fd)
+            except FileExistsError:
+                continue
+            directory_fd = os.open(
+                name,
+                os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW,
+                dir_fd=root_fd,
+            )
+            metadata = os.fstat(directory_fd)
+            if not stat.S_ISDIR(metadata.st_mode) or stat.S_IMODE(metadata.st_mode) != 0o700:
+                os.close(directory_fd)
+                os.close(root_fd)
+                raise SystemExit("new benchmark run directory is not private")
+            return cls(
+                root_fd=root_fd,
+                directory_fd=directory_fd,
+                path=resolved_root / name,
+                device=metadata.st_dev,
+                inode=metadata.st_ino,
+            )
+        os.close(root_fd)
+        raise SystemExit("could not allocate a unique benchmark run directory")
+
+    @classmethod
+    def reopen(
+        cls,
+        path: Path,
+        expected_device: int,
+        expected_inode: int,
+    ) -> "SecureRunDirectory":
+        directory_fd = open_directory(path)
+        metadata = os.fstat(directory_fd)
+        if (
+            not stat.S_ISDIR(metadata.st_mode)
+            or metadata.st_dev != expected_device
+            or metadata.st_ino != expected_inode
+        ):
+            os.close(directory_fd)
+            raise SystemExit("benchmark run directory identity changed")
+        return cls(
+            root_fd=-1,
+            directory_fd=directory_fd,
+            path=path,
+            device=metadata.st_dev,
+            inode=metadata.st_ino,
+        )
+
+    def create_file(self, name: str) -> int:
+        validate_leaf_name(name)
+        return os.open(
+            name,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW,
+            0o600,
+            dir_fd=self.directory_fd,
+        )
+
+    def atomic_write(self, name: str, data: bytes) -> None:
+        validate_leaf_name(name)
+        temporary = f".{name}.{secrets.token_hex(8)}.tmp"
+        descriptor = self.create_file(temporary)
+        try:
+            write_all(descriptor, data)
+            os.fsync(descriptor)
+        finally:
+            os.close(descriptor)
+        try:
+            os.replace(
+                temporary,
+                name,
+                src_dir_fd=self.directory_fd,
+                dst_dir_fd=self.directory_fd,
+            )
+            os.fsync(self.directory_fd)
+        finally:
+            try:
+                os.unlink(temporary, dir_fd=self.directory_fd)
+            except FileNotFoundError:
+                pass
+
+    def read_regular(self, name: str, maximum_bytes: int) -> tuple[bytes, os.stat_result]:
+        validate_leaf_name(name)
+        descriptor = os.open(
+            name,
+            os.O_RDONLY | os.O_NOFOLLOW,
+            dir_fd=self.directory_fd,
+        )
+        try:
+            metadata = os.fstat(descriptor)
+            if not stat.S_ISREG(metadata.st_mode):
+                raise ValueError(f"{name} is not a regular file")
+            if metadata.st_size <= 0 or metadata.st_size > maximum_bytes:
+                raise ValueError(f"{name} size is invalid: {metadata.st_size}")
+            data = read_bounded(descriptor, maximum_bytes)
+            return data, metadata
+        finally:
+            os.close(descriptor)
+
+    def visible_identity_matches(self) -> bool:
+        try:
+            metadata = self.path.lstat()
+        except OSError:
+            return False
+        return (
+            stat.S_ISDIR(metadata.st_mode)
+            and metadata.st_dev == self.device
+            and metadata.st_ino == self.inode
+        )
+
+    def close(self) -> None:
+        if self.directory_fd >= 0:
+            os.close(self.directory_fd)
+            self.directory_fd = -1
+        if self.root_fd >= 0:
+            os.close(self.root_fd)
+            self.root_fd = -1
+
+
+def validate_leaf_name(name: str) -> None:
+    if not name or name in {".", ".."} or "/" in name:
+        raise ValueError(f"invalid run-directory filename: {name!r}")
+
+
+def write_all(descriptor: int, data: bytes) -> None:
+    view = memoryview(data)
+    while view:
+        written = os.write(descriptor, view)
+        if written <= 0:
+            raise OSError("short descriptor-relative write")
+        view = view[written:]
+
+
+def read_bounded(descriptor: int, maximum_bytes: int) -> bytes:
+    chunks: list[bytes] = []
+    remaining = maximum_bytes + 1
+    while remaining > 0:
+        chunk = os.read(descriptor, min(1024 * 1024, remaining))
+        if not chunk:
+            break
+        chunks.append(chunk)
+        remaining -= len(chunk)
+    data = b"".join(chunks)
+    if len(data) > maximum_bytes:
+        raise ValueError(f"file exceeds {maximum_bytes} bytes")
+    return data
+
+
+def terminate_group(process: subprocess.Popen[Any]) -> None:
+    """Terminate the supervised session and always reap the direct child."""
+
+    def signal_supervised(sig: int) -> None:
+        if process.poll() is not None:
+            return
+        try:
+            os.killpg(process.pid, sig)
+            return
+        except ProcessLookupError:
+            return
+        except PermissionError:
+            # Sandboxed macOS sessions can deny process-group signalling even
+            # though the direct child remains ours. Fall back to that child;
+            # its own cleanup owns any descendants.
+            try:
+                process.send_signal(sig)
+            except (ProcessLookupError, PermissionError):
+                return
+
+    def group_exists() -> bool:
+        try:
+            os.killpg(process.pid, 0)
+            return True
+        except ProcessLookupError:
+            return False
+        except PermissionError:
+            return process.poll() is None
+
+    deadline = time.monotonic() + 10
+    signal_supervised(signal.SIGTERM)
+    while group_exists() and time.monotonic() < deadline:
+        process.poll()
+        time.sleep(0.05)
+    if group_exists():
+        signal_supervised(signal.SIGKILL)
+    try:
+        process.wait(timeout=10)
+    except subprocess.TimeoutExpired:
+        signal_supervised(signal.SIGKILL)
+        process.wait()
+
+
+def parse_timestamp(value: Any, field: str) -> datetime:
+    if not isinstance(value, str):
+        raise ValueError(f"{field} must be an ISO-8601 string")
+    normalized = value[:-1] + "+00:00" if value.endswith("Z") else value
+    parsed = datetime.fromisoformat(normalized)
+    if parsed.tzinfo is None:
+        raise ValueError(f"{field} must include a timezone")
+    return parsed.astimezone(timezone.utc)
+
+
+def observed_bucket(metrics: dict[str, Any], expected: int) -> bool:
+    if metrics.get("decodeRowBucket") == expected:
+        return True
+    return any(
+        isinstance(item, dict) and item.get("decodeRowBucket") == expected
+        for item in metrics.get("costInputs", [])
+    )
+
+
+def recursively_present_keys(value: Any, wanted: set[str]) -> set[str]:
+    found: set[str] = set()
+    if isinstance(value, dict):
+        for key, child in value.items():
+            if key in wanted:
+                found.add(key)
+            found.update(recursively_present_keys(child, wanted))
+    elif isinstance(value, list):
+        for child in value:
+            found.update(recursively_present_keys(child, wanted))
+    return found
+
+
+def effective_quantization_bits(artifact: dict[str, Any]) -> int | None:
+    quantization = artifact.get("quantization")
+    if not isinstance(quantization, dict):
+        return None
+    bits = quantization.get("bits")
+    if isinstance(bits, int) and not isinstance(bits, bool):
+        return bits
+    overrides = quantization.get("perLayerOverridesByBits", {})
+    if not isinstance(overrides, dict):
+        return None
+    values = {
+        int(key)
+        for key, count in overrides.items()
+        if isinstance(key, str)
+        and key.isdigit()
+        and isinstance(count, int)
+        and count > 0
+    }
+    return next(iter(values)) if len(values) == 1 else None
+
+
+def expected_coverage(report: dict[str, Any]) -> dict[str, str]:
+    target = report.get("target", {})
+    assistant = report.get("assistant", {})
+    target_name = str(target.get("modelID", "")).lower()
+    assistant_name = str(assistant.get("modelID", "")).lower()
+    qat4 = (
+        "qat" in target_name
+        and "qat" in assistant_name
+        and effective_quantization_bits(target) == 4
+        and effective_quantization_bits(assistant) == 4
+    )
+    eight_bit_target = (
+        target.get("modelType") == "gemma4"
+        and effective_quantization_bits(target) == 8
+    )
+    assistant_dtype = str(assistant.get("dtype", "")).lower().replace("_", "").replace("-", "")
+    bf16_assistant = (
+        assistant.get("modelType") == "gemma4_assistant"
+        and assistant_dtype in {"bfloat16", "bf16"}
+        and assistant.get("quantization") is None
+    )
+    return {
+        "qat4BitShortContextSmoke": "covered" if qat4 else "not_run",
+        "eightBitTargetPairing": "covered" if eight_bit_target else "not_run",
+        "bf16AssistantPairing": "covered" if bf16_assistant else "not_run",
+        "officialTensorFixtures": "not_implemented",
+        "structuredOutput": "not_implemented",
+        "videoPrefill": "not_implemented",
+        "longSlidingAndPrefixContexts": "not_implemented",
+        "opaqueTokenEvidence": "covered",
+        "productionServingStopPolicy": (
+            "not_in_this_report"
+            if report.get("purpose") == "raw_parity_stress"
+            else "covered"
+        ),
+        "artifactProvenanceAndDrift": "covered",
+        "conservativeAssistantSizing": "covered",
+    }
+
+
+def validate_report_artifact(
+    report_artifact: Any,
+    expected: dict[str, Any],
+    label: str,
+) -> None:
+    if not isinstance(report_artifact, dict):
+        raise ValueError(f"report {label} artifact is not an object")
+    for key in (
+        "modelID",
+        "resolvedPath",
+        "revision",
+        "configSizeBytes",
+        "configSHA256",
+        "weightFiles",
+        "artifactFingerprint",
+    ):
+        if report_artifact.get(key) != expected[key]:
+            raise ValueError(f"report {label} {key} does not match launch provenance")
+
+
+def validate_report(
+    run: SecureRunDirectory,
+    *,
+    fingerprint: str,
+    launch_time: float,
+    mode: str,
+    build_configuration: str,
+    target: dict[str, Any],
+    assistant: dict[str, Any],
+    max_tokens: int,
+    warmup: int,
+    repetitions: int,
+    seed: int,
+) -> None:
+    encoded, metadata = run.read_regular(REPORT_NAME, MAX_REPORT_BYTES)
+    if metadata.st_mtime < launch_time - 1:
+        raise ValueError("report mtime predates this launch")
+    report = json.loads(encoded.decode("utf-8"))
+    if not isinstance(report, dict):
+        raise ValueError("report root is not an object")
+    if report.get("schemaVersion") != REPORT_SCHEMA_VERSION:
+        raise ValueError(
+            f"schemaVersion is {report.get('schemaVersion')}, expected {REPORT_SCHEMA_VERSION}"
+        )
+    expected_fingerprint = f"{build_configuration}:{fingerprint}"
+    if report.get("runFingerprint") != expected_fingerprint:
+        raise ValueError("run fingerprint does not match this launch")
+    if report.get("buildConfiguration") != build_configuration:
+        raise ValueError("report build configuration does not match this launch")
+    if report.get("complete") is not True:
+        raise ValueError("report is only a partial checkpoint")
+    if report.get("expectedCaseCount") != 40:
+        raise ValueError("expectedCaseCount is not 40")
+    if report.get("maxTokensPerRow") != max_tokens:
+        raise ValueError("maxTokensPerRow does not match the request")
+    if report.get("warmupIterations") != warmup:
+        raise ValueError("warmupIterations does not match the request")
+    if report.get("measurementRepetitions") != repetitions:
+        raise ValueError("measurementRepetitions does not match the request")
+    if report.get("modeOrderSeed") != seed:
+        raise ValueError("modeOrderSeed does not match the request")
+    validate_report_artifact(report.get("target"), target, "target")
+    validate_report_artifact(report.get("assistant"), assistant, "assistant")
+
+    expected_purpose = (
+        "raw_parity_stress" if mode == "raw-parity" else "production_performance"
+    )
+    expected_stop = (
+        "raw_fixed_length_no_stop"
+        if mode == "raw-parity"
+        else "production_target_eos"
+    )
+    if report.get("purpose") != expected_purpose:
+        raise ValueError("report purpose does not match this launch")
+    stop_policy = report.get("stopPolicy", {})
+    if stop_policy.get("kind") != expected_stop:
+        raise ValueError("report stop policy does not match this launch")
+    configured_stop_count = stop_policy.get("configuredTokenCount")
+    if mode == "raw-parity" and configured_stop_count != 0:
+        raise ValueError("raw parity report claims configured stop tokens")
+    if mode == "production-performance" and (
+        not isinstance(configured_stop_count, int) or configured_stop_count <= 0
+    ):
+        raise ValueError("production performance report has no target EOS evidence")
+    exposed_token_arrays = recursively_present_keys(report, {"tokenIDs"})
+    if exposed_token_arrays:
+        raise ValueError("report recursively exposes raw token IDs")
+    if mode != "production-performance":
+        exposed = recursively_present_keys(report, PERFORMANCE_KEYS)
+        if exposed:
+            raise ValueError(
+                f"non-performance report recursively exposes performance keys: {sorted(exposed)}"
+            )
+    elif not isinstance(report.get("elapsedMs"), (int, float)):
+        raise ValueError("production performance report omitted elapsedMs")
+
+    started_at = parse_timestamp(report.get("startedAt"), "startedAt")
+    generated_at = parse_timestamp(report.get("generatedAt"), "generatedAt")
+    completed_at = parse_timestamp(report.get("completedAt"), "completedAt")
+    launch_datetime = datetime.fromtimestamp(launch_time, timezone.utc)
+    now = datetime.now(timezone.utc)
+    if started_at < launch_datetime.replace(microsecond=0):
+        raise ValueError("report startedAt predates this launch")
+    if not (started_at <= generated_at <= now) or not (started_at <= completed_at <= now):
+        raise ValueError("report timestamps are not fresh and ordered")
+
+    cases = report.get("cases")
+    if not isinstance(cases, list) or len(cases) != 40:
+        count = len(cases) if isinstance(cases, list) else "invalid"
+        raise ValueError(f"report has {count} cases")
+    expected_keys = {
+        (kind, width, batch)
+        for kind, widths in (
+            ("target_only", [None]),
+            ("fixed", list(range(1, 9))),
+            ("adaptive", [None]),
+        )
+        for width in widths
+        for batch in (1, 2, 4, 8)
+    }
+    actual_keys: set[tuple[str, int | None, int]] = set()
+    baseline_rows: dict[int, list[tuple[str, int, str]]] = {}
+    for case in cases:
+        if not isinstance(case, dict):
+            raise ValueError("case is not an object")
+        mode_value = case.get("mode", {})
+        kind = mode_value.get("kind")
+        width = mode_value.get("verificationWidth")
+        batch = case.get("batchSize")
+        actual_keys.add((kind, width, batch))
+        if case.get("measurementRepetitions") != repetitions:
+            raise ValueError(f"case {kind}/{width}/B{batch} repetition count is wrong")
+        if case.get("tokenParity") is not True or case.get("parityMismatchRows") != []:
+            raise ValueError(f"case {kind}/{width}/B{batch} failed token parity")
+        rows = case.get("rows", [])
+        if not isinstance(rows, list) or len(rows) != batch:
+            raise ValueError(f"case {kind}/{width}/B{batch} has the wrong row count")
+        row_evidence: list[tuple[str, int, str]] = []
+        for row_index, row in enumerate(rows):
+            if not isinstance(row, dict):
+                raise ValueError(f"case {kind}/{width}/B{batch} row {row_index} is invalid")
+            token_count = row.get("tokenCount")
+            digest = row.get("opaqueTokenDigest")
+            if not isinstance(token_count, int) or token_count <= 0:
+                raise ValueError(f"case {kind}/{width}/B{batch} row {row_index} has no token count")
+            if (
+                not isinstance(digest, str)
+                or len(digest) != 64
+                or set(digest.lower()) - HEX_DIGITS
+            ):
+                raise ValueError(f"case {kind}/{width}/B{batch} row {row_index} has invalid opaque evidence")
+            if mode == "raw-parity" and (
+                row.get("finishReason") != "length" or token_count != max_tokens
+            ):
+                raise ValueError(f"case {kind}/{width}/B{batch} row {row_index} is not fixed length")
+            if mode != "raw-parity" and row.get("finishReason") not in {"stop", "length"}:
+                raise ValueError(f"case {kind}/{width}/B{batch} row {row_index} has invalid terminal reason")
+            row_evidence.append((str(row.get("promptName", "")), token_count, digest))
+        if kind == "target_only":
+            baseline_rows[batch] = row_evidence
+        elif baseline_rows.get(batch) != row_evidence:
+            raise ValueError(f"case {kind}/{width}/B{batch} opaque evidence differs from baseline")
+        if mode != "raw-parity":
+            if case.get("medianAggregateDecodeTokensPerSecond") is None:
+                raise ValueError("production performance case omitted aggregate throughput")
+
+        metrics = case.get("metrics", {})
+        expected_bucket = batch
+        skipped = metrics.get("skippedRows", {})
+        if skipped:
+            raise ValueError(f"case {kind}/{width}/B{batch} reported unapproved skips: {skipped}")
+        if kind == "target_only":
+            if metrics.get("active") is not False:
+                raise ValueError(f"target-only B{batch} reported MTP active")
+            if metrics.get("rounds") != 0 or metrics.get("proposedTokens") != 0:
+                raise ValueError(f"target-only B{batch} reported speculative work")
+        elif kind == "fixed":
+            if metrics.get("active") is not True or not observed_bucket(metrics, expected_bucket):
+                raise ValueError(f"fixed L{width}/B{batch} did not prove activation/bucket")
+            depth = width - 1
+            if metrics.get("depthSelections", {}).get(str(depth), 0) <= 0:
+                raise ValueError(f"fixed L{width}/B{batch} never selected depth {depth}")
+            if depth > 0:
+                if metrics.get("rounds", 0) <= 0 or metrics.get("proposedTokens", 0) <= 0:
+                    raise ValueError(f"fixed L{width}/B{batch} did not draft")
+                if not any(
+                    item.get("decodeRowBucket") == expected_bucket
+                    and item.get("draftDepth") == depth
+                    and item.get("sampleCount", 0) > 0
+                    for item in metrics.get("costInputs", [])
+                    if isinstance(item, dict)
+                ):
+                    raise ValueError(f"fixed L{width}/B{batch} lacks depth/bucket cost evidence")
+        elif kind == "adaptive":
+            if metrics.get("active") is not True or not observed_bucket(metrics, expected_bucket):
+                raise ValueError(f"adaptive B{batch} did not prove activation/bucket")
+            if metrics.get("rounds", 0) <= 0 or metrics.get("proposedTokens", 0) <= 0:
+                raise ValueError(f"adaptive B{batch} did not draft")
+            if not any(
+                int(depth) > 0 and count > 0
+                for depth, count in metrics.get("depthSelections", {}).items()
+            ):
+                raise ValueError(f"adaptive B{batch} never selected nonzero depth")
+            if not any(
+                item.get("decodeRowBucket") == expected_bucket
+                and item.get("draftDepth", 0) > 0
+                and item.get("sampleCount", 0) > 0
+                for item in metrics.get("costInputs", [])
+                if isinstance(item, dict)
+            ):
+                raise ValueError(
+                    f"adaptive B{batch} lacks positive-depth cost evidence for its requested bucket"
+                )
+    if actual_keys != expected_keys:
+        missing = sorted(expected_keys - actual_keys, key=str)
+        extra = sorted(actual_keys - expected_keys, key=str)
+        raise ValueError(f"case set mismatch; missing={missing}, extra={extra}")
+
+    coverage = report.get("coverage", {})
+    for field, expected in expected_coverage(report).items():
+        if coverage.get(field) != expected:
+            raise ValueError(f"coverage.{field} is not dynamically labeled {expected}")
+
+
+def fingerprint_for(
+    args: argparse.Namespace,
+    *,
+    target_id: str,
+    assistant_id: str,
+    target: dict[str, Any],
+    assistant: dict[str, Any],
+    warmup: int,
+    repetitions: int,
+    build_configuration: str,
+) -> str:
+    payload = json.dumps(
+        {
+            "target_id": target_id,
+            "assistant_id": assistant_id,
+            "target_fingerprint": target["artifactFingerprint"],
+            "assistant_fingerprint": assistant["artifactFingerprint"],
+            "mode": args.mode,
+            "build_configuration": build_configuration,
+            "test_filter": args.test_filter,
+            "max_tokens": args.max_tokens,
+            "warmup": warmup,
+            "repetitions": repetitions,
+            "seed": args.seed,
+            "launch_ns": time.time_ns(),
+            "nonce": secrets.token_hex(16),
+        },
+        sort_keys=True,
+    ).encode()
+    return hashlib.sha256(payload).hexdigest()
+
+
+def worker_main(args: argparse.Namespace, warmup: int, repetitions: int) -> int:
+    run = SecureRunDirectory.reopen(
+        args._worker_run_directory,
+        args._worker_run_device,
+        args._worker_run_inode,
+    )
+    try:
+        build_configuration = "debug" if args.debug else "release"
+        target_id, target = resolve_model_snapshot(
+            args.target_id, args.target_path, DEFAULT_TARGET_ID, "target"
+        )
+        assistant_id, assistant = resolve_model_snapshot(
+            args.assistant_id, args.assistant_path, DEFAULT_ASSISTANT_ID, "assistant"
+        )
+        target_facts = artifact_facts(target_id, target)
+        assistant_facts = artifact_facts(assistant_id, assistant)
+        fingerprint = fingerprint_for(
+            args,
+            target_id=target_id,
+            assistant_id=assistant_id,
+            target=target_facts,
+            assistant=assistant_facts,
+            warmup=warmup,
+            repetitions=repetitions,
+            build_configuration=build_configuration,
+        )
+        launch_time = time.time()
+        output = run.path / REPORT_NAME
+        log_path = run.path / LOG_NAME
+
+        environment = os.environ.copy()
+        environment.update(
+            {
+                "DARKBLOOM_LIVE_MLX_TESTS": "1",
+                "DARKBLOOM_LIVE_MLX_GEMMA": "1",
+                "DARKBLOOM_LIVE_MLX_MTP": "1",
+                "DARKBLOOM_MTP_EXTERNAL_SUPERVISOR": SUPERVISOR_CONTRACT,
+                "DARKBLOOM_MTP_TARGET_ID": target_id,
+                "DARKBLOOM_MTP_ASSISTANT_ID": assistant_id,
+                "DARKBLOOM_MTP_TARGET_PATH": str(target),
+                "DARKBLOOM_MTP_ASSISTANT_PATH": str(assistant),
+                "DARKBLOOM_MTP_BENCHMARK_OUTPUT": str(output),
+                "DARKBLOOM_MTP_BENCHMARK_RUN_DIRECTORY": str(run.path),
+                "DARKBLOOM_MTP_BENCHMARK_RUN_DEVICE": str(run.device),
+                "DARKBLOOM_MTP_BENCHMARK_RUN_INODE": str(run.inode),
+                "DARKBLOOM_MTP_BENCHMARK_BUILD_CONFIGURATION": build_configuration,
+                "DARKBLOOM_MTP_BENCHMARK_MAX_TOKENS": str(args.max_tokens),
+                "DARKBLOOM_MTP_BENCHMARK_MODE": args.mode,
+                "DARKBLOOM_MTP_BENCHMARK_WARMUP": str(warmup),
+                "DARKBLOOM_MTP_BENCHMARK_REPETITIONS": str(repetitions),
+                "DARKBLOOM_MTP_BENCHMARK_SEED": str(args.seed),
+                "DARKBLOOM_MTP_BENCHMARK_RUN_FINGERPRINT": fingerprint,
+                "DARKBLOOM_MTP_BENCHMARK_DEADLINE_SECONDS": str(
+                    max(1, args.timeout_seconds - 30)
+                ),
+                "HF_HUB_OFFLINE": "1",
+                "TRANSFORMERS_OFFLINE": "1",
+            }
+        )
+        command = [
+            "swift",
+            "test",
+            "-c",
+            build_configuration,
+            "--filter",
+            args.test_filter,
+        ]
+        print(f"target={target}")
+        print(f"assistant={assistant}")
+        print(f"run_directory={run.path}")
+        print(f"result={output}")
+        print(f"log={log_path}")
+        print(f"mode={args.mode}")
+        print(f"build_configuration={build_configuration}")
+        print(f"test_filter={args.test_filter}")
+        print(f"launch_fingerprint={fingerprint}")
+        print(f"report_fingerprint={build_configuration}:{fingerprint}")
+        sys.stdout.flush()
+
+        process = subprocess.Popen(
+            command,
+            cwd=PACKAGE_ROOT,
+            env=environment,
+            stdout=args._worker_log_fd,
+            stderr=subprocess.STDOUT,
+        )
+        return_code = process.wait()
+        if return_code != 0:
+            print(f"live test failed with exit {return_code}; see {log_path}", file=sys.stderr)
+            return return_code
+
+        try:
+            if artifact_facts(target_id, target) != target_facts:
+                raise ValueError("target artifact drifted during the live run")
+            if artifact_facts(assistant_id, assistant) != assistant_facts:
+                raise ValueError("assistant artifact drifted during the live run")
+        except (OSError, ValueError) as error:
+            print(f"artifact drift validation failed: {error}; see {log_path}", file=sys.stderr)
+            return 3
+
+        if args.test_filter.startswith(DEFAULT_TEST_FILTER):
+            try:
+                validate_report(
+                    run,
+                    fingerprint=fingerprint,
+                    launch_time=launch_time,
+                    mode=args.mode,
+                    build_configuration=build_configuration,
+                    target=target_facts,
+                    assistant=assistant_facts,
+                    max_tokens=args.max_tokens,
+                    warmup=warmup,
+                    repetitions=repetitions,
+                    seed=args.seed,
+                )
+            except (OSError, ValueError, UnicodeDecodeError, json.JSONDecodeError) as error:
+                print(
+                    f"benchmark report validation failed: {error}; see {log_path}",
+                    file=sys.stderr,
+                )
+                return 3
+            print(output)
+        else:
+            print(f"focused live test passed; log={log_path}")
+        return 0
+    finally:
+        run.close()
+
+
+def supervisor_main(args: argparse.Namespace, warmup: int, repetitions: int) -> int:
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    requested = args.output or REPO_ROOT / "tmp/mtp-benchmarks" / f"mtp-{timestamp}.json"
+    run = SecureRunDirectory.create(requested)
+    log_descriptor = run.create_file(LOG_NAME)
+    manifest = {
+        "schema_version": 1,
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "build_configuration": "debug" if args.debug else "release",
+        "mode": args.mode,
+        "test_filter": args.test_filter,
+        "timeout_seconds": args.timeout_seconds,
+    }
+    run.atomic_write(
+        "run.json",
+        (json.dumps(manifest, indent=2, sort_keys=True) + "\n").encode(),
+    )
+
+    worker_command = [
+        sys.executable,
+        str(Path(__file__).resolve()),
+        *sys.argv[1:],
+        "--_worker-run-directory",
+        str(run.path),
+        "--_worker-run-device",
+        str(run.device),
+        "--_worker-run-inode",
+        str(run.inode),
+        "--_worker-log-fd",
+        str(log_descriptor),
+    ]
+    process: subprocess.Popen[Any] | None = None
+    previous_handlers: dict[int, Any] = {}
+
+    def handle_signal(signum: int, _frame: Any) -> None:
+        if process is not None:
+            terminate_group(process)
+        raise SystemExit(128 + signum)
+
+    try:
+        process = subprocess.Popen(
+            worker_command,
+            pass_fds=(log_descriptor,),
+            start_new_session=True,
+        )
+        for signum in (signal.SIGINT, signal.SIGTERM, signal.SIGHUP):
+            previous_handlers[signum] = signal.signal(signum, handle_signal)
+        try:
+            return_code = process.wait(timeout=args.timeout_seconds)
+        except subprocess.TimeoutExpired:
+            print(
+                f"live test timed out after {args.timeout_seconds}s; see {run.path / LOG_NAME}",
+                file=sys.stderr,
+            )
+            return_code = 124
+        finally:
+            terminate_group(process)
+        if not run.visible_identity_matches():
+            print("benchmark run directory path was replaced", file=sys.stderr)
+            return 3
+        return return_code
+    finally:
+        for signum, previous in previous_handlers.items():
+            signal.signal(signum, previous)
+        os.close(log_descriptor)
+        run.close()
+
+
+def self_test_output_safety() -> int:
+    requested = Path(tempfile.gettempdir()) / f"mtp-self-test-{secrets.token_hex(8)}.json"
+    run = SecureRunDirectory.create(requested)
+    held = run.path.with_name(run.path.name + ".held")
+    outside = run.path.with_name(run.path.name + ".outside")
+    try:
+        outside.mkdir(mode=0o700)
+        victim = outside / "victim.json"
+        victim.write_bytes(b"sentinel")
+        os.symlink(victim, "probe.json", dir_fd=run.directory_fd)
+        run.path.rename(held)
+        run.path.symlink_to(outside, target_is_directory=True)
+        run.atomic_write("probe.json", b"{}\n")
+        if (
+            not (held / "probe.json").is_file()
+            or (outside / "probe.json").exists()
+            or victim.read_bytes() != b"sentinel"
+        ):
+            raise RuntimeError("descriptor-relative write escaped after symlink replacement")
+        print("secure output symlink-replacement self-test passed")
+        return 0
+    finally:
+        run.close()
+        try:
+            run.path.unlink()
+        except OSError:
+            pass
+        for path in (held, outside):
+            try:
+                for child in path.iterdir():
+                    child.unlink()
+                path.rmdir()
+            except OSError:
+                pass
+
+
+def self_test_artifact_provenance() -> int:
+    with tempfile.TemporaryDirectory(prefix="mtp-artifact-self-test-") as value:
+        root = Path(value)
+        repository = root / "models--example--assistant"
+        snapshot = repository / "snapshots" / ("a" * 40)
+        blobs = repository / "blobs"
+        snapshot.mkdir(parents=True)
+        blobs.mkdir()
+        (snapshot / "config.json").write_text('{"model_type":"gemma4_assistant"}')
+        first_oid = "b" * 64
+        second_oid = "c" * 64
+        (blobs / first_oid).write_bytes(b"first")
+        (blobs / second_oid).write_bytes(b"other")
+        weight = snapshot / "model.safetensors"
+        weight.symlink_to(blobs / first_oid)
+        model_id, resolved = resolve_model_snapshot(
+            None, snapshot, DEFAULT_ASSISTANT_ID, "assistant"
+        )
+        before = artifact_facts(model_id, resolved)
+        if (
+            model_id != "example/assistant"
+            or before["weightFiles"][0]["identityKind"] != "hf_blob_sha256"
+            or before["weightFiles"][0]["contentIdentity"] != first_oid
+        ):
+            raise RuntimeError("Hugging Face blob provenance was not captured")
+        try:
+            resolve_model_snapshot(
+                "wrong/assistant", snapshot, DEFAULT_ASSISTANT_ID, "assistant"
+            )
+        except SystemExit:
+            pass
+        else:
+            raise RuntimeError("explicit model/path mismatch was accepted")
+        weight.unlink()
+        weight.symlink_to(blobs / second_oid)
+        if artifact_facts(model_id, resolved) == before:
+            raise RuntimeError("weight symlink drift was not detected")
+    print("artifact provenance symlink self-test passed")
+    return 0
+
+
+def parse_arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--target-id")
+    parser.add_argument("--assistant-id")
+    parser.add_argument("--target-path", type=Path)
+    parser.add_argument("--assistant-path", type=Path)
+    parser.add_argument("--timeout-seconds", type=int, default=3600)
+    parser.add_argument("--max-tokens", type=int, default=16)
+    parser.add_argument(
+        "--mode",
+        choices=("raw-parity", "production-performance"),
+        default="raw-parity",
+        help="raw parity recursively omits performance keys; performance requires release",
+    )
+    parser.add_argument("--warmup", type=int)
+    parser.add_argument("--repetitions", type=int)
+    parser.add_argument("--seed", type=int, default=0x4D545032)
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="select an approved temp root and run-name prefix; output is always unique",
+    )
+    parser.add_argument("--debug", action="store_true", help="use a debug Swift build")
+    parser.add_argument(
+        "--test-filter",
+        default=DEFAULT_TEST_FILTER,
+        help="Swift test filter; all env-gated MTP live tests remain process-supervised",
+    )
+    parser.add_argument("--self-test-output-safety", action="store_true", help=argparse.SUPPRESS)
+    parser.add_argument("--self-test-artifact-provenance", action="store_true", help=argparse.SUPPRESS)
+    parser.add_argument("--_worker-run-directory", type=Path, help=argparse.SUPPRESS)
+    parser.add_argument("--_worker-run-device", type=int, help=argparse.SUPPRESS)
+    parser.add_argument("--_worker-run-inode", type=int, help=argparse.SUPPRESS)
+    parser.add_argument("--_worker-log-fd", type=int, help=argparse.SUPPRESS)
+    args = parser.parse_args()
+    if args.timeout_seconds <= 0 or args.max_tokens <= 0 or args.seed < 0:
+        parser.error("--timeout-seconds and --max-tokens must be positive; --seed nonnegative")
+    if args.mode == "production-performance" and args.debug:
+        parser.error("production-performance mode requires a release build")
+    if not args.test_filter or args.test_filter.startswith("-"):
+        parser.error("--test-filter must be nonempty")
+    return args
+
+
+def main() -> int:
+    args = parse_arguments()
+    if args.self_test_output_safety:
+        return self_test_output_safety()
+    if args.self_test_artifact_provenance:
+        return self_test_artifact_provenance()
+    warmup = args.warmup if args.warmup is not None else (
+        0 if args.mode == "raw-parity" else 1
+    )
+    repetitions = args.repetitions if args.repetitions is not None else (
+        1 if args.mode == "raw-parity" else 3
+    )
+    if warmup < 0 or repetitions <= 0:
+        raise SystemExit("--warmup must be nonnegative and --repetitions positive")
+    internal_values = (
+        args._worker_run_directory,
+        args._worker_run_device,
+        args._worker_run_inode,
+        args._worker_log_fd,
+    )
+    if any(value is not None for value in internal_values):
+        if any(value is None for value in internal_values):
+            raise SystemExit("incomplete internal worker contract")
+        return worker_main(args, warmup, repetitions)
+    return supervisor_main(args, warmup, repetitions)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run-mtp-benchmark.py
+++ b/scripts/run-mtp-benchmark.py
@@ -247,7 +247,29 @@ def artifact_facts(model_id: str, snapshot: Path) -> dict[str, Any]:
     repository = snapshot.parent.parent
     config = confined_regular_file(snapshot / "config.json", repository)
     config_size = config.stat().st_size
+    if config_size > 4 * 1024 * 1024:
+        raise ValueError("config.json exceeds the 4 MiB launch-side cap")
     config_digest = sha256_file(config)
+    # Independently parse the coverage-relevant metadata from the SAME bytes
+    # that were hashed, so the supervisor's coverage gates do not depend
+    # solely on the Swift inspector's transcription of these fields.
+    with open(config, "rb") as handle:
+        parsed = json.loads(read_bounded(handle.fileno(), 4 * 1024 * 1024))
+    if not isinstance(parsed, dict):
+        raise ValueError("config.json root is not an object")
+    raw_quantization = parsed.get("quantization")
+    config_metadata = {
+        "model_type": parsed.get("model_type"),
+        "dtype": parsed.get("dtype"),
+        "quantization_bits": (
+            raw_quantization.get("bits")
+            if isinstance(raw_quantization, dict)
+            and isinstance(raw_quantization.get("bits"), int)
+            and not isinstance(raw_quantization.get("bits"), bool)
+            else None
+        ),
+        "has_quantization": isinstance(raw_quantization, dict),
+    }
     entries, truncated = bounded_scandir(snapshot, MAX_SNAPSHOT_ENTRIES)
     if truncated:
         raise ValueError(f"snapshot entry scan exceeds {MAX_SNAPSHOT_ENTRIES}")
@@ -302,6 +324,7 @@ def artifact_facts(model_id: str, snapshot: Path) -> dict[str, Any]:
         "revision": revision,
         "configSizeBytes": config_size,
         "configSHA256": config_digest,
+        "configMetadata": config_metadata,
         "weightFiles": weights,
         "artifactFingerprint": hashlib.sha256(payload).hexdigest(),
     }
@@ -439,6 +462,8 @@ class SecureRunDirectory:
             try:
                 os.unlink(temporary, dir_fd=self.directory_fd)
             except FileNotFoundError:
+                # os.replace already moved the temp file into place, so
+                # best-effort cleanup finding nothing is the success case.
                 pass
 
     def read_regular(self, name: str, maximum_bytes: int) -> tuple[bytes, os.stat_result]:
@@ -512,17 +537,23 @@ def terminate_group(process: subprocess.Popen[Any]) -> None:
     """Terminate the supervised session and always reap the direct child."""
 
     def signal_supervised(sig: int) -> None:
-        if process.poll() is not None:
-            return
+        # Always try the GROUP first, even when the direct worker has already
+        # exited: a crashed worker can leave its `swift test` descendants
+        # alive in the supervised group, and the pgid stays valid while any
+        # member lives. Returning early on poll() would skip both the SIGTERM
+        # and the SIGKILL and orphan a live MLX benchmark.
         try:
             os.killpg(process.pid, sig)
             return
         except ProcessLookupError:
+            # The whole group is gone.
             return
         except PermissionError:
             # Sandboxed macOS sessions can deny process-group signalling even
             # though the direct child remains ours. Fall back to that child;
             # its own cleanup owns any descendants.
+            if process.poll() is not None:
+                return
             try:
                 process.send_signal(sig)
             except (ProcessLookupError, PermissionError):
@@ -760,8 +791,11 @@ def expected_coverage(report: dict[str, Any]) -> dict[str, str]:
         and effective_quantization_bits(target) == 4
         and effective_quantization_bits(assistant) == 4
     )
+    # Both official Gemma 4 target config types count: multimodal checkpoints
+    # report "gemma4" and text-only checkpoints report "gemma4_text" (mirrors
+    # MTPBenchmarkCoverage.shortContextMatrix).
     eight_bit_target = (
-        target.get("modelType") == "gemma4"
+        target.get("modelType") in ("gemma4", "gemma4_text")
         and effective_quantization_bits(target) == 8
     )
     assistant_dtype = str(assistant.get("dtype", "")).lower().replace("_", "").replace("-", "")
@@ -775,7 +809,11 @@ def expected_coverage(report: dict[str, Any]) -> dict[str, str]:
         "eightBitTargetPairing": "covered" if eight_bit_target else "not_run",
         "bf16AssistantPairing": "covered" if bf16_assistant else "not_run",
         "officialTensorFixtures": "not_implemented",
+        # The short cached-model matrix never exercises tool templates or
+        # image prefill; a report claiming either as covered must fail.
+        "toolTemplateDecodeParity": "not_in_this_report",
         "structuredOutput": "not_implemented",
+        "imagePrefill": "not_in_this_report",
         "videoPrefill": "not_implemented",
         "longSlidingAndPrefixContexts": "not_implemented",
         "opaqueTokenEvidence": "covered",
@@ -807,6 +845,20 @@ def validate_report_artifact(
     ):
         if report_artifact.get(key) != expected[key]:
             raise ValueError(f"report {label} {key} does not match launch provenance")
+    # Anchor the coverage-relevant metadata to the launch-side parse of the
+    # SAME hashed config bytes: a regressed Swift inspector must not be able
+    # to claim false QAT/8-bit/BF16 coverage while fingerprints still match.
+    metadata = expected.get("configMetadata") or {}
+    if report_artifact.get("modelType") != metadata.get("model_type"):
+        raise ValueError(f"report {label} modelType does not match launch config.json")
+    raw_dtype = metadata.get("dtype")
+    if raw_dtype is not None and report_artifact.get("dtype") != raw_dtype:
+        raise ValueError(f"report {label} dtype does not match launch config.json")
+    if not metadata.get("has_quantization") and report_artifact.get("quantization") is not None:
+        raise ValueError(f"report {label} invents quantization absent from launch config.json")
+    raw_bits = metadata.get("quantization_bits")
+    if raw_bits is not None and effective_quantization_bits(report_artifact) != raw_bits:
+        raise ValueError(f"report {label} quantization bits do not match launch config.json")
 
 
 def validate_report(
@@ -1321,6 +1373,8 @@ def self_test_output_safety() -> int:
         try:
             run.path.unlink()
         except OSError:
+            # Self-test teardown is best-effort; a failed unlink must not
+            # mask the assertion result above.
             pass
         for path in (held, outside):
             try:
@@ -1328,6 +1382,8 @@ def self_test_output_safety() -> int:
                     child.unlink()
                 path.rmdir()
             except OSError:
+                # Best-effort teardown: the directory may be non-empty or
+                # already gone after the checks above.
                 pass
 
 

--- a/scripts/run-mtp-benchmark.py
+++ b/scripts/run-mtp-benchmark.py
@@ -636,6 +636,15 @@ def validate_zero_speculative_work(metrics: dict[str, Any], label: str) -> None:
     ):
         if metrics.get(field) != 0:
             raise ValueError(f"{label} reported speculative work in {field}")
+    # Target verification with zero claimed rounds is still speculative work.
+    # These counters are optional in the schema (inactive metrics omit them),
+    # so absence counts as zero.
+    for field in (
+        "rectangularVerificationRounds",
+        "serialVerificationRounds",
+    ):
+        if metrics.get(field) not in (None, 0):
+            raise ValueError(f"{label} reported speculative work in {field}")
     for field in (
         "acceptanceByPosition",
         "conditionalAcceptance",
@@ -738,14 +747,41 @@ def validate_automatic_adaptive_within_cap(
     cap = automatic_rectangular_cap(metrics)
     if cap is None or batch * 2 <= cap:
         return False
-    rounds = metrics.get("rounds", 0)
     if (
         not positive_costs_within_cap(metrics, cap)
-        or metrics.get("serialVerificationRounds", 0) != 0
-        or (rounds > 0 and metrics.get("proposedTokens", 0) <= 0)
-        or (rounds == 0 and metrics.get("rectangularVerificationRounds", 0) != 0)
+        or metrics.get("serialVerificationRounds", 0) not in (None, 0)
     ):
         raise ValueError(f"{label} escaped its automatic rectangular limit")
+    rounds = metrics.get("rounds", 0)
+    if rounds > 0:
+        # Drafting after tail rows drained inside the cap: every row-round
+        # proposes at least one token and is scored by at least one
+        # rectangular batch verification (rounds count per-row finalizes;
+        # verifier counters count per-batch passes, so equality is NOT the
+        # invariant here).
+        if (
+            metrics.get("proposedTokens", 0) <= 0
+            or (metrics.get("rectangularVerificationRounds") or 0) <= 0
+        ):
+            raise ValueError(
+                f"{label} drafted without rectangular verification evidence")
+        return True
+    # Zero rounds: nothing may have been proposed, accepted, committed, or
+    # verified. Seed steps alone remain legitimate — they are recorded at
+    # step launch and a seed's row can terminate before its round runs.
+    if (
+        metrics.get("proposedTokens", 0) != 0
+        or metrics.get("acceptedDraftTokens", 0) != 0
+        or metrics.get("committedTokens", 0) != 0
+        or metrics.get("rectangularVerificationRounds", 0) not in (None, 0)
+        or any(count != 0 for count in metrics.get("acceptanceByPosition", []))
+        or any(
+            item.get("draftDepth", 0) != 0
+            for item in metrics.get("costInputs", [])
+            if isinstance(item, dict)
+        )
+    ):
+        raise ValueError(f"{label} reported speculative counters without rounds")
     return True
 
 
@@ -1015,7 +1051,12 @@ def validate_report(
                 and token_count != max_tokens
             ):
                 raise ValueError(f"case {kind}/{width}/B{batch} row {row_index} length terminal is premature")
-            row_evidence.append((str(row.get("promptName", "")), token_count, digest))
+            # finishReason is part of the cross-mode evidence: identical
+            # tokens with a different terminal reason (EOS at the budget as
+            # "stop" vs "length") is an OpenAI-visible divergence.
+            row_evidence.append(
+                (str(row.get("promptName", "")), token_count, digest,
+                 str(row.get("finishReason", ""))))
         if kind == "target_only":
             baseline_rows[batch] = row_evidence
         elif baseline_rows.get(batch) != row_evidence:

--- a/scripts/run-mtp-benchmark.py
+++ b/scripts/run-mtp-benchmark.py
@@ -257,7 +257,10 @@ def artifact_facts(model_id: str, snapshot: Path) -> dict[str, Any]:
         parsed = json.loads(read_bounded(handle.fileno(), 4 * 1024 * 1024))
     if not isinstance(parsed, dict):
         raise ValueError("config.json root is not an object")
+    # Mirrors MTPBenchmarkModelFacts.swift: "quantization" falls back to the HF "quantization_config" key.
     raw_quantization = parsed.get("quantization")
+    if not isinstance(raw_quantization, dict):
+        raw_quantization = parsed.get("quantization_config")
     config_metadata = {
         "model_type": parsed.get("model_type"),
         "dtype": parsed.get("dtype"),
@@ -1006,6 +1009,12 @@ def validate_report(
                 raise ValueError(f"case {kind}/{width}/B{batch} row {row_index} is not fixed length")
             if mode != "raw-parity" and row.get("finishReason") not in {"stop", "length"}:
                 raise ValueError(f"case {kind}/{width}/B{batch} row {row_index} has invalid terminal reason")
+            if (
+                mode != "raw-parity"
+                and row.get("finishReason") == "length"
+                and token_count != max_tokens
+            ):
+                raise ValueError(f"case {kind}/{width}/B{batch} row {row_index} length terminal is premature")
             row_evidence.append((str(row.get("promptName", "")), token_count, digest))
         if kind == "target_only":
             baseline_rows[batch] = row_evidence

--- a/scripts/run-mtp-benchmark.py
+++ b/scripts/run-mtp-benchmark.py
@@ -24,10 +24,13 @@ PACKAGE_ROOT = REPO_ROOT / "provider-swift"
 DEFAULT_TARGET_ID = "mlx-community/gemma-4-26B-A4B-it-qat-4bit"
 DEFAULT_ASSISTANT_ID = "mlx-community/gemma-4-26B-A4B-it-qat-assistant-4bit"
 DEFAULT_TEST_FILTER = "GemmaMTPPerformanceLiveTests"
-REPORT_SCHEMA_VERSION = 4
+REPORT_SCHEMA_VERSION = 5
 REPORT_NAME = "report.json"
 LOG_NAME = "benchmark.log"
 SUPERVISOR_CONTRACT = "run-mtp-benchmark-v1"
+M5_INACTIVE_REASON_PREFIX = (
+    "rectangular MTP verification is disabled on Apple M5"
+)
 MAX_CACHE_ROOTS = 8
 MAX_FALLBACK_REPOSITORY_ENTRIES = 4096
 MAX_FALLBACK_REPOSITORIES = 8
@@ -567,6 +570,57 @@ def observed_bucket(metrics: dict[str, Any], expected: int) -> bool:
     )
 
 
+def expected_mtp_expectation(expect_inactive: bool) -> dict[str, Any]:
+    return {
+        "kind": "expected_inactive" if expect_inactive else "active",
+        "allowedInactiveReasonValues": [],
+        "allowedInactiveReasonPrefixes": (
+            [M5_INACTIVE_REASON_PREFIX] if expect_inactive else []
+        ),
+    }
+
+
+def inactive_reason_matches(
+    metrics: dict[str, Any], expectation: dict[str, Any]
+) -> bool:
+    reason = metrics.get("inactiveReason")
+    if not isinstance(reason, str) or not reason:
+        return False
+    return reason in expectation["allowedInactiveReasonValues"] or any(
+        reason.startswith(prefix)
+        for prefix in expectation["allowedInactiveReasonPrefixes"]
+    )
+
+
+def validate_zero_speculative_work(metrics: dict[str, Any], label: str) -> None:
+    for field in (
+        "rounds",
+        "seedRows",
+        "proposedTokens",
+        "acceptedDraftTokens",
+        "committedTokens",
+    ):
+        if metrics.get(field) != 0:
+            raise ValueError(f"{label} reported speculative work in {field}")
+    for field in (
+        "acceptanceByPosition",
+        "conditionalAcceptance",
+        "skippedRows",
+        "depthSelections",
+        "controllerFallbacks",
+        "costInputs",
+    ):
+        if metrics.get(field) not in ([], {}):
+            raise ValueError(f"{label} reported speculative work in {field}")
+    for field in (
+        "totalRoundWallTimeNanos",
+        "assistantTimeNanos",
+        "targetVerifyTimeNanos",
+    ):
+        if metrics.get(field) is not None:
+            raise ValueError(f"{label} reported speculative timing in {field}")
+
+
 def recursively_present_keys(value: Any, wanted: set[str]) -> set[str]:
     found: set[str] = set()
     if isinstance(value, dict):
@@ -674,6 +728,7 @@ def validate_report(
     warmup: int,
     repetitions: int,
     seed: int,
+    expect_mtp_inactive: bool,
 ) -> None:
     encoded, metadata = run.read_regular(REPORT_NAME, MAX_REPORT_BYTES)
     if metadata.st_mtime < launch_time - 1:
@@ -685,11 +740,18 @@ def validate_report(
         raise ValueError(
             f"schemaVersion is {report.get('schemaVersion')}, expected {REPORT_SCHEMA_VERSION}"
         )
-    expected_fingerprint = f"{build_configuration}:{fingerprint}"
+    expectation = expected_mtp_expectation(expect_mtp_inactive)
+    expected_fingerprint = (
+        f"{build_configuration}:{expectation['kind']}:{fingerprint}"
+    )
     if report.get("runFingerprint") != expected_fingerprint:
         raise ValueError("run fingerprint does not match this launch")
     if report.get("buildConfiguration") != build_configuration:
         raise ValueError("report build configuration does not match this launch")
+    if report.get("mtpExpectation") != expectation:
+        raise ValueError("report MTP expectation does not match this launch")
+    if mode == "production-performance" and expect_mtp_inactive:
+        raise ValueError("production performance cannot be expected-inactive")
     if report.get("complete") is not True:
         raise ValueError("report is only a partial checkpoint")
     if report.get("expectedCaseCount") != 40:
@@ -815,9 +877,21 @@ def validate_report(
         if kind == "target_only":
             if metrics.get("active") is not False:
                 raise ValueError(f"target-only B{batch} reported MTP active")
-            if metrics.get("rounds") != 0 or metrics.get("proposedTokens") != 0:
-                raise ValueError(f"target-only B{batch} reported speculative work")
+            validate_zero_speculative_work(metrics, f"target-only B{batch}")
         elif kind == "fixed":
+            if expect_mtp_inactive:
+                if metrics.get("active") is not False:
+                    raise ValueError(
+                        f"fixed L{width}/B{batch} unexpectedly reported MTP active"
+                    )
+                if not inactive_reason_matches(metrics, expectation):
+                    raise ValueError(
+                        f"fixed L{width}/B{batch} inactive reason is not allowed"
+                    )
+                validate_zero_speculative_work(
+                    metrics, f"fixed L{width}/B{batch} expected-inactive"
+                )
+                continue
             if metrics.get("active") is not True or not observed_bucket(metrics, expected_bucket):
                 raise ValueError(f"fixed L{width}/B{batch} did not prove activation/bucket")
             depth = width - 1
@@ -835,6 +909,19 @@ def validate_report(
                 ):
                     raise ValueError(f"fixed L{width}/B{batch} lacks depth/bucket cost evidence")
         elif kind == "adaptive":
+            if expect_mtp_inactive:
+                if metrics.get("active") is not False:
+                    raise ValueError(
+                        f"adaptive B{batch} unexpectedly reported MTP active"
+                    )
+                if not inactive_reason_matches(metrics, expectation):
+                    raise ValueError(
+                        f"adaptive B{batch} inactive reason is not allowed"
+                    )
+                validate_zero_speculative_work(
+                    metrics, f"adaptive B{batch} expected-inactive"
+                )
+                continue
             if metrics.get("active") is not True or not observed_bucket(metrics, expected_bucket):
                 raise ValueError(f"adaptive B{batch} did not prove activation/bucket")
             if metrics.get("rounds", 0) <= 0 or metrics.get("proposedTokens", 0) <= 0:
@@ -883,6 +970,7 @@ def fingerprint_for(
             "target_fingerprint": target["artifactFingerprint"],
             "assistant_fingerprint": assistant["artifactFingerprint"],
             "mode": args.mode,
+            "mtp_expectation": expected_mtp_expectation(args.expect_mtp_inactive),
             "build_configuration": build_configuration,
             "test_filter": args.test_filter,
             "max_tokens": args.max_tokens,
@@ -945,6 +1033,9 @@ def worker_main(args: argparse.Namespace, warmup: int, repetitions: int) -> int:
                 "DARKBLOOM_MTP_BENCHMARK_BUILD_CONFIGURATION": build_configuration,
                 "DARKBLOOM_MTP_BENCHMARK_MAX_TOKENS": str(args.max_tokens),
                 "DARKBLOOM_MTP_BENCHMARK_MODE": args.mode,
+                "DARKBLOOM_MTP_BENCHMARK_EXPECT_MTP_INACTIVE": (
+                    "1" if args.expect_mtp_inactive else "0"
+                ),
                 "DARKBLOOM_MTP_BENCHMARK_WARMUP": str(warmup),
                 "DARKBLOOM_MTP_BENCHMARK_REPETITIONS": str(repetitions),
                 "DARKBLOOM_MTP_BENCHMARK_SEED": str(args.seed),
@@ -970,10 +1061,14 @@ def worker_main(args: argparse.Namespace, warmup: int, repetitions: int) -> int:
         print(f"result={output}")
         print(f"log={log_path}")
         print(f"mode={args.mode}")
+        print(f"expect_mtp_inactive={args.expect_mtp_inactive}")
         print(f"build_configuration={build_configuration}")
         print(f"test_filter={args.test_filter}")
         print(f"launch_fingerprint={fingerprint}")
-        print(f"report_fingerprint={build_configuration}:{fingerprint}")
+        expectation_kind = expected_mtp_expectation(args.expect_mtp_inactive)["kind"]
+        print(
+            f"report_fingerprint={build_configuration}:{expectation_kind}:{fingerprint}"
+        )
         sys.stdout.flush()
 
         process = subprocess.Popen(
@@ -1011,6 +1106,7 @@ def worker_main(args: argparse.Namespace, warmup: int, repetitions: int) -> int:
                     warmup=warmup,
                     repetitions=repetitions,
                     seed=args.seed,
+                    expect_mtp_inactive=args.expect_mtp_inactive,
                 )
             except (OSError, ValueError, UnicodeDecodeError, json.JSONDecodeError) as error:
                 print(
@@ -1036,6 +1132,7 @@ def supervisor_main(args: argparse.Namespace, warmup: int, repetitions: int) -> 
         "created_at": datetime.now(timezone.utc).isoformat(),
         "build_configuration": "debug" if args.debug else "release",
         "mode": args.mode,
+        "mtp_expectation": expected_mtp_expectation(args.expect_mtp_inactive),
         "test_filter": args.test_filter,
         "timeout_seconds": args.timeout_seconds,
     }
@@ -1185,6 +1282,14 @@ def parse_arguments() -> argparse.Namespace:
         default="raw-parity",
         help="raw parity recursively omits performance keys; performance requires release",
     )
+    parser.add_argument(
+        "--expect-mtp-inactive",
+        action="store_true",
+        help=(
+            "require fixed/adaptive cases to match the stable Apple M5 hardware "
+            "safety-veto reason, perform zero speculative work, and retain target-only parity"
+        ),
+    )
     parser.add_argument("--warmup", type=int)
     parser.add_argument("--repetitions", type=int)
     parser.add_argument("--seed", type=int, default=0x4D545032)
@@ -1210,6 +1315,8 @@ def parse_arguments() -> argparse.Namespace:
         parser.error("--timeout-seconds and --max-tokens must be positive; --seed nonnegative")
     if args.mode == "production-performance" and args.debug:
         parser.error("production-performance mode requires a release build")
+    if args.mode == "production-performance" and args.expect_mtp_inactive:
+        parser.error("production-performance mode rejects --expect-mtp-inactive")
     if not args.test_filter or args.test_filter.startswith("-"):
         parser.error("--test-filter must be nonempty")
     return args

--- a/scripts/run-mtp-benchmark.py
+++ b/scripts/run-mtp-benchmark.py
@@ -243,6 +243,37 @@ def append_fingerprint_field(payload: bytearray, value: str) -> None:
     payload.extend(encoded)
 
 
+def collect_nested_bit_overrides(value: Any, counts: dict[int, int]) -> None:
+    """Mirror of MTPBenchmarkModelFacts.collectNestedBitOverrides: count every
+    nested object carrying an integer `bits` anywhere under the quantization
+    dictionary's values."""
+    if isinstance(value, dict):
+        bits = value.get("bits")
+        if isinstance(bits, int) and not isinstance(bits, bool):
+            counts[bits] = counts.get(bits, 0) + 1
+        for child in value.values():
+            collect_nested_bit_overrides(child, counts)
+    elif isinstance(value, list):
+        for child in value:
+            collect_nested_bit_overrides(child, counts)
+
+
+def launch_effective_quantization_bits(raw_quantization: Any) -> int | None:
+    """Launch-side twin of `effective_quantization_bits`, computed from the
+    hashed config bytes: top-level integer `bits` wins; otherwise a UNIQUE
+    nested override value (per-layer `bits`) is the effective width."""
+    if not isinstance(raw_quantization, dict):
+        return None
+    bits = raw_quantization.get("bits")
+    if isinstance(bits, int) and not isinstance(bits, bool):
+        return bits
+    counts: dict[int, int] = {}
+    for value in raw_quantization.values():
+        collect_nested_bit_overrides(value, counts)
+    unique = {value for value, count in counts.items() if count > 0}
+    return next(iter(unique)) if len(unique) == 1 else None
+
+
 def artifact_facts(model_id: str, snapshot: Path) -> dict[str, Any]:
     repository = snapshot.parent.parent
     config = confined_regular_file(snapshot / "config.json", repository)
@@ -264,13 +295,7 @@ def artifact_facts(model_id: str, snapshot: Path) -> dict[str, Any]:
     config_metadata = {
         "model_type": parsed.get("model_type"),
         "dtype": parsed.get("dtype"),
-        "quantization_bits": (
-            raw_quantization.get("bits")
-            if isinstance(raw_quantization, dict)
-            and isinstance(raw_quantization.get("bits"), int)
-            and not isinstance(raw_quantization.get("bits"), bool)
-            else None
-        ),
+        "effective_quantization_bits": launch_effective_quantization_bits(raw_quantization),
         "has_quantization": isinstance(raw_quantization, dict),
     }
     entries, truncated = bounded_scandir(snapshot, MAX_SNAPSHOT_ENTRIES)
@@ -890,13 +915,15 @@ def validate_report_artifact(
     metadata = expected.get("configMetadata") or {}
     if report_artifact.get("modelType") != metadata.get("model_type"):
         raise ValueError(f"report {label} modelType does not match launch config.json")
-    raw_dtype = metadata.get("dtype")
-    if raw_dtype is not None and report_artifact.get("dtype") != raw_dtype:
+    # Strict TWO-WAY equality: a report may neither invent a dtype the hashed
+    # config lacks nor drop/alter one it has — BF16 coverage keys on this.
+    if report_artifact.get("dtype") != metadata.get("dtype"):
         raise ValueError(f"report {label} dtype does not match launch config.json")
-    if not metadata.get("has_quantization") and report_artifact.get("quantization") is not None:
-        raise ValueError(f"report {label} invents quantization absent from launch config.json")
-    raw_bits = metadata.get("quantization_bits")
-    if raw_bits is not None and effective_quantization_bits(report_artifact) != raw_bits:
+    if bool(metadata.get("has_quantization")) != (report_artifact.get("quantization") is not None):
+        raise ValueError(f"report {label} quantization presence does not match launch config.json")
+    # Compare the EFFECTIVE bits the coverage gate consumes (top-level or
+    # unique per-layer override), so override-only configs are anchored too.
+    if effective_quantization_bits(report_artifact) != metadata.get("effective_quantization_bits"):
         raise ValueError(f"report {label} quantization bits do not match launch config.json")
 
 
@@ -1051,6 +1078,12 @@ def validate_report(
                 and token_count != max_tokens
             ):
                 raise ValueError(f"case {kind}/{width}/B{batch} row {row_index} length terminal is premature")
+            if (
+                mode != "raw-parity"
+                and row.get("finishReason") == "stop"
+                and token_count > max_tokens
+            ):
+                raise ValueError(f"case {kind}/{width}/B{batch} row {row_index} stop terminal exceeds maxTokens")
             # finishReason is part of the cross-mode evidence: identical
             # tokens with a different terminal reason (EOS at the budget as
             # "stop" vs "length") is an OpenAI-visible divergence.

--- a/scripts/run-mtp-benchmark.py
+++ b/scripts/run-mtp-benchmark.py
@@ -748,6 +748,10 @@ def validate_automatic_fixed_fallback(
         ):
             raise ValueError(f"{label} lacks clamped-depth evidence")
         return True
+    # Complete zero-work evidence, mirroring the Swift validator field for
+    # field: a zero-fit clamp certifies that EXACT canonical fallback
+    # occurred, so any speculative array, counter, or timing residue must
+    # reject the report.
     if (
         metrics.get("selectedDepth") != 0
         or selections.get("0", 0) <= 0
@@ -756,8 +760,14 @@ def validate_automatic_fixed_fallback(
         or metrics.get("proposedTokens", 0) != 0
         or metrics.get("acceptedDraftTokens", 0) != 0
         or metrics.get("committedTokens", 0) != 0
-        or metrics.get("rectangularVerificationRounds", 0) != 0
+        or metrics.get("rectangularVerificationRounds", 0) not in (None, 0)
+        or metrics.get("acceptanceByPosition") not in ([], None)
+        or metrics.get("conditionalAcceptance") not in ([], None)
+        or metrics.get("skippedRows") not in ({}, None)
         or metrics.get("costInputs") not in ([], None)
+        or metrics.get("totalRoundWallTimeNanos") not in (None, 0)
+        or metrics.get("assistantTimeNanos") is not None
+        or metrics.get("targetVerifyTimeNanos") is not None
     ):
         raise ValueError(f"{label} reported uncategorized work")
     return True

--- a/scripts/run-mtp-benchmark.py
+++ b/scripts/run-mtp-benchmark.py
@@ -621,6 +621,100 @@ def validate_zero_speculative_work(metrics: dict[str, Any], label: str) -> None:
             raise ValueError(f"{label} reported speculative timing in {field}")
 
 
+def automatic_rectangular_cap(metrics: dict[str, Any]) -> int | None:
+    if metrics.get("verificationMode") != "automatic":
+        return None
+    cap = metrics.get("maxAutomaticRectangularTokens")
+    if isinstance(cap, int) and not isinstance(cap, bool) and cap >= 0:
+        return cap
+    return None
+
+
+def positive_cost_inputs(metrics: dict[str, Any]) -> list[dict[str, Any]]:
+    return [
+        item
+        for item in metrics.get("costInputs", [])
+        if isinstance(item, dict)
+        and item.get("draftDepth", 0) > 0
+        and item.get("sampleCount", 0) > 0
+    ]
+
+
+def positive_costs_within_cap(metrics: dict[str, Any], cap: int) -> bool:
+    return all(
+        item.get("decodeRowBucket", 0) * (item.get("draftDepth", 0) + 1) <= cap
+        for item in positive_cost_inputs(metrics)
+    )
+
+
+def validate_automatic_fixed_fallback(
+    metrics: dict[str, Any], batch: int, depth: int, label: str
+) -> bool:
+    """Mirror MTPBenchmarkRunner.validateAutomaticDepthLimitFallback.
+
+    A fixed depth whose batch * (1 + k) exceeds the automatic cap is clamped
+    before seed/draft work: either to a smaller positive depth (rectangular
+    rounds without controller cost samples, because cost attribution rejects
+    depth-mismatched work) or to certified zero-work target-only chaining.
+    """
+    cap = automatic_rectangular_cap(metrics)
+    if cap is None or batch * (depth + 1) <= cap:
+        return False
+    selections = metrics.get("depthSelections", {})
+    has_positive_depth = any(
+        key.isdigit() and int(key) > 0 and count > 0
+        for key, count in selections.items()
+        if isinstance(key, str) and isinstance(count, int)
+    )
+    if (
+        metrics.get("controllerFallbacks", {}).get("automatic_rectangular_limit", 0) <= 0
+        or not positive_costs_within_cap(metrics, cap)
+        or metrics.get("serialVerificationRounds", 0) != 0
+    ):
+        raise ValueError(f"{label} escaped its rectangular limit")
+    if has_positive_depth:
+        if (
+            metrics.get("rounds", 0) <= 0
+            or metrics.get("proposedTokens", 0) <= 0
+            or metrics.get("rectangularVerificationRounds", 0) <= 0
+        ):
+            raise ValueError(f"{label} lacks clamped-depth evidence")
+        return True
+    if (
+        metrics.get("selectedDepth") != 0
+        or selections.get("0", 0) <= 0
+        or metrics.get("rounds", 0) != 0
+        or metrics.get("seedRows", 0) != 0
+        or metrics.get("proposedTokens", 0) != 0
+        or metrics.get("acceptedDraftTokens", 0) != 0
+        or metrics.get("committedTokens", 0) != 0
+        or metrics.get("rectangularVerificationRounds", 0) != 0
+        or metrics.get("costInputs") not in ([], None)
+    ):
+        raise ValueError(f"{label} reported uncategorized work")
+    return True
+
+
+def validate_automatic_adaptive_within_cap(
+    metrics: dict[str, Any], batch: int, label: str
+) -> bool:
+    """Adaptive drafting cannot be demanded when even depth one exceeds the
+    automatic cap at this batch size; any drafting after tail rows drain must
+    stay rectangular and inside the cap."""
+    cap = automatic_rectangular_cap(metrics)
+    if cap is None or batch * 2 <= cap:
+        return False
+    rounds = metrics.get("rounds", 0)
+    if (
+        not positive_costs_within_cap(metrics, cap)
+        or metrics.get("serialVerificationRounds", 0) != 0
+        or (rounds > 0 and metrics.get("proposedTokens", 0) <= 0)
+        or (rounds == 0 and metrics.get("rectangularVerificationRounds", 0) != 0)
+    ):
+        raise ValueError(f"{label} escaped its automatic rectangular limit")
+    return True
+
+
 def recursively_present_keys(value: Any, wanted: set[str]) -> set[str]:
     found: set[str] = set()
     if isinstance(value, dict):
@@ -892,9 +986,15 @@ def validate_report(
                     metrics, f"fixed L{width}/B{batch} expected-inactive"
                 )
                 continue
-            if metrics.get("active") is not True or not observed_bucket(metrics, expected_bucket):
-                raise ValueError(f"fixed L{width}/B{batch} did not prove activation/bucket")
+            if metrics.get("active") is not True:
+                raise ValueError(f"fixed L{width}/B{batch} did not prove activation")
             depth = width - 1
+            if validate_automatic_fixed_fallback(
+                metrics, batch, depth, f"fixed L{width}/B{batch}"
+            ):
+                continue
+            if not observed_bucket(metrics, expected_bucket):
+                raise ValueError(f"fixed L{width}/B{batch} did not prove its bucket")
             if metrics.get("depthSelections", {}).get(str(depth), 0) <= 0:
                 raise ValueError(f"fixed L{width}/B{batch} never selected depth {depth}")
             if depth > 0:
@@ -924,6 +1024,10 @@ def validate_report(
                 continue
             if metrics.get("active") is not True or not observed_bucket(metrics, expected_bucket):
                 raise ValueError(f"adaptive B{batch} did not prove activation/bucket")
+            if validate_automatic_adaptive_within_cap(
+                metrics, batch, f"adaptive B{batch}"
+            ):
+                continue
             if metrics.get("rounds", 0) <= 0 or metrics.get("proposedTokens", 0) <= 0:
                 raise ValueError(f"adaptive B{batch} did not draft")
             if not any(


### PR DESCRIPTION
## Summary

- complete Gemma 4 frozen-KV MTP from catalog metadata through the production ProviderCore engine funnel
- pin the MERGED engine main `15c8857f7a640fb54266e80fa4df1fd0cc412a91` (squash of mlx-swift-lm PR #75; tree byte-identical to the reviewed branch head, gate suites re-run green at the exact pin)
- use automatic exact verification with fixed initial `k=1` instead of regressive serial speculation
- apply a maximum rectangular work size of 4 on M1/M2/unknown hardware and 8 on M3/M4/M5
- allow `DARKBLOOM_MTP_MAX_RECTANGULAR_TOKENS` to tighten, never expand, the certified hardware maximum
- preserve target-only availability on unsafe batch shapes and every assistant/config/storage failure
- report configured work cap and actual rectangular/serial round counts in benchmark and provider snapshots

MTP remains default-off. This PR does not publish an assistant artifact, write registry metadata, release, or deploy.

## Before

```mermaid
flowchart LR
  subgraph Behavior
    A1[Gemma MTP enabled on M1-M5] --> B1[assistant drafts k tokens]
    B1 --> C1[serial target verify by default]
    C1 --> D1[exact target-authoritative commit]
    D1 --> E1[all measured batches regress]
  end
  subgraph Code
    F1[EngineV2SlotFactory] --> G1[CBv2MTPConfig serial_target]
    G1 --> H1[serial column verifier]
    H1 --> I1[provider reports verification mode]
  end
```

## After

```mermaid
flowchart LR
  subgraph Behavior
    A2[Gemma MTP enabled] --> B2[chip policy selects exact work cap]
    B2 --> C2[fixed k=1 automatic plan]
    C2 -->|shape fits| D2[one exact rectangular target pass]
    D2 --> E2[target-authoritative accept and KV commit]
    C2 -->|shape does not fit| F2[target-only chained decode with no draft work]
  end
  subgraph Code
    G2[MTPAutomaticVerificationPolicy] --> H2[EngineV2SlotFactory automatic config]
    H2 --> I2[engine depth cap and decode-shaped attention]
    I2 --> J2[MTP metrics snapshot]
    J2 --> K2[benchmark validation and provider status]
  end
```

## Correctness And Acceleration Contract

Every committed token and retained KV entry remains target-authoritative. The assistant can change only performance and availability.

Automatic mode bounds `batch * (1+k)` before seed or draft work. Positive depths keep projections and feed-forward work rectangular, but each attention query uses canonical `L=1` SDPA against its exact visible staged KV prefix. When no positive depth fits, the engine performs ordinary target-only chaining and records zero assistant, rectangular-verifier, and serial-verifier work.

`serial_target` remains explicit for diagnostics and defensive correctness fallback. It is no longer the production default because it is structurally unable to beat target-only decode.

## Accepted Beta Risk On Uncertified Chips (Owner Decision)

M4 Max and M5 Max are byte-certified. M1, M2, M3, and unknown chips run the identical automatic mechanism with conservative caps but have **no physical parity certificate**: on those chips, near-tie argmax flips versus canonical decode are possible inside the capped shapes. The owner explicitly accepted this for the opt-in beta to gather fleet data from every generation. The worst case is a different-but-valid token at genuine probability ties (loss of cross-fleet bit-reproducibility), never KV corruption, crashes, or drafter-injected content — acceptance, rollback, and lifecycle remain target-authoritative and are covered by the adversarial suites. Each generation graduates to certified status by running the supervised raw-parity matrix once (`scripts/run-mtp-benchmark.py --mode raw-parity`).

## Provider Guarantees

- M1/M2/unknown maximum automatic rectangular work: 4
- M3/M4/M5 maximum automatic rectangular work: 8
- production initial depth: fixed `k=1`
- operator override can only reduce the hardware maximum
- local override takes precedence; local-only mode never contacts the coordinator
- catalog activation requires manifest, size, count, role, config, revision, and per-file digest anchors
- assistant bytes are charged exactly once across admission, reservations, sizing, re-slicing, heartbeat capacity, standalone serving, and recovery
- every assistant error produces a stable target-only fallback reason
- assistant checkpoints remain excluded from target advertisement and attestation

## Exactness Evidence

- M5 Max production QAT target and QAT assistant: byte-exact layer state, final logits, and storage-owning K/V throughout the safe envelope B1/L2...L8, B2/L2...L4, and B4/L2
- M5 Max B4/L2 partial rollback, accepted 1 and rejected 1: `kvMismatches=0`
- M4 Max exact checks at B1/L3, B2/L2, and B4/L2, including partial rollback
- M1 through M3 were not physically available; conservative bounds derive from the pinned MLX kernel dispatch and cannot be expanded by configuration

## Release TPS Evidence

Production QAT target plus 236 MB QAT assistant, fixed `k=1`, 32 output tokens, one warmup, three repetitions:

| M5 Max batch | Target-only TPS | Automatic MTP TPS | Delta | Strategy |
|---:|---:|---:|---:|---|
| 1 | 119.67 | 139.73 | +16.76% | rectangular only |
| 2 | 173.97 | 187.43 | +7.73% | rectangular only |
| 4 | 180.77 | 222.02 | +22.82% | rectangular only |
| 8 | 306.77 | 306.65 | -0.04% | target-only; zero verifier rounds |

M4 Max fixed-`k=1` deltas were +11.4% at B1, +0.3% at B2, and +8.3% at B4.

## Validation

- M5 Max supervised automatic raw-parity matrix at the exact head commits: 40/40 byte token parity, zero mismatch rows, 348 rounds with 479 proposed and 438 accepted drafts (repeated partial rejections exercising rollback), zero serial rounds, 133 rectangular rounds, every positive cost input within the cap; report SHA-256 `0605bb9650ebbe4968fc0d909cac4b9394a7e8e2b87b6b92187234b4a0037a40`
- M4 Max supervised automatic raw-parity matrix at the exact head commits: 40/40 byte token parity, zero mismatch rows, 380 rounds with 537 proposed and 442 accepted drafts, zero serial rounds, 144 rectangular rounds, every positive cost input within the cap; report SHA-256 `27e2072c6a70cc50d1a2867f7d67a4091080dc9495fc259ff93c16adf8e1b167`
- The matrices found and fixed two validator defects: a depth clamped to a smaller positive depth must not be required to record depth-zero selections, and clamped rounds legitimately record no controller cost samples because cost attribution rejects depth-mismatched work; the Python supervisor now mirrors the same cap contract
- 11 engine authority/parity tests
- 14 depth-controller and automatic-cap tests
- 10 round/lifecycle tests
- 12 mixed/compiled/quantized tests
- 63 focused provider MTP tests
- 25 benchmark schema/metrics tests
- real M4/M5 QAT exactness and release TPS runs
- parent and nested `git diff --check`

The aggregate engine `CBv2MTP` selection has a known SwiftPM/XCTest compiled-suite hang. Each relevant bounded suite passes independently.

## Deliberately Deferred

- physical M1, M2, and M3 parity/TPS matrices and any resulting cap expansion
- stochastic MTP acceptance
- paged-window speculative staging
- EAGLE, Medusa, and tree verification
- official cross-runtime tensor fixtures
- default-on rollout, assistant publication, registry mutation, release, and deployment



