### PR TITLE
Expose loaded LM Studio models in self-route

### DIFF
--- a/coordinator/api/provider.go
+++ b/coordinator/api/provider.go
@@ -640,6 +640,10 @@ func (s *Server) providerReadLoop(ctx context.Context, conn *websocket.Conn, pro
 			updateMsg := msg.Payload.(*protocol.ModelsUpdateMessage)
 			s.handleModelsUpdate(providerID, provider, updateMsg)
 
+		case protocol.TypeLMStudioModelsUpdate:
+			updateMsg := msg.Payload.(*protocol.LMStudioModelsUpdateMessage)
+			s.handleLMStudioModelsUpdate(providerID, updateMsg)
+
 		case protocol.TypePrefetchModelStatus:
 			statusMsg := msg.Payload.(*protocol.PrefetchModelStatusMessage)
 			// Observability only. The terminal "verified" state means the build
@@ -777,6 +781,21 @@ func (s *Server) handleModelsUpdate(providerID string, provider *registry.Provid
 		// Requests may have queued against the concrete previous build while it
 		// was still acceptable. Recheck immediately: drain to another provider if
 		// one exists, otherwise fail fast instead of waiting for queue timeout.
+		s.registry.DrainQueuedRequestsForModel(id)
+		s.registry.RejectUnservableQueuedRequests(id)
+	}
+}
+
+func (s *Server) handleLMStudioModelsUpdate(providerID string, msg *protocol.LMStudioModelsUpdateMessage) {
+	added, removed := s.registry.ReplaceLMStudioModels(providerID, msg.Models)
+	for _, id := range added {
+		s.logger.Info("linked provider now exposes loaded LM Studio model",
+			"provider_id", providerID, "model_id", id)
+		s.registry.DrainQueuedRequestsForModel(id)
+	}
+	for _, id := range removed {
+		s.logger.Info("linked provider no longer exposes LM Studio model",
+			"provider_id", providerID, "model_id", id)
 		s.registry.DrainQueuedRequestsForModel(id)
 		s.registry.RejectUnservableQueuedRequests(id)
 	}

--- a/coordinator/protocol/messages.go
+++ b/coordinator/protocol/messages.go
@@ -43,6 +43,7 @@ const (
 	TypeLoadModelStatus         = "load_model_status"
 	TypePrefetchModelStatus     = "prefetch_model_status"
 	TypeModelsUpdate            = "models_update"
+	TypeLMStudioModelsUpdate    = "lmstudio_models_update"
 	TypePrefixCacheLookup       = "prefix_cache_lookup"
 	TypePrefixCacheReady        = "prefix_cache_ready"
 	TypePrefixCacheLookupV2     = "prefix_cache_lookup_v2"
@@ -561,6 +562,14 @@ type ModelsUpdateMessage struct {
 	Models []ModelInfo `json:"models"`
 }
 
+// LMStudioModelsUpdateMessage is the authoritative set of LM Studio model
+// instances currently loaded on a linked provider Mac. These models are
+// owner-only and use the reserved "lmstudio/" namespace.
+type LMStudioModelsUpdateMessage struct {
+	Type   string      `json:"type"`
+	Models []ModelInfo `json:"models"`
+}
+
 // PrefetchModelStatusMessage is the provider's progress/terminal reply to a
 // PrefetchModelMessage. Status is one of PrefetchModelStatusStarted,
 // PrefetchModelStatusDownloading, PrefetchModelStatusVerified,
@@ -779,6 +788,13 @@ func (pm *ProviderMessage) UnmarshalJSON(data []byte) error {
 		var msg ModelsUpdateMessage
 		if err := json.Unmarshal(data, &msg); err != nil {
 			return fmt.Errorf("protocol: failed to unmarshal models_update: %w", err)
+		}
+		pm.Payload = &msg
+
+	case TypeLMStudioModelsUpdate:
+		var msg LMStudioModelsUpdateMessage
+		if err := json.Unmarshal(data, &msg); err != nil {
+			return fmt.Errorf("protocol: failed to unmarshal lmstudio_models_update: %w", err)
 		}
 		pm.Payload = &msg
 

--- a/coordinator/protocol/messages_model_lifecycle_test.go
+++ b/coordinator/protocol/messages_model_lifecycle_test.go
@@ -201,6 +201,22 @@ func TestProviderMessageUnmarshalModelsUpdate(t *testing.T) {
 	}
 }
 
+func TestProviderMessageUnmarshalLMStudioModelsUpdate(t *testing.T) {
+	data := []byte(`{"type":"lmstudio_models_update","models":[{"id":"lmstudio/laguna","size_bytes":1024,"model_type":"chat","quantization":"4bit"}]}`)
+
+	var msg ProviderMessage
+	if err := json.Unmarshal(data, &msg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if msg.Type != TypeLMStudioModelsUpdate {
+		t.Fatalf("Type=%q, want %q", msg.Type, TypeLMStudioModelsUpdate)
+	}
+	update, ok := msg.Payload.(*LMStudioModelsUpdateMessage)
+	if !ok || len(update.Models) != 1 || update.Models[0].ID != "lmstudio/laguna" {
+		t.Fatalf("decoded update = %#v", msg.Payload)
+	}
+}
+
 func TestPrefetchModelStatusVerifiedRoundTrip(t *testing.T) {
 	msg := PrefetchModelStatusMessage{
 		Type:    TypePrefetchModelStatus,

--- a/coordinator/registry/lmstudio.go
+++ b/coordinator/registry/lmstudio.go
@@ -1,0 +1,62 @@
+package registry
+
+import (
+	"strings"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+)
+
+const (
+	lmStudioModelPrefix = "lmstudio/"
+	maxLMStudioModels   = 64
+)
+
+// ReplaceLMStudioModels replaces only the dynamic LM Studio portion of a
+// provider's inventory. It is intentionally limited to linked providers and a
+// reserved namespace so these off-catalog models can only use owner self-route.
+func (r *Registry) ReplaceLMStudioModels(providerID string, models []protocol.ModelInfo) (added, removed []string) {
+	r.mu.RLock()
+	p := r.providers[providerID]
+	r.mu.RUnlock()
+	if p == nil {
+		return nil, nil
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.AccountID == "" {
+		return nil, nil
+	}
+
+	next := make([]protocol.ModelInfo, 0, len(p.Models)+min(len(models), maxLMStudioModels))
+	previous := make(map[string]struct{})
+	for _, model := range p.Models {
+		if strings.HasPrefix(model.ID, lmStudioModelPrefix) {
+			previous[model.ID] = struct{}{}
+			continue
+		}
+		next = append(next, model)
+	}
+
+	seen := make(map[string]struct{})
+	for _, model := range models {
+		if len(seen) >= maxLMStudioModels || !strings.HasPrefix(model.ID, lmStudioModelPrefix) || model.ID == lmStudioModelPrefix {
+			continue
+		}
+		if _, duplicate := seen[model.ID]; duplicate {
+			continue
+		}
+		seen[model.ID] = struct{}{}
+		next = append(next, model)
+		if _, existed := previous[model.ID]; !existed {
+			added = append(added, model.ID)
+		}
+	}
+	for id := range previous {
+		if _, remains := seen[id]; !remains {
+			removed = append(removed, id)
+		}
+	}
+	p.Models = next
+	return added, removed
+}

--- a/coordinator/registry/lmstudio.go
+++ b/coordinator/registry/lmstudio.go
@@ -40,7 +40,10 @@ func (r *Registry) ReplaceLMStudioModels(providerID string, models []protocol.Mo
 
 	seen := make(map[string]struct{})
 	for _, model := range models {
-		if len(seen) >= maxLMStudioModels || !strings.HasPrefix(model.ID, lmStudioModelPrefix) || model.ID == lmStudioModelPrefix {
+		if len(seen) >= maxLMStudioModels {
+			break
+		}
+		if !strings.HasPrefix(model.ID, lmStudioModelPrefix) || model.ID == lmStudioModelPrefix {
 			continue
 		}
 		if _, duplicate := seen[model.ID]; duplicate {

--- a/coordinator/registry/lmstudio_test.go
+++ b/coordinator/registry/lmstudio_test.go
@@ -1,0 +1,68 @@
+package registry
+
+import (
+	"testing"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+)
+
+func TestReplaceLMStudioModelsIsAuthoritativeAndPreservesNativeModels(t *testing.T) {
+	r := New(testLogger())
+	p := &Provider{
+		ID:        "provider",
+		AccountID: "owner",
+		Models:    []protocol.ModelInfo{{ID: "native"}, {ID: "lmstudio/old"}},
+	}
+	r.providers[p.ID] = p
+
+	added, removed := r.ReplaceLMStudioModels(p.ID, []protocol.ModelInfo{
+		{ID: "lmstudio/laguna", ModelType: "chat"},
+		{ID: "not-namespaced"},
+		{ID: "lmstudio/laguna"},
+	})
+
+	if len(added) != 1 || added[0] != "lmstudio/laguna" {
+		t.Fatalf("added = %v", added)
+	}
+	if len(removed) != 1 || removed[0] != "lmstudio/old" {
+		t.Fatalf("removed = %v", removed)
+	}
+	if len(p.Models) != 2 || p.Models[0].ID != "native" || p.Models[1].ID != "lmstudio/laguna" {
+		t.Fatalf("models = %+v", p.Models)
+	}
+
+	_, removed = r.ReplaceLMStudioModels(p.ID, nil)
+	if len(removed) != 1 || removed[0] != "lmstudio/laguna" || len(p.Models) != 1 || p.Models[0].ID != "native" {
+		t.Fatalf("empty replacement: removed=%v models=%+v", removed, p.Models)
+	}
+}
+
+func TestReplaceLMStudioModelsRequiresLinkedProvider(t *testing.T) {
+	r := New(testLogger())
+	p := &Provider{ID: "provider", Models: []protocol.ModelInfo{{ID: "native"}}}
+	r.providers[p.ID] = p
+
+	added, removed := r.ReplaceLMStudioModels(p.ID, []protocol.ModelInfo{{ID: "lmstudio/laguna"}})
+	if len(added) != 0 || len(removed) != 0 || len(p.Models) != 1 {
+		t.Fatalf("unlinked provider mutated: added=%v removed=%v models=%+v", added, removed, p.Models)
+	}
+}
+
+func TestLMStudioNamespaceIsNeverPubliclyRoutable(t *testing.T) {
+	r := New(testLogger())
+	p := &Provider{Models: []protocol.ModelInfo{{ID: "lmstudio/laguna"}}}
+
+	r.mu.RLock()
+	p.mu.Lock()
+	public := r.providerServesRoutableModelLocked(p, "lmstudio/laguna", false)
+	owner := r.providerServesRoutableModelLocked(p, "lmstudio/laguna", true)
+	p.mu.Unlock()
+	r.mu.RUnlock()
+
+	if public {
+		t.Fatal("LM Studio model became public fleet capacity")
+	}
+	if !owner {
+		t.Fatal("LM Studio model should remain available to owner self-route")
+	}
+}

--- a/coordinator/registry/routing_eligibility.go
+++ b/coordinator/registry/routing_eligibility.go
@@ -1,6 +1,9 @@
 package registry
 
-import "time"
+import (
+	"strings"
+	"time"
+)
 
 // routing_eligibility.go holds the composable primitives shared by every
 // provider-eligibility decision. Five functions historically re-implemented
@@ -73,6 +76,11 @@ func (r *Registry) providerLivenessGateLocked(p *Provider, minTrust TrustLevel, 
 // alias routability, warm detection, and the load planner so the catalog +
 // dedicated decision cannot drift across them. Caller holds r.mu and p.mu.
 func (r *Registry) providerServesRoutableModelLocked(p *Provider, model string, allowDedicated bool) bool {
+	// LM Studio is an explicit owner convenience, never public fleet capacity.
+	// Keep the namespace private even if a future catalog entry uses the same ID.
+	if strings.HasPrefix(model, lmStudioModelPrefix) && !allowDedicated {
+		return false
+	}
 	var serves bool
 	if allowDedicated {
 		serves = r.providerServesOwnedRoutableModelLocked(p, model)

--- a/docs/provider/self-route.md
+++ b/docs/provider/self-route.md
@@ -45,6 +45,21 @@ In the console UI: the **My Machine** toggle in the chat composer sends
 `prefer` (prioritized, never stuck), and the **"My Machine only — free"**
 checkbox on an API key sets the strict `self_route_only` ceiling.
 
+### Using models loaded in LM Studio
+
+Darkbloom also watches LM Studio's default local server at
+`127.0.0.1:1234`. When both apps are running, any text model you load in LM
+Studio appears automatically in your self-route model list as
+`lmstudio/<lm-studio-model-key>`; unloading it removes it again. No Darkbloom
+restart or model copy is needed.
+
+For example, loading `laguna-s-2.1-nvfp4-mlx` in LM Studio exposes
+`lmstudio/laguna-s-2.1-nvfp4-mlx`. Use that exact model id with
+`X-Darkbloom-Route: self`. These models are never advertised to the public
+fleet. The coordinator still sees only encrypted request and response data;
+the signed provider decrypts locally and passes the request over loopback to
+LM Studio.
+
 The policy resolution is server-side in `coordinator/api/self_route.go:49-65`.
 
 ### Exclusive vs prefer

--- a/docs/reference/protocol-messages.md
+++ b/docs/reference/protocol-messages.md
@@ -6,7 +6,7 @@ The provider WebSocket is mounted at `GET /ws/provider`. All messages are JSON w
 
 | Direction | Types |
 |---|---|
-| Provider → Coordinator | `register`, `heartbeat`, `inference_accepted`, `inference_response_chunk`, `inference_complete`, `inference_error`, `attestation_response`, `code_attestation_response`, `load_model_status`, `prefetch_model_status`, `models_update` |
+| Provider → Coordinator | `register`, `heartbeat`, `inference_accepted`, `inference_response_chunk`, `inference_complete`, `inference_error`, `attestation_response`, `code_attestation_response`, `load_model_status`, `prefetch_model_status`, `models_update`, `lmstudio_models_update` |
 | Coordinator → Provider | `inference_request`, `cancel`, `attestation_challenge`, `runtime_status`, `load_model`, `prefetch_model`, `desired_models`, `trust_status` |
 
 Unknown provider→coordinator types are rejected by [`ProviderMessage.UnmarshalJSON`](../../coordinator/protocol/messages.go).

--- a/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClientCodec.swift
+++ b/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClientCodec.swift
@@ -184,6 +184,9 @@ public enum CoordinatorClientCodec {
         case .modelsUpdate(let models):
             return .modelsUpdate(ProviderMessage.ModelsUpdate(models: models))
 
+        case .lmStudioModelsUpdate(let models):
+            return .lmStudioModelsUpdate(ProviderMessage.LMStudioModelsUpdate(models: models))
+
         case .prefixCacheLookup(
             let requestId, let nonce, let outcome, let tier,
             let cachedTokens, let prefillTokensSaved, let stageMs

--- a/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClientTypes.swift
+++ b/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClientTypes.swift
@@ -151,6 +151,8 @@ public enum OutboundMessage: Sendable {
     /// (e.g. a verified prefetch), carrying full `ModelInfo` including the
     /// computed weight hash so the coordinator can cross-check before routing.
     case modelsUpdate(models: [ModelInfo])
+    /// Replaces the linked provider's owner-only LM Studio inventory.
+    case lmStudioModelsUpdate(models: [ModelInfo])
     case prefixCacheLookup(
         requestId: String,
         cacheReceiptNonce: String,

--- a/provider-swift/Sources/ProviderCore/LMStudio/LMStudioClient.swift
+++ b/provider-swift/Sources/ProviderCore/LMStudio/LMStudioClient.swift
@@ -1,0 +1,184 @@
+import Foundation
+
+struct LMStudioLoadedModel: Sendable, Equatable {
+    let darkbloomID: String
+    let instanceID: String
+    let sizeBytes: UInt64
+    let quantization: String
+    let contextLength: Int64
+    let maxConcurrency: UInt32
+    let isVision: Bool
+
+    var modelInfo: ModelInfo {
+        ModelInfo(
+            id: darkbloomID,
+            modelType: "chat",
+            quantization: quantization,
+            sizeBytes: sizeBytes,
+            estimatedMemoryGb: Double(sizeBytes) / 1_073_741_824,
+            isVision: isVision
+        )
+    }
+}
+
+enum LMStudioClientError: Error {
+    case invalidResponse
+    case httpStatus(Int)
+    case invalidRequest
+
+    var statusCode: UInt16 {
+        switch self {
+        case .httpStatus(let status) where (400..<500).contains(status):
+            return UInt16(status)
+        default:
+            return 502
+        }
+    }
+}
+
+struct LMStudioClient: Sendable {
+    static let defaultBaseURL = URL(string: "http://127.0.0.1:1234")!
+
+    let baseURL: URL
+    let session: URLSession
+
+    init(baseURL: URL = defaultBaseURL, session: URLSession = .shared) {
+        self.baseURL = baseURL
+        self.session = session
+    }
+
+    func loadedModels() async throws -> [LMStudioLoadedModel] {
+        var request = URLRequest(url: baseURL.appending(path: "api/v1/models"))
+        request.timeoutInterval = 1
+        let (data, response) = try await session.data(for: request)
+        guard let http = response as? HTTPURLResponse else {
+            throw LMStudioClientError.invalidResponse
+        }
+        guard http.statusCode == 200 else {
+            throw LMStudioClientError.httpStatus(http.statusCode)
+        }
+
+        let payload = try JSONDecoder().decode(ModelsResponse.self, from: data)
+        return payload.models.compactMap { model in
+            guard model.type == "llm", !model.key.isEmpty,
+                let instance = model.loadedInstances.first, !instance.id.isEmpty
+            else { return nil }
+            return LMStudioLoadedModel(
+                darkbloomID: "lmstudio/\(model.key)",
+                instanceID: instance.id,
+                sizeBytes: model.sizeBytes,
+                quantization: model.quantization?.name ?? "",
+                contextLength: instance.config?.contextLength ?? model.maxContextLength ?? 0,
+                maxConcurrency: UInt32(clamping: max(1, instance.config?.parallel ?? 1)),
+                isVision: model.capabilities?.vision ?? false
+            )
+        }.sorted { $0.darkbloomID < $1.darkbloomID }
+    }
+
+    func streamChatCompletion(
+        body: Data,
+        instanceID: String,
+        onEvent: (String) async throws -> Void
+    ) async throws {
+        var request = URLRequest(url: baseURL.appending(path: "v1/chat/completions"))
+        request.httpMethod = "POST"
+        request.timeoutInterval = 60 * 60
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try Self.streamingRequestBody(body, instanceID: instanceID)
+
+        let (bytes, response) = try await session.bytes(for: request)
+        guard let http = response as? HTTPURLResponse else {
+            throw LMStudioClientError.invalidResponse
+        }
+        guard (200..<300).contains(http.statusCode) else {
+            throw LMStudioClientError.httpStatus(http.statusCode)
+        }
+
+        var eventBytes = Data()
+        for try await byte in bytes {
+            try Task.checkCancellation()
+            eventBytes.append(byte)
+            if eventBytes.count > 1_048_576 {
+                throw LMStudioClientError.invalidResponse
+            }
+            let separatorLength: Int
+            if eventBytes.suffix(2).elementsEqual([10, 10]) {
+                separatorLength = 2
+            } else if eventBytes.suffix(4).elementsEqual([13, 10, 13, 10]) {
+                separatorLength = 4
+            } else {
+                continue
+            }
+            let payload = eventBytes.dropLast(separatorLength)
+            if !payload.isEmpty {
+                let event = String(decoding: payload, as: UTF8.self)
+                    .replacingOccurrences(of: "\r\n", with: "\n")
+                try await onEvent(event + "\n\n")
+            }
+            eventBytes.removeAll(keepingCapacity: true)
+        }
+        if !eventBytes.isEmpty {
+            let event = String(decoding: eventBytes, as: UTF8.self)
+                .replacingOccurrences(of: "\r\n", with: "\n")
+            try await onEvent(event + "\n\n")
+        }
+    }
+
+    static func streamingRequestBody(_ body: Data, instanceID: String) throws -> Data {
+        guard var object = try JSONSerialization.jsonObject(with: body) as? [String: Any] else {
+            throw LMStudioClientError.invalidRequest
+        }
+        object["model"] = instanceID
+        object["stream"] = true
+        var streamOptions = object["stream_options"] as? [String: Any] ?? [:]
+        streamOptions["include_usage"] = true
+        object["stream_options"] = streamOptions
+        return try JSONSerialization.data(withJSONObject: object)
+    }
+}
+
+private extension LMStudioClient {
+    struct ModelsResponse: Decodable {
+        let models: [Model]
+    }
+
+    struct Model: Decodable {
+        let type: String
+        let key: String
+        let sizeBytes: UInt64
+        let maxContextLength: Int64?
+        let quantization: Quantization?
+        let loadedInstances: [LoadedInstance]
+        let capabilities: Capabilities?
+
+        enum CodingKeys: String, CodingKey {
+            case type, key, quantization, capabilities
+            case sizeBytes = "size_bytes"
+            case maxContextLength = "max_context_length"
+            case loadedInstances = "loaded_instances"
+        }
+    }
+
+    struct Quantization: Decodable {
+        let name: String
+    }
+
+    struct Capabilities: Decodable {
+        let vision: Bool?
+    }
+
+    struct LoadedInstance: Decodable {
+        let id: String
+        let config: InstanceConfig?
+    }
+
+    struct InstanceConfig: Decodable {
+        let contextLength: Int64?
+        let parallel: Int?
+
+        enum CodingKeys: String, CodingKey {
+            case contextLength = "context_length"
+            case parallel
+        }
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Protocol/Messages.swift
+++ b/provider-swift/Sources/ProviderCore/Protocol/Messages.swift
@@ -70,6 +70,7 @@ public enum ProviderMessage: Sendable, Equatable {
     case loadModelStatus(LoadModelStatus)
     case prefetchModelStatus(PrefetchModelStatus)
     case modelsUpdate(ModelsUpdate)
+    case lmStudioModelsUpdate(LMStudioModelsUpdate)
     case prefixCacheLookup(PrefixCacheLookup)
     case prefixCacheReady(PrefixCacheReady)
     case prefixCacheLookupV2(PrefixCacheLookupV2)
@@ -478,6 +479,16 @@ public enum ProviderMessage: Sendable, Equatable {
         }
     }
 
+    /// The authoritative set of LM Studio text-model instances currently
+    /// loaded on this Mac. IDs use the reserved `lmstudio/` namespace.
+    public struct LMStudioModelsUpdate: Sendable, Equatable {
+        public var models: [ModelInfo]
+
+        public init(models: [ModelInfo]) {
+            self.models = models
+        }
+    }
+
     public struct AttestationResponse: Sendable, Equatable {
         public var nonce: String
         public var signature: String
@@ -555,6 +566,7 @@ extension ProviderMessage: Codable {
         case loadModelStatus = "load_model_status"
         case prefetchModelStatus = "prefetch_model_status"
         case modelsUpdate = "models_update"
+        case lmStudioModelsUpdate = "lmstudio_models_update"
         case prefixCacheLookup = "prefix_cache_lookup"
         case prefixCacheReady = "prefix_cache_ready"
         case prefixCacheLookupV2 = "prefix_cache_lookup_v2"
@@ -763,6 +775,10 @@ extension ProviderMessage: Codable {
             // Reuse the ModelInfo encoding shared with `register`'s models[].
             try container.encode(u.models, forKey: .models)
 
+        case .lmStudioModelsUpdate(let u):
+            try container.encode(TypeValue.lmStudioModelsUpdate, forKey: .type)
+            try container.encode(u.models, forKey: .models)
+
         case .prefixCacheLookup(let receipt):
             try container.encode(TypeValue.prefixCacheLookup, forKey: .type)
             try container.encode(receipt.requestId, forKey: .requestId)
@@ -954,6 +970,11 @@ extension ProviderMessage: Codable {
 
         case .modelsUpdate:
             self = .modelsUpdate(ModelsUpdate(
+                models: try container.decode([ModelInfo].self, forKey: .models)
+            ))
+
+        case .lmStudioModelsUpdate:
+            self = .lmStudioModelsUpdate(LMStudioModelsUpdate(
                 models: try container.decode([ModelInfo].self, forKey: .models)
             ))
 

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+Capacity.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+Capacity.swift
@@ -98,6 +98,23 @@ extension ProviderLoop {
             totalActive += engineV2.activeRequests
         }
 
+        for model in lmStudioModels.values.sorted(by: { $0.darkbloomID < $1.darkbloomID }) {
+            let running = requestToModel.values.reduce(into: 0) { count, modelID in
+                if modelID == model.darkbloomID { count += 1 }
+            }
+            allSlots.append(BackendSlotCapacity(
+                model: model.darkbloomID,
+                state: running > 0 ? "running" : "idle",
+                numRunning: UInt32(clamping: running),
+                numWaiting: 0,
+                activeTokens: 0,
+                maxTokensPotential: model.contextLength,
+                maxConcurrency: model.maxConcurrency,
+                activeTokenBudgetMax: model.contextLength * Int64(model.maxConcurrency)
+            ))
+            totalActive += running
+        }
+
         let gbDivisor = 1024.0 * 1024.0 * 1024.0
         let totalMem = ProcessInfo.processInfo.physicalMemory
 

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+Capacity.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+Capacity.swift
@@ -98,19 +98,26 @@ extension ProviderLoop {
             totalActive += engineV2.activeRequests
         }
 
+        var lmStudioRunning: [String: Int] = [:]
+        for modelID in requestToModel.values where modelID.hasPrefix("lmstudio/") {
+            lmStudioRunning[modelID, default: 0] += 1
+        }
         for model in lmStudioModels.values.sorted(by: { $0.darkbloomID < $1.darkbloomID }) {
-            let running = requestToModel.values.reduce(into: 0) { count, modelID in
-                if modelID == model.darkbloomID { count += 1 }
-            }
+            let running = lmStudioRunning[model.darkbloomID, default: 0]
+            let contextLength = max(0, model.contextLength)
+            let (potential, potentialOverflow) = contextLength.multipliedReportingOverflow(
+                by: Int64(clamping: running))
+            let (budget, budgetOverflow) = contextLength.multipliedReportingOverflow(
+                by: Int64(model.maxConcurrency))
             allSlots.append(BackendSlotCapacity(
                 model: model.darkbloomID,
                 state: running > 0 ? "running" : "idle",
                 numRunning: UInt32(clamping: running),
                 numWaiting: 0,
                 activeTokens: 0,
-                maxTokensPotential: model.contextLength,
+                maxTokensPotential: potentialOverflow ? .max : potential,
                 maxConcurrency: model.maxConcurrency,
-                activeTokenBudgetMax: model.contextLength * Int64(model.maxConcurrency)
+                activeTokenBudgetMax: budgetOverflow ? .max : budget
             ))
             totalActive += running
         }

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+InferenceHandler.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+InferenceHandler.swift
@@ -34,7 +34,7 @@ extension ProviderLoop {
 
     /// Coordinator admission: sends the 503 reroute and returns true if the
     /// request must be dropped because we're draining.
-    private func rejectIfDrainingForUpdate(
+    internal func rejectIfDrainingForUpdate(
         requestId: String,
         send: SendHandle,
         lookupReceiptFinalizer: PrefixCacheLookupReceiptFinalizer
@@ -245,6 +245,27 @@ extension ProviderLoop {
         // deliberately conservative: when in doubt it admits and lets the
         // post-accept load path below make the final call.
         let modelId = chatRequest.model
+        if let lmStudioModel = lmStudioModels[modelId] {
+            if rejectIfDrainingForUpdate(
+                requestId: requestId,
+                send: send,
+                lookupReceiptFinalizer: lookupReceiptFinalizer)
+            {
+                return
+            }
+            let token = await cancellationRegistry.register(requestId: requestId)
+            receiptTransferredToTask = true
+            await handleLMStudioInference(
+                requestId: requestId,
+                requestBody: decryptedData,
+                senderKey: senderKey,
+                model: lmStudioModel,
+                token: token,
+                lookupReceiptFinalizer: lookupReceiptFinalizer,
+                send: send
+            )
+            return
+        }
         if await fastAdmissionReject(modelId: modelId) {
             logger.warning("[\(requestId)] Pre-accept reject for '\(modelId)': insufficient capacity to load")
             lookupReceiptFinalizer.sendTerminal(

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+LMStudio.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+LMStudio.swift
@@ -25,10 +25,16 @@ extension ProviderLoop {
             discovered = []
         }
 
-        let next = Dictionary(uniqueKeysWithValues: discovered.map { ($0.darkbloomID, $0) })
+        var next: [String: LMStudioLoadedModel] = [:]
+        for model in discovered {
+            next[model.darkbloomID] = model
+        }
         guard force || next != lmStudioModels else { return }
         lmStudioModels = next
-        send.send(.lmStudioModelsUpdate(models: discovered.map(\.modelInfo)))
+        let models = next.values
+            .sorted { $0.darkbloomID < $1.darkbloomID }
+            .map(\.modelInfo)
+        send.send(.lmStudioModelsUpdate(models: models))
         await updateAggregateCapacity()
     }
 

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+LMStudio.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+LMStudio.swift
@@ -2,6 +2,9 @@ import Foundation
 
 private struct LMStudioRelayEncryptionError: Error {}
 
+private let lmStudioActivePollNanoseconds: UInt64 = 2_000_000_000
+private let lmStudioIdlePollNanoseconds: UInt64 = 10_000_000_000
+
 extension ProviderLoop {
     internal func startLMStudioMonitor(send: SendHandle) {
         lmStudioMonitorTask?.cancel()
@@ -9,9 +12,16 @@ extension ProviderLoop {
             guard let self else { return }
             while !Task.isCancelled {
                 await self.refreshLMStudioModels(send: send)
-                try? await Task.sleep(nanoseconds: 2_000_000_000)
+                let interval = await self.lmStudioPollIntervalNanoseconds()
+                try? await Task.sleep(nanoseconds: interval)
             }
         }
+    }
+
+    private func lmStudioPollIntervalNanoseconds() -> UInt64 {
+        lmStudioModels.isEmpty
+            ? lmStudioIdlePollNanoseconds
+            : lmStudioActivePollNanoseconds
     }
 
     internal func refreshLMStudioModels(send: SendHandle, force: Bool = false) async {

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+LMStudio.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+LMStudio.swift
@@ -1,0 +1,204 @@
+import Foundation
+
+private struct LMStudioRelayEncryptionError: Error {}
+
+extension ProviderLoop {
+    internal func startLMStudioMonitor(send: SendHandle) {
+        lmStudioMonitorTask?.cancel()
+        lmStudioMonitorTask = Task { [weak self] in
+            guard let self else { return }
+            while !Task.isCancelled {
+                await self.refreshLMStudioModels(send: send)
+                try? await Task.sleep(nanoseconds: 2_000_000_000)
+            }
+        }
+    }
+
+    internal func refreshLMStudioModels(send: SendHandle, force: Bool = false) async {
+        let discovered: [LMStudioLoadedModel]
+        do {
+            discovered = try await lmStudioClient.loadedModels()
+        } catch {
+            // LM Studio is optional. If it disappears, remove any models it
+            // previously exposed; otherwise stay silent.
+            if lmStudioModels.isEmpty { return }
+            discovered = []
+        }
+
+        let next = Dictionary(uniqueKeysWithValues: discovered.map { ($0.darkbloomID, $0) })
+        guard force || next != lmStudioModels else { return }
+        lmStudioModels = next
+        send.send(.lmStudioModelsUpdate(models: discovered.map(\.modelInfo)))
+        await updateAggregateCapacity()
+    }
+
+    internal func handleLMStudioInference(
+        requestId: String,
+        requestBody: Data,
+        senderKey: Data,
+        model: LMStudioLoadedModel,
+        token: InferenceCancellationToken,
+        lookupReceiptFinalizer: PrefixCacheLookupReceiptFinalizer,
+        send: SendHandle
+    ) async {
+        requestToModel[requestId] = model.darkbloomID
+        powerAssertion.acquire()
+        await updateAggregateCapacity()
+        send.send(.inferenceAccepted(requestId: requestId))
+
+        let client = lmStudioClient
+        let keyPair = self.keyPair
+        let stats = self.stats
+        let signer = self.signer
+        let registry = self.cancellationRegistry
+        let log = self.logger
+        let me = self
+
+        let task = Task.detached {
+            defer {
+                lookupReceiptFinalizer.finalize(failure: .policy)
+                Task {
+                    await registry.finish(requestId: requestId)
+                    await me.finishInflightRequest(requestId: requestId)
+                }
+            }
+
+            let sharedKey: Data
+            do {
+                sharedKey = try keyPair.precomputeSharedKey(recipientPublicKey: senderKey)
+            } catch {
+                stats.incrementChunkEncryptionErrors()
+                lookupReceiptFinalizer.sendTerminal(
+                    .inferenceError(
+                        requestId: requestId,
+                        error: "response encryption failed",
+                        statusCode: 500,
+                        errorReason: nil),
+                    fallbackFailure: .policy,
+                    send: send)
+                return
+            }
+
+            var fullResponseText = ""
+            var promptTokens = 0
+            var completionTokens = 0
+            var contentFrameCount = 0
+            var deliveredOutput = false
+
+            do {
+                try await client.streamChatCompletion(
+                    body: requestBody,
+                    instanceID: model.instanceID
+                ) { frame in
+                    if token.isCancelled { throw CancellationError() }
+                    if let parsed = Self.parseStreamChunk(frame) {
+                        var frameHasOutput = false
+                        if let content = parsed.contentDelta, !content.isEmpty {
+                            fullResponseText += content
+                            frameHasOutput = true
+                        }
+                        if let reasoning = parsed.reasoningDelta, !reasoning.isEmpty {
+                            fullResponseText += reasoning
+                            frameHasOutput = true
+                        }
+                        if let toolCalls = parsed.toolCallsDelta, !toolCalls.isEmpty {
+                            fullResponseText += Self.encodeToolCallsForHash(toolCalls)
+                            frameHasOutput = true
+                        }
+                        if frameHasOutput {
+                            deliveredOutput = true
+                            contentFrameCount += 1
+                        }
+                        if let usage = parsed.usage {
+                            promptTokens = usage.promptTokens
+                            completionTokens = usage.completionTokens
+                        }
+                    }
+
+                    let encrypted: EncryptedPayload
+                    do {
+                        encrypted = try keyPair.encryptPayloadFast(
+                            sharedKey: sharedKey,
+                            plaintext: Data(frame.utf8)
+                        )
+                    } catch {
+                        throw LMStudioRelayEncryptionError()
+                    }
+                    send.sendChunk(.inferenceChunk(
+                        requestId: requestId,
+                        data: "",
+                        encryptedData: encrypted
+                    ))
+                }
+            } catch {
+                if error is CancellationError || token.isCancelled {
+                    if !deliveredOutput {
+                        stats.incrementCancellationsBeforeOutput()
+                        lookupReceiptFinalizer.sendTerminal(
+                            .inferenceError(
+                                requestId: requestId,
+                                error: "request cancelled",
+                                statusCode: 499,
+                                errorReason: nil),
+                            fallbackFailure: .policy,
+                            send: send)
+                        return
+                    }
+                    stats.incrementCancellationsPartialComplete()
+                } else if error is LMStudioRelayEncryptionError {
+                    stats.incrementChunkEncryptionErrors()
+                    lookupReceiptFinalizer.sendTerminal(
+                        .inferenceError(
+                            requestId: requestId,
+                            error: "response encryption failed",
+                            statusCode: 500,
+                            errorReason: nil),
+                        fallbackFailure: .policy,
+                        send: send)
+                    return
+                } else {
+                    let status = (error as? LMStudioClientError)?.statusCode ?? 502
+                    log.warning("[\(requestId)] LM Studio inference failed (\(type(of: error)))")
+                    lookupReceiptFinalizer.sendTerminal(
+                        .inferenceError(
+                            requestId: requestId,
+                            error: status == 502 ? "LM Studio is unavailable" : "LM Studio rejected the request",
+                            statusCode: status,
+                            errorReason: nil),
+                        fallbackFailure: status == 503 ? .capacity : .policy,
+                        send: send)
+                    return
+                }
+            }
+
+            if completionTokens == 0 && contentFrameCount > 0 {
+                completionTokens = contentFrameCount
+            }
+            stats.incrementRequestsServed()
+            stats.addTokensGenerated(UInt64(max(0, completionTokens)))
+            let attestation = computeResponseAttestation(
+                identity: signer,
+                requestId: requestId,
+                completionTokens: UInt64(max(0, completionTokens)),
+                responseBody: fullResponseText
+            )
+            lookupReceiptFinalizer.sendTerminal(
+                .inferenceComplete(
+                    requestId: requestId,
+                    usage: UsageInfo(
+                        promptTokens: UInt64(max(0, promptTokens)),
+                        completionTokens: UInt64(max(0, completionTokens))
+                    ),
+                    stopSequence: nil,
+                    seSignature: attestation.signature,
+                    responseHash: attestation.hash),
+                fallbackFailure: .policy,
+                send: send)
+        }
+
+        inflightTasks[requestId] = task
+        if completedBeforeTaskRegistration.remove(requestId) != nil {
+            inflightTasks.removeValue(forKey: requestId)
+        }
+    }
+}

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+Serve.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+Serve.swift
@@ -234,6 +234,7 @@ extension ProviderLoop {
         startIdleMonitor()
         startCapacityRefreshMonitor()
         startAutoUpdateMonitor()
+        startLMStudioMonitor(send: send)
 
         logger.info("Coordinator client started, entering event loop")
 
@@ -245,6 +246,7 @@ extension ProviderLoop {
                 switch event {
                 case .connected:
                     logger.info("Connected to coordinator")
+                    await refreshLMStudioModels(send: send, force: true)
 
                 case .disconnected:
                     logger.warning("Disconnected from coordinator")
@@ -323,6 +325,8 @@ extension ProviderLoop {
         autoUpdateTask = nil
         autoReportTask?.cancel()
         autoReportTask = nil
+        lmStudioMonitorTask?.cancel()
+        lmStudioMonitorTask = nil
         // Cancel any scheduled desired-build prefetch retries before tearing
         // the prefetch subsystem down.
         for task in desiredPrefetchRetryTasks.values { task.cancel() }
@@ -389,9 +393,10 @@ extension ProviderLoop {
     }
 
     private func privacyCapabilitiesForRegistration() -> PrivacyCapabilities {
-        // textBackendInprocess + textProxyDisabled: always true on the Swift
-        //   provider -- inference runs in-process via mlx-swift-lm, no HTTP
-        //   proxy is involved.
+        // textBackendInprocess + textProxyDisabled describe the public Swift
+        // backend, which always runs in-process via mlx-swift-lm. The optional
+        // LM Studio loopback bridge advertises only reserved, owner-only model
+        // IDs and is never eligible for public routing.
         // pythonRuntimeLocked + dangerousModulesBlocked: report false. There
         //   is no Python runtime to lock anymore. Coordinator's Swift-runtime
         //   trust path (registry.BackendUsesSwiftRuntime) doesn't read these.

--- a/provider-swift/Sources/ProviderCore/ProviderLoop.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop.swift
@@ -357,6 +357,12 @@ public actor ProviderLoop {
     /// `installPrefetchCoordinatorForTesting`.
     internal var outboundSend: SendHandle?
 
+    /// Optional loopback bridge for text models the owner has loaded in LM
+    /// Studio. Dynamic inventory is kept separate from native MLX slots.
+    internal let lmStudioClient = LMStudioClient()
+    internal var lmStudioModels: [String: LMStudioLoadedModel] = [:]
+    internal var lmStudioMonitorTask: Task<Void, Never>?
+
     /// Tracks coordinator-driven preload tasks so they can be cancelled on shutdown.
     internal var preloadTasks: [String: Task<Void, Never>] = [:]
 

--- a/provider-swift/Tests/ProviderCoreTests/Helpers/MockCoordinator.swift
+++ b/provider-swift/Tests/ProviderCoreTests/Helpers/MockCoordinator.swift
@@ -607,6 +607,7 @@ public final class MockCoordinator: @unchecked Sendable {
             case .loadModelStatus(let s):    captured.loadModelStatuses.append(s)
             case .prefetchModelStatus(let s): captured.prefetchModelStatuses.append(s)
             case .modelsUpdate(let u):       captured.modelsUpdates.append(u)
+            case .lmStudioModelsUpdate:      break
             case .prefixCacheLookup(let r):  captured.prefixCacheLookups.append(r)
             case .prefixCacheReady(let r):   captured.prefixCacheReady.append(r)
             case .prefixCacheLookupV2(let r): captured.prefixCacheLookupsV2.append(r)

--- a/provider-swift/Tests/ProviderCoreTests/LMStudioClientTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/LMStudioClientTests.swift
@@ -1,0 +1,109 @@
+import Foundation
+import Testing
+@testable import ProviderCore
+
+private final class LMStudioURLProtocol: URLProtocol, @unchecked Sendable {
+    static let lock = NSLock()
+    nonisolated(unsafe) static var responseData = Data()
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        Self.lock.lock()
+        let data = request.url?.path == "/v1/chat/completions"
+            ? Data("data: {\"choices\":[{\"delta\":{\"content\":\"hi\"}}]}\n\ndata: [DONE]\n\n".utf8)
+            : Self.responseData
+        Self.lock.unlock()
+        let response = HTTPURLResponse(
+            url: request.url!, statusCode: 200, httpVersion: nil,
+            headerFields: ["Content-Type": request.url?.path == "/v1/chat/completions"
+                ? "text/event-stream" : "application/json"]
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: data)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}
+
+@Test func lmStudioDiscoveryOnlyAdvertisesLoadedTextModels() async throws {
+    LMStudioURLProtocol.lock.withLock {
+        LMStudioURLProtocol.responseData = Data(#"""
+        {
+          "models": [
+            {
+              "type": "llm",
+              "key": "laguna-s-2.1-nvfp4-mlx",
+              "size_bytes": 71905944629,
+              "quantization": {"name": "4bit"},
+              "capabilities": {"vision": false},
+              "loaded_instances": [{"id": "laguna-instance", "config": {"context_length": 131072, "parallel": 2}}]
+            },
+            {
+              "type": "llm",
+              "key": "downloaded-but-not-loaded",
+              "size_bytes": 10,
+              "loaded_instances": []
+            },
+            {
+              "type": "embedding",
+              "key": "embedding-model",
+              "size_bytes": 10,
+              "loaded_instances": [{"id": "embedding-instance"}]
+            }
+          ]
+        }
+        """#.utf8)
+    }
+
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [LMStudioURLProtocol.self]
+    let client = LMStudioClient(
+        baseURL: URL(string: "http://127.0.0.1:1234")!,
+        session: URLSession(configuration: config)
+    )
+
+    let models = try await client.loadedModels()
+    let model = try #require(models.first)
+    #expect(models.count == 1)
+    #expect(model.darkbloomID == "lmstudio/laguna-s-2.1-nvfp4-mlx")
+    #expect(model.instanceID == "laguna-instance")
+    #expect(model.contextLength == 131_072)
+    #expect(model.maxConcurrency == 2)
+    #expect(model.modelInfo.sizeBytes == 71_905_944_629)
+}
+
+@Test func lmStudioRequestRewritePreservesBodyAndForcesStreamingUsage() throws {
+    let body = Data(#"{"model":"lmstudio/laguna","messages":[{"role":"user","content":"hello"}],"temperature":0.2,"stream":false}"#.utf8)
+    let rewritten = try LMStudioClient.streamingRequestBody(body, instanceID: "loaded-instance")
+    let object = try #require(
+        try JSONSerialization.jsonObject(with: rewritten) as? [String: Any]
+    )
+
+    #expect(object["model"] as? String == "loaded-instance")
+    #expect(object["stream"] as? Bool == true)
+    #expect(object["temperature"] as? Double == 0.2)
+    let options = try #require(object["stream_options"] as? [String: Any])
+    #expect(options["include_usage"] as? Bool == true)
+}
+
+@Test func lmStudioStreamingPreservesSSEEventBoundaries() async throws {
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [LMStudioURLProtocol.self]
+    let client = LMStudioClient(
+        baseURL: URL(string: "http://127.0.0.1:1234")!,
+        session: URLSession(configuration: config)
+    )
+    let body = Data(#"{"model":"lmstudio/laguna","messages":[]}"#.utf8)
+    var events: [String] = []
+
+    try await client.streamChatCompletion(body: body, instanceID: "loaded-instance") {
+        events.append($0)
+    }
+
+    try #require(events.count == 2)
+    #expect(events[0].hasPrefix("data: {\"choices\""))
+    #expect(events[1] == "data: [DONE]\n\n")
+}

--- a/provider-swift/Tests/ProviderCoreTests/LMStudioClientTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/LMStudioClientTests.swift
@@ -28,82 +28,85 @@ private final class LMStudioURLProtocol: URLProtocol, @unchecked Sendable {
     override func stopLoading() {}
 }
 
-@Test func lmStudioDiscoveryOnlyAdvertisesLoadedTextModels() async throws {
-    LMStudioURLProtocol.lock.withLock {
-        LMStudioURLProtocol.responseData = Data(#"""
-        {
-          "models": [
+@Suite("LM Studio client", .serialized)
+struct LMStudioClientTests {
+    @Test func discoveryOnlyAdvertisesLoadedTextModels() async throws {
+        LMStudioURLProtocol.lock.withLock {
+            LMStudioURLProtocol.responseData = Data(#"""
             {
-              "type": "llm",
-              "key": "laguna-s-2.1-nvfp4-mlx",
-              "size_bytes": 71905944629,
-              "quantization": {"name": "4bit"},
-              "capabilities": {"vision": false},
-              "loaded_instances": [{"id": "laguna-instance", "config": {"context_length": 131072, "parallel": 2}}]
-            },
-            {
-              "type": "llm",
-              "key": "downloaded-but-not-loaded",
-              "size_bytes": 10,
-              "loaded_instances": []
-            },
-            {
-              "type": "embedding",
-              "key": "embedding-model",
-              "size_bytes": 10,
-              "loaded_instances": [{"id": "embedding-instance"}]
+              "models": [
+                {
+                  "type": "llm",
+                  "key": "laguna-s-2.1-nvfp4-mlx",
+                  "size_bytes": 71905944629,
+                  "quantization": {"name": "4bit"},
+                  "capabilities": {"vision": false},
+                  "loaded_instances": [{"id": "laguna-instance", "config": {"context_length": 131072, "parallel": 2}}]
+                },
+                {
+                  "type": "llm",
+                  "key": "downloaded-but-not-loaded",
+                  "size_bytes": 10,
+                  "loaded_instances": []
+                },
+                {
+                  "type": "embedding",
+                  "key": "embedding-model",
+                  "size_bytes": 10,
+                  "loaded_instances": [{"id": "embedding-instance"}]
+                }
+              ]
             }
-          ]
+            """#.utf8)
         }
-        """#.utf8)
+
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [LMStudioURLProtocol.self]
+        let client = LMStudioClient(
+            baseURL: URL(string: "http://127.0.0.1:1234")!,
+            session: URLSession(configuration: config)
+        )
+
+        let models = try await client.loadedModels()
+        let model = try #require(models.first)
+        #expect(models.count == 1)
+        #expect(model.darkbloomID == "lmstudio/laguna-s-2.1-nvfp4-mlx")
+        #expect(model.instanceID == "laguna-instance")
+        #expect(model.contextLength == 131_072)
+        #expect(model.maxConcurrency == 2)
+        #expect(model.modelInfo.sizeBytes == 71_905_944_629)
     }
 
-    let config = URLSessionConfiguration.ephemeral
-    config.protocolClasses = [LMStudioURLProtocol.self]
-    let client = LMStudioClient(
-        baseURL: URL(string: "http://127.0.0.1:1234")!,
-        session: URLSession(configuration: config)
-    )
+    @Test func requestRewritePreservesBodyAndForcesStreamingUsage() throws {
+        let body = Data(#"{"model":"lmstudio/laguna","messages":[{"role":"user","content":"hello"}],"temperature":0.2,"stream":false}"#.utf8)
+        let rewritten = try LMStudioClient.streamingRequestBody(body, instanceID: "loaded-instance")
+        let object = try #require(
+            try JSONSerialization.jsonObject(with: rewritten) as? [String: Any]
+        )
 
-    let models = try await client.loadedModels()
-    let model = try #require(models.first)
-    #expect(models.count == 1)
-    #expect(model.darkbloomID == "lmstudio/laguna-s-2.1-nvfp4-mlx")
-    #expect(model.instanceID == "laguna-instance")
-    #expect(model.contextLength == 131_072)
-    #expect(model.maxConcurrency == 2)
-    #expect(model.modelInfo.sizeBytes == 71_905_944_629)
-}
-
-@Test func lmStudioRequestRewritePreservesBodyAndForcesStreamingUsage() throws {
-    let body = Data(#"{"model":"lmstudio/laguna","messages":[{"role":"user","content":"hello"}],"temperature":0.2,"stream":false}"#.utf8)
-    let rewritten = try LMStudioClient.streamingRequestBody(body, instanceID: "loaded-instance")
-    let object = try #require(
-        try JSONSerialization.jsonObject(with: rewritten) as? [String: Any]
-    )
-
-    #expect(object["model"] as? String == "loaded-instance")
-    #expect(object["stream"] as? Bool == true)
-    #expect(object["temperature"] as? Double == 0.2)
-    let options = try #require(object["stream_options"] as? [String: Any])
-    #expect(options["include_usage"] as? Bool == true)
-}
-
-@Test func lmStudioStreamingPreservesSSEEventBoundaries() async throws {
-    let config = URLSessionConfiguration.ephemeral
-    config.protocolClasses = [LMStudioURLProtocol.self]
-    let client = LMStudioClient(
-        baseURL: URL(string: "http://127.0.0.1:1234")!,
-        session: URLSession(configuration: config)
-    )
-    let body = Data(#"{"model":"lmstudio/laguna","messages":[]}"#.utf8)
-    var events: [String] = []
-
-    try await client.streamChatCompletion(body: body, instanceID: "loaded-instance") {
-        events.append($0)
+        #expect(object["model"] as? String == "loaded-instance")
+        #expect(object["stream"] as? Bool == true)
+        #expect(object["temperature"] as? Double == 0.2)
+        let options = try #require(object["stream_options"] as? [String: Any])
+        #expect(options["include_usage"] as? Bool == true)
     }
 
-    try #require(events.count == 2)
-    #expect(events[0].hasPrefix("data: {\"choices\""))
-    #expect(events[1] == "data: [DONE]\n\n")
+    @Test func streamingPreservesSSEEventBoundaries() async throws {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [LMStudioURLProtocol.self]
+        let client = LMStudioClient(
+            baseURL: URL(string: "http://127.0.0.1:1234")!,
+            session: URLSession(configuration: config)
+        )
+        let body = Data(#"{"model":"lmstudio/laguna","messages":[]}"#.utf8)
+        var events: [String] = []
+
+        try await client.streamChatCompletion(body: body, instanceID: "loaded-instance") {
+            events.append($0)
+        }
+
+        try #require(events.count == 2)
+        #expect(events[0].hasPrefix("data: {\"choices\""))
+        #expect(events[1] == "data: [DONE]\n\n")
+    }
 }

--- a/provider-swift/Tests/ProviderCoreTests/ProtocolTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ProtocolTests.swift
@@ -564,6 +564,24 @@ import Testing
     #expect(u.models[0].weightHash == "deadbeef")
 }
 
+@Test func lmStudioModelsUpdateRoundTrips() throws {
+    let info = ModelInfo(
+        id: "lmstudio/laguna-s-2.1-nvfp4-mlx",
+        modelType: "chat",
+        quantization: "4bit",
+        sizeBytes: 71_905_944_629,
+        estimatedMemoryGb: 67
+    )
+    let message: ProviderMessage = .lmStudioModelsUpdate(
+        ProviderMessage.LMStudioModelsUpdate(models: [info])
+    )
+
+    let encoded = try ProviderProtocolCodec.encodeProviderMessage(message)
+    let object = try jsonObject(encoded)
+    #expect(object["type"] as? String == "lmstudio_models_update")
+    #expect(try ProviderProtocolCodec.decodeProviderMessage(from: encoded) == message)
+}
+
 @Test func modelInfoTemplateRenderOKTriState() throws {
     // Wire contract (shared with coordinator/protocol/messages.go):
     // `template_render_ok` is tri-state — absent (old provider / check


### PR DESCRIPTION
## What this does

If LM Studio is running on the same Mac, models loaded there now show up in Darkbloom's self-route `/v1/models` response as `lmstudio/<model-key>`. They can be used right away through the normal OpenAI-compatible endpoint, and disappear when unloaded—no Darkbloom restart or duplicate download needed.

This stays owner-only: LM Studio models are never advertised as public fleet capacity. The coordinator relay remains encrypted, and the provider only hands plaintext to LM Studio over loopback.

For example, `laguna-s-2.1-nvfp4-mlx` appears as `lmstudio/laguna-s-2.1-nvfp4-mlx`.

## Before

```mermaid
flowchart LR
  subgraph Behavior
    B1[Load a model in LM Studio] --> B2[No change in Darkbloom]
    B3[Self-route request] --> B4[Native Darkbloom models only]
  end
  subgraph Code
    C1[ProviderLoop] --> C2[Native MLX handler]
    C3[Registry] --> C4[Catalog inventory]
  end
```

## After

```mermaid
flowchart LR
  subgraph Behavior
    B1[Load a model in LM Studio] --> B2[Appears in self-route /v1/models]
    B2 --> B3[Accepts inference immediately]
    B4[Unload the model] --> B5[Disappears]
  end
  subgraph Code
    C1[LMStudioClient poll] --> C2[ReplaceLMStudioModels]
    C2 --> C3[Owner-only registry entry]
    C4[ProviderLoop request] --> C5[LM Studio loopback stream]
    C5 --> C6[Encrypted relay response]
  end
```

## Checks

- `go test ./coordinator/...`
- `swift build`
- Focused Swift protocol, discovery, request rewrite, and SSE streaming tests

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/562"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787279256&installation_model_id=21733&pr_number=562&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F562&signature=c5525cb16c58e468ef00c31fbd5dd3c28861d7a1617757537f06fcada1ef58b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->