### PR TITLE
feat(telemetry): give the paged rollout an observable posture, and fix the backend key collision

### DIFF
--- a/console-ui/__tests__/provider-backend-slot-telemetry.test.ts
+++ b/console-ui/__tests__/provider-backend-slot-telemetry.test.ts
@@ -29,3 +29,52 @@ describe("MyBackendSlot measured telemetry mirror", () => {
     expect(slot.model_load_time_ms).toBeUndefined();
   });
 });
+
+// The v0.8.0 paged-KV rollout discriminator. Go models it as `*string` with
+// `omitempty`, so a non-nil pointer to "" is still emitted as `"kv_backend":""`
+// while a pre-0.8.0 provider omits the key entirely. Those two must stay
+// distinguishable here, or the rollout dashboard cannot tell "provider says
+// nothing" from "provider says empty" — and, worse, would be free to fold both
+// into "contiguous".
+describe("MyBackendSlot kv_backend discriminator", () => {
+  const base = `"model":"gemma-4-26b-qat-4bit","state":"running","num_running":1,"num_waiting":0,"active_tokens":100,"max_tokens_potential":400`;
+
+  it("carries an explicit backend kind", () => {
+    const slot = JSON.parse(`{${base},"kv_backend":"paged"}`) as MyBackendSlot;
+    expect(slot.kv_backend).toBe("paged");
+    expect("kv_backend" in slot).toBe(true);
+  });
+
+  it("is undefined when a pre-0.8.0 provider omits it (absent ⇒ unknown)", () => {
+    const slot = JSON.parse(`{${base}}`) as MyBackendSlot;
+    expect(slot.kv_backend).toBeUndefined();
+    expect("kv_backend" in slot).toBe(false);
+    // Absent is UNKNOWN. It must never read as an observation of either kind.
+    expect(slot.kv_backend).not.toBe("contiguous");
+    expect(slot.kv_backend).not.toBe("paged");
+  });
+
+  it("keeps an explicit empty value distinguishable from omission", () => {
+    const explicit = JSON.parse(`{${base},"kv_backend":""}`) as MyBackendSlot;
+    const omitted = JSON.parse(`{${base}}`) as MyBackendSlot;
+    expect(explicit.kv_backend).toBe("");
+    expect("kv_backend" in explicit).toBe(true);
+    expect("kv_backend" in omitted).toBe(false);
+    // The reason the Go side is a pointer and this side is optional: these two
+    // slots are NOT the same observation.
+    expect(explicit.kv_backend).not.toBe(omitted.kv_backend);
+  });
+
+  it("accepts both shipped kinds at the type level", () => {
+    const slots: MyBackendSlot[] = (["paged", "contiguous"] as const).map((kind) => ({
+      model: "gpt-oss-20b",
+      state: "running",
+      num_running: 0,
+      num_waiting: 0,
+      active_tokens: 0,
+      max_tokens_potential: 0,
+      kv_backend: kind,
+    }));
+    expect(slots.map((s) => s.kv_backend)).toEqual(["paged", "contiguous"]);
+  });
+});

