### PR TITLE
feat(inference): coordinator request actor fixes terminal-ordering races (step 3 of generation-deadline redesign)

### DIFF
--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -1817,7 +1817,18 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 		// Track providers that failed during retry so we don't dispatch to them again.
 		excludeProviders: make(map[string]struct{}),
 	}
+	d.actor = s.newRequestActor(
+		uuid.NewString(), consumerKey, model, publicModel,
+		chatActorEndpoint(isResponsesAPI), stream, 0)
 	d.run()
+}
+
+// chatActorEndpoint names the endpoint for the request actor's shadow journal.
+func chatActorEndpoint(isResponsesAPI bool) string {
+	if isResponsesAPI {
+		return "responses"
+	}
+	return "chat_completions"
 }
 
 // handleStreamingResponseWithFirstChunk streams SSE chunks to the consumer.
@@ -2069,6 +2080,14 @@ func (s *Server) handleStreamingResponseWithFirstChunk(w http.ResponseWriter, r 
 			return
 
 		case <-timer.C:
+			if !s.actorAcceptsClientTimeout(pr) {
+				// A provider terminal already won this attempt (its ChunkCh close /
+				// ErrorCh signal is imminent). Do not contradict billing by telling
+				// the client it timed out — re-arm and consume the real terminal
+				// (the fix for incident race #2).
+				timer.Reset(inferenceTimeout)
+				continue
+			}
 			markInferenceOutcome(r.Context(), pr.Model, requestClassTimeout)
 			s.refundReservedBalance(pr, "provider_timeout:"+pr.RequestID)
 			s.ddIncr("inference.in_band_error", []string{"model:" + pr.Model, "reason:timeout"})
@@ -2157,6 +2176,12 @@ func (s *Server) handleResponsesStreamingResponseWithFirstChunk(w http.ResponseW
 			return
 
 		case <-timer.C:
+			if !s.actorAcceptsClientTimeout(pr) {
+				// Provider terminal already won — do not contradict billing with a
+				// timeout; consume the real terminal instead (race #2).
+				timer.Reset(inferenceTimeout)
+				continue
+			}
 			markInferenceOutcome(r.Context(), pr.Model, requestClassTimeout)
 			s.refundReservedBalance(pr, "provider_timeout:"+pr.RequestID)
 			s.ddIncr("inference.in_band_error", []string{"model:" + pr.Model, "reason:timeout"})
@@ -2170,6 +2195,18 @@ func (s *Server) handleResponsesStreamingResponseWithFirstChunk(w http.ResponseW
 		}
 	}
 }
+
+// providerTerminalGrace bounds how long a non-streaming client-deadline path
+// waits for an already-won provider terminal to actually deliver on the pending
+// request's channels. It is entered only when the request actor reports a
+// provider terminal already claimed this attempt (incident race #2): the client
+// deadline (ctx) is a one-shot that stays permanently fired, so the wait is on
+// the real terminal channel plus this bounded timer, never on ctx again. It
+// matches the 2s grace the streaming path uses to wait for CompleteCh after
+// ChunkCh closes; if it expires the request falls through to the existing refund
+// + timeout (bounded quiescence — never hang forever). A var (not a const) only
+// so tests can shrink it; production never mutates it.
+var providerTerminalGrace = 2 * time.Second
 
 // handleNonStreamingResponseWithFirstChunk collects all chunks from the
 // provider and assembles them into a single OpenAI-compatible JSON response.
