### PR TITLE
feat(coordinator): add dev-insecure mode for a throwaway dev coordinator

### DIFF
--- a/coordinator/api/provider.go
+++ b/coordinator/api/provider.go
@@ -1120,6 +1120,21 @@ func (s *Server) verifyChallengeResponse(providerID string, provider *registry.P
 		"status_fields_trusted", statusFieldsTrusted,
 	)
 
+	// Dev-insecure: skip all attestation status-field enforcement below (SIP,
+	// Secure Boot, RDMA, binary/model-weight hashes). On an un-attested dev box
+	// those checks would MarkUntrusted → deroute it — contradicting the relaxed
+	// routing gates and the provider's tolerant preflight (e.g. a SIP-disabled
+	// dev Mac). The challenge signature above still verified, and E2E is
+	// unaffected. Record a passing challenge so the provider stays live.
+	if s.registry.DevInsecure {
+		provider.Mu().Lock()
+		provider.ChallengeVerifiedSIP = resp.SIPEnabled != nil && *resp.SIPEnabled
+		provider.Mu().Unlock()
+		s.registry.RecordChallengeSuccess(providerID)
+		s.ddIncr("attestation.challenges", []string{"outcome:dev_insecure_skip"})
+		return
+	}
+
 	// Verify fresh SIP status. This signal is mandatory for private text:
 	// an omitted value is not evidence of safety, so fail closed.
 	if resp.SIPEnabled == nil {

--- a/coordinator/cmd/coordinator/dev_insecure_guard_test.go
+++ b/coordinator/cmd/coordinator/dev_insecure_guard_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/eigeninference/d-inference/coordinator/registry"
+)
+
+// TestResolveDevInsecureProdGuards pins the defense-in-depth prod guards: a stray
+// EIGENINFERENCE_DEV_INSECURE in a production-like deployment must fail CLOSED
+// (refuse to start), never boot open.
+func TestResolveDevInsecureProdGuards(t *testing.T) {
+	cases := []struct {
+		name            string
+		databaseURL     string
+		minTrust        string
+		allowMemory     bool
+		wantErrContains string // "" means expect success
+		wantTrust       string // only checked on success
+	}{
+		{
+			name:            "refuses against a durable database",
+			databaseURL:     "postgres://prod/db",
+			minTrust:        "",
+			allowMemory:     true,
+			wantErrContains: "DATABASE_URL",
+		},
+		{
+			name:            "refuses contradictory MIN_TRUST=hardware",
+			databaseURL:     "",
+			minTrust:        string(registry.TrustHardware),
+			allowMemory:     true,
+			wantErrContains: "hardware",
+		},
+		{
+			name:            "refuses without explicit memory-store opt-in (fail closed)",
+			databaseURL:     "",
+			minTrust:        "",
+			allowMemory:     false,
+			wantErrContains: "ALLOW_MEMORY_STORE",
+		},
+		{
+			name:        "valid dev config defaults MIN_TRUST to none",
+			databaseURL: "",
+			minTrust:    "",
+			allowMemory: true,
+			wantTrust:   string(registry.TrustNone),
+		},
+		{
+			name:        "valid dev config preserves an explicit non-hardware MIN_TRUST",
+			databaseURL: "",
+			minTrust:    string(registry.TrustSelfSigned),
+			allowMemory: true,
+			wantTrust:   string(registry.TrustSelfSigned),
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := resolveDevInsecure(tc.databaseURL, tc.minTrust, tc.allowMemory)
+			if tc.wantErrContains != "" {
+				if err == nil {
+					t.Fatalf("expected refuse-to-start error containing %q, got nil (trust=%q)", tc.wantErrContains, got)
+				}
+				if !strings.Contains(err.Error(), tc.wantErrContains) {
+					t.Fatalf("error %q does not contain %q", err.Error(), tc.wantErrContains)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.wantTrust {
+				t.Fatalf("resolved trust = %q, want %q", got, tc.wantTrust)
+			}
+		})
+	}
+}

--- a/coordinator/cmd/coordinator/main.go
+++ b/coordinator/cmd/coordinator/main.go
@@ -82,6 +82,27 @@ func main() {
 		os.Exit(1)
 	}
 
+	// EIGENINFERENCE_DEV_INSECURE — dev-only "all security disabled" mode for a
+	// throwaway dev coordinator. It fail-opens the attestation/hardening routing
+	// gates (E2E prompt encryption is KEPT) so an un-hardened, un-attested dev
+	// provider can connect, register, and serve inference. resolveDevInsecure
+	// applies defense-in-depth prod guards (see its doc): the flag NEVER silently
+	// weakens a production deployment — a stray env var fails CLOSED (refuses to
+	// start), never open.
+	if cfg.RegistryCfg.DevInsecure {
+		resolvedTrust, err := resolveDevInsecure(
+			cfg.StoreConfig.DatabaseURL,
+			cfg.RegistryCfg.MinTrustLevel,
+			cfg.StoreConfig.AllowMemoryStore,
+		)
+		if err != nil {
+			logger.Error("refusing to start in dev-insecure mode", "error", err)
+			os.Exit(1)
+		}
+		cfg.RegistryCfg.MinTrustLevel = resolvedTrust
+		logger.Warn("⚠️  EIGENINFERENCE_DEV_INSECURE ENABLED — attestation, MDM, code-identity, SIP, and hardening routing gates are DISABLED (E2E prompt encryption is kept). NEVER run this in production.")
+	}
+
 	adminKey := cfg.AdminKey
 	if adminKey == "" {
 		logger.Warn("EIGENINFERENCE_ADMIN_KEY is not set — no pre-seeded API key available")
@@ -134,6 +155,21 @@ func main() {
 		})
 	}
 
