### PR TITLE
ci(v0.8.0): make the paged gates capable of failing — blocking lane, built-backend assertion, teacher-forced floor

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,7 @@
+# actionlint runner-label vocabulary. The repo runs on Blacksmith-hosted
+# runners, whose labels actionlint cannot know about; without this file every
+# job flags [runner-label] and the lint is unusable as a gate.
+self-hosted-runner:
+  labels:
+    - blacksmith-4vcpu-ubuntu-2404
+    - blacksmith-12vcpu-macos-latest

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,0 +1,92 @@
+# E2E load benchmarks, split out of integration.yml (v0.8.0 gate audit).
+#
+# WHY A SEPARATE WORKFLOW: this job runs under the `benchmarks` environment,
+# whose required-reviewer rule (repo Settings -> Environments -> benchmarks)
+# makes every run wait for a manual approval — a deliberate cost control for
+# a 30-minute macOS runner job that posts PR comments. While it shared a
+# workflow with the E2E integration job, that pending approval held the
+# WHOLE "Integration Tests" workflow in `waiting` on every PR (26/26 runs
+# this release), hiding the integration job's actual conclusion behind a
+# benchmark nobody approved. In its own workflow, an unapproved benchmark
+# holds only this file's status open.
+#
+# The approval rule itself is repo configuration, not YAML: to run these on
+# a PR, approve the deployment in the run's UI; to stop gating them, remove
+# the required reviewer from the `benchmarks` environment.
+
+name: E2E Benchmarks
+
+on:
+  pull_request:
+
+jobs:
+  benchmark:
+    name: E2E Benchmarks
+    runs-on: blacksmith-12vcpu-macos-latest
+    timeout-minutes: 30
+    environment: benchmarks
+    env:
+      DARKBLOOM_REPO_ROOT: ${{ github.workspace }}
+      TESTBED_PROVIDER_CONFIG: debug
+      BENCHMARK_MD_PATH: /tmp/benchmark-results.md
+      RUNNER_DESC: macos-15 (M1 Virtual)
+      GPT_OSS_REVISION: 773a7da77e569019bb0fd17a554b263738d669a3
+      GEMMA_REVISION: 0e3cbab38ce568cf6e23543010d08d03b731910c
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          submodules: recursive
+
+      - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
+        with:
+          go-version-file: go.mod
+
+      - name: Install Postgres
+        run: brew install postgresql@16
+
+      - name: Build provider (Swift)
+        run: |
+          cd provider-swift
+          swift build -c debug
+
+      - name: Extract mlx.metallib
+        run: |
+          python3 -m venv /tmp/mlxvenv
+          /tmp/mlxvenv/bin/pip install 'mlx==0.31.2'
+          cp /tmp/mlxvenv/lib/python*/site-packages/mlx/lib/mlx.metallib \
+             provider-swift/.build/debug/mlx.metallib
+
+      - name: Install Hugging Face client
+        # Benchmarks serve the CBv2 default (gpt-oss-20b, ~12 GB) plus the
+        # secondary multi-model checkpoint (gemma-4-26B QAT, ~14.5 GB) for
+        # TestBenchmark_MultiModelMultiProvider. Warm HF cache ⇒ no-op.
+        run: /tmp/mlxvenv/bin/pip install huggingface_hub
+
+      - name: Download public models (pull request)
+        run: |
+          echo "Pull request: downloading public models without Hugging Face authentication"
+          /tmp/mlxvenv/bin/python -c "import os; from huggingface_hub import snapshot_download; snapshot_download('mlx-community/gpt-oss-20b-MXFP4-Q8', revision=os.environ['GPT_OSS_REVISION'], token=False)"
+          /tmp/mlxvenv/bin/python -c "import os; from huggingface_hub import snapshot_download; snapshot_download('mlx-community/gemma-4-26B-A4B-it-qat-4bit', revision=os.environ['GEMMA_REVISION'], token=False)"
+
+      - name: Run benchmarks
+        run: |
+          PATH="$(brew --prefix postgresql@16)/bin:$PATH"
+          export PATH
+          go test ./e2e/ -count=1 -v -timeout 25m -p=1 \
+            -run 'TestBenchmark'
+
+      - name: Post benchmark results
+        if: always()
+        run: |
+          if [ ! -f /tmp/benchmark-results.md ]; then
+            echo "No benchmark results file found"
+            exit 0
+          fi
+          BODY=$(cat /tmp/benchmark-results.md)
+          gh pr comment ${{ github.event.pull_request.number }} \
+            --body "$BODY" \
+            --edit-last \
+            || gh pr comment ${{ github.event.pull_request.number }} \
+            --body "$BODY"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,11 @@ jobs:
       - name: Run tests
         env:
           DATABASE_URL: postgres://testbed:testbed@127.0.0.1:5432/testbed?sslmode=disable
-        run: go test -race $(go list ./... | grep -v /e2e)
+        run: |
+          # Word splitting is the point here: one argument per package path,
+          # and Go package paths contain no spaces.
+          # shellcheck disable=SC2046
+          go test -race $(go list ./... | grep -v /e2e)
       - name: Check formatting
         run: |
           UNFORMATTED=$(gofmt -l .)
@@ -161,16 +165,32 @@ jobs:
         run: swift test
       - name: Verify production prompt parity
         run: ./scripts/verify-prompt-parity.sh
+      # FLAKE-ORDERING GUARD (audit fix, v0.8.0): every nested step below runs
+      # under `if: ${{ !cancelled() && ... }}`. Before this, the nested paged
+      # suites ran with the default `success()` condition, so ANY earlier step
+      # failure — including a known-flaky unit test in `Run Swift tests` —
+      # SKIPPED all six paged correctness gates. On the v0.8.0 PR head that is
+      # exactly what happened: the unit step failed on unrelated flakes and
+      # the paged gates reported `skipped`, i.e. the release's central
+      # correctness signal was silenced by an unrelated flake. `!cancelled()`
+      # keeps the gates running after an earlier failure; each nested RUN step
+      # still requires its own build/metallib prerequisites to have succeeded
+      # so a red build produces one attributable failure, not six cascading
+      # ones. A nested-step failure fails the job as usual (no
+      # continue-on-error anywhere in this chain).
       - name: Build nested mlx-swift-lm tests
+        id: build-nested-tests
+        if: ${{ !cancelled() }}
         working-directory: libs/mlx-swift-lm
         # Cold builds compile the full Cmlx C++/Metal tree (~20 min on the
         # 12-vcpu runner); warm runs restore libs/mlx-swift-lm/.build from
         # the SwiftPM cache and finish in ~1 min.
         timeout-minutes: 35
         run: swift build --build-tests
-      - name: Run nested paged safety and prompt-hash tests directly
+      - name: Place metallib for nested test bundles
+        id: place-nested-metallib
+        if: ${{ !cancelled() && steps.build-nested-tests.outcome == 'success' }}
         working-directory: libs/mlx-swift-lm
-        timeout-minutes: 10
         run: |
           set -euo pipefail
           cp "$RUNNER_TEMP/mlx.metallib" .build/debug/mlx.metallib
@@ -180,9 +200,7 @@ jobs:
               cp "$RUNNER_TEMP/mlx.metallib" "$macos/mlx.metallib"
             fi
           done
-          swift test --skip-build --filter CBv2PagedSafetyTests
-          swift test --skip-build --filter CBv2PrefixCacheHasherTests
-      # NOTE (v0.8.0): the guards below exist because these four gates once
+      # NOTE (v0.8.0): the guards below exist because these gates once
       # reported GREEN while executing NOTHING. `Tests/BenchCBv2Tests`
       # depended on the BenchCBv2 EXECUTABLE target, so SwiftPM routed the
       # swift-testing pass at that binary, which rejects
@@ -192,13 +210,12 @@ jobs:
       #
       # FIXED: BenchCBv2 is now split into a `BenchCBv2Core` library plus a
       # thin executable shim, and the test target depends on the library.
-      # The four suites execute 10 / 14 / 34 / 12 = 70 cases.
       #
       # The guards STAY as a permanent tripwire. This failure mode is silent
       # by construction — a dark suite and a passing one are
       # indistinguishable by exit code — so any future change that re-routes
       # the swift-testing pass must be RED here, not green.
-      # The four suites below are already compiled by the `swift build
+      # The suites below are already compiled by the `swift build
       # --build-tests` step above but were never executed, so the paged-KV
       # migration had no automated numerical gate. They add no compile time,
       # only run time; one step each so a slow or failing suite is
@@ -206,32 +223,54 @@ jobs:
       # placed by the step above.
       #
       # The bodies are ONE script (scripts/run-nested-suite.sh), which is what
-      # carries the executed-count tripwire. Four inline copies of a check
-      # whose failure mode is silence is four chances to edit one and miss
-      # three.
+      # carries the executed-count and zero-skip tripwires. ALL six suites go
+      # through it — a bare `swift test --filter` here would bypass the
+      # tripwire and reintroduce the dark-gate hole the script closes (the
+      # safety and prompt-hash suites below used to run bare for exactly that
+      # reason). Inline copies of a check whose failure mode is silence are
+      # that many chances to edit one and miss the rest.
+      - name: Run nested paged safety tests
+        if: ${{ !cancelled() && steps.place-nested-metallib.outcome == 'success' }}
+        working-directory: libs/mlx-swift-lm
+        # Runtime smoke over the JIT-compiled paged Metal kernels.
+        timeout-minutes: 10
+        run: ../../scripts/run-nested-suite.sh CBv2PagedSafetyTests
+      - name: Run nested prompt-hash tests
+        if: ${{ !cancelled() && steps.place-nested-metallib.outcome == 'success' }}
+        working-directory: libs/mlx-swift-lm
+        # Prefix-cache prompt-hash identity; pure Swift.
+        timeout-minutes: 10
+        run: ../../scripts/run-nested-suite.sh CBv2PrefixCacheHasherTests
       - name: Run nested paged eligibility tests
+        if: ${{ !cancelled() && steps.place-nested-metallib.outcome == 'success' }}
         working-directory: libs/mlx-swift-lm
         # Pure Swift threadgroup-budget arithmetic; no GPU dispatch.
         timeout-minutes: 5
         run: ../../scripts/run-nested-suite.sh CBv2PagedEligibilityTests
       - name: Run nested paged backend tests
+        if: ${{ !cancelled() && steps.place-nested-metallib.outcome == 'success' }}
         working-directory: libs/mlx-swift-lm
         # Pool bookkeeping, per-sequence page tables, windowed rings,
         # reservation admission, backend lifecycle. Small MLX arrays only.
         timeout-minutes: 10
         run: ../../scripts/run-nested-suite.sh CBv2PagedBackendTests
       - name: Run nested paged kernel parity tests
+        if: ${{ !cancelled() && steps.place-nested-metallib.outcome == 'success' }}
         working-directory: libs/mlx-swift-lm
-        # Heaviest of the four: fp32 decode-kernel parity, bitwise
+        # Heaviest of the set: fp32 decode-kernel parity, bitwise
         # batch-composition invariance, and a 200-step greedy token match.
         # Dispatches the JIT-compiled Metal kernels, exactly as
         # CBv2PagedSafetyTests' runtimeSmoke already does in this job.
         timeout-minutes: 20
         run: ../../scripts/run-nested-suite.sh CBv2PagedKernelTests
       - name: Run nested KV-sharing contiguous/paged parity tests
+        if: ${{ !cancelled() && steps.place-nested-metallib.outcome == 'success' }}
         working-directory: libs/mlx-swift-lm
-        # Two-arm differential over TinyTestModel's KV-sharing variant; the
-        # paged arm self-skips (XCTSkip) if the backend is unavailable here.
+        # Two-arm differential over TinyTestModel's KV-sharing variant. The
+        # paged arm used to XCTSkip when the backend was unavailable; the
+        # runner script now FAILS on any skip, because "paged unavailable on
+        # the gate runner" is precisely the condition this lane must not be
+        # green under.
         timeout-minutes: 10
         run: ../../scripts/run-nested-suite.sh CBv2KVSharingParityTests
       - name: Run atomic installer artifact tests

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -9,7 +9,16 @@ jobs:
   integration-tests:
     name: E2E Integration Tests
     runs-on: blacksmith-12vcpu-macos-latest
-    timeout-minutes: 90
+    # Job budget = the sum of every step's worst case, not the warm-path wall
+    # time (a green run takes ~26m with warm caches). Test allowances:
+    # 25m (blocking paged lane) + 15m (expected-red exact-cache lane)
+    # + 10m (default-posture smoke) + 15m (mixed-version, released provider)
+    # + 30m (reverse lane: TWO sequential `go test -timeout 15m` runs)
+    # = 95m. Setup/build/download overhead: ~3m warm, but a cold runner pays
+    # the full Swift provider build, the cargo sidecar build, and the
+    # gpt-oss-20b (~12 GB) + gemma-4 snapshot downloads — budget 25m.
+    # 95m + 25m = 120m.
+    timeout-minutes: 120
     env:
       DARKBLOOM_REPO_ROOT: ${{ github.workspace }}
       DARKBLOOM_PROMPT_SIDECAR_BINARY: ${{ github.workspace }}/coordinator/promptsidecar/target/release/promptsidecar