@@ -2190,150 +2227,7 @@ func (s *Server) handleNonStreamingResponseWithFirstChunk(w http.ResponseWriter,
 		select {
 		case chunk, ok := <-pr.ChunkCh:
 			if !ok {
-				select {
-				case errMsg, ok := <-pr.ErrorCh:
-					if ok && errMsg.Error != "" {
-						s.refundReservedBalance(pr, "provider_error:"+pr.RequestID)
-						s.noteInferenceError(pr.ProviderID, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason)
-						s.updateInferenceRouteOutcomeForPending(pr, preResponseProviderErrorOutcome(pr, errMsg))
-						s.writeGenericProviderError(w, errMsg)
-						return
-					}
-				default:
-				}
-				// The provider forwards the raw backend response as a single
-				// chunk. Detect complete responses (object=chat.completion
-				// or object=response) and pass through directly — this is
-				// format-agnostic and works for chat completions, Responses
-				// API, or any future endpoint without parsing.
-				if len(chunks) == 1 {
-					raw := strings.TrimPrefix(chunks[0], "data: ")
-					var obj map[string]any
-					if err := json.Unmarshal([]byte(raw), &obj); err == nil {
-						objType, _ := obj["object"].(string)
-						// Complete responses have object=chat.completion or
-						// object=response. Delta chunks have object=chat.completion.chunk.
-						if objType == "chat.completion" || objType == "response" {
-							var completeUsage protocol.UsageInfo
-							select {
-							case u, ok := <-pr.CompleteCh:
-								if !ok {
-									s.refundReservedBalance(pr, "provider_incomplete:"+pr.RequestID)
-									s.updateInferenceRouteOutcomeForPending(pr, preResponseProviderIncompleteOutcome(pr))
-									writeJSON(w, http.StatusBadGateway, errorResponse("provider_error", "provider ended without completion"))
-									return
-								}
-								completeUsage = u
-							case <-ctx.Done():
-								if errors.Is(ctx.Err(), context.DeadlineExceeded) {
-									s.refundReservedBalance(pr, "provider_timeout:"+pr.RequestID)
-									s.updateInferenceRouteOutcomeForPending(pr, preResponseTimeoutOutcome(pr, "usage_timeout_before_response"))
-									writeJSON(w, http.StatusGatewayTimeout, errorResponse("timeout", "timed out waiting for usage info"))
-								} else {
-									s.refundReservedBalance(pr, "client_gone:"+pr.RequestID)
-									s.updateInferenceRouteOutcomeForPending(pr, clientGoneBeforeResponseOutcome(pr))
-								}
-								return
-							}
-							if objType == "chat.completion" {
-								normalizeCompleteChatResponse(obj, consumerModel(pr))
-								// The provider engine reports "stop" even when generation
-								// hit the max-tokens bound — correct it from the
-								// authoritative token counts.
-								rewriteRawFinishReason(obj, completeUsage, pr.RequestedMaxTokens)
-								// Keep the passthrough path consistent with the
-								// SSE-reconstruction path: surface the provider's
-								// accurate reasoning-token count if its raw usage
-								// object didn't already carry one.
-								injectReasoningDetailIntoRawUsage(obj, completeUsage)
-								injectCacheDetailIntoRawUsage(obj, completeUsage)
-								if pr.ConsumerEndpoint == completionsEndpoint ||
-									pr.ConsumerEndpoint == messagesEndpoint {
-									encoded, err := json.Marshal(obj)
-									if err != nil {
-										writeJSON(w, http.StatusBadGateway, errorResponse("provider_error", "invalid provider response"))
-										return
-									}
-									msg := extractMessage([]string{"data: " + string(encoded)})
-									resp := buildGenericEndpointResponse(pr, msg, completeUsage)
-									s.noteInferenceSuccess(pr)
-									writeJSON(w, http.StatusOK, resp)
-									return
-								}
-								if pr.IsResponsesAPI {
-									var chatResp types.ChatCompletionResponse
-									b, err := json.Marshal(obj)
-									if err != nil {
-										log.Printf("WARN: failed to marshal chat response for Responses API conversion: %v", err)
-										writeJSON(w, http.StatusBadGateway, errorResponse("provider_error", "invalid provider response"))
-										return
-									}
-									if err := json.Unmarshal(b, &chatResp); err != nil {
-										log.Printf("WARN: failed to unmarshal chat response into typed struct: %v", err)
-										writeJSON(w, http.StatusBadGateway, errorResponse("provider_error", "invalid provider response"))
-										return
-									}
-									respObj := chatCompletionToResponses(
-										chatResp, consumerModel(pr), pr.SESignature,
-										pr.ResponseHash, pr.Traits)
-									s.noteInferenceSuccess(pr)
-									writeJSON(w, http.StatusOK, respObj)
-									return
-								}
-							} else {
-								// Native passthrough (object=="response"): the provider
-								// echoed the concrete build id; rewrite it to the public
-								// alias so the consumer never sees the quant/build.
-								sanitizeCacheDetailIntoRawResponsesUsage(obj, completeUsage)
-								if pr.PublicModel != "" {
-									obj["model"] = consumerModel(pr)
-								}
-							}
-							if pr.SESignature != "" {
-								obj["se_signature"] = pr.SESignature
-								obj["response_hash"] = pr.ResponseHash
-							}
-							s.noteInferenceSuccess(pr)
-							writeJSON(w, http.StatusOK, obj)
-							return
-						}
-					}
-				}
-
-				// Fallback: SSE delta chunks — reconstruct into response.
-				msg := extractMessage(chunks)
-				select {
-				case usage, ok := <-pr.CompleteCh:
-					if !ok {
-						s.refundReservedBalance(pr, "provider_incomplete:"+pr.RequestID)
-						s.updateInferenceRouteOutcomeForPending(pr, preResponseProviderIncompleteOutcome(pr))
-						writeJSON(w, http.StatusBadGateway, errorResponse("provider_error", "provider ended without completion"))
-						return
-					}
-					var resp any
-					if pr.IsResponsesAPI {
-						resp = buildResponsesResponse(
-							pr.RequestID, consumerModel(pr), msg, usage,
-							pr.RequestedMaxTokens, pr.SESignature, pr.ResponseHash,
-							pr.Traits)
-					} else if pr.ConsumerEndpoint == completionsEndpoint ||
-						pr.ConsumerEndpoint == messagesEndpoint {
-						resp = buildGenericEndpointResponse(pr, msg, usage)
-					} else {
-						resp = buildNonStreamingResponse(pr.RequestID, consumerModel(pr), msg, usage, pr.RequestedMaxTokens, pr.SESignature, pr.ResponseHash)
-					}
-					s.noteInferenceSuccess(pr)
-					writeJSON(w, http.StatusOK, resp)
-				case <-ctx.Done():
-					if errors.Is(ctx.Err(), context.DeadlineExceeded) {
-						s.refundReservedBalance(pr, "provider_timeout:"+pr.RequestID)
-						s.updateInferenceRouteOutcomeForPending(pr, preResponseTimeoutOutcome(pr, "usage_timeout_before_response"))
-						writeJSON(w, http.StatusGatewayTimeout, errorResponse("timeout", "timed out waiting for usage info"))
-					} else {
-						s.refundReservedBalance(pr, "client_gone:"+pr.RequestID)
-						s.updateInferenceRouteOutcomeForPending(pr, clientGoneBeforeResponseOutcome(pr))
-					}
-				}
+				s.finalizeNonStreamingResponse(w, pr, ctx, chunks)
 				return
 			}
 			chunks = append(chunks, chunk)
@@ -2342,14 +2236,24 @@ func (s *Server) handleNonStreamingResponseWithFirstChunk(w http.ResponseWriter,
 			if !ok {
 				continue
 			}
-			s.refundReservedBalance(pr, "provider_error:"+pr.RequestID)
-			s.noteInferenceError(pr.ProviderID, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason)
-			s.updateInferenceRouteOutcomeForPending(pr, preResponseProviderErrorOutcome(pr, errMsg))
-			s.writeGenericProviderError(w, errMsg)
+			s.writeNonStreamingProviderError(w, pr, errMsg)
 			return
 
 		case <-ctx.Done():
 			if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+				if !s.actorAcceptsClientTimeout(pr) {
+					// A provider terminal already won this attempt (its billing
+					// is in progress); the client deadline must NOT contradict
+					// billing with a timeout (incident race #2). ctx is a one-shot
+					// deadline that stays permanently fired, so re-selecting on it
+					// would busy-loop — instead drain the real terminal channel
+					// under a bounded grace and finalize exactly like the normal
+					// outer loop. Only fall through to the timeout below if the
+					// grace expires with no terminal arriving.
+					if s.drainNonStreamingTerminal(w, pr, ctx, &chunks) {
+						return
+					}
+				}
 				s.refundReservedBalance(pr, "provider_timeout:"+pr.RequestID)
 				s.updateInferenceRouteOutcomeForPending(pr, preResponseTimeoutOutcome(pr, "response_timeout_before_response"))
 				writeJSON(w, http.StatusGatewayTimeout, errorResponse("timeout", "request timed out"))
@@ -2360,6 +2264,242 @@ func (s *Server) handleNonStreamingResponseWithFirstChunk(w http.ResponseWriter,
 			return
 		}
 	}
+}
+
+// completionOutcome classifies how the non-streaming handler's wait for the
+// provider's completion usage ended.
+type completionOutcome int
+
+const (
+	completionUsage      completionOutcome = iota // usage delivered; build the response
+	completionIncomplete                          // CompleteCh closed with no usage
+	completionTimeout                             // client deadline fired and no terminal arrived
+	completionClientGone                          // client disconnected before the response
+)
+
+// awaitCompletion waits for the provider's completion usage on pr.CompleteCh,
+// bounded by the client deadline ctx. On the normal path it behaves exactly as
+// the previous inline `select { <-CompleteCh; <-ctx.Done() }`.
+//
+// Race #2 fix: when the deadline fires but the request actor reports a provider
+// terminal already won the attempt (its billing is in progress), it does NOT
+// report a timeout immediately. Because ctx is a one-shot deadline that stays
+// permanently fired, re-selecting on it would busy-loop; instead it waits a
+// bounded providerTerminalGrace for the real completion on CompleteCh — never on
+// ctx again — and reports the real outcome. Only if that grace ALSO expires with
+// no terminal does it report a timeout. actorAcceptsClientTimeout is a no-op on
+// its reject path (it claims no terminal and moves no money), so this cannot
+// double-settle.
+func (s *Server) awaitCompletion(ctx context.Context, pr *registry.PendingRequest) (protocol.UsageInfo, completionOutcome) {
+	select {
+	case u, ok := <-pr.CompleteCh:
+		if !ok {
+			return protocol.UsageInfo{}, completionIncomplete
+		}
+		return u, completionUsage
+	case <-ctx.Done():
+		if !errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			return protocol.UsageInfo{}, completionClientGone
+		}
+		if s.actorAcceptsClientTimeout(pr) {
+			return protocol.UsageInfo{}, completionTimeout
+		}
+		select {
+		case u, ok := <-pr.CompleteCh:
+			if !ok {
+				return protocol.UsageInfo{}, completionIncomplete
+			}
+			return u, completionUsage
+		case <-time.After(providerTerminalGrace):
+			return protocol.UsageInfo{}, completionTimeout
+		}
+	}
+}
+
+// writeNonStreamingCompletionFailure handles the non-success completion outcomes
+// shared by the passthrough and SSE-reconstruction paths: it refunds, records
+// the route outcome, and writes the client response. It returns true when it
+// handled a failure (the caller must return); it returns false only for
+// completionUsage, where the caller proceeds to build a success response.
+// refundReservedBalance finalizes the reservation through a CAS, so a refund
+// here is a no-op if a provider terminal already settled — this can never
+// double-refund.
+func (s *Server) writeNonStreamingCompletionFailure(w http.ResponseWriter, pr *registry.PendingRequest, outcome completionOutcome) bool {
+	switch outcome {
+	case completionIncomplete:
+		s.refundReservedBalance(pr, "provider_incomplete:"+pr.RequestID)
+		s.updateInferenceRouteOutcomeForPending(pr, preResponseProviderIncompleteOutcome(pr))
+		writeJSON(w, http.StatusBadGateway, errorResponse("provider_error", "provider ended without completion"))
+		return true
+	case completionTimeout:
+		s.refundReservedBalance(pr, "provider_timeout:"+pr.RequestID)
+		s.updateInferenceRouteOutcomeForPending(pr, preResponseTimeoutOutcome(pr, "usage_timeout_before_response"))
+		writeJSON(w, http.StatusGatewayTimeout, errorResponse("timeout", "timed out waiting for usage info"))
+		return true
+	case completionClientGone:
+		s.refundReservedBalance(pr, "client_gone:"+pr.RequestID)
+		s.updateInferenceRouteOutcomeForPending(pr, clientGoneBeforeResponseOutcome(pr))
+		return true
+	default:
+		return false
+	}
+}
+
+// writeNonStreamingProviderError refunds, records provider health + route
+// outcome, and writes the provider error response. Shared by the outer-loop
+// ErrorCh case and finalizeNonStreamingResponse's buffered-error check so the
+// two stay identical.
+func (s *Server) writeNonStreamingProviderError(w http.ResponseWriter, pr *registry.PendingRequest, errMsg protocol.InferenceErrorMessage) {
+	s.refundReservedBalance(pr, "provider_error:"+pr.RequestID)
+	s.noteInferenceError(pr.ProviderID, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason)
+	s.updateInferenceRouteOutcomeForPending(pr, preResponseProviderErrorOutcome(pr, errMsg))
+	s.writeGenericProviderError(w, errMsg)
+}
+
+// drainNonStreamingTerminal is the race #2 grace path for the outer-loop
+// deadline branch. The request actor has reported that a provider terminal
+// already won the attempt, so the client deadline must not report a timeout.
+// ctx is already permanently fired, so this drains the real terminal channel
+// (pr.ChunkCh) under a bounded grace instead of re-selecting on ctx, then
+// finalizes the response exactly like the normal outer loop. A provider error
+// terminal also closes pr.ChunkCh after buffering its error on pr.ErrorCh, so
+// finalizeNonStreamingResponse's own non-blocking ErrorCh check delivers it —
+// the drain only needs to observe the ChunkCh close. It returns true when it
+// produced a terminal response (the caller must return); false when the grace
+// expires with no terminal (the caller falls through to its timeout).
+func (s *Server) drainNonStreamingTerminal(w http.ResponseWriter, pr *registry.PendingRequest, ctx context.Context, chunks *[]string) bool {
+	grace := time.NewTimer(providerTerminalGrace)
+	defer grace.Stop()
+	for {
+		select {
+		case chunk, ok := <-pr.ChunkCh:
+			if !ok {
+				s.finalizeNonStreamingResponse(w, pr, ctx, *chunks)
+				return true
+			}
+			*chunks = append(*chunks, chunk)
+		case <-grace.C:
+			return false
+		}
+	}
+}
+
+// finalizeNonStreamingResponse assembles and writes the client response once
+// pr.ChunkCh has closed. It first surfaces any buffered provider error, then
+// either passes a single complete backend response through directly or
+// reconstructs the response from SSE delta chunks, waiting for the provider's
+// completion usage via awaitCompletion. Every path writes exactly one response
+// and returns.
+func (s *Server) finalizeNonStreamingResponse(w http.ResponseWriter, pr *registry.PendingRequest, ctx context.Context, chunks []string) {
+	select {
+	case errMsg, ok := <-pr.ErrorCh:
+		if ok && errMsg.Error != "" {
+			s.writeNonStreamingProviderError(w, pr, errMsg)
+			return
+		}
+	default:
+	}
+	// The provider forwards the raw backend response as a single chunk. Detect
+	// complete responses (object=chat.completion or object=response) and pass
+	// through directly — this is format-agnostic and works for chat completions,
+	// Responses API, or any future endpoint without parsing.
+	if len(chunks) == 1 {
+		raw := strings.TrimPrefix(chunks[0], "data: ")
+		var obj map[string]any
+		if err := json.Unmarshal([]byte(raw), &obj); err == nil {
+			objType, _ := obj["object"].(string)
+			// Complete responses have object=chat.completion or object=response.
+			// Delta chunks have object=chat.completion.chunk.
+			if objType == "chat.completion" || objType == "response" {
+				completeUsage, outcome := s.awaitCompletion(ctx, pr)
+				if s.writeNonStreamingCompletionFailure(w, pr, outcome) {
+					return
+				}
+				if objType == "chat.completion" {
+					normalizeCompleteChatResponse(obj, consumerModel(pr))
+					// The provider engine reports "stop" even when generation
+					// hit the max-tokens bound — correct it from the
+					// authoritative token counts.
+					rewriteRawFinishReason(obj, completeUsage, pr.RequestedMaxTokens)
+					// Keep the passthrough path consistent with the
+					// SSE-reconstruction path: surface the provider's accurate
+					// reasoning-token count if its raw usage object didn't
+					// already carry one.
+					injectReasoningDetailIntoRawUsage(obj, completeUsage)
+					injectCacheDetailIntoRawUsage(obj, completeUsage)
+					if pr.ConsumerEndpoint == completionsEndpoint ||
+						pr.ConsumerEndpoint == messagesEndpoint {
+						encoded, err := json.Marshal(obj)
+						if err != nil {
+							writeJSON(w, http.StatusBadGateway, errorResponse("provider_error", "invalid provider response"))
+							return
+						}
+						msg := extractMessage([]string{"data: " + string(encoded)})
+						resp := buildGenericEndpointResponse(pr, msg, completeUsage)
+						s.noteInferenceSuccess(pr)
+						writeJSON(w, http.StatusOK, resp)
+						return
+					}
+					if pr.IsResponsesAPI {
+						var chatResp types.ChatCompletionResponse
+						b, err := json.Marshal(obj)
+						if err != nil {
+							log.Printf("WARN: failed to marshal chat response for Responses API conversion: %v", err)
+							writeJSON(w, http.StatusBadGateway, errorResponse("provider_error", "invalid provider response"))
+							return
+						}
+						if err := json.Unmarshal(b, &chatResp); err != nil {
+							log.Printf("WARN: failed to unmarshal chat response into typed struct: %v", err)
+							writeJSON(w, http.StatusBadGateway, errorResponse("provider_error", "invalid provider response"))
+							return
+						}
+						respObj := chatCompletionToResponses(
+							chatResp, consumerModel(pr), pr.SESignature,
+							pr.ResponseHash, pr.Traits)
+						s.noteInferenceSuccess(pr)
+						writeJSON(w, http.StatusOK, respObj)
+						return
+					}
+				} else {
+					// Native passthrough (object=="response"): the provider
+					// echoed the concrete build id; rewrite it to the public
+					// alias so the consumer never sees the quant/build.
+					sanitizeCacheDetailIntoRawResponsesUsage(obj, completeUsage)
+					if pr.PublicModel != "" {
+						obj["model"] = consumerModel(pr)
+					}
+				}
+				if pr.SESignature != "" {
+					obj["se_signature"] = pr.SESignature
+					obj["response_hash"] = pr.ResponseHash
+				}
+				s.noteInferenceSuccess(pr)
+				writeJSON(w, http.StatusOK, obj)
+				return
+			}
+		}
+	}
+
+	// Fallback: SSE delta chunks — reconstruct into response.
+	msg := extractMessage(chunks)
+	usage, outcome := s.awaitCompletion(ctx, pr)
+	if s.writeNonStreamingCompletionFailure(w, pr, outcome) {
+		return
+	}
+	var resp any
+	if pr.IsResponsesAPI {
+		resp = buildResponsesResponse(
+			pr.RequestID, consumerModel(pr), msg, usage,
+			pr.RequestedMaxTokens, pr.SESignature, pr.ResponseHash,
+			pr.Traits)
+	} else if pr.ConsumerEndpoint == completionsEndpoint ||
+		pr.ConsumerEndpoint == messagesEndpoint {
+		resp = buildGenericEndpointResponse(pr, msg, usage)
+	} else {
+		resp = buildNonStreamingResponse(pr.RequestID, consumerModel(pr), msg, usage, pr.RequestedMaxTokens, pr.SESignature, pr.ResponseHash)
+	}
+	s.noteInferenceSuccess(pr)
+	writeJSON(w, http.StatusOK, resp)
 }
 
 // rewriteRawFinishReason corrects a provider-reported "stop" finish_reason to
@@ -4415,6 +4555,17 @@ reserveProvider:
 		return
 	}
 	pendingCleanup = false
