### PR TITLE
fix(cache): restore exact hybrid SSD prefix reuse

### DIFF
--- a/console-ui/src/lib/telemetry-types.ts
+++ b/console-ui/src/lib/telemetry-types.ts
@@ -129,4 +129,13 @@ export const TELEMETRY_ALLOWED_FIELDS = new Set<string>([
   // Go + Swift allowlists).
   "multimodal",
   "media_kind",
+  // Exact-prefix replay diagnostics: bounded enums and counts only.
+  "prefix_reuse_strategy",
+  "prefix_matched_tokens",
+  "prefix_replay_tokens",
+  "prefix_saved_tokens",
+  "prefix_boundary_splits",
+  "prefix_construction_failure",
+  "prefix_capacity_refusal",
+  "prefix_cold_fallback",
 ]);

--- a/coordinator/api/telemetry_handlers.go
+++ b/coordinator/api/telemetry_handlers.go
@@ -126,6 +126,16 @@ var telemetryFieldAllowlist = map[string]struct{}{
 	// NEVER rides telemetry. Mirror of the Swift + TS allowlists.
 	"multimodal": {},
 	"media_kind": {},
+	// Exact-prefix replay diagnostics: bounded strategy/reason values and
+	// aggregate token counts only. Never prompt/token content or cache keys.
+	"prefix_reuse_strategy":       {},
+	"prefix_matched_tokens":       {},
+	"prefix_replay_tokens":        {},
+	"prefix_saved_tokens":         {},
+	"prefix_boundary_splits":      {},
+	"prefix_construction_failure": {},
+	"prefix_capacity_refusal":     {},
+	"prefix_cold_fallback":        {},
 	// Console UI context
 	"url":        {},
 	"user_agent": {},

--- a/docs/architecture/cache-aware-routing.md
+++ b/docs/architecture/cache-aware-routing.md
@@ -170,8 +170,10 @@ parity, provider capability identity, and proof mismatch rate before enabling
 `on` in an isolated development or canary environment. Rollback always sets
 routing to `off` before rolling back binaries.
 
-The v0.7.11 release does not activate routing. Current production Gemma 4 and
-GPT-OSS layouts require full replay and advertise no reusable v2 model
-capability. Production activation remains blocked on a genuinely eligible
-model, a real positive-hit test, stable correlation telemetry, and a separately
-provisioned 256-bit cache master key.
+The v0.7.11 release does not activate routing. Providers with
+`cbv2-frozen-full-3` contiguous native-float support can advertise Gemma 4 and GPT-OSS
+as protocol-v2 models only after SSD scan readiness; paged hybrid slots remain
+v1/cold. Production activation is still a separate operational decision:
+positive durable-hit evidence, stable correlation telemetry, healthy prompt
+artifacts, routing-mode enablement, and a separately provisioned 256-bit cache
+master key remain required.

--- a/docs/architecture/cache-aware-routing.md
+++ b/docs/architecture/cache-aware-routing.md
@@ -172,8 +172,13 @@ routing to `off` before rolling back binaries.
 
 The v0.7.11 release does not activate routing. Providers with
 `cbv2-frozen-full-3` contiguous native-float support can advertise Gemma 4 and GPT-OSS
-as protocol-v2 models only after SSD scan readiness; paged hybrid slots remain
-v1/cold. Production activation is still a separate operational decision:
+as protocol-v2 models only after SSD scan readiness
+(`provider-swift/Sources/ProviderCore/KVCacheSSD/SSDPrefixCache.swift:325-343`,
+`provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClientState.swift:176-184`,
+`provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClient+Registration.swift:27-36`);
+paged hybrid slots remain v1/cold
+(`provider-swift/Sources/ProviderCore/Inference/PrefixCachePolicy.swift:110-129`).
+Production activation is still a separate operational decision:
 positive durable-hit evidence, stable correlation telemetry, healthy prompt
 artifacts, routing-mode enablement, and a separately provisioned 256-bit cache
 master key remain required.

--- a/docs/architecture/gemma4-cbv2-mtp.md
+++ b/docs/architecture/gemma4-cbv2-mtp.md
@@ -47,8 +47,8 @@ The production branch now includes:
 - A depth-zero, batch-bucketed goodput controller with isolated target-only
   probes, conditional acceptance, bounded exploration, hysteresis, and exact
   seed-cost attribution.
-- Safe hybrid prefix-cache policy: full replay whenever a storage-owning full
-  layer follows sliding attention.
+- Exact hybrid prefix reuse: contiguous unquantized full rows remain immutable through
+  M while finite-window state rebuilds from C; paged hybrids fail cold.
 - Provider local/catalog resolution, mandatory immutable catalog anchors,
   bounded nonblocking prefetch, assistant-owned quantization, exact target
   binding, fail-open target-only fallback, memory accounting, slot lifetime,
@@ -64,7 +64,9 @@ Review-driven correctness defects found and fixed during implementation:
 - Mixed terminal depths changed quantized MoE target batch cadence.
 - Mixed eligible/ineligible rows split one target decode batch into different
   shapes.
-- Hybrid prefix-cache partial replay permanently cached polluted activations.
+- Mutating C-bound hybrid replay permanently cached polluted activations;
+  frozen-full replay removes that write path and remains target-authoritative
+  with MTP active or inactive.
 - The oldest retained sliding key at `anchor-window` was incorrectly visible
   to the assistant.
 - Depth-zero timing included chained neighbor work while MTP timing did not.

--- a/docs/architecture/gemma4-cbv2-mtp.md
+++ b/docs/architecture/gemma4-cbv2-mtp.md
@@ -48,7 +48,11 @@ The production branch now includes:
   probes, conditional acceptance, bounded exploration, hysteresis, and exact
   seed-cost attribution.
 - Exact hybrid prefix reuse: contiguous unquantized full rows remain immutable through
-  M while finite-window state rebuilds from C; paged hybrids fail cold.
+  M while finite-window state rebuilds from C
+  (`libs/mlx-swift-lm/Libraries/MLXLMCommon/ContinuousBatchingV2/SequenceKV/ContiguousKVBackend.swift:162-230`;
+  `libs/mlx-swift-lm/Libraries/MLXLMCommon/ContinuousBatchingV2/SequenceKV/FrozenReplayFullSequenceKV.swift:54-99`);
+  paged hybrids fail cold during typed capability derivation
+  (`libs/mlx-swift-lm/Libraries/MLXLMCommon/ContinuousBatchingV2/PrefixReusePlan.swift:127-153`).
 - Provider local/catalog resolution, mandatory immutable catalog anchors,
   bounded nonblocking prefetch, assistant-owned quantization, exact target
   binding, fail-open target-only fallback, memory accounting, slot lifetime,
@@ -66,7 +70,9 @@ Review-driven correctness defects found and fixed during implementation:
   shapes.
 - Mutating C-bound hybrid replay permanently cached polluted activations;
   frozen-full replay removes that write path and remains target-authoritative
-  with MTP active or inactive.
+  with MTP active or inactive
+  (`libs/mlx-swift-lm/Libraries/MLXLMCommon/ContinuousBatchingV2/SequenceKV/FrozenReplayFullSequenceKV.swift:73-99`;
+  `libs/mlx-swift-lm/Libraries/MLXLMCommon/ContinuousBatchingV2/MTP/EngineLoopV2+MTPFinalize.swift:45-149`).
 - The oldest retained sliding key at `anchor-window` was incorrectly visible
   to the assistant.
 - Depth-zero timing included chained neighbor work while MTP timing did not.

--- a/docs/architecture/inference.md
+++ b/docs/architecture/inference.md
@@ -55,9 +55,13 @@ disabled with `DARKBLOOM_PREFIX_CACHE=0`; there is no production RAM cache or
 persistent memory carve. CBv2 layer-aware block snapshots are enabled only for
 layouts that can resume exactly. Interleaved hybrids use frozen-full tail replay
 on contiguous unquantized rows: sliding state rebuilds from C while owning full K/V
-remains immutable through M. Paged hybrids and quantized rows remain cold-only.
+remains immutable through M
+(`libs/mlx-swift-lm/Libraries/MLXLMCommon/ContinuousBatchingV2/SequenceKV/ContiguousKVBackend.swift:162-230`;
+`libs/mlx-swift-lm/Libraries/MLXLMCommon/ContinuousBatchingV2/SequenceKV/FrozenReplayFullSequenceKV.swift:54-99`).
+Paged hybrids and quantized rows remain cold-only
+(`libs/mlx-swift-lm/Libraries/MLXLMCommon/ContinuousBatchingV2/PrefixReusePlan.swift:120-153`).
 The production capability policy is
-`provider-swift/Sources/ProviderCore/Inference/PrefixCachePolicy.swift`.
+`provider-swift/Sources/ProviderCore/Inference/PrefixCachePolicy.swift:108-139`.
 
 See [`reference/ssd-kv-cache.md`](../reference/ssd-kv-cache.md) for the as-built reference and
 [`reference/ssd-kv-cache-hybrid-models.md`](../reference/ssd-kv-cache-hybrid-models.md) for the hybrid-model design.

--- a/docs/architecture/inference.md
+++ b/docs/architecture/inference.md
@@ -53,9 +53,10 @@ An EngineV2 prefix cache accelerates repeated or shared prompts. The encrypted
 SSD tier is the only production tier. It is selected by default and can be
 disabled with `DARKBLOOM_PREFIX_CACHE=0`; there is no production RAM cache or
 persistent memory carve. CBv2 layer-aware block snapshots are enabled only for
-layouts that can resume exactly. Interleaved hybrids with a storage-owning full
-layer after sliding attention require full replay and remain cold-only. The
-production gate is
+layouts that can resume exactly. Interleaved hybrids use frozen-full tail replay
+on contiguous unquantized rows: sliding state rebuilds from C while owning full K/V
+remains immutable through M. Paged hybrids and quantized rows remain cold-only.
+The production capability policy is
 `provider-swift/Sources/ProviderCore/Inference/PrefixCachePolicy.swift`.
 
 See [`reference/ssd-kv-cache.md`](../reference/ssd-kv-cache.md) for the as-built reference and

--- a/docs/developer/release.md
+++ b/docs/developer/release.md
@@ -90,15 +90,19 @@ go test ./e2e -run TestBenchmark -count=1 -v -timeout 30m
 The sidecar request deadline (`EIGENINFERENCE_PROMPT_SIDECAR_TIMEOUT_MS`) and
 provider SSD stage deadline (`DARKBLOOM_PREFIX_CACHE_SSD_MAX_STAGE_MS`) are
 functional upper bounds, not performance claims. Cache-hit and miss latency
-acceptance requires a positive-hit-capable real model; current production
-Gemma 4 and GPT-OSS layouts remain cold-only, so the protected benchmark is a
-human gate rather than a fabricated pass.
+acceptance requires a positive-hit-capable real model. Contiguous,
+unquantized Gemma 4 and GPT-OSS slots now use frozen-full replay; paged hybrids
+remain cold-only. Protected benchmarks and human approval are still mandatory
+before routing activation.
 
 Local M4 release-preparation evidence on 2026-07-17:
 
 - Rust planner fixture: p50 146 µs, p99 562 µs.
 - Persistent Unix HTTP planning: p50 165 µs, p99 595 µs.
 - Real encrypted DBK3 fixture: miss p95 0.145 ms, hit-stage p95 9.182 ms.
+
+Frozen-full local evidence from 2026-07-19 is recorded in
+`docs/reports/2026-07-19-frozen-full-prefix-cache-proof.md`.
 
 The automated gates are derived from the configured one-second planning/stage
 deadlines; the Rust gate additionally requires at least a 16× p99 safety

--- a/docs/developer/release.md
+++ b/docs/developer/release.md
@@ -92,8 +92,12 @@ provider SSD stage deadline (`DARKBLOOM_PREFIX_CACHE_SSD_MAX_STAGE_MS`) are
 functional upper bounds, not performance claims. Cache-hit and miss latency
 acceptance requires a positive-hit-capable real model. Contiguous,
 unquantized Gemma 4 and GPT-OSS slots now use frozen-full replay; paged hybrids
-remain cold-only. Protected benchmarks and human approval are still mandatory
-before routing activation.
+remain cold-only
+(`provider-swift/Sources/ProviderCore/Inference/EngineV2SlotFactory.swift:289-317`;
+`libs/mlx-swift-lm/Libraries/MLXLMCommon/ContinuousBatchingV2/PrefixReusePlan.swift:127-153`;
+`libs/mlx-swift-lm/Libraries/MLXLMCommon/ContinuousBatchingV2/SequenceKV/FrozenReplayFullSequenceKV.swift:54-99`).
+Protected benchmarks and human approval are still mandatory before routing
+activation.
 
 Local M4 release-preparation evidence on 2026-07-17:
 

--- a/docs/reference/ssd-kv-cache-hybrid-models.md
+++ b/docs/reference/ssd-kv-cache-hybrid-models.md
@@ -50,18 +50,25 @@ Rejected paths:
 - quantized rows: snapshots are lossy and cannot be adopted exactly;
 - unknown/invalid layouts or backend implementations.
 
-An explicit paged selection keeps hybrid reuse cold for the entire slot build,
-even if paged pool construction later degrades serving to contiguous. This is a
-deliberate fail-cold construction rule: reload with a contiguous selection to
-enable frozen replay rather than changing cache capability as a side effect of
-an unrelated backend fallback.
+An explicit paged selection derives cache capability from the resolved serving
+backend. A slot that remains paged keeps interleaved hybrid reuse cold. A kernel,
+physical-capacity, or pool-construction fallback resolves contiguous before SSD
+construction and enables frozen-full reuse in the same build
+(`provider-swift/Sources/ProviderCore/Inference/EngineV2SlotFactory.swift`
+`makeProductionBundle`).
 
 Any failed invariant or capacity check falls back to cold prefill before KV
 state is published. The coordinator protocol schema is unchanged.
 
 The generic saved-token floor is 1,024. Long frozen hybrids with
-`R >= 25,600` enforce 1,536 because the final real Gemma matrix found the
-1,024-saved boundary noisy/negative while 1,536 and 7,168 were beneficial.
+`R >= 25,600` configure a 1,536-token minimum because the final real Gemma
+matrix found the 1,024-saved boundary noisy/negative while 1,536 and 7,168 were
+beneficial. Durable donation is deliberately strict and block-rounded:
+`prefixTokens > R + minimum`. With 256-token blocks and `R = 25,600`, the exact
+27,136 boundary is discarded and 27,392 is the first persisted boundary, so
+the first durable entry saves 1,792 tokens
+(`provider-swift/Sources/ProviderCore/KVCacheSSD/SSDPrefixCache.swift`
+`donate`).
 
 ## Accounting and lifecycle
 

--- a/docs/reference/ssd-kv-cache-hybrid-models.md
+++ b/docs/reference/ssd-kv-cache-hybrid-models.md
@@ -1,42 +1,95 @@
 # SSD KV Cache for Hybrid Models
 
-Hybrid sliding-window models are deliberately cold-only in the production SSD
-cache. The retired `PrefixCacheManager` exact-checkpoint tier is no longer part
-of the provider.
+Interleaved sliding/full models use frozen-full tail replay on the contiguous,
+unquantized native-floating-point backend. Gemma 4 QAT and GPT-OSS can therefore advertise exact reusable
+prefix capability after their SSD scan is ready. Paged and quantized hybrid
+rows remain cold-only.
 
-## Why partial hybrid adoption is unsafe
+## Root cause and invariant
 
-A sliding-window layer needs prior tokens at a replay boundary. If a
-storage-owning full-attention layer follows it, that full layer permanently
-caches keys and values derived from the incomplete sliding context. Replaying a
-larger suffix does not repair those polluted full-attention entries because
-later decode continues to attend them.
+The v0.7.5 algorithm restored every owning full-attention row only through a
+replay start C, then appended projected K/V while rebuilding omitted sliding
+state. Early replay activations were computed without their true finite-window
+history. A downstream full layer stored those divergent projections
+permanently, so decode continued attending polluted K/V after the sliding error
+itself had flushed.
 
-`cbv2RequiredRecompute` therefore requires the entire matched prefix to be
-recomputed whenever a storage-owning full layer follows sliding attention.
-Such a match saves zero prefill tokens.
+The exact invariant is:
 
-## Production behavior
+- M is the whole-block matched boundary.
+- R is the conservative finite-window dependency span:
+  `windowed-layer count × largest window`, clamped to M.
+- C is `M - R`.
+- Sliding rows start empty at C and rebuild normally through M.
+- Every storage-owning full row keeps exact cached K/V immutable through M.
+- During replay, a full row has a logical read cursor beginning at C and a
+  separate immutable storage high-water M. It exposes only `[0, chunkEnd)` to
+  attention and ignores replay-generated K/V.
+- At M, the full row transitions exactly once to ordinary append mode.
 
-`PrefixCachePolicy.supportsReusablePrefixes` mirrors the engine rule before an
-SSD cache is constructed. Unsafe hybrid layouts advertise no reusable cache
-capability, create no receipt-confirmed routing holder, and serve through the
-ordinary cold path. This includes the currently supported Gemma 4 and GPT-OSS
-layouts.
+This removes the persistence path for replay error. Once R has flushed every
+finite-window dependency, the state at M is identical to cold prefill without
+storing any sliding layer on SSD.
 
-Pure full-attention layouts, all-windowed layouts, and layouts whose windowed
-layers trail every storage-owning full layer remain structurally eligible. They
-still pass the weight binding, prompt-contract, disk, staging, and effective
-token gates described in `ssd-kv-cache.md`.
+## Typed capability and fail-cold policy
 
-Supporting interleaved hybrids in the future requires an exact prompt-boundary
-snapshot that restores every storage-owning row, including the retained
-sliding-window state. Relaxing the replay rule without that state would change
-model outputs and is prohibited.
+`CBv2PrefixReuseCapability` derives support from the exact layer layout and KV
+backend before cache construction. Each hit produces a
+`CBv2PrefixReusePlan` carrying M, C, R, strategy, saved tokens, restored tokens,
+capacity-reservation tokens, and full-KV byte facts.
+
+Supported paths:
+
+- contiguous unquantized native-float, interleaved hybrid: `frozen_full_replay`;
+- contiguous native-float or paged FP16, structurally safe layout: existing direct or
+  ordinary tail replay.
+
+Rejected paths:
+
+- paged interleaved hybrid: requires a separately proved dual-cursor paged row;
+- quantized rows: snapshots are lossy and cannot be adopted exactly;
+- unknown/invalid layouts or backend implementations.
+
+An explicit paged selection keeps hybrid reuse cold for the entire slot build,
+even if paged pool construction later degrades serving to contiguous. This is a
+deliberate fail-cold construction rule: reload with a contiguous selection to
+enable frozen replay rather than changing cache capability as a side effect of
+an unrelated backend fallback.
+
+Any failed invariant or capacity check falls back to cold prefill before KV
+state is published. The coordinator protocol schema is unchanged.
+
+The generic saved-token floor is 1,024. Long frozen hybrids with
+`R >= 25,600` enforce 1,536 because the final real Gemma matrix found the
+1,024-saved boundary noisy/negative while 1,536 and 7,168 were beneficial.
+
+## Accounting and lifecycle
+
+SSD staging reconciles encrypted file estimates to exact rehydrated MLX bytes.
+Frozen adoption transfers those arrays directly into full rows instead of
+copying them. Engine and process-wide admission reserve native-width owning
+full rows through the request's maximum sequence length before publication;
+replay work below M consumes that existing reservation and is not
+double-charged. Sliding rings retain their ordinary window-capped allocation.
+
+Cancellation, preemption, shutdown, corruption, capacity refusal, and unload
+release every staging ticket, cache pin, backend row, and reservation. A
+preempted request discards the plan and restarts cold.
+
+## Layout epoch
+
+DBK3 remains the file format. Snapshot semantics changed, so the layout identity
+is `cbv2-frozen-full-3|native-fp|<blockSize>|<layerDigest>`. An existing
+`cbv2-snap-2` binding rotates the durable cache epoch and deletes old blocks
+before protocol-v2 readiness can be advertised.
 
 ## Code locations
 
-- Recompute rule: `libs/mlx-swift-lm/Libraries/MLXLMCommon/ContinuousBatchingV2/CBv2Contracts.swift`
-- Layout gate: `provider-swift/Sources/ProviderCore/Inference/PrefixCachePolicy.swift`
+- Planner: `libs/mlx-swift-lm/Libraries/MLXLMCommon/ContinuousBatchingV2/PrefixReusePlan.swift`
+- Frozen row: `libs/mlx-swift-lm/Libraries/MLXLMCommon/ContinuousBatchingV2/SequenceKV/FrozenReplayFullSequenceKV.swift`
+- Backend adoption: `libs/mlx-swift-lm/Libraries/MLXLMCommon/ContinuousBatchingV2/SequenceKV/ContiguousKVBackend.swift`
+- Scheduler boundaries/accounting: `libs/mlx-swift-lm/Libraries/MLXLMCommon/ContinuousBatchingV2/SchedulerV2.swift`
+- Provider policy: `provider-swift/Sources/ProviderCore/Inference/PrefixCachePolicy.swift`
 - SSD construction: `provider-swift/Sources/ProviderCore/KVCacheSSD/SSDPrefixCacheFactory.swift`
-- Regression tests: `provider-swift/Tests/ProviderCoreTests/PrefixCachePolicyTests.swift`
+- Proof suites: `CBv2FrozenReplayTests.swift`, `CBv2FrozenReplayModelTests.swift`,
+  and `FrozenReplayRealModelTests.swift`

--- a/docs/reference/ssd-kv-cache.md
+++ b/docs/reference/ssd-kv-cache.md
@@ -1,7 +1,8 @@
 # SSD KV Cache Reference
 
-This is the as-built v0.7.5 reference for the ContinuousBatchingV2 encrypted
-SSD prefix cache. The pre-v0.7.5 `BatchScheduler`, `PrefixCacheManager`, and
+This is the current reference for the ContinuousBatchingV2 encrypted SSD prefix
+cache, including the `cbv2-frozen-full-3` hybrid replay semantics. The
+pre-v0.7.5 `BatchScheduler`, `PrefixCacheManager`, and
 `EncryptedPrefixCachePersistence` implementations are retired.
 
 ## Status
@@ -30,16 +31,16 @@ is for unsigned tests only and does not preserve cache data across restarts.
 2. `SSDPrefixCache` probes its in-memory HMAC-tag index before submission.
 3. On a hit, it reserves staging bytes in `GlobalKVCacheBudget`, reads and
    authenticates a contiguous block run, and seeds the engine's staging map.
-4. ContinuousBatchingV2 adopts only the reusable prefix and recomputes the
-   model-specific sliding-window bound.
+4. ContinuousBatchingV2 derives a typed M/C/R plan. Safe layouts restore full
+   rows through C. Interleaved contiguous native-float hybrids restore owning full rows
+   through M and keep them immutable while replay rebuilds sliding rows from C.
 5. Completed requests donate eligible block snapshots to a bounded write-behind
    queue. Admission, write-rate, low-disk, TTL, and box-wide LRU guards apply.
 
-Structurally safe layouts share this layer-aware CBv2 block path. Interleaved
-hybrids with a storage-owning full-attention layer after sliding attention are
-cold-only because exactness requires full replay; they advertise no reusable
-cache capability. Eligible layouts persist a donation only when it also clears
-the configured effective-token floor. See
+Structurally safe layouts preserve their existing direct/tail-replay path.
+Interleaved hybrids use frozen-full replay on contiguous unquantized rows. Paged
+hybrids, quantized rows, and unknown layouts fail cold. Eligible layouts persist
+a donation only when it also clears the configured effective-token floor. See
 [`ssd-kv-cache-hybrid-models.md`](./ssd-kv-cache-hybrid-models.md).
 
 ## Environment variables
@@ -49,7 +50,7 @@ the configured effective-token floor. See
 | `DARKBLOOM_PREFIX_CACHE` | unset/on | Single production kill switch; any explicit non-affirmative value disables encrypted SSD |
 | `DARKBLOOM_PREFIX_CACHE_DISK_GB` | min(20 GiB, free/2) | Box-wide SSD budget |
 | `DARKBLOOM_PREFIX_CACHE_SSD_TTL_SECONDS` | 900 | Sliding TTL; overrides can only shorten the 15-minute maximum |
-| `DARKBLOOM_PREFIX_CACHE_SSD_MIN_EFFECTIVE_TOKENS` | 1024 | Minimum reusable tokens after the hybrid recompute bound |
+| `DARKBLOOM_PREFIX_CACHE_SSD_MIN_EFFECTIVE_TOKENS` | 1024 | Generic minimum saved tokens; frozen hybrids with R ≥ 25,600 enforce at least 1,536 from real Gemma evidence |
 | `DARKBLOOM_PREFIX_CACHE_SSD_MAX_STAGE_MB` | 1024 | Per-request staging-memory cap |
 | `DARKBLOOM_PREFIX_CACHE_SSD_MAX_STAGE_MS` | 1000 | Maximum estimated staging time |
 | `DARKBLOOM_PREFIX_CACHE_SSD_MAX_WRITE_GB_PER_DAY` | 150 | Daily endurance limit; `0` means unlimited |
@@ -78,8 +79,11 @@ prefix hashes, request IDs, and cache-scope values never touch disk.
 Reusable entries require both a verified weight hash and a prompt contract
 computed from the loaded model's tokenizer, template, and config artifacts.
 If either identity is unavailable, the SSD tier stays disabled. Reads also
-verify that binding, the layout epoch, block size, and full lookup tag. Any
-parse, binding, or authentication failure is deleted and treated as a cold miss.
+verify that binding, the `cbv2-frozen-full-3` layout epoch, block size, and full
+lookup tag. Any parse, binding, or authentication failure is deleted and
+treated as a cold miss. Upgrading from `cbv2-snap-2` rotates the per-model cache
+epoch and purges old blocks before readiness is advertised; DBK3 itself is
+unchanged.
 
 The legacy `darkbloom/kv/` tree is swept on startup. The `kv3/` root is
 separate and is not touched by that cleanup; the retired `kv2/` layout is

--- a/docs/reports/2026-07-19-frozen-full-prefix-cache-proof.md
+++ b/docs/reports/2026-07-19-frozen-full-prefix-cache-proof.md
@@ -1,0 +1,108 @@
+# Frozen-Full Hybrid Prefix Cache Proof
+
+Date: 2026-07-19  
+Parent base: `ac3d934a979036611b2ea3b66e51c977abfd7483`  
+Engine base: `bdf4b367a3dec5a0db23797f759427965a81c0fd`
+
+## Root cause
+
+The old C-bound replay restored owning full-attention K/V only through C.
+Sliding rows started empty at C, so early replay hidden states differed from
+cold prefill. Every downstream owning full layer appended projections of those
+states. Those divergent K/V entries never aged out and changed later logits.
+
+The v0.7.11 full-replay gate was therefore necessary for the mutating replay
+implementation. Changing a window count, cache threshold, block size, or other
+configuration cannot remove the persistent write path.
+
+## Exact architecture
+
+For matched boundary M:
+
+- R is `windowed-layer count × largest window`, clamped to M.
+- C is `M - R`.
+- Sliding rows start empty at C.
+- Owning full rows restore exact cached arrays through M.
+- A frozen row reads from C while retaining an independent immutable high-water
+  M. Replay-generated full-layer K/V is ignored.
+- Chunks cannot cross C or M.
+- At M the full row transitions once to ordinary append.
+- Preemption discards the plan and state; cancellation and shutdown release all
+  rows, pins, and reservations.
+
+DBK3 remains unchanged. The cache-layout identity is
+`cbv2-frozen-full-3|native-fp|<blockSize>|<layerDigest>`.
+
+The backend is intentionally described as native floating point, not FP16.
+Real GPT-OSS full rows are FP32. The dynamic plan measured their exact aggregate
+full-KV rate as 49,152 bytes per token. Claiming FP16 would under-account the
+backend and contradict executable evidence. Quantized and paged hybrid rows
+remain fail-cold.
+
+## Correctness evidence
+
+Deterministic weight-backed tests permanently cover:
+
+- `[full, sliding, sliding, full]`, including the first persistent full-layer
+  K/V divergence;
+- ten prompt lengths around 256-token block boundaries;
+- divergent tails;
+- mixed B=2 and B=4 absolute positions;
+- the actual `Gemma4TextModel` implementation with `attention_k_eq_v=true`;
+- cancellation during replay, preemption rollback, exact reservation balance,
+  contiguous positive admission, paged hybrid refusal, and quantized refusal;
+- MTP off/on with fully accepted and fully rejected drafts and terminal
+  donation.
+
+Real downloaded weights passed:
+
+- GPT-OSS at the original 2,817-token counterexample: old maximum absolute
+  logit drift `0.20875001`; frozen logit/KV drift `0`; 64 greedy tokens and
+  every post-token raw-logit vector bit-exact.
+- Gemma 4 QAT at prompt lengths 26,625, 26,881, and 27,137: raw logits, owning
+  full K/V, and at least 128 greedy tokens per prompt bit-exact.
+- Gemma 4 QAT at 32,769 tokens: raw logits bit-exact.
+
+Bit-exactness uses tolerance zero. The old GPT counterexample is pinned within
+`0.00001` solely to make the negative canary robust to decimal formatting.
+
+## Performance evidence
+
+These are single local real-weight measurements, not fleet latency promises.
+They isolate cold model compute from frozen replay compute.
+
+- GPT-OSS 2,817 tokens, M=2,816, R=1,536, saved=1,280:
+  cold `6.084 s`; replay `2.167 s`; `64.4%` reduction.
+- GPT-OSS 4,097 tokens, M=4,096, R=1,536, saved=2,560:
+  cold `5.219 s`; replay `2.098 s`; `59.8%` reduction.
+- GPT-OSS 8,193 tokens, M=8,192, R=1,536, saved=6,656:
+  cold `12.135 s`; replay `2.500 s`; `79.4%` reduction.
+- Gemma QAT 26,625 tokens, M=26,624, R=25,600, saved=1,024:
+  cold `44.357 s`; replay `58.625 s`; `32.2%` slower in this contended run.
+- Gemma QAT 26,881 tokens, M=26,880, R=25,600, saved=1,280:
+  cold `65.884 s`; replay `56.774 s`; `13.8%` reduction.
+- Gemma QAT 27,137 tokens, M=27,136, R=25,600, saved=1,536:
+  cold `54.538 s`; replay `49.187 s`; `9.8%` reduction.
+- Gemma QAT 32,769 tokens, M=32,768, R=25,600, saved=7,168:
+  cold `61.320 s`; replay `47.127 s`; `23.1%` reduction.
+
+The realistic Gemma conclusion is not that every hit is large: benefit is
+small and noisy just above the 25,600-token replay span, including one negative
+sample under concurrent machine load, and becomes consistently material only
+as the matched prefix grows beyond it. The enforced real-model performance gate
+therefore targets the 32k benefit point, and production raises long-hybrid
+admission to at least 1,536 saved tokens; the SSD stage gate applies to every
+hit.
+
+SSD lifecycle measurements:
+
+- deterministic DBK3 stage p95: miss `0.512 ms`, hit `17.410 ms`, both below
+  the configured `1,000 ms` gate;
+- real GPT-OSS warm same-engine TTFT `3.574 s` versus cache-off `4.264 s`;
+- real GPT-OSS warm-after-restart TTFT `3.928 s` versus cache-off `4.264 s`;
+- 13 encrypted blocks, `163,612,332` bytes, survived restart and rehydrated;
+- every staged reservation and backend reservation returned to zero in the
+  lifecycle and real-model tests.
+
+The miss-stage overhead is materially below saved prefill and does not alter
+the cold model forward path.

--- a/e2e/exact_cache_routing_test.go
+++ b/e2e/exact_cache_routing_test.go
@@ -63,13 +63,18 @@ func TestIntegrationExactCacheRouting(t *testing.T) {
 	require.NoError(t, suite.Coordinator.Registry.SendLoadModel(providers[0].ID, model))
 	firstModel := waitForLoadedModel(t, providers[0], model, 3*time.Minute)
 	require.Equal(t, firstModel.WeightHash, secondModel.WeightHash)
-	for _, provider := range providers {
-		provider.Mu().Lock()
-		_, advertised := provider.PrefixCacheV2Models[model]
-		provider.Mu().Unlock()
-		require.False(t, advertised,
-			"unsafe hybrid attention layout advertised reusable cache evidence")
-	}
+	require.Eventually(t, func() bool {
+		for _, provider := range providers {
+			provider.Mu().Lock()
+			_, advertised := provider.PrefixCacheV2Models[model]
+			provider.Mu().Unlock()
+			if !advertised {
+				return false
+			}
+		}
+		return true
+	}, 30*time.Second, 100*time.Millisecond,
+		"contiguous frozen-full hybrid slots did not advertise after SSD scan readiness")
 
 	fixture := loadExactCacheArtifacts(t, model, firstModel.WeightHash)
 	contractArtifacts, err := promptcontract.PromptArtifacts(fixture.manifest.Files)
@@ -77,6 +82,13 @@ func TestIntegrationExactCacheRouting(t *testing.T) {
 	contractID, err := promptcontract.ContractID(
 		contractArtifacts, promptcontract.CurrentVersions())
 	require.NoError(t, err)
+	for _, provider := range providers {
+		provider.Mu().Lock()
+		capability := provider.PrefixCacheV2Models[model]
+		provider.Mu().Unlock()
+		require.Equal(t, contractID, capability.PromptContractID)
+		require.Equal(t, firstModel.WeightHash, capability.ModelAggregateHash)
+	}
 
 	artifactServer := httptest.NewServer(http.HandlerFunc(func(
 		w http.ResponseWriter, request *http.Request,
@@ -155,22 +167,29 @@ func TestIntegrationExactCacheRouting(t *testing.T) {
 
 	prompt := longExactCachePrompt()
 	first := postExactCacheChat(t, suite, suite.Users[0].APIKey, model, prompt)
-	require.Zero(t, first.cachedTokens, "unsafe hybrid model reported a cache hit")
-	holders, attempts := suite.Coordinator.Registry.CacheRoutingStateCounts()
-	require.Zero(t, holders, "unsafe hybrid model published a reusable cache holder")
-	require.Zero(t, attempts, "unsafe hybrid model entered the v2 receipt protocol")
+	require.Zero(t, first.cachedTokens, "first request must prefill cold before donation")
+	require.Eventually(t, func() bool {
+		_, attempts := suite.Coordinator.Registry.CacheRoutingStateCounts()
+		return attempts > 0
+	}, 5*time.Second, 100*time.Millisecond,
+		"first request did not enter the provider-confirmed cache protocol")
+	require.Eventually(t, func() bool {
+		holders, _ := suite.Coordinator.Registry.CacheRoutingStateCounts()
+		return holders > 0
+	}, 2*time.Minute, 250*time.Millisecond,
+		"durable frozen-full donation did not publish a reusable cache holder")
 
-	// Bring the second provider into the candidate set. Current production
-	// models interleave sliding and storage-owning full attention, so exact
-	// replay requires a full prefill and both providers must remain cold.
+	// Bring the second provider into the candidate set. Provider-confirmed
+	// evidence must keep the repeated request on the owner and preserve exact
+	// deterministic output through frozen-full adoption.
 	stabilizeExactCacheRoutingCosts(providers, model)
 	providers[1].Mu().Lock()
 	providers[1].Status = registry.StatusOnline
 	providers[1].Mu().Unlock()
 
 	second := postExactCacheChat(t, suite, suite.Users[0].APIKey, model, prompt)
-	require.Zero(t, second.cachedTokens,
-		"hybrid full-replay policy was misreported as reusable prefix work")
+	require.Positive(t, second.cachedTokens)
+	require.Equal(t, first.content, second.content)
 
 	isolated := postExactCacheChat(t, suite, suite.Users[1].APIKey, model, prompt)
 	require.Zero(t, isolated.cachedTokens,

--- a/e2e/testbed/suite.go
+++ b/e2e/testbed/suite.go
@@ -481,7 +481,11 @@ func (p *Provider) Start(ctx context.Context, coordinatorURL string, cfg Provide
 		cmd.Env = append(cmd.Env, "DARKBLOOM_AUTH_TOKEN_PATH="+cfg.AuthTokenPath)
 	}
 	if cfg.EnableEphemeralPrefixCache {
-		cmd.Env = append(cmd.Env, "DARKBLOOM_PREFIX_CACHE_ALLOW_EPHEMERAL=1")
+		cmd.Env = append(
+			cmd.Env,
+			"DARKBLOOM_PREFIX_CACHE_ALLOW_EPHEMERAL=1",
+			"DARKBLOOM_PREFIX_CACHE_TEST_ROOT="+filepath.Join(p.StateDir, "prefix-cache"),
+		)
 	}
 
 	if err := cmd.Start(); err != nil {

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge+Capacity.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge+Capacity.swift
@@ -86,7 +86,8 @@ extension EngineV2Bridge {
         //                           conservative for sliding-window models,
         //                           whose engine ledger plateaus per layer)
         //   activeTokenBudgetMax  ← min(kvBytesCapacity, live fleet clamp) /
-        //                           fp16 rate (the engine's admission ceiling
+        //                           resolved native rate (the engine's
+        //                           admission ceiling
         //                           in tokens, clamped to the sizing
         //                           function's CURRENT answer when the caller
         //                           supplies fleet context — see the doc

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge+PrefixCache.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge+PrefixCache.swift
@@ -170,24 +170,6 @@ public final class EngineV2RequestUsageSignal: @unchecked Sendable {
 
 extension EngineV2Bridge {
 
-    static func nativeFullReservationDelta(
-        stagedBytes: Int,
-        stagedTokens: Int,
-        nominalBytesPerToken: Int,
-        worstCaseTokens: Int
-    ) -> UInt64? {
-        guard stagedBytes > 0, stagedTokens > 0,
-            stagedBytes.isMultiple(of: stagedTokens),
-            nominalBytesPerToken >= 0,
-            worstCaseTokens > 0
-        else { return nil }
-        let exact = stagedBytes / stagedTokens
-        let delta = max(0, exact - nominalBytesPerToken)
-        let (total, overflow) = delta.multipliedReportingOverflow(by: worstCaseTokens)
-        guard !overflow else { return nil }
-        return UInt64(total)
-    }
-
     func emitPrefixCacheColdFallback(
         requestId: String,
         reason: String,

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge+PrefixCache.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge+PrefixCache.swift
@@ -170,6 +170,114 @@ public final class EngineV2RequestUsageSignal: @unchecked Sendable {
 
 extension EngineV2Bridge {
 
+    static func nativeFullReservationDelta(
+        stagedBytes: Int,
+        stagedTokens: Int,
+        nominalBytesPerToken: Int,
+        worstCaseTokens: Int
+    ) -> UInt64? {
+        guard stagedBytes > 0, stagedTokens > 0,
+            stagedBytes.isMultiple(of: stagedTokens),
+            nominalBytesPerToken >= 0,
+            worstCaseTokens > 0
+        else { return nil }
+        let exact = stagedBytes / stagedTokens
+        let delta = max(0, exact - nominalBytesPerToken)
+        let (total, overflow) = delta.multipliedReportingOverflow(by: worstCaseTokens)
+        guard !overflow else { return nil }
+        return UInt64(total)
+    }
+
+    func emitPrefixCacheColdFallback(
+        requestId: String,
+        reason: String,
+        capacityRefusal: Bool
+    ) {
+        prefixCacheFallbackTelemetrySeen &+= 1
+        guard prefixCacheFallbackTelemetrySeen == 1
+            || prefixCacheFallbackTelemetrySeen.isMultiple(of: 64)
+        else { return }
+        var event = TelemetryEvent(
+            source: .provider,
+            severity: .warn,
+            kind: .engineHealth,
+            message: "engine_v2: prefix reuse fell back cold"
+        )
+        event.fields = TelemetryFieldFilter.filter([
+            "component": .string("engine"),
+            "operation": .string("prefix_cache_replay"),
+            "backend": .string(kvBackendKind.rawValue),
+            "model": .string(modelId),
+            "reason": .string(reason),
+            "prefix_reuse_strategy": .string("none"),
+            "prefix_matched_tokens": .int(0),
+            "prefix_replay_tokens": .int(0),
+            "prefix_saved_tokens": .int(0),
+            "prefix_boundary_splits": .int(0),
+            "prefix_capacity_refusal": .bool(capacityRefusal),
+            "prefix_cold_fallback": .bool(true),
+        ])
+        event.requestId = requestId
+        emit(event)
+    }
+
+    /// Content-free exact-prefix replay outcome. All values are bounded enums,
+    /// booleans, or aggregate counts; token ids and prompt/cache identities
+    /// never enter telemetry.
+    func emitPrefixReuseTelemetry(requestId: String, usage: CBv2Usage) {
+        switch usage.prefixCacheOutcome {
+        case .hit:
+            prefixCacheHitTelemetrySeen &+= 1
+            guard prefixCacheHitTelemetrySeen == 1
+                || prefixCacheHitTelemetrySeen.isMultiple(of: 64)
+            else { return }
+        case .skippedCapacity, .adoptionFailed:
+            prefixCacheFallbackTelemetrySeen &+= 1
+            guard prefixCacheFallbackTelemetrySeen == 1
+                || prefixCacheFallbackTelemetrySeen.isMultiple(of: 64)
+            else { return }
+        case .disabled, .skippedPolicy, .miss:
+            return
+        }
+        let outcome: String
+        switch usage.prefixCacheOutcome {
+        case .disabled: outcome = "disabled"
+        case .skippedPolicy: outcome = "skipped_policy"
+        case .miss: outcome = "miss"
+        case .hit: outcome = "hit"
+        case .skippedCapacity: outcome = "skipped_capacity"
+        case .adoptionFailed: outcome = "adoption_failed"
+        }
+        let coldFallback =
+            usage.prefixCacheOutcome == .skippedPolicy
+            || usage.prefixCacheOutcome == .skippedCapacity
+            || usage.prefixCacheOutcome == .adoptionFailed
+        var event = TelemetryEvent(
+            source: .provider,
+            severity: coldFallback ? .warn : .info,
+            kind: .engineHealth,
+            message: "engine_v2: exact prefix reuse resolved"
+        )
+        event.fields = TelemetryFieldFilter.filter([
+            "component": .string("engine"),
+            "operation": .string("prefix_cache_replay"),
+            "backend": .string(kvBackendKind.rawValue),
+            "model": .string(modelId),
+            "reason": .string(outcome),
+            "prefix_reuse_strategy": .string(
+                usage.prefixCacheStrategy?.rawValue ?? "none"),
+            "prefix_matched_tokens": .int(max(0, usage.prefixCacheMatchedTokens)),
+            "prefix_replay_tokens": .int(max(0, usage.prefixCacheReplayTokens)),
+            "prefix_saved_tokens": .int(max(0, usage.prefixCachePrefillTokensSaved)),
+            "prefix_boundary_splits": .int(max(0, usage.prefixCacheBoundarySplits)),
+            "prefix_capacity_refusal": .bool(
+                usage.prefixCacheOutcome == .skippedCapacity),
+            "prefix_cold_fallback": .bool(coldFallback),
+        ])
+        event.requestId = requestId
+        emit(event)
+    }
+
     /// The slot's TOTAL KV byte claim: for contiguous, the engine admission
     /// ceiling; for paged, the immutable PHYSICAL backend capacity.
     /// Fleet sizing (`makeEngineV2BridgeForSlot`) and the heartbeat clamp

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge.swift
@@ -359,6 +359,32 @@ public actor EngineV2Bridge {
             return stream
         }
 
+        // Translate with a PLACEHOLDER engine id — the real id is minted
+        // below, AFTER the shared-budget await, in the same synchronous
+        // stretch as `engine.submit` and the `idMap` registration. Validate
+        // total token arithmetic before minting cache tickets or staging.
+        var cbv2Request = EngineV2Translation.cbv2Request(
+            id: CBv2RequestID(0),
+            promptTokens: promptTokens,
+            request: request,
+            defaultMaxTokens: defaultMaxTokens,
+            stopTokenIds: stopTokenIds,
+            cacheScope: cacheScope,
+            cacheEnabled: cacheEnabled,
+            multimodal: multimodal
+        )
+        let (worstCaseTokens, tokenCountOverflow) = promptTokens.count.addingReportingOverflow(
+            cbv2Request.maxTokens)
+        guard !tokenCountOverflow else {
+            usageSignal?.finalizeLookup(
+                failure: .capacity,
+                fallbackTier: ssdPrefixCache == nil ? .memory : .ssd)
+            continuation.yield(.error(
+                "token_budget_exhausted: request token count overflow"))
+            continuation.finish()
+            return stream
+        }
+
         // The SSD staging ticket must be submission-unique even when seeded
         // sampling intentionally reuses a deterministic engine request id.
         // Mint it before staging and pass the same identity through
@@ -424,43 +450,7 @@ public actor EngineV2Bridge {
                 return stream
             }
         }
-
-        // Translate with a PLACEHOLDER engine id — the real id is minted
-        // below, AFTER the shared-budget await, in the same synchronous
-        // stretch as `engine.submit` and the `idMap` registration. Minting
-        // before the suspension would let two concurrent IDENTICAL seeded
-        // submissions both pass the collision check and hand the engine
-        // duplicate live ids.
-        var cbv2Request = EngineV2Translation.cbv2Request(
-            id: CBv2RequestID(0),
-            promptTokens: promptTokens,
-            request: request,
-            defaultMaxTokens: defaultMaxTokens,
-            stopTokenIds: stopTokenIds,
-            cacheScope: cacheScope,
-            cacheEnabled: cacheEnabled,
-            multimodal: multimodal
-        )
         cbv2Request.prefixCacheReceiptID = prefixCacheReceiptID
-        let (worstCaseTokens, tokenCountOverflow) = promptTokens.count.addingReportingOverflow(
-            cbv2Request.maxTokens)
-        guard !tokenCountOverflow else {
-            if let prefixCacheReceiptID {
-                if ssdStaged {
-                    await ssdPrefixCache?.abandonStaging(requestID: prefixCacheReceiptID)
-                }
-                if readyReceiptRegistered {
-                    ssdPrefixCache?.discardReadyReceipt(requestID: prefixCacheReceiptID)
-                }
-            }
-            usageSignal?.finalizeLookup(
-                failure: .capacity,
-                fallbackTier: ssdPrefixCache == nil ? .memory : .ssd)
-            continuation.yield(.error(
-                "token_budget_exhausted: request token count overflow"))
-            continuation.finish()
-            return stream
-        }
 
         // SHARED-BUDGET ADMISSION GATE: reserve this request's worst-case KV
         // footprint (prompt + maxTokens at the resolved native serving rate)

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge.swift
@@ -496,6 +496,12 @@ public actor EngineV2Bridge {
                     requestID: id,
                     kvBytesPerToken: kvBytesPerToken,
                     tokenCount: worstCaseTokens)
+                if sharedKVReserved {
+                    emitPrefixCacheColdFallback(
+                        requestId: id,
+                        reason: "shared_kv_capacity",
+                        capacityRefusal: true)
+                }
             }
             guard sharedKVReserved else {
                 if ssdReuseAttempted {
@@ -876,6 +882,8 @@ public actor EngineV2Bridge {
                 usageSignal?.record(
                     usage: usage,
                     fallbackTier: ssdPrefixCache == nil ? .memory : .ssd)
+                ssdPrefixCache?.recordPrefillTokensSaved(
+                    usage.prefixCachePrefillTokensSaved)
                 emitPrefixReuseTelemetry(requestId: id, usage: usage)
                 finishAndEmit(
                     id: id, reason: reason, usage: usage,

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge.swift
@@ -95,10 +95,10 @@ public actor EngineV2Bridge {
     let maxConcurrentRequests: Int
     /// Per-token KV byte cost for bytes→tokens capacity derivation
     /// (0 = unknown; capacity then falls back to the engine's token counts).
-    /// This is the unquantized fp16 rate: v0.7.5 rejects `kv_quant` intent with
-    /// a warning and EngineV2 builds only fp16 caches, so heartbeat budgets and
-    /// the shared-budget reservation below are
-    /// sized to the caches actually built — see `EngineV2KVSizing`.
+    /// This is the resolved native serving rate. Contiguous GPT-OSS adds the
+    /// fp32 owning-full-row delta to the nominal fp16 sizing rate; Gemma and
+    /// paged slots remain fp16. Heartbeats and process-wide reservations use
+    /// the same value so neither can overstate capacity.
     let kvBytesPerToken: Int
     /// Process-wide KV reservation ledger shared by every EngineV2 slot.
     /// When set (production), each v2 submission must RESERVE its worst-case
@@ -390,10 +390,7 @@ public actor EngineV2Bridge {
         // where lookup never ran (rejections below, pump terminals).
         // Vision requests never stage (engine policy symmetry).
         var ssdStaged = false
-        var ssdStagedDeviceBytes = 0
-        var ssdStagedTokens = 0
         var ssdReuseAttempted = false
-        var ssdCapacityFallbackEmitted = false
         if !cacheEnabled {
             usageSignal?.recordCacheDisabled(tier: ssdPrefixCache == nil ? .memory : .ssd)
         } else if multimodal != nil {
@@ -411,12 +408,9 @@ public actor EngineV2Bridge {
                     requestId: id,
                     reason: "stage_capacity",
                     capacityRefusal: true)
-                ssdCapacityFallbackEmitted = true
             }
             ssdStaged = stageResult.staged
             ssdReuseAttempted = stageResult.staged
-            ssdStagedDeviceBytes = stageResult.deviceBytes
-            ssdStagedTokens = stageResult.stagedTokens
             // `stage` suspended this actor — re-check the duplicate guard
             // (same discipline as the shared-budget gate below).
             guard active[id] == nil else {
@@ -448,10 +442,29 @@ public actor EngineV2Bridge {
             multimodal: multimodal
         )
         cbv2Request.prefixCacheReceiptID = prefixCacheReceiptID
+        let (worstCaseTokens, tokenCountOverflow) = promptTokens.count.addingReportingOverflow(
+            cbv2Request.maxTokens)
+        guard !tokenCountOverflow else {
+            if let prefixCacheReceiptID {
+                if ssdStaged {
+                    await ssdPrefixCache?.abandonStaging(requestID: prefixCacheReceiptID)
+                }
+                if readyReceiptRegistered {
+                    ssdPrefixCache?.discardReadyReceipt(requestID: prefixCacheReceiptID)
+                }
+            }
+            usageSignal?.finalizeLookup(
+                failure: .capacity,
+                fallbackTier: ssdPrefixCache == nil ? .memory : .ssd)
+            continuation.yield(.error(
+                "token_budget_exhausted: request token count overflow"))
+            continuation.finish()
+            return stream
+        }
 
         // SHARED-BUDGET ADMISSION GATE: reserve this request's worst-case KV
-        // footprint (prompt + maxTokens at the nominal configured rate) in
-        // the process-wide ledger BEFORE handing the
+        // footprint (prompt + maxTokens at the resolved native serving rate)
+        // in the process-wide ledger BEFORE handing the
         // request to the engine. The engine's private byte ledger
         // (`AdmissionV2`, sized to its own `kvBytesCapacity`) only knows its
         // own slot; when another slot (legacy or v2) already has live KV
@@ -469,7 +482,6 @@ public actor EngineV2Bridge {
         // (unit tests / standalone), the per-token rate is unknown (0), or
         // maxTokens ≤ 0 (degenerate request — the engine finishes it
         // immediately without allocating any KV).
-        let worstCaseTokens = promptTokens.count + cbv2Request.maxTokens
         var sharedKVReserved = false
         // PAGED slots skip the per-request shared-KV reserve: the pool is
         // physically committed at construction (`materializeSlabs`) and
@@ -495,48 +507,8 @@ public actor EngineV2Bridge {
                     kvBytesPerToken: kvBytesPerToken,
                     tokenCount: worstCaseTokens)
             }
-            if sharedKVReserved, ssdReuseAttempted, ssdStagedDeviceBytes > 0,
-                ssdStagedTokens > 0,
-                let cache = ssdPrefixCache
-            {
-                let additional = Self.nativeFullReservationDelta(
-                    stagedBytes: ssdStagedDeviceBytes,
-                    stagedTokens: ssdStagedTokens,
-                    nominalBytesPerToken: cache.config.nominalFullKVBytesPerToken,
-                    worstCaseTokens: worstCaseTokens)
-                if let additional, additional > 0 {
-                    let augmented = await kvBudget.increaseReservation(
-                        requestID: id,
-                        additionalBytes: additional)
-                    if !augmented, let prefixCacheReceiptID {
-                        if ssdStaged {
-                            await cache.abandonStaging(requestID: prefixCacheReceiptID)
-                        }
-                        await kvBudget.release(requestID: id)
-                        sharedKVReserved = false
-                        ssdStaged = false
-                        emitPrefixCacheColdFallback(
-                            requestId: id,
-                            reason: "native_kv_capacity",
-                            capacityRefusal: true)
-                        ssdCapacityFallbackEmitted = true
-                    }
-                } else if additional == nil, let prefixCacheReceiptID {
-                    if ssdStaged {
-                        await cache.abandonStaging(requestID: prefixCacheReceiptID)
-                    }
-                    await kvBudget.release(requestID: id)
-                    sharedKVReserved = false
-                    ssdStaged = false
-                    emitPrefixCacheColdFallback(
-                        requestId: id,
-                        reason: "native_kv_accounting",
-                        capacityRefusal: true)
-                    ssdCapacityFallbackEmitted = true
-                }
-            }
             guard sharedKVReserved else {
-                if ssdReuseAttempted, !ssdCapacityFallbackEmitted {
+                if ssdReuseAttempted {
                     emitPrefixCacheColdFallback(
                         requestId: id,
                         reason: "shared_kv_capacity",

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge.swift
@@ -392,6 +392,8 @@ public actor EngineV2Bridge {
         var ssdStaged = false
         var ssdStagedDeviceBytes = 0
         var ssdStagedTokens = 0
+        var ssdReuseAttempted = false
+        var ssdCapacityFallbackEmitted = false
         if !cacheEnabled {
             usageSignal?.recordCacheDisabled(tier: ssdPrefixCache == nil ? .memory : .ssd)
         } else if multimodal != nil {
@@ -409,8 +411,10 @@ public actor EngineV2Bridge {
                     requestId: id,
                     reason: "stage_capacity",
                     capacityRefusal: true)
+                ssdCapacityFallbackEmitted = true
             }
             ssdStaged = stageResult.staged
+            ssdReuseAttempted = stageResult.staged
             ssdStagedDeviceBytes = stageResult.deviceBytes
             ssdStagedTokens = stageResult.stagedTokens
             // `stage` suspended this actor — re-check the duplicate guard
@@ -446,8 +450,8 @@ public actor EngineV2Bridge {
         cbv2Request.prefixCacheReceiptID = prefixCacheReceiptID
 
         // SHARED-BUDGET ADMISSION GATE: reserve this request's worst-case KV
-        // footprint (prompt + maxTokens at the fp16 rate — the caches v2
-        // actually builds) in the process-wide ledger BEFORE handing the
+        // footprint (prompt + maxTokens at the nominal configured rate) in
+        // the process-wide ledger BEFORE handing the
         // request to the engine. The engine's private byte ledger
         // (`AdmissionV2`, sized to its own `kvBytesCapacity`) only knows its
         // own slot; when another slot (legacy or v2) already has live KV
@@ -491,7 +495,7 @@ public actor EngineV2Bridge {
                     kvBytesPerToken: kvBytesPerToken,
                     tokenCount: worstCaseTokens)
             }
-            if sharedKVReserved, ssdStaged, ssdStagedDeviceBytes > 0,
+            if sharedKVReserved, ssdReuseAttempted, ssdStagedDeviceBytes > 0,
                 ssdStagedTokens > 0,
                 let cache = ssdPrefixCache
             {
@@ -505,31 +509,39 @@ public actor EngineV2Bridge {
                         requestID: id,
                         additionalBytes: additional)
                     if !augmented, let prefixCacheReceiptID {
-                        await cache.abandonStaging(requestID: prefixCacheReceiptID)
+                        if ssdStaged {
+                            await cache.abandonStaging(requestID: prefixCacheReceiptID)
+                        }
+                        await kvBudget.release(requestID: id)
+                        sharedKVReserved = false
                         ssdStaged = false
-                        ssdStagedDeviceBytes = 0
-                        ssdStagedTokens = 0
                         emitPrefixCacheColdFallback(
                             requestId: id,
                             reason: "native_kv_capacity",
                             capacityRefusal: true)
+                        ssdCapacityFallbackEmitted = true
                     }
                 } else if additional == nil, let prefixCacheReceiptID {
-                    await cache.abandonStaging(requestID: prefixCacheReceiptID)
+                    if ssdStaged {
+                        await cache.abandonStaging(requestID: prefixCacheReceiptID)
+                    }
+                    await kvBudget.release(requestID: id)
+                    sharedKVReserved = false
                     ssdStaged = false
-                    ssdStagedDeviceBytes = 0
-                    ssdStagedTokens = 0
                     emitPrefixCacheColdFallback(
                         requestId: id,
                         reason: "native_kv_accounting",
                         capacityRefusal: true)
+                    ssdCapacityFallbackEmitted = true
                 }
             }
             guard sharedKVReserved else {
-                emitPrefixCacheColdFallback(
-                    requestId: id,
-                    reason: "shared_kv_capacity",
-                    capacityRefusal: true)
+                if ssdReuseAttempted, !ssdCapacityFallbackEmitted {
+                    emitPrefixCacheColdFallback(
+                        requestId: id,
+                        reason: "shared_kv_capacity",
+                        capacityRefusal: true)
+                }
                 if let prefixCacheReceiptID {
                     if ssdStaged {
                         await ssdPrefixCache?.abandonStaging(requestID: prefixCacheReceiptID)

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge.swift
@@ -155,6 +155,8 @@ public actor EngineV2Bridge {
     /// This counter is a separate namespace: advancing it must never perturb
     /// engine idMap/cancellation or sampler reproducibility.
     var nextPrefixCacheReceiptRawId: UInt64 = 1
+    var prefixCacheHitTelemetrySeen: UInt64 = 0
+    var prefixCacheFallbackTelemetrySeen: UInt64 = 0
     /// Live per-request pump tasks, so `shutdown()` can cancel any that
     /// outlive the engine drain (defense against a leaked stream). Keyed by
     /// the (normalized) provider request-id; each entry removes itself when
@@ -388,6 +390,8 @@ public actor EngineV2Bridge {
         // where lookup never ran (rejections below, pump terminals).
         // Vision requests never stage (engine policy symmetry).
         var ssdStaged = false
+        var ssdStagedDeviceBytes = 0
+        var ssdStagedTokens = 0
         if !cacheEnabled {
             usageSignal?.recordCacheDisabled(tier: ssdPrefixCache == nil ? .memory : .ssd)
         } else if multimodal != nil {
@@ -400,7 +404,15 @@ public actor EngineV2Bridge {
                 promptTokens: promptTokens,
                 cacheScope: cacheScope)
             usageSignal?.record(stageResult: stageResult)
+            if case .skippedCapacity = stageResult.disposition {
+                emitPrefixCacheColdFallback(
+                    requestId: id,
+                    reason: "stage_capacity",
+                    capacityRefusal: true)
+            }
             ssdStaged = stageResult.staged
+            ssdStagedDeviceBytes = stageResult.deviceBytes
+            ssdStagedTokens = stageResult.stagedTokens
             // `stage` suspended this actor — re-check the duplicate guard
             // (same discipline as the shared-budget gate below).
             guard active[id] == nil else {
@@ -479,7 +491,45 @@ public actor EngineV2Bridge {
                     kvBytesPerToken: kvBytesPerToken,
                     tokenCount: worstCaseTokens)
             }
+            if sharedKVReserved, ssdStaged, ssdStagedDeviceBytes > 0,
+                ssdStagedTokens > 0,
+                let cache = ssdPrefixCache
+            {
+                let additional = Self.nativeFullReservationDelta(
+                    stagedBytes: ssdStagedDeviceBytes,
+                    stagedTokens: ssdStagedTokens,
+                    nominalBytesPerToken: cache.config.nominalFullKVBytesPerToken,
+                    worstCaseTokens: worstCaseTokens)
+                if let additional, additional > 0 {
+                    let augmented = await kvBudget.increaseReservation(
+                        requestID: id,
+                        additionalBytes: additional)
+                    if !augmented, let prefixCacheReceiptID {
+                        await cache.abandonStaging(requestID: prefixCacheReceiptID)
+                        ssdStaged = false
+                        ssdStagedDeviceBytes = 0
+                        ssdStagedTokens = 0
+                        emitPrefixCacheColdFallback(
+                            requestId: id,
+                            reason: "native_kv_capacity",
+                            capacityRefusal: true)
+                    }
+                } else if additional == nil, let prefixCacheReceiptID {
+                    await cache.abandonStaging(requestID: prefixCacheReceiptID)
+                    ssdStaged = false
+                    ssdStagedDeviceBytes = 0
+                    ssdStagedTokens = 0
+                    emitPrefixCacheColdFallback(
+                        requestId: id,
+                        reason: "native_kv_accounting",
+                        capacityRefusal: true)
+                }
+            }
             guard sharedKVReserved else {
+                emitPrefixCacheColdFallback(
+                    requestId: id,
+                    reason: "shared_kv_capacity",
+                    capacityRefusal: true)
                 if let prefixCacheReceiptID {
                     if ssdStaged {
                         await ssdPrefixCache?.abandonStaging(requestID: prefixCacheReceiptID)
@@ -852,6 +902,7 @@ public actor EngineV2Bridge {
                 usageSignal?.record(
                     usage: usage,
                     fallbackTier: ssdPrefixCache == nil ? .memory : .ssd)
+                emitPrefixReuseTelemetry(requestId: id, usage: usage)
                 finishAndEmit(
                     id: id, reason: reason, usage: usage,
                     sawFirstToken: sawFirstToken, continuation: continuation

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Config.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Config.swift
@@ -251,8 +251,8 @@ public enum EngineV2Factory {
 
     /// WARN `engine_health` event when a model configured for `kv_quant` is
     /// served through engine_v2, which does NOT support KV-quant and uses
-    /// fp16 caches (`makeProductionEngine` builds `CBv2LayerCache`, never a
-    /// quantized cache). Surfacing this keeps the operator from assuming
+    /// unquantized native-float caches (`makeProductionEngine` builds
+    /// `CBv2LayerCache`, never a quantized cache). Surfacing this keeps the operator from assuming
     /// the memory savings apply. Allowlisted fields only.
     static func emitKVQuantUnsupportedTelemetry(
         modelId: String,
@@ -262,7 +262,7 @@ public enum EngineV2Factory {
             source: .provider,
             severity: .warn,
             kind: .engineHealth,
-            message: "engine_v2: kv_quant not supported — using fp16 caches"
+            message: "engine_v2: kv_quant not supported — using unquantized native KV"
         )
         event.fields = TelemetryFieldFilter.filter([
             "component": .string("engine"),

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Factory+Production.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Factory+Production.swift
@@ -110,6 +110,22 @@ extension EngineV2Factory {
         }
     }
 
+    /// Process-wide per-request reservation rate for the contiguous backend.
+    /// GPT-OSS owning full-attention rows are fp32 while the sizing snapshot is
+    /// all-fp16; Gemma and paged rows stay at the nominal fp16 rate.
+    static func nativeKVBytesPerToken(
+        nominalFP16BytesPerToken: Int,
+        fp16FullKVBytesPerToken: Int,
+        fullRowsUseFP32: Bool
+    ) -> Int {
+        guard nominalFP16BytesPerToken > 0 else { return 0 }
+        guard fullRowsUseFP32 else { return nominalFP16BytesPerToken }
+        guard fp16FullKVBytesPerToken >= 0 else { return Int.max }
+        let (nativeRate, overflow) = nominalFP16BytesPerToken.addingReportingOverflow(
+            fp16FullKVBytesPerToken)
+        return overflow ? Int.max : nativeRate
+    }
+
     /// Build the real `EngineV2` over a loaded model.
     ///
     /// - Parameters:
@@ -177,6 +193,61 @@ extension EngineV2Factory {
         public let kvBackendFallbackReason: String?
     }
 
+    /// Fully resolved backend resources, created before SSD cache construction
+    /// so provider capability follows the backend that will actually serve.
+    final class ProductionBackendPreparation {
+        let layerKinds: [CBv2LayerKind]
+        let kind: EngineV2KVBackendKind
+        let fallbackReason: String?
+
+        private let lock = NSLock()
+        private let modelIdentity: ObjectIdentifier
+        private let maxConcurrentRequests: Int
+        private var backend: CBv2KVBackend?
+        private var caches: [any CBv2AttendingLayerCache]?
+
+        init(
+            model: any LanguageModel,
+            maxConcurrentRequests: Int,
+            layerKinds: [CBv2LayerKind],
+            backend: CBv2KVBackend,
+            caches: [any CBv2AttendingLayerCache],
+            kind: EngineV2KVBackendKind,
+            fallbackReason: String?
+        ) {
+            self.modelIdentity = ObjectIdentifier(model)
+            self.maxConcurrentRequests = max(1, maxConcurrentRequests)
+            self.layerKinds = layerKinds
+            self.backend = backend
+            self.caches = caches
+            self.kind = kind
+            self.fallbackReason = fallbackReason
+        }
+
+        func consume(
+            model: any LanguageModel,
+            maxConcurrentRequests: Int
+        ) throws -> (CBv2KVBackend, [any CBv2AttendingLayerCache]) {
+            try lock.withLock {
+                guard modelIdentity == ObjectIdentifier(model) else {
+                    throw CBv2KVError.backendIneligible(
+                        reason: "prepared backend model identity changed before assembly")
+                }
+                guard self.maxConcurrentRequests == max(1, maxConcurrentRequests) else {
+                    throw CBv2KVError.backendIneligible(
+                        reason: "prepared backend concurrency changed before assembly")
+                }
+                guard let backend, let caches else {
+                    throw CBv2KVError.backendIneligible(
+                        reason: "prepared backend was already consumed")
+                }
+                self.backend = nil
+                self.caches = nil
+                return (backend, caches)
+            }
+        }
+    }
+
     /// Build the real `EngineV2` over a loaded model, returning the engine
     /// together with the KV-backend decision (`ProductionBuild`).
     ///
@@ -202,6 +273,36 @@ extension EngineV2Factory {
         environment: [String: String] = ProcessInfo.processInfo.environment,
         pagedPreflightOverride: (([CBv2LayerKind]) throws -> Void)? = nil
     ) throws -> ProductionBuild {
+        let preparedBackend = try prepareProductionBackend(
+            model: model,
+            kvBytesCapacity: kvBytesCapacity,
+            maxConcurrentRequests: maxConcurrentRequests,
+            kvBackend: kvBackend,
+            maxContextLength: maxContextLength,
+            environment: environment,
+            pagedPreflightOverride: pagedPreflightOverride)
+        return try assembleProductionBuild(
+            model: model,
+            tokenizer: tokenizer,
+            prefixCache: prefixCache,
+            maxConcurrentRequests: maxConcurrentRequests,
+            mtpDrafter: mtpDrafter,
+            mtpConfig: mtpConfig,
+            preparedBackend: preparedBackend)
+    }
+
+    /// Resolve and materialize the exact production backend without creating
+    /// EngineV2. Slot assembly uses this phase before SSD construction, then
+    /// injects the cache only when the resolved backend capability supports it.
+    static func prepareProductionBackend(
+        model: any LanguageModel,
+        kvBytesCapacity: Int,
+        maxConcurrentRequests: Int = EngineV2Factory.productionMaxConcurrentRequests,
+        kvBackend: EngineV2KVBackendSelection = .auto,
+        maxContextLength: Int? = nil,
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        pagedPreflightOverride: (([CBv2LayerKind]) throws -> Void)? = nil
+    ) throws -> ProductionBackendPreparation {
         guard kvBytesCapacity > 0 else {
             throw EngineV2ProductionError.noKVHeadroom
         }
@@ -253,17 +354,22 @@ extension EngineV2Factory {
         }
 
         let schedulerConfig = CBv2SchedulerConfig(
-            maxConcurrentRequests: max(1, maxConcurrentRequests),
-            enablePrefixCache: prefixCache != nil)
-        let engineLoopConfig = CBv2EngineLoopConfig()
+            maxConcurrentRequests: max(1, maxConcurrentRequests))
 
-        func contiguousAssembly() -> (CBv2KVBackend, [any CBv2AttendingLayerCache]) {
+        func contiguousPreparation() -> ProductionBackendPreparation {
             let backend = CBv2ContiguousKVBackend(
                 config: CBv2ContiguousBackendConfig(bytesCapacity: cappedCapacity))
             let caches = newCaches { index, kind in
                 CBv2LayerCache(layerIndex: index, kind: kind)
             }
-            return (backend, caches)
+            return ProductionBackendPreparation(
+                model: model,
+                maxConcurrentRequests: maxConcurrentRequests,
+                layerKinds: layerKinds,
+                backend: backend,
+                caches: caches,
+                kind: .contiguous,
+                fallbackReason: fallbackReason)
         }
 
         if resolvedKind == .paged {
@@ -316,17 +422,14 @@ extension EngineV2Factory {
                     // Resource and size eligibility has already thrown
                     // catchably; first traffic cannot discover either.
                     paged.pool.materializeSlabs()
-                    return ProductionBuild(
-                        engine: makeEngineV2(
-                            model: model, tokenizer: tokenizer, layerKinds: layerKinds,
-                            backend: paged, caches: caches,
-                            schedulerConfig: schedulerConfig,
-                            prefixCache: prefixCache,
-                            loopConfig: engineLoopConfig,
-                            mtpDrafter: mtpDrafter,
-                            mtpConfig: mtpConfig),
-                        kvBackendKind: .paged,
-                        kvBackendFallbackReason: nil)
+                    return ProductionBackendPreparation(
+                        model: model,
+                        maxConcurrentRequests: maxConcurrentRequests,
+                        layerKinds: layerKinds,
+                        backend: paged,
+                        caches: caches,
+                        kind: .paged,
+                        fallbackReason: nil)
                 } catch let error as CBv2KVError {
                     // Paged ineligibility/capacity is a supported degradation:
                     // fall back to the contiguous backend (INFO telemetry at the
@@ -341,18 +444,40 @@ extension EngineV2Factory {
                 }
             }
         }
-        let (backend, caches) = contiguousAssembly()
+        return contiguousPreparation()
+    }
+
+    /// Final engine assembly over an already resolved backend. This method has
+    /// no backend fallback path, so its cache capability cannot drift.
+    static func assembleProductionBuild(
+        model: any LanguageModel,
+        tokenizer: any MLXLMCommon.Tokenizer,
+        prefixCache: (any CBv2PrefixCache)?,
+        maxConcurrentRequests: Int,
+        mtpDrafter: (any CBv2MTPDrafter)?,
+        mtpConfig: CBv2MTPConfig,
+        preparedBackend: ProductionBackendPreparation
+    ) throws -> ProductionBuild {
+        let (backend, caches) = try preparedBackend.consume(
+            model: model,
+            maxConcurrentRequests: maxConcurrentRequests)
+        let schedulerConfig = CBv2SchedulerConfig(
+            maxConcurrentRequests: max(1, maxConcurrentRequests),
+            enablePrefixCache: prefixCache != nil)
         return ProductionBuild(
             engine: makeEngineV2(
-                model: model, tokenizer: tokenizer, layerKinds: layerKinds,
-                backend: backend, caches: caches,
+                model: model,
+                tokenizer: tokenizer,
+                layerKinds: preparedBackend.layerKinds,
+                backend: backend,
+                caches: caches,
                 schedulerConfig: schedulerConfig,
                 prefixCache: prefixCache,
-                loopConfig: engineLoopConfig,
+                loopConfig: CBv2EngineLoopConfig(),
                 mtpDrafter: mtpDrafter,
                 mtpConfig: mtpConfig),
-            kvBackendKind: .contiguous,
-            kvBackendFallbackReason: fallbackReason)
+            kvBackendKind: preparedBackend.kind,
+            kvBackendFallbackReason: preparedBackend.fallbackReason)
     }
 
     /// Shared final assembly for both backends.

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2KVSizing.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2KVSizing.swift
@@ -2,18 +2,20 @@
 //
 // Per-token KV byte-cost resolution for the ContinuousBatchingV2 bridge.
 //
-// The v2 engine builds UNQUANTIZED (fp16) `CBv2LayerCache`s regardless of the
-// provider's `kv_quant` setting — KV-quant is not composed with EngineV2
-// (`EngineV2Factory.makeProductionEngine` always uses `CBv2LayerCache`). A
+// The v2 engine builds UNQUANTIZED native-float `CBv2LayerCache`s regardless
+// of the provider's `kv_quant` setting — KV-quant is not composed with EngineV2
+// (`EngineV2Factory.makeProductionEngine` always uses `CBv2LayerCache`). The
+// sizing snapshot remains an all-fp16 baseline; slot assembly adds GPT-OSS's
+// fp32 owning-full-row delta before heartbeat/shared-budget publication. A
 // stale or test sizing input can still carry a quantized `kvBytesPerToken`
 // rate that is 2–4× smaller than fp16. Feeding that rate into the bridge would
 // make heartbeat token budgets (`kvBytesCapacity / kvBytesPerToken`) and
 // active-token counts (`kvBytesInUse / kvBytesPerToken`) OVERSTATE capacity by
-// the same 2–4×, and would under-size the shared-budget KV reservation.
+// the same 2–4×, and would under-size the native shared-budget KV reservation.
 //
 // `resolve` is retained as compatibility test math for the removed quantized
 // input shape. Production v0.7.5 rejects kv_quant intent with a warning and
-// takes the fp16 rate directly from SlotSizingSnapshot.
+// takes the fp16 baseline from SlotSizingSnapshot before native-width resolution.
 
 import Foundation
 

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2SlotFactory.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2SlotFactory.swift
@@ -255,20 +255,48 @@ enum EngineV2SlotFactory {
             let ssdLayerKinds: [CBv2LayerKind]?
             ssdLayerKinds = EngineV2Factory.cbv2LayerKinds(model: servingModel)
             if let ssdLayerKinds {
+                let prefixReuseCapability = PrefixCachePolicy.prefixReuseCapability(
+                    layerKinds: ssdLayerKinds,
+                    backendSelection: kvBackendSelection,
+                    pagedKilled: EngineV2KVBackendPolicy.killSwitchDisabled(
+                        environment: environment))
                 if let promptContractID {
                     ssdPrefixCache = await SSDPrefixCacheFactory.make(
                         modelId: modelId,
                         promptContractID: promptContractID,
                         weightHash: weightHash,
                         layerKinds: ssdLayerKinds,
+                        prefixReuseCapability: prefixReuseCapability,
                         kvBudget: kvBudget,
-                        environment: environment)
+                        environment: environment,
+                        onConstructionFailure: { failure in
+                            Self.emitPrefixCacheConstructionFailure(
+                                modelId: modelId,
+                                capability: prefixReuseCapability,
+                                failure: failure,
+                                emitTelemetry: emitTelemetry)
+                        })
                 } else {
+                    Self.emitPrefixCacheConstructionFailure(
+                        modelId: modelId,
+                        capability: prefixReuseCapability,
+                        failure: .promptContractUnavailable,
+                        emitTelemetry: emitTelemetry)
                     logWarning(
                         "engine_v2: SSD prefix cache skipped for \(modelId) — "
                             + "prompt contract could not be computed from local artifacts")
                 }
             } else {
+                let unavailableCapability = PrefixCachePolicy.prefixReuseCapability(
+                    layerKinds: [],
+                    backendSelection: kvBackendSelection,
+                    pagedKilled: EngineV2KVBackendPolicy.killSwitchDisabled(
+                        environment: environment))
+                Self.emitPrefixCacheConstructionFailure(
+                    modelId: modelId,
+                    capability: unavailableCapability,
+                    failure: .layoutUnavailable,
+                    emitTelemetry: emitTelemetry)
                 logInfo(
                     "engine_v2: SSD prefix cache skipped for \(modelId) — no "
                         + "derivable CBv2 layer kinds (non-adapted family)")
@@ -354,5 +382,34 @@ enum EngineV2SlotFactory {
             assistantBytes: mtpStatus.assistantBytes,
             mtpArtifact: prepared.mtpArtifact,
             mtpStatus: mtpStatus)
+    }
+
+    private static func emitPrefixCacheConstructionFailure(
+        modelId: String,
+        capability: CBv2PrefixReuseCapability,
+        failure: SSDPrefixCacheConstructionFailure,
+        emitTelemetry: (@Sendable (TelemetryEvent) -> Void)?
+    ) {
+        var event = TelemetryEvent(
+            source: .provider,
+            severity: .warn,
+            kind: .engineHealth,
+            message: "engine_v2: SSD prefix cache construction failed"
+        )
+        event.fields = TelemetryFieldFilter.filter([
+            "component": .string("engine"),
+            "operation": .string("prefix_cache_construction"),
+            "backend": .string(capability.backend.rawValue),
+            "model": .string(modelId),
+            "prefix_reuse_strategy": .string(
+                capability.strategy?.rawValue ?? "none"),
+            "prefix_construction_failure": .string(failure.rawValue),
+            "prefix_cold_fallback": .bool(true),
+        ])
+        if let emitTelemetry {
+            emitTelemetry(event)
+        } else {
+            TelemetryClient.shared.emit(event)
+        }
     }
 }

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2SlotFactory.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2SlotFactory.swift
@@ -21,10 +21,20 @@
 // are limited to `makeEngineOverride` (scripted engines, no weights).
 
 import Foundation
+import MLXLLM
 import MLXLMCommon
 import ProviderCoreFoundation
 
 enum EngineV2SlotFactory {
+
+    /// Narrow assembly seams for production-order regression tests. Normal
+    /// callers use the empty value and execute only concrete production code.
+    struct AssemblyOverrides {
+        var promptContractID: String? = nil
+        var pagedPreflight: (([CBv2LayerKind]) throws -> Void)? = nil
+        var makePrefixCache:
+            (([CBv2LayerKind], CBv2PrefixReuseCapability) async -> SSDPrefixCache?)? = nil
+    }
 
     /// Human-readable cache state for the slot-serving log line.
     static func prefixCacheStateDescription(
@@ -66,8 +76,8 @@ enum EngineV2SlotFactory {
     ///   - kvBudget: process-wide shared KV reservation ledger (nil ⇒ no
     ///     shared gating — unit tests only; both production callers pass
     ///     their ledger).
-    ///   - kvQuantConfigured: operator set `kv_quant` — v2 is fp16-only,
-    ///     so a WARN telemetry event fires once per load.
+    ///   - kvQuantConfigured: operator set `kv_quant` — v2 uses unquantized
+    ///     native-float KV, so a WARN telemetry event fires once per load.
     ///   - weightHash: the slot's verified weight hash binding for SSD
     ///     artifacts. Nil or blank disables reusable SSD caching.
     ///   - environment: prefix-cache policy environment
@@ -147,6 +157,7 @@ enum EngineV2SlotFactory {
         weightHash: String? = nil,
         specDecPreparation: SpecDecPreparation,
         preparedModel: EngineV2PreparedModel? = nil,
+        assemblyOverrides: AssemblyOverrides = AssemblyOverrides(),
         environment: [String: String] = ProcessInfo.processInfo.environment,
         emitTelemetry: (@Sendable (TelemetryEvent) -> Void)? = nil,
         makeEngineOverride: (@Sendable (String, Int) throws -> any CBv2Engine)? = nil,
@@ -229,8 +240,33 @@ enum EngineV2SlotFactory {
 
         // SSD offload never carves the live KV grant.
         let engineKVBytesCapacity = kvBytesCapacity
-        let promptContractID = modelDirectory.flatMap {
-            try? PromptContractIdentity.compute(modelDirectory: $0)
+        let promptContractID =
+            assemblyOverrides.promptContractID
+            ?? modelDirectory.flatMap {
+                try? PromptContractIdentity.compute(modelDirectory: $0)
+            }
+        let preparedBackend: EngineV2Factory.ProductionBackendPreparation?
+        if makeEngineOverride == nil {
+            do {
+                preparedBackend = try EngineV2Factory.prepareProductionBackend(
+                    model: servingModel,
+                    kvBytesCapacity: engineKVBytesCapacity,
+                    maxConcurrentRequests: maxConcurrentRequests,
+                    kvBackend: kvBackendSelection,
+                    maxContextLength: sizing.maxContextLength > 0
+                        ? sizing.maxContextLength : nil,
+                    environment: environment,
+                    pagedPreflightOverride: assemblyOverrides.pagedPreflight)
+            } catch {
+                EngineV2Factory.emitRefusalTelemetry(
+                    modelId: modelId,
+                    reason: EngineV2RefusalReason.classify(error),
+                    error: error,
+                    emitTelemetry: emitTelemetry)
+                throw error
+            }
+        } else {
+            preparedBackend = nil
         }
 
         // Encrypted SSD is the only production prefix-cache tier.
@@ -252,30 +288,34 @@ enum EngineV2SlotFactory {
         // unsupportedModel at engine build anyway).
         var ssdPrefixCache: SSDPrefixCache?
         if makeEngineOverride == nil, PrefixCachePolicy.isEnabled(environment: environment) {
-            let ssdLayerKinds: [CBv2LayerKind]?
-            ssdLayerKinds = EngineV2Factory.cbv2LayerKinds(model: servingModel)
-            if let ssdLayerKinds {
+            if let preparedBackend {
+                let ssdLayerKinds = preparedBackend.layerKinds
+                let resolvedSelection: EngineV2KVBackendSelection =
+                    preparedBackend.kind == .paged ? .paged : .contiguous
                 let prefixReuseCapability = PrefixCachePolicy.prefixReuseCapability(
                     layerKinds: ssdLayerKinds,
-                    backendSelection: kvBackendSelection,
-                    pagedKilled: EngineV2KVBackendPolicy.killSwitchDisabled(
-                        environment: environment))
+                    backendSelection: resolvedSelection)
                 if let promptContractID {
-                    ssdPrefixCache = await SSDPrefixCacheFactory.make(
-                        modelId: modelId,
-                        promptContractID: promptContractID,
-                        weightHash: weightHash,
-                        layerKinds: ssdLayerKinds,
-                        prefixReuseCapability: prefixReuseCapability,
-                        kvBudget: kvBudget,
-                        environment: environment,
-                        onConstructionFailure: { failure in
-                            Self.emitPrefixCacheConstructionFailure(
-                                modelId: modelId,
-                                capability: prefixReuseCapability,
-                                failure: failure,
-                                emitTelemetry: emitTelemetry)
-                        })
+                    if let makePrefixCache = assemblyOverrides.makePrefixCache {
+                        ssdPrefixCache = await makePrefixCache(
+                            ssdLayerKinds, prefixReuseCapability)
+                    } else {
+                        ssdPrefixCache = await SSDPrefixCacheFactory.make(
+                            modelId: modelId,
+                            promptContractID: promptContractID,
+                            weightHash: weightHash,
+                            layerKinds: ssdLayerKinds,
+                            prefixReuseCapability: prefixReuseCapability,
+                            kvBudget: kvBudget,
+                            environment: environment,
+                            onConstructionFailure: { failure in
+                                Self.emitPrefixCacheConstructionFailure(
+                                    modelId: modelId,
+                                    capability: prefixReuseCapability,
+                                    failure: failure,
+                                    emitTelemetry: emitTelemetry)
+                            })
+                    }
                 } else {
                     Self.emitPrefixCacheConstructionFailure(
                         modelId: modelId,
@@ -289,9 +329,7 @@ enum EngineV2SlotFactory {
             } else {
                 let unavailableCapability = PrefixCachePolicy.prefixReuseCapability(
                     layerKinds: [],
-                    backendSelection: kvBackendSelection,
-                    pagedKilled: EngineV2KVBackendPolicy.killSwitchDisabled(
-                        environment: environment))
+                    backendSelection: .contiguous)
                 Self.emitPrefixCacheConstructionFailure(
                     modelId: modelId,
                     capability: unavailableCapability,
@@ -316,23 +354,34 @@ enum EngineV2SlotFactory {
                     kvBackendFallbackReason: nil)
             }
         } else {
+            guard let preparedBackend else {
+                preconditionFailure("production backend preparation missing")
+            }
             makeEngine = {
-                return try EngineV2Factory.makeProductionBuild(
+                try EngineV2Factory.assembleProductionBuild(
                     model: servingModel,
                     tokenizer: tokenizer.inner,
-                    kvBytesCapacity: engineKVBytesCapacity,
                     prefixCache: enginePrefixCache,
                     maxConcurrentRequests: maxConcurrentRequests,
                     mtpDrafter: assistantHandle?.drafter,
                     mtpConfig: mtpConfig,
-                    kvBackend: kvBackendSelection,
-                    // Sizes the paged pool's per-group split
-                    // (`nominalMaxSequenceLength`); 0/unknown → factory
-                    // default.
-                    maxContextLength: sizing.maxContextLength > 0
-                        ? sizing.maxContextLength : nil,
-                    environment: environment)
+                    preparedBackend: preparedBackend)
             }
+        }
+
+        let processKVBytesPerToken: Int
+        if let preparedBackend {
+            let capability = CBv2PrefixReuseCapability.derive(
+                layerKinds: preparedBackend.layerKinds,
+                backend: .contiguousUnquantized)
+            processKVBytesPerToken = EngineV2Factory.nativeKVBytesPerToken(
+                nominalFP16BytesPerToken: sizing.fp16KVBytesPerToken,
+                fp16FullKVBytesPerToken: capability.fullKVBytesPerToken,
+                fullRowsUseFP32:
+                    preparedBackend.kind == .contiguous
+                    && servingModel is GPTOSSModel)
+        } else {
+            processKVBytesPerToken = sizing.fp16KVBytesPerToken
         }
 
         let bridge = try EngineV2Factory.makeBridge(
@@ -342,7 +391,7 @@ enum EngineV2SlotFactory {
             extraEOSTokens: snapshot.extraEOSTokens,
             defaultMaxTokens: sizing.defaultMaxTokens,
             maxConcurrentRequests: maxConcurrentRequests,
-            kvBytesPerToken: sizing.fp16KVBytesPerToken,
+            kvBytesPerToken: processKVBytesPerToken,
             // Shared KV ledger: v2 submissions RESERVE their worst-case
             // KV here before engine admission (process-wide gate) and the
             // reservation is what the model-LOAD gate subtracts.
@@ -364,7 +413,7 @@ enum EngineV2SlotFactory {
                     ssdCache: ssdPrefixCache))
 
         // WARN once (per load) that kv_quant is ignored on the v2 path
-        // (fp16 caches are what the engine builds).
+        // (unquantized native-float caches are what the engine builds).
         if kvQuantConfigured {
             EngineV2Factory.emitKVQuantUnsupportedTelemetry(
                 modelId: modelId, emitTelemetry: emitTelemetry)

--- a/provider-swift/Sources/ProviderCore/Inference/GlobalKVCacheBudget.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/GlobalKVCacheBudget.swift
@@ -200,26 +200,17 @@ public actor GlobalKVCacheBudget {
         return commit(requestID: requestID, bytes: bytes)
     }
 
-    /// Atomically grow an existing request reservation. Used when SSD staging
-    /// reveals native KV width (for example GPT-OSS fp32 full rows) after the
-    /// initial nominal token reservation was taken.
+    /// Compatibility surface for callers that grow an existing raw-byte
+    /// reservation. Production contiguous KV now reserves its native width
+    /// atomically up front; SSD staging uses `resizeReservationBytes`.
+    @available(*, deprecated, message: "Reserve native KV up front or use resizeReservationBytes")
     public func increaseReservation(requestID: String, additionalBytes: UInt64) -> Bool {
-        guard additionalBytes > 0, var current = reservations[requestID] else {
+        guard additionalBytes > 0, let current = reservations[requestID] else {
             return additionalBytes == 0 && reservations[requestID] != nil
         }
-        let (newBytes, overflow) = current.bytes.addingReportingOverflow(additionalBytes)
+        let (target, overflow) = current.bytes.addingReportingOverflow(additionalBytes)
         guard !overflow else { return false }
-        let available = availableReservationBytes()
-        guard additionalBytes <= available else {
-            reclaimer.scheduleReclaim(shortfall: additionalBytes - available)
-            recordCommitRejection()
-            return false
-        }
-        current.bytes = newBytes
-        reservations[requestID] = current
-        rejectionStreakStart = nil
-        lastRejectionAt = nil
-        return true
+        return resizeReservationBytes(requestID: requestID, bytes: target)
     }
 
     /// Atomically resize an existing raw-byte reservation after encrypted file

--- a/provider-swift/Sources/ProviderCore/Inference/GlobalKVCacheBudget.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/GlobalKVCacheBudget.swift
@@ -200,6 +200,48 @@ public actor GlobalKVCacheBudget {
         return commit(requestID: requestID, bytes: bytes)
     }
 
+    /// Atomically grow an existing request reservation. Used when SSD staging
+    /// reveals native KV width (for example GPT-OSS fp32 full rows) after the
+    /// initial nominal token reservation was taken.
+    public func increaseReservation(requestID: String, additionalBytes: UInt64) -> Bool {
+        guard additionalBytes > 0, var current = reservations[requestID] else {
+            return additionalBytes == 0 && reservations[requestID] != nil
+        }
+        let (newBytes, overflow) = current.bytes.addingReportingOverflow(additionalBytes)
+        guard !overflow else { return false }
+        let available = availableReservationBytes()
+        guard additionalBytes <= available else {
+            reclaimer.scheduleReclaim(shortfall: additionalBytes - available)
+            recordCommitRejection()
+            return false
+        }
+        current.bytes = newBytes
+        reservations[requestID] = current
+        rejectionStreakStart = nil
+        lastRejectionAt = nil
+        return true
+    }
+
+    /// Atomically resize an existing raw-byte reservation after encrypted file
+    /// estimates have been rehydrated into exact MLX arrays.
+    public func resizeReservationBytes(requestID: String, bytes: UInt64) -> Bool {
+        guard bytes > 0, var current = reservations[requestID] else { return false }
+        if bytes > current.bytes {
+            let additional = bytes - current.bytes
+            let available = availableReservationBytes()
+            guard additional <= available else {
+                reclaimer.scheduleReclaim(shortfall: additional - available)
+                recordCommitRejection()
+                return false
+            }
+        }
+        current.bytes = bytes
+        reservations[requestID] = current
+        rejectionStreakStart = nil
+        lastRejectionAt = nil
+        return true
+    }
+
     /// Reserve a loading model's WEIGHT footprint for the duration of its load,
     /// unconditionally. A model's weights are not yet visible in MLX active/cache
     /// while `loadModelContainer` is still allocating them, so a KV reservation

--- a/provider-swift/Sources/ProviderCore/Inference/PrefixCachePolicy.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/PrefixCachePolicy.swift
@@ -105,42 +105,54 @@ enum PrefixCachePolicy {
         return n  // 0 ⇒ disabled
     }
 
-    // MARK: - SSD adoption bound
+    // MARK: - Exact prefix-reuse capability
 
-    /// Whether the engine can resume from a partial layer snapshot without
-    /// changing model outputs. A storage-owning full-attention layer after any
-    /// sliding-window layer permanently caches activations computed from an
-    /// incomplete replay window, so `cbv2RequiredRecompute` correctly requires
-    /// full replay for that layout. Advertising reusable SSD evidence for such
-    /// a model would be false: staging can match bytes but save zero prefill.
-    static func supportsReusablePrefixes(layerKinds: [CBv2LayerKind]) -> Bool {
-        var sawWindowedLayer = false
-        for kind in layerKinds {
-            if case .slidingWindow = kind.attention {
-                sawWindowedLayer = true
-            } else if sawWindowedLayer, kind.sharesKVWithLayer == nil {
-                return false
-            }
+    /// Construct the engine-owned typed capability for the backend selected
+    /// before cache construction. `.auto` is the shipped contiguous,
+    /// unquantized native-float backend. Explicit paged selection remains eligible only for layouts
+    /// whose ordinary single-cursor replay is exact; interleaved hybrids fail
+    /// cold until a separately-proven paged dual-cursor row exists.
+    static func prefixReuseCapability(
+        layerKinds: [CBv2LayerKind],
+        backendSelection: EngineV2KVBackendSelection,
+        pagedKilled: Bool = false
+    ) -> CBv2PrefixReuseCapability {
+        let backend: CBv2PrefixReuseBackend
+        switch backendSelection {
+        case .auto, .contiguous:
+            backend = .contiguousUnquantized
+        case .paged:
+            backend = pagedKilled ? .contiguousUnquantized : .pagedFP16
         }
-        return true
+        return CBv2PrefixReuseCapability.derive(
+            layerKinds: layerKinds,
+            backend: backend)
     }
 
-    /// The model's adoption bound: `windowCount × maxWindow` over its layer
-    /// kinds for layouts that pass `supportsReusablePrefixes`. 0 for pure
-    /// full-attention models (every whole-block hit is adoptable).
+    /// Conservative finite-window replay length. Kept as a policy convenience
+    /// for SSD donation/stage benefit gates; the engine plan remains
+    /// authoritative per matched boundary.
     static func adoptionBoundTokens(layerKinds: [CBv2LayerKind]) -> Int {
-        var maxWindow = 0
-        var windowCount = 0
-        for kind in layerKinds {
-            if case .slidingWindow(let window) = kind.attention {
-                maxWindow = max(maxWindow, window)
-                windowCount += 1
-            }
-        }
-        // Same overflow posture as the engine's derivation: the product can
-        // only overflow at absurd model shapes; saturate rather than trap.
-        let (bound, overflow) = windowCount.multipliedReportingOverflow(by: maxWindow)
-        return overflow ? Int.max : bound
+        CBv2PrefixReuseCapability.derive(
+            layerKinds: layerKinds,
+            backend: .contiguousUnquantized
+        ).conservativeReplayBoundTokens
+    }
+
+    /// Real Gemma QAT evidence is noisy/negative at only 1,024 saved tokens
+    /// and positive from 1,536 onward; GPT's shorter 1,536-token replay span
+    /// remains beneficial at the generic 1,024 floor. The environment may
+    /// raise either floor but cannot lower the proved long-hybrid minimum.
+    static func minEffectiveTokens(
+        capability: CBv2PrefixReuseCapability,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> Int {
+        let configured = SSDPrefixCachePolicy.minEffectiveTokens(environment: environment)
+        let longHybridFloor =
+            capability.strategy == .frozenFullReplay
+                && capability.conservativeReplayBoundTokens >= 25_600
+            ? 1_536 : 0
+        return max(configured, longHybridFloor)
     }
 
 }

--- a/provider-swift/Sources/ProviderCore/Inference/PrefixCacheReceipts.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/PrefixCacheReceipts.swift
@@ -236,17 +236,20 @@ struct SSDPrefixCacheStageResult: Sendable, Equatable {
     let stageMs: Double
     let chainHashes: [Data]
     let blockSize: Int
+    let deviceBytes: Int
 
     init(
         disposition: SSDPrefixCacheStageDisposition,
         stageMs: Double,
         chainHashes: [Data] = [],
-        blockSize: Int = 0
+        blockSize: Int = 0,
+        deviceBytes: Int = 0
     ) {
         self.disposition = disposition
         self.stageMs = stageMs
         self.chainHashes = chainHashes
         self.blockSize = blockSize
+        self.deviceBytes = max(0, deviceBytes)
     }
 
     var staged: Bool {

--- a/provider-swift/Sources/ProviderCore/KVCacheSSD/SSDBlockStore.swift
+++ b/provider-swift/Sources/ProviderCore/KVCacheSSD/SSDBlockStore.swift
@@ -142,7 +142,7 @@ enum SSDBlockStore {
 
     // MARK: Layout epoch
 
-    /// `"cbv2-snap-2|f16|<blockSize>|<layerKindsDigest[:8]>"` — bumps
+    /// `"cbv2-frozen-full-3|native-fp|<blockSize>|<layerKindsDigest[:8]>"` — bumps
     /// whenever the engine's snapshot semantics, KV dtype policy, block
     /// size, or the model's layer-kind derivation change, so old files
     /// fail closed. The provider binary version is deliberately NOT in
@@ -160,7 +160,7 @@ enum SSDBlockStore {
         }
         let digest = SHA256.hash(data: Data(canonical.utf8))
         let hex = digest.map { String(format: "%02x", $0) }.joined().prefix(16)
-        return "cbv2-snap-2|f16|\(blockSize)|\(hex)"
+        return "cbv2-frozen-full-3|native-fp|\(blockSize)|\(hex)"
     }
 
     // MARK: Paths

--- a/provider-swift/Sources/ProviderCore/KVCacheSSD/SSDPrefixCache.swift
+++ b/provider-swift/Sources/ProviderCore/KVCacheSSD/SSDPrefixCache.swift
@@ -111,9 +111,9 @@ public final class SSDPrefixCache: CBv2PrefixCache, SSDEvictableStore, @unchecke
         /// `windowCount × maxWindow` — the engine's recompute bound; the
         /// staging benefit gate subtracts it from `matched`.
         let adoptionBoundTokens: Int
-        /// Nominal full-row bytes per token used by the provider's initial
-        /// request reservation. Staging reports exact native bytes so the
-        /// bridge can reserve only the fp32/native-width delta.
+        /// Nominal fp16 full-row bytes per token used by SSD replay planning.
+        /// The slot factory independently gives every contiguous request a
+        /// resolved native-width process reservation before staging.
         let nominalFullKVBytesPerToken: Int
         let layoutEpoch: String
         let epochStore: SSDCacheEpochStore?

--- a/provider-swift/Sources/ProviderCore/KVCacheSSD/SSDPrefixCache.swift
+++ b/provider-swift/Sources/ProviderCore/KVCacheSSD/SSDPrefixCache.swift
@@ -111,6 +111,10 @@ public final class SSDPrefixCache: CBv2PrefixCache, SSDEvictableStore, @unchecke
         /// `windowCount × maxWindow` — the engine's recompute bound; the
         /// staging benefit gate subtracts it from `matched`.
         let adoptionBoundTokens: Int
+        /// Nominal full-row bytes per token used by the provider's initial
+        /// request reservation. Staging reports exact native bytes so the
+        /// bridge can reserve only the fp32/native-width delta.
+        let nominalFullKVBytesPerToken: Int
         let layoutEpoch: String
         let epochStore: SSDCacheEpochStore?
         /// `…/darkbloom/kv3/<modelKey>` — files live here, per-model, in
@@ -133,6 +137,7 @@ public final class SSDPrefixCache: CBv2PrefixCache, SSDEvictableStore, @unchecke
             weightHash: String,
             blockSize: Int,
             adoptionBoundTokens: Int,
+            nominalFullKVBytesPerToken: Int = 0,
             layoutEpoch: String,
             epochStore: SSDCacheEpochStore? = nil,
             root: URL,
@@ -148,6 +153,7 @@ public final class SSDPrefixCache: CBv2PrefixCache, SSDEvictableStore, @unchecke
             self.weightHash = weightHash
             self.blockSize = blockSize
             self.adoptionBoundTokens = adoptionBoundTokens
+            self.nominalFullKVBytesPerToken = max(0, nominalFullKVBytesPerToken)
             self.layoutEpoch = layoutEpoch
             self.epochStore = epochStore
             self.root = root
@@ -900,7 +906,10 @@ public final class SSDPrefixCache: CBv2PrefixCache, SSDEvictableStore, @unchecke
         let evidenceHashes = maxBlocks > 0
             ? hasher.chainHashes(tokens: promptTokens, maxBlocks: maxBlocks)
             : []
-        func finish(_ disposition: SSDPrefixCacheStageDisposition) -> SSDPrefixCacheStageResult {
+        func finish(
+            _ disposition: SSDPrefixCacheStageDisposition,
+            deviceBytes: Int = 0
+        ) -> SSDPrefixCacheStageResult {
             let elapsed = started.duration(to: .now).components
             let milliseconds =
                 Double(elapsed.seconds) * 1_000
@@ -909,7 +918,8 @@ public final class SSDPrefixCache: CBv2PrefixCache, SSDEvictableStore, @unchecke
                 disposition: disposition,
                 stageMs: max(0, milliseconds),
                 chainHashes: evidenceHashes,
-                blockSize: config.blockSize)
+                blockSize: config.blockSize,
+                deviceBytes: deviceBytes)
         }
         let stageEpoch: String?
         if let epochStore = config.epochStore {
@@ -968,41 +978,36 @@ public final class SSDPrefixCache: CBv2PrefixCache, SSDEvictableStore, @unchecke
         }
         guard k > 0 else { return finish(.skippedCost) }
 
-        // Concurrent same-prefix request: attach to the existing staged
-        // entry (ONE entry, ONE per-entry reservation, one residency ticket
-        // per attached request). The provisional reservation below is only
-        // the memory-pressure gate for the case where THIS request has to
-        // build the entry — on attach it is redundant with the entry's own
-        // reservation and released immediately.
+        // Concurrent same-prefix request: attach BEFORE taking a provisional
+        // reservation. The existing entry already owns one exact reservation;
+        // requiring spare headroom for a zero-allocation ticket would produce
+        // false cold fallbacks under a full but correctly-accounted budget.
         let terminalTag = tags16[k - 1]
         let reservationKey = reservationKey(forRequestID: requestID)
-        if let kvBudget {
-            guard await kvBudget.reserveBytes(requestID: reservationKey, bytes: UInt64(runBytes))
-            else { return finish(.skippedCapacity) }
-        }
-        let attached = lock.withLock { () -> Bool in
+        let attachedBytes = lock.withLock { () -> Int? in
             guard !closed,
                 !destructiveChangeInProgress,
                 cacheEpochMatches(stageEpoch)
-            else { return false }
+            else { return nil }
             guard let existing = stagedEntries[terminalTag],
                 existing.cacheEpoch == stageEpoch,
                 existing.matched == k * config.blockSize
-            else { return false }
+            else { return nil }
             existing.openTickets.insert(requestID)
             tickets[requestID] = terminalTag
-            return true
+            return existing.deviceBytes
         }
-        if attached {
-            // Redundant with the entry's per-entry reservation — release it
-            // so a shared entry is charged to the shared KV budget exactly
-            // once, no matter how many requests attach.
-            await releaseReservation(reservationKey)
+        if let attachedBytes {
             return finish(.staged(
                 matchedTokens: k * config.blockSize,
                 expectedPrefillTokensSaved: max(
                     0, k * config.blockSize - min(config.adoptionBoundTokens, k * config.blockSize)),
-                shortenedByCorruption: false))
+                shortenedByCorruption: false),
+                deviceBytes: attachedBytes)
+        }
+        if let kvBudget {
+            guard await kvBudget.reserveBytes(requestID: reservationKey, bytes: UInt64(runBytes))
+            else { return finish(.skippedCapacity) }
         }
 
         // Read + decrypt + verify blocks 1..k off the engine threads.
@@ -1087,13 +1092,38 @@ public final class SSDPrefixCache: CBv2PrefixCache, SSDEvictableStore, @unchecke
             await releaseReservation(reservationKey)
             return finish(.skippedPolicy)
         }
+        var exactDeviceBytes = 0
+        for entry in prefix {
+            guard let entry else { continue }
+            let (entryBytes, entryOverflow) = entry.keys.nbytes.addingReportingOverflow(
+                entry.values.nbytes)
+            let (total, totalOverflow) = exactDeviceBytes.addingReportingOverflow(entryBytes)
+            guard !entryOverflow, !totalOverflow else {
+                await releaseReservation(reservationKey)
+                return finish(.skippedCapacity)
+            }
+            exactDeviceBytes = total
+        }
+        guard exactDeviceBytes > 0 else {
+            await releaseReservation(reservationKey)
+            return finish(.missCorrupt)
+        }
+        if let kvBudget, exactDeviceBytes != stagedRunBytes {
+            guard await kvBudget.resizeReservationBytes(
+                requestID: reservationKey,
+                bytes: UInt64(exactDeviceBytes))
+            else {
+                await releaseReservation(reservationKey)
+                return finish(.skippedCapacity)
+            }
+        }
 
         // Post-build resolution: another concurrent request may have won the
         // race and created the entry while we were reading off-thread, in
         // which case we ATTACH (and release our now-redundant provisional
         // reservation); otherwise we CREATE and our reservation becomes the
         // entry's per-entry reservation.
-        enum StageResolution { case created, attached, failed }
+        enum StageResolution { case created, attached(deviceBytes: Int), failed }
         let resolution: StageResolution = lock.withLock {
             guard !closed,
                 !destructiveChangeInProgress,
@@ -1105,7 +1135,7 @@ public final class SSDPrefixCache: CBv2PrefixCache, SSDEvictableStore, @unchecke
             {
                 existing.openTickets.insert(requestID)
                 tickets[requestID] = terminalTag
-                return .attached
+                return .attached(deviceBytes: existing.deviceBytes)
             }
             let usedTag = tags16[usableBlocks - 1]
             if let existing = stagedEntries[usedTag],
@@ -1114,26 +1144,27 @@ public final class SSDPrefixCache: CBv2PrefixCache, SSDEvictableStore, @unchecke
             {
                 existing.openTickets.insert(requestID)
                 tickets[requestID] = usedTag
-                return .attached
+                return .attached(deviceBytes: existing.deviceBytes)
             }
             stagedEntries[usedTag] = StagedEntry(
-                matched: matched, prefix: prefix, deviceBytes: stagedRunBytes,
+                matched: matched, prefix: prefix, deviceBytes: exactDeviceBytes,
                 cacheEpoch: stageEpoch, firstTicket: requestID, reservationKey: reservationKey)
             tickets[requestID] = usedTag
-            statsBox.add(stages: 1, stagedBytesDelta: stagedRunBytes)
+            statsBox.add(stages: 1, stagedBytesDelta: exactDeviceBytes)
             return .created
         }
         switch resolution {
         case .failed:
             await releaseReservation(reservationKey)
             return finish(.skippedPolicy)
-        case .attached:
+        case .attached(let attachedDeviceBytes):
             // Redundant with the winner's per-entry reservation.
             await releaseReservation(reservationKey)
             return finish(.staged(
                 matchedTokens: matched,
                 expectedPrefillTokensSaved: effective,
-                shortenedByCorruption: shortenedByCorruption))
+                shortenedByCorruption: shortenedByCorruption),
+                deviceBytes: attachedDeviceBytes)
         case .created:
             break  // reservation is now owned by the staged entry
         }
@@ -1151,7 +1182,8 @@ public final class SSDPrefixCache: CBv2PrefixCache, SSDEvictableStore, @unchecke
         return finish(.staged(
             matchedTokens: matched,
             expectedPrefillTokensSaved: effective,
-            shortenedByCorruption: shortenedByCorruption))
+            shortenedByCorruption: shortenedByCorruption),
+            deviceBytes: exactDeviceBytes)
     }
 
     func stage(

--- a/provider-swift/Sources/ProviderCore/KVCacheSSD/SSDPrefixCache.swift
+++ b/provider-swift/Sources/ProviderCore/KVCacheSSD/SSDPrefixCache.swift
@@ -501,12 +501,19 @@ public final class SSDPrefixCache: CBv2PrefixCache, SSDEvictableStore, @unchecke
                 return (staged.matched, staged.prefix)
             }
             if let (matched, prefix) = hit {
-                statsBox.add(hits: 1, tokensSaved: matched)
+                statsBox.add(hits: 1)
                 return (matched, prefix)
             }
         }
         statsBox.add(misses: 1)
         return nil
+    }
+
+    /// Terminal engine truth for prefill work actually skipped. Lookup knows
+    /// only M; hybrid replay still computes R and must not count it as saved.
+    func recordPrefillTokensSaved(_ tokens: Int) {
+        guard tokens > 0 else { return }
+        statsBox.add(tokensSaved: tokens)
     }
 
     // MARK: - CBv2PrefixCache: endAdoption (the staging release hook)
@@ -742,6 +749,9 @@ public final class SSDPrefixCache: CBv2PrefixCache, SSDEvictableStore, @unchecke
         let durableTags = Array(tags16.prefix(maxPersistBlocks))
         let durableFullTags = Array(fullTags.prefix(maxPersistBlocks))
         let durableChainHashes = Array(hashes.prefix(maxPersistBlocks))
+        let (durableTokenCount, durableTokenOverflow) =
+            durableTags.count.multipliedReportingOverflow(by: config.blockSize)
+        guard !durableTokenOverflow, durableTokenCount > donationFloor else { return }
         let onDurable: (@Sendable () -> Void)?
         if let receiptRequestID, !durableTags.isEmpty {
             onDurable = { [weak self] in

--- a/provider-swift/Sources/ProviderCore/KVCacheSSD/SSDPrefixCache.swift
+++ b/provider-swift/Sources/ProviderCore/KVCacheSSD/SSDPrefixCache.swift
@@ -968,7 +968,12 @@ public final class SSDPrefixCache: CBv2PrefixCache, SSDEvictableStore, @unchecke
                 continue
             }
             runSizes = sizes
-            runBytes = sizes.reduce(0, +)
+            runBytes = 0
+            for size in sizes {
+                let (sum, overflow) = runBytes.addingReportingOverflow(max(0, size))
+                guard !overflow else { return finish(.skippedCapacity) }
+                runBytes = sum
+            }
             if runBytes <= config.maxStageBytes,
                 SSDPrefixCachePolicy.estimatedStageMillis(bytes: runBytes) <= config.maxStageMillis
             {
@@ -1005,8 +1010,14 @@ public final class SSDPrefixCache: CBv2PrefixCache, SSDEvictableStore, @unchecke
                 shortenedByCorruption: false),
                 deviceBytes: attachedBytes)
         }
+        // Multi-block conversion temporarily holds three full representations:
+        // decrypted host Data, per-block MLX inputs, and concatenated outputs.
+        let (initialPeakBytes, initialPeakOverflow) = runBytes.multipliedReportingOverflow(by: 3)
+        guard !initialPeakOverflow else { return finish(.skippedCapacity) }
         if let kvBudget {
-            guard await kvBudget.reserveBytes(requestID: reservationKey, bytes: UInt64(runBytes))
+            guard await kvBudget.reserveBytes(
+                requestID: reservationKey,
+                bytes: UInt64(initialPeakBytes))
             else { return finish(.skippedCapacity) }
         }
 
@@ -1066,15 +1077,33 @@ public final class SSDPrefixCache: CBv2PrefixCache, SSDEvictableStore, @unchecke
         // memory pressure ⇒ silent recompute, exactly as if the shortened
         // run had been probed first).
         var stagedRunBytes = runBytes
+        var reservedPeakBytes = initialPeakBytes
         if usableBlocks < k {
-            stagedRunBytes = runSizes.prefix(usableBlocks).reduce(0, +)
-            if let kvBudget, stagedRunBytes != runBytes {
-                await kvBudget.release(requestID: reservationKey)
-                guard stagedRunBytes > 0,
-                    await kvBudget.reserveBytes(
-                        requestID: reservationKey, bytes: UInt64(stagedRunBytes))
-                else { return finish(.skippedCapacity) }
+            stagedRunBytes = 0
+            for size in runSizes.prefix(usableBlocks) {
+                let (sum, overflow) = stagedRunBytes.addingReportingOverflow(max(0, size))
+                guard !overflow else {
+                    await releaseReservation(reservationKey)
+                    return finish(.skippedCapacity)
+                }
+                stagedRunBytes = sum
             }
+            let (shortenedPeakBytes, shortenedPeakOverflow) =
+                stagedRunBytes.multipliedReportingOverflow(by: 3)
+            guard !shortenedPeakOverflow else {
+                await releaseReservation(reservationKey)
+                return finish(.skippedCapacity)
+            }
+            if let kvBudget, shortenedPeakBytes != reservedPeakBytes {
+                guard await kvBudget.resizeReservationBytes(
+                    requestID: reservationKey,
+                    bytes: UInt64(shortenedPeakBytes))
+                else {
+                    await releaseReservation(reservationKey)
+                    return finish(.skippedCapacity)
+                }
+            }
+            reservedPeakBytes = shortenedPeakBytes
         }
 
         // Rebuild per-layer arrays: per (layer × tensor), one MLXArray per
@@ -1108,7 +1137,26 @@ public final class SSDPrefixCache: CBv2PrefixCache, SSDEvictableStore, @unchecke
             await releaseReservation(reservationKey)
             return finish(.missCorrupt)
         }
-        if let kvBudget, exactDeviceBytes != stagedRunBytes {
+        let (conversionPeakBytes, conversionPeakOverflow) =
+            stagedRunBytes.addingReportingOverflow(exactDeviceBytes)
+        guard !conversionPeakOverflow else {
+            await releaseReservation(reservationKey)
+            return finish(.skippedCapacity)
+        }
+        if let kvBudget, conversionPeakBytes != reservedPeakBytes {
+            guard await kvBudget.resizeReservationBytes(
+                requestID: reservationKey,
+                bytes: UInt64(conversionPeakBytes))
+            else {
+                await releaseReservation(reservationKey)
+                return finish(.skippedCapacity)
+            }
+        }
+        // The evaluated prefix owns its MLX storage. Drop decrypted host chunks
+        // before converting the provisional peak reservation to steady device
+        // residence, so no unaccounted host+device overlap remains.
+        blockPayloads.removeAll(keepingCapacity: false)
+        if let kvBudget, exactDeviceBytes != conversionPeakBytes {
             guard await kvBudget.resizeReservationBytes(
                 requestID: reservationKey,
                 bytes: UInt64(exactDeviceBytes))

--- a/provider-swift/Sources/ProviderCore/KVCacheSSD/SSDPrefixCacheFactory.swift
+++ b/provider-swift/Sources/ProviderCore/KVCacheSSD/SSDPrefixCacheFactory.swift
@@ -51,17 +51,24 @@ enum SSDPrefixCacheFactory {
     /// separate root is fully self-contained, zero coupling. Survival
     /// after a legacy sweep is pinned by tests.
     static let ssdRootDirectoryName = "darkbloom/kv3"
+    /// Testbed-only isolated root. Honored only together with the explicit
+    /// ephemeral-key escape hatch, which also forces an in-memory KEK.
+    static let testRootEnvironmentKey = "DARKBLOOM_PREFIX_CACHE_TEST_ROOT"
 
-    static func cacheDirectory(modelId: String) -> URL {
+    static func cacheDirectory(
+        modelId: String,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> URL {
         let modelKey = SHA256.hash(data: Data(modelId.utf8))
             .map { String(format: "%02x", $0) }.joined().prefix(12)
-        let root = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first
-            ?? FileManager.default.temporaryDirectory
-        return root.appendingPathComponent(
-            "\(Self.ssdRootDirectoryName)/\(modelKey)", isDirectory: true)
+        return cacheRootDirectory(environment: environment)
+            .appendingPathComponent(String(modelKey), isDirectory: true)
     }
 
-    static func cacheRootDirectory() -> URL {
+    static func cacheRootDirectory(
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> URL {
+        if let root = isolatedTestRoot(environment: environment) { return root }
         let root = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first
             ?? FileManager.default.temporaryDirectory
         return root.appendingPathComponent(Self.ssdRootDirectoryName, isDirectory: true)
@@ -71,7 +78,7 @@ enum SSDPrefixCacheFactory {
         environment: [String: String] = ProcessInfo.processInfo.environment,
         intervalSeconds: Int = 60
     ) {
-        let root = cacheRootDirectory()
+        let root = cacheRootDirectory(environment: environment)
         let ttl = SSDPrefixCachePolicy.ttlSeconds(environment: environment)
         SSDWholeRootMaintainer.shared.startPeriodicMaintenance(
             root: root,
@@ -87,6 +94,21 @@ enum SSDPrefixCacheFactory {
 
     static func stopWholeRootMaintenance() {
         SSDWholeRootMaintainer.shared.stopPeriodicMaintenance(root: cacheRootDirectory())
+    }
+
+    private static func ephemeralAllowed(environment: [String: String]) -> Bool {
+        let raw = environment["DARKBLOOM_PREFIX_CACHE_ALLOW_EPHEMERAL"]?
+            .trimmingCharacters(in: .whitespaces).lowercased() ?? ""
+        return raw == "1" || raw == "true" || raw == "yes" || raw == "on"
+    }
+
+    private static func isolatedTestRoot(environment: [String: String]) -> URL? {
+        guard ephemeralAllowed(environment: environment),
+            let raw = environment[testRootEnvironmentKey]?
+                .trimmingCharacters(in: .whitespacesAndNewlines),
+            !raw.isEmpty
+        else { return nil }
+        return URL(fileURLWithPath: raw, isDirectory: true).standardizedFileURL
     }
 
     /// Build the SSD tier for a supported model slot. Reusable ciphertext is
@@ -120,8 +142,8 @@ enum SSDPrefixCacheFactory {
             #endif
             return nil
         }
-        let wholeRoot = cacheRootDirectory()
-        let dir = cacheDirectory(modelId: modelId)
+        let wholeRoot = cacheRootDirectory(environment: environment)
+        let dir = cacheDirectory(modelId: modelId, environment: environment)
         do {
             try SSDBlockStore.prepareModelRoot(
                 dedicatedRoot: wholeRoot,
@@ -138,37 +160,55 @@ enum SSDPrefixCacheFactory {
         // — restart warmth is the feature). Same construction + escape
         // hatch as the legacy tier.
         let kekKey: SymmetricKey
-        do {
-            let se = try PersistentEnclaveKey.loadOrCreate()
-            let kek = KVCacheKEK(
-                wrapper: SecureEnclaveKeyWrappingService(enclaveKey: se),
-                storage: KeychainWrappedKEKStorage())
-            kekKey = try await kek.loadOrCreate()
-        } catch {
-            let ephEnv = environment["DARKBLOOM_PREFIX_CACHE_ALLOW_EPHEMERAL"]?
-                .trimmingCharacters(in: .whitespaces).lowercased() ?? ""
-            let allowEphemeral =
-                ephEnv == "1" || ephEnv == "true" || ephEnv == "yes" || ephEnv == "on"
-            guard allowEphemeral else {
-                onConstructionFailure?(.keyUnavailable)
-                #if canImport(os)
-                logger.warning(
-                    "ssd prefix cache disabled for \(modelId, privacy: .public): KEK unavailable (\(String(describing: error), privacy: .public))")
-                #endif
-                return nil
-            }
+        var usedEphemeral = false
+        let forceEphemeral = isolatedTestRoot(environment: environment) != nil
+        if forceEphemeral {
             let kek = KVCacheKEK(
                 wrapper: InMemoryKeyWrappingService(),
                 storage: InMemoryWrappedKEKStorage(identifier: "ephemeral-ssd"))
-            guard let ephKey = try? await kek.loadOrCreate() else {
+            guard let key = try? await kek.loadOrCreate() else {
                 onConstructionFailure?(.ephemeralKeyUnavailable)
                 return nil
             }
+            kekKey = key
+            usedEphemeral = true
+        } else {
+            do {
+                let se = try PersistentEnclaveKey.loadOrCreate()
+                let kek = KVCacheKEK(
+                    wrapper: SecureEnclaveKeyWrappingService(enclaveKey: se),
+                    storage: KeychainWrappedKEKStorage())
+                kekKey = try await kek.loadOrCreate()
+            } catch {
+                guard ephemeralAllowed(environment: environment) else {
+                    onConstructionFailure?(.keyUnavailable)
+                    #if canImport(os)
+                    logger.warning(
+                        "ssd prefix cache disabled for \(modelId, privacy: .public): KEK unavailable (\(String(describing: error), privacy: .public))")
+                    #endif
+                    return nil
+                }
+                let kek = KVCacheKEK(
+                    wrapper: InMemoryKeyWrappingService(),
+                    storage: InMemoryWrappedKEKStorage(identifier: "ephemeral-ssd"))
+                guard let ephKey = try? await kek.loadOrCreate() else {
+                    onConstructionFailure?(.ephemeralKeyUnavailable)
+                    return nil
+                }
+                kekKey = ephKey
+                usedEphemeral = true
+            }
+        }
+        if usedEphemeral {
             #if canImport(os)
-            logger.warning(
-                "ssd prefix cache (\(modelId, privacy: .public)): EPHEMERAL in-memory KEK (DARKBLOOM_PREFIX_CACHE_ALLOW_EPHEMERAL) — files do not survive restart; TEST/STRESS ONLY")
+            if forceEphemeral {
+                logger.warning(
+                    "ssd prefix cache (\(modelId, privacy: .public)): isolated TEST root with ephemeral in-memory KEK — files do not survive process exit")
+            } else {
+                logger.warning(
+                    "ssd prefix cache (\(modelId, privacy: .public)): EPHEMERAL in-memory KEK (DARKBLOOM_PREFIX_CACHE_ALLOW_EPHEMERAL) — files do not survive restart; TEST/STRESS ONLY")
+            }
             #endif
-            kekKey = ephKey
         }
 
         let blockSize = PrefixCachePolicy.blockSize

--- a/provider-swift/Sources/ProviderCore/KVCacheSSD/SSDPrefixCacheFactory.swift
+++ b/provider-swift/Sources/ProviderCore/KVCacheSSD/SSDPrefixCacheFactory.swift
@@ -19,6 +19,18 @@ import MLXLMCommon
 import os
 #endif
 
+enum SSDPrefixCacheConstructionFailure: String, Sendable {
+    case missingWeightHash = "missing_weight_hash"
+    case unsupportedPlan = "unsupported_plan"
+    case unsafePath = "unsafe_path"
+    case keyUnavailable = "key_unavailable"
+    case ephemeralKeyUnavailable = "ephemeral_key_unavailable"
+    case blockContractMismatch = "block_contract_mismatch"
+    case epochUnavailable = "epoch_unavailable"
+    case promptContractUnavailable = "prompt_contract_unavailable"
+    case layoutUnavailable = "layout_unavailable"
+}
+
 enum SSDPrefixCacheFactory {
 
     #if canImport(os)
@@ -86,20 +98,25 @@ enum SSDPrefixCacheFactory {
         promptContractID: String,
         weightHash: String?,
         layerKinds: [CBv2LayerKind],
+        prefixReuseCapability: CBv2PrefixReuseCapability,
         kvBudget: GlobalKVCacheBudget?,
-        environment: [String: String] = ProcessInfo.processInfo.environment
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        onConstructionFailure:
+            (@Sendable (SSDPrefixCacheConstructionFailure) -> Void)? = nil
     ) async -> SSDPrefixCache? {
         guard let weightHash = verifiedWeightHash(weightHash) else {
+            onConstructionFailure?(.missingWeightHash)
             #if canImport(os)
             logger.warning(
                 "ssd prefix cache disabled for \(modelId, privacy: .public): verified live weight hash unavailable")
             #endif
             return nil
         }
-        guard PrefixCachePolicy.supportsReusablePrefixes(layerKinds: layerKinds) else {
+        guard prefixReuseCapability.isSupported else {
+            onConstructionFailure?(.unsupportedPlan)
             #if canImport(os)
             logger.info(
-                "ssd prefix cache disabled for \(modelId, privacy: .public): hybrid attention layout requires full replay")
+                "ssd prefix cache disabled for \(modelId, privacy: .public): prefix reuse unsupported (\(prefixReuseCapability.unsupportedReason?.rawValue ?? "unknown", privacy: .public), backend=\(prefixReuseCapability.backend.rawValue, privacy: .public))")
             #endif
             return nil
         }
@@ -110,6 +127,7 @@ enum SSDPrefixCacheFactory {
                 dedicatedRoot: wholeRoot,
                 modelRoot: dir)
         } catch {
+            onConstructionFailure?(.unsafePath)
             #if canImport(os)
             logger.warning(
                 "ssd prefix cache disabled for \(modelId, privacy: .public): unsafe cache path (\(String(describing: error), privacy: .public))")
@@ -132,6 +150,7 @@ enum SSDPrefixCacheFactory {
             let allowEphemeral =
                 ephEnv == "1" || ephEnv == "true" || ephEnv == "yes" || ephEnv == "on"
             guard allowEphemeral else {
+                onConstructionFailure?(.keyUnavailable)
                 #if canImport(os)
                 logger.warning(
                     "ssd prefix cache disabled for \(modelId, privacy: .public): KEK unavailable (\(String(describing: error), privacy: .public))")
@@ -141,7 +160,10 @@ enum SSDPrefixCacheFactory {
             let kek = KVCacheKEK(
                 wrapper: InMemoryKeyWrappingService(),
                 storage: InMemoryWrappedKEKStorage(identifier: "ephemeral-ssd"))
-            guard let ephKey = try? await kek.loadOrCreate() else { return nil }
+            guard let ephKey = try? await kek.loadOrCreate() else {
+                onConstructionFailure?(.ephemeralKeyUnavailable)
+                return nil
+            }
             #if canImport(os)
             logger.warning(
                 "ssd prefix cache (\(modelId, privacy: .public)): EPHEMERAL in-memory KEK (DARKBLOOM_PREFIX_CACHE_ALLOW_EPHEMERAL) — files do not survive restart; TEST/STRESS ONLY")
@@ -153,6 +175,7 @@ enum SSDPrefixCacheFactory {
         guard PromptContractIdentity.blockHashVersion == CBv2BlockHasher.version,
             PromptContractIdentity.blockSize == UInt32(blockSize)
         else {
+            onConstructionFailure?(.blockContractMismatch)
             #if canImport(os)
             logger.warning(
                 "ssd prefix cache disabled for \(modelId, privacy: .public): prompt-contract/block-hasher binary mismatch")
@@ -178,6 +201,7 @@ enum SSDPrefixCacheFactory {
                     layoutEpoch: layoutEpoch,
                     keyFingerprint: keyFingerprint))
         } catch {
+            onConstructionFailure?(.epochUnavailable)
             #if canImport(os)
             logger.warning(
                 "ssd prefix cache disabled for \(modelId, privacy: .public): cache epoch unavailable (\(String(describing: error), privacy: .public))")
@@ -189,13 +213,16 @@ enum SSDPrefixCacheFactory {
             promptContractID: promptContractID,
             weightHash: weightHash,
             blockSize: blockSize,
-            adoptionBoundTokens: PrefixCachePolicy.adoptionBoundTokens(layerKinds: layerKinds),
+            adoptionBoundTokens: prefixReuseCapability.conservativeReplayBoundTokens,
+            nominalFullKVBytesPerToken: prefixReuseCapability.fullKVBytesPerToken,
             layoutEpoch: layoutEpoch,
             epochStore: epochStore,
             root: dir,
             dedicatedRoot: wholeRoot,
             ttlSeconds: SSDPrefixCachePolicy.ttlSeconds(environment: environment),
-            minEffectiveTokens: SSDPrefixCachePolicy.minEffectiveTokens(environment: environment),
+            minEffectiveTokens: PrefixCachePolicy.minEffectiveTokens(
+                capability: prefixReuseCapability,
+                environment: environment),
             maxStageBytes: SSDPrefixCachePolicy.maxStageBytes(environment: environment),
             maxStageMillis: SSDPrefixCachePolicy.maxStageMillis(environment: environment),
             nowSeconds: { Int64(Date().timeIntervalSince1970) })
@@ -224,7 +251,7 @@ enum SSDPrefixCacheFactory {
         startWholeRootMaintenance(environment: environment)
         #if canImport(os)
         logger.info(
-            "ssd prefix cache active for \(modelId, privacy: .public) at \(dir.path, privacy: .public): ttl \(config.ttlSeconds)s sliding, box-wide disk budget \(PrefixCachePolicy.ssdDiskBudgetBytes(environment: environment, freeBytes: PrefixCachePolicy.volumeFreeBytes(at: dir))) B, adoption bound \(config.adoptionBoundTokens) tok — HMAC-keyed names (T-041 leak #2 closed), no memory carve")
+            "ssd prefix cache active for \(modelId, privacy: .public) at \(dir.path, privacy: .public): strategy \(prefixReuseCapability.strategy?.rawValue ?? "none", privacy: .public), backend \(prefixReuseCapability.backend.rawValue, privacy: .public), ttl \(config.ttlSeconds)s sliding, box-wide disk budget \(PrefixCachePolicy.ssdDiskBudgetBytes(environment: environment, freeBytes: PrefixCachePolicy.volumeFreeBytes(at: dir))) B, replay bound \(config.adoptionBoundTokens) tok — HMAC-keyed names (T-041 leak #2 closed), no memory carve")
         #endif
         return cache
     }

--- a/provider-swift/Sources/ProviderCore/Telemetry/TelemetryEvent.swift
+++ b/provider-swift/Sources/ProviderCore/Telemetry/TelemetryEvent.swift
@@ -266,6 +266,12 @@ public enum TelemetryFieldFilter {
         // boolean and a coarse image/video/mixed label; media/prompt content
         // NEVER rides telemetry. Mirror in Go + TS allowlists.
         "multimodal", "media_kind",
+        // Exact-prefix replay telemetry. Counts and bounded enums only; never
+        // token ids, prompt text, hashes, cache keys, or account scope.
+        "prefix_reuse_strategy", "prefix_matched_tokens", "prefix_replay_tokens",
+        "prefix_saved_tokens", "prefix_boundary_splits",
+        "prefix_construction_failure", "prefix_capacity_refusal",
+        "prefix_cold_fallback",
     ]
 
     /// Filter a dictionary to only the keys the coordinator accepts.

--- a/provider-swift/Tests/ProviderCoreTests/EngineV2BridgeTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/EngineV2BridgeTests.swift
@@ -1813,6 +1813,38 @@ struct EngineV2SharedBudgetTests {
         #expect(fixture.cache.bytesInUse == 0)
     }
 
+    @Test("bridge records terminal saved-prefill truth exactly once")
+    func terminalSavedPrefillUpdatesSSDStats() async throws {
+        let parent = FileManager.default.temporaryDirectory.resolvingSymlinksInPath()
+            .appendingPathComponent("bridge-terminal-saved-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: parent, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: parent) }
+        let budget = TestBudgets.ample()
+        let fixture = try await makeBridgeStagedCache(parent: parent, budget: budget)
+        defer { fixture.cache.close() }
+        let engine = ScriptedCBv2Engine(script: .stream([
+            .finished(
+                reason: .stop,
+                usage: CBv2Usage(
+                    promptTokens: fixture.prompt.count,
+                    completionTokens: 0,
+                    prefixCacheOutcome: .hit,
+                    prefixCacheMatchedTokens: 64,
+                    prefixCachePrefillTokensSaved: 7))
+        ]))
+        let bridge = makeBridge(
+            engine: engine,
+            ssdPrefixCache: fixture.cache)
+
+        _ = await record(await bridge.submitTokenized(
+            promptTokens: fixture.prompt,
+            request: makeRequest(maxTokens: 1),
+            requestId: "req-terminal-saved",
+            cacheScope: "scope",
+            cacheEnabled: false))
+        #expect(fixture.cache.stats().tokensSaved == 7)
+    }
+
     @Test("native request byte multiplication overflow rejects before engine submission")
     func nativeRateOverflowRejectsRequest() async {
         let engine = ScriptedCBv2Engine(script: .manual)
@@ -1884,11 +1916,13 @@ struct EngineV2SharedBudgetTests {
         let fixture = try await makeBridgeStagedCache(parent: parent, budget: budget)
         defer { fixture.cache.close() }
         let engine = ScriptedCBv2Engine(script: .manual)
+        let telemetry = TelemetrySink()
         let bridge = makeBridge(
             engine: engine,
             kvBytesPerToken: kvBytesPerToken,
             kvBudget: budget,
-            ssdPrefixCache: fixture.cache)
+            ssdPrefixCache: fixture.cache,
+            telemetry: telemetry)
         let signal = EngineV2RequestUsageSignal()
 
         let stream = await bridge.submitTokenized(
@@ -1902,6 +1936,10 @@ struct EngineV2SharedBudgetTests {
         #expect(engine.submitted.first?.prefixCacheReceiptID != nil)
         #expect(fixture.cache.bytesInUse == 0, "optional staging must be abandoned before retry")
         #expect(await budget.outstandingReservedBytes() == coldBytes)
+        #expect(telemetry.events.contains {
+            $0.fields?["reason"]?.description == "shared_kv_capacity"
+                && $0.fields?["prefix_cold_fallback"]?.description == "true"
+        })
 
         let consumer = Task { await record(stream) }
         engine.manualContinuation?.yield(.finished(

--- a/provider-swift/Tests/ProviderCoreTests/EngineV2BridgeTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/EngineV2BridgeTests.swift
@@ -270,7 +270,8 @@ private func makeRequest(
 
 private func makeBridgeStagedCache(
     parent: URL,
-    budget: GlobalKVCacheBudget
+    budget: GlobalKVCacheBudget,
+    nominalFullKVBytesPerToken: Int = 16
 ) async throws -> (cache: SSDPrefixCache, prompt: [Int]) {
     _ = LiveInferenceFixtures.ensureMetallibColocated()
     let root = parent.appendingPathComponent("aaaaaaaaaaaa", isDirectory: true)
@@ -285,6 +286,7 @@ private func makeBridgeStagedCache(
             weightHash: "bridge-stage-weight",
             blockSize: 8,
             adoptionBoundTokens: 0,
+            nominalFullKVBytesPerToken: nominalFullKVBytesPerToken,
             layoutEpoch: SSDBlockStore.layoutEpoch(blockSize: 8, layerKinds: layerKinds),
             root: root,
             dedicatedRoot: parent,
@@ -1614,7 +1616,12 @@ struct EngineV2SharedBudgetTests {
     func sharedBudgetGateRejectsBeforeEngine() async {
         let engine = ScriptedCBv2Engine(script: .manual)
         let budget = TestBudgets.exhausted()
-        let bridge = makeBridge(engine: engine, kvBytesPerToken: 4000, kvBudget: budget)
+        let telemetry = TelemetrySink()
+        let bridge = makeBridge(
+            engine: engine,
+            kvBytesPerToken: 4000,
+            kvBudget: budget,
+            telemetry: telemetry)
         let (events, _) = await record(await bridge.submitTokenized(
             promptTokens: [1, 2, 3, 4, 5],
             request: makeRequest(maxTokens: 16),
@@ -1627,6 +1634,9 @@ struct EngineV2SharedBudgetTests {
         // and no bookkeeping leaked.
         #expect(engine.submitted.isEmpty)
         #expect(await budget.outstandingReservedBytes() == 0)
+        #expect(!telemetry.events.contains {
+            $0.fields?["operation"]?.description == "prefix_cache_replay"
+        })
         let counters = await bridge._testCounters()
         #expect(counters.active == 0)
         // Classified exactly like the legacy KV-reserve rejection: retryable
@@ -1770,6 +1780,58 @@ struct EngineV2SharedBudgetTests {
         engine.manualContinuation?.finish()
         _ = await consumer.value
         #expect(await budget.outstandingReservedBytes() == 0)
+    }
+
+    @Test("native-width augmentation refusal rejects before cold over-admission")
+    func nativeWidthRefusalRejectsRequest() async throws {
+        let parent = FileManager.default.temporaryDirectory.resolvingSymlinksInPath()
+            .appendingPathComponent("bridge-native-width-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: parent, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: parent) }
+
+        let kvBytesPerToken = 1_000_000
+        let worstCaseTokens = 66
+        let nominalBytes = UInt64(kvBytesPerToken * worstCaseTokens)
+        let gib: UInt64 = 1_073_741_824
+        let budget = GlobalKVCacheBudget(
+            capFraction: 1.0,
+            activationReserveBytes: 0,
+            memorySnapshot: {
+                .init(
+                    total: 3 * gib,
+                    active: gib - nominalBytes,
+                    cache: 0,
+                    systemAvailable: nominalBytes)
+            })
+        let fixture = try await makeBridgeStagedCache(
+            parent: parent,
+            budget: budget,
+            nominalFullKVBytesPerToken: 0)
+        defer { fixture.cache.close() }
+        let engine = ScriptedCBv2Engine(script: .manual)
+        let telemetry = TelemetrySink()
+        let bridge = makeBridge(
+            engine: engine,
+            kvBytesPerToken: kvBytesPerToken,
+            kvBudget: budget,
+            ssdPrefixCache: fixture.cache,
+            telemetry: telemetry)
+
+        let (events, _) = await record(await bridge.submitTokenized(
+            promptTokens: fixture.prompt,
+            request: makeRequest(maxTokens: 1),
+            requestId: "req-native-width",
+            cacheScope: "scope"))
+        #expect(engine.submitted.isEmpty)
+        #expect(events == [.error(
+            "token_budget_exhausted: request requires \(worstCaseTokens) tokens "
+                + "but the shared KV budget has no headroom")])
+        #expect(fixture.cache.bytesInUse == 0)
+        #expect(await budget.outstandingReservedBytes() == 0)
+        #expect(telemetry.events.contains {
+            $0.fields?["reason"]?.description == "native_kv_capacity"
+                && $0.fields?["prefix_capacity_refusal"]?.description == "true"
+        })
     }
 }
 

--- a/provider-swift/Tests/ProviderCoreTests/EngineV2BridgeTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/EngineV2BridgeTests.swift
@@ -201,6 +201,18 @@ private func record(
     return (events, tps)
 }
 
+private func waitForBudgetRelease(
+    _ budget: GlobalKVCacheBudget,
+    timeout: Duration = .seconds(1)
+) async -> Bool {
+    let deadline = ContinuousClock.now.advanced(by: timeout)
+    while await budget.outstandingReservedBytes() != 0 {
+        if ContinuousClock.now >= deadline { return false }
+        try? await Task.sleep(for: .milliseconds(10))
+    }
+    return true
+}
+
 // MARK: - Shared builders
 
 private func makeBridge(
@@ -270,8 +282,7 @@ private func makeRequest(
 
 private func makeBridgeStagedCache(
     parent: URL,
-    budget: GlobalKVCacheBudget,
-    nominalFullKVBytesPerToken: Int = 16
+    budget: GlobalKVCacheBudget
 ) async throws -> (cache: SSDPrefixCache, prompt: [Int]) {
     _ = LiveInferenceFixtures.ensureMetallibColocated()
     let root = parent.appendingPathComponent("aaaaaaaaaaaa", isDirectory: true)
@@ -286,7 +297,7 @@ private func makeBridgeStagedCache(
             weightHash: "bridge-stage-weight",
             blockSize: 8,
             adoptionBoundTokens: 0,
-            nominalFullKVBytesPerToken: nominalFullKVBytesPerToken,
+            nominalFullKVBytesPerToken: 16,
             layoutEpoch: SSDBlockStore.layoutEpoch(blockSize: 8, layerKinds: layerKinds),
             root: root,
             dedicatedRoot: parent,
@@ -973,10 +984,15 @@ struct EngineV2CancellationTests {
     @Test("bridge cancel maps the provider request-id to the minted engine id")
     func bridgeCancelMapsId() async {
         let engine = ScriptedCBv2Engine(script: .manual)
-        let bridge = makeBridge(engine: engine)
+        let budget = TestBudgets.ample()
+        let bridge = makeBridge(
+            engine: engine,
+            kvBytesPerToken: 4_000,
+            kvBudget: budget)
         let stream = await bridge.submit(request: makeRequest(), requestId: "req-abc")
         let engineId = await bridge._testEngineRequestId(for: "req-abc")
         #expect(engineId != nil)
+        #expect(await budget.outstandingReservedBytes() > 0)
 
         await bridge.cancel(requestId: "req-abc")
         #expect(engine.cancelled == [engineId!])
@@ -989,6 +1005,7 @@ struct EngineV2CancellationTests {
         let (events, _) = await record(stream)
         #expect(events.last == .error("request cancelled"))
         #expect(await bridge._testEngineRequestId(for: "req-abc") == nil)
+        #expect(await budget.outstandingReservedBytes() == 0)
     }
 
     @Test("cancel for an unknown id is a no-op")
@@ -1727,6 +1744,121 @@ struct EngineV2SharedBudgetTests {
         #expect(await budget.outstandingReservedBytes() == 0)
     }
 
+    @Test("native rate is reserved on cache miss, disabled cache, and staged hit exactly once")
+    func nativeRateCoversEveryCacheStateWithoutDoubleReservation() async throws {
+        let parent = FileManager.default.temporaryDirectory.resolvingSymlinksInPath()
+            .appendingPathComponent("bridge-native-states-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: parent, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: parent) }
+
+        let budget = TestBudgets.ample()
+        let fixture = try await makeBridgeStagedCache(parent: parent, budget: budget)
+        defer { fixture.cache.close() }
+        let engine = ScriptedCBv2Engine(script: .manual)
+        let nativeRate = 4_000
+        let requestBytes = UInt64(nativeRate * (fixture.prompt.count + 1))
+        let bridge = makeBridge(
+            engine: engine,
+            kvBytesPerToken: nativeRate,
+            kvBudget: budget,
+            ssdPrefixCache: fixture.cache)
+
+        let missPrompt = fixture.prompt.map { $0 + 10_000 }
+        let miss = await bridge.submitTokenized(
+            promptTokens: missPrompt,
+            request: makeRequest(maxTokens: 1),
+            requestId: "req-native-miss",
+            cacheScope: "scope")
+        #expect(fixture.cache.bytesInUse == 0)
+        #expect(await budget.outstandingReservedBytes() == requestBytes)
+        engine.manualContinuation?.yield(.finished(
+            reason: .stop,
+            usage: CBv2Usage(promptTokens: missPrompt.count, completionTokens: 0)))
+        engine.manualContinuation?.finish()
+        _ = await record(miss)
+        #expect(await budget.outstandingReservedBytes() == 0)
+
+        let disabled = await bridge.submitTokenized(
+            promptTokens: fixture.prompt,
+            request: makeRequest(maxTokens: 1),
+            requestId: "req-native-disabled",
+            cacheScope: "scope",
+            cacheEnabled: false)
+        #expect(fixture.cache.bytesInUse == 0)
+        #expect(await budget.outstandingReservedBytes() == requestBytes)
+        engine.manualContinuation?.yield(.finished(
+            reason: .stop,
+            usage: CBv2Usage(promptTokens: fixture.prompt.count, completionTokens: 0)))
+        engine.manualContinuation?.finish()
+        _ = await record(disabled)
+        #expect(await budget.outstandingReservedBytes() == 0)
+
+        let staged = await bridge.submitTokenized(
+            promptTokens: fixture.prompt,
+            request: makeRequest(maxTokens: 1),
+            requestId: "req-native-staged",
+            cacheScope: "scope")
+        let stagedBytes = fixture.cache.bytesInUse
+        #expect(stagedBytes > 0)
+        #expect(
+            await budget.outstandingReservedBytes()
+                == requestBytes + UInt64(stagedBytes),
+            "staging and the native request span are each reserved exactly once")
+        engine.manualContinuation?.yield(.finished(
+            reason: .stop,
+            usage: CBv2Usage(promptTokens: fixture.prompt.count, completionTokens: 0)))
+        engine.manualContinuation?.finish()
+        _ = await record(staged)
+        #expect(await waitForBudgetRelease(budget))
+        #expect(fixture.cache.bytesInUse == 0)
+    }
+
+    @Test("native request byte multiplication overflow rejects before engine submission")
+    func nativeRateOverflowRejectsRequest() async {
+        let engine = ScriptedCBv2Engine(script: .manual)
+        let budget = TestBudgets.ample()
+        let bridge = makeBridge(
+            engine: engine,
+            kvBytesPerToken: Int.max,
+            kvBudget: budget)
+        let (events, _) = await record(await bridge.submitTokenized(
+            promptTokens: [1],
+            request: makeRequest(maxTokens: 1),
+            requestId: "req-native-overflow"))
+        #expect(engine.submitted.isEmpty)
+        #expect(events == [.error(
+            "token_budget_exhausted: request requires 2 tokens "
+                + "but the shared KV budget has no headroom")])
+        #expect(await budget.outstandingReservedBytes() == 0)
+    }
+
+    @Test("prompt plus max-token overflow unwinds staged cache state")
+    func tokenCountOverflowUnwindsStaging() async throws {
+        let parent = FileManager.default.temporaryDirectory.resolvingSymlinksInPath()
+            .appendingPathComponent("bridge-token-overflow-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: parent, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: parent) }
+        let budget = TestBudgets.ample()
+        let fixture = try await makeBridgeStagedCache(parent: parent, budget: budget)
+        defer { fixture.cache.close() }
+        let engine = ScriptedCBv2Engine(script: .manual)
+        let bridge = makeBridge(
+            engine: engine,
+            kvBytesPerToken: 4_000,
+            kvBudget: budget,
+            ssdPrefixCache: fixture.cache)
+
+        let (events, _) = await record(await bridge.submitTokenized(
+            promptTokens: fixture.prompt,
+            request: makeRequest(maxTokens: Int.max),
+            requestId: "req-token-overflow",
+            cacheScope: "scope"))
+        #expect(events == [.error("token_budget_exhausted: request token count overflow")])
+        #expect(engine.submitted.isEmpty)
+        #expect(await waitForBudgetRelease(budget))
+        #expect(fixture.cache.bytesInUse == 0)
+    }
+
     @Test("SSD staging never false-rejects a request that fits cold at the exact boundary")
     func stagingFallsBackToColdReservation() async throws {
         let parent = FileManager.default.temporaryDirectory.resolvingSymlinksInPath()
@@ -1782,16 +1914,17 @@ struct EngineV2SharedBudgetTests {
         #expect(await budget.outstandingReservedBytes() == 0)
     }
 
-    @Test("native-width augmentation refusal rejects before cold over-admission")
+    @Test("native-width rate rejects staged-to-cold fallback before over-admission")
     func nativeWidthRefusalRejectsRequest() async throws {
         let parent = FileManager.default.temporaryDirectory.resolvingSymlinksInPath()
             .appendingPathComponent("bridge-native-width-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: parent, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: parent) }
 
-        let kvBytesPerToken = 1_000_000
+        let nominalKVBytesPerToken = 1_000_000
+        let nativeKVBytesPerToken = nominalKVBytesPerToken + 16
         let worstCaseTokens = 66
-        let nominalBytes = UInt64(kvBytesPerToken * worstCaseTokens)
+        let nominalBytes = UInt64(nominalKVBytesPerToken * worstCaseTokens)
         let gib: UInt64 = 1_073_741_824
         let budget = GlobalKVCacheBudget(
             capFraction: 1.0,
@@ -1803,16 +1936,13 @@ struct EngineV2SharedBudgetTests {
                     cache: 0,
                     systemAvailable: nominalBytes)
             })
-        let fixture = try await makeBridgeStagedCache(
-            parent: parent,
-            budget: budget,
-            nominalFullKVBytesPerToken: 0)
+        let fixture = try await makeBridgeStagedCache(parent: parent, budget: budget)
         defer { fixture.cache.close() }
         let engine = ScriptedCBv2Engine(script: .manual)
         let telemetry = TelemetrySink()
         let bridge = makeBridge(
             engine: engine,
-            kvBytesPerToken: kvBytesPerToken,
+            kvBytesPerToken: nativeKVBytesPerToken,
             kvBudget: budget,
             ssdPrefixCache: fixture.cache,
             telemetry: telemetry)
@@ -1829,7 +1959,7 @@ struct EngineV2SharedBudgetTests {
         #expect(fixture.cache.bytesInUse == 0)
         #expect(await budget.outstandingReservedBytes() == 0)
         #expect(telemetry.events.contains {
-            $0.fields?["reason"]?.description == "native_kv_capacity"
+            $0.fields?["reason"]?.description == "shared_kv_capacity"
                 && $0.fields?["prefix_capacity_refusal"]?.description == "true"
         })
     }

--- a/provider-swift/Tests/ProviderCoreTests/EngineV2BridgeTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/EngineV2BridgeTests.swift
@@ -1832,8 +1832,8 @@ struct EngineV2SharedBudgetTests {
         #expect(await budget.outstandingReservedBytes() == 0)
     }
 
-    @Test("prompt plus max-token overflow unwinds staged cache state")
-    func tokenCountOverflowUnwindsStaging() async throws {
+    @Test("prompt plus max-token overflow rejects before cache staging")
+    func tokenCountOverflowRejectsBeforeStaging() async throws {
         let parent = FileManager.default.temporaryDirectory.resolvingSymlinksInPath()
             .appendingPathComponent("bridge-token-overflow-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: parent, withIntermediateDirectories: true)
@@ -1855,6 +1855,7 @@ struct EngineV2SharedBudgetTests {
             cacheScope: "scope"))
         #expect(events == [.error("token_budget_exhausted: request token count overflow")])
         #expect(engine.submitted.isEmpty)
+        #expect(fixture.cache.stats().stages == 0)
         #expect(await waitForBudgetRelease(budget))
         #expect(fixture.cache.bytesInUse == 0)
     }

--- a/provider-swift/Tests/ProviderCoreTests/EngineV2KVBackendGateTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/EngineV2KVBackendGateTests.swift
@@ -10,6 +10,7 @@
 // These tests CONSTRUCT engines (paged construction materializes its slab
 // pool — a small Metal eval), but never run a forward pass.
 
+import CryptoKit
 import Foundation
 import MLX
 import MLXLLM
@@ -66,6 +67,30 @@ private func tinyGemma4Text() throws -> Gemma4TextModel {
         "use_double_wide_mlp": false,
     ])
     return Gemma4TextModel(config)
+}
+
+private struct GateProcessorError: Error {}
+
+private struct GateProcessor: UserInputProcessor {
+    func prepare(input: UserInput) async throws -> LMInput {
+        throw GateProcessorError()
+    }
+}
+
+private final class GateCacheCapture: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _cache: SSDPrefixCache?
+    private var _capability: CBv2PrefixReuseCapability?
+
+    func set(cache: SSDPrefixCache, capability: CBv2PrefixReuseCapability) {
+        lock.withLock {
+            _cache = cache
+            _capability = capability
+        }
+    }
+
+    var cache: SSDPrefixCache? { lock.withLock { _cache } }
+    var capability: CBv2PrefixReuseCapability? { lock.withLock { _capability } }
 }
 
 private let gateTestCapacity = 8 << 20  // 8 MiB pool — tiny but constructible
@@ -174,5 +199,241 @@ struct EngineV2KVBackendGateTests {
         #expect(build.kvBackendKind == .contiguous)
         #expect(build.kvBackendFallbackReason?.hasPrefix("kernel_preflight:") == true)
         await build.engine.shutdown()
+    }
+
+    @Test("explicit paged fallback constructs frozen-full cache for resolved contiguous backend")
+    func pagedFallbackConstructsFrozenCache() async throws {
+        struct PreflightFailure: Error {}
+        let model = try tinyGemma4Text()
+        let prepared = try EngineV2Factory.prepareProductionBackend(
+            model: model,
+            kvBytesCapacity: gateTestCapacity,
+            maxConcurrentRequests: 2,
+            kvBackend: .paged,
+            maxContextLength: 2048,
+            environment: [:],
+            pagedPreflightOverride: { _ in throw PreflightFailure() })
+        #expect(prepared.kind == .contiguous)
+        #expect(prepared.fallbackReason?.hasPrefix("kernel_preflight:") == true)
+
+        let capability = PrefixCachePolicy.prefixReuseCapability(
+            layerKinds: prepared.layerKinds,
+            backendSelection: .contiguous)
+        #expect(capability.strategy == .frozenFullReplay)
+        #expect(capability.isSupported)
+
+        let capacityFallback = try EngineV2Factory.prepareProductionBackend(
+            model: model,
+            kvBytesCapacity: 1_024,
+            maxConcurrentRequests: 2,
+            kvBackend: .paged,
+            maxContextLength: 2048,
+            environment: [:],
+            pagedPreflightOverride: { _ in })
+        #expect(capacityFallback.kind == .contiguous)
+        #expect(capacityFallback.fallbackReason?.hasPrefix("physical_capacity:") == true)
+        #expect(PrefixCachePolicy.prefixReuseCapability(
+            layerKinds: capacityFallback.layerKinds,
+            backendSelection: .contiguous
+        ).strategy == .frozenFullReplay)
+
+        let root = FileManager.default.temporaryDirectory.resolvingSymlinksInPath()
+            .appendingPathComponent("paged-fallback-cache-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let cache = SSDPrefixCache(
+            config: .init(
+                modelId: "tiny-gemma-paged-fallback",
+                promptContractID: "tiny-gemma-contract",
+                weightHash: "tiny-gemma-weights",
+                blockSize: PrefixCachePolicy.blockSize,
+                adoptionBoundTokens: capability.conservativeReplayBoundTokens,
+                nominalFullKVBytesPerToken: capability.fullKVBytesPerToken,
+                layoutEpoch: SSDBlockStore.layoutEpoch(
+                    blockSize: PrefixCachePolicy.blockSize,
+                    layerKinds: prepared.layerKinds),
+                root: root,
+                ttlSeconds: 900,
+                minEffectiveTokens: 1,
+                maxStageBytes: 1 << 20,
+                maxStageMillis: 1_000,
+                nowSeconds: { 1_000 }),
+            kekKey: SymmetricKey(size: .bits256),
+            kvBudget: nil,
+            diskBudget: SSDDiskBudget(),
+            maxWriteBytesPerDay: 0,
+            strictFsync: false,
+            diskBudgetBytes: { 1 << 20 })
+        defer { cache.close() }
+
+        let build = try EngineV2Factory.assembleProductionBuild(
+            model: model,
+            tokenizer: StubBridgeTokenizer(),
+            prefixCache: cache,
+            maxConcurrentRequests: 2,
+            mtpDrafter: nil,
+            mtpConfig: CBv2MTPConfig(),
+            preparedBackend: prepared)
+        #expect(build.kvBackendKind == .contiguous)
+        let engine = try #require(build.engine as? EngineV2)
+        #expect(engine.prefixReuseCapability.strategy == .frozenFullReplay)
+        #expect(throws: CBv2KVError.self) {
+            _ = try EngineV2Factory.assembleProductionBuild(
+                model: model,
+                tokenizer: StubBridgeTokenizer(),
+                prefixCache: cache,
+                maxConcurrentRequests: 2,
+                mtpDrafter: nil,
+                mtpConfig: CBv2MTPConfig(),
+                preparedBackend: prepared)
+        }
+        await build.engine.shutdown()
+    }
+
+    @Test("slot factory resolves paged fallback before constructing frozen cache")
+    func slotFactoryOrdersResolvedBackendBeforeCache() async throws {
+        struct PreflightFailure: Error {}
+        let model = try tinyGemma4Text()
+        let tokenizer = StubBridgeTokenizer()
+        let container = ModelContainer(
+            context: ModelContext(
+                configuration: ModelConfiguration(id: "tiny/gemma"),
+                model: model,
+                processor: GateProcessor(),
+                tokenizer: tokenizer))
+        let preparedModel = EngineV2PreparedModel(
+            snapshot: EngineV2ModelSnapshot(
+                model: model,
+                eosTokenIds: [1],
+                extraEOSTokens: []),
+            servingModel: model,
+            assistant: nil,
+            mtpStatus: .disabled(.configDisabled, configured: false),
+            mtpArtifact: nil)
+        let root = FileManager.default.temporaryDirectory.resolvingSymlinksInPath()
+            .appendingPathComponent("slot-fallback-cache-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let capture = GateCacheCapture()
+
+        let bundle = try await EngineV2SlotFactory.makeProductionBundle(
+            modelId: "tiny-gemma",
+            modelType: "gemma4_text",
+            isVLM: false,
+            modelDirectory: nil,
+            container: container,
+            tokenizer: TokenizerHandle(tokenizer),
+            sizing: SlotSizingSnapshot(
+                weightsBytes: 1,
+                fp16KVBytesPerToken: 1_024,
+                maxContextLength: 2_048,
+                defaultMaxTokens: 32),
+            kvBytesCapacity: gateTestCapacity,
+            maxConcurrentRequests: 2,
+            kvBudget: nil,
+            kvQuantConfigured: false,
+            kvBackendConfig: "paged",
+            weightHash: String(repeating: "a", count: 64),
+            specDecPreparation: SpecDecPreparation(
+                artifact: nil,
+                status: .disabled(.configDisabled, configured: false)),
+            preparedModel: preparedModel,
+            assemblyOverrides: .init(
+                promptContractID: "tiny-gemma-contract",
+                pagedPreflight: { _ in throw PreflightFailure() },
+                makePrefixCache: { layerKinds, capability in
+                    let cache = SSDPrefixCache(
+                        config: .init(
+                            modelId: "tiny-gemma",
+                            promptContractID: "tiny-gemma-contract",
+                            weightHash: String(repeating: "a", count: 64),
+                            blockSize: PrefixCachePolicy.blockSize,
+                            adoptionBoundTokens: capability.conservativeReplayBoundTokens,
+                            nominalFullKVBytesPerToken: capability.fullKVBytesPerToken,
+                            layoutEpoch: SSDBlockStore.layoutEpoch(
+                                blockSize: PrefixCachePolicy.blockSize,
+                                layerKinds: layerKinds),
+                            root: root,
+                            ttlSeconds: 900,
+                            minEffectiveTokens: 1,
+                            maxStageBytes: 1 << 20,
+                            maxStageMillis: 1_000,
+                            nowSeconds: { 1_000 }),
+                        kekKey: SymmetricKey(size: .bits256),
+                        kvBudget: nil,
+                        diskBudget: SSDDiskBudget(),
+                        maxWriteBytesPerDay: 0,
+                        strictFsync: false,
+                        diskBudgetBytes: { 1 << 20 })
+                    capture.set(cache: cache, capability: capability)
+                    return cache
+                }),
+            environment: [:])
+        let cache = try #require(capture.cache)
+        let backendKind = await bundle.bridge.kvBackendKind
+        #expect(backendKind == .contiguous)
+        #expect(bundle.bridge.ssdPrefixCache === cache)
+        #expect(capture.capability?.strategy == .frozenFullReplay)
+        #expect(capture.capability?.backend == .contiguousUnquantized)
+        await bundle.bridge.shutdown()
+    }
+
+    @Test("slot factory publishes GPT-OSS native contiguous rate without SSD staging")
+    func slotFactoryPublishesNativeGPTOSSRate() async throws {
+        let model = try tinyGPTOSS()
+        let tokenizer = StubBridgeTokenizer()
+        let container = ModelContainer(
+            context: ModelContext(
+                configuration: ModelConfiguration(id: "tiny/gpt-oss"),
+                model: model,
+                processor: GateProcessor(),
+                tokenizer: tokenizer))
+        let preparedModel = EngineV2PreparedModel(
+            snapshot: EngineV2ModelSnapshot(
+                model: model,
+                eosTokenIds: [1],
+                extraEOSTokens: []),
+            servingModel: model,
+            assistant: nil,
+            mtpStatus: .disabled(.configDisabled, configured: false),
+            mtpArtifact: nil)
+        let nominalRate = 100_000
+        let expectedRate =
+            nominalRate
+            + CBv2PrefixReuseCapability.derive(
+                layerKinds: model.cbv2LayerKinds,
+                backend: .contiguousUnquantized
+            ).fullKVBytesPerToken
+
+        let bundle = try await EngineV2SlotFactory.makeProductionBundle(
+            modelId: "tiny-gpt-oss",
+            modelType: "gpt_oss",
+            isVLM: false,
+            modelDirectory: nil,
+            container: container,
+            tokenizer: TokenizerHandle(tokenizer),
+            sizing: SlotSizingSnapshot(
+                weightsBytes: 1,
+                fp16KVBytesPerToken: nominalRate,
+                maxContextLength: 2_048,
+                defaultMaxTokens: 32),
+            kvBytesCapacity: gateTestCapacity,
+            maxConcurrentRequests: 2,
+            kvBudget: nil,
+            kvQuantConfigured: false,
+            kvBackendConfig: "contiguous",
+            weightHash: String(repeating: "b", count: 64),
+            specDecPreparation: SpecDecPreparation(
+                artifact: nil,
+                status: .disabled(.configDisabled, configured: false)),
+            preparedModel: preparedModel,
+            environment: [PrefixCachePolicy.environmentFlag: "0"])
+        let backendKind = await bundle.bridge.kvBackendKind
+        let nativeRate = await bundle.bridge.kvBytesPerToken
+        let heartbeat = await bundle.bridge.backendSlotCapacity()
+        #expect(backendKind == .contiguous)
+        #expect(nativeRate == expectedRate)
+        #expect(heartbeat.kvBytesPerToken == Int64(expectedRate))
+        await bundle.bridge.shutdown()
     }
 }

--- a/provider-swift/Tests/ProviderCoreTests/EngineV2PrefixCacheWiringTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/EngineV2PrefixCacheWiringTests.swift
@@ -81,20 +81,23 @@ private final class PrefixTelemetryCapture: @unchecked Sendable {
 @Suite("EngineV2 prefix cache: usage detail")
 struct EngineV2PrefixCacheUsageTests {
 
-    @Test("native full-row delta covers the complete request span")
-    func nativeReservationDelta() {
-        #expect(EngineV2Bridge.nativeFullReservationDelta(
-            stagedBytes: 49_152 * 2_816,
-            stagedTokens: 2_816,
-            nominalBytesPerToken: 24_576,
-            worstCaseTokens: 2_817 + 4_096
-        ) == UInt64(24_576 * (2_817 + 4_096)))
-        #expect(EngineV2Bridge.nativeFullReservationDelta(
-            stagedBytes: 10,
-            stagedTokens: 3,
-            nominalBytesPerToken: 1,
-            worstCaseTokens: 10
-        ) == nil)
+    @Test("native contiguous rate includes fp32 owning-full rows without staging")
+    func nativeReservationRate() {
+        #expect(EngineV2Factory.nativeKVBytesPerToken(
+            nominalFP16BytesPerToken: 100_000,
+            fp16FullKVBytesPerToken: 24_576,
+            fullRowsUseFP32: true
+        ) == 124_576)
+        #expect(EngineV2Factory.nativeKVBytesPerToken(
+            nominalFP16BytesPerToken: 100_000,
+            fp16FullKVBytesPerToken: 24_576,
+            fullRowsUseFP32: false
+        ) == 100_000)
+        #expect(EngineV2Factory.nativeKVBytesPerToken(
+            nominalFP16BytesPerToken: Int.max,
+            fp16FullKVBytesPerToken: 1,
+            fullRowsUseFP32: true
+        ) == Int.max)
     }
 
     @Test("bridge records prefixCacheHitTokens into the per-request signal at the terminal")

--- a/provider-swift/Tests/ProviderCoreTests/EngineV2PrefixCacheWiringTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/EngineV2PrefixCacheWiringTests.swift
@@ -65,8 +65,37 @@ private struct PrefixStubTokenizer: MLXLMCommon.Tokenizer {
     }
 }
 
+private final class PrefixTelemetryCapture: @unchecked Sendable {
+    private let lock = NSLock()
+    private var events: [TelemetryEvent] = []
+
+    func append(_ event: TelemetryEvent) {
+        lock.withLock { events.append(event) }
+    }
+
+    var snapshot: [TelemetryEvent] {
+        lock.withLock { events }
+    }
+}
+
 @Suite("EngineV2 prefix cache: usage detail")
 struct EngineV2PrefixCacheUsageTests {
+
+    @Test("native full-row delta covers the complete request span")
+    func nativeReservationDelta() {
+        #expect(EngineV2Bridge.nativeFullReservationDelta(
+            stagedBytes: 49_152 * 2_816,
+            stagedTokens: 2_816,
+            nominalBytesPerToken: 24_576,
+            worstCaseTokens: 2_817 + 4_096
+        ) == UInt64(24_576 * (2_817 + 4_096)))
+        #expect(EngineV2Bridge.nativeFullReservationDelta(
+            stagedBytes: 10,
+            stagedTokens: 3,
+            nominalBytesPerToken: 1,
+            worstCaseTokens: 10
+        ) == nil)
+    }
 
     @Test("bridge records prefixCacheHitTokens into the per-request signal at the terminal")
     func usageSignalRecords() async throws {
@@ -94,6 +123,62 @@ struct EngineV2PrefixCacheUsageTests {
         for await _ in stream {}
 
         #expect(signal.prefixCacheHitTokens == 256)
+    }
+
+    @Test("bridge emits content-free frozen replay plan telemetry")
+    func frozenReplayTelemetry() async throws {
+        let engine = PrefixScriptedEngine(events: [
+            .finished(
+                reason: .stop,
+                usage: CBv2Usage(
+                    promptTokens: 2817,
+                    completionTokens: 1,
+                    prefixCacheHitTokens: 1280,
+                    prefixCacheOutcome: .hit,
+                    prefixCacheMatchedTokens: 2816,
+                    prefixCachePrefillTokensSaved: 1280,
+                    prefixCacheStrategy: .frozenFullReplay,
+                    prefixCacheReplayTokens: 1536,
+                    prefixCacheBoundarySplits: 1)),
+        ])
+        let capture = PrefixTelemetryCapture()
+        let bridge = EngineV2Bridge(
+            engine: engine,
+            modelId: "gpt-oss-20b",
+            tokenizer: TokenizerHandle(PrefixStubTokenizer()),
+            eosTokenIds: [2],
+            emitTelemetry: { capture.append($0) })
+
+        let stream = await bridge.submitTokenized(
+            promptTokens: Array(repeating: 7, count: 2817),
+            request: ChatCompletionRequest(
+                model: "gpt-oss-20b",
+                messages: [ChatMessage(role: "user", content: "hi")]),
+            requestId: "req-frozen-telemetry")
+        for await _ in stream {}
+
+        let replay = try #require(capture.snapshot.first {
+            $0.fields?["operation"]?.description == "prefix_cache_replay"
+        })
+        #expect(replay.fields?["prefix_reuse_strategy"]?.description == "frozen_full_replay")
+        #expect(replay.fields?["prefix_matched_tokens"]?.description == "2816")
+        #expect(replay.fields?["prefix_replay_tokens"]?.description == "1536")
+        #expect(replay.fields?["prefix_saved_tokens"]?.description == "1280")
+        #expect(replay.fields?["prefix_boundary_splits"]?.description == "1")
+        #expect(replay.fields?["prefix_capacity_refusal"]?.description == "false")
+        #expect(replay.fields?["prefix_cold_fallback"]?.description == "false")
+        #expect(replay.fields?.keys.contains("request_id") != true)
+
+        await bridge.emitPrefixCacheColdFallback(
+            requestId: "req-capacity",
+            reason: "stage_capacity",
+            capacityRefusal: true)
+        let fallback = try #require(capture.snapshot.last {
+            $0.requestId == "req-capacity"
+        })
+        #expect(fallback.fields?["prefix_capacity_refusal"]?.description == "true")
+        #expect(fallback.fields?["prefix_cold_fallback"]?.description == "true")
+        #expect(fallback.fields?["reason"]?.description == "stage_capacity")
     }
 
     @Test("injectCachedTokens: splices prompt_tokens_details into a usage frame")

--- a/provider-swift/Tests/ProviderCoreTests/EngineV2SSDPrefixCacheLiveTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/EngineV2SSDPrefixCacheLiveTests.swift
@@ -154,19 +154,26 @@ struct EngineV2SSDPrefixCacheLiveTests {
         ttlSeconds: Int64 = 900
     ) -> SSDPrefixCache {
         let blockSize = PrefixCachePolicy.blockSize
+        let capability = CBv2PrefixReuseCapability.derive(
+            layerKinds: live.layerKinds,
+            backend: .contiguousUnquantized)
         let config = SSDPrefixCache.Config(
             modelId: live.modelID,
-            promptContractID: try! PromptContractIdentity.compute(
-                modelDirectory: live.modelDirectory),
+            // This suite proves cache/engine behavior on real weights. Prompt
+            // artifact readiness has its own production parity suite and may
+            // deliberately be unavailable on a raw upstream HF snapshot.
+            promptContractID: "live-real-weight-cache-contract-v1",
             weightHash: "live-test-weights",
             blockSize: blockSize,
-            adoptionBoundTokens: PrefixCachePolicy.adoptionBoundTokens(
-                layerKinds: live.layerKinds),
+            adoptionBoundTokens: capability.conservativeReplayBoundTokens,
+            nominalFullKVBytesPerToken: capability.fullKVBytesPerToken,
             layoutEpoch: SSDBlockStore.layoutEpoch(
                 blockSize: blockSize, layerKinds: live.layerKinds),
             root: dir,
             ttlSeconds: ttlSeconds,
-            minEffectiveTokens: SSDPrefixCachePolicy.defaultMinEffectiveTokens,
+            minEffectiveTokens: PrefixCachePolicy.minEffectiveTokens(
+                capability: capability,
+                environment: [:]),
             maxStageBytes: SSDPrefixCachePolicy.defaultMaxStageBytes,
             maxStageMillis: 60_000,  // generous: CI boxes vary
             nowSeconds: { clock.now })
@@ -476,7 +483,7 @@ struct EngineV2SSDPrefixCacheLiveTests {
             live: live, dir: dir, kek: SymmetricKey(size: .bits256), clock: clock)
         let bridge = try makeBridge(live, ssdCache: cache)
 
-        // Typical prompt (~1.5k tokens) — WAY under the 26,624-token
+        // Typical prompt (~1.5k tokens) — WAY under the 27,136-token
         // donation floor: the request serves normally and the tier writes
         // NOTHING; the engine keeps its full live KV grant.
         let conversation = try buildConversation(live, minTurn1Tokens: 1500)
@@ -497,7 +504,7 @@ struct EngineV2SSDPrefixCacheLiveTests {
     }
 
     @Test(
-        "gemma-qat, DEFAULT config, long context (>26.6k): tail cached, adopted from disk byte-identically",
+        "gemma-qat, DEFAULT config, long context (>27.1k): tail cached, adopted from disk byte-identically",
         .enabled(if:
             LiveInferenceFixtures.liveTestsEnabled
                 && ProcessInfo.processInfo.environment["DARKBLOOM_LIVE_MLX_GEMMA"] != nil)
@@ -507,14 +514,21 @@ struct EngineV2SSDPrefixCacheLiveTests {
         let blockSize = PrefixCachePolicy.blockSize
         let bound = PrefixCachePolicy.adoptionBoundTokens(layerKinds: live.layerKinds)
         #expect(bound == 25_600)
+        let capability = PrefixCachePolicy.prefixReuseCapability(
+            layerKinds: live.layerKinds,
+            backendSelection: .contiguous)
+        let benefitFloor = PrefixCachePolicy.minEffectiveTokens(
+            capability: capability,
+            environment: [:])
+        #expect(benefitFloor == 1_536)
 
-        // Past the donation floor (bound + 1,024) with whole-block margin.
-        let minTurn1 = bound + SSDPrefixCachePolicy.defaultMinEffectiveTokens + 3 * blockSize
+        // Past the evidence-backed donation floor (bound + 1,536) with margin.
+        let minTurn1 = bound + benefitFloor + 3 * blockSize
         let conversation = try buildConversation(live, minTurn1Tokens: minTurn1)
         #expect(conversation.sharedPrefixTokens >= minTurn1)
         let sharedBlocks = conversation.sharedPrefixTokens / blockSize
         let expectedMinHit = sharedBlocks * blockSize - bound
-        #expect(expectedMinHit >= SSDPrefixCachePolicy.defaultMinEffectiveTokens)
+        #expect(expectedMinHit >= benefitFloor)
         print("[ssd-live] gemma long-context: turn1=\(conversation.turn1Tokens.count) tok, "
             + "shared=\(conversation.sharedPrefixTokens), bound=\(bound), "
             + "expectedMinHit=\(expectedMinHit)")
@@ -546,7 +560,7 @@ struct EngineV2SSDPrefixCacheLiveTests {
         let turn2Warm = try await runTurn(
             bridge: bridge, live: live, promptTokens: conversation.turn2Tokens,
             maxTokens: maxTokens, requestId: "gemma-t2-warm")
-        #expect(turn2Warm.prefixCacheHitTokens >= SSDPrefixCachePolicy.defaultMinEffectiveTokens,
+        #expect(turn2Warm.prefixCacheHitTokens >= benefitFloor,
             "gemma warm turn 2 hit \(turn2Warm.prefixCacheHitTokens) (< 1024)")
         #expect(cache.bytesInUse == 0, "staging must drain after adoption")
         await bridge.shutdown()

--- a/provider-swift/Tests/ProviderCoreTests/FrozenReplayRealModelTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/FrozenReplayRealModelTests.swift
@@ -1,0 +1,533 @@
+import Foundation
+import MLX
+import MLXLLM
+import MLXLMCommon
+import MLXVLM
+import Testing
+
+@testable import ProviderCore
+
+@Suite("Frozen-full replay real-model proof", .serialized)
+struct FrozenReplayRealModelTests {
+    private static let enabled =
+        LiveInferenceFixtures.liveTestsEnabled
+        && ProcessInfo.processInfo.environment["DARKBLOOM_FROZEN_REPLAY_REAL_MODELS"] != nil
+
+    private struct Loaded: @unchecked Sendable {
+        let container: ModelContainer
+        let model: any LanguageModel
+        let layerKinds: [CBv2LayerKind]
+        let vocabularySize: Int
+    }
+
+    private struct State {
+        let backend: CBv2ContiguousKVBackend
+        let rows: [CBv2SequenceKV?]
+    }
+
+    private func loadGPTOSS() async throws -> Loaded {
+        guard LiveInferenceFixtures.ensureMetallibColocated() != nil else {
+            throw LiveFixtureSkip.missingMetallib
+        }
+        let modelID = "mlx-community/gpt-oss-20b-MXFP4-Q8"
+        guard case .found(let directory) = LiveInferenceFixtures.locate(modelID) else {
+            throw LiveFixtureSkip.modelNotInCache(modelID)
+        }
+        LiveInferenceFixtures.applyMemoryBudget(maxBytes: 48 * 1_073_741_824)
+        let container = try await LLMModelFactory.shared.loadContainer(
+            from: directory,
+            using: LocalTokenizerLoader())
+        let snapshot = await container.perform { context in
+            EngineV2ModelSnapshot(
+                model: context.model,
+                eosTokenIds: context.configuration.eosTokenIds,
+                extraEOSTokens: context.configuration.extraEOSTokens.sorted())
+        }
+        let model = try #require(snapshot.model as? GPTOSSModel)
+        return Loaded(
+            container: container,
+            model: model,
+            layerKinds: model.cbv2LayerKinds,
+            vocabularySize: model.vocabularySize)
+    }
+
+    private func loadGemmaQAT() async throws -> Loaded {
+        guard LiveInferenceFixtures.ensureMetallibColocated() != nil else {
+            throw LiveFixtureSkip.missingMetallib
+        }
+        let modelID = "mlx-community/gemma-4-26B-A4B-it-qat-4bit"
+        guard case .found(let directory) = LiveInferenceFixtures.locate(modelID) else {
+            throw LiveFixtureSkip.modelNotInCache(modelID)
+        }
+        LiveInferenceFixtures.applyMemoryBudget(maxBytes: 64 * 1_073_741_824)
+        let container = try await VLMModelFactory.shared.loadContainer(
+            from: directory,
+            using: LocalTokenizerLoader())
+        let snapshot = await container.perform { context in
+            EngineV2ModelSnapshot(
+                model: context.model,
+                eosTokenIds: context.configuration.eosTokenIds,
+                extraEOSTokens: context.configuration.extraEOSTokens.sorted())
+        }
+        let extraction = try EngineV2VLMTextExtraction.extractTextModel(
+            from: snapshot.model,
+            modelDirectory: directory)
+        return Loaded(
+            container: container,
+            model: extraction.model,
+            layerKinds: extraction.model.cbv2LayerKinds,
+            vocabularySize: extraction.model.vocabularySize)
+    }
+
+    private func makeBank(_ loaded: Loaded) -> CBv2LayerCacheBank {
+        switch loaded.model {
+        case let gpt as GPTOSSModel:
+            return CBv2LayerCacheBank(caches: gpt.newCacheV2 { index, kind in
+                CBv2LayerCache(layerIndex: index, kind: kind)
+            })
+        case let gemma as Gemma4TextModel:
+            return CBv2LayerCacheBank(caches: gemma.newCacheV2 { index, kind in
+                CBv2LayerCache(layerIndex: index, kind: kind)
+            })
+        default:
+            preconditionFailure("real frozen-replay proof received unsupported model type")
+        }
+    }
+
+    private func process(
+        loaded: Loaded,
+        state: [CBv2SequenceKV?],
+        tokens: ArraySlice<Int>,
+        chunkSize: Int
+    ) -> MLXArray {
+        let model = CBv2SteppableLanguageModelAdapter(loaded.model)
+        let bank = makeBank(loaded)
+        var logits = MLXArray.zeros([1, 1, loaded.vocabularySize])
+        var cursor = tokens.startIndex
+        while cursor < tokens.endIndex {
+            let count = min(chunkSize, tokens.endIndex - cursor)
+            logits = model.forward(
+                tokens: MLXArray(tokens[cursor ..< cursor + count].map(Int32.init))
+                    .reshaped(1, count),
+                caches: bank.layerCaches(rowStates: [state]))
+            eval(logits)
+            cursor += count
+        }
+        return logits
+    }
+
+    private func coldState(
+        loaded: Loaded,
+        promptLength: Int,
+        maxLength: Int,
+        capacityBytes: Int
+    ) throws -> State {
+        let backend = CBv2ContiguousKVBackend(
+            config: .init(bytesCapacity: capacityBytes))
+        return State(
+            backend: backend,
+            rows: try backend.makeSequenceState(
+                layerKinds: loaded.layerKinds,
+                promptLength: promptLength,
+                maxLength: maxLength))
+    }
+
+    private func frozenState(
+        loaded: Loaded,
+        donor: [CBv2SequenceKV?],
+        matched: Int,
+        maxLength: Int,
+        capacityBytes: Int
+    ) throws -> (state: State, plan: CBv2PrefixReusePlan) {
+        let capability = CBv2PrefixReuseCapability.derive(
+            layerKinds: loaded.layerKinds,
+            backend: .contiguousUnquantized)
+        let prefix = zip(loaded.layerKinds, donor).map {
+            kind, row -> (keys: MLXArray, values: MLXArray, offset: Int)? in
+            guard kind.sharesKVWithLayer == nil,
+                case .full = kind.attention,
+                let snapshot = row?.snapshot()
+            else { return nil }
+            return (
+                snapshot.keys[.ellipsis, 0 ..< matched, 0...],
+                snapshot.values[.ellipsis, 0 ..< matched, 0...],
+                matched)
+        }
+        let exactBytes = prefix.compactMap { $0 }.reduce(0) {
+            $0 + $1.keys.nbytes + $1.values.nbytes
+        }
+        let plan = try #require(
+            capability.plan(
+                matchedBoundary: matched,
+                exactStagedFullKVBytes: exactBytes,
+                maximumSequenceLength: maxLength))
+        let backend = CBv2ContiguousKVBackend(
+            config: .init(bytesCapacity: capacityBytes))
+        return (
+            State(
+                backend: backend,
+                rows: try backend.makeSequenceState(
+                    adopting: prefix,
+                    plan: plan,
+                    layerKinds: loaded.layerKinds,
+                    maxLength: maxLength)),
+            plan)
+    }
+
+    private func oldMutatingState(
+        loaded: Loaded,
+        donor: [CBv2SequenceKV?],
+        replayStart: Int,
+        maxLength: Int
+    ) throws -> [CBv2SequenceKV?] {
+        try zip(loaded.layerKinds, donor).map { kind, row in
+            guard kind.sharesKVWithLayer == nil else { return nil }
+            switch kind.attention {
+            case .slidingWindow(let window):
+                return CBv2WindowedSequenceKV(
+                    window: window,
+                    kvHeads: kind.kvHeads,
+                    headDim: kind.headDim,
+                    initialOffset: replayStart)
+            case .full:
+                let snapshot = try #require(row?.snapshot())
+                let resumed = CBv2FullSequenceKV(
+                    promptLength: replayStart,
+                    maxLength: maxLength,
+                    kvHeads: kind.kvHeads,
+                    headDim: kind.headDim)
+                _ = resumed.update(
+                    keys: snapshot.keys[.ellipsis, 0 ..< replayStart, 0...],
+                    values: snapshot.values[.ellipsis, 0 ..< replayStart, 0...])
+                return resumed
+            }
+        }
+    }
+
+    private func maxAbsDiff(_ lhs: MLXArray, _ rhs: MLXArray) -> Float {
+        eval(lhs, rhs)
+        return abs(lhs - rhs).max().item(Float.self)
+    }
+
+    private func greedyToken(_ logits: MLXArray) -> Int {
+        logits[0, -1].argMax().item(Int.self)
+    }
+
+    private func assertFullKVBitExact(
+        loaded: Loaded,
+        lhs: [CBv2SequenceKV?],
+        rhs: [CBv2SequenceKV?]
+    ) throws {
+        for (index, kind) in loaded.layerKinds.enumerated()
+        where kind.sharesKVWithLayer == nil {
+            guard case .full = kind.attention else { continue }
+            let left = try #require(lhs[index]?.snapshot())
+            let right = try #require(rhs[index]?.snapshot())
+            #expect(left.offset == right.offset)
+            #expect(maxAbsDiff(left.keys, right.keys) == 0)
+            #expect(maxAbsDiff(left.values, right.values) == 0)
+        }
+    }
+
+    private func assertGreedyContinuationBitExact(
+        loaded: Loaded,
+        cold: State,
+        frozen: State,
+        coldLogits initialCold: MLXArray,
+        frozenLogits initialFrozen: MLXArray,
+        count: Int
+    ) {
+        var coldLogits = initialCold
+        var frozenLogits = initialFrozen
+        var coldTokens: [Int] = []
+        var frozenTokens: [Int] = []
+        for _ in 0 ..< count {
+            let coldToken = greedyToken(coldLogits)
+            let frozenToken = greedyToken(frozenLogits)
+            coldTokens.append(coldToken)
+            frozenTokens.append(frozenToken)
+            #expect(coldToken == frozenToken)
+            coldLogits = process(
+                loaded: loaded,
+                state: cold.rows,
+                tokens: [coldToken][...],
+                chunkSize: 1)
+            frozenLogits = process(
+                loaded: loaded,
+                state: frozen.rows,
+                tokens: [frozenToken][...],
+                chunkSize: 1)
+            #expect(maxAbsDiff(coldLogits, frozenLogits) == 0)
+        }
+        #expect(coldTokens == frozenTokens)
+    }
+
+    @Test(
+        "real GPT-OSS 2,817-token counterexample: old drift 0.20875001, frozen logits/KV/tokens exact",
+        .enabled(if: Self.enabled))
+    func realGPTOSSCounterexample() async throws {
+        let loaded = try await loadGPTOSS()
+        let promptLength = 2_817
+        let prompt = (0 ..< promptLength).map {
+            1_000 + ($0 * 7_919) % 50_000
+        }
+        let matched = 2_816
+        let maxLength = promptLength + 128
+        let cold = try coldState(
+            loaded: loaded,
+            promptLength: promptLength,
+            maxLength: maxLength,
+            capacityBytes: 2 << 30)
+        let coldStarted = CFAbsoluteTimeGetCurrent()
+        var coldLogits = process(
+            loaded: loaded,
+            state: cold.rows,
+            tokens: prompt[...],
+            chunkSize: 128)
+        let coldSeconds = CFAbsoluteTimeGetCurrent() - coldStarted
+        let (frozen, plan) = try frozenState(
+            loaded: loaded,
+            donor: cold.rows,
+            matched: matched,
+            maxLength: maxLength,
+            capacityBytes: 2 << 30)
+        #expect(plan.replayTokens == 1_536)
+        #expect(plan.replayStart == 1_280)
+        let frozenStarted = CFAbsoluteTimeGetCurrent()
+        var frozenLogits = process(
+            loaded: loaded,
+            state: frozen.rows,
+            tokens: prompt[plan.replayStart...],
+            chunkSize: 128)
+        let frozenSeconds = CFAbsoluteTimeGetCurrent() - frozenStarted
+
+        let oldRows = try oldMutatingState(
+            loaded: loaded,
+            donor: cold.rows,
+            replayStart: plan.replayStart,
+            maxLength: maxLength)
+        let oldLogits = process(
+            loaded: loaded,
+            state: oldRows,
+            tokens: prompt[plan.replayStart...],
+            chunkSize: 128)
+        let oldDrift = maxAbsDiff(coldLogits, oldLogits)
+        let firstFullIndex = try #require(loaded.layerKinds.firstIndex { kind in
+            guard kind.sharesKVWithLayer == nil else { return false }
+            if case .full = kind.attention { return true }
+            return false
+        })
+        let firstFull = try #require(cold.rows[firstFullIndex]?.snapshot())
+        print(
+            "[frozen-real-gptoss] prompt=\(promptLength) M=\(matched) "
+                + "R=\(plan.replayTokens) saved=\(plan.prefillTokensSaved) "
+                + "cold_s=\(coldSeconds) frozen_replay_s=\(frozenSeconds) "
+                + "old_max_abs=\(oldDrift) frozen_max_abs="
+                + "\(maxAbsDiff(coldLogits, frozenLogits)) "
+                + "full_k_dtype=\(firstFull.keys.dtype) "
+                + "full_v_dtype=\(firstFull.values.dtype) "
+                + "exact_full_bytes_per_token=\(plan.fullKVBytesPerToken)")
+        #expect(abs(oldDrift - 0.20875001) < 0.00001)
+        #expect(maxAbsDiff(coldLogits, frozenLogits) == 0)
+        #expect(frozenSeconds < coldSeconds)
+        try assertFullKVBitExact(
+            loaded: loaded,
+            lhs: cold.rows,
+            rhs: frozen.rows)
+
+        for _ in 0 ..< 64 {
+            let coldToken = greedyToken(coldLogits)
+            let frozenToken = greedyToken(frozenLogits)
+            #expect(coldToken == frozenToken)
+            coldLogits = process(
+                loaded: loaded,
+                state: cold.rows,
+                tokens: [coldToken][...],
+                chunkSize: 1)
+            frozenLogits = process(
+                loaded: loaded,
+                state: frozen.rows,
+                tokens: [frozenToken][...],
+                chunkSize: 1)
+            #expect(maxAbsDiff(coldLogits, frozenLogits) == 0)
+        }
+
+        cold.backend.release(cold.rows)
+        frozen.backend.release(frozen.rows)
+        #expect(cold.backend.bytesReserved == 0)
+        #expect(frozen.backend.bytesReserved == 0)
+        MLX.Memory.clearCache()
+        _ = loaded.container
+    }
+
+    @Test(
+        "real GPT-OSS 4k/8k benefit curve remains raw-logit exact",
+        .enabled(if: Self.enabled))
+    func realGPTOSSBenefitCurve() async throws {
+        let loaded = try await loadGPTOSS()
+        for promptLength in [4_097, 8_193] {
+            let prompt = (0 ..< promptLength).map {
+                1_000 + ($0 * 7_919) % 50_000
+            }
+            let matched = ((promptLength - 1) / 256) * 256
+            let maxLength = promptLength + 32
+            let cold = try coldState(
+                loaded: loaded,
+                promptLength: promptLength,
+                maxLength: maxLength,
+                capacityBytes: 4 << 30)
+            let coldStarted = CFAbsoluteTimeGetCurrent()
+            let coldLogits = process(
+                loaded: loaded,
+                state: cold.rows,
+                tokens: prompt[...],
+                chunkSize: 128)
+            let coldSeconds = CFAbsoluteTimeGetCurrent() - coldStarted
+            let (frozen, plan) = try frozenState(
+                loaded: loaded,
+                donor: cold.rows,
+                matched: matched,
+                maxLength: maxLength,
+                capacityBytes: 4 << 30)
+            let frozenStarted = CFAbsoluteTimeGetCurrent()
+            let frozenLogits = process(
+                loaded: loaded,
+                state: frozen.rows,
+                tokens: prompt[plan.replayStart...],
+                chunkSize: 128)
+            let frozenSeconds = CFAbsoluteTimeGetCurrent() - frozenStarted
+            #expect(maxAbsDiff(coldLogits, frozenLogits) == 0)
+            #expect(frozenSeconds <= coldSeconds * 0.8)
+            print(
+                "[frozen-real-gptoss-curve] prompt=\(promptLength) M=\(matched) "
+                    + "R=\(plan.replayTokens) saved=\(plan.prefillTokensSaved) "
+                    + "cold_s=\(coldSeconds) frozen_replay_s=\(frozenSeconds)")
+            cold.backend.release(cold.rows)
+            frozen.backend.release(frozen.rows)
+            #expect(cold.backend.bytesReserved == 0)
+            #expect(frozen.backend.bytesReserved == 0)
+            MLX.Memory.clearCache()
+        }
+        _ = loaded.container
+    }
+
+    @Test(
+        "real Gemma QAT: raw logits and 128 greedy tokens exact across long prompts",
+        .enabled(if: Self.enabled))
+    func realGemmaQATLongContexts() async throws {
+        let loaded = try await loadGemmaQAT()
+        let capacityBytes = 8 << 30
+        for promptLength in [26_625, 26_881, 27_137] {
+            let prompt = (0 ..< promptLength).map {
+                1_000 + ($0 * 7_919) % max(2, loaded.vocabularySize - 1_000)
+            }
+            let matched = ((promptLength - 1) / 256) * 256
+            let maxLength = promptLength + 160
+            let cold = try coldState(
+                loaded: loaded,
+                promptLength: promptLength,
+                maxLength: maxLength,
+                capacityBytes: capacityBytes)
+            let coldStarted = CFAbsoluteTimeGetCurrent()
+            let coldLogits = process(
+                loaded: loaded,
+                state: cold.rows,
+                tokens: prompt[...],
+                chunkSize: 256)
+            let coldSeconds = CFAbsoluteTimeGetCurrent() - coldStarted
+            let (frozen, plan) = try frozenState(
+                loaded: loaded,
+                donor: cold.rows,
+                matched: matched,
+                maxLength: maxLength,
+                capacityBytes: capacityBytes)
+            #expect(plan.strategy == .frozenFullReplay)
+            #expect(plan.replayTokens == 25_600)
+            #expect(plan.replayStart == matched - 25_600)
+            let frozenStarted = CFAbsoluteTimeGetCurrent()
+            let frozenLogits = process(
+                loaded: loaded,
+                state: frozen.rows,
+                tokens: prompt[plan.replayStart...],
+                chunkSize: 256)
+            let frozenSeconds = CFAbsoluteTimeGetCurrent() - frozenStarted
+            print(
+                "[frozen-real-gemma] prompt=\(promptLength) M=\(matched) "
+                    + "R=\(plan.replayTokens) saved=\(plan.prefillTokensSaved) "
+                    + "cold_s=\(coldSeconds) frozen_replay_s=\(frozenSeconds) "
+                    + "frozen_max_abs=\(maxAbsDiff(coldLogits, frozenLogits))")
+            #expect(maxAbsDiff(coldLogits, frozenLogits) == 0)
+            try assertFullKVBitExact(
+                loaded: loaded,
+                lhs: cold.rows,
+                rhs: frozen.rows)
+            assertGreedyContinuationBitExact(
+                loaded: loaded,
+                cold: cold,
+                frozen: frozen,
+                coldLogits: coldLogits,
+                frozenLogits: frozenLogits,
+                count: 128)
+
+            cold.backend.release(cold.rows)
+            frozen.backend.release(frozen.rows)
+            #expect(cold.backend.bytesReserved == 0)
+            #expect(frozen.backend.bytesReserved == 0)
+            MLX.Memory.clearCache()
+        }
+        _ = loaded.container
+    }
+
+    @Test(
+        "real Gemma QAT 32k benefit point remains raw-logit exact",
+        .enabled(if: Self.enabled))
+    func realGemmaQAT32KBenefit() async throws {
+        let loaded = try await loadGemmaQAT()
+        let promptLength = 32_769
+        let prompt = (0 ..< promptLength).map {
+            1_000 + ($0 * 7_919) % max(2, loaded.vocabularySize - 1_000)
+        }
+        let matched = 32_768
+        let maxLength = promptLength + 32
+        let capacityBytes = 8 << 30
+        let cold = try coldState(
+            loaded: loaded,
+            promptLength: promptLength,
+            maxLength: maxLength,
+            capacityBytes: capacityBytes)
+        let coldStarted = CFAbsoluteTimeGetCurrent()
+        let coldLogits = process(
+            loaded: loaded,
+            state: cold.rows,
+            tokens: prompt[...],
+            chunkSize: 256)
+        let coldSeconds = CFAbsoluteTimeGetCurrent() - coldStarted
+        let (frozen, plan) = try frozenState(
+            loaded: loaded,
+            donor: cold.rows,
+            matched: matched,
+            maxLength: maxLength,
+            capacityBytes: capacityBytes)
+        let frozenStarted = CFAbsoluteTimeGetCurrent()
+        let frozenLogits = process(
+            loaded: loaded,
+            state: frozen.rows,
+            tokens: prompt[plan.replayStart...],
+            chunkSize: 256)
+        let frozenSeconds = CFAbsoluteTimeGetCurrent() - frozenStarted
+        #expect(plan.replayTokens == 25_600)
+        #expect(plan.prefillTokensSaved == 7_168)
+        #expect(maxAbsDiff(coldLogits, frozenLogits) == 0)
+        #expect(frozenSeconds <= coldSeconds * 0.85)
+        print(
+            "[frozen-real-gemma-curve] prompt=\(promptLength) M=\(matched) "
+                + "R=\(plan.replayTokens) saved=\(plan.prefillTokensSaved) "
+                + "cold_s=\(coldSeconds) frozen_replay_s=\(frozenSeconds)")
+        cold.backend.release(cold.rows)
+        frozen.backend.release(frozen.rows)
+        #expect(cold.backend.bytesReserved == 0)
+        #expect(frozen.backend.bytesReserved == 0)
+        MLX.Memory.clearCache()
+        _ = loaded.container
+    }
+}

--- a/provider-swift/Tests/ProviderCoreTests/GlobalKVCacheBudgetTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/GlobalKVCacheBudgetTests.swift
@@ -37,7 +37,7 @@ private let gib: UInt64 = 1024 * 1024 * 1024
     #expect(!(await budget.reserve(requestID: "overflow", kvBytesPerToken: Int.max, tokenCount: Int.max)))
 }
 
-@Test func globalKVCacheBudgetGrowsAndReconcilesNativeByteReservationsAtomically() async {
+@Test func globalKVCacheBudgetReconcilesExactByteReservationsAtomically() async {
     let budget = GlobalKVCacheBudget(capFraction: 1.0, activationReserveBytes: 0) {
         GlobalKVCacheBudget.MemorySnapshot(
             total: 8 * gib,
@@ -46,9 +46,12 @@ private let gib: UInt64 = 1024 * 1024 * 1024
             systemAvailable: 1_000)
     }
     #expect(await budget.reserveBytes(requestID: "native", bytes: 400))
-    #expect(await budget.increaseReservation(requestID: "native", additionalBytes: 300))
+    #expect(await budget.outstandingReservedBytes() == 400)
+    #expect(await budget.increaseReservation(requestID: "native", additionalBytes: 100))
+    #expect(await budget.outstandingReservedBytes() == 500)
+    #expect(await budget.resizeReservationBytes(requestID: "native", bytes: 700))
     #expect(await budget.outstandingReservedBytes() == 700)
-    #expect(!(await budget.increaseReservation(requestID: "native", additionalBytes: 301)))
+    #expect(!(await budget.resizeReservationBytes(requestID: "native", bytes: 1_001)))
     #expect(await budget.outstandingReservedBytes() == 700)
     #expect(await budget.resizeReservationBytes(requestID: "native", bytes: 512))
     #expect(await budget.outstandingReservedBytes() == 512)

--- a/provider-swift/Tests/ProviderCoreTests/GlobalKVCacheBudgetTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/GlobalKVCacheBudgetTests.swift
@@ -37,6 +37,26 @@ private let gib: UInt64 = 1024 * 1024 * 1024
     #expect(!(await budget.reserve(requestID: "overflow", kvBytesPerToken: Int.max, tokenCount: Int.max)))
 }
 
+@Test func globalKVCacheBudgetGrowsAndReconcilesNativeByteReservationsAtomically() async {
+    let budget = GlobalKVCacheBudget(capFraction: 1.0, activationReserveBytes: 0) {
+        GlobalKVCacheBudget.MemorySnapshot(
+            total: 8 * gib,
+            active: 0,
+            cache: 0,
+            systemAvailable: 1_000)
+    }
+    #expect(await budget.reserveBytes(requestID: "native", bytes: 400))
+    #expect(await budget.increaseReservation(requestID: "native", additionalBytes: 300))
+    #expect(await budget.outstandingReservedBytes() == 700)
+    #expect(!(await budget.increaseReservation(requestID: "native", additionalBytes: 301)))
+    #expect(await budget.outstandingReservedBytes() == 700)
+    #expect(await budget.resizeReservationBytes(requestID: "native", bytes: 512))
+    #expect(await budget.outstandingReservedBytes() == 512)
+    #expect(!(await budget.resizeReservationBytes(requestID: "missing", bytes: 1)))
+    await budget.release(requestID: "native")
+    #expect(await budget.outstandingReservedBytes() == 0)
+}
+
 /// The cap fraction bounds the total reservable bytes: 0.5 × 8 GiB = 4 GiB cap
 /// (the fraction binds, not the 6 GiB floor), so a 3 GiB reservation fits but a
 /// further 2 GiB (→5 GiB) does not.

--- a/provider-swift/Tests/ProviderCoreTests/PrefixCachePolicyTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/PrefixCachePolicyTests.swift
@@ -57,7 +57,7 @@ struct PrefixCachePolicyTests {
         }
     }
 
-    @Test("reusable prefixes reject a storage-owning full layer after sliding attention")
+    @Test("typed capability enables frozen contiguous hybrids and rejects paged hybrids")
     func reusableLayoutSafety() {
         let full = CBv2LayerKind(
             attention: .full, headDim: 64, kvHeads: 4, queryHeads: 8)
@@ -67,15 +67,33 @@ struct PrefixCachePolicyTests {
             attention: .full, sharesKVWithLayer: 0,
             headDim: 64, kvHeads: 4, queryHeads: 8)
 
-        #expect(PrefixCachePolicy.supportsReusablePrefixes(layerKinds: [full, full]))
-        #expect(PrefixCachePolicy.supportsReusablePrefixes(layerKinds: [full, windowed]))
-        #expect(PrefixCachePolicy.supportsReusablePrefixes(layerKinds: [windowed, windowed]))
-        #expect(PrefixCachePolicy.supportsReusablePrefixes(
-            layerKinds: [windowed, sharedFull]))
-        #expect(!PrefixCachePolicy.supportsReusablePrefixes(
-            layerKinds: [windowed, full]))
-        #expect(!PrefixCachePolicy.supportsReusablePrefixes(
-            layerKinds: [full, windowed, full]))
+        #expect(PrefixCachePolicy.prefixReuseCapability(
+            layerKinds: [full, full], backendSelection: .contiguous).strategy == .direct)
+        #expect(PrefixCachePolicy.prefixReuseCapability(
+            layerKinds: [full, windowed], backendSelection: .paged).strategy == .tailReplay)
+        #expect(PrefixCachePolicy.prefixReuseCapability(
+            layerKinds: [windowed, sharedFull],
+            backendSelection: .contiguous).unsupportedReason == .invalidLayout)
+
+        let hybrid = PrefixCachePolicy.prefixReuseCapability(
+            layerKinds: [full, windowed, full],
+            backendSelection: .contiguous)
+        #expect(hybrid.isSupported)
+        #expect(hybrid.strategy == .frozenFullReplay)
+        #expect(hybrid.plan(matchedBoundary: 512)?.replayStart == 384)
+        #expect(hybrid.plan(matchedBoundary: 512)?.restoredFullTokens == 512)
+
+        let pagedHybrid = PrefixCachePolicy.prefixReuseCapability(
+            layerKinds: [windowed, full],
+            backendSelection: .paged)
+        #expect(!pagedHybrid.isSupported)
+        #expect(pagedHybrid.unsupportedReason == .pagedHybridRequiresDualCursor)
+
+        let killedPagedHybrid = PrefixCachePolicy.prefixReuseCapability(
+            layerKinds: [windowed, full],
+            backendSelection: .paged,
+            pagedKilled: true)
+        #expect(killedPagedHybrid.strategy == .frozenFullReplay)
     }
 
     @Test("adoptionBoundTokens: windowCount × maxWindow; 0 for pure full attention")
@@ -94,6 +112,68 @@ struct PrefixCachePolicyTests {
         mixed[0].attention = .slidingWindow(512)
         #expect(PrefixCachePolicy.adoptionBoundTokens(layerKinds: mixed) == 2 * 512)
         #expect(PrefixCachePolicy.adoptionBoundTokens(layerKinds: []) == 0)
+    }
+
+    @Test("Gemma QAT and GPT-OSS contiguous layouts qualify for v2; paged stays cold")
+    func productionHybridCapabilities() {
+        let sliding128 = CBv2LayerKind(
+            attention: .slidingWindow(128),
+            headDim: 64,
+            kvHeads: 8,
+            queryHeads: 64)
+        let gptFull = CBv2LayerKind(
+            attention: .full,
+            headDim: 64,
+            kvHeads: 8,
+            queryHeads: 64)
+        let gpt = (0 ..< 12).flatMap { _ in [sliding128, gptFull] }
+
+        let sliding1024 = CBv2LayerKind(
+            attention: .slidingWindow(1024),
+            headDim: 256,
+            kvHeads: 1,
+            queryHeads: 16)
+        let gemmaFull = CBv2LayerKind(
+            attention: .full,
+            headDim: 256,
+            kvHeads: 1,
+            queryHeads: 16)
+        let gemma = (0 ..< 5).flatMap { _ in
+            Array(repeating: sliding1024, count: 5) + [gemmaFull]
+        }
+
+        for kinds in [gpt, gemma] {
+            let contiguous = PrefixCachePolicy.prefixReuseCapability(
+                layerKinds: kinds,
+                backendSelection: .contiguous)
+            #expect(contiguous.isSupported)
+            #expect(contiguous.strategy == .frozenFullReplay)
+
+            let paged = PrefixCachePolicy.prefixReuseCapability(
+                layerKinds: kinds,
+                backendSelection: .paged)
+            #expect(!paged.isSupported)
+            #expect(paged.unsupportedReason == .pagedHybridRequiresDualCursor)
+        }
+        #expect(PrefixCachePolicy.adoptionBoundTokens(layerKinds: gpt) == 1_536)
+        #expect(PrefixCachePolicy.adoptionBoundTokens(layerKinds: gemma) == 25_600)
+        let gptCapability = PrefixCachePolicy.prefixReuseCapability(
+            layerKinds: gpt,
+            backendSelection: .contiguous)
+        let gemmaCapability = PrefixCachePolicy.prefixReuseCapability(
+            layerKinds: gemma,
+            backendSelection: .contiguous)
+        #expect(PrefixCachePolicy.minEffectiveTokens(
+            capability: gptCapability,
+            environment: [:]) == 1_024)
+        #expect(PrefixCachePolicy.minEffectiveTokens(
+            capability: gemmaCapability,
+            environment: [:]) == 1_536)
+        #expect(PrefixCachePolicy.minEffectiveTokens(
+            capability: gemmaCapability,
+            environment: [
+                SSDPrefixCachePolicy.minEffectiveTokensFlag: "2048"
+            ]) == 2_048)
     }
 
 }

--- a/provider-swift/Tests/ProviderCoreTests/SSDCacheEpochStoreTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/SSDCacheEpochStoreTests.swift
@@ -1,4 +1,6 @@
+import CryptoKit
 import Foundation
+import MLXLMCommon
 import Testing
 
 @testable import ProviderCore
@@ -53,6 +55,111 @@ struct SSDCacheEpochStoreTests {
         #expect(changed.current != rotatedEpoch)
         #expect(first.current == nil)
         #expect(!FileManager.default.fileExists(atPath: block.path))
+    }
+
+    @Test("frozen-full layout epoch purges snap-2 blocks before publication")
+    func frozenReplayEpochRotation() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cache-epoch-frozen-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let old = try SSDCacheEpochStore(
+            root: root,
+            binding: binding(
+                contract: String(repeating: "b", count: 64),
+                layout: "cbv2-snap-2|f16|256|deadbeef"))
+        let oldEpoch = try #require(old.current)
+        let block = SSDBlockStore.fileURL(
+            root: root,
+            tag16Hex: String(repeating: "a", count: 32))
+        try FileManager.default.createDirectory(
+            at: block.deletingLastPathComponent(),
+            withIntermediateDirectories: true)
+        try Data("old-semantics".utf8).write(to: block)
+
+        let currentLayout = SSDBlockStore.layoutEpoch(
+            blockSize: 256,
+            layerKinds: [
+                CBv2LayerKind(
+                    attention: .full,
+                    headDim: 64,
+                    kvHeads: 8,
+                    queryHeads: 64)
+            ])
+        #expect(currentLayout.hasPrefix("cbv2-frozen-full-3|native-fp|"))
+        let current = try SSDCacheEpochStore(
+            root: root,
+            binding: binding(
+                contract: String(repeating: "b", count: 64),
+                layout: currentLayout))
+        #expect(current.current != oldEpoch)
+        #expect(old.current == nil)
+        #expect(!FileManager.default.fileExists(atPath: block.path))
+    }
+
+    @Test("provider advertises v2 only after frozen cache scan readiness")
+    func advertisementWaitsForScan() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cache-ready-frozen-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let kinds = [
+            CBv2LayerKind(
+                attention: .slidingWindow(128),
+                headDim: 64,
+                kvHeads: 8,
+                queryHeads: 64),
+            CBv2LayerKind(
+                attention: .full,
+                headDim: 64,
+                kvHeads: 8,
+                queryHeads: 64),
+        ]
+        let layout = SSDBlockStore.layoutEpoch(blockSize: 256, layerKinds: kinds)
+        let epochStore = try SSDCacheEpochStore(
+            root: root,
+            binding: binding(
+                contract: String(repeating: "b", count: 64),
+                layout: layout))
+        let cache = SSDPrefixCache(
+            config: .init(
+                modelId: "gpt-oss",
+                promptContractID: String(repeating: "b", count: 64),
+                weightHash: String(repeating: "a", count: 64),
+                blockSize: 256,
+                adoptionBoundTokens: 128,
+                layoutEpoch: layout,
+                epochStore: epochStore,
+                root: root,
+                ttlSeconds: 900,
+                minEffectiveTokens: 1,
+                maxStageBytes: 1 << 20,
+                maxStageMillis: 1_000,
+                nowSeconds: { 1_000 }),
+            kekKey: SymmetricKey(size: .bits256),
+            kvBudget: nil,
+            diskBudget: SSDDiskBudget(),
+            maxWriteBytesPerDay: 0,
+            strictFsync: false,
+            diskBudgetBytes: { 1 << 30 })
+        let state = ProviderState()
+        state.setPrefixCacheV2Sources(["gpt-oss": cache])
+        #expect(state.prefixCacheV2Advertisement().protocolVersion == 1)
+        #expect(state.prefixCacheV2Advertisement().models.isEmpty)
+
+        cache.startBackgroundTasks(sweepIntervalSeconds: 3_600)
+        for _ in 0 ..< 100
+        where state.prefixCacheV2Advertisement().protocolVersion != 2 {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        let ready = state.prefixCacheV2Advertisement()
+        #expect(ready.protocolVersion == 2)
+        #expect(ready.models.map(\.modelId) == ["gpt-oss"])
+        #expect(ready.models.allSatisfy { $0.ready })
+
+        await cache.closeAndWait()
+        #expect(state.prefixCacheV2Advertisement().protocolVersion == 1)
     }
 
     @Test("epoch metadata symlink is rejected without following it")
@@ -146,14 +253,17 @@ struct SSDCacheEpochStoreTests {
         #expect(current != originalEpoch)
     }
 
-    private func binding(contract: String) -> SSDCacheEpochStore.Binding {
+    private func binding(
+        contract: String,
+        layout: String = "layout"
+    ) -> SSDCacheEpochStore.Binding {
         SSDCacheEpochStore.Binding(
             modelId: "model",
             modelAggregateHash: String(repeating: "a", count: 64),
             promptContractId: contract,
             blockHashVersion: "dbk3",
             blockSize: 256,
-            layoutEpoch: "layout",
+            layoutEpoch: layout,
             keyFingerprint: String(repeating: "e", count: 64))
     }
 }

--- a/provider-swift/Tests/ProviderCoreTests/SSDPrefixCacheTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/SSDPrefixCacheTests.swift
@@ -789,6 +789,9 @@ struct SSDPrefixCacheLifecycleTests {
         // Engine-side synchronous lookup hits the staging map.
         let hit = reader.lookup(tokens: prompt, layerKinds: fixtureLayerKinds, cacheSalt: nil)
         let (matched, prefix) = try #require(hit)
+        #expect(reader.stats().tokensSaved == 0, "lookup M is not terminal saved-prefill truth")
+        reader.recordPrefillTokensSaved(7)
+        #expect(reader.stats().tokensSaved == 7)
         #expect(matched == tokenCount)  // 8 whole blocks
         #expect(prefix.count == 2)
         #expect(prefix[1] == nil)  // windowed layer never cached
@@ -2674,6 +2677,23 @@ struct SSDPrefixCacheDonationGateTests {
                 tokens: Array(0 ..< 64) + [1], matched: hit.matched, cacheSalt: nil)
         }
         reader.completeStaging(requestID: "r-cap")
+    }
+
+    @Test("stage cap below hybrid benefit floor writes no unusable blocks")
+    func byteCapBelowBenefitFloorSkipsDonation() async throws {
+        let dir = tempDir("gate-bytecap-floor")
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let cache = makeCache(
+            dir: dir,
+            kek: SymmetricKey(size: .bits256),
+            clock: ClockBox(10_000),
+            adoptionBound: 32,
+            minEffectiveTokens: 8,
+            maxStageBytes: 3 * 512)
+        defer { cache.close() }
+
+        donate(cache, tokenCount: 64)
+        await expectNoWrites(cache, dir: dir)
     }
 
     @Test("write-behind admits one full max-size (~600 MB) donation; oversize is dropped, never stalled")

--- a/provider-swift/Tests/ProviderCoreTests/SSDPrefixCacheTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/SSDPrefixCacheTests.swift
@@ -196,7 +196,7 @@ struct SSDBlockStoreTests {
         SSDBlockMetadata(
             lookupTag: String(repeating: "ab", count: 32),
             weightHash: "w-hash",
-            layoutEpoch: "cbv2-snap-2|f16|8|deadbeef",
+            layoutEpoch: "cbv2-frozen-full-3|native-fp|8|deadbeef",
             blockSize: 8,
             layerCount: 2,
             chunks: sizes.enumerated().map { i, _ in
@@ -228,7 +228,7 @@ struct SSDBlockStoreTests {
         }
     }
 
-    @Test("legacy DBK2 bytes and snap-1 epochs are rejected by the DBK3 tier")
+    @Test("legacy DBK2 bytes and pre-frozen epochs are rejected by the DBK3 tier")
     func legacyArtifactsFailClosed() throws {
         let dir = tempDir("legacy-store")
         defer { try? FileManager.default.removeItem(at: dir) }
@@ -239,7 +239,7 @@ struct SSDBlockStoreTests {
         let metadata = SSDBlockMetadata(
             lookupTag: tagHex + String(repeating: "0", count: 32),
             weightHash: "test-weight-hash",
-            layoutEpoch: "cbv2-snap-1|f16|\(fixtureBlockSize)|legacy",
+            layoutEpoch: "cbv2-snap-2|f16|\(fixtureBlockSize)|legacy",
             blockSize: fixtureBlockSize,
             layerCount: fixtureLayerKinds.count,
             chunks: [
@@ -251,7 +251,7 @@ struct SSDBlockStoreTests {
             chunkPlaintextSizes: chunks.map(\.count),
             createdAt: 1_000)
         try SSDBlockStore.write(to: url, metadata: metadata, chunks: chunks, kekKey: kek)
-        #expect(try SSDBlockStore.readMetadataOnly(from: url).layoutEpoch.hasPrefix("cbv2-snap-1|"))
+        #expect(try SSDBlockStore.readMetadataOnly(from: url).layoutEpoch.hasPrefix("cbv2-snap-2|"))
 
         let cache = makeCache(
             dir: dir, kek: kek, clock: ClockBox(1_001), ttlSeconds: 0)
@@ -361,7 +361,7 @@ struct SSDBlockStoreTests {
         let c = SSDBlockStore.layoutEpoch(blockSize: 16, layerKinds: fixtureLayerKinds)
         #expect(a != b)
         #expect(a != c)
-        #expect(a.hasPrefix("cbv2-snap-2|f16|8|"))
+        #expect(a.hasPrefix("cbv2-frozen-full-3|native-fp|8|"))
     }
 
     @Test("atomic writer uses the exact Darkbloom-owned crash-temp grammar")
@@ -1589,6 +1589,21 @@ struct SSDReadyWriteBarrierTests {
 
 // MARK: - Staging reservation hygiene
 
+private final class BudgetAvailableBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value: UInt64
+
+    init(_ value: UInt64) { self.value = value }
+
+    func set(_ value: UInt64) {
+        lock.withLock { self.value = value }
+    }
+
+    var current: UInt64 {
+        lock.withLock { value }
+    }
+}
+
 @Suite("SSD prefix cache: staging reservations", .serialized)
 struct SSDPrefixCacheReservationTests {
 
@@ -1680,12 +1695,6 @@ struct SSDPrefixCacheReservationTests {
         bytes[bytes.count - 10] ^= 0xFF
         try bytes.write(to: lastURL)
 
-        // Expected staged bytes = the surviving 7 blocks' file sizes.
-        var expectedBytes = 0
-        for i in 0 ..< chain.count - 1 {
-            expectedBytes += try Data(contentsOf: fileURL(i)).count
-        }
-
         let prompt = tokens + [7]
         let stageResult = await cache.stage(
             requestID: "req-short", promptTokens: prompt, cacheScope: "")
@@ -1694,11 +1703,12 @@ struct SSDPrefixCacheReservationTests {
             matchedTokens: 7 * fixtureBlockSize,
             expectedPrefillTokensSaved: 7 * fixtureBlockSize,
             shortenedByCorruption: true))
+        let expectedBytes = stageResult.deviceBytes
+        #expect(expectedBytes > 0)
         #expect(cache.stats().corruptDropped == 1)
         // Regression (Codex, v0.7.5 SSD review): the reservation and the
-        // staging accounting must reflect the SHORTENED run — they used to
-        // stay at the original 8-block figure, falsely consuming shared KV
-        // headroom until this request's release.
+        // staging accounting must reflect exact rehydrated MLX bytes for the
+        // SHORTENED run — never the original run or encrypted file overhead.
         #expect(await budget.outstandingReservedBytes() == UInt64(expectedBytes))
         #expect(cache.bytesInUse == expectedBytes)
 
@@ -1881,6 +1891,51 @@ struct SSDPrefixCacheReservationTests {
         cache.completeStaging(requestID: requestA)
         #expect(await waitForZeroOutstanding(budget), "the last user must drain the entry reservation")
         #expect(cache.bytesInUse == 0)
+    }
+
+    @Test("same-prefix attachment needs no spare provisional headroom")
+    func attachAtCapacity() async throws {
+        let dir = tempDir("res-attach-full")
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let available = BudgetAvailableBox(64 * 1_073_741_824)
+        let budget = GlobalKVCacheBudget(
+            capFraction: 0.9,
+            activationReserveBytes: 0,
+            configReserveBytes: 0,
+            memorySnapshot: {
+                GlobalKVCacheBudget.MemorySnapshot(
+                    total: 64 * 1_073_741_824,
+                    active: 0,
+                    cache: 0,
+                    systemAvailable: available.current)
+            })
+        let cache = await makeStagedCache(
+            dir: dir,
+            kek: SymmetricKey(size: .bits256),
+            clock: ClockBox(10_000),
+            kvBudget: budget)
+        defer { cache.close() }
+        let prompt = Array(0 ..< tokenCount) + [1]
+        let first = await cache.stage(
+            requestID: "attach-a",
+            promptTokens: prompt,
+            cacheScope: "")
+        #expect(first.staged)
+        let reserved = await budget.outstandingReservedBytes()
+        #expect(reserved == UInt64(first.deviceBytes))
+        available.set(reserved)
+
+        let second = await cache.stage(
+            requestID: "attach-b",
+            promptTokens: prompt,
+            cacheScope: "")
+        #expect(second.staged)
+        #expect(second.deviceBytes == first.deviceBytes)
+        #expect(await budget.outstandingReservedBytes() == reserved)
+
+        cache.completeStaging(requestID: "attach-a")
+        cache.completeStaging(requestID: "attach-b")
+        #expect(await waitForZeroOutstanding(budget))
     }
 
     @Test("two cache instances may reserve the same raw receipt id independently")
@@ -2467,31 +2522,31 @@ struct SSDPrefixCacheDonationGateTests {
         #expect(dbk3Files(under: dir).count == 11)
     }
 
-    @Test("gemma constants: the >26.6k long-context tail caches; anything shorter writes nothing")
+    @Test("gemma constants: the >27.1k evidence-backed tail caches; shorter writes nothing")
     func gemmaConstantsGate() async throws {
         let dir = tempDir("gate-gemma")
         defer { try? FileManager.default.removeItem(at: dir) }
         let clock = ClockBox(10_000)
-        // Real gemma-4-26B numbers: bound 25 × 1,024 = 25,600; floor 26,624.
+        // Real Gemma numbers: bound 25,600 + measured saved-token floor 1,536.
         let cache = makeCache(
             dir: dir, kek: SymmetricKey(size: .bits256), clock: clock,
-            blockSize: 256, adoptionBound: 25_600, minEffectiveTokens: 1024)
+            blockSize: 256, adoptionBound: 25_600, minEffectiveTokens: 1_536)
         defer { cache.close() }
 
         // A typical prompt (4k) AND the exact floor both write nothing —
         // the negative that used to be enforced by excluding gemma wholesale.
         donate(cache, tokenCount: 4096)
         await expectNoWrites(cache, dir: dir)
-        donate(cache, tokenCount: 26_624)
+        donate(cache, tokenCount: 27_136)
         await expectNoWrites(cache, dir: dir)
 
-        // The long-context tail (105 whole blocks = 26,880 tokens) persists.
-        donate(cache, tokenCount: 26_880 + 5)
+        // The long-context tail (107 whole blocks = 27,392 tokens) persists.
+        donate(cache, tokenCount: 27_392 + 5)
         let deadline = ContinuousClock.now + .seconds(30)
-        while ContinuousClock.now < deadline, cache.index.count < 105 {
+        while ContinuousClock.now < deadline, cache.index.count < 107 {
             try? await Task.sleep(for: .milliseconds(50))
         }
-        #expect(cache.index.count == 105)
+        #expect(cache.index.count == 107)
     }
 
     @Test("unknown/saturated adoption bound: never persists (the only 'never cached' case)")

--- a/provider-swift/Tests/ProviderCoreTests/SSDPrefixCacheTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/SSDPrefixCacheTests.swift
@@ -623,6 +623,26 @@ struct SSDPrefixCacheModeTests {
         #expect(SSDPrefixCacheFactory.verifiedWeightHash("  abcd1234  ") == "abcd1234")
     }
 
+    @Test("test root is isolated and requires the ephemeral-key gate")
+    func isolatedTestRoot() {
+        let root = tempDir("factory-test-root").standardizedFileURL
+        defer { try? FileManager.default.removeItem(at: root) }
+        let raw = [
+            "DARKBLOOM_PREFIX_CACHE_ALLOW_EPHEMERAL": "1",
+            SSDPrefixCacheFactory.testRootEnvironmentKey: root.path,
+        ]
+        #expect(SSDPrefixCacheFactory.cacheRootDirectory(environment: raw) == root)
+        #expect(
+            SSDPrefixCacheFactory.cacheDirectory(
+                modelId: "isolated-model",
+                environment: raw
+            ).deletingLastPathComponent() == root)
+        #expect(
+            SSDPrefixCacheFactory.cacheRootDirectory(environment: [
+                SSDPrefixCacheFactory.testRootEnvironmentKey: root.path
+            ]) != root)
+    }
+
     @Test("durable-byte stage estimate is positive, conservative, and wire-bounded")
     func durableStageEstimate() {
         #expect(SSDPrefixCachePolicy.estimatedStageMillis(bytes: 1) == 1)

--- a/provider-swift/Tests/ProviderCoreTests/SSDPrefixCacheTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/SSDPrefixCacheTests.swift
@@ -1812,6 +1812,55 @@ struct SSDPrefixCacheReservationTests {
         #expect(cache.bytesInUse == 0)
     }
 
+    @Test("conversion peak reserves host, per-block MLX, and concatenated arrays")
+    func conversionPeakReservationCoversThreeRepresentations() async throws {
+        let dir = tempDir("res-conversion-peak")
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let available = BudgetAvailableBox(64 * 1_073_741_824)
+        let budget = GlobalKVCacheBudget(
+            capFraction: 0.9,
+            activationReserveBytes: 0,
+            configReserveBytes: 0,
+            memorySnapshot: {
+                GlobalKVCacheBudget.MemorySnapshot(
+                    total: 64 * 1_073_741_824,
+                    active: 0,
+                    cache: 0,
+                    systemAvailable: available.current)
+            })
+        let cache = await makeStagedCache(
+            dir: dir,
+            kek: SymmetricKey(size: .bits256),
+            clock: ClockBox(10_000),
+            kvBudget: budget)
+        defer { cache.close() }
+        let fileBytes = try dbk3Files(under: dir).reduce(0) { total, url in
+            total + (try url.resourceValues(forKeys: [.fileSizeKey]).fileSize ?? 0)
+        }
+        #expect(fileBytes > 0)
+        available.set(UInt64(fileBytes * 5 / 2))
+
+        let refused = await cache.stage(
+            requestID: "req-peak",
+            promptTokens: Array(0 ..< tokenCount) + [1],
+            cacheScope: "")
+        #expect(refused.disposition == .skippedCapacity)
+        #expect(await budget.outstandingReservedBytes() == 0)
+        #expect(cache.bytesInUse == 0)
+
+        available.set(UInt64(fileBytes * 4))
+        let staged = await cache.stage(
+            requestID: "req-peak-success",
+            promptTokens: Array(0 ..< tokenCount) + [1],
+            cacheScope: "")
+        #expect(staged.staged)
+        #expect(staged.deviceBytes > 0)
+        #expect(await budget.outstandingReservedBytes() == UInt64(staged.deviceBytes))
+        cache.completeStaging(requestID: "req-peak-success")
+        #expect(await waitForZeroOutstanding(budget))
+        #expect(cache.bytesInUse == 0)
+    }
+
     @Test("close(): open tickets drained, reservations released, files kept")
     func closeDrainsTickets() async throws {
         let dir = tempDir("res-close")


### PR DESCRIPTION
## Outcome

Restores exact encrypted SSD prefix reuse for contiguous unquantized Gemma 4 and GPT-OSS providers. Hybrid slots can advertise protocol v2 only after the cache scan is ready; paged, quantized, invalid, and unknown layouts remain explicitly cold.

Depends on engine PR https://github.com/Layr-Labs/mlx-swift-lm/pull/78.

Pinned engine commit: `716b8b9e5e190959e67e7c079275ea2812403b91`.

Parent commit: `640b2d7f2`.

## Provider capability restoration

The old provider Boolean rejected every layout with an owning full-attention layer after sliding attention. That gate was correct for mutating replay, but unnecessarily disabled useful exact reuse once the engine gained independent frozen-full storage/read cursors.

The provider now derives a typed model/backend capability before constructing SSD state:

- contiguous unquantized hybrid: `frozen_full_replay`;
- safe contiguous/paged layout: existing direct or tail replay;
- paged hybrid: fail cold with `paged_hybrid_requires_dual_cursor`;
- quantized, malformed, or unknown: fail cold.

An explicit paged selection remains cache-cold even if serving later falls back to contiguous. Reload with a contiguous selection to enable frozen replay; capability never changes as an accidental side effect of backend fallback.

## DBK3 and layout epoch

DBK3 remains byte-format compatible: AES-GCM block encryption, wrapped per-block keys, HMAC lookup names, weight hash, prompt contract, account scope, no-follow I/O, durable-ready barrier, request tickets, and proof sequencing are unchanged.

Replay semantics do change, so the layout identity rotates from `cbv2-snap-2` to:

`cbv2-frozen-full-3|native-fp|<blockSize>|<layerDigest>`

Binding drift persists a fresh cache epoch and purges old blocks before v2 readiness can be advertised. Coordinator holder evidence automatically invalidates because the advertised cache epoch changes. No coordinator protocol schema changed.

## Native-width accounting and lifecycle

Real GPT-OSS owning full K/V is FP32. The implementation therefore never assumes FP16:

- SSD staging uses encrypted file bytes only as a pre-read cost gate, then reconciles reservations and telemetry to exact rehydrated `MLXArray.nbytes`.
- Duplicate requests attach to an existing staged entry before attempting a provisional reservation, so zero-allocation attachment succeeds with no spare headroom.
- Provider process-wide reservations apply the measured native-width delta across the complete `prompt + max_tokens` span.
- Engine and backend admission prepay native owning-full storage through maximum sequence length plus fixed sliding rings before adoption is published.
- Replay, decode, and MTP chunks add no duplicate KV charge after that prepayment.
- Cancellation, refusal, preemption, disconnect, shutdown, and unload balance every staging ticket, pin, and reservation.

Long frozen hybrids with `R >= 25,600` enforce at least 1,536 saved tokens. This excludes the noisy/negative 1,024-token Gemma boundary while preserving GPT's validated 1,024-token floor. Operators may raise but not lower the proved long-hybrid floor.

## Telemetry and privacy

Adds low-cardinality engine-health fields for strategy, matched/replay/saved tokens, boundary splits, construction failures, capacity refusal, and cold fallback.

- Prompt text, token IDs, raw hashes, cache keys, and account scope never enter telemetry.
- Hit and fallback events are sampled at the first event and every 64th event.
- Ordinary misses and policy skips emit no per-request cache event, preserving the provider's telemetry quota.
- Swift, Go, and TypeScript allowlists remain symmetric.

## Before

```mermaid
flowchart LR
  subgraph Behavior_Before[Behavior before]
    B1[Gemma or GPT provider loads] --> B2[Boolean layout gate]
    B2 --> B3[Hybrid rejected]
    B3 --> B4[No SSD cache object]
    B4 --> B5[Provider advertises protocol v1]
    B5 --> B6[Every repeated prefix runs cold]
  end
  subgraph Code_Before[Code before]
    C1[EngineV2SlotFactory] --> C2[PrefixCachePolicy supportsReusablePrefixes]
    C2 --> C3[SSDPrefixCacheFactory returns nil]
    C3 --> C4[ProviderState has no v2 source]
    C4 --> C5[Coordinator sees no exact holder]
  end
```

## After

```mermaid
flowchart LR
  subgraph Behavior_After[Behavior after]
    A1[Contiguous Gemma or GPT loads] --> A2[Typed backend capability]
    A2 --> A3[SSD scan and epoch validation]
    A3 --> A4[Advertise protocol v2 when ready]
    A4 --> A5[Stage exact native full KV]
    A5 --> A6[Frozen replay rebuilds sliding state]
    A6 --> A7[Exact warm response and receipt]
    P1[Explicit paged hybrid] --> P2[Fail cold with reason]
  end
  subgraph Code_After[Code after]
    D1[EngineV2SlotFactory] --> D2[PrefixReuseCapability]
    D2 --> D3[SSDPrefixCacheFactory]
    D3 --> D4[cache epoch store]
    D4 --> D5[EngineV2Bridge stage]
    D5 --> D6[GlobalKV native reservation]
    D6 --> D7[Engine frozen plan]
    D7 --> D8[ProviderState v2 capability]
    D8 --> D9[Coordinator proof routing]
  end
```

## Exact correctness evidence

- Real GPT-OSS, 2,817-token old-bound counterexample: old max logit drift `0.20875001`; frozen logits/KV and 64 greedy tokens bit-exact; exact owning-full rate `49,152 B/token`.
- Real Gemma QAT: raw logits, owning-full K/V, and at least 128 greedy tokens bit-exact for 26,625 / 26,881 / 27,137-token prompts.
- Real Gemma QAT 32,769-token logits bit-exact.
- Deterministic `[full, sliding, sliding, full]`, ten 256-token boundary-adjacent lengths, divergent tails, B=2/B=4 positions, actual Gemma class with K=V, MTP accepted/rejected drafts, cancellation, preemption, shutdown, duplicate staging, wrong key, corruption, truncation, restart, and epoch rotation all pass.

## Performance evidence

- GPT 4,097: cold `5.219s`, frozen replay `2.098s`.
- GPT 8,193: cold `12.135s`, frozen replay `2.500s`.
- Gemma 32,769: cold `61.320s`, frozen replay `47.127s`.
- Deterministic encrypted SSD stage p95 remained below 18 ms versus the configured 1,000 ms gate.
- Real GPT encrypted donate/restart: 13 blocks / 163,612,332 bytes; warm same-engine TTFT `3.574s`, warm restart `3.928s`, cache-off `4.264s`.

Detailed evidence: `docs/reports/2026-07-19-frozen-full-prefix-cache-proof.md`.

## Verification

- Provider serial suite: 1,534 tests passed before the final evidence-floor-only policy change; all changed policy/accounting/SSD/epoch/telemetry suites passed afterward.
- Engine frozen/prefix/core/MTP/paged/quantized suites passed.
- Real-model proof suite: 4/4 passed.
- Coordinator: `go test ./...`, telemetry race test, and build passed.
- Console: 476 tests, lint, and production build passed.
- Nested engine and provider release builds passed.
- `git diff --check` and IDE lints passed.
- Two independent same-model reviews passed with no remaining findings.

The monolithic all-package engine run was attempted twice but compiled-decode warmup blocked behind concurrent GPU tests in another worktree. Every changed engine suite and the release build completed successfully; engine PR CI remains the merge gate for the all-package lane.

## Rollout

1. Merge engine PR #78.
2. Re-pin this PR to the exact merged engine SHA before merging the parent.
3. Keep coordinator cache routing off.
4. Verify prompt-contract artifacts, cache scan readiness, epoch rotation, stage p95, exact receipts, and zero reservation leaks on isolated contiguous canaries.
5. Canary GPT first, then Gemma above the 1,536-saved-token floor.
6. Enable routing only after holder/lookup correlation and warm TTFT remain healthy.

## Rollback

- First set coordinator cache routing off.
- Set `DARKBLOOM_PREFIX_CACHE=0` or roll back the provider to force cold serving.
- Do not restore `cbv2-snap-2` blocks under the new engine; epoch mismatch intentionally purges them.

## Limitations and remaining gates

- Paged hybrid and quantized reuse remain disabled.
- Production prompt artifacts are currently failed, and cache routing is currently off; this PR does not activate either.
- This PR must be re-pinned from engine feature commit `716b8b9e5e190959e67e7c079275ea2812403b91` to the engine PR's merged commit before parent merge.
- No release, tag, deploy, or production mutation is included.

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/559"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787040740&installation_id=133247490&pr_number=559&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F559&signature=716cbb1dfea41ad83044369d02c1b1af96f04863f12f3e5d74d0caa9f0633480"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->