### PR TITLE
feat(engine-v2): an explicit paged request refuses instead of degrading, and a refused sweep exits non-zero

### DIFF
--- a/docs/provider/quickstart.md
+++ b/docs/provider/quickstart.md
@@ -134,12 +134,16 @@ end = "08:00"
 - `backend.max_model_slots` — maximum resident models at once (default 3).
 - `backend.engine_v2_kv_backend` — KV-cache backend for the inference engine:
   `"auto"` (default — contiguous for every model), experimental `"paged"`,
-  or `"contiguous"`. Vision models always serve contiguous; models the
-  paged kernel cannot
-  serve fall back to contiguous automatically. Per-model overrides:
-  `engine_v2_kv_backend_by_model` (TOML table of model id → value). Fleet
-  kill switch: launch with `DARKBLOOM_CBV2_PAGED_KV=0` (survives restarts —
-  it is forwarded into the launchd service environment). An explicit paged
+  or `"contiguous"`. Vision models always serve contiguous. Under `"auto"`, a
+  model the paged kernel cannot serve falls back to contiguous automatically;
+  under an explicit `"paged"` the model FAILS to load instead (503, and the
+  coordinator reroutes), so a paged fleet can never silently serve contiguous.
+  Per-model overrides: `engine_v2_kv_backend_by_model` (TOML table of model
+  id → value). Fleet kill switch: launch with `DARKBLOOM_CBV2_PAGED_KV=0`
+  (survives restarts — it is forwarded into the launchd service
+  environment); the kill switch always falls back and never fails, so
+  pulling it on a paged fleet gives you contiguous service, not 503s. An
+  explicit paged
   model eagerly commits a separately capped physical pool derived from useful
   concurrent context demand, live memory, machine size, and Metal buffer
   limits; it never preallocates the full logical admission grant.

--- a/provider-swift/Sources/ProviderBenchmark/ThroughputSweep.swift
+++ b/provider-swift/Sources/ProviderBenchmark/ThroughputSweep.swift
@@ -128,6 +128,16 @@ public enum ThroughputSweep {
             hardware: hardware, efficiency: efficiency, derived: derived,
             kvBackend: kvBackend, resolvedBackends: decodeOutcome.resolvedBackends)
 
+        // Only when NOTHING ran. A failure alongside cells that did resolve is
+        // a partial result, not the story of the run, and must not be
+        // presented as one.
+        let constructionFailure = decodeOutcome.resolvedBackends.isEmpty
+            ? decodeOutcome.constructionFailure.map {
+                ThroughputSweepReport.DecodeConstructionFailure(
+                    kvBackendSelection: kvBackend.rawValue, reason: $0)
+            }
+            : nil
+
         return ThroughputSweepReport(
             modelID: modelID,
             modelPath: modelDirectory.path,
@@ -140,7 +150,8 @@ public enum ThroughputSweep {
             prefill: prefill,
             decode: decode,
             derived: derived,
-            notes: notes
+            notes: notes,
+            decodeConstructionFailure: constructionFailure
         )
     }
 
@@ -198,14 +209,21 @@ public enum ThroughputSweep {
     }
 
     /// Decode samples plus the KV backend the engine ACTUALLY built for those
-    /// cells. `.auto`/`.paged` are selections, not outcomes — paged degrades to
+    /// cells. `.auto` is a selection, not an outcome — it degrades to
     /// contiguous on kill switch, kernel preflight, or pool capacity, and a