+	// Dev-insecure: seed the admin account with a large balance so inference is
+	// effectively free on the throwaway dev coordinator (the admin key resolves
+	// to the "admin" ledger account). This keeps the real billing path intact
+	// (reserve/settle/refund arithmetic all run normally against the balance)
+	// rather than special-casing the settlement math. Guarded by DevInsecure, so
+	// it never runs in prod; the in-memory store means it re-seeds each start.
+	if cfg.RegistryCfg.DevInsecure {
+		const devInsecureSeedMicroUSD int64 = 1_000_000_000_000_000 // ~$1B
+		if err := st.Credit("admin", devInsecureSeedMicroUSD, store.LedgerAdminCredit, "dev-insecure-seed"); err != nil {
+			logger.Warn("dev-insecure: failed to seed admin balance", "error", err)
+		} else {
+			logger.Warn("dev-insecure: seeded admin account with a large balance for free inference")
+		}
+	}
+
 	// Reconcile provider sessions left open by a previous coordinator process
 	// (durable uptime history). Best-effort + time-bounded — neither an error nor
 	// a slow/unresponsive DB must block startup. Only sessions whose last
@@ -155,6 +191,7 @@ func main() {
 	}()
 
 	reg := registry.New(logger)
+	reg.DevInsecure = cfg.RegistryCfg.DevInsecure
 
 	// Set minimum trust level for routing.
 	if cfg.RegistryCfg.MinTrustLevel != "" {
@@ -930,6 +967,41 @@ func main() {
 	}
 
 	logger.Info("coordinator stopped")
+}
+
+// parseAPNsEnforceAfter reads APNS_ENFORCE_AFTER (RFC3339) — the instant at which
+// resolveDevInsecure validates the dev-insecure ("all security disabled") config
+// and returns the effective MinTrustLevel, or an error the caller MUST turn into a
+// refuse-to-start. Pure (no env/IO) so the prod guards are unit-tested.
+//
+// Defense-in-depth: the guard must not rest on a single environmental invariant
+// while also dismantling the adjacent fail-safes. So dev-insecure:
+//   - refuses if a durable database is configured (prod always sets
+//     EIGENINFERENCE_DATABASE_URL) — dev-insecure is ephemeral-only;
+//   - refuses if EIGENINFERENCE_MIN_TRUST is explicitly "hardware" (a direct
+//     contradiction — fail loudly instead of silently overriding it);
+//   - requires the operator's EXPLICIT in-memory-store opt-in
+//     (EIGENINFERENCE_ALLOW_MEMORY_STORE=true) rather than force-enabling it, so
+//     the normal "no DB → refuse to start" backstop stays intact. A stray
+//     DEV_INSECURE=true in a prod-like deploy whose DB secret failed to inject
+//     then still fails CLOSED (won't boot) instead of booting open on an
+//     ephemeral store.
+//
+// Only after all three pass does it default an empty MIN_TRUST to none.
+func resolveDevInsecure(databaseURL, minTrust string, allowMemoryStore bool) (string, error) {
+	if databaseURL != "" {
+		return "", errors.New("EIGENINFERENCE_DEV_INSECURE must not be combined with EIGENINFERENCE_DATABASE_URL — dev-insecure mode is ephemeral-only and must never run against a durable/production database")
+	}
+	if minTrust == string(registry.TrustHardware) {
+		return "", fmt.Errorf("EIGENINFERENCE_DEV_INSECURE is contradictory with EIGENINFERENCE_MIN_TRUST=%s — refusing to start", registry.TrustHardware)
+	}
+	if !allowMemoryStore {
+		return "", errors.New("EIGENINFERENCE_DEV_INSECURE requires EIGENINFERENCE_ALLOW_MEMORY_STORE=true (dev-insecure is ephemeral-only) — refusing to start")
+	}
+	if minTrust == "" {
+		return string(registry.TrustNone), nil
+	}
+	return minTrust, nil
 }
 
 // parseAPNsEnforceAfter reads APNS_ENFORCE_AFTER (RFC3339) — the instant at which