@@ -213,10 +222,11 @@ jobs:
       #
       # COST, honestly: this is a second provider boot plus a second
       # gpt-oss-20b load (warm HF cache, but the weights still page in) for
-      # two inference round-trips. Same shape as the reverse-compat lane
-      # below, which the repo already budgets 15m for the same two tests.
-      # Step budget for the job is 25+15+10+15+15=80m against a 90m job
-      # timeout (budgets are per-step upper bounds, not expected wall time).
+      # two inference round-trips. Same shape as each half of the
+      # reverse-compat lane below, which budgets 15m per `go test` for the
+      # same two tests. The full job arithmetic (95m of test allowances —
+      # the reverse lane counts TWICE, two sequential 15m runs — plus cold
+      # setup overhead) lives on `timeout-minutes` at the top of the job.
       - name: Run default-posture smoke (.auto = paged — BLOCKING gate)
         env:
           DARKBLOOM_TESTBED_EXPECT_KV_BACKEND: paged

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -88,11 +88,11 @@ jobs:
           print(f"Pinned exact-cache snapshot: {selected.name}")
           PY
 
-      # THE PAGED GATE. Pinned to an EXPLICIT paged posture, not left on the
-      # provider's default, because `.auto` is ALLOWED to degrade: a paged
-      # preflight, capacity-planning or pool-construction failure silently
-      # lands an `.auto` slot on contiguous and the suite still passes. That
-      # made this job green whether or not paged ever ran.
+      # THE PAGED GATE — BLOCKING. Pinned to an EXPLICIT paged posture, not
+      # left on the provider's default, because `.auto` is ALLOWED to degrade:
+      # a paged preflight, capacity-planning or pool-construction failure
+      # silently lands an `.auto` slot on contiguous and the suite still
+      # passes. That made this job green whether or not paged ever ran.
       #
       # `EngineV2KVBackendPolicy.degradesPagedFailure` returns false for an
       # explicit `.paged` selection: it REFUSES the load with
@@ -106,26 +106,27 @@ jobs:
       # `engine_v2_max_concurrent` as 4. Paged at B=4 measures 0.98x of
       # contiguous against 1.17x at B=8, so setting the backend alone would
       # have bought the B=1 regression and none of the throughput.
-      # NON-BLOCKING because of the FIXTURE, not because of the default.
-      # `.auto` resolves PAGED as of v0.8.0, so paged is what the fleet
-      # serves. This lane runs gemma-4-e2b-it-4bit, and e2b is the one
-      # checkpoint where paged ADOPTION is the inexact arm: an adopted
-      # paged slot answers differently from its own cold run. e2b appears
-      # zero times in the production catalog -- on the two models we do
-      # serve, paged adoption is the EXACT arm and contiguous is the one
-      # that diverges -- so this red describes the fixture, not the fleet.
       #
-      # EXPECTED RED until the e2b paged adoption path is fixed or this
-      # fixture moves to a served model. Kept, pinned, and visible rather
-      # than removed: the red IS the finding, and unpinning it would
-      # recreate the "gate that cannot fail" pattern this release fixed
-      # four separate times. Promote back to blocking when the fixture
-      # stops being the exception -- NOT on any further `.auto` change.
-      - name: Run integration + profile tests (paged @ 8 — informational)
-        continue-on-error: true
+      # DARKBLOOM_TESTBED_EXPECT_KV_BACKEND closes the last construction-side
+      # hole: after the providers register, the testbed pre-warms each
+      # advertised slot and asserts the ENGINE-REPORTED `kv_backend` on the
+      # heartbeat equals the lane's declared backend, failing the suite when
+      # it does not. Explicit-paged refusal covers the load path; the
+      # expectation covers everything else (a future degrade path, a testbed
+      # regression that stops writing the TOML, the wrong binary under test).
+      #
+      # BLOCKING as of the v0.8.0 gate audit. This step used to be
+      # `continue-on-error: true` because ONE fixture-specific test
+      # (TestIntegrationExactCacheRouting) is expected-red on paged — which
+      # meant the whole 16-test paged lane could fail without failing the
+      # job, and on the PR head it was in fact swallowing a live FAIL. The
+      # expected-red test now runs in its own informational step below;
+      # everything here must pass.
+      - name: Run integration + profile tests (paged @ 8 — BLOCKING gate)
         env:
           DARKBLOOM_TESTBED_KV_BACKEND: paged
           DARKBLOOM_TESTBED_MAX_CONCURRENT: "8"
+          DARKBLOOM_TESTBED_EXPECT_KV_BACKEND: paged
         run: |
           set -euo pipefail
           PATH="$(brew --prefix postgresql@16)/bin:$PATH"
@@ -141,12 +142,53 @@ jobs:
           echo "KV posture requested: engine_v2_kv_backend=$DARKBLOOM_TESTBED_KV_BACKEND" \
                "engine_v2_max_concurrent=$DARKBLOOM_TESTBED_MAX_CONCURRENT" \
                "DARKBLOOM_CBV2_PAGED_KV=<unset>"
-          echo "Explicit paged refuses rather than degrades, so a green run here" \
-               "served paged. Grep the log for 'provider KV posture' to confirm."
+          echo "Backend assertion armed: the testbed fails any suite whose" \
+               "providers do not report kv_backend=$DARKBLOOM_TESTBED_EXPECT_KV_BACKEND."
           go test ./e2e/ -count=1 -v -timeout 25m -p=1 \
-            -run 'TestIntegration|TestProfile'
+            -run 'TestIntegration|TestProfile' \
+            -skip '^TestIntegrationExactCacheRouting$'
 
-      # Default-posture lane. The step above is the only one that pins a
+      # EXPECTED RED — because of the FIXTURE, not because of the default.
+      # `.auto` resolves PAGED as of v0.8.0, so paged is what the fleet
+      # serves. This test runs gemma-4-e2b-it-4bit, and e2b is the one
+      # checkpoint where paged ADOPTION is the inexact arm: an adopted
+      # paged slot answers differently from its own cold run. e2b appears
+      # zero times in the production catalog -- on the two models we do
+      # serve, paged adoption is the EXACT arm and contiguous is the one
+      # that diverges -- so this red describes the fixture, not the fleet.
+      #
+      # EXPECTED RED until the e2b paged adoption path is fixed or this
+      # fixture moves to a served model. Kept, pinned, and visible rather
+      # than removed: the red IS the finding, and unpinning it would
+      # recreate the "gate that cannot fail" pattern this release fixed
+      # four separate times. Promote back to blocking when the fixture
+      # stops being the exception -- NOT on any further `.auto` change.
+      #
+      # ISOLATED in its own step (v0.8.0 gate audit) so `continue-on-error`
+      # covers exactly the one expected-red test instead of the entire paged
+      # lane it used to blanket. No DARKBLOOM_TESTBED_EXPECT_KV_BACKEND here:
+      # the expectation pre-warms every slot at suite start, and this test's
+      # cold-vs-adopted routing semantics are exactly what a pre-warm would
+      # perturb — its posture is already pinned by the explicit paged TOML.
+      - name: Run exact-cache routing (paged @ 8 — expected red, informational)
+        continue-on-error: true
+        env:
+          DARKBLOOM_TESTBED_KV_BACKEND: paged
+          DARKBLOOM_TESTBED_MAX_CONCURRENT: "8"
+        run: |
+          set -euo pipefail
+          PATH="$(brew --prefix postgresql@16)/bin:$PATH"
+          export PATH
+          if [ -n "${DARKBLOOM_CBV2_PAGED_KV:-}" ]; then
+            echo "::error::DARKBLOOM_CBV2_PAGED_KV=${DARKBLOOM_CBV2_PAGED_KV} is set;" \
+                 "the kill switch degrades paged silently and voids this lane"
+            exit 1
+          fi
+          echo "Expected-red fixture lane: e2b paged adoption is the known inexact arm."
+          go test ./e2e/ -count=1 -v -timeout 15m -p=1 \
+            -run '^TestIntegrationExactCacheRouting$'
+
+      # Default-posture lane. The steps above are the only ones that pin a
       # backend, so without this NOTHING would still exercise what a stock
       # install actually does: launch with no `--config` at all, on `.auto`,
       # at the provider's own memberwise cap. That is a different code path
@@ -158,18 +200,39 @@ jobs:
       # naming `auto` would write a TOML and thereby change the launch path
       # and drop the cap to the decoder's 4, testing neither default.
       #
+      # `.auto` resolves PAGED as of v0.8.0 — that is the release posture and
+      # what a stock install serves. (This step's name previously claimed
+      # `.auto = contiguous`, a leftover from before the flip: the BLOCKING
+      # smoke was labeled as covering the fleet's non-default backend while
+      # actually covering its default.) `.auto` is also the posture that is
+      # ALLOWED to degrade silently, so this lane sets
+      # DARKBLOOM_TESTBED_EXPECT_KV_BACKEND=paged: a stock install that
+      # quietly falls back to contiguous now FAILS this gate with the
+      # engine-reported fallback reason instead of green-lighting a fleet
+      # that no longer serves what the release shipped.
+      #
       # COST, honestly: this is a second provider boot plus a second
       # gpt-oss-20b load (warm HF cache, but the weights still page in) for
       # two inference round-trips. Same shape as the reverse-compat lane
       # below, which the repo already budgets 15m for the same two tests.
-      # Step budget for the job goes 25+15+15=55m to 25+10+15+15=65m against
-      # a 90m job timeout.
-      - name: Run default-posture smoke (.auto = contiguous — BLOCKING gate)
+      # Step budget for the job is 25+15+10+15+15=80m against a 90m job
+      # timeout (budgets are per-step upper bounds, not expected wall time).
+      - name: Run default-posture smoke (.auto = paged — BLOCKING gate)
+        env:
+          DARKBLOOM_TESTBED_EXPECT_KV_BACKEND: paged
         run: |
           set -euo pipefail
           PATH="$(brew --prefix postgresql@16)/bin:$PATH"
           export PATH
-          echo "KV posture requested: provider default (no testbed override)"
+          if [ -n "${DARKBLOOM_CBV2_PAGED_KV:-}" ]; then
+            echo "::error::DARKBLOOM_CBV2_PAGED_KV=${DARKBLOOM_CBV2_PAGED_KV} is set;" \
+                 "the kill switch degrades paged silently and voids this gate"
+            exit 1
+          fi
+          echo "KV posture requested: provider default (no testbed override;" \
+               ".auto resolves paged as of v0.8.0)"
+          echo "Backend assertion armed: a silent .auto degrade to contiguous" \
+               "fails this gate via DARKBLOOM_TESTBED_EXPECT_KV_BACKEND=paged."
           go test ./e2e/ -count=1 -v -timeout 10m -p=1 \
             -run '^TestIntegration_(NonStreaming|Streaming)Inference$'
 
@@ -263,74 +326,11 @@ jobs:
             done
           )
 
-  benchmark:
-    name: E2E Benchmarks
-    runs-on: blacksmith-12vcpu-macos-latest
-    timeout-minutes: 30
-    if: github.event_name == 'pull_request'
-    environment: benchmarks
-    env:
-      DARKBLOOM_REPO_ROOT: ${{ github.workspace }}
-      TESTBED_PROVIDER_CONFIG: debug
-      BENCHMARK_MD_PATH: /tmp/benchmark-results.md
-      RUNNER_DESC: macos-15 (M1 Virtual)
-      GPT_OSS_REVISION: 773a7da77e569019bb0fd17a554b263738d669a3
-      GEMMA_REVISION: 0e3cbab38ce568cf6e23543010d08d03b731910c
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          submodules: recursive
-
-      - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
-        with:
-          go-version-file: go.mod
-
-      - name: Install Postgres
-        run: brew install postgresql@16
-
-      - name: Build provider (Swift)
-        run: |
-          cd provider-swift
-          swift build -c debug
-
-      - name: Extract mlx.metallib
-        run: |
-          python3 -m venv /tmp/mlxvenv
-          /tmp/mlxvenv/bin/pip install 'mlx==0.31.2'
-          cp /tmp/mlxvenv/lib/python*/site-packages/mlx/lib/mlx.metallib \
-             provider-swift/.build/debug/mlx.metallib
-
-      - name: Install Hugging Face client
-        # Benchmarks serve the CBv2 default (gpt-oss-20b, ~12 GB) plus the
-        # secondary multi-model checkpoint (gemma-4-26B QAT, ~14.5 GB) for
-        # TestBenchmark_MultiModelMultiProvider. Warm HF cache ⇒ no-op.
-        run: /tmp/mlxvenv/bin/pip install huggingface_hub
-
-      - name: Download public models (pull request)
-        run: |
-          echo "Pull request: downloading public models without Hugging Face authentication"
-          /tmp/mlxvenv/bin/python -c "import os; from huggingface_hub import snapshot_download; snapshot_download('mlx-community/gpt-oss-20b-MXFP4-Q8', revision=os.environ['GPT_OSS_REVISION'], token=False)"
-          /tmp/mlxvenv/bin/python -c "import os; from huggingface_hub import snapshot_download; snapshot_download('mlx-community/gemma-4-26B-A4B-it-qat-4bit', revision=os.environ['GEMMA_REVISION'], token=False)"
-
-      - name: Run benchmarks
-        run: |
-          PATH="$(brew --prefix postgresql@16)/bin:$PATH"
-          export PATH
-          go test ./e2e/ -count=1 -v -timeout 25m -p=1 \
-            -run 'TestBenchmark'
-
-      - name: Post benchmark results
-        if: always()
-        run: |
-          if [ ! -f /tmp/benchmark-results.md ]; then
-            echo "No benchmark results file found"
-            exit 0
-          fi
-          BODY=$(cat /tmp/benchmark-results.md)
-          gh pr comment ${{ github.event.pull_request.number }} \
-            --body "$BODY" \
-            --edit-last \
-            || gh pr comment ${{ github.event.pull_request.number }} \
-            --body "$BODY"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  # The E2E Benchmarks job used to live here as a second job. It is gated on
+  # the approval-required `benchmarks` environment, which is created on every
+  # PR and — measured over this release's 26 PR runs — never approved, so the
+  # workflow-level status of "Integration Tests" was permanently `waiting`
+  # even when the integration job above had long since completed. The
+  # benchmark job now lives in `.github/workflows/benchmarks.yml` so its
+  # (deliberate, cost-controlling) approval gate holds only its own workflow
+  # open, and this one concludes with the integration job's real result.

