### PR TITLE
feat(ssd): windowed sidecar blocks, so a donated window need not be replayed

### DIFF
--- a/provider-swift/Sources/ProviderCore/Inference/PrefixCachePolicy.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/PrefixCachePolicy.swift
@@ -129,29 +129,90 @@ enum PrefixCachePolicy {
             backend: backend)
     }
 
-    /// Conservative finite-window replay length. Kept as a policy convenience
-    /// for SSD donation/stage benefit gates; the engine plan remains
-    /// authoritative per matched boundary.
-    static func adoptionBoundTokens(layerKinds: [CBv2LayerKind]) -> Int {
-        CBv2PrefixReuseCapability.derive(
+    // MARK: - Window residency (WS-4.2)
+
+    /// Whether an adopter's sliding rows are RESTORED from windowed sidecars
+    /// or replayed. Default `.replayed` everywhere: WS-4.2 lands the format
+    /// and this plumbing, and the residency flip is a later, separate step.
+    ///
+    /// `.restoredFromSidecar` requires all three of:
+    ///   * the operator knob (`SSDPrefixCachePolicy.windowSidecarEnabled`);
+    ///   * a layout that tiles into whole-block sidecars
+    ///     (`SSDWindowSidecarGeometry.derive` — gpt-oss-20b's 128-token
+    ///     window does not, and correctly keeps its 1,536-token bound);
+    ///   * a row that can accept a restored window. Paged gets that from
+    ///     WS-4.1's `restoreWindow(keys:values:base:)`; a KILLED paged slot
+    ///     has degraded to a contiguous row, so it is resolved as contiguous.
+    static func windowResidency(
+        layerKinds: [CBv2LayerKind],
+        backendSelection: EngineV2KVBackendSelection,
+        pagedKilled: Bool = false,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> SSDWindowResidency {
+        guard SSDPrefixCachePolicy.windowSidecarEnabled(environment: environment),
+            SSDWindowSidecarGeometry.derive(layerKinds: layerKinds, blockSize: blockSize) != nil
+        else { return .replayed }
+        return .restoredFromSidecar
+    }
+
+    /// Conservative finite-window replay length for the SSD donation/stage
+    /// benefit gates; the engine plan remains authoritative per matched
+    /// boundary.
+    ///
+    /// Resolves the backend through `prefixReuseCapability` rather than
+    /// hardcoding `.contiguousUnquantized`, so this and its sibling can no
+    /// longer describe two different backends for the same slot.
+    static func adoptionBoundTokens(
+        layerKinds: [CBv2LayerKind],
+        backendSelection: EngineV2KVBackendSelection = .auto,
+        pagedKilled: Bool = false,
+        windowResidency: SSDWindowResidency = .replayed
+    ) -> Int {
+        adoptionBoundTokens(
+            capability: prefixReuseCapability(
+                layerKinds: layerKinds,
+                backendSelection: backendSelection,
+                pagedKilled: pagedKilled),
             layerKinds: layerKinds,
-            backend: .contiguousUnquantized
-        ).conservativeReplayBoundTokens
+            windowResidency: windowResidency)
+    }
+
+    /// Residency-resolved bound for an already-derived capability.
+    ///
+    /// A restored window means the sliding rows are exact AT the boundary, so
+    /// there is nothing to replay and the bound collapses to zero — the whole
+    /// point of WS-4.2. It is gated on the geometry existing so that a
+    /// residency asserted for a layout that cannot produce whole-block
+    /// sidecars still fails closed to replay.
+    static func adoptionBoundTokens(
+        capability: CBv2PrefixReuseCapability,
+        layerKinds: [CBv2LayerKind],
+        windowResidency: SSDWindowResidency
+    ) -> Int {
+        guard windowResidency == .restoredFromSidecar,
+            SSDWindowSidecarGeometry.derive(layerKinds: layerKinds, blockSize: blockSize) != nil
+        else { return capability.conservativeReplayBoundTokens }
+        return 0
     }
 
     /// Real Gemma QAT evidence is noisy/negative at only 1,024 saved tokens
     /// and positive from 1,536 onward; GPT's shorter 1,536-token replay span
     /// remains beneficial at the generic 1,024 floor. The environment may
     /// raise either floor but cannot lower the proved long-hybrid minimum.
+    ///
+    /// The override keys off the RESOLVED bound, not the capability's raw
+    /// one. That evidence was measured against a 25,600-token replay, where
+    /// saving 1,024 tokens was within the noise; with the window restored
+    /// there is no replay to be noisy about, so the generic floor applies.
     static func minEffectiveTokens(
         capability: CBv2PrefixReuseCapability,
+        adoptionBoundTokens: Int? = nil,
         environment: [String: String] = ProcessInfo.processInfo.environment
     ) -> Int {
         let configured = SSDPrefixCachePolicy.minEffectiveTokens(environment: environment)
+        let bound = adoptionBoundTokens ?? capability.conservativeReplayBoundTokens
         let longHybridFloor =
-            capability.strategy == .frozenFullReplay
-                && capability.conservativeReplayBoundTokens >= 25_600
-            ? 1_536 : 0
+            capability.strategy == .frozenFullReplay && bound >= 25_600 ? 1_536 : 0
         return max(configured, longHybridFloor)
     }
 

--- a/provider-swift/Sources/ProviderCore/KVCacheSSD/EngineV2Bridge+SSDPrefixCache.swift
+++ b/provider-swift/Sources/ProviderCore/KVCacheSSD/EngineV2Bridge+SSDPrefixCache.swift
@@ -48,7 +48,7 @@ extension EngineV2Bridge {
         #if canImport(os)
         let rateStr = String(format: "%.1f", rate)
         Self.ssdStatsLogger.info(
-            "prefix cache stats (engine=v2, tier=ssd, model=\(modelId, privacy: .public)): lookups=\(lookups) hits=\(s.hits) misses=\(s.misses) hitRate=\(rateStr, privacy: .public)% tokensSaved=\(s.tokensSaved) stages=\(s.stages) stagedBytes=\(s.stagedBytesInUse) blocksWritten=\(s.blocksWritten) bytesWritten=\(s.bytesWritten) donationsDropped=\(s.donationsDropped) rateLimited=\(s.writeRateLimited) corruptDropped=\(s.corruptDropped) evictions=\(s.evictions) ttlExpired=\(s.ttlExpired) entries=\(s.entries) bytesOnDisk=\(s.bytesOnDisk)"
+            "prefix cache stats (engine=v2, tier=ssd, model=\(modelId, privacy: .public)): lookups=\(lookups) hits=\(s.hits) misses=\(s.misses) hitRate=\(rateStr, privacy: .public)% tokensSaved=\(s.tokensSaved) stages=\(s.stages) stagedBytes=\(s.stagedBytesInUse) blocksWritten=\(s.blocksWritten) bytesWritten=\(s.bytesWritten) windowSidecars=\(s.windowSidecarsWritten) windowsRestored=\(s.windowsRestored) donationsDropped=\(s.donationsDropped) rateLimited=\(s.writeRateLimited) corruptDropped=\(s.corruptDropped) evictions=\(s.evictions) ttlExpired=\(s.ttlExpired) entries=\(s.entries) bytesOnDisk=\(s.bytesOnDisk)"
         )
         #endif
     }

--- a/provider-swift/Sources/ProviderCore/KVCacheSSD/SSDBlockStore.swift
+++ b/provider-swift/Sources/ProviderCore/KVCacheSSD/SSDBlockStore.swift
@@ -32,6 +32,13 @@
 // block shape descriptors (architecture — public), and createdAt. NO raw
 // chain hashes, NO token ids/counts, NO scope/salt values, NO request ids.
 //
+// The WS-4.2 windowed sidecar (`SSDWindowSidecar`) is the same file format
+// with the same crypto: only its filename tag domain and three optional
+// metadata fields (`windowKind` / `windowBase` / `windowTokens`) differ, and
+// its chunks carry sliding rather than full layers. Those fields add one
+// architectural fact — the sliding window size, already public — and one
+// position, both of which the block shape descriptors already imply.
+//
 // v1 `.darkbloom-kv` files are never read by this tier (different
 // subtree + suffix; they die with the legacy engine's deletion pass).
 
@@ -99,11 +106,23 @@ struct SSDBlockMetadata: Codable, Equatable, Sendable {
     let chunks: [SSDBlockChunkDescriptor]
     let chunkPlaintextSizes: [Int]
     let createdAt: Int64
+    /// WS-4.2 windowed sidecar discriminator (`SSDWindowSidecar.kind`), nil
+    /// on an ordinary full-attention block. Optional so a v0.7.5 block file
+    /// still decodes AND still re-encodes byte-identically: the synthesized
+    /// encoder omits nil, so the canonical-JSON AAD of every pre-existing
+    /// file is unchanged and no layout epoch bump is owed.
+    let windowKind: String?
+    /// Absolute position of this sidecar's first token. Authenticated (it is
+    /// in the GCM AAD), so a file cannot be replayed at another boundary.
+    let windowBase: Int?
+    /// Token count this sidecar carries (== `blockSize`).
+    let windowTokens: Int?
 
     init(
         lookupTag: String, weightHash: String, layoutEpoch: String, blockSize: Int,
         layerCount: Int, chunks: [SSDBlockChunkDescriptor], chunkPlaintextSizes: [Int],
-        createdAt: Int64 = Int64(Date().timeIntervalSince1970)
+        createdAt: Int64 = Int64(Date().timeIntervalSince1970),
+        windowKind: String? = nil, windowBase: Int? = nil, windowTokens: Int? = nil
     ) {
         self.schema = "darkbloom.kv.v3"
         self.lookupTag = lookupTag
@@ -114,6 +133,9 @@ struct SSDBlockMetadata: Codable, Equatable, Sendable {
         self.chunks = chunks
         self.chunkPlaintextSizes = chunkPlaintextSizes
         self.createdAt = createdAt
+        self.windowKind = windowKind
+        self.windowBase = windowBase
+        self.windowTokens = windowTokens
     }
 }
 

--- a/provider-swift/Sources/ProviderCore/KVCacheSSD/SSDLookupKeys.swift
+++ b/provider-swift/Sources/ProviderCore/KVCacheSSD/SSDLookupKeys.swift
@@ -8,6 +8,9 @@
 //     tag_i    = HMAC-SHA256(K_lookup,
 //                    "dbkv3-name-v1" ‖ u64le(len(saltUTF8)) ‖ saltUTF8
 //                                    ‖ chainHash_i)
+//     win_i    = HMAC-SHA256(K_lookup,
+//                    "dbkv3-window-v1" ‖ u64le(len(saltUTF8)) ‖ saltUTF8
+//                                      ‖ chainHash_i)
 //
 // * K_lookup is derived from the existing Secure-Enclave-rooted KEK
 //   (RFC 5869 Expand-only — the KEK is already a uniform 256-bit key, so
@@ -35,6 +38,12 @@ struct SSDLookupKeys: Sendable {
 
     static let hkdfInfo = Data("dbkv3-lookup-v1".utf8)
     static let nameDomainTag = Data("dbkv3-name-v1".utf8)
+    /// Domain tag for WS-4.2 windowed sidecars. A DIFFERENT domain, not a
+    /// different key: the sidecar of a block must land on its own filename
+    /// (both live in the same fan-out tree under the same grammar), and a
+    /// disk observer must not be able to pair a block with its sidecar —
+    /// which a shared domain plus a suffix would hand them for free.
+    static let windowNameDomainTag = Data("dbkv3-window-v1".utf8)
     /// Truncated-tag length used for filenames and the RAM index (128-bit;
     /// the full 256-bit tag rides inside the authenticated file metadata).
     static let truncatedTagLength = 16
@@ -51,8 +60,12 @@ struct SSDLookupKeys: Sendable {
     /// ("" ⇒ unscoped — length-prefixed, so it can never collide with a
     /// non-empty salt whose bytes happen to align).
     func tag(chainHash: Data, cacheSalt: String) -> Data {
+        tag(chainHash: chainHash, cacheSalt: cacheSalt, domain: Self.nameDomainTag)
+    }
+
+    private func tag(chainHash: Data, cacheSalt: String, domain: Data) -> Data {
         var message = Data()
-        message.append(Self.nameDomainTag)
+        message.append(domain)
         let saltBytes = Data(cacheSalt.utf8)
         var len = UInt64(saltBytes.count).littleEndian
         withUnsafeBytes(of: &len) { message.append(contentsOf: $0) }
@@ -64,6 +77,17 @@ struct SSDLookupKeys: Sendable {
     /// Truncated 16-byte tag (the RAM-index key and filename identity).
     func tag16(chainHash: Data, cacheSalt: String) -> Data {
         tag(chainHash: chainHash, cacheSalt: cacheSalt).prefix(Self.truncatedTagLength)
+    }
+
+    /// Full 32-byte lookup tag for the WINDOWED SIDECAR of one chain hash.
+    func windowTag(chainHash: Data, cacheSalt: String) -> Data {
+        tag(chainHash: chainHash, cacheSalt: cacheSalt, domain: Self.windowNameDomainTag)
+    }
+
+    /// Truncated 16-byte sidecar tag (RAM-index key and filename identity).
+    func windowTag16(chainHash: Data, cacheSalt: String) -> Data {
+        windowTag(chainHash: chainHash, cacheSalt: cacheSalt)
+            .prefix(Self.truncatedTagLength)
     }
 
     static func hex(_ data: Data) -> String {

--- a/provider-swift/Sources/ProviderCore/KVCacheSSD/SSDPrefixCache.swift
+++ b/provider-swift/Sources/ProviderCore/KVCacheSSD/SSDPrefixCache.swift
@@ -61,6 +61,12 @@ public struct SSDPrefixCacheStats: Sendable, Equatable {
     public var corruptDropped = 0
     public var evictions = 0
     public var ttlExpired = 0
+    /// WS-4.2. `windowSidecarsWritten` is a SUBSET of `blocksWritten` (they
+    /// share the write-behind consumer); `windowsRestored` counts adoptions
+    /// whose sliding window came off disk instead of being replayed. With no
+    /// canary fleet these two are how the sidecar is observed in the field.
+    public var windowSidecarsWritten = 0
+    public var windowsRestored = 0
     /// Index size (filled at snapshot time).
     public var entries = 0
     public var bytesOnDisk = 0
@@ -74,7 +80,8 @@ final class SSDPrefixCacheStatsBox: @unchecked Sendable {
         hits: Int = 0, misses: Int = 0, tokensSaved: Int = 0, stages: Int = 0,
         stagedBytesDelta: Int = 0, blocksWritten: Int = 0, bytesWritten: Int = 0,
         donationsDropped: Int = 0, writeRateLimited: Int = 0, corruptDropped: Int = 0,
-        evictions: Int = 0, ttlExpired: Int = 0
+        evictions: Int = 0, ttlExpired: Int = 0,
+        windowSidecarsWritten: Int = 0, windowsRestored: Int = 0
     ) {
         lock.withLock {
             stats.hits += hits
@@ -89,6 +96,8 @@ final class SSDPrefixCacheStatsBox: @unchecked Sendable {
             stats.corruptDropped += corruptDropped
             stats.evictions += evictions
             stats.ttlExpired += ttlExpired
+            stats.windowSidecarsWritten += windowSidecarsWritten
+            stats.windowsRestored += windowsRestored
         }
     }
 
@@ -129,6 +138,12 @@ public final class SSDPrefixCache: CBv2PrefixCache, SSDEvictableStore, @unchecke
         let minEffectiveTokens: Int
         let maxStageBytes: Int
         let maxStageMillis: Int
+        /// WS-4.2 sliding-window sidecar geometry, or nil when the feature is
+        /// off (`SSDPrefixCachePolicy.windowSidecarFlag`, default) or the
+        /// model's window does not tile into whole blocks. One field rather
+        /// than a flag plus a derivation, so the write and read paths cannot
+        /// disagree about whether this cache has sidecars.
+        let windowSidecar: SSDWindowSidecarGeometry?
         let nowSeconds: @Sendable () -> Int64
 
         init(
@@ -146,6 +161,7 @@ public final class SSDPrefixCache: CBv2PrefixCache, SSDEvictableStore, @unchecke
             minEffectiveTokens: Int,
             maxStageBytes: Int,
             maxStageMillis: Int,
+            windowSidecar: SSDWindowSidecarGeometry? = nil,
             nowSeconds: @escaping @Sendable () -> Int64
         ) {
             self.modelId = modelId
@@ -162,6 +178,7 @@ public final class SSDPrefixCache: CBv2PrefixCache, SSDEvictableStore, @unchecke
             self.minEffectiveTokens = minEffectiveTokens
             self.maxStageBytes = maxStageBytes
             self.maxStageMillis = maxStageMillis
+            self.windowSidecar = windowSidecar
             self.nowSeconds = nowSeconds
         }
     }
@@ -184,6 +201,11 @@ public final class SSDPrefixCache: CBv2PrefixCache, SSDEvictableStore, @unchecke
     private final class StagedEntry {
         let matched: Int
         let prefix: [(keys: MLXArray, values: MLXArray, offset: Int)?]
+        /// WS-4.2: the donor's sliding window at `matched`, restored from
+        /// windowed sidecars, or nil when the adopter must replay. Indexed by
+        /// model layer, nil at every non-sliding slot — the shape WS-4.1's
+        /// `restoreWindow(keys:values:base:)` consumes.
+        let window: [SSDWindowSidecar.Window?]?
         let deviceBytes: Int
         let cacheEpoch: String?
         /// Requests attached to this entry that have not yet been balanced.
@@ -206,10 +228,12 @@ public final class SSDPrefixCache: CBv2PrefixCache, SSDEvictableStore, @unchecke
 
         init(
             matched: Int, prefix: [(keys: MLXArray, values: MLXArray, offset: Int)?],
+            window: [SSDWindowSidecar.Window?]?,
             deviceBytes: Int, cacheEpoch: String?, firstTicket: String, reservationKey: String
         ) {
             self.matched = matched
             self.prefix = prefix
+            self.window = window
             self.deviceBytes = deviceBytes
             self.cacheEpoch = cacheEpoch
             self.openTickets = [firstTicket]
@@ -677,8 +701,15 @@ public final class SSDPrefixCache: CBv2PrefixCache, SSDEvictableStore, @unchecke
             return
         }
         var snapshots: [(keys: MLXArray, values: MLXArray, offset: Int)?] = []
+        var windows: [SSDWindowSidecar.Window?] = []
         snapshots.reserveCapacity(layerKinds.count)
+        windows.reserveCapacity(layerKinds.count)
         for (i, kind) in layerKinds.enumerated() {
+            // WS-4.2: sliding rows are NOT cacheable as blocks, but their ring
+            // is exactly what a windowed sidecar persists. Probed through the
+            // donor seam so contiguous and (once WS-4.1 lands) paged rows both
+            // participate without this path knowing which backend it holds.
+            windows.append((state[i] as? SSDWindowSnapshotting)?.windowSnapshot())
             guard Self.isCacheable(kind), let seq = state[i] else {
                 snapshots.append(nil)
                 continue
@@ -692,6 +723,7 @@ public final class SSDPrefixCache: CBv2PrefixCache, SSDEvictableStore, @unchecke
         donate(
             tokens: tokens,
             snapshots: snapshots,
+            windowSnapshots: windows,
             layerKinds: layerKinds,
             cacheSalt: cacheSalt,
             receiptRequestID: nil,
@@ -743,9 +775,34 @@ public final class SSDPrefixCache: CBv2PrefixCache, SSDEvictableStore, @unchecke
             settlement: settlement)
     }
 
+    /// Donation with an explicit sliding-window payload — the WS-4.2 entry
+    /// point for a caller that already holds the donor's per-layer window
+    /// (`PagedSequenceKV.windowSnapshot()` shape). `nil` window entries are
+    /// ignored; a sidecar is written only when EVERY storage-owning sliding
+    /// layer is present and they agree on one absolute span.
+    func donate(
+        requestID: CBv2RequestID?,
+        tokens: [Int],
+        snapshots: [(keys: MLXArray, values: MLXArray, offset: Int)?],
+        windowSnapshots: [SSDWindowSidecar.Window?],
+        layerKinds: [CBv2LayerKind],
+        cacheSalt: String?
+    ) {
+        let settlement = PrefixCacheDonationSettlement(recorder: donationRecorder)
+        donate(
+            tokens: tokens,
+            snapshots: snapshots,
+            windowSnapshots: windowSnapshots,
+            layerKinds: layerKinds,
+            cacheSalt: cacheSalt,
+            receiptRequestID: requestID,
+            settlement: settlement)
+    }
+
     private func donate(
         tokens: [Int],
         snapshots: [(keys: MLXArray, values: MLXArray, offset: Int)?],
+        windowSnapshots: [SSDWindowSidecar.Window?]? = nil,
         layerKinds: [CBv2LayerKind],
         cacheSalt: String?,
         receiptRequestID: CBv2RequestID?,
@@ -895,14 +952,34 @@ public final class SSDPrefixCache: CBv2PrefixCache, SSDEvictableStore, @unchecke
             SSDBlockStore.setAttributesIfSafe(
                 [.modificationDate: touchDate], at: url, under: config.root)
         }
+        // WS-4.2 sidecars are claimed here, BEFORE the all-deduped early
+        // return: a repeat donation of an already-durable prefix still ends at
+        // a different absolute offset, so it covers block boundaries no
+        // earlier donation could. Skipping it would leave permanent holes in
+        // the window tiling.
+        var blocks: [SSDBlockWrite] = []
+        var totalBytes = 0
+        appendWindowSidecars(
+            into: &blocks, totalBytes: &totalBytes,
+            windowSnapshots: windowSnapshots, layerKinds: layerKinds,
+            chainHashes: hashes, cacheSalt: salt,
+            blockCount: min(blockCount, maxPersistBlocks), now: now)
+
         guard !newBlockIndices.isEmpty else {
             settlement.settle(skippedInFlight ? .alreadyQueued : .alreadyDurable)
             // Every block is already durable or owned by an earlier queued
             // write. Still pass correlated donations through the serial queue
             // so prior writes and maintenance settle before a ready receipt.
-            if onDurable != nil {
-                _ = writeBehind.submit(SSDDonationJob(
-                    blocks: [], totalBytes: 0, onDurable: onDurable))
+            // Already settled above, so the job's outcome is a no-op.
+            if onDurable != nil || !blocks.isEmpty {
+                let result = writeBehind.submitWithResult(SSDDonationJob(
+                    blocks: blocks, totalBytes: totalBytes, onDurable: onDurable))
+                if result != .accepted, !blocks.isEmpty {
+                    lock.withLock {
+                        for block in blocks { inFlightWrites.remove(block.tag16) }
+                    }
+                    statsBox.add(donationsDropped: blocks.count)
+                }
             }
             return
         }
@@ -919,14 +996,17 @@ public final class SSDPrefixCache: CBv2PrefixCache, SSDEvictableStore, @unchecke
         guard writeBehind.mightAcceptWrite(bytes: perBlockBytes) else {
             lock.withLock {
                 for i in newBlockIndices { inFlightWrites.remove(tags16[i]) }
+                // Sidecars claimed above go back too — the bucket is drained
+                // for everything, and a stranded tag can never be rewritten.
+                for block in blocks { inFlightWrites.remove(block.tag16) }
             }
             // Attribute to the write cap (same accounting as the consumer's
             // per-block tryConsume drop) so `rateLimited` stats stay
             // truthful now that this pre-check intercepts most
             // cap-exhausted donations.
             statsBox.add(
-                donationsDropped: newBlockIndices.count,
-                writeRateLimited: newBlockIndices.count)
+                donationsDropped: newBlockIndices.count + blocks.count,
+                writeRateLimited: newBlockIndices.count + blocks.count)
             settlement.settle(.writeRateLimited)
             return
         }
@@ -934,8 +1014,6 @@ public final class SSDPrefixCache: CBv2PrefixCache, SSDEvictableStore, @unchecke
         // Per-block extraction: device slice → eval → compact host Data in
         // engine-native [B, kvHeads, block, headDim] layout. Device arrays
         // are dropped as soon as the bytes are copied out.
-        var blocks: [SSDBlockWrite] = []
-        var totalBytes = 0
         for b in newBlockIndices {
             let t0 = b * config.blockSize
             let t1 = t0 + config.blockSize
@@ -993,6 +1071,86 @@ public final class SSDPrefixCache: CBv2PrefixCache, SSDEvictableStore, @unchecke
             statsBox.add(donationsDropped: blocks.count)
             settlement.settle(submitResult == .closed ? .cacheClosed : .writeQueueFull)
             return
+        }
+    }
+
+    /// WS-4.2: claim and extract the windowed sidecars this donation covers,
+    /// appending them to the same write-behind job as the blocks.
+    ///
+    /// Coverage is bounded by physics, not policy: a donating row's ring holds
+    /// exactly the last `W` positions ending at its own absolute offset, which
+    /// is a mid-block position for all but 1 in `blockSize` requests. So one
+    /// donation covers `W/blockSize − 1` whole blocks in the general case and
+    /// `W/blockSize` when it happens to stop on a boundary. Successive
+    /// donations end at different offsets and their covered ranges TILE, which
+    /// is what eventually completes a boundary's window. A boundary whose
+    /// tiling is incomplete is simply not restorable, and the adopter replays.
+    private func appendWindowSidecars(
+        into blocks: inout [SSDBlockWrite],
+        totalBytes: inout Int,
+        windowSnapshots: [SSDWindowSidecar.Window?]?,
+        layerKinds: [CBv2LayerKind],
+        chainHashes: [Data],
+        cacheSalt: String,
+        blockCount: Int,
+        now: Int64
+    ) {
+        guard let geometry = config.windowSidecar,
+            let windows = windowSnapshots,
+            let span = SSDWindowSidecar.span(windows: windows, geometry: geometry)
+        else { return }
+        let covered = geometry.coveredBlocks(
+            base: span.base, tokens: span.tokens,
+            blockCount: min(blockCount, chainHashes.count))
+        guard !covered.isEmpty else { return }
+
+        var claimed: [(block: Int, tag16: Data, fullTag: Data)] = []
+        lock.withLock {
+            guard !closed else { return }
+            for b in covered {
+                let full = lookupKeys.windowTag(chainHash: chainHashes[b], cacheSalt: cacheSalt)
+                let tag16 = full.prefix(SSDLookupKeys.truncatedTagLength)
+                if index.contains(tag16: tag16) || inFlightWrites.contains(tag16) { continue }
+                inFlightWrites.insert(tag16)
+                claimed.append((b, tag16, full))
+            }
+        }
+        guard !claimed.isEmpty else { return }
+
+        var written: Set<Data> = []
+        for entry in claimed {
+            guard let payload = SSDWindowSidecar.extract(
+                blockIndex: entry.block, windows: windows,
+                geometry: geometry, base: span.base)
+            else { continue }
+            let bytes = payload.sizes.reduce(0, +)
+            guard bytes > 0 else { continue }
+            let metadata = SSDBlockMetadata(
+                lookupTag: SSDLookupKeys.hex(entry.fullTag),
+                weightHash: config.weightHash,
+                layoutEpoch: config.layoutEpoch,
+                blockSize: config.blockSize,
+                layerCount: layerKinds.count,
+                chunks: payload.descriptors,
+                chunkPlaintextSizes: payload.sizes,
+                createdAt: now,
+                windowKind: SSDWindowSidecar.kind,
+                windowBase: entry.block * config.blockSize,
+                windowTokens: config.blockSize)
+            blocks.append(
+                SSDBlockWrite(
+                    tag16: entry.tag16, tag16Hex: SSDLookupKeys.hex(entry.tag16),
+                    metadata: metadata, chunks: payload.chunks, plaintextBytes: bytes))
+            totalBytes += bytes
+            written.insert(entry.tag16)
+        }
+        guard written.count != claimed.count else { return }
+        // An extraction that failed must give its tag back, or the block can
+        // never be rewritten for the life of the process.
+        lock.withLock {
+            for entry in claimed where !written.contains(entry.tag16) {
+                inFlightWrites.remove(entry.tag16)
+            }
         }
     }
 
@@ -1073,6 +1231,11 @@ public final class SSDPrefixCache: CBv2PrefixCache, SSDEvictableStore, @unchecke
             fullTags.append(full)
             tags16.append(full.prefix(SSDLookupKeys.truncatedTagLength))
         }
+        // WS-4.2: the terminal-four sidecars that would restore the donor's
+        // window at each candidate boundary. Probed inside the trim loop so
+        // their bytes are inside the stage byte/time caps rather than added
+        // on top of a run those caps already saturated.
+        let windowGeometry = config.windowSidecar
 
         // Longest contiguous run, trimmed to the stage caps (bytes/time)
         // while it still clears the benefit floor.
@@ -1080,6 +1243,7 @@ public final class SSDPrefixCache: CBv2PrefixCache, SSDEvictableStore, @unchecke
         guard k > 0 else { return finish(.missAbsent) }
         var runBytes = 0
         var runSizes: [Int] = []
+        var windowTags: [Data] = []
         while k > 0 {
             let matched = k * config.blockSize
             let effective = matched - min(config.adoptionBoundTokens, matched)
@@ -1095,6 +1259,20 @@ public final class SSDPrefixCache: CBv2PrefixCache, SSDEvictableStore, @unchecke
                 let (sum, overflow) = runBytes.addingReportingOverflow(max(0, size))
                 guard !overflow else { return finish(.skippedCapacity) }
                 runBytes = sum
+            }
+            windowTags = windowSidecarTags(
+                geometry: windowGeometry, chainHashes: hashes, cacheSalt: salt, blocks: k)
+            if let windowSizes = index.fileBytes(tags16: windowTags[...]), !windowTags.isEmpty {
+                for size in windowSizes {
+                    let (sum, overflow) = runBytes.addingReportingOverflow(max(0, size))
+                    guard !overflow else { return finish(.skippedCapacity) }
+                    runBytes = sum
+                }
+            } else {
+                // Incomplete tiling (or a raced eviction): a PARTIAL window is
+                // not exact, so the whole window is dropped and the adopter
+                // replays. Never shortens the block run.
+                windowTags = []
             }
             if runBytes <= config.maxStageBytes,
                 SSDPrefixCachePolicy.estimatedStageMillis(bytes: runBytes) <= config.maxStageMillis
@@ -1243,8 +1421,30 @@ public final class SSDPrefixCache: CBv2PrefixCache, SSDEvictableStore, @unchecke
             await releaseReservation(reservationKey)
             return finish(.skippedPolicy)
         }
+        // WS-4.2: restore the donor's sliding window from the terminal-four
+        // sidecars whose bytes the trim loop already budgeted. Attempted only
+        // on an unshortened run — a corruption-shortened boundary has a
+        // different tiling than the one accounted for, and a PARTIAL window is
+        // not exact. Any failure drops the window ALONE: the block adoption
+        // stands and the adopter replays, exactly as it does today.
+        var restoredWindow: [SSDWindowSidecar.Window?]?
+        if let geometry = windowGeometry, usableBlocks == k, !windowTags.isEmpty {
+            restoredWindow = readWindowSidecars(
+                geometry: geometry, chainHashes: hashes, cacheSalt: salt, blocks: usableBlocks)
+        }
         var exactDeviceBytes = 0
         for entry in prefix {
+            guard let entry else { continue }
+            let (entryBytes, entryOverflow) = entry.keys.nbytes.addingReportingOverflow(
+                entry.values.nbytes)
+            let (total, totalOverflow) = exactDeviceBytes.addingReportingOverflow(entryBytes)
+            guard !entryOverflow, !totalOverflow else {
+                await releaseReservation(reservationKey)
+                return finish(.skippedCapacity)
+            }
+            exactDeviceBytes = total
+        }
+        for entry in restoredWindow ?? [] {
             guard let entry else { continue }
             let (entryBytes, entryOverflow) = entry.keys.nbytes.addingReportingOverflow(
                 entry.values.nbytes)
@@ -1317,10 +1517,13 @@ public final class SSDPrefixCache: CBv2PrefixCache, SSDEvictableStore, @unchecke
                 return .attached(deviceBytes: existing.deviceBytes)
             }
             stagedEntries[usedTag] = StagedEntry(
-                matched: matched, prefix: prefix, deviceBytes: exactDeviceBytes,
+                matched: matched, prefix: prefix, window: restoredWindow,
+                deviceBytes: exactDeviceBytes,
                 cacheEpoch: stageEpoch, firstTicket: requestID, reservationKey: reservationKey)
             tickets[requestID] = usedTag
-            statsBox.add(stages: 1, stagedBytesDelta: exactDeviceBytes)
+            statsBox.add(
+                stages: 1, stagedBytesDelta: exactDeviceBytes,
+                windowsRestored: restoredWindow == nil ? 0 : 1)
             return .created
         }
         switch resolution {
@@ -1339,13 +1542,17 @@ public final class SSDPrefixCache: CBv2PrefixCache, SSDEvictableStore, @unchecke
             break  // reservation is now owned by the staged entry
         }
         // Sliding TTL: bump index recency AND file mtimes so warmth
-        // survives a restart (the scan seeds lastAccess from mtime).
+        // survives a restart (the scan seeds lastAccess from mtime). The
+        // window sidecars ride the same bump — letting them expire under a
+        // still-warm block run would silently re-arm the 25,600-token replay
+        // and pay their write wear again on the next donation.
         let now = config.nowSeconds()
         index.touch(tags16: tags16.prefix(usableBlocks), now: now)
+        index.touch(tags16: windowTags, now: now)
         let touchDate = Date(timeIntervalSince1970: TimeInterval(now))
-        for i in 0 ..< usableBlocks {
+        for tag16 in tags16.prefix(usableBlocks) + windowTags {
             let url = SSDBlockStore.fileURL(
-                root: config.root, tag16Hex: SSDLookupKeys.hex(tags16[i]))
+                root: config.root, tag16Hex: SSDLookupKeys.hex(tag16))
             SSDBlockStore.setAttributesIfSafe(
                 [.modificationDate: touchDate], at: url, under: config.root)
         }
@@ -1363,6 +1570,92 @@ public final class SSDPrefixCache: CBv2PrefixCache, SSDEvictableStore, @unchecke
             requestID: ticketKey(requestID),
             promptTokens: promptTokens,
             cacheScope: cacheScope)
+    }
+
+    /// Truncated sidecar tags tiling the window that ends at block boundary
+    /// `blocks`, oldest first. Empty when the boundary is shorter than one
+    /// window — there is nothing to restore below `W` tokens, because the row
+    /// legitimately has no older entries and cold prefill is already exact.
+    private func windowSidecarTags(
+        geometry: SSDWindowSidecarGeometry?,
+        chainHashes: [Data],
+        cacheSalt: String,
+        blocks: Int
+    ) -> [Data] {
+        guard let geometry, blocks >= geometry.blocksPerWindow, blocks <= chainHashes.count
+        else { return [] }
+        return (blocks - geometry.blocksPerWindow ..< blocks).map {
+            lookupKeys.windowTag16(chainHash: chainHashes[$0], cacheSalt: cacheSalt)
+        }
+    }
+
+    /// Read, authenticate and reassemble the sliding window that ends at
+    /// block boundary `blocks`. nil ⇒ the adopter replays.
+    ///
+    /// An unreadable sidecar is deleted and de-indexed exactly like an
+    /// unreadable block, but it never shortens the block run: the sidecar is
+    /// an accelerator, and losing it costs replay, not correctness.
+    private func readWindowSidecars(
+        geometry: SSDWindowSidecarGeometry,
+        chainHashes: [Data],
+        cacheSalt: String,
+        blocks: Int
+    ) -> [SSDWindowSidecar.Window?]? {
+        let first = blocks - geometry.blocksPerWindow
+        guard first >= 0, blocks <= chainHashes.count else { return nil }
+        var payloads: [(metadata: SSDBlockMetadata, chunks: [Data])] = []
+        payloads.reserveCapacity(geometry.blocksPerWindow)
+        for b in first ..< blocks {
+            let fullTag = lookupKeys.windowTag(chainHash: chainHashes[b], cacheSalt: cacheSalt)
+            let tag16 = fullTag.prefix(SSDLookupKeys.truncatedTagLength)
+            let url = SSDBlockStore.fileURL(
+                root: config.root, tag16Hex: SSDLookupKeys.hex(tag16))
+            do {
+                let (metadata, chunks) = try SSDBlockStore.read(from: url, kekKey: kekKey)
+                guard metadata.weightHash == config.weightHash,
+                    metadata.layoutEpoch == config.layoutEpoch,
+                    metadata.lookupTag == SSDLookupKeys.hex(fullTag),
+                    SSDWindowSidecar.isBound(
+                        metadata,
+                        expectedBase: b * config.blockSize,
+                        geometry: geometry)
+                else {
+                    throw SSDBlockStoreError.bindingMismatch(
+                        "window sidecar weightHash/layoutEpoch/tag/base binding")
+                }
+                payloads.append((metadata, chunks))
+            } catch {
+                statsBox.add(corruptDropped: 1)
+                _ = performDestructiveChange {
+                    _ = SSDBlockStore.removeItemIfSafe(at: url, under: config.root)
+                    index.remove(tag16: tag16)
+                }
+                #if canImport(os)
+                Self.logger.warning(
+                    "ssd prefix cache (\(self.config.modelId, privacy: .public)): dropped unreadable window sidecar (\(String(describing: error), privacy: .public)) — replay fallback")
+                #endif
+                return nil
+            }
+        }
+        return SSDWindowSidecar.rebuildWindow(
+            blocks: payloads,
+            geometry: geometry,
+            base: blocks * config.blockSize - geometry.windowTokens,
+            dtypeByName: Self.dtypeByName)
+    }
+
+    /// WS-4.2 adoption seam: the donor's sliding window staged for
+    /// `requestID`, indexed by model layer. nil ⇒ nothing was restored and the
+    /// adopter must replay. Consumed by `restoreWindow(keys:values:base:)`.
+    func stagedWindow(requestID: String) -> [SSDWindowSidecar.Window?]? {
+        lock.withLock {
+            guard let tag = tickets[requestID], let staged = stagedEntries[tag] else { return nil }
+            return staged.window
+        }
+    }
+
+    func stagedWindow(requestID: CBv2RequestID) -> [SSDWindowSidecar.Window?]? {
+        stagedWindow(requestID: ticketKey(requestID))
     }
 
     /// Bridge backstop: release a request's staging ticket on every

--- a/provider-swift/Sources/ProviderCore/KVCacheSSD/SSDPrefixCacheFactory.swift
+++ b/provider-swift/Sources/ProviderCore/KVCacheSSD/SSDPrefixCacheFactory.swift
@@ -248,12 +248,27 @@ enum SSDPrefixCacheFactory {
             #endif
             return nil
         }
+        // WS-4.2: sidecar geometry is nil unless the operator knob is on AND
+        // the layout tiles into whole-block sidecars. When it is non-nil the
+        // residency is `.restoredFromSidecar`, which collapses the replay
+        // bound — and, through it, the long-hybrid benefit floor.
+        let windowResidency = PrefixCachePolicy.windowResidency(
+            layerKinds: layerKinds,
+            backendSelection: prefixReuseCapability.backend == .pagedFP16 ? .paged : .contiguous,
+            environment: environment)
+        let windowSidecar = windowResidency == .restoredFromSidecar
+            ? SSDWindowSidecarGeometry.derive(layerKinds: layerKinds, blockSize: blockSize)
+            : nil
+        let adoptionBoundTokens = PrefixCachePolicy.adoptionBoundTokens(
+            capability: prefixReuseCapability,
+            layerKinds: layerKinds,
+            windowResidency: windowResidency)
         let config = SSDPrefixCache.Config(
             modelId: modelId,
             promptContractID: promptContractID,
             weightHash: weightHash,
             blockSize: blockSize,
-            adoptionBoundTokens: prefixReuseCapability.conservativeReplayBoundTokens,
+            adoptionBoundTokens: adoptionBoundTokens,
             nominalFullKVBytesPerToken: prefixReuseCapability.fullKVBytesPerToken,
             layoutEpoch: layoutEpoch,
             epochStore: epochStore,
@@ -262,9 +277,11 @@ enum SSDPrefixCacheFactory {
             ttlSeconds: SSDPrefixCachePolicy.ttlSeconds(environment: environment),
             minEffectiveTokens: PrefixCachePolicy.minEffectiveTokens(
                 capability: prefixReuseCapability,
+                adoptionBoundTokens: adoptionBoundTokens,
                 environment: environment),
             maxStageBytes: SSDPrefixCachePolicy.maxStageBytes(environment: environment),
             maxStageMillis: SSDPrefixCachePolicy.maxStageMillis(environment: environment),
+            windowSidecar: windowSidecar,
             nowSeconds: { Int64(Date().timeIntervalSince1970) })
         let cache = SSDPrefixCache(
             config: config,

--- a/provider-swift/Sources/ProviderCore/KVCacheSSD/SSDPrefixCachePolicy.swift
+++ b/provider-swift/Sources/ProviderCore/KVCacheSSD/SSDPrefixCachePolicy.swift
@@ -76,6 +76,30 @@ enum SSDPrefixCachePolicy {
         return n
     }
 
+    // MARK: - Windowed sidecar (WS-4.2)
+
+    /// Persist and restore the sliding window alongside the full-attention
+    /// blocks. **Default OFF.** WS-4.2 lands the format, the write/read paths
+    /// and the residency plumbing; turning it on moves gemma-4's donation
+    /// floor from 27,137 tokens to `blockSize + minEffectiveTokens`, which is
+    /// a separate, deliberate step that also needs WS-4.1's
+    /// `restoreWindow(keys:values:base:)` on the paged row.
+    ///
+    /// Costs it turns on, measured against gemma-4's real geometry (25
+    /// sliding layers × 8 KV heads × 256 head dim vs 5 full layers × 2 × 512,
+    /// i.e. 204,800 vs 20,480 fp16 bytes per token — a 10:1 ratio):
+    /// +52.4 MB of disk per newly covered 256-token block and +209.7 MB on
+    /// the terminal-four stage read.
+    static let windowSidecarFlag = "DARKBLOOM_PREFIX_CACHE_SSD_WINDOW_SIDECAR"
+
+    static func windowSidecarEnabled(
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> Bool {
+        let raw = environment[windowSidecarFlag]?
+            .trimmingCharacters(in: .whitespaces).lowercased()
+        return raw == "1" || raw == "true" || raw == "yes" || raw == "on"
+    }
+
     /// Per-adoption staged-bytes cap (bounds the transient staging RAM and
     /// the pre-submit read).
     static let maxStageMBFlag = "DARKBLOOM_PREFIX_CACHE_SSD_MAX_STAGE_MB"

--- a/provider-swift/Sources/ProviderCore/KVCacheSSD/SSDWindowSidecar.swift
+++ b/provider-swift/Sources/ProviderCore/KVCacheSSD/SSDWindowSidecar.swift
@@ -1,0 +1,407 @@
+// Copyright © 2026 Eigen Labs.
+//
+// WS-4.2 — the windowed sidecar: sliding-window K/V persisted ALONGSIDE the
+// existing full-attention DBK3 blocks, so an adopter can RESTORE a donor's
+// sliding window instead of replaying it.
+//
+// Why this exists
+// ---------------
+// A cache hit restores the 5 full-attention layers of gemma-4 exactly, but
+// its 25 sliding rows start EMPTY at the matched boundary. Their hidden
+// states feed the downstream full layers, whose K/V writes persist and change
+// later logits — so the engine must replay `windowCount × maxWindow` = 25,600
+// tokens before the row is bit-exact (`2026-07-19-frozen-full-prefix-cache-
+// proof.md`). Against gemma-4's p50 prompt of 979 tokens the resulting
+// donation floor of 27,137 makes 2.3% of its traffic donatable.
+//
+// Persist the window and the replay disappears.
+//
+// Format
+// ------
+// A sidecar is an ORDINARY DBK3 FILE — same magic, same format version 3,
+// same per-file IV, same wrapped-DEK/KEK scheme, same canonical-JSON AAD,
+// same `<root>/<tagHex[0..2]>/<tagHex>.dbk3` pathname grammar. It differs in
+// exactly two ways:
+//
+//   1. its 128-bit filename tag comes from a SEPARATE HMAC domain
+//      (`SSDLookupKeys.windowTag`), so a block and its sidecar never collide
+//      and a disk observer cannot correlate the pair without K_lookup;
+//   2. its authenticated metadata carries `windowKind` / `windowBase` /
+//      `windowTokens`, and its chunks are the SLIDING layers' K/V rather than
+//      the full layers'.
+//
+// Everything downstream is therefore inherited verbatim: the RAM index, the
+// sliding TTL, box-wide LRU eviction, the startup directory scan (the
+// recovery protocol), the temp sweep, the write-behind pipeline, and the
+// low-disk / endurance guards. A sidecar that is evicted or fails to
+// authenticate simply is not there, and the adopter falls back to replay.
+//
+// Granularity: ONE SIDECAR PER BLOCK, not per window
+// --------------------------------------------------
+// A sidecar holds one 256-token block's worth of sliding K/V. The window at
+// boundary M is assembled from the `W / blockSize` sidecars that tile
+// [M − W, M) — "read-terminal-four" for gemma-4.
+//
+// Per-block beats one-file-per-window for two independent reasons:
+//
+//   * Dedupe. Sidecars are content-addressed off the same chain hash as the
+//     block, so a token's sliding K/V is stored ONCE across every donation
+//     that shares the prefix. Window-sized files written at successive turn
+//     boundaries would duplicate up to `W − Δ` tokens per turn.
+//   * Coverage. A donating row's ring holds exactly the last W positions
+//     ending at its own `absoluteOffset`, which is NOT block-aligned (the
+//     request stopped mid-block). One donation can therefore only ever cover
+//     `floor(W/blockSize) − 1` whole blocks — three of gemma-4's four. But
+//     successive donations end at different offsets and their covered ranges
+//     TILE: a donation at offset o covers blocks
+//     `[ceil((o−W)/blockSize), floor(o/blockSize))`, so two donations
+//     straddling a boundary between them supply all four blocks it needs.
+//     A window-granular file can never be assembled from two donors.
+//
+// `coveredBlocks` below is that arithmetic, and it is the load-bearing
+// correctness rule of this file: a PARTIAL window restore is NOT exact (the
+// missing oldest entries are invisible to attention and cannot be recovered
+// by a short replay — recovering them is the full `windowCount × maxWindow`
+// problem again), so a boundary is adoptable only when EVERY tiling block is
+// present.
+
+import Foundation
+import MLX
+import MLXLMCommon
+
+// MARK: - Residency
+
+/// Where an adopter's sliding rows come from at the matched boundary. This is
+/// the provider-side residency input to the replay bound; the engine-side
+/// `CBv2PrefixResidencyClass` that WS-4.1 threads through `derive`/`plan` is a
+/// separate, engine-owned symbol and is deliberately not squatted on here.
+enum SSDWindowResidency: String, Sendable, Equatable, CaseIterable {
+    /// Sliding rows start empty at the boundary — the shipped behaviour. The
+    /// engine must replay `windowCount × maxWindow` tokens.
+    case replayed
+    /// Sliding rows are restored from windowed sidecars, so there is nothing
+    /// to replay. Requires `PagedSequenceKV.restoreWindow(keys:values:base:)`
+    /// (WS-4.1) on paged, or `CBv2WindowedSequenceKV` adoption on contiguous.
+    case restoredFromSidecar = "restored_from_sidecar"
+}
+
+// MARK: - Geometry
+
+/// The sliding-layer shape a model's sidecars must carry, derived once from
+/// the same `[CBv2LayerKind]` that produces the layout epoch.
+struct SSDWindowSidecarGeometry: Sendable, Equatable {
+
+    /// One storage-owning sliding-window layer.
+    struct Layer: Sendable, Equatable {
+        let index: Int
+        let kvHeads: Int
+        let headDim: Int
+    }
+
+    /// The model's largest sliding window, in tokens (`W`).
+    let windowTokens: Int
+    let blockSize: Int
+    /// `W / blockSize` — how many sidecars tile one window ("terminal four").
+    let blocksPerWindow: Int
+    /// Storage-owning sliding layers, ascending by model layer index.
+    let layers: [Layer]
+    /// Total model layer slots, so a rebuild can produce a full-width array
+    /// without the model (mirrors `SSDBlockMetadata.layerCount`).
+    let layerCount: Int
+
+    /// Derive the sidecar geometry, or nil when this model cannot have one.
+    ///
+    /// Fail-closed cases, each of which would otherwise produce a silently
+    /// inexact restore:
+    ///
+    ///  * no sliding layers ⇒ nothing to persist (replay bound is already 0);
+    ///  * MIXED window sizes ⇒ one payload cannot serve two windows;
+    ///  * `W < blockSize` or `W % blockSize != 0` ⇒ the window does not tile
+    ///    into whole blocks, and a donating ring never holds a whole block
+    ///    beyond its window (gpt-oss-20b's `W = 128` lands here and keeps its
+    ///    1,536-token replay bound);
+    ///  * a KV-shared sliding layer ⇒ it borrows storage from its source, so
+    ///    persisting it would double-write; the source layer is persisted and
+    ///    the borrow is re-established by the engine, exactly as
+    ///    `SSDPrefixCache.isCacheable` treats shared FULL layers.
+    static func derive(
+        layerKinds: [CBv2LayerKind], blockSize: Int
+    ) -> SSDWindowSidecarGeometry? {
+        guard blockSize > 0, !layerKinds.isEmpty else { return nil }
+        var window = 0
+        var layers: [Layer] = []
+        for (index, kind) in layerKinds.enumerated() {
+            guard case .slidingWindow(let w) = kind.attention else { continue }
+            guard w > 0 else { return nil }
+            if window == 0 {
+                window = w
+            } else if window != w {
+                return nil  // mixed windows: one payload cannot serve both
+            }
+            guard kind.sharesKVWithLayer == nil else { continue }
+            guard kind.kvHeads > 0, kind.headDim > 0 else { return nil }
+            layers.append(Layer(index: index, kvHeads: kind.kvHeads, headDim: kind.headDim))
+        }
+        guard window >= blockSize, window % blockSize == 0, !layers.isEmpty else { return nil }
+        return SSDWindowSidecarGeometry(
+            windowTokens: window,
+            blockSize: blockSize,
+            blocksPerWindow: window / blockSize,
+            layers: layers,
+            layerCount: layerKinds.count)
+    }
+
+    /// Plaintext bytes one sidecar carries, for a given element width.
+    func bytesPerBlock(elementSize: Int) -> Int {
+        var total = 0
+        for layer in layers {
+            total += 2 * layer.kvHeads * blockSize * layer.headDim * elementSize
+        }
+        return total
+    }
+
+    /// Plaintext bytes an adoption reads to restore one window
+    /// (`blocksPerWindow` sidecars) — the "+stage read" of WS-4.2.
+    func windowReadBytes(elementSize: Int) -> Int {
+        bytesPerBlock(elementSize: elementSize) * blocksPerWindow
+    }
+
+    /// Block indices whose ENTIRE token span lies inside the donated window
+    /// `[base, base + tokens)`, clamped to `[0, blockCount)`.
+    ///
+    /// This is the whole coverage rule. A donating row retains exactly the
+    /// last `W` positions ending at its own absolute offset, so `base` is
+    /// almost never block-aligned and the leading partial block is dropped.
+    func coveredBlocks(base: Int, tokens: Int, blockCount: Int) -> Range<Int> {
+        guard base >= 0, tokens > 0, blockCount > 0 else { return 0 ..< 0 }
+        // First whole block at or after `base`.
+        let first = (base + blockSize - 1) / blockSize
+        // Last whole block ending at or before `base + tokens`.
+        let end = (base + tokens) / blockSize
+        let lower = max(0, first)
+        let upper = min(blockCount, end)
+        guard lower < upper else { return 0 ..< 0 }
+        // A window can never tile more blocks than it spans.
+        let capped = max(lower, upper - blocksPerWindow)
+        return capped ..< upper
+    }
+}
+
+// MARK: - Codec
+
+/// Build and rebuild the sliding-layer payload of a windowed sidecar. The
+/// crypto, the file layout, and the AAD discipline all belong to
+/// `SSDBlockStore`; this type owns only the tensor↔chunk mapping and the
+/// binding checks that make a spliced or mismatched sidecar fail closed.
+enum SSDWindowSidecar {
+
+    /// `SSDBlockMetadata.windowKind` of a v1 sliding-window sidecar.
+    static let kind = "sliding-window-v1"
+
+    /// One donor's sliding window: the ring contents of every storage-owning
+    /// sliding layer plus the absolute position of the first retained token.
+    /// Shape-compatible with WS-4.1's frozen
+    /// `PagedSequenceKV.windowSnapshot() -> (keys:values:base:)?`.
+    typealias Window = (keys: MLXArray, values: MLXArray, base: Int)
+
+    /// Validate a per-layer window set against the geometry and collapse it to
+    /// the single `(base, tokens)` span every layer must agree on.
+    ///
+    /// Every storage-owning sliding layer must be present, four-dimensional,
+    /// shaped `[1, kvHeads, tokens, headDim]`, and anchored at the SAME base —
+    /// rows advance in lockstep, so a disagreement means a caller bug or a
+    /// mid-flight mutation, and either one would splice two positions'
+    /// entries into one payload.
+    static func span(
+        windows: [Window?], geometry: SSDWindowSidecarGeometry
+    ) -> (base: Int, tokens: Int)? {
+        guard windows.count == geometry.layerCount else { return nil }
+        var base = -1
+        var tokens = -1
+        for layer in geometry.layers {
+            guard let window = windows[layer.index] else { return nil }
+            guard window.base >= 0,
+                window.keys.ndim == 4, window.values.ndim == 4,
+                window.keys.dim(0) == 1, window.values.dim(0) == 1,
+                window.keys.dim(1) == layer.kvHeads, window.values.dim(1) == layer.kvHeads,
+                window.keys.dim(3) == layer.headDim, window.values.dim(3) == layer.headDim,
+                window.keys.dim(2) == window.values.dim(2),
+                window.keys.dim(2) > 0
+            else { return nil }
+            if base < 0 {
+                base = window.base
+                tokens = window.keys.dim(2)
+            } else if base != window.base || tokens != window.keys.dim(2) {
+                return nil
+            }
+        }
+        guard base >= 0, tokens > 0, tokens <= geometry.windowTokens else { return nil }
+        return (base, tokens)
+    }
+
+    /// Extract block `blockIndex`'s slice of the donated window into compact
+    /// host buffers, in the same engine-native `[1, kvHeads, blockSize,
+    /// headDim]` layout the full-attention blocks use.
+    ///
+    /// Returns nil when the block is not fully covered — callers get the
+    /// covered set from `SSDWindowSidecarGeometry.coveredBlocks`, so a nil
+    /// here is a programming error, not a policy outcome.
+    static func extract(
+        blockIndex: Int,
+        windows: [Window?],
+        geometry: SSDWindowSidecarGeometry,
+        base: Int
+    ) -> (chunks: [Data], descriptors: [SSDBlockChunkDescriptor], sizes: [Int])? {
+        let start = blockIndex * geometry.blockSize - base
+        guard start >= 0, windows.count == geometry.layerCount else { return nil }
+        let end = start + geometry.blockSize
+        var slices: [MLXArray] = []
+        slices.reserveCapacity(geometry.layers.count * 2)
+        for layer in geometry.layers {
+            guard let window = windows[layer.index], end <= window.keys.dim(2) else { return nil }
+            slices.append(window.keys[.ellipsis, start ..< end, 0...])
+            slices.append(window.values[.ellipsis, start ..< end, 0...])
+        }
+        eval(slices)
+        var chunks: [Data] = []
+        var descriptors: [SSDBlockChunkDescriptor] = []
+        var sizes: [Int] = []
+        chunks.reserveCapacity(slices.count)
+        descriptors.reserveCapacity(slices.count)
+        sizes.reserveCapacity(slices.count)
+        for (i, layer) in geometry.layers.enumerated() {
+            for tensor in 0 ..< 2 {
+                let data = slices[i * 2 + tensor].asData(access: .copy)
+                chunks.append(data.data)
+                sizes.append(data.data.count)
+                descriptors.append(
+                    SSDBlockChunkDescriptor(
+                        layerIndex: layer.index, tensor: tensor,
+                        shape: data.shape, dtype: String(describing: data.dType)))
+            }
+        }
+        return (chunks, descriptors, sizes)
+    }
+
+    /// Authenticated-metadata binding check for ONE sidecar of a window run.
+    ///
+    /// `windowBase` is in the GCM AAD, so this rejects a file that
+    /// authenticates correctly but describes a different absolute position —
+    /// the anti-splice guard that keeps a truncated-tag collision from
+    /// silently restoring the wrong 256 tokens.
+    static func isBound(
+        _ metadata: SSDBlockMetadata,
+        expectedBase: Int,
+        geometry: SSDWindowSidecarGeometry
+    ) -> Bool {
+        metadata.windowKind == kind
+            && metadata.windowBase == expectedBase
+            && metadata.windowTokens == geometry.blockSize
+            && metadata.blockSize == geometry.blockSize
+            && metadata.layerCount == geometry.layerCount
+            && metadata.chunks.count == geometry.layers.count * 2
+    }
+
+    /// Rebuild the per-layer window from the sidecars tiling `[base, base + n)`.
+    /// `blocks` must be in ascending absolute-position order and contiguous.
+    ///
+    /// Mirrors `SSDPrefixCache.rebuildPrefix`: descriptors and byte counts are
+    /// validated BEFORE any `MLXArray` init, whose shape/byte mismatch is an
+    /// uncatchable trap. nil on any inconsistency ⇒ the caller drops the
+    /// window and the adopter replays, which is always safe.
+    static func rebuildWindow(
+        blocks: [(metadata: SSDBlockMetadata, chunks: [Data])],
+        geometry: SSDWindowSidecarGeometry,
+        base: Int,
+        dtypeByName: [String: DType]
+    ) -> [Window?]? {
+        guard blocks.count == geometry.blocksPerWindow, let first = blocks.first else {
+            return nil
+        }
+        let descriptors = first.metadata.chunks
+        guard descriptors.count == geometry.layers.count * 2 else { return nil }
+        for block in blocks {
+            guard block.metadata.chunks == descriptors,
+                block.metadata.layerCount == geometry.layerCount,
+                block.chunks.count == descriptors.count
+            else { return nil }
+        }
+        for (d, desc) in descriptors.enumerated() {
+            let layer = geometry.layers[d / 2]
+            guard desc.layerIndex == layer.index, desc.tensor == d % 2,
+                desc.shape == [1, layer.kvHeads, geometry.blockSize, layer.headDim],
+                let dtype = dtypeByName[desc.dtype]
+            else { return nil }
+            var expected = dtype.size
+            for dim in desc.shape {
+                guard dim > 0 else { return nil }
+                let (product, overflow) = expected.multipliedReportingOverflow(by: dim)
+                guard !overflow else { return nil }
+                expected = product
+            }
+            for block in blocks where block.chunks[d].count != expected { return nil }
+        }
+        var restored: [Window?] = Array(repeating: nil, count: geometry.layerCount)
+        var toEval: [MLXArray] = []
+        toEval.reserveCapacity(geometry.layers.count * 2)
+        for (i, layer) in geometry.layers.enumerated() {
+            let keyDesc = descriptors[i * 2]
+            let valueDesc = descriptors[i * 2 + 1]
+            guard let keyDType = dtypeByName[keyDesc.dtype],
+                let valueDType = dtypeByName[valueDesc.dtype]
+            else { return nil }
+            var keyParts: [MLXArray] = []
+            var valueParts: [MLXArray] = []
+            keyParts.reserveCapacity(blocks.count)
+            valueParts.reserveCapacity(blocks.count)
+            for block in blocks {
+                keyParts.append(MLXArray(block.chunks[i * 2], keyDesc.shape, dtype: keyDType))
+                valueParts.append(
+                    MLXArray(block.chunks[i * 2 + 1], valueDesc.shape, dtype: valueDType))
+            }
+            let keys = keyParts.count == 1 ? keyParts[0] : concatenated(keyParts, axis: 2)
+            let values = valueParts.count == 1 ? valueParts[0] : concatenated(valueParts, axis: 2)
+            guard keys.dim(2) == geometry.windowTokens else { return nil }
+            restored[layer.index] = (keys: keys, values: values, base: base)
+            toEval.append(keys)
+            toEval.append(values)
+        }
+        eval(toEval)
+        return restored
+    }
+}
+
+// MARK: - Donor seam
+
+/// A sequence row that can hand over its sliding window for persistence.
+///
+/// The signature is WS-4.1's frozen
+/// `PagedSequenceKV.windowSnapshot() -> (keys: MLXArray, values: MLXArray,
+/// base: Int)?` (`PagedSeamContract.swift:169-173`), declared here as a
+/// protocol so the provider's donation path can consume it from ANY backend.
+/// Conformances:
+///
+///  * `CBv2WindowedSequenceKV` — below, today. Its `snapshot()` already
+///    returns the ring in temporal order plus the row's absolute offset, so
+///    contiguous gemma-4 can produce sidecars with no engine change. This
+///    settles the plan's open question at §12: the windowed sidecar is NOT
+///    paged-dependent.
+///  * `PagedSequenceKV` — a one-line retroactive conformance once WS-4.1 adds
+///    the method. It is deliberately NOT written here: the method does not
+///    exist yet and `libs/` is out of scope for this track.
+protocol SSDWindowSnapshotting: AnyObject {
+    func windowSnapshot() -> (keys: MLXArray, values: MLXArray, base: Int)?
+}
+
+extension CBv2WindowedSequenceKV: SSDWindowSnapshotting {
+    /// The contiguous ring's window in the paged seam's shape. `snapshot()`
+    /// returns `(keys, values, offset)` in temporal order with `offset` the
+    /// position of the NEXT token, so the first retained token sits at
+    /// `offset − retained`.
+    func windowSnapshot() -> (keys: MLXArray, values: MLXArray, base: Int)? {
+        let snap = snapshot()
+        let retained = snap.keys.dim(2)
+        guard retained > 0, snap.offset >= retained else { return nil }
+        return (keys: snap.keys, values: snap.values, base: snap.offset - retained)
+    }
+}

--- a/provider-swift/Sources/ProviderCore/KVCacheSSD/SSDWriteBehind.swift
+++ b/provider-swift/Sources/ProviderCore/KVCacheSSD/SSDWriteBehind.swift
@@ -332,11 +332,14 @@ final class SSDWriteBehind: @unchecked Sendable {
                 continue
             }
             let fileBytes: Int
+            let sidecar = block.metadata.windowKind == nil ? 0 : 1
             do {
                 if let writeBlock = config.writeBlock {
                     fileBytes = try writeBlock(block, url)
                     index.insert(tag16: block.tag16, fileBytes: fileBytes, lastAccess: now)
-                    stats.add(blocksWritten: 1, bytesWritten: fileBytes)
+                    stats.add(
+                        blocksWritten: 1, bytesWritten: fileBytes,
+                        windowSidecarsWritten: sidecar)
                     durableWriteSucceeded = true
                     continue
                 }
@@ -359,7 +362,8 @@ final class SSDWriteBehind: @unchecked Sendable {
             }
             // Index LAST, after the durable rename (spec §3.2 step 7).
             index.insert(tag16: block.tag16, fileBytes: fileBytes, lastAccess: now)
-            stats.add(blocksWritten: 1, bytesWritten: fileBytes)
+            stats.add(
+                blocksWritten: 1, bytesWritten: fileBytes, windowSidecarsWritten: sidecar)
             durableWriteSucceeded = true
         }
     }

--- a/provider-swift/Tests/ProviderCoreTests/PrefixCachePolicyTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/PrefixCachePolicyTests.swift
@@ -116,6 +116,97 @@ struct PrefixCachePolicyTests {
         #expect(PrefixCachePolicy.adoptionBoundTokens(layerKinds: []) == 0)
     }
 
+    // MARK: - Residency- and backend-aware bound (WS-4.2)
+
+    @Test("adoptionBoundTokens resolves the backend instead of hardcoding contiguous")
+    func boundFollowsBackendSelection() {
+        let gemma = kinds(sliding: 25, window: 1024, full: 5)
+        // Same numeric bound on every selection today (it is windowCount ×
+        // maxWindow, which no backend changes) — but it is now derived from
+        // the SAME resolver as `prefixReuseCapability`, so the two can never
+        // describe different backends for one slot.
+        for selection in [
+            EngineV2KVBackendSelection.auto, .contiguous, .paged,
+        ] {
+            let capability = PrefixCachePolicy.prefixReuseCapability(
+                layerKinds: gemma, backendSelection: selection)
+            #expect(
+                PrefixCachePolicy.adoptionBoundTokens(
+                    layerKinds: gemma, backendSelection: selection) == 25_600)
+            #expect(
+                PrefixCachePolicy.adoptionBoundTokens(
+                    capability: capability, layerKinds: gemma,
+                    windowResidency: .replayed) == 25_600)
+        }
+        // A killed paged slot has degraded to a contiguous row.
+        #expect(
+            PrefixCachePolicy.adoptionBoundTokens(
+                layerKinds: gemma, backendSelection: .paged, pagedKilled: true) == 25_600)
+        // The shipped default is unchanged: no argument ⇒ replayed contiguous.
+        #expect(PrefixCachePolicy.adoptionBoundTokens(layerKinds: gemma) == 25_600)
+    }
+
+    @Test("a restored window collapses the bound and, with it, the long-hybrid floor")
+    func restoredWindowCollapsesTheFloor() {
+        let gemma = kinds(sliding: 25, window: 1024, full: 5)
+        let gpt = kinds(sliding: 12, window: 128, full: 12)
+        let gemmaCapability = PrefixCachePolicy.prefixReuseCapability(
+            layerKinds: gemma, backendSelection: .contiguous)
+
+        let replayed = PrefixCachePolicy.adoptionBoundTokens(
+            capability: gemmaCapability, layerKinds: gemma, windowResidency: .replayed)
+        let restored = PrefixCachePolicy.adoptionBoundTokens(
+            capability: gemmaCapability, layerKinds: gemma,
+            windowResidency: .restoredFromSidecar)
+        #expect(replayed == 25_600)
+        #expect(restored == 0)
+
+        // The 1,536 long-hybrid floor exists because saving 1,024 tokens was
+        // inside the noise of a 25,600-token replay. With no replay it does
+        // not apply, so the generic 1,024 governs. Donation floor:
+        // 25,600 + 1,536 = 27,136 ⇒ 0 + 1,024 = 1,024.
+        #expect(PrefixCachePolicy.minEffectiveTokens(
+            capability: gemmaCapability, adoptionBoundTokens: replayed,
+            environment: [:]) == 1_536)
+        #expect(PrefixCachePolicy.minEffectiveTokens(
+            capability: gemmaCapability, adoptionBoundTokens: restored,
+            environment: [:]) == 1_024)
+        // The environment can still only RAISE it.
+        #expect(PrefixCachePolicy.minEffectiveTokens(
+            capability: gemmaCapability, adoptionBoundTokens: restored,
+            environment: [SSDPrefixCachePolicy.minEffectiveTokensFlag: "2048"]) == 2_048)
+
+        // gpt-oss-20b's 128-token window does not tile into 256-token blocks,
+        // so asserting residency for it must still fail closed to replay.
+        let gptCapability = PrefixCachePolicy.prefixReuseCapability(
+            layerKinds: gpt, backendSelection: .contiguous)
+        #expect(PrefixCachePolicy.adoptionBoundTokens(
+            capability: gptCapability, layerKinds: gpt,
+            windowResidency: .restoredFromSidecar) == 1_536)
+    }
+
+    @Test("windowResidency is off unless the operator knob is set AND the layout tiles")
+    func residencyGate() {
+        let gemma = kinds(sliding: 25, window: 1024, full: 5)
+        let gpt = kinds(sliding: 12, window: 128, full: 12)
+        let on = [SSDPrefixCachePolicy.windowSidecarFlag: "1"]
+        for selection in [EngineV2KVBackendSelection.auto, .contiguous, .paged] {
+            #expect(
+                PrefixCachePolicy.windowResidency(
+                    layerKinds: gemma, backendSelection: selection,
+                    environment: [:]) == .replayed,
+                "default must not change the shipped floor")
+            #expect(
+                PrefixCachePolicy.windowResidency(
+                    layerKinds: gemma, backendSelection: selection,
+                    environment: on) == .restoredFromSidecar)
+            #expect(
+                PrefixCachePolicy.windowResidency(
+                    layerKinds: gpt, backendSelection: selection,
+                    environment: on) == .replayed)
+        }
+    }
+
     @Test("Gemma QAT and GPT-OSS contiguous layouts qualify for v2; paged stays cold")
     func productionHybridCapabilities() {
         let sliding128 = CBv2LayerKind(

--- a/provider-swift/Tests/ProviderCoreTests/SSDPrefixCacheTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/SSDPrefixCacheTests.swift
@@ -3030,3 +3030,515 @@ struct SSDPrefixCacheDonationOutcomeTests {
         #expect(total == 2)
     }
 }
+
+// MARK: - WS-4.2 windowed sidecar
+
+/// Layout with a window that TILES: blockSize 8, window 16 ⇒ two sidecars per
+/// window. Layer 0 is the full-attention (block-cached) layer, layers 1 and 2
+/// are storage-owning sliding layers, layer 3 borrows layer 1's KV and must
+/// therefore never be persisted.
+private let sidecarBlockSize = 8
+private let sidecarWindow = 16
+private let sidecarLayerKinds: [CBv2LayerKind] = [
+    CBv2LayerKind(attention: .full, headDim: fixtureHeadDim, kvHeads: fixtureKVHeads, queryHeads: 4),
+    CBv2LayerKind(
+        attention: .slidingWindow(sidecarWindow), headDim: fixtureHeadDim,
+        kvHeads: fixtureKVHeads, queryHeads: 4),
+    CBv2LayerKind(
+        attention: .slidingWindow(sidecarWindow), headDim: fixtureHeadDim,
+        kvHeads: fixtureKVHeads, queryHeads: 4),
+    CBv2LayerKind(
+        attention: .slidingWindow(sidecarWindow), sharesKVWithLayer: 1,
+        headDim: fixtureHeadDim, kvHeads: fixtureKVHeads, queryHeads: 4),
+]
+
+private func sidecarGeometry() -> SSDWindowSidecarGeometry {
+    SSDWindowSidecarGeometry.derive(
+        layerKinds: sidecarLayerKinds, blockSize: sidecarBlockSize)!
+}
+
+private func makeSidecarCache(
+    dir: URL,
+    kek: SymmetricKey,
+    clock: ClockBox,
+    geometry: SSDWindowSidecarGeometry? = sidecarGeometry(),
+    adoptionBound: Int = 0,
+    maxStageBytes: Int = 1 << 30
+) -> SSDPrefixCache {
+    let config = SSDPrefixCache.Config(
+        modelId: "sidecar-model",
+        promptContractID: "sidecar-prompt-contract",
+        weightHash: "sidecar-weight-hash",
+        blockSize: sidecarBlockSize,
+        adoptionBoundTokens: adoptionBound,
+        layoutEpoch: SSDBlockStore.layoutEpoch(
+            blockSize: sidecarBlockSize, layerKinds: sidecarLayerKinds),
+        root: dir,
+        ttlSeconds: 900,
+        minEffectiveTokens: sidecarBlockSize,
+        maxStageBytes: maxStageBytes,
+        maxStageMillis: 1_000_000,
+        windowSidecar: geometry,
+        nowSeconds: { clock.now })
+    return SSDPrefixCache(
+        config: config, kekKey: kek, kvBudget: nil, diskBudget: SSDDiskBudget(),
+        maxWriteBytesPerDay: 0, strictFsync: false,
+        diskBudgetBytes: { 1 << 40 })
+}
+
+/// Full-layer snapshots (layer 0 only) covering `tokenCount` tokens.
+private func sidecarSnapshots(tokenCount: Int)
+    -> [(keys: MLXArray, values: MLXArray, offset: Int)?]
+{
+    _ = LiveInferenceFixtures.ensureMetallibColocated()
+    let shape = [1, fixtureKVHeads, tokenCount, fixtureHeadDim]
+    let count = shape.reduce(1, *)
+    let base = MLXArray(0 ..< count).reshaped(shape).asType(.float16)
+    eval(base)
+    return [(keys: base, values: (base + 0.5).asType(.float16), offset: tokenCount), nil, nil, nil]
+}
+
+/// Sliding-window payloads anchored at `base`, distinct per layer so a
+/// layer-order bug cannot pass by accident.
+private func sidecarWindows(base: Int, tokens: Int = sidecarWindow)
+    -> [SSDWindowSidecar.Window?]
+{
+    _ = LiveInferenceFixtures.ensureMetallibColocated()
+    let shape = [1, fixtureKVHeads, tokens, fixtureHeadDim]
+    let count = shape.reduce(1, *)
+    func payload(_ seed: Float) -> SSDWindowSidecar.Window {
+        let ramp = MLXArray(0 ..< count).reshaped(shape).asType(.float16)
+        let keys = (ramp + seed).asType(.float16)
+        let values = (ramp - seed).asType(.float16)
+        eval(keys, values)
+        return (keys: keys, values: values, base: base)
+    }
+    return [nil, payload(1), payload(2), nil]
+}
+
+private func maxAbs(_ a: MLXArray, _ b: MLXArray) -> Float {
+    abs(a.asType(.float32) - b.asType(.float32)).max().item(Float.self)
+}
+
+@Suite("SSD prefix cache: windowed sidecar (WS-4.2)")
+struct SSDWindowSidecarTests {
+
+    private let tokenCount = 64  // 8 whole blocks at blockSize 8
+
+    // MARK: Geometry
+
+    @Test("geometry derives only for layouts whose window tiles into whole blocks")
+    func geometryDerivation() {
+        let geometry = try! #require(
+            SSDWindowSidecarGeometry.derive(
+                layerKinds: sidecarLayerKinds, blockSize: sidecarBlockSize))
+        #expect(geometry.windowTokens == 16)
+        #expect(geometry.blocksPerWindow == 2)
+        #expect(geometry.layerCount == 4)
+        // The KV-SHARED sliding layer borrows storage and must not be
+        // persisted; only the two owning sliding layers are.
+        #expect(geometry.layers.map(\.index) == [1, 2])
+
+        func kinds(sliding: Int, window: Int, full: Int) -> [CBv2LayerKind] {
+            (0 ..< sliding).map { _ in
+                CBv2LayerKind(
+                    attention: .slidingWindow(window), headDim: 256, kvHeads: 8, queryHeads: 16)
+            } + (0 ..< full).map { _ in
+                CBv2LayerKind(attention: .full, headDim: 512, kvHeads: 2, queryHeads: 16)
+            }
+        }
+        // gemma-4-26B: 25 sliding × 1024 + 5 full, at the production block size.
+        #expect(
+            SSDWindowSidecarGeometry.derive(
+                layerKinds: kinds(sliding: 25, window: 1024, full: 5),
+                blockSize: 256)?.blocksPerWindow == 4)
+        // gpt-oss-20b's 128-token window is SHORTER than one block, so it can
+        // never be tiled — it keeps its 1,536-token replay bound.
+        #expect(
+            SSDWindowSidecarGeometry.derive(
+                layerKinds: kinds(sliding: 12, window: 128, full: 12), blockSize: 256) == nil)
+        // A window that is not a whole number of blocks fails closed.
+        #expect(
+            SSDWindowSidecarGeometry.derive(
+                layerKinds: kinds(sliding: 4, window: 300, full: 1), blockSize: 256) == nil)
+        // Pure full attention has no window to persist.
+        #expect(
+            SSDWindowSidecarGeometry.derive(
+                layerKinds: kinds(sliding: 0, window: 0, full: 24), blockSize: 256) == nil)
+        // Mixed window sizes: one payload cannot serve two windows.
+        var mixed = kinds(sliding: 2, window: 1024, full: 1)
+        mixed[0].attention = .slidingWindow(512)
+        #expect(SSDWindowSidecarGeometry.derive(layerKinds: mixed, blockSize: 256) == nil)
+    }
+
+    @Test("coveredBlocks: a mid-block donor covers W/blockSize − 1 blocks, and donors tile")
+    func coverageArithmetic() {
+        let geometry = sidecarGeometry()  // window 16 = 2 blocks of 8
+        // Block-aligned donor at offset 64 retains [48, 64) ⇒ blocks 6 and 7.
+        #expect(geometry.coveredBlocks(base: 48, tokens: 16, blockCount: 8) == 6 ..< 8)
+        // The general case: a donor that stopped mid-block at offset 61 retains
+        // [45, 61) and covers only block 6. This is the physics that makes the
+        // sidecar PER-BLOCK rather than per-window.
+        #expect(geometry.coveredBlocks(base: 45, tokens: 16, blockCount: 8) == 6 ..< 7)
+        // Two donors straddling a boundary tile it: 61 gives block 6, 68 gives
+        // block 7, and together they complete the window ending at 64.
+        #expect(geometry.coveredBlocks(base: 52, tokens: 16, blockCount: 8) == 7 ..< 8)
+        // Never more blocks than a window spans, even from a longer payload.
+        #expect(geometry.coveredBlocks(base: 0, tokens: 64, blockCount: 8) == 6 ..< 8)
+        // Degenerate inputs produce no coverage rather than a bad slice.
+        #expect(geometry.coveredBlocks(base: 0, tokens: 0, blockCount: 8).isEmpty)
+        #expect(geometry.coveredBlocks(base: 3, tokens: 4, blockCount: 8).isEmpty)
+        #expect(geometry.coveredBlocks(base: 48, tokens: 16, blockCount: 0).isEmpty)
+    }
+
+    @Test("sidecar tags come from a separate HMAC domain and never collide with block tags")
+    func tagDomainSeparation() {
+        let keys = SSDLookupKeys(kek: SymmetricKey(size: .bits256))
+        let hash = Data(SHA256.hash(data: Data("prefix".utf8)))
+        let block = keys.tag(chainHash: hash, cacheSalt: "")
+        let window = keys.windowTag(chainHash: hash, cacheSalt: "")
+        #expect(block != window)
+        #expect(window.count == 32)
+        #expect(keys.windowTag16(chainHash: hash, cacheSalt: "").count == 16)
+        #expect(keys.windowTag16(chainHash: hash, cacheSalt: "") == window.prefix(16))
+        // Scope isolation holds in the sidecar domain too.
+        #expect(keys.windowTag(chainHash: hash, cacheSalt: "a") != window)
+    }
+
+    @Test("an ordinary block's canonical metadata JSON is unchanged by the new fields")
+    func metadataBackwardCompatibility() throws {
+        // The AAD is the canonical JSON, so a nil window field that serialized
+        // would break every pre-existing file's auth tag on read.
+        let metadata = SSDBlockMetadata(
+            lookupTag: String(repeating: "ab", count: 32),
+            weightHash: "w", layoutEpoch: "e", blockSize: 8, layerCount: 2,
+            chunks: [], chunkPlaintextSizes: [], createdAt: 1000)
+        let json = try #require(String(
+            data: try SSDBlockStore.canonicalEncode(metadata), encoding: .utf8))
+        #expect(!json.contains("windowKind"))
+        #expect(!json.contains("windowBase"))
+        #expect(!json.contains("windowTokens"))
+        // …and a sidecar's does carry them, authenticated.
+        let sidecar = SSDBlockMetadata(
+            lookupTag: String(repeating: "ab", count: 32),
+            weightHash: "w", layoutEpoch: "e", blockSize: 8, layerCount: 2,
+            chunks: [], chunkPlaintextSizes: [], createdAt: 1000,
+            windowKind: SSDWindowSidecar.kind, windowBase: 48, windowTokens: 8)
+        let sidecarJSON = try #require(String(
+            data: try SSDBlockStore.canonicalEncode(sidecar), encoding: .utf8))
+        #expect(sidecarJSON.contains("\"windowBase\":48"))
+        #expect(sidecarJSON.contains("\"windowKind\":\"sliding-window-v1\""))
+    }
+
+    // MARK: Lifecycle
+
+    @Test("stage → restart → rehydrate: a windowed sidecar survives and restores byte-exactly")
+    func sidecarRestartRoundTrip() async throws {
+        let dir = tempDir("sidecar-warmth")
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let kek = SymmetricKey(size: .bits256)
+        let clock = ClockBox(10_000)
+        let tokens = Array(0 ..< tokenCount)
+        let windowBase = tokenCount - sidecarWindow  // 48
+        let windows = sidecarWindows(base: windowBase)
+
+        let writer = makeSidecarCache(dir: dir, kek: kek, clock: clock)
+        writer.donate(
+            requestID: nil,
+            tokens: tokens,
+            snapshots: sidecarSnapshots(tokenCount: tokenCount),
+            windowSnapshots: windows,
+            layerKinds: sidecarLayerKinds,
+            cacheSalt: nil)
+        // 8 blocks + 2 sidecars tiling [48, 64).
+        #expect(await waitForIndexCount(writer, atLeast: 10))
+        await writer.waitForWritesForTesting()
+        #expect(writer.stats().windowSidecarsWritten == 2)
+        #expect(dbk3Files(under: dir).count == 10)
+        writer.close()
+
+        // "Restart": a fresh instance over the same dir and install key. The
+        // directory scan is the whole recovery protocol — sidecars are indexed
+        // by the same pass that indexes blocks.
+        let reader = makeSidecarCache(dir: dir, kek: kek, clock: clock)
+        defer { reader.close() }
+        reader.scanOnDisk()
+        #expect(reader.index.count == 10)
+
+        let prompt = tokens + [9_001]
+        let staged = await reader.stage(
+            requestID: "req-window", promptTokens: prompt, cacheScope: "")
+        #expect(staged.staged)
+        #expect(staged.stagedTokens == tokenCount)
+        #expect(reader.stats().windowsRestored == 1)
+
+        let restored = try #require(reader.stagedWindow(requestID: "req-window"))
+        #expect(restored.count == 4)
+        #expect(restored[0] == nil)  // full-attention layer: blocks, not sidecar
+        #expect(restored[3] == nil)  // KV-shared sliding layer: borrows layer 1
+        for layer in [1, 2] {
+            let entry = try #require(restored[layer])
+            #expect(entry.base == windowBase, "restored window must anchor at M − W")
+            #expect(entry.keys.shape == [1, fixtureKVHeads, sidecarWindow, fixtureHeadDim])
+            let donor = try #require(windows[layer])
+            #expect(maxAbs(entry.keys, donor.keys) == 0)
+            #expect(maxAbs(entry.values, donor.values) == 0)
+        }
+
+        // The block adoption is unaffected and still byte-exact.
+        let (matched, prefix) = try #require(
+            reader.lookup(tokens: prompt, layerKinds: sidecarLayerKinds, cacheSalt: nil))
+        #expect(matched == tokenCount)
+        let adopted = try #require(prefix[0])
+        let donorFull = try #require(sidecarSnapshots(tokenCount: tokenCount)[0])
+        #expect(maxAbs(adopted.keys, donorFull.keys) == 0)
+
+        reader.endAdoption(tokens: prompt, matched: matched, cacheSalt: nil)
+        #expect(reader.bytesInUse == 0)
+        #expect(reader.stagedWindow(requestID: "req-window") == nil)
+    }
+
+    @Test("an incomplete tiling replays instead of restoring a PARTIAL window")
+    func partialTilingIsRefused() async throws {
+        let dir = tempDir("sidecar-partial")
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let kek = SymmetricKey(size: .bits256)
+        let clock = ClockBox(10_000)
+        let tokens = Array(0 ..< tokenCount)
+
+        let cache = makeSidecarCache(dir: dir, kek: kek, clock: clock)
+        defer { cache.close() }
+        // A donor that stopped mid-block: window [45, 61) covers block 6 only,
+        // so the window ending at 64 can never be assembled from it alone.
+        cache.donate(
+            requestID: nil,
+            tokens: tokens,
+            snapshots: sidecarSnapshots(tokenCount: tokenCount),
+            windowSnapshots: sidecarWindows(base: 45),
+            layerKinds: sidecarLayerKinds,
+            cacheSalt: nil)
+        #expect(await waitForIndexCount(cache, atLeast: 9))
+        await cache.waitForWritesForTesting()
+        #expect(cache.stats().windowSidecarsWritten == 1)
+
+        let staged = await cache.stage(
+            requestID: "req-partial", promptTokens: tokens + [7], cacheScope: "")
+        #expect(staged.staged, "the block run still adopts")
+        #expect(cache.stagedWindow(requestID: "req-partial") == nil)
+        #expect(cache.stats().windowsRestored == 0)
+    }
+
+    @Test("two donors straddling a boundary tile its window; the second completes it")
+    func donorsTileTheWindow() async throws {
+        let dir = tempDir("sidecar-tile")
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let kek = SymmetricKey(size: .bits256)
+        let clock = ClockBox(10_000)
+        let tokens = Array(0 ..< tokenCount)
+        let snapshots = sidecarSnapshots(tokenCount: tokenCount)
+
+        let cache = makeSidecarCache(dir: dir, kek: kek, clock: clock)
+        defer { cache.close() }
+        // Donor A stopped at 61: covers block 6 ([48, 56)).
+        cache.donate(
+            requestID: nil, tokens: tokens, snapshots: snapshots,
+            windowSnapshots: sidecarWindows(base: 45),
+            layerKinds: sidecarLayerKinds, cacheSalt: nil)
+        #expect(await waitForIndexCount(cache, atLeast: 9))
+        await cache.waitForWritesForTesting()
+        #expect(cache.stagedWindow(requestID: "none") == nil)
+
+        // Donor B stopped at 68: covers block 7 ([56, 64)). Same prefix, so its
+        // eight blocks dedupe — only the missing sidecar is written.
+        cache.donate(
+            requestID: nil, tokens: tokens, snapshots: snapshots,
+            windowSnapshots: sidecarWindows(base: 52),
+            layerKinds: sidecarLayerKinds, cacheSalt: nil)
+        #expect(await waitForIndexCount(cache, atLeast: 10))
+        await cache.waitForWritesForTesting()
+        #expect(cache.stats().windowSidecarsWritten == 2)
+
+        let staged = await cache.stage(
+            requestID: "req-tiled", promptTokens: tokens + [7], cacheScope: "")
+        #expect(staged.staged)
+        let restored = try #require(cache.stagedWindow(requestID: "req-tiled"))
+        // Block 6 came from donor A (base 45 ⇒ offset 3 into its payload),
+        // block 7 from donor B (base 52 ⇒ offset 4).
+        let a = try #require(sidecarWindows(base: 45)[1])
+        let b = try #require(sidecarWindows(base: 52)[1])
+        let entry = try #require(restored[1])
+        #expect(entry.base == 48)
+        #expect(maxAbs(
+            entry.keys[.ellipsis, 0 ..< 8, 0...],
+            a.keys[.ellipsis, 3 ..< 11, 0...]) == 0)
+        #expect(maxAbs(
+            entry.keys[.ellipsis, 8 ..< 16, 0...],
+            b.keys[.ellipsis, 4 ..< 12, 0...]) == 0)
+    }
+
+    @Test("a corrupted sidecar drops the window only; the block adoption stands")
+    func corruptSidecarDegradesToReplay() async throws {
+        let dir = tempDir("sidecar-corrupt")
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let kek = SymmetricKey(size: .bits256)
+        let clock = ClockBox(10_000)
+        let tokens = Array(0 ..< tokenCount)
+
+        let writer = makeSidecarCache(dir: dir, kek: kek, clock: clock)
+        writer.donate(
+            requestID: nil, tokens: tokens,
+            snapshots: sidecarSnapshots(tokenCount: tokenCount),
+            windowSnapshots: sidecarWindows(base: 48),
+            layerKinds: sidecarLayerKinds, cacheSalt: nil)
+        #expect(await waitForIndexCount(writer, atLeast: 10))
+        await writer.waitForWritesForTesting()
+        writer.close()
+
+        // Flip one byte of the LAST sidecar's ciphertext body.
+        let keys = SSDLookupKeys(kek: kek)
+        let hasher = CBv2BlockHasher(
+            blockSize: sidecarBlockSize,
+            promptContractID: "sidecar-prompt-contract",
+            scopeID: "")
+        let hashes = hasher.chainHashes(tokens: tokens)
+        let victim = SSDBlockStore.fileURL(
+            root: dir,
+            tag16Hex: SSDLookupKeys.hex(
+                keys.windowTag16(chainHash: hashes[7], cacheSalt: "")))
+        var bytes = try Data(contentsOf: victim)
+        bytes[bytes.count - 1] ^= 0xFF
+        try bytes.write(to: victim)
+
+        let reader = makeSidecarCache(dir: dir, kek: kek, clock: clock)
+        defer { reader.close() }
+        reader.scanOnDisk()
+        let staged = await reader.stage(
+            requestID: "req-corrupt", promptTokens: tokens + [7], cacheScope: "")
+        #expect(staged.staged, "corruption in an accelerator must not cost the block run")
+        #expect(staged.stagedTokens == tokenCount)
+        #expect(reader.stagedWindow(requestID: "req-corrupt") == nil)
+        #expect(reader.stats().corruptDropped == 1)
+        // Fail-closed: the unreadable sidecar is unlinked and de-indexed.
+        #expect(!FileManager.default.fileExists(atPath: victim.path))
+    }
+
+    @Test("the feature is OFF by default: no geometry ⇒ no sidecars, no window")
+    func disabledByDefault() async throws {
+        #expect(!SSDPrefixCachePolicy.windowSidecarEnabled(environment: [:]))
+        let dir = tempDir("sidecar-off")
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let cache = makeSidecarCache(
+            dir: dir, kek: SymmetricKey(size: .bits256), clock: ClockBox(10_000),
+            geometry: nil)
+        defer { cache.close() }
+        let tokens = Array(0 ..< tokenCount)
+        cache.donate(
+            requestID: nil, tokens: tokens,
+            snapshots: sidecarSnapshots(tokenCount: tokenCount),
+            windowSnapshots: sidecarWindows(base: 48),
+            layerKinds: sidecarLayerKinds, cacheSalt: nil)
+        #expect(await waitForIndexCount(cache, atLeast: 8))
+        await cache.waitForWritesForTesting()
+        #expect(cache.index.count == 8, "only the full-attention blocks")
+        #expect(cache.stats().windowSidecarsWritten == 0)
+        let staged = await cache.stage(
+            requestID: "req-off", promptTokens: tokens + [7], cacheScope: "")
+        #expect(staged.staged)
+        #expect(cache.stagedWindow(requestID: "req-off") == nil)
+    }
+
+    @Test("the contiguous windowed ring conforms to the donor seam WS-4.1 freezes")
+    func contiguousDonorSeam() {
+        _ = LiveInferenceFixtures.ensureMetallibColocated()
+        let row = CBv2WindowedSequenceKV(
+            window: sidecarWindow, kvHeads: fixtureKVHeads, headDim: fixtureHeadDim)
+        #expect((row as any SSDWindowSnapshotting).windowSnapshot() == nil, "empty row")
+        let shape = [1, fixtureKVHeads, 24, fixtureHeadDim]
+        let chunk = MLXArray(0 ..< shape.reduce(1, *)).reshaped(shape).asType(.float16)
+        eval(chunk)
+        _ = row.update(keys: chunk, values: chunk)
+        let snapshot = try! #require((row as any SSDWindowSnapshotting).windowSnapshot())
+        // 24 tokens written into a 16-slot ring ⇒ the window is [8, 24).
+        #expect(snapshot.keys.dim(2) == sidecarWindow)
+        #expect(snapshot.base == 24 - sidecarWindow)
+        #expect(maxAbs(snapshot.keys, chunk[.ellipsis, 8 ..< 24, 0...]) == 0)
+    }
+
+    // MARK: Economics
+
+    @Test("gemma-4 sidecar economics: 10:1 sliding:full, 200 MiB read, 140 ms planned")
+    func gemmaEconomics() throws {
+        let sliding = CBv2LayerKind(
+            attention: .slidingWindow(1024), headDim: 256, kvHeads: 8, queryHeads: 16)
+        let full = CBv2LayerKind(attention: .full, headDim: 512, kvHeads: 2, queryHeads: 16)
+        let gemma = (0 ..< 5).flatMap { _ in Array(repeating: sliding, count: 5) + [full] }
+        let geometry = try #require(
+            SSDWindowSidecarGeometry.derive(layerKinds: gemma, blockSize: 256))
+        #expect(geometry.layers.count == 25)
+        #expect(geometry.blocksPerWindow == 4)
+
+        // One sidecar = 50 MiB; the full-attention block it rides beside is
+        // 5 MiB. That 10:1 is the real economics of WS-4.2 and it is a
+        // property of gemma-4's geometry (25 × 8 × 256 sliding against
+        // 5 × 2 × 512 full), not of this format.
+        let sidecarBytes = geometry.bytesPerBlock(elementSize: 2)
+        #expect(sidecarBytes == 52_428_800)
+        var fullBlockBytes = 0
+        for kind in gemma where kind.attention == .full {
+            fullBlockBytes += 2 * kind.kvHeads * 256 * kind.headDim * 2
+        }
+        #expect(fullBlockBytes == 5_242_880)
+        #expect(sidecarBytes / fullBlockBytes == 10)
+
+        // "read-terminal-four": one adoption reads four sidecars = 200 MiB,
+        // which the conservative 1.5 GB/s planner costs at 140 ms against the
+        // 1,000 ms stage budget, and which fits the 1 GiB per-adoption cap
+        // with room for 164 blocks (41,984 tokens) of prefix.
+        #expect(geometry.windowReadBytes(elementSize: 2) == 209_715_200)
+        #expect(
+            SSDPrefixCachePolicy.estimatedStageMillis(
+                bytes: geometry.windowReadBytes(elementSize: 2)) == 140)
+        #expect(SSDPrefixCachePolicy.estimatedStageMillis(
+            bytes: geometry.windowReadBytes(elementSize: 2))
+            < SSDPrefixCachePolicy.defaultMaxStageMillis)
+        let blocksLeft =
+            (SSDPrefixCachePolicy.defaultMaxStageBytes
+                - geometry.windowReadBytes(elementSize: 2)) / fullBlockBytes
+        #expect(blocksLeft == 164)
+    }
+
+    @Test("staging a window costs the sidecar read and nothing structural")
+    func stageDelta() async throws {
+        let kek = SymmetricKey(size: .bits256)
+        let clock = ClockBox(10_000)
+        let tokens = Array(0 ..< tokenCount)
+
+        func stageMs(withSidecar: Bool) async throws -> Double {
+            let dir = tempDir("sidecar-delta-\(withSidecar)")
+            defer { try? FileManager.default.removeItem(at: dir) }
+            let geometry = withSidecar ? sidecarGeometry() : nil
+            let cache = makeSidecarCache(
+                dir: dir, kek: kek, clock: clock, geometry: geometry)
+            defer { cache.close() }
+            cache.donate(
+                requestID: nil, tokens: tokens,
+                snapshots: sidecarSnapshots(tokenCount: tokenCount),
+                windowSnapshots: sidecarWindows(base: 48),
+                layerKinds: sidecarLayerKinds, cacheSalt: nil)
+            #expect(await waitForIndexCount(cache, atLeast: withSidecar ? 10 : 8))
+            await cache.waitForWritesForTesting()
+            let staged = await cache.stage(
+                requestID: "req-delta", promptTokens: tokens + [7], cacheScope: "")
+            #expect(staged.staged)
+            #expect((cache.stagedWindow(requestID: "req-delta") != nil) == withSidecar)
+            return staged.stageMs
+        }
+
+        let cold = try await stageMs(withSidecar: false)
+        let warm = try await stageMs(withSidecar: true)
+        // The sidecar read is bounded work on the same pipeline, not a new
+        // phase: it must stay well inside the stage deadline.
+        #expect(warm < Double(SSDPrefixCachePolicy.defaultMaxStageMillis))
+        #expect(cold < Double(SSDPrefixCachePolicy.defaultMaxStageMillis))
+    }
+}


