### PR TITLE
chore(release): prepare provider v0.7.15 (CBv2 prefill stack)

### DIFF
--- a/coordinator/api/server.go
+++ b/coordinator/api/server.go
@@ -145,7 +145,7 @@ func keyLimitResetFromContext(ctx context.Context) string {
 // 0.6.0 is the APNs code-identity / VLM-routing / graceful-update release.
 // Keep this fallback in sync with ProviderCore.version so dev/in-memory
 // coordinators advertise the same floor as the Swift binary they expect.
-var LatestProviderVersion = "0.7.14"
+var LatestProviderVersion = "0.7.15"
 
 // minProviderVersionForDesiredModels is the first provider version whose Swift
 // runtime understands the desired_models message. The coordinator must NOT send

--- a/provider-swift/Sources/ProviderCore/ProviderCore.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderCore.swift
@@ -154,5 +154,20 @@ public enum ProviderCore {
     // carry a typed terminal_cause and reconciled attempt_usage on the wire
     // (optional fields; old coordinators ignore them). Kill-switch:
     // DARKBLOOM_CBV2_LEGACY_REQUEST_TIMEOUT=1 restores the legacy wall.
-    public static let version = "0.7.14"
+    // 0.7.15 cuts CBv2 prompt work that was computed and discarded. Prompt
+    // chunks no longer build full [B, L, vocab] logits for positions the
+    // engine never reads; the final decoder layer keeps full attention and
+    // every K/V write but evaluates only the frontier row; and equal-length
+    // text chunks execute as ONE rectangular [B, L] forward instead of B
+    // separate ones, which is what fixes concurrent-burst TTFT. Decode is
+    // untouched: the compiled [B, 1] path and MTP verification never enter
+    // the prompt seam, and packing disengages for any model or cache
+    // provider that does not vouch for per-row independence. Measured on
+    // Gemma 4 26B-A4B QAT 4-bit (M4 Max): TTFT -15%/-20%/-19% at
+    // 128/512/2048 tokens and -25% for a 4x512 burst, decode within noise,
+    // exact output invariance held. Kill switches:
+    // DARKBLOOM_GEMMA4_PREFILL_TAIL_ROWS=0 and
+    // DARKBLOOM_GEMMA4_PREFILL_LAST_QUERY=0; the opt-in mixed-step prefill
+    // quota is DARKBLOOM_CBV2_MIXED_PREFILL_CAP.
+    public static let version = "0.7.15"
 }


### PR DESCRIPTION
## Summary

Prepares the `v0.7.15` provider release, carrying the CBv2 prefill stack merged in #573 / #576 / #577 and [Layr-Labs/mlx-swift-lm#84](https://github.com/Layr-Labs/mlx-swift-lm/pull/84).

`2 files changed, 17 insertions(+), 2 deletions(-)` — two version constants plus the version-history note.

| File | 0.7.14 → 0.7.15 |
|---|---|
| `provider-swift/Sources/ProviderCore/ProviderCore.swift` | `public static let version` |
| `coordinator/api/server.go` | `var LatestProviderVersion` |

Both must move together: `scripts/check-release-version.sh` requires the tag version, both source constants, the built CLI `--version`, and the app plist to agree. The workflow validates source and never rewrites it, so this has to land before the tag is pushed.

## What ships

- **Prompt-output narrowing** — prompt chunks no longer build full `[B, L, 262144]` logits for positions the engine never reads.
- **Final-layer narrowing** — the last decoder layer keeps full attention and every K/V write, but evaluates only the frontier row.
- **Rectangular packed prefill** — equal-length text chunks execute as one layer-major `[B, L]` forward instead of B separate ones. This is what fixes the concurrent-burst case.
- **Mixed-step prefill quota** — opt-in, default off.

Measured on Gemma 4 26B-A4B QAT 4-bit, M4 Max 128 GB:

| Prompt | TTFT before | after | Δ |
|---:|---:|---:|---:|
| 128 | 207.6 ms | 176.1 ms | −15.2% |
| 512 | 474.9 ms | 379.5 ms | −20.1% |
| 2,048 | 1,800.4 ms | 1,456.5 ms | −19.1% |

4 × 512 concurrent burst: **1,881.6 ms → 1,412.8 ms (−24.9%)**. Decode moved within noise; exact output invariance held on every run.

**Caveat carried forward from #577:** those deltas compare against a reference recorded on a *different binary*. The stronger evidence is a same-binary OFF/ON bracket using the shipped kill switches; that has not been run yet.

## Risk and rollback

Decode is structurally untouched — the compiled `[B, 1]` path and MTP verification never enter the prompt seam — and packing disengages automatically for any model or cache provider that does not vouch for per-row independence, so the paged backend is unaffected.

Runtime switches, no rebuild:
- `DARKBLOOM_GEMMA4_PREFILL_TAIL_ROWS=0`
- `DARKBLOOM_GEMMA4_PREFILL_LAST_QUERY=0`
- `DARKBLOOM_CBV2_MIXED_PREFILL_CAP=<n>` (quota, off unless set)

Note that prompt-output narrowing and packed prefill are **always on** — they have no env gate, so backing those out means reverting the submodule bump and redeploying.

## Verified locally

- `scripts/check-release-version.sh 0.7.15` → `release version integrity: 0.7.15`
- Same script correctly **rejects** a stale tag: `source=0.7.15 requested=0.7.14`
- Built CLI reports `0.7.15`; tag + source + binary agree
- `gofmt` clean; `go test ./api/` passes

## After merge

1. Tag `v0.7.15` on the merge commit and push — fires `release-swift.yml`, which requires reviewer approval on the prod environment.
2. CI builds/signs/notarizes, computes SHA-256 **after** signing, uploads to R2, and registers via `POST /v1/releases`.
3. **Verify `GET /v1/releases/latest` returns the new row.** It 404s when no row exists, and both `scripts/install.sh` and `darkbloom update` depend on it — a mis-registered release breaks installs and self-updates, and the fix is registering the release, not bumping code.
4. The `LatestProviderVersion` change only takes effect for the display/fallback path after a coordinator deploy (human-operated, per `docs/operations/coordinator-deploy.md`).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/578"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787554374&installation_model_id=21733&pr_number=578&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F578&signature=e93ef4b7de07b21d62bdef8b995ed297ecb2c18b1c717f0505fd93ff840b15ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->