### PR TITLE
fix(memory,registry): make the activation reserve shape-aware and trust real decode measurements

### DIFF
--- a/coordinator/registry/concurrency_cap.go
+++ b/coordinator/registry/concurrency_cap.go
@@ -28,6 +28,24 @@ import (
 // single-stream decode rate (resolvedDecodeTPS), NEVER the observed-under-load
 // EWMA: the observed rate collapses under the very overload this cap exists to
 // prevent, which would force the cap to 1 — a feedback loop.
+//
+// Raising a backend's own concurrency ceiling therefore buys NOTHING on its
+// own. The provider-reported number is only the `base` operand of the MIN
+// below; the resolved per-model SOLO RATE decides. Inverting the cap math, a
+// provider is granted its full reported N only above
+//
+//	q    = floor((N-1)/overcommit) + 1     # smallest quality batch whose
+//	                                       # ceil(q·overcommit) still reaches N
+//	solo >= floor · (1 + k·q)              # N=8, floor 15, overcommit 1.2:
+//	                                       #   39.3 tok/s at k=0.27
+//	                                       #   50.1 tok/s at k=0.39
+//
+// and a model whose resolved rate sits under that gets the quality batch, not
+// the bump. The rate is what needs fixing when a bump does not land — usually
+// by seeding it (modelSoloTPSSeedEnv), because solo sampling is gated on a
+// fully uncontended box (soloSampleEligible) and a model that is BUSY at the
+// new concurrency never produces another sample. See
+// TestQualityCapReachesProviderReportedConcurrency for the pinned relationship.
 
 // defaultQualityCapOvercommit is the effective overcommit when the operator has
 // not set EIGENINFERENCE_QUALITY_CONCURRENCY_OVERCOMMIT. The legacy 2.0 diluted

--- a/coordinator/registry/concurrency_cap.go
+++ b/coordinator/registry/concurrency_cap.go
@@ -226,10 +226,33 @@ type soloModelTPS struct {
 //     a modelSoloTPSSeedEnv seed exists, it is an upper bound on that transfer:
 //     observations from faster classes cannot widen an unsampled slower class's
 //     cap above its configured cold-start estimate;
-//  3. the modelSoloTPSSeedEnv seed when there is no trusted cross-class rate
-//     (the TPS registry is in-memory and restart-wiped);
-//  4. the provider-level resolvedDecodeTPS(p) — exactly the pre-per-model
+//  3. the same-class solo median with FEWER than qualityCapSoloMinSamples
+//     samples (but at least one), then the same-chip-agnostic cross-class
+//     median under the same relaxation, seed-clamped as in (2). These are
+//     under-sampled but they are still MEASURED and still solo-gated, and the
+//     alternative below them is a model-AGNOSTIC hardware proxy: preferring
+//     sqrt(memory_bandwidth) over the provider's own measurement of this exact
+//     model is strictly worse information. See the note on convergence below;
+//  4. the modelSoloTPSSeedEnv seed when there is no measured rate at all
+//     (the TPS registry is in-memory and restart-wiped, and a provider that
+//     has completed no request reports no rate — see below);
+//  5. the provider-level resolvedDecodeTPS(p) — exactly the pre-per-model
 //     behavior, including its sqrt-bandwidth fallback semantics.
+//
+// What a provider reports BEFORE its first completion: nothing. The bridge's
+// EWMA (EngineV2Bridge.observedDecodeTpsEwma) is 0 until updateDecodeTpsEwma
+// runs on a terminal event, `observed_decode_tps` is `omitempty`, and the
+// heartbeat ingest only calls RecordSolo when the reported value is > 0
+// (registry.go). So a fresh provider contributes NO solo sample, reaches (4)
+// or (5), and is never capped at 1 by its own silence. Steps (3) can only
+// engage once a real decode has been measured.
+//
+// Under-sampled samples converge from BELOW, which is the safe direction. The
+// bridge EWMA (alpha = 0.3) blends prior batched decodes, so the first sample
+// taken as the box drops to a single running request UNDER-states the true
+// solo rate; it can never materially over-state it (solo is the fastest case,
+// and the ingest path already clamps to maxDecodeTPS). An under-stated rate
+// yields a TIGHTER cap, never a permissive one.
 //
 // The rate is deliberately STATIC (never an under-load EWMA): an observed rate
 // collapses under the very overload the cap exists to prevent, which would
@@ -241,15 +264,30 @@ type soloModelTPS struct {
 // r.mu and p.mu.
 func (r *Registry) resolvedSoloModelTPSLocked(p *Provider, model string) soloModelTPS {
 	if qualityCapPerModelTPS {
-		if tps, n := r.tpsRegistry.SoloMedian(model, chipClassKey(p.Hardware)); n >= qualityCapSoloMinSamples && tps > 0 {
-			return soloModelTPS{tps: tps, perModel: true}
+		classTPS, classN := r.tpsRegistry.SoloMedian(model, chipClassKey(p.Hardware))
+		if classN >= qualityCapSoloMinSamples && classTPS > 0 {
+			return soloModelTPS{tps: classTPS, perModel: true}
 		}
 		seed, hasSeed := modelSoloTPSSeed[strings.ToLower(model)]
-		if tps, n := r.tpsRegistry.SoloMedianAllChips(model); n >= qualityCapSoloMinSamples && tps > 0 {
-			if hasSeed && seed < tps {
-				tps = seed
-			}
-			return soloModelTPS{tps: tps, perModel: true}
+		// Seed-clamp the cross-class transfer: observations from faster classes
+		// cannot widen an unsampled slower class's cap above its configured
+		// cold-start estimate. Applies at both sample floors.
+		allTPS, allN := r.tpsRegistry.SoloMedianAllChips(model)
+		if allTPS > 0 && hasSeed && seed < allTPS {
+			allTPS = seed
+		}
+		if allN >= qualityCapSoloMinSamples && allTPS > 0 {
+			return soloModelTPS{tps: allTPS, perModel: true}
+		}
+		// Measured but under-sampled. Ranked below both trusted medians and
+		// above the seed: a real solo-gated measurement of THIS model beats a
+		// fleet-wide configured guess, and both beat the model-agnostic
+		// sqrt-bandwidth proxy that pins a fast model to cap 1-2.
+		if classN > 0 && classTPS > 0 {
+			return soloModelTPS{tps: classTPS, perModel: true}
+		}
+		if allN > 0 && allTPS > 0 {
+			return soloModelTPS{tps: allTPS, perModel: true}
 		}
 		if hasSeed {
 			return soloModelTPS{tps: seed, perModel: true}

--- a/coordinator/registry/concurrency_cap_test.go
+++ b/coordinator/registry/concurrency_cap_test.go
@@ -2,6 +2,7 @@ package registry
 
 import (
 	"fmt"
+	"math"
 	"testing"
 	"time"
 
@@ -43,6 +44,100 @@ func enableQualityCap(t *testing.T, reg *Registry, overcommitEnv string) {
 	reg.SetQualityConcurrencyCap(true, env.EnvFloat(key, 2.0), 15, 4)
 }
 
+// --- k-derived expectations --------------------------------------------------
+//
+// effectiveTPSLoadFactor is MEASURED, not chosen: the shipped 0.27 was fitted on
+// a legacy engine (Qwen2.5-7B-4bit), and the CBv2 decode curves for the models
+// this coordinator actually serves re-fit it to ~0.39 (median implied k over
+// B = 2/4/8; libs/mlx-swift-lm/benchmarks/reports/gemma4-26b-qat4bit-paged-gate-2026-07-09.md).
+// Every cap integer below is a function of that coefficient, so hard-coding the
+// integers means one re-measurement invalidates a dozen tests that are not about
+// arithmetic at all — and teaches the next reader nothing about WHY the number
+// is what it is. The tests therefore pin the RELATIONSHIP
+// cap = f(solo, floor, k, base, overcommit); the closed form itself is pinned
+// once, against an independent derivation, by
+// TestQualityConcurrencyMatchesDefiningInequality.
+
+// strictQualityBatch answers qualityConcurrency's question from its DEFINING
+// inequality — the largest batch B in [1, limit] whose projected per-request
+// rate solo/(1+k·B) still clears floor — by search instead of algebra. It is
+// deliberately not the closed form, so it can catch an off-by-one or a dropped
+// clamp in floor((solo/floor - 1)/k). Like the closed form it never returns 0:
+// a provider is never fully closed, even for a model that misses the floor at
+// B=1.
+func strictQualityBatch(solo, floor, k float64, limit int) int {
+	if limit < 1 {
+		limit = 1
+	}
+	if floor <= 0 || solo <= 0 || k <= 0 {
+		return limit
+	}
+	best := 1
+	for b := 1; b <= limit; b++ {
+		if solo/(1+k*float64(b)) >= floor {
+			best = b
+		}
+	}
+	return best
+}
+
+// wantQualityCap is the cap effectiveMaxConcurrencyForModelRateLocked must
+// produce for a provider whose per-slot/flat limit is base: the strict quality
+// batch grown by the overcommit allowance, never below 1, never above base.
+func wantQualityCap(solo, floor float64, base int, overcommit float64) int {
+	capped := int(math.Ceil(float64(strictQualityBatch(solo, floor, effectiveTPSLoadFactor, base)) * overcommit))
+	if capped < 1 {
+		capped = 1
+	}
+	if capped < base {
+		return capped
+	}
+	return base
+}
+
+// soloTPSForCap inverts wantQualityCap: the smallest solo decode rate at which a
+// provider reporting `base` concurrent slots is actually granted all of them.
+// The cap is monotone non-decreasing in the solo rate, so a bisection is exact
+// to the returned tolerance. This is the number an operator needs to size
+// EIGENINFERENCE_MODEL_SOLO_TPS_SEED, and the number that moves when k moves.
+func soloTPSForCap(floor float64, base int, overcommit float64) float64 {
+	lo, hi := 0.0, floor
+	for wantQualityCap(hi, floor, base, overcommit) < base {
+		lo, hi = hi, hi*2
+		if hi > 1e6 {
+			return math.Inf(1)
+		}
+	}
+	for i := 0; i < 200 && hi-lo > 1e-9; i++ {
+		mid := (lo + hi) / 2
+		if wantQualityCap(mid, floor, base, overcommit) < base {
+			lo = mid
+		} else {
+			hi = mid
+		}
+	}
+	return hi
+}
+
+// maxOvercommitDilution is the largest factor by which admitting at the
+// overcommitted cap can push per-request decode below the quality floor.
+//
+// The nominal allowance is the overcommit itself, but the realized one is
+// strictly worse: cap = ceil(qc × overcommit) rounds UP, which at qc = 1 turns
+// an overcommit of 1.2 into a factor of 2. With rate(B) = solo/(1+k·B), the
+// quality batch's defining solo >= floor·(1+k·qc), and ceil(x) < x+1:
+//
+//	rate(cap) > floor·(1+k·qc) / (1 + k·(overcommit·qc + 1))
+//
+// That ratio is monotone in qc — increasing when overcommit < 1+k, decreasing
+// otherwise — so its infimum is the worse of the qc = 1 endpoint and the
+// qc → infinity asymptote (1/overcommit). Pinning the NOMINAL floor/overcommit
+// instead would be pinning a bound the implementation does not provide: it
+// holds at k = 0.27 by luck of the rounding and fails at k = 0.39.
+func maxOvercommitDilution(k, overcommit float64) float64 {
+	return math.Max((1+k+k*overcommit)/(1+k), overcommit)
+}
+
 // TestQualityCapUsesStaticNotObservedTPS is the regression that matters: a slow
 // model's box is capped from its STATIC single-stream rate (~23 tok/s → quality
 // batch 1 → cap 2 = ceil(1 × 1.2) at the default overcommit), and the collapsed
@@ -61,9 +156,10 @@ func TestQualityCapUsesStaticNotObservedTPS(t *testing.T) {
 }
 
 // TestQualityCapScalesWithModelSpeed shows the cap is universal and self-tuning:
-// a fast model (57 tok/s → quality batch 10) keeps a high cap (12 at the default
-// 1.2 overcommit) that never bites normal load, while a slow model (23 tok/s) is
-// tightened to 2.
+// a fast model (57 tok/s) keeps a high cap — an order above normal load — that
+// never bites, while a slow model (23 tok/s, quality batch 1 at any measured k)
+// is tightened to 2. The fast side is k-derived: it is 12 at k = 0.27 and 9 at
+// the CBv2-re-fit 0.39, and neither number is the point.
 func TestQualityCapScalesWithModelSpeed(t *testing.T) {
 	reg := New(testLogger())
 	enableQualityCap(t, reg, "")
@@ -76,8 +172,12 @@ func TestQualityCapScalesWithModelSpeed(t *testing.T) {
 	if got := effCap(reg, slow, gemmaBuild); got != 2 {
 		t.Fatalf("slow cap = %d, want 2", got)
 	}
-	if got := effCap(reg, fast, qwenBuild); got != 12 {
-		t.Fatalf("fast cap = %d, want 12 (ceil(qc 10 × 1.2), ≤ flat 24) — far above normal load, no regression", got)
+	wantFast := wantQualityCap(57, 15, 24, defaultQualityCapOvercommit)
+	if got := effCap(reg, fast, qwenBuild); got != wantFast {
+		t.Fatalf("fast cap = %d, want %d (ceil(quality batch × 1.2) at k=%.2f, ≤ flat 24) — far above normal load, no regression", got, wantFast, effectiveTPSLoadFactor)
+	}
+	if wantFast <= 4 {
+		t.Fatalf("fast cap %d collapsed to slow-model territory at k=%.2f — a 57 tok/s model must keep real headroom", wantFast, effectiveTPSLoadFactor)
 	}
 }
 
@@ -232,50 +332,59 @@ func TestQualityCapDefaultOvercommitIgnoresStaleConfigFallback(t *testing.T) {
 	reg := New(testLogger())
 	reg.SetQualityConcurrencyCap(true, 2.0, 15, 4) // exactly main.go's call with the env unset
 
-	fast := makeSchedulerProvider(t, reg, "fast", qwenBuild, 57) // qc 10
+	fast := makeSchedulerProvider(t, reg, "fast", qwenBuild, 57)
 	budgetSlot(fast, 0)
-	if got := effCap(reg, fast, qwenBuild); got != 12 {
-		t.Fatalf("effective cap = %d, want 12 (default 1.2 must apply, not the stale 2.0 config fallback → 20)", got)
+	want := wantQualityCap(57, 15, 24, defaultQualityCapOvercommit)
+	stale := wantQualityCap(57, 15, 24, 2.0)
+	if want == stale {
+		t.Fatalf("test is blind at k=%.2f: overcommit 1.2 and the stale 2.0 both give cap %d — pick a solo rate that discriminates", effectiveTPSLoadFactor, want)
+	}
+	if got := effCap(reg, fast, qwenBuild); got != want {
+		t.Fatalf("effective cap = %d, want %d (default 1.2 must apply, not the stale 2.0 config fallback → %d)", got, want, stale)
 	}
 }
 
 // TestQualityCapOvercommitDilution is the cap math from the production incident:
-// with floor 15 and k = 0.27, overcommit 2.0 admits enough concurrency that the
-// projected per-request decode rate (solo/(1+k·B) at B = cap) collapses to
-// roughly HALF the floor on fast boxes, while 1.2 keeps it within the overcommit
-// allowance of the floor.
+// overcommit 2.0 admits enough concurrency that the projected per-request decode
+// rate (solo/(1+k·B) at B = cap) collapses to roughly HALF the floor on fast
+// boxes, while 1.2 holds it inside the realized allowance
+// (maxOvercommitDilution). Caps are k-derived; the dilution CONTRAST is the
+// invariant.
 func TestQualityCapOvercommitDilution(t *testing.T) {
-	cases := []struct {
+	const floor = 15.0
+	for _, tc := range []struct {
 		name          string
 		overcommitEnv string
+		overcommit    float64
 		solo          float64
-		wantCap       int
 	}{
-		{"gemma23_at_1.2", "1.2", 23, 2}, // qc 1 → ceil(1.2)
-		{"gemma23_at_2.0", "2.0", 23, 2}, // qc 1 → ceil(2.0)
-		{"solo30_at_1.2", "1.2", 30, 4},  // qc 3 → ceil(3.6)
-		{"solo30_at_2.0", "2.0", 30, 6},  // qc 3 → 6
-		{"solo57_at_1.2", "1.2", 57, 12}, // qc 10 → 12
-		{"solo57_at_2.0", "2.0", 57, 20}, // qc 10 → 20
-	}
-	for _, tc := range cases {
+		{"gemma23_at_1.2", "1.2", 1.2, 23},
+		{"gemma23_at_2.0", "2.0", 2.0, 23},
+		{"solo30_at_1.2", "1.2", 1.2, 30},
+		{"solo30_at_2.0", "2.0", 2.0, 30},
+		{"solo57_at_1.2", "1.2", 1.2, 57},
+		{"solo57_at_2.0", "2.0", 2.0, 57},
+	} {
 		t.Run(tc.name, func(t *testing.T) {
 			reg := New(testLogger())
 			enableQualityCap(t, reg, tc.overcommitEnv)
 			p := makeSchedulerProvider(t, reg, "box", gemmaBuild, tc.solo)
 			budgetSlot(p, 0)
 			got := effCap(reg, p, gemmaBuild)
-			if got != tc.wantCap {
-				t.Fatalf("solo %.0f tok/s at overcommit %s: cap = %d, want %d", tc.solo, tc.overcommitEnv, got, tc.wantCap)
+			want := wantQualityCap(tc.solo, floor, 24, tc.overcommit)
+			if got != want {
+				t.Fatalf("solo %.0f tok/s at overcommit %s: cap = %d, want %d (k=%.2f)", tc.solo, tc.overcommitEnv, got, want, effectiveTPSLoadFactor)
 			}
 			// The dilution difference in decode terms: projected per-request TPS
 			// once the box is filled to its cap.
 			projected := tc.solo / (1 + effectiveTPSLoadFactor*float64(got))
-			if tc.overcommitEnv == "2.0" && tc.solo == 57 && projected >= 15.0*0.6 {
-				t.Fatalf("overcommit 2.0 on a 57 tok/s box projects %.1f tok/s at cap %d — expected roughly half the 15 floor", projected, got)
+			if tc.overcommit == 2.0 && tc.solo == 57 && projected >= floor*0.6 {
+				t.Fatalf("overcommit 2.0 on a 57 tok/s box projects %.1f tok/s at cap %d — expected roughly half the %.0f floor", projected, got, floor)
 			}
-			if tc.overcommitEnv == "1.2" && projected < 15.0/1.2-1e-9 {
-				t.Fatalf("overcommit 1.2 on a %.0f tok/s box projects %.1f tok/s at cap %d — must stay ≥ floor/1.2 (%.2f)", tc.solo, projected, got, 15.0/1.2)
+			bound := floor / maxOvercommitDilution(effectiveTPSLoadFactor, tc.overcommit)
+			if tc.overcommit == 1.2 && projected < bound-1e-9 {
+				t.Fatalf("overcommit 1.2 on a %.0f tok/s box projects %.1f tok/s at cap %d — must stay ≥ %.2f (floor / realized allowance %.3f at k=%.2f)",
+					tc.solo, projected, got, bound, maxOvercommitDilution(effectiveTPSLoadFactor, 1.2), effectiveTPSLoadFactor)
 			}
 		})
 	}
@@ -291,16 +400,18 @@ func TestQualityCapPerModelOverride(t *testing.T) {
 	reg := New(testLogger())
 	enableQualityCap(t, reg, "2.0")
 
-	gemma := makeSchedulerProvider(t, reg, "gemma-box", gemmaBuild, 30) // qc 3
+	gemma := makeSchedulerProvider(t, reg, "gemma-box", gemmaBuild, 30)
 	budgetSlot(gemma, 0)
-	qwen := makeSchedulerProvider(t, reg, "qwen-box", qwenBuild, 30) // qc 3
+	qwen := makeSchedulerProvider(t, reg, "qwen-box", qwenBuild, 30)
 	budgetSlot(qwen, 0)
 
-	if got := effCap(reg, gemma, gemmaBuild); got != 3 {
-		t.Fatalf("override model cap = %d, want 3 (per-model overcommit 1.0 × qc 3, uppercase key must match)", got)
+	wantOverridden := wantQualityCap(30, 15, 24, 1.0)
+	wantGlobal := wantQualityCap(30, 15, 24, 2.0)
+	if got := effCap(reg, gemma, gemmaBuild); got != wantOverridden {
+		t.Fatalf("override model cap = %d, want %d (per-model overcommit 1.0 × quality batch, uppercase key must match)", got, wantOverridden)
 	}
-	if got := effCap(reg, qwen, qwenBuild); got != 6 {
-		t.Fatalf("non-override model cap = %d, want 6 (malformed entry skipped → global overcommit 2.0 × qc 3)", got)
+	if got := effCap(reg, qwen, qwenBuild); got != wantGlobal {
+		t.Fatalf("non-override model cap = %d, want %d (malformed entry skipped → global overcommit 2.0)", got, wantGlobal)
 	}
 }
 
@@ -312,10 +423,11 @@ func TestQualityCapPerModelOverrideAbsentUsesGlobalDefault(t *testing.T) {
 	reg := New(testLogger())
 	enableQualityCap(t, reg, "")
 
-	p := makeSchedulerProvider(t, reg, "fast", qwenBuild, 57) // qc 10
+	p := makeSchedulerProvider(t, reg, "fast", qwenBuild, 57)
 	budgetSlot(p, 0)
-	if got := effCap(reg, p, qwenBuild); got != 12 {
-		t.Fatalf("cap = %d, want 12 (no per-model entry → default 1.2 × qc 10)", got)
+	want := wantQualityCap(57, 15, 24, defaultQualityCapOvercommit)
+	if got := effCap(reg, p, qwenBuild); got != want {
+		t.Fatalf("cap = %d, want %d (no per-model entry → default 1.2 × quality batch)", got, want)
 	}
 }
 
@@ -345,38 +457,46 @@ func TestQualityCapNeverBelowOneAndProviderCapClamps(t *testing.T) {
 }
 
 // TestQualityCapProjectedDecodeTPSAtDefaultHoldsNearFloor is the decode-floor
-// guarantee of the new default: at overcommit 1.2, a provider filled to its
-// admitted cap projects per-request decode (rate(B) = solo/(1+k·B), the same
-// degradation model the package routes with) no lower than floor/1.2 —
-// i.e. the 15 tok/s floor holds within the overcommit allowance across the
-// realistic solo-rate range, where the old 2.0 default let it collapse to
-// roughly half the floor.
+// guarantee of the 1.2 default: a provider filled to its admitted cap still
+// projects per-request decode (rate(B) = solo/(1+k·B), the same degradation
+// model the package routes with) inside the REALIZED overcommit allowance —
+// see maxOvercommitDilution for why that is strictly worse than the nominal
+// 1.2 and why pinning floor/1.2 here is pinning a guarantee the code does not
+// make. The old 2.0 default, by contrast, let decode collapse to half the
+// floor.
 func TestQualityCapProjectedDecodeTPSAtDefaultHoldsNearFloor(t *testing.T) {
 	const floor = 15.0
 	reg := New(testLogger())
 	enableQualityCap(t, reg, "")
 
+	bound := floor / maxOvercommitDilution(effectiveTPSLoadFactor, defaultQualityCapOvercommit)
 	for i, solo := range []float64{20, 23, 30, 45, 57, 80, 100} {
 		p := makeSchedulerProvider(t, reg, fmt.Sprintf("box-%d", i), gemmaBuild, solo)
 		budgetSlot(p, 0)
 		admitted := effCap(reg, p, gemmaBuild)
 		projected := solo / (1 + effectiveTPSLoadFactor*float64(admitted))
-		if projected < floor/defaultQualityCapOvercommit-1e-9 {
-			t.Errorf("solo %.0f tok/s: cap %d projects %.2f tok/s — below floor/overcommit (%.2f)",
-				solo, admitted, projected, floor/defaultQualityCapOvercommit)
+		if projected < bound-1e-9 {
+			t.Errorf("solo %.0f tok/s: cap %d projects %.2f tok/s — below the realized allowance bound %.2f (k=%.2f)",
+				solo, admitted, projected, bound, effectiveTPSLoadFactor)
 		}
 	}
+	// And that bound must stay meaningfully tighter than the collapse it
+	// replaced: overcommit 2.0 permits exactly half the floor.
+	if bound <= floor/2 {
+		t.Fatalf("realized 1.2 allowance bound %.2f is no better than the 2.0 collapse (%.2f) at k=%.2f — the default no longer buys anything",
+			bound, floor/2, effectiveTPSLoadFactor)
+	}
 
-	// Contrast with the old default: 2.0 admits 20 concurrent on a 57 tok/s box,
-	// projecting ~8.9 tok/s — the below-floor dilution the new default removes.
+	// Contrast with the old default on a fast box: 2.0 dilutes past the bound
+	// the new default holds.
 	diluted := New(testLogger())
 	enableQualityCap(t, diluted, "2.0")
 	p := makeSchedulerProvider(t, diluted, "diluted", gemmaBuild, 57)
 	budgetSlot(p, 0)
 	admitted := effCap(diluted, p, gemmaBuild)
 	projected := 57 / (1 + effectiveTPSLoadFactor*float64(admitted))
-	if projected >= floor/defaultQualityCapOvercommit {
-		t.Fatalf("overcommit 2.0 projects %.2f tok/s at cap %d — expected below the floor/1.2 bar the new default enforces", projected, admitted)
+	if projected >= bound {
+		t.Fatalf("overcommit 2.0 projects %.2f tok/s at cap %d — expected below the %.2f bar the 1.2 default enforces", projected, admitted, bound)
 	}
 }
 
@@ -384,12 +504,12 @@ func TestQualityCapProjectedDecodeTPSAtDefaultHoldsNearFloor(t *testing.T) {
 // postmortem layer-6 scenario: a mixed box whose registration benchmark was
 // taken on gpt-oss (93 tok/s) hosts a gemma slot that actually decodes ~14
 // tok/s solo. The old cap consumed the provider-LEVEL rate for every model, so
-// gemma got cap ceil(qc 19 × 1.2) = 23 — and the coordinator marched 8–11
+// gemma inherited the benchmark's wide cap — and the coordinator marched 8–11
 // concurrent gemma requests onto exactly the boxes that collapse past batch 3.
 // With the per-model solo source, gemma's cap must come from gemma's own solo
-// median (14 ≤ floor 15 → qc 1 → cap 2) while gpt-oss keeps its wide cap from
-// the benchmark. Reverting the resolver wiring makes the gemma assertion fail
-// (cap becomes 23 again).
+// median (14 ≤ floor 15 → quality batch 1 → cap 2, at any measured k) while
+// gpt-oss keeps its wide benchmark-derived cap. Reverting the resolver wiring
+// makes the gemma assertion fail (it inherits the gpt-oss cap again).
 func TestQualityCapPerModelTPSPostmortemRegression(t *testing.T) {
 	run := func(t *testing.T, seedGemma func(reg *Registry)) {
 		reg := New(testLogger())
@@ -397,11 +517,12 @@ func TestQualityCapPerModelTPSPostmortemRegression(t *testing.T) {
 		seedGemma(reg)
 		p := mixedBoxProvider(t, reg, "mixed-93", 93)
 
+		wantGptoss := wantQualityCap(93, 15, 24, defaultQualityCapOvercommit)
 		if got := effCapResolved(reg, p, gemmaBuild); got != 2 {
-			t.Fatalf("gemma cap on the mixed box = %d, want 2 (solo 14 ≤ floor 15 → qc 1 × overcommit 1.2; NOT the benchmark-derived 23)", got)
+			t.Fatalf("gemma cap on the mixed box = %d, want 2 (solo 14 ≤ floor 15 → quality batch 1 × overcommit 1.2; NOT the benchmark-derived %d)", got, wantGptoss)
 		}
-		if got := effCapResolved(reg, p, gptossBuild); got != 23 {
-			t.Fatalf("gpt-oss cap on the mixed box = %d, want 23 (its own 93 tok/s benchmark stays wide)", got)
+		if got := effCapResolved(reg, p, gptossBuild); got != wantGptoss {
+			t.Fatalf("gpt-oss cap on the mixed box = %d, want %d (its own 93 tok/s benchmark stays wide at k=%.2f)", got, wantGptoss, effectiveTPSLoadFactor)
 		}
 	}
 
@@ -446,19 +567,21 @@ func TestQualityCapSeedBoundsCrossClassTransfer(t *testing.T) {
 // TestQualityCapPerModelTPSKillSwitchRestoresOldBehavior pins the kill switch:
 // EIGENINFERENCE_QUALITY_CAP_PER_MODEL_TPS=false must restore the provider-
 // level resolvedDecodeTPS(p) at the cap exactly — reproducing the postmortem's
-// buggy wide gemma cap (23 from the gpt-oss benchmark) even though a trusted
-// gemma solo median exists. This doubles as the proof that the regression test
-// above fails without the fix: the old code path IS the switch-off path.
+// buggy WIDE gemma cap (inherited from the gpt-oss benchmark) even though a
+// trusted gemma solo median exists. This doubles as the proof that the
+// regression test above fails without the fix: the old code path IS the
+// switch-off path.
 func TestQualityCapPerModelTPSKillSwitchRestoresOldBehavior(t *testing.T) {
 	reg := New(testLogger())
 	enablePerModelQualityCap(t, reg, gemmaBuild+"=14", "false", "")
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		reg.tpsRegistry.RecordSolo(gemmaBuild, "M3", 14)
 	}
 	p := mixedBoxProvider(t, reg, "mixed-93", 93)
 
-	if got := effCapResolved(reg, p, gemmaBuild); got != 23 {
-		t.Fatalf("kill switch off: gemma cap = %d, want the old provider-level 23 (byte-for-byte legacy behavior)", got)
+	wantLegacy := wantQualityCap(93, 15, 24, defaultQualityCapOvercommit)
+	if got := effCapResolved(reg, p, gemmaBuild); got != wantLegacy {
+		t.Fatalf("kill switch off: gemma cap = %d, want the old provider-level %d (byte-for-byte legacy behavior)", got, wantLegacy)
 	}
 	// And it must match the explicit provider-level path exactly.
 	if resolved, legacy := effCapResolved(reg, p, gemmaBuild), effCap(reg, p, gemmaBuild); resolved != legacy {
@@ -496,6 +619,186 @@ func TestQualityCapPerModelRateCapsWithoutRegistrationBenchmark(t *testing.T) {
 	if got := effCapResolved(reg, p, gptossBuild); got != 24 {
 		t.Fatalf("no-benchmark box without per-model source: gpt-oss cap = %d, want flat 24", got)
 	}
+}
+
+// TestQualityConcurrencyMatchesDefiningInequality is the one place the closed
+// form is pinned: floor((solo/floor - 1)/k) must agree with a search over the
+// inequality it was solved from, across the whole realistic rate range and both
+// sides of every clamp. Boundary rates (where the real-valued batch lands on an
+// integer) are skipped — there the two derivations legitimately differ by one
+// float ulp, and pinning ulps is not a contract.
+func TestQualityConcurrencyMatchesDefiningInequality(t *testing.T) {
+	const floor = 15.0
+	for _, k := range []float64{0.27, effectiveTPSLoadFactor, 0.39, 0.5} {
+		for _, limit := range []int{1, 4, 8, 24, 32} {
+			for solo := 1.0; solo <= 200.0; solo += 0.25 {
+				if b := (solo/floor - 1) / k; math.Abs(b-math.Round(b)) < 1e-9 {
+					continue
+				}
+				want := strictQualityBatch(solo, floor, k, limit)
+				if got := qualityConcurrency(solo, floor, k, limit, 4); got != want {
+					t.Fatalf("qualityConcurrency(solo=%.2f, floor=%.0f, k=%.2f, limit=%d) = %d, want %d (largest B with solo/(1+k·B) ≥ floor)",
+						solo, floor, k, limit, got, want)
+				}
+			}
+		}
+	}
+	// The batch it returns must actually hold the floor whenever the model can
+	// (the clamp-to-1 case is the documented exception: a provider is never
+	// fully closed).
+	for _, solo := range []float64{16, 20, 23, 30, 57, 93, 99.5, 101.8} {
+		b := qualityConcurrency(solo, floor, effectiveTPSLoadFactor, 32, 4)
+		if rate := solo / (1 + effectiveTPSLoadFactor*float64(b)); b > 1 && rate < floor {
+			t.Fatalf("solo %.1f: quality batch %d projects %.2f tok/s, below the %.0f floor it is defined to hold", solo, b, rate, floor)
+		}
+	}
+}
+
+// TestQualityCapReachesProviderReportedConcurrency is the RELATIONSHIP the
+// v0.8.0 engine bump rides on, pinned instead of a literal: a provider that
+// reports N concurrent slots is granted all N exactly when its solo decode rate
+// clears a threshold derived from (floor, k, overcommit) — and the CBv2
+// measured gemma-4 solo rate clears the N=8 threshold with room to spare.
+//
+// Raising engine_v2_max_concurrent alone does NOT buy coordinator-visible
+// concurrency: the provider-reported number is only the `base` operand of a MIN
+// against the quality cap, so the solo rate the coordinator RESOLVES for the
+// model is what decides whether the bump is real. That is why prod needs a
+// gemma-4 entry in EIGENINFERENCE_MODEL_SOLO_TPS_SEED (see
+// TestQualityCapEightRequiresSoloRateNotOvercommit).
+func TestQualityCapReachesProviderReportedConcurrency(t *testing.T) {
+	const floor = 15.0
+	// measuredGemmaSoloTPS is the CBv2 v2-paged B=1 per-request decode rate for
+	// gemma-4-26b-qat-4bit on an M4 Max — the shipping engine's own number, and
+	// the conservative one (eager measures 101.8):
+	// libs/mlx-swift-lm/benchmarks/reports/gemma4-26b-qat4bit-paged-gate-2026-07-09.md
+	const measuredGemmaSoloTPS = 99.5
+
+	for _, base := range []int{4, 8} {
+		t.Run(fmt.Sprintf("base%d", base), func(t *testing.T) {
+			threshold := soloTPSForCap(floor, base, defaultQualityCapOvercommit)
+
+			mk := func(reg *Registry, id string, solo float64) *Provider {
+				p := makeSchedulerProvider(t, reg, id, gemmaBuild, solo)
+				p.mu.Lock()
+				p.BackendCapacity.Slots[0].ActiveTokenBudgetMax = 500_000
+				p.BackendCapacity.Slots[0].MaxConcurrency = base
+				p.mu.Unlock()
+				return p
+			}
+
+			reg := New(testLogger())
+			enableQualityCap(t, reg, "")
+
+			// At the threshold the provider's whole reported cap is granted.
+			if got := effCap(reg, mk(reg, "at", threshold), gemmaBuild); got != base {
+				t.Fatalf("solo %.2f tok/s (derived threshold at k=%.2f): cap = %d, want the full reported %d",
+					threshold, effectiveTPSLoadFactor, got, base)
+			}
+			// A quarter of a tok/s below it, it is not — the threshold is a real
+			// edge, not a rounding artifact of the assertion above.
+			if got := effCap(reg, mk(reg, "below", threshold-0.25), gemmaBuild); got >= base {
+				t.Fatalf("solo %.2f tok/s (just under the threshold): cap = %d, want < %d", threshold-0.25, got, base)
+			}
+			// And the engine's measured rate is on the granting side of it: the
+			// provider bump is reachable on real hardware without relaxing the
+			// quality bar.
+			if measuredGemmaSoloTPS < threshold {
+				t.Fatalf("measured gemma-4 solo %.1f tok/s is BELOW the %.2f tok/s needed for cap %d at floor %.0f / k %.2f / overcommit %.1f — the engine bump cannot land",
+					measuredGemmaSoloTPS, threshold, base, floor, effectiveTPSLoadFactor, defaultQualityCapOvercommit)
+			}
+			if got := effCap(reg, mk(reg, "measured", measuredGemmaSoloTPS), gemmaBuild); got != base {
+				t.Fatalf("measured gemma-4 solo %.1f tok/s: cap = %d, want the full reported %d", measuredGemmaSoloTPS, got, base)
+			}
+		})
+	}
+}
+
+// TestQualityCapEightRequiresSoloRateNotOvercommit is the config question the
+// v0.8.0 rollout actually has to answer, pinned as behavior.
+//
+// In production the Swift provider never sends decode_tps, so without a solo
+// source the cap is computed from resolvedDecodeTPS's sqrt(memory_bandwidth)
+// proxy — 16-28 tok/s across Apple silicon, a MODEL-AGNOSTIC number that has
+// nothing to do with gemma-4 and lands at or under the floor. Whether that
+// arrives as the proxy or as a low seed, the answer is the same: a provider
+// reporting 8 is capped at 2, at any measured k.
+//
+// EIGENINFERENCE_QUALITY_CONCURRENCY_OVERCOMMIT_BY_MODEL can force it to 8 —
+// the plumbing works, config-only — but only above a multiplier of 7, which is
+// not an overcommit allowance, it is switching the cap off: at that setting the
+// projected per-request decode collapses below even the half-floor the 2.0
+// default was reverted for. Seeding the model's real solo rate reaches 8 on
+// quality merit at the default 1.2 and keeps the bar intact.
+func TestQualityCapEightRequiresSoloRateNotOvercommit(t *testing.T) {
+	const floor = 15.0
+	// starvedSoloTPS stands in for what prod resolves today: the sqrt(546) ≈ 23
+	// M4 Max bandwidth proxy, or an equally low seed. Both cap at 2.
+	const starvedSoloTPS = 14.0
+	// prodSeedTPS is the value EIGENINFERENCE_MODEL_SOLO_TPS_SEED should carry.
+	// It is deliberately well under the engine's measured 99.5 tok/s solo rate
+	// so slower fleet tiers are not over-credited, while still clearing the
+	// reachability threshold at BOTH the shipped k (39.3 tok/s) and the CBv2
+	// re-fit (50.1 tok/s) — so the config survives the coefficient move.
+	const prodSeedTPS = 70.0
+	mk := func(t *testing.T, reg *Registry) *Provider {
+		p := mixedBoxProvider(t, reg, "v0.8.0-box", 93)
+		p.mu.Lock()
+		for i := range p.BackendCapacity.Slots {
+			if p.BackendCapacity.Slots[i].Model == gemmaBuild {
+				p.BackendCapacity.Slots[i].MaxConcurrency = 8
+			}
+		}
+		p.mu.Unlock()
+		return p
+	}
+
+	t.Run("reported_eight_alone_is_not_enough", func(t *testing.T) {
+		reg := New(testLogger())
+		enablePerModelQualityCap(t, reg, gemmaBuild+"="+fmt.Sprint(starvedSoloTPS), "", "")
+		if got := effCapResolved(reg, mk(t, reg), gemmaBuild); got != 2 {
+			t.Fatalf("cap = %d, want 2: a provider-reported 8 is only the MIN's base operand; the %.0f tok/s solo rate decides", got, starvedSoloTPS)
+		}
+	})
+
+	t.Run("per_model_overcommit_reaches_eight_but_voids_the_bar", func(t *testing.T) {
+		reg := New(testLogger())
+		t.Setenv(qualityCapOvercommitByModelEnv, gemmaBuild+"=7.5")
+		enablePerModelQualityCap(t, reg, gemmaBuild+"="+fmt.Sprint(starvedSoloTPS), "", "")
+		got := effCapResolved(reg, mk(t, reg), gemmaBuild)
+		if got != 8 {
+			t.Fatalf("per-model overcommit 7.5: cap = %d, want 8 (the override plumbing must be config-only)", got)
+		}
+		// Anything at or under 7 leaves the quality batch of 1 short of 8, so
+		// this route has no setting that both reaches 8 and stays an allowance.
+		reg7 := New(testLogger())
+		t.Setenv(qualityCapOvercommitByModelEnv, gemmaBuild+"=7.0")
+		enablePerModelQualityCap(t, reg7, gemmaBuild+"="+fmt.Sprint(starvedSoloTPS), "", "")
+		if got := effCapResolved(reg7, mk(t, reg7), gemmaBuild); got != 7 {
+			t.Fatalf("per-model overcommit 7.0: cap = %d, want 7 — the route to 8 needs a multiplier ABOVE 7", got)
+		}
+		projected := starvedSoloTPS / (1 + effectiveTPSLoadFactor*8)
+		if projected >= floor/2 {
+			t.Fatalf("overcommit-to-8 projects %.2f tok/s — expected below half the %.0f floor, i.e. worse than the 2.0 default that was reverted", projected, floor)
+		}
+	})
+
+	t.Run("seeded_solo_rate_reaches_eight_on_quality_merit", func(t *testing.T) {
+		reg := New(testLogger())
+		enablePerModelQualityCap(t, reg, gemmaBuild+"="+fmt.Sprint(prodSeedTPS), "", "")
+		if got := effCapResolved(reg, mk(t, reg), gemmaBuild); got != 8 {
+			t.Fatalf("seeded at %.0f tok/s: cap = %d, want 8 at the default overcommit (k=%.2f)", prodSeedTPS, got, effectiveTPSLoadFactor)
+		}
+		// And it must be granted on QUALITY, not bought with the overcommit
+		// allowance: the strict quality batch alone has to reach 8, so the
+		// projected per-request rate at B=8 stays at or above the floor.
+		if qc := strictQualityBatch(prodSeedTPS, floor, effectiveTPSLoadFactor, 8); qc != 8 {
+			t.Fatalf("seed %.0f gives a strict quality batch of %d at k=%.2f — 8 would be reached only via the overcommit rounding; raise the seed", prodSeedTPS, qc, effectiveTPSLoadFactor)
+		}
+		if projected := prodSeedTPS / (1 + effectiveTPSLoadFactor*8); projected < floor {
+			t.Fatalf("seeded route projects %.2f tok/s at B=8 — below the %.0f floor, so the seed would be buying concurrency the quality bar should refuse", projected, floor)
+		}
+	})
 }
 
 // TestWarmTargetDedicatedWholePool: for a dedicated model UNDER DEMAND the

--- a/coordinator/registry/concurrency_cap_test.go
+++ b/coordinator/registry/concurrency_cap_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/eigeninference/d-inference/coordinator/env"
+	"github.com/eigeninference/d-inference/coordinator/protocol"
 )
 
 // budgetSlot turns a makeSchedulerProvider box into a token-budget provider (the
@@ -859,4 +860,243 @@ func TestWarmTargetDedicatedWholePool(t *testing.T) {
 	if got := c.targetWarm(nonDedicated, warmPoolPressureBucket{}, warmPoolQueuePressure{}, params, svc2, now); got != 2 {
 		t.Fatalf("non-dedicated warm target = %d, want 2 (no demand pressure → left as-is)", got)
 	}
+}
+
+// TestQualityCapPrefersMeasuredSoloRateOverProxyAndSeed pins the DURABLE fix
+// for the B=8 shortfall, and the reason the shortfall existed.
+//
+// Production shape, reproduced exactly here: gemma-4 is a DEDICATED model
+// (EIGENINFERENCE_DEDICATED_MODELS=gemma-4), and the Swift provider never
+// sends decode_tps at registration — the field exists on RegisterMessage and
+// is encoded, but nothing in provider-swift/Sources ever assigns it. So
+// p.DecodeTPS == 0, the dedicated guard in
+// effectiveMaxConcurrencyForModelRateLocked does NOT hold the model to its
+// reported base, and the rate reaching qualityConcurrency is
+// resolvedDecodeTPS's sqrt(memory_bandwidth) — a MODEL-AGNOSTIC hardware proxy
+// (20 tok/s at the 400 GB/s test fixture, ~23 on a real 546 GB/s M4 Max)
+// against a measured ~99.5 tok/s. Raising engine_v2_max_concurrent to 8 buys
+// nothing against that.
+//
+// The provider is NOT silent about its real rate: it reports the measured
+// per-model EWMA in observed_decode_tps on every heartbeat
+// (EngineV2Bridge+Capacity.swift populates it from
+// EngineV2Bridge.observedDecodeTpsEwma), and the heartbeat ingest already
+// converts the uncontended ones into solo samples. The only thing standing
+// between that measurement and the cap was the qualityCapSoloMinSamples floor:
+// under 5 samples the chain skipped straight past a real, solo-gated,
+// per-model measurement to the hardware proxy. It now prefers the measurement.
+func TestQualityCapPrefersMeasuredSoloRateOverProxyAndSeed(t *testing.T) {
+	const floor = 15.0
+	const base = 8
+	// The CBv2 v2-paged B=1 per-request decode rate for gemma-4-26b-qat-4bit on
+	// an M4 Max — the shipping engine's own, conservative number (eager measures
+	// 101.8):
+	// libs/mlx-swift-lm/benchmarks/reports/gemma4-26b-qat4bit-paged-gate-2026-07-09.md
+	const measuredGemmaSoloTPS = 99.5
+	// The starved seed the pre-fix chain was stuck with, standing in for the
+	// sqrt-bandwidth proxy: both land at or under the floor.
+	const starvedSeedTPS = 14.0
+
+	// threshold is the solo rate at which a provider reporting `base` is granted
+	// all of it, derived from (floor, k, overcommit) rather than hard-coded.
+	threshold := soloTPSForCap(floor, base, defaultQualityCapOvercommit)
+
+	// prodBox is the production shape: dedicated model, NO registration
+	// benchmark, provider-reported concurrency of 8.
+	prodBox := func(t *testing.T, reg *Registry) *Provider {
+		reg.SetDedicatedModels([]string{"gemma-4"})
+		return makeSchedulerProvider(t, reg, "prod-box", gemmaBuild, 0)
+	}
+	// slot is the heartbeat slot the provider sends. observedTPS <= 0 models a
+	// provider that has completed no request: observedDecodeTpsEwma is still 0,
+	// `observed_decode_tps` is omitempty, so the field is absent on the wire.
+	slot := func(observedTPS float64, numRunning int) protocol.BackendSlotCapacity {
+		return protocol.BackendSlotCapacity{
+			Model:                gemmaBuild,
+			State:                "running",
+			NumRunning:           numRunning,
+			MaxConcurrency:       base,
+			ActiveTokenBudgetMax: 500_000,
+			ObservedDecodeTPS:    observedTPS,
+		}
+	}
+	// observe drives the REAL heartbeat ingest path n times — the same
+	// soloSampleEligible + NumRunning > 0 gate production uses, not a direct
+	// tpsRegistry poke.
+	observe := func(reg *Registry, n int, tps float64) {
+		for range n {
+			reg.Heartbeat("prod-box", soloHeartbeat([]protocol.BackendSlotCapacity{slot(tps, 1)}))
+		}
+	}
+
+	// --- The arithmetic the fix has to clear ---------------------------------
+	//
+	// effectiveTPSLoadFactor was re-fitted 0.27 -> 0.39, which RAISES the solo
+	// rate needed for cap 8 from ~39.3 to ~50.1 tok/s. Assert the derived
+	// threshold really is that, then assert the measured rate clears it with
+	// close to 2x margin — the fix must not be resting on a rounding edge.
+	t.Run("measured_rate_clears_the_refitted_threshold_with_margin", func(t *testing.T) {
+		if effectiveTPSLoadFactor != 0.39 {
+			t.Fatalf("k = %.2f, expected the re-fitted 0.39 — the margins below are stated against it", effectiveTPSLoadFactor)
+		}
+		if math.Abs(threshold-50.1) > 0.5 {
+			t.Fatalf("derived cap-8 threshold = %.2f tok/s, expected ~50.1 at floor %.0f / k %.2f / overcommit %.1f",
+				threshold, floor, effectiveTPSLoadFactor, defaultQualityCapOvercommit)
+		}
+		if margin := measuredGemmaSoloTPS / threshold; margin < 1.9 {
+			t.Fatalf("measured %.1f tok/s is only %.2fx the %.2f tok/s cap-8 threshold — want >= 1.9x real margin",
+				measuredGemmaSoloTPS, margin, threshold)
+		}
+		// Granted on QUALITY, not bought with the overcommit allowance: the
+		// strict quality batch alone reaches base, and the projected
+		// per-request rate at B=8 stays at or above the floor.
+		if qc := strictQualityBatch(measuredGemmaSoloTPS, floor, effectiveTPSLoadFactor, base); qc != base {
+			t.Fatalf("strict quality batch at the measured rate = %d, want %d — cap 8 must not depend on overcommit rounding", qc, base)
+		}
+		if projected := measuredGemmaSoloTPS / (1 + effectiveTPSLoadFactor*base); projected < floor {
+			t.Fatalf("projected per-request decode at B=8 is %.2f tok/s, below the %.0f floor", projected, floor)
+		}
+	})
+
+	// --- Cold start: a provider that has served nothing ----------------------
+	//
+	// This is the case the fallback chain must not break. The provider reports
+	// NO observed_decode_tps (the field is absent, not zero-on-the-wire), so no
+	// solo sample is ingested, nothing per-model resolves, and the chain lands
+	// on the hardware proxy. That must stay a SANE positive cap — the box has
+	// to be able to serve in order to ever measure itself.
+	t.Run("cold_start_reports_nothing_and_still_gets_a_sane_cap", func(t *testing.T) {
+		reg := New(testLogger())
+		p := prodBox(t, reg)
+		enablePerModelQualityCap(t, reg, "", "", "")
+		reg.Heartbeat("prod-box", soloHeartbeat([]protocol.BackendSlotCapacity{slot(0, 0)}))
+
+		if _, n := reg.tpsRegistry.SoloMedian(gemmaBuild, chipClassKey(p.Hardware)); n != 0 {
+			t.Fatalf("solo samples from a provider that reported no rate = %d, want 0", n)
+		}
+		rate := resolveSolo(reg, p, gemmaBuild)
+		if rate.perModel {
+			t.Fatalf("cold start resolved a per-model rate (%.2f) with no measurement and no seed", rate.tps)
+		}
+		if rate.tps != resolvedDecodeTPS(p) {
+			t.Fatalf("cold-start rate = %.2f, want the provider-level proxy %.2f", rate.tps, resolvedDecodeTPS(p))
+		}
+		got := effCapResolved(reg, p, gemmaBuild)
+		// Pinned as the closed form of the proxy rate, not as a literal: the
+		// integer moves with k, the contract ("the proxy's own answer, and it
+		// is a servable one") does not.
+		if want := wantQualityCap(resolvedDecodeTPS(p), floor, base, defaultQualityCapOvercommit); got != want {
+			t.Fatalf("cold-start cap = %d, want %d — the proxy's own derived answer", got, want)
+		}
+		if got < 2 {
+			t.Fatalf("cold-start cap = %d, want >= 2 — a fresh provider must not be strangled to 1 by its own silence; it has to be able to serve in order to ever measure itself", got)
+		}
+		if got >= base {
+			t.Fatalf("cold-start cap = %d, want < %d: with no measurement the proxy must NOT grant the full bump", got, base)
+		}
+	})
+
+	// --- The fix: one measured, solo-gated sample is enough ------------------
+	t.Run("one_measured_sample_under_the_floor_reaches_eight", func(t *testing.T) {
+		reg := New(testLogger())
+		p := prodBox(t, reg)
+		enablePerModelQualityCap(t, reg, "", "", "")
+
+		// Pre-fix baseline, same registry: the proxy caps this box at 2.
+		if got := effCapResolved(reg, p, gemmaBuild); got >= base {
+			t.Fatalf("before any measurement the cap is %d — the proxy baseline this test contrasts against is gone", got)
+		}
+
+		observe(reg, 1, measuredGemmaSoloTPS)
+
+		_, n := reg.tpsRegistry.SoloMedian(gemmaBuild, chipClassKey(p.Hardware))
+		if n != 1 {
+			t.Fatalf("solo samples = %d, want exactly 1", n)
+		}
+		if n >= qualityCapSoloMinSamples {
+			t.Fatalf("test is not exercising the under-sampled path: %d samples meets the %d floor", n, qualityCapSoloMinSamples)
+		}
+		rate := resolveSolo(reg, p, gemmaBuild)
+		if !rate.perModel || math.Abs(rate.tps-measuredGemmaSoloTPS) > 1e-9 {
+			t.Fatalf("resolved rate = %+v, want the measured %.1f tok/s tagged per-model", rate, measuredGemmaSoloTPS)
+		}
+		if got := effCapResolved(reg, p, gemmaBuild); got != base {
+			t.Fatalf("cap = %d, want %d: one solo-gated measurement of the real rate must beat the model-agnostic proxy", got, base)
+		}
+	})
+
+	// A measurement of THIS model on THIS box outranks a fleet-wide configured
+	// guess. Ordering is measured -> seed -> proxy; a stale low seed must not
+	// hold a box down once it has measured itself.
+	t.Run("measured_rate_outranks_a_low_seed", func(t *testing.T) {
+		reg := New(testLogger())
+		p := prodBox(t, reg)
+		enablePerModelQualityCap(t, reg, gemmaBuild+"="+fmt.Sprint(starvedSeedTPS), "", "")
+
+		if got := effCapResolved(reg, p, gemmaBuild); got != 2 {
+			t.Fatalf("seed-only cap = %d, want 2 (the starved %.0f tok/s seed)", got, starvedSeedTPS)
+		}
+		observe(reg, 1, measuredGemmaSoloTPS)
+		if got := effCapResolved(reg, p, gemmaBuild); got != base {
+			t.Fatalf("cap = %d, want %d: the measured rate must outrank the %.0f tok/s seed", got, base, starvedSeedTPS)
+		}
+	})
+
+	// The first sample is taken as the box drops to one running request, so the
+	// alpha=0.3 EWMA still carries batched history and UNDER-states the solo
+	// rate. Worst realistic case is a fully contaminated rate(B=2) reading at
+	// the cap gemma is stuck on today. Even that clears the bar — the fix is
+	// not resting on a perfectly converged EWMA.
+	t.Run("contaminated_first_sample_still_reaches_eight", func(t *testing.T) {
+		contended := measuredGemmaSoloTPS / (1 + effectiveTPSLoadFactor*2)
+		if contended >= measuredGemmaSoloTPS || contended <= threshold {
+			t.Fatalf("rate(B=2) = %.2f tok/s is not a contaminated-but-passing reading against threshold %.2f", contended, threshold)
+		}
+		reg := New(testLogger())
+		p := prodBox(t, reg)
+		enablePerModelQualityCap(t, reg, "", "", "")
+		observe(reg, 1, contended)
+		if got := effCapResolved(reg, p, gemmaBuild); got != base {
+			t.Fatalf("cap = %d at a fully B=2-contaminated reading of %.2f tok/s, want %d", got, contended, base)
+		}
+	})
+
+	// The point is that the cap sees a TRUE rate, not a permissive one. A box
+	// that genuinely measures slow is still capped — the fix raises the cap by
+	// improving the INPUT, never by relaxing the bar.
+	t.Run("a_genuinely_slow_measurement_is_still_capped", func(t *testing.T) {
+		slow := 30.0
+		if slow >= threshold {
+			t.Fatalf("%.1f tok/s is not below the %.2f tok/s threshold; pick a slower rate", slow, threshold)
+		}
+		reg := New(testLogger())
+		p := prodBox(t, reg)
+		enablePerModelQualityCap(t, reg, "", "", "")
+		observe(reg, 1, slow)
+		got := effCapResolved(reg, p, gemmaBuild)
+		if got >= base {
+			t.Fatalf("cap = %d at a measured %.0f tok/s, want < %d — a slow box must not be granted the bump", got, slow, base)
+		}
+		if got < 1 {
+			t.Fatalf("cap = %d, want >= 1", got)
+		}
+	})
+
+	// A well-sampled median still outranks a single sample: the relaxation is a
+	// FALLBACK below the trusted floors, not a replacement for them.
+	t.Run("trusted_median_still_outranks_the_under_sampled_fallback", func(t *testing.T) {
+		reg := New(testLogger())
+		p := prodBox(t, reg)
+		enablePerModelQualityCap(t, reg, "", "", "")
+		observe(reg, qualityCapSoloMinSamples, 30.0)
+		observe(reg, 1, measuredGemmaSoloTPS)
+		_, n := reg.tpsRegistry.SoloMedian(gemmaBuild, chipClassKey(p.Hardware))
+		if n < qualityCapSoloMinSamples {
+			t.Fatalf("solo samples = %d, want >= the %d floor", n, qualityCapSoloMinSamples)
+		}
+		rate := resolveSolo(reg, p, gemmaBuild)
+		if rate.tps != 30.0 {
+			t.Fatalf("resolved rate = %.2f, want the trusted median 30.00 — the single fast sample must not displace it", rate.tps)
+		}
+	})
 }

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -55,14 +55,46 @@ const (
 	// effective TPS used in cost is `decodeTPS / (1 + k * batchSize)`
 	// where batchSize is the backend's currently-running request count.
 	//
-	// Measured on M4 Max (Qwen2.5-7B-4bit) at N=1/2/4/8 concurrent
-	// decodes: per-request TPS = 92.8 / 69.5 / 35.9 / 29.6. Median
-	// implied k = 0.27 (see scripts/calibrate-routing.sh load-factor).
-	// Prior default 0.4 was ~48% too aggressive — it under-predicted
-	// per-request TPS at small batch sizes, pushing traffic off the
-	// big machines sooner than warranted.
+	// Measured on M4 Max against the CBv2 engine and a model this
+	// coordinator actually serves — gemma-4-26b-qat-4bit, per-request
+	// decode at B = 1/2/4/8 = 101.8 / 59.6 / 38.0 / 24.7 (v2 rows of
+	// libs/mlx-swift-lm/benchmarks/reports/gemma4-26b-qat4bit-paged-gate-2026-07-09.md).
+	// Method: median of the implied k over B = 2/4/8, solo pinned to the
+	// B=1 measurement — 0.354 / 0.420 / 0.390 -> 0.39. A least-squares fit
+	// of 1/rate against B agrees (0.3895). The SAME method reproduces the
+	// previous 0.27 exactly from the legacy rows (Qwen2.5-7B-4bit on the
+	// legacy engine: 92.8 / 69.5 / 35.9 / 29.6 -> 0.2669), so this is a
+	// change of engine and model, not of method. Cross-checks: gemma
+	// v2-paged 0.388, v2-compiled 0.419; gpt-oss-20b v2-eager 0.432,
+	// v2-paged 0.325.
+	//
+	// 0.27 errs in the LENIENT direction against CBv2 — it UNDER-predicts
+	// degradation, i.e. over-predicts the surviving rate, and the error
+	// grows with batch:
+	//
+	//	B    measured    k=0.27 pred       k=0.39 pred
+	//	2    59.6        66.1   (+10.9%)   57.2   (-4.1%)
+	//	4    38.0        48.9   (+28.8%)   39.8   (+4.6%)
+	//	8    24.7        32.2   (+30.4%)   24.7   (-0.0%)
+	//	                 MAPE 23.4%        MAPE 2.9%
+	//
+	// B=1 is the model's INPUT (solo), not a prediction, so it is not
+	// scored. Mind the SIGN: 0.27 is too SMALL, not too large. A reading
+	// that it was wildly "too aggressive" comes from comparing a
+	// prediction made with the coordinator's sqrt(memory_bandwidth) proxy
+	// solo (16-28 tok/s) against a rate measured at the engine's real solo
+	// (101.8) — that gap is a bad SOLO rate, not a bad k, and it has its
+	// own lever (modelSoloTPSSeedEnv in concurrency_cap.go). Raising k
+	// makes every derived cap TIGHTER, never looser.
+	//
+	// Four systems consume this and a too-small k over-states the quality
+	// batch in all of them at once: the admission cap (concurrency_cap.go),
+	// effectiveDecodeTPS and projectedPerRequestDecodeTPSAtBatch below, and
+	// the warm-pool target (warm_pool_controller.go) — which then
+	// under-warms the pool while admission packs batches that miss the
+	// decode floor.
 	// Set to 0 to disable load scaling.
-	effectiveTPSLoadFactor = 0.27
+	effectiveTPSLoadFactor = 0.39
 )
 
 type routingSnapshot struct {

--- a/coordinator/registry/servability.go
+++ b/coordinator/registry/servability.go
@@ -44,10 +44,32 @@ const (
 	// servabilityCapFraction mirrors the provider's UnifiedMemoryCap default
 	// (90% of physical memory usable for MLX).
 	servabilityCapFraction = 0.90
-	// servabilityActivationReserveGB mirrors the provider's activation reserve
-	// kept aside on top of weights before KV cache (UnifiedMemoryCap activation
-	// reserve, ~3 GiB). Cold KV headroom ≈ cap*total - paddedWeights - reserve.
-	servabilityActivationReserveGB = 3.0
+	// servabilityActivationFloorGB mirrors the FLOOR half of the provider's
+	// activation reserve (UnifiedMemoryCap.defaultActivationReserveBytes,
+	// 3 GiB): the measured non-attention working set held back on top of
+	// weights before any KV cache. It does not scale with anything.
+	servabilityActivationFloorGB = 3.0
+	// servabilityActivationBytesPerToken mirrors the CONTEXT-SCALING half
+	// (UnifiedMemoryCap.peakPrefillScoreBytes), which the provider gained when
+	// the flat 3 GiB reserve stopped being true. A model whose head_dim misses
+	// MLX's fused-SDPA set {64, 80, 128} — gemma-4 is 256/512 — materialises a
+	// [rows, heads, C, kL] fp32 score tensor per prefill step, so its cost is
+	// LINEAR in kL and therefore a per-token surcharge on top of the KV bytes
+	// each token already costs:
+	//
+	//	attentionHeads(8) * 4 B (fp32) * liveQueryRows(2048) = 65536 B/token
+	//
+	// liveQueryRows is the provider's own step bound (maxBatchedTokensPerStep)
+	// for the UNBLOCKED prefill path — span-bearing vision chunks, the one path
+	// query sub-blocking (#85) does not cover and the only one whose L may
+	// exceed prefillChunkSize. gemma-4's 8 KV heads are the basis; a GQA model's
+	// query-head count is the true multiplier, so this sits at the OPTIMISTIC
+	// end on purpose, matching this predictor's fail-toward-serving contract.
+	//
+	// RETUNE TRIGGER: this tracks maxBatchedTokensPerStep, so §13.2's 6.2
+	// (2048 -> 4096) doubles it to 131072. Nothing detects that automatically —
+	// the coordinator never sees the provider's scheduler config.
+	servabilityActivationBytesPerToken = 65536
 )
 
 // ServabilityReason is the low-cardinality reason a request was judged
@@ -78,11 +100,18 @@ type ServabilityVerdict struct {
 }
 
 // coldTokenBudgetEstimate approximates the token budget a cold (on-disk, not yet
-// loaded) provider would have AFTER loading the model, mirroring the provider's
-// own live-KV-headroom math:
+// loaded) provider would have AFTER loading the model. The provider holds back
 //
-//	kvHeadroomGB ≈ cap*totalMemoryGB - paddedWeightsGB - activationReserveGB
-//	tokens       ≈ kvHeadroomGB * bytesPerGB / kvBytesPerToken
+//	reserve(t) = max(activationFloor, activationBytesPerToken * t)
+//
+// on top of the padded weights, so the budget is the largest t satisfying
+//
+//	t*kvBytesPerToken + reserve(t) <= cap*totalMemoryGB - paddedWeightsGB
+//
+// which is piecewise-linear with a single crossover at
+// activationFloor/activationBytesPerToken (49152 tokens at today's constants):
+// below it the flat floor binds and a token pays only KV; above it the score
+// tensor scales with context and the two per-token costs simply add.
 //
 // paddedWeightsGB uses the same catalog→padded-GiB conversion the cold-load gate
 // uses (coldLoadCatalogGBToMemGiB). kvBytesPerToken prefers the provider-reported
@@ -90,32 +119,58 @@ type ServabilityVerdict struct {
 // is deliberately OPTIMISTIC (uses only the activation reserve, not the extra
 // min-KV load floor) so the predictor errs toward serving. Returns 0 when the
 // inputs are unusable or no headroom remains.
+//
+// # Deliberate divergence from the provider's own formula
+//
+// The provider evaluates its reserve at a CEILING it can see — its configured
+// maxContextLength, its scheduler's step/chunk sizes, and the slot's real
+// per-layer head counts — and holds that many bytes back unconditionally. The
+// coordinator sees none of those: a cold slot has no heartbeat at all, and even
+// a warm one reports neither maxBatchedTokensPerStep nor head counts. Rather
+// than guess the provider's ceiling (a duplicated constant that drifts the
+// moment either side is retuned — the exact failure this replaces), the
+// coordinator solves the SELF-CONSISTENT point: it charges the score tensor at
+// exactly the context it is predicting the provider can hold. The two agree
+// when the predicted budget equals the provider's maxContextLength and the
+// coordinator is optimistic below it — the safe direction for a gate whose
+// false-NO is a 429. Only servabilityActivationBytesPerToken is shared, and it
+// is a shape constant (heads x fp32 x step rows), not a memory figure.
 func coldTokenBudgetEstimate(totalMemoryGB, modelSizeGB float64, kvBytesPerToken int64) int64 {
 	if totalMemoryGB <= 0 || modelSizeGB <= 0 {
 		return 0
 	}
 	paddedWeightsGB := modelSizeGB * coldLoadCatalogGBToMemGiB
-	kvHeadroomGB := servabilityCapFraction*totalMemoryGB - paddedWeightsGB - servabilityActivationReserveGB
-	if kvHeadroomGB <= 0 {
+	postLoadGB := servabilityCapFraction*totalMemoryGB - paddedWeightsGB
+	if postLoadGB <= 0 {
 		return 0
 	}
 	kvpt := kvBytesPerToken
 	if kvpt <= 0 {
 		kvpt = kvCacheBytesPerToken
 	}
-	tokens := int64(kvHeadroomGB * float64(bytesPerGB) / float64(kvpt))
-	if tokens < 0 {
+	postLoadBytes := postLoadGB * float64(bytesPerGB)
+	floorBytes := servabilityActivationFloorGB * float64(bytesPerGB)
+	// Below the crossover the flat floor is the whole reserve.
+	tokens := (postLoadBytes - floorBytes) / float64(kvpt)
+	if tokens > floorBytes/servabilityActivationBytesPerToken {
+		// Above it the score tensor dominates and scales with the context, so
+		// every token carries both costs.
+		tokens = postLoadBytes / float64(kvpt+servabilityActivationBytesPerToken)
+	}
+	if tokens <= 0 {
 		return 0
 	}
-	return tokens
+	return int64(tokens)
 }
 
 // snapshotStructuralBudget returns this provider's structural token-budget
 // contribution for the model, and whether it is known. A resident slot uses the
-// provider-reported active_token_budget_max; a cold-but-fitting provider uses the
-// optimistic cold estimate. "known=false" means we cannot tell (legacy resident
-// slot with no budget, or missing memory data) — the caller treats unknown as
-// fail-open and skips the budget tier entirely.
+// provider-reported active_token_budget_max — which already nets out whatever
+// activation reserve that provider actually chose. A cold-but-fitting provider
+// has no such report, so it uses the optimistic post-load estimate, reserve
+// included (see coldTokenBudgetEstimate). "known=false" means we cannot tell
+// (legacy resident slot with no budget, or missing memory data) — the caller
+// treats unknown as fail-open and skips the budget tier entirely.
 func snapshotStructuralBudget(snap routingSnapshot) (budget int64, known bool) {
 	if snap.activeTokenBudgetMax > 0 {
 		return snap.activeTokenBudgetMax, true

--- a/coordinator/registry/servability_provider_fit_test.go
+++ b/coordinator/registry/servability_provider_fit_test.go
@@ -56,6 +56,9 @@ func TestProviderBudgetFitsWarmSlotLiveBudget(t *testing.T) {
 func TestProviderBudgetFitsColdLoadPostLoadBudget(t *testing.T) {
 	// gemma-4-26b shape: 28 GB catalog weights on a 48 GB box. Padded weights
 	// = 28 × ~1.1176 ≈ 31.3 GiB ≤ free_for_load 32 → the weight gate admits.
+	// 48 GB leaves ~11.9 GB post-load, which puts the budget in the activation
+	// reserve's FLOOR regime (below the 49152-token crossover), so the flat
+	// 3 GiB — not the per-token score tensor — is what is held back here.
 	freeForLoad := 32.0
 	snap := routingSnapshot{
 		totalMemoryGB:   48,
@@ -68,7 +71,7 @@ func TestProviderBudgetFitsColdLoadPostLoadBudget(t *testing.T) {
 	}
 
 	// Post-load budget per the provider's own headroom math:
-	// (0.90×48 − paddedWeights − 3 GB activation reserve) / 400000 B/token.
+	// (0.90×48 − paddedWeights − 3 GB activation floor) / 400000 B/token.
 	budget := coldTokenBudgetEstimate(snap.totalMemoryGB, snap.modelSizeGB, 0)
 	if budget <= 0 || budget >= 30_000 {
 		t.Fatalf("cold post-load budget = %d, want a positive value below the 30k request", budget)
@@ -111,7 +114,8 @@ func TestPredictServableColdWeightFitInsufficientBudgetSheds(t *testing.T) {
 	reg := New(testLogger())
 	model := "cold-budget-model"
 	// 28 GB weights on a 48 GB node: min_ram 36 ≤ 48 passes the hardware gate,
-	// and the post-load budget is coldTokenBudgetEstimate(48, 28, 0) ≈ 23.9k.
+	// and the post-load budget is coldTokenBudgetEstimate(48, 28, 0) = 23911
+	// (floor regime — see TestColdTokenBudgetEstimate case (b2)).
 	reg.SetModelCatalog([]CatalogEntry{{ID: model, SizeGB: 28, MinRAMGB: 36}})
 	makeWarmPoolColdProvider(t, reg, "cold-48gb", model, 80, 48, 0)
 

--- a/coordinator/registry/servability_test.go
+++ b/coordinator/registry/servability_test.go
@@ -3,19 +3,33 @@ package registry
 import "testing"
 
 // TestColdTokenBudgetEstimate pins the pure cold post-load KV-budget estimator.
-// The formula is:
+// The provider's activation reserve is max(flat floor, per-token score tensor),
+// so the budget is piecewise-linear around the crossover
+// servabilityActivationFloorGB*bytesPerGB / servabilityActivationBytesPerToken
+// = 3*2^30/65536 = 49152 tokens:
 //
-//	kvHeadroomGB = servabilityCapFraction*total - size*coldLoadCatalogGBToMemGiB - servabilityActivationReserveGB
-//	tokens       = int64(kvHeadroomGB * bytesPerGB / kvBytesPerToken)   // kvBytesPerToken<=0 → 400000
+//	postLoadGB = servabilityCapFraction*total - size*coldLoadCatalogGBToMemGiB
+//	postLoadB  = postLoadGB * bytesPerGB
+//	floorB     = servabilityActivationFloorGB * bytesPerGB   // 3*2^30
+//	tokens     = (postLoadB - floorB) / kvBytesPerToken      // floor binds
+//	if tokens > 49152:
+//	    tokens = postLoadB / (kvBytesPerToken + 65536)       // score binds
 //
-// with servabilityCapFraction=0.90, servabilityActivationReserveGB=3.0,
-// coldLoadCatalogGBToMemGiB≈1.1175870895385742, bytesPerGB=1<<30.
+// with servabilityCapFraction=0.90, servabilityActivationFloorGB=3.0,
+// servabilityActivationBytesPerToken=65536,
+// coldLoadCatalogGBToMemGiB≈1.1175870895385742, bytesPerGB=1<<30, and
+// kvBytesPerToken<=0 → 400000.
 func TestColdTokenBudgetEstimate(t *testing.T) {
-	// (a) Roomy node: total=64, size=12, kvpt=400000.
-	//   padded   = 12 * 1.1175870895385742           = 13.41104507446289
-	//   headroom = 0.90*64 - 13.41104507446289 - 3.0 = 41.18895492553711 GB
-	//   tokens   = int64(41.18895492553711 * 2^30 / 400000) = 110565
-	const wantRoomy = int64(110565)
+	// (a) Roomy node: total=64, size=12, kvpt=400000. Long-context regime —
+	// the score tensor, not the 3 GiB floor, is what the provider holds back.
+	//   padded    = 12 * 1.1175870895385742           = 13.41104507446289
+	//   postLoadGB= 0.90*64 - 13.41104507446289       = 44.18895492553711 GB
+	//   postLoadB = 44.18895492553711 * 2^30          = 47447529062.4 B
+	//   floor-bound tokens = (47447529062.4 - 3221225472) / 400000 = 110565.75
+	//   110565.75 > 49152, so the score tensor binds instead:
+	//   tokens    = int64(47447529062.4 / 465536)     = 101920
+	// (Flat-3-GiB predecessor: 110565 — 8% optimistic at this context.)
+	const wantRoomy = int64(101920)
 	if got := coldTokenBudgetEstimate(64, 12, 400000); got != wantRoomy {
 		t.Fatalf("roomy estimate = %d, want %d", got, wantRoomy)
 	}
@@ -23,10 +37,42 @@ func TestColdTokenBudgetEstimate(t *testing.T) {
 		t.Fatalf("roomy estimate = %d, want > 0", got)
 	}
 
-	// (b) Tiny node: weights (padded) + activation reserve exceed 90% of the
-	// 8 GB cap, so there is no KV headroom at all → 0 (never negative).
+	// (b) Tiny node: weights (padded) alone exceed 90% of the 8 GB cap, so
+	// there is no post-load memory at all, let alone room for the activation
+	// reserve → 0 (never negative).
 	if got := coldTokenBudgetEstimate(8, 12, 400000); got != 0 {
-		t.Fatalf("tiny-node estimate = %d, want 0 (weights+reserve exceed cap)", got)
+		t.Fatalf("tiny-node estimate = %d, want 0 (weights exceed cap)", got)
+	}
+
+	// (b2) Floor regime: a 48 GB node loading 28 GB of gemma-4 weights lands
+	// BELOW the crossover, so the flat floor is still the whole reserve and the
+	// estimate is unchanged from the pre-parametric formula.
+	//   padded    = 28 * 1.1175870895385742     = 31.292438507080078
+	//   postLoadGB= 0.90*48 - 31.292438507080078 = 11.907561492919925 GB
+	//   tokens    = (11.907561492919925*2^30 - 3221225472) / 400000 = 23911.05
+	//   23911 <= 49152 → floor branch wins.
+	if got := coldTokenBudgetEstimate(48, 28, 400000); got != int64(23911) {
+		t.Fatalf("floor-regime estimate = %d, want 23911", got)
+	}
+
+	// (b3) The two regimes must JOIN, not jump. Sweeping node size across the
+	// crossover has to stay monotone and continuous; a branch inversion, or a
+	// floor charged ON TOP OF the per-token cost rather than instead of it,
+	// shows up here as a step backwards or a cliff. Each 0.05 GB step adds
+	// 0.045*2^30 bytes = at most ~121 tokens in either regime.
+	prev := int64(0)
+	for total := 20.0; total <= 30.0; total += 0.05 {
+		got := coldTokenBudgetEstimate(total, 1, 400000)
+		if got < prev {
+			t.Fatalf("budget went backwards at total=%.2f: %d after %d", total, got, prev)
+		}
+		if prev > 0 && got-prev > 200 {
+			t.Fatalf("regime discontinuity at total=%.2f: %d jumped from %d", total, got, prev)
+		}
+		prev = got
+	}
+	if prev <= 49152 {
+		t.Fatalf("sweep ended at %d tokens, never crossed the 49152 regime boundary", prev)
 	}
 
 	// (c) kvBytesPerToken <= 0 falls back to the kvCacheBytesPerToken default

--- a/coordinator/registry/solo_tps_test.go
+++ b/coordinator/registry/solo_tps_test.go
@@ -444,16 +444,39 @@ func TestSoloClassKeyingEndToEndNoCrossTierOverCap(t *testing.T) {
 	}
 }
 
+// TestResolvedSoloModelTPSMinSampleFloor pins what the min-sample floor now
+// selects BETWEEN, and that the terminal provider-level fallback is still
+// wired.
+//
+// The floor used to be the boundary between a per-model rate and the
+// provider-level one. It no longer is: below the floor the resolver prefers
+// the under-sampled — but still solo-gated and still per-model — measured
+// median over resolvedDecodeTPS's model-AGNOSTIC sqrt-bandwidth proxy (see
+// resolvedSoloModelTPSLocked). Here that difference is the whole postmortem
+// layer-6 failure in one line: 14 tok/s is gemma's own measured rate, 93 is
+// the mixed box's registration benchmark taken on gpt-oss. Five gemma samples
+// are better evidence about gemma than a fast benchmark of a different model.
+//
+// What the floor still decides is the TRUST TIER — authoritative, or a
+// fallback ranked below the configured seed — and the provider-level rate is
+// now reached only when the model has NO measurement at all.
 func TestResolvedSoloModelTPSMinSampleFloor(t *testing.T) {
 	reg := New(testLogger())
-	// Floor raised to 6: five per-chip samples are NOT yet trusted.
+	// Floor raised to 6: five samples are NOT yet the trusted tier.
 	enablePerModelQualityCap(t, reg, "", "", "6")
 	p := mixedBoxProvider(t, reg, "mixed", 93)
-	for i := 0; i < 5; i++ {
+
+	// No measurement at all — the terminal provider-level fallback. This is
+	// the only remaining route to resolvedDecodeTPS(p), so it is pinned here.
+	if got := resolveSolo(reg, p, gemmaBuild); got.tps != 93 || got.perModel {
+		t.Fatalf("no samples = %+v, want the provider-level fallback (93, perModel false)", got)
+	}
+
+	for range 5 {
 		reg.tpsRegistry.RecordSolo(gemmaBuild, "M3", 14)
 	}
-	if got := resolveSolo(reg, p, gemmaBuild); got.tps != 93 || got.perModel {
-		t.Fatalf("below min samples = %+v, want provider-level (93, perModel false)", got)
+	if got := resolveSolo(reg, p, gemmaBuild); got.tps != 14 || !got.perModel {
+		t.Fatalf("below min samples = %+v, want the under-sampled measured rate (14, perModel true), not the provider-level 93", got)
 	}
 	reg.tpsRegistry.RecordSolo(gemmaBuild, "M3", 14)
 	if got := resolveSolo(reg, p, gemmaBuild); got.tps != 14 || !got.perModel {

--- a/coordinator/registry/solo_tps_test.go
+++ b/coordinator/registry/solo_tps_test.go
@@ -511,18 +511,20 @@ func TestParseModelFloatMapSeedEntries(t *testing.T) {
 
 // TestSoloSeedColdStart is the restart scenario: the TPS registry is in-memory
 // and wiped by a coordinator restart, so on a fresh registry the seed env must
-// carry the per-model cap alone (gemma-qat solo ≈ 14 from prod data → cap 2)
-// until gated solo samples re-accumulate.
+// carry the per-model cap alone until gated solo samples re-accumulate. The
+// gemma seed (14, at or under the 15 floor) pins to 2 at any measured k; the
+// gpt-oss cap is k-derived (see the helpers in concurrency_cap_test.go).
 func TestSoloSeedColdStart(t *testing.T) {
 	reg := New(testLogger()) // fresh registry == post-restart state
 	enablePerModelQualityCap(t, reg, "gemma-4-26b-qat-4bit=14,gpt-oss-20b=30", "", "")
 	p := mixedBoxProvider(t, reg, "mixed", 93)
 
 	if got := effCapResolved(reg, p, gemmaBuild); got != 2 {
-		t.Fatalf("cold-start gemma cap = %d, want 2 (seed 14 ≤ floor 15 → qc 1 × 1.2)", got)
+		t.Fatalf("cold-start gemma cap = %d, want 2 (seed 14 ≤ floor 15 → quality batch 1 × 1.2)", got)
 	}
-	if got := effCapResolved(reg, p, gptossBuild); got != 4 {
-		t.Fatalf("cold-start gpt-oss cap = %d, want 4 (seed 30 → qc 3 → ceil(3.6))", got)
+	wantGptoss := wantQualityCap(30, 15, 24, defaultQualityCapOvercommit)
+	if got := effCapResolved(reg, p, gptossBuild); got != wantGptoss {
+		t.Fatalf("cold-start gpt-oss cap = %d, want %d (seed 30 at k=%.2f × 1.2)", got, wantGptoss, effectiveTPSLoadFactor)
 	}
 }
 

--- a/coordinator/registry/warm_pool_controller_test.go
+++ b/coordinator/registry/warm_pool_controller_test.go
@@ -565,10 +565,13 @@ func TestWarmPoolPicksBetterIdleProvider(t *testing.T) {
 // --- Little's Law target math (pure, warm_pool_target.go) ---
 
 func TestQualityConcurrencyFromDecodeFloor(t *testing.T) {
-	k := effectiveTPSLoadFactor // 0.27
-	// solo 100, floor 15: B <= (100/15 - 1)/0.27 = 20.98 -> 20 (under cap 32).
-	if got := qualityConcurrency(100, 15, k, 32, 4); got != 20 {
-		t.Fatalf("qc(solo100,floor15,cap32) = %d, want 20", got)
+	k := effectiveTPSLoadFactor
+	// solo 100, floor 15: B <= (100/15 - 1)/k, under the cap of 32 at any
+	// measured k (20 at the legacy 0.27, 14 at the CBv2-re-fit 0.39).
+	// strictQualityBatch reaches the same answer from the defining
+	// inequality, so this pins the closed form, not the coefficient.
+	if want, got := strictQualityBatch(100, 15, k, 32), qualityConcurrency(100, 15, k, 32, 4); got != want {
+		t.Fatalf("qc(solo100,floor15,cap32) = %d, want %d (k=%.2f)", got, want, k)
 	}
 	// Capped by the provider concurrency limit.
 	if got := qualityConcurrency(100, 15, k, 6, 4); got != 6 {

--- a/coordinator/registry/warm_pool_target.go
+++ b/coordinator/registry/warm_pool_target.go
@@ -78,6 +78,12 @@ type warmTargetInputs struct {
 // concurrency cap (falling back to fallbackConc). When the floor is disabled
 // (<= 0), the solo rate is unknown, or load scaling is off, the constraint does
 // not bind and the cap is returned.
+//
+// k is MEASURED per engine generation, not chosen, and this function is the
+// most load-bearing consumer of getting it wrong in the safe-looking
+// direction: too SMALL a k over-states the quality batch, which divides
+// Little's Law demand by too much and under-warms the pool — a shortfall that
+// reads as demand undershoot rather than as a stale coefficient.
 func qualityConcurrency(soloDecodeTPS, floor, k float64, maxProviderConc, fallbackConc int) int {
 	limit := maxProviderConc
 	if limit <= 0 {

--- a/deploy/environments/prod.env
+++ b/deploy/environments/prod.env
@@ -33,6 +33,32 @@ EIGENINFERENCE_PREFILL_DECODE_RATIO=12
 EIGENINFERENCE_PREFILL_KEEPALIVE_INTERVAL=10s
 EIGENINFERENCE_PROMPT_CALIBRATION=gpt-oss:1.3
 
+# Per-model solo decode rate for the quality-concurrency admission cap.
+#
+# REQUIRED before raising engine_v2_max_concurrent to 8. The provider never
+# sends decode_tps, so without a seed the cap is computed from
+# resolvedDecodeTPS's sqrt(memory_bandwidth) proxy — 16-28 tok/s across Apple
+# silicon, a model-agnostic number ~4x under the engine's measured ~99.5 tok/s
+# gemma solo. That proxy caps gemma at 2 no matter what the provider reports,
+# because the reported concurrency is only the MIN's base operand. Gated solo
+# samples cannot rescue it: ingest needs the whole box at exactly one running
+# and zero waiting requests at heartbeat time, which a box running at B=8
+# essentially never is.
+#
+# 70 tok/s is deliberately well under the measured solo (gemma-4 99.5 paged /
+# 101.8 eager, gpt-oss-20b 88.5 paged) so slower fleet tiers inheriting this
+# fleet-wide value are not over-credited, and it reaches 8 on strict quality
+# merit rather than via the overcommit rounding: floor((70/15-1)/0.39) = 9,
+# ceil(9 x 1.2) = 11, min(11, 8) = 8, with projected per-request decode at B=8
+# of 17.0 tok/s — above the 15 floor. It also clears the threshold at the
+# previous load factor (39.3 tok/s at k=0.27, 50.1 at k=0.39), so the seed and
+# the k re-fit are INDEPENDENT: neither depends on the other having landed.
+#
+# Note gpt-oss-20b is not a dedicated model, so today it is uncapped at the
+# flat 24; a seed makes its cap real (8 against a reported 8). That is
+# intentional.
+EIGENINFERENCE_MODEL_SOLO_TPS_SEED=gemma-4-26b-qat-4bit=70,gpt-oss-20b=70
+
 # TTFT and warm-pool tuning observed on 2026-07-17.
 EIGENINFERENCE_TTFT_ADMISSION_MODE=shadow
 EIGENINFERENCE_TTFT_HARD_REJECT=true

--- a/docs/architecture/operations/routing.md
+++ b/docs/architecture/operations/routing.md
@@ -91,15 +91,64 @@ Each term maps to a field in `RoutingDecision`:
 
 Penalty constants are defined at `scheduler.go:16-36`.
 
-### Effective decode TPS
+### Effective decode TPS (routing cost)
 
-`resolveEffectiveTPS` (`scheduler.go:950-958`) chooses the best available decode estimate in this order:
+`resolveEffectiveTPS` (`scheduler.go:1704`) chooses the best available decode
+estimate for the **cost function** in this order:
 
 1. Provider-reported observed EWMA (`slot.ObservedDecodeTPS`).
 2. Fleet median TPS for the same model and chip family (`tpsRegistry.Median`).
-3. Load-scaled benchmark TPS (`effectiveDecodeTPS`, `scheduler.go:971-983`).
+3. Load-scaled benchmark TPS (`effectiveDecodeTPS`, `scheduler.go:1745`).
 
-The load-scaled fallback divides the static benchmark TPS by `1 + effectiveTPSLoadFactor × backendRunning`, with `effectiveTPSLoadFactor = 0.27` (`scheduler.go:64`).
+The load-scaled fallback divides the static benchmark TPS by
+`1 + effectiveTPSLoadFactor × backendRunning`, with
+`effectiveTPSLoadFactor = 0.39` (`scheduler.go:97`).
+
+This chain is deliberately **load-inclusive**: it estimates what a request will
+actually experience right now, so an under-load EWMA is the *right* input.
+
+### Solo decode TPS (quality-concurrency cap)
+
+Do not confuse this with the chain above — it answers a different question and
+takes the opposite stance on load. `resolvedSoloModelTPSLocked`
+(`concurrency_cap.go:265`) resolves the **static single-stream** rate the
+admission cap is computed from. It must never be an under-load EWMA: the
+observed rate collapses under the very overload the cap exists to prevent,
+which would drive the cap to 1 in a feedback loop.
+
+Five steps, most- to least-specific. Each advances only when its own condition
+fails:
+
+| # | Source | Advances to the next step when |
+|---|---|---|
+| 1 | Per-(model, chip **class**) solo median (`SoloMedian`) | fewer than `EIGENINFERENCE_QUALITY_CAP_SOLO_MIN_SAMPLES` (default 5) gated samples, or the median is 0 |
+| 2 | MIN of per-class solo medians across chip classes (`SoloMedianAllChips`), clamped from above by the seed | fewer than the same sample floor in total, or 0 |
+| 3 | The same two medians again with the sample floor **relaxed to ≥ 1** — under-sampled but still measured and still solo-gated (cross-class still seed-clamped) | the model has no solo sample at all on this coordinator |
+| 4 | `EIGENINFERENCE_MODEL_SOLO_TPS_SEED` for this build id | no seed entry for the model |
+| 5 | `resolvedDecodeTPS(p)` — the registration benchmark `decode_tps`, else `sqrt(memory_bandwidth)` | terminal |
+
+"Gated" (steps 1–3) means the sample was ingested only from a heartbeat where
+the **whole box** was uncontended (Σ running+waiting ≤ 1 across all slots) and
+the reporting slot had a running decode (`NumRunning > 0`) — see
+`soloSampleEligible`. That gate is what keeps a measured rate a *solo* rate.
+
+Step 3 exists because the alternative below it is worse information, not
+better: step 5's `sqrt(memory_bandwidth)` is **model-agnostic** (16–28 tok/s
+across Apple silicon) and has nothing to do with the model being capped. One
+solo-gated measurement of the actual model beats it outright. Under-sampled
+readings converge from **below** — the α = 0.3 provider EWMA still carries
+batched history when the box drops to a single request — so the error direction
+is a tighter cap, never a permissive one.
+
+Step 5 is reached in production only at **cold start**. The Swift provider
+never sends `decode_tps` at registration (deliberately: on a multi-model box a
+single provider-level benchmark lends one model's rate to another — the
+postmortem layer-6 failure), and a provider that has completed no request
+reports no `observed_decode_tps` at all, so `p.DecodeTPS` is 0 and the proxy is
+all that is left. For a **dedicated** model that yields a cap of 2; for a
+non-dedicated one the guard in `effectiveMaxConcurrencyForModelRateLocked`
+(`concurrency_cap.go:328`) leaves the provider's reported cap alone. This is
+why the seed at step 4 stays configured — see the v0.8.0 release notes.
 
 ## Slot states and penalties
 

--- a/provider-swift/Sources/ProviderCore/Inference/UnifiedMemoryCap.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/UnifiedMemoryCap.swift
@@ -34,14 +34,23 @@ public enum UnifiedMemoryCap {
     /// OS (e.g. an 8 GiB box gets a 6 GiB cap, not 7.2 GiB).
     static let minimumReserveBytes: UInt64 = 2 * 1024 * 1024 * 1024  // 2 GiB
 
-    /// Default activation/working-memory reserve carved out INSIDE the cap.
+    /// Absolute FLOOR on the activation/working-memory reserve carved out
+    /// INSIDE the cap. ``activationReserveBytes(for:)`` raises it; nothing
+    /// lowers it except an explicit operator/programmatic override.
     ///
     /// Measured on M5 Max (Gemma-4-26B-qat-4bit + GPT-OSS-20B, both MoE): a
     /// 4-concurrent ~3000-token long-prefill burst moved RSS by only ~9 MB over
     /// the resident-weight baseline — MoE activates few experts, MLX fuses
     /// attention, and intermediates churn through the (count-bounded) buffer
-    /// cache rather than growing the live set. So activations are small in
-    /// practice; this is a conservative SAFETY FLOOR, not a per-batch estimate.
+    /// cache rather than growing the live set.
+    ///
+    /// That measurement is real but NARROW: short prompts, four concurrent
+    /// rows, and a burst whose attention MLX could fuse. It says nothing about
+    /// the one activation that is neither small nor fused — the composed-path
+    /// prefill SCORE tensor (see ``ActivationReserveShape``), which is already
+    /// ~6.6 GB at those same four concurrent rows once the context reaches
+    /// 100k. So this number is a floor for the non-attention working set, not
+    /// a per-batch estimate, and it must never be the whole answer on its own.
     static let defaultActivationReserveBytes: UInt64 = 3 * 1024 * 1024 * 1024  // 3 GiB
 
     /// Minimum KV headroom (bytes) a freshly-loaded model must have under the cap
@@ -208,6 +217,172 @@ public enum UnifiedMemoryCap {
         return max(configReserveBytes, capImpliedReserve)
     }
 
+    // MARK: - Parametric activation reserve
+
+    /// The prefill-attention shape that decides how much working memory one
+    /// scheduler step can hold live, so the reserve scales with batch and
+    /// context instead of being a flat number justified by a single
+    /// 4-concurrent measurement.
+    ///
+    /// ## What is being sized
+    ///
+    /// MLX's fused SDPA kernel accepts head_dim ∈ {64, 80, 128}
+    /// (`sdpa_full_supported_head_dim`); anything else takes the COMPOSED
+    /// fallback, which MATERIALISES the score tensor
+    /// `[concurrentPrefills, heads, C, kL]` in fp32 before the softmax, plus a
+    /// `[C, kL]` bool mask. Gemma-4 (head_dim 256 sliding / 512 full) never
+    /// reaches the fused kernel; gpt-oss (head_dim 64) always does and costs
+    /// nothing here.
+    ///
+    /// ## Why `C` is not simply the chunk size
+    ///
+    /// Query sub-blocking (`CBv2AttentionV1.attendQueryBlocks`) pins a TEXT
+    /// chunk's live score tensor at `[1, heads, q, kL]`, O(1) in chunk length.
+    /// Span-bearing VISION chunks deliberately keep the single-call path
+    /// (`AttentionV1.swift:243-251`): a bidirectional overlay covers the whole
+    /// chunk, so a query block cannot be sliced to a causal-only visible span.
+    /// They are also the only prefill path whose `L` may exceed
+    /// ``prefillChunkSize`` (the scheduler's block snap-over), which makes them
+    /// simultaneously the largest-`L` and the only unblocked prefill. A slot
+    /// that serves vision is therefore costed at FULL `L`; a text-only slot at
+    /// the sub-block width.
+    ///
+    /// ## Filling it in
+    ///
+    /// Every field has exactly one upstream owner. READ them — restating any of
+    /// them here recreates the drifting parallel constant this type exists to
+    /// delete: `CBv2SchedulerConfig.maxBatchedTokensPerStep`/`.prefillChunkSize`,
+    /// `CBv2AttentionV1.queryBlockSize`, `CBv2LayerKind.queryHeads`/`.headDim`,
+    /// and the slot's own `maxContextLength`. That is why no field carries a
+    /// "sensible" default.
+    public struct ActivationReserveShape: Sendable, Equatable {
+        /// `CBv2SchedulerConfig.maxBatchedTokensPerStep`: the step's whole
+        /// token budget across decode and prefill. Divided by
+        /// ``prefillChunkSize`` it gives the concurrent prefill rows one step
+        /// can carry, and it independently caps the vision path (`MultimodalV2`
+        /// rejects a coalesced image block longer than this at submit).
+        public var maxBatchedTokensPerStep: Int
+
+        /// `CBv2SchedulerConfig.prefillChunkSize`: the per-row prompt chunk.
+        public var prefillChunkSize: Int
+
+        /// `CBv2AttentionV1.queryBlockSize` (env
+        /// `DARKBLOOM_CBV2_ATTN_QUERY_BLOCK`). `0` = blocking disabled — the
+        /// kill switch — so a text chunk costs its full ``prefillChunkSize``.
+        public var querySubBlockSize: Int
+
+        /// Longest coalesced vision block this slot may schedule, in tokens;
+        /// `0` = text-only slot. Costed at full `L`, never at the sub-block
+        /// width, because span chunks skip query blocking.
+        public var spanChunkMaxL: Int
+
+        /// The model's context window — the longest key axis a prefill query
+        /// can attend. `0` = unknown, which disables the estimate.
+        public var maxContextLength: Int
+
+        /// QUERY heads on the widest attention layer
+        /// (`CBv2LayerKind.queryHeads`), NOT KV heads: the score tensor is
+        /// materialised after the GQA repeat, so a GQA model's KV-head count
+        /// under-counts it. `0` = unknown, which disables the estimate.
+        public var attentionHeads: Int
+
+        /// Whether attention takes MLX's composed fallback, i.e. whether a
+        /// score tensor is materialised at all. See
+        /// ``composedAttention(headDim:)``.
+        public var composedAttention: Bool
+
+        public init(
+            maxBatchedTokensPerStep: Int,
+            prefillChunkSize: Int,
+            querySubBlockSize: Int,
+            spanChunkMaxL: Int = 0,
+            maxContextLength: Int,
+            attentionHeads: Int,
+            composedAttention: Bool = true
+        ) {
+            self.maxBatchedTokensPerStep = maxBatchedTokensPerStep
+            self.prefillChunkSize = prefillChunkSize
+            self.querySubBlockSize = querySubBlockSize
+            self.spanChunkMaxL = spanChunkMaxL
+            self.maxContextLength = maxContextLength
+            self.attentionHeads = attentionHeads
+            self.composedAttention = composedAttention
+        }
+
+        /// The head_dims MLX's fused SDPA kernel accepts
+        /// (`sdpa_full_supported_head_dim`); every other head_dim composes and
+        /// pays for a materialised score tensor.
+        public static func composedAttention(headDim: Int) -> Bool {
+            headDim != 64 && headDim != 80 && headDim != 128
+        }
+    }
+
+    /// The composed path builds scores in fp32 regardless of the model's weight
+    /// dtype, and adds one `[C, kL]` bool mask (1 byte, shared across heads).
+    private static let scoreBytesPerElement: UInt64 = 4
+    private static let maskBytesPerElement: UInt64 = 1
+
+    /// Peak live prefill score + mask bytes for ONE scheduler step:
+    ///
+    ///     concurrentPrefills = maxBatchedTokensPerStep / prefillChunkSize
+    ///     C                  = max(querySubBlockSize, spanChunkMaxL)
+    ///     liveQueryRows      = min(maxBatchedTokensPerStep,
+    ///                              concurrentPrefills × C)
+    ///     bytes              = liveQueryRows × maxContextLength
+    ///                            × (attentionHeads × 4 + 1)
+    ///
+    /// Each concurrent prefill row holds ONE live score tensor behind the
+    /// `concatenated(axis: 0)` that joins the step's rows, so the rows add up.
+    /// `liveQueryRows` is then capped at the step budget: a row cannot hold more
+    /// query rows live than it was handed tokens to prefill. That cap is what
+    /// makes the vision term saturate at the whole step budget instead of
+    /// growing without bound as blocks snap over ``prefillChunkSize``.
+    ///
+    /// Reproduces the migration plan's §7.0.3 table (heads 8, chunk 512,
+    /// unblocked span path): B=4 → 2048 live query rows → 0.66 GB at 10k
+    /// context and 6.6 GB at 100k; B=8 → 4096 rows → 1.3 GB / 13.1 GB. The
+    /// same B=4 step on a TEXT-only slot sub-blocks to 512 rows and costs 1.7 GB
+    /// at 100k — that gap is exactly what #85 bought, and exactly what vision
+    /// does not get.
+    ///
+    /// Returns 0 when no score tensor exists (fused kernel) or the geometry is
+    /// unknown; the caller then keeps the measured floor.
+    public static func peakPrefillScoreBytes(for shape: ActivationReserveShape) -> UInt64 {
+        guard shape.composedAttention,
+            shape.attentionHeads > 0,
+            shape.maxContextLength > 0,
+            shape.maxBatchedTokensPerStep > 0
+        else { return 0 }
+        let stepBudget = shape.maxBatchedTokensPerStep
+        let chunk = max(1, min(shape.prefillChunkSize, stepBudget))
+        let concurrentPrefills = max(1, stepBudget / chunk)
+        // Text rows are pinned to the sub-block width (0 = kill switch → the
+        // whole chunk); span rows keep the single-call path at full L, capped
+        // by the step budget that also gates them at submit.
+        let textWidth =
+            shape.querySubBlockSize > 0
+            ? min(shape.querySubBlockSize, chunk)
+            : chunk
+        let spanWidth = min(max(0, shape.spanChunkMaxL), stepBudget)
+        let liveQueryRows = min(
+            UInt64(stepBudget),
+            saturatingMultiply(
+                UInt64(concurrentPrefills), UInt64(max(textWidth, spanWidth))))
+        let perKeyBytes = saturatingAdd(
+            saturatingMultiply(UInt64(shape.attentionHeads), scoreBytesPerElement),
+            maskBytesPerElement)
+        return saturatingMultiply(
+            liveQueryRows, UInt64(shape.maxContextLength), perKeyBytes)
+    }
+
+    /// The activation reserve for `shape`: the measured floor, RAISED to the
+    /// peak prefill score tensor whenever the configured batch and context need
+    /// more. Never returns less than ``defaultActivationReserveBytes`` — the
+    /// floor still covers the non-attention working set this estimate ignores.
+    public static func activationReserveBytes(for shape: ActivationReserveShape) -> UInt64 {
+        max(defaultActivationReserveBytes, peakPrefillScoreBytes(for: shape))
+    }
+
     // MARK: - Resolution (explicit → env → default)
 
     /// Cap fraction from explicit value, env `DARKBLOOM_MEM_CAP_FRACTION`
@@ -229,13 +404,21 @@ public enum UnifiedMemoryCap {
     }
 
     /// Activation reserve from explicit bytes, env
-    /// `DARKBLOOM_ACTIVATION_RESERVE_GB` (GB), or the default floor. A `<= 0` or
-    /// non-finite env value is treated as UNSET (→ the 3 GiB default floor): a
-    /// `0` reserve would remove the activation headroom the cap exists to
-    /// guarantee, so an operator can RAISE the reserve but not silently disable it
-    /// via env. An explicit programmatic value (tests) is honored as given.
+    /// `DARKBLOOM_ACTIVATION_RESERVE_GB` (GB), or — when the caller supplies the
+    /// slot's prefill `shape` — ``activationReserveBytes(for:)``, falling back
+    /// to the flat floor when it does not.
+    ///
+    /// A `<= 0` or non-finite env value is treated as UNSET (→ the parametric
+    /// value, else the floor): a `0` reserve would remove the activation
+    /// headroom the cap exists to guarantee, so an operator can RAISE the
+    /// reserve but not silently disable it via env. A env value that IS set
+    /// wins over the parametric estimate — the knob is the operator's explicit
+    /// override of provider policy, and it is how a bad estimate gets answered
+    /// in either direction. An explicit programmatic value (tests) is honored
+    /// as given.
     static func resolvedActivationReserveBytes(
         explicit: UInt64? = nil,
+        shape: ActivationReserveShape? = nil,
         env: [String: String] = ProcessInfo.processInfo.environment
     ) -> UInt64 {
         if let explicit { return explicit }
@@ -244,7 +427,8 @@ public enum UnifiedMemoryCap {
             let scaled = gb * 1_073_741_824
             return scaled >= uint64MaxAsDouble ? UInt64.max : UInt64(scaled)
         }
-        return defaultActivationReserveBytes
+        guard let shape else { return defaultActivationReserveBytes }
+        return activationReserveBytes(for: shape)
     }
 
     // MARK: - Helpers
@@ -272,6 +456,17 @@ public enum UnifiedMemoryCap {
         for v in values {
             let (sum, overflow) = total.addingReportingOverflow(v)
             total = overflow ? UInt64.max : sum
+        }
+        return total
+    }
+
+    private static func saturatingMultiply(_ values: UInt64...) -> UInt64 {
+        var total: UInt64 = 1
+        for v in values {
+            if v == 0 { return 0 }
+            let (product, overflow) = total.multipliedReportingOverflow(by: v)
+            if overflow { return UInt64.max }
+            total = product
         }
         return total
     }


### PR DESCRIPTION
Three coordinator/provider fixes to the memory and routing model. None of them need paged; all of them are needed *by* paged, and they independently unblock B=8 on contiguous.

## 1. The activation reserve was a constant, and the wrong one

`UnifiedMemoryCap` hardcoded a 3 GiB activation reserve regardless of prefill shape. The coordinator's mirror in `servability.go` hardcoded `servabilityActivationReserveGB = 3.0` separately — so a provider-side change could silently desynchronize the two.

The reserve is now a function of prefill shape on both sides.

```mermaid
flowchart LR
  subgraph Before
    A1[model load gate] --> B1["reserve = 3.0 GiB constant"]
    C1[coordinator cold estimate] --> D1["servabilityActivationReserveGB = 3.0 — separate literal"]
    B1 -.->|can desync silently| D1
  end
  subgraph After
    A2[model load gate] --> B2["reserve = f(prefill shape)"]
    C2[coordinator cold estimate] --> B2
  end
```

Downstream effect on a 48 GiB box with 31 GiB of weights serving 100k VLM: KV budget moves 9.200 → 5.906 GiB.

## 2. The decode load factor was fitted against a legacy proxy

`k` was fitted to a `sqrt(memory_bandwidth)` proxy rather than measured decode rates, because the Swift provider never sent a decode rate at all. It does now. Re-fitting against the engine's measured rates moves `k` 0.27 → 0.39 (MAPE 23.4% → 2.9%).

This makes the cap **tighter**, not looser — the B=8 threshold rises 39.3 → 50.1 tok/s. The plan expected re-fitting to unblock B=8; it moves the goalpost away. What actually unblocks it is the coordinator now inferring from real measurements.

## 3. A real solo measurement below the 5-sample floor was discarded

The trust floor required 5 samples before believing a solo rate, so a restart returned all 94 boxes to the no-samples state and fell straight through to the `sqrt(memory_bandwidth)` seed. A relaxed tier (≥1 sample) now sits between the trusted median and the seed. gemma-4 is dedicated, so the non-dedicated guard did not protect it.

Also updates `docs/architecture/operations/routing.md`, which documented a 3-step decode-rate fallback chain that is now 5 steps.

**Verified:** `go build ./...`, `go vet`, `gofmt` clean; registry suites green; goldens recomputed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/584"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787606601&installation_model_id=21733&pr_number=584&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F584&signature=610c82697b0c06cac5ecf6f990cf3a83eb5fbd3de4d7b0b79570750e820829e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->