### PR TITLE
feat(publish): template-republish tooling — extract-template subcommand + dry-run-first operator script

### DIFF
--- a/provider-swift/Sources/ProviderCoreFoundation/WeightHasher.swift
+++ b/provider-swift/Sources/ProviderCoreFoundation/WeightHasher.swift
@@ -106,6 +106,49 @@ public struct WeightHasher: Sendable {
         return hashFilesWithRelativeKey(keyed)
     }
 
+    /// Combine already-known per-file SHA-256 digests into the manifest
+    /// aggregate hash WITHOUT reading any file bytes.
+    ///
+    /// Byte-identical to `hashFilesWithRelativeKey` for the same
+    /// (path → digest) inputs, and to the Go coordinator's
+    /// `aggregateManifestFileHashes`: digests are decoded from hex, sorted by
+    /// path (lexicographic; ties broken on the digest hex, matching
+    /// `ManifestBuilder`), concatenated as raw 32-byte digests, and SHA-256'd.
+    ///
+    /// Used by the republish flow, where a new manifest is derived from an old
+    /// manifest's per-file digests plus one new small file — the multi-GB
+    /// weight shards are never downloaded.
+    ///
+    /// Returns nil when any digest is not a valid 64-character hex string.
+    public static func aggregateFromDigests(_ files: [(path: String, sha256Hex: String)]) -> String? {
+        let sorted = files.sorted {
+            if $0.path != $1.path { return $0.path < $1.path }
+            return $0.sha256Hex < $1.sha256Hex
+        }
+        var finalHasher = SHA256()
+        for entry in sorted {
+            guard let digest = decodeHexDigest(entry.sha256Hex), digest.count == 32 else {
+                return nil
+            }
+            digest.withUnsafeBytes { finalHasher.update(bufferPointer: $0) }
+        }
+        return finalHasher.finalize().map { String(format: "%02x", $0) }.joined()
+    }
+
+    private static func decodeHexDigest(_ hex: String) -> Data? {
+        guard hex.count == 64 else { return nil }
+        var bytes = [UInt8]()
+        bytes.reserveCapacity(32)
+        var index = hex.startIndex
+        while index < hex.endIndex {
+            let next = hex.index(index, offsetBy: 2)
+            guard let byte = UInt8(hex[index ..< next], radix: 16) else { return nil }
+            bytes.append(byte)
+            index = next
+        }
+        return Data(bytes)
+    }
+
     /// Hash files in sorted order of the caller-supplied sort key, combining per-file
     /// digests into a final hash. Used by both the legacy attestation path (sort key =
     /// absolute path) and the manifest builder (sort key = relative POSIX path).

