### PR TITLE
feat(cache): granular cache_init_failed attribution + report subsystem coverage

### DIFF
--- a/coordinator/api/exact_cache_metrics.go
+++ b/coordinator/api/exact_cache_metrics.go
@@ -189,6 +189,12 @@ func (s *Server) registerExactCacheGauges() {
 			return float64(s.Providers.ByReason[reason])
 		}), MetricLabel{"reason", reason})
 	}
+	for _, failure := range registry.PrefixCacheInitFailureDetails() {
+		failure := failure
+		s.metrics.RegisterGaugeLabels("exact_cache_eligibility_init_failure", gauge(func(s ExactCacheStatus) float64 {
+			return float64(s.Providers.ByInitFailure[failure])
+		}), MetricLabel{"failure", failure})
+	}
 	for _, backend := range registry.PrefixCacheStatusBackends() {
 		backend := backend
 		s.metrics.RegisterGaugeLabels("exact_cache_eligibility_backend", gauge(func(s ExactCacheStatus) float64 {
@@ -311,6 +317,10 @@ func (s *Server) emitExactCacheDDGauges() {
 	for _, reason := range registry.PrefixCacheStatusReasons() {
 		s.ddGauge("exact_cache.eligibility_reason", float64(status.Providers.ByReason[reason]),
 			[]string{"reason:" + reason})
+	}
+	for _, failure := range registry.PrefixCacheInitFailureDetails() {
+		s.ddGauge("exact_cache.eligibility_init_failure", float64(status.Providers.ByInitFailure[failure]),
+			[]string{"failure:" + failure})
 	}
 	for _, backend := range registry.PrefixCacheStatusBackends() {
 		s.ddGauge("exact_cache.eligibility_backend", float64(status.Providers.ByBackend[backend]),

--- a/coordinator/api/exact_cache_status_test.go
+++ b/coordinator/api/exact_cache_status_test.go
@@ -28,10 +28,16 @@ func TestExactCacheStatusIsAggregateAndPrivacySafe(t *testing.T) {
 	v1Statuses := []protocol.PrefixCacheModelStatus{{
 		ModelID: "private-model-v1", Backend: "paged", ReplayStrategy: "none",
 		State: "disabled", Reason: "paged_hybrid_unsupported",
+	}, {
+		ModelID: "private-model-v1-dynamic", Backend: "contiguous",
+		ReplayStrategy: "frozen_full", State: "error",
+		Reason: "cache_init_failed", InitFailure: "template_dynamic_date",
 	}}
 	reg.Register("private-provider-v1", nil, &protocol.RegisterMessage{
 		PrefixCacheProtocol: 1,
-		Models:              []protocol.ModelInfo{{ID: "private-model-v1"}},
+		Models: []protocol.ModelInfo{
+			{ID: "private-model-v1"}, {ID: "private-model-v1-dynamic"},
+		},
 		PrefixCacheStatuses: &v1Statuses,
 	})
 	v2Statuses := []protocol.PrefixCacheModelStatus{{
@@ -71,12 +77,24 @@ func TestExactCacheStatusIsAggregateAndPrivacySafe(t *testing.T) {
 		status.Providers.V2 != 1 || status.Providers.V2ReadyModels != 1 {
 		t.Fatalf("provider protocol status=%+v", status.Providers)
 	}
-	if status.Providers.LoadedModels != 2 ||
-		status.Providers.ReportedLoadedModels != 2 ||
-		status.Providers.ExcludedModels != 1 ||
+	if status.Providers.LoadedModels != 3 ||
+		status.Providers.ReportedLoadedModels != 3 ||
+		status.Providers.ExcludedModels != 2 ||
 		status.Providers.ByReason["paged_hybrid_unsupported"] != 1 ||
-		status.Providers.ByReplayStrategy["frozen_full"] != 1 {
+		status.Providers.ByReason["cache_init_failed"] != 1 ||
+		status.Providers.ByReplayStrategy["frozen_full"] != 2 {
 		t.Fatalf("provider eligibility status=%+v", status.Providers)
+	}
+	// The granular init-failure breakdown must ride the public JSON with the
+	// full zero-bucketed vocabulary, and the reported detail must count.
+	if status.Providers.ByInitFailure["template_dynamic_date"] != 1 {
+		t.Fatalf("init failure breakdown=%+v", status.Providers.ByInitFailure)
+	}
+	for _, detail := range registry.PrefixCacheInitFailureDetails() {
+		if _, ok := status.Providers.ByInitFailure[detail]; !ok {
+			t.Fatalf("init failure bucket %q missing: %+v",
+				detail, status.Providers.ByInitFailure)
+		}
 	}
 	if status.RoutingMode != registry.CacheRoutingOff {
 		t.Fatalf("routing mode=%q, want off", status.RoutingMode)
@@ -142,6 +160,8 @@ func TestExactCacheStatusIsAggregateAndPrivacySafe(t *testing.T) {
 		"exact_cache_eligibility_state{state=disabled}",
 		"exact_cache_eligibility_reason{reason=paged_hybrid_unsupported}",
 		"exact_cache_eligibility_reason{reason=scan_failed}",
+		"exact_cache_eligibility_init_failure{failure=template_dynamic_date}",
+		"exact_cache_eligibility_init_failure{failure=key_unavailable}",
 		"exact_cache_eligibility_backend{backend=contiguous}",
 		"exact_cache_eligibility_backend{backend=paged}",
 		"exact_cache_eligibility_strategy{strategy=frozen_full}",
@@ -173,6 +193,7 @@ func TestExactCacheStatusIsAggregateAndPrivacySafe(t *testing.T) {
 	for _, metric := range []string{
 		"exact_cache.eligibility_state",
 		"exact_cache.eligibility_reason",
+		"exact_cache.eligibility_init_failure",
 		"exact_cache.eligibility_backend",
 		"exact_cache.eligibility_strategy",
 		"exact_cache.holder_removed",

--- a/coordinator/protocol/messages.go
+++ b/coordinator/protocol/messages.go
@@ -165,6 +165,13 @@ type PrefixCacheModelStatus struct {
 	ReplayStrategy string `json:"replay_strategy"`
 	State          string `json:"state"`
 	Reason         string `json:"reason"`
+	// InitFailure is the optional granular sub-cause, populated by 0.7.14+
+	// providers only when Reason == "cache_init_failed". It is a detail
+	// field rather than a new Reason value so deployed coordinators (which
+	// drop unknown-reason entries entry-wise) keep seeing failing providers;
+	// omitted (empty) from older providers. Mirror of the Swift
+	// PrefixCacheInitFailureDetail enum.
+	InitFailure string `json:"init_failure,omitempty"`
 }
 
 // PrefixCacheDonationOutcomeCount is one cumulative, process-local counter

--- a/coordinator/protocol/prefix_cache_telemetry_test.go
+++ b/coordinator/protocol/prefix_cache_telemetry_test.go
@@ -63,3 +63,55 @@ func TestPrefixCacheTelemetryOptionalWireCompatibility(t *testing.T) {
 		t.Fatalf("authoritative empty snapshots were omitted: %s", empty)
 	}
 }
+
+// TestPrefixCacheInitFailureDetailWireSymmetry pins the "init_failure" JSON
+// key to the Swift PrefixCacheInitFailureDetail CodingKey. The detail is a
+// pure additive field: Swift omits it when nil (encodeIfPresent), Go mirrors
+// with omitempty, and a status without the key decodes to "" — so pre-0.7.14
+// providers and coordinators stay wire-compatible in both directions.
+func TestPrefixCacheInitFailureDetailWireSymmetry(t *testing.T) {
+	plain := []PrefixCacheModelStatus{{
+		ModelID: "model", Backend: "contiguous", ReplayStrategy: "direct",
+		State: "disabled", Reason: "weight_hash_unavailable",
+	}}
+	encodedPlain, err := json.Marshal(HeartbeatMessage{
+		Type: TypeHeartbeat, PrefixCacheStatuses: &plain,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(encodedPlain), "init_failure") {
+		t.Fatalf("empty detail leaked onto the wire: %s", encodedPlain)
+	}
+	var decodedPlain HeartbeatMessage
+	if err := json.Unmarshal(encodedPlain, &decodedPlain); err != nil {
+		t.Fatal(err)
+	}
+	if (*decodedPlain.PrefixCacheStatuses)[0].InitFailure != "" {
+		t.Fatalf("omitted detail decoded non-empty: %s", encodedPlain)
+	}
+
+	detailed := []PrefixCacheModelStatus{{
+		ModelID: "model", Backend: "contiguous", ReplayStrategy: "direct",
+		State: "error", Reason: "cache_init_failed",
+		InitFailure: "key_unavailable",
+	}}
+	encoded, err := json.Marshal(HeartbeatMessage{
+		Type: TypeHeartbeat, PrefixCacheStatuses: &detailed,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(encoded), `"init_failure":"key_unavailable"`) {
+		t.Fatalf("detail key drifted from the Swift mirror: %s", encoded)
+	}
+	var decoded HeartbeatMessage
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if decoded.PrefixCacheStatuses == nil ||
+		len(*decoded.PrefixCacheStatuses) != 1 ||
+		(*decoded.PrefixCacheStatuses)[0] != detailed[0] {
+		t.Fatalf("detailed status did not round-trip: %s", encoded)
+	}
+}

--- a/coordinator/registry/cache_eligibility.go
+++ b/coordinator/registry/cache_eligibility.go
@@ -38,12 +38,19 @@ var (
 	// prefixCacheInitFailureDetails is the granular sub-cause vocabulary for
 	// reason == "cache_init_failed" (optional `init_failure` wire field,
 	// 0.7.14+ providers). Mirror of the Swift PrefixCacheInitFailureDetail.
+	// The template_* values discriminate the prompt-contract path (the
+	// dominant production source): missing standalone chat_template.jinja vs
+	// strftime_now determinism exclusion vs render self-check failure;
+	// prompt_contract_unavailable remains the residual bucket.
 	prefixCacheInitFailureDetails = []string{
 		"key_unavailable",
 		"ephemeral_key_unavailable",
 		"block_contract_mismatch",
 		"epoch_unavailable",
 		"prompt_contract_unavailable",
+		"template_artifact_missing",
+		"template_dynamic_date",
+		"template_render_failed",
 		"epoch_lost",
 		"cache_closed",
 		"unknown",

--- a/coordinator/registry/cache_eligibility.go
+++ b/coordinator/registry/cache_eligibility.go
@@ -35,6 +35,19 @@ var (
 	prefixCacheReplayStrategies = []string{
 		"direct", "frozen_full", "tail_replay", "none", "unknown",
 	}
+	// prefixCacheInitFailureDetails is the granular sub-cause vocabulary for
+	// reason == "cache_init_failed" (optional `init_failure` wire field,
+	// 0.7.14+ providers). Mirror of the Swift PrefixCacheInitFailureDetail.
+	prefixCacheInitFailureDetails = []string{
+		"key_unavailable",
+		"ephemeral_key_unavailable",
+		"block_contract_mismatch",
+		"epoch_unavailable",
+		"prompt_contract_unavailable",
+		"epoch_lost",
+		"cache_closed",
+		"unknown",
+	}
 	prefixCacheDonationOutcomes = []string{
 		"donated",
 		"below_effective_token_floor",
@@ -57,6 +70,9 @@ func PrefixCacheStatusReasons() []string  { return append([]string(nil), prefixC
 func PrefixCacheStatusBackends() []string { return append([]string(nil), prefixCacheStatusBackends...) }
 func PrefixCacheReplayStrategies() []string {
 	return append([]string(nil), prefixCacheReplayStrategies...)
+}
+func PrefixCacheInitFailureDetails() []string {
+	return append([]string(nil), prefixCacheInitFailureDetails...)
 }
 func PrefixCacheDonationOutcomes() []string {
 	return append([]string(nil), prefixCacheDonationOutcomes...)
@@ -111,11 +127,30 @@ func sanitizePrefixCacheStatuses(
 			!validPrefixCacheStateReason(status.State, status.Reason) {
 			continue
 		}
+		status.InitFailure = sanitizePrefixCacheInitFailure(
+			status.Reason, status.InitFailure)
 		result[status.ModelID] = status
 		sanitized = append(sanitized, status)
 	}
 	*statuses = sanitized
 	return result, true
+}
+
+// sanitizePrefixCacheInitFailure normalizes the OPTIONAL granular detail to
+// the fixed vocabulary. It only ever strips the detail to "" — an unexpected
+// or misplaced detail NEVER drops the entry or the snapshot, because the
+// detail is diagnostic garnish while the (state, reason) tuple is the signal:
+//   - detail outside reason == "cache_init_failed" is stripped (misplaced);
+//   - an unknown future detail is stripped (forward compatibility);
+//   - the empty detail from pre-0.7.14 providers passes through unchanged.
+func sanitizePrefixCacheInitFailure(reason, detail string) string {
+	if detail == "" || reason != "cache_init_failed" {
+		return ""
+	}
+	if !containsFixed(prefixCacheInitFailureDetails, detail) {
+		return ""
+	}
+	return detail
 }
 
 func validPrefixCacheStateReason(state, reason string) bool {

--- a/coordinator/registry/cache_eligibility_test.go
+++ b/coordinator/registry/cache_eligibility_test.go
@@ -37,6 +37,11 @@ func TestPrefixCacheTelemetryEnumCasingIsPinned(t *testing.T) {
 			got:  PrefixCacheReplayStrategies(),
 			want: "direct,frozen_full,tail_replay,none,unknown",
 		},
+		"init failure details": {
+			got: PrefixCacheInitFailureDetails(),
+			want: "key_unavailable,ephemeral_key_unavailable,block_contract_mismatch," +
+				"epoch_unavailable,prompt_contract_unavailable,epoch_lost,cache_closed,unknown",
+		},
 		"donation outcomes": {
 			got: PrefixCacheDonationOutcomes(),
 			want: "donated,below_effective_token_floor,no_complete_block,lossy_snapshot," +
@@ -228,6 +233,129 @@ func TestPrefixCacheTelemetrySanitizesOptionalCompatibility(t *testing.T) {
 	if aggregate.ReportedLoadedModels != 1 ||
 		aggregate.ByReason["config_disabled"] != 1 {
 		t.Fatalf("known owner-local aggregate = %+v", aggregate)
+	}
+}
+
+func TestPrefixCacheInitFailureDetailSanitizationKeepsEntries(t *testing.T) {
+	// The granular detail is diagnostic-only: it is normalized (possibly to
+	// "") but NEVER costs the entry or the snapshot, in either direction of
+	// version skew.
+	for name, test := range map[string]struct {
+		status protocol.PrefixCacheModelStatus
+		want   string
+	}{
+		"valid detail preserved": {
+			status: protocol.PrefixCacheModelStatus{
+				ModelID: "model", Backend: "contiguous", ReplayStrategy: "none",
+				State: "error", Reason: "cache_init_failed",
+				InitFailure: "key_unavailable",
+			},
+			want: "key_unavailable",
+		},
+		"unknown future detail stripped entry kept": {
+			status: protocol.PrefixCacheModelStatus{
+				ModelID: "model", Backend: "contiguous", ReplayStrategy: "none",
+				State: "error", Reason: "cache_init_failed",
+				InitFailure: "future_detail",
+			},
+			want: "",
+		},
+		"detail under mismatched reason stripped entry kept": {
+			status: protocol.PrefixCacheModelStatus{
+				ModelID: "model", Backend: "contiguous", ReplayStrategy: "none",
+				State: "disabled", Reason: "config_disabled",
+				InitFailure: "key_unavailable",
+			},
+			want: "",
+		},
+		"old provider empty detail preserved": {
+			status: protocol.PrefixCacheModelStatus{
+				ModelID: "model", Backend: "contiguous", ReplayStrategy: "none",
+				State: "error", Reason: "cache_init_failed",
+			},
+			want: "",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			statuses := []protocol.PrefixCacheModelStatus{test.status}
+			msg := protocol.RegisterMessage{
+				Models:              []protocol.ModelInfo{{ID: "model"}},
+				PrefixCacheStatuses: &statuses,
+			}
+			reg := cacheEligibilityTestRegistry()
+			if err := reg.ValidatePrefixCacheRegistration(&msg); err != nil {
+				t.Fatalf("optional detail closed registration: %v", err)
+			}
+			if msg.PrefixCacheStatuses == nil || len(*msg.PrefixCacheStatuses) != 1 {
+				t.Fatalf("detail sanitization dropped the entry: %+v", msg.PrefixCacheStatuses)
+			}
+			got := (*msg.PrefixCacheStatuses)[0]
+			if got.InitFailure != test.want {
+				t.Fatalf("init failure=%q, want %q", got.InitFailure, test.want)
+			}
+			if got.State != test.status.State || got.Reason != test.status.Reason {
+				t.Fatalf("state/reason changed by detail sanitization: %+v", got)
+			}
+		})
+	}
+}
+
+func TestPrefixCacheInitFailureAggregationBreakdown(t *testing.T) {
+	reg := cacheEligibilityTestRegistry()
+	statuses := []protocol.PrefixCacheModelStatus{
+		{
+			ModelID: "key-lost", Backend: "contiguous", ReplayStrategy: "none",
+			State: "error", Reason: "cache_init_failed",
+			InitFailure: "key_unavailable",
+		},
+		{
+			ModelID: "epoch-lost", Backend: "paged", ReplayStrategy: "none",
+			State: "error", Reason: "cache_init_failed",
+			InitFailure: "epoch_lost",
+		},
+		{
+			ModelID: "old-provider", Backend: "contiguous", ReplayStrategy: "none",
+			State: "error", Reason: "cache_init_failed",
+		},
+		{
+			ModelID: "healthy", Backend: "contiguous", ReplayStrategy: "unknown",
+			State: "pending", Reason: "scan_pending",
+		},
+	}
+	msg := protocol.RegisterMessage{
+		Models: []protocol.ModelInfo{
+			{ID: "key-lost"}, {ID: "epoch-lost"}, {ID: "old-provider"}, {ID: "healthy"},
+		},
+		PrefixCacheStatuses: &statuses,
+	}
+	if err := reg.ValidatePrefixCacheRegistration(&msg); err != nil {
+		t.Fatal(err)
+	}
+	if reg.Register("provider", nil, &msg) == nil {
+		t.Fatal("provider did not register")
+	}
+
+	aggregate := reg.PrefixCacheProtocolStatus()
+	// The plain reason total keeps its meaning: detail-less entries from old
+	// providers still count, so the detail buckets sum to at most the total.
+	if aggregate.ByReason["cache_init_failed"] != 3 {
+		t.Fatalf("cache_init_failed total=%d, want 3", aggregate.ByReason["cache_init_failed"])
+	}
+	if aggregate.ByInitFailure["key_unavailable"] != 1 ||
+		aggregate.ByInitFailure["epoch_lost"] != 1 {
+		t.Fatalf("detail breakdown=%+v", aggregate.ByInitFailure)
+	}
+	detailTotal := 0
+	for _, count := range aggregate.ByInitFailure {
+		detailTotal += count
+	}
+	if detailTotal != 2 {
+		t.Fatalf("detail bucket sum=%d, want 2 (old provider has no detail)", detailTotal)
+	}
+	for _, detail := range PrefixCacheInitFailureDetails() {
+		if _, ok := aggregate.ByInitFailure[detail]; !ok {
+			t.Fatalf("missing zero bucket for %q: %+v", detail, aggregate.ByInitFailure)
+		}
 	}
 }
 

--- a/coordinator/registry/cache_eligibility_test.go
+++ b/coordinator/registry/cache_eligibility_test.go
@@ -40,7 +40,8 @@ func TestPrefixCacheTelemetryEnumCasingIsPinned(t *testing.T) {
 		"init failure details": {
 			got: PrefixCacheInitFailureDetails(),
 			want: "key_unavailable,ephemeral_key_unavailable,block_contract_mismatch," +
-				"epoch_unavailable,prompt_contract_unavailable,epoch_lost,cache_closed,unknown",
+				"epoch_unavailable,prompt_contract_unavailable,template_artifact_missing," +
+				"template_dynamic_date,template_render_failed,epoch_lost,cache_closed,unknown",
 		},
 		"donation outcomes": {
 			got: PrefixCacheDonationOutcomes(),
@@ -252,6 +253,14 @@ func TestPrefixCacheInitFailureDetailSanitizationKeepsEntries(t *testing.T) {
 			},
 			want: "key_unavailable",
 		},
+		"discriminated template detail preserved": {
+			status: protocol.PrefixCacheModelStatus{
+				ModelID: "model", Backend: "contiguous", ReplayStrategy: "none",
+				State: "error", Reason: "cache_init_failed",
+				InitFailure: "template_artifact_missing",
+			},
+			want: "template_artifact_missing",
+		},
 		"unknown future detail stripped entry kept": {
 			status: protocol.PrefixCacheModelStatus{
 				ModelID: "model", Backend: "contiguous", ReplayStrategy: "none",
@@ -318,13 +327,19 @@ func TestPrefixCacheInitFailureAggregationBreakdown(t *testing.T) {
 			State: "error", Reason: "cache_init_failed",
 		},
 		{
+			ModelID: "gpt-oss-dynamic", Backend: "contiguous", ReplayStrategy: "none",
+			State: "error", Reason: "cache_init_failed",
+			InitFailure: "template_dynamic_date",
+		},
+		{
 			ModelID: "healthy", Backend: "contiguous", ReplayStrategy: "unknown",
 			State: "pending", Reason: "scan_pending",
 		},
 	}
 	msg := protocol.RegisterMessage{
 		Models: []protocol.ModelInfo{
-			{ID: "key-lost"}, {ID: "epoch-lost"}, {ID: "old-provider"}, {ID: "healthy"},
+			{ID: "key-lost"}, {ID: "epoch-lost"}, {ID: "old-provider"},
+			{ID: "gpt-oss-dynamic"}, {ID: "healthy"},
 		},
 		PrefixCacheStatuses: &statuses,
 	}
@@ -338,19 +353,20 @@ func TestPrefixCacheInitFailureAggregationBreakdown(t *testing.T) {
 	aggregate := reg.PrefixCacheProtocolStatus()
 	// The plain reason total keeps its meaning: detail-less entries from old
 	// providers still count, so the detail buckets sum to at most the total.
-	if aggregate.ByReason["cache_init_failed"] != 3 {
-		t.Fatalf("cache_init_failed total=%d, want 3", aggregate.ByReason["cache_init_failed"])
+	if aggregate.ByReason["cache_init_failed"] != 4 {
+		t.Fatalf("cache_init_failed total=%d, want 4", aggregate.ByReason["cache_init_failed"])
 	}
 	if aggregate.ByInitFailure["key_unavailable"] != 1 ||
-		aggregate.ByInitFailure["epoch_lost"] != 1 {
+		aggregate.ByInitFailure["epoch_lost"] != 1 ||
+		aggregate.ByInitFailure["template_dynamic_date"] != 1 {
 		t.Fatalf("detail breakdown=%+v", aggregate.ByInitFailure)
 	}
 	detailTotal := 0
 	for _, count := range aggregate.ByInitFailure {
 		detailTotal += count
 	}
-	if detailTotal != 2 {
-		t.Fatalf("detail bucket sum=%d, want 2 (old provider has no detail)", detailTotal)
+	if detailTotal != 3 {
+		t.Fatalf("detail bucket sum=%d, want 3 (old provider has no detail)", detailTotal)
 	}
 	for _, detail := range PrefixCacheInitFailureDetails() {
 		if _, ok := aggregate.ByInitFailure[detail]; !ok {

--- a/coordinator/registry/cache_status.go
+++ b/coordinator/registry/cache_status.go
@@ -2,7 +2,10 @@ package registry
 
 // PrefixCacheProtocolStatus is an aggregate, identity-free view of connected
 // provider cache capability. V2ReadyModels counts advertised ready
-// provider/model pairs, not unique models.
+// provider/model pairs, not unique models. ByInitFailure breaks the
+// ByReason["cache_init_failed"] total down by the optional granular detail;
+// entries from providers that do not report a detail count toward the reason
+// total only, so the detail buckets sum to AT MOST the reason total.
 type PrefixCacheProtocolStatus struct {
 	V0                     int            `json:"v0"`
 	V1                     int            `json:"v1"`
@@ -16,6 +19,7 @@ type PrefixCacheProtocolStatus struct {
 	ByReason               map[string]int `json:"by_reason"`
 	ByBackend              map[string]int `json:"by_backend"`
 	ByReplayStrategy       map[string]int `json:"by_replay_strategy"`
+	ByInitFailure          map[string]int `json:"by_init_failure"`
 }
 
 func (r *Registry) PrefixCacheProtocolStatus() PrefixCacheProtocolStatus {
@@ -24,6 +28,7 @@ func (r *Registry) PrefixCacheProtocolStatus() PrefixCacheProtocolStatus {
 		ByReason:         zeroIntBuckets(prefixCacheStatusReasons),
 		ByBackend:        zeroIntBuckets(prefixCacheStatusBackends),
 		ByReplayStrategy: zeroIntBuckets(prefixCacheReplayStrategies),
+		ByInitFailure:    zeroIntBuckets(prefixCacheInitFailureDetails),
 	}
 	if r == nil {
 		return status
@@ -52,6 +57,10 @@ func (r *Registry) PrefixCacheProtocolStatus() PrefixCacheProtocolStatus {
 			status.ByReason[modelStatus.Reason]++
 			status.ByBackend[modelStatus.Backend]++
 			status.ByReplayStrategy[modelStatus.ReplayStrategy]++
+			if modelStatus.Reason == "cache_init_failed" &&
+				modelStatus.InitFailure != "" {
+				status.ByInitFailure[modelStatus.InitFailure]++
+			}
 			if modelStatus.State != "ready" {
 				status.ExcludedModels++
 			}

--- a/provider-swift/Package.swift
+++ b/provider-swift/Package.swift
@@ -262,11 +262,12 @@ let package = Package(
         // target's pure helpers. The CLI's command types live in the
         // executable target (which uses `@main`, so it is importable via
         // `@testable import darkbloom`). Currently covers the `log` argv
-        // builders in LogsCommand.
+        // builders in LogsCommand and the report/logs subsystem coverage
+        // drift test (ProviderCore's ProviderLogSubsystems).
         // ----------------------------------------------------------------
         .testTarget(
             name: "DarkbloomCLITests",
-            dependencies: ["darkbloom"],
+            dependencies: ["darkbloom", "ProviderCore"],
             path: "Tests/DarkbloomCLITests"
         ),
 

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2SlotFactory.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2SlotFactory.swift
@@ -308,7 +308,8 @@ enum EngineV2SlotFactory {
                             ssdLayerKinds, prefixReuseCapability)
                         cacheConstructionStatus = ssdPrefixCache == nil
                             ? PrefixCacheConstructionStatus(
-                                state: .error, reason: .cacheInitFailed)
+                                state: .error, reason: .cacheInitFailed,
+                                detail: .unknown)
                             : .scanPending
                     } else {
                         ssdPrefixCache = await SSDPrefixCacheFactory.make(
@@ -331,12 +332,14 @@ enum EngineV2SlotFactory {
                         cacheConstructionStatus = ssdPrefixCache == nil
                             ? (cacheConstructionStatusBox.snapshot
                                 ?? PrefixCacheConstructionStatus(
-                                    state: .error, reason: .cacheInitFailed))
+                                    state: .error, reason: .cacheInitFailed,
+                                    detail: .unknown))
                             : .scanPending
                     }
                 } else {
                     cacheConstructionStatus = PrefixCacheConstructionStatus(
-                        state: .error, reason: .cacheInitFailed)
+                        state: .error, reason: .cacheInitFailed,
+                        detail: .promptContractUnavailable)
                     Self.emitPrefixCacheConstructionFailure(
                         modelId: modelId,
                         capability: prefixReuseCapability,
@@ -375,7 +378,8 @@ enum EngineV2SlotFactory {
             backend: cacheBackend,
             replayStrategy: PrefixCacheReplayStrategy(cacheCapability),
             state: cacheConstructionStatus.state,
-            reason: cacheConstructionStatus.reason)
+            reason: cacheConstructionStatus.reason,
+            initFailure: cacheConstructionStatus.detail)
         let enginePrefixCache: (any CBv2PrefixCache)? = ssdPrefixCache
 
         let makeEngine: () throws -> EngineV2Factory.ProductionBuild

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2SlotFactory.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2SlotFactory.swift
@@ -240,11 +240,23 @@ enum EngineV2SlotFactory {
 
         // SSD offload never carves the live KV grant.
         let engineKVBytesCapacity = kvBytesCapacity
-        let promptContractID =
-            assemblyOverrides.promptContractID
-            ?? modelDirectory.flatMap {
-                try? PromptContractIdentity.compute(modelDirectory: $0)
+        // Discriminated no-contract cause for eligibility telemetry; only
+        // reported on the promptContractID-nil branch below.
+        var promptContractFailure = SSDPrefixCacheConstructionFailure.promptContractUnavailable
+        let promptContractID: String?
+        if let overridden = assemblyOverrides.promptContractID {
+            promptContractID = overridden
+        } else if let modelDirectory {
+            do {
+                promptContractID = try PromptContractIdentity.compute(
+                    modelDirectory: modelDirectory)
+            } catch {
+                promptContractID = nil
+                promptContractFailure = Self.promptContractConstructionFailure(error)
             }
+        } else {
+            promptContractID = nil
+        }
         let preparedBackend: EngineV2Factory.ProductionBackendPreparation?
         if makeEngineOverride == nil {
             do {
@@ -337,17 +349,18 @@ enum EngineV2SlotFactory {
                             : .scanPending
                     }
                 } else {
-                    cacheConstructionStatus = PrefixCacheConstructionStatus(
-                        state: .error, reason: .cacheInitFailed,
-                        detail: .promptContractUnavailable)
+                    cacheConstructionStatus = PrefixCacheConstructionStatusBox.status(
+                        failure: promptContractFailure,
+                        capability: prefixReuseCapability)
                     Self.emitPrefixCacheConstructionFailure(
                         modelId: modelId,
                         capability: prefixReuseCapability,
-                        failure: .promptContractUnavailable,
+                        failure: promptContractFailure,
                         emitTelemetry: emitTelemetry)
                     logWarning(
                         "engine_v2: SSD prefix cache skipped for \(modelId) — "
-                            + "prompt contract could not be computed from local artifacts")
+                            + "prompt contract unavailable "
+                            + "(\(promptContractFailure.rawValue))")
                 }
             } else {
                 let unavailableCapability = PrefixCachePolicy.prefixReuseCapability(
@@ -471,6 +484,24 @@ enum EngineV2SlotFactory {
             assistantBytes: mtpStatus.assistantBytes,
             mtpArtifact: prepared.mtpArtifact,
             mtpStatus: mtpStatus)
+    }
+
+    /// Map a discriminated PromptContractIdentity failure to its
+    /// construction-failure case; anything unexpected stays in the residual
+    /// prompt_contract_unavailable bucket.
+    static func promptContractConstructionFailure(
+        _ error: Swift.Error
+    ) -> SSDPrefixCacheConstructionFailure {
+        switch error as? PromptContractIdentity.Error {
+        case .templateArtifactMissing:
+            return .templateArtifactMissing
+        case .templateDynamicDate:
+            return .templateDynamicDate
+        case .templateRenderFailed:
+            return .templateRenderFailed
+        case .invalidArtifact, nil:
+            return .promptContractUnavailable
+        }
     }
 
     private static func emitPrefixCacheConstructionFailure(

--- a/provider-swift/Sources/ProviderCore/Inference/PrefixCacheEligibilityStatus.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/PrefixCacheEligibilityStatus.swift
@@ -4,6 +4,18 @@ import MLXLMCommon
 struct PrefixCacheConstructionStatus: Sendable {
     let state: PrefixCacheStatusState
     let reason: PrefixCacheStatusReason
+    /// Granular sub-cause; non-nil only when `reason == .cacheInitFailed`.
+    let detail: PrefixCacheInitFailureDetail?
+
+    init(
+        state: PrefixCacheStatusState,
+        reason: PrefixCacheStatusReason,
+        detail: PrefixCacheInitFailureDetail? = nil
+    ) {
+        self.state = state
+        self.reason = reason
+        self.detail = detail
+    }
 
     static let configDisabled = PrefixCacheConstructionStatus(
         state: .disabled, reason: .configDisabled)
@@ -50,10 +62,21 @@ final class PrefixCacheConstructionStatusBox: @unchecked Sendable {
         case .unsafePath:
             return PrefixCacheConstructionStatus(
                 state: .error, reason: .diskUnavailable)
-        case .keyUnavailable, .ephemeralKeyUnavailable, .blockContractMismatch,
-            .epochUnavailable, .promptContractUnavailable:
+        case .keyUnavailable:
             return PrefixCacheConstructionStatus(
-                state: .error, reason: .cacheInitFailed)
+                state: .error, reason: .cacheInitFailed, detail: .keyUnavailable)
+        case .ephemeralKeyUnavailable:
+            return PrefixCacheConstructionStatus(
+                state: .error, reason: .cacheInitFailed, detail: .ephemeralKeyUnavailable)
+        case .blockContractMismatch:
+            return PrefixCacheConstructionStatus(
+                state: .error, reason: .cacheInitFailed, detail: .blockContractMismatch)
+        case .epochUnavailable:
+            return PrefixCacheConstructionStatus(
+                state: .error, reason: .cacheInitFailed, detail: .epochUnavailable)
+        case .promptContractUnavailable:
+            return PrefixCacheConstructionStatus(
+                state: .error, reason: .cacheInitFailed, detail: .promptContractUnavailable)
         }
     }
 }

--- a/provider-swift/Sources/ProviderCore/Inference/PrefixCacheEligibilityStatus.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/PrefixCacheEligibilityStatus.swift
@@ -40,7 +40,9 @@ final class PrefixCacheConstructionStatusBox: @unchecked Sendable {
         lock.withLock { value }
     }
 
-    private static func status(
+    /// Single source of the failure → (state, reason, detail) mapping —
+    /// also used directly by the slot factory's no-prompt-contract path.
+    static func status(
         failure: SSDPrefixCacheConstructionFailure,
         capability: CBv2PrefixReuseCapability
     ) -> PrefixCacheConstructionStatus {
@@ -74,6 +76,15 @@ final class PrefixCacheConstructionStatusBox: @unchecked Sendable {
         case .epochUnavailable:
             return PrefixCacheConstructionStatus(
                 state: .error, reason: .cacheInitFailed, detail: .epochUnavailable)
+        case .templateArtifactMissing:
+            return PrefixCacheConstructionStatus(
+                state: .error, reason: .cacheInitFailed, detail: .templateArtifactMissing)
+        case .templateDynamicDate:
+            return PrefixCacheConstructionStatus(
+                state: .error, reason: .cacheInitFailed, detail: .templateDynamicDate)
+        case .templateRenderFailed:
+            return PrefixCacheConstructionStatus(
+                state: .error, reason: .cacheInitFailed, detail: .templateRenderFailed)
         case .promptContractUnavailable:
             return PrefixCacheConstructionStatus(
                 state: .error, reason: .cacheInitFailed, detail: .promptContractUnavailable)

--- a/provider-swift/Sources/ProviderCore/KVCacheSSD/EngineV2Bridge+SSDPrefixCache.swift
+++ b/provider-swift/Sources/ProviderCore/KVCacheSSD/EngineV2Bridge+SSDPrefixCache.swift
@@ -39,15 +39,18 @@ extension EngineV2Bridge {
         }
     }
 
-    /// One info line per interval — the `tier=ssd` sibling of the
-    /// `engine=v2` RAM-cache line in `darkbloom logs`.
+    /// One line per interval — the `tier=ssd` sibling of the `engine=v2`
+    /// RAM-cache line in `darkbloom logs`. Logged at .notice so it persists
+    /// to disk for `darkbloom report` (info is memory-ring-buffer only);
+    /// the default cadence is one line per 120s per slot, so persistence
+    /// cost stays negligible.
     static func logSSDPrefixCacheStats(cache: SSDPrefixCache, modelId: String) {
         let s = cache.stats()
         let lookups = s.hits + s.misses
         let rate = lookups > 0 ? (Double(s.hits) * 100.0 / Double(lookups)) : 0.0
         #if canImport(os)
         let rateStr = String(format: "%.1f", rate)
-        Self.ssdStatsLogger.info(
+        Self.ssdStatsLogger.notice(
             "prefix cache stats (engine=v2, tier=ssd, model=\(modelId, privacy: .public)): lookups=\(lookups) hits=\(s.hits) misses=\(s.misses) hitRate=\(rateStr, privacy: .public)% tokensSaved=\(s.tokensSaved) stages=\(s.stages) stagedBytes=\(s.stagedBytesInUse) blocksWritten=\(s.blocksWritten) bytesWritten=\(s.bytesWritten) donationsDropped=\(s.donationsDropped) rateLimited=\(s.writeRateLimited) corruptDropped=\(s.corruptDropped) evictions=\(s.evictions) ttlExpired=\(s.ttlExpired) entries=\(s.entries) bytesOnDisk=\(s.bytesOnDisk)"
         )
         #endif

--- a/provider-swift/Sources/ProviderCore/KVCacheSSD/SSDPrefixCache.swift
+++ b/provider-swift/Sources/ProviderCore/KVCacheSSD/SSDPrefixCache.swift
@@ -222,6 +222,9 @@ public final class SSDPrefixCache: CBv2PrefixCache, SSDEvictableStore, @unchecke
     private var scanReady = false
     private var scanFailed = false
     private var cacheStatusFailure: PrefixCacheStatusReason?
+    /// Granular companion to `cacheStatusFailure`; set together with it and
+    /// reported as `init_failure` only when the reason is `.cacheInitFailed`.
+    private var cacheStatusFailureDetail: PrefixCacheInitFailureDetail?
     private var destructiveChangeInProgress = false
     /// tag16 of the run's TERMINAL block → staged entry.
     private var stagedEntries: [Data: StagedEntry] = [:]
@@ -369,26 +372,31 @@ public final class SSDPrefixCache: CBv2PrefixCache, SSDEvictableStore, @unchecke
     private func prefixCacheModelStatusLocked(
         base: PrefixCacheModelStatus
     ) -> PrefixCacheModelStatus {
-        let status: (PrefixCacheStatusState, PrefixCacheStatusReason)
+        let status:
+            (PrefixCacheStatusState, PrefixCacheStatusReason, PrefixCacheInitFailureDetail?)
         if closed {
-            status = (.error, .cacheInitFailed)
+            status = (.error, .cacheInitFailed, .cacheClosed)
         } else if scanFailed {
-            status = (.error, .scanFailed)
+            status = (.error, .scanFailed, nil)
         } else if let cacheStatusFailure {
-            status = (.error, cacheStatusFailure)
+            status = (
+                .error, cacheStatusFailure,
+                cacheStatusFailure == .cacheInitFailed ? cacheStatusFailureDetail : nil
+            )
         } else if !scanReady || destructiveChangeInProgress {
-            status = (.pending, .scanPending)
+            status = (.pending, .scanPending, nil)
         } else if config.epochStore != nil && config.epochStore?.current == nil {
-            status = (.error, .cacheInitFailed)
+            status = (.error, .cacheInitFailed, .epochLost)
         } else {
-            status = (.ready, .ready)
+            status = (.ready, .ready, nil)
         }
         return PrefixCacheModelStatus(
             modelId: base.modelId,
             backend: base.backend,
             replayStrategy: base.replayStrategy,
             state: status.0,
-            reason: status.1)
+            reason: status.1,
+            initFailure: status.2)
     }
 
     func takeNextPrefixCacheV2Sequence(expectedEpoch: String) -> UInt64? {
@@ -408,6 +416,7 @@ public final class SSDPrefixCache: CBv2PrefixCache, SSDEvictableStore, @unchecke
             scanReady = false
             scanFailed = false
             cacheStatusFailure = nil
+            cacheStatusFailureDetail = nil
             // Release the PER-ENTRY reservations (each resident entry holds
             // exactly one, keyed by its creator). Attaching requests already
             // released their redundant provisional reservation at attach
@@ -1653,6 +1662,8 @@ public final class SSDPrefixCache: CBv2PrefixCache, SSDEvictableStore, @unchecke
             lock.withLock {
                 scanReady = false
                 cacheStatusFailure = .cacheInitFailed
+                // A failed epoch persist orphans the durable generation.
+                cacheStatusFailureDetail = .epochLost
             }
             return nil
         }

--- a/provider-swift/Sources/ProviderCore/KVCacheSSD/SSDPrefixCache.swift
+++ b/provider-swift/Sources/ProviderCore/KVCacheSSD/SSDPrefixCache.swift
@@ -1617,7 +1617,9 @@ public final class SSDPrefixCache: CBv2PrefixCache, SSDEvictableStore, @unchecke
             }
         }
         #if canImport(os)
-        Self.logger.info(
+        // .notice: once-per-load lifecycle summary that must persist for
+        // `darkbloom report` (info stays in the memory ring buffer).
+        Self.logger.notice(
             "ssd prefix cache (\(self.config.modelId, privacy: .public)): startup scan indexed \(indexed) blocks (\(self.index.totalBytes) B), dropped \(dropped) stale, \(expired) expired")
         #endif
     }

--- a/provider-swift/Sources/ProviderCore/KVCacheSSD/SSDPrefixCacheFactory.swift
+++ b/provider-swift/Sources/ProviderCore/KVCacheSSD/SSDPrefixCacheFactory.swift
@@ -137,7 +137,10 @@ enum SSDPrefixCacheFactory {
         guard prefixReuseCapability.isSupported else {
             onConstructionFailure?(.unsupportedPlan)
             #if canImport(os)
-            logger.info(
+            // .notice (not .info): info lines live in the memory ring buffer
+            // only and rarely survive to the `log show --last 24h` that
+            // `darkbloom report` runs — lifecycle lines must persist to disk.
+            logger.notice(
                 "ssd prefix cache disabled for \(modelId, privacy: .public): prefix reuse unsupported (\(prefixReuseCapability.unsupportedReason?.rawValue ?? "unknown", privacy: .public), backend=\(prefixReuseCapability.backend.rawValue, privacy: .public))")
             #endif
             return nil
@@ -290,7 +293,7 @@ enum SSDPrefixCacheFactory {
         cache.startBackgroundTasks()
         startWholeRootMaintenance(environment: environment)
         #if canImport(os)
-        logger.info(
+        logger.notice(
             "ssd prefix cache active for \(modelId, privacy: .public) at \(dir.path, privacy: .public): strategy \(prefixReuseCapability.strategy?.rawValue ?? "none", privacy: .public), backend \(prefixReuseCapability.backend.rawValue, privacy: .public), ttl \(config.ttlSeconds)s sliding, box-wide disk budget \(PrefixCachePolicy.ssdDiskBudgetBytes(environment: environment, freeBytes: PrefixCachePolicy.volumeFreeBytes(at: dir))) B, replay bound \(config.adoptionBoundTokens) tok — HMAC-keyed names (T-041 leak #2 closed), no memory carve")
         #endif
         return cache

--- a/provider-swift/Sources/ProviderCore/KVCacheSSD/SSDPrefixCacheFactory.swift
+++ b/provider-swift/Sources/ProviderCore/KVCacheSSD/SSDPrefixCacheFactory.swift
@@ -27,6 +27,12 @@ enum SSDPrefixCacheConstructionFailure: String, Sendable {
     case ephemeralKeyUnavailable = "ephemeral_key_unavailable"
     case blockContractMismatch = "block_contract_mismatch"
     case epochUnavailable = "epoch_unavailable"
+    // Discriminated prompt-contract sub-causes (the dominant production
+    // cache_init_failed source): manifest gap vs design exclusion vs render
+    // bug. promptContractUnavailable remains the residual bucket.
+    case templateArtifactMissing = "template_artifact_missing"
+    case templateDynamicDate = "template_dynamic_date"
+    case templateRenderFailed = "template_render_failed"
     case promptContractUnavailable = "prompt_contract_unavailable"
     case layoutUnavailable = "layout_unavailable"
 }

--- a/provider-swift/Sources/ProviderCore/Protocol/Messages.swift
+++ b/provider-swift/Sources/ProviderCore/Protocol/Messages.swift
@@ -46,6 +46,11 @@ public enum PrefixCacheInitFailureDetail: String, Codable, Sendable, Equatable, 
     case blockContractMismatch = "block_contract_mismatch"
     case epochUnavailable = "epoch_unavailable"
     case promptContractUnavailable = "prompt_contract_unavailable"
+    // Discriminated prompt-contract sub-causes (0.7.14+): manifest gap vs
+    // deliberate determinism exclusion vs render self-check failure.
+    case templateArtifactMissing = "template_artifact_missing"
+    case templateDynamicDate = "template_dynamic_date"
+    case templateRenderFailed = "template_render_failed"
     case epochLost = "epoch_lost"
     case cacheClosed = "cache_closed"
     case unknown

--- a/provider-swift/Sources/ProviderCore/Protocol/Messages.swift
+++ b/provider-swift/Sources/ProviderCore/Protocol/Messages.swift
@@ -35,25 +35,47 @@ public enum PrefixCacheStatusReason: String, Codable, Sendable, Equatable, CaseI
     case cacheInitFailed = "cache_init_failed"
 }
 
+/// Granular sub-cause carried ONLY alongside `reason == .cacheInitFailed`.
+/// A separate optional detail — never a new `PrefixCacheStatusReason` value —
+/// because already-deployed coordinators drop status entries with unknown
+/// reasons entry-wise; a new reason enum would make failing providers
+/// invisible to them, while an unknown extra key is simply ignored.
+public enum PrefixCacheInitFailureDetail: String, Codable, Sendable, Equatable, CaseIterable {
+    case keyUnavailable = "key_unavailable"
+    case ephemeralKeyUnavailable = "ephemeral_key_unavailable"
+    case blockContractMismatch = "block_contract_mismatch"
+    case epochUnavailable = "epoch_unavailable"
+    case promptContractUnavailable = "prompt_contract_unavailable"
+    case epochLost = "epoch_lost"
+    case cacheClosed = "cache_closed"
+    case unknown
+}
+
 public struct PrefixCacheModelStatus: Codable, Sendable, Equatable {
     public let modelId: String
     public let backend: PrefixCacheStatusBackend
     public let replayStrategy: PrefixCacheReplayStrategy
     public let state: PrefixCacheStatusState
     public let reason: PrefixCacheStatusReason
+    /// Optional granular detail; populated only when `reason == .cacheInitFailed`.
+    /// Synthesized Codable uses encodeIfPresent/decodeIfPresent for optionals,
+    /// so nil omits the `init_failure` key entirely (old-coordinator safe).
+    public let initFailure: PrefixCacheInitFailureDetail?
 
     public init(
         modelId: String,
         backend: PrefixCacheStatusBackend,
         replayStrategy: PrefixCacheReplayStrategy,
         state: PrefixCacheStatusState,
-        reason: PrefixCacheStatusReason
+        reason: PrefixCacheStatusReason,
+        initFailure: PrefixCacheInitFailureDetail? = nil
     ) {
         self.modelId = modelId
         self.backend = backend
         self.replayStrategy = replayStrategy
         self.state = state
         self.reason = reason
+        self.initFailure = initFailure
     }
 
     enum CodingKeys: String, CodingKey {
@@ -62,6 +84,7 @@ public struct PrefixCacheModelStatus: Codable, Sendable, Equatable {
         case replayStrategy = "replay_strategy"
         case state
         case reason
+        case initFailure = "init_failure"
     }
 }
 

--- a/provider-swift/Sources/ProviderCore/Protocol/Messages.swift
+++ b/provider-swift/Sources/ProviderCore/Protocol/Messages.swift
@@ -91,6 +91,22 @@ public struct PrefixCacheModelStatus: Codable, Sendable, Equatable {
         case reason
         case initFailure = "init_failure"
     }
+
+    /// Custom decode ONLY to make the optional detail forward-tolerant: an
+    /// unknown future `init_failure` string decodes to nil instead of
+    /// rejecting the whole message (the detail is diagnostic garnish; the
+    /// (state, reason) tuple is the signal). Encoding stays synthesized.
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        modelId = try container.decode(String.self, forKey: .modelId)
+        backend = try container.decode(PrefixCacheStatusBackend.self, forKey: .backend)
+        replayStrategy = try container.decode(
+            PrefixCacheReplayStrategy.self, forKey: .replayStrategy)
+        state = try container.decode(PrefixCacheStatusState.self, forKey: .state)
+        reason = try container.decode(PrefixCacheStatusReason.self, forKey: .reason)
+        initFailure = (try container.decodeIfPresent(String.self, forKey: .initFailure))
+            .flatMap(PrefixCacheInitFailureDetail.init(rawValue:))
+    }
 }
 
 public enum PrefixCacheDonationOutcome: String, Codable, Sendable, Equatable, CaseIterable {

--- a/provider-swift/Sources/ProviderCore/ProviderLogSubsystems.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLogSubsystems.swift
@@ -1,0 +1,38 @@
+// Copyright © 2026 Eigen Labs.
+//
+// The single source of truth for every unified-logging subsystem the
+// provider stack writes to. `darkbloom report` and `darkbloom logs` build
+// their `/usr/bin/log` predicates from THIS list — a collector predicate
+// naming only one subsystem silently loses every other component's lines
+// (the v0.7.13 incident: reports carried zero KVCacheSSD/engine-bridge
+// output). A drift test scans Sources for `subsystem:` literals and fails
+// if a new subsystem is not registered here.
+
+import Foundation
+
+public enum ProviderLogSubsystems {
+    /// Every subsystem any provider-stack component logs to:
+    /// - `dev.darkbloom.provider`: ProviderLoop, CoordinatorClient,
+    ///   Security, Telemetry, legacy KVCache.
+    /// - `com.darkbloom.provider`: all of KVCacheSSD (factory, cache, block
+    ///   store, write-behind) and the EngineV2 bridge/logprobs.
+    /// - `io.darkbloom.provider`: the CLI's fan-activity lease.
+    /// - `io.darkbloom.fan`: the DarkbloomFanHelper daemon.
+    public static let all: [String] = [
+        "dev.darkbloom.provider",
+        "com.darkbloom.provider",
+        "io.darkbloom.provider",
+        "io.darkbloom.fan",
+    ]
+
+    /// NSPredicate source for `/usr/bin/log show|stream --predicate`
+    /// matching every provider subsystem. Note `log show` only returns what
+    /// the log store persisted: .notice/.warning/.error lines persist to
+    /// disk by default, while .info/.debug live in the memory ring buffer
+    /// only — low-frequency lifecycle lines that reports must capture are
+    /// logged at .notice for exactly this reason.
+    public static func unifiedLogPredicate() -> String {
+        all.map { #"subsystem == "\#($0)""# }
+            .joined(separator: " OR ")
+    }
+}

--- a/provider-swift/Sources/ProviderCoreFoundation/PromptContractIdentity.swift
+++ b/provider-swift/Sources/ProviderCoreFoundation/PromptContractIdentity.swift
@@ -8,8 +8,23 @@ public enum PromptContractIdentity {
     public static let blockHashVersion = "darkbloom-block-chain-v1"
     public static let blockSize: UInt32 = 256
 
+    /// Discriminated failure causes for fleet attribution. IMPORTANT: this
+    /// computation is mirrored by the Rust prompt sidecar — error cases may
+    /// tell the sub-causes apart, but the accept/reject behavior, guard
+    /// ordering, and hash encoding must stay byte-identical across changes.
     public enum Error: Swift.Error, Equatable {
+        /// Everything structural: path violations, missing core artifacts,
+        /// encode limits.
         case invalidArtifact
+        /// No readable standalone `chat_template.jinja` in the snapshot
+        /// (template embedded in tokenizer_config.json only — e.g. Qwen 2.5,
+        /// gemma-4 mlx-community snapshots).
+        case templateArtifactMissing
+        /// Template renders wall-clock time (`strftime_now`, all GPT-OSS
+        /// variants) — deliberate determinism exclusion.
+        case templateDynamicDate
+        /// `TemplateRenderCheck` canonical-fixture render self-check failed.
+        case templateRenderFailed
     }
 
     public static func compute(files: [ManifestFile]) throws -> String {
@@ -57,11 +72,18 @@ public enum PromptContractIdentity {
         let root = modelDirectory.standardizedFileURL
         let rootPrefix = root.path.hasSuffix("/") ? root.path : root.path + "/"
         let standaloneTemplate = root.appendingPathComponent("chat_template.jinja")
-        guard let template = try? String(contentsOf: standaloneTemplate, encoding: .utf8),
-              !template.contains("strftime_now"),
-              TemplateRenderCheck.renderOK(at: root) == true
+        // Same accept/reject conditions and short-circuit order as the
+        // original combined guard (read → strftime_now → render check);
+        // split only so each rejection throws its discriminated cause.
+        guard let template = try? String(contentsOf: standaloneTemplate, encoding: .utf8)
         else {
-            throw Error.invalidArtifact
+            throw Error.templateArtifactMissing
+        }
+        guard !template.contains("strftime_now") else {
+            throw Error.templateDynamicDate
+        }
+        guard TemplateRenderCheck.renderOK(at: root) == true else {
+            throw Error.templateRenderFailed
         }
         guard let enumerator = FileManager.default.enumerator(
             at: root,

--- a/provider-swift/Sources/darkbloom/LogsCommand.swift
+++ b/provider-swift/Sources/darkbloom/LogsCommand.swift
@@ -6,8 +6,8 @@ struct Logs: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         abstract: "Show provider logs from macOS unified logging.",
         discussion: """
-        Streams live logs from macOS unified logging \
-        (subsystem: \(subsystem)) by default.
+        Streams live logs from macOS unified logging (all Darkbloom \
+        provider log subsystems) by default.
 
         Use --last to show a historical window (e.g. 1h, 30m, 24h). Combine \
         --last with --follow to print that history first and then keep \
@@ -33,8 +33,7 @@ struct Logs: AsyncParsableCommand {
     @Option(name: [.short, .long], help: "Number of lines to show (only applies with --file).")
     var lines: Int = 50
 
-    private static let subsystem = "dev.darkbloom.provider"
-    private static let predicate = #"subsystem == "\#(subsystem)""#
+    private static let predicate = ProviderLogSubsystems.unifiedLogPredicate()
 
     mutating func run() async throws {
         await runUpdateBannerIfEnabled()

--- a/provider-swift/Sources/darkbloom/ReportCommand.swift
+++ b/provider-swift/Sources/darkbloom/ReportCommand.swift
@@ -6,8 +6,8 @@ struct Report: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         abstract: "Upload recent unified logs to the coordinator for troubleshooting.",
         discussion: """
-        Collects the last 24 hours of macOS unified logs for the
-        dev.darkbloom.provider subsystem and uploads them to the coordinator.
+        Collects the last 24 hours of macOS unified logs for all Darkbloom
+        provider log subsystems and uploads them to the coordinator.
         The uploaded report can be retrieved by the Darkbloom team using
         your device's serial number.
 
@@ -104,7 +104,7 @@ struct Report: AsyncParsableCommand {
         process.executableURL = URL(fileURLWithPath: "/usr/bin/log")
         process.arguments = [
             "show",
-            "--predicate", "subsystem == \"dev.darkbloom.provider\"",
+            "--predicate", ProviderLogSubsystems.unifiedLogPredicate(),
             "--style", "ndjson",
             "--last", last,
             "--info",

--- a/provider-swift/Tests/DarkbloomCLITests/LogsCommandArgvTests.swift
+++ b/provider-swift/Tests/DarkbloomCLITests/LogsCommandArgvTests.swift
@@ -1,3 +1,4 @@
+import ProviderCore
 import Testing
 
 @testable import darkbloom
@@ -10,8 +11,9 @@ import Testing
 ///      historical (`showArgv`) and live (`streamArgv`) phases.
 @Suite("Logs argv builders")
 struct LogsCommandArgvTests {
-    /// Matches the subsystem predicate the command builds internally.
-    static let predicate = #"subsystem == "dev.darkbloom.provider""#
+    /// Matches the all-subsystems predicate the command builds internally
+    /// (the exact string is pinned by ProviderLogSubsystemsTests).
+    static let predicate = ProviderLogSubsystems.unifiedLogPredicate()
 
     // MARK: - streamArgv
 

--- a/provider-swift/Tests/DarkbloomCLITests/ProviderLogSubsystemsTests.swift
+++ b/provider-swift/Tests/DarkbloomCLITests/ProviderLogSubsystemsTests.swift
@@ -56,4 +56,42 @@ struct ProviderLogSubsystemsTests {
             unregistered.isEmpty,
             "subsystems logged but not collected by report/logs: \(unregistered.sorted())")
     }
+
+    /// Second drift pass: a `Logger(subsystem: someConstant, ...)` call site
+    /// evades the literal scan silently, so any NON-literal subsystem
+    /// argument must be an explicitly allowlisted pass-through wrapper.
+    /// Adding a new indirect call site fails here: either use an inline
+    /// string literal or extend the wrapper allowlist consciously.
+    @Test("non-literal Logger subsystem arguments are allowlisted wrappers")
+    func indirectSubsystemArgumentsAreAllowlisted() throws {
+        let allowedWrapperFiles: Set<String> = ["ProviderLogger.swift"]
+
+        let sourcesDirectory = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("Sources", isDirectory: true)
+        let enumerator = try #require(FileManager.default.enumerator(
+            at: sourcesDirectory,
+            includingPropertiesForKeys: [.isRegularFileKey]))
+        // A Logger/os.Logger construction whose subsystem argument does NOT
+        // start with a string literal (i.e. an identifier/member reference).
+        let regex = try NSRegularExpression(
+            pattern: #"Logger\(\s*subsystem:\s*([A-Za-z_][A-Za-z0-9_.]*)"#)
+
+        var offenders: [String] = []
+        for case let url as URL in enumerator where url.pathExtension == "swift" {
+            guard let contents = try? String(contentsOf: url, encoding: .utf8) else {
+                continue
+            }
+            let range = NSRange(contents.startIndex..., in: contents)
+            guard !regex.matches(in: contents, range: range).isEmpty else { continue }
+            if !allowedWrapperFiles.contains(url.lastPathComponent) {
+                offenders.append(url.lastPathComponent)
+            }
+        }
+        #expect(
+            offenders.isEmpty,
+            "indirect Logger subsystem arguments outside the wrapper allowlist (use an inline literal so the drift scan sees it): \(offenders.sorted())")
+    }
 }

--- a/provider-swift/Tests/DarkbloomCLITests/ProviderLogSubsystemsTests.swift
+++ b/provider-swift/Tests/DarkbloomCLITests/ProviderLogSubsystemsTests.swift
@@ -1,0 +1,59 @@
+import Foundation
+import ProviderCore
+import Testing
+
+/// Coverage pins for the `darkbloom report` / `darkbloom logs` collection
+/// predicate. The v0.7.13 incident: both commands filtered on the single
+/// `dev.darkbloom.provider` subsystem while all KVCacheSSD and engine-bridge
+/// code logs to `com.darkbloom.provider` — so uploaded reports carried zero
+/// SSD-cache lines. These tests pin the predicate AND scan the package
+/// sources so a future subsystem cannot silently escape collection again.
+@Suite("Provider log subsystems")
+struct ProviderLogSubsystemsTests {
+
+    @Test("unified log predicate covers every registered subsystem")
+    func predicateIsPinned() {
+        #expect(ProviderLogSubsystems.unifiedLogPredicate()
+            == #"subsystem == "dev.darkbloom.provider" OR "#
+            + #"subsystem == "com.darkbloom.provider" OR "#
+            + #"subsystem == "io.darkbloom.provider" OR "#
+            + #"subsystem == "io.darkbloom.fan""#)
+    }
+
+    @Test("every subsystem literal under Sources is registered for collection")
+    func sourceSubsystemLiteralsAreRegistered() throws {
+        // Tests/DarkbloomCLITests/<this file> -> package root -> Sources.
+        let sourcesDirectory = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()  // DarkbloomCLITests
+            .deletingLastPathComponent()  // Tests
+            .deletingLastPathComponent()  // package root
+            .appendingPathComponent("Sources", isDirectory: true)
+        let enumerator = try #require(FileManager.default.enumerator(
+            at: sourcesDirectory,
+            includingPropertiesForKeys: [.isRegularFileKey]))
+        let regex = try NSRegularExpression(pattern: #"subsystem:\s*"([^"]+)""#)
+
+        var found: Set<String> = []
+        for case let url as URL in enumerator where url.pathExtension == "swift" {
+            guard let contents = try? String(contentsOf: url, encoding: .utf8) else {
+                continue
+            }
+            let range = NSRange(contents.startIndex..., in: contents)
+            for match in regex.matches(in: contents, range: range) {
+                guard let subsystemRange = Range(match.range(at: 1), in: contents)
+                else { continue }
+                found.insert(String(contents[subsystemRange]))
+            }
+        }
+
+        // Sanity: the scan actually saw the known subsystems — an empty or
+        // partial result would mean the walk broke, not that coverage holds.
+        #expect(found.isSuperset(of: ProviderLogSubsystems.all))
+        // Drift gate: any subsystem logged anywhere in Sources MUST be in
+        // the collection list, or `darkbloom report` silently drops it.
+        let unregistered = found.subtracting(ProviderLogSubsystems.all)
+        #expect(
+            unregistered.isEmpty,
+            "subsystems logged but not collected by report/logs: \(unregistered.sorted())")
+    }
+}

--- a/provider-swift/Tests/ProviderCoreFoundationTests/PromptContractIdentityTests.swift
+++ b/provider-swift/Tests/ProviderCoreFoundationTests/PromptContractIdentityTests.swift
@@ -48,7 +48,9 @@ struct PromptContractIdentityTests {
         for (name, data) in contents {
             try data.write(to: root.appendingPathComponent(name))
         }
-        #expect(throws: PromptContractIdentity.Error.invalidArtifact) {
+        // Embedded-template-only snapshots (Qwen 2.5 family, mlx-community
+        // gemma-4) reject with the discriminated manifest-gap cause.
+        #expect(throws: PromptContractIdentity.Error.templateArtifactMissing) {
             try PromptContractIdentity.compute(modelDirectory: root)
         }
     }
@@ -66,7 +68,13 @@ struct PromptContractIdentityTests {
         try Data("{{ messages }}".utf8).write(
             to: root.appendingPathComponent("chat_template.jinja"))
 
-        #expect(try PromptContractIdentity.compute(modelDirectory: root).count == 64)
+        // Byte-identity pin: the contract ID for this fixed fixture must never
+        // move (the Rust prompt sidecar mirrors this computation). Guard-path
+        // refactors may only change WHICH error is thrown, never the accepted
+        // inputs or the resulting hash.
+        #expect(
+            try PromptContractIdentity.compute(modelDirectory: root)
+                == "f55113f73235e26eab178d5f1f4d2b439ab206928e0ecad3e546b788be23f55d")
     }
 
     @Test("unsupported renderer semantics do not produce a contract identity")
@@ -82,7 +90,7 @@ struct PromptContractIdentityTests {
         try Data(#"{% include "unsupported.jinja" %}"#.utf8).write(
             to: root.appendingPathComponent("chat_template.jinja"))
 
-        #expect(throws: PromptContractIdentity.Error.invalidArtifact) {
+        #expect(throws: PromptContractIdentity.Error.templateRenderFailed) {
             try PromptContractIdentity.compute(modelDirectory: root)
         }
     }
@@ -100,7 +108,9 @@ struct PromptContractIdentityTests {
         try Data(#"{{ strftime_now("%Y-%m-%d") }}"#.utf8).write(
             to: root.appendingPathComponent("chat_template.jinja"))
 
-        #expect(throws: PromptContractIdentity.Error.invalidArtifact) {
+        // GPT-OSS-style wall-clock templates reject with the discriminated
+        // determinism-exclusion cause.
+        #expect(throws: PromptContractIdentity.Error.templateDynamicDate) {
             try PromptContractIdentity.compute(modelDirectory: root)
         }
     }

--- a/provider-swift/Tests/ProviderCoreTests/EngineV2KVBackendGateTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/EngineV2KVBackendGateTests.swift
@@ -93,6 +93,17 @@ private final class GateCacheCapture: @unchecked Sendable {
     var capability: CBv2PrefixReuseCapability? { lock.withLock { _capability } }
 }
 
+private final class TelemetryEventCapture: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _events: [TelemetryEvent] = []
+
+    func append(_ event: TelemetryEvent) {
+        lock.withLock { _events.append(event) }
+    }
+
+    var snapshot: [TelemetryEvent] { lock.withLock { _events } }
+}
+
 private let gateTestCapacity = 8 << 20  // 8 MiB pool — tiny but constructible
 
 private func makeBuild(
@@ -380,6 +391,81 @@ struct EngineV2KVBackendGateTests {
         #expect(status.replayStrategy == .frozenFull)
         #expect(status.state == .pending)
         #expect(status.reason == .scanPending)
+        await bundle.bridge.shutdown()
+    }
+
+    @Test("slot factory discriminates the missing-template prompt-contract failure")
+    func slotFactoryDiscriminatesMissingTemplateContract() async throws {
+        // A snapshot dir WITHOUT a standalone chat_template.jinja (template
+        // embedded in tokenizer_config.json — the dominant production
+        // cache_init_failed shape) must surface template_artifact_missing in
+        // BOTH the eligibility status detail and the construction-failure
+        // telemetry event, via the real makeProductionBundle do/catch path.
+        let snapshot = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "slot-factory-embedded-template-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: snapshot, withIntermediateDirectories: false)
+        defer { try? FileManager.default.removeItem(at: snapshot) }
+        try Data(#"{"model_type":"fixture"}"#.utf8).write(
+            to: snapshot.appendingPathComponent("config.json"))
+        try Data(#"{"version":"1.0"}"#.utf8).write(
+            to: snapshot.appendingPathComponent("tokenizer.json"))
+        try Data(#"{"chat_template":"{{ messages }}"}"#.utf8).write(
+            to: snapshot.appendingPathComponent("tokenizer_config.json"))
+
+        let model = try tinyGPTOSS()
+        let tokenizer = StubBridgeTokenizer()
+        let container = ModelContainer(
+            context: ModelContext(
+                configuration: ModelConfiguration(id: "tiny/gpt-oss"),
+                model: model,
+                processor: GateProcessor(),
+                tokenizer: tokenizer))
+        let preparedModel = EngineV2PreparedModel(
+            snapshot: EngineV2ModelSnapshot(
+                model: model,
+                eosTokenIds: [1],
+                extraEOSTokens: []),
+            servingModel: model,
+            assistant: nil,
+            mtpStatus: .disabled(.configDisabled, configured: false),
+            mtpArtifact: nil)
+        let events = TelemetryEventCapture()
+        let bundle = try await EngineV2SlotFactory.makeProductionBundle(
+            modelId: "tiny-gpt-oss",
+            modelType: "gpt_oss",
+            isVLM: false,
+            modelDirectory: snapshot,
+            container: container,
+            tokenizer: TokenizerHandle(tokenizer),
+            sizing: SlotSizingSnapshot(
+                weightsBytes: 1,
+                fp16KVBytesPerToken: 100_000,
+                maxContextLength: 2_048,
+                defaultMaxTokens: 32),
+            kvBytesCapacity: gateTestCapacity,
+            maxConcurrentRequests: 2,
+            kvBudget: nil,
+            kvQuantConfigured: false,
+            kvBackendConfig: "contiguous",
+            weightHash: String(repeating: "c", count: 64),
+            specDecPreparation: SpecDecPreparation(
+                artifact: nil,
+                status: .disabled(.configDisabled, configured: false)),
+            preparedModel: preparedModel,
+            environment: [:],
+            emitTelemetry: { events.append($0) })
+        #expect(bundle.bridge.ssdPrefixCache == nil)
+        let status = bundle.bridge.prefixCacheModelStatus()
+        #expect(status.state == .error)
+        #expect(status.reason == .cacheInitFailed)
+        #expect(status.initFailure == .templateArtifactMissing)
+        let failureEvent = try #require(events.snapshot.first { event in
+            event.fields?["prefix_construction_failure"] != nil
+        })
+        #expect(
+            failureEvent.fields?["prefix_construction_failure"]?.description
+                == "template_artifact_missing")
         await bundle.bridge.shutdown()
     }
 

--- a/provider-swift/Tests/ProviderCoreTests/PrefixCachePolicyTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/PrefixCachePolicyTests.swift
@@ -4,6 +4,7 @@
 
 import Foundation
 import MLXLMCommon
+import ProviderCoreFoundation
 import Testing
 
 @testable import ProviderCore
@@ -214,6 +215,9 @@ struct PrefixCachePolicyTests {
                 (.ephemeralKeyUnavailable, .error, .cacheInitFailed, .ephemeralKeyUnavailable),
                 (.blockContractMismatch, .error, .cacheInitFailed, .blockContractMismatch),
                 (.epochUnavailable, .error, .cacheInitFailed, .epochUnavailable),
+                (.templateArtifactMissing, .error, .cacheInitFailed, .templateArtifactMissing),
+                (.templateDynamicDate, .error, .cacheInitFailed, .templateDynamicDate),
+                (.templateRenderFailed, .error, .cacheInitFailed, .templateRenderFailed),
                 (.promptContractUnavailable, .error, .cacheInitFailed, .promptContractUnavailable),
             ]
         for test in expected {
@@ -221,6 +225,28 @@ struct PrefixCachePolicyTests {
             #expect(box.snapshot?.state == test.state, "\(test.failure)")
             #expect(box.snapshot?.reason == test.reason, "\(test.failure)")
             #expect(box.snapshot?.detail == test.detail, "\(test.failure)")
+        }
+    }
+
+    @Test("prompt-contract errors map to discriminated construction failures")
+    func promptContractErrorMapping() {
+        struct UnrelatedError: Error {}
+        let expected:
+            [(error: any Error, failure: SSDPrefixCacheConstructionFailure)] = [
+                (
+                    PromptContractIdentity.Error.templateArtifactMissing,
+                    .templateArtifactMissing
+                ),
+                (PromptContractIdentity.Error.templateDynamicDate, .templateDynamicDate),
+                (PromptContractIdentity.Error.templateRenderFailed, .templateRenderFailed),
+                (PromptContractIdentity.Error.invalidArtifact, .promptContractUnavailable),
+                (UnrelatedError(), .promptContractUnavailable),
+            ]
+        for test in expected {
+            #expect(
+                EngineV2SlotFactory.promptContractConstructionFailure(test.error)
+                    == test.failure,
+                "\(test.error)")
         }
     }
 

--- a/provider-swift/Tests/ProviderCoreTests/PrefixCachePolicyTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/PrefixCachePolicyTests.swift
@@ -178,7 +178,7 @@ struct PrefixCachePolicyTests {
             ]) == 2_048)
     }
 
-    @Test("construction failures map to bounded eligibility reasons")
+    @Test("construction failures map to bounded eligibility reasons and details")
     func constructionFailureReasons() {
         let windowed = CBv2LayerKind(
             attention: .slidingWindow(128),
@@ -195,17 +195,33 @@ struct PrefixCachePolicyTests {
             backendSelection: .paged)
         let box = PrefixCacheConstructionStatusBox()
 
-        box.record(failure: .unsupportedPlan, capability: pagedHybrid)
-        #expect(box.snapshot?.state == .disabled)
-        #expect(box.snapshot?.reason == .pagedHybridUnsupported)
-
-        box.record(failure: .missingWeightHash, capability: pagedHybrid)
-        #expect(box.snapshot?.state == .disabled)
-        #expect(box.snapshot?.reason == .weightHashUnavailable)
-
-        box.record(failure: .unsafePath, capability: pagedHybrid)
-        #expect(box.snapshot?.state == .error)
-        #expect(box.snapshot?.reason == .diskUnavailable)
+        // Every construction failure maps to exactly one (state, reason,
+        // init-failure detail) triple; detail is non-nil ONLY under
+        // `.cacheInitFailed`, where it disambiguates the five sub-causes
+        // v0.7.13 collapsed into one bucket.
+        let expected:
+            [(
+                failure: SSDPrefixCacheConstructionFailure,
+                state: PrefixCacheStatusState,
+                reason: PrefixCacheStatusReason,
+                detail: PrefixCacheInitFailureDetail?
+            )] = [
+                (.unsupportedPlan, .disabled, .pagedHybridUnsupported, nil),
+                (.missingWeightHash, .disabled, .weightHashUnavailable, nil),
+                (.layoutUnavailable, .disabled, .unsupportedLayout, nil),
+                (.unsafePath, .error, .diskUnavailable, nil),
+                (.keyUnavailable, .error, .cacheInitFailed, .keyUnavailable),
+                (.ephemeralKeyUnavailable, .error, .cacheInitFailed, .ephemeralKeyUnavailable),
+                (.blockContractMismatch, .error, .cacheInitFailed, .blockContractMismatch),
+                (.epochUnavailable, .error, .cacheInitFailed, .epochUnavailable),
+                (.promptContractUnavailable, .error, .cacheInitFailed, .promptContractUnavailable),
+            ]
+        for test in expected {
+            box.record(failure: test.failure, capability: pagedHybrid)
+            #expect(box.snapshot?.state == test.state, "\(test.failure)")
+            #expect(box.snapshot?.reason == test.reason, "\(test.failure)")
+            #expect(box.snapshot?.detail == test.detail, "\(test.failure)")
+        }
     }
 
 }

--- a/provider-swift/Tests/ProviderCoreTests/ProductionPromptParityTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ProductionPromptParityTests.swift
@@ -28,7 +28,7 @@ struct ProductionPromptParityTests {
             if !model.cacheRoutingEligible {
                 #expect(model.ineligibilityReason == "dynamic_time")
                 #expect(model.cases.isEmpty)
-                #expect(throws: PromptContractIdentity.Error.invalidArtifact) {
+                #expect(throws: PromptContractIdentity.Error.templateDynamicDate) {
                     try PromptContractIdentity.compute(modelDirectory: modelDirectory)
                 }
                 continue

--- a/provider-swift/Tests/ProviderCoreTests/ProtocolTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ProtocolTests.swift
@@ -129,6 +129,29 @@ import Testing
     #expect(decoded.prefixCacheStatuses == [plain, detailed])
 }
 
+@Test func prefixCacheInitFailureDetailDecodeToleratesUnknownValues() throws {
+    // Forward compatibility mirror of the Go side: an unknown future detail
+    // string must decode to nil (field dropped), never reject the message.
+    let json = """
+        {"model_id":"m","backend":"contiguous","replay_strategy":"frozen_full",\
+        "state":"error","reason":"cache_init_failed",\
+        "init_failure":"some_future_detail_value"}
+        """
+    let decoded = try JSONDecoder().decode(
+        PrefixCacheModelStatus.self, from: Data(json.utf8))
+    #expect(decoded.initFailure == nil)
+    #expect(decoded.reason == .cacheInitFailed)
+
+    let known = """
+        {"model_id":"m","backend":"contiguous","replay_strategy":"frozen_full",\
+        "state":"error","reason":"cache_init_failed",\
+        "init_failure":"template_dynamic_date"}
+        """
+    let decodedKnown = try JSONDecoder().decode(
+        PrefixCacheModelStatus.self, from: Data(known.utf8))
+    #expect(decodedKnown.initFailure == .templateDynamicDate)
+}
+
 @Test func prefixCacheTelemetryEnumCasingIsPinned() {
     #expect(Set(PrefixCacheStatusState.allCases.map(\.rawValue)) == [
         "ready", "pending", "disabled", "error",

--- a/provider-swift/Tests/ProviderCoreTests/ProtocolTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ProtocolTests.swift
@@ -148,8 +148,9 @@ import Testing
     ])
     #expect(Set(PrefixCacheInitFailureDetail.allCases.map(\.rawValue)) == [
         "key_unavailable", "ephemeral_key_unavailable", "block_contract_mismatch",
-        "epoch_unavailable", "prompt_contract_unavailable", "epoch_lost",
-        "cache_closed", "unknown",
+        "epoch_unavailable", "prompt_contract_unavailable",
+        "template_artifact_missing", "template_dynamic_date", "template_render_failed",
+        "epoch_lost", "cache_closed", "unknown",
     ])
     #expect(Set(PrefixCacheDonationOutcome.allCases.map(\.rawValue)) == [
         "donated", "below_effective_token_floor", "no_complete_block",

--- a/provider-swift/Tests/ProviderCoreTests/ProtocolTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ProtocolTests.swift
@@ -89,6 +89,46 @@ import Testing
     ])
 }
 
+@Test func prefixCacheInitFailureDetailIsOptionalOnTheWire() throws {
+    // The granular detail must be a pure ADDITIVE key: omitted entirely when
+    // nil (v0.7.13 coordinators drop unknown-REASON entries, but ignore
+    // unknown KEYS — so the detail rides `init_failure`, never a new reason).
+    let plain = PrefixCacheModelStatus(
+        modelId: "model-plain",
+        backend: .contiguous,
+        replayStrategy: .frozenFull,
+        state: .disabled,
+        reason: .weightHashUnavailable)
+    let detailed = PrefixCacheModelStatus(
+        modelId: "model-detailed",
+        backend: .paged,
+        replayStrategy: .tailReplay,
+        state: .error,
+        reason: .cacheInitFailed,
+        initFailure: .keyUnavailable)
+    let message = ProviderMessage.heartbeat(ProviderMessage.Heartbeat(
+        status: .idle,
+        stats: ProviderStats(),
+        systemMetrics: SystemMetrics(
+            memoryPressure: 0, cpuUsage: 0, thermalState: .nominal),
+        prefixCacheStatuses: [plain, detailed]))
+    let data = try ProviderProtocolCodec.encodeProviderMessage(message)
+    let object = try jsonObject(data)
+    let statusObjects = try #require(
+        object["prefix_cache_statuses"] as? [[String: Any]])
+    let plainObject = try #require(statusObjects.first)
+    #expect(plainObject["init_failure"] == nil)
+    let detailedObject = try #require(statusObjects.last)
+    #expect(detailedObject["init_failure"] as? String == "key_unavailable")
+
+    guard case .heartbeat(let decoded) =
+        try ProviderProtocolCodec.decodeProviderMessage(from: data)
+    else {
+        throw TestFailure.unexpectedMessage
+    }
+    #expect(decoded.prefixCacheStatuses == [plain, detailed])
+}
+
 @Test func prefixCacheTelemetryEnumCasingIsPinned() {
     #expect(Set(PrefixCacheStatusState.allCases.map(\.rawValue)) == [
         "ready", "pending", "disabled", "error",
@@ -105,6 +145,11 @@ import Testing
     ])
     #expect(Set(PrefixCacheReplayStrategy.allCases.map(\.rawValue)) == [
         "direct", "frozen_full", "tail_replay", "none", "unknown",
+    ])
+    #expect(Set(PrefixCacheInitFailureDetail.allCases.map(\.rawValue)) == [
+        "key_unavailable", "ephemeral_key_unavailable", "block_contract_mismatch",
+        "epoch_unavailable", "prompt_contract_unavailable", "epoch_lost",
+        "cache_closed", "unknown",
     ])
     #expect(Set(PrefixCacheDonationOutcome.allCases.map(\.rawValue)) == [
         "donated", "below_effective_token_floor", "no_complete_block",

--- a/provider-swift/Tests/ProviderCoreTests/SSDPrefixCacheTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/SSDPrefixCacheTests.swift
@@ -1125,6 +1125,82 @@ struct SSDPrefixCacheLifecycleTests {
         #expect(current.cacheEpoch != original.cacheEpoch)
     }
 
+    @Test("runtime cache_init_failed statuses carry granular init-failure details")
+    func runtimeInitFailureStatusesCarryDetail() throws {
+        let base = PrefixCacheModelStatus(
+            modelId: "test-model",
+            backend: .contiguous,
+            replayStrategy: .direct,
+            state: .pending,
+            reason: .scanPending)
+        let binding = SSDCacheEpochStore.Binding(
+            modelId: "test-model",
+            modelAggregateHash: "test-weight-hash",
+            promptContractId: "test-prompt-contract",
+            blockHashVersion: CBv2BlockHasher.version,
+            blockSize: fixtureBlockSize,
+            layoutEpoch: SSDBlockStore.layoutEpoch(
+                blockSize: fixtureBlockSize, layerKinds: fixtureLayerKinds),
+            keyFingerprint: String(repeating: "e", count: 64))
+
+        // Closed cache: the terminal runtime state reports .cacheClosed.
+        let closedDir = tempDir("status-detail-closed")
+        defer { try? FileManager.default.removeItem(at: closedDir) }
+        let closedCache = makeCache(
+            dir: closedDir, kek: SymmetricKey(size: .bits256), clock: ClockBox(10_000))
+        closedCache.close()
+        let closedStatus = closedCache.prefixCacheModelStatus(base: base)
+        #expect(closedStatus.state == .error)
+        #expect(closedStatus.reason == .cacheInitFailed)
+        #expect(closedStatus.initFailure == .cacheClosed)
+
+        // Ledger-lost epoch: another owner (different binding) takes over the
+        // root, the original store's epoch becomes unverifiable → .epochLost.
+        let lostDir = tempDir("status-detail-epoch-lost")
+        defer { try? FileManager.default.removeItem(at: lostDir) }
+        let lostStore = try SSDCacheEpochStore(root: lostDir, binding: binding)
+        let lostCache = makeCache(
+            dir: lostDir, kek: SymmetricKey(size: .bits256), clock: ClockBox(10_000),
+            epochStore: lostStore)
+        defer { lostCache.close() }
+        lostCache.scanOnDisk()
+        let readyStatus = lostCache.prefixCacheModelStatus(base: base)
+        #expect(readyStatus.state == .ready)
+        #expect(readyStatus.reason == .ready)
+        #expect(readyStatus.initFailure == nil)
+        let rebound = SSDCacheEpochStore.Binding(
+            modelId: binding.modelId,
+            modelAggregateHash: "different-weight-hash",
+            promptContractId: binding.promptContractId,
+            blockHashVersion: binding.blockHashVersion,
+            blockSize: binding.blockSize,
+            layoutEpoch: binding.layoutEpoch,
+            keyFingerprint: binding.keyFingerprint)
+        _ = try SSDCacheEpochStore(root: lostDir, binding: rebound)
+        let lostStatus = lostCache.prefixCacheModelStatus(base: base)
+        #expect(lostStatus.state == .error)
+        #expect(lostStatus.reason == .cacheInitFailed)
+        #expect(lostStatus.initFailure == .epochLost)
+
+        // Destructive-change persist failure: the epoch record vanished under
+        // an active mutation → cacheStatusFailure with the .epochLost detail.
+        let persistDir = tempDir("status-detail-persist-failure")
+        defer { try? FileManager.default.removeItem(at: persistDir) }
+        let persistStore = try SSDCacheEpochStore(root: persistDir, binding: binding)
+        let persistCache = makeCache(
+            dir: persistDir, kek: SymmetricKey(size: .bits256), clock: ClockBox(10_000),
+            epochStore: persistStore)
+        defer { persistCache.close() }
+        persistCache.scanOnDisk()
+        try FileManager.default.removeItem(
+            at: persistDir.appendingPathComponent("cache-epoch.json"))
+        #expect(!persistCache.holdDestructiveEpochForTesting {})
+        let persistStatus = persistCache.prefixCacheModelStatus(base: base)
+        #expect(persistStatus.state == .error)
+        #expect(persistStatus.reason == .cacheInitFailed)
+        #expect(persistStatus.initFailure == .epochLost)
+    }
+
     @Test("reconciliation drops a symlink-replaced indexed file without following it")
     func reconciliationDropsSymlinkReplacement() throws {
         let dir = tempDir("reconcile-symlink")


### PR DESCRIPTION
## Summary

Production telemetry shows **111 of 153 loaded model slots** reporting `cache_init_failed` — one opaque bucket collapsing eight-plus distinct root causes, invisible in `darkbloom report` uploads because the SSD cache logs to a subsystem the report never collected, and its lifecycle lines were `.info` (memory-only, evaporate before `log show` runs). This PR makes every cache init failure attributable, fleet-wide, without a new reason enum (the deployed v0.7.13 coordinator drops unknown-reason entries entry-wise; it ignores unknown keys — so the detail rides an optional key).

- **Granular `init_failure` wire detail** (11-value vocabulary) on `PrefixCacheModelStatus`, populated only when `reason == cache_init_failed`: `key_unavailable`, `ephemeral_key_unavailable`, `block_contract_mismatch`, `epoch_unavailable`, `prompt_contract_unavailable`, `template_artifact_missing`, `template_dynamic_date`, `template_render_failed`, `epoch_lost`, `cache_closed`, `unknown`. Swift encode omits the key when nil (fixture-pinned); decode tolerates unknown future values (nil, never rejects the message).
- **Discriminated prompt-contract errors**: `PromptContractIdentity.compute(modelDirectory:)` now throws `templateArtifactMissing` / `templateDynamicDate` / `templateRenderFailed` instead of one swallowed `invalidArtifact`. Accept/reject behavior and contract IDs are **byte-identical** (pinned by a pre-change hash fixture + the Rust-shared vector corpus; the Rust sidecar is untouched). Verified on fleet machines: gpt-oss-20b fails on `strftime_now` (`template_dynamic_date`), community Qwen/Gemma variants fail on missing standalone `chat_template.jinja` (`template_artifact_missing`).
- **Coordinator sanitize + aggregate**: strip-but-keep on every status ingress path (registration, heartbeat, v2-capability update) — a misplaced/unknown/empty detail never drops an entry or creates unbounded map keys. `GET /v1/cache/status` gains a zero-bucketed `by_init_failure` breakdown; process metrics + Datadog gain `exact_cache_eligibility_init_failure{failure=...}`.
- **`darkbloom report`/`logs` collect all four provider subsystems** (`dev.`/`com.`/`io.darkbloom.provider`, `io.darkbloom.fan`) via one shared `ProviderLogSubsystems` constant — previously reports carried **zero** SSD-cache and engine-bridge lines. Two drift tests: every `subsystem:` literal under `Sources/` must be registered, and non-literal `Logger(subsystem:)` call sites must be allowlisted wrappers.
- **Lifecycle cache lines persist**: one-per-load and 120s-interval stats lines elevated `.info` → `.notice` (info lives in the memory ring buffer and rarely survives to a later `log show --last 24h`, which is exactly what report runs).

## Behavior

```mermaid
flowchart LR
  subgraph Before
    A1[SSD cache init fails<br/>8+ distinct causes] --> B1[reason: cache_init_failed<br/>opaque]
    B1 --> C1["/v1/cache/status: 111 error slots,<br/>no attribution"]
    D1[darkbloom report] --> E1[collects dev.darkbloom.provider only<br/>zero SSD-cache lines,<br/>info lines already evaporated]
  end
  subgraph After
    A2[SSD cache init fails] --> B2["reason: cache_init_failed<br/>+ init_failure: template_dynamic_date /<br/>key_unavailable / epoch_lost / ..."]
    B2 --> C2["/v1/cache/status by_init_failure +<br/>Datadog eligibility_init_failure gauges"]
    D2[darkbloom report] --> E2[collects all 4 darkbloom subsystems;<br/>lifecycle lines persist at .notice]
  end
```

## Code

```mermaid
flowchart LR
  subgraph Before
    F1["PromptContractIdentity.compute<br/>throws invalidArtifact (collapsed)"] --> G1["EngineV2SlotFactory: try? swallows"]
    G1 --> H1["PrefixCacheConstructionStatusBox<br/>5 failures → cacheInitFailed"]
    H1 --> I1["PrefixCacheModelStatus<br/>{state, reason}"]
    I1 --> J1["cache_eligibility.go sanitize<br/>→ by_reason only"]
  end
  subgraph After
    F2["compute throws templateArtifactMissing /<br/>templateDynamicDate / templateRenderFailed"] --> G2["slot factory do/catch maps to<br/>SSDPrefixCacheConstructionFailure (12 cases)"]
    G2 --> H2["status box maps failure →<br/>(state, reason, initFailure detail)"]
    H2 --> I2["PrefixCacheModelStatus + optional<br/>init_failure (omitted when nil)"]
    I2 --> J2["sanitize strip-but-keep on all ingress →<br/>by_init_failure + eligibility_init_failure gauges"]
  end
```

## Mixed-version safety

| Cell | Result |
|---|---|
| v0.7.14 provider → deployed v0.7.13 coordinator | extra JSON key ignored (plain `json.Unmarshal`, no `DisallowUnknownFields` on the WS path); entries kept |
| v0.7.13 provider → new coordinator | absent detail = `""`, counts toward reason total only |
| future provider, new detail value → new coordinator | detail stripped, entry kept, no new map keys |
| Swift decoding unknown future detail | decodes to nil (custom tolerant `init(from:)`), never rejects the message |

## Testing

- Go: full `go test ./...` green, `gofmt` clean. New: enum/wire symmetry pins, 4-case strip-but-keep sanitizer table, aggregation breakdown, handler-level `/v1/cache/status` JSON + gauge pins.
- Swift: full `swift test` — 1,627 tests, 0 failures. New: 12-way construction mapping triples, 3 runtime detail scenarios, wire omission/emission/tolerant-decode pins, contract-ID byte-identity hash pin (validated against pre-change code), predicate pin + two subsystem drift tests.
- `scripts/verify-prompt-parity.sh` (the mandatory CI/release gate) passes end to end, including the Rust-shared vector corpus and the sidecar load harness (`passed: true`).
- Two independent reviews: adversarial mixed-version/edge-case review — PASS; correctness review — one blocker (parity fixture expecting the old collapsed error) found and fixed in `2db861bd4`, re-proven by the full parity gate.

## Follow-ups (deliberately out of scope)

- `cache_closed` transient: heartbeats racing a model unload report `error/cache_init_failed/cache_closed` during the drain window — pre-existing v0.7.13 behavior that this PR merely labels; the at-source fix (filter `modelsUnloading` in capacity assembly) touches the heartbeat capacity path and belongs in its own change. Ops guidance: treat the `cache_closed` bucket as lifecycle noise.
- Provider-owned structured diagnostic ring file (deterministic retention, zero logd dependence) as the durable tier-3 diagnostics story.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/571"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787442570&installation_model_id=21733&pr_number=571&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F571&signature=fab0e9ea2f6777a0cd798a32cfcdbd0d7031afef2f6e4e2312280a28665240b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->