--- a/e2e/integration_test.go
+++ b/e2e/integration_test.go
@@ -214,21 +214,122 @@ func TestIntegration_StreamingInference(t *testing.T) {
 	timer.Stop()
 	ri.EndWithDuration(0)
 
-	var chunks int
+	// Counting bare `data: ` lines was vacuous: the `[DONE]` sentinel is a
+	// `data: ` line, so a stream that produced NOTHING but its terminator
+	// (or only role-preamble boilerplate) still passed. Require at least one
+	// payload-bearing chunk: not `[DONE]`, parses as a chunk, and carries
+	// non-empty delta text. gpt-oss is a reasoning model, so the Harmony
+	// analysis channel (`delta.reasoning`) counts as payload exactly as
+	// TestIntegration_StreamingContentValidation already treats it — under a
+	// small token cap the final `content` channel may not start at all.
+	var chunks, payloadChunks int
 	scanner := bufio.NewScanner(resp.Body)
 	for scanner.Scan() {
-		if strings.HasPrefix(scanner.Text(), "data: ") {
-			chunks++
-			ri.StreamChunk(chunks)
+		line := scanner.Text()
+		if !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+		chunks++
+		ri.StreamChunk(chunks)
+		data := strings.TrimPrefix(line, "data: ")
+		if data == "[DONE]" {
+			continue
+		}
+		var chunk struct {
+			Choices []struct {
+				Delta struct {
+					Content   string `json:"content"`
+					Reasoning string `json:"reasoning"`
+				} `json:"delta"`
+			} `json:"choices"`
+		}
+		if err := json.Unmarshal([]byte(data), &chunk); err != nil {
+			continue
+		}
+		if len(chunk.Choices) > 0 &&
+			(chunk.Choices[0].Delta.Content != "" || chunk.Choices[0].Delta.Reasoning != "") {
+			payloadChunks++
 		}
 	}
 	require.Greater(t, chunks, 0, "expected at least one SSE chunk")
-	t.Logf("streaming: received %d SSE chunks", chunks)
+	require.Greater(t, payloadChunks, 0,
+		"expected at least one parseable chunk carrying delta content/reasoning — "+
+			"a stream of boilerplate plus [DONE] is not an inference")
+	t.Logf("streaming: received %d SSE chunks (%d payload-bearing)", chunks, payloadChunks)
 
 	run := tbprofile.NewProfiler(testbed.DefaultTestConfig(), buf).BuildProfile()
 	t.Logf("\n%s", run.SummaryTable())
 
 	assertAccounting(t, s)
+}
+
+// Within-backend greedy determinism: the same temperature-0 prompt, sent
+// twice to the same provider process, must produce byte-identical
+// completions. This is the one CONTENT property the e2e layer can assert
+// without lying: cross-backend token equality is known-divergent on gemma-4
+// (8.85% teacher-forced disagreement, accepted drift) and golden-token
+// pinning would break on any harmless kernel/template change — but a single
+// engine slot answering the same greedy question two different ways is a
+// nondeterminism bug on ANY backend, and no e2e test asserted anything about
+// content at all.
+//
+// The suite runs one provider (startSuite's default), so "the same provider"
+// is structural, and requests are sequential, so both runs decode at batch
+// size 1 — this does not depend on batch-composition invariance, which the
+// live Swift parity suite owns.
+func TestIntegration_GreedyDeterminism(t *testing.T) {
+	s := startSuite(t)
+
+	// 256 tokens for the same reason as TestIntegration_E2EEncryptionCorrectness:
+	// gpt-oss spends its first tokens in the Harmony analysis channel, and the
+	// assertion below wants the final `content` channel populated too.
+	const prompt = "What is 2+2? Answer with just the number."
+	type completion struct {
+		content   string
+		reasoning string
+		tokens    int
+	}
+	run := func(attempt int) completion {
+		resp := postChatCompletions(t, s, prompt, false, 256)
+		defer resp.Body.Close()
+		respBody, _ := io.ReadAll(resp.Body)
+		require.Equal(t, http.StatusOK, resp.StatusCode,
+			"attempt %d: body: %s", attempt, string(respBody[:min(len(respBody), 500)]))
+
+		var result struct {
+			Choices []struct {
+				Message struct {
+					Content   string `json:"content"`
+					Reasoning string `json:"reasoning"`
+				} `json:"message"`
+			} `json:"choices"`
+			Usage struct {
+				CompletionTokens int `json:"completion_tokens"`
+			} `json:"usage"`
+		}
+		require.NoError(t, json.Unmarshal(respBody, &result), "attempt %d", attempt)
+		require.Len(t, result.Choices, 1, "attempt %d", attempt)
+		require.NotEmpty(t, result.Choices[0].Message.Content,
+			"attempt %d produced no content — nothing to compare", attempt)
+		return completion{
+			content:   result.Choices[0].Message.Content,
+			reasoning: result.Choices[0].Message.Reasoning,
+			tokens:    result.Usage.CompletionTokens,
+		}
+	}
+
+	first := run(1)
+	second := run(2)
+
+	require.Equal(t, first.content, second.content,
+		"greedy temperature-0 completions differ across two runs on the same provider — "+
+			"within-backend nondeterminism")
+	require.Equal(t, first.reasoning, second.reasoning,
+		"greedy reasoning channels differ across two runs on the same provider")
+	require.Equal(t, first.tokens, second.tokens,
+		"identical greedy runs reported different completion token counts")
+	t.Logf("determinism: two greedy runs byte-identical (%d completion tokens, content=%q)",
+		first.tokens, first.content[:min(len(first.content), 80)])
 }
 
 func TestIntegration_MultipleRequestsAccounting(t *testing.T) {

--- a/e2e/testbed/config.go
+++ b/e2e/testbed/config.go
@@ -276,6 +276,14 @@ type SuiteConfig struct {
 	// DARKBLOOM_CBV2_PAGED_KV gotcha.
 	KVBackend     string
 	MaxConcurrent int
+	// ExpectKVBackend asserts the KV backend every engine slot was actually
+	// BUILT with ("paged" or "contiguous"); the suite pre-warms each slot and
+	// fails Start when the heartbeat-reported kv_backend differs or never
+	// arrives. "" falls back to DARKBLOOM_TESTBED_EXPECT_KV_BACKEND, and an
+	// unset env leaves the assertion off. Orthogonal to KVBackend: that knob
+	// REQUESTS a backend, this one asserts the CONSTRUCTED one — a lane
+	// exercising the `.auto` default sets only the expectation.
+	ExpectKVBackend string
 }
 
 func DefaultSuiteConfig() SuiteConfig {

--- a/e2e/testbed/kv_expectation.go
+++ b/e2e/testbed/kv_expectation.go
@@ -1,0 +1,194 @@
+package testbed
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/registry"
+)
+
+// Built-backend assertion (v0.8.0 gate audit).
+//
+// Everything else in the KV posture plumbing describes what the testbed ASKS
+// the provider for. Nothing asserted what the engine BUILT: an `.auto` slot
+// whose paged construction fails degrades to contiguous by design, and an
+// explicit-paged lane whose TOML plumbing silently broke would launch on
+// `.auto` and degrade the same way — in both cases the "paged" lane measures
+// contiguous and stays green. This file closes that hole with the one signal
+// that reflects construction truth: `BackendSlotCapacity.KVBackend` on the
+// provider heartbeat, which is `EngineV2Bridge.kvBackendKind` — the RESOLVED
+// backend after every veto and fallback, per slot, every heartbeat.
+//
+// A lane declares intent with DARKBLOOM_TESTBED_EXPECT_KV_BACKEND (or the
+// SuiteConfig field); the suite then refuses to come up unless every
+// (provider, advertised model) slot reports exactly that backend. Slots are
+// pre-warmed through the coordinator's own `load_model` push — the same
+// pre-warm mechanism production uses — because a freshly-booted testbed
+// provider has nothing resident (empty persisted set → `.nothingToPreload`)
+// and a backend that was never constructed cannot be observed.
+
+// EnvExpectKVBackend declares the KV backend every engine slot in the suite
+// must have actually been BUILT with: "paged" or "contiguous". Empty/unset
+// disables the assertion. Distinct from DARKBLOOM_TESTBED_KV_BACKEND, which
+// selects what to REQUEST; this one asserts what was CONSTRUCTED, so a lane
+// can pin the request, the expectation, or both.
+const EnvExpectKVBackend = "DARKBLOOM_TESTBED_EXPECT_KV_BACKEND"
+
+// kvExpectationTimeout bounds the pre-warm + first-observation wait per
+// suite. The dominant term is the model load the pre-warm triggers (a 12 GB
+// checkpoint paging in from a CI runner's disk); the heartbeat that carries
+// the observation follows within the provider's 5s default cadence.
+const kvExpectationTimeout = 5 * time.Minute
+
+// ResolveExpectedKVBackend returns the backend the suite must have built:
+// the explicit value when set, else DARKBLOOM_TESTBED_EXPECT_KV_BACKEND,
+// else "" (assertion disabled). A value that is neither "paged" nor
+// "contiguous" is a hard error, not a silent no-op: a typo in this knob
+// would otherwise disarm the exact assertion the lane exists to make
+// (the same lesson as ResolveMaxConcurrent).
+func ResolveExpectedKVBackend(explicit string) (string, error) {
+	raw := explicit
+	source := "suite config"
+	if raw == "" {
+		raw = os.Getenv(EnvExpectKVBackend)
+		source = "env " + EnvExpectKVBackend
+	}
+	switch raw {
+	case "", KVBackendPaged, KVBackendContiguous:
+		return raw, nil
+	default:
+		return "", fmt.Errorf(
+			"%s=%q is not an assertable KV backend (want %q or %q); "+
+				"refusing to run with a disarmed backend assertion",
+			source, raw, KVBackendPaged, KVBackendContiguous)
+	}
+}
+
+// verifyKVBackendExpectation is the Suite.Start hook: resolve the declared
+// expectation and, when one exists, hold suite startup until every provider
+// slot proves it was built with that backend (or fail the suite).
+func (s *Suite) verifyKVBackendExpectation() error {
+	expected, err := ResolveExpectedKVBackend(s.Config.ExpectKVBackend)
+	if err != nil {
+		return err
+	}
+	if expected == "" {
+		return nil
+	}
+	return VerifyRegistryKVBackends(
+		s.Ctx, s.Coordinator.Registry, expected, kvExpectationTimeout, s.Logger)
+}
+
+// kvSlotTarget is one (provider, model) pair the assertion must observe.
+type kvSlotTarget struct {
+	providerID string
+	model      string
+}
+
+func (t kvSlotTarget) String() string { return t.providerID + "/" + t.model }
+
+// VerifyRegistryKVBackends asserts that every model advertised by every
+// registered provider is served by an engine slot whose heartbeat-reported
+// `kv_backend` equals expected.
+//
+// Mechanics: collect the (provider, advertised model) pairs, push a
+// `load_model` to each so lazily-loading providers construct their engines
+// now (send errors are logged, not fatal — the assertion is the observation,
+// not the push), then poll the registry's per-slot record until every pair
+// reports. A pair that reports a DIFFERENT backend fails immediately, with
+// the engine's own fallback-reason class (kill_switch, kernel_preflight,
+// physical_capacity, ...) in the error so the log names WHY the build
+// degraded. Pairs still unobserved at the deadline fail with the full
+// pending list: "could not verify" is a failure, because the lane declared
+// an expectation and green-without-proof is the exact pattern this exists
+// to end.
+func VerifyRegistryKVBackends(
+	ctx context.Context,
+	reg *registry.Registry,
+	expected string,
+	timeout time.Duration,
+	logger *slog.Logger,
+) error {
+	if expected != KVBackendPaged && expected != KVBackendContiguous {
+		return fmt.Errorf("unassertable expected KV backend %q", expected)
+	}
+
+	var targets []kvSlotTarget
+	reg.ForEachProvider(func(p *registry.Provider) {
+		p.Mu().Lock()
+		for _, m := range p.Models {
+			if m.ID != "" {
+				targets = append(targets, kvSlotTarget{providerID: p.ID, model: m.ID})
+			}
+		}
+		p.Mu().Unlock()
+	})
+	sort.Slice(targets, func(i, j int) bool { return targets[i].String() < targets[j].String() })
+	if len(targets) == 0 {
+		return fmt.Errorf(
+			"KV backend expectation %q declared but no provider advertises any model — nothing to assert",
+			expected)
+	}
+
+	logger.Info("verifying built KV backend",
+		"expected", expected, "slots", len(targets), "timeout", timeout)
+
+	// Pre-warm: a fresh testbed provider loads lazily, and an engine that was
+	// never constructed reports nothing. Fire-and-forget by design; a
+	// provider that cannot load will simply never report and the deadline
+	// below converts that into a failure that names it.
+	for _, t := range targets {
+		if err := reg.SendLoadModel(t.providerID, t.model); err != nil {
+			logger.Warn("kv-backend pre-warm load_model send failed",
+				"provider_id", t.providerID, "model", t.model, "error", err)
+		}
+	}
+
+	deadline := time.Now().Add(timeout)
+	pending := targets
+	for {
+		var stillPending []kvSlotTarget
+		for _, t := range pending {
+			backend, fallback := reg.SlotKVBackendTags(t.providerID, t.model)
+			switch backend {
+			case expected:
+				logger.Info("built KV backend verified",
+					"provider_id", t.providerID, "model", t.model, "kv_backend", backend)
+			case registry.KVBackendUnknown:
+				// No heartbeat has named this slot yet — keep waiting.
+				stillPending = append(stillPending, t)
+			default:
+				return fmt.Errorf(
+					"provider %s built kv_backend=%q for %s (fallback reason class: %s); "+
+						"this lane declares %s=%q — the engine under test is not the one "+
+						"the lane claims to measure",
+					t.providerID, backend, t.model, fallback, EnvExpectKVBackend, expected)
+			}
+		}
+		if len(stillPending) == 0 {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			names := make([]string, len(stillPending))
+			for i, t := range stillPending {
+				names[i] = t.String()
+			}
+			return fmt.Errorf(
+				"KV backend expectation %q unverified after %v: no heartbeat named a backend "+
+					"for [%s]. Either the pre-warm load failed (an explicit-paged build REFUSES "+
+					"instead of degrading — check the provider log for pagedUnavailable), the "+
+					"model never loaded, or the provider predates per-slot kv_backend reporting",
+				expected, timeout, strings.Join(names, ", "))
+		}
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("KV backend expectation %q interrupted: %w", expected, ctx.Err())
+		case <-time.After(500 * time.Millisecond):
+		}
+	}
+}

--- a/e2e/testbed/kv_expectation_test.go
+++ b/e2e/testbed/kv_expectation_test.go
@@ -1,0 +1,181 @@
+package testbed
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+	"github.com/eigeninference/d-inference/coordinator/registry"
+)
+
+// These tests drive the REAL registry (Register + Heartbeat, the same ingest
+// path a live provider's frames take), not a stub of it: the assertion under
+// test exists because "looked verified" and "was verified" diverged once
+// already, and a mocked registry would let them diverge again silently.
+
+func kvExpectationLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(&strings.Builder{}, nil))
+}
+
+func registerExpectationProvider(r *registry.Registry, id string, models ...string) {
+	infos := make([]protocol.ModelInfo, 0, len(models))
+	for _, m := range models {
+		infos = append(infos, protocol.ModelInfo{ID: m, ModelType: "gpt_oss", Quantization: "4bit"})
+	}
+	r.Register(id, nil, &protocol.RegisterMessage{
+		Type:    "register",
+		Backend: "mlx",
+		Models:  infos,
+	})
+}
+
+func heartbeatKVBackend(r *registry.Registry, id string, backendByModel map[string]string) {
+	slots := make([]protocol.BackendSlotCapacity, 0, len(backendByModel))
+	for model, backend := range backendByModel {
+		b := backend
+		slots = append(slots, protocol.BackendSlotCapacity{
+			Model:     model,
+			State:     "running",
+			KVBackend: &b,
+		})
+	}
+	r.Heartbeat(id, &protocol.HeartbeatMessage{
+		Type:   protocol.TypeHeartbeat,
+		Status: "serving",
+		BackendCapacity: &protocol.BackendCapacity{
+			TotalMemoryGB: 64,
+			Slots:         slots,
+		},
+	})
+}
+
+func TestResolveExpectedKVBackendValidatesInsteadOfDisarming(t *testing.T) {
+	t.Setenv(EnvExpectKVBackend, "")
+
+	if got, err := ResolveExpectedKVBackend(""); err != nil || got != "" {
+		t.Fatalf("unset expectation = (%q, %v), want disabled with no error", got, err)
+	}
+	if got, err := ResolveExpectedKVBackend(KVBackendPaged); err != nil || got != KVBackendPaged {
+		t.Fatalf("explicit paged = (%q, %v)", got, err)
+	}
+
+	t.Setenv(EnvExpectKVBackend, KVBackendContiguous)
+	if got, err := ResolveExpectedKVBackend(""); err != nil || got != KVBackendContiguous {
+		t.Fatalf("env contiguous = (%q, %v)", got, err)
+	}
+	// Suite config wins over env, mirroring the KVBackend request knob.
+	if got, err := ResolveExpectedKVBackend(KVBackendPaged); err != nil || got != KVBackendPaged {
+		t.Fatalf("explicit-over-env = (%q, %v)", got, err)
+	}
+
+	// A typo must be a hard error: silently disarming the assertion is the
+	// exact failure mode this knob exists to remove.
+	t.Setenv(EnvExpectKVBackend, "pagd")
+	if _, err := ResolveExpectedKVBackend(""); err == nil {
+		t.Fatal("misspelled expectation resolved silently instead of failing")
+	}
+	// "auto" is a request, not an observable build — reject it too.
+	if _, err := ResolveExpectedKVBackend("auto"); err == nil {
+		t.Fatal("'auto' accepted as an expectation; only built kinds are assertable")
+	}
+}
+
+func TestVerifyRegistryKVBackendsPassesWhenEverySlotMatches(t *testing.T) {
+	r := registry.New(kvExpectationLogger())
+	registerExpectationProvider(r, "box-a", "m/one")
+	registerExpectationProvider(r, "box-b", "m/one", "m/two")
+	heartbeatKVBackend(r, "box-a", map[string]string{"m/one": registry.KVBackendPaged})
+	heartbeatKVBackend(r, "box-b", map[string]string{
+		"m/one": registry.KVBackendPaged,
+		"m/two": registry.KVBackendPaged,
+	})
+
+	err := VerifyRegistryKVBackends(
+		context.Background(), r, KVBackendPaged, 5*time.Second, kvExpectationLogger())
+	if err != nil {
+		t.Fatalf("all-paged fleet failed a paged expectation: %v", err)
+	}
+}
+
+func TestVerifyRegistryKVBackendsFailsFastOnMismatchWithFallbackReason(t *testing.T) {
+	r := registry.New(kvExpectationLogger())
+	registerExpectationProvider(r, "box-degraded", "m/one")
+	backend := registry.KVBackendContiguous
+	reason := "kernel_preflight: paged decode kernel failed self-check"
+	r.Heartbeat("box-degraded", &protocol.HeartbeatMessage{
+		Type:   protocol.TypeHeartbeat,
+		Status: "serving",
+		BackendCapacity: &protocol.BackendCapacity{
+			TotalMemoryGB: 64,
+			Slots: []protocol.BackendSlotCapacity{{
+				Model:                   "m/one",
+				State:                   "running",
+				KVBackend:               &backend,
+				KVBackendFallbackReason: &reason,
+			}},
+		},
+	})
+
+	start := time.Now()
+	err := VerifyRegistryKVBackends(
+		context.Background(), r, KVBackendPaged, 30*time.Second, kvExpectationLogger())
+	if err == nil {
+		t.Fatal("a contiguous slot passed a paged expectation — the silent-degrade hole is back")
+	}
+	// Mismatch is a verdict, not a wait: it must not burn the deadline.
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Fatalf("mismatch took %v to report; must fail fast, not poll out the deadline", elapsed)
+	}
+	for _, want := range []string{registry.KVBackendContiguous, "kernel_preflight", EnvExpectKVBackend} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("mismatch error %q does not name %q", err.Error(), want)
+		}
+	}
+}
+
+func TestVerifyRegistryKVBackendsFailsWhenNothingEverReports(t *testing.T) {
+	r := registry.New(kvExpectationLogger())
+	// Registered, advertises a model, but never heartbeats a slot — the
+	// pre-0.8.0 provider shape, or a load that never completed. "Could not
+	// verify" must be a failure that names the slot, not a green.
+	registerExpectationProvider(r, "box-silent", "m/one")
+
+	err := VerifyRegistryKVBackends(
+		context.Background(), r, KVBackendPaged, 1500*time.Millisecond, kvExpectationLogger())
+	if err == nil {
+		t.Fatal("an unobservable fleet passed the expectation")
+	}
+	if !strings.Contains(err.Error(), "box-silent/m/one") {
+		t.Fatalf("timeout error %q does not name the unverified slot", err.Error())
+	}
+}
+
+func TestVerifyRegistryKVBackendsWaitsForALateFirstHeartbeat(t *testing.T) {
+	r := registry.New(kvExpectationLogger())
+	registerExpectationProvider(r, "box-lazy", "m/one")
+
+	// The production sequence: registration first, engine construction and
+	// the first capacity heartbeat only after the pre-warm load completes.
+	go func() {
+		time.Sleep(400 * time.Millisecond)
+		heartbeatKVBackend(r, "box-lazy", map[string]string{"m/one": registry.KVBackendPaged})
+	}()
+
+	err := VerifyRegistryKVBackends(
+		context.Background(), r, KVBackendPaged, 10*time.Second, kvExpectationLogger())
+	if err != nil {
+		t.Fatalf("late-but-matching heartbeat failed the expectation: %v", err)
+	}
+}
+
+func TestVerifyRegistryKVBackendsRefusesAnEmptyFleet(t *testing.T) {
+	r := registry.New(kvExpectationLogger())
+	err := VerifyRegistryKVBackends(
+		context.Background(), r, KVBackendPaged, time.Second, kvExpectationLogger())
+	if err == nil {
+		t.Fatal("expectation with nothing to assert must fail, not vacuously pass")
+	}
+}

