### PR TITLE
fix(metallib): key the cache on mlx working-tree contents, not just HEAD

### DIFF
--- a/scripts/fetch-metallib.sh
+++ b/scripts/fetch-metallib.sh
@@ -43,40 +43,65 @@ test -f "$MLX_SRC/mlx/version.h" || {
   exit 1
 }
 
-MLX_SHA="$(git -C "$MLX_SRC" rev-parse HEAD 2>/dev/null || echo nogit)"
-
 # The commit alone is NOT a sufficient cache key: kernel work happens in the
 # WORKING TREE long before it is committed, and serving a metallib built from
 # different sources than the host code that dispatches into it is not a stale
 # cache — it is a hang. (Observed: patching `qmm_t_impl`'s M parameter while
 # reusing the pre-patch metallib wedges the GPU at 0% CPU.) So fold any
 # uncommitted change — tracked diffs AND untracked files — into the key.
-MLX_TREE_HASH="$({
-    git -C "$MLX_SRC" diff HEAD -- 2>/dev/null || true
-    git -C "$MLX_SRC" ls-files --others --exclude-standard 2>/dev/null \
-        | while IFS= read -r f; do
+#
+# `git diff` is normalized for determinism: --binary so binary edits actually
+# change the hash instead of collapsing to "Binary files differ",
+# --no-ext-diff so a user's difftool cannot alter the key, and --no-color so
+# terminal settings cannot either.
+if git -C "$MLX_SRC" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    MLX_SHA="$(git -C "$MLX_SRC" rev-parse HEAD 2>/dev/null || echo nogit)"
+    MLX_TREE_HASH="$({
+        git -C "$MLX_SRC" diff HEAD --binary --no-ext-diff --no-color -- 2>/dev/null || true
+        {
+            git -C "$MLX_SRC" ls-files --others --exclude-standard 2>/dev/null || true
+        } | while IFS= read -r f; do
             printf '%s\n' "$f"
             cat "$MLX_SRC/$f" 2>/dev/null || true
         done
-} | shasum -a 256 | cut -d' ' -f1)"
-# Hash of empty input == a clean tree; keep those cache entries keyed exactly
-# as before so existing caches stay valid.
+    } | shasum -a 256 | cut -d' ' -f1)"
+else
+    # Not a git checkout (source tarball, vendored copy). There is no commit
+    # and no diff to read, so hashing nothing would mark ANY local edit as
+    # "clean" and reintroduce exactly the bug this key is meant to prevent.
+    # Hash the source contents instead.
+    MLX_SHA="nogit"
+    MLX_TREE_HASH="$(
+        find "$MLX_SRC/mlx" -type f \( -name '*.h' -o -name '*.metal' -o -name '*.cpp' \) -print0 2>/dev/null \
+            | sort -z | xargs -0 shasum -a 256 2>/dev/null | shasum -a 256 | cut -d' ' -f1
+    )"
+    echo "→ mlx source is not a git checkout; keying metallib on file contents (${MLX_TREE_HASH:0:12})"
+fi
+
+# Hash of empty input == a clean git tree.
 MLX_CLEAN_HASH="$(printf '' | shasum -a 256 | cut -d' ' -f1)"
-if [ "$MLX_TREE_HASH" = "$MLX_CLEAN_HASH" ]; then
-    MLX_TREE_SUFFIX=""
+if [ "$MLX_SHA" != "nogit" ] && [ "$MLX_TREE_HASH" = "$MLX_CLEAN_HASH" ]; then
+    # Clean tree. The key is versioned (-c2) rather than bare: entries written
+    # by the PREVIOUS version of this script used the bare name and could have
+    # been built from a DIRTY tree, so reusing them would resurrect the very
+    # mismatch this change exists to prevent. The suffix retires them.
+    MLX_TREE_SUFFIX="-c2"
 else
     MLX_TREE_SUFFIX="-w${MLX_TREE_HASH:0:12}"
-    echo "→ mlx working tree is dirty; keying metallib on its contents (${MLX_TREE_HASH:0:12})"
+    if [ "$MLX_SHA" != "nogit" ]; then
+        echo "→ mlx working tree is dirty; keying metallib on its contents (${MLX_TREE_HASH:0:12})"
+    fi
 fi
 
 # Cache the built metallib by mlx commit + working-tree contents + deployment
 # target so repeat runs are instant (the build is ~1 min). Override with
 # METALLIB_CACHE_DIR.
 CACHE_DIR="${METALLIB_CACHE_DIR:-/tmp/mlx-metallib-cache}"
-CACHED="$CACHE_DIR/mlx-${MLX_SHA}${MLX_TREE_SUFFIX}-dt${DEPLOYMENT_TARGET}.metallib"
+CACHE_KEY="mlx-${MLX_SHA}${MLX_TREE_SUFFIX}-dt${DEPLOYMENT_TARGET}"
+CACHED="$CACHE_DIR/${CACHE_KEY}.metallib"
 
 if [ ! -s "$CACHED" ]; then
-    echo "→ Building mlx.metallib from $MLX_SRC @ ${MLX_SHA:0:12} (deployment target $DEPLOYMENT_TARGET)"
+    echo "→ Building mlx.metallib from $MLX_SRC @ $CACHE_KEY"
     BUILD_DIR="$(mktemp -d)"
     cmake -S "$MLX_SRC" -B "$BUILD_DIR" \
         -DCMAKE_BUILD_TYPE=Release \
@@ -89,7 +114,7 @@ if [ ! -s "$CACHED" ]; then
     cp "$BUILD_DIR/mlx/backend/metal/kernels/mlx.metallib" "$CACHED"
     rm -rf "$BUILD_DIR"
 else
