### PR TITLE
fix(release): install Go before prompt parity

### DIFF
--- a/.github/workflows/release-swift.yml
+++ b/.github/workflows/release-swift.yml
@@ -185,9 +185,15 @@ jobs:
       - name: Validate release version integrity
         run: ./scripts/check-release-version.sh "$VERSION"
 
+      - name: Set up Go for prompt parity
+        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.4.0
+        with:
+          go-version: '1.25.0'
+
       - name: Show toolchain versions
         run: |
           set -euo pipefail
+          go version
           xcodebuild -version
           swift --version
           xcrun --sdk macosx --show-sdk-version


### PR DESCRIPTION
## Summary

- install the pinned Go 1.25 toolchain on the production macOS release runner before cross-language prompt parity
- print the selected Go version with the other release toolchains
- unblock the failed v0.7.11 release without weakening or skipping the parity gate

The first `v0.7.11` workflow stopped before building or uploading because the clean macOS runner returned `go: command not found` from `verify-prompt-parity.sh`.

## Before

```mermaid
flowchart LR
  subgraph Behavior[Behavior]
    Tag[Provider release tag] --> Runner[Clean macOS runner]
    Runner --> Parity[Prompt parity script]
    Parity --> Missing[Go command missing]
    Missing --> Stop[Release stops before build]
  end
  subgraph Code[Code]
    Workflow[release-swift.yml] --> Rust[Install Rust]
    Rust --> Script[verify-prompt-parity.sh]
    Script --> GoBinary[Go fixture generator unavailable]
  end
```

## After

```mermaid
flowchart LR
  subgraph Behavior[Behavior]
    Tag[Provider release tag] --> Runner[Clean macOS runner]
    Runner --> Setup[Install pinned Go]
    Setup --> Parity[Go Rust Swift parity]
    Parity --> Release[Build sign notarize publish]
  end
  subgraph Code[Code]
    Workflow[release-swift.yml] --> SetupGo[actions setup-go 1.25.0]
    SetupGo --> Versions[Print go version]
    Versions --> Script[verify-prompt-parity.sh]
  end
```

## Verification

- `./scripts/check-release-version.sh 0.7.11`
- `./scripts/verify-prompt-parity.sh`
- workflow YAML parse
- `git diff --check`
- pre-push hooks

## Release follow-up

After merge, publish with the accepted alias tag `v0.7.11-swift.1`. The original `v0.7.11` tag remains immutable and records the failed pre-build attempt; the alias resolves provider version `0.7.11` and uses the same immutable R2 version path.

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/556"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787020851&installation_id=133247490&pr_number=556&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F556&signature=c86d979a9aeea1bc262370452740fe4d7b6c9ec9f9b96ac91f148d05415455da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->