--- a/e2e/testbed/suite.go
+++ b/e2e/testbed/suite.go
@@ -194,7 +194,14 @@ func (s *Suite) Start(ctx context.Context) (err error) {
 	if err = s.startProviders(); err != nil {
 		return err
 	}
-	err = s.waitForProviderRegistration(3 * time.Minute)
+	if err = s.waitForProviderRegistration(3 * time.Minute); err != nil {
+		return err
+	}
+	// Built-backend assertion: when the lane declares an expected KV backend
+	// (DARKBLOOM_TESTBED_EXPECT_KV_BACKEND or SuiteConfig.ExpectKVBackend),
+	// refuse to come up until every provider slot proves the engine it
+	// actually constructed matches. See kv_expectation.go.
+	err = s.verifyKVBackendExpectation()
 	return err
 }
 

--- a/provider-swift/Tests/DarkbloomFanCoreTests/FanControllerTests.swift
+++ b/provider-swift/Tests/DarkbloomFanCoreTests/FanControllerTests.swift
@@ -903,7 +903,17 @@ struct FanControllerTests {
         backend.installWriteHook { key, bytes in
             if key == "F0Md", bytes == [1] {
                 entered.signal()
-                release.wait()
+                // Holding engage INSIDE its critical section is the point of
+                // this test, and the hook runs on the actor's thread — a
+                // cooperative-pool thread — so this wait unavoidably parks
+                // one. Two mitigations keep that safe: the coordination
+                // below runs entirely on a GCD thread, so releasing this
+                // wait never itself needs a pool thread (no starvation
+                // cycle), and the wait is BOUNDED so a pathological stall
+                // degrades to a weaker-contention run instead of wedging
+                // the suite. Actor serialization still guarantees the
+                // ordering assertion either way.
+                _ = release.wait(timeout: .now() + 30)
             }
         }
         let controller = try makeController(backend: backend)
@@ -911,11 +921,27 @@ struct FanControllerTests {
         let engage = Task.detached {
             try await controller.engage(speedPercent: 80)
         }
-        #expect(await waitForSemaphore(entered, timeout: .now() + 2) == .success)
-        let restore = Task.detached {
-            try await controller.restoreAutomatic()
-        }
-        release.signal()
+        // Wait for engage to reach the held write, issue restore, and unblock
+        // the hook — all from ONE dedicated GCD thread. The previous shape did
+        // this from the test's own task with a 2-second deadline: under
+        // full-suite load the detached engage task could take longer than 2s
+        // just to be SCHEDULED, and the test flaked on scheduler latency
+        // rather than on anything about the controller. The deadline is now
+        // generous (it bounds only the failure path) and no step between
+        // "engage reached the hook" and "hook released" depends on the
+        // cooperative pool having a free thread.
+        let (reached, restore): (DispatchTimeoutResult, Task<Void, any Error>) =
+            await withCheckedContinuation { continuation in
+                DispatchQueue.global().async {
+                    let reached = entered.wait(timeout: .now() + 30)
+                    let restore = Task.detached {
+                        try await controller.restoreAutomatic()
+                    }
+                    release.signal()
+                    continuation.resume(returning: (reached, restore))
+                }
+            }
+        #expect(reached == .success, "engage never reached the held F0Md write")
         _ = try await engage.value
         try await restore.value
 
@@ -946,17 +972,6 @@ private func captureControllerError(
     } catch {
         Issue.record("unexpected error type: \(error)")
         return nil
-    }
-}
-
-private func waitForSemaphore(
-    _ semaphore: DispatchSemaphore,
-    timeout: DispatchTime
-) async -> DispatchTimeoutResult {
-    await withCheckedContinuation { continuation in
-        DispatchQueue.global().async {
-            continuation.resume(returning: semaphore.wait(timeout: timeout))
-        }
     }
 }
 

--- a/provider-swift/Tests/ProviderCoreTests/EngineV2PagedParityLiveTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/EngineV2PagedParityLiveTests.swift
@@ -151,6 +151,28 @@ struct EngineV2PagedParityLiveTests {
             max_tokens: maxTokens)
     }
 
