### PR TITLE
feat(cache): expose eligibility and lifecycle telemetry

### DIFF
--- a/coordinator/api/cache_eligibility_integration_test.go
+++ b/coordinator/api/cache_eligibility_integration_test.go
@@ -18,6 +18,7 @@ import (
 func TestCacheEligibilityHeartbeatLifecycleThroughProviderWebSocket(t *testing.T) {
 	logger := slog.New(slog.DiscardHandler)
 	reg := registry.New(logger)
+	reg.SetModelCatalog([]registry.CatalogEntry{{ID: "public-model"}})
 	srv := NewServer(reg, store.NewMemory(store.Config{}), ServerConfig{}, logger)
 	httpServer := httptest.NewServer(srv.Handler())
 	defer httpServer.Close()
@@ -34,16 +35,26 @@ func TestCacheEligibilityHeartbeatLifecycleThroughProviderWebSocket(t *testing.T
 	}
 	defer conn.Close(websocket.StatusNormalClosure, "")
 
-	initialStatuses := []protocol.PrefixCacheModelStatus{{
-		ModelID: "model", Backend: "contiguous", ReplayStrategy: "none",
-		State: "disabled", Reason: "weight_hash_unavailable",
-	}}
-	initialOutcomes := []protocol.PrefixCacheDonationOutcomeCount{{
-		Outcome: "donated", Count: 2,
-	}}
+	initialStatuses := []protocol.PrefixCacheModelStatus{
+		{
+			ModelID: "model", Backend: "contiguous", ReplayStrategy: "none",
+			State: "disabled", Reason: "weight_hash_unavailable",
+		},
+		{
+			ModelID: "future-model", Backend: "future_backend", ReplayStrategy: "future_strategy",
+			State: "warming", Reason: "future_reason",
+		},
+	}
+	initialOutcomes := []protocol.PrefixCacheDonationOutcomeCount{
+		{Outcome: "donated", Count: 2},
+		{Outcome: "future_outcome", Count: 100},
+	}
 	writeProviderJSON(t, ctx, conn, protocol.RegisterMessage{
-		Type:                        protocol.TypeRegister,
-		Models:                      []protocol.ModelInfo{{ID: "model"}},
+		Type: protocol.TypeRegister,
+		Models: []protocol.ModelInfo{
+			{ID: "model"},
+			{ID: "future-model"},
+		},
 		Backend:                     "mlx-swift",
 		PrefixCacheProtocol:         1,
 		PrefixCacheStatuses:         &initialStatuses,
@@ -51,7 +62,8 @@ func TestCacheEligibilityHeartbeatLifecycleThroughProviderWebSocket(t *testing.T
 	})
 	waitCacheCondition(t, func() bool {
 		status := reg.PrefixCacheProtocolStatus()
-		return status.ReportedLoadedModels == 1 &&
+		return reg.ProviderCount() == 1 &&
+			status.ReportedLoadedModels == 1 &&
 			status.ByReason["weight_hash_unavailable"] == 1
 	})
 
@@ -59,9 +71,10 @@ func TestCacheEligibilityHeartbeatLifecycleThroughProviderWebSocket(t *testing.T
 		ModelID: "model", Backend: "contiguous", ReplayStrategy: "direct",
 		State: "pending", Reason: "scan_pending",
 	}}
-	fiveOutcomes := []protocol.PrefixCacheDonationOutcomeCount{{
-		Outcome: "donated", Count: 5,
-	}}
+	fiveOutcomes := []protocol.PrefixCacheDonationOutcomeCount{
+		{Outcome: "donated", Count: 5},
+		{Outcome: "future_outcome", Count: 101},
+	}
 	writeProviderJSON(t, ctx, conn, protocol.HeartbeatMessage{
 		Type: protocol.TypeHeartbeat, Status: "idle",
 		Stats:                       protocol.HeartbeatStats{},
@@ -74,12 +87,44 @@ func TestCacheEligibilityHeartbeatLifecycleThroughProviderWebSocket(t *testing.T
 			reg.CacheRoutingLifecycleStatus().DonationOutcomes["donated"] == 3
 	})
 
+	oversizedStatuses := make([]protocol.PrefixCacheModelStatus, 17)
+	duplicateOutcomes := []protocol.PrefixCacheDonationOutcomeCount{
+		{Outcome: "donated", Count: 6},
+		{Outcome: "donated", Count: 7},
+	}
+	writeProviderJSON(t, ctx, conn, protocol.HeartbeatMessage{
+		Type: protocol.TypeHeartbeat, Status: "idle",
+		Stats:                       protocol.HeartbeatStats{},
+		PrefixCacheStatuses:         &oversizedStatuses,
+		PrefixCacheDonationOutcomes: &duplicateOutcomes,
+	})
+	waitCacheCondition(t, func() bool {
+		return reg.ProviderCount() == 1 &&
+			reg.PrefixCacheProtocolStatus().ReportedLoadedModels == 0 &&
+			reg.CacheRoutingLifecycleStatus().DonationOutcomes["donated"] == 3
+	})
+
+	sixOutcomes := []protocol.PrefixCacheDonationOutcomeCount{
+		{Outcome: "donated", Count: 6},
+	}
+	writeProviderJSON(t, ctx, conn, protocol.HeartbeatMessage{
+		Type: protocol.TypeHeartbeat, Status: "idle",
+		Stats:                       protocol.HeartbeatStats{},
+		PrefixCacheStatuses:         &replacement,
+		PrefixCacheDonationOutcomes: &sixOutcomes,
+	})
+	waitCacheCondition(t, func() bool {
+		return reg.ProviderCount() == 1 &&
+			reg.PrefixCacheProtocolStatus().ByReason["scan_pending"] == 1 &&
+			reg.CacheRoutingLifecycleStatus().DonationOutcomes["donated"] == 4
+	})
+
 	empty := []protocol.PrefixCacheModelStatus{}
 	writeProviderJSON(t, ctx, conn, protocol.HeartbeatMessage{
 		Type: protocol.TypeHeartbeat, Status: "idle",
 		Stats:                       protocol.HeartbeatStats{},
 		PrefixCacheStatuses:         &empty,
-		PrefixCacheDonationOutcomes: &fiveOutcomes,
+		PrefixCacheDonationOutcomes: &sixOutcomes,
 	})
 	waitCacheCondition(t, func() bool {
 		return reg.PrefixCacheProtocolStatus().ReportedLoadedModels == 0
@@ -100,6 +145,57 @@ func TestCacheEligibilityHeartbeatLifecycleThroughProviderWebSocket(t *testing.T
 	waitCacheCondition(t, func() bool { return reg.ProviderCount() == 0 })
 	if got := reg.PrefixCacheProtocolStatus().LoadedModels; got != 0 {
 		t.Fatalf("disconnect retained loaded status: %d", got)
+	}
+}
+
+func TestStructuralOptionalCacheTelemetryDoesNotCloseRegistration(t *testing.T) {
+	logger := slog.New(slog.DiscardHandler)
+	reg := registry.New(logger)
+	reg.SetModelCatalog([]registry.CatalogEntry{{ID: "public-model"}})
+	srv := NewServer(reg, store.NewMemory(store.Config{}), ServerConfig{}, logger)
+	httpServer := httptest.NewServer(srv.Handler())
+	defer httpServer.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	conn, _, err := websocket.Dial(
+		ctx,
+		"ws"+strings.TrimPrefix(httpServer.URL, "http")+"/ws/provider",
+		nil,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close(websocket.StatusNormalClosure, "")
+
+	oversizedStatuses := make([]protocol.PrefixCacheModelStatus, 17)
+	duplicateOutcomes := []protocol.PrefixCacheDonationOutcomeCount{
+		{Outcome: "donated", Count: 1},
+		{Outcome: "donated", Count: 2},
+	}
+	writeProviderJSON(t, ctx, conn, protocol.RegisterMessage{
+		Type:                        protocol.TypeRegister,
+		Models:                      []protocol.ModelInfo{{ID: "owner-local"}},
+		Backend:                     "mlx-swift",
+		PrefixCacheProtocol:         1,
+		PrefixCacheStatuses:         &oversizedStatuses,
+		PrefixCacheDonationOutcomes: &duplicateOutcomes,
+	})
+	waitCacheCondition(t, func() bool { return reg.ProviderCount() == 1 })
+	status := reg.PrefixCacheProtocolStatus()
+	if status.ReportedLoadedModels != 0 ||
+		reg.CacheRoutingLifecycleStatus().DonationOutcomes["donated"] != 0 {
+		t.Fatalf("structural telemetry was not dropped: providers=%+v lifecycle=%+v",
+			status, reg.CacheRoutingLifecycleStatus())
+	}
+
+	// A subsequent heartbeat proves the provider socket remained usable.
+	writeProviderJSON(t, ctx, conn, protocol.HeartbeatMessage{
+		Type: protocol.TypeHeartbeat, Status: "idle", Stats: protocol.HeartbeatStats{},
+	})
+	time.Sleep(25 * time.Millisecond)
+	if reg.ProviderCount() != 1 {
+		t.Fatal("optional structural telemetry closed provider registration")
 	}
 }
 

--- a/coordinator/api/cache_eligibility_integration_test.go
+++ b/coordinator/api/cache_eligibility_integration_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/eigeninference/d-inference/coordinator/promptcontract"
 	"github.com/eigeninference/d-inference/coordinator/protocol"
 	"github.com/eigeninference/d-inference/coordinator/registry"
 	"github.com/eigeninference/d-inference/coordinator/store"
@@ -196,6 +197,103 @@ func TestStructuralOptionalCacheTelemetryDoesNotCloseRegistration(t *testing.T) 
 	time.Sleep(25 * time.Millisecond)
 	if reg.ProviderCount() != 1 {
 		t.Fatal("optional structural telemetry closed provider registration")
+	}
+}
+
+func TestReadyCacheStatusHeartbeatReconcilesWithCapabilities(t *testing.T) {
+	logger := slog.New(slog.DiscardHandler)
+	reg := registry.New(logger)
+	srv := NewServer(reg, store.NewMemory(store.Config{}), ServerConfig{}, logger)
+	httpServer := httptest.NewServer(srv.Handler())
+	defer httpServer.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	conn, _, err := websocket.Dial(
+		ctx,
+		"ws"+strings.TrimPrefix(httpServer.URL, "http")+"/ws/provider",
+		nil,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close(websocket.StatusNormalClosure, "")
+
+	capability := cacheEligibilityV2Capability("model")
+	ready := protocol.PrefixCacheModelStatus{
+		ModelID: capability.ModelID, Backend: "contiguous", ReplayStrategy: "direct",
+		State: "ready", Reason: "ready",
+	}
+	statuses := []protocol.PrefixCacheModelStatus{ready}
+	writeProviderJSON(t, ctx, conn, protocol.RegisterMessage{
+		Type: protocol.TypeRegister,
+		Models: []protocol.ModelInfo{{
+			ID: capability.ModelID, WeightHash: capability.ModelAggregateHash,
+		}},
+		Backend:             "mlx-swift",
+		PrefixCacheProtocol: 2,
+		PrefixCacheV2Models: []protocol.PrefixCacheV2Capability{capability},
+		PrefixCacheStatuses: &statuses,
+	})
+	waitCacheCondition(t, func() bool {
+		status := reg.PrefixCacheProtocolStatus()
+		return status.V2ReadyModels == 1 && status.ByState["ready"] == 1
+	})
+
+	capacity := &protocol.BackendCapacity{Slots: []protocol.BackendSlotCapacity{{
+		Model: capability.ModelID, State: "idle",
+	}}}
+	pending := []protocol.PrefixCacheModelStatus{{
+		ModelID: capability.ModelID, Backend: "contiguous", ReplayStrategy: "direct",
+		State: "pending", Reason: "scan_pending",
+	}}
+	writeProviderJSON(t, ctx, conn, protocol.HeartbeatMessage{
+		Type: protocol.TypeHeartbeat, Status: "idle", Stats: protocol.HeartbeatStats{},
+		PrefixCacheStatuses: &pending, BackendCapacity: capacity,
+	})
+	waitCacheCondition(t, func() bool {
+		status := reg.PrefixCacheProtocolStatus()
+		return status.V2ReadyModels == 1 &&
+			status.ReportedLoadedModels == 0 &&
+			status.UnreportedLoadedModels == 1
+	})
+
+	restored := []protocol.PrefixCacheModelStatus{ready}
+	writeProviderJSON(t, ctx, conn, protocol.HeartbeatMessage{
+		Type: protocol.TypeHeartbeat, Status: "idle", Stats: protocol.HeartbeatStats{},
+		PrefixCacheStatuses: &restored, BackendCapacity: capacity,
+	})
+	waitCacheCondition(t, func() bool {
+		return reg.PrefixCacheProtocolStatus().ByState["ready"] == 1
+	})
+
+	emptyCapabilities := []protocol.PrefixCacheV2Capability{}
+	readyOnV1 := []protocol.PrefixCacheModelStatus{ready}
+	writeProviderJSON(t, ctx, conn, protocol.HeartbeatMessage{
+		Type: protocol.TypeHeartbeat, Status: "idle", Stats: protocol.HeartbeatStats{},
+		PrefixCacheProtocol: 1,
+		PrefixCacheV2Models: &emptyCapabilities,
+		PrefixCacheStatuses: &readyOnV1,
+		BackendCapacity:     capacity,
+	})
+	waitCacheCondition(t, func() bool {
+		status := reg.PrefixCacheProtocolStatus()
+		return status.V1 == 1 &&
+			status.V2ReadyModels == 0 &&
+			status.ReportedLoadedModels == 0
+	})
+}
+
+func cacheEligibilityV2Capability(modelID string) protocol.PrefixCacheV2Capability {
+	return protocol.PrefixCacheV2Capability{
+		ModelID:            modelID,
+		ModelAggregateHash: strings.Repeat("a", 64),
+		PromptContractID:   strings.Repeat("b", 64),
+		BlockHashVersion:   promptcontract.BlockHashVersion,
+		BlockSize:          promptcontract.BlockSize,
+		CacheEpoch:         "11111111-1111-1111-1111-111111111111",
+		Enabled:            true,
+		Ready:              true,
 	}
 }
 

--- a/coordinator/api/cache_eligibility_integration_test.go
+++ b/coordinator/api/cache_eligibility_integration_test.go
@@ -1,0 +1,127 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+	"github.com/eigeninference/d-inference/coordinator/registry"
+	"github.com/eigeninference/d-inference/coordinator/store"
+	"nhooyr.io/websocket"
+)
+
+func TestCacheEligibilityHeartbeatLifecycleThroughProviderWebSocket(t *testing.T) {
+	logger := slog.New(slog.DiscardHandler)
+	reg := registry.New(logger)
+	srv := NewServer(reg, store.NewMemory(store.Config{}), ServerConfig{}, logger)
+	httpServer := httptest.NewServer(srv.Handler())
+	defer httpServer.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	conn, _, err := websocket.Dial(
+		ctx,
+		"ws"+strings.TrimPrefix(httpServer.URL, "http")+"/ws/provider",
+		nil,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close(websocket.StatusNormalClosure, "")
+
+	initialStatuses := []protocol.PrefixCacheModelStatus{{
+		ModelID: "model", Backend: "contiguous", ReplayStrategy: "none",
+		State: "disabled", Reason: "weight_hash_unavailable",
+	}}
+	initialOutcomes := []protocol.PrefixCacheDonationOutcomeCount{{
+		Outcome: "donated", Count: 2,
+	}}
+	writeProviderJSON(t, ctx, conn, protocol.RegisterMessage{
+		Type:                        protocol.TypeRegister,
+		Models:                      []protocol.ModelInfo{{ID: "model"}},
+		Backend:                     "mlx-swift",
+		PrefixCacheProtocol:         1,
+		PrefixCacheStatuses:         &initialStatuses,
+		PrefixCacheDonationOutcomes: &initialOutcomes,
+	})
+	waitCacheCondition(t, func() bool {
+		status := reg.PrefixCacheProtocolStatus()
+		return status.ReportedLoadedModels == 1 &&
+			status.ByReason["weight_hash_unavailable"] == 1
+	})
+
+	replacement := []protocol.PrefixCacheModelStatus{{
+		ModelID: "model", Backend: "contiguous", ReplayStrategy: "direct",
+		State: "pending", Reason: "scan_pending",
+	}}
+	fiveOutcomes := []protocol.PrefixCacheDonationOutcomeCount{{
+		Outcome: "donated", Count: 5,
+	}}
+	writeProviderJSON(t, ctx, conn, protocol.HeartbeatMessage{
+		Type: protocol.TypeHeartbeat, Status: "idle",
+		Stats:                       protocol.HeartbeatStats{},
+		PrefixCacheStatuses:         &replacement,
+		PrefixCacheDonationOutcomes: &fiveOutcomes,
+	})
+	waitCacheCondition(t, func() bool {
+		status := reg.PrefixCacheProtocolStatus()
+		return status.ByReason["scan_pending"] == 1 &&
+			reg.CacheRoutingLifecycleStatus().DonationOutcomes["donated"] == 3
+	})
+
+	empty := []protocol.PrefixCacheModelStatus{}
+	writeProviderJSON(t, ctx, conn, protocol.HeartbeatMessage{
+		Type: protocol.TypeHeartbeat, Status: "idle",
+		Stats:                       protocol.HeartbeatStats{},
+		PrefixCacheStatuses:         &empty,
+		PrefixCacheDonationOutcomes: &fiveOutcomes,
+	})
+	waitCacheCondition(t, func() bool {
+		return reg.PrefixCacheProtocolStatus().ReportedLoadedModels == 0
+	})
+
+	// An old-provider-style omission does not recreate or fabricate status.
+	writeProviderJSON(t, ctx, conn, protocol.HeartbeatMessage{
+		Type: protocol.TypeHeartbeat, Status: "idle", Stats: protocol.HeartbeatStats{},
+	})
+	time.Sleep(25 * time.Millisecond)
+	if got := reg.PrefixCacheProtocolStatus().ReportedLoadedModels; got != 0 {
+		t.Fatalf("omitted snapshot changed authoritative clear: %d", got)
+	}
+
+	if err := conn.Close(websocket.StatusNormalClosure, "done"); err != nil {
+		t.Fatal(err)
+	}
+	waitCacheCondition(t, func() bool { return reg.ProviderCount() == 0 })
+	if got := reg.PrefixCacheProtocolStatus().LoadedModels; got != 0 {
+		t.Fatalf("disconnect retained loaded status: %d", got)
+	}
+}
+
+func writeProviderJSON(t *testing.T, ctx context.Context, conn *websocket.Conn, value any) {
+	t.Helper()
+	data, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := conn.Write(ctx, websocket.MessageText, data); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func waitCacheCondition(t *testing.T, condition func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if condition() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("timed out waiting for cache telemetry state")
+}

--- a/coordinator/api/exact_cache_metrics.go
+++ b/coordinator/api/exact_cache_metrics.go
@@ -165,6 +165,42 @@ func (s *Server) registerExactCacheGauges() {
 	s.metrics.RegisterGauge("exact_cache_v2_ready_models", gauge(func(s ExactCacheStatus) float64 {
 		return float64(s.Providers.V2ReadyModels)
 	}))
+	s.metrics.RegisterGauge("exact_cache_loaded_models", gauge(func(s ExactCacheStatus) float64 {
+		return float64(s.Providers.LoadedModels)
+	}))
+	s.metrics.RegisterGauge("exact_cache_reported_loaded_models", gauge(func(s ExactCacheStatus) float64 {
+		return float64(s.Providers.ReportedLoadedModels)
+	}))
+	s.metrics.RegisterGauge("exact_cache_unreported_loaded_models", gauge(func(s ExactCacheStatus) float64 {
+		return float64(s.Providers.UnreportedLoadedModels)
+	}))
+	s.metrics.RegisterGauge("exact_cache_excluded_models", gauge(func(s ExactCacheStatus) float64 {
+		return float64(s.Providers.ExcludedModels)
+	}))
+	for _, state := range registry.PrefixCacheStatusStates() {
+		state := state
+		s.metrics.RegisterGaugeLabels("exact_cache_eligibility_state", gauge(func(s ExactCacheStatus) float64 {
+			return float64(s.Providers.ByState[state])
+		}), MetricLabel{"state", state})
+	}
+	for _, reason := range registry.PrefixCacheStatusReasons() {
+		reason := reason
+		s.metrics.RegisterGaugeLabels("exact_cache_eligibility_reason", gauge(func(s ExactCacheStatus) float64 {
+			return float64(s.Providers.ByReason[reason])
+		}), MetricLabel{"reason", reason})
+	}
+	for _, backend := range registry.PrefixCacheStatusBackends() {
+		backend := backend
+		s.metrics.RegisterGaugeLabels("exact_cache_eligibility_backend", gauge(func(s ExactCacheStatus) float64 {
+			return float64(s.Providers.ByBackend[backend])
+		}), MetricLabel{"backend", backend})
+	}
+	for _, strategy := range registry.PrefixCacheReplayStrategies() {
+		strategy := strategy
+		s.metrics.RegisterGaugeLabels("exact_cache_eligibility_strategy", gauge(func(s ExactCacheStatus) float64 {
+			return float64(s.Providers.ByReplayStrategy[strategy])
+		}), MetricLabel{"strategy", strategy})
+	}
 	s.metrics.RegisterGauge("exact_cache_holders", gauge(func(s ExactCacheStatus) float64 {
 		return float64(s.Holders)
 	}))
@@ -184,6 +220,21 @@ func (s *Server) registerExactCacheGauges() {
 		s.metrics.RegisterGaugeLabels("exact_cache_ssd_lifecycle", gauge(func(s ExactCacheStatus) float64 {
 			return float64(lifecycle.value(s.Lifecycle))
 		}), MetricLabel{"event", lifecycle.name})
+	}
+	s.metrics.RegisterGauge("exact_cache_holder_added", gauge(func(s ExactCacheStatus) float64 {
+		return float64(s.Lifecycle.HolderAdded)
+	}))
+	for _, reason := range registry.CacheHolderRemovalReasons() {
+		reason := reason
+		s.metrics.RegisterGaugeLabels("exact_cache_holder_removed", gauge(func(s ExactCacheStatus) float64 {
+			return float64(s.Lifecycle.HolderRemoved[reason])
+		}), MetricLabel{"reason", reason})
+	}
+	for _, outcome := range registry.PrefixCacheDonationOutcomes() {
+		outcome := outcome
+		s.metrics.RegisterGaugeLabels("exact_cache_donation_outcome", gauge(func(s ExactCacheStatus) float64 {
+			return float64(s.Lifecycle.DonationOutcomes[outcome])
+		}), MetricLabel{"outcome", outcome})
 	}
 }
 
@@ -249,12 +300,41 @@ func (s *Server) emitExactCacheDDGauges() {
 	s.ddGauge("exact_cache.provider_protocol", float64(status.Providers.V1), []string{"version:1"})
 	s.ddGauge("exact_cache.provider_protocol", float64(status.Providers.V2), []string{"version:2"})
 	s.ddGauge("exact_cache.v2_ready_models", float64(status.Providers.V2ReadyModels), nil)
+	s.ddGauge("exact_cache.loaded_models", float64(status.Providers.LoadedModels), nil)
+	s.ddGauge("exact_cache.reported_loaded_models", float64(status.Providers.ReportedLoadedModels), nil)
+	s.ddGauge("exact_cache.unreported_loaded_models", float64(status.Providers.UnreportedLoadedModels), nil)
+	s.ddGauge("exact_cache.excluded_models", float64(status.Providers.ExcludedModels), nil)
+	for _, state := range registry.PrefixCacheStatusStates() {
+		s.ddGauge("exact_cache.eligibility_state", float64(status.Providers.ByState[state]),
+			[]string{"state:" + state})
+	}
+	for _, reason := range registry.PrefixCacheStatusReasons() {
+		s.ddGauge("exact_cache.eligibility_reason", float64(status.Providers.ByReason[reason]),
+			[]string{"reason:" + reason})
+	}
+	for _, backend := range registry.PrefixCacheStatusBackends() {
+		s.ddGauge("exact_cache.eligibility_backend", float64(status.Providers.ByBackend[backend]),
+			[]string{"backend:" + backend})
+	}
+	for _, strategy := range registry.PrefixCacheReplayStrategies() {
+		s.ddGauge("exact_cache.eligibility_strategy", float64(status.Providers.ByReplayStrategy[strategy]),
+			[]string{"strategy:" + strategy})
+	}
 	s.ddGauge("exact_cache.holders", float64(status.Holders), nil)
 	s.ddGauge("exact_cache.attempts", float64(status.Attempts), nil)
 	s.ddGauge("exact_cache.ssd_lifecycle", float64(status.Lifecycle.SSDLookups), []string{"event:lookup"})
 	s.ddGauge("exact_cache.ssd_lifecycle", float64(status.Lifecycle.SSDHits), []string{"event:hit"})
 	s.ddGauge("exact_cache.ssd_lifecycle", float64(status.Lifecycle.SSDMisses), []string{"event:miss"})
 	s.ddGauge("exact_cache.ssd_lifecycle", float64(status.Lifecycle.SSDDonations), []string{"event:donation"})
+	s.ddGauge("exact_cache.holder_added", float64(status.Lifecycle.HolderAdded), nil)
+	for _, reason := range registry.CacheHolderRemovalReasons() {
+		s.ddGauge("exact_cache.holder_removed", float64(status.Lifecycle.HolderRemoved[reason]),
+			[]string{"reason:" + reason})
+	}
+	for _, outcome := range registry.PrefixCacheDonationOutcomes() {
+		s.ddGauge("exact_cache.donation_outcome", float64(status.Lifecycle.DonationOutcomes[outcome]),
+			[]string{"outcome:" + outcome})
+	}
 }
 
 func boolGauge(value bool) float64 {

--- a/coordinator/api/exact_cache_status_test.go
+++ b/coordinator/api/exact_cache_status_test.go
@@ -145,6 +145,7 @@ func TestExactCacheStatusIsAggregateAndPrivacySafe(t *testing.T) {
 		"exact_cache_eligibility_backend{backend=contiguous}",
 		"exact_cache_eligibility_backend{backend=paged}",
 		"exact_cache_eligibility_strategy{strategy=frozen_full}",
+		"exact_cache_eligibility_strategy{strategy=tail_replay}",
 		"exact_cache_holders",
 		"exact_cache_attempts",
 		"exact_cache_ssd_lifecycle{event=lookup}",
@@ -161,7 +162,6 @@ func TestExactCacheStatusIsAggregateAndPrivacySafe(t *testing.T) {
 			t.Fatalf("missing exact-cache gauge %q", key)
 		}
 	}
-
 	collector := newUDPCollector(t)
 	defer collector.Close()
 	ddClient := newTestDD(t, collector)

--- a/coordinator/api/exact_cache_status_test.go
+++ b/coordinator/api/exact_cache_status_test.go
@@ -25,10 +25,19 @@ func TestExactCacheStatusIsAggregateAndPrivacySafe(t *testing.T) {
 	reg.Register("private-provider-v0", nil, &protocol.RegisterMessage{
 		Models: []protocol.ModelInfo{{ID: "private-model-v0"}},
 	})
+	v1Statuses := []protocol.PrefixCacheModelStatus{{
+		ModelID: "private-model-v1", Backend: "paged", ReplayStrategy: "none",
+		State: "disabled", Reason: "paged_hybrid_unsupported",
+	}}
 	reg.Register("private-provider-v1", nil, &protocol.RegisterMessage{
 		PrefixCacheProtocol: 1,
 		Models:              []protocol.ModelInfo{{ID: "private-model-v1"}},
+		PrefixCacheStatuses: &v1Statuses,
 	})
+	v2Statuses := []protocol.PrefixCacheModelStatus{{
+		ModelID: "private-model-v2", Backend: "contiguous", ReplayStrategy: "frozen_full",
+		State: "ready", Reason: "ready",
+	}}
 	v2 := reg.Register("private-provider-v2", nil, &protocol.RegisterMessage{
 		PrefixCacheProtocol: 2,
 		Models: []protocol.ModelInfo{{
@@ -42,6 +51,7 @@ func TestExactCacheStatusIsAggregateAndPrivacySafe(t *testing.T) {
 			CacheEpoch:       "11111111-1111-1111-1111-111111111111",
 			Enabled:          true, Ready: true,
 		}},
+		PrefixCacheStatuses: &v2Statuses,
 	})
 	if v2 == nil {
 		t.Fatal("register v2 provider")
@@ -60,6 +70,13 @@ func TestExactCacheStatusIsAggregateAndPrivacySafe(t *testing.T) {
 	if status.Providers.V0 != 1 || status.Providers.V1 != 1 ||
 		status.Providers.V2 != 1 || status.Providers.V2ReadyModels != 1 {
 		t.Fatalf("provider protocol status=%+v", status.Providers)
+	}
+	if status.Providers.LoadedModels != 2 ||
+		status.Providers.ReportedLoadedModels != 2 ||
+		status.Providers.ExcludedModels != 1 ||
+		status.Providers.ByReason["paged_hybrid_unsupported"] != 1 ||
+		status.Providers.ByReplayStrategy["frozen_full"] != 1 {
+		t.Fatalf("provider eligibility status=%+v", status.Providers)
 	}
 	if status.RoutingMode != registry.CacheRoutingOff {
 		t.Fatalf("routing mode=%q, want off", status.RoutingMode)
@@ -117,15 +134,61 @@ func TestExactCacheStatusIsAggregateAndPrivacySafe(t *testing.T) {
 		"exact_cache_provider_protocol{version=1}",
 		"exact_cache_provider_protocol{version=2}",
 		"exact_cache_v2_ready_models",
+		"exact_cache_loaded_models",
+		"exact_cache_reported_loaded_models",
+		"exact_cache_unreported_loaded_models",
+		"exact_cache_excluded_models",
+		"exact_cache_eligibility_state{state=ready}",
+		"exact_cache_eligibility_state{state=disabled}",
+		"exact_cache_eligibility_reason{reason=paged_hybrid_unsupported}",
+		"exact_cache_eligibility_reason{reason=scan_failed}",
+		"exact_cache_eligibility_backend{backend=contiguous}",
+		"exact_cache_eligibility_backend{backend=paged}",
+		"exact_cache_eligibility_strategy{strategy=frozen_full}",
 		"exact_cache_holders",
 		"exact_cache_attempts",
 		"exact_cache_ssd_lifecycle{event=lookup}",
 		"exact_cache_ssd_lifecycle{event=miss}",
 		"exact_cache_ssd_lifecycle{event=hit}",
 		"exact_cache_ssd_lifecycle{event=donation}",
+		"exact_cache_holder_added",
+		"exact_cache_holder_removed{reason=ttl}",
+		"exact_cache_holder_removed{reason=capability_change}",
+		"exact_cache_donation_outcome{outcome=donated}",
+		"exact_cache_donation_outcome{outcome=write_queue_full}",
 	} {
 		if _, ok := gauges[key]; !ok {
 			t.Fatalf("missing exact-cache gauge %q", key)
+		}
+	}
+
+	collector := newUDPCollector(t)
+	defer collector.Close()
+	ddClient := newTestDD(t, collector)
+	defer ddClient.Close()
+	srv.SetDatadog(ddClient)
+	srv.emitExactCacheDDGauges()
+	_ = ddClient.Statsd.Flush()
+	packets := collector.drain()
+	for _, metric := range []string{
+		"exact_cache.eligibility_state",
+		"exact_cache.eligibility_reason",
+		"exact_cache.eligibility_backend",
+		"exact_cache.eligibility_strategy",
+		"exact_cache.holder_removed",
+		"exact_cache.donation_outcome",
+	} {
+		if !hasMetric(packets, metric) {
+			t.Fatalf("missing Datadog gauge %q in %v", metric, packets)
+		}
+	}
+	encodedPackets := strings.Join(packets, "\n")
+	for _, sensitive := range []string{
+		"private-provider", "private-model", strings.Repeat("a", 64),
+		strings.Repeat("b", 64), "11111111-1111-1111-1111-111111111111",
+	} {
+		if strings.Contains(encodedPackets, sensitive) {
+			t.Fatalf("Datadog cache gauges leaked %q: %s", sensitive, encodedPackets)
 		}
 	}
 }

--- a/coordinator/api/provider.go
+++ b/coordinator/api/provider.go
@@ -467,34 +467,40 @@ func (s *Server) providerReadLoop(ctx context.Context, conn *websocket.Conn, pro
 
 		case protocol.TypeHeartbeat:
 			hbMsg := msg.Payload.(*protocol.HeartbeatMessage)
-			if hbMsg.PrefixCacheStatuses != nil ||
+			replaceCacheCapabilities :=
+				hbMsg.PrefixCacheProtocol != 0 || hbMsg.PrefixCacheV2Models != nil
+			if replaceCacheCapabilities ||
+				hbMsg.PrefixCacheStatuses != nil ||
 				hbMsg.PrefixCacheDonationOutcomes != nil {
-				if err := s.registry.UpdatePrefixCacheTelemetry(
-					providerID,
-					hbMsg.PrefixCacheStatuses,
-					hbMsg.PrefixCacheDonationOutcomes,
-				); err != nil {
-					s.logger.Warn("rejecting malformed heartbeat cache telemetry",
-						"provider_id", providerID, "error", err)
-					s.ddIncr("routing.cache_telemetry_rejected", []string{"source:heartbeat"})
-					if hbMsg.PrefixCacheStatuses != nil {
-						s.registry.ClearPrefixCacheStatuses(providerID)
-					}
-				}
-			}
-			if hbMsg.PrefixCacheProtocol != 0 || hbMsg.PrefixCacheV2Models != nil {
-				capabilities := []protocol.PrefixCacheV2Capability(nil)
+				var capabilities []protocol.PrefixCacheV2Capability
 				if hbMsg.PrefixCacheV2Models != nil {
 					capabilities = *hbMsg.PrefixCacheV2Models
 				}
-				if err := s.registry.UpdatePrefixCacheCapabilities(
-					providerID, hbMsg.PrefixCacheProtocol, capabilities,
-				); err != nil {
+				_, err := s.registry.UpdatePrefixCacheSnapshot(
+					providerID,
+					replaceCacheCapabilities,
+					hbMsg.PrefixCacheProtocol,
+					capabilities,
+					hbMsg.PrefixCacheStatuses,
+					hbMsg.PrefixCacheDonationOutcomes,
+				)
+				if err != nil && replaceCacheCapabilities {
 					s.logger.Warn("rejecting malformed heartbeat cache capabilities",
 						"provider_id", providerID, "error", err)
 					s.ddIncr("routing.cache_capability_rejected", []string{"source:heartbeat"})
 					// Malformed refreshes cannot leave stale v2 evidence live.
-					_ = s.registry.UpdatePrefixCacheCapabilities(providerID, 1, nil)
+					_, _ = s.registry.UpdatePrefixCacheSnapshot(
+						providerID,
+						true,
+						1,
+						nil,
+						hbMsg.PrefixCacheStatuses,
+						hbMsg.PrefixCacheDonationOutcomes,
+					)
+				} else if err != nil {
+					s.logger.Warn("failed to apply heartbeat cache telemetry",
+						"provider_id", providerID, "error", err)
+					s.ddIncr("routing.cache_telemetry_rejected", []string{"source:heartbeat"})
 				}
 			}
 			s.registry.Heartbeat(providerID, hbMsg)

--- a/coordinator/api/provider.go
+++ b/coordinator/api/provider.go
@@ -293,7 +293,7 @@ func (s *Server) providerReadLoop(ctx context.Context, conn *websocket.Conn, pro
 		switch msg.Type {
 		case protocol.TypeRegister:
 			regMsg := msg.Payload.(*protocol.RegisterMessage)
-			if err := registry.ValidatePrefixCacheRegistration(regMsg); err != nil {
+			if err := s.registry.ValidatePrefixCacheRegistration(regMsg); err != nil {
 				s.logger.Warn("rejecting malformed provider cache capabilities",
 					"provider_id", providerID, "error", err)
 				s.ddIncr("routing.cache_capability_rejected", []string{"source:register"})
@@ -467,6 +467,21 @@ func (s *Server) providerReadLoop(ctx context.Context, conn *websocket.Conn, pro
 
 		case protocol.TypeHeartbeat:
 			hbMsg := msg.Payload.(*protocol.HeartbeatMessage)
+			if hbMsg.PrefixCacheStatuses != nil ||
+				hbMsg.PrefixCacheDonationOutcomes != nil {
+				if err := s.registry.UpdatePrefixCacheTelemetry(
+					providerID,
+					hbMsg.PrefixCacheStatuses,
+					hbMsg.PrefixCacheDonationOutcomes,
+				); err != nil {
+					s.logger.Warn("rejecting malformed heartbeat cache telemetry",
+						"provider_id", providerID, "error", err)
+					s.ddIncr("routing.cache_telemetry_rejected", []string{"source:heartbeat"})
+					if hbMsg.PrefixCacheStatuses != nil {
+						s.registry.ClearPrefixCacheStatuses(providerID)
+					}
+				}
+			}
 			if hbMsg.PrefixCacheProtocol != 0 || hbMsg.PrefixCacheV2Models != nil {
 				capabilities := []protocol.PrefixCacheV2Capability(nil)
 				if hbMsg.PrefixCacheV2Models != nil {

--- a/coordinator/protocol/messages.go
+++ b/coordinator/protocol/messages.go
@@ -155,28 +155,50 @@ type PrefixCacheV2Capability struct {
 	Ready              bool   `json:"ready"`
 }
 
+// PrefixCacheModelStatus is a content-free status for one concrete loaded
+// model slot. Every dimension is a fixed enum validated at the coordinator
+// boundary; no cache identity, provider identity, path, hash, or request data
+// is carried.
+type PrefixCacheModelStatus struct {
+	ModelID        string `json:"model_id"`
+	Backend        string `json:"backend"`
+	ReplayStrategy string `json:"replay_strategy"`
+	State          string `json:"state"`
+	Reason         string `json:"reason"`
+}
+
+// PrefixCacheDonationOutcomeCount is one cumulative, process-local counter
+// from the provider's SSD donation path. Outcome is a fixed enum; Count is
+// monotonic for the lifetime of the provider process.
+type PrefixCacheDonationOutcomeCount struct {
+	Outcome string `json:"outcome"`
+	Count   uint64 `json:"count"`
+}
+
 // ---------------------------------------------------------------------------
 // Provider → Coordinator messages
 // ---------------------------------------------------------------------------
 
 // RegisterMessage is sent when a provider first connects.
 type RegisterMessage struct {
-	Type                    string                    `json:"type"`
-	Hardware                Hardware                  `json:"hardware"`
-	Models                  []ModelInfo               `json:"models"`
-	Backend                 string                    `json:"backend"`
-	Version                 string                    `json:"version,omitempty"`                   // provider binary version (e.g. "0.2.31")
-	PublicKey               string                    `json:"public_key,omitempty"`                // base64-encoded X25519 public key for E2E encryption
-	EncryptedResponseChunks bool                      `json:"encrypted_response_chunks,omitempty"` // true when text response chunks are returned encrypted to the coordinator
-	Attestation             json.RawMessage           `json:"attestation,omitempty"`               // signed Secure Enclave attestation blob
-	PrefillTPS              float64                   `json:"prefill_tps,omitempty"`               // benchmark: prefill tokens per second
-	DecodeTPS               float64                   `json:"decode_tps,omitempty"`                // benchmark: decode tokens per second
-	AuthToken               string                    `json:"auth_token,omitempty"`                // device-linked provider token (from darkbloom login)
-	PrivateOnly             bool                      `json:"private_only,omitempty"`              // when true, this machine serves only its owner's self-route requests, never the public fleet
-	PrefixCacheProtocol     int                       `json:"prefix_cache_protocol,omitempty"`     // provider-confirmed prefix-cache protocol version
-	PrefixCacheV2Models     []PrefixCacheV2Capability `json:"prefix_cache_v2_models,omitempty"`
-	ToolConstraintProtocol  int                       `json:"tool_constraint_protocol,omitempty"` // inference-time tool grammar protocol version
-	ToolConstraintModels    []string                  `json:"tool_constraint_models,omitempty"`   // concrete model IDs enforced by this provider
+	Type                        string                             `json:"type"`
+	Hardware                    Hardware                           `json:"hardware"`
+	Models                      []ModelInfo                        `json:"models"`
+	Backend                     string                             `json:"backend"`
+	Version                     string                             `json:"version,omitempty"`                   // provider binary version (e.g. "0.2.31")
+	PublicKey                   string                             `json:"public_key,omitempty"`                // base64-encoded X25519 public key for E2E encryption
+	EncryptedResponseChunks     bool                               `json:"encrypted_response_chunks,omitempty"` // true when text response chunks are returned encrypted to the coordinator
+	Attestation                 json.RawMessage                    `json:"attestation,omitempty"`               // signed Secure Enclave attestation blob
+	PrefillTPS                  float64                            `json:"prefill_tps,omitempty"`               // benchmark: prefill tokens per second
+	DecodeTPS                   float64                            `json:"decode_tps,omitempty"`                // benchmark: decode tokens per second
+	AuthToken                   string                             `json:"auth_token,omitempty"`                // device-linked provider token (from darkbloom login)
+	PrivateOnly                 bool                               `json:"private_only,omitempty"`              // when true, this machine serves only its owner's self-route requests, never the public fleet
+	PrefixCacheProtocol         int                                `json:"prefix_cache_protocol,omitempty"`     // provider-confirmed prefix-cache protocol version
+	PrefixCacheV2Models         []PrefixCacheV2Capability          `json:"prefix_cache_v2_models,omitempty"`
+	PrefixCacheStatuses         *[]PrefixCacheModelStatus          `json:"prefix_cache_statuses,omitempty"`
+	PrefixCacheDonationOutcomes *[]PrefixCacheDonationOutcomeCount `json:"prefix_cache_donation_outcomes,omitempty"`
+	ToolConstraintProtocol      int                                `json:"tool_constraint_protocol,omitempty"` // inference-time tool grammar protocol version
+	ToolConstraintModels        []string                           `json:"tool_constraint_models,omitempty"`   // concrete model IDs enforced by this provider
 
 	// APNs code-identity attestation (v0.6.0): the device token the coordinator
 	// pushes the E_K(nonce) code-identity challenge to, and which APNs environment
@@ -221,6 +243,10 @@ type HeartbeatMessage struct {
 	// v2 capabilities and a v2 provider authoritatively clearing its live set.
 	PrefixCacheProtocol int                        `json:"prefix_cache_protocol,omitempty"`
 	PrefixCacheV2Models *[]PrefixCacheV2Capability `json:"prefix_cache_v2_models,omitempty"`
+	// Optional pointers preserve old-provider omission versus an authoritative
+	// empty snapshot/counter set from a current provider.
+	PrefixCacheStatuses         *[]PrefixCacheModelStatus          `json:"prefix_cache_statuses,omitempty"`
+	PrefixCacheDonationOutcomes *[]PrefixCacheDonationOutcomeCount `json:"prefix_cache_donation_outcomes,omitempty"`
 
 	// APNs code-identity attestation (W5 Fix 2): a provider that only obtained
 	// its APNs device token AFTER registration (headless/late-token Mac) — or

--- a/coordinator/protocol/prefix_cache_telemetry_test.go
+++ b/coordinator/protocol/prefix_cache_telemetry_test.go
@@ -1,0 +1,65 @@
+package protocol
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestPrefixCacheTelemetryOptionalWireCompatibility(t *testing.T) {
+	legacy, err := json.Marshal(RegisterMessage{Type: TypeRegister})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, field := range []string{
+		"prefix_cache_statuses",
+		"prefix_cache_donation_outcomes",
+	} {
+		if strings.Contains(string(legacy), field) {
+			t.Fatalf("legacy registration emitted %q: %s", field, legacy)
+		}
+	}
+
+	statuses := []PrefixCacheModelStatus{{
+		ModelID: "model", Backend: "contiguous", ReplayStrategy: "frozen_full",
+		State: "disabled", Reason: "weight_hash_unavailable",
+	}}
+	outcomes := []PrefixCacheDonationOutcomeCount{{
+		Outcome: "write_queue_full", Count: 3,
+	}}
+	encoded, err := json.Marshal(HeartbeatMessage{
+		Type: TypeHeartbeat, PrefixCacheStatuses: &statuses,
+		PrefixCacheDonationOutcomes: &outcomes,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded HeartbeatMessage
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if decoded.PrefixCacheStatuses == nil ||
+		len(*decoded.PrefixCacheStatuses) != 1 ||
+		(*decoded.PrefixCacheStatuses)[0] != statuses[0] {
+		t.Fatalf("status snapshot did not round-trip: %s", encoded)
+	}
+	if decoded.PrefixCacheDonationOutcomes == nil ||
+		len(*decoded.PrefixCacheDonationOutcomes) != 1 ||
+		(*decoded.PrefixCacheDonationOutcomes)[0] != outcomes[0] {
+		t.Fatalf("donation outcomes did not round-trip: %s", encoded)
+	}
+
+	emptyStatuses := []PrefixCacheModelStatus{}
+	emptyOutcomes := []PrefixCacheDonationOutcomeCount{}
+	empty, err := json.Marshal(HeartbeatMessage{
+		Type: TypeHeartbeat, PrefixCacheStatuses: &emptyStatuses,
+		PrefixCacheDonationOutcomes: &emptyOutcomes,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(empty), `"prefix_cache_statuses":[]`) ||
+		!strings.Contains(string(empty), `"prefix_cache_donation_outcomes":[]`) {
+		t.Fatalf("authoritative empty snapshots were omitted: %s", empty)
+	}
+}

--- a/coordinator/registry/cache_capabilities_v2.go
+++ b/coordinator/registry/cache_capabilities_v2.go
@@ -191,6 +191,8 @@ func (r *Registry) UpdatePrefixCacheCapabilities(
 	}
 	changed := provider.PrefixCacheProtocol != version ||
 		!equalPrefixCacheCapabilities(provider.PrefixCacheV2Models, validated)
+	removalReason := prefixCacheCapabilityRemovalReason(
+		provider.PrefixCacheV2Models, validated)
 	if changed {
 		provider.PrefixCacheProtocol = version
 		provider.PrefixCacheV2Models = validated
@@ -202,7 +204,33 @@ func (r *Registry) UpdatePrefixCacheCapabilities(
 	tracker := r.cacheRouting
 	r.mu.RUnlock()
 	if changed && tracker != nil {
-		tracker.disconnect(providerID)
+		tracker.disconnect(providerID, removalReason)
 	}
 	return nil
+}
+
+func prefixCacheCapabilityRemovalReason(
+	previous, current map[string]protocol.PrefixCacheV2Capability,
+) cacheHolderRemovalReason {
+	if len(previous) == 0 || len(previous) != len(current) {
+		return cacheHolderRemovalCapabilityChange
+	}
+	epochChanged := false
+	for modelID, before := range previous {
+		after, ok := current[modelID]
+		if !ok {
+			return cacheHolderRemovalCapabilityChange
+		}
+		if before.CacheEpoch != after.CacheEpoch {
+			epochChanged = true
+			before.CacheEpoch = after.CacheEpoch
+		}
+		if before != after {
+			return cacheHolderRemovalCapabilityChange
+		}
+	}
+	if epochChanged {
+		return cacheHolderRemovalEpochChange
+	}
+	return cacheHolderRemovalCapabilityChange
 }

--- a/coordinator/registry/cache_capabilities_v2.go
+++ b/coordinator/registry/cache_capabilities_v2.go
@@ -168,45 +168,15 @@ func (r *Registry) UpdatePrefixCacheCapabilities(
 	version int,
 	capabilities []protocol.PrefixCacheV2Capability,
 ) error {
-	if r == nil {
-		return nil
-	}
-	r.mu.RLock()
-	provider := r.providers[providerID]
-	r.mu.RUnlock()
-	if provider == nil {
-		return fmt.Errorf("%w: provider is not registered", errInvalidPrefixCacheCapability)
-	}
-
-	provider.mu.Lock()
-	models, err := uniqueProviderModels(provider.Models)
-	if err != nil {
-		provider.mu.Unlock()
-		return err
-	}
-	validated, err := validatePrefixCacheCapabilities(version, capabilities, models)
-	if err != nil {
-		provider.mu.Unlock()
-		return err
-	}
-	changed := provider.PrefixCacheProtocol != version ||
-		!equalPrefixCacheCapabilities(provider.PrefixCacheV2Models, validated)
-	removalReason := prefixCacheCapabilityRemovalReason(
-		provider.PrefixCacheV2Models, validated)
-	if changed {
-		provider.PrefixCacheProtocol = version
-		provider.PrefixCacheV2Models = validated
-		provider.prefixCacheRevision++
-	}
-	provider.mu.Unlock()
-
-	r.mu.RLock()
-	tracker := r.cacheRouting
-	r.mu.RUnlock()
-	if changed && tracker != nil {
-		tracker.disconnect(providerID, removalReason)
-	}
-	return nil
+	_, err := r.UpdatePrefixCacheSnapshot(
+		providerID,
+		true,
+		version,
+		capabilities,
+		nil,
+		nil,
+	)
+	return err
 }
 
 func prefixCacheCapabilityRemovalReason(

--- a/coordinator/registry/cache_eligibility.go
+++ b/coordinator/registry/cache_eligibility.go
@@ -9,8 +9,11 @@ import (
 )
 
 const (
-	maxPrefixCacheStatuses         = 16
-	maxPrefixCacheDonationOutcomes = 13
+	maxPrefixCacheStatuses = 16
+	// The aggregate vocabulary remains the 13 known outcomes below. The raw
+	// wire cap leaves 19 slots for future-version outcomes while bounding all
+	// duplicate/filter work to a small fixed array.
+	maxPrefixCacheDonationOutcomeEntries = 32
 )
 
 var (
@@ -214,7 +217,7 @@ func sanitizePrefixCacheDonationOutcomes(
 	if outcomes == nil {
 		return nil
 	}
-	if len(*outcomes) > maxPrefixCacheDonationOutcomes {
+	if len(*outcomes) > maxPrefixCacheDonationOutcomeEntries {
 		*outcomes = []protocol.PrefixCacheDonationOutcomeCount{}
 		return map[string]uint64{}
 	}

--- a/coordinator/registry/cache_eligibility.go
+++ b/coordinator/registry/cache_eligibility.go
@@ -18,7 +18,6 @@ var (
 	prefixCacheStatusReasons = []string{
 		"ready",
 		"config_disabled",
-		"no_loaded_slot",
 		"weight_hash_unavailable",
 		"runtime_identity_unavailable",
 		"unsupported_layout",
@@ -30,7 +29,9 @@ var (
 		"cache_init_failed",
 	}
 	prefixCacheStatusBackends   = []string{"contiguous", "paged", "unknown"}
-	prefixCacheReplayStrategies = []string{"direct", "frozen_full", "none", "unknown"}
+	prefixCacheReplayStrategies = []string{
+		"direct", "frozen_full", "tail_replay", "none", "unknown",
+	}
 	prefixCacheDonationOutcomes = []string{
 		"donated",
 		"below_effective_token_floor",
@@ -122,7 +123,7 @@ func validPrefixCacheStateReason(state, reason string) bool {
 		return reason == "scan_pending"
 	case "disabled":
 		switch reason {
-		case "config_disabled", "no_loaded_slot", "weight_hash_unavailable",
+		case "config_disabled", "weight_hash_unavailable",
 			"runtime_identity_unavailable", "unsupported_layout",
 			"unsupported_backend", "paged_hybrid_unsupported":
 			return true
@@ -134,6 +135,72 @@ func validPrefixCacheStateReason(state, reason string) bool {
 		}
 	}
 	return false
+}
+
+func concreteReadyPrefixCacheStatus(status protocol.PrefixCacheModelStatus) bool {
+	if status.State != "ready" || status.Reason != "ready" {
+		return false
+	}
+	if status.Backend != "contiguous" && status.Backend != "paged" {
+		return false
+	}
+	switch status.ReplayStrategy {
+	case "direct", "frozen_full", "tail_replay":
+		return true
+	default:
+		return false
+	}
+}
+
+// reconcilePrefixCacheStatuses cross-validates optional ready status against
+// the authoritative routing capability snapshot. Contradictory ready entries
+// are dropped. If an advertised v2 capability then lacks exactly one concrete
+// ready status, the entire optional snapshot becomes unreported rather than
+// weakening or deleting the strict routing capability.
+func reconcilePrefixCacheStatuses(
+	version int,
+	capabilities map[string]protocol.PrefixCacheV2Capability,
+	statuses map[string]protocol.PrefixCacheModelStatus,
+	reported bool,
+) (map[string]protocol.PrefixCacheModelStatus, bool) {
+	if !reported {
+		return nil, false
+	}
+	reconciled := make(map[string]protocol.PrefixCacheModelStatus, len(statuses))
+	for modelID, status := range statuses {
+		if status.State == "ready" {
+			if version < 2 || !concreteReadyPrefixCacheStatus(status) {
+				continue
+			}
+			if _, capable := capabilities[modelID]; !capable {
+				continue
+			}
+		}
+		reconciled[modelID] = status
+	}
+	for modelID := range capabilities {
+		status, ok := reconciled[modelID]
+		if !ok || !concreteReadyPrefixCacheStatus(status) {
+			return nil, false
+		}
+	}
+	return reconciled, true
+}
+
+func retainPrefixCacheStatuses(
+	statuses *[]protocol.PrefixCacheModelStatus,
+	reconciled map[string]protocol.PrefixCacheModelStatus,
+) {
+	if statuses == nil {
+		return
+	}
+	filtered := make([]protocol.PrefixCacheModelStatus, 0, len(reconciled))
+	for _, status := range *statuses {
+		if _, ok := reconciled[status.ModelID]; ok {
+			filtered = append(filtered, status)
+		}
+	}
+	*statuses = filtered
 }
 
 // sanitizePrefixCacheDonationOutcomes applies the same non-fatal policy to
@@ -189,14 +256,26 @@ func containsFixed(values []string, candidate string) bool {
 // Optional telemetry never closes registration and is scoped only to the
 // provider's advertised inventory; owner-local/off-catalog models are valid.
 func (r *Registry) ValidatePrefixCacheRegistration(msg *protocol.RegisterMessage) error {
-	if err := ValidatePrefixCacheRegistration(msg); err != nil {
-		return err
+	if msg == nil {
+		return fmt.Errorf("%w: missing registration", errInvalidPrefixCacheCapability)
 	}
 	models, err := uniqueProviderModels(msg.Models)
 	if err != nil {
 		return err
 	}
-	sanitizePrefixCacheStatuses(msg.PrefixCacheStatuses, models)
+	capabilities, err := validatePrefixCacheCapabilities(
+		msg.PrefixCacheProtocol, msg.PrefixCacheV2Models, models)
+	if err != nil {
+		return err
+	}
+	statuses, reported := sanitizePrefixCacheStatuses(msg.PrefixCacheStatuses, models)
+	statuses, reported = reconcilePrefixCacheStatuses(
+		msg.PrefixCacheProtocol, capabilities, statuses, reported)
+	if reported {
+		retainPrefixCacheStatuses(msg.PrefixCacheStatuses, statuses)
+	} else {
+		msg.PrefixCacheStatuses = nil
+	}
 	sanitizePrefixCacheDonationOutcomes(msg.PrefixCacheDonationOutcomes)
 	return nil
 }
@@ -213,63 +292,13 @@ func (r *Registry) UpdatePrefixCacheTelemetry(
 	if r == nil || (statuses == nil && outcomes == nil) {
 		return nil
 	}
-	r.mu.RLock()
-	provider := r.providers[providerID]
-	r.mu.RUnlock()
-	if provider == nil {
-		return fmt.Errorf("%w: provider is not registered", errInvalidPrefixCacheCapability)
-	}
-
-	provider.mu.Lock()
-	models, err := uniqueProviderModels(provider.Models)
-	if err != nil {
-		provider.mu.Unlock()
-		return err
-	}
-	validatedStatuses, reported := sanitizePrefixCacheStatuses(statuses, models)
-	validatedOutcomes := sanitizePrefixCacheDonationOutcomes(outcomes)
-	if reported {
-		provider.PrefixCacheStatuses = validatedStatuses
-		provider.PrefixCacheStatusReported = true
-	}
-	deltas := make(map[string]uint64)
-	if outcomes != nil {
-		nextOutcomes := make(map[string]uint64, len(provider.PrefixCacheDonationOutcomes)+len(validatedOutcomes))
-		for outcome, previous := range provider.PrefixCacheDonationOutcomes {
-			nextOutcomes[outcome] = previous
-		}
-		for outcome, current := range validatedOutcomes {
-			previous := provider.PrefixCacheDonationOutcomes[outcome]
-			if current >= previous {
-				deltas[outcome] = current - previous
-				nextOutcomes[outcome] = current
-			}
-		}
-		provider.PrefixCacheDonationOutcomes = nextOutcomes
-	}
-	provider.mu.Unlock()
-
-	r.mu.RLock()
-	tracker := r.cacheRouting
-	r.mu.RUnlock()
-	if tracker != nil {
-		tracker.recordDonationOutcomes(deltas)
-	}
-	return nil
-}
-
-func (r *Registry) ClearPrefixCacheStatuses(providerID string) {
-	if r == nil {
-		return
-	}
-	r.mu.RLock()
-	provider := r.providers[providerID]
-	r.mu.RUnlock()
-	if provider == nil {
-		return
-	}
-	provider.mu.Lock()
-	provider.PrefixCacheStatuses = nil
-	provider.PrefixCacheStatusReported = true
-	provider.mu.Unlock()
+	_, err := r.UpdatePrefixCacheSnapshot(
+		providerID,
+		false,
+		0,
+		nil,
+		statuses,
+		outcomes,
+	)
+	return err
 }

--- a/coordinator/registry/cache_eligibility.go
+++ b/coordinator/registry/cache_eligibility.go
@@ -3,6 +3,7 @@ package registry
 import (
 	"fmt"
 	"math"
+	"strings"
 
 	"github.com/eigeninference/d-inference/coordinator/protocol"
 )
@@ -57,49 +58,60 @@ func PrefixCacheDonationOutcomes() []string {
 	return append([]string(nil), prefixCacheDonationOutcomes...)
 }
 
-func validatePrefixCacheStatuses(
+// sanitizePrefixCacheStatuses projects optional provider observability into the
+// fixed vocabulary this coordinator understands. Telemetry is never an
+// admission policy:
+//   - nil preserves old-provider omission;
+//   - oversized arrays, duplicate model IDs, or blank/non-canonical model IDs
+//     drop the whole snapshot to an authoritative empty set;
+//   - unknown future enums, invalid tuples, and models absent from this
+//     provider's own advertised inventory drop only that entry.
+//
+// The length check runs before iteration, and accepted arrays are capped at 16,
+// so hostile optional telemetry cannot create unbounded work.
+func sanitizePrefixCacheStatuses(
 	statuses *[]protocol.PrefixCacheModelStatus,
 	models map[string]protocol.ModelInfo,
-	catalog map[string]struct{},
-) (map[string]protocol.PrefixCacheModelStatus, bool, error) {
+) (map[string]protocol.PrefixCacheModelStatus, bool) {
 	if statuses == nil {
-		return nil, false, nil
+		return nil, false
 	}
 	if len(*statuses) > maxPrefixCacheStatuses {
-		return nil, false, fmt.Errorf(
-			"%w: too many prefix-cache statuses", errInvalidPrefixCacheCapability)
+		*statuses = []protocol.PrefixCacheModelStatus{}
+		return map[string]protocol.PrefixCacheModelStatus{}, true
 	}
-	result := make(map[string]protocol.PrefixCacheModelStatus, len(*statuses))
+
+	seen := make(map[string]struct{}, len(*statuses))
 	for _, status := range *statuses {
-		if status.ModelID == "" {
-			return nil, false, fmt.Errorf(
-				"%w: blank prefix-cache status model", errInvalidPrefixCacheCapability)
+		if status.ModelID == "" || strings.TrimSpace(status.ModelID) != status.ModelID {
+			*statuses = []protocol.PrefixCacheModelStatus{}
+			return map[string]protocol.PrefixCacheModelStatus{}, true
 		}
+		if _, duplicate := seen[status.ModelID]; duplicate {
+			*statuses = []protocol.PrefixCacheModelStatus{}
+			return map[string]protocol.PrefixCacheModelStatus{}, true
+		}
+		seen[status.ModelID] = struct{}{}
+	}
+
+	result := make(map[string]protocol.PrefixCacheModelStatus, len(*statuses))
+	sanitized := make([]protocol.PrefixCacheModelStatus, 0, len(*statuses))
+	for _, status := range *statuses {
 		if _, ok := models[status.ModelID]; !ok {
-			return nil, false, fmt.Errorf(
-				"%w: status model %q is not advertised", errInvalidPrefixCacheCapability, status.ModelID)
-		}
-		if catalog != nil {
-			if _, ok := catalog[status.ModelID]; !ok {
-				return nil, false, fmt.Errorf(
-					"%w: status model %q is not in catalog", errInvalidPrefixCacheCapability, status.ModelID)
-			}
-		}
-		if _, duplicate := result[status.ModelID]; duplicate {
-			return nil, false, fmt.Errorf(
-				"%w: duplicate status model %q", errInvalidPrefixCacheCapability, status.ModelID)
+			continue
 		}
 		if !containsFixed(prefixCacheStatusStates, status.State) ||
 			!containsFixed(prefixCacheStatusReasons, status.Reason) ||
 			!containsFixed(prefixCacheStatusBackends, status.Backend) ||
 			!containsFixed(prefixCacheReplayStrategies, status.ReplayStrategy) ||
 			!validPrefixCacheStateReason(status.State, status.Reason) {
-			return nil, false, fmt.Errorf(
-				"%w: invalid status tuple for %q", errInvalidPrefixCacheCapability, status.ModelID)
+			continue
 		}
 		result[status.ModelID] = status
+		sanitized = append(sanitized, status)
 	}
-	return result, true, nil
+	*statuses = sanitized
+	return result, true
 }
 
 func validPrefixCacheStateReason(state, reason string) bool {
@@ -124,30 +136,43 @@ func validPrefixCacheStateReason(state, reason string) bool {
 	return false
 }
 
-func validatePrefixCacheDonationOutcomes(
+// sanitizePrefixCacheDonationOutcomes applies the same non-fatal policy to
+// cumulative donation counters. Oversized or duplicate snapshots are ignored
+// wholesale; unknown future outcomes and invalid counts are dropped entry-wise.
+// On heartbeat, an empty sanitized map preserves the provider's prior monotonic
+// baseline, so malformed optional counters cannot manufacture a reset delta.
+func sanitizePrefixCacheDonationOutcomes(
 	outcomes *[]protocol.PrefixCacheDonationOutcomeCount,
-) (map[string]uint64, error) {
+) map[string]uint64 {
 	if outcomes == nil {
-		return nil, nil
+		return nil
 	}
 	if len(*outcomes) > maxPrefixCacheDonationOutcomes {
-		return nil, fmt.Errorf(
-			"%w: too many prefix-cache donation outcomes", errInvalidPrefixCacheCapability)
+		*outcomes = []protocol.PrefixCacheDonationOutcomeCount{}
+		return map[string]uint64{}
 	}
+
+	seen := make(map[string]struct{}, len(*outcomes))
+	for _, outcome := range *outcomes {
+		if _, duplicate := seen[outcome.Outcome]; duplicate {
+			*outcomes = []protocol.PrefixCacheDonationOutcomeCount{}
+			return map[string]uint64{}
+		}
+		seen[outcome.Outcome] = struct{}{}
+	}
+
 	result := make(map[string]uint64, len(*outcomes))
+	sanitized := make([]protocol.PrefixCacheDonationOutcomeCount, 0, len(*outcomes))
 	for _, outcome := range *outcomes {
 		if !containsFixed(prefixCacheDonationOutcomes, outcome.Outcome) ||
 			outcome.Count == 0 || outcome.Count > math.MaxInt64 {
-			return nil, fmt.Errorf(
-				"%w: invalid donation outcome %q", errInvalidPrefixCacheCapability, outcome.Outcome)
-		}
-		if _, duplicate := result[outcome.Outcome]; duplicate {
-			return nil, fmt.Errorf(
-				"%w: duplicate donation outcome %q", errInvalidPrefixCacheCapability, outcome.Outcome)
+			continue
 		}
 		result[outcome.Outcome] = outcome.Count
+		sanitized = append(sanitized, outcome)
 	}
-	return result, nil
+	*outcomes = sanitized
+	return result
 }
 
 func containsFixed(values []string, candidate string) bool {
@@ -159,9 +184,10 @@ func containsFixed(values []string, candidate string) bool {
 	return false
 }
 
-// ValidatePrefixCacheRegistration validates all optional cache observability
-// snapshots against both the provider inventory and the live catalog. A nil
-// catalog preserves development/test behavior.
+// ValidatePrefixCacheRegistration keeps authoritative routing capability
+// validation fail-closed, then sanitizes optional observability in place.
+// Optional telemetry never closes registration and is scoped only to the
+// provider's advertised inventory; owner-local/off-catalog models are valid.
 func (r *Registry) ValidatePrefixCacheRegistration(msg *protocol.RegisterMessage) error {
 	if err := ValidatePrefixCacheRegistration(msg); err != nil {
 		return err
@@ -170,22 +196,9 @@ func (r *Registry) ValidatePrefixCacheRegistration(msg *protocol.RegisterMessage
 	if err != nil {
 		return err
 	}
-	var catalog map[string]struct{}
-	if r != nil {
-		r.mu.RLock()
-		if r.modelCatalog != nil {
-			catalog = make(map[string]struct{}, len(r.modelCatalog))
-			for modelID := range r.modelCatalog {
-				catalog[modelID] = struct{}{}
-			}
-		}
-		r.mu.RUnlock()
-	}
-	if _, _, err := validatePrefixCacheStatuses(msg.PrefixCacheStatuses, models, catalog); err != nil {
-		return err
-	}
-	_, err = validatePrefixCacheDonationOutcomes(msg.PrefixCacheDonationOutcomes)
-	return err
+	sanitizePrefixCacheStatuses(msg.PrefixCacheStatuses, models)
+	sanitizePrefixCacheDonationOutcomes(msg.PrefixCacheDonationOutcomes)
+	return nil
 }
 
 // UpdatePrefixCacheTelemetry replaces the optional connection-scoped status
@@ -202,13 +215,6 @@ func (r *Registry) UpdatePrefixCacheTelemetry(
 	}
 	r.mu.RLock()
 	provider := r.providers[providerID]
-	var catalog map[string]struct{}
-	if r.modelCatalog != nil {
-		catalog = make(map[string]struct{}, len(r.modelCatalog))
-		for modelID := range r.modelCatalog {
-			catalog[modelID] = struct{}{}
-		}
-	}
 	r.mu.RUnlock()
 	if provider == nil {
 		return fmt.Errorf("%w: provider is not registered", errInvalidPrefixCacheCapability)
@@ -220,16 +226,8 @@ func (r *Registry) UpdatePrefixCacheTelemetry(
 		provider.mu.Unlock()
 		return err
 	}
-	validatedStatuses, reported, err := validatePrefixCacheStatuses(statuses, models, catalog)
-	if err != nil {
-		provider.mu.Unlock()
-		return err
-	}
-	validatedOutcomes, err := validatePrefixCacheDonationOutcomes(outcomes)
-	if err != nil {
-		provider.mu.Unlock()
-		return err
-	}
+	validatedStatuses, reported := sanitizePrefixCacheStatuses(statuses, models)
+	validatedOutcomes := sanitizePrefixCacheDonationOutcomes(outcomes)
 	if reported {
 		provider.PrefixCacheStatuses = validatedStatuses
 		provider.PrefixCacheStatusReported = true

--- a/coordinator/registry/cache_eligibility.go
+++ b/coordinator/registry/cache_eligibility.go
@@ -1,0 +1,277 @@
+package registry
+
+import (
+	"fmt"
+	"math"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+)
+
+const (
+	maxPrefixCacheStatuses         = 16
+	maxPrefixCacheDonationOutcomes = 13
+)
+
+var (
+	prefixCacheStatusStates  = []string{"ready", "pending", "disabled", "error"}
+	prefixCacheStatusReasons = []string{
+		"ready",
+		"config_disabled",
+		"no_loaded_slot",
+		"weight_hash_unavailable",
+		"runtime_identity_unavailable",
+		"unsupported_layout",
+		"unsupported_backend",
+		"paged_hybrid_unsupported",
+		"scan_pending",
+		"scan_failed",
+		"disk_unavailable",
+		"cache_init_failed",
+	}
+	prefixCacheStatusBackends   = []string{"contiguous", "paged", "unknown"}
+	prefixCacheReplayStrategies = []string{"direct", "frozen_full", "none", "unknown"}
+	prefixCacheDonationOutcomes = []string{
+		"donated",
+		"below_effective_token_floor",
+		"no_complete_block",
+		"lossy_snapshot",
+		"incomplete_layer_state",
+		"stage_size_exceeded",
+		"write_rate_limited",
+		"write_queue_full",
+		"already_durable",
+		"already_queued",
+		"cache_closed",
+		"disk_unavailable",
+		"write_failed",
+	}
+)
+
+func PrefixCacheStatusStates() []string   { return append([]string(nil), prefixCacheStatusStates...) }
+func PrefixCacheStatusReasons() []string  { return append([]string(nil), prefixCacheStatusReasons...) }
+func PrefixCacheStatusBackends() []string { return append([]string(nil), prefixCacheStatusBackends...) }
+func PrefixCacheReplayStrategies() []string {
+	return append([]string(nil), prefixCacheReplayStrategies...)
+}
+func PrefixCacheDonationOutcomes() []string {
+	return append([]string(nil), prefixCacheDonationOutcomes...)
+}
+
+func validatePrefixCacheStatuses(
+	statuses *[]protocol.PrefixCacheModelStatus,
+	models map[string]protocol.ModelInfo,
+	catalog map[string]struct{},
+) (map[string]protocol.PrefixCacheModelStatus, bool, error) {
+	if statuses == nil {
+		return nil, false, nil
+	}
+	if len(*statuses) > maxPrefixCacheStatuses {
+		return nil, false, fmt.Errorf(
+			"%w: too many prefix-cache statuses", errInvalidPrefixCacheCapability)
+	}
+	result := make(map[string]protocol.PrefixCacheModelStatus, len(*statuses))
+	for _, status := range *statuses {
+		if status.ModelID == "" {
+			return nil, false, fmt.Errorf(
+				"%w: blank prefix-cache status model", errInvalidPrefixCacheCapability)
+		}
+		if _, ok := models[status.ModelID]; !ok {
+			return nil, false, fmt.Errorf(
+				"%w: status model %q is not advertised", errInvalidPrefixCacheCapability, status.ModelID)
+		}
+		if catalog != nil {
+			if _, ok := catalog[status.ModelID]; !ok {
+				return nil, false, fmt.Errorf(
+					"%w: status model %q is not in catalog", errInvalidPrefixCacheCapability, status.ModelID)
+			}
+		}
+		if _, duplicate := result[status.ModelID]; duplicate {
+			return nil, false, fmt.Errorf(
+				"%w: duplicate status model %q", errInvalidPrefixCacheCapability, status.ModelID)
+		}
+		if !containsFixed(prefixCacheStatusStates, status.State) ||
+			!containsFixed(prefixCacheStatusReasons, status.Reason) ||
+			!containsFixed(prefixCacheStatusBackends, status.Backend) ||
+			!containsFixed(prefixCacheReplayStrategies, status.ReplayStrategy) ||
+			!validPrefixCacheStateReason(status.State, status.Reason) {
+			return nil, false, fmt.Errorf(
+				"%w: invalid status tuple for %q", errInvalidPrefixCacheCapability, status.ModelID)
+		}
+		result[status.ModelID] = status
+	}
+	return result, true, nil
+}
+
+func validPrefixCacheStateReason(state, reason string) bool {
+	switch state {
+	case "ready":
+		return reason == "ready"
+	case "pending":
+		return reason == "scan_pending"
+	case "disabled":
+		switch reason {
+		case "config_disabled", "no_loaded_slot", "weight_hash_unavailable",
+			"runtime_identity_unavailable", "unsupported_layout",
+			"unsupported_backend", "paged_hybrid_unsupported":
+			return true
+		}
+	case "error":
+		switch reason {
+		case "scan_failed", "disk_unavailable", "cache_init_failed":
+			return true
+		}
+	}
+	return false
+}
+
+func validatePrefixCacheDonationOutcomes(
+	outcomes *[]protocol.PrefixCacheDonationOutcomeCount,
+) (map[string]uint64, error) {
+	if outcomes == nil {
+		return nil, nil
+	}
+	if len(*outcomes) > maxPrefixCacheDonationOutcomes {
+		return nil, fmt.Errorf(
+			"%w: too many prefix-cache donation outcomes", errInvalidPrefixCacheCapability)
+	}
+	result := make(map[string]uint64, len(*outcomes))
+	for _, outcome := range *outcomes {
+		if !containsFixed(prefixCacheDonationOutcomes, outcome.Outcome) ||
+			outcome.Count == 0 || outcome.Count > math.MaxInt64 {
+			return nil, fmt.Errorf(
+				"%w: invalid donation outcome %q", errInvalidPrefixCacheCapability, outcome.Outcome)
+		}
+		if _, duplicate := result[outcome.Outcome]; duplicate {
+			return nil, fmt.Errorf(
+				"%w: duplicate donation outcome %q", errInvalidPrefixCacheCapability, outcome.Outcome)
+		}
+		result[outcome.Outcome] = outcome.Count
+	}
+	return result, nil
+}
+
+func containsFixed(values []string, candidate string) bool {
+	for _, value := range values {
+		if value == candidate {
+			return true
+		}
+	}
+	return false
+}
+
+// ValidatePrefixCacheRegistration validates all optional cache observability
+// snapshots against both the provider inventory and the live catalog. A nil
+// catalog preserves development/test behavior.
+func (r *Registry) ValidatePrefixCacheRegistration(msg *protocol.RegisterMessage) error {
+	if err := ValidatePrefixCacheRegistration(msg); err != nil {
+		return err
+	}
+	models, err := uniqueProviderModels(msg.Models)
+	if err != nil {
+		return err
+	}
+	var catalog map[string]struct{}
+	if r != nil {
+		r.mu.RLock()
+		if r.modelCatalog != nil {
+			catalog = make(map[string]struct{}, len(r.modelCatalog))
+			for modelID := range r.modelCatalog {
+				catalog[modelID] = struct{}{}
+			}
+		}
+		r.mu.RUnlock()
+	}
+	if _, _, err := validatePrefixCacheStatuses(msg.PrefixCacheStatuses, models, catalog); err != nil {
+		return err
+	}
+	_, err = validatePrefixCacheDonationOutcomes(msg.PrefixCacheDonationOutcomes)
+	return err
+}
+
+// UpdatePrefixCacheTelemetry replaces the optional connection-scoped status
+// snapshot and folds monotonic donation-counter deltas into central aggregate
+// counters. Omitted fields preserve mixed-version behavior; a present empty
+// status array authoritatively clears loaded-model status.
+func (r *Registry) UpdatePrefixCacheTelemetry(
+	providerID string,
+	statuses *[]protocol.PrefixCacheModelStatus,
+	outcomes *[]protocol.PrefixCacheDonationOutcomeCount,
+) error {
+	if r == nil || (statuses == nil && outcomes == nil) {
+		return nil
+	}
+	r.mu.RLock()
+	provider := r.providers[providerID]
+	var catalog map[string]struct{}
+	if r.modelCatalog != nil {
+		catalog = make(map[string]struct{}, len(r.modelCatalog))
+		for modelID := range r.modelCatalog {
+			catalog[modelID] = struct{}{}
+		}
+	}
+	r.mu.RUnlock()
+	if provider == nil {
+		return fmt.Errorf("%w: provider is not registered", errInvalidPrefixCacheCapability)
+	}
+
+	provider.mu.Lock()
+	models, err := uniqueProviderModels(provider.Models)
+	if err != nil {
+		provider.mu.Unlock()
+		return err
+	}
+	validatedStatuses, reported, err := validatePrefixCacheStatuses(statuses, models, catalog)
+	if err != nil {
+		provider.mu.Unlock()
+		return err
+	}
+	validatedOutcomes, err := validatePrefixCacheDonationOutcomes(outcomes)
+	if err != nil {
+		provider.mu.Unlock()
+		return err
+	}
+	if reported {
+		provider.PrefixCacheStatuses = validatedStatuses
+		provider.PrefixCacheStatusReported = true
+	}
+	deltas := make(map[string]uint64)
+	if outcomes != nil {
+		nextOutcomes := make(map[string]uint64, len(provider.PrefixCacheDonationOutcomes)+len(validatedOutcomes))
+		for outcome, previous := range provider.PrefixCacheDonationOutcomes {
+			nextOutcomes[outcome] = previous
+		}
+		for outcome, current := range validatedOutcomes {
+			previous := provider.PrefixCacheDonationOutcomes[outcome]
+			if current >= previous {
+				deltas[outcome] = current - previous
+				nextOutcomes[outcome] = current
+			}
+		}
+		provider.PrefixCacheDonationOutcomes = nextOutcomes
+	}
+	provider.mu.Unlock()
+
+	r.mu.RLock()
+	tracker := r.cacheRouting
+	r.mu.RUnlock()
+	if tracker != nil {
+		tracker.recordDonationOutcomes(deltas)
+	}
+	return nil
+}
+
+func (r *Registry) ClearPrefixCacheStatuses(providerID string) {
+	if r == nil {
+		return
+	}
+	r.mu.RLock()
+	provider := r.providers[providerID]
+	r.mu.RUnlock()
+	if provider == nil {
+		return
+	}
+	provider.mu.Lock()
+	provider.PrefixCacheStatuses = nil
+	provider.PrefixCacheStatusReported = true
+	provider.mu.Unlock()
+}

--- a/coordinator/registry/cache_eligibility_test.go
+++ b/coordinator/registry/cache_eligibility_test.go
@@ -25,7 +25,7 @@ func TestPrefixCacheTelemetryEnumCasingIsPinned(t *testing.T) {
 		},
 		"reasons": {
 			got: PrefixCacheStatusReasons(),
-			want: "ready,config_disabled,no_loaded_slot,weight_hash_unavailable," +
+			want: "ready,config_disabled,weight_hash_unavailable," +
 				"runtime_identity_unavailable,unsupported_layout,unsupported_backend," +
 				"paged_hybrid_unsupported,scan_pending,scan_failed,disk_unavailable,cache_init_failed",
 		},
@@ -33,7 +33,8 @@ func TestPrefixCacheTelemetryEnumCasingIsPinned(t *testing.T) {
 			got: PrefixCacheStatusBackends(), want: "contiguous,paged,unknown",
 		},
 		"strategies": {
-			got: PrefixCacheReplayStrategies(), want: "direct,frozen_full,none,unknown",
+			got:  PrefixCacheReplayStrategies(),
+			want: "direct,frozen_full,tail_replay,none,unknown",
 		},
 		"donation outcomes": {
 			got: PrefixCacheDonationOutcomes(),
@@ -205,6 +206,199 @@ func TestPrefixCacheTelemetryOmissionAndRoutingCapabilityStrictness(t *testing.T
 	}
 }
 
+func TestPrefixCacheReadyStatusCapabilityReconciliation(t *testing.T) {
+	const epoch = "11111111-1111-1111-1111-111111111111"
+	capability := testV2Capability(epoch)
+	model := protocol.ModelInfo{
+		ID: capability.ModelID, WeightHash: capability.ModelAggregateHash,
+	}
+	ready := protocol.PrefixCacheModelStatus{
+		ModelID: capability.ModelID, Backend: "contiguous", ReplayStrategy: "direct",
+		State: "ready", Reason: "ready",
+	}
+
+	for _, test := range []struct {
+		name         string
+		version      int
+		capabilities []protocol.PrefixCacheV2Capability
+		statuses     []protocol.PrefixCacheModelStatus
+		wantReported bool
+		wantCount    int
+	}{
+		{
+			name:    "protocol one ready is dropped",
+			version: 1, statuses: []protocol.PrefixCacheModelStatus{ready},
+			wantReported: true,
+		},
+		{
+			name:    "ready unknown backend makes v2 status unreported",
+			version: 2, capabilities: []protocol.PrefixCacheV2Capability{capability},
+			statuses: []protocol.PrefixCacheModelStatus{{
+				ModelID: capability.ModelID, Backend: "unknown", ReplayStrategy: "direct",
+				State: "ready", Reason: "ready",
+			}},
+		},
+		{
+			name:    "ready none strategy makes v2 status unreported",
+			version: 2, capabilities: []protocol.PrefixCacheV2Capability{capability},
+			statuses: []protocol.PrefixCacheModelStatus{{
+				ModelID: capability.ModelID, Backend: "paged", ReplayStrategy: "none",
+				State: "ready", Reason: "ready",
+			}},
+		},
+		{
+			name:    "ready unknown strategy makes v2 status unreported",
+			version: 2, capabilities: []protocol.PrefixCacheV2Capability{capability},
+			statuses: []protocol.PrefixCacheModelStatus{{
+				ModelID: capability.ModelID, Backend: "paged", ReplayStrategy: "unknown",
+				State: "ready", Reason: "ready",
+			}},
+		},
+		{
+			name:    "v2 capability missing ready status becomes unreported",
+			version: 2, capabilities: []protocol.PrefixCacheV2Capability{capability},
+			statuses: []protocol.PrefixCacheModelStatus{{
+				ModelID: capability.ModelID, Backend: "paged", ReplayStrategy: "tail_replay",
+				State: "pending", Reason: "scan_pending",
+			}},
+		},
+		{
+			name:    "concrete matching ready status remains reported",
+			version: 2, capabilities: []protocol.PrefixCacheV2Capability{capability},
+			statuses: []protocol.PrefixCacheModelStatus{{
+				ModelID: capability.ModelID, Backend: "paged", ReplayStrategy: "tail_replay",
+				State: "ready", Reason: "ready",
+			}},
+			wantReported: true, wantCount: 1,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			statuses := append([]protocol.PrefixCacheModelStatus(nil), test.statuses...)
+			msg := protocol.RegisterMessage{
+				Models:              []protocol.ModelInfo{model},
+				PrefixCacheProtocol: test.version,
+				PrefixCacheV2Models: test.capabilities,
+				PrefixCacheStatuses: &statuses,
+			}
+			if err := cacheEligibilityTestRegistry().
+				ValidatePrefixCacheRegistration(&msg); err != nil {
+				t.Fatal(err)
+			}
+			reported := msg.PrefixCacheStatuses != nil
+			if reported != test.wantReported {
+				t.Fatalf("reported=%v, want %v; statuses=%+v",
+					reported, test.wantReported, msg.PrefixCacheStatuses)
+			}
+			if reported && len(*msg.PrefixCacheStatuses) != test.wantCount {
+				t.Fatalf("status count=%d, want %d", len(*msg.PrefixCacheStatuses), test.wantCount)
+			}
+		})
+	}
+
+	// Off-catalog owner-local models remain valid when provider inventory,
+	// capability, and concrete ready status agree.
+	reg := cacheEligibilityTestRegistry()
+	reg.SetModelCatalog([]CatalogEntry{{ID: "public-model"}})
+	ownerCapability := capability
+	ownerCapability.ModelID = "owner-local"
+	ownerStatus := ready
+	ownerStatus.ModelID = ownerCapability.ModelID
+	ownerStatuses := []protocol.PrefixCacheModelStatus{ownerStatus}
+	owner := protocol.RegisterMessage{
+		Models: []protocol.ModelInfo{{
+			ID: ownerCapability.ModelID, WeightHash: ownerCapability.ModelAggregateHash,
+		}},
+		PrefixCacheProtocol: 2,
+		PrefixCacheV2Models: []protocol.PrefixCacheV2Capability{ownerCapability},
+		PrefixCacheStatuses: &ownerStatuses,
+	}
+	if err := reg.ValidatePrefixCacheRegistration(&owner); err != nil {
+		t.Fatalf("matching owner-local ready status rejected: %v", err)
+	}
+	provider := reg.Register("owner", nil, &owner)
+	if provider == nil {
+		t.Fatal("owner-local provider did not register")
+	}
+	aggregate := reg.PrefixCacheProtocolStatus()
+	if aggregate.V2ReadyModels != 1 || aggregate.ByState["ready"] != 1 {
+		t.Fatalf("owner-local ready aggregate=%+v", aggregate)
+	}
+
+	// Old-provider omission never invalidates a strict valid capability.
+	omitted := protocol.RegisterMessage{
+		Models:              []protocol.ModelInfo{model},
+		PrefixCacheProtocol: 2,
+		PrefixCacheV2Models: []protocol.PrefixCacheV2Capability{capability},
+	}
+	if err := reg.ValidatePrefixCacheRegistration(&omitted); err != nil {
+		t.Fatal(err)
+	}
+	if omitted.PrefixCacheStatuses != nil {
+		t.Fatal("old-provider omission was converted to a status snapshot")
+	}
+}
+
+func TestPrefixCacheHeartbeatSnapshotReconcilesAtomically(t *testing.T) {
+	const epoch = "11111111-1111-1111-1111-111111111111"
+	capability := testV2Capability(epoch)
+	ready := protocol.PrefixCacheModelStatus{
+		ModelID: capability.ModelID, Backend: "contiguous", ReplayStrategy: "direct",
+		State: "ready", Reason: "ready",
+	}
+	statuses := []protocol.PrefixCacheModelStatus{ready}
+	reg := cacheEligibilityTestRegistry()
+	provider := reg.Register("provider", nil, &protocol.RegisterMessage{
+		Models: []protocol.ModelInfo{{
+			ID: capability.ModelID, WeightHash: capability.ModelAggregateHash,
+		}},
+		PrefixCacheProtocol: 2,
+		PrefixCacheV2Models: []protocol.PrefixCacheV2Capability{capability},
+		PrefixCacheStatuses: &statuses,
+	})
+
+	pending := []protocol.PrefixCacheModelStatus{{
+		ModelID: capability.ModelID, Backend: "contiguous", ReplayStrategy: "direct",
+		State: "pending", Reason: "scan_pending",
+	}}
+	if _, err := reg.UpdatePrefixCacheSnapshot(
+		provider.ID, false, 0, nil, &pending, nil); err != nil {
+		t.Fatal(err)
+	}
+	provider.mu.Lock()
+	if !provider.PrefixCacheV2Models[capability.ModelID].Ready ||
+		provider.PrefixCacheStatusReported ||
+		len(provider.PrefixCacheStatuses) != 0 {
+		t.Fatalf("capability/status contradiction leaked after replacement: %+v", provider)
+	}
+	provider.mu.Unlock()
+
+	restored := []protocol.PrefixCacheModelStatus{ready}
+	if _, err := reg.UpdatePrefixCacheSnapshot(
+		provider.ID, false, 0, nil, &restored, nil); err != nil {
+		t.Fatal(err)
+	}
+	provider.mu.Lock()
+	if !provider.PrefixCacheStatusReported ||
+		provider.PrefixCacheStatuses[capability.ModelID].State != "ready" {
+		t.Fatalf("matching status did not restore: %+v", provider.PrefixCacheStatuses)
+	}
+	provider.mu.Unlock()
+
+	readyOnV1 := []protocol.PrefixCacheModelStatus{ready}
+	if _, err := reg.UpdatePrefixCacheSnapshot(
+		provider.ID, true, 1, nil, &readyOnV1, nil); err != nil {
+		t.Fatal(err)
+	}
+	provider.mu.Lock()
+	if provider.PrefixCacheProtocol != 1 ||
+		len(provider.PrefixCacheV2Models) != 0 ||
+		!provider.PrefixCacheStatusReported ||
+		len(provider.PrefixCacheStatuses) != 0 {
+		t.Fatalf("protocol-v1 ready telemetry was not atomically dropped: %+v", provider)
+	}
+	provider.mu.Unlock()
+}
+
 func TestPrefixCacheStatusReplacementClearDisconnectAndMixedOmission(t *testing.T) {
 	reg := cacheEligibilityTestRegistry()
 	statuses := []protocol.PrefixCacheModelStatus{
@@ -235,12 +429,12 @@ func TestPrefixCacheStatusReplacementClearDisconnectAndMixedOmission(t *testing.
 	legacy.mu.Unlock()
 
 	got := reg.PrefixCacheProtocolStatus()
-	if got.LoadedModels != 4 || got.ReportedLoadedModels != 3 ||
-		got.UnreportedLoadedModels != 1 || got.ExcludedModels != 2 ||
-		got.ByState["ready"] != 1 ||
+	if got.LoadedModels != 4 || got.ReportedLoadedModels != 2 ||
+		got.UnreportedLoadedModels != 2 || got.ExcludedModels != 2 ||
+		got.ByState["ready"] != 0 ||
 		got.ByReason["scan_pending"] != 1 ||
 		got.ByReason["weight_hash_unavailable"] != 1 ||
-		got.ByBackend["contiguous"] != 2 ||
+		got.ByBackend["contiguous"] != 1 ||
 		got.ByReplayStrategy["frozen_full"] != 1 {
 		t.Fatalf("initial aggregate = %+v", got)
 	}
@@ -257,7 +451,7 @@ func TestPrefixCacheStatusReplacementClearDisconnectAndMixedOmission(t *testing.
 		t.Fatalf("authoritative clear/old omission aggregate = %+v", got)
 	}
 
-	replacement := []protocol.PrefixCacheModelStatus{statuses[0]}
+	replacement := []protocol.PrefixCacheModelStatus{statuses[1]}
 	if err := reg.UpdatePrefixCacheTelemetry("current", &replacement, nil); err != nil {
 		t.Fatal(err)
 	}
@@ -284,11 +478,17 @@ func TestPrefixCacheDonationDeltasAndModelUpdateCleanup(t *testing.T) {
 		ModelID: "old", Backend: "contiguous", ReplayStrategy: "direct",
 		State: "ready", Reason: "ready",
 	}}
+	capability := testV2Capability("11111111-1111-1111-1111-111111111111")
+	capability.ModelID = "old"
 	baseline := []protocol.PrefixCacheDonationOutcomeCount{{
 		Outcome: "donated", Count: 2,
 	}}
 	provider := reg.Register("provider", nil, &protocol.RegisterMessage{
-		Models:                      []protocol.ModelInfo{{ID: "old"}},
+		Models: []protocol.ModelInfo{{
+			ID: "old", WeightHash: capability.ModelAggregateHash,
+		}},
+		PrefixCacheProtocol:         2,
+		PrefixCacheV2Models:         []protocol.PrefixCacheV2Capability{capability},
 		PrefixCacheStatuses:         &statuses,
 		PrefixCacheDonationOutcomes: &baseline,
 	})

--- a/coordinator/registry/cache_eligibility_test.go
+++ b/coordinator/registry/cache_eligibility_test.go
@@ -1,0 +1,259 @@
+package registry
+
+import (
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+)
+
+func cacheEligibilityTestRegistry() *Registry {
+	return New(slog.New(slog.NewTextHandler(io.Discard, nil)))
+}
+
+func TestPrefixCacheTelemetryEnumCasingIsPinned(t *testing.T) {
+	for name, test := range map[string]struct {
+		got  []string
+		want string
+	}{
+		"states": {
+			got:  PrefixCacheStatusStates(),
+			want: "ready,pending,disabled,error",
+		},
+		"reasons": {
+			got: PrefixCacheStatusReasons(),
+			want: "ready,config_disabled,no_loaded_slot,weight_hash_unavailable," +
+				"runtime_identity_unavailable,unsupported_layout,unsupported_backend," +
+				"paged_hybrid_unsupported,scan_pending,scan_failed,disk_unavailable,cache_init_failed",
+		},
+		"backends": {
+			got: PrefixCacheStatusBackends(), want: "contiguous,paged,unknown",
+		},
+		"strategies": {
+			got: PrefixCacheReplayStrategies(), want: "direct,frozen_full,none,unknown",
+		},
+		"donation outcomes": {
+			got: PrefixCacheDonationOutcomes(),
+			want: "donated,below_effective_token_floor,no_complete_block,lossy_snapshot," +
+				"incomplete_layer_state,stage_size_exceeded,write_rate_limited,write_queue_full," +
+				"already_durable,already_queued,cache_closed,disk_unavailable,write_failed",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if got := strings.Join(test.got, ","); got != test.want {
+				t.Fatalf("enum values=%q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+func TestPrefixCacheStatusValidationRejectsUnboundedOrAmbiguousSnapshots(t *testing.T) {
+	reg := cacheEligibilityTestRegistry()
+	reg.SetModelCatalog([]CatalogEntry{{ID: "model"}})
+	base := protocol.RegisterMessage{
+		Models: []protocol.ModelInfo{{ID: "model"}},
+	}
+	valid := protocol.PrefixCacheModelStatus{
+		ModelID: "model", Backend: "contiguous", ReplayStrategy: "direct",
+		State: "ready", Reason: "ready",
+	}
+	validStatuses := []protocol.PrefixCacheModelStatus{valid}
+	base.PrefixCacheStatuses = &validStatuses
+	if err := reg.ValidatePrefixCacheRegistration(&base); err != nil {
+		t.Fatalf("valid snapshot rejected: %v", err)
+	}
+
+	for _, test := range []struct {
+		name   string
+		mutate func(*protocol.PrefixCacheModelStatus)
+	}{
+		{name: "state", mutate: func(s *protocol.PrefixCacheModelStatus) { s.State = "warming" }},
+		{name: "reason", mutate: func(s *protocol.PrefixCacheModelStatus) { s.Reason = "free-form" }},
+		{name: "backend", mutate: func(s *protocol.PrefixCacheModelStatus) { s.Backend = "metal" }},
+		{name: "strategy", mutate: func(s *protocol.PrefixCacheModelStatus) { s.ReplayStrategy = "tail" }},
+		{name: "state reason mismatch", mutate: func(s *protocol.PrefixCacheModelStatus) {
+			s.State = "error"
+		}},
+		{name: "inventory", mutate: func(s *protocol.PrefixCacheModelStatus) { s.ModelID = "other" }},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			candidate := valid
+			test.mutate(&candidate)
+			statuses := []protocol.PrefixCacheModelStatus{candidate}
+			msg := base
+			msg.PrefixCacheStatuses = &statuses
+			if err := reg.ValidatePrefixCacheRegistration(&msg); err == nil {
+				t.Fatal("invalid status snapshot accepted")
+			}
+		})
+	}
+
+	duplicates := []protocol.PrefixCacheModelStatus{valid, valid}
+	msg := base
+	msg.PrefixCacheStatuses = &duplicates
+	if err := reg.ValidatePrefixCacheRegistration(&msg); err == nil {
+		t.Fatal("duplicate status model accepted")
+	}
+	tooMany := make([]protocol.PrefixCacheModelStatus, maxPrefixCacheStatuses+1)
+	for index := range tooMany {
+		tooMany[index] = valid
+		tooMany[index].ModelID = "model"
+	}
+	msg.PrefixCacheStatuses = &tooMany
+	if err := reg.ValidatePrefixCacheRegistration(&msg); err == nil {
+		t.Fatal("oversized status snapshot accepted")
+	}
+
+	offCatalog := base
+	offCatalog.Models = []protocol.ModelInfo{{ID: "off-catalog"}}
+	offCatalogStatuses := []protocol.PrefixCacheModelStatus{{
+		ModelID: "off-catalog", Backend: "unknown", ReplayStrategy: "none",
+		State: "disabled", Reason: "config_disabled",
+	}}
+	offCatalog.PrefixCacheStatuses = &offCatalogStatuses
+	if err := reg.ValidatePrefixCacheRegistration(&offCatalog); err == nil {
+		t.Fatal("off-catalog status accepted")
+	}
+
+	badOutcome := []protocol.PrefixCacheDonationOutcomeCount{{
+		Outcome: "request_specific_failure", Count: 1,
+	}}
+	msg = base
+	msg.PrefixCacheDonationOutcomes = &badOutcome
+	if err := reg.ValidatePrefixCacheRegistration(&msg); err == nil {
+		t.Fatal("free-form donation outcome accepted")
+	}
+}
+
+func TestPrefixCacheStatusReplacementClearDisconnectAndMixedOmission(t *testing.T) {
+	reg := cacheEligibilityTestRegistry()
+	statuses := []protocol.PrefixCacheModelStatus{
+		{ModelID: "ready", Backend: "contiguous", ReplayStrategy: "direct", State: "ready", Reason: "ready"},
+		{ModelID: "scan", Backend: "paged", ReplayStrategy: "unknown", State: "pending", Reason: "scan_pending"},
+		{ModelID: "hash", Backend: "contiguous", ReplayStrategy: "frozen_full", State: "disabled", Reason: "weight_hash_unavailable"},
+	}
+	current := reg.Register("current", nil, &protocol.RegisterMessage{
+		PrefixCacheProtocol: 1,
+		Models:              []protocol.ModelInfo{{ID: "ready"}, {ID: "scan"}, {ID: "hash"}},
+		PrefixCacheStatuses: &statuses,
+	})
+	current.mu.Lock()
+	current.BackendCapacity = &protocol.BackendCapacity{Slots: []protocol.BackendSlotCapacity{
+		{Model: "ready", State: "idle"},
+		{Model: "scan", State: "running"},
+		{Model: "hash", State: "reloading"},
+	}}
+	current.mu.Unlock()
+	legacy := reg.Register("legacy", nil, &protocol.RegisterMessage{
+		PrefixCacheProtocol: 1,
+		Models:              []protocol.ModelInfo{{ID: "legacy"}},
+	})
+	legacy.mu.Lock()
+	legacy.BackendCapacity = &protocol.BackendCapacity{Slots: []protocol.BackendSlotCapacity{{
+		Model: "legacy", State: "idle",
+	}}}
+	legacy.mu.Unlock()
+
+	got := reg.PrefixCacheProtocolStatus()
+	if got.LoadedModels != 4 || got.ReportedLoadedModels != 3 ||
+		got.UnreportedLoadedModels != 1 || got.ExcludedModels != 2 ||
+		got.ByState["ready"] != 1 ||
+		got.ByReason["scan_pending"] != 1 ||
+		got.ByReason["weight_hash_unavailable"] != 1 ||
+		got.ByBackend["contiguous"] != 2 ||
+		got.ByReplayStrategy["frozen_full"] != 1 {
+		t.Fatalf("initial aggregate = %+v", got)
+	}
+
+	empty := []protocol.PrefixCacheModelStatus{}
+	if err := reg.UpdatePrefixCacheTelemetry("current", &empty, nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := reg.UpdatePrefixCacheTelemetry("current", nil, nil); err != nil {
+		t.Fatal(err)
+	}
+	got = reg.PrefixCacheProtocolStatus()
+	if got.ReportedLoadedModels != 0 || got.UnreportedLoadedModels != 4 {
+		t.Fatalf("authoritative clear/old omission aggregate = %+v", got)
+	}
+
+	replacement := []protocol.PrefixCacheModelStatus{statuses[0]}
+	if err := reg.UpdatePrefixCacheTelemetry("current", &replacement, nil); err != nil {
+		t.Fatal(err)
+	}
+	got = reg.PrefixCacheProtocolStatus()
+	if got.ReportedLoadedModels != 1 || got.UnreportedLoadedModels != 3 {
+		t.Fatalf("replacement aggregate = %+v", got)
+	}
+
+	reg.Disconnect("current")
+	got = reg.PrefixCacheProtocolStatus()
+	if got.LoadedModels != 1 || got.ReportedLoadedModels != 0 ||
+		got.UnreportedLoadedModels != 1 {
+		t.Fatalf("disconnect retained status = %+v", got)
+	}
+}
+
+func TestPrefixCacheDonationDeltasAndModelUpdateCleanup(t *testing.T) {
+	reg := cacheEligibilityTestRegistry()
+	reg.SetModelCatalog([]CatalogEntry{{ID: "old"}, {ID: "new"}})
+	reg.SetModelAliases(map[string]AliasTarget{
+		"public": {Desired: "new", Previous: "old"},
+	})
+	statuses := []protocol.PrefixCacheModelStatus{{
+		ModelID: "old", Backend: "contiguous", ReplayStrategy: "direct",
+		State: "ready", Reason: "ready",
+	}}
+	baseline := []protocol.PrefixCacheDonationOutcomeCount{{
+		Outcome: "donated", Count: 2,
+	}}
+	provider := reg.Register("provider", nil, &protocol.RegisterMessage{
+		Models:                      []protocol.ModelInfo{{ID: "old"}},
+		PrefixCacheStatuses:         &statuses,
+		PrefixCacheDonationOutcomes: &baseline,
+	})
+	reg.cacheRouting.mu.Lock()
+	reg.cacheRouting.upsertHolderLocked("old-holder", cacheHolder{
+		ProviderID: provider.ID, ModelID: "old",
+		UpdatedAt: time.Now(), ExpiresAt: time.Now().Add(time.Minute),
+	})
+	reg.cacheRouting.mu.Unlock()
+
+	five := []protocol.PrefixCacheDonationOutcomeCount{{Outcome: "donated", Count: 5}}
+	if err := reg.UpdatePrefixCacheTelemetry("provider", nil, &five); err != nil {
+		t.Fatal(err)
+	}
+	if got := reg.CacheRoutingLifecycleStatus().DonationOutcomes["donated"]; got != 3 {
+		t.Fatalf("donation delta = %d, want 3", got)
+	}
+	decreased := []protocol.PrefixCacheDonationOutcomeCount{{Outcome: "donated", Count: 1}}
+	if err := reg.UpdatePrefixCacheTelemetry("provider", nil, &decreased); err != nil {
+		t.Fatal(err)
+	}
+	four := []protocol.PrefixCacheDonationOutcomeCount{{Outcome: "donated", Count: 4}}
+	if err := reg.UpdatePrefixCacheTelemetry("provider", nil, &four); err != nil {
+		t.Fatal(err)
+	}
+	if got := reg.CacheRoutingLifecycleStatus().DonationOutcomes["donated"]; got != 3 {
+		t.Fatalf("counter rollback inflated central total: %d", got)
+	}
+
+	merged, dropped := reg.MergeProviderModels("provider", []protocol.ModelInfo{{ID: "new"}})
+	if len(merged) != 1 || len(dropped) != 1 || dropped[0] != "old" {
+		t.Fatalf("model update merged=%v dropped=%v", merged, dropped)
+	}
+	provider.mu.Lock()
+	_, staleStatus := provider.PrefixCacheStatuses["old"]
+	_, staleCapability := provider.PrefixCacheV2Models["old"]
+	provider.mu.Unlock()
+	if staleStatus || staleCapability {
+		t.Fatal("model update retained stale cache state")
+	}
+	if got := reg.CacheRoutingLifecycleStatus().
+		HolderRemoved[string(cacheHolderRemovalCapabilityChange)]; got != 1 {
+		t.Fatalf("model update capability-change removals=%d, want 1", got)
+	}
+}

--- a/coordinator/registry/cache_eligibility_test.go
+++ b/coordinator/registry/cache_eligibility_test.go
@@ -50,81 +50,158 @@ func TestPrefixCacheTelemetryEnumCasingIsPinned(t *testing.T) {
 	}
 }
 
-func TestPrefixCacheStatusValidationRejectsUnboundedOrAmbiguousSnapshots(t *testing.T) {
+func TestPrefixCacheTelemetrySanitizesOptionalCompatibility(t *testing.T) {
 	reg := cacheEligibilityTestRegistry()
-	reg.SetModelCatalog([]CatalogEntry{{ID: "model"}})
-	base := protocol.RegisterMessage{
-		Models: []protocol.ModelInfo{{ID: "model"}},
+	reg.SetModelCatalog([]CatalogEntry{{ID: "public-model"}})
+	statuses := []protocol.PrefixCacheModelStatus{
+		{
+			ModelID: "owner-local", Backend: "unknown", ReplayStrategy: "none",
+			State: "disabled", Reason: "config_disabled",
+		},
+		{
+			ModelID: "future-model", Backend: "future_backend", ReplayStrategy: "future_strategy",
+			State: "warming", Reason: "future_reason",
+		},
+		{
+			ModelID: "not-advertised", Backend: "contiguous", ReplayStrategy: "direct",
+			State: "ready", Reason: "ready",
+		},
 	}
+	outcomes := []protocol.PrefixCacheDonationOutcomeCount{
+		{Outcome: "donated", Count: 7},
+		{Outcome: "future_donation_outcome", Count: 9},
+		{Outcome: "write_failed", Count: 0},
+	}
+	msg := protocol.RegisterMessage{
+		Models: []protocol.ModelInfo{
+			{ID: "owner-local"},
+			{ID: "future-model"},
+		},
+		PrefixCacheStatuses:         &statuses,
+		PrefixCacheDonationOutcomes: &outcomes,
+	}
+	if err := reg.ValidatePrefixCacheRegistration(&msg); err != nil {
+		t.Fatalf("optional telemetry closed owner-local registration: %v", err)
+	}
+	if msg.PrefixCacheStatuses == nil || len(*msg.PrefixCacheStatuses) != 1 ||
+		(*msg.PrefixCacheStatuses)[0].ModelID != "owner-local" {
+		t.Fatalf("status sanitization = %+v, want owner-local known entry", msg.PrefixCacheStatuses)
+	}
+	if msg.PrefixCacheDonationOutcomes == nil ||
+		len(*msg.PrefixCacheDonationOutcomes) != 1 ||
+		(*msg.PrefixCacheDonationOutcomes)[0].Outcome != "donated" {
+		t.Fatalf("donation sanitization = %+v, want donated known entry", msg.PrefixCacheDonationOutcomes)
+	}
+	provider := reg.Register("owner", nil, &msg)
+	if provider == nil {
+		t.Fatal("owner-local provider was not registered")
+	}
+	aggregate := reg.PrefixCacheProtocolStatus()
+	if aggregate.ReportedLoadedModels != 1 ||
+		aggregate.ByReason["config_disabled"] != 1 {
+		t.Fatalf("known owner-local aggregate = %+v", aggregate)
+	}
+}
+
+func TestPrefixCacheTelemetryStructuralAbuseDropsWholeOptionalSnapshot(t *testing.T) {
+	reg := cacheEligibilityTestRegistry()
 	valid := protocol.PrefixCacheModelStatus{
 		ModelID: "model", Backend: "contiguous", ReplayStrategy: "direct",
 		State: "ready", Reason: "ready",
 	}
-	validStatuses := []protocol.PrefixCacheModelStatus{valid}
-	base.PrefixCacheStatuses = &validStatuses
-	if err := reg.ValidatePrefixCacheRegistration(&base); err != nil {
-		t.Fatalf("valid snapshot rejected: %v", err)
-	}
-
 	for _, test := range []struct {
-		name   string
-		mutate func(*protocol.PrefixCacheModelStatus)
+		name     string
+		statuses []protocol.PrefixCacheModelStatus
 	}{
-		{name: "state", mutate: func(s *protocol.PrefixCacheModelStatus) { s.State = "warming" }},
-		{name: "reason", mutate: func(s *protocol.PrefixCacheModelStatus) { s.Reason = "free-form" }},
-		{name: "backend", mutate: func(s *protocol.PrefixCacheModelStatus) { s.Backend = "metal" }},
-		{name: "strategy", mutate: func(s *protocol.PrefixCacheModelStatus) { s.ReplayStrategy = "tail" }},
-		{name: "state reason mismatch", mutate: func(s *protocol.PrefixCacheModelStatus) {
-			s.State = "error"
-		}},
-		{name: "inventory", mutate: func(s *protocol.PrefixCacheModelStatus) { s.ModelID = "other" }},
+		{
+			name:     "duplicate model ids",
+			statuses: []protocol.PrefixCacheModelStatus{valid, valid},
+		},
+		{
+			name: "blank model id",
+			statuses: []protocol.PrefixCacheModelStatus{{
+				Backend: "contiguous", ReplayStrategy: "direct", State: "ready", Reason: "ready",
+			}},
+		},
+		{
+			name: "non-canonical model id",
+			statuses: []protocol.PrefixCacheModelStatus{{
+				ModelID: " model ", Backend: "contiguous", ReplayStrategy: "direct",
+				State: "ready", Reason: "ready",
+			}},
+		},
+		{
+			name:     "oversized",
+			statuses: make([]protocol.PrefixCacheModelStatus, maxPrefixCacheStatuses+1),
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			candidate := valid
-			test.mutate(&candidate)
-			statuses := []protocol.PrefixCacheModelStatus{candidate}
-			msg := base
-			msg.PrefixCacheStatuses = &statuses
-			if err := reg.ValidatePrefixCacheRegistration(&msg); err == nil {
-				t.Fatal("invalid status snapshot accepted")
+			statuses := append([]protocol.PrefixCacheModelStatus(nil), test.statuses...)
+			msg := protocol.RegisterMessage{
+				Models:              []protocol.ModelInfo{{ID: "model"}},
+				PrefixCacheStatuses: &statuses,
+			}
+			if err := reg.ValidatePrefixCacheRegistration(&msg); err != nil {
+				t.Fatalf("structural optional telemetry closed registration: %v", err)
+			}
+			if msg.PrefixCacheStatuses == nil || len(*msg.PrefixCacheStatuses) != 0 {
+				t.Fatalf("structural snapshot was not dropped: %+v", msg.PrefixCacheStatuses)
 			}
 		})
 	}
 
-	duplicates := []protocol.PrefixCacheModelStatus{valid, valid}
-	msg := base
-	msg.PrefixCacheStatuses = &duplicates
-	if err := reg.ValidatePrefixCacheRegistration(&msg); err == nil {
-		t.Fatal("duplicate status model accepted")
+	for _, test := range []struct {
+		name     string
+		outcomes []protocol.PrefixCacheDonationOutcomeCount
+	}{
+		{
+			name: "duplicate outcomes",
+			outcomes: []protocol.PrefixCacheDonationOutcomeCount{
+				{Outcome: "donated", Count: 1},
+				{Outcome: "donated", Count: 2},
+			},
+		},
+		{
+			name:     "oversized",
+			outcomes: make([]protocol.PrefixCacheDonationOutcomeCount, maxPrefixCacheDonationOutcomes+1),
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			outcomes := append([]protocol.PrefixCacheDonationOutcomeCount(nil), test.outcomes...)
+			msg := protocol.RegisterMessage{
+				Models:                      []protocol.ModelInfo{{ID: "model"}},
+				PrefixCacheDonationOutcomes: &outcomes,
+			}
+			if err := reg.ValidatePrefixCacheRegistration(&msg); err != nil {
+				t.Fatalf("structural optional telemetry closed registration: %v", err)
+			}
+			if msg.PrefixCacheDonationOutcomes == nil ||
+				len(*msg.PrefixCacheDonationOutcomes) != 0 {
+				t.Fatalf("structural outcome snapshot was not dropped: %+v", msg.PrefixCacheDonationOutcomes)
+			}
+		})
 	}
-	tooMany := make([]protocol.PrefixCacheModelStatus, maxPrefixCacheStatuses+1)
-	for index := range tooMany {
-		tooMany[index] = valid
-		tooMany[index].ModelID = "model"
+}
+
+func TestPrefixCacheTelemetryOmissionAndRoutingCapabilityStrictness(t *testing.T) {
+	reg := cacheEligibilityTestRegistry()
+	legacy := protocol.RegisterMessage{Models: []protocol.ModelInfo{{ID: "model"}}}
+	if err := reg.ValidatePrefixCacheRegistration(&legacy); err != nil {
+		t.Fatal(err)
 	}
-	msg.PrefixCacheStatuses = &tooMany
-	if err := reg.ValidatePrefixCacheRegistration(&msg); err == nil {
-		t.Fatal("oversized status snapshot accepted")
+	if legacy.PrefixCacheStatuses != nil || legacy.PrefixCacheDonationOutcomes != nil {
+		t.Fatal("old-provider omission was converted into a reported snapshot")
 	}
 
-	offCatalog := base
-	offCatalog.Models = []protocol.ModelInfo{{ID: "off-catalog"}}
-	offCatalogStatuses := []protocol.PrefixCacheModelStatus{{
-		ModelID: "off-catalog", Backend: "unknown", ReplayStrategy: "none",
-		State: "disabled", Reason: "config_disabled",
-	}}
-	offCatalog.PrefixCacheStatuses = &offCatalogStatuses
-	if err := reg.ValidatePrefixCacheRegistration(&offCatalog); err == nil {
-		t.Fatal("off-catalog status accepted")
+	badCapability := protocol.RegisterMessage{
+		Models:              []protocol.ModelInfo{{ID: "model"}},
+		PrefixCacheProtocol: 2,
+		PrefixCacheV2Models: []protocol.PrefixCacheV2Capability{{
+			ModelID: "not-advertised",
+		}},
 	}
-
-	badOutcome := []protocol.PrefixCacheDonationOutcomeCount{{
-		Outcome: "request_specific_failure", Count: 1,
-	}}
-	msg = base
-	msg.PrefixCacheDonationOutcomes = &badOutcome
-	if err := reg.ValidatePrefixCacheRegistration(&msg); err == nil {
-		t.Fatal("free-form donation outcome accepted")
+	if err := reg.ValidatePrefixCacheRegistration(&badCapability); err == nil {
+		t.Fatal("authoritative routing capability validation became fail-open")
 	}
 }
 
@@ -222,12 +299,25 @@ func TestPrefixCacheDonationDeltasAndModelUpdateCleanup(t *testing.T) {
 	})
 	reg.cacheRouting.mu.Unlock()
 
-	five := []protocol.PrefixCacheDonationOutcomeCount{{Outcome: "donated", Count: 5}}
+	five := []protocol.PrefixCacheDonationOutcomeCount{
+		{Outcome: "donated", Count: 5},
+		{Outcome: "future_outcome", Count: 99},
+	}
 	if err := reg.UpdatePrefixCacheTelemetry("provider", nil, &five); err != nil {
 		t.Fatal(err)
 	}
 	if got := reg.CacheRoutingLifecycleStatus().DonationOutcomes["donated"]; got != 3 {
 		t.Fatalf("donation delta = %d, want 3", got)
+	}
+	oversized := make(
+		[]protocol.PrefixCacheDonationOutcomeCount,
+		maxPrefixCacheDonationOutcomes+1,
+	)
+	if err := reg.UpdatePrefixCacheTelemetry("provider", nil, &oversized); err != nil {
+		t.Fatalf("oversized optional outcomes became fatal: %v", err)
+	}
+	if got := reg.CacheRoutingLifecycleStatus().DonationOutcomes["donated"]; got != 3 {
+		t.Fatalf("dropped structural snapshot changed aggregate: %d", got)
 	}
 	decreased := []protocol.PrefixCacheDonationOutcomeCount{{Outcome: "donated", Count: 1}}
 	if err := reg.UpdatePrefixCacheTelemetry("provider", nil, &decreased); err != nil {

--- a/coordinator/registry/cache_eligibility_test.go
+++ b/coordinator/registry/cache_eligibility_test.go
@@ -1,6 +1,7 @@
 package registry
 
 import (
+	"fmt"
 	"io"
 	"log/slog"
 	"strings"
@@ -48,6 +49,132 @@ func TestPrefixCacheTelemetryEnumCasingIsPinned(t *testing.T) {
 				t.Fatalf("enum values=%q, want %q", got, test.want)
 			}
 		})
+	}
+}
+
+func TestDonationOutcomeForwardVersionHeadroomPreservesKnownCounters(t *testing.T) {
+	knownOutcomes := PrefixCacheDonationOutcomes()
+	if len(knownOutcomes) != 13 {
+		t.Fatalf("known outcome buckets=%d, want 13", len(knownOutcomes))
+	}
+	knownCounters := func(offset uint64) []protocol.PrefixCacheDonationOutcomeCount {
+		result := make(
+			[]protocol.PrefixCacheDonationOutcomeCount,
+			0,
+			len(knownOutcomes),
+		)
+		for index, outcome := range knownOutcomes {
+			result = append(result, protocol.PrefixCacheDonationOutcomeCount{
+				Outcome: outcome,
+				Count:   uint64(index+1) + offset,
+			})
+		}
+		return result
+	}
+	withFuture := func(
+		known []protocol.PrefixCacheDonationOutcomeCount,
+		futureCount int,
+	) []protocol.PrefixCacheDonationOutcomeCount {
+		result := append([]protocol.PrefixCacheDonationOutcomeCount(nil), known...)
+		for index := range futureCount {
+			result = append(result, protocol.PrefixCacheDonationOutcomeCount{
+				Outcome: fmt.Sprintf("future_outcome_%d", index),
+				Count:   uint64(index + 1),
+			})
+		}
+		return result
+	}
+
+	reg := cacheEligibilityTestRegistry()
+	allKnownPlusOneFuture := withFuture(knownCounters(0), 1)
+	registration := protocol.RegisterMessage{
+		Models:                      []protocol.ModelInfo{{ID: "model"}},
+		PrefixCacheDonationOutcomes: &allKnownPlusOneFuture,
+	}
+	if err := reg.ValidatePrefixCacheRegistration(&registration); err != nil {
+		t.Fatalf("known+future registration became fatal: %v", err)
+	}
+	if got := len(*registration.PrefixCacheDonationOutcomes); got != len(knownOutcomes) {
+		t.Fatalf("known+future sanitized entries=%d, want %d", got, len(knownOutcomes))
+	}
+
+	atCap := withFuture(
+		knownCounters(0),
+		maxPrefixCacheDonationOutcomeEntries-len(knownOutcomes),
+	)
+	atCapRegistration := protocol.RegisterMessage{
+		Models:                      []protocol.ModelInfo{{ID: "model"}},
+		PrefixCacheDonationOutcomes: &atCap,
+	}
+	if err := reg.ValidatePrefixCacheRegistration(&atCapRegistration); err != nil {
+		t.Fatalf("at-cap registration became fatal: %v", err)
+	}
+	if got := len(*atCapRegistration.PrefixCacheDonationOutcomes); got != len(knownOutcomes) {
+		t.Fatalf("at-cap sanitized entries=%d, want %d", got, len(knownOutcomes))
+	}
+
+	overCap := append(
+		withFuture(
+			knownCounters(0),
+			maxPrefixCacheDonationOutcomeEntries-len(knownOutcomes),
+		),
+		protocol.PrefixCacheDonationOutcomeCount{
+			Outcome: "future_outcome_over_cap", Count: 1,
+		},
+	)
+	overCapRegistration := protocol.RegisterMessage{
+		Models:                      []protocol.ModelInfo{{ID: "model"}},
+		PrefixCacheDonationOutcomes: &overCap,
+	}
+	if err := reg.ValidatePrefixCacheRegistration(&overCapRegistration); err != nil {
+		t.Fatalf("over-cap optional telemetry became fatal: %v", err)
+	}
+	if got := len(*overCapRegistration.PrefixCacheDonationOutcomes); got != 0 {
+		t.Fatalf("over-cap snapshot retained %d entries, want 0", got)
+	}
+
+	baseline := knownCounters(0)
+	provider := reg.Register("provider", nil, &protocol.RegisterMessage{
+		Models:                      []protocol.ModelInfo{{ID: "model"}},
+		PrefixCacheDonationOutcomes: &baseline,
+	})
+	updated := withFuture(knownCounters(10), 1)
+	if err := reg.UpdatePrefixCacheTelemetry(provider.ID, nil, &updated); err != nil {
+		t.Fatal(err)
+	}
+	for _, outcome := range knownOutcomes {
+		if got := reg.CacheRoutingLifecycleStatus().DonationOutcomes[outcome]; got != 10 {
+			t.Fatalf("%s delta=%d, want 10", outcome, got)
+		}
+	}
+
+	overCapHeartbeat := append(
+		withFuture(
+			knownCounters(20),
+			maxPrefixCacheDonationOutcomeEntries-len(knownOutcomes),
+		),
+		protocol.PrefixCacheDonationOutcomeCount{
+			Outcome: "future_outcome_over_cap", Count: 1,
+		},
+	)
+	if err := reg.UpdatePrefixCacheTelemetry(
+		provider.ID, nil, &overCapHeartbeat); err != nil {
+		t.Fatalf("over-cap heartbeat became fatal: %v", err)
+	}
+	for _, outcome := range knownOutcomes {
+		if got := reg.CacheRoutingLifecycleStatus().DonationOutcomes[outcome]; got != 10 {
+			t.Fatalf("%s changed after over-cap snapshot: %d", outcome, got)
+		}
+	}
+
+	recovered := withFuture(knownCounters(30), 1)
+	if err := reg.UpdatePrefixCacheTelemetry(provider.ID, nil, &recovered); err != nil {
+		t.Fatal(err)
+	}
+	for _, outcome := range knownOutcomes {
+		if got := reg.CacheRoutingLifecycleStatus().DonationOutcomes[outcome]; got != 30 {
+			t.Fatalf("%s recovered total=%d, want 30", outcome, got)
+		}
 	}
 }
 
@@ -163,8 +290,11 @@ func TestPrefixCacheTelemetryStructuralAbuseDropsWholeOptionalSnapshot(t *testin
 			},
 		},
 		{
-			name:     "oversized",
-			outcomes: make([]protocol.PrefixCacheDonationOutcomeCount, maxPrefixCacheDonationOutcomes+1),
+			name: "oversized",
+			outcomes: make(
+				[]protocol.PrefixCacheDonationOutcomeCount,
+				maxPrefixCacheDonationOutcomeEntries+1,
+			),
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -511,7 +641,7 @@ func TestPrefixCacheDonationDeltasAndModelUpdateCleanup(t *testing.T) {
 	}
 	oversized := make(
 		[]protocol.PrefixCacheDonationOutcomeCount,
-		maxPrefixCacheDonationOutcomes+1,
+		maxPrefixCacheDonationOutcomeEntries+1,
 	)
 	if err := reg.UpdatePrefixCacheTelemetry("provider", nil, &oversized); err != nil {
 		t.Fatalf("oversized optional outcomes became fatal: %v", err)

--- a/coordinator/registry/cache_receipts.go
+++ b/coordinator/registry/cache_receipts.go
@@ -118,7 +118,10 @@ func validCacheOutcome(outcome string) bool {
 	}
 }
 
-func (t *cacheRoutingTracker) disconnect(providerID string) {
+func (t *cacheRoutingTracker) disconnect(
+	providerID string,
+	reason cacheHolderRemovalReason,
+) {
 	if t == nil || providerID == "" {
 		return
 	}
@@ -126,7 +129,7 @@ func (t *cacheRoutingTracker) disconnect(providerID string) {
 	defer t.mu.Unlock()
 	for key, holders := range t.holders {
 		if _, exists := holders[providerID]; exists {
-			t.removeHolderLocked(key, providerID)
+			t.removeHolderLocked(key, providerID, reason)
 		}
 	}
 	for nonce, attempt := range t.attempts {
@@ -146,7 +149,10 @@ func (t *cacheRoutingTracker) disconnect(providerID string) {
 	}
 }
 
-func (t *cacheRoutingTracker) invalidateProviderModel(providerID, modelID string) {
+func (t *cacheRoutingTracker) invalidateProviderModel(
+	providerID, modelID string,
+	reason cacheHolderRemovalReason,
+) {
 	if t == nil || providerID == "" || modelID == "" {
 		return
 	}
@@ -154,7 +160,7 @@ func (t *cacheRoutingTracker) invalidateProviderModel(providerID, modelID string
 	defer t.mu.Unlock()
 	for key, holders := range t.holders {
 		if holder, exists := holders[providerID]; exists && holder.ModelID == modelID {
-			t.removeHolderLocked(key, providerID)
+			t.removeHolderLocked(key, providerID, reason)
 		}
 	}
 	for nonce, attempt := range t.attempts {
@@ -200,6 +206,7 @@ func (t *cacheRoutingTracker) upsertHolderLocked(key string, holder cacheHolder)
 	}
 	if _, exists := holders[holder.ProviderID]; !exists {
 		t.holderCount++
+		t.holderAdded++
 	}
 	holders[holder.ProviderID] = holder
 	t.trackHolderOrderLocked(key, holder.ProviderID, holder.UpdatedAt)
@@ -213,7 +220,7 @@ func (t *cacheRoutingTracker) upsertHolderLocked(key string, holder cacheHolder)
 				oldestUpdatedAt = candidate.UpdatedAt
 			}
 		}
-		t.removeHolderLocked(key, oldestProviderID)
+		t.removeHolderLocked(key, oldestProviderID, cacheHolderRemovalCapacityEviction)
 	}
 	t.enforceCapLocked()
 }
@@ -229,7 +236,7 @@ func (t *cacheRoutingTracker) activeHolderLocked(
 	if now.Before(holder.ExpiresAt) {
 		return holder, true
 	}
-	t.removeHolderLocked(key, providerID)
+	t.removeHolderLocked(key, providerID, cacheHolderRemovalTTL)
 	return cacheHolder{}, false
 }
 
@@ -260,12 +267,16 @@ func (t *cacheRoutingTracker) trackHolderOrderLocked(
 	t.holderOrderByRef[ref] = entry
 }
 
-func (t *cacheRoutingTracker) removeHolderLocked(key, providerID string) {
+func (t *cacheRoutingTracker) removeHolderLocked(
+	key, providerID string,
+	reason cacheHolderRemovalReason,
+) {
 	ref := cacheHolderRef{key: key, providerID: providerID}
 	if holders := t.holders[key]; holders != nil {
 		if _, exists := holders[providerID]; exists {
 			delete(holders, providerID)
 			t.holderCount--
+			t.holderRemoved[string(reason)]++
 		}
 		if len(holders) == 0 {
 			delete(t.holders, key)
@@ -281,7 +292,7 @@ func (t *cacheRoutingTracker) sweepLocked(now time.Time) {
 	for key, holders := range t.holders {
 		for providerID, holder := range holders {
 			if !now.Before(holder.ExpiresAt) {
-				t.removeHolderLocked(key, providerID)
+				t.removeHolderLocked(key, providerID, cacheHolderRemovalTTL)
 			}
 		}
 	}
@@ -302,7 +313,10 @@ func (t *cacheRoutingTracker) sweepIfDueLocked(now time.Time) {
 
 func (t *cacheRoutingTracker) enforceCapLocked() {
 	for t.holderCount > t.maxEntries {
-		t.removeHolderLocked(t.holderOrder[0].ref.key, t.holderOrder[0].ref.providerID)
+		t.removeHolderLocked(
+			t.holderOrder[0].ref.key,
+			t.holderOrder[0].ref.providerID,
+			cacheHolderRemovalCapacityEviction)
 	}
 }
 

--- a/coordinator/registry/cache_receipts_v2.go
+++ b/coordinator/registry/cache_receipts_v2.go
@@ -177,7 +177,8 @@ func (r *Registry) disablePrefixCacheV2Model(providerID, modelID string) {
 	if ok {
 		if tracker != nil {
 			tracker.rejectCapability(providerID, modelID, capability)
-			tracker.invalidateProviderModel(providerID, modelID)
+			tracker.invalidateProviderModel(
+				providerID, modelID, cacheHolderRemovalCapabilityChange)
 		}
 		provider.prefixCacheRevision++
 	}
@@ -309,6 +310,7 @@ func (t *cacheRoutingTracker) applyLookupV2Result(
 			t.removeHolderLocked(
 				cacheBoundaryKey(routeKey, attempt.Plan, capability.CacheEpoch, anchor),
 				providerID,
+				cacheHolderRemovalMissInvalidation,
 			)
 		}
 	}

--- a/coordinator/registry/cache_receipts_v2_test.go
+++ b/coordinator/registry/cache_receipts_v2_test.go
@@ -248,6 +248,13 @@ func TestPrefixCacheV2CapabilityEpochChangeClearsEvidence(t *testing.T) {
 		ModelID:    oldCapability.ModelID,
 		CacheEpoch: oldCapability.CacheEpoch,
 	}] = 4
+	registry.cacheRouting.upsertHolderLocked("epoch-holder", cacheHolder{
+		ProviderID: provider.ID,
+		ModelID:    oldCapability.ModelID,
+		CacheEpoch: oldCapability.CacheEpoch,
+		UpdatedAt:  time.Now(),
+		ExpiresAt:  time.Now().Add(time.Minute),
+	})
 
 	if err := registry.UpdatePrefixCacheCapabilities(
 		provider.ID, 2, []protocol.PrefixCacheV2Capability{newCapability}); err != nil {
@@ -261,5 +268,8 @@ func TestPrefixCacheV2CapabilityEpochChangeClearsEvidence(t *testing.T) {
 			"epoch refresh retained evidence: attempts=%d sequences=%d",
 			len(registry.cacheRouting.attempts),
 			len(registry.cacheRouting.v2Sequences))
+	}
+	if got := registry.cacheRouting.holderRemoved[string(cacheHolderRemovalEpochChange)]; got != 1 {
+		t.Fatalf("epoch-change holder removals=%d, want 1", got)
 	}
 }

--- a/coordinator/registry/cache_routing.go
+++ b/coordinator/registry/cache_routing.go
@@ -128,6 +128,28 @@ type cacheRoutingCapability struct {
 	CapabilityRevision uint64
 }
 
+type cacheHolderRemovalReason string
+
+const (
+	cacheHolderRemovalTTL              cacheHolderRemovalReason = "ttl"
+	cacheHolderRemovalDisconnect       cacheHolderRemovalReason = "disconnect"
+	cacheHolderRemovalEpochChange      cacheHolderRemovalReason = "epoch_change"
+	cacheHolderRemovalCapabilityChange cacheHolderRemovalReason = "capability_change"
+	cacheHolderRemovalMissInvalidation cacheHolderRemovalReason = "miss_invalidation"
+	cacheHolderRemovalCapacityEviction cacheHolderRemovalReason = "capacity_eviction"
+)
+
+func CacheHolderRemovalReasons() []string {
+	return []string{
+		string(cacheHolderRemovalTTL),
+		string(cacheHolderRemovalDisconnect),
+		string(cacheHolderRemovalEpochChange),
+		string(cacheHolderRemovalCapabilityChange),
+		string(cacheHolderRemovalMissInvalidation),
+		string(cacheHolderRemovalCapacityEviction),
+	}
+}
+
 type cacheAttemptOrderEntry struct {
 	nonce     string
 	createdAt time.Time
@@ -234,6 +256,9 @@ type cacheRoutingTracker struct {
 	ssdHits             uint64
 	ssdMisses           uint64
 	ssdDonations        uint64
+	holderAdded         uint64
+	holderRemoved       map[string]uint64
+	donationOutcomes    map[string]uint64
 }
 
 func newCacheRoutingTracker(ttl time.Duration, maxHolders int) *cacheRoutingTracker {
@@ -247,8 +272,10 @@ func newCacheRoutingTracker(ttl time.Duration, maxHolders int) *cacheRoutingTrac
 		ttl: ttl, maxHolders: maxHolders, maxEntries: cacheRoutingMaxEntries, maxAttempts: cacheRoutingMaxAttempts,
 		holders: make(map[string]map[string]cacheHolder), attempts: make(map[string]cacheAttempt),
 		holderOrderByRef: make(map[cacheHolderRef]*cacheHolderOrderEntry), attemptOrderByNonce: make(map[string]*cacheAttemptOrderEntry),
-		v2Sequences: make(map[cacheV2SequenceKey]uint64),
-		rejectedV2:  make(map[cacheV2ProviderModelKey]protocol.PrefixCacheV2Capability),
+		v2Sequences:      make(map[cacheV2SequenceKey]uint64),
+		rejectedV2:       make(map[cacheV2ProviderModelKey]protocol.PrefixCacheV2Capability),
+		holderRemoved:    make(map[string]uint64),
+		donationOutcomes: make(map[string]uint64),
 	}
 }
 
@@ -271,10 +298,13 @@ func (r *Registry) CacheRoutingStateCounts() (holders, attempts int) {
 }
 
 type CacheRoutingLifecycleStatus struct {
-	SSDLookups   uint64 `json:"ssd_lookups"`
-	SSDHits      uint64 `json:"ssd_hits"`
-	SSDMisses    uint64 `json:"ssd_misses"`
-	SSDDonations uint64 `json:"ssd_donations"`
+	SSDLookups       uint64            `json:"ssd_lookups"`
+	SSDHits          uint64            `json:"ssd_hits"`
+	SSDMisses        uint64            `json:"ssd_misses"`
+	SSDDonations     uint64            `json:"ssd_donations"`
+	HolderAdded      uint64            `json:"holder_added"`
+	HolderRemoved    map[string]uint64 `json:"holder_removed"`
+	DonationOutcomes map[string]uint64 `json:"donation_outcomes"`
 }
 
 func (r *Registry) CacheRoutingLifecycleStatus() CacheRoutingLifecycleStatus {
@@ -289,8 +319,45 @@ func (r *Registry) CacheRoutingLifecycleStatus() CacheRoutingLifecycleStatus {
 	}
 	tracker.mu.Lock()
 	defer tracker.mu.Unlock()
+	holderRemoved := zeroUint64Buckets(CacheHolderRemovalReasons())
+	for reason, count := range tracker.holderRemoved {
+		holderRemoved[reason] = count
+	}
+	donationOutcomes := zeroUint64Buckets(prefixCacheDonationOutcomes)
+	for outcome, count := range tracker.donationOutcomes {
+		donationOutcomes[outcome] = count
+	}
 	return CacheRoutingLifecycleStatus{
 		SSDLookups: tracker.ssdLookups, SSDHits: tracker.ssdHits,
 		SSDMisses: tracker.ssdMisses, SSDDonations: tracker.ssdDonations,
+		HolderAdded: tracker.holderAdded, HolderRemoved: holderRemoved,
+		DonationOutcomes: donationOutcomes,
+	}
+}
+
+func zeroUint64Buckets(values []string) map[string]uint64 {
+	result := make(map[string]uint64, len(values))
+	for _, value := range values {
+		result[value] = 0
+	}
+	return result
+}
+
+func (t *cacheRoutingTracker) recordDonationOutcomes(deltas map[string]uint64) {
+	if t == nil || len(deltas) == 0 {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	for outcome, delta := range deltas {
+		if delta == 0 || !containsFixed(prefixCacheDonationOutcomes, outcome) {
+			continue
+		}
+		current := t.donationOutcomes[outcome]
+		if ^uint64(0)-current < delta {
+			t.donationOutcomes[outcome] = ^uint64(0)
+		} else {
+			t.donationOutcomes[outcome] = current + delta
+		}
 	}
 }

--- a/coordinator/registry/cache_routing_exact_test.go
+++ b/coordinator/registry/cache_routing_exact_test.go
@@ -225,6 +225,11 @@ func TestExactV2ReadyCreatesLongestPrefixHolderAndMissInvalidates(t *testing.T) 
 	); len(hints) != 0 {
 		t.Fatalf("miss left stale exact holders: %+v", hints)
 	}
+	lifecycle := r.CacheRoutingLifecycleStatus()
+	if lifecycle.HolderAdded != 2 ||
+		lifecycle.HolderRemoved[string(cacheHolderRemovalMissInvalidation)] != 2 {
+		t.Fatalf("miss lifecycle counters = %+v", lifecycle)
+	}
 }
 
 func TestExactV2CoordinatorRestartDropsEphemeralRoutingState(t *testing.T) {
@@ -750,9 +755,34 @@ func TestExactRoutingExpiryAndDisconnectRemoveConnectionEvidence(t *testing.T) {
 		UpdatedAt: now, ExpiresAt: now.Add(time.Minute),
 	})
 	r.cacheRouting.mu.Unlock()
-	r.cacheRouting.disconnect(provider.ID)
+	r.cacheRouting.disconnect(provider.ID, cacheHolderRemovalDisconnect)
 	if len(r.cacheRouting.hints(
 		plan, capabilities, r.cacheRouteKeys.route, CacheRoutingOn, now)) != 0 {
 		t.Fatal("disconnect left connection-scoped holder evidence")
+	}
+	lifecycle := r.CacheRoutingLifecycleStatus()
+	if lifecycle.HolderAdded != 2 ||
+		lifecycle.HolderRemoved[string(cacheHolderRemovalTTL)] != 1 ||
+		lifecycle.HolderRemoved[string(cacheHolderRemovalDisconnect)] != 1 {
+		t.Fatalf("expiry/disconnect lifecycle counters = %+v", lifecycle)
+	}
+}
+
+func TestExactRoutingHolderCapacityEvictionIsCounted(t *testing.T) {
+	tracker := newCacheRoutingTracker(time.Minute, 1)
+	now := time.Now()
+	tracker.mu.Lock()
+	tracker.upsertHolderLocked("boundary", cacheHolder{
+		ProviderID: "first", UpdatedAt: now, ExpiresAt: now.Add(time.Minute),
+	})
+	tracker.upsertHolderLocked("boundary", cacheHolder{
+		ProviderID: "second", UpdatedAt: now.Add(time.Second), ExpiresAt: now.Add(time.Minute),
+	})
+	added := tracker.holderAdded
+	removed := tracker.holderRemoved[string(cacheHolderRemovalCapacityEviction)]
+	count := tracker.holderCount
+	tracker.mu.Unlock()
+	if added != 2 || removed != 1 || count != 1 {
+		t.Fatalf("capacity lifecycle added=%d removed=%d holders=%d", added, removed, count)
 	}
 }

--- a/coordinator/registry/cache_snapshot.go
+++ b/coordinator/registry/cache_snapshot.go
@@ -1,0 +1,134 @@
+package registry
+
+import "github.com/eigeninference/d-inference/coordinator/protocol"
+
+func clonePrefixCacheCapabilities(
+	in map[string]protocol.PrefixCacheV2Capability,
+) map[string]protocol.PrefixCacheV2Capability {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]protocol.PrefixCacheV2Capability, len(in))
+	for modelID, capability := range in {
+		out[modelID] = capability
+	}
+	return out
+}
+
+func clonePrefixCacheStatuses(
+	in map[string]protocol.PrefixCacheModelStatus,
+) map[string]protocol.PrefixCacheModelStatus {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]protocol.PrefixCacheModelStatus, len(in))
+	for modelID, status := range in {
+		out[modelID] = status
+	}
+	return out
+}
+
+// UpdatePrefixCacheSnapshot atomically applies the resulting authoritative
+// capability and optional observability state from one heartbeat. Strict
+// capability errors abort the update. Optional status is sanitized and
+// reconciled against the same resulting capability map before either becomes
+// visible, so /v1/cache/status cannot observe a transient contradiction.
+func (r *Registry) UpdatePrefixCacheSnapshot(
+	providerID string,
+	replaceCapabilities bool,
+	version int,
+	capabilities []protocol.PrefixCacheV2Capability,
+	statuses *[]protocol.PrefixCacheModelStatus,
+	outcomes *[]protocol.PrefixCacheDonationOutcomeCount,
+) (bool, error) {
+	if r == nil {
+		return false, nil
+	}
+	r.mu.RLock()
+	provider := r.providers[providerID]
+	r.mu.RUnlock()
+	if provider == nil {
+		return false, errInvalidPrefixCacheCapability
+	}
+
+	provider.mu.Lock()
+	models, err := uniqueProviderModels(provider.Models)
+	if err != nil {
+		provider.mu.Unlock()
+		return false, err
+	}
+
+	resultVersion := provider.PrefixCacheProtocol
+	resultCapabilities := clonePrefixCacheCapabilities(provider.PrefixCacheV2Models)
+	if replaceCapabilities {
+		resultCapabilities, err = validatePrefixCacheCapabilities(
+			version, capabilities, models)
+		if err != nil {
+			provider.mu.Unlock()
+			return false, err
+		}
+		resultVersion = version
+	}
+
+	resultStatuses := clonePrefixCacheStatuses(provider.PrefixCacheStatuses)
+	statusReported := provider.PrefixCacheStatusReported
+	if statuses != nil {
+		resultStatuses, statusReported = sanitizePrefixCacheStatuses(statuses, models)
+	}
+	resultStatuses, statusReported = reconcilePrefixCacheStatuses(
+		resultVersion, resultCapabilities, resultStatuses, statusReported)
+	if statuses != nil {
+		if statusReported {
+			retainPrefixCacheStatuses(statuses, resultStatuses)
+		} else {
+			*statuses = nil
+		}
+	}
+
+	validatedOutcomes := sanitizePrefixCacheDonationOutcomes(outcomes)
+	deltas := make(map[string]uint64)
+	nextOutcomes := provider.PrefixCacheDonationOutcomes
+	if outcomes != nil {
+		nextOutcomes = make(
+			map[string]uint64,
+			len(provider.PrefixCacheDonationOutcomes)+len(validatedOutcomes),
+		)
+		for outcome, previous := range provider.PrefixCacheDonationOutcomes {
+			nextOutcomes[outcome] = previous
+		}
+		for outcome, current := range validatedOutcomes {
+			previous := provider.PrefixCacheDonationOutcomes[outcome]
+			if current >= previous {
+				deltas[outcome] = current - previous
+				nextOutcomes[outcome] = current
+			}
+		}
+	}
+
+	capabilitiesChanged := provider.PrefixCacheProtocol != resultVersion ||
+		!equalPrefixCacheCapabilities(provider.PrefixCacheV2Models, resultCapabilities)
+	removalReason := prefixCacheCapabilityRemovalReason(
+		provider.PrefixCacheV2Models, resultCapabilities)
+	if capabilitiesChanged {
+		provider.PrefixCacheProtocol = resultVersion
+		provider.PrefixCacheV2Models = resultCapabilities
+		provider.prefixCacheRevision++
+	}
+	provider.PrefixCacheStatuses = resultStatuses
+	provider.PrefixCacheStatusReported = statusReported
+	if outcomes != nil {
+		provider.PrefixCacheDonationOutcomes = nextOutcomes
+	}
+	provider.mu.Unlock()
+
+	r.mu.RLock()
+	tracker := r.cacheRouting
+	r.mu.RUnlock()
+	if capabilitiesChanged && tracker != nil {
+		tracker.disconnect(providerID, removalReason)
+	}
+	if tracker != nil {
+		tracker.recordDonationOutcomes(deltas)
+	}
+	return capabilitiesChanged, nil
+}

--- a/coordinator/registry/cache_status.go
+++ b/coordinator/registry/cache_status.go
@@ -4,14 +4,27 @@ package registry
 // provider cache capability. V2ReadyModels counts advertised ready
 // provider/model pairs, not unique models.
 type PrefixCacheProtocolStatus struct {
-	V0            int `json:"v0"`
-	V1            int `json:"v1"`
-	V2            int `json:"v2"`
-	V2ReadyModels int `json:"v2_ready_models"`
+	V0                     int            `json:"v0"`
+	V1                     int            `json:"v1"`
+	V2                     int            `json:"v2"`
+	V2ReadyModels          int            `json:"v2_ready_models"`
+	LoadedModels           int            `json:"loaded_models"`
+	ReportedLoadedModels   int            `json:"reported_loaded_models"`
+	UnreportedLoadedModels int            `json:"unreported_loaded_models"`
+	ExcludedModels         int            `json:"excluded_models"`
+	ByState                map[string]int `json:"by_state"`
+	ByReason               map[string]int `json:"by_reason"`
+	ByBackend              map[string]int `json:"by_backend"`
+	ByReplayStrategy       map[string]int `json:"by_replay_strategy"`
 }
 
 func (r *Registry) PrefixCacheProtocolStatus() PrefixCacheProtocolStatus {
-	var status PrefixCacheProtocolStatus
+	status := PrefixCacheProtocolStatus{
+		ByState:          zeroIntBuckets(prefixCacheStatusStates),
+		ByReason:         zeroIntBuckets(prefixCacheStatusReasons),
+		ByBackend:        zeroIntBuckets(prefixCacheStatusBackends),
+		ByReplayStrategy: zeroIntBuckets(prefixCacheReplayStrategies),
+	}
 	if r == nil {
 		return status
 	}
@@ -31,6 +44,61 @@ func (r *Registry) PrefixCacheProtocolStatus() PrefixCacheProtocolStatus {
 				}
 			}
 		}
+		loaded := loadedProviderModelsLocked(provider)
+		for modelID, modelStatus := range provider.PrefixCacheStatuses {
+			loaded[modelID] = struct{}{}
+			status.ReportedLoadedModels++
+			status.ByState[modelStatus.State]++
+			status.ByReason[modelStatus.Reason]++
+			status.ByBackend[modelStatus.Backend]++
+			status.ByReplayStrategy[modelStatus.ReplayStrategy]++
+			if modelStatus.State != "ready" {
+				status.ExcludedModels++
+			}
+		}
+		if provider.PrefixCacheStatusReported {
+			for modelID := range loaded {
+				if _, reported := provider.PrefixCacheStatuses[modelID]; !reported {
+					status.UnreportedLoadedModels++
+				}
+			}
+		} else {
+			status.UnreportedLoadedModels += len(loaded)
+		}
+		status.LoadedModels += len(loaded)
 	})
 	return status
+}
+
+func zeroIntBuckets(values []string) map[string]int {
+	result := make(map[string]int, len(values))
+	for _, value := range values {
+		result[value] = 0
+	}
+	return result
+}
+
+func loadedProviderModelsLocked(provider *Provider) map[string]struct{} {
+	loaded := make(map[string]struct{})
+	if provider.BackendCapacity != nil {
+		for _, slot := range provider.BackendCapacity.Slots {
+			if slot.Model == "" {
+				continue
+			}
+			switch slot.State {
+			case "idle", "running", "reloading", "crashed":
+				loaded[slot.Model] = struct{}{}
+			}
+		}
+		return loaded
+	}
+	for _, modelID := range provider.WarmModels {
+		if modelID != "" {
+			loaded[modelID] = struct{}{}
+		}
+	}
+	if provider.CurrentModel != "" {
+		loaded[provider.CurrentModel] = struct{}{}
+	}
+	return loaded
 }

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -2785,9 +2785,9 @@ func (r *Registry) Register(id string, conn *websocket.Conn, msg *protocol.Regis
 
 	models := msg.Models
 	modelInventory, _ := uniqueProviderModels(models)
-	cacheStatuses, cacheStatusReported, _ := validatePrefixCacheStatuses(
-		msg.PrefixCacheStatuses, modelInventory, nil)
-	cacheDonationOutcomes, _ := validatePrefixCacheDonationOutcomes(
+	cacheStatuses, cacheStatusReported := sanitizePrefixCacheStatuses(
+		msg.PrefixCacheStatuses, modelInventory)
+	cacheDonationOutcomes := sanitizePrefixCacheDonationOutcomes(
 		msg.PrefixCacheDonationOutcomes)
 
 	// Validate X25519 public key if provided.

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -530,6 +530,14 @@ type Provider struct {
 	// PrefixCacheV2Models is the validated, connection-scoped capability set
 	// keyed by concrete model ID. It is authoritative for v2 receipt identity.
 	PrefixCacheV2Models map[string]protocol.PrefixCacheV2Capability
+	// PrefixCacheStatuses is the optional, validated, connection-scoped status
+	// snapshot for concrete loaded model slots. Reported distinguishes current
+	// providers that authoritatively sent [] from old providers that omit it.
+	PrefixCacheStatuses       map[string]protocol.PrefixCacheModelStatus
+	PrefixCacheStatusReported bool
+	// PrefixCacheDonationOutcomes is the last cumulative process-local
+	// snapshot. Heartbeats contribute only monotonic deltas to central totals.
+	PrefixCacheDonationOutcomes map[string]uint64
 	// ToolConstraintProtocol advertises inference-time tool grammar support.
 	// ToolConstraintModels is the explicit concrete-model allowlist; required,
 	// named, and none choices never route by binary version inference alone.
@@ -2145,13 +2153,13 @@ func (r *Registry) mergeProviderModels(
 	}
 
 	p.mu.Lock()
-	defer p.mu.Unlock()
 	// present tracks only builds that passed validation and were merged — the
 	// hard-swap drop is derived from THIS set, never from the raw message. A
 	// desired build rejected for a bad weight hash therefore does NOT cause its
 	// previous sibling to be dropped (which would strand the provider on neither
 	// build — the exact failure the hash check exists to prevent).
 	present := make(map[string]struct{}, len(models))
+	cacheStateInvalidated := make(map[string]struct{})
 	for _, m := range models {
 		if m.ID == "" {
 			continue
@@ -2180,6 +2188,12 @@ func (r *Registry) mergeProviderModels(
 		replaced := false
 		for i := range p.Models {
 			if p.Models[i].ID == m.ID {
+				if !strings.EqualFold(p.Models[i].WeightHash, m.WeightHash) {
+					delete(p.PrefixCacheStatuses, m.ID)
+					delete(p.PrefixCacheV2Models, m.ID)
+					p.prefixCacheRevision++
+					cacheStateInvalidated[m.ID] = struct{}{}
+				}
 				p.Models[i] = m
 				replaced = true
 				break
@@ -2229,11 +2243,27 @@ func (r *Registry) mergeProviderModels(
 					"provider_id", providerID, "model_id", m.ID)
 				dropped = append(dropped, m.ID)
 				delete(p.ToolConstraintModels, m.ID)
+				delete(p.PrefixCacheStatuses, m.ID)
+				delete(p.PrefixCacheV2Models, m.ID)
+				p.prefixCacheRevision++
+				cacheStateInvalidated[m.ID] = struct{}{}
 				continue
 			}
 			kept = append(kept, m)
 		}
 		p.Models = kept
+	}
+	p.mu.Unlock()
+	if len(cacheStateInvalidated) > 0 {
+		r.mu.RLock()
+		tracker := r.cacheRouting
+		r.mu.RUnlock()
+		if tracker != nil {
+			for modelID := range cacheStateInvalidated {
+				tracker.invalidateProviderModel(
+					providerID, modelID, cacheHolderRemovalCapabilityChange)
+			}
+		}
 	}
 	return merged, dropped
 }
@@ -2754,6 +2784,11 @@ func (r *Registry) Register(id string, conn *websocket.Conn, msg *protocol.Regis
 	}
 
 	models := msg.Models
+	modelInventory, _ := uniqueProviderModels(models)
+	cacheStatuses, cacheStatusReported, _ := validatePrefixCacheStatuses(
+		msg.PrefixCacheStatuses, modelInventory, nil)
+	cacheDonationOutcomes, _ := validatePrefixCacheDonationOutcomes(
+		msg.PrefixCacheDonationOutcomes)
 
 	// Validate X25519 public key if provided.
 	// Reject invalid keys at registration rather than failing at encryption time.
@@ -2770,35 +2805,38 @@ func (r *Registry) Register(id string, conn *websocket.Conn, msg *protocol.Regis
 	}
 
 	p := &Provider{
-		ID:                      id,
-		Hardware:                msg.Hardware,
-		Models:                  models,
-		Backend:                 msg.Backend,
-		PublicKey:               pubKey,
-		EncryptedResponseChunks: msg.EncryptedResponseChunks,
-		PrivateOnly:             msg.PrivateOnly,
-		APNsDeviceToken:         msg.APNsDeviceToken,
-		APNsEnvironment:         msg.APNsEnvironment,
-		PrefillTPS:              msg.PrefillTPS,
-		DecodeTPS:               msg.DecodeTPS,
-		PrefixCacheProtocol:     msg.PrefixCacheProtocol,
-		PrefixCacheV2Models:     prefixCacheV2CapabilityMap(msg.PrefixCacheV2Models),
-		ToolConstraintProtocol:  msg.ToolConstraintProtocol,
-		ToolConstraintModels:    toolConstraintModelSet(msg.ToolConstraintModels, msg.Models),
-		TrustLevel:              TrustNone,
-		RuntimeVerified:         true,  // default to verified; API layer sets false when manifest check fails
-		RuntimeManifestChecked:  true,  // default to true; API layer sets false when no manifest is configured
-		ChallengeVerifiedSIP:    false, // starts false; set true by attestation challenge handler after SIP check
-		PrivacyCapabilities:     msg.PrivacyCapabilities,
-		TemplateHashes:          CloneStringMap(msg.TemplateHashes),
-		Status:                  StatusOnline,
-		Conn:                    conn,
-		writer:                  newProviderWriter(conn),
-		LastHeartbeat:           time.Now(),
-		Reputation:              NewReputation(),
-		pendingReqs:             make(map[string]*PendingRequest),
-		challengeSettled:        make(chan struct{}, 1),
-		registry:                r,
+		ID:                          id,
+		Hardware:                    msg.Hardware,
+		Models:                      models,
+		Backend:                     msg.Backend,
+		PublicKey:                   pubKey,
+		EncryptedResponseChunks:     msg.EncryptedResponseChunks,
+		PrivateOnly:                 msg.PrivateOnly,
+		APNsDeviceToken:             msg.APNsDeviceToken,
+		APNsEnvironment:             msg.APNsEnvironment,
+		PrefillTPS:                  msg.PrefillTPS,
+		DecodeTPS:                   msg.DecodeTPS,
+		PrefixCacheProtocol:         msg.PrefixCacheProtocol,
+		PrefixCacheV2Models:         prefixCacheV2CapabilityMap(msg.PrefixCacheV2Models),
+		PrefixCacheStatuses:         cacheStatuses,
+		PrefixCacheStatusReported:   cacheStatusReported,
+		PrefixCacheDonationOutcomes: cacheDonationOutcomes,
+		ToolConstraintProtocol:      msg.ToolConstraintProtocol,
+		ToolConstraintModels:        toolConstraintModelSet(msg.ToolConstraintModels, msg.Models),
+		TrustLevel:                  TrustNone,
+		RuntimeVerified:             true,  // default to verified; API layer sets false when manifest check fails
+		RuntimeManifestChecked:      true,  // default to true; API layer sets false when no manifest is configured
+		ChallengeVerifiedSIP:        false, // starts false; set true by attestation challenge handler after SIP check
+		PrivacyCapabilities:         msg.PrivacyCapabilities,
+		TemplateHashes:              CloneStringMap(msg.TemplateHashes),
+		Status:                      StatusOnline,
+		Conn:                        conn,
+		writer:                      newProviderWriter(conn),
+		LastHeartbeat:               time.Now(),
+		Reputation:                  NewReputation(),
+		pendingReqs:                 make(map[string]*PendingRequest),
+		challengeSettled:            make(chan struct{}, 1),
+		registry:                    r,
 	}
 
 	// Connection-scope the challenge-settled signal (DAR-326 FIX 4c): the channel is
@@ -3802,7 +3840,7 @@ func (r *Registry) Disconnect(id string) {
 	r.drainQueuedRequestsForModels(disconnectedModels)
 	// Cache holders and nonce-bound attempts are connection-scoped. Clear them
 	// after releasing registry/provider locks.
-	r.cacheRouting.disconnect(id)
+	r.cacheRouting.disconnect(id, cacheHolderRemovalDisconnect)
 
 	// Close all pending request channels so consumers get errors. Pending
 	// requests created by tests may leave these channels nil, and consumer

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -2253,6 +2253,13 @@ func (r *Registry) mergeProviderModels(
 		}
 		p.Models = kept
 	}
+	p.PrefixCacheStatuses, p.PrefixCacheStatusReported =
+		reconcilePrefixCacheStatuses(
+			p.PrefixCacheProtocol,
+			p.PrefixCacheV2Models,
+			p.PrefixCacheStatuses,
+			p.PrefixCacheStatusReported,
+		)
 	p.mu.Unlock()
 	if len(cacheStateInvalidated) > 0 {
 		r.mu.RLock()
@@ -2789,6 +2796,13 @@ func (r *Registry) Register(id string, conn *websocket.Conn, msg *protocol.Regis
 		msg.PrefixCacheStatuses, modelInventory)
 	cacheDonationOutcomes := sanitizePrefixCacheDonationOutcomes(
 		msg.PrefixCacheDonationOutcomes)
+	cacheCapabilities := prefixCacheV2CapabilityMap(msg.PrefixCacheV2Models)
+	cacheStatuses, cacheStatusReported = reconcilePrefixCacheStatuses(
+		msg.PrefixCacheProtocol,
+		cacheCapabilities,
+		cacheStatuses,
+		cacheStatusReported,
+	)
 
 	// Validate X25519 public key if provided.
 	// Reject invalid keys at registration rather than failing at encryption time.
@@ -2817,7 +2831,7 @@ func (r *Registry) Register(id string, conn *websocket.Conn, msg *protocol.Regis
 		PrefillTPS:                  msg.PrefillTPS,
 		DecodeTPS:                   msg.DecodeTPS,
 		PrefixCacheProtocol:         msg.PrefixCacheProtocol,
-		PrefixCacheV2Models:         prefixCacheV2CapabilityMap(msg.PrefixCacheV2Models),
+		PrefixCacheV2Models:         cacheCapabilities,
 		PrefixCacheStatuses:         cacheStatuses,
 		PrefixCacheStatusReported:   cacheStatusReported,
 		PrefixCacheDonationOutcomes: cacheDonationOutcomes,

--- a/docs/architecture/cache-aware-routing.md
+++ b/docs/architecture/cache-aware-routing.md
@@ -142,13 +142,14 @@ concrete loaded model slot. The coordinator publishes only counts by
 loaded totals. This makes a v1 slot attributable without exposing the model:
 
 - state: `ready`, `pending`, `disabled`, or `error`;
-- reasons: `ready`, `config_disabled`, `no_loaded_slot`,
-  `weight_hash_unavailable`, `runtime_identity_unavailable`,
+- reasons: `ready`, `config_disabled`, `weight_hash_unavailable`,
+  `runtime_identity_unavailable`,
   `unsupported_layout`, `unsupported_backend`,
   `paged_hybrid_unsupported`, `scan_pending`, `scan_failed`,
   `disk_unavailable`, or `cache_init_failed`;
 - backend: `contiguous`, `paged`, or `unknown`;
-- replay strategy: `direct`, `frozen_full`, `none`, or `unknown`.
+- replay strategy: `direct`, `frozen_full`, `tail_replay`, `none`, or
+  `unknown`.
 
 Old providers omit the field and contribute only to
 `unreported_loaded_models`; omission is never interpreted as a reason.
@@ -165,6 +166,16 @@ status; a dropped donation snapshot preserves the prior monotonic counter
 baseline. Field omission preserves the prior mixed-version behavior.
 Authoritative `prefix_cache_v2_models` validation remains strict and can still
 reject registration or quarantine malformed routing evidence.
+Because statuses describe loaded slots, there is no unloaded-slot reason. A
+`ready/ready` status is retained only when the same resulting snapshot has a
+v2 capability for that concrete model, a concrete backend
+(`contiguous|paged`), and a supported replay strategy
+(`direct|frozen_full|tail_replay`). Conversely, once a provider has supplied
+the optional status field, every v2 capability must have exactly one matching
+ready status. Registration, heartbeat capability/status replacement, and model
+updates reconcile these views under one provider lock. Contradictory optional
+status becomes unreported; routing capability is never weakened. Providers that
+omit the optional field retain backward-compatible v2 capability behavior.
 Provider SSD donation opportunities are cumulative fixed-enum counters, and
 holder additions/removals are counted by `ttl`, `disconnect`, `epoch_change`,
 `capability_change`, `miss_invalidation`, or `capacity_eviction`. The response

--- a/docs/architecture/cache-aware-routing.md
+++ b/docs/architecture/cache-aware-routing.md
@@ -135,14 +135,34 @@ tags only.
 lifecycle counters; sidecar enabled/running/ready, child generation, categorical
 restart reason, failure streak, timeouts/overloads/RSS, cold/warm contract loads,
 and planner outcomes; preload generation/counts; prompt artifact
-ready/pending/failed counts; protocol 0/1/2 provider counts; ready v2
-provider-model count; and bounded holder/attempt counts. It never includes model
-IDs, provider IDs, accounts, scopes, prompts, tokens, or chain hashes.
+ready/pending/failed counts; protocol 0/1/2 provider counts; and bounded
+holder/attempt counts. Current providers also report one bounded status for each
+concrete loaded model slot. The coordinator publishes only counts by
+`state`, `reason`, `backend`, and `replay_strategy`, plus reported/unreported
+loaded totals. This makes a v1 slot attributable without exposing the model:
+
+- state: `ready`, `pending`, `disabled`, or `error`;
+- reasons: `ready`, `config_disabled`, `no_loaded_slot`,
+  `weight_hash_unavailable`, `runtime_identity_unavailable`,
+  `unsupported_layout`, `unsupported_backend`,
+  `paged_hybrid_unsupported`, `scan_pending`, `scan_failed`,
+  `disk_unavailable`, or `cache_init_failed`;
+- backend: `contiguous`, `paged`, or `unknown`;
+- replay strategy: `direct`, `frozen_full`, `none`, or `unknown`.
+
+Old providers omit the field and contribute only to
+`unreported_loaded_models`; omission is never interpreted as a reason.
+Provider SSD donation opportunities are cumulative fixed-enum counters, and
+holder additions/removals are counted by `ttl`, `disconnect`, `epoch_change`,
+`capability_change`, `miss_invalidation`, or `capacity_eviction`. The response
+never includes model IDs, provider IDs, accounts, scopes, paths, hashes, epochs,
+prompts, token IDs, request IDs, or cache keys.
 The response and gauge projection are implemented in
 `coordinator/api/exact_cache_status.go` and `exact_cache_metrics.go`; bounded artifact aggregation lives in
-`coordinator/promptcontract/provisioner.go:Counts`, protocol distribution in
-`coordinator/registry/cache_status.go:PrefixCacheProtocolStatus`, and holder /
-attempt counts in `coordinator/registry/cache_routing.go:CacheRoutingStateCounts`.
+`coordinator/promptcontract/provisioner.go:Counts`, protocol/eligibility
+aggregation in `coordinator/registry/cache_status.go:PrefixCacheProtocolStatus`,
+and holder/attempt lifecycle counts in
+`coordinator/registry/cache_routing.go`.
 
 For each selected hint, terminal correlation stays on the in-memory
 `PendingRequest` and emits bounded tags:
@@ -190,6 +210,12 @@ as protocol-v2 models only after SSD scan readiness
 `provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClient+Registration.swift:27-36`);
 paged hybrid slots remain v1/cold
 (`provider-swift/Sources/ProviderCore/Inference/PrefixCachePolicy.swift:110-129`).
+Registration and every current-provider heartbeat carry an optional
+`prefix_cache_statuses` replacement snapshot and cumulative
+`prefix_cache_donation_outcomes`. An explicit empty status array clears the
+connection's prior snapshot; absence preserves mixed-version compatibility.
+Model removal, unload heartbeats, capability changes, and disconnects remove
+connection-scoped status/evidence so stale slots cannot remain in aggregates.
 Production activation is still a separate operational decision:
 positive durable-hit evidence, stable correlation telemetry, healthy prompt
 artifacts, routing-mode enablement, and a separately provisioned 256-bit cache

--- a/docs/architecture/cache-aware-routing.md
+++ b/docs/architecture/cache-aware-routing.md
@@ -152,6 +152,19 @@ loaded totals. This makes a v1 slot attributable without exposing the model:
 
 Old providers omit the field and contribute only to
 `unreported_loaded_models`; omission is never interpreted as a reason.
+These fields are optional observability, never provider-admission policy.
+Status model IDs are checked only against that provider's advertised inventory;
+owner-local/off-catalog models are valid. Unknown future enum values, invalid
+state/reason tuples, unadvertised status models, unknown donation outcomes, and
+invalid counts drop only the affected entry while known entries still
+aggregate. To keep processing bounded and ambiguity-free, an array beyond its
+fixed cap (16 statuses or 13 outcomes), duplicate model/outcome keys, or a
+blank/non-canonical status model ID drops that whole optional snapshot.
+A dropped/present status snapshot becomes authoritative empty and clears stale
+status; a dropped donation snapshot preserves the prior monotonic counter
+baseline. Field omission preserves the prior mixed-version behavior.
+Authoritative `prefix_cache_v2_models` validation remains strict and can still
+reject registration or quarantine malformed routing evidence.
 Provider SSD donation opportunities are cumulative fixed-enum counters, and
 holder additions/removals are counted by `ttl`, `disconnect`, `epoch_change`,
 `capability_change`, `miss_invalidation`, or `capacity_eviction`. The response
@@ -214,6 +227,8 @@ Registration and every current-provider heartbeat carry an optional
 `prefix_cache_statuses` replacement snapshot and cumulative
 `prefix_cache_donation_outcomes`. An explicit empty status array clears the
 connection's prior snapshot; absence preserves mixed-version compatibility.
+Unsupported future observability is sanitized under the non-fatal rules above;
+it never closes registration.
 Model removal, unload heartbeats, capability changes, and disconnects remove
 connection-scoped status/evidence so stale slots cannot remain in aggregates.
 Production activation is still a separate operational decision:

--- a/docs/architecture/cache-aware-routing.md
+++ b/docs/architecture/cache-aware-routing.md
@@ -159,8 +159,10 @@ owner-local/off-catalog models are valid. Unknown future enum values, invalid
 state/reason tuples, unadvertised status models, unknown donation outcomes, and
 invalid counts drop only the affected entry while known entries still
 aggregate. To keep processing bounded and ambiguity-free, an array beyond its
-fixed cap (16 statuses or 13 outcomes), duplicate model/outcome keys, or a
-blank/non-canonical status model ID drops that whole optional snapshot.
+fixed cap (16 statuses or 32 raw outcome entries), duplicate model/outcome
+keys, or a blank/non-canonical status model ID drops that whole optional
+snapshot. Donation aggregation still has exactly 13 known buckets; the raw cap
+reserves 19 entries for future outcomes, which are filtered individually.
 A dropped/present status snapshot becomes authoritative empty and clears stale
 status; a dropped donation snapshot preserves the prior monotonic counter
 baseline. Field omission preserves the prior mixed-version behavior.

--- a/docs/operations/coordinator-deploy.md
+++ b/docs/operations/coordinator-deploy.md
@@ -99,7 +99,31 @@ Before changing `MODE=on`, require all of the following:
    generations, zero restarts, no preload failures, no planning timeout/overload
    loop, and a stable RSS plateau below the configured memory limit. The
    recorded child generation and restart reason must make any later restart
-   attributable.
+   attributable. Under `providers`, require
+   `loaded_models == reported_loaded_models`,
+   `unreported_loaded_models == 0`, and inspect `by_reason` before treating
+   protocol-v1 capacity as a rollout-version problem.
+
+Interpret provider eligibility in this order:
+
+1. `scan_pending` is transient after load; sustained growth means scans are not
+   reaching readiness.
+2. `config_disabled`, `weight_hash_unavailable`,
+   `runtime_identity_unavailable`, `unsupported_layout`,
+   `unsupported_backend`, and `paged_hybrid_unsupported` are deterministic
+   exclusions. A binary-version upgrade alone does not make them ready.
+3. `scan_failed`, `disk_unavailable`, and `cache_init_failed` require provider
+   disk/key/cache initialization investigation.
+4. Donation outcomes explain durable-ready absence: policy/shape outcomes
+   (`below_effective_token_floor`, `no_complete_block`, `lossy_snapshot`,
+   `incomplete_layer_state`, `stage_size_exceeded`) differ from pressure/failure
+   outcomes (`write_rate_limited`, `write_queue_full`, `cache_closed`,
+   `disk_unavailable`, `write_failed`). `already_durable` is successful dedupe,
+   and `already_queued` means an earlier write for the same blocks is still in
+   flight; neither is a failed donation.
+5. Holder removals are expected under `ttl`, `disconnect`, `epoch_change`,
+   `capability_change`, `miss_invalidation`, and `capacity_eviction`; compare
+   their deltas before diagnosing unexplained holder loss.
 
 After a human changes `MODE=on`, hold the first stage at 1% and 1 plan/second.
 Require both a 30-minute clean window and at least 100 successful plans before
@@ -198,6 +222,8 @@ jq -e -n \
   ($e.lifecycle.ssd_misses - $s.lifecycle.ssd_misses) > 0 and
   ($e.lifecycle.ssd_donations - $s.lifecycle.ssd_donations) > 0 and
   ($e.lifecycle.ssd_hits - $s.lifecycle.ssd_hits) > 0 and
+  (($e.lifecycle.donation_outcomes.donated // 0) -
+   ($s.lifecycle.donation_outcomes.donated // 0)) > 0 and
   (($me.counters["exact_cache_cached_tokens_total{tier=ssd}"] // 0) -
    ($ms.counters["exact_cache_cached_tokens_total{tier=ssd}"] // 0)) > 0 and
   (($me.counters["exact_cache_prefill_tokens_saved_total{tier=ssd}"] // 0) -

--- a/docs/reference/ssd-kv-cache.md
+++ b/docs/reference/ssd-kv-cache.md
@@ -79,7 +79,9 @@ deltas, and exports aggregate outcomes through `/v1/cache/status`, Prometheus,
 and Datadog. Optional status/outcome fields are forward-compatible and
 non-fatal: unknown entries are dropped, structurally ambiguous/oversized
 snapshots are discarded within fixed bounds, and provider registration remains
-available. Routing capability fields remain independently strict.
+available. Donation input accepts at most 32 raw entries while aggregating only
+the 13 known outcomes, leaving fixed forward-version headroom without adding
+metric buckets. Routing capability fields remain independently strict.
 
 ## Environment variables
 

--- a/docs/reference/ssd-kv-cache.md
+++ b/docs/reference/ssd-kv-cache.md
@@ -53,7 +53,10 @@ weight identity, layout/backend support, disk setup, and initialization failures
 use the fixed reason vocabulary documented in
 [`cache-aware-routing.md`](../architecture/cache-aware-routing.md). A provider
 advertises exact protocol v2 only when at least one slot is actually ready; the
-status snapshot still explains every loaded v1 slot.
+status snapshot still explains every loaded v1 slot. Ready status and v2
+capability are published from one reconciled snapshot: ready requires a
+concrete backend and replay strategy, and each capability requires one ready
+status when optional telemetry is present. Unloaded models emit no status.
 
 Every call into the SSD donation path settles exactly one process-local outcome:
 
@@ -61,6 +64,12 @@ Every call into the SSD donation path settles exactly one process-local outcome:
 `lossy_snapshot`, `incomplete_layer_state`, `stage_size_exceeded`,
 `write_rate_limited`, `write_queue_full`, `already_durable`, `already_queued`,
 `cache_closed`, `disk_unavailable`, or `write_failed`.
+
+If cache teardown races a write already executing, a successful durable write
+is classified `cache_closed` for both correlated and uncorrelated donations
+because ready-receipt delivery can no longer complete. A real write failure
+remains `write_failed`; ordinary successful completion remains `donated`. The
+per-opportunity settlement box still records exactly one outcome.
 
 These are cumulative counters, not per-request events. The provider sends only
 the fixed enum and count. No model/request/provider identifier, path, token,

--- a/docs/reference/ssd-kv-cache.md
+++ b/docs/reference/ssd-kv-cache.md
@@ -43,6 +43,32 @@ hybrids, quantized rows, and unknown layouts fail cold. Eligible layouts persist
 a donation only when it also clears the configured effective-token floor. See
 [`ssd-kv-cache-hybrid-models.md`](./ssd-kv-cache-hybrid-models.md).
 
+## Eligibility and donation telemetry
+
+Each loaded provider slot produces a bounded `prefix_cache_statuses` entry from
+its actual cache-construction state. `ready` is emitted only after the startup
+disk scan and cache epoch are usable. Before that the slot is
+`pending/scan_pending`; scan failure is `error/scan_failed`. Configuration,
+weight identity, layout/backend support, disk setup, and initialization failures
+use the fixed reason vocabulary documented in
+[`cache-aware-routing.md`](../architecture/cache-aware-routing.md). A provider
+advertises exact protocol v2 only when at least one slot is actually ready; the
+status snapshot still explains every loaded v1 slot.
+
+Every call into the SSD donation path settles exactly one process-local outcome:
+
+`donated`, `below_effective_token_floor`, `no_complete_block`,
+`lossy_snapshot`, `incomplete_layer_state`, `stage_size_exceeded`,
+`write_rate_limited`, `write_queue_full`, `already_durable`, `already_queued`,
+`cache_closed`, `disk_unavailable`, or `write_failed`.
+
+These are cumulative counters, not per-request events. The provider sends only
+the fixed enum and count. No model/request/provider identifier, path, token,
+prompt, cache scope, hash, epoch, account, serial, or free-form error is retained
+or sent. The coordinator baselines registration, consumes monotonic heartbeat
+deltas, and exports aggregate outcomes through `/v1/cache/status`, Prometheus,
+and Datadog.
+
 ## Environment variables
 
 | Variable | Default | Meaning |

--- a/docs/reference/ssd-kv-cache.md
+++ b/docs/reference/ssd-kv-cache.md
@@ -67,7 +67,10 @@ the fixed enum and count. No model/request/provider identifier, path, token,
 prompt, cache scope, hash, epoch, account, serial, or free-form error is retained
 or sent. The coordinator baselines registration, consumes monotonic heartbeat
 deltas, and exports aggregate outcomes through `/v1/cache/status`, Prometheus,
-and Datadog.
+and Datadog. Optional status/outcome fields are forward-compatible and
+non-fatal: unknown entries are dropped, structurally ambiguous/oversized
+snapshots are discarded within fixed bounds, and provider registration remains
+available. Routing capability fields remain independently strict.
 
 ## Environment variables
 

--- a/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClient+Registration.swift
+++ b/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClient+Registration.swift
@@ -33,7 +33,9 @@ extension CoordinatorClient {
             modelWeightHashOverrides: modelWeightHashOverrides,
             prefixCacheProtocol: prefixCache.protocolVersion,
             prefixCacheV2Models: prefixCache.protocolVersion == 2
-                ? prefixCache.models : nil
+                ? prefixCache.models : nil,
+            prefixCacheStatuses: prefixCache.statuses,
+            prefixCacheDonationOutcomes: prefixCache.donationOutcomes
         )
         guard let jsonString = String(data: jsonData, encoding: .utf8) else {
             throw CoordinatorError.encodingFailed
@@ -102,7 +104,9 @@ extension CoordinatorClient {
             apnsEnvironment: effectiveEnv,
             prefixCacheProtocol: prefixCache.protocolVersion,
             prefixCacheV2Models: prefixCache.protocolVersion == 2
-                ? prefixCache.models : nil
+                ? prefixCache.models : nil,
+            prefixCacheStatuses: prefixCache.statuses,
+            prefixCacheDonationOutcomes: prefixCache.donationOutcomes
         )
 
         do {

--- a/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClientCodec.swift
+++ b/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClientCodec.swift
@@ -12,7 +12,9 @@ public enum CoordinatorClientCodec {
         apnsDeviceTokenOverride: String? = nil,
         modelWeightHashOverrides: [String: String]? = nil,
         prefixCacheProtocol: Int = 1,
-        prefixCacheV2Models: [PrefixCacheV2Capability]? = nil
+        prefixCacheV2Models: [PrefixCacheV2Capability]? = nil,
+        prefixCacheStatuses: [PrefixCacheModelStatus]? = nil,
+        prefixCacheDonationOutcomes: [PrefixCacheDonationOutcomeCount]? = nil
     ) -> ProviderMessage {
         // A token that arrived after the config was built (APNs slow at startup)
         // overrides the config value so a reconnect re-registers WITH it.
@@ -55,6 +57,8 @@ public enum CoordinatorClientCodec {
             apnsEnvironment: effectiveEnv,
             prefixCacheProtocol: prefixCacheProtocol,
             prefixCacheV2Models: prefixCacheV2Models,
+            prefixCacheStatuses: prefixCacheStatuses,
+            prefixCacheDonationOutcomes: prefixCacheDonationOutcomes,
             toolConstraintProtocol: constrainedModels.isEmpty ? nil : 1,
             toolConstraintModels: constrainedModels.isEmpty ? nil : constrainedModels
         ))
@@ -68,7 +72,9 @@ public enum CoordinatorClientCodec {
         apnsDeviceTokenOverride: String? = nil,
         modelWeightHashOverrides: [String: String]? = nil,
         prefixCacheProtocol: Int = 1,
-        prefixCacheV2Models: [PrefixCacheV2Capability]? = nil
+        prefixCacheV2Models: [PrefixCacheV2Capability]? = nil,
+        prefixCacheStatuses: [PrefixCacheModelStatus]? = nil,
+        prefixCacheDonationOutcomes: [PrefixCacheDonationOutcomeCount]? = nil
     ) throws -> Data {
         try ProviderProtocolCodec.encodeProviderMessage(
             registrationMessage(
@@ -79,7 +85,9 @@ public enum CoordinatorClientCodec {
                 apnsDeviceTokenOverride: apnsDeviceTokenOverride,
                 modelWeightHashOverrides: modelWeightHashOverrides,
                 prefixCacheProtocol: prefixCacheProtocol,
-                prefixCacheV2Models: prefixCacheV2Models
+                prefixCacheV2Models: prefixCacheV2Models,
+                prefixCacheStatuses: prefixCacheStatuses,
+                prefixCacheDonationOutcomes: prefixCacheDonationOutcomes
             )
         )
     }
@@ -94,7 +102,9 @@ public enum CoordinatorClientCodec {
         apnsDeviceToken: String? = nil,
         apnsEnvironment: String? = nil,
         prefixCacheProtocol: Int? = nil,
-        prefixCacheV2Models: [PrefixCacheV2Capability]? = nil
+        prefixCacheV2Models: [PrefixCacheV2Capability]? = nil,
+        prefixCacheStatuses: [PrefixCacheModelStatus]? = nil,
+        prefixCacheDonationOutcomes: [PrefixCacheDonationOutcomeCount]? = nil
     ) -> ProviderMessage {
         .heartbeat(ProviderMessage.Heartbeat(
             status: status,
@@ -106,7 +116,9 @@ public enum CoordinatorClientCodec {
             apnsDeviceToken: apnsDeviceToken,
             apnsEnvironment: apnsEnvironment,
             prefixCacheProtocol: prefixCacheProtocol,
-            prefixCacheV2Models: prefixCacheV2Models
+            prefixCacheV2Models: prefixCacheV2Models,
+            prefixCacheStatuses: prefixCacheStatuses,
+            prefixCacheDonationOutcomes: prefixCacheDonationOutcomes
         ))
     }
 

--- a/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClientState.swift
+++ b/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClientState.swift
@@ -141,6 +141,8 @@ public final class ProviderState: @unchecked Sendable {
     private var _currentModelHash: String? = nil
     private var _backendCapacity: BackendCapacity? = nil
     private var _prefixCacheV2Sources: [String: SSDPrefixCache] = [:]
+    private var _prefixCacheStatuses: [PrefixCacheModelStatus] = []
+    private var _prefixCacheRuntimeIdentityAvailable = true
 
     public init() {}
 
@@ -169,18 +171,54 @@ public final class ProviderState: @unchecked Sendable {
         set { lock.withLock { _backendCapacity = newValue } }
     }
 
-    func setPrefixCacheV2Sources(_ sources: [String: SSDPrefixCache]) {
-        lock.withLock { _prefixCacheV2Sources = sources }
+    func setPrefixCacheSnapshot(
+        sources: [String: SSDPrefixCache],
+        statuses: [PrefixCacheModelStatus],
+        runtimeIdentityAvailable: Bool
+    ) {
+        lock.withLock {
+            _prefixCacheV2Sources = sources
+            _prefixCacheStatuses = statuses
+            _prefixCacheRuntimeIdentityAvailable = runtimeIdentityAvailable
+        }
     }
 
     func prefixCacheV2Advertisement() -> (
         protocolVersion: Int,
-        models: [PrefixCacheV2Capability]
+        models: [PrefixCacheV2Capability],
+        statuses: [PrefixCacheModelStatus],
+        donationOutcomes: [PrefixCacheDonationOutcomeCount]
     ) {
-        let sources = lock.withLock { _prefixCacheV2Sources }
-        let models = sources.values.compactMap { $0.prefixCacheV2Capability() }
-            .sorted { $0.modelId < $1.modelId }
-        return (models.isEmpty ? 1 : 2, models)
+        let snapshot = lock.withLock {
+            (
+                sources: _prefixCacheV2Sources,
+                statuses: _prefixCacheStatuses,
+                runtimeIdentityAvailable: _prefixCacheRuntimeIdentityAvailable
+            )
+        }
+        let sources = snapshot.sources
+        var models: [PrefixCacheV2Capability] = []
+        let statuses = snapshot.statuses.map { status in
+            let current: PrefixCacheModelStatus
+            if let source = sources[status.modelId] {
+                let advertisement = source.prefixCacheAdvertisement(base: status)
+                if let capability = advertisement.capability {
+                    models.append(capability)
+                }
+                current = advertisement.status
+            } else {
+                current = status
+            }
+            return snapshot.runtimeIdentityAvailable
+                ? current : current.withoutRuntimeIdentity()
+        }.sorted { $0.modelId < $1.modelId }
+        models.sort { $0.modelId < $1.modelId }
+        return (
+            models.isEmpty || !snapshot.runtimeIdentityAvailable ? 1 : 2,
+            models,
+            statuses,
+            PrefixCacheDonationTelemetry.shared.snapshot()
+        )
     }
 }
 

--- a/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClientState.swift
+++ b/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClientState.swift
@@ -198,7 +198,7 @@ public final class ProviderState: @unchecked Sendable {
         }
         let sources = snapshot.sources
         var models: [PrefixCacheV2Capability] = []
-        let statuses = snapshot.statuses.map { status in
+        var statuses = snapshot.statuses.map { status in
             let current: PrefixCacheModelStatus
             if let source = sources[status.modelId] {
                 let advertisement = source.prefixCacheAdvertisement(base: status)
@@ -212,6 +212,17 @@ public final class ProviderState: @unchecked Sendable {
             return snapshot.runtimeIdentityAvailable
                 ? current : current.withoutRuntimeIdentity()
         }.sorted { $0.modelId < $1.modelId }
+        if !snapshot.runtimeIdentityAvailable {
+            models.removeAll(keepingCapacity: true)
+        }
+        let capableModels = Set(models.map(\.modelId))
+        statuses = statuses.filter { status in
+            status.state != .ready ||
+                (status.isConcreteReady && capableModels.contains(status.modelId))
+        }
+        let readyModels = Set(
+            statuses.lazy.filter(\.isConcreteReady).map(\.modelId))
+        models.removeAll { !readyModels.contains($0.modelId) }
         models.sort { $0.modelId < $1.modelId }
         return (
             models.isEmpty || !snapshot.runtimeIdentityAvailable ? 1 : 2,

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge+PrefixCache.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge+PrefixCache.swift
@@ -170,6 +170,11 @@ public final class EngineV2RequestUsageSignal: @unchecked Sendable {
 
 extension EngineV2Bridge {
 
+    nonisolated func prefixCacheModelStatus() -> PrefixCacheModelStatus {
+        guard let ssdPrefixCache else { return prefixCacheBaseStatus }
+        return ssdPrefixCache.prefixCacheModelStatus(base: prefixCacheBaseStatus)
+    }
+
     func emitPrefixCacheColdFallback(
         requestId: String,
         reason: String,

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge.swift
@@ -120,6 +120,7 @@ public actor EngineV2Bridge {
     /// (`completeStaging`), and shutdown. nil means caching is disabled or
     /// SSD initialization was unavailable.
     nonisolated let ssdPrefixCache: SSDPrefixCache?
+    nonisolated let prefixCacheBaseStatus: PrefixCacheModelStatus
     nonisolated let prefixCacheEvidenceSequencer: PrefixCacheEvidenceSequencer?
     /// Periodic prefix-cache stats logger (v2 analog of the legacy
     /// checkpoint-tier logger). Started by the slot factory when an active
@@ -235,6 +236,7 @@ public actor EngineV2Bridge {
         kvBytesPerToken: Int = 0,
         kvBudget: GlobalKVCacheBudget? = nil,
         ssdPrefixCache: SSDPrefixCache? = nil,
+        prefixCacheStatus: PrefixCacheModelStatus? = nil,
         kvBackendKind: EngineV2KVBackendKind = .contiguous,
         emitTelemetry: (@Sendable (TelemetryEvent) -> Void)? = nil
     ) {
@@ -253,6 +255,12 @@ public actor EngineV2Bridge {
         self.kvBytesPerToken = kvBytesPerToken
         self.kvBudget = kvBudget
         self.ssdPrefixCache = ssdPrefixCache
+        self.prefixCacheBaseStatus = prefixCacheStatus ?? PrefixCacheModelStatus(
+            modelId: modelId,
+            backend: PrefixCacheStatusBackend(kvBackendKind),
+            replayStrategy: .unknown,
+            state: ssdPrefixCache == nil ? .disabled : .pending,
+            reason: ssdPrefixCache == nil ? .unsupportedBackend : .scanPending)
         self.prefixCacheEvidenceSequencer = ssdPrefixCache.map {
             PrefixCacheEvidenceSequencer(cache: $0)
         }

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Config.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Config.swift
@@ -134,6 +134,7 @@ public enum EngineV2Factory {
         kvBytesPerToken: Int = 0,
         kvBudget: GlobalKVCacheBudget? = nil,
         ssdPrefixCache: SSDPrefixCache? = nil,
+        prefixCacheStatus: PrefixCacheModelStatus? = nil,
         emitTelemetry: (@Sendable (TelemetryEvent) -> Void)? = nil,
         makeEngine: () throws -> EngineV2Factory.ProductionBuild
     ) throws -> EngineV2Bridge {
@@ -158,6 +159,7 @@ public enum EngineV2Factory {
                 // pre-submit staging hook + release backstops + shutdown
                 // over the SAME instance the engine holds as its cache.
                 ssdPrefixCache: ssdPrefixCache,
+                prefixCacheStatus: prefixCacheStatus,
                 kvBackendKind: build.kvBackendKind,
                 emitTelemetry: emitTelemetry
             )

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2SlotFactory.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2SlotFactory.swift
@@ -287,7 +287,13 @@ enum EngineV2SlotFactory {
         // family with no derivable kinds gets no cache (it would throw
         // unsupportedModel at engine build anyway).
         var ssdPrefixCache: SSDPrefixCache?
-        if makeEngineOverride == nil, PrefixCachePolicy.isEnabled(environment: environment) {
+        var cacheCapability: CBv2PrefixReuseCapability?
+        var cacheConstructionStatus = PrefixCacheConstructionStatus.configDisabled
+        let cacheConstructionStatusBox = PrefixCacheConstructionStatusBox()
+        if makeEngineOverride != nil {
+            cacheConstructionStatus = PrefixCacheConstructionStatus(
+                state: .disabled, reason: .unsupportedBackend)
+        } else if PrefixCachePolicy.isEnabled(environment: environment) {
             if let preparedBackend {
                 let ssdLayerKinds = preparedBackend.layerKinds
                 let resolvedSelection: EngineV2KVBackendSelection =
@@ -295,10 +301,15 @@ enum EngineV2SlotFactory {
                 let prefixReuseCapability = PrefixCachePolicy.prefixReuseCapability(
                     layerKinds: ssdLayerKinds,
                     backendSelection: resolvedSelection)
+                cacheCapability = prefixReuseCapability
                 if let promptContractID {
                     if let makePrefixCache = assemblyOverrides.makePrefixCache {
                         ssdPrefixCache = await makePrefixCache(
                             ssdLayerKinds, prefixReuseCapability)
+                        cacheConstructionStatus = ssdPrefixCache == nil
+                            ? PrefixCacheConstructionStatus(
+                                state: .error, reason: .cacheInitFailed)
+                            : .scanPending
                     } else {
                         ssdPrefixCache = await SSDPrefixCacheFactory.make(
                             modelId: modelId,
@@ -309,14 +320,23 @@ enum EngineV2SlotFactory {
                             kvBudget: kvBudget,
                             environment: environment,
                             onConstructionFailure: { failure in
+                                cacheConstructionStatusBox.record(
+                                    failure: failure, capability: prefixReuseCapability)
                                 Self.emitPrefixCacheConstructionFailure(
                                     modelId: modelId,
                                     capability: prefixReuseCapability,
                                     failure: failure,
                                     emitTelemetry: emitTelemetry)
                             })
+                        cacheConstructionStatus = ssdPrefixCache == nil
+                            ? (cacheConstructionStatusBox.snapshot
+                                ?? PrefixCacheConstructionStatus(
+                                    state: .error, reason: .cacheInitFailed))
+                            : .scanPending
                     }
                 } else {
+                    cacheConstructionStatus = PrefixCacheConstructionStatus(
+                        state: .error, reason: .cacheInitFailed)
                     Self.emitPrefixCacheConstructionFailure(
                         modelId: modelId,
                         capability: prefixReuseCapability,
@@ -330,6 +350,9 @@ enum EngineV2SlotFactory {
                 let unavailableCapability = PrefixCachePolicy.prefixReuseCapability(
                     layerKinds: [],
                     backendSelection: .contiguous)
+                cacheCapability = unavailableCapability
+                cacheConstructionStatus = PrefixCacheConstructionStatus(
+                    state: .disabled, reason: .unsupportedLayout)
                 Self.emitPrefixCacheConstructionFailure(
                     modelId: modelId,
                     capability: unavailableCapability,
@@ -341,6 +364,18 @@ enum EngineV2SlotFactory {
             }
         }
 
+        let cacheBackend: PrefixCacheStatusBackend
+        if let preparedBackend {
+            cacheBackend = preparedBackend.kind == .paged ? .paged : .contiguous
+        } else {
+            cacheBackend = .unknown
+        }
+        let prefixCacheStatus = PrefixCacheModelStatus(
+            modelId: modelId,
+            backend: cacheBackend,
+            replayStrategy: PrefixCacheReplayStrategy(cacheCapability),
+            state: cacheConstructionStatus.state,
+            reason: cacheConstructionStatus.reason)
         let enginePrefixCache: (any CBv2PrefixCache)? = ssdPrefixCache
 
         let makeEngine: () throws -> EngineV2Factory.ProductionBuild
@@ -400,6 +435,7 @@ enum EngineV2SlotFactory {
             // release backstops, and shutdown (closed by `makeBridge` on
             // an engine-init failure so background tasks never leak).
             ssdPrefixCache: ssdPrefixCache,
+            prefixCacheStatus: prefixCacheStatus,
             emitTelemetry: emitTelemetry,
             makeEngine: makeEngine)
 

--- a/provider-swift/Sources/ProviderCore/Inference/PrefixCacheEligibilityStatus.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/PrefixCacheEligibilityStatus.swift
@@ -1,0 +1,103 @@
+import Foundation
+import MLXLMCommon
+
+struct PrefixCacheConstructionStatus: Sendable {
+    let state: PrefixCacheStatusState
+    let reason: PrefixCacheStatusReason
+
+    static let configDisabled = PrefixCacheConstructionStatus(
+        state: .disabled, reason: .configDisabled)
+    static let scanPending = PrefixCacheConstructionStatus(
+        state: .pending, reason: .scanPending)
+}
+
+final class PrefixCacheConstructionStatusBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value: PrefixCacheConstructionStatus?
+
+    func record(
+        failure: SSDPrefixCacheConstructionFailure,
+        capability: CBv2PrefixReuseCapability
+    ) {
+        lock.withLock {
+            value = Self.status(failure: failure, capability: capability)
+        }
+    }
+
+    var snapshot: PrefixCacheConstructionStatus? {
+        lock.withLock { value }
+    }
+
+    private static func status(
+        failure: SSDPrefixCacheConstructionFailure,
+        capability: CBv2PrefixReuseCapability
+    ) -> PrefixCacheConstructionStatus {
+        switch failure {
+        case .missingWeightHash:
+            return PrefixCacheConstructionStatus(
+                state: .disabled, reason: .weightHashUnavailable)
+        case .unsupportedPlan:
+            let reason: PrefixCacheStatusReason
+            if capability.unsupportedReason?.rawValue == "paged_hybrid_requires_dual_cursor" {
+                reason = .pagedHybridUnsupported
+            } else {
+                reason = .unsupportedLayout
+            }
+            return PrefixCacheConstructionStatus(state: .disabled, reason: reason)
+        case .layoutUnavailable:
+            return PrefixCacheConstructionStatus(
+                state: .disabled, reason: .unsupportedLayout)
+        case .unsafePath:
+            return PrefixCacheConstructionStatus(
+                state: .error, reason: .diskUnavailable)
+        case .keyUnavailable, .ephemeralKeyUnavailable, .blockContractMismatch,
+            .epochUnavailable, .promptContractUnavailable:
+            return PrefixCacheConstructionStatus(
+                state: .error, reason: .cacheInitFailed)
+        }
+    }
+}
+
+extension PrefixCacheStatusBackend {
+    init(_ backend: EngineV2KVBackendKind) {
+        switch backend {
+        case .contiguous:
+            self = .contiguous
+        case .paged:
+            self = .paged
+        }
+    }
+}
+
+extension PrefixCacheReplayStrategy {
+    init(_ capability: CBv2PrefixReuseCapability?) {
+        guard let capability else {
+            self = .unknown
+            return
+        }
+        guard capability.isSupported else {
+            self = .none
+            return
+        }
+        switch capability.strategy?.rawValue {
+        case "direct":
+            self = .direct
+        case "frozen_full_replay":
+            self = .frozenFull
+        default:
+            self = .unknown
+        }
+    }
+}
+
+extension PrefixCacheModelStatus {
+    func withoutRuntimeIdentity() -> PrefixCacheModelStatus {
+        guard state == .ready || state == .pending else { return self }
+        return PrefixCacheModelStatus(
+            modelId: modelId,
+            backend: backend,
+            replayStrategy: replayStrategy,
+            state: .disabled,
+            reason: .runtimeIdentityUnavailable)
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Inference/PrefixCacheEligibilityStatus.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/PrefixCacheEligibilityStatus.swift
@@ -84,6 +84,8 @@ extension PrefixCacheReplayStrategy {
             self = .direct
         case "frozen_full_replay":
             self = .frozenFull
+        case "tail_replay":
+            self = .tailReplay
         default:
             self = .unknown
         }
@@ -91,6 +93,18 @@ extension PrefixCacheReplayStrategy {
 }
 
 extension PrefixCacheModelStatus {
+    var isConcreteReady: Bool {
+        guard state == .ready, reason == .ready,
+            backend == .contiguous || backend == .paged
+        else { return false }
+        switch replayStrategy {
+        case .direct, .frozenFull, .tailReplay:
+            return true
+        case .none, .unknown:
+            return false
+        }
+    }
+
     func withoutRuntimeIdentity() -> PrefixCacheModelStatus {
         guard state == .ready || state == .pending else { return self }
         return PrefixCacheModelStatus(

--- a/provider-swift/Sources/ProviderCore/KVCacheSSD/BoundedSingleConsumerPipeline.swift
+++ b/provider-swift/Sources/ProviderCore/KVCacheSSD/BoundedSingleConsumerPipeline.swift
@@ -97,6 +97,7 @@ final class BoundedSingleConsumerPipeline<Payload: Sendable>: @unchecked Sendabl
     ///     consumer Task, one payload at a time.
     init(
         capacity: Int,
+        onDropped: (@Sendable (Payload) -> Void)? = nil,
         consume: @escaping @Sendable (Payload) async -> Void
     ) {
         let cap = max(1, capacity)
@@ -126,6 +127,8 @@ final class BoundedSingleConsumerPipeline<Payload: Sendable>: @unchecked Sendabl
                 // empties.
                 if !Task.isCancelled {
                     await consume(payload)
+                } else {
+                    onDropped?(payload)
                 }
                 state.completeOne()
             }

--- a/provider-swift/Sources/ProviderCore/KVCacheSSD/PrefixCacheDonationTelemetry.swift
+++ b/provider-swift/Sources/ProviderCore/KVCacheSSD/PrefixCacheDonationTelemetry.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+protocol PrefixCacheDonationRecording: Sendable {
+    func record(_ outcome: PrefixCacheDonationOutcome)
+}
+
+/// Process-lifetime, privacy-safe donation counters. Heartbeats publish only
+/// this fixed outcome vocabulary and monotonic counts; no model, request,
+/// account, provider, path, hash, or cache identity is retained.
+final class PrefixCacheDonationTelemetry: PrefixCacheDonationRecording, @unchecked Sendable {
+    static let shared = PrefixCacheDonationTelemetry()
+
+    private let lock = NSLock()
+    private var counts: [PrefixCacheDonationOutcome: UInt64] = [:]
+
+    func record(_ outcome: PrefixCacheDonationOutcome) {
+        lock.withLock {
+            let current = counts[outcome, default: 0]
+            counts[outcome] = current == .max ? .max : current + 1
+        }
+    }
+
+    func snapshot() -> [PrefixCacheDonationOutcomeCount] {
+        lock.withLock {
+            PrefixCacheDonationOutcome.allCases.compactMap { outcome in
+                guard let count = counts[outcome], count > 0 else { return nil }
+                return PrefixCacheDonationOutcomeCount(outcome: outcome, count: count)
+            }
+        }
+    }
+}
+
+/// A donation crosses synchronous extraction and asynchronous write-behind
+/// branches. This settlement box guarantees exactly one final outcome for the
+/// opportunity regardless of which branch terminates it.
+final class PrefixCacheDonationSettlement: @unchecked Sendable {
+    private let lock = NSLock()
+    private let recorder: any PrefixCacheDonationRecording
+    private var settled = false
+
+    init(recorder: any PrefixCacheDonationRecording) {
+        self.recorder = recorder
+    }
+
+    func settle(_ outcome: PrefixCacheDonationOutcome) {
+        let shouldRecord = lock.withLock {
+            guard !settled else { return false }
+            settled = true
+            return true
+        }
+        if shouldRecord {
+            recorder.record(outcome)
+        }
+    }
+}

--- a/provider-swift/Sources/ProviderCore/KVCacheSSD/SSDPrefixCache.swift
+++ b/provider-swift/Sources/ProviderCore/KVCacheSSD/SSDPrefixCache.swift
@@ -176,6 +176,7 @@ public final class SSDPrefixCache: CBv2PrefixCache, SSDEvictableStore, @unchecke
     let index: SSDBlockIndex
     private let kvBudget: GlobalKVCacheBudget?
     private let diskBudget: SSDDiskBudget
+    private let donationRecorder: any PrefixCacheDonationRecording
     let statsBox = SSDPrefixCacheStatsBox()
     private var writeBehind: SSDWriteBehind!
 
@@ -219,6 +220,8 @@ public final class SSDPrefixCache: CBv2PrefixCache, SSDEvictableStore, @unchecke
     private let lock = NSLock()
     private var closed = false
     private var scanReady = false
+    private var scanFailed = false
+    private var cacheStatusFailure: PrefixCacheStatusReason?
     private var destructiveChangeInProgress = false
     /// tag16 of the run's TERMINAL block → staged entry.
     private var stagedEntries: [Data: StagedEntry] = [:]
@@ -258,7 +261,8 @@ public final class SSDPrefixCache: CBv2PrefixCache, SSDEvictableStore, @unchecke
         strictFsync: Bool = false,
         diskBudgetBytes: @escaping @Sendable () -> Int,
         maintainWholeRoot: (@Sendable () -> Void)? = nil,
-        cacheInstanceNamespace: String = UUID().uuidString
+        cacheInstanceNamespace: String = UUID().uuidString,
+        donationRecorder: any PrefixCacheDonationRecording = PrefixCacheDonationTelemetry.shared
     ) {
         self.config = config
         self.kekKey = kekKey
@@ -267,6 +271,7 @@ public final class SSDPrefixCache: CBv2PrefixCache, SSDEvictableStore, @unchecke
         self.index = SSDBlockIndex()
         self.kvBudget = kvBudget
         self.diskBudget = diskBudget
+        self.donationRecorder = donationRecorder
         let root = config.root
         self.writeBehind = SSDWriteBehind(
             config: SSDWriteBehind.Config(
@@ -323,24 +328,67 @@ public final class SSDPrefixCache: CBv2PrefixCache, SSDEvictableStore, @unchecke
     var isClosed: Bool { lock.withLock { closed } }
 
     func prefixCacheV2Capability() -> PrefixCacheV2Capability? {
+        lock.withLock { prefixCacheV2CapabilityLocked() }
+    }
+
+    func prefixCacheModelStatus(base: PrefixCacheModelStatus) -> PrefixCacheModelStatus {
+        lock.withLock { prefixCacheModelStatusLocked(base: base) }
+    }
+
+    func prefixCacheAdvertisement(base: PrefixCacheModelStatus) -> (
+        capability: PrefixCacheV2Capability?,
+        status: PrefixCacheModelStatus
+    ) {
         lock.withLock {
-            guard !closed,
-                scanReady,
-                !destructiveChangeInProgress,
-                let epoch = config.epochStore?.current,
-                config.blockSize > 0,
-                config.blockSize <= Int(UInt32.max)
-            else { return nil }
-            return PrefixCacheV2Capability(
-                modelId: config.modelId,
-                modelAggregateHash: config.weightHash,
-                promptContractId: config.promptContractID,
-                blockHashVersion: CBv2BlockHasher.version,
-                blockSize: UInt32(config.blockSize),
-                cacheEpoch: epoch,
-                enabled: true,
-                ready: true)
+            (
+                prefixCacheV2CapabilityLocked(),
+                prefixCacheModelStatusLocked(base: base)
+            )
         }
+    }
+
+    private func prefixCacheV2CapabilityLocked() -> PrefixCacheV2Capability? {
+        guard !closed,
+            scanReady,
+            !destructiveChangeInProgress,
+            let epoch = config.epochStore?.current,
+            config.blockSize > 0,
+            config.blockSize <= Int(UInt32.max)
+        else { return nil }
+        return PrefixCacheV2Capability(
+            modelId: config.modelId,
+            modelAggregateHash: config.weightHash,
+            promptContractId: config.promptContractID,
+            blockHashVersion: CBv2BlockHasher.version,
+            blockSize: UInt32(config.blockSize),
+            cacheEpoch: epoch,
+            enabled: true,
+            ready: true)
+    }
+
+    private func prefixCacheModelStatusLocked(
+        base: PrefixCacheModelStatus
+    ) -> PrefixCacheModelStatus {
+        let status: (PrefixCacheStatusState, PrefixCacheStatusReason)
+        if closed {
+            status = (.error, .cacheInitFailed)
+        } else if scanFailed {
+            status = (.error, .scanFailed)
+        } else if let cacheStatusFailure {
+            status = (.error, cacheStatusFailure)
+        } else if !scanReady || destructiveChangeInProgress {
+            status = (.pending, .scanPending)
+        } else if config.epochStore != nil && config.epochStore?.current == nil {
+            status = (.error, .cacheInitFailed)
+        } else {
+            status = (.ready, .ready)
+        }
+        return PrefixCacheModelStatus(
+            modelId: base.modelId,
+            backend: base.backend,
+            replayStrategy: base.replayStrategy,
+            state: status.0,
+            reason: status.1)
     }
 
     func takeNextPrefixCacheV2Sequence(expectedEpoch: String) -> UInt64? {
@@ -358,6 +406,8 @@ public final class SSDPrefixCache: CBv2PrefixCache, SSDEvictableStore, @unchecke
             guard !closed else { return false }
             closed = true
             scanReady = false
+            scanFailed = false
+            cacheStatusFailure = nil
             // Release the PER-ENTRY reservations (each resident entry holds
             // exactly one, keyed by its creator). Attaching requests already
             // released their redundant provisional reservation at attach
@@ -621,7 +671,11 @@ public final class SSDPrefixCache: CBv2PrefixCache, SSDEvictableStore, @unchecke
     public func donate(
         tokens: [Int], state: [CBv2SequenceKV?], layerKinds: [CBv2LayerKind], cacheSalt: String?
     ) {
-        guard state.count == layerKinds.count else { return }
+        let settlement = PrefixCacheDonationSettlement(recorder: donationRecorder)
+        guard state.count == layerKinds.count else {
+            settlement.settle(.incompleteLayerState)
+            return
+        }
         var snapshots: [(keys: MLXArray, values: MLXArray, offset: Int)?] = []
         snapshots.reserveCapacity(layerKinds.count)
         for (i, kind) in layerKinds.enumerated() {
@@ -629,10 +683,19 @@ public final class SSDPrefixCache: CBv2PrefixCache, SSDEvictableStore, @unchecke
                 snapshots.append(nil)
                 continue
             }
-            guard seq.snapshotIsLossless else { return }  // quantized KV never donates
+            guard seq.snapshotIsLossless else {
+                settlement.settle(.lossySnapshot)
+                return
+            }
             snapshots.append(seq.snapshot())
         }
-        donate(tokens: tokens, snapshots: snapshots, layerKinds: layerKinds, cacheSalt: cacheSalt)
+        donate(
+            tokens: tokens,
+            snapshots: snapshots,
+            layerKinds: layerKinds,
+            cacheSalt: cacheSalt,
+            receiptRequestID: nil,
+            settlement: settlement)
     }
 
     public func donate(
@@ -650,12 +713,14 @@ public final class SSDPrefixCache: CBv2PrefixCache, SSDEvictableStore, @unchecke
         layerKinds: [CBv2LayerKind],
         cacheSalt: String?
     ) {
+        let settlement = PrefixCacheDonationSettlement(recorder: donationRecorder)
         donate(
             tokens: tokens,
             snapshots: snapshots,
             layerKinds: layerKinds,
             cacheSalt: cacheSalt,
-            receiptRequestID: requestID)
+            receiptRequestID: requestID,
+            settlement: settlement)
     }
 
     /// Runs on the engine's donation queue. The engine holds the donor KV
@@ -668,12 +733,14 @@ public final class SSDPrefixCache: CBv2PrefixCache, SSDEvictableStore, @unchecke
         snapshots: [(keys: MLXArray, values: MLXArray, offset: Int)?],
         layerKinds: [CBv2LayerKind], cacheSalt: String?
     ) {
+        let settlement = PrefixCacheDonationSettlement(recorder: donationRecorder)
         donate(
             tokens: tokens,
             snapshots: snapshots,
             layerKinds: layerKinds,
             cacheSalt: cacheSalt,
-            receiptRequestID: nil)
+            receiptRequestID: nil,
+            settlement: settlement)
     }
 
     private func donate(
@@ -681,13 +748,24 @@ public final class SSDPrefixCache: CBv2PrefixCache, SSDEvictableStore, @unchecke
         snapshots: [(keys: MLXArray, values: MLXArray, offset: Int)?],
         layerKinds: [CBv2LayerKind],
         cacheSalt: String?,
-        receiptRequestID: CBv2RequestID?
+        receiptRequestID: CBv2RequestID?,
+        settlement: PrefixCacheDonationSettlement
     ) {
-        guard !isClosed, snapshots.count == layerKinds.count else { return }
+        guard !isClosed else {
+            settlement.settle(.cacheClosed)
+            return
+        }
+        guard snapshots.count == layerKinds.count else {
+            settlement.settle(.incompleteLayerState)
+            return
+        }
         let salt = cacheSalt ?? ""
         let hasher = hasher(cacheSalt: salt)
         let blockCount = hasher.fullBlockCount(tokenCount: tokens.count)
-        guard blockCount > 0 else { return }
+        guard blockCount > 0 else {
+            settlement.settle(.noCompleteBlock)
+            return
+        }
         let prefixTokens = blockCount * config.blockSize
 
         // PER-DONATION gate (Gaj, 2026-07-07 — replaces the binary
@@ -704,7 +782,10 @@ public final class SSDPrefixCache: CBv2PrefixCache, SSDEvictableStore, @unchecke
         // model is effectively never cached, by construction.
         let (donationFloor, floorOverflow) =
             config.adoptionBoundTokens.addingReportingOverflow(config.minEffectiveTokens)
-        guard !floorOverflow, prefixTokens > donationFloor else { return }
+        guard !floorOverflow, prefixTokens > donationFloor else {
+            settlement.settle(.belowEffectiveTokenFloor)
+            return
+        }
 
         // Validate cacheable-layer coverage (PrefixCacheV2 semantics: a
         // cacheable layer with missing/short state makes the whole
@@ -716,10 +797,16 @@ public final class SSDPrefixCache: CBv2PrefixCache, SSDEvictableStore, @unchecke
                 snap.offset >= prefixTokens,
                 snap.keys.ndim == 4, snap.keys.dim(2) >= prefixTokens,
                 snap.values.ndim == 4, snap.values.dim(2) >= prefixTokens
-            else { return }
+            else {
+                settlement.settle(.incompleteLayerState)
+                return
+            }
             cacheable.append((i, snap.keys, snap.values))
         }
-        guard !cacheable.isEmpty else { return }
+        guard !cacheable.isEmpty else {
+            settlement.settle(.incompleteLayerState)
+            return
+        }
 
         // Chain hashes + HMAC tags; dedupe BEFORE any copy (spec §3.2).
         let hashes = hasher.chainHashes(tokens: tokens, maxBlocks: blockCount)
@@ -744,22 +831,28 @@ public final class SSDPrefixCache: CBv2PrefixCache, SSDEvictableStore, @unchecke
             let elements = dims.reduce(1, *)
             perBlockBytes += 2 * elements * layer.keys.dtype.size
         }
-        guard perBlockBytes > 0 else { return }
+        guard perBlockBytes > 0 else {
+            settlement.settle(.incompleteLayerState)
+            return
+        }
         let maxPersistBlocks = config.maxStageBytes / perBlockBytes
         let durableTags = Array(tags16.prefix(maxPersistBlocks))
         let durableFullTags = Array(fullTags.prefix(maxPersistBlocks))
         let durableChainHashes = Array(hashes.prefix(maxPersistBlocks))
         let (durableTokenCount, durableTokenOverflow) =
             durableTags.count.multipliedReportingOverflow(by: config.blockSize)
-        guard !durableTokenOverflow, durableTokenCount > donationFloor else { return }
-        let onDurable: (@Sendable () -> Void)?
+        guard !durableTokenOverflow, durableTokenCount > donationFloor else {
+            settlement.settle(.stageSizeExceeded)
+            return
+        }
+        let onDurable: (@Sendable () -> Bool)?
         if let receiptRequestID, !durableTags.isEmpty {
             onDurable = { [weak self] in
                 self?.settleDurableDonation(
                     requestID: receiptRequestID,
                     tags16: durableTags,
                     fullTags: durableFullTags,
-                    chainHashes: durableChainHashes)
+                    chainHashes: durableChainHashes) ?? false
             }
         } else {
             onDurable = nil
@@ -767,13 +860,26 @@ public final class SSDPrefixCache: CBv2PrefixCache, SSDEvictableStore, @unchecke
 
         let now = config.nowSeconds()
         var newBlockIndices: [Int] = []
+        var skippedInFlight = false
+        var closedDuringDedupe = false
         lock.withLock {
-            guard !closed else { return }
+            guard !closed else {
+                closedDuringDedupe = true
+                return
+            }
             for (i, tag16) in tags16.enumerated() where i < maxPersistBlocks {
-                if index.contains(tag16: tag16) || inFlightWrites.contains(tag16) { continue }
+                if index.contains(tag16: tag16) { continue }
+                if inFlightWrites.contains(tag16) {
+                    skippedInFlight = true
+                    continue
+                }
                 inFlightWrites.insert(tag16)
                 newBlockIndices.append(i)
             }
+        }
+        if closedDuringDedupe {
+            settlement.settle(.cacheClosed)
+            return
         }
         // Sliding-TTL bump for the blocks this active conversation reused —
         // index recency AND file mtimes (best-effort), so donation-only
@@ -790,9 +896,10 @@ public final class SSDPrefixCache: CBv2PrefixCache, SSDEvictableStore, @unchecke
                 [.modificationDate: touchDate], at: url, under: config.root)
         }
         guard !newBlockIndices.isEmpty else {
-            // An all-deduped donation is already durable, but still pass it
-            // through the serial maintenance queue so TTL/budget enforcement
-            // completes before any ready receipt is emitted.
+            settlement.settle(skippedInFlight ? .alreadyQueued : .alreadyDurable)
+            // Every block is already durable or owned by an earlier queued
+            // write. Still pass correlated donations through the serial queue
+            // so prior writes and maintenance settle before a ready receipt.
             if onDurable != nil {
                 _ = writeBehind.submit(SSDDonationJob(
                     blocks: [], totalBytes: 0, onDurable: onDurable))
@@ -820,6 +927,7 @@ public final class SSDPrefixCache: CBv2PrefixCache, SSDEvictableStore, @unchecke
             statsBox.add(
                 donationsDropped: newBlockIndices.count,
                 writeRateLimited: newBlockIndices.count)
+            settlement.settle(.writeRateLimited)
             return
         }
 
@@ -871,15 +979,19 @@ public final class SSDPrefixCache: CBv2PrefixCache, SSDEvictableStore, @unchecke
                     chunks: chunks, plaintextBytes: blockBytes))
         }
 
-        guard writeBehind.submit(SSDDonationJob(
-            blocks: blocks, totalBytes: totalBytes, onDurable: onDurable))
-        else {
+        let submitResult = writeBehind.submitWithResult(SSDDonationJob(
+            blocks: blocks,
+            totalBytes: totalBytes,
+            onDurable: onDurable,
+            onOutcome: { outcome in settlement.settle(outcome) }))
+        guard submitResult == .accepted else {
             // Queue overflow / byte cap / closed: drop the donation, settle
             // the in-flight tags so a later donation can retry these blocks.
             lock.withLock {
                 for block in blocks { inFlightWrites.remove(block.tag16) }
             }
             statsBox.add(donationsDropped: blocks.count)
+            settlement.settle(submitResult == .closed ? .cacheClosed : .writeQueueFull)
             return
         }
     }
@@ -1401,8 +1513,15 @@ public final class SSDPrefixCache: CBv2PrefixCache, SSDEvictableStore, @unchecke
     /// (weightHash / layoutEpoch / blockSize) and TTL-expired files are
     /// deleted; everything else is indexed with mtime as lastAccess.
     func scanOnDisk() {
+        lock.withLock {
+            if !closed {
+                scanReady = false
+                scanFailed = false
+            }
+        }
         guard hasSafeRoot else {
             index.removeAll()
+            markScanFailed()
             return
         }
         SSDBlockStore.sweepStaleTempFiles(under: config.root)
@@ -1411,7 +1530,10 @@ public final class SSDPrefixCache: CBv2PrefixCache, SSDEvictableStore, @unchecke
         guard let fanouts = try? fm.contentsOfDirectory(
             at: config.root, includingPropertiesForKeys: [.isDirectoryKey],
             options: [.skipsHiddenFiles])
-        else { return }
+        else {
+            markScanFailed()
+            return
+        }
         var indexed = 0
         var dropped = 0
         var expired = 0
@@ -1425,6 +1547,7 @@ public final class SSDPrefixCache: CBv2PrefixCache, SSDEvictableStore, @unchecke
                     == dir.resolvingSymlinksInPath().standardizedFileURL.path
             else {
                 index.removeAll()
+                markScanFailed()
                 return
             }
             guard let files = try? fm.contentsOfDirectory(
@@ -1434,7 +1557,11 @@ public final class SSDPrefixCache: CBv2PrefixCache, SSDEvictableStore, @unchecke
                     .isSymbolicLinkKey,
                 ],
                 options: [.skipsHiddenFiles])
-            else { continue }
+            else {
+                index.removeAll()
+                markScanFailed()
+                return
+            }
             for url in files where url.pathExtension == SSDBlockStore.fileExtension {
                 if isClosed { return }
                 guard let fileValues = try? url.resourceValues(
@@ -1443,6 +1570,7 @@ public final class SSDPrefixCache: CBv2PrefixCache, SSDEvictableStore, @unchecke
                     SSDBlockStore.isSafeBlockURL(url, modelRoot: config.root)
                 else {
                     index.removeAll()
+                    markScanFailed()
                     return
                 }
                 let name = url.deletingPathExtension().lastPathComponent
@@ -1476,6 +1604,7 @@ public final class SSDPrefixCache: CBv2PrefixCache, SSDEvictableStore, @unchecke
         lock.withLock {
             if !closed {
                 scanReady = true
+                scanFailed = false
             }
         }
         #if canImport(os)
@@ -1506,6 +1635,14 @@ public final class SSDPrefixCache: CBv2PrefixCache, SSDEvictableStore, @unchecke
         SSDBlockStore.isSafeModelRoot(config.root, dedicatedRoot: config.dedicatedRoot)
     }
 
+    private func markScanFailed() {
+        lock.withLock {
+            guard !closed else { return }
+            scanReady = false
+            scanFailed = true
+        }
+    }
+
     /// Persist a fresh generation before deleting or forgetting durable
     /// blocks, and suppress capability publication until the mutation ends.
     private func performDestructiveChange<T>(_ body: () -> T) -> T? {
@@ -1513,7 +1650,10 @@ public final class SSDPrefixCache: CBv2PrefixCache, SSDEvictableStore, @unchecke
         defer { endDestructiveChange() }
         guard let epochStore = config.epochStore else { return body() }
         guard let result = epochStore.performOwnedDestructiveChange(body) else {
-            lock.withLock { scanReady = false }
+            lock.withLock {
+                scanReady = false
+                cacheStatusFailure = .cacheInitFailed
+            }
             return nil
         }
         return result
@@ -1569,12 +1709,12 @@ public final class SSDPrefixCache: CBv2PrefixCache, SSDEvictableStore, @unchecke
         tags16: [Data],
         fullTags: [Data],
         chainHashes: [Data]
-    ) {
+    ) -> Bool {
         guard tags16.count == fullTags.count,
             tags16.count == chainHashes.count,
             !tags16.isEmpty,
             !isClosed
-        else { return }
+        else { return false }
         var readableBlocks = 0
         for i in tags16.indices {
             guard index.contains(tag16: tags16[i]) else { break }
@@ -1587,20 +1727,20 @@ public final class SSDPrefixCache: CBv2PrefixCache, SSDEvictableStore, @unchecke
                     metadata.layoutEpoch == config.layoutEpoch,
                     metadata.blockSize == config.blockSize,
                     metadata.lookupTag == SSDLookupKeys.hex(fullTags[i])
-                else { return }
+                else { return false }
                 readableBlocks += 1
             } catch {
                 // A durable-ready receipt must never attest through corruption,
                 // a torn write, stale binding, or unreadable ciphertext.
-                return
+                return false
             }
         }
         let readyTokens = readableBlocks * config.blockSize
         let recompute = min(config.adoptionBoundTokens, readyTokens)
         let expectedSaved = max(0, readyTokens - recompute)
-        guard expectedSaved >= config.minEffectiveTokens else { return }
+        guard expectedSaved >= config.minEffectiveTokens else { return false }
         guard let durableSizes = index.fileBytes(tags16: tags16.prefix(readableBlocks))
-        else { return }
+        else { return false }
         let durableBytes = durableSizes.reduce(0) { total, next in
             let (sum, overflow) = total.addingReportingOverflow(max(0, next))
             return overflow ? Int.max : sum
@@ -1627,7 +1767,10 @@ public final class SSDPrefixCache: CBv2PrefixCache, SSDEvictableStore, @unchecke
                             }.joined(),
                             tokenCount: UInt64(readyTokens))))
             }
-        if let delivery { delivery.0(delivery.1) }
+        if let delivery {
+            delivery.0(delivery.1)
+        }
+        return true
     }
 
     /// Must be called with `lock` held. Returns the retired entry's

--- a/provider-swift/Sources/ProviderCore/KVCacheSSD/SSDWriteBehind.swift
+++ b/provider-swift/Sources/ProviderCore/KVCacheSSD/SSDWriteBehind.swift
@@ -269,7 +269,7 @@ final class SSDWriteBehind: @unchecked Sendable {
         // Empty jobs represent all-deduped, already-durable donations. For a
         // real job, at least one successful write allows settlement to reprobe
         // a shorter leading contiguous run after all attempts complete.
-        var maySettleDurable = job.blocks.isEmpty
+        var durableWriteSucceeded = job.blocks.isEmpty
         var rateLimited = false
         var diskUnavailable = false
         defer {
@@ -282,18 +282,23 @@ final class SSDWriteBehind: @unchecked Sendable {
             } else {
                 diskBudget.enforce(budgetBytes: config.diskBudgetBytes())
             }
-            let ready = maySettleDurable ? (job.onDurable?() ?? !job.blocks.isEmpty) : false
+            let readyReceiptSettled = durableWriteSucceeded ? job.onDurable?() : nil
+            let closedAtSettlement = queuedBytesLock.withLock { closed }
             let outcome: PrefixCacheDonationOutcome
             if job.blocks.isEmpty {
                 outcome = .alreadyDurable
-            } else if ready {
-                outcome = .donated
-            } else if rateLimited {
+            } else if !durableWriteSucceeded && rateLimited {
                 outcome = .writeRateLimited
-            } else if diskUnavailable {
+            } else if !durableWriteSucceeded && diskUnavailable {
                 outcome = .diskUnavailable
-            } else {
+            } else if !durableWriteSucceeded {
                 outcome = .writeFailed
+            } else if closedAtSettlement {
+                outcome = .cacheClosed
+            } else if job.onDurable != nil && readyReceiptSettled != true {
+                outcome = .writeFailed
+            } else {
+                outcome = .donated
             }
             job.onOutcome(outcome)
         }
@@ -332,7 +337,7 @@ final class SSDWriteBehind: @unchecked Sendable {
                     fileBytes = try writeBlock(block, url)
                     index.insert(tag16: block.tag16, fileBytes: fileBytes, lastAccess: now)
                     stats.add(blocksWritten: 1, bytesWritten: fileBytes)
-                    maySettleDurable = true
+                    durableWriteSucceeded = true
                     continue
                 }
                 fileBytes = try SSDBlockStore.write(
@@ -355,7 +360,7 @@ final class SSDWriteBehind: @unchecked Sendable {
             // Index LAST, after the durable rename (spec §3.2 step 7).
             index.insert(tag16: block.tag16, fileBytes: fileBytes, lastAccess: now)
             stats.add(blocksWritten: 1, bytesWritten: fileBytes)
-            maySettleDurable = true
+            durableWriteSucceeded = true
         }
     }
 

--- a/provider-swift/Sources/ProviderCore/KVCacheSSD/SSDWriteBehind.swift
+++ b/provider-swift/Sources/ProviderCore/KVCacheSSD/SSDWriteBehind.swift
@@ -42,18 +42,28 @@ struct SSDBlockWrite: Sendable {
 struct SSDDonationJob: Sendable {
     let blocks: [SSDBlockWrite]
     let totalBytes: Int
-    /// Called only after every block succeeded and post-write TTL/budget
-    /// maintenance completed. Never called for drops or partial failures.
-    let onDurable: (@Sendable () -> Void)?
+    /// Re-probes the durable leading run after at least one block landed (or an
+    /// all-deduped job) and post-write maintenance completed. Returns true only
+    /// when the surviving run still clears the effective-token floor.
+    let onDurable: (@Sendable () -> Bool)?
+    let onOutcome: @Sendable (PrefixCacheDonationOutcome) -> Void
 
     init(
         blocks: [SSDBlockWrite], totalBytes: Int,
-        onDurable: (@Sendable () -> Void)? = nil
+        onDurable: (@Sendable () -> Bool)? = nil,
+        onOutcome: @escaping @Sendable (PrefixCacheDonationOutcome) -> Void = { _ in }
     ) {
         self.blocks = blocks
         self.totalBytes = totalBytes
         self.onDurable = onDurable
+        self.onOutcome = onOutcome
     }
+}
+
+enum SSDDonationSubmitResult: Sendable, Equatable {
+    case accepted
+    case queueFull
+    case closed
 }
 
 // MARK: - Endurance rate limiter
@@ -145,6 +155,7 @@ final class SSDWriteBehind: @unchecked Sendable {
     private var queuedBytes = 0
     /// Jobs admitted but not yet picked up by the consumer (see `submit`).
     private var queuedJobs = 0
+    private var closed = false
     private var enospcCooldownUntil: Int64 = 0
     private var pipeline: BoundedSingleConsumerPipeline<SSDDonationJob>!
 
@@ -170,9 +181,20 @@ final class SSDWriteBehind: @unchecked Sendable {
         self.onBlockSettled = onBlockSettled
         self.sweepExpired = sweepExpired
         self.pipeline = BoundedSingleConsumerPipeline<SSDDonationJob>(
-            capacity: max(1, config.maxJobs)
+            capacity: max(1, config.maxJobs),
+            onDropped: { [weak self] job in
+                guard let self else {
+                    job.onOutcome(.cacheClosed)
+                    return
+                }
+                self.settleDroppedOnClose(job)
+            }
         ) { [weak self] job in
-            self?.consume(job)
+            guard let self else {
+                job.onOutcome(.cacheClosed)
+                return
+            }
+            self.consume(job)
         }
     }
 
@@ -197,24 +219,30 @@ final class SSDWriteBehind: @unchecked Sendable {
     /// could never be rewritten). With the pre-count, a full queue drops
     /// THIS donation instead — whose tags the caller settles immediately.
     func submit(_ job: SSDDonationJob) -> Bool {
-        let admitted = queuedBytesLock.withLock { () -> Bool in
+        submitWithResult(job) == .accepted
+    }
+
+    func submitWithResult(_ job: SSDDonationJob) -> SSDDonationSubmitResult {
+        let admission = queuedBytesLock.withLock { () -> SSDDonationSubmitResult in
+            guard !closed else { return .closed }
             guard queuedJobs < config.maxJobs,
                 queuedBytes + job.totalBytes <= config.maxQueuedBytes
-            else { return false }
+            else { return .queueFull }
             queuedJobs += 1
             queuedBytes += job.totalBytes
-            return true
+            return .accepted
         }
-        guard admitted else { return false }
+        guard admission == .accepted else { return admission }
         guard pipeline.submit(job) else {
             // Pipeline shut down (never a capacity eviction — see above).
-            queuedBytesLock.withLock {
+            let result: SSDDonationSubmitResult = queuedBytesLock.withLock {
                 queuedJobs -= 1
                 queuedBytes -= job.totalBytes
+                return closed ? .closed : .queueFull
             }
-            return false
+            return result
         }
-        return true
+        return .accepted
     }
 
     /// Stop accepting and cancel the consumer. In-flight write completes;
@@ -222,6 +250,7 @@ final class SSDWriteBehind: @unchecked Sendable {
     /// owner's `close()` clearing the whole set). On-disk files remain —
     /// they are the product.
     func close() {
+        queuedBytesLock.withLock { closed = true }
         pipeline.shutdown()
     }
 
@@ -241,6 +270,8 @@ final class SSDWriteBehind: @unchecked Sendable {
         // real job, at least one successful write allows settlement to reprobe
         // a shorter leading contiguous run after all attempts complete.
         var maySettleDurable = job.blocks.isEmpty
+        var rateLimited = false
+        var diskUnavailable = false
         defer {
             // Opportunistic maintenance on the serial consumer: TTL sweep +
             // box-wide LRU budget enforcement (unlink-only, spec §4.1).
@@ -251,11 +282,25 @@ final class SSDWriteBehind: @unchecked Sendable {
             } else {
                 diskBudget.enforce(budgetBytes: config.diskBudgetBytes())
             }
-            if maySettleDurable { job.onDurable?() }
+            let ready = maySettleDurable ? (job.onDurable?() ?? !job.blocks.isEmpty) : false
+            let outcome: PrefixCacheDonationOutcome
+            if job.blocks.isEmpty {
+                outcome = .alreadyDurable
+            } else if ready {
+                outcome = .donated
+            } else if rateLimited {
+                outcome = .writeRateLimited
+            } else if diskUnavailable {
+                outcome = .diskUnavailable
+            } else {
+                outcome = .writeFailed
+            }
+            job.onOutcome(outcome)
         }
 
         let now = config.nowSeconds()
         if now < queuedBytesLock.withLock({ enospcCooldownUntil }) {
+            diskUnavailable = true
             settleAll(job, dropped: job.blocks.count)
             return
         }
@@ -263,6 +308,7 @@ final class SSDWriteBehind: @unchecked Sendable {
         if let space = config.volumeSpace() {
             let floor = SSDPrefixCachePolicy.lowDiskFloorBytes(volumeCapacityBytes: space.capacity)
             if space.free < floor {
+                diskUnavailable = true
                 settleAll(job, dropped: job.blocks.count)
                 return
             }
@@ -271,6 +317,7 @@ final class SSDWriteBehind: @unchecked Sendable {
         for block in job.blocks {
             defer { onBlockSettled(block.tag16) }
             guard rateLimiter.tryConsume(bytes: block.plaintextBytes) else {
+                rateLimited = true
                 stats.add(donationsDropped: 1, writeRateLimited: 1)
                 continue
             }
@@ -294,6 +341,7 @@ final class SSDWriteBehind: @unchecked Sendable {
             } catch {
                 stats.add(donationsDropped: 1)
                 if isENOSPC(error) {
+                    diskUnavailable = true
                     queuedBytesLock.withLock {
                         enospcCooldownUntil = now + SSDPrefixCachePolicy.enospcCooldownSeconds
                     }
@@ -314,6 +362,15 @@ final class SSDWriteBehind: @unchecked Sendable {
     private func settleAll(_ job: SSDDonationJob, dropped: Int) {
         for block in job.blocks { onBlockSettled(block.tag16) }
         stats.add(donationsDropped: dropped)
+    }
+
+    private func settleDroppedOnClose(_ job: SSDDonationJob) {
+        queuedBytesLock.withLock {
+            queuedJobs = max(0, queuedJobs - 1)
+            queuedBytes = max(0, queuedBytes - job.totalBytes)
+        }
+        settleAll(job, dropped: job.blocks.count)
+        job.onOutcome(.cacheClosed)
     }
 
     private func isENOSPC(_ error: Error) -> Bool {

--- a/provider-swift/Sources/ProviderCore/Protocol/Messages.swift
+++ b/provider-swift/Sources/ProviderCore/Protocol/Messages.swift
@@ -1,5 +1,96 @@
 import Foundation
 
+public enum PrefixCacheStatusBackend: String, Codable, Sendable, Equatable, CaseIterable {
+    case contiguous
+    case paged
+    case unknown
+}
+
+public enum PrefixCacheReplayStrategy: String, Codable, Sendable, Equatable, CaseIterable {
+    case direct
+    case frozenFull = "frozen_full"
+    case none
+    case unknown
+}
+
+public enum PrefixCacheStatusState: String, Codable, Sendable, Equatable, CaseIterable {
+    case ready
+    case pending
+    case disabled
+    case error
+}
+
+public enum PrefixCacheStatusReason: String, Codable, Sendable, Equatable, CaseIterable {
+    case ready
+    case configDisabled = "config_disabled"
+    case noLoadedSlot = "no_loaded_slot"
+    case weightHashUnavailable = "weight_hash_unavailable"
+    case runtimeIdentityUnavailable = "runtime_identity_unavailable"
+    case unsupportedLayout = "unsupported_layout"
+    case unsupportedBackend = "unsupported_backend"
+    case pagedHybridUnsupported = "paged_hybrid_unsupported"
+    case scanPending = "scan_pending"
+    case scanFailed = "scan_failed"
+    case diskUnavailable = "disk_unavailable"
+    case cacheInitFailed = "cache_init_failed"
+}
+
+public struct PrefixCacheModelStatus: Codable, Sendable, Equatable {
+    public let modelId: String
+    public let backend: PrefixCacheStatusBackend
+    public let replayStrategy: PrefixCacheReplayStrategy
+    public let state: PrefixCacheStatusState
+    public let reason: PrefixCacheStatusReason
+
+    public init(
+        modelId: String,
+        backend: PrefixCacheStatusBackend,
+        replayStrategy: PrefixCacheReplayStrategy,
+        state: PrefixCacheStatusState,
+        reason: PrefixCacheStatusReason
+    ) {
+        self.modelId = modelId
+        self.backend = backend
+        self.replayStrategy = replayStrategy
+        self.state = state
+        self.reason = reason
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case modelId = "model_id"
+        case backend
+        case replayStrategy = "replay_strategy"
+        case state
+        case reason
+    }
+}
+
+public enum PrefixCacheDonationOutcome: String, Codable, Sendable, Equatable, CaseIterable {
+    case donated
+    case belowEffectiveTokenFloor = "below_effective_token_floor"
+    case noCompleteBlock = "no_complete_block"
+    case lossySnapshot = "lossy_snapshot"
+    case incompleteLayerState = "incomplete_layer_state"
+    case stageSizeExceeded = "stage_size_exceeded"
+    case writeRateLimited = "write_rate_limited"
+    case writeQueueFull = "write_queue_full"
+    case alreadyDurable = "already_durable"
+    case alreadyQueued = "already_queued"
+    case cacheClosed = "cache_closed"
+    case diskUnavailable = "disk_unavailable"
+    case writeFailed = "write_failed"
+}
+
+public struct PrefixCacheDonationOutcomeCount: Codable, Sendable, Equatable {
+    public let outcome: PrefixCacheDonationOutcome
+    public let count: UInt64
+
+    public init(outcome: PrefixCacheDonationOutcome, count: UInt64) {
+        self.outcome = outcome
+        self.count = count
+    }
+}
+
 public struct PrefixCacheV2Capability: Codable, Sendable, Equatable {
     public let modelId: String
     public let modelAggregateHash: String
@@ -103,6 +194,8 @@ public enum ProviderMessage: Sendable, Equatable {
         /// providers; only version 2 carries exact, provider-proven ownership.
         public var prefixCacheProtocol: Int?
         public var prefixCacheV2Models: [PrefixCacheV2Capability]?
+        public var prefixCacheStatuses: [PrefixCacheModelStatus]?
+        public var prefixCacheDonationOutcomes: [PrefixCacheDonationOutcomeCount]?
         /// Inference-time tool grammar capability. Protocol 1 is advertised
         /// only with concrete model IDs whose Gemma contract is enforced.
         public var toolConstraintProtocol: Int?
@@ -129,6 +222,8 @@ public enum ProviderMessage: Sendable, Equatable {
             apnsEnvironment: String? = nil,
             prefixCacheProtocol: Int? = nil,
             prefixCacheV2Models: [PrefixCacheV2Capability]? = nil,
+            prefixCacheStatuses: [PrefixCacheModelStatus]? = nil,
+            prefixCacheDonationOutcomes: [PrefixCacheDonationOutcomeCount]? = nil,
             toolConstraintProtocol: Int? = nil,
             toolConstraintModels: [String]? = nil
         ) {
@@ -152,6 +247,8 @@ public enum ProviderMessage: Sendable, Equatable {
             self.apnsEnvironment = apnsEnvironment
             self.prefixCacheProtocol = prefixCacheProtocol
             self.prefixCacheV2Models = prefixCacheV2Models
+            self.prefixCacheStatuses = prefixCacheStatuses
+            self.prefixCacheDonationOutcomes = prefixCacheDonationOutcomes
             self.toolConstraintProtocol = toolConstraintProtocol
             self.toolConstraintModels = toolConstraintModels
         }
@@ -175,6 +272,8 @@ public enum ProviderMessage: Sendable, Equatable {
         public var apnsEnvironment: String?
         public var prefixCacheProtocol: Int?
         public var prefixCacheV2Models: [PrefixCacheV2Capability]?
+        public var prefixCacheStatuses: [PrefixCacheModelStatus]?
+        public var prefixCacheDonationOutcomes: [PrefixCacheDonationOutcomeCount]?
 
         public init(
             status: ProviderStatus,
@@ -186,7 +285,9 @@ public enum ProviderMessage: Sendable, Equatable {
             apnsDeviceToken: String? = nil,
             apnsEnvironment: String? = nil,
             prefixCacheProtocol: Int? = nil,
-            prefixCacheV2Models: [PrefixCacheV2Capability]? = nil
+            prefixCacheV2Models: [PrefixCacheV2Capability]? = nil,
+            prefixCacheStatuses: [PrefixCacheModelStatus]? = nil,
+            prefixCacheDonationOutcomes: [PrefixCacheDonationOutcomeCount]? = nil
         ) {
             self.status = status
             self.activeModel = activeModel
@@ -198,6 +299,8 @@ public enum ProviderMessage: Sendable, Equatable {
             self.apnsEnvironment = apnsEnvironment
             self.prefixCacheProtocol = prefixCacheProtocol
             self.prefixCacheV2Models = prefixCacheV2Models
+            self.prefixCacheStatuses = prefixCacheStatuses
+            self.prefixCacheDonationOutcomes = prefixCacheDonationOutcomes
         }
     }
 
@@ -598,6 +701,8 @@ extension ProviderMessage: Codable {
         case apnsEnvironment = "apns_environment"
         case prefixCacheProtocol = "prefix_cache_protocol"
         case prefixCacheV2Models = "prefix_cache_v2_models"
+        case prefixCacheStatuses = "prefix_cache_statuses"
+        case prefixCacheDonationOutcomes = "prefix_cache_donation_outcomes"
         case toolConstraintProtocol = "tool_constraint_protocol"
         case toolConstraintModels = "tool_constraint_models"
         // Heartbeat
@@ -687,6 +792,9 @@ extension ProviderMessage: Codable {
                 try container.encode(version, forKey: .prefixCacheProtocol)
             }
             try container.encodeIfPresent(r.prefixCacheV2Models, forKey: .prefixCacheV2Models)
+            try container.encodeIfPresent(r.prefixCacheStatuses, forKey: .prefixCacheStatuses)
+            try container.encodeIfPresent(
+                r.prefixCacheDonationOutcomes, forKey: .prefixCacheDonationOutcomes)
             if let version = r.toolConstraintProtocol, version != 0 {
                 try container.encode(version, forKey: .toolConstraintProtocol)
             }
@@ -710,6 +818,9 @@ extension ProviderMessage: Codable {
                 try container.encode(version, forKey: .prefixCacheProtocol)
             }
             try container.encodeIfPresent(h.prefixCacheV2Models, forKey: .prefixCacheV2Models)
+            try container.encodeIfPresent(h.prefixCacheStatuses, forKey: .prefixCacheStatuses)
+            try container.encodeIfPresent(
+                h.prefixCacheDonationOutcomes, forKey: .prefixCacheDonationOutcomes)
 
         case .inferenceAccepted(let a):
             try container.encode(TypeValue.inferenceAccepted, forKey: .type)
@@ -880,6 +991,11 @@ extension ProviderMessage: Codable {
                 prefixCacheProtocol: try container.decodeIfPresent(Int.self, forKey: .prefixCacheProtocol),
                 prefixCacheV2Models: try container.decodeIfPresent(
                     [PrefixCacheV2Capability].self, forKey: .prefixCacheV2Models),
+                prefixCacheStatuses: try container.decodeIfPresent(
+                    [PrefixCacheModelStatus].self, forKey: .prefixCacheStatuses),
+                prefixCacheDonationOutcomes: try container.decodeIfPresent(
+                    [PrefixCacheDonationOutcomeCount].self,
+                    forKey: .prefixCacheDonationOutcomes),
                 toolConstraintProtocol: try container.decodeIfPresent(
                     Int.self, forKey: .toolConstraintProtocol),
                 toolConstraintModels: try container.decodeIfPresent(
@@ -899,7 +1015,12 @@ extension ProviderMessage: Codable {
                 prefixCacheProtocol: try container.decodeIfPresent(
                     Int.self, forKey: .prefixCacheProtocol),
                 prefixCacheV2Models: try container.decodeIfPresent(
-                    [PrefixCacheV2Capability].self, forKey: .prefixCacheV2Models)
+                    [PrefixCacheV2Capability].self, forKey: .prefixCacheV2Models),
+                prefixCacheStatuses: try container.decodeIfPresent(
+                    [PrefixCacheModelStatus].self, forKey: .prefixCacheStatuses),
+                prefixCacheDonationOutcomes: try container.decodeIfPresent(
+                    [PrefixCacheDonationOutcomeCount].self,
+                    forKey: .prefixCacheDonationOutcomes)
             ))
 
         case .inferenceAccepted:

--- a/provider-swift/Sources/ProviderCore/Protocol/Messages.swift
+++ b/provider-swift/Sources/ProviderCore/Protocol/Messages.swift
@@ -9,6 +9,7 @@ public enum PrefixCacheStatusBackend: String, Codable, Sendable, Equatable, Case
 public enum PrefixCacheReplayStrategy: String, Codable, Sendable, Equatable, CaseIterable {
     case direct
     case frozenFull = "frozen_full"
+    case tailReplay = "tail_replay"
     case none
     case unknown
 }
@@ -23,7 +24,6 @@ public enum PrefixCacheStatusState: String, Codable, Sendable, Equatable, CaseIt
 public enum PrefixCacheStatusReason: String, Codable, Sendable, Equatable, CaseIterable {
     case ready
     case configDisabled = "config_disabled"
-    case noLoadedSlot = "no_loaded_slot"
     case weightHashUnavailable = "weight_hash_unavailable"
     case runtimeIdentityUnavailable = "runtime_identity_unavailable"
     case unsupportedLayout = "unsupported_layout"

--- a/provider-swift/Sources/ProviderCore/Protocol/ProtocolCodec.swift
+++ b/provider-swift/Sources/ProviderCore/Protocol/ProtocolCodec.swift
@@ -127,6 +127,12 @@ public enum ProviderProtocolCodec {
         if let models = register.prefixCacheV2Models, !models.isEmpty {
             try fields.append(("prefix_cache_v2_models", encodeValue(models)))
         }
+        if let statuses = register.prefixCacheStatuses {
+            try fields.append(("prefix_cache_statuses", encodeValue(statuses)))
+        }
+        if let outcomes = register.prefixCacheDonationOutcomes {
+            try fields.append(("prefix_cache_donation_outcomes", encodeValue(outcomes)))
+        }
         if let version = register.toolConstraintProtocol, version != 0 {
             try fields.append(("tool_constraint_protocol", encodeValue(version)))
         }

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+Capacity.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+Capacity.swift
@@ -138,15 +138,17 @@ extension ProviderLoop {
             freeForLoadGb: freeForLoadGb
         )
         state.inferenceActive = totalActive > 0
-        if binaryHash?.isEmpty == false {
-            state.setPrefixCacheV2Sources(
-                Dictionary(uniqueKeysWithValues: modelSlots.compactMap { modelId, slot in
-                    guard advertisedModels[modelId] != nil else { return nil }
-                    return slot.engineV2.ssdPrefixCache.map { (modelId, $0) }
-                }))
-        } else {
-            state.setPrefixCacheV2Sources([:])
+        let loadedSlots = modelSlots.compactMap { modelId, slot
+            -> (String, EngineV2Bridge)? in
+            guard advertisedModels[modelId] != nil else { return nil }
+            return (modelId, slot.engineV2)
         }
+        state.setPrefixCacheSnapshot(
+            sources: Dictionary(uniqueKeysWithValues: loadedSlots.compactMap { modelId, bridge in
+                bridge.ssdPrefixCache.map { (modelId, $0) }
+            }),
+            statuses: loadedSlots.map { _, bridge in bridge.prefixCacheModelStatus() },
+            runtimeIdentityAvailable: binaryHash?.isEmpty == false)
     }
 
 }

--- a/provider-swift/Tests/ProviderCoreTests/EngineV2KVBackendGateTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/EngineV2KVBackendGateTests.swift
@@ -375,6 +375,11 @@ struct EngineV2KVBackendGateTests {
         #expect(bundle.bridge.ssdPrefixCache === cache)
         #expect(capture.capability?.strategy == .frozenFullReplay)
         #expect(capture.capability?.backend == .contiguousUnquantized)
+        let status = bundle.bridge.prefixCacheModelStatus()
+        #expect(status.backend == .contiguous)
+        #expect(status.replayStrategy == .frozenFull)
+        #expect(status.state == .pending)
+        #expect(status.reason == .scanPending)
         await bundle.bridge.shutdown()
     }
 
@@ -434,6 +439,9 @@ struct EngineV2KVBackendGateTests {
         #expect(backendKind == .contiguous)
         #expect(nativeRate == expectedRate)
         #expect(heartbeat.kvBytesPerToken == Int64(expectedRate))
+        let status = bundle.bridge.prefixCacheModelStatus()
+        #expect(status.state == .disabled)
+        #expect(status.reason == .configDisabled)
         await bundle.bridge.shutdown()
     }
 }

--- a/provider-swift/Tests/ProviderCoreTests/PrefixCachePolicyTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/PrefixCachePolicyTests.swift
@@ -71,6 +71,8 @@ struct PrefixCachePolicyTests {
             layerKinds: [full, full], backendSelection: .contiguous).strategy == .direct)
         #expect(PrefixCachePolicy.prefixReuseCapability(
             layerKinds: [full, windowed], backendSelection: .paged).strategy == .tailReplay)
+        #expect(PrefixCacheReplayStrategy(PrefixCachePolicy.prefixReuseCapability(
+            layerKinds: [full, windowed], backendSelection: .paged)) == .tailReplay)
         #expect(PrefixCachePolicy.prefixReuseCapability(
             layerKinds: [windowed, sharedFull],
             backendSelection: .contiguous).unsupportedReason == .invalidLayout)

--- a/provider-swift/Tests/ProviderCoreTests/PrefixCachePolicyTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/PrefixCachePolicyTests.swift
@@ -176,4 +176,34 @@ struct PrefixCachePolicyTests {
             ]) == 2_048)
     }
 
+    @Test("construction failures map to bounded eligibility reasons")
+    func constructionFailureReasons() {
+        let windowed = CBv2LayerKind(
+            attention: .slidingWindow(128),
+            headDim: 64,
+            kvHeads: 8,
+            queryHeads: 64)
+        let full = CBv2LayerKind(
+            attention: .full,
+            headDim: 64,
+            kvHeads: 8,
+            queryHeads: 64)
+        let pagedHybrid = PrefixCachePolicy.prefixReuseCapability(
+            layerKinds: [windowed, full],
+            backendSelection: .paged)
+        let box = PrefixCacheConstructionStatusBox()
+
+        box.record(failure: .unsupportedPlan, capability: pagedHybrid)
+        #expect(box.snapshot?.state == .disabled)
+        #expect(box.snapshot?.reason == .pagedHybridUnsupported)
+
+        box.record(failure: .missingWeightHash, capability: pagedHybrid)
+        #expect(box.snapshot?.state == .disabled)
+        #expect(box.snapshot?.reason == .weightHashUnavailable)
+
+        box.record(failure: .unsafePath, capability: pagedHybrid)
+        #expect(box.snapshot?.state == .error)
+        #expect(box.snapshot?.reason == .diskUnavailable)
+    }
+
 }

--- a/provider-swift/Tests/ProviderCoreTests/ProtocolTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ProtocolTests.swift
@@ -94,7 +94,7 @@ import Testing
         "ready", "pending", "disabled", "error",
     ])
     #expect(Set(PrefixCacheStatusReason.allCases.map(\.rawValue)) == [
-        "ready", "config_disabled", "no_loaded_slot",
+        "ready", "config_disabled",
         "weight_hash_unavailable", "runtime_identity_unavailable",
         "unsupported_layout", "unsupported_backend",
         "paged_hybrid_unsupported", "scan_pending", "scan_failed",
@@ -104,7 +104,7 @@ import Testing
         "contiguous", "paged", "unknown",
     ])
     #expect(Set(PrefixCacheReplayStrategy.allCases.map(\.rawValue)) == [
-        "direct", "frozen_full", "none", "unknown",
+        "direct", "frozen_full", "tail_replay", "none", "unknown",
     ])
     #expect(Set(PrefixCacheDonationOutcome.allCases.map(\.rawValue)) == [
         "donated", "below_effective_token_floor", "no_complete_block",

--- a/provider-swift/Tests/ProviderCoreTests/ProtocolTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ProtocolTests.swift
@@ -39,6 +39,81 @@ import Testing
     #expect(decoded.prefixCacheV2Models == [capability])
 }
 
+@Test func prefixCacheTelemetrySnapshotsAreOptionalBoundedWireEnums() throws {
+    let legacy = ProviderMessage.heartbeat(ProviderMessage.Heartbeat(
+        status: .idle,
+        stats: ProviderStats(),
+        systemMetrics: SystemMetrics(
+            memoryPressure: 0, cpuUsage: 0, thermalState: .nominal)))
+    let legacyObject = try jsonObject(
+        try ProviderProtocolCodec.encodeProviderMessage(legacy))
+    #expect(legacyObject["prefix_cache_statuses"] == nil)
+    #expect(legacyObject["prefix_cache_donation_outcomes"] == nil)
+
+    let status = PrefixCacheModelStatus(
+        modelId: "model",
+        backend: .contiguous,
+        replayStrategy: .frozenFull,
+        state: .disabled,
+        reason: .weightHashUnavailable)
+    let current = ProviderMessage.heartbeat(ProviderMessage.Heartbeat(
+        status: .idle,
+        stats: ProviderStats(),
+        systemMetrics: SystemMetrics(
+            memoryPressure: 0, cpuUsage: 0, thermalState: .nominal),
+        prefixCacheProtocol: 1,
+        prefixCacheV2Models: [],
+        prefixCacheStatuses: [status],
+        prefixCacheDonationOutcomes: [
+            PrefixCacheDonationOutcomeCount(outcome: .writeQueueFull, count: 3)
+        ]))
+    let data = try ProviderProtocolCodec.encodeProviderMessage(current)
+    let object = try jsonObject(data)
+    let statusObject = try #require(
+        (object["prefix_cache_statuses"] as? [[String: Any]])?.first)
+    #expect(statusObject["replay_strategy"] as? String == "frozen_full")
+    #expect(statusObject["reason"] as? String == "weight_hash_unavailable")
+    let outcomeObject = try #require(
+        (object["prefix_cache_donation_outcomes"] as? [[String: Any]])?.first)
+    #expect(outcomeObject["outcome"] as? String == "write_queue_full")
+    #expect(outcomeObject["count"] as? Int == 3)
+
+    guard case .heartbeat(let decoded) =
+        try ProviderProtocolCodec.decodeProviderMessage(from: data)
+    else {
+        throw TestFailure.unexpectedMessage
+    }
+    #expect(decoded.prefixCacheStatuses == [status])
+    #expect(decoded.prefixCacheDonationOutcomes == [
+        PrefixCacheDonationOutcomeCount(outcome: .writeQueueFull, count: 3)
+    ])
+}
+
+@Test func prefixCacheTelemetryEnumCasingIsPinned() {
+    #expect(Set(PrefixCacheStatusState.allCases.map(\.rawValue)) == [
+        "ready", "pending", "disabled", "error",
+    ])
+    #expect(Set(PrefixCacheStatusReason.allCases.map(\.rawValue)) == [
+        "ready", "config_disabled", "no_loaded_slot",
+        "weight_hash_unavailable", "runtime_identity_unavailable",
+        "unsupported_layout", "unsupported_backend",
+        "paged_hybrid_unsupported", "scan_pending", "scan_failed",
+        "disk_unavailable", "cache_init_failed",
+    ])
+    #expect(Set(PrefixCacheStatusBackend.allCases.map(\.rawValue)) == [
+        "contiguous", "paged", "unknown",
+    ])
+    #expect(Set(PrefixCacheReplayStrategy.allCases.map(\.rawValue)) == [
+        "direct", "frozen_full", "none", "unknown",
+    ])
+    #expect(Set(PrefixCacheDonationOutcome.allCases.map(\.rawValue)) == [
+        "donated", "below_effective_token_floor", "no_complete_block",
+        "lossy_snapshot", "incomplete_layer_state", "stage_size_exceeded",
+        "write_rate_limited", "write_queue_full", "already_durable",
+        "already_queued", "cache_closed", "disk_unavailable", "write_failed",
+    ])
+}
+
 @Test func prefixCacheV2MessagesRemainDistinctAndBoundReadyAnchors() throws {
     let prompt = PrefixCacheAnchor(
         chainHash: String(repeating: "c", count: 64), tokenCount: 256)
@@ -206,6 +281,14 @@ import Testing
         cacheEpoch: "11111111-1111-1111-1111-111111111111",
         enabled: true,
         ready: true)
+    let cacheStatus = PrefixCacheModelStatus(
+        modelId: "model",
+        backend: .contiguous,
+        replayStrategy: .direct,
+        state: .ready,
+        reason: .ready)
+    let donationOutcome = PrefixCacheDonationOutcomeCount(
+        outcome: .donated, count: 7)
     let message = ProviderMessage.register(ProviderMessage.Register(
         hardware: sampleHardware(),
         models: [sampleModel()],
@@ -216,6 +299,8 @@ import Testing
         apnsEnvironment: "production",
         prefixCacheProtocol: 2,
         prefixCacheV2Models: [capability],
+        prefixCacheStatuses: [cacheStatus],
+        prefixCacheDonationOutcomes: [donationOutcome],
         toolConstraintProtocol: 1,
         toolConstraintModels: ["model"]
     ))
@@ -226,6 +311,8 @@ import Testing
     #expect(object["private_only"] as? Bool == true)
     #expect(object["prefix_cache_protocol"] as? Int == 2)
     #expect((object["prefix_cache_v2_models"] as? [[String: Any]])?.count == 1)
+    #expect((object["prefix_cache_statuses"] as? [[String: Any]])?.count == 1)
+    #expect((object["prefix_cache_donation_outcomes"] as? [[String: Any]])?.count == 1)
     #expect(object["tool_constraint_protocol"] as? Int == 1)
     #expect(object["tool_constraint_models"] as? [String] == ["model"])
     // Raw attestation bytes preserved verbatim (the reason this path exists).
@@ -238,6 +325,8 @@ import Testing
     #expect(r.apnsEnvironment == "production")
     #expect(r.privateOnly == true)
     #expect(r.prefixCacheV2Models == [capability])
+    #expect(r.prefixCacheStatuses == [cacheStatus])
+    #expect(r.prefixCacheDonationOutcomes == [donationOutcome])
     #expect(r.toolConstraintProtocol == 1)
     #expect(r.toolConstraintModels == ["model"])
 }

--- a/provider-swift/Tests/ProviderCoreTests/SSDCacheEpochStoreTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/SSDCacheEpochStoreTests.swift
@@ -170,6 +170,37 @@ struct SSDCacheEpochStoreTests {
         #expect(ready.statuses.first?.state == .ready)
         #expect(ready.statuses.first?.reason == .ready)
 
+        state.setPrefixCacheSnapshot(
+            sources: ["gpt-oss": cache],
+            statuses: [PrefixCacheModelStatus(
+                modelId: "gpt-oss",
+                backend: .unknown,
+                replayStrategy: .none,
+                state: .ready,
+                reason: .ready)],
+            runtimeIdentityAvailable: true)
+        let unknown = state.prefixCacheV2Advertisement()
+        #expect(unknown.protocolVersion == 1)
+        #expect(unknown.models.isEmpty)
+        #expect(unknown.statuses.isEmpty)
+
+        state.setPrefixCacheSnapshot(
+            sources: ["gpt-oss": cache],
+            statuses: [],
+            runtimeIdentityAvailable: true)
+        let missing = state.prefixCacheV2Advertisement()
+        #expect(missing.protocolVersion == 1)
+        #expect(missing.models.isEmpty)
+
+        state.setPrefixCacheSnapshot(
+            sources: ["gpt-oss": cache],
+            statuses: [PrefixCacheModelStatus(
+                modelId: "gpt-oss",
+                backend: .contiguous,
+                replayStrategy: .frozenFull,
+                state: .ready,
+                reason: .ready)],
+            runtimeIdentityAvailable: true)
         await cache.closeAndWait()
         #expect(state.prefixCacheV2Advertisement().protocolVersion == 1)
     }

--- a/provider-swift/Tests/ProviderCoreTests/SSDCacheEpochStoreTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/SSDCacheEpochStoreTests.swift
@@ -144,9 +144,19 @@ struct SSDCacheEpochStoreTests {
             strictFsync: false,
             diskBudgetBytes: { 1 << 30 })
         let state = ProviderState()
-        state.setPrefixCacheV2Sources(["gpt-oss": cache])
+        state.setPrefixCacheSnapshot(
+            sources: ["gpt-oss": cache],
+            statuses: [PrefixCacheModelStatus(
+                modelId: "gpt-oss",
+                backend: .contiguous,
+                replayStrategy: .frozenFull,
+                state: .pending,
+                reason: .scanPending)],
+            runtimeIdentityAvailable: true)
         #expect(state.prefixCacheV2Advertisement().protocolVersion == 1)
         #expect(state.prefixCacheV2Advertisement().models.isEmpty)
+        #expect(state.prefixCacheV2Advertisement().statuses.first?.state == .pending)
+        #expect(state.prefixCacheV2Advertisement().statuses.first?.reason == .scanPending)
 
         cache.startBackgroundTasks(sweepIntervalSeconds: 3_600)
         for _ in 0 ..< 100
@@ -157,6 +167,8 @@ struct SSDCacheEpochStoreTests {
         #expect(ready.protocolVersion == 2)
         #expect(ready.models.map(\.modelId) == ["gpt-oss"])
         #expect(ready.models.allSatisfy { $0.ready })
+        #expect(ready.statuses.first?.state == .ready)
+        #expect(ready.statuses.first?.reason == .ready)
 
         await cache.closeAndWait()
         #expect(state.prefixCacheV2Advertisement().protocolVersion == 1)
@@ -182,6 +194,24 @@ struct SSDCacheEpochStoreTests {
                 contract: String(repeating: "b", count: 64)))
         }
         #expect(try Data(contentsOf: outside) == Data("outside".utf8))
+    }
+
+    @Test("missing runtime identity explains protocol-v1 status")
+    func runtimeIdentityGateIsReported() {
+        let state = ProviderState()
+        state.setPrefixCacheSnapshot(
+            sources: [:],
+            statuses: [PrefixCacheModelStatus(
+                modelId: "model",
+                backend: .contiguous,
+                replayStrategy: .direct,
+                state: .pending,
+                reason: .scanPending)],
+            runtimeIdentityAvailable: false)
+        let snapshot = state.prefixCacheV2Advertisement()
+        #expect(snapshot.protocolVersion == 1)
+        #expect(snapshot.statuses.first?.state == .disabled)
+        #expect(snapshot.statuses.first?.reason == .runtimeIdentityUnavailable)
     }
 
     @Test("interrupted binding rebuild cannot publish its invalidating epoch")

--- a/provider-swift/Tests/ProviderCoreTests/SSDPrefixCacheTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/SSDPrefixCacheTests.swift
@@ -1501,14 +1501,18 @@ struct SSDReadyWriteBarrierTests {
 
     private final class OutcomeBox: @unchecked Sendable {
         private let lock = NSLock()
-        private var value: PrefixCacheDonationOutcome?
+        private var values: [PrefixCacheDonationOutcome] = []
 
         func set(_ outcome: PrefixCacheDonationOutcome) {
-            lock.withLock { value = outcome }
+            lock.withLock { values.append(outcome) }
         }
 
         var outcome: PrefixCacheDonationOutcome? {
-            lock.withLock { value }
+            lock.withLock { values.last }
+        }
+
+        var count: Int {
+            lock.withLock { values.count }
         }
     }
 
@@ -1623,6 +1627,74 @@ struct SSDReadyWriteBarrierTests {
             blocks: [block(4)], totalBytes: 1,
             onDurable: { closedCounter.increment(); return true })) == .closed)
         #expect(closedCounter.count == 0)
+    }
+
+    @Test("in-flight close classifies correlated and uncorrelated durable writes as cache_closed")
+    func inFlightCloseOutcome() async throws {
+        for correlated in [false, true] {
+            let dir = tempDir("inflight-close-\(correlated)")
+            let entered = DispatchSemaphore(value: 0)
+            let release = DispatchSemaphore(value: 0)
+            let settled = Counter()
+            let readyAttempted = Counter()
+            let outcome = OutcomeBox()
+            let writer = pipeline(
+                dir: dir,
+                writeBlock: { _, _ in
+                    entered.signal()
+                    _ = release.wait(timeout: .now() + 5)
+                    return 1
+                },
+                onBlockSettled: { _ in settled.increment() })
+            let onDurable: (@Sendable () -> Bool)?
+            if correlated {
+                onDurable = { @Sendable in
+                    readyAttempted.increment()
+                    return false
+                }
+            } else {
+                onDurable = nil
+            }
+
+            #expect(writer.submit(.init(
+                blocks: [block(correlated ? 0xA1 : 0xB2)],
+                totalBytes: 1,
+                onDurable: onDurable,
+                onOutcome: outcome.set)))
+            #expect(await waitForSemaphore(entered, timeout: .now() + 5) == .success)
+            writer.close()
+            release.signal()
+            await writer.waitUntilDrained()
+
+            #expect(settled.count == 1)
+            #expect(readyAttempted.count == (correlated ? 1 : 0))
+            #expect(outcome.outcome == .cacheClosed)
+            #expect(outcome.count == 1)
+            try? FileManager.default.removeItem(at: dir)
+        }
+
+        let failedDir = tempDir("inflight-close-write-failure")
+        let failedEntered = DispatchSemaphore(value: 0)
+        let failedRelease = DispatchSemaphore(value: 0)
+        let failedOutcome = OutcomeBox()
+        let failedWriter = pipeline(
+            dir: failedDir,
+            writeBlock: { _, _ in
+                failedEntered.signal()
+                _ = failedRelease.wait(timeout: .now() + 5)
+                throw InjectedWriteError.failed
+            })
+        #expect(failedWriter.submit(.init(
+            blocks: [block(0xC3)],
+            totalBytes: 1,
+            onOutcome: failedOutcome.set)))
+        #expect(await waitForSemaphore(failedEntered, timeout: .now() + 5) == .success)
+        failedWriter.close()
+        failedRelease.signal()
+        await failedWriter.waitUntilDrained()
+        #expect(failedOutcome.outcome == .writeFailed)
+        #expect(failedOutcome.count == 1)
+        try? FileManager.default.removeItem(at: failedDir)
     }
 
     @Test("queue overflow drops the new receipt job without blocking")

--- a/provider-swift/Tests/ProviderCoreTests/SSDPrefixCacheTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/SSDPrefixCacheTests.swift
@@ -98,7 +98,8 @@ private func makeCache(
     kvBudget: GlobalKVCacheBudget? = nil,
     diskBudget: SSDDiskBudget = SSDDiskBudget(),
     epochStore: SSDCacheEpochStore? = nil,
-    maintainWholeRoot: (@Sendable () -> Void)? = nil
+    maintainWholeRoot: (@Sendable () -> Void)? = nil,
+    donationRecorder: any PrefixCacheDonationRecording = PrefixCacheDonationTelemetry.shared
 ) -> SSDPrefixCache {
     let config = SSDPrefixCache.Config(
         modelId: "test-model",
@@ -119,7 +120,8 @@ private func makeCache(
         config: config, kekKey: kek, kvBudget: kvBudget, diskBudget: diskBudget,
         maxWriteBytesPerDay: maxWriteBytesPerDay, strictFsync: false,
         diskBudgetBytes: { diskBudgetBytes },
-        maintainWholeRoot: maintainWholeRoot)
+        maintainWholeRoot: maintainWholeRoot,
+        donationRecorder: donationRecorder)
 }
 
 /// Poll until the cache's index holds `count` entries (write-behind is
@@ -467,6 +469,14 @@ struct SSDBlockStoreTests {
         defer { cache.close() }
         cache.scanOnDisk()
         #expect(cache.index.count == 0)
+        let scanStatus = cache.prefixCacheModelStatus(base: PrefixCacheModelStatus(
+            modelId: "test-model",
+            backend: .contiguous,
+            replayStrategy: .direct,
+            state: .pending,
+            reason: .scanPending))
+        #expect(scanStatus.state == .error)
+        #expect(scanStatus.reason == .scanFailed)
         let escapedFile = outsideFanout.appendingPathComponent(
             "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.dbk3")
         try Data("must-survive".utf8).write(to: escapedFile)
@@ -1096,7 +1106,16 @@ struct SSDPrefixCacheLifecycleTests {
         var enteredIterator = entered.makeAsyncIterator()
         _ = await enteredIterator.next()
 
-        #expect(cache.prefixCacheV2Capability() == nil)
+        let mutationAdvertisement = cache.prefixCacheAdvertisement(
+            base: PrefixCacheModelStatus(
+                modelId: "test-model",
+                backend: .contiguous,
+                replayStrategy: .direct,
+                state: .pending,
+                reason: .scanPending))
+        #expect(mutationAdvertisement.capability == nil)
+        #expect(mutationAdvertisement.status.state == .pending)
+        #expect(mutationAdvertisement.status.reason == .scanPending)
         #expect(
             cache.takeNextPrefixCacheV2Sequence(expectedEpoch: original.cacheEpoch) == nil)
 
@@ -1480,6 +1499,19 @@ struct SSDReadyWriteBarrierTests {
         }
     }
 
+    private final class OutcomeBox: @unchecked Sendable {
+        private let lock = NSLock()
+        private var value: PrefixCacheDonationOutcome?
+
+        func set(_ outcome: PrefixCacheDonationOutcome) {
+            lock.withLock { value = outcome }
+        }
+
+        var outcome: PrefixCacheDonationOutcome? {
+            lock.withLock { value }
+        }
+    }
+
     private enum InjectedWriteError: Error { case failed }
 
     private func block(_ byte: UInt8) -> SSDBlockWrite {
@@ -1535,48 +1567,61 @@ struct SSDReadyWriteBarrierTests {
 
         let lowCounter = Counter()
         let lowSettled = Counter()
+        let lowOutcome = OutcomeBox()
         let low = pipeline(
             dir: dir,
             volumeSpace: { (free: 0, capacity: 1) },
             onBlockSettled: { _ in lowSettled.increment() })
         #expect(low.submit(.init(
-            blocks: [block(1)], totalBytes: 1, onDurable: lowCounter.increment)))
+            blocks: [block(1)], totalBytes: 1,
+            onDurable: { lowCounter.increment(); return true },
+            onOutcome: lowOutcome.set)))
         #expect(await lowSettled.waitForCount(1))
         low.close()
         await low.waitUntilDrained()
         #expect(lowCounter.count == 0)
+        #expect(lowOutcome.outcome == .diskUnavailable)
 
         let errorCounter = Counter()
         let errorSettled = Counter()
+        let errorOutcome = OutcomeBox()
         let generic = pipeline(
             dir: dir,
             writeBlock: { _, _ in throw InjectedWriteError.failed },
             onBlockSettled: { _ in errorSettled.increment() })
         #expect(generic.submit(.init(
-            blocks: [block(2)], totalBytes: 1, onDurable: errorCounter.increment)))
+            blocks: [block(2)], totalBytes: 1,
+            onDurable: { errorCounter.increment(); return true },
+            onOutcome: errorOutcome.set)))
         #expect(await errorSettled.waitForCount(1))
         generic.close()
         await generic.waitUntilDrained()
         #expect(errorCounter.count == 0)
+        #expect(errorOutcome.outcome == .writeFailed)
 
         let enospcCounter = Counter()
         let enospcSettled = Counter()
+        let enospcOutcome = OutcomeBox()
         let enospc = pipeline(
             dir: dir,
             writeBlock: { _, _ in throw POSIXError(.ENOSPC) },
             onBlockSettled: { _ in enospcSettled.increment() })
         #expect(enospc.submit(.init(
-            blocks: [block(3)], totalBytes: 1, onDurable: enospcCounter.increment)))
+            blocks: [block(3)], totalBytes: 1,
+            onDurable: { enospcCounter.increment(); return true },
+            onOutcome: enospcOutcome.set)))
         #expect(await enospcSettled.waitForCount(1))
         enospc.close()
         await enospc.waitUntilDrained()
         #expect(enospcCounter.count == 0)
+        #expect(enospcOutcome.outcome == .diskUnavailable)
 
         let closedCounter = Counter()
         let closed = pipeline(dir: dir)
         closed.close()
-        #expect(!closed.submit(.init(
-            blocks: [block(4)], totalBytes: 1, onDurable: closedCounter.increment)))
+        #expect(closed.submitWithResult(.init(
+            blocks: [block(4)], totalBytes: 1,
+            onDurable: { closedCounter.increment(); return true })) == .closed)
         #expect(closedCounter.count == 0)
     }
 
@@ -1600,8 +1645,9 @@ struct SSDReadyWriteBarrierTests {
         #expect(enteredResult == .success)
         #expect(pipeline.submit(.init(blocks: [block(2)], totalBytes: 1)))
         let dropped = Counter()
-        #expect(!pipeline.submit(.init(
-            blocks: [block(3)], totalBytes: 1, onDurable: dropped.increment)))
+        #expect(pipeline.submitWithResult(.init(
+            blocks: [block(3)], totalBytes: 1,
+            onDurable: { dropped.increment(); return true })) == .queueFull)
         #expect(dropped.count == 0)
         release.signal()
         #expect(await settled.waitForCount(2))
@@ -2752,5 +2798,163 @@ struct SSDPrefixCacheDonationGateTests {
         // A job larger than the whole cap is rejected IMMEDIATELY
         // (deterministic regardless of consumer state) — drop, not stall.
         #expect(!writeBehind.submit(syntheticJob(tagByte: 0xB2, claimedBytes: effectiveCap + 1)))
+    }
+}
+
+private final class DonationOutcomeRecorder: PrefixCacheDonationRecording, @unchecked Sendable {
+    private let lock = NSLock()
+    private var counts: [PrefixCacheDonationOutcome: Int] = [:]
+
+    func record(_ outcome: PrefixCacheDonationOutcome) {
+        lock.withLock { counts[outcome, default: 0] += 1 }
+    }
+
+    func count(_ outcome: PrefixCacheDonationOutcome) -> Int {
+        lock.withLock { counts[outcome, default: 0] }
+    }
+}
+
+@Suite("SSD prefix cache: donation outcomes", .serialized)
+struct SSDPrefixCacheDonationOutcomeTests {
+    @Test("every donation opportunity settles one bounded outcome")
+    func branchOutcomes() async throws {
+        let root = tempDir("donation-outcomes")
+        defer { try? FileManager.default.removeItem(at: root) }
+        let recorder = DonationOutcomeRecorder()
+
+        let noBlock = makeCache(
+            dir: root.appendingPathComponent("no-block"),
+            kek: SymmetricKey(size: .bits256),
+            clock: ClockBox(10_000),
+            donationRecorder: recorder)
+        noBlock.donate(
+            tokens: Array(0 ..< 7),
+            snapshots: fixtureSnapshots(tokenCount: 7),
+            layerKinds: fixtureLayerKinds,
+            cacheSalt: nil)
+
+        let belowFloor = makeCache(
+            dir: root.appendingPathComponent("floor"),
+            kek: SymmetricKey(size: .bits256),
+            clock: ClockBox(10_000),
+            adoptionBound: 8,
+            minEffectiveTokens: 8,
+            donationRecorder: recorder)
+        belowFloor.donate(
+            tokens: Array(0 ..< 16),
+            snapshots: fixtureSnapshots(tokenCount: 16),
+            layerKinds: fixtureLayerKinds,
+            cacheSalt: nil)
+
+        let incomplete = makeCache(
+            dir: root.appendingPathComponent("incomplete"),
+            kek: SymmetricKey(size: .bits256),
+            clock: ClockBox(10_000),
+            donationRecorder: recorder)
+        incomplete.donate(
+            tokens: Array(0 ..< 16),
+            snapshots: [nil, nil],
+            layerKinds: fixtureLayerKinds,
+            cacheSalt: nil)
+
+        let stageCapped = makeCache(
+            dir: root.appendingPathComponent("stage-cap"),
+            kek: SymmetricKey(size: .bits256),
+            clock: ClockBox(10_000),
+            maxStageBytes: 512,
+            donationRecorder: recorder)
+        stageCapped.donate(
+            tokens: Array(0 ..< 16),
+            snapshots: fixtureSnapshots(tokenCount: 16),
+            layerKinds: fixtureLayerKinds,
+            cacheSalt: nil)
+
+        let rateLimited = makeCache(
+            dir: root.appendingPathComponent("rate"),
+            kek: SymmetricKey(size: .bits256),
+            clock: ClockBox(10_000),
+            maxWriteBytesPerDay: 1,
+            donationRecorder: recorder)
+        rateLimited.donate(
+            tokens: Array(0 ..< 16),
+            snapshots: fixtureSnapshots(tokenCount: 16),
+            layerKinds: fixtureLayerKinds,
+            cacheSalt: nil)
+
+        let lossy = makeCache(
+            dir: root.appendingPathComponent("lossy"),
+            kek: SymmetricKey(size: .bits256),
+            clock: ClockBox(10_000),
+            donationRecorder: recorder)
+        let quantized = CBv2QuantizedSequenceKV(
+            promptLength: 16,
+            maxLength: 32,
+            kvHeads: fixtureKVHeads,
+            headDim: 64,
+            groupSize: 64,
+            bits: 4)
+        lossy.donate(
+            tokens: Array(0 ..< 16),
+            state: [quantized, nil],
+            layerKinds: fixtureLayerKinds,
+            cacheSalt: nil)
+
+        let closed = makeCache(
+            dir: root.appendingPathComponent("closed"),
+            kek: SymmetricKey(size: .bits256),
+            clock: ClockBox(10_000),
+            donationRecorder: recorder)
+        closed.close()
+        closed.donate(
+            tokens: Array(0 ..< 16),
+            snapshots: fixtureSnapshots(tokenCount: 16),
+            layerKinds: fixtureLayerKinds,
+            cacheSalt: nil)
+
+        #expect(recorder.count(.noCompleteBlock) == 1)
+        #expect(recorder.count(.belowEffectiveTokenFloor) == 1)
+        #expect(recorder.count(.incompleteLayerState) == 1)
+        #expect(recorder.count(.stageSizeExceeded) == 1)
+        #expect(recorder.count(.writeRateLimited) == 1)
+        #expect(recorder.count(.lossySnapshot) == 1)
+        #expect(recorder.count(.cacheClosed) == 1)
+
+        for cache in [noBlock, belowFloor, incomplete, stageCapped, rateLimited, lossy] {
+            cache.close()
+        }
+    }
+
+    @Test("durable and deduplicated donations settle distinctly")
+    func durableOutcomes() async throws {
+        let dir = tempDir("donation-durable")
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let recorder = DonationOutcomeRecorder()
+        let cache = makeCache(
+            dir: dir,
+            kek: SymmetricKey(size: .bits256),
+            clock: ClockBox(10_000),
+            donationRecorder: recorder)
+        defer { cache.close() }
+
+        let tokens = Array(0 ..< 16)
+        let snapshots = fixtureSnapshots(tokenCount: tokens.count)
+        cache.donate(
+            tokens: tokens,
+            snapshots: snapshots,
+            layerKinds: fixtureLayerKinds,
+            cacheSalt: nil)
+        await cache.waitForWritesForTesting()
+        #expect(recorder.count(.donated) == 1)
+
+        cache.donate(
+            tokens: tokens,
+            snapshots: snapshots,
+            layerKinds: fixtureLayerKinds,
+            cacheSalt: nil)
+        #expect(recorder.count(.alreadyDurable) == 1)
+        let total = PrefixCacheDonationOutcome.allCases.reduce(0) {
+            $0 + recorder.count($1)
+        }
+        #expect(total == 2)
     }
 }


### PR DESCRIPTION
## Summary

- report bounded per-loaded-model cache eligibility snapshots so operators can distinguish ready v2 slots from fixed exclusion reasons
- aggregate donation outcomes and holder lifecycle removals without exposing prompts, scopes, hashes, accounts, requests, or provider identity
- preserve mixed-version availability by treating optional observability as bounded, lossy, forward-compatible, and non-fatal while keeping routing capabilities strict
- reconcile ready telemetry atomically with real v2 capabilities and classify in-flight teardown donations exactly once

## Before

```mermaid
flowchart LR
  subgraph Behavior["Behavior"]
    A["Loaded provider slots"] --> B["Aggregate v1 / v2 totals only"]
    B --> C["Operators cannot explain v1 exclusions"]
    D["SSD donation opportunity"] --> E["Donation count may remain zero"]
    E --> F["No central skip reason"]
    G["Holder disappears"] --> H["No removal cause"]
  end
  subgraph Code["Code"]
    I["Register / heartbeat"] --> J["prefix_cache_v2_models"]
    J --> K["Registry capability set"]
    L["SSDPrefixCache donate"] --> M["Local stats only"]
    N["cacheRoutingTracker removal"] --> O["Delete holder"]
  end
```

## After

```mermaid
flowchart LR
  subgraph Behavior["Behavior"]
    A["Loaded provider slots"] --> B["Optional eligibility snapshot"]
    B --> C["Bounded counts by state / reason / backend / replay strategy"]
    D["SSD donation opportunity"] --> E["Monotonic fixed-enum outcome counters"]
    E --> F["Coordinator status and metrics explain skips"]
    G["Holder disappears"] --> H["TTL / disconnect / epoch / capability / miss / capacity reason"]
  end
  subgraph Code["Code"]
    I["Swift slot and SSD state"] --> J["Optional register / heartbeat telemetry"]
    J --> K["Sanitize and atomically reconcile with strict v2 capability"]
    K --> L["Registry connection-scoped snapshot"]
    L --> M["/v1/cache/status + Prometheus + Datadog"]
    N["Holder and donation branches"] --> M
  end
```

## Compatibility and privacy

- old providers omit all new fields and remain fully compatible
- off-catalog owner-local inventory remains available; optional malformed or future telemetry is dropped rather than registration-fatal
- strict `prefix_cache_v2_models` routing validation remains fail-closed and unchanged
- raw donation envelopes are capped at 32 entries while exports remain fixed to 13 known outcomes
- aggregates contain only fixed low-cardinality enums and counts; no prompt-derived or provider-identifying values are exported

## Test plan

- [x] Full coordinator `go test ./...`
- [x] Focused registry/API race suites
- [x] Full provider `swift test` — 1,621 tests / 170 suites
- [x] Protocol symmetry, old-provider omission, off-catalog, future-enum, malformed snapshot, replacement/clear/disconnect regressions
- [x] SSD donation branch and in-flight teardown race coverage
- [x] Holder add/removal exact-once reason coverage
- [x] Metrics/status/privacy/cardinality tests
- [x] `git diff --check`
- [x] Two independent final reviews: PASS

## Rollout

The coordinator can consume the fields immediately because they are optional. Eligibility and donation reason coverage appears as providers adopt the release containing this change; holder lifecycle telemetry is coordinator-only.

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/568"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787381409&installation_model_id=21733&pr_number=568&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F568&signature=1fc8ca28ec4ecebbb20d0f3a6cb7410ff2390fa737dafa82f5c65575bf023e08"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->