### PR TITLE
fix(store): make withdrawable backfill exactly once

### DIFF
--- a/coordinator/store/postgres.go
+++ b/coordinator/store/postgres.go
@@ -713,19 +713,6 @@ func (s *PostgresStore) migrate(ctx context.Context) error {
 		// (60 providers × batch/10s × 50 rows × 5 indexes = ~30-40% of the
 		// connection pool). No read endpoints consumed this table.',
 
-		// Withdrawable balance — tracks the withdrawable subset of balance_micro_usd.
-		`ALTER TABLE balances ADD COLUMN IF NOT EXISTS withdrawable_micro_usd BIGINT NOT NULL DEFAULT 0`,
-
-		// Backfill withdrawable from ledger history: sum earnings minus
-		// successful withdrawals. Idempotent — only updates rows where
-		// withdrawable is still 0 (first deploy) so it won't overwrite
-		// live values on restart.
-		`UPDATE balances b SET withdrawable_micro_usd = GREATEST(0, COALESCE((
-			SELECT SUM(amount_micro_usd) FROM ledger_entries
-			WHERE account_id = b.account_id
-			  AND entry_type IN ('payout', 'referral_reward', 'admin_reward', 'stripe_payout')
-		), 0)) WHERE b.withdrawable_micro_usd = 0`,
-
 		// Materialized usage totals — eliminates full-table scan of usage
 		// on every stats cache miss.  Single counter row incremented
 		// atomically by RecordUsage / RecordUsageWithCostAndLocation.
@@ -1048,6 +1035,10 @@ func (s *PostgresStore) migrate(ctx context.Context) error {
 		if _, err := s.pool.Exec(ctx, m); err != nil {
 			return fmt.Errorf("migration failed: %w", err)
 		}
+	}
+
+	if err := s.migrateWithdrawableBalance(ctx); err != nil {
+		return err
 	}
 
 	// DAR-349: build the provider_earnings(job_id) partial unique index outside

--- a/coordinator/store/postgres_withdrawable_migration.go
+++ b/coordinator/store/postgres_withdrawable_migration.go
@@ -1,0 +1,245 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+)
+
+const withdrawableBalanceMigrationID = "backfill_withdrawable_balance_v1"
+
+const legacyWithdrawableBalanceBackfill = `
+	WITH classified_ledger AS MATERIALIZED (
+		SELECT
+			account_id,
+			id,
+			balance_after::numeric AS balance_after,
+			CASE
+				WHEN entry_type IN (
+					'payout',
+					'referral_reward',
+					'admin_reward',
+					'provider_floor_draw',
+					'stripe_payout',
+					'withdrawal'
+				) THEN amount_micro_usd::numeric
+				WHEN entry_type IN ('charge', 'refund')
+				  AND strpos(reference, 'stripe_withdraw:') = 1
+					THEN amount_micro_usd::numeric
+				ELSE 0::numeric
+			END AS withdrawable_delta,
+			entry_type = 'refund'
+			  AND strpos(reference, 'stripe_withdraw:') <> 1
+				AS has_generic_refund,
+			entry_type = 'migration' AS has_balance_migration
+		FROM ledger_entries
+	),
+	ledger_state AS MATERIALIZED (
+		SELECT
+			account_id,
+			id,
+			balance_after,
+			withdrawable_delta,
+			has_generic_refund,
+			has_balance_migration,
+			SUM(withdrawable_delta) OVER (
+				PARTITION BY account_id
+				ORDER BY id
+				ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+			) AS cumulative_withdrawable_delta
+		FROM classified_ledger
+	),
+	ledger_summary AS (
+		SELECT
+			account_id,
+			SUM(withdrawable_delta) AS final_withdrawable_delta,
+			BOOL_OR(withdrawable_delta <> 0) AS has_withdrawable_activity,
+			BOOL_OR(has_generic_refund) AS has_generic_refund,
+			BOOL_OR(has_balance_migration) AS has_balance_migration,
+			LEAST(
+				0::numeric,
+				MIN(balance_after - cumulative_withdrawable_delta)
+			) AS ordinary_debit_adjustment
+		FROM ledger_state
+		GROUP BY account_id
+	),
+	backfill AS (
+		SELECT
+			b.account_id,
+			GREATEST(
+				0::numeric,
+				LEAST(
+					b.balance_micro_usd::numeric,
+					s.final_withdrawable_delta + s.ordinary_debit_adjustment
+				)
+			)::bigint AS withdrawable_micro_usd
+		FROM balances b
+		JOIN ledger_summary s ON s.account_id = b.account_id
+		WHERE b.balance_micro_usd > 0
+		  AND NOT s.has_balance_migration
+		  AND NOT (
+			s.has_generic_refund
+			AND s.has_withdrawable_activity
+		  )
+	),
+	updated AS (
+		UPDATE balances b
+		SET withdrawable_micro_usd = backfill.withdrawable_micro_usd
+		FROM backfill
+		WHERE b.account_id = backfill.account_id
+		  AND b.withdrawable_micro_usd = 0
+		  AND backfill.withdrawable_micro_usd > 0
+		RETURNING 1
+	)
+	SELECT
+		(
+			SELECT COUNT(*)
+			FROM ledger_summary
+			WHERE has_balance_migration
+			   OR (
+				has_generic_refund
+				AND has_withdrawable_activity
+			   )
+		) AS ambiguous_accounts,
+		(SELECT COUNT(*) FROM updated) AS updated_accounts`
+
+type withdrawableMigrationResult string
+
+const (
+	withdrawableMigrationBackfilled withdrawableMigrationResult = "backfilled_legacy_schema"
+	withdrawableMigrationPreserved  withdrawableMigrationResult = "preserved_existing_schema"
+	withdrawableMigrationSkipped    withdrawableMigrationResult = "already_applied"
+)
+
+type withdrawableMigrationOutcome struct {
+	Result       withdrawableMigrationResult
+	RowsAffected int64
+}
+
+// migrateWithdrawableBalance records privacy-safe startup observability around
+// the one-time financial migration. Account identifiers and monetary values are
+// deliberately excluded.
+func (s *PostgresStore) migrateWithdrawableBalance(ctx context.Context) error {
+	started := time.Now()
+	outcome, err := s.applyWithdrawableBalanceMigration(ctx)
+	if err != nil {
+		slog.Error("postgres migration failed",
+			"migration", withdrawableBalanceMigrationID,
+			"result", "failed",
+			"duration_ms", time.Since(started).Milliseconds())
+		return fmt.Errorf("store: migrate withdrawable balance: %w", err)
+	}
+	slog.Info("postgres migration completed",
+		"migration", withdrawableBalanceMigrationID,
+		"result", string(outcome.Result),
+		"duration_ms", time.Since(started).Milliseconds())
+	return nil
+}
+
+// applyWithdrawableBalanceMigration atomically claims and applies the legacy
+// backfill. The unique marker insert is the concurrency gate: a concurrent
+// insert waits for the claiming transaction. It then either observes the
+// committed marker and skips, or acquires the claim after a rollback and
+// retries the complete migration.
+//
+// The schema predicate is the safety boundary. A pre-existing
+// withdrawable_micro_usd column proves that live split-balance accounting may
+// already have started. In that state, zero is a legitimate result of charges,
+// withdrawals, refunds, or account migration, and ledger history cannot
+// reconstruct it safely because:
+//   - generic refunds may be withdrawable Stripe reversals or non-withdrawable
+//     inference reservation refunds;
+//   - migration ledger entries record total balance, not the moved withdrawable
+//     subset; and
+//   - ordinary charges consume non-withdrawable credit before earnings.
+//
+// Therefore an existing column is preserved byte-for-byte and only receives
+// the marker. The set-wise historical reconstruction runs solely when this
+// transaction itself adds the column to a legacy schema. That is the only
+// authoritative boundary available: the original deployment stored no marker
+// or cutoff. The reconstruction replays financial provenance set-wise in
+// ledger ID order. Direct withdrawable deltas are provider/referral/admin/floor
+// earnings, explicit withdrawal types, and pre-split Stripe charge/refund rows
+// identified by their stripe_withdraw: reference. Ordinary charges clamp
+// withdrawable funds only after non-withdrawable credit is exhausted, and later
+// deposits never reclassify spent earnings. A generic refund cannot reveal how
+// much of its original debit consumed each provenance class, and
+// LedgerMigration records total balance rather than the separately moved
+// withdrawable subset. A legacy schema containing either ambiguity fails
+// closed, rolling back the marker and column for explicit offline
+// reconciliation instead of guessing.
+func (s *PostgresStore) applyWithdrawableBalanceMigration(ctx context.Context) (withdrawableMigrationOutcome, error) {
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return withdrawableMigrationOutcome{}, fmt.Errorf("begin: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	var claimed bool
+	err = tx.QueryRow(ctx, `
+		INSERT INTO schema_migrations (id)
+		VALUES ($1)
+		ON CONFLICT (id) DO NOTHING
+		RETURNING true`,
+		withdrawableBalanceMigrationID,
+	).Scan(&claimed)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return withdrawableMigrationOutcome{Result: withdrawableMigrationSkipped}, nil
+	}
+	if err != nil {
+		return withdrawableMigrationOutcome{}, fmt.Errorf("claim marker: %w", err)
+	}
+	if !claimed {
+		return withdrawableMigrationOutcome{}, errors.New("marker claim returned false")
+	}
+
+	var columnExists bool
+	if err := tx.QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM information_schema.columns
+			WHERE table_schema = current_schema()
+			  AND table_name = 'balances'
+			  AND column_name = 'withdrawable_micro_usd'
+		)`).Scan(&columnExists); err != nil {
+		return withdrawableMigrationOutcome{}, fmt.Errorf("inspect balances schema: %w", err)
+	}
+
+	if columnExists {
+		if err := tx.Commit(ctx); err != nil {
+			return withdrawableMigrationOutcome{}, fmt.Errorf("commit preserved marker: %w", err)
+		}
+		return withdrawableMigrationOutcome{Result: withdrawableMigrationPreserved}, nil
+	}
+
+	if _, err := tx.Exec(ctx,
+		`ALTER TABLE balances ADD COLUMN IF NOT EXISTS withdrawable_micro_usd BIGINT NOT NULL DEFAULT 0`,
+	); err != nil {
+		return withdrawableMigrationOutcome{}, fmt.Errorf("add withdrawable column: %w", err)
+	}
+
+	var ambiguousAccounts, updatedAccounts int64
+	if err := tx.QueryRow(ctx, legacyWithdrawableBalanceBackfill).Scan(
+		&ambiguousAccounts,
+		&updatedAccounts,
+	); err != nil {
+		return withdrawableMigrationOutcome{}, fmt.Errorf("backfill legacy balances: %w", err)
+	}
+	if ambiguousAccounts > 0 {
+		return withdrawableMigrationOutcome{}, fmt.Errorf(
+			"legacy ledger provenance is ambiguous for %d accounts; offline reconciliation required",
+			ambiguousAccounts,
+		)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return withdrawableMigrationOutcome{}, fmt.Errorf("commit: %w", err)
+	}
+	return withdrawableMigrationOutcome{
+		Result:       withdrawableMigrationBackfilled,
+		RowsAffected: updatedAccounts,
+	}, nil
+}

--- a/coordinator/store/postgres_withdrawable_migration_test.go
+++ b/coordinator/store/postgres_withdrawable_migration_test.go
@@ -1,0 +1,506 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestWithdrawableBalanceMigrationFirstRunAndRestart(t *testing.T) {
+	databaseURL := newWithdrawableTestDatabase(t)
+	s := newWithdrawableMigrationStore(t, databaseURL)
+	prepareWithdrawableMigrationSchema(t, s, false)
+
+	// Actual pre-split Stripe encoding: withdrawals were ordinary `charge`
+	// entries with a stripe_withdraw: reference, while failures/reversals were
+	// matching `refund` entries. The reconstruction must classify those direct
+	// withdrawable deltas without treating inference charges as withdrawals.
+	seedMigrationBalance(t, s, "legacy-withdrawal", 175, nil)
+	seedMigrationLedger(t, s, "legacy-withdrawal", LedgerStripeDeposit, 100, 100, "deposit")
+	seedMigrationLedger(t, s, "legacy-withdrawal", LedgerPayout, 100, 200, "payout")
+	seedMigrationLedger(t, s, "legacy-withdrawal", LedgerCharge, -50, 150, "stripe_withdraw:legacy")
+	seedMigrationLedger(t, s, "legacy-withdrawal", LedgerReferralReward, 25, 175, "referral")
+
+	seedMigrationBalance(t, s, "legacy-reversal", 100, nil)
+	seedMigrationLedger(t, s, "legacy-reversal", LedgerPayout, 100, 100, "payout")
+	seedMigrationLedger(t, s, "legacy-reversal", LedgerCharge, -80, 20, "stripe_withdraw:reversed")
+	seedMigrationLedger(t, s, "legacy-reversal", LedgerRefund, 80, 100, "stripe_withdraw:reversed")
+
+	// Focused coverage for the remaining direct withdrawable entry types.
+	seedMigrationBalance(t, s, "typed-deltas", 25, nil)
+	seedMigrationLedger(t, s, "typed-deltas", LedgerAdminReward, 10, 10, "admin")
+	seedMigrationLedger(t, s, "typed-deltas", LedgerFloorDraw, 20, 30, "floor")
+	seedMigrationLedger(t, s, "typed-deltas", LedgerWithdrawal, -5, 25, "legacy-onchain")
+
+	seedMigrationBalance(t, s, "capped-by-total", 25, nil)
+	seedMigrationLedger(t, s, "capped-by-total", LedgerPayout, 100, 100, "payout")
+	seedMigrationLedger(t, s, "capped-by-total", LedgerCharge, -75, 25, "inference")
+
+	// Earned funds can be fully spent before a later non-withdrawable deposit.
+	// A final-balance cap or aggregate SUM would incorrectly make the deposit
+	// withdrawable; chronological provenance must leave this at zero.
+	seedMigrationBalance(t, s, "spent-then-deposited", 50, nil)
+	seedMigrationLedger(t, s, "spent-then-deposited", LedgerPayout, 100, 100, "payout")
+	seedMigrationLedger(t, s, "spent-then-deposited", LedgerCharge, -100, 0, "inference")
+	seedMigrationLedger(t, s, "spent-then-deposited", LedgerStripeDeposit, 50, 50, "later-deposit")
+
+	seedMigrationBalance(t, s, "no-eligible-earnings", 100, nil)
+	seedMigrationLedger(t, s, "no-eligible-earnings", LedgerStripeDeposit, 100, 100, "deposit")
+
+	seedMigrationBalance(t, s, "negative-net-earnings", 10, nil)
+	seedMigrationLedger(t, s, "negative-net-earnings", LedgerPayout, 50, 50, "payout")
+	seedMigrationLedger(t, s, "negative-net-earnings", LedgerStripePayout, -50, 0, "withdrawal")
+	seedMigrationLedger(t, s, "negative-net-earnings", LedgerStripeDeposit, 10, 10, "deposit")
+
+	outcome, err := s.applyWithdrawableBalanceMigration(context.Background())
+	if err != nil {
+		t.Fatalf("first migration: %v", err)
+	}
+	if outcome.Result != withdrawableMigrationBackfilled || outcome.RowsAffected != 4 {
+		t.Fatalf("first outcome = %+v, want backfilled with 4 changed rows", outcome)
+	}
+	for accountID, want := range map[string]int64{
+		"legacy-withdrawal":     75,
+		"legacy-reversal":       100,
+		"typed-deltas":          25,
+		"capped-by-total":       25,
+		"spent-then-deposited":  0,
+		"no-eligible-earnings":  0,
+		"negative-net-earnings": 0,
+	} {
+		if got := migrationWithdrawableBalance(t, s, accountID); got != want {
+			t.Errorf("%s withdrawable = %d, want %d", accountID, got, want)
+		}
+	}
+	count, firstAppliedAt := migrationMarker(t, s)
+	if count != 1 {
+		t.Fatalf("marker count after first run = %d, want 1", count)
+	}
+
+	// Zero is now a legitimate live state. Add new eligible history that would
+	// make the old every-startup statement recreate funds, then prove restart
+	// skips without changing either the balance or the exact marker row.
+	if _, err := s.pool.Exec(context.Background(),
+		`UPDATE balances SET withdrawable_micro_usd = 0 WHERE account_id = 'capped-by-total'`); err != nil {
+		t.Fatal(err)
+	}
+	seedMigrationLedger(t, s, "capped-by-total", LedgerPayout, 500, 525, "post-migration-payout")
+
+	restart, err := s.applyWithdrawableBalanceMigration(context.Background())
+	if err != nil {
+		t.Fatalf("restart migration: %v", err)
+	}
+	if restart.Result != withdrawableMigrationSkipped || restart.RowsAffected != 0 {
+		t.Fatalf("restart outcome = %+v, want already-applied skip", restart)
+	}
+	if got := migrationWithdrawableBalance(t, s, "capped-by-total"); got != 0 {
+		t.Fatalf("restart recreated withdrawn funds: got %d, want 0", got)
+	}
+	count, secondAppliedAt := migrationMarker(t, s)
+	if count != 1 || !secondAppliedAt.Equal(firstAppliedAt) {
+		t.Fatalf("marker changed on restart: count=%d first=%s second=%s",
+			count, firstAppliedAt, secondAppliedAt)
+	}
+}
+
+func TestWithdrawableBalanceMigrationRejectsAmbiguousLegacyProvenance(t *testing.T) {
+	tests := []struct {
+		name string
+		seed func(t *testing.T, s *PostgresStore)
+	}{
+		{
+			name: "generic reservation refund",
+			seed: func(t *testing.T, s *PostgresStore) {
+				seedMigrationBalance(t, s, "ambiguous-refund", 100, nil)
+				seedMigrationLedger(t, s, "ambiguous-refund", LedgerPayout, 100, 100, "payout")
+				seedMigrationLedger(t, s, "ambiguous-refund", LedgerCharge, -100, 0, "reserve")
+				seedMigrationLedger(t, s, "ambiguous-refund", LedgerRefund, 100, 100, "reservation_refund")
+			},
+		},
+		{
+			name: "generic refund with zero net direct deltas",
+			seed: func(t *testing.T, s *PostgresStore) {
+				seedMigrationBalance(t, s, "ambiguous-zero-net", 100, nil)
+				seedMigrationLedger(t, s, "ambiguous-zero-net", LedgerPayout, 100, 100, "payout")
+				seedMigrationLedger(t, s, "ambiguous-zero-net", LedgerStripePayout, -100, 0, "withdrawal")
+				seedMigrationLedger(t, s, "ambiguous-zero-net", LedgerRefund, 100, 100, "reservation_refund")
+			},
+		},
+		{
+			name: "balance migration without withdrawable subset",
+			seed: func(t *testing.T, s *PostgresStore) {
+				seedMigrationBalance(t, s, "ambiguous-migration", 100, nil)
+				seedMigrationLedger(t, s, "ambiguous-migration", LedgerMigration, 100, 100, "migrate:in")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			databaseURL := newWithdrawableTestDatabase(t)
+			s := newWithdrawableMigrationStore(t, databaseURL)
+			prepareWithdrawableMigrationSchema(t, s, false)
+			tt.seed(t, s)
+
+			if _, err := s.applyWithdrawableBalanceMigration(context.Background()); err == nil {
+				t.Fatal("ambiguous migration unexpectedly guessed withdrawable provenance")
+			}
+			if count, _ := migrationMarker(t, s); count != 0 {
+				t.Fatalf("ambiguous migration left marker count %d, want 0", count)
+			}
+			var columnExists bool
+			if err := s.pool.QueryRow(context.Background(), `
+				SELECT EXISTS (
+					SELECT 1 FROM information_schema.columns
+					WHERE table_schema = current_schema()
+					  AND table_name = 'balances'
+					  AND column_name = 'withdrawable_micro_usd'
+				)`).Scan(&columnExists); err != nil {
+				t.Fatal(err)
+			}
+			if columnExists {
+				t.Fatal("ambiguous migration committed the withdrawable column")
+			}
+		})
+	}
+}
+
+func TestWithdrawableBalanceMigrationPreservesLiveAccounting(t *testing.T) {
+	databaseURL := newWithdrawableTestDatabase(t)
+	s := newWithdrawableMigrationStore(t, databaseURL)
+	prepareWithdrawableMigrationSchema(t, s, true)
+
+	zero := int64(0)
+	refunded := int64(80)
+	migrated := int64(40)
+	floorDraw := int64(30)
+	seedMigrationBalance(t, s, "withdrawn-to-zero", 50, &zero)
+	seedMigrationLedger(t, s, "withdrawn-to-zero", LedgerPayout, 100, 100, "earning")
+	seedMigrationLedger(t, s, "withdrawn-to-zero", LedgerStripePayout, -100, 0, "withdrawal")
+	seedMigrationLedger(t, s, "withdrawn-to-zero", LedgerStripeDeposit, 50, 50, "later-deposit")
+
+	seedMigrationBalance(t, s, "reversed-withdrawal", 80, &refunded)
+	seedMigrationLedger(t, s, "reversed-withdrawal", LedgerPayout, 100, 100, "earning")
+	seedMigrationLedger(t, s, "reversed-withdrawal", LedgerStripePayout, -100, 0, "withdrawal")
+	seedMigrationLedger(t, s, "reversed-withdrawal", LedgerRefund, 80, 80, "stripe_withdraw:refund")
+
+	seedMigrationBalance(t, s, "migration-source", 0, &zero)
+	seedMigrationLedger(t, s, "migration-source", LedgerPayout, 100, 100, "earning")
+	seedMigrationLedger(t, s, "migration-source", LedgerMigration, -100, 0, "migrate:out")
+	seedMigrationBalance(t, s, "migration-destination", 100, &migrated)
+	seedMigrationLedger(t, s, "migration-destination", LedgerMigration, 100, 100, "migrate:in")
+
+	seedMigrationBalance(t, s, "floor-draw", 30, &floorDraw)
+	seedMigrationLedger(t, s, "floor-draw", LedgerFloorDraw, 30, 30, "floor")
+
+	outcome, err := s.applyWithdrawableBalanceMigration(context.Background())
+	if err != nil {
+		t.Fatalf("preservation migration: %v", err)
+	}
+	if outcome.Result != withdrawableMigrationPreserved || outcome.RowsAffected != 0 {
+		t.Fatalf("outcome = %+v, want existing-schema preservation", outcome)
+	}
+	for accountID, want := range map[string]int64{
+		"withdrawn-to-zero":     0,
+		"reversed-withdrawal":   80,
+		"migration-source":      0,
+		"migration-destination": 40,
+		"floor-draw":            30,
+	} {
+		if got := migrationWithdrawableBalance(t, s, accountID); got != want {
+			t.Errorf("%s withdrawable changed: got %d, want %d", accountID, got, want)
+		}
+	}
+	if count, _ := migrationMarker(t, s); count != 1 {
+		t.Fatalf("marker count = %d, want 1", count)
+	}
+}
+
+func TestPostgresStartupRunsWithdrawableMigrationOnce(t *testing.T) {
+	databaseURL := newWithdrawableTestDatabase(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	first, err := NewPostgres(ctx, Config{DatabaseURL: databaseURL})
+	if err != nil {
+		t.Fatalf("first NewPostgres: %v", err)
+	}
+	if count, _ := migrationMarker(t, first); count != 1 {
+		first.Close()
+		t.Fatalf("first startup marker count = %d, want 1", count)
+	}
+	if err := first.CreditWithdrawable("live-zero", 100, LedgerPayout, "earning"); err != nil {
+		first.Close()
+		t.Fatalf("credit live balance: %v", err)
+	}
+	if err := first.DebitWithdrawable("live-zero", 100, LedgerStripePayout, "withdrawal"); err != nil {
+		first.Close()
+		t.Fatalf("withdraw live balance: %v", err)
+	}
+	first.Close()
+
+	restart, err := NewPostgres(ctx, Config{DatabaseURL: databaseURL})
+	if err != nil {
+		t.Fatalf("restart NewPostgres: %v", err)
+	}
+	defer restart.Close()
+	if got := restart.GetWithdrawableBalance("live-zero"); got != 0 {
+		t.Fatalf("restart recreated withdrawn funds: got %d, want 0", got)
+	}
+	if count, _ := migrationMarker(t, restart); count != 1 {
+		t.Fatalf("restart marker count = %d, want 1", count)
+	}
+}
+
+func TestWithdrawableBalanceMigrationConcurrentReplicas(t *testing.T) {
+	for attempt := 0; attempt < 5; attempt++ {
+		t.Run(fmt.Sprintf("attempt-%d", attempt), func(t *testing.T) {
+			databaseURL := newWithdrawableTestDatabase(t)
+			first := newWithdrawableMigrationStore(t, databaseURL)
+			second := newWithdrawableMigrationStore(t, databaseURL)
+			prepareWithdrawableMigrationSchema(t, first, false)
+			seedMigrationBalance(t, first, "concurrent", 50, nil)
+			seedMigrationLedger(t, first, "concurrent", LedgerPayout, 50, 50, "earning")
+
+			if _, err := first.pool.Exec(context.Background(), `
+				CREATE FUNCTION delay_withdrawable_backfill()
+				RETURNS trigger LANGUAGE plpgsql AS $$
+				BEGIN
+					PERFORM pg_sleep(0.1);
+					RETURN NEW;
+				END $$;
+				CREATE TRIGGER delay_withdrawable_backfill
+				BEFORE UPDATE ON balances
+				FOR EACH ROW EXECUTE FUNCTION delay_withdrawable_backfill()`); err != nil {
+				t.Fatalf("install overlap trigger: %v", err)
+			}
+
+			start := make(chan struct{})
+			outcomes := make(chan withdrawableMigrationOutcome, 2)
+			errs := make(chan error, 2)
+			var wg sync.WaitGroup
+			for _, replica := range []*PostgresStore{first, second} {
+				wg.Add(1)
+				go func(s *PostgresStore) {
+					defer wg.Done()
+					<-start
+					outcome, err := s.applyWithdrawableBalanceMigration(context.Background())
+					outcomes <- outcome
+					errs <- err
+				}(replica)
+			}
+			close(start)
+			wg.Wait()
+			close(outcomes)
+			close(errs)
+
+			for err := range errs {
+				if err != nil {
+					t.Fatalf("concurrent migration: %v", err)
+				}
+			}
+			var backfilled, skipped int
+			for outcome := range outcomes {
+				switch outcome.Result {
+				case withdrawableMigrationBackfilled:
+					backfilled++
+				case withdrawableMigrationSkipped:
+					skipped++
+				default:
+					t.Fatalf("unexpected concurrent outcome: %+v", outcome)
+				}
+			}
+			if backfilled != 1 || skipped != 1 {
+				t.Fatalf("concurrent outcomes backfilled=%d skipped=%d, want 1/1", backfilled, skipped)
+			}
+			if got := migrationWithdrawableBalance(t, first, "concurrent"); got != 50 {
+				t.Fatalf("withdrawable = %d, want 50", got)
+			}
+			if count, _ := migrationMarker(t, first); count != 1 {
+				t.Fatalf("marker count = %d, want 1", count)
+			}
+		})
+	}
+}
+
+func TestWithdrawableBalanceMigrationBlockedReplicaTakesOverAfterRollback(t *testing.T) {
+	databaseURL := newWithdrawableTestDatabase(t)
+	first := newWithdrawableMigrationStore(t, databaseURL)
+	second := newWithdrawableMigrationStore(t, databaseURL)
+	prepareWithdrawableMigrationSchema(t, first, false)
+	seedMigrationBalance(t, first, "rollback-takeover", 60, nil)
+	seedMigrationLedger(t, first, "rollback-takeover", LedgerPayout, 60, 60, "earning")
+
+	// Sequences are intentionally non-transactional. The first claimant sleeps
+	// while holding the uncommitted unique marker, then fails. The waiter is
+	// already blocked on that marker; after rollback it acquires the claim, sees
+	// sequence value 2, and completes the whole migration.
+	if _, err := first.pool.Exec(context.Background(), `
+		CREATE SEQUENCE fail_first_withdrawable_backfill;
+		CREATE FUNCTION fail_first_withdrawable_backfill()
+		RETURNS trigger LANGUAGE plpgsql AS $$
+		BEGIN
+			IF nextval('fail_first_withdrawable_backfill') = 1 THEN
+				PERFORM pg_sleep(0.3);
+				RAISE EXCEPTION 'forced first claimant rollback';
+			END IF;
+			RETURN NEW;
+		END $$;
+		CREATE TRIGGER fail_first_withdrawable_backfill
+			BEFORE UPDATE ON balances
+			FOR EACH ROW EXECUTE FUNCTION fail_first_withdrawable_backfill()`); err != nil {
+		t.Fatalf("install one-shot failure trigger: %v", err)
+	}
+
+	type migrationCall struct {
+		outcome withdrawableMigrationOutcome
+		err     error
+	}
+	firstDone := make(chan migrationCall, 1)
+	secondDone := make(chan migrationCall, 1)
+	go func() {
+		outcome, err := first.applyWithdrawableBalanceMigration(context.Background())
+		firstDone <- migrationCall{outcome: outcome, err: err}
+	}()
+	triggerDeadline := time.Now().Add(2 * time.Second)
+	for {
+		var firstClaimantEnteredTrigger bool
+		if err := second.pool.QueryRow(context.Background(),
+			`SELECT is_called FROM fail_first_withdrawable_backfill`,
+		).Scan(&firstClaimantEnteredTrigger); err != nil {
+			t.Fatalf("observe first claimant trigger: %v", err)
+		}
+		if firstClaimantEnteredTrigger {
+			break
+		}
+		if time.Now().After(triggerDeadline) {
+			t.Fatal("first claimant did not reach the failure trigger")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	go func() {
+		outcome, err := second.applyWithdrawableBalanceMigration(context.Background())
+		secondDone <- migrationCall{outcome: outcome, err: err}
+	}()
+
+	select {
+	case result := <-secondDone:
+		t.Fatalf("second replica did not wait on uncommitted marker: %+v", result)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	failed := <-firstDone
+	if failed.err == nil {
+		t.Fatalf("first claimant unexpectedly committed: %+v", failed.outcome)
+	}
+	takeover := <-secondDone
+	if takeover.err != nil {
+		t.Fatalf("blocked replica failed to take over: %v", takeover.err)
+	}
+	if takeover.outcome.Result != withdrawableMigrationBackfilled || takeover.outcome.RowsAffected != 1 {
+		t.Fatalf("takeover outcome = %+v, want one-row backfill", takeover.outcome)
+	}
+	if got := migrationWithdrawableBalance(t, second, "rollback-takeover"); got != 60 {
+		t.Fatalf("takeover withdrawable = %d, want 60", got)
+	}
+	if count, _ := migrationMarker(t, second); count != 1 {
+		t.Fatalf("takeover marker count = %d, want 1", count)
+	}
+}
+
+func TestWithdrawableBalanceMigrationFailureRollsBackAndRetries(t *testing.T) {
+	databaseURL := newWithdrawableTestDatabase(t)
+	s := newWithdrawableMigrationStore(t, databaseURL)
+	prepareWithdrawableMigrationSchema(t, s, false)
+	seedMigrationBalance(t, s, "retry", 75, nil)
+	seedMigrationLedger(t, s, "retry", LedgerPayout, 75, 75, "earning")
+
+	if _, err := s.pool.Exec(context.Background(), `
+		CREATE FUNCTION reject_withdrawable_backfill()
+		RETURNS trigger LANGUAGE plpgsql AS $$
+		BEGIN
+			RAISE EXCEPTION 'forced withdrawable migration failure';
+		END $$;
+		CREATE TRIGGER reject_withdrawable_backfill
+			BEFORE UPDATE ON balances
+			FOR EACH ROW EXECUTE FUNCTION reject_withdrawable_backfill()`); err != nil {
+		t.Fatalf("install failure trigger: %v", err)
+	}
+
+	if _, err := s.applyWithdrawableBalanceMigration(context.Background()); err == nil {
+		t.Fatal("migration unexpectedly succeeded through failure trigger")
+	}
+	if count, _ := migrationMarker(t, s); count != 0 {
+		t.Fatalf("failed migration left marker count %d, want 0", count)
+	}
+	var columnExists bool
+	if err := s.pool.QueryRow(context.Background(), `
+		SELECT EXISTS (
+			SELECT 1 FROM information_schema.columns
+			WHERE table_schema = current_schema()
+			  AND table_name = 'balances'
+			  AND column_name = 'withdrawable_micro_usd'
+		)`).Scan(&columnExists); err != nil {
+		t.Fatal(err)
+	}
+	if columnExists {
+		t.Fatal("failed migration committed the withdrawable column")
+	}
+
+	if _, err := s.pool.Exec(context.Background(), `
+		DROP TRIGGER reject_withdrawable_backfill ON balances;
+		DROP FUNCTION reject_withdrawable_backfill()`); err != nil {
+		t.Fatalf("remove failure trigger: %v", err)
+	}
+	outcome, err := s.applyWithdrawableBalanceMigration(context.Background())
+	if err != nil {
+		t.Fatalf("retry migration: %v", err)
+	}
+	if outcome.Result != withdrawableMigrationBackfilled || outcome.RowsAffected != 1 {
+		t.Fatalf("retry outcome = %+v, want one-row backfill", outcome)
+	}
+	if got := migrationWithdrawableBalance(t, s, "retry"); got != 75 {
+		t.Fatalf("retry withdrawable = %d, want 75", got)
+	}
+	if count, _ := migrationMarker(t, s); count != 1 {
+		t.Fatalf("retry marker count = %d, want 1", count)
+	}
+}
+
+func TestWithdrawableBalanceMigrationRestartDoesNotScanFinancialTables(t *testing.T) {
+	databaseURL := newWithdrawableTestDatabase(t)
+	locker := newWithdrawableMigrationStore(t, databaseURL)
+	restart := newWithdrawableMigrationStore(t, databaseURL)
+	prepareWithdrawableMigrationSchema(t, locker, true)
+	if _, err := locker.pool.Exec(context.Background(),
+		`INSERT INTO schema_migrations (id) VALUES ($1)`,
+		withdrawableBalanceMigrationID); err != nil {
+		t.Fatalf("seed migration marker: %v", err)
+	}
+
+	lockTx, err := locker.pool.Begin(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer lockTx.Rollback(context.Background())
+	if _, err := lockTx.Exec(context.Background(),
+		`LOCK TABLE balances, ledger_entries IN ACCESS EXCLUSIVE MODE`); err != nil {
+		t.Fatalf("lock financial tables: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	outcome, err := restart.applyWithdrawableBalanceMigration(ctx)
+	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) {
+			t.Fatal("restart touched or scanned a locked financial table")
+		}
+		t.Fatalf("restart migration: %v", err)
+	}
+	if outcome.Result != withdrawableMigrationSkipped {
+		t.Fatalf("restart outcome = %+v, want already-applied skip", outcome)
+	}
+}

--- a/coordinator/store/postgres_withdrawable_migration_test_helpers_test.go
+++ b/coordinator/store/postgres_withdrawable_migration_test_helpers_test.go
@@ -1,0 +1,176 @@
+package store
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"os"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+var withdrawableTestDatabaseSequence atomic.Uint64
+
+func newWithdrawableTestDatabase(t *testing.T) string {
+	t.Helper()
+
+	sourceURL := os.Getenv("DATABASE_URL")
+	if sourceURL == "" {
+		t.Skip("DATABASE_URL not set — skipping PostgreSQL integration test")
+	}
+	targetURL, err := url.Parse(sourceURL)
+	if err != nil {
+		t.Fatalf("parse database URL: %v", err)
+	}
+	if targetURL.Scheme == "" || targetURL.Host == "" {
+		t.Fatalf("DATABASE_URL must be a PostgreSQL URL for isolated database tests")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	admin, err := pgxpool.New(ctx, sourceURL)
+	if err != nil {
+		t.Fatalf("connect database server: %v", err)
+	}
+
+	databaseName := fmt.Sprintf("dinf_withdrawable_%d_%d",
+		time.Now().UnixNano(), withdrawableTestDatabaseSequence.Add(1))
+	quotedDatabase := pgx.Identifier{databaseName}.Sanitize()
+	if _, err := admin.Exec(ctx, "CREATE DATABASE "+quotedDatabase+" TEMPLATE template0"); err != nil {
+		admin.Close()
+		t.Fatalf("create isolated throwaway database: %v", err)
+	}
+
+	targetURL.Path = "/" + databaseName
+
+	t.Cleanup(func() {
+		dropCtx, dropCancel := context.WithTimeout(context.Background(), 20*time.Second)
+		defer dropCancel()
+		if _, err := admin.Exec(dropCtx, "DROP DATABASE "+quotedDatabase+" WITH (FORCE)"); err != nil {
+			t.Errorf("drop isolated throwaway database: %v", err)
+		}
+		admin.Close()
+	})
+	return targetURL.String()
+}
+
+func newWithdrawableMigrationStore(t *testing.T, databaseURL string) *PostgresStore {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	pool, err := pgxpool.New(ctx, databaseURL)
+	if err != nil {
+		t.Fatalf("open migration store: %v", err)
+	}
+	if err := pool.Ping(ctx); err != nil {
+		pool.Close()
+		t.Fatalf("ping migration store: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	return &PostgresStore{
+		pool:       pool,
+		priceCache: make(map[string]cachedPrice),
+	}
+}
+
+func prepareWithdrawableMigrationSchema(t *testing.T, s *PostgresStore, withWithdrawableColumn bool) {
+	t.Helper()
+	balanceColumns := `
+		account_id TEXT PRIMARY KEY,
+		balance_micro_usd BIGINT NOT NULL DEFAULT 0,
+		updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()`
+	if withWithdrawableColumn {
+		balanceColumns = `
+			account_id TEXT PRIMARY KEY,
+			balance_micro_usd BIGINT NOT NULL DEFAULT 0,
+			withdrawable_micro_usd BIGINT NOT NULL DEFAULT 0,
+			updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()`
+	}
+	for _, statement := range []string{
+		`CREATE TABLE schema_migrations (
+			id TEXT PRIMARY KEY,
+			applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+		)`,
+		`CREATE TABLE balances (` + balanceColumns + `)`,
+		`CREATE TABLE ledger_entries (
+			id BIGSERIAL PRIMARY KEY,
+			account_id TEXT NOT NULL,
+			entry_type TEXT NOT NULL,
+			amount_micro_usd BIGINT NOT NULL,
+			balance_after BIGINT NOT NULL,
+			reference TEXT NOT NULL DEFAULT '',
+			created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+		)`,
+	} {
+		if _, err := s.pool.Exec(context.Background(), statement); err != nil {
+			t.Fatalf("prepare migration schema: %v\n%s", err, statement)
+		}
+	}
+}
+
+func seedMigrationBalance(t *testing.T, s *PostgresStore, accountID string, balance int64, withdrawable *int64) {
+	t.Helper()
+	var err error
+	if withdrawable == nil {
+		_, err = s.pool.Exec(context.Background(),
+			`INSERT INTO balances (account_id, balance_micro_usd) VALUES ($1, $2)`,
+			accountID, balance)
+	} else {
+		_, err = s.pool.Exec(context.Background(),
+			`INSERT INTO balances (account_id, balance_micro_usd, withdrawable_micro_usd) VALUES ($1, $2, $3)`,
+			accountID, balance, *withdrawable)
+	}
+	if err != nil {
+		t.Fatalf("seed balance %q: %v", accountID, err)
+	}
+}
+
+func seedMigrationLedger(
+	t *testing.T,
+	s *PostgresStore,
+	accountID string,
+	entryType LedgerEntryType,
+	amount int64,
+	balanceAfter int64,
+	reference string,
+) {
+	t.Helper()
+	if _, err := s.pool.Exec(context.Background(), `
+		INSERT INTO ledger_entries (account_id, entry_type, amount_micro_usd, balance_after, reference)
+		VALUES ($1, $2, $3, $4, $5)`,
+		accountID, string(entryType), amount, balanceAfter, reference); err != nil {
+		t.Fatalf("seed ledger %q/%q: %v", accountID, entryType, err)
+	}
+}
+
+func migrationWithdrawableBalance(t *testing.T, s *PostgresStore, accountID string) int64 {
+	t.Helper()
+	var amount int64
+	if err := s.pool.QueryRow(context.Background(),
+		`SELECT withdrawable_micro_usd FROM balances WHERE account_id = $1`,
+		accountID).Scan(&amount); err != nil {
+		t.Fatalf("read withdrawable balance %q: %v", accountID, err)
+	}
+	return amount
+}
+
+func migrationMarker(t *testing.T, s *PostgresStore) (count int, appliedAt time.Time) {
+	t.Helper()
+	if err := s.pool.QueryRow(context.Background(),
+		`SELECT COUNT(*) FROM schema_migrations WHERE id = $1`,
+		withdrawableBalanceMigrationID).Scan(&count); err != nil {
+		t.Fatalf("read migration marker: %v", err)
+	}
+	if count == 1 {
+		if err := s.pool.QueryRow(context.Background(),
+			`SELECT applied_at FROM schema_migrations WHERE id = $1`,
+			withdrawableBalanceMigrationID).Scan(&appliedAt); err != nil {
+			t.Fatalf("read migration applied_at: %v", err)
+		}
+	}
+	return count, appliedAt
+}

--- a/docs/operations/coordinator-deploy.md
+++ b/docs/operations/coordinator-deploy.md
@@ -94,6 +94,13 @@ marker without reading or rewriting `balances` or `ledger_entries`; this preserv
 legitimate live zero balances. Only a legacy schema where the column is absent gets the
 set-wise historical backfill. Concurrent starters serialize on the marker, and a
 failure rolls back both the marker and all migration changes.
+See
+[`coordinator/store/postgres.go:1037-1041`](../../coordinator/store/postgres.go#L1037-L1041)
+for the startup call,
+[`coordinator/store/postgres_withdrawable_migration.go:175-244`](../../coordinator/store/postgres_withdrawable_migration.go#L175-L244)
+for the transactional claim/schema boundary, and
+[`coordinator/store/postgres_withdrawable_migration.go:15-108`](../../coordinator/store/postgres_withdrawable_migration.go#L15-L108)
+for the legacy-only set-wise reconstruction.
 
 Startup emits one privacy-safe `postgres migration completed` log with only the
 migration name, result, and duration. Expected results are
@@ -106,6 +113,10 @@ withdrawable column fails closed if its ledger contains generic refunds or accou
 migrations whose withdrawable provenance cannot be reconstructed exactly. The marker,
 new column, and partial updates all roll back; reconcile that database offline rather
 than bypassing the check.
+The result/duration logging implementation is
+[`coordinator/store/postgres_withdrawable_migration.go:123-140`](../../coordinator/store/postgres_withdrawable_migration.go#L123-L140);
+the fail-closed ambiguity gate and transaction commit are
+[`coordinator/store/postgres_withdrawable_migration.go:225-244`](../../coordinator/store/postgres_withdrawable_migration.go#L225-L244).
 
 ```bash
 # No rows = safe to proceed. Rows here = investigate/kill blockers first.