+
+	// Register this single generic (/v1/completions, /v1/messages) attempt with a
+	// request actor so its terminal is arbitrated synchronously on the provider
+	// read loop (race #1) and its client-facing stream timer defers to an accepted
+	// terminal (race #2), exactly like the chat/responses path. The generic path
+	// is single-attempt (one stable requestID across provider reselection), so no
+	// speculative winner selection is needed; the sole attempt wins by default.
+	genericActor := s.newRequestActor(
+		uuid.NewString(), consumerKey, model, publicModel, endpoint, stream, 0)
+	genericActor.registerAttempt(requestID, provider.ID, "primary", pr.Attempt)
+	defer genericActor.close()
 
 	s.logger.Info("inference request dispatched",
 		"request_id", requestID,

--- a/coordinator/api/dispatch.go
+++ b/coordinator/api/dispatch.go
@@ -136,6 +136,12 @@ type dispatchState struct {
 	// (budget < context — this node was memory-pressured).
 	lastErrProviderBudget int64
 	committed             bool
+	// actor is the per-logical-request serialization point for terminal, winner,
+	// and retry decisions shared with the provider read loop and the client
+	// delivery timers. Every provider attempt this dispatch creates (primary,
+	// queued, speculative backup, retry) is registered under it. See
+	// request_actor.go.
+	actor *requestActor
 	// keepalive emits SSE keepalive comments during a long prefill once the
 	// request has been dispatched, committing HTTP 200 early so the consumer
 	// connection does not time out. nil when disabled or non-streaming.
@@ -476,6 +482,12 @@ func applyTimingDecomposition(out *store.InferenceRouteOutcome, t *registry.Requ
 // backup win, the primary otherwise. MarkFirstChunkArrived is kept (idempotent:
 // it preserves an earlier preamble's first-byte time for dispatch_to_first_chunk_ms).
 func (d *dispatchState) commitFirstContent(pr *registry.PendingRequest, chunk string) {
+	// Select the durable logical winner BEFORE any attempt-specific client write
+	// (the fix for incident race #3 and the speculative winner race). This is the
+	// single compare-and-set that atomically marks every other active attempt a
+	// speculative_loser, so a loser's later provider terminal is rejected by the
+	// read loop (acceptProviderTerminal) and can never settle or write.
+	d.actor.selectWinner(pr.RequestID)
 	d.firstChunk = chunk
 	pr.MarkFirstChunkArrived()
 	pr.MarkFirstContentArrived()
@@ -496,6 +508,29 @@ func (d *dispatchState) commitFirstContent(pr *registry.PendingRequest, chunk st
 	if d.s.registry.RecordCapacityAccept(pr.ProviderID, pr.Model) {
 		pr.MarkRateOutcomeCounted()
 	}
+}
+
+// registerAttempt binds a freshly dispatched provider attempt to the request
+// actor so the provider read loop can arbitrate its terminal and so it
+// participates in winner selection. role is "primary" or "backup". No-op when the
+// actor is disabled/absent.
+//
+// Ordering: callers invoke this in the dispatch goroutine immediately after the
+// provider write returns, before that goroutine reads any provider frame and
+// long before the provider can round-trip a response. A provider terminal
+// therefore cannot be decoded on the read loop before the attempt is bound; the
+// legacy fallback in acceptProviderTerminal is a safety net, not a live window.
+func (d *dispatchState) registerAttempt(provider *registry.Provider, pr *registry.PendingRequest, role string) {
+	if d.actor == nil || pr == nil {
+		return
+	}
+	providerID := ""
+	if provider != nil {
+		providerID = provider.ID
+	} else {
+		providerID = pr.ProviderID
+	}
+	d.actor.registerAttempt(pr.RequestID, providerID, role, pr.Attempt)
 }
 
 func (d *dispatchState) successRoutingOutcomeFor(pr *registry.PendingRequest) *store.InferenceRouteOutcome {
@@ -1676,6 +1711,10 @@ func (d *dispatchState) runSpeculative() dispatchOutcome {
 	}
 	if backupPR != nil {
 		backupPR.UsedBackup = true
+		// Register the speculative backup as a second active attempt under the
+		// same request actor so exactly one of {primary, backup} can win and the
+		// loser's later provider terminal is rejected (never settles).
+		d.registerAttempt(backupProvider, backupPR, "backup")
 	}
 	s.logger.Info("speculative_dispatch",
 		"request_id", d.requestID,
@@ -2434,6 +2473,12 @@ func (d *dispatchState) run() {
 	// nil-safe (no-op when keepalives are disabled or the writer already took over).
 	defer func() { d.keepalive.takeOver() }()
 
+	// Unbind this request's attempts from the actor table once the handler has
+	// fully delivered its response. A still-later provider terminal then falls
+	// back to the legacy path (which no-ops on an unknown request), exactly as
+	// before the actor existed.
+	defer d.actor.close()
+
 	for attempt := range maxDispatchAttempts {
 		d.attempt = attempt
 		// Deadline-bounded failover: after the first attempt, stop failing over
@@ -2461,6 +2506,11 @@ func (d *dispatchState) run() {
 		}
 
 		d.requestID = d.pr.RequestID
+		// Register this attempt with the request actor now that it has been
+		// dispatched: the provider read loop can now arbitrate its terminal, and
+		// it can win/lose the logical request. Covers both the direct and queued
+		// primary paths (both reach here with d.pr set).
+		d.registerAttempt(d.provider, d.pr, "primary")
 		// d.pr.Attempt is already stamped at PendingRequest construction in
 		// dispatchOneProvider (and on the queued path), before the provider send —
 		// so it is never written here, where it would race handleComplete.
@@ -2702,6 +2752,15 @@ exhausted:
 	// from pre-dispatch rejections).
 	if d.stream {
 		s.recordRequestOutcomeForContext(r.Context(), d.model, orClassSuccess)
+	}
+
+	// Catch-all durable winner selection before any client write. commitFirstContent
+	// already selects the winner for content commits; this idempotently covers the
+	// empty-completion / clean-close commits (which set committed without content),
+	// so the committed attempt is always the actor's recorded winner before the
+	// response is handed to the delivery writer.
+	if d.pr != nil {
+		d.actor.selectWinner(d.pr.RequestID)
 	}
 
 	d.writeCommittedResponse()

--- a/coordinator/api/generic_endpoint_stream.go
+++ b/coordinator/api/generic_endpoint_stream.go
@@ -95,6 +95,12 @@ func (s *Server) handleGenericEndpointStreamingResponse(
 			return
 
 		case <-timer.C:
+			if !s.actorAcceptsClientTimeout(pr) {
+				// Provider terminal already won — do not contradict billing with a
+				// timeout; consume the real terminal instead (race #2).
+				timer.Reset(inferenceTimeout)
+				continue
+			}
 			markInferenceOutcome(r.Context(), pr.Model, requestClassTimeout)
 			s.refundReservedBalance(pr, "provider_timeout:"+pr.RequestID)
 			s.ddIncr("inference.in_band_error", []string{"model:" + pr.Model, "reason:timeout"})

--- a/coordinator/api/nonstreaming_terminal_test.go
+++ b/coordinator/api/nonstreaming_terminal_test.go
@@ -1,0 +1,310 @@
+package api
+
+// Regression tests for incident race #2 on the NON-STREAMING path
+// (handleNonStreamingResponseWithFirstChunk, which backs Chat, Responses,
+// Completions, and Messages when stream=false).
+//
+// The gap: the streaming paths gate their client timeout on
+// actorAcceptsClientTimeout, but the non-streaming handler's ctx-deadline
+// branches unconditionally refunded + 504'd — so a provider terminal that had
+// already won the attempt's actor claim (billing in progress / complete on
+// another goroutine) could be contradicted by a spurious client timeout. The fix
+// makes each deadline branch, when the actor reports a terminal already won, wait
+// a bounded providerTerminalGrace on the REAL terminal channel (never on the
+// already-fired ctx, which would busy-loop) and deliver the real outcome.
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+	"github.com/eigeninference/d-inference/coordinator/registry"
+)
+
+// bindWonProviderTerminal binds a request actor for pr in the server's actor
+// table and has the provider read loop claim the given terminal SYNCHRONOUSLY,
+// exactly as providerReadLoop does before launching the slow billing work. This
+// is the "a provider terminal already won this attempt" precondition for race #2.
+func bindWonProviderTerminal(t *testing.T, srv *Server, prov *registry.Provider, pr *registry.PendingRequest, kind terminalKind) {
+	t.Helper()
+	prov.AddPending(pr)
+	actor, _ := newTestActor(t, srv.actors, nil)
+	actor.registerAttempt(pr.RequestID, prov.ID, "primary", 0)
+	t.Cleanup(actor.close)
+	if !srv.acceptProviderTerminal(prov.ID, prov, pr.RequestID, kind) {
+		t.Fatalf("provider %s terminal must be claimed on the read loop", kind)
+	}
+}
+
+// firedDeadlineCtx returns a context whose one-shot deadline has already elapsed,
+// so ctx.Err() is DeadlineExceeded and ctx.Done() stays permanently ready —
+// exactly the state handleNonStreamingResponseWithFirstChunk's inner ctx is in
+// once the client deadline fires.
+func firedDeadlineCtx(t *testing.T) context.Context {
+	t.Helper()
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+	t.Cleanup(cancel)
+	if !errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		t.Fatalf("ctx should be DeadlineExceeded, got %v", ctx.Err())
+	}
+	return ctx
+}
+
+// TestNonStreamingOuterLoopDeadlineDefersToWonProviderTerminal is the end-to-end
+// regression guard for the outer-loop deadline site. A provider completion wins
+// the actor claim (as the read loop would), then the client deadline fires while
+// the completion's channel signals are still pending, and only AFTER the deadline
+// does the real terminal land — the exact race #2 window. Without the fix the
+// handler refunds + 504s on ctx.Done(); with it, it drains the real terminal and
+// returns the true 200 response.
+//
+// Ordering is made deterministic by two ordered context deadlines (not sleeps):
+// the client deadline fires first, the terminal is delivered strictly later, so
+// the handler is provably in its deadline branch with ChunkCh still open when the
+// terminal arrives. The genuine claim race (provider terminal vs client timeout)
+// is reproduced at the actor level by pre-claiming the terminal.
+func TestNonStreamingOuterLoopDeadlineDefersToWonProviderTerminal(t *testing.T) {
+	srv, _, ledger := billingTestServer(t)
+	prov := srv.registry.Register("prov-outer-race", nil, &protocol.RegisterMessage{})
+
+	consumerID := testConsumerID
+	initialBalance := ledger.Balance(consumerID)
+	const reservedMicroUSD int64 = 25_000
+	if err := ledger.Charge(consumerID, reservedMicroUSD, "reserve:"+consumerID); err != nil {
+		t.Fatalf("reserve balance: %v", err)
+	}
+
+	pr := &registry.PendingRequest{
+		RequestID:        "outer-loop-race",
+		Model:            "race-model",
+		ConsumerKey:      consumerID,
+		ProviderID:       prov.ID,
+		ReservedMicroUSD: reservedMicroUSD,
+		ChunkCh:          make(chan string, 4),
+		CompleteCh:       make(chan protocol.UsageInfo, 1),
+		ErrorCh:          make(chan protocol.InferenceErrorMessage, 1),
+	}
+	bindWonProviderTerminal(t, srv, prov, pr, terminalComplete)
+
+	// Two ordered deadlines: the client deadline (handlerCtx) fires first; the
+	// terminal is delivered strictly after (terminalCtx), i.e. the completion's
+	// billing tail finishes just AFTER the client deadline fired.
+	handlerCtx, cancelH := context.WithTimeout(context.Background(), 30*time.Millisecond)
+	defer cancelH()
+	terminalCtx, cancelT := context.WithTimeout(context.Background(), 150*time.Millisecond)
+	defer cancelT()
+
+	usage := protocol.UsageInfo{PromptTokens: 3, CompletionTokens: 7}
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		<-terminalCtx.Done() // strictly after the client deadline fired
+		pr.CompleteCh <- usage
+		close(pr.ChunkCh)
+		close(pr.CompleteCh)
+	}()
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil).WithContext(handlerCtx)
+	rr := httptest.NewRecorder()
+	completeChunk := `data: {"id":"chatcmpl-outer-race","object":"chat.completion","choices":[{"message":{"role":"assistant","content":"ok"}}]}`
+
+	srv.handleNonStreamingResponseWithFirstChunk(rr, req, pr, []string{completeChunk})
+	wg.Wait()
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 — a won provider terminal must not be overridden by a spurious client timeout; body = %s", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), `"content":"ok"`) {
+		t.Fatalf("client did not receive the real completion body: %s", rr.Body.String())
+	}
+	// No spurious refund: the reservation stays held (real billing would settle
+	// it; the timeout path would have refunded the whole reserve).
+	if pr.IsReservationFinalized() {
+		t.Fatal("reservation must not be finalized by the timeout path once a provider terminal won (no spurious refund)")
+	}
+	if got := ledger.Balance(consumerID); got != initialBalance-reservedMicroUSD {
+		t.Fatalf("balance = %d, want held reserve %d (a spurious refund would restore %d)", got, initialBalance-reservedMicroUSD, initialBalance)
+	}
+}
+
+// TestAwaitCompletionActorRejectGraceReturnsUsage covers the sites-1/2 helper:
+// with the client deadline already fired but a provider completion having won the
+// actor claim, awaitCompletion must NOT report a timeout — it must fall through to
+// the INNER grace select and return the real usage once it arrives.
+//
+// CompleteCh starts EMPTY (not pre-buffered): if it were already buffered, Go's
+// outer select would have two ready cases (fired ctx.Done() AND a ready
+// CompleteCh) and could resolve via the ordinary first-case branch by chance,
+// passing even if the ctx.Done() branch's actor-reject/grace logic were reverted.
+// With CompleteCh empty, the outer select's only ready case is ctx.Done(), so the
+// call is forced through the actor-reject branch into the inner grace select.
+// Usage is delivered from a goroutine after a delay comfortably larger than the
+// outer-to-inner-select transition (an errors.Is check plus one actor mutex
+// lock/unlock — microseconds) and comfortably smaller than the shrunk grace
+// window — the same real-timer-margin idiom
+// TestNonStreamingOuterLoopDeadlineDefersToWonProviderTerminal uses (30ms vs
+// 150ms), not a flaky sleep-and-hope.
+func TestAwaitCompletionActorRejectGraceReturnsUsage(t *testing.T) {
+	old := providerTerminalGrace
+	providerTerminalGrace = 200 * time.Millisecond
+	defer func() { providerTerminalGrace = old }()
+
+	srv, _, _ := billingTestServer(t)
+	prov := srv.registry.Register("prov-await", nil, &protocol.RegisterMessage{})
+	pr := &registry.PendingRequest{
+		RequestID:  "await-reject",
+		ProviderID: prov.ID,
+		ChunkCh:    make(chan string, 1),
+		CompleteCh: make(chan protocol.UsageInfo, 1),
+		ErrorCh:    make(chan protocol.InferenceErrorMessage, 1),
+	}
+	bindWonProviderTerminal(t, srv, prov, pr, terminalComplete)
+
+	// handleComplete's channel tail, delayed so it can only land in the inner
+	// grace select, not the outer one.
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		pr.CompleteCh <- protocol.UsageInfo{CompletionTokens: 9}
+	}()
+
+	usage, outcome := srv.awaitCompletion(firedDeadlineCtx(t), pr)
+	if outcome != completionUsage {
+		t.Fatalf("outcome = %v, want completionUsage (deadline must defer to the won terminal)", outcome)
+	}
+	if usage.CompletionTokens != 9 {
+		t.Fatalf("usage = %+v, want the real completion usage", usage)
+	}
+}
+
+// TestAwaitCompletionNoActorReportsTimeout confirms the legacy path is preserved:
+// with no actor bound, a fired deadline still reports a timeout immediately (no
+// added latency, no grace).
+func TestAwaitCompletionNoActorReportsTimeout(t *testing.T) {
+	srv, _, _ := billingTestServer(t)
+	pr := &registry.PendingRequest{
+		RequestID:  "await-noactor",
+		CompleteCh: make(chan protocol.UsageInfo, 1),
+		ErrorCh:    make(chan protocol.InferenceErrorMessage, 1),
+	}
+	if _, outcome := srv.awaitCompletion(firedDeadlineCtx(t), pr); outcome != completionTimeout {
+		t.Fatalf("outcome = %v, want completionTimeout for an attempt with no bound actor", outcome)
+	}
+}
+
+// TestDrainNonStreamingTerminalDeliversWonCompletion drives the outer-loop grace
+// helper directly with a fired deadline and a won completion terminal: it must
+// finalize the real 200 response, not fall through to a timeout, and must not
+// refund.
+func TestDrainNonStreamingTerminalDeliversWonCompletion(t *testing.T) {
+	srv, _, _ := billingTestServer(t)
+	prov := srv.registry.Register("prov-drain-ok", nil, &protocol.RegisterMessage{})
+	pr := &registry.PendingRequest{
+		RequestID:        "drain-ok",
+		Model:            "m",
+		ProviderID:       prov.ID,
+		ConsumerKey:      testConsumerID,
+		ReservedMicroUSD: 10_000,
+		ChunkCh:          make(chan string, 2),
+		CompleteCh:       make(chan protocol.UsageInfo, 1),
+		ErrorCh:          make(chan protocol.InferenceErrorMessage, 1),
+	}
+	bindWonProviderTerminal(t, srv, prov, pr, terminalComplete)
+
+	// handleComplete's channel tail: usage buffered, then ChunkCh closed.
+	pr.CompleteCh <- protocol.UsageInfo{PromptTokens: 2, CompletionTokens: 5}
+	close(pr.ChunkCh)
+	close(pr.CompleteCh)
+
+	chunks := []string{`data: {"object":"chat.completion","choices":[{"message":{"role":"assistant","content":"hi"}}]}`}
+	rr := httptest.NewRecorder()
+	if !srv.drainNonStreamingTerminal(rr, pr, firedDeadlineCtx(t), &chunks) {
+		t.Fatal("drain must report it produced a terminal response")
+	}
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), `"content":"hi"`) {
+		t.Fatalf("real completion not delivered: %s", rr.Body.String())
+	}
+	if pr.IsReservationFinalized() {
+		t.Fatal("success path must not refund the reservation")
+	}
+}
+
+// TestDrainNonStreamingTerminalDeliversWonProviderError proves the drain path
+// also delivers a real provider ERROR terminal (the error is buffered on ErrorCh
+// and surfaced by finalizeNonStreamingResponse's non-blocking check after the
+// ChunkCh close) rather than a spurious timeout.
+func TestDrainNonStreamingTerminalDeliversWonProviderError(t *testing.T) {
+	srv, _, _ := billingTestServer(t)
+	prov := srv.registry.Register("prov-drain-err", nil, &protocol.RegisterMessage{})
+	pr := &registry.PendingRequest{
+		RequestID:        "drain-err",
+		Model:            "m",
+		ProviderID:       prov.ID,
+		ConsumerKey:      testConsumerID,
+		ReservedMicroUSD: 5_000,
+		ChunkCh:          make(chan string, 1),
+		CompleteCh:       make(chan protocol.UsageInfo, 1),
+		ErrorCh:          make(chan protocol.InferenceErrorMessage, 1),
+	}
+	bindWonProviderTerminal(t, srv, prov, pr, terminalError)
+
+	// handleInferenceError's channel tail: error buffered, then channels closed.
+	pr.ErrorCh <- protocol.InferenceErrorMessage{RequestID: "drain-err", Error: "boom", StatusCode: http.StatusBadGateway, ErrorReason: "provider_error"}
+	close(pr.ChunkCh)
+	close(pr.CompleteCh)
+	close(pr.ErrorCh)
+
+	chunks := []string(nil)
+	rr := httptest.NewRecorder()
+	if !srv.drainNonStreamingTerminal(rr, pr, firedDeadlineCtx(t), &chunks) {
+		t.Fatal("drain must produce the real provider error response")
+	}
+	if rr.Code == http.StatusGatewayTimeout {
+		t.Fatalf("client got a spurious timeout instead of the provider error; body = %s", rr.Body.String())
+	}
+	if rr.Code != http.StatusBadGateway || !strings.Contains(rr.Body.String(), "boom") {
+		t.Fatalf("provider error not delivered: status=%d body=%s", rr.Code, rr.Body.String())
+	}
+}
+
+// TestDrainNonStreamingTerminalGraceExpiryFallsThrough verifies the bounded
+// quiescence invariant: if the won terminal never actually delivers on the
+// channels (billing hung past the grace), the drain returns false within the
+// grace so the caller falls through to its refund + timeout — it never hangs.
+func TestDrainNonStreamingTerminalGraceExpiryFallsThrough(t *testing.T) {
+	old := providerTerminalGrace
+	providerTerminalGrace = 15 * time.Millisecond
+	defer func() { providerTerminalGrace = old }()
+
+	srv, _, _ := billingTestServer(t)
+	prov := srv.registry.Register("prov-drain-grace", nil, &protocol.RegisterMessage{})
+	pr := &registry.PendingRequest{
+		RequestID:  "drain-grace",
+		Model:      "m",
+		ProviderID: prov.ID,
+		ChunkCh:    make(chan string, 1),
+		CompleteCh: make(chan protocol.UsageInfo, 1),
+		ErrorCh:    make(chan protocol.InferenceErrorMessage, 1),
+	}
+	// Terminal claimed, but the channels NEVER deliver (ChunkCh stays open).
+	bindWonProviderTerminal(t, srv, prov, pr, terminalComplete)
+
+	chunks := []string{"data: partial"}
+	rr := httptest.NewRecorder()
+	start := time.Now()
+	if srv.drainNonStreamingTerminal(rr, pr, firedDeadlineCtx(t), &chunks) {
+		t.Fatal("drain must return false when the grace expires with no terminal delivered")
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("drain must be bounded by the grace; took %v", elapsed)
+	}
+}

--- a/coordinator/api/provider.go
+++ b/coordinator/api/provider.go
@@ -501,18 +501,30 @@ func (s *Server) providerReadLoop(ctx context.Context, conn *websocket.Conn, pro
 
 		case protocol.TypeInferenceComplete:
 			completeMsg := msg.Payload.(*protocol.InferenceCompleteMessage)
-			// Run completion handling (billing settlement) off the read loop.
-			// Billing does synchronous DB calls (GetModelPrice, Credit, Charge)
-			// that can block for seconds under DB pressure. If the read loop is
-			// blocked, attestation challenge responses can't be read from the
-			// WebSocket, causing challenge timeouts and provider derouting.
-			saferun.Go(s.logger, "handleComplete", func() {
-				s.handleComplete(providerID, provider, completeMsg)
-			})
+			// Claim the attempt's terminal SYNCHRONOUSLY, in wire order, before
+			// launching the slow billing work — this is the fix for incident
+			// race #1. The first terminal decoded for an attempt wins under the
+			// actor mutex; a later-decoded error can no longer beat this
+			// completion just because its billing goroutine was scheduled first.
+			// Only after the claim is accepted do we run completion handling
+			// (billing settlement) off the read loop: billing does synchronous DB
+			// calls that can block for seconds under DB pressure, which would
+			// otherwise stall attestation challenge reads on this socket.
+			if s.acceptProviderTerminal(providerID, provider, completeMsg.RequestID, terminalComplete) {
+				saferun.Go(s.logger, "handleComplete", func() {
+					s.handleComplete(providerID, provider, completeMsg)
+				})
+			}
 
 		case protocol.TypeInferenceError:
 			errMsg := msg.Payload.(*protocol.InferenceErrorMessage)
-			s.handleInferenceError(providerID, provider, errMsg)
+			// Same synchronous, wire-ordered terminal claim (race #1). A superseded
+			// error (an earlier completion/timeout already won the attempt) is
+			// dropped to telemetry by acceptProviderTerminal after transport
+			// cleanup, so a late error can never overturn an earlier terminal.
+			if s.acceptProviderTerminal(providerID, provider, errMsg.RequestID, terminalError) {
+				s.handleInferenceError(providerID, provider, errMsg)
+			}
 
 		case protocol.TypePrefixCacheLookup:
 			lookupMsg := msg.Payload.(*protocol.PrefixCacheLookupMessage)

--- a/coordinator/api/request_actor.go
+++ b/coordinator/api/request_actor.go
@@ -1,0 +1,489 @@
+package api
+
+// Coordinator request actor.
+//
+// A requestActor is the single per-logical-request serialization point for the
+// terminal-state decisions that used to be decided by goroutine scheduling and
+// independent channel/timer ordering. One actor owns one inbound logical
+// request; its (at most two concurrent — primary + one speculative backup)
+// provider attempts are registered under it. Every terminal decision is taken
+// under the actor's sync.Mutex, so ordering is determined by CALL ORDER, not by
+// which goroutine the Go scheduler happens to run first.
+//
+// It closes the following races from the 2026-07-20 generation-deadline
+// incident report:
+//
+//   - Race #1 "Provider frame order does not determine the winning terminal":
+//     the provider WebSocket read loop calls claimAttemptTerminal SYNCHRONOUSLY
+//     (in wire order) before launching the slow async billing work, so the FIRST
+//     decoded terminal for an attempt wins under the mutex — a later-decoded
+//     error can no longer beat an earlier-decoded completion just because the
+//     completion's billing goroutine was scheduled later.
+//
+//   - Race #2 "Billing can complete while the client sees a timeout": the
+//     client-facing timeout timer claims a terminalTimeout through the same
+//     mutex before telling the client it timed out. If a provider terminal
+//     already won the attempt, the claim is rejected and the timer path keeps
+//     waiting for the real terminal instead of contradicting billing.
+//
+//   - Race #3 / speculative winner: selectWinner is one durable compare-and-set
+//     from "no winner" to the committing attempt that atomically marks every
+//     other active attempt a speculative_loser. Once a winner is selected, a
+//     loser's later terminal is rejected. The one residual slice — a loser whose
+//     terminal is decoded BEFORE the relay reaches selectWinner (both attempts
+//     still active, no winner yet) — stays gated exactly as legacy today: the
+//     actor can only ever SUPPRESS a settlement, never add one, so it is
+//     money-neutral versus current behavior. Fully closing that slice (gating
+//     billing on the durable winner) is the later finance-on-journal step, not
+//     this one.
+//
+// AUTHORITY BOUNDARY (this step): the actor's in-memory CAS is the authoritative
+// control-flow decision. It best-effort MIRRORS each decision into the durable
+// settlement journal (coordinator/store) so the journal stops being inert and
+// step 7 has real production shape to build on, but journaling is money-neutral
+// (see journalReservation), never blocks the request, and a journal
+// failure/mismatch can only log+metric — it can never change the client-visible
+// or financial outcome. The existing process-local reservation/billing code in
+// registry/reservations/provider.go remains authoritative for money in this
+// step; the actor only decides ordering/winner/retry and stops the client timer.
+
+import (
+	"sync"
+	"sync/atomic"
+
+	"github.com/eigeninference/d-inference/coordinator/registry"
+	"github.com/eigeninference/d-inference/coordinator/store"
+)
+
+// terminalKind enumerates the terminal events an attempt can accept. The first
+// one claimed for an attempt wins; all later ones are telemetry-only.
+type terminalKind int
+
+const (
+	terminalNone       terminalKind = iota
+	terminalComplete                // provider inference_complete
+	terminalError                   // provider inference_error
+	terminalTimeout                 // coordinator-side attempt/client timeout
+	terminalDisconnect              // provider disconnect
+	terminalCancel                  // client cancellation / request fence
+)
+
+func (k terminalKind) String() string {
+	switch k {
+	case terminalComplete:
+		return "complete"
+	case terminalError:
+		return "error"
+	case terminalTimeout:
+		return "timeout"
+	case terminalDisconnect:
+		return "disconnect"
+	case terminalCancel:
+		return "cancel"
+	default:
+		return "none"
+	}
+}
+
+// attemptDisposition tracks an attempt's role in winner arbitration. It mirrors
+// the store's AttemptDisposition but is the fast in-memory copy the actor uses
+// for its authoritative decisions.
+type attemptDisposition int
+
+const (
+	dispActive attemptDisposition = iota
+	dispWinner
+	dispLoser
+	dispFailedRetry
+)
+
+// attemptSlot is the actor's per-attempt record.
+type attemptSlot struct {
+	attemptID   string
+	providerID  string
+	role        string // "primary" | "backup"
+	ordinal     int    // dispatch attempt ordinal
+	terminal    terminalKind
+	disposition attemptDisposition
+}
+
+// requestActor serializes terminal/winner/retry decisions for one logical
+// request. All mutable state is guarded by mu.
+type requestActor struct {
+	logicalID string
+	table     *actorTable
+
+	// journal runs a best-effort settlement-journal op. In production it hands
+	// the op to the async telemetry sink; tests may inject a synchronous runner
+	// so journal rows are observable deterministically. It never affects the
+	// in-memory decision.
+	journal      func(func())
+	store        store.SettlementStore
+	onJournalErr func(op string, err error)
+
+	// Immutable request metadata used for journaling only.
+	consumerAccount string
+	model           string
+	publicModel     string
+	endpoint        string
+	stream          bool
+	budgetMS        int64
+
+	reservedOnce sync.Once
+	ingressSeq   atomic.Uint64
+
+	mu          sync.Mutex
+	attempts    map[string]*attemptSlot
+	attemptIDs  []string
+	winner      string
+	winnerEpoch int64
+	fenced      bool
+	fenceCause  string
+}
+
+// nextIngress returns a strictly increasing per-actor sequence used to keep the
+// journaled terminal/winner/fence rows monotonic in the store.
+func (a *requestActor) nextIngress() uint64 { return a.ingressSeq.Add(1) }
+
+// actorTable maps a provider attempt (request) ID to its owning requestActor so
+// the provider read loop — which only knows the attempt ID — can reach the
+// actor. Binding is additive: an attempt with no actor falls back to the legacy
+// (pre-actor) code path, so the actor is never able to suppress a terminal for a
+// path that was not wired to it.
+type actorTable struct {
+	mu        sync.RWMutex
+	byAttempt map[string]*requestActor
+}
+
+func newActorTable() *actorTable {
+	return &actorTable{byAttempt: make(map[string]*requestActor)}
+}
+
+func (t *actorTable) lookup(attemptID string) *requestActor {
+	if t == nil || attemptID == "" {
+		return nil
+	}
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.byAttempt[attemptID]
+}
+
+func (t *actorTable) bind(attemptID string, actor *requestActor) {
+	if t == nil || attemptID == "" || actor == nil {
+		return
+	}
+	t.mu.Lock()
+	t.byAttempt[attemptID] = actor
+	t.mu.Unlock()
+}
+
+func (t *actorTable) unbind(attemptIDs []string) {
+	if t == nil || len(attemptIDs) == 0 {
+		return
+	}
+	t.mu.Lock()
+	for _, id := range attemptIDs {
+		delete(t.byAttempt, id)
+	}
+	t.mu.Unlock()
+}
+
+// newRequestActor builds an actor for one logical request. The Server wires the
+// journal runner, store, and error sink; tests build it directly with a real
+// in-memory store and a synchronous journal runner.
+func (s *Server) newRequestActor(logicalID, consumerAccount, model, publicModel, endpoint string, stream bool, budgetMS int64) *requestActor {
+	if budgetMS <= 0 {
+		budgetMS = inferenceTimeout.Milliseconds()
+	}
+	a := &requestActor{
+		logicalID:       logicalID,
+		table:           s.actors,
+		store:           s.store,
+		consumerAccount: consumerAccount,
+		model:           model,
+		publicModel:     publicModel,
+		endpoint:        endpoint,
+		stream:          stream,
+		budgetMS:        budgetMS,
+		attempts:        make(map[string]*attemptSlot),
+	}
+	a.journal = func(op func()) {
+		if !settlementJournalEnabled() {
+			return
+		}
+		s.submitTelemetry("settlement_journal", op)
+	}
+	a.onJournalErr = func(name string, err error) {
+		s.ddIncr("settlement.journal_error", []string{"op:" + name})
+	}
+	return a
+}
+
+// close unbinds all of the actor's attempts from the table. Called once the
+// handler has fully delivered its response; any still-later provider terminal
+// then falls back to the legacy path (which no-ops on an unknown request),
+// exactly as before the actor existed.
+func (a *requestActor) close() {
+	if a == nil {
+		return
+	}
+	a.mu.Lock()
+	ids := append([]string(nil), a.attemptIDs...)
+	a.mu.Unlock()
+	a.table.unbind(ids)
+}
+
+// registerAttempt records a new provider attempt and binds it in the table so
+// the read loop can find this actor. It is called once per dispatched attempt
+// (primary/queued in the orchestrator, backup in the speculative path). The
+// first registration also lazily journals the logical request reservation.
+func (a *requestActor) registerAttempt(attemptID, providerID, role string, ordinal int) {
+	if a == nil || attemptID == "" {
+		return
+	}
+	a.mu.Lock()
+	if _, exists := a.attempts[attemptID]; !exists {
+		a.attempts[attemptID] = &attemptSlot{
+			attemptID:   attemptID,
+			providerID:  providerID,
+			role:        role,
+			ordinal:     ordinal,
+			disposition: dispActive,
+		}
+		a.attemptIDs = append(a.attemptIDs, attemptID)
+	}
+	a.mu.Unlock()
+
+	a.table.bind(attemptID, a)
+	a.journalReservation()
+	a.journalAttempt(attemptID, providerID, role, ordinal)
+}
+
+// claimAttemptTerminal is the synchronous first-terminal-wins gate. It reports
+// whether THIS caller won the attempt's terminal. A rejected claim means the
+// event is telemetry-only: a terminal was already accepted for the attempt, the
+// attempt is a speculative loser, or a different attempt already won the logical
+// request. Ordering is decided here, under the mutex, not by goroutine
+// scheduling — the fix for incident race #1 and the timeout-vs-billing race #2.
+func (a *requestActor) claimAttemptTerminal(attemptID string, kind terminalKind) bool {
+	if a == nil {
+		return true
+	}
+	a.mu.Lock()
+	slot := a.attempts[attemptID]
+	if slot == nil {
+		a.mu.Unlock()
+		return false
+	}
+	if slot.terminal != terminalNone {
+		// First terminal already won this attempt (race #1 / late duplicate).
+		a.mu.Unlock()
+		return false
+	}
+	loser := slot.disposition == dispLoser || slot.disposition == dispFailedRetry ||
+		(a.winner != "" && a.winner != attemptID)
+	slot.terminal = kind
+	if loser {
+		if slot.disposition == dispActive {
+			slot.disposition = dispLoser
+		}
+		a.mu.Unlock()
+		return false
+	}
+	a.mu.Unlock()
+	a.journalTerminalRow(attemptID, kind)
+	return true
+}
+
+// selectWinner performs the single durable winner compare-and-set for the
+// logical request: from "no winner" to attemptID, atomically marking every other
+// still-active attempt a speculative_loser. It is called by the dispatch
+// goroutine at content/clean-close commit, before any attempt-specific client
+// write. Idempotent for the same winner; returns false if a different attempt
+// already won, the request is fenced, or the attempt is unknown.
+//
+// Loser rejection is absolute only for terminals that arrive AFTER this call:
+// a peer terminal decoded before selectWinner runs (both attempts still active)
+// is still gated the legacy way, which the actor can only ever narrow, never
+// widen (it never adds a settlement). Closing that slice by gating billing on
+// the durable winner is the later finance-on-journal step.
+func (a *requestActor) selectWinner(attemptID string) bool {
+	if a == nil || attemptID == "" {
+		return true
+	}
+	a.mu.Lock()
+	slot := a.attempts[attemptID]
+	if slot == nil {
+		a.mu.Unlock()
+		return false
+	}
+	if a.winner == attemptID {
+		a.mu.Unlock()
+		return true
+	}
+	if a.winner != "" || a.fenced {
+		// A different attempt already won, or the request is fenced (client gone /
+		// cancelled / budget expired): no new winner may be selected.
+		a.mu.Unlock()
+		return false
+	}
+	a.winner = attemptID
+	slot.disposition = dispWinner
+	for id, peer := range a.attempts {
+		if id != attemptID && peer.disposition == dispActive {
+			peer.disposition = dispLoser
+		}
+	}
+	seq := a.nextIngress()
+	epoch := a.winnerEpoch
+	a.mu.Unlock()
+	a.journalWinner(attemptID, epoch, seq)
+	return true
+}
+
+// hasActivePeer reports whether an attempt other than the given one is still
+// active (no terminal, not a loser). The live speculative dispatch loop already
+// enforces the invariant that a failed attempt with a live eligible peer waits
+// for the peer (via its single-goroutine race sub-waits), so this method backs
+// the actor's assertion of that invariant in tests rather than driving control
+// flow itself.
+func (a *requestActor) hasActivePeer(attemptID string) bool {
+	if a == nil {
+		return false
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	for id, slot := range a.attempts {
+		if id == attemptID {
+			continue
+		}
+		if slot.disposition == dispActive && slot.terminal == terminalNone {
+			return true
+		}
+	}
+	return false
+}
+
+// retryReleaseWinner clears a winner that failed before any client-visible
+// output so a replacement attempt can be created. The current coordinator
+// dispatcher never retries AFTER selecting a winner (it commits on first content
+// and streams), so this has no live caller today; it is implemented and tested
+// so the actor already models the invariant the durable journal enforces, and
+// journals ReleaseRequestWinnerForRetry. It succeeds only when attemptID is the
+// current winner and no other attempt is still active.
+func (a *requestActor) retryReleaseWinner(attemptID string) bool {
+	if a == nil || attemptID == "" {
+		return false
+	}
+	a.mu.Lock()
+	slot := a.attempts[attemptID]
+	if slot == nil || a.winner != attemptID || a.fenced {
+		a.mu.Unlock()
+		return false
+	}
+	// The winner must have failed with a retryable terminal; a clean completion
+	// (or a not-yet-terminal winner) is never released for retry.
+	if slot.terminal == terminalNone || slot.terminal == terminalComplete {
+		a.mu.Unlock()
+		return false
+	}
+	for id, peer := range a.attempts {
+		if id != attemptID && peer.disposition == dispActive && peer.terminal == terminalNone {
+			a.mu.Unlock()
+			return false
+		}
+	}
+	epoch := a.winnerEpoch
+	a.winner = ""
+	a.winnerEpoch++
+	slot.disposition = dispFailedRetry
+	a.mu.Unlock()
+	a.journalRelease(attemptID, epoch)
+	return true
+}
+
+// fence atomically freezes the logical request: no new winner, no retry. It
+// models client cancellation / client-gone / budget expiry and is journaled via
+// FenceRequest. In this step the live client-cancellation path still runs the
+// existing cancelDispatch + parked-settlement machinery unchanged (that path is
+// money-critical and stays authoritative), so fence is exercised through the
+// actor's tests and journal; wiring it as the live cancellation owner belongs to
+// the later cancellation-ownership step. Idempotent for the same cause.
+func (a *requestActor) fence(cause string) bool {
+	if a == nil {
+		return false
+	}
+	a.mu.Lock()
+	if a.fenced {
+		a.mu.Unlock()
+		return false
+	}
+	a.fenced = true
+	a.fenceCause = cause
+	seq := a.nextIngress()
+	a.mu.Unlock()
+	a.journalFence(cause, seq)
+	return true
+}
+
+// ---- Server-side helpers that wrap the actor for the wired call sites ----
+
+// acceptProviderTerminal is the read-loop gate for a decoded provider terminal
+// (complete/error). It claims the attempt terminal SYNCHRONOUSLY in wire order
+// and returns true when the caller should proceed with the (slow, async) billing
+// / error handling; false when the terminal was superseded. Attempts with no
+// bound actor fall back to the legacy path (always proceed).
+//
+// The reject path performs NO transport cleanup, on purpose. RemovePending is the
+// legacy single-owner settlement/transport claim, owned by exactly one of: the
+// WINNING provider-terminal handler (handleComplete/handleInferenceError), the
+// dispatch loop's cancelDispatch for a speculative loser (which also refunds the
+// loser's top-up), or the timeout path that won the actor claim
+// (actorAcceptsClientTimeout). If this reject path also removed pending it would
+// RACE those owners — e.g. steal the completion's RemovePending, making
+// handleComplete drop billing and never close ChunkCh (a hung stream), or steal
+// the loser's cancelDispatch removal and skip its top-up refund. So a superseded
+// terminal is dropped to telemetry only.
+func (s *Server) acceptProviderTerminal(providerID string, provider *registry.Provider, attemptID string, kind terminalKind) bool {
+	actor := s.actors.lookup(attemptID)
+	if actor == nil {
+		return true
+	}
+	if actor.claimAttemptTerminal(attemptID, kind) {
+		return true
+	}
+	s.ddIncr("inference.terminal_superseded", []string{"kind:" + kind.String()})
+	return false
+}
+
+// actorAcceptsClientTimeout is the client-facing timer gate (race #2). It
+// returns true when the caller may tell the client the request timed out; false
+// when a provider terminal already won the attempt, in which case the caller
+// must keep waiting for the real terminal instead of contradicting billing.
+// Attempts with no bound actor keep the legacy always-timeout behavior.
+//
+// When the timeout WINS the claim, this path becomes the single RemovePending
+// owner for the attempt: the provider's (possibly in-flight) completion/error
+// will be rejected by acceptProviderTerminal, so handleComplete/
+// handleInferenceError will not run and would otherwise leave the transport
+// entry lingering until disconnect. Removing it here is race-free precisely
+// because a won timeout claim guarantees no provider-terminal handler runs.
+func (s *Server) actorAcceptsClientTimeout(pr *registry.PendingRequest) bool {
+	if pr == nil {
+		return true
+	}
+	actor := s.actors.lookup(pr.RequestID)
+	if actor == nil {
+		return true
+	}
+	if !actor.claimAttemptTerminal(pr.RequestID, terminalTimeout) {
+		return false
+	}
+	if p := s.registry.GetProvider(pr.ProviderID); p != nil {
+		if removed := p.RemovePending(pr.RequestID); removed != nil {
+			s.chunkKeys.forget(removed.SessionPrivKey)
+		}
+		s.registry.SetProviderIdle(pr.ProviderID)
+	}
+	return true
+}

--- a/coordinator/api/request_actor_journal.go
+++ b/coordinator/api/request_actor_journal.go
@@ -1,0 +1,170 @@
+package api
+
+// Best-effort, money-neutral mirroring of the request actor's authoritative
+// control-flow decisions into the durable settlement journal (coordinator/store).
+//
+// Nothing here can change the client-visible or financial outcome: journaling is
+// gated by a kill switch, runs off the request's critical path through the
+// injected journal runner, swallows every error into a metric, and never moves
+// money (the request row is created with ServiceHold=true and a zero reserved
+// amount, and attempts carry a zero top-up). Its purpose is to give the durable
+// journal real production shape and exercise the store's invariants for real, so
+// the later step that flips finance onto the journal has less to change. The
+// process-local reservation/billing code remains the money authority in this
+// step.
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/store"
+)
+
+// envSettlementJournal is the kill switch for settlement-journal mirroring.
+// Default true: the actor journals its terminal/winner/retry/fence decisions.
+// Because journaling is money-neutral and off the request's critical path,
+// disabling it changes nothing the client or ledger observes; the switch exists
+// purely as an operational safety valve.
+const envSettlementJournal = "EIGENINFERENCE_SETTLEMENT_JOURNAL"
+
+func settlementJournalEnabled() bool { return envEnabledDefaultTrue(envSettlementJournal) }
+
+// journalTerminal maps a terminalKind to the (kind, cause, envelope) strings the
+// settlement journal records. It is shadow metadata only; the wire-accurate v1
+// terminal vocabulary is a later step. Only a clean completion journals as
+// kind="complete"; every non-success terminal journals as kind="error" so the
+// journal never has to satisfy the store's cancelled-terminal fence checks with
+// synthetic data.
+func (k terminalKind) journalTerminal() (kind, cause, envelope string) {
+	switch k {
+	case terminalComplete:
+		return "complete", "stop", "inference_complete"
+	case terminalError:
+		return "error", "provider_error", "inference_error"
+	case terminalTimeout:
+		return "error", "attempt_budget_exhausted", "inference_error"
+	case terminalDisconnect:
+		return "error", "provider_disconnect", "inference_error"
+	case terminalCancel:
+		return "error", "request_error", "inference_error"
+	default:
+		return "error", "no_terminal", "inference_error"
+	}
+}
+
+// runJournal executes a store op through the injected runner and records any
+// error as a metric. It never returns anything the caller acts on.
+func (a *requestActor) runJournal(name string, op func(context.Context) error) {
+	if a == nil || a.store == nil || a.journal == nil {
+		return
+	}
+	a.journal(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := op(ctx); err != nil && a.onJournalErr != nil {
+			a.onJournalErr(name, err)
+		}
+	})
+}
+
+// journalReservation inserts the logical request row exactly once. It is
+// deliberately money-neutral: ServiceHold=true skips any ledger debit in both
+// store backends, and a zero ReservedMicroUSD means no balance is moved even in
+// the hold-accounting path. Real reserved/charged amounts are a step-7 concern.
+func (a *requestActor) journalReservation() {
+	if a == nil || a.consumerAccount == "" {
+		return
+	}
+	a.reservedOnce.Do(func() {
+		req := store.RequestSettlement{
+			ClientRequestID:   a.logicalID,
+			ConsumerAccountID: a.consumerAccount,
+			Model:             a.model,
+			PublicModel:       a.publicModel,
+			Endpoint:          a.endpoint,
+			Stream:            a.stream,
+			ReservedMicroUSD:  0,
+			RequestBudgetMS:   a.budgetMS,
+			StartedAt:         time.Now(),
+		}
+		a.runJournal("begin_reservation", func(ctx context.Context) error {
+			_, _, err := a.store.BeginRequestReservation(ctx, store.BeginRequestReservationParams{
+				Request:     req,
+				ServiceHold: true,
+			})
+			return err
+		})
+	})
+}
+
+func (a *requestActor) journalAttempt(attemptID, providerID, role string, ordinal int) {
+	attempt := store.RequestAttempt{
+		ClientRequestID:   a.logicalID,
+		ProviderRequestID: attemptID,
+		ProviderID:        providerID,
+		Attempt:           ordinal,
+		Role:              role,
+		BudgetMS:          a.budgetMS,
+		TopUpMicroUSD:     0,
+	}
+	a.runJournal("begin_attempt", func(ctx context.Context) error {
+		if _, _, err := a.store.BeginAttemptBeforeDispatch(ctx, store.BeginAttemptParams{Attempt: attempt}); err != nil {
+			return err
+		}
+		return a.store.MarkAttemptDispatched(ctx, a.logicalID, attemptID, time.Now())
+	})
+}
+
+func (a *requestActor) journalWinner(attemptID string, epoch int64, seq uint64) {
+	a.runJournal("select_winner", func(ctx context.Context) error {
+		_, _, err := a.store.SelectRequestWinner(ctx, store.WinnerSelection{
+			ClientRequestID:   a.logicalID,
+			ProviderRequestID: attemptID,
+			ExpectedEpoch:     epoch,
+			IngressSequence:   seq,
+		})
+		return err
+	})
+}
+
+func (a *requestActor) journalRelease(attemptID string, epoch int64) {
+	a.runJournal("release_winner", func(ctx context.Context) error {
+		_, _, err := a.store.ReleaseRequestWinnerForRetry(ctx, a.logicalID, attemptID, epoch)
+		return err
+	})
+}
+
+func (a *requestActor) journalTerminalRow(attemptID string, k terminalKind) {
+	kind, cause, envelope := k.journalTerminal()
+	seq := a.nextIngress()
+	snapshot := []byte(fmt.Sprintf(`{"attempt":%q,"kind":%q,"cause":%q}`, attemptID, kind, cause))
+	term := store.AttemptTerminal{
+		ClientRequestID:   a.logicalID,
+		ProviderRequestID: attemptID,
+		IngressSequence:   seq,
+		SnapshotHash:      store.HashSettlementSnapshot(snapshot),
+		Snapshot:          snapshot,
+		Envelope:          envelope,
+		Kind:              kind,
+		Cause:             cause,
+		Stage:             "decode",
+		Source:            "provider",
+	}
+	a.runJournal("claim_terminal", func(ctx context.Context) error {
+		_, _, err := a.store.ClaimAttemptTerminal(ctx, store.AttemptTerminalClaim{Terminal: term})
+		return err
+	})
+}
+
+func (a *requestActor) journalFence(cause string, seq uint64) {
+	a.runJournal("fence_request", func(ctx context.Context) error {
+		_, _, err := a.store.FenceRequest(ctx, store.RequestFence{
+			ClientRequestID: a.logicalID,
+			Cause:           cause,
+			Sequence:        seq,
+			FenceVersion:    1,
+		})
+		return err
+	})
+}

--- a/coordinator/api/request_actor_test.go
+++ b/coordinator/api/request_actor_test.go
@@ -1,0 +1,431 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sync"
+	"testing"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+	"github.com/eigeninference/d-inference/coordinator/registry"
+	"github.com/eigeninference/d-inference/coordinator/store"
+	"github.com/google/uuid"
+)
+
+// newTestActor builds a requestActor wired to a real in-memory settlement store
+// with a SYNCHRONOUS journal runner, so the durable journal is exercised for
+// real and its rows are observable deterministically. Pass st == nil to disable
+// journaling entirely (used by the concurrency stress tests, which only assert
+// the in-memory CAS). journalErrs collects any store-journal error so happy-path
+// tests can assert the store invariants passed.
+func newTestActor(t *testing.T, tbl *actorTable, st store.SettlementStore) (*requestActor, *[]string) {
+	t.Helper()
+	if tbl == nil {
+		tbl = newActorTable()
+	}
+	var mu sync.Mutex
+	errs := &[]string{}
+	a := &requestActor{
+		logicalID:       "req-" + uuid.NewString(),
+		table:           tbl,
+		store:           st,
+		journal:         func(op func()) { op() },
+		consumerAccount: "acct-consumer",
+		model:           "test-model",
+		publicModel:     "test-model",
+		endpoint:        "chat_completions",
+		stream:          true,
+		budgetMS:        600000,
+		attempts:        make(map[string]*attemptSlot),
+	}
+	a.onJournalErr = func(op string, err error) {
+		mu.Lock()
+		*errs = append(*errs, op+": "+err.Error())
+		mu.Unlock()
+	}
+	return a, errs
+}
+
+// --- Race #1: first decoded terminal wins, regardless of goroutine scheduling ---
+
+func TestActorFirstTerminalWinsBothWireOrders(t *testing.T) {
+	// error-then-complete: the error is decoded first, so it wins; the later
+	// completion is rejected (telemetry only).
+	a, _ := newTestActor(t, nil, nil)
+	a.registerAttempt("A", "prov-1", "primary", 0)
+	if !a.claimAttemptTerminal("A", terminalError) {
+		t.Fatal("first error terminal must be accepted")
+	}
+	if a.claimAttemptTerminal("A", terminalComplete) {
+		t.Fatal("later completion must lose to the earlier error")
+	}
+
+	// complete-then-error: the completion is decoded first, so it wins; the later
+	// error is rejected. Same rule, opposite order — the OUTCOME follows CALL
+	// ORDER, not which handler is slower.
+	b, _ := newTestActor(t, nil, nil)
+	b.registerAttempt("A", "prov-1", "primary", 0)
+	if !b.claimAttemptTerminal("A", terminalComplete) {
+		t.Fatal("first completion terminal must be accepted")
+	}
+	if b.claimAttemptTerminal("A", terminalError) {
+		t.Fatal("later error must lose to the earlier completion")
+	}
+}
+
+func TestActorConcurrentTerminalsExactlyOneWins(t *testing.T) {
+	// Two goroutines claim complete/error for the same attempt at maximum
+	// concurrency. Regardless of Go's scheduling, exactly one must win — this is
+	// the actual regression guard for incident race #1. Run under -race.
+	for i := 0; i < 2000; i++ {
+		a, _ := newTestActor(t, nil, nil)
+		a.registerAttempt("A", "prov-1", "primary", 0)
+		start := make(chan struct{})
+		var acceptedComplete, acceptedError bool
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			<-start
+			acceptedComplete = a.claimAttemptTerminal("A", terminalComplete)
+		}()
+		go func() {
+			defer wg.Done()
+			<-start
+			acceptedError = a.claimAttemptTerminal("A", terminalError)
+		}()
+		close(start)
+		wg.Wait()
+		if acceptedComplete == acceptedError {
+			t.Fatalf("iter %d: exactly one terminal must win; got complete=%v error=%v",
+				i, acceptedComplete, acceptedError)
+		}
+	}
+}
+
+// --- Race #2: a client timeout firing concurrently with terminal acceptance ---
+
+func TestActorTimeoutVsCompletionExactlyOneWins(t *testing.T) {
+	// The client-facing timeout timer and the provider's completion race for the
+	// SAME attempt terminal. Exactly one wins under the mutex, so billing and the
+	// client outcome can never disagree: if the timeout wins, the completion is
+	// rejected (no billing); if the completion wins, the timeout is rejected (the
+	// client is never told it timed out). Run under -race.
+	for i := 0; i < 2000; i++ {
+		a, _ := newTestActor(t, nil, nil)
+		a.registerAttempt("A", "prov-1", "primary", 0)
+		start := make(chan struct{})
+		var billed, toldTimeout bool
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			<-start
+			// The provider read loop: only a won claim proceeds to bill.
+			billed = a.claimAttemptTerminal("A", terminalComplete)
+		}()
+		go func() {
+			defer wg.Done()
+			<-start
+			// The client timer: only a won claim tells the client it timed out.
+			toldTimeout = a.claimAttemptTerminal("A", terminalTimeout)
+		}()
+		close(start)
+		wg.Wait()
+		if billed == toldTimeout {
+			t.Fatalf("iter %d: billing and timeout must be mutually exclusive; billed=%v toldTimeout=%v",
+				i, billed, toldTimeout)
+		}
+	}
+}
+
+func TestServerActorAcceptsClientTimeoutGate(t *testing.T) {
+	s := NewServer(registry.New(slog.Default()), store.NewMemory(store.Config{}), ServerConfig{}, slog.Default())
+
+	// No actor bound for an attempt: the legacy always-timeout behavior is kept.
+	if !s.actorAcceptsClientTimeout(&registry.PendingRequest{RequestID: "unbound"}) {
+		t.Fatal("unbound attempt must keep legacy timeout behavior")
+	}
+
+	// A provider terminal already accepted: the timer must NOT contradict it.
+	a, _ := newTestActor(t, s.actors, nil)
+	a.registerAttempt("A", "prov-1", "primary", 0)
+	if !a.claimAttemptTerminal("A", terminalComplete) {
+		t.Fatal("provider completion should be accepted")
+	}
+	if s.actorAcceptsClientTimeout(&registry.PendingRequest{RequestID: "A"}) {
+		t.Fatal("client timeout must be refused once a provider terminal won the attempt")
+	}
+
+	// A fresh attempt with no terminal yet: the timer may claim the timeout.
+	b, _ := newTestActor(t, s.actors, nil)
+	b.registerAttempt("B", "prov-1", "primary", 0)
+	if !s.actorAcceptsClientTimeout(&registry.PendingRequest{RequestID: "B"}) {
+		t.Fatal("client timeout should be accepted when no provider terminal has won")
+	}
+	// ...and having done so, the provider's later completion is superseded.
+	if b.claimAttemptTerminal("B", terminalComplete) {
+		t.Fatal("provider completion must lose to the already-accepted timeout")
+	}
+}
+
+// TestAcceptProviderTerminalRejectDoesNotTouchPending is the regression guard for
+// the complete-then-error hang: a superseded provider terminal must NOT call
+// RemovePending, so it cannot race (and steal) the winning handler's own
+// RemovePending — which would make handleComplete drop billing and hang the
+// stream. Here the completion wins the claim; the later error is superseded, and
+// the provider's pending record must remain intact for the winning handler.
+func TestAcceptProviderTerminalRejectDoesNotTouchPending(t *testing.T) {
+	s := NewServer(registry.New(slog.Default()), store.NewMemory(store.Config{}), ServerConfig{}, slog.Default())
+	prov := s.registry.Register("prov-1", nil, &protocol.RegisterMessage{})
+	pending := &registry.PendingRequest{RequestID: "A", ProviderID: "prov-1"}
+	prov.AddPending(pending)
+
+	a, _ := newTestActor(t, s.actors, nil)
+	a.registerAttempt("A", "prov-1", "primary", 0)
+
+	// Completion wins the claim (the read loop would launch handleComplete).
+	if !s.acceptProviderTerminal("prov-1", prov, "A", terminalComplete) {
+		t.Fatal("first completion terminal must be accepted")
+	}
+	// A later error for the same attempt is superseded — and must leave the
+	// pending record for the winning handler to remove.
+	if s.acceptProviderTerminal("prov-1", prov, "A", terminalError) {
+		t.Fatal("superseded error must be rejected")
+	}
+	if prov.GetPending("A") == nil {
+		t.Fatal("reject path must NOT remove the pending record (the winning handler owns it)")
+	}
+}
+
+// --- Race #3 / speculative: exactly one durable winner; loser never settles ---
+
+func TestActorSpeculativeSingleWinnerLoserNeverSettles(t *testing.T) {
+	st := store.NewMemory(store.Config{})
+	a, jerrs := newTestActor(t, nil, st)
+	ctx := context.Background()
+
+	a.registerAttempt("A", "prov-1", "primary", 0)
+	a.registerAttempt("B", "prov-2", "backup", 0)
+
+	if !a.selectWinner("A") {
+		t.Fatal("primary must win the winner CAS")
+	}
+	if a.selectWinner("B") {
+		t.Fatal("backup must lose the winner CAS")
+	}
+
+	// The loser's later provider completion is rejected: it can never settle.
+	if a.claimAttemptTerminal("B", terminalComplete) {
+		t.Fatal("speculative loser terminal must be rejected")
+	}
+	// The winner's completion is accepted.
+	if !a.claimAttemptTerminal("A", terminalComplete) {
+		t.Fatal("winner completion must be accepted")
+	}
+
+	// The durable journal mirrors the decision.
+	reqRow, err := st.GetRequestSettlement(ctx, a.logicalID)
+	if err != nil {
+		t.Fatalf("request row: %v", err)
+	}
+	if reqRow.WinnerAttemptID != "A" {
+		t.Fatalf("journal winner = %q, want A", reqRow.WinnerAttemptID)
+	}
+	loser, err := st.GetRequestAttempt(ctx, a.logicalID, "B")
+	if err != nil {
+		t.Fatalf("loser row: %v", err)
+	}
+	if loser.Disposition != store.AttemptDispositionSpeculativeLoser {
+		t.Fatalf("loser disposition = %q, want speculative_loser", loser.Disposition)
+	}
+	if _, err := st.GetAttemptTerminal(ctx, a.logicalID, "B"); !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("loser must have no accepted terminal in the journal, got err=%v", err)
+	}
+	if _, err := st.GetAttemptTerminal(ctx, a.logicalID, "A"); err != nil {
+		t.Fatalf("winner terminal should be journaled: %v", err)
+	}
+	if len(*jerrs) != 0 {
+		t.Fatalf("journal must have no errors on the happy path, got %v", *jerrs)
+	}
+}
+
+func TestActorConcurrentWinnerCASExactlyOne(t *testing.T) {
+	// Primary and backup produce first output concurrently. Exactly one may win;
+	// the loser's later terminal must be rejected. Run under -race.
+	for i := 0; i < 2000; i++ {
+		a, _ := newTestActor(t, nil, nil)
+		a.registerAttempt("A", "prov-1", "primary", 0)
+		a.registerAttempt("B", "prov-2", "backup", 0)
+		start := make(chan struct{})
+		var wonA, wonB bool
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() { defer wg.Done(); <-start; wonA = a.selectWinner("A") }()
+		go func() { defer wg.Done(); <-start; wonB = a.selectWinner("B") }()
+		close(start)
+		wg.Wait()
+		if wonA == wonB {
+			t.Fatalf("iter %d: exactly one winner; wonA=%v wonB=%v", i, wonA, wonB)
+		}
+		loserID := "A"
+		if wonA {
+			loserID = "B"
+		}
+		if a.claimAttemptTerminal(loserID, terminalComplete) {
+			t.Fatalf("iter %d: loser %s terminal must be rejected", i, loserID)
+		}
+	}
+}
+
+// --- Invariant 4: a failed attempt with an active eligible peer waits ---
+
+func TestActorFailedPrimaryWaitsForActiveBackup(t *testing.T) {
+	st := store.NewMemory(store.Config{})
+	a, jerrs := newTestActor(t, nil, st)
+
+	a.registerAttempt("A", "prov-1", "primary", 0)
+	a.registerAttempt("B", "prov-2", "backup", 0)
+
+	// Primary fails. Its terminal is recorded, but it does NOT select a winner or
+	// finalize the request while the backup remains eligible.
+	if !a.claimAttemptTerminal("A", terminalError) {
+		t.Fatal("primary error terminal must be accepted")
+	}
+	a.mu.Lock()
+	winner := a.winner
+	a.mu.Unlock()
+	if winner != "" {
+		t.Fatalf("failed primary must not select a winner; winner=%q", winner)
+	}
+	if !a.hasActivePeer("A") {
+		t.Fatal("backup must still be an active eligible peer")
+	}
+
+	// The backup can still win and settle.
+	if !a.selectWinner("B") {
+		t.Fatal("active backup must be able to win after the primary failed")
+	}
+	if !a.claimAttemptTerminal("B", terminalComplete) {
+		t.Fatal("backup completion must be accepted")
+	}
+	if len(*jerrs) != 0 {
+		t.Fatalf("journal errors: %v", *jerrs)
+	}
+}
+
+// --- Late / duplicate terminals are no-ops ---
+
+func TestActorLateDuplicateTerminalIsNoOp(t *testing.T) {
+	a, _ := newTestActor(t, nil, nil)
+	a.registerAttempt("A", "prov-1", "primary", 0)
+
+	if !a.claimAttemptTerminal("A", terminalComplete) {
+		t.Fatal("first terminal accepted")
+	}
+	// Duplicate of the same kind, a different kind, a disconnect, and a cancel:
+	// all superseded after a decision was made.
+	for _, k := range []terminalKind{terminalComplete, terminalError, terminalDisconnect, terminalCancel} {
+		if a.claimAttemptTerminal("A", k) {
+			t.Fatalf("late %s terminal must be a no-op", k)
+		}
+	}
+	// An unknown attempt is also refused (never suppresses nor invents a claim).
+	if a.claimAttemptTerminal("unknown", terminalComplete) {
+		t.Fatal("terminal for an unregistered attempt must be refused")
+	}
+}
+
+// --- retryReleaseWinner: release an invisible failed winner, then replace it ---
+
+func TestActorRetryReleaseWinnerAndReplace(t *testing.T) {
+	st := store.NewMemory(store.Config{})
+	a, jerrs := newTestActor(t, nil, st)
+	ctx := context.Background()
+
+	a.registerAttempt("A", "prov-1", "primary", 0)
+	if !a.selectWinner("A") {
+		t.Fatal("A must win")
+	}
+	// A clean completion may NOT be released for retry.
+	if !a.claimAttemptTerminal("A", terminalError) {
+		t.Fatal("winner error terminal accepted")
+	}
+	if !a.retryReleaseWinner("A") {
+		t.Fatal("a failed invisible winner must be releasable for retry")
+	}
+	// Winner cleared and epoch advanced.
+	a.mu.Lock()
+	winner, epoch := a.winner, a.winnerEpoch
+	a.mu.Unlock()
+	if winner != "" || epoch != 1 {
+		t.Fatalf("after release winner=%q epoch=%d, want \"\"/1", winner, epoch)
+	}
+	// A replacement attempt can now be created and win.
+	a.registerAttempt("A2", "prov-3", "primary", 1)
+	if !a.selectWinner("A2") {
+		t.Fatal("replacement attempt must win after release")
+	}
+	if !a.claimAttemptTerminal("A2", terminalComplete) {
+		t.Fatal("replacement completion accepted")
+	}
+
+	reqRow, err := st.GetRequestSettlement(ctx, a.logicalID)
+	if err != nil {
+		t.Fatalf("request row: %v", err)
+	}
+	if reqRow.WinnerAttemptID != "A2" {
+		t.Fatalf("journal winner = %q, want A2", reqRow.WinnerAttemptID)
+	}
+	if len(*jerrs) != 0 {
+		t.Fatalf("journal errors: %v", *jerrs)
+	}
+}
+
+func TestActorRetryReleaseRejectsCleanWinner(t *testing.T) {
+	a, _ := newTestActor(t, nil, nil)
+	a.registerAttempt("A", "prov-1", "primary", 0)
+	a.selectWinner("A")
+	// No terminal yet: nothing to release.
+	if a.retryReleaseWinner("A") {
+		t.Fatal("winner without a terminal must not be released")
+	}
+	// A clean completion is absorbing: never released for retry.
+	a.claimAttemptTerminal("A", terminalComplete)
+	if a.retryReleaseWinner("A") {
+		t.Fatal("a cleanly completed winner must not be released for retry")
+	}
+}
+
+// --- fence freezes winner selection ---
+
+func TestActorFenceBlocksWinnerSelection(t *testing.T) {
+	st := store.NewMemory(store.Config{})
+	a, jerrs := newTestActor(t, nil, st)
+
+	a.registerAttempt("A", "prov-1", "primary", 0)
+	if !a.fence("client_cancelled") {
+		t.Fatal("first fence must succeed")
+	}
+	if a.fence("client_cancelled") {
+		t.Fatal("second fence is idempotent (no re-fence)")
+	}
+	if a.selectWinner("A") {
+		t.Fatal("no winner may be selected after a fence")
+	}
+	if len(*jerrs) != 0 {
+		t.Fatalf("journal errors: %v", *jerrs)
+	}
+}
+
+// --- the read-loop passthrough helper is legacy-safe when no actor is bound ---
+
+func TestAcceptProviderTerminalLegacyPassthrough(t *testing.T) {
+	s := NewServer(registry.New(slog.Default()), store.NewMemory(store.Config{}), ServerConfig{}, slog.Default())
+	// No actor bound for this attempt: the read loop proceeds exactly as before
+	// the actor existed (returns true). provider may be nil on this path.
+	if !s.acceptProviderTerminal("prov-1", nil, "unbound-attempt", terminalComplete) {
+		t.Fatal("an attempt with no bound actor must fall back to the legacy path")
+	}
+}