-    echo "→ Using cached metallib for ${MLX_SHA:0:12}"
+    echo "→ Using cached metallib $CACHE_KEY"
 fi
 
 # Sanity: the _nax kernels must be present, otherwise the build silently used an

--- a/scripts/fetch-metallib.sh
+++ b/scripts/fetch-metallib.sh
@@ -45,10 +45,35 @@ test -f "$MLX_SRC/mlx/version.h" || {
 
 MLX_SHA="$(git -C "$MLX_SRC" rev-parse HEAD 2>/dev/null || echo nogit)"
 
-# Cache the built metallib by mlx commit + deployment target so repeat runs are
-# instant (the build is ~1 min). Override with METALLIB_CACHE_DIR.
+# The commit alone is NOT a sufficient cache key: kernel work happens in the
+# WORKING TREE long before it is committed, and serving a metallib built from
+# different sources than the host code that dispatches into it is not a stale
+# cache — it is a hang. (Observed: patching `qmm_t_impl`'s M parameter while
+# reusing the pre-patch metallib wedges the GPU at 0% CPU.) So fold any
+# uncommitted change — tracked diffs AND untracked files — into the key.
+MLX_TREE_HASH="$({
+    git -C "$MLX_SRC" diff HEAD -- 2>/dev/null || true
+    git -C "$MLX_SRC" ls-files --others --exclude-standard 2>/dev/null \
+        | while IFS= read -r f; do
+            printf '%s\n' "$f"
+            cat "$MLX_SRC/$f" 2>/dev/null || true
+        done
+} | shasum -a 256 | cut -d' ' -f1)"
+# Hash of empty input == a clean tree; keep those cache entries keyed exactly
+# as before so existing caches stay valid.
+MLX_CLEAN_HASH="$(printf '' | shasum -a 256 | cut -d' ' -f1)"
+if [ "$MLX_TREE_HASH" = "$MLX_CLEAN_HASH" ]; then
+    MLX_TREE_SUFFIX=""
+else
+    MLX_TREE_SUFFIX="-w${MLX_TREE_HASH:0:12}"
+    echo "→ mlx working tree is dirty; keying metallib on its contents (${MLX_TREE_HASH:0:12})"
+fi
+
+# Cache the built metallib by mlx commit + working-tree contents + deployment
+# target so repeat runs are instant (the build is ~1 min). Override with
+# METALLIB_CACHE_DIR.
 CACHE_DIR="${METALLIB_CACHE_DIR:-/tmp/mlx-metallib-cache}"
-CACHED="$CACHE_DIR/mlx-${MLX_SHA}-dt${DEPLOYMENT_TARGET}.metallib"
+CACHED="$CACHE_DIR/mlx-${MLX_SHA}${MLX_TREE_SUFFIX}-dt${DEPLOYMENT_TARGET}.metallib"
 
 if [ ! -s "$CACHED" ]; then
     echo "→ Building mlx.metallib from $MLX_SRC @ ${MLX_SHA:0:12} (deployment target $DEPLOYMENT_TARGET)"


### PR DESCRIPTION
## Summary

`scripts/fetch-metallib.sh` keyed its cache on the mlx submodule's **HEAD commit** plus the deployment target. Kernel work happens in the **working tree** long before it is committed, so any uncommitted change to mlx kernels silently reused a metallib built from *different sources* than the host code dispatching into it.

## Why this is a correctness bug, not a cache-hygiene nit

Hit while patching `qmm_t_impl`'s `M` parameter (`const constant int&` → `const int`). The host encoded the argument one way; the cached metallib expected the other. Result: **the GPU wedged at 0% CPU with no error message**, which presented as a hung test suite and cost a debugging cycle chasing a phantom regression.

The worse failure mode is silent: a benchmark run in that state reports confident numbers for kernels that were never built. Any uncommitted-kernel A/B measured through this script was untrustworthy.

## Fix

Fold uncommitted state into the cache key — tracked diffs plus untracked file contents, hashed and appended as a `-w<hash>` suffix:

```
mlx-<sha>-dt<target>.metallib            # clean tree (unchanged key)
mlx-<sha>-w<hash>-dt<target>.metallib    # dirty tree
```

A clean tree hashes to the empty-input digest and keeps its **existing** key, so current caches stay valid and committed builds are byte-for-byte unaffected. A dirty tree now rebuilds once per distinct source state and prints which content hash it keyed on.

## Before / After

```mermaid
flowchart LR
  subgraph Before
    A1[edit mlx kernel source] --> B1["key = HEAD sha + target"]
    B1 --> C1{cache hit?}
    C1 -- yes --> D1[reuse PRE-EDIT metallib]
    D1 --> E1[host/kernel ABI mismatch]
    E1 --> F1[GPU hang at 0% CPU<br/>or silently wrong benchmark]
  end
  subgraph After
    A2[edit mlx kernel source] --> B2["key = HEAD sha + tracked diff<br/>+ untracked contents + target"]
    B2 --> C2{cache hit?}
    C2 -- no, tree changed --> D2[rebuild metallib from actual sources]
    C2 -- yes, identical tree --> E2[reuse correct metallib]
    D2 --> F2[host and kernel agree]
    E2 --> F2
  end
```

## Verification

Reproduced the stale hit (`Using cached metallib for d5a240408508`, hash `2e535253…`) against patched sources, applied the fix, and confirmed the same tree now rebuilds to a different metallib (`6b3099c9…`). Clean-tree runs still resolve to the original cache entry.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/574"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787549365&installation_model_id=21733&pr_number=574&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F574&signature=81cd3d04b63bb5c8192c3349028af33bfbac488af285ef933eb23c859a8910dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->