+    /// Triage for a loop-gate arm's `ensureModelLoaded` failure. Exactly ONE
+    /// failure shape is an environmental skip: the PRE-load free-memory gate
+    /// (`evictUntilAvailable`) refusing because this box is busy — an
+    /// `InferenceError.modelLoadFailed` carrying the gate's
+    /// "Insufficient memory (X GB free, need Y GB) …" message. Everything
+    /// else reaching this catch IS a load-path regression the loop gates
+    /// exist to expose — explicit-paged refusal (the policy REFUSES instead
+    /// of degrading for an explicit `.paged` selection), VLM extraction or
+    /// engine-construction breakage, an invalid model directory, the
+    /// post-bridge headroom guard unloading a fresh paged slot — and must
+    /// fail the test, not return green.
+    private func triageLoopGateLoadFailure(_ error: Error, arm: String) {
+        if case InferenceError.modelLoadFailed(let message) = error,
+            message.hasPrefix("Insufficient memory (")
+        {
+            print("[\(arm)] skipping — pre-load free-memory gate refused on this busy box: \(message)")
+            return
+        }
+        Issue.record(
+            "\(arm): ensureModelLoaded failed with a non-memory-pressure error — a load-path regression, not a busy box: \(String(describing: error))")
+    }
+
     /// Mixed-length greedy workload: different prompts and budgets so
     /// concurrent rows join/leave at different steps (the batch-composition
     /// churn the oracle must survive).
@@ -327,16 +349,10 @@ struct EngineV2PagedParityLiveTests {
         do {
             try await loop.ensureModelLoaded(modelId: Self.gptossModelID)
         } catch {
-            // A busy box legitimately fails the PRE-load free-memory gate;
-            // that is a box condition, not a regression — skip loudly.
-            // The post-bridge guard failure this test exists for reads
-            // "engine build left insufficient KV headroom" and must FAIL.
-            let text = String(describing: error)
-            if text.contains("engine build left insufficient KV headroom") {
-                Issue.record("post-bridge guard unloaded the paged slot: \(text)")
-                return
-            }
-            print("[paged-loop] skipping — load gate refused on this box: \(text)")
+            // Only the pre-load free-memory refusal skips; every other load
+            // failure (including the post-bridge headroom guard) records an
+            // Issue and fails. See triageLoopGateLoadFailure.
+            triageLoopGateLoadFailure(error, arm: "paged-loop")
             return
         }
 
@@ -504,16 +520,12 @@ struct EngineV2PagedParityLiveTests {
         do {
             try await loop.ensureModelLoaded(modelId: Self.gemmaModelID)
         } catch {
-            // Same triage as the gpt-oss arm: a busy box legitimately fails
-            // the PRE-load free-memory gate (box condition, skip loudly);
-            // the post-bridge headroom guard unloading a fresh paged slot is
-            // the regression this drill exists for and must FAIL.
-            let text = String(describing: error)
-            if text.contains("engine build left insufficient KV headroom") {
-                Issue.record("post-bridge guard unloaded the paged gemma slot: \(text)")
-                return
-            }
-            print("[gemma-paged-loop] skipping — load gate refused on this box: \(text)")
+            // Same triage as the gpt-oss arm: only the pre-load free-memory
+            // refusal skips; explicit-paged refusal, VLM extraction failure,
+            // engine-construction breakage, an invalid model dir, and the
+            // post-bridge headroom guard all FAIL. See
+            // triageLoopGateLoadFailure.
+            triageLoopGateLoadFailure(error, arm: "gemma-paged-loop")
             return
         }
 

--- a/provider-swift/Tests/ProviderCoreTests/EngineV2PagedParityLiveTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/EngineV2PagedParityLiveTests.swift
@@ -21,15 +21,32 @@
 //      finish — deeper-token drift between decode kernels is allowed and
 //      logged for eyeballing.
 //
-// Gemma-4 paged is deliberately NOT covered here: production gemma
-// checkpoints are VLM slots, which the gate vetoes to contiguous by
-// design (text-only gemma paged is covered by the tiny-model gate tests
-// and the engine repo's BenchCBv2RealModel --engines v2-paged runs).
+// Gemma-4 (VLM) paged IS covered here — see the two gemma arms at the end
+// of the suite. An earlier revision excluded it on the premise that
+// production gemma checkpoints "are VLM slots, which the gate vetoes to
+// contiguous by design". That premise is FALSE: the VLM veto in
+// `EngineV2KVBackendPolicy.applySlotVetoes` fires only when the paged cache
+// does NOT vouch for multimodal span masks, and
+// `PagedLayerCache.honorsSpanMaskContextsByConstruction == true` makes the
+// veto inert — so gemma-4 VLM slots build and serve PAGED in production
+// under `.auto` exactly like every other model, and a live suite that never
+// exercised that was gating a fiction. What the gemma arms deliberately do
+// NOT assert is cross-backend token equality: gemma-4's paged-vs-contiguous
+// greedy divergence is known and ACCEPTED (8.85% teacher-forced
+// disagreement, floor-gated separately in PagedTeacherForcedAgreementTests),
+// so the assertable properties for this model are batch-composition
+// invariance WITHIN the paged backend and serve-liveness through the real
+// ProviderLoop load gates.
 //
 // Gated like every multi-GB suite: DARKBLOOM_LIVE_MLX_TESTS=1 + the
 // checkpoint in the local HF cache; skips cleanly otherwise. The logical
 // grant is 8 GiB; the physical pool is independently capped by production
 // policy.
+//
+// MEMORY: the suite is `.serialized` and the gemma arms are declared AFTER
+// the gpt-oss arms on purpose — the two checkpoints (~12 GiB + ~15 GiB)
+// must never be resident concurrently within this suite; a live full-suite
+// run already peaks around 30.5 GiB with other suites in parallel.
 
 import Foundation
 import MLX
@@ -344,5 +361,184 @@ struct EngineV2PagedParityLiveTests {
         #expect(out.1 == nil, "paged slot must serve after passing the guards: \(out.1 ?? "")")
         #expect(!out.0.isEmpty)
         await loop.unloadModel(Self.gptossModelID)
+    }
+
+    // MARK: - Gemma-4 (VLM) arms — declared last; see the MEMORY note above.
+
+    static let gemmaModelID = "mlx-community/gemma-4-26B-A4B-it-qat-4bit"
+
+    private func gemmaGreedyRequest(_ prompt: String, maxTokens: Int) -> ChatCompletionRequest {
+        ChatCompletionRequest(
+            model: Self.gemmaModelID,
+            messages: [ChatMessage(role: "user", content: prompt)],
+            temperature: 0,
+            max_tokens: maxTokens)
+    }
+
+    /// Batch-composition invariance on the model the header used to claim
+    /// could not serve paged. Cross-backend token equality is NOT asserted
+    /// (known, accepted divergence — see the header); what a VLM gemma slot
+    /// must still deliver on the paged backend is the ragged-NaN-class
+    /// oracle: each request's greedy output byte-identical whether it
+    /// decoded alone or with batchmates.
+    ///
+    /// Built through `LiveInferenceFixtures.loadBridge` (the production
+    /// `EngineV2SlotFactory.makeProductionBridge` construction, VLM text
+    /// extraction included) with an explicit "paged" selection — which
+    /// REFUSES rather than degrades, so reaching the assertions at all
+    /// proves construction; the `kvBackendKind` check pins it against a
+    /// future revival of the VLM veto silently seating contiguous.
+    @Test("explicit paged gemma-4 (VLM): solo == concurrent, token-exact")
+    func gemmaPagedBatchCompositionInvariance() async throws {
+        guard LiveInferenceFixtures.liveTestsEnabled else { return }
+        let loaded = try await LiveInferenceFixtures.loadBridge(
+            modelID: Self.gemmaModelID,
+            maxConcurrentRequests: Int(BackendSettings.defaultEngineV2MaxConcurrent),
+            memoryBudgetBytes: 48 * Self.gib,
+            kvBackendConfig: "paged")
+        let bridge = loaded.bridge
+
+        // Only non-throwing #expects from here on, so control always reaches
+        // the deterministic shutdown below and the next (serialized) test
+        // never overlaps this model's residency.
+        #expect(
+            await bridge.kvBackendKind == .paged,
+            "explicit paged must construct for a VLM gemma-4 slot — the span-mask veto is inert (PagedLayerCache.honorsSpanMaskContextsByConstruction)")
+
+        var solos: [(text: String, completion: Int)] = []
+        for (index, item) in Self.workload.enumerated() {
+            let out = await collect(
+                await bridge.submit(
+                    request: gemmaGreedyRequest(item.prompt, maxTokens: item.maxTokens),
+                    requestId: "gemma-paged-solo-\(index)"))
+            #expect(out.error == nil, "gemma solo \(index) errored: \(out.error ?? "")")
+            #expect(out.completion > 0, "gemma solo \(index) produced no tokens")
+            solos.append((out.text, out.completion))
+        }
+
+        let batched = await withTaskGroup(
+            of: (Int, (text: String, completion: Int, error: String?)).self
+        ) { group in
+            for (index, item) in Self.workload.enumerated() {
+                group.addTask {
+                    let out = await self.collect(
+                        await bridge.submit(
+                            request: self.gemmaGreedyRequest(
+                                item.prompt, maxTokens: item.maxTokens),
+                            requestId: "gemma-paged-batch-\(index)"))
+                    return (index, out)
+                }
+            }
+            var results = [(text: String, completion: Int, error: String?)?](
+                repeating: nil, count: Self.workload.count)
+            for await (index, out) in group { results[index] = out }
+            return results
+        }
+        for (index, maybe) in batched.enumerated() {
+            guard let out = maybe else {
+                Issue.record("gemma concurrent \(index) never finished")
+                continue
+            }
+            #expect(out.error == nil, "gemma concurrent \(index) errored: \(out.error ?? "")")
+            #expect(
+                out.text == solos[index].text,
+                "gemma batch-composition variance on request \(index): solo=\(solos[index].text.prefix(120)) batched=\(out.text.prefix(120))")
+        }
+
+        await bridge.shutdown()
+        MLX.Memory.clearCache()
+    }
+
+    /// Serve-liveness through the REAL `ProviderLoop.ensureModelLoaded`
+    /// gates for the gemma-4 VLM checkpoint — the same loop-path drill the
+    /// gpt-oss arm runs, on the model whose production posture (VLM slot,
+    /// paged under `.auto`) this suite previously never exercised.
+    @Test("loop path: paged gemma-4 (VLM) survives the load guards and serves")
+    func gemmaPagedSlotSurvivesLoadGuardsThroughProviderLoop() async throws {
+        guard LiveInferenceFixtures.liveTestsEnabled else { return }
+        guard LiveInferenceFixtures.ensureMetallibColocated() != nil else {
+            throw LiveFixtureSkip.missingMetallib
+        }
+        guard case .found = LiveInferenceFixtures.locate(Self.gemmaModelID) else {
+            throw LiveFixtureSkip.modelNotInCache(Self.gemmaModelID)
+        }
+        let gib: UInt64 = 1 << 30
+        let reserveGiB: UInt64 = 40
+
+        let config = ProviderLoopConfig(
+            coordinatorURL: "ws://127.0.0.1:0/ignored",
+            hardware: HardwareInfo(
+                machineModel: "Mac16,5", chipName: "Apple M4 Max", chipFamily: .m4,
+                chipTier: .max,
+                memoryGb: ProcessInfo.processInfo.physicalMemory / gib,
+                memoryAvailableGb: max(1, ProcessInfo.processInfo.physicalMemory / gib - 4),
+                cpuCores: CpuCores(total: 16, performance: 12, efficiency: 4),
+                gpuCores: 40, memoryBandwidthGbs: 546
+            ),
+            models: [
+                ModelInfo(
+                    id: Self.gemmaModelID, modelType: "gemma4",
+                    sizeBytes: 15 * gib, estimatedMemoryGb: 16.0)
+            ],
+            config: ProviderConfig(
+                provider: ProviderSettings(
+                    name: "gemma-paged-loop-live", memoryReserveGB: reserveGiB),
+                backend: BackendSettings(
+                    idleTimeoutMins: 0,
+                    maxModelSlots: 1,
+                    engineV2KVBackend: "paged"),
+                coordinator: CoordinatorSettings(heartbeatIntervalSecs: 60)
+            )
+        )
+        let loop = try ProviderLoop(
+            config: config, purgeLegacyFiles: false, attestationSigner: nil)
+        let runtime = EngineV2Runtime()
+        await loop.setEngineV2RuntimeForTesting(runtime)
+        defer {
+            Task {
+                await loop.unloadModel(Self.gemmaModelID)
+                MLX.Memory.clearCache()
+            }
+        }
+
+        do {
+            try await loop.ensureModelLoaded(modelId: Self.gemmaModelID)
+        } catch {
+            // Same triage as the gpt-oss arm: a busy box legitimately fails
+            // the PRE-load free-memory gate (box condition, skip loudly);
+            // the post-bridge headroom guard unloading a fresh paged slot is
+            // the regression this drill exists for and must FAIL.
+            let text = String(describing: error)
+            if text.contains("engine build left insufficient KV headroom") {
+                Issue.record("post-bridge guard unloaded the paged gemma slot: \(text)")
+                return
+            }
+            print("[gemma-paged-loop] skipping — load gate refused on this box: \(text)")
+            return
+        }
+
+        let bridge = try #require(await loop.slotBridgeForTesting(modelId: Self.gemmaModelID))
+        let servedKind = await bridge.kvBackendKind
+        #expect(
+            servedKind == .paged,
+            "loop path must serve VLM gemma-4 PAGED — the span-mask veto is inert by construction")
+        let out = await {
+            var text = ""
+            var error: String?
+            for await event in await bridge.submit(
+                request: ChatCompletionRequest(
+                    model: Self.gemmaModelID,
+                    messages: [ChatMessage(role: "user", content: "Say OK.")],
+                    temperature: 0, max_tokens: 8),
+                requestId: "gemma-paged-loop-1")
+            {
+                if case .chunk(let c) = event { text += c }
+                if case .error(let e) = event { error = e }
+            }
+            return (text, error)
+        }()
+        #expect(out.1 == nil, "paged gemma slot must serve after passing the guards: \(out.1 ?? "")")
+        #expect(!out.0.isEmpty)
+        await loop.unloadModel(Self.gemmaModelID)
     }
 }