--- a/provider-swift/Sources/ProviderCoreFoundation/WeightHasher.swift
+++ b/provider-swift/Sources/ProviderCoreFoundation/WeightHasher.swift
@@ -109,11 +109,13 @@ public struct WeightHasher: Sendable {
     /// Combine already-known per-file SHA-256 digests into the manifest
     /// aggregate hash WITHOUT reading any file bytes.
     ///
-    /// Byte-identical to `hashFilesWithRelativeKey` for the same
-    /// (path → digest) inputs, and to the Go coordinator's
-    /// `aggregateManifestFileHashes`: digests are decoded from hex, sorted by
-    /// path (lexicographic; ties broken on the digest hex, matching
-    /// `ManifestBuilder`), concatenated as raw 32-byte digests, and SHA-256'd.
+    /// Byte-identical to `hashFilesWithRelativeKey` for unique-path inputs
+    /// (duplicate paths tie-break differently — digest hex here vs input
+    /// order there — but valid manifests reject duplicates before either
+    /// runs), and to the Go coordinator's `aggregateManifestFileHashes`:
+    /// digests are decoded from hex, sorted by path (lexicographic; ties
+    /// broken on the digest hex, matching `ManifestBuilder`), concatenated
+    /// as raw 32-byte digests, and SHA-256'd.
     ///
     /// Used by the republish flow, where a new manifest is derived from an old
     /// manifest's per-file digests plus one new small file — the multi-GB

--- a/provider-swift/Sources/darkbloom-publish/DarkbloomPublish.swift
+++ b/provider-swift/Sources/darkbloom-publish/DarkbloomPublish.swift
@@ -9,6 +9,6 @@ struct DarkbloomPublish: AsyncParsableCommand {
             Runs on Linux or macOS. Used by the publish-model.sh wrapper on \
             a GCP VM to produce a manifest.json before bytes are uploaded to R2.
             """,
-        subcommands: [HashCommand.self]
+        subcommands: [HashCommand.self, ExtractTemplateCommand.self]
     )
 }

--- a/provider-swift/Sources/darkbloom-publish/ExtractTemplateCommand.swift
+++ b/provider-swift/Sources/darkbloom-publish/ExtractTemplateCommand.swift
@@ -1,0 +1,148 @@
+import ArgumentParser
+import Crypto
+import Foundation
+import ProviderCoreFoundation
+
+/// Republish helper for models that were published without a standalone
+/// `chat_template.jinja` (their template only exists as the `chat_template`
+/// field inside tokenizer_config.json). The provider's SSD prefix cache
+/// (`PromptContractIdentity`) hard-requires the standalone file, so those
+/// models report `cache_init_failed` until republished.
+///
+/// This subcommand extracts the template, validates it the same way the
+/// prompt-contract gate does (no `strftime_now`, passes
+/// `TemplateRenderCheck.renderOK`), and derives a NEW manifest version from
+/// the old manifest's per-file digests plus the new file — no weight bytes
+/// are read, so it runs on a laptop against a few small downloaded artifacts.
+struct ExtractTemplateCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "extract-template",
+        abstract: "Extract chat_template.jinja from tokenizer_config.json and build a republish manifest for a new version."
+    )
+
+    @Option(name: .long, help: "Path to the OLD manifest.json (already downloaded from the old r2_prefix).")
+    var manifest: String
+
+    @Option(name: .long, help: "Directory containing the small artifact files downloaded from the old prefix (config.json, tokenizer.json, tokenizer_config.json, ...).")
+    var artifactsDir: String
+
+    @Option(name: .long, help: "New version string, e.g. 2026-07-23-r2.")
+    var newVersion: String
+
+    @Option(name: .long, help: "Output path for the NEW manifest.json.")
+    var output: String
+
+    @Option(name: .long, help: "Output path for the extracted chat_template.jinja.")
+    var templateOutput: String
+
+    mutating func validate() throws {
+        do {
+            try ManifestBuilder.validateVersion(newVersion)
+        } catch let ManifestBuilder.Error.invalidVersion(_, reason) {
+            throw ValidationError("--new-version: \(reason)")
+        }
+        var isDir: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: artifactsDir, isDirectory: &isDir), isDir.boolValue else {
+            throw ValidationError("--artifacts-dir: not a directory: \(artifactsDir)")
+        }
+    }
+
+    mutating func run() async throws {
+        // 1) Decode the old manifest and reject unprocessable ones (wrong
+        // schema, already has a standalone template, bad digests).
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let oldManifest = try decoder.decode(
+            ModelManifest.self, from: Data(contentsOf: URL(fileURLWithPath: manifest)))
+        try TemplateExtraction.validateOldManifest(oldManifest)
+        guard oldManifest.version != newVersion else {
+            throw ValidationError(
+                "--new-version equals the old manifest version (\(newVersion)) — republishing onto the same r2_prefix would mutate the old version")
+        }
+
+        // 2) Extract the template from tokenizer_config.json (string or
+        // [{name, template}] list form).
+        let artifactsURL = URL(fileURLWithPath: artifactsDir)
+        let tokenizerConfigURL = artifactsURL.appendingPathComponent("tokenizer_config.json")
+        guard FileManager.default.fileExists(atPath: tokenizerConfigURL.path) else {
+            throw ValidationError("tokenizer_config.json not found in --artifacts-dir: \(tokenizerConfigURL.path)")
+        }
+        let template = try TemplateExtraction.extractTemplate(
+            fromTokenizerConfig: Data(contentsOf: tokenizerConfigURL))
+
+        // 3) Same gates as PromptContractIdentity.compute(modelDirectory:):
+        // no dynamic-date templates, and the artifacts dir (WITH the new
+        // standalone file) must pass the render self-check.
+        try TemplateExtraction.validateDeterministic(template: template)
+
+        let templateData = Data(template.utf8)
+        let templateOutputURL = URL(fileURLWithPath: templateOutput)
+        try writeCreatingParentDirectory(templateData, to: templateOutputURL)
+        try writeCreatingParentDirectory(
+            templateData,
+            to: artifactsURL.appendingPathComponent(TemplateExtraction.templateFilename))
+
+        switch TemplateRenderCheck.renderOK(at: artifactsURL) {
+        case true?:
+            break
+        case false?:
+            throw ValidationError(
+                "template failed the render self-check (TemplateRenderCheck) — a template that crashes on canonical request shapes must not ship")
+        case nil:
+            throw ValidationError(
+                "render self-check found no usable template in the artifacts dir — the extracted template is empty or whitespace-only")
+        }
+
+        // 4) New manifest = old per-file digests + the new template file;
+        // aggregate recomputed digests-only, r2_prefix derived canonically.
+        let role = ModelScanner.roleFor(filename: TemplateExtraction.templateFilename)
+        let templateSHA = SHA256.hash(data: templateData)
+            .map { String(format: "%02x", $0) }.joined()
+        let templateFile = ManifestFile(
+            path: TemplateExtraction.templateFilename,
+            sizeBytes: Int64(templateData.count),
+            sha256: templateSHA,
+            role: role
+        )
+        let newManifest = try TemplateExtraction.buildRepublishManifest(
+            oldManifest: oldManifest,
+            newVersion: newVersion,
+            templateFile: templateFile
+        )
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys, .prettyPrinted]
+        encoder.dateEncodingStrategy = .iso8601
+        try writeCreatingParentDirectory(
+            try encoder.encode(newManifest), to: URL(fileURLWithPath: output))
+
+        if !TemplateExtraction.oldPrefixMatchesDerivation(oldManifest) {
+            FileHandle.standardError.write(Data("""
+                warning: old manifest r2_prefix (\(oldManifest.r2Prefix)) does not match today's \
+                derivation for \(oldManifest.modelID)/\(oldManifest.version) — server-side copies \
+                must use the OLD prefix as recorded, not a re-derived one\n
+                """.utf8))
+        }
+
+        print("""
+            Republish manifest built.
+              model_id:   \(newManifest.modelID)
+              version:    \(oldManifest.version)  ->  \(newManifest.version)
+              r2_prefix:  \(oldManifest.r2Prefix)  ->  \(newManifest.r2Prefix)
+              added file: \(TemplateExtraction.templateFilename) (role \(role), \(templateFile.sizeBytes) bytes)
+                sha256:   \(templateSHA)
+              aggregate:  \(oldManifest.aggregateSHA256)
+                      ->  \(newManifest.aggregateSHA256)
+              files:      \(oldManifest.fileCount) -> \(newManifest.fileCount), \
+            total \(oldManifest.totalSizeBytes) -> \(newManifest.totalSizeBytes) bytes
+              template:   \(templateOutputURL.path)
+              manifest:   \(URL(fileURLWithPath: output).path)
+            """)
+    }
+
+    private func writeCreatingParentDirectory(_ data: Data, to url: URL) throws {
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try data.write(to: url)
+    }
+}

--- a/provider-swift/Sources/darkbloom-publish/TemplateExtraction.swift
+++ b/provider-swift/Sources/darkbloom-publish/TemplateExtraction.swift
@@ -99,6 +99,10 @@ enum TemplateExtraction {
             guard isLowerSHA256Hex(file.sha256) else {
                 throw Error.invalidManifestFileDigest(path: file.path)
             }
+            guard file.sizeBytes >= 0 else {
+                throw Error.inconsistentManifest(
+                    "negative size_bytes for \(file.path)")
+            }
         }
         guard manifest.fileCount == manifest.files.count else {
             throw Error.inconsistentManifest(

--- a/provider-swift/Sources/darkbloom-publish/TemplateExtraction.swift
+++ b/provider-swift/Sources/darkbloom-publish/TemplateExtraction.swift
@@ -1,0 +1,223 @@
+import Crypto
+import Foundation
+import ProviderCoreFoundation
+
+/// Pure logic for the `extract-template` republish flow: pull the chat
+/// template out of a tokenizer_config.json, validate it is safe to republish,
+/// and derive a new manifest version from an old manifest's per-file digests
+/// plus the extracted template file — without ever reading weight bytes.
+///
+/// Kept IO-free so DarkbloomPublishTests can exercise every branch; the
+/// command (`ExtractTemplateCommand`) does the file reads/writes.
+enum TemplateExtraction {
+
+    /// The standalone template filename `PromptContractIdentity` requires.
+    static let templateFilename = "chat_template.jinja"
+
+    enum Error: Swift.Error, CustomStringConvertible, Equatable {
+        case manifestAlreadyHasTemplate(modelID: String)
+        case unsupportedSchemaVersion(Int)
+        case invalidModelID(String)
+        case invalidManifestFilePath(String)
+        case duplicateManifestFilePath(String)
+        case invalidManifestFileDigest(path: String)
+        case inconsistentManifest(String)
+        case tokenizerConfigNotJSONObject
+        case chatTemplateKeyMissing
+        case chatTemplateEmpty
+        case chatTemplateArrayWithoutDefault
+        case chatTemplateUnsupportedShape
+        case dynamicDateTemplate
+        case aggregateComputationFailed
+
+        var description: String {
+            switch self {
+            case .manifestAlreadyHasTemplate(let modelID):
+                return "model \(modelID) already has a standalone \(templateFilename) in its manifest — nothing to republish"
+            case .unsupportedSchemaVersion(let v):
+                return "unsupported manifest schema_version \(v) (expected \(ManifestBuilder.schemaVersion))"
+            case .invalidModelID(let reason):
+                return "old manifest model_id is invalid: \(reason)"
+            case .invalidManifestFilePath(let path):
+                return "old manifest file path \(path) is invalid (must be a clean relative POSIX path)"
+            case .duplicateManifestFilePath(let path):
+                return "old manifest file path \(path) is duplicated (case-insensitive)"
+            case .invalidManifestFileDigest(let path):
+                return "old manifest file \(path) has an invalid sha256 (must be 64 lowercase hex characters)"
+            case .inconsistentManifest(let reason):
+                return "old manifest is internally inconsistent (\(reason)) — refusing to derive a new version from it"
+            case .tokenizerConfigNotJSONObject:
+                return "tokenizer_config.json is not a JSON object"
+            case .chatTemplateKeyMissing:
+                return "tokenizer_config.json has no \"chat_template\" key — nothing to extract"
+            case .chatTemplateEmpty:
+                return "tokenizer_config.json \"chat_template\" is empty"
+            case .chatTemplateArrayWithoutDefault:
+                return "tokenizer_config.json \"chat_template\" is a template list without a \"default\" entry"
+            case .chatTemplateUnsupportedShape:
+                return "tokenizer_config.json \"chat_template\" is neither a string nor a [{name, template}] list"
+            case .dynamicDateTemplate:
+                return "template contains strftime_now — dynamic-date templates cannot produce deterministic prompt contracts and must not be republished"
+            case .aggregateComputationFailed:
+                return "failed to recompute the aggregate hash from per-file digests"
+            }
+        }
+    }
+
+    // MARK: - Old-manifest validation
+
+    /// Reject manifests the republish flow cannot or must not process: wrong
+    /// schema, an existing standalone template entry, per-file digests the
+    /// coordinator would reject (non-lowercase / non-hex), or internal
+    /// inconsistency (aggregate / file_count / total_size not matching the
+    /// file list — the same checks the coordinator runs on register). The new
+    /// manifest is derived purely from these digests, so garbage in must not
+    /// become a registered version.
+    static func validateOldManifest(_ manifest: ModelManifest) throws {
+        guard manifest.schemaVersion == ManifestBuilder.schemaVersion else {
+            throw Error.unsupportedSchemaVersion(manifest.schemaVersion)
+        }
+        do {
+            try ManifestBuilder.validateModelID(manifest.modelID)
+        } catch let ManifestBuilder.Error.invalidModelID(_, reason) {
+            throw Error.invalidModelID(reason)
+        }
+        // Case-insensitive, like the coordinator's duplicate-path check — a
+        // manifest carrying any casing of chat_template.jinja would collide
+        // with the file this flow adds.
+        if manifest.files.contains(where: { $0.path.lowercased() == templateFilename }) {
+            throw Error.manifestAlreadyHasTemplate(modelID: manifest.modelID)
+        }
+        var seenPaths = Set<String>()
+        for file in manifest.files {
+            guard isValidRelativePath(file.path) else {
+                throw Error.invalidManifestFilePath(file.path)
+            }
+            guard seenPaths.insert(file.path.lowercased()).inserted else {
+                throw Error.duplicateManifestFilePath(file.path)
+            }
+            guard isLowerSHA256Hex(file.sha256) else {
+                throw Error.invalidManifestFileDigest(path: file.path)
+            }
+        }
+        guard manifest.fileCount == manifest.files.count else {
+            throw Error.inconsistentManifest(
+                "file_count \(manifest.fileCount) != files length \(manifest.files.count)")
+        }
+        let totalSize = manifest.files.reduce(Int64(0)) { $0 + $1.sizeBytes }
+        guard manifest.totalSizeBytes == totalSize else {
+            throw Error.inconsistentManifest(
+                "total_size_bytes \(manifest.totalSizeBytes) != files sum \(totalSize)")
+        }
+        guard let aggregate = WeightHasher.aggregateFromDigests(
+            manifest.files.map { (path: $0.path, sha256Hex: $0.sha256) }
+        ), aggregate == manifest.aggregateSHA256 else {
+            throw Error.inconsistentManifest("aggregate_sha256 does not match the per-file digests")
+        }
+    }
+
+    // MARK: - Template extraction
+
+    /// Extract the chat template string from tokenizer_config.json bytes.
+    ///
+    /// Handles both shapes the ecosystem produces:
+    /// - `"chat_template": "<template>"` (plain string), and
+    /// - `"chat_template": [{"name": ..., "template": ...}, ...]` (named
+    ///   list — the entry named "default" is taken; a list without one is an
+    ///   error rather than a guess).
+    ///
+    /// The returned string is the decoded template exactly as the JSON
+    /// decoder unescapes it (\n, \", \uXXXX handled); callers write it as
+    /// UTF-8 with no added trailing newline so the standalone file is
+    /// byte-exact.
+    static func extractTemplate(fromTokenizerConfig data: Data) throws -> String {
+        guard let json = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any] else {
+            throw Error.tokenizerConfigNotJSONObject
+        }
+        guard let value = json["chat_template"] else {
+            throw Error.chatTemplateKeyMissing
+        }
+        if let template = value as? String {
+            guard !template.isEmpty else { throw Error.chatTemplateEmpty }
+            return template
+        }
+        if let entries = value as? [Any] {
+            for entry in entries {
+                guard let dict = entry as? [String: Any] else { continue }
+                if dict["name"] as? String == "default", let template = dict["template"] as? String {
+                    guard !template.isEmpty else { throw Error.chatTemplateEmpty }
+                    return template
+                }
+            }
+            throw Error.chatTemplateArrayWithoutDefault
+        }
+        throw Error.chatTemplateUnsupportedShape
+    }
+
+    /// Templates that read the wall clock render differently on every day,
+    /// so their prompt contract is not deterministic — refuse to republish.
+    static func validateDeterministic(template: String) throws {
+        if template.contains("strftime_now") {
+            throw Error.dynamicDateTemplate
+        }
+    }
+
+    // MARK: - New-manifest derivation
+
+    /// Build the republished manifest: same model id, old files plus the new
+    /// template entry, new version, the canonical r2_prefix for that version
+    /// (same derivation as `ManifestBuilder.build` and the coordinator's
+    /// `modelR2Prefix`), and the aggregate recomputed from per-file digests
+    /// only.
+    static func buildRepublishManifest(
+        oldManifest: ModelManifest,
+        newVersion: String,
+        templateFile: ManifestFile
+    ) throws -> ModelManifest {
+        var files = oldManifest.files + [templateFile]
+        files.sort {
+            if $0.path != $1.path { return $0.path < $1.path }
+            return $0.sha256 < $1.sha256
+        }
+
+        guard let aggregate = WeightHasher.aggregateFromDigests(
+            files.map { (path: $0.path, sha256Hex: $0.sha256) }
+        ) else {
+            throw Error.aggregateComputationFailed
+        }
+
+        let r2Prefix = "v2/\(ManifestBuilder.safeModelID(oldManifest.modelID))/\(newVersion)"
+
+        return ModelManifest(
+            schemaVersion: ManifestBuilder.schemaVersion,
+            modelID: oldManifest.modelID,
+            version: newVersion,
+            r2Prefix: r2Prefix,
+            aggregateSHA256: aggregate,
+            totalSizeBytes: files.reduce(0) { $0 + $1.sizeBytes },
+            fileCount: files.count,
+            files: files,
+            createdAt: Date()
+        )
+    }
+
+    /// Whether the old manifest's r2_prefix still matches today's derivation
+    /// for its own (model id, version). A mismatch is not fatal — the new
+    /// prefix is derived independently and is what the coordinator will
+    /// expect — but it is surprising enough to surface to the operator.
+    static func oldPrefixMatchesDerivation(_ manifest: ModelManifest) -> Bool {
+        manifest.r2Prefix == "v2/\(ManifestBuilder.safeModelID(manifest.modelID))/\(manifest.version)"
+    }
+
+    private static func isLowerSHA256Hex(_ value: String) -> Bool {
+        value.count == 64 && value.allSatisfy { ("0" ... "9").contains($0) || ("a" ... "f").contains($0) }
+    }
+
+    /// Mirror of the coordinator's `validManifestRelativePath`: non-empty,
+    /// relative, forward-slash separated, no empty / "." / ".." segments.
+    private static func isValidRelativePath(_ path: String) -> Bool {
+        guard !path.isEmpty, !path.hasPrefix("/"), !path.contains("\\") else { return false }
+        return path.split(separator: "/", omittingEmptySubsequences: false)
+            .allSatisfy { !$0.isEmpty && $0 != "." && $0 != ".." }
+    }
+}

--- a/provider-swift/Tests/DarkbloomPublishTests/AggregateFromDigestsTests.swift
+++ b/provider-swift/Tests/DarkbloomPublishTests/AggregateFromDigestsTests.swift
@@ -1,0 +1,89 @@
+import XCTest
+import Foundation
+import ProviderCoreFoundation
+
+/// Parity and pinning for `WeightHasher.aggregateFromDigests` — the
+/// digests-only aggregate used by the republish flow. It must be
+/// byte-identical to `WeightHasher.hashFilesWithRelativeKey` (which reads
+/// file bytes) and to the Go coordinator's `aggregateManifestFileHashes`
+/// (which validates every registered manifest).
+final class AggregateFromDigestsTests: XCTestCase {
+
+    private func makeTempDir() throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("agg-digests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: dir) }
+        return dir
+    }
+
+    /// Build the aggregate two ways over the same real files — streaming the
+    /// bytes (hashFilesWithRelativeKey) vs combining known digests
+    /// (aggregateFromDigests) — and require identical output.
+    func testParityWithHashFilesWithRelativeKey() throws {
+        let dir = try makeTempDir()
+        let contents: [String: Data] = [
+            "config.json": Data("{\"a\":1}".utf8),
+            "tokenizer.json": Data(repeating: 0x7F, count: 4096),
+            "adapters/lora.safetensors": Data(repeating: 0xC3, count: 999),
+            "model-00001-of-00002.safetensors": Data(repeating: 0xAA, count: 65536 * 2 + 17),
+            "model-00002-of-00002.safetensors": Data(),
+        ]
+        var keyed: [(file: URL, sortKey: String)] = []
+        var digests: [(path: String, sha256Hex: String)] = []
+        for (relPath, data) in contents {
+            let url = dir.appendingPathComponent(relPath)
+            try FileManager.default.createDirectory(
+                at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+            try data.write(to: url)
+            keyed.append((file: url, sortKey: relPath))
+            let digest = try XCTUnwrap(WeightHasher.hashSingleFile(at: url))
+            digests.append((path: relPath, sha256Hex: digest.map { String(format: "%02x", $0) }.joined()))
+        }
+
+        let fromBytes = try XCTUnwrap(WeightHasher.hashFilesWithRelativeKey(keyed))
+        let fromDigests = try XCTUnwrap(WeightHasher.aggregateFromDigests(digests))
+        XCTAssertEqual(fromBytes, fromDigests,
+                       "digests-only aggregate must be byte-identical to the streaming aggregate")
+        // Input order must not matter.
+        XCTAssertEqual(WeightHasher.aggregateFromDigests(digests.reversed()), fromDigests)
+    }
+
+    /// Fixed cross-language test vector. Same fixture as
+    /// ProviderCoreFoundationTests/GoldenVectorTest (files "a", "bb", "ccc")
+    /// so the digests-only helper, ManifestBuilder, and the Go coordinator's
+    /// aggregateManifestFileHashes are all pinned to one expected aggregate:
+    ///
+    ///   sorted by path, concat raw 32-byte digests, SHA-256:
+    ///   5b658afdbc19cde3b9ede40aabd9364369a75c79f6baca3f08ff5e443e058900
+    func testPinnedCrossLanguageVector() {
+        // Deliberately unsorted input — sorting is part of the contract.
+        let digests: [(path: String, sha256Hex: String)] = [
+            (path: "tokenizer.json",
+             sha256Hex: "3b64db95cb55c763391c707108489ae18b4112d783300de38e033b4c98c3deaf"),
+            (path: "config.json",
+             sha256Hex: "ca978112ca1bbdcafac231b39a23dc4da786eff8147c4e72b9807785afee48bb"),
+            (path: "model.safetensors",
+             sha256Hex: "64daa44ad493ff28a96effab6e77f1732a3d97d83241581b37dbd70a7a4900fe"),
+        ]
+        XCTAssertEqual(
+            WeightHasher.aggregateFromDigests(digests),
+            "5b658afdbc19cde3b9ede40aabd9364369a75c79f6baca3f08ff5e443e058900",
+            "Aggregate drift — the digests-only helper no longer matches the pinned Go/Swift vector.")
+    }
+
+    func testInvalidDigestsReturnNil() {
+        XCTAssertNil(WeightHasher.aggregateFromDigests([(path: "a", sha256Hex: "abc")]),
+                     "short digest must be rejected")
+        XCTAssertNil(WeightHasher.aggregateFromDigests([
+            (path: "a", sha256Hex: String(repeating: "zz", count: 32))
+        ]), "non-hex digest must be rejected")
+    }
+
+    func testEmptyInputMatchesEmptySHA256() {
+        // SHA-256 of zero bytes — same as Go's h.Sum(nil) over no writes.
+        XCTAssertEqual(
+            WeightHasher.aggregateFromDigests([]),
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
+    }
+}

--- a/provider-swift/Tests/DarkbloomPublishTests/ExtractTemplateCommandTests.swift
+++ b/provider-swift/Tests/DarkbloomPublishTests/ExtractTemplateCommandTests.swift
@@ -144,6 +144,19 @@ final class ExtractTemplateCommandTests: XCTestCase {
                        "extracted template must be byte-exact after UTF-8 encoding")
     }
 
+    func testExtractSurrogatePairsAndCombiningMarksExactBytes() throws {
+        // \ud83d\ude00 is the UTF-16 surrogate pair for U+1F600 (😀, UTF-8
+        // F0 9F 98 80); "e\u0301" is decomposed e + COMBINING ACUTE ACCENT and
+        // must survive WITHOUT NFC normalization (65 CC 81, not C3 A9).
+        let json = #"{"chat_template": "hi \ud83d\ude00 e\u0301"}"#
+        let template = try TemplateExtraction.extractTemplate(
+            fromTokenizerConfig: Data(json.utf8))
+        XCTAssertEqual(
+            [UInt8](Data(template.utf8)),
+            [0x68, 0x69, 0x20, 0xF0, 0x9F, 0x98, 0x80, 0x20, 0x65, 0xCC, 0x81],
+            "surrogate pairs must decode to exact UTF-8 and combining marks must not be normalized")
+    }
+
     func testExtractArrayFormTakesDefaultEntry() throws {
         // "default" is deliberately NOT the first entry.
         let json = """
@@ -280,6 +293,20 @@ final class ExtractTemplateCommandTests: XCTestCase {
         XCTAssertThrowsError(try TemplateExtraction.validateOldManifest(badTotal))
 
         XCTAssertNoThrow(try TemplateExtraction.validateOldManifest(good))
+    }
+
+    func testNegativeManifestFileSizeIsRejected() {
+        // Mirror of the coordinator's validateManifestFile size check: a
+        // negative size would otherwise flow into the new manifest's totals.
+        let old = makeOldManifest(extraFiles: [
+            ManifestFile(path: "vocab.json", sizeBytes: -1,
+                         sha256: String(repeating: "8c", count: 32), role: "tokenizer")
+        ])
+        XCTAssertThrowsError(try TemplateExtraction.validateOldManifest(old)) { error in
+            guard case .inconsistentManifest? = error as? TemplateExtraction.Error else {
+                return XCTFail("expected inconsistentManifest, got \(error)")
+            }
+        }
     }
 
     func testUppercaseManifestDigestIsRejected() {

--- a/provider-swift/Tests/DarkbloomPublishTests/ExtractTemplateCommandTests.swift
+++ b/provider-swift/Tests/DarkbloomPublishTests/ExtractTemplateCommandTests.swift
@@ -1,0 +1,463 @@
+import XCTest
+import Crypto
+import Foundation
+import ProviderCoreFoundation
+@testable import darkbloom_publish
+
+/// Coverage for the `darkbloom-publish extract-template` republish flow:
+/// golden byte-exact extraction from both tokenizer_config shapes, the
+/// rejection gates (strftime_now, already-has-template, missing key, list
+/// without default), and the full-command integration including the
+/// TemplateRenderCheck gate and digests-only manifest derivation.
+final class ExtractTemplateCommandTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    /// Healthy ChatML-style template (mirrors TemplateRenderCheckTests) —
+    /// renders every canonical fixture for a text-only model.
+    private let chatMLTemplate = """
+        {%- for message in messages -%}
+        {{ '<|im_start|>' + message['role'] + '\\n' + message['content'] + '<|im_end|>\\n' }}
+        {%- endfor -%}
+        {%- if add_generation_prompt -%}{{ '<|im_start|>assistant\\n' }}{%- endif -%}
+        """
+
+    /// Incident-class template (mirrors TemplateRenderCheckTests): compiles,
+    /// renders plain chats, but crashes while declaring tools — must be
+    /// caught by the render self-check gate.
+    private let incidentClassTemplate = """
+        {%- if tools -%}
+            {%- for tool in tools -%}
+                {{ tool['function']['response']['type'] | upper }}
+            {%- endfor -%}
+        {%- endif -%}
+        {%- for message in messages -%}
+            {%- if message['content'] is string -%}{{ message['role'] }}: {{ message['content'] }}
+            {%- endif -%}
+        {%- endfor -%}
+        """
+
+    private let textConfigJSON = #"{"model_type": "qwen3"}"#
+
+    /// Raw tokenizer_config JSON exercising JSON escapes: \n, \", \t, a
+    /// unicode escape (\u00e9 = é), and a literal multi-byte character.
+    private let escapedTokenizerConfigJSON = """
+        {"bos_token": "<s>", "chat_template": "{{ bos_token }}caf\\u00e9 says \\"hi\\"\\nline2\\ttab ✓"}
+        """
+
+    /// The exact decoded template string the escaped fixture must produce.
+    private let escapedTemplateExpected = "{{ bos_token }}café says \"hi\"\nline2\ttab ✓"
+
+    // MARK: - Helpers
+
+    private func makeTempDir(_ label: String) throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("extract-template-\(label)-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: dir) }
+        return dir
+    }
+
+    private func sha256Hex(_ data: Data) -> String {
+        SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+    }
+
+    /// A realistic old manifest: config/tokenizer artifacts plus two weight
+    /// shards that will never exist on local disk (digests-only derivation).
+    private func makeOldManifest(
+        modelID: String = "mlx-community/test-model",
+        version: String = "2026-05-25-r1",
+        extraFiles: [ManifestFile] = []
+    ) -> ModelManifest {
+        var files = [
+            ManifestFile(path: "config.json", sizeBytes: 100,
+                         sha256: String(repeating: "1a", count: 32), role: "config"),
+            ManifestFile(path: "model-00001-of-00002.safetensors", sizeBytes: 5_000_000_000,
+                         sha256: String(repeating: "2b", count: 32), role: "weight"),
+            ManifestFile(path: "model-00002-of-00002.safetensors", sizeBytes: 4_000_000_000,
+                         sha256: String(repeating: "3c", count: 32), role: "weight"),
+            ManifestFile(path: "tokenizer.json", sizeBytes: 2000,
+                         sha256: String(repeating: "4d", count: 32), role: "tokenizer"),
+            ManifestFile(path: "tokenizer_config.json", sizeBytes: 300,
+                         sha256: String(repeating: "5e", count: 32), role: "tokenizer"),
+        ] + extraFiles
+        files.sort { $0.path < $1.path }
+        let aggregate = WeightHasher.aggregateFromDigests(
+            files.map { (path: $0.path, sha256Hex: $0.sha256) })!
+        return ModelManifest(
+            schemaVersion: 1,
+            modelID: modelID,
+            version: version,
+            r2Prefix: "v2/\(ManifestBuilder.safeModelID(modelID))/\(version)",
+            aggregateSHA256: aggregate,
+            totalSizeBytes: files.reduce(0) { $0 + $1.sizeBytes },
+            fileCount: files.count,
+            files: files,
+            createdAt: Date(timeIntervalSince1970: 1_750_000_000)
+        )
+    }
+
+    private func writeManifest(_ manifest: ModelManifest, to dir: URL) throws -> URL {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys, .prettyPrinted]
+        encoder.dateEncodingStrategy = .iso8601
+        let url = dir.appendingPathComponent("manifest.old.json")
+        try encoder.encode(manifest).write(to: url)
+        return url
+    }
+
+    /// Run the full command against an artifacts dir + old manifest; returns
+    /// the decoded new manifest and the paths of the written outputs.
+    @discardableResult
+    private func runCommand(
+        oldManifest: ModelManifest,
+        artifactsDir: URL,
+        newVersion: String = "2026-07-23-r2"
+    ) async throws -> (manifest: ModelManifest, templateOut: URL, manifestOut: URL) {
+        let workDir = try makeTempDir("out")
+        let manifestURL = try writeManifest(oldManifest, to: workDir)
+        let templateOut = workDir.appendingPathComponent("chat_template.jinja")
+        let manifestOut = workDir.appendingPathComponent("manifest.new.json")
+
+        var cmd = try ExtractTemplateCommand.parse([
+            "--manifest", manifestURL.path,
+            "--artifacts-dir", artifactsDir.path,
+            "--new-version", newVersion,
+            "--output", manifestOut.path,
+            "--template-output", templateOut.path,
+        ])
+        try await cmd.run()
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let newManifest = try decoder.decode(ModelManifest.self, from: Data(contentsOf: manifestOut))
+        return (newManifest, templateOut, manifestOut)
+    }
+
+    // MARK: - Golden extraction (pure)
+
+    func testExtractStringFormExactBytes() throws {
+        let template = try TemplateExtraction.extractTemplate(
+            fromTokenizerConfig: Data(escapedTokenizerConfigJSON.utf8))
+        XCTAssertEqual(template, escapedTemplateExpected)
+        XCTAssertEqual(Data(template.utf8), Data(escapedTemplateExpected.utf8),
+                       "extracted template must be byte-exact after UTF-8 encoding")
+    }
+
+    func testExtractArrayFormTakesDefaultEntry() throws {
+        // "default" is deliberately NOT the first entry.
+        let json = """
+            {"chat_template": [
+                {"name": "tool_use", "template": "TOOL-TEMPLATE"},
+                {"name": "default", "template": "caf\\u00e9 \\"quoted\\"\\nDEFAULT-TEMPLATE"}
+            ]}
+            """
+        let template = try TemplateExtraction.extractTemplate(fromTokenizerConfig: Data(json.utf8))
+        XCTAssertEqual(template, "café \"quoted\"\nDEFAULT-TEMPLATE")
+    }
+
+    func testExtractArrayWithoutDefaultIsRejected() {
+        let json = #"{"chat_template": [{"name": "tool_use", "template": "T"}]}"#
+        XCTAssertThrowsError(
+            try TemplateExtraction.extractTemplate(fromTokenizerConfig: Data(json.utf8))
+        ) { error in
+            XCTAssertEqual(error as? TemplateExtraction.Error, .chatTemplateArrayWithoutDefault)
+        }
+    }
+
+    func testExtractMissingChatTemplateKeyIsRejected() {
+        let json = #"{"bos_token": "<s>"}"#
+        XCTAssertThrowsError(
+            try TemplateExtraction.extractTemplate(fromTokenizerConfig: Data(json.utf8))
+        ) { error in
+            XCTAssertEqual(error as? TemplateExtraction.Error, .chatTemplateKeyMissing)
+        }
+    }
+
+    func testExtractEmptyTemplateIsRejected() {
+        XCTAssertThrowsError(
+            try TemplateExtraction.extractTemplate(
+                fromTokenizerConfig: Data(#"{"chat_template": ""}"#.utf8))
+        ) { error in
+            XCTAssertEqual(error as? TemplateExtraction.Error, .chatTemplateEmpty)
+        }
+    }
+
+    func testExtractUnsupportedShapeIsRejected() {
+        XCTAssertThrowsError(
+            try TemplateExtraction.extractTemplate(
+                fromTokenizerConfig: Data(#"{"chat_template": 42}"#.utf8))
+        ) { error in
+            XCTAssertEqual(error as? TemplateExtraction.Error, .chatTemplateUnsupportedShape)
+        }
+    }
+
+    // MARK: - Rejection gates (pure)
+
+    func testStrftimeNowIsRejected() {
+        XCTAssertThrowsError(
+            try TemplateExtraction.validateDeterministic(
+                template: #"{{ strftime_now("%Y-%m-%d") }} rest of template"#)
+        ) { error in
+            XCTAssertEqual(error as? TemplateExtraction.Error, .dynamicDateTemplate)
+        }
+        XCTAssertNoThrow(try TemplateExtraction.validateDeterministic(template: chatMLTemplate))
+    }
+
+    func testManifestAlreadyHasTemplateIsRejected() {
+        let old = makeOldManifest(extraFiles: [
+            ManifestFile(path: "chat_template.jinja", sizeBytes: 10,
+                         sha256: String(repeating: "6f", count: 32), role: "template")
+        ])
+        XCTAssertThrowsError(try TemplateExtraction.validateOldManifest(old)) { error in
+            XCTAssertEqual(
+                error as? TemplateExtraction.Error,
+                .manifestAlreadyHasTemplate(modelID: "mlx-community/test-model"))
+        }
+
+        // Case-insensitive, like the coordinator's duplicate-path check.
+        let mixedCase = makeOldManifest(extraFiles: [
+            ManifestFile(path: "Chat_Template.jinja", sizeBytes: 10,
+                         sha256: String(repeating: "6f", count: 32), role: "other")
+        ])
+        XCTAssertThrowsError(try TemplateExtraction.validateOldManifest(mixedCase)) { error in
+            XCTAssertEqual(
+                error as? TemplateExtraction.Error,
+                .manifestAlreadyHasTemplate(modelID: "mlx-community/test-model"))
+        }
+    }
+
+    func testTraversalAndDuplicatePathsAreRejected() {
+        let traversal = makeOldManifest(extraFiles: [
+            ManifestFile(path: "../escape.json", sizeBytes: 1,
+                         sha256: String(repeating: "7a", count: 32), role: "other")
+        ])
+        XCTAssertThrowsError(try TemplateExtraction.validateOldManifest(traversal)) { error in
+            XCTAssertEqual(
+                error as? TemplateExtraction.Error, .invalidManifestFilePath("../escape.json"))
+        }
+
+        let duplicate = makeOldManifest(extraFiles: [
+            ManifestFile(path: "CONFIG.json", sizeBytes: 1,
+                         sha256: String(repeating: "8b", count: 32), role: "other")
+        ])
+        XCTAssertThrowsError(try TemplateExtraction.validateOldManifest(duplicate)) { error in
+            guard case .duplicateManifestFilePath? = error as? TemplateExtraction.Error else {
+                return XCTFail("expected duplicateManifestFilePath, got \(error)")
+            }
+        }
+    }
+
+    func testInternallyInconsistentManifestIsRejected() {
+        // Same digest-trust rationale as the coordinator's register checks:
+        // a manifest whose aggregate/total/count don't match its own file
+        // list must never seed a new version.
+        let good = makeOldManifest()
+
+        let badAggregate = ModelManifest(
+            schemaVersion: good.schemaVersion, modelID: good.modelID, version: good.version,
+            r2Prefix: good.r2Prefix, aggregateSHA256: String(repeating: "9", count: 64),
+            totalSizeBytes: good.totalSizeBytes, fileCount: good.fileCount,
+            files: good.files, createdAt: good.createdAt)
+        XCTAssertThrowsError(try TemplateExtraction.validateOldManifest(badAggregate)) { error in
+            guard case .inconsistentManifest? = error as? TemplateExtraction.Error else {
+                return XCTFail("expected inconsistentManifest, got \(error)")
+            }
+        }
+
+        let badCount = ModelManifest(
+            schemaVersion: good.schemaVersion, modelID: good.modelID, version: good.version,
+            r2Prefix: good.r2Prefix, aggregateSHA256: good.aggregateSHA256,
+            totalSizeBytes: good.totalSizeBytes, fileCount: good.fileCount + 1,
+            files: good.files, createdAt: good.createdAt)
+        XCTAssertThrowsError(try TemplateExtraction.validateOldManifest(badCount))
+
+        let badTotal = ModelManifest(
+            schemaVersion: good.schemaVersion, modelID: good.modelID, version: good.version,
+            r2Prefix: good.r2Prefix, aggregateSHA256: good.aggregateSHA256,
+            totalSizeBytes: good.totalSizeBytes + 1, fileCount: good.fileCount,
+            files: good.files, createdAt: good.createdAt)
+        XCTAssertThrowsError(try TemplateExtraction.validateOldManifest(badTotal))
+
+        XCTAssertNoThrow(try TemplateExtraction.validateOldManifest(good))
+    }
+
+    func testUppercaseManifestDigestIsRejected() {
+        let old = makeOldManifest(extraFiles: [
+            ManifestFile(path: "vocab.json", sizeBytes: 10,
+                         sha256: String(repeating: "AB", count: 32), role: "tokenizer")
+        ])
+        XCTAssertThrowsError(try TemplateExtraction.validateOldManifest(old)) { error in
+            XCTAssertEqual(
+                error as? TemplateExtraction.Error,
+                .invalidManifestFileDigest(path: "vocab.json"))
+        }
+    }
+
+    // MARK: - Role classification (task requirement)
+
+    func testChatTemplateJinjaRoleIsTemplate() {
+        XCTAssertEqual(ModelScanner.roleFor(filename: "chat_template.jinja"), "template")
+    }
+
+    // MARK: - Full-command integration
+
+    func testCommandHappyPathBuildsRepublishManifest() async throws {
+        let artifacts = try makeTempDir("artifacts")
+        try Data(escapedTokenizerConfigJSON.utf8)
+            .write(to: artifacts.appendingPathComponent("tokenizer_config.json"))
+        try Data(textConfigJSON.utf8).write(to: artifacts.appendingPathComponent("config.json"))
+
+        let old = makeOldManifest()
+        let (new, templateOut, _) = try await runCommand(oldManifest: old, artifactsDir: artifacts)
+
+        // Written template is byte-exact — decoded escapes, no trailing newline.
+        let writtenBytes = try Data(contentsOf: templateOut)
+        XCTAssertEqual(writtenBytes, Data(escapedTemplateExpected.utf8))
+        // ... and mirrored into the artifacts dir for the render check.
+        XCTAssertEqual(
+            try Data(contentsOf: artifacts.appendingPathComponent("chat_template.jinja")),
+            Data(escapedTemplateExpected.utf8))
+
+        // Manifest identity: same model id, new version, canonical prefix.
+        XCTAssertEqual(new.schemaVersion, 1)
+        XCTAssertEqual(new.modelID, old.modelID)
+        XCTAssertEqual(new.version, "2026-07-23-r2")
+        XCTAssertEqual(
+            new.r2Prefix,
+            "v2/\(ManifestBuilder.safeModelID(old.modelID))/2026-07-23-r2")
+
+        // Files: old entries preserved verbatim + the new template entry.
+        XCTAssertEqual(new.fileCount, old.fileCount + 1)
+        XCTAssertEqual(new.files.count, new.fileCount)
+        let byPath = Dictionary(uniqueKeysWithValues: new.files.map { ($0.path, $0) })
+        for oldFile in old.files {
+            XCTAssertEqual(byPath[oldFile.path], oldFile, "old entry must be preserved: \(oldFile.path)")
+        }
+        let added = try XCTUnwrap(byPath["chat_template.jinja"])
+        XCTAssertEqual(added.role, "template")
+        XCTAssertEqual(added.sizeBytes, Int64(writtenBytes.count))
+        XCTAssertEqual(added.sha256, sha256Hex(writtenBytes))
+
+        // Manifest is sorted by path and internally consistent.
+        XCTAssertEqual(new.files.map(\.path), new.files.map(\.path).sorted())
+        XCTAssertEqual(new.totalSizeBytes, old.totalSizeBytes + Int64(writtenBytes.count))
+        XCTAssertEqual(
+            new.aggregateSHA256,
+            WeightHasher.aggregateFromDigests(new.files.map { (path: $0.path, sha256Hex: $0.sha256) }))
+        XCTAssertNotEqual(new.aggregateSHA256, old.aggregateSHA256)
+    }
+
+    func testCommandRejectsRenderCheckFailure() async throws {
+        // Incident-class template: compiles, crashes on the tool fixture —
+        // the render gate must refuse to ship it.
+        let artifacts = try makeTempDir("artifacts")
+        let config = try JSONSerialization.data(
+            withJSONObject: ["chat_template": incidentClassTemplate])
+        try config.write(to: artifacts.appendingPathComponent("tokenizer_config.json"))
+        try Data(textConfigJSON.utf8).write(to: artifacts.appendingPathComponent("config.json"))
+
+        do {
+            try await runCommand(oldManifest: makeOldManifest(), artifactsDir: artifacts)
+            XCTFail("expected render self-check rejection")
+        } catch {
+            XCTAssertTrue(
+                String(describing: error).contains("render self-check"),
+                "unexpected error: \(error)")
+        }
+    }
+
+    func testCommandRejectsManifestThatAlreadyHasTemplate() async throws {
+        let artifacts = try makeTempDir("artifacts")
+        try Data(escapedTokenizerConfigJSON.utf8)
+            .write(to: artifacts.appendingPathComponent("tokenizer_config.json"))
+        try Data(textConfigJSON.utf8).write(to: artifacts.appendingPathComponent("config.json"))
+
+        let old = makeOldManifest(extraFiles: [
+            ManifestFile(path: "chat_template.jinja", sizeBytes: 10,
+                         sha256: String(repeating: "6f", count: 32), role: "template")
+        ])
+        do {
+            try await runCommand(oldManifest: old, artifactsDir: artifacts)
+            XCTFail("expected already-has-template rejection")
+        } catch {
+            XCTAssertTrue(
+                String(describing: error).contains("already has a standalone"),
+                "unexpected error: \(error)")
+        }
+    }
+
+    func testCommandRejectsStrftimeNowTemplate() async throws {
+        let artifacts = try makeTempDir("artifacts")
+        let config = try JSONSerialization.data(withJSONObject: [
+            "chat_template": "{{ strftime_now(\"%Y-%m-%d\") }}\n" + chatMLTemplate
+        ])
+        try config.write(to: artifacts.appendingPathComponent("tokenizer_config.json"))
+        try Data(textConfigJSON.utf8).write(to: artifacts.appendingPathComponent("config.json"))
+
+        do {
+            try await runCommand(oldManifest: makeOldManifest(), artifactsDir: artifacts)
+            XCTFail("expected strftime_now rejection")
+        } catch {
+            XCTAssertTrue(
+                String(describing: error).contains("strftime_now"),
+                "unexpected error: \(error)")
+        }
+    }
+
+    func testCommandRejectsSameVersion() async throws {
+        let artifacts = try makeTempDir("artifacts")
+        try Data(escapedTokenizerConfigJSON.utf8)
+            .write(to: artifacts.appendingPathComponent("tokenizer_config.json"))
+        try Data(textConfigJSON.utf8).write(to: artifacts.appendingPathComponent("config.json"))
+
+        do {
+            try await runCommand(
+                oldManifest: makeOldManifest(version: "2026-07-23-r2"),
+                artifactsDir: artifacts,
+                newVersion: "2026-07-23-r2")
+            XCTFail("expected same-version rejection")
+        } catch {
+            XCTAssertTrue(
+                String(describing: error).contains("equals the old manifest version"),
+                "unexpected error: \(error)")
+        }
+    }
+
+    func testCommandRejectsInvalidNewVersion() throws {
+        let artifacts = try makeTempDir("artifacts")
+        for bad in ["a/b", "", "has space", "../up"] {
+            XCTAssertThrowsError(try {
+                var cmd = try ExtractTemplateCommand.parse([
+                    "--manifest", "/tmp/whatever.json",
+                    "--artifacts-dir", artifacts.path,
+                    "--new-version", bad,
+                    "--output", "/tmp/out.json",
+                    "--template-output", "/tmp/out.jinja",
+                ])
+                try cmd.validate()
+            }(), "version \(bad) must be rejected")
+        }
+    }
+
+    // MARK: - Render-check integration (task requirement)
+
+    func testExtractedTemplatePassesRenderCheckFixture() throws {
+        // Minimal valid artifacts dir (mirrors TemplateRenderCheckTests):
+        // extracted-template file + tokenizer_config + text config.json.
+        let artifacts = try makeTempDir("renderok")
+        let config = try JSONSerialization.data(withJSONObject: [
+            "bos_token": "<s>",
+            "chat_template": chatMLTemplate,
+        ])
+        try config.write(to: artifacts.appendingPathComponent("tokenizer_config.json"))
+        try Data(textConfigJSON.utf8).write(to: artifacts.appendingPathComponent("config.json"))
+
+        let template = try TemplateExtraction.extractTemplate(
+            fromTokenizerConfig: Data(contentsOf: artifacts.appendingPathComponent("tokenizer_config.json")))
+        XCTAssertEqual(template, chatMLTemplate)
+        try Data(template.utf8).write(to: artifacts.appendingPathComponent("chat_template.jinja"))
+
+        XCTAssertEqual(TemplateRenderCheck.renderOK(at: artifacts), true)
+    }
+}

--- a/scripts/republish-template.sh
+++ b/scripts/republish-template.sh
@@ -179,6 +179,13 @@ printf 'Skipping weight/large files entirely: %s (server-side copied later)\n' "
 
 DOWNLOADED=0
 while IFS=$'\t' read -r rel_path expected_sha; do
+  # Defense in depth: the Swift tool re-validates manifest paths, but this
+  # loop writes to disk first — never let a hostile manifest path escape the
+  # artifacts dir.
+  if [[ -z "$rel_path" || "$rel_path" == /* || "$rel_path" == *".."* || "$rel_path" == *"\\"* ]]; then
+    printf 'Refusing unsafe manifest path: %s\n' "$rel_path" >&2
+    exit 1
+  fi
   dest="$ARTIFACTS_DIR/$rel_path"
   mkdir -p "$(dirname "$dest")"
   printf 'Downloading %s\n' "$rel_path"

--- a/scripts/republish-template.sh
+++ b/scripts/republish-template.sh
@@ -87,6 +87,14 @@ if [[ -z "$MODEL_ID" ]]; then
   printf 'Model id is required.\n' >&2
   exit 1
 fi
+# Mirror ManifestBuilder.validateModelID: ASCII [A-Za-z0-9._/-] only, no
+# leading "/", no "..". Hostile ids otherwise die later at the catalog 404,
+# but validating here keeps every downstream URL/S3-key/printed-command use
+# trivially safe.
+if [[ ! "$MODEL_ID" =~ ^[A-Za-z0-9._/-]+$ || "$MODEL_ID" == /* || "$MODEL_ID" == *".."* ]]; then
+  printf 'Model id must use only [A-Za-z0-9._/-], not start with "/", and contain no "..": %s\n' "$MODEL_ID" >&2
+  exit 1
+fi
 # Mirror ManifestBuilder.validateVersion: non-empty, [A-Za-z0-9._-] only
 # (which excludes "/"), no "..".
 if [[ -z "$NEW_VERSION" || ! "$NEW_VERSION" =~ ^[A-Za-z0-9._-]+$ || "$NEW_VERSION" == *".."* ]]; then
@@ -117,7 +125,7 @@ fi
 # ---------------------------------------------------------------------------
 # 1) Catalog record -> current version + r2_prefix -> old manifest.
 # ---------------------------------------------------------------------------
-WORK_DIR="$(mktemp -d -t darkbloom-republish.XXXXXX)"
+WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/darkbloom-republish.XXXXXX")"
 ARTIFACTS_DIR="$WORK_DIR/artifacts"
 OLD_MANIFEST="$WORK_DIR/manifest.old.json"
 NEW_MANIFEST="$WORK_DIR/manifest.json"
@@ -174,8 +182,18 @@ while IFS=$'\t' read -r rel_path expected_sha; do
   dest="$ARTIFACTS_DIR/$rel_path"
   mkdir -p "$(dirname "$dest")"
   printf 'Downloading %s\n' "$rel_path"
-  curl -fsS "$MODEL_CDN_BASE_URL/$OLD_PREFIX/$rel_path" -o "$dest"
-  actual_sha="$(python3 -c 'import hashlib,sys; print(hashlib.sha256(open(sys.argv[1],"rb").read()).hexdigest())' "$dest")"
+  # --max-filesize enforces the small-artifact cap on the wire (the manifest's
+  # claimed size_bytes is only a filter); the hash streams in 1 MiB chunks so
+  # an oversized body can never be slurped into memory first.
+  curl -fsS --max-filesize "$MAX_ARTIFACT_BYTES" \
+    "$MODEL_CDN_BASE_URL/$OLD_PREFIX/$rel_path" -o "$dest"
+  actual_sha="$(python3 -c '
+import hashlib, sys
+h = hashlib.sha256()
+with open(sys.argv[1], "rb") as f:
+    for chunk in iter(lambda: f.read(1 << 20), b""):
+        h.update(chunk)
+print(h.hexdigest())' "$dest")"
   if [[ "$actual_sha" != "$expected_sha" ]]; then
     printf 'SHA-256 mismatch for %s: manifest %s, downloaded %s\n' "$rel_path" "$expected_sha" "$actual_sha" >&2
     exit 1
@@ -281,29 +299,36 @@ METADATA="$(jq -c '.metadata // {}' "$CATALOG_JSON")"
 INPUT_PRICE="$(curl -fsS "$COORDINATOR_URL/v1/pricing" 2>/dev/null | jq -r --arg m "$MODEL_ID" '.prices[]? | select(.model == $m) | .input_price' || true)"
 OUTPUT_PRICE="$(curl -fsS "$COORDINATOR_URL/v1/pricing" 2>/dev/null | jq -r --arg m "$MODEL_ID" '.prices[]? | select(.model == $m) | .output_price' || true)"
 
+# The printed command is destined for copy-paste with prod-write credentials.
+# Catalog-sourced free text (display name, description, metadata JSON) is NOT
+# charset-validated at registration, so every interpolated value is rendered
+# shell-safe with %q — a catalog field containing `"; rm ...` or a stray quote
+# pastes as an inert literal instead of executing.
+q() { printf '%q' "$1"; }
+
 cat <<EOF
 
 Next (human step) — register the new version, verify a provider converges,
 then promote:
 
   gh workflow run register-model.yml \\
-    -f model_id="$MODEL_ID" \\
-    -f version="$NEW_VERSION" \\
-    -f display_name="$DISPLAY_NAME" \\
-    -f family="$FAMILY" \\
-    -f architecture="$ARCHITECTURE" \\
-    -f quantization="$QUANTIZATION" \\
-    -f capabilities_csv="$CAPABILITIES_CSV" \\
-    -f max_context_length="$MAX_CONTEXT" \\
-    -f max_output_length="$MAX_OUTPUT" \\
-    -f min_ram_gb="$MIN_RAM_GB" \\
-    -f description="$DESCRIPTION" \\
-    -f runtime_parameters_json='$RUNTIME_PARAMS' \\
-    -f metadata_json='$METADATA' \\
-    -f input_price="${INPUT_PRICE:-<input_price micro-USD per 1M tokens>}" \\
-    -f output_price="${OUTPUT_PRICE:-<output_price micro-USD per 1M tokens>}" \\
-    -f promote="false" \\
-    -f coordinator_url="$COORDINATOR_URL"
+    -f model_id=$(q "$MODEL_ID") \\
+    -f version=$(q "$NEW_VERSION") \\
+    -f display_name=$(q "$DISPLAY_NAME") \\
+    -f family=$(q "$FAMILY") \\
+    -f architecture=$(q "$ARCHITECTURE") \\
+    -f quantization=$(q "$QUANTIZATION") \\
+    -f capabilities_csv=$(q "$CAPABILITIES_CSV") \\
+    -f max_context_length=$(q "$MAX_CONTEXT") \\
+    -f max_output_length=$(q "$MAX_OUTPUT") \\
+    -f min_ram_gb=$(q "$MIN_RAM_GB") \\
+    -f description=$(q "$DESCRIPTION") \\
+    -f runtime_parameters_json=$(q "$RUNTIME_PARAMS") \\
+    -f metadata_json=$(q "$METADATA") \\
+    -f input_price=$(q "${INPUT_PRICE:-<input_price micro-USD per 1M tokens>}") \\
+    -f output_price=$(q "${OUTPUT_PRICE:-<output_price micro-USD per 1M tokens>}") \\
+    -f promote=false \\
+    -f coordinator_url=$(q "$COORDINATOR_URL")
 
 Promotion (after verifying the registered version):
   POST $COORDINATOR_URL/v1/admin/models/$MODEL_ID/promote {"version": "$NEW_VERSION"}

--- a/scripts/republish-template.sh
+++ b/scripts/republish-template.sh
@@ -1,0 +1,316 @@
+#!/usr/bin/env bash
+# Republish a registry model as a NEW VERSION with its chat template extracted
+# into a standalone chat_template.jinja.
+#
+# Why: the provider's SSD prefix cache (PromptContractIdentity) hard-requires a
+# standalone chat_template.jinja in the model snapshot. Models published with
+# the template only embedded in tokenizer_config.json report cache_init_failed
+# on every slot. The fix is a new version of the same model id: identical
+# weight objects (server-side R2 copies, no bytes downloaded), plus the
+# extracted template file, plus a manifest whose aggregate is recomputed from
+# the old manifest's per-file digests.
+#
+# DEFAULT MODE IS DRY-RUN: fetches + local build only, prints the exact
+# commands that WOULD run. Pass --execute to arm the R2 copies and uploads.
+# Registration + promotion always stays a human step (the gh command is
+# printed, never run).
+#
+# The old prefix is never mutated and nothing is ever deleted.
+set -euo pipefail
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    printf 'Missing required command: %s\n' "$1" >&2
+    exit 1
+  fi
+}
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: republish-template.sh [MODEL_ID] [NEW_VERSION] [--dry-run|--execute]
+
+  MODEL_ID     registry model id (e.g. mlx-community/foo); prompted if omitted
+  NEW_VERSION  new version tag, no slashes (e.g. 2026-07-23-r2); prompted if omitted
+  --dry-run    (default) print the copy/upload/register commands without running them
+  --execute    perform the R2 server-side copies and uploads (registration stays manual)
+
+Environment:
+  COORDINATOR_URL       coordinator base URL   (default https://api.darkbloom.dev)
+  MODEL_CDN_BASE_URL    model CDN base URL     (default https://models.darkbloom.ai)
+  R2_BUCKET             R2 bucket              (default darkbloom-models)
+  R2_ACCOUNT_ID         Cloudflare account id  (required with --execute)
+  GCP_PROJECT           GCP project for Secret Manager (required with --execute)
+  R2_ACCESS_KEY_SECRET  Secret Manager name    (default darkbloom-r2-access-key-id)
+  R2_SECRET_KEY_SECRET  Secret Manager name    (default darkbloom-r2-secret-access-key)
+EOF
+  exit 1
+}
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+COORDINATOR_URL="${COORDINATOR_URL:-https://api.darkbloom.dev}"
+MODEL_CDN_BASE_URL="${MODEL_CDN_BASE_URL:-https://models.darkbloom.ai}"
+R2_ACCESS_KEY_SECRET="${R2_ACCESS_KEY_SECRET:-darkbloom-r2-access-key-id}"
+R2_SECRET_KEY_SECRET="${R2_SECRET_KEY_SECRET:-darkbloom-r2-secret-access-key}"
+R2_BUCKET="${R2_BUCKET:-darkbloom-models}"
+MAX_ARTIFACT_BYTES=100000000 # small-artifact cap; weights are never downloaded
+
+EXECUTE=0
+MODEL_ID=""
+NEW_VERSION=""
+for arg in "$@"; do
+  case "$arg" in
+    --execute) EXECUTE=1 ;;
+    --dry-run) EXECUTE=0 ;;
+    -h|--help) usage ;;
+    -*) printf 'Unknown flag: %s\n' "$arg" >&2; usage ;;
+    *)
+      if [[ -z "$MODEL_ID" ]]; then MODEL_ID="$arg"
+      elif [[ -z "$NEW_VERSION" ]]; then NEW_VERSION="$arg"
+      else printf 'Unexpected argument: %s\n' "$arg" >&2; usage
+      fi
+      ;;
+  esac
+done
+
+require_cmd curl
+require_cmd jq
+require_cmd swift
+require_cmd python3
+
+if [[ -z "$MODEL_ID" ]]; then
+  read -r -p "Model id (e.g. mlx-community/foo): " MODEL_ID
+fi
+if [[ -z "$NEW_VERSION" ]]; then
+  read -r -p "New version (no slashes, e.g. 2026-07-23-r2): " NEW_VERSION
+fi
+if [[ -z "$MODEL_ID" ]]; then
+  printf 'Model id is required.\n' >&2
+  exit 1
+fi
+# Mirror ManifestBuilder.validateVersion: non-empty, [A-Za-z0-9._-] only
+# (which excludes "/"), no "..".
+if [[ -z "$NEW_VERSION" || ! "$NEW_VERSION" =~ ^[A-Za-z0-9._-]+$ || "$NEW_VERSION" == *".."* ]]; then
+  printf 'New version must be non-empty, use only [A-Za-z0-9._-], and contain no "..": %s\n' "$NEW_VERSION" >&2
+  exit 1
+fi
+
+if [[ "$EXECUTE" == 1 ]]; then
+  require_cmd aws
+  require_cmd gcloud
+  if [[ -z "${GCP_PROJECT:-}" ]]; then
+    GCP_PROJECT="$(gcloud config get-value project 2>/dev/null || true)"
+  fi
+  if [[ -z "${GCP_PROJECT:-}" ]]; then
+    printf 'GCP_PROJECT is required or must be configured in gcloud.\n' >&2
+    exit 1
+  fi
+  if [[ -z "${R2_ACCOUNT_ID:-}" ]]; then
+    printf 'R2_ACCOUNT_ID is required with --execute.\n' >&2
+    exit 1
+  fi
+  R2_ENDPOINT="https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com"
+else
+  # Dry-run never needs credentials; show a placeholder endpoint if unset.
+  R2_ENDPOINT="https://${R2_ACCOUNT_ID:-<R2_ACCOUNT_ID>}.r2.cloudflarestorage.com"
+fi
+
+# ---------------------------------------------------------------------------
+# 1) Catalog record -> current version + r2_prefix -> old manifest.
+# ---------------------------------------------------------------------------
+WORK_DIR="$(mktemp -d -t darkbloom-republish.XXXXXX)"
+ARTIFACTS_DIR="$WORK_DIR/artifacts"
+OLD_MANIFEST="$WORK_DIR/manifest.old.json"
+NEW_MANIFEST="$WORK_DIR/manifest.json"
+TEMPLATE_FILE="$WORK_DIR/chat_template.jinja"
+mkdir -p "$ARTIFACTS_DIR"
+printf 'Working directory (kept for inspection): %s\n' "$WORK_DIR"
+
+CATALOG_URL="$COORDINATOR_URL/v1/models/catalog/$MODEL_ID"
+printf 'Fetching catalog record: %s\n' "$CATALOG_URL"
+CATALOG_JSON="$WORK_DIR/catalog.json"
+if ! curl -fsS "$CATALOG_URL" -o "$CATALOG_JSON"; then
+  printf 'Model %s not found in the coordinator catalog (%s).\n' "$MODEL_ID" "$CATALOG_URL" >&2
+  exit 1
+fi
+
+OLD_VERSION="$(jq -r '.version // empty' "$CATALOG_JSON")"
+OLD_PREFIX="$(jq -r '.r2_prefix // empty' "$CATALOG_JSON")"
+if [[ -z "$OLD_VERSION" || -z "$OLD_PREFIX" ]]; then
+  printf 'Catalog record for %s has no active version/r2_prefix — nothing to republish.\n' "$MODEL_ID" >&2
+  exit 1
+fi
+if [[ "$NEW_VERSION" == "$OLD_VERSION" ]]; then
+  printf 'New version %s equals the current active version — republishing onto the same prefix would mutate it. Pick a fresh version.\n' "$NEW_VERSION" >&2
+  exit 1
+fi
+printf 'Current active version: %s (prefix %s)\n' "$OLD_VERSION" "$OLD_PREFIX"
+
+printf 'Fetching old manifest: %s/%s/manifest.json\n' "$MODEL_CDN_BASE_URL" "$OLD_PREFIX"
+curl -fsS "$MODEL_CDN_BASE_URL/$OLD_PREFIX/manifest.json" -o "$OLD_MANIFEST"
+
+# The manifest must describe exactly what the catalog told us.
+jq -e --arg id "$MODEL_ID" --arg v "$OLD_VERSION" --arg p "$OLD_PREFIX" \
+  '.model_id == $id and .version == $v and .r2_prefix == $p' "$OLD_MANIFEST" >/dev/null || {
+  printf 'Old manifest model_id/version/r2_prefix does not match the catalog record — refusing to continue.\n' >&2
+  exit 1
+}
+
+# Fail fast with a friendly message; the Swift tool re-checks authoritatively.
+if jq -e '.files[] | select(.path == "chat_template.jinja")' "$OLD_MANIFEST" >/dev/null; then
+  printf 'Model %s (version %s) already ships a standalone chat_template.jinja — nothing to republish.\n' "$MODEL_ID" "$OLD_VERSION" >&2
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# 2) Download ONLY the small config/tokenizer/template artifacts.
+# ---------------------------------------------------------------------------
+WEIGHT_SUMMARY="$(jq -r --argjson cap "$MAX_ARTIFACT_BYTES" \
+  '[.files[] | select((.role == "config" or .role == "tokenizer" or .role == "template") and .size_bytes < $cap | not)] | "\(length) file(s), \(([.[].size_bytes] | add // 0) / 1e9 | floor) GB"' \
+  "$OLD_MANIFEST")"
+printf 'Skipping weight/large files entirely: %s (server-side copied later)\n' "$WEIGHT_SUMMARY"
+
+DOWNLOADED=0
+while IFS=$'\t' read -r rel_path expected_sha; do
+  dest="$ARTIFACTS_DIR/$rel_path"
+  mkdir -p "$(dirname "$dest")"
+  printf 'Downloading %s\n' "$rel_path"
+  curl -fsS "$MODEL_CDN_BASE_URL/$OLD_PREFIX/$rel_path" -o "$dest"
+  actual_sha="$(python3 -c 'import hashlib,sys; print(hashlib.sha256(open(sys.argv[1],"rb").read()).hexdigest())' "$dest")"
+  if [[ "$actual_sha" != "$expected_sha" ]]; then
+    printf 'SHA-256 mismatch for %s: manifest %s, downloaded %s\n' "$rel_path" "$expected_sha" "$actual_sha" >&2
+    exit 1
+  fi
+  DOWNLOADED=$((DOWNLOADED + 1))
+done < <(jq -r --argjson cap "$MAX_ARTIFACT_BYTES" \
+  '.files[] | select((.role == "config" or .role == "tokenizer" or .role == "template") and .size_bytes < $cap) | [.path, .sha256] | @tsv' \
+  "$OLD_MANIFEST")
+
+if [[ "$DOWNLOADED" == 0 ]]; then
+  printf 'No config/tokenizer/template artifacts listed in the old manifest — cannot extract a template.\n' >&2
+  exit 1
+fi
+printf 'Downloaded %d small artifact(s) into %s\n' "$DOWNLOADED" "$ARTIFACTS_DIR"
+
+# ---------------------------------------------------------------------------
+# 3) Extract the template + build the new manifest (local, digests-only).
+# ---------------------------------------------------------------------------
+printf 'Running darkbloom-publish extract-template...\n'
+(cd "$ROOT_DIR/provider-swift" && swift run -c release darkbloom-publish extract-template \
+  --manifest "$OLD_MANIFEST" \
+  --artifacts-dir "$ARTIFACTS_DIR" \
+  --new-version "$NEW_VERSION" \
+  --output "$NEW_MANIFEST" \
+  --template-output "$TEMPLATE_FILE")
+
+NEW_PREFIX="$(jq -r '.r2_prefix' "$NEW_MANIFEST")"
+
+# Refuse to clobber an existing published version at the target prefix.
+if curl -fsS -o /dev/null "$MODEL_CDN_BASE_URL/$NEW_PREFIX/manifest.json" 2>/dev/null; then
+  printf 'Target prefix %s already has a manifest.json — refusing to overwrite an existing version.\n' "$NEW_PREFIX" >&2
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# 4) Copy/upload plan — printed in dry-run, executed with --execute.
+#    Old-prefix objects are ONLY ever the SOURCE of server-side copies.
+# ---------------------------------------------------------------------------
+printf '\nNew manifest summary:\n'
+jq '{model_id, version, r2_prefix, aggregate_sha256, total_size_bytes, file_count}' "$NEW_MANIFEST"
+
+printf '\nExtracted template (first 20 lines of %s):\n' "$TEMPLATE_FILE"
+head -20 "$TEMPLATE_FILE"
+printf '\n--- end of template preview ---\n'
+
+run_or_print() {
+  if [[ "$EXECUTE" == 1 ]]; then
+    printf '+'; printf ' %q' "$@"; printf '\n'
+    "$@"
+  else
+    printf ' '; printf ' %q' "$@"; printf '\n'
+  fi
+}
+
+if [[ "$EXECUTE" == 1 ]]; then
+  printf '\nFetching R2 credentials from GCP Secret Manager...\n'
+  AWS_ACCESS_KEY_ID="$(gcloud secrets versions access latest --project "$GCP_PROJECT" --secret "$R2_ACCESS_KEY_SECRET")"
+  AWS_SECRET_ACCESS_KEY="$(gcloud secrets versions access latest --project "$GCP_PROJECT" --secret "$R2_SECRET_KEY_SECRET")"
+  export AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
+  export AWS_DEFAULT_REGION="auto"
+  printf 'Server-side copying %s -> %s (no bytes downloaded)...\n' "$OLD_PREFIX" "$NEW_PREFIX"
+else
+  printf '\nDRY RUN — the following commands WOULD run with --execute:\n\n'
+  printf '# server-side copies (CopyObject within bucket %s; old prefix is read-only source)\n' "$R2_BUCKET"
+fi
+
+while IFS= read -r rel_path; do
+  run_or_print aws s3 cp \
+    "s3://$R2_BUCKET/$OLD_PREFIX/$rel_path" \
+    "s3://$R2_BUCKET/$NEW_PREFIX/$rel_path" \
+    --endpoint-url "$R2_ENDPOINT" --only-show-errors
+done < <(jq -r '.files[].path' "$OLD_MANIFEST")
+
+if [[ "$EXECUTE" == 0 ]]; then
+  printf '\n# new-file uploads (manifest.json LAST — it is the publish commit point)\n'
+fi
+run_or_print aws s3 cp "$TEMPLATE_FILE" \
+  "s3://$R2_BUCKET/$NEW_PREFIX/chat_template.jinja" \
+  --endpoint-url "$R2_ENDPOINT" --only-show-errors
+run_or_print aws s3 cp "$NEW_MANIFEST" \
+  "s3://$R2_BUCKET/$NEW_PREFIX/manifest.json" \
+  --endpoint-url "$R2_ENDPOINT" --only-show-errors
+
+if [[ "$EXECUTE" == 1 ]]; then
+  printf '\nUpload complete. Verify: %s/%s/manifest.json\n' "$MODEL_CDN_BASE_URL" "$NEW_PREFIX"
+fi
+
+# ---------------------------------------------------------------------------
+# 5) Registration + promotion stays a human step: print the exact command.
+#    Prefilled from the live catalog record and public pricing endpoint.
+# ---------------------------------------------------------------------------
+DISPLAY_NAME="$(jq -r '.display_name // .id' "$CATALOG_JSON")"
+FAMILY="$(jq -r '.family // ""' "$CATALOG_JSON")"
+ARCHITECTURE="$(jq -r '.architecture // ""' "$CATALOG_JSON")"
+QUANTIZATION="$(jq -r '.quantization // ""' "$CATALOG_JSON")"
+CAPABILITIES_CSV="$(jq -r '(.capabilities // []) | join(",")' "$CATALOG_JSON")"
+MAX_CONTEXT="$(jq -r '.max_context_length // 0' "$CATALOG_JSON")"
+MAX_OUTPUT="$(jq -r '.max_output_length // 0' "$CATALOG_JSON")"
+MIN_RAM_GB="$(jq -r '.min_ram_gb // 0' "$CATALOG_JSON")"
+DESCRIPTION="$(jq -r '.description // ""' "$CATALOG_JSON")"
+RUNTIME_PARAMS="$(jq -c '.runtime_parameters // {}' "$CATALOG_JSON")"
+METADATA="$(jq -c '.metadata // {}' "$CATALOG_JSON")"
+INPUT_PRICE="$(curl -fsS "$COORDINATOR_URL/v1/pricing" 2>/dev/null | jq -r --arg m "$MODEL_ID" '.prices[]? | select(.model == $m) | .input_price' || true)"
+OUTPUT_PRICE="$(curl -fsS "$COORDINATOR_URL/v1/pricing" 2>/dev/null | jq -r --arg m "$MODEL_ID" '.prices[]? | select(.model == $m) | .output_price' || true)"
+
+cat <<EOF
+
+Next (human step) — register the new version, verify a provider converges,
+then promote:
+
+  gh workflow run register-model.yml \\
+    -f model_id="$MODEL_ID" \\
+    -f version="$NEW_VERSION" \\
+    -f display_name="$DISPLAY_NAME" \\
+    -f family="$FAMILY" \\
+    -f architecture="$ARCHITECTURE" \\
+    -f quantization="$QUANTIZATION" \\
+    -f capabilities_csv="$CAPABILITIES_CSV" \\
+    -f max_context_length="$MAX_CONTEXT" \\
+    -f max_output_length="$MAX_OUTPUT" \\
+    -f min_ram_gb="$MIN_RAM_GB" \\
+    -f description="$DESCRIPTION" \\
+    -f runtime_parameters_json='$RUNTIME_PARAMS' \\
+    -f metadata_json='$METADATA' \\
+    -f input_price="${INPUT_PRICE:-<input_price micro-USD per 1M tokens>}" \\
+    -f output_price="${OUTPUT_PRICE:-<output_price micro-USD per 1M tokens>}" \\
+    -f promote="false" \\
+    -f coordinator_url="$COORDINATOR_URL"
+
+Promotion (after verifying the registered version):
+  POST $COORDINATOR_URL/v1/admin/models/$MODEL_ID/promote {"version": "$NEW_VERSION"}
+  (scripts/admin.sh, or re-run the workflow with promote=true)
+
+EOF
+
+if [[ "$EXECUTE" == 0 ]]; then
+  printf 'DRY RUN complete — nothing was uploaded or copied. Re-run with --execute to arm.\n'
+fi


### PR DESCRIPTION
## Summary

Operator tooling for republishing a registry model as a **new version whose manifest adds a standalone `chat_template.jinja`** extracted from `tokenizer_config.json`. Motivation: the provider's prompt contract (`PromptContractIdentity.compute`) hard-requires that standalone file — models published without it report `cache_init_failed` and can never initialize the SSD prefix cache (see #571 for the attribution telemetry). Prod's four public catalog models already ship the file; this tooling targets the dev catalog's template-less models (`mlx-community/gemma-4-31b-4bit`, Qwen family) and every future publish.

- **`darkbloom-publish extract-template`**: byte-exact template extraction (string and named-array `chat_template` forms, surrogate pairs and combining marks preserved, no trailing newline), validation gates (rejects `strftime_now`, already-has-template, render-check failure, path traversal, case-insensitive duplicates, internally inconsistent manifests, negative sizes), and a new manifest built **from per-file digests alone** — no weight bytes are ever downloaded.
- **`WeightHasher.aggregateFromDigests`**: digests-only aggregate, byte-identical to `hashFilesWithRelativeKey` (unique paths) and the Go coordinator's `aggregateManifestFileHashes`, pinned by a shared cross-language vector.
- **`scripts/republish-template.sh`**: dry-run-by-default operator workflow — catalog fetch → prefix-pinned manifest validation → SHA-verified small-artifact download → extraction → server-side R2 copies (old prefix is never mutated, nothing is ever deleted, manifest uploads **last** so a partial run is invisible to the register handler's per-file HEAD check) → prints a `%q`-shell-safe register/promote command (registration and promotion stay human steps).

## Proof on real production data

Round-trip: taking `gemma-4-26b`'s production manifest, removing its template entry, embedding the real template into `tokenizer_config.json`, and running the tool reconstructs the **exact published state** — template sha `85a08664…` (16,448 bytes) and aggregate `a4722b60…` byte-identical to what the Go coordinator validated at original publish time. Real-prod dry-runs correctly refuse healthy models ("already ships a standalone chat_template.jinja") and trip the `strftime_now` guard on gpt-oss-20b's embedded template.

## Behavior

```mermaid
flowchart LR
  subgraph Before
    A1[model published without<br/>standalone chat_template.jinja] --> B1[provider slot:<br/>prompt contract uncomputable]
    B1 --> C1[SSD prefix cache never initializes<br/>reason: cache_init_failed]
    D1[fixing it = full manual republish<br/>weights re-uploaded, error-prone]
  end
  subgraph After
    A2[republish-template.sh MODEL NEW_VERSION] --> B2[extract + validate template,<br/>rebuild manifest from digests]
    B2 --> C2[server-side R2 copy to new prefix<br/>+ template + manifest last]
    C2 --> D2[human registers + promotes;<br/>providers delta-fetch ONE small file<br/>into the same snapshot dir]
    D2 --> E2[slot computes contract on reload<br/>SSD cache initializes]
  end
```

## Code

```mermaid
flowchart LR
  subgraph Before
    F1[darkbloom-publish hash<br/>local weights required] --> G1[manual aws s3 cp + register]
  end
  subgraph After
    F2[TemplateExtraction<br/>extract + 9 validation gates] --> G2[WeightHasher.aggregateFromDigests<br/>no weight bytes needed]
    G2 --> H2[ExtractTemplateCommand<br/>new manifest, canonical r2_prefix]
    H2 --> I2[republish-template.sh<br/>dry-run default, --execute armed,<br/>printf %q printed commands]
  end
```

## Review provenance

Two independent reviews per repo quality gate:
- **Safety/adversarial — PASS**: dry-run proven inert (every mutation behind `--execute`), no deletes / no old-prefix writes / no registry POST, manifest-last crash safety confirmed against the register handler's HEAD checks, credentials env-only, live hostile-input probes (`$(touch …)` ids, `../` versions) all rejected. Its Medium (`%q` quoting of the printed command) and Lows (MODEL_ID validation, wire-enforced size cap + streamed hash) are fixed in `0df9e0386`.
- **Correctness — PASS**: cross-language aggregate + slug/prefix derivations reproduced byte-identically against the real Go functions; extraction byte-exactness verified including surrogate pairs; all validation gates test-covered. Its nits (bash path guard ordering, negative-size check, doc qualifier, surrogate-pair test) are fixed in `90b2b7c86`.

Tests: 29 `DarkbloomPublishTests` + 58 `ProviderCoreFoundationTests` + 6 Swift Testing prompt-contract tests, 0 failures; `shellcheck` and `bash -n` clean.

## Operator runbook (before `--execute`)

- Set the four env vars as a **matched set** for dev-coordinator runs (`COORDINATOR_URL`, `MODEL_CDN_BASE_URL`, `R2_BUCKET`, `R2_ACCOUNT_ID`) — the read source and write bucket are decoupled; confirm the CDN fronts the exact bucket you're writing, and eyeball the printed `s3://` targets and `coordinator_url=` in the dry-run first.
- Never run execute mode under `bash -x` (the secret assignments would trace to stderr).
- After `--execute`, before registering: HEAD the new prefix's `manifest.json` and spot-check a couple of copied objects (the register HEAD check validates presence + size, not content hash).
- Registration (`gh workflow run register-model.yml`, printed prefilled) and promotion stay human steps; verify one provider converges before promoting.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/572"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787443838&installation_model_id=21733&pr_number=572&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F572&signature=b9456cef05c68a59d15af06e81777d474ee1a161371cb44b39758c40f45a81bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->