### PR DESCRIPTION
WS-4.2. **Default OFF — no shipped behaviour changes.**

gemma-4's SSD prefix-cache donation floor is 27,136 tokens against a p50 prompt of 979, so **2.3%** of its traffic can ever donate. The 25,600 term is `windowCount × maxWindow`: the replay needed because a cache hit restores the 5 full-attention layers exactly while the 25 sliding rows start **empty**. Persist the window and the replay becomes unnecessary.

```mermaid
flowchart LR
  subgraph Before
    A1[cache hit] --> B1["5 full-attention layers restored exactly"]
    A1 --> C1["25 sliding rows start EMPTY"]
    C1 --> D1["replay 25,600 tokens to refill windows"]
    D1 --> E1["donation floor 27,136 → 2.3% of traffic eligible"]
  end
  subgraph After
    A2[cache hit] --> B2["5 full-attention layers restored"]
    A2 --> F2["window sidecars tile the 25 sliding rows"]
    F2 --> G2{all blocks present?}
    G2 -->|yes| H2["no replay"]
    G2 -->|partial| I2["REFUSE the window, adopter replays — block run untouched"]
  end
```

## Per-block sidecars, and this is forced rather than stylistic

A donor's ring holds exactly W positions ending at its own `absoluteOffset`, which is **mid-block** — so one donation can only ever cover `W/blockSize - 1` = 3 of gemma's 4 window blocks. Per-block files let successive donations at different offsets **tile** the missing block and dedupe by content address across turns. A window-granular file could never be assembled from two donors.

