### PR TITLE
fix(inference): replace flat 120s engine wall with typed progress leases (generation-deadline root fix)

### DIFF
--- a/coordinator/api/attempt_usage_route_test.go
+++ b/coordinator/api/attempt_usage_route_test.go
@@ -1,0 +1,199 @@
+package api
+
+// Attempt-usage observability (deadline incident fix): a typed error terminal
+// can carry the engine-reconciled partial usage of the failed attempt
+// (InferenceErrorMessage.AttemptUsage). The coordinator persists those token
+// counts on the route row — the incident's "every strict route had null
+// prompt_tokens/completion_tokens" gap — WITHOUT touching billing: refunds,
+// reservations, earnings, and cost stay exactly as for a usage-less error.
+
+import (
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+	"github.com/eigeninference/d-inference/coordinator/registry"
+	"github.com/eigeninference/d-inference/coordinator/store"
+)
+
+func attemptUsageErrMsg(reqID string, usage *protocol.UsageInfo) protocol.InferenceErrorMessage {
+	return protocol.InferenceErrorMessage{
+		Type:          protocol.TypeInferenceError,
+		RequestID:     reqID,
+		Error:         "request exceeded safety deadline",
+		StatusCode:    504,
+		TerminalCause: terminalCauseSafetyDeadline,
+		AttemptUsage:  usage,
+	}
+}
+
+// Every provider-error route-outcome constructor must carry the attempt usage
+// when present, and CompletionTokensSet must force-persist the authoritative
+// count (even 0) instead of leaving NULL.
+func TestProviderErrorOutcomesCarryAttemptUsage(t *testing.T) {
+	usage := &protocol.UsageInfo{PromptTokens: 123, CompletionTokens: 456, ReasoningTokens: 7}
+	pr := &registry.PendingRequest{RequestID: "req-usage", Model: "test-model"}
+	msg := attemptUsageErrMsg(pr.RequestID, usage)
+
+	cases := []struct {
+		name    string
+		outcome *store.InferenceRouteOutcome
+	}{
+		{"post_commit", postCommitProviderErrorOutcome(pr, msg)},
+		{"pre_response", preResponseProviderErrorOutcome(pr, msg)},
+		{"pre_commit", preCommitProviderErrorOutcome(pr, msg)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := tc.outcome
+			if out.PromptTokens != 123 || out.CompletionTokens != 456 || out.ReasoningTokens != 7 {
+				t.Errorf("tokens = %d/%d/%d, want 123/456/7",
+					out.PromptTokens, out.CompletionTokens, out.ReasoningTokens)
+			}
+			if !out.CompletionTokensSet {
+				t.Error("CompletionTokensSet must be true when attempt usage is present")
+			}
+			// ZERO billing: attempt usage must never invent a route cost.
+			if out.CostMicroUSD != 0 {
+				t.Errorf("CostMicroUSD = %d, want 0 (observability only)", out.CostMicroUSD)
+			}
+		})
+	}
+
+	// The client-error branch of preCommitProviderErrorOutcome keeps usage too.
+	clientMsg := attemptUsageErrMsg(pr.RequestID, usage)
+	clientMsg.StatusCode = 400
+	clientMsg.TerminalCause = ""
+	if out := preCommitProviderErrorOutcome(pr, clientMsg); out.PromptTokens != 123 || out.CompletionTokens != 456 {
+		t.Errorf("client-error branch tokens = %d/%d, want 123/456", out.PromptTokens, out.CompletionTokens)
+	}
+}
+
+// Legacy regression: without attempt usage the outcomes look exactly like
+// before — zero token values, with CompletionTokensSet still governed by the
+// terminal-status force rules (error=true, partial_success=false).
+func TestProviderErrorOutcomesWithoutAttemptUsageUnchanged(t *testing.T) {
+	pr := &registry.PendingRequest{RequestID: "req-legacy", Model: "test-model"}
+	msg := protocol.InferenceErrorMessage{
+		Type: protocol.TypeInferenceError, RequestID: pr.RequestID,
+		Error: "boom", StatusCode: 500,
+	}
+
+	pre := preCommitProviderErrorOutcome(pr, msg)
+	if pre.PromptTokens != 0 || pre.CompletionTokens != 0 || pre.ReasoningTokens != 0 {
+		t.Errorf("pre-commit legacy tokens = %d/%d/%d, want 0/0/0",
+			pre.PromptTokens, pre.CompletionTokens, pre.ReasoningTokens)
+	}
+	if !pre.CompletionTokensSet {
+		t.Error("error terminal must still force-persist completion_tokens=0 (existing behavior)")
+	}
+
+	post := postCommitProviderErrorOutcome(pr, msg)
+	if post.CompletionTokensSet {
+		t.Error("partial_success without usage must not force completion_tokens (existing behavior)")
+	}
+}
+
+// End-to-end persistence through the memory store: an error-terminal outcome
+// built from a usage-bearing message lands on the inference_routes row.
+func TestAttemptUsagePersistsOnErrorRouteRow(t *testing.T) {
+	st := store.NewMemory(store.Config{AdminKey: "test-key"})
+	pr := &registry.PendingRequest{RequestID: "req-row", Model: "test-model", Attempt: 0}
+	if err := st.RecordInferenceRoute(&store.InferenceRouteRecord{
+		RequestID:  pr.RequestID,
+		Attempt:    pr.Attempt,
+		Model:      pr.Model,
+		ProviderID: "prov-row",
+	}); err != nil {
+		t.Fatalf("RecordInferenceRoute: %v", err)
+	}
+
+	msg := attemptUsageErrMsg(pr.RequestID, &protocol.UsageInfo{PromptTokens: 123, CompletionTokens: 456, ReasoningTokens: 7})
+	if err := st.UpdateInferenceRouteOutcome(pr.RequestID, pr.Attempt, postCommitProviderErrorOutcome(pr, msg)); err != nil {
+		t.Fatalf("UpdateInferenceRouteOutcome: %v", err)
+	}
+
+	rec := findRouteRecord(st, pr.RequestID)
+	if rec == nil {
+		t.Fatal("route record not found")
+	}
+	if rec.FinalStatus != finalStatusPartialSuccess {
+		t.Errorf("final_status = %q, want partial_success", rec.FinalStatus)
+	}
+	if rec.PromptTokens != 123 || rec.CompletionTokens != 456 || rec.ReasoningTokens != 7 {
+		t.Errorf("persisted tokens = %d/%d/%d, want 123/456/7",
+			rec.PromptTokens, rec.CompletionTokens, rec.ReasoningTokens)
+	}
+	if rec.CostMicroUSD != 0 {
+		t.Errorf("cost_micro_usd = %d, want 0 (error terminals never bill from attempt usage)", rec.CostMicroUSD)
+	}
+}
+
+// The consumer-gone (parked settlement) branch of handleInferenceError also
+// persists attempt usage — and its refund behavior stays exactly as-is: the
+// full reservation is refunded no matter what usage the terminal reported.
+func TestConsumerGoneErrorPersistsAttemptUsageAndStillRefunds(t *testing.T) {
+	srv, st, ledger := billingTestServer(t)
+	srv.settleGrace = 5 * time.Second
+
+	model := "attempt-usage-gone-model"
+	provider := srv.registry.Register("attempt-usage-gone-provider", nil, &protocol.RegisterMessage{
+		Models: []protocol.ModelInfo{{ID: model, ModelType: "chat", Quantization: "4bit"}},
+	})
+	consumerID := testConsumerID
+	balanceBefore := ledger.Balance(consumerID)
+	const reserved int64 = 1_000_000
+	if err := ledger.Charge(consumerID, reserved, "reserve:attempt-usage-gone"); err != nil {
+		t.Fatalf("reserve balance: %v", err)
+	}
+	pr := &registry.PendingRequest{
+		RequestID:        "attempt-usage-gone",
+		Model:            model,
+		ConsumerKey:      consumerID,
+		ReservedMicroUSD: reserved,
+	}
+	if err := st.RecordInferenceRoute(&store.InferenceRouteRecord{
+		RequestID:  pr.RequestID,
+		Attempt:    pr.Attempt,
+		Model:      model,
+		ProviderID: provider.ID,
+	}); err != nil {
+		t.Fatalf("record route: %v", err)
+	}
+	parkConsumerGone(srv, provider, pr)
+
+	msg := attemptUsageErrMsg(pr.RequestID, &protocol.UsageInfo{PromptTokens: 321, CompletionTokens: 654, ReasoningTokens: 9})
+	srv.handleInferenceError(provider.ID, provider, &msg)
+
+	// Route update and refund are async off the read loop; poll briefly.
+	deadline := time.Now().Add(2 * time.Second)
+	var rec *store.InferenceRouteRecord
+	for time.Now().Before(deadline) {
+		rec = findRouteRecord(st, pr.RequestID)
+		if rec != nil && rec.FinalStatus != "" && ledger.Balance(consumerID) == balanceBefore {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if rec == nil || rec.FinalStatus == "" {
+		t.Fatal("route outcome never finalized")
+	}
+	if rec.PromptTokens != 321 || rec.CompletionTokens != 654 || rec.ReasoningTokens != 9 {
+		t.Errorf("persisted tokens = %d/%d/%d, want 321/654/9",
+			rec.PromptTokens, rec.CompletionTokens, rec.ReasoningTokens)
+	}
+	if rec.CostMicroUSD != 0 {
+		t.Errorf("cost_micro_usd = %d, want 0", rec.CostMicroUSD)
+	}
+	// ZERO billing change: full refund exactly as for a usage-less error.
+	if got := ledger.Balance(consumerID); got != balanceBefore {
+		t.Errorf("consumer balance = %d, want %d (full refund despite reported usage)", got, balanceBefore)
+	}
+	// A neutral typed cause on the parked path is health-neutral too.
+	provider.Mu().Lock()
+	failed := provider.Reputation.FailedJobs
+	provider.Mu().Unlock()
+	if failed != 0 {
+		t.Errorf("FailedJobs = %d, want 0 (safety_deadline is not a provider fault)", failed)
+	}
+}

--- a/coordinator/api/capacity_cooldown_followups_test.go
+++ b/coordinator/api/capacity_cooldown_followups_test.go
@@ -49,7 +49,7 @@ func TestCapacityCooldown404NotLoadedStrikes(t *testing.T) {
 	lazy := makeRoutableProvider(t, reg, "p-lazy-load", model)
 	for round := 0; round < 4; round++ {
 		for i := 0; i < 3; i++ {
-			srv.noteInferenceError(lazy.ID, capacityTestPending(model, lazy.ID, round*10+i), http.StatusNotFound, notLoaded, "")
+			srv.noteInferenceError(lazy.ID, capacityTestPending(model, lazy.ID, round*10+i), http.StatusNotFound, notLoaded, "", "")
 		}
 		srv.noteInferenceSuccess(capacityTestPending(model, lazy.ID, round))
 	}
@@ -60,7 +60,7 @@ func TestCapacityCooldown404NotLoadedStrikes(t *testing.T) {
 	// Black hole flavor: 404s forever, zero accepts — trips at the threshold.
 	stuck := makeRoutableProvider(t, reg, "p-never-loads", model)
 	for i := 0; i < 5; i++ {
-		srv.noteInferenceError(stuck.ID, capacityTestPending(model, stuck.ID, i), http.StatusNotFound, notLoaded, "")
+		srv.noteInferenceError(stuck.ID, capacityTestPending(model, stuck.ID, i), http.StatusNotFound, notLoaded, "", "")
 	}
 	if !reg.CapacityCooldownActive(stuck.ID, model) {
 		t.Fatal("a box that 404s 'not loaded' forever with zero accepts did not trip")
@@ -70,7 +70,7 @@ func TestCapacityCooldown404NotLoadedStrikes(t *testing.T) {
 	// request-shape error) never strikes, no matter how many arrive.
 	notFound := makeRoutableProvider(t, reg, "p-model-not-found", model)
 	for i := 0; i < 10; i++ {
-		srv.noteInferenceError(notFound.ID, capacityTestPending(model, notFound.ID, i), http.StatusNotFound, "model not found", "")
+		srv.noteInferenceError(notFound.ID, capacityTestPending(model, notFound.ID, i), http.StatusNotFound, "model not found", "", "")
 	}
 	if reg.CapacityCooldownActive(notFound.ID, model) {
 		t.Fatal("request-shape 404 'model not found' tripped the capacity cooldown")
@@ -98,7 +98,7 @@ func TestCapacityRateExcludesColdModelMiss(t *testing.T) {
 	// must stay empty.
 	cold := makeRoutableProvider(t, reg, "p-cold-miss", model)
 	for i := 0; i < sampleFloor; i++ {
-		srv.noteInferenceError(cold.ID, capacityTestPending(model, cold.ID, i), http.StatusNotFound, notLoaded, "")
+		srv.noteInferenceError(cold.ID, capacityTestPending(model, cold.ID, i), http.StatusNotFound, notLoaded, "", "")
 		srv.noteInferenceSuccess(capacityTestPending(model, cold.ID, i))
 	}
 	if rate, samples := reg.CapacityRejectRate(cold.ID, model); samples != 0 || rate != 0 {
@@ -109,7 +109,7 @@ func TestCapacityRateExcludesColdModelMiss(t *testing.T) {
 	// the rate — the mechanism the penalty exists for.
 	gray := makeRoutableProvider(t, reg, "p-graybox", model)
 	for i := 0; i < sampleFloor; i++ {
-		srv.noteInferenceError(gray.ID, capacityTestPending(model, gray.ID, i), http.StatusServiceUnavailable, genuine, "")
+		srv.noteInferenceError(gray.ID, capacityTestPending(model, gray.ID, i), http.StatusServiceUnavailable, genuine, "", "")
 		srv.noteInferenceSuccess(capacityTestPending(model, gray.ID, i))
 	}
 	if rate, samples := reg.CapacityRejectRate(gray.ID, model); samples == 0 || rate <= 0 {
@@ -142,7 +142,7 @@ func TestCapacityRejectDeterministicBatchBudgetArmsNoGrayBoxState(t *testing.T) 
 	// binding term was the context, identical fleet-wide.
 	det := makeRoutableProvider(t, reg, "p-oversized-prompt", model)
 	setProviderModelBudget(t, reg, det.ID, model, 5_000_000)
-	srv.noteInferenceError(det.ID, capacityTestPending(model, det.ID, 0), http.StatusServiceUnavailable, batchBudget, "")
+	srv.noteInferenceError(det.ID, capacityTestPending(model, det.ID, 0), http.StatusServiceUnavailable, batchBudget, "", "")
 	if reg.BudgetClampActive(det.ID, model) {
 		t.Fatal("a request-deterministic batch-budget reject must not arm the budget clamp")
 	}
@@ -152,7 +152,7 @@ func TestCapacityRejectDeterministicBatchBudgetArmsNoGrayBoxState(t *testing.T) 
 	// ...but repeated ones with zero interleaved accepts still trip the
 	// black-hole cooldown (the budget-misreporting signature).
 	for i := 1; i < 5; i++ {
-		srv.noteInferenceError(det.ID, capacityTestPending(model, det.ID, i), http.StatusServiceUnavailable, batchBudget, "")
+		srv.noteInferenceError(det.ID, capacityTestPending(model, det.ID, i), http.StatusServiceUnavailable, batchBudget, "", "")
 	}
 	if !reg.CapacityCooldownActive(det.ID, model) {
 		t.Fatal("repeated deterministic batch-budget rejects with zero accepts must still trip the cooldown")
@@ -163,7 +163,7 @@ func TestCapacityRejectDeterministicBatchBudgetArmsNoGrayBoxState(t *testing.T) 
 	// provider-specific capacity signal: full gray-box state.
 	pressured := makeRoutableProvider(t, reg, "p-pressured", model)
 	setProviderModelBudget(t, reg, pressured.ID, model, 90_000)
-	srv.noteInferenceError(pressured.ID, capacityTestPending(model, pressured.ID, 0), http.StatusServiceUnavailable, batchBudget, "")
+	srv.noteInferenceError(pressured.ID, capacityTestPending(model, pressured.ID, 0), http.StatusServiceUnavailable, batchBudget, "", "")
 	if !reg.BudgetClampActive(pressured.ID, model) {
 		t.Fatal("a node-pressured batch-budget reject (budget < context) must arm the budget clamp")
 	}
@@ -196,7 +196,7 @@ func TestGrayBoxClassificationTrustsStructuredReason(t *testing.T) {
 	nodeBudget := makeRoutableProvider(t, reg, "p-reasoned-node", model)
 	setProviderModelBudget(t, reg, nodeBudget.ID, model, 5_000_000)
 	srv.noteInferenceError(nodeBudget.ID, capacityTestPending(model, nodeBudget.ID, 0),
-		http.StatusServiceUnavailable, batchBudget, "request_exceeds_node_budget")
+		http.StatusServiceUnavailable, batchBudget, "request_exceeds_node_budget", "")
 	if !reg.BudgetClampActive(nodeBudget.ID, model) {
 		t.Fatal("a structured request_exceeds_node_budget reason must feed the clamp despite the stale >=context budget snapshot")
 	}
@@ -209,7 +209,7 @@ func TestGrayBoxClassificationTrustsStructuredReason(t *testing.T) {
 	legacy := makeRoutableProvider(t, reg, "p-reasonless", model)
 	setProviderModelBudget(t, reg, legacy.ID, model, 5_000_000)
 	srv.noteInferenceError(legacy.ID, capacityTestPending(model, legacy.ID, 0),
-		http.StatusServiceUnavailable, batchBudget, "")
+		http.StatusServiceUnavailable, batchBudget, "", "")
 	if reg.BudgetClampActive(legacy.ID, model) {
 		t.Fatal("reasonless deterministic batch-budget reject must stay strike-only (heuristic unchanged)")
 	}
@@ -222,7 +222,7 @@ func TestGrayBoxClassificationTrustsStructuredReason(t *testing.T) {
 	srv.noteInferenceError(ctxReason.ID, capacityTestPending(model, ctxReason.ID, 0),
 		http.StatusServiceUnavailable,
 		"token_budget_exhausted: request requires 200000 tokens but only 90000 available",
-		"request_exceeds_context")
+		"request_exceeds_context", "")
 	if reg.BudgetClampActive(ctxReason.ID, model) {
 		t.Fatal("an explicit request_exceeds_context reason must not arm the clamp")
 	}

--- a/coordinator/api/capacity_cooldown_test.go
+++ b/coordinator/api/capacity_cooldown_test.go
@@ -105,7 +105,7 @@ func TestCapacityCooldownTripsMetricLogAndRoutingDiverts(t *testing.T) {
 	// The incident pattern: every dispatch to the black hole bounces with the
 	// capacity string (classified 503) and it never serves anything.
 	for i := 0; i < 8; i++ {
-		srv.noteInferenceError(blackHole.ID, capacityTestPending(model, blackHole.ID, i), 503, rejectStr, "")
+		srv.noteInferenceError(blackHole.ID, capacityTestPending(model, blackHole.ID, i), 503, rejectStr, "", "")
 	}
 	if !reg.CapacityCooldownActive(blackHole.ID, model) {
 		t.Fatal("black-hole provider not in capacity cooldown after 8 zero-accept rejects")
@@ -142,7 +142,7 @@ func TestCapacityCooldownTripsMetricLogAndRoutingDiverts(t *testing.T) {
 	// keeps SERVING (accepts interleaved), so it must NEVER trip.
 	for round := 0; round < 5; round++ {
 		for i := 0; i < 4; i++ {
-			srv.noteInferenceError(healthy.ID, capacityTestPending(model, healthy.ID, round*10+i), 503, rejectStr, "")
+			srv.noteInferenceError(healthy.ID, capacityTestPending(model, healthy.ID, round*10+i), 503, rejectStr, "", "")
 		}
 		srv.noteInferenceSuccess(capacityTestPending(model, healthy.ID, round))
 	}
@@ -153,7 +153,7 @@ func TestCapacityCooldownTripsMetricLogAndRoutingDiverts(t *testing.T) {
 	// Client-shape 4xx carrying a capacity-looking string never strikes.
 	other := makeRoutableProvider(t, reg, "p-4xx", model)
 	for i := 0; i < 10; i++ {
-		srv.noteInferenceError(other.ID, capacityTestPending(model, other.ID, i), 400, rejectStr, "")
+		srv.noteInferenceError(other.ID, capacityTestPending(model, other.ID, i), 400, rejectStr, "", "")
 	}
 	if reg.CapacityCooldownActive(other.ID, model) {
 		t.Fatal("client-shape 4xx with a capacity string tripped the capacity cooldown")
@@ -164,7 +164,7 @@ func TestCapacityCooldownTripsMetricLogAndRoutingDiverts(t *testing.T) {
 	ctxProvider := makeRoutableProvider(t, reg, "p-ctx", model)
 	for i := 0; i < 10; i++ {
 		srv.noteInferenceError(ctxProvider.ID, capacityTestPending(model, ctxProvider.ID, i), 503,
-			"token_budget_exhausted: request exceeds model context window (200000 prompt tokens > 131072 context)", "")
+			"token_budget_exhausted: request exceeds model context window (200000 prompt tokens > 131072 context)", "", "")
 	}
 	if reg.CapacityCooldownActive(ctxProvider.ID, model) {
 		t.Fatal("deterministic context-overflow rejections tripped the capacity cooldown")
@@ -211,7 +211,7 @@ func TestCapacityCooldownRetryReselectionEscapesSink(t *testing.T) {
 			// The sink instantly capacity-rejects; the retry loop records the
 			// failure and re-selects.
 			sinkPicks++
-			srv.noteInferenceError(sink.ID, pr, 503, rejectStr, "")
+			srv.noteInferenceError(sink.ID, pr, 503, rejectStr, "", "")
 			reg.SetProviderIdle(sink.ID)
 			continue
 		}

--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -293,7 +293,14 @@ func (s *Server) writeGenericProviderError(w http.ResponseWriter, errMsg protoco
 // InferenceErrorMessage.ErrorReason ("" for synthetic timeouts and legacy
 // providers) — the reason feeds the gray-box request-shape classification the
 // same way the dispatch failover trusts it (classifyRejection P1).
-func (s *Server) noteInferenceError(providerID string, pr *registry.PendingRequest, statusCode int, errStr, errReason string) {
+// terminalCause is the provider's typed InferenceErrorMessage.TerminalCause
+// ("" for synthetic terminals and legacy providers): a typed NEUTRAL cause
+// (safety_deadline / backpressure_timeout / cancelled — platform policy or
+// consumer behavior) feeds NOTHING here, strike or clear; a typed CAPACITY
+// cause (admission_timeout — healthy but busy) feeds only the black-hole
+// capacity cooldown. Absent/engine_error/unknown causes keep the legacy
+// status/string funnels bit-for-bit (see api/terminal_cause.go).
+func (s *Server) noteInferenceError(providerID string, pr *registry.PendingRequest, statusCode int, errStr, errReason, terminalCause string) {
 	if providerID == "" || pr == nil {
 		return
 	}
@@ -308,6 +315,31 @@ func (s *Server) noteInferenceError(providerID string, pr *registry.PendingReque
 	// pre-commit provider errors. Capacity-class rejections never carry these
 	// reasons, so the capacity-reject cooldown feed below is unaffected.
 	if isNonProviderFaultErrorReason(errReason) {
+		return
+	}
+	// Typed terminal-cause gate (the deadline-incident fix): the provider told
+	// us WHY the attempt died, so the status/string heuristics below must not
+	// misread a platform-policy terminal as sickness. Neutral causes touch no
+	// tracker at all — strictly neutral, never a success/clear either.
+	// admission_timeout records exactly one capacity-signal strike (the
+	// black-hole cooldown, whose zero-interleaved-accepts discriminator keeps
+	// serving boxes safe) and skips every fault breaker. All other causes —
+	// absent (legacy/synthetic), engine_error, the fault causes
+	// (prefill_stall / decode_stall / watchdog), and unknown drift values —
+	// fall through to the unchanged legacy funnels.
+	switch class, _ := classifyTerminalCause(terminalCause); class {
+	case causeClassNeutral:
+		return
+	case causeClassCapacity:
+		if s.registry.RecordCapacityRejectBusy(providerID, pr.Model) {
+			s.ddIncr(metricCapacityCooldownTripped, []string{"provider_id:" + providerID, "model:" + pr.Model})
+			s.logger.Warn("capacity-reject cooldown tripped: provider+model admission-timing-out with zero interleaved accepts — routing will skip the pair until the cooldown expires",
+				"provider_id", providerID,
+				"model", pr.Model,
+				"status_code", statusCode,
+				"terminal_cause", terminalCause,
+			)
+		}
 		return
 	}
 	if s.registry.RecordInferenceError(providerID, pr.Model, statusCode, pr.Traits.CooldownShape()) {
@@ -486,9 +518,9 @@ func (s *Server) noteInferenceSuccess(pr *registry.PendingRequest) {
 // so arms where cancelDispatch did refund are safe, and a failed pre-commit
 // attempt never reaches settlement (its channels are closed and it is neither
 // pending nor parked), so this can never double-credit against a settle.
-func (s *Server) noteDispatchProviderError(provider *registry.Provider, pr *registry.PendingRequest, statusCode int, errStr, errReason string, held *[]string) (discardedHeld bool) {
+func (s *Server) noteDispatchProviderError(provider *registry.Provider, pr *registry.PendingRequest, statusCode int, errStr, errReason, terminalCause string, held *[]string) (discardedHeld bool) {
 	if provider != nil {
-		s.noteInferenceError(provider.ID, pr, statusCode, errStr, errReason)
+		s.noteInferenceError(provider.ID, pr, statusCode, errStr, errReason, terminalCause)
 	}
 	s.refundProviderExtra(pr)
 	if held == nil || len(*held) == 0 {
@@ -1907,7 +1939,7 @@ func (s *Server) handleStreamingResponseWithFirstChunk(w http.ResponseWriter, r 
 				case errMsg, ok := <-pr.ErrorCh:
 					if ok && errMsg.Error != "" {
 						s.refundReservedBalance(pr, "provider_error:"+pr.RequestID)
-						s.noteInferenceError(pr.ProviderID, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason)
+						s.noteInferenceError(pr.ProviderID, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason, errMsg.TerminalCause)
 						s.ddIncr("inference.in_band_error", []string{"model:" + pr.Model, "reason:provider_error"})
 						s.updateInferenceRouteOutcomeForPending(pr, postCommitProviderErrorOutcome(pr, errMsg))
 						errData, _ := json.Marshal(map[string]any{
@@ -2052,7 +2084,7 @@ func (s *Server) handleStreamingResponseWithFirstChunk(w http.ResponseWriter, r 
 				continue
 			}
 			s.refundReservedBalance(pr, "provider_error:"+pr.RequestID)
-			s.noteInferenceError(pr.ProviderID, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason)
+			s.noteInferenceError(pr.ProviderID, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason, errMsg.TerminalCause)
 			s.ddIncr("inference.in_band_error", []string{"model:" + pr.Model, "reason:provider_error"})
 			s.updateInferenceRouteOutcomeForPending(pr, postCommitProviderErrorOutcome(pr, errMsg))
 			errData, _ := json.Marshal(map[string]any{
@@ -2143,7 +2175,7 @@ func (s *Server) handleResponsesStreamingResponseWithFirstChunk(w http.ResponseW
 				continue
 			}
 			s.refundReservedBalance(pr, "provider_error:"+pr.RequestID)
-			s.noteInferenceError(pr.ProviderID, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason)
+			s.noteInferenceError(pr.ProviderID, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason, errMsg.TerminalCause)
 			s.ddIncr("inference.in_band_error", []string{"model:" + pr.Model, "reason:provider_error"})
 			s.updateInferenceRouteOutcomeForPending(pr, postCommitProviderErrorOutcome(pr, errMsg))
 			emitter.emitError("provider_error", errMsg.Error)
@@ -2185,7 +2217,7 @@ func (s *Server) handleNonStreamingResponseWithFirstChunk(w http.ResponseWriter,
 				case errMsg, ok := <-pr.ErrorCh:
 					if ok && errMsg.Error != "" {
 						s.refundReservedBalance(pr, "provider_error:"+pr.RequestID)
-						s.noteInferenceError(pr.ProviderID, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason)
+						s.noteInferenceError(pr.ProviderID, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason, errMsg.TerminalCause)
 						s.updateInferenceRouteOutcomeForPending(pr, preResponseProviderErrorOutcome(pr, errMsg))
 						s.writeGenericProviderError(w, errMsg)
 						return
@@ -2334,7 +2366,7 @@ func (s *Server) handleNonStreamingResponseWithFirstChunk(w http.ResponseWriter,
 				continue
 			}
 			s.refundReservedBalance(pr, "provider_error:"+pr.RequestID)
-			s.noteInferenceError(pr.ProviderID, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason)
+			s.noteInferenceError(pr.ProviderID, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason, errMsg.TerminalCause)
 			s.updateInferenceRouteOutcomeForPending(pr, preResponseProviderErrorOutcome(pr, errMsg))
 			s.writeGenericProviderError(w, errMsg)
 			return
@@ -4464,7 +4496,7 @@ reserveProvider:
 				s.sendProviderCancel(provider, requestID)
 				refundExtra()
 				refundReservation()
-				s.noteInferenceError(provider.ID, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason)
+				s.noteInferenceError(provider.ID, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason, errMsg.TerminalCause)
 				s.updateInferenceRouteOutcomeForPending(pr, preCommitProviderErrorOutcome(pr, errMsg))
 				s.writeGenericProviderError(w, errMsg)
 				return
@@ -4479,7 +4511,7 @@ reserveProvider:
 		s.sendProviderCancel(provider, requestID)
 		refundExtra()
 		refundReservation()
-		s.noteInferenceError(provider.ID, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason)
+		s.noteInferenceError(provider.ID, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason, errMsg.TerminalCause)
 		s.updateInferenceRouteOutcomeForPending(pr, preCommitProviderErrorOutcome(pr, errMsg))
 		s.writeGenericProviderError(w, errMsg)
 		return
@@ -4531,7 +4563,7 @@ reserveProvider:
 					s.sendProviderCancel(provider, requestID)
 					refundExtra()
 					refundReservation()
-					s.noteInferenceError(provider.ID, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason)
+					s.noteInferenceError(provider.ID, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason, errMsg.TerminalCause)
 					s.updateInferenceRouteOutcomeForPending(pr, preCommitProviderErrorOutcome(pr, errMsg))
 					s.writeGenericProviderError(w, errMsg)
 					return
@@ -4546,7 +4578,7 @@ reserveProvider:
 			s.sendProviderCancel(provider, requestID)
 			refundExtra()
 			refundReservation()
-			s.noteInferenceError(provider.ID, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason)
+			s.noteInferenceError(provider.ID, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason, errMsg.TerminalCause)
 			s.updateInferenceRouteOutcomeForPending(pr, preCommitProviderErrorOutcome(pr, errMsg))
 			s.writeGenericProviderError(w, errMsg)
 			return
@@ -4560,7 +4592,7 @@ reserveProvider:
 			// breaker (single-attempt path: no retry here, but repeated
 			// stalls must still accumulate into the routing cooldown). No
 			// provider message on this synthetic timeout, so errStr is "".
-			s.noteInferenceError(provider.ID, pr, http.StatusGatewayTimeout, "", "")
+			s.noteInferenceError(provider.ID, pr, http.StatusGatewayTimeout, "", "", "")
 			s.ddIncr("inference.dispatches", []string{"status:timeout"})
 			s.updateInferenceRouteOutcomeForPending(pr, pendingRouteOutcome(pr, "timeout", "accepted_timeout", http.StatusGatewayTimeout))
 			writeJSON(w, http.StatusGatewayTimeout, errorResponse("timeout", "provider accepted but timed out before first chunk"))

--- a/coordinator/api/dispatch.go
+++ b/coordinator/api/dispatch.go
@@ -1494,13 +1494,16 @@ func (d *dispatchState) waitFirstChunk() (outcome dispatchOutcome) {
 		case outcomeCommitted:
 			d.updateRoutingOutcomeForAttempt(target, d.successRoutingOutcomeFor(target.pending))
 		case outcomeRetry:
-			// A 504 here is a coordinator-synthesized first-chunk timeout ONLY
-			// when there is no typed terminal cause: a typed provider 504
-			// (safety_deadline / backpressure_timeout) is a real provider
-			// terminal and must keep its provider-error route class and its
-			// attempt usage (setLastError clears the cause for synthetic
-			// timeouts, so the discriminator cannot go stale).
-			if d.lastErrCode == http.StatusGatewayTimeout && d.lastErrTerminalCause == "" {
+			// A 504 here is a coordinator-synthesized first-chunk timeout
+			// unless it carries a KNOWN typed 504 cause (safety_deadline /
+			// backpressure_timeout) — those are real provider terminals and
+			// keep their provider-error route class and attempt usage.
+			// setLastError clears the cause for synthetic timeouts (so the
+			// discriminator cannot go stale), and an UNKNOWN cause value
+			// stays on this legacy timeout path, mirroring
+			// classifyTerminalCause's unknown→legacy rule for mixed-version
+			// rollouts.
+			if d.lastErrCode == http.StatusGatewayTimeout && !isTypedTimeout504Cause(d.lastErrTerminalCause) {
 				d.updateRoutingOutcomeForAttempt(target, d.errorRoutingOutcomeFor(target.pending, "timeout", "first_chunk_timeout", d.lastErrCode))
 			} else {
 				// Post-dispatch provider failure (incl. OOM/model-load): admitted but failed.
@@ -2329,9 +2332,10 @@ func (d *dispatchState) waitAccepted() (outcome dispatchOutcome) {
 		case outcomeCommitted:
 			d.updateRoutingOutcomeForAttempt(target, d.successRoutingOutcomeFor(target.pending))
 		case outcomeRetry:
-			// Synthetic-timeout 504s only when untyped — a typed provider 504
-			// keeps its provider-error class + usage (see waitFirstChunk).
-			if d.lastErrCode == http.StatusGatewayTimeout && d.lastErrTerminalCause == "" {
+			// Synthetic-timeout 504s unless a KNOWN typed 504 cause — a typed
+			// provider 504 keeps its provider-error class + usage; unknown
+			// causes stay legacy (see waitFirstChunk).
+			if d.lastErrCode == http.StatusGatewayTimeout && !isTypedTimeout504Cause(d.lastErrTerminalCause) {
 				if d.preambleLiveness {
 					d.updateRoutingOutcomeForAttempt(target, d.errorRoutingOutcomeFor(target.pending, "timeout", "preamble_liveness_timeout", d.lastErrCode))
 				} else {

--- a/coordinator/api/dispatch.go
+++ b/coordinator/api/dispatch.go
@@ -566,6 +566,14 @@ func (d *dispatchState) setLastError(errText string, statusCode int) {
 	// fault): clear any budget captured from a prior attempt so it never bleeds
 	// into a later classification.
 	d.lastErrProviderBudget = 0
+	// Same bleed-through rule for the typed terminal fields: a coordinator-
+	// synthesized error is not a provider terminal, so a stale typed cause from
+	// a prior attempt must not reclassify it (shouldStopFailover trusts a typed
+	// admission_timeout as transient capacity) and stale usage must not land on
+	// its route row. An empty cause here is also what lets the wait loops'
+	// 504 branches tell a synthetic timeout from a typed provider 504.
+	d.lastErrTerminalCause = ""
+	d.lastErrAttemptUsage = nil
 }
 
 func (d *dispatchState) noteProviderBodyTooLarge(errText string, bodyBytes int) {
@@ -1486,7 +1494,13 @@ func (d *dispatchState) waitFirstChunk() (outcome dispatchOutcome) {
 		case outcomeCommitted:
 			d.updateRoutingOutcomeForAttempt(target, d.successRoutingOutcomeFor(target.pending))
 		case outcomeRetry:
-			if d.lastErrCode == http.StatusGatewayTimeout {
+			// A 504 here is a coordinator-synthesized first-chunk timeout ONLY
+			// when there is no typed terminal cause: a typed provider 504
+			// (safety_deadline / backpressure_timeout) is a real provider
+			// terminal and must keep its provider-error route class and its
+			// attempt usage (setLastError clears the cause for synthetic
+			// timeouts, so the discriminator cannot go stale).
+			if d.lastErrCode == http.StatusGatewayTimeout && d.lastErrTerminalCause == "" {
 				d.updateRoutingOutcomeForAttempt(target, d.errorRoutingOutcomeFor(target.pending, "timeout", "first_chunk_timeout", d.lastErrCode))
 			} else {
 				// Post-dispatch provider failure (incl. OOM/model-load): admitted but failed.
@@ -2315,7 +2329,9 @@ func (d *dispatchState) waitAccepted() (outcome dispatchOutcome) {
 		case outcomeCommitted:
 			d.updateRoutingOutcomeForAttempt(target, d.successRoutingOutcomeFor(target.pending))
 		case outcomeRetry:
-			if d.lastErrCode == http.StatusGatewayTimeout {
+			// Synthetic-timeout 504s only when untyped — a typed provider 504
+			// keeps its provider-error class + usage (see waitFirstChunk).
+			if d.lastErrCode == http.StatusGatewayTimeout && d.lastErrTerminalCause == "" {
 				if d.preambleLiveness {
 					d.updateRoutingOutcomeForAttempt(target, d.errorRoutingOutcomeFor(target.pending, "timeout", "preamble_liveness_timeout", d.lastErrCode))
 				} else {

--- a/coordinator/api/dispatch.go
+++ b/coordinator/api/dispatch.go
@@ -1246,8 +1246,8 @@ func (d *dispatchState) dispatchPrimary() dispatchOutcome {
 // provider error and, unless held boilerplate was discarded (which emits its own
 // pre-content failover counter), emits the generic retry counter. This is the
 // exact `if !d.noteProviderError(...) { s.ddIncr(retry) }` pattern.
-func (d *dispatchState) noteDispatchRetry(provider *registry.Provider, pr *registry.PendingRequest, statusCode int, errStr, errReason string, held *[]string) {
-	if !d.noteProviderError(provider, pr, statusCode, errStr, errReason, held) {
+func (d *dispatchState) noteDispatchRetry(provider *registry.Provider, pr *registry.PendingRequest, statusCode int, errStr, errReason, terminalCause string, held *[]string) {
+	if !d.noteProviderError(provider, pr, statusCode, errStr, errReason, terminalCause, held) {
 		d.s.ddIncr("inference.dispatches", []string{"status:retry"})
 	}
 }
@@ -1276,11 +1276,11 @@ func (d *dispatchState) noteDispatchRetry(provider *registry.Provider, pr *regis
 // (with its retry_precontent counter) run for EVERY reason:
 // noteDispatchProviderError only feeds noteInferenceError for a non-nil
 // provider, while the refund + held handling are unconditional.
-func (d *dispatchState) noteProviderError(provider *registry.Provider, pr *registry.PendingRequest, statusCode int, errStr, errReason string, held *[]string) (discardedHeld bool) {
+func (d *dispatchState) noteProviderError(provider *registry.Provider, pr *registry.PendingRequest, statusCode int, errStr, errReason, terminalCause string, held *[]string) (discardedHeld bool) {
 	if isNonProviderFaultErrorReason(errReason) {
 		provider = nil
 	}
-	return d.s.noteDispatchProviderError(provider, pr, statusCode, errStr, errReason, held)
+	return d.s.noteDispatchProviderError(provider, pr, statusCode, errStr, errReason, terminalCause, held)
 }
 
 // rejectionReasonOversized is the rejection-ledger reason_code for a request the
@@ -1494,7 +1494,7 @@ func (d *dispatchState) waitFirstChunk() (outcome dispatchOutcome) {
 					s.cancelDispatch(provider, pr)
 					d.setLastInferenceError(provider, errMsg)
 					d.lastFailedVersion = failedProviderVersion(provider)
-					d.noteDispatchRetry(provider, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason, &d.heldChunks)
+					d.noteDispatchRetry(provider, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason, errMsg.TerminalCause, &d.heldChunks)
 					d.provider = nil
 					d.pr = nil
 					return outcomeRetry
@@ -1536,7 +1536,7 @@ func (d *dispatchState) waitFirstChunk() (outcome dispatchOutcome) {
 			if s.metrics != nil {
 				s.metrics.IncCounter("inference_dispatches_total", MetricLabel{"result", "retry"})
 			}
-			d.noteDispatchRetry(provider, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason, &d.heldChunks)
+			d.noteDispatchRetry(provider, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason, errMsg.TerminalCause, &d.heldChunks)
 			d.provider = nil
 			d.pr = nil
 			return outcomeRetry
@@ -1714,7 +1714,7 @@ func (d *dispatchState) waitNoBackup() dispatchOutcome {
 					s.cancelDispatch(provider, pr)
 					d.setLastInferenceError(provider, errMsg)
 					d.lastFailedVersion = failedProviderVersion(provider)
-					d.noteDispatchRetry(provider, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason, &d.heldChunks)
+					d.noteDispatchRetry(provider, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason, errMsg.TerminalCause, &d.heldChunks)
 					d.provider = nil
 					d.pr = nil
 					return outcomeRetry
@@ -1736,7 +1736,7 @@ func (d *dispatchState) waitNoBackup() dispatchOutcome {
 			if s.metrics != nil {
 				s.metrics.IncCounter("inference_dispatches_total", MetricLabel{"result", "retry"})
 			}
-			d.noteDispatchRetry(provider, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason, &d.heldChunks)
+			d.noteDispatchRetry(provider, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason, errMsg.TerminalCause, &d.heldChunks)
 			d.provider = nil
 			d.pr = nil
 			return outcomeRetry
@@ -1828,7 +1828,7 @@ func (d *dispatchState) runRace(backupProvider *registry.Provider, backupPR *reg
 					s.cancelDispatch(provider, pr)
 					d.setLastInferenceError(provider, errMsg)
 					d.lastFailedVersion = failedProviderVersion(provider)
-					d.noteDispatchRetry(provider, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason, &d.heldChunks)
+					d.noteDispatchRetry(provider, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason, errMsg.TerminalCause, &d.heldChunks)
 					d.provider = nil
 					d.pr = nil
 					return outcomeRetry
@@ -1867,7 +1867,7 @@ func (d *dispatchState) runRace(backupProvider *registry.Provider, backupPR *reg
 					d.excludeProviders[backupProvider.ID] = struct{}{}
 					d.lastFailedVersion = failedProviderVersion(backupProvider)
 					d.updateSpeculativeFailure(backupPR, errMsg)
-					d.noteProviderError(backupProvider, backupPR, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason, &backupHeld)
+					d.noteProviderError(backupProvider, backupPR, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason, errMsg.TerminalCause, &backupHeld)
 					// Preserve a deterministic-unservable verdict from this loser so the
 					// surviving primary's error can't mask it (see latchDeterministicLoser).
 					d.latchDeterministicLoser(backupProvider, errMsg)
@@ -1915,7 +1915,7 @@ func (d *dispatchState) runRace(backupProvider *registry.Provider, backupPR *reg
 			s.cancelDispatch(provider, pr)
 			d.lastFailedVersion = failedProviderVersion(provider)
 			d.updateSpeculativeFailure(pr, errMsg)
-			d.noteProviderError(provider, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason, &d.heldChunks)
+			d.noteProviderError(provider, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason, errMsg.TerminalCause, &d.heldChunks)
 			// Preserve a deterministic-unservable verdict from this loser so the
 			// surviving backup's error can't mask it (see latchDeterministicLoser).
 			d.latchDeterministicLoser(provider, errMsg)
@@ -1931,7 +1931,7 @@ func (d *dispatchState) runRace(backupProvider *registry.Provider, backupPR *reg
 			s.cancelDispatch(backupProvider, backupPR)
 			d.lastFailedVersion = failedProviderVersion(backupProvider)
 			d.updateSpeculativeFailure(backupPR, errMsg)
-			d.noteProviderError(backupProvider, backupPR, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason, &backupHeld)
+			d.noteProviderError(backupProvider, backupPR, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason, errMsg.TerminalCause, &backupHeld)
 			// Preserve a deterministic-unservable verdict from this loser so the
 			// surviving primary's error can't mask it (see latchDeterministicLoser).
 			d.latchDeterministicLoser(backupProvider, errMsg)
@@ -1955,10 +1955,10 @@ func (d *dispatchState) runRace(backupProvider *registry.Provider, backupPR *reg
 			// acceptedWait timeout path so a stalling provider/model
 			// (shape-keyed) trips its cooldown.
 			if len(d.heldChunks) > 0 {
-				s.noteInferenceError(provider.ID, pr, http.StatusGatewayTimeout, "", "")
+				s.noteInferenceError(provider.ID, pr, http.StatusGatewayTimeout, "", "", "")
 			}
 			if len(backupHeld) > 0 {
-				s.noteInferenceError(backupProvider.ID, backupPR, http.StatusGatewayTimeout, "", "")
+				s.noteInferenceError(backupProvider.ID, backupPR, http.StatusGatewayTimeout, "", "", "")
 			}
 			s.cancelDispatch(provider, pr)
 			s.registry.RecordWarmPoolTTFTMiss(d.model, d.deadline)
@@ -2014,7 +2014,7 @@ func (d *dispatchState) raceBackupChunkClosedWaitPrimary(provider *registry.Prov
 					d.setLastInferenceError(provider, errMsg2)
 					d.lastFailedVersion = failedProviderVersion(provider)
 					d.updateSpeculativeFailure(pr, errMsg2)
-					d.noteDispatchRetry(provider, pr, errMsg2.StatusCode, errMsg2.Error, errMsg2.ErrorReason, &d.heldChunks)
+					d.noteDispatchRetry(provider, pr, errMsg2.StatusCode, errMsg2.Error, errMsg2.ErrorReason, errMsg2.TerminalCause, &d.heldChunks)
 					d.provider = nil
 					d.pr = nil
 					d.requestID = ""
@@ -2039,7 +2039,7 @@ func (d *dispatchState) raceBackupChunkClosedWaitPrimary(provider *registry.Prov
 			d.setLastInferenceError(provider, errMsg2)
 			d.lastFailedVersion = failedProviderVersion(provider)
 			d.updateSpeculativeFailure(pr, errMsg2)
-			d.noteDispatchRetry(provider, pr, errMsg2.StatusCode, errMsg2.Error, errMsg2.ErrorReason, &d.heldChunks)
+			d.noteDispatchRetry(provider, pr, errMsg2.StatusCode, errMsg2.Error, errMsg2.ErrorReason, errMsg2.TerminalCause, &d.heldChunks)
 			d.provider = nil
 			d.pr = nil
 			d.requestID = ""
@@ -2111,7 +2111,7 @@ func (d *dispatchState) racePrimaryFailedWaitBackup(backupProvider *registry.Pro
 					d.setLastInferenceError(backupProvider, errMsg2)
 					d.lastFailedVersion = failedProviderVersion(backupProvider)
 					d.updateSpeculativeFailure(backupPR, errMsg2)
-					d.noteDispatchRetry(backupProvider, backupPR, errMsg2.StatusCode, errMsg2.Error, errMsg2.ErrorReason, &backupHeld)
+					d.noteDispatchRetry(backupProvider, backupPR, errMsg2.StatusCode, errMsg2.Error, errMsg2.ErrorReason, errMsg2.TerminalCause, &backupHeld)
 					d.provider = nil
 					d.pr = nil
 					return outcomeRetry
@@ -2141,7 +2141,7 @@ func (d *dispatchState) racePrimaryFailedWaitBackup(backupProvider *registry.Pro
 			d.setLastInferenceError(backupProvider, errMsg2)
 			d.lastFailedVersion = failedProviderVersion(backupProvider)
 			d.updateSpeculativeFailure(backupPR, errMsg2)
-			d.noteProviderError(backupProvider, backupPR, errMsg2.StatusCode, errMsg2.Error, errMsg2.ErrorReason, &backupHeld)
+			d.noteProviderError(backupProvider, backupPR, errMsg2.StatusCode, errMsg2.Error, errMsg2.ErrorReason, errMsg2.TerminalCause, &backupHeld)
 			d.provider = nil
 			d.pr = nil
 			return outcomeRetry
@@ -2206,7 +2206,7 @@ func (d *dispatchState) raceBackupErrWaitPrimary(provider *registry.Provider, pr
 					s.cancelDispatch(provider, pr)
 					d.setLastInferenceError(provider, errMsg2)
 					d.lastFailedVersion = failedProviderVersion(provider)
-					d.noteDispatchRetry(provider, pr, errMsg2.StatusCode, errMsg2.Error, errMsg2.ErrorReason, &d.heldChunks)
+					d.noteDispatchRetry(provider, pr, errMsg2.StatusCode, errMsg2.Error, errMsg2.ErrorReason, errMsg2.TerminalCause, &d.heldChunks)
 					d.provider = nil
 					d.pr = nil
 					return outcomeRetry
@@ -2226,7 +2226,7 @@ func (d *dispatchState) raceBackupErrWaitPrimary(provider *registry.Provider, pr
 			d.setLastInferenceError(provider, errMsg2)
 			d.lastFailedVersion = failedProviderVersion(provider)
 			d.updateSpeculativeFailure(pr, errMsg2)
-			d.noteProviderError(provider, pr, errMsg2.StatusCode, errMsg2.Error, errMsg2.ErrorReason, &d.heldChunks)
+			d.noteProviderError(provider, pr, errMsg2.StatusCode, errMsg2.Error, errMsg2.ErrorReason, errMsg2.TerminalCause, &d.heldChunks)
 			d.provider = nil
 			d.pr = nil
 			d.requestID = ""
@@ -2343,7 +2343,7 @@ func (d *dispatchState) waitAccepted() (outcome dispatchOutcome) {
 					if s.metrics != nil {
 						s.metrics.IncCounter("inference_dispatches_total", MetricLabel{"result", "retry"})
 					}
-					d.noteDispatchRetry(provider, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason, &d.heldChunks)
+					d.noteDispatchRetry(provider, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason, errMsg.TerminalCause, &d.heldChunks)
 					d.provider = nil
 					d.pr = nil
 					return outcomeRetry
@@ -2375,7 +2375,7 @@ func (d *dispatchState) waitAccepted() (outcome dispatchOutcome) {
 			if s.metrics != nil {
 				s.metrics.IncCounter("inference_dispatches_total", MetricLabel{"result", "retry"})
 			}
-			d.noteDispatchRetry(provider, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason, &d.heldChunks)
+			d.noteDispatchRetry(provider, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason, errMsg.TerminalCause, &d.heldChunks)
 			d.provider = nil
 			d.pr = nil
 			return outcomeRetry
@@ -2388,7 +2388,7 @@ func (d *dispatchState) waitAccepted() (outcome dispatchOutcome) {
 			// that repeatedly acks and stalls enters cooldown instead
 			// of soaking retries forever. (504 is one of the breaker's
 			// counted codes; this arm is where those 504s originate.)
-			s.noteInferenceError(provider.ID, pr, http.StatusGatewayTimeout, "", "")
+			s.noteInferenceError(provider.ID, pr, http.StatusGatewayTimeout, "", "", "")
 			d.setLastError("provider accepted but timed out before first chunk", http.StatusGatewayTimeout)
 			if d.preambleLiveness {
 				d.setLastError("provider sent preamble but stalled before first content", http.StatusGatewayTimeout)

--- a/coordinator/api/dispatch.go
+++ b/coordinator/api/dispatch.go
@@ -135,7 +135,18 @@ type dispatchState struct {
 	// budget" rejection as deterministic (budget >= context) vs transient
 	// (budget < context — this node was memory-pressured).
 	lastErrProviderBudget int64
-	committed             bool
+	// lastErrTerminalCause is the typed terminal_cause from the last provider
+	// error ("" for legacy providers). shouldStopFailover trusts a typed
+	// admission_timeout as transient capacity directly — the provider's engine
+	// TOLD us it was busy — instead of inferring from error-string substrings
+	// that the fixed "admission_timeout: …" text would never match.
+	lastErrTerminalCause string
+	// lastErrAttemptUsage is the typed partial usage from the last provider
+	// error (nil for legacy providers), applied to the failed attempt's route
+	// row by providerFailedRoutingOutcomeFor so pre-content typed failures on
+	// the ordinary dispatch path keep their observability data.
+	lastErrAttemptUsage *protocol.UsageInfo
+	committed           bool
 	// keepalive emits SSE keepalive comments during a long prefill once the
 	// request has been dispatched, committing HTTP 200 early so the consumer
 	// connection does not time out. nil when disabled or non-streaming.
@@ -604,6 +615,8 @@ func (d *dispatchState) setLastInferenceError(provider *registry.Provider, msg p
 	d.lastErrCode = msg.StatusCode
 	d.lastErrReason = msg.ErrorReason
 	d.lastErrProviderBudget = providerReportedBudget(provider, d.model)
+	d.lastErrTerminalCause = msg.TerminalCause
+	d.lastErrAttemptUsage = msg.AttemptUsage
 }
 
 // providerReportedBudget reads a provider's reported token budget for a model,
@@ -637,8 +650,11 @@ func (d *dispatchState) providerFailedRoutingOutcomeFor(pr *registry.PendingRequ
 		// the admission-mismatch gauge — keyed on the SAME vocabulary as the
 		// reputation and breaker exemptions (isNonProviderFaultErrorReason).
 		// The structured reason survives on the row (see
-		// routeOutcomeUsesProviderErrorText).
-		return d.errorRoutingOutcomeFor(pr, "error", errorClassClientError, d.lastErrCode)
+		// routeOutcomeUsesProviderErrorText). Typed partial usage (if any)
+		// still lands on the row — observability only, no billing effect.
+		out := d.errorRoutingOutcomeFor(pr, "error", errorClassClientError, d.lastErrCode)
+		applyAttemptUsage(out, d.lastErrAttemptUsage)
+		return out
 	}
 	class := "provider_error"
 	if providerDisconnectedError(d.lastErr, d.lastErrCode) {
@@ -646,6 +662,12 @@ func (d *dispatchState) providerFailedRoutingOutcomeFor(pr *registry.PendingRequ
 	}
 	out := d.errorRoutingOutcomeFor(pr, "error", class, d.lastErrCode)
 	out.AdmittedButFailed = true
+	// Pre-content typed failures on the ordinary dispatch path flow through
+	// the deferred route update via this builder (not the standalone
+	// preResponse/postCommit constructors), so the typed attempt_usage
+	// retained by setLastInferenceError must be applied here too or the row
+	// records null token counts for the most common failure path.
+	applyAttemptUsage(out, d.lastErrAttemptUsage)
 	return out
 }
 
@@ -1349,7 +1371,19 @@ func (d *dispatchState) shouldStopFailover() bool {
 	if d.latchJinjaTerminalReject(d.lastErrReason, "") {
 		return true
 	}
-	switch classifyRejection(d.lastErrReason, d.lastErr, d.lastErrProviderBudget, d.modelMaxContext) {
+	// Typed-cause override (highest-fidelity signal): a provider that attaches
+	// terminal_cause=admission_timeout is TELLING us its engine was too busy to
+	// admit the request within the admission lease — definitionally a
+	// this-node transient-capacity condition (a healthier/idler provider may
+	// serve). Without this, the fixed "admission_timeout: …" error text falls
+	// through the legacy capacity substrings, gets classified as a generic
+	// fault, and walks the unbounded fault-failover ladder to a final 503
+	// instead of the bounded capacity retries and uptime-neutral 429.
+	kind := classifyRejection(d.lastErrReason, d.lastErr, d.lastErrProviderBudget, d.modelMaxContext)
+	if d.lastErrTerminalCause == terminalCauseAdmissionTimeout {
+		kind = rejectionTransientCapacity
+	}
+	switch kind {
 	case rejectionDeterministicUnservable:
 		d.s.ddIncr("routing.dispatch_to_capacity_503", []string{"model:" + d.model, "reason:deterministic"})
 		d.unservable = true

--- a/coordinator/api/dispatch_nonfault_breaker_test.go
+++ b/coordinator/api/dispatch_nonfault_breaker_test.go
@@ -84,7 +84,7 @@ func TestNoteDispatchRetry_JinjaSkipsProviderFaultBreakers(t *testing.T) {
 	d := &dispatchState{s: srv, model: pr.Model}
 	for range breakerStrikeRounds {
 		d.noteDispatchRetry(provider, pr, http.StatusInternalServerError,
-			"Runtime error: upper filter requires string", "jinja_template", nil)
+			"Runtime error: upper filter requires string", "jinja_template", "", nil)
 	}
 	assertBreakerStates(t, reg, provider, pr, false)
 }
@@ -100,7 +100,7 @@ func TestNoteProviderError_JinjaKeepsRefundAndHeldDiscard(t *testing.T) {
 	d := &dispatchState{s: srv, model: pr.Model}
 	held := []string{`data: {"choices":[{"delta":{"role":"assistant"}}]}`}
 	if !d.noteProviderError(provider, pr, http.StatusInternalServerError,
-		"Runtime error: upper filter requires string", "jinja_template", &held) {
+		"Runtime error: upper filter requires string", "jinja_template", "", &held) {
 		t.Error("held boilerplate must still be discarded (return true) for an exempt reason")
 	}
 	if len(held) != 0 {
@@ -122,7 +122,7 @@ func TestNoteDispatchRetry_ToolNoncomplianceSkipsProviderFaultBreakers(t *testin
 	d := &dispatchState{s: srv, model: pr.Model}
 	for range breakerStrikeRounds {
 		d.noteDispatchRetry(provider, pr, http.StatusUnprocessableEntity,
-			"model did not emit the required tool call", "tool_noncompliance", nil)
+			"model did not emit the required tool call", "tool_noncompliance", "", nil)
 	}
 	assertBreakerStates(t, reg, provider, pr, false)
 }
@@ -135,7 +135,7 @@ func TestNoteProviderError_Plain500StillFeedsBreakers(t *testing.T) {
 	srv, reg, provider, pr := newBreakerExemptionHarness(t, "plain-500")
 	d := &dispatchState{s: srv, model: pr.Model}
 	for range breakerStrikeRounds {
-		d.noteProviderError(provider, pr, http.StatusInternalServerError, "boom", "", nil)
+		d.noteProviderError(provider, pr, http.StatusInternalServerError, "boom", "", "", nil)
 	}
 	assertBreakerStates(t, reg, provider, pr, true)
 }
@@ -151,7 +151,7 @@ func TestNoteProviderError_Capacity503StillFeedsCapacityCooldown(t *testing.T) {
 	// accepts; feed a couple beyond it.
 	for range 7 {
 		d.noteProviderError(provider, pr, http.StatusServiceUnavailable,
-			"token_budget_exhausted: insufficient KV headroom", "token_budget_exhausted", nil)
+			"token_budget_exhausted: insufficient KV headroom", "token_budget_exhausted", "", nil)
 	}
 	if !reg.CapacityCooldownActive(provider.ID, pr.Model) {
 		t.Error("capacity-reject cooldown must still trip for capacity-class 503s (reason gate must key on jinja_*/tool_noncompliance only)")

--- a/coordinator/api/dispatch_terminal_cause_test.go
+++ b/coordinator/api/dispatch_terminal_cause_test.go
@@ -1,0 +1,130 @@
+package api
+
+// Regression tests for the PR review findings on typed-terminal handling in
+// the dispatch ladder: the typed fields must survive setLastInferenceError so
+// (1) a typed admission_timeout is classified as transient capacity by
+// shouldStopFailover even though its fixed error text matches none of the
+// legacy capacity substrings, and (2) typed attempt_usage reaches the failed
+// attempt's route row on the ordinary (waitFirstChunk/waitAccepted) path,
+// which builds its outcome from dispatch state rather than the standalone
+// constructors.
+
+import (
+	"testing"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+	"github.com/eigeninference/d-inference/coordinator/registry"
+)
+
+// typedAdmissionTimeoutMsg is shaped exactly like the Swift provider's typed
+// admission-timeout terminal: 503, cause-prefixed human text that matches NO
+// legacy capacity substring, and the typed cause field.
+func typedAdmissionTimeoutMsg() protocol.InferenceErrorMessage {
+	return protocol.InferenceErrorMessage{
+		RequestID:     "req-1",
+		Error:         "admission_timeout: admission lease expired before engine work began",
+		StatusCode:    503,
+		TerminalCause: terminalCauseAdmissionTimeout,
+	}
+}
+
+// TestShouldStopFailover_TypedAdmissionTimeoutIsTransientCapacity: the typed
+// cause must classify as transient capacity — bounded failover, then the
+// uptime-neutral 429 — not walk the unbounded fault ladder to a 503.
+func TestShouldStopFailover_TypedAdmissionTimeoutIsTransientCapacity(t *testing.T) {
+	d := &dispatchState{s: newTestServerForDispatch(t), model: "m"}
+	d.setLastInferenceError(nil, typedAdmissionTimeoutMsg())
+
+	// Sanity: the fixed text alone would NOT classify as capacity (this is the
+	// exact gap — remove the typed override and this test's premise breaks).
+	if kind := classifyRejection(d.lastErrReason, d.lastErr, 0, 0); kind != rejectionNotCapacity {
+		t.Fatalf("premise: bare admission_timeout text classified %v, want rejectionNotCapacity", kind)
+	}
+
+	// Bounded transient-capacity failover: keep failing over below the cap…
+	for i := 1; i < maxCapacityClassRetries; i++ {
+		if d.shouldStopFailover() {
+			t.Fatalf("attempt %d: transient capacity must keep failing over below the cap", i)
+		}
+		if d.unservable {
+			t.Fatalf("attempt %d: must not latch unservable below the cap", i)
+		}
+	}
+	// …and stop AT the cap with the unservable latch (→ single neutral 429).
+	if !d.shouldStopFailover() {
+		t.Fatalf("attempt %d: transient capacity must stop at maxCapacityClassRetries", maxCapacityClassRetries)
+	}
+	if !d.unservable {
+		t.Fatal("capacity-cap stop must latch unservable (the 429 path), not a fault 503")
+	}
+	if d.terminalClientError {
+		t.Fatal("admission_timeout is capacity, never a terminal client error")
+	}
+}
+
+// TestShouldStopFailover_LegacyAdmissionTextStaysFault pins the mixed-version
+// contract: the SAME error text WITHOUT the typed cause (legacy provider)
+// keeps the historical fault-failover classification. The typed field is the
+// only thing that upgrades it.
+func TestShouldStopFailover_LegacyAdmissionTextStaysFault(t *testing.T) {
+	msg := typedAdmissionTimeoutMsg()
+	msg.TerminalCause = ""
+	d := &dispatchState{s: newTestServerForDispatch(t), model: "m"}
+	d.setLastInferenceError(nil, msg)
+
+	if d.shouldStopFailover() {
+		t.Fatal("legacy (untyped) admission text must keep fault failover, not stop")
+	}
+	if d.capacityRetries != 0 {
+		t.Fatalf("capacityRetries = %d, want 0 for a legacy fault", d.capacityRetries)
+	}
+}
+
+// TestProviderFailedRoutingOutcomeCarriesTypedAttemptUsage: the ordinary
+// dispatch path's route-outcome builder must apply the usage retained by
+// setLastInferenceError — on both the provider-fault branch and the
+// deterministic client-error branch — and a following legacy error must clear
+// it (no stale carryover between attempts).
+func TestProviderFailedRoutingOutcomeCarriesTypedAttemptUsage(t *testing.T) {
+	d := &dispatchState{s: newTestServerForDispatch(t), model: "m"}
+	pr := &registry.PendingRequest{RequestID: "req-usage", Model: "m"}
+
+	usage := &protocol.UsageInfo{PromptTokens: 123, CompletionTokens: 456, ReasoningTokens: 7}
+	msg := protocol.InferenceErrorMessage{
+		RequestID: "req-usage", Error: "safety_deadline: safety ceiling expired",
+		StatusCode: 504, TerminalCause: terminalCauseSafetyDeadline, AttemptUsage: usage,
+	}
+	d.setLastInferenceError(nil, msg)
+
+	out := d.providerFailedRoutingOutcomeFor(pr)
+	if out.PromptTokens != 123 || out.CompletionTokens != 456 || out.ReasoningTokens != 7 {
+		t.Fatalf("provider-fault branch: tokens = (%d,%d,%d), want (123,456,7)",
+			out.PromptTokens, out.CompletionTokens, out.ReasoningTokens)
+	}
+	if !out.CompletionTokensSet {
+		t.Fatal("CompletionTokensSet must be forced so a zero count is written, not skipped")
+	}
+	if out.CostMicroUSD != 0 {
+		t.Fatalf("observability only: CostMicroUSD = %d, want 0", out.CostMicroUSD)
+	}
+
+	// Client-error branch (4xx) also carries the usage.
+	msg4xx := msg
+	msg4xx.StatusCode = 400
+	d.setLastInferenceError(nil, msg4xx)
+	if out := d.providerFailedRoutingOutcomeFor(pr); out.PromptTokens != 123 || !out.CompletionTokensSet {
+		t.Fatalf("client-error branch dropped attempt usage: %+v", out)
+	}
+
+	// A later LEGACY error (no usage) must clear the retained usage — the next
+	// attempt's row must not inherit attempt 1's tokens. (CompletionTokensSet
+	// stays true: error rows force-persist an authoritative 0 vs NULL by
+	// pre-existing design; carryover is checked by the VALUES.)
+	d.setLastInferenceError(nil, protocol.InferenceErrorMessage{
+		RequestID: "req-usage", Error: "boom", StatusCode: 500,
+	})
+	if out := d.providerFailedRoutingOutcomeFor(pr); out.PromptTokens != 0 ||
+		out.CompletionTokens != 0 || out.ReasoningTokens != 0 {
+		t.Fatalf("legacy follow-up must clear stale usage, got %+v", out)
+	}
+}

--- a/coordinator/api/dispatch_terminal_cause_test.go
+++ b/coordinator/api/dispatch_terminal_cause_test.go
@@ -177,7 +177,7 @@ func TestTypedProvider504KeepsProviderErrorRouteClass(t *testing.T) {
 		AttemptUsage: &protocol.UsageInfo{PromptTokens: 11, CompletionTokens: 2},
 	})
 	// The exact discriminator the wait-loop defers use:
-	if d.lastErrCode == 504 && d.lastErrTerminalCause == "" {
+	if d.lastErrCode == 504 && !isTypedTimeout504Cause(d.lastErrTerminalCause) {
 		t.Fatal("typed 504 must NOT satisfy the synthetic-timeout discriminator")
 	}
 	out := d.providerFailedRoutingOutcomeFor(pr)
@@ -190,7 +190,27 @@ func TestTypedProvider504KeepsProviderErrorRouteClass(t *testing.T) {
 
 	// Untyped (synthetic) 504 still satisfies the timeout discriminator.
 	d.setLastError("timeout waiting for first response", 504)
-	if !(d.lastErrCode == 504 && d.lastErrTerminalCause == "") {
+	if !(d.lastErrCode == 504 && !isTypedTimeout504Cause(d.lastErrTerminalCause)) {
 		t.Fatal("synthetic 504 must satisfy the synthetic-timeout discriminator")
+	}
+
+	// An UNKNOWN future cause on a 504 also stays on the legacy
+	// synthetic-timeout path — mirroring classifyTerminalCause's
+	// unknown→legacy rule — so mixed-version rollouts cannot corrupt the
+	// first_chunk/accepted timeout route telemetry.
+	d.setLastInferenceError(nil, protocol.InferenceErrorMessage{
+		RequestID: "req-504", Error: "graceful_exit: node shutting down",
+		StatusCode: 504, TerminalCause: "graceful_exit",
+	})
+	if !(d.lastErrCode == 504 && !isTypedTimeout504Cause(d.lastErrTerminalCause)) {
+		t.Fatal("unknown-cause 504 must stay on the synthetic-timeout (legacy) path")
+	}
+	// And the two known typed 504 causes are exactly the exception set.
+	if !isTypedTimeout504Cause(terminalCauseSafetyDeadline) ||
+		!isTypedTimeout504Cause(terminalCauseBackpressureTimeout) {
+		t.Fatal("safety_deadline and backpressure_timeout must be the typed 504 exceptions")
+	}
+	if isTypedTimeout504Cause(terminalCauseAdmissionTimeout) || isTypedTimeout504Cause("") {
+		t.Fatal("only the two known 504 causes may bypass the timeout classification")
 	}
 }

--- a/coordinator/api/dispatch_terminal_cause_test.go
+++ b/coordinator/api/dispatch_terminal_cause_test.go
@@ -128,3 +128,69 @@ func TestProviderFailedRoutingOutcomeCarriesTypedAttemptUsage(t *testing.T) {
 		t.Fatalf("legacy follow-up must clear stale usage, got %+v", out)
 	}
 }
+
+// TestSetLastErrorClearsTypedTerminalFields: a coordinator-synthesized error
+// (timeout / no-provider / coordinator fault) replacing a typed provider
+// terminal must clear the retained cause and usage — otherwise
+// shouldStopFailover reclassifies the unrelated later failure as transient
+// capacity (stale admission_timeout) and can latch the 429 path after mixed
+// failures while more providers remain, and stale usage lands on the wrong
+// attempt's route row.
+func TestSetLastErrorClearsTypedTerminalFields(t *testing.T) {
+	d := &dispatchState{s: newTestServerForDispatch(t), model: "m"}
+	msg := typedAdmissionTimeoutMsg()
+	msg.AttemptUsage = &protocol.UsageInfo{PromptTokens: 5, CompletionTokens: 3}
+	d.setLastInferenceError(nil, msg)
+	if d.lastErrTerminalCause == "" || d.lastErrAttemptUsage == nil {
+		t.Fatal("premise: typed fields must be retained from the provider terminal")
+	}
+
+	d.setLastError("timeout waiting for first response", 504)
+	if d.lastErrTerminalCause != "" {
+		t.Fatalf("synthetic error must clear the typed cause, got %q", d.lastErrTerminalCause)
+	}
+	if d.lastErrAttemptUsage != nil {
+		t.Fatalf("synthetic error must clear the typed usage, got %+v", d.lastErrAttemptUsage)
+	}
+	// And the synthetic timeout must NOT classify as transient capacity.
+	if d.shouldStopFailover() {
+		t.Fatal("a synthetic timeout after a typed capacity terminal must keep fault failover")
+	}
+	if d.capacityRetries != 0 {
+		t.Fatalf("capacityRetries = %d, want 0 — stale cause must not count capacity retries", d.capacityRetries)
+	}
+}
+
+// TestTypedProvider504KeepsProviderErrorRouteClass: the wait loops' route
+// defers use `504 && no typed cause` to mean a coordinator-synthesized
+// timeout. A typed provider 504 (safety_deadline / backpressure_timeout) must
+// instead flow through providerFailedRoutingOutcomeFor — keeping the
+// provider_error class and its attempt usage — while an untyped 504 keeps the
+// synthetic-timeout classification bit-for-bit.
+func TestTypedProvider504KeepsProviderErrorRouteClass(t *testing.T) {
+	d := &dispatchState{s: newTestServerForDispatch(t), model: "m"}
+	pr := &registry.PendingRequest{RequestID: "req-504", Model: "m"}
+
+	d.setLastInferenceError(nil, protocol.InferenceErrorMessage{
+		RequestID: "req-504", Error: "safety_deadline: safety ceiling expired",
+		StatusCode: 504, TerminalCause: terminalCauseSafetyDeadline,
+		AttemptUsage: &protocol.UsageInfo{PromptTokens: 11, CompletionTokens: 2},
+	})
+	// The exact discriminator the wait-loop defers use:
+	if d.lastErrCode == 504 && d.lastErrTerminalCause == "" {
+		t.Fatal("typed 504 must NOT satisfy the synthetic-timeout discriminator")
+	}
+	out := d.providerFailedRoutingOutcomeFor(pr)
+	if out.ErrorClass != "provider_error" {
+		t.Fatalf("typed 504 route class = %q, want provider_error", out.ErrorClass)
+	}
+	if out.PromptTokens != 11 || out.CompletionTokens != 2 || !out.CompletionTokensSet {
+		t.Fatalf("typed 504 must carry attempt usage, got %+v", out)
+	}
+
+	// Untyped (synthetic) 504 still satisfies the timeout discriminator.
+	d.setLastError("timeout waiting for first response", 504)
+	if !(d.lastErrCode == 504 && d.lastErrTerminalCause == "") {
+		t.Fatal("synthetic 504 must satisfy the synthetic-timeout discriminator")
+	}
+}

--- a/coordinator/api/generic_endpoint_stream.go
+++ b/coordinator/api/generic_endpoint_stream.go
@@ -84,7 +84,7 @@ func (s *Server) handleGenericEndpointStreamingResponse(
 				continue
 			}
 			s.refundReservedBalance(pr, "provider_error:"+pr.RequestID)
-			s.noteInferenceError(pr.ProviderID, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason)
+			s.noteInferenceError(pr.ProviderID, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason, errMsg.TerminalCause)
 			s.ddIncr("inference.in_band_error", []string{"model:" + pr.Model, "reason:provider_error"})
 			s.updateInferenceRouteOutcomeForPending(pr, postCommitProviderErrorOutcome(pr, errMsg))
 			emitter.emitError("provider_error", errMsg.Error)

--- a/coordinator/api/nonfault_outcome_generic_test.go
+++ b/coordinator/api/nonfault_outcome_generic_test.go
@@ -79,16 +79,16 @@ func TestGenericPathNonFaultReasonsSkipBreakers(t *testing.T) {
 	// 5, stable identity at 8).
 	for range 10 {
 		srv.noteInferenceError(provider.ID, pr, http.StatusInternalServerError,
-			"Runtime error: upper filter requires string", "jinja_template")
+			"Runtime error: upper filter requires string", "jinja_template", "")
 		srv.noteInferenceError(provider.ID, pr, 422,
-			"model did not emit the required tool call", "tool_noncompliance")
+			"model did not emit the required tool call", "tool_noncompliance", "")
 	}
 	assertBreakerStates(t, reg, provider, pr, false)
 
 	// Control: the same volume of plain 500s through the same chokepoint still
 	// trips the breakers — the gate keys on the structured reason only.
 	for range 10 {
-		srv.noteInferenceError(provider.ID, pr, http.StatusInternalServerError, "boom", "")
+		srv.noteInferenceError(provider.ID, pr, http.StatusInternalServerError, "boom", "", "")
 	}
 	assertBreakerStates(t, reg, provider, pr, true)
 }

--- a/coordinator/api/provider.go
+++ b/coordinator/api/provider.go
@@ -2311,6 +2311,15 @@ func (s *Server) handleInferenceError(providerID string, provider *registry.Prov
 	// attempted provider must not eat a reputation strike for what the model
 	// generated). A plain 422 with no structured reason still counts —
 	// only the typed vocabulary exonerates.
+	// Typed terminal cause (new providers). Classify once and emit the typed
+	// terminal metrics; neutral (safety_deadline / backpressure_timeout /
+	// cancelled — platform policy or consumer behavior) and capacity
+	// (admission_timeout — healthy but busy) causes are exempt from the fault
+	// recorder below regardless of status/string shape. Absent, engine_error,
+	// or unknown causes keep the legacy heuristics bit-for-bit.
+	causeClass := s.noteTypedTerminalCause(msg.TerminalCause)
+	causeNeutralForHealth := causeClass == causeClassNeutral || causeClass == causeClassCapacity
+
 	loweredErr := strings.ToLower(msg.Error)
 	capacityRejection := msg.StatusCode == http.StatusServiceUnavailable ||
 		msg.StatusCode == http.StatusTooManyRequests ||
@@ -2319,7 +2328,7 @@ func (s *Server) handleInferenceError(providerID string, provider *registry.Prov
 	cancelTerminal := msg.StatusCode == 499 ||
 		strings.Contains(loweredErr, "request cancelled")
 	nonProviderFault := isNonProviderFaultErrorReason(msg.ErrorReason)
-	if !capacityRejection && !cancelTerminal && !nonProviderFault {
+	if !capacityRejection && !cancelTerminal && !nonProviderFault && !causeNeutralForHealth {
 		s.registry.RecordJobFailure(providerID)
 	}
 
@@ -2332,7 +2341,14 @@ func (s *Server) handleInferenceError(providerID string, provider *registry.Prov
 	// attracting 100% of the alias traffic as repeated 500s — cooling the pair
 	// makes the desired build unroutable so alias resolution falls back to the
 	// previous build.
-	if isModelLoadFailure(loweredErr) {
+	// A typed fully-neutral cause (safety_deadline / backpressure_timeout /
+	// cancelled) is strictly neutral, and a typed capacity cause
+	// (admission_timeout) feeds ONLY the capacity cooldown recorded in
+	// noteInferenceError — neither may feed the load cooldown. Their error
+	// text never carries the load-failure vocabulary anyway; the explicit
+	// allowlist (legacy or fault only) makes both guarantees unconditional
+	// rather than dependent on provider error-string phrasing.
+	if (causeClass == causeClassLegacy || causeClass == causeClassFault) && isModelLoadFailure(loweredErr) {
 		if s.registry.RecordDispatchLoadFailure(providerID, pr.Model) {
 			s.logger.Warn("load-failure cool-down started",
 				"provider_id", providerID,
@@ -2362,6 +2378,7 @@ func (s *Server) handleInferenceError(providerID string, provider *registry.Prov
 		if !cancelTerminal {
 			outcome.AdmittedButFailed = true
 		}
+		applyAttemptUsage(outcome, msg.AttemptUsage)
 		s.updateInferenceRouteOutcomeForPending(pr, outcome)
 		// Consumer disconnected — no reader for the channels; settle by
 		// refunding, OFF the read loop (a store Credit can block for seconds
@@ -2394,6 +2411,7 @@ func (s *Server) handleInferenceError(providerID string, provider *registry.Prov
 		"provider_id", providerID,
 		"error", msg.Error,
 		"status_code", msg.StatusCode,
+		"terminal_cause", msg.TerminalCause,
 	)
 }
 

--- a/coordinator/api/route_outcome.go
+++ b/coordinator/api/route_outcome.go
@@ -237,12 +237,33 @@ func providerDisconnectedError(errorText string, statusCode int) bool {
 	return statusCode == 502 && strings.EqualFold(strings.TrimSpace(errorText), "provider disconnected")
 }
 
+// applyAttemptUsage copies a typed error terminal's provider-reported partial
+// usage (InferenceErrorMessage.AttemptUsage, new providers only) onto the
+// route row for OBSERVABILITY. This is the fix for the deadline incident's
+// "every strict route had null prompt_tokens / completion_tokens" finding: the
+// engine reconciles partial usage at the terminal, and the route row now keeps
+// it. CompletionTokensSet force-persists an authoritative 0 (vs NULL).
+// Strictly telemetry: billing, refunds, reservations, provider earnings, and
+// payouts never read these route fields on an error terminal, and this helper
+// deliberately never touches CostMicroUSD.
+func applyAttemptUsage(out *store.InferenceRouteOutcome, usage *protocol.UsageInfo) {
+	if out == nil || usage == nil {
+		return
+	}
+	out.PromptTokens = usage.PromptTokens
+	out.CompletionTokens = usage.CompletionTokens
+	out.CompletionTokensSet = true
+	out.ReasoningTokens = usage.ReasoningTokens
+}
+
 func postCommitProviderErrorOutcome(pr *registry.PendingRequest, msg protocol.InferenceErrorMessage) *store.InferenceRouteOutcome {
 	class := "provider_error_after_commit"
 	if providerDisconnectedError(msg.Error, msg.StatusCode) {
 		class = "provider_disconnect_after_commit"
 	}
-	return providerFailedPendingRouteOutcomeWithReason(pr, finalStatusPartialSuccess, class, msg.StatusCode, msg.ErrorReason, msg.Error)
+	out := providerFailedPendingRouteOutcomeWithReason(pr, finalStatusPartialSuccess, class, msg.StatusCode, msg.ErrorReason, msg.Error)
+	applyAttemptUsage(out, msg.AttemptUsage)
+	return out
 }
 
 func preResponseProviderErrorOutcome(pr *registry.PendingRequest, msg protocol.InferenceErrorMessage) *store.InferenceRouteOutcome {
@@ -250,7 +271,9 @@ func preResponseProviderErrorOutcome(pr *registry.PendingRequest, msg protocol.I
 	if providerDisconnectedError(msg.Error, msg.StatusCode) {
 		class = "provider_disconnect_before_response"
 	}
-	return providerFailedPendingRouteOutcomeWithReason(pr, finalStatusError, class, msg.StatusCode, msg.ErrorReason, msg.Error)
+	out := providerFailedPendingRouteOutcomeWithReason(pr, finalStatusError, class, msg.StatusCode, msg.ErrorReason, msg.Error)
+	applyAttemptUsage(out, msg.AttemptUsage)
+	return out
 }
 
 func preCommitProviderErrorOutcome(pr *registry.PendingRequest, msg protocol.InferenceErrorMessage) *store.InferenceRouteOutcome {
@@ -265,13 +288,17 @@ func preCommitProviderErrorOutcome(pr *registry.PendingRequest, msg protocol.Inf
 		// vocabulary as the reputation and breaker exemptions
 		// (isNonProviderFaultErrorReason) so the lists cannot drift.
 		// msg.ErrorReason is threaded through so rows keep their reason.
-		return pendingRouteOutcomeWithReason(pr, finalStatusError, errorClassClientError, msg.StatusCode, msg.ErrorReason, msg.Error)
+		out := pendingRouteOutcomeWithReason(pr, finalStatusError, errorClassClientError, msg.StatusCode, msg.ErrorReason, msg.Error)
+		applyAttemptUsage(out, msg.AttemptUsage)
+		return out
 	}
 	class := "provider_error"
 	if providerDisconnectedError(msg.Error, msg.StatusCode) {
 		class = "provider_disconnect_pre_commit"
 	}
-	return providerFailedPendingRouteOutcomeWithReason(pr, finalStatusError, class, msg.StatusCode, msg.ErrorReason, msg.Error)
+	out := providerFailedPendingRouteOutcomeWithReason(pr, finalStatusError, class, msg.StatusCode, msg.ErrorReason, msg.Error)
+	applyAttemptUsage(out, msg.AttemptUsage)
+	return out
 }
 
 func postCommitProviderIncompleteOutcome(pr *registry.PendingRequest) *store.InferenceRouteOutcome {

--- a/coordinator/api/terminal_cause.go
+++ b/coordinator/api/terminal_cause.go
@@ -1,0 +1,111 @@
+package api
+
+// Typed provider terminal causes (InferenceErrorMessage.TerminalCause).
+//
+// Background (docs/reports/2026-07-20-generation-deadline-incident-and-redesign.md):
+// the provider engine's flat 120s wall killed healthy requests and reported
+// them as generic 500 inference_errors, so the coordinator recorded a provider
+// job failure and struck every health breaker ~178K times/week for what was
+// the PLATFORM's own policy. New providers now attach a typed terminal_cause
+// so the coordinator can tell platform-policy terminals from real provider
+// sickness. The vocabulary is CLOSED and mirrored bit-for-bit by the Swift
+// provider — do not rename values.
+//
+// Classification policy (the cause → breaker table from the incident report):
+//
+//	admission_timeout     → neutral for node/shape/identity health; recorded
+//	                        as a capacity signal (black-hole cooldown strike
+//	                        only — RecordCapacityRejectBusy)
+//	safety_deadline       → fully neutral (platform policy, not a fault)
+//	backpressure_timeout  → fully neutral (client/coordinator slowness)
+//	cancelled             → fully neutral (consumer behavior)
+//	prefill_stall         → fault (real provider sickness): legacy funnels
+//	decode_stall          → fault: legacy funnels
+//	watchdog              → fault: legacy funnels
+//	engine_error          → legacy behavior exactly
+//	absent ("")           → legacy provider: legacy behavior exactly
+//	unknown value         → treated as absent, plus a vocabulary-drift metric
+//
+// "Neutral" means NEUTRAL, not positive: neutral terminals never strike a
+// breaker AND never clear one or count as an accept/success.
+const (
+	terminalCauseAdmissionTimeout    = "admission_timeout"
+	terminalCausePrefillStall        = "prefill_stall"
+	terminalCauseDecodeStall         = "decode_stall"
+	terminalCauseSafetyDeadline      = "safety_deadline"
+	terminalCauseBackpressureTimeout = "backpressure_timeout"
+	terminalCauseWatchdog            = "watchdog"
+	terminalCauseCancelled           = "cancelled"
+	terminalCauseEngineError         = "engine_error"
+)
+
+// terminalCauseClass is the coordinator-side health classification of a typed
+// terminal cause.
+type terminalCauseClass int
+
+const (
+	// causeClassLegacy: absent cause, engine_error, or an unknown value — the
+	// historical string/status heuristics apply unchanged (legacy providers
+	// must see zero behavior change).
+	causeClassLegacy terminalCauseClass = iota
+	// causeClassFault: real provider sickness — full legacy fault behavior
+	// (RecordJobFailure + every breaker funnel) applies.
+	causeClassFault
+	// causeClassNeutral: platform policy / client behavior — no fault
+	// recorder, no breaker strike, no capacity outcome, and no clears either.
+	causeClassNeutral
+	// causeClassCapacity: the provider was healthy but busy — neutral for all
+	// health breakers, recorded as a capacity-reject signal only.
+	causeClassCapacity
+)
+
+// classifyTerminalCause maps a wire terminal_cause to its health class.
+// known is false ONLY for a non-empty value outside the closed vocabulary
+// (vocabulary drift — callers emit metricUnknownTerminalCause); the class is
+// then causeClassLegacy so drift can never change behavior.
+func classifyTerminalCause(cause string) (class terminalCauseClass, known bool) {
+	switch cause {
+	case "":
+		return causeClassLegacy, true
+	case terminalCauseAdmissionTimeout:
+		return causeClassCapacity, true
+	case terminalCauseSafetyDeadline, terminalCauseBackpressureTimeout, terminalCauseCancelled:
+		return causeClassNeutral, true
+	case terminalCausePrefillStall, terminalCauseDecodeStall, terminalCauseWatchdog:
+		return causeClassFault, true
+	case terminalCauseEngineError:
+		return causeClassLegacy, true
+	default:
+		return causeClassLegacy, false
+	}
+}
+
+// metricTypedTerminal counts every provider inference_error terminal that
+// carried a typed terminal_cause, tagged with the cause only (low
+// cardinality: the 8 closed-vocabulary values plus "unknown"). Never tagged
+// with request or provider IDs.
+const metricTypedTerminal = "inference.typed_terminal"
+
+// metricUnknownTerminalCause counts non-empty terminal_cause values outside
+// the closed vocabulary — the vocabulary-drift alarm. Behavior for such
+// terminals stays exactly legacy; this counter is how we notice a provider
+// shipped a cause the coordinator does not understand yet.
+const metricUnknownTerminalCause = "inference.typed_terminal_unknown_cause"
+
+// noteTypedTerminalCause classifies a wire terminal_cause and emits the typed
+// terminal metrics exactly once per provider error terminal (call it only
+// from handleInferenceError, the single provider-frame ingress). An empty
+// cause is a legacy terminal: no metric, legacy class.
+func (s *Server) noteTypedTerminalCause(cause string) terminalCauseClass {
+	if cause == "" {
+		return causeClassLegacy
+	}
+	class, known := classifyTerminalCause(cause)
+	tag := "cause:" + cause
+	if !known {
+		tag = "cause:unknown"
+		s.ddIncr(metricUnknownTerminalCause, nil)
+	}
+	s.ddIncr(metricTypedTerminal, []string{tag})
+	return class
+}

--- a/coordinator/api/terminal_cause.go
+++ b/coordinator/api/terminal_cause.go
@@ -80,6 +80,18 @@ func classifyTerminalCause(cause string) (class terminalCauseClass, known bool) 
 	}
 }
 
+// isTypedTimeout504Cause reports whether cause is one of the KNOWN typed
+// causes the provider maps to a 504 status (safety_deadline,
+// backpressure_timeout). The dispatch wait loops use it to tell a typed
+// provider 504 from a coordinator-synthesized timeout 504. An UNKNOWN
+// future cause value deliberately does NOT count: consistent with
+// classifyTerminalCause's unknown→legacy rule, an off-vocabulary 504 keeps
+// the legacy synthetic-timeout route classification during mixed-version
+// rollouts instead of being guessed into provider_error/admitted_but_failed.
+func isTypedTimeout504Cause(cause string) bool {
+	return cause == terminalCauseSafetyDeadline || cause == terminalCauseBackpressureTimeout
+}
+
 // metricTypedTerminal counts every provider inference_error terminal that
 // carried a typed terminal_cause, tagged with the cause only (low
 // cardinality: the 8 closed-vocabulary values plus "unknown"). Never tagged

--- a/coordinator/api/terminal_cause_test.go
+++ b/coordinator/api/terminal_cause_test.go
@@ -1,0 +1,333 @@
+package api
+
+// Typed terminal-cause health classification (the generation-deadline incident
+// fix): the provider's flat safety deadline used to arrive as a generic 500,
+// so the coordinator recorded a provider job failure and struck every health
+// breaker for a PLATFORM policy ~178K times/week. These tests pin, for every
+// value of the closed terminal_cause vocabulary (plus absent and unknown),
+// exactly which failure recorders and breakers fire — through the REAL glue:
+// handleInferenceError (reputation + load cooldown) and noteInferenceError
+// (shape breaker, node-health breaker, stable-identity ejection, capacity
+// cooldown), the same two funnels the incident report warns must be gated
+// together.
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"testing"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+	"github.com/eigeninference/d-inference/coordinator/registry"
+	"github.com/eigeninference/d-inference/coordinator/store"
+)
+
+// deliverTypedError routes one full provider error terminal through both
+// production funnels: handleInferenceError (provider read-loop side), then —
+// exactly like the live relay/dispatch readers — the message echoed on ErrorCh
+// is fed to noteInferenceError (consumer side).
+func deliverTypedError(t *testing.T, srv *Server, provider *registry.Provider, model, requestID string, msg protocol.InferenceErrorMessage) *registry.PendingRequest {
+	t.Helper()
+	pr := &registry.PendingRequest{
+		RequestID:  requestID,
+		ProviderID: provider.ID,
+		Model:      model,
+		ChunkCh:    make(chan string, 1),
+		CompleteCh: make(chan protocol.UsageInfo, 1),
+		ErrorCh:    make(chan protocol.InferenceErrorMessage, 1),
+	}
+	provider.AddPending(pr)
+	msg.Type = protocol.TypeInferenceError
+	msg.RequestID = requestID
+	srv.handleInferenceError(provider.ID, provider, &msg)
+	em, ok := <-pr.ErrorCh
+	if !ok {
+		t.Fatalf("ErrorCh closed without a terminal for %s", requestID)
+	}
+	srv.noteInferenceError(pr.ProviderID, pr, em.StatusCode, em.Error, em.ErrorReason, em.TerminalCause)
+	return pr
+}
+
+// TestTerminalCauseHealthClassification is the cause → funnel table. A plain
+// sickness-shaped 500 body is used for every case so any behavior difference
+// comes from the typed cause alone:
+//
+//	admission_timeout               → no fault anywhere; capacity cooldown strike
+//	safety_deadline / backpressure_timeout / cancelled → fully neutral
+//	prefill_stall / decode_stall / watchdog            → full fault (legacy funnels)
+//	engine_error / absent / unknown                    → legacy behavior exactly
+func TestTerminalCauseHealthClassification(t *testing.T) {
+	cases := []struct {
+		name  string
+		cause string
+		// wantJobFailures: registry.RecordJobFailure fired every round.
+		wantJobFailures bool
+		// wantFaultBreakers: shape-keyed inference-error cooldown, node-health
+		// breaker, and stable-identity ejection all opened after the strikes.
+		wantFaultBreakers bool
+		// wantCapacityCooldown: the black-hole capacity cooldown tripped.
+		wantCapacityCooldown bool
+	}{
+		{"admission_timeout", terminalCauseAdmissionTimeout, false, false, true},
+		{"prefill_stall", terminalCausePrefillStall, true, true, false},
+		{"decode_stall", terminalCauseDecodeStall, true, true, false},
+		{"safety_deadline", terminalCauseSafetyDeadline, false, false, false},
+		{"backpressure_timeout", terminalCauseBackpressureTimeout, false, false, false},
+		{"watchdog", terminalCauseWatchdog, true, true, false},
+		{"cancelled", terminalCauseCancelled, false, false, false},
+		{"engine_error", terminalCauseEngineError, true, true, false},
+		{"legacy_absent", "", true, true, false},
+		{"unknown_drift_value", "lease_reaped", true, true, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv, reg, provider, _ := newBreakerExemptionHarness(t, "cause-"+tc.name)
+			model := "test-model"
+			var lastPR *registry.PendingRequest
+			// breakerStrikeRounds (10) comfortably exceeds every threshold:
+			// shape cooldown 2, node breaker 5, ejection 8, capacity cooldown 5.
+			for i := range breakerStrikeRounds {
+				lastPR = deliverTypedError(t, srv, provider, model,
+					fmt.Sprintf("req-%s-%d", tc.name, i), protocol.InferenceErrorMessage{
+						Error:         "engine failure: generation aborted",
+						StatusCode:    500,
+						TerminalCause: tc.cause,
+					})
+			}
+
+			provider.Mu().Lock()
+			failed := provider.Reputation.FailedJobs
+			provider.Mu().Unlock()
+			wantFailed := 0
+			if tc.wantJobFailures {
+				wantFailed = breakerStrikeRounds
+			}
+			if failed != wantFailed {
+				t.Errorf("Reputation.FailedJobs = %d, want %d", failed, wantFailed)
+			}
+
+			assertBreakerStates(t, reg, provider, lastPR, tc.wantFaultBreakers)
+
+			if got := reg.CapacityCooldownActive(provider.ID, model); got != tc.wantCapacityCooldown {
+				t.Errorf("capacity cooldown active = %v, want %v", got, tc.wantCapacityCooldown)
+			}
+		})
+	}
+}
+
+// Neutral must mean NEUTRAL, not positive: a typed neutral terminal must not
+// clear an already-open breaker or count as an accept/success. Trip the
+// funnels with legacy faults first, then pour neutral terminals through and
+// assert everything is still open.
+func TestNeutralTerminalCauseDoesNotClearBreakers(t *testing.T) {
+	srv, reg, provider, _ := newBreakerExemptionHarness(t, "neutral-no-clear")
+	model := "test-model"
+
+	// Open all three fault breakers with legacy (absent-cause) 500s.
+	var lastPR *registry.PendingRequest
+	for i := range breakerStrikeRounds {
+		lastPR = deliverTypedError(t, srv, provider, model,
+			fmt.Sprintf("req-open-%d", i), protocol.InferenceErrorMessage{
+				Error:      "engine failure: generation aborted",
+				StatusCode: 500,
+			})
+	}
+	assertBreakerStates(t, reg, provider, lastPR, true)
+
+	// Neutral terminals of every neutral flavor must leave them open.
+	for i, cause := range []string{terminalCauseSafetyDeadline, terminalCauseBackpressureTimeout, terminalCauseCancelled} {
+		lastPR = deliverTypedError(t, srv, provider, model,
+			fmt.Sprintf("req-neutral-%d", i), protocol.InferenceErrorMessage{
+				Error:         "request exceeded safety deadline",
+				StatusCode:    504,
+				TerminalCause: cause,
+			})
+	}
+	assertBreakerStates(t, reg, provider, lastPR, true)
+
+	// And the neutral terminals themselves recorded nothing new: reputation
+	// failures stay at the legacy count.
+	provider.Mu().Lock()
+	failed := provider.Reputation.FailedJobs
+	provider.Mu().Unlock()
+	if failed != breakerStrikeRounds {
+		t.Errorf("Reputation.FailedJobs = %d, want %d (neutral terminals must not add failures)", failed, breakerStrikeRounds)
+	}
+}
+
+// A typed neutral cause must exempt even when the body/status carries the
+// sickness shape AND when the legacy string heuristics would NOT exempt it —
+// the cause wins over the strings in both funnels. Regression guard for
+// "fixing only one funnel still falsely penalizes providers".
+func TestSafetyDeadline500IsFullyNeutral(t *testing.T) {
+	srv, reg, provider, _ := newBreakerExemptionHarness(t, "safety-500")
+	model := "test-model"
+	var lastPR *registry.PendingRequest
+	for i := range breakerStrikeRounds {
+		// 500 + fault-shaped text: legacy heuristics would strike everything.
+		lastPR = deliverTypedError(t, srv, provider, model,
+			fmt.Sprintf("req-safety-%d", i), protocol.InferenceErrorMessage{
+				Error:         "generation error: request exceeded 120s deadline",
+				StatusCode:    500,
+				TerminalCause: terminalCauseSafetyDeadline,
+			})
+	}
+	provider.Mu().Lock()
+	failed := provider.Reputation.FailedJobs
+	totalJobs := provider.Reputation.TotalJobs
+	provider.Mu().Unlock()
+	if failed != 0 || totalJobs != 0 {
+		t.Errorf("FailedJobs/TotalJobs = %d/%d, want 0/0 (platform deadline is not a provider fault)", failed, totalJobs)
+	}
+	assertBreakerStates(t, reg, provider, lastPR, false)
+	if reg.CapacityCooldownActive(provider.ID, model) {
+		t.Error("safety_deadline must not feed the capacity cooldown either")
+	}
+}
+
+// admission_timeout is a capacity signal with the black-hole safety semantics:
+// strikes with zero interleaved accepts trip the capacity cooldown, but an
+// accept resets the streak so a serving box can never trip.
+func TestAdmissionTimeoutAcceptResetsCapacityStreak(t *testing.T) {
+	srv, reg, provider, _ := newBreakerExemptionHarness(t, "admission-accept")
+	model := "test-model"
+	// Interleave: threshold is 5 strikes with zero interleaved accepts; an
+	// accept after every 3 strikes must keep the pair un-cooled forever.
+	for round := range 4 {
+		for i := range 3 {
+			deliverTypedError(t, srv, provider, model,
+				fmt.Sprintf("req-adm-%d-%d", round, i), protocol.InferenceErrorMessage{
+					Error:         "admission timeout: engine did not admit request",
+					StatusCode:    503,
+					TerminalCause: terminalCauseAdmissionTimeout,
+				})
+		}
+		reg.RecordCapacityAccept(provider.ID, model)
+	}
+	if reg.CapacityCooldownActive(provider.ID, model) {
+		t.Error("interleaved accepts must keep an admission-timing-out but serving pair out of the capacity cooldown")
+	}
+	// And admission timeouts never touched the fault side.
+	provider.Mu().Lock()
+	failed := provider.Reputation.FailedJobs
+	provider.Mu().Unlock()
+	if failed != 0 {
+		t.Errorf("FailedJobs = %d, want 0", failed)
+	}
+}
+
+// Legacy regression: with the cause ABSENT, the pre-existing string/status
+// carve-outs still behave exactly as before (capacity strings and cancel
+// terminals skip reputation; plain faults count). Mirrors
+// TestHandleInferenceErrorReputationCarveout through the shared deliver glue
+// so the new cause gate provably changed nothing for legacy frames.
+func TestLegacyAbsentCauseKeepsExistingCarveouts(t *testing.T) {
+	srv, _, provider, _ := newBreakerExemptionHarness(t, "legacy-carveout")
+	model := "test-model"
+
+	// Legacy capacity rejection (503) and cancel (499): no reputation failure.
+	deliverTypedError(t, srv, provider, model, "req-legacy-503", protocol.InferenceErrorMessage{
+		Error: "token_budget_exhausted", StatusCode: 503,
+	})
+	deliverTypedError(t, srv, provider, model, "req-legacy-499", protocol.InferenceErrorMessage{
+		Error: "request cancelled by consumer", StatusCode: 499,
+	})
+	provider.Mu().Lock()
+	failed := provider.Reputation.FailedJobs
+	provider.Mu().Unlock()
+	if failed != 0 {
+		t.Fatalf("legacy capacity/cancel terminals: FailedJobs = %d, want 0", failed)
+	}
+
+	// Legacy plain fault: reputation failure recorded.
+	deliverTypedError(t, srv, provider, model, "req-legacy-500", protocol.InferenceErrorMessage{
+		Error: "model crashed during generation", StatusCode: 500,
+	})
+	provider.Mu().Lock()
+	failed = provider.Reputation.FailedJobs
+	provider.Mu().Unlock()
+	if failed != 1 {
+		t.Fatalf("legacy plain 500: FailedJobs = %d, want 1", failed)
+	}
+}
+
+// classifyTerminalCause unit table: every vocabulary value maps to its class
+// and only out-of-vocabulary values report unknown.
+func TestClassifyTerminalCause(t *testing.T) {
+	cases := []struct {
+		cause     string
+		wantClass terminalCauseClass
+		wantKnown bool
+	}{
+		{"", causeClassLegacy, true},
+		{terminalCauseAdmissionTimeout, causeClassCapacity, true},
+		{terminalCausePrefillStall, causeClassFault, true},
+		{terminalCauseDecodeStall, causeClassFault, true},
+		{terminalCauseSafetyDeadline, causeClassNeutral, true},
+		{terminalCauseBackpressureTimeout, causeClassNeutral, true},
+		{terminalCauseWatchdog, causeClassFault, true},
+		{terminalCauseCancelled, causeClassNeutral, true},
+		{terminalCauseEngineError, causeClassLegacy, true},
+		{"lease_reaped", causeClassLegacy, false},
+		{"SAFETY_DEADLINE", causeClassLegacy, false}, // vocabulary is exact-match
+	}
+	for _, tc := range cases {
+		class, known := classifyTerminalCause(tc.cause)
+		if class != tc.wantClass || known != tc.wantKnown {
+			t.Errorf("classifyTerminalCause(%q) = (%v, %v), want (%v, %v)",
+				tc.cause, class, known, tc.wantClass, tc.wantKnown)
+		}
+	}
+}
+
+// Typed terminal metrics: a known cause emits inference.typed_terminal tagged
+// with the cause; an unknown value emits the vocabulary-drift counter and is
+// tagged cause:unknown; a legacy frame emits neither.
+func TestTypedTerminalMetrics(t *testing.T) {
+	collector := newUDPCollector(t)
+	defer collector.Close()
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	st := store.NewMemory(store.Config{AdminKey: "test-key"})
+	reg := registry.New(logger)
+	srv := NewServer(reg, st, ServerConfig{}, logger)
+	dd := newTestDD(t, collector)
+	defer dd.Close()
+	srv.SetDatadog(dd)
+
+	provider := reg.Register("provider-typed-metrics", nil, &protocol.RegisterMessage{
+		Type:   protocol.TypeRegister,
+		Models: []protocol.ModelInfo{{ID: "test-model", ModelType: "chat", Quantization: "4bit"}},
+	})
+
+	deliverTypedError(t, srv, provider, "test-model", "req-metric-typed", protocol.InferenceErrorMessage{
+		Error: "deadline", StatusCode: 504, TerminalCause: terminalCauseSafetyDeadline,
+	})
+	deliverTypedError(t, srv, provider, "test-model", "req-metric-unknown", protocol.InferenceErrorMessage{
+		Error: "??", StatusCode: 500, TerminalCause: "lease_reaped",
+	})
+	deliverTypedError(t, srv, provider, "test-model", "req-metric-legacy", protocol.InferenceErrorMessage{
+		Error: "boom", StatusCode: 500,
+	})
+
+	_ = dd.Statsd.Flush()
+	packets := collector.drain()
+
+	typed := findMetrics(packets, metricTypedTerminal+":")
+	if len(typed) != 2 {
+		t.Fatalf("typed_terminal packets = %d (%v), want 2 (typed + unknown; legacy emits none)", len(typed), typed)
+	}
+	if !hasMetric(typed, "cause:"+terminalCauseSafetyDeadline) {
+		t.Errorf("missing cause:safety_deadline tag in %v", typed)
+	}
+	if !hasMetric(typed, "cause:unknown") {
+		t.Errorf("unknown vocabulary value must be tagged cause:unknown, got %v", typed)
+	}
+	if hasMetric(typed, "cause:lease_reaped") {
+		t.Errorf("raw drift value must never become a tag, got %v", typed)
+	}
+	if drift := findMetrics(packets, metricUnknownTerminalCause+":"); len(drift) != 1 {
+		t.Errorf("unknown-cause drift counter packets = %d (%v), want 1", len(drift), drift)
+	}
+}

--- a/coordinator/protocol/messages.go
+++ b/coordinator/protocol/messages.go
@@ -464,6 +464,23 @@ type InferenceErrorMessage struct {
 	Error       string `json:"error"`
 	StatusCode  int    `json:"status_code"`
 	ErrorReason string `json:"error_reason,omitempty"`
+	// TerminalCause is the provider's typed terminal cause for this error
+	// (closed vocabulary, mirrored by the Swift provider): admission_timeout,
+	// prefill_stall, decode_stall, safety_deadline, backpressure_timeout,
+	// watchdog, cancelled, engine_error. Optional: absent/empty means a legacy
+	// provider and the coordinator applies its historical string/status
+	// heuristics; an unknown value is treated as absent (plus a drift metric).
+	// The coordinator classifies provider health from this cause
+	// (api/terminal_cause.go) — platform-policy terminals (safety_deadline,
+	// backpressure_timeout, cancelled) and capacity waits (admission_timeout)
+	// must not strike health breakers.
+	TerminalCause string `json:"terminal_cause,omitempty"`
+	// AttemptUsage carries the engine-reconciled token usage of the failed
+	// attempt at its terminal (partial generation included). Optional; legacy
+	// providers omit it. OBSERVABILITY ONLY on the coordinator: it is persisted
+	// on the route row and emitted in telemetry, but it never feeds billing,
+	// refunds, reservations, provider earnings, or payouts.
+	AttemptUsage *UsageInfo `json:"attempt_usage,omitempty"`
 }
 
 // ---------------------------------------------------------------------------

--- a/coordinator/protocol/messages_terminal_cause_test.go
+++ b/coordinator/protocol/messages_terminal_cause_test.go
@@ -93,7 +93,10 @@ func TestInferenceErrorUnknownCauseDecodesVerbatim(t *testing.T) {
 	if err := json.Unmarshal([]byte(raw), &pm); err != nil {
 		t.Fatalf("envelope unmarshal: %v", err)
 	}
-	msg := pm.Payload.(*InferenceErrorMessage)
+	msg, ok := pm.Payload.(*InferenceErrorMessage)
+	if !ok {
+		t.Fatalf("payload type = %T, want *InferenceErrorMessage", pm.Payload)
+	}
 	if msg.TerminalCause != "lease_reaped" {
 		t.Errorf("terminal_cause = %q, want lease_reaped (verbatim)", msg.TerminalCause)
 	}

--- a/coordinator/protocol/messages_terminal_cause_test.go
+++ b/coordinator/protocol/messages_terminal_cause_test.go
@@ -1,0 +1,158 @@
+package protocol
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// Typed error-terminal wire contract (deadline incident fix): the Swift
+// provider attaches an optional terminal_cause (closed vocabulary) and an
+// optional attempt_usage (engine-reconciled partial usage) to the existing
+// inference_error message. These tests pin the exact JSON names and the
+// legacy-compatibility behavior at the decode boundary.
+
+// Both optional fields present, decoded through the ProviderMessage envelope —
+// the production single-parse ingress path (type_scan fast path + concrete
+// struct unmarshal).
+func TestInferenceErrorTypedTerminalEnvelopeDecode(t *testing.T) {
+	raw := `{
+		"type": "inference_error",
+		"request_id": "req-typed-1",
+		"error": "request exceeded safety deadline",
+		"status_code": 504,
+		"error_reason": "provider_error",
+		"terminal_cause": "safety_deadline",
+		"attempt_usage": {
+			"prompt_tokens": 123,
+			"completion_tokens": 456,
+			"reasoning_tokens": 7
+		}
+	}`
+
+	var pm ProviderMessage
+	if err := json.Unmarshal([]byte(raw), &pm); err != nil {
+		t.Fatalf("envelope unmarshal: %v", err)
+	}
+	if pm.Type != TypeInferenceError {
+		t.Fatalf("type = %q, want %q", pm.Type, TypeInferenceError)
+	}
+	msg, ok := pm.Payload.(*InferenceErrorMessage)
+	if !ok {
+		t.Fatalf("payload type = %T, want *InferenceErrorMessage", pm.Payload)
+	}
+	if msg.TerminalCause != "safety_deadline" {
+		t.Errorf("terminal_cause = %q, want safety_deadline", msg.TerminalCause)
+	}
+	if msg.AttemptUsage == nil {
+		t.Fatal("attempt_usage = nil, want decoded usage")
+	}
+	if msg.AttemptUsage.PromptTokens != 123 {
+		t.Errorf("attempt_usage.prompt_tokens = %d, want 123", msg.AttemptUsage.PromptTokens)
+	}
+	if msg.AttemptUsage.CompletionTokens != 456 {
+		t.Errorf("attempt_usage.completion_tokens = %d, want 456", msg.AttemptUsage.CompletionTokens)
+	}
+	if msg.AttemptUsage.ReasoningTokens != 7 {
+		t.Errorf("attempt_usage.reasoning_tokens = %d, want 7", msg.AttemptUsage.ReasoningTokens)
+	}
+	// The legacy fields must be untouched by the additions.
+	if msg.RequestID != "req-typed-1" || msg.StatusCode != 504 || msg.ErrorReason != "provider_error" {
+		t.Errorf("legacy fields mismatch: %+v", msg)
+	}
+}
+
+// A legacy provider frame (no new fields) decodes with zero values: empty
+// cause, nil usage. This is the absent = legacy contract.
+func TestInferenceErrorLegacyFrameDecode(t *testing.T) {
+	raw := `{"type":"inference_error","request_id":"req-legacy","error":"boom","status_code":500}`
+
+	var pm ProviderMessage
+	if err := json.Unmarshal([]byte(raw), &pm); err != nil {
+		t.Fatalf("envelope unmarshal: %v", err)
+	}
+	msg, ok := pm.Payload.(*InferenceErrorMessage)
+	if !ok {
+		t.Fatalf("payload type = %T, want *InferenceErrorMessage", pm.Payload)
+	}
+	if msg.TerminalCause != "" {
+		t.Errorf("terminal_cause = %q, want empty (legacy)", msg.TerminalCause)
+	}
+	if msg.AttemptUsage != nil {
+		t.Errorf("attempt_usage = %+v, want nil (legacy)", msg.AttemptUsage)
+	}
+}
+
+// An unknown terminal_cause value decodes verbatim — the protocol layer never
+// classifies; treating unknown-as-legacy (plus the drift metric) is the api
+// layer's job (api/terminal_cause.go).
+func TestInferenceErrorUnknownCauseDecodesVerbatim(t *testing.T) {
+	raw := `{"type":"inference_error","request_id":"req-drift","error":"x","status_code":500,"terminal_cause":"lease_reaped"}`
+
+	var pm ProviderMessage
+	if err := json.Unmarshal([]byte(raw), &pm); err != nil {
+		t.Fatalf("envelope unmarshal: %v", err)
+	}
+	msg := pm.Payload.(*InferenceErrorMessage)
+	if msg.TerminalCause != "lease_reaped" {
+		t.Errorf("terminal_cause = %q, want lease_reaped (verbatim)", msg.TerminalCause)
+	}
+	if msg.AttemptUsage != nil {
+		t.Errorf("attempt_usage = %+v, want nil", msg.AttemptUsage)
+	}
+}
+
+// Marshaling a message without the new fields must keep the legacy wire shape
+// byte-compatible: omitempty must suppress both keys (mixed-fleet safety —
+// old coordinators/providers never see phantom keys).
+func TestInferenceErrorLegacyWireShapeUnchanged(t *testing.T) {
+	msg := InferenceErrorMessage{
+		Type:       TypeInferenceError,
+		RequestID:  "req-wire",
+		Error:      "boom",
+		StatusCode: 500,
+	}
+	data, err := json.Marshal(msg)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(data), "terminal_cause") {
+		t.Errorf("unset terminal_cause leaked into wire JSON: %s", data)
+	}
+	if strings.Contains(string(data), "attempt_usage") {
+		t.Errorf("unset attempt_usage leaked into wire JSON: %s", data)
+	}
+}
+
+// Round-trip with both fields set: exact wire key names are load-bearing (the
+// Swift provider mirrors them; renaming either silently reverts the fleet to
+// legacy semantics).
+func TestInferenceErrorTypedTerminalRoundTrip(t *testing.T) {
+	msg := InferenceErrorMessage{
+		Type:          TypeInferenceError,
+		RequestID:     "req-rt",
+		Error:         "deadline",
+		StatusCode:    504,
+		TerminalCause: "admission_timeout",
+		AttemptUsage:  &UsageInfo{PromptTokens: 9, CompletionTokens: 3, ReasoningTokens: 1},
+	}
+	data, err := json.Marshal(msg)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	for _, key := range []string{`"terminal_cause":"admission_timeout"`, `"attempt_usage"`, `"prompt_tokens":9`, `"completion_tokens":3`, `"reasoning_tokens":1`} {
+		if !strings.Contains(string(data), key) {
+			t.Errorf("wire JSON missing %s: %s", key, data)
+		}
+	}
+	var decoded InferenceErrorMessage
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if decoded.TerminalCause != msg.TerminalCause {
+		t.Errorf("terminal_cause round-trip = %q, want %q", decoded.TerminalCause, msg.TerminalCause)
+	}
+	if decoded.AttemptUsage == nil || *decoded.AttemptUsage != *msg.AttemptUsage {
+		t.Errorf("attempt_usage round-trip = %+v, want %+v", decoded.AttemptUsage, msg.AttemptUsage)
+	}
+}

--- a/coordinator/registry/capacity_cooldown.go
+++ b/coordinator/registry/capacity_cooldown.go
@@ -217,6 +217,23 @@ func (r *Registry) RecordCapacityRejectRequestShape(providerID, modelID string) 
 	return r.recordCapacityReject(providerID, modelID, false, false)
 }
 
+// RecordCapacityRejectBusy records a typed admission-timeout capacity signal
+// (InferenceErrorMessage terminal_cause=admission_timeout): the provider
+// accepted the dispatch but its engine could not admit the request before the
+// admission lease expired — a healthy-but-busy statement, never a fault and
+// never a token-budget-honesty statement. It feeds ONLY the black-hole
+// cooldown strike (the zero-interleaved-accepts discriminator keeps a serving
+// box safe): a pair that admission-times-out EVERYTHING with zero accepts is
+// a routing black hole exactly like a 100%-capacity-rejecting one. It arms
+// NEITHER gray-box tracker — not the budget clamp (an admission timeout says
+// nothing about the reported token budget, and a false clamp blocks the very
+// dispatches whose accepts prove release) and not the no-accept-reset
+// capacity-503 rate window (transient load would accumulate a false reject
+// rate against a healthy pair).
+func (r *Registry) RecordCapacityRejectBusy(providerID, modelID string) (tripped bool) {
+	return r.recordCapacityReject(providerID, modelID, false, false)
+}
+
 // recordCapacityReject is the shared implementation. deratePair gates the
 // gray-box capacity-503 rate window (true only for genuine capacity rejects);
 // armClamp gates the budget clamp (false only for request-deterministic

--- a/provider-swift/Sources/ProviderBenchmark/MTPBenchmarkRunner.swift
+++ b/provider-swift/Sources/ProviderBenchmark/MTPBenchmarkRunner.swift
@@ -844,6 +844,12 @@ public enum MTPBenchmarkRunner {
                 case .error:
                     throw MTPBenchmarkError.unsuccessfulTerminal(
                         row: row, reason: "engine_error")
+                case .terminal(let cause, _):
+                    // A typed platform/engine terminal (deadline lease / step
+                    // watchdog) is an unsuccessful benchmark terminal, same as
+                    // a plain engine error — surface the cause for triage.
+                    throw MTPBenchmarkError.unsuccessfulTerminal(
+                        row: row, reason: "terminal_\(cause)")
                 case .stop:
                     finishReason = "stop"
                 case .length:

--- a/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClientCodec.swift
+++ b/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClientCodec.swift
@@ -149,12 +149,17 @@ public enum CoordinatorClientCodec {
                 responseHash: responseHash
             ))
 
-        case .inferenceError(let requestId, let error, let statusCode, let errorReason):
+        case .inferenceError(
+            let requestId, let error, let statusCode, let errorReason,
+            let terminalCause, let attemptUsage
+        ):
             return .inferenceError(ProviderMessage.InferenceError(
                 requestId: requestId,
                 error: error,
                 statusCode: statusCode,
-                errorReason: errorReason
+                errorReason: errorReason,
+                terminalCause: terminalCause,
+                attemptUsage: attemptUsage
             ))
 
         case .attestationResponse(let payload):

--- a/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClientTypes.swift
+++ b/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClientTypes.swift
@@ -137,7 +137,14 @@ public enum OutboundMessage: Sendable {
         seSignature: String?,
         responseHash: String?
     )
-    case inferenceError(requestId: String, error: String, statusCode: UInt16, errorReason: String?)
+    case inferenceError(
+        requestId: String,
+        error: String,
+        statusCode: UInt16,
+        errorReason: String?,
+        terminalCause: InferenceTerminalCause?,
+        attemptUsage: UsageInfo?
+    )
     case attestationResponse(AttestationResponsePayload)
     case codeAttestationResponse(nonce: String, signature: String)
     case loadModelStatus(modelId: String, status: ProviderMessage.LoadModelStatus.Status, error: String?)
@@ -172,6 +179,28 @@ public enum OutboundMessage: Sendable {
     )
     case prefixCacheLookupV2(ProviderMessage.PrefixCacheLookupV2)
     case prefixCacheReadyV2(ProviderMessage.PrefixCacheReadyV2)
+
+    /// Legacy-signature convenience for the many call sites that emit an
+    /// inference error with no typed terminal cause or attempt usage (model
+    /// not loaded, encryption failure, template/jinja faults, …). Forwards to
+    /// the full case with the typed fields nil so those sites — and their
+    /// byte-identical legacy wire shape — stay untouched. Resolves to this
+    /// static member (4 labels), never the 6-label case, because the labels
+    /// differ.
+    public static func inferenceError(
+        requestId: String,
+        error: String,
+        statusCode: UInt16,
+        errorReason: String?
+    ) -> OutboundMessage {
+        .inferenceError(
+            requestId: requestId,
+            error: error,
+            statusCode: statusCode,
+            errorReason: errorReason,
+            terminalCause: nil,
+            attemptUsage: nil)
+    }
 }
 
 public struct AttestationResponsePayload: Sendable {

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge+PrefixCache.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge+PrefixCache.swift
@@ -6,8 +6,9 @@
 //
 //   * `EngineV2RequestUsageSignal` — per-request out-of-band carrier for
 //     the engine's terminal `prefixCacheHitTokens` (the logprobs-channel
-//     pattern: `GenerationEvent.info` deliberately stays `.chunk/.info/
-//     .error`, so usage DETAIL rides beside the stream, not inside it).
+//     pattern: `GenerationEvent.info` carries no prefix-cache DETAIL — the
+//     shared event stays `.chunk/.info/.error/.terminal` — so usage DETAIL
+//     rides beside the stream, not inside it).
 //     The coordinator frames loop splices it into the trailing SSE usage
 //     chunk as OpenAI-standard `prompt_tokens_details.cached_tokens`.
 //

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge.swift
@@ -984,6 +984,26 @@ public actor EngineV2Bridge {
                 ))
             }
             continuation.yield(.error("request cancelled"))
+        case .terminal(let cbCause, let message):
+            // Typed platform/engine terminal (a monotonic deadline lease or
+            // the step watchdog). Reconcile usage the same way as any other
+            // non-natural finish, then carry BOTH the machine-readable cause
+            // AND that usage through — instead of flattening the deadline into
+            // a generic string with zero usage (the incident behavior).
+            let final = recordFinish(id: id, usage: usage, success: false)
+            emitInferenceErrorTelemetry(requestId: id)
+            if let wireCause = Self.wireTerminalCause(cbCause) {
+                continuation.yield(.terminal(
+                    cause: wireCause,
+                    message: message,
+                    promptTokens: final.prompt,
+                    completionTokens: final.completion))
+            } else {
+                // No wire mapping (the `.legacyRequestTimeout` kill-switch, or
+                // any future engine cause): fall back to the legacy string
+                // shape byte-for-byte — never guess a typed cause.
+                continuation.yield(.error(message))
+            }
         case .error(let message):
             _ = recordFinish(id: id, usage: usage, success: false)
             emitInferenceErrorTelemetry(requestId: id)
@@ -1003,6 +1023,26 @@ public actor EngineV2Bridge {
         }
         if !sawFirstToken {
             wedgeMonitor.recordTerminalWithoutFirstToken()
+        }
+    }
+
+    /// Map an engine terminal cause to its wire vocabulary, or nil when there
+    /// is no mapping (the request then falls back to the legacy `.error(String)`
+    /// shape — NEVER guess a cause). Only the six lease/watchdog causes have a
+    /// wire mapping; `.legacyRequestTimeout` (the rollback kill-switch) and any
+    /// future engine case stay untyped, matching the pre-fix behavior exactly.
+    private static func wireTerminalCause(
+        _ cause: CBv2TerminalCause
+    ) -> InferenceTerminalCause? {
+        switch cause {
+        case .admissionTimeout: return .admissionTimeout
+        case .prefillStall: return .prefillStall
+        case .decodeStall: return .decodeStall
+        case .safetyDeadline: return .safetyDeadline
+        case .backpressureTimeout: return .backpressureTimeout
+        case .watchdog: return .watchdog
+        case .legacyRequestTimeout: return nil
+        @unknown default: return nil
         }
     }
 

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Factory+Production.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Factory+Production.swift
@@ -447,6 +447,27 @@ extension EngineV2Factory {
         return contiguousPreparation()
     }
 
+    /// Emergency rollback kill-switch for the monotonic deadline leases. Set
+    /// `DARKBLOOM_CBV2_LEGACY_REQUEST_TIMEOUT` to `1`/`true`/`yes`/`on` to
+    /// restore the legacy single total-lifetime wall
+    /// (`CBv2EngineLoopConfig.useLegacyRequestTimeout = true`) — the incident
+    /// behavior — for one release cycle while a regression is investigated.
+    /// Absent or any other value keeps the new-lease default: a typo must never
+    /// silently re-arm the flat 120s wall. Opposite polarity to the
+    /// `DARKBLOOM_CBV2_PAGED_KV` kill-switch (that one is on by default).
+    static let legacyRequestTimeoutEnvKey = "DARKBLOOM_CBV2_LEGACY_REQUEST_TIMEOUT"
+
+    /// True only when the kill-switch env var is set to an affirmative value.
+    static func legacyRequestTimeoutEnabled(
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> Bool {
+        guard let raw = environment[legacyRequestTimeoutEnvKey] else { return false }
+        switch raw.trimmingCharacters(in: .whitespaces).lowercased() {
+        case "1", "true", "yes", "on": return true
+        default: return false
+        }
+    }
+
     /// Final engine assembly over an already resolved backend. This method has
     /// no backend fallback path, so its cache capability cannot drift.
     static func assembleProductionBuild(
@@ -473,7 +494,12 @@ extension EngineV2Factory {
                 caches: caches,
                 schedulerConfig: schedulerConfig,
                 prefixCache: prefixCache,
-                loopConfig: CBv2EngineLoopConfig(),
+                // New monotonic phase leases are on by default
+                // (`useLegacyRequestTimeout` defaults false). The ONLY override
+                // is the emergency rollback kill-switch below — production never
+                // otherwise touches the lease config.
+                loopConfig: CBv2EngineLoopConfig(
+                    useLegacyRequestTimeout: Self.legacyRequestTimeoutEnabled()),
                 mtpDrafter: mtpDrafter,
                 mtpConfig: mtpConfig),
             kvBackendKind: preparedBackend.kind,

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Logprobs.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Logprobs.swift
@@ -13,8 +13,9 @@
 //
 // The upstream SSE encoder (`MLXOpenAIService.streamChatCompletionFrames` /
 // `OpenAIChatCompletionChunk`) has no logprobs field, and the provider's
-// `GenerationEvent` deliberately stays `.chunk/.info/.error` (extending it
-// would broaden the shared event contract). So the
+// `GenerationEvent` deliberately carries NO logprobs case (it stays
+// `.chunk/.info/.error/.terminal`; a logprobs case would broaden the shared
+// event contract). So the
 // entries travel OUT-OF-BAND: the bridge pump converts each delta's
 // logprobs (`EngineV2Translation.sseTokenLogprobs`) and appends them to a
 // per-request `EngineV2LogprobsChannel`; the coordinator inference handler

--- a/provider-swift/Sources/ProviderCore/Inference/InferenceTypes.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/InferenceTypes.swift
@@ -25,7 +25,21 @@ public enum GenerationEvent: Sendable {
     case info(
         promptTokens: Int, completionTokens: Int, tokensPerSecond: Double,
         finishReason: String?)
+    /// Legacy string-only error terminal (engine faults, teardown sentinel,
+    /// capacity markers). Carries no machine-readable cause or usage.
     case error(String)
+    /// Typed platform/engine terminal (a CBv2 monotonic deadline lease or the
+    /// step watchdog), carrying the machine-readable cause AND the
+    /// engine-reconciled usage generated before it fired — so a policy
+    /// deadline is no longer flattened into an indistinguishable string error
+    /// with zero usage. `cause` is already the wire vocabulary; the bridge
+    /// only ever produces the six engine lease/watchdog causes (any other
+    /// CBv2 cause, e.g. the legacy-timeout kill-switch, stays a `.error`).
+    /// Reasoning tokens are always 0 here (the engine does not classify
+    /// reasoning); the provider fills that in on the success path only.
+    case terminal(
+        cause: InferenceTerminalCause, message: String,
+        promptTokens: Int, completionTokens: Int)
 }
 
 /// Model-architecture fields read from `config.json`, used by

--- a/provider-swift/Sources/ProviderCore/Inference/MultiModelBatchSchedulerEngine.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/MultiModelBatchSchedulerEngine.swift
@@ -615,6 +615,10 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
                 var lastTokenAt: Date?
                 var stopReason: String = "stop"
                 var failed: String?
+                // Typed platform/engine terminal (deadline lease / watchdog),
+                // carrying the cause + reconciled usage so they survive the
+                // throw instead of being flattened into a string by `failed`.
+                var failedTerminal: MultiModelBatchSchedulerEngineError?
                 startedAt = Date()
 
                 for await event in upstream {
@@ -672,7 +676,28 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
                         if let reason { stopReason = reason }
                     case .error(let message):
                         failed = message
+                    case .terminal(let cause, let message, let p, let c):
+                        // Preserve the machine-readable cause AND the
+                        // engine-reconciled usage (partial generation included)
+                        // so the provider can emit terminal_cause/attempt_usage
+                        // instead of a generic string with zero usage. The
+                        // human-readable message is cause-prefixed so the wire
+                        // `error` field is informative on its own.
+                        failedTerminal = .platformTerminal(
+                            cause: cause,
+                            message: "\(cause.rawValue): \(message)",
+                            attemptUsage: UsageInfo(
+                                promptTokens: UInt64(max(0, p)),
+                                completionTokens: UInt64(max(0, c))))
                     }
+                }
+
+                if let failedTerminal {
+                    // A typed terminal wins over any legacy string: it carries
+                    // the cause + usage the status mapper and coordinator need.
+                    await releaseBox.fire()
+                    continuation.finish(throwing: failedTerminal)
+                    return
                 }
 
                 if let failed {

--- a/provider-swift/Sources/ProviderCore/Inference/MultiModelBatchSchedulerEngineError.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/MultiModelBatchSchedulerEngineError.swift
@@ -71,6 +71,17 @@ public enum MultiModelBatchSchedulerEngineError: Error, LocalizedError, Equatabl
     /// never transient capacity — so it surfaces as 400, not a retry
     /// signal.
     case multimodalRejected(String)
+    /// A typed CBv2 platform/engine terminal (a monotonic deadline lease or
+    /// the step watchdog) fired mid-generation. Unlike `.generationFailed`,
+    /// this carries the machine-readable `cause` AND the engine-reconciled
+    /// `attemptUsage` (partial generation included), so the provider can emit
+    /// an `inference_error` with `terminal_cause`/`attempt_usage` and the
+    /// coordinator can classify health/retry from the cause instead of parsing
+    /// a string. Status is cause-derived (`mapInferenceErrorToStatus`); never
+    /// 429 (a policy deadline must not be relabeled a rate limit). `message`
+    /// already includes the cause for the human-readable `error` field.
+    case platformTerminal(
+        cause: InferenceTerminalCause, message: String, attemptUsage: UsageInfo)
 
     public var errorDescription: String? {
         switch self {
@@ -96,6 +107,8 @@ public enum MultiModelBatchSchedulerEngineError: Error, LocalizedError, Equatabl
             return
                 "Model '\(id)' does not support image or video input on this provider"
         case .multimodalRejected(let message):
+            return message
+        case .platformTerminal(_, let message, _):
             return message
         }
     }

--- a/provider-swift/Sources/ProviderCore/Protocol/Messages.swift
+++ b/provider-swift/Sources/ProviderCore/Protocol/Messages.swift
@@ -353,12 +353,33 @@ public enum ProviderMessage: Sendable, Equatable {
         /// provider cannot confidently classify the failure (the coordinator then
         /// derives a reason from status/class). Omitted on the wire when nil.
         public var errorReason: String?
+        /// Typed terminal cause for this error (closed vocabulary, mirrored by
+        /// the coordinator's Go `terminal_cause` field). Present for CBv2
+        /// platform/engine terminals (deadline leases, step watchdog) and the
+        /// provider's own pre-output cancellation; nil for every legacy string
+        /// error. Omitted on the wire when nil so the legacy shape stays
+        /// byte-identical.
+        public var terminalCause: InferenceTerminalCause?
+        /// Engine-reconciled token usage of the failed attempt at its terminal
+        /// (partial generation included). OBSERVABILITY ONLY — the coordinator
+        /// persists/telemeters it but never bills from it. Omitted on the wire
+        /// when nil (legacy providers, or a terminal with no usage).
+        public var attemptUsage: UsageInfo?
 
-        public init(requestId: String, error: String, statusCode: UInt16, errorReason: String? = nil) {
+        public init(
+            requestId: String,
+            error: String,
+            statusCode: UInt16,
+            errorReason: String? = nil,
+            terminalCause: InferenceTerminalCause? = nil,
+            attemptUsage: UsageInfo? = nil
+        ) {
             self.requestId = requestId
             self.error = error
             self.statusCode = statusCode
             self.errorReason = errorReason
+            self.terminalCause = terminalCause
+            self.attemptUsage = attemptUsage
         }
     }
 
@@ -726,6 +747,8 @@ extension ProviderMessage: Codable {
         case error
         case statusCode = "status_code"
         case errorReason = "error_reason"
+        case terminalCause = "terminal_cause"
+        case attemptUsage = "attempt_usage"
         // AttestationResponse
         case nonce, signature
         case statusSignature = "status_signature"
@@ -848,6 +871,10 @@ extension ProviderMessage: Codable {
             try container.encode(e.error, forKey: .error)
             try container.encode(e.statusCode, forKey: .statusCode)
             try container.encodeIfPresent(e.errorReason, forKey: .errorReason)
+            // Optional typed-terminal additions; omitted when nil so the legacy
+            // wire shape is byte-identical (mirrors Go `omitempty`).
+            try container.encodeIfPresent(e.terminalCause?.rawValue, forKey: .terminalCause)
+            try container.encodeIfPresent(e.attemptUsage, forKey: .attemptUsage)
 
         case .attestationResponse(let a):
             try container.encode(TypeValue.attestationResponse, forKey: .type)
@@ -1045,11 +1072,18 @@ extension ProviderMessage: Codable {
             ))
 
         case .inferenceError:
+            // Unknown terminal_cause strings decode to nil (tolerant): a newer
+            // provider value must never crash an older decoder — it falls back to
+            // the legacy string/status heuristics, exactly like an absent field.
+            let terminalCause = (try container.decodeIfPresent(String.self, forKey: .terminalCause))
+                .flatMap(InferenceTerminalCause.init(rawValue:))
             self = .inferenceError(InferenceError(
                 requestId: try container.decode(String.self, forKey: .requestId),
                 error: try container.decode(String.self, forKey: .error),
                 statusCode: try container.decode(UInt16.self, forKey: .statusCode),
-                errorReason: try container.decodeIfPresent(String.self, forKey: .errorReason)
+                errorReason: try container.decodeIfPresent(String.self, forKey: .errorReason),
+                terminalCause: terminalCause,
+                attemptUsage: try container.decodeIfPresent(UsageInfo.self, forKey: .attemptUsage)
             ))
 
         case .attestationResponse:

--- a/provider-swift/Sources/ProviderCore/Protocol/Types.swift
+++ b/provider-swift/Sources/ProviderCore/Protocol/Types.swift
@@ -270,6 +270,28 @@ public enum PrefixCacheTier: String, Codable, Sendable, Equatable {
     case ssd
 }
 
+/// Closed wire vocabulary for `inference_error.terminal_cause`. Mirrors the
+/// coordinator's Go `InferenceErrorMessage.TerminalCause` string field
+/// (`coordinator/protocol/messages.go`) EXACTLY — the raw values ARE the wire
+/// contract, so they must not drift. Omitted on the wire when nil (legacy
+/// providers send no terminal cause and the coordinator falls back to its
+/// historical string/status heuristics).
+///
+/// The provider only ever EMITS the six engine lease/watchdog causes (mapped
+/// from `CBv2TerminalCause`) plus `cancelled` (tagged by the provider's own
+/// pre-output cancellation path). `engineError` is part of the closed
+/// vocabulary the coordinator recognizes but the provider never emits it.
+public enum InferenceTerminalCause: String, Codable, Sendable, Equatable, CaseIterable {
+    case admissionTimeout = "admission_timeout"
+    case prefillStall = "prefill_stall"
+    case decodeStall = "decode_stall"
+    case safetyDeadline = "safety_deadline"
+    case backpressureTimeout = "backpressure_timeout"
+    case watchdog
+    case cancelled
+    case engineError = "engine_error"
+}
+
 public struct UsageInfo: Codable, Sendable, Equatable {
     public var promptTokens: UInt64
     public var completionTokens: UInt64

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+ErrorMapping.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+ErrorMapping.swift
@@ -90,6 +90,29 @@ extension ProviderLoop {
                 return 400
             case .generationFailed:
                 return 500
+            case .platformTerminal(let cause, _, _):
+                // Client-facing status only — the coordinator's HEALTH
+                // decisions key off `terminal_cause`, not this code. NEVER 429:
+                // the incident report forbids relabeling a policy timeout as a
+                // rate limit.
+                switch cause {
+                case .admissionTimeout:
+                    // Capacity wait before engine admission — retry once
+                    // capacity frees (matches the token-budget 503 posture).
+                    return 503
+                case .safetyDeadline, .backpressureTimeout:
+                    // Time-bound platform terminals → gateway timeout.
+                    return 504
+                case .prefillStall, .decodeStall, .watchdog:
+                    // Engine progress faults → server error.
+                    return 500
+                case .cancelled:
+                    // Client-closed request (defense-in-depth; the provider
+                    // tags cancels 499 directly, not via this enum).
+                    return 499
+                case .engineError:
+                    return 500
+                }
             }
         }
         // VLM inline-media decode errors. All but the temp-file write are
@@ -111,6 +134,22 @@ extension ProviderLoop {
             }
         }
         return 500
+    }
+
+    /// Extract the typed terminal cause and engine-reconciled usage from an
+    /// inference error, for the optional `terminal_cause`/`attempt_usage`
+    /// fields on the outgoing `inference_error`. Only a CBv2 platform/engine
+    /// terminal carries them; every other error returns (nil, nil) so the wire
+    /// message stays byte-identical to the legacy shape.
+    static func inferenceTerminalMetadata(
+        from error: Error
+    ) -> (cause: InferenceTerminalCause?, usage: UsageInfo?) {
+        if let engErr = error as? MultiModelBatchSchedulerEngineError,
+            case .platformTerminal(let cause, _, let usage) = engErr
+        {
+            return (cause, usage)
+        }
+        return (nil, nil)
     }
 
     static func isStreamClosedWithoutTerminal(_ error: Error) -> Bool {

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+InferenceHandler.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+InferenceHandler.swift
@@ -575,7 +575,13 @@ extension ProviderLoop {
                             requestId: requestId,
                             error: "request cancelled",
                             statusCode: 499,
-                            errorReason: nil),
+                            errorReason: nil,
+                            // Pre-output client cancellation — tag it so the
+                            // coordinator classifies this health-neutral (never
+                            // a provider fault). Nothing was delivered, so no
+                            // attempt usage rides along (the coordinator refunds).
+                            terminalCause: .cancelled,
+                            attemptUsage: nil),
                         fallbackFailure: .policy,
                         send: send)
                     return
@@ -610,12 +616,18 @@ extension ProviderLoop {
                         )
                     }
                 }
+                // Defense-in-depth: a typed platform terminal normally surfaces
+                // mid-stream, but if one is thrown synchronously at stream start
+                // carry its cause + usage too (non-terminal errors → nil, nil).
+                let terminal = Self.inferenceTerminalMetadata(from: error)
                 lookupReceiptFinalizer.sendTerminal(
                     .inferenceError(
                         requestId: requestId,
                         error: error.localizedDescription,
                         statusCode: statusCode,
-                        errorReason: reason),
+                        errorReason: reason,
+                        terminalCause: terminal.cause,
+                        attemptUsage: terminal.usage),
                     fallbackFailure: statusCode == 503 ? .capacity : .policy,
                     send: send)
                 return
@@ -807,6 +819,11 @@ extension ProviderLoop {
                         providerStats.incrementStreamClosedWithoutTerminal()
                     }
                     let statusCode = Self.mapInferenceErrorToStatus(error)
+                    // A CBv2 platform/engine terminal (deadline lease / step
+                    // watchdog) carries a typed cause + engine-reconciled usage;
+                    // every other error yields (nil, nil) and the wire message
+                    // stays byte-identical to the legacy shape.
+                    let terminal = Self.inferenceTerminalMetadata(from: error)
                     // Mid-stream generation errors use typed classification only:
                     // tool-choice violations are request/model-output faults, while
                     // string-based Jinja classification remains confined to stream
@@ -817,7 +834,9 @@ extension ProviderLoop {
                             requestId: requestId,
                             error: error.localizedDescription,
                             statusCode: statusCode,
-                            errorReason: classifyTypedInferenceErrorReason(error)),
+                            errorReason: classifyTypedInferenceErrorReason(error),
+                            terminalCause: terminal.cause,
+                            attemptUsage: terminal.usage),
                         fallbackFailure: statusCode == 503 ? .capacity : .policy,
                         send: send)
                     return
@@ -873,7 +892,13 @@ extension ProviderLoop {
                             requestId: requestId,
                             error: "request cancelled",
                             statusCode: 499,
-                            errorReason: nil),
+                            errorReason: nil,
+                            // Pre-output client cancellation — tag it so the
+                            // coordinator classifies this health-neutral (never
+                            // a provider fault). Nothing was delivered, so no
+                            // attempt usage rides along (the coordinator refunds).
+                            terminalCause: .cancelled,
+                            attemptUsage: nil),
                         fallbackFailure: .policy,
                         send: send)
                     return

--- a/provider-swift/Tests/ProviderCoreTests/EngineV2BridgeTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/EngineV2BridgeTests.swift
@@ -172,12 +172,15 @@ private enum RecordedEvent: Equatable, CustomStringConvertible {
     case chunk(String)
     case info(prompt: Int, completion: Int)
     case error(String)
+    case terminal(cause: InferenceTerminalCause, prompt: Int, completion: Int)
 
     var description: String {
         switch self {
         case .chunk(let s): return "chunk(\(s))"
         case .info(let p, let c): return "info(\(p),\(c))"
         case .error(let m): return "error(\(m))"
+        case .terminal(let cause, let p, let c):
+            return "terminal(\(cause.rawValue),\(p),\(c))"
         }
     }
 }
@@ -196,6 +199,8 @@ private func record(
             tps.append(tokensPerSecond)
         case .error(let message):
             events.append(.error(message))
+        case .terminal(let cause, _, let prompt, let completion):
+            events.append(.terminal(cause: cause, prompt: prompt, completion: completion))
         }
     }
     return (events, tps)
@@ -659,6 +664,41 @@ struct EngineV2EventFramingTests {
         let bridge = makeBridge(engine: engine)
         let (events, _) = await record(await bridge.submit(request: makeRequest()))
         #expect(events == [.chunk("x"), .info(prompt: 5, completion: 1)])
+    }
+
+    /// Deadline-first-principles regression: a typed platform/engine terminal
+    /// used to be flattened into a generic string error with ZERO usage. It now
+    /// surfaces as `.terminal` carrying the machine-readable cause AND the
+    /// engine-reconciled usage the watchdog observed before firing.
+    @Test("typed platform terminal surfaces as .terminal with cause + reconciled usage")
+    func typedTerminalCarriesCauseAndUsage() async {
+        // Watchdog-style: no deltas, the engine reports the real counts it saw.
+        let engine = ScriptedCBv2Engine(script: .stream([
+            .finished(
+                reason: .terminal(cause: .decodeStall, message: "decode made no progress"),
+                usage: CBv2Usage(promptTokens: 11, completionTokens: 5)),
+        ]))
+        let bridge = makeBridge(engine: engine)
+        let (events, _) = await record(await bridge.submit(request: makeRequest()))
+        #expect(events == [.terminal(cause: .decodeStall, prompt: 11, completion: 5)])
+        // It is NOT flattened into a legacy string error.
+        #expect(!events.contains { if case .error = $0 { return true }; return false })
+    }
+
+    /// `.legacyRequestTimeout` (the rollback kill-switch's terminal) has NO wire
+    /// cause — the bridge must fall back to the legacy `.error(String)` shape
+    /// byte-for-byte, never guess a typed cause.
+    @Test(".legacyRequestTimeout has no wire cause → legacy .error string")
+    func legacyTimeoutTerminalStaysLegacyError() async {
+        let engine = ScriptedCBv2Engine(script: .stream([
+            .finished(
+                reason: .terminal(
+                    cause: .legacyRequestTimeout, message: "request exceeded 120s deadline"),
+                usage: CBv2Usage(promptTokens: 3, completionTokens: 0)),
+        ]))
+        let bridge = makeBridge(engine: engine)
+        let (events, _) = await record(await bridge.submit(request: makeRequest()))
+        #expect(events == [.error("request exceeded 120s deadline")])
     }
 
     /// Regression: the v2 bridge used to flatten `.length` into the same

--- a/provider-swift/Tests/ProviderCoreTests/EngineV2CoResidencyLiveTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/EngineV2CoResidencyLiveTests.swift
@@ -98,6 +98,7 @@ struct EngineV2CoResidencyLiveTests {
             case .chunk(let chunk): text += chunk
             case .info(_, let completionTokens, _, _): completion = completionTokens
             case .error(let message): error = message
+            case .terminal(_, let message, _, _): error = message
             }
         }
         return (text, completion, error)

--- a/provider-swift/Tests/ProviderCoreTests/EngineV2PagedParityLiveTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/EngineV2PagedParityLiveTests.swift
@@ -117,6 +117,7 @@ struct EngineV2PagedParityLiveTests {
             case .chunk(let chunk): text += chunk
             case .info(_, let completionTokens, _, _): completion = completionTokens
             case .error(let message): error = message
+            case .terminal(_, let message, _, _): error = message
             }
         }
         return (text, completion, error)

--- a/provider-swift/Tests/ProviderCoreTests/EngineV2ProductionWiringTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/EngineV2ProductionWiringTests.swift
@@ -347,6 +347,8 @@ struct EngineV2SlotBuildTests {
                 sawInfo = true
             case .error(let message):
                 Issue.record("unexpected error event: \(message)")
+            case .terminal(let cause, let message, _, _):
+                Issue.record("unexpected terminal event: \(cause.rawValue) \(message)")
             }
         }
         #expect(sawChunk)

--- a/provider-swift/Tests/ProviderCoreTests/EngineV2SSDPrefixCacheLiveTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/EngineV2SSDPrefixCacheLiveTests.swift
@@ -291,6 +291,8 @@ struct EngineV2SSDPrefixCacheLiveTests {
                 break
             case .error(let message):
                 streamError = message
+            case .terminal(_, let message, _, _):
+                streamError = message
             }
         }
         if let streamError {

--- a/provider-swift/Tests/ProviderCoreTests/GemmaMTPProductionLiveTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/GemmaMTPProductionLiveTests.swift
@@ -275,6 +275,9 @@ struct GemmaMTPProductionLiveTests {
         case .error:
             throw MTPBenchmarkError.unsuccessfulTerminal(
                 row: 0, reason: "engine_error")
+        case .terminal(let cause, _):
+            throw MTPBenchmarkError.unsuccessfulTerminal(
+                row: 0, reason: "terminal_\(cause)")
         }
         guard !tokens.isEmpty else { throw MTPBenchmarkError.emptyTokenStream(row: 0) }
         return tokens

--- a/provider-swift/Tests/ProviderCoreTests/GemmaToolCallLiveTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/GemmaToolCallLiveTests.swift
@@ -176,7 +176,7 @@ struct GemmaToolCallLiveTests {
         for await event in stream {
             switch event {
             case .chunk(let t): text += t
-            case .info, .error: break
+            case .info, .error, .terminal: break
             }
         }
 

--- a/provider-swift/Tests/ProviderCoreTests/LiveInferenceFixtures.swift
+++ b/provider-swift/Tests/ProviderCoreTests/LiveInferenceFixtures.swift
@@ -369,6 +369,10 @@ func collect(
             collected.info = (prompt, completion, tps)
         case .error(let message):
             collected.error = message
+        case .terminal(_, let message, _, _):
+            // A typed platform/engine terminal is an error terminal for this
+            // generic collector — record its (cause-prefixed) message.
+            collected.error = message
         }
     }
     return collected

--- a/provider-swift/Tests/ProviderCoreTests/MultiModelBatchSchedulerEngineTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/MultiModelBatchSchedulerEngineTests.swift
@@ -296,6 +296,68 @@ func fromSchedulerMessageFallsThroughToGenerationFailed() {
     #expect(ProviderLoop.mapInferenceErrorToStatus(err) == 500)
 }
 
+@Test("platformTerminal maps each cause to its client status, never 429")
+func platformTerminalStatusMapping() {
+    // Client-facing status only — the coordinator's HEALTH decisions key off
+    // terminal_cause, not this code. The incident report forbids 429 for any
+    // policy deadline.
+    let cases: [(InferenceTerminalCause, UInt16)] = [
+        (.admissionTimeout, 503),
+        (.safetyDeadline, 504),
+        (.backpressureTimeout, 504),
+        (.prefillStall, 500),
+        (.decodeStall, 500),
+        (.watchdog, 500),
+    ]
+    for (cause, expected) in cases {
+        let err = MultiModelBatchSchedulerEngineError.platformTerminal(
+            cause: cause, message: "\(cause.rawValue): x",
+            attemptUsage: UsageInfo(promptTokens: 1, completionTokens: 2))
+        let status = ProviderLoop.mapInferenceErrorToStatus(err)
+        #expect(status == expected, "cause \(cause.rawValue) → \(status), expected \(expected)")
+        #expect(status != 429, "a policy deadline must never be relabeled a rate limit")
+    }
+}
+
+@Test("platformTerminal carries cause + usage to the handler; legacy errors do not")
+func platformTerminalMetadataExtraction() {
+    let usage = UsageInfo(promptTokens: 9, completionTokens: 4)
+    let terminal = MultiModelBatchSchedulerEngineError.platformTerminal(
+        cause: .decodeStall, message: "decode_stall: no progress", attemptUsage: usage)
+    let meta = ProviderLoop.inferenceTerminalMetadata(from: terminal)
+    #expect(meta.cause == .decodeStall)
+    #expect(meta.usage?.promptTokens == 9)
+    #expect(meta.usage?.completionTokens == 4)
+    // The human-readable error stays informative (cause-prefixed).
+    #expect(terminal.errorDescription == "decode_stall: no progress")
+
+    // Mixed-version: a legacy string error yields today's exact wire shape —
+    // no typed cause, no attempt usage, still 500.
+    let legacy = MultiModelBatchSchedulerEngineError.generationFailed("boom")
+    let legacyMeta = ProviderLoop.inferenceTerminalMetadata(from: legacy)
+    #expect(legacyMeta.cause == nil)
+    #expect(legacyMeta.usage == nil)
+    #expect(ProviderLoop.mapInferenceErrorToStatus(legacy) == 500)
+}
+
+@Test("legacy-request-timeout kill-switch: only affirmative values enable it")
+func legacyRequestTimeoutKillSwitchParse() {
+    let key = EngineV2Factory.legacyRequestTimeoutEnvKey
+    // Absent → new-lease default (kill-switch off).
+    #expect(EngineV2Factory.legacyRequestTimeoutEnabled(environment: [:]) == false)
+    for on in ["1", "true", "TRUE", "yes", "on", " On "] {
+        #expect(
+            EngineV2Factory.legacyRequestTimeoutEnabled(environment: [key: on]) == true,
+            "\(on) should enable the kill-switch")
+    }
+    // A typo must not silently re-arm the flat 120s wall.
+    for off in ["0", "false", "no", "off", "", "garbage"] {
+        #expect(
+            EngineV2Factory.legacyRequestTimeoutEnabled(environment: [key: off]) == false,
+            "\(off) must not enable the kill-switch")
+    }
+}
+
 @Test("invalidRole maps to 400 (P2 #5)")
 func invalidRoleMapsToBadRequest() {
     let err = MultiModelBatchSchedulerEngineError.invalidRole("developer")

--- a/provider-swift/Tests/ProviderCoreTests/MultiModelBatchSchedulerEngineTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/MultiModelBatchSchedulerEngineTests.swift
@@ -308,6 +308,8 @@ func platformTerminalStatusMapping() {
         (.prefillStall, 500),
         (.decodeStall, 500),
         (.watchdog, 500),
+        (.cancelled, 499),
+        (.engineError, 500),
     ]
     for (cause, expected) in cases {
         let err = MultiModelBatchSchedulerEngineError.platformTerminal(

--- a/provider-swift/Tests/ProviderCoreTests/ProtocolTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ProtocolTests.swift
@@ -460,6 +460,64 @@ import Testing
     #expect(e2.errorReason == nil)
 }
 
+@Test func inferenceErrorEncodesTypedTerminalFieldsOnlyWhenPresent() throws {
+    // Deadline-first-principles: the optional `terminal_cause` + `attempt_usage`
+    // fields ride the existing inference_error message and mirror the Go side
+    // (`coordinator/protocol/messages.go`) exactly.
+    //
+    // Present → snake_case keys on the wire, round-trip back to the values.
+    let withTerminal = ProviderMessage.inferenceError(ProviderMessage.InferenceError(
+        requestId: "req-term",
+        error: "decode_stall: decode made no confirmed token progress",
+        statusCode: 500,
+        terminalCause: .decodeStall,
+        attemptUsage: UsageInfo(promptTokens: 7, completionTokens: 42)
+    ))
+    let withData = try ProviderProtocolCodec.encodeProviderMessage(withTerminal)
+    let withObject = try jsonObject(withData)
+    #expect(withObject["terminal_cause"] as? String == "decode_stall")
+    let usageObject = withObject["attempt_usage"] as? [String: Any]
+    #expect(usageObject?["prompt_tokens"] as? Int == 7)
+    #expect(usageObject?["completion_tokens"] as? Int == 42)
+    // reasoning_tokens is 0 here → omitted (mirrors Go `omitempty`).
+    #expect(usageObject?["reasoning_tokens"] == nil)
+
+    let decodedWith = try ProviderProtocolCodec.decodeProviderMessage(from: withData)
+    #expect(decodedWith == withTerminal)
+    guard case .inferenceError(let e) = decodedWith else { throw TestFailure.unexpectedMessage }
+    #expect(e.terminalCause == .decodeStall)
+    #expect(e.attemptUsage?.promptTokens == 7)
+    #expect(e.attemptUsage?.completionTokens == 42)
+
+    // Absent (legacy) → BOTH keys omitted AND the full serialized shape is
+    // byte-identical to the pre-fix message (the Go side asserts the same
+    // legacy bytes). Encoder uses sorted keys, so the string is deterministic.
+    let legacy = ProviderMessage.inferenceError(ProviderMessage.InferenceError(
+        requestId: "req-error",
+        error: "model not loaded",
+        statusCode: 503
+    ))
+    let legacyData = try ProviderProtocolCodec.encodeProviderMessage(legacy)
+    let legacyString = String(data: legacyData, encoding: .utf8)
+    #expect(
+        legacyString
+            == #"{"error":"model not loaded","request_id":"req-error","status_code":503,"type":"inference_error"}"#)
+    let legacyObject = try jsonObject(legacyData)
+    #expect(legacyObject["terminal_cause"] == nil)
+    #expect(legacyObject["attempt_usage"] == nil)
+    #expect(try ProviderProtocolCodec.decodeProviderMessage(from: legacyData) == legacy)
+
+    // Unknown terminal_cause string → tolerant decode (nil), never a throw; a
+    // newer provider value must not crash an older decoder.
+    let unknownJSON = #"{"type":"inference_error","request_id":"r","error":"x","status_code":500,"terminal_cause":"some_future_cause"}"#
+    let decodedUnknown = try ProviderProtocolCodec.decodeProviderMessage(from: unknownJSON)
+    guard case .inferenceError(let unknown) = decodedUnknown else {
+        throw TestFailure.unexpectedMessage
+    }
+    #expect(unknown.terminalCause == nil)
+    #expect(unknown.statusCode == 500)
+}
+
 @Test func loadModelMessagesRoundTripWithCoordinator() throws {
     // Coordinator → provider preload request
     let goLoadRequest = #"{"type":"load_model","model_id":"mlx-community/Qwen3-0.6B-8bit"}"#


### PR DESCRIPTION
## Summary

Root-cause fix for the generation-deadline incident
([docs/reports/2026-07-20-generation-deadline-incident-and-redesign.md](docs/reports/2026-07-20-generation-deadline-incident-and-redesign.md)),
built as a deliberate **lean, first-principles cut** from current master —
three coordinated changes, no settlement journal, no signing, no partial
billing, no new message types.

**The bug:** CBv2 stamped every request `Date()+120s` at engine enqueue,
covering the entire engine lifetime (waiting, prefill, decode, preemption,
backpressure) — a regression from the pre-CBv2 scheduler where 120s applied
only to never-admitted requests. Healthy mid-generation requests were killed
(~178K/week; a 16K-token generation needs ~290s), their reconciled partial
usage was discarded at two provider translation boundaries, and the
resulting generic 500 made the coordinator refund the consumer, pay the
provider nothing, and strike provider health breakers — punishing healthy
providers for our own policy, invisibly (the uptime metric records success
at content-commit, so 98% of these deaths counted as successes).

**The fix (three layers):**

1. **Engine** ([Layr-Labs/mlx-swift-lm#82](https://github.com/Layr-Labs/mlx-swift-lm/pull/82),
   pinned here at `d4e83ca85`): the flat wall becomes independent
   **monotonic** mechanisms — admission-only 120s timeout (the original
   intent; never re-arms after admission/preemption), prefill/decode
   **progress** leases (a request producing tokens is never expired; a
   stuck one dies in 120s), a conservative request-derived safety ceiling
   (~12× headroom at a 5 tok/s floor), and the watchdog now reports
   reconciled usage instead of zero. Terminals are typed and carry usage.
   `useLegacyRequestTimeout` kill-switch restores the old wall.
2. **Provider** (`provider-swift/`): the typed cause + usage now survive
   `EngineV2Bridge` and `MultiModelBatchSchedulerEngine` (which previously
   flattened both into bare strings) and reach the wire as two **optional**
   fields on the existing `inference_error`: `terminal_cause` (closed
   8-value vocabulary) and `attempt_usage`. Absent fields = byte-identical
   legacy JSON (fixture-pinned). Status mapping: `admission_timeout`→503,
   `safety_deadline`/`backpressure_timeout`→504, stalls/`watchdog`→500,
   `cancelled`→499 — never 429. Env kill-switch
   `DARKBLOOM_CBV2_LEGACY_REQUEST_TIMEOUT`.
3. **Coordinator** (`coordinator/`): mirrors the fields; classifies typed
   causes across **every** health funnel (`RecordJobFailure`, shape/error
   cooldown, node breaker, stable-identity ejection, load cooldown,
   capacity tracker): `admission_timeout` = capacity signal only;
   `safety_deadline`/`backpressure_timeout`/`cancelled` = strictly neutral
   (no strikes **and** no clears); `prefill_stall`/`decode_stall`/
   `watchdog` = full fault (real provider sickness); absent/unknown cause =
   **bit-for-bit legacy behavior** (regression-pinned). `attempt_usage`
   persists on error route rows for observability — refunds, reservations,
   earnings, ledger untouched.

**Mixed versions are safe by construction:** old provider + new coordinator
= exact legacy behavior; new provider + old coordinator = unknown optional
JSON fields ignored.

## Behavior

```mermaid
flowchart TB
  subgraph Before
    B1[Healthy request, tokens flowing] --> B2[Killed at 120s wall]
    B2 --> B3[Usage reconciled then discarded twice]
    B3 --> B4[Generic 500 inference_error]
    B4 --> B5[Consumer refunded, output discarded]
    B4 --> B6[Provider paid nothing + health breakers struck]
    B4 --> B7[Retry cascade: up to 63 attempts x 120s each]
  end
  subgraph After
    A1[Healthy request, tokens flowing] --> A2[Never expired - finishes naturally: stop / length]
    A3[Genuinely stuck request] --> A4[Dies in <=120s with typed cause + partial usage]
    A4 --> A5{Coordinator classifies}
    A5 -->|admission_timeout| A6[Capacity signal only]
    A5 -->|safety_deadline / backpressure / cancelled| A7[Strictly neutral: no strike, no clear]
    A5 -->|prefill/decode stall, watchdog| A8[Fault - real sickness]
    A5 -->|absent / unknown| A9[Bit-for-bit legacy]
    A4 --> A10[Usage persisted on route row - work no longer invisible]
  end
```

## Code

```mermaid
flowchart LR
  subgraph Before
    C1[EngineLoopV2: Date+120s inline checks] --> C2[EngineV2Bridge: error String, usage dropped]
    C2 --> C3[SchedulerEngine: rethrow String]
    C3 --> C4[inference_error: no cause, no usage]
    C4 --> C5[handleInferenceError: all funnels strike unconditionally]
  end
  subgraph After
    D1[Engine: CBv2DeadlineLeases + terminal cause,usage] --> D2[Bridge: GenerationEvent.terminal cause+usage]
    D2 --> D3[SchedulerEngine: platformTerminal error]
    D3 --> D4[inference_error + terminal_cause + attempt_usage optional fields]
    D4 --> D5[terminal_cause.go - NEW: classify -> gate every funnel]
    D5 --> D6[applyAttemptUsage -> route rows]
  end
```

## Accepted tradeoffs (reviewed, bounded)

- Non-streaming requests genuinely needing >600s now hit the coordinator's
  600s absolute cap instead of the engine's 120s wall — longer
  time-to-failure for the unservable tail, bounded by the existing
  cancel-on-return defer (provider work stops at ≤600s), and offset by
  eliminating the 120s retry-amplification cascade (observed up to 63
  attempts) and letting the entire 120–600s cohort succeed. Streaming is
  unaffected (per-chunk idle timer).
- Requests legitimately live longer → providers report busy longer. This is
  accurate capacity signal (admission is heartbeat/engine-reported), not a
  stale-assumption risk.

## Test plan

- [x] Engine: 49/49 lease+scheduler-loop tests (injected fake clock, no
      sleeps), including the headline regression — a slow but progressing
      decode survives far past 120s and finishes naturally (fails on the
      old engine); ~400-test CBv2 surface green; one pre-existing failure
      verified identical on base
- [x] Provider: `swift test` 1627/1627; byte-identical legacy JSON fixture;
      per-cause status mapping; mixed-version fallbacks
- [x] Coordinator: `go test ./...` all packages; `-race` clean on
      api/protocol/registry; classification table test drives the REAL
      Server+Registry funnels for all 8 causes + absent + unknown; legacy
      funnels regression-pinned; refund-preserved-with-usage test
- [x] `gofmt`/`go vet` clean; protocol symmetry Swift↔Go verified on both
      sides (exact raw values + omission semantics)
- [x] Adversarial review: PASS, no must-fix findings; its two minor items
      (load-cooldown gate tightened to legacy|fault, kill-switch comment
      corrected to behavior-compatible) are included in this diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/570"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787431890&installation_model_id=21733&pr_number=570&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F570&signature=ef99a5632d5fc2988199793d52dabddf123b4e5b8de853c852545d2ebb13bfd1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->