--- a/provider-swift/Tests/ProviderCoreTests/GPUEnforcementTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/GPUEnforcementTests.swift
@@ -30,13 +30,31 @@ struct GPUEnforcementTests {
         #expect(status.recommendedMaxWorkingSetSizeBytes > 0, "working set should be positive")
     }
 
-    @Test("requireMetal pins MLX default device to GPU")
-    func requireMetalPinsGPU() throws {
-        // Even if some other test has set CPU as default, requireMetal()
-        // must restore GPU.
-        Device.setDefault(device: .cpu)
-        _ = try GPUEnforcement.requireMetal()
-        #expect(Device.defaultDevice().deviceType == .gpu, "default device must be GPU after requireMetal()")
+    @Test("requireMetal restores a CPU-planted default back to GPU (child process)")
+    func requireMetalPinsGPU() async {
+        // MLX's default device is PROCESS-GLOBAL, and swift-testing runs
+        // suites in parallel inside ONE process. This test used to plant
+        // `Device.setDefault(device: .cpu)` inline to prove requireMetal()
+        // restores GPU — and in the window before the restore, any
+        // concurrently-running suite that dispatched a GPU-only Metal kernel
+        // died with `[metal_kernel] Only supports the GPU` → fatalError →
+        // SIGTRAP, killing the whole test process (observed live as a flake
+        // attributed to whichever suite happened to be mid-dispatch).
+        // `.serialized` cannot fix that: it serializes within a suite, never
+        // across suites sharing the process, and the CPU plant's blast
+        // radius is exactly cross-suite.
+        //
+        // The assertion is worth keeping in its strong form — "requireMetal
+        // RESTORES gpu from a planted cpu default", not merely "gpu stays
+        // gpu" — so the plant runs in a CHILD process via an exit test. The
+        // child owns its global device; the parent process never leaves GPU.
+        await #expect(processExitsWith: .success) {
+            Device.setDefault(device: .cpu)
+            _ = try GPUEnforcement.requireMetal()
+            #expect(
+                Device.defaultDevice().deviceType == .gpu,
+                "default device must be GPU after requireMetal()")
+        }
     }
 
     @Test("requireMetal is idempotent")

--- a/provider-swift/Tests/ProviderCoreTests/PagedDecodeAccuracyProbeTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/PagedDecodeAccuracyProbeTests.swift
@@ -22,6 +22,11 @@
 // |K| <= 1.66, |V| <= 16.9), so the reference is the exact answer both are
 // approximating and "closer to the reference" is a meaningful ranking.
 //
+// The enabled path ASSERTS (v0.8.0 audit): per shape/history, paged's
+// reference relErr must stay within 3x of contiguous's — DRIFT passes, a
+// materially-less-accurate kernel (the BUG reading) fails. The dark path
+// (env unset) stays an early return with no assertions.
+//
 // No model weights. Run with:
 //   DARKBLOOM_PAGED_DIVERGENCE_PROBE=1 \
 //     swift test --filter PagedDecodeAccuracyProbeTests
@@ -156,13 +161,23 @@ struct PagedDecodeAccuracyProbeTests {
                 let pagedOut = try run(paged: true)
                 let contigOut = try run(paged: false)
 
-                // fp32 reference over the SAME values. The decode query sees
-                // the whole history here (history + 1 <= window for every case
-                // above), so no mask is needed.
+                // fp32 reference over the SAME values, restricted to the key
+                // set the real arms actually attend. A sliding row retains
+                // only the trailing `window` positions, self inclusive
+                // (`retainedCount = min(written, window)` — identical on
+                // both backends), so whenever history + 1 > window a
+                // maskless full-history reference is WRONG BY CONSTRUCTION:
+                // it scores keys both arms already evicted. That invalid row
+                // used to report a fictitious ~0.841 relErr on BOTH arms for
+                // `gptoss sliding` at history 200 vs window 128. Slicing to
+                // the attended range (instead of masking) gives the exact
+                // softmax support set; for history + 1 <= window it is the
+                // whole history, unchanged.
+                let attendedStart = shape.window.map { max(0, history + 1 - $0) } ?? 0
                 let reference = PagedAttentionReference.composedAttention(
                     queries: qAll[0..., 0..., step, 0...].asType(.float32),
-                    keys: kAll.asType(.float32),
-                    values: vAll.asType(.float32),
+                    keys: kAll[0..., 0..., attendedStart..., 0...].asType(.float32),
+                    values: vAll[0..., 0..., attendedStart..., 0...].asType(.float32),
                     scale: shape.scale, boolMask: nil, sinks: nil, softcap: nil)
                 eval(reference)
 
@@ -170,14 +185,14 @@ struct PagedDecodeAccuracyProbeTests {
                 // bug look like in these same units? A window off-by-one, an
                 // evicted page, or a mis-resolved page table all present as
                 // "the query attended the wrong key set". The mildest such
-                // failure is losing exactly ONE key at the oldest end, so
-                // that is the planted bug. A gate whose threshold does not
-                // sit between the honest disagreement and this number is not
-                // a gate.
+                // failure is losing exactly ONE key at the oldest end OF THE
+                // ATTENDED WINDOW, so that is the planted bug. A gate whose
+                // threshold does not sit between the honest disagreement and
+                // this number is not a gate.
                 let planted = PagedAttentionReference.composedAttention(
                     queries: qAll[0..., 0..., step, 0...].asType(.float32),
-                    keys: kAll[0..., 0..., 1..., 0...].asType(.float32),
-                    values: vAll[0..., 0..., 1..., 0...].asType(.float32),
+                    keys: kAll[0..., 0..., (attendedStart + 1)..., 0...].asType(.float32),
+                    values: vAll[0..., 0..., (attendedStart + 1)..., 0...].asType(.float32),
                     scale: shape.scale, boolMask: nil, sinks: nil, softcap: nil)
                 eval(planted)
 
@@ -191,6 +206,31 @@ struct PagedDecodeAccuracyProbeTests {
                             "[acc] %@  %4d   %12.3e   %12.3e   %12.3e   %7.2fx   %12.3e",
                         shape.name, history, p.rel, c.rel, pc.rel,
                         c.rel > 0 ? p.rel / c.rel : Float.nan, bug.rel))
+
+                // ==== THE GATE (v0.8.0 audit): the minimal honest assertion
+                // this probe supports. Paged may not sit more than 3x farther
+                // from the fp32 reference than contiguous does, per shape and
+                // history. Why 3x and not tighter: both arms are equally
+                // valid fp16 evaluations whose individual error is dominated
+                // by reduction-order rounding, so their RATIO is a noisy
+                // statistic — measured ratios run 0.04x..1.22x across shapes
+                // (contiguous is the LESS accurate arm on gemma4-full!), so
+                // sub-3x movement is indistinguishable from kernel scheduling
+                // and cannot be interpreted as a defect. What 3x separates on
+                // MOST shapes is rounding noise from a wrong key set: the
+                // planted one-lost-key calibration measures 1e-1..1e0 there,
+                // 50-500x above honest disagreement. On gemma4-full at long
+                // histories the planted bug measures BELOW the noise
+                // (4.8e-05 at h=33) — the calibration finding, restated: a
+                // subtle wrong-key-set bug is sub-drift on some shapes and
+                // NOT catchable at this seam by any threshold, so a tighter
+                // bound would only flap on noise while catching nothing this
+                // loose one misses. The absolute floor keeps a degenerate
+                // near-zero contiguous error from turning the ratio into a
+                // coin toss.
+                #expect(
+                    p.rel <= max(3.0 * c.rel, 1e-6),
+                    "\(shape.name) history \(history): paged relErr \(p.rel) exceeds 3x contiguous relErr \(c.rel) against the fp32 reference — the paged kernel is materially less accurate, not merely different (one-lost-key calibration for this shape: \(bug.rel))")
                 MLX.Memory.clearCache()
             }
         }