--- a/coordinator/api/server.go
+++ b/coordinator/api/server.go
@@ -288,6 +288,10 @@ type Server struct {
 	// mid-stream, so a late provider terminal can settle them (or the reservation
 	// is refunded on grace expiry). See settlement.go.
 	settlements *settlementHolder
+	// actors maps a provider attempt (request) ID to the per-logical-request
+	// requestActor that owns its terminal/winner/retry arbitration. See
+	// request_actor.go.
+	actors *actorTable
 	// settleGrace overrides defaultTerminalSettleGrace (tests set it small).
 	settleGrace time.Duration
 	// zombieCanceller throttles cancels for chunks on abandoned streams. See zombie_stream.go.
@@ -705,6 +709,7 @@ func NewServer(reg *registry.Registry, st store.Store, cfg ServerConfig, logger 
 		codeAttestThrottle:   newCodeAttestThrottle(),
 		trustReuseCache:      newTrustReuseCache(),
 		settlements:          newSettlementHolder(),
+		actors:               newActorTable(),
 		zombieCanceller:      newZombieStreamCanceller(),
 		serviceReservations:  newServiceReservationManager(st, cfg.ServiceReservations),
 		routeTelemetry:       newTelemetrySink(logger, defaultTelemetrySinkCapacity, defaultTelemetrySinkWorkers),


### PR DESCRIPTION
## Summary

Step 3 of the generation-deadline redesign
([docs/reports/2026-07-20-generation-deadline-incident-and-redesign.md](docs/reports/2026-07-20-generation-deadline-incident-and-redesign.md),
[docs/reports/2026-07-22-generation-deadline-implementation-map.md](docs/reports/2026-07-22-generation-deadline-implementation-map.md)),
stacked on #564 (steps 1-2). This fixes the concrete terminal-ordering races
that make deadline/timeout changes unsafe to ship on their own:

- **Race #1 — provider frame order doesn't determine the winning terminal.**
  The provider WebSocket read loop launched completion billing
  asynchronously while a synchronously-handled following error frame could
  remove the pending request first, so goroutine scheduling — not wire
  order — decided the outcome. `acceptProviderTerminal` now claims the
  attempt terminal synchronously, in decode order, under the new
  `requestActor`'s mutex, before any billing/error handling proceeds.
- **Race #2 — billing can complete while the client sees a timeout.** A
  client-facing timer could fire and tell the client "timed out" while
  billing completed successfully elsewhere. Both streaming paths and the
  non-streaming path (Chat/Responses/Completions/Messages when
  `stream=false`) now check `actorAcceptsClientTimeout` and defer to the
  real terminal when a provider terminal already won. Non-streaming needed
  extra care since its `ctx` is a one-shot deadline (not a resettable
  timer) — re-selecting on it would busy-loop, so it waits a bounded grace
  directly on the real terminal channel instead.
- **Speculative winner selection.** `selectWinner` is a durable
  compare-and-set from no-winner to the first attempt with real output; the
  losing attempt (primary or backup) becomes `speculative_loser` and its
  later terminal is rejected — it can never write or settle.

**Deliberate scope cuts** from the full design doc: a plain mutex-guarded
actor (no formal ordered-event-stream abstraction), no cryptographic
terminal signing, at most 2 concurrent attempts (matches current
production). Critically: **the existing process-local reservation/billing
code stays unchanged and authoritative** — the actor owns
ordering/winner/retry decisions only, and best-effort/money-neutral mirrors
those decisions into the durable settlement journal from steps 1-2
(zero/service-hold amounts, `SealSettlementEffects` never called). Turning
the journal into the real source of truth is a later step.

## Behavior

```mermaid
flowchart LR
  subgraph Before
    B1[Provider completes] --> B2[handleComplete launched async]
    B3[Provider errors, decoded after] --> B4[handleInferenceError sync, removes pending first]
    B4 -.can win the race.-> B5[Client sees error; completion billing silently lost or races]
    B6[Client timeout timer fires] --> B7[Tell client: timed out]
    B8[Billing completes concurrently] -.-> B7
    B7 -.contradicts.-> B8
  end
  subgraph After
    A1[Provider completes] --> A2[acceptProviderTerminal claims SYNCHRONOUSLY, in wire order]
    A3[Provider errors, decoded after] --> A4[acceptProviderTerminal: rejected, superseded]
    A2 --> A5[handleComplete proceeds - one deterministic winner]
    A6[Client timeout timer fires] --> A7{actorAcceptsClientTimeout?}
    A7 -->|provider terminal already won| A8[Defer: wait for/consume the real terminal]
    A7 -->|no terminal yet| A9[Tell client: timed out - real timeout]
  end
```

## Code

```mermaid
flowchart TB
  subgraph Before
    P1[provider.go read loop] --> P2[TypeInferenceComplete: saferun.Go handleComplete]
    P1 --> P3[TypeInferenceError: sync handleInferenceError, RemovePending]
    C1[consumer.go / generic_endpoint_stream.go timers] --> C2[timer fires -> refund + write timeout, unconditional]
    N1[consumer.go handleNonStreamingResponseWithFirstChunk] --> N2[~180-line inline nested select, ctx.Done unconditional refund+504 x3]
  end
  subgraph After
    Q1[request_actor.go - NEW] --> Q2[requestActor: mutex, claimAttemptTerminal, selectWinner, registerAttempt]
    Q1 --> Q3[request_actor_journal.go - NEW: money-neutral mirror into SettlementStore]
    P4[provider.go read loop] --> P5[acceptProviderTerminal gates both Complete/Error before dispatch]
    P5 --> Q2
    C3[consumer.go / generic_endpoint_stream.go timers] --> C4[actorAcceptsClientTimeout gate; Reset+continue on defer]
    C4 --> Q2
    N3[consumer.go handleNonStreamingResponseWithFirstChunk] --> N4[awaitCompletion / drainNonStreamingTerminal / finalizeNonStreamingResponse]
    N4 --> Q2
    N4 -.bounded grace, never re-selects fired ctx.Done.-> N4
  end
```

## Test plan

- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` — clean
- [x] `go test -count=1 ./...` — full repo, all 24 packages pass
- [x] `go test -race -count=1 ./api/... ./store/...` — clean, run repeatedly
      (up to 10x on the new/changed tests) for flake confidence
- [x] New tests (`request_actor_test.go`, `nonstreaming_terminal_test.go`):
      both wire orderings of complete-vs-error, concurrent winner CAS (2000
      iterations under `-race`), timeout-vs-completion concurrency, a failed
      primary waiting for an active backup, late/duplicate terminals as
      no-ops, the `RemovePending` single-ownership invariant, and a full
      end-to-end non-streaming regression test with a real ledger-balance
      assertion proving no spurious refund — all using real goroutines and
      explicit barriers/ordered timers, never `time.Sleep` as a race-wait
- [x] Two independent Claude review passes (adversarial, not confirmatory):
      first pass caught a real gap — the non-streaming path never got the
      race #2 guard, unlike streaming — which was fixed and verified with a
      dedicated regression test; second pass confirmed the fix fully closes
      the gap, the refactor is behavior-preserving for the ordinary
      (non-race) path, no double-write/double-refund is possible
      (`FinalizeReservation`/`RemovePending` are genuine mutex-guarded CASes,
      verified by reading the code), and nothing else regressed
- [x] One documented, pre-existing (non-regression) money-neutral edge case:
      if a won provider terminal's async billing is slower than the bounded
      grace window, the HTTP path refunds first and the later billing
      goroutine finds the reservation already finalized and skips —
      provider underpaid, consumer never double-charged. Mirrors the same
      tradeoff the existing SSE Responses streaming path already makes with
      its own grace window; fixing this class of edge case for real is the
      later finance-on-journal step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/566"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787379639&installation_model_id=21733&pr_number=566&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F566&signature=2508a40ca8c6531fdd1966e8fa3d89930a70d88d10ded31c6a684cf6de10d228"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->