### PR TITLE
fix(tools): Gemma 4 tool-calling reliability — exhaustive schema normalization, turn repair, typed errors

### DIFF
--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -23,6 +23,7 @@ import (
 	"math"
 	"net/http"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -2332,8 +2333,17 @@ func extractMessage(chunks []string) extractedMessage {
 	var contentBuilder strings.Builder
 	var reasoningBuilder strings.Builder
 	finishReason := ""
-	// Tool calls are indexed — accumulate argument fragments by index.
-	toolCallMap := map[int]map[string]any{}
+	// Tool calls are indexed — argument fragments accumulate onto the wire
+	// index's CURRENT logical call. Logical calls are kept in arrival order
+	// (toolCalls) because a wire index is NOT unique: our engine emits every
+	// parallel call with index 0 (E6), so index-keyed storage alone would let
+	// a second call overwrite the first's id/name and concatenate both
+	// argument streams into one corrupted call. A delta whose non-empty id
+	// DIFFERS from the current entry's non-empty id starts a NEW logical
+	// call; id-less deltas (argument fragments) keep accumulating onto the
+	// index's current call, so well-behaved indexed streams are unchanged.
+	var toolCalls []map[string]any
+	activeCallByIndex := map[int]int{}
 
 	for _, chunk := range chunks {
 		line := strings.TrimPrefix(chunk, "data: ")
@@ -2396,16 +2406,27 @@ func extractMessage(chunks []string) extractedMessage {
 				reasoningBuilder.WriteString(c.Message.ReasoningContent)
 			}
 			for _, tc := range c.Delta.ToolCalls {
-				existing, ok := toolCallMap[tc.Index]
+				pos, ok := activeCallByIndex[tc.Index]
+				if ok && tc.ID != "" {
+					if existingID, _ := toolCalls[pos]["id"].(string); existingID != "" && existingID != tc.ID {
+						// A NEW id on an already-active wire index is a new
+						// logical call, not a continuation (the all-index-0
+						// engine shape) — never merge two calls into one.
+						ok = false
+					}
+				}
 				if !ok {
-					existing = map[string]any{
+					entry := map[string]any{
 						"index": tc.Index,
 						"function": map[string]any{
 							"arguments": "",
 						},
 					}
-					toolCallMap[tc.Index] = existing
+					toolCalls = append(toolCalls, entry)
+					pos = len(toolCalls) - 1
+					activeCallByIndex[tc.Index] = pos
 				}
+				existing := toolCalls[pos]
 				if tc.ID != "" {
 					existing["id"] = tc.ID
 				}
@@ -2432,13 +2453,18 @@ func extractMessage(chunks []string) extractedMessage {
 		}
 	}
 	msg := extractedMessage{Content: content, Reasoning: reasoning, FinishReason: finishReason}
-	if len(toolCallMap) > 0 {
-		msg.ToolCalls = make([]map[string]any, 0, len(toolCallMap))
-		for i := range len(toolCallMap) {
-			if tc, ok := toolCallMap[i]; ok {
-				delete(tc, "index")
-				msg.ToolCalls = append(msg.ToolCalls, tc)
-			}
+	if len(toolCalls) > 0 {
+		// Order by wire index for well-behaved indexed streams; the stable
+		// sort preserves ARRIVAL order among equal indices (the all-index-0
+		// shape), and — unlike the old dense 0..n-1 map walk — sparse indices
+		// are never dropped.
+		sort.SliceStable(toolCalls, func(i, j int) bool {
+			return toolCalls[i]["index"].(int) < toolCalls[j]["index"].(int)
+		})
+		msg.ToolCalls = make([]map[string]any, 0, len(toolCalls))
+		for _, tc := range toolCalls {
+			delete(tc, "index")
+			msg.ToolCalls = append(msg.ToolCalls, tc)
 		}
 	}
 	return msg

--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -2330,15 +2330,128 @@ func normalizeSSEChunk(chunk string) string {
 const maxLogicalToolCalls = 128
 
 // toolCallWireIndex reads an accumulated tool-call entry's wire index.
-// Entries are always created with an int "index", so the comma-ok is
-// defensive only: a corrupt entry cannot panic the request path — it sorts
-// last, keeping arrival order relative to other corrupt entries.
+// Entries are always created with an int "index" (toolCallAccumulator.apply),
+// so the comma-ok is defensive only: a corrupt entry cannot panic the request
+// path — it sorts last, keeping arrival order relative to other corrupt
+// entries.
 func toolCallWireIndex(tc map[string]any) int {
 	idx, ok := tc["index"].(int)
 	if !ok {
 		return math.MaxInt
 	}
 	return idx
+}
+
+// streamedToolCallDelta is a single tool_calls entry from a streaming delta
+// frame.
+type streamedToolCallDelta struct {
+	Index    int    `json:"index"`
+	ID       string `json:"id,omitempty"`
+	Type     string `json:"type,omitempty"`
+	Function struct {
+		Name      string `json:"name,omitempty"`
+		Arguments string `json:"arguments,omitempty"`
+	} `json:"function,omitempty"`
+}
+
+// toolCallAccumulator reconstructs logical tool calls from streamed deltas.
+// Logical calls are kept in ARRIVAL order (calls) because a wire index is
+// NOT unique: our engine emits every parallel call with index 0 (E6), so
+// index-keyed storage alone would let a second call overwrite the first's
+// id/name and concatenate both argument streams into one corrupted call.
+// activeByIndex maps each wire index to the position (in calls) of its
+// CURRENT logical call — the one still receiving that index's id-less
+// argument fragments; a delta whose non-empty id DIFFERS from that entry's
+// non-empty id starts a NEW logical call, so well-behaved indexed streams
+// are unchanged.
+type toolCallAccumulator struct {
+	calls         []map[string]any
+	activeByIndex map[int]int
+	// droppedDeltas counts deltas swallowed past maxLogicalToolCalls
+	// (dropped new logical calls and their argument fragments).
+	droppedDeltas int
+}
+
+func newToolCallAccumulator() *toolCallAccumulator {
+	return &toolCallAccumulator{activeByIndex: map[int]int{}}
+}
+
+// apply folds one streamed delta into the accumulator. Past
+// maxLogicalToolCalls, a delta that would start a new logical call is
+// dropped and its wire index forgotten, so the dropped call's later id-less
+// fragments can never accumulate onto a kept call; kept calls keep receiving
+// their own fragments as usual.
+func (a *toolCallAccumulator) apply(tc streamedToolCallDelta) {
+	pos, ok := a.activeByIndex[tc.Index]
+	if ok && tc.ID != "" {
+		if existingID, _ := a.calls[pos]["id"].(string); existingID != "" && existingID != tc.ID {
+			// A NEW id on an already-active wire index is a new logical
+			// call, not a continuation (the all-index-0 engine shape) —
+			// never merge two calls into one.
+			ok = false
+		}
+	}
+	if !ok {
+		if len(a.calls) >= maxLogicalToolCalls {
+			// Cap reached: drop the new logical call. The kept call at
+			// this wire index (if any) is complete as-is. This also
+			// bounds activeByIndex: keys are only ever added alongside a
+			// kept call, so both structures stay <= maxLogicalToolCalls
+			// entries no matter how many distinct ids or sparse wire
+			// indices are streamed.
+			a.droppedDeltas++
+			delete(a.activeByIndex, tc.Index)
+			return
+		}
+		entry := map[string]any{
+			"index": tc.Index,
+			"function": map[string]any{
+				"arguments": "",
+			},
+		}
+		a.calls = append(a.calls, entry)
+		pos = len(a.calls) - 1
+		a.activeByIndex[tc.Index] = pos
+	}
+	entry := a.calls[pos]
+	if tc.ID != "" {
+		entry["id"] = tc.ID
+	}
+	if tc.Type != "" {
+		entry["type"] = tc.Type
+	}
+	fn, fnOK := entry["function"].(map[string]any)
+	if !fnOK {
+		// Defensive: entries are always created with a function map —
+		// never panic the request path on a corrupt entry.
+		fn = map[string]any{}
+		entry["function"] = fn
+	}
+	if tc.Function.Name != "" {
+		fn["name"] = tc.Function.Name
+	}
+	args, _ := fn["arguments"].(string)
+	fn["arguments"] = args + tc.Function.Arguments
+}
+
+// finalize returns the reconstructed calls (nil when there are none),
+// ordered by wire index for well-behaved indexed streams; the stable sort
+// preserves ARRIVAL order among equal indices (the all-index-0 shape), and —
+// unlike the old dense 0..n-1 map walk — sparse indices are never dropped.
+// The internal "index" key is stripped from the returned maps.
+func (a *toolCallAccumulator) finalize() []map[string]any {
+	if len(a.calls) == 0 {
+		return nil
+	}
+	sort.SliceStable(a.calls, func(i, j int) bool {
+		return toolCallWireIndex(a.calls[i]) < toolCallWireIndex(a.calls[j])
+	})
+	out := make([]map[string]any, 0, len(a.calls))
+	for _, tc := range a.calls {
+		delete(tc, "index")
+		out = append(out, tc)
+	}
+	return out
 }
 
 // extractedMessage holds the reconstructed assistant message from SSE chunks,
@@ -2356,20 +2469,9 @@ func extractMessage(chunks []string) extractedMessage {
 	var contentBuilder strings.Builder
 	var reasoningBuilder strings.Builder
 	finishReason := ""
-	// Tool calls are indexed — argument fragments accumulate onto the wire
-	// index's CURRENT logical call. Logical calls are kept in arrival order
-	// (toolCalls) because a wire index is NOT unique: our engine emits every
-	// parallel call with index 0 (E6), so index-keyed storage alone would let
-	// a second call overwrite the first's id/name and concatenate both
-	// argument streams into one corrupted call. A delta whose non-empty id
-	// DIFFERS from the current entry's non-empty id starts a NEW logical
-	// call; id-less deltas (argument fragments) keep accumulating onto the
-	// index's current call, so well-behaved indexed streams are unchanged.
-	var toolCalls []map[string]any
-	activeCallByIndex := map[int]int{}
-	// Deltas swallowed past maxLogicalToolCalls (dropped new logical calls
-	// and their argument fragments).
-	droppedToolCallDeltas := 0
+	// See toolCallAccumulator for the logical-call model (arrival order,
+	// non-unique wire indices, the maxLogicalToolCalls cap).
+	acc := newToolCallAccumulator()
 
 	for _, chunk := range chunks {
 		line := strings.TrimPrefix(chunk, "data: ")
@@ -2389,18 +2491,10 @@ func extractMessage(chunks []string) extractedMessage {
 		}
 		var choices []struct {
 			Delta struct {
-				Content          string `json:"content"`
-				Reasoning        string `json:"reasoning"`
-				ReasoningContent string `json:"reasoning_content"`
-				ToolCalls        []struct {
-					Index    int    `json:"index"`
-					ID       string `json:"id,omitempty"`
-					Type     string `json:"type,omitempty"`
-					Function struct {
-						Name      string `json:"name,omitempty"`
-						Arguments string `json:"arguments,omitempty"`
-					} `json:"function,omitempty"`
-				} `json:"tool_calls,omitempty"`
+				Content          string                  `json:"content"`
+				Reasoning        string                  `json:"reasoning"`
+				ReasoningContent string                  `json:"reasoning_content"`
+				ToolCalls        []streamedToolCallDelta `json:"tool_calls,omitempty"`
 			} `json:"delta"`
 			Message struct {
 				Content          string `json:"content"`
@@ -2432,59 +2526,7 @@ func extractMessage(chunks []string) extractedMessage {
 				reasoningBuilder.WriteString(c.Message.ReasoningContent)
 			}
 			for _, tc := range c.Delta.ToolCalls {
-				pos, ok := activeCallByIndex[tc.Index]
-				if ok && tc.ID != "" {
-					if existingID, _ := toolCalls[pos]["id"].(string); existingID != "" && existingID != tc.ID {
-						// A NEW id on an already-active wire index is a new
-						// logical call, not a continuation (the all-index-0
-						// engine shape) — never merge two calls into one.
-						ok = false
-					}
-				}
-				if !ok {
-					if len(toolCalls) >= maxLogicalToolCalls {
-						// Cap reached: drop the new logical call. The kept
-						// call at this wire index (if any) is complete
-						// as-is — forgetting the index keeps the dropped
-						// call's later id-less fragments from accumulating
-						// onto a kept call. This also bounds
-						// activeCallByIndex: keys are only ever added
-						// alongside a kept call, so both structures stay
-						// <= maxLogicalToolCalls entries no matter how many
-						// distinct ids or sparse wire indices are streamed.
-						droppedToolCallDeltas++
-						delete(activeCallByIndex, tc.Index)
-						continue
-					}
-					entry := map[string]any{
-						"index": tc.Index,
-						"function": map[string]any{
-							"arguments": "",
-						},
-					}
-					toolCalls = append(toolCalls, entry)
-					pos = len(toolCalls) - 1
-					activeCallByIndex[tc.Index] = pos
-				}
-				existing := toolCalls[pos]
-				if tc.ID != "" {
-					existing["id"] = tc.ID
-				}
-				if tc.Type != "" {
-					existing["type"] = tc.Type
-				}
-				fn, fnOK := existing["function"].(map[string]any)
-				if !fnOK {
-					// Defensive: entries are always created with a function
-					// map — never panic the request path on a corrupt entry.
-					fn = map[string]any{}
-					existing["function"] = fn
-				}
-				if tc.Function.Name != "" {
-					fn["name"] = tc.Function.Name
-				}
-				args, _ := fn["arguments"].(string)
-				fn["arguments"] = args + tc.Function.Arguments
+				acc.apply(tc)
 			}
 		}
 	}
@@ -2500,23 +2542,10 @@ func extractMessage(chunks []string) extractedMessage {
 		}
 	}
 	msg := extractedMessage{Content: content, Reasoning: reasoning, FinishReason: finishReason}
-	if droppedToolCallDeltas > 0 {
-		log.Printf("WARN: extractMessage: logical tool-call cap (%d) reached; dropped %d tool-call delta(s) from excess calls", maxLogicalToolCalls, droppedToolCallDeltas)
+	if acc.droppedDeltas > 0 {
+		log.Printf("WARN: extractMessage: logical tool-call cap (%d) reached; dropped %d tool-call delta(s) from excess calls", maxLogicalToolCalls, acc.droppedDeltas)
 	}
-	if len(toolCalls) > 0 {
-		// Order by wire index for well-behaved indexed streams; the stable
-		// sort preserves ARRIVAL order among equal indices (the all-index-0
-		// shape), and — unlike the old dense 0..n-1 map walk — sparse indices
-		// are never dropped.
-		sort.SliceStable(toolCalls, func(i, j int) bool {
-			return toolCallWireIndex(toolCalls[i]) < toolCallWireIndex(toolCalls[j])
-		})
-		msg.ToolCalls = make([]map[string]any, 0, len(toolCalls))
-		for _, tc := range toolCalls {
-			delete(tc, "index")
-			msg.ToolCalls = append(msg.ToolCalls, tc)
-		}
-	}
+	msg.ToolCalls = acc.finalize()
 	return msg
 }
 

--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -247,6 +247,35 @@ func (s *Server) refundProviderExtra(pr *registry.PendingRequest) {
 	s.ddIncr("billing.reservation_extra_refunds", []string{"model:" + pr.Model})
 }
 
+// writeGenericProviderError writes the terminal HTTP body for a provider error
+// on paths WITHOUT a failover ladder or in-band SSE error framing: the generic
+// inference handlers (/v1/messages, /v1/completions) and the non-streaming
+// chat response assembly. Deterministic non-provider-fault reasons surface the
+// SAME curated bodies as the chat dispatch ladder — a jinja_* template-render
+// failure becomes the 422 model_capability invalid_request_error (the raw
+// template backtrace never reaches a client), gated by the ladder's
+// EIGENINFERENCE_JINJA_TERMINAL_REJECT kill switch; tool_noncompliance keeps
+// its provider-typed 422 message (already curated and content-free) but in the
+// invalid_request_error/model_capability envelope instead of provider_error.
+// Every other error keeps the legacy raw passthrough byte-for-byte.
+func (s *Server) writeGenericProviderError(w http.ResponseWriter, errMsg protocol.InferenceErrorMessage) {
+	if jinjaTerminalRejectEnabled() && isJinjaTemplateErrorReason(errMsg.ErrorReason) {
+		writeJSON(w, http.StatusUnprocessableEntity,
+			errorResponse("invalid_request_error", jinjaTerminalRejectMessage, withCode("model_capability")))
+		return
+	}
+	if normalizeInferenceErrorReason(errMsg.ErrorReason) == errorReasonToolNoncompliance {
+		writeJSON(w, http.StatusUnprocessableEntity,
+			errorResponse("invalid_request_error", errMsg.Error, withCode("model_capability")))
+		return
+	}
+	statusCode := errMsg.StatusCode
+	if statusCode == 0 {
+		statusCode = http.StatusBadGateway
+	}
+	writeJSON(w, statusCode, errorResponse("provider_error", errMsg.Error))
+}
+
 // noteInferenceError feeds the circuit breakers for a provider-side error
 // received on a pending request's ErrorCh (any phase, pre- or post-commit):
 //   - the shape-keyed inference-error breaker (counts only sickness-shaped
@@ -1971,11 +2000,7 @@ func (s *Server) handleNonStreamingResponseWithFirstChunk(w http.ResponseWriter,
 						s.refundReservedBalance(pr, "provider_error:"+pr.RequestID)
 						s.noteInferenceError(pr.ProviderID, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason)
 						s.updateInferenceRouteOutcomeForPending(pr, preResponseProviderErrorOutcome(pr, errMsg))
-						statusCode := errMsg.StatusCode
-						if statusCode == 0 {
-							statusCode = http.StatusBadGateway
-						}
-						writeJSON(w, statusCode, errorResponse("provider_error", errMsg.Error))
+						s.writeGenericProviderError(w, errMsg)
 						return
 					}
 				default:
@@ -2102,11 +2127,7 @@ func (s *Server) handleNonStreamingResponseWithFirstChunk(w http.ResponseWriter,
 			s.refundReservedBalance(pr, "provider_error:"+pr.RequestID)
 			s.noteInferenceError(pr.ProviderID, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason)
 			s.updateInferenceRouteOutcomeForPending(pr, preResponseProviderErrorOutcome(pr, errMsg))
-			statusCode := errMsg.StatusCode
-			if statusCode == 0 {
-				statusCode = http.StatusBadGateway
-			}
-			writeJSON(w, statusCode, errorResponse("provider_error", errMsg.Error))
+			s.writeGenericProviderError(w, errMsg)
 			return
 
 		case <-ctx.Done():
@@ -4010,11 +4031,7 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 				refundReservation()
 				s.noteInferenceError(provider.ID, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason)
 				s.updateInferenceRouteOutcomeForPending(pr, preCommitProviderErrorOutcome(pr, errMsg))
-				statusCode := errMsg.StatusCode
-				if statusCode == 0 {
-					statusCode = http.StatusBadGateway
-				}
-				writeJSON(w, statusCode, errorResponse("provider_error", errMsg.Error))
+				s.writeGenericProviderError(w, errMsg)
 				return
 			default:
 				committed = true
@@ -4029,11 +4046,7 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 		refundReservation()
 		s.noteInferenceError(provider.ID, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason)
 		s.updateInferenceRouteOutcomeForPending(pr, preCommitProviderErrorOutcome(pr, errMsg))
-		statusCode := errMsg.StatusCode
-		if statusCode == 0 {
-			statusCode = http.StatusBadGateway
-		}
-		writeJSON(w, statusCode, errorResponse("provider_error", errMsg.Error))
+		s.writeGenericProviderError(w, errMsg)
 		return
 	case <-ttftTimer.C:
 		provider.RemovePending(requestID)
@@ -4085,11 +4098,7 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 					refundReservation()
 					s.noteInferenceError(provider.ID, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason)
 					s.updateInferenceRouteOutcomeForPending(pr, preCommitProviderErrorOutcome(pr, errMsg))
-					statusCode := errMsg.StatusCode
-					if statusCode == 0 {
-						statusCode = http.StatusBadGateway
-					}
-					writeJSON(w, statusCode, errorResponse("provider_error", errMsg.Error))
+					s.writeGenericProviderError(w, errMsg)
 					return
 				default:
 					committed = true
@@ -4104,11 +4113,7 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 			refundReservation()
 			s.noteInferenceError(provider.ID, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason)
 			s.updateInferenceRouteOutcomeForPending(pr, preCommitProviderErrorOutcome(pr, errMsg))
-			statusCode := errMsg.StatusCode
-			if statusCode == 0 {
-				statusCode = http.StatusBadGateway
-			}
-			writeJSON(w, statusCode, errorResponse("provider_error", errMsg.Error))
+			s.writeGenericProviderError(w, errMsg)
 			return
 		case <-chunkTimer.C:
 			provider.RemovePending(requestID)

--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -267,6 +267,19 @@ func (s *Server) noteInferenceError(providerID string, pr *registry.PendingReque
 	if providerID == "" || pr == nil {
 		return
 	}
+	// Deterministic request/model-capability faults (isNonProviderFaultErrorReason:
+	// jinja_* template-render failures, tool_noncompliance) never feed the
+	// provider-health breakers — the provider executed faithfully; the request
+	// shape or the model's sampled output is what failed. Gating HERE (the single
+	// breaker chokepoint) mirrors the dispatch-funnel gate
+	// (dispatchState.noteProviderError) and the reputation exemption
+	// (handleInferenceError), and closes the generic-inference path
+	// (/v1/messages, /v1/completions), which calls noteInferenceError directly on
+	// pre-commit provider errors. Capacity-class rejections never carry these
+	// reasons, so the capacity-reject cooldown feed below is unaffected.
+	if isNonProviderFaultErrorReason(errReason) {
+		return
+	}
 	if s.registry.RecordInferenceError(providerID, pr.Model, statusCode, pr.Traits.CooldownShape()) {
 		s.ddIncr("routing.cooldown_entered", []string{"model:" + pr.Model})
 	}

--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -2318,6 +2318,29 @@ func normalizeSSEChunk(chunk string) string {
 	return "data: " + string(out)
 }
 
+// maxLogicalToolCalls caps how many logical tool calls a single stream may
+// reconstruct. Chunks come from providers, which are only semi-trusted: a
+// buggy or malicious provider could otherwise stream an unbounded number of
+// distinct-id tool-call deltas and grow the reconstruction (and its wire-index
+// tracking) without limit. Real parallel-tool-call fan-out is tiny (typically
+// <= 4 calls), so 128 is far above anything legitimate while bounding the
+// worst case. Past the cap, deltas that would START a new logical call are
+// dropped (counted + logged); argument fragments for already-kept calls still
+// accumulate, so kept calls are never truncated or corrupted.
+const maxLogicalToolCalls = 128
+
+// toolCallWireIndex reads an accumulated tool-call entry's wire index.
+// Entries are always created with an int "index", so the comma-ok is
+// defensive only: a corrupt entry cannot panic the request path — it sorts
+// last, keeping arrival order relative to other corrupt entries.
+func toolCallWireIndex(tc map[string]any) int {
+	idx, ok := tc["index"].(int)
+	if !ok {
+		return math.MaxInt
+	}
+	return idx
+}
+
 // extractedMessage holds the reconstructed assistant message from SSE chunks,
 // including text content, reasoning, and any tool calls.
 type extractedMessage struct {
@@ -2344,6 +2367,9 @@ func extractMessage(chunks []string) extractedMessage {
 	// index's current call, so well-behaved indexed streams are unchanged.
 	var toolCalls []map[string]any
 	activeCallByIndex := map[int]int{}
+	// Deltas swallowed past maxLogicalToolCalls (dropped new logical calls
+	// and their argument fragments).
+	droppedToolCallDeltas := 0
 
 	for _, chunk := range chunks {
 		line := strings.TrimPrefix(chunk, "data: ")
@@ -2416,6 +2442,20 @@ func extractMessage(chunks []string) extractedMessage {
 					}
 				}
 				if !ok {
+					if len(toolCalls) >= maxLogicalToolCalls {
+						// Cap reached: drop the new logical call. The kept
+						// call at this wire index (if any) is complete
+						// as-is — forgetting the index keeps the dropped
+						// call's later id-less fragments from accumulating
+						// onto a kept call. This also bounds
+						// activeCallByIndex: keys are only ever added
+						// alongside a kept call, so both structures stay
+						// <= maxLogicalToolCalls entries no matter how many
+						// distinct ids or sparse wire indices are streamed.
+						droppedToolCallDeltas++
+						delete(activeCallByIndex, tc.Index)
+						continue
+					}
 					entry := map[string]any{
 						"index": tc.Index,
 						"function": map[string]any{
@@ -2433,11 +2473,18 @@ func extractMessage(chunks []string) extractedMessage {
 				if tc.Type != "" {
 					existing["type"] = tc.Type
 				}
-				fn := existing["function"].(map[string]any)
+				fn, fnOK := existing["function"].(map[string]any)
+				if !fnOK {
+					// Defensive: entries are always created with a function
+					// map — never panic the request path on a corrupt entry.
+					fn = map[string]any{}
+					existing["function"] = fn
+				}
 				if tc.Function.Name != "" {
 					fn["name"] = tc.Function.Name
 				}
-				fn["arguments"] = fn["arguments"].(string) + tc.Function.Arguments
+				args, _ := fn["arguments"].(string)
+				fn["arguments"] = args + tc.Function.Arguments
 			}
 		}
 	}
@@ -2453,13 +2500,16 @@ func extractMessage(chunks []string) extractedMessage {
 		}
 	}
 	msg := extractedMessage{Content: content, Reasoning: reasoning, FinishReason: finishReason}
+	if droppedToolCallDeltas > 0 {
+		log.Printf("WARN: extractMessage: logical tool-call cap (%d) reached; dropped %d tool-call delta(s) from excess calls", maxLogicalToolCalls, droppedToolCallDeltas)
+	}
 	if len(toolCalls) > 0 {
 		// Order by wire index for well-behaved indexed streams; the stable
 		// sort preserves ARRIVAL order among equal indices (the all-index-0
 		// shape), and — unlike the old dense 0..n-1 map walk — sparse indices
 		// are never dropped.
 		sort.SliceStable(toolCalls, func(i, j int) bool {
-			return toolCalls[i]["index"].(int) < toolCalls[j]["index"].(int)
+			return toolCallWireIndex(toolCalls[i]) < toolCallWireIndex(toolCalls[j])
 		})
 		msg.ToolCalls = make([]map[string]any, 0, len(toolCalls))
 		for _, tc := range toolCalls {

--- a/coordinator/api/consumer_toolcall_cap_test.go
+++ b/coordinator/api/consumer_toolcall_cap_test.go
@@ -1,0 +1,124 @@
+package api
+
+import (
+	"fmt"
+	"math"
+	"testing"
+)
+
+// T11/T10 (PR #548 review): chunks come from providers, which are only
+// semi-trusted — a buggy or malicious provider can stream an unbounded
+// number of distinct-id tool-call deltas into the non-streaming
+// reconstruction. extractMessage caps LOGICAL tool calls at
+// maxLogicalToolCalls: past the cap, deltas that would start a new logical
+// call are dropped (counted + logged), while argument fragments for
+// already-kept calls keep accumulating — kept calls are never truncated or
+// corrupted, and huge/sparse wire indices cannot grow the tracking map past
+// the cap either.
+
+// capCallID builds the distinct id for the i-th flood call.
+func capCallID(i int) string { return fmt.Sprintf("c%d", i) }
+
+// A malicious all-index-0 stream of cap+1 distinct-id calls keeps exactly
+// the first maxLogicalToolCalls calls, in arrival order, and drops the rest.
+func TestExtractMessageCapsLogicalToolCalls(t *testing.T) {
+	var chunks []string
+	for i := 1; i <= maxLogicalToolCalls+1; i++ {
+		chunks = append(chunks, tcDelta(0, capCallID(i), "fn", fmt.Sprintf(`{"n":%d}`, i)))
+	}
+
+	msg := extractMessage(chunks)
+	if len(msg.ToolCalls) != maxLogicalToolCalls {
+		t.Fatalf("tool_calls length = %d, want cap %d", len(msg.ToolCalls), maxLogicalToolCalls)
+	}
+	for i, tc := range msg.ToolCalls {
+		if wantID := capCallID(i + 1); tc["id"] != wantID {
+			t.Fatalf("call %d id = %v, want %s (arrival order must be stable under the cap)", i, tc["id"], wantID)
+		}
+	}
+	last := msg.ToolCalls[maxLogicalToolCalls-1]
+	fn := last["function"].(map[string]any)
+	if want := fmt.Sprintf(`{"n":%d}`, maxLogicalToolCalls); fn["arguments"] != want {
+		t.Errorf("last kept call arguments = %q, want %q (dropped call must not contaminate it)", fn["arguments"], want)
+	}
+}
+
+// Past the cap, kept calls still accumulate their own argument fragments,
+// and fragments belonging to a dropped call are swallowed — never merged
+// onto a kept call at the same wire index.
+func TestExtractMessageAtCapKeepsAccumulatingKeptCalls(t *testing.T) {
+	chunks := []string{
+		// A long-running kept call on its own wire index.
+		tcDelta(5, "keeper", "keep_fn", `{"k":`),
+	}
+	// Fill the remaining cap slots with distinct-id calls at index 0.
+	for i := 1; i <= maxLogicalToolCalls-1; i++ {
+		chunks = append(chunks, tcDelta(0, capCallID(i), "fn", fmt.Sprintf(`{"n":%d}`, i)))
+	}
+	chunks = append(chunks,
+		// Cap is full: this new logical call must be dropped...
+		tcDelta(0, "overflow", "fn", `{"evil":true}`),
+		// ...and its id-less fragments swallowed, not merged onto the
+		// last kept index-0 call.
+		tcDelta(0, "", "", `LEAK`),
+		// The kept call keeps accumulating fragments as usual.
+		tcDelta(5, "", "", `1}`),
+	)
+
+	msg := extractMessage(chunks)
+	if len(msg.ToolCalls) != maxLogicalToolCalls {
+		t.Fatalf("tool_calls length = %d, want cap %d", len(msg.ToolCalls), maxLogicalToolCalls)
+	}
+	// Output is index-ordered: the index-0 group first, keeper (index 5) last.
+	keeper := msg.ToolCalls[maxLogicalToolCalls-1]
+	if keeper["id"] != "keeper" {
+		t.Fatalf("last call id = %v, want keeper (index 5 sorts after index 0)", keeper["id"])
+	}
+	keeperFn := keeper["function"].(map[string]any)
+	if keeperFn["arguments"] != `{"k":1}` {
+		t.Errorf("keeper arguments = %q, want %q (kept calls must keep accumulating past the cap)", keeperFn["arguments"], `{"k":1}`)
+	}
+	lastKept := msg.ToolCalls[maxLogicalToolCalls-2]
+	if wantID := capCallID(maxLogicalToolCalls - 1); lastKept["id"] != wantID {
+		t.Fatalf("last index-0 call id = %v, want %s", lastKept["id"], wantID)
+	}
+	lastKeptFn := lastKept["function"].(map[string]any)
+	if want := fmt.Sprintf(`{"n":%d}`, maxLogicalToolCalls-1); lastKeptFn["arguments"] != want {
+		t.Errorf("last kept index-0 arguments = %q, want %q (dropped call's fragments must be swallowed, not merged)", lastKeptFn["arguments"], want)
+	}
+	for _, tc := range msg.ToolCalls {
+		if tc["id"] == "overflow" {
+			t.Errorf("dropped call id overflow must not appear in output: %v", tc)
+		}
+	}
+}
+
+// Huge and sparse wire indices are fine for Go maps (no preallocation by
+// key value), but each distinct index could otherwise add a tracking entry
+// forever; the logical-call cap bounds that too.
+func TestExtractMessageCapBoundsSparseHugeIndices(t *testing.T) {
+	var chunks []string
+	for i := 1; i <= maxLogicalToolCalls+10; i++ {
+		// Distinct sparse indices, including very large ones.
+		chunks = append(chunks, tcDelta(i*1000003, capCallID(i), "fn", `{}`))
+	}
+	msg := extractMessage(chunks)
+	if len(msg.ToolCalls) != maxLogicalToolCalls {
+		t.Fatalf("tool_calls length = %d, want cap %d", len(msg.ToolCalls), maxLogicalToolCalls)
+	}
+}
+
+// T5 (PR #548 review): the sort comparator must never panic on a corrupt
+// "index" value. Entries are always built with an int index, so this is
+// unreachable from extractMessage input — the helper is pinned directly.
+func TestToolCallWireIndexCorruptValue(t *testing.T) {
+	if got := toolCallWireIndex(map[string]any{"index": 3}); got != 3 {
+		t.Errorf("int index = %d, want 3", got)
+	}
+	if got := toolCallWireIndex(map[string]any{"index": "corrupt"}); got != math.MaxInt {
+		t.Errorf("corrupt index = %d, want math.MaxInt (sorts last, no panic)", got)
+	}
+	if got := toolCallWireIndex(map[string]any{}); got != math.MaxInt {
+		t.Errorf("missing index = %d, want math.MaxInt (sorts last, no panic)", got)
+	}
+}

--- a/coordinator/api/consumer_toolcall_cap_test.go
+++ b/coordinator/api/consumer_toolcall_cap_test.go
@@ -122,3 +122,50 @@ func TestToolCallWireIndexCorruptValue(t *testing.T) {
 		t.Errorf("missing index = %d, want math.MaxInt (sorts last, no panic)", got)
 	}
 }
+
+// A hand-built entry with a corrupt "index" (unreachable through
+// extractMessage, which always stores int) must not panic finalize; it
+// sorts last, after all valid indices.
+func TestToolCallFinalizeCorruptIndexNoPanic(t *testing.T) {
+	acc := newToolCallAccumulator()
+	acc.calls = []map[string]any{
+		{"index": "corrupt", "id": "bad", "function": map[string]any{"arguments": ""}},
+		{"index": 1, "id": "good_b", "function": map[string]any{"arguments": ""}},
+		{"index": 0, "id": "good_a", "function": map[string]any{"arguments": ""}},
+	}
+	out := acc.finalize()
+	if len(out) != 3 {
+		t.Fatalf("finalize length = %d, want 3", len(out))
+	}
+	if out[0]["id"] != "good_a" || out[1]["id"] != "good_b" || out[2]["id"] != "bad" {
+		t.Fatalf("want valid entries index-ordered with corrupt entry last, got %v / %v / %v", out[0]["id"], out[1]["id"], out[2]["id"])
+	}
+}
+
+// A hand-built entry whose "function" or "arguments" value was corrupted
+// (also unreachable through extractMessage) must not panic apply; the
+// corrupt value is replaced and accumulation continues.
+func TestToolCallApplyCorruptFunctionNoPanic(t *testing.T) {
+	acc := newToolCallAccumulator()
+	acc.calls = []map[string]any{
+		{"index": 0, "id": "call_a", "function": "corrupt"},
+		{"index": 1, "id": "call_b", "function": map[string]any{"arguments": 42}},
+	}
+	acc.activeByIndex = map[int]int{0: 0, 1: 1}
+
+	var frag streamedToolCallDelta
+	frag.Index = 0
+	frag.Function.Arguments = `{"x":1}`
+	acc.apply(frag)
+	frag.Index = 1
+	acc.apply(frag)
+
+	fn0 := acc.calls[0]["function"].(map[string]any)
+	if fn0["arguments"] != `{"x":1}` {
+		t.Errorf("corrupt function map: arguments = %q, want %q", fn0["arguments"], `{"x":1}`)
+	}
+	fn1 := acc.calls[1]["function"].(map[string]any)
+	if fn1["arguments"] != `{"x":1}` {
+		t.Errorf("corrupt arguments value: arguments = %q, want %q", fn1["arguments"], `{"x":1}`)
+	}
+}

--- a/coordinator/api/consumer_toolcall_reconstruction_test.go
+++ b/coordinator/api/consumer_toolcall_reconstruction_test.go
@@ -1,0 +1,162 @@
+package api
+
+import "testing"
+
+// E6 (2026-07-15 platform errors deep dive): the engine emits EVERY streamed
+// parallel tool call with `index: 0`, and extractMessage keyed reconstruction
+// by index — so a second call overwrote the first's id/name and concatenated
+// both argument streams into one corrupted call. Defensively, a delta whose
+// non-empty id DIFFERS from the current entry's non-empty id starts a NEW
+// logical call (arrival order preserved); well-behaved indexed streams keep
+// index-keyed accumulation. (The engine-side proper fix — unique indices in
+// MLXOpenAIService — lives in the submodule and ships separately.)
+
+func tcDelta(index int, id, name, args string) string {
+	chunk := `data: {"choices":[{"delta":{"tool_calls":[{"index":` + itoa(index)
+	if id != "" {
+		chunk += `,"id":"` + id + `"`
+	}
+	chunk += `,"function":{`
+	sep := ""
+	if name != "" {
+		chunk += `"name":"` + name + `"`
+		sep = ","
+	}
+	chunk += sep + `"arguments":` + quoteJSON(args) + `}}]}}]}`
+	return chunk
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	digits := ""
+	for n > 0 {
+		digits = string(rune('0'+n%10)) + digits
+		n /= 10
+	}
+	return digits
+}
+
+func quoteJSON(s string) string {
+	out := `"`
+	for _, r := range s {
+		switch r {
+		case '"':
+			out += `\"`
+		case '\\':
+			out += `\\`
+		default:
+			out += string(r)
+		}
+	}
+	return out + `"`
+}
+
+// Two parallel calls both streamed at index 0 with distinct ids: the second
+// id must START A NEW logical call — two calls out, each with its own
+// id/name/arguments — instead of one merged call with concatenated args.
+func TestExtractMessageTwoIndexZeroCallsWithDistinctIDs(t *testing.T) {
+	chunks := []string{
+		tcDelta(0, "call_a", "get_weather", ""),
+		tcDelta(0, "", "", `{"city":`),
+		tcDelta(0, "", "", `"SF"}`),
+		tcDelta(0, "call_b", "get_time", ""),
+		tcDelta(0, "", "", `{"tz":"PST"}`),
+	}
+
+	msg := extractMessage(chunks)
+	if len(msg.ToolCalls) != 2 {
+		t.Fatalf("tool_calls length = %d, want 2 (second index-0 id must not merge into the first call): %v", len(msg.ToolCalls), msg.ToolCalls)
+	}
+	first, second := msg.ToolCalls[0], msg.ToolCalls[1]
+	if first["id"] != "call_a" || second["id"] != "call_b" {
+		t.Fatalf("ids = %v, %v; want call_a then call_b (arrival order)", first["id"], second["id"])
+	}
+	fn1 := first["function"].(map[string]any)
+	fn2 := second["function"].(map[string]any)
+	if fn1["name"] != "get_weather" || fn2["name"] != "get_time" {
+		t.Errorf("names = %v, %v; want get_weather / get_time", fn1["name"], fn2["name"])
+	}
+	if fn1["arguments"] != `{"city":"SF"}` {
+		t.Errorf("first arguments = %q, want %q", fn1["arguments"], `{"city":"SF"}`)
+	}
+	if fn2["arguments"] != `{"tz":"PST"}` {
+		t.Errorf("second arguments = %q, want %q (must not contain the first call's fragments)", fn2["arguments"], `{"tz":"PST"}`)
+	}
+}
+
+// The id being RE-SENT on later deltas of the same call (some engines repeat
+// it on every frame) is a continuation, never a split.
+func TestExtractMessageRepeatedSameIDDoesNotSplit(t *testing.T) {
+	chunks := []string{
+		tcDelta(0, "call_a", "run", ""),
+		tcDelta(0, "call_a", "", `{"a":`),
+		tcDelta(0, "call_a", "", `1}`),
+	}
+	msg := extractMessage(chunks)
+	if len(msg.ToolCalls) != 1 {
+		t.Fatalf("tool_calls length = %d, want 1", len(msg.ToolCalls))
+	}
+	fn := msg.ToolCalls[0]["function"].(map[string]any)
+	if fn["arguments"] != `{"a":1}` {
+		t.Errorf("arguments = %q, want %q", fn["arguments"], `{"a":1}`)
+	}
+}
+
+// Well-behaved indexed streams (unique index per call, interleaved deltas)
+// keep index-keyed accumulation and index-ordered output.
+func TestExtractMessageWellBehavedIndexedStreamUnchanged(t *testing.T) {
+	chunks := []string{
+		tcDelta(1, "call_b", "second", ""),
+		tcDelta(0, "call_a", "first", ""),
+		tcDelta(0, "", "", `{"x":1}`),
+		tcDelta(1, "", "", `{"y":2}`),
+	}
+	msg := extractMessage(chunks)
+	if len(msg.ToolCalls) != 2 {
+		t.Fatalf("tool_calls length = %d, want 2", len(msg.ToolCalls))
+	}
+	if msg.ToolCalls[0]["id"] != "call_a" || msg.ToolCalls[1]["id"] != "call_b" {
+		t.Fatalf("output must be index-ordered: got %v, %v", msg.ToolCalls[0]["id"], msg.ToolCalls[1]["id"])
+	}
+	fn1 := msg.ToolCalls[0]["function"].(map[string]any)
+	fn2 := msg.ToolCalls[1]["function"].(map[string]any)
+	if fn1["arguments"] != `{"x":1}` || fn2["arguments"] != `{"y":2}` {
+		t.Errorf("arguments = %q / %q, want index-keyed accumulation", fn1["arguments"], fn2["arguments"])
+	}
+}
+
+// Sparse wire indices (0 and 2) must both survive — the old dense 0..n-1 map
+// walk silently dropped the call at index 2.
+func TestExtractMessageSparseIndicesNotDropped(t *testing.T) {
+	chunks := []string{
+		tcDelta(0, "call_a", "first", `{}`),
+		tcDelta(2, "call_c", "third", `{}`),
+	}
+	msg := extractMessage(chunks)
+	if len(msg.ToolCalls) != 2 {
+		t.Fatalf("tool_calls length = %d, want 2 (sparse index dropped)", len(msg.ToolCalls))
+	}
+	if msg.ToolCalls[1]["id"] != "call_c" {
+		t.Errorf("second call id = %v, want call_c", msg.ToolCalls[1]["id"])
+	}
+}
+
+// Three calls all at index 0: arrival order is preserved across every split.
+func TestExtractMessageThreeIndexZeroCalls(t *testing.T) {
+	chunks := []string{
+		tcDelta(0, "c1", "f1", `{"n":1}`),
+		tcDelta(0, "c2", "f2", `{"n":2}`),
+		tcDelta(0, "c3", "f3", `{"n":3}`),
+	}
+	msg := extractMessage(chunks)
+	if len(msg.ToolCalls) != 3 {
+		t.Fatalf("tool_calls length = %d, want 3", len(msg.ToolCalls))
+	}
+	for i, wantID := range []string{"c1", "c2", "c3"} {
+		if msg.ToolCalls[i]["id"] != wantID {
+			t.Errorf("call %d id = %v, want %s", i, msg.ToolCalls[i]["id"], wantID)
+		}
+	}
+}

--- a/coordinator/api/dispatch.go
+++ b/coordinator/api/dispatch.go
@@ -1170,8 +1170,7 @@ func (d *dispatchState) shouldStopFailover() bool {
 	// template renders the same request body identically on every provider,
 	// so the ladder stops on the first occurrence and surfaces one 422
 	// model_capability rejection. Kill switch: EIGENINFERENCE_JINJA_TERMINAL_REJECT.
-	if jinjaTerminalRejectEnabled() && isJinjaTemplateErrorReason(d.lastErrReason) {
-		d.latchJinjaTerminalReject(d.lastErrReason, "")
+	if d.latchJinjaTerminalReject(d.lastErrReason, "") {
 		return true
 	}
 	switch classifyRejection(d.lastErrReason, d.lastErr, d.lastErrProviderBudget, d.modelMaxContext) {
@@ -1195,12 +1194,19 @@ func (d *dispatchState) shouldStopFailover() bool {
 }
 
 // latchJinjaTerminalReject latches the terminal 422 for a deterministic
-// template-render failure (see envJinjaTerminalReject). The latched code is
-// OUR classification (422 Unprocessable Entity — the request is well-formed
-// but unrenderable by this model), not the provider's raw 500. src tags the
-// metric emission site ("" = the shouldStopFailover survivor path,
-// "race_loser" = latchDeterministicLoser).
-func (d *dispatchState) latchJinjaTerminalReject(reason, src string) {
+// template-render failure and reports whether it latched — a no-op returning
+// false when the kill switch (envJinjaTerminalReject) is off or reason is not
+// jinja_*. It is the SINGLE jinja-stop point shared by shouldStopFailover
+// (survivor path) and latchDeterministicLoser (race-loser mirror), so the
+// enable+reason guard and the latched fields cannot drift between the two
+// sites. The latched code is OUR classification (422 Unprocessable Entity —
+// the request is well-formed but unrenderable by this model), not the
+// provider's raw 500. src tags the metric emission site ("" = the
+// shouldStopFailover survivor path, "race_loser" = latchDeterministicLoser).
+func (d *dispatchState) latchJinjaTerminalReject(reason, src string) (latched bool) {
+	if !jinjaTerminalRejectEnabled() || !isJinjaTemplateErrorReason(reason) {
+		return false
+	}
 	tags := []string{"model:" + d.model, "code:422", "reason:" + normalizeInferenceErrorReason(reason)}
 	if src != "" {
 		tags = append(tags, "src:"+src)
@@ -1210,6 +1216,7 @@ func (d *dispatchState) latchJinjaTerminalReject(reason, src string) {
 	d.terminalClientErrorCode = http.StatusUnprocessableEntity
 	d.terminalClientErrorReason = rejectionReasonTemplateRenderFailed
 	d.terminalClientErrorMessage = jinjaTerminalRejectMessage
+	return true
 }
 
 // latchDeterministicLoser preserves a DETERMINISTIC-unservable rejection observed
@@ -1239,8 +1246,7 @@ func (d *dispatchState) latchDeterministicLoser(provider *registry.Provider, msg
 	// Mirror the jinja_* reason stop (E4) at the race-loser site for the same
 	// masking reason: a deterministic template-render failure from the loser
 	// must not be storm-resumed through the survivor's transient error.
-	if jinjaTerminalRejectEnabled() && isJinjaTemplateErrorReason(msg.ErrorReason) {
-		d.latchJinjaTerminalReject(msg.ErrorReason, "race_loser")
+	if d.latchJinjaTerminalReject(msg.ErrorReason, "race_loser") {
 		return
 	}
 	budget := providerReportedBudget(provider, d.model)

--- a/coordinator/api/dispatch.go
+++ b/coordinator/api/dispatch.go
@@ -2425,6 +2425,23 @@ exhausted:
 			// HTTP 200 was already sent by a prefill keepalive; the status code is
 			// frozen, so surface the terminal failure in-band. Responses streams use
 			// a different error shape (event: error, no [DONE]) than chat completions.
+			//
+			// A latched terminal client error with a curated message (today: only
+			// the jinja_* template-render stop, which latches
+			// terminalClientErrorMessage) surfaces the same invalid_request_error /
+			// model_capability body the status-coded writer below returns — NOT a
+			// provider_error wrapping d.lastErr, which would leak the provider's
+			// raw template backtrace mid-stream. Non-jinja terminals (plain 4xx
+			// latches leave the message empty) keep the exact legacy in-band
+			// shapes below.
+			if d.terminalClientError && d.terminalClientErrorMessage != "" {
+				if d.isResponsesAPI {
+					writeResponsesSSEErrorEvent(w, "invalid_request_error", d.terminalClientErrorMessage)
+				} else {
+					writeSSEErrorEvent(w, errorResponse("invalid_request_error", d.terminalClientErrorMessage, withCode("model_capability")))
+				}
+				return
+			}
 			rateLimited := statusCode == http.StatusTooManyRequests
 			capMsg := fmt.Sprintf("all providers at capacity after %d attempt(s): %s", d.attempt+1, d.lastErr)
 			errMsg := fmt.Sprintf("inference failed after %d attempt(s): %s", d.attempt+1, d.lastErr)

--- a/coordinator/api/dispatch.go
+++ b/coordinator/api/dispatch.go
@@ -159,6 +159,15 @@ type dispatchState struct {
 	// code is ground truth; the human-readable provider string drifts across versions.
 	terminalClientError     bool
 	terminalClientErrorCode int
+	// terminalClientErrorReason, when non-empty, overrides the exhausted
+	// ladder's rejection-ledger reason_code for a latched terminal client
+	// error ("template_render_failed" for the jinja_* stop — distinguishable
+	// from the StatusCode-driven stop's generic "client_error").
+	terminalClientErrorReason string
+	// terminalClientErrorMessage, when non-empty, overrides the surfaced
+	// error-body message (the jinja_* stop surfaces the curated
+	// model_capability text, not the provider's raw template backtrace).
+	terminalClientErrorMessage string
 
 	// ---- per-attempt scratch (reset each attempt) ----
 	attempt          int
@@ -196,6 +205,32 @@ const envTTFTTerminalReject = "EIGENINFERENCE_TTFT_TERMINAL_REJECT"
 func ttftTerminalRejectEnabled() bool {
 	return envEnabledDefaultTrue(envTTFTTerminalReject)
 }
+
+// envJinjaTerminalReject is the kill switch for the deterministic
+// template-render rejection stop (E4, 2026-07-15 platform errors deep dive).
+// A provider error_reason of jinja_channel_tags / jinja_null_bridge /
+// jinja_template means the model's chat template could not render the
+// request's tool schemas or message history — the same body renders the same
+// way on every provider, so failing over is pure waste (prod: 1.57 dispatch
+// rows per jinja request, observed up to 17 attempts, 0% eventual success).
+// Default true: the ladder stops on the FIRST jinja_* rejection at any
+// attempt and surfaces one 422 model_capability invalid_request_error. Set
+// =false to restore the legacy fail-over-on-500 behavior. Read live (not a
+// Server field) following the envTTFTTerminalReject pattern, so it stays
+// confined to this file and is overridable in tests via t.Setenv.
+const envJinjaTerminalReject = "EIGENINFERENCE_JINJA_TERMINAL_REJECT"
+
+// jinjaTerminalRejectEnabled reports whether a jinja_* provider rejection
+// terminates the dispatch ladder. Default true.
+func jinjaTerminalRejectEnabled() bool {
+	return envEnabledDefaultTrue(envJinjaTerminalReject)
+}
+
+// jinjaTerminalRejectMessage is the OpenAI-style error body surfaced for a
+// latched template-render failure — a curated model_capability message
+// instead of the provider's raw Jinja backtrace (which names filters and
+// template internals no API consumer can act on).
+const jinjaTerminalRejectMessage = "the request's tool schemas or message history cannot be rendered by this model's chat template; simplify the tool parameter schemas or message structure, or use a different model"
 
 // queueMaxTTFTMs returns the TTFT ceiling for queued requests. Public routes
 // inherit the prompt-scaled admission threshold; self-route / prefer-owner paths
@@ -463,6 +498,13 @@ func (d *dispatchState) errorRoutingOutcome(status, class string, code int) *sto
 func routeOutcomeUsesProviderErrorText(class string) bool {
 	class = strings.ToLower(strings.TrimSpace(class))
 	return class == errorReasonProviderError ||
+		// client_error rows keep the provider-supplied reason too: a jinja_*
+		// template-render failure is recorded as class client_error (not a
+		// provider fault) but its reason must stay jinja_* on the row, so the
+		// inference.error{reason:jinja_*} series measures real render failures
+		// instead of being silenced by the reclassification. The reason is
+		// still whitelisted downstream (normalizeInferenceErrorReason).
+		class == errorClassClientError ||
 		strings.HasPrefix(class, "provider_error") ||
 		strings.HasPrefix(class, "provider_disconnect") ||
 		strings.Contains(class, "provider_incomplete")
@@ -509,10 +551,14 @@ func providerReportedBudget(provider *registry.Provider, model string) int64 {
 // pre-dispatch failures (queue reservation DB error, invalid key, keygen, send
 // failure) and coordinator-side timeouts are NOT flagged.
 func (d *dispatchState) providerFailedRoutingOutcome() *store.InferenceRouteOutcome {
-	if isTerminalClientErrorCode(d.lastErrCode) {
-		// Deterministic client-shape 4xx: a malformed/unservable-by-shape request,
-		// not a provider fault. Record as client_error WITHOUT AdmittedButFailed so
-		// it stays out of the admission-mismatch gauge.
+	if isTerminalClientErrorCode(d.lastErrCode) || isJinjaTemplateErrorReason(d.lastErrReason) {
+		// Deterministic client-shape rejection: a 4xx status the provider maps
+		// for malformed bodies, OR a jinja_* template-render reason (a provider
+		// 500 by status, but a request-shape fault — the template renders the
+		// same body identically fleet-wide). Record as client_error WITHOUT
+		// AdmittedButFailed so it stays out of the admission-mismatch gauge;
+		// the jinja_* reason itself survives on the row (see
+		// routeOutcomeUsesProviderErrorText).
 		return d.errorRoutingOutcome("error", errorClassClientError, d.lastErrCode)
 	}
 	class := "provider_error"
@@ -1037,6 +1083,13 @@ func (d *dispatchState) noteDispatchRetry(provider *registry.Provider, pr *regis
 // "prompt_too_long" and the legacy dispatch-exhausted "unservable_token_budget".
 const rejectionReasonOversized = "oversized_request"
 
+// rejectionReasonTemplateRenderFailed is the rejection-ledger reason_code for
+// a request the dispatch loop stopped because the model's chat template
+// cannot render it (provider error_reason jinja_channel_tags /
+// jinja_null_bridge / jinja_template — see envJinjaTerminalReject).
+// Distinguishable from the StatusCode-driven stop's generic "client_error".
+const rejectionReasonTemplateRenderFailed = "template_render_failed"
+
 // shouldStopFailover is the single choke point that decides, after a dispatched
 // attempt failed with outcomeRetry, whether the dispatch loop should STOP failing
 // over because the request is unservable — rather than walk all 64 providers and
@@ -1080,6 +1133,16 @@ func (d *dispatchState) shouldStopFailover() bool {
 		d.terminalClientErrorCode = d.lastErrCode
 		return true
 	}
+	// Reason-driven stop (E4): a jinja_* error_reason is a DETERMINISTIC
+	// template-render failure. It arrives as a provider 500 — which the
+	// code-driven stop above deliberately ignores — but the model's chat
+	// template renders the same request body identically on every provider,
+	// so the ladder stops on the first occurrence and surfaces one 422
+	// model_capability rejection. Kill switch: EIGENINFERENCE_JINJA_TERMINAL_REJECT.
+	if jinjaTerminalRejectEnabled() && isJinjaTemplateErrorReason(d.lastErrReason) {
+		d.latchJinjaTerminalReject(d.lastErrReason, "")
+		return true
+	}
 	switch classifyRejection(d.lastErrReason, d.lastErr, d.lastErrProviderBudget, d.modelMaxContext) {
 	case rejectionDeterministicUnservable:
 		d.s.ddIncr("routing.dispatch_to_capacity_503", []string{"model:" + d.model, "reason:deterministic"})
@@ -1098,6 +1161,24 @@ func (d *dispatchState) shouldStopFailover() bool {
 	default:
 		return false
 	}
+}
+
+// latchJinjaTerminalReject latches the terminal 422 for a deterministic
+// template-render failure (see envJinjaTerminalReject). The latched code is
+// OUR classification (422 Unprocessable Entity — the request is well-formed
+// but unrenderable by this model), not the provider's raw 500. src tags the
+// metric emission site ("" = the shouldStopFailover survivor path,
+// "race_loser" = latchDeterministicLoser).
+func (d *dispatchState) latchJinjaTerminalReject(reason, src string) {
+	tags := []string{"model:" + d.model, "code:422", "reason:" + normalizeInferenceErrorReason(reason)}
+	if src != "" {
+		tags = append(tags, "src:"+src)
+	}
+	d.s.ddIncr("routing.dispatch_client_error_stop", tags)
+	d.terminalClientError = true
+	d.terminalClientErrorCode = http.StatusUnprocessableEntity
+	d.terminalClientErrorReason = rejectionReasonTemplateRenderFailed
+	d.terminalClientErrorMessage = jinjaTerminalRejectMessage
 }
 
 // latchDeterministicLoser preserves a DETERMINISTIC-unservable rejection observed
@@ -1122,6 +1203,13 @@ func (d *dispatchState) latchDeterministicLoser(provider *registry.Provider, msg
 		d.s.ddIncr("routing.dispatch_client_error_stop", []string{"model:" + d.model, "code:" + strconv.Itoa(msg.StatusCode), "src:race_loser"})
 		d.terminalClientError = true
 		d.terminalClientErrorCode = msg.StatusCode
+		return
+	}
+	// Mirror the jinja_* reason stop (E4) at the race-loser site for the same
+	// masking reason: a deterministic template-render failure from the loser
+	// must not be storm-resumed through the survivor's transient error.
+	if jinjaTerminalRejectEnabled() && isJinjaTemplateErrorReason(msg.ErrorReason) {
+		d.latchJinjaTerminalReject(msg.ErrorReason, "race_loser")
 		return
 	}
 	budget := providerReportedBudget(provider, d.model)
@@ -2228,6 +2316,12 @@ exhausted:
 			// never be reclassified to 429/503 — this is a client fault, not capacity.
 			statusCode = d.terminalClientErrorCode
 			reason = "client_error"
+			if d.terminalClientErrorReason != "" {
+				// The jinja_* stop records its own ledger reason
+				// (template_render_failed) so template-render rejections stay
+				// distinguishable from generic client-shape 4xxs.
+				reason = d.terminalClientErrorReason
+			}
 			s.ddIncr("routing.client_error_passthrough", []string{"model:" + d.model, "code:" + strconv.Itoa(statusCode)})
 		} else if d.unservable {
 			// The loop stopped early because no provider can serve this request
@@ -2323,8 +2417,14 @@ exhausted:
 		} else if d.terminalClientError {
 			// Surface the provider's client-shape error verbatim as an
 			// invalid_request_error, with no misleading "after N attempt(s)" framing
-			// (it was returned once, deterministically).
-			writeJSON(w, statusCode, errorResponse("invalid_request_error", d.lastErr))
+			// (it was returned once, deterministically). A jinja_* latch surfaces
+			// the curated model_capability message instead of the provider's raw
+			// template backtrace.
+			if d.terminalClientErrorMessage != "" {
+				writeJSON(w, statusCode, errorResponse("invalid_request_error", d.terminalClientErrorMessage, withCode("model_capability")))
+			} else {
+				writeJSON(w, statusCode, errorResponse("invalid_request_error", d.lastErr))
+			}
 		} else {
 			writeJSON(w, statusCode, errorResponse("provider_error",
 				fmt.Sprintf("inference failed after %d attempt(s): %s", d.attempt+1, d.lastErr)))

--- a/coordinator/api/dispatch.go
+++ b/coordinator/api/dispatch.go
@@ -1069,11 +1069,42 @@ func (d *dispatchState) dispatchPrimary() dispatchOutcome {
 // noteDispatchRetry feeds the inference-error breaker + refund for a pre-commit
 // provider error and, unless held boilerplate was discarded (which emits its own
 // pre-content failover counter), emits the generic retry counter. This is the
-// exact `if !s.noteDispatchProviderError(...) { s.ddIncr(retry) }` pattern.
+// exact `if !d.noteProviderError(...) { s.ddIncr(retry) }` pattern.
 func (d *dispatchState) noteDispatchRetry(provider *registry.Provider, pr *registry.PendingRequest, statusCode int, errStr, errReason string, held *[]string) {
-	if !d.s.noteDispatchProviderError(provider, pr, statusCode, errStr, errReason, held) {
+	if !d.noteProviderError(provider, pr, statusCode, errStr, errReason, held) {
 		d.s.ddIncr("inference.dispatches", []string{"status:retry"})
 	}
+}
+
+// noteProviderError is the dispatch loop's single funnel into
+// noteDispatchProviderError. When the structured error_reason proves a
+// NON-provider fault (isNonProviderFaultErrorReason: jinja_* template-render
+// failures, tool_noncompliance), the provider is withheld from the call so
+// none of the provider-fault trackers fed by noteInferenceError — the
+// shape-keyed inference-error breaker, the per-provider node-health breaker,
+// the stable-identity ejection breaker, and the capacity-reject cooldown —
+// records the terminal. A jinja_* failure arrives as a raw provider 500,
+// exactly the sickness shape all three breakers count, so without this gate
+// a few malformed tool histories could quarantine healthy providers/pairs
+// before the E4 relabel ever runs (the relabel happens later, in
+// shouldStopFailover / the route-outcome writers); tool_noncompliance 422s
+// are code-neutral in every breaker today, but gating them here keeps the
+// reason vocabulary in lockstep with the reputation exemption in
+// handleInferenceError.
+//
+// The skip keys on the structured REASON only — never on the status code —
+// so capacity rejections (token_budget_exhausted / queue_full / cold "not
+// loaded" misses, with or without a structured reason) flow through
+// unchanged and the capacity-reject cooldown still sees every legitimate
+// 503/404. The attempt's reservation-top-up refund and held-chunk discard
+// (with its retry_precontent counter) run for EVERY reason:
+// noteDispatchProviderError only feeds noteInferenceError for a non-nil
+// provider, while the refund + held handling are unconditional.
+func (d *dispatchState) noteProviderError(provider *registry.Provider, pr *registry.PendingRequest, statusCode int, errStr, errReason string, held *[]string) (discardedHeld bool) {
+	if isNonProviderFaultErrorReason(errReason) {
+		provider = nil
+	}
+	return d.s.noteDispatchProviderError(provider, pr, statusCode, errStr, errReason, held)
 }
 
 // rejectionReasonOversized is the rejection-ledger reason_code for a request the
@@ -1647,7 +1678,7 @@ func (d *dispatchState) runRace(backupProvider *registry.Provider, backupPR *reg
 					d.excludeProviders[backupProvider.ID] = struct{}{}
 					d.lastFailedVersion = failedProviderVersion(backupProvider)
 					d.updateSpeculativeFailure(backupPR, errMsg)
-					s.noteDispatchProviderError(backupProvider, backupPR, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason, &backupHeld)
+					d.noteProviderError(backupProvider, backupPR, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason, &backupHeld)
 					// Preserve a deterministic-unservable verdict from this loser so the
 					// surviving primary's error can't mask it (see latchDeterministicLoser).
 					d.latchDeterministicLoser(backupProvider, errMsg)
@@ -1695,7 +1726,7 @@ func (d *dispatchState) runRace(backupProvider *registry.Provider, backupPR *reg
 			s.cancelDispatch(provider, pr)
 			d.lastFailedVersion = failedProviderVersion(provider)
 			d.updateSpeculativeFailure(pr, errMsg)
-			s.noteDispatchProviderError(provider, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason, &d.heldChunks)
+			d.noteProviderError(provider, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason, &d.heldChunks)
 			// Preserve a deterministic-unservable verdict from this loser so the
 			// surviving backup's error can't mask it (see latchDeterministicLoser).
 			d.latchDeterministicLoser(provider, errMsg)
@@ -1711,7 +1742,7 @@ func (d *dispatchState) runRace(backupProvider *registry.Provider, backupPR *reg
 			s.cancelDispatch(backupProvider, backupPR)
 			d.lastFailedVersion = failedProviderVersion(backupProvider)
 			d.updateSpeculativeFailure(backupPR, errMsg)
-			s.noteDispatchProviderError(backupProvider, backupPR, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason, &backupHeld)
+			d.noteProviderError(backupProvider, backupPR, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason, &backupHeld)
 			// Preserve a deterministic-unservable verdict from this loser so the
 			// surviving primary's error can't mask it (see latchDeterministicLoser).
 			d.latchDeterministicLoser(backupProvider, errMsg)
@@ -1921,7 +1952,7 @@ func (d *dispatchState) racePrimaryFailedWaitBackup(backupProvider *registry.Pro
 			d.setLastInferenceError(backupProvider, errMsg2)
 			d.lastFailedVersion = failedProviderVersion(backupProvider)
 			d.updateSpeculativeFailure(backupPR, errMsg2)
-			s.noteDispatchProviderError(backupProvider, backupPR, errMsg2.StatusCode, errMsg2.Error, errMsg2.ErrorReason, &backupHeld)
+			d.noteProviderError(backupProvider, backupPR, errMsg2.StatusCode, errMsg2.Error, errMsg2.ErrorReason, &backupHeld)
 			d.provider = nil
 			d.pr = nil
 			return outcomeRetry
@@ -2006,7 +2037,7 @@ func (d *dispatchState) raceBackupErrWaitPrimary(provider *registry.Provider, pr
 			d.setLastInferenceError(provider, errMsg2)
 			d.lastFailedVersion = failedProviderVersion(provider)
 			d.updateSpeculativeFailure(pr, errMsg2)
-			s.noteDispatchProviderError(provider, pr, errMsg2.StatusCode, errMsg2.Error, errMsg2.ErrorReason, &d.heldChunks)
+			d.noteProviderError(provider, pr, errMsg2.StatusCode, errMsg2.Error, errMsg2.ErrorReason, &d.heldChunks)
 			d.provider = nil
 			d.pr = nil
 			d.requestID = ""

--- a/coordinator/api/dispatch.go
+++ b/coordinator/api/dispatch.go
@@ -551,13 +551,14 @@ func providerReportedBudget(provider *registry.Provider, model string) int64 {
 // pre-dispatch failures (queue reservation DB error, invalid key, keygen, send
 // failure) and coordinator-side timeouts are NOT flagged.
 func (d *dispatchState) providerFailedRoutingOutcome() *store.InferenceRouteOutcome {
-	if isTerminalClientErrorCode(d.lastErrCode) || isJinjaTemplateErrorReason(d.lastErrReason) {
-		// Deterministic client-shape rejection: a 4xx status the provider maps
-		// for malformed bodies, OR a jinja_* template-render reason (a provider
-		// 500 by status, but a request-shape fault — the template renders the
-		// same body identically fleet-wide). Record as client_error WITHOUT
-		// AdmittedButFailed so it stays out of the admission-mismatch gauge;
-		// the jinja_* reason itself survives on the row (see
+	if isTerminalClientErrorCode(d.lastErrCode) || isNonProviderFaultErrorReason(d.lastErrReason) {
+		// Deterministic non-provider fault: a 4xx status the provider maps for
+		// malformed bodies, OR a structured non-provider-fault reason (jinja_*
+		// template-render failures, tool_noncompliance model-output 422s).
+		// Record as client_error WITHOUT AdmittedButFailed so neither pollutes
+		// the admission-mismatch gauge — keyed on the SAME vocabulary as the
+		// reputation and breaker exemptions (isNonProviderFaultErrorReason).
+		// The structured reason survives on the row (see
 		// routeOutcomeUsesProviderErrorText).
 		return d.errorRoutingOutcome("error", errorClassClientError, d.lastErrCode)
 	}

--- a/coordinator/api/dispatch_jinja_keepalive_test.go
+++ b/coordinator/api/dispatch_jinja_keepalive_test.go
@@ -1,0 +1,235 @@
+package api
+
+// PR #548 review follow-up (Codex P2, dispatch.go ~2424): when the prefill
+// keepalive has already committed HTTP 200 (long prefill / cold load before a
+// template-render failure), the exhausted ladder's keepaliveCommitted branch
+// returned BEFORE the terminalClientErrorMessage handling — so a latched
+// jinja_* terminal streamed out as a provider_error SSE event carrying the
+// provider's RAW template backtrace instead of the curated
+// invalid_request_error / model_capability body the status-coded path
+// returns. These tests drive the real dispatch ladder over the fake-provider
+// WS harness with keepalives enabled.
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+	"github.com/eigeninference/d-inference/coordinator/registry"
+	"github.com/eigeninference/d-inference/coordinator/store"
+	"nhooyr.io/websocket"
+)
+
+// setupKeepaliveFailoverServer mirrors setupFailoverServer with the prefill
+// SSE keepalive enabled at a test-fast cadence, so a script that stalls a few
+// intervals before erroring deterministically commits HTTP 200 first.
+func setupKeepaliveFailoverServer(t *testing.T, interval time.Duration) (*registry.Registry, *store.MemoryStore, *httptest.Server) {
+	t.Helper()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	st := store.NewMemory(store.Config{AdminKey: "test-key"})
+	reg := registry.New(logger)
+	srv := NewServer(reg, st, ServerConfig{}, logger)
+	srv.challengeInterval = 500 * time.Millisecond
+	srv.SetPrefillKeepaliveInterval(interval)
+	ts := httptest.NewServer(srv.Handler())
+	t.Cleanup(ts.Close)
+	return reg, st, ts
+}
+
+// sendInferenceErrorWithReason mirrors sendInferenceError but carries the
+// structured error_reason a 0.7.11+ provider stamps on the wire (the E4/E5
+// vocabulary the coordinator's terminal classification keys on).
+func (fp *failoverProvider) sendInferenceErrorWithReason(ctx context.Context, req protocol.InferenceRequestMessage, errMsg string, statusCode int, errReason string) {
+	msg := protocol.InferenceErrorMessage{
+		Type:        protocol.TypeInferenceError,
+		RequestID:   req.RequestID,
+		Error:       errMsg,
+		StatusCode:  statusCode,
+		ErrorReason: errReason,
+	}
+	data, _ := json.Marshal(msg)
+	if err := fp.conn.Write(ctx, websocket.MessageText, data); err != nil {
+		fp.t.Logf("provider %s: write inference_error: %v", fp.name, err)
+	}
+}
+
+// postSSE posts a streaming request to path and drains the full response —
+// like postChat, but for an arbitrary endpoint (/v1/responses too).
+func postSSE(ctx context.Context, tsURL, path, apiKey, body string) (int, string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, tsURL+path, strings.NewReader(body))
+	if err != nil {
+		return 0, "", err
+	}
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return 0, "", err
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(resp.Body)
+	return resp.StatusCode, string(respBody), nil
+}
+
+// rawJinjaBacktrace is the provider-side template error text that must NEVER
+// reach the consumer once the terminal classification has latched.
+const rawJinjaBacktrace = "Runtime error: upper filter requires string"
+
+// keepaliveJinjaScript stalls past several keepalive intervals (so the SSE 200
+// deterministically commits) and then rejects with a jinja_* 500.
+func keepaliveJinjaScript(stall time.Duration) inferenceScript {
+	return func(ctx context.Context, fp *failoverProvider, req protocol.InferenceRequestMessage, body []byte) {
+		time.Sleep(stall)
+		fp.sendInferenceErrorWithReason(ctx, req, rawJinjaBacktrace, http.StatusInternalServerError, "jinja_template")
+	}
+}
+
+// A latched jinja terminal AFTER the keepalive committed HTTP 200 must stream
+// the curated invalid_request_error / model_capability body in-band — not a
+// provider_error event wrapping the raw template backtrace. Fails without the
+// keepaliveCommitted curated-error branch in the exhausted ladder.
+func TestJinjaTerminal_AfterKeepaliveCommit_CuratedInBandError(t *testing.T) {
+	reg, _, ts := setupKeepaliveFailoverServer(t, 25*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	const model = "jinja-keepalive-model"
+	startFailoverProvider(t, ctx, ts, reg, failoverProviderConfig{
+		Name: "provider-a", Version: "0.6.20", DecodeTPS: 200,
+		Models: []failoverModelSpec{{ID: model}},
+		Script: keepaliveJinjaScript(300 * time.Millisecond),
+	})
+
+	status, body, err := postSSE(ctx, ts.URL, "/v1/chat/completions", "test-key", buildChatBody(t, model, true, nil))
+	if err != nil {
+		t.Fatalf("chat request: %v", err)
+	}
+	if status != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (keepalive already committed); body = %s", status, body)
+	}
+	if !strings.Contains(body, ": keepalive") {
+		t.Fatalf("no keepalive comment in stream — the test did not exercise the committed path; body = %s", body)
+	}
+	if !strings.Contains(body, jinjaTerminalRejectMessage) {
+		t.Errorf("in-band error is missing the curated model_capability message; body = %s", body)
+	}
+	if !strings.Contains(body, `"invalid_request_error"`) {
+		t.Errorf("in-band error type = want invalid_request_error; body = %s", body)
+	}
+	if !strings.Contains(body, `"model_capability"`) {
+		t.Errorf("in-band error code = want model_capability; body = %s", body)
+	}
+	if strings.Contains(body, rawJinjaBacktrace) {
+		t.Errorf("raw provider template backtrace leaked to the consumer; body = %s", body)
+	}
+	if strings.Contains(body, `"provider_error"`) {
+		t.Errorf("latched jinja terminal surfaced as provider_error; body = %s", body)
+	}
+	if n := strings.Count(body, "data: [DONE]"); n != 1 {
+		t.Errorf("stream has %d [DONE] terminators, want exactly 1; body = %s", n, body)
+	}
+}
+
+// Same latch on a /v1/responses stream: the Responses error shape
+// (event: error, no [DONE]) must carry the curated message with type
+// invalid_request_error instead of provider_error + raw backtrace.
+func TestJinjaTerminal_AfterKeepaliveCommit_ResponsesShape(t *testing.T) {
+	reg, _, ts := setupKeepaliveFailoverServer(t, 25*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	const model = "jinja-keepalive-responses-model"
+	startFailoverProvider(t, ctx, ts, reg, failoverProviderConfig{
+		Name: "provider-a", Version: "0.6.20", DecodeTPS: 200,
+		Models: []failoverModelSpec{{ID: model}},
+		Script: keepaliveJinjaScript(300 * time.Millisecond),
+	})
+
+	reqBody, err := json.Marshal(map[string]any{
+		"model": model, "input": "keepalive responses test prompt",
+		"stream": true, "max_output_tokens": 64,
+	})
+	if err != nil {
+		t.Fatalf("marshal responses body: %v", err)
+	}
+	status, body, err := postSSE(ctx, ts.URL, "/v1/responses", "test-key", string(reqBody))
+	if err != nil {
+		t.Fatalf("responses request: %v", err)
+	}
+	if status != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (keepalive already committed); body = %s", status, body)
+	}
+	if !strings.Contains(body, ": keepalive") {
+		t.Fatalf("no keepalive comment in stream — the test did not exercise the committed path; body = %s", body)
+	}
+	if !strings.Contains(body, "event: error") {
+		t.Errorf("responses stream missing the event: error terminal; body = %s", body)
+	}
+	if !strings.Contains(body, jinjaTerminalRejectMessage) {
+		t.Errorf("in-band error is missing the curated model_capability message; body = %s", body)
+	}
+	if !strings.Contains(body, `"invalid_request_error"`) {
+		t.Errorf("in-band error type = want invalid_request_error; body = %s", body)
+	}
+	if strings.Contains(body, rawJinjaBacktrace) {
+		t.Errorf("raw provider template backtrace leaked to the consumer; body = %s", body)
+	}
+	if strings.Contains(body, `"provider_error"`) {
+		t.Errorf("latched jinja terminal surfaced as provider_error; body = %s", body)
+	}
+	if strings.Contains(body, "data: [DONE]") {
+		t.Errorf("responses error shape must not emit [DONE]; body = %s", body)
+	}
+}
+
+// Control (non-latched behavior preserved): with the jinja kill switch OFF,
+// nothing latches, so the keepalive-committed request keeps the legacy
+// transparent-failover behavior — the second provider serves and no in-band
+// error event reaches the consumer. Guards the new branch's condition (it must
+// fire ONLY when a curated terminal message is latched).
+func TestJinjaKillSwitch_AfterKeepaliveCommit_TransparentFailover(t *testing.T) {
+	t.Setenv(envJinjaTerminalReject, "false")
+	reg, _, ts := setupKeepaliveFailoverServer(t, 25*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	const model = "jinja-keepalive-killswitch-model"
+	rec := &dispatchRecorder{}
+	script := func(ctx context.Context, fp *failoverProvider, req protocol.InferenceRequestMessage, body []byte) {
+		if rec.record(fp.name) == 1 {
+			time.Sleep(300 * time.Millisecond) // let the keepalive commit HTTP 200
+			fp.sendInferenceErrorWithReason(ctx, req, rawJinjaBacktrace, http.StatusInternalServerError, "jinja_template")
+			return
+		}
+		fp.serveFull(ctx, req, model, markerFor(fp.name))
+	}
+	startFailoverProvider(t, ctx, ts, reg, failoverProviderConfig{
+		Name: "provider-a", Version: "0.6.20", DecodeTPS: 200,
+		Models: []failoverModelSpec{{ID: model}}, Script: script,
+	})
+	startFailoverProvider(t, ctx, ts, reg, failoverProviderConfig{
+		Name: "provider-b", Version: "0.6.20", DecodeTPS: 1,
+		Models: []failoverModelSpec{{ID: model}}, Script: script,
+	})
+
+	status, body, err := postSSE(ctx, ts.URL, "/v1/chat/completions", "test-key", buildChatBody(t, model, true, nil))
+	if err != nil {
+		t.Fatalf("chat request: %v", err)
+	}
+	if !strings.Contains(body, ": keepalive") {
+		t.Fatalf("no keepalive comment in stream — the test did not exercise the committed path; body = %s", body)
+	}
+	seq := rec.sequence()
+	if len(seq) != 2 {
+		t.Fatalf("dispatch sequence = %v, want 2 (kill switch off → legacy failover); status=%d body=%s", seq, status, body)
+	}
+	assertCleanFailoverStream(t, status, body, markerFor(seq[1]))
+}

--- a/coordinator/api/dispatch_jinja_terminal_test.go
+++ b/coordinator/api/dispatch_jinja_terminal_test.go
@@ -1,0 +1,292 @@
+package api
+
+import (
+	"log/slog"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+	"github.com/eigeninference/d-inference/coordinator/registry"
+	"github.com/eigeninference/d-inference/coordinator/store"
+)
+
+// E4 (2026-07-15 platform errors deep dive): a provider error_reason of
+// jinja_channel_tags / jinja_null_bridge / jinja_template is a DETERMINISTIC
+// template-render failure (the same body renders identically on every
+// provider). The dispatch ladder must stop on the FIRST occurrence and latch
+// a single 422 model_capability rejection — instead of failing over
+// fleet-wide (prod: 1.57 dispatch rows per jinja request, observed up to 17)
+// — and the provider must take no reputation hit for it.
+
+func TestShouldStopFailover_JinjaReasonsStopWith422(t *testing.T) {
+	for _, reason := range []string{"jinja_template", "jinja_channel_tags", "jinja_null_bridge"} {
+		d := &dispatchState{
+			s: newTestServerForDispatch(t), model: "m",
+			lastErrCode:   500,
+			lastErr:       "Runtime error: upper filter requires string",
+			lastErrReason: reason,
+		}
+		if !d.shouldStopFailover() {
+			t.Fatalf("%s: a jinja provider rejection must stop failover on the first attempt", reason)
+		}
+		if !d.terminalClientError {
+			t.Fatalf("%s: jinja stop must latch terminalClientError", reason)
+		}
+		if d.terminalClientErrorCode != http.StatusUnprocessableEntity {
+			t.Fatalf("%s: latched code = %d, want 422 (our classification, not the provider's raw 500)", reason, d.terminalClientErrorCode)
+		}
+		if d.terminalClientErrorReason != rejectionReasonTemplateRenderFailed {
+			t.Fatalf("%s: ledger reason = %q, want %q", reason, d.terminalClientErrorReason, rejectionReasonTemplateRenderFailed)
+		}
+		if d.terminalClientErrorMessage != jinjaTerminalRejectMessage {
+			t.Fatalf("%s: surfaced message = %q, want the curated model_capability text", reason, d.terminalClientErrorMessage)
+		}
+	}
+}
+
+// A plain provider 500 with no jinja reason must keep failing over exactly as
+// before — the stop keys on the normalized REASON, never on the 500 status.
+func TestShouldStopFailover_NonJinja500StillFailsOver(t *testing.T) {
+	for _, reason := range []string{"", "provider_error", "model_load"} {
+		d := &dispatchState{
+			s: newTestServerForDispatch(t), model: "m",
+			lastErrCode: 500, lastErr: "boom", lastErrReason: reason,
+		}
+		if d.shouldStopFailover() {
+			t.Fatalf("reason %q: a non-jinja 500 must fail over, not stop", reason)
+		}
+		if d.terminalClientError {
+			t.Fatalf("reason %q: must not latch terminalClientError", reason)
+		}
+	}
+}
+
+// Provider-cased / dashed variants normalize before matching (the wire value
+// is produced by a different codebase and must not bypass the stop on casing).
+func TestShouldStopFailover_JinjaReasonNormalizes(t *testing.T) {
+	d := &dispatchState{
+		s: newTestServerForDispatch(t), model: "m",
+		lastErrCode: 500, lastErrReason: " Jinja-Template ",
+	}
+	if !d.shouldStopFailover() {
+		t.Fatal("a cased/dashed jinja reason must still stop failover")
+	}
+	if d.terminalClientErrorCode != http.StatusUnprocessableEntity {
+		t.Fatalf("latched code = %d, want 422", d.terminalClientErrorCode)
+	}
+}
+
+// Kill switch: EIGENINFERENCE_JINJA_TERMINAL_REJECT=false restores the legacy
+// fail-over-on-500 behavior (and must not latch anything).
+func TestShouldStopFailover_JinjaKillSwitch(t *testing.T) {
+	t.Setenv(envJinjaTerminalReject, "false")
+	d := &dispatchState{
+		s: newTestServerForDispatch(t), model: "m",
+		lastErrCode: 500, lastErrReason: "jinja_template",
+	}
+	if d.shouldStopFailover() {
+		t.Fatal("with the kill switch off, a jinja 500 must fall back to legacy failover")
+	}
+	if d.terminalClientError {
+		t.Fatal("kill switch must not latch terminalClientError")
+	}
+}
+
+// A jinja rejection observed from a speculative race LOSER (whose error is
+// never written to d.lastErr) must latch via latchDeterministicLoser so the
+// survivor's later transient error cannot resume the storm.
+func TestLatchDeterministicLoser_JinjaReason(t *testing.T) {
+	d := &dispatchState{s: newTestServerForDispatch(t), model: "m"}
+	d.latchDeterministicLoser(nil, protocol.InferenceErrorMessage{
+		StatusCode:  500,
+		Error:       "Runtime error: upper filter requires string",
+		ErrorReason: "jinja_template",
+	})
+	if !d.terminalClientError || d.terminalClientErrorCode != http.StatusUnprocessableEntity {
+		t.Fatalf("race-loser jinja must latch 422; got latched=%v code=%d", d.terminalClientError, d.terminalClientErrorCode)
+	}
+	if d.terminalClientErrorReason != rejectionReasonTemplateRenderFailed {
+		t.Fatalf("ledger reason = %q, want %q", d.terminalClientErrorReason, rejectionReasonTemplateRenderFailed)
+	}
+	// Survivor reports a transient error that alone would NOT stop failover.
+	d.lastErrCode = 0
+	d.lastErr = "request rejected: queue full"
+	if !d.shouldStopFailover() {
+		t.Fatal("a latched race-loser jinja rejection must stop failover regardless of the survivor's error")
+	}
+}
+
+// The race-loser mirror honors the kill switch too.
+func TestLatchDeterministicLoser_JinjaKillSwitch(t *testing.T) {
+	t.Setenv(envJinjaTerminalReject, "false")
+	d := &dispatchState{s: newTestServerForDispatch(t), model: "m"}
+	d.latchDeterministicLoser(nil, protocol.InferenceErrorMessage{
+		StatusCode: 500, ErrorReason: "jinja_template",
+	})
+	if d.terminalClientError {
+		t.Fatal("kill switch must disable the race-loser jinja latch")
+	}
+}
+
+// 422 itself must remain failover-able (existing policy: the provider maps
+// model-OUTPUT-validation faults to 422, which can recover on a re-sample) —
+// the jinja stop keys on the REASON, and must not have widened the
+// StatusCode stop set.
+func TestShouldStopFailover_Plain422StillFailsOver(t *testing.T) {
+	d := &dispatchState{
+		s: newTestServerForDispatch(t), model: "m",
+		lastErrCode: 422, lastErr: "model output was not valid JSON",
+	}
+	if d.shouldStopFailover() {
+		t.Fatal("a plain 422 must keep failing over; only jinja_* reasons stop")
+	}
+}
+
+// Route-outcome taxonomy: a jinja failure is recorded as class client_error
+// WITHOUT AdmittedButFailed (not an admission mismatch, not a provider
+// fault), while the row's ErrorReason PRESERVES the jinja_* value so the
+// inference.error{reason:jinja_*} series keeps measuring real render
+// failures.
+func TestJinjaRouteOutcome_ClientErrorClassPreservesReason(t *testing.T) {
+	pr := &registry.PendingRequest{RequestID: "r1", Model: "m"}
+	out := preCommitProviderErrorOutcome(pr, protocol.InferenceErrorMessage{
+		StatusCode:  500,
+		Error:       "Runtime error: upper filter requires string",
+		ErrorReason: "jinja_template",
+	})
+	if out.ErrorClass != errorClassClientError {
+		t.Fatalf("class = %q, want %q", out.ErrorClass, errorClassClientError)
+	}
+	if out.AdmittedButFailed {
+		t.Fatal("a jinja render failure must NOT set AdmittedButFailed")
+	}
+	if out.ErrorReason != errorReasonJinjaTemplate {
+		t.Fatalf("reason = %q, want %q preserved on the row", out.ErrorReason, errorReasonJinjaTemplate)
+	}
+
+	d := &dispatchState{
+		s: newTestServerForDispatch(t), model: "m",
+		lastErrCode: 500, lastErr: "upper filter requires string", lastErrReason: "jinja_template",
+	}
+	dout := d.providerFailedRoutingOutcome()
+	if dout.ErrorClass != errorClassClientError || dout.AdmittedButFailed {
+		t.Fatalf("providerFailedRoutingOutcome for jinja: class=%q admitted=%v, want client_error + not admitted", dout.ErrorClass, dout.AdmittedButFailed)
+	}
+	if dout.ErrorReason != errorReasonJinjaTemplate {
+		t.Fatalf("providerFailedRoutingOutcome reason = %q, want %q", dout.ErrorReason, errorReasonJinjaTemplate)
+	}
+}
+
+// isJinjaTemplateErrorReason is the single normalization point shared by the
+// dispatch stop, the reputation exemption, and the outcome taxonomy.
+func TestIsJinjaTemplateErrorReason(t *testing.T) {
+	for reason, want := range map[string]bool{
+		"jinja_template":     true,
+		"jinja_channel_tags": true,
+		"jinja_null_bridge":  true,
+		"Jinja-Template":     true,
+		" jinja_template ":   true,
+		"":                   false,
+		"provider_error":     false,
+		"model_load":         false,
+		"tool_noncompliance": false,
+		"jinja":              false,
+	} {
+		if got := isJinjaTemplateErrorReason(reason); got != want {
+			t.Errorf("isJinjaTemplateErrorReason(%q) = %v, want %v", reason, got, want)
+		}
+	}
+}
+
+// handleInferenceError must NOT record a reputation failure for a jinja_*
+// terminal — the request shape, not the provider, is at fault. Capacity and
+// cancel exemptions stay unchanged, and a plain 500 still counts.
+func TestHandleInferenceError_JinjaSkipsRecordJobFailure(t *testing.T) {
+	cases := []struct {
+		name        string
+		msg         protocol.InferenceErrorMessage
+		wantFailure bool
+	}{
+		{
+			name: "jinja_template 500 is exempt",
+			msg: protocol.InferenceErrorMessage{
+				StatusCode: 500, Error: "Runtime error: upper filter requires string",
+				ErrorReason: "jinja_template",
+			},
+			wantFailure: false,
+		},
+		{
+			name: "jinja_channel_tags 500 is exempt",
+			msg: protocol.InferenceErrorMessage{
+				StatusCode: 500, Error: "template raised", ErrorReason: "jinja_channel_tags",
+			},
+			wantFailure: false,
+		},
+		{
+			name: "jinja_null_bridge 500 is exempt",
+			msg: protocol.InferenceErrorMessage{
+				StatusCode: 500, Error: "Cannot convert value", ErrorReason: "jinja_null_bridge",
+			},
+			wantFailure: false,
+		},
+		{
+			name:        "plain 500 still records a failure",
+			msg:         protocol.InferenceErrorMessage{StatusCode: 500, Error: "boom"},
+			wantFailure: true,
+		},
+		{
+			name:        "capacity 503 stays exempt",
+			msg:         protocol.InferenceErrorMessage{StatusCode: 503, Error: "token_budget_exhausted: full"},
+			wantFailure: false,
+		},
+		{
+			name:        "cancel 499 stays exempt",
+			msg:         protocol.InferenceErrorMessage{StatusCode: 499, Error: "request cancelled"},
+			wantFailure: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+			st := store.NewMemory(store.Config{AdminKey: "test-key"})
+			reg := registry.New(logger)
+			srv := NewServer(reg, st, ServerConfig{}, logger)
+			provider := reg.Register("provider-jinja-"+tc.name, nil, &protocol.RegisterMessage{
+				Type:     protocol.TypeRegister,
+				Hardware: protocol.Hardware{ChipName: "Apple M3 Max", MemoryGB: 64},
+				Models:   []protocol.ModelInfo{{ID: "test-model", ModelType: "chat", Quantization: "4bit"}},
+				Backend:  "mlx-swift",
+			})
+			pr := &registry.PendingRequest{
+				RequestID:  "req-jinja",
+				Model:      "test-model",
+				ChunkCh:    make(chan string, 1),
+				CompleteCh: make(chan protocol.UsageInfo, 1),
+				ErrorCh:    make(chan protocol.InferenceErrorMessage, 1),
+			}
+			provider.AddPending(pr)
+
+			msg := tc.msg
+			msg.RequestID = pr.RequestID
+			srv.handleInferenceError(provider.ID, provider, &msg)
+
+			wantFailed := 0
+			if tc.wantFailure {
+				wantFailed = 1
+			}
+			if got := provider.Reputation.FailedJobs; got != wantFailed {
+				t.Errorf("Reputation.FailedJobs = %d, want %d", got, wantFailed)
+			}
+			// The terminal is still delivered to the consumer channel either way.
+			select {
+			case delivered := <-pr.ErrorCh:
+				if delivered.StatusCode != tc.msg.StatusCode {
+					t.Errorf("delivered status = %d, want %d", delivered.StatusCode, tc.msg.StatusCode)
+				}
+			default:
+				t.Error("terminal error was not delivered to ErrorCh")
+			}
+		})
+	}
+}

--- a/coordinator/api/dispatch_nonfault_breaker_test.go
+++ b/coordinator/api/dispatch_nonfault_breaker_test.go
@@ -1,0 +1,163 @@
+package api
+
+// PR #548 review follow-up (Codex P2, dispatch.go ~1143): a jinja_* provider
+// error arrives as a raw 500 — exactly the sickness shape the inference-error,
+// node-health, and stable-identity breakers count — and the dispatch loop fed
+// it to all three via noteDispatchProviderError BEFORE the E4 relabel in
+// shouldStopFailover ran. A few malformed tool histories could therefore
+// quarantine healthy providers/pairs. The dispatch funnel (noteProviderError)
+// now withholds the provider for non-provider-fault reasons
+// (isNonProviderFaultErrorReason: jinja_* + tool_noncompliance), while
+// keeping the refund + held-chunk side effects and leaving every
+// capacity-class rejection (which the capacity cooldown legitimately keys on)
+// untouched.
+
+import (
+	"log/slog"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+	"github.com/eigeninference/d-inference/coordinator/registry"
+	"github.com/eigeninference/d-inference/coordinator/store"
+)
+
+// newBreakerExemptionHarness builds a server with one registered provider that
+// carries a stable identity (AccountID), so all three provider-fault breakers
+// AND the stable-identity ejection breaker are armed for the test.
+func newBreakerExemptionHarness(t *testing.T, name string) (*Server, *registry.Registry, *registry.Provider, *registry.PendingRequest) {
+	t.Helper()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	st := store.NewMemory(store.Config{AdminKey: "test-key"})
+	reg := registry.New(logger)
+	srv := NewServer(reg, st, ServerConfig{}, logger)
+	provider := reg.Register("provider-"+name, nil, &protocol.RegisterMessage{
+		Type:     protocol.TypeRegister,
+		Hardware: protocol.Hardware{ChipName: "Apple M3 Max", MemoryGB: 64},
+		Models:   []protocol.ModelInfo{{ID: "test-model", ModelType: "chat", Quantization: "4bit"}},
+		Backend:  "mlx-swift",
+	})
+	provider.Mu().Lock()
+	provider.AccountID = "acct-" + name
+	provider.Mu().Unlock()
+	pr := &registry.PendingRequest{
+		RequestID: "req-" + name,
+		Model:     "test-model",
+	}
+	return srv, reg, provider, pr
+}
+
+// assertBreakerStates asserts the open/closed state of the three
+// provider-fault breakers the dispatch funnel feeds, one assert per breaker so
+// a regression names the exact breaker that tripped.
+func assertBreakerStates(t *testing.T, reg *registry.Registry, provider *registry.Provider, pr *registry.PendingRequest, wantOpen bool) {
+	t.Helper()
+	if got := reg.InferenceErrorCooldownActive(provider.ID, pr.Model, pr.Traits.CooldownShape()); got != wantOpen {
+		t.Errorf("inference-error pair cooldown active = %v, want %v", got, wantOpen)
+	}
+	if got := reg.ProviderBreakerOpen(provider.ID); got != wantOpen {
+		t.Errorf("node-health breaker open = %v, want %v", got, wantOpen)
+	}
+	sid := reg.GetProviderStableIdentity(provider.ID)
+	if sid == "" {
+		t.Fatal("test provider must carry a stable identity (AccountID) so the ejection breaker is armed")
+	}
+	if got := reg.HealthEjectionOpen(sid); got != wantOpen {
+		t.Errorf("stable-identity ejection open = %v, want %v", got, wantOpen)
+	}
+}
+
+// breakerStrikeRounds comfortably exceeds every trip threshold involved:
+// inference-error cooldown (2 strikes in window), node-health breaker
+// (5 consecutive faults), stable-identity ejection (8 consecutive faults).
+const breakerStrikeRounds = 10
+
+// A jinja_* 500 must feed NONE of the provider-fault breakers: the template
+// renders the same request body identically on every provider, so the fault
+// belongs to the request, not the node. Fails without the noteProviderError
+// reason gate on all three asserts (a raw 500 trips each breaker at its
+// threshold). Fed through noteDispatchRetry — the dominant dispatch funnel —
+// so the gate is proven on the wrapped path, not just the helper.
+func TestNoteDispatchRetry_JinjaSkipsProviderFaultBreakers(t *testing.T) {
+	srv, reg, provider, pr := newBreakerExemptionHarness(t, "jinja-skip")
+	d := &dispatchState{s: srv, model: pr.Model}
+	for range breakerStrikeRounds {
+		d.noteDispatchRetry(provider, pr, http.StatusInternalServerError,
+			"Runtime error: upper filter requires string", "jinja_template", nil)
+	}
+	assertBreakerStates(t, reg, provider, pr, false)
+}
+
+// The non-breaker side effects must survive the reason gate: the attempt's
+// reservation top-up is still refunded and held boilerplate is still
+// discarded (returning true so callers skip the generic retry counter).
+func TestNoteProviderError_JinjaKeepsRefundAndHeldDiscard(t *testing.T) {
+	srv, _, provider, pr := newBreakerExemptionHarness(t, "jinja-side-effects")
+	pr.ConsumerKey = "consumer-key"
+	pr.BaseReservedMicroUSD = 1_000
+	pr.ReservedMicroUSD = 1_500 // provider-specific top-up to refund
+	d := &dispatchState{s: srv, model: pr.Model}
+	held := []string{`data: {"choices":[{"delta":{"role":"assistant"}}]}`}
+	if !d.noteProviderError(provider, pr, http.StatusInternalServerError,
+		"Runtime error: upper filter requires string", "jinja_template", &held) {
+		t.Error("held boilerplate must still be discarded (return true) for an exempt reason")
+	}
+	if len(held) != 0 {
+		t.Errorf("held chunks = %d, want 0 (discarded)", len(held))
+	}
+	if pr.ReservedMicroUSD != pr.BaseReservedMicroUSD {
+		t.Errorf("ReservedMicroUSD = %d, want base %d (top-up refunded)", pr.ReservedMicroUSD, pr.BaseReservedMicroUSD)
+	}
+}
+
+// tool_noncompliance is gated too, for consistency with the reputation
+// exemption (handleInferenceError): the MODEL's output broke the forced
+// tool_choice contract. Its 422 is already code-neutral in all three breakers
+// today, so this documents (and pins) the intended end state rather than
+// fixing a live trip — if a future provider version ever surfaced the reason
+// on a 5xx, the gate keeps it out of the breakers.
+func TestNoteDispatchRetry_ToolNoncomplianceSkipsProviderFaultBreakers(t *testing.T) {
+	srv, reg, provider, pr := newBreakerExemptionHarness(t, "toolnc-skip")
+	d := &dispatchState{s: srv, model: pr.Model}
+	for range breakerStrikeRounds {
+		d.noteDispatchRetry(provider, pr, http.StatusUnprocessableEntity,
+			"model did not emit the required tool call", "tool_noncompliance", nil)
+	}
+	assertBreakerStates(t, reg, provider, pr, false)
+}
+
+// Control: a plain 500 with no exonerating reason still feeds all three
+// breakers through the same funnel — the gate must not widen into a blanket
+// breaker bypass. Fed through noteProviderError directly (the race-site
+// funnel), covering the second call path.
+func TestNoteProviderError_Plain500StillFeedsBreakers(t *testing.T) {
+	srv, reg, provider, pr := newBreakerExemptionHarness(t, "plain-500")
+	d := &dispatchState{s: srv, model: pr.Model}
+	for range breakerStrikeRounds {
+		d.noteProviderError(provider, pr, http.StatusInternalServerError, "boom", "", nil)
+	}
+	assertBreakerStates(t, reg, provider, pr, true)
+}
+
+// Guard for the "do not skip capacity cooldowns" constraint: a capacity-class
+// 503 — whose structured reason (token_budget_exhausted) is deliberately NOT
+// in the non-provider-fault vocabulary — must keep feeding the capacity-reject
+// cooldown through the gated funnel, so black-hole detection still works.
+func TestNoteProviderError_Capacity503StillFeedsCapacityCooldown(t *testing.T) {
+	srv, reg, provider, pr := newBreakerExemptionHarness(t, "capacity-503")
+	d := &dispatchState{s: srv, model: pr.Model}
+	// Default capacity cooldown threshold is 5 strikes with zero interleaved
+	// accepts; feed a couple beyond it.
+	for range 7 {
+		d.noteProviderError(provider, pr, http.StatusServiceUnavailable,
+			"token_budget_exhausted: insufficient KV headroom", "token_budget_exhausted", nil)
+	}
+	if !reg.CapacityCooldownActive(provider.ID, pr.Model) {
+		t.Error("capacity-reject cooldown must still trip for capacity-class 503s (reason gate must key on jinja_*/tool_noncompliance only)")
+	}
+	// And the fault breakers stay closed for capacity sheds, as before.
+	if reg.ProviderBreakerOpen(provider.ID) {
+		t.Error("node-health breaker must ignore capacity-class 503s (healthy shed)")
+	}
+}

--- a/coordinator/api/nonfault_outcome_generic_test.go
+++ b/coordinator/api/nonfault_outcome_generic_test.go
@@ -2,6 +2,8 @@ package api
 
 import (
 	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/eigeninference/d-inference/coordinator/protocol"
@@ -89,4 +91,69 @@ func TestGenericPathNonFaultReasonsSkipBreakers(t *testing.T) {
 		srv.noteInferenceError(provider.ID, pr, http.StatusInternalServerError, "boom", "")
 	}
 	assertBreakerStates(t, reg, provider, pr, true)
+}
+
+// PR #548 review round 4 (Codex P2): the generic endpoints (/v1/messages,
+// /v1/completions) and the non-streaming chat assembly must surface the SAME
+// curated bodies as the chat dispatch ladder for non-provider-fault reasons —
+// never the raw template backtrace as a retryable-looking provider_error 500.
+func TestWriteGenericProviderError(t *testing.T) {
+	srv := newTestServerForDispatch(t)
+
+	cases := []struct {
+		name       string
+		msg        protocol.InferenceErrorMessage
+		wantStatus int
+		wantType   string
+		wantInBody string
+		absentBody string
+	}{
+		{
+			name:       "jinja becomes curated 422",
+			msg:        protocol.InferenceErrorMessage{StatusCode: 500, Error: "Runtime error: upper filter requires string", ErrorReason: "jinja_template"},
+			wantStatus: 422, wantType: "invalid_request_error",
+			wantInBody: "model_capability", absentBody: "upper filter",
+		},
+		{
+			name:       "tool_noncompliance keeps typed message in curated envelope",
+			msg:        protocol.InferenceErrorMessage{StatusCode: 422, Error: "model did not emit the required tool call", ErrorReason: "tool_noncompliance"},
+			wantStatus: 422, wantType: "invalid_request_error",
+			wantInBody: "required tool call",
+		},
+		{
+			name:       "plain 500 keeps raw passthrough",
+			msg:        protocol.InferenceErrorMessage{StatusCode: 500, Error: "boom"},
+			wantStatus: 500, wantType: "provider_error", wantInBody: "boom",
+		},
+		{
+			name:       "zero status defaults to 502",
+			msg:        protocol.InferenceErrorMessage{Error: "gone"},
+			wantStatus: 502, wantType: "provider_error", wantInBody: "gone",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			srv.writeGenericProviderError(rec, tc.msg)
+			if rec.Code != tc.wantStatus {
+				t.Fatalf("status = %d, want %d", rec.Code, tc.wantStatus)
+			}
+			body := rec.Body.String()
+			if !strings.Contains(body, tc.wantType) || !strings.Contains(body, tc.wantInBody) {
+				t.Fatalf("body = %s, want type %q and %q", body, tc.wantType, tc.wantInBody)
+			}
+			if tc.absentBody != "" && strings.Contains(body, tc.absentBody) {
+				t.Fatalf("body must not leak %q: %s", tc.absentBody, body)
+			}
+		})
+	}
+
+	// Kill switch: with the ladder's jinja terminal reject disabled, the
+	// generic path falls back to the legacy raw passthrough too.
+	t.Setenv("EIGENINFERENCE_JINJA_TERMINAL_REJECT", "false")
+	rec := httptest.NewRecorder()
+	srv.writeGenericProviderError(rec, protocol.InferenceErrorMessage{StatusCode: 500, Error: "Runtime error: upper filter requires string", ErrorReason: "jinja_template"})
+	if rec.Code != 500 || !strings.Contains(rec.Body.String(), "provider_error") {
+		t.Fatalf("kill switch off: status=%d body=%s, want raw provider_error 500", rec.Code, rec.Body.String())
+	}
 }

--- a/coordinator/api/nonfault_outcome_generic_test.go
+++ b/coordinator/api/nonfault_outcome_generic_test.go
@@ -1,0 +1,92 @@
+package api
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+	"github.com/eigeninference/d-inference/coordinator/registry"
+)
+
+// PR #548 review round 3 (Codex P2): tool_noncompliance route rows must not be
+// provider-failure outcomes. The outcome builders key on the SAME shared
+// vocabulary as the reputation and breaker exemptions
+// (isNonProviderFaultErrorReason), so the lists cannot drift.
+
+func TestPreCommitOutcome_NonProviderFaultReasons(t *testing.T) {
+	pr := &registry.PendingRequest{RequestID: "r1", Model: "m"}
+	for _, tc := range []struct {
+		code   int
+		reason string
+	}{
+		{422, "tool_noncompliance"},
+		{500, "jinja_template"},
+	} {
+		out := preCommitProviderErrorOutcome(pr, protocol.InferenceErrorMessage{
+			StatusCode: tc.code, Error: "x", ErrorReason: tc.reason,
+		})
+		if out.ErrorClass != errorClassClientError {
+			t.Fatalf("%s: class = %q, want %q", tc.reason, out.ErrorClass, errorClassClientError)
+		}
+		if out.AdmittedButFailed {
+			t.Fatalf("%s: AdmittedButFailed must stay false", tc.reason)
+		}
+		if out.ErrorReason != tc.reason {
+			t.Fatalf("%s: reason = %q, must survive on the row", tc.reason, out.ErrorReason)
+		}
+	}
+
+	// Control: a plain 422 with NO structured reason stays a provider-fault
+	// outcome — the reclassification cannot widen to generic output-validation
+	// errors.
+	ctrl := preCommitProviderErrorOutcome(pr, protocol.InferenceErrorMessage{
+		StatusCode: 422, Error: "model output was not valid JSON",
+	})
+	if ctrl.ErrorClass != "provider_error" || !ctrl.AdmittedButFailed {
+		t.Fatalf("plain 422: class=%q admitted=%v, want provider_error/admitted",
+			ctrl.ErrorClass, ctrl.AdmittedButFailed)
+	}
+}
+
+func TestProviderFailedRoutingOutcome_ToolNoncompliance(t *testing.T) {
+	d := &dispatchState{
+		s: newTestServerForDispatch(t), model: "m",
+		lastErrCode: 422, lastErr: "model did not emit the required tool call",
+		lastErrReason: "tool_noncompliance",
+	}
+	out := d.providerFailedRoutingOutcome()
+	if out.ErrorClass != errorClassClientError || out.AdmittedButFailed {
+		t.Fatalf("class=%q admitted=%v, want client_error/not-admitted",
+			out.ErrorClass, out.AdmittedButFailed)
+	}
+	if out.ErrorReason != "tool_noncompliance" {
+		t.Fatalf("reason = %q, must survive on the row", out.ErrorReason)
+	}
+}
+
+// PR #548 review round 3 (Codex P2): the generic inference path
+// (/v1/messages, /v1/completions) calls noteInferenceError DIRECTLY on
+// pre-commit provider errors, bypassing the dispatch funnel's gate. The gate
+// now lives inside noteInferenceError itself (the single breaker chokepoint),
+// so jinja_*/tool_noncompliance never feed the provider-fault breakers from
+// any path. Fails without the noteInferenceError gate.
+func TestGenericPathNonFaultReasonsSkipBreakers(t *testing.T) {
+	srv, reg, provider, pr := newBreakerExemptionHarness(t, "generic-nonfault")
+
+	// Far past every trip threshold (pair cooldown trips at 2, node health at
+	// 5, stable identity at 8).
+	for range 10 {
+		srv.noteInferenceError(provider.ID, pr, http.StatusInternalServerError,
+			"Runtime error: upper filter requires string", "jinja_template")
+		srv.noteInferenceError(provider.ID, pr, 422,
+			"model did not emit the required tool call", "tool_noncompliance")
+	}
+	assertBreakerStates(t, reg, provider, pr, false)
+
+	// Control: the same volume of plain 500s through the same chokepoint still
+	// trips the breakers — the gate keys on the structured reason only.
+	for range 10 {
+		srv.noteInferenceError(provider.ID, pr, http.StatusInternalServerError, "boom", "")
+	}
+	assertBreakerStates(t, reg, provider, pr, true)
+}

--- a/coordinator/api/provider.go
+++ b/coordinator/api/provider.go
@@ -2169,6 +2169,12 @@ func (s *Server) handleInferenceError(providerID string, provider *registry.Prov
 	// pr==nil with zero reputation effect, and the old fleet emits one for
 	// every mid-stream disconnect — penalizing them would erode the whole
 	// fleet's reputation for consumer behavior.
+	//
+	// A jinja_* error_reason (template render failure) is exempt too (E4): the
+	// model's chat template could not render the REQUEST's tool schemas or
+	// message history — a request-shape fault that fails identically on every
+	// provider (prod: jinja requests averaged 1.57 dispatch rows, each one
+	// erasing reputation fleet-wide for a body the provider never controlled).
 	loweredErr := strings.ToLower(msg.Error)
 	capacityRejection := msg.StatusCode == http.StatusServiceUnavailable ||
 		msg.StatusCode == http.StatusTooManyRequests ||
@@ -2176,7 +2182,8 @@ func (s *Server) handleInferenceError(providerID string, provider *registry.Prov
 		strings.Contains(loweredErr, "insufficient memory")
 	cancelTerminal := msg.StatusCode == 499 ||
 		strings.Contains(loweredErr, "request cancelled")
-	if !capacityRejection && !cancelTerminal {
+	templateRenderFault := isJinjaTemplateErrorReason(msg.ErrorReason)
+	if !capacityRejection && !cancelTerminal && !templateRenderFault {
 		s.registry.RecordJobFailure(providerID)
 	}
 

--- a/coordinator/api/provider.go
+++ b/coordinator/api/provider.go
@@ -2170,11 +2170,18 @@ func (s *Server) handleInferenceError(providerID string, provider *registry.Prov
 	// every mid-stream disconnect — penalizing them would erode the whole
 	// fleet's reputation for consumer behavior.
 	//
-	// A jinja_* error_reason (template render failure) is exempt too (E4): the
-	// model's chat template could not render the REQUEST's tool schemas or
-	// message history — a request-shape fault that fails identically on every
-	// provider (prod: jinja requests averaged 1.57 dispatch rows, each one
-	// erasing reputation fleet-wide for a body the provider never controlled).
+	// A structured NON-provider-fault error_reason is exempt too
+	// (isNonProviderFaultErrorReason): jinja_* template-render failures (E4 —
+	// the model's chat template could not render the REQUEST's tool schemas
+	// or message history, a request-shape fault that fails identically on
+	// every provider; prod: jinja requests averaged 1.57 dispatch rows, each
+	// one erasing reputation fleet-wide for a body the provider never
+	// controlled) and tool_noncompliance (E5 — the MODEL's sampled output
+	// broke a forced tool_choice contract; the 422 stays on the bounded
+	// failover path precisely because a re-sample can comply, so each
+	// attempted provider must not eat a reputation strike for what the model
+	// generated). A plain 422 with no structured reason still counts —
+	// only the typed vocabulary exonerates.
 	loweredErr := strings.ToLower(msg.Error)
 	capacityRejection := msg.StatusCode == http.StatusServiceUnavailable ||
 		msg.StatusCode == http.StatusTooManyRequests ||
@@ -2182,8 +2189,8 @@ func (s *Server) handleInferenceError(providerID string, provider *registry.Prov
 		strings.Contains(loweredErr, "insufficient memory")
 	cancelTerminal := msg.StatusCode == 499 ||
 		strings.Contains(loweredErr, "request cancelled")
-	templateRenderFault := isJinjaTemplateErrorReason(msg.ErrorReason)
-	if !capacityRejection && !cancelTerminal && !templateRenderFault {
+	nonProviderFault := isNonProviderFaultErrorReason(msg.ErrorReason)
+	if !capacityRejection && !cancelTerminal && !nonProviderFault {
 		s.registry.RecordJobFailure(providerID)
 	}
 

--- a/coordinator/api/route_outcome.go
+++ b/coordinator/api/route_outcome.go
@@ -32,6 +32,25 @@ const (
 // every provider — so it is NOT a provider fault and NOT an admission mismatch.
 const errorClassClientError = "client_error"
 
+// isJinjaTemplateErrorReason reports whether a provider-supplied error_reason
+// identifies a DETERMINISTIC chat-template render failure (the DAR-329/341
+// provider vocabulary). The template renders the request's tool schemas and
+// message history the same way on every provider, so these are request-shape /
+// model-capability faults: the dispatch ladder stops on the first occurrence
+// (E4, see dispatch.go), the provider takes no reputation hit
+// (handleInferenceError), and route rows record class client_error — while the
+// jinja_* reason itself is PRESERVED on the row, so the
+// inference.error{reason:jinja_template} series keeps measuring real render
+// failures rather than being silenced by reclassification.
+func isJinjaTemplateErrorReason(reason string) bool {
+	switch normalizeInferenceErrorReason(reason) {
+	case errorReasonJinjaChannelTags, errorReasonJinjaNullBridge, errorReasonJinjaTemplate:
+		return true
+	default:
+		return false
+	}
+}
+
 // Final-status values persisted on inference_routes (store.InferenceRouteOutcome
 // .FinalStatus). Centralized so status comparisons/constructions don't drift on a
 // bare string literal.
@@ -192,11 +211,14 @@ func preResponseProviderErrorOutcome(pr *registry.PendingRequest, msg protocol.I
 }
 
 func preCommitProviderErrorOutcome(pr *registry.PendingRequest, msg protocol.InferenceErrorMessage) *store.InferenceRouteOutcome {
-	if isTerminalClientErrorCode(msg.StatusCode) {
-		// Deterministic client-shape 4xx: the request body is malformed/unservable
-		// by shape (fails identically on every provider), not a provider fault.
-		// Record as client_error WITHOUT AdmittedButFailed so it never pollutes the
-		// admission-mismatch gauge.
+	if isTerminalClientErrorCode(msg.StatusCode) || isJinjaTemplateErrorReason(msg.ErrorReason) {
+		// Deterministic client-shape rejection: a 4xx status the provider maps
+		// for malformed bodies, OR a jinja_* template-render reason (arrives as
+		// a provider 500 but is a request-shape fault — the template renders
+		// the same body identically on every provider). Record as client_error
+		// WITHOUT AdmittedButFailed so it never pollutes the admission-mismatch
+		// gauge; msg.ErrorReason is threaded through so jinja rows keep their
+		// jinja_* reason.
 		return pendingRouteOutcomeWithReason(pr, finalStatusError, errorClassClientError, msg.StatusCode, msg.ErrorReason, msg.Error)
 	}
 	class := "provider_error"

--- a/coordinator/api/route_outcome.go
+++ b/coordinator/api/route_outcome.go
@@ -243,14 +243,17 @@ func preResponseProviderErrorOutcome(pr *registry.PendingRequest, msg protocol.I
 }
 
 func preCommitProviderErrorOutcome(pr *registry.PendingRequest, msg protocol.InferenceErrorMessage) *store.InferenceRouteOutcome {
-	if isTerminalClientErrorCode(msg.StatusCode) || isJinjaTemplateErrorReason(msg.ErrorReason) {
-		// Deterministic client-shape rejection: a 4xx status the provider maps
-		// for malformed bodies, OR a jinja_* template-render reason (arrives as
-		// a provider 500 but is a request-shape fault — the template renders
-		// the same body identically on every provider). Record as client_error
-		// WITHOUT AdmittedButFailed so it never pollutes the admission-mismatch
-		// gauge; msg.ErrorReason is threaded through so jinja rows keep their
-		// jinja_* reason.
+	if isTerminalClientErrorCode(msg.StatusCode) || isNonProviderFaultErrorReason(msg.ErrorReason) {
+		// Deterministic non-provider fault: a 4xx status the provider maps for
+		// malformed bodies, OR a structured non-provider-fault reason — jinja_*
+		// template-render failures (arrive as provider 500s but are
+		// request-shape faults, identical fleet-wide) and tool_noncompliance
+		// (model-output-dependent 422s; the provider executed faithfully).
+		// Record as client_error WITHOUT AdmittedButFailed so neither pollutes
+		// the provider-fault or admission-mismatch telemetry, keyed on the SAME
+		// vocabulary as the reputation and breaker exemptions
+		// (isNonProviderFaultErrorReason) so the lists cannot drift.
+		// msg.ErrorReason is threaded through so rows keep their reason.
 		return pendingRouteOutcomeWithReason(pr, finalStatusError, errorClassClientError, msg.StatusCode, msg.ErrorReason, msg.Error)
 	}
 	class := "provider_error"

--- a/coordinator/api/route_outcome.go
+++ b/coordinator/api/route_outcome.go
@@ -58,6 +58,30 @@ func isJinjaTemplateErrorReason(reason string) bool {
 	}
 }
 
+// isNonProviderFaultErrorReason reports whether a provider-supplied
+// error_reason identifies a failure that is NOT the provider's fault:
+//
+//   - jinja_* template-render failures (isJinjaTemplateErrorReason, E4): the
+//     REQUEST's tool schemas or message history cannot be rendered by the
+//     model's chat template — deterministic for the request and identical on
+//     every provider;
+//   - tool_noncompliance (E5): the MODEL's sampled output broke a forced
+//     tool_choice contract (did not emit the required call / emitted one
+//     outside the allowed set / exceeded the deferred content limit) —
+//     output-dependent, a re-sample can comply.
+//
+// This is the single reason vocabulary shared by the reputation exemption
+// (handleInferenceError: no RecordJobFailure) and the dispatch-path breaker
+// exemption (dispatchState.noteProviderError: no inference-error /
+// node-health / stable-identity / capacity-cooldown feeds): a malformed tool
+// history or an unlucky sample must never quarantine a healthy provider.
+// Capacity and cancel exemptions are status/string-driven and stay with
+// their call sites — this helper is strictly the structured-REASON list.
+func isNonProviderFaultErrorReason(reason string) bool {
+	return isJinjaTemplateErrorReason(reason) ||
+		normalizeInferenceErrorReason(reason) == errorReasonToolNoncompliance
+}
+
 // Final-status values persisted on inference_routes (store.InferenceRouteOutcome
 // .FinalStatus). Centralized so status comparisons/constructions don't drift on a
 // bare string literal.

--- a/coordinator/api/route_outcome.go
+++ b/coordinator/api/route_outcome.go
@@ -23,7 +23,14 @@ const (
 	errorReasonCancelled          = "cancelled"
 	errorReasonProviderError      = "provider_error"
 	errorReasonClientError        = "client_error"
-	errorReasonUnknown            = "unknown"
+	// errorReasonToolNoncompliance (E5): the provider's typed 422 for a model
+	// that failed a forced tool_choice contract (did not emit the required
+	// call / emitted one outside the allowed set / exceeded the deferred
+	// content limit). Output-dependent — a re-sample can comply — so 422 stays
+	// on the normal bounded-failover path, NEVER in the terminal client-error
+	// stop set (see isTerminalClientErrorCode).
+	errorReasonToolNoncompliance = "tool_noncompliance"
+	errorReasonUnknown           = "unknown"
 )
 
 // errorClassClientError is the route-outcome error_class for a DETERMINISTIC
@@ -73,6 +80,7 @@ var validInferenceErrorReasons = map[string]struct{}{
 	errorReasonCancelled:          {},
 	errorReasonProviderError:      {},
 	errorReasonClientError:        {},
+	errorReasonToolNoncompliance:  {},
 	errorReasonUnknown:            {},
 }
 

--- a/coordinator/api/route_outcome_tool_noncompliance_test.go
+++ b/coordinator/api/route_outcome_tool_noncompliance_test.go
@@ -1,10 +1,13 @@
 package api
 
 import (
+	"log/slog"
+	"os"
 	"testing"
 
 	"github.com/eigeninference/d-inference/coordinator/protocol"
 	"github.com/eigeninference/d-inference/coordinator/registry"
+	"github.com/eigeninference/d-inference/coordinator/store"
 )
 
 // E5: providers map a forced-tool_choice violation ("model did not emit the
@@ -32,6 +35,112 @@ func TestToolNoncomplianceOutcomePreservesReason(t *testing.T) {
 	})
 	if out.ErrorReason != errorReasonToolNoncompliance {
 		t.Fatalf("reason = %q, want %q on the route row", out.ErrorReason, errorReasonToolNoncompliance)
+	}
+}
+
+// isNonProviderFaultErrorReason is the shared vocabulary behind the
+// reputation exemption (handleInferenceError) and the dispatch-path breaker
+// exemption (noteProviderError): jinja_* + tool_noncompliance, nothing else.
+func TestIsNonProviderFaultErrorReason(t *testing.T) {
+	for reason, want := range map[string]bool{
+		"jinja_template":         true,
+		"jinja_channel_tags":     true,
+		"jinja_null_bridge":      true,
+		"tool_noncompliance":     true,
+		" Tool-Noncompliance ":   true, // wire casing/dashes normalize
+		"":                       false,
+		"provider_error":         false,
+		"client_error":           false, // generic client shape ≠ exonerating
+		"model_load":             false, // load faults ARE provider faults
+		"cancelled":              false, // cancel exemption is status/string-driven
+		"token_budget_exhausted": false, // capacity exemption is status/string-driven
+		"unknown":                false,
+	} {
+		if got := isNonProviderFaultErrorReason(reason); got != want {
+			t.Errorf("isNonProviderFaultErrorReason(%q) = %v, want %v", reason, got, want)
+		}
+	}
+}
+
+// handleInferenceError must NOT record a reputation failure for a
+// tool_noncompliance 422 — the MODEL's output, not the provider, broke the
+// forced tool_choice contract (mirrors the jinja_* exemption in
+// TestHandleInferenceError_JinjaSkipsRecordJobFailure). A plain 422 with no
+// structured reason still counts, so the exemption cannot over-widen.
+// The tool_noncompliance case FAILS without the isNonProviderFaultErrorReason
+// exemption in handleInferenceError.
+func TestHandleInferenceError_ToolNoncomplianceSkipsRecordJobFailure(t *testing.T) {
+	cases := []struct {
+		name        string
+		msg         protocol.InferenceErrorMessage
+		wantFailure bool
+	}{
+		{
+			name: "tool_noncompliance 422 is exempt",
+			msg: protocol.InferenceErrorMessage{
+				StatusCode: 422, Error: "model did not emit the required tool call",
+				ErrorReason: "tool_noncompliance",
+			},
+			wantFailure: false,
+		},
+		{
+			name: "wire-cased tool_noncompliance normalizes into the exemption",
+			msg: protocol.InferenceErrorMessage{
+				StatusCode: 422, Error: "model emitted a tool call outside tool_choice",
+				ErrorReason: " Tool-Noncompliance ",
+			},
+			wantFailure: false,
+		},
+		{
+			name: "plain 422 with no structured reason still records a failure",
+			msg: protocol.InferenceErrorMessage{
+				StatusCode: 422, Error: "model output was not valid JSON",
+			},
+			wantFailure: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+			st := store.NewMemory(store.Config{AdminKey: "test-key"})
+			reg := registry.New(logger)
+			srv := NewServer(reg, st, ServerConfig{}, logger)
+			provider := reg.Register("provider-toolnc-"+tc.name, nil, &protocol.RegisterMessage{
+				Type:     protocol.TypeRegister,
+				Hardware: protocol.Hardware{ChipName: "Apple M3 Max", MemoryGB: 64},
+				Models:   []protocol.ModelInfo{{ID: "test-model", ModelType: "chat", Quantization: "4bit"}},
+				Backend:  "mlx-swift",
+			})
+			pr := &registry.PendingRequest{
+				RequestID:  "req-toolnc",
+				Model:      "test-model",
+				ChunkCh:    make(chan string, 1),
+				CompleteCh: make(chan protocol.UsageInfo, 1),
+				ErrorCh:    make(chan protocol.InferenceErrorMessage, 1),
+			}
+			provider.AddPending(pr)
+
+			msg := tc.msg
+			msg.RequestID = pr.RequestID
+			srv.handleInferenceError(provider.ID, provider, &msg)
+
+			wantFailed := 0
+			if tc.wantFailure {
+				wantFailed = 1
+			}
+			if got := provider.Reputation.FailedJobs; got != wantFailed {
+				t.Errorf("Reputation.FailedJobs = %d, want %d", got, wantFailed)
+			}
+			// The terminal is still delivered to the consumer channel either way.
+			select {
+			case delivered := <-pr.ErrorCh:
+				if delivered.StatusCode != tc.msg.StatusCode {
+					t.Errorf("delivered status = %d, want %d", delivered.StatusCode, tc.msg.StatusCode)
+				}
+			default:
+				t.Error("terminal error was not delivered to ErrorCh")
+			}
+		})
 	}
 }
 

--- a/coordinator/api/route_outcome_tool_noncompliance_test.go
+++ b/coordinator/api/route_outcome_tool_noncompliance_test.go
@@ -1,0 +1,54 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+	"github.com/eigeninference/d-inference/coordinator/registry"
+)
+
+// E5: providers map a forced-tool_choice violation ("model did not emit the
+// required tool call" / "outside tool_choice" / "deferred content limit") to a
+// typed 422 with error_reason "tool_noncompliance". The coordinator must
+// accept the reason into durable telemetry (whitelist) and keep the 422 on the
+// normal bounded-failover path — a re-sample can comply.
+
+func TestToolNoncomplianceReasonIsWhitelisted(t *testing.T) {
+	if got := normalizeInferenceErrorReason("tool_noncompliance"); got != errorReasonToolNoncompliance {
+		t.Fatalf("normalizeInferenceErrorReason(tool_noncompliance) = %q, want %q (must not collapse to unknown)", got, errorReasonToolNoncompliance)
+	}
+	// Wire-casing variants normalize into the same reason.
+	if got := normalizeInferenceErrorReason(" Tool-Noncompliance "); got != errorReasonToolNoncompliance {
+		t.Fatalf("cased/dashed variant = %q, want %q", got, errorReasonToolNoncompliance)
+	}
+}
+
+func TestToolNoncomplianceOutcomePreservesReason(t *testing.T) {
+	pr := &registry.PendingRequest{RequestID: "r1", Model: "m"}
+	out := preCommitProviderErrorOutcome(pr, protocol.InferenceErrorMessage{
+		StatusCode:  422,
+		Error:       "model did not emit the required tool call",
+		ErrorReason: "tool_noncompliance",
+	})
+	if out.ErrorReason != errorReasonToolNoncompliance {
+		t.Fatalf("reason = %q, want %q on the route row", out.ErrorReason, errorReasonToolNoncompliance)
+	}
+}
+
+// The E4 jinja terminal stop must NOT catch a tool_noncompliance 422: the
+// violation is output-dependent (another sample / provider can comply), so
+// failover continues under the existing 422 policy.
+func TestToolNoncompliance422RemainsFailoverable(t *testing.T) {
+	d := &dispatchState{
+		s: newTestServerForDispatch(t), model: "m",
+		lastErrCode:   422,
+		lastErr:       "model did not emit the required tool call",
+		lastErrReason: "tool_noncompliance",
+	}
+	if d.shouldStopFailover() {
+		t.Fatal("a tool_noncompliance 422 must keep failing over, not stop the ladder")
+	}
+	if d.terminalClientError {
+		t.Fatal("tool_noncompliance must not latch a terminal client error")
+	}
+}

--- a/coordinator/api/toolschema.go
+++ b/coordinator/api/toolschema.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"io"
 	"slices"
+	"strings"
 )
 
 // Tool-schema normalization (DAR-130), a Go port of the Swift provider's
@@ -313,6 +314,25 @@ func injectDefaultTypesIntoSchema(dict map[string]any, depth int, changed *bool,
 	if _, present := dict["type"]; !present && (positional || looksLikeSchemaNode(dict)) {
 		dict["type"] = inferredType(dict)
 		*changed = true
+	}
+
+	// An OBJECT-typed schema node must carry a mapping `properties`. The served
+	// Gemma template's OBJECT branch otherwise falls into its
+	// `{%- elif value is mapping -%}` fallback (filter_keys=true), which
+	// iterates the node's OWN keys — `patternProperties`, `$defs`, any junk —
+	// as if each were a property schema; those containers carry no `type`, so
+	// `value['type'] | upper` throws the exact render error this normalizer
+	// exists to prevent. Mirrors the Swift twin (ToolSchemaNormalization) and
+	// gemma4 enforcement invariant 4: a missing OR non-mapping `properties` on
+	// an object-typed node becomes an empty map. Render-neutral for templates
+	// that guard on `properties` truthiness (an empty dict is falsy in Jinja),
+	// and runs AFTER type resolution so inferred-object nodes (e.g. a typeless
+	// patternProperties-only schema) are covered too.
+	if t, _ := dict["type"].(string); strings.EqualFold(t, "object") {
+		if _, isMap := dict["properties"].(map[string]any); !isMap {
+			dict["properties"] = map[string]any{}
+			*changed = true
+		}
 	}
 	return dict
 }

--- a/coordinator/api/toolschema.go
+++ b/coordinator/api/toolschema.go
@@ -178,66 +178,108 @@ func normalizeToolEntry(tool any, changed *bool) any {
 	return toolDict
 }
 
-// injectDefaultTypes recursively default-fills `type` on JSON-Schema nodes. A
-// node gets a type only when it looks like a schema node (has properties /
-// items / additionalProperties / enum / description / anyOf / oneOf / allOf)
-// — we never invent types on arbitrary maps. The inferred default favours
-// structure: object when it has properties, array when it has items,
-// otherwise string.
+// injectDefaultTypes recursively default-fills `type` on JSON-Schema nodes,
+// starting from a tool's schema home (a NON-positional root: a bare `{}`
+// parameters object stays `{}`, and a type is only invented when the map
+// carries a schema marker key — see looksLikeSchemaNode). The inferred
+// default favours structure: object when it has properties, array when it
+// has items, otherwise string.
 //
 // depth is the current nesting level (0 at each tool schema home); *changed is
 // set to true if any descendant node is repaired. At maxToolSchemaDepth we
 // stop descending and return the node UNCHANGED — the only depth-bounded path,
 // keeping unbounded recursion off the request hot path (see maxToolSchemaDepth).
 func injectDefaultTypes(node any, depth int, changed *bool) any {
+	return injectTypes(node, depth, changed, false)
+}
+
+// injectTypes is the traversal core behind injectDefaultTypes. positional
+// reports whether node sits in a SCHEMA-POSITIONAL slot — a value under
+// `properties`/`patternProperties`, `items` (including tuple-form members),
+// `prefixItems`, a map-valued `additionalProperties`, or a member of
+// `anyOf`/`oneOf`/`allOf`. JSON Schema defines every value in those slots to
+// BE a schema, so a positional value needs no marker-key evidence:
+//
+//   - a boolean (the valid JSON-Schema allow/deny-all shorthand, e.g.
+//     `"x": true` under properties) is replaced with {"type":"string"} —
+//     Gemma-style templates subscript every property value
+//     (`value['type'] | upper`), which throws on a bool;
+//   - a map is guaranteed a string `type` after recursion (missing →
+//     inferredType; present-but-non-string → collapsed, see the schema arm),
+//     with NO looksLikeSchemaNode gate — that heuristic previously let valid
+//     marker-less schemas (`{}`, const-/default-/$ref-/format-only nodes)
+//     through to crash the template's `| upper`;
+//   - arrays keep positionality for their members (tuple-form `items`,
+//     `prefixItems`, union member lists).
+//
+// Non-positional maps (the tool schema roots) keep the marker-key heuristic:
+// we still never invent types on arbitrary caller maps.
+func injectTypes(node any, depth int, changed *bool, positional bool) any {
 	if depth >= maxToolSchemaDepth {
 		return node
 	}
 	switch n := node.(type) {
+	case bool:
+		if positional {
+			*changed = true
+			return map[string]any{"type": "string"}
+		}
+		return node
 	case []any:
 		for i, v := range n {
-			n[i] = injectDefaultTypes(v, depth+1, changed)
+			n[i] = injectTypes(v, depth+1, changed, positional)
 		}
 		return n
 	case map[string]any:
-		return injectDefaultTypesIntoSchema(n, depth, changed)
+		return injectDefaultTypesIntoSchema(n, depth, changed, positional)
 	default:
 		return node
 	}
 }
 
-// injectDefaultTypesIntoSchema is the map-shaped arm of injectDefaultTypes.
+// injectDefaultTypesIntoSchema is the map-shaped arm of injectTypes.
 // Children are normalized BEFORE this node's own type is repaired — ordering
 // is load-bearing: a union member declaring `"type": ["string","null"]` must
 // collapse first so the parent's union inference sees a concrete string.
 //
-// depth/changed are threaded exactly as in injectDefaultTypes: children recurse
-// at depth+1 (through injectDefaultTypes, which re-checks the depth ceiling), and
+// depth/changed are threaded exactly as in injectTypes: children recurse at
+// depth+1 (through injectTypes, which re-checks the depth ceiling), and
 // *changed is set true the moment any node here is actually repaired (a type
-// collapsed, a missing type inferred, or nullable set), so the caller can skip
-// the re-encode when nothing moved.
-func injectDefaultTypesIntoSchema(dict map[string]any, depth int, changed *bool) map[string]any {
-	if props, ok := dict["properties"].(map[string]any); ok {
-		for k, v := range props {
-			props[k] = injectDefaultTypes(v, depth+1, changed)
+// collapsed, a missing type inferred, nullable set, or a boolean/typeless
+// positional child rewritten), so the caller can skip the re-encode when
+// nothing moved. positional is this NODE's own slot kind (see injectTypes);
+// values under the schema-container keys below are always positional.
+func injectDefaultTypesIntoSchema(dict map[string]any, depth int, changed *bool, positional bool) map[string]any {
+	for _, key := range []string{"properties", "patternProperties"} {
+		if props, ok := dict[key].(map[string]any); ok {
+			for k, v := range props {
+				props[k] = injectTypes(v, depth+1, changed, true)
+			}
 		}
 	}
 	if items, ok := dict["items"]; ok {
-		dict["items"] = injectDefaultTypes(items, depth+1, changed)
+		dict["items"] = injectTypes(items, depth+1, changed, true)
+	}
+	if prefix, ok := dict["prefixItems"].([]any); ok {
+		for i, v := range prefix {
+			prefix[i] = injectTypes(v, depth+1, changed, true)
+		}
 	}
 	// additionalProperties may itself be a schema (map-shaped params, e.g.
 	// {"additionalProperties":{"type":"string"}}) — recurse so its inner schema
-	// gets a default type too. A bare `true`/`false` is left untouched. Routed
-	// through injectDefaultTypes (not the schema arm directly) so the depth
-	// ceiling bounds an additionalProperties chain too; for an in-budget map the
-	// result is identical to processing it as a schema node.
+	// gets a default type too. A bare `true`/`false` is left untouched here (it
+	// is the standard allow/deny-all switch, is never subscripted by the
+	// templates, and rewriting it would change validation semantics for no
+	// render gain) — only the MAP-valued form is schema-positional. Routed
+	// through injectTypes so the depth ceiling bounds an additionalProperties
+	// chain too.
 	if addl, ok := dict["additionalProperties"].(map[string]any); ok {
-		dict["additionalProperties"] = injectDefaultTypes(addl, depth+1, changed)
+		dict["additionalProperties"] = injectTypes(addl, depth+1, changed, true)
 	}
 	for _, key := range schemaUnionKeys {
 		if variants, ok := dict[key].([]any); ok {
 			for i, v := range variants {
-				variants[i] = injectDefaultTypes(v, depth+1, changed)
+				variants[i] = injectTypes(v, depth+1, changed, true)
 			}
 		}
 	}
@@ -265,7 +307,10 @@ func injectDefaultTypesIntoSchema(dict map[string]any, depth int, changed *bool)
 		}
 	}
 
-	if _, present := dict["type"]; !present && looksLikeSchemaNode(dict) {
+	// A positional node IS a schema by definition, so a missing type is always
+	// filled; a non-positional map (a tool schema root) still needs marker-key
+	// evidence before we invent one.
+	if _, present := dict["type"]; !present && (positional || looksLikeSchemaNode(dict)) {
 		dict["type"] = inferredType(dict)
 		*changed = true
 	}
@@ -306,11 +351,13 @@ func collapsedType(members []string, dict map[string]any) string {
 }
 
 // looksLikeSchemaNode reports whether the map carries any JSON-Schema marker
-// key. Only such nodes receive a defaulted `type`.
+// key. Only NON-positional nodes (the tool schema roots) need this evidence
+// to receive a defaulted `type` — schema-positional values are schemas by
+// definition (see injectTypes).
 func looksLikeSchemaNode(dict map[string]any) bool {
 	for _, key := range []string{
-		"properties", "items", "additionalProperties",
-		"enum", "description", "anyOf", "oneOf", "allOf",
+		"properties", "patternProperties", "items", "prefixItems",
+		"additionalProperties", "enum", "description", "anyOf", "oneOf", "allOf",
 	} {
 		if _, ok := dict[key]; ok {
 			return true
@@ -320,17 +367,20 @@ func looksLikeSchemaNode(dict map[string]any) bool {
 }
 
 // inferredType is the structural default for a schema node's `type`: object
-// when it has properties (or additionalProperties), array when it has items,
-// a union member's type when it is an anyOf/oneOf/allOf (skipping "null" —
-// mislabelling a union as a string would be wrong), otherwise string.
+// when it has properties / patternProperties / additionalProperties, array
+// when it has items / prefixItems, a union member's type when it is an
+// anyOf/oneOf/allOf (skipping "null" — mislabelling a union as a string would
+// be wrong), otherwise string.
 func inferredType(dict map[string]any) string {
-	_, hasProps := dict["properties"]
-	_, hasAddl := dict["additionalProperties"]
-	if hasProps || hasAddl {
-		return "object"
+	for _, key := range []string{"properties", "patternProperties", "additionalProperties"} {
+		if _, ok := dict[key]; ok {
+			return "object"
+		}
 	}
-	if _, ok := dict["items"]; ok {
-		return "array"
+	for _, key := range []string{"items", "prefixItems"} {
+		if _, ok := dict[key]; ok {
+			return "array"
+		}
 	}
 	if t, ok := unionMemberType(dict); ok {
 		return t

--- a/coordinator/api/toolschema_corpus_test.go
+++ b/coordinator/api/toolschema_corpus_test.go
@@ -1,0 +1,268 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+// The E1 crash corpus (2026-07-15 platform errors deep dive): valid JSON-Schema
+// shapes that the marker-key heuristic (looksLikeSchemaNode) let through
+// untyped, crashing the served Gemma template's `{{ value['type'] | upper }}`
+// with "Runtime error: upper filter requires string" (23,134 provider 500s per
+// day). Positional awareness fixes them: ANY value under properties /
+// patternProperties / items / prefixItems / map-valued additionalProperties /
+// anyOf / oneOf / allOf IS a schema and is guaranteed a string `type`.
+
+// A property schema that is a bare `{}` — the "anything" schema, valid and
+// emitted by real SDKs for untyped params — must gain {"type":"string"}.
+func TestNormalizeToolSchemas_Corpus_EmptyPropertySchema(t *testing.T) {
+	body := []byte(`{"tools":[{"type":"function","function":{"name":"f",
+	  "parameters":{"type":"object","properties":{"x":{}}}}}]}`)
+
+	x := tsnMap(t, tsnProps(t, NormalizeToolSchemas(body))["x"], "x")
+	if got := tsnType(t, x, "x"); got != "string" {
+		t.Errorf("x type = %q, want string", got)
+	}
+}
+
+// Property schemas whose ONLY content is a non-marker annotation/validation
+// key (const / default / title / format / pattern / $ref / minimum /
+// maxLength) are valid JSON Schema, carried no marker key, and previously
+// stayed typeless. Every one must gain a string type with its original key
+// preserved.
+func TestNormalizeToolSchemas_Corpus_MarkerlessAnnotationOnlyNodes(t *testing.T) {
+	cases := map[string]string{
+		"const-only":     `{"const":"fixed"}`,
+		"default-only":   `{"default":5}`,
+		"title-only":     `{"title":"T"}`,
+		"format-only":    `{"format":"date-time"}`,
+		"pattern-only":   `{"pattern":"^a"}`,
+		"ref-only":       `{"$ref":"#/$defs/x"}`,
+		"minimum-only":   `{"minimum":1}`,
+		"maxLength-only": `{"maxLength":10}`,
+	}
+	for name, schema := range cases {
+		body := []byte(`{"tools":[{"type":"function","function":{"name":"f",
+		  "parameters":{"type":"object","properties":{"x":` + schema + `}}}}]}`)
+		out := NormalizeToolSchemas(body)
+		x := tsnMap(t, tsnProps(t, out)["x"], name)
+		if got := tsnType(t, x, name); got != "string" {
+			t.Errorf("%s: type = %q, want string", name, got)
+		}
+		// The original annotation key survives beside the injected type.
+		if len(x) != 2 {
+			t.Errorf("%s: node = %#v, want original key + injected type only", name, x)
+		}
+	}
+}
+
+// Boolean property schemas (`"x": true` / `"y": false`) are valid JSON Schema
+// (allow-all / deny-all). The template subscripts every property value, so
+// booleans must be replaced with {"type":"string"}.
+func TestNormalizeToolSchemas_Corpus_BooleanPropertySchemas(t *testing.T) {
+	body := []byte(`{"tools":[{"type":"function","function":{"name":"f",
+	  "parameters":{"type":"object","properties":{"x":true,"y":false}}}}]}`)
+
+	props := tsnProps(t, NormalizeToolSchemas(body))
+	for _, name := range []string{"x", "y"} {
+		node := tsnMap(t, props[name], name)
+		if !reflect.DeepEqual(node, map[string]any{"type": "string"}) {
+			t.Errorf("%s = %#v, want {\"type\":\"string\"}", name, node)
+		}
+	}
+}
+
+// A boolean `items` value (valid: `items: true`) is schema-positional too.
+func TestNormalizeToolSchemas_Corpus_BooleanItems(t *testing.T) {
+	body := []byte(`{"tools":[{"type":"function","function":{"name":"f",
+	  "parameters":{"type":"object","properties":{"arr":{"type":"array","items":true}}}}}]}`)
+
+	arr := tsnMap(t, tsnProps(t, NormalizeToolSchemas(body))["arr"], "arr")
+	items := tsnMap(t, arr["items"], "arr.items")
+	if !reflect.DeepEqual(items, map[string]any{"type": "string"}) {
+		t.Errorf("items = %#v, want {\"type\":\"string\"}", items)
+	}
+}
+
+// A scalar non-string `type` (e.g. `"type": 123`) collapses to the structural
+// inference instead of reaching `| upper` as a number.
+func TestNormalizeToolSchemas_Corpus_ScalarNonStringType(t *testing.T) {
+	body := []byte(`{"tools":[{"type":"function","function":{"name":"f",
+	  "parameters":{"type":"object","properties":{
+	    "n":{"type":123},
+	    "b":{"type":true},
+	    "o":{"type":42,"properties":{"inner":{}}}}}}}]}`)
+
+	props := tsnProps(t, NormalizeToolSchemas(body))
+	if got := tsnType(t, tsnMap(t, props["n"], "n"), "n"); got != "string" {
+		t.Errorf("n type = %q, want string", got)
+	}
+	if got := tsnType(t, tsnMap(t, props["b"], "b"), "b"); got != "string" {
+		t.Errorf("b type = %q, want string", got)
+	}
+	o := tsnMap(t, props["o"], "o")
+	if got := tsnType(t, o, "o"); got != "object" {
+		t.Errorf("o type = %q, want object (inferred from properties)", got)
+	}
+	inner := tsnMap(t, tsnMap(t, o["properties"], "o.properties")["inner"], "inner")
+	if got := tsnType(t, inner, "inner"); got != "string" {
+		t.Errorf("o.properties.inner type = %q, want string", got)
+	}
+}
+
+// patternProperties values are schemas and are traversed like properties.
+func TestNormalizeToolSchemas_Corpus_PatternProperties(t *testing.T) {
+	body := []byte(`{"tools":[{"type":"function","function":{"name":"f",
+	  "parameters":{"type":"object","properties":{
+	    "env":{"type":"object","patternProperties":{"^ENV_":{},"^NUM_":{"minimum":0},"^ANY_":true}}}}}}]}`)
+
+	env := tsnMap(t, tsnProps(t, NormalizeToolSchemas(body))["env"], "env")
+	pp := tsnMap(t, env["patternProperties"], "env.patternProperties")
+	for _, name := range []string{"^ENV_", "^NUM_", "^ANY_"} {
+		node := tsnMap(t, pp[name], name)
+		if got := tsnType(t, node, name); got != "string" {
+			t.Errorf("patternProperties[%q] type = %q, want string", name, got)
+		}
+	}
+	// A typeless node whose only marker is patternProperties infers "object".
+	body2 := []byte(`{"tools":[{"type":"function","function":{"name":"f",
+	  "parameters":{"type":"object","properties":{"env":{"patternProperties":{"^X_":{"type":"string"}}}}}}}]}`)
+	env2 := tsnMap(t, tsnProps(t, NormalizeToolSchemas(body2))["env"], "env2")
+	if got := tsnType(t, env2, "env2"); got != "object" {
+		t.Errorf("patternProperties-only node type = %q, want object", got)
+	}
+}
+
+// prefixItems members (2020-12 tuple schemas) are schemas; the node itself
+// infers "array" from prefixItems.
+func TestNormalizeToolSchemas_Corpus_PrefixItems(t *testing.T) {
+	body := []byte(`{"tools":[{"type":"function","function":{"name":"f",
+	  "parameters":{"type":"object","properties":{
+	    "pair":{"prefixItems":[{},{"const":1},true]}}}}}]}`)
+
+	pair := tsnMap(t, tsnProps(t, NormalizeToolSchemas(body))["pair"], "pair")
+	if got := tsnType(t, pair, "pair"); got != "array" {
+		t.Errorf("pair type = %q, want array (inferred from prefixItems)", got)
+	}
+	prefix, ok := pair["prefixItems"].([]any)
+	if !ok || len(prefix) != 3 {
+		t.Fatalf("prefixItems = %v, want 3 members", pair["prefixItems"])
+	}
+	for i, member := range prefix {
+		node := tsnMap(t, member, "prefixItems member")
+		if got := tsnType(t, node, "prefixItems member"); got != "string" {
+			t.Errorf("prefixItems[%d] type = %q, want string", i, got)
+		}
+	}
+}
+
+// Tuple-form `items` (draft-04 array form) members are schema-positional.
+func TestNormalizeToolSchemas_Corpus_TupleFormItems(t *testing.T) {
+	body := []byte(`{"tools":[{"type":"function","function":{"name":"f",
+	  "parameters":{"type":"object","properties":{
+	    "tup":{"type":"array","items":[{},false]}}}}}]}`)
+
+	tup := tsnMap(t, tsnProps(t, NormalizeToolSchemas(body))["tup"], "tup")
+	items, ok := tup["items"].([]any)
+	if !ok || len(items) != 2 {
+		t.Fatalf("items = %v, want 2 members", tup["items"])
+	}
+	for i, member := range items {
+		node := tsnMap(t, member, "items member")
+		if got := tsnType(t, node, "items member"); got != "string" {
+			t.Errorf("items[%d] type = %q, want string", i, got)
+		}
+	}
+}
+
+// Union members are schema-positional even when marker-less.
+func TestNormalizeToolSchemas_Corpus_MarkerlessUnionMembers(t *testing.T) {
+	body := []byte(`{"tools":[{"type":"function","function":{"name":"f",
+	  "parameters":{"type":"object","properties":{
+	    "u":{"anyOf":[{},{"const":3}]},
+	    "o":{"oneOf":[{"format":"uuid"}]},
+	    "a":{"allOf":[{}]}}}}}]}`)
+
+	props := tsnProps(t, NormalizeToolSchemas(body))
+	for name, key := range map[string]string{"u": "anyOf", "o": "oneOf", "a": "allOf"} {
+		node := tsnMap(t, props[name], name)
+		members, ok := node[key].([]any)
+		if !ok || len(members) == 0 {
+			t.Fatalf("%s.%s = %v, want non-empty array", name, key, node[key])
+		}
+		for i, member := range members {
+			m := tsnMap(t, member, key+" member")
+			if got := tsnType(t, m, key+" member"); got != "string" {
+				t.Errorf("%s.%s[%d] type = %q, want string", name, key, i, got)
+			}
+		}
+	}
+}
+
+// A map-valued additionalProperties that is a bare `{}` is schema-positional
+// and gains a type (the bool form stays untouched — see
+// TestNormalizeToolSchemas_BareAdditionalPropertiesBoolUntouched).
+func TestNormalizeToolSchemas_Corpus_EmptyMapAdditionalProperties(t *testing.T) {
+	body := []byte(`{"tools":[{"type":"function","function":{"name":"f",
+	  "parameters":{"type":"object","properties":{
+	    "meta":{"type":"object","additionalProperties":{}}}}}}]}`)
+
+	meta := tsnMap(t, tsnProps(t, NormalizeToolSchemas(body))["meta"], "meta")
+	addl := tsnMap(t, meta["additionalProperties"], "meta.additionalProperties")
+	if got := tsnType(t, addl, "additionalProperties"); got != "string" {
+		t.Errorf("additionalProperties type = %q, want string", got)
+	}
+}
+
+// Positional awareness must NOT leak to non-positional maps: a bare `{}`
+// parameters ROOT stays `{}` (the template treats empty params as absent), and
+// a marker-less junk map at the root is not typed either.
+func TestNormalizeToolSchemas_Corpus_RootStaysMarkerGated(t *testing.T) {
+	body := []byte(`{"tools":[` +
+		`{"type":"function","function":{"name":"noargs","parameters":{}}},` +
+		`{"type":"function","function":{"name":"junk","parameters":{"foo":"bar"}}}]}`)
+
+	out := NormalizeToolSchemas(body)
+	if !bytes.Equal(out, body) {
+		t.Fatalf("marker-less roots must not be repaired (no re-encode):\n in: %s\nout: %s", body, out)
+	}
+}
+
+// The corpus normalization is idempotent (second pass returns identical bytes).
+func TestNormalizeToolSchemas_Corpus_Idempotent(t *testing.T) {
+	body := []byte(`{"tools":[{"type":"function","function":{"name":"f",
+	  "parameters":{"type":"object","properties":{
+	    "x":{},"b":true,"n":{"type":123},
+	    "env":{"type":"object","patternProperties":{"^E_":{}}},
+	    "pair":{"prefixItems":[{}]},
+	    "u":{"anyOf":[{}]}},
+	  "patternProperties":{"^root_":{"default":1}}}}}]}`)
+
+	once := NormalizeToolSchemas(body)
+	if bytes.Equal(once, body) {
+		t.Fatal("first pass did not normalize")
+	}
+	twice := NormalizeToolSchemas(once)
+	if !bytes.Equal(once, twice) {
+		t.Errorf("not idempotent:\n once: %s\ntwice: %s", once, twice)
+	}
+	// And the repaired document is valid JSON with all corpus nodes typed.
+	var decoded map[string]any
+	if err := json.Unmarshal(once, &decoded); err != nil {
+		t.Fatalf("normalized body is not valid JSON: %v", err)
+	}
+}
+
+// Depth ceiling still bounds the positional traversal: a chain nested past
+// maxToolSchemaDepth returns the deep tail unrepaired (and unchanged).
+func TestNormalizeToolSchemas_Corpus_DepthCeilingStillHolds(t *testing.T) {
+	body := tsnDeepPropertiesBody(maxToolSchemaDepth + 4)
+	out := NormalizeToolSchemas(body)
+	// The document normalizes (outer levels gain types) without hanging or
+	// blowing the stack; the leaf past the ceiling is allowed to stay typeless.
+	if bytes.Equal(out, body) {
+		t.Fatal("outer levels above the ceiling should still normalize")
+	}
+}

--- a/coordinator/api/toolschema_corpus_test.go
+++ b/coordinator/api/toolschema_corpus_test.go
@@ -266,3 +266,43 @@ func TestNormalizeToolSchemas_Corpus_DepthCeilingStillHolds(t *testing.T) {
 		t.Fatal("outer levels above the ceiling should still normalize")
 	}
 }
+
+// The served Gemma template's OBJECT branch falls back to iterating a node's
+// OWN keys (`filter_keys=true`) when `properties` is missing or not a mapping;
+// containers like patternProperties carry no `type`, so `| upper` throws.
+// Every object-typed node must therefore end with a mapping `properties`
+// (Swift twin parity: ToolSchemaNormalization + gemma4 enforcement inv. 4).
+func TestNormalizeToolSchemas_Corpus_ObjectNodesAlwaysCarryProperties(t *testing.T) {
+	// Codex P2 shape: explicit object with patternProperties but no properties.
+	body := []byte(`{"tools":[{"type":"function","function":{"name":"f",
+	  "parameters":{"type":"object","properties":{
+	    "env":{"type":"object","patternProperties":{"^ENV_":{"type":"string"}}}}}}}]}`)
+	env := tsnMap(t, tsnProps(t, NormalizeToolSchemas(body))["env"], "env")
+	injected, ok := env["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("object node with patternProperties must gain a properties map, got %T", env["properties"])
+	}
+	if len(injected) != 0 {
+		t.Errorf("injected properties = %v, want empty", injected)
+	}
+
+	// A typeless patternProperties-only node infers "object" and must gain it too.
+	body2 := []byte(`{"tools":[{"type":"function","function":{"name":"f",
+	  "parameters":{"type":"object","properties":{"env":{"patternProperties":{"^X_":{"type":"string"}}}}}}}]}`)
+	env2 := tsnMap(t, tsnProps(t, NormalizeToolSchemas(body2))["env"], "env2")
+	if got := tsnType(t, env2, "env2"); got != "object" {
+		t.Fatalf("inferred type = %q, want object", got)
+	}
+	if _, ok := env2["properties"].(map[string]any); !ok {
+		t.Fatalf("inferred-object node must gain a properties map, got %T", env2["properties"])
+	}
+
+	// Non-mapping properties on an object node is replaced with an empty map
+	// (the template's `is mapping` guard would otherwise re-expose the fallback).
+	body3 := []byte(`{"tools":[{"type":"function","function":{"name":"f",
+	  "parameters":{"type":"object","properties":{"o":{"type":"object","properties":"junk"}}}}}]}`)
+	o := tsnMap(t, tsnProps(t, NormalizeToolSchemas(body3))["o"], "o")
+	if _, ok := o["properties"].(map[string]any); !ok {
+		t.Fatalf("non-mapping properties must become an empty map, got %T", o["properties"])
+	}
+}

--- a/provider-swift/Package.swift
+++ b/provider-swift/Package.swift
@@ -211,6 +211,11 @@ let package = Package(
                 "ProviderBenchmark",
                 .product(name: "HummingbirdTesting", package: "hummingbird"),
                 .product(name: "HummingbirdWebSocket", package: "hummingbird-websocket"),
+                // Direct Jinja access for the served-template render
+                // regression (Gemma4ServedTemplateRenderTests) — the
+                // normalizers under test live in ProviderCore, which
+                // ProviderCoreFoundationTests cannot link.
+                .product(name: "Jinja", package: "swift-jinja"),
             ],
             path: "Tests/ProviderCoreTests"
         ),

--- a/provider-swift/Sources/ProviderCore/Inference/Gemma4TemplateFixes.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/Gemma4TemplateFixes.swift
@@ -1,7 +1,15 @@
 // Copyright © 2026 Eigen Labs.
 //
-// Gemma 4 currently uses the upstream/MLX template directly. Keep this explicit
-// no-op hook so future Gemma-specific template fixes stay separate from GPT-OSS.
+// Gemma 4 uses the upstream/MLX chat template directly (byte-identical to
+// mlx-community/gemma-4-26b-a4b-it-qat-4bit, sha 94899c0f…). That template has
+// request-shape landmines the fixes here defuse in code — the artifact is NOT
+// repinned (2026-07-15 platform errors deep dive, E1/E2/E3):
+//
+//   • `format_parameters` renders `{{ value['type'] | upper }}` over every
+//     tool property → `normalizeTools` enforces "every property value is a
+//     mapping with a String type" (Gemma4ToolSchemaEnforcement).
+//
+// Mirrors the per-model hook pattern of `GPTOSSHarmonyTemplateFix`.
 
 enum Gemma4TemplateFix {
     static func applies(to context: ChatTemplateFixContext) -> Bool {
@@ -20,7 +28,7 @@ enum Gemma4TemplateFix {
     static func normalizeTools(
         _ tools: [[String: any Sendable]]
     ) -> [[String: any Sendable]] {
-        tools
+        Gemma4ToolSchemaEnforcement.normalizeToolSpecs(tools)
     }
 
     static func extraEOSTokenIds(tokenToId: (String) -> Int?) -> Set<Int> {

--- a/provider-swift/Sources/ProviderCore/Inference/Gemma4TemplateFixes.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/Gemma4TemplateFixes.swift
@@ -8,6 +8,11 @@
 //   • `format_parameters` renders `{{ value['type'] | upper }}` over every
 //     tool property → `normalizeTools` enforces "every property value is a
 //     mapping with a String type" (Gemma4ToolSchemaEnforcement).
+//   • the tool-response forward scan only reads the CONTIGUOUS run after an
+//     assistant tool_calls message, and consecutive assistant text turns
+//     close/continue incorrectly → `normalizeMessages` re-pairs results,
+//     rejects orphans as 400, and merges dangling assistant text
+//     (Gemma4TurnStructure).
 //
 // Mirrors the per-model hook pattern of `GPTOSSHarmonyTemplateFix`.
 
@@ -22,7 +27,7 @@ enum Gemma4TemplateFix {
     static func normalizeMessages(
         _ messages: [[String: any Sendable]]
     ) throws -> [[String: any Sendable]] {
-        messages
+        try Gemma4TurnStructure.normalizeMessages(messages)
     }
 
     static func normalizeTools(

--- a/provider-swift/Sources/ProviderCore/Inference/Gemma4TemplateFixes.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/Gemma4TemplateFixes.swift
@@ -13,6 +13,10 @@
 //     close/continue incorrectly → `normalizeMessages` re-pairs results,
 //     rejects orphans as 400, and merges dangling assistant text
 //     (Gemma4TurnStructure).
+//   • a raw-string `tool_calls[].function.arguments` (empty / malformed /
+//     non-object JSON survives the engine decode as a String) renders as
+//     double-brace garbage the model then imitates → `normalizeMessages`
+//     parses or rejects it first (Gemma4ToolCallArguments).
 //
 // Mirrors the per-model hook pattern of `GPTOSSHarmonyTemplateFix`.
 
@@ -27,7 +31,8 @@ enum Gemma4TemplateFix {
     static func normalizeMessages(
         _ messages: [[String: any Sendable]]
     ) throws -> [[String: any Sendable]] {
-        try Gemma4TurnStructure.normalizeMessages(messages)
+        let hardened = try Gemma4ToolCallArguments.normalizeMessages(messages)
+        return try Gemma4TurnStructure.normalizeMessages(hardened)
     }
 
     static func normalizeTools(

--- a/provider-swift/Sources/ProviderCore/Inference/Gemma4ToolCallArguments.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/Gemma4ToolCallArguments.swift
@@ -1,0 +1,78 @@
+// Copyright © 2026 Eigen Labs.
+//
+// Gemma4 tool-call `arguments` hardening (E3, 2026-07-15 platform errors deep
+// dive). By the time chat-template dicts reach the model fix hooks,
+// `tool_calls[].function.arguments` is either a decoded JSON object or the
+// RAW STRING: the engine's `decodeToolCallArguments`
+// (libs/mlx-swift-lm .../ParserUtilities.swift) returns the string unchanged
+// when it is empty, malformed, or valid-but-non-object JSON. The served Gemma
+// template's `{%- elif function['arguments'] is string -%}` branch then dumps
+// that string verbatim inside its own `call:name{…}` braces, producing the
+// double-brace corruption `call:f{{"a":1}}` — which the model imitates on the
+// next turn and the output parser shreds.
+//
+// Repair at the gemma4 hook (provider-side; the engine submodule is not
+// touched):
+//   • arguments missing / empty (or whitespace-only) → `{}` (renders an
+//     empty argument list);
+//   • arguments a String → parse as JSON; a JSON OBJECT replaces the string
+//     (null leaves re-stripped — the raw string bypassed the earlier
+//     sanitize pass);
+//   • parse failure or JSON non-object (array / scalar / null) → throw
+//     `invalidToolPayload` (deterministic 400) instead of rendering garbage.
+
+import Foundation
+
+enum Gemma4ToolCallArguments {
+
+    static func normalizeMessages(
+        _ messages: [[String: any Sendable]]
+    ) throws -> [[String: any Sendable]] {
+        try messages.map { message in
+            guard (message["role"] as? String) == "assistant",
+                let calls = message["tool_calls"] as? [any Sendable], !calls.isEmpty
+            else { return message }
+            var output = message
+            output["tool_calls"] =
+                try calls.map { call -> any Sendable in
+                    guard var callMap = call as? [String: any Sendable],
+                        var function = callMap["function"] as? [String: any Sendable]
+                    else { return call }
+                    function["arguments"] = try normalizedArguments(function["arguments"])
+                    callMap["function"] = function
+                    return callMap
+                } as [any Sendable]
+            return output
+        }
+    }
+
+    private static func normalizedArguments(
+        _ raw: (any Sendable)?
+    ) throws -> [String: any Sendable] {
+        guard let raw else { return [:] }
+        if let mapping = raw as? [String: any Sendable] {
+            return mapping
+        }
+        if let text = raw as? String {
+            if text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                return [:]
+            }
+            guard let data = text.data(using: .utf8),
+                let decoded = try? JSONSerialization.jsonObject(
+                    with: data, options: [.fragmentsAllowed]),
+                let object = decoded as? [String: any Sendable]
+            else {
+                throw MultiModelBatchSchedulerEngineError.invalidToolPayload(
+                    "tool_calls[].function.arguments must be a JSON object")
+            }
+            // The raw string bypassed the earlier message-level null strip;
+            // re-sanitize so a `{"a":null}` payload cannot re-introduce an
+            // NSNull leaf the Jinja value bridge throws on.
+            return sanitizeJinjaObject(object)
+        }
+        // A non-string non-mapping shape (array / number / bool) is not an
+        // OpenAI arguments payload.
+        throw MultiModelBatchSchedulerEngineError.invalidToolPayload(
+            "tool_calls[].function.arguments must be a JSON object")
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Inference/Gemma4ToolSchemaEnforcement.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/Gemma4ToolSchemaEnforcement.swift
@@ -1,0 +1,187 @@
+// Copyright © 2026 Eigen Labs.
+//
+// Gemma4-specific tool-spec enforcement (E1 last line of defense, 2026-07-15
+// platform errors deep dive). The served Gemma template's
+// `format_parameters` macro renders `{{ value['type'] | upper }}` (and
+// subscripts `value['description']` / `value['items']` / …) over EVERY
+// property value it iterates, and `format_function_declaration` only closes
+// its `parameters:{` block inside the `params['type']` branch. The shared
+// normalizers (`ToolSchemaNormalization` here; `NormalizeToolSchemas` on the
+// coordinator) repair schemas exhaustively, but this walk is the FINAL
+// invariant for gemma4 even when a caller bypasses them:
+//
+//   1. `function.parameters`, when present, is a mapping — a non-mapping (or
+//      an empty one) is dropped so the template's `{%- if params -%}` guard
+//      skips the block instead of opening an unclosable `parameters:{`.
+//   2. Every property value is a MAPPING with a String `type` (scalars that
+//      the shared normalizer deliberately leaves — e.g. `"x": 5` — become
+//      `{"type":"string"}`; a bool is already rewritten by the shared pass).
+//   3. A non-empty parameters root carries a String `type` (the macro renders
+//      `params['type'] | upper` and the closing brace lives in that branch).
+//   4. An OBJECT-typed node without a mapping `properties` gains
+//      `properties: {}` — otherwise the template's
+//      `{%- elif value is mapping -%}` fallback iterates the node's OWN
+//      non-standard keys as if they were property schemas (the
+//      `filter_keys=true` branch), subscripting arbitrary junk.
+//   5. `required` members are coerced to strings (scalars stringified,
+//      composites dropped); a non-array `required` is removed.
+//   6. `description` values the template interpolates are coerced to strings.
+//
+// Mirrors the per-model precedent of `GPTOSSHarmonyTemplateFix.normalizeTools`.
+
+import Foundation
+
+enum Gemma4ToolSchemaEnforcement {
+
+    static func normalizeToolSpecs(
+        _ tools: [[String: any Sendable]]
+    ) -> [[String: any Sendable]] {
+        tools.map(normalizeToolSpec)
+    }
+
+    private static func normalizeToolSpec(
+        _ tool: [String: any Sendable]
+    ) -> [String: any Sendable] {
+        var output = tool
+        guard var function = output["function"] as? [String: any Sendable] else {
+            return output
+        }
+        // format_function_declaration string-concatenates the name and renders
+        // the description unconditionally — both must be strings.
+        function["name"] = stringValue(function["name"]) ?? ""
+        function["description"] = stringValue(function["description"]) ?? ""
+        if let parameters = function["parameters"] {
+            if let normalized = normalizeParametersValue(parameters) {
+                function["parameters"] = normalized
+            } else {
+                function.removeValue(forKey: "parameters")
+            }
+        }
+        output["function"] = function
+        return output
+    }
+
+    /// Normalize one `function.parameters` value. Returns nil when the value
+    /// cannot be rendered as a parameters mapping (non-mapping, or empty after
+    /// normalization) — the caller then REMOVES the key so the template's
+    /// `{%- if params -%}` guard is falsy regardless of how the Jinja runtime
+    /// treats empty mappings.
+    private static func normalizeParametersValue(
+        _ parameters: any Sendable
+    ) -> [String: any Sendable]? {
+        guard let mapping = parameters as? [String: any Sendable] else { return nil }
+        if mapping.isEmpty { return nil }
+        // Exhaustive shared normalization first (the positional rule), then the
+        // gemma-specific render invariants on top.
+        let injected =
+            ToolSchemaNormalization.injectDefaultTypes(mapping)
+            as? [String: any Sendable] ?? mapping
+        var root = enforceSchemaNode(injected)
+        // Invariant 3: the closing `}` of `parameters:{` is only emitted inside
+        // the `params['type']` branch, and that branch upper-cases the value.
+        if !(root["type"] is String) {
+            root["type"] = "object"
+        }
+        return root
+    }
+
+    /// Recursive gemma render invariants for one schema node (the parameters
+    /// root or any nested schema the template can reach through `properties` /
+    /// `items`).
+    private static func enforceSchemaNode(
+        _ node: [String: any Sendable]
+    ) -> [String: any Sendable] {
+        var output = node
+
+        // Invariant 6: `{%- if value['description'] -%}` + interpolation — a
+        // truthy non-string could throw in the interpolation; coerce.
+        if let description = output["description"], !(description is String) {
+            output["description"] = stringValue(description) ?? ""
+        }
+
+        // Invariant 2: every property value is a mapping with a String type.
+        if let props = output["properties"] {
+            if let mapping = props as? [String: any Sendable] {
+                output["properties"] = mapping.mapValues(enforcePropertyValue)
+            } else {
+                // A non-mapping `properties` fails the template's `is mapping`
+                // guard AND re-exposes the filter_keys fallback — replace with
+                // an empty mapping so the safe branch is taken.
+                output["properties"] = [String: any Sendable]()
+            }
+        }
+
+        // Invariant 4: OBJECT-typed nodes must carry a mapping `properties` so
+        // the template never falls back to iterating the node's own keys.
+        if let type = output["type"] as? String, type.uppercased() == "OBJECT",
+            !(output["properties"] is [String: any Sendable]) {
+            output["properties"] = [String: any Sendable]()
+        }
+
+        // Invariant 5: required member coercion.
+        if let required = output["required"] {
+            if let members = required as? [any Sendable] {
+                output["required"] = members.compactMap(requiredMemberString)
+            } else {
+                output.removeValue(forKey: "required")
+            }
+        }
+
+        // The template recurses into a mapping `items` (dictsorting its keys
+        // and rendering nested `properties`/`required`/`type`); enforce there
+        // too. Non-mapping items are skipped by the template's `is mapping`
+        // guard and stay as the shared normalizer left them.
+        if let items = output["items"] as? [String: any Sendable] {
+            output["items"] = enforceSchemaNode(items)
+        }
+
+        return output
+    }
+
+    /// A property value the template iterates: must be a mapping with a String
+    /// `type` (`value['type'] | upper` renders unconditionally).
+    private static func enforcePropertyValue(
+        _ value: any Sendable
+    ) -> any Sendable {
+        guard let mapping = value as? [String: any Sendable] else {
+            return ["type": "string"] as [String: any Sendable]
+        }
+        var output = enforceSchemaNode(mapping)
+        if !(output["type"] is String) {
+            output["type"] = inferredPropertyType(output)
+        }
+        return output
+    }
+
+    /// Structural default mirroring the shared normalizer's inference for the
+    /// defensive re-check (the shared pass normally already injected one).
+    private static func inferredPropertyType(
+        _ dict: [String: any Sendable]
+    ) -> String {
+        if dict["properties"] != nil || dict["patternProperties"] != nil
+            || dict["additionalProperties"] != nil {
+            return "object"
+        }
+        if dict["items"] != nil || dict["prefixItems"] != nil {
+            return "array"
+        }
+        return "string"
+    }
+
+    /// `required` members render as `<|"|>{{- item -}}<|"|>`: strings pass,
+    /// scalar non-strings are stringified, composites (maps/arrays) are
+    /// dropped rather than interpolating a Swift repr into the prompt.
+    private static func requiredMemberString(_ member: any Sendable) -> String? {
+        if let s = member as? String { return s }
+        if member is [String: any Sendable] || member is [any Sendable] { return nil }
+        if member is NSNull { return nil }
+        return String(describing: member)
+    }
+
+    private static func stringValue(_ value: Any?) -> String? {
+        guard let value else { return nil }
+        if let string = value as? String { return string }
+        if value is NSNull { return nil }
+        return String(describing: value)
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Inference/Gemma4TurnStructure.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/Gemma4TurnStructure.swift
@@ -78,6 +78,9 @@ enum Gemma4TurnStructure {
         // the id-less tail.
         var pairedResults: [Int: [String: [[String: any Sendable]]]] = [:]
         var idlessResults: [Int: [[String: any Sendable]]] = [:]
+        // Highest ORIGINAL index observed among each owner's collected results —
+        // the boundary for the trailing-turn exemption below.
+        var lastResultIndexByOwner: [Int: Int] = [:]
 
         for (index, message) in messages.enumerated() {
             let role = message["role"] as? String
@@ -89,6 +92,7 @@ enum Gemma4TurnStructure {
                         )
                     }
                     pairedResults[owner, default: [:]][id, default: []].append(message)
+                    lastResultIndexByOwner[owner] = index
                 } else {
                     guard let owner = lastToolCallTurn else {
                         // validateGenericToolHistory already rejects this; keep
@@ -97,6 +101,7 @@ enum Gemma4TurnStructure {
                             "tool message has no preceding assistant tool_calls")
                     }
                     idlessResults[owner, default: []].append(message)
+                    lastResultIndexByOwner[owner] = index
                 }
                 continue
             }
@@ -120,6 +125,28 @@ enum Gemma4TurnStructure {
             out.append(message)
             let calls = toolCalls(of: message)
             guard !calls.isEmpty else { continue }
+
+            // A declared call id with neither a paired result nor an id-less
+            // result to cover it leaves the served template's forward scan
+            // answerless — exactly the dangling `<|tool_response>` shape this
+            // repair exists to prevent — so a MID-HISTORY unanswered turn
+            // fails closed as a clean 400. TRAILING exemption: when nothing
+            // follows the turn (and its collected results) in the original
+            // sequence, the history legitimately ends awaiting the model's
+            // continuation, and the template's own tool_call-terminal branch
+            // handles it; that shape passes through unchanged.
+            let paired = pairedResults[index] ?? [:]
+            let unanswered = calls.compactMap(callID).filter { paired[$0] == nil }
+            let uncovered = unanswered.count - (idlessResults[index] ?? []).count
+            if uncovered > 0 {
+                let boundary = max(index, lastResultIndexByOwner[index] ?? index)
+                if boundary < messages.count - 1 {
+                    throw MultiModelBatchSchedulerEngineError.invalidToolPayload(
+                        "assistant tool_call ids [\(unanswered.joined(separator: ", "))] "
+                            + "have no tool results before the next message")
+                }
+            }
+
             var byID = pairedResults[index] ?? [:]
             // The template's forward scan reads results in listed order; the
             // tool_calls order is the canonical one.

--- a/provider-swift/Sources/ProviderCore/Inference/Gemma4TurnStructure.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/Gemma4TurnStructure.swift
@@ -197,10 +197,19 @@ enum Gemma4TurnStructure {
                 output["content"] = prefix
             }
         }
-        // Don't silently lose the earlier turn's reasoning when the later one
-        // has none of its own.
+        // Never lose the earlier turn's reasoning: carry it when the later
+        // turn has none, and concatenate (earlier first, the same "\n\n" join
+        // the content path uses) when both turns carry the same key. The
+        // served template only renders reasoning on tool_call-bearing turns,
+        // so this is render-neutral today — but the repair contract is that
+        // normalization never drops history data.
         for key in ["thinking", "reasoning", "reasoning_content"] {
-            if output[key] == nil, let carried = earlier[key] as? String, !carried.isEmpty {
+            guard let carried = earlier[key] as? String,
+                !carried.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            else { continue }
+            if let existing = output[key] as? String, !existing.isEmpty {
+                output[key] = carried + "\n\n" + existing
+            } else {
                 output[key] = carried
             }
         }

--- a/provider-swift/Sources/ProviderCore/Inference/Gemma4TurnStructure.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/Gemma4TurnStructure.swift
@@ -1,0 +1,209 @@
+// Copyright © 2026 Eigen Labs.
+//
+// Gemma4 turn-structure normalization (E2, 2026-07-15 platform errors deep
+// dive). The served Gemma template (sha 94899c0f…) has two history-shape
+// landmines that Google's 2026-07-09 canonical template fixes upstream; the
+// artifact is NOT repinned, so the equivalent repairs ship here in code:
+//
+//   1. After an assistant `tool_calls` message the template FORWARD-SCANS
+//      only the CONTIGUOUS run of `role:"tool"` messages that immediately
+//      follow it. Results that are not contiguous (e.g. answered under a
+//      later assistant's run, or ordered across two back-to-back tool_call
+//      turns) are rendered under the wrong turn — and when the scan finds
+//      nothing at all the turn emits a dangling `<|tool_response>` opener
+//      (`ns_tr_out.flag` unset) instead of a closed turn. Repair: re-emit
+//      each assistant's answering tool results as one contiguous block
+//      immediately after it, ordered by its tool_calls order.
+//
+//   2. Consecutive assistant messages render as one "continued" model turn
+//      (`continue_same_model_turn` suppresses the second `<|turn>model`
+//      opener) — but a TEXT-only assistant message has already CLOSED the
+//      turn (`<turn|>`), so the follow-up text floats outside any opener.
+//      Repair: merge a text-only assistant message into an immediately
+//      following assistant message (its content becomes a `\n\n`-joined
+//      prefix), so consecutive assistant turns render one closed turn.
+//
+// A `role:"tool"` message whose `tool_call_id` answers NO preceding assistant
+// tool_call cannot be placed anywhere — that is a malformed history and
+// throws `invalidToolPayload` (clean 400), mirroring the Harmony splitter's
+// orphan rule (`GPTOSSHarmonyTemplateFixes.splitParallelToolCalls`).
+//
+// Runs AFTER `ChatTemplateFixes.validateGenericToolHistory`, which guarantees
+// every tool message sits in a run headed by an assistant `tool_calls`
+// message — so "nearest preceding tool-call turn" always exists here.
+
+import Foundation
+
+enum Gemma4TurnStructure {
+
+    static func normalizeMessages(
+        _ messages: [[String: any Sendable]]
+    ) throws -> [[String: any Sendable]] {
+        let repaired = try repairToolResultPlacement(messages)
+        return mergeDanglingAssistantText(repaired)
+    }
+
+    // MARK: - Tool-result re-pairing
+
+    private static func toolCalls(of message: [String: any Sendable]) -> [[String: any Sendable]] {
+        guard (message["role"] as? String) == "assistant",
+            let calls = message["tool_calls"] as? [any Sendable], !calls.isEmpty
+        else { return [] }
+        return calls.compactMap { $0 as? [String: any Sendable] }
+    }
+
+    private static func callID(_ call: [String: any Sendable]) -> String? {
+        guard let id = call["id"] as? String, !id.isEmpty else { return nil }
+        return id
+    }
+
+    /// Re-emit every `role:"tool"` result as part of one contiguous block
+    /// immediately after its OWNING assistant `tool_calls` message, ordered by
+    /// that message's tool_calls order. A result's owner is the most recent
+    /// preceding assistant that declared its `tool_call_id` (repeat-id clients
+    /// re-issue the same id each round; most-recent is the only sane pairing).
+    /// Results carrying no `tool_call_id` stay attached, in arrival order,
+    /// after the id-paired block of the nearest preceding tool-call turn (they
+    /// render today via the template's name fallback; dropping or rejecting
+    /// them would regress working histories). An id that matches NO preceding
+    /// declaration is an orphan → 400.
+    private static func repairToolResultPlacement(
+        _ messages: [[String: any Sendable]]
+    ) throws -> [[String: any Sendable]] {
+        // Owner index (into `messages`) for every declared call id, updated in
+        // scan order so a re-declared id re-binds to the most recent turn.
+        var ownerByCallID: [String: Int] = [:]
+        var lastToolCallTurn: Int? = nil
+        // Per-owner collected results: call id → results (arrival order), plus
+        // the id-less tail.
+        var pairedResults: [Int: [String: [[String: any Sendable]]]] = [:]
+        var idlessResults: [Int: [[String: any Sendable]]] = [:]
+
+        for (index, message) in messages.enumerated() {
+            let role = message["role"] as? String
+            if role == "tool" {
+                if let id = message["tool_call_id"] as? String, !id.isEmpty {
+                    guard let owner = ownerByCallID[id] else {
+                        throw MultiModelBatchSchedulerEngineError.invalidToolPayload(
+                            "tool result for tool_call_id \(id) has no matching assistant tool_call"
+                        )
+                    }
+                    pairedResults[owner, default: [:]][id, default: []].append(message)
+                } else {
+                    guard let owner = lastToolCallTurn else {
+                        // validateGenericToolHistory already rejects this; keep
+                        // the same clean 400 if reached through another path.
+                        throw MultiModelBatchSchedulerEngineError.invalidToolPayload(
+                            "tool message has no preceding assistant tool_calls")
+                    }
+                    idlessResults[owner, default: []].append(message)
+                }
+                continue
+            }
+            let calls = toolCalls(of: message)
+            if !calls.isEmpty {
+                lastToolCallTurn = index
+                for call in calls {
+                    if let id = callID(call) {
+                        ownerByCallID[id] = index
+                    }
+                }
+            }
+        }
+
+        var out: [[String: any Sendable]] = []
+        out.reserveCapacity(messages.count)
+        for (index, message) in messages.enumerated() {
+            if (message["role"] as? String) == "tool" {
+                continue  // re-emitted below, next to its owner
+            }
+            out.append(message)
+            let calls = toolCalls(of: message)
+            guard !calls.isEmpty else { continue }
+            var byID = pairedResults[index] ?? [:]
+            // The template's forward scan reads results in listed order; the
+            // tool_calls order is the canonical one.
+            for call in calls {
+                guard let id = callID(call), let results = byID.removeValue(forKey: id)
+                else { continue }
+                out.append(contentsOf: results)
+            }
+            // Results whose id was declared by this turn but is not in its
+            // tool_calls order slot anymore (defensive; unreachable today).
+            for id in byID.keys.sorted() {
+                out.append(contentsOf: byID[id] ?? [])
+            }
+            out.append(contentsOf: idlessResults[index] ?? [])
+        }
+        return out
+    }
+
+    // MARK: - Consecutive assistant text merge
+
+    private static func isTextOnlyAssistant(_ message: [String: any Sendable]) -> Bool {
+        guard (message["role"] as? String) == "assistant" else { return false }
+        if let calls = message["tool_calls"] as? [any Sendable], !calls.isEmpty {
+            return false
+        }
+        if let responses = message["tool_responses"] as? [any Sendable], !responses.isEmpty {
+            return false
+        }
+        // Content-parts arrays are left alone: they carry non-text items the
+        // merge cannot represent as a string prefix.
+        return message["content"] is String || message["content"] == nil
+    }
+
+    /// Fold a text-only assistant message into an immediately FOLLOWING
+    /// assistant message so the pair renders as one closed model turn (the
+    /// template suppresses the second turn opener but the first message has
+    /// already emitted a turn CLOSE — the follow-up otherwise floats outside
+    /// any opener). Left-to-right, so a chain of assistant texts folds into
+    /// the final one.
+    private static func mergeDanglingAssistantText(
+        _ messages: [[String: any Sendable]]
+    ) -> [[String: any Sendable]] {
+        var working = messages
+        var out: [[String: any Sendable]] = []
+        out.reserveCapacity(working.count)
+        var i = 0
+        while i < working.count {
+            let message = working[i]
+            if i + 1 < working.count, isTextOnlyAssistant(message),
+                (working[i + 1]["role"] as? String) == "assistant" {
+                working[i + 1] = merged(message, into: working[i + 1])
+                i += 1
+                continue
+            }
+            out.append(message)
+            i += 1
+        }
+        return out
+    }
+
+    private static func merged(
+        _ earlier: [String: any Sendable],
+        into later: [String: any Sendable]
+    ) -> [String: any Sendable] {
+        var output = later
+        let prefix = (earlier["content"] as? String)?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        if !prefix.isEmpty {
+            if let existing = output["content"] as? String {
+                output["content"] = existing.isEmpty ? prefix : prefix + "\n\n" + existing
+            } else if var parts = output["content"] as? [any Sendable] {
+                parts.insert(["type": "text", "text": prefix] as [String: any Sendable], at: 0)
+                output["content"] = parts
+            } else {
+                output["content"] = prefix
+            }
+        }
+        // Don't silently lose the earlier turn's reasoning when the later one
+        // has none of its own.
+        for key in ["thinking", "reasoning", "reasoning_content"] {
+            if output[key] == nil, let carried = earlier[key] as? String, !carried.isEmpty {
+                output[key] = carried
+            }
+        }
+        return output
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Inference/InferenceErrorClassifier.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/InferenceErrorClassifier.swift
@@ -16,17 +16,38 @@ import Foundation
 // logged (E2E privacy).
 //
 // The emitted vocabulary MUST stay in lockstep with the coordinator's Go
-// `error_reason` field: "jinja_channel_tags", "jinja_null_bridge",
-// "jinja_template", "model_load". nil ⇒ unclassifiable (coordinator falls back
-// to deriving a reason from status/class). Do NOT invent other provider-side
-// values.
+// `error_reason` field (`coordinator/api/route_outcome.go`
+// validInferenceErrorReasons): "jinja_channel_tags", "jinja_null_bridge",
+// "jinja_template", "model_load", "tool_noncompliance". nil ⇒ unclassifiable
+// (coordinator falls back to deriving a reason from status/class). Do NOT
+// invent other provider-side values.
+
+/// Classify a TYPED engine error into the shared `error_reason` vocabulary,
+/// or nil. Type-driven only (no string scans), so it is safe at catch sites
+/// where haystack matching could misfire — e.g. the mid-stream generation
+/// catch, whose engine error text must never accidentally classify as a
+/// template failure (the coordinator terminally rejects jinja_* reasons, E4).
+func classifyTypedInferenceErrorReason(_ error: Error) -> String? {
+    if let engineError = error as? MultiModelBatchSchedulerEngineError,
+        case .toolChoiceViolation = engineError {
+        // E5: the model failed the forced tool_choice contract (missing /
+        // disallowed call, or over-limit deferred prose) — output-dependent,
+        // never a provider fault.
+        return "tool_noncompliance"
+    }
+    return nil
+}
 
 /// Classify an inference `Error` into the shared normalized `error_reason`
 /// vocabulary, or nil when it cannot be confidently classified.
 ///
-/// Pure + side-effect-free: inspects only the error's textual descriptions and
-/// concrete type name, never any request/message content.
+/// Pure + side-effect-free: inspects only the error's concrete type and
+/// textual descriptions, never any request/message content.
 func classifyInferenceErrorReason(_ error: Error) -> String? {
+    // Typed classifications win before any string scan.
+    if let typed = classifyTypedInferenceErrorReason(error) {
+        return typed
+    }
     // `String(describing:)` carries the RICH template text (e.g. the Harmony
     // "...passed a message containing <|channel|> tags in the content field..."
     // message) that `localizedDescription` collapses to the lossy

--- a/provider-swift/Sources/ProviderCore/Inference/MultiModelBatchSchedulerEngine.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/MultiModelBatchSchedulerEngine.swift
@@ -633,7 +633,7 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
                                             await releaseBox.fire()
                                             continuation.finish(
                                                 throwing: MultiModelBatchSchedulerEngineError
-                                                    .generationFailed(
+                                                    .toolChoiceViolation(
                                                         "required tool call response exceeded deferred content limit"))
                                             return
                                         }
@@ -646,7 +646,7 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
                                     await cancelUpstream()
                                     await releaseBox.fire()
                                     continuation.finish(
-                                        throwing: MultiModelBatchSchedulerEngineError.generationFailed(
+                                        throwing: MultiModelBatchSchedulerEngineError.toolChoiceViolation(
                                             "required tool call response exceeded deferred content limit"))
                                     return
                                 }
@@ -687,17 +687,21 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
                 // choices hold text until a call is proven, so a non-compliant
                 // model can never return a normal text answer with `stop`.
                 let toolCalls = toolHandler?.finish() ?? []
+                // Forced tool_choice noncompliance is a typed 422
+                // (`tool_noncompliance`), not a generic 500: it depends on
+                // what the model GENERATED, so a re-sample can comply, and
+                // it must not read as a provider fault (E5).
                 if toolCalls.contains(where: { !allowedToolNames.contains($0.function.name) }) {
                     await releaseBox.fire()
                     continuation.finish(
-                        throwing: MultiModelBatchSchedulerEngineError.generationFailed(
+                        throwing: MultiModelBatchSchedulerEngineError.toolChoiceViolation(
                             "model emitted a tool call outside tool_choice"))
                     return
                 }
                 if requiresToolCall && toolCalls.isEmpty {
                     await releaseBox.fire()
                     continuation.finish(
-                        throwing: MultiModelBatchSchedulerEngineError.generationFailed(
+                        throwing: MultiModelBatchSchedulerEngineError.toolChoiceViolation(
                             "model did not emit the required tool call"))
                     return
                 }

--- a/provider-swift/Sources/ProviderCore/Inference/MultiModelBatchSchedulerEngineError.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/MultiModelBatchSchedulerEngineError.swift
@@ -39,6 +39,15 @@ public enum MultiModelBatchSchedulerEngineError: Error, LocalizedError, Equatabl
     /// histories do not trip model-specific Jinja assertions as provider
     /// 500s.
     case invalidToolPayload(String)
+    /// The MODEL failed to satisfy the request's forced `tool_choice`
+    /// contract: it did not emit the required tool call, emitted a call
+    /// outside the allowed set, or produced more deferred prose than the
+    /// enforcement buffer holds. This depends on what the model GENERATED —
+    /// a re-sample (or another provider) can comply — so it surfaces as 422
+    /// with error_reason "tool_noncompliance" (E5), which stays on the
+    /// coordinator's normal bounded-failover path, NOT as a generic 500
+    /// that burns provider reputation.
+    case toolChoiceViolation(String)
     /// Admission rejection caused by the batch token budget / global
     /// KV-cache headroom / pending-queue timeout. Surfaces as 503 so
     /// clients back off and retry once capacity frees up.
@@ -75,6 +84,8 @@ public enum MultiModelBatchSchedulerEngineError: Error, LocalizedError, Equatabl
         case .invalidRole(let role):
             return "Unsupported chat message role: '\(role)'"
         case .invalidToolPayload(let message):
+            return message
+        case .toolChoiceViolation(let message):
             return message
         case .tokenBudgetExhausted(let message):
             return message

--- a/provider-swift/Sources/ProviderCore/Inference/ToolSchemaNormalization.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/ToolSchemaNormalization.swift
@@ -130,6 +130,19 @@ enum ToolSchemaNormalization {
         if dict["type"] == nil, positional || looksLikeSchemaNode(dict) {
             dict["type"] = inferredType(for: dict)
         }
+
+        // An OBJECT-typed schema node must carry a mapping `properties` —
+        // otherwise the served Gemma template's OBJECT branch falls back to
+        // iterating the node's OWN keys (`filter_keys=true`) as property
+        // schemas; containers like `patternProperties` carry no `type`, so
+        // `value['type'] | upper` throws. Mirrors coordinator toolschema.go
+        // and gemma4 enforcement invariant 4; runs AFTER type resolution so
+        // inferred-object nodes are covered, and is render-neutral elsewhere
+        // (an empty dict is falsy in Jinja truthiness guards).
+        if let t = dict["type"] as? String, t.uppercased() == "OBJECT",
+            !(dict["properties"] is [String: Any]) {
+            dict["properties"] = [String: Any]()
+        }
         return dict
     }
 

--- a/provider-swift/Sources/ProviderCore/Inference/ToolSchemaNormalization.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/ToolSchemaNormalization.swift
@@ -48,32 +48,59 @@ enum ToolSchemaNormalization {
         return out
     }
 
-    /// Recursively default-fill `type` on JSON-Schema nodes. A node gets a type
-    /// only when it looks like a schema node (has properties / items / enum /
-    /// description / anyOf / oneOf / allOf) — we never invent types on arbitrary
-    /// maps. The inferred default favours structure: object when it has
+    /// Recursively default-fill `type` on JSON-Schema nodes, starting from a
+    /// tool's schema home (a NON-positional root: a bare `{}` parameters object
+    /// stays `{}`, and a type is only invented when the map carries a schema
+    /// marker key). The inferred default favours structure: object when it has
     /// properties, array when it has items, otherwise string.
+    ///
+    /// Semantically mirrors the coordinator's Go `injectDefaultTypes`
+    /// (`coordinator/api/toolschema.go`) including its POSITIONAL rule: any
+    /// value in a schema-positional slot — under `properties` /
+    /// `patternProperties`, `items` (including tuple-form members),
+    /// `prefixItems`, a map-valued `additionalProperties`, or a member of
+    /// `anyOf`/`oneOf`/`allOf` — IS a schema by definition, so it needs no
+    /// marker-key evidence: booleans (the valid allow/deny-all shorthand)
+    /// become `{"type":"string"}` and maps are guaranteed a string `type`.
     static func injectDefaultTypes(_ node: Any) -> Any {
+        injectTypes(node, positional: false)
+    }
+
+    /// Traversal core behind ``injectDefaultTypes(_:)``; `positional` reports
+    /// whether `node` sits in a schema-positional slot (see the mirror note
+    /// above). Arrays keep positionality for their members (tuple-form
+    /// `items`, `prefixItems`, union member lists).
+    private static func injectTypes(_ node: Any, positional: Bool) -> Any {
+        if positional, isJSONBoolean(node) {
+            return ["type": "string"] as [String: Any]
+        }
         if let arr = node as? [Any] {
-            return arr.map(injectDefaultTypes)
+            return arr.map { injectTypes($0, positional: positional) }
         }
         guard var dict = node as? [String: Any] else { return node }
 
-        if let props = dict["properties"] as? [String: Any] {
-            dict["properties"] = props.mapValues(injectDefaultTypes)
+        for key in ["properties", "patternProperties"] {
+            if let props = dict[key] as? [String: Any] {
+                dict[key] = props.mapValues { injectTypes($0, positional: true) }
+            }
         }
         if let items = dict["items"] {
-            dict["items"] = injectDefaultTypes(items)
+            dict["items"] = injectTypes(items, positional: true)
+        }
+        if let prefix = dict["prefixItems"] as? [Any] {
+            dict["prefixItems"] = prefix.map { injectTypes($0, positional: true) }
         }
         // additionalProperties may itself be a schema (map-shaped params, e.g.
         // {"additionalProperties":{"type":"string"}}) — recurse so its inner schema
-        // gets a default type too. A bare `true`/`false` is left untouched.
+        // gets a default type too. A bare `true`/`false` is left untouched (the
+        // standard allow/deny-all switch; templates never subscript it) — only
+        // the MAP-valued form is schema-positional.
         if let addl = dict["additionalProperties"], addl is [String: Any] {
-            dict["additionalProperties"] = injectDefaultTypes(addl)
+            dict["additionalProperties"] = injectTypes(addl, positional: true)
         }
         for key in ["anyOf", "oneOf", "allOf"] {
             if let variants = dict[key] as? [Any] {
-                dict[key] = variants.map(injectDefaultTypes)
+                dict[key] = variants.map { injectTypes($0, positional: true) }
             }
         }
 
@@ -82,10 +109,12 @@ enum ToolSchemaNormalization {
         // for nullable fields — `"type": ["string","null"]` — which Pydantic
         // emits for every Optional[...] tool parameter. Collapse it to a single
         // representative string (never delete the key: a node whose only content
-        // is its type would not be refilled below and would crash anyway).
-        // Nullability is preserved losslessly: the gemma template natively
-        // renders the standard `nullable` key, so collapsing away a "null"
-        // member sets it (without clobbering an explicit value).
+        // is its type would not be refilled below and would crash anyway). A
+        // scalar non-string `type` (e.g. `"type": 123`) collapses the same way,
+        // to the structural inference. Nullability is preserved losslessly: the
+        // gemma template natively renders the standard `nullable` key, so
+        // collapsing away a "null" member sets it (without clobbering an
+        // explicit value).
         if let t = dict["type"], !(t is String) {
             let members = (t as? [Any])?.compactMap { $0 as? String } ?? []
             if members.contains("null"), members.contains(where: { $0 != "null" }),
@@ -95,15 +124,36 @@ enum ToolSchemaNormalization {
             dict["type"] = collapsedType(members: members, in: dict)
         }
 
-        let looksLikeSchemaNode =
-            dict["properties"] != nil || dict["items"] != nil ||
-            dict["additionalProperties"] != nil ||
-            dict["enum"] != nil || dict["description"] != nil ||
-            dict["anyOf"] != nil || dict["oneOf"] != nil || dict["allOf"] != nil
-        if dict["type"] == nil, looksLikeSchemaNode {
+        // A positional node IS a schema by definition, so a missing type is
+        // always filled; a non-positional map (a tool schema root) still needs
+        // marker-key evidence before we invent one.
+        if dict["type"] == nil, positional || looksLikeSchemaNode(dict) {
             dict["type"] = inferredType(for: dict)
         }
         return dict
+    }
+
+    /// Marker-key evidence gate for NON-positional nodes (the tool schema
+    /// roots): only maps carrying a JSON-Schema marker key receive a defaulted
+    /// `type` there.
+    private static func looksLikeSchemaNode(_ dict: [String: Any]) -> Bool {
+        for key in [
+            "properties", "patternProperties", "items", "prefixItems",
+            "additionalProperties", "enum", "description", "anyOf", "oneOf", "allOf",
+        ] where dict[key] != nil {
+            return true
+        }
+        return false
+    }
+
+    /// True only for a REAL boolean. JSONSerialization delivers JSON booleans
+    /// as `NSNumber` (CFBoolean), and `as? Bool` alone would also match numeric
+    /// 0/1 NSNumbers — a schema value of `0`/`1` must NOT be mistaken for a
+    /// boolean schema, so the underlying CF type is checked.
+    private static func isJSONBoolean(_ node: Any) -> Bool {
+        if type(of: node) == Bool.self { return true }
+        guard let number = node as? NSNumber else { return false }
+        return CFGetTypeID(number) == CFBooleanGetTypeID()
     }
 
     /// Collapse a non-string `type` value (pre-extracted string members of the
@@ -121,14 +171,16 @@ enum ToolSchemaNormalization {
     }
 
     /// Structural default for a schema node's `type`: object when it has
-    /// properties, array when it has items, a union member's type when it is an
+    /// properties / patternProperties / additionalProperties, array when it has
+    /// items / prefixItems, a union member's type when it is an
     /// anyOf/oneOf/allOf (skipping "null" — mislabelling a union as a string
     /// would be wrong), otherwise string.
     private static func inferredType(for dict: [String: Any]) -> String {
-        if dict["properties"] != nil || dict["additionalProperties"] != nil {
+        if dict["properties"] != nil || dict["patternProperties"] != nil
+            || dict["additionalProperties"] != nil {
             return "object"
         }
-        if dict["items"] != nil {
+        if dict["items"] != nil || dict["prefixItems"] != nil {
             return "array"
         }
         if let unionType = unionMemberType(dict) {

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+ErrorMapping.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+ErrorMapping.swift
@@ -60,6 +60,13 @@ extension ProviderLoop {
                 return 400
             case .invalidToolPayload:
                 return 400
+            case .toolChoiceViolation:
+                // The MODEL failed the forced tool_choice contract — output-
+                // dependent, so a re-sample / another provider can comply.
+                // 422 keeps it on the coordinator's normal bounded-failover
+                // path (never the terminal client-error stop set) and out of
+                // the 5xx provider-fault classes (E5).
+                return 422
             case .queueFull:
                 return 429
             case .tokenBudgetExhausted:

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+InferenceHandler.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+InferenceHandler.swift
@@ -702,14 +702,18 @@ extension ProviderLoop {
                         providerStats.incrementStreamClosedWithoutTerminal()
                     }
                     let statusCode = Self.mapInferenceErrorToStatus(error)
-                    // Mid-stream generation error. Left unclassified (nil): the
-                    // Harmony channel-tags / null-bridge template failures surface
-                    // at stream START (see the catch below), not here.
+                    // Mid-stream generation error. TYPED classification only
+                    // (tool_noncompliance for a forced tool_choice violation,
+                    // E5); string-based classification stays off this path —
+                    // the Harmony channel-tags / null-bridge template failures
+                    // surface at stream START (see the catch below), and a
+                    // haystack misfire here would hand the coordinator a
+                    // terminally-rejected jinja_* reason for an engine fault.
                     send.send(.inferenceError(
                         requestId: requestId,
                         error: error.localizedDescription,
                         statusCode: statusCode,
-                        errorReason: nil
+                        errorReason: classifyTypedInferenceErrorReason(error)
                     ))
                     return
                 }

--- a/provider-swift/Tests/ProviderCoreTests/EngineV2ProductionWiringTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/EngineV2ProductionWiringTests.swift
@@ -1082,7 +1082,8 @@ struct EngineV2RequestRoutingTests {
             for try await event in stream { events.append(event) }
             Issue.record("expected required tool call failure")
         } catch let error as MultiModelBatchSchedulerEngineError {
-            #expect(error == .generationFailed("model did not emit the required tool call"))
+            // E5: tool-choice noncompliance is the typed 422 case, not a 500.
+            #expect(error == .toolChoiceViolation("model did not emit the required tool call"))
         }
         #expect(events.isEmpty, "text must stay suppressed when no required call is emitted")
     }
@@ -1115,7 +1116,8 @@ struct EngineV2RequestRoutingTests {
             for try await event in stream { events.append(event) }
             Issue.record("expected deferred content limit failure")
         } catch let error as MultiModelBatchSchedulerEngineError {
-            #expect(error == .generationFailed(
+            // E5: tool-choice noncompliance is the typed 422 case, not a 500.
+            #expect(error == .toolChoiceViolation(
                 "required tool call response exceeded deferred content limit"))
         }
         #expect(events.isEmpty)
@@ -1189,7 +1191,8 @@ struct EngineV2RequestRoutingTests {
             for try await _ in stream {}
             Issue.record("expected named tool_choice mismatch")
         } catch let error as MultiModelBatchSchedulerEngineError {
-            #expect(error == .generationFailed("model emitted a tool call outside tool_choice"))
+            // E5: tool-choice noncompliance is the typed 422 case, not a 500.
+            #expect(error == .toolChoiceViolation("model emitted a tool call outside tool_choice"))
         }
     }
 

--- a/provider-swift/Tests/ProviderCoreTests/Gemma4ServedTemplateRenderTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/Gemma4ServedTemplateRenderTests.swift
@@ -1,0 +1,361 @@
+import CryptoKit
+import Foundation
+import Jinja
+import Testing
+
+@testable import ProviderCore
+
+/// Render-level E1 regression against the SERVED Gemma chat template
+/// (`gemma-4-26b-qat-4bit` @ 2026-06-08-r1, byte-identical to
+/// mlx-community/gemma-4-26b-a4b-it-qat-4bit, template sha256 94899c0f…).
+///
+/// The fixture embeds the template's `format_parameters`,
+/// `format_function_declaration`, and `format_argument` macros VERBATIM (the
+/// declaration macro calls the other two), followed by the template's own
+/// tool-declaration driver loop (served lines 196–203). Each crash-corpus
+/// case is proven BOTH ways against the real Jinja engine:
+///
+///   • un-normalized (null-sanitize only — exactly what reached the template
+///     before this fix when a caller bypassed the shared normalizers): the
+///     render THROWS (the production `jinja_template` 500, live error text
+///     "upper filter requires string");
+///   • after `ChatTemplateFixes.normalizeTools` with a gemma4 context (the
+///     production chokepoint: shared normalization + Gemma4 enforcement):
+///     the render succeeds.
+@Suite("Gemma4 served-template render regression (E1)")
+struct Gemma4ServedTemplateRenderTests {
+
+    /// Served macros, verbatim (do NOT reformat — byte-exactness is the point).
+    private static let servedMacros = #"""
+{%- macro format_parameters(properties, required, filter_keys=false) -%}
+    {%- set standard_keys = ['description', 'type', 'properties', 'required', 'nullable'] -%}
+    {%- set ns = namespace(found_first=false) -%}
+    {%- for key, value in properties | dictsort -%}
+        {%- set add_comma = false -%}
+        {%- if not filter_keys or key not in standard_keys -%}
+            {%- if ns.found_first %},{% endif -%}
+            {%- set ns.found_first = true -%}
+            {{ key }}:{
+            {%- if value['description'] -%}
+                description:<|"|>{{ value['description'] }}<|"|>
+                {%- set add_comma = true -%}
+            {%- endif -%}
+            {%- if value['type'] | upper == 'STRING' -%}
+                {%- if value['enum'] -%}
+                    {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                    enum:{{ format_argument(value['enum']) }}
+                {%- endif -%}
+            {%- elif value['type'] | upper == 'ARRAY' -%}
+                {%- if value['items'] is mapping and value['items'] -%}
+                    {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                    items:{
+                    {%- set ns_items = namespace(found_first=false) -%}
+                    {%- for item_key, item_value in value['items'] | dictsort -%}
+                        {%- if item_value is not none -%}
+                            {%- if ns_items.found_first %},{% endif -%}
+                            {%- set ns_items.found_first = true -%}
+                            {%- if item_key == 'properties' -%}
+                                properties:{
+                                {%- if item_value is mapping -%}
+                                    {{- format_parameters(item_value, value['items']['required'] | default([])) -}}
+                                {%- endif -%}
+                                }
+                            {%- elif item_key == 'required' -%}
+                                required:[
+                                {%- for req_item in item_value -%}
+                                    <|"|>{{- req_item -}}<|"|>
+                                    {%- if not loop.last %},{% endif -%}
+                                {%- endfor -%}
+                                ]
+                            {%- elif item_key == 'type' -%}
+                                {%- if item_value is string -%}
+                                    type:{{ format_argument(item_value | upper) }}
+                                {%- else -%}
+                                    type:{{ format_argument(item_value | map('upper') | list) }}
+                                {%- endif -%}
+                            {%- else -%}
+                                {{ item_key }}:{{ format_argument(item_value) }}
+                            {%- endif -%}
+                        {%- endif -%}
+                    {%- endfor -%}
+                    }
+                {%- endif -%}
+            {%- endif -%}
+            {%- if value['nullable'] %}
+                {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                nullable:true
+            {%- endif -%}
+            {%- if value['type'] | upper == 'OBJECT' -%}
+                {%- if value['properties'] is defined and value['properties'] is mapping -%}
+                    {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                    properties:{
+                    {{- format_parameters(value['properties'], value['required'] | default([])) -}}
+                    }
+                {%- elif value is mapping -%}
+                    {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                    properties:{
+                    {{- format_parameters(value, value['required'] | default([]), filter_keys=true) -}}
+                    }
+                {%- endif -%}
+                {%- if value['required'] -%}
+                    {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                    required:[
+                    {%- for item in value['required'] | default([]) -%}
+                        <|"|>{{- item -}}<|"|>
+                        {%- if not loop.last %},{% endif -%}
+                    {%- endfor -%}
+                    ]
+                {%- endif -%}
+            {%- endif -%}
+            {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+            type:<|"|>{{ value['type'] | upper }}<|"|>}
+        {%- endif -%}
+    {%- endfor -%}
+{%- endmacro -%}
+{%- macro format_function_declaration(tool_data) -%}
+    declaration:{{- tool_data['function']['name'] -}}{description:<|"|>{{- tool_data['function']['description'] -}}<|"|>
+    {%- set params = tool_data['function']['parameters'] -%}
+    {%- if params -%}
+        ,parameters:{
+        {%- if params['properties'] -%}
+            properties:{ {{- format_parameters(params['properties'], params['required']) -}} },
+        {%- endif -%}
+        {%- if params['required'] -%}
+            required:[
+            {%- for item in params['required'] -%}
+                <|"|>{{- item -}}<|"|>
+                {{- ',' if not loop.last -}}
+            {%- endfor -%}
+            ],
+        {%- endif -%}
+        {%- if params['type'] -%}
+            type:<|"|>{{- params['type'] | upper -}}<|"|>}
+        {%- endif -%}
+    {%- endif -%}
+    {%- if 'response' in tool_data['function'] -%}
+        {%- set response_declaration = tool_data['function']['response'] -%}
+        ,response:{
+        {%- if response_declaration['description'] -%}
+            description:<|"|>{{- response_declaration['description'] -}}<|"|>,
+        {%- endif -%}
+        {%- if response_declaration['type'] | upper == 'OBJECT' -%}
+            type:<|"|>{{- response_declaration['type'] | upper -}}<|"|>}
+        {%- endif -%}
+    {%- endif -%}
+    }
+{%- endmacro -%}
+{%- macro format_argument(argument, escape_keys=True) -%}
+    {%- if argument is string -%}
+        {{- '<|"|>' + argument + '<|"|>' -}}
+    {%- elif argument is boolean -%}
+        {{- 'true' if argument else 'false' -}}
+    {%- elif argument is mapping -%}
+        {{- '{' -}}
+        {%- set ns = namespace(found_first=false) -%}
+        {%- for key, value in argument | dictsort -%}
+            {%- if ns.found_first %},{% endif -%}
+            {%- set ns.found_first = true -%}
+            {%- if escape_keys -%}
+                {{- '<|"|>' + key + '<|"|>' -}}
+            {%- else -%}
+                {{- key -}}
+            {%- endif -%}
+            :{{- format_argument(value, escape_keys=escape_keys) -}}
+        {%- endfor -%}
+        {{- '}' -}}
+    {%- elif argument is sequence -%}
+        {{- '[' -}}
+        {%- for item in argument -%}
+            {{- format_argument(item, escape_keys=escape_keys) -}}
+            {%- if not loop.last %},{% endif -%}
+        {%- endfor -%}
+        {{- ']' -}}
+    {%- else -%}
+        {{- argument -}}
+    {%- endif -%}
+{%- endmacro -%}
+
+"""#
+
+    /// The served template's tool-declaration driver (lines 196–203).
+    private static let toolDeclarationDriver = #"""
+    {%- if tools -%}
+        {%- for tool in tools %}
+            {{- '<|tool>' -}}
+            {{- format_function_declaration(tool) | trim -}}
+            {{- '<tool|>' -}}
+        {%- endfor %}
+    {%- endif -%}
+    """#
+
+    private static let fixtureSource = servedMacros + "\n" + toolDeclarationDriver
+
+    private let gemmaContext = ChatTemplateFixContext(
+        modelId: "gemma-4-26b-a4b-it-qat-4bit", modelType: "gemma4_text")
+
+    private func tool(parameters: [String: any Sendable]) -> [String: any Sendable] {
+        [
+            "type": "function",
+            "function": [
+                "name": "probe", "description": "corpus probe",
+                "parameters": parameters,
+            ] as [String: any Sendable],
+        ]
+    }
+
+    /// Render the fixture with the same compile options as the runtime
+    /// tokenizer (swift-transformers `compiledTemplate(for:)`).
+    private func render(tools: [[String: any Sendable]]) throws -> String {
+        let template = try Template(
+            Self.fixtureSource, with: .init(lstripBlocks: true, trimBlocks: true))
+        let context: [String: Value] = [
+            "tools": .array(try tools.map { try Value(any: $0) })
+        ]
+        return try template.render(context)
+    }
+
+    /// The pre-fix pipeline: null-sanitize only (what `sanitizeTools` did
+    /// before the Gemma enforcement existed).
+    private func renderUnnormalized(_ parameters: [String: any Sendable]) throws -> String {
+        let sanitized = ChatTemplateFixes.sanitizeTools([tool(parameters: parameters)]) ?? []
+        return try render(tools: sanitized)
+    }
+
+    /// The production pipeline for gemma4.
+    private func renderNormalized(_ parameters: [String: any Sendable]) throws -> String {
+        let normalized =
+            ChatTemplateFixes.normalizeTools(
+                [tool(parameters: parameters)], context: gemmaContext) ?? []
+        return try render(tools: normalized)
+    }
+
+    /// E1 crash corpus: every case is a VALID request shape whose raw render
+    /// throws in the served macros.
+    private static let crashCorpus: [(name: String, parameters: [String: any Sendable])] = [
+        (
+            "empty property schema",
+            ["type": "object", "properties": ["x": [String: any Sendable]()] as [String: any Sendable]]
+        ),
+        (
+            "const-only property",
+            ["type": "object", "properties": ["c": ["const": "v"] as [String: any Sendable]] as [String: any Sendable]]
+        ),
+        (
+            "default-only property",
+            ["type": "object", "properties": ["d": ["default": 5] as [String: any Sendable]] as [String: any Sendable]]
+        ),
+        (
+            "$ref-only property",
+            ["type": "object", "properties": ["r": ["$ref": "#/$defs/x"] as [String: any Sendable]] as [String: any Sendable]]
+        ),
+        (
+            "format-only property",
+            ["type": "object", "properties": ["f": ["format": "date-time"] as [String: any Sendable]] as [String: any Sendable]]
+        ),
+        (
+            "boolean true schema",
+            ["type": "object", "properties": ["b": true] as [String: any Sendable]]
+        ),
+        (
+            "boolean false schema",
+            ["type": "object", "properties": ["bf": false] as [String: any Sendable]]
+        ),
+        (
+            "scalar non-string type",
+            ["type": "object", "properties": ["n": ["type": 123] as [String: any Sendable]] as [String: any Sendable]]
+        ),
+        (
+            "patternProperties without properties",
+            [
+                "type": "object",
+                "properties": [
+                    "env": [
+                        "type": "object",
+                        "patternProperties": ["^E_": ["type": "string"] as [String: any Sendable]]
+                            as [String: any Sendable],
+                    ] as [String: any Sendable]
+                ] as [String: any Sendable],
+            ]
+        ),
+        (
+            "prefixItems-only property",
+            [
+                "type": "object",
+                "properties": [
+                    "pair": ["prefixItems": [["type": "string"] as [String: any Sendable]] as [any Sendable]]
+                        as [String: any Sendable]
+                ] as [String: any Sendable],
+            ]
+        ),
+        (
+            "scalar property value",
+            ["type": "object", "properties": ["s": 5] as [String: any Sendable]]
+        ),
+        (
+            "object node with junk keys",
+            [
+                "type": "object",
+                "properties": [
+                    "cfg": ["type": "object", "minProperties": 1] as [String: any Sendable]
+                ] as [String: any Sendable],
+            ]
+        ),
+    ]
+
+    @Test func corpusThrowsWithoutNormalization() {
+        for (name, parameters) in Self.crashCorpus {
+            #expect(throws: (any Error).self, "\(name) must throw un-normalized") {
+                _ = try renderUnnormalized(parameters)
+            }
+        }
+    }
+
+    @Test func corpusRendersAfterNormalization() throws {
+        for (name, parameters) in Self.crashCorpus {
+            let rendered = try renderNormalized(parameters)
+            #expect(rendered.contains("<|tool>declaration:probe"), "\(name): \(rendered)")
+            #expect(rendered.contains("<tool|>"), "\(name): \(rendered)")
+        }
+    }
+
+    /// Every property value the corpus normalizes must render an upper-cased
+    /// string type — the exact expression that crashed in production.
+    @Test func normalizedBooleanSchemaRendersStringType() throws {
+        let rendered = try renderNormalized(
+            ["type": "object", "properties": ["b": true] as [String: any Sendable]])
+        // The served macro emits a space before `type` when no other keys
+        // rendered (its add_comma else-branch) — asserted as-rendered.
+        #expect(rendered.contains(#"b:{ type:<|"|>STRING<|"|>}"#))
+    }
+
+    /// Control: a fully-typed, well-formed spec renders WITHOUT any
+    /// normalization — the fixture itself is healthy; the corpus failures
+    /// above are the request shapes, not a broken fixture.
+    @Test func wellFormedSpecRendersUnnormalized() throws {
+        let rendered = try renderUnnormalized([
+            "type": "object",
+            "properties": [
+                "city": ["type": "string", "description": "c"] as [String: any Sendable]
+            ] as [String: any Sendable],
+            "required": ["city"],
+        ])
+        #expect(rendered.contains("declaration:probe"))
+        #expect(rendered.contains(#"city:{"#))
+        #expect(rendered.contains(#"type:<|"|>STRING<|"|>"#))
+        #expect(rendered.contains(#"required:[<|"|>city<|"|>]"#))
+    }
+
+    /// The embedded macros must stay byte-identical to the served template:
+    /// this is the sha256 of lines 1–147 (`sed -n '1,147p'`, trailing newline
+    /// included) of the 94899c0f… artifact. Guards against accidental
+    /// reformatting of the fixture, which would silently detach this
+    /// regression test from the production artifact.
+    @Test func servedMacroFixtureIsByteExact() {
+        let expectedSHA256 = "a489e5fcbc51a77fd665cba6d20e924d52bde8b0a8e1712f95c8e1f8859d879d"
+        #expect(sha256Hex(Self.servedMacros) == expectedSHA256)
+    }
+
+    private func sha256Hex(_ text: String) -> String {
+        SHA256.hash(data: Data(text.utf8)).map { String(format: "%02x", $0) }.joined()
+    }
+}

--- a/provider-swift/Tests/ProviderCoreTests/Gemma4ServedTemplateRenderTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/Gemma4ServedTemplateRenderTests.swift
@@ -358,4 +358,27 @@ struct Gemma4ServedTemplateRenderTests {
     private func sha256Hex(_ text: String) -> String {
         SHA256.hash(data: Data(text.utf8)).map { String(format: "%02x", $0) }.joined()
     }
+
+    /// Post-push Codex P2 shape: an object property carrying ONLY
+    /// `patternProperties` crashes the served macros un-normalized (the
+    /// OBJECT fallback iterates the node's own keys; the patternProperties
+    /// container has no `type`) and must render after the production
+    /// pipeline injects the empty `properties` map.
+    @Test func patternPropertiesOnlyObjectRendersAfterNormalization() throws {
+        let parameters: [String: any Sendable] = [
+            "type": "object",
+            "properties": [
+                "env": [
+                    "type": "object",
+                    "patternProperties":
+                        ["^ENV_": ["type": "string"] as [String: any Sendable]]
+                        as [String: any Sendable],
+                ] as [String: any Sendable],
+            ] as [String: any Sendable],
+        ]
+        #expect(throws: (any Error).self, "un-normalized patternProperties-only object must throw") {
+            _ = try renderUnnormalized(parameters)
+        }
+        _ = try renderNormalized(parameters)
+    }
 }

--- a/provider-swift/Tests/ProviderCoreTests/Gemma4ToolCallArgumentsTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/Gemma4ToolCallArgumentsTests.swift
@@ -1,0 +1,139 @@
+import Foundation
+import Testing
+
+@testable import ProviderCore
+
+/// E3 tool-call `arguments` hardening (`Gemma4TemplateFix.normalizeMessages`
+/// → `Gemma4ToolCallArguments`): the engine's `decodeToolCallArguments`
+/// returns the RAW STRING when arguments are empty / malformed / non-object
+/// JSON, and the served Gemma template's `is string` branch renders it as
+/// double-brace garbage (`call:f{{"a":1}}`). Missing/empty become `{}`,
+/// object strings are parsed, and everything else is a clean 400.
+@Suite("Gemma4 tool-call arguments hardening (E3)")
+struct Gemma4ToolCallArgumentsTests {
+
+    private func assistantCall(arguments: (any Sendable)?) -> [[String: any Sendable]] {
+        var function: [String: any Sendable] = ["name": "run"]
+        if let arguments {
+            function["arguments"] = arguments
+        }
+        return [
+            [
+                "role": "assistant", "content": "",
+                "tool_calls": [
+                    ["id": "call_1", "type": "function", "function": function]
+                        as [String: any Sendable]
+                ] as [any Sendable],
+            ],
+            ["role": "tool", "tool_call_id": "call_1", "content": "ok"],
+        ]
+    }
+
+    private func normalizedArguments(
+        _ messages: [[String: any Sendable]]
+    ) throws -> [String: any Sendable]? {
+        let out = try Gemma4TemplateFix.normalizeMessages(messages)
+        let calls = out.first?["tool_calls"] as? [any Sendable]
+        let call = calls?.first as? [String: any Sendable]
+        let function = call?["function"] as? [String: any Sendable]
+        return function?["arguments"] as? [String: any Sendable]
+    }
+
+    // MARK: - Empty / missing
+
+    @Test func missingArgumentsBecomeEmptyObject() throws {
+        let args = try normalizedArguments(assistantCall(arguments: nil))
+        #expect(args?.isEmpty == true)
+    }
+
+    @Test func emptyAndWhitespaceStringsBecomeEmptyObject() throws {
+        for raw in ["", "   ", "\n"] {
+            let args = try normalizedArguments(assistantCall(arguments: raw))
+            #expect(args?.isEmpty == true, "raw=\(raw.debugDescription)")
+        }
+    }
+
+    // MARK: - Parseable object strings
+
+    /// The raw-string shape the engine hands over on its non-object fallback:
+    /// a VALID object string must become a mapping (the template's
+    /// `is mapping` branch), never render verbatim.
+    @Test func objectStringIsParsedIntoMapping() throws {
+        let args = try normalizedArguments(
+            assistantCall(arguments: #"{"command":"ls -la","depth":2}"#))
+        #expect(args?["command"] as? String == "ls -la")
+        #expect((args?["depth"] as? Int) == 2)
+    }
+
+    /// A null INSIDE the parsed object is re-stripped (the raw string bypassed
+    /// the earlier sanitize pass; an NSNull leaf would crash the Jinja bridge).
+    @Test func nullLeavesInsideParsedObjectAreStripped() throws {
+        let args = try normalizedArguments(
+            assistantCall(arguments: #"{"keep":1,"drop":null}"#))
+        #expect(args?["keep"] as? Int == 1)
+        #expect(args?["drop"] == nil)
+    }
+
+    // MARK: - Deterministic 400s
+
+    @Test func malformedAndNonObjectStringsThrow() {
+        for raw in ["{bad", "null", "[1,2]", "42", "\"str\"", "true"] {
+            do {
+                _ = try Gemma4TemplateFix.normalizeMessages(assistantCall(arguments: raw))
+                Issue.record("\(raw.debugDescription): expected invalidToolPayload")
+            } catch let error as MultiModelBatchSchedulerEngineError {
+                guard case .invalidToolPayload(let message) = error else {
+                    Issue.record("\(raw.debugDescription): wrong case \(error)")
+                    continue
+                }
+                #expect(
+                    message == "tool_calls[].function.arguments must be a JSON object",
+                    "raw=\(raw.debugDescription)")
+            } catch {
+                Issue.record("\(raw.debugDescription): unexpected error \(error)")
+            }
+        }
+    }
+
+    @Test func nonStringNonMappingArgumentsThrow() {
+        for raw: any Sendable in [[1, 2] as [any Sendable], 42, false] {
+            #expect(throws: MultiModelBatchSchedulerEngineError.self) {
+                _ = try Gemma4TemplateFix.normalizeMessages(assistantCall(arguments: raw))
+            }
+        }
+    }
+
+    // MARK: - Preservation
+
+    @Test func decodedObjectArgumentsPassThrough() throws {
+        let args = try normalizedArguments(
+            assistantCall(arguments: ["city": "SF"] as [String: any Sendable]))
+        #expect(args?["city"] as? String == "SF")
+    }
+
+    @Test func nonAssistantAndCallLessMessagesUntouched() throws {
+        let input: [[String: any Sendable]] = [
+            ["role": "user", "content": "hi"],
+            ["role": "assistant", "content": "plain answer"],
+        ]
+        let out = try Gemma4TemplateFix.normalizeMessages(input)
+        #expect(out.count == 2)
+        #expect(out[1]["tool_calls"] == nil)
+    }
+
+    /// Wiring: the production chokepoint rejects the malformed shape for
+    /// gemma4 contexts and leaves other model families on their own paths.
+    @Test func chatTemplateFixesRejectsMalformedForGemma() {
+        let gemma = ChatTemplateFixContext(
+            modelId: "gemma-4-26b-a4b-it-qat-4bit", modelType: "gemma4_text")
+        #expect(throws: MultiModelBatchSchedulerEngineError.self) {
+            _ = try ChatTemplateFixes.normalizeMessages(
+                assistantCall(arguments: "{bad"), context: gemma)
+        }
+        let qwen = ChatTemplateFixContext(modelId: "qwen3-8b", modelType: "qwen3")
+        #expect(throws: Never.self) {
+            _ = try ChatTemplateFixes.normalizeMessages(
+                assistantCall(arguments: "{bad"), context: qwen)
+        }
+    }
+}

--- a/provider-swift/Tests/ProviderCoreTests/Gemma4ToolSchemaEnforcementTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/Gemma4ToolSchemaEnforcementTests.swift
@@ -1,0 +1,211 @@
+import Foundation
+import Testing
+
+@testable import ProviderCore
+
+/// E1 last-line-of-defense invariants for gemma4 tool specs
+/// (`Gemma4TemplateFix.normalizeTools` → `Gemma4ToolSchemaEnforcement`): even
+/// if a caller bypasses the shared normalizers, every `function.parameters`
+/// handed to the served Gemma template is a mapping in which EVERY property
+/// value is a mapping with a String `type`, the non-empty root carries a
+/// String `type` (the macro's closing brace lives in that branch), OBJECT
+/// nodes carry a mapping `properties` (so the template's filter_keys fallback
+/// never iterates junk keys), and `required` members are strings.
+@Suite("Gemma4 tool schema enforcement (E1)")
+struct Gemma4ToolSchemaEnforcementTests {
+
+    private let gemmaContext = ChatTemplateFixContext(
+        modelId: "gemma-4-26b-a4b-it-qat-4bit", modelType: "gemma4_text")
+
+    private func tool(parameters: (any Sendable)?) -> [String: any Sendable] {
+        var function: [String: any Sendable] = [
+            "name": "f", "description": "d",
+        ]
+        if let parameters {
+            function["parameters"] = parameters
+        }
+        return ["type": "function", "function": function]
+    }
+
+    private func params(of tool: [String: any Sendable]?) -> [String: any Sendable]? {
+        (tool?["function"] as? [String: any Sendable])?["parameters"]
+            as? [String: any Sendable]
+    }
+
+    @Test func appliesGatesOnGemma4() {
+        #expect(Gemma4TemplateFix.applies(to: gemmaContext))
+        #expect(
+            !Gemma4TemplateFix.applies(
+                to: ChatTemplateFixContext(modelId: "gpt-oss-20b", modelType: "gpt_oss")))
+    }
+
+    @Test func scalarAndBooleanPropertyValuesBecomeTypedMappings() throws {
+        let out = Gemma4TemplateFix.normalizeTools([
+            tool(parameters: [
+                "type": "object",
+                "properties": [
+                    "num": 5,
+                    "str": "shorthand",
+                    "flag": true,
+                ] as [String: any Sendable],
+            ] as [String: any Sendable])
+        ])
+        let props = try #require(params(of: out.first)?["properties"] as? [String: any Sendable])
+        for name in ["num", "str", "flag"] {
+            let node = try #require(props[name] as? [String: any Sendable], "\(name)")
+            #expect(node["type"] as? String == "string", "\(name)")
+        }
+    }
+
+    @Test func typelessPropertyMappingsGainStringType() throws {
+        let out = Gemma4TemplateFix.normalizeTools([
+            tool(parameters: [
+                "properties": [
+                    "empty": [String: any Sendable](),
+                    "constOnly": ["const": "x"] as [String: any Sendable],
+                ] as [String: any Sendable]
+            ] as [String: any Sendable])
+        ])
+        let root = try #require(params(of: out.first))
+        // Root gains a String type (parameters:{ only closes in that branch).
+        #expect(root["type"] as? String == "object")
+        let props = try #require(root["properties"] as? [String: any Sendable])
+        for name in ["empty", "constOnly"] {
+            let node = try #require(props[name] as? [String: any Sendable], "\(name)")
+            #expect(node["type"] as? String == "string", "\(name)")
+        }
+    }
+
+    @Test func nonMappingParametersAreDropped() throws {
+        for junk in ["a string" as any Sendable, [1, 2] as [any Sendable], 42 as any Sendable] {
+            let out = Gemma4TemplateFix.normalizeTools([tool(parameters: junk)])
+            let function = try #require(out.first?["function"] as? [String: any Sendable])
+            #expect(function["parameters"] == nil)
+        }
+    }
+
+    @Test func emptyParametersAreDropped() throws {
+        let out = Gemma4TemplateFix.normalizeTools([
+            tool(parameters: [String: any Sendable]())
+        ])
+        let function = try #require(out.first?["function"] as? [String: any Sendable])
+        #expect(function["parameters"] == nil)
+    }
+
+    @Test func objectNodeWithoutPropertiesGainsEmptyProperties() throws {
+        let out = Gemma4TemplateFix.normalizeTools([
+            tool(parameters: [
+                "type": "object",
+                "properties": [
+                    // OBJECT-typed with junk keys and NO properties: without the
+                    // injected empty `properties` the template's filter_keys
+                    // fallback iterates `minProperties`/`patternProperties` as
+                    // if they were property schemas.
+                    "cfg": [
+                        "type": "object",
+                        "minProperties": 1,
+                        "patternProperties": ["^e_": [String: any Sendable]()]
+                            as [String: any Sendable],
+                    ] as [String: any Sendable]
+                ] as [String: any Sendable],
+            ] as [String: any Sendable])
+        ])
+        let props = try #require(params(of: out.first)?["properties"] as? [String: any Sendable])
+        let cfg = try #require(props["cfg"] as? [String: any Sendable])
+        let injected = try #require(cfg["properties"] as? [String: any Sendable])
+        #expect(injected.isEmpty)
+    }
+
+    @Test func requiredMembersAreCoercedToStrings() throws {
+        let out = Gemma4TemplateFix.normalizeTools([
+            tool(parameters: [
+                "type": "object",
+                "properties": ["a": ["type": "string"] as [String: any Sendable]]
+                    as [String: any Sendable],
+                "required": ["a", 1, true, ["nested": "junk"] as [String: any Sendable]]
+                    as [any Sendable],
+            ] as [String: any Sendable])
+        ])
+        let required = try #require(params(of: out.first)?["required"] as? [String])
+        #expect(required.count == 3)
+        #expect(required[0] == "a")
+        // Scalars stringified, the composite dropped.
+        #expect(required.allSatisfy { !$0.isEmpty })
+    }
+
+    @Test func nonArrayRequiredIsRemoved() throws {
+        let out = Gemma4TemplateFix.normalizeTools([
+            tool(parameters: [
+                "type": "object",
+                "properties": [String: any Sendable](),
+                "required": "a",
+            ] as [String: any Sendable])
+        ])
+        let root = try #require(params(of: out.first))
+        #expect(root["required"] == nil)
+    }
+
+    @Test func nestedItemsAreEnforced() throws {
+        let out = Gemma4TemplateFix.normalizeTools([
+            tool(parameters: [
+                "type": "object",
+                "properties": [
+                    "arr": [
+                        "type": "array",
+                        "items": [
+                            "properties": ["inner": 7] as [String: any Sendable],
+                            "required": [3] as [any Sendable],
+                        ] as [String: any Sendable],
+                    ] as [String: any Sendable]
+                ] as [String: any Sendable],
+            ] as [String: any Sendable])
+        ])
+        let props = try #require(params(of: out.first)?["properties"] as? [String: any Sendable])
+        let arr = try #require(props["arr"] as? [String: any Sendable])
+        let items = try #require(arr["items"] as? [String: any Sendable])
+        let inner = try #require(
+            (items["properties"] as? [String: any Sendable])?["inner"] as? [String: any Sendable])
+        #expect(inner["type"] as? String == "string")
+        #expect(items["required"] as? [String] == ["3"])
+    }
+
+    @Test func functionNameAndDescriptionCoercedToStrings() throws {
+        let out = Gemma4TemplateFix.normalizeTools([
+            [
+                "type": "function",
+                "function": ["name": 7, "parameters": ["properties": [String: any Sendable]()] as [String: any Sendable]]
+                    as [String: any Sendable],
+            ]
+        ])
+        let function = try #require(out.first?["function"] as? [String: any Sendable])
+        // The declaration macro string-concatenates the name and renders the
+        // description unconditionally — both must exist as strings.
+        #expect(function["name"] as? String == "7")
+        #expect(function["description"] as? String == "")
+    }
+
+    @Test func wellFormedSpecPassesThroughValueEquivalent() throws {
+        let parameters: [String: any Sendable] = [
+            "type": "object",
+            "properties": [
+                "city": ["type": "string", "description": "c"] as [String: any Sendable],
+                "opts": [
+                    "type": "object",
+                    "properties": ["verbose": ["type": "boolean"] as [String: any Sendable]]
+                        as [String: any Sendable],
+                ] as [String: any Sendable],
+            ] as [String: any Sendable],
+            "required": ["city"],
+        ]
+        let out = Gemma4TemplateFix.normalizeTools([tool(parameters: parameters)])
+        let root = try #require(params(of: out.first))
+        #expect(root["type"] as? String == "object")
+        let props = try #require(root["properties"] as? [String: any Sendable])
+        let city = try #require(props["city"] as? [String: any Sendable])
+        #expect(city["type"] as? String == "string")
+        #expect(city["description"] as? String == "c")
+        let opts = try #require(props["opts"] as? [String: any Sendable])
+        #expect((opts["properties"] as? [String: any Sendable])?.count == 1)
+        #expect(root["required"] as? [String] == ["city"])
+    }
+}

--- a/provider-swift/Tests/ProviderCoreTests/Gemma4TurnStructureTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/Gemma4TurnStructureTests.swift
@@ -316,4 +316,54 @@ struct Gemma4TurnStructureTests {
         let out = try Gemma4TemplateFix.normalizeMessages(input)
         #expect((out[1]["reasoning_content"] as? String) == "earlier thoughts")
     }
+
+    /// PR #548 round 3 (Codex P2): an unanswered assistant tool_call turn
+    /// MID-HISTORY leaves the served template's forward scan answerless (the
+    /// dangling tool_response shape) — fail closed as a clean 400.
+    @Test func unansweredMidHistoryCallThrows() {
+        let input: [[String: any Sendable]] = [
+            ["role": "user", "content": "hi"],
+            assistant(text: "", callIDs: ["a"]),
+            ["role": "user", "content": "and then?"],
+        ]
+        #expect(throws: MultiModelBatchSchedulerEngineError.self) {
+            _ = try Gemma4TemplateFix.normalizeMessages(input)
+        }
+    }
+
+    /// A partially answered turn (one of two calls resolved) followed by more
+    /// history is equally broken.
+    @Test func partiallyAnsweredMidHistoryCallThrows() {
+        let input: [[String: any Sendable]] = [
+            assistant(text: "", callIDs: ["a", "b"]),
+            toolResult(id: "a"),
+            ["role": "user", "content": "next"],
+        ]
+        #expect(throws: MultiModelBatchSchedulerEngineError.self) {
+            _ = try Gemma4TemplateFix.normalizeMessages(input)
+        }
+    }
+
+    /// TRAILING exemption: a history that ENDS on an unanswered tool_call turn
+    /// is the legitimate continuation shape and passes through unchanged.
+    @Test func trailingUnansweredCallPasses() throws {
+        let input: [[String: any Sendable]] = [
+            ["role": "user", "content": "hi"],
+            assistant(text: "", callIDs: ["a"]),
+        ]
+        let out = try Gemma4TemplateFix.normalizeMessages(input)
+        #expect(out.count == 2)
+    }
+
+    /// An id-less result covers an otherwise-unanswered call (legacy pairing
+    /// the template renders via its name fallback).
+    @Test func idlessResultCoversUnansweredCallMidHistory() throws {
+        let input: [[String: any Sendable]] = [
+            assistant(text: "", callIDs: ["a"]),
+            toolResult(id: nil),
+            ["role": "user", "content": "next"],
+        ]
+        let out = try Gemma4TemplateFix.normalizeMessages(input)
+        #expect(out.count == 3)
+    }
 }

--- a/provider-swift/Tests/ProviderCoreTests/Gemma4TurnStructureTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/Gemma4TurnStructureTests.swift
@@ -1,0 +1,293 @@
+import Foundation
+import Testing
+
+@testable import ProviderCore
+
+/// E2 turn-structure normalization for the served Gemma template
+/// (`Gemma4TemplateFix.normalizeMessages` → `Gemma4TurnStructure`): the
+/// template's forward scan only reads the CONTIGUOUS `role:"tool"` run after
+/// an assistant tool_calls message (non-contiguous results render under the
+/// wrong turn / leave a dangling `<|tool_response>` opener), and a text-only
+/// assistant message followed by another assistant message closes its turn
+/// while the follow-up renders without an opener.
+@Suite("Gemma4 turn structure (E2)")
+struct Gemma4TurnStructureTests {
+
+    private let gemmaContext = ChatTemplateFixContext(
+        modelId: "gemma-4-26b-a4b-it-qat-4bit", modelType: "gemma4_text")
+
+    private func assistant(
+        text: String = "",
+        callIDs: [String] = [],
+        reasoning: String? = nil
+    ) -> [String: any Sendable] {
+        var message: [String: any Sendable] = ["role": "assistant", "content": text]
+        if !callIDs.isEmpty {
+            message["tool_calls"] = callIDs.map { id -> [String: any Sendable] in
+                [
+                    "id": id, "type": "function",
+                    "function": ["name": "fn_\(id)", "arguments": [String: any Sendable]()]
+                        as [String: any Sendable],
+                ]
+            } as [any Sendable]
+        }
+        if let reasoning {
+            message["reasoning_content"] = reasoning
+        }
+        return message
+    }
+
+    private func toolResult(id: String?, text: String = "ok") -> [String: any Sendable] {
+        var message: [String: any Sendable] = ["role": "tool", "content": text]
+        if let id { message["tool_call_id"] = id }
+        return message
+    }
+
+    private func roleAndIDs(_ messages: [[String: any Sendable]]) -> [String] {
+        messages.map { message in
+            let role = (message["role"] as? String) ?? "?"
+            if role == "tool" {
+                return "tool(\((message["tool_call_id"] as? String) ?? "-"))"
+            }
+            if let calls = message["tool_calls"] as? [any Sendable], !calls.isEmpty {
+                let ids = calls.compactMap { ($0 as? [String: any Sendable])?["id"] as? String }
+                return "\(role)[\(ids.joined(separator: ","))]"
+            }
+            return role
+        }
+    }
+
+    // MARK: - Re-pairing
+
+    /// Two back-to-back tool_call turns whose results arrive as one trailing
+    /// run: the template's forward scan from the FIRST turn hits the second
+    /// assistant and stops (dangling `<|tool_response>` opener). Results must
+    /// be re-emitted contiguously after their owning turns.
+    @Test func repairsResultsAcrossConsecutiveToolCallTurns() throws {
+        let input = [
+            assistant(callIDs: ["id1"]),
+            assistant(callIDs: ["id2"]),
+            toolResult(id: "id1", text: "r1"),
+            toolResult(id: "id2", text: "r2"),
+        ]
+        let out = try Gemma4TemplateFix.normalizeMessages(input)
+        #expect(
+            roleAndIDs(out) == [
+                "assistant[id1]", "tool(id1)", "assistant[id2]", "tool(id2)",
+            ])
+    }
+
+    /// Results inside one contiguous run are re-ordered to the tool_calls
+    /// order (the template renders the run positionally).
+    @Test func ordersResultsByToolCallsOrder() throws {
+        let input = [
+            assistant(callIDs: ["id1", "id2"]),
+            toolResult(id: "id2", text: "r2"),
+            toolResult(id: "id1", text: "r1"),
+        ]
+        let out = try Gemma4TemplateFix.normalizeMessages(input)
+        #expect(roleAndIDs(out) == ["assistant[id1,id2]", "tool(id1)", "tool(id2)"])
+    }
+
+    /// Multiple results for the same call id keep arrival order.
+    @Test func keepsArrivalOrderForRepeatedResultIDs() throws {
+        let input = [
+            assistant(callIDs: ["id1"]),
+            toolResult(id: "id1", text: "first"),
+            toolResult(id: "id1", text: "second"),
+        ]
+        let out = try Gemma4TemplateFix.normalizeMessages(input)
+        #expect((out[1]["content"] as? String) == "first")
+        #expect((out[2]["content"] as? String) == "second")
+    }
+
+    /// A re-used call id (retry loops re-issue the same id every round) pairs
+    /// with the MOST RECENT declaring turn.
+    @Test func reusedCallIDPairsWithMostRecentTurn() throws {
+        let input = [
+            assistant(callIDs: ["id1"]),
+            toolResult(id: "id1", text: "round1"),
+            assistant(callIDs: ["id1"]),
+            toolResult(id: "id1", text: "round2"),
+        ]
+        let out = try Gemma4TemplateFix.normalizeMessages(input)
+        #expect(roleAndIDs(out) == ["assistant[id1]", "tool(id1)", "assistant[id1]", "tool(id1)"])
+        #expect((out[1]["content"] as? String) == "round1")
+        #expect((out[3]["content"] as? String) == "round2")
+    }
+
+    /// Results without a tool_call_id stay attached, in arrival order, after
+    /// the paired block of the run's tool-call turn (the template renders them
+    /// via its name fallback — they must not be dropped or rejected).
+    @Test func idlessResultsStayAttachedAfterPairedBlock() throws {
+        let input = [
+            assistant(callIDs: ["id1"]),
+            toolResult(id: nil, text: "legacy"),
+            toolResult(id: "id1", text: "r1"),
+        ]
+        let out = try Gemma4TemplateFix.normalizeMessages(input)
+        #expect(roleAndIDs(out) == ["assistant[id1]", "tool(id1)", "tool(-)"])
+        #expect((out[2]["content"] as? String) == "legacy")
+    }
+
+    // MARK: - Orphans
+
+    /// A result whose id matches NO preceding assistant tool_call is a clean
+    /// 400 (invalidToolPayload), mirroring the Harmony splitter's orphan rule.
+    @Test func orphanResultThrowsInvalidToolPayload() {
+        let input = [
+            assistant(callIDs: ["id1"]),
+            toolResult(id: "id1"),
+            toolResult(id: "ghost"),
+        ]
+        #expect(throws: MultiModelBatchSchedulerEngineError.self) {
+            _ = try Gemma4TemplateFix.normalizeMessages(input)
+        }
+        do {
+            _ = try Gemma4TemplateFix.normalizeMessages(input)
+            Issue.record("expected invalidToolPayload")
+        } catch let error as MultiModelBatchSchedulerEngineError {
+            guard case .invalidToolPayload(let message) = error else {
+                Issue.record("wrong case: \(error)")
+                return
+            }
+            #expect(message.contains("ghost"))
+        } catch {
+            Issue.record("unexpected error: \(error)")
+        }
+    }
+
+    /// A result answering a call that is only declared LATER is an orphan too
+    /// (results cannot precede their call).
+    @Test func resultForFutureCallThrows() {
+        let input = [
+            assistant(callIDs: ["id1"]),
+            toolResult(id: "id2"),
+            assistant(callIDs: ["id2"]),
+        ]
+        #expect(throws: MultiModelBatchSchedulerEngineError.self) {
+            _ = try Gemma4TemplateFix.normalizeMessages(input)
+        }
+    }
+
+    // MARK: - Assistant text merge
+
+    /// A text-only assistant message immediately followed by another assistant
+    /// message folds into it (`\n\n`-joined prefix) so the pair renders one
+    /// closed model turn.
+    @Test func mergesConsecutiveAssistantText() throws {
+        let input: [[String: any Sendable]] = [
+            ["role": "user", "content": "hi"],
+            assistant(text: "part one"),
+            assistant(text: "part two"),
+        ]
+        let out = try Gemma4TemplateFix.normalizeMessages(input)
+        #expect(out.count == 2)
+        #expect((out[1]["content"] as? String) == "part one\n\npart two")
+    }
+
+    /// A chain of text-only turns folds into the FINAL assistant message —
+    /// including one that carries tool_calls.
+    @Test func mergesChainIntoToolCallTurn() throws {
+        let input = [
+            assistant(text: "a"),
+            assistant(text: "b"),
+            assistant(text: "c", callIDs: ["id1"]),
+            toolResult(id: "id1"),
+        ]
+        let out = try Gemma4TemplateFix.normalizeMessages(input)
+        #expect(out.count == 2)
+        #expect((out[0]["content"] as? String) == "a\n\nb\n\nc")
+        #expect(roleAndIDs(out) == ["assistant[id1]", "tool(id1)"])
+    }
+
+    /// An EMPTY text-only assistant message contributes no prefix (no stray
+    /// newlines) and disappears.
+    @Test func emptyAssistantTextFoldsAway() throws {
+        let input: [[String: any Sendable]] = [
+            assistant(text: "  "),
+            assistant(text: "answer"),
+        ]
+        let out = try Gemma4TemplateFix.normalizeMessages(input)
+        #expect(out.count == 1)
+        #expect((out[0]["content"] as? String) == "answer")
+    }
+
+    /// The earlier turn's reasoning is carried when the later turn has none.
+    @Test func mergeCarriesReasoningWhenLaterHasNone() throws {
+        let input: [[String: any Sendable]] = [
+            assistant(text: "thought out loud", reasoning: "chain"),
+            assistant(text: "final"),
+        ]
+        let out = try Gemma4TemplateFix.normalizeMessages(input)
+        #expect(out.count == 1)
+        #expect((out[0]["reasoning_content"] as? String) == "chain")
+        #expect((out[0]["content"] as? String) == "thought out loud\n\nfinal")
+    }
+
+    /// A tool_calls turn followed by an assistant text turn is the template's
+    /// own well-formed continuation (open turn → content → close): NOT merged.
+    @Test func toolCallTurnThenTextIsNotMerged() throws {
+        let input = [
+            assistant(callIDs: ["id1"]),
+            toolResult(id: "id1"),
+            assistant(text: "the answer"),
+        ]
+        let out = try Gemma4TemplateFix.normalizeMessages(input)
+        #expect(out.count == 3)
+        #expect(roleAndIDs(out) == ["assistant[id1]", "tool(id1)", "assistant"])
+    }
+
+    /// Assistant messages with content-parts arrays are left alone (the merge
+    /// cannot represent non-text parts as a string prefix).
+    @Test func contentPartsAssistantIsNotMergedAway() throws {
+        let parts: [[String: any Sendable]] = [["type": "text", "text": "see image"]]
+        let input: [[String: any Sendable]] = [
+            ["role": "assistant", "content": parts as [any Sendable]],
+            assistant(text: "follow-up"),
+        ]
+        let out = try Gemma4TemplateFix.normalizeMessages(input)
+        #expect(out.count == 2)
+    }
+
+    // MARK: - Wiring
+
+    /// The production chokepoint (`ChatTemplateFixes.normalizeMessages`) runs
+    /// the gemma repair for gemma4 contexts…
+    @Test func chatTemplateFixesRoutesGemmaContexts() throws {
+        let input = [
+            assistant(callIDs: ["id1"]),
+            assistant(callIDs: ["id2"]),
+            toolResult(id: "id1"),
+            toolResult(id: "id2"),
+        ]
+        let out = try ChatTemplateFixes.normalizeMessages(input, context: gemmaContext)
+        #expect(roleAndIDs(out) == ["assistant[id1]", "tool(id1)", "assistant[id2]", "tool(id2)"])
+    }
+
+    /// …and non-gemma contexts are untouched by it (`applies(to:)` gates).
+    @Test func nonGemmaContextsAreUntouched() throws {
+        let input = [
+            assistant(text: "a"),
+            assistant(text: "b"),
+        ]
+        let out = try ChatTemplateFixes.normalizeMessages(
+            input, context: ChatTemplateFixContext(modelId: "qwen3-8b", modelType: "qwen3"))
+        #expect(out.count == 2)
+    }
+
+    /// Plain histories (no tools, no consecutive assistants) pass through
+    /// value-identical.
+    @Test func plainHistoriesPassThrough() throws {
+        let input: [[String: any Sendable]] = [
+            ["role": "system", "content": "s"],
+            ["role": "user", "content": "u"],
+            assistant(text: "a"),
+            ["role": "user", "content": "u2"],
+        ]
+        let out = try Gemma4TemplateFix.normalizeMessages(input)
+        #expect(out.count == 4)
+        #expect(roleAndIDs(out) == ["system", "user", "assistant", "user"])
+        #expect((out[2]["content"] as? String) == "a")
+    }
+}

--- a/provider-swift/Tests/ProviderCoreTests/Gemma4TurnStructureTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/Gemma4TurnStructureTests.swift
@@ -290,4 +290,30 @@ struct Gemma4TurnStructureTests {
         #expect(roleAndIDs(out) == ["system", "user", "assistant", "user"])
         #expect((out[2]["content"] as? String) == "a")
     }
+
+    /// Post-push Codex P2: when BOTH merged assistant turns carry reasoning,
+    /// the earlier turn's reasoning must be concatenated ahead of the later
+    /// one (same "\n\n" join as content) — never silently dropped.
+    @Test func mergeConcatenatesBothTurnsReasoning() throws {
+        let input: [[String: any Sendable]] = [
+            ["role": "user", "content": "hi"],
+            assistant(text: "part one", reasoning: "earlier thoughts"),
+            assistant(text: "part two", reasoning: "later thoughts"),
+        ]
+        let out = try Gemma4TemplateFix.normalizeMessages(input)
+        #expect(out.count == 2)
+        #expect((out[1]["content"] as? String) == "part one\n\npart two")
+        #expect((out[1]["reasoning_content"] as? String) == "earlier thoughts\n\nlater thoughts")
+    }
+
+    /// Carry (not concatenate) when only the earlier turn has reasoning.
+    @Test func mergeCarriesEarlierReasoningWhenLaterHasNone() throws {
+        let input: [[String: any Sendable]] = [
+            ["role": "user", "content": "hi"],
+            assistant(text: "part one", reasoning: "earlier thoughts"),
+            assistant(text: "part two"),
+        ]
+        let out = try Gemma4TemplateFix.normalizeMessages(input)
+        #expect((out[1]["reasoning_content"] as? String) == "earlier thoughts")
+    }
 }

--- a/provider-swift/Tests/ProviderCoreTests/JinjaSanitizationTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/JinjaSanitizationTests.swift
@@ -257,9 +257,15 @@ final class JinjaSanitizationTests: XCTestCase {
         XCTAssertEqual(function?["description"] as? String, "")
     }
 
-    func testMissingToolDescriptionIsNotFilledForNonHarmonyTemplates() throws {
+    /// Models with NO model-specific template fix (neither Harmony nor
+    /// Gemma 4) must not have a missing tool description invented for them.
+    /// Gemma 4 now fills it too (its template interpolates the description
+    /// unconditionally) — that behavior is pinned in
+    /// `Gemma4ToolSchemaEnforcementTests`, so the fixture here is a model
+    /// outside both families.
+    func testMissingToolDescriptionIsNotFilledForModelsWithoutTemplateFix() throws {
         let request = try ProviderLoop.decodeOpenAIRequest(Data(#"""
-        {"model":"gemma-4-26b","messages":[{"role":"user","content":"x"}],
+        {"model":"qwen3-30b","messages":[{"role":"user","content":"x"}],
          "tools":[{"type":"function","function":{"name":"add","parameters":{"type":"object"}}}]}
         """#.utf8))
 
@@ -267,7 +273,7 @@ final class JinjaSanitizationTests: XCTestCase {
         let sanitized = try XCTUnwrap(
             ChatTemplateFixes.normalizeTools(
                 [rawSpec],
-                context: .init(modelId: "gemma-4-26b")
+                context: .init(modelId: "qwen3-30b")
             )?.first)
         let function = sanitized["function"] as? [String: any Sendable]
         XCTAssertNil(function?["description"])
@@ -457,7 +463,12 @@ final class JinjaSanitizationTests: XCTestCase {
         XCTAssertNil(bad["properties"])
     }
 
-    func testToolSchemaConcatCleanupDoesNotRunForNonHarmonyTemplates() throws {
+    /// Models with NO model-specific template fix keep malformed tool specs
+    /// byte-for-byte (only null/Optional leaves are sanitized). Gemma 4 now
+    /// repairs these shapes as well — its coercions are pinned in
+    /// `Gemma4ToolSchemaEnforcementTests` — so the fixture here is a model
+    /// outside both the Harmony and Gemma 4 families.
+    func testToolSchemaConcatCleanupDoesNotRunForModelsWithoutTemplateFix() throws {
         let rawSpec: [String: any Sendable] = [
             "type": "function",
             "function": [
@@ -478,7 +489,7 @@ final class JinjaSanitizationTests: XCTestCase {
         let sanitized = try XCTUnwrap(
             ChatTemplateFixes.normalizeTools(
                 [rawSpec],
-                context: .init(modelId: "gemma-4-26b")
+                context: .init(modelId: "qwen3-30b")
             )?.first)
         let function = try XCTUnwrap(sanitized["function"] as? [String: any Sendable])
         XCTAssertEqual(function["description"] as? Int, 42)

--- a/provider-swift/Tests/ProviderCoreTests/ToolChoiceViolationErrorTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ToolChoiceViolationErrorTests.swift
@@ -1,0 +1,73 @@
+import Foundation
+import Testing
+
+@testable import ProviderCore
+
+/// E5: forced tool_choice enforcement failures ("model did not emit the
+/// required tool call" / "outside tool_choice" / "deferred content limit")
+/// were thrown as `.generationFailed` → generic 500 `cbv2_engine_error`,
+/// reading as a provider fault for an OUTPUT-dependent condition a re-sample
+/// can fix. They are now the typed `.toolChoiceViolation` → HTTP 422 with
+/// wire error_reason "tool_noncompliance" (whitelisted coordinator-side).
+@Suite("Tool-choice violation typed error (E5)")
+struct ToolChoiceViolationErrorTests {
+
+    private let violations = [
+        "model did not emit the required tool call",
+        "model emitted a tool call outside tool_choice",
+        "required tool call response exceeded deferred content limit",
+    ]
+
+    @Test func mapsTo422() {
+        for message in violations {
+            let status = ProviderLoop.mapInferenceErrorToStatus(
+                MultiModelBatchSchedulerEngineError.toolChoiceViolation(message))
+            #expect(status == 422, "\(message)")
+        }
+    }
+
+    @Test func classifiesAsToolNoncompliance() {
+        for message in violations {
+            let error = MultiModelBatchSchedulerEngineError.toolChoiceViolation(message)
+            #expect(classifyTypedInferenceErrorReason(error) == "tool_noncompliance")
+            // The full classifier routes through the typed check first.
+            #expect(classifyInferenceErrorReason(error) == "tool_noncompliance")
+        }
+    }
+
+    @Test func errorDescriptionCarriesTheMessage() {
+        let error = MultiModelBatchSchedulerEngineError.toolChoiceViolation(
+            "model did not emit the required tool call")
+        #expect(error.errorDescription == "model did not emit the required tool call")
+    }
+
+    /// The typed classifier is TYPE-driven: other engine errors (including a
+    /// generationFailed whose text mentions the same phrases) yield nil, so
+    /// the mid-stream terminal cannot mislabel an engine fault.
+    @Test func typedClassifierIgnoresOtherErrors() {
+        #expect(
+            classifyTypedInferenceErrorReason(
+                MultiModelBatchSchedulerEngineError.generationFailed(
+                    "model did not emit the required tool call")) == nil)
+        #expect(
+            classifyTypedInferenceErrorReason(
+                MultiModelBatchSchedulerEngineError.invalidToolPayload("bad")) == nil)
+        #expect(classifyTypedInferenceErrorReason(CancellationError()) == nil)
+    }
+
+    /// Regression: the jinja string classification is unchanged by the typed
+    /// fast path.
+    @Test func jinjaClassificationUnchanged() {
+        struct FakeTemplateError: Error, CustomStringConvertible {
+            let description = "Jinja.TemplateException: upper filter requires string"
+        }
+        #expect(classifyInferenceErrorReason(FakeTemplateError()) == "jinja_template")
+    }
+
+    /// A generationFailed still maps to 500 — the typed case is what moved.
+    @Test func generationFailedStill500() {
+        let status = ProviderLoop.mapInferenceErrorToStatus(
+            MultiModelBatchSchedulerEngineError.generationFailed("boom"))
+        #expect(status == 500)
+    }
+}

--- a/provider-swift/Tests/ProviderCoreTests/ToolSchemaNormalizationCorpusTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ToolSchemaNormalizationCorpusTests.swift
@@ -177,4 +177,31 @@ struct ToolSchemaNormalizationCorpusTests {
         #expect(props["one"] as? Int == 1)
         #expect(props["zero"] as? Int == 0)
     }
+
+    /// Post-push Codex P2: an OBJECT-typed node without a mapping
+    /// `properties` re-exposes the served template's `filter_keys=true`
+    /// fallback, which iterates the node's OWN keys (patternProperties has
+    /// no `type` -> `| upper` throws). The shared normalizer must inject an
+    /// empty `properties` map — mirror of coordinator toolschema.go and
+    /// gemma4 enforcement invariant 4.
+    @Test func objectNodesAlwaysCarryPropertiesMap() throws {
+        let props = try normalizedProps(
+            #"{"type":"object","properties":{"env":{"type":"object","patternProperties":{"^ENV_":{"type":"string"}}}}}"#)
+        let env = try #require(props["env"] as? [String: Any])
+        let injected = try #require(env["properties"] as? [String: Any], "object node must gain properties")
+        #expect(injected.isEmpty)
+
+        // Typeless patternProperties-only node: inferred object gains it too.
+        let props2 = try normalizedProps(
+            #"{"type":"object","properties":{"env":{"patternProperties":{"^X_":{"type":"string"}}}}}"#)
+        let env2 = try #require(props2["env"] as? [String: Any])
+        #expect(env2["type"] as? String == "object")
+        #expect(env2["properties"] is [String: Any])
+
+        // Non-mapping properties on an object node becomes an empty map.
+        let props3 = try normalizedProps(
+            #"{"type":"object","properties":{"o":{"type":"object","properties":"junk"}}}"#)
+        let o = try #require(props3["o"] as? [String: Any])
+        #expect(o["properties"] is [String: Any])
+    }
 }

--- a/provider-swift/Tests/ProviderCoreTests/ToolSchemaNormalizationCorpusTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ToolSchemaNormalizationCorpusTests.swift
@@ -1,0 +1,180 @@
+import Foundation
+import Testing
+
+@testable import ProviderCore
+
+/// E1 crash-corpus mirror (2026-07-15 platform errors deep dive) of the
+/// coordinator's `toolschema_corpus_test.go`: valid JSON-Schema shapes the
+/// marker-key heuristic previously let through UNTYPED, crashing the served
+/// Gemma template's `{{ value['type'] | upper }}` ("upper filter requires
+/// string", 23k provider 500s/day). The positional rule guarantees a string
+/// `type` on every value in a schema-positional slot.
+@Suite("Tool schema normalization crash corpus (E1)")
+struct ToolSchemaNormalizationCorpusTests {
+
+    private func normalizedProps(_ parametersJSON: String) throws -> [String: Any] {
+        let body = """
+            {"tools":[{"type":"function","function":{"name":"f",
+              "parameters":\(parametersJSON)}}]}
+            """.data(using: .utf8)!
+        let out = ToolSchemaNormalization.ensureParameterTypes(in: body)
+        let root = (try? JSONSerialization.jsonObject(with: out)) as? [String: Any] ?? [:]
+        let tools = try #require(root["tools"] as? [[String: Any]])
+        let function = try #require(tools[0]["function"] as? [String: Any])
+        let params = try #require(function["parameters"] as? [String: Any])
+        return try #require(params["properties"] as? [String: Any])
+    }
+
+    private func typeOf(_ node: Any?) -> String? {
+        (node as? [String: Any])?["type"] as? String
+    }
+
+    @Test func emptyPropertySchemaGainsStringType() throws {
+        let props = try normalizedProps(#"{"type":"object","properties":{"x":{}}}"#)
+        #expect(typeOf(props["x"]) == "string")
+    }
+
+    @Test func markerlessAnnotationOnlyNodesGainStringType() throws {
+        let cases: [String: String] = [
+            "const-only": #"{"const":"fixed"}"#,
+            "default-only": #"{"default":5}"#,
+            "title-only": #"{"title":"T"}"#,
+            "format-only": #"{"format":"date-time"}"#,
+            "pattern-only": #"{"pattern":"^a"}"#,
+            "ref-only": ##"{"$ref":"#/$defs/x"}"##,
+            "minimum-only": #"{"minimum":1}"#,
+            "maxLength-only": #"{"maxLength":10}"#,
+        ]
+        for (name, schema) in cases {
+            let props = try normalizedProps(
+                #"{"type":"object","properties":{"x":"# + schema + "}}")
+            let node = try #require(props["x"] as? [String: Any], "\(name)")
+            #expect(node["type"] as? String == "string", "\(name)")
+            // The original annotation key survives beside the injected type.
+            #expect(node.count == 2, "\(name): \(node)")
+        }
+    }
+
+    @Test func booleanPropertySchemasBecomeStringTyped() throws {
+        let props = try normalizedProps(
+            #"{"type":"object","properties":{"x":true,"y":false}}"#)
+        for name in ["x", "y"] {
+            let node = try #require(props[name] as? [String: Any], "\(name)")
+            #expect(node["type"] as? String == "string", "\(name)")
+            #expect(node.count == 1, "\(name)")
+        }
+    }
+
+    @Test func booleanItemsBecomeStringTyped() throws {
+        let props = try normalizedProps(
+            #"{"type":"object","properties":{"arr":{"type":"array","items":true}}}"#)
+        let arr = try #require(props["arr"] as? [String: Any])
+        let items = try #require(arr["items"] as? [String: Any])
+        #expect(items["type"] as? String == "string")
+    }
+
+    @Test func scalarNonStringTypeCollapses() throws {
+        let props = try normalizedProps(
+            #"{"type":"object","properties":{"n":{"type":123},"o":{"type":42,"properties":{"inner":{}}}}}"#)
+        #expect(typeOf(props["n"]) == "string")
+        let o = try #require(props["o"] as? [String: Any])
+        #expect(o["type"] as? String == "object")
+        let inner = (o["properties"] as? [String: Any])?["inner"]
+        #expect(typeOf(inner) == "string")
+    }
+
+    @Test func patternPropertiesValuesAreSchemas() throws {
+        let props = try normalizedProps(
+            #"{"type":"object","properties":{"env":{"type":"object","patternProperties":{"^ENV_":{},"^ANY_":true}}}}"#)
+        let env = try #require(props["env"] as? [String: Any])
+        let pp = try #require(env["patternProperties"] as? [String: Any])
+        #expect(typeOf(pp["^ENV_"]) == "string")
+        #expect(typeOf(pp["^ANY_"]) == "string")
+    }
+
+    @Test func patternPropertiesOnlyNodeInfersObject() throws {
+        let props = try normalizedProps(
+            #"{"type":"object","properties":{"env":{"patternProperties":{"^X_":{"type":"string"}}}}}"#)
+        #expect(typeOf(props["env"]) == "object")
+    }
+
+    @Test func prefixItemsMembersAreSchemas() throws {
+        let props = try normalizedProps(
+            #"{"type":"object","properties":{"pair":{"prefixItems":[{},{"const":1},true]}}}"#)
+        let pair = try #require(props["pair"] as? [String: Any])
+        #expect(pair["type"] as? String == "array")
+        let members = try #require(pair["prefixItems"] as? [Any])
+        #expect(members.count == 3)
+        for member in members {
+            #expect(typeOf(member) == "string")
+        }
+    }
+
+    @Test func tupleFormItemsMembersAreSchemas() throws {
+        let props = try normalizedProps(
+            #"{"type":"object","properties":{"tup":{"type":"array","items":[{},false]}}}"#)
+        let tup = try #require(props["tup"] as? [String: Any])
+        let members = try #require(tup["items"] as? [Any])
+        for member in members {
+            #expect(typeOf(member) == "string")
+        }
+    }
+
+    @Test func markerlessUnionMembersAreSchemas() throws {
+        let props = try normalizedProps(
+            #"{"type":"object","properties":{"u":{"anyOf":[{},{"const":3}]},"o":{"oneOf":[{"format":"uuid"}]},"a":{"allOf":[{}]}}}"#)
+        for (name, key) in [("u", "anyOf"), ("o", "oneOf"), ("a", "allOf")] {
+            let node = try #require(props[name] as? [String: Any], "\(name)")
+            let members = try #require(node[key] as? [Any], "\(name)")
+            for member in members {
+                #expect(typeOf(member) == "string", "\(name).\(key)")
+            }
+        }
+    }
+
+    @Test func emptyMapAdditionalPropertiesGainsType() throws {
+        let props = try normalizedProps(
+            #"{"type":"object","properties":{"meta":{"type":"object","additionalProperties":{}}}}"#)
+        let meta = try #require(props["meta"] as? [String: Any])
+        #expect(typeOf(meta["additionalProperties"]) == "string")
+    }
+
+    @Test func bareBooleanAdditionalPropertiesUntouched() throws {
+        let props = try normalizedProps(
+            #"{"type":"object","properties":{"open":{"type":"object","additionalProperties":true}}}"#)
+        let open = try #require(props["open"] as? [String: Any])
+        #expect(open["additionalProperties"] as? Bool == true)
+        #expect(!(open["additionalProperties"] is [String: Any]))
+    }
+
+    /// Positional awareness must not leak to non-positional roots: a bare `{}`
+    /// parameters and a marker-less junk-map root stay untyped.
+    @Test func rootStaysMarkerGated() throws {
+        let body = """
+            {"tools":[
+              {"type":"function","function":{"name":"noargs","parameters":{}}},
+              {"type":"function","function":{"name":"junk","parameters":{"foo":"bar"}}}]}
+            """.data(using: .utf8)!
+        let out = ToolSchemaNormalization.ensureParameterTypes(in: body)
+        let root = (try? JSONSerialization.jsonObject(with: out)) as? [String: Any] ?? [:]
+        let tools = try #require(root["tools"] as? [[String: Any]])
+        let empty = try #require(
+            (tools[0]["function"] as? [String: Any])?["parameters"] as? [String: Any])
+        #expect(empty.isEmpty)
+        let junk = try #require(
+            (tools[1]["function"] as? [String: Any])?["parameters"] as? [String: Any])
+        #expect(junk["type"] == nil)
+        #expect(junk["foo"] as? String == "bar")
+    }
+
+    /// A numeric 0/1 property value must NOT be mistaken for a boolean schema
+    /// (JSONSerialization bridges both through NSNumber).
+    @Test func numericZeroOneNotMistakenForBooleanSchema() throws {
+        let props = try normalizedProps(
+            #"{"type":"object","properties":{"one":1,"zero":0}}"#)
+        // Scalars are not booleans: the shared normalizer leaves them for the
+        // model-scoped enforcement (Gemma4ToolSchemaEnforcement) to repair.
+        #expect(props["one"] as? Int == 1)
+        #expect(props["zero"] as? Int == 0)
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the Gemma 4 tool-calling failure class measured in production on 2026-07-15 (24h, attempt-level):

- **23,134 `jinja_template` provider 500s** — 42.4% of all Gemma tool terminal attempts — live error text `Runtime error: upper filter requires string`. The served Gemma chat template renders `{{ value['type'] | upper }}` over every tool-parameter schema node; valid OpenAI schemas without a string `type` (empty `{}`, `const`/`default`/`format`-only nodes, boolean schemas, non-contiguous shapes) crash the render.
- Each failure was **retried across the fleet** (avg 1.57 dispatches, observed up to 17 attempts, 0 eventual successes) and **charged to provider reputation** via `RecordJobFailure` — a request-shape fault penalizing healthy machines.
- Forced `tool_choice` noncompliance ("model did not emit the required tool call") surfaced as generic 500 `cbv2_engine_error`.
- Streamed **parallel tool calls are all emitted with `index: 0`**; the coordinator's index-keyed reconstruction merged them into one corrupted call (overwritten id/name, concatenated arguments).

Per operator decision, the model artifact/template is **not** re-versioned — every fix ships in code. Google's 2026-07-09 canonical template update fixes turn closures but still ships the unguarded `| upper`, so normalization is required regardless of template version.

## Changes by issue

| ID | Fix | Where |
|---|---|---|
| E1 | Exhaustive, position-aware tool-schema normalization: every value in a schema-positional slot (`properties`, `patternProperties`, `items` incl. tuple form, `prefixItems`, map `additionalProperties`, union members) is a schema — boolean schemas become `{"type":"string"}`, maps always end with a string `type` | `coordinator/api/toolschema.go` (fleet-wide on coordinator deploy), `provider-swift .../ToolSchemaNormalization.swift`, new `Gemma4ToolSchemaEnforcement.swift` (final invariant for gemma4) |
| E2 | Turn-structure normalization replacing the upstream template fix: tool results re-paired contiguously after their owning assistant `tool_calls` message; orphan `tool_call_id` → clean 400; consecutive assistant text turns merged | new `Gemma4TurnStructure.swift` via `Gemma4TemplateFix.normalizeMessages` |
| E3 | `tool_calls[].function.arguments` hardening: missing/empty → `{}`; string → parsed JSON object; parse failure / non-object → 400 `invalidToolPayload` (was: raw string rendered as double-brace corruption the model then imitates) | new `Gemma4ToolCallArguments.swift` |
| E4 | Deterministic template failures (`jinja_channel_tags`/`jinja_null_bridge`/`jinja_template`) stop the dispatch ladder on the FIRST attempt and return one 422 (`model_capability`); rejection ledger reason `template_render_failed`; **no `RecordJobFailure`**. Kill switch `EIGENINFERENCE_JINJA_TERMINAL_REJECT` (default on) | `coordinator/api/dispatch.go`, `coordinator/api/provider.go` |
| E5 | Typed `toolChoiceViolation` → HTTP 422 + normalized wire reason `tool_noncompliance` (whitelisted coordinator-side); still fails over (a different sample can comply) | `MultiModelBatchSchedulerEngineError.swift`, `ProviderLoop+ErrorMapping.swift`, `InferenceErrorClassifier.swift`, `coordinator/api/route_outcome.go` |
| E6 | Defensive reconstruction: a streamed delta re-using a wire index with a DIFFERENT non-empty id starts a new logical call (also fixes a latent sparse-index drop) | `coordinator/api/consumer.go` `extractMessage` |

## Before / After

### Behavior

```mermaid
flowchart LR
  subgraph Before
    A1["Gemma tool request<br/>(valid OpenAI schema)"] --> B1["template render throws<br/>upper filter requires string"]
    B1 --> C1["500 jinja_template"]
    C1 --> D1["retried on up to 17 providers<br/>each takes a reputation hit"]
    D1 --> E1["final 500 to client, 0% success"]
    F1["tool_choice=required but<br/>model answers in prose"] --> G1["generic 500 cbv2_engine_error"]
    H1["two parallel tool calls<br/>both stream index 0"] --> I1["merged into one corrupted call"]
  end
  subgraph After
    A2["Gemma tool request<br/>(valid OpenAI schema)"] --> B2["normalized: every schema node<br/>has a string type, turns re-paired,<br/>arguments are objects"]
    B2 --> C2["render succeeds, 200"]
    B2 -. "truly unrenderable" .-> D2["ONE attempt, 422 model_capability<br/>no reputation hit<br/>ledger: template_render_failed"]
    F2["tool_choice=required but<br/>model answers in prose"] --> G2["422 tool_noncompliance<br/>bounded failover"]
    H2["two parallel tool calls"] --> I2["distinct ids, both calls preserved"]
  end
```

### Code

```mermaid
flowchart LR
  subgraph Before
    a1["NormalizeToolSchemas"] -- "marker heuristic misses empty,<br/>const-only, boolean schemas" --> b1["applyChatTemplate throws"]
    c1["Gemma4TemplateFix (no-op)"] --> b1
    b1 --> d1["handleInferenceError:<br/>RecordJobFailure always"]
    d1 --> e1["shouldStopFailover treats 500<br/>as retryable: retry storm"]
    f1["makeEventStream tool enforcement"] -- "generationFailed" --> g1["mapInferenceErrorToStatus: 500"]
    h1["extractMessage keyed by index"] --> i1["index collision merges calls"]
  end
  subgraph After
    a2["NormalizeToolSchemas:<br/>positional injectTypes"] --> b2["render OK"]
    c2["Gemma4TemplateFix:<br/>SchemaEnforcement, TurnStructure,<br/>ToolCallArguments"] --> b2
    b2 -. "jinja reason latched" .-> e2["latchJinjaTerminalReject: one 422<br/>provider.go skips RecordJobFailure"]
    f2["makeEventStream"] -- "toolChoiceViolation" --> g2["ErrorMapping: 422<br/>reason tool_noncompliance"]
    h2["extractMessage id-aware,<br/>arrival-ordered"] --> i2["parallel calls preserved"]
  end
```

## Tests

- Coordinator: all 21 packages green, `gofmt` clean. New: 13 schema-corpus tests, 9 jinja-terminal tests (incl. kill switch, race-loser latch, reputation matrix), 3 `tool_noncompliance`, 5 reconstruction tests.
- Provider: 1,345/1,345 tests across 148 suites. New suites: corpus mirror (14), gemma enforcement (11), **served-template render regression (5)** — embeds the served template's macros byte-exactly (SHA-pinned `94899c0f…`) and reproduces the exact production error without the fix — turn structure (16), arguments hardening (9), tool-choice violation (6).
- Fails-without-fix verified per issue by reverting the implementation.
- Known pre-existing master flakes (`EngineV2LivenessRecoveryTests` cooldown re-wedge, reproduced on clean origin/master) are unrelated; all pass in isolation and on the final full run.

## Rollout

- Coordinator half (E1-coordinator, E4, E6) takes effect fleet-wide on the next coordinator deploy — no provider release needed.
- Provider half (E1-provider, E2, E3, E5) ships with the next provider release (v0.7.11).
- Kill switch: `EIGENINFERENCE_JINJA_TERMINAL_REJECT=false` restores legacy failover for template errors.

## Deferred follow-ups (engine submodule, separate PR)

- Unique streamed tool-call indices in `MLXOpenAIService.streamChatCompletionFrames` (proper E6 fix; this PR's coordinator fix is defensive and sufficient for correctness).
- `ToolCallProcessor` silently drops unparseable tagged tool output (E7).
- Whether `tool_noncompliance` 422s should also skip provider reputation.

Production evidence and the full remediation plan: `docs/reports/2026-07-15-platform-errors-remediation-plan.md` (local ops doc, untracked).
