### PR TITLE
feat(provider): make Gemma 4 MTP production-default

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -45,6 +45,7 @@ This directory is the source of truth for how Darkbloom works. The code in `coor
 | Doc | Topic |
 |---|---|
 | [inference.md](inference.md) | How inference requests are decoded, batched, and served |
+| [gemma4-cbv2-mtp.md](gemma4-cbv2-mtp.md) | Default-on verified Gemma 4 MTP, target-only fallback, promotion, memory, and rollout |
 | [cache-aware-routing.md](cache-aware-routing.md) | Provider-confirmed prefix-cache routing, receipts, scoring, and rollout |
 | [prompt-contract-sidecar.md](prompt-contract-sidecar.md) | Local prompt planning, artifact identity, binary block hashing, and failure isolation |
 | [request-outcome-observability.md](request-outcome-observability.md) | Request outcome taxonomy across client, provider, and billing paths |

--- a/docs/architecture/gemma4-cbv2-mtp.md
+++ b/docs/architecture/gemma4-cbv2-mtp.md
@@ -5,9 +5,10 @@
 implementation in mlx-swift-lm PR
 [#74](https://github.com/Layr-Labs/mlx-swift-lm/pull/74), plus the exact
 automatic-verifier repair in mlx-swift-lm PR
-[#75](https://github.com/Layr-Labs/mlx-swift-lm/pull/75). The code is included
-in the v0.7.11 candidate but remains default-off. Production has no `spec_dec`
-assistant artifact, and release publication is not MTP activation.
+[#75](https://github.com/Layr-Labs/mlx-swift-lm/pull/75). Supported Gemma 4
+catalog builds now use verified MTP assistants by default. The QAT target has
+an immutable `spec_dec` pointer; activation remains runtime-confirmed rather
+than inferred from release or catalog publication.
 
 The recorded parity matrix is implementation evidence, not universal
 certification for every M1, M2, M3, or unknown Apple chip/model combination.
@@ -50,9 +51,10 @@ The production branch now includes:
 - Safe hybrid prefix-cache policy: full replay whenever a storage-owning full
   layer follows sliding attention.
 - Provider local/catalog resolution, mandatory immutable catalog anchors,
-  bounded nonblocking prefetch, assistant-owned quantization, exact target
-  binding, fail-open target-only fallback, memory accounting, slot lifetime,
-  rebuild posture preservation, metrics, and kill switch.
+  bounded fetch and retry, assistant-owned quantization, exact target binding,
+  fail-open target-only fallback, one-load activation, idle atomic promotion,
+  memory accounting, slot lifetime, rebuild posture preservation, metrics,
+  and a launchd-persistent kill switch.
 - A production-backed cache-only validation and benchmark harness with process
   supervision, raw-token parity, release performance mode, bounded inventory,
   secure output handling, and explicit coverage labels.
@@ -124,8 +126,8 @@ unprofitable shapes.
 
 The short adaptive cases begin with an untrained controller and mostly select
 depth zero. They validate safe exploration and fallback, not convergence.
-Production-duration traffic replay remains required before setting controller
-seeds or enabling MTP by default.
+Production-duration traffic replay remains required before changing controller
+seeds or expanding beyond the shipped conservative fixed depth.
 
 The sanitized schema-v4 release reports are stored in the gitignored run
 directories beginning `tmp/mtp-20260714T030432Z-` (QAT-4bit assistant) and
@@ -158,7 +160,8 @@ supervisor; same-user mutation after catalog verification remains a general
 path/fd TOCTOU concern; official cross-runtime tensor fixtures, real
 long-prefix validation, video, structured output, and production-duration
 controller convergence remain unimplemented. These do not weaken the completed
-target-authority matrices, but they block a default-on production rollout.
+target-authority matrices or the conservative default-on greedy path; they
+block broader stochastic, paged-window, and depth-envelope expansion.
 
 ## Scope
 
@@ -232,7 +235,7 @@ read-only source worktree `.worktrees/mtp-build`:
 | engine `13a726e` | Scheduler `1+k` planning, speculative KV contracts, window staging, rectangular attention, Gemma model and drafter seams |
 | engine `e11a108` | Seed/draft/verify step, finalize-time accept walk, lifecycle integration, metrics |
 | parent `c228c257` | `spec_dec` R2 artifact resolver and store |
-| parent `37f785b0` | Provider config, beta switch, assistant advertisement exclusion |
+| parent `37f785b0` | Historical provider config switch and assistant advertisement exclusion |
 | parent `5040e86b` | Drafter memory-accounting and slot-lifetime scaffolding |
 
 Those commits were based on older parent and engine revisions. They are
@@ -267,6 +270,44 @@ flowchart LR
 The coordinator performs no speculation. Existing free-form catalog metadata
 provides an immutable pointer to an assistant artifact. Old providers ignore
 that metadata and continue target-only serving.
+
+### Production-default lifecycle
+
+Policy precedence is exact:
+
+1. `DARKBLOOM_CBV2_MTP=0` forces target-only behavior. `darkbloom start`
+   copies it into the launchd plist, so watchdog/login/restart relaunches keep
+   the rollback.
+2. Explicit `[backend] mtp = false` is the persistent config opt-out.
+3. Explicit `true` and an absent key are default-on. This makes pre-v0.7.12
+   configs migrate without a rewrite.
+4. Non-Gemma targets are always target-only.
+
+For a cold Gemma load, `SpecDecArtifactFunnel.prepareForLoad` fetches fresh
+catalog identity before any model-load or re-slice gate, validates all
+`spec_dec` trust anchors, verifies a cached artifact without network access or
+performs one bounded download, and returns only an immutable verified
+candidate. Target plus assistant memory is reserved before assistant load.
+The slot is published MTP-active only after the concrete engine reports
+`mtp.active=true` and post-build headroom passes.
+
+Optional fleet-wide artifact work never sits ahead of daemon liveness, the
+local endpoint, or coordinator registration. Only a demanded Gemma cold load
+awaits its bounded artifact preparation; failures immediately preserve the
+target-only path and enter backoff.
+
+Failures publish a target-only slot with one stable reason. The funnel retries
+network/catalog failures on a bounded backoff and periodically re-reads catalog
+identity. A newly verified or revised artifact emits one deduplicated
+artifact-ready event. `ProviderLoop+MTPPromotion` waits for remote and local
+work to drain, blocks new work for that model, reuses the retained target
+container, reserves assistant memory, computes replacement fleet grants,
+builds an unregistered replacement, and verifies activation and headroom. It
+then swaps the slot and runtime registration before retiring the old bridge.
+Any failure releases the candidate exactly once, restores prior grants, and
+leaves the old engine serving. Promotion is capped at three attempts per
+immutable assistant identity; a changed revision/hash resets that ledger.
+Unload, shutdown, and update drain cancel owned promotion work.
 
 ## Stable Interfaces
 
@@ -552,7 +593,7 @@ full-suite verification, independent review, and final refactor.
 
 ### Provider Tests
 
-- Config absent, present, invalid, beta toggle, and serialization.
+- Config absent/default-on, explicit opt-out, invalid, and serialization.
 - Local assistant path precedence.
 - Catalog metadata resolution and shared-prefix reuse.
 - Manifest digest, size, file-count, path, and hash rejection.
@@ -846,8 +887,8 @@ teach `EngineLoopV2` a parallel sampling stack:
 Artifact resolution, assistant ownership, and memory sizing do not change.
 The provider continues to pass the bound drafter and `CBv2MTPConfig` through
 the single production factory (`EngineV2SlotFactory.swift:317-440` and
-`EngineV2Factory+Production.swift:365-394`). A new stochastic mode flag belongs
-in that config and defaults off independently of the existing MTP beta switch.
+`EngineV2Factory+Production.swift:365-394`). A future stochastic mode flag
+belongs in that config and defaults off independently of production greedy MTP.
 
 #### Device And Host-Sync Plan
 
@@ -1298,7 +1339,7 @@ When implementation is review-ready:
 
 1. Open the engine PR with before/after behavior and code diagrams.
 2. Pin its exact commit in the parent provider PR.
-3. Ship provider support default-off.
+3. Ship provider support with a launchd-persistent emergency kill switch.
 4. Publish one immutable verified assistant artifact.
 5. Attach `spec_dec` metadata to existing target builds.
 6. Run owned-box HTTP and routed canaries.

--- a/docs/provider/beta-features.md
+++ b/docs/provider/beta-features.md
@@ -74,23 +74,8 @@ Notes and caveats:
   `provider-swift/Sources/ProviderCore/Config/ProviderConfig.swift` for a
   future EngineV2 implementation.
 
-### `mtp` — Gemma 4 multi-token prediction code path
-
-The v0.7.11 provider contains the default-off MTP implementation, but shipping
-that code does not activate speculative decoding:
-
-```bash
-darkbloom beta enable mtp
-darkbloom restart
-```
-
-Activation additionally requires a verified `spec_dec` assistant artifact in
-the model catalog. Production has no such artifact as of the v0.7.11 release
-preparation, so an enabled provider still falls back to target-only decoding.
-
-The implementation has target-authoritative verification and focused parity
-coverage. That is not a universal certification of token-identical behavior on
-every M1, M2, M3, or unknown Apple chip/model combination. Those hardware
-cohorts require separate canaries and the supervised benchmark matrix before
-activation. Provider publication, exact-cache routing activation, and MTP
-activation are three independent rollout decisions.
+Gemma 4 MTP is no longer a beta feature. Supported target builds use verified
+catalog assistants by default, fail open to target-only serving, and promote an
+already-loaded idle slot when a background assistant download completes. Use
+the production rollback documented in [Installation](installation.md), not
+`darkbloom beta`.

--- a/docs/provider/cli-reference.md
+++ b/docs/provider/cli-reference.md
@@ -222,12 +222,11 @@ darkbloom beta disable <feature>    # turn off
 | Feature | Effect |
 |---------|--------|
 | `kv-quant` | Forward-compatibility toggle; v0.7.5 warns and continues with fp16 KV |
-| `mtp` | Default-off Gemma 4 MTP code path; requires a separately published and verified `spec_dec` artifact, which production does not currently have |
 
 `enable`/`disable` read-modify-write the TOML config and report whether a restart
 is required. See [Beta Features](beta-features.md) for the full guide. `darkbloom
-beta list` also accepts `--json`. Installing a provider release does not enable
-MTP, and local parity results are not a blanket M1–M3/unknown-chip certification.
+beta list` also accepts `--json`. MTP is production-default and is intentionally
+not part of this beta workflow.
 
 ## `darkbloom fan` (experimental)
 
@@ -360,6 +359,14 @@ These are the standard `ExitCode` values used by the ArgumentParser-based CLI.
 | Variable | Description |
 |----------|-------------|
 | `DARKBLOOM_NO_UPDATE_CHECK` | Skip the update banner at CLI startup |
+| `DARKBLOOM_CBV2_MTP=0` | Force target-only Gemma 4 serving. Install it persistently with `darkbloom stop && DARKBLOOM_CBV2_MTP=0 darkbloom start`; subsequent launchd/watchdog restarts retain it |
 
 There is no `DARKBLOOM_LOG_LEVEL` or `DARKBLOOM_CONFIG` environment variable;
 use `--config` and the TOML file for configuration.
+
+Supported Gemma 4 catalog builds otherwise fetch and verify their `spec_dec`
+assistant automatically on first load. MTP is advertised active only after the
+replacement runtime confirms activation and memory headroom. Failures stay
+target-only; an assistant that arrives later promotes the idle slot without a
+second restart. A persistent non-environment opt-out is `mtp = false` under
+`[backend]`; a missing key means default-on.

--- a/docs/provider/installation.md
+++ b/docs/provider/installation.md
@@ -97,6 +97,27 @@ url = "wss://api.darkbloom.dev/ws/provider"
 private_only = false
 ```
 
+Supported Gemma 4 catalog builds use multi-token prediction by default. On the
+first ordinary start, the provider reads the build's fresh `metadata.spec_dec`,
+downloads and cryptographically verifies the immutable assistant, accounts for
+target plus assistant memory, and publishes MTP only after the runtime reports
+it active. Any catalog, download, verification, memory, or construction failure
+keeps the target-only engine available. A download that finishes after a
+target-only slot was published promotes that retained target automatically at
+an idle boundary; no second restart is required.
+
+Emergency rollback has highest precedence:
+
+```bash
+darkbloom stop
+DARKBLOOM_CBV2_MTP=0 darkbloom start
+```
+
+The start command stores the allowlisted variable in the launchd plist, so the
+opt-out survives ordinary `darkbloom restart`, watchdog relaunches, and login.
+Alternatively, `mtp = false` under `[backend]` is a persistent config opt-out.
+An absent `mtp` key migrates to default-on; explicit `false` stays off.
+
 ## Updating the provider
 
 ```bash

--- a/docs/provider/quickstart.md
+++ b/docs/provider/quickstart.md
@@ -113,11 +113,11 @@ auto_restart = true
 
 [backend]
 model = ""
-continuous_batching = true
 enabled_models = []
 idle_timeout_mins = 60
 max_model_slots = 3
 kv_quant = false
+mtp = true
 
 [coordinator]
 url = "wss://api.darkbloom.dev/ws/provider"
@@ -134,6 +134,14 @@ end = "08:00"
 - `backend.idle_timeout_mins` — minutes of inactivity before an idle model is
   unloaded (default 60; 0 disables eviction).
 - `backend.max_model_slots` — maximum resident models at once (default 3).
+- `backend.mtp` — Gemma 4 multi-token prediction policy. It defaults to `true`,
+  including for old configs where the key is absent. Supported catalog builds
+  fetch and verify their assistant during the first load; failures serve
+  target-only, and a later completed download promotes the idle slot without a
+  restart. Explicit `false` is a persistent opt-out. The higher-precedence
+  emergency kill switch is installed with:
+  `darkbloom stop && DARKBLOOM_CBV2_MTP=0 darkbloom start`; launchd preserves it
+  across subsequent restarts.
 - `backend.kv_quant` — retained for forward compatibility, but v0.7.5 serves
   fp16-only KV. Setting it logs a warning and does not enable quantization. See
   [Beta Features](beta-features.md).

--- a/provider-swift/Sources/ProviderCore/Config/BetaFeatures.swift
+++ b/provider-swift/Sources/ProviderCore/Config/BetaFeatures.swift
@@ -77,22 +77,6 @@ public enum BetaFeatures {
             read: { $0.backend.kvQuant },
             write: { enabled, config in config.backend.kvQuant = enabled }
         ),
-        BetaFeature(
-            id: "mtp",
-            title: "Multi-token prediction (speculative decoding)",
-            summary: "Gemma 4 drafter-assisted decode on CBv2 — faster greedy decode, token-identical output.",
-            details: """
-            Binds a small drafter model to Gemma 4 slots so greedy \
-            (temperature-0) requests decode several tokens per step. Output \
-            is token-identical to MTP-off; drafter resolution and load are \
-            fail-open (any problem falls back to plain decode). The drafter \
-            comes from the catalog's spec_dec pointer, or set \
-            mtp_drafter_path under [backend] to a local drafter directory.
-            """,
-            requiresRestart: true,
-            read: { $0.backend.mtp },
-            write: { enabled, config in config.backend.mtp = enabled }
-        ),
         // (adaptive-prefill was retired with the legacy engine, v0.7.5 —
         // CBv2 chunks prefill engine-internally.)
     ]