--- a/provider-swift/Tests/ProviderCoreTests/PagedDivergenceProbeTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/PagedDivergenceProbeTests.swift
@@ -583,7 +583,9 @@ struct PagedDivergenceProbeTests {
 
 // MARK: - Teacher-forced agreement
 
-/// The measurement behind the proposed replacement gate.
+/// The replacement gate (measurement AND assertion — see the per-model
+/// floors in `agreementRates`; the dark path with the env vars unset stays
+/// an early return that asserts nothing).
 ///
 /// Free-running greedy comparison is a bad instrument: after ONE flip the two
 /// arms are reading different contexts, so every later step is comparing two
@@ -630,9 +632,27 @@ struct PagedTeacherForcedAgreementTests {
     func agreementRates() async throws {
         guard Self.enabled else { return }
         let probe = PagedDivergenceProbeTests()
-        for (modelID, isVLM, budget) in [
-            ("mlx-community/gemma-4-26B-A4B-it-qat-4bit", true, 72),
-            ("mlx-community/gpt-oss-20b-MXFP4-Q8", false, 48),
+        // `candidateFloor` is the per-model gate on the paged-fp16 candidate
+        // arm, in percent agreement. Calibration (2026-07, M4 Max 128 GB,
+        // this exact harness):
+        //   * gpt-oss measured 100.00% — clean, so it is pinned EXACT: any
+        //     flip on gpt-oss is new behavior and must fail.
+        //   * gemma-4 measured 91.15% — the accepted cross-backend drift
+        //     (equally-valid fp16 evaluations disagreeing at near-ties,
+        //     amplified by 30 layers of top-8-of-128 MoE routing; see the
+        //     margin statistics this test prints). The 88% floor sits below
+        //     the measured drift band and catches only GROSS regression
+        //     (wrong key set, broken gather, corrupted pages — failure modes
+        //     that measured orders of magnitude worse in the planted-bug
+        //     calibration of PagedDecodeAccuracyProbeTests).
+        // DO NOT "tighten" the gemma floor toward 91%: the calibration
+        // finding is that subtle real bugs present BELOW the drift band —
+        // they are not catchable by this statistic at any threshold — so a
+        // tighter floor buys no bug-detection, only a gate that flaps
+        // whenever legitimate drift wanders a point.
+        for (modelID, isVLM, budget, candidateFloor) in [
+            ("mlx-community/gemma-4-26B-A4B-it-qat-4bit", true, 72, 88.0),
+            ("mlx-community/gpt-oss-20b-MXFP4-Q8", false, 48, 100.0),
         ] {
             let live = try await probe.loadForAgreement(
                 modelID: modelID, isVLM: isVLM, budget: budget * 1024 * 1024 * 1024,
@@ -745,6 +765,29 @@ struct PagedTeacherForcedAgreementTests {
             print(
                 "[tf]   flip-position overlap fp16 vs fp32: \(a.intersection(b).count)"
                     + " of \(a.count)/\(b.count) — identical set: \(a == b)")
+
+            // ==== THE GATE (v0.8.0 audit): measure AND assert. ====
+            // This test used to print the three agreement rates and assert
+            // nothing — a 0%-agreement paged backend would have exited green.
+            func agreementPercent(_ label: String) -> Double {
+                guard let t = totals[label], t.total > 0 else { return -1 }
+                return 100.0 * Double(t.agree) / Double(t.total)
+            }
+            let controlRate = agreementPercent("contiguous-rerun")
+            let candidateRate = agreementPercent("paged-fp16(candidate)")
+
+            // Control arm first: the same backend re-scored against its own
+            // forced tokens. Anything under 100% means the HARNESS is
+            // nondeterministic and neither number below says anything about
+            // the paged backend — fail on the instrument, loudly, so a bad
+            // candidate reading is never trusted or "explained".
+            #expect(
+                controlRate == 100.0,
+                "\(modelID): contiguous-rerun control scored \(controlRate)% (want exactly 100%) — the harness is nondeterministic and every arm's rate is meaningless")
+
+            #expect(
+                candidateRate >= candidateFloor,
+                "\(modelID): paged-fp16 candidate teacher-forced agreement \(candidateRate)% fell below the \(candidateFloor)% floor (gpt-oss calibrated 100.00% exact; gemma-4 calibrated 91.15% with accepted drift) — gross paged regression")
             MLX.Memory.clearCache()
         }
     }

--- a/provider-swift/Tests/ProviderCoreTests/StartupPreloadTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/StartupPreloadTests.swift
@@ -442,31 +442,38 @@ struct StartupPreloadGateTests {
     @Test("gate proceeds at the timeout; loads continue in the background")
     func gateTimesOutAndContinuesInBackground() async throws {
         let recorder = PreloadRecorder()
+        let releaseLoad = PreloadGate()
         let loop = try await makePreloadLoop(
             models: [preloadModelInfo("a", memoryGb: 2)],
             backend: BackendSettings(
                 preloadModels: ["a"],
                 startupPreloadTimeoutSecs: 1,  // minimum configurable gate
                 startupSelftest: false))
-        // One 3s load vs a 1s gate: generous margins in both directions so a
-        // parallel-suite scheduling stall can't flip the outcome.
+        // EVENT-DRIVEN, not timer-vs-timer. This used to race a 1s gate
+        // against a 3s scripted load and assert the gate's wall-clock
+        // elapsed stayed under 2.8s — which measured the machine's
+        // scheduler, not the gate: under full-suite load either timer's
+        // wakeup could stretch past the margin and flip the outcome (the
+        // elapsed bound was the suite's reliable flake). The load now PARKS
+        // on an async gate the test releases only after the outcome is
+        // asserted, so "the gate released while the load was still running"
+        // is guaranteed by construction and no wall-clock number is
+        // asserted at all. The only timer left is the gate's own 1s
+        // timeout — the production code under test.
         await loop.setStartupPreloadLoadOverrideForTesting({ id in
-            try await Task.sleep(for: .seconds(3))
+            await releaseLoad.wait()
             recorder.recordLoad(id)
         })
 
-        let clock = ContinuousClock()
-        let start = clock.now
         let outcome = await loop.runStartupPreloadGateForTesting()
-        let gateElapsed = clock.now - start
 
-        // Availability beats perfection: the gate released at ~1s even though
-        // ~2s of loading remained.
+        // Availability beats perfection: the gate released while the load
+        // (still parked on releaseLoad) provably had not finished.
         #expect(outcome == .timedOut)
-        #expect(gateElapsed < .milliseconds(2800))
         #expect(recorder.loads.isEmpty)
 
         // The driver keeps warming in the background after the gate released.
+        releaseLoad.signal()
         var waited = 0
         while recorder.loads.isEmpty, waited < 200 {
             try await Task.sleep(for: .milliseconds(50))

--- a/provider-swift/Tests/ProviderCoreTests/StartupPreloadTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/StartupPreloadTests.swift
@@ -465,7 +465,40 @@ struct StartupPreloadGateTests {
             recorder.recordLoad(id)
         })
 
-        let outcome = await loop.runStartupPreloadGateForTesting()
+        // FAIL-SAFE, independent of the code under test: the load stays
+        // parked until AFTER the outcome is asserted, so if the production
+        // 1s gate timeout regresses and never fires, the gate call would
+        // await forever and turn that regression into a suite-level hang
+        // (the CI step has no shorter timeout of its own). Race the gate
+        // against a 30s deadline — comfortably above the 1s production
+        // bound. When the deadline wins it releases the parked load (so the
+        // hung gate can unwind through the warm path and the task group can
+        // drain) and the test fails promptly with a clear message. The
+        // deadline arm signals ONLY on a genuine 30s elapse: on the normal
+        // path its sleep is cancelled and it exits without touching
+        // releaseLoad, keeping the loads-empty assertion below race-free.
+        let raced = await withTaskGroup(
+            of: ProviderLoop.StartupPreloadGateOutcome?.self
+        ) { group in
+            group.addTask { await loop.runStartupPreloadGateForTesting() }
+            group.addTask {
+                do {
+                    try await Task.sleep(for: .seconds(30))
+                } catch {
+                    return nil  // gate resolved first; deadline cancelled
+                }
+                releaseLoad.signal()
+                return nil
+            }
+            let first = await group.next() ?? nil
+            group.cancelAll()
+            return first
+        }
+        guard let outcome = raced else {
+            Issue.record(
+                "startup preload gate did not resolve within the 30s test fail-safe — the production 1s gate timeout never fired. Failing instead of hanging the suite; the parked load was force-released so the run can unwind.")
+            return
+        }
 
         // Availability beats perfection: the gate released while the load
         // (still parked on releaseLoad) provably had not finished.

--- a/scripts/run-nested-suite.sh
+++ b/scripts/run-nested-suite.sh
@@ -37,3 +37,19 @@ if ! grep -qE 'Test run with [1-9][0-9]* test|Executed [1-9][0-9]* test' "$log";
     echo "::error::${filter} executed ZERO tests — the gate did not run"
     exit 1
 fi
+
+# The executed-count check above is satisfiable by a run that SKIPPED every
+# test it "executed": XCTest prints `Executed 3 tests, with 3 tests skipped`
+# and swift-testing prints a skip count too, both with exit code 0. A suite
+# whose every case self-skips (XCTSkip on a missing fixture, a gating env var
+# nobody set) asserts nothing — the same dark-gate failure mode, one layer up.
+# Fail on ANY nonzero skip count: these nested suites are hermetic by design
+# (tiny models, no weights, no env gates), so a skip here means a precondition
+# broke, not that skipping was intended.
+if grep -qE 'with [1-9][0-9]* tests? skipped|skipped [1-9][0-9]* test' "$log"; then
+    echo "::error::${filter} skipped one or more tests — a skipped gate gates" \
+         "nothing. If the skip is a broken precondition (missing metallib," \
+         "missing fixture), fix the precondition; do not let the lane stay" \
+         "green on a suite that did not run its assertions."
+    exit 1
+fi

--- a/scripts/run-nested-suite.sh
+++ b/scripts/run-nested-suite.sh
@@ -39,14 +39,25 @@ if ! grep -qE 'Test run with [1-9][0-9]* test|Executed [1-9][0-9]* test' "$log";
 fi
 
 # The executed-count check above is satisfiable by a run that SKIPPED every
-# test it "executed": XCTest prints `Executed 3 tests, with 3 tests skipped`
-# and swift-testing prints a skip count too, both with exit code 0. A suite
-# whose every case self-skips (XCTSkip on a missing fixture, a gating env var
-# nobody set) asserts nothing — the same dark-gate failure mode, one layer up.
-# Fail on ANY nonzero skip count: these nested suites are hermetic by design
-# (tiny models, no weights, no env gates), so a skip here means a precondition
-# broke, not that skipping was intended.
-if grep -qE 'with [1-9][0-9]* tests? skipped|skipped [1-9][0-9]* test' "$log"; then
+# test it "executed", and the two frameworks report skips in DIFFERENT shapes
+# (both reproduced on the pinned Swift 6.1 toolchain):
+#
+#   XCTest aggregate (CBv2KVSharingParityTests, CBv2PrefixCacheHasherTests):
+#     Executed 2 tests, with 1 test skipped and 0 failures (0 unexpected) ...
+#
+#   swift-testing per-test line (the four CBv2Paged* suites):
+#     ✘ Test skip() skipped: "missing fixture"
+#     ✘ Test conditionSkip() skipped.
+#   ...while its AGGREGATE counts skipped cases as passed —
+#     ✔ Test run with 4 tests passed after 0.001 seconds.
+#   — so there is no skip count to grep for; only the per-test line exists.
+#
+# A suite whose every case self-skips (XCTSkip on a missing fixture, a
+# .disabled/.enabled(if:) trait nobody meant to trip) asserts nothing — the
+# same dark-gate failure mode, one layer up. Fail on ANY skip: these nested
+# suites are hermetic by design (tiny models, no weights, no env gates), so a
+# skip here means a precondition broke, not that skipping was intended.
+if grep -qE '✘ (Test|Suite) .+ skipped[.:]|with [1-9][0-9]* tests? skipped|skipped [1-9][0-9]* test' "$log"; then
     echo "::error::${filter} skipped one or more tests — a skipped gate gates" \
          "nothing. If the skip is a broken precondition (missing metallib," \
          "missing fixture), fix the precondition; do not let the lane stay" \

--- a/scripts/run-nested-suite.sh
+++ b/scripts/run-nested-suite.sh
@@ -46,18 +46,26 @@ fi
 #     Executed 2 tests, with 1 test skipped and 0 failures (0 unexpected) ...
 #
 #   swift-testing per-test line (the four CBv2Paged* suites):
-#     ✘ Test skip() skipped: "missing fixture"
-#     ✘ Test conditionSkip() skipped.
+#     ✘ Test skip() skipped: "missing fixture"        (Swift 6.1 runtime)
+#     ➜ Test skip() skipped: "missing fixture"        (Swift 6.3 runtime)
+#     ✘ Test conditionSkip() skipped.                  (no-reason variant)
 #   ...while its AGGREGATE counts skipped cases as passed —
 #     ✔ Test run with 4 tests passed after 0.001 seconds.
 #   — so there is no skip count to grep for; only the per-test line exists.
+#
+# The LEADING GLYPH IS TOOLCHAIN-DEPENDENT (✘ on 6.1, ➜ on 6.3; both
+# reproduced empirically, and stable across tty/pipe, NO_COLOR, and
+# SWT_SF_SYMBOLS_ENABLED) — so the pattern must not hardcode any glyph.
+# `^[^A-Za-z0-9]*` anchors to line start and admits only glyph/space bytes
+# before "Test"/"Suite", which keeps prose inside a test's own log output
+# from matching while accepting whatever symbol a future runtime picks.
 #
 # A suite whose every case self-skips (XCTSkip on a missing fixture, a
 # .disabled/.enabled(if:) trait nobody meant to trip) asserts nothing — the
 # same dark-gate failure mode, one layer up. Fail on ANY skip: these nested
 # suites are hermetic by design (tiny models, no weights, no env gates), so a
 # skip here means a precondition broke, not that skipping was intended.
-if grep -qE '✘ (Test|Suite) .+ skipped[.:]|with [1-9][0-9]* tests? skipped|skipped [1-9][0-9]* test' "$log"; then
+if grep -qE '^[^A-Za-z0-9]*(Test|Suite) .+ skipped[.:]|with [1-9][0-9]* tests? skipped|skipped [1-9][0-9]* test' "$log"; then
     echo "::error::${filter} skipped one or more tests — a skipped gate gates" \
          "nothing. If the skip is a broken precondition (missing metallib," \
          "missing fixture), fix the precondition; do not let the lane stay" \


### PR DESCRIPTION
## Summary

The v0.8.0 release (#590) flips the fleet's default KV backend to PagedAttention and deleted the 24h canary soaks on the premise that CI is the safety net. The gate audit then established the gates provide close to no signal. This PR makes them capable of failing on the regressions they exist to catch — without flipping the one deliberately-red fixture to green.

The three headline changes:

1. **The paged e2e lane becomes blocking.** `integration.yml`'s `continue-on-error: true` covered the whole 16-test paged lane and was actively swallowing a live `--- FAIL: TestIntegrationExactCacheRouting` on this PR's head. The expected-red exact-cache fixture (gemma-4-e2b, the one checkpoint where paged *adoption* is the inexact arm — the red is the finding) now runs in its own `continue-on-error` step with the full rationale preserved; everything else in the lane fails the job.
2. **The testbed asserts the backend that was actually BUILT.** Nothing anywhere verified which backend constructed — an `.auto` paged failure silently degrades to contiguous, and the "paged" lane would then measure contiguous forever. New `DARKBLOOM_TESTBED_EXPECT_KV_BACKEND`: after provider registration the suite pre-warms every advertised slot through the coordinator's own `load_model` push, then fails startup unless every slot's heartbeat-reported `kv_backend` (`EngineV2Bridge.kvBackendKind` — the resolved kind after every veto and fallback) matches the lane's declaration, naming the engine's fallback-reason class (`kill_switch`, `kernel_preflight`, …) on mismatch. Wired in both blocking lanes: explicit-paged expects `paged`, and the default-posture smoke — renamed from the load-bearing misinformation `.auto = contiguous` to `.auto = paged` — also expects `paged`, so a silent `.auto` degrade now fails a blocking gate instead of green-lighting a fleet that stopped serving what the release shipped.
3. **Teacher-forced agreement becomes an assertion.** `PagedTeacherForcedAgreementTests` computed per-model top-1 agreement across three arms on real weights, printed it, and asserted nothing (0 `#expect` in the file). Enabled path now gates: contiguous-rerun control **== 100%** (anything less means the harness is nondeterministic — fail the instrument, not the candidate), gpt-oss candidate **== 100%** (calibrated clean), gemma-4 candidate **≥ 88%** (calibrated 91.15%; the in-code note explains why the floor must NOT be tightened — subtle bugs measure below the drift band and are not catchable by this statistic at any threshold, so a tighter floor only flaps). Dark path (env unset) is untouched: early return, no assertions, ~0s.

And the rest of the audit list:

| # | Fix |
|---|-----|
| 4 | `scripts/run-nested-suite.sh` also fails on a **nonzero skip count** — `Executed 3 tests, with 3 tests skipped` used to satisfy the executed-count tripwire. |
| 5 | `CBv2PagedSafetyTests` + `CBv2PrefixCacheHasherTests` no longer run as bare `swift test --filter` (which bypassed the tripwire); all six nested suites go through the script, one step each. |
| 6 | All six nested paged steps run under `if: ${{ !cancelled() && <build prerequisites succeeded> }}` — a unit-test flake can no longer skip the paged correctness gates (on this PR's head, all six reported `skipped` because of unrelated unit flakes). Nested failures still fail the job. |
| 7 | De-flaked the three named flakes: `GPUEnforcementTests` no longer plants a process-global CPU default in a parallel test process (the plant moves to a child process via an exit test — `.serialized` can't help since it doesn't serialize across suites); `FanControllerTests.concurrentCallsSerialize` moves its wait/issue/release coordination onto a dedicated GCD thread with a 30s bounded hook hold (was a 2s hard deadline that measured scheduler latency); `StartupPreloadTests` gate-timeout test is now event-driven (load parks on a gate the test releases only after asserting the outcome) instead of racing a 1s timer against a 3s timer under a 2.8s wall-clock bound. |
| 8 | `PagedDecodeAccuracyProbeTests` gets its minimal honest assertion (paged relErr ≤ 3× contiguous vs the fp32 reference; in-code note on why tighter is impossible) and its invalid reference row fixed: `gptoss sliding` at history 200 vs window 128 used a maskless full-history reference — wrong by construction, reporting a fictitious 0.841 on both arms. The reference is now sliced to the attended window (`retainedCount = min(written, window)`, the exact semantics of both backends). |
| 9 | `EngineV2PagedParityLiveTests` excluded gemma-4 on a false premise ("VLM slots, vetoed to contiguous by design" — `PagedLayerCache.honorsSpanMaskContextsByConstruction = true` makes that veto inert, so gemma-4 VLM slots serve paged in production). Header fixed; gemma-4 arms added asserting what IS assertable: batch-composition invariance within the paged backend and serve-liveness through the real `ProviderLoop` load gates — deliberately NOT cross-backend token equality (known, accepted 8.85% teacher-forced divergence). Declared after the gpt-oss arms in the `.serialized` suite so the two checkpoints are never resident together. |
| 10 | e2e content gates: new `TestIntegration_GreedyDeterminism` (same greedy temperature-0 prompt twice to the same provider must be byte-identical — within-backend determinism, the one content property that is assertable given accepted cross-backend drift), and `TestIntegration_StreamingInference` no longer counts `data: [DONE]` as a chunk — it requires at least one parseable chunk carrying delta content/reasoning. |
| 11 | The `Integration Tests` workflow sat `waiting` on 26/26 PR runs. Root cause: not the runner — the e2e job runs and completes on `blacksmith-12vcpu-macos-latest` — but the `E2E Benchmarks` job's `environment: benchmarks`, which has a required-reviewer rule and has never been approved, holding the whole workflow's status open forever. The benchmark job moves to its own workflow (`benchmarks.yml`), so its (deliberate, cost-controlling) approval gate holds only its own status open and `Integration Tests` concludes with the integration job's real result. The approval rule itself lives in repo Settings → Environments → `benchmarks` and is untouched. |

Also: `.github/actionlint.yaml` declares the Blacksmith runner labels so `actionlint` is usable as a gate (the three touched workflow files now lint clean).

**Deliberately NOT done:** `DARKBLOOM_LIVE_MLX_TESTS` / `DARKBLOOM_PAGED_DIVERGENCE_PROBE` are not set in any workflow — the gate is package-wide (16 files wake up, missing weights fail rather than skip, 26 GiB of weights and ~30.5 GiB RSS), so no hosted runner can run them. They remain local/self-hosted tools; the follow-up is a runner with a model cache. Branch protection is untouched. The expected-red exact-cache lane stays red on purpose.

## Behavior: what merges green, before vs after

```mermaid
flowchart LR
  subgraph Before["Before — gates that could not fail"]
    A1[Any paged e2e regression] -->|continue-on-error over whole lane| G1[job green]
    B1[.auto silently degrades to contiguous] -->|nothing asserts built backend| G1
    C1[Unrelated unit-test flake] -->|nested paged steps skipped| G1
    D1[Nested suite all-skipped / run bare] -->|tripwire bypassed or satisfied| G1
    E1[Paged agreement collapses to 0%] -->|probe prints, asserts nothing| G1
    F1[Every PR run] -->|benchmarks env never approved| W1[workflow status: waiting forever]
  end
  subgraph After["After — same events, real verdicts"]
    A2[Any paged e2e regression] -->|blocking lane| R2[job red]
    B2[.auto silently degrades] -->|DARKBLOOM_TESTBED_EXPECT_KV_BACKEND=paged fails suite startup with fallback reason| R2
    C2[Unrelated unit-test flake] -->|"if: !cancelled() — six nested gates still run"| V2[paged gates verdict preserved]
    D2[Nested suite all-skipped or zero-test] -->|run-nested-suite.sh tripwires| R2
    E2[Agreement below floor / control below 100%] -->|#expect in enabled path| R2
    F2[Every PR run] -->|benchmarks in own workflow| K2[Integration Tests concludes; only E2E Benchmarks waits for approval]
    X2[gemma-4-e2b exact-cache fixture red] -->|its own continue-on-error step, rationale preserved| I2[informational — still visible, still red]
  end
```

## Code: which gates moved from vacuous to real

```mermaid
flowchart TB
  subgraph Before["Before"]
    ba["integration.yml: one paged step<br/>continue-on-error: true<br/>run TestIntegration | TestProfile"] --> bb["exit code discarded"]
    bc["Suite.Start: register providers,<br/>force-trust, return"] --> bd["no backend observation"]
    be["ci.yml: swift test --filter CBv2PagedSafetyTests<br/>swift test --filter CBv2PrefixCacheHasherTests (bare)"] --> bf["no executed-count tripwire"]
    bg["run-nested-suite.sh: grep 'Executed [1-9]'"] --> bh["all-skipped run passes"]
    bi["agreementRates(): totals -> print"] --> bj["0 #expect"]
    bk["TestIntegration_StreamingInference:<br/>count 'data: ' lines"] --> bl["[DONE] counts as a chunk"]
  end
  subgraph After["After"]
    aa["integration.yml: blocking paged step<br/>(-skip exact-cache) + isolated expected-red step<br/>+ .auto smoke renamed and armed"] --> ab["real exit codes; expected-red scoped to one test"]
    ac["Suite.Start -> verifyKVBackendExpectation()<br/>-> VerifyRegistryKVBackends():<br/>SendLoadModel pre-warm, poll SlotKVBackendTags,<br/>fail on mismatch/timeout"] --> ad["built backend proven per slot,<br/>fallback class named on failure"]
    ae["ci.yml: six steps, all via run-nested-suite.sh,<br/>if: !cancelled() + prerequisite outcomes"] --> af["tripwires on every suite,<br/>flake cannot skip them"]
    ag["run-nested-suite.sh: + fail on<br/>'with N tests skipped'"] --> ah["skips are red"]
    ai["agreementRates(): totals -> print -> #expect<br/>control == 100%, candidate >= per-model floor"] --> aj["probe is a gate"]
    ak["StreamingInference: parse chunks,<br/>require delta content/reasoning; new<br/>TestIntegration_GreedyDeterminism"] --> al["content asserted end to end"]
  end
```

## Verification (all run on this branch)

- `actionlint` clean on `ci.yml`, `integration.yml`, `benchmarks.yml` (via new `.github/actionlint.yaml` runner-label vocabulary); `bash -n scripts/run-nested-suite.sh` clean.
- `cd e2e && go build ./... && go vet ./...` clean; `gofmt` clean; full `e2e/testbed/...` unit suites pass. The new `kv_expectation` tests drive a **real** `registry.Registry` through `Register`/`Heartbeat` (pass / mismatch-with-fallback-reason / never-reports / late-heartbeat / empty-fleet).
- `cd provider-swift && swift build --build-tests` clean; `GPUEnforcementTests` 4/4 (the CPU plant now runs in a child process via an exit test), `FanControllerTests` 40/40, `StartupPreload*` 24/24.
- **Dark path** (gating env unset): all 4 probe/parity suites, 11 tests, pass in **0.001s** of test time — the added assertions cost CI nothing.
- **Enabled path, run live** (M4 Max 128 GB, weights in local HF cache):
  - Teacher-forced agreement (109s): gemma-4 contiguous-rerun control **100.00%** (192/192), paged-fp16 candidate **91.15%** (175/192, floor 88) — matching the calibration exactly; fp32 control also 91.15% (flips land on low-margin near-ties: flipped p50 margin 0.60 vs agreed p50 5.92). gpt-oss: all three arms **100.00%**.
  - Decode-accuracy probe: every shape/history passes the 3× bound (measured ratios 0.04x–1.22x); the fixed `gptoss sliding @200` row now reads 2.0e-03/1.8e-03 (ratio 1.11x) instead of the fictitious 0.841-on-both-arms.
  - New gemma-4 parity arms: batch-composition invariance and loop-path serve-liveness both pass on real weights (35s).
- **End-to-end proof of the backend gate against a real provider** (local Postgres + built provider binary): with `DARKBLOOM_TESTBED_EXPECT_KV_BACKEND=paged` and a default `.auto` launch, suite startup pre-warmed via `load_model`, the heartbeat named `kv_backend=paged`, verification passed, test green (54s). With the expectation deliberately set to `contiguous`, startup **failed loud**: `provider … built kv_backend="paged" … (fallback reason class: none); this lane declares DARKBLOOM_TESTBED_EXPECT_KV_BACKEND="contiguous" — the engine under test is not the one the lane claims to measure`. The gate can fail; that is the point of this PR.

**Do not merge without a green `Integration Tests` run on this branch — the newly-blocking lane is doing its first real work here.**

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/592"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787777835&installation_model_id=21733&pr_number=592&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F592&signature=e1965aba9137855fa04469dfbabf397ff47400978b33b97d192dc152bd363571"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->