### PR TITLE
test(bench): one-command Gemma 4 continuous-batching benchmark + recorded baseline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 .PHONY: help \
         coordinator-test coordinator-build coordinator-build-linux coordinator \
         prompt-sidecar-format prompt-sidecar-check prompt-sidecar-test prompt-sidecar-build prompt-sidecar \
-        provider-build provider-test provider \
+        provider-build provider-test provider benchmark-gemma-contbatch \
         ui-install ui-build ui-lint ui-test ui \
         e2e-integration e2e-benchmark e2e \
         test build all clean
@@ -51,6 +51,9 @@ provider-test: ## swift test for the Swift provider CLI
 	cd provider-swift && swift test
 
 provider: provider-build provider-test ## Build + test provider
+
+benchmark-gemma-contbatch: ## Build and benchmark Gemma 4 26B continuous batching
+	python3 scripts/benchmark-gemma-contbatch.py $(GEMMA_BENCHMARK_ARGS)
 
 # ---- Console UI (Next.js 16) ----------------------------------------------
 

--- a/docs/reports/2026-07-23-gemma-4-26b-qat4bit-continuous-batching-baseline.json
+++ b/docs/reports/2026-07-23-gemma-4-26b-qat4bit-continuous-batching-baseline.json
@@ -1,0 +1,185 @@
+{
+  "schemaVersion": 1,
+  "name": "gemma-4-26b-qat4bit-continuous-batching-baseline-2026-07-23",
+  "modelID": "mlx-community/gemma-4-26B-A4B-it-qat-4bit",
+  "sourceCommit": "0fb9d2b689e4934caf01c7242c1d2ea992ebeff5",
+  "modelSnapshot": "0e3cbab38ce568cf6e23543010d08d03b731910c",
+  "hardware": {
+    "chipName": "Apple M4 Max",
+    "gpuCores": 40,
+    "memoryGb": 128,
+    "memoryBandwidthGbs": 546
+  },
+  "configuration": {
+    "iterations": 3,
+    "prefillLengths": [128, 512, 2048],
+    "decodePromptTokens": 64,
+    "decodeTokens": 64,
+    "arrivalPromptTokens": 512,
+    "arrivalDecodeTokens": 64,
+    "maxBatch": 4,
+    "compiledDecode": true,
+    "prefixCache": false,
+    "mtp": false,
+    "kvBackend": "contiguous"
+  },
+  "summary": {
+    "prefill": [
+      {
+        "promptTokens": 128,
+        "medianElapsedMs": 152.391916,
+        "medianTokensPerSecond": 839.9395673980503,
+        "samples": [
+          {"elapsedMs": 167.561042, "tokensPerSecond": 763.9007162536027},
+          {"elapsedMs": 152.359334, "tokensPerSecond": 840.1191882343093},
+          {"elapsedMs": 152.391916, "tokensPerSecond": 839.9395673980503}
+        ]
+      },
+      {
+        "promptTokens": 512,
+        "medianElapsedMs": 406.099958,
+        "medianTokensPerSecond": 1260.7733389620296,
+        "samples": [
+          {"elapsedMs": 407.260792, "tokensPerSecond": 1257.1796992429363},
+          {"elapsedMs": 406.099958, "tokensPerSecond": 1260.7733389620296},
+          {"elapsedMs": 405.871041, "tokensPerSecond": 1261.4844329334646}
+        ]
+      },
+      {
+        "promptTokens": 2048,
+        "medianElapsedMs": 1584.189417,
+        "medianTokensPerSecond": 1292.774701069727,
+        "samples": [
+          {"elapsedMs": 1584.269666, "tokensPerSecond": 1292.7092173460828},
+          {"elapsedMs": 1578.109625, "tokensPerSecond": 1297.7552177340026},
+          {"elapsedMs": 1584.189417, "tokensPerSecond": 1292.774701069727}
+        ]
+      }
+    ],
+    "schedulerTTFT": [
+      {
+        "promptTokens": 128,
+        "medianTTFTMs": 207.611875,
+        "samples": [
+          {"ttftMs": 214.070875, "msPerPrefillToken": 1.685597440944882},
+          {"ttftMs": 207.611875, "msPerPrefillToken": 1.6347391732283465},
+          {"ttftMs": 201.863583, "msPerPrefillToken": 1.5894770314960631}
+        ]
+      },
+      {
+        "promptTokens": 512,
+        "medianTTFTMs": 474.925542,
+        "samples": [
+          {"ttftMs": 474.925542, "msPerPrefillToken": 0.9294041917808218},
+          {"ttftMs": 477.476583, "msPerPrefillToken": 0.9343964442270059},
+          {"ttftMs": 455.228125, "msPerPrefillToken": 0.8908573874755381}
+        ]
+      },
+      {
+        "promptTokens": 2048,
+        "medianTTFTMs": 1800.395875,
+        "samples": [
+          {"ttftMs": 1800.395875, "msPerPrefillToken": 0.8795290058622374},
+          {"ttftMs": 1825.300875, "msPerPrefillToken": 0.8916955911089398},
+          {"ttftMs": 1790.626334, "msPerPrefillToken": 0.8747563917928677}
+        ]
+      }
+    ],
+    "decode": [
+      {"batchSize": 1, "elapsedMs": 593.76875, "perRequestTokensPerSecond": 107.78606991358168, "aggregateTokensPerSecond": 107.78606991358168},
+      {"batchSize": 2, "elapsedMs": 799.166792, "perRequestTokensPerSecond": 80.08340766992231, "aggregateTokensPerSecond": 160.16681533984462},
+      {"batchSize": 3, "elapsedMs": 998.477542, "perRequestTokensPerSecond": 64.09758588240736, "aggregateTokensPerSecond": 192.29275764722206},
+      {"batchSize": 4, "elapsedMs": 1248.393416, "perRequestTokensPerSecond": 51.26589036736797, "aggregateTokensPerSecond": 205.0635614694719}
+    ],
+    "arrival": [
+      {
+        "name": "burst",
+        "arrivalDelaysMs": [0, 0, 0, 0],
+        "medianTTFTMs": 1881.616958,
+        "medianPerRequestDecodeTokensPerSecond": 48.299854032767705,
+        "medianAggregateDecodeTokensPerSecond": 193.17071253832094,
+        "medianEndToEndTokensPerSecond": 80.34575351311611,
+        "medianMakespanMs": 3186.229375,
+        "outputsStableAcrossIterations": true,
+        "outputsMatchBurst": true,
+        "samples": [
+          {"iteration": 1, "aggregateDecodeTokensPerSecond": 196.63951910625767, "endToEndTokensPerSecond": 87.35609278036016, "makespanMs": 2930.534},
+          {"iteration": 2, "aggregateDecodeTokensPerSecond": 193.17071253832094, "endToEndTokensPerSecond": 80.34575351311611, "makespanMs": 3186.229375},
+          {"iteration": 3, "aggregateDecodeTokensPerSecond": 188.9673677449244, "endToEndTokensPerSecond": 78.00798188518634, "makespanMs": 3281.715458}
+        ],
+        "rows": [
+          {"row": 0, "medianTTFTMs": 1881.616666, "medianDecodeTokensPerSecond": 48.30672621728693},
+          {"row": 1, "medianTTFTMs": 1881.620709, "medianDecodeTokensPerSecond": 48.30218461281574},
+          {"row": 2, "medianTTFTMs": 1881.616291, "medianDecodeTokensPerSecond": 48.297523452719666},
+          {"row": 3, "medianTTFTMs": 1881.61725, "medianDecodeTokensPerSecond": 48.29303907032423}
+        ]
+      },
+      {
+        "name": "stagger-25ms",
+        "arrivalDelaysMs": [0, 25, 50, 75],
+        "medianTTFTMs": 1674.039021,
+        "medianPerRequestDecodeTokensPerSecond": 49.44454470902673,
+        "medianAggregateDecodeTokensPerSecond": 97.70628516872306,
+        "medianEndToEndTokensPerSecond": 85.44255740254626,
+        "medianMakespanMs": 2996.165,
+        "outputsStableAcrossIterations": true,
+        "outputsMatchBurst": true,
+        "samples": [
+          {"iteration": 1, "aggregateDecodeTokensPerSecond": 98.01077345856447, "endToEndTokensPerSecond": 85.89529975299648, "makespanMs": 2980.372625},
+          {"iteration": 2, "aggregateDecodeTokensPerSecond": 97.70628516872306, "endToEndTokensPerSecond": 85.44255740254626, "makespanMs": 2996.165},
+          {"iteration": 3, "aggregateDecodeTokensPerSecond": 91.38874997234765, "endToEndTokensPerSecond": 78.8479139031243, "makespanMs": 3246.756792}
+        ],
+        "rows": [
+          {"row": 0, "medianTTFTMs": 416.939208, "medianDecodeTokensPerSecond": 24.4685878305017},
+          {"row": 1, "medianTTFTMs": 1706.011209, "medianDecodeTokensPerSecond": 50.00952232902271},
+          {"row": 2, "medianTTFTMs": 1681.037542, "medianDecodeTokensPerSecond": 50.00438034403212},
+          {"row": 3, "medianTTFTMs": 1656.016708, "medianDecodeTokensPerSecond": 49.99953702809643}
+        ]
+      },
+      {
+        "name": "stagger-100ms",
+        "arrivalDelaysMs": [0, 100, 200, 300],
+        "medianTTFTMs": 1518.517084,
+        "medianPerRequestDecodeTokensPerSecond": 49.51095712380846,
+        "medianAggregateDecodeTokensPerSecond": 96.80484161179227,
+        "medianEndToEndTokensPerSecond": 84.53860470623975,
+        "medianMakespanMs": 3028.202333,
+        "outputsStableAcrossIterations": true,
+        "outputsMatchBurst": true,
+        "samples": [
+          {"iteration": 1, "aggregateDecodeTokensPerSecond": 98.94479498844612, "endToEndTokensPerSecond": 86.66412845038086, "makespanMs": 2953.932666},
+          {"iteration": 2, "aggregateDecodeTokensPerSecond": 96.80484161179227, "endToEndTokensPerSecond": 84.53860470623975, "makespanMs": 3028.202333},
+          {"iteration": 3, "aggregateDecodeTokensPerSecond": 92.79097865485299, "endToEndTokensPerSecond": 80.38787882560628, "makespanMs": 3184.559709}
+        ],
+        "rows": [
+          {"row": 0, "medianTTFTMs": 424.961333, "medianDecodeTokensPerSecond": 24.2410915070903},
+          {"row": 1, "medianTTFTMs": 1656.409458, "medianDecodeTokensPerSecond": 49.81303145147681},
+          {"row": 2, "medianTTFTMs": 1550.689084, "medianDecodeTokensPerSecond": 49.80785926512654},
+          {"row": 3, "medianTTFTMs": 1461.149833, "medianDecodeTokensPerSecond": 49.80318028215759}
+        ]
+      },
+      {
+        "name": "rolling-250ms",
+        "arrivalDelaysMs": [0, 250, 500, 750],
+        "medianTTFTMs": 838.759833,
+        "medianPerRequestDecodeTokensPerSecond": 39.147266676952114,
+        "medianAggregateDecodeTokensPerSecond": 95.7307519539108,
+        "medianEndToEndTokensPerSecond": 83.43855274346625,
+        "medianMakespanMs": 3068.126083,
+        "outputsStableAcrossIterations": true,
+        "outputsMatchBurst": true,
+        "samples": [
+          {"iteration": 1, "aggregateDecodeTokensPerSecond": 96.85643690055366, "endToEndTokensPerSecond": 84.94944444362464, "makespanMs": 3013.557083},
+          {"iteration": 2, "aggregateDecodeTokensPerSecond": 95.7307519539108, "endToEndTokensPerSecond": 83.43855274346625, "makespanMs": 3068.126083},
+          {"iteration": 3, "aggregateDecodeTokensPerSecond": 91.10031009847846, "endToEndTokensPerSecond": 78.96558681608157, "makespanMs": 3241.918541}
+        ],
+        "rows": [
+          {"row": 0, "medianTTFTMs": 435.67425, "medianDecodeTokensPerSecond": 24.19587444317698},
+          {"row": 1, "medianTTFTMs": 621.315291, "medianDecodeTokensPerSecond": 29.22888686119079},
+          {"row": 2, "medianTTFTMs": 1306.803625, "medianDecodeTokensPerSecond": 49.89222029151824},
+          {"row": 3, "medianTTFTMs": 1008.551583, "medianDecodeTokensPerSecond": 49.887657074386475}
+        ]
+      }
+    ]
+  }
+}

--- a/docs/reports/2026-07-23-gemma-4-26b-qat4bit-continuous-batching-baseline.md
+++ b/docs/reports/2026-07-23-gemma-4-26b-qat4bit-continuous-batching-baseline.md
@@ -122,9 +122,18 @@ through every topology and reused for all measurements. Request IDs are unique,
 pattern order rotates across repetitions, and every row must finish with
 `.length` and exactly 64 tokens.
 
-Scheduled delays are relative to the scenario start. Actual submissions were
-within roughly 5-36 ms of those targets because Swift tasks can wake between
-GPU scheduling operations.
+PROVENANCE CAVEAT: this baseline was recorded with the ORIGINAL arrival
+benchmark, which slept each row's delay relative to its own task start rather
+than to the scenario start. Actual submissions therefore landed within roughly
+5-36 ms of their targets, so these arrival figures describe a topology that
+drifted from its name. The harness has since been corrected to sleep to an
+absolute deadline and to REJECT any sample whose arrival error exceeds 5 ms,
+which means a run of the current harness would refuse to reproduce the numbers
+in this section. Re-record this baseline against the unmodified engine before
+using its arrival rows for attribution.
+
+The decode rows carry the same warning: they are single measurements, because
+`--iterations` did not repeat the decode sweep when this baseline was taken.
 
 ### Per-Repetition Results
 

--- a/docs/reports/2026-07-23-gemma-4-26b-qat4bit-continuous-batching-baseline.md
+++ b/docs/reports/2026-07-23-gemma-4-26b-qat4bit-continuous-batching-baseline.md
@@ -1,0 +1,238 @@
+# Gemma 4 26B QAT 4-bit Continuous-Batching Baseline
+
+This document freezes the pre-optimization baseline for Gemma 4 26B QAT
+4-bit on Darkbloom's production `ContinuousBatchingV2` engine. It is the
+comparison point for subsequent Gemma prefill, decode, scheduling, and
+batch-composition changes.
+
+The requested "Q80 4-bit" model was interpreted as the repository's QAT
+4-bit build:
+
+```text
+mlx-community/gemma-4-26B-A4B-it-qat-4bit
+```
+
+The machine-readable companion is
+[`2026-07-23-gemma-4-26b-qat4bit-continuous-batching-baseline.json`](2026-07-23-gemma-4-26b-qat4bit-continuous-batching-baseline.json).
+
+## Environment
+
+| Field | Value |
+|---|---|
+| Date | 2026-07-23 |
+| Host | MacBook Pro, Apple M4 Max |
+| CPU | 16 cores (12 performance, 4 efficiency) |
+| GPU | 40 cores |
+| Unified memory | 128 GB |
+| Peak memory bandwidth used by report | 546 GB/s |
+| macOS | 26.5.2 (25F84) |
+| Provider version | 0.7.14 |
+| Root commit | `0fb9d2b689e4934caf01c7242c1d2ea992ebeff5` |
+| `libs/mlx` | `d5a240408508f2be37f1a4893da0b415e8c0db55` |
+| `libs/mlx-swift` | `df1fdc5f7821a1fabe921fdefbc42ac74dcfb6bc` |
+| `libs/mlx-swift-lm` | `dc2cd5510cadc7813044c4d0571feca83f39b60a` |
+| Model snapshot | `0e3cbab38ce568cf6e23543010d08d03b731910c` |
+| Measured weight payload | 15.608614044 GB |
+| Quantization | 4 bit |
+| `mlx.metallib` SHA-256 | `2e535253422c537dac8039ccae10305a7fece153341b8e96c3d52ad18bc58bfa` |
+| Build | Swift release |
+| Engine | Production `EngineV2Factory.makeProductionEngine` |
+| Compiled decode | Enabled (default) |
+| KV backend | Auto, therefore contiguous |
+| Prefix cache | Disabled |
+| MTP | Disabled (no drafter) |
+| Maximum concurrent rows | 4 |
+| Thermal state | No thermal or performance warning before or after the runs |
+
+The arrival benchmark drives the production engine directly. It excludes
+coordinator/network transport, provider bridge translation, tokenization,
+prefix caching, MTP, provider memory-ledger reserves, and per-model TOML
+overrides.
+
+## Raw Prefill
+
+Raw prefill is one full model forward over an exact-length token array. The
+first shape can include residual compilation cost, so the baseline uses the
+median of three same-process repetitions.
+
+| Prompt tokens | Iteration | Elapsed (ms) | Prefill (tok/s) |
+|---:|---:|---:|---:|
+| 128 | 1 | 167.561 | 763.901 |
+| 128 | 2 | 152.359 | 840.119 |
+| 128 | 3 | 152.392 | 839.940 |
+| 512 | 1 | 407.261 | 1,257.180 |
+| 512 | 2 | 406.100 | 1,260.773 |
+| 512 | 3 | 405.871 | 1,261.484 |
+| 2,048 | 1 | 1,584.270 | 1,292.709 |
+| 2,048 | 2 | 1,578.110 | 1,297.755 |
+| 2,048 | 3 | 1,584.189 | 1,292.775 |
+
+| Prompt tokens | Median elapsed (ms) | Median prefill (tok/s) |
+|---:|---:|---:|
+| 128 | 152.392 | 839.940 |
+| 512 | 406.100 | 1,260.773 |
+| 2,048 | 1,584.189 | 1,292.775 |
+
+## Production TTFT
+
+Production TTFT uses a fresh prefix-cache-free engine for each request and
+measures submission through the first token. It therefore includes internal
+512-token prefill chunking, per-engine compiled-decode startup, scheduling, and
+the first decode step.
+
+| Prompt tokens | Iteration | TTFT (ms) | TTFT / prefill token (ms) |
+|---:|---:|---:|---:|
+| 128 | 1 | 214.071 | 1.686 |
+| 128 | 2 | 207.612 | 1.635 |
+| 128 | 3 | 201.864 | 1.589 |
+| 512 | 1 | 474.926 | 0.929 |
+| 512 | 2 | 477.477 | 0.934 |
+| 512 | 3 | 455.228 | 0.891 |
+| 2,048 | 1 | 1,800.396 | 0.880 |
+| 2,048 | 2 | 1,825.301 | 0.892 |
+| 2,048 | 3 | 1,790.626 | 0.875 |
+
+| Prompt tokens | Median TTFT (ms) |
+|---:|---:|
+| 128 | 207.612 |
+| 512 | 474.926 |
+| 2,048 | 1,800.396 |
+
+## Decode Batch Curve
+
+Each row has a 64-token prompt and produces 64 measured decode tokens after
+the first emitted token. Aggregate throughput sums work across every row;
+per-request throughput is aggregate divided by the batch size.
+
+| Batch | Elapsed (ms) | Per-request (tok/s) | Aggregate (tok/s) |
+|---:|---:|---:|---:|
+| 1 | 593.769 | 107.786 | 107.786 |
+| 2 | 799.167 | 80.083 | 160.167 |
+| 3 | 998.478 | 64.098 | 192.293 |
+| 4 | 1,248.393 | 51.266 | 205.064 |
+
+The B=1 result was independently repeated with a shorter decode and measured
+106.909 tok/s.
+
+## Arrival Invariance
+
+Each scenario submits the same four distinct 512-token prompts and requires
+exactly 64 greedy output tokens per request. One production engine is warmed
+through every topology and reused for all measurements. Request IDs are unique,
+pattern order rotates across repetitions, and every row must finish with
+`.length` and exactly 64 tokens.
+
+Scheduled delays are relative to the scenario start. Actual submissions were
+within roughly 5-36 ms of those targets because Swift tasks can wake between
+GPU scheduling operations.
+
+### Per-Repetition Results
+
+`Decode-window TPS` is `sum(N-1)` divided by the interval from the earliest
+first token to the latest last token. For staggered workloads it intentionally
+includes later prefills and low-concurrency gaps. `End-to-end TPS` is all 256
+output tokens divided by submission-to-final-completion makespan.
+
+| Schedule (ms) | Iteration | Decode-window TPS | End-to-end TPS | Makespan (ms) |
+|---|---:|---:|---:|---:|
+| 0/0/0/0 | 1 | 196.640 | 87.356 | 2,930.534 |
+| 0/0/0/0 | 2 | 193.171 | 80.346 | 3,186.229 |
+| 0/0/0/0 | 3 | 188.967 | 78.008 | 3,281.715 |
+| 0/25/50/75 | 1 | 98.011 | 85.895 | 2,980.373 |
+| 0/25/50/75 | 2 | 97.706 | 85.443 | 2,996.165 |
+| 0/25/50/75 | 3 | 91.389 | 78.848 | 3,246.757 |
+| 0/100/200/300 | 1 | 98.945 | 86.664 | 2,953.933 |
+| 0/100/200/300 | 2 | 96.805 | 84.539 | 3,028.202 |
+| 0/100/200/300 | 3 | 92.791 | 80.388 | 3,184.560 |
+| 0/250/500/750 | 1 | 96.856 | 84.949 | 3,013.557 |
+| 0/250/500/750 | 2 | 95.731 | 83.439 | 3,068.126 |
+| 0/250/500/750 | 3 | 91.100 | 78.966 | 3,241.919 |
+
+### Arrival Summary
+
+The TTFT and per-request decode columns below pool all four rows across all
+three repetitions. Row-level medians follow because pooled medians hide the
+early request's decode degradation.
+
+| Schedule (ms) | Median TTFT (ms) | Median request decode (tok/s) | Median decode-window TPS | Median end-to-end TPS | Median makespan (ms) |
+|---|---:|---:|---:|---:|---:|
+| 0/0/0/0 | 1,881.617 | 48.300 | 193.171 | 80.346 | 3,186.229 |
+| 0/25/50/75 | 1,674.039 | 49.445 | 97.706 | 85.443 | 2,996.165 |
+| 0/100/200/300 | 1,518.517 | 49.511 | 96.805 | 84.539 | 3,028.202 |
+| 0/250/500/750 | 838.760 | 39.147 | 95.731 | 83.439 | 3,068.126 |
+
+### Per-Row Medians
+
+| Schedule (ms) | Row | Median TTFT (ms) | Median decode (tok/s) |
+|---|---:|---:|---:|
+| 0/0/0/0 | 0 | 1,881.617 | 48.307 |
+| 0/0/0/0 | 1 | 1,881.621 | 48.302 |
+| 0/0/0/0 | 2 | 1,881.616 | 48.298 |
+| 0/0/0/0 | 3 | 1,881.617 | 48.293 |
+| 0/25/50/75 | 0 | 416.939 | 24.469 |
+| 0/25/50/75 | 1 | 1,706.011 | 50.010 |
+| 0/25/50/75 | 2 | 1,681.038 | 50.004 |
+| 0/25/50/75 | 3 | 1,656.017 | 50.000 |
+| 0/100/200/300 | 0 | 424.961 | 24.241 |
+| 0/100/200/300 | 1 | 1,656.409 | 49.813 |
+| 0/100/200/300 | 2 | 1,550.689 | 49.808 |
+| 0/100/200/300 | 3 | 1,461.150 | 49.803 |
+| 0/250/500/750 | 0 | 435.674 | 24.196 |
+| 0/250/500/750 | 1 | 621.315 | 29.229 |
+| 0/250/500/750 | 2 | 1,306.804 | 49.892 |
+| 0/250/500/750 | 3 | 1,008.552 | 49.888 |
+
+### Invariance Result
+
+- Every row produced exactly 64 tokens and terminated with `.length`.
+- Every row's full token sequence was identical across all repetitions.
+- Every row's full token sequence matched the corresponding burst row.
+- Output behavior is invariant to arrival topology for this greedy corpus.
+- Latency and decode allocation are not invariant to arrival topology.
+
+A burst places all four requests in the prefill queue before work begins. All
+rows receive their first token together near 1.88 seconds and then decode near
+48.3 tok/s each. With any tested stagger, row 0 obtains its first token near
+0.42 seconds, but later prefills interrupt it and reduce its decode rate to
+roughly 24 tok/s. Later rows decode near 49-50 tok/s after their prefills finish.
+
+The staggered decode-window rate is about half the burst rate because its clock
+starts at row 0's early token and includes all later prefill gaps. It must not be
+read as a 50% loss in completed workload throughput: end-to-end output TPS and
+makespan improve modestly in these four-request scenarios.
+
+## One-Command Reproduction
+
+From the repository root:
+
+```bash
+make benchmark-gemma-contbatch
+```
+
+The command rebuilds the release provider after source changes, installs the
+metallib matching the current MLX commit, runs the full matrix, compares the
+summary with the machine-readable baseline, and writes timestamped plus
+`latest` Markdown/JSON reports under `tmp/benchmarks/`.
+
+The metallib cache is namespaced by the nested MLX commit plus any tracked diff
+and untracked files. Dirty kernel work therefore cannot silently reuse the clean
+commit's metallib, and the runner does not trust an unrelated global cache.
+
+Optional runner arguments can be passed through Make:
+
+```bash
+make benchmark-gemma-contbatch \
+  GEMMA_BENCHMARK_ARGS="--label my-change --iterations 5"
+```
+
+Use `--skip-build` only when the release binary already contains the changes
+being measured:
+
+```bash
+make benchmark-gemma-contbatch \
+  GEMMA_BENCHMARK_ARGS="--skip-build --label repeat-2"
+```
+
+The benchmark results are hardware- and thermal-state-specific. Compare runs on
+the same host, keep background GPU work stopped, and prefer multiple repetitions
+for decisions smaller than the observed run-to-run spread.