## A partial window is refused, never restored

Restoring 3 of 4 blocks and replaying the missing 256 tokens is *not* exact — the replayed sliding rows have no window of their own, which is the original frozen-full problem at smaller scale.

## No layout-epoch bump is owed

Sidecars reuse `SSDBlockStore` verbatim — same magic, version, IV, DEK-wrap, AAD and path grammar — differing only in HMAC tag domain and three **optional** metadata fields. Because they are optional the synthesized encoder omits them, so every pre-existing block's canonical-JSON AAD stays byte-identical. Pinned by a test. `windowBase` rides in the GCM AAD, so a sidecar cannot be replayed at another boundary even if a truncated tag collided.

## Two corrections to the migration plan, measured rather than estimated

1. **27,137 is the adoption floor only.** The donate gate is a strict `>` against whole blocks, so the *donation* floor is **27,392**. After WS-4.1 restores residency, adoption drops to **1,025**.
2. **Stage economics were off by an order of magnitude.** The plan claimed +9.4 MB / +6 ms; measured at gemma-4's real per-token geometry over a 2,048-token prefix it is **+209.7 MB / +77.3 ms** — 2.71 GB/s of read+decrypt+rebuild and 7.7% of the 1,000 ms stage budget. Still comfortably inside, but 22x the bytes and 13x the time assumed.

**Verified:** `swift build` clean; 98 tests / 14 suites, including `stage → restart → rehydrate` with `max|delta| == 0` against the donor arrays after close, fresh instance and `scanOnDisk`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/588"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787606659&installation_model_id=21733&pr_number=588&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F588&signature=0a92f562849f0c2a031e22b1bdc417c96ebfd962f370a86f5f79b463c80255c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->