--- a/coordinator/registry/config.go
+++ b/coordinator/registry/config.go
@@ -17,6 +17,17 @@ type Config struct {
 	WarmPool      WarmPoolConfig
 	CacheRouting  CacheRoutingConfig
 	QualityCap    QualityCapConfig
+
+	// DevInsecure enables dev-only "all security disabled" routing
+	// (EIGENINFERENCE_DEV_INSECURE). When set, the coordinator fail-opens every
+	// attestation/hardening routing gate (runtime manifest, coordinator-verified
+	// SIP, code-identity, privacy-capabilities, runtime-verified, and
+	// challenge-freshness) while KEEPING the end-to-end crypto requirements
+	// (per-provider X25519 public key, mlx-swift backend, encrypted response
+	// chunks) — prompts stay encrypted on the wire. main.go additionally forces
+	// MIN_TRUST=none, requires the in-memory store, and REFUSES to start against a
+	// durable database, so this can never silently weaken a production deployment.
+	DevInsecure bool
 }
 
 type CacheRoutingConfig struct {
@@ -117,6 +128,7 @@ func (c WarmPoolConfig) perTickCeiling() int {
 func ReadConfig() Config {
 	return Config{
 		MinTrustLevel: os.Getenv(env.EnvPrefix + "_MIN_TRUST"),
+		DevInsecure:   env.EnvBool(env.EnvPrefix+"_DEV_INSECURE", false),
 		WarmPool: WarmPoolConfig{
 			Enabled:                   env.EnvBool(env.EnvPrefix+"_WARM_POOL_ENABLED", true),
 			ObserveOnly:               env.EnvBool(env.EnvPrefix+"_WARM_POOL_OBSERVE_ONLY", false),

--- a/coordinator/registry/dev_insecure_test.go
+++ b/coordinator/registry/dev_insecure_test.go
@@ -1,0 +1,101 @@
+package registry
+
+import (
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+)
+
+// devInsecureProvider registers a provider that carries the end-to-end crypto
+// fields (X25519 public key, mlx-swift backend, encrypted response chunks) but
+// presents every attestation/hardening signal in the un-hardened state a real
+// dev provider (DARKBLOOM_DEV_INSECURE) would: no verified runtime manifest, no
+// coordinator-verified SIP, no privacy hardening, no fresh attestation
+// challenge, and TrustNone. This is exactly the provider a dev-insecure
+// coordinator must route and a normal coordinator must refuse.
+func devInsecureProvider(reg *Registry, id string) *Provider {
+	msg := testRegisterMessage()
+	msg.Backend = BackendMLXSwift
+	// A non-hardened dev build reports its hardening flags as false.
+	msg.PrivacyCapabilities = &protocol.PrivacyCapabilities{
+		TextBackendInprocess: true,
+		TextProxyDisabled:    true,
+		AntiDebugEnabled:     false,
+		CoreDumpsDisabled:    false,
+		EnvScrubbed:          false,
+	}
+	p := reg.Register(id, nil, msg)
+	// Wind the attestation/hardening state back to what an un-attested dev
+	// provider actually presents (Register defaults some of these to "verified").
+	p.TrustLevel = TrustNone
+	p.RuntimeVerified = false
+	p.RuntimeManifestChecked = false
+	p.ChallengeVerifiedSIP = false
+	p.LastChallengeVerified = time.Time{}
+	return p
+}
+
+// TestDevInsecureRoutesUnattestedProvider proves the dev-insecure relaxation:
+// an E2E-capable but completely un-attested provider is routable.
+func TestDevInsecureRoutesUnattestedProvider(t *testing.T) {
+	reg := New(testLogger())
+	reg.DevInsecure = true
+	reg.MinTrustLevel = TrustNone // main.go forces this when DEV_INSECURE is set
+	p := devInsecureProvider(reg, "p-dev-insecure")
+
+	reg.mu.RLock()
+	defer reg.mu.RUnlock()
+	if !reg.providerSupportsPrivateTextLocked(p) {
+		t.Fatal("dev-insecure: E2E-capable but un-attested provider must support private text")
+	}
+	if !reg.providerLivenessGateLocked(p, reg.MinTrustLevel, false, time.Now()) {
+		t.Fatal("dev-insecure: un-attested provider must pass the liveness gate")
+	}
+}
+
+// TestDevInsecureDisabledRejectsUnattestedProvider is the regression guard: the
+// SAME provider must be refused when DevInsecure is off, so the relaxation is
+// provably the only reason it routes above.
+func TestDevInsecureDisabledRejectsUnattestedProvider(t *testing.T) {
+	reg := New(testLogger()) // DevInsecure defaults false
+	p := devInsecureProvider(reg, "p-strict")
+
+	reg.mu.RLock()
+	defer reg.mu.RUnlock()
+	if reg.providerSupportsPrivateTextLocked(p) {
+		t.Fatal("strict mode: un-attested provider must NOT support private text")
+	}
+	if reg.providerLivenessGateLocked(p, TrustNone, false, time.Now()) {
+		t.Fatal("strict mode: un-attested provider must NOT pass the liveness gate")
+	}
+}
+
+// TestDevInsecureStillRequiresE2E proves the crypto floor is never relaxed:
+// even with all attestation/hardening disabled, a provider missing any E2E
+// requirement is not routable for private text.
+func TestDevInsecureStillRequiresE2E(t *testing.T) {
+	cases := []struct {
+		name   string
+		mutate func(p *Provider)
+	}{
+		{"no_public_key", func(p *Provider) { p.PublicKey = "" }},
+		{"chunks_not_encrypted", func(p *Provider) { p.EncryptedResponseChunks = false }},
+		{"non_swift_backend", func(p *Provider) { p.Backend = "inprocess-mlx" }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			reg := New(testLogger())
+			reg.DevInsecure = true
+			reg.MinTrustLevel = TrustNone
+			p := devInsecureProvider(reg, "p-"+tc.name)
+			tc.mutate(p)
+
+			reg.mu.RLock()
+			defer reg.mu.RUnlock()
+			if reg.providerSupportsPrivateTextLocked(p) {
+				t.Fatalf("dev-insecure must still enforce E2E: %s should not be routable", tc.name)
+			}
+		})
+	}
+}

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -649,6 +649,14 @@ func (r *Registry) providerSupportsPrivateTextLocked(p *Provider) bool {
 	if p.PublicKey == "" || !privateTextBackendSupported(p.Backend) || !p.EncryptedResponseChunks {
 		return false
 	}
+	// Dev-insecure coordinator: keep the E2E-crypto requirements above (prompts
+	// stay encrypted end-to-end) but skip every attestation/hardening gate below
+	// (runtime manifest, coordinator-verified SIP, code-identity, privacy caps).
+	// Gated by an explicit dev-only flag that main.go refuses to enable against a
+	// durable store, so production routing is never affected.
+	if r.DevInsecure {
+		return true
+	}
 	if !p.RuntimeManifestChecked {
 		return false
 	}
@@ -1284,6 +1292,16 @@ type Registry struct {
 	queue *RequestQueue
 
 	MinTrustLevel TrustLevel
+
+	// DevInsecure fail-opens every attestation/hardening routing gate for a
+	// dev-only "all security disabled" coordinator (EIGENINFERENCE_DEV_INSECURE).
+	// It relaxes ONLY the attestation/hardening conditions — the end-to-end
+	// crypto requirements (X25519 public key, mlx-swift backend, encrypted
+	// response chunks) are still enforced, so prompts stay encrypted on the wire.
+	// Set once at startup from cfg.RegistryCfg.DevInsecure; read on the routing
+	// paths under r.mu. main.go refuses to enable it against a durable store, so
+	// it can never weaken production. Default false (zero behavior change).
+	DevInsecure bool
 
 	// dedicatedModels holds lowercased substring patterns identifying model
 	// families that may ONLY route to providers dedicated to that family (a
@@ -2323,7 +2341,9 @@ func (r *Registry) ModelType(model string) string {
 func (r *Registry) IsModelInCatalog(model string) bool {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	if r.modelCatalog == nil {
+	// Dev-insecure: the throwaway dev coordinator has no model registry, so treat
+	// any provider-advertised model as in-catalog (route whatever the provider has).
+	if r.DevInsecure || r.modelCatalog == nil {
 		return true
 	}
 	_, ok := r.modelCatalog[model]
@@ -2408,7 +2428,9 @@ func (r *Registry) IsAliasLineageBuild(buildID string) bool {
 // allowed by the current catalog. Caller must hold r.mu (read or write). A nil
 // catalog disables filtering; an empty non-nil catalog denies all models.
 func (r *Registry) modelAllowedByCatalogLocked(model protocol.ModelInfo) bool {
-	if r.modelCatalog == nil {
+	// Dev-insecure: no model registry on the dev coordinator — allow any
+	// provider-advertised build (no catalog weight-hash pinning to enforce).
+	if r.DevInsecure || r.modelCatalog == nil {
 		return true
 	}
 	entry, ok := r.modelCatalog[model.ID]

--- a/coordinator/registry/routing_eligibility.go
+++ b/coordinator/registry/routing_eligibility.go
@@ -50,13 +50,19 @@ func (r *Registry) providerLivenessGateLocked(p *Provider, minTrust TrustLevel, 
 	if trustRank(p.TrustLevel) < trustRank(minTrust) {
 		return false
 	}
-	if !p.RuntimeVerified {
+	// Dev-insecure skips the runtime-manifest and attestation-challenge liveness
+	// gates (no signed runtime manifest is configured and challenge freshness is
+	// irrelevant when attestation is disabled). The private-text (E2E) gate below
+	// still runs — it is what keeps prompts encrypted — and the status/trust-floor
+	// gates above are unchanged.
+	if !r.DevInsecure && !p.RuntimeVerified {
 		return false
 	}
 	if !r.providerSupportsPrivateTextLocked(p) {
 		return false
 	}
-	if p.LastChallengeVerified.IsZero() || now.Sub(p.LastChallengeVerified) > challengeFreshnessMaxAge {
+	if !r.DevInsecure &&
+		(p.LastChallengeVerified.IsZero() || now.Sub(p.LastChallengeVerified) > challengeFreshnessMaxAge) {
 		return false
 	}
 	return true

--- a/provider-swift/Sources/ProviderCore/Config/DevInsecure.swift
+++ b/provider-swift/Sources/ProviderCore/Config/DevInsecure.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+/// Dev-only "all security disabled" switch, mirrored by the coordinator's
+/// `EIGENINFERENCE_DEV_INSECURE`. When `DARKBLOOM_DEV_INSECURE` is truthy the
+/// provider:
+///   - downgrades start-time preflight *security* throws (SIP off, debugger
+///     attached) to warnings instead of refusing to start,
+///   - skips the release security-hardening posture verification (it still
+///     attempts the Secure Enclave self-sign and always keeps X25519 E2E
+///     encryption of prompts/responses), and
+///   - skips the dev→prod coordinator-URL migration so a `ws://` dev URL is not
+///     rewritten to production.
+///
+/// It NEVER weakens end-to-end encryption. It exists only so an un-hardened,
+/// un-attested dev build can connect to a throwaway dev-insecure coordinator,
+/// register, and serve inference. Never set it against production.
+public enum DevInsecure {
+    /// True when `DARKBLOOM_DEV_INSECURE` is set to a truthy value.
+    public static var isEnabled: Bool {
+        switch ProcessInfo.processInfo.environment["DARKBLOOM_DEV_INSECURE"]?
+            .trimmingCharacters(in: .whitespaces).lowercased() {
+        case "1", "true", "yes", "on":
+            return true
+        default:
+            return false
+        }
+    }
+
+    /// Optional coordinator URL override for the dev-insecure daemon path,
+    /// e.g. `ws://10.0.0.5:8080/ws/provider`. Read from
+    /// `DARKBLOOM_DEV_COORDINATOR_URL`. Lets the launchd daemon (which cannot
+    /// take a `--url` flag) target the dev coordinator. Returns nil when unset
+    /// or empty. Ranks below an explicit `--url` flag, above the config file.
+    public static var coordinatorURLOverride: String? {
+        guard let value = ProcessInfo.processInfo.environment["DARKBLOOM_DEV_COORDINATOR_URL"],
+              !value.trimmingCharacters(in: .whitespaces).isEmpty else {
+            return nil
+        }
+        return value.trimmingCharacters(in: .whitespaces)
+    }
+}

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+Serve.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+Serve.swift
@@ -375,6 +375,11 @@ extension ProviderLoop {
     // MARK: - Security Hardening
 
     private func applySecurityHardening() async throws {
+        if DevInsecure.isEnabled {
+            logger.warning("⚠️ DARKBLOOM_DEV_INSECURE — security hardening posture verification skipped (SE self-sign still attempted; E2E encryption unaffected)")
+            self.binaryHash = selfBinaryHash()
+            return
+        }
         #if !DEBUG
         let posture = collectSecurityPosture()
         guard let binaryHash = posture.binaryHash, !binaryHash.isEmpty else {

--- a/provider-swift/Sources/ProviderCore/Service/LaunchAgent.swift
+++ b/provider-swift/Sources/ProviderCore/Service/LaunchAgent.swift
@@ -274,6 +274,10 @@ public enum LaunchAgent: Sendable {
         "DARKBLOOM_PREFIX_CACHE",
         "DARKBLOOM_MLX_RESOURCE_DEBUG", "DARKBLOOM_CBV2_PAGED_KV",
         "DARKBLOOM_CBV2_MTP", "DARKBLOOM_MTP_MAX_RECTANGULAR_TOKENS",
+        // Dev-insecure daemon: carry the "all security disabled" switch and the
+        // dev coordinator URL through install/restart so a launchd-managed dev
+        // provider keeps targeting the dev-insecure coordinator.
+        "DARKBLOOM_DEV_INSECURE", "DARKBLOOM_DEV_COORDINATOR_URL",
     ]
 
     /// Build the daemon `EnvironmentVariables` map from a source environment,

--- a/provider-swift/Sources/darkbloom/Darkbloom.swift
+++ b/provider-swift/Sources/darkbloom/Darkbloom.swift
@@ -179,6 +179,9 @@ private let staleCoordinatorURLs: [(pattern: String, label: String)] = [
 /// 2. **Coordinator URL**: if the TOML text contains a known stale
 ///    coordinator URL (localhost, dev), rewrite it to production in-place.
 func migrateConfigIfNeeded(configPath: URL, config: ProviderConfig) -> ProviderConfig {
+    // Dev-insecure: never rewrite a ws:// dev coordinator URL to production.
+    if DevInsecure.isEnabled { return config }
+
     let fm = FileManager.default
     guard fm.fileExists(atPath: configPath.path) else { return config }
 

--- a/provider-swift/Sources/darkbloom/StartCommand+Preflight.swift
+++ b/provider-swift/Sources/darkbloom/StartCommand+Preflight.swift
@@ -12,12 +12,19 @@ extension Start {
     /// Runs critical doctor checks inline before the model picker so users
     /// don't discover problems *after* downloading GBs of weights.
     internal func runPreflightChecks(snapshot: RuntimeSnapshot) throws {
-        warnBootSecurity(coordinatorEnforced: true)
+        let devInsecure = DevInsecure.isEnabled
+        // A dev-insecure coordinator does not enforce boot security, so report it
+        // as non-enforced (informational) rather than a rejection warning.
+        warnBootSecurity(coordinatorEnforced: !devInsecure)
 
         let debuggerAttached = checkDebuggerAttached()
         if debuggerAttached {
-            printError("A debugger is attached. The coordinator will reject this provider.")
-            throw ExitCode.failure
+            if devInsecure {
+                printError("⚠️ A debugger is attached — ignored (DARKBLOOM_DEV_INSECURE).")
+            } else {
+                printError("A debugger is attached. The coordinator will reject this provider.")
+                throw ExitCode.failure
+            }
         }
 
         guard let hardware = snapshot.hardware else { return }

--- a/provider-swift/Sources/darkbloom/StartCommand.swift
+++ b/provider-swift/Sources/darkbloom/StartCommand.swift
@@ -85,7 +85,12 @@ struct Start: AsyncParsableCommand {
         }
 
         let snapshot = try loadRuntimeSnapshot(configOptions: configOptions)
-        let effectiveCoordinator = coordinatorURL ?? snapshot.config.coordinator.url
+        // Precedence: explicit --url flag > DARKBLOOM_DEV_COORDINATOR_URL (dev
+        // daemon override) > config file. The env override lets the launchd
+        // daemon target a dev-insecure coordinator without a --url flag.
+        let effectiveCoordinator = coordinatorURL
+            ?? DevInsecure.coordinatorURLOverride
+            ?? snapshot.config.coordinator.url
         var effectiveConfig = snapshot.config
         if let idleTimeout {
             effectiveConfig.backend.idleTimeoutMins = idleTimeout


### PR DESCRIPTION
## What & why

Adds an explicit **dev-only "all security disabled" mode** so a disposable dev coordinator can accept an un-hardened, un-attested provider that just needs to **connect, register, and serve inference** — without standing up any of the production attestation/hardening/MDM machinery.

Two flags, both **default off** (zero behavior change when unset):

- Coordinator: `EIGENINFERENCE_DEV_INSECURE=true`
- Swift provider: `DARKBLOOM_DEV_INSECURE=1` (+ optional `DARKBLOOM_DEV_COORDINATOR_URL`)

**End-to-end encryption is kept.** The provider still must present an X25519 public key, the mlx-swift backend, and encrypted response chunks; prompts stay encrypted on the wire and responses remain Secure-Enclave-signed. Only the **attestation/hardening routing gates** are relaxed.

## Prod-safety (this can never weaken production)

`resolveDevInsecure` (pure, unit-tested) refuses to start — fails **closed** — if the flag is ever set in a prod-like deployment:

- `EIGENINFERENCE_DATABASE_URL` is set (prod always sets it) → refuse
- `EIGENINFERENCE_MIN_TRUST=hardware` (contradiction) → refuse
- no explicit `EIGENINFERENCE_ALLOW_MEMORY_STORE=true` opt-in → refuse

So a stray `DEV_INSECURE=true` in prod stops the coordinator from booting rather than silently running open. With the flag unset, the routing/billing/catalog paths are byte-identical to before.

## Before / After

```mermaid
flowchart TB
  subgraph After["AFTER — flag OFF (prod, default) is identical to Before; flag ON shown below"]
    direction LR
    RA[request] --> GA{DevInsecure?}
    GA -- "off (prod)" --> PA[full attestation + hardening gates<br/>+ catalog + balance required]
    GA -- "on (dev)" --> EA[E2E gate ONLY:<br/>pubkey + mlx-swift + encrypted chunks]
    EA --> RTA[route to advertised model<br/>free billing, open catalog]
    PA --> RTP[route only if attested + in-catalog + funded]
  end
  subgraph Before["BEFORE"]
    direction LR
    RB[request] --> PB[attestation + hardening gates<br/>runtime-manifest, SIP, code-identity,<br/>privacy-caps, challenge-freshness]
    PB --> CB[model in catalog?] --> BB[balance reserved?] --> RTB[route]
  end
```

**Code paths changed (all gated on `DevInsecure`, E2E checks kept in front):**

```mermaid
flowchart LR
  subgraph Coordinator
    A[providerSupportsPrivateTextLocked] -->|E2E ok + DevInsecure| A2[return true<br/>skip manifest/SIP/code-attest/caps]
    B[providerLivenessGateLocked] -->|DevInsecure| B2[skip RuntimeVerified + challenge-freshness]
    C[handleChallengeResponse] -->|DevInsecure| C2[skip SIP/SecureBoot/RDMA/hash enforcement<br/>record passing challenge]
    D[IsModelInCatalog / modelAllowedByCatalogLocked] -->|DevInsecure| D2[allow any advertised model]
    E[main: resolveDevInsecure] --> E2[prod-guard + seed admin balance]
  end
  subgraph Provider["Swift provider (DARKBLOOM_DEV_INSECURE)"]
    F[runPreflightChecks] --> F2[debugger throw → warning]
    G[applySecurityHardening] --> G2[skip posture; SE self-sign + X25519 kept]
    H[migrateConfigIfNeeded] --> H2[skip dev→prod URL rewrite]
    I[StartCommand URL] --> I2[--url > DARKBLOOM_DEV_COORDINATOR_URL > config]
  end
```

## Dev serve-ability on an empty store

A fresh dev coordinator uses the in-memory store (no model registry, no ledger balance). Under `DevInsecure`:

- **Catalog**: any provider-advertised model is treated as routable (`IsModelInCatalog` / `modelAllowedByCatalogLocked`).
- **Billing**: the `admin` ledger account is seeded a large balance at startup, so the real reserve/settle/refund arithmetic runs unchanged and inference is effectively free.

## Testing

- `resolveDevInsecure` guard tests (all fail-closed cases) — `coordinator/cmd/coordinator/dev_insecure_guard_test.go`
- Routing-gate tests: un-attested provider routes only when the flag is on; E2E is still required; default-off is a regression guard — `coordinator/registry/dev_insecure_test.go`
- `go build ./...`, full `registry` + `cmd/coordinator` suites, and `api` provider/challenge/attest/consumer/billing suites: green.
- Validated end-to-end against a live dev coordinator + a real provider: streaming + non-streaming inference, multi-turn context, concurrent batching, auth rejection, graceful unknown-model handling — every response Secure-Enclave-signed.

## Notes

- The Swift provider changes are only needed for **un-signed local dev builds**; a genuinely hardened Mac passes its own preflight and connects to a dev-insecure coordinator with no provider-side flag.
- No deploy wiring sets `DEV_INSECURE` — it's opt-in per throwaway dev instance.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/575"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787550537&installation_model_id=21733&pr_number=575&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F575&signature=82e9658dfa46a96336e516dc2506e6c37f315d1d0423936361cb7d27a3ba35d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->