### PR TITLE
Run the paged correctness suites in CI, not just the safety gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,14 +161,14 @@ jobs:
         run: swift test
       - name: Verify production prompt parity
         run: ./scripts/verify-prompt-parity.sh
-      - name: Build nested paged safety tests
+      - name: Build nested mlx-swift-lm tests
         working-directory: libs/mlx-swift-lm
         # Cold builds compile the full Cmlx C++/Metal tree (~20 min on the
         # 12-vcpu runner); warm runs restore libs/mlx-swift-lm/.build from
         # the SwiftPM cache and finish in ~1 min.
         timeout-minutes: 35
         run: swift build --build-tests
-      - name: Run nested paged and prompt-hash tests directly
+      - name: Run nested paged safety and prompt-hash tests directly
         working-directory: libs/mlx-swift-lm
         timeout-minutes: 10
         run: |
@@ -182,6 +182,37 @@ jobs:
           done
           swift test --skip-build --filter CBv2PagedSafetyTests
           swift test --skip-build --filter CBv2PrefixCacheHasherTests
+      # The four suites below are already compiled by the `swift build
+      # --build-tests` step above but were never executed, so the paged-KV
+      # migration had no automated numerical gate. They add no compile time,
+      # only run time; one step each so a slow or failing suite is
+      # attributable straight from the job summary. They reuse the metallib
+      # placed by the step above.
+      - name: Run nested paged eligibility tests
+        working-directory: libs/mlx-swift-lm
+        # Pure Swift threadgroup-budget arithmetic; no GPU dispatch.
+        timeout-minutes: 5
+        run: swift test --skip-build --filter CBv2PagedEligibilityTests
+      - name: Run nested paged backend tests
+        working-directory: libs/mlx-swift-lm
+        # Pool bookkeeping, per-sequence page tables, windowed rings,
+        # reservation admission, backend lifecycle. Small MLX arrays only.
+        timeout-minutes: 10
+        run: swift test --skip-build --filter CBv2PagedBackendTests
+      - name: Run nested paged kernel parity tests
+        working-directory: libs/mlx-swift-lm
+        # Heaviest of the four: fp32 decode-kernel parity, bitwise
+        # batch-composition invariance, and a 200-step greedy token match.
+        # Dispatches the JIT-compiled Metal kernels, exactly as
+        # CBv2PagedSafetyTests' runtimeSmoke already does in this job.
+        timeout-minutes: 20
+        run: swift test --skip-build --filter CBv2PagedKernelTests
+      - name: Run nested KV-sharing contiguous/paged parity tests
+        working-directory: libs/mlx-swift-lm
+        # Two-arm differential over TinyTestModel's KV-sharing variant; the
+        # paged arm self-skips (XCTSkip) if the backend is unavailable here.
+        timeout-minutes: 10
+        run: swift test --skip-build --filter CBv2KVSharingParityTests
       - name: Run atomic installer artifact tests
         timeout-minutes: 2
         run: ./scripts/test-install-atomic.sh
@@ -212,7 +243,8 @@ jobs:
           swift build -c release --product darkbloom-fan-helper
       - name: Build nested mlx-swift-lm tests (warms nested cache)
         working-directory: libs/mlx-swift-lm
-        # The test-provider job runs CBv2PagedSafetyTests from this nested
+        # The test-provider job runs the CBv2 paged suites (safety, kernel
+        # parity, backend, eligibility, KV-sharing parity) from this nested
         # .build; saving it here keeps that lane warm across PRs.
         timeout-minutes: 35
         run: swift build --build-tests


### PR DESCRIPTION
CI executed exactly one engine paged suite — `CBv2PagedSafetyTests` — whose own header scopes it to *"missing/corrupt SwiftPM resources, Metal maxBufferLength violations, and hostile size arithmetic"*. **Zero numerical assertions.**

Meanwhile `CBv2PagedKernelTests` (fp32 decode-kernel parity, bitwise batch-composition invariance, 200-step greedy token match), `CBv2PagedBackendTests`, `CBv2PagedEligibilityTests` and `CBv2KVSharingParityTests` (a two-arm contiguous/paged differential) were compiled by the existing `swift build --build-tests` and then **never executed**.

The paged-KV migration has four concurrent tracks mutating `PagedKVPool` and `PagedLayerCache`, and there is no canary fleet — pre-release verification is the only safety net.

Four separately-named, individually-timed steps, ordered cheapest-first for fail-fast: eligibility 5m, backend 10m, kernel 20m, KV-sharing parity 10m. The 35-minute build timeout is unchanged — these are already compiled by the existing build step, so this adds **run time only, no compile time**.

Also corrects two now-false strings: the build step was named *"Build nested paged safety tests"* though it builds the whole bundle, and `cache-swift`'s comment claimed `test-provider` runs only `CBv2PagedSafetyTests`.

**Risk to watch on the first run:** the kernel and backend suites dispatch JIT-compiled Metal with no skip guard. Assessed low — the already-green `CBv2PagedSafetyTests` calls `PagedAttentionKernel.runtimeSmoke()` in this same job. `CBv2KVSharingParityTests` throws `XCTSkip` when paged is unavailable.

```mermaid
flowchart LR
  subgraph Before
    B1["swift build --build-tests<br/>compiles ALL suites"] --> R1["run: PagedSafety<br/>+ PrefixCacheHasher"]
    B1 -.->|"compiled, never run"| X1["PagedKernel<br/>PagedBackend<br/>PagedEligibility<br/>KVSharingParity"]
    X1 --> Y1["kernel regression<br/>lands CI-green"]
  end
  subgraph After
    B2["swift build --build-tests"] --> R2["run: PagedSafety<br/>+ PrefixCacheHasher"]
    B2 --> N2["run: Eligibility 5m<br/>Backend 10m<br/>Kernel 20m<br/>KVSharingParity 10m"]
    N2 --> Z2["numerical gate<br/>attributable per suite"]
  end
```

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/581"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787599936&installation_model_id=21733&pr_number=581&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F581&signature=490dd7cdd9599b822b480ee2824b4065ee17ea6443abc2a7a8ae8c78f7f84b71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->