@@ -252,6 +263,10 @@ withdrawn funds. For the rollout that introduces this migration, recovery is
 **roll-forward only**: fix the startup problem and restart the target image, or build a
 patched image from the previous application commit with the marker-safe migration
 included.
+The marker ID is defined at
+[`coordinator/store/postgres_withdrawable_migration.go:13`](../../coordinator/store/postgres_withdrawable_migration.go#L13),
+and the marker-preserving existing-schema path is
+[`coordinator/store/postgres_withdrawable_migration.go:182-217`](../../coordinator/store/postgres_withdrawable_migration.go#L182-L217).
 
 ```bash
 # Use an immutable digest from the release's reviewed marker-safe allowlist.

--- a/docs/operations/coordinator-deploy.md
+++ b/docs/operations/coordinator-deploy.md
@@ -33,7 +33,7 @@ How to build, deploy, and update the Darkbloom coordinator and the Swift provide
 | Persistent storage | Host disk `/mnt/disks/userdata`, bind-mounted into the container. Holds the MicroMDM BoltDB (`micromdm/`), prompt artifacts, and logs. `start.sh` symlinks `/data -> /mnt/disks/userdata`. Any old `step-ca/` tree is retired migration residue; no step-ca process is running and it must not be restored as an active dependency. |
 | Images | Cloud Build trigger builds on every master push → `us-east4-docker.pkg.dev/darkbloom-mainnet/coordinator/coordinator:<SHORT_SHA>` |
 | Env file | `/etc/d-inference/env` on the VM (root-only). It must live on the boot disk, not tmpfs. [`deploy/gcp/prod/refresh-env.sh`](../../deploy/gcp/prod/refresh-env.sh) preserves every existing value, fails if the observed live tuning set is incomplete, and adds only absent release defaults. |
-| Fallback | The previous container is kept (stopped) as `coordinator_fallback_<timestamp>` for instant rollback |
+| Fallback | The previous container is kept stopped for forensics. Restart it only when its immutable image digest is on the reviewed marker-safe allowlist; pre-`backfill_withdrawable_balance_v1` images are never rollback targets. |
 
 The live host still has stale Caddy `/acme/*` routing and lacks
 `stream_close_delay 5m`. Those are separate Caddy-maintenance changes. Do not
@@ -85,6 +85,27 @@ The image tag is the 7-char short SHA of the master commit.
 migrations; an `ALTER TABLE` queued behind a long-running query's relation lock will
 hang the whole deploy (2026-07-03 outage: repeated restarts stacked migrations behind a
 58-minute runaway query — recovery was killing the blocking PID, not more restarts).
+
+The historical withdrawable-balance backfill is no longer part of the repeatable
+startup statement list. Migration `backfill_withdrawable_balance_v1` uses a unique
+`schema_migrations` claim in the same transaction as its schema/data changes. On an
+existing database that already has `balances.withdrawable_micro_usd`, it records the
+marker without reading or rewriting `balances` or `ledger_entries`; this preserves
+legitimate live zero balances. Only a legacy schema where the column is absent gets the
+set-wise historical backfill. Concurrent starters serialize on the marker, and a
+failure rolls back both the marker and all migration changes.
+
+Startup emits one privacy-safe `postgres migration completed` log with only the
+migration name, result, and duration. Expected results are
+`backfilled_legacy_schema` on a fresh or genuinely legacy schema,
+`preserved_existing_schema` on the first upgraded startup of a database that already
+has live split-balance accounting, and `already_applied` thereafter. A rollback to a
+coordinator version before this migration reintroduces the old every-startup backfill
+and is not financially safe; roll forward instead. A genuinely legacy schema with no
+withdrawable column fails closed if its ledger contains generic refunds or account
+migrations whose withdrawable provenance cannot be reconstructed exactly. The marker,
+new column, and partial updates all roll back; reconcile that database offline rather
+than bypassing the check.
 
 ```bash
 # No rows = safe to proceed. Rows here = investigate/kill blockers first.
@@ -224,18 +245,32 @@ psql "$PROD_DB_URL" -c "select date_trunc('minute', created_at) m,
 
 ### 6. Rollback
 
-The old container is still on the box, stopped, with the pre-swap image and env:
+Never restart a fallback coordinator that predates
+`backfill_withdrawable_balance_v1`. Older binaries ignore the marker and run the
+historical withdrawable-balance reconstruction on every startup, which can recreate
+withdrawn funds. For the rollout that introduces this migration, recovery is
+**roll-forward only**: fix the startup problem and restart the target image, or build a
+patched image from the previous application commit with the marker-safe migration
+included.
 
 ```bash
+# Use an immutable digest from the release's reviewed marker-safe allowlist.
+# A mutable tag, stopped container name, or source-file presence is not proof.
+FALLBACK_IMAGE=us-east4-docker.pkg.dev/darkbloom-mainnet/coordinator/coordinator@sha256:<reviewed-digest>
 sudo docker stop -t 630 coordinator && sudo docker rm coordinator
-sudo docker rename <fallback-name> coordinator   # or docker start <fallback-name>
-sudo docker start coordinator
-# If env was changed, restore the timestamped backup first:
 sudo cp /etc/d-inference/env.bak.<timestamp> /etc/d-inference/env
+sudo docker run -d --name coordinator \
+  --network host \
+  --restart unless-stopped \
+  --stop-timeout 630 \
+  -v /mnt/disks/userdata:/mnt/disks/userdata \
+  --env-file /etc/d-inference/env \
+  "$FALLBACK_IMAGE"
 ```
 
-Rollback time: ~30 seconds. Providers reconnect automatically (the live registry is
-in-process and rebuilt on reconnect; durable state is in RDS and on the persistent disk).
+Providers reconnect automatically after a marker-safe recovery (the live registry is
+in-process and rebuilt on reconnect; durable state is in RDS and on the persistent
+disk).
 
 ## Provider CLI release
 


### PR DESCRIPTION
## Outcome

Stops every coordinator restart from rescanning 23M+ ledger rows and prevents historical reconstruction from recreating legitimately spent or withdrawn funds. The migration now claims one atomic marker across replicas, preserves existing live split-balance state, and fails closed when genuinely legacy history is ambiguous.

Closes #555.

## What changed

- remove the correlated withdrawable backfill from the repeatable startup migration list
- add transactional marker `backfill_withdrawable_balance_v1`
- serialize overlapping replicas with `INSERT ... ON CONFLICT DO NOTHING RETURNING`
- preserve an existing withdrawable column without scanning financial tables
- reconstruct only genuinely legacy missing-column schemas through one chronological set-wise ledger pass
- reject ambiguous generic-refund or account-migration histories for offline reconciliation
- emit only migration name, result, and duration
- document marker-safe roll-forward/rollback rules

Financial invariant: `0 <= withdrawable_micro_usd <= balance_micro_usd`.

## Before

```mermaid
flowchart LR
  subgraph Behavior[Behavior]
    A1[Every coordinator startup] --> B1[Scan zero balances]
    B1 --> C1[Correlated scans over ledger history]
    C1 --> D1[Rewrite legitimate live zero balances]
    D1 --> E1[Multi-minute startup and financial replay risk]
  end
  subgraph Code[Code]
    A2[PostgresStore migrate] --> B2[Repeatable migrations slice]
    B2 --> C2[Ungarded UPDATE balances]
    C2 --> D2[Concurrent replicas race and block]
  end
```

## After

```mermaid
flowchart LR
  subgraph Behavior[Behavior]
    A1[First marker-safe startup] --> B1[Atomically claim migration]
    B1 --> C1{Withdrawable column exists}
    C1 -->|Yes| D1[Preserve all live balances without scan]
    C1 -->|No| E1[Set-wise legacy reconstruction]
    D1 --> F1[Commit marker]
    E1 --> F1
    F1 --> G1[Later startups skip immediately]
  end
  subgraph Code[Code]
    A2[PostgresStore migrate] --> B2[migrateWithdrawableBalance]
    B2 --> C2[Unique marker claim in transaction]
    C2 --> D2[DDL DML and marker commit together]
    D2 --> E2[Concurrent waiter skips or takes over after rollback]
  end
```

## Verification

Passed in the isolated worktree:

- real PostgreSQL 16 integration suite, including repeated concurrent replicas
- focused migration race suite with `-count=3`
- complete store suite
- `go test ./... -count=1`
- `go test -race ./... -count=1`
- `go vet ./...`
- golangci-lint v2.12.2: zero issues
- gofmt and `git diff --check`
- zero leaked throwaway databases
- two independent correctness reviews: pass

Regression coverage includes first run, restart/no-scan proof under exclusive table locks, concurrent claim, claimant rollback/waiter takeover, failure/retry, legitimate live zero after withdrawal, positive/no earnings, direct delta types, legacy withdrawals/reversals, generic-refund ambiguity, account-migration ambiguity, and existing live split-balance states.

## Deployment / rollback

The currently deployed database already has the withdrawable column, so its first startup on this code records `preserved_existing_schema` without reading `balances` or `ledger_entries`; later starts report `already_applied`.

Do not restart a pre-marker coordinator after this lands: old binaries ignore the marker and replay the unsafe historical statement. Recovery is roll-forward with a marker-safe image.

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/557"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787024243&installation_id=133247490&pr_number=557&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F557&signature=da15dcf81f45775bf6ef9a9342f3072a2039b7a3769e963c40b7d842e57f609d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->