-    /// release gate that cannot see the degradation silently measures the wrong
-    /// backend.
+    /// release gate that cannot see the degradation silently measures the
+    /// wrong backend. Since OPEN-9 an EXPLICIT `.paged` no longer degrades at
+    /// all: it refuses, every cell fails to construct, and `constructionFailure`
+    /// is the only record of why the curve is empty.
     private struct DecodeOutcome {
         var samples: [ThroughputSweepReport.DecodeSample] = []
-        /// Distinct resolved-backend descriptors, in first-seen order.
+        /// Distinct resolved-backend descriptors, in first-seen order. EMPTY
+        /// means no cell ever built an engine.
         var resolvedBackends: [String] = []
+        /// Last construction error seen, verbatim. Meaningful only when
+        /// `resolvedBackends` is empty — otherwise some cells did run and a
+        /// single failure is a partial result, not the story of the run.
+        var constructionFailure: String?
 
         /// Returns true when `descriptor` had not been seen before.
         @discardableResult
@@ -253,14 +271,19 @@ public enum ThroughputSweep {
 
         // Warm-up at B=1 with a short generation to compile decode kernels
         // (CBv2 compiled decode pays its cold start here, not in a sample).
-        await runDecodeBatch(
+        let warmUp = await runDecodeBatch(
             container: container, modelID: modelID, baseTokens: baseTokens,
             batchSize: 1, decodeTokens: 4, promptLen: promptLen, weightBytes: weightBytes,
             isVLM: isVLM, modelDirectory: modelDirectory, kvBackend: kvBackend)
+        // The warm-up is the FIRST cell to hit a refused paged selection, so
+        // it carries the reason even when the sized cells below fail
+        // identically. Keep it: an operator should not have to infer the
+        // cause from a curve of zeros.
+        outcome.constructionFailure = warmUp.constructionFailure
 
         for iteration in 1 ... repetitions {
             for batchSize in sizes {
-                let (totalTokens, maxElapsed, resolved) = await runDecodeBatch(
+                let (totalTokens, maxElapsed, resolved, failure) = await runDecodeBatch(
                     container: container, modelID: modelID, baseTokens: baseTokens,
                     batchSize: batchSize, decodeTokens: genTokens, promptLen: promptLen,
                     weightBytes: weightBytes, isVLM: isVLM, modelDirectory: modelDirectory,
@@ -268,6 +291,7 @@ public enum ThroughputSweep {
                 if outcome.record(resolved), let resolved {
                     log("  engine resolved kv backend: \(resolved)")
                 }
+                if let failure { outcome.constructionFailure = failure }
                 let secs = seconds(maxElapsed)
                 let aggregate = secs > 0 ? Double(totalTokens) / secs : 0
                 let perSeq = aggregate / Double(batchSize)
@@ -303,7 +327,10 @@ public enum ThroughputSweep {
         isVLM: Bool,
         modelDirectory: URL?,
         kvBackend: EngineV2KVBackendSelection
-    ) async -> (totalTokens: Int, maxElapsed: Duration, resolvedBackend: String?) {
+    ) async -> (
+        totalTokens: Int, maxElapsed: Duration, resolvedBackend: String?,
+        constructionFailure: String?
+    ) {
         // The engine's KV admission ceiling: the same unified-memory budget a
         // single-model provider slot would be granted. Far above what these
         // short rows need — admission never binds in the sweep.
@@ -344,8 +371,12 @@ public enum ThroughputSweep {
                     } ?? build.kvBackendKind.rawValue)
             }
         } catch {
+            // Since OPEN-9 this is the path an explicit `--kv-backend paged`
+            // takes when paged cannot be served: a refusal, not a degrade.
+            // Return the reason so the report and the process exit status can
+            // both name it instead of showing a bare curve of zeros.
             log("  engine construction failed: \(error)")
-            return (0, .zero, nil)
+            return (0, .zero, nil, "\(error)")
         }
         let engine = parts.engine
         let eosTokenIds = parts.eosTokenIds
@@ -401,7 +432,7 @@ public enum ThroughputSweep {
         await engine.shutdown()
         return (
             totalTokens: result.0, maxElapsed: result.1,
-            resolvedBackend: parts.resolvedBackend)
+            resolvedBackend: parts.resolvedBackend, constructionFailure: nil)
     }
 
     // MARK: - Helpers

--- a/provider-swift/Sources/ProviderBenchmark/ThroughputSweep.swift
+++ b/provider-swift/Sources/ProviderBenchmark/ThroughputSweep.swift
@@ -12,9 +12,10 @@ import MLXVLM
 /// same `LLMModelFactory` + `LocalTokenizerLoader` the serve path uses, runs
 /// prefill through `model.callAsFunction(_:cache:)`, and runs decode through
 /// the PRODUCTION ContinuousBatchingV2 engine, constructed via
-/// `EngineV2Factory.makeProductionEngine` — the exact one-engine entry point
-/// every serving slot uses as of v0.7.5. It does **not** reimplement any
-/// inference numerics; it only drives the engine and times it.
+/// `EngineV2Factory.makeProductionBuild` — the one-engine entry point every
+/// serving slot uses (`makeProductionEngine` is its thin wrapper, which
+/// discards the resolved-backend metadata this report needs). It does **not**
+/// reimplement any inference numerics; it only drives the engine and times it.
 ///
 /// The decode-vs-batch curve is the point: a memory-bandwidth-bound dense model
 /// amortizes one weight read across the batch and scales ~linearly, while a
@@ -45,6 +46,12 @@ public enum ThroughputSweep {
     /// `DecodeSample`, so callers can take a median instead of trusting a single
     /// noisy GPU measurement. The `derived` block is always computed from the
     /// per-batch medians.
+    ///
+    /// `kvBackend` is the operator-facing selection handed to the production
+    /// factory. `.auto` resolves to contiguous today, so it is the default here
+    /// too — a run with no new flags measures exactly what it measured before.
+    /// A `.paged` selection can still degrade to contiguous, so the report
+    /// notes carry the backend the engine ACTUALLY built with.
     public static func run(
         modelID: String,
         modelDirectory: URL,
@@ -53,6 +60,7 @@ public enum ThroughputSweep {
         decodeTokens: Int = defaultDecodeTokens,
         decodePromptTokens: Int = defaultDecodePromptTokens,
         decodeIterations: Int = defaultDecodeIterations,
+        kvBackend: EngineV2KVBackendSelection = .auto,
         hardware: HardwareInfo,
         efficiency: Double = DecodeBandwidthModel.defaultBandwidthEfficiency
     ) async throws -> ThroughputSweepReport {
@@ -90,7 +98,7 @@ public enum ThroughputSweep {
 
         let prefill = await measurePrefill(
             container: container, baseTokens: baseTokens, lengths: promptLengths)
-        let decode = await measureDecode(
+        let decodeOutcome = await measureDecode(
             container: container,
             modelID: modelID,
             baseTokens: baseTokens,
@@ -100,8 +108,10 @@ public enum ThroughputSweep {
             iterations: decodeIterations,
             weightBytes: facts.weightBytes,
             isVLM: isVLM,
-            modelDirectory: modelDirectory
+            modelDirectory: modelDirectory,
+            kvBackend: kvBackend
         )
+        let decode = decodeOutcome.samples
 
         // One median sample per batch size: the B=1 implied read and the
         // batch-scaling linearity must not hang off a single measurement.
@@ -114,7 +124,9 @@ public enum ThroughputSweep {
             efficiency: efficiency
         )
 
-        let notes = makeNotes(hardware: hardware, efficiency: efficiency, derived: derived)
+        let notes = makeNotes(
+            hardware: hardware, efficiency: efficiency, derived: derived,
+            kvBackend: kvBackend, resolvedBackends: decodeOutcome.resolvedBackends)
 
         return ThroughputSweepReport(
             modelID: modelID,
@@ -185,6 +197,25 @@ public enum ThroughputSweep {
         let elapsed: Duration
     }
 
+    /// Decode samples plus the KV backend the engine ACTUALLY built for those
+    /// cells. `.auto`/`.paged` are selections, not outcomes — paged degrades to
+    /// contiguous on kill switch, kernel preflight, or pool capacity, and a
+    /// release gate that cannot see the degradation silently measures the wrong
+    /// backend.
+    private struct DecodeOutcome {
+        var samples: [ThroughputSweepReport.DecodeSample] = []
+        /// Distinct resolved-backend descriptors, in first-seen order.
+        var resolvedBackends: [String] = []
+
+        /// Returns true when `descriptor` had not been seen before.
+        @discardableResult
+        mutating func record(_ descriptor: String?) -> Bool {
+            guard let descriptor, !resolvedBackends.contains(descriptor) else { return false }
+            resolvedBackends.append(descriptor)
+            return true
+        }
+    }
+
     /// For each batch size B, build a fresh `BatchedEngine`, submit B greedy
     /// requests (each with a distinct rotated prompt so MoE routing differs
     /// per row), drop the first emitted token per row to exclude prefill, and
@@ -208,34 +239,40 @@ public enum ThroughputSweep {
         iterations: Int,
         weightBytes: Int,
         isVLM: Bool,
-        modelDirectory: URL?
-    ) async -> [ThroughputSweepReport.DecodeSample] {
+        modelDirectory: URL?,
+        kvBackend: EngineV2KVBackendSelection
+    ) async -> DecodeOutcome {
         let sizes = batchSizes.filter { $0 > 0 }.sorted()
-        guard !sizes.isEmpty else { return [] }
+        guard !sizes.isEmpty else { return DecodeOutcome() }
         let promptLen = max(1, decodePromptTokens)
         let genTokens = max(1, decodeTokens)
         let repetitions = max(1, iterations)
-        log("decode sweep: batch sizes \(sizes), \(genTokens) tok/seq, prompt \(promptLen) tok/seq, \(repetitions) repetition(s)")
+        log("decode sweep: batch sizes \(sizes), \(genTokens) tok/seq, prompt \(promptLen) tok/seq, \(repetitions) repetition(s), kv backend selection \(kvBackend.rawValue)")
+
+        var outcome = DecodeOutcome()
 
         // Warm-up at B=1 with a short generation to compile decode kernels
         // (CBv2 compiled decode pays its cold start here, not in a sample).
         await runDecodeBatch(
             container: container, modelID: modelID, baseTokens: baseTokens,
             batchSize: 1, decodeTokens: 4, promptLen: promptLen, weightBytes: weightBytes,
-            isVLM: isVLM, modelDirectory: modelDirectory)
+            isVLM: isVLM, modelDirectory: modelDirectory, kvBackend: kvBackend)
 
-        var samples: [ThroughputSweepReport.DecodeSample] = []
         for iteration in 1 ... repetitions {
             for batchSize in sizes {
-                let (totalTokens, maxElapsed) = await runDecodeBatch(
+                let (totalTokens, maxElapsed, resolved) = await runDecodeBatch(
                     container: container, modelID: modelID, baseTokens: baseTokens,
                     batchSize: batchSize, decodeTokens: genTokens, promptLen: promptLen,
-                    weightBytes: weightBytes, isVLM: isVLM, modelDirectory: modelDirectory)
+                    weightBytes: weightBytes, isVLM: isVLM, modelDirectory: modelDirectory,
+                    kvBackend: kvBackend)
+                if outcome.record(resolved), let resolved {
+                    log("  engine resolved kv backend: \(resolved)")
+                }
                 let secs = seconds(maxElapsed)
                 let aggregate = secs > 0 ? Double(totalTokens) / secs : 0
                 let perSeq = aggregate / Double(batchSize)
                 log("  [\(iteration)/\(repetitions)] B=\(batchSize): aggregate \(String(format: "%.1f", aggregate)) tok/s, per-seq \(String(format: "%.1f", perSeq)) tok/s")
-                samples.append(ThroughputSweepReport.DecodeSample(
+                outcome.samples.append(ThroughputSweepReport.DecodeSample(
                     batchSize: batchSize,
                     decodeTokensPerSequence: genTokens,
                     aggregateTokensPerSecond: aggregate,
@@ -244,14 +281,16 @@ public enum ThroughputSweep {
                 ))
             }
         }
-        return samples
+        return outcome
     }
 
-    /// Build the production CBv2 engine (`EngineV2Factory.makeProductionEngine`
+    /// Build the production CBv2 engine (`EngineV2Factory.makeProductionBuild`
     /// — the same construction every serving slot uses), run `batchSize`
     /// greedy rows to completion, shut the engine down, and return
-    /// `(totalDecodedTokens, maxRowElapsed)` where the clock starts after each
-    /// row's first token (prefill excluded).
+    /// `(totalDecodedTokens, maxRowElapsed, resolvedBackend)` where the clock
+    /// starts after each row's first token (prefill excluded) and
+    /// `resolvedBackend` names the KV backend the factory actually chose
+    /// (nil when construction failed).
     @discardableResult
     private static func runDecodeBatch(
         container: ModelContainer,
@@ -262,8 +301,9 @@ public enum ThroughputSweep {
         promptLen: Int,
         weightBytes: Int,
         isVLM: Bool,
-        modelDirectory: URL?
-    ) async -> (totalTokens: Int, maxElapsed: Duration) {
+        modelDirectory: URL?,
+        kvBackend: EngineV2KVBackendSelection
+    ) async -> (totalTokens: Int, maxElapsed: Duration, resolvedBackend: String?) {
         // The engine's KV admission ceiling: the same unified-memory budget a
         // single-model provider slot would be granted. Far above what these
         // short rows need — admission never binds in the sweep.
@@ -276,6 +316,8 @@ public enum ThroughputSweep {
         struct EngineParts: @unchecked Sendable {
             let engine: any CBv2Engine
             let eosTokenIds: Set<Int>
+            /// The backend the factory resolved to, with any fallback reason.
+            let resolvedBackend: String
         }
         let parts: EngineParts
         do {
@@ -284,17 +326,26 @@ public enum ThroughputSweep {
                 // weight-sharing text extraction, exactly like a slot build.
                 let servingModel = try EngineV2Factory.benchmarkServingModel(
                     model: ctx.model, isVLM: isVLM, modelDirectory: modelDirectory)
+                // `makeProductionBuild` is the construction
+                // `makeProductionEngine` wraps, and additionally hands back the
+                // backend kind the engine actually resolved to — the fact a
+                // paged gate run has to record.
+                let build = try EngineV2Factory.makeProductionBuild(
+                    model: servingModel,
+                    tokenizer: ctx.tokenizer,
+                    kvBytesCapacity: kvCapacity,
+                    maxConcurrentRequests: max(batchSize, 1),
+                    kvBackend: kvBackend)
                 return EngineParts(
-                    engine: try EngineV2Factory.makeProductionEngine(
-                        model: servingModel,
-                        tokenizer: ctx.tokenizer,
-                        kvBytesCapacity: kvCapacity,
-                        maxConcurrentRequests: max(batchSize, 1)),
-                    eosTokenIds: ctx.configuration.eosTokenIds)
+                    engine: build.engine,
+                    eosTokenIds: ctx.configuration.eosTokenIds,
+                    resolvedBackend: build.kvBackendFallbackReason.map {
+                        "\(build.kvBackendKind.rawValue) (fallback: \($0))"
+                    } ?? build.kvBackendKind.rawValue)
             }
         } catch {
             log("  engine construction failed: \(error)")
-            return (0, .zero)
+            return (0, .zero, nil)
         }
         let engine = parts.engine
         let eosTokenIds = parts.eosTokenIds
@@ -348,7 +399,9 @@ public enum ThroughputSweep {
         }
 
         await engine.shutdown()
-        return result
+        return (
+            totalTokens: result.0, maxElapsed: result.1,
+            resolvedBackend: parts.resolvedBackend)
     }
 
     // MARK: - Helpers
@@ -443,9 +496,17 @@ public enum ThroughputSweep {
     private static func makeNotes(
         hardware: HardwareInfo,
         efficiency: Double,
-        derived: ThroughputSweepReport.Derived
+        derived: ThroughputSweepReport.Derived,
+        kvBackend: EngineV2KVBackendSelection,
+        resolvedBackends: [String]
     ) -> [String] {
         var notes: [String] = []
+        notes.append(
+            "kv backend: selection=\(kvBackend.rawValue), resolved="
+                + (resolvedBackends.isEmpty
+                    ? "n/a (no decode cells ran)"
+                    : resolvedBackends.joined(separator: " + "))
+                + " — decode numbers describe the RESOLVED backend, not the selection.")
         notes.append(
             "implied per-token read assumes \(Int(efficiency * 100))% of \(hardware.memoryBandwidthGbs) GB/s peak bandwidth.")
         notes.append(

--- a/provider-swift/Sources/ProviderBenchmark/ThroughputSweepReport.swift
+++ b/provider-swift/Sources/ProviderBenchmark/ThroughputSweepReport.swift
@@ -10,7 +10,8 @@ import Foundation
 public struct ThroughputSweepReport: Codable, Sendable {
 
     /// Bumped when the JSON shape changes so downstream parsers can gate.
-    public static let currentSchemaVersion = 1
+    /// 2 adds the optional `decodeConstructionFailure` block.
+    public static let currentSchemaVersion = 2
 
     public struct Hardware: Codable, Sendable {
         public let chipName: String
@@ -124,6 +125,28 @@ public struct ThroughputSweepReport: Codable, Sendable {
         }
     }
 
+    /// Present ONLY when engine construction failed for EVERY decode cell,
+    /// so the sweep measured nothing at all. The samples are still emitted
+    /// (all zero) and `notes` still records the selection, but a reader —
+    /// human or script — needs the CAUSE, not just an empty curve.
+    ///
+    /// The case this exists for: `--kv-backend paged` on a box where paged
+    /// cannot be served. Since OPEN-9 that is a hard refusal rather than a
+    /// silent degrade to contiguous, so the run legitimately produces no
+    /// numbers, and `darkbloom benchmark` exits non-zero off this field
+    /// rather than reporting success with an empty curve.
+    public struct DecodeConstructionFailure: Codable, Sendable {
+        /// The `--kv-backend` selection the run was launched with.
+        public let kvBackendSelection: String
+        /// The construction error, verbatim, from the last cell that failed.
+        public let reason: String
+
+        public init(kvBackendSelection: String, reason: String) {
+            self.kvBackendSelection = kvBackendSelection
+            self.reason = reason
+        }
+    }
+
     public let schemaVersion: Int
     public let modelID: String
     public let modelPath: String
@@ -132,6 +155,10 @@ public struct ThroughputSweepReport: Codable, Sendable {
     public let decode: [DecodeSample]
     public let derived: Derived
     public let notes: [String]
+    /// Non-nil only when no decode cell could be constructed. Omitted from
+    /// the JSON entirely on a healthy run, so successful reports keep their
+    /// existing shape.
+    public let decodeConstructionFailure: DecodeConstructionFailure?
 
     public init(
         schemaVersion: Int = ThroughputSweepReport.currentSchemaVersion,
@@ -141,7 +168,8 @@ public struct ThroughputSweepReport: Codable, Sendable {
         prefill: [PrefillSample],
         decode: [DecodeSample],
         derived: Derived,
-        notes: [String]
+        notes: [String],
+        decodeConstructionFailure: DecodeConstructionFailure? = nil
     ) {
         self.schemaVersion = schemaVersion
         self.modelID = modelID
@@ -151,6 +179,7 @@ public struct ThroughputSweepReport: Codable, Sendable {
         self.decode = decode
         self.derived = derived
         self.notes = notes
+        self.decodeConstructionFailure = decodeConstructionFailure
     }
 
     // MARK: - Derived assembly

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Config.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Config.swift
@@ -88,6 +88,16 @@ public enum EngineV2RefusalReason: String, Sendable {
     /// A load-time KV re-slice would push some co-resident slot below the
     /// minimum serviceable grant (`EngineV2KVSizing` floor).
     case resliceFloor = "reslice_floor"
+    /// An EXPLICITLY requested paged backend could not be served
+    /// (`EngineV2ProductionError.pagedUnavailable`): kernel preflight,
+    /// physical-capacity planning, or `PagedKVBackend` construction. Kept
+    /// SEPARATE from `engineInitFailed` on purpose — with no canary fleet
+    /// this is the aggregate signal that a paged rollout is regressing,
+    /// and folding it into the catch-all would make it indistinguishable
+    /// from an unrelated bad model load. An `.auto` selection never lands
+    /// here; it degrades to contiguous and reports INFO
+    /// `engine_v2_kv_backend` with a fallback reason instead.
+    case pagedBackendUnavailable = "paged_backend_unavailable"
     /// Any other engine-construction failure.
     case engineInitFailed = "engine_init_failed"
 
@@ -98,6 +108,8 @@ public enum EngineV2RefusalReason: String, Sendable {
             return .noKVHeadroom
         case EngineV2ProductionError.unsupportedModel:
             return .unsupportedModel
+        case EngineV2ProductionError.pagedUnavailable:
+            return .pagedBackendUnavailable
         case is EngineV2VLMTextExtractionError:
             return .vlmExtractionFailed
         default:
@@ -243,34 +255,6 @@ public enum EngineV2Factory {
             "backend": .string("engine_v2"),
             "model": .string(modelId),
             "reason": .string(reason),
-        ])
-        if let emitTelemetry {
-            emitTelemetry(event)
-        } else {
-            TelemetryClient.shared.emit(event)
-        }
-    }
-
-    /// WARN `engine_health` event when a model configured for `kv_quant` is
-    /// served through engine_v2, which does NOT support KV-quant and uses
-    /// unquantized native-float caches (`makeProductionEngine` builds
-    /// `CBv2LayerCache`, never a quantized cache). Surfacing this keeps the operator from assuming
-    /// the memory savings apply. Allowlisted fields only.
-    static func emitKVQuantUnsupportedTelemetry(
-        modelId: String,
-        emitTelemetry: (@Sendable (TelemetryEvent) -> Void)?
-    ) {
-        var event = TelemetryEvent(
-            source: .provider,
-            severity: .warn,
-            kind: .engineHealth,
-            message: "engine_v2: kv_quant not supported — using unquantized native KV"
-        )
-        event.fields = TelemetryFieldFilter.filter([
-            "component": .string("engine"),
-            "operation": .string("engine_v2_kv_quant_unsupported"),
-            "backend": .string("engine_v2"),
-            "model": .string(modelId),
         ])
         if let emitTelemetry {
             emitTelemetry(event)

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Factory+Production.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Factory+Production.swift
@@ -27,6 +27,11 @@
 // `engine_health` telemetry (`operation=engine_v2_refusal`) + rethrow —
 // the load fails with a 503 and the coordinator reroutes. There is no
 // legacy engine to fall back to.
+//
+// An EXPLICITLY requested paged backend that cannot be built takes that
+// same route: `pagedUnavailable` rather than a quiet contiguous engine,
+// so a paged benchmark or e2e run can never report paged and measure
+// contiguous. `.auto` and the fleet kill switch still degrade.
 
 import Foundation
 import MLX
@@ -45,6 +50,15 @@ enum EngineV2ProductionError: Error, CustomStringConvertible {
     /// admitted with a zero ceiling would reject every request, so the
     /// load is refused (503; the coordinator reroutes).
     case noKVHeadroom
+    /// An EXPLICIT paged request could not be served: `engine_v2_kv_backend
+    /// = "paged"`, a per-model override in `engine_v2_kv_backend_by_model`,
+    /// or the benchmark's `--kv-backend paged`. Those are claims someone
+    /// VERIFIES against — with no canary fleet, benchmarks and e2e are the
+    /// only safety net, so degrading a named paged run to contiguous would
+    /// report paged while measuring contiguous. `.auto` still degrades.
+    /// Carries the underlying reason (kernel preflight, physical-capacity
+    /// planning, or pool construction) verbatim.
+    case pagedUnavailable(String)
 
     var description: String {
         switch self {
@@ -52,6 +66,9 @@ enum EngineV2ProductionError: Error, CustomStringConvertible {
             return "engine_v2: model type \(type) has no CBv2 adapter"
         case .noKVHeadroom:
             return "engine_v2: no KV byte headroom under the unified-memory cap"
+        case .pagedUnavailable(let reason):
+            return "engine_v2: paged KV backend explicitly requested but "
+                + "unavailable — \(reason)"
         }
     }
 }
@@ -187,9 +204,11 @@ extension EngineV2Factory {
     public struct ProductionBuild {
         public let engine: any CBv2Engine
         public let kvBackendKind: EngineV2KVBackendKind
-        /// Non-nil when a paged selection fell back to contiguous (fleet
-        /// kill switch, kernel ineligibility, pool-construction capacity).
-        /// A fallback is a supported degradation — INFO, never a refusal.
+        /// Non-nil when a paged selection DEGRADED to contiguous: the fleet
+        /// kill switch always, and preflight/capacity/eligibility failures
+        /// under `.auto`. A degrade is supported — INFO, never a refusal.
+        /// An EXPLICIT `.paged` selection never degrades for a failure; it
+        /// throws `EngineV2ProductionError.pagedUnavailable`.
         public let kvBackendFallbackReason: String?
     }
 
@@ -199,6 +218,12 @@ extension EngineV2Factory {
         let layerKinds: [CBv2LayerKind]
         let kind: EngineV2KVBackendKind
         let fallbackReason: String?
+        /// The ONE scheduler config of this build. Constructed in
+        /// `prepareProductionBackend`, where it sizes the paged pool's
+        /// `maxPrefillChunk`, and carried here so `assembleProductionBuild`
+        /// hands the ENGINE that same instance instead of an unrelated
+        /// twin that happened to agree on the memberwise defaults.
+        let schedulerConfig: CBv2SchedulerConfig
 
         private let lock = NSLock()
         private let modelIdentity: ObjectIdentifier
@@ -213,7 +238,8 @@ extension EngineV2Factory {
             backend: CBv2KVBackend,
             caches: [any CBv2AttendingLayerCache],
             kind: EngineV2KVBackendKind,
-            fallbackReason: String?
+            fallbackReason: String?,
+            schedulerConfig: CBv2SchedulerConfig
         ) {
             self.modelIdentity = ObjectIdentifier(model)
             self.maxConcurrentRequests = max(1, maxConcurrentRequests)
@@ -222,6 +248,7 @@ extension EngineV2Factory {
             self.caches = caches
             self.kind = kind
             self.fallbackReason = fallbackReason
+            self.schedulerConfig = schedulerConfig
         }
 
         func consume(
@@ -253,13 +280,16 @@ extension EngineV2Factory {
     ///
     /// KV-backend gate (see `EngineV2KVBackendPolicy` for the full layer
     /// order): the caller passes the operator selection with slot vetoes
-    /// (VLM, kv-quant) already applied; `.auto` is always contiguous.
-    /// Paged remains an explicit experimental selection.
+    /// (VLM) already applied; `.auto` is always contiguous. Paged remains
+    /// an explicit experimental selection.
     /// The `DARKBLOOM_CBV2_PAGED_KV=0` fleet kill switch is enforced at
     /// THIS deepest layer so no call path (benchmarks included) bypasses
-    /// it. Paged construction throwing `CBv2KVError` (kernel ineligibility,
-    /// pool capacity) falls back to contiguous — a paged-ineligible model
-    /// must load and serve, never refuse.
+    /// it, and it DEGRADES rather than refuses — an operator override is
+    /// not a failure. Everything that IS a failure (kernel preflight,
+    /// physical-capacity planning, `PagedKVBackend` throwing `CBv2KVError`)
+    /// degrades to contiguous under `.auto` but THROWS
+    /// `EngineV2ProductionError.pagedUnavailable` under an explicit
+    /// `.paged`, so a paged run can never silently serve contiguous.
     public static func makeProductionBuild(
         model: any LanguageModel,
         tokenizer: any MLXLMCommon.Tokenizer,
@@ -346,6 +376,17 @@ extension EngineV2Factory {
         case .auto: resolvedKind = .contiguous
         }
         var fallbackReason: String?
+        // DEGRADE, not refuse — even on an explicit paged selection. This
+        // is the branch that must never be collapsed into the failure
+        // handling below: the kill switch says "DO NOT do what you asked",
+        // a preflight/capacity failure says "we CANNOT do what you asked".
+        // Only the second is a broken promise worth a 503. An operator who
+        // sets DARKBLOOM_CBV2_PAGED_KV=0 on a fleet configured
+        // `engine_v2_kv_backend = "paged"` is asking for contiguous
+        // SERVICE, not for every slot to start failing — a kill switch
+        // that refuses is not a kill switch. `killSwitchForcesContiguous`
+        // in `EngineV2KVBackendGateTests` is the only thing pinning this
+        // apart from the refusal cases; keep it a degrade assertion.
         if resolvedKind == .paged,
             EngineV2KVBackendPolicy.killSwitchDisabled(environment: environment)
         {
@@ -353,6 +394,34 @@ extension EngineV2Factory {
             fallbackReason = "kill_switch"
         }
 
+        // Paged FAILED: we CANNOT do what was asked (kernel preflight,
+        // physical-capacity planning, or pool construction) — the other
+        // half of the distinction drawn at the kill switch above. The
+        // degrade-or-refuse rule itself lives in
+        // `EngineV2KVBackendPolicy.degradesPagedFailure`, next to the
+        // other four selection layers and unit-testable without building
+        // an engine; note the degrade branch is currently reachable only
+        // once `.auto` starts resolving paged, since today it short-
+        // circuits to contiguous before any of this runs.
+        //
+        // The refusal is a catchable throw, never a trap: the slot factory
+        // maps it to ERROR `engine_v2_refusal` (reason
+        // `paged_backend_unavailable`) + 503 and the coordinator reroutes;
+        // the benchmark logs the cell as failed. Slot vetoes (VLM) resolve
+        // BEFORE this call, so a `.paged` arriving here is a request
+        // nothing has excused.
+        func degradeOrRefuse(_ reason: String) throws -> String {
+            guard EngineV2KVBackendPolicy.degradesPagedFailure(selection: kvBackend)
+            else {
+                throw EngineV2ProductionError.pagedUnavailable(reason)
+            }
+            return reason
+        }
+
+        // ONE scheduler config for the whole build: this instance sizes the
+        // paged pool's `maxPrefillChunk` below AND is the instance the
+        // engine runs on — `assembleProductionBuild` reads it back off the
+        // preparation and sets only `enablePrefixCache`.
         let schedulerConfig = CBv2SchedulerConfig(
             maxConcurrentRequests: max(1, maxConcurrentRequests))
 
@@ -369,7 +438,8 @@ extension EngineV2Factory {
                 backend: backend,
                 caches: caches,
                 kind: .contiguous,
-                fallbackReason: fallbackReason)
+                fallbackReason: fallbackReason,
+                schedulerConfig: schedulerConfig)
         }
 
         if resolvedKind == .paged {
@@ -381,7 +451,7 @@ extension EngineV2Factory {
                 }
             } catch {
                 resolvedKind = .contiguous
-                fallbackReason = "kernel_preflight: \(error)"
+                fallbackReason = try degradeOrRefuse("kernel_preflight: \(error)")
             }
         }
 
@@ -400,18 +470,23 @@ extension EngineV2Factory {
                     maxBufferLength: maxBufferLength))
             switch decision {
             case .contiguous(let reason):
-                fallbackReason = reason
+                fallbackReason = try degradeOrRefuse(reason)
             case .paged(let plan):
                 do {
                     let paged = try PagedKVBackend(
                         layerKinds: layerKinds,
                         config: PagedKVPoolConfig(
                             capacityBytes: plan.capacityBytes,
-                            // LOCKSTEP: a windowed-layer update larger than the
-                            // ring's provision traps the process
-                            // (PagedSequenceKV precondition) — size the pool to
-                            // the scheduler's REAL chunk, never a parallel
-                            // constant.
+                            // LOCKSTEP: a windowed-layer update larger than
+                            // the ring's provision traps the PROCESS
+                            // (`PagedSequenceKV` precondition), so the pool
+                            // must be sized from the chunk the engine
+                            // actually schedules. `schedulerConfig` IS that
+                            // instance: it is carried on the preparation and
+                            // `assembleProductionBuild` hands the very same
+                            // value to `EngineV2`, copying it only to set
+                            // `enablePrefixCache`. There is no second config
+                            // left to drift from.
                             maxPrefillChunk: schedulerConfig.prefillChunkSize,
                             nominalMaxSequenceLength: max(
                                 1, maxContextLength ?? 8192),
@@ -429,17 +504,21 @@ extension EngineV2Factory {
                         backend: paged,
                         caches: caches,
                         kind: .paged,
-                        fallbackReason: nil)
+                        fallbackReason: nil,
+                        schedulerConfig: schedulerConfig)
                 } catch let error as CBv2KVError {
-                    // Paged ineligibility/capacity is a supported degradation:
-                    // fall back to the contiguous backend (INFO telemetry at the
-                    // bridge — never the engine_v2_refusal path).
+                    // Paged ineligibility/capacity under `.auto` is a
+                    // supported degradation: fall back to the contiguous
+                    // backend (INFO telemetry at the bridge — never the
+                    // engine_v2_refusal path). Under an explicit `.paged`,
+                    // `degradeOrRefuse` rethrows it as `pagedUnavailable`.
                     switch error {
                     case .backendIneligible(let reason):
-                        fallbackReason = "ineligible: \(reason)"
+                        fallbackReason = try degradeOrRefuse("ineligible: \(reason)")
                     case .capacityExhausted(let needed, let available):
-                        fallbackReason =
-                            "pool_construction_capacity: needed \(needed), available \(available)"
+                        fallbackReason = try degradeOrRefuse(
+                            "pool_construction_capacity: needed \(needed), "
+                                + "available \(available)")
                     }
                 }
             }
@@ -469,7 +548,9 @@ extension EngineV2Factory {
     }
 
     /// Final engine assembly over an already resolved backend. This method has
-    /// no backend fallback path, so its cache capability cannot drift.
+    /// no backend fallback path, so its cache capability cannot drift, and it
+    /// builds no scheduler config of its own — it runs the engine on the very
+    /// instance `prepareProductionBackend` sized the paged pool against.
     static func assembleProductionBuild(
         model: any LanguageModel,
         tokenizer: any MLXLMCommon.Tokenizer,
@@ -482,9 +563,16 @@ extension EngineV2Factory {
         let (backend, caches) = try preparedBackend.consume(
             model: model,
             maxConcurrentRequests: maxConcurrentRequests)
-        let schedulerConfig = CBv2SchedulerConfig(
-            maxConcurrentRequests: max(1, maxConcurrentRequests),
-            enablePrefixCache: prefixCache != nil)
+        // The ONE config, read back off the preparation. `consume` has
+        // already refused a `maxConcurrentRequests` that differs from the
+        // prepared one, so the only field this phase may decide is
+        // `enablePrefixCache` — SSD cache construction deliberately runs
+        // AFTER backend preparation, because the cache's replay capability
+        // follows the backend that will actually serve. Everything else,
+        // `prefillChunkSize` above all, reaches the engine byte-identical
+        // to what the paged pool's `maxPrefillChunk` was sized from.
+        var schedulerConfig = preparedBackend.schedulerConfig
+        schedulerConfig.enablePrefixCache = prefixCache != nil
         return ProductionBuild(
             engine: makeEngineV2(
                 model: model,

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2KVBackendPolicy.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2KVBackendPolicy.swift
@@ -12,11 +12,14 @@
 //      overrides in `engine_v2_kv_backend_by_model`. Unrecognized values
 //      WARN and fall back to "auto" — safe by construction because every
 //      auto path still passes the vetoes below.
-//   2. Slot vetoes (`EngineV2SlotFactory`): VLM slots and `kv_quant`
-//      configs force contiguous. The paged cache cannot bind multimodal
-//      span masks (vision requests would 4xx at submit with
-//      `CBv2MultimodalError.unsupportedBackend`) and serves fp16 pages
-//      only.
+//   2. Slot veto (`EngineV2SlotFactory`): VLM slots force contiguous —
+//      the paged cache cannot bind multimodal span masks, so vision
+//      requests would 4xx at submit with
+//      `CBv2MultimodalError.unsupportedBackend`. A veto is POLICY, not
+//      failure, so it stays silent even under an explicit "paged"
+//      selection; only layer 5 refuses. This layer is collapsing toward
+//      the identity function — the kv-quant veto went with the feature,
+//      and the VLM veto lifts when span masks land.
 //   3. Fleet kill switch: `DARKBLOOM_CBV2_PAGED_KV=0` forces contiguous
 //      everywhere, enforced at engine construction (the deepest layer) so
 //      no call path can bypass it. Forwarded through the launchd plist
@@ -26,9 +29,15 @@
 //      Paged is experimental and requires the explicit "paged" selection.
 //      This is intentionally not a family table: adding a future model
 //      family cannot silently turn a stale/default config into paged.
-//   5. Eligibility fallback: `PagedKVBackend` construction throwing
-//      `backendIneligible` falls back to contiguous — a paged-ineligible
-//      model must load and serve, never refuse.
+//   5. Failure handling, and it depends on WHO asked. Kernel preflight,
+//      physical-capacity planning, and `PagedKVBackend` construction can
+//      each fail. Under "auto" they degrade to contiguous — a
+//      paged-ineligible model must still load and serve. Under an
+//      EXPLICIT "paged" they THROW
+//      (`EngineV2ProductionError.pagedUnavailable`): with no canary
+//      fleet, benchmarks and e2e ARE the safety net, and a silent degrade
+//      makes a run report paged while measuring contiguous. The layer-3
+//      kill switch is an override, not a failure, and always degrades.
 
 import Foundation
 
@@ -42,8 +51,8 @@ public enum EngineV2KVBackendKind: String, Sendable, Equatable {
 public enum EngineV2KVBackendSelection: String, Sendable, Equatable, CaseIterable {
     /// Production default: contiguous for every current and future model.
     case auto
-    /// Force paged where structurally possible (VLM/kv-quant slots and
-    /// kernel-ineligible models still fall back to contiguous).
+    /// Force paged. VLM slots still resolve contiguous (slot veto), but a
+    /// paged FAILURE refuses instead of degrading — see layer 5.
     case paged
     /// Force contiguous.
     case contiguous
@@ -87,24 +96,52 @@ public enum EngineV2KVBackendPolicy {
     }
 
     /// Slot-veto layer: force contiguous for slots the paged cache cannot
-    /// serve. VLM slots — the paged cache cannot bind multimodal span
-    /// masks, so media requests would 4xx at submit on an otherwise
-    /// paged-ELIGIBLE model (gemma-4's shapes construct fine; only vision
-    /// traffic breaks, which is why eligibility fallback alone is not
-    /// enough). kv-quant intent — the pool serves fp16 pages only.
+    /// serve. Today that is VLM alone — the paged cache cannot bind
+    /// multimodal span masks, so media requests would 4xx at submit on an
+    /// otherwise paged-ELIGIBLE model (gemma-4's shapes construct fine;
+    /// only vision traffic breaks, which is why layer 5 alone is not
+    /// enough).
+    ///
+    /// A veto is POLICY ("we choose not to"), not failure ("we cannot"),
+    /// so it is SILENT: it forces contiguous even for an explicit paged
+    /// selection rather than throwing `pagedUnavailable`.
+    ///
+    /// Collapsing toward the identity function. The kv-quant veto went
+    /// with the feature (quantized paged pages are separate later work).
+    /// The VLM veto lifts once span masks land — gemma-4 serves as a VLM
+    /// slot, so paged MUST eventually serve it. Deliberately left as ONE
+    /// condition so that lift, and the delete of this function with its
+    /// caller's log line, stays a one-line change.
     /// Returns the effective selection plus a veto tag for the slot log.
     public static func applySlotVetoes(
         selection: EngineV2KVBackendSelection,
-        isVLM: Bool,
-        kvQuantConfigured: Bool
+        isVLM: Bool
     ) -> (selection: EngineV2KVBackendSelection, veto: String?) {
         guard selection != .contiguous else { return (.contiguous, nil) }
-        if isVLM {
-            return (.contiguous, selection == .paged ? "vlm" : nil)
-        }
-        if kvQuantConfigured {
-            return (.contiguous, "kv_quant")
-        }
-        return (selection, nil)
+        guard isVLM else { return (selection, nil) }
+        return (.contiguous, selection == .paged ? "vlm" : nil)
+    }
+
+    /// Layer 5. Paged could not be built — kernel preflight, physical
+    /// capacity planning, or `PagedKVBackend` construction FAILED. True
+    /// when the caller must record the reason and degrade to contiguous;
+    /// false when it must REFUSE with the reason attached.
+    ///
+    /// The split is by who asked, not by what broke. `.auto` is the
+    /// fleet's default and has promised nothing, so a model that cannot
+    /// serve paged must still load and serve. An explicit "paged" — the
+    /// operator config, a per-model override, or the benchmark's
+    /// `--kv-backend paged` — is a claim someone measures against, and
+    /// with no canary fleet those runs ARE the safety net: degrading one
+    /// silently makes it report paged while measuring contiguous.
+    ///
+    /// NOT the same question as the layer-3 kill switch, which always
+    /// degrades. A failure means "we CANNOT do what you asked"; the kill
+    /// switch means "do NOT do what you asked". Only the first is a
+    /// broken promise. Do not collapse them.
+    public static func degradesPagedFailure(
+        selection: EngineV2KVBackendSelection
+    ) -> Bool {
+        selection != .paged
     }
 }

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2SlotFactory.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2SlotFactory.swift
@@ -76,8 +76,6 @@ enum EngineV2SlotFactory {
     ///   - kvBudget: process-wide shared KV reservation ledger (nil ⇒ no
     ///     shared gating — unit tests only; both production callers pass
     ///     their ledger).
-    ///   - kvQuantConfigured: operator set `kv_quant` — v2 uses unquantized
-    ///     native-float KV, so a WARN telemetry event fires once per load.
     ///   - weightHash: the slot's verified weight hash binding for SSD
     ///     artifacts. Nil or blank disables reusable SSD caching.
     ///   - environment: prefix-cache policy environment
@@ -101,7 +99,6 @@ enum EngineV2SlotFactory {
         kvBytesCapacity: Int,
         maxConcurrentRequests: Int,
         kvBudget: GlobalKVCacheBudget?,
-        kvQuantConfigured: Bool,
         kvBackendConfig: String = "auto",
         kvBackendConfigByModel: [String: String] = [:],
         weightHash: String? = nil,
@@ -122,7 +119,6 @@ enum EngineV2SlotFactory {
             kvBytesCapacity: kvBytesCapacity,
             maxConcurrentRequests: maxConcurrentRequests,
             kvBudget: kvBudget,
-            kvQuantConfigured: kvQuantConfigured,
             kvBackendConfig: kvBackendConfig,
             kvBackendConfigByModel: kvBackendConfigByModel,
             weightHash: weightHash,
@@ -151,7 +147,6 @@ enum EngineV2SlotFactory {
         kvBytesCapacity: Int,
         maxConcurrentRequests: Int,
         kvBudget: GlobalKVCacheBudget?,
-        kvQuantConfigured: Bool,
         kvBackendConfig: String = "auto",
         kvBackendConfigByModel: [String: String] = [:],
         weightHash: String? = nil,
@@ -168,10 +163,13 @@ enum EngineV2SlotFactory {
         // KV-backend gate, slot-veto layer (`EngineV2KVBackendPolicy`):
         // parse the operator selection (per-model override wins; typo →
         // WARN + auto), then force contiguous for slots the paged cache
-        // cannot serve — VLM (span masks unsupported: media would 4xx at
-        // submit) and kv_quant intent (fp16 pages only). `auto` resolves
-        // contiguous; the fleet kill switch, physical-capacity planning,
-        // and eligibility fallback live in `makeProductionBuild`.
+        // cannot serve — VLM alone now (span masks unsupported: media
+        // would 4xx at submit). A veto is policy, so it is silent even for
+        // an explicit paged request; kv_quant is no longer a veto because
+        // the feature is being removed, and it survives here only as the
+        // WARN below. `auto` resolves contiguous; the fleet kill switch,
+        // physical-capacity planning, and the degrade-or-REFUSE decision
+        // for an explicit paged request live in `makeProductionBuild`.
         let parsedKVBackend = EngineV2KVBackendPolicy.parseSelection(
             global: kvBackendConfig, byModel: kvBackendConfigByModel, modelID: modelId)
         if let unrecognized = parsedKVBackend.unrecognized {
@@ -181,8 +179,7 @@ enum EngineV2SlotFactory {
         }
         let vetoed = EngineV2KVBackendPolicy.applySlotVetoes(
             selection: parsedKVBackend.selection,
-            isVLM: isVLM,
-            kvQuantConfigured: kvQuantConfigured)
+            isVLM: isVLM)
         let kvBackendSelection = vetoed.selection
         if let veto = vetoed.veto {
             logInfo(
@@ -448,12 +445,6 @@ enum EngineV2SlotFactory {
                 + prefixCacheStateDescription(
                     ssdCache: ssdPrefixCache))
 
-        // WARN once (per load) that kv_quant is ignored on the v2 path
-        // (unquantized native-float caches are what the engine builds).
-        if kvQuantConfigured {
-            EngineV2Factory.emitKVQuantUnsupportedTelemetry(
-                modelId: modelId, emitTelemetry: emitTelemetry)
-        }
         let reason = mtpStatus.reason?.rawValue ?? "none"
         let revision = mtpStatus.revision ?? "none"
         logInfo(

--- a/provider-swift/Sources/darkbloom/BenchmarkCommand+Sweep.swift
+++ b/provider-swift/Sources/darkbloom/BenchmarkCommand+Sweep.swift
@@ -17,24 +17,42 @@ extension Benchmark {
             printError("--prefill-lengths must contain at least one positive integer")
             throw ExitCode.failure
         }
-        guard maxBatch >= 1 else {
-            printError("--max-batch must be >= 1")
-            throw ExitCode.failure
-        }
         guard decodeIterations >= 1 else {
             printError("--decode-iterations must be >= 1")
             throw ExitCode.failure
         }
-        let batchSizes = Array(1 ... maxBatch)
+        // An explicit list wins over the ladder: the release gates need the
+        // cells {1,2,4,8}, not every integer up to 8.
+        let batches: [Int]
+        if let raw = batchSizes {
+            batches = Self.parsePositiveInts(raw)
+            guard !batches.isEmpty else {
+                printError("--batch-sizes must contain at least one positive integer")
+                throw ExitCode.failure
+            }
+        } else {
+            guard maxBatch >= 1 else {
+                printError("--max-batch must be >= 1")
+                throw ExitCode.failure
+            }
+            batches = Array(1 ... maxBatch)
+        }
+        guard let backend = EngineV2KVBackendSelection(
+            rawValue: kvBackend.trimmingCharacters(in: .whitespaces).lowercased())
+        else {
+            printError("--kv-backend must be one of: auto, contiguous, paged")
+            throw ExitCode.failure
+        }
 
         let report = try await ThroughputSweep.run(
             modelID: modelID,
             modelDirectory: modelDirectory,
             promptLengths: lengths,
-            batchSizes: batchSizes,
+            batchSizes: batches,
             decodeTokens: decodeTokens,
             decodePromptTokens: decodePromptTokens,
             decodeIterations: decodeIterations,
+            kvBackend: backend,
             hardware: hardware
         )
 

--- a/provider-swift/Sources/darkbloom/BenchmarkCommand+Sweep.swift
+++ b/provider-swift/Sources/darkbloom/BenchmarkCommand+Sweep.swift
@@ -56,7 +56,43 @@ extension Benchmark {
             hardware: hardware
         )
 
+        // The artifact ALWAYS ships, including on a refused run: the operator
+        // needs the notes line and the failure reason more than the status,
+        // and swallowing the report to signal an error would trade a good
+        // diagnostic for a bad one.
         print(try report.jsonString())
+
+        if let message = Self.sweepFailureMessage(
+            backend: backend, failure: report.decodeConstructionFailure)
+        {
+            printError(message)
+            throw ExitCode.failure
+        }
+    }
+
+    /// Exit-status decision for a completed sweep: the message to print
+    /// before failing, or nil when the run may report success.
+    ///
+    /// A sweep that constructed no engine measured NOTHING. Exiting 0 there
+    /// is indistinguishable from success to `set -e`, to CI, and to any
+    /// wrapper that checks status before parsing the report — and with no
+    /// canary fleet this benchmark IS the safety net for the paged rollout,
+    /// so it must not report success on total failure.
+    ///
+    /// Only for an EXPLICIT `--kv-backend`. `auto` keeps its old behaviour
+    /// exactly: it promised nothing about the backend, so a run that could
+    /// not build one is an ordinary bad run rather than a broken guarantee,
+    /// and scripts pinned to today's exit status must not start failing.
+    ///
+    /// The message names the REASON, not just the count: "no decode cells"
+    /// alone sends the reader back to the stderr log to find out why.
+    static func sweepFailureMessage(
+        backend: EngineV2KVBackendSelection,
+        failure: ThroughputSweepReport.DecodeConstructionFailure?
+    ) -> String? {
+        guard backend != .auto, let failure else { return nil }
+        return "--kv-backend \(backend.rawValue) produced no decode cells: "
+            + failure.reason
     }
 
     func runSchedulerPrefillBenchmark(

--- a/provider-swift/Sources/darkbloom/BenchmarkCommand.swift
+++ b/provider-swift/Sources/darkbloom/BenchmarkCommand.swift
@@ -59,9 +59,13 @@ struct Benchmark: AsyncParsableCommand {
 
     @Option(name: .long, help: """
         Sweep: KV backend the decode engine is built with — auto|contiguous|paged \
-        (default auto, which resolves to contiguous today). A paged selection can \
-        still fall back to contiguous (fleet kill switch, kernel preflight, pool \
-        capacity); the backend that actually served is recorded in the report notes.
+        (default auto, which resolves to contiguous today). An explicit paged \
+        selection FAILS the run rather than degrading: if kernel preflight or \
+        pool capacity cannot serve paged, engine construction throws, the cell \
+        records no samples, and the command exits non-zero naming the reason — \
+        so a paged benchmark can never measure contiguous. Only \
+        DARKBLOOM_CBV2_PAGED_KV=0 still degrades. The backend that actually \
+        served is recorded in the report notes.
         """)
     var kvBackend = "auto"
 

--- a/provider-swift/Sources/darkbloom/BenchmarkCommand.swift
+++ b/provider-swift/Sources/darkbloom/BenchmarkCommand.swift
@@ -38,6 +38,13 @@ struct Benchmark: AsyncParsableCommand {
     @Option(name: .long, help: "Sweep: maximum decode batch size; measures B=1...N (default 6).")
     var maxBatch = 6
 
+    @Option(name: .long, help: """
+        Sweep: explicit comma-separated decode batch sizes (e.g. 1,2,4,8). \
+        When present this replaces the B=1...--max-batch ladder, so a release \
+        gate measures only the cells it needs instead of the whole ramp.
+        """)
+    var batchSizes: String?
+
     @Option(name: .long, help: "Sweep: decode tokens generated per sequence (default 64).")
     var decodeTokens = ThroughputSweep.defaultDecodeTokens
 
@@ -49,6 +56,14 @@ struct Benchmark: AsyncParsableCommand {
         Each repetition emits its own decode sample so callers can take a median.
         """)
     var decodeIterations = ThroughputSweep.defaultDecodeIterations
+
+    @Option(name: .long, help: """
+        Sweep: KV backend the decode engine is built with — auto|contiguous|paged \
+        (default auto, which resolves to contiguous today). A paged selection can \
+        still fall back to contiguous (fleet kill switch, kernel preflight, pool \
+        capacity); the backend that actually served is recorded in the report notes.
+        """)
+    var kvBackend = "auto"
 
     @Flag(name: .long, help: """
         Run the cold-prefill TTFT benchmark through the production \

--- a/provider-swift/Tests/DarkbloomCLITests/BenchmarkSweepExitTests.swift
+++ b/provider-swift/Tests/DarkbloomCLITests/BenchmarkSweepExitTests.swift
@@ -1,0 +1,70 @@
+// Copyright © 2026 Eigen Labs.
+//
+// Exit-status contract for `darkbloom benchmark --sweep`.
+//
+// A sweep that constructed no engine measured NOTHING. Exiting 0 there is
+// indistinguishable from success to `set -e`, to CI, and to any wrapper
+// that checks status before parsing the report. With no canary fleet this
+// benchmark IS the safety net for the paged rollout (OPEN-9), so a refused
+// `--kv-backend paged` run must fail the process, not return an empty
+// curve with a green status.
+//
+// The `auto` half matters just as much: `auto` promised nothing about the
+// backend, so a run that could not build one is an ordinary bad run and
+// must keep its existing exit status. Widening the failure to `auto` would
+// start failing scripts that are green today.
+
+import ProviderBenchmark
+import ProviderCore
+import Testing
+
+@testable import darkbloom
+
+private func failure(
+    _ selection: String = "paged",
+    reason: String = "engine_v2: paged KV backend explicitly requested but "
+        + "unavailable — kernel_preflight: ineligible head dim"
+) -> ThroughputSweepReport.DecodeConstructionFailure {
+    .init(kvBackendSelection: selection, reason: reason)
+}
+
+@Suite("benchmark sweep exit status")
+struct BenchmarkSweepExitTests {
+
+    @Test("explicit paged with zero decode cells fails and names the reason")
+    func explicitPagedFails() throws {
+        let message = Benchmark.sweepFailureMessage(
+            backend: .paged, failure: failure())
+        let text = try #require(message)
+        // Names the selection so the operator knows which flag broke...
+        #expect(text.contains("--kv-backend paged"))
+        // ...and the CAUSE, not just the count. "produced no decode cells"
+        // on its own sends the reader back to the stderr log.
+        #expect(text.contains("kernel_preflight: ineligible head dim"))
+    }
+
+    @Test("explicit contiguous with zero decode cells also fails")
+    func explicitContiguousFails() {
+        // Not paged-specific: an explicit backend of either kind is a claim
+        // the run is measured against.
+        let message = Benchmark.sweepFailureMessage(
+            backend: .contiguous,
+            failure: failure("contiguous", reason: "engine_v2: no KV byte headroom"))
+        #expect(message?.contains("--kv-backend contiguous") == true)
+        #expect(message?.contains("no KV byte headroom") == true)
+    }
+
+    @Test("auto keeps its old exit status even with zero decode cells")
+    func autoDoesNotFail() {
+        // The narrow scope of the change. `auto` degrades by design; a
+        // failed auto run stays exit 0 exactly as it does today.
+        #expect(Benchmark.sweepFailureMessage(backend: .auto, failure: failure()) == nil)
+    }
+
+    @Test("a sweep that produced cells succeeds for every selection")
+    func healthyRunSucceeds() {
+        for backend in EngineV2KVBackendSelection.allCases {
+            #expect(Benchmark.sweepFailureMessage(backend: backend, failure: nil) == nil)
+        }
+    }
+}

--- a/provider-swift/Tests/ProviderCoreTests/EngineV2KVBackendGateTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/EngineV2KVBackendGateTests.swift
@@ -3,9 +3,11 @@
 // KV-backend GATE tests over the REAL `EngineV2Factory.makeProductionBuild`
 // with tiny real-family models (JSON-decoded configs, random-init weights,
 // no downloads): production-safe `auto` (always contiguous), the fleet
-// kill switch at the deepest layer, explicit
-// selections, and the eligibility fallback (ineligible head dim → paged
-// selection degrades to contiguous, never a refusal).
+// kill switch at the deepest layer, explicit selections, and the
+// degrade-or-REFUSE split — an explicit paged request that cannot be
+// served throws `EngineV2ProductionError.pagedUnavailable` with the reason
+// attached, while the kill switch still degrades because an operator
+// override is not a failure.
 //
 // These tests CONSTRUCT engines (paged construction materializes its slab
 // pool — a small Metal eval), but never run a forward pass.
@@ -93,6 +95,13 @@ private final class GateCacheCapture: @unchecked Sendable {
     var capability: CBv2PrefixReuseCapability? { lock.withLock { _capability } }
 }
 
+private final class GateTelemetrySink: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _events: [TelemetryEvent] = []
+    var events: [TelemetryEvent] { lock.withLock { _events } }
+    func record(_ event: TelemetryEvent) { lock.withLock { _events.append(event) } }
+}
+
 private let gateTestCapacity = 8 << 20  // 8 MiB pool — tiny but constructible
 
 private func makeBuild(
@@ -112,6 +121,34 @@ private func makeBuild(
         maxContextLength: 2048,
         environment: environment,
         pagedPreflightOverride: pagedPreflightOverride)
+}
+
+/// Run `body` and require it REFUSED an explicit paged request, returning
+/// the reason the refusal carries. `body` COMPLETING is itself the
+/// failure: it means the policy silently degraded to contiguous, which is
+/// the exact defect OPEN-9 closes — a run that reports paged and measures
+/// contiguous. Also pins the telemetry classification, because
+/// `engine_init_failed` would bury a paged regression among unrelated bad
+/// model loads.
+private func pagedRefusalReason(
+    _ body: () async throws -> Void
+) async -> String? {
+    do {
+        try await body()
+        Issue.record("explicit paged must refuse, not degrade to contiguous")
+        return nil
+    } catch let error as EngineV2ProductionError {
+        guard case .pagedUnavailable(let reason) = error else {
+            Issue.record("expected .pagedUnavailable, got \(error)")
+            return nil
+        }
+        #expect(EngineV2RefusalReason.classify(error) == .pagedBackendUnavailable)
+        #expect("\(error)".contains("explicitly requested but unavailable"))
+        return reason
+    } catch {
+        Issue.record("expected EngineV2ProductionError, got \(error)")
+        return nil
+    }
 }
 
 // MARK: - Tests
@@ -169,6 +206,13 @@ struct EngineV2KVBackendGateTests {
         await build.engine.shutdown()
     }
 
+    // DEGRADE, deliberately — the one paged-to-contiguous case that
+    // survives OPEN-9, and the only test pinning the distinction. The kill
+    // switch is an operator override ("do NOT do what you asked"), not a
+    // failure ("we CANNOT do what you asked"); refusing here would 503
+    // every slot on a fleet configured `engine_v2_kv_backend = "paged"`
+    // the moment an operator pulled it. The three refusal tests below are
+    // the other half of that split.
     @Test("fleet kill switch forces explicit paged to contiguous at the deepest layer")
     func killSwitchForcesContiguous() async throws {
         let build = try makeBuild(
@@ -180,62 +224,89 @@ struct EngineV2KVBackendGateTests {
         await build.engine.shutdown()
     }
 
-    @Test("kernel-ineligible shape falls back to contiguous, never refuses")
-    func ineligibleFallsBack() async throws {
+    @Test("kernel-ineligible shape REFUSES an explicit paged request")
+    func ineligibleShapeRefusesExplicitPaged() async throws {
         // headDim 80 is outside the paged kernel's {64,128,256,512}.
-        let build = try makeBuild(model: try tinyGPTOSS(headDim: 80), kvBackend: .paged)
-        #expect(build.kvBackendKind == .contiguous)
-        #expect(build.kvBackendFallbackReason?.hasPrefix("kernel_preflight:") == true)
-        await build.engine.shutdown()
+        let reason = await pagedRefusalReason {
+            let build = try makeBuild(
+                model: try tinyGPTOSS(headDim: 80), kvBackend: .paged)
+            // Reached only on a policy regression; still tear the engine
+            // down so the failure is one clean assertion, not a leak too.
+            await build.engine.shutdown()
+        }
+        #expect(reason?.hasPrefix("kernel_preflight:") == true)
     }
 
-    @Test("failed kernel preflight falls back to contiguous before slab construction")
-    func failedPreflightFallsBack() async throws {
+    @Test("failed kernel preflight REFUSES before slab construction")
+    func failedPreflightRefuses() async throws {
         struct PreflightFailure: Error {}
-        let build = try makeBuild(
-            model: try tinyGPTOSS(),
-            kvBackend: .paged,
-            pagedPreflightOverride: { _ in throw PreflightFailure() })
-        #expect(build.kvBackendKind == .contiguous)
-        #expect(build.kvBackendFallbackReason?.hasPrefix("kernel_preflight:") == true)
-        await build.engine.shutdown()
+        let reason = await pagedRefusalReason {
+            let build = try makeBuild(
+                model: try tinyGPTOSS(),
+                kvBackend: .paged,
+                pagedPreflightOverride: { _ in throw PreflightFailure() })
+            await build.engine.shutdown()
+        }
+        #expect(reason?.hasPrefix("kernel_preflight:") == true)
+        // The underlying cause survives into the refusal, so an operator
+        // reading the 503 sees WHY paged could not be served.
+        #expect(reason?.contains("PreflightFailure") == true)
     }
 
-    @Test("explicit paged fallback constructs frozen-full cache for resolved contiguous backend")
+    @Test("physical-capacity shortfall REFUSES an explicit paged request")
+    func capacityShortfallRefusesExplicitPaged() async throws {
+        let reason = await pagedRefusalReason {
+            _ = try EngineV2Factory.prepareProductionBackend(
+                model: try tinyGemma4Text(),
+                kvBytesCapacity: 1_024,
+                maxConcurrentRequests: 2,
+                kvBackend: .paged,
+                maxContextLength: 2048,
+                environment: [:],
+                pagedPreflightOverride: { _ in })
+        }
+        #expect(reason?.hasPrefix("physical_capacity:") == true)
+    }
+
+    @Test("`.auto` still degrades when paged cannot be served")
+    func autoDegradesOnPagedFailure() async throws {
+        // Layer 5's degrade half. `.auto` short-circuits to contiguous
+        // before any paged attempt today, so the real construction path
+        // cannot reach the branch; the policy predicate is the seam that
+        // decides it, and it must keep answering "degrade" for every
+        // non-explicit selection or an auto fleet starts 503-ing the day
+        // auto begins resolving paged.
+        #expect(EngineV2KVBackendPolicy.degradesPagedFailure(selection: .auto))
+        #expect(EngineV2KVBackendPolicy.degradesPagedFailure(selection: .contiguous))
+        #expect(!EngineV2KVBackendPolicy.degradesPagedFailure(selection: .paged))
+    }
+
+    @Test("kill-switch degrade constructs frozen-full cache for resolved contiguous backend")
     func pagedFallbackConstructsFrozenCache() async throws {
-        struct PreflightFailure: Error {}
         let model = try tinyGemma4Text()
+        // The kill switch is now the only route to a DEGRADED preparation
+        // from an explicit paged selection — preflight and capacity
+        // failures refuse instead (see the three refusal tests above). The
+        // property under test is unchanged: whatever produces a resolved
+        // contiguous backend must also produce a frozen-full SSD cache
+        // capability, so the cache can never be built for a backend that
+        // is not the one serving.
         let prepared = try EngineV2Factory.prepareProductionBackend(
             model: model,
             kvBytesCapacity: gateTestCapacity,
             maxConcurrentRequests: 2,
             kvBackend: .paged,
             maxContextLength: 2048,
-            environment: [:],
-            pagedPreflightOverride: { _ in throw PreflightFailure() })
+            environment: [EngineV2KVBackendPolicy.killSwitchEnvKey: "0"],
+            pagedPreflightOverride: { _ in })
         #expect(prepared.kind == .contiguous)
-        #expect(prepared.fallbackReason?.hasPrefix("kernel_preflight:") == true)
+        #expect(prepared.fallbackReason == "kill_switch")
 
         let capability = PrefixCachePolicy.prefixReuseCapability(
             layerKinds: prepared.layerKinds,
             backendSelection: .contiguous)
         #expect(capability.strategy == .frozenFullReplay)
         #expect(capability.isSupported)
-
-        let capacityFallback = try EngineV2Factory.prepareProductionBackend(
-            model: model,
-            kvBytesCapacity: 1_024,
-            maxConcurrentRequests: 2,
-            kvBackend: .paged,
-            maxContextLength: 2048,
-            environment: [:],
-            pagedPreflightOverride: { _ in })
-        #expect(capacityFallback.kind == .contiguous)
-        #expect(capacityFallback.fallbackReason?.hasPrefix("physical_capacity:") == true)
-        #expect(PrefixCachePolicy.prefixReuseCapability(
-            layerKinds: capacityFallback.layerKinds,
-            backendSelection: .contiguous
-        ).strategy == .frozenFullReplay)
 
         let root = FileManager.default.temporaryDirectory.resolvingSymlinksInPath()
             .appendingPathComponent("paged-fallback-cache-\(UUID().uuidString)", isDirectory: true)
@@ -290,9 +361,38 @@ struct EngineV2KVBackendGateTests {
         await build.engine.shutdown()
     }
 
-    @Test("slot factory resolves paged fallback before constructing frozen cache")
+    @Test("paged pool is sized from the ONE scheduler config the engine runs on")
+    func pagedPoolLocksStepWithSchedulerConfig() async throws {
+        let model = try tinyGemma4Text()
+        let prepared = try EngineV2Factory.prepareProductionBackend(
+            model: model,
+            kvBytesCapacity: gateTestCapacity,
+            maxConcurrentRequests: 2,
+            kvBackend: .paged,
+            maxContextLength: 2048,
+            environment: [:])
+        #expect(prepared.kind == .paged)
+        let (backend, _) = try prepared.consume(model: model, maxConcurrentRequests: 2)
+        let paged = try #require(backend as? PagedKVBackend)
+        // LOCKSTEP. `PagedSequenceKV` PRECONDITIONS that a windowed update
+        // never exceeds the pool's `maxPrefillChunk` — a process kill, not
+        // a throw — so the pool must be sized from the chunk the ENGINE
+        // actually schedules. There is now one `CBv2SchedulerConfig` per
+        // build, carried on the preparation and reused verbatim by
+        // `assembleProductionBuild`; this pins the pool against it so a
+        // re-introduced parallel constant fails here instead of aborting
+        // the daemon under a long windowed prefill.
+        #expect(
+            paged.pool.config.maxPrefillChunk
+                == prepared.schedulerConfig.prefillChunkSize)
+        #expect(prepared.schedulerConfig.maxConcurrentRequests == 2)
+        // Prefix caching is the ONLY field assembly may still decide, and
+        // it is off until a cache instance is supplied.
+        #expect(!prepared.schedulerConfig.enablePrefixCache)
+    }
+
+    @Test("slot factory resolves the degraded backend before constructing frozen cache")
     func slotFactoryOrdersResolvedBackendBeforeCache() async throws {
-        struct PreflightFailure: Error {}
         let model = try tinyGemma4Text()
         let tokenizer = StubBridgeTokenizer()
         let container = ModelContainer(
@@ -331,7 +431,6 @@ struct EngineV2KVBackendGateTests {
             kvBytesCapacity: gateTestCapacity,
             maxConcurrentRequests: 2,
             kvBudget: nil,
-            kvQuantConfigured: false,
             kvBackendConfig: "paged",
             weightHash: String(repeating: "a", count: 64),
             specDecPreparation: SpecDecPreparation(
@@ -340,7 +439,10 @@ struct EngineV2KVBackendGateTests {
             preparedModel: preparedModel,
             assemblyOverrides: .init(
                 promptContractID: "tiny-gemma-contract",
-                pagedPreflight: { _ in throw PreflightFailure() },
+                // Kill-switch degrade, not a preflight failure: an
+                // explicit `paged` config whose preflight fails now
+                // refuses out of this same call (see
+                // `slotFactoryRefusesExplicitPagedRequest`).
                 makePrefixCache: { layerKinds, capability in
                     let cache = SSDPrefixCache(
                         config: .init(
@@ -368,7 +470,7 @@ struct EngineV2KVBackendGateTests {
                     capture.set(cache: cache, capability: capability)
                     return cache
                 }),
-            environment: [:])
+            environment: [EngineV2KVBackendPolicy.killSwitchEnvKey: "0"])
         let cache = try #require(capture.cache)
         let backendKind = await bundle.bridge.kvBackendKind
         #expect(backendKind == .contiguous)
@@ -381,6 +483,77 @@ struct EngineV2KVBackendGateTests {
         #expect(status.state == .pending)
         #expect(status.reason == .scanPending)
         await bundle.bridge.shutdown()
+    }
+
+    @Test("slot factory REFUSES an explicit paged request it cannot serve")
+    func slotFactoryRefusesExplicitPagedRequest() async throws {
+        struct PreflightFailure: Error {}
+        let model = try tinyGemma4Text()
+        let tokenizer = StubBridgeTokenizer()
+        let container = ModelContainer(
+            context: ModelContext(
+                configuration: ModelConfiguration(id: "tiny/gemma"),
+                model: model,
+                processor: GateProcessor(),
+                tokenizer: tokenizer))
+        let preparedModel = EngineV2PreparedModel(
+            snapshot: EngineV2ModelSnapshot(
+                model: model,
+                eosTokenIds: [1],
+                extraEOSTokens: []),
+            servingModel: model,
+            assistant: nil,
+            mtpStatus: .disabled(.configDisabled, configured: false),
+            mtpArtifact: nil)
+        let telemetry = GateTelemetrySink()
+
+        // The production 503 path end to end: operator config says paged,
+        // the kernel cannot be preflighted, so the LOAD fails instead of
+        // quietly serving a contiguous slot under a paged label.
+        let reason = await pagedRefusalReason {
+            _ = try await EngineV2SlotFactory.makeProductionBundle(
+                modelId: "tiny-gemma",
+                modelType: "gemma4_text",
+                isVLM: false,
+                modelDirectory: nil,
+                container: container,
+                tokenizer: TokenizerHandle(tokenizer),
+                sizing: SlotSizingSnapshot(
+                    weightsBytes: 1,
+                    fp16KVBytesPerToken: 1_024,
+                    maxContextLength: 2_048,
+                    defaultMaxTokens: 32),
+                kvBytesCapacity: gateTestCapacity,
+                maxConcurrentRequests: 2,
+                kvBudget: nil,
+                kvBackendConfig: "paged",
+                weightHash: String(repeating: "a", count: 64),
+                specDecPreparation: SpecDecPreparation(
+                    artifact: nil,
+                    status: .disabled(.configDisabled, configured: false)),
+                preparedModel: preparedModel,
+                assemblyOverrides: .init(
+                    promptContractID: "tiny-gemma-contract",
+                    pagedPreflight: { _ in throw PreflightFailure() }),
+                environment: [:],
+                emitTelemetry: { telemetry.record($0) })
+        }
+        #expect(reason?.hasPrefix("kernel_preflight:") == true)
+
+        // ERROR `engine_v2_refusal`, classified so a paged-rollout
+        // regression stays separable from every other bad load in
+        // aggregate — `engine_init_failed` would bury it.
+        let refusals = telemetry.events.filter {
+            $0.fields?["operation"]?.description == "engine_v2_refusal"
+        }
+        #expect(refusals.count == 1)
+        #expect(refusals.first?.severity == .error)
+        #expect(
+            refusals.first?.fields?["reason"]?.description
+                == "paged_backend_unavailable")
+        #expect(
+            refusals.first?.fields?["error"]?.description
+                .contains("kernel_preflight:") == true)
     }
 
     @Test("slot factory publishes GPT-OSS native contiguous rate without SSD staging")
@@ -425,7 +598,6 @@ struct EngineV2KVBackendGateTests {
             kvBytesCapacity: gateTestCapacity,
             maxConcurrentRequests: 2,
             kvBudget: nil,
-            kvQuantConfigured: false,
             kvBackendConfig: "contiguous",
             weightHash: String(repeating: "b", count: 64),
             specDecPreparation: SpecDecPreparation(

--- a/provider-swift/Tests/ProviderCoreTests/EngineV2KVBackendPolicyTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/EngineV2KVBackendPolicyTests.swift
@@ -3,7 +3,7 @@
 // Pure-logic tests for the paged-KV backend selection policy
 // (`EngineV2KVBackendPolicy`): operator-string parsing (per-model override
 // semantics, and the slot-veto layer (VLM forces contiguous; kv-quant is
-// no longer a veto — the feature is being removed from the product).
+// no longer a veto — the feature is gone from the product).
 // The family/eligibility layers live in `EngineV2KVBackendGateTests`
 // (real tiny models); the wire-through lives in the wiring tests.
 
@@ -109,7 +109,7 @@ struct EngineV2KVBackendPolicyTests {
 
         // Clean text slots pass through untouched — including the slots
         // that used to be vetoed for kv-quant intent, which is no longer
-        // a backend consideration.
+        // a backend consideration anywhere in the product.
         let paged = EngineV2KVBackendPolicy.applySlotVetoes(
             selection: .paged, isVLM: false)
         #expect(paged.selection == .paged)

--- a/provider-swift/Tests/ProviderCoreTests/EngineV2KVBackendPolicyTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/EngineV2KVBackendPolicyTests.swift
@@ -2,8 +2,8 @@
 //
 // Pure-logic tests for the paged-KV backend selection policy
 // (`EngineV2KVBackendPolicy`): operator-string parsing (per-model override
-// precedence, typo fail-safe), the fleet kill switch's negative-only
-// semantics, and the slot-veto layer (VLM / kv-quant force contiguous).
+// semantics, and the slot-veto layer (VLM forces contiguous; kv-quant is
+// no longer a veto — the feature is being removed from the product).
 // The family/eligibility layers live in `EngineV2KVBackendGateTests`
 // (real tiny models); the wire-through lives in the wiring tests.
 
@@ -89,42 +89,39 @@ struct EngineV2KVBackendPolicyTests {
 
     // MARK: slot vetoes
 
-    @Test("VLM and kv-quant force contiguous; clean slots pass through")
+    @Test("VLM forces contiguous; clean slots pass through")
     func slotVetoes() {
         // Explicit paged on a VLM slot: vetoed, tagged for the slot log.
+        // A veto is POLICY, not failure — it must stay a silent force to
+        // contiguous, NOT the `pagedUnavailable` refusal an explicit paged
+        // request gets when the backend genuinely cannot be built.
         let pagedVLM = EngineV2KVBackendPolicy.applySlotVetoes(
-            selection: .paged, isVLM: true, kvQuantConfigured: false)
+            selection: .paged, isVLM: true)
         #expect(pagedVLM.selection == .contiguous)
         #expect(pagedVLM.veto == "vlm")
 
         // Auto on a VLM slot resolves contiguous silently (the default
         // doing its job is not an override worth logging).
         let autoVLM = EngineV2KVBackendPolicy.applySlotVetoes(
-            selection: .auto, isVLM: true, kvQuantConfigured: false)
+            selection: .auto, isVLM: true)
         #expect(autoVLM.selection == .contiguous)
         #expect(autoVLM.veto == nil)
 
-        // kv-quant intent vetoes both paged and auto (fp16 pages only).
-        for selection in [EngineV2KVBackendSelection.paged, .auto] {
-            let vetoed = EngineV2KVBackendPolicy.applySlotVetoes(
-                selection: selection, isVLM: false, kvQuantConfigured: true)
-            #expect(vetoed.selection == .contiguous)
-            #expect(vetoed.veto == "kv_quant")
-        }
-
-        // Clean text slots pass through untouched.
+        // Clean text slots pass through untouched — including the slots
+        // that used to be vetoed for kv-quant intent, which is no longer
+        // a backend consideration.
         let paged = EngineV2KVBackendPolicy.applySlotVetoes(
-            selection: .paged, isVLM: false, kvQuantConfigured: false)
+            selection: .paged, isVLM: false)
         #expect(paged.selection == .paged)
         #expect(paged.veto == nil)
         let auto = EngineV2KVBackendPolicy.applySlotVetoes(
-            selection: .auto, isVLM: false, kvQuantConfigured: false)
+            selection: .auto, isVLM: false)
         #expect(auto.selection == .auto)
         #expect(auto.veto == nil)
 
         // Contiguous is never vetoed (nothing to force).
         let contiguous = EngineV2KVBackendPolicy.applySlotVetoes(
-            selection: .contiguous, isVLM: true, kvQuantConfigured: true)
+            selection: .contiguous, isVLM: true)
         #expect(contiguous.selection == .contiguous)
         #expect(contiguous.veto == nil)
     }

--- a/provider-swift/Tests/ProviderCoreTests/ThroughputSweepTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ThroughputSweepTests.swift
@@ -171,6 +171,9 @@ struct ThroughputSweepReportTests {
         let json = try report.jsonString()
         #expect(json.contains("impliedReadFractionOfWeights"))
         #expect(json.contains("\"regime\""))
+        // A healthy run keeps its old shape: the OPEN-9 failure block is
+        // omitted from the JSON entirely, not emitted as null.
+        #expect(!json.contains("decodeConstructionFailure"))
 
         let decoded = try JSONDecoder().decode(
             ThroughputSweepReport.self, from: Data(json.utf8))
@@ -178,6 +181,42 @@ struct ThroughputSweepReportTests {
         #expect(decoded.decode.count == 2)
         #expect(decoded.derived.regime == .dense)
         #expect(decoded.schemaVersion == ThroughputSweepReport.currentSchemaVersion)
+    }
+
+    @Test("a refused sweep carries the reason, not just an empty curve")
+    func constructionFailureRoundTrip() throws {
+        // The OPEN-9 case: `--kv-backend paged` on a box that cannot serve
+        // paged now refuses per cell, so the sweep measures nothing. The
+        // report still ships (an operator needs the artifact) and must say
+        // WHY it is empty — `darkbloom benchmark` exits non-zero off this
+        // field and quotes the reason.
+        let derived = ThroughputSweepReport.makeDerived(
+            decode: [], totalParams: 26_000_000_000,
+            weightBytes: Int(26_000_000_000.0 * DecodeBandwidthModel.fourBitBytesPerParam),
+            quantBits: 4, bandwidthGBps: 400)
+        let reason =
+            "engine_v2: paged KV backend explicitly requested but unavailable "
+            + "— kernel_preflight: PagedKernelPreflightError.ineligible"
+        let report = ThroughputSweepReport(
+            modelID: "mlx-community/gemma-4-26B-A4B-it-qat-4bit",
+            modelPath: "/models/gemma",
+            hardware: .init(
+                chipName: "Apple M4 Max", memoryGb: 128, gpuCores: 40,
+                memoryBandwidthGbs: 546),
+            prefill: [],
+            decode: [],
+            derived: derived,
+            notes: ["kv backend: selection=paged, resolved=n/a (no decode cells ran)"],
+            decodeConstructionFailure: .init(
+                kvBackendSelection: "paged", reason: reason)
+        )
+
+        let decoded = try JSONDecoder().decode(
+            ThroughputSweepReport.self, from: Data(try report.jsonString().utf8))
+        let failure = try #require(decoded.decodeConstructionFailure)
+        #expect(failure.kvBackendSelection == "paged")
+        #expect(failure.reason == reason)
+        #expect(decoded.decode.isEmpty)
     }
 }
 


### PR DESCRIPTION
Stacks on #585 (kv-quant retirement, shares `docs/provider/quickstart.md`) and merges `paged-kv/bench-kv-backend` (#583, shares `BenchmarkCommand.swift`).

Two halves of one problem: **a paged rollout with no canary fleet cannot afford silent degradation.**

## An explicit paged request now refuses instead of degrading

`.auto` keeps falling back to contiguous — that is what `auto` means. But an operator who wrote `paged` and got contiguous has an unmeasured, unlabelled fleet, and every gate in this migration would report "paged" while measuring contiguous.

## A refused sweep now exits non-zero

The benchmark still exited **0** having produced zero decode cells. That is indistinguishable from success to `set -e`, to CI, and to any wrapper that checks status before parsing. With no canary fleet the benchmark *is* the safety net, and a safety net that returns 0 on total failure is not one.

```mermaid
flowchart LR
  subgraph Before
    A1["--kv-backend paged"] --> B1{paged constructible?}
    B1 -->|no| C1["silently degrade to contiguous"]
    C1 --> D1["sweep runs, exit 0"]
    D1 --> E1["CI green, dashboard says paged, fleet is contiguous"]
  end
  subgraph After
    A2["--kv-backend paged"] --> B2{paged constructible?}
    B2 -->|no| F2["refuse: named error, no slot"]
    F2 --> G2["report written WITH decodeConstructionFailure"]
    G2 --> H2["exit non-zero — CI fails loudly"]
    A3["--kv-backend auto"] --> I3["degrade to contiguous, exit 0 — unchanged"]
  end
```

Non-zero **only** when an explicit `--kv-backend` was requested and zero decode cells ran. The report is still written, because an operator needs the reason more than the status — which required two additive fields on `ThroughputSweepReport`, since the CLI could not otherwise *see* the reason: `ThroughputSweep` caught the construction failure, logged it to stderr and dropped it. An operator opening an empty report now learns why it is empty. Schema 1 → 2; successful reports byte-identical apart from that field.

Also corrects the two operator docs this falsified — the `--kv-backend` help text and the quickstart fallback paragraph both still promised that an explicit paged selection degrades.

**Verified:** `swift build` clean; 21/21 backend-policy and gate tests; `scripts/gemma_contbatch/validation.py` already failed a refused sweep via `require_positive`, so the missing piece really was only the process exit status.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/586"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787606628&installation_model_id=21733&pr_number=586&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F586&signature=6d2f75a2250a50624c289037da831918a16bc528977a746b91417967f2d36a29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->