--- a/provider-swift/Sources/ProviderBenchmark/ArrivalInvarianceBenchmark.swift
+++ b/provider-swift/Sources/ProviderBenchmark/ArrivalInvarianceBenchmark.swift
@@ -10,6 +10,10 @@ public struct ArrivalInvarianceBenchmarkReport: Codable, Sendable {
         public let row: Int
         public let scheduledDelayMs: Int
         public let submittedAtMs: Double
+        /// Signed distance between the measured submission offset and the
+        /// intended one (`submittedAtMs - scheduledDelayMs`); positive means
+        /// the request entered the engine later than the topology asked for.
+        public let arrivalErrorMs: Double
         public let ttftMs: Double
         public let decodeTokensPerSecond: Double
         public let generatedTokens: Int
@@ -23,6 +27,11 @@ public struct ArrivalInvarianceBenchmarkReport: Codable, Sendable {
         public let aggregateDecodeTokensPerSecond: Double
         public let endToEndTokensPerSecond: Double
         public let makespanMs: Double
+        /// Worst absolute arrival error across this sample's rows.
+        public let maxArrivalErrorMs: Double
+        /// Attempts discarded before this one because their arrivals missed
+        /// the tolerance. Non-zero means the host was scheduling badly.
+        public let discardedAttempts: Int
     }
 
     public struct Pattern: Codable, Sendable {
@@ -35,6 +44,11 @@ public struct ArrivalInvarianceBenchmarkReport: Codable, Sendable {
         public let medianMakespanMs: Double
         public let outputsStableAcrossIterations: Bool
         public let outputsMatchBurst: Bool
+        /// Per-row median of the *measured* submission offsets, directly
+        /// comparable to `arrivalDelaysMs`.
+        public let measuredArrivalOffsetsMs: [Double]
+        public let maxArrivalErrorMs: Double
+        public let arrivalWithinTolerance: Bool
     }
 
     public let schemaVersion: Int
@@ -43,6 +57,11 @@ public struct ArrivalInvarianceBenchmarkReport: Codable, Sendable {
     public let promptTokensPerRequest: Int
     public let decodeTokensPerRequest: Int
     public let iterations: Int
+    /// Bound enforced on every measured row's `arrivalErrorMs`. Samples that
+    /// exceed it are re-run, and the benchmark fails rather than reporting
+    /// numbers produced by a topology it did not actually deliver.
+    public let arrivalToleranceMs: Double
+    public let arrivalMaxAttemptsPerSample: Int
     public let patterns: [Pattern]
 
     public func jsonString() throws -> String {
@@ -67,7 +86,9 @@ public enum ArrivalInvarianceBenchmark {
         let weightBytes: Int
     }
 
-    private struct EngineParts: @unchecked Sendable {
+    // `CBv2Engine` is `AnyObject, Sendable` in the frozen contract, so this
+    // needs no `@unchecked` escape hatch (same reasoning as EngineV2Bridge).
+    private struct EngineParts: Sendable {
         let engine: any CBv2Engine
     }
 
@@ -91,16 +112,44 @@ public enum ArrivalInvarianceBenchmark {
         PatternDefinition(name: "rolling-250ms", delaysMs: [0, 250, 500, 750]),
     ]
 
+    /// The tightest inter-arrival gap any topology asks for (25 ms today),
+    /// derived from the definitions so a future, denser pattern automatically
+    /// tightens the bound instead of silently outgrowing it.
+    private static let minimumArrivalGapMs: Double = {
+        let gaps = patterns
+            .flatMap { zip($0.delaysMs, $0.delaysMs.dropFirst()).map { $1 - $0 } }
+            .filter { $0 > 0 }
+        return Double(gaps.min() ?? 25)
+    }()
+
+    /// Default arrival tolerance: one fifth of the tightest gap, so even two
+    /// adjacent rows erring in opposite directions stay >= 15 ms apart and the
+    /// named topology remains the topology that was actually delivered.
+    /// Override with `DARKBLOOM_ARRIVAL_TOLERANCE_MS` on hosts that cannot
+    /// hold it (the loosened value is recorded in the report).
+    private static let defaultArrivalToleranceMs = minimumArrivalGapMs / 5
+
+    private static let arrivalToleranceEnvKey = "DARKBLOOM_ARRIVAL_TOLERANCE_MS"
+
+    /// Settle time between a rejected attempt and its retry.
+    private static let retryCooldownNanoseconds: UInt64 = 250_000_000
+
     public static func run(
         modelID: String,
         modelDirectory: URL,
         promptTokens: Int = 512,
         decodeTokens: Int = 64,
-        iterations: Int = 3
+        iterations: Int = 3,
+        arrivalToleranceMs: Double? = nil,
+        maxAttemptsPerSample: Int = 3
     ) async throws -> ArrivalInvarianceBenchmarkReport {
         let promptTokens = max(2, promptTokens)
         let decodeTokens = max(2, decodeTokens)
         let iterations = max(1, iterations)
+        let toleranceMs = resolvedToleranceMs(explicit: arrivalToleranceMs)
+        let maxAttempts = max(1, maxAttemptsPerSample)
+        log("arrival tolerance \(String(format: "%.2f", toleranceMs)) ms, "
+            + "up to \(maxAttempts) attempt(s) per sample")
         log("loading model \(modelID)")
         log("  path: \(modelDirectory.path)")
 
@@ -149,6 +198,9 @@ public enum ArrivalInvarianceBenchmark {
             // every arrival topology are fully warm before measurements begin.
             for pattern in patterns {
                 log("warming \(pattern.name)")
+                // Warm-up arrivals still use absolute deadlines, but a cold
+                // engine is exactly when the host mis-schedules, so timing is
+                // observed and not enforced here.
                 _ = try await measure(
                     engine: engine,
                     facts: facts,
@@ -156,7 +208,10 @@ public enum ArrivalInvarianceBenchmark {
                     promptTokens: promptTokens,
                     decodeTokens: min(8, decodeTokens),
                     iteration: 0,
-                    requestIDBase: nextRequestID
+                    requestIDBase: nextRequestID,
+                    toleranceMs: toleranceMs,
+                    maxAttempts: 1,
+                    enforceTolerance: false
                 )
                 nextRequestID += UInt64(pattern.delaysMs.count)
             }
@@ -174,13 +229,19 @@ public enum ArrivalInvarianceBenchmark {
                         promptTokens: promptTokens,
                         decodeTokens: decodeTokens,
                         iteration: iteration,
-                        requestIDBase: nextRequestID
+                        requestIDBase: nextRequestID,
+                        toleranceMs: toleranceMs,
+                        maxAttempts: maxAttempts,
+                        enforceTolerance: true
                     )
-                    nextRequestID += UInt64(pattern.delaysMs.count)
+                    // Every attempt burns a distinct block of request IDs so a
+                    // retried sample can never collide with a discarded one.
+                    nextRequestID += UInt64(pattern.delaysMs.count * maxAttempts)
                     log(
                         "  \(pattern.name) i=\(iteration): aggregate "
                             + "\(String(format: "%.1f", sample.report.aggregateDecodeTokensPerSecond)) tok/s, "
-                            + "makespan \(String(format: "%.1f", sample.report.makespanMs)) ms"
+                            + "makespan \(String(format: "%.1f", sample.report.makespanMs)) ms, "
+                            + "arrival err \(String(format: "%.2f", sample.report.maxArrivalErrorMs)) ms"
                     )
                     samplesByPattern[pattern.name, default: []].append(sample)
                 }
@@ -203,6 +264,12 @@ public enum ArrivalInvarianceBenchmark {
             let allOutputs = measured.map(\.outputs)
             let firstOutputs = allOutputs.first ?? []
             let stable = allOutputs.allSatisfy { $0 == firstOutputs }
+            let measuredOffsets = definition.delaysMs.indices.map { index in
+                median(reports.compactMap { sample in
+                    sample.rows.first { $0.row == index }?.submittedAtMs
+                })
+            }
+            let worstArrivalError = reports.map(\.maxArrivalErrorMs).max() ?? 0
             return ArrivalInvarianceBenchmarkReport.Pattern(
                 name: definition.name,
                 arrivalDelaysMs: definition.delaysMs,
@@ -216,21 +283,42 @@ public enum ArrivalInvarianceBenchmark {
                 ),
                 medianMakespanMs: median(reports.map(\.makespanMs)),
                 outputsStableAcrossIterations: stable,
-                outputsMatchBurst: allOutputs.allSatisfy { $0 == burstOutputs }
+                outputsMatchBurst: allOutputs.allSatisfy { $0 == burstOutputs },
+                measuredArrivalOffsetsMs: measuredOffsets,
+                maxArrivalErrorMs: worstArrivalError,
+                arrivalWithinTolerance: worstArrivalError <= toleranceMs
             )
         }
 
         return ArrivalInvarianceBenchmarkReport(
-            schemaVersion: 1,
+            schemaVersion: 2,
             modelID: modelID,
             modelPath: modelDirectory.path,
             promptTokensPerRequest: promptTokens,
             decodeTokensPerRequest: decodeTokens,
             iterations: iterations,
+            arrivalToleranceMs: toleranceMs,
+            arrivalMaxAttemptsPerSample: maxAttempts,
             patterns: patternReports
         )
     }
 
+    /// Explicit argument wins, then `DARKBLOOM_ARRIVAL_TOLERANCE_MS`, then the
+    /// default. A non-positive or non-finite override is ignored rather than
+    /// silently disabling the check.
+    private static func resolvedToleranceMs(explicit: Double?) -> Double {
+        if let explicit, explicit.isFinite, explicit > 0 { return explicit }
+        if let raw = ProcessInfo.processInfo.environment[arrivalToleranceEnvKey],
+           let parsed = Double(raw.trimmingCharacters(in: .whitespaces)),
+           parsed.isFinite, parsed > 0 {
+            return parsed
+        }
+        return defaultArrivalToleranceMs
+    }
+
+    /// Runs one arrival topology, re-running it while the delivered arrivals
+    /// miss `toleranceMs`, and failing outright once the attempts are spent —
+    /// a sample whose arrivals were not the named topology is never reported.
     private static func measure(
         engine: any CBv2Engine,
         facts: ModelFacts,
@@ -238,20 +326,84 @@ public enum ArrivalInvarianceBenchmark {
         promptTokens: Int,
         decodeTokens: Int,
         iteration: Int,
-        requestIDBase: UInt64
+        requestIDBase: UInt64,
+        toleranceMs: Double,
+        maxAttempts: Int,
+        enforceTolerance: Bool
     ) async throws -> MeasuredSample {
+        let rowCount = pattern.delaysMs.count
+        // Built before the clock starts so prompt tiling cannot leak into the
+        // measured submission offsets.
+        let prompts = (0 ..< rowCount).map { row in
+            ThroughputSweep.tile(facts.baseTokens, to: promptTokens, offset: row * 17 + 1)
+        }
+        let attempts = max(1, maxAttempts)
+        var worstObserved = 0.0
+
+        for attempt in 0 ..< attempts {
+            let (rows, scenarioStartedAt) = try await runArrivals(
+                engine: engine,
+                pattern: pattern,
+                prompts: prompts,
+                decodeTokens: decodeTokens,
+                requestIDBase: requestIDBase + UInt64(attempt * rowCount)
+            )
+            let maxArrivalError = rows
+                .map { abs($0.report.arrivalErrorMs) }
+                .max() ?? 0
+
+            if !enforceTolerance || maxArrivalError <= toleranceMs {
+                return makeSample(
+                    rows: rows,
+                    iteration: iteration,
+                    scenarioStartedAt: scenarioStartedAt,
+                    maxArrivalErrorMs: maxArrivalError,
+                    discardedAttempts: attempt
+                )
+            }
+
+            worstObserved = max(worstObserved, maxArrivalError)
+            log(
+                "  \(pattern.name) i=\(iteration): discarding attempt \(attempt + 1)"
+                    + "/\(attempts), arrival error "
+                    + "\(String(format: "%.2f", maxArrivalError)) ms > "
+                    + "\(String(format: "%.2f", toleranceMs)) ms tolerance"
+            )
+            try await Task.sleep(nanoseconds: retryCooldownNanoseconds)
+        }
+
+        throw BenchmarkError.arrivalOutOfTolerance(
+            pattern: pattern.name,
+            iteration: iteration,
+            observedMs: worstObserved,
+            toleranceMs: toleranceMs,
+            attempts: attempts
+        )
+    }
+
+    /// Submits one full topology once. Each row sleeps to an ABSOLUTE deadline
+    /// derived from the shared scenario start, so a late-starting child task
+    /// eats into its own sleep instead of shifting the whole schedule.
+    private static func runArrivals(
+        engine: any CBv2Engine,
+        pattern: PatternDefinition,
+        prompts: [[Int]],
+        decodeTokens: Int,
+        requestIDBase: UInt64
+    ) async throws -> (rows: [MeasuredRow], scenarioStartedAt: UInt64) {
+        let clock = SuspendingClock()
         let scenarioStartedAt = DispatchTime.now().uptimeNanoseconds
+        let scenarioStartInstant = clock.now
+
         let rows = try await withThrowingTaskGroup(of: MeasuredRow.self) { group in
             for (row, delayMs) in pattern.delaysMs.enumerated() {
-                let prompt = ThroughputSweep.tile(
-                    facts.baseTokens,
-                    to: promptTokens,
-                    offset: row * 17 + 1
-                )
+                let prompt = prompts[row]
                 group.addTask {
-                    if delayMs > 0 {
-                        try await Task.sleep(nanoseconds: UInt64(delayMs) * 1_000_000)
-                    }
+                    try await sleepUntilArrival(
+                        offsetMs: delayMs,
+                        scenarioStart: scenarioStartInstant,
+                        clock: clock
+                    )
                     return try await consumeRow(
                         engine: engine,
                         requestID: requestIDBase + UInt64(row),
@@ -270,7 +422,30 @@ public enum ArrivalInvarianceBenchmark {
             }
             return rows.sorted { $0.report.row < $1.report.row }
         }
+        return (rows, scenarioStartedAt)
+    }
 
+    /// Sleeps to `scenarioStart + offsetMs`, never "offsetMs from whenever this
+    /// task happened to be scheduled". Zero tolerance keeps the OS from
+    /// coalescing the wake-up into a later timer batch.
+    private static func sleepUntilArrival(
+        offsetMs: Int,
+        scenarioStart: SuspendingClock.Instant,
+        clock: SuspendingClock
+    ) async throws {
+        guard offsetMs > 0 else { return }
+        let deadline = scenarioStart.advanced(by: .milliseconds(offsetMs))
+        guard clock.now < deadline else { return }
+        try await Task.sleep(until: deadline, tolerance: .zero, clock: clock)
+    }
+
+    private static func makeSample(
+        rows: [MeasuredRow],
+        iteration: Int,
+        scenarioStartedAt: UInt64,
+        maxArrivalErrorMs: Double,
+        discardedAttempts: Int
+    ) -> MeasuredSample {
         let first = rows.map(\.firstTokenAt).min() ?? scenarioStartedAt
         let last = rows.map(\.lastTokenAt).max() ?? first
         let finished = rows.map(\.finishedAt).max() ?? last
@@ -292,7 +467,9 @@ public enum ArrivalInvarianceBenchmark {
                 endToEndTokensPerSecond: makespanSeconds > 0
                     ? Double(totalTokens) / makespanSeconds
                     : 0,
-                makespanMs: makespanSeconds * 1000
+                makespanMs: makespanSeconds * 1000,
+                maxArrivalErrorMs: maxArrivalErrorMs,
+                discardedAttempts: discardedAttempts
             ),
             outputs: rows.map(\.tokenIDs)
         )
@@ -383,11 +560,13 @@ public enum ArrivalInvarianceBenchmark {
         let decodeTPS = tokenIDs.count > 1 && decodeSeconds > 0
             ? Double(tokenIDs.count - 1) / decodeSeconds
             : 0
+        let submittedAtMs = milliseconds(from: scenarioStartedAt, to: submittedAt)
         return MeasuredRow(
             report: ArrivalInvarianceBenchmarkReport.Row(
                 row: row,
                 scheduledDelayMs: delayMs,
-                submittedAtMs: milliseconds(from: scenarioStartedAt, to: submittedAt),
+                submittedAtMs: submittedAtMs,
+                arrivalErrorMs: submittedAtMs - Double(delayMs),
                 ttftMs: milliseconds(from: submittedAt, to: first),
                 decodeTokensPerSecond: decodeTPS,
                 generatedTokens: tokenIDs.count,
@@ -442,6 +621,13 @@ public enum ArrivalInvarianceBenchmark {
         case noTokens(Int)
         case unexpectedFinish(row: Int, reason: String)
         case unexpectedTokenCount(row: Int, expected: Int, actual: Int)
+        case arrivalOutOfTolerance(
+            pattern: String,
+            iteration: Int,
+            observedMs: Double,
+            toleranceMs: Double,
+            attempts: Int
+        )
 
         var description: String {
             switch self {
@@ -450,6 +636,14 @@ public enum ArrivalInvarianceBenchmark {
                 return "row \(row) finished unexpectedly: \(reason)"
             case .unexpectedTokenCount(let row, let expected, let actual):
                 return "row \(row) produced \(actual) tokens, expected \(expected)"
+            case .arrivalOutOfTolerance(
+                let pattern, let iteration, let observed, let tolerance, let attempts
+            ):
+                return "arrival topology \(pattern) iteration \(iteration) could not be "
+                    + "delivered within \(String(format: "%.2f", tolerance)) ms in "
+                    + "\(attempts) attempt(s) (worst arrival error "
+                    + "\(String(format: "%.2f", observed)) ms); host scheduling is too "
+                    + "noisy for this measurement"
             }
         }
     }

--- a/provider-swift/Sources/ProviderBenchmark/ArrivalInvarianceBenchmark.swift
+++ b/provider-swift/Sources/ProviderBenchmark/ArrivalInvarianceBenchmark.swift
@@ -1,0 +1,460 @@
+import Foundation
+import MLX
+import MLXLLM
+import MLXLMCommon
+import MLXVLM
+import ProviderCore
+
+public struct ArrivalInvarianceBenchmarkReport: Codable, Sendable {
+    public struct Row: Codable, Sendable {
+        public let row: Int
+        public let scheduledDelayMs: Int
+        public let submittedAtMs: Double
+        public let ttftMs: Double
+        public let decodeTokensPerSecond: Double
+        public let generatedTokens: Int
+        public let completedAtMs: Double
+        public let tokenChecksum: String
+    }
+
+    public struct Sample: Codable, Sendable {
+        public let iteration: Int
+        public let rows: [Row]
+        public let aggregateDecodeTokensPerSecond: Double
+        public let endToEndTokensPerSecond: Double
+        public let makespanMs: Double
+    }
+
+    public struct Pattern: Codable, Sendable {
+        public let name: String
+        public let arrivalDelaysMs: [Int]
+        public let samples: [Sample]
+        public let medianTTFTMs: Double
+        public let medianPerRequestDecodeTokensPerSecond: Double
+        public let medianAggregateDecodeTokensPerSecond: Double
+        public let medianMakespanMs: Double
+        public let outputsStableAcrossIterations: Bool
+        public let outputsMatchBurst: Bool
+    }
+
+    public let schemaVersion: Int
+    public let modelID: String
+    public let modelPath: String
+    public let promptTokensPerRequest: Int
+    public let decodeTokensPerRequest: Int
+    public let iterations: Int
+    public let patterns: [Pattern]
+
+    public func jsonString() throws -> String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        return String(decoding: try encoder.encode(self), as: UTF8.self)
+    }
+}
+
+/// Measures production ContinuousBatchingV2 under equivalent request sets
+/// submitted with different arrival schedules. Prefix caching is absent, all
+/// rows use greedy decoding, and exact output-token checksums pin numerical
+/// invariance independently from latency and throughput.
+public enum ArrivalInvarianceBenchmark {
+    private struct PatternDefinition: Sendable {
+        let name: String
+        let delaysMs: [Int]
+    }
+
+    private struct ModelFacts: Sendable {
+        let baseTokens: [Int]
+        let weightBytes: Int
+    }
+
+    private struct EngineParts: @unchecked Sendable {
+        let engine: any CBv2Engine
+    }
+
+    private struct MeasuredRow: Sendable {
+        let report: ArrivalInvarianceBenchmarkReport.Row
+        let tokenIDs: [Int]
+        let firstTokenAt: UInt64
+        let lastTokenAt: UInt64
+        let finishedAt: UInt64
+    }
+
+    private struct MeasuredSample: Sendable {
+        let report: ArrivalInvarianceBenchmarkReport.Sample
+        let outputs: [[Int]]
+    }
+
+    private static let patterns = [
+        PatternDefinition(name: "burst", delaysMs: [0, 0, 0, 0]),
+        PatternDefinition(name: "stagger-25ms", delaysMs: [0, 25, 50, 75]),
+        PatternDefinition(name: "stagger-100ms", delaysMs: [0, 100, 200, 300]),
+        PatternDefinition(name: "rolling-250ms", delaysMs: [0, 250, 500, 750]),
+    ]
+
+    public static func run(
+        modelID: String,
+        modelDirectory: URL,
+        promptTokens: Int = 512,
+        decodeTokens: Int = 64,
+        iterations: Int = 3
+    ) async throws -> ArrivalInvarianceBenchmarkReport {
+        let promptTokens = max(2, promptTokens)
+        let decodeTokens = max(2, decodeTokens)
+        let iterations = max(1, iterations)
+        log("loading model \(modelID)")
+        log("  path: \(modelDirectory.path)")
+
+        let isVLM = ThroughputSweep.readHasVisionConfig(modelDirectory: modelDirectory)
+        let container: ModelContainer
+        if isVLM {
+            container = try await VLMModelFactory.shared.loadContainer(
+                from: modelDirectory,
+                using: LocalTokenizerLoader()
+            )
+        } else {
+            container = try await LLMModelFactory.shared.loadContainer(
+                from: modelDirectory,
+                using: LocalTokenizerLoader()
+            )
+        }
+
+        let facts = await container.perform { context -> ModelFacts in
+            let encoded = context.tokenizer.encode(
+                text: ThroughputSweep.seedText,
+                addSpecialTokens: false
+            )
+            let bytes = context.model.parameters().flattened().reduce(0) {
+                $0 + $1.1.nbytes
+            }
+            return ModelFacts(
+                baseTokens: encoded.isEmpty ? [0] : encoded,
+                weightBytes: bytes
+            )
+        }
+
+        let engine = try await makeEngine(
+            container: container,
+            modelDirectory: modelDirectory,
+            isVLM: isVLM,
+            weightBytes: facts.weightBytes,
+            maxConcurrentRequests: patterns.map(\.delaysMs.count).max() ?? 1
+        )
+
+        var samplesByPattern = Dictionary(
+            uniqueKeysWithValues: patterns.map { ($0.name, [MeasuredSample]()) }
+        )
+        var nextRequestID: UInt64 = 1
+        do {
+            // Reuse one engine so its asynchronous compiled-decode startup and
+            // every arrival topology are fully warm before measurements begin.
+            for pattern in patterns {
+                log("warming \(pattern.name)")
+                _ = try await measure(
+                    engine: engine,
+                    facts: facts,
+                    pattern: pattern,
+                    promptTokens: promptTokens,
+                    decodeTokens: min(8, decodeTokens),
+                    iteration: 0,
+                    requestIDBase: nextRequestID
+                )
+                nextRequestID += UInt64(pattern.delaysMs.count)
+            }
+
+            // Rotate topology order each repetition to avoid a fixed thermal or
+            // allocator-order bias while retaining deterministic reproduction.
+            for iteration in 1 ... iterations {
+                let shift = (iteration - 1) % patterns.count
+                let ordered = Array(patterns[shift...]) + Array(patterns[..<shift])
+                for pattern in ordered {
+                    let sample = try await measure(
+                        engine: engine,
+                        facts: facts,
+                        pattern: pattern,
+                        promptTokens: promptTokens,
+                        decodeTokens: decodeTokens,
+                        iteration: iteration,
+                        requestIDBase: nextRequestID
+                    )
+                    nextRequestID += UInt64(pattern.delaysMs.count)
+                    log(
+                        "  \(pattern.name) i=\(iteration): aggregate "
+                            + "\(String(format: "%.1f", sample.report.aggregateDecodeTokensPerSecond)) tok/s, "
+                            + "makespan \(String(format: "%.1f", sample.report.makespanMs)) ms"
+                    )
+                    samplesByPattern[pattern.name, default: []].append(sample)
+                }
+            }
+        } catch {
+            await stopAndReclaim(engine)
+            throw error
+        }
+        await stopAndReclaim(engine)
+
+        let measuredByPattern = patterns.map {
+            ($0, samplesByPattern[$0.name, default: []].sorted {
+                $0.report.iteration < $1.report.iteration
+            })
+        }
+
+        let burstOutputs = measuredByPattern.first?.1.first?.outputs ?? []
+        let patternReports = measuredByPattern.map { definition, measured in
+            let reports = measured.map(\.report)
+            let allOutputs = measured.map(\.outputs)
+            let firstOutputs = allOutputs.first ?? []
+            let stable = allOutputs.allSatisfy { $0 == firstOutputs }
+            return ArrivalInvarianceBenchmarkReport.Pattern(
+                name: definition.name,
+                arrivalDelaysMs: definition.delaysMs,
+                samples: reports,
+                medianTTFTMs: median(reports.flatMap { $0.rows.map(\.ttftMs) }),
+                medianPerRequestDecodeTokensPerSecond: median(
+                    reports.flatMap { $0.rows.map(\.decodeTokensPerSecond) }
+                ),
+                medianAggregateDecodeTokensPerSecond: median(
+                    reports.map(\.aggregateDecodeTokensPerSecond)
+                ),
+                medianMakespanMs: median(reports.map(\.makespanMs)),
+                outputsStableAcrossIterations: stable,
+                outputsMatchBurst: allOutputs.allSatisfy { $0 == burstOutputs }
+            )
+        }
+
+        return ArrivalInvarianceBenchmarkReport(
+            schemaVersion: 1,
+            modelID: modelID,
+            modelPath: modelDirectory.path,
+            promptTokensPerRequest: promptTokens,
+            decodeTokensPerRequest: decodeTokens,
+            iterations: iterations,
+            patterns: patternReports
+        )
+    }
+
+    private static func measure(
+        engine: any CBv2Engine,
+        facts: ModelFacts,
+        pattern: PatternDefinition,
+        promptTokens: Int,
+        decodeTokens: Int,
+        iteration: Int,
+        requestIDBase: UInt64
+    ) async throws -> MeasuredSample {
+        let scenarioStartedAt = DispatchTime.now().uptimeNanoseconds
+        let rows = try await withThrowingTaskGroup(of: MeasuredRow.self) { group in
+            for (row, delayMs) in pattern.delaysMs.enumerated() {
+                let prompt = ThroughputSweep.tile(
+                    facts.baseTokens,
+                    to: promptTokens,
+                    offset: row * 17 + 1
+                )
+                group.addTask {
+                    if delayMs > 0 {
+                        try await Task.sleep(nanoseconds: UInt64(delayMs) * 1_000_000)
+                    }
+                    return try await consumeRow(
+                        engine: engine,
+                        requestID: requestIDBase + UInt64(row),
+                        row: row,
+                        delayMs: delayMs,
+                        prompt: prompt,
+                        decodeTokens: decodeTokens,
+                        scenarioStartedAt: scenarioStartedAt
+                    )
+                }
+            }
+
+            var rows: [MeasuredRow] = []
+            for try await row in group {
+                rows.append(row)
+            }
+            return rows.sorted { $0.report.row < $1.report.row }
+        }
+
+        let first = rows.map(\.firstTokenAt).min() ?? scenarioStartedAt
+        let last = rows.map(\.lastTokenAt).max() ?? first
+        let finished = rows.map(\.finishedAt).max() ?? last
+        let decodeIntervals = rows.reduce(0) {
+            $0 + max(0, $1.report.generatedTokens - 1)
+        }
+        let decodeSeconds = seconds(from: first, to: last)
+        let makespanSeconds = seconds(from: scenarioStartedAt, to: finished)
+        let aggregateTPS = decodeSeconds > 0
+            ? Double(decodeIntervals) / decodeSeconds
+            : 0
+        let totalTokens = rows.reduce(0) { $0 + $1.report.generatedTokens }
+
+        return MeasuredSample(
+            report: ArrivalInvarianceBenchmarkReport.Sample(
+                iteration: iteration,
+                rows: rows.map(\.report),
+                aggregateDecodeTokensPerSecond: aggregateTPS,
+                endToEndTokensPerSecond: makespanSeconds > 0
+                    ? Double(totalTokens) / makespanSeconds
+                    : 0,
+                makespanMs: makespanSeconds * 1000
+            ),
+            outputs: rows.map(\.tokenIDs)
+        )
+    }
+
+    private static func makeEngine(
+        container: ModelContainer,
+        modelDirectory: URL,
+        isVLM: Bool,
+        weightBytes: Int,
+        maxConcurrentRequests: Int
+    ) async throws -> any CBv2Engine {
+        let kvCapacity = Int(min(
+            UnifiedMemoryCap.kvBudgetBytes(
+                physicalBytes: ProcessInfo.processInfo.physicalMemory,
+                residentWeightBytes: UInt64(max(0, weightBytes)),
+                configReserveBytes: 0
+            ),
+            UInt64(Int.max)
+        ))
+        let parts = try await container.perform { context -> EngineParts in
+            let servingModel = try EngineV2Factory.benchmarkServingModel(
+                model: context.model,
+                isVLM: isVLM,
+                modelDirectory: modelDirectory
+            )
+            return EngineParts(engine: try EngineV2Factory.makeProductionEngine(
+                model: servingModel,
+                tokenizer: context.tokenizer,
+                kvBytesCapacity: kvCapacity,
+                maxConcurrentRequests: maxConcurrentRequests
+            ))
+        }
+        return parts.engine
+    }
+
+    private static func consumeRow(
+        engine: any CBv2Engine,
+        requestID: UInt64,
+        row: Int,
+        delayMs: Int,
+        prompt: [Int],
+        decodeTokens: Int,
+        scenarioStartedAt: UInt64
+    ) async throws -> MeasuredRow {
+        let submittedAt = DispatchTime.now().uptimeNanoseconds
+        let stream = try engine.submit(CBv2Request(
+            id: CBv2RequestID(requestID),
+            promptTokens: prompt,
+            sampling: CBv2SamplingParams(temperature: 0.0),
+            maxTokens: decodeTokens,
+            stopTokens: []
+        ))
+
+        var tokenIDs: [Int] = []
+        var timestamps: [UInt64] = []
+        var finishedAt = submittedAt
+        var finishReason: CBv2FinishReason?
+        for await event in stream {
+            let now = DispatchTime.now().uptimeNanoseconds
+            switch event {
+            case .delta(_, let tokens, _):
+                tokenIDs.append(contentsOf: tokens)
+                timestamps.append(contentsOf: repeatElement(now, count: tokens.count))
+            case .finished(let reason, _):
+                finishedAt = now
+                finishReason = reason
+            }
+        }
+
+        guard let first = timestamps.first, let last = timestamps.last else {
+            throw BenchmarkError.noTokens(row)
+        }
+        guard finishReason == .length else {
+            throw BenchmarkError.unexpectedFinish(
+                row: row,
+                reason: String(describing: finishReason)
+            )
+        }
+        guard tokenIDs.count == decodeTokens else {
+            throw BenchmarkError.unexpectedTokenCount(
+                row: row,
+                expected: decodeTokens,
+                actual: tokenIDs.count
+            )
+        }
+        let decodeSeconds = seconds(from: first, to: last)
+        let decodeTPS = tokenIDs.count > 1 && decodeSeconds > 0
+            ? Double(tokenIDs.count - 1) / decodeSeconds
+            : 0
+        return MeasuredRow(
+            report: ArrivalInvarianceBenchmarkReport.Row(
+                row: row,
+                scheduledDelayMs: delayMs,
+                submittedAtMs: milliseconds(from: scenarioStartedAt, to: submittedAt),
+                ttftMs: milliseconds(from: submittedAt, to: first),
+                decodeTokensPerSecond: decodeTPS,
+                generatedTokens: tokenIDs.count,
+                completedAtMs: milliseconds(from: scenarioStartedAt, to: finishedAt),
+                tokenChecksum: checksum(tokenIDs)
+            ),
+            tokenIDs: tokenIDs,
+            firstTokenAt: first,
+            lastTokenAt: last,
+            finishedAt: finishedAt
+        )
+    }
+
+    private static func stopAndReclaim(_ engine: any CBv2Engine) async {
+        await engine.shutdown()
+        Stream().synchronize()
+        Memory.clearCache()
+    }
+
+    private static func seconds(from start: UInt64, to end: UInt64) -> Double {
+        Double(end - start) / 1_000_000_000
+    }
+
+    private static func milliseconds(from start: UInt64, to end: UInt64) -> Double {
+        Double(end - start) / 1_000_000
+    }
+
+    private static func median(_ values: [Double]) -> Double {
+        guard !values.isEmpty else { return 0 }
+        let sorted = values.sorted()
+        let middle = sorted.count / 2
+        if sorted.count.isMultiple(of: 2) {
+            return (sorted[middle - 1] + sorted[middle]) / 2
+        }
+        return sorted[middle]
+    }
+
+    private static func checksum(_ tokens: [Int]) -> String {
+        var value: UInt64 = 0xcbf29ce484222325
+        for token in tokens {
+            var word = UInt64(bitPattern: Int64(token))
+            for _ in 0 ..< 8 {
+                value ^= word & 0xff
+                value &*= 0x100000001b3
+                word >>= 8
+            }
+        }
+        return String(format: "%016llx", value)
+    }
+
+    private enum BenchmarkError: Error, CustomStringConvertible {
+        case noTokens(Int)
+        case unexpectedFinish(row: Int, reason: String)
+        case unexpectedTokenCount(row: Int, expected: Int, actual: Int)
+
+        var description: String {
+            switch self {
+            case .noTokens(let row): return "row \(row) produced no tokens"
+            case .unexpectedFinish(let row, let reason):
+                return "row \(row) finished unexpectedly: \(reason)"
+            case .unexpectedTokenCount(let row, let expected, let actual):
+                return "row \(row) produced \(actual) tokens, expected \(expected)"
+            }
+        }
+    }
+
+    private static func log(_ message: String) {
+        FileHandle.standardError.write(Data("[arrival-invariance] \(message)\n".utf8))
+    }
+}

--- a/provider-swift/Sources/ProviderBenchmark/ThroughputSweep.swift
+++ b/provider-swift/Sources/ProviderBenchmark/ThroughputSweep.swift
@@ -28,6 +28,7 @@ public enum ThroughputSweep {
     public static let defaultBatchSizes = [1, 2, 3, 4, 5, 6]
     public static let defaultDecodeTokens = 64
     public static let defaultDecodePromptTokens = 64
+    public static let defaultDecodeIterations = 1
 
     /// Snapshot of model facts read once, off-actor, inside `perform`.
     private struct ModelFacts: Sendable {
@@ -38,6 +39,12 @@ public enum ThroughputSweep {
 
     /// Run the full sweep. `hardware` supplies the peak memory bandwidth used to
     /// invert decode tok/s into implied bytes/token.
+    ///
+    /// `decodeIterations` repeats the whole decode batch curve that many times
+    /// inside the one loaded process; every repetition is emitted as its own
+    /// `DecodeSample`, so callers can take a median instead of trusting a single
+    /// noisy GPU measurement. The `derived` block is always computed from the
+    /// per-batch medians.
     public static func run(
         modelID: String,
         modelDirectory: URL,
@@ -45,6 +52,7 @@ public enum ThroughputSweep {
         batchSizes: [Int] = defaultBatchSizes,
         decodeTokens: Int = defaultDecodeTokens,
         decodePromptTokens: Int = defaultDecodePromptTokens,
+        decodeIterations: Int = defaultDecodeIterations,
         hardware: HardwareInfo,
         efficiency: Double = DecodeBandwidthModel.defaultBandwidthEfficiency
     ) async throws -> ThroughputSweepReport {
@@ -89,13 +97,16 @@ public enum ThroughputSweep {
             batchSizes: batchSizes,
             decodeTokens: decodeTokens,
             decodePromptTokens: decodePromptTokens,
+            iterations: decodeIterations,
             weightBytes: facts.weightBytes,
             isVLM: isVLM,
             modelDirectory: modelDirectory
         )
 
+        // One median sample per batch size: the B=1 implied read and the
+        // batch-scaling linearity must not hang off a single measurement.
         let derived = ThroughputSweepReport.makeDerived(
-            decode: decode,
+            decode: medianDecodeByBatch(decode),
             totalParams: facts.totalParams,
             weightBytes: facts.weightBytes,
             quantBits: quantBits,
@@ -179,6 +190,11 @@ public enum ThroughputSweep {
     /// per row), drop the first emitted token per row to exclude prefill, and
     /// report the aggregate + per-sequence steady-state decode tok/s.
     ///
+    /// The whole curve is repeated `iterations` times, batch-size-inner /
+    /// repetition-outer, so slow thermal drift is shared across batch sizes
+    /// instead of being charged entirely to the last one. Every repetition is
+    /// returned as its own sample; medians are the caller's job.
+    ///
     /// Engines run one batch size at a time: two engines on the same
     /// `ModelContainer` race shared MLX/Metal state and produce noise (matches
     /// `PerformanceLiveTests`).
@@ -189,6 +205,7 @@ public enum ThroughputSweep {
         batchSizes: [Int],
         decodeTokens: Int,
         decodePromptTokens: Int,
+        iterations: Int,
         weightBytes: Int,
         isVLM: Bool,
         modelDirectory: URL?
@@ -197,7 +214,8 @@ public enum ThroughputSweep {
         guard !sizes.isEmpty else { return [] }
         let promptLen = max(1, decodePromptTokens)
         let genTokens = max(1, decodeTokens)
-        log("decode sweep: batch sizes \(sizes), \(genTokens) tok/seq, prompt \(promptLen) tok/seq")
+        let repetitions = max(1, iterations)
+        log("decode sweep: batch sizes \(sizes), \(genTokens) tok/seq, prompt \(promptLen) tok/seq, \(repetitions) repetition(s)")
 
         // Warm-up at B=1 with a short generation to compile decode kernels
         // (CBv2 compiled decode pays its cold start here, not in a sample).
@@ -207,22 +225,24 @@ public enum ThroughputSweep {
             isVLM: isVLM, modelDirectory: modelDirectory)
 
         var samples: [ThroughputSweepReport.DecodeSample] = []
-        for batchSize in sizes {
-            let (totalTokens, maxElapsed) = await runDecodeBatch(
-                container: container, modelID: modelID, baseTokens: baseTokens,
-                batchSize: batchSize, decodeTokens: genTokens, promptLen: promptLen,
-                weightBytes: weightBytes, isVLM: isVLM, modelDirectory: modelDirectory)
-            let secs = seconds(maxElapsed)
-            let aggregate = secs > 0 ? Double(totalTokens) / secs : 0
-            let perSeq = aggregate / Double(batchSize)
-            log("  B=\(batchSize): aggregate \(String(format: "%.1f", aggregate)) tok/s, per-seq \(String(format: "%.1f", perSeq)) tok/s")
-            samples.append(ThroughputSweepReport.DecodeSample(
-                batchSize: batchSize,
-                decodeTokensPerSequence: genTokens,
-                aggregateTokensPerSecond: aggregate,
-                perSequenceTokensPerSecond: perSeq,
-                elapsedMs: secs * 1000
-            ))
+        for iteration in 1 ... repetitions {
+            for batchSize in sizes {
+                let (totalTokens, maxElapsed) = await runDecodeBatch(
+                    container: container, modelID: modelID, baseTokens: baseTokens,
+                    batchSize: batchSize, decodeTokens: genTokens, promptLen: promptLen,
+                    weightBytes: weightBytes, isVLM: isVLM, modelDirectory: modelDirectory)
+                let secs = seconds(maxElapsed)
+                let aggregate = secs > 0 ? Double(totalTokens) / secs : 0
+                let perSeq = aggregate / Double(batchSize)
+                log("  [\(iteration)/\(repetitions)] B=\(batchSize): aggregate \(String(format: "%.1f", aggregate)) tok/s, per-seq \(String(format: "%.1f", perSeq)) tok/s")
+                samples.append(ThroughputSweepReport.DecodeSample(
+                    batchSize: batchSize,
+                    decodeTokensPerSequence: genTokens,
+                    aggregateTokensPerSecond: aggregate,
+                    perSequenceTokensPerSecond: perSeq,
+                    elapsedMs: secs * 1000
+                ))
+            }
         }
         return samples
     }
@@ -361,6 +381,38 @@ public enum ThroughputSweep {
     static func seconds(_ duration: Duration) -> Double {
         Double(duration.components.seconds)
             + Double(duration.components.attoseconds) / 1e18
+    }
+
+    /// Collapse repeated decode measurements to one median sample per batch
+    /// size, ascending. Feeding this (not the raw repetition list) to
+    /// `makeDerived` keeps the B=1 implied read and the batch-scaling
+    /// linearity off a single noisy measurement, and stops a repeated batch
+    /// size from being counted N times in the linearity average.
+    static func medianDecodeByBatch(
+        _ samples: [ThroughputSweepReport.DecodeSample]
+    ) -> [ThroughputSweepReport.DecodeSample] {
+        var grouped: [Int: [ThroughputSweepReport.DecodeSample]] = [:]
+        for sample in samples { grouped[sample.batchSize, default: []].append(sample) }
+        return grouped.keys.sorted().compactMap { batchSize in
+            guard let group = grouped[batchSize], let first = group.first else { return nil }
+            return ThroughputSweepReport.DecodeSample(
+                batchSize: batchSize,
+                decodeTokensPerSequence: first.decodeTokensPerSequence,
+                aggregateTokensPerSecond: median(group.map(\.aggregateTokensPerSecond)),
+                perSequenceTokensPerSecond: median(group.map(\.perSequenceTokensPerSecond)),
+                elapsedMs: median(group.map(\.elapsedMs))
+            )
+        }
+    }
+
+    /// Low median for even counts is avoided: use the two-sided average so the
+    /// result matches Python's `statistics.median` (the runner recomputes it).
+    static func median(_ values: [Double]) -> Double {
+        guard !values.isEmpty else { return 0 }
+        let sorted = values.sorted()
+        let middle = sorted.count / 2
+        if sorted.count % 2 == 1 { return sorted[middle] }
+        return (sorted[middle - 1] + sorted[middle]) / 2
     }
 
     /// Whether the checkpoint's config.json declares a `vision_config`

--- a/provider-swift/Sources/darkbloom/BenchmarkCommand+Sweep.swift
+++ b/provider-swift/Sources/darkbloom/BenchmarkCommand+Sweep.swift
@@ -60,6 +60,33 @@ extension Benchmark {
         print(try report.jsonString())
     }
 
+    func runArrivalInvarianceBenchmark(
+        modelID: String,
+        modelDirectory: URL
+    ) async throws {
+        guard arrivalPromptTokens >= 2 else {
+            printError("--arrival-prompt-tokens must be >= 2")
+            throw ExitCode.failure
+        }
+        guard arrivalDecodeTokens >= 2 else {
+            printError("--arrival-decode-tokens must be >= 2")
+            throw ExitCode.failure
+        }
+        guard arrivalIterations >= 1 else {
+            printError("--arrival-iterations must be >= 1")
+            throw ExitCode.failure
+        }
+
+        let report = try await ArrivalInvarianceBenchmark.run(
+            modelID: modelID,
+            modelDirectory: modelDirectory,
+            promptTokens: arrivalPromptTokens,
+            decodeTokens: arrivalDecodeTokens,
+            iterations: arrivalIterations
+        )
+        print(try report.jsonString())
+    }
+
     /// Parse a comma-separated list of positive integers, ignoring blanks and
     /// non-numeric tokens.
     static func parsePositiveInts(_ raw: String) -> [Int] {

--- a/provider-swift/Sources/darkbloom/BenchmarkCommand+Sweep.swift
+++ b/provider-swift/Sources/darkbloom/BenchmarkCommand+Sweep.swift
@@ -21,6 +21,10 @@ extension Benchmark {
             printError("--max-batch must be >= 1")
             throw ExitCode.failure
         }
+        guard decodeIterations >= 1 else {
+            printError("--decode-iterations must be >= 1")
+            throw ExitCode.failure
+        }
         let batchSizes = Array(1 ... maxBatch)
 
         let report = try await ThroughputSweep.run(
@@ -30,6 +34,7 @@ extension Benchmark {
             batchSizes: batchSizes,
             decodeTokens: decodeTokens,
             decodePromptTokens: decodePromptTokens,
+            decodeIterations: decodeIterations,
             hardware: hardware
         )
 

--- a/provider-swift/Sources/darkbloom/BenchmarkCommand.swift
+++ b/provider-swift/Sources/darkbloom/BenchmarkCommand.swift
@@ -44,6 +44,12 @@ struct Benchmark: AsyncParsableCommand {
     @Option(name: .long, help: "Sweep: decode prompt length in tokens per sequence (default 64).")
     var decodePromptTokens = ThroughputSweep.defaultDecodePromptTokens
 
+    @Option(name: .long, help: """
+        Sweep: measured repetitions of the whole decode batch curve (default 1). \
+        Each repetition emits its own decode sample so callers can take a median.
+        """)
+    var decodeIterations = ThroughputSweep.defaultDecodeIterations
+
     @Flag(name: .long, help: """
         Run the cold-prefill TTFT benchmark through the production \
         ContinuousBatchingV2 engine and print a JSON report (engine-internal \

--- a/provider-swift/Sources/darkbloom/BenchmarkCommand.swift
+++ b/provider-swift/Sources/darkbloom/BenchmarkCommand.swift
@@ -54,6 +54,18 @@ struct Benchmark: AsyncParsableCommand {
     @Option(name: .long, help: "Scheduler prefill: measured iterations per length.")
     var prefillIterations = 2
 
+    @Flag(name: .long, help: "Measure production CBv2 burst-versus-staggered request arrivals and output invariance.")
+    var arrivalInvariance = false
+
+    @Option(name: .long, help: "Arrival benchmark: prompt tokens per request.")
+    var arrivalPromptTokens = 512
+
+    @Option(name: .long, help: "Arrival benchmark: generated tokens per request.")
+    var arrivalDecodeTokens = 64
+
+    @Option(name: .long, help: "Arrival benchmark: measured iterations per arrival pattern.")
+    var arrivalIterations = 3
+
     mutating func run() async throws {
         do {
             _ = try GPUEnforcement.requireMetal()
@@ -95,6 +107,14 @@ struct Benchmark: AsyncParsableCommand {
 
         if schedulerPrefill {
             try await runSchedulerPrefillBenchmark(
+                modelID: selectedModel.id,
+                modelDirectory: modelPath
+            )
+            return
+        }
+
+        if arrivalInvariance {
+            try await runArrivalInvarianceBenchmark(
                 modelID: selectedModel.id,
                 modelDirectory: modelPath
             )

--- a/provider-swift/Tests/ProviderCoreTests/ThroughputSweepTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ThroughputSweepTests.swift
@@ -208,3 +208,325 @@ struct SchedulerPrefillBenchmarkTests {
         #expect(SchedulerPrefillBenchmark.strategyLabel == "cbv2")
     }
 }
+
+// MARK: - --decode-iterations median reduction
+//
+// `--decode-iterations N` re-runs the whole decode batch curve N times and
+// emits every repetition as its own `DecodeSample`. `ThroughputSweep.run` then
+// reduces those raw samples with `medianDecodeByBatch` before handing them to
+// `ThroughputSweepReport.makeDerived`.
+//
+// The bug this replaced: a single sample was copied through and *labelled* a
+// median, so a wild first observation (cold cache, thermal spike, a stray
+// process) became the reported number. These tests pin the reduction so that
+// regression cannot come back silently — they are pure arithmetic (no MLX, no
+// model, no GPU).
+
+/// Deterministic PRNG so the "input order must not matter" shuffles are
+/// reproducible across runs (a flaky permutation would be useless evidence).
+private struct SplitMix64: RandomNumberGenerator {
+    private var state: UInt64
+    init(seed: UInt64) { state = seed }
+    mutating func next() -> UInt64 {
+        state &+= 0x9E37_79B9_7F4A_7C15
+        var z = state
+        z = (z ^ (z >> 30)) &* 0xBF58_476D_1CE4_E5B9
+        z = (z ^ (z >> 27)) &* 0x94D0_49BB_1331_11EB
+        return z ^ (z >> 31)
+    }
+}
+
+@Suite("throughput sweep: decode-iteration median reduction")
+struct ThroughputSweepMedianTests {
+
+    // MARK: Fixtures
+
+    /// One decode sample. `perSequence` defaults to the honest
+    /// `aggregate / batchSize` the sweep computes.
+    private func sample(
+        batch: Int,
+        aggregate: Double,
+        perSequence: Double? = nil,
+        elapsedMs: Double = 1000,
+        tokensPerSequence: Int = 64
+    ) -> ThroughputSweepReport.DecodeSample {
+        ThroughputSweepReport.DecodeSample(
+            batchSize: batch,
+            decodeTokensPerSequence: tokensPerSequence,
+            aggregateTokensPerSecond: aggregate,
+            perSequenceTokensPerSecond: perSequence ?? (aggregate / Double(batch)),
+            elapsedMs: elapsedMs
+        )
+    }
+
+    /// Emission order of the real sweep: repetition-outer, batch-inner.
+    /// `aggregatesByBatch[b]` lists that batch size's per-repetition readings.
+    private func curve(_ aggregatesByBatch: [(batch: Int, perRepetition: [Double])])
+        -> [ThroughputSweepReport.DecodeSample]
+    {
+        let reps = aggregatesByBatch.map(\.perRepetition.count).max() ?? 0
+        var out: [ThroughputSweepReport.DecodeSample] = []
+        for r in 0 ..< reps {
+            for entry in aggregatesByBatch where r < entry.perRepetition.count {
+                out.append(sample(batch: entry.batch, aggregate: entry.perRepetition[r]))
+            }
+        }
+        return out
+    }
+
+    private func aggregate(
+        _ samples: [ThroughputSweepReport.DecodeSample], batch: Int
+    ) -> Double? {
+        samples.first(where: { $0.batchSize == batch })?.aggregateTokensPerSecond
+    }
+
+    // MARK: 1. Odd-count median is the true middle, not the first sample
+
+    @Test("odd-count median picks the middle value and ignores a wild first sample")
+    func oddCountMedianIgnoresLeadingOutlier() {
+        // This is exactly the old bug: the FIRST reading is a wild outlier.
+        // A 3-repetition run must report 110, not the 900 it happened to see
+        // first.
+        #expect(ThroughputSweep.median([900, 100, 110]) == 110)
+        // ...and symmetrically for a wild *low* first reading.
+        #expect(ThroughputSweep.median([1, 100, 110]) == 100)
+        // Middle-of-five, unsorted input.
+        #expect(ThroughputSweep.median([4, 1, 3, 2, 5]) == 3)
+        // Single value is its own median; N=1 is the default path.
+        #expect(ThroughputSweep.median([42.5]) == 42.5)
+        // Degenerate input must not trap.
+        #expect(ThroughputSweep.median([]) == 0)
+
+        // Restated at the sample level: the reduction must not just take
+        // `group.first` (which it does use, but only for the non-numeric
+        // `decodeTokensPerSequence` field).
+        let reduced = ThroughputSweep.medianDecodeByBatch(
+            curve([(batch: 1, perRepetition: [900, 100, 110])]))
+        #expect(reduced.count == 1)
+        #expect(aggregate(reduced, batch: 1) == 110)
+        #expect(aggregate(reduced, batch: 1) != 900)
+    }
+
+    // MARK: 2. Even-count median matches Python's statistics.median
+
+    @Test("even-count median averages the two middle values (Python statistics.median)")
+    func evenCountMedianAveragesMiddlePair() {
+        // CONVENTION: for an even number of samples, `statistics.median` in
+        // Python returns the ARITHMETIC MEAN of the two middle values (it is
+        // NOT `median_low`/`median_high`). The Python side of this benchmark
+        // reduces the same decode samples with `statistics.median`, so the
+        // Swift helper must use the same convention or the two reports
+        // disagree on identical data.
+        //
+        // Expected values below were produced by CPython:
+        //   statistics.median([10, 20, 30, 40])        -> 25.0
+        //   statistics.median([1, 2])                  -> 1.5
+        //   statistics.median([1, 2, 3, 4, 5, 6])      -> 3.5
+        //   statistics.median([2.5, 7.5])              -> 5.0
+        #expect(ThroughputSweep.median([10, 20, 30, 40]) == 25.0)
+        #expect(ThroughputSweep.median([1, 2]) == 1.5)
+        #expect(ThroughputSweep.median([1, 2, 3, 4, 5, 6]) == 3.5)
+        #expect(ThroughputSweep.median([2.5, 7.5]) == 5.0)
+        // Unsorted input reduces identically (the helper sorts first).
+        #expect(ThroughputSweep.median([40, 10, 30, 20]) == 25.0)
+
+        // Explicitly NOT the low median (20) and NOT the high median (30).
+        let m = ThroughputSweep.median([10, 20, 30, 40])
+        #expect(m != 20)
+        #expect(m != 30)
+
+        // Even repetition counts flow through the sample reduction the same way.
+        let reduced = ThroughputSweep.medianDecodeByBatch(
+            curve([(batch: 2, perRepetition: [40, 10, 30, 20])]))
+        #expect(aggregate(reduced, batch: 2) == 25.0)
+    }
+
+    // MARK: 3. Grouping per batch size, independent of input order
+
+    @Test("samples are grouped per batch size and reduced independently")
+    func groupsByBatchSizeIndependently() {
+        let samples = curve([
+            (batch: 1, perRepetition: [900, 100, 110]),  // median 110
+            (batch: 2, perRepetition: [200, 220, 210]),  // median 210
+            (batch: 4, perRepetition: [400, 352, 300]),  // median 352
+        ])
+        #expect(samples.count == 9)
+
+        let reduced = ThroughputSweep.medianDecodeByBatch(samples)
+
+        // One row per DISTINCT batch size (not one per repetition), ascending.
+        #expect(reduced.count == 3)
+        #expect(reduced.map(\.batchSize) == [1, 2, 4])
+
+        // Each batch size is reduced from its OWN group only — no bleed.
+        #expect(aggregate(reduced, batch: 1) == 110)
+        #expect(aggregate(reduced, batch: 2) == 210)
+        #expect(aggregate(reduced, batch: 4) == 352)
+
+        // Non-aggregate numeric fields are reduced by median too.
+        #expect(reduced[0].perSequenceTokensPerSecond == 110)  // median of 900/1,100/1,110/1
+        #expect(reduced[1].perSequenceTokensPerSecond == 105)  // median of 100,110,105
+        #expect(reduced.allSatisfy { $0.decodeTokensPerSequence == 64 })
+        #expect(reduced.allSatisfy { $0.elapsedMs == 1000 })
+    }
+
+    @Test("input ordering does not change the reduction")
+    func reductionIsOrderIndependent() {
+        let samples = curve([
+            (batch: 1, perRepetition: [900, 100, 110]),
+            (batch: 2, perRepetition: [200, 220, 210]),
+            (batch: 4, perRepetition: [400, 352, 300]),
+        ])
+        let expected = ThroughputSweep.medianDecodeByBatch(samples)
+
+        func fingerprint(_ rows: [ThroughputSweepReport.DecodeSample])
+            -> [[Double]]
+        {
+            rows.map {
+                [Double($0.batchSize), Double($0.decodeTokensPerSequence),
+                 $0.aggregateTokensPerSecond, $0.perSequenceTokensPerSecond, $0.elapsedMs]
+            }
+        }
+
+        // Reversed emission order.
+        #expect(fingerprint(ThroughputSweep.medianDecodeByBatch(samples.reversed()))
+            == fingerprint(expected))
+
+        // Batch-outer / repetition-inner (the other plausible loop nesting).
+        let batchOuter = [1, 2, 4].flatMap { b in
+            samples.filter { $0.batchSize == b }
+        }
+        #expect(fingerprint(ThroughputSweep.medianDecodeByBatch(batchOuter))
+            == fingerprint(expected))
+
+        // Deterministic pseudo-random permutations.
+        var rng = SplitMix64(seed: 0xDA4B_1001)
+        for _ in 0 ..< 50 {
+            let shuffled = samples.shuffled(using: &rng)
+            #expect(fingerprint(ThroughputSweep.medianDecodeByBatch(shuffled))
+                == fingerprint(expected))
+        }
+    }
+
+    // MARK: 4. makeDerived consumes the medians, not the first sample
+
+    @Test("derived decode tok/s at B=1 is the median, not the first observation")
+    func derivedUsesMedianAtB1() {
+        // B=1 readings: 900 (outlier, emitted first), 100, 110 -> median 110.
+        let samples = curve([
+            (batch: 1, perRepetition: [900, 100, 110]),
+            (batch: 2, perRepetition: [220, 220, 220]),
+        ])
+
+        let derived = ThroughputSweepReport.makeDerived(
+            decode: ThroughputSweep.medianDecodeByBatch(samples),
+            totalParams: 26_000_000_000,
+            weightBytes: Int(26_000_000_000.0 * DecodeBandwidthModel.fourBitBytesPerParam),
+            quantBits: 4,
+            bandwidthGBps: 400,
+            efficiency: 0.8
+        )
+        #expect(derived.decodeTokensPerSecondAtB1 == 110)
+        #expect(derived.decodeTokensPerSecondAtB1 != 900)
+
+        // The bandwidth inversion therefore hangs off the median as well:
+        // 400 * 0.8 / 110 GB/token.
+        #expect(abs(derived.impliedReadGBPerTokenAtB1 - (320.0 / 110.0)) < 1e-12)
+
+        // Feeding the RAW samples instead reproduces the old bug: `makeDerived`
+        // takes the first B=1 row it finds, i.e. the 900 outlier.
+        let rawDerived = ThroughputSweepReport.makeDerived(
+            decode: samples,
+            totalParams: 26_000_000_000,
+            weightBytes: Int(26_000_000_000.0 * DecodeBandwidthModel.fourBitBytesPerParam),
+            quantBits: 4,
+            bandwidthGBps: 400,
+            efficiency: 0.8
+        )
+        #expect(rawDerived.decodeTokensPerSecondAtB1 == 900)
+        #expect(rawDerived.decodeTokensPerSecondAtB1 != derived.decodeTokensPerSecondAtB1)
+    }
+
+    @Test("per-batch derived metrics are computed once, not once per repetition")
+    func derivedCountsEachBatchSizeOnce() {
+        // All B=1 readings identical (110) so the B=1 anchor is the same for
+        // both paths — this isolates the "counted N times" effect from the
+        // "outlier" effect of the previous test.
+        //
+        //   B=2 readings 220, 220, 100 -> median 220 -> ratio (220/110)/2 = 1.0
+        //   B=4 readings 352, 352, 352 -> median 352 -> ratio (352/110)/4 = 0.8
+        //   linearity = mean(1.0, 0.8) = 0.9   (two points, one per batch size)
+        let samples = curve([
+            (batch: 1, perRepetition: [110, 110, 110]),
+            (batch: 2, perRepetition: [220, 220, 100]),
+            (batch: 4, perRepetition: [352, 352, 352]),
+        ])
+
+        let reduced = ThroughputSweep.medianDecodeByBatch(samples)
+        // Two B>1 points reach the linearity average, not six.
+        #expect(reduced.count == 3)
+
+        func linearity(_ decode: [ThroughputSweepReport.DecodeSample]) -> Double? {
+            ThroughputSweepReport.makeDerived(
+                decode: decode,
+                totalParams: 26_000_000_000,
+                weightBytes: Int(26_000_000_000.0 * DecodeBandwidthModel.fourBitBytesPerParam),
+                quantBits: 4, bandwidthGBps: 400, efficiency: 0.8
+            ).batchScalingLinearity
+        }
+
+        let medianLinearity = try? #require(linearity(reduced))
+        #expect(medianLinearity != nil)
+        #expect(abs((medianLinearity ?? 0) - 0.9) < 1e-12)
+
+        // Raw samples average SIX ratios (three per batch size), so the low
+        // B=2 repetition drags the answer down:
+        //   (1.0 + 1.0 + 0.4545… + 0.8 + 0.8 + 0.8) / 6 = 0.80909…
+        let rawLinearity = try? #require(linearity(samples))
+        #expect(rawLinearity != nil)
+        #expect(abs((rawLinearity ?? 0) - 0.8090909090909091) < 1e-12)
+        #expect(abs((rawLinearity ?? 0) - (medianLinearity ?? 0)) > 1e-3)
+    }
+
+    // MARK: 5. N = 1 (the default) is provably unchanged
+
+    @Test("single-iteration sweeps pass through untouched")
+    func singleIterationIsIdentity() throws {
+        #expect(ThroughputSweep.defaultDecodeIterations == 1)
+
+        // One sample per batch size — exactly what the default path produces.
+        let samples = [
+            sample(batch: 1, aggregate: 21, elapsedMs: 1234.5),
+            sample(batch: 2, aggregate: 37.8, elapsedMs: 999.25),
+            sample(batch: 6, aggregate: 101.4, elapsedMs: 1500),
+        ]
+        let reduced = ThroughputSweep.medianDecodeByBatch(samples)
+
+        #expect(reduced.count == samples.count)
+        for (original, row) in zip(samples, reduced) {
+            #expect(row.batchSize == original.batchSize)
+            #expect(row.decodeTokensPerSequence == original.decodeTokensPerSequence)
+            #expect(row.aggregateTokensPerSecond == original.aggregateTokensPerSecond)
+            #expect(row.perSequenceTokensPerSecond == original.perSequenceTokensPerSecond)
+            #expect(row.elapsedMs == original.elapsedMs)
+        }
+
+        // ...and the whole `derived` block is byte-identical to the pre-median
+        // behaviour, so N=1 reports cannot drift.
+        func derived(_ decode: [ThroughputSweepReport.DecodeSample]) throws -> Data {
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.sortedKeys]
+            return try encoder.encode(ThroughputSweepReport.makeDerived(
+                decode: decode,
+                totalParams: 26_000_000_000,
+                weightBytes: Int(26_000_000_000.0 * DecodeBandwidthModel.fourBitBytesPerParam),
+                quantBits: 4, bandwidthGBps: 400, efficiency: 0.8))
+        }
+        #expect(try derived(reduced) == (try derived(samples)))
+    }
+
+    @Test("empty decode input reduces to an empty curve")
+    func emptyInput() {
+        #expect(ThroughputSweep.medianDecodeByBatch([]).isEmpty)
+    }
+}

--- a/scripts/benchmark-gemma-contbatch.py
+++ b/scripts/benchmark-gemma-contbatch.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+"""Run and report the reproducible Gemma continuous-batching benchmark."""
+
+import subprocess
+import sys
+
+from gemma_contbatch.runner import main
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (RuntimeError, subprocess.CalledProcessError) as error:
+        print(f"benchmark failed: {error}", file=sys.stderr)
+        raise SystemExit(1) from error

--- a/scripts/gemma_contbatch/__init__.py
+++ b/scripts/gemma_contbatch/__init__.py
@@ -1,0 +1,1 @@
+"""Reproducible Gemma continuous-batching benchmark tooling."""

--- a/scripts/gemma_contbatch/arrival.py
+++ b/scripts/gemma_contbatch/arrival.py
@@ -1,0 +1,135 @@
+"""Strict validation of the arrival-invariance payload.
+
+Two independent things have to hold before an arrival number means anything:
+the measured matrix must be complete and bit-exact across topologies (here),
+and the topology the engine received must be the one the pattern is named for
+(`arrival_timing`). Both are fail-closed.
+"""
+
+from __future__ import annotations
+
+import argparse
+from collections import defaultdict
+from statistics import median
+
+from .arrival_timing import validate_arrival_bounds, validate_pattern_arrival
+from .checks import close_enough, require_positive
+from .config import EXPECTED_ARRIVAL_PATTERNS
+
+
+def validate_pattern_rows(
+    name: str, sample: dict, delays: list[int], decode_tokens: int
+) -> list[dict]:
+    rows = sample.get("rows", [])
+    if len(rows) != len(delays) or {row.get("row") for row in rows} != set(
+        range(len(delays))
+    ):
+        raise RuntimeError(
+            f"arrival topology {name} iteration {sample.get('iteration')} "
+            "has incomplete rows"
+        )
+    for row in rows:
+        if row.get("generatedTokens") != decode_tokens:
+            raise RuntimeError(
+                f"arrival topology {name} row {row.get('row')} completed "
+                f"{row.get('generatedTokens')} tokens"
+            )
+        for key in ("ttftMs", "decodeTokensPerSecond", "completedAtMs"):
+            require_positive(
+                row.get(key), f"arrival.{name}.row[{row.get('row')}].{key}"
+            )
+        if not row.get("tokenChecksum"):
+            raise RuntimeError(
+                f"arrival topology {name} row {row.get('row')} has no checksum"
+            )
+    return rows
+
+
+def validate_pattern_medians(name: str, pattern: dict, samples: list[dict]) -> None:
+    all_rows = [row for sample in samples for row in sample["rows"]]
+    computed_medians = {
+        "medianTTFTMs": median(row["ttftMs"] for row in all_rows),
+        "medianPerRequestDecodeTokensPerSecond": median(
+            row["decodeTokensPerSecond"] for row in all_rows
+        ),
+        "medianAggregateDecodeTokensPerSecond": median(
+            sample["aggregateDecodeTokensPerSecond"] for sample in samples
+        ),
+        "medianMakespanMs": median(sample["makespanMs"] for sample in samples),
+    }
+    for key, computed in computed_medians.items():
+        require_positive(pattern.get(key), f"arrival.{name}.{key}")
+        if not close_enough(pattern[key], computed):
+            raise RuntimeError(
+                f"arrival topology {name} reported inconsistent {key}: "
+                f"{pattern[key]} vs recomputed {computed}"
+            )
+
+
+def validate_checksums(checksum_sets: dict[str, dict[int, set[str]]]) -> None:
+    canonical_checksums: dict[int, str] = {}
+    for row, checksums in checksum_sets["burst"].items():
+        if len(checksums) != 1:
+            raise RuntimeError(f"burst row {row} changed output across iterations")
+        canonical_checksums[row] = next(iter(checksums))
+    for name, rows in checksum_sets.items():
+        for row, checksums in rows.items():
+            if len(checksums) != 1:
+                raise RuntimeError(
+                    f"arrival topology {name} row {row} changed output across iterations"
+                )
+            if next(iter(checksums)) != canonical_checksums.get(row):
+                raise RuntimeError(
+                    f"arrival topology {name} row {row} differs from burst output"
+                )
+
+
+def validate_arrival(args: argparse.Namespace, arrival: dict) -> None:
+    if arrival.get("promptTokensPerRequest") != args.arrival_prompt_tokens:
+        raise RuntimeError("arrival benchmark reported the wrong prompt length")
+    if arrival.get("decodeTokensPerRequest") != args.arrival_decode_tokens:
+        raise RuntimeError("arrival benchmark reported the wrong decode budget")
+    tolerance, max_attempts = validate_arrival_bounds(arrival)
+
+    patterns = arrival.get("patterns", [])
+    pattern_by_name = {pattern.get("name"): pattern for pattern in patterns}
+    if len(patterns) != len(EXPECTED_ARRIVAL_PATTERNS) or set(pattern_by_name) != set(
+        EXPECTED_ARRIVAL_PATTERNS
+    ):
+        raise RuntimeError("arrival topology matrix is incomplete")
+
+    checksum_sets: dict[str, dict[int, set[str]]] = {}
+    for name, delays in EXPECTED_ARRIVAL_PATTERNS.items():
+        pattern = pattern_by_name[name]
+        if pattern.get("arrivalDelaysMs") != delays:
+            raise RuntimeError(f"arrival topology {name} has unexpected delays")
+        if not pattern.get("outputsStableAcrossIterations") or not pattern.get(
+            "outputsMatchBurst"
+        ):
+            raise RuntimeError(f"arrival topology {name} failed exact output invariance")
+        samples = pattern.get("samples", [])
+        actual_iterations = {sample.get("iteration") for sample in samples}
+        expected_iterations = set(range(1, args.iterations + 1))
+        if len(samples) != args.iterations or actual_iterations != expected_iterations:
+            raise RuntimeError(f"arrival topology {name} has incomplete iterations")
+        checksum_sets[name] = defaultdict(set)
+        for sample_index, sample in enumerate(samples):
+            for key in (
+                "aggregateDecodeTokensPerSecond",
+                "endToEndTokensPerSecond",
+                "makespanMs",
+            ):
+                require_positive(
+                    sample.get(key), f"arrival.{name}[{sample_index}].{key}"
+                )
+            for row in validate_pattern_rows(
+                name, sample, delays, args.arrival_decode_tokens
+            ):
+                checksum_sets[name][int(row["row"])].add(row["tokenChecksum"])
+
+        validate_pattern_medians(name, pattern, samples)
+        # Only now, with a complete and self-consistent matrix, is it worth
+        # asking whether the arrivals that produced it were the named topology.
+        validate_pattern_arrival(name, pattern, delays, tolerance, max_attempts)
+
+    validate_checksums(checksum_sets)

--- a/scripts/gemma_contbatch/arrival_timing.py
+++ b/scripts/gemma_contbatch/arrival_timing.py
@@ -1,0 +1,224 @@
+"""Validation that the *delivered* arrival topology was the named one.
+
+The arrival benchmark names its topologies (burst / 25 ms / 100 ms / 250 ms),
+but a name only means something if the engine actually received requests on
+that schedule. Since arrival `schemaVersion` 2 the benchmark sleeps to absolute
+deadlines and reports what it measured, so this module checks the delivered
+arrivals and never the requested `arrivalDelaysMs`.
+
+Every check here fails closed. A payload without the measured evidence, a
+topology the host could not deliver, a measured offset outside the reported
+tolerance, or a reported aggregate that its own rows contradict all abort the
+run -- otherwise host scheduling noise is free to be read as an engine
+performance change.
+"""
+
+from __future__ import annotations
+
+from statistics import median
+
+from .checks import (
+    close_enough,
+    require_bool,
+    require_finite,
+    require_non_negative,
+    require_non_negative_int,
+)
+from .config import EXPECTED_ARRIVAL_PATTERNS
+
+STALE_BINARY_HINT = (
+    "the arrival payload predates schemaVersion 2 and carries no measured "
+    "arrival evidence, so its topology claims cannot be verified; rebuild the "
+    "benchmark binary (swift build -c release --product darkbloom) and re-run"
+)
+
+
+def require_field(payload: object, key: str, path: str) -> object:
+    """Presence check whose failure names a stale binary, not a bad metric."""
+    if not isinstance(payload, dict) or key not in payload:
+        raise RuntimeError(f"{path}.{key} is missing: {STALE_BINARY_HINT}")
+    return payload[key]
+
+
+def tightest_requested_gap_ms() -> float:
+    """The smallest positive inter-arrival gap any expected topology asks for.
+
+    Mirrors the benchmark's own derivation so a denser future topology tightens
+    the bound here too instead of silently outgrowing it.
+    """
+    gaps = [
+        second - first
+        for delays in EXPECTED_ARRIVAL_PATTERNS.values()
+        for first, second in zip(delays, delays[1:])
+        if second - first > 0
+    ]
+    return float(min(gaps)) if gaps else 25.0
+
+
+def validate_arrival_bounds(arrival: dict) -> tuple[float, int]:
+    """The root tolerance/attempt budget the rest of the checks are read against."""
+    tolerance = require_finite(
+        require_field(arrival, "arrivalToleranceMs", "arrival"),
+        "arrival.arrivalToleranceMs",
+    )
+    if tolerance <= 0:
+        raise RuntimeError(
+            f"arrival.arrivalToleranceMs must be positive, got {tolerance}"
+        )
+    # An unbounded tolerance (via DARKBLOOM_ARRIVAL_TOLERANCE_MS) would let the
+    # binary certify any schedule as the named one. Half the tightest gap keeps
+    # adjacent rows from ever crossing.
+    ceiling = tightest_requested_gap_ms() / 2
+    if tolerance > ceiling:
+        raise RuntimeError(
+            f"arrival tolerance {tolerance:.2f} ms exceeds half the tightest "
+            f"requested inter-arrival gap ({ceiling:.2f} ms), so a topology could "
+            "be certified that is not the named one; lower "
+            "DARKBLOOM_ARRIVAL_TOLERANCE_MS"
+        )
+    attempts = require_non_negative_int(
+        require_field(arrival, "arrivalMaxAttemptsPerSample", "arrival"),
+        "arrival.arrivalMaxAttemptsPerSample",
+    )
+    if attempts < 1:
+        raise RuntimeError(
+            f"arrival.arrivalMaxAttemptsPerSample must be >= 1, got {attempts}"
+        )
+    return tolerance, attempts
+
+
+def validate_row_arrival(name: str, row: dict, delays: list[int], path: str) -> float:
+    """Checks one row's measured submission and returns its absolute error."""
+    index = int(row["row"])
+    scheduled = require_field(row, "scheduledDelayMs", path)
+    if scheduled != delays[index]:
+        raise RuntimeError(
+            f"arrival topology {name} row {index} was scheduled at {scheduled} ms, "
+            f"but the topology asks for {delays[index]} ms"
+        )
+    submitted = require_non_negative(
+        require_field(row, "submittedAtMs", path), f"{path}.submittedAtMs"
+    )
+    error = require_finite(
+        require_field(row, "arrivalErrorMs", path), f"{path}.arrivalErrorMs"
+    )
+    recomputed = submitted - float(delays[index])
+    if not close_enough(error, recomputed):
+        raise RuntimeError(
+            f"arrival topology {name} row {index} reported arrivalErrorMs "
+            f"{error} ms, but submittedAtMs {submitted} ms against the requested "
+            f"{delays[index]} ms implies {recomputed}"
+        )
+    return abs(error)
+
+
+def validate_sample_arrival(
+    name: str,
+    sample: dict,
+    sample_index: int,
+    delays: list[int],
+    max_attempts: int,
+) -> float:
+    """Checks one iteration's arrival evidence and returns its worst error."""
+    path = f"arrival.{name}[{sample_index}]"
+    iteration = sample.get("iteration")
+    discarded = require_non_negative_int(
+        require_field(sample, "discardedAttempts", path), f"{path}.discardedAttempts"
+    )
+    if discarded > max_attempts - 1:
+        raise RuntimeError(
+            f"arrival topology {name} iteration {iteration} reports {discarded} "
+            f"discarded attempt(s), which the {max_attempts}-attempt budget cannot "
+            "produce"
+        )
+    reported = require_non_negative(
+        require_field(sample, "maxArrivalErrorMs", path), f"{path}.maxArrivalErrorMs"
+    )
+    worst = max(
+        validate_row_arrival(name, row, delays, f"{path}.row[{row.get('row')}]")
+        for row in sample["rows"]
+    )
+    if not close_enough(reported, worst):
+        raise RuntimeError(
+            f"arrival topology {name} iteration {iteration} reported "
+            f"maxArrivalErrorMs {reported:.4f} ms, but its rows show {worst:.4f} ms"
+        )
+    return reported
+
+
+def validate_measured_offsets(
+    name: str, pattern: dict, delays: list[int], tolerance: float
+) -> None:
+    """Each per-row median submission must land on the requested offset."""
+    path = f"arrival.{name}"
+    offsets = require_field(pattern, "measuredArrivalOffsetsMs", path)
+    if not isinstance(offsets, list) or len(offsets) != len(delays):
+        raise RuntimeError(
+            f"arrival topology {name} reported measured arrival offsets "
+            f"{offsets!r} for {len(delays)} rows"
+        )
+    samples = pattern["samples"]
+    for index, (measured, requested) in enumerate(zip(offsets, delays)):
+        offset = require_non_negative(
+            measured, f"{path}.measuredArrivalOffsetsMs[{index}]"
+        )
+        recomputed = median(
+            row["submittedAtMs"]
+            for sample in samples
+            for row in sample["rows"]
+            if int(row["row"]) == index
+        )
+        if not close_enough(offset, recomputed):
+            raise RuntimeError(
+                f"arrival topology {name} reported a measured offset of "
+                f"{offset} ms for row {index}, but its samples median "
+                f"{recomputed} ms"
+            )
+        drift = offset - float(requested)
+        if abs(drift) > tolerance:
+            raise RuntimeError(
+                f"arrival topology {name} row {index} was delivered at "
+                f"{offset:.2f} ms, {drift:+.2f} ms from the requested {requested} ms "
+                f"offset (tolerance {tolerance:.2f} ms); the measured topology is "
+                "not the named one"
+            )
+
+
+def validate_pattern_arrival(
+    name: str,
+    pattern: dict,
+    delays: list[int],
+    tolerance: float,
+    max_attempts: int,
+) -> None:
+    """Full delivered-topology check for one arrival pattern."""
+    path = f"arrival.{name}"
+    worst = max(
+        validate_sample_arrival(name, sample, index, delays, max_attempts)
+        for index, sample in enumerate(pattern["samples"])
+    )
+    reported = require_non_negative(
+        require_field(pattern, "maxArrivalErrorMs", path), f"{path}.maxArrivalErrorMs"
+    )
+    if not close_enough(reported, worst):
+        raise RuntimeError(
+            f"arrival topology {name} reported maxArrivalErrorMs {reported:.4f} ms, "
+            f"but its iterations show {worst:.4f} ms"
+        )
+    within = require_bool(
+        require_field(pattern, "arrivalWithinTolerance", path),
+        f"{path}.arrivalWithinTolerance",
+    )
+    if within and reported > tolerance:
+        raise RuntimeError(
+            f"arrival topology {name} claims arrivalWithinTolerance with a worst "
+            f"arrival error of {reported:.2f} ms, above the {tolerance:.2f} ms "
+            "tolerance it was measured against"
+        )
+    if not within:
+        raise RuntimeError(
+            f"arrival topology {name} was not delivered within {tolerance:.2f} ms "
+            f"(worst measured arrival error {reported:.2f} ms); host scheduling, "
+            "not the engine, shaped this run"
+        )
+    validate_measured_offsets(name, pattern, delays, tolerance)

--- a/scripts/gemma_contbatch/baseline.py
+++ b/scripts/gemma_contbatch/baseline.py
@@ -2,8 +2,9 @@
 
 A percentage delta against the committed baseline is only an *engine* delta if
 everything else is held constant. These checks refuse to compare when the model
-snapshot, the host hardware, or the workload shape differs, instead of silently
-attributing a weight/config/hardware difference to the code under test.
+snapshot, the host hardware, the workload shape, or the performance-relevant
+environment differs, instead of silently attributing a weight/config/hardware/
+kill-switch difference to the code under test.
 """
 
 from __future__ import annotations
@@ -11,6 +12,8 @@ from __future__ import annotations
 import argparse
 import json
 from pathlib import Path
+
+from .environment import baseline_environment
 
 
 NO_COMPARE_HINT = "pass --no-compare to run without a baseline comparison"
@@ -122,13 +125,74 @@ def validate_configuration_pin(args: argparse.Namespace, baseline: dict) -> None
         )
 
 
+def describe_env_value(value: str | None) -> str:
+    """`unset` is a bareword so it cannot be confused with the string 'unset'."""
+    return "unset" if value is None else repr(value)
+
+
+def validate_environment_pin(baseline: dict, environment: dict[str, str]) -> None:
+    """Refuse to compare when engine kill switches or MLX flags differ.
+
+    Values are compared verbatim. The harness does not normalise truthiness
+    ("0" vs "false" vs unset): each switch decides that for itself, and a
+    guess here would silently re-open the hole this pin closes.
+
+    The asymmetry that matters is a baseline with no recorded environment --
+    the committed baseline predates this pin. Such a baseline is read as an
+    implicit *empty* environment, i.e. "recorded with engine defaults":
+
+      * absent in baseline + empty run  -> match, the comparison proceeds.
+        Both sides are the default configuration, which is exactly what the
+        committed baseline was recorded under.
+      * absent in baseline + non-empty run -> REFUSE. This is the dangerous
+        case the pin exists for: a switch flipped on one side only, whose
+        effect would otherwise be reported as a code regression (or hide one).
+
+    That is deliberately not fail-open: the only permissive path requires the
+    run itself to carry no overrides. The residual risk is an old baseline
+    recorded *with* an override by a runner too old to write the block; the
+    committed baseline was not, and every baseline written from here on
+    records the block unconditionally (empty dict when nothing is set), so the
+    ambiguity is bounded to reports predating this pin.
+    """
+    try:
+        recorded = baseline_environment(baseline)
+    except RuntimeError as error:
+        raise RuntimeError(f"{error}; {NO_COMPARE_HINT}") from error
+    baseline_values = {} if recorded is None else recorded
+    # Union of keys, taking the baseline's record verbatim: the run side is
+    # already allowlist-filtered at capture, and filtering the baseline again
+    # here would let a hand-edited pin disappear instead of refusing.
+    mismatches = [
+        f"{name}={describe_env_value(environment.get(name))} "
+        f"(baseline {describe_env_value(baseline_values.get(name))})"
+        for name in sorted(set(environment) | set(baseline_values))
+        if environment.get(name) != baseline_values.get(name)
+    ]
+    if not mismatches:
+        return
+    subject = (
+        "the baseline, which records none (read as engine defaults)"
+        if recorded is None
+        else "the baseline environment"
+    )
+    raise RuntimeError(
+        f"performance environment does not match {subject}: "
+        + ", ".join(mismatches)
+        + "; "
+        + NO_COMPARE_HINT
+    )
+
+
 def validate_baseline_pins(
     args: argparse.Namespace,
     baseline: dict,
     model_snapshot: str,
     hardware: dict,
+    environment: dict[str, str],
 ) -> None:
     """Every pin that must hold before a delta can be read as an engine delta."""
     validate_model_pin(baseline, args.model, model_snapshot)
     validate_hardware_pin(baseline, hardware)
     validate_configuration_pin(args, baseline)
+    validate_environment_pin(baseline, environment)

--- a/scripts/gemma_contbatch/baseline.py
+++ b/scripts/gemma_contbatch/baseline.py
@@ -1,0 +1,134 @@
+"""Baseline loading and the fail-closed pins that gate a comparison.
+
+A percentage delta against the committed baseline is only an *engine* delta if
+everything else is held constant. These checks refuse to compare when the model
+snapshot, the host hardware, or the workload shape differs, instead of silently
+attributing a weight/config/hardware difference to the code under test.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+NO_COMPARE_HINT = "pass --no-compare to run without a baseline comparison"
+
+HARDWARE_FIELDS = ("chipName", "gpuCores", "memoryGb", "memoryBandwidthGbs")
+
+
+def load_baseline(path: Path) -> dict:
+    with path.open(encoding="utf-8") as handle:
+        baseline = json.load(handle)
+    if not isinstance(baseline, dict):
+        raise RuntimeError(f"baseline {path} is not a JSON object")
+    return baseline
+
+
+def resolve_model_snapshot(raw_outputs: dict[str, dict]) -> str:
+    """The HuggingFace snapshot directory name shared by every raw payload.
+
+    `ModelScanner.resolveLocalPath` returns `.../snapshots/<commit>`, so the
+    final path component identifies the exact weights that were measured. All
+    three benchmarks must have resolved the same one.
+    """
+    snapshots: dict[str, str] = {}
+    for name, payload in raw_outputs.items():
+        model_path = payload.get("modelPath")
+        if not isinstance(model_path, str) or not model_path.strip():
+            raise RuntimeError(f"{name} did not report a model path")
+        snapshots[name] = Path(model_path).name
+    distinct = sorted(set(snapshots.values()))
+    if len(distinct) != 1:
+        raise RuntimeError(
+            "benchmarks resolved different model snapshots: "
+            + ", ".join(f"{name}={value}" for name, value in sorted(snapshots.items()))
+        )
+    snapshot = distinct[0]
+    if not snapshot:
+        raise RuntimeError("resolved an empty model snapshot directory")
+    return snapshot
+
+
+def validate_model_pin(baseline: dict, model_id: str, model_snapshot: str) -> None:
+    baseline_model = baseline.get("modelID")
+    if baseline_model != model_id:
+        raise RuntimeError(
+            f"baseline model {baseline_model} does not match {model_id}; "
+            + NO_COMPARE_HINT
+        )
+    baseline_snapshot = baseline.get("modelSnapshot")
+    if not isinstance(baseline_snapshot, str) or not baseline_snapshot.strip():
+        raise RuntimeError(
+            "baseline does not pin modelSnapshot, so weight differences would be "
+            "reported as engine deltas; " + NO_COMPARE_HINT
+        )
+    if baseline_snapshot != model_snapshot:
+        raise RuntimeError(
+            f"model snapshot {model_snapshot} does not match the baseline "
+            f"snapshot {baseline_snapshot}; " + NO_COMPARE_HINT
+        )
+
+
+def validate_hardware_pin(baseline: dict, hardware: dict) -> None:
+    baseline_hardware = baseline.get("hardware")
+    if not isinstance(baseline_hardware, dict):
+        raise RuntimeError(
+            "baseline does not pin hardware, so host differences would be reported "
+            "as engine deltas; " + NO_COMPARE_HINT
+        )
+    missing = [field for field in HARDWARE_FIELDS if field not in baseline_hardware]
+    if missing:
+        raise RuntimeError(
+            "baseline hardware is missing " + ", ".join(missing) + "; " + NO_COMPARE_HINT
+        )
+    mismatches = [
+        f"{field}={hardware.get(field)!r} (baseline {baseline_hardware[field]!r})"
+        for field in HARDWARE_FIELDS
+        if hardware.get(field) != baseline_hardware[field]
+    ]
+    if mismatches:
+        raise RuntimeError(
+            "hardware does not match the baseline host: "
+            + ", ".join(mismatches)
+            + "; "
+            + NO_COMPARE_HINT
+        )
+
+
+def validate_configuration_pin(args: argparse.Namespace, baseline: dict) -> None:
+    baseline_configuration = baseline.get("configuration")
+    if not isinstance(baseline_configuration, dict):
+        raise RuntimeError("baseline does not record a configuration; " + NO_COMPARE_HINT)
+    expected = {
+        "decodePromptTokens": args.decode_prompt_tokens,
+        "decodeTokens": args.decode_tokens,
+        "arrivalPromptTokens": args.arrival_prompt_tokens,
+        "arrivalDecodeTokens": args.arrival_decode_tokens,
+        "maxBatch": args.max_batch,
+        "prefillLengths": list(args.prefill_lengths),
+    }
+    mismatches = [
+        f"{key}={value} (baseline {baseline_configuration.get(key)})"
+        for key, value in expected.items()
+        if baseline_configuration.get(key) != value
+    ]
+    if mismatches:
+        raise RuntimeError(
+            "benchmark shape is not comparable to the baseline: "
+            + ", ".join(mismatches)
+            + "; pass --no-compare for a different workload"
+        )
+
+
+def validate_baseline_pins(
+    args: argparse.Namespace,
+    baseline: dict,
+    model_snapshot: str,
+    hardware: dict,
+) -> None:
+    """Every pin that must hold before a delta can be read as an engine delta."""
+    validate_model_pin(baseline, args.model, model_snapshot)
+    validate_hardware_pin(baseline, hardware)
+    validate_configuration_pin(args, baseline)

--- a/scripts/gemma_contbatch/checks.py
+++ b/scripts/gemma_contbatch/checks.py
@@ -1,0 +1,62 @@
+"""Shared fail-closed primitives used by the raw-payload validators.
+
+Every helper raises `RuntimeError` with the JSON path that failed, so a bad
+payload names the field that broke instead of surfacing later as a confusing
+summary number.
+"""
+
+from __future__ import annotations
+
+import math
+
+
+def is_number(value: object) -> bool:
+    """True for real JSON numbers. `bool` is a subclass of `int`, so exclude it."""
+    return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+
+def assert_finite(value: object, path: str = "root") -> None:
+    if isinstance(value, float) and not math.isfinite(value):
+        raise RuntimeError(f"non-finite metric at {path}: {value}")
+    if isinstance(value, dict):
+        for key, child in value.items():
+            assert_finite(child, f"{path}.{key}")
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            assert_finite(child, f"{path}[{index}]")
+
+
+def require_positive(value: object, path: str) -> None:
+    if not is_number(value) or value <= 0:
+        raise RuntimeError(f"expected positive metric at {path}, got {value!r}")
+
+
+def require_finite(value: object, path: str) -> float:
+    """A finite number, returned as a float for arithmetic."""
+    if not is_number(value) or not math.isfinite(float(value)):
+        raise RuntimeError(f"expected a finite number at {path}, got {value!r}")
+    return float(value)
+
+
+def require_non_negative(value: object, path: str) -> float:
+    number = require_finite(value, path)
+    if number < 0:
+        raise RuntimeError(f"expected a non-negative number at {path}, got {value!r}")
+    return number
+
+
+def require_bool(value: object, path: str) -> bool:
+    if not isinstance(value, bool):
+        raise RuntimeError(f"expected a boolean at {path}, got {value!r}")
+    return value
+
+
+def require_non_negative_int(value: object, path: str) -> int:
+    if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+        raise RuntimeError(f"expected a non-negative integer at {path}, got {value!r}")
+    return value
+
+
+def close_enough(left: float, right: float) -> bool:
+    """The tolerance the module uses when recomputing a reported aggregate."""
+    return math.isclose(left, right, rel_tol=1e-9, abs_tol=1e-6)

--- a/scripts/gemma_contbatch/config.py
+++ b/scripts/gemma_contbatch/config.py
@@ -10,12 +10,6 @@ DEFAULT_MODEL = "mlx-community/gemma-4-26B-A4B-it-qat-4bit"
 BASELINE_RELATIVE_PATH = Path(
     "docs/reports/2026-07-23-gemma-4-26b-qat4bit-continuous-batching-baseline.json"
 )
-PERFORMANCE_ENV_PREFIXES = (
-    "DARKBLOOM_CBV2_",
-    "DARKBLOOM_MEM_CAP_",
-    "DARKBLOOM_ACTIVATION_RESERVE_",
-    "MLX_METAL_",
-)
 EXPECTED_ARRIVAL_PATTERNS = {
     "burst": [0, 0, 0, 0],
     "stagger-25ms": [0, 25, 50, 75],

--- a/scripts/gemma_contbatch/config.py
+++ b/scripts/gemma_contbatch/config.py
@@ -1,0 +1,77 @@
+"""Benchmark constants and command-line parsing."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+
+DEFAULT_MODEL = "mlx-community/gemma-4-26B-A4B-it-qat-4bit"
+BASELINE_RELATIVE_PATH = Path(
+    "docs/reports/2026-07-23-gemma-4-26b-qat4bit-continuous-batching-baseline.json"
+)
+PERFORMANCE_ENV_PREFIXES = (
+    "DARKBLOOM_CBV2_",
+    "DARKBLOOM_MEM_CAP_",
+    "DARKBLOOM_ACTIVATION_RESERVE_",
+    "MLX_METAL_",
+)
+EXPECTED_ARRIVAL_PATTERNS = {
+    "burst": [0, 0, 0, 0],
+    "stagger-25ms": [0, 25, 50, 75],
+    "stagger-100ms": [0, 100, 200, 300],
+    "rolling-250ms": [0, 250, 500, 750],
+}
+
+
+def parse_positive_ints(value: str) -> list[int]:
+    try:
+        values = [int(part.strip()) for part in value.split(",") if part.strip()]
+    except ValueError as error:
+        raise argparse.ArgumentTypeError("expected comma-separated integers") from error
+    if not values or any(item <= 0 for item in values):
+        raise argparse.ArgumentTypeError("values must be positive integers")
+    return values
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Build Darkbloom and run Gemma raw-prefill, production-TTFT, "
+            "decode-batch, and arrival-invariance benchmarks."
+        )
+    )
+    parser.add_argument("--model", default=DEFAULT_MODEL)
+    parser.add_argument("--iterations", type=int, default=3)
+    parser.add_argument(
+        "--prefill-lengths", type=parse_positive_ints, default=[128, 512, 2048]
+    )
+    parser.add_argument("--max-batch", type=int, default=4)
+    parser.add_argument("--decode-prompt-tokens", type=int, default=64)
+    parser.add_argument("--decode-tokens", type=int, default=64)
+    parser.add_argument("--arrival-prompt-tokens", type=int, default=512)
+    parser.add_argument("--arrival-decode-tokens", type=int, default=64)
+    parser.add_argument("--label", default="")
+    parser.add_argument("--output-dir", default="tmp/benchmarks")
+    parser.add_argument("--baseline", default=str(BASELINE_RELATIVE_PATH))
+    parser.add_argument("--no-compare", action="store_true")
+    parser.add_argument("--skip-build", action="store_true")
+    parser.add_argument("--skip-metallib", action="store_true")
+    args = parser.parse_args()
+
+    numeric = {
+        "--iterations": args.iterations,
+        "--max-batch": args.max_batch,
+        "--decode-prompt-tokens": args.decode_prompt_tokens,
+        "--decode-tokens": args.decode_tokens,
+        "--arrival-prompt-tokens": args.arrival_prompt_tokens,
+        "--arrival-decode-tokens": args.arrival_decode_tokens,
+    }
+    invalid = [name for name, value in numeric.items() if value <= 0]
+    if invalid:
+        parser.error(f"{', '.join(invalid)} must be positive")
+    if any(length < 2 for length in args.prefill_lengths):
+        parser.error("--prefill-lengths values must be >= 2")
+    if len(set(args.prefill_lengths)) != len(args.prefill_lengths):
+        parser.error("--prefill-lengths must not contain duplicates")
+    return args

--- a/scripts/gemma_contbatch/environment.py
+++ b/scripts/gemma_contbatch/environment.py
@@ -1,0 +1,107 @@
+"""The performance-relevant process environment: what it is, and how to read it.
+
+The engine ships per-feature kill switches and MLX kernel flags. Flipping one
+changes measured throughput without changing a single line of committed code,
+so the set of switches in effect is as much a part of "what was measured" as
+the model snapshot and the host. This module owns the single definition of
+which variables count, so the copy recorded in a report and the copy compared
+against a baseline can never diverge.
+
+The set is an explicit allowlist rather than the whole environment: a report
+must not leak secrets or paths, and an unrelated variable (PATH, TERM, HOME,
+SSH_AUTH_SOCK) must never block a comparison.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+
+# Variable families that change how tokens are computed or scheduled. A prefix
+# is used where the engine exposes a family of related knobs.
+#
+#   DARKBLOOM_ACTIVATION_RESERVE_  UnifiedMemoryCap activation reserve -> KV headroom
+#   DARKBLOOM_CBV2_                continuous-batching v2 scheduler/kernel switches
+#                                  (e.g. MIXED_PREFILL_CAP, PAGED_KV, COMPILED, MTP)
+#   DARKBLOOM_GEMMA4_              Gemma-4 prefill kernel kill switches
+#                                  (PREFILL_TAIL_ROWS, PREFILL_LAST_QUERY, ...)
+#   DARKBLOOM_MEM_CAP_             UnifiedMemoryCap fraction -> what fits in memory
+#   DARKBLOOM_MTP_                 multi-token prediction / speculative decode
+#   DARKBLOOM_PREFIX_CACHE         prefix-cache admission, persistence, and limits
+#   MLX_METAL_                     MLX Metal backend behaviour
+PERFORMANCE_ENV_PREFIXES = (
+    "DARKBLOOM_ACTIVATION_RESERVE_",
+    "DARKBLOOM_CBV2_",
+    "DARKBLOOM_GEMMA4_",
+    "DARKBLOOM_MEM_CAP_",
+    "DARKBLOOM_MTP_",
+    "DARKBLOOM_PREFIX_CACHE",
+    "MLX_METAL_",
+)
+
+# Individually named switches that do not share a family prefix. Each one
+# selects a different code path through prefill, decode, or the quantized
+# expert kernels, so a run with one flipped is not comparable to a run without.
+PERFORMANCE_ENV_NAMES = frozenset(
+    {
+        "DARKBLOOM_ADAPTIVE_PREFILL_ALLOW_8192",
+        "DARKBLOOM_B1_GREEDY_FAST_PATH",
+        "DARKBLOOM_BF16_CHUNK_MB",
+        "DARKBLOOM_BF16_WEIGHTS",
+        "DARKBLOOM_COMPILED_DECODE",
+        "DARKBLOOM_ENGINE_V2",
+        "DARKBLOOM_ENGINE_V2_MODELS",
+        "DARKBLOOM_EXPERT_TILES_GATEUP",
+        "DARKBLOOM_GEMMA_B1_FAST_PATH",
+        "DARKBLOOM_KV_GPTOSS_KERNEL",
+        "DARKBLOOM_MLX_MEMORY_RESERVE_GB",
+        "MLX_COMPILED_DECODE",
+        "MLX_DISABLE_COMPILE",
+        "MLX_GATHER_QMM_EXPERT_SLICES",
+        "MLX_METALLIB_PATH",
+    }
+)
+
+
+def is_performance_variable(name: str) -> bool:
+    return name.startswith(PERFORMANCE_ENV_PREFIXES) or name in PERFORMANCE_ENV_NAMES
+
+
+def performance_environment(environ: Mapping[str, str]) -> dict[str, str]:
+    """The allowlisted overrides in effect, sorted for a stable report diff."""
+    return {
+        key: value
+        for key, value in sorted(environ.items())
+        if is_performance_variable(key)
+    }
+
+
+def baseline_environment(baseline: Mapping[str, object]) -> dict[str, str] | None:
+    """The environment a baseline recorded: `None` when it recorded none.
+
+    `None` means "this baseline predates the environment pin" and is not the
+    same as `{}`, which is a positive record of "no overrides were set".
+    Malformed shapes raise rather than being coerced -- a pin that cannot be
+    read is not a pin.
+    """
+    metadata = baseline.get("metadata")
+    if metadata is None:
+        return None
+    if not isinstance(metadata, dict):
+        raise RuntimeError("baseline metadata is not a JSON object")
+    if "environment" not in metadata:
+        return None
+    environment = metadata["environment"]
+    if not isinstance(environment, dict):
+        raise RuntimeError("baseline metadata.environment is not a JSON object")
+    invalid = sorted(
+        str(key)
+        for key, value in environment.items()
+        if not isinstance(key, str) or not isinstance(value, str)
+    )
+    if invalid:
+        raise RuntimeError(
+            "baseline metadata.environment has non-string entries: "
+            + ", ".join(invalid)
+        )
+    return dict(environment)

--- a/scripts/gemma_contbatch/process.py
+++ b/scripts/gemma_contbatch/process.py
@@ -1,0 +1,95 @@
+"""Subprocess, hashing, source fingerprinting, and atomic file helpers."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+
+
+def run_step(
+    command: list[str], cwd: Path, env: dict[str, str] | None = None
+) -> None:
+    print(f"+ {shlex.join(command)}", file=sys.stderr, flush=True)
+    subprocess.run(command, cwd=cwd, check=True, env=env)
+
+
+def run_json(command: list[str], cwd: Path) -> dict:
+    print(f"+ {shlex.join(command)}", file=sys.stderr, flush=True)
+    result = subprocess.run(
+        command,
+        cwd=cwd,
+        check=False,
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    if result.returncode != 0:
+        if result.stdout:
+            print(result.stdout, file=sys.stderr)
+        raise subprocess.CalledProcessError(result.returncode, command)
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError as error:
+        print(result.stdout, file=sys.stderr)
+        raise RuntimeError(f"benchmark emitted invalid JSON: {error}") from error
+
+
+def capture(command: list[str], cwd: Path) -> str:
+    result = subprocess.run(
+        command,
+        cwd=cwd,
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def capture_optional(command: list[str], cwd: Path) -> str:
+    try:
+        return capture(command, cwd)
+    except (OSError, subprocess.CalledProcessError):
+        return "unavailable"
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def source_fingerprint(path: Path) -> tuple[list[str], str]:
+    status = capture(["git", "status", "--short"], path).splitlines()
+    digest = hashlib.sha256()
+    digest.update(capture(["git", "rev-parse", "HEAD"], path).encode())
+    if status:
+        tracked_diff = subprocess.run(
+            ["git", "diff", "--binary", "HEAD"],
+            cwd=path,
+            check=True,
+            stdout=subprocess.PIPE,
+        ).stdout
+        digest.update(tracked_diff)
+        untracked = capture(
+            ["git", "ls-files", "--others", "--exclude-standard"], path
+        ).splitlines()
+        for relative in sorted(untracked):
+            source = path / relative
+            digest.update(relative.encode())
+            if source.is_file():
+                with source.open("rb") as handle:
+                    for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                        digest.update(chunk)
+    return status, digest.hexdigest()
+
+
+def atomic_write(path: Path, content: str) -> None:
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    temporary.write_text(content, encoding="utf-8")
+    temporary.replace(path)

--- a/scripts/gemma_contbatch/report.py
+++ b/scripts/gemma_contbatch/report.py
@@ -1,0 +1,160 @@
+"""Markdown rendering for benchmark reports."""
+
+from __future__ import annotations
+
+from .results import index_by
+
+
+def format_number(value: float, digits: int = 1) -> str:
+    return f"{value:,.{digits}f}"
+
+
+def format_delta(value: float | None) -> str:
+    return "n/a" if value is None else f"{value:+.2f}%"
+
+
+def lookup_comparison(comparisons: dict | None, section: str, key: str) -> dict:
+    if not comparisons:
+        return {}
+    lookup_key = {
+        "prefill": "promptTokens",
+        "schedulerTTFT": "promptTokens",
+        "decode": "batchSize",
+        "arrival": "name",
+    }[section]
+    return index_by(comparisons.get(section, []), lookup_key).get(key, {})
+
+
+def markdown_report(report: dict) -> str:
+    summary = report["summary"]
+    metadata = report["metadata"]
+    configuration = report["configuration"]
+    comparisons = report.get("comparison")
+    hardware = report["raw"]["throughputSweep"]["hardware"]
+    model_path = report["raw"]["throughputSweep"]["modelPath"]
+    dirty = metadata["gitStatus"] or ["clean"]
+    dirty_value = "<br>".join(dirty)
+
+    lines = [
+        "# Gemma Continuous-Batching Benchmark",
+        "",
+        "| Field | Value |",
+        "|---|---|",
+        f"| Generated | {report['generatedAt']} |",
+        f"| Label | {report.get('label') or 'unlabeled'} |",
+        f"| Model | `{report['modelID']}` |",
+        f"| Model path | `{model_path}` |",
+        f"| Hardware | {hardware['chipName']}, {hardware['gpuCores']} GPU cores, {hardware['memoryGb']} GB |",
+        f"| Root commit | `{metadata['rootCommit']}` |",
+        f"| Binary SHA-256 | `{metadata['binarySha256']}` |",
+        f"| Metallib SHA-256 | `{metadata['metallibSha256']}` |",
+        f"| Working tree | {dirty_value} |",
+        f"| Duration | {format_number(report['durationSeconds'], 1)} seconds |",
+        "",
+        "## Configuration",
+        "",
+        "| Setting | Value |",
+        "|---|---:|",
+        f"| Iterations | {configuration['iterations']} |",
+        f"| Prefill lengths | {', '.join(map(str, configuration['prefillLengths']))} |",
+        f"| Decode prompt / output | {configuration['decodePromptTokens']} / {configuration['decodeTokens']} tokens |",
+        f"| Maximum decode batch | {configuration['maxBatch']} |",
+        f"| Arrival prompt / output | {configuration['arrivalPromptTokens']} / {configuration['arrivalDecodeTokens']} tokens |",
+        "",
+        "## Raw Prefill",
+        "",
+        "| Prompt | Median elapsed | Median tok/s | vs baseline tok/s |",
+        "|---:|---:|---:|---:|",
+    ]
+    for item in summary["prefill"]:
+        delta = lookup_comparison(
+            comparisons, "prefill", item["promptTokens"]
+        ).get("tokensPerSecondPercent")
+        lines.append(
+            f"| {item['promptTokens']:,} | {format_number(item['medianElapsedMs'])} ms "
+            f"| {format_number(item['medianTokensPerSecond'])} | {format_delta(delta)} |"
+        )
+
+    lines += [
+        "",
+        "## Production TTFT",
+        "",
+        "| Prompt | Median TTFT | vs baseline |",
+        "|---:|---:|---:|",
+    ]
+    for item in summary["schedulerTTFT"]:
+        delta = lookup_comparison(
+            comparisons, "schedulerTTFT", item["promptTokens"]
+        ).get("ttftMsPercent")
+        lines.append(
+            f"| {item['promptTokens']:,} | {format_number(item['medianTTFTMs'])} ms "
+            f"| {format_delta(delta)} |"
+        )
+
+    lines += [
+        "",
+        "## Decode Batch Curve",
+        "",
+        "| Batch | Per-request tok/s | Aggregate tok/s | Aggregate vs baseline |",
+        "|---:|---:|---:|---:|",
+    ]
+    for item in summary["decode"]:
+        delta = lookup_comparison(
+            comparisons, "decode", item["batchSize"]
+        ).get("aggregatePercent")
+        lines.append(
+            f"| {item['batchSize']} | {format_number(item['perRequestTokensPerSecond'])} "
+            f"| {format_number(item['aggregateTokensPerSecond'])} | {format_delta(delta)} |"
+        )
+
+    lines += [
+        "",
+        "## Arrival Schedules",
+        "",
+        "| Schedule | Median TTFT | Decode-window TPS | End-to-end TPS | Makespan | E2E vs baseline |",
+        "|---|---:|---:|---:|---:|---:|",
+    ]
+    for item in summary["arrival"]:
+        delta = lookup_comparison(comparisons, "arrival", item["name"]).get(
+            "endToEndPercent"
+        )
+        delays = "/".join(map(str, item["arrivalDelaysMs"]))
+        lines.append(
+            f"| {item['name']} ({delays} ms) | {format_number(item['medianTTFTMs'])} ms "
+            f"| {format_number(item['medianAggregateDecodeTokensPerSecond'])} "
+            f"| {format_number(item['medianEndToEndTokensPerSecond'])} "
+            f"| {format_number(item['medianMakespanMs'])} ms | {format_delta(delta)} |"
+        )
+
+    lines += [
+        "",
+        "## Per-Row Arrival Detail",
+        "",
+        "| Schedule | Row | Median TTFT | Median decode tok/s |",
+        "|---|---:|---:|---:|",
+    ]
+    for item in summary["arrival"]:
+        for row in item["rows"]:
+            lines.append(
+                f"| {item['name']} | {row['row']} | {format_number(row['medianTTFTMs'])} ms "
+                f"| {format_number(row['medianDecodeTokensPerSecond'])} |"
+            )
+
+    invariant = all(
+        item["outputsStableAcrossIterations"] and item["outputsMatchBurst"]
+        for item in summary["arrival"]
+    )
+    lines += [
+        "",
+        "## Validation",
+        "",
+        f"- Exact output invariance: {'PASS' if invariant else 'FAIL'}",
+        f"- Thermal state before: {metadata['thermalBefore'].replace(chr(10), '; ')}",
+        f"- Thermal state after: {metadata['thermalAfter'].replace(chr(10), '; ')}",
+        "",
+        "Decode-window TPS spans the earliest first token through the latest last token, so staggered schedules include later prefills and low-concurrency gaps. End-to-end TPS is all output tokens divided by total makespan.",
+        "",
+        "The complete raw benchmark payload and every repetition are in the companion JSON report.",
+        "",
+    ]
+    return "\n".join(lines)

--- a/scripts/gemma_contbatch/report.py
+++ b/scripts/gemma_contbatch/report.py
@@ -13,7 +13,58 @@ def format_delta(value: float | None) -> str:
     return "n/a" if value is None else f"{value:+.2f}%"
 
 
-def lookup_comparison(comparisons: dict | None, section: str, key: str) -> dict:
+def format_offsets(values: list[float | int], digits: int = 0) -> str:
+    return " / ".join(f"{float(value):.{digits}f}" for value in values)
+
+
+def arrival_fidelity_lines(summary: dict) -> list[str]:
+    """Requested vs *delivered* arrival offsets, plus the retry evidence.
+
+    The topology names only describe the run if the engine actually received
+    requests on that schedule, so the measured offsets are reported next to the
+    requested ones. `discardedAttempts` is a host-noise signal -- it is omitted
+    entirely when every topology landed on the first attempt.
+    """
+    tolerance = summary["arrivalToleranceMs"]
+    lines = [
+        "",
+        "## Arrival Timing Fidelity",
+        "",
+        f"Measured against a {tolerance:.2f} ms tolerance, up to "
+        f"{summary['arrivalMaxAttemptsPerSample']} attempt(s) per sample.",
+        "",
+        "| Schedule | Requested (ms) | Measured (ms) | Max error | Within tolerance |",
+        "|---|---|---|---:|---|",
+    ]
+    for item in summary["arrival"]:
+        lines.append(
+            f"| {item['name']} | {format_offsets(item['arrivalDelaysMs'])} "
+            f"| {format_offsets(item['measuredArrivalOffsetsMs'], 1)} "
+            f"| {item['maxArrivalErrorMs']:.2f} ms "
+            f"| {'yes' if item['arrivalWithinTolerance'] else 'NO'} |"
+        )
+    discarded = [item for item in summary["arrival"] if item["discardedAttempts"]]
+    if discarded:
+        lines += [
+            "",
+            "Attempts discarded for missing the arrival tolerance (host scheduling noise):",
+            "",
+        ]
+        for item in discarded:
+            per_iteration = ", ".join(
+                f"i={sample['iteration']}: {sample['discardedAttempts']}"
+                for sample in item["samples"]
+                if sample["discardedAttempts"]
+            )
+            lines.append(
+                f"- {item['name']}: {item['discardedAttempts']} ({per_iteration})"
+            )
+    return lines
+
+
+def lookup_comparison(
+    comparisons: dict | None, section: str, key: str | int
+) -> dict:
     if not comparisons:
         return {}
     lookup_key = {
@@ -43,6 +94,7 @@ def markdown_report(report: dict) -> str:
         f"| Generated | {report['generatedAt']} |",
         f"| Label | {report.get('label') or 'unlabeled'} |",
         f"| Model | `{report['modelID']}` |",
+        f"| Model snapshot | `{report['modelSnapshot']}` |",
         f"| Model path | `{model_path}` |",
         f"| Hardware | {hardware['chipName']}, {hardware['gpuCores']} GPU cores, {hardware['memoryGb']} GB |",
         f"| Root commit | `{metadata['rootCommit']}` |",
@@ -59,6 +111,7 @@ def markdown_report(report: dict) -> str:
         f"| Prefill lengths | {', '.join(map(str, configuration['prefillLengths']))} |",
         f"| Decode prompt / output | {configuration['decodePromptTokens']} / {configuration['decodeTokens']} tokens |",
         f"| Maximum decode batch | {configuration['maxBatch']} |",
+        f"| Decode samples per batch | {configuration['decodeIterations']} |",
         f"| Arrival prompt / output | {configuration['arrivalPromptTokens']} / {configuration['arrivalDecodeTokens']} tokens |",
         "",
         "## Raw Prefill",
@@ -95,15 +148,16 @@ def markdown_report(report: dict) -> str:
         "",
         "## Decode Batch Curve",
         "",
-        "| Batch | Per-request tok/s | Aggregate tok/s | Aggregate vs baseline |",
-        "|---:|---:|---:|---:|",
+        "| Batch | Samples | Median per-request tok/s | Median aggregate tok/s | Aggregate vs baseline |",
+        "|---:|---:|---:|---:|---:|",
     ]
     for item in summary["decode"]:
         delta = lookup_comparison(
             comparisons, "decode", item["batchSize"]
         ).get("aggregatePercent")
         lines.append(
-            f"| {item['batchSize']} | {format_number(item['perRequestTokensPerSecond'])} "
+            f"| {item['batchSize']} | {item['sampleCount']} "
+            f"| {format_number(item['perRequestTokensPerSecond'])} "
             f"| {format_number(item['aggregateTokensPerSecond'])} | {format_delta(delta)} |"
         )
 
@@ -126,17 +180,22 @@ def markdown_report(report: dict) -> str:
             f"| {format_number(item['medianMakespanMs'])} ms | {format_delta(delta)} |"
         )
 
+    lines += arrival_fidelity_lines(summary)
+
     lines += [
         "",
         "## Per-Row Arrival Detail",
         "",
-        "| Schedule | Row | Median TTFT | Median decode tok/s |",
-        "|---|---:|---:|---:|",
+        "| Schedule | Row | Requested arrival | Measured arrival | Median TTFT | Median decode tok/s |",
+        "|---|---:|---:|---:|---:|---:|",
     ]
     for item in summary["arrival"]:
         for row in item["rows"]:
+            index = row["row"]
             lines.append(
-                f"| {item['name']} | {row['row']} | {format_number(row['medianTTFTMs'])} ms "
+                f"| {item['name']} | {index} | {item['arrivalDelaysMs'][index]} ms "
+                f"| {format_number(item['measuredArrivalOffsetsMs'][index], 2)} ms "
+                f"| {format_number(row['medianTTFTMs'])} ms "
                 f"| {format_number(row['medianDecodeTokensPerSecond'])} |"
             )
 
@@ -144,15 +203,26 @@ def markdown_report(report: dict) -> str:
         item["outputsStableAcrossIterations"] and item["outputsMatchBurst"]
         for item in summary["arrival"]
     )
+    arrivals_delivered = all(
+        item["arrivalWithinTolerance"] for item in summary["arrival"]
+    )
+    worst_arrival_error = max(
+        (item["maxArrivalErrorMs"] for item in summary["arrival"]), default=0.0
+    )
     lines += [
         "",
         "## Validation",
         "",
         f"- Exact output invariance: {'PASS' if invariant else 'FAIL'}",
+        f"- Delivered arrival topology: {'PASS' if arrivals_delivered else 'FAIL'} "
+        f"(worst arrival error {worst_arrival_error:.2f} ms against a "
+        f"{summary['arrivalToleranceMs']:.2f} ms tolerance)",
         f"- Thermal state before: {metadata['thermalBefore'].replace(chr(10), '; ')}",
         f"- Thermal state after: {metadata['thermalAfter'].replace(chr(10), '; ')}",
         "",
         "Decode-window TPS spans the earliest first token through the latest last token, so staggered schedules include later prefills and low-concurrency gaps. End-to-end TPS is all output tokens divided by total makespan.",
+        "",
+        "Arrival offsets are measured at submission against absolute deadlines, so every schedule above is the one the engine actually received, not the one that was requested.",
         "",
         "The complete raw benchmark payload and every repetition are in the companion JSON report.",
         "",

--- a/scripts/gemma_contbatch/results.py
+++ b/scripts/gemma_contbatch/results.py
@@ -1,0 +1,231 @@
+"""Benchmark summaries, baseline comparisons, and comparison validation."""
+
+from __future__ import annotations
+
+import argparse
+from collections import defaultdict
+from statistics import median
+
+
+def summarize(sweep: dict, scheduler: dict, arrival: dict) -> dict:
+    prefill_groups: dict[int, list[dict]] = defaultdict(list)
+    for sample in sweep["prefill"]:
+        prefill_groups[int(sample["promptTokens"])].append(sample)
+    prefill = []
+    for prompt_tokens, samples in sorted(prefill_groups.items()):
+        prefill.append(
+            {
+                "promptTokens": prompt_tokens,
+                "medianElapsedMs": median(item["elapsedMs"] for item in samples),
+                "medianTokensPerSecond": median(
+                    item["prefillTokensPerSecond"] for item in samples
+                ),
+                "samples": [
+                    {
+                        "elapsedMs": item["elapsedMs"],
+                        "tokensPerSecond": item["prefillTokensPerSecond"],
+                    }
+                    for item in samples
+                ],
+            }
+        )
+
+    ttft_groups: dict[int, list[dict]] = defaultdict(list)
+    for sample in scheduler["samples"]:
+        ttft_groups[int(sample["promptTokens"])].append(sample)
+    scheduler_ttft = []
+    for prompt_tokens, samples in sorted(ttft_groups.items()):
+        scheduler_ttft.append(
+            {
+                "promptTokens": prompt_tokens,
+                "medianTTFTMs": median(item["ttftMs"] for item in samples),
+                "samples": [
+                    {
+                        "ttftMs": item["ttftMs"],
+                        "msPerPrefillToken": item["msPerPrefillToken"],
+                    }
+                    for item in samples
+                ],
+            }
+        )
+
+    decode = [
+        {
+            "batchSize": item["batchSize"],
+            "elapsedMs": item["elapsedMs"],
+            "perRequestTokensPerSecond": item["perSequenceTokensPerSecond"],
+            "aggregateTokensPerSecond": item["aggregateTokensPerSecond"],
+        }
+        for item in sweep["decode"]
+    ]
+
+    arrival_summary = []
+    for pattern in arrival["patterns"]:
+        all_rows = [row for sample in pattern["samples"] for row in sample["rows"]]
+        row_groups: dict[int, list[dict]] = defaultdict(list)
+        for sample in pattern["samples"]:
+            for row in sample["rows"]:
+                row_groups[int(row["row"])].append(row)
+        rows = [
+            {
+                "row": row,
+                "medianTTFTMs": median(item["ttftMs"] for item in samples),
+                "medianDecodeTokensPerSecond": median(
+                    item["decodeTokensPerSecond"] for item in samples
+                ),
+            }
+            for row, samples in sorted(row_groups.items())
+        ]
+        arrival_summary.append(
+            {
+                "name": pattern["name"],
+                "arrivalDelaysMs": pattern["arrivalDelaysMs"],
+                "medianTTFTMs": median(row["ttftMs"] for row in all_rows),
+                "medianPerRequestDecodeTokensPerSecond": median(
+                    row["decodeTokensPerSecond"] for row in all_rows
+                ),
+                "medianAggregateDecodeTokensPerSecond": median(
+                    item["aggregateDecodeTokensPerSecond"]
+                    for item in pattern["samples"]
+                ),
+                "medianEndToEndTokensPerSecond": median(
+                    item["endToEndTokensPerSecond"] for item in pattern["samples"]
+                ),
+                "medianMakespanMs": median(
+                    item["makespanMs"] for item in pattern["samples"]
+                ),
+                "outputsStableAcrossIterations": pattern[
+                    "outputsStableAcrossIterations"
+                ],
+                "outputsMatchBurst": pattern["outputsMatchBurst"],
+                "samples": [
+                    {
+                        "iteration": item["iteration"],
+                        "aggregateDecodeTokensPerSecond": item[
+                            "aggregateDecodeTokensPerSecond"
+                        ],
+                        "endToEndTokensPerSecond": item["endToEndTokensPerSecond"],
+                        "makespanMs": item["makespanMs"],
+                    }
+                    for item in pattern["samples"]
+                ],
+                "rows": rows,
+            }
+        )
+
+    return {
+        "prefill": prefill,
+        "schedulerTTFT": scheduler_ttft,
+        "decode": decode,
+        "arrival": arrival_summary,
+    }
+
+
+def index_by(items: list[dict], key: str) -> dict:
+    return {item[key]: item for item in items}
+
+
+def percent_delta(current: float, baseline: float) -> float | None:
+    if baseline == 0:
+        return None
+    return (current / baseline - 1.0) * 100.0
+
+
+def compare(current: dict, baseline: dict) -> dict:
+    baseline_summary = baseline["summary"]
+    comparisons: dict[str, object] = {"baselineName": baseline.get("name", "baseline")}
+
+    base_prefill = index_by(baseline_summary["prefill"], "promptTokens")
+    comparisons["prefill"] = [
+        {
+            "promptTokens": item["promptTokens"],
+            "tokensPerSecondPercent": percent_delta(
+                item["medianTokensPerSecond"],
+                base_prefill[item["promptTokens"]]["medianTokensPerSecond"],
+            ),
+            "elapsedMsPercent": percent_delta(
+                item["medianElapsedMs"],
+                base_prefill[item["promptTokens"]]["medianElapsedMs"],
+            ),
+        }
+        for item in current["prefill"]
+        if item["promptTokens"] in base_prefill
+    ]
+
+    base_ttft = index_by(baseline_summary["schedulerTTFT"], "promptTokens")
+    comparisons["schedulerTTFT"] = [
+        {
+            "promptTokens": item["promptTokens"],
+            "ttftMsPercent": percent_delta(
+                item["medianTTFTMs"],
+                base_ttft[item["promptTokens"]]["medianTTFTMs"],
+            ),
+        }
+        for item in current["schedulerTTFT"]
+        if item["promptTokens"] in base_ttft
+    ]
+
+    base_decode = index_by(baseline_summary["decode"], "batchSize")
+    comparisons["decode"] = [
+        {
+            "batchSize": item["batchSize"],
+            "perRequestPercent": percent_delta(
+                item["perRequestTokensPerSecond"],
+                base_decode[item["batchSize"]]["perRequestTokensPerSecond"],
+            ),
+            "aggregatePercent": percent_delta(
+                item["aggregateTokensPerSecond"],
+                base_decode[item["batchSize"]]["aggregateTokensPerSecond"],
+            ),
+        }
+        for item in current["decode"]
+        if item["batchSize"] in base_decode
+    ]
+
+    base_arrival = index_by(baseline_summary["arrival"], "name")
+    comparisons["arrival"] = [
+        {
+            "name": item["name"],
+            "ttftMsPercent": percent_delta(
+                item["medianTTFTMs"], base_arrival[item["name"]]["medianTTFTMs"]
+            ),
+            "aggregateDecodePercent": percent_delta(
+                item["medianAggregateDecodeTokensPerSecond"],
+                base_arrival[item["name"]][
+                    "medianAggregateDecodeTokensPerSecond"
+                ],
+            ),
+            "endToEndPercent": percent_delta(
+                item["medianEndToEndTokensPerSecond"],
+                base_arrival[item["name"]]["medianEndToEndTokensPerSecond"],
+            ),
+            "makespanPercent": percent_delta(
+                item["medianMakespanMs"],
+                base_arrival[item["name"]]["medianMakespanMs"],
+            ),
+        }
+        for item in current["arrival"]
+        if item["name"] in base_arrival
+    ]
+    return comparisons
+
+
+def validate_comparison_shape(args: argparse.Namespace, baseline: dict) -> None:
+    baseline_configuration = baseline.get("configuration", {})
+    expected = {
+        "decodePromptTokens": args.decode_prompt_tokens,
+        "decodeTokens": args.decode_tokens,
+        "arrivalPromptTokens": args.arrival_prompt_tokens,
+        "arrivalDecodeTokens": args.arrival_decode_tokens,
+    }
+    mismatches = [
+        f"{key}={value} (baseline {baseline_configuration.get(key)})"
+        for key, value in expected.items()
+        if baseline_configuration.get(key) != value
+    ]
+    if mismatches:
+        raise RuntimeError(
+            "benchmark shape is not comparable to the baseline: "
+            + ", ".join(mismatches)
+            + "; pass --no-compare for a different workload"
+        )

--- a/scripts/gemma_contbatch/results.py
+++ b/scripts/gemma_contbatch/results.py
@@ -1,124 +1,8 @@
-"""Benchmark summaries, baseline comparisons, and comparison validation."""
+"""Baseline comparison of a summary against the committed baseline."""
 
 from __future__ import annotations
 
-import argparse
-from collections import defaultdict
-from statistics import median
-
-
-def summarize(sweep: dict, scheduler: dict, arrival: dict) -> dict:
-    prefill_groups: dict[int, list[dict]] = defaultdict(list)
-    for sample in sweep["prefill"]:
-        prefill_groups[int(sample["promptTokens"])].append(sample)
-    prefill = []
-    for prompt_tokens, samples in sorted(prefill_groups.items()):
-        prefill.append(
-            {
-                "promptTokens": prompt_tokens,
-                "medianElapsedMs": median(item["elapsedMs"] for item in samples),
-                "medianTokensPerSecond": median(
-                    item["prefillTokensPerSecond"] for item in samples
-                ),
-                "samples": [
-                    {
-                        "elapsedMs": item["elapsedMs"],
-                        "tokensPerSecond": item["prefillTokensPerSecond"],
-                    }
-                    for item in samples
-                ],
-            }
-        )
-
-    ttft_groups: dict[int, list[dict]] = defaultdict(list)
-    for sample in scheduler["samples"]:
-        ttft_groups[int(sample["promptTokens"])].append(sample)
-    scheduler_ttft = []
-    for prompt_tokens, samples in sorted(ttft_groups.items()):
-        scheduler_ttft.append(
-            {
-                "promptTokens": prompt_tokens,
-                "medianTTFTMs": median(item["ttftMs"] for item in samples),
-                "samples": [
-                    {
-                        "ttftMs": item["ttftMs"],
-                        "msPerPrefillToken": item["msPerPrefillToken"],
-                    }
-                    for item in samples
-                ],
-            }
-        )
-
-    decode = [
-        {
-            "batchSize": item["batchSize"],
-            "elapsedMs": item["elapsedMs"],
-            "perRequestTokensPerSecond": item["perSequenceTokensPerSecond"],
-            "aggregateTokensPerSecond": item["aggregateTokensPerSecond"],
-        }
-        for item in sweep["decode"]
-    ]
-
-    arrival_summary = []
-    for pattern in arrival["patterns"]:
-        all_rows = [row for sample in pattern["samples"] for row in sample["rows"]]
-        row_groups: dict[int, list[dict]] = defaultdict(list)
-        for sample in pattern["samples"]:
-            for row in sample["rows"]:
-                row_groups[int(row["row"])].append(row)
-        rows = [
-            {
-                "row": row,
-                "medianTTFTMs": median(item["ttftMs"] for item in samples),
-                "medianDecodeTokensPerSecond": median(
-                    item["decodeTokensPerSecond"] for item in samples
-                ),
-            }
-            for row, samples in sorted(row_groups.items())
-        ]
-        arrival_summary.append(
-            {
-                "name": pattern["name"],
-                "arrivalDelaysMs": pattern["arrivalDelaysMs"],
-                "medianTTFTMs": median(row["ttftMs"] for row in all_rows),
-                "medianPerRequestDecodeTokensPerSecond": median(
-                    row["decodeTokensPerSecond"] for row in all_rows
-                ),
-                "medianAggregateDecodeTokensPerSecond": median(
-                    item["aggregateDecodeTokensPerSecond"]
-                    for item in pattern["samples"]
-                ),
-                "medianEndToEndTokensPerSecond": median(
-                    item["endToEndTokensPerSecond"] for item in pattern["samples"]
-                ),
-                "medianMakespanMs": median(
-                    item["makespanMs"] for item in pattern["samples"]
-                ),
-                "outputsStableAcrossIterations": pattern[
-                    "outputsStableAcrossIterations"
-                ],
-                "outputsMatchBurst": pattern["outputsMatchBurst"],
-                "samples": [
-                    {
-                        "iteration": item["iteration"],
-                        "aggregateDecodeTokensPerSecond": item[
-                            "aggregateDecodeTokensPerSecond"
-                        ],
-                        "endToEndTokensPerSecond": item["endToEndTokensPerSecond"],
-                        "makespanMs": item["makespanMs"],
-                    }
-                    for item in pattern["samples"]
-                ],
-                "rows": rows,
-            }
-        )
-
-    return {
-        "prefill": prefill,
-        "schedulerTTFT": scheduler_ttft,
-        "decode": decode,
-        "arrival": arrival_summary,
-    }
+from .baseline import NO_COMPARE_HINT
 
 
 def index_by(items: list[dict], key: str) -> dict:
@@ -131,11 +15,51 @@ def percent_delta(current: float, baseline: float) -> float | None:
     return (current / baseline - 1.0) * 100.0
 
 
+def index_against_baseline(
+    section: str, current_items: list[dict], baseline_items: list[dict], key: str
+) -> dict:
+    """Index the baseline section, refusing any partial overlap.
+
+    A comparison that silently skips the rows the baseline happens to be missing
+    is worse than no comparison: the report still claims to be a baseline diff
+    while quietly hiding whichever measurements moved the most.
+    """
+    baseline_index = index_by(baseline_items, key)
+    current_keys = [item[key] for item in current_items]
+    duplicates = sorted(
+        {value for value in current_keys if current_keys.count(value) > 1}, key=repr
+    )
+    absent_from_baseline = sorted(
+        {value for value in current_keys if value not in baseline_index},
+        key=repr,
+    )
+    absent_from_run = sorted(set(baseline_index) - set(current_keys), key=repr)
+    problems = []
+    if len(baseline_index) != len(baseline_items):
+        problems.append(f"duplicate {key} in the baseline")
+    if duplicates:
+        problems.append(f"duplicate {key} in this run: {duplicates}")
+    if absent_from_baseline:
+        problems.append(f"{key} missing from the baseline: {absent_from_baseline}")
+    if absent_from_run:
+        problems.append(f"{key} missing from this run: {absent_from_run}")
+    if problems:
+        raise RuntimeError(
+            f"baseline {section} shape does not match this run ("
+            + "; ".join(problems)
+            + "); "
+            + NO_COMPARE_HINT
+        )
+    return baseline_index
+
+
 def compare(current: dict, baseline: dict) -> dict:
     baseline_summary = baseline["summary"]
     comparisons: dict[str, object] = {"baselineName": baseline.get("name", "baseline")}
 
-    base_prefill = index_by(baseline_summary["prefill"], "promptTokens")
+    base_prefill = index_against_baseline(
+        "prefill", current["prefill"], baseline_summary["prefill"], "promptTokens"
+    )
     comparisons["prefill"] = [
         {
             "promptTokens": item["promptTokens"],
@@ -149,10 +73,14 @@ def compare(current: dict, baseline: dict) -> dict:
             ),
         }
         for item in current["prefill"]
-        if item["promptTokens"] in base_prefill
     ]
 
-    base_ttft = index_by(baseline_summary["schedulerTTFT"], "promptTokens")
+    base_ttft = index_against_baseline(
+        "schedulerTTFT",
+        current["schedulerTTFT"],
+        baseline_summary["schedulerTTFT"],
+        "promptTokens",
+    )
     comparisons["schedulerTTFT"] = [
         {
             "promptTokens": item["promptTokens"],
@@ -162,10 +90,11 @@ def compare(current: dict, baseline: dict) -> dict:
             ),
         }
         for item in current["schedulerTTFT"]
-        if item["promptTokens"] in base_ttft
     ]
 
-    base_decode = index_by(baseline_summary["decode"], "batchSize")
+    base_decode = index_against_baseline(
+        "decode", current["decode"], baseline_summary["decode"], "batchSize"
+    )
     comparisons["decode"] = [
         {
             "batchSize": item["batchSize"],
@@ -179,10 +108,11 @@ def compare(current: dict, baseline: dict) -> dict:
             ),
         }
         for item in current["decode"]
-        if item["batchSize"] in base_decode
     ]
 
-    base_arrival = index_by(baseline_summary["arrival"], "name")
+    base_arrival = index_against_baseline(
+        "arrival", current["arrival"], baseline_summary["arrival"], "name"
+    )
     comparisons["arrival"] = [
         {
             "name": item["name"],
@@ -205,27 +135,5 @@ def compare(current: dict, baseline: dict) -> dict:
             ),
         }
         for item in current["arrival"]
-        if item["name"] in base_arrival
     ]
     return comparisons
-
-
-def validate_comparison_shape(args: argparse.Namespace, baseline: dict) -> None:
-    baseline_configuration = baseline.get("configuration", {})
-    expected = {
-        "decodePromptTokens": args.decode_prompt_tokens,
-        "decodeTokens": args.decode_tokens,
-        "arrivalPromptTokens": args.arrival_prompt_tokens,
-        "arrivalDecodeTokens": args.arrival_decode_tokens,
-    }
-    mismatches = [
-        f"{key}={value} (baseline {baseline_configuration.get(key)})"
-        for key, value in expected.items()
-        if baseline_configuration.get(key) != value
-    ]
-    if mismatches:
-        raise RuntimeError(
-            "benchmark shape is not comparable to the baseline: "
-            + ", ".join(mismatches)
-            + "; pass --no-compare for a different workload"
-        )

--- a/scripts/gemma_contbatch/runner.py
+++ b/scripts/gemma_contbatch/runner.py
@@ -10,6 +10,11 @@ import time
 from datetime import datetime, timezone
 from pathlib import Path
 
+from .baseline import (
+    load_baseline,
+    resolve_model_snapshot,
+    validate_baseline_pins,
+)
 from .config import PERFORMANCE_ENV_PREFIXES, parse_args
 from .process import (
     atomic_write,
@@ -21,7 +26,8 @@ from .process import (
     source_fingerprint,
 )
 from .report import markdown_report
-from .results import compare, summarize, validate_comparison_shape
+from .results import compare
+from .summary import summarize
 from .validation import assert_finite, validate_raw_outputs
 
 
@@ -86,6 +92,8 @@ def main() -> int:
             str(args.decode_tokens),
             "--decode-prompt-tokens",
             str(args.decode_prompt_tokens),
+            "--decode-iterations",
+            str(args.iterations),
         ],
         provider_dir,
     )
@@ -114,8 +122,15 @@ def main() -> int:
         provider_dir,
     )
 
+    raw_outputs = {
+        "throughputSweep": sweep,
+        "schedulerPrefill": scheduler,
+        "arrivalInvariance": arrival,
+    }
     validate_raw_outputs(args, sweep, scheduler, arrival)
     summary = summarize(sweep, scheduler, arrival)
+    model_snapshot = resolve_model_snapshot(raw_outputs)
+    hardware = sweep["hardware"]
 
     environment = {
         key: value
@@ -123,16 +138,23 @@ def main() -> int:
         if key.startswith(PERFORMANCE_ENV_PREFIXES)
     }
     report = {
-        "schemaVersion": 1,
+        # 2: the arrival summary carries the measured delivered-topology
+        # evidence (offsets, arrival error, tolerance, discarded attempts).
+        "schemaVersion": 2,
         "generatedAt": generated_at,
         "label": args.label,
         "modelID": args.model,
+        "modelSnapshot": model_snapshot,
+        "hardware": hardware,
         "configuration": {
             "iterations": args.iterations,
             "prefillLengths": args.prefill_lengths,
             "decodePromptTokens": args.decode_prompt_tokens,
             "decodeTokens": args.decode_tokens,
             "maxBatch": args.max_batch,
+            # The decode curve is repeated once per iteration, so every batch
+            # size in the summary is a median over exactly this many samples.
+            "decodeIterations": args.iterations,
             "arrivalPromptTokens": args.arrival_prompt_tokens,
             "arrivalDecodeTokens": args.arrival_decode_tokens,
         },
@@ -149,11 +171,7 @@ def main() -> int:
             "thermalAfter": capture_optional(["pmset", "-g", "therm"], repo_root),
         },
         "summary": summary,
-        "raw": {
-            "throughputSweep": sweep,
-            "schedulerPrefill": scheduler,
-            "arrivalInvariance": arrival,
-        },
+        "raw": raw_outputs,
         "durationSeconds": time.monotonic() - started,
         "invocation": shlex.join([sys.executable, *sys.argv]),
     }
@@ -162,13 +180,11 @@ def main() -> int:
         baseline_path = Path(args.baseline)
         if not baseline_path.is_absolute():
             baseline_path = repo_root / baseline_path
-        with baseline_path.open(encoding="utf-8") as handle:
-            baseline = json.load(handle)
-        if baseline.get("modelID") != args.model:
-            raise RuntimeError(
-                f"baseline model {baseline.get('modelID')} does not match {args.model}"
-            )
-        validate_comparison_shape(args, baseline)
+        baseline = load_baseline(baseline_path)
+        # Pin weights, host, and workload before any delta is computed: an
+        # unpinned snapshot or a different Mac turns unrelated differences into
+        # what reads as an engine regression.
+        validate_baseline_pins(args, baseline, model_snapshot, hardware)
         report["comparison"] = compare(summary, baseline)
 
     assert_finite(report)

--- a/scripts/gemma_contbatch/runner.py
+++ b/scripts/gemma_contbatch/runner.py
@@ -1,0 +1,197 @@
+"""Benchmark build, execution, validation, and report orchestration."""
+
+from __future__ import annotations
+
+import json
+import os
+import shlex
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+from .config import PERFORMANCE_ENV_PREFIXES, parse_args
+from .process import (
+    atomic_write,
+    capture,
+    capture_optional,
+    run_json,
+    run_step,
+    sha256,
+    source_fingerprint,
+)
+from .report import markdown_report
+from .results import compare, summarize, validate_comparison_shape
+from .validation import assert_finite, validate_raw_outputs
+
+
+def safe_label(label: str) -> str:
+    normalized = "".join(character if character.isalnum() else "-" for character in label)
+    return "-".join(part for part in normalized.split("-") if part).lower()
+
+
+def main() -> int:
+    args = parse_args()
+    repo_root = Path(__file__).resolve().parents[2]
+    provider_dir = repo_root / "provider-swift"
+    binary = provider_dir / ".build/release/darkbloom"
+    metallib = provider_dir / ".build/release/mlx.metallib"
+    mlx_metal_source = repo_root / "libs/mlx-swift/Source/Cmlx/mlx"
+    started = time.monotonic()
+    generated_at = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+    thermal_before = capture_optional(["pmset", "-g", "therm"], repo_root)
+
+    if not (repo_root / "libs/mlx-swift/Package.swift").is_file():
+        raise RuntimeError("MLX submodules are missing; run git submodule update --init --recursive")
+    if not args.skip_build:
+        run_step(["swift", "build", "-c", "release", "--product", "darkbloom"], provider_dir)
+    mlx_metal_status, mlx_metal_fingerprint = source_fingerprint(mlx_metal_source)
+    if not args.skip_metallib:
+        metallib_environment = os.environ.copy()
+        source_cache = (
+            repo_root
+            / "tmp/benchmarks/metallib-cache"
+            / mlx_metal_fingerprint[:16]
+        )
+        source_cache.mkdir(parents=True, exist_ok=True)
+        metallib_environment["METALLIB_CACHE_DIR"] = str(source_cache)
+        if mlx_metal_status:
+            print(
+                f"Dirty MLX Metal source: using cache {source_cache}",
+                file=sys.stderr,
+            )
+        run_step(
+            [str(repo_root / "scripts/fetch-metallib.sh"), "release"],
+            repo_root,
+            env=metallib_environment,
+        )
+    if not binary.is_file() or not metallib.is_file():
+        raise RuntimeError("release binary or mlx.metallib is missing")
+
+    benchmark = [str(binary), "benchmark", "--model", args.model]
+    repeated_lengths = ",".join(
+        str(length)
+        for length in args.prefill_lengths
+        for _ in range(args.iterations)
+    )
+    sweep = run_json(
+        benchmark
+        + [
+            "--sweep",
+            "--prefill-lengths",
+            repeated_lengths,
+            "--max-batch",
+            str(args.max_batch),
+            "--decode-tokens",
+            str(args.decode_tokens),
+            "--decode-prompt-tokens",
+            str(args.decode_prompt_tokens),
+        ],
+        provider_dir,
+    )
+    scheduler = run_json(
+        benchmark
+        + [
+            "--scheduler-prefill",
+            "--prefill-lengths",
+            ",".join(map(str, args.prefill_lengths)),
+            "--prefill-iterations",
+            str(args.iterations),
+        ],
+        provider_dir,
+    )
+    arrival = run_json(
+        benchmark
+        + [
+            "--arrival-invariance",
+            "--arrival-prompt-tokens",
+            str(args.arrival_prompt_tokens),
+            "--arrival-decode-tokens",
+            str(args.arrival_decode_tokens),
+            "--arrival-iterations",
+            str(args.iterations),
+        ],
+        provider_dir,
+    )
+
+    validate_raw_outputs(args, sweep, scheduler, arrival)
+    summary = summarize(sweep, scheduler, arrival)
+
+    environment = {
+        key: value
+        for key, value in sorted(os.environ.items())
+        if key.startswith(PERFORMANCE_ENV_PREFIXES)
+    }
+    report = {
+        "schemaVersion": 1,
+        "generatedAt": generated_at,
+        "label": args.label,
+        "modelID": args.model,
+        "configuration": {
+            "iterations": args.iterations,
+            "prefillLengths": args.prefill_lengths,
+            "decodePromptTokens": args.decode_prompt_tokens,
+            "decodeTokens": args.decode_tokens,
+            "maxBatch": args.max_batch,
+            "arrivalPromptTokens": args.arrival_prompt_tokens,
+            "arrivalDecodeTokens": args.arrival_decode_tokens,
+        },
+        "metadata": {
+            "rootCommit": capture(["git", "rev-parse", "HEAD"], repo_root),
+            "gitStatus": capture(["git", "status", "--short"], repo_root).splitlines(),
+            "submodules": capture(["git", "submodule", "status"], repo_root).splitlines(),
+            "mlxMetalSourceStatus": mlx_metal_status,
+            "mlxMetalSourceFingerprint": mlx_metal_fingerprint,
+            "binarySha256": sha256(binary),
+            "metallibSha256": sha256(metallib),
+            "environment": environment,
+            "thermalBefore": thermal_before,
+            "thermalAfter": capture_optional(["pmset", "-g", "therm"], repo_root),
+        },
+        "summary": summary,
+        "raw": {
+            "throughputSweep": sweep,
+            "schedulerPrefill": scheduler,
+            "arrivalInvariance": arrival,
+        },
+        "durationSeconds": time.monotonic() - started,
+        "invocation": shlex.join([sys.executable, *sys.argv]),
+    }
+
+    if not args.no_compare:
+        baseline_path = Path(args.baseline)
+        if not baseline_path.is_absolute():
+            baseline_path = repo_root / baseline_path
+        with baseline_path.open(encoding="utf-8") as handle:
+            baseline = json.load(handle)
+        if baseline.get("modelID") != args.model:
+            raise RuntimeError(
+                f"baseline model {baseline.get('modelID')} does not match {args.model}"
+            )
+        validate_comparison_shape(args, baseline)
+        report["comparison"] = compare(summary, baseline)
+
+    assert_finite(report)
+    markdown = markdown_report(report)
+    output_dir = Path(args.output_dir)
+    if not output_dir.is_absolute():
+        output_dir = repo_root / output_dir
+    output_dir.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    suffix = f"-{safe_label(args.label)}" if args.label else ""
+    stem = f"gemma-contbatch-{timestamp}{suffix}"
+    json_text = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    paths = {
+        output_dir / f"{stem}.json": json_text,
+        output_dir / f"{stem}.md": markdown,
+        output_dir / "gemma-contbatch-latest.json": json_text,
+        output_dir / "gemma-contbatch-latest.md": markdown,
+    }
+    for path, content in paths.items():
+        atomic_write(path, content)
+
+    print(markdown)
+    print("Reports:")
+    print(f"  {output_dir / f'{stem}.md'}")
+    print(f"  {output_dir / f'{stem}.json'}")
+    return 0

--- a/scripts/gemma_contbatch/runner.py
+++ b/scripts/gemma_contbatch/runner.py
@@ -15,7 +15,9 @@ from .baseline import (
     resolve_model_snapshot,
     validate_baseline_pins,
 )
-from .config import PERFORMANCE_ENV_PREFIXES, parse_args
+from .checks import assert_finite
+from .config import parse_args
+from .environment import performance_environment
 from .process import (
     atomic_write,
     capture,
@@ -28,7 +30,7 @@ from .process import (
 from .report import markdown_report
 from .results import compare
 from .summary import summarize
-from .validation import assert_finite, validate_raw_outputs
+from .validation import validate_raw_outputs
 
 
 def safe_label(label: str) -> str:
@@ -132,11 +134,9 @@ def main() -> int:
     model_snapshot = resolve_model_snapshot(raw_outputs)
     hardware = sweep["hardware"]
 
-    environment = {
-        key: value
-        for key, value in sorted(os.environ.items())
-        if key.startswith(PERFORMANCE_ENV_PREFIXES)
-    }
+    # The same capture is recorded in the report and pinned against the
+    # baseline below, so the two can never describe different runs.
+    environment = performance_environment(os.environ)
     report = {
         # 2: the arrival summary carries the measured delivered-topology
         # evidence (offsets, arrival error, tolerance, discarded attempts).
@@ -181,10 +181,11 @@ def main() -> int:
         if not baseline_path.is_absolute():
             baseline_path = repo_root / baseline_path
         baseline = load_baseline(baseline_path)
-        # Pin weights, host, and workload before any delta is computed: an
-        # unpinned snapshot or a different Mac turns unrelated differences into
-        # what reads as an engine regression.
-        validate_baseline_pins(args, baseline, model_snapshot, hardware)
+        # Pin weights, host, workload, and engine/Metal overrides before any
+        # delta is computed: an unpinned snapshot, a different Mac, or a
+        # flipped kill switch turns unrelated differences into what reads as
+        # an engine regression.
+        validate_baseline_pins(args, baseline, model_snapshot, hardware, environment)
         report["comparison"] = compare(summary, baseline)
 
     assert_finite(report)

--- a/scripts/gemma_contbatch/summary.py
+++ b/scripts/gemma_contbatch/summary.py
@@ -1,0 +1,157 @@
+"""Per-benchmark median summaries of the raw benchmark payloads.
+
+Every headline number in the summary is a median over the repetitions that
+were actually measured; the raw per-repetition samples are kept alongside it
+so a reader can see the spread the median came from.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from statistics import median
+
+
+def summarize(sweep: dict, scheduler: dict, arrival: dict) -> dict:
+    prefill_groups: dict[int, list[dict]] = defaultdict(list)
+    for sample in sweep["prefill"]:
+        prefill_groups[int(sample["promptTokens"])].append(sample)
+    prefill = []
+    for prompt_tokens, samples in sorted(prefill_groups.items()):
+        prefill.append(
+            {
+                "promptTokens": prompt_tokens,
+                "medianElapsedMs": median(item["elapsedMs"] for item in samples),
+                "medianTokensPerSecond": median(
+                    item["prefillTokensPerSecond"] for item in samples
+                ),
+                "samples": [
+                    {
+                        "elapsedMs": item["elapsedMs"],
+                        "tokensPerSecond": item["prefillTokensPerSecond"],
+                    }
+                    for item in samples
+                ],
+            }
+        )
+
+    ttft_groups: dict[int, list[dict]] = defaultdict(list)
+    for sample in scheduler["samples"]:
+        ttft_groups[int(sample["promptTokens"])].append(sample)
+    scheduler_ttft = []
+    for prompt_tokens, samples in sorted(ttft_groups.items()):
+        scheduler_ttft.append(
+            {
+                "promptTokens": prompt_tokens,
+                "medianTTFTMs": median(item["ttftMs"] for item in samples),
+                "samples": [
+                    {
+                        "ttftMs": item["ttftMs"],
+                        "msPerPrefillToken": item["msPerPrefillToken"],
+                    }
+                    for item in samples
+                ],
+            }
+        )
+
+    # The decode curve is repeated once per iteration (`--decode-iterations`),
+    # so every batch size carries N samples and the headline numbers are real
+    # medians -- never a single GPU measurement relabelled as one.
+    decode_groups: dict[int, list[dict]] = defaultdict(list)
+    for sample in sweep["decode"]:
+        decode_groups[int(sample["batchSize"])].append(sample)
+    decode = [
+        {
+            "batchSize": batch_size,
+            "sampleCount": len(samples),
+            "elapsedMs": median(item["elapsedMs"] for item in samples),
+            "perRequestTokensPerSecond": median(
+                item["perSequenceTokensPerSecond"] for item in samples
+            ),
+            "aggregateTokensPerSecond": median(
+                item["aggregateTokensPerSecond"] for item in samples
+            ),
+            "samples": [
+                {
+                    "elapsedMs": item["elapsedMs"],
+                    "perRequestTokensPerSecond": item["perSequenceTokensPerSecond"],
+                    "aggregateTokensPerSecond": item["aggregateTokensPerSecond"],
+                }
+                for item in samples
+            ],
+        }
+        for batch_size, samples in sorted(decode_groups.items())
+    ]
+
+    arrival_summary = []
+    for pattern in arrival["patterns"]:
+        all_rows = [row for sample in pattern["samples"] for row in sample["rows"]]
+        row_groups: dict[int, list[dict]] = defaultdict(list)
+        for sample in pattern["samples"]:
+            for row in sample["rows"]:
+                row_groups[int(row["row"])].append(row)
+        rows = [
+            {
+                "row": row,
+                "medianTTFTMs": median(item["ttftMs"] for item in samples),
+                "medianDecodeTokensPerSecond": median(
+                    item["decodeTokensPerSecond"] for item in samples
+                ),
+            }
+            for row, samples in sorted(row_groups.items())
+        ]
+        arrival_summary.append(
+            {
+                "name": pattern["name"],
+                "arrivalDelaysMs": pattern["arrivalDelaysMs"],
+                "medianTTFTMs": median(row["ttftMs"] for row in all_rows),
+                "medianPerRequestDecodeTokensPerSecond": median(
+                    row["decodeTokensPerSecond"] for row in all_rows
+                ),
+                "medianAggregateDecodeTokensPerSecond": median(
+                    item["aggregateDecodeTokensPerSecond"]
+                    for item in pattern["samples"]
+                ),
+                "medianEndToEndTokensPerSecond": median(
+                    item["endToEndTokensPerSecond"] for item in pattern["samples"]
+                ),
+                "medianMakespanMs": median(
+                    item["makespanMs"] for item in pattern["samples"]
+                ),
+                "outputsStableAcrossIterations": pattern[
+                    "outputsStableAcrossIterations"
+                ],
+                "outputsMatchBurst": pattern["outputsMatchBurst"],
+                # Measured evidence that the arrivals were the named topology,
+                # carried into the summary so the report shows what was
+                # delivered next to what was requested.
+                "measuredArrivalOffsetsMs": pattern["measuredArrivalOffsetsMs"],
+                "maxArrivalErrorMs": pattern["maxArrivalErrorMs"],
+                "arrivalWithinTolerance": pattern["arrivalWithinTolerance"],
+                "discardedAttempts": sum(
+                    int(item["discardedAttempts"]) for item in pattern["samples"]
+                ),
+                "samples": [
+                    {
+                        "iteration": item["iteration"],
+                        "aggregateDecodeTokensPerSecond": item[
+                            "aggregateDecodeTokensPerSecond"
+                        ],
+                        "endToEndTokensPerSecond": item["endToEndTokensPerSecond"],
+                        "makespanMs": item["makespanMs"],
+                        "maxArrivalErrorMs": item["maxArrivalErrorMs"],
+                        "discardedAttempts": item["discardedAttempts"],
+                    }
+                    for item in pattern["samples"]
+                ],
+                "rows": rows,
+            }
+        )
+
+    return {
+        "prefill": prefill,
+        "schedulerTTFT": scheduler_ttft,
+        "decode": decode,
+        "arrival": arrival_summary,
+        "arrivalToleranceMs": arrival["arrivalToleranceMs"],
+        "arrivalMaxAttemptsPerSample": arrival["arrivalMaxAttemptsPerSample"],
+    }

--- a/scripts/gemma_contbatch/validation.py
+++ b/scripts/gemma_contbatch/validation.py
@@ -1,0 +1,206 @@
+"""Strict validation of raw benchmark output."""
+
+from __future__ import annotations
+
+import argparse
+import math
+from collections import Counter, defaultdict
+from statistics import median
+
+from .config import EXPECTED_ARRIVAL_PATTERNS
+
+
+def assert_finite(value: object, path: str = "root") -> None:
+    if isinstance(value, float) and not math.isfinite(value):
+        raise RuntimeError(f"non-finite metric at {path}: {value}")
+    if isinstance(value, dict):
+        for key, child in value.items():
+            assert_finite(child, f"{path}.{key}")
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            assert_finite(child, f"{path}[{index}]")
+
+
+def require_positive(value: object, path: str) -> None:
+    if not isinstance(value, (int, float)) or isinstance(value, bool) or value <= 0:
+        raise RuntimeError(f"expected positive metric at {path}, got {value!r}")
+
+
+def validate_raw_outputs(
+    args: argparse.Namespace, sweep: dict, scheduler: dict, arrival: dict
+) -> None:
+    for name, payload in (
+        ("throughput sweep", sweep),
+        ("scheduler prefill", scheduler),
+        ("arrival invariance", arrival),
+    ):
+        if payload.get("modelID", "").replace("\\/", "/") != args.model:
+            raise RuntimeError(f"{name} returned the wrong model ID")
+        assert_finite(payload, name)
+
+    expected_prefill_counts = Counter(
+        {length: args.iterations for length in args.prefill_lengths}
+    )
+    prefill_samples = sweep.get("prefill", [])
+    actual_prefill_counts = Counter(
+        int(sample.get("promptTokens", -1)) for sample in prefill_samples
+    )
+    if actual_prefill_counts != expected_prefill_counts:
+        raise RuntimeError(
+            "raw prefill matrix incomplete: "
+            f"expected {expected_prefill_counts}, got {actual_prefill_counts}"
+        )
+    for index, sample in enumerate(prefill_samples):
+        require_positive(sample.get("elapsedMs"), f"prefill[{index}].elapsedMs")
+        require_positive(
+            sample.get("prefillTokensPerSecond"),
+            f"prefill[{index}].prefillTokensPerSecond",
+        )
+
+    decode_samples = sweep.get("decode", [])
+    expected_batches = set(range(1, args.max_batch + 1))
+    actual_batches = {int(sample.get("batchSize", -1)) for sample in decode_samples}
+    if len(decode_samples) != args.max_batch or actual_batches != expected_batches:
+        raise RuntimeError(
+            f"decode matrix incomplete: expected {expected_batches}, got {actual_batches}"
+        )
+    for index, sample in enumerate(decode_samples):
+        batch_size = int(sample["batchSize"])
+        if sample.get("decodeTokensPerSequence") != args.decode_tokens:
+            raise RuntimeError(f"decode[{index}] reported the wrong token budget")
+        for key in (
+            "elapsedMs",
+            "aggregateTokensPerSecond",
+            "perSequenceTokensPerSecond",
+        ):
+            require_positive(sample.get(key), f"decode[{index}].{key}")
+        observed_tokens = (
+            sample["aggregateTokensPerSecond"] * sample["elapsedMs"] / 1000.0
+        )
+        expected_tokens = batch_size * args.decode_tokens
+        if abs(observed_tokens - expected_tokens) > 0.5:
+            raise RuntimeError(
+                f"decode[{index}] completed {observed_tokens:.2f} tokens, "
+                f"expected {expected_tokens}"
+            )
+
+    scheduler_samples = scheduler.get("samples", [])
+    expected_scheduler_keys = {
+        (length, iteration)
+        for length in args.prefill_lengths
+        for iteration in range(1, args.iterations + 1)
+    }
+    actual_scheduler_keys = {
+        (int(sample.get("promptTokens", -1)), int(sample.get("iteration", -1)))
+        for sample in scheduler_samples
+    }
+    if (
+        len(scheduler_samples) != len(expected_scheduler_keys)
+        or actual_scheduler_keys != expected_scheduler_keys
+    ):
+        raise RuntimeError("scheduler TTFT matrix is incomplete")
+    for index, sample in enumerate(scheduler_samples):
+        require_positive(sample.get("ttftMs"), f"scheduler[{index}].ttftMs")
+        require_positive(
+            sample.get("msPerPrefillToken"),
+            f"scheduler[{index}].msPerPrefillToken",
+        )
+
+    if arrival.get("promptTokensPerRequest") != args.arrival_prompt_tokens:
+        raise RuntimeError("arrival benchmark reported the wrong prompt length")
+    if arrival.get("decodeTokensPerRequest") != args.arrival_decode_tokens:
+        raise RuntimeError("arrival benchmark reported the wrong decode budget")
+    patterns = arrival.get("patterns", [])
+    pattern_by_name = {pattern.get("name"): pattern for pattern in patterns}
+    if len(patterns) != len(EXPECTED_ARRIVAL_PATTERNS) or set(pattern_by_name) != set(
+        EXPECTED_ARRIVAL_PATTERNS
+    ):
+        raise RuntimeError("arrival topology matrix is incomplete")
+    checksum_sets: dict[str, dict[int, set[str]]] = {}
+    for name, delays in EXPECTED_ARRIVAL_PATTERNS.items():
+        pattern = pattern_by_name[name]
+        if pattern.get("arrivalDelaysMs") != delays:
+            raise RuntimeError(f"arrival topology {name} has unexpected delays")
+        if not pattern.get("outputsStableAcrossIterations") or not pattern.get(
+            "outputsMatchBurst"
+        ):
+            raise RuntimeError(f"arrival topology {name} failed exact output invariance")
+        samples = pattern.get("samples", [])
+        actual_iterations = {sample.get("iteration") for sample in samples}
+        expected_iterations = set(range(1, args.iterations + 1))
+        if len(samples) != args.iterations or actual_iterations != expected_iterations:
+            raise RuntimeError(f"arrival topology {name} has incomplete iterations")
+        all_rows: list[dict] = []
+        checksum_sets[name] = defaultdict(set)
+        for sample_index, sample in enumerate(samples):
+            for key in (
+                "aggregateDecodeTokensPerSecond",
+                "endToEndTokensPerSecond",
+                "makespanMs",
+            ):
+                require_positive(
+                    sample.get(key), f"arrival.{name}[{sample_index}].{key}"
+                )
+            rows = sample.get("rows", [])
+            if len(rows) != len(delays) or {row.get("row") for row in rows} != set(
+                range(len(delays))
+            ):
+                raise RuntimeError(
+                    f"arrival topology {name} iteration {sample.get('iteration')} "
+                    "has incomplete rows"
+                )
+            for row in rows:
+                all_rows.append(row)
+                if row.get("generatedTokens") != args.arrival_decode_tokens:
+                    raise RuntimeError(
+                        f"arrival topology {name} row {row.get('row')} completed "
+                        f"{row.get('generatedTokens')} tokens"
+                    )
+                for key in (
+                    "ttftMs",
+                    "decodeTokensPerSecond",
+                    "completedAtMs",
+                ):
+                    require_positive(
+                        row.get(key),
+                        f"arrival.{name}.row[{row.get('row')}].{key}",
+                    )
+                if not row.get("tokenChecksum"):
+                    raise RuntimeError(
+                        f"arrival topology {name} row {row.get('row')} has no checksum"
+                    )
+                checksum_sets[name][int(row["row"])].add(row["tokenChecksum"])
+
+        computed_medians = {
+            "medianTTFTMs": median(row["ttftMs"] for row in all_rows),
+            "medianPerRequestDecodeTokensPerSecond": median(
+                row["decodeTokensPerSecond"] for row in all_rows
+            ),
+            "medianAggregateDecodeTokensPerSecond": median(
+                sample["aggregateDecodeTokensPerSecond"] for sample in samples
+            ),
+            "medianMakespanMs": median(sample["makespanMs"] for sample in samples),
+        }
+        for key, computed in computed_medians.items():
+            require_positive(pattern.get(key), f"arrival.{name}.{key}")
+            if not math.isclose(pattern[key], computed, rel_tol=1e-9, abs_tol=1e-6):
+                raise RuntimeError(
+                    f"arrival topology {name} reported inconsistent {key}: "
+                    f"{pattern[key]} vs recomputed {computed}"
+                )
+
+    canonical_checksums: dict[int, str] = {}
+    for row, checksums in checksum_sets["burst"].items():
+        if len(checksums) != 1:
+            raise RuntimeError(f"burst row {row} changed output across iterations")
+        canonical_checksums[row] = next(iter(checksums))
+    for name, rows in checksum_sets.items():
+        for row, checksums in rows.items():
+            if len(checksums) != 1:
+                raise RuntimeError(
+                    f"arrival topology {name} row {row} changed output across iterations"
+                )
+            if next(iter(checksums)) != canonical_checksums.get(row):
+                raise RuntimeError(
+                    f"arrival topology {name} row {row} differs from burst output"
+                )

--- a/scripts/gemma_contbatch/validation.py
+++ b/scripts/gemma_contbatch/validation.py
@@ -3,41 +3,13 @@
 from __future__ import annotations
 
 import argparse
-import math
-from collections import Counter, defaultdict
-from statistics import median
+from collections import Counter
 
-from .config import EXPECTED_ARRIVAL_PATTERNS
-
-
-def assert_finite(value: object, path: str = "root") -> None:
-    if isinstance(value, float) and not math.isfinite(value):
-        raise RuntimeError(f"non-finite metric at {path}: {value}")
-    if isinstance(value, dict):
-        for key, child in value.items():
-            assert_finite(child, f"{path}.{key}")
-    elif isinstance(value, list):
-        for index, child in enumerate(value):
-            assert_finite(child, f"{path}[{index}]")
+from .arrival import validate_arrival
+from .checks import assert_finite, require_positive
 
 
-def require_positive(value: object, path: str) -> None:
-    if not isinstance(value, (int, float)) or isinstance(value, bool) or value <= 0:
-        raise RuntimeError(f"expected positive metric at {path}, got {value!r}")
-
-
-def validate_raw_outputs(
-    args: argparse.Namespace, sweep: dict, scheduler: dict, arrival: dict
-) -> None:
-    for name, payload in (
-        ("throughput sweep", sweep),
-        ("scheduler prefill", scheduler),
-        ("arrival invariance", arrival),
-    ):
-        if payload.get("modelID", "").replace("\\/", "/") != args.model:
-            raise RuntimeError(f"{name} returned the wrong model ID")
-        assert_finite(payload, name)
-
+def validate_prefill(args: argparse.Namespace, sweep: dict) -> None:
     expected_prefill_counts = Counter(
         {length: args.iterations for length in args.prefill_lengths}
     )
@@ -57,12 +29,22 @@ def validate_raw_outputs(
             f"prefill[{index}].prefillTokensPerSecond",
         )
 
+
+def validate_decode(args: argparse.Namespace, sweep: dict) -> None:
+    # The decode curve is repeated once per iteration, so every batch size must
+    # carry exactly `--iterations` samples; anything else means the median in
+    # the summary would be computed over the wrong number of measurements.
     decode_samples = sweep.get("decode", [])
-    expected_batches = set(range(1, args.max_batch + 1))
-    actual_batches = {int(sample.get("batchSize", -1)) for sample in decode_samples}
-    if len(decode_samples) != args.max_batch or actual_batches != expected_batches:
+    expected_decode_counts = Counter(
+        {batch_size: args.iterations for batch_size in range(1, args.max_batch + 1)}
+    )
+    actual_decode_counts = Counter(
+        int(sample.get("batchSize", -1)) for sample in decode_samples
+    )
+    if actual_decode_counts != expected_decode_counts:
         raise RuntimeError(
-            f"decode matrix incomplete: expected {expected_batches}, got {actual_batches}"
+            "decode matrix incomplete: "
+            f"expected {expected_decode_counts}, got {actual_decode_counts}"
         )
     for index, sample in enumerate(decode_samples):
         batch_size = int(sample["batchSize"])
@@ -84,6 +66,8 @@ def validate_raw_outputs(
                 f"expected {expected_tokens}"
             )
 
+
+def validate_scheduler(args: argparse.Namespace, scheduler: dict) -> None:
     scheduler_samples = scheduler.get("samples", [])
     expected_scheduler_keys = {
         (length, iteration)
@@ -106,101 +90,20 @@ def validate_raw_outputs(
             f"scheduler[{index}].msPerPrefillToken",
         )
 
-    if arrival.get("promptTokensPerRequest") != args.arrival_prompt_tokens:
-        raise RuntimeError("arrival benchmark reported the wrong prompt length")
-    if arrival.get("decodeTokensPerRequest") != args.arrival_decode_tokens:
-        raise RuntimeError("arrival benchmark reported the wrong decode budget")
-    patterns = arrival.get("patterns", [])
-    pattern_by_name = {pattern.get("name"): pattern for pattern in patterns}
-    if len(patterns) != len(EXPECTED_ARRIVAL_PATTERNS) or set(pattern_by_name) != set(
-        EXPECTED_ARRIVAL_PATTERNS
+
+def validate_raw_outputs(
+    args: argparse.Namespace, sweep: dict, scheduler: dict, arrival: dict
+) -> None:
+    for name, payload in (
+        ("throughput sweep", sweep),
+        ("scheduler prefill", scheduler),
+        ("arrival invariance", arrival),
     ):
-        raise RuntimeError("arrival topology matrix is incomplete")
-    checksum_sets: dict[str, dict[int, set[str]]] = {}
-    for name, delays in EXPECTED_ARRIVAL_PATTERNS.items():
-        pattern = pattern_by_name[name]
-        if pattern.get("arrivalDelaysMs") != delays:
-            raise RuntimeError(f"arrival topology {name} has unexpected delays")
-        if not pattern.get("outputsStableAcrossIterations") or not pattern.get(
-            "outputsMatchBurst"
-        ):
-            raise RuntimeError(f"arrival topology {name} failed exact output invariance")
-        samples = pattern.get("samples", [])
-        actual_iterations = {sample.get("iteration") for sample in samples}
-        expected_iterations = set(range(1, args.iterations + 1))
-        if len(samples) != args.iterations or actual_iterations != expected_iterations:
-            raise RuntimeError(f"arrival topology {name} has incomplete iterations")
-        all_rows: list[dict] = []
-        checksum_sets[name] = defaultdict(set)
-        for sample_index, sample in enumerate(samples):
-            for key in (
-                "aggregateDecodeTokensPerSecond",
-                "endToEndTokensPerSecond",
-                "makespanMs",
-            ):
-                require_positive(
-                    sample.get(key), f"arrival.{name}[{sample_index}].{key}"
-                )
-            rows = sample.get("rows", [])
-            if len(rows) != len(delays) or {row.get("row") for row in rows} != set(
-                range(len(delays))
-            ):
-                raise RuntimeError(
-                    f"arrival topology {name} iteration {sample.get('iteration')} "
-                    "has incomplete rows"
-                )
-            for row in rows:
-                all_rows.append(row)
-                if row.get("generatedTokens") != args.arrival_decode_tokens:
-                    raise RuntimeError(
-                        f"arrival topology {name} row {row.get('row')} completed "
-                        f"{row.get('generatedTokens')} tokens"
-                    )
-                for key in (
-                    "ttftMs",
-                    "decodeTokensPerSecond",
-                    "completedAtMs",
-                ):
-                    require_positive(
-                        row.get(key),
-                        f"arrival.{name}.row[{row.get('row')}].{key}",
-                    )
-                if not row.get("tokenChecksum"):
-                    raise RuntimeError(
-                        f"arrival topology {name} row {row.get('row')} has no checksum"
-                    )
-                checksum_sets[name][int(row["row"])].add(row["tokenChecksum"])
+        if payload.get("modelID", "").replace("\\/", "/") != args.model:
+            raise RuntimeError(f"{name} returned the wrong model ID")
+        assert_finite(payload, name)
 
-        computed_medians = {
-            "medianTTFTMs": median(row["ttftMs"] for row in all_rows),
-            "medianPerRequestDecodeTokensPerSecond": median(
-                row["decodeTokensPerSecond"] for row in all_rows
-            ),
-            "medianAggregateDecodeTokensPerSecond": median(
-                sample["aggregateDecodeTokensPerSecond"] for sample in samples
-            ),
-            "medianMakespanMs": median(sample["makespanMs"] for sample in samples),
-        }
-        for key, computed in computed_medians.items():
-            require_positive(pattern.get(key), f"arrival.{name}.{key}")
-            if not math.isclose(pattern[key], computed, rel_tol=1e-9, abs_tol=1e-6):
-                raise RuntimeError(
-                    f"arrival topology {name} reported inconsistent {key}: "
-                    f"{pattern[key]} vs recomputed {computed}"
-                )
-
-    canonical_checksums: dict[int, str] = {}
-    for row, checksums in checksum_sets["burst"].items():
-        if len(checksums) != 1:
-            raise RuntimeError(f"burst row {row} changed output across iterations")
-        canonical_checksums[row] = next(iter(checksums))
-    for name, rows in checksum_sets.items():
-        for row, checksums in rows.items():
-            if len(checksums) != 1:
-                raise RuntimeError(
-                    f"arrival topology {name} row {row} changed output across iterations"
-                )
-            if next(iter(checksums)) != canonical_checksums.get(row):
-                raise RuntimeError(
-                    f"arrival topology {name} row {row} differs from burst output"
-                )
+    validate_prefill(args, sweep)
+    validate_decode(args, sweep)
+    validate_scheduler(args, scheduler)
+    validate_arrival(args, arrival)


### PR DESCRIPTION
## Summary

Adds a one-command, fail-closed benchmark for the Gemma 4 26B-A4B QAT 4-bit continuous-batching path, and commits the pre-optimization baseline it compares against.

```bash
make benchmark-gemma-contbatch
make benchmark-gemma-contbatch GEMMA_BENCHMARK_ARGS="--label my-change --iterations 3"
```

One invocation: builds the release provider, refreshes the matching metallib, runs four sweeps through the **production** `EngineV2Factory.makeProductionEngine` entry point, diffs against the committed baseline, and writes timestamped Markdown + JSON to the gitignored `tmp/benchmarks/`.

## Why it fails closed

A benchmark that reports a number for a run that did not actually happen is worse than no benchmark. The runner refuses results on: model-id or matrix mismatch, wrong cardinality, non-positive metrics, decode-token reconstruction mismatch, TTFT iteration mismatch, arrival topology/row/token mismatch, checksum failure, broken output invariance. It recomputes every median it prints rather than trusting the payload.

Two measurement decisions worth reviewing:

- **Arrival patterns share one warmed engine.** A fresh engine per pattern charges asynchronous compiled-decode startup to whichever pattern ran first, which is a measurement artifact, not a property of the arrival topology. Pattern order is rotated across repetitions.
- **Both decode-window and end-to-end TPS are reported.** Staggered arrivals put prefill gaps inside the decode window, so decode-window TPS alone overstates what the workload actually delivered.

## Baseline recorded

`mlx-community/gemma-4-26B-A4B-it-qat-4bit` @ `0e3cbab3`, Apple M4 Max, 40-core GPU, 128 GB.

| Prompt | Raw prefill | Production TTFT |
|---:|---:|---:|
| 128 | 839.9 tok/s | 207.6 ms |
| 512 | 1,260.8 tok/s | 474.9 ms |
| 2,048 | 1,292.8 tok/s | 1,800.4 ms |

Decode aggregate: B1 107.8, B2 160.2, B3 192.3, B4 205.1 tok/s. 4 × 512 burst TTFT 1,881.6 ms. Output tokens were exactly invariant across all four arrival topologies.

Committed in both human-readable and machine-readable form so later runs diff automatically.

## Before / After

```mermaid
flowchart LR
  subgraph Before
    A1[perf question] --> B1[hand-run darkbloom benchmark]
    B1 --> C1[eyeball stdout]
    C1 --> D1[numbers in a scrollback buffer]
    D1 --> E1[no baseline, no invariance check]
  end
  subgraph After
    A2[make benchmark-gemma-contbatch] --> B2[release build + matching metallib]
    B2 --> C2[4 sweeps via production EngineV2]
    C2 --> D2{strict validation}
    D2 -- reject --> F2[non-zero exit, no report]
    D2 -- accept --> G2[diff vs committed baseline]
    G2 --> H2["tmp/benchmarks/*.md + *.json"]
  end
```

```mermaid
flowchart TB
  subgraph Code
    M[Makefile: benchmark-gemma-contbatch] --> S[scripts/benchmark-gemma-contbatch.py]
    S --> R[gemma_contbatch.runner]
    R --> C[config: CLI + matrix]
    R --> P[process: build, metallib, darkbloom]
    R --> V[validation: fail-closed checks]
    R --> A[results: medians + baseline diff]
    A --> O[reporting: markdown + json]
    P --> B1["darkbloom benchmark --sweep"]
    P --> B2["darkbloom benchmark --scheduler-prefill"]
    P --> B3["darkbloom benchmark --arrival-invariance"]
    B3 --> N[ArrivalInvarianceBenchmark.swift NEW]
  end
```

## Notes

- Generated reports land in `tmp/benchmarks/` and are gitignored; only the baseline docs under `docs/reports/` are committed.
- The Python runner is split into focused modules (`config`, `process`, `validation`, `results`, `reporting`, `runner`), each well under 300 lines, per the repo's modularity guidance.
- This PR is measurement only — no serving-path behavior changes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/573"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787549336&installation_model_id=21733&pr_number=573&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F573&signature=bfc78e924b53f1812ac350e2ed7801e10c900e01a6bb589eb4ddbc5908ecbb2b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->