--- a/provider-swift/Sources/ProviderCore/Config/ProviderConfig.swift
+++ b/provider-swift/Sources/ProviderCore/Config/ProviderConfig.swift
@@ -142,12 +142,11 @@ public struct BackendSettings: Sendable, Equatable, Codable {
     /// false: availability beats perfection — a self-test failure may be
     /// transient and the model can still serve via the lazy-load path.
     public var startupSelftestFailClosed: Bool
-    /// MTP (multi-token prediction / speculative decoding) opt-in for CBv2
-    /// (`mtp` under `[backend]`, default false — beta id `mtp`). When enabled,
-    /// slot build resolves a Gemma drafter (`mtp_drafter_path` if set, else the
-    /// catalog entry's `spec_dec` download) and binds it to the engine. Drafter
-    /// resolution/load is fail-open: any failure means plain decode, never a
-    /// slot failure. `DARKBLOOM_CBV2_MTP` remains the engine-side kill switch.
+    /// Gemma 4 MTP policy (`mtp` under `[backend]`, default true). A missing key
+    /// migrates to production-default activation; an explicit `false` remains a
+    /// persistent per-provider opt-out. `DARKBLOOM_CBV2_MTP=0` has highest
+    /// precedence and forces target-only behavior even when this field is true.
+    /// Resolution/load is fail-open: any failure means target-only decode.
     public var mtp: Bool
     /// Optional local drafter directory override (`mtp_drafter_path` under
     /// `[backend]`) — the canary path: `config.json` + `*.safetensors`, no R2
@@ -178,7 +177,7 @@ public struct BackendSettings: Sendable, Equatable, Codable {
         startupPreloadTimeoutSecs: UInt64 = 120,
         startupSelftest: Bool = true,
         startupSelftestFailClosed: Bool = false,
-        mtp: Bool = false,
+        mtp: Bool = true,
         mtpDrafterPath: String? = nil
     ) {
         self.port = port
@@ -254,7 +253,7 @@ public struct BackendSettings: Sendable, Equatable, Codable {
         self.startupSelftest = try container.decodeIfPresent(Bool.self, forKey: .startupSelftest) ?? true
         self.startupSelftestFailClosed =
             try container.decodeIfPresent(Bool.self, forKey: .startupSelftestFailClosed) ?? false
-        self.mtp = try container.decodeIfPresent(Bool.self, forKey: .mtp) ?? false
+        self.mtp = try container.decodeIfPresent(Bool.self, forKey: .mtp) ?? true
         self.mtpDrafterPath = try container.decodeIfPresent(String.self, forKey: .mtpDrafterPath)
         // Retired keys: presence-only scan so startup can WARN (values are
         // ignored; an old provider.toml must keep loading cleanly).

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge+Capacity.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge+Capacity.swift
@@ -169,6 +169,16 @@ extension EngineV2Bridge {
         active.count
     }
 
+    /// Drain-safe replacement boundary. Outer provider request maps can clear
+    /// before the engine has finalized a cancelled row, so promotion must
+    /// require both bridge ownership and engine queue state to be empty.
+    public func isQuiescentForReplacement() -> Bool {
+        let snapshot = capacitySnapshot()
+        return active.isEmpty
+            && snapshot.activeRequests == 0
+            && snapshot.waitingRequests == 0
+    }
+
     /// This engine's live-KV admission ceiling in bytes.
     /// The heartbeat (`EngineV2Runtime.capacitySummary`) uses it as the
     /// grant input to the live budget clamp

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2SlotFactory.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2SlotFactory.swift
@@ -25,6 +25,12 @@ import MLXLMCommon
 import ProviderCoreFoundation
 
 enum EngineV2SlotFactory {
+    static func mtpCompatibleKVBackend(
+        _ selection: EngineV2KVBackendSelection,
+        assistantActive: Bool
+    ) -> EngineV2KVBackendSelection {
+        assistantActive && selection == .paged ? .contiguous : selection
+    }
 
     /// Human-readable cache state for the slot-serving log line.
     static func prefixCacheStateDescription(
@@ -172,7 +178,7 @@ enum EngineV2SlotFactory {
             selection: parsedKVBackend.selection,
             isVLM: isVLM,
             kvQuantConfigured: kvQuantConfigured)
-        let kvBackendSelection = vetoed.selection
+        var kvBackendSelection = vetoed.selection
         if let veto = vetoed.veto {
             logInfo(
                 "engine_v2: \(modelId) paged KV backend forced to contiguous "
@@ -210,6 +216,14 @@ enum EngineV2SlotFactory {
         let servingModel = prepared.servingModel
         let assistantHandle = prepared.assistant
         let mtpStatus = prepared.mtpStatus
+        let mtpKVBackend = mtpCompatibleKVBackend(
+            kvBackendSelection, assistantActive: assistantHandle != nil)
+        if mtpKVBackend != kvBackendSelection {
+            kvBackendSelection = mtpKVBackend
+            logInfo(
+                "engine_v2: \(modelId) paged KV backend forced to contiguous "
+                    + "(MTP requires transactional sliding-window rollback)")
+        }
         let automaticRectangularTokens = MTPAutomaticVerificationPolicy.maxRectangularTokens(
             environment: environment)
         let mtpConfig = CBv2MTPConfig(

--- a/provider-swift/Sources/ProviderCore/Inference/GlobalKVCacheBudget.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/GlobalKVCacheBudget.swift
@@ -220,6 +220,33 @@ public actor GlobalKVCacheBudget {
         reservations[requestID] = Reservation(bytes: bytes, createdAt: .now)
     }
 
+    /// Atomically add optional residency to an existing pending-load promise.
+    /// Unlike `replacePendingLoadReservation`, growth is conditional on current
+    /// live headroom and every concurrent reservation. The mandatory target
+    /// remains reserved when an optional assistant loses this race.
+    public func increaseReservationIfAvailable(
+        requestID: String,
+        additionalBytes: UInt64
+    ) -> Bool {
+        guard additionalBytes > 0,
+            var current = reservations[requestID]
+        else { return false }
+        let available = availableReservationBytes()
+        guard additionalBytes <= available else {
+            reclaimer.scheduleReclaim(shortfall: additionalBytes - available)
+            recordCommitRejection()
+            return false
+        }
+        let (total, overflow) = current.bytes.addingReportingOverflow(
+            additionalBytes)
+        guard !overflow else { return false }
+        current.bytes = total
+        reservations[requestID] = current
+        rejectionStreakStart = nil
+        lastRejectionAt = nil
+        return true
+    }
+
     /// Atomically replace the in-flight load reservation when target weights
     /// become live but an optional assistant is still pending. Zero removes it.
     public func replacePendingLoadReservation(requestID: String, bytes: UInt64) {

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+AutoUpdate.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+AutoUpdate.swift
@@ -208,6 +208,7 @@ extension ProviderLoop {
     /// hot-swap.
     private func beginUpdateDraining() {
         updatePhase = .draining
+        cancelSpecDecPromotions()
     }
 
     /// Download, verify, and stage the release bundle while still serving.

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+Cancellation.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+Cancellation.swift
@@ -119,6 +119,7 @@ extension ProviderLoop {
     /// all three so a local stream is never cut off mid-generation.
     internal var hasInflightWork: Bool {
         !inflightTasks.isEmpty || !requestToModel.isEmpty || localReservations.hasAny
+            || !specDecPromotionTasks.isEmpty
     }
 
     internal func waitForInflightDrain(timeout: Duration) async -> Bool {

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+EngineV2.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+EngineV2.swift
@@ -144,7 +144,7 @@ extension ProviderLoop {
     /// One existing slot's re-slice bookkeeping: its sizing inputs, its
     /// engine grant BEFORE this re-slice (the restore point), and the
     /// bridge whose ceiling gets updated.
-    private struct ExistingSlotGrant {
+    internal struct ExistingSlotGrant {
         let slot: EngineV2KVSizing.ResliceSlot
         let previousGrant: Int
         let bridge: EngineV2Bridge
@@ -154,9 +154,12 @@ extension ProviderLoop {
     /// cap minus Σ resident weights (ALL slots, including any mid-unload —
     /// their weights are still resident — plus the newcomer's), minus the
     /// activation reserve, honoring the operator `memory_reserve_gb`.
-    private func fleetKVBudgetBytes(extraWeightBytes: Int) -> UInt64 {
+    internal func fleetKVBudgetBytes(
+        extraWeightBytes: Int,
+        replacingModelId: String? = nil
+    ) -> UInt64 {
         var totalWeights = UInt64(max(0, extraWeightBytes))
-        for (_, slot) in modelSlots {
+        for (modelId, slot) in modelSlots where modelId != replacingModelId {
             let (sum, overflow) = totalWeights
                 .addingReportingOverflow(UInt64(max(0, slot.sizing.weightsBytes)))
             totalWeights = overflow ? .max : sum
@@ -178,7 +181,7 @@ extension ProviderLoop {
     /// load. Paged physical claims are tracked separately by
     /// `slotKVBytesClaim()` for fleet accounting and never shrink when this
     /// logical target is re-sliced.
-    private func existingSlotGrants(excludingModelId: String) async -> [ExistingSlotGrant] {
+    internal func existingSlotGrants(excludingModelId: String) async -> [ExistingSlotGrant] {
         var existing: [ExistingSlotGrant] = []
         for (slotModelId, slot) in modelSlots
         where slotModelId != excludingModelId && !modelsUnloading.contains(slotModelId) {
@@ -535,7 +538,9 @@ extension ProviderLoop {
         kvBytesCapacity: Int,
         specDecPreparation: SpecDecPreparation,
         preparedModel: EngineV2PreparedModel?,
-        cacheEligibleWeightHash: String? = nil
+        cacheEligibleWeightHash: String? = nil,
+        registerRuntime: Bool = true,
+        logConstruction: Bool = true
     ) async throws -> ProviderEngineBundle {
         let maxConcurrent = engineV2MaxConcurrent(forModel: modelId)
 
@@ -606,7 +611,7 @@ extension ProviderLoop {
                 weightHash: cacheEligibleWeightHash,
                 specDecPreparation: specDecPreparation,
                 preparedModel: preparedModel,
-                logInfo: { slotLogger.info($0) },
+                logInfo: { if logConstruction { slotLogger.info($0) } },
                 logWarning: { slotLogger.warning($0) })
         }
         let bridge = bundle.bridge
@@ -616,14 +621,16 @@ extension ProviderLoop {
         // (Prefix-cache construction — RAM carve AND the SSD offload tier —
         // budget bookkeeping, stats loggers, and the cache-state log line
         // all live inside the shared slot factory.)
-        await engineV2Runtime.register(modelId: modelId, bridge: bridge)
-        if isVLM {
+        if registerRuntime {
+            await engineV2Runtime.register(modelId: modelId, bridge: bridge)
+        }
+        if registerRuntime, isVLM {
             logger.info(
                 "engine_v2: serving \(modelId) via ContinuousBatchingV2 "
                     + "(vlm routing: text→v2, media→v2 multimodal prefill "
                     + "(image+video, fail-loud)) "
                     + "[kv=\(bridge.kvBackendKind.rawValue)]")
-        } else {
+        } else if registerRuntime {
             logger.info(
                 "engine_v2: serving \(modelId) via ContinuousBatchingV2 "
                     + "[kv=\(bridge.kvBackendKind.rawValue)]")

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+IdleTimeout.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+IdleTimeout.swift
@@ -58,7 +58,11 @@ extension ProviderLoop {
         var candidates: [String] = []
         let modelsWithInflight = Set(requestToModel.values)
         for (modelId, slot) in modelSlots {
-            if modelsUnloading.contains(modelId) { continue }
+            if modelsUnloading.contains(modelId)
+                || modelsPromotingSpecDec.contains(modelId)
+            {
+                continue
+            }
             let elapsed = now - slot.lastInferenceAt
             let hasInflight = modelsWithInflight.contains(modelId) || hasLocalReservation(modelId)
             if IdleTimeoutPolicy.shouldUnload(
@@ -76,6 +80,7 @@ extension ProviderLoop {
             guard !currentInflight.contains(modelId),
                   !hasLocalReservation(modelId),
                   !modelsUnloading.contains(modelId),
+                  !modelsPromotingSpecDec.contains(modelId),
                   let slot = modelSlots[modelId] else { continue }
 
             let elapsed = ContinuousClock.now - slot.lastInferenceAt

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+InferenceHandler.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+InferenceHandler.swift
@@ -245,6 +245,17 @@ extension ProviderLoop {
         // deliberately conservative: when in doubt it admits and lets the
         // post-accept load path below make the final call.
         let modelId = chatRequest.model
+        if modelsPromotingSpecDec.contains(modelId) {
+            lookupReceiptFinalizer.sendTerminal(
+                .inferenceError(
+                    requestId: requestId,
+                    error: "model engine is being safely upgraded",
+                    statusCode: 503,
+                    errorReason: nil),
+                fallbackFailure: .capacity,
+                send: send)
+            return
+        }
         if await fastAdmissionReject(modelId: modelId) {
             logger.warning("[\(requestId)] Pre-accept reject for '\(modelId)': insufficient capacity to load")
             lookupReceiptFinalizer.sendTerminal(
@@ -270,6 +281,17 @@ extension ProviderLoop {
             send: send,
             lookupReceiptFinalizer: lookupReceiptFinalizer)
         {
+            return
+        }
+        if modelsPromotingSpecDec.contains(modelId) {
+            lookupReceiptFinalizer.sendTerminal(
+                .inferenceError(
+                    requestId: requestId,
+                    error: "model engine is being safely upgraded",
+                    statusCode: 503,
+                    errorReason: nil),
+                fallbackFailure: .capacity,
+                send: send)
             return
         }
 

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+LocalEndpoint.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+LocalEndpoint.swift
@@ -101,6 +101,10 @@ extension ProviderLoop {
         // Fast-path drain/shutdown reject; an authoritative re-check follows the
         // `await` below, right before the reservation is taken (see comment there).
         try throwIfRefusingNewLocalWork()
+        if modelsPromotingSpecDec.contains(modelId) {
+            throw MultiModelBatchSchedulerEngineError.queueFull(
+                "model engine is being safely upgraded")
+        }
         do {
             try await ensureModelLoaded(modelId: modelId)
         } catch let err as InferenceError {
@@ -121,6 +125,10 @@ extension ProviderLoop {
         // is atomic — the reservation is either refused or counted in
         // `hasInflightWork` before any drain snapshot can miss it.
         try throwIfRefusingNewLocalWork()
+        if modelsPromotingSpecDec.contains(modelId) {
+            throw MultiModelBatchSchedulerEngineError.queueFull(
+                "model engine is being safely upgraded")
+        }
         localReservations.reserve(modelId)
         modelSlots[modelId]?.lastInferenceAt = .now
         let release: @Sendable (String) async -> Void = { [weak self] mid in

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+MTP.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+MTP.swift
@@ -1,43 +1,13 @@
 import Foundation
 
 extension ProviderLoop {
-    static let specDecCatalogPrewarmTimeout: Duration = .seconds(2)
-
-    /// Warm the in-process target-to-assistant metadata map before any startup
-    /// preload or unified-local request can construct a target slot. This does
-    /// not download assistant bytes and is bounded/fail-open; every ordinary
-    /// load remains a local-only catalog-cache/artifact-cache consultation.
-    func prewarmSpecDecCatalog() async {
-        let backend = loopConfig.config.backend
-        guard backend.mtp,
-            backend.mtpDrafterPath?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty != false,
-            SpecDecArtifactFunnel.killSwitchEnabled(
-                environment: ProcessInfo.processInfo.environment),
-            let modelId = advertisedModels.values
-                .filter({ EngineV2SupportedModels.isGemma4Target(modelType: $0.modelType) })
-                .map(\.id)
-                .sorted()
-                .first
-        else { return }
-
-        let warmed = await specDecFunnel.prewarmCatalog(
-            modelId: modelId,
-            timeout: Self.specDecCatalogPrewarmTimeout)
-        if warmed {
-            logger.info("mtp: catalog metadata prewarm complete")
-        } else {
-            logger.warning(
-                "mtp: catalog metadata prewarm failed or exceeded deadline; "
-                    + "startup continues target-only until a later full slot load")
-        }
-    }
-
     func specDecPreparation(
         modelId: String,
         modelInfo: ModelInfo,
         allowDownload: Bool = true
     ) async -> SpecDecPreparation {
-        let prepared = await specDecFunnel.prepare(
+        let started = ContinuousClock.now
+        let prepared = await specDecFunnel.prepareForLoad(
             .init(
                 modelId: modelId,
                 modelType: modelInfo.modelType,
@@ -45,45 +15,22 @@ extension ProviderLoop {
                 localPath: loopConfig.config.backend.mtpDrafterPath,
                 allowDownload: allowDownload,
                 environment: ProcessInfo.processInfo.environment))
+        let elapsed = ContinuousClock.now - started
+        let durationMs = Int64(max(
+            0,
+            Double(elapsed.components.seconds) * 1_000
+                + Double(elapsed.components.attoseconds) / 1e15))
         let reason = prepared.status.reason?.rawValue ?? "ready"
+        let policy = loopConfig.config.backend.mtp
+            ? "default_or_config_on"
+            : "config_off"
         logger.info(
-            "mtp: model=\(modelId) configured=\(prepared.status.configured) "
+            "mtp: model=\(modelId) policy=\(policy) "
                 + "artifact_ready=\(prepared.artifact != nil) reason=\(reason) "
                 + "revision=\(prepared.status.revision ?? "none") "
-                + "artifact_bytes=\(prepared.status.artifactBytes)")
+                + "artifact_bytes=\(prepared.status.artifactBytes) "
+                + "download_verify_ms=\(durationMs)")
         return prepared
     }
 
-    /// Assistant memory is optional: if it does not fit after target admission,
-    /// preserve target loadability and record a stable target-only fallback.
-    func admitSpecDecIfMemoryAllows(
-        _ preparation: SpecDecPreparation,
-        targetRequiredGb: Double
-    ) async -> SpecDecPreparation {
-        guard let artifact = preparation.artifact else { return preparation }
-        guard Self.assistantMemoryFits(
-            availableGb: await availableMemoryGb(),
-            targetRequiredGb: targetRequiredGb,
-            assistantBytes: artifact.residentBytes)
-        else {
-            logger.warning(
-                "mtp: model assistant skipped reason=\(MTPFallbackReason.assistantMemoryUnavailable.rawValue) "
-                    + "assistant_bytes=\(artifact.residentBytes)")
-            return preparation.fallingBack(.assistantMemoryUnavailable)
-        }
-        return preparation
-    }
-
-    static func assistantMemoryFits(
-        availableGb: Double,
-        targetRequiredGb: Double,
-        assistantBytes: UInt64
-    ) -> Bool {
-        guard availableGb.isFinite, targetRequiredGb.isFinite,
-            availableGb >= 0, targetRequiredGb >= 0
-        else { return false }
-        let assistantGb = Double(assistantBytes) / 1_073_741_824.0
-        let required = targetRequiredGb + assistantGb
-        return required.isFinite && availableGb >= required
-    }
 }

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+MTPPromotion.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+MTPPromotion.swift
@@ -1,0 +1,282 @@
+import Foundation
+import MLX
+
+private struct SpecDecPromotionFailure: Error {
+    let reason: MTPFallbackReason
+}
+
+extension ProviderLoop {
+    static let specDecPromotionIdleTimeout: Duration = .seconds(300)
+    static let specDecPromotionPollInterval: Duration = .milliseconds(250)
+
+    func runSpecDecPromotion(
+        modelId: String,
+        artifact: SpecDecArtifact,
+        generation: UInt64,
+        attempt: Int,
+        taskID: UUID
+    ) async {
+        let started = ContinuousClock.now
+        logger.info(
+            "mtp: promotion model=\(modelId) attempt=\(attempt) result=waiting_for_idle "
+                + "source=\(artifact.source.rawValue) revision=\(artifact.revision) "
+                + "assistant_bytes=\(artifact.residentBytes)")
+
+        while true {
+            guard promotionMayContinue(
+                modelId: modelId, generation: generation, taskID: taskID)
+            else {
+                restoreCancelledPromotionAttempt(
+                    modelId: modelId, artifact: artifact)
+                finishSpecDecPromotionTask(modelId: modelId, taskID: taskID)
+                return
+            }
+            let observedBridge = modelSlots[modelId]?.engineV2
+            let engineBusy: Bool
+            if let observedBridge {
+                engineBusy = !(await observedBridge.isQuiescentForReplacement())
+            } else {
+                engineBusy = true
+            }
+            // Re-read actor-owned admission state AFTER the bridge await. A
+            // request may have entered while the actor was reentrant.
+            let remoteBusy = requestToModel.values.contains(modelId)
+            let localBusy = hasLocalReservation(modelId)
+            if !remoteBusy, !localBusy, !engineBusy, !isLoadingAny,
+                modelSlots[modelId]?.engineV2 === observedBridge
+            {
+                break
+            }
+            if ContinuousClock.now - started >= Self.specDecPromotionIdleTimeout {
+                logSpecDecPromotionResult(
+                    modelId: modelId, artifact: artifact,
+                    result: "fallback",
+                    reason: .promotionBusyTimeout,
+                    attempt: attempt,
+                    started: started)
+                finishSpecDecPromotionTask(modelId: modelId, taskID: taskID)
+                return
+            }
+            do {
+                try await taskSleep(Self.specDecPromotionPollInterval)
+            } catch {
+                restoreCancelledPromotionAttempt(
+                    modelId: modelId, artifact: artifact)
+                finishSpecDecPromotionTask(modelId: modelId, taskID: taskID)
+                return
+            }
+        }
+
+        guard promotionMayContinue(
+            modelId: modelId, generation: generation, taskID: taskID),
+            let originalSlot = modelSlots[modelId]
+        else {
+            restoreCancelledPromotionAttempt(
+                modelId: modelId, artifact: artifact)
+            finishSpecDecPromotionTask(modelId: modelId, taskID: taskID)
+            return
+        }
+        let originalBridge = originalSlot.engineV2
+        modelsPromotingSpecDec.insert(modelId)
+        isLoadingAny = true
+        await originalBridge.beginRecoveryReload()
+        let reservationID = "mtp-promotion:\(modelId)"
+        var gateHeld = false
+        var replacementBundle: ProviderEngineBundle?
+        var previousGrants: [ExistingSlotGrant] = []
+        var preparedAssistant: ProviderMTPAssistantHandle?
+        var replacementRegistered = false
+
+        do {
+            guard await kvBudget.reserveBytes(
+                requestID: reservationID,
+                bytes: artifact.residentBytes)
+            else {
+                throw SpecDecPromotionFailure(reason: .assistantMemoryUnavailable)
+            }
+
+            let slotLogger = logger
+            let prepared = try await EngineV2SlotFactory.prepareProductionModel(
+                modelId: modelId,
+                isVLM: originalSlot.isVLM,
+                modelDirectory: ModelScanner.resolveLocalPath(modelID: modelId),
+                container: originalSlot.container,
+                specDecPreparation: .init(
+                    artifact: artifact, status: .candidate(artifact)),
+                assistantLoader: engineV2SlotHooks?.assistantLoader
+                    ?? Gemma4ProviderMTPAssistantLoader(),
+                emitTelemetry: engineV2SlotHooks?.emitTelemetry,
+                logInfo: { slotLogger.info($0) },
+                logWarning: { slotLogger.warning($0) })
+            guard let assistant = prepared.assistant, prepared.mtpStatus.active else {
+                throw SpecDecPromotionFailure(
+                    reason: prepared.mtpStatus.reason ?? .assistantLoadFailed)
+            }
+            preparedAssistant = assistant
+
+            guard promotionMayContinue(
+                modelId: modelId, generation: generation, taskID: taskID),
+                modelSlots[modelId]?.engineV2 === originalBridge
+            else { throw CancellationError() }
+
+            await acquireResliceGate()
+            gateHeld = true
+            guard promotionMayContinue(
+                modelId: modelId, generation: generation, taskID: taskID),
+                modelSlots[modelId]?.engineV2 === originalBridge
+            else { throw CancellationError() }
+
+            let sizing = originalSlot.sizing.replacingAuxiliaryWeightBytes(
+                prepared.assistantBytes)
+            previousGrants = await existingSlotGrants(excludingModelId: "")
+            let budget = fleetKVBudgetBytes(
+                extraWeightBytes: sizing.weightsBytes,
+                replacingModelId: modelId)
+            let targets = EngineV2KVSizing.resliceGrants(
+                existing: previousGrants.map(\.slot),
+                newcomer: nil,
+                fleetKVBudgetBytes: budget)
+            guard EngineV2KVSizing.resliceMeetsServiceabilityFloor(
+                targets, fixedCarveBytes: [:])
+            else {
+                throw SpecDecPromotionFailure(reason: .assistantResliceFloor)
+            }
+            for entry in previousGrants {
+                if let target = targets[entry.slot.modelId],
+                    target < entry.previousGrant
+                {
+                    await entry.bridge.updateKVBytesCapacity(target)
+                }
+            }
+
+            let replacement = try await makeEngineV2BundleForSlot(
+                modelId: modelId,
+                modelType: originalSlot.modelType,
+                isVLM: originalSlot.isVLM,
+                modelDirectory: ModelScanner.resolveLocalPath(modelID: modelId),
+                container: originalSlot.container,
+                tokenizer: originalSlot.tokenizer,
+                sizing: sizing,
+                kvBytesCapacity: targets[modelId] ?? 0,
+                specDecPreparation: .init(
+                    artifact: artifact, status: .candidate(artifact)),
+                preparedModel: prepared,
+                cacheEligibleWeightHash: originalSlot.cacheEligibleWeightHash,
+                registerRuntime: false,
+                logConstruction: false)
+            replacementBundle = replacement
+
+            MLX.Memory.clearCache()
+            let postBuildServeable = KVHeadroomProbe.postBuildServeable(
+                kvBackendKind: replacement.bridge.kvBackendKind,
+                pagedPoolBytes: await replacement.bridge.kvBackendPoolBytes())
+            let runtimeActive = engineV2SlotHooks != nil
+                ? replacement.mtpStatus.active
+                : await replacement.bridge.mtpStatusSnapshot().active
+            guard runtimeActive else {
+                throw SpecDecPromotionFailure(reason: .engineInactive)
+            }
+            guard postBuildServeable else {
+                throw SpecDecPromotionFailure(reason: .assistantPostBuildHeadroom)
+            }
+            await replacement.bridge.beginRecoveryReload()
+            guard promotionMayContinue(
+                modelId: modelId, generation: generation, taskID: taskID),
+                modelSlots[modelId]?.engineV2 === originalBridge
+            else { throw CancellationError() }
+
+            await engineV2Runtime.register(
+                modelId: modelId, bridge: replacement.bridge)
+            replacementRegistered = true
+            guard promotionMayContinue(
+                modelId: modelId, generation: generation, taskID: taskID),
+                modelSlots[modelId]?.engineV2 === originalBridge
+            else { throw CancellationError() }
+
+            modelSlots[modelId] = ModelSlot(
+                engineBundle: replacement,
+                container: originalSlot.container,
+                tokenizer: originalSlot.tokenizer,
+                sizing: sizing,
+                cacheEligibleWeightHash: originalSlot.cacheEligibleWeightHash,
+                isVLM: originalSlot.isVLM,
+                modelType: originalSlot.modelType,
+                lastInferenceAt: originalSlot.lastInferenceAt)
+            replacementBundle = nil
+            preparedAssistant = nil
+            await originalBridge.shutdown()
+            originalSlot.engineBundle.releaseAssistant()
+            MLX.Memory.clearCache()
+            await kvBudget.release(requestID: reservationID)
+            for entry in previousGrants {
+                if let target = targets[entry.slot.modelId],
+                    target > entry.previousGrant,
+                    entry.slot.modelId != modelId
+                {
+                    await entry.bridge.updateKVBytesCapacity(target)
+                }
+            }
+            await replacement.bridge.endRecoveryReload()
+            releaseResliceGate()
+            gateHeld = false
+            syncWarmModelState()
+            await updateAggregateCapacity()
+            logSpecDecPromotionResult(
+                modelId: modelId, artifact: artifact,
+                result: "active", reason: nil, attempt: attempt,
+                started: started)
+            specDecPromotionAttempts.removeValue(forKey: modelId)
+        } catch {
+            if replacementRegistered {
+                if modelSlots[modelId]?.engineV2 === originalBridge,
+                    !modelsUnloading.contains(modelId)
+                {
+                    await engineV2Runtime.register(
+                        modelId: modelId, bridge: originalBridge)
+                } else {
+                    await engineV2Runtime.unregister(modelId: modelId)
+                }
+            }
+            if let replacementBundle {
+                await replacementBundle.bridge.shutdown()
+                replacementBundle.releaseAssistant()
+            } else {
+                preparedAssistant?.release()
+            }
+            MLX.Memory.clearCache()
+            for entry in previousGrants {
+                await entry.bridge.updateKVBytesCapacity(entry.previousGrant)
+            }
+            await kvBudget.release(requestID: reservationID)
+            if modelSlots[modelId]?.engineV2 === originalBridge {
+                await originalBridge.endRecoveryReload()
+            }
+            if gateHeld {
+                releaseResliceGate()
+            }
+            let reason: MTPFallbackReason
+            if let failure = error as? SpecDecPromotionFailure {
+                reason = failure.reason
+            } else if error is CancellationError {
+                reason = .downloadCancelled
+            } else {
+                reason = .promotionConstructionFailed
+            }
+            if !(error is CancellationError) {
+                logSpecDecPromotionResult(
+                    modelId: modelId, artifact: artifact,
+                    result: "fallback", reason: reason, attempt: attempt,
+                    started: started)
+            } else {
+                restoreCancelledPromotionAttempt(
+                    modelId: modelId, artifact: artifact)
+            }
+        }
+
+        modelsPromotingSpecDec.remove(modelId)
+        isLoadingAny = false
+        releaseLoadGateWaiters()
+        finishSpecDecPromotionTask(modelId: modelId, taskID: taskID)
+    }
+
+}

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+MTPPromotionPolicy.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+MTPPromotionPolicy.swift
@@ -1,0 +1,143 @@
+import Foundation
+
+extension ProviderLoop {
+    func specDecArtifactBecameReady(
+        modelId: String,
+        artifact: SpecDecArtifact,
+        generation: UInt64 = 0
+    ) {
+        let identity = Self.specDecIdentity(artifact)
+        if generation > 0 {
+            let latest = specDecPromotionGenerations[modelId] ?? 0
+            guard generation >= latest else { return }
+            specDecPromotionGenerations[modelId] = generation
+        }
+        guard !isShuttingDown,
+            updatePhase == .idle,
+            !modelsUnloading.contains(modelId),
+            loopConfig.config.backend.mtp,
+            SpecDecArtifactFunnel.killSwitchEnabled(
+                environment: ProcessInfo.processInfo.environment),
+            let slot = modelSlots[modelId],
+            EngineV2SupportedModels.isGemma4Target(modelType: slot.modelType),
+            !Self.sameSpecDecIdentity(slot.engineBundle.mtpArtifact, artifact)
+        else { return }
+        if specDecPromotionTasks[modelId] != nil {
+            let pending = pendingSpecDecPromotions[modelId]
+            if pending == nil || generation >= pending?.generation ?? 0 {
+                pendingSpecDecPromotions[modelId] = .init(
+                    artifact: artifact, generation: generation)
+            }
+            return
+        }
+        var attemptState = specDecPromotionAttempts[modelId]
+        if attemptState?.identity != identity {
+            attemptState = .init(
+                identity: identity, attempts: 0)
+        }
+        guard var attemptState, attemptState.attempts < 3 else { return }
+        attemptState.attempts += 1
+        specDecPromotionAttempts[modelId] = attemptState
+        let attempt = attemptState.attempts
+
+        let id = UUID()
+        specDecPromotionTaskIDs[modelId] = id
+        specDecPromotionTasks[modelId] = Task { [weak self] in
+            await self?.runSpecDecPromotion(
+                modelId: modelId,
+                artifact: artifact,
+                generation: generation,
+                attempt: attempt,
+                taskID: id)
+        }
+    }
+
+    func cancelSpecDecPromotions() {
+        for task in specDecPromotionTasks.values { task.cancel() }
+    }
+
+    static func sameSpecDecIdentity(
+        _ lhs: SpecDecArtifact?,
+        _ rhs: SpecDecArtifact
+    ) -> Bool {
+        guard let lhs else { return false }
+        return specDecIdentity(lhs) == specDecIdentity(rhs)
+    }
+
+    static func specDecIdentity(_ artifact: SpecDecArtifact) -> String {
+        var components = [
+            artifact.source.rawValue,
+            artifact.revision,
+            String(artifact.artifactBytes),
+            artifact.manifestSHA256 ?? "local",
+            artifact.localConfigSHA256 ?? "catalog",
+        ]
+        if let weights = artifact.localWeightSHA256 {
+            components.append(contentsOf: weights.sorted { $0.key < $1.key }
+                .flatMap { [$0.key, $0.value] })
+        }
+        return components.joined(separator: ":")
+    }
+
+    func promotionMayContinue(
+        modelId: String,
+        generation: UInt64,
+        taskID: UUID
+    ) -> Bool {
+        !Task.isCancelled
+            && !isShuttingDown
+            && updatePhase == .idle
+            && specDecPromotionTaskIDs[modelId] == taskID
+            && (generation == 0
+                || specDecPromotionGenerations[modelId] == generation)
+            && modelSlots[modelId] != nil
+            && !modelsUnloading.contains(modelId)
+    }
+
+    func finishSpecDecPromotionTask(modelId: String, taskID: UUID) {
+        guard specDecPromotionTaskIDs[modelId] == taskID else { return }
+        specDecPromotionTaskIDs.removeValue(forKey: modelId)
+        specDecPromotionTasks.removeValue(forKey: modelId)
+        if let pending = pendingSpecDecPromotions.removeValue(forKey: modelId) {
+            specDecArtifactBecameReady(
+                modelId: modelId,
+                artifact: pending.artifact,
+                generation: pending.generation)
+        }
+    }
+
+    func restoreCancelledPromotionAttempt(
+        modelId: String,
+        artifact: SpecDecArtifact
+    ) {
+        let identity = Self.specDecIdentity(artifact)
+        guard var state = specDecPromotionAttempts[modelId],
+            state.identity == identity,
+            state.attempts > 0
+        else { return }
+        state.attempts -= 1
+        specDecPromotionAttempts[modelId] = state
+    }
+
+    func logSpecDecPromotionResult(
+        modelId: String,
+        artifact: SpecDecArtifact,
+        result: String,
+        reason: MTPFallbackReason?,
+        attempt: Int,
+        started: ContinuousClock.Instant
+    ) {
+        let elapsed = ContinuousClock.now - started
+        let durationMs = Int64(max(
+            0,
+            Double(elapsed.components.seconds) * 1_000
+                + Double(elapsed.components.attoseconds) / 1e15))
+        logger.info(
+            "mtp: promotion model=\(modelId) attempt=\(attempt) result=\(result) "
+                + "reason=\(reason?.rawValue ?? "none") "
+                + "source=\(artifact.source.rawValue) "
+                + "revision=\(artifact.revision) "
+                + "assistant_bytes=\(artifact.residentBytes) "
+                + "duration_ms=\(durationMs)")
+    }
+}

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+ModelLoading.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+ModelLoading.swift
@@ -279,7 +279,9 @@ extension ProviderLoop {
         if modelSlots.count >= maxModelSlots {
             let modelsWithInflight = Set(requestToModel.values)
             let evictable = modelSlots.filter {
-                !modelsWithInflight.contains($0.key) && !hasLocalReservation($0.key) && !modelsUnloading.contains($0.key)
+                !modelsWithInflight.contains($0.key) && !hasLocalReservation($0.key)
+                    && !modelsUnloading.contains($0.key)
+                    && !modelsPromotingSpecDec.contains($0.key)
             }
             if evictable.isEmpty || !allowEviction {
                 isLoadingAny = false
@@ -331,11 +333,26 @@ extension ProviderLoop {
                 recordModelLoadError(model: modelId, message: message)
                 throw InferenceError.modelLoadFailed(message)
             }
-            // The assistant is optional and must never make an otherwise
-            // loadable target fail. It is charged before allocation when it
-            // fits; otherwise this load continues target-only.
-            mtpPreparation = await admitSpecDecIfMemoryAllows(
-                mtpPreparation, targetRequiredGb: requiredGb)
+            // Make mandatory target residency visible first, then atomically
+            // grow that promise for the optional assistant. A concurrent KV
+            // claim can win only the optional race; the target remains
+            // reserved and serves target-only.
+            let targetPendingBytes = Self.pendingLoadReservationBytes(
+                estimatedWeightsGb: modelInfo.estimatedMemoryGb,
+                extraWeightBytes: 0)
+            await kvBudget.reservePendingLoad(
+                requestID: pendingLoadID, bytes: targetPendingBytes)
+            if let artifact = mtpPreparation.artifact,
+                !(await kvBudget.increaseReservationIfAvailable(
+                    requestID: pendingLoadID,
+                    additionalBytes: artifact.residentBytes))
+            {
+                logger.warning(
+                    "mtp: model assistant skipped reason=\(MTPFallbackReason.assistantMemoryUnavailable.rawValue) "
+                        + "assistant_bytes=\(artifact.residentBytes)")
+                mtpPreparation = mtpPreparation.fallingBack(
+                    .assistantMemoryUnavailable)
+            }
             let extraWeightBytes = mtpPreparation.artifact?.residentBytes ?? 0
             try Task.checkCancellation()
             if isShuttingDown { throw CancellationError() }
@@ -346,11 +363,6 @@ extension ProviderLoop {
             // blows the unified-memory cap. Released once the weights are resident.
             // Includes `extraWeightBytes` (the drafter): those bytes land in
             // mlxUsed during this load window just like the target's.
-            let pendingLoadBytes = Self.pendingLoadReservationBytes(
-                estimatedWeightsGb: modelInfo.estimatedMemoryGb,
-                extraWeightBytes: extraWeightBytes)
-            await kvBudget.reservePendingLoad(requestID: pendingLoadID, bytes: pendingLoadBytes)
-
             logger.info("Loading model: \(modelId) from \(modelPath.path)")
             // Cold-start load timing (slot-level `model_load_time_ms`): from
             // here to slot install — covering the weight load, sizing, and
@@ -735,6 +747,19 @@ extension ProviderLoop {
         else { return }
         let engineV2 = engineBundle.bridge
         modelsUnloading.insert(modelId)
+        // Promotion can retain this target container while loading/building a
+        // replacement. Fence new work first, then cancel AND await promotion
+        // cleanup before releasing weights or regrowing survivor grants.
+        if let promotion = specDecPromotionTasks[modelId] {
+            promotion.cancel()
+            await promotion.value
+        }
+        specDecPromotionTasks.removeValue(forKey: modelId)
+        specDecPromotionTaskIDs.removeValue(forKey: modelId)
+        pendingSpecDecPromotions.removeValue(forKey: modelId)
+        modelsPromotingSpecDec.remove(modelId)
+        specDecPromotionAttempts.removeValue(forKey: modelId)
+        specDecPromotionGenerations.removeValue(forKey: modelId)
         // Retire the slot's v2 bridge: unregister so heartbeats/cancellation
         // stop fanning out to it, then drain the engine gracefully (running
         // requests finish, new submissions are rejected).
@@ -865,7 +890,11 @@ extension ProviderLoop {
             let modelsWithInflight = Set(requestToModel.values)
             let candidate = allowEviction
                 ? modelSlots
-                    .filter { !modelsWithInflight.contains($0.key) && !hasLocalReservation($0.key) && !modelsUnloading.contains($0.key) }
+                    .filter {
+                        !modelsWithInflight.contains($0.key) && !hasLocalReservation($0.key)
+                            && !modelsUnloading.contains($0.key)
+                            && !modelsPromotingSpecDec.contains($0.key)
+                    }
                     .min(by: { $0.value.lastInferenceAt < $1.value.lastInferenceAt })
                 : nil
 
@@ -938,7 +967,9 @@ extension ProviderLoop {
         // evicted to make room, so its presence means we must NOT pre-reject.
         let modelsWithInflight = Set(requestToModel.values)
         let hasEvictable = modelSlots.contains {
-            !modelsWithInflight.contains($0.key) && !hasLocalReservation($0.key) && !modelsUnloading.contains($0.key)
+            !modelsWithInflight.contains($0.key) && !hasLocalReservation($0.key)
+                && !modelsUnloading.contains($0.key)
+                && !modelsPromotingSpecDec.contains($0.key)
         }
 
         // Not enough free memory and nothing idle to evict. Drop the reclaimable

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+Serve.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+Serve.swift
@@ -86,16 +86,22 @@ extension ProviderLoop {
         // 1. Apply security hardening
         try await applySecurityHardening()
 
-        // MTP catalog metadata is process-local. Give it one short, owned
-        // prewarm before either startup preloads or the unified local endpoint
-        // can perform the first normal cold target load. This never downloads
-        // assistant bytes and fails open on timeout.
-        await prewarmSpecDecCatalog()
+        // Artifact completion is a lifecycle event: a verified assistant that
+        // arrives after a target-only slot was published promotes that retained
+        // target at the next idle boundary. Initial cold loads await the same
+        // bounded funnel and normally activate before publication.
+        await specDecFunnel.setArtifactReadyHandler {
+            [weak self] modelId, artifact, generation in
+            await self?.specDecArtifactBecameReady(
+                modelId: modelId,
+                artifact: artifact,
+                generation: generation)
+        }
 
         // Unified mode: also expose a local OpenAI endpoint off the same loaded
-        // models. It starts after the bounded metadata prewarm, but still before
-        // the coordinator connection, so local serving keeps coordinator
-        // independence while a cached assistant can join the first target load.
+        // models. It starts before the coordinator connection; local serving
+        // remains coordinator-independent and may use an explicit local
+        // assistant path.
         if let localEndpoint = loopConfig.localEndpoint {
             startLocalEndpoint(localEndpoint)
         }
@@ -315,6 +321,7 @@ extension ProviderLoop {
 
         logger.info("Event stream ended, shutting down")
         isShuttingDown = true
+        cancelSpecDecPromotions()
         idleMonitorTask?.cancel()
         idleMonitorTask = nil
         capacityRefreshTask?.cancel()

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+Testing.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+Testing.swift
@@ -399,6 +399,26 @@ extension ProviderLoop {
         modelSlots[modelId]?.engineBundle.mtpStatus
     }
 
+    func specDecPromotionTaskCountForTesting() -> Int {
+        specDecPromotionTasks.count
+    }
+
+    func specDecPromotionInProgressForTesting(modelId: String) -> Bool {
+        modelsPromotingSpecDec.contains(modelId)
+    }
+
+    func specDecPromotionAttemptCountForTesting(modelId: String) -> Int {
+        specDecPromotionAttempts[modelId]?.attempts ?? 0
+    }
+
+    func reserveLocalModelForTesting(_ modelId: String) {
+        localReservations.reserve(modelId)
+    }
+
+    func releaseLocalModelForTesting(_ modelId: String) {
+        localReservations.release(modelId)
+    }
+
     /// Test seam: the live bridge for a loaded slot.
     func slotBridgeForTesting(modelId: String) -> EngineV2Bridge? {
         modelSlots[modelId]?.engineV2

--- a/provider-swift/Sources/ProviderCore/ProviderLoop.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop.swift
@@ -285,6 +285,24 @@ public actor ProviderLoop {
     /// thrashing rebuilds).
     internal var engineV2LastRecoveryAt: [String: ContinuousClock.Instant] = [:]
 
+    /// Verified-assistant promotion lifecycle. One task per model waits for an
+    /// idle boundary, builds a replacement over retained target weights, and
+    /// swaps only after runtime activation and memory checks pass.
+    internal var specDecPromotionTasks: [String: Task<Void, Never>] = [:]
+    internal var specDecPromotionTaskIDs: [String: UUID] = [:]
+    internal var modelsPromotingSpecDec: Set<String> = []
+    internal struct SpecDecPromotionAttemptState {
+        let identity: String
+        var attempts: Int
+    }
+    internal struct SpecDecPromotionCandidate {
+        let artifact: SpecDecArtifact
+        let generation: UInt64
+    }
+    internal var specDecPromotionAttempts: [String: SpecDecPromotionAttemptState] = [:]
+    internal var specDecPromotionGenerations: [String: UInt64] = [:]
+    internal var pendingSpecDecPromotions: [String: SpecDecPromotionCandidate] = [:]
+
     /// Tracks in-flight inference tasks by request ID so they can be cancelled.
     internal var inflightTasks: [String: Task<Void, Never>] = [:]
 

--- a/provider-swift/Sources/ProviderCore/Server/StandaloneServer.swift
+++ b/provider-swift/Sources/ProviderCore/Server/StandaloneServer.swift
@@ -80,8 +80,8 @@ public struct StandaloneServerConfig: Sendable {
     public let engineV2KVBackend: String
     /// Per-model overrides (`engine_v2_kv_backend_by_model`).
     public let engineV2KVBackendByModel: [String: String]
-    /// MTP beta configuration. Defaults off; the CLI/config owner passes these
-    /// through when standalone MTP is intentionally enabled.
+    /// MTP policy. Defaults on; coordinator-independent local mode can activate
+    /// only from an explicit local assistant path and otherwise stays target-only.
     public let mtp: Bool
     public let mtpDrafterPath: String?
 
@@ -96,7 +96,7 @@ public struct StandaloneServerConfig: Sendable {
         engineV2MaxConcurrentByModel: [String: UInt64] = [:],
         engineV2KVBackend: String = "auto",
         engineV2KVBackendByModel: [String: String] = [:],
-        mtp: Bool = false,
+        mtp: Bool = true,
         mtpDrafterPath: String? = nil
     ) {
         self.port = port
@@ -1225,11 +1225,15 @@ public actor StandaloneServer {
                     // that loads can actually serve (matches the runtime KV gate).
                     headroomGb: Double(UnifiedMemoryCap.loadHeadroomBytes()) / (1024.0 * 1024.0 * 1024.0))
             try await ensureMemoryHeadroomForLoad(requiredGb: targetRequiredGb)
+            let targetPendingBytes = ProviderLoop.pendingLoadReservationBytes(
+                estimatedWeightsGb: modelInfo.estimatedMemoryGb,
+                extraWeightBytes: 0)
+            await kvBudget.reservePendingLoad(
+                requestID: pendingLoadID, bytes: targetPendingBytes)
             if let artifact = mtpPreparation.artifact {
-                if !ProviderLoop.assistantMemoryFits(
-                    availableGb: await availableMemoryGb(),
-                    targetRequiredGb: targetRequiredGb,
-                    assistantBytes: artifact.residentBytes)
+                if !(await kvBudget.increaseReservationIfAvailable(
+                    requestID: pendingLoadID,
+                    additionalBytes: artifact.residentBytes))
                 {
                     mtpPreparation = mtpPreparation.fallingBack(
                         .assistantMemoryUnavailable)
@@ -1243,12 +1247,6 @@ public actor StandaloneServer {
             // Keep incoming weights visible to the process-wide KV ledger while
             // loadContainer is suspended. Existing-model requests continue to
             // serve during this await and must not reserve the same headroom.
-            let pendingLoadBytes = ProviderLoop.pendingLoadReservationBytes(
-                estimatedWeightsGb: modelInfo.estimatedMemoryGb,
-                extraWeightBytes: extraWeightBytes)
-            await kvBudget.reservePendingLoad(
-                requestID: pendingLoadID, bytes: pendingLoadBytes)
-
             try await v2TestHooks?.beforeWeightLoad?(modelId)
             let reusableSSDRequested = PrefixCachePolicy.isEnabled()
             let preLoadCacheHash = reusableSSDRequested

--- a/provider-swift/Sources/ProviderCore/SpecDec/SpecDecArtifactFunnel+Load.swift
+++ b/provider-swift/Sources/ProviderCore/SpecDec/SpecDecArtifactFunnel+Load.swift
@@ -1,0 +1,142 @@
+import Foundation
+
+extension SpecDecArtifactFunnel {
+    func prepareForLoad(_ request: Request) async -> SpecDecPreparation {
+        guard !isShutdown else {
+            return .init(
+                artifact: nil,
+                status: .disabled(.catalogUnavailable, configured: request.enabled))
+        }
+        let id = UUID()
+        let task = Task { await self.performLoadPreparation(request) }
+        loadPreparations[id] = task
+        let result = await withTaskCancellationHandler {
+            await task.value
+        } onCancel: {
+            task.cancel()
+        }
+        loadPreparations.removeValue(forKey: id)
+        return result
+    }
+
+    /// Initial/cold-load path. Network and file I/O happen before the provider's
+    /// model-load and re-slice gates are acquired. A verified warm artifact is
+    /// returned without network access after the fresh catalog identity is read;
+    /// an empty cache waits for one bounded verified download so one ordinary
+    /// start can publish an MTP-active slot.
+    private func performLoadPreparation(
+        _ request: Request
+    ) async -> SpecDecPreparation {
+        guard !isShutdown else {
+            return .init(
+                artifact: nil,
+                status: .disabled(.catalogUnavailable, configured: request.enabled))
+        }
+        guard request.enabled else {
+            return .init(artifact: nil, status: .disabled(.configDisabled, configured: false))
+        }
+        guard Self.killSwitchEnabled(environment: request.environment) else {
+            return .init(artifact: nil, status: .disabled(.killSwitchDisabled, configured: true))
+        }
+        guard Self.isGemma4Target(modelType: request.modelType) else {
+            return .init(artifact: nil, status: .disabled(.targetUnsupported, configured: true))
+        }
+        if let rawPath = request.localPath?.trimmingCharacters(in: .whitespacesAndNewlines),
+            !rawPath.isEmpty
+        {
+            guard let artifact = SpecDecStore.inspectLocalArtifact(path: rawPath) else {
+                return .init(
+                    artifact: nil,
+                    status: .disabled(.localArtifactInvalid, configured: true))
+            }
+            return .init(artifact: artifact, status: .candidate(artifact))
+        }
+        guard request.allowDownload, let catalog else {
+            return .init(
+                artifact: nil,
+                status: .disabled(.catalogDisabled, configured: true))
+        }
+
+        knownRequests[request.modelId] = request
+        if reevaluations[request.modelId] != nil,
+            let previousReason = prefetchFailures[request.modelId]
+        {
+            return .init(
+                artifact: nil,
+                status: .disabled(previousReason, configured: true))
+        }
+        let generation = beginCatalogGeneration(modelId: request.modelId)
+        let model: CatalogModel
+        do {
+            guard let fresh = try await catalog.freshModel(id: request.modelId) else {
+                guard isCurrentCatalogGeneration(
+                    modelId: request.modelId, generation: generation)
+                else {
+                    return .init(
+                        artifact: nil,
+                        status: .disabled(.catalogUnavailable, configured: true))
+                }
+                prefetchFailures[request.modelId] = .catalogModelMissing
+                scheduleReevaluation(for: request)
+                return .init(
+                    artifact: nil,
+                    status: .disabled(.catalogModelMissing, configured: true))
+            }
+            model = fresh
+        } catch {
+            guard isCurrentCatalogGeneration(
+                modelId: request.modelId, generation: generation)
+            else {
+                return .init(
+                    artifact: nil,
+                    status: .disabled(.catalogUnavailable, configured: true))
+            }
+            prefetchFailures[request.modelId] = .catalogUnavailable
+            scheduleReevaluation(for: request)
+            return .init(
+                artifact: nil,
+                status: .disabled(.catalogUnavailable, configured: true))
+        }
+        guard !isShutdown,
+            isCurrentCatalogGeneration(
+                modelId: request.modelId, generation: generation)
+        else {
+            return .init(
+                artifact: nil,
+                status: .disabled(.catalogUnavailable, configured: true))
+        }
+
+        let cached = await resolver.resolve(model: model, allowDownload: false)
+        let resolution: SpecDecResolution
+        if cached.reason == .artifactNotCached {
+            resolution = await resolver.prefetch(model: model)
+        } else {
+            resolution = cached
+        }
+        guard !isShutdown,
+            isCurrentCatalogGeneration(
+                modelId: request.modelId, generation: generation)
+        else {
+            return .init(
+                artifact: nil,
+                status: .disabled(.catalogUnavailable, configured: true))
+        }
+        guard let artifact = resolution.artifact else {
+            prefetchFailures[request.modelId] =
+                resolution.reason ?? .publicationFailed
+            scheduleReevaluation(for: request)
+            return .init(
+                artifact: nil,
+                status: .disabled(
+                    resolution.reason ?? .publicationFailed, configured: true))
+        }
+        prefetchFailures.removeValue(forKey: request.modelId)
+        reevaluationAttempts.removeValue(forKey: request.modelId)
+        await notifyReady(
+            modelId: request.modelId,
+            artifact: artifact,
+            generation: generation)
+        scheduleSteadyRefresh(for: request)
+        return .init(artifact: artifact, status: .candidate(artifact))
+    }
+}

--- a/provider-swift/Sources/ProviderCore/SpecDec/SpecDecArtifactFunnel+Reevaluation.swift
+++ b/provider-swift/Sources/ProviderCore/SpecDec/SpecDecArtifactFunnel+Reevaluation.swift
@@ -1,0 +1,115 @@
+import Foundation
+
+extension SpecDecArtifactFunnel {
+    func notifyReady(
+        modelId: String,
+        artifact: SpecDecArtifact,
+        generation: UInt64
+    ) async {
+        guard isCurrentCatalogGeneration(
+            modelId: modelId, generation: generation)
+        else { return }
+        guard let handler = artifactReadyHandler, !isShutdown else { return }
+        await handler(modelId, artifact, generation)
+    }
+
+    func scheduleReevaluation(for request: Request) {
+        guard !isShutdown, reevaluations[request.modelId] == nil else { return }
+        let attempt = reevaluationAttempts[request.modelId, default: 0]
+        guard attempt < reevaluationDelays.count else {
+            scheduleSteadyRefresh(for: request)
+            return
+        }
+        reevaluationAttempts[request.modelId] = attempt + 1
+        scheduleReevaluation(for: request, after: reevaluationDelays[attempt])
+    }
+
+    func scheduleSteadyRefresh(for request: Request) {
+        guard !isShutdown, reevaluations[request.modelId] == nil,
+            steadyRefreshInterval > .zero
+        else { return }
+        scheduleReevaluation(for: request, after: steadyRefreshInterval)
+    }
+
+    private func scheduleReevaluation(for request: Request, after delay: Duration) {
+        let id = UUID()
+        let task = Task { [weak self] in
+            do {
+                try await taskSleep(delay)
+            } catch {
+                await self?.finishReevaluation(
+                    modelId: request.modelId, id: id)
+                return
+            }
+            await self?.runReevaluation(request: request, id: id)
+        }
+        reevaluations[request.modelId] = Reevaluation(id: id, task: task)
+    }
+
+    private func runReevaluation(request: Request, id: UUID) async {
+        guard !isShutdown, reevaluations[request.modelId]?.id == id,
+            let catalog
+        else { return }
+        let generation = beginCatalogGeneration(modelId: request.modelId)
+
+        let resolution: SpecDecResolution
+        do {
+            guard let model = try await catalog.freshModel(id: request.modelId) else {
+                finishReevaluation(modelId: request.modelId, id: id)
+                guard isCurrentCatalogGeneration(
+                    modelId: request.modelId, generation: generation),
+                    !isShutdown
+                else { return }
+                prefetchFailures[request.modelId] = .catalogModelMissing
+                scheduleReevaluation(for: request)
+                return
+            }
+            guard isCurrentCatalogGeneration(
+                modelId: request.modelId, generation: generation),
+                !isShutdown
+            else {
+                finishReevaluation(modelId: request.modelId, id: id)
+                return
+            }
+            let cached = await resolver.resolve(model: model, allowDownload: false)
+            if cached.reason == .artifactNotCached {
+                resolution = await resolver.prefetch(model: model)
+            } else {
+                resolution = cached
+            }
+        } catch {
+            finishReevaluation(modelId: request.modelId, id: id)
+            guard isCurrentCatalogGeneration(
+                modelId: request.modelId, generation: generation),
+                !isShutdown
+            else { return }
+            prefetchFailures[request.modelId] = .catalogUnavailable
+            scheduleReevaluation(for: request)
+            return
+        }
+        finishReevaluation(modelId: request.modelId, id: id)
+        guard !isShutdown,
+            isCurrentCatalogGeneration(
+                modelId: request.modelId, generation: generation)
+        else { return }
+        if let artifact = resolution.artifact {
+            prefetchFailures.removeValue(forKey: request.modelId)
+            reevaluationAttempts.removeValue(forKey: request.modelId)
+            await notifyReady(
+                modelId: request.modelId,
+                artifact: artifact,
+                generation: generation)
+            scheduleSteadyRefresh(for: request)
+        } else {
+            if let reason = resolution.reason {
+                prefetchFailures[request.modelId] = reason
+            }
+            scheduleReevaluation(for: request)
+        }
+    }
+
+    private func finishReevaluation(modelId: String, id: UUID) {
+        guard reevaluations[modelId]?.id == id else { return }
+        reevaluations.removeValue(forKey: modelId)
+    }
+}

--- a/provider-swift/Sources/ProviderCore/SpecDec/SpecDecArtifactFunnel.swift
+++ b/provider-swift/Sources/ProviderCore/SpecDec/SpecDecArtifactFunnel.swift
@@ -50,6 +50,9 @@ actor SpecDecCatalogLookup: SpecDecCatalogLooking {
 /// One target-independent artifact funnel shared by coordinator-serving and
 /// standalone slots. It never loads model weights and never throws.
 actor SpecDecArtifactFunnel {
+    typealias ArtifactReadyHandler =
+        @Sendable (String, SpecDecArtifact, UInt64) async -> Void
+
     struct Request: Sendable {
         let modelId: String
         let modelType: String?
@@ -59,17 +62,34 @@ actor SpecDecArtifactFunnel {
         let environment: [String: String]
     }
 
-    private let resolver: SpecDecResolver
-    private let catalog: (any SpecDecCatalogLooking)?
+    let resolver: SpecDecResolver
+    let catalog: (any SpecDecCatalogLooking)?
     private struct Prefetch {
         let id: UUID
+        let generation: UInt64
         let task: Task<Void, Never>
     }
     private var prefetches: [String: Prefetch] = [:]
-    private var prefetchFailures: [String: MTPFallbackReason] = [:]
+    var prefetchFailures: [String: MTPFallbackReason] = [:]
     private let maximumPrefetches = 2
-    private var isShutdown = false
+    var isShutdown = false
     private var shutdownTasks: [Task<Void, Never>] = []
+    var loadPreparations: [UUID: Task<SpecDecPreparation, Never>] = [:]
+    private var shutdownLoadPreparations:
+        [Task<SpecDecPreparation, Never>] = []
+    var artifactReadyHandler: ArtifactReadyHandler?
+    struct Reevaluation {
+        let id: UUID
+        let task: Task<Void, Never>
+    }
+    var reevaluations: [String: Reevaluation] = [:]
+    var reevaluationAttempts: [String: Int] = [:]
+    var knownRequests: [String: Request] = [:]
+    var catalogGenerations: [String: UInt64] = [:]
+    var reevaluationDelays: [Duration] = [
+        .seconds(30), .seconds(60), .seconds(120),
+    ]
+    var steadyRefreshInterval: Duration = .seconds(600)
     /// Cooldown for stale-entry catalog refreshes so a model that is
     /// permanently missing spec-dec metadata cannot make every load attempt
     /// refetch the catalog. Internal-settable for tests.
@@ -81,39 +101,26 @@ actor SpecDecArtifactFunnel {
         self.catalog = catalog
     }
 
-    /// Populate only the small catalog metadata cache before startup model
-    /// loads. The deadline is intentionally short and fail-open; target loads
-    /// never await catalog or artifact network I/O themselves.
-    @discardableResult
-    func prewarmCatalog(
-        modelId: String,
-        timeout: Duration,
-        sleep: @escaping @Sendable (Duration) async throws -> Void = { duration in
-            try await taskSleep(duration)
-        }
-    ) async -> Bool {
-        guard !isShutdown, let catalog else { return false }
-        return await withTaskGroup(of: Bool.self) { group in
-            group.addTask {
-                do {
-                    _ = try await catalog.model(id: modelId)
-                    return true
-                } catch {
-                    return false
-                }
-            }
-            group.addTask {
-                do {
-                    try await sleep(timeout)
-                } catch {
-                    return false
-                }
-                return false
-            }
-            let result = await group.next() ?? false
-            group.cancelAll()
-            return result
-        }
+    func setArtifactReadyHandler(_ handler: ArtifactReadyHandler?) {
+        artifactReadyHandler = handler
+    }
+
+    func beginCatalogGeneration(modelId: String) -> UInt64 {
+        let next = (catalogGenerations[modelId] ?? 0) &+ 1
+        catalogGenerations[modelId] = next
+        return next
+    }
+
+    func isCurrentCatalogGeneration(modelId: String, generation: UInt64) -> Bool {
+        catalogGenerations[modelId] == generation
+    }
+
+    func configureReevaluationForTesting(
+        delays: [Duration],
+        steadyInterval: Duration
+    ) {
+        reevaluationDelays = delays
+        steadyRefreshInterval = steadyInterval
     }
 
     func prepare(_ request: Request) async -> SpecDecPreparation {
@@ -130,6 +137,9 @@ actor SpecDecArtifactFunnel {
         }
         guard Self.isGemma4Target(modelType: request.modelType) else {
             return .init(artifact: nil, status: .disabled(.targetUnsupported, configured: true))
+        }
+        if request.allowDownload {
+            knownRequests[request.modelId] = request
         }
 
         // An explicitly configured local artifact is authoritative. An invalid
@@ -190,17 +200,28 @@ actor SpecDecArtifactFunnel {
     func shutdown() async {
         if isShutdown {
             for task in shutdownTasks { await task.value }
+            for task in shutdownLoadPreparations { _ = await task.value }
             return
         }
         // Terminal before the first suspension: reentrant prepare calls and
         // tasks returning from catalog lookup cannot enqueue successor work.
         isShutdown = true
         let tasks = prefetches.values.map(\.task)
-        shutdownTasks = tasks
+        let refreshTasks = reevaluations.values.map(\.task)
+        let preparations = Array(loadPreparations.values)
+        shutdownTasks = tasks + refreshTasks
+        shutdownLoadPreparations = preparations
         prefetches.removeAll()
-        for task in tasks { task.cancel() }
-        for task in tasks { await task.value }
+        reevaluations.removeAll()
+        loadPreparations.removeAll()
+        knownRequests.removeAll()
+        catalogGenerations.removeAll()
+        for task in shutdownTasks { task.cancel() }
+        for task in shutdownLoadPreparations { task.cancel() }
+        for task in shutdownTasks { await task.value }
+        for task in shutdownLoadPreparations { _ = await task.value }
         shutdownTasks.removeAll()
+        shutdownLoadPreparations.removeAll()
     }
 
     private func schedulePrefetch(
@@ -214,26 +235,45 @@ actor SpecDecArtifactFunnel {
             return
         }
         let id = UUID()
+        let generation = beginCatalogGeneration(modelId: modelId)
         let resolver = self.resolver
         let task = Task {
             let reason: MTPFallbackReason?
             do {
                 guard let model = try await catalog.model(id: modelId) else {
-                    self.finishPrefetch(
-                        modelId: modelId, id: id, reason: .catalogModelMissing)
+                    await self.finishPrefetch(
+                        modelId: modelId, id: id,
+                        generation: generation,
+                        resolution: .fallback(.catalogModelMissing))
                     return
                 }
                 guard self.prefetchMayContinue(modelId: modelId, id: id) else {
                     return
                 }
+                guard self.isCurrentCatalogGeneration(
+                    modelId: modelId, generation: generation)
+                else {
+                    await self.finishPrefetch(
+                        modelId: modelId, id: id, generation: generation,
+                        resolution: .fallback(.catalogUnavailable))
+                    return
+                }
                 let result = await resolver.prefetch(model: model)
                 reason = result.artifact == nil ? result.reason : nil
+                await self.finishPrefetch(
+                    modelId: modelId, id: id, generation: generation,
+                    resolution: result)
+                return
             } catch {
                 reason = .catalogUnavailable
             }
-            self.finishPrefetch(modelId: modelId, id: id, reason: reason)
+            await self.finishPrefetch(
+                modelId: modelId, id: id,
+                generation: generation,
+                resolution: .fallback(reason ?? .catalogUnavailable))
         }
-        prefetches[modelId] = Prefetch(id: id, task: task)
+        prefetches[modelId] = Prefetch(
+            id: id, generation: generation, task: task)
     }
 
     /// Refresh a suspected-stale cached catalog entry, then prefetch the
@@ -255,26 +295,45 @@ actor SpecDecArtifactFunnel {
         }
         catalogRefreshedAt[modelId] = now
         let id = UUID()
+        let generation = beginCatalogGeneration(modelId: modelId)
         let resolver = self.resolver
         let task = Task {
             let reason: MTPFallbackReason?
             do {
                 guard let model = try await catalog.freshModel(id: modelId) else {
-                    self.finishPrefetch(
-                        modelId: modelId, id: id, reason: .catalogModelMissing)
+                    await self.finishPrefetch(
+                        modelId: modelId, id: id,
+                        generation: generation,
+                        resolution: .fallback(.catalogModelMissing))
                     return
                 }
                 guard self.prefetchMayContinue(modelId: modelId, id: id) else {
                     return
                 }
+                guard self.isCurrentCatalogGeneration(
+                    modelId: modelId, generation: generation)
+                else {
+                    await self.finishPrefetch(
+                        modelId: modelId, id: id, generation: generation,
+                        resolution: .fallback(.catalogUnavailable))
+                    return
+                }
                 let result = await resolver.prefetch(model: model)
                 reason = result.artifact == nil ? result.reason : nil
+                await self.finishPrefetch(
+                    modelId: modelId, id: id, generation: generation,
+                    resolution: result)
+                return
             } catch {
                 reason = .catalogUnavailable
             }
-            self.finishPrefetch(modelId: modelId, id: id, reason: reason)
+            await self.finishPrefetch(
+                modelId: modelId, id: id,
+                generation: generation,
+                resolution: .fallback(reason ?? .catalogUnavailable))
         }
-        prefetches[modelId] = Prefetch(id: id, task: task)
+        prefetches[modelId] = Prefetch(
+            id: id, generation: generation, task: task)
     }
 
     private func scheduleArtifactPrefetch(modelId: String, model: CatalogModel) {
@@ -285,15 +344,18 @@ actor SpecDecArtifactFunnel {
             return
         }
         let id = UUID()
+        let generation = beginCatalogGeneration(modelId: modelId)
         let resolver = self.resolver
         let task = Task {
             let result = await resolver.prefetch(model: model)
-            self.finishPrefetch(
+            await self.finishPrefetch(
                 modelId: modelId,
                 id: id,
-                reason: result.artifact == nil ? result.reason : nil)
+                generation: generation,
+                resolution: result)
         }
-        prefetches[modelId] = Prefetch(id: id, task: task)
+        prefetches[modelId] = Prefetch(
+            id: id, generation: generation, task: task)
     }
 
     private func prefetchMayContinue(modelId: String, id: UUID) -> Bool {
@@ -303,12 +365,30 @@ actor SpecDecArtifactFunnel {
     private func finishPrefetch(
         modelId: String,
         id: UUID,
-        reason: MTPFallbackReason?
-    ) {
+        generation: UInt64,
+        resolution: SpecDecResolution
+    ) async {
         guard prefetches[modelId]?.id == id else { return }
         prefetches.removeValue(forKey: modelId)
-        if let reason {
+        guard !isShutdown,
+            isCurrentCatalogGeneration(
+                modelId: modelId, generation: generation)
+        else { return }
+        if let artifact = resolution.artifact {
+            prefetchFailures.removeValue(forKey: modelId)
+            reevaluationAttempts.removeValue(forKey: modelId)
+            await notifyReady(
+                modelId: modelId,
+                artifact: artifact,
+                generation: generation)
+            if let request = knownRequests[modelId] {
+                scheduleSteadyRefresh(for: request)
+            }
+        } else if let reason = resolution.reason {
             prefetchFailures[modelId] = reason
+            if let request = knownRequests[modelId] {
+                scheduleReevaluation(for: request)
+            }
         } else {
             prefetchFailures.removeValue(forKey: modelId)
         }

--- a/provider-swift/Sources/ProviderCore/SpecDec/SpecDecResolver.swift
+++ b/provider-swift/Sources/ProviderCore/SpecDec/SpecDecResolver.swift
@@ -225,7 +225,8 @@ public struct SpecDecResolver: Sendable {
     private func boundedDownload(
         reference: SpecDecArtifactReference
     ) async -> SpecDecResolution {
-        await withTaskGroup(of: SpecDecResolution.self) { group in
+        let started = ContinuousClock.now
+        let result = await withTaskGroup(of: SpecDecResolution.self) { group in
             group.addTask {
                 await downloadAndPublish(reference: reference)
             }
@@ -233,11 +234,11 @@ public struct SpecDecResolver: Sendable {
                 do {
                     try await taskSleep(prefetchTimeout)
                     return .fallback(
-                        .fileDownloadFailed,
+                        .downloadTimedOut,
                         detail: "MTP prefetch exceeded its owned deadline")
                 } catch {
                     return .fallback(
-                        .fileDownloadFailed,
+                        .downloadCancelled,
                         detail: "MTP prefetch was cancelled")
                 }
             }
@@ -246,6 +247,14 @@ public struct SpecDecResolver: Sendable {
             group.cancelAll()
             return result
         }
+        let elapsed = ContinuousClock.now - started
+        let milliseconds = Int64(max(
+            0,
+            Double(elapsed.components.seconds) * 1_000
+                + Double(elapsed.components.attoseconds) / 1e15))
+        Self.logger.info(
+            "spec-dec: revision=\(reference.revision) download_verify_ms=\(milliseconds) result=\(result.reason?.rawValue ?? "ready")")
+        return result
     }
 
     private func resolutionKey(

--- a/provider-swift/Sources/ProviderCore/SpecDec/SpecDecTypes.swift
+++ b/provider-swift/Sources/ProviderCore/SpecDec/SpecDecTypes.swift
@@ -22,6 +22,8 @@ public enum MTPFallbackReason: String, Sendable, Equatable {
     case fileTypeDisallowed = "file_type_disallowed"
     case pathInvalid = "path_invalid"
     case fileDownloadFailed = "file_download_failed"
+    case downloadTimedOut = "download_timed_out"
+    case downloadCancelled = "download_cancelled"
     case fileDigestMismatch = "file_digest_mismatch"
     case warmArtifactCorrupt = "warm_artifact_corrupt"
     case publicationFailed = "publication_failed"
@@ -30,6 +32,8 @@ public enum MTPFallbackReason: String, Sendable, Equatable {
     case assistantMemoryUnavailable = "assistant_memory_unavailable"
     case assistantResliceFloor = "assistant_reslice_floor"
     case assistantPostBuildHeadroom = "assistant_post_build_headroom"
+    case promotionBusyTimeout = "promotion_busy_timeout"
+    case promotionConstructionFailed = "promotion_construction_failed"
     case engineInactive = "engine_inactive"
 }
 

--- a/provider-swift/Tests/ProviderCoreTests/MTPConfigTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/MTPConfigTests.swift
@@ -1,10 +1,7 @@
 // Copyright © 2026 Eigen Labs.
 //
-// MTP config + hygiene surface (Gemma 4 MTP plan §4 D5): the `[backend]`
-// `mtp` / `mtp_drafter_path` TOML keys, the `mtp` beta-feature registry
-// entry (`darkbloom beta enable mtp` is registry-driven, zero CLI code),
-// and the `gemma4_assistant` supported-set carve-out (a hand-downloaded
-// drafter checkpoint must never be advertised as a servable chat model).
+// MTP config + hygiene surface: production-default policy, persistent opt-out,
+// environment kill-switch precedence, and assistant namespace exclusion.
 
 import Testing
 
@@ -30,8 +27,18 @@ struct MTPConfigKeyTests {
         #expect(MTPAutomaticVerificationPolicy.initialDraftTokens == 1)
     }
 
+    @Test("active MTP forces transactional contiguous KV")
+    func mtpForcesContiguousKV() {
+        #expect(EngineV2SlotFactory.mtpCompatibleKVBackend(
+            .paged, assistantActive: true) == .contiguous)
+        #expect(EngineV2SlotFactory.mtpCompatibleKVBackend(
+            .paged, assistantActive: false) == .paged)
+        #expect(EngineV2SlotFactory.mtpCompatibleKVBackend(
+            .contiguous, assistantActive: true) == .contiguous)
+    }
 
-    @Test("absent keys default to mtp=false, no drafter path")
+
+    @Test("old configs without keys migrate to mtp=true")
     func defaultsWhenAbsent() {
         let config = ConfigManager.parse(
             """
@@ -42,7 +49,7 @@ struct MTPConfigKeyTests {
             port = 8100
             """)
 
-        #expect(config.backend.mtp == false)
+        #expect(config.backend.mtp == true)
         #expect(config.backend.mtpDrafterPath == nil)
     }
 
@@ -54,11 +61,11 @@ struct MTPConfigKeyTests {
             name = "test-provider"
 
             [backend]
-            mtp = true
+            mtp = false
             mtp_drafter_path = "/opt/drafters/gemma4-assistant-4bit"
             """)
 
-        #expect(config.backend.mtp == true)
+        #expect(config.backend.mtp == false)
         #expect(config.backend.mtpDrafterPath == "/opt/drafters/gemma4-assistant-4bit")
     }
 
@@ -79,9 +86,9 @@ struct MTPConfigKeyTests {
 
     // ConfigManager.parse falls back to a full default config on any decode
     // failure (documented behavior: a malformed provider.toml must never
-    // brick a provider) — so a wrongly-typed value yields the safe default
-    // (MTP off), never a crash or a half-parsed config.
-    @Test("wrongly-typed mtp value falls back to defaults (off)")
+    // brick a provider) — so a wrongly-typed value yields the production
+    // default, never a crash or a half-parsed config.
+    @Test("wrongly-typed mtp value falls back to production default")
     func invalidMTPValueFallsBack() {
         let config = ConfigManager.parse(
             """
@@ -92,7 +99,7 @@ struct MTPConfigKeyTests {
             mtp = "yes"
             """)
 
-        #expect(config.backend.mtp == false)
+        #expect(config.backend.mtp == true)
         #expect(config.backend.mtpDrafterPath == nil)
     }
 
@@ -108,7 +115,7 @@ struct MTPConfigKeyTests {
             mtp_drafter_path = 42
             """)
 
-        #expect(config.backend.mtp == false)
+        #expect(config.backend.mtp == true)
         #expect(config.backend.mtpDrafterPath == nil)
     }
 
@@ -143,74 +150,33 @@ struct MTPConfigKeyTests {
     }
 }
 
-// MARK: - Beta feature
+@Suite("MTP production policy")
+struct MTPProductionPolicyTests {
+    @Test("MTP is not exposed through the beta workflow")
+    func betaEntryRemoved() {
+        #expect(BetaFeatures.feature(id: "mtp") == nil)
+        #expect(!BetaFeatures.all.contains { $0.id == "mtp" })
+    }
 
-@Suite("MTP beta feature")
-struct MTPBetaFeatureTests {
-
-    private func freshConfig() -> ProviderConfig {
-        ProviderConfig(
+    @Test("explicit config opt-out survives serialization")
+    func explicitOptOutRoundTrips() {
+        let original = ProviderConfig(
             provider: ProviderSettings(name: "test-provider"),
-            backend: BackendSettings(),
-            coordinator: CoordinatorSettings()
-        )
+            backend: BackendSettings(mtp: false),
+            coordinator: CoordinatorSettings())
+        let decoded = ConfigManager.parse(ConfigManager.serialize(original))
+        #expect(decoded.backend.mtp == false)
     }
 
-    @Test("registry exposes mtp, restart-required, default off")
-    func registryEntry() throws {
-        let feature = try #require(BetaFeatures.feature(id: "mtp"))
-        #expect(feature.id == "mtp")
-        #expect(feature.requiresRestart == true)
-        #expect(feature.isEnabled(in: freshConfig()) == false)
-        // Case-insensitive lookup, like every other beta id.
-        #expect(BetaFeatures.feature(id: "MTP")?.id == "mtp")
-    }
-
-    @Test("apply toggles config.backend.mtp both ways")
-    func applyTogglesField() {
-        let feature = BetaFeatures.feature(id: "mtp")!
-        var config = freshConfig()
-
-        feature.apply(true, to: &config)
-        #expect(config.backend.mtp == true)
-        #expect(feature.isEnabled(in: config) == true)
-        #expect(BetaFeatures.enabledIDs(in: config) == ["mtp"])
-
-        feature.apply(false, to: &config)
-        #expect(config.backend.mtp == false)
-        #expect(feature.isEnabled(in: config) == false)
-        #expect(BetaFeatures.enabledIDs(in: config).isEmpty)
-    }
-
-    @Test("apply only mutates its mapped field")
-    func applyIsScoped() {
-        let feature = BetaFeatures.feature(id: "mtp")!
-        var config = freshConfig()
-        let before = config
-
-        feature.apply(true, to: &config)
-
-        #expect(config.backend.kvQuant == before.backend.kvQuant)
-        #expect(config.backend.mtpDrafterPath == before.backend.mtpDrafterPath)
-        #expect(config.backend.port == before.backend.port)
-        #expect(config.provider == before.provider)
-        #expect(config.coordinator == before.coordinator)
-    }
-
-    // `darkbloom beta enable mtp` = apply(true) + ConfigManager.save; the
-    // daemon reads the TOML back on restart. This round-trip is the whole
-    // enable path, minus the file I/O.
-    @Test("toggle survives a TOML round-trip")
-    func roundTripsThroughTOML() {
-        let feature = BetaFeatures.feature(id: "mtp")!
-        var config = freshConfig()
-        feature.apply(true, to: &config)
-
-        let toml = ConfigManager.serialize(config)
-        let decoded = ConfigManager.parse(toml)
-
-        #expect(toml.contains("mtp = true"))
-        #expect(feature.isEnabled(in: decoded) == true)
+    @Test("environment kill switch is persisted into the launchd service")
+    func killSwitchSurvivesLaunchdRestarts() {
+        let persisted = LaunchAgent.passthroughEnvironment(from: [
+            "DARKBLOOM_CBV2_MTP": "0",
+            "UNRELATED": "secret",
+        ])
+        #expect(persisted == ["DARKBLOOM_CBV2_MTP": "0"])
+        #expect(!SpecDecArtifactFunnel.killSwitchEnabled(environment: persisted))
+        #expect(SpecDecArtifactFunnel.killSwitchEnabled(environment: [:]))
     }
 }
 

--- a/provider-swift/Tests/ProviderCoreTests/MTPResliceFallbackTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/MTPResliceFallbackTests.swift
@@ -141,6 +141,17 @@ private final class MTPFloorEngine: CBv2Engine, @unchecked Sendable {
         let held = lock.withLock { () -> [AsyncStream<CBv2Event>.Continuation] in
             let held = continuations
             continuations.removeAll()
+            submitted = 0
+            return held
+        }
+        for continuation in held { continuation.finish() }
+    }
+
+    func finishHeld() {
+        let held = lock.withLock { () -> [AsyncStream<CBv2Event>.Continuation] in
+            let held = continuations
+            continuations.removeAll()
+            submitted = 0
             return held
         }
         for continuation in held { continuation.finish() }
@@ -150,6 +161,7 @@ private final class MTPFloorEngine: CBv2Engine, @unchecked Sendable {
 private final class MTPRecoveryEngineFactory: @unchecked Sendable {
     private let lock = NSLock()
     private var count = 0
+    private var engines: [MTPFloorEngine] = []
     private let blockRecovery: Bool
     private let recoveryStarted = DispatchSemaphore(value: 0)
     private let recoveryResume = DispatchSemaphore(value: 0)
@@ -170,7 +182,9 @@ private final class MTPRecoveryEngineFactory: @unchecked Sendable {
             recoveryStarted.signal()
             recoveryResume.wait()
         }
-        return MTPFloorEngine(capacityBytes: grant, hangs: index == 0)
+        let engine = MTPFloorEngine(capacityBytes: grant, hangs: index == 0)
+        lock.withLock { engines.append(engine) }
+        return engine
     }
 
     func waitForRecoveryStart() -> Bool {
@@ -178,6 +192,27 @@ private final class MTPRecoveryEngineFactory: @unchecked Sendable {
     }
 
     func resumeRecovery() { recoveryResume.signal() }
+
+    func finishFirstEngine() {
+        lock.withLock { engines.first }?.finishHeld()
+    }
+}
+
+private final class MTPFailingPromotionEngineFactory: @unchecked Sendable {
+    struct Failure: Error {}
+    private let lock = NSLock()
+    private var count = 0
+
+    var buildCount: Int { lock.withLock { count } }
+
+    func make(grant: Int) throws -> any CBv2Engine {
+        let index = lock.withLock { () -> Int in
+            defer { count += 1 }
+            return count
+        }
+        if index > 0 { throw Failure() }
+        return MTPFloorEngine(capacityBytes: grant)
+    }
 }
 
 private final class MTPFloorPrepared: CBv2MTPPreparedCapture {}
@@ -218,14 +253,72 @@ private struct MTPFloorAssistantLoader: ProviderMTPAssistantLoading {
     }
 }
 
-private func mtpFloorArtifact() throws -> SpecDecArtifact {
+private actor MTPPromotionLoadGate {
+    private var entered = false
+    private var enteredWaiters: [CheckedContinuation<Void, Never>] = []
+    private var continuation: CheckedContinuation<Void, any Error>?
+
+    func waitUntilEntered() async {
+        if entered { return }
+        await withCheckedContinuation { enteredWaiters.append($0) }
+    }
+
+    func wait() async throws {
+        entered = true
+        let waiters = enteredWaiters
+        enteredWaiters.removeAll()
+        for waiter in waiters { waiter.resume() }
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation {
+                self.continuation = $0
+            }
+        } onCancel: {
+            Task { await self.cancel() }
+        }
+    }
+
+    private func cancel() {
+        continuation?.resume(throwing: CancellationError())
+        continuation = nil
+    }
+}
+
+private final class MTPPromotionWeakOwner: @unchecked Sendable {
+    private let lock = NSLock()
+    private weak var owner: AnyObject?
+
+    func record(_ owner: AnyObject) {
+        lock.withLock { self.owner = owner }
+    }
+
+    var isAlive: Bool { lock.withLock { owner != nil } }
+}
+
+private struct MTPGatedAssistantLoader: ProviderMTPAssistantLoading {
+    let gate: MTPPromotionLoadGate
+    let ownerProbe: MTPPromotionWeakOwner
+
+    func loadAndBind(
+        artifact: SpecDecArtifact,
+        target: any LanguageModel
+    ) async throws -> ProviderMTPAssistantHandle {
+        let owner = NSObject()
+        ownerProbe.record(owner)
+        let handle = ProviderMTPAssistantHandle(
+            owner: owner, drafter: MTPFloorDrafter())
+        try await gate.wait()
+        return handle
+    }
+}
+
+private func mtpFloorArtifact(fill: UInt8 = 0x5a) throws -> SpecDecArtifact {
     let directory = FileManager.default.temporaryDirectory
         .appendingPathComponent("mtp-floor-\(UUID().uuidString)", isDirectory: true)
     try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
     try Data(#"{"model_type":"gemma4_assistant"}"#.utf8)
         .write(to: directory.appendingPathComponent("config.json"))
     let weightURL = directory.appendingPathComponent("model.safetensors")
-    try Data(repeating: 0x5a, count: 4096).write(to: weightURL)
+    try Data(repeating: fill, count: 4096).write(to: weightURL)
     return try #require(SpecDecStore.inspectLocalArtifact(path: directory.path))
 }
 
@@ -271,7 +364,7 @@ private func mtpFloorLoop(
                 backend: .init(
                     idleTimeoutMins: 0,
                     maxModelSlots: 3,
-                    mtp: mtpDrafterPath != nil,
+                    mtp: true,
                     mtpDrafterPath: mtpDrafterPath),
                 coordinator: .init(heartbeatIntervalSecs: 60))),
         purgeLegacyFiles: false,
@@ -541,6 +634,398 @@ struct MTPResliceFallbackTests {
         #expect(await server.debugOutstandingKVReservationBytes() == 0)
         await bridge.shutdown()
         await server.stopAndWait()
+    }
+
+    @Test("verified background artifact promotes an idle target-only slot without restart")
+    func backgroundArtifactPromotesIdleSlot() async throws {
+        let artifact = try mtpFloorArtifact()
+        defer { try? FileManager.default.removeItem(at: artifact.directory) }
+        let factory = MTPRecoveryEngineFactory()
+        let loop = try mtpFloorLoop(models: [
+            .init(
+                id: mtpFloorNewID, modelType: "gemma4",
+                sizeBytes: 1, estimatedMemoryGb: 1),
+        ])
+        let runtime = EngineV2Runtime()
+        await loop.setEngineV2RuntimeForTesting(runtime)
+        await loop.setEngineV2SlotHooksForTesting(.init(
+            physicalMemoryBytes: mtpFloorPhysical,
+            assistantLoader: MTPFloorAssistantLoader(),
+            makeEngine: { _, grant in factory.make(grant: grant) }))
+
+        let container = mtpFloorContainer()
+        let initial = try await loop.resliceAndBuildEngineV2BundleForTesting(
+            modelId: mtpFloorNewID,
+            modelType: "gemma4",
+            newcomer: EngineV2NewcomerBox(container),
+            tokenizer: TokenizerHandle(MTPFloorTokenizer()),
+            sizing: mtpFloorSizing(weightsGiB: 15),
+            specDecPreparation: .init(
+                artifact: nil,
+                status: .disabled(.artifactNotCached, configured: true)))
+        await loop.installModelBundleForTesting(
+            modelId: mtpFloorNewID,
+            bundle: initial.bundle,
+            container: container,
+            tokenizer: TokenizerHandle(MTPFloorTokenizer()),
+            sizing: initial.sizing,
+            modelType: "gemma4")
+        let oldBridge = initial.bundle.bridge
+
+        await loop.specDecArtifactBecameReady(
+            modelId: mtpFloorNewID, artifact: artifact)
+        await loop.specDecArtifactBecameReady(
+            modelId: mtpFloorNewID, artifact: artifact)
+        #expect(await loop.specDecPromotionTaskCountForTesting() == 1)
+        for _ in 0..<400 {
+            if await loop.slotMTPStatusForTesting(modelId: mtpFloorNewID)?.active == true {
+                break
+            }
+            try await Task.sleep(nanoseconds: 5_000_000)
+        }
+
+        let promoted = try #require(
+            await loop.slotBridgeForTesting(modelId: mtpFloorNewID))
+        #expect(promoted !== oldBridge)
+        #expect(await loop.slotMTPStatusForTesting(modelId: mtpFloorNewID)?.active == true)
+        #expect(await loop.slotSizingForTesting(modelId: mtpFloorNewID)?
+            .auxiliaryWeightBytes == Int(artifact.residentBytes))
+        #expect(factory.buildCount == 2, "duplicate signals must coalesce")
+        #expect(await runtime.bridge(forModel: mtpFloorNewID) === promoted)
+        await loop.unloadModel(mtpFloorNewID)
+    }
+
+    @Test("promotion construction failure preserves the old serving engine")
+    func promotionFailurePreservesServingTarget() async throws {
+        let artifact = try mtpFloorArtifact()
+        defer { try? FileManager.default.removeItem(at: artifact.directory) }
+        let factory = MTPFailingPromotionEngineFactory()
+        let loop = try mtpFloorLoop(models: [
+            .init(
+                id: mtpFloorNewID, modelType: "gemma4",
+                sizeBytes: 1, estimatedMemoryGb: 1),
+        ])
+        let runtime = EngineV2Runtime()
+        await loop.setEngineV2RuntimeForTesting(runtime)
+        await loop.setEngineV2SlotHooksForTesting(.init(
+            physicalMemoryBytes: mtpFloorPhysical,
+            assistantLoader: MTPFloorAssistantLoader(),
+            makeEngine: { _, grant in try factory.make(grant: grant) }))
+        let container = mtpFloorContainer()
+        let initial = try await loop.resliceAndBuildEngineV2BundleForTesting(
+            modelId: mtpFloorNewID,
+            modelType: "gemma4",
+            newcomer: EngineV2NewcomerBox(container),
+            tokenizer: TokenizerHandle(MTPFloorTokenizer()),
+            sizing: mtpFloorSizing(weightsGiB: 15),
+            specDecPreparation: .init(
+                artifact: nil,
+                status: .disabled(.artifactNotCached, configured: true)))
+        await loop.installModelBundleForTesting(
+            modelId: mtpFloorNewID,
+            bundle: initial.bundle,
+            container: container,
+            tokenizer: TokenizerHandle(MTPFloorTokenizer()),
+            sizing: initial.sizing,
+            modelType: "gemma4")
+        let oldBridge = initial.bundle.bridge
+
+        await loop.specDecArtifactBecameReady(
+            modelId: mtpFloorNewID, artifact: artifact)
+        for _ in 0..<400 {
+            if await loop.specDecPromotionTaskCountForTesting() == 0 { break }
+            try await Task.sleep(nanoseconds: 5_000_000)
+        }
+
+        #expect(await loop.slotBridgeForTesting(modelId: mtpFloorNewID) === oldBridge)
+        #expect(await runtime.bridge(forModel: mtpFloorNewID) === oldBridge)
+        #expect(await loop.slotMTPStatusForTesting(modelId: mtpFloorNewID)?.active == false)
+        #expect(await loop.slotSizingForTesting(modelId: mtpFloorNewID)?
+            .auxiliaryWeightBytes == 0)
+        #expect(factory.buildCount == 2)
+
+        // The same immutable artifact gets at most three promotion attempts.
+        // Periodic catalog refreshes cannot create an endless rebuild loop.
+        for _ in 0..<3 {
+            await loop.specDecArtifactBecameReady(
+                modelId: mtpFloorNewID, artifact: artifact)
+            for _ in 0..<400 {
+                if await loop.specDecPromotionTaskCountForTesting() == 0 { break }
+                try await Task.sleep(nanoseconds: 5_000_000)
+            }
+        }
+        #expect(factory.buildCount == 4)
+
+        let revised = try mtpFloorArtifact(fill: 0x6b)
+        defer { try? FileManager.default.removeItem(at: revised.directory) }
+        await loop.specDecArtifactBecameReady(
+            modelId: mtpFloorNewID, artifact: revised)
+        for _ in 0..<400 {
+            if await loop.specDecPromotionTaskCountForTesting() == 0 { break }
+            try await Task.sleep(nanoseconds: 5_000_000)
+        }
+        #expect(factory.buildCount == 5, "a new assistant identity resets the bounded ledger")
+        await loop.unloadModel(mtpFloorNewID)
+    }
+
+    @Test("active work delays promotion and continues on the old engine")
+    func activeWorkDelaysPromotion() async throws {
+        let artifact = try mtpFloorArtifact()
+        defer { try? FileManager.default.removeItem(at: artifact.directory) }
+        let factory = MTPRecoveryEngineFactory()
+        let loop = try mtpFloorLoop(models: [
+            .init(
+                id: mtpFloorNewID, modelType: "gemma4",
+                sizeBytes: 1, estimatedMemoryGb: 1),
+        ])
+        let runtime = EngineV2Runtime()
+        await loop.setEngineV2RuntimeForTesting(runtime)
+        await loop.setEngineV2SlotHooksForTesting(.init(
+            physicalMemoryBytes: mtpFloorPhysical,
+            assistantLoader: MTPFloorAssistantLoader(),
+            makeEngine: { _, grant in factory.make(grant: grant) }))
+        let container = mtpFloorContainer()
+        let initial = try await loop.resliceAndBuildEngineV2BundleForTesting(
+            modelId: mtpFloorNewID,
+            modelType: "gemma4",
+            newcomer: EngineV2NewcomerBox(container),
+            tokenizer: TokenizerHandle(MTPFloorTokenizer()),
+            sizing: mtpFloorSizing(weightsGiB: 15),
+            specDecPreparation: .init(
+                artifact: nil,
+                status: .disabled(.artifactNotCached, configured: true)))
+        await loop.installModelBundleForTesting(
+            modelId: mtpFloorNewID,
+            bundle: initial.bundle,
+            container: container,
+            tokenizer: TokenizerHandle(MTPFloorTokenizer()),
+            sizing: initial.sizing,
+            modelType: "gemma4")
+        let oldBridge = initial.bundle.bridge
+        await loop.reserveLocalModelForTesting(mtpFloorNewID)
+
+        await loop.specDecArtifactBecameReady(
+            modelId: mtpFloorNewID, artifact: artifact)
+        try await Task.sleep(nanoseconds: 50_000_000)
+        #expect(factory.buildCount == 1)
+        #expect(await loop.slotBridgeForTesting(modelId: mtpFloorNewID) === oldBridge)
+
+        await loop.releaseLocalModelForTesting(mtpFloorNewID)
+        for _ in 0..<400 {
+            if await loop.slotMTPStatusForTesting(modelId: mtpFloorNewID)?.active == true {
+                break
+            }
+            try await Task.sleep(nanoseconds: 5_000_000)
+        }
+        #expect(factory.buildCount == 2)
+        #expect(await loop.slotBridgeForTesting(modelId: mtpFloorNewID) !== oldBridge)
+        await loop.unloadModel(mtpFloorNewID)
+    }
+
+    @Test("shutdown cancellation leaves a waiting promotion target-only")
+    func shutdownCancelsWaitingPromotion() async throws {
+        let artifact = try mtpFloorArtifact()
+        defer { try? FileManager.default.removeItem(at: artifact.directory) }
+        let factory = MTPRecoveryEngineFactory()
+        let loop = try mtpFloorLoop(models: [
+            .init(
+                id: mtpFloorNewID, modelType: "gemma4",
+                sizeBytes: 1, estimatedMemoryGb: 1),
+        ])
+        let runtime = EngineV2Runtime()
+        await loop.setEngineV2RuntimeForTesting(runtime)
+        await loop.setEngineV2SlotHooksForTesting(.init(
+            physicalMemoryBytes: mtpFloorPhysical,
+            assistantLoader: MTPFloorAssistantLoader(),
+            makeEngine: { _, grant in factory.make(grant: grant) }))
+        let container = mtpFloorContainer()
+        let initial = try await loop.resliceAndBuildEngineV2BundleForTesting(
+            modelId: mtpFloorNewID,
+            modelType: "gemma4",
+            newcomer: EngineV2NewcomerBox(container),
+            tokenizer: TokenizerHandle(MTPFloorTokenizer()),
+            sizing: mtpFloorSizing(weightsGiB: 15),
+            specDecPreparation: .init(
+                artifact: nil,
+                status: .disabled(.artifactNotCached, configured: true)))
+        await loop.installModelBundleForTesting(
+            modelId: mtpFloorNewID,
+            bundle: initial.bundle,
+            container: container,
+            tokenizer: TokenizerHandle(MTPFloorTokenizer()),
+            sizing: initial.sizing,
+            modelType: "gemma4")
+        let oldBridge = initial.bundle.bridge
+        await loop.reserveLocalModelForTesting(mtpFloorNewID)
+        await loop.specDecArtifactBecameReady(
+            modelId: mtpFloorNewID, artifact: artifact)
+
+        await loop.beginShutdownForTesting()
+        await loop.cancelSpecDecPromotions()
+        await loop.releaseLocalModelForTesting(mtpFloorNewID)
+        for _ in 0..<100 {
+            if await loop.specDecPromotionTaskCountForTesting() == 0 { break }
+            try await Task.sleep(nanoseconds: 5_000_000)
+        }
+
+        #expect(factory.buildCount == 1)
+        #expect(await loop.slotBridgeForTesting(modelId: mtpFloorNewID) === oldBridge)
+        #expect(await loop.slotMTPStatusForTesting(modelId: mtpFloorNewID)?.active == false)
+        #expect(await loop.specDecPromotionAttemptCountForTesting(
+            modelId: mtpFloorNewID) == 0)
+        await loop.unloadModel(mtpFloorNewID)
+    }
+
+    @Test("engine rows must drain after outer request ownership clears")
+    func engineQuiescenceDelaysPromotion() async throws {
+        let artifact = try mtpFloorArtifact()
+        defer { try? FileManager.default.removeItem(at: artifact.directory) }
+        let factory = MTPRecoveryEngineFactory()
+        let loop = try mtpFloorLoop(models: [
+            .init(
+                id: mtpFloorNewID, modelType: "gemma4",
+                sizeBytes: 1, estimatedMemoryGb: 1),
+        ])
+        await loop.setEngineV2RuntimeForTesting(EngineV2Runtime())
+        await loop.setEngineV2SlotHooksForTesting(.init(
+            physicalMemoryBytes: mtpFloorPhysical,
+            assistantLoader: MTPFloorAssistantLoader(),
+            makeEngine: { _, grant in factory.make(grant: grant) }))
+        let container = mtpFloorContainer()
+        let initial = try await loop.resliceAndBuildEngineV2BundleForTesting(
+            modelId: mtpFloorNewID,
+            modelType: "gemma4",
+            newcomer: EngineV2NewcomerBox(container),
+            tokenizer: TokenizerHandle(MTPFloorTokenizer()),
+            sizing: mtpFloorSizing(weightsGiB: 15),
+            specDecPreparation: .init(
+                artifact: nil,
+                status: .disabled(.artifactNotCached, configured: true)))
+        await loop.installModelBundleForTesting(
+            modelId: mtpFloorNewID,
+            bundle: initial.bundle,
+            container: container,
+            tokenizer: TokenizerHandle(MTPFloorTokenizer()),
+            sizing: initial.sizing,
+            modelType: "gemma4")
+        let oldBridge = initial.bundle.bridge
+        _ = await oldBridge.submitTokenized(
+            promptTokens: [1, 2, 3],
+            request: ChatCompletionRequest(
+                model: mtpFloorNewID,
+                messages: [.init(role: "user", content: "hi")]),
+            requestId: "mtp-engine-quiescence")
+
+        await loop.specDecArtifactBecameReady(
+            modelId: mtpFloorNewID, artifact: artifact)
+        try await Task.sleep(nanoseconds: 50_000_000)
+        #expect(factory.buildCount == 1)
+        #expect(await loop.slotBridgeForTesting(modelId: mtpFloorNewID) === oldBridge)
+
+        factory.finishFirstEngine()
+        for _ in 0..<400 {
+            if await loop.slotMTPStatusForTesting(modelId: mtpFloorNewID)?.active == true {
+                break
+            }
+            try await Task.sleep(nanoseconds: 5_000_000)
+        }
+        #expect(factory.buildCount == 2)
+        #expect(await loop.slotBridgeForTesting(modelId: mtpFloorNewID) !== oldBridge)
+        await loop.unloadModel(mtpFloorNewID)
+    }
+
+    @Test("unload cancels a waiting promotion without constructing an engine")
+    func unloadCancelsWaitingPromotion() async throws {
+        let artifact = try mtpFloorArtifact()
+        defer { try? FileManager.default.removeItem(at: artifact.directory) }
+        let factory = MTPRecoveryEngineFactory()
+        let loop = try mtpFloorLoop(models: [
+            .init(
+                id: mtpFloorNewID, modelType: "gemma4",
+                sizeBytes: 1, estimatedMemoryGb: 1),
+        ])
+        await loop.setEngineV2RuntimeForTesting(EngineV2Runtime())
+        await loop.setEngineV2SlotHooksForTesting(.init(
+            physicalMemoryBytes: mtpFloorPhysical,
+            assistantLoader: MTPFloorAssistantLoader(),
+            makeEngine: { _, grant in factory.make(grant: grant) }))
+        let container = mtpFloorContainer()
+        let initial = try await loop.resliceAndBuildEngineV2BundleForTesting(
+            modelId: mtpFloorNewID,
+            modelType: "gemma4",
+            newcomer: EngineV2NewcomerBox(container),
+            tokenizer: TokenizerHandle(MTPFloorTokenizer()),
+            sizing: mtpFloorSizing(weightsGiB: 15),
+            specDecPreparation: .init(
+                artifact: nil,
+                status: .disabled(.artifactNotCached, configured: true)))
+        await loop.installModelBundleForTesting(
+            modelId: mtpFloorNewID,
+            bundle: initial.bundle,
+            container: container,
+            tokenizer: TokenizerHandle(MTPFloorTokenizer()),
+            sizing: initial.sizing,
+            modelType: "gemma4")
+        await loop.reserveLocalModelForTesting(mtpFloorNewID)
+        await loop.specDecArtifactBecameReady(
+            modelId: mtpFloorNewID, artifact: artifact)
+
+        await loop.unloadModel(mtpFloorNewID)
+        await loop.releaseLocalModelForTesting(mtpFloorNewID)
+
+        #expect(factory.buildCount == 1)
+        #expect(await loop.slotBridgeForTesting(modelId: mtpFloorNewID) == nil)
+        #expect(await loop.specDecPromotionTaskCountForTesting() == 0)
+    }
+
+    @Test("unload awaits cancellation during assistant construction")
+    func unloadAwaitsAssistantConstructionCancellation() async throws {
+        let artifact = try mtpFloorArtifact()
+        defer { try? FileManager.default.removeItem(at: artifact.directory) }
+        let gate = MTPPromotionLoadGate()
+        let ownerProbe = MTPPromotionWeakOwner()
+        let factory = MTPRecoveryEngineFactory()
+        let loop = try mtpFloorLoop(models: [
+            .init(
+                id: mtpFloorNewID, modelType: "gemma4",
+                sizeBytes: 1, estimatedMemoryGb: 1),
+        ])
+        await loop.setEngineV2RuntimeForTesting(EngineV2Runtime())
+        await loop.setEngineV2SlotHooksForTesting(.init(
+            physicalMemoryBytes: mtpFloorPhysical,
+            assistantLoader: MTPGatedAssistantLoader(
+                gate: gate, ownerProbe: ownerProbe),
+            makeEngine: { _, grant in factory.make(grant: grant) }))
+        let container = mtpFloorContainer()
+        let initial = try await loop.resliceAndBuildEngineV2BundleForTesting(
+            modelId: mtpFloorNewID,
+            modelType: "gemma4",
+            newcomer: EngineV2NewcomerBox(container),
+            tokenizer: TokenizerHandle(MTPFloorTokenizer()),
+            sizing: mtpFloorSizing(weightsGiB: 15),
+            specDecPreparation: .init(
+                artifact: nil,
+                status: .disabled(.artifactNotCached, configured: true)))
+        await loop.installModelBundleForTesting(
+            modelId: mtpFloorNewID,
+            bundle: initial.bundle,
+            container: container,
+            tokenizer: TokenizerHandle(MTPFloorTokenizer()),
+            sizing: initial.sizing,
+            modelType: "gemma4")
+
+        await loop.specDecArtifactBecameReady(
+            modelId: mtpFloorNewID, artifact: artifact)
+        await gate.waitUntilEntered()
+        #expect(ownerProbe.isAlive)
+        #expect(await initial.bundle.bridge.backendSlotCapacity().state == "reloading")
+        await loop.unloadModel(mtpFloorNewID)
+
+        #expect(await loop.slotBridgeForTesting(modelId: mtpFloorNewID) == nil)
+        #expect(await loop.specDecPromotionTaskCountForTesting() == 0)
+        #expect(await loop.outstandingKVReservationBytesForTesting() == 0)
+        #expect(!ownerProbe.isAlive)
+        #expect(factory.buildCount == 1)
     }
 
     @Test("liveness rebuild revalidates cached artifact and recovers target-only")

--- a/provider-swift/Tests/ProviderCoreTests/ProviderMTPFactoryTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ProviderMTPFactoryTests.swift
@@ -168,7 +168,7 @@ private actor MTPFreshProcessCatalog: SpecDecCatalogLooking {
 
 @Suite("Provider MTP target/assistant preparation")
 struct ProviderMTPFactoryTests {
-    @Test("fresh-process catalog prewarm activates a verified cached assistant on first load")
+    @Test("fresh-process load activates a verified cached assistant")
     func freshProcessCachedCatalogAssistantActivates() async throws {
         let staged = try mtpCatalogArtifact()
         defer { try? FileManager.default.removeItem(at: staged.directory) }
@@ -197,8 +197,7 @@ struct ProviderMTPFactoryTests {
         let funnel = SpecDecArtifactFunnel(
             resolver: SpecDecResolver(storeRoot: root), catalog: catalog)
 
-        #expect(await funnel.prewarmCatalog(modelId: model.id, timeout: .seconds(1)))
-        let preparation = await funnel.prepare(.init(
+        let preparation = await funnel.prepareForLoad(.init(
             modelId: model.id, modelType: "gemma4", enabled: true,
             localPath: nil, allowDownload: true, environment: [:]))
         #expect(preparation.artifact?.source == .catalog)

--- a/provider-swift/Tests/ProviderCoreTests/SpecDecArtifactFunnelTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/SpecDecArtifactFunnelTests.swift
@@ -73,22 +73,6 @@ private actor StaleFunnelCatalog: SpecDecCatalogLooking {
     }
 }
 
-private actor SlowFunnelCatalog: SpecDecCatalogLooking {
-    func cachedModel(id: String) -> CatalogModel? { nil }
-    func model(id: String) async throws -> CatalogModel? {
-        try await taskSleep(.seconds(5))
-        return nil
-    }
-}
-
-private actor FunnelSleepProbe {
-    private(set) var durations: [Duration] = []
-
-    func sleep(_ duration: Duration) {
-        durations.append(duration)
-    }
-}
-
 private func funnelModel(id: String = "gemma-4-target", metadata: [String: JSONValue]? = nil) -> CatalogModel {
     CatalogModel(
         id: id, s3Name: "unused", displayName: id, sizeGb: 1,
@@ -97,14 +81,22 @@ private func funnelModel(id: String = "gemma-4-target", metadata: [String: JSONV
 
 private let localAssistantConfig = Data(#"{"model_type":"gemma4_assistant"}"#.utf8)
 
-private func makeLocalAssistant() throws -> URL {
+private func makeLocalAssistant(fill: UInt8 = 0x5a) throws -> URL {
     let root = FileManager.default.temporaryDirectory
         .appendingPathComponent("specdec-local-\(UUID().uuidString)", isDirectory: true)
     try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
     try localAssistantConfig.write(to: root.appendingPathComponent("config.json"))
-    try Data(repeating: 0x5a, count: 4096)
+    try Data(repeating: fill, count: 4096)
         .write(to: root.appendingPathComponent("model.safetensors"))
     return root
+}
+
+private actor FunnelArtifactRecorder {
+    private(set) var revisions: [String] = []
+
+    func record(_ artifact: SpecDecArtifact) {
+        revisions.append(artifact.revision)
+    }
 }
 
 @Suite("SpecDec production artifact funnel")
@@ -357,20 +349,93 @@ struct SpecDecArtifactFunnelTests {
         #expect(await catalog.cancellations == 1)
     }
 
-    @Test("catalog prewarm fails open when the short deadline wins")
-    func prewarmDeadline() async {
-        let sleepProbe = FunnelSleepProbe()
+    @Test("concurrent shutdown callers await foreground preparation")
+    func concurrentShutdownAwaitsForegroundPreparation() async throws {
+        let catalog = GatedFunnelCatalog(funnelModel())
         let funnel = SpecDecArtifactFunnel(
             resolver: SpecDecResolver(
                 storeRoot: FileManager.default.temporaryDirectory,
                 cdnBaseURL: "http://127.0.0.1:1"),
-            catalog: SlowFunnelCatalog())
-        let warmed = await funnel.prewarmCatalog(
-            modelId: "gemma-4-target",
-            timeout: .milliseconds(20),
-            sleep: { duration in await sleepProbe.sleep(duration) })
-        #expect(!warmed)
-        #expect(await sleepProbe.durations == [.milliseconds(20)])
+            catalog: catalog)
+        let request = SpecDecArtifactFunnel.Request(
+            modelId: "gemma-4-target", modelType: "gemma4", enabled: true,
+            localPath: nil, allowDownload: true, environment: [:])
+        let preparation = Task { await funnel.prepareForLoad(request) }
+        for _ in 0..<100 {
+            if await catalog.calls > 0 { break }
+            try await Task.sleep(nanoseconds: 5_000_000)
+        }
+
+        async let first: Void = funnel.shutdown()
+        async let second: Void = funnel.shutdown()
+        for _ in 0..<100 {
+            if await catalog.cancellations > 0 { break }
+            try await Task.sleep(nanoseconds: 5_000_000)
+        }
+        await catalog.release()
+        _ = await (first, second)
+        let result = await preparation.value
+
+        #expect(result.status.reason == .catalogUnavailable)
+        #expect(await catalog.active == 0)
+        #expect(await catalog.cancellations == 1)
+    }
+
+    @Test("newer catalog generation suppresses an older artifact-ready event")
+    func generationOrdersArtifactEvents() async throws {
+        let firstURL = try makeLocalAssistant(fill: 0x11)
+        let secondURL = try makeLocalAssistant(fill: 0x22)
+        defer {
+            try? FileManager.default.removeItem(at: firstURL)
+            try? FileManager.default.removeItem(at: secondURL)
+        }
+        let first = try #require(
+            SpecDecStore.inspectLocalArtifact(path: firstURL.path))
+        let second = try #require(
+            SpecDecStore.inspectLocalArtifact(path: secondURL.path))
+        let recorder = FunnelArtifactRecorder()
+        let funnel = SpecDecArtifactFunnel(
+            resolver: SpecDecResolver(), catalog: nil)
+        await funnel.setArtifactReadyHandler { _, artifact, _ in
+            await recorder.record(artifact)
+        }
+
+        let older = await funnel.beginCatalogGeneration(modelId: "gemma")
+        let newer = await funnel.beginCatalogGeneration(modelId: "gemma")
+        await funnel.notifyReady(
+            modelId: "gemma", artifact: first, generation: older)
+        await funnel.notifyReady(
+            modelId: "gemma", artifact: second, generation: newer)
+
+        #expect(await recorder.revisions == [second.revision])
+        await funnel.shutdown()
+    }
+
+    @Test("foreground failures honor backoff and periodic rediscovery continues")
+    func foregroundBackoffAndPeriodicRediscovery() async throws {
+        let catalog = FunnelCatalog(nil)
+        let funnel = SpecDecArtifactFunnel(
+            resolver: SpecDecResolver(
+                storeRoot: FileManager.default.temporaryDirectory,
+                cdnBaseURL: "http://127.0.0.1:1"),
+            catalog: catalog)
+        await funnel.configureReevaluationForTesting(
+            delays: [.milliseconds(5), .milliseconds(5), .milliseconds(5)],
+            steadyInterval: .milliseconds(10))
+        let request = SpecDecArtifactFunnel.Request(
+            modelId: "gemma-4-target", modelType: "gemma4", enabled: true,
+            localPath: nil, allowDownload: true, environment: [:])
+
+        _ = await funnel.prepareForLoad(request)
+        let callsAfterFailure = await catalog.calls
+        _ = await funnel.prepareForLoad(request)
+        #expect(await catalog.calls == callsAfterFailure)
+
+        for _ in 0..<200 {
+            if await catalog.calls >= 5 { break }
+            try await Task.sleep(nanoseconds: 5_000_000)
+        }
+        #expect(await catalog.calls >= 5)
         await funnel.shutdown()
     }
 }

--- a/provider-swift/Tests/ProviderCoreTests/SpecDecCapacityTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/SpecDecCapacityTests.swift
@@ -195,18 +195,28 @@ struct SpecDecLoadGateTests {
                 == .max)
     }
 
-    @Test("assistant admission boundary is exact and malformed inputs fail closed")
-    func assistantAdmissionBoundary() {
-        let oneGiB: UInt64 = 1_073_741_824
-        #expect(ProviderLoop.assistantMemoryFits(
-            availableGb: 11, targetRequiredGb: 10, assistantBytes: oneGiB))
-        #expect(!ProviderLoop.assistantMemoryFits(
-            availableGb: 10.999, targetRequiredGb: 10,
-            assistantBytes: oneGiB))
-        #expect(!ProviderLoop.assistantMemoryFits(
-            availableGb: .nan, targetRequiredGb: 10, assistantBytes: oneGiB))
-        #expect(!ProviderLoop.assistantMemoryFits(
-            availableGb: 11, targetRequiredGb: .infinity, assistantBytes: oneGiB))
+    @Test("assistant growth is atomic against concurrent reservations")
+    func assistantAdmissionBoundary() async {
+        let unit: UInt64 = 1_073_741_824
+        let budget = GlobalKVCacheBudget(
+            capFraction: 1.0,
+            activationReserveBytes: 0,
+            memorySnapshot: {
+                .init(
+                    total: 10 * unit, active: 0, cache: 0,
+                    systemAvailable: 10 * unit)
+            })
+        await budget.reservePendingLoad(requestID: "target", bytes: 6 * unit)
+        #expect(await budget.reserveBytes(
+            requestID: "concurrent", bytes: unit))
+        #expect(!(await budget.increaseReservationIfAvailable(
+            requestID: "target", additionalBytes: 2 * unit)))
+        #expect(await budget.outstandingReservedBytes() == 7 * unit)
+
+        await budget.release(requestID: "concurrent")
+        #expect(await budget.increaseReservationIfAvailable(
+            requestID: "target", additionalBytes: 2 * unit))
+        #expect(await budget.outstandingReservedBytes() == 8 * unit)
     }
 
     @Test("pending reservation atomically transfers from target+assistant to assistant only")

--- a/provider-swift/Tests/ProviderCoreTests/SpecDecResolverTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/SpecDecResolverTests.swift
@@ -148,6 +148,22 @@ private final class OneShotPortBox: @unchecked Sendable {
     }
 }
 
+private actor SpecDecStaticCatalog: SpecDecCatalogLooking {
+    var modelValue: CatalogModel
+    private(set) var freshCalls = 0
+
+    init(_ model: CatalogModel) {
+        self.modelValue = model
+    }
+
+    func cachedModel(id: String) -> CatalogModel? { modelValue }
+    func model(id: String) async throws -> CatalogModel? { modelValue }
+    func freshModel(id: String) async throws -> CatalogModel? {
+        freshCalls += 1
+        return modelValue
+    }
+}
+
 // MARK: - Fixture helpers
 
 private func sha256Hex(_ data: Data) -> String {
@@ -316,6 +332,60 @@ struct SpecDecResolverTests {
         let remaining = try FileManager.default.contentsOfDirectory(
             at: storeRoot, includingPropertiesForKeys: nil)
         #expect(!remaining.contains { $0.lastPathComponent.hasPrefix(".staging-") })
+    }
+
+    @Test("fresh empty cache downloads and returns active candidate in one load")
+    func oneLoadDownloadsVerifiedCandidate() async throws {
+        let server = SpecDecFileServer()
+        let baseURL = try await server.start()
+        defer { Task { await server.shutdown() } }
+        let fixture = DrafterFixture(prefix: "v2-specdec/gemma4-one-load/v1")
+        server.setFiles(try fixture.served())
+        let root = makeTempStoreRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let catalog = SpecDecStaticCatalog(
+            try makePinnedModel(id: "gemma-4", fixture: fixture))
+        let funnel = SpecDecArtifactFunnel(
+            resolver: SpecDecResolver(
+                storeRoot: root, cdnBaseURL: baseURL.absoluteString),
+            catalog: catalog)
+
+        let prepared = await funnel.prepareForLoad(.init(
+            modelId: "gemma-4", modelType: "gemma4", enabled: true,
+            localPath: nil, allowDownload: true, environment: [:]))
+
+        #expect(prepared.artifact?.revision == "v1")
+        #expect(prepared.status.reason == nil)
+        #expect(await catalog.freshCalls == 1)
+        #expect(server.requestedPaths().filter { $0.hasSuffix("manifest.json") }.count == 1)
+        await funnel.shutdown()
+    }
+
+    @Test("verified cached assistant activates in one load with no CDN access")
+    func oneLoadUsesVerifiedCacheOffline() async throws {
+        let server = SpecDecFileServer()
+        let baseURL = try await server.start()
+        defer { Task { await server.shutdown() } }
+        let fixture = DrafterFixture(prefix: "v2-specdec/gemma4-one-load-cached/v1")
+        server.setFiles(try fixture.served())
+        let root = makeTempStoreRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let model = try makePinnedModel(id: "gemma-4", fixture: fixture)
+        let resolver = SpecDecResolver(
+            storeRoot: root, cdnBaseURL: baseURL.absoluteString)
+        _ = try #require(await resolver.prefetch(model: model).artifact)
+        server.clearRequested()
+        server.setFiles([:])
+        let funnel = SpecDecArtifactFunnel(
+            resolver: resolver, catalog: SpecDecStaticCatalog(model))
+
+        let prepared = await funnel.prepareForLoad(.init(
+            modelId: "gemma-4", modelType: "gemma4", enabled: true,
+            localPath: nil, allowDownload: true, environment: [:]))
+
+        #expect(prepared.artifact?.revision == "v1")
+        #expect(server.requestedPaths().isEmpty)
+        await funnel.shutdown()
     }
 
     @Test("corrupt file (SHA mismatch after retries) fails open: nil, nothing published")
@@ -840,7 +910,7 @@ struct SpecDecResolverTests {
         let result = await resolver.prefetch(model: model)
         #expect(ContinuousClock.now - started < .milliseconds(300))
         #expect(result.artifact == nil)
-        #expect(result.reason == .fileDownloadFailed)
+        #expect(result.reason == .downloadTimedOut)
         let contents = (try? FileManager.default.contentsOfDirectory(
             at: root, includingPropertiesForKeys: nil)) ?? []
         #expect(!contents.contains { $0.lastPathComponent.hasPrefix(".staging-") })


### PR DESCRIPTION
## Outcome

Supported Gemma 4 targets now use verified multi-token prediction by default. A normal provider start/load can fetch, verify, bind, and publish an MTP-active engine in one lifecycle; if the assistant arrives after a target-only slot is already serving, the provider promotes that retained target automatically at an idle boundary without an operator restart.

Every optional failure remains fail-open: the existing target-only engine keeps serving, memory/grants are restored, and MTP is never reported active until the concrete runtime confirms it.

## Behavior and code flow: Before

```mermaid
flowchart LR
  subgraph Behavior_Before[Behavior: Before]
    B1[Provider starts] --> B2[Gemma target loads]
    B2 --> B3{Assistant already cached?}
    B3 -- No --> B4[Publish target-only slot]
    B4 --> B5[Download assistant in background]
    B5 --> B6[Operator restarts provider]
    B6 --> B7[MTP can activate]
    B3 -- Yes --> B7
  end

  subgraph Code_Before[Code: Before]
    C1[backend.mtp default false] --> C2[Beta enable workflow]
    C2 --> C3[SpecDec prepare checks local cache]
    C3 --> C4[Prefetch task has no slot callback]
    C4 --> C5[ModelSlot remains target-only]
  end
```

## Behavior and code flow: After

```mermaid
flowchart LR
  subgraph Behavior_After[Behavior: After]
    A1[Provider establishes liveness] --> A2[Demanded Gemma load]
    A2 --> A3[Fetch fresh spec_dec metadata]
    A3 --> A4{Verified assistant available?}
    A4 -- Cached --> A5[Atomically reserve target plus assistant]
    A4 -- Download --> A5
    A5 --> A6[Load and bind assistant]
    A6 --> A7{Runtime active and headroom safe?}
    A7 -- Yes --> A8[Publish MTP-active slot]
    A7 -- No --> A9[Publish target-only fallback]
    A4 -- Failure --> A9
    A9 --> A10[Bounded retry and periodic rediscovery]
    A10 --> A11[Verified artifact-ready event]
    A11 --> A12[Wait for outer and engine quiescence]
    A12 --> A13[Build fenced replacement over retained target]
    A13 --> A14{Replacement active and safe?}
    A14 -- Yes --> A15[Atomically swap; retire old residency]
    A14 -- No --> A9
  end

  subgraph Code_After[Code: After]
    D1[BackendSettings default-on policy] --> D2[SpecDecArtifactFunnel prepareForLoad]
    D2 --> D3[Generation-ordered verified resolver]
    D3 --> D4[ProviderLoop MTP promotion policy]
    D4 --> D5[Atomic GlobalKV reservation]
    D5 --> D6[Re-slice gate and unregistered replacement build]
    D6 --> D7[EngineV2 runtime activation check]
    D7 --> D8[Runtime registration and ModelSlot swap]
    D8 --> D9[Old bridge/assistant release before survivor growth]
  end
```

## Default policy and exact opt-out precedence

1. `DARKBLOOM_CBV2_MTP=0` has highest precedence and forces target-only behavior.
2. `darkbloom start` persists that allowlisted variable into the launchd plist, so watchdog, login, and ordinary restart relaunches retain the rollback.
3. Explicit `[backend] mtp = false` is the persistent config opt-out.
4. Explicit `mtp = true` and an absent key are default-on. Existing configs without the key migrate without a rewrite; deliberate old `false` values remain off.
5. Non-Gemma and unsupported model families remain target-only and never enter assistant resolution.

MTP was removed from `darkbloom beta`; the remaining beta registry no longer exposes or mutates it.

## One-start verified assistant lifecycle

- Cold Gemma loads fetch fresh catalog identity before model-load/re-slice locks.
- `spec_dec` metadata must bind immutable prefix, manifest digest, config digest, size, count, roles, and revision.
- Cached bytes are cryptographically revalidated without CDN traffic; empty caches use bounded, deduplicated download and immutable publication.
- Mandatory target residency is reserved first. Optional assistant growth is then admitted atomically against all live unified-memory promises.
- The assistant is loaded with its own quantization, bound to the exact serving target, and included in slot sizing and fleet re-slicing.
- Active MTP forces contiguous KV because transactional sliding-window rollback is required.
- Publication happens only after runtime `mtp.active=true` and the post-build headroom guard passes.

Optional fleet artifact work does not block daemon liveness, local endpoint startup, or coordinator registration. Only a demanded Gemma cold load awaits its bounded preparation.

## Automatic late-download promotion

- Artifact completion is generation-ordered; stale catalog results cannot overtake newer revisions.
- Fast retries are bounded, then low-frequency rediscovery continues so long outages do not require a restart.
- Promotion signals deduplicate, retain the newest pending revision, and cap construction attempts per immutable artifact identity.
- The provider waits for both outer reservations and concrete engine queues to become quiescent.
- Capacity reports `reloading` while promotion fences new work.
- The retained target container is reused; target weights are not downloaded again.
- A replacement is built unregistered, runtime activation and headroom are verified, then runtime registration and `ModelSlot` swap occur atomically.
- The old bridge, assistant, and cache residency are retired before the re-slice gate is released or survivor grants grow.

Unload, update drain, and shutdown cancel and await owned promotion/preparation work. Cancellation does not consume a promotion attempt.

## Fail-open and observability guarantees

Stable low-cardinality reasons cover metadata, manifest, digest, download timeout/cancellation, memory, re-slice floor, construction, headroom, busy timeout, and inactive-engine fallbacks. Logs report policy, active state, source/revision, download+verification duration, assistant bytes, real promotion attempt/result/duration, and cumulative proposed/accepted/emitted counters. No prompts or token IDs are emitted.

## Verification

Passed on the final reviewed diff:

- `swift test --no-parallel --filter MTPResliceFallbackTests` — 15 lifecycle/promotion tests.
- `swift test --no-parallel --filter SpecDecArtifactFunnelTests` — 14 ordering/backoff/shutdown tests.
- `swift test --no-parallel --filter SpecDecResolverTests` — 22 live-isolated HTTP/filesystem verification tests.
- `swift test --no-parallel --filter ProviderMTPFactoryTests` — 10 factory/ownership tests.
- `swift test --no-parallel --filter SpecDecCapacity` — 18 memory/accounting tests.
- `swift test --no-parallel --filter MTPConfig` — 15 policy/config/non-Gemma tests.
- `swift test --no-parallel --filter standalonePendingLoadReservesWeightsBeforeAwaitingContainer` — standalone atomic pending-load path.
- `swift test --no-parallel --filter StartupPreloader` — 7 preload tests.
- `swift test --no-parallel --filter CBv2MTP` in `libs/mlx-swift-lm` — 75 engine tests.
- `swift test --no-parallel --filter Gemma4MTP` in `libs/mlx-swift-lm` — 17 Gemma MTP tests.
- Supervised real local QAT target + QAT-4bit assistant load/bind passed via `scripts/run-mtp-benchmark.py`; final launch fingerprint `25c093a0045df9e218fde66be2a2a7f7f40e5fcdd379dfec9bcb3e042eb8a717`.
- `swift build -c release --product darkbloom` passed.
- `git diff --check`, IDE diagnostics, commit hook, and pre-push hook passed.
- Two independent same-model lifecycle/memory reviews passed the final current diff after all findings were fixed.

Existing performance evidence retained by the implementation contract: QAT-4bit assistant fixed-k=1 production sweeps measured positive aggregate decode TPS at B=1/B=2/B=4 on M4 Max and M5 Max, while unsafe/unprofitable shapes select depth zero.

## Rollout and rollback

No rollout, release, tag, deploy, catalog write, or production mutation is included here.

Roll out by shipping the provider normally; supported catalog targets with valid `metadata.spec_dec` converge automatically. Observe MTP active state, fallback reason, assistant bytes, promotion results, acceptance, committed goodput, memory, and TTFT before broad fleet expansion.

Emergency per-machine rollback:

```bash
darkbloom stop
DARKBLOOM_CBV2_MTP=0 darkbloom start
```

The launchd plist retains the opt-out across later restarts. A persistent config rollback is:

```toml
[backend]
mtp = false
```

## Known limitations

- Production MTP remains target-authoritative greedy decode; stochastic sampling, structured constraints, and unsupported request traits use ordinary target-only decoding.
- MTP uses contiguous KV; paged sliding-window speculative transactions remain a separately gated future capability.
- Promotion waits for an idle/drain-safe boundary and is capped at three construction attempts per immutable assistant identity; a new revision/hash resets the ledger.
- The monolithic provider `swift test` process has a pre-existing cross-suite quiescence interaction after thousands of passing tests (reproduced outside affected suites). All affected suites, the isolated stall suite, release build, real QAT load/bind, commit hook, and pre-push aggregate gate pass.

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/558"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787039305&installation_id=133247490&pr_number=558&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F558&signature=f103bec8d9ea35fdb2fb2ad2e03a0c90d0666cfd1e89627ec97e12c28451b803"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->