--- a/console-ui/src/app/providers/types.ts
+++ b/console-ui/src/app/providers/types.ts
@@ -40,6 +40,12 @@ export interface MyBackendSlot {
   // they are optional here.
   observed_prefill_tps?: number; // EWMA of measured prefill TPS (admission→first token)
   model_load_time_ms?: number; // measured cold-start load time (ms) for this slot's model
+  // Per-slot KV-cache backend the provider's engine was actually built with,
+  // mirrored from Go BackendSlotCapacity.KVBackend (`*string`, omitempty).
+  // A pre-0.8.0 provider omits the key, so `undefined` means UNKNOWN — never
+  // read it as "contiguous", or the paged-rollout comparison silently counts
+  // every legacy provider as a contiguous sample.
+  kv_backend?: "paged" | "contiguous" | string;
 }
 
 export interface MyBackendCapacity {

--- a/console-ui/src/lib/telemetry-types.ts
+++ b/console-ui/src/lib/telemetry-types.ts
@@ -150,6 +150,14 @@ export const TELEMETRY_ALLOWED_FIELDS = new Set<string>([
   "pages_pinned",
   "cow_events",
   "pool_utilization",
+  // Paged pool re-slice residue: raw bytes, not a second ratio. Above,
+  // `pool_utilization` is OCCUPANCY; a grant-vs-pool ratio under a
+  // near-identical name collides with it in any `group by kv_backend`, and a
+  // clamped ratio drops the overflow magnitude. `pool_bytes` is the
+  // denominator, so share-of-pool stays derivable.
+  "pool_bytes",
+  "pool_deferred_growth_bytes",
+  "pool_stranded_bytes",
   // MTP (speculative decode) posture. MTP inflates observed_decode_tps with
   // no discriminator, so a partially-MTP fleet biases routing on a metric the
   // coordinator believes is homogeneous. Bounded enums and counters only.

--- a/console-ui/src/lib/telemetry-types.ts
+++ b/console-ui/src/lib/telemetry-types.ts
@@ -147,8 +147,8 @@ export const TELEMETRY_ALLOWED_FIELDS = new Set<string>([
   "kv_backend",
   "prefix_reuse_backend",
   // Paged KV pool metrics: aggregate pool counters only.
-  "pages_pinned",
-  "cow_events",
+  // `pages_pinned` / `cow_events` deliberately absent: no mechanism exists,
+  // and a producerless key reads as a legitimate zero. See the Go mirror.
   "pool_utilization",
   // Paged pool re-slice residue: raw bytes, not a second ratio. Above,
   // `pool_utilization` is OCCUPANCY; a grant-vs-pool ratio under a

--- a/console-ui/src/lib/telemetry-types.ts
+++ b/console-ui/src/lib/telemetry-types.ts
@@ -140,4 +140,21 @@ export const TELEMETRY_ALLOWED_FIELDS = new Set<string>([
   "prefix_construction_failure",
   "prefix_capacity_refusal",
   "prefix_cold_fallback",
+  // KV-backend discriminator (v0.8.0 paged rollout). `backend` stays the
+  // engine/runtime name; `kv_backend` is the KV storage kind, the same key
+  // and vocabulary as BackendSlotCapacity.kv_backend on the heartbeat wire.
+  // `prefix_reuse_backend` is the finer prefix-reuse row identity.
+  "kv_backend",
+  "prefix_reuse_backend",
+  // Paged KV pool metrics: aggregate pool counters only.
+  "pages_pinned",
+  "cow_events",
+  "pool_utilization",
+  // MTP (speculative decode) posture. MTP inflates observed_decode_tps with
+  // no discriminator, so a partially-MTP fleet biases routing on a metric the
+  // coordinator believes is homogeneous. Bounded enums and counters only.
+  "mtp_enabled",
+  "mtp_active",
+  "mtp_inactive_reason",
+  "mtp_acceptance_rate",
 ]);

--- a/coordinator/api/telemetry_allowlist_parity_test.go
+++ b/coordinator/api/telemetry_allowlist_parity_test.go
@@ -1,0 +1,399 @@
+package api
+
+// Three-way telemetry field-allowlist parity guard.
+//
+// The allowlist is mirrored in three places:
+//
+//	Go   (authoritative, server-side filter) telemetryFieldAllowlist, this package
+//	Swift (client-side pre-filter)           provider-swift/Sources/ProviderCore/Telemetry/TelemetryEvent.swift
+//	TS   (console-ui client-side set)        console-ui/src/lib/telemetry-types.ts
+//
+// Drift is silent in the dangerous direction: add a field to Go alone and the
+// Swift client filter strips it before transmission, so the field simply never
+// exists. Nothing errors, no test fails, and the gap is invisible until someone
+// goes looking for a metric that was never emitted. The pre-existing guards all
+// miss this — coordinator/protocol/telemetry_symmetry_test.go pins event shape,
+// TelemetrySymmetryTests.swift pins the kind set, and
+// TestTelemetryFieldAllowlistHasKnownKeys only checks Go-side existence of seven
+// hardcoded keys.
+//
+// This test parses the two client mirrors out of their source files at test time
+// and asserts set equality against the Go map. The "parser" is deliberately dumb:
+// it locates the set literal by its opening line, then pulls double-quoted string
+// members out of it. It is not a Swift or TypeScript parser and must never grow
+// into one — if either literal stops being a flat list of quoted strings, rewrite
+// this guard rather than teaching it syntax.
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+const (
+	mirrorSwift = "Swift"
+	mirrorTS    = "TypeScript"
+
+	swiftAllowlistPath = "provider-swift/Sources/ProviderCore/Telemetry/TelemetryEvent.swift"
+	tsAllowlistPath    = "console-ui/src/lib/telemetry-types.ts"
+
+	swiftAllowlistOpen  = "private static let allowed: Set<String> = ["
+	swiftAllowlistClose = "]"
+
+	tsAllowlistOpen  = "export const TELEMETRY_ALLOWED_FIELDS = new Set<string>(["
+	tsAllowlistClose = "]);"
+)
+
+// ---------------------------------------------------------------------------
+// Known, documented, pre-existing gaps
+// ---------------------------------------------------------------------------
+
+// telemetryMirrorGap is one (key, mirror) pair that is currently allowed to
+// disagree with the Go allowlist.
+type telemetryMirrorGap struct {
+	key    string
+	mirror string
+	why    string
+}
+
+// telemetryKnownMirrorGaps enumerates the realised drift that already ships, as
+// documented in docs/reference/telemetry-schema.md:110 ("Discrepancies").
+//
+// These are client-side completeness gaps, not wire incompatibilities: the Go
+// server accepts all five keys, but the named client never sends them because
+// its own filter drops them first. Fixing the drift is a separate change with
+// its own review — this list exists so that the guard passes on the current tree
+// while still catching any NEW divergence.
+//
+// Each entry must be justified. To retire one, delete it here and add the key to
+// the named mirror in the same change; TestTelemetryAllowlistKnownGapsAreStillReal
+// fails on stale entries so this list cannot rot.
+var telemetryKnownMirrorGaps = []telemetryMirrorGap{
+	// 1. network_reachable — emitted only by coordinator-side connectivity
+	//    bookkeeping today; neither client populates it.
+	{key: "network_reachable", mirror: mirrorSwift, why: "docs/reference/telemetry-schema.md:110 — Go only"},
+	{key: "network_reachable", mirror: mirrorTS, why: "docs/reference/telemetry-schema.md:110 — Go only"},
+
+	// 2. coordinator_url — same connectivity group as network_reachable.
+	{key: "coordinator_url", mirror: mirrorSwift, why: "docs/reference/telemetry-schema.md:110 — Go only"},
+	{key: "coordinator_url", mirror: mirrorTS, why: "docs/reference/telemetry-schema.md:110 — Go only"},
+
+	// 3. url — browser context; the TS mirror has it, Swift has no use for it.
+	{key: "url", mirror: mirrorSwift, why: "docs/reference/telemetry-schema.md:110 — Go, TS (console-UI context)"},
+
+	// 4. user_agent — browser context; TS only, as above.
+	{key: "user_agent", mirror: mirrorSwift, why: "docs/reference/telemetry-schema.md:110 — Go, TS (console-UI context)"},
+
+	// 5. route — console-UI SPA route; TS only, as above.
+	{key: "route", mirror: mirrorSwift, why: "docs/reference/telemetry-schema.md:110 — Go, TS (console-UI context)"},
+}
+
+func telemetryGapIndex() map[string]map[string]string {
+	idx := make(map[string]map[string]string, len(telemetryKnownMirrorGaps))
+	for _, g := range telemetryKnownMirrorGaps {
+		if idx[g.key] == nil {
+			idx[g.key] = map[string]string{}
+		}
+		idx[g.key][g.mirror] = g.why
+	}
+	return idx
+}
+
+// ---------------------------------------------------------------------------
+// Diff
+// ---------------------------------------------------------------------------
+
+// telemetryParityFinding is one actionable disagreement between mirrors.
+type telemetryParityFinding struct {
+	key    string
+	mirror string // the mirror that is out of step
+	detail string
+}
+
+func (f telemetryParityFinding) String() string {
+	return "  " + f.key + ": " + f.detail
+}
+
+// diffTelemetryMirrors compares each client mirror against the authoritative Go
+// allowlist in both directions and returns every disagreement not covered by
+// telemetryKnownMirrorGaps.
+//
+// Missing-from-client is the silent-drift direction (field never transmitted).
+// Extra-in-client is the wasted-bandwidth direction (field sent, dropped by the
+// server) and is never excused.
+func diffTelemetryMirrors(goSet map[string]struct{}, mirrors map[string]map[string]struct{}, excused map[string]map[string]string) []telemetryParityFinding {
+	var out []telemetryParityFinding
+
+	names := make([]string, 0, len(mirrors))
+	for name := range mirrors {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		client := mirrors[name]
+
+		for _, key := range telemetrySortedKeys(goSet) {
+			if _, ok := client[key]; ok {
+				continue
+			}
+			if _, ok := excused[key][name]; ok {
+				continue
+			}
+			out = append(out, telemetryParityFinding{
+				key:    key,
+				mirror: name,
+				detail: "present in Go (telemetryFieldAllowlist) but MISSING from the " + name +
+					" mirror — the " + name + " client filter will strip it, so the field will never be transmitted",
+			})
+		}
+
+		for _, key := range telemetrySortedKeys(client) {
+			if _, ok := goSet[key]; ok {
+				continue
+			}
+			out = append(out, telemetryParityFinding{
+				key:    key,
+				mirror: name,
+				detail: "present in the " + name + " mirror but MISSING from Go (telemetryFieldAllowlist) — " +
+					"the server will drop it on ingest",
+			})
+		}
+	}
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+func TestTelemetryAllowlistThreeWayParity(t *testing.T) {
+	root := telemetryRepoRoot(t)
+
+	swift := loadTelemetryMirror(t, filepath.Join(root, swiftAllowlistPath), swiftAllowlistOpen, swiftAllowlistClose, mirrorSwift)
+	ts := loadTelemetryMirror(t, filepath.Join(root, tsAllowlistPath), tsAllowlistOpen, tsAllowlistClose, mirrorTS)
+
+	findings := diffTelemetryMirrors(
+		telemetryFieldAllowlist,
+		map[string]map[string]struct{}{mirrorSwift: swift, mirrorTS: ts},
+		telemetryGapIndex(),
+	)
+	if len(findings) == 0 {
+		return
+	}
+
+	var b strings.Builder
+	b.WriteString("telemetry field allowlist has drifted between mirrors:\n")
+	for _, f := range findings {
+		b.WriteString(f.String())
+		b.WriteString("\n")
+	}
+	b.WriteString("\nAll three mirrors must agree:\n")
+	b.WriteString("  Go   coordinator/api/telemetry_handlers.go        telemetryFieldAllowlist\n")
+	b.WriteString("  " + mirrorSwift + " " + swiftAllowlistPath + "  TelemetryFieldFilter.allowed\n")
+	b.WriteString("  " + mirrorTS + " " + tsAllowlistPath + "        TELEMETRY_ALLOWED_FIELDS\n")
+	b.WriteString("Add the key to every mirror. If the omission is deliberate, add it to\n")
+	b.WriteString("telemetryKnownMirrorGaps in this file with a justification.\n")
+	t.Fatal(b.String())
+}
+
+// TestTelemetryAllowlistKnownGapsAreStillReal keeps the exception list honest: an
+// entry that no longer describes real drift must be deleted, not left to silently
+// excuse a future regression on the same key.
+func TestTelemetryAllowlistKnownGapsAreStillReal(t *testing.T) {
+	root := telemetryRepoRoot(t)
+
+	mirrors := map[string]map[string]struct{}{
+		mirrorSwift: loadTelemetryMirror(t, filepath.Join(root, swiftAllowlistPath), swiftAllowlistOpen, swiftAllowlistClose, mirrorSwift),
+		mirrorTS:    loadTelemetryMirror(t, filepath.Join(root, tsAllowlistPath), tsAllowlistOpen, tsAllowlistClose, mirrorTS),
+	}
+
+	for _, g := range telemetryKnownMirrorGaps {
+		client, ok := mirrors[g.mirror]
+		if !ok {
+			t.Errorf("known gap %q names unknown mirror %q", g.key, g.mirror)
+			continue
+		}
+		if _, inGo := telemetryFieldAllowlist[g.key]; !inGo {
+			t.Errorf("stale exception: %q is no longer in the Go allowlist; remove the %s entry from telemetryKnownMirrorGaps",
+				g.key, g.mirror)
+			continue
+		}
+		if _, present := client[g.key]; present {
+			t.Errorf("stale exception: %q is now present in the %s mirror; remove that entry from telemetryKnownMirrorGaps "+
+				"(and update docs/reference/telemetry-schema.md:110)", g.key, g.mirror)
+		}
+	}
+}
+
+// TestTelemetryAllowlistDiffDetectsNewDrift exercises the comparison itself on
+// synthetic sets, so the guard's teeth are proven independently of whatever the
+// real mirrors happen to contain today.
+func TestTelemetryAllowlistDiffDetectsNewDrift(t *testing.T) {
+	goSet := map[string]struct{}{"shared": {}, "go_only": {}, "excused": {}}
+	mirrors := map[string]map[string]struct{}{
+		mirrorSwift: {"shared": {}, "excused_is_absent_here": {}},
+		mirrorTS:    {"shared": {}, "go_only": {}},
+	}
+	excused := map[string]map[string]string{
+		"excused": {mirrorSwift: "test", mirrorTS: "test"},
+	}
+
+	findings := diffTelemetryMirrors(goSet, mirrors, excused)
+
+	want := map[string]string{
+		mirrorSwift + "/go_only":                "missing from client",
+		mirrorSwift + "/excused_is_absent_here": "missing from Go",
+	}
+	got := map[string]bool{}
+	for _, f := range findings {
+		got[f.mirror+"/"+f.key] = true
+	}
+	for k := range want {
+		if !got[k] {
+			t.Errorf("diff missed %s; findings: %v", k, findings)
+		}
+	}
+	if got[mirrorSwift+"/excused"] || got[mirrorTS+"/excused"] {
+		t.Errorf("diff reported an excused gap; findings: %v", findings)
+	}
+	if got[mirrorTS+"/go_only"] {
+		t.Errorf("diff reported a key the TS mirror does have; findings: %v", findings)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Source-file scraping
+// ---------------------------------------------------------------------------
+
+// telemetryRepoRoot walks up from the test's working directory (coordinator/api)
+// looking for the module root. Skips rather than fails when it cannot find one,
+// so the guard is inert in a partial checkout instead of spuriously red.
+func telemetryRepoRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Skipf("cannot determine working directory: %v", err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Skip("repo root (go.mod) not found above the test working directory; " +
+				"skipping telemetry allowlist parity check")
+		}
+		dir = parent
+	}
+}
+
+// loadTelemetryMirror reads one client allowlist. A missing file skips the test
+// (partial checkout — provider-swift and console-ui are not needed to build the
+// coordinator); a present-but-unparseable file fails, because that means the
+// literal changed shape and the guard has quietly stopped guarding.
+func loadTelemetryMirror(t *testing.T, path, openMark, closeMark, name string) map[string]struct{} {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			t.Skipf("%s mirror not present at %s; skipping telemetry allowlist parity check", name, path)
+		}
+		t.Fatalf("read %s mirror %s: %v", name, path, err)
+	}
+	set, err := parseQuotedSetLiteral(string(raw), openMark, closeMark)
+	if err != nil {
+		t.Fatalf("parse %s allowlist in %s: %v\n"+
+			"The set literal changed shape. Update the markers in "+
+			"telemetry_allowlist_parity_test.go — do not delete this guard.", name, path, err)
+	}
+	return set
+}
+
+// parseQuotedSetLiteral extracts the double-quoted members of a flat set literal.
+//
+// It scans for the line containing openMark, then consumes lines until one whose
+// trimmed text equals closeMark, collecting every double-quoted token. Line
+// comments are stripped first so commentary cannot contribute phantom members.
+func parseQuotedSetLiteral(src, openMark, closeMark string) (map[string]struct{}, error) {
+	lines := strings.Split(src, "\n")
+
+	start := -1
+	for i, line := range lines {
+		if strings.Contains(line, openMark) {
+			start = i
+			break
+		}
+	}
+	if start < 0 {
+		return nil, fmt.Errorf("opening marker %q not found", openMark)
+	}
+
+	out := make(map[string]struct{})
+	// Tolerate members on the opening line itself (neither mirror does this
+	// today, but the literals get reflowed by formatters).
+	head := lines[start][strings.Index(lines[start], openMark)+len(openMark):]
+	collectQuotedTokens(stripTrailingLineComment(head), out)
+
+	for _, line := range lines[start+1:] {
+		body := stripTrailingLineComment(line)
+		if strings.TrimSpace(body) == closeMark {
+			if len(out) == 0 {
+				return nil, fmt.Errorf("set literal after %q is empty", openMark)
+			}
+			return out, nil
+		}
+		collectQuotedTokens(body, out)
+	}
+	return nil, fmt.Errorf("closing marker %q not found after %q", closeMark, openMark)
+}
+
+// stripTrailingLineComment removes a trailing // comment, ignoring // that
+// appears inside a double-quoted string.
+func stripTrailingLineComment(line string) string {
+	inQuote, escaped := false, false
+	for i := range len(line) {
+		c := line[i]
+		switch {
+		case escaped:
+			escaped = false
+		case c == '\\' && inQuote:
+			escaped = true
+		case c == '"':
+			inQuote = !inQuote
+		case c == '/' && !inQuote && i+1 < len(line) && line[i+1] == '/':
+			return line[:i]
+		}
+	}
+	return line
+}
+
+// collectQuotedTokens adds every double-quoted token in s to out.
+func collectQuotedTokens(s string, out map[string]struct{}) {
+	for {
+		i := strings.IndexByte(s, '"')
+		if i < 0 {
+			return
+		}
+		j := strings.IndexByte(s[i+1:], '"')
+		if j < 0 {
+			return
+		}
+		if key := s[i+1 : i+1+j]; key != "" {
+			out[key] = struct{}{}
+		}
+		s = s[i+j+2:]
+	}
+}
+
+func telemetrySortedKeys(m map[string]struct{}) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/coordinator/api/telemetry_handlers.go
+++ b/coordinator/api/telemetry_handlers.go
@@ -150,8 +150,13 @@ var telemetryFieldAllowlist = map[string]struct{}{
 	"prefix_reuse_backend": {},
 	// Paged KV pool metrics (v0.8.0). Aggregate pool counters only — never
 	// page contents or block hashes. Mirror of the Swift + TS allowlists.
-	"pages_pinned":     {},
-	"cow_events":       {},
+	// pages_pinned and cow_events are deliberately NOT allowlisted. Neither
+	// mechanism exists: PagedKVPool has no pin concept (only reserve/in-use)
+	// and copy-on-write page splitting is unimplemented — every page is
+	// refcount 0 or 1. An allowlisted key with no producer is worse than an
+	// absent one, because it reads as a legitimate zero: a panel built on
+	// cow_events would report "no COW events" for a feature that does not
+	// exist. Add the key WITH its mechanism, in all three mirrors at once.
 	"pool_utilization": {},
 	// Paged pool re-slice residue (v0.8.0 co-residency). RAW BYTES, and
 	// deliberately not a second ratio: pool_utilization above is OCCUPANCY,

--- a/coordinator/api/telemetry_handlers.go
+++ b/coordinator/api/telemetry_handlers.go
@@ -153,6 +153,18 @@ var telemetryFieldAllowlist = map[string]struct{}{
 	"pages_pinned":     {},
 	"cow_events":       {},
 	"pool_utilization": {},
+	// Paged pool re-slice residue (v0.8.0 co-residency). RAW BYTES, and
+	// deliberately not a second ratio: pool_utilization above is OCCUPANCY,
+	// and a grant-vs-pool ratio under a near-identical name collides with it
+	// in every dashboard that groups by kv_backend. A clamped min(a,b)/b also
+	// discards the overflow magnitude — precisely the figure needed when a
+	// slot's fair share exceeds its committed pool and the box 503s on
+	// stranded slabs. pool_bytes is the denominator, emitted so share-of-pool
+	// stays derivable from the raw terms. See docs/reference/telemetry-schema.md
+	// "Adding a field: one key, one meaning".
+	"pool_bytes":                 {},
+	"pool_deferred_growth_bytes": {},
+	"pool_stranded_bytes":        {},
 	// Multi-token prediction (speculative decode) posture. MTP inflates
 	// observed_decode_tps with no discriminator, so a partially-MTP fleet
 	// biases coordinator routing on a metric it believes is homogeneous;

--- a/coordinator/api/telemetry_handlers.go
+++ b/coordinator/api/telemetry_handlers.go
@@ -139,6 +139,31 @@ var telemetryFieldAllowlist = map[string]struct{}{
 	"prefix_construction_failure": {},
 	"prefix_capacity_refusal":     {},
 	"prefix_cold_fallback":        {},
+	// KV-backend discriminator (v0.8.0 paged rollout). `backend` names the
+	// ENGINE or runtime ("engine_v2", "mlx-swift"); `kv_backend` names the KV
+	// storage kind ("paged" | "contiguous") and is deliberately the same key
+	// as BackendSlotCapacity.KVBackend on the heartbeat wire, so telemetry and
+	// per-slot capacity group identically. `prefix_reuse_backend` is the finer
+	// prefix-reuse row identity (contiguous_unquantized | contiguous_quantized
+	// | paged_fp16 | unknown) that "contiguous" alone cannot express.
+	"kv_backend":           {},
+	"prefix_reuse_backend": {},
+	// Paged KV pool metrics (v0.8.0). Aggregate pool counters only — never
+	// page contents or block hashes. Mirror of the Swift + TS allowlists.
+	"pages_pinned":     {},
+	"cow_events":       {},
+	"pool_utilization": {},
+	// Multi-token prediction (speculative decode) posture. MTP inflates
+	// observed_decode_tps with no discriminator, so a partially-MTP fleet
+	// biases coordinator routing on a metric it believes is homogeneous;
+	// these four make the split visible. mtp_inactive_reason carries
+	// MTPFallbackReason values plus "inert_kv_unsupported" — enabled, drafter
+	// resident, zero rounds executed, every row skipped as kv_unsupported.
+	// Bounded enums and counters only; never draft tokens or prompt content.
+	"mtp_enabled":         {},
+	"mtp_active":          {},
+	"mtp_inactive_reason": {},
+	"mtp_acceptance_rate": {},
 	// Console UI context
 	"url":        {},
 	"user_agent": {},

--- a/coordinator/api/telemetry_handlers_test.go
+++ b/coordinator/api/telemetry_handlers_test.go
@@ -197,6 +197,10 @@ func TestTelemetryIngest_UnknownEnumsCoerced(t *testing.T) {
 	}
 }
 
+// TestTelemetryFieldAllowlistHasKnownKeys is a Go-side existence spot-check only.
+// Cross-language agreement between the Go, Swift, and TypeScript allowlists is
+// enforced by TestTelemetryAllowlistThreeWayParity in
+// telemetry_allowlist_parity_test.go.
 func TestTelemetryFieldAllowlistHasKnownKeys(t *testing.T) {
 	for _, k := range []string{"component", "model", "exit_code", "reason", "duration_ms", "boot_macos_major", "boot_sip_status"} {
 		if _, ok := telemetryFieldAllowlist[k]; !ok {

--- a/coordinator/protocol/messages.go
+++ b/coordinator/protocol/messages.go
@@ -281,6 +281,27 @@ type BackendSlotCapacity struct {
 	KVBytesPerToken       int64   `json:"kv_bytes_per_token,omitempty"`       // per-token KV cache memory cost in bytes (provider-side only)
 	ModelLoadTimeMS       int64   `json:"model_load_time_ms,omitempty"`       // measured cold-start load time (ms) for the model in this slot; omitted when unmeasured
 
+	// KVBackend names the KV-cache backend this slot's engine was actually
+	// built with — the provider's `EngineV2Bridge.kvBackendKind`, i.e. the
+	// RESOLVED kind after every veto and fallback, not the operator's
+	// requested `engine_v2_kv_backend`. Values: "paged" | "contiguous".
+	// This is the fleet's only per-slot, every-heartbeat record of the
+	// v0.8.0 paged rollout; without it a mixed fleet cannot be A/B'd on
+	// TTFT, decode TPS or error rate by backend, and a fleet-wide
+	// regression cannot be attributed to the rollout at all.
+	//
+	// POINTER, deliberately. Pre-0.8.0 providers omit the key entirely and
+	// nil MUST read as "unknown", never as "contiguous" — otherwise the
+	// rollout dashboard books every legacy provider as a contiguous sample
+	// and the comparison lies. A non-nil pointer to "" still marshals as
+	// `"kv_backend":""` (omitempty tests the pointer, not the pointee), so
+	// an authoritative "slot present, backend unnameable" stays distinct
+	// from omission. Same idiom as FreeForLoadGB / PrefixCacheStatuses.
+	//
+	// MEASUREMENT ONLY — decoded for observability; routing is NOT gated on
+	// it. Acting on the backend kind is a separate change.
+	KVBackend *string `json:"kv_backend,omitempty"`
+
 	// Engine-health (first-token wedge) signals — low-cardinality, NON-PRIVATE
 	// diagnostics that let the coordinator SEE a wedged MLX/Metal first-token
 	// path (provider emits the preamble, then the first blocking eval never

--- a/coordinator/protocol/messages_backend_capacity_test.go
+++ b/coordinator/protocol/messages_backend_capacity_test.go
@@ -422,3 +422,143 @@ func TestBackendSlotCapacityWedgeFields(t *testing.T) {
 		t.Fatalf("legacy slot should default wedge fields to zero/false, got %+v", legacy)
 	}
 }
+
+// The v0.8.0 paged-KV rollout discriminator. `KVBackend` is a *string, not a
+// string, for exactly one reason: a pre-0.8.0 provider omits `kv_backend`
+// entirely and nil must read as UNKNOWN. A plain string would decode omission
+// to "", making "old provider" indistinguishable from any value a provider
+// actually sent — and a rollout dashboard that folds unknown into contiguous
+// reports an A/B comparison that is simply false. The three tests below pin
+// present, omitted and explicit-empty as three DIFFERENT decoded states.
+
+func TestBackendSlotCapacityKVBackendRoundTrip(t *testing.T) {
+	paged := "paged"
+	msg := HeartbeatMessage{
+		Type:   TypeHeartbeat,
+		Status: "serving",
+		BackendCapacity: &BackendCapacity{
+			Slots: []BackendSlotCapacity{{
+				Model:     "gemma-4-26b-qat-4bit",
+				State:     "running",
+				KVBackend: &paged,
+			}},
+		},
+	}
+
+	data, err := json.Marshal(msg)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !bytes.Contains(data, []byte(`"kv_backend":"paged"`)) {
+		t.Fatalf("kv_backend missing from wire: %s", data)
+	}
+
+	var decoded HeartbeatMessage
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if decoded.BackendCapacity == nil || len(decoded.BackendCapacity.Slots) != 1 {
+		t.Fatalf("decoded slots = %+v", decoded.BackendCapacity)
+	}
+	got := decoded.BackendCapacity.Slots[0].KVBackend
+	if got == nil {
+		t.Fatal("KVBackend decoded nil, want \"paged\"")
+	}
+	if *got != "paged" {
+		t.Fatalf("KVBackend=%q, want \"paged\"", *got)
+	}
+
+	// The other shipped kind, so the field is not accidentally paged-only and a
+	// contiguous slot is a POSITIVE observation rather than an absence.
+	contiguous := "contiguous"
+	slotData, err := json.Marshal(BackendSlotCapacity{
+		Model: "gpt-oss-20b", State: "running", KVBackend: &contiguous,
+	})
+	if err != nil {
+		t.Fatalf("marshal contiguous: %v", err)
+	}
+	var contiguousSlot BackendSlotCapacity
+	if err := json.Unmarshal(slotData, &contiguousSlot); err != nil {
+		t.Fatalf("unmarshal contiguous: %v", err)
+	}
+	if contiguousSlot.KVBackend == nil || *contiguousSlot.KVBackend != "contiguous" {
+		t.Fatalf("contiguous round-trip = %v", contiguousSlot.KVBackend)
+	}
+}
+
+func TestBackendSlotCapacityKVBackendOmittedCompatibility(t *testing.T) {
+	// Exactly the pre-0.8.0 heartbeat shape.
+	data := []byte(`{
+		"type":"heartbeat",
+		"status":"serving",
+		"active_model":null,
+		"stats":{},
+		"system_metrics":{},
+		"backend_capacity":{"slots":[{"model":"qwen","state":"running"}]}
+	}`)
+
+	var decoded HeartbeatMessage
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if decoded.BackendCapacity == nil || len(decoded.BackendCapacity.Slots) != 1 {
+		t.Fatalf("decoded slots = %+v", decoded.BackendCapacity)
+	}
+	// nil, i.e. UNKNOWN — not "", not "contiguous". A legacy provider is not a
+	// contiguous data point.
+	if got := decoded.BackendCapacity.Slots[0].KVBackend; got != nil {
+		t.Fatalf("omitted kv_backend decoded to %q, want nil (unknown)", *got)
+	}
+
+	// Reverse direction: a slot that never sets it keeps the prior wire shape,
+	// so a 0.8.0 coordinator stays byte-compatible with pre-0.8.0 consumers.
+	legacyShape, err := json.Marshal(BackendSlotCapacity{Model: "qwen", State: "running"})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if bytes.Contains(legacyShape, []byte("kv_backend")) {
+		t.Fatalf("nil KVBackend should be omitted, got %s", legacyShape)
+	}
+}
+
+func TestBackendSlotCapacityKVBackendExplicitEmptyCompatibility(t *testing.T) {
+	data := []byte(`{
+		"type":"heartbeat",
+		"status":"serving",
+		"active_model":null,
+		"stats":{},
+		"system_metrics":{},
+		"backend_capacity":{"slots":[{"model":"qwen","state":"running","kv_backend":""}]}
+	}`)
+
+	var decoded HeartbeatMessage
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if decoded.BackendCapacity == nil || len(decoded.BackendCapacity.Slots) != 1 {
+		t.Fatalf("decoded slots = %+v", decoded.BackendCapacity)
+	}
+	got := decoded.BackendCapacity.Slots[0].KVBackend
+	if got == nil {
+		t.Fatal("explicit empty kv_backend decoded to nil: omission and an explicit empty value must stay distinguishable")
+	}
+	if *got != "" {
+		t.Fatalf("explicit empty kv_backend = %q, want \"\"", *got)
+	}
+
+	// `omitempty` on a POINTER tests the pointer, not the pointee, so an
+	// explicit "" survives a re-marshal instead of collapsing into omission.
+	// This is the mechanism the whole present/omitted/empty distinction rests
+	// on: a plain `string` field would drop the key here and silently downgrade
+	// an authoritative empty value to "unknown".
+	empty := ""
+	reencoded, err := json.Marshal(BackendSlotCapacity{
+		Model: "qwen", State: "running", KVBackend: &empty,
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !bytes.Contains(reencoded, []byte(`"kv_backend":""`)) {
+		t.Fatalf("explicit empty kv_backend should survive marshal, got %s", reencoded)
+	}
+}

--- a/coordinator/registry/concurrency_cap.go
+++ b/coordinator/registry/concurrency_cap.go
@@ -28,6 +28,24 @@ import (
 // single-stream decode rate (resolvedDecodeTPS), NEVER the observed-under-load
 // EWMA: the observed rate collapses under the very overload this cap exists to
 // prevent, which would force the cap to 1 — a feedback loop.
+//
+// Raising a backend's own concurrency ceiling therefore buys NOTHING on its
+// own. The provider-reported number is only the `base` operand of the MIN
+// below; the resolved per-model SOLO RATE decides. Inverting the cap math, a
+// provider is granted its full reported N only above
+//
+//	q    = floor((N-1)/overcommit) + 1     # smallest quality batch whose
+//	                                       # ceil(q·overcommit) still reaches N
+//	solo >= floor · (1 + k·q)              # N=8, floor 15, overcommit 1.2:
+//	                                       #   39.3 tok/s at k=0.27
+//	                                       #   50.1 tok/s at k=0.39
+//
+// and a model whose resolved rate sits under that gets the quality batch, not
+// the bump. The rate is what needs fixing when a bump does not land — usually
+// by seeding it (modelSoloTPSSeedEnv), because solo sampling is gated on a
+// fully uncontended box (soloSampleEligible) and a model that is BUSY at the
+// new concurrency never produces another sample. See
+// TestQualityCapReachesProviderReportedConcurrency for the pinned relationship.
 
 // defaultQualityCapOvercommit is the effective overcommit when the operator has
 // not set EIGENINFERENCE_QUALITY_CONCURRENCY_OVERCOMMIT. The legacy 2.0 diluted

--- a/coordinator/registry/concurrency_cap.go
+++ b/coordinator/registry/concurrency_cap.go
@@ -226,10 +226,33 @@ type soloModelTPS struct {
 //     a modelSoloTPSSeedEnv seed exists, it is an upper bound on that transfer:
 //     observations from faster classes cannot widen an unsampled slower class's
 //     cap above its configured cold-start estimate;
-//  3. the modelSoloTPSSeedEnv seed when there is no trusted cross-class rate
-//     (the TPS registry is in-memory and restart-wiped);
-//  4. the provider-level resolvedDecodeTPS(p) — exactly the pre-per-model
+//  3. the same-class solo median with FEWER than qualityCapSoloMinSamples
+//     samples (but at least one), then the same-chip-agnostic cross-class
+//     median under the same relaxation, seed-clamped as in (2). These are
+//     under-sampled but they are still MEASURED and still solo-gated, and the
+//     alternative below them is a model-AGNOSTIC hardware proxy: preferring
+//     sqrt(memory_bandwidth) over the provider's own measurement of this exact
+//     model is strictly worse information. See the note on convergence below;
+//  4. the modelSoloTPSSeedEnv seed when there is no measured rate at all
+//     (the TPS registry is in-memory and restart-wiped, and a provider that
+//     has completed no request reports no rate — see below);
+//  5. the provider-level resolvedDecodeTPS(p) — exactly the pre-per-model
 //     behavior, including its sqrt-bandwidth fallback semantics.
+//
+// What a provider reports BEFORE its first completion: nothing. The bridge's
+// EWMA (EngineV2Bridge.observedDecodeTpsEwma) is 0 until updateDecodeTpsEwma
+// runs on a terminal event, `observed_decode_tps` is `omitempty`, and the
+// heartbeat ingest only calls RecordSolo when the reported value is > 0
+// (registry.go). So a fresh provider contributes NO solo sample, reaches (4)
+// or (5), and is never capped at 1 by its own silence. Steps (3) can only
+// engage once a real decode has been measured.
+//
+// Under-sampled samples converge from BELOW, which is the safe direction. The
+// bridge EWMA (alpha = 0.3) blends prior batched decodes, so the first sample
+// taken as the box drops to a single running request UNDER-states the true
+// solo rate; it can never materially over-state it (solo is the fastest case,
+// and the ingest path already clamps to maxDecodeTPS). An under-stated rate
+// yields a TIGHTER cap, never a permissive one.
 //
 // The rate is deliberately STATIC (never an under-load EWMA): an observed rate
 // collapses under the very overload the cap exists to prevent, which would
@@ -241,15 +264,30 @@ type soloModelTPS struct {
 // r.mu and p.mu.
 func (r *Registry) resolvedSoloModelTPSLocked(p *Provider, model string) soloModelTPS {
 	if qualityCapPerModelTPS {
-		if tps, n := r.tpsRegistry.SoloMedian(model, chipClassKey(p.Hardware)); n >= qualityCapSoloMinSamples && tps > 0 {
-			return soloModelTPS{tps: tps, perModel: true}
+		classTPS, classN := r.tpsRegistry.SoloMedian(model, chipClassKey(p.Hardware))
+		if classN >= qualityCapSoloMinSamples && classTPS > 0 {
+			return soloModelTPS{tps: classTPS, perModel: true}
 		}
 		seed, hasSeed := modelSoloTPSSeed[strings.ToLower(model)]
-		if tps, n := r.tpsRegistry.SoloMedianAllChips(model); n >= qualityCapSoloMinSamples && tps > 0 {
-			if hasSeed && seed < tps {
-				tps = seed
-			}
-			return soloModelTPS{tps: tps, perModel: true}
+		// Seed-clamp the cross-class transfer: observations from faster classes
+		// cannot widen an unsampled slower class's cap above its configured
+		// cold-start estimate. Applies at both sample floors.
+		allTPS, allN := r.tpsRegistry.SoloMedianAllChips(model)
+		if allTPS > 0 && hasSeed && seed < allTPS {
+			allTPS = seed
+		}
+		if allN >= qualityCapSoloMinSamples && allTPS > 0 {
+			return soloModelTPS{tps: allTPS, perModel: true}
+		}
+		// Measured but under-sampled. Ranked below both trusted medians and
+		// above the seed: a real solo-gated measurement of THIS model beats a
+		// fleet-wide configured guess, and both beat the model-agnostic
+		// sqrt-bandwidth proxy that pins a fast model to cap 1-2.
+		if classN > 0 && classTPS > 0 {
+			return soloModelTPS{tps: classTPS, perModel: true}
+		}
+		if allN > 0 && allTPS > 0 {
+			return soloModelTPS{tps: allTPS, perModel: true}
 		}
 		if hasSeed {
 			return soloModelTPS{tps: seed, perModel: true}

--- a/coordinator/registry/concurrency_cap_test.go
+++ b/coordinator/registry/concurrency_cap_test.go
@@ -2,6 +2,7 @@ package registry
 
 import (
 	"fmt"
+	"math"
 	"testing"
 	"time"
 
@@ -43,6 +44,100 @@ func enableQualityCap(t *testing.T, reg *Registry, overcommitEnv string) {
 	reg.SetQualityConcurrencyCap(true, env.EnvFloat(key, 2.0), 15, 4)
 }
 
+// --- k-derived expectations --------------------------------------------------
+//
+// effectiveTPSLoadFactor is MEASURED, not chosen: the shipped 0.27 was fitted on
+// a legacy engine (Qwen2.5-7B-4bit), and the CBv2 decode curves for the models
+// this coordinator actually serves re-fit it to ~0.39 (median implied k over
+// B = 2/4/8; libs/mlx-swift-lm/benchmarks/reports/gemma4-26b-qat4bit-paged-gate-2026-07-09.md).
+// Every cap integer below is a function of that coefficient, so hard-coding the
+// integers means one re-measurement invalidates a dozen tests that are not about
+// arithmetic at all — and teaches the next reader nothing about WHY the number
+// is what it is. The tests therefore pin the RELATIONSHIP
+// cap = f(solo, floor, k, base, overcommit); the closed form itself is pinned
+// once, against an independent derivation, by
+// TestQualityConcurrencyMatchesDefiningInequality.
+
+// strictQualityBatch answers qualityConcurrency's question from its DEFINING
+// inequality — the largest batch B in [1, limit] whose projected per-request
+// rate solo/(1+k·B) still clears floor — by search instead of algebra. It is
+// deliberately not the closed form, so it can catch an off-by-one or a dropped
+// clamp in floor((solo/floor - 1)/k). Like the closed form it never returns 0:
+// a provider is never fully closed, even for a model that misses the floor at
+// B=1.
+func strictQualityBatch(solo, floor, k float64, limit int) int {
+	if limit < 1 {
+		limit = 1
+	}
+	if floor <= 0 || solo <= 0 || k <= 0 {
+		return limit
+	}
+	best := 1
+	for b := 1; b <= limit; b++ {
+		if solo/(1+k*float64(b)) >= floor {
+			best = b
+		}
+	}
+	return best
+}
+
+// wantQualityCap is the cap effectiveMaxConcurrencyForModelRateLocked must
+// produce for a provider whose per-slot/flat limit is base: the strict quality
+// batch grown by the overcommit allowance, never below 1, never above base.
+func wantQualityCap(solo, floor float64, base int, overcommit float64) int {
+	capped := int(math.Ceil(float64(strictQualityBatch(solo, floor, effectiveTPSLoadFactor, base)) * overcommit))
+	if capped < 1 {
+		capped = 1
+	}
+	if capped < base {
+		return capped
+	}
+	return base
+}
+
+// soloTPSForCap inverts wantQualityCap: the smallest solo decode rate at which a
+// provider reporting `base` concurrent slots is actually granted all of them.
+// The cap is monotone non-decreasing in the solo rate, so a bisection is exact
+// to the returned tolerance. This is the number an operator needs to size
+// EIGENINFERENCE_MODEL_SOLO_TPS_SEED, and the number that moves when k moves.
+func soloTPSForCap(floor float64, base int, overcommit float64) float64 {
+	lo, hi := 0.0, floor
+	for wantQualityCap(hi, floor, base, overcommit) < base {
+		lo, hi = hi, hi*2
+		if hi > 1e6 {
+			return math.Inf(1)
+		}
+	}
+	for i := 0; i < 200 && hi-lo > 1e-9; i++ {
+		mid := (lo + hi) / 2
+		if wantQualityCap(mid, floor, base, overcommit) < base {
+			lo = mid
+		} else {
+			hi = mid
+		}
+	}
+	return hi
+}
+
+// maxOvercommitDilution is the largest factor by which admitting at the
+// overcommitted cap can push per-request decode below the quality floor.
+//
+// The nominal allowance is the overcommit itself, but the realized one is
+// strictly worse: cap = ceil(qc × overcommit) rounds UP, which at qc = 1 turns
+// an overcommit of 1.2 into a factor of 2. With rate(B) = solo/(1+k·B), the
+// quality batch's defining solo >= floor·(1+k·qc), and ceil(x) < x+1:
+//
+//	rate(cap) > floor·(1+k·qc) / (1 + k·(overcommit·qc + 1))
+//
+// That ratio is monotone in qc — increasing when overcommit < 1+k, decreasing
+// otherwise — so its infimum is the worse of the qc = 1 endpoint and the
+// qc → infinity asymptote (1/overcommit). Pinning the NOMINAL floor/overcommit
+// instead would be pinning a bound the implementation does not provide: it
+// holds at k = 0.27 by luck of the rounding and fails at k = 0.39.
+func maxOvercommitDilution(k, overcommit float64) float64 {
+	return math.Max((1+k+k*overcommit)/(1+k), overcommit)
+}
+
 // TestQualityCapUsesStaticNotObservedTPS is the regression that matters: a slow
 // model's box is capped from its STATIC single-stream rate (~23 tok/s → quality
 // batch 1 → cap 2 = ceil(1 × 1.2) at the default overcommit), and the collapsed
@@ -61,9 +156,10 @@ func TestQualityCapUsesStaticNotObservedTPS(t *testing.T) {
 }
 
 // TestQualityCapScalesWithModelSpeed shows the cap is universal and self-tuning:
-// a fast model (57 tok/s → quality batch 10) keeps a high cap (12 at the default
-// 1.2 overcommit) that never bites normal load, while a slow model (23 tok/s) is
-// tightened to 2.
+// a fast model (57 tok/s) keeps a high cap — an order above normal load — that
+// never bites, while a slow model (23 tok/s, quality batch 1 at any measured k)
+// is tightened to 2. The fast side is k-derived: it is 12 at k = 0.27 and 9 at
+// the CBv2-re-fit 0.39, and neither number is the point.
 func TestQualityCapScalesWithModelSpeed(t *testing.T) {
 	reg := New(testLogger())
 	enableQualityCap(t, reg, "")
@@ -76,8 +172,12 @@ func TestQualityCapScalesWithModelSpeed(t *testing.T) {
 	if got := effCap(reg, slow, gemmaBuild); got != 2 {
 		t.Fatalf("slow cap = %d, want 2", got)
 	}
-	if got := effCap(reg, fast, qwenBuild); got != 12 {
-		t.Fatalf("fast cap = %d, want 12 (ceil(qc 10 × 1.2), ≤ flat 24) — far above normal load, no regression", got)
+	wantFast := wantQualityCap(57, 15, 24, defaultQualityCapOvercommit)
+	if got := effCap(reg, fast, qwenBuild); got != wantFast {
+		t.Fatalf("fast cap = %d, want %d (ceil(quality batch × 1.2) at k=%.2f, ≤ flat 24) — far above normal load, no regression", got, wantFast, effectiveTPSLoadFactor)
+	}
+	if wantFast <= 4 {
+		t.Fatalf("fast cap %d collapsed to slow-model territory at k=%.2f — a 57 tok/s model must keep real headroom", wantFast, effectiveTPSLoadFactor)
 	}
 }
 
@@ -232,50 +332,59 @@ func TestQualityCapDefaultOvercommitIgnoresStaleConfigFallback(t *testing.T) {
 	reg := New(testLogger())
 	reg.SetQualityConcurrencyCap(true, 2.0, 15, 4) // exactly main.go's call with the env unset
 
-	fast := makeSchedulerProvider(t, reg, "fast", qwenBuild, 57) // qc 10
+	fast := makeSchedulerProvider(t, reg, "fast", qwenBuild, 57)
 	budgetSlot(fast, 0)
-	if got := effCap(reg, fast, qwenBuild); got != 12 {
-		t.Fatalf("effective cap = %d, want 12 (default 1.2 must apply, not the stale 2.0 config fallback → 20)", got)
+	want := wantQualityCap(57, 15, 24, defaultQualityCapOvercommit)
+	stale := wantQualityCap(57, 15, 24, 2.0)
+	if want == stale {
+		t.Fatalf("test is blind at k=%.2f: overcommit 1.2 and the stale 2.0 both give cap %d — pick a solo rate that discriminates", effectiveTPSLoadFactor, want)
+	}
+	if got := effCap(reg, fast, qwenBuild); got != want {
+		t.Fatalf("effective cap = %d, want %d (default 1.2 must apply, not the stale 2.0 config fallback → %d)", got, want, stale)
 	}
 }
 
 // TestQualityCapOvercommitDilution is the cap math from the production incident:
-// with floor 15 and k = 0.27, overcommit 2.0 admits enough concurrency that the
-// projected per-request decode rate (solo/(1+k·B) at B = cap) collapses to
-// roughly HALF the floor on fast boxes, while 1.2 keeps it within the overcommit
-// allowance of the floor.
+// overcommit 2.0 admits enough concurrency that the projected per-request decode
+// rate (solo/(1+k·B) at B = cap) collapses to roughly HALF the floor on fast
+// boxes, while 1.2 holds it inside the realized allowance
+// (maxOvercommitDilution). Caps are k-derived; the dilution CONTRAST is the
+// invariant.
 func TestQualityCapOvercommitDilution(t *testing.T) {
-	cases := []struct {
+	const floor = 15.0
+	for _, tc := range []struct {
 		name          string
 		overcommitEnv string
+		overcommit    float64
 		solo          float64
-		wantCap       int
 	}{
-		{"gemma23_at_1.2", "1.2", 23, 2}, // qc 1 → ceil(1.2)
-		{"gemma23_at_2.0", "2.0", 23, 2}, // qc 1 → ceil(2.0)
-		{"solo30_at_1.2", "1.2", 30, 4},  // qc 3 → ceil(3.6)
-		{"solo30_at_2.0", "2.0", 30, 6},  // qc 3 → 6
-		{"solo57_at_1.2", "1.2", 57, 12}, // qc 10 → 12
-		{"solo57_at_2.0", "2.0", 57, 20}, // qc 10 → 20
-	}
-	for _, tc := range cases {
+		{"gemma23_at_1.2", "1.2", 1.2, 23},
+		{"gemma23_at_2.0", "2.0", 2.0, 23},
+		{"solo30_at_1.2", "1.2", 1.2, 30},
+		{"solo30_at_2.0", "2.0", 2.0, 30},
+		{"solo57_at_1.2", "1.2", 1.2, 57},
+		{"solo57_at_2.0", "2.0", 2.0, 57},
+	} {
 		t.Run(tc.name, func(t *testing.T) {
 			reg := New(testLogger())
 			enableQualityCap(t, reg, tc.overcommitEnv)
 			p := makeSchedulerProvider(t, reg, "box", gemmaBuild, tc.solo)
 			budgetSlot(p, 0)
 			got := effCap(reg, p, gemmaBuild)
-			if got != tc.wantCap {
-				t.Fatalf("solo %.0f tok/s at overcommit %s: cap = %d, want %d", tc.solo, tc.overcommitEnv, got, tc.wantCap)
+			want := wantQualityCap(tc.solo, floor, 24, tc.overcommit)
+			if got != want {
+				t.Fatalf("solo %.0f tok/s at overcommit %s: cap = %d, want %d (k=%.2f)", tc.solo, tc.overcommitEnv, got, want, effectiveTPSLoadFactor)
 			}
 			// The dilution difference in decode terms: projected per-request TPS
 			// once the box is filled to its cap.
 			projected := tc.solo / (1 + effectiveTPSLoadFactor*float64(got))
-			if tc.overcommitEnv == "2.0" && tc.solo == 57 && projected >= 15.0*0.6 {
-				t.Fatalf("overcommit 2.0 on a 57 tok/s box projects %.1f tok/s at cap %d — expected roughly half the 15 floor", projected, got)
+			if tc.overcommit == 2.0 && tc.solo == 57 && projected >= floor*0.6 {
+				t.Fatalf("overcommit 2.0 on a 57 tok/s box projects %.1f tok/s at cap %d — expected roughly half the %.0f floor", projected, got, floor)
 			}
-			if tc.overcommitEnv == "1.2" && projected < 15.0/1.2-1e-9 {
-				t.Fatalf("overcommit 1.2 on a %.0f tok/s box projects %.1f tok/s at cap %d — must stay ≥ floor/1.2 (%.2f)", tc.solo, projected, got, 15.0/1.2)
+			bound := floor / maxOvercommitDilution(effectiveTPSLoadFactor, tc.overcommit)
+			if tc.overcommit == 1.2 && projected < bound-1e-9 {
+				t.Fatalf("overcommit 1.2 on a %.0f tok/s box projects %.1f tok/s at cap %d — must stay ≥ %.2f (floor / realized allowance %.3f at k=%.2f)",
+					tc.solo, projected, got, bound, maxOvercommitDilution(effectiveTPSLoadFactor, 1.2), effectiveTPSLoadFactor)
 			}
 		})
 	}
@@ -291,16 +400,18 @@ func TestQualityCapPerModelOverride(t *testing.T) {
 	reg := New(testLogger())
 	enableQualityCap(t, reg, "2.0")
 
-	gemma := makeSchedulerProvider(t, reg, "gemma-box", gemmaBuild, 30) // qc 3
+	gemma := makeSchedulerProvider(t, reg, "gemma-box", gemmaBuild, 30)
 	budgetSlot(gemma, 0)
-	qwen := makeSchedulerProvider(t, reg, "qwen-box", qwenBuild, 30) // qc 3
+	qwen := makeSchedulerProvider(t, reg, "qwen-box", qwenBuild, 30)
 	budgetSlot(qwen, 0)
 
-	if got := effCap(reg, gemma, gemmaBuild); got != 3 {
-		t.Fatalf("override model cap = %d, want 3 (per-model overcommit 1.0 × qc 3, uppercase key must match)", got)
+	wantOverridden := wantQualityCap(30, 15, 24, 1.0)
+	wantGlobal := wantQualityCap(30, 15, 24, 2.0)
+	if got := effCap(reg, gemma, gemmaBuild); got != wantOverridden {
+		t.Fatalf("override model cap = %d, want %d (per-model overcommit 1.0 × quality batch, uppercase key must match)", got, wantOverridden)
 	}
-	if got := effCap(reg, qwen, qwenBuild); got != 6 {
-		t.Fatalf("non-override model cap = %d, want 6 (malformed entry skipped → global overcommit 2.0 × qc 3)", got)
+	if got := effCap(reg, qwen, qwenBuild); got != wantGlobal {
+		t.Fatalf("non-override model cap = %d, want %d (malformed entry skipped → global overcommit 2.0)", got, wantGlobal)
 	}
 }
 
@@ -312,10 +423,11 @@ func TestQualityCapPerModelOverrideAbsentUsesGlobalDefault(t *testing.T) {
 	reg := New(testLogger())
 	enableQualityCap(t, reg, "")
 
-	p := makeSchedulerProvider(t, reg, "fast", qwenBuild, 57) // qc 10
+	p := makeSchedulerProvider(t, reg, "fast", qwenBuild, 57)
 	budgetSlot(p, 0)
-	if got := effCap(reg, p, qwenBuild); got != 12 {
-		t.Fatalf("cap = %d, want 12 (no per-model entry → default 1.2 × qc 10)", got)
+	want := wantQualityCap(57, 15, 24, defaultQualityCapOvercommit)
+	if got := effCap(reg, p, qwenBuild); got != want {
+		t.Fatalf("cap = %d, want %d (no per-model entry → default 1.2 × quality batch)", got, want)
 	}
 }
 
@@ -345,38 +457,46 @@ func TestQualityCapNeverBelowOneAndProviderCapClamps(t *testing.T) {
 }
 
 // TestQualityCapProjectedDecodeTPSAtDefaultHoldsNearFloor is the decode-floor
-// guarantee of the new default: at overcommit 1.2, a provider filled to its
-// admitted cap projects per-request decode (rate(B) = solo/(1+k·B), the same
-// degradation model the package routes with) no lower than floor/1.2 —
-// i.e. the 15 tok/s floor holds within the overcommit allowance across the
-// realistic solo-rate range, where the old 2.0 default let it collapse to
-// roughly half the floor.
+// guarantee of the 1.2 default: a provider filled to its admitted cap still
+// projects per-request decode (rate(B) = solo/(1+k·B), the same degradation
+// model the package routes with) inside the REALIZED overcommit allowance —
+// see maxOvercommitDilution for why that is strictly worse than the nominal
+// 1.2 and why pinning floor/1.2 here is pinning a guarantee the code does not
+// make. The old 2.0 default, by contrast, let decode collapse to half the
+// floor.
 func TestQualityCapProjectedDecodeTPSAtDefaultHoldsNearFloor(t *testing.T) {
 	const floor = 15.0
 	reg := New(testLogger())
 	enableQualityCap(t, reg, "")
 
+	bound := floor / maxOvercommitDilution(effectiveTPSLoadFactor, defaultQualityCapOvercommit)
 	for i, solo := range []float64{20, 23, 30, 45, 57, 80, 100} {
 		p := makeSchedulerProvider(t, reg, fmt.Sprintf("box-%d", i), gemmaBuild, solo)
 		budgetSlot(p, 0)
 		admitted := effCap(reg, p, gemmaBuild)
 		projected := solo / (1 + effectiveTPSLoadFactor*float64(admitted))
-		if projected < floor/defaultQualityCapOvercommit-1e-9 {
-			t.Errorf("solo %.0f tok/s: cap %d projects %.2f tok/s — below floor/overcommit (%.2f)",
-				solo, admitted, projected, floor/defaultQualityCapOvercommit)
+		if projected < bound-1e-9 {
+			t.Errorf("solo %.0f tok/s: cap %d projects %.2f tok/s — below the realized allowance bound %.2f (k=%.2f)",
+				solo, admitted, projected, bound, effectiveTPSLoadFactor)
 		}
 	}
+	// And that bound must stay meaningfully tighter than the collapse it
+	// replaced: overcommit 2.0 permits exactly half the floor.
+	if bound <= floor/2 {
+		t.Fatalf("realized 1.2 allowance bound %.2f is no better than the 2.0 collapse (%.2f) at k=%.2f — the default no longer buys anything",
+			bound, floor/2, effectiveTPSLoadFactor)
+	}
 
-	// Contrast with the old default: 2.0 admits 20 concurrent on a 57 tok/s box,
-	// projecting ~8.9 tok/s — the below-floor dilution the new default removes.
+	// Contrast with the old default on a fast box: 2.0 dilutes past the bound
+	// the new default holds.
 	diluted := New(testLogger())
 	enableQualityCap(t, diluted, "2.0")
 	p := makeSchedulerProvider(t, diluted, "diluted", gemmaBuild, 57)
 	budgetSlot(p, 0)
 	admitted := effCap(diluted, p, gemmaBuild)
 	projected := 57 / (1 + effectiveTPSLoadFactor*float64(admitted))
-	if projected >= floor/defaultQualityCapOvercommit {
-		t.Fatalf("overcommit 2.0 projects %.2f tok/s at cap %d — expected below the floor/1.2 bar the new default enforces", projected, admitted)
+	if projected >= bound {
+		t.Fatalf("overcommit 2.0 projects %.2f tok/s at cap %d — expected below the %.2f bar the 1.2 default enforces", projected, admitted, bound)
 	}
 }
 
@@ -384,12 +504,12 @@ func TestQualityCapProjectedDecodeTPSAtDefaultHoldsNearFloor(t *testing.T) {
 // postmortem layer-6 scenario: a mixed box whose registration benchmark was
 // taken on gpt-oss (93 tok/s) hosts a gemma slot that actually decodes ~14
 // tok/s solo. The old cap consumed the provider-LEVEL rate for every model, so
-// gemma got cap ceil(qc 19 × 1.2) = 23 — and the coordinator marched 8–11
+// gemma inherited the benchmark's wide cap — and the coordinator marched 8–11
 // concurrent gemma requests onto exactly the boxes that collapse past batch 3.
 // With the per-model solo source, gemma's cap must come from gemma's own solo
-// median (14 ≤ floor 15 → qc 1 → cap 2) while gpt-oss keeps its wide cap from
-// the benchmark. Reverting the resolver wiring makes the gemma assertion fail
-// (cap becomes 23 again).
+// median (14 ≤ floor 15 → quality batch 1 → cap 2, at any measured k) while
+// gpt-oss keeps its wide benchmark-derived cap. Reverting the resolver wiring
+// makes the gemma assertion fail (it inherits the gpt-oss cap again).
 func TestQualityCapPerModelTPSPostmortemRegression(t *testing.T) {
 	run := func(t *testing.T, seedGemma func(reg *Registry)) {
 		reg := New(testLogger())
@@ -397,11 +517,12 @@ func TestQualityCapPerModelTPSPostmortemRegression(t *testing.T) {
 		seedGemma(reg)
 		p := mixedBoxProvider(t, reg, "mixed-93", 93)
 
+		wantGptoss := wantQualityCap(93, 15, 24, defaultQualityCapOvercommit)
 		if got := effCapResolved(reg, p, gemmaBuild); got != 2 {
-			t.Fatalf("gemma cap on the mixed box = %d, want 2 (solo 14 ≤ floor 15 → qc 1 × overcommit 1.2; NOT the benchmark-derived 23)", got)
+			t.Fatalf("gemma cap on the mixed box = %d, want 2 (solo 14 ≤ floor 15 → quality batch 1 × overcommit 1.2; NOT the benchmark-derived %d)", got, wantGptoss)
 		}
-		if got := effCapResolved(reg, p, gptossBuild); got != 23 {
-			t.Fatalf("gpt-oss cap on the mixed box = %d, want 23 (its own 93 tok/s benchmark stays wide)", got)
+		if got := effCapResolved(reg, p, gptossBuild); got != wantGptoss {
+			t.Fatalf("gpt-oss cap on the mixed box = %d, want %d (its own 93 tok/s benchmark stays wide at k=%.2f)", got, wantGptoss, effectiveTPSLoadFactor)
 		}
 	}
 
@@ -446,19 +567,21 @@ func TestQualityCapSeedBoundsCrossClassTransfer(t *testing.T) {
 // TestQualityCapPerModelTPSKillSwitchRestoresOldBehavior pins the kill switch:
 // EIGENINFERENCE_QUALITY_CAP_PER_MODEL_TPS=false must restore the provider-
 // level resolvedDecodeTPS(p) at the cap exactly — reproducing the postmortem's
-// buggy wide gemma cap (23 from the gpt-oss benchmark) even though a trusted
-// gemma solo median exists. This doubles as the proof that the regression test
-// above fails without the fix: the old code path IS the switch-off path.
+// buggy WIDE gemma cap (inherited from the gpt-oss benchmark) even though a
+// trusted gemma solo median exists. This doubles as the proof that the
+// regression test above fails without the fix: the old code path IS the
+// switch-off path.
 func TestQualityCapPerModelTPSKillSwitchRestoresOldBehavior(t *testing.T) {
 	reg := New(testLogger())
 	enablePerModelQualityCap(t, reg, gemmaBuild+"=14", "false", "")
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		reg.tpsRegistry.RecordSolo(gemmaBuild, "M3", 14)
 	}
 	p := mixedBoxProvider(t, reg, "mixed-93", 93)
 
-	if got := effCapResolved(reg, p, gemmaBuild); got != 23 {
-		t.Fatalf("kill switch off: gemma cap = %d, want the old provider-level 23 (byte-for-byte legacy behavior)", got)
+	wantLegacy := wantQualityCap(93, 15, 24, defaultQualityCapOvercommit)
+	if got := effCapResolved(reg, p, gemmaBuild); got != wantLegacy {
+		t.Fatalf("kill switch off: gemma cap = %d, want the old provider-level %d (byte-for-byte legacy behavior)", got, wantLegacy)
 	}
 	// And it must match the explicit provider-level path exactly.
 	if resolved, legacy := effCapResolved(reg, p, gemmaBuild), effCap(reg, p, gemmaBuild); resolved != legacy {
@@ -496,6 +619,186 @@ func TestQualityCapPerModelRateCapsWithoutRegistrationBenchmark(t *testing.T) {
 	if got := effCapResolved(reg, p, gptossBuild); got != 24 {
 		t.Fatalf("no-benchmark box without per-model source: gpt-oss cap = %d, want flat 24", got)
 	}
+}
+
+// TestQualityConcurrencyMatchesDefiningInequality is the one place the closed
+// form is pinned: floor((solo/floor - 1)/k) must agree with a search over the
+// inequality it was solved from, across the whole realistic rate range and both
+// sides of every clamp. Boundary rates (where the real-valued batch lands on an
+// integer) are skipped — there the two derivations legitimately differ by one
+// float ulp, and pinning ulps is not a contract.
+func TestQualityConcurrencyMatchesDefiningInequality(t *testing.T) {
+	const floor = 15.0
+	for _, k := range []float64{0.27, effectiveTPSLoadFactor, 0.39, 0.5} {
+		for _, limit := range []int{1, 4, 8, 24, 32} {
+			for solo := 1.0; solo <= 200.0; solo += 0.25 {
+				if b := (solo/floor - 1) / k; math.Abs(b-math.Round(b)) < 1e-9 {
+					continue
+				}
+				want := strictQualityBatch(solo, floor, k, limit)
+				if got := qualityConcurrency(solo, floor, k, limit, 4); got != want {
+					t.Fatalf("qualityConcurrency(solo=%.2f, floor=%.0f, k=%.2f, limit=%d) = %d, want %d (largest B with solo/(1+k·B) ≥ floor)",
+						solo, floor, k, limit, got, want)
+				}
+			}
+		}
+	}
+	// The batch it returns must actually hold the floor whenever the model can
+	// (the clamp-to-1 case is the documented exception: a provider is never
+	// fully closed).
+	for _, solo := range []float64{16, 20, 23, 30, 57, 93, 99.5, 101.8} {
+		b := qualityConcurrency(solo, floor, effectiveTPSLoadFactor, 32, 4)
+		if rate := solo / (1 + effectiveTPSLoadFactor*float64(b)); b > 1 && rate < floor {
+			t.Fatalf("solo %.1f: quality batch %d projects %.2f tok/s, below the %.0f floor it is defined to hold", solo, b, rate, floor)
+		}
+	}
+}
+
+// TestQualityCapReachesProviderReportedConcurrency is the RELATIONSHIP the
+// v0.8.0 engine bump rides on, pinned instead of a literal: a provider that
+// reports N concurrent slots is granted all N exactly when its solo decode rate
+// clears a threshold derived from (floor, k, overcommit) — and the CBv2
+// measured gemma-4 solo rate clears the N=8 threshold with room to spare.
+//
+// Raising engine_v2_max_concurrent alone does NOT buy coordinator-visible
+// concurrency: the provider-reported number is only the `base` operand of a MIN
+// against the quality cap, so the solo rate the coordinator RESOLVES for the
+// model is what decides whether the bump is real. That is why prod needs a
+// gemma-4 entry in EIGENINFERENCE_MODEL_SOLO_TPS_SEED (see
+// TestQualityCapEightRequiresSoloRateNotOvercommit).
+func TestQualityCapReachesProviderReportedConcurrency(t *testing.T) {
+	const floor = 15.0
+	// measuredGemmaSoloTPS is the CBv2 v2-paged B=1 per-request decode rate for
+	// gemma-4-26b-qat-4bit on an M4 Max — the shipping engine's own number, and
+	// the conservative one (eager measures 101.8):
+	// libs/mlx-swift-lm/benchmarks/reports/gemma4-26b-qat4bit-paged-gate-2026-07-09.md
+	const measuredGemmaSoloTPS = 99.5
+
+	for _, base := range []int{4, 8} {
+		t.Run(fmt.Sprintf("base%d", base), func(t *testing.T) {
+			threshold := soloTPSForCap(floor, base, defaultQualityCapOvercommit)
+
+			mk := func(reg *Registry, id string, solo float64) *Provider {
+				p := makeSchedulerProvider(t, reg, id, gemmaBuild, solo)
+				p.mu.Lock()
+				p.BackendCapacity.Slots[0].ActiveTokenBudgetMax = 500_000
+				p.BackendCapacity.Slots[0].MaxConcurrency = base
+				p.mu.Unlock()
+				return p
+			}
+
+			reg := New(testLogger())
+			enableQualityCap(t, reg, "")
+
+			// At the threshold the provider's whole reported cap is granted.
+			if got := effCap(reg, mk(reg, "at", threshold), gemmaBuild); got != base {
+				t.Fatalf("solo %.2f tok/s (derived threshold at k=%.2f): cap = %d, want the full reported %d",
+					threshold, effectiveTPSLoadFactor, got, base)
+			}
+			// A quarter of a tok/s below it, it is not — the threshold is a real
+			// edge, not a rounding artifact of the assertion above.
+			if got := effCap(reg, mk(reg, "below", threshold-0.25), gemmaBuild); got >= base {
+				t.Fatalf("solo %.2f tok/s (just under the threshold): cap = %d, want < %d", threshold-0.25, got, base)
+			}
+			// And the engine's measured rate is on the granting side of it: the
+			// provider bump is reachable on real hardware without relaxing the
+			// quality bar.
+			if measuredGemmaSoloTPS < threshold {
+				t.Fatalf("measured gemma-4 solo %.1f tok/s is BELOW the %.2f tok/s needed for cap %d at floor %.0f / k %.2f / overcommit %.1f — the engine bump cannot land",
+					measuredGemmaSoloTPS, threshold, base, floor, effectiveTPSLoadFactor, defaultQualityCapOvercommit)
+			}
+			if got := effCap(reg, mk(reg, "measured", measuredGemmaSoloTPS), gemmaBuild); got != base {
+				t.Fatalf("measured gemma-4 solo %.1f tok/s: cap = %d, want the full reported %d", measuredGemmaSoloTPS, got, base)
+			}
+		})
+	}
+}
+
+// TestQualityCapEightRequiresSoloRateNotOvercommit is the config question the
+// v0.8.0 rollout actually has to answer, pinned as behavior.
+//
+// In production the Swift provider never sends decode_tps, so without a solo
+// source the cap is computed from resolvedDecodeTPS's sqrt(memory_bandwidth)
+// proxy — 16-28 tok/s across Apple silicon, a MODEL-AGNOSTIC number that has
+// nothing to do with gemma-4 and lands at or under the floor. Whether that
+// arrives as the proxy or as a low seed, the answer is the same: a provider
+// reporting 8 is capped at 2, at any measured k.
+//
+// EIGENINFERENCE_QUALITY_CONCURRENCY_OVERCOMMIT_BY_MODEL can force it to 8 —
+// the plumbing works, config-only — but only above a multiplier of 7, which is
+// not an overcommit allowance, it is switching the cap off: at that setting the
+// projected per-request decode collapses below even the half-floor the 2.0
+// default was reverted for. Seeding the model's real solo rate reaches 8 on
+// quality merit at the default 1.2 and keeps the bar intact.
+func TestQualityCapEightRequiresSoloRateNotOvercommit(t *testing.T) {
+	const floor = 15.0
+	// starvedSoloTPS stands in for what prod resolves today: the sqrt(546) ≈ 23
+	// M4 Max bandwidth proxy, or an equally low seed. Both cap at 2.
+	const starvedSoloTPS = 14.0
+	// prodSeedTPS is the value EIGENINFERENCE_MODEL_SOLO_TPS_SEED should carry.
+	// It is deliberately well under the engine's measured 99.5 tok/s solo rate
+	// so slower fleet tiers are not over-credited, while still clearing the
+	// reachability threshold at BOTH the shipped k (39.3 tok/s) and the CBv2
+	// re-fit (50.1 tok/s) — so the config survives the coefficient move.
+	const prodSeedTPS = 70.0
+	mk := func(t *testing.T, reg *Registry) *Provider {
+		p := mixedBoxProvider(t, reg, "v0.8.0-box", 93)
+		p.mu.Lock()
+		for i := range p.BackendCapacity.Slots {
+			if p.BackendCapacity.Slots[i].Model == gemmaBuild {
+				p.BackendCapacity.Slots[i].MaxConcurrency = 8
+			}
+		}
+		p.mu.Unlock()
+		return p
+	}
+
+	t.Run("reported_eight_alone_is_not_enough", func(t *testing.T) {
+		reg := New(testLogger())
+		enablePerModelQualityCap(t, reg, gemmaBuild+"="+fmt.Sprint(starvedSoloTPS), "", "")
+		if got := effCapResolved(reg, mk(t, reg), gemmaBuild); got != 2 {
+			t.Fatalf("cap = %d, want 2: a provider-reported 8 is only the MIN's base operand; the %.0f tok/s solo rate decides", got, starvedSoloTPS)
+		}
+	})
+
+	t.Run("per_model_overcommit_reaches_eight_but_voids_the_bar", func(t *testing.T) {
+		reg := New(testLogger())
+		t.Setenv(qualityCapOvercommitByModelEnv, gemmaBuild+"=7.5")
+		enablePerModelQualityCap(t, reg, gemmaBuild+"="+fmt.Sprint(starvedSoloTPS), "", "")
+		got := effCapResolved(reg, mk(t, reg), gemmaBuild)
+		if got != 8 {
+			t.Fatalf("per-model overcommit 7.5: cap = %d, want 8 (the override plumbing must be config-only)", got)
+		}
+		// Anything at or under 7 leaves the quality batch of 1 short of 8, so
+		// this route has no setting that both reaches 8 and stays an allowance.
+		reg7 := New(testLogger())
+		t.Setenv(qualityCapOvercommitByModelEnv, gemmaBuild+"=7.0")
+		enablePerModelQualityCap(t, reg7, gemmaBuild+"="+fmt.Sprint(starvedSoloTPS), "", "")
+		if got := effCapResolved(reg7, mk(t, reg7), gemmaBuild); got != 7 {
+			t.Fatalf("per-model overcommit 7.0: cap = %d, want 7 — the route to 8 needs a multiplier ABOVE 7", got)
+		}
+		projected := starvedSoloTPS / (1 + effectiveTPSLoadFactor*8)
+		if projected >= floor/2 {
+			t.Fatalf("overcommit-to-8 projects %.2f tok/s — expected below half the %.0f floor, i.e. worse than the 2.0 default that was reverted", projected, floor)
+		}
+	})
+
+	t.Run("seeded_solo_rate_reaches_eight_on_quality_merit", func(t *testing.T) {
+		reg := New(testLogger())
+		enablePerModelQualityCap(t, reg, gemmaBuild+"="+fmt.Sprint(prodSeedTPS), "", "")
+		if got := effCapResolved(reg, mk(t, reg), gemmaBuild); got != 8 {
+			t.Fatalf("seeded at %.0f tok/s: cap = %d, want 8 at the default overcommit (k=%.2f)", prodSeedTPS, got, effectiveTPSLoadFactor)
+		}
+		// And it must be granted on QUALITY, not bought with the overcommit
+		// allowance: the strict quality batch alone has to reach 8, so the
+		// projected per-request rate at B=8 stays at or above the floor.
+		if qc := strictQualityBatch(prodSeedTPS, floor, effectiveTPSLoadFactor, 8); qc != 8 {
+			t.Fatalf("seed %.0f gives a strict quality batch of %d at k=%.2f — 8 would be reached only via the overcommit rounding; raise the seed", prodSeedTPS, qc, effectiveTPSLoadFactor)
+		}
+		if projected := prodSeedTPS / (1 + effectiveTPSLoadFactor*8); projected < floor {
+			t.Fatalf("seeded route projects %.2f tok/s at B=8 — below the %.0f floor, so the seed would be buying concurrency the quality bar should refuse", projected, floor)
+		}
+	})
 }
 
 // TestWarmTargetDedicatedWholePool: for a dedicated model UNDER DEMAND the

--- a/coordinator/registry/concurrency_cap_test.go
+++ b/coordinator/registry/concurrency_cap_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/eigeninference/d-inference/coordinator/env"
+	"github.com/eigeninference/d-inference/coordinator/protocol"
 )
 
 // budgetSlot turns a makeSchedulerProvider box into a token-budget provider (the
@@ -859,4 +860,243 @@ func TestWarmTargetDedicatedWholePool(t *testing.T) {
 	if got := c.targetWarm(nonDedicated, warmPoolPressureBucket{}, warmPoolQueuePressure{}, params, svc2, now); got != 2 {
 		t.Fatalf("non-dedicated warm target = %d, want 2 (no demand pressure → left as-is)", got)
 	}
+}
+
+// TestQualityCapPrefersMeasuredSoloRateOverProxyAndSeed pins the DURABLE fix
+// for the B=8 shortfall, and the reason the shortfall existed.
+//
+// Production shape, reproduced exactly here: gemma-4 is a DEDICATED model
+// (EIGENINFERENCE_DEDICATED_MODELS=gemma-4), and the Swift provider never
+// sends decode_tps at registration — the field exists on RegisterMessage and
+// is encoded, but nothing in provider-swift/Sources ever assigns it. So
+// p.DecodeTPS == 0, the dedicated guard in
+// effectiveMaxConcurrencyForModelRateLocked does NOT hold the model to its
+// reported base, and the rate reaching qualityConcurrency is
+// resolvedDecodeTPS's sqrt(memory_bandwidth) — a MODEL-AGNOSTIC hardware proxy
+// (20 tok/s at the 400 GB/s test fixture, ~23 on a real 546 GB/s M4 Max)
+// against a measured ~99.5 tok/s. Raising engine_v2_max_concurrent to 8 buys
+// nothing against that.
+//
+// The provider is NOT silent about its real rate: it reports the measured
+// per-model EWMA in observed_decode_tps on every heartbeat
+// (EngineV2Bridge+Capacity.swift populates it from
+// EngineV2Bridge.observedDecodeTpsEwma), and the heartbeat ingest already
+// converts the uncontended ones into solo samples. The only thing standing
+// between that measurement and the cap was the qualityCapSoloMinSamples floor:
+// under 5 samples the chain skipped straight past a real, solo-gated,
+// per-model measurement to the hardware proxy. It now prefers the measurement.
+func TestQualityCapPrefersMeasuredSoloRateOverProxyAndSeed(t *testing.T) {
+	const floor = 15.0
+	const base = 8
+	// The CBv2 v2-paged B=1 per-request decode rate for gemma-4-26b-qat-4bit on
+	// an M4 Max — the shipping engine's own, conservative number (eager measures
+	// 101.8):
+	// libs/mlx-swift-lm/benchmarks/reports/gemma4-26b-qat4bit-paged-gate-2026-07-09.md
+	const measuredGemmaSoloTPS = 99.5
+	// The starved seed the pre-fix chain was stuck with, standing in for the
+	// sqrt-bandwidth proxy: both land at or under the floor.
+	const starvedSeedTPS = 14.0
+
+	// threshold is the solo rate at which a provider reporting `base` is granted
+	// all of it, derived from (floor, k, overcommit) rather than hard-coded.
+	threshold := soloTPSForCap(floor, base, defaultQualityCapOvercommit)
+
+	// prodBox is the production shape: dedicated model, NO registration
+	// benchmark, provider-reported concurrency of 8.
+	prodBox := func(t *testing.T, reg *Registry) *Provider {
+		reg.SetDedicatedModels([]string{"gemma-4"})
+		return makeSchedulerProvider(t, reg, "prod-box", gemmaBuild, 0)
+	}
+	// slot is the heartbeat slot the provider sends. observedTPS <= 0 models a
+	// provider that has completed no request: observedDecodeTpsEwma is still 0,
+	// `observed_decode_tps` is omitempty, so the field is absent on the wire.
+	slot := func(observedTPS float64, numRunning int) protocol.BackendSlotCapacity {
+		return protocol.BackendSlotCapacity{
+			Model:                gemmaBuild,
+			State:                "running",
+			NumRunning:           numRunning,
+			MaxConcurrency:       base,
+			ActiveTokenBudgetMax: 500_000,
+			ObservedDecodeTPS:    observedTPS,
+		}
+	}
+	// observe drives the REAL heartbeat ingest path n times — the same
+	// soloSampleEligible + NumRunning > 0 gate production uses, not a direct
+	// tpsRegistry poke.
+	observe := func(reg *Registry, n int, tps float64) {
+		for range n {
+			reg.Heartbeat("prod-box", soloHeartbeat([]protocol.BackendSlotCapacity{slot(tps, 1)}))
+		}
+	}
+
+	// --- The arithmetic the fix has to clear ---------------------------------
+	//
+	// effectiveTPSLoadFactor was re-fitted 0.27 -> 0.39, which RAISES the solo
+	// rate needed for cap 8 from ~39.3 to ~50.1 tok/s. Assert the derived
+	// threshold really is that, then assert the measured rate clears it with
+	// close to 2x margin — the fix must not be resting on a rounding edge.
+	t.Run("measured_rate_clears_the_refitted_threshold_with_margin", func(t *testing.T) {
+		if effectiveTPSLoadFactor != 0.39 {
+			t.Fatalf("k = %.2f, expected the re-fitted 0.39 — the margins below are stated against it", effectiveTPSLoadFactor)
+		}
+		if math.Abs(threshold-50.1) > 0.5 {
+			t.Fatalf("derived cap-8 threshold = %.2f tok/s, expected ~50.1 at floor %.0f / k %.2f / overcommit %.1f",
+				threshold, floor, effectiveTPSLoadFactor, defaultQualityCapOvercommit)
+		}
+		if margin := measuredGemmaSoloTPS / threshold; margin < 1.9 {
+			t.Fatalf("measured %.1f tok/s is only %.2fx the %.2f tok/s cap-8 threshold — want >= 1.9x real margin",
+				measuredGemmaSoloTPS, margin, threshold)
+		}
+		// Granted on QUALITY, not bought with the overcommit allowance: the
+		// strict quality batch alone reaches base, and the projected
+		// per-request rate at B=8 stays at or above the floor.
+		if qc := strictQualityBatch(measuredGemmaSoloTPS, floor, effectiveTPSLoadFactor, base); qc != base {
+			t.Fatalf("strict quality batch at the measured rate = %d, want %d — cap 8 must not depend on overcommit rounding", qc, base)
+		}
+		if projected := measuredGemmaSoloTPS / (1 + effectiveTPSLoadFactor*base); projected < floor {
+			t.Fatalf("projected per-request decode at B=8 is %.2f tok/s, below the %.0f floor", projected, floor)
+		}
+	})
+
+	// --- Cold start: a provider that has served nothing ----------------------
+	//
+	// This is the case the fallback chain must not break. The provider reports
+	// NO observed_decode_tps (the field is absent, not zero-on-the-wire), so no
+	// solo sample is ingested, nothing per-model resolves, and the chain lands
+	// on the hardware proxy. That must stay a SANE positive cap — the box has
+	// to be able to serve in order to ever measure itself.
+	t.Run("cold_start_reports_nothing_and_still_gets_a_sane_cap", func(t *testing.T) {
+		reg := New(testLogger())
+		p := prodBox(t, reg)
+		enablePerModelQualityCap(t, reg, "", "", "")
+		reg.Heartbeat("prod-box", soloHeartbeat([]protocol.BackendSlotCapacity{slot(0, 0)}))
+
+		if _, n := reg.tpsRegistry.SoloMedian(gemmaBuild, chipClassKey(p.Hardware)); n != 0 {
+			t.Fatalf("solo samples from a provider that reported no rate = %d, want 0", n)
+		}
+		rate := resolveSolo(reg, p, gemmaBuild)
+		if rate.perModel {
+			t.Fatalf("cold start resolved a per-model rate (%.2f) with no measurement and no seed", rate.tps)
+		}
+		if rate.tps != resolvedDecodeTPS(p) {
+			t.Fatalf("cold-start rate = %.2f, want the provider-level proxy %.2f", rate.tps, resolvedDecodeTPS(p))
+		}
+		got := effCapResolved(reg, p, gemmaBuild)
+		// Pinned as the closed form of the proxy rate, not as a literal: the
+		// integer moves with k, the contract ("the proxy's own answer, and it
+		// is a servable one") does not.
+		if want := wantQualityCap(resolvedDecodeTPS(p), floor, base, defaultQualityCapOvercommit); got != want {
+			t.Fatalf("cold-start cap = %d, want %d — the proxy's own derived answer", got, want)
+		}
+		if got < 2 {
+			t.Fatalf("cold-start cap = %d, want >= 2 — a fresh provider must not be strangled to 1 by its own silence; it has to be able to serve in order to ever measure itself", got)
+		}
+		if got >= base {
+			t.Fatalf("cold-start cap = %d, want < %d: with no measurement the proxy must NOT grant the full bump", got, base)
+		}
+	})
+
+	// --- The fix: one measured, solo-gated sample is enough ------------------
+	t.Run("one_measured_sample_under_the_floor_reaches_eight", func(t *testing.T) {
+		reg := New(testLogger())
+		p := prodBox(t, reg)
+		enablePerModelQualityCap(t, reg, "", "", "")
+
+		// Pre-fix baseline, same registry: the proxy caps this box at 2.
+		if got := effCapResolved(reg, p, gemmaBuild); got >= base {
+			t.Fatalf("before any measurement the cap is %d — the proxy baseline this test contrasts against is gone", got)
+		}
+
+		observe(reg, 1, measuredGemmaSoloTPS)
+
+		_, n := reg.tpsRegistry.SoloMedian(gemmaBuild, chipClassKey(p.Hardware))
+		if n != 1 {
+			t.Fatalf("solo samples = %d, want exactly 1", n)
+		}
+		if n >= qualityCapSoloMinSamples {
+			t.Fatalf("test is not exercising the under-sampled path: %d samples meets the %d floor", n, qualityCapSoloMinSamples)
+		}
+		rate := resolveSolo(reg, p, gemmaBuild)
+		if !rate.perModel || math.Abs(rate.tps-measuredGemmaSoloTPS) > 1e-9 {
+			t.Fatalf("resolved rate = %+v, want the measured %.1f tok/s tagged per-model", rate, measuredGemmaSoloTPS)
+		}
+		if got := effCapResolved(reg, p, gemmaBuild); got != base {
+			t.Fatalf("cap = %d, want %d: one solo-gated measurement of the real rate must beat the model-agnostic proxy", got, base)
+		}
+	})
+
+	// A measurement of THIS model on THIS box outranks a fleet-wide configured
+	// guess. Ordering is measured -> seed -> proxy; a stale low seed must not
+	// hold a box down once it has measured itself.
+	t.Run("measured_rate_outranks_a_low_seed", func(t *testing.T) {
+		reg := New(testLogger())
+		p := prodBox(t, reg)
+		enablePerModelQualityCap(t, reg, gemmaBuild+"="+fmt.Sprint(starvedSeedTPS), "", "")
+
+		if got := effCapResolved(reg, p, gemmaBuild); got != 2 {
+			t.Fatalf("seed-only cap = %d, want 2 (the starved %.0f tok/s seed)", got, starvedSeedTPS)
+		}
+		observe(reg, 1, measuredGemmaSoloTPS)
+		if got := effCapResolved(reg, p, gemmaBuild); got != base {
+			t.Fatalf("cap = %d, want %d: the measured rate must outrank the %.0f tok/s seed", got, base, starvedSeedTPS)
+		}
+	})
+
+	// The first sample is taken as the box drops to one running request, so the
+	// alpha=0.3 EWMA still carries batched history and UNDER-states the solo
+	// rate. Worst realistic case is a fully contaminated rate(B=2) reading at
+	// the cap gemma is stuck on today. Even that clears the bar — the fix is
+	// not resting on a perfectly converged EWMA.
+	t.Run("contaminated_first_sample_still_reaches_eight", func(t *testing.T) {
+		contended := measuredGemmaSoloTPS / (1 + effectiveTPSLoadFactor*2)
+		if contended >= measuredGemmaSoloTPS || contended <= threshold {
+			t.Fatalf("rate(B=2) = %.2f tok/s is not a contaminated-but-passing reading against threshold %.2f", contended, threshold)
+		}
+		reg := New(testLogger())
+		p := prodBox(t, reg)
+		enablePerModelQualityCap(t, reg, "", "", "")
+		observe(reg, 1, contended)
+		if got := effCapResolved(reg, p, gemmaBuild); got != base {
+			t.Fatalf("cap = %d at a fully B=2-contaminated reading of %.2f tok/s, want %d", got, contended, base)
+		}
+	})
+
+	// The point is that the cap sees a TRUE rate, not a permissive one. A box
+	// that genuinely measures slow is still capped — the fix raises the cap by
+	// improving the INPUT, never by relaxing the bar.
+	t.Run("a_genuinely_slow_measurement_is_still_capped", func(t *testing.T) {
+		slow := 30.0
+		if slow >= threshold {
+			t.Fatalf("%.1f tok/s is not below the %.2f tok/s threshold; pick a slower rate", slow, threshold)
+		}
+		reg := New(testLogger())
+		p := prodBox(t, reg)
+		enablePerModelQualityCap(t, reg, "", "", "")
+		observe(reg, 1, slow)
+		got := effCapResolved(reg, p, gemmaBuild)
+		if got >= base {
+			t.Fatalf("cap = %d at a measured %.0f tok/s, want < %d — a slow box must not be granted the bump", got, slow, base)
+		}
+		if got < 1 {
+			t.Fatalf("cap = %d, want >= 1", got)
+		}
+	})
+
+	// A well-sampled median still outranks a single sample: the relaxation is a
+	// FALLBACK below the trusted floors, not a replacement for them.
+	t.Run("trusted_median_still_outranks_the_under_sampled_fallback", func(t *testing.T) {
+		reg := New(testLogger())
+		p := prodBox(t, reg)
+		enablePerModelQualityCap(t, reg, "", "", "")
+		observe(reg, qualityCapSoloMinSamples, 30.0)
+		observe(reg, 1, measuredGemmaSoloTPS)
+		_, n := reg.tpsRegistry.SoloMedian(gemmaBuild, chipClassKey(p.Hardware))
+		if n < qualityCapSoloMinSamples {
+			t.Fatalf("solo samples = %d, want >= the %d floor", n, qualityCapSoloMinSamples)
+		}
+		rate := resolveSolo(reg, p, gemmaBuild)
+		if rate.tps != 30.0 {
+			t.Fatalf("resolved rate = %.2f, want the trusted median 30.00 — the single fast sample must not displace it", rate.tps)
+		}
+	})
 }

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -55,14 +55,46 @@ const (
 	// effective TPS used in cost is `decodeTPS / (1 + k * batchSize)`
 	// where batchSize is the backend's currently-running request count.
 	//
-	// Measured on M4 Max (Qwen2.5-7B-4bit) at N=1/2/4/8 concurrent
-	// decodes: per-request TPS = 92.8 / 69.5 / 35.9 / 29.6. Median
-	// implied k = 0.27 (see scripts/calibrate-routing.sh load-factor).
-	// Prior default 0.4 was ~48% too aggressive — it under-predicted
-	// per-request TPS at small batch sizes, pushing traffic off the
-	// big machines sooner than warranted.
+	// Measured on M4 Max against the CBv2 engine and a model this
+	// coordinator actually serves — gemma-4-26b-qat-4bit, per-request
+	// decode at B = 1/2/4/8 = 101.8 / 59.6 / 38.0 / 24.7 (v2 rows of
+	// libs/mlx-swift-lm/benchmarks/reports/gemma4-26b-qat4bit-paged-gate-2026-07-09.md).
+	// Method: median of the implied k over B = 2/4/8, solo pinned to the
+	// B=1 measurement — 0.354 / 0.420 / 0.390 -> 0.39. A least-squares fit
+	// of 1/rate against B agrees (0.3895). The SAME method reproduces the
+	// previous 0.27 exactly from the legacy rows (Qwen2.5-7B-4bit on the
+	// legacy engine: 92.8 / 69.5 / 35.9 / 29.6 -> 0.2669), so this is a
+	// change of engine and model, not of method. Cross-checks: gemma
+	// v2-paged 0.388, v2-compiled 0.419; gpt-oss-20b v2-eager 0.432,
+	// v2-paged 0.325.
+	//
+	// 0.27 errs in the LENIENT direction against CBv2 — it UNDER-predicts
+	// degradation, i.e. over-predicts the surviving rate, and the error
+	// grows with batch:
+	//
+	//	B    measured    k=0.27 pred       k=0.39 pred
+	//	2    59.6        66.1   (+10.9%)   57.2   (-4.1%)
+	//	4    38.0        48.9   (+28.8%)   39.8   (+4.6%)
+	//	8    24.7        32.2   (+30.4%)   24.7   (-0.0%)
+	//	                 MAPE 23.4%        MAPE 2.9%
+	//
+	// B=1 is the model's INPUT (solo), not a prediction, so it is not
+	// scored. Mind the SIGN: 0.27 is too SMALL, not too large. A reading
+	// that it was wildly "too aggressive" comes from comparing a
+	// prediction made with the coordinator's sqrt(memory_bandwidth) proxy
+	// solo (16-28 tok/s) against a rate measured at the engine's real solo
+	// (101.8) — that gap is a bad SOLO rate, not a bad k, and it has its
+	// own lever (modelSoloTPSSeedEnv in concurrency_cap.go). Raising k
+	// makes every derived cap TIGHTER, never looser.
+	//
+	// Four systems consume this and a too-small k over-states the quality
+	// batch in all of them at once: the admission cap (concurrency_cap.go),
+	// effectiveDecodeTPS and projectedPerRequestDecodeTPSAtBatch below, and
+	// the warm-pool target (warm_pool_controller.go) — which then
+	// under-warms the pool while admission packs batches that miss the
+	// decode floor.
 	// Set to 0 to disable load scaling.
-	effectiveTPSLoadFactor = 0.27
+	effectiveTPSLoadFactor = 0.39
 )
 
 type routingSnapshot struct {

--- a/coordinator/registry/servability.go
+++ b/coordinator/registry/servability.go
@@ -44,10 +44,32 @@ const (
 	// servabilityCapFraction mirrors the provider's UnifiedMemoryCap default
 	// (90% of physical memory usable for MLX).
 	servabilityCapFraction = 0.90
-	// servabilityActivationReserveGB mirrors the provider's activation reserve
-	// kept aside on top of weights before KV cache (UnifiedMemoryCap activation
-	// reserve, ~3 GiB). Cold KV headroom ≈ cap*total - paddedWeights - reserve.
-	servabilityActivationReserveGB = 3.0
+	// servabilityActivationFloorGB mirrors the FLOOR half of the provider's
+	// activation reserve (UnifiedMemoryCap.defaultActivationReserveBytes,
+	// 3 GiB): the measured non-attention working set held back on top of
+	// weights before any KV cache. It does not scale with anything.
+	servabilityActivationFloorGB = 3.0
+	// servabilityActivationBytesPerToken mirrors the CONTEXT-SCALING half
+	// (UnifiedMemoryCap.peakPrefillScoreBytes), which the provider gained when
+	// the flat 3 GiB reserve stopped being true. A model whose head_dim misses
+	// MLX's fused-SDPA set {64, 80, 128} — gemma-4 is 256/512 — materialises a
+	// [rows, heads, C, kL] fp32 score tensor per prefill step, so its cost is
+	// LINEAR in kL and therefore a per-token surcharge on top of the KV bytes
+	// each token already costs:
+	//
+	//	attentionHeads(8) * 4 B (fp32) * liveQueryRows(2048) = 65536 B/token
+	//
+	// liveQueryRows is the provider's own step bound (maxBatchedTokensPerStep)
+	// for the UNBLOCKED prefill path — span-bearing vision chunks, the one path
+	// query sub-blocking (#85) does not cover and the only one whose L may
+	// exceed prefillChunkSize. gemma-4's 8 KV heads are the basis; a GQA model's
+	// query-head count is the true multiplier, so this sits at the OPTIMISTIC
+	// end on purpose, matching this predictor's fail-toward-serving contract.
+	//
+	// RETUNE TRIGGER: this tracks maxBatchedTokensPerStep, so §13.2's 6.2
+	// (2048 -> 4096) doubles it to 131072. Nothing detects that automatically —
+	// the coordinator never sees the provider's scheduler config.
+	servabilityActivationBytesPerToken = 65536
 )
 
 // ServabilityReason is the low-cardinality reason a request was judged
@@ -78,11 +100,18 @@ type ServabilityVerdict struct {
 }
 
 // coldTokenBudgetEstimate approximates the token budget a cold (on-disk, not yet
-// loaded) provider would have AFTER loading the model, mirroring the provider's
-// own live-KV-headroom math:
+// loaded) provider would have AFTER loading the model. The provider holds back
 //
-//	kvHeadroomGB ≈ cap*totalMemoryGB - paddedWeightsGB - activationReserveGB
-//	tokens       ≈ kvHeadroomGB * bytesPerGB / kvBytesPerToken
+//	reserve(t) = max(activationFloor, activationBytesPerToken * t)
+//
+// on top of the padded weights, so the budget is the largest t satisfying
+//
+//	t*kvBytesPerToken + reserve(t) <= cap*totalMemoryGB - paddedWeightsGB
+//
+// which is piecewise-linear with a single crossover at
+// activationFloor/activationBytesPerToken (49152 tokens at today's constants):
+// below it the flat floor binds and a token pays only KV; above it the score
+// tensor scales with context and the two per-token costs simply add.
 //
 // paddedWeightsGB uses the same catalog→padded-GiB conversion the cold-load gate
 // uses (coldLoadCatalogGBToMemGiB). kvBytesPerToken prefers the provider-reported
@@ -90,32 +119,58 @@ type ServabilityVerdict struct {
 // is deliberately OPTIMISTIC (uses only the activation reserve, not the extra
 // min-KV load floor) so the predictor errs toward serving. Returns 0 when the
 // inputs are unusable or no headroom remains.
+//
+// # Deliberate divergence from the provider's own formula
+//
+// The provider evaluates its reserve at a CEILING it can see — its configured
+// maxContextLength, its scheduler's step/chunk sizes, and the slot's real
+// per-layer head counts — and holds that many bytes back unconditionally. The
+// coordinator sees none of those: a cold slot has no heartbeat at all, and even
+// a warm one reports neither maxBatchedTokensPerStep nor head counts. Rather
+// than guess the provider's ceiling (a duplicated constant that drifts the
+// moment either side is retuned — the exact failure this replaces), the
+// coordinator solves the SELF-CONSISTENT point: it charges the score tensor at
+// exactly the context it is predicting the provider can hold. The two agree
+// when the predicted budget equals the provider's maxContextLength and the
+// coordinator is optimistic below it — the safe direction for a gate whose
+// false-NO is a 429. Only servabilityActivationBytesPerToken is shared, and it
+// is a shape constant (heads x fp32 x step rows), not a memory figure.
 func coldTokenBudgetEstimate(totalMemoryGB, modelSizeGB float64, kvBytesPerToken int64) int64 {
 	if totalMemoryGB <= 0 || modelSizeGB <= 0 {
 		return 0
 	}
 	paddedWeightsGB := modelSizeGB * coldLoadCatalogGBToMemGiB
-	kvHeadroomGB := servabilityCapFraction*totalMemoryGB - paddedWeightsGB - servabilityActivationReserveGB
-	if kvHeadroomGB <= 0 {
+	postLoadGB := servabilityCapFraction*totalMemoryGB - paddedWeightsGB
+	if postLoadGB <= 0 {
 		return 0
 	}
 	kvpt := kvBytesPerToken
 	if kvpt <= 0 {
 		kvpt = kvCacheBytesPerToken
 	}
-	tokens := int64(kvHeadroomGB * float64(bytesPerGB) / float64(kvpt))
-	if tokens < 0 {
+	postLoadBytes := postLoadGB * float64(bytesPerGB)
+	floorBytes := servabilityActivationFloorGB * float64(bytesPerGB)
+	// Below the crossover the flat floor is the whole reserve.
+	tokens := (postLoadBytes - floorBytes) / float64(kvpt)
+	if tokens > floorBytes/servabilityActivationBytesPerToken {
+		// Above it the score tensor dominates and scales with the context, so
+		// every token carries both costs.
+		tokens = postLoadBytes / float64(kvpt+servabilityActivationBytesPerToken)
+	}
+	if tokens <= 0 {
 		return 0
 	}
-	return tokens
+	return int64(tokens)
 }
 
 // snapshotStructuralBudget returns this provider's structural token-budget
 // contribution for the model, and whether it is known. A resident slot uses the
-// provider-reported active_token_budget_max; a cold-but-fitting provider uses the
-// optimistic cold estimate. "known=false" means we cannot tell (legacy resident
-// slot with no budget, or missing memory data) — the caller treats unknown as
-// fail-open and skips the budget tier entirely.
+// provider-reported active_token_budget_max — which already nets out whatever
+// activation reserve that provider actually chose. A cold-but-fitting provider
+// has no such report, so it uses the optimistic post-load estimate, reserve
+// included (see coldTokenBudgetEstimate). "known=false" means we cannot tell
+// (legacy resident slot with no budget, or missing memory data) — the caller
+// treats unknown as fail-open and skips the budget tier entirely.
 func snapshotStructuralBudget(snap routingSnapshot) (budget int64, known bool) {
 	if snap.activeTokenBudgetMax > 0 {
 		return snap.activeTokenBudgetMax, true

--- a/coordinator/registry/servability_provider_fit_test.go
+++ b/coordinator/registry/servability_provider_fit_test.go
@@ -56,6 +56,9 @@ func TestProviderBudgetFitsWarmSlotLiveBudget(t *testing.T) {
 func TestProviderBudgetFitsColdLoadPostLoadBudget(t *testing.T) {
 	// gemma-4-26b shape: 28 GB catalog weights on a 48 GB box. Padded weights
 	// = 28 × ~1.1176 ≈ 31.3 GiB ≤ free_for_load 32 → the weight gate admits.
+	// 48 GB leaves ~11.9 GB post-load, which puts the budget in the activation
+	// reserve's FLOOR regime (below the 49152-token crossover), so the flat
+	// 3 GiB — not the per-token score tensor — is what is held back here.
 	freeForLoad := 32.0
 	snap := routingSnapshot{
 		totalMemoryGB:   48,
@@ -68,7 +71,7 @@ func TestProviderBudgetFitsColdLoadPostLoadBudget(t *testing.T) {
 	}
 
 	// Post-load budget per the provider's own headroom math:
-	// (0.90×48 − paddedWeights − 3 GB activation reserve) / 400000 B/token.
+	// (0.90×48 − paddedWeights − 3 GB activation floor) / 400000 B/token.
 	budget := coldTokenBudgetEstimate(snap.totalMemoryGB, snap.modelSizeGB, 0)
 	if budget <= 0 || budget >= 30_000 {
 		t.Fatalf("cold post-load budget = %d, want a positive value below the 30k request", budget)
@@ -111,7 +114,8 @@ func TestPredictServableColdWeightFitInsufficientBudgetSheds(t *testing.T) {
 	reg := New(testLogger())
 	model := "cold-budget-model"
 	// 28 GB weights on a 48 GB node: min_ram 36 ≤ 48 passes the hardware gate,
-	// and the post-load budget is coldTokenBudgetEstimate(48, 28, 0) ≈ 23.9k.
+	// and the post-load budget is coldTokenBudgetEstimate(48, 28, 0) = 23911
+	// (floor regime — see TestColdTokenBudgetEstimate case (b2)).
 	reg.SetModelCatalog([]CatalogEntry{{ID: model, SizeGB: 28, MinRAMGB: 36}})
 	makeWarmPoolColdProvider(t, reg, "cold-48gb", model, 80, 48, 0)
 

--- a/coordinator/registry/servability_test.go
+++ b/coordinator/registry/servability_test.go
@@ -3,19 +3,33 @@ package registry
 import "testing"
 
 // TestColdTokenBudgetEstimate pins the pure cold post-load KV-budget estimator.
-// The formula is:
+// The provider's activation reserve is max(flat floor, per-token score tensor),
+// so the budget is piecewise-linear around the crossover
+// servabilityActivationFloorGB*bytesPerGB / servabilityActivationBytesPerToken
+// = 3*2^30/65536 = 49152 tokens:
 //
-//	kvHeadroomGB = servabilityCapFraction*total - size*coldLoadCatalogGBToMemGiB - servabilityActivationReserveGB
-//	tokens       = int64(kvHeadroomGB * bytesPerGB / kvBytesPerToken)   // kvBytesPerToken<=0 → 400000
+//	postLoadGB = servabilityCapFraction*total - size*coldLoadCatalogGBToMemGiB
+//	postLoadB  = postLoadGB * bytesPerGB
+//	floorB     = servabilityActivationFloorGB * bytesPerGB   // 3*2^30
+//	tokens     = (postLoadB - floorB) / kvBytesPerToken      // floor binds
+//	if tokens > 49152:
+//	    tokens = postLoadB / (kvBytesPerToken + 65536)       // score binds
 //
-// with servabilityCapFraction=0.90, servabilityActivationReserveGB=3.0,
-// coldLoadCatalogGBToMemGiB≈1.1175870895385742, bytesPerGB=1<<30.
+// with servabilityCapFraction=0.90, servabilityActivationFloorGB=3.0,
+// servabilityActivationBytesPerToken=65536,
+// coldLoadCatalogGBToMemGiB≈1.1175870895385742, bytesPerGB=1<<30, and
+// kvBytesPerToken<=0 → 400000.
 func TestColdTokenBudgetEstimate(t *testing.T) {
-	// (a) Roomy node: total=64, size=12, kvpt=400000.
-	//   padded   = 12 * 1.1175870895385742           = 13.41104507446289
-	//   headroom = 0.90*64 - 13.41104507446289 - 3.0 = 41.18895492553711 GB
-	//   tokens   = int64(41.18895492553711 * 2^30 / 400000) = 110565
-	const wantRoomy = int64(110565)
+	// (a) Roomy node: total=64, size=12, kvpt=400000. Long-context regime —
+	// the score tensor, not the 3 GiB floor, is what the provider holds back.
+	//   padded    = 12 * 1.1175870895385742           = 13.41104507446289
+	//   postLoadGB= 0.90*64 - 13.41104507446289       = 44.18895492553711 GB
+	//   postLoadB = 44.18895492553711 * 2^30          = 47447529062.4 B
+	//   floor-bound tokens = (47447529062.4 - 3221225472) / 400000 = 110565.75
+	//   110565.75 > 49152, so the score tensor binds instead:
+	//   tokens    = int64(47447529062.4 / 465536)     = 101920
+	// (Flat-3-GiB predecessor: 110565 — 8% optimistic at this context.)
+	const wantRoomy = int64(101920)
 	if got := coldTokenBudgetEstimate(64, 12, 400000); got != wantRoomy {
 		t.Fatalf("roomy estimate = %d, want %d", got, wantRoomy)
 	}
@@ -23,10 +37,42 @@ func TestColdTokenBudgetEstimate(t *testing.T) {
 		t.Fatalf("roomy estimate = %d, want > 0", got)
 	}
 
-	// (b) Tiny node: weights (padded) + activation reserve exceed 90% of the
-	// 8 GB cap, so there is no KV headroom at all → 0 (never negative).
+	// (b) Tiny node: weights (padded) alone exceed 90% of the 8 GB cap, so
+	// there is no post-load memory at all, let alone room for the activation
+	// reserve → 0 (never negative).
 	if got := coldTokenBudgetEstimate(8, 12, 400000); got != 0 {
-		t.Fatalf("tiny-node estimate = %d, want 0 (weights+reserve exceed cap)", got)
+		t.Fatalf("tiny-node estimate = %d, want 0 (weights exceed cap)", got)
+	}
+
+	// (b2) Floor regime: a 48 GB node loading 28 GB of gemma-4 weights lands
+	// BELOW the crossover, so the flat floor is still the whole reserve and the
+	// estimate is unchanged from the pre-parametric formula.
+	//   padded    = 28 * 1.1175870895385742     = 31.292438507080078
+	//   postLoadGB= 0.90*48 - 31.292438507080078 = 11.907561492919925 GB
+	//   tokens    = (11.907561492919925*2^30 - 3221225472) / 400000 = 23911.05
+	//   23911 <= 49152 → floor branch wins.
+	if got := coldTokenBudgetEstimate(48, 28, 400000); got != int64(23911) {
+		t.Fatalf("floor-regime estimate = %d, want 23911", got)
+	}
+
+	// (b3) The two regimes must JOIN, not jump. Sweeping node size across the
+	// crossover has to stay monotone and continuous; a branch inversion, or a
+	// floor charged ON TOP OF the per-token cost rather than instead of it,
+	// shows up here as a step backwards or a cliff. Each 0.05 GB step adds
+	// 0.045*2^30 bytes = at most ~121 tokens in either regime.
+	prev := int64(0)
+	for total := 20.0; total <= 30.0; total += 0.05 {
+		got := coldTokenBudgetEstimate(total, 1, 400000)
+		if got < prev {
+			t.Fatalf("budget went backwards at total=%.2f: %d after %d", total, got, prev)
+		}
+		if prev > 0 && got-prev > 200 {
+			t.Fatalf("regime discontinuity at total=%.2f: %d jumped from %d", total, got, prev)
+		}
+		prev = got
+	}
+	if prev <= 49152 {
+		t.Fatalf("sweep ended at %d tokens, never crossed the 49152 regime boundary", prev)
 	}
 
 	// (c) kvBytesPerToken <= 0 falls back to the kvCacheBytesPerToken default

--- a/coordinator/registry/servability_test.go
+++ b/coordinator/registry/servability_test.go
@@ -44,6 +44,19 @@ func TestColdTokenBudgetEstimate(t *testing.T) {
 		t.Fatalf("tiny-node estimate = %d, want 0 (weights exceed cap)", got)
 	}
 
+	// (b1) The OTHER zero, and the one that only exists because the reserve is
+	// subtracted separately from the weights: a 20 GB node loading 14 GB of
+	// weights clears the cap with 0.90*20 - 14*1.1175870895385742 = 2.3538 GB
+	// to spare, so it survives the postLoadGB<=0 early return — but 2.35 GB
+	// cannot cover the 3 GiB activation floor, so the floor branch computes
+	// (2.3538*2^30 - 3221225472)/400000 = -1734.68 and the tokens<=0 guard
+	// clamps it. Drop that guard and this returns a NEGATIVE budget, which
+	// PredictServable would publish as FleetMaxBudget. Distinct from (b): there
+	// the weights alone bust the cap and the reserve never enters it.
+	if got := coldTokenBudgetEstimate(20, 14, 400000); got != 0 {
+		t.Fatalf("reserve-bound estimate = %d, want 0 (weights fit, activation floor does not)", got)
+	}
+
 	// (b2) Floor regime: a 48 GB node loading 28 GB of gemma-4 weights lands
 	// BELOW the crossover, so the flat floor is still the whole reserve and the
 	// estimate is unchanged from the pre-parametric formula.

--- a/coordinator/registry/solo_tps_test.go
+++ b/coordinator/registry/solo_tps_test.go
@@ -444,16 +444,39 @@ func TestSoloClassKeyingEndToEndNoCrossTierOverCap(t *testing.T) {
 	}
 }
 
+// TestResolvedSoloModelTPSMinSampleFloor pins what the min-sample floor now
+// selects BETWEEN, and that the terminal provider-level fallback is still
+// wired.
+//
+// The floor used to be the boundary between a per-model rate and the
+// provider-level one. It no longer is: below the floor the resolver prefers
+// the under-sampled — but still solo-gated and still per-model — measured
+// median over resolvedDecodeTPS's model-AGNOSTIC sqrt-bandwidth proxy (see
+// resolvedSoloModelTPSLocked). Here that difference is the whole postmortem
+// layer-6 failure in one line: 14 tok/s is gemma's own measured rate, 93 is
+// the mixed box's registration benchmark taken on gpt-oss. Five gemma samples
+// are better evidence about gemma than a fast benchmark of a different model.
+//
+// What the floor still decides is the TRUST TIER — authoritative, or a
+// fallback ranked below the configured seed — and the provider-level rate is
+// now reached only when the model has NO measurement at all.
 func TestResolvedSoloModelTPSMinSampleFloor(t *testing.T) {
 	reg := New(testLogger())
-	// Floor raised to 6: five per-chip samples are NOT yet trusted.
+	// Floor raised to 6: five samples are NOT yet the trusted tier.
 	enablePerModelQualityCap(t, reg, "", "", "6")
 	p := mixedBoxProvider(t, reg, "mixed", 93)
-	for i := 0; i < 5; i++ {
+
+	// No measurement at all — the terminal provider-level fallback. This is
+	// the only remaining route to resolvedDecodeTPS(p), so it is pinned here.
+	if got := resolveSolo(reg, p, gemmaBuild); got.tps != 93 || got.perModel {
+		t.Fatalf("no samples = %+v, want the provider-level fallback (93, perModel false)", got)
+	}
+
+	for range 5 {
 		reg.tpsRegistry.RecordSolo(gemmaBuild, "M3", 14)
 	}
-	if got := resolveSolo(reg, p, gemmaBuild); got.tps != 93 || got.perModel {
-		t.Fatalf("below min samples = %+v, want provider-level (93, perModel false)", got)
+	if got := resolveSolo(reg, p, gemmaBuild); got.tps != 14 || !got.perModel {
+		t.Fatalf("below min samples = %+v, want the under-sampled measured rate (14, perModel true), not the provider-level 93", got)
 	}
 	reg.tpsRegistry.RecordSolo(gemmaBuild, "M3", 14)
 	if got := resolveSolo(reg, p, gemmaBuild); got.tps != 14 || !got.perModel {

--- a/coordinator/registry/solo_tps_test.go
+++ b/coordinator/registry/solo_tps_test.go
@@ -511,18 +511,20 @@ func TestParseModelFloatMapSeedEntries(t *testing.T) {
 
 // TestSoloSeedColdStart is the restart scenario: the TPS registry is in-memory
 // and wiped by a coordinator restart, so on a fresh registry the seed env must
-// carry the per-model cap alone (gemma-qat solo ≈ 14 from prod data → cap 2)
-// until gated solo samples re-accumulate.
+// carry the per-model cap alone until gated solo samples re-accumulate. The
+// gemma seed (14, at or under the 15 floor) pins to 2 at any measured k; the
+// gpt-oss cap is k-derived (see the helpers in concurrency_cap_test.go).
 func TestSoloSeedColdStart(t *testing.T) {
 	reg := New(testLogger()) // fresh registry == post-restart state
 	enablePerModelQualityCap(t, reg, "gemma-4-26b-qat-4bit=14,gpt-oss-20b=30", "", "")
 	p := mixedBoxProvider(t, reg, "mixed", 93)
 
 	if got := effCapResolved(reg, p, gemmaBuild); got != 2 {
-		t.Fatalf("cold-start gemma cap = %d, want 2 (seed 14 ≤ floor 15 → qc 1 × 1.2)", got)
+		t.Fatalf("cold-start gemma cap = %d, want 2 (seed 14 ≤ floor 15 → quality batch 1 × 1.2)", got)
 	}
-	if got := effCapResolved(reg, p, gptossBuild); got != 4 {
-		t.Fatalf("cold-start gpt-oss cap = %d, want 4 (seed 30 → qc 3 → ceil(3.6))", got)
+	wantGptoss := wantQualityCap(30, 15, 24, defaultQualityCapOvercommit)
+	if got := effCapResolved(reg, p, gptossBuild); got != wantGptoss {
+		t.Fatalf("cold-start gpt-oss cap = %d, want %d (seed 30 at k=%.2f × 1.2)", got, wantGptoss, effectiveTPSLoadFactor)
 	}
 }
 

--- a/coordinator/registry/warm_pool_controller_test.go
+++ b/coordinator/registry/warm_pool_controller_test.go
@@ -565,10 +565,13 @@ func TestWarmPoolPicksBetterIdleProvider(t *testing.T) {
 // --- Little's Law target math (pure, warm_pool_target.go) ---
 
 func TestQualityConcurrencyFromDecodeFloor(t *testing.T) {
-	k := effectiveTPSLoadFactor // 0.27
-	// solo 100, floor 15: B <= (100/15 - 1)/0.27 = 20.98 -> 20 (under cap 32).
-	if got := qualityConcurrency(100, 15, k, 32, 4); got != 20 {
-		t.Fatalf("qc(solo100,floor15,cap32) = %d, want 20", got)
+	k := effectiveTPSLoadFactor
+	// solo 100, floor 15: B <= (100/15 - 1)/k, under the cap of 32 at any
+	// measured k (20 at the legacy 0.27, 14 at the CBv2-re-fit 0.39).
+	// strictQualityBatch reaches the same answer from the defining
+	// inequality, so this pins the closed form, not the coefficient.
+	if want, got := strictQualityBatch(100, 15, k, 32), qualityConcurrency(100, 15, k, 32, 4); got != want {
+		t.Fatalf("qc(solo100,floor15,cap32) = %d, want %d (k=%.2f)", got, want, k)
 	}
 	// Capped by the provider concurrency limit.
 	if got := qualityConcurrency(100, 15, k, 6, 4); got != 6 {

--- a/coordinator/registry/warm_pool_target.go
+++ b/coordinator/registry/warm_pool_target.go
@@ -78,6 +78,12 @@ type warmTargetInputs struct {
 // concurrency cap (falling back to fallbackConc). When the floor is disabled
 // (<= 0), the solo rate is unknown, or load scaling is off, the constraint does
 // not bind and the cap is returned.
+//
+// k is MEASURED per engine generation, not chosen, and this function is the
+// most load-bearing consumer of getting it wrong in the safe-looking
+// direction: too SMALL a k over-states the quality batch, which divides
+// Little's Law demand by too much and under-warms the pool — a shortfall that
+// reads as demand undershoot rather than as a stale coefficient.
 func qualityConcurrency(soloDecodeTPS, floor, k float64, maxProviderConc, fallbackConc int) int {
 	limit := maxProviderConc
 	if limit <= 0 {

--- a/deploy/environments/prod.env
+++ b/deploy/environments/prod.env
@@ -33,6 +33,32 @@ EIGENINFERENCE_PREFILL_DECODE_RATIO=12
 EIGENINFERENCE_PREFILL_KEEPALIVE_INTERVAL=10s
 EIGENINFERENCE_PROMPT_CALIBRATION=gpt-oss:1.3
 
+# Per-model solo decode rate for the quality-concurrency admission cap.
+#
+# REQUIRED before raising engine_v2_max_concurrent to 8. The provider never
+# sends decode_tps, so without a seed the cap is computed from
+# resolvedDecodeTPS's sqrt(memory_bandwidth) proxy — 16-28 tok/s across Apple
+# silicon, a model-agnostic number ~4x under the engine's measured ~99.5 tok/s
+# gemma solo. That proxy caps gemma at 2 no matter what the provider reports,
+# because the reported concurrency is only the MIN's base operand. Gated solo
+# samples cannot rescue it: ingest needs the whole box at exactly one running
+# and zero waiting requests at heartbeat time, which a box running at B=8
+# essentially never is.
+#
+# 70 tok/s is deliberately well under the measured solo (gemma-4 99.5 paged /
+# 101.8 eager, gpt-oss-20b 88.5 paged) so slower fleet tiers inheriting this
+# fleet-wide value are not over-credited, and it reaches 8 on strict quality
+# merit rather than via the overcommit rounding: floor((70/15-1)/0.39) = 9,
+# ceil(9 x 1.2) = 11, min(11, 8) = 8, with projected per-request decode at B=8
+# of 17.0 tok/s — above the 15 floor. It also clears the threshold at the
+# previous load factor (39.3 tok/s at k=0.27, 50.1 at k=0.39), so the seed and
+# the k re-fit are INDEPENDENT: neither depends on the other having landed.
+#
+# Note gpt-oss-20b is not a dedicated model, so today it is uncapped at the
+# flat 24; a seed makes its cap real (8 against a reported 8). That is
+# intentional.
+EIGENINFERENCE_MODEL_SOLO_TPS_SEED=gemma-4-26b-qat-4bit=70,gpt-oss-20b=70
+
 # TTFT and warm-pool tuning observed on 2026-07-17.
 EIGENINFERENCE_TTFT_ADMISSION_MODE=shadow
 EIGENINFERENCE_TTFT_HARD_REJECT=true

--- a/docs/architecture/operations/routing.md
+++ b/docs/architecture/operations/routing.md
@@ -91,15 +91,64 @@ Each term maps to a field in `RoutingDecision`:
 
 Penalty constants are defined at `scheduler.go:16-36`.
 
-### Effective decode TPS
+### Effective decode TPS (routing cost)
 
-`resolveEffectiveTPS` (`scheduler.go:950-958`) chooses the best available decode estimate in this order:
+`resolveEffectiveTPS` (`scheduler.go:1704`) chooses the best available decode
+estimate for the **cost function** in this order:
 
 1. Provider-reported observed EWMA (`slot.ObservedDecodeTPS`).
 2. Fleet median TPS for the same model and chip family (`tpsRegistry.Median`).
-3. Load-scaled benchmark TPS (`effectiveDecodeTPS`, `scheduler.go:971-983`).
+3. Load-scaled benchmark TPS (`effectiveDecodeTPS`, `scheduler.go:1745`).
 
-The load-scaled fallback divides the static benchmark TPS by `1 + effectiveTPSLoadFactor × backendRunning`, with `effectiveTPSLoadFactor = 0.27` (`scheduler.go:64`).
+The load-scaled fallback divides the static benchmark TPS by
+`1 + effectiveTPSLoadFactor × backendRunning`, with
+`effectiveTPSLoadFactor = 0.39` (`scheduler.go:97`).
+
+This chain is deliberately **load-inclusive**: it estimates what a request will
+actually experience right now, so an under-load EWMA is the *right* input.
+
+### Solo decode TPS (quality-concurrency cap)
+
+Do not confuse this with the chain above — it answers a different question and
+takes the opposite stance on load. `resolvedSoloModelTPSLocked`
+(`concurrency_cap.go:265`) resolves the **static single-stream** rate the
+admission cap is computed from. It must never be an under-load EWMA: the
+observed rate collapses under the very overload the cap exists to prevent,
+which would drive the cap to 1 in a feedback loop.
+
+Five steps, most- to least-specific. Each advances only when its own condition
+fails:
+
+| # | Source | Advances to the next step when |
+|---|---|---|
+| 1 | Per-(model, chip **class**) solo median (`SoloMedian`) | fewer than `EIGENINFERENCE_QUALITY_CAP_SOLO_MIN_SAMPLES` (default 5) gated samples, or the median is 0 |
+| 2 | MIN of per-class solo medians across chip classes (`SoloMedianAllChips`), clamped from above by the seed | fewer than the same sample floor in total, or 0 |
+| 3 | The same two medians again with the sample floor **relaxed to ≥ 1** — under-sampled but still measured and still solo-gated (cross-class still seed-clamped) | the model has no solo sample at all on this coordinator |
+| 4 | `EIGENINFERENCE_MODEL_SOLO_TPS_SEED` for this build id | no seed entry for the model |
+| 5 | `resolvedDecodeTPS(p)` — the registration benchmark `decode_tps`, else `sqrt(memory_bandwidth)` | terminal |
+
+"Gated" (steps 1–3) means the sample was ingested only from a heartbeat where
+the **whole box** was uncontended (Σ running+waiting ≤ 1 across all slots) and
+the reporting slot had a running decode (`NumRunning > 0`) — see
+`soloSampleEligible`. That gate is what keeps a measured rate a *solo* rate.
+
+Step 3 exists because the alternative below it is worse information, not
+better: step 5's `sqrt(memory_bandwidth)` is **model-agnostic** (16–28 tok/s
+across Apple silicon) and has nothing to do with the model being capped. One
+solo-gated measurement of the actual model beats it outright. Under-sampled
+readings converge from **below** — the α = 0.3 provider EWMA still carries
+batched history when the box drops to a single request — so the error direction
+is a tighter cap, never a permissive one.
+
+Step 5 is reached in production only at **cold start**. The Swift provider
+never sends `decode_tps` at registration (deliberately: on a multi-model box a
+single provider-level benchmark lends one model's rate to another — the
+postmortem layer-6 failure), and a provider that has completed no request
+reports no `observed_decode_tps` at all, so `p.DecodeTPS` is 0 and the proxy is
+all that is left. For a **dedicated** model that yields a cap of 2; for a
+non-dedicated one the guard in `effectiveMaxConcurrencyForModelRateLocked`
+(`concurrency_cap.go:328`) leaves the provider's reported cap alone. This is
+why the seed at step 4 stays configured — see the v0.8.0 release notes.
 
 ## Slot states and penalties
 

--- a/docs/architecture/operations/telemetry.md
+++ b/docs/architecture/operations/telemetry.md
@@ -26,9 +26,13 @@ The coordinator coerces unknown source/severity/kind values to safe defaults (`c
 
 All three field allowlists (Go server, Swift client, TypeScript client) must also stay in sync:
 
-* Go: `telemetryFieldAllowlist` (`telemetry_handlers.go:48-87`)
-* Swift: `TelemetryFieldFilter.allowed` (`TelemetryEvent.swift:229-236`)
-* TypeScript: `TELEMETRY_ALLOWED_FIELDS` (`telemetry-types.ts:54-85`)
+* Go: `telemetryFieldAllowlist` (`telemetry_handlers.go:48-171`)
+* Swift: `TelemetryFieldFilter.allowed` (`TelemetryEvent.swift:238-294`)
+* TypeScript: `TELEMETRY_ALLOWED_FIELDS` (`telemetry-types.ts:58-160`)
+
+This is enforced, not merely asked for: `coordinator/api/telemetry_allowlist_parity_test.go`
+scrapes both client mirrors at test time and diffs them against the Go map in both
+directions. Adding a field to one mirror alone fails `TestTelemetryAllowlistThreeWayParity`.
 
 ## Wire event shape
 
@@ -52,7 +56,7 @@ type TelemetryEvent struct {
 }
 ```
 
-The Swift struct uses identical snake_case `CodingKeys` and omits empty optionals (`TelemetryEvent.swift:69-77`). The TypeScript interface uses the same optional fields (`telemetry-types.ts:34-50`).
+The Swift struct uses identical snake_case `CodingKeys` and omits empty optionals (`TelemetryEvent.swift:78-86`). The TypeScript interface uses the same optional fields (`telemetry-types.ts:38-54`).
 
 ## Enums
 
@@ -125,7 +129,13 @@ Events are forwarded to Datadog Logs API asynchronously and are **not** persiste
 
 ## Field allowlist
 
-Only non-sensitive operational fields may be attached to events. The current allowlist (`telemetry_handlers.go:48-87`) includes generic metadata (`component`, `operation`, `duration_ms`), provider/backend context (`model`, `backend`, `hardware_chip`, `memory_gb`), coordinator context (`provider_id`, `trust_level`, `queue_depth`), connectivity (`reconnect_count`, `ws_state`), billing booleans (`billing_method`, `payment_failed`), and UI context (`url`, `route`).
+Only non-sensitive operational fields may be attached to events. The current allowlist (`telemetry_handlers.go:48-171`) includes generic metadata (`component`, `operation`, `duration_ms`), provider/backend context (`model`, `backend`, `hardware_chip`, `memory_gb`), coordinator context (`provider_id`, `trust_level`, `queue_depth`), connectivity (`reconnect_count`, `ws_state`), billing booleans (`billing_method`, `payment_failed`), UI context (`url`, `route`), and the OOM, engine-health, KV-budget-audit, media, and exact-prefix-replay diagnostic cohorts.
+
+v0.8.0 added three more cohorts, all bounded enums and counters:
+
+* **KV-backend discriminator** — `kv_backend` (`paged` | `contiguous`, the same key and vocabulary as `BackendSlotCapacity.kv_backend` on the heartbeat wire) and `prefix_reuse_backend`. These exist because `backend` was overloaded across three unrelated value vocabularies; see [the ruling in the schema reference](../../reference/telemetry-schema.md#backend-key-semantics), which also names the producer sites still to be corrected.
+* **Paged KV pool** — `pages_pinned`, `cow_events`, `pool_utilization`.
+* **MTP / speculative decode** — `mtp_enabled`, `mtp_active`, `mtp_inactive_reason`, `mtp_acceptance_rate`. MTP was previously invisible to the coordinator while silently inflating `observed_decode_tps`, so a partially-MTP fleet biased routing on a metric assumed homogeneous.
 
 **Prompt or response content must never appear in telemetry.** This is enforced by design (no such field exists) and by the allowlist.
 

--- a/docs/architecture/operations/telemetry.md
+++ b/docs/architecture/operations/telemetry.md
@@ -133,9 +133,11 @@ Only non-sensitive operational fields may be attached to events. The current all
 
 v0.8.0 added three more cohorts, all bounded enums and counters:
 
-* **KV-backend discriminator** — `kv_backend` (`paged` | `contiguous`, the same key and vocabulary as `BackendSlotCapacity.kv_backend` on the heartbeat wire) and `prefix_reuse_backend`. These exist because `backend` was overloaded across three unrelated value vocabularies; see [the ruling in the schema reference](../../reference/telemetry-schema.md#backend-key-semantics), which also names the producer sites still to be corrected.
-* **Paged KV pool** — `pages_pinned`, `cow_events`, `pool_utilization`.
+* **KV-backend discriminator** — `kv_backend` (`paged` | `contiguous`, the same key and vocabulary as `BackendSlotCapacity.kv_backend` on the heartbeat wire) and `prefix_reuse_backend`. These exist because `backend` was overloaded across three unrelated value vocabularies; see [the ruling in the schema reference](../../reference/telemetry-schema.md#backend-key-semantics). All producer sites now emit the split keys.
+* **Paged KV pool** — `pages_pinned`, `cow_events`, `pool_utilization`. Only `pool_utilization` has a producer; the other two are blocked on engine mechanisms that do not exist yet (no pin concept, no copy-on-write page splitting) and are deliberately left unproduced rather than emitted as a hardcoded zero.
 * **MTP / speculative decode** — `mtp_enabled`, `mtp_active`, `mtp_inactive_reason`, `mtp_acceptance_rate`. MTP was previously invisible to the coordinator while silently inflating `observed_decode_tps`, so a partially-MTP fleet biased routing on a metric assumed homogeneous.
+
+The producer for the paged-pool and MTP cohorts is `engine_v2_slot_posture`, an INFO `engine_health` event sampled per slot every 60 s by `EngineV2Bridge+MTP.swift` — recurring and traffic-independent, because a rollout dashboard needs a fleet inventory rather than a once-per-load notification.
 
 **Prompt or response content must never appear in telemetry.** This is enforced by design (no such field exists) and by the allowlist.
 

--- a/docs/reference/telemetry-schema.md
+++ b/docs/reference/telemetry-schema.md
@@ -105,6 +105,9 @@ The coordinator silently drops any `fields` key not in this set. Keys must be ke
 | `pages_pinned` | Go, Swift, TS |
 | `cow_events` | Go, Swift, TS |
 | `pool_utilization` | Go, Swift, TS |
+| `pool_bytes` | Go, Swift, TS |
+| `pool_deferred_growth_bytes` | Go, Swift, TS |
+| `pool_stranded_bytes` | Go, Swift, TS |
 | `mtp_enabled` | Go, Swift, TS |
 | `mtp_active` | Go, Swift, TS |
 | `mtp_inactive_reason` | Go, Swift, TS |
@@ -123,6 +126,51 @@ Canonical server allowlist: [`telemetry_handlers.go:48-171`](../../coordinator/a
 ## Discrepancies
 
 - The TypeScript allowlist in [`console-ui/src/lib/telemetry-types.ts`](../../console-ui/src/lib/telemetry-types.ts) currently omits `network_reachable` and `coordinator_url`, which the Go server accepts. Swift's client-side filter also omits `network_reachable`, `coordinator_url`, `url`, `user_agent`, and `route`. Unknown keys are dropped server-side without error, so this is a client-side completeness gap, not a wire incompatibility.
+
+## Adding a field: one key, one meaning
+
+**One key, one meaning. Before adding a metric, grep the allowlist for the
+concept, not just the name. Prefer raw quantities to ratios at the emission
+point — ratios clamp, hide their denominator, and collide semantically far
+more easily than counts do.**
+
+This has now been paid for twice. `backend` carried three unrelated value
+vocabularies across its producer sites (below), and within a single wave of
+fixing that, `pool_utilization` acquired two producers meaning two different
+things — pool occupancy and a slot's grant-as-fraction-of-pool. Both collisions
+passed every review that checked *names*, because both were spelled correctly.
+Neither would have survived a reviewer asking "is this concept already emitted
+under some other spelling?"
+
+Three corollaries worth stating, since each one is what actually went wrong:
+
+* **Distinct `operation` values do not partition a field.** A dashboard grouping
+  by `kv_backend` or `model` sees every event that carries the key, whatever
+  operation produced it. If two operations disagree about what a key means, the
+  aggregate is noise.
+* **A near-miss name is not a fix.** Two keys both ending `_utilization`, both on
+  paged slots, is the same trap with an extra word. Rename the *concept* or emit
+  the raw terms; do not park a second meaning next to the first in a dropdown.
+* **Raw quantities compose; ratios do not.** A consumer can derive a ratio from
+  numerator and denominator, then also sum, diff and threshold them. It cannot
+  recover either term from a ratio — and a clamped ratio (`min(a, b) / b`) throws
+  away exactly the overflow case the metric existed to expose.
+
+A new key must land in **all three** allowlist mirrors. `TelemetryFieldFilter`
+drops unmirrored keys silently, so a half-applied rename deletes the value rather
+than moving it, and the producer still looks healthy.
+
+**The tempting reuse is the dangerous one.** When the paged re-slice residue
+needed byte fields, every existing byte key in the allowlist belonged to another
+cohort: `peak_memory_bytes`, `available_bytes`, `mlx_active_bytes`,
+`mlx_cache_bytes` and `system_available_bytes` are OOM / memory-snapshot terms,
+and `reserved_bytes` / `reservations` are the KV budget's outstanding
+reservations. `reserved_bytes` is the one that looks right — a paged pool does
+reserve bytes — and reusing it would have been the same collision one level down:
+two unrelated reservation concepts under one key, discovered later by whoever
+summed them. Three new keys (`pool_bytes`, `pool_deferred_growth_bytes`,
+`pool_stranded_bytes`) and a three-mirror change was the cheaper answer, because
+a metric you cannot interpret is worse than a metric that cost three file edits.
 
 ## `backend` key semantics
 
@@ -153,37 +201,131 @@ The other two axes move to their own keys:
   `contiguousQuantized` vs `contiguousUnquantized` is a real distinction that
   `contiguous` cannot express; collapsing it would be a silent data loss.
 
-**Producer sites that must change** (all outside the allowlist change; none were
-edited here):
+**Producer sites — landed.** All four now emit the split keys:
 
-1. `EngineV2Bridge+PrefixCache.swift:197` and `:252` — currently
-   `"backend": .string(kvBackendKind.rawValue)`. Must become
-   `"backend": .string("engine_v2")` **plus**
-   `"kv_backend": .string(kvBackendKind.rawValue)`.
-2. `EngineV2SlotFactory.swift:479` — currently
-   `"backend": .string(capability.backend.rawValue)`. Must become
-   `"backend": .string("engine_v2")`, `"kv_backend": .string(kvBackendKind.rawValue)`,
-   and `"prefix_reuse_backend": .string(capability.backend.rawValue)`. Note the
-   `CBv2PrefixReuseBackend` raw values are camelCase today; emit them snake_cased
-   (`contiguous_unquantized`, `contiguous_quantized`, `paged_fp16`, `unknown`) to
-   match every other telemetry enum.
+1. `EngineV2Bridge+PrefixCache.swift` (`prefix_cache_replay`, both the cold-fallback
+   and the resolved-outcome event) — `backend` is `engine_v2`, and the KV storage
+   kind moved to `kv_backend`.
+2. `EngineV2SlotFactory.swift` (`prefix_cache_construction`) — `backend` is
+   `engine_v2`, `kv_backend` carries the resolved `EngineV2KVBackendKind`, and the
+   `CBv2PrefixReuseBackend` row identity moved to `prefix_reuse_backend`.
+   **Correction to an earlier note here:** those raw values are *not* camelCase.
+   `PrefixReusePlan.swift:14-17` already spells them `contiguous_unquantized`,
+   `contiguous_quantized`, `paged_fp16`, `unknown`, so `.rawValue` is emitted
+   directly and no mapping layer exists (or should be added).
+3. `EngineV2Config.swift` (`engine_v2_kv_backend`) — the kind was previously legible
+   only inside the free-form `reason` string, where `fallback:kill_switch` hides it
+   from any `group by`. It now also rides `kv_backend`; `reason` keeps the
+   fallback detail.
+4. `EngineV2Bridge+MTP.swift` (`engine_v2_slot_posture`) — new recurring per-slot
+   sample, described under [MTP](#mtp-speculative-decode) below.
 
-Until those three sites change, `backend` on `prefix_cache_replay` and
-`prefix_cache_construction` events still carries a KV/prefix value and must be read
-with that caveat. The allowlist entries land first so the producers can be corrected
-without a second coordinator deploy.
+`kv_backend` is **omitted** rather than guessed when a slot's backend was never
+resolved (`EngineV2SlotFactory`'s no-prepared-backend branch). Absent means
+UNKNOWN, matching `BackendSlotCapacity.KVBackend`'s `*string` + `omitempty`
+contract on the heartbeat wire. Never substitute a third vocabulary value such as
+`"unknown"`: omission has to stay distinguishable from an observation.
 
 ## v0.8.0 field semantics
 
 ### Paged KV pool
 
-| Field | Type | Meaning |
-|---|---|---|
-| `pages_pinned` | int | Pages currently pinned in the paged pool and therefore not evictable. |
-| `cow_events` | int | Cumulative copy-on-write page splits (shared prefix page diverged and had to be duplicated). |
-| `pool_utilization` | float | Occupied pool pages / total pool pages, `[0,1]`. |
+| Field | Type | Meaning | Producer |
+|---|---|---|---|
+| `pages_pinned` | int | Pages currently pinned in the paged pool and therefore not evictable. | **none — see below** |
+| `cow_events` | int | Cumulative copy-on-write page splits (shared prefix page diverged and had to be duplicated). | **none — see below** |
+| `pool_utilization` | float | Occupied pool **bytes** / total pool bytes, `[0,1]`. | `engine_v2_slot_posture` |
 
 Aggregate counters only — never page contents, block hashes, or token ids.
+
+> **`pool_utilization` briefly had two producers with two meanings; resolved.**
+> `EngineV2Bridge+MTP.swift` (`operation=engine_v2_slot_posture`) emits the
+> occupancy defined in the table above. `EngineV2Bridge.swift`
+> (`operation=paged_pool_resize_clamped`, Wave 1 track W15) also emitted the key,
+> as `min(requestedBytes, poolBytes) / poolBytes` — a slot's re-sliced fair share
+> as a fraction of its committed pool, explicitly *not* occupancy. Distinct
+> `operation` values did not contain it: both events are paged slots tagged
+> `kv_backend=paged`, so `avg(pool_utilization) by kv_backend` — the rollout
+> dashboard's natural query — blended two unrelated populations.
+>
+> **Ruling:** `pool_utilization` keeps the documented occupancy meaning. The
+> grant-vs-pool relationship is emitted as **raw bytes, not a second ratio**, and
+> must include its denominator so share-of-pool stays derivable without guessing.
+> A second `*_utilization` key was rejected: it sits next to this one in every
+> dropdown, and `min(a, b) / b` discards the overflow magnitude at exactly the
+> point co-residency diagnosis needs it. See
+> [one key, one meaning](#adding-a-field-one-key-one-meaning).
+
+#### Paged pool re-slice residue
+
+| Field | Type | Meaning | Producer |
+|---|---|---|---|
+| `pool_bytes` | int | The slot's committed paged pool, `PagedKVPool.bytesCapacity`. The **denominator**: always emitted with the deltas below so share-of-pool is derivable. |
+| `pool_deferred_growth_bytes` | int | Grant growth the pool could not absorb — the re-sliced fair share exceeds the construction-fixed pool. |
+| `pool_stranded_bytes` | int | Pool bytes committed to this slot that its current fair share cannot use. |
+
+Producer: `paged_pool_resize_clamped` (`EngineV2Bridge.swift`), edge-triggered on a
+change in the residue — WARN while a residue exists, INFO on the edge back to
+exact. All three ship together; a delta without its denominator is not
+interpretable.
+
+**Querying these for the co-residency admission defect (D1) — read this before
+building the panel.** Paged commits slabs per slot at construction, so on a
+memory-tight box a later model can measure too little headroom against the load
+minimum and 503 where an all-contiguous configuration would have served.
+
+The intuitive query is wrong. At the instant of the 503 the failure lands on the
+SECOND model, while the committed slabs that ate the headroom belong to the
+FIRST — and that first slot's `pool_stranded_bytes` may still be **zero**, because
+residue only becomes non-zero once a re-slice cuts a slot's share below its own
+pool. A panel keyed on "stranded > 0 at the time of the error" will show nothing
+during exactly the incident it was built for.
+
+* **`pool_bytes` is the term that is always present.** `Σ pool_bytes by provider`
+  against the box's KV budget is what exposes the commitment that consumed the
+  headroom, and it is emitted on every one of these events regardless of residue.
+* **`pool_stranded_bytes` is the sharper signal once co-residency settles** — it
+  names bytes a slot holds and cannot use — but it is a follow-on diagnostic, not
+  the trigger condition.
+
+**`pool_utilization` is a byte ratio, not a page ratio.** `PagedKVPool` exposes only
+`bytesInUse` / `bytesReserved` / `bytesCapacity`; its page counters are per-group and
+internal, and `pageBytes` differs per `(kvHeads, headDim)` group, so a page ratio
+would weight a small group equally with a large one. The byte ratio is that same
+ratio weighted by page size. It is derived from
+`CBv2CapacitySnapshot.kvBytesInUse / .kvBytesBackendCapacity`, which on the paged
+backend are exactly `PagedKVPool.bytesInUse` / `.bytesCapacity`
+(`EngineLoopV2.swift:2295-2297`). In-use, not reserved: reserved is the worst-case
+admission charge and would report a pool as full while its pages are still cold.
+A zero backend capacity means UNKNOWN, so the key is omitted rather than sent as `0`.
+
+**`pages_pinned` and `cow_events` have no producer, and cannot yet.** Neither
+mechanism exists in the engine: `PagedKVPool` has no pin concept (only
+reserve / in-use), and copy-on-write page splitting is unimplemented — "today every
+page has refcount 0 or 1" (`PagedKVPool.swift` header). They are blocked on the
+prefix-sharing work, not on plumbing, and emitting a hardcoded `0` would be
+indistinguishable from a measured zero. Unblocking them needs, in the engine repo:
+
+```swift
+// MLXLMCommon/ContinuousBatchingV2/Paged/PagedKVPool.swift
+public struct PagedKVPoolStats: Sendable, Equatable {
+    public var pageCount: Int      // Σ over groups
+    public var pagesInUse: Int     // Σ pages actually touched
+    public var pagesReserved: Int  // Σ worst-case admission charges
+    public var pagesPinned: Int    // Σ pages with refcount > 1  — NEEDS the mechanism
+    public var cowEvents: Int      // cumulative page duplications — NEEDS the mechanism
+}
+extension PagedKVPool { public var stats: PagedKVPoolStats { /* Σ over groups */ } }
+
+// MLXLMCommon/ContinuousBatchingV2/CBv2Contracts.swift — CBv2Engine
+func pagedPoolStats() -> PagedKVPoolStats?   // nil on contiguous backends
+```
+
+plus a one-line provider forwarder on `EngineV2Bridge`. The first three fields are
+pure plumbing over counters `PagedKVGroup` already keeps; `pagesPinned` and
+`cowEvents` additionally need refcount sharing and a duplication counter to exist.
+Once `pagedPoolStats()` lands, `pool_utilization` should switch to the exact page
+ratio and this section's byte-ratio caveat can be dropped.
 
 ### MTP (speculative decode)
 
@@ -197,29 +339,52 @@ coordinator routing on a metric the coordinator believes is homogeneous.
 | Field | Type | Meaning |
 |---|---|---|
 | `mtp_enabled` | bool | `ProviderMTPStatusSnapshot.configured` — MTP is configured and the kill switch is off. |
-| `mtp_active` | bool | `ProviderMTPStatusSnapshot.active` — the drafter is loaded and the engine reports itself active. |
+| `mtp_active` | bool | `ProviderMTPStatusSnapshot.active` — the drafter is loaded, the engine reports itself active, **and the slot is not inert** (see `inert_kv_unsupported`). A slot executing zero rounds is not active. |
 | `mtp_inactive_reason` | string | Bounded enum, present whenever MTP is not *productively* running. |
 | `mtp_acceptance_rate` | float | `acceptedDraftTokens / proposedTokens` for the reporting window, `[0,1]`; omitted when `proposedTokens == 0`. |
+
+All four are produced by `engine_v2_slot_posture`, an INFO `engine_health` event
+emitted by a per-bridge sampler on the same 60 s cadence as the MTP metrics log
+(`EngineV2Bridge+MTP.swift`). The sampler runs for **every** slot, MTP or not:
+`mtp_enabled: false` is itself the observation that resolves a partially-MTP fleet,
+and the paged-pool fields do not depend on MTP. The emission point is deliberate —
+a once-per-engine-construction event (like `engine_v2_kv_backend`) rides a sink that
+drops on full behind a 100/min limit and is a notification, not an inventory; a
+per-request event makes idle slots vanish; an edge-triggered event (like
+`step_wedge`) never reports a healthy slot. The per-slot every-heartbeat channel is
+`BackendSlotCapacity`, which already carries `kv_backend`; this is its
+telemetry-side counterpart.
 
 `mtp_inactive_reason` values are
 [`MTPFallbackReason`](../../provider-swift/Sources/ProviderCore/SpecDec/SpecDecTypes.swift)
 raw values (`config_disabled`, `kill_switch_disabled`, `target_unsupported`, …,
-`engine_inactive`) **plus one value that has no enum case yet**:
+`engine_inactive`), plus one that names a state the enum could not previously
+express:
 
-* `inert_kv_unsupported` — **enabled but doing nothing.** On a paged `gemma-4-26b-qat-4bit`
-  slot MTP currently reports `mtp_active = true` while executing zero rounds: the
-  provider derives `active` from assistant-load success
-  ([`ProviderEngineBundle.swift:32,36`](../../provider-swift/Sources/ProviderCore/Inference/ProviderEngineBundle.swift)),
-  not from rounds executed. The slot charges ~236 MB of drafter residency, produces
-  no rounds, and climbs `skippedRows["kv_unsupported"]`
-  ([`EngineLoopV2+MTPPlanning.swift:47,169`](../../libs/mlx-swift-lm/Libraries/MLXLMCommon/ContinuousBatchingV2/MTP/EngineLoopV2+MTPPlanning.swift)).
-  Without this value the state is unnameable: `mtp_active` is `true` and every
-  existing `MTPFallbackReason` is wrong.
+* `inert_kv_unsupported` — **enabled but doing nothing.** On a paged
+  `gemma-4-26b-qat-4bit` slot the drafter loads, the engine reports MTP active, and
+  every planned row is refused by the storage-eligibility guard
+  ([`EngineLoopV2+MTPPlanning.swift:47`](../../libs/mlx-swift-lm/Libraries/MLXLMCommon/ContinuousBatchingV2/MTP/EngineLoopV2+MTPPlanning.swift)),
+  so not one round runs while ~236 MB of drafter residency is charged. It is
+  distinct from `engine_inactive`, where the engine says it is OFF; here the engine
+  says it is ON and produces nothing, which is exactly why the state stayed
+  invisible.
 
-  **Follow-up required, not done here** (`SpecDecTypes.swift` is outside this change):
-  add `case inertKVUnsupported = "inert_kv_unsupported"` to `MTPFallbackReason` and
-  derive it in `ProviderMTPStatusSnapshot.init` when
-  `rounds == 0 && skippedRows["kv_unsupported", default: 0] > 0`.
+  Derived in `ProviderMTPStatusSnapshot.init` when the drafter activated, the engine
+  reports active, `rounds == 0`, and `skippedRows["kv_unsupported"] > 0`. **`active`
+  is false in this state.** Reporting it active is what hid the bug, and it also
+  inverted the field's purpose: an inert slot does not inflate
+  `observed_decode_tps`, so discounting its throughput is wrong in the opposite
+  direction.
+
+  `rounds` counts only rounds that drafted *and* verified, and the skip is recorded
+  per scheduled row, so the state can only be reached after real traffic has been
+  planned and refused — never on a freshly built engine. That bounds the blast
+  radius of the `active` change: the post-build MTP teardown gate
+  (`ProviderLoop+ModelLoading`, `ProviderLoop+EngineV2Liveness`, `StandaloneServer`)
+  reads `active` on a zero-traffic engine, where `rounds == 0` **and** the skip count
+  is `0`, so it cannot mis-fire there. Post-load nothing else consults the snapshot,
+  so the inert slot's residency is reported, not reclaimed.
 
 `mtp_acceptance_rate` is a per-event ratio and therefore **not** re-aggregatable by a
 plain average — a fleet roll-up must weight each sample by its proposed-token count.

--- a/docs/reference/telemetry-schema.md
+++ b/docs/reference/telemetry-schema.md
@@ -100,11 +100,128 @@ The coordinator silently drops any `fields` key not in this set. Keys must be ke
 | `url` | Go, TS |
 | `user_agent` | Go, TS |
 | `route` | Go, TS |
+| `kv_backend` | Go, Swift, TS |
+| `prefix_reuse_backend` | Go, Swift, TS |
+| `pages_pinned` | Go, Swift, TS |
+| `cow_events` | Go, Swift, TS |
+| `pool_utilization` | Go, Swift, TS |
+| `mtp_enabled` | Go, Swift, TS |
+| `mtp_active` | Go, Swift, TS |
+| `mtp_inactive_reason` | Go, Swift, TS |
+| `mtp_acceptance_rate` | Go, Swift, TS |
+
+This table is not exhaustive: the OOM / memory-pressure, engine-health (first-token
+wedge), eval-in-flight, KV-budget audit, media, and exact-prefix-replay cohorts are
+allowlisted in all three mirrors but have never been transcribed here. Absence from
+this table does **not** mean a key is rejected — the Go map is the authority, and
+`TestTelemetryAllowlistThreeWayParity` is what keeps the three mirrors honest.
 
 **Important:** No prompt or response content is ever placed in telemetry. The allowlist contains only non-sensitive operational metadata.
 
-Canonical server allowlist: [`telemetry_handlers.go:48-87`](../../coordinator/api/telemetry_handlers.go). Swift client-side filter: [`TelemetryFieldFilter.allowed`](../../provider-swift/Sources/ProviderCore/Telemetry/TelemetryEvent.swift). TS client-side set: [`TELEMETRY_ALLOWED_FIELDS`](../../console-ui/src/lib/telemetry-types.ts).
+Canonical server allowlist: [`telemetry_handlers.go:48-171`](../../coordinator/api/telemetry_handlers.go). Swift client-side filter: [`TelemetryFieldFilter.allowed`](../../provider-swift/Sources/ProviderCore/Telemetry/TelemetryEvent.swift) (`TelemetryEvent.swift:238-294`). TS client-side set: [`TELEMETRY_ALLOWED_FIELDS`](../../console-ui/src/lib/telemetry-types.ts) (`telemetry-types.ts:58-160`).
 
 ## Discrepancies
 
 - The TypeScript allowlist in [`console-ui/src/lib/telemetry-types.ts`](../../console-ui/src/lib/telemetry-types.ts) currently omits `network_reachable` and `coordinator_url`, which the Go server accepts. Swift's client-side filter also omits `network_reachable`, `coordinator_url`, `url`, `user_agent`, and `route`. Unknown keys are dropped server-side without error, so this is a client-side completeness gap, not a wire incompatibility.
+
+## `backend` key semantics
+
+`backend` was overloaded. Across producer sites it carried **three unrelated value
+vocabularies**, so any `group by backend` dashboard mis-buckets:
+
+| Meaning | Values | Producer sites |
+|---|---|---|
+| Engine identity | `engine_v2` | `EngineV2Bridge+Capacity.swift:220`, `EngineV2Bridge.swift:1207,1231`, `EngineV2Config.swift:215,255`, `EngineV2VisionPrefill.swift:468`, `MultiModelBatchSchedulerEngine.swift:854` |
+| Process runtime identity | `mlx-swift` | `darkbloom/StartCommand+Modes.swift:209` |
+| KV storage kind | `paged`, `contiguous` | `EngineV2Bridge+PrefixCache.swift:197,252` |
+| Prefix-reuse row identity | `contiguousUnquantized`, `contiguousQuantized`, `pagedFP16`, `unknown` | `EngineV2SlotFactory.swift:479` |
+
+**Ruling.** `backend` keeps the majority meaning — the engine or process runtime
+executing inference (`engine_v2`, `mlx-swift`). It is also the meaning that matches
+`RegisterMessage.backend` on the wire, so telemetry and registration stay joinable.
+The other two axes move to their own keys:
+
+* `kv_backend` — the KV storage kind, `paged` | `contiguous`. This is **not a new
+  name**: it is deliberately the same key and the same two-value vocabulary as
+  [`BackendSlotCapacity.KVBackend`](../../coordinator/protocol/messages.go) on the
+  heartbeat wire (`messages.go:303`) and `kvBackend` in
+  [`Types.swift:518`](../../provider-swift/Sources/ProviderCore/Protocol/Types.swift).
+  Telemetry and per-slot capacity therefore group identically, which is the whole
+  point of the v0.8.0 rollout dashboard.
+* `prefix_reuse_backend` — the finer `CBv2PrefixReuseBackend` row identity. It gets
+  its own key rather than being folded into `kv_backend` because
+  `contiguousQuantized` vs `contiguousUnquantized` is a real distinction that
+  `contiguous` cannot express; collapsing it would be a silent data loss.
+
+**Producer sites that must change** (all outside the allowlist change; none were
+edited here):
+
+1. `EngineV2Bridge+PrefixCache.swift:197` and `:252` — currently
+   `"backend": .string(kvBackendKind.rawValue)`. Must become
+   `"backend": .string("engine_v2")` **plus**
+   `"kv_backend": .string(kvBackendKind.rawValue)`.
+2. `EngineV2SlotFactory.swift:479` — currently
+   `"backend": .string(capability.backend.rawValue)`. Must become
+   `"backend": .string("engine_v2")`, `"kv_backend": .string(kvBackendKind.rawValue)`,
+   and `"prefix_reuse_backend": .string(capability.backend.rawValue)`. Note the
+   `CBv2PrefixReuseBackend` raw values are camelCase today; emit them snake_cased
+   (`contiguous_unquantized`, `contiguous_quantized`, `paged_fp16`, `unknown`) to
+   match every other telemetry enum.
+
+Until those three sites change, `backend` on `prefix_cache_replay` and
+`prefix_cache_construction` events still carries a KV/prefix value and must be read
+with that caveat. The allowlist entries land first so the producers can be corrected
+without a second coordinator deploy.
+
+## v0.8.0 field semantics
+
+### Paged KV pool
+
+| Field | Type | Meaning |
+|---|---|---|
+| `pages_pinned` | int | Pages currently pinned in the paged pool and therefore not evictable. |
+| `cow_events` | int | Cumulative copy-on-write page splits (shared prefix page diverged and had to be duplicated). |
+| `pool_utilization` | float | Occupied pool pages / total pool pages, `[0,1]`. |
+
+Aggregate counters only — never page contents, block hashes, or token ids.
+
+### MTP (speculative decode)
+
+MTP is otherwise **invisible** to the coordinator: before this change, `mtp`,
+`speculat`, and `draft` matched nothing in `coordinator/protocol/`,
+`coordinator/api/`, the provider `Protocol/` and `Telemetry/` trees, or
+`console-ui/src/lib/`. That matters beyond diagnostics: MTP inflates
+`observed_decode_tps` with no discriminator, so a partially-MTP fleet biases
+coordinator routing on a metric the coordinator believes is homogeneous.
+
+| Field | Type | Meaning |
+|---|---|---|
+| `mtp_enabled` | bool | `ProviderMTPStatusSnapshot.configured` — MTP is configured and the kill switch is off. |
+| `mtp_active` | bool | `ProviderMTPStatusSnapshot.active` — the drafter is loaded and the engine reports itself active. |
+| `mtp_inactive_reason` | string | Bounded enum, present whenever MTP is not *productively* running. |
+| `mtp_acceptance_rate` | float | `acceptedDraftTokens / proposedTokens` for the reporting window, `[0,1]`; omitted when `proposedTokens == 0`. |
+
+`mtp_inactive_reason` values are
+[`MTPFallbackReason`](../../provider-swift/Sources/ProviderCore/SpecDec/SpecDecTypes.swift)
+raw values (`config_disabled`, `kill_switch_disabled`, `target_unsupported`, …,
+`engine_inactive`) **plus one value that has no enum case yet**:
+
+* `inert_kv_unsupported` — **enabled but doing nothing.** On a paged `gemma-4-26b-qat-4bit`
+  slot MTP currently reports `mtp_active = true` while executing zero rounds: the
+  provider derives `active` from assistant-load success
+  ([`ProviderEngineBundle.swift:32,36`](../../provider-swift/Sources/ProviderCore/Inference/ProviderEngineBundle.swift)),
+  not from rounds executed. The slot charges ~236 MB of drafter residency, produces
+  no rounds, and climbs `skippedRows["kv_unsupported"]`
+  ([`EngineLoopV2+MTPPlanning.swift:47,169`](../../libs/mlx-swift-lm/Libraries/MLXLMCommon/ContinuousBatchingV2/MTP/EngineLoopV2+MTPPlanning.swift)).
+  Without this value the state is unnameable: `mtp_active` is `true` and every
+  existing `MTPFallbackReason` is wrong.
+
+  **Follow-up required, not done here** (`SpecDecTypes.swift` is outside this change):
+  add `case inertKVUnsupported = "inert_kv_unsupported"` to `MTPFallbackReason` and
+  derive it in `ProviderMTPStatusSnapshot.init` when
+  `rounds == 0 && skippedRows["kv_unsupported", default: 0] > 0`.
+
+`mtp_acceptance_rate` is a per-event ratio and therefore **not** re-aggregatable by a
+plain average — a fleet roll-up must weight each sample by its proposed-token count.
+If weighted aggregation is needed server-side, add `mtp_proposed_tokens` and
+`mtp_accepted_tokens` rather than post-processing the ratio.

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge+Capacity.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge+Capacity.swift
@@ -155,6 +155,13 @@ extension EngineV2Bridge {
             // Slot-level bookkeeping (recorded by ensureModelLoaded on
             // load completion) — previously the legacy scheduler's field.
             modelLoadTimeMs: modelLoadTimeMs,
+            // Per-slot KV-backend discriminator. This is the RESOLVED kind
+            // the engine was built with (post-veto, post-fallback), not the
+            // operator's request, and it is reported on EVERY heartbeat —
+            // unlike the once-per-construction `engine_v2_kv_backend`
+            // telemetry event, which rides a droppable best-effort sink and
+            // is therefore not a fleet inventory.
+            kvBackend: kvBackendKind.rawValue,
             stepsExecuted: Int64(wedgeMonitor.lastStepsSample),
             admits: Int64(wedgeMonitor.admits),
             firstTokensEmitted: Int64(wedgeMonitor.firstTokens),

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge+MTP.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge+MTP.swift
@@ -10,23 +10,39 @@ extension EngineV2Bridge {
         subsystem: "com.darkbloom.provider", category: "engine_v2_mtp")
     #endif
 
+    /// Record MTP activation and (re)start the periodic per-slot posture
+    /// sampler.
+    ///
+    /// The sampler is deliberately NOT gated on MTP being active. It also
+    /// carries paged-pool occupancy, which a slot with no drafter must still
+    /// report, and `mtp_enabled: false` is itself the observation that makes
+    /// a partially-MTP fleet resolvable. `metricsInterval == .zero` still
+    /// disables it (tests).
     func configureMTPStatus(
         _ status: MTPActivationStatus,
         metricsInterval: Duration = .seconds(60)
     ) {
         mtpActivationStatus = status
-        mtpMetricsTask?.cancel()
-        mtpMetricsTask = nil
-        guard status.active, metricsInterval > .zero else { return }
+        slotPostureTask?.cancel()
+        slotPostureTask = nil
+        guard metricsInterval > .zero else { return }
         let bridge = self
-        mtpMetricsTask = Task { [weak bridge] in
+        slotPostureTask = Task { [weak bridge] in
             while !Task.isCancelled {
                 try? await taskSleep(metricsInterval)
                 if Task.isCancelled { return }
                 guard let bridge else { return }
-                await bridge.logMTPSnapshot()
+                await bridge.sampleSlotPosture()
             }
         }
+    }
+
+    /// One posture tick: read the engine's MTP metrics ONCE, log it when a
+    /// drafter is loaded, and emit the telemetry sample unconditionally.
+    private func sampleSlotPosture() {
+        let snapshot = mtpStatusSnapshot()
+        if mtpActivationStatus.active { logMTPSnapshot(snapshot) }
+        emitSlotPostureTelemetry(snapshot)
     }
 
     /// Public/test-visible lock-safe snapshot. `EngineV2.mtpMetricsSnapshot()`
@@ -37,8 +53,7 @@ extension EngineV2Bridge {
         return ProviderMTPStatusSnapshot(status: mtpActivationStatus, metrics: metrics)
     }
 
-    private func logMTPSnapshot() {
-        let snapshot = mtpStatusSnapshot()
+    private func logMTPSnapshot(_ snapshot: ProviderMTPStatusSnapshot) {
         #if canImport(os)
         let reason = snapshot.fallbackReason?.rawValue ?? "none"
         let revision = snapshot.assistantRevision ?? "none"
@@ -50,5 +65,98 @@ extension EngineV2Bridge {
             "mtp metrics model=\(self.modelId, privacy: .public) configured=\(snapshot.configured) active=\(snapshot.active) reason=\(reason, privacy: .public) revision=\(revision, privacy: .public) assistant_bytes=\(snapshot.assistantResidentBytes) depth=\(snapshot.selectedDepth) decode_bucket=\(snapshot.decodeRowBucket) rounds=\(snapshot.rounds) seeds=\(snapshot.seedRows) proposed=\(snapshot.proposedTokens) accepted=\(snapshot.acceptedDraftTokens) emitted=\(snapshot.committedEmittedTokens) skipped=\(skipped, privacy: .public) controller=\(controller, privacy: .public)"
         )
         #endif
+    }
+
+    /// The producer for the v0.8.0 MTP and paged-pool telemetry fields.
+    ///
+    /// WHY THIS EMISSION POINT. These fields exist so a paged rollout can be
+    /// judged with no canary fleet, and that needs a FLEET INVENTORY: every
+    /// loaded slot, recurring, independent of traffic. Three shapes that are
+    /// not that, all present in this codebase already:
+    ///
+    ///   * Once per engine construction — the `engine_v2_kv_backend` event's
+    ///     mistake (EngineV2Config). It rides a best-effort sink that DROPS
+    ///     ON FULL behind a 100/min limit, so a single event per model load
+    ///     is a notification, not an inventory: miss it and the slot is
+    ///     invisible until the next restart.
+    ///   * Per request — an idle slot vanishes from the fleet view, and
+    ///     `inert_kv_unsupported` is precisely a slot that charges full
+    ///     drafter residency while producing nothing.
+    ///   * Edge triggered, like `step_wedge` — a healthy slot never reports,
+    ///     so "no event" and "no provider" are indistinguishable.
+    ///
+    /// A per-bridge timer on the existing 60 s MTP cadence satisfies all
+    /// three, is bounded fleet-wide (one event per slot per minute, and
+    /// `max_model_slots` defaults to 3), and runs off the inference hot path.
+    /// The per-slot every-heartbeat channel is `BackendSlotCapacity`, which
+    /// already carries `kv_backend`; this is its telemetry-side counterpart.
+    /// Internal rather than private so a test can drive it with a
+    /// hand-built snapshot: the inert state needs `CBv2MTPMetrics`, which
+    /// only a concrete `EngineV2` produces, and standing up a real engine
+    /// would make this a weights-and-Metal test instead of a field test.
+    func emitSlotPostureTelemetry(_ snapshot: ProviderMTPStatusSnapshot) {
+        var fields: [String: AnyCodableValue] = [
+            "component": .string("engine"),
+            "operation": .string("engine_v2_slot_posture"),
+            // Three axes, three keys — see the ruling in
+            // docs/reference/telemetry-schema.md. `backend` is the engine
+            // executing inference; `kv_backend` is the KV storage kind, the
+            // same key and vocabulary as BackendSlotCapacity.KVBackend, so a
+            // rollout dashboard groups telemetry and capacity identically.
+            "backend": .string("engine_v2"),
+            "kv_backend": .string(kvBackendKind.rawValue),
+            "model": .string(modelId),
+            "mtp_enabled": .bool(snapshot.configured),
+            "mtp_active": .bool(snapshot.active),
+        ]
+        // Present whenever MTP is not PRODUCTIVELY running, which includes
+        // `inert_kv_unsupported` — enabled, drafter resident, zero rounds.
+        // Absent only when MTP is genuinely producing rounds.
+        if let reason = snapshot.fallbackReason {
+            fields["mtp_inactive_reason"] = .string(reason.rawValue)
+        }
+        // OMITTED, never 0.0, when nothing was proposed. A zero would read as
+        // "the target rejects every draft" rather than "no drafts existed",
+        // and would drag any unweighted fleet average toward zero. This is a
+        // per-event ratio in the first place: a roll-up must weight each
+        // sample by its proposed-token count.
+        if snapshot.proposedTokens > 0 {
+            fields["mtp_acceptance_rate"] = .double(
+                Double(snapshot.acceptedDraftTokens) / Double(snapshot.proposedTokens))
+        }
+        // Paged pool occupancy, in BYTES over bytes — not pages over pages.
+        // `PagedKVPool` exposes only bytesInUse/bytesReserved/bytesCapacity;
+        // its page counters are per-group and internal. The byte ratio is a
+        // page ratio weighted by page size (pageBytes differs per (kvHeads,
+        // headDim) group), which is the more useful occupancy figure anyway.
+        // Stated here and in the schema doc so the units cannot silently
+        // drift — that drift is the whole reason `backend` had to be split.
+        //
+        // In-use, not reserved: reserved is the worst-case admission charge
+        // and would report a pool as full while its pages are still cold.
+        // A zero backend capacity means UNKNOWN (test stubs, idle
+        // point-updates), never an empty pool, so the key is omitted.
+        if kvBackendKind == .paged {
+            let capacity = capacitySnapshot()
+            if capacity.kvBytesBackendCapacity > 0 {
+                let used = Double(max(0, capacity.kvBytesInUse))
+                fields["pool_utilization"] = .double(
+                    min(1.0, used / Double(capacity.kvBytesBackendCapacity)))
+            }
+        }
+        // `pages_pinned` and `cow_events` have NO producer here on purpose.
+        // Neither mechanism exists yet: PagedKVPool has no pin concept (only
+        // reserve/in-use), and copy-on-write page splitting is unimplemented
+        // — "today every page has refcount 0 or 1" (PagedKVPool.swift header).
+        // Emitting a hardcoded 0 would be indistinguishable from a measured
+        // zero and would make the dashboard assert a fact nothing observed.
+        var event = TelemetryEvent(
+            source: .provider,
+            severity: .info,
+            kind: .engineHealth,
+            message: "engine_v2: slot posture"
+        )
+        event.fields = TelemetryFieldFilter.filter(fields)
+        emit(event)
     }
 }

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge+MTP.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge+MTP.swift
@@ -150,6 +150,11 @@ extension EngineV2Bridge {
         // — "today every page has refcount 0 or 1" (PagedKVPool.swift header).
         // Emitting a hardcoded 0 would be indistinguishable from a measured
         // zero and would make the dashboard assert a fact nothing observed.
+        //
+        // For the same reason the two keys are no longer ALLOWLISTED either:
+        // a key that survives the filter but is never written reads as a
+        // legitimate zero to anyone building a panel on it. Add each key in
+        // the same change as its mechanism, across all three mirrors.
         var event = TelemetryEvent(
             source: .provider,
             severity: .info,

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge+PrefixCache.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge+PrefixCache.swift
@@ -194,7 +194,14 @@ extension EngineV2Bridge {
         event.fields = TelemetryFieldFilter.filter([
             "component": .string("engine"),
             "operation": .string("prefix_cache_replay"),
-            "backend": .string(kvBackendKind.rawValue),
+            // `backend` names the ENGINE executing inference, matching
+            // RegisterMessage.backend on the wire. The KV STORAGE KIND is a
+            // separate axis and rides `kv_backend` — deliberately the same
+            // key and vocabulary as BackendSlotCapacity.KVBackend on the
+            // heartbeat wire, so telemetry and per-slot capacity group
+            // identically. Never fold one into the other.
+            "backend": .string("engine_v2"),
+            "kv_backend": .string(kvBackendKind.rawValue),
             "model": .string(modelId),
             "reason": .string(reason),
             "prefix_reuse_strategy": .string("none"),
@@ -249,7 +256,9 @@ extension EngineV2Bridge {
         event.fields = TelemetryFieldFilter.filter([
             "component": .string("engine"),
             "operation": .string("prefix_cache_replay"),
-            "backend": .string(kvBackendKind.rawValue),
+            // Same two axes as the cold-fallback event above.
+            "backend": .string("engine_v2"),
+            "kv_backend": .string(kvBackendKind.rawValue),
             "model": .string(modelId),
             "reason": .string(outcome),
             "prefix_reuse_strategy": .string(

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge.swift
@@ -33,6 +33,45 @@ import ProviderCoreFoundation
 import os
 #endif
 
+/// What a paged slot's construction-fixed pool could NOT do when the fleet
+/// re-slicer moved its grant.
+///
+/// A contiguous slot resizes its admission ledger and its physical capacity
+/// together, so every re-slice is exact. A paged slot's slabs are
+/// materialized once at engine construction (`PagedKVPool.materializeSlabs`)
+/// and `PagedKVPool` has no resize primitive, so a non-exact re-slice leaves
+/// one of two residues:
+///
+///   * GROW past the pool ⇒ `deferredGrowthBytes` of awarded fair share the
+///     slot cannot serve. The fleet re-slicer believes this slot holds them.
+///   * SHRINK below the pool ⇒ `strandedBytes` of physical KV the slot still
+///     owns after its fair share was cut. Nobody can use them: the re-slicer
+///     has already promised those bytes to a co-resident slot's logical
+///     grant while Metal still holds them here, so `Σ(logical grants) ≤
+///     fleet budget` stops implying `Σ(physical KV) ≤ fleet budget`.
+///
+/// Both are ZERO on a contiguous slot and on an exact paged re-slice. They
+/// are precisely the two inputs a real pool resize consumes — and, with no
+/// canary fleet, the only signal that a box's paged slots are partitioned by
+/// model ARRIVAL ORDER rather than by fair share.
+public struct PagedPoolResizeShortfall: Sendable, Equatable {
+    /// Committed physical pool bytes (`CBv2CapacitySnapshot
+    /// .kvBytesBackendCapacity`); always > 0 — an UNKNOWN pool yields no
+    /// shortfall at all rather than a fabricated one.
+    public let poolBytes: Int
+    /// The logical fair share the re-slicer last asked this slot to hold,
+    /// recorded BEFORE the physical clamp.
+    public let requestedBytes: Int
+
+    /// Awarded grant the construction-fixed pool cannot serve.
+    public var deferredGrowthBytes: Int { max(0, requestedBytes - poolBytes) }
+    /// Physical KV held past the current fair share; unreclaimable without
+    /// an unload/rebuild of the slot's engine.
+    public var strandedBytes: Int { max(0, poolBytes - requestedBytes) }
+    /// The pool and the fair share agree — nothing to resize.
+    public var isExact: Bool { poolBytes == requestedBytes }
+}
+
 /// Bridges one `CBv2Engine` (one loaded model) to the provider's
 /// `GenerationEvent` streaming surface.
 ///
@@ -126,8 +165,11 @@ public actor EngineV2Bridge {
     /// checkpoint-tier logger). Started by the slot factory when an active
     /// cache exists; cancelled in `shutdown()`.
     var prefixCacheStatsTask: Task<Void, Never>?
-    /// Periodic content-free MTP metrics logger, cancelled by `shutdown()`.
-    var mtpMetricsTask: Task<Void, Never>?
+    /// Periodic content-free per-slot POSTURE sampler: the MTP metrics log
+    /// plus the `engine_v2_slot_posture` telemetry event that produces the
+    /// v0.8.0 MTP and paged-pool fields. Runs for every slot, MTP or not —
+    /// see `configureMTPStatus`. Cancelled by `shutdown()`.
+    var slotPostureTask: Task<Void, Never>?
     var mtpActivationStatus = MTPActivationStatus.disabled(
         .configDisabled, configured: false)
     /// Injectable telemetry sink (tests); nil ⇒ `TelemetryClient.shared`.
@@ -224,6 +266,16 @@ public actor EngineV2Bridge {
     /// Set on the OLD bridge being drained; the recovered slot's fresh
     /// bridge starts clean.
     var recoveryReloading = false
+    /// The logical fair share the fleet re-slicer last asked this slot to
+    /// hold, recorded BEFORE the paged physical clamp so the part a
+    /// construction-fixed pool cannot honour stays measurable
+    /// (`pagedPoolResizeShortfall()`). nil until the first re-slice: a
+    /// freshly-built slot's admission ceiling IS its pool, by construction.
+    var lastRequestedKVBytesCapacity: Int?
+    /// Last shortfall shape published to telemetry, so the clamp signal is
+    /// emitted on CHANGE only — the re-slicer fires on every load and unload
+    /// of every co-resident model, and an unchanged residue is not news.
+    var lastPagedShortfallEmitted: PagedPoolResizeShortfall?
 
     public init(
         engine: any CBv2Engine,
@@ -705,15 +757,36 @@ public actor EngineV2Bridge {
     /// does NOT reclaim physical memory; callers must never count it as
     /// freed. A later GROW can restore admission only up to the same pool.
     /// Reclaiming or adding physical bytes requires an unload/rebuild.
+    ///
+    /// Neither residue is silent any more: the pre-clamp target is recorded
+    /// and the difference is published as a `PagedPoolResizeShortfall`
+    /// (accessor + `paged_pool_resize_clamped` telemetry). Multi-model boxes
+    /// need it — a paged slot sized against the box as it looked at ITS load
+    /// instant is otherwise indistinguishable from one holding its fair
+    /// share.
     public func updateKVBytesCapacity(_ bytes: Int) {
         let requested = max(0, bytes)
         guard let engine = ownedEngine else { return }
-        if kvBackendKind == .paged {
-            let physical = max(0, engine.capacity().kvBytesBackendCapacity)
-            engine.updateKVBytesCapacity(min(requested, physical))
-        } else {
+        guard kvBackendKind == .paged else {
             engine.updateKVBytesCapacity(requested)
+            return
         }
+        lastRequestedKVBytesCapacity = requested
+        // `kvBytesBackendCapacity == 0` means UNKNOWN, never "no pool" — the
+        // `CBv2CapacitySnapshot` contract says so in as many words. Clamping
+        // to it would pin this slot's admission ledger at ZERO for the rest
+        // of its life: the loaded-but-unserveable black hole the post-load
+        // guard exists to prevent, reached through a legal contract state.
+        // An unknown pool therefore does not bind, exactly as
+        // `backendSlotCapacity` already refuses to bind the heartbeat.
+        let physical = engine.capacity().kvBytesBackendCapacity
+        guard physical > 0 else {
+            engine.updateKVBytesCapacity(requested)
+            return
+        }
+        engine.updateKVBytesCapacity(min(requested, physical))
+        publishPagedPoolResizeShortfall(
+            PagedPoolResizeShortfall(poolBytes: physical, requestedBytes: requested))
     }
 
     /// Record the slot's cold-start load time for heartbeat reporting
@@ -728,6 +801,93 @@ public actor EngineV2Bridge {
     /// serveable-KV guard (`KVHeadroomProbe.postBuildServeable`).
     public func kvBackendPoolBytes() -> UInt64 {
         UInt64(max(0, capacitySnapshot().kvBytesBackendCapacity))
+    }
+
+    /// What this slot's construction-fixed paged pool could not do for the
+    /// re-slicer's most recent grant. nil on a contiguous slot, on a paged
+    /// slot whose pool capacity is UNKNOWN, and before the first re-slice
+    /// (a freshly-built slot's ceiling IS its pool).
+    public func pagedPoolResizeShortfall() -> PagedPoolResizeShortfall? {
+        guard kvBackendKind == .paged, let requested = lastRequestedKVBytesCapacity else {
+            return nil
+        }
+        let pool = capacitySnapshot().kvBytesBackendCapacity
+        guard pool > 0 else { return nil }
+        return PagedPoolResizeShortfall(poolBytes: pool, requestedBytes: requested)
+    }
+
+    /// Publish a change in the paged resize residue as `engine_health` /
+    /// `operation=paged_pool_resize_clamped`. WARN while a residue exists,
+    /// INFO on the edge back to exact. Off the inference hot path (the
+    /// re-slicer runs at model load/unload only) and carries aggregate pool
+    /// arithmetic exclusively — every key is already in the coordinator's
+    /// allowlist, and the filter is applied so a future key cannot leak.
+    ///
+    /// DELIBERATELY NOT `pool_utilization`. That key is defined fleet-wide as
+    /// OCCUPANCY (`bytesInUse / bytesCapacity`, produced by
+    /// `engine_v2_slot_posture` in `EngineV2Bridge+MTP.swift`), and this
+    /// event's grant-vs-pool ratio is a different quantity on the same
+    /// population — both are paged slots tagged `kv_backend=paged`, so
+    /// `avg(pool_utilization) by kv_backend` would blend them into noise.
+    /// That is the `backend`-overloading defect recurring, so the ratio is
+    /// not emitted here at all.
+    ///
+    /// RULED (Main, wave 2): this event carries RAW BYTES, never a second
+    /// ratio. A second `*_utilization` key was rejected — `min(a, b) / b`
+    /// clamps to 1.0 exactly when the fair share exceeds the pool, which is
+    /// the case co-residency exists to diagnose, so the magnitude vanishes
+    /// at the only moment it matters. Bytes compose: a consumer can sum,
+    /// diff, threshold, and derive the ratio from them; nothing recovers
+    /// bytes from a clamped ratio. The binding condition is that the ratio
+    /// stay DERIVABLE, so the denominator ships with the delta:
+    /// `pool_bytes` + `pool_deferred_growth_bytes` + `pool_stranded_bytes`.
+    ///
+    /// All three keys are mirrored (Go `telemetry_handlers.go`, Swift
+    /// `TelemetryEvent.swift`, TS `telemetry-types.ts`) and are emitted
+    /// TOGETHER. `pool_bytes` is the denominator and must never ship without
+    /// the deltas, nor they without it: `TelemetryFieldFilter` drops
+    /// unmirrored keys SILENTLY, so a partial set would look healthy at the
+    /// producer and arrive uninterpretable.
+    ///
+    /// `pool_stranded_bytes` is the fleet-visible diagnostic for the
+    /// co-residency admission defect — paged commits slabs per slot at
+    /// construction, so on a memory-tight box a later slot measures too
+    /// little headroom against the load minimum and 503s where an
+    /// all-contiguous box would have served. Without this number that
+    /// reaches the fleet as a mystery 503.
+    private func publishPagedPoolResizeShortfall(_ shortfall: PagedPoolResizeShortfall) {
+        guard shortfall != lastPagedShortfallEmitted else { return }
+        // Nothing to report when a slot has been exact all along.
+        if shortfall.isExact, lastPagedShortfallEmitted == nil { return }
+        lastPagedShortfallEmitted = shortfall
+        let reason: String
+        if shortfall.deferredGrowthBytes > 0 {
+            reason = "deferred_grow"
+        } else if shortfall.strandedBytes > 0 {
+            reason = "unreclaimed_shrink"
+        } else {
+            reason = "exact"
+        }
+        var event = TelemetryEvent(
+            source: .provider,
+            severity: shortfall.isExact ? .info : .warn,
+            kind: .engineHealth,
+            message: shortfall.isExact
+                ? "engine_v2: paged pool matches the re-sliced grant"
+                : "engine_v2: paged pool cannot follow the re-sliced grant "
+                    + "(pool \(shortfall.poolBytes) B vs grant \(shortfall.requestedBytes) B)")
+        event.fields = TelemetryFieldFilter.filter([
+            "component": .string("engine"),
+            "operation": .string("paged_pool_resize_clamped"),
+            "backend": .string("engine_v2"),
+            "kv_backend": .string("paged"),
+            "model": .string(modelId),
+            "reason": .string(reason),
+            "pool_bytes": .int(shortfall.poolBytes),
+            "pool_deferred_growth_bytes": .int(shortfall.deferredGrowthBytes),
+            "pool_stranded_bytes": .int(shortfall.strandedBytes),
+        ])
+        emit(event)
     }
 
     /// Runtime fan-out helper: cancel iff this bridge owns the request-id.
@@ -752,8 +912,8 @@ public actor EngineV2Bridge {
         let statsTask = prefixCacheStatsTask
         prefixCacheStatsTask = nil
         statsTask?.cancel()
-        mtpMetricsTask?.cancel()
-        mtpMetricsTask = nil
+        slotPostureTask?.cancel()
+        slotPostureTask = nil
         let live = pumpTasks
         pumpTasks.removeAll()
         for task in live.values { task.cancel() }

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Config.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Config.swift
@@ -230,10 +230,13 @@ public enum EngineV2Factory {
     }
 
     /// INFO `engine_health` event reporting which KV backend a slot was
-    /// built with (`operation=engine_v2_kv_backend`, `reason=paged |
-    /// contiguous | fallback:<why>`). Emitted once per engine construction
-    /// so the fleet dashboard can attribute serving backends and spot
-    /// unexpected fallbacks. Allowlisted fields only — no wire changes.
+    /// built with (`operation=engine_v2_kv_backend`, `kv_backend=paged |
+    /// contiguous`, `reason=paged | contiguous | fallback:<why>`). Emitted
+    /// once per engine construction, so it is a NOTIFICATION of a load, not
+    /// a fleet inventory — the sink drops on full behind a rate limit. The
+    /// recurring per-slot inventory is `engine_v2_slot_posture`
+    /// (`EngineV2Bridge+MTP`) plus `BackendSlotCapacity.kv_backend` on every
+    /// heartbeat. Allowlisted fields only — no wire changes.
     static func emitKVBackendTelemetry(
         modelId: String,
         kind: EngineV2KVBackendKind,
@@ -252,7 +255,13 @@ public enum EngineV2Factory {
         event.fields = TelemetryFieldFilter.filter([
             "component": .string("engine"),
             "operation": .string("engine_v2_kv_backend"),
+            // `backend` is the engine; `kv_backend` is the KV storage kind.
+            // The kind was already here, but only inside the free-form
+            // `reason` string, where "fallback:kill_switch" hides it from
+            // any `group by`. It gets its own key so this event joins the
+            // heartbeat and the posture sample on the same value.
             "backend": .string("engine_v2"),
+            "kv_backend": .string(kind.rawValue),
             "model": .string(modelId),
             "reason": .string(reason),
         ])

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2SlotFactory.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2SlotFactory.swift
@@ -165,11 +165,12 @@ enum EngineV2SlotFactory {
         // WARN + auto), then force contiguous for slots the paged cache
         // cannot serve — VLM alone now (span masks unsupported: media
         // would 4xx at submit). A veto is policy, so it is silent even for
-        // an explicit paged request; kv_quant is no longer a veto because
-        // the feature is being removed, and it survives here only as the
-        // WARN below. `auto` resolves contiguous; the fleet kill switch,
-        // physical-capacity planning, and the degrade-or-REFUSE decision
-        // for an explicit paged request live in `makeProductionBuild`.
+        // an explicit paged request. kv_quant is gone from the product
+        // entirely — it is no longer a veto, no longer a parameter, and no
+        // longer warned about. `auto` resolves contiguous; the fleet kill
+        // switch, physical-capacity planning, and the degrade-or-REFUSE
+        // decision for an explicit paged request live in
+        // `makeProductionBuild`.
         let parsedKVBackend = EngineV2KVBackendPolicy.parseSelection(
             global: kvBackendConfig, byModel: kvBackendConfigByModel, modelID: modelId)
         if let unrecognized = parsedKVBackend.unrecognized {
@@ -293,6 +294,10 @@ enum EngineV2SlotFactory {
         } else if PrefixCachePolicy.isEnabled(environment: environment) {
             if let preparedBackend {
                 let ssdLayerKinds = preparedBackend.layerKinds
+                // Hoisted: `ProductionBackendPreparation` is non-Sendable, so
+                // the @Sendable construction-failure closure below must
+                // capture the resolved kind, not the preparation.
+                let preparedKVBackendKind = preparedBackend.kind
                 let resolvedSelection: EngineV2KVBackendSelection =
                     preparedBackend.kind == .paged ? .paged : .contiguous
                 let prefixReuseCapability = PrefixCachePolicy.prefixReuseCapability(
@@ -321,6 +326,7 @@ enum EngineV2SlotFactory {
                                     failure: failure, capability: prefixReuseCapability)
                                 Self.emitPrefixCacheConstructionFailure(
                                     modelId: modelId,
+                                    kvBackendKind: preparedKVBackendKind,
                                     capability: prefixReuseCapability,
                                     failure: failure,
                                     emitTelemetry: emitTelemetry)
@@ -336,6 +342,7 @@ enum EngineV2SlotFactory {
                         state: .error, reason: .cacheInitFailed)
                     Self.emitPrefixCacheConstructionFailure(
                         modelId: modelId,
+                        kvBackendKind: preparedKVBackendKind,
                         capability: prefixReuseCapability,
                         failure: .promptContractUnavailable,
                         emitTelemetry: emitTelemetry)
@@ -352,6 +359,10 @@ enum EngineV2SlotFactory {
                     state: .disabled, reason: .unsupportedLayout)
                 Self.emitPrefixCacheConstructionFailure(
                     modelId: modelId,
+                    // No prepared backend in this branch, so the KV kind was
+                    // never resolved — the same reason `cacheBackend` below
+                    // reports `.unknown`. Omitted, never guessed.
+                    kvBackendKind: nil,
                     capability: unavailableCapability,
                     failure: .layoutUnavailable,
                     emitTelemetry: emitTelemetry)
@@ -462,6 +473,7 @@ enum EngineV2SlotFactory {
 
     private static func emitPrefixCacheConstructionFailure(
         modelId: String,
+        kvBackendKind: EngineV2KVBackendKind?,
         capability: CBv2PrefixReuseCapability,
         failure: SSDPrefixCacheConstructionFailure,
         emitTelemetry: (@Sendable (TelemetryEvent) -> Void)?
@@ -472,16 +484,36 @@ enum EngineV2SlotFactory {
             kind: .engineHealth,
             message: "engine_v2: SSD prefix cache construction failed"
         )
-        event.fields = TelemetryFieldFilter.filter([
+        var fields: [String: AnyCodableValue] = [
             "component": .string("engine"),
             "operation": .string("prefix_cache_construction"),
-            "backend": .string(capability.backend.rawValue),
+            // Three axes, three keys. `backend` is the ENGINE executing
+            // inference (matches RegisterMessage.backend on the wire);
+            // `kv_backend` is the KV storage kind (same key and vocabulary as
+            // BackendSlotCapacity.KVBackend on the heartbeat wire);
+            // `prefix_reuse_backend` is the finer prefix-reuse ROW identity,
+            // which keeps its own key because contiguous_quantized vs
+            // contiguous_unquantized is a distinction "contiguous" cannot
+            // express. Folding any of these together silently mis-buckets
+            // every `group by backend` dashboard.
+            "backend": .string("engine_v2"),
             "model": .string(modelId),
+            "prefix_reuse_backend": .string(capability.backend.rawValue),
             "prefix_reuse_strategy": .string(
                 capability.strategy?.rawValue ?? "none"),
             "prefix_construction_failure": .string(failure.rawValue),
             "prefix_cold_fallback": .bool(true),
-        ])
+        ]
+        // ABSENT ⇒ UNKNOWN. Same contract as BackendSlotCapacity.KVBackend
+        // (`*string` + omitempty) on the heartbeat wire: a slot whose backend
+        // was never resolved omits the key. Do NOT substitute a third
+        // vocabulary value such as "unknown" — omission must stay
+        // distinguishable from an observation, and any value here would be
+        // read as one.
+        if let kvBackendKind {
+            fields["kv_backend"] = .string(kvBackendKind.rawValue)
+        }
+        event.fields = TelemetryFieldFilter.filter(fields)
         if let emitTelemetry {
             emitTelemetry(event)
         } else {

--- a/provider-swift/Sources/ProviderCore/Inference/ProviderEngineBundle.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/ProviderEngineBundle.swift
@@ -28,12 +28,39 @@ public struct ProviderMTPStatusSnapshot: Sendable, Equatable {
 
     init(status: MTPActivationStatus, metrics: CBv2MTPMetrics?) {
         let engineActive = metrics?.active == true
+        // "Enabled but inert": drafter resident, engine reporting itself
+        // active, zero rounds executed, and every planned row skipped as
+        // kv_unsupported. `rounds` counts only rounds that DRAFTED and
+        // VERIFIED, and the skip is recorded per scheduled row, so this can
+        // only become true after real traffic has been planned and refused —
+        // never on a freshly built engine. That matters: the post-build MTP
+        // teardown gate (ProviderLoop+ModelLoading, +EngineV2Liveness,
+        // StandaloneServer) reads `active` on a zero-traffic engine, where
+        // rounds == 0 and the skip count is 0, so it cannot mis-fire there.
+        let inertKVUnsupported =
+            status.active && engineActive
+            && (metrics?.rounds ?? 0) == 0
+            && (metrics?.skippedRows["kv_unsupported"] ?? 0) > 0
         self.configured = status.configured
-        self.active = status.active && engineActive
+        // A slot executing zero rounds is NOT active. Reporting it active is
+        // exactly what hid this state: it also made `mtp_active` lie to the
+        // routing correction it exists for — an inert slot does not inflate
+        // observed_decode_tps, so discounting its throughput is wrong in the
+        // opposite direction.
+        self.active = status.active && engineActive && !inertKVUnsupported
         self.verificationMode = metrics?.verificationMode.rawValue
         self.rectangularVerificationRounds = metrics?.rectangularVerificationRounds ?? 0
         self.serialVerificationRounds = metrics?.serialVerificationRounds ?? 0
-        self.fallbackReason = status.active && !engineActive ? .engineInactive : status.reason
+        // Precedence: engine-says-off outranks engine-says-on-but-idle; the
+        // two are mutually exclusive by construction. A load-time reason
+        // (`status.reason`) still wins when the assistant never activated.
+        if status.active && !engineActive {
+            self.fallbackReason = .engineInactive
+        } else if inertKVUnsupported {
+            self.fallbackReason = .inertKVUnsupported
+        } else {
+            self.fallbackReason = status.reason
+        }
         self.assistantSource = status.source
         self.assistantRevision = status.revision
         self.assistantArtifactBytes = status.artifactBytes

--- a/provider-swift/Sources/ProviderCore/Inference/UnifiedMemoryCap.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/UnifiedMemoryCap.swift
@@ -34,14 +34,23 @@ public enum UnifiedMemoryCap {
     /// OS (e.g. an 8 GiB box gets a 6 GiB cap, not 7.2 GiB).
     static let minimumReserveBytes: UInt64 = 2 * 1024 * 1024 * 1024  // 2 GiB
 
-    /// Default activation/working-memory reserve carved out INSIDE the cap.
+    /// Absolute FLOOR on the activation/working-memory reserve carved out
+    /// INSIDE the cap. ``activationReserveBytes(for:)`` raises it; nothing
+    /// lowers it except an explicit operator/programmatic override.
     ///
     /// Measured on M5 Max (Gemma-4-26B-qat-4bit + GPT-OSS-20B, both MoE): a
     /// 4-concurrent ~3000-token long-prefill burst moved RSS by only ~9 MB over
     /// the resident-weight baseline — MoE activates few experts, MLX fuses
     /// attention, and intermediates churn through the (count-bounded) buffer
-    /// cache rather than growing the live set. So activations are small in
-    /// practice; this is a conservative SAFETY FLOOR, not a per-batch estimate.
+    /// cache rather than growing the live set.
+    ///
+    /// That measurement is real but NARROW: short prompts, four concurrent
+    /// rows, and a burst whose attention MLX could fuse. It says nothing about
+    /// the one activation that is neither small nor fused — the composed-path
+    /// prefill SCORE tensor (see ``ActivationReserveShape``), which is already
+    /// ~6.6 GB at those same four concurrent rows once the context reaches
+    /// 100k. So this number is a floor for the non-attention working set, not
+    /// a per-batch estimate, and it must never be the whole answer on its own.
     static let defaultActivationReserveBytes: UInt64 = 3 * 1024 * 1024 * 1024  // 3 GiB
 
     /// Minimum KV headroom (bytes) a freshly-loaded model must have under the cap
@@ -208,6 +217,172 @@ public enum UnifiedMemoryCap {
         return max(configReserveBytes, capImpliedReserve)
     }
 
+    // MARK: - Parametric activation reserve
+
+    /// The prefill-attention shape that decides how much working memory one
+    /// scheduler step can hold live, so the reserve scales with batch and
+    /// context instead of being a flat number justified by a single
+    /// 4-concurrent measurement.
+    ///
+    /// ## What is being sized
+    ///
+    /// MLX's fused SDPA kernel accepts head_dim ∈ {64, 80, 128}
+    /// (`sdpa_full_supported_head_dim`); anything else takes the COMPOSED
+    /// fallback, which MATERIALISES the score tensor
+    /// `[concurrentPrefills, heads, C, kL]` in fp32 before the softmax, plus a
+    /// `[C, kL]` bool mask. Gemma-4 (head_dim 256 sliding / 512 full) never
+    /// reaches the fused kernel; gpt-oss (head_dim 64) always does and costs
+    /// nothing here.
+    ///
+    /// ## Why `C` is not simply the chunk size
+    ///
+    /// Query sub-blocking (`CBv2AttentionV1.attendQueryBlocks`) pins a TEXT
+    /// chunk's live score tensor at `[1, heads, q, kL]`, O(1) in chunk length.
+    /// Span-bearing VISION chunks deliberately keep the single-call path
+    /// (`AttentionV1.swift:243-251`): a bidirectional overlay covers the whole
+    /// chunk, so a query block cannot be sliced to a causal-only visible span.
+    /// They are also the only prefill path whose `L` may exceed
+    /// ``prefillChunkSize`` (the scheduler's block snap-over), which makes them
+    /// simultaneously the largest-`L` and the only unblocked prefill. A slot
+    /// that serves vision is therefore costed at FULL `L`; a text-only slot at
+    /// the sub-block width.
+    ///
+    /// ## Filling it in
+    ///
+    /// Every field has exactly one upstream owner. READ them — restating any of
+    /// them here recreates the drifting parallel constant this type exists to
+    /// delete: `CBv2SchedulerConfig.maxBatchedTokensPerStep`/`.prefillChunkSize`,
+    /// `CBv2AttentionV1.queryBlockSize`, `CBv2LayerKind.queryHeads`/`.headDim`,
+    /// and the slot's own `maxContextLength`. That is why no field carries a
+    /// "sensible" default.
+    public struct ActivationReserveShape: Sendable, Equatable {
+        /// `CBv2SchedulerConfig.maxBatchedTokensPerStep`: the step's whole
+        /// token budget across decode and prefill. Divided by
+        /// ``prefillChunkSize`` it gives the concurrent prefill rows one step
+        /// can carry, and it independently caps the vision path (`MultimodalV2`
+        /// rejects a coalesced image block longer than this at submit).
+        public var maxBatchedTokensPerStep: Int
+
+        /// `CBv2SchedulerConfig.prefillChunkSize`: the per-row prompt chunk.
+        public var prefillChunkSize: Int
+
+        /// `CBv2AttentionV1.queryBlockSize` (env
+        /// `DARKBLOOM_CBV2_ATTN_QUERY_BLOCK`). `0` = blocking disabled — the
+        /// kill switch — so a text chunk costs its full ``prefillChunkSize``.
+        public var querySubBlockSize: Int
+
+        /// Longest coalesced vision block this slot may schedule, in tokens;
+        /// `0` = text-only slot. Costed at full `L`, never at the sub-block
+        /// width, because span chunks skip query blocking.
+        public var spanChunkMaxL: Int
+
+        /// The model's context window — the longest key axis a prefill query
+        /// can attend. `0` = unknown, which disables the estimate.
+        public var maxContextLength: Int
+
+        /// QUERY heads on the widest attention layer
+        /// (`CBv2LayerKind.queryHeads`), NOT KV heads: the score tensor is
+        /// materialised after the GQA repeat, so a GQA model's KV-head count
+        /// under-counts it. `0` = unknown, which disables the estimate.
+        public var attentionHeads: Int
+
+        /// Whether attention takes MLX's composed fallback, i.e. whether a
+        /// score tensor is materialised at all. See
+        /// ``composedAttention(headDim:)``.
+        public var composedAttention: Bool
+
+        public init(
+            maxBatchedTokensPerStep: Int,
+            prefillChunkSize: Int,
+            querySubBlockSize: Int,
+            spanChunkMaxL: Int = 0,
+            maxContextLength: Int,
+            attentionHeads: Int,
+            composedAttention: Bool = true
+        ) {
+            self.maxBatchedTokensPerStep = maxBatchedTokensPerStep
+            self.prefillChunkSize = prefillChunkSize
+            self.querySubBlockSize = querySubBlockSize
+            self.spanChunkMaxL = spanChunkMaxL
+            self.maxContextLength = maxContextLength
+            self.attentionHeads = attentionHeads
+            self.composedAttention = composedAttention
+        }
+
+        /// The head_dims MLX's fused SDPA kernel accepts
+        /// (`sdpa_full_supported_head_dim`); every other head_dim composes and
+        /// pays for a materialised score tensor.
+        public static func composedAttention(headDim: Int) -> Bool {
+            headDim != 64 && headDim != 80 && headDim != 128
+        }
+    }
+
+    /// The composed path builds scores in fp32 regardless of the model's weight
+    /// dtype, and adds one `[C, kL]` bool mask (1 byte, shared across heads).
+    private static let scoreBytesPerElement: UInt64 = 4
+    private static let maskBytesPerElement: UInt64 = 1
+
+    /// Peak live prefill score + mask bytes for ONE scheduler step:
+    ///
+    ///     concurrentPrefills = maxBatchedTokensPerStep / prefillChunkSize
+    ///     C                  = max(querySubBlockSize, spanChunkMaxL)
+    ///     liveQueryRows      = min(maxBatchedTokensPerStep,
+    ///                              concurrentPrefills × C)
+    ///     bytes              = liveQueryRows × maxContextLength
+    ///                            × (attentionHeads × 4 + 1)
+    ///
+    /// Each concurrent prefill row holds ONE live score tensor behind the
+    /// `concatenated(axis: 0)` that joins the step's rows, so the rows add up.
+    /// `liveQueryRows` is then capped at the step budget: a row cannot hold more
+    /// query rows live than it was handed tokens to prefill. That cap is what
+    /// makes the vision term saturate at the whole step budget instead of
+    /// growing without bound as blocks snap over ``prefillChunkSize``.
+    ///
+    /// Reproduces the migration plan's §7.0.3 table (heads 8, chunk 512,
+    /// unblocked span path): B=4 → 2048 live query rows → 0.66 GB at 10k
+    /// context and 6.6 GB at 100k; B=8 → 4096 rows → 1.3 GB / 13.1 GB. The
+    /// same B=4 step on a TEXT-only slot sub-blocks to 512 rows and costs 1.7 GB
+    /// at 100k — that gap is exactly what #85 bought, and exactly what vision
+    /// does not get.
+    ///
+    /// Returns 0 when no score tensor exists (fused kernel) or the geometry is
+    /// unknown; the caller then keeps the measured floor.
+    public static func peakPrefillScoreBytes(for shape: ActivationReserveShape) -> UInt64 {
+        guard shape.composedAttention,
+            shape.attentionHeads > 0,
+            shape.maxContextLength > 0,
+            shape.maxBatchedTokensPerStep > 0
+        else { return 0 }
+        let stepBudget = shape.maxBatchedTokensPerStep
+        let chunk = max(1, min(shape.prefillChunkSize, stepBudget))
+        let concurrentPrefills = max(1, stepBudget / chunk)
+        // Text rows are pinned to the sub-block width (0 = kill switch → the
+        // whole chunk); span rows keep the single-call path at full L, capped
+        // by the step budget that also gates them at submit.
+        let textWidth =
+            shape.querySubBlockSize > 0
+            ? min(shape.querySubBlockSize, chunk)
+            : chunk
+        let spanWidth = min(max(0, shape.spanChunkMaxL), stepBudget)
+        let liveQueryRows = min(
+            UInt64(stepBudget),
+            saturatingMultiply(
+                UInt64(concurrentPrefills), UInt64(max(textWidth, spanWidth))))
+        let perKeyBytes = saturatingAdd(
+            saturatingMultiply(UInt64(shape.attentionHeads), scoreBytesPerElement),
+            maskBytesPerElement)
+        return saturatingMultiply(
+            liveQueryRows, UInt64(shape.maxContextLength), perKeyBytes)
+    }
+
+    /// The activation reserve for `shape`: the measured floor, RAISED to the
+    /// peak prefill score tensor whenever the configured batch and context need
+    /// more. Never returns less than ``defaultActivationReserveBytes`` — the
+    /// floor still covers the non-attention working set this estimate ignores.
+    public static func activationReserveBytes(for shape: ActivationReserveShape) -> UInt64 {
+        max(defaultActivationReserveBytes, peakPrefillScoreBytes(for: shape))
+    }
+
     // MARK: - Resolution (explicit → env → default)
 
     /// Cap fraction from explicit value, env `DARKBLOOM_MEM_CAP_FRACTION`
@@ -229,13 +404,21 @@ public enum UnifiedMemoryCap {
     }
 
     /// Activation reserve from explicit bytes, env
-    /// `DARKBLOOM_ACTIVATION_RESERVE_GB` (GB), or the default floor. A `<= 0` or
-    /// non-finite env value is treated as UNSET (→ the 3 GiB default floor): a
-    /// `0` reserve would remove the activation headroom the cap exists to
-    /// guarantee, so an operator can RAISE the reserve but not silently disable it
-    /// via env. An explicit programmatic value (tests) is honored as given.
+    /// `DARKBLOOM_ACTIVATION_RESERVE_GB` (GB), or — when the caller supplies the
+    /// slot's prefill `shape` — ``activationReserveBytes(for:)``, falling back
+    /// to the flat floor when it does not.
+    ///
+    /// A `<= 0` or non-finite env value is treated as UNSET (→ the parametric
+    /// value, else the floor): a `0` reserve would remove the activation
+    /// headroom the cap exists to guarantee, so an operator can RAISE the
+    /// reserve but not silently disable it via env. A env value that IS set
+    /// wins over the parametric estimate — the knob is the operator's explicit
+    /// override of provider policy, and it is how a bad estimate gets answered
+    /// in either direction. An explicit programmatic value (tests) is honored
+    /// as given.
     static func resolvedActivationReserveBytes(
         explicit: UInt64? = nil,
+        shape: ActivationReserveShape? = nil,
         env: [String: String] = ProcessInfo.processInfo.environment
     ) -> UInt64 {
         if let explicit { return explicit }
@@ -244,7 +427,8 @@ public enum UnifiedMemoryCap {
             let scaled = gb * 1_073_741_824
             return scaled >= uint64MaxAsDouble ? UInt64.max : UInt64(scaled)
         }
-        return defaultActivationReserveBytes
+        guard let shape else { return defaultActivationReserveBytes }
+        return activationReserveBytes(for: shape)
     }
 
     // MARK: - Helpers
@@ -272,6 +456,17 @@ public enum UnifiedMemoryCap {
         for v in values {
             let (sum, overflow) = total.addingReportingOverflow(v)
             total = overflow ? UInt64.max : sum
+        }
+        return total
+    }
+
+    private static func saturatingMultiply(_ values: UInt64...) -> UInt64 {
+        var total: UInt64 = 1
+        for v in values {
+            if v == 0 { return 0 }
+            let (product, overflow) = total.multipliedReportingOverflow(by: v)
+            if overflow { return UInt64.max }
+            total = product
         }
         return total
     }

--- a/provider-swift/Sources/ProviderCore/Protocol/Types.swift
+++ b/provider-swift/Sources/ProviderCore/Protocol/Types.swift
@@ -450,6 +450,20 @@ public struct BackendSlotCapacity: Codable, Sendable, Equatable {
     public var maxConcurrency: UInt32
     public var modelLoadTimeMs: Int64
 
+    /// The KV-cache backend this slot's engine was actually built with:
+    /// `EngineV2Bridge.kvBackendKind.rawValue` — "paged" | "contiguous",
+    /// the RESOLVED kind after every veto and fallback, not the operator's
+    /// requested `engine_v2_kv_backend`. The coordinator's only per-slot,
+    /// every-heartbeat record of the v0.8.0 paged rollout.
+    ///
+    /// OPTIONAL, deliberately: nil ⇒ not reported, which the coordinator
+    /// reads as UNKNOWN and never as contiguous (mirrors the Go
+    /// `KVBackend *string`). Encoded with `encodeIfPresent`, NOT the
+    /// non-zero/false omission the counters below use, so an explicit ""
+    /// still goes on the wire — Go's pointer `omitempty` tests the pointer,
+    /// not the pointee, and the two sides must agree on that.
+    public var kvBackend: String?
+
     // MARK: - Engine-health (first-token wedge) signals
     //
     // Low-cardinality, NON-PRIVATE diagnostic counters that let the coordinator
@@ -501,6 +515,7 @@ public struct BackendSlotCapacity: Codable, Sendable, Equatable {
         case kvBytesPerToken = "kv_bytes_per_token"
         case maxConcurrency = "max_concurrency"
         case modelLoadTimeMs = "model_load_time_ms"
+        case kvBackend = "kv_backend"
         case stepsExecuted = "steps_executed"
         case admits
         case firstTokensEmitted = "first_tokens_emitted"
@@ -526,6 +541,7 @@ public struct BackendSlotCapacity: Codable, Sendable, Equatable {
         queuedTokenBudget: Int64 = 0,
         kvBytesPerToken: Int64 = 0,
         modelLoadTimeMs: Int64 = 0,
+        kvBackend: String? = nil,
         stepsExecuted: Int64 = 0,
         admits: Int64 = 0,
         firstTokensEmitted: Int64 = 0,
@@ -549,6 +565,7 @@ public struct BackendSlotCapacity: Codable, Sendable, Equatable {
         self.queuedTokenBudget = queuedTokenBudget
         self.kvBytesPerToken = kvBytesPerToken
         self.modelLoadTimeMs = modelLoadTimeMs
+        self.kvBackend = kvBackend
         self.stepsExecuted = stepsExecuted
         self.admits = admits
         self.firstTokensEmitted = firstTokensEmitted
@@ -575,6 +592,9 @@ public struct BackendSlotCapacity: Codable, Sendable, Equatable {
         queuedTokenBudget = try container.decodeIfPresent(Int64.self, forKey: .queuedTokenBudget) ?? 0
         kvBytesPerToken = try container.decodeIfPresent(Int64.self, forKey: .kvBytesPerToken) ?? 0
         modelLoadTimeMs = try container.decodeIfPresent(Int64.self, forKey: .modelLoadTimeMs) ?? 0
+        // No `?? ""` fallback: absent must stay absent, or the coordinator
+        // cannot tell a pre-0.8.0 provider from one reporting an empty kind.
+        kvBackend = try container.decodeIfPresent(String.self, forKey: .kvBackend)
         stepsExecuted = try container.decodeIfPresent(Int64.self, forKey: .stepsExecuted) ?? 0
         admits = try container.decodeIfPresent(Int64.self, forKey: .admits) ?? 0
         firstTokensEmitted = try container.decodeIfPresent(Int64.self, forKey: .firstTokensEmitted) ?? 0
@@ -601,6 +621,7 @@ public struct BackendSlotCapacity: Codable, Sendable, Equatable {
         try encodeIfNonZero(queuedTokenBudget, forKey: .queuedTokenBudget, into: &container)
         try encodeIfNonZero(kvBytesPerToken, forKey: .kvBytesPerToken, into: &container)
         try encodeIfNonZero(modelLoadTimeMs, forKey: .modelLoadTimeMs, into: &container)
+        try container.encodeIfPresent(kvBackend, forKey: .kvBackend)
         try encodeIfNonZero(stepsExecuted, forKey: .stepsExecuted, into: &container)
         try encodeIfNonZero(admits, forKey: .admits, into: &container)
         try encodeIfNonZero(firstTokensEmitted, forKey: .firstTokensEmitted, into: &container)

--- a/provider-swift/Sources/ProviderCore/SpecDec/SpecDecTypes.swift
+++ b/provider-swift/Sources/ProviderCore/SpecDec/SpecDecTypes.swift
@@ -31,6 +31,16 @@ public enum MTPFallbackReason: String, Sendable, Equatable {
     case assistantResliceFloor = "assistant_reslice_floor"
     case assistantPostBuildHeadroom = "assistant_post_build_headroom"
     case engineInactive = "engine_inactive"
+    /// ENABLED BUT INERT — the one reason that is not a load failure. The
+    /// drafter loaded, the engine reports MTP active, and yet not one round
+    /// has run because every planned row was skipped as `kv_unsupported`
+    /// (`EngineLoopV2+MTPPlanning.mtpPlanAction`). Today's shape: a paged
+    /// gemma-4 slot, whose windowed layers the drafter's KV path cannot
+    /// serve — it charges full drafter residency and returns nothing.
+    /// Distinct from `engineInactive`, where the engine says it is OFF;
+    /// here the engine says it is ON and produces nothing, which is why
+    /// this state was invisible until it was given a name.
+    case inertKVUnsupported = "inert_kv_unsupported"
 }
 
 public enum SpecDecArtifactSource: String, Sendable, Equatable {

--- a/provider-swift/Sources/ProviderCore/Telemetry/TelemetryEvent.swift
+++ b/provider-swift/Sources/ProviderCore/Telemetry/TelemetryEvent.swift
@@ -273,6 +273,24 @@ public enum TelemetryFieldFilter {
         "prefix_saved_tokens", "prefix_boundary_splits",
         "prefix_construction_failure", "prefix_capacity_refusal",
         "prefix_cold_fallback",
+        // KV-backend discriminator (v0.8.0 paged rollout). `backend` stays the
+        // ENGINE/runtime name ("engine_v2", "mlx-swift"); `kv_backend` is the
+        // KV storage kind ("paged" | "contiguous"), the same key and vocabulary
+        // as BackendSlotCapacity.kv_backend on the heartbeat wire.
+        // `prefix_reuse_backend` carries the finer CBv2PrefixReuseBackend row
+        // identity that "contiguous" alone cannot express.
+        "kv_backend", "prefix_reuse_backend",
+        // Paged KV pool metrics. Aggregate pool counters only — never page
+        // contents or block hashes. Mirror in Go + TS allowlists.
+        "pages_pinned", "cow_events", "pool_utilization",
+        // MTP (speculative decode) posture. MTP inflates observed_decode_tps
+        // with no discriminator, so a partially-MTP fleet biases coordinator
+        // routing on a metric it believes is homogeneous. mtp_inactive_reason
+        // carries MTPFallbackReason.rawValue plus "inert_kv_unsupported" —
+        // enabled, drafter resident, zero rounds, rows skipped kv_unsupported.
+        // Bounded enums and counters only; never draft tokens or prompt text.
+        "mtp_enabled", "mtp_active", "mtp_inactive_reason",
+        "mtp_acceptance_rate",
     ]
 
     /// Filter a dictionary to only the keys the coordinator accepts.

--- a/provider-swift/Sources/ProviderCore/Telemetry/TelemetryEvent.swift
+++ b/provider-swift/Sources/ProviderCore/Telemetry/TelemetryEvent.swift
@@ -283,6 +283,14 @@ public enum TelemetryFieldFilter {
         // Paged KV pool metrics. Aggregate pool counters only — never page
         // contents or block hashes. Mirror in Go + TS allowlists.
         "pages_pinned", "cow_events", "pool_utilization",
+        // Paged pool re-slice residue. RAW BYTES, not a second ratio:
+        // pool_utilization above is OCCUPANCY, and a grant-vs-pool ratio under
+        // a near-identical name collides with it wherever a dashboard groups
+        // by kv_backend. A clamped ratio also discards the overflow magnitude
+        // at exactly the point co-residency diagnosis needs it. pool_bytes is
+        // the denominator, shipped alongside the deltas so share-of-pool stays
+        // derivable from raw terms. Mirror in Go + TS allowlists.
+        "pool_bytes", "pool_deferred_growth_bytes", "pool_stranded_bytes",
         // MTP (speculative decode) posture. MTP inflates observed_decode_tps
         // with no discriminator, so a partially-MTP fleet biases coordinator
         // routing on a metric it believes is homogeneous. mtp_inactive_reason

--- a/provider-swift/Sources/ProviderCore/Telemetry/TelemetryEvent.swift
+++ b/provider-swift/Sources/ProviderCore/Telemetry/TelemetryEvent.swift
@@ -282,7 +282,9 @@ public enum TelemetryFieldFilter {
         "kv_backend", "prefix_reuse_backend",
         // Paged KV pool metrics. Aggregate pool counters only — never page
         // contents or block hashes. Mirror in Go + TS allowlists.
-        "pages_pinned", "cow_events", "pool_utilization",
+        // pages_pinned / cow_events deliberately absent: no mechanism exists,
+        // and a producerless key reads as a legitimate zero. See the Go mirror.
+        "pool_utilization",
         // Paged pool re-slice residue. RAW BYTES, not a second ratio:
         // pool_utilization above is OCCUPANCY, and a grant-vs-pool ratio under
         // a near-identical name collides with it wherever a dashboard groups

--- a/provider-swift/Tests/ProviderCoreTests/EngineV2CoResidencyLiveTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/EngineV2CoResidencyLiveTests.swift
@@ -16,6 +16,29 @@
 //      serving path (MultiModelBatchSchedulerEngine → bridge);
 //   5. unload gemma → gpt-oss's grant grows back to the full budget.
 //
+// RUNS ON BOTH KV BACKENDS. The drill is the same; the ARITHMETIC is not,
+// and the difference is the whole of migration-plan §15:
+//
+//   * CONTIGUOUS — the admission ceiling IS the fleet grant. It shrinks
+//     when gemma arrives and grows back when gemma leaves. Steps 1/3/5
+//     assert exactly that.
+//   * PAGED — the ceiling is the physically materialized pool, sized ONCE
+//     at engine construction by `PagedKVPhysicalCapacityPolicy` (useful
+//     concurrent context ∧ machine size ∧ live headroom — never the grant).
+//     A co-resident load cannot shrink it (a ledger shrink frees no slabs)
+//     and a co-resident unload cannot grow it (a ledger grow mints no
+//     pages). So the paged arm asserts the ceiling is INVARIANT across the
+//     whole lifecycle, and that the fair share the slot cannot take is
+//     reported as `PagedPoolResizeShortfall.deferredGrowthBytes` instead of
+//     vanishing silently.
+//
+// The earlier revision of this file pinned `contiguous` and explained the
+// pin by claiming a lone paged slot would commit "~the full fleet budget"
+// as slabs and fail the later load closed. That was true when it was
+// written (#531) and stopped being true one PR later (#535), which bounded
+// physical capacity by demand. Neither the giant pool nor the failed load
+// happens; what happens is the frozen ceiling above.
+//
 // Gated like the other multi-GB suites: DARKBLOOM_LIVE_MLX_TESTS +
 // DARKBLOOM_LIVE_MLX_GEMMA, and each checkpoint skips cleanly when absent
 // from the local HF cache (LiveInferenceFixtures pattern).
@@ -44,7 +67,13 @@ struct EngineV2CoResidencyLiveTests {
     /// Real ProviderLoop over the two production checkpoints, with an
     /// isolated runtime. Estimated sizes mirror the on-disk footprints
     /// (gpt-oss ~12.1 GiB, gemma-qat ~14.9 GiB).
-    private func makeLiveLoop() throws -> (loop: ProviderLoop, runtime: EngineV2Runtime) {
+    ///
+    /// `kvBackend` is the EXPLICIT `[backend] engine_v2_kv_backend` setting,
+    /// never `auto`: an arm that silently degraded to the other backend
+    /// would report a pass for a drill it never ran.
+    private func makeLiveLoop(
+        kvBackend: String
+    ) throws -> (loop: ProviderLoop, runtime: EngineV2Runtime) {
         let config = ProviderLoopConfig(
             coordinatorURL: "ws://127.0.0.1:0/ignored",
             hardware: HardwareInfo(
@@ -64,19 +93,9 @@ struct EngineV2CoResidencyLiveTests {
             ],
             config: ProviderConfig(
                 provider: ProviderSettings(name: "coresidency-live", memoryReserveGB: Self.reserveGiB),
-                // PINNED contiguous: this drill asserts the LEDGER
-                // shrink/serve/regrow arithmetic, which is identical on the
-                // paged backend (paged re-slices are ledger-only). Under
-                // paged-by-default, gpt-oss's lone-slot grant would be
-                // physically committed as slabs (~the full fleet budget on
-                // this box) and the later gemma load correctly FAILS CLOSED
-                // at the post-load headroom guard — the designed v1 paged
-                // co-residency behavior, but not what this test measures.
-                // Meaningful paged co-residency at these scales needs the
-                // pool-resize follow-up.
                 backend: BackendSettings(
                     idleTimeoutMins: 0, maxModelSlots: 3,
-                    engineV2KVBackend: "contiguous"),
+                    engineV2KVBackend: kvBackend),
                 coordinator: CoordinatorSettings(heartbeatIntervalSecs: 60)
             )
         )
@@ -104,8 +123,10 @@ struct EngineV2CoResidencyLiveTests {
         return (text, completion, error)
     }
 
-    @Test("load B while A streams: shrink, serve both, admission ceiling, regrow")
-    func coResidencyLifecycle() async throws {
+    @Test(
+        "load B while A streams: shrink, serve both, admission ceiling, regrow",
+        arguments: ["contiguous", "paged"])
+    func coResidencyLifecycle(kvBackend: String) async throws {
         guard LiveInferenceFixtures.liveTestsEnabled, LiveInferenceFixtures.gemmaTestsEnabled else {
             return  // env-gated (multi-GB weights)
         }
@@ -120,7 +141,8 @@ struct EngineV2CoResidencyLiveTests {
         }
         LiveInferenceFixtures.applyMemoryBudget(maxBytes: 64 * 1024 * 1024 * 1024)
 
-        let (loop, runtime) = try makeLiveLoop()
+        let paged = kvBackend == "paged"
+        let (loop, runtime) = try makeLiveLoop(kvBackend: kvBackend)
         await loop.setEngineV2RuntimeForTesting(runtime)
         // Structured teardown: unload whatever loaded, on every exit path.
         defer {
@@ -131,7 +153,7 @@ struct EngineV2CoResidencyLiveTests {
             }
         }
 
-        // ---- 1. Load A (gpt-oss): the lone slot holds the FULL budget. ----
+        // ---- 1. Load A (gpt-oss). ----
         try await loop.ensureModelLoaded(modelId: Self.gptossID)
         let bridgeA = try #require(await loop.slotBridgeForTesting(modelId: Self.gptossID))
         let sizingA = try #require(await loop.slotSizingForTesting(modelId: Self.gptossID))
@@ -140,16 +162,35 @@ struct EngineV2CoResidencyLiveTests {
         let budgetAlone = UnifiedMemoryCap.kvBudgetBytes(
             residentWeightBytes: UInt64(sizingA.weightsBytes),
             configReserveBytes: reserveBytes)
-        #expect(grantA0 == Int(budgetAlone), "single model must hold the FULL fleet budget")
+        // The explicit backend selection must have been honoured — a
+        // degraded arm measures the wrong thing.
+        #expect(await bridgeA.kvBackendKind == (paged ? .paged : .contiguous))
+        let poolA = Int(await bridgeA.kvBackendPoolBytes())
+        if paged {
+            // The lone slot's ceiling is POOL truth, not the fleet budget:
+            // demand-bounded, and far below the budget on any real box.
+            #expect(grantA0 == poolA)
+            #expect(UInt64(grantA0) <= budgetAlone)
+            #expect(UInt64(grantA0) >= UnifiedMemoryCap.minimumLoadKVBytes)
+            // No re-slice has happened yet, so there is no residue.
+            #expect(await bridgeA.pagedPoolResizeShortfall() == nil)
+        } else {
+            #expect(grantA0 == Int(budgetAlone), "single model must hold the FULL fleet budget")
+        }
         // Engine-truth rate for the admission-probe arithmetic below.
         #expect(sizingA.fp16KVBytesPerToken == 24_576)
 
-        // ---- Admission-ceiling probe P: a worst-case request that FITS the
-        // full grant but NOT the post-shrink share, submitted DIRECTLY to
-        // the engine so the verdict is the admission ledger's canEverFit —
-        // pure grant arithmetic (drift-test-pinned against estimatedBytes),
-        // immune to free-RAM contention from concurrent suites. Sized 15%
-        // above the expected post-shrink share, well below the full grant.
+        // ---- Admission-ceiling probes, submitted DIRECTLY to the engine so
+        // the verdict is the admission ledger's canEverFit — pure grant
+        // arithmetic (drift-test-pinned against estimatedBytes), immune to
+        // free-RAM contention from concurrent suites.
+        //
+        // CONTIGUOUS: one probe, sized 15% above the expected post-shrink
+        // share and 15% below the current grant, so it flips from admitted
+        // to refused across the co-resident load.
+        // PAGED: two probes straddling the pool-bound ceiling. Both keep
+        // their verdict across the whole lifecycle — that invariance IS the
+        // finding.
         let gemmaSizingPreview = EngineV2KVSizing.ResliceSlot(
             modelId: Self.gemmaQatID, fp16KVBytesPerToken: 20_480, maxContextLength: 262_144)
         let previewBudget = UnifiedMemoryCap.kvBudgetBytes(
@@ -165,40 +206,63 @@ struct EngineV2CoResidencyLiveTests {
             newcomer: gemmaSizingPreview,
             fleetKVBudgetBytes: previewBudget)
         let expectedShrunkA = try #require(previewTargets[Self.gptossID])
-        let probeBytes = min(
-            UInt64(Double(expectedShrunkA) * 1.15),
-            UInt64(Double(grantA0) * 0.85))
-        let probeTokens = Int(probeBytes) / sizingA.fp16KVBytesPerToken
-        #expect(probeTokens * sizingA.fp16KVBytesPerToken > expectedShrunkA,
-                "probe must exceed the post-shrink ceiling to be meaningful")
-        print("[co-residency] probeTokens=\(probeTokens) (~\(probeBytes / Self.gib)GiB worst-case)")
         let probePrompt = try await tokenize("Write a very long story.", loop: loop)
         let engineA = await bridgeA.engine
-        /// Submit the probe straight to the engine ledger. Returns the
-        /// stream when admitted (caller cancels + drains), nil when the
-        /// ledger refused it (capacityExhausted).
-        @Sendable func submitLedgerProbe(_ id: UInt64) -> AsyncStream<CBv2Event>? {
+        func tokens(forBytes bytes: UInt64) -> Int {
+            Int(bytes) / sizingA.fp16KVBytesPerToken
+        }
+        /// Submit a worst-case probe straight to the engine ledger. Returns
+        /// the stream when admitted (drained here), nil when the ledger
+        /// refused it (capacityExhausted).
+        @Sendable func ledgerAdmits(_ id: UInt64, maxTokens: Int) async -> Bool {
+            let stream: AsyncStream<CBv2Event>?
             do {
-                return try engineA.submit(
+                stream = try engineA.submit(
                     CBv2Request(
                         id: CBv2RequestID(id),
                         promptTokens: probePrompt,
-                        maxTokens: probeTokens))
+                        maxTokens: maxTokens))
             } catch {
-                return nil
+                return false
             }
+            guard let stream else { return false }
+            // Submit-no-throw IS the verdict: cancel immediately and drain
+            // so the probe's reservations release.
+            engineA.cancel(CBv2RequestID(id))
+            for await _ in stream {}
+            return true
         }
-        do {
-            // Pre-shrink: the ledger ADMITS the worst case under the full
-            // grant. Cancel immediately (submit-no-throw IS the verdict) and
-            // drain so its reservations release.
-            let probeId: UInt64 = 0x7000_0001
-            let probe = submitLedgerProbe(probeId)
-            #expect(probe != nil, "the worst-case probe must fit the FULL grant pre-shrink")
-            if let probe {
-                engineA.cancel(CBv2RequestID(probeId))
-                for await _ in probe {}
-            }
+
+        // Sized against the CURRENT ceiling in both arms.
+        let underCeilingTokens = tokens(forBytes: UInt64(Double(grantA0) * 0.85))
+        let overCeilingTokens = tokens(forBytes: UInt64(Double(grantA0) * 1.15))
+        let shrinkProbeTokens = tokens(
+            forBytes: min(
+                UInt64(Double(expectedShrunkA) * 1.15),
+                UInt64(Double(grantA0) * 0.85)))
+        print(
+            "[co-residency/\(kvBackend)] grantA0=\(UInt64(grantA0) / Self.gib)GiB "
+                + "poolA=\(UInt64(poolA) / Self.gib)GiB "
+                + "expectedShrunkA=\(UInt64(expectedShrunkA) / Self.gib)GiB")
+
+        if paged {
+            // A pool-bound ceiling: below it admits, above it refuses.
+            #expect(await ledgerAdmits(0x7000_0001, maxTokens: underCeilingTokens))
+            #expect(!(await ledgerAdmits(0x7000_0002, maxTokens: overCeilingTokens)))
+            // The fair share gemma's arrival will award is LARGER than the
+            // pool — this box is in the deferred-growth regime, which is
+            // what makes the invariance below meaningful rather than
+            // coincidental.
+            #expect(
+                expectedShrunkA > grantA0,
+                "paged arm needs a fair share above the pool to be meaningful")
+        } else {
+            #expect(
+                shrinkProbeTokens * sizingA.fp16KVBytesPerToken > expectedShrunkA,
+                "probe must exceed the post-shrink ceiling to be meaningful")
+            #expect(
+                await ledgerAdmits(0x7000_0001, maxTokens: shrinkProbeTokens),
+                "the worst-case probe must fit the FULL grant pre-shrink")
         }
 
         // ---- 2. Stream on A while B loads. ----
@@ -218,14 +282,15 @@ struct EngineV2CoResidencyLiveTests {
         let bridgeB = try #require(await loop.slotBridgeForTesting(modelId: Self.gemmaQatID))
         let sizingB = try #require(await loop.slotSizingForTesting(modelId: Self.gemmaQatID))
         #expect(sizingB.fp16KVBytesPerToken == 20_480)
+        #expect(await bridgeB.kvBackendKind == (paged ? .paged : .contiguous))
 
-        // A's in-flight stream completes untouched across the shrink.
+        // A's in-flight stream completes untouched across the re-slice.
         let resultA = await collectorA.value
         #expect(resultA.error == nil, "A's stream must survive the shrink: \(resultA.error ?? "")")
         #expect(resultA.completion > 0)
         #expect(resultA.text.contains("10"), "greedy count should reach 10: \(resultA.text.prefix(200))")
 
-        // ---- 3. Both grants re-sliced; Σ ≤ fleet budget; ceilings live. ----
+        // ---- 3. Grants after the re-slice. ----
         let grantA1 = await bridgeA.engineKVBytesCapacity()
         let grantB = await bridgeB.engineKVBytesCapacity()
         let fleetBudget = UnifiedMemoryCap.kvBudgetBytes(
@@ -243,39 +308,81 @@ struct EngineV2CoResidencyLiveTests {
                 fp16KVBytesPerToken: sizingB.fp16KVBytesPerToken,
                 maxContextLength: sizingB.maxContextLength),
             fleetKVBudgetBytes: fleetBudget)
-        #expect(grantA1 == expected[Self.gptossID])
-        #expect(grantB == expected[Self.gemmaQatID])
-        #expect(grantA1 < grantA0)
-        #expect(UInt64(grantA1) + UInt64(grantB) <= fleetBudget)
+        let targetA = try #require(expected[Self.gptossID])
         print(
-            "[co-residency] fleetBudget=\(fleetBudget / Self.gib)GiB "
+            "[co-residency/\(kvBackend)] fleetBudget=\(fleetBudget / Self.gib)GiB "
                 + "grantA0=\(UInt64(grantA0) / Self.gib)GiB "
                 + "grantA1=\(UInt64(grantA1) / Self.gib)GiB "
                 + "grantB=\(UInt64(grantB) / Self.gib)GiB")
 
-        // ---- 4. A's NEXT admission respects the SHRUNK ceiling: the same
-        // worst-case probe that was admitted pre-shrink is now REFUSED by
-        // the ledger (canEverFit against the re-sliced capacity). ----
-        let refusedProbe = submitLedgerProbe(0x7000_0002)
-        #expect(refusedProbe == nil, "post-shrink probe must be refused by the admission ledger")
-        if let refusedProbe {  // drain if the assertion failed, don't leak
-            engineA.cancel(CBv2RequestID(0x7000_0002))
-            for await _ in refusedProbe {}
+        if paged {
+            // A ledger grow mints no pages: A's ceiling did not move, and
+            // the fair share it cannot take is reported, not lost.
+            #expect(grantA1 == grantA0)
+            #expect(grantA1 == poolA)
+            #expect(await bridgeA.kvBackendPoolBytes() == UInt64(poolA))
+            let shortfall = try #require(await bridgeA.pagedPoolResizeShortfall())
+            #expect(shortfall.poolBytes == poolA)
+            #expect(shortfall.requestedBytes == targetA)
+            #expect(shortfall.deferredGrowthBytes == targetA - poolA)
+            #expect(shortfall.strandedBytes == 0)
+            // Σ(PHYSICAL pools) ≤ fleet budget still holds — the pools are
+            // demand-bounded, so co-residency does not over-commit KV. It
+            // under-commits it, badly: see the ratio printed below.
+            let poolB = await bridgeB.kvBackendPoolBytes()
+            #expect(UInt64(poolA) + poolB <= fleetBudget)
+            print(
+                "[co-residency/paged] Σpools=\((UInt64(poolA) + poolB) / Self.gib)GiB "
+                    + "of fleetBudget=\(fleetBudget / Self.gib)GiB "
+                    + "(deferred on A alone: \(UInt64(shortfall.deferredGrowthBytes) / Self.gib)GiB)")
+        } else {
+            #expect(grantA1 == targetA)
+            #expect(grantB == expected[Self.gemmaQatID])
+            #expect(grantA1 < grantA0)
+            #expect(UInt64(grantA1) + UInt64(grantB) <= fleetBudget)
+            #expect(await bridgeA.pagedPoolResizeShortfall() == nil)
+        }
+
+        // ---- 4. A's NEXT admission. Contiguous: the same worst-case probe
+        // that was admitted pre-shrink is now REFUSED by the ledger. Paged:
+        // both probes keep their pre-load verdict, because a co-resident
+        // load cannot move a pool-bound ceiling in either direction. ----
+        if paged {
+            #expect(await ledgerAdmits(0x7000_0003, maxTokens: underCeilingTokens))
+            #expect(!(await ledgerAdmits(0x7000_0004, maxTokens: overCeilingTokens)))
+        } else {
+            #expect(
+                !(await ledgerAdmits(0x7000_0003, maxTokens: shrinkProbeTokens)),
+                "post-shrink probe must be refused by the admission ledger")
         }
 
         // Both slots serve a REAL decode through the production path.
         _ = try await loop.runStartupSelfTestDecode(modelId: Self.gptossID)
         _ = try await loop.runStartupSelfTestDecode(modelId: Self.gemmaQatID)
 
-        // ---- 5. Unload B: A grows back to the FULL budget. ----
+        // ---- 5. Unload B. ----
         await loop.unloadModel(Self.gemmaQatID)
         let grantA2 = await bridgeA.engineKVBytesCapacity()
         let budgetAfterUnload = UnifiedMemoryCap.kvBudgetBytes(
             residentWeightBytes: UInt64(sizingA.weightsBytes),
             configReserveBytes: reserveBytes)
-        #expect(grantA2 == Int(budgetAfterUnload))
-        #expect(grantA2 > grantA1)
-        print("[co-residency] after unload grantA2=\(UInt64(grantA2) / Self.gib)GiB")
+        if paged {
+            // The regrow is deferred, not taken: the survivor is left
+            // holding a pool sized for a box that no longer exists.
+            #expect(grantA2 == poolA)
+            #expect(grantA2 == grantA1)
+            let shortfall = try #require(await bridgeA.pagedPoolResizeShortfall())
+            #expect(shortfall.requestedBytes == Int(budgetAfterUnload))
+            #expect(shortfall.deferredGrowthBytes == Int(budgetAfterUnload) - poolA)
+            print(
+                "[co-residency/paged] after unload grantA2=\(UInt64(grantA2) / Self.gib)GiB "
+                    + "deferred=\(UInt64(shortfall.deferredGrowthBytes) / Self.gib)GiB "
+                    + "of budget=\(budgetAfterUnload / Self.gib)GiB")
+        } else {
+            #expect(grantA2 == Int(budgetAfterUnload))
+            #expect(grantA2 > grantA1)
+            print("[co-residency/contiguous] after unload grantA2=\(UInt64(grantA2) / Self.gib)GiB")
+        }
 
         // A still serves after the round trip.
         _ = try await loop.runStartupSelfTestDecode(modelId: Self.gptossID)

--- a/provider-swift/Tests/ProviderCoreTests/EngineV2ProductionWiringTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/EngineV2ProductionWiringTests.swift
@@ -685,17 +685,212 @@ struct EngineV2ReslicingWiringTests {
         #expect(engineA.capacityUpdates.last == grownA)
     }
 
-    @Test("mixed paged+contiguous: re-slice moves ledgers only; the paged pool never resizes and bounds every regrow")
+    @Test("all-paged co-residency: the shrink strands physical KV, the regrow is deferred, and both residues are measured")
+    func allPagedCoResidencyStrandsThenDefers() async throws {
+        // THE POST-FLIP SHAPE. Once `.auto` resolves `.paged` there is no
+        // contiguous slot left to contrast against — BOTH co-resident slots
+        // are paged — so the surviving asymmetry is not paged-vs-contiguous.
+        // It is between a slot's CONSTRUCTION-FIXED pool and the fair share
+        // the fleet re-slicer keeps moving underneath it.
+        //
+        // Each pool here is smaller than the logical grant its slot was
+        // built with: the production shape since #535, where
+        // `PagedKVPhysicalCapacityPolicy` bounds physical capacity by useful
+        // concurrent context, machine size, and live headroom — never by the
+        // grant. (The stale premise in §15 of the migration plan, that a
+        // lone paged slot commits ~the whole fleet budget as slabs, predates
+        // that policy: it was written in #531 and bounded in #535.)
+        //
+        // The drill:
+        //   1. A loads alone at the FULL fleet budget and materializes a
+        //      pool sized for the box as it looked THEN;
+        //   2. B arrives and the share is re-cut. A's pool is now LARGER
+        //      than A's share — the surplus is STRANDED: re-promised to B on
+        //      paper, still held by A's slabs in Metal;
+        //   3. B leaves and A's share returns to the whole budget, far past
+        //      the pool, which cannot grow — the regrow is DEFERRED.
+        // Not one byte moves either way today. Both residues are now
+        // MEASURED, which is exactly what a pool resize consumes and the
+        // only signal an operator gets with no canary fleet.
+        let loop = try makeWiringLoop()
+        let runtime = EngineV2Runtime()
+        let recorder = GrantRecorder()
+        let telemetry = WiringTelemetrySink()
+        let enginesBox = EngineBox()
+        await loop.setEngineV2RuntimeForTesting(runtime)
+        await loop.setEngineV2SlotHooksForTesting(
+            ProviderLoop.EngineV2SlotHooks(
+                eosTokenIds: [2],
+                emitTelemetry: telemetry.callback(),
+                physicalMemoryBytes: wiringPhysicalBytes,
+                kvBackendKindByModel: [
+                    "gemma-4-26b-qat-4bit": .paged,
+                    "gpt-oss-20b": .paged,
+                ],
+                makeEngine: { _, grant in
+                    recorder.record(grant)
+                    let engine = WiringScriptedEngine(
+                        script: .manual,
+                        kvBytesCapacity: grant,
+                        // Demand-shaped pool, capped below the logical grant.
+                        kvBytesBackendCapacity: grant * 3 / 5)
+                    enginesBox.append(engine)
+                    return engine
+                }))
+
+        let sizingA = makeSizing(weightsGiB: 15, kvRate: 20_480, maxContext: 262_144)
+        let bridgeA = try await loop.resliceAndBuildEngineV2SlotForTesting(
+            modelId: "gemma-4-26b-qat-4bit",
+            modelType: "gemma4",
+            container: makeStubContainer(),
+            tokenizer: TokenizerHandle(WiringStubTokenizer()),
+            sizing: sizingA)
+        await loop.installModelSlotForTesting(
+            modelId: "gemma-4-26b-qat-4bit",
+            container: makeStubContainer(),
+            tokenizer: TokenizerHandle(WiringStubTokenizer()),
+            engineV2: bridgeA,
+            sizing: sizingA,
+            modelType: "gemma4")
+        let engineA = enginesBox.all[0]
+        let grantA0 = recorder.granted[0]
+        let poolA = grantA0 * 3 / 5
+        #expect(await bridgeA.kvBackendKind == .paged)
+        #expect(await bridgeA.kvBackendPoolBytes() == UInt64(poolA))
+        // A lone slot has not been re-sliced, so there is no residue to
+        // report yet — its ceiling IS its pool, by construction.
+        #expect(await bridgeA.pagedPoolResizeShortfall() == nil)
+
+        // ---- Load paged B: A's ledger shrinks past its own pool. ----
+        let sizingB = makeSizing(weightsGiB: 12, kvRate: 24_576, maxContext: 131_072)
+        let bridgeB = try await loop.resliceAndBuildEngineV2SlotForTesting(
+            modelId: "gpt-oss-20b",
+            modelType: "gpt_oss",
+            container: makeStubContainer(),
+            tokenizer: TokenizerHandle(WiringStubTokenizer()),
+            sizing: sizingB)
+        await loop.installModelSlotForTesting(
+            modelId: "gpt-oss-20b",
+            container: makeStubContainer(),
+            tokenizer: TokenizerHandle(WiringStubTokenizer()),
+            engineV2: bridgeB,
+            sizing: sizingB,
+            modelType: "gpt_oss")
+        #expect(await bridgeB.kvBackendKind == .paged)
+
+        let fleetBudget2 = UnifiedMemoryCap.kvBudgetBytes(
+            physicalBytes: wiringPhysicalBytes,
+            residentWeightBytes: UInt64(sizingA.weightsBytes + sizingB.weightsBytes),
+            configReserveBytes: wiringReserveBytes)
+        let targets = EngineV2KVSizing.resliceGrants(
+            existing: [
+                .init(
+                    modelId: "gemma-4-26b-qat-4bit",
+                    fp16KVBytesPerToken: sizingA.fp16KVBytesPerToken,
+                    maxContextLength: sizingA.maxContextLength)
+            ],
+            newcomer: .init(
+                modelId: "gpt-oss-20b",
+                fp16KVBytesPerToken: sizingB.fp16KVBytesPerToken,
+                maxContextLength: sizingB.maxContextLength),
+            fleetKVBudgetBytes: fleetBudget2)
+        let targetA = try #require(targets["gemma-4-26b-qat-4bit"])
+        let targetB = try #require(targets["gpt-oss-20b"])
+
+        // The ledger contract is unchanged: the shrink reaches the engine
+        // unclamped and the pool does not move a byte.
+        #expect(targetA < poolA)
+        #expect(engineA.capacityUpdates.last == targetA)
+        #expect(await bridgeA.engineKVBytesCapacity() == targetA)
+        #expect(await bridgeA.kvBackendPoolBytes() == UInt64(poolA))
+        #expect(await bridgeB.engineKVBytesCapacity() == targetB)
+
+        // …and the shrink's residue is now named: physical KV A still owns
+        // after its share was cut. A ledger-only shrink frees nothing, so
+        // callers must never bank these bytes.
+        let afterLoad = try #require(await bridgeA.pagedPoolResizeShortfall())
+        #expect(afterLoad.poolBytes == poolA)
+        #expect(afterLoad.requestedBytes == targetA)
+        #expect(afterLoad.strandedBytes == poolA - targetA)
+        #expect(afterLoad.deferredGrowthBytes == 0)
+        #expect(!afterLoad.isExact)
+
+        // DEFECT PIN (migration plan §15). This is the whole reason a pool
+        // resize is a release blocker: Σ(logical grants) ≤ fleet budget
+        // still holds, but Σ(PHYSICAL pools) does not — A's slabs were
+        // sized against a box that no longer exists. When the resize lands
+        // this assertion MUST be inverted, not deleted.
+        let poolB = await bridgeB.kvBackendPoolBytes()
+        #expect(UInt64(targetA + targetB) <= fleetBudget2)
+        #expect(UInt64(poolA) + poolB > fleetBudget2)
+
+        // ---- Unload B: the regrow is deferred, not honoured. ----
+        await loop.unloadModel("gpt-oss-20b")
+        let regrowTarget = UnifiedMemoryCap.kvBudgetBytes(
+            physicalBytes: wiringPhysicalBytes,
+            residentWeightBytes: UInt64(sizingA.weightsBytes),
+            configReserveBytes: wiringReserveBytes)
+        #expect(regrowTarget > UInt64(poolA))
+        #expect(engineA.capacityUpdates.last == poolA)
+        #expect(await bridgeA.engineKVBytesCapacity() == poolA)
+        #expect(await bridgeA.kvBackendPoolBytes() == UInt64(poolA))
+        #expect(await bridgeA.slotKVBytesClaim() == poolA)
+
+        let afterUnload = try #require(await bridgeA.pagedPoolResizeShortfall())
+        #expect(afterUnload.requestedBytes == Int(regrowTarget))
+        #expect(afterUnload.deferredGrowthBytes == Int(regrowTarget) - poolA)
+        #expect(afterUnload.strandedBytes == 0)
+
+        // Both residues surfaced, in order, as operator-visible signals —
+        // the substitute for a canary fleet.
+        let clamps = telemetry.events.filter {
+            $0.fields?["operation"]?.description == "paged_pool_resize_clamped"
+        }
+        #expect(clamps.map { $0.fields?["reason"]?.description } == [
+            "unreclaimed_shrink", "deferred_grow",
+        ])
+        #expect(clamps.allSatisfy { $0.severity == .warn })
+        #expect(clamps.allSatisfy { $0.fields?["kv_backend"]?.description == "paged" })
+        #expect(clamps.allSatisfy {
+            $0.fields?["model"]?.description == "gemma-4-26b-qat-4bit"
+        })
+        // Raw bytes, never a ratio (Main's ruling): the denominator ships
+        // with every delta, so share-of-pool is derivable and the overflow
+        // magnitude survives — a clamped ratio would read 1.0 for both of
+        // these and lose exactly the number co-residency is diagnosed by.
+        // The allowlist filter is applied at the producer, so an unmirrored
+        // key would vanish silently; asserting the values back is what
+        // proves all three cleared it.
+        #expect(clamps.allSatisfy {
+            $0.fields?["pool_bytes"]?.description == String(poolA)
+        })
+        let shrinkEvent = try #require(clamps.first)
+        #expect(shrinkEvent.fields?["pool_stranded_bytes"]?.description
+            == String(poolA - targetA))
+        #expect(shrinkEvent.fields?["pool_deferred_growth_bytes"]?.description == "0")
+        let regrowEvent = try #require(clamps.last)
+        #expect(regrowEvent.fields?["pool_deferred_growth_bytes"]?.description
+            == String(Int(regrowTarget) - poolA))
+        #expect(regrowEvent.fields?["pool_stranded_bytes"]?.description == "0")
+    }
+
+    @Test("mixed paged+contiguous: only the contiguous survivor can actually take its regrow")
     func mixedPagedContiguousResliceIsLedgerOnly() async throws {
+        // A mixed box stays reachable after the flip: `.auto` degrades to
+        // contiguous whenever `PagedKVPhysicalCapacityPolicy` cannot carve a
+        // ≥1 GiB pool, which is the normal outcome for the SECOND load on a
+        // small box. So this pins what mixed now means, rather than the
+        // pre-flip paged-vs-contiguous contrast that a paged default erases.
+        //
         // Slot A is PAGED with a demand-capped physical pool SMALLER than
-        // its logical grant (the production shape after the v0.7.6 fix:
-        // physical capacity is designed from demand, never the full
-        // logical grant). Slot B is contiguous. The ProviderLoop-driven
+        // its logical grant; slot B is contiguous. The ProviderLoop-driven
         // load/unload re-slice must:
         //   * shrink/grow ONLY admission ledgers,
         //   * keep A's physical pool byte-for-byte constant, and
-        //   * clamp A's regrow to pool truth — a ledger-only re-slice can
-        //     never "restore" physical bytes the pool does not hold.
+        //   * let the CONTIGUOUS survivor take its regrow in full — the one
+        //     thing its paged neighbour cannot do (see
+        //     `allPagedCoResidencyStrandsThenDefers`), and the reason a
+        //     paged-by-default fleet loses capacity that a mixed one keeps.
         let loop = try makeWiringLoop()
         let runtime = EngineV2Runtime()
         let recorder = GrantRecorder()
@@ -757,6 +952,7 @@ struct EngineV2ReslicingWiringTests {
             engineV2: bridgeB,
             sizing: sizingB,
             modelType: "gpt_oss")
+        let engineB = enginesBox.all[1]
         #expect(await bridgeB.kvBackendKind == .contiguous)
 
         let fleetBudget2 = UnifiedMemoryCap.kvBudgetBytes(
@@ -776,28 +972,36 @@ struct EngineV2ReslicingWiringTests {
                 maxContextLength: sizingB.maxContextLength),
             fleetKVBudgetBytes: fleetBudget2)
         let targetA = try #require(targets["gemma-4-26b-qat-4bit"])
+        let targetB = try #require(targets["gpt-oss-20b"])
         // The two-model fair share sits below the pool here, so the shrink
         // reaches the engine unclamped — and the pool still never moved.
         #expect(UInt64(targetA) < poolA)
         #expect(engineA.capacityUpdates.last == targetA)
         #expect(await bridgeA.engineKVBytesCapacity() == targetA)
         #expect(await bridgeA.kvBackendPoolBytes() == poolA)
-        #expect(await bridgeB.engineKVBytesCapacity() == targets["gpt-oss-20b"])
+        #expect(await bridgeB.engineKVBytesCapacity() == targetB)
+        // The paged slot is holding physical KV its share no longer covers.
+        #expect(
+            await bridgeA.pagedPoolResizeShortfall()?.strandedBytes
+                == Int(poolA) - targetA)
+        // A contiguous slot resizes ledger and physical capacity together,
+        // so it has no residue to report at all.
+        #expect(await bridgeB.pagedPoolResizeShortfall() == nil)
 
-        // Unload B: the regrow's single-survivor target is the FULL fleet
-        // budget (> pool), but the paged bridge clamps the restore to pool
-        // truth — admission can never advertise physical bytes the slabs
-        // do not hold, and the pool itself is byte-for-byte unchanged.
-        await loop.unloadModel("gpt-oss-20b")
-        let regrowTarget = UnifiedMemoryCap.kvBudgetBytes(
+        // Unload the PAGED slot: the contiguous survivor's regrow target is
+        // the FULL fleet budget under its own weights, and — unlike its
+        // paged neighbour, whose identical regrow clamps to pool truth — it
+        // takes every byte.
+        await loop.unloadModel("gemma-4-26b-qat-4bit")
+        let regrowB = UnifiedMemoryCap.kvBudgetBytes(
             physicalBytes: wiringPhysicalBytes,
-            residentWeightBytes: UInt64(sizingA.weightsBytes),
+            residentWeightBytes: UInt64(sizingB.weightsBytes),
             configReserveBytes: wiringReserveBytes)
-        #expect(regrowTarget > poolA)
-        #expect(engineA.capacityUpdates.last == Int(poolA))
-        #expect(await bridgeA.engineKVBytesCapacity() == Int(poolA))
-        #expect(await bridgeA.kvBackendPoolBytes() == poolA)
-        #expect(await bridgeA.slotKVBytesClaim() == Int(poolA))
+        #expect(regrowB > UInt64(targetB))
+        #expect(engineB.capacityUpdates.last == Int(regrowB))
+        #expect(await bridgeB.engineKVBytesCapacity() == Int(regrowB))
+        #expect(await bridgeB.slotKVBytesClaim() == Int(regrowB))
+        #expect(await bridgeB.pagedPoolResizeShortfall() == nil)
     }
 
     @Test("restore-on-throw: B's construction failure restores A's grant EXACTLY")

--- a/provider-swift/Tests/ProviderCoreTests/MTPPostureTelemetryTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/MTPPostureTelemetryTests.swift
@@ -1,0 +1,403 @@
+// Copyright © 2026 Eigen Labs.
+//
+// Producers for the v0.8.0 MTP + paged-pool telemetry fields.
+//
+// These fields were allowlisted in all three mirrors (Go, Swift, TS) ahead of
+// any producer. An allowlisted field with no producer is dead weight, so what
+// this suite defends is emission: that a real slot actually puts the values on
+// the wire, that the three `backend` axes stay three separate keys, and that
+// "enabled but inert" is nameable and named.
+
+import Foundation
+import MLXLMCommon
+import Testing
+
+@testable import ProviderCore
+
+// MARK: - Fixtures
+
+private final class PostureTelemetrySink: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _events: [TelemetryEvent] = []
+    var events: [TelemetryEvent] { lock.withLock { _events } }
+    func callback() -> @Sendable (TelemetryEvent) -> Void {
+        { [weak self] event in
+            guard let self else { return }
+            self.lock.withLock { self._events.append(event) }
+        }
+    }
+
+    /// Newest posture sample, or nil.
+    var posture: TelemetryEvent? {
+        events.last { $0.fields?["operation"]?.description == "engine_v2_slot_posture" }
+    }
+}
+
+/// Engine stub reporting a paged pool that is partly occupied. `kvBytesInUse`
+/// and `kvBytesBackendCapacity` are what a paged `EngineLoopV2` publishes from
+/// `PagedKVPool.bytesInUse` / `.bytesCapacity`.
+private final class PagedPoolStubEngine: CBv2Engine, @unchecked Sendable {
+    private let inUse: Int
+    private let poolBytes: Int
+
+    init(kvBytesInUse: Int, poolBytes: Int) {
+        self.inUse = kvBytesInUse
+        self.poolBytes = poolBytes
+    }
+
+    func submit(_ request: CBv2Request) throws -> AsyncStream<CBv2Event> {
+        let (stream, continuation) = AsyncStream<CBv2Event>.makeStream()
+        continuation.finish()
+        return stream
+    }
+    func cancel(_ id: CBv2RequestID) {}
+    func capacity() -> CBv2CapacitySnapshot {
+        CBv2CapacitySnapshot(
+            activeRequests: 0, waitingRequests: 0, kvBytesInUse: inUse,
+            kvBytesCapacity: poolBytes, kvBytesBackendCapacity: poolBytes,
+            activeTokens: 0)
+    }
+    func updateKVBytesCapacity(_ bytes: Int) {}
+    func shutdown() async {}
+}
+
+private func makePostureBridge(
+    engine: any CBv2Engine,
+    kvBackendKind: EngineV2KVBackendKind,
+    telemetry: PostureTelemetrySink
+) -> EngineV2Bridge {
+    EngineV2Bridge(
+        engine: engine,
+        modelId: "gemma-4-26b-qat-4bit",
+        tokenizer: TokenizerHandle(StubBridgeTokenizer()),
+        eosTokenIds: [],
+        kvBackendKind: kvBackendKind,
+        emitTelemetry: telemetry.callback())
+}
+
+/// A drafter that loaded and activated — the load-time truth the provider had
+/// been mistaking for "MTP is working".
+private func activatedStatus() -> MTPActivationStatus {
+    MTPActivationStatus
+        .disabled(.configDisabled, configured: true)
+        .activated(assistantBytes: 236 * 1024 * 1024)
+}
+
+private func field(_ event: TelemetryEvent?, _ key: String) -> String? {
+    event?.fields?[key]?.description
+}
+
+// MARK: - Tests
+
+@Suite("MTP + paged-pool posture telemetry")
+struct MTPPostureTelemetryTests {
+
+    // MARK: Enabled but inert
+
+    @Test("paged slot with zero MTP rounds reports inert_kv_unsupported")
+    func inertPagedSlotIsNamed() async {
+        // The shape observed on a paged gemma-4 slot: the drafter loaded, the
+        // engine reports MTP active, and every planned row is refused by the
+        // storage-eligibility guard, so not one round runs.
+        var metrics = CBv2MTPMetrics()
+        metrics.active = true
+        metrics.rounds = 0
+        metrics.skippedRows = ["kv_unsupported": 128]
+
+        let snapshot = ProviderMTPStatusSnapshot(status: activatedStatus(), metrics: metrics)
+
+        #expect(snapshot.configured)
+        // A slot executing zero rounds is not active. Reporting it active is
+        // what hid this state for the whole migration.
+        #expect(!snapshot.active)
+        #expect(snapshot.fallbackReason == .inertKVUnsupported)
+        #expect(snapshot.fallbackReason?.rawValue == "inert_kv_unsupported")
+
+        let telemetry = PostureTelemetrySink()
+        let bridge = makePostureBridge(
+            engine: PagedPoolStubEngine(kvBytesInUse: 3 << 30, poolBytes: 12 << 30),
+            kvBackendKind: .paged,
+            telemetry: telemetry)
+        await bridge.emitSlotPostureTelemetry(snapshot)
+
+        let event = telemetry.posture
+        #expect(event != nil)
+        #expect(field(event, "mtp_enabled") == "true")
+        #expect(field(event, "mtp_active") == "false")
+        #expect(field(event, "mtp_inactive_reason") == "inert_kv_unsupported")
+        // Enabled-and-inert is a PAGED-slot state; the sample must say so or
+        // the rollout dashboard cannot attribute it to the backend that
+        // caused it.
+        #expect(field(event, "kv_backend") == "paged")
+        // Nothing was proposed, so the ratio is absent rather than 0.0 — a
+        // zero would read as "the target rejects every draft".
+        #expect(event?.fields?["mtp_acceptance_rate"] == nil)
+
+        await bridge.shutdown()
+    }
+
+    @Test("inert is distinct from engine_inactive")
+    func inertIsNotEngineInactive() {
+        var inert = CBv2MTPMetrics()
+        inert.active = true
+        inert.rounds = 0
+        inert.skippedRows = ["kv_unsupported": 4]
+        #expect(
+            ProviderMTPStatusSnapshot(status: activatedStatus(), metrics: inert)
+                .fallbackReason == .inertKVUnsupported)
+
+        // Engine says OFF: a different fact, and it keeps its own reason.
+        var off = CBv2MTPMetrics()
+        off.active = false
+        off.rounds = 0
+        off.skippedRows = ["kv_unsupported": 4]
+        #expect(
+            ProviderMTPStatusSnapshot(status: activatedStatus(), metrics: off)
+                .fallbackReason == .engineInactive)
+
+        // No engine metrics at all is also engine-inactive, not inert.
+        #expect(
+            ProviderMTPStatusSnapshot(status: activatedStatus(), metrics: nil)
+                .fallbackReason == .engineInactive)
+    }
+
+    @Test("zero rounds without kv_unsupported skips is not inert")
+    func idleSlotIsNotInert() {
+        // Freshly built engine: nothing has been planned yet, so rounds and
+        // skips are both zero. This is the state the post-build MTP teardown
+        // gate reads, and it must NOT be mistaken for inert — doing so would
+        // tear down and rebuild every MTP slot at load.
+        var fresh = CBv2MTPMetrics()
+        fresh.active = true
+        fresh.rounds = 0
+        fresh.skippedRows = [:]
+        let snapshot = ProviderMTPStatusSnapshot(status: activatedStatus(), metrics: fresh)
+        #expect(snapshot.active)
+        #expect(snapshot.fallbackReason == nil)
+
+        // Skipped for an unrelated reason is also not inert.
+        var otherSkip = CBv2MTPMetrics()
+        otherSkip.active = true
+        otherSkip.rounds = 0
+        otherSkip.skippedRows = ["batch_gate": 9]
+        #expect(ProviderMTPStatusSnapshot(status: activatedStatus(), metrics: otherSkip).active)
+    }
+
+    @Test("a slot that ran rounds stays active even after kv_unsupported skips")
+    func productiveSlotStaysActive() async {
+        // Mixed traffic: some rows unsupported, but rounds DID run. Inert
+        // means zero rounds, not "some rows were skipped".
+        var metrics = CBv2MTPMetrics()
+        metrics.active = true
+        metrics.rounds = 40
+        metrics.draftedTokens = 200
+        metrics.acceptedTokens = 150
+        metrics.skippedRows = ["kv_unsupported": 3]
+
+        let snapshot = ProviderMTPStatusSnapshot(status: activatedStatus(), metrics: metrics)
+        #expect(snapshot.active)
+        #expect(snapshot.fallbackReason == nil)
+
+        let telemetry = PostureTelemetrySink()
+        let bridge = makePostureBridge(
+            engine: PagedPoolStubEngine(kvBytesInUse: 0, poolBytes: 8 << 30),
+            kvBackendKind: .paged,
+            telemetry: telemetry)
+        await bridge.emitSlotPostureTelemetry(snapshot)
+
+        let event = telemetry.posture
+        #expect(field(event, "mtp_active") == "true")
+        // Productively running, so there is no inactive reason to carry.
+        #expect(event?.fields?["mtp_inactive_reason"] == nil)
+        #expect(field(event, "mtp_acceptance_rate") == "0.75")
+
+        await bridge.shutdown()
+    }
+
+    // MARK: The `backend` key split
+
+    @Test("posture keeps engine identity and KV storage kind on separate keys")
+    func backendAxesStaySeparate() async {
+        let telemetry = PostureTelemetrySink()
+        let bridge = makePostureBridge(
+            engine: PagedPoolStubEngine(kvBytesInUse: 1 << 30, poolBytes: 4 << 30),
+            kvBackendKind: .paged,
+            telemetry: telemetry)
+        await bridge.emitSlotPostureTelemetry(
+            ProviderMTPStatusSnapshot(status: activatedStatus(), metrics: nil))
+
+        let event = telemetry.posture
+        // `backend` is the engine executing inference — the majority meaning,
+        // and the one that joins RegisterMessage.backend. It must NOT carry
+        // the KV storage kind, which is what mis-bucketed every `group by
+        // backend` dashboard before this split.
+        #expect(field(event, "backend") == "engine_v2")
+        #expect(field(event, "kv_backend") == "paged")
+
+        await bridge.shutdown()
+    }
+
+    @Test("contiguous slots report kv_backend and omit pool utilization")
+    func contiguousSlotHasNoPool() async {
+        let telemetry = PostureTelemetrySink()
+        let bridge = makePostureBridge(
+            engine: PagedPoolStubEngine(kvBytesInUse: 1 << 30, poolBytes: 4 << 30),
+            kvBackendKind: .contiguous,
+            telemetry: telemetry)
+        await bridge.emitSlotPostureTelemetry(
+            ProviderMTPStatusSnapshot(status: activatedStatus(), metrics: nil))
+
+        let event = telemetry.posture
+        #expect(field(event, "backend") == "engine_v2")
+        #expect(field(event, "kv_backend") == "contiguous")
+        // There is no pool on a contiguous slot. Absent, never 0.0.
+        #expect(event?.fields?["pool_utilization"] == nil)
+
+        await bridge.shutdown()
+    }
+
+    // MARK: Paged pool occupancy
+
+    @Test("pool_utilization is occupied over total pool bytes")
+    func poolUtilizationIsMeasured() async {
+        let telemetry = PostureTelemetrySink()
+        let bridge = makePostureBridge(
+            engine: PagedPoolStubEngine(kvBytesInUse: 3 << 30, poolBytes: 12 << 30),
+            kvBackendKind: .paged,
+            telemetry: telemetry)
+        await bridge.emitSlotPostureTelemetry(
+            ProviderMTPStatusSnapshot(status: activatedStatus(), metrics: nil))
+
+        #expect(field(telemetry.posture, "pool_utilization") == "0.25")
+
+        await bridge.shutdown()
+    }
+
+    @Test("unknown pool capacity omits utilization rather than reporting empty")
+    func unknownPoolCapacityIsOmitted() async {
+        // kvBytesBackendCapacity == 0 means UNKNOWN (test stubs, idle
+        // point-update snapshots) and must never read as an empty pool.
+        let telemetry = PostureTelemetrySink()
+        let bridge = makePostureBridge(
+            engine: InertStubEngine(kvBytesCapacity: 1 << 30),
+            kvBackendKind: .paged,
+            telemetry: telemetry)
+        await bridge.emitSlotPostureTelemetry(
+            ProviderMTPStatusSnapshot(status: activatedStatus(), metrics: nil))
+
+        let event = telemetry.posture
+        #expect(event != nil)
+        #expect(event?.fields?["pool_utilization"] == nil)
+
+        await bridge.shutdown()
+    }
+
+    // MARK: The producer is actually wired
+
+    @Test("every slot emits posture on the periodic sampler, MTP or not")
+    func periodicSamplerEmitsForEverySlot() async throws {
+        // The point of the ticket: these fields need a PRODUCER, and the
+        // producer must be a recurring per-slot inventory rather than a
+        // once-per-construction notification. Drive the real timer.
+        let telemetry = PostureTelemetrySink()
+        let bridge = makePostureBridge(
+            engine: PagedPoolStubEngine(kvBytesInUse: 2 << 30, poolBytes: 8 << 30),
+            kvBackendKind: .paged,
+            telemetry: telemetry)
+
+        // MTP never loaded on this slot. It must still report — `mtp_enabled:
+        // false` is itself the observation that resolves a partial-MTP fleet,
+        // and the paged-pool fields do not depend on MTP at all.
+        await bridge.configureMTPStatus(
+            .disabled(.configDisabled, configured: false),
+            metricsInterval: .milliseconds(20))
+
+        let deadline = ContinuousClock.now.advanced(by: .seconds(5))
+        while telemetry.posture == nil, ContinuousClock.now < deadline {
+            try await Task.sleep(for: .milliseconds(20))
+        }
+
+        let event = try #require(telemetry.posture, "periodic sampler produced no posture event")
+        #expect(event.kind == .engineHealth)
+        #expect(field(event, "component") == "engine")
+        #expect(field(event, "model") == "gemma-4-26b-qat-4bit")
+        #expect(field(event, "backend") == "engine_v2")
+        #expect(field(event, "kv_backend") == "paged")
+        #expect(field(event, "mtp_enabled") == "false")
+        #expect(field(event, "mtp_active") == "false")
+        #expect(field(event, "mtp_inactive_reason") == "config_disabled")
+        #expect(field(event, "pool_utilization") == "0.25")
+
+        await bridge.shutdown()
+    }
+
+    @Test("shutdown stops the sampler")
+    func shutdownStopsSampler() async throws {
+        let telemetry = PostureTelemetrySink()
+        let bridge = makePostureBridge(
+            engine: PagedPoolStubEngine(kvBytesInUse: 0, poolBytes: 1 << 30),
+            kvBackendKind: .paged,
+            telemetry: telemetry)
+        await bridge.configureMTPStatus(
+            .disabled(.configDisabled, configured: false),
+            metricsInterval: .milliseconds(20))
+
+        let deadline = ContinuousClock.now.advanced(by: .seconds(5))
+        while telemetry.posture == nil, ContinuousClock.now < deadline {
+            try await Task.sleep(for: .milliseconds(20))
+        }
+        _ = try #require(telemetry.posture)
+
+        await bridge.shutdown()
+        let afterShutdown = telemetry.events.count
+        try await Task.sleep(for: .milliseconds(200))
+        #expect(telemetry.events.count == afterShutdown)
+    }
+
+    @Test("a zero interval disables the sampler entirely")
+    func zeroIntervalDisablesSampler() async throws {
+        let telemetry = PostureTelemetrySink()
+        let bridge = makePostureBridge(
+            engine: PagedPoolStubEngine(kvBytesInUse: 0, poolBytes: 1 << 30),
+            kvBackendKind: .paged,
+            telemetry: telemetry)
+        await bridge.configureMTPStatus(
+            .disabled(.configDisabled, configured: false), metricsInterval: .zero)
+
+        try await Task.sleep(for: .milliseconds(120))
+        #expect(telemetry.posture == nil)
+
+        await bridge.shutdown()
+    }
+
+    // MARK: Allowlist
+
+    @Test("every posture field survives the client-side allowlist filter")
+    func postureFieldsAreAllowlisted() async {
+        // TelemetryFieldFilter drops unknown keys SILENTLY. A producer whose
+        // keys are not mirrored would emit nothing and look healthy.
+        var metrics = CBv2MTPMetrics()
+        metrics.active = true
+        metrics.rounds = 12
+        metrics.draftedTokens = 100
+        metrics.acceptedTokens = 60
+
+        let telemetry = PostureTelemetrySink()
+        let bridge = makePostureBridge(
+            engine: PagedPoolStubEngine(kvBytesInUse: 1 << 30, poolBytes: 2 << 30),
+            kvBackendKind: .paged,
+            telemetry: telemetry)
+        await bridge.emitSlotPostureTelemetry(
+            ProviderMTPStatusSnapshot(status: activatedStatus(), metrics: metrics))
+
+        let fields = telemetry.posture?.fields ?? [:]
+        for key in [
+            "component", "operation", "backend", "kv_backend", "model",
+            "mtp_enabled", "mtp_active", "mtp_acceptance_rate", "pool_utilization",
+        ] {
+            #expect(fields[key] != nil, "\(key) was dropped by the allowlist filter")
+        }
+
+        await bridge.shutdown()
+    }
+}

--- a/provider-swift/Tests/ProviderCoreTests/ProtocolTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ProtocolTests.swift
@@ -1306,6 +1306,64 @@ private func samplePrivacyCapabilities() -> PrivacyCapabilities {
     #expect(legacyDecoded.reasoningTokens == 0)
 }
 
+// The v0.8.0 paged-KV rollout discriminator. `kvBackend` is `String?`, not
+// `String`, and encodes with `encodeIfPresent` rather than the non-zero/false
+// omission every other additive field here uses: a pre-0.8.0 provider omits
+// `kv_backend` entirely and nil MUST stay distinguishable from an explicit
+// value, or the coordinator books every legacy provider as a contiguous
+// sample and the rollout A/B is measuring its own blind spot. Mirrors
+// `KVBackend *string` + `omitempty` in coordinator/protocol/messages.go; the
+// Go-side triple lives in messages_backend_capacity_test.go.
+//
+// BOTH directions on purpose. `BackendSlotCapacity` hand-rolls CodingKeys,
+// `init(from:)` and `encode(to:)`, so one wire field costs six coordinated
+// edits — and an encode-only assertion still passes when `init(from:)` forgot
+// the key.
+@Test func backendSlotCapacityRoundTripsKVBackendDiscriminator() throws {
+    // 1. PRESENT — both shipped kinds survive encode → wire → decode.
+    for kind in ["paged", "contiguous"] {
+        let slot = BackendSlotCapacity(
+            model: "gemma-4-26b-qat-4bit",
+            state: "running",
+            numRunning: 1,
+            numWaiting: 0,
+            activeTokens: 128,
+            maxTokensPotential: 512,
+            kvBackend: kind)
+        let encoded = try JSONEncoder().encode(slot)
+        let object = try jsonObject(encoded)
+        #expect(object["kv_backend"] as? String == kind)
+        let decoded = try JSONDecoder().decode(BackendSlotCapacity.self, from: encoded)
+        #expect(decoded.kvBackend == kind)
+    }
+
+    // What the provider actually puts in that field is the RESOLVED engine
+    // kind (EngineV2Bridge+Capacity passes `kvBackendKind.rawValue`), so pin
+    // the two literals the wire can carry — renaming a case would otherwise
+    // change the wire silently.
+    #expect(EngineV2KVBackendKind.paged.rawValue == "paged")
+    #expect(EngineV2KVBackendKind.contiguous.rawValue == "contiguous")
+
+    // 2. OMITTED — a pre-0.8.0 payload decodes to nil (UNKNOWN, never
+    //    "contiguous"), and a slot that never sets it re-encodes without the
+    //    key, so the wire shape older consumers see is unchanged.
+    let legacyRaw = #"{"model":"qwen","state":"running","num_running":2,"num_waiting":0,"active_tokens":3000,"max_tokens_potential":8000}"#
+    let legacy = try JSONDecoder().decode(BackendSlotCapacity.self, from: Data(legacyRaw.utf8))
+    #expect(legacy.kvBackend == nil)
+    let legacyReencoded = try jsonObject(JSONEncoder().encode(legacy))
+    #expect(legacyReencoded["kv_backend"] == nil)
+
+    // 3. EXPLICIT EMPTY — survives both directions and stays distinct from
+    //    omission. This is the case a plain `String` (or the `encodeIfNonZero`
+    //    treatment the counters get) would silently collapse into "unknown".
+    let emptyRaw = #"{"model":"qwen","state":"running","num_running":1,"num_waiting":0,"active_tokens":0,"max_tokens_potential":0,"kv_backend":""}"#
+    let empty = try JSONDecoder().decode(BackendSlotCapacity.self, from: Data(emptyRaw.utf8))
+    #expect(empty.kvBackend == "")
+    #expect(empty.kvBackend != legacy.kvBackend)
+    let emptyReencoded = try jsonObject(JSONEncoder().encode(empty))
+    #expect(emptyReencoded["kv_backend"] as? String == "")
+}
+
 private func jsonObject(_ data: Data) throws -> [String: Any] {
     guard let object = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
         throw TestFailure.notJSONObject


### PR DESCRIPTION
Stacks on #586 (paged refusal, shares `EngineV2SlotFactory.swift`) and merges #580 (three-way allowlist parity guard) and #584 (memory/routing, shares `servability_test.go`).

**With no canary fleet, telemetry is how we judge a paged rollout.** Nine v0.8.0 fields were allowlisted and nothing emitted them — which is worse than having no field, because the dashboard renders a clean baseline that is really just absence.

## The `backend` key collided on three semantic axes, not two

Engine identity, KV storage, and prefix-reuse provenance were all being written to one key from four sites, so a paged slot and a contiguous slot could group identically.

```mermaid
flowchart LR
  subgraph Before
    A1[EngineV2SlotFactory] --> K1["backend"]
    A2[PrefixCache wiring] --> K1
    A3[EngineV2Config] --> K1
    A4[slot posture] --> K1
    K1 --> D1["one key, three meanings — paged and contiguous group identically"]
    M1["mtp_active = status.active && engineActive"] --> M2["inert slot reports ACTIVE"]
    M2 --> M3["coordinator applies the TPS-inflation correction to a slot producing zero drafts"]
  end
  subgraph After
    B1[EngineV2SlotFactory] --> KA["kv_backend"]
    B2[PrefixCache wiring] --> KB["prefix_reuse_backend"]
    B3[EngineV2Config] --> KC["backend = engine identity"]
    B4[slot posture, 60s per slot] --> KA & KB & KC
    N1["mtp_active = drafts actually emitted"] --> N2["inert reports FALSE + mtp_inactive_reason"]
  end
```

The discriminator is a **string**, not a bool, because an absent value must stay distinguishable from an explicit empty one — otherwise every pre-0.8.0 provider books as a contiguous sample and the rollout dashboard shows a clean baseline made entirely of old providers.

## MTP has a third state and it was unnamed

Enabled, loaded, and emitting zero drafts. `mtp_active` is now **false** there. The field exists to flag the routing hazard — MTP inflates `observed_decode_tps` — and an inert slot inflates nothing, so reporting it active *inverts* the correction rather than being merely imprecise. All three production readers traced.

## Emission point

A per-bridge sampler on the existing 60s cadence, ungated so every loaded slot reports. Rejected: once-per-construction (the documented `engine_v2_kv_backend` mistake — a drop-on-full sink behind a 100/min limit is a notification, not an inventory); per-request (an idle slot vanishes, and *inert* is precisely a slot that looks busy while doing nothing); edge-triggered (a healthy slot never reports).

## Two fields removed again, deliberately

`pages_pinned` and `cow_events` were allowlisted with no producer **and no possible producer** — PagedKVPool has no pin concept and copy-on-write splitting is unimplemented. The producer site already refused to emit a hardcoded `0` because it would be indistinguishable from a measured zero; that argument applies one level up and had not been followed through. A key that survives the filter but is never written reads as a legitimate zero to anyone building a panel on it.

Paged-pool bytes therefore ship as **raw quantities** — `pool_bytes`, `pool_deferred_growth_bytes`, `pool_stranded_bytes` — not a second ratio beside `pool_utilization`. A ratio clamps at 1.0 exactly when the interesting thing is how far past capacity demand went, and raw quantities compose across slots where ratios do not.

**Verified:** `swift build` clean; `go test -run TestTelemetryAllowlist` 3/3 (the parity guard is what proves the mirrors stayed in sync); gofmt clean; 168 tests / 20 suites. The central claim is mutation-tested — reverting `active` to `status.active && engineActive` fails the inert test on exactly its two assertions and passes again on revert.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/587"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787606641&installation_model_id=21733&pr_number=587&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F587&signature=6d32182cc39f917b7f7046d562400ab90c9b62aa8b0b4a706bbf93dccfe92323"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->