### PR TITLE
fix(v0.8.0): ten instrumentation and parity-harness follow-ups (merge after #590)

### DIFF
--- a/coordinator/api/dispatch.go
+++ b/coordinator/api/dispatch.go
@@ -1486,12 +1486,17 @@ func (d *dispatchState) latchDeterministicLoser(provider *registry.Provider, msg
 		d.s.ddIncr("routing.dispatch_client_error_stop", []string{"model:" + d.model, "code:" + strconv.Itoa(msg.StatusCode), "src:race_loser"})
 		d.terminalClientError = true
 		d.terminalClientErrorCode = msg.StatusCode
+		// The verdict slot owns the terminal outcome's kv_backend attribution
+		// from this point (see latchTerminalAttribution): the response the
+		// client gets IS this loser's 4xx, whatever the surviving racer does.
+		d.latchTerminalAttribution(provider)
 		return
 	}
 	// Mirror the jinja_* reason stop (E4) at the race-loser site for the same
 	// masking reason: a deterministic template-render failure from the loser
 	// must not be storm-resumed through the survivor's transient error.
 	if d.latchJinjaTerminalReject(msg.ErrorReason, "race_loser") {
+		d.latchTerminalAttribution(provider)
 		return
 	}
 	budget := providerReportedBudget(provider, d.model)
@@ -1499,6 +1504,7 @@ func (d *dispatchState) latchDeterministicLoser(provider *registry.Provider, msg
 		d.s.ddIncr("routing.dispatch_to_capacity_503", []string{"model:" + d.model, "reason:deterministic"})
 		d.unservable = true
 		d.unservableReason = rejectionReasonOversized
+		d.latchTerminalAttribution(provider)
 	}
 }
 
@@ -2175,7 +2181,11 @@ func (d *dispatchState) racePrimaryFailedWaitBackup(backupProvider *registry.Pro
 	// The primary already failed and d.pr is cleared: the BACKUP is the only
 	// racer left, so every failure or timeout below is the backup's. Re-latch
 	// now so the terminal outcome names the backup's backend rather than
-	// falling back to the dead primary's latch.
+	// falling back to the dead primary's latch. When the primary's failure
+	// latched a DETERMINISTIC verdict (latchDeterministicLoser just ran), the
+	// re-latch is a no-op by design: the terminal response will be the
+	// primary's 4xx/422/429, so the primary keeps the attribution even
+	// though the backup keeps racing (noteServingSlotFor's freeze rule).
 	d.noteServingSlotFor(backupPR)
 	backupDeadline := time.NewTimer(d.deadline - d.speculativeAt)
 	for {

--- a/coordinator/api/dispatch_speculative_outcome_test.go
+++ b/coordinator/api/dispatch_speculative_outcome_test.go
@@ -134,6 +134,131 @@ func TestSpeculativeBackupFailureAttributesBackupKVBackend(t *testing.T) {
 	}
 }
 
+// heartbeatSlotKV reports a serving slot with an explicit KV backend for the
+// provider, so kvBackendAttribution resolves a real tag instead of unknown.
+func heartbeatSlotKV(d *dispatchState, p *registry.Provider, backend string) {
+	d.s.registry.Heartbeat(p.ID, &protocol.HeartbeatMessage{
+		Type:   protocol.TypeHeartbeat,
+		Status: "serving",
+		BackendCapacity: &protocol.BackendCapacity{
+			TotalMemoryGB: 64,
+			Slots: []protocol.BackendSlotCapacity{
+				{Model: d.model, State: "running", KVBackend: &backend},
+			},
+		},
+	})
+}
+
+// TestDeterministicPrimaryVerdictKeepsPrimaryAttribution pins the freeze rule
+// (the deterministic-loser interaction with the backup re-latch): when the
+// PRIMARY's failure latches a deterministic terminal verdict — a client 4xx
+// identical on every provider — the terminal response IS that verdict no
+// matter what the backup does next, so the outcome attribution must keep
+// naming the primary's backend. The re-latch on entry to
+// racePrimaryFailedWaitBackup is a deliberate no-op in that state; without
+// the freeze, the primary's controlling 400 booked under the backup's
+// kv_backend tag.
+func TestDeterministicPrimaryVerdictKeepsPrimaryAttribution(t *testing.T) {
+	d, _, primary, primaryPR, backup, backupPR := speculativeFailureTestState(t, time.Second, 500*time.Millisecond)
+	heartbeatSlotKV(d, primary, registry.KVBackendPaged)
+	heartbeatSlotKV(d, backup, registry.KVBackendContiguous)
+
+	// Dispatch latched the primary's slot...
+	d.pr = primaryPR
+	d.noteServingSlot()
+
+	// ...then the primary failed with a deterministic client 4xx: runRace's
+	// ErrorCh arm records the failure, latches the verdict, and clears
+	// d.provider/d.pr before entering the backup wait.
+	verdict := protocol.InferenceErrorMessage{
+		Error:       "prompt malformed",
+		ErrorReason: "bad_request",
+		StatusCode:  http.StatusBadRequest,
+	}
+	d.updateSpeculativeFailure(primaryPR, verdict)
+	d.latchDeterministicLoser(primary, verdict)
+	if !d.terminalClientError {
+		t.Fatal("the primary's 400 must latch a terminal client verdict")
+	}
+	d.pr, d.provider, d.requestID = nil, nil, ""
+
+	// The backup fails too — its 502 must NOT steal the attribution.
+	backupPR.ErrorCh <- protocol.InferenceErrorMessage{
+		Error:       "backup failed",
+		ErrorReason: "backup_failure",
+		StatusCode:  http.StatusBadGateway,
+	}
+	if got := d.racePrimaryFailedWaitBackup(backup, backupPR, nil); got != outcomeRetry {
+		t.Fatalf("outcome = %v, want retry", got)
+	}
+
+	attr := d.kvBackendAttribution()
+	if attr.Backend != registry.KVBackendPaged {
+		t.Errorf("terminal attribution = %q, want %q (the primary's deterministic 4xx controls the outcome)",
+			attr.Backend, registry.KVBackendPaged)
+	}
+}
+
+// TestPromotedBackupSavedOnLiveMismatch pins the promotion-save: a live
+// attribution read through a MISMATCHED d.pr means a backup was promoted
+// outside every noteServingSlot site (AcceptedCh / preamble promotion). The
+// read must save the resolution, so a promoted backup that then errors or
+// times out pre-content — after the wait path clears d.pr — books under its
+// own backend, not the cancelled primary's stale latch.
+func TestPromotedBackupSavedOnLiveMismatch(t *testing.T) {
+	d, _, primary, primaryPR, backup, backupPR := speculativeFailureTestState(t, time.Second, 500*time.Millisecond)
+	heartbeatSlotKV(d, primary, registry.KVBackendPaged)
+	heartbeatSlotKV(d, backup, registry.KVBackendContiguous)
+
+	d.pr = primaryPR
+	d.noteServingSlot()
+
+	// Promotion outside the choke point: d.pr moves to the backup with no
+	// explicit re-latch.
+	d.pr = backupPR
+	if got := d.kvBackendAttribution().Backend; got != registry.KVBackendContiguous {
+		t.Fatalf("live mismatch read = %q, want the backup's %q", got, registry.KVBackendContiguous)
+	}
+
+	// The promoted backup fails pre-content; the wait path clears d.pr. The
+	// exhaustion fallback must name the promoted slot.
+	d.pr = nil
+	if got := d.kvBackendAttribution().Backend; got != registry.KVBackendContiguous {
+		t.Errorf("terminal fallback = %q, want %q (the live mismatch read must save the promotion)",
+			got, registry.KVBackendContiguous)
+	}
+}
+
+// TestFrozenLatchSurvivesLiveMismatchRead pins the interaction of the two
+// rules above: once the primary's deterministic verdict latches, a live read
+// through a promoted backup stays truthful (returns the backup) but must NOT
+// move the persistent latch — the terminal fallback still belongs to the
+// verdict slot.
+func TestFrozenLatchSurvivesLiveMismatchRead(t *testing.T) {
+	d, _, primary, primaryPR, backup, backupPR := speculativeFailureTestState(t, time.Second, 500*time.Millisecond)
+	heartbeatSlotKV(d, primary, registry.KVBackendPaged)
+	heartbeatSlotKV(d, backup, registry.KVBackendContiguous)
+
+	d.pr = primaryPR
+	d.noteServingSlot()
+	verdict := protocol.InferenceErrorMessage{
+		Error:       "prompt malformed",
+		ErrorReason: "bad_request",
+		StatusCode:  http.StatusBadRequest,
+	}
+	d.latchDeterministicLoser(primary, verdict)
+
+	d.pr = backupPR
+	if got := d.kvBackendAttribution().Backend; got != registry.KVBackendContiguous {
+		t.Fatalf("live read = %q, want the backup's %q (live reads stay truthful)", got, registry.KVBackendContiguous)
+	}
+	d.pr = nil
+	if got := d.kvBackendAttribution().Backend; got != registry.KVBackendPaged {
+		t.Errorf("terminal fallback = %q, want %q (the frozen verdict latch must survive live reads)",
+			got, registry.KVBackendPaged)
+	}
+}
+
 func TestCapturedRoutingAttemptStillHandlesOrdinaryRetry(t *testing.T) {
 	d, _, primary, primaryPR, _, _ := speculativeFailureTestState(t, time.Second, 500*time.Millisecond)
 	captured := routingAttempt(primary, primaryPR, primaryPR.RequestID, primaryPR.Attempt)

--- a/coordinator/api/kv_backend_metrics.go
+++ b/coordinator/api/kv_backend_metrics.go
@@ -170,12 +170,44 @@ func (d *dispatchState) noteServingSlot() {
 // Gate G5 segments per backend in a mixed-backend fleet. The invariant the
 // re-latch sites maintain: the latch always names the slot whose failure would
 // be the terminal one — the last slot still racing.
+//
+// EXCEPTION — a latched deterministic verdict freezes the latch. Once
+// shouldStopFailover/latchDeterministicLoser has latched d.unservable or
+// d.terminalClientError, the terminal response IS that verdict (the 4xx/422/
+// 429 of the slot that produced it), regardless of what a still-racing backup
+// does next. Re-latching to the backup would book the PRIMARY's controlling
+// 4xx under the backup's backend. latchTerminalAttribution pins the latch to
+// the verdict slot at the moment the verdict latches; this guard keeps it
+// there. A backup that goes on to WIN is unaffected: commit-path reads go
+// through the live d.pr (see kvBackendAttribution), not this latch.
 func (d *dispatchState) noteServingSlotFor(pr *registry.PendingRequest) {
 	if pr == nil || pr.ProviderID == "" {
 		return
 	}
+	if d.attributionLatchFrozen() {
+		return
+	}
 	d.servedKVBackend = d.s.kvBackendAttribution(pr.ProviderID, pr.Model)
 	d.servedKVProviderID, d.servedKVModel = pr.ProviderID, pr.Model
+}
+
+// attributionLatchFrozen reports whether a deterministic terminal verdict has
+// latched — from that point the outcome attribution belongs to the slot whose
+// verdict controls the terminal response, and must not follow later racers.
+func (d *dispatchState) attributionLatchFrozen() bool {
+	return d.unservable || d.terminalClientError
+}
+
+// latchTerminalAttribution pins the outcome attribution to the provider whose
+// deterministic verdict just latched (latchDeterministicLoser). It is the
+// pinning act itself, so it bypasses the freeze guard — and must run at the
+// SAME site that latches the verdict, before any backup re-latch can race it.
+func (d *dispatchState) latchTerminalAttribution(provider *registry.Provider) {
+	if provider == nil || provider.ID == "" {
+		return
+	}
+	d.servedKVBackend = d.s.providerKVBackendAttribution(provider, d.model)
+	d.servedKVProviderID, d.servedKVModel = provider.ID, d.model
 }
 
 // kvBackendAttribution is the KV-backend metric pair for this dispatch. It
@@ -189,13 +221,25 @@ func (d *dispatchState) noteServingSlotFor(pr *registry.PendingRequest) {
 // and the success path reads it again at commit, so re-resolving would take a
 // second registry read lock per request for a value that provably has not
 // moved. A speculative backup shows up as a KEY MISMATCH, not as a stale
-// latch, and still re-resolves.
+// latch, and still re-resolves — and SAVES the resolution: a mismatch means a
+// promotion the latch has not caught up with (backup promoted via AcceptedCh
+// or preamble outside the noteServingSlot choke point). The promoted slot can
+// error or time out pre-content AFTER the wait path clears d.pr, and the
+// exhaustion fallback must then name the promoted slot, not the cancelled
+// primary's stale latch. noteServingSlotFor owns the freeze rule (a latched
+// deterministic verdict pins the latch to the verdict slot), so a frozen
+// latch survives this save while the live return value stays truthful.
 func (d *dispatchState) kvBackendAttribution() kvBackendAttribution {
 	if pr := d.pr; pr != nil && pr.ProviderID != "" {
 		if pr.ProviderID == d.servedKVProviderID && pr.Model == d.servedKVModel {
 			return d.servedKVBackend
 		}
-		return d.s.kvBackendAttribution(pr.ProviderID, pr.Model)
+		att := d.s.kvBackendAttribution(pr.ProviderID, pr.Model)
+		if !d.attributionLatchFrozen() {
+			d.servedKVBackend = att
+			d.servedKVProviderID, d.servedKVModel = pr.ProviderID, pr.Model
+		}
+		return att
 	}
 	if d.servedKVProviderID == "" {
 		// Never latched: no attempt ever reached a slot.

--- a/provider-swift/Sources/ProviderBenchmark/BackendParityHarness.swift
+++ b/provider-swift/Sources/ProviderBenchmark/BackendParityHarness.swift
@@ -788,10 +788,19 @@ public enum BackendParityHarness {
         // Gated on an actual `.hit`: on a miss there is no adoption to judge
         // and a difference would be nondeterminism, a different finding with
         // a different owner. nil is NOT MEASURED, never "exact".
+        //
+        // Exactness compares the whole TERMINAL OUTCOME, not just the token
+        // IDs — `judgeAdoptionExactness` holds the rule and the reasons.
         let adopted = secondUsage.prefixCacheOutcome == .hit
-        let adoptionTokenExact: Bool? = adopted
-            ? first.row.tokens == second.row.tokens
+        let exactness: (exact: Bool, mismatchReason: String?)? = adopted
+            ? Self.judgeAdoptionExactness(
+                coldTokens: first.row.tokens,
+                adoptedTokens: second.row.tokens,
+                coldFinish: first.row.finishReason,
+                adoptedFinish: second.row.finishReason)
             : nil
+        let adoptionTokenExact: Bool? = exactness?.exact
+        let adoptionMismatchReason: String? = exactness?.mismatchReason
         // The window the comparison ACTUALLY covered. A verdict of "exact"
         // over 8 tokens and one over 48 are different claims and must not
         // print the same; the shorter stream bounds what could be observed.
@@ -833,6 +842,7 @@ public enum BackendParityHarness {
             cacheMisses: stats.misses,
             cacheTokensSaved: stats.tokensSaved,
             adoptionTokenExact: adoptionTokenExact,
+            adoptionMismatchReason: adoptionMismatchReason,
             adoptionComparedTokens: adoptionComparedTokens,
             probeResolvedBackend: box.kind.rawValue,
             probeFallbackReason: box.fallbackReason)
@@ -946,14 +956,10 @@ public enum BackendParityHarness {
         // submit error or a non-clean terminal, and would make the arm
         // measure admission instead of numerics.
         //
-        // An ALLOWLIST of clean terminals, not a blocklist of known-bad
-        // prefixes. `describe(CBv2FinishReason)` can grow a case, and
-        // `generate` already adds two reasons of its own (`submit_error:`,
-        // `unterminated`) that no `CBv2FinishReason` spells — a blocklist
-        // waves through every reason nobody thought to enumerate, which is
-        // the shape of gate this whole probe exists to refuse.
-        let cleanTerminals: Set<String> = ["stop", "length"]
-        let unclean = rows.filter { !cleanTerminals.contains($0.finishReason) }
+        // The clean-terminal ALLOWLIST is shared with the prefix-reuse
+        // probe's adoption-exactness judge (`Self.cleanTerminals`) so the
+        // two probes can never disagree about what "ended cleanly" means.
+        let unclean = rows.filter { !Self.cleanTerminals.contains($0.finishReason) }
         guard unclean.isEmpty else {
             return .init(
                 perturbation: perturbation, tokenExact: nil,
@@ -1147,6 +1153,70 @@ public enum BackendParityHarness {
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
         guard trimmed.count > 40 else { return trimmed }
         return String(trimmed.prefix(37)) + "..."
+    }
+
+    /// Terminals a request may end with and still count as a valid
+    /// comparand: the model stopped (`stop`) or the budget ran out
+    /// (`length`). An ALLOWLIST, not a blocklist of known-bad prefixes:
+    /// `describe(CBv2FinishReason)` can grow a case, and `generateWithUsage`
+    /// adds two reasons of its own (`submit_error:`, `unterminated`) that no
+    /// `CBv2FinishReason` spells — a blocklist waves through every reason
+    /// nobody thought to enumerate, which is the shape of gate this harness
+    /// exists to refuse. Shared by the fp32 numerics control and the
+    /// prefix-reuse adoption-exactness judge.
+    static let cleanTerminals: Set<String> = ["stop", "length"]
+
+    /// Whether the ADOPTING request reproduced the cold request's outcome —
+    /// the WHOLE outcome, not just the token IDs. The same tokens under
+    /// different finish reasons (`stop` on the cold arm, `length` or
+    /// `error(…)` on the adopted one) mean adoption changed how the request
+    /// ENDED, and a non-clean terminal on either stream means at least one
+    /// comparand was cut short by machinery (an engine error, a forced
+    /// terminal, a submit failure) rather than by the model — its token
+    /// stream is a truncation artifact, and "the truncated prefixes agree"
+    /// is not the claim `adoptionTokenExact = true` makes.
+    ///
+    /// Returns `exact` plus a mismatch reason naming the SHAPE of the
+    /// failure, because the shapes are different findings: diverging tokens
+    /// can be precision drift on a sensitive checkpoint (see the symmetric
+    /// arm of the criterion), while a terminal mismatch never is. Pure and
+    /// static so the rule is unit-testable without an engine.
+    static func judgeAdoptionExactness(
+        coldTokens: [Int],
+        adoptedTokens: [Int],
+        coldFinish: String,
+        adoptedFinish: String
+    ) -> (exact: Bool, mismatchReason: String?) {
+        var reasons: [String] = []
+        if coldTokens != adoptedTokens {
+            reasons.append("token streams diverged")
+        }
+        if coldFinish != adoptedFinish {
+            reasons.append(
+                "terminal mismatch: cold finished '\(coldFinish)', "
+                    + "adopted finished '\(adoptedFinish)'")
+        } else if !cleanTerminals.contains(coldFinish) {
+            // Identical but unclean: both arms were cut short the same way,
+            // so neither stream is the model's answer and the comparison
+            // proves nothing about adoption.
+            reasons.append("non-clean terminal on both arms: '\(coldFinish)'")
+        }
+        // The mismatched-terminal case can also hide an UNCLEAN side; name
+        // it too, so `error(…)` is never summarized as a mere mismatch.
+        if coldFinish != adoptedFinish {
+            let unclean = [("cold", coldFinish), ("adopted", adoptedFinish)]
+                .filter { !cleanTerminals.contains($0.1) }
+            if !unclean.isEmpty {
+                reasons.append(
+                    "non-clean terminal on "
+                        + unclean.map { "\($0.0) ('\($0.1)')" }
+                            .joined(separator: " and "))
+            }
+        }
+        guard reasons.isEmpty else {
+            return (false, reasons.joined(separator: "; "))
+        }
+        return (true, nil)
     }
 
     static func describe(_ reason: CBv2FinishReason) -> String {

--- a/provider-swift/Sources/ProviderBenchmark/BackendParityHarness.swift
+++ b/provider-swift/Sources/ProviderBenchmark/BackendParityHarness.swift
@@ -817,15 +817,28 @@ public enum BackendParityHarness {
         // Exactness compares the whole TERMINAL OUTCOME, not just the token
         // IDs — `judgeAdoptionExactness` holds the rule and the reasons.
         let adopted = secondUsage.prefixCacheOutcome == .hit
-        let exactness: (exact: Bool, mismatchReason: String?)? = adopted
+        let exactness: AdoptionExactness? = adopted
             ? Self.judgeAdoptionExactness(
                 coldTokens: first.row.tokens,
                 adoptedTokens: second.row.tokens,
                 coldFinish: first.row.finishReason,
                 adoptedFinish: second.row.finishReason)
             : nil
-        let adoptionTokenExact: Bool? = exactness?.exact
-        let adoptionMismatchReason: String? = exactness?.mismatchReason
+        var adoptionTokenExact: Bool?
+        var adoptionMismatchReason: String?
+        var adoptionInconclusiveReason: String?
+        switch exactness {
+        case .exact: adoptionTokenExact = true
+        case .inexact(let reason):
+            adoptionTokenExact = false
+            adoptionMismatchReason = reason
+        case .inconclusive(let reason):
+            // Deliberately leaves `adoptionTokenExact` nil: the comparison
+            // ran but proved nothing, and only the reason field separates
+            // that from "never ran".
+            adoptionInconclusiveReason = reason
+        case nil: break
+        }
         // The window the comparison ACTUALLY covered. A verdict of "exact"
         // over 8 tokens and one over 48 are different claims and must not
         // print the same; the shorter stream bounds what could be observed.
@@ -843,7 +856,7 @@ public enum BackendParityHarness {
             + "\(describe(secondUsage.prefixCacheOutcome)), "
             + "resolved=\(box.kind.rawValue), "
             + "finish=\(first.row.finishReason)/\(second.row.finishReason), "
-            + "adoptionExact=\(adoptionTokenExact.map(String.init) ?? "not_measured") "
+            + "adoptionExact=\(adoptionTokenExact.map(String.init) ?? (adoptionInconclusiveReason != nil ? "inconclusive" : "not_measured")) "
             + "over \(adoptionComparedTokens) tokens, "
             + "matched=\(secondUsage.prefixCacheMatchedTokens), "
             + "saved=\(secondUsage.prefixCachePrefillTokensSaved), "
@@ -868,6 +881,7 @@ public enum BackendParityHarness {
             cacheTokensSaved: stats.tokensSaved,
             adoptionTokenExact: adoptionTokenExact,
             adoptionMismatchReason: adoptionMismatchReason,
+            adoptionInconclusiveReason: adoptionInconclusiveReason,
             adoptionComparedTokens: adoptionComparedTokens,
             probeResolvedBackend: box.kind.rawValue,
             probeFallbackReason: box.fallbackReason)
@@ -1212,16 +1226,27 @@ public enum BackendParityHarness {
         return String(trimmed.prefix(37)) + "..."
     }
 
-    /// Terminals a request may end with and still count as a valid
-    /// comparand: the model stopped (`stop`) or the budget ran out
-    /// (`length`). An ALLOWLIST, not a blocklist of known-bad prefixes:
-    /// `describe(CBv2FinishReason)` can grow a case, and `generateWithUsage`
-    /// adds two reasons of its own (`submit_error:`, `unterminated`) that no
-    /// `CBv2FinishReason` spells — a blocklist waves through every reason
-    /// nobody thought to enumerate, which is the shape of gate this harness
-    /// exists to refuse. Shared by the fp32 numerics control and the
-    /// prefix-reuse adoption-exactness judge.
-    static let cleanTerminals: Set<String> = ["stop", "length"]
+    /// Canonical clean-terminal allowlist — one definition, owned by the
+    /// verdict layer so the report's per-row evidence partition and this
+    /// harness can never disagree about what "ended cleanly" means.
+    static let cleanTerminals = BackendParityCriteria.cleanTerminals
+
+    /// What the ADOPTION comparison established.
+    ///
+    /// Three states, because the two failure directions are different
+    /// findings with different owners: `.inexact` is adoption CHANGING the
+    /// observed outcome (the criterion FAILs — a cache the caller cannot see
+    /// must not change the answer), while `.inconclusive` is the comparison
+    /// itself being destroyed by machinery — both arms cut short by the
+    /// SAME non-clean terminal, so the two identical truncated streams
+    /// prove nothing in either direction (the criterion is UNAVAILABLE;
+    /// failing it would let a transient watchdog kill read as "adoption
+    /// changed the answer", and passing it would certify nothing).
+    enum AdoptionExactness: Equatable, Sendable {
+        case exact
+        case inexact(reason: String)
+        case inconclusive(reason: String)
+    }
 
     /// Whether the ADOPTING request reproduced the cold request's outcome —
     /// the WHOLE outcome, not just the token IDs. The same tokens under
@@ -1233,17 +1258,17 @@ public enum BackendParityHarness {
     /// stream is a truncation artifact, and "the truncated prefixes agree"
     /// is not the claim `adoptionTokenExact = true` makes.
     ///
-    /// Returns `exact` plus a mismatch reason naming the SHAPE of the
-    /// failure, because the shapes are different findings: diverging tokens
-    /// can be precision drift on a sensitive checkpoint (see the symmetric
-    /// arm of the criterion), while a terminal mismatch never is. Pure and
-    /// static so the rule is unit-testable without an engine.
+    /// Reasons name the SHAPE of the failure, because the shapes are
+    /// different findings: diverging tokens can be precision drift on a
+    /// sensitive checkpoint (see the symmetric arm of the criterion), while
+    /// a terminal mismatch never is. Pure and static so the rule is
+    /// unit-testable without an engine.
     static func judgeAdoptionExactness(
         coldTokens: [Int],
         adoptedTokens: [Int],
         coldFinish: String,
         adoptedFinish: String
-    ) -> (exact: Bool, mismatchReason: String?) {
+    ) -> AdoptionExactness {
         var reasons: [String] = []
         if coldTokens != adoptedTokens {
             reasons.append("token streams diverged")
@@ -1252,15 +1277,9 @@ public enum BackendParityHarness {
             reasons.append(
                 "terminal mismatch: cold finished '\(coldFinish)', "
                     + "adopted finished '\(adoptedFinish)'")
-        } else if !cleanTerminals.contains(coldFinish) {
-            // Identical but unclean: both arms were cut short the same way,
-            // so neither stream is the model's answer and the comparison
-            // proves nothing about adoption.
-            reasons.append("non-clean terminal on both arms: '\(coldFinish)'")
-        }
-        // The mismatched-terminal case can also hide an UNCLEAN side; name
-        // it too, so `error(…)` is never summarized as a mere mismatch.
-        if coldFinish != adoptedFinish {
+            // The mismatched-terminal case can also hide an UNCLEAN side;
+            // name it too, so `error(…)` is never summarized as a mere
+            // stop/length disagreement.
             let unclean = [("cold", coldFinish), ("adopted", adoptedFinish)]
                 .filter { !cleanTerminals.contains($0.1) }
             if !unclean.isEmpty {
@@ -1269,11 +1288,25 @@ public enum BackendParityHarness {
                         + unclean.map { "\($0.0) ('\($0.1)')" }
                             .joined(separator: " and "))
             }
+        } else if !cleanTerminals.contains(coldFinish) {
+            // Identical unclean terminals: both arms were cut short the
+            // same way, so neither stream is the model's answer. With the
+            // tokens ALSO identical this is not a mismatch — nothing
+            // observed differed — but it is not exactness either; it is a
+            // comparison with no power. Genuinely diverging tokens under
+            // the shared failure still count as a mismatch below.
+            if reasons.isEmpty {
+                return .inconclusive(
+                    reason: "both arms were cut short identically ('\(coldFinish)'), "
+                        + "so the identical truncated streams prove nothing about "
+                        + "adoption")
+            }
+            reasons.append("non-clean terminal on both arms: '\(coldFinish)'")
         }
         guard reasons.isEmpty else {
-            return (false, reasons.joined(separator: "; "))
+            return .inexact(reason: reasons.joined(separator: "; "))
         }
-        return (true, nil)
+        return .exact
     }
 
     static func describe(_ reason: CBv2FinishReason) -> String {

--- a/provider-swift/Sources/ProviderBenchmark/BackendParityHarness.swift
+++ b/provider-swift/Sources/ProviderBenchmark/BackendParityHarness.swift
@@ -355,6 +355,7 @@ public enum BackendParityHarness {
             selection: selection.rawValue,
             resolvedBackend: box.kind.rawValue,
             fallbackReason: box.fallbackReason,
+            pagedPoolDType: box.pagedPoolDType,
             rows: rows,
             mtp: mtp,
             packedPrefill: packed,
@@ -363,6 +364,30 @@ public enum BackendParityHarness {
     }
 
     // MARK: - Engine construction
+
+    /// The pool dtype every harness engine is PINNED to unless a probe
+    /// overrides it (only the fp32 numerics control does). Ambient
+    /// `DARKBLOOM_CBV2_PAGED_KV_DTYPE=float32` in the invoking shell would
+    /// otherwise leak into the candidate arm, and the "float16 → float32"
+    /// control would compare two identical fp32 engines — a tautology that
+    /// corrupts the run's numerical-stability evidence while labelling
+    /// itself a control. Literal rather than
+    /// `EngineV2Factory.pagedPoolDTypeEnvKey`: that constant is internal to
+    /// ProviderCore.
+    static let pinnedPoolDTypeEnvironment = ["DARKBLOOM_CBV2_PAGED_KV_DTYPE": "float16"]
+
+    /// The environment an engine build actually sees: ambient, with the pool
+    /// dtype pinned to fp16, with the probe's own overrides winning last.
+    /// Pure and separated from `buildEngine` so the precedence is testable
+    /// without constructing an engine.
+    static func engineEnvironment(
+        ambient: [String: String],
+        overrides: [String: String]
+    ) -> [String: String] {
+        ambient
+            .merging(pinnedPoolDTypeEnvironment) { _, pinned in pinned }
+            .merging(overrides) { _, override in override }
+    }
 
     private static func buildEngine(
         container: ModelContainer,
@@ -379,9 +404,9 @@ public enum BackendParityHarness {
         // allocation and the paged kernel preflight want serialized GPU
         // access. The serving model itself is NOT re-resolved here — see the
         // comment in `run`.
-        let environment = environmentOverrides.isEmpty
-            ? ProcessInfo.processInfo.environment
-            : ProcessInfo.processInfo.environment.merging(environmentOverrides) { _, new in new }
+        let environment = engineEnvironment(
+            ambient: ProcessInfo.processInfo.environment,
+            overrides: environmentOverrides)
         return try await container.perform { _ -> EngineBox in
             let build = try EngineV2Factory.makeProductionBuild(
                 model: serving.model,
@@ -890,6 +915,7 @@ public enum BackendParityHarness {
         configuration: Configuration
     ) async -> BackendParityReport.NumericsControl {
         let perturbation = "paged pool dtype float16 -> float32"
+        let candidateDType = candidate.pagedPoolDType
 
         guard candidate.resolvedBackend == EngineV2KVBackendKind.paged.rawValue,
             !candidate.rows.isEmpty
@@ -898,7 +924,8 @@ public enum BackendParityHarness {
                 perturbation: perturbation, tokenExact: nil,
                 detail: "the candidate arm did not serve paged rows "
                     + "(resolved \(candidate.resolvedBackend ?? "nothing"), "
-                    + "\(candidate.rows.count) rows), so there is nothing to perturb")
+                    + "\(candidate.rows.count) rows), so there is nothing to perturb",
+                candidatePoolDType: candidateDType)
         }
 
         let box: EngineBox
@@ -914,7 +941,8 @@ public enum BackendParityHarness {
         } catch {
             return .init(
                 perturbation: perturbation, tokenExact: nil,
-                detail: "the fp32 control engine would not build: \(error)")
+                detail: "the fp32 control engine would not build: \(error)",
+                candidatePoolDType: candidateDType)
         }
 
         // Trust the arm ONLY on the RESOLVED dtype. A silently ignored knob
@@ -927,7 +955,28 @@ public enum BackendParityHarness {
                 perturbation: perturbation, tokenExact: nil,
                 detail: "requested fp32 pages but the pool resolved "
                     + "\(box.pagedPoolDType ?? "nil") — the perturbation never happened, "
-                    + "so this arm is NOT a control")
+                    + "so this arm is NOT a control",
+                candidatePoolDType: candidateDType,
+                controlPoolDType: box.pagedPoolDType)
+        }
+
+        // The mirror-image check on the CANDIDATE arm. `buildEngine` pins
+        // every non-control engine to fp16 pages precisely so this cannot
+        // fire, but the pin lives in a different function than the claim —
+        // verify the recorded resolution rather than trusting the plumbing,
+        // exactly as the fp32 guard above refuses to trust the env knob. Two
+        // arms on the same dtype would agree tautologically and masquerade
+        // as a held control.
+        guard candidateDType != box.pagedPoolDType else {
+            await box.engine.shutdown()
+            return .init(
+                perturbation: perturbation, tokenExact: nil,
+                detail: "the candidate arm's pool ALSO resolved "
+                    + "\(candidateDType ?? "nil") pages, so both arms carry the same "
+                    + "dtype — the perturbation never happened and any agreement would "
+                    + "be a tautology, so this arm is NOT a control",
+                candidatePoolDType: candidateDType,
+                controlPoolDType: box.pagedPoolDType)
         }
 
         var rows: [BackendParityObservation.Row] = []
@@ -966,7 +1015,9 @@ public enum BackendParityHarness {
                 detail: "the fp32 control arm hit \(unclean.count) non-clean terminal(s) "
                     + "(\(unclean.map(\.finishReason).joined(separator: "; "))) — fp32 halves "
                     + "the pool's seats and its byte accounting under-counts, so this arm "
-                    + "measured admission rather than numerics and is NOT a control")
+                    + "measured admission rather than numerics and is NOT a control",
+                candidatePoolDType: candidateDType,
+                controlPoolDType: box.pagedPoolDType)
         }
 
         // Rows that EXIST but carry no tokens compare equal, and `rowMismatch`
@@ -981,7 +1032,9 @@ public enum BackendParityHarness {
         {
             return .init(
                 perturbation: perturbation, tokenExact: nil,
-                detail: "the control could not be scored — \(blocker)")
+                detail: "the control could not be scored — \(blocker)",
+                candidatePoolDType: candidateDType,
+                controlPoolDType: box.pagedPoolDType)
         }
 
         if let mismatch = BackendParityCriteria.rowMismatch(
@@ -992,7 +1045,9 @@ public enum BackendParityHarness {
                 perturbation: perturbation, tokenExact: false,
                 detail: "paged with fp32 pages diverged from paged with fp16 pages on the "
                     + "SAME backend: \(mismatch)",
-                firstFlip: mismatch)
+                firstFlip: mismatch,
+                candidatePoolDType: candidateDType,
+                controlPoolDType: box.pagedPoolDType)
         }
 
         // Carry the SAMPLE SIZE into the verdict. "Token-exact" over three
@@ -1010,7 +1065,9 @@ public enum BackendParityHarness {
             detail: "paged with fp32 pages produced token ids IDENTICAL to paged with fp16 "
                 + "pages across \(rows.count) prompts and \(total) tokens (shortest row "
                 + "\(shortest)), so this model's argmax survives a benign storage-precision "
-                + "change over that many decode steps")
+                + "change over that many decode steps",
+            candidatePoolDType: candidateDType,
+            controlPoolDType: box.pagedPoolDType)
     }
 
     // MARK: - Probe: MTP

--- a/provider-swift/Sources/ProviderBenchmark/BackendParityReport.swift
+++ b/provider-swift/Sources/ProviderBenchmark/BackendParityReport.swift
@@ -30,7 +30,20 @@ public struct BackendParityReport: Codable, Sendable {
 
     /// Bumped when the JSON shape changes so downstream parsers can gate.
     /// 2 adds the `EXPECTED_SHORTFALL` verdict.
-    public static let currentSchemaVersion = 2
+    /// 3 adds the dtype-provenance and adoption-evidence fields:
+    ///  - `BackendParityObservation.pagedPoolDType` — the RESOLVED pool dtype
+    ///    per arm, read off the constructed pool;
+    ///  - `NumericsControl.candidatePoolDType` / `.controlPoolDType` — both
+    ///    control arms' resolved dtypes, and with them the validity rule
+    ///    (`controlValidityBlocker`) that a same-dtype control is DISREGARDED
+    ///    at evaluation rather than quoted;
+    ///  - `PrefixReuse.adoptionMismatchReason` — why adoption was NOT exact
+    ///    (terminal outcomes are judged, not just token ids);
+    ///  - `PrefixReuse.adoptionInconclusiveReason` — the adoption comparison
+    ///    ran but was unjudgeable (both arms cut short identically);
+    ///    `adoptionTokenExact` stays nil and the prefix-reuse criterion is
+    ///    UNAVAILABLE, never PASS or FAIL.
+    public static let currentSchemaVersion = 3
 
     public enum Verdict: String, Codable, Sendable, CaseIterable {
         case pass = "PASS"
@@ -515,10 +528,12 @@ public struct BackendParityObservation: Codable, Sendable, Equatable {
         /// "Exact" is a claim about the whole REQUEST OUTCOME, not just the
         /// token IDs: the same tokens with different finish reasons (`stop`
         /// on one arm, `length` or `error(…)` on the other) means adoption
-        /// changed how the request ENDED, and a non-clean terminal on either
-        /// stream means at least one comparand was cut short by machinery
-        /// rather than by the model — both record `false`, with the shape of
-        /// the mismatch named in `adoptionMismatchReason`.
+        /// changed how the request ENDED — that records `false`, with the
+        /// shape of the mismatch named in `adoptionMismatchReason`. But two
+        /// streams cut short IDENTICALLY by machinery (the same `error(…)`
+        /// on both arms) prove nothing in either direction: that records
+        /// nil with `adoptionInconclusiveReason` set, and the criterion is
+        /// UNAVAILABLE — a transient failure must not pass OR fail the gate.
         public let adoptionTokenExact: Bool?
         /// WHY `adoptionTokenExact` is `false`, in one operator-readable
         /// phrase ("token streams diverged", "terminal mismatch: cold
@@ -527,6 +542,15 @@ public struct BackendParityObservation: Codable, Sendable, Equatable {
         /// the observation — not recomputed by the report — because the
         /// harness is the only party that saw both raw streams.
         public let adoptionMismatchReason: String?
+        /// WHY the adoption comparison RAN but could not be judged: both
+        /// requests were cut short by the SAME non-clean terminal, so the
+        /// two identical truncated streams are machinery artifacts, not
+        /// answers. Distinct from `adoptionTokenExact == nil` with this
+        /// field ALSO nil, which means the comparison never ran (no cache
+        /// hit). Renders the prefix-reuse criterion UNAVAILABLE with this
+        /// reason — never PASS (nothing was proven exact) and never FAIL
+        /// (identical outcomes are not "adoption changed the answer").
+        public let adoptionInconclusiveReason: String?
         /// Completion tokens the exactness comparison actually covered. This
         /// is the oracle's WINDOW and bounds what it could possibly have seen:
         /// the measured paged adoption divergence appears at completion token
@@ -567,6 +591,7 @@ public struct BackendParityObservation: Codable, Sendable, Equatable {
             cacheTokensSaved: Int = 0,
             adoptionTokenExact: Bool? = nil,
             adoptionMismatchReason: String? = nil,
+            adoptionInconclusiveReason: String? = nil,
             adoptionComparedTokens: Int = 0,
             probeResolvedBackend: String? = nil,
             probeFallbackReason: String? = nil,
@@ -589,6 +614,7 @@ public struct BackendParityObservation: Codable, Sendable, Equatable {
             self.cacheTokensSaved = cacheTokensSaved
             self.adoptionTokenExact = adoptionTokenExact
             self.adoptionMismatchReason = adoptionMismatchReason
+            self.adoptionInconclusiveReason = adoptionInconclusiveReason
             self.adoptionComparedTokens = adoptionComparedTokens
             self.probeResolvedBackend = probeResolvedBackend
             self.probeFallbackReason = probeFallbackReason
@@ -677,6 +703,19 @@ public enum BackendParityCriteria {
             prefixReuse(baseline: baseline, candidate: candidate),
         ]
     }
+
+    /// Terminals a request may end with and still count as a valid
+    /// comparand: the model stopped (`stop`) or the budget ran out
+    /// (`length`). An ALLOWLIST, not a blocklist of known-bad prefixes:
+    /// `describe(CBv2FinishReason)` can grow a case, and `generateWithUsage`
+    /// adds two reasons of its own (`submit_error:`, `unterminated`) that no
+    /// `CBv2FinishReason` spells — a blocklist waves through every reason
+    /// nobody thought to enumerate, which is the shape of gate this harness
+    /// exists to refuse. One definition, shared by the per-row evidence
+    /// partition below, the harness's fp32 numerics control, and its
+    /// prefix-reuse adoption-exactness judge, so no two consumers can ever
+    /// disagree about what "ended cleanly" means.
+    static let cleanTerminals: Set<String> = ["stop", "length"]
 
     /// The precondition every cross-backend criterion shares: two arms that
     /// both built, and that built DIFFERENT backends. Returns the blocking
@@ -886,10 +925,13 @@ public enum BackendParityCriteria {
         ]
 
         // Per-row evidence. The zero-evidence guard above only catches ALL
-        // rows empty; a row that generated zero tokens on BOTH arms is still
-        // a non-observation — two matching `submit_error` shapes agree about
-        // nothing — so it is excluded from the agreement computation and
-        // disclosed. Below the floor the criterion refuses outright.
+        // rows empty; a row with zero tokens and a FAILED terminal on both
+        // arms is still a non-observation — two matching `submit_error`
+        // shapes agree about nothing — so it is excluded from the agreement
+        // computation and disclosed. Clean zero-token rows stay in (an
+        // immediate EOS is an observation, and clean-vs-failed is a real
+        // asymmetry `rowMismatch` must report). Below the floor the
+        // criterion refuses outright.
         var scoredBaseline = baseline.rows
         var scoredCandidate = candidate.rows
         var exclusionNote: String?
@@ -1425,10 +1467,16 @@ public enum BackendParityCriteria {
                 + "temperature 0, so the reported savings are not savings. "
                 + "Token counts are only meaningful conditional on exactness, which "
                 + "is why this outranks the comparison below"
+            let unjudged = [(baseline.label, base), (candidate.label, cand)]
+                .filter { $0.1.adoptionInconclusiveReason != nil }
             if let exact = exactArms.first {
                 detail += ". ASYMMETRIC, which isolates the backend: \(exact.0) adopted "
                     + "the same prefix on the same prompt in the same process and stayed "
                     + "exact, so precision sensitivity cannot explain this one"
+            } else if let other = unjudged.first {
+                detail += ". The other arm's comparison was INCONCLUSIVE — \(other.0): "
+                    + "\(other.1.adoptionInconclusiveReason ?? "") — so neither asymmetry "
+                    + "nor model-wide sensitivity is established by this run"
             } else {
                 detail += ". SYMMETRIC — every measured arm is inexact. When the "
                     + "mismatches are token divergence, that is a property of the MODEL "
@@ -1440,6 +1488,31 @@ public enum BackendParityCriteria {
             }
             return .init(
                 id: id, title: title, verdict: .fail, detail: detail,
+                measurements: measurements)
+        }
+
+        // An arm whose comparison RAN but was unjudgeable — cold and adopted
+        // both cut short by the SAME non-clean terminal — blocks the
+        // criterion. Exactness is the precondition for every count below
+        // ("exactness BEFORE arithmetic"), and this arm neither established
+        // it nor refuted it: identical truncated streams prove nothing, so
+        // certifying savings over them would launder a machinery failure
+        // into a parity verdict. Distinct from `adoptionTokenExact == nil`
+        // with no reason (the comparison never ran — no hit), which keeps
+        // its explicit NOT-MEASURED caveat on the pass path instead.
+        let inconclusive = [(baseline.label, base), (candidate.label, cand)]
+            .filter { $0.1.adoptionInconclusiveReason != nil }
+        if !inconclusive.isEmpty {
+            return .init(
+                id: id, title: title, verdict: .unavailable,
+                detail: "adoption exactness could not be judged on "
+                    + inconclusive.map {
+                        "\($0.0) (\($0.1.adoptionInconclusiveReason ?? ""))"
+                    }.joined(separator: " and ")
+                    + " — the cold and adopted requests were cut short identically, and "
+                    + "identical truncated streams prove nothing about adoption, so this "
+                    + "is neither a PASS (nothing was shown exact) nor a FAIL (nothing "
+                    + "changed the answer); re-run once the underlying failure clears",
                 measurements: measurements)
         }
 
@@ -1617,18 +1690,29 @@ public enum BackendParityCriteria {
     /// which ONE prompt decoded while the rest failed identically on both
     /// arms sails past it — and `rowMismatch` then reads each matching
     /// `submit_error`/`unterminated` pair as a row that AGREED. A row with
-    /// zero tokens on both arms is not a match; it is a non-observation, and
-    /// counting it toward parity lets a partially-failed release-gate run
-    /// report agreement it never measured.
+    /// zero tokens and a FAILED terminal on both arms is not a match; it is
+    /// a non-observation, and counting it toward parity lets a
+    /// partially-failed release-gate run report agreement it never measured.
+    ///
+    /// The failed-terminal half of that predicate is load-bearing. A row
+    /// where both arms cleanly finished `stop` with zero tokens (the model
+    /// hit EOS immediately, both sides) is a real — if thin — matching
+    /// observation and stays IN as agreement. And a row where one arm
+    /// cleanly stopped while the other returned `submit_error` is a real
+    /// observed ASYMMETRY that must be reported as the divergence it is,
+    /// never quietly removed: excluding it would let a run with enough other
+    /// productive rows PASS while claiming "finish reasons equal".
     struct PairedRowEvidence {
-        /// Row pairs where at least one arm generated a token — the actual
-        /// observations. (One-sided emptiness stays IN: an arm that decoded
-        /// nothing while the other decoded something is a real asymmetry,
-        /// and `rowMismatch` reports it as the divergence it is.)
+        /// Row pairs carrying an observable outcome: at least one arm
+        /// generated a token, or at least one arm ended on a CLEAN terminal.
+        /// (One-sided emptiness and clean-vs-failed rows stay IN: an arm
+        /// that decoded nothing — or failed — while the other did not is a
+        /// real asymmetry, and `rowMismatch` reports it.)
         let baselineEvidence: [BackendParityObservation.Row]
         let candidateEvidence: [BackendParityObservation.Row]
-        /// One rendered line per row where NEITHER arm generated a token,
-        /// naming the failure shape(s) the rows carried.
+        /// One rendered line per row where NEITHER arm generated a token
+        /// and BOTH terminals were failed measurements, naming the failure
+        /// shape(s) the rows carried.
         let nonObservations: [String]
         let totalRows: Int
 
@@ -1639,9 +1723,9 @@ public enum BackendParityCriteria {
         var floorBlocker: String? {
             let observed = baselineEvidence.count
             guard observed * 2 < totalRows else { return nil }
-            return "only \(observed) of \(totalRows) row(s) produced tokens on either "
-                + "arm — the criterion is below its minimum-evidence floor (half the "
-                + "rows) and is not scored. Failed rows: "
+            return "only \(observed) of \(totalRows) row(s) carried an observable "
+                + "outcome — the criterion is below its minimum-evidence floor (half "
+                + "the rows) and is not scored. Failed rows: "
                 + nonObservations.joined(separator: "; ")
         }
 
@@ -1649,7 +1733,7 @@ public enum BackendParityCriteria {
         var exclusionNote: String? {
             guard !nonObservations.isEmpty else { return nil }
             return "\(nonObservations.count) of \(totalRows) row(s) EXCLUDED as "
-                + "non-observations (zero tokens on both arms): "
+                + "non-observations (zero tokens and failed terminals on both arms): "
                 + nonObservations.joined(separator: "; ")
         }
     }
@@ -1667,7 +1751,10 @@ public enum BackendParityCriteria {
         var nonObservations: [String] = []
         for (base, cand) in zip(baseline, candidate) {
             guard base.prompt == cand.prompt else { return nil }
-            if base.tokens.isEmpty, cand.tokens.isEmpty {
+            if base.tokens.isEmpty, cand.tokens.isEmpty,
+                !cleanTerminals.contains(base.finishReason),
+                !cleanTerminals.contains(cand.finishReason)
+            {
                 let shapes =
                     base.finishReason == cand.finishReason
                     ? (base.finishReason.isEmpty ? "no finish reason" : base.finishReason)
@@ -1869,7 +1956,10 @@ public enum BackendParityCriteria {
             summary += "/\(reuse.adoptionComparedTokens)tok"
         case .some(false): summary += ", adoptionExact=FALSE"
             summary += "/\(reuse.adoptionComparedTokens)tok"
-        case nil: summary += ", adoptionExact=not_measured"
+        case nil:
+            summary +=
+                reuse.adoptionInconclusiveReason != nil
+                ? ", adoptionExact=INCONCLUSIVE" : ", adoptionExact=not_measured"
         }
         if reuse.promptTokens > 0, reuse.adoptionTokenExact != nil {
             let pct = Double(reuse.secondPrefillTokensSaved) / Double(reuse.promptTokens) * 100

--- a/provider-swift/Sources/ProviderBenchmark/BackendParityReport.swift
+++ b/provider-swift/Sources/ProviderBenchmark/BackendParityReport.swift
@@ -148,17 +148,29 @@ public struct BackendParityReport: Codable, Sendable {
         public let detail: String
         /// First flip against the unperturbed arm, when not exact.
         public let firstFlip: String?
+        /// RESOLVED pool dtype of the unperturbed candidate arm this control
+        /// compared against, read off the constructed pool — never the env
+        /// knob. Nil on artifacts that predate the field.
+        public let candidatePoolDType: String?
+        /// RESOLVED pool dtype of the control's own perturbed arm. A control
+        /// whose two arms carry the SAME dtype perturbed nothing, and
+        /// `BackendParityCriteria.controlValidityBlocker` refuses it.
+        public let controlPoolDType: String?
 
         public init(
             perturbation: String,
             tokenExact: Bool?,
             detail: String,
-            firstFlip: String? = nil
+            firstFlip: String? = nil,
+            candidatePoolDType: String? = nil,
+            controlPoolDType: String? = nil
         ) {
             self.perturbation = perturbation
             self.tokenExact = tokenExact
             self.detail = detail
             self.firstFlip = firstFlip
+            self.candidatePoolDType = candidatePoolDType
+            self.controlPoolDType = controlPoolDType
         }
 
         /// Leading clause for `token_exactness`, so the reader meets "the
@@ -590,6 +602,12 @@ public struct BackendParityObservation: Codable, Sendable, Equatable {
     /// depends on this arm then reports UNAVAILABLE.
     public let resolvedBackend: String?
     public let fallbackReason: String?
+    /// Dtype of the pages the PAGED pool was ACTUALLY built with, read off
+    /// the constructed pool (`ProductionBuild.pagedPoolDType`), never the
+    /// env knob. Nil on contiguous arms and on artifacts that predate the
+    /// field. The numerics control compares this against its own resolved
+    /// dtype so two identical-dtype arms can never masquerade as a control.
+    public let pagedPoolDType: String?
     public let constructionFailure: String?
     public let rows: [Row]
     public let mtp: MTP?
@@ -601,6 +619,7 @@ public struct BackendParityObservation: Codable, Sendable, Equatable {
         selection: String,
         resolvedBackend: String? = nil,
         fallbackReason: String? = nil,
+        pagedPoolDType: String? = nil,
         constructionFailure: String? = nil,
         rows: [Row] = [],
         mtp: MTP? = nil,
@@ -611,6 +630,7 @@ public struct BackendParityObservation: Codable, Sendable, Equatable {
         self.selection = selection
         self.resolvedBackend = resolvedBackend
         self.fallbackReason = fallbackReason
+        self.pagedPoolDType = pagedPoolDType
         self.constructionFailure = constructionFailure
         self.rows = rows
         self.mtp = mtp
@@ -687,6 +707,32 @@ public enum BackendParityCriteria {
                 + " — no cross-backend comparison was performed"
         }
         return nil
+    }
+
+    /// Why a numerics control must be DISREGARDED, or nil when it is sound.
+    ///
+    /// The control's whole claim is "the same backend under a benign dtype
+    /// perturbation". If both arms RESOLVED the same pool dtype — e.g. an
+    /// ambient `DARKBLOOM_CBV2_PAGED_KV_DTYPE=float32` leaked into the
+    /// candidate before the harness pinned it — then nothing was perturbed
+    /// and its agreement is a tautology, not evidence. Checked at EVALUATION
+    /// rather than only at measurement so a stored artifact from a harness
+    /// that predates the pinning is rejected too. Artifacts too old to carry
+    /// the dtype fields pass through: absence of the record is not proof of
+    /// a tautology, and their controls stay exactly as trustworthy as they
+    /// were when written.
+    static func controlValidityBlocker(
+        _ control: BackendParityReport.NumericsControl
+    ) -> String? {
+        guard let candidateDType = control.candidatePoolDType,
+            let controlDType = control.controlPoolDType
+        else { return nil }
+        guard candidateDType == controlDType else { return nil }
+        return "both control arms resolved \(candidateDType) pages "
+            + "(candidate \(candidateDType), control \(controlDType)) — the "
+            + "perturbation never happened, so its "
+            + (control.tokenExact == true ? "agreement" : "verdict")
+            + " is a tautology about one configuration, not a control"
     }
 
     /// Relative precision of the fp16 KV the paged pool stores (11-bit
@@ -869,15 +915,30 @@ public enum BackendParityCriteria {
 
         if let mismatch = rowMismatch(baseline: scoredBaseline, candidate: scoredCandidate) {
             measurements["firstFlip"] = mismatch
+            // A same-dtype control is DISREGARDED, never quoted: quoting
+            // "CONTROL HELD" off two identical engines would launder a
+            // tautology into the one sentence readers act on.
+            let controlBlocker = control.flatMap(controlValidityBlocker)
             if let control {
-                measurements["control"] = control.tokenExact.map {
-                    $0 ? "TOKEN-EXACT" : "NOT token-exact"
-                } ?? "NOT RUN"
+                if let controlBlocker {
+                    measurements["control"] = "INVALID — \(controlBlocker)"
+                } else {
+                    measurements["control"] = control.tokenExact.map {
+                        $0 ? "TOKEN-EXACT" : "NOT token-exact"
+                    } ?? "NOT RUN"
+                }
             }
             // The control LEADS. A reader must meet "the incumbent also flips
             // here" before the divergence it explains, for the same reason
             // EXPECTED_SHORTFALL rides the summary line.
-            var detail = control.map { "\($0.headline) " } ?? ""
+            var detail: String
+            if let controlBlocker {
+                detail = "CONTROL INVALID (\(controlBlocker)), so nothing here "
+                    + "distinguishes a backend difference from ordinary numerical "
+                    + "drift. "
+            } else {
+                detail = control.map { "\($0.headline) " } ?? ""
+            }
             detail += "\(candidate.label) diverged from \(baseline.label) at the first "
                 + "flip: \(mismatch). NOT scored as a regression: free-running greedy "
                 + "decode is a PASS-ONLY signal here, because the incumbent fails it too "

--- a/provider-swift/Sources/ProviderBenchmark/BackendParityReport.swift
+++ b/provider-swift/Sources/ProviderBenchmark/BackendParityReport.swift
@@ -499,7 +499,22 @@ public struct BackendParityObservation: Codable, Sendable, Equatable {
         /// would mean nondeterminism, which is a different finding. `nil`
         /// therefore means NOT MEASURED and must never be read as exact —
         /// the criterion says so out loud rather than passing quietly.
+        ///
+        /// "Exact" is a claim about the whole REQUEST OUTCOME, not just the
+        /// token IDs: the same tokens with different finish reasons (`stop`
+        /// on one arm, `length` or `error(…)` on the other) means adoption
+        /// changed how the request ENDED, and a non-clean terminal on either
+        /// stream means at least one comparand was cut short by machinery
+        /// rather than by the model — both record `false`, with the shape of
+        /// the mismatch named in `adoptionMismatchReason`.
         public let adoptionTokenExact: Bool?
+        /// WHY `adoptionTokenExact` is `false`, in one operator-readable
+        /// phrase ("token streams diverged", "terminal mismatch: cold
+        /// finished 'stop', adopted finished 'length'", "non-clean terminal
+        /// …"). nil whenever exactness is `true` or not measured. Carried on
+        /// the observation — not recomputed by the report — because the
+        /// harness is the only party that saw both raw streams.
+        public let adoptionMismatchReason: String?
         /// Completion tokens the exactness comparison actually covered. This
         /// is the oracle's WINDOW and bounds what it could possibly have seen:
         /// the measured paged adoption divergence appears at completion token
@@ -539,6 +554,7 @@ public struct BackendParityObservation: Codable, Sendable, Equatable {
             cacheMisses: Int = 0,
             cacheTokensSaved: Int = 0,
             adoptionTokenExact: Bool? = nil,
+            adoptionMismatchReason: String? = nil,
             adoptionComparedTokens: Int = 0,
             probeResolvedBackend: String? = nil,
             probeFallbackReason: String? = nil,
@@ -560,6 +576,7 @@ public struct BackendParityObservation: Codable, Sendable, Equatable {
             self.cacheMisses = cacheMisses
             self.cacheTokensSaved = cacheTokensSaved
             self.adoptionTokenExact = adoptionTokenExact
+            self.adoptionMismatchReason = adoptionMismatchReason
             self.adoptionComparedTokens = adoptionComparedTokens
             self.probeResolvedBackend = probeResolvedBackend
             self.probeFallbackReason = probeFallbackReason
@@ -1301,11 +1318,20 @@ public enum BackendParityCriteria {
         if !inexact.isEmpty {
             let exactArms = [(baseline.label, base), (candidate.label, cand)]
                 .filter { $0.1.adoptionTokenExact == true }
+            // Name the SHAPE of each arm's mismatch, because they are
+            // different findings: diverging token streams are the reuse
+            // path rewriting the output, while identical tokens under a
+            // terminal mismatch (`stop` vs `length`, an `error(…)` arm)
+            // are adoption changing how the request ENDED — and the
+            // precision-drift explanation below can only ever excuse the
+            // first kind.
             var detail = "adoption CHANGED THE ANSWER on "
-                + inexact.map(\.0).joined(separator: " and ")
-                + ": the adopting request returned different tokens than the cold "
-                + "request for the SAME prompt at temperature 0, so the reported "
-                + "savings are not savings — prefill was skipped that was needed. "
+                + inexact.map {
+                    "\($0.0) (\($0.1.adoptionMismatchReason ?? "token streams diverged"))"
+                }.joined(separator: " and ")
+                + ": the adopting request's outcome — token stream or terminal — "
+                + "differed from the cold request's for the SAME prompt at "
+                + "temperature 0, so the reported savings are not savings. "
                 + "Token counts are only meaningful conditional on exactness, which "
                 + "is why this outranks the comparison below"
             if let exact = exactArms.first {
@@ -1313,11 +1339,13 @@ public enum BackendParityCriteria {
                     + "the same prefix on the same prompt in the same process and stayed "
                     + "exact, so precision sensitivity cannot explain this one"
             } else {
-                detail += ". SYMMETRIC — every measured arm is inexact, so this is a "
-                    + "property of the MODEL (a cold prefill and an adopted replay "
-                    + "accumulate differently, and this checkpoint's argmax is sensitive "
-                    + "enough to show it), NOT evidence against either backend. Do not "
-                    + "cite it as one; see the precision caveat on token_exactness"
+                detail += ". SYMMETRIC — every measured arm is inexact. When the "
+                    + "mismatches are token divergence, that is a property of the MODEL "
+                    + "(a cold prefill and an adopted replay accumulate differently, and "
+                    + "this checkpoint's argmax is sensitive enough to show it), NOT "
+                    + "evidence against either backend — do not cite it as one; see the "
+                    + "precision caveat on token_exactness. A TERMINAL mismatch named "
+                    + "above is not excused by precision drift and stays a real finding"
             }
             return .init(
                 id: id, title: title, verdict: .fail, detail: detail,
@@ -1440,7 +1468,8 @@ public enum BackendParityCriteria {
         }
         if let weakest = exercised.min() {
             let window = [base, cand].map(\.adoptionComparedTokens).min() ?? 0
-            detail += ". Adoption was token-exact against each arm's OWN cold request over "
+            detail += ". Adoption was token- and terminal-exact against each arm's OWN "
+                + "cold request over "
                 + "\(window) completion tokens — the WINDOW bounds what could be seen, and a "
                 + "known paged adoption divergence appears at token 20, so read a short "
                 + "window as no evidence rather than weak evidence. The thinner arm also "

--- a/provider-swift/Sources/ProviderBenchmark/BackendParityReport.swift
+++ b/provider-swift/Sources/ProviderBenchmark/BackendParityReport.swift
@@ -839,7 +839,35 @@ public enum BackendParityCriteria {
             candidate.label: tokenSummary(candidate.rows),
         ]
 
-        if let mismatch = rowMismatch(baseline: baseline.rows, candidate: candidate.rows) {
+        // Per-row evidence. The zero-evidence guard above only catches ALL
+        // rows empty; a row that generated zero tokens on BOTH arms is still
+        // a non-observation — two matching `submit_error` shapes agree about
+        // nothing — so it is excluded from the agreement computation and
+        // disclosed. Below the floor the criterion refuses outright.
+        var scoredBaseline = baseline.rows
+        var scoredCandidate = candidate.rows
+        var exclusionNote: String?
+        if let evidence = pairedRowEvidence(
+            baseline: baseline.rows, candidate: candidate.rows),
+            !evidence.nonObservations.isEmpty
+        {
+            measurements["excludedRows"] = evidence.exclusionNote
+            if let floor = evidence.floorBlocker {
+                return .init(
+                    id: id, title: title, verdict: .unavailable,
+                    detail: "MOST OF THIS RUN FAILED — this is NOT agreement between "
+                        + "the backends. \(floor). Rows that fail identically on both "
+                        + "arms are non-observations, not matches, and a verdict scored "
+                        + "on the surviving minority would owe more to which prompts "
+                        + "survived than to the backends",
+                    measurements: measurements)
+            }
+            scoredBaseline = evidence.baselineEvidence
+            scoredCandidate = evidence.candidateEvidence
+            exclusionNote = evidence.exclusionNote
+        }
+
+        if let mismatch = rowMismatch(baseline: scoredBaseline, candidate: scoredCandidate) {
             measurements["firstFlip"] = mismatch
             if let control {
                 measurements["control"] = control.tokenExact.map {
@@ -859,7 +887,7 @@ public enum BackendParityCriteria {
                 + "first flip the two arms decode different contexts so later positions "
                 + "compare unrelated conversations"
             if let first = firstDivergingRow(
-                baseline: baseline.rows, candidate: candidate.rows),
+                baseline: scoredBaseline, candidate: scoredCandidate),
                 let probe = argmaxResolvable(row: first.row, index: first.index)
             {
                 measurements["argmaxMargin"] = String(format: "%.3e", probe.margin)
@@ -871,12 +899,13 @@ public enum BackendParityCriteria {
                     + (probe.resolvable ? "resolvable" : "NOT resolvable")
                     + " at that precision"
             }
+            if let exclusionNote { detail += ". \(exclusionNote)" }
             return .init(
                 id: id, title: title, verdict: .unavailable, detail: detail,
                 measurements: measurements)
         }
 
-        let total = baseline.rows.reduce(0) { $0 + $1.tokens.count }
+        let total = scoredBaseline.reduce(0) { $0 + $1.tokens.count }
         // The SHORTEST row, not only the total. A run whose prompts each emit
         // one token before `stop` clears the zero-evidence guard above and
         // reports agreement over three tokens — true, and far thinner than
@@ -885,12 +914,13 @@ public enum BackendParityCriteria {
         // which would refuse genuine passes on short-answer prompts. Measured
         // on gemma-4-e2b-it-4bit, where raw un-templated parity prompts do
         // exactly this.
-        let shortest = baseline.rows.map(\.tokens.count).min() ?? 0
+        let shortest = scoredBaseline.map(\.tokens.count).min() ?? 0
         return .init(
             id: id, title: title, verdict: .pass,
-            detail: "\(baseline.rows.count) prompts, \(total) generated token ids identical "
+            detail: "\(scoredBaseline.count) prompts, \(total) generated token ids identical "
                 + "between \(baseline.label) and \(candidate.label), finish reasons equal "
-                + "(shortest row \(shortest) token\(shortest == 1 ? "" : "s"))",
+                + "(shortest row \(shortest) token\(shortest == 1 ? "" : "s"))"
+                + (exclusionNote.map { ". \($0)" } ?? ""),
             measurements: measurements)
     }
 
@@ -1518,6 +1548,80 @@ public enum BackendParityCriteria {
             + (reasons.isEmpty
                 ? "no finish reason recorded"
                 : "finish=\(reasons.joined(separator: "/"))")
+    }
+
+    /// The per-row evidence behind a paired comparison.
+    ///
+    /// `zeroEvidenceBlocker` refuses the all-rows-empty case, but a run in
+    /// which ONE prompt decoded while the rest failed identically on both
+    /// arms sails past it — and `rowMismatch` then reads each matching
+    /// `submit_error`/`unterminated` pair as a row that AGREED. A row with
+    /// zero tokens on both arms is not a match; it is a non-observation, and
+    /// counting it toward parity lets a partially-failed release-gate run
+    /// report agreement it never measured.
+    struct PairedRowEvidence {
+        /// Row pairs where at least one arm generated a token — the actual
+        /// observations. (One-sided emptiness stays IN: an arm that decoded
+        /// nothing while the other decoded something is a real asymmetry,
+        /// and `rowMismatch` reports it as the divergence it is.)
+        let baselineEvidence: [BackendParityObservation.Row]
+        let candidateEvidence: [BackendParityObservation.Row]
+        /// One rendered line per row where NEITHER arm generated a token,
+        /// naming the failure shape(s) the rows carried.
+        let nonObservations: [String]
+        let totalRows: Int
+
+        /// Non-nil when fewer than half the rows are observations: whatever
+        /// the surviving rows say, most of the run failed, and a criterion
+        /// scored on the remainder would owe its verdict to which prompts
+        /// happened to survive.
+        var floorBlocker: String? {
+            let observed = baselineEvidence.count
+            guard observed * 2 < totalRows else { return nil }
+            return "only \(observed) of \(totalRows) row(s) produced tokens on either "
+                + "arm — the criterion is below its minimum-evidence floor (half the "
+                + "rows) and is not scored. Failed rows: "
+                + nonObservations.joined(separator: "; ")
+        }
+
+        /// Non-nil disclosure when scoring proceeds but rows were excluded.
+        var exclusionNote: String? {
+            guard !nonObservations.isEmpty else { return nil }
+            return "\(nonObservations.count) of \(totalRows) row(s) EXCLUDED as "
+                + "non-observations (zero tokens on both arms): "
+                + nonObservations.joined(separator: "; ")
+        }
+    }
+
+    /// Partition paired rows into observations and non-observations, or nil
+    /// when the rows cannot be paired at all (count or prompt-order
+    /// mismatch) — `rowMismatch` owns reporting those.
+    static func pairedRowEvidence(
+        baseline: [BackendParityObservation.Row],
+        candidate: [BackendParityObservation.Row]
+    ) -> PairedRowEvidence? {
+        guard baseline.count == candidate.count else { return nil }
+        var baseEvidence: [BackendParityObservation.Row] = []
+        var candEvidence: [BackendParityObservation.Row] = []
+        var nonObservations: [String] = []
+        for (base, cand) in zip(baseline, candidate) {
+            guard base.prompt == cand.prompt else { return nil }
+            if base.tokens.isEmpty, cand.tokens.isEmpty {
+                let shapes =
+                    base.finishReason == cand.finishReason
+                    ? (base.finishReason.isEmpty ? "no finish reason" : base.finishReason)
+                    : "\(base.finishReason) vs \(cand.finishReason)"
+                nonObservations.append("prompt '\(base.prompt)': \(shapes)")
+            } else {
+                baseEvidence.append(base)
+                candEvidence.append(cand)
+            }
+        }
+        return PairedRowEvidence(
+            baselineEvidence: baseEvidence,
+            candidateEvidence: candEvidence,
+            nonObservations: nonObservations,
+            totalRows: baseline.count)
     }
 
     /// The blocking reason when a PAIR of token streams cannot be compared at

--- a/provider-swift/Sources/ProviderBenchmark/ThroughputSweep.swift
+++ b/provider-swift/Sources/ProviderBenchmark/ThroughputSweep.swift
@@ -215,9 +215,34 @@ public enum ThroughputSweep {
 
     // MARK: - Decode
 
-    private struct RowMeasure: Sendable {
+    struct RowMeasure: Sendable {
         let produced: Int
         let elapsed: Duration
+        /// Non-nil when `engine.submit` threw for this row: the row decoded
+        /// NOTHING and its zeros are an absence, not a measurement.
+        var submitFailure: String? = nil
+    }
+
+    /// Aggregate a batch's row measurements into one cell. Any row whose
+    /// submission failed poisons the WHOLE cell: the curve point would be
+    /// computed over fewer live sequences than the batch size it is labelled
+    /// with, so the caller must record it as unmeasured rather than let a
+    /// zero-token row deflate a "measured" sample. Internal (not private)
+    /// so the poisoning rule is pinned by unit tests without a GPU.
+    static func aggregateRows(_ rows: [RowMeasure]) -> (
+        totalTokens: Int, maxElapsed: Duration, submitFailure: String?
+    ) {
+        var total = 0
+        var maxElapsed: Duration = .zero
+        var submitFailure: String?
+        for row in rows {
+            total += row.produced
+            if row.elapsed > maxElapsed { maxElapsed = row.elapsed }
+            if submitFailure == nil, let failure = row.submitFailure {
+                submitFailure = failure
+            }
+        }
+        return (total, maxElapsed, submitFailure)
     }
 
     /// Decode samples plus the KV backend the engine ACTUALLY built for those
@@ -323,7 +348,7 @@ public enum ThroughputSweep {
 
         for iteration in 1 ... repetitions {
             for batchSize in sizes {
-                let (totalTokens, maxElapsed, resolved, failure) = await runDecodeBatch(
+                let (totalTokens, maxElapsed, resolved, failure, submitFailure) = await runDecodeBatch(
                     container: container, modelID: modelID, baseTokens: baseTokens,
                     batchSize: batchSize, decodeTokens: genTokens, promptLen: promptLen,
                     weightBytes: weightBytes, isVLM: isVLM, modelDirectory: modelDirectory,
@@ -336,6 +361,20 @@ public enum ThroughputSweep {
                     if outcome.recordUnmeasured(batchSize: batchSize, reason: failure) {
                         log("  B=\(batchSize): NO measurement — \(failure)")
                     }
+                }
+                if let submitFailure {
+                    // The engine BUILT (resolved backend recorded above) but
+                    // a row's submission threw — e.g. an admission or
+                    // runtime-capacity failure at a larger batch. The cell
+                    // decoded fewer live rows than its label claims, so it is
+                    // UNMEASURED (which fails an explicit-backend sweep via
+                    // decodeCoverage), never a zero-deflated sample.
+                    if outcome.recordUnmeasured(
+                        batchSize: batchSize, reason: "submit failed: \(submitFailure)")
+                    {
+                        log("  B=\(batchSize): NO measurement — submit failed: \(submitFailure)")
+                    }
+                    continue
                 }
                 let secs = seconds(maxElapsed)
                 let aggregate = secs > 0 ? Double(totalTokens) / secs : 0
@@ -357,10 +396,13 @@ public enum ThroughputSweep {
     /// Build the production CBv2 engine (`EngineV2Factory.makeProductionBuild`
     /// — the same construction every serving slot uses), run `batchSize`
     /// greedy rows to completion, shut the engine down, and return
-    /// `(totalDecodedTokens, maxRowElapsed, resolvedBackend)` where the clock
-    /// starts after each row's first token (prefill excluded) and
-    /// `resolvedBackend` names the KV backend the factory actually chose
-    /// (nil when construction failed).
+    /// `(totalDecodedTokens, maxRowElapsed, resolvedBackend,
+    /// constructionFailure, submitFailure)` where the clock starts after
+    /// each row's first token (prefill excluded), `resolvedBackend` names
+    /// the KV backend the factory actually chose (nil when construction
+    /// failed), and `submitFailure` is non-nil when the engine built but any
+    /// row's `engine.submit` threw — the cell is then unmeasured, never a
+    /// zero-token sample (see `aggregateRows`).
     @discardableResult
     private static func runDecodeBatch(
         container: ModelContainer,
@@ -375,7 +417,7 @@ public enum ThroughputSweep {
         kvBackend: EngineV2KVBackendSelection
     ) async -> (
         totalTokens: Int, maxElapsed: Duration, resolvedBackend: String?,
-        constructionFailure: String?
+        constructionFailure: String?, submitFailure: String?
     ) {
         // The engine's KV admission ceiling: the same unified-memory budget a
         // single-model provider slot would be granted. Far above what these
@@ -420,12 +462,13 @@ public enum ThroughputSweep {
             // Return the reason so the report and the process exit status can
             // both name it instead of showing a bare curve of zeros.
             log("  engine construction failed: \(error)")
-            return (0, .zero, nil, "\(error)")
+            return (0, .zero, nil, "\(error)", nil)
         }
         let engine = parts.engine
         let eosTokenIds = parts.eosTokenIds
 
-        let result = await withTaskGroup(of: RowMeasure.self) { group -> (Int, Duration) in
+        let result = await withTaskGroup(of: RowMeasure.self) {
+            group -> (Int, Duration, String?) in
             for i in 0 ..< batchSize {
                 // Distinct rotated prompt per row so each sequence routes to a
                 // different mix of experts (otherwise identical prompts would
@@ -443,7 +486,8 @@ public enum ThroughputSweep {
                         ))
                     } catch {
                         Self.log("  submit failed: \(error)")
-                        return RowMeasure(produced: 0, elapsed: .zero)
+                        return RowMeasure(
+                            produced: 0, elapsed: .zero, submitFailure: "\(error)")
                     }
                     var sawFirst = false
                     var start = ContinuousClock.now
@@ -464,19 +508,17 @@ public enum ThroughputSweep {
                     return RowMeasure(produced: produced, elapsed: ContinuousClock.now - start)
                 }
             }
-            var total = 0
-            var maxElapsed: Duration = .zero
-            for await row in group {
-                total += row.produced
-                if row.elapsed > maxElapsed { maxElapsed = row.elapsed }
-            }
-            return (total, maxElapsed)
+            var rows: [RowMeasure] = []
+            for await row in group { rows.append(row) }
+            let cell = Self.aggregateRows(rows)
+            return (cell.totalTokens, cell.maxElapsed, cell.submitFailure)
         }
 
         await engine.shutdown()
         return (
             totalTokens: result.0, maxElapsed: result.1,
-            resolvedBackend: parts.resolvedBackend, constructionFailure: nil)
+            resolvedBackend: parts.resolvedBackend, constructionFailure: nil,
+            submitFailure: result.2)
     }
 
     // MARK: - Helpers

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2SlotFactory.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2SlotFactory.swift
@@ -421,15 +421,12 @@ enum EngineV2SlotFactory {
 
         let processKVBytesPerToken: Int
         if let preparedBackend {
-            let capability = CBv2PrefixReuseCapability.derive(
+            processKVBytesPerToken = slotKVBytesPerToken(
+                resolvedKind: preparedBackend.kind,
+                pagedPoolDType: preparedBackend.pagedPoolDType,
                 layerKinds: preparedBackend.layerKinds,
-                backend: .contiguousUnquantized)
-            processKVBytesPerToken = EngineV2Factory.nativeKVBytesPerToken(
                 nominalFP16BytesPerToken: sizing.fp16KVBytesPerToken,
-                fp16FullKVBytesPerToken: capability.fullKVBytesPerToken,
-                fullRowsUseFP32:
-                    preparedBackend.kind == .contiguous
-                    && servingModel is GPTOSSModel)
+                servingModelIsGPTOSS: servingModel is GPTOSSModel)
         } else {
             processKVBytesPerToken = sizing.fp16KVBytesPerToken
         }
@@ -476,6 +473,47 @@ enum EngineV2SlotFactory {
             assistantBytes: mtpStatus.assistantBytes,
             mtpArtifact: prepared.mtpArtifact,
             mtpStatus: mtpStatus)
+    }
+
+    /// Per-token KV rate the bridge reserves at and the heartbeat divides
+    /// by (`kv_bytes_per_token` / `activeTokenBudgetMax` in
+    /// `EngineV2Bridge+Capacity`), derived from the backend the slot was
+    /// ACTUALLY built with:
+    ///
+    ///   * contiguous + GPT-OSS ⇒ the native-width rate (fp32 owning
+    ///     full-attention rows on top of the fp16 sizing snapshot),
+    ///   * paged with fp32 pages (`DARKBLOOM_CBV2_PAGED_KV_DTYPE=float32`)
+    ///     ⇒ a flat 2x — every page doubles, windowed layers included —
+    ///     so the advertised token budget HALVES to match the pool's real
+    ///     page count. Without this the byte figure is right and the
+    ///     divisor is half the truth, and `BackendCapacity.Slots` being
+    ///     scheduler-authoritative means the coordinator over-admits ~2x
+    ///     against a pool that holds half the tokens,
+    ///   * everything else ⇒ the nominal fp16 rate unchanged.
+    ///
+    /// `pagedPoolDType` must come off `ProductionBackendPreparation` (the
+    /// CONSTRUCTED pool reporting itself), never the requested env value:
+    /// an fp32 request that degraded to contiguous carries nil here and
+    /// must not double a backend that has no pages. Pure and static so the
+    /// dtype→rate→budget wiring is unit-testable without loading a model.
+    static func slotKVBytesPerToken(
+        resolvedKind: EngineV2KVBackendKind,
+        pagedPoolDType: String?,
+        layerKinds: [CBv2LayerKind],
+        nominalFP16BytesPerToken: Int,
+        servingModelIsGPTOSS: Bool
+    ) -> Int {
+        let capability = CBv2PrefixReuseCapability.derive(
+            layerKinds: layerKinds,
+            backend: .contiguousUnquantized)
+        return EngineV2Factory.processKVBytesPerToken(
+            nominalFP16BytesPerToken: nominalFP16BytesPerToken,
+            fp16FullKVBytesPerToken: capability.fullKVBytesPerToken,
+            fullRowsUseFP32:
+                resolvedKind == .contiguous && servingModelIsGPTOSS,
+            // Only a resolved PAGED backend has pages whose dtype can
+            // widen the rate; a contiguous build ignores the knob.
+            pagedPoolDType: resolvedKind == .paged ? pagedPoolDType : nil)
     }
 
     private static func emitPrefixCacheConstructionFailure(

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+Trust.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+Trust.swift
@@ -64,7 +64,12 @@ extension ProviderLoop {
                 requestedGlobal: loopConfig.config.backend.engineV2KVBackend,
                 requestedByModel: loopConfig.config.backend.engineV2KVBackendByModel,
                 lastModelLoadError: lastModelLoadError,
-                desiredModels: desiredModelsForPosture())
+                desiredModels: desiredModelsForPosture(),
+                // Expiry follows THIS box's idle-unload horizon, not the
+                // default: 0 (unload disabled) never expires by age, a
+                // longer-than-default timeout keeps evidence just as long.
+                failureMaxAge: DaemonSlotPostureBuilder.failureMaxAge(
+                    idleTimeoutMins: loopConfig.config.backend.idleTimeoutMins))
         )
     }
 

--- a/provider-swift/Sources/ProviderCore/Service/DaemonStateFile.swift
+++ b/provider-swift/Sources/ProviderCore/Service/DaemonStateFile.swift
@@ -284,18 +284,42 @@ public enum DaemonSlotPostureBuilder {
     }
 
     /// How long the synthetic failed-slot entry outlives its failure without
-    /// a fresh one. One hour — the daemon's own idle-unload horizon
-    /// (`idle_timeout_mins` default): past it, every REAL slot from the
-    /// failure's era has been unloaded and rebuilt on demand anyway, so a
-    /// failure older than that horizon describes a previous era of the box,
-    /// not its current posture — history for the logs, not a live-looking
+    /// a fresh one. One hour — the daemon's DEFAULT idle-unload horizon
+    /// (`idle_timeout_mins`): past it, every REAL slot from the failure's
+    /// era has been unloaded and rebuilt on demand anyway, so a failure
+    /// older than that horizon describes a previous era of the box, not its
+    /// current posture — history for the logs, not a live-looking
     /// `NOT SERVING` row in `status`/`doctor`. Deliberately wedge-scale, not
     /// stale-scale (`KVBackendPosture.staleAfterSeconds` is ~10 s): a
     /// genuinely failed slot must not flap out of `doctor` between two
     /// commands of the same debugging session, and any retry of the load
     /// refreshes `at` (`recordModelLoadError`), keeping a PERSISTENT failure
     /// visible for as long as it actually recurs.
+    ///
+    /// This constant is the FLOOR; the effective horizon follows the
+    /// CONFIGURED idle timeout — see ``failureMaxAge(idleTimeoutMins:)``.
     public static let failureMaxAgeSeconds: Double = 3_600
+
+    /// The effective failed-slot expiry horizon for a box's configured
+    /// idle-unload timeout. The whole rationale for expiring by age is "the
+    /// idle-unload horizon has passed, so no real slot from the failure's
+    /// era survives" — a fixed 3600 s only implements that for the DEFAULT
+    /// configuration:
+    ///
+    ///   * `idle_timeout_mins = 0` (idle unload disabled): nil — there is no
+    ///     era boundary, slots live until an operator acts, so the failure
+    ///     row only clears via a live slot, config removal, or a fresh
+    ///     outcome. Expiring it by age would hide a real failure on exactly
+    ///     the box configured to never forget its slots.
+    ///   * above 60 min: use it — a box that keeps slots for 4 h keeps its
+    ///     failure evidence for 4 h.
+    ///   * at or below 60 min: keep the one-hour floor. The wedge-scale
+    ///     rationale above still holds — a 5-minute idle timeout must not
+    ///     make a genuine failure flap out of `doctor` mid-debugging-session.
+    public static func failureMaxAge(idleTimeoutMins: UInt64) -> Double? {
+        guard idleTimeoutMins > 0 else { return nil }
+        return max(Double(idleTimeoutMins) * 60, failureMaxAgeSeconds)
+    }
 
     /// `live` slots first (sorted by model id), then at most one synthetic
     /// entry for `lastModelLoadError` — and only while that failure is
@@ -309,13 +333,16 @@ public enum DaemonSlotPostureBuilder {
     ///     model resolved the failure the other way, and a row that outlives
     ///     the config that produced it reports `NOT SERVING` forever for a
     ///     model nobody wants served;
-    ///   * the failure is younger than ``failureMaxAgeSeconds``.
+    ///   * the failure is younger than `failureMaxAge` (the caller passes
+    ///     ``failureMaxAge(idleTimeoutMins:)`` for its configured idle
+    ///     timeout; nil ⇒ no expiry by age — idle unload disabled).
     public static func build(
         live: [LiveSlot],
         requestedGlobal: String,
         requestedByModel: [String: String],
         lastModelLoadError: DaemonState.ModelLoadError?,
         desiredModels: Set<String>? = nil,
+        failureMaxAge: Double? = failureMaxAgeSeconds,
         now: Double = Date().timeIntervalSince1970
     ) -> [DaemonState.SlotPosture] {
         func requested(_ modelID: String) -> String {
@@ -336,7 +363,7 @@ public enum DaemonSlotPostureBuilder {
         if let failure = lastModelLoadError,
             !live.contains(where: { $0.model == failure.model }),
             desiredModels.map({ $0.contains(failure.model) }) ?? true,
-            now - failure.at <= failureMaxAgeSeconds
+            failureMaxAge.map({ now - failure.at <= $0 }) ?? true
         {
             out.append(
                 DaemonState.SlotPosture(

--- a/provider-swift/Sources/ProviderCore/Service/KVBackendGuard.swift
+++ b/provider-swift/Sources/ProviderCore/Service/KVBackendGuard.swift
@@ -91,10 +91,19 @@ public enum KVBackendGuardStore {
     /// Path override, resolved from the CALLER's environment (see above).
     public static let pathEnvKey = "DARKBLOOM_KV_BACKEND_GUARD"
 
+    /// Only an ABSOLUTE override is honored. A relative path would resolve
+    /// against each process's own working directory — the launchd-spawned
+    /// watchdog (CWD `/`) and the daemon would silently read and WRITE
+    /// different guard files, which defeats the override's one purpose: a
+    /// single file both processes agree on. There is no shared CWD to
+    /// absolutize a relative path against, so it is rejected (the default
+    /// path is used) rather than guessed at.
     public static func path(
         environment: [String: String] = ProcessInfo.processInfo.environment
     ) -> URL {
-        if let override = environment[pathEnvKey], !override.isEmpty {
+        if let override = environment[pathEnvKey], !override.isEmpty,
+            override.hasPrefix("/")
+        {
             return URL(fileURLWithPath: override)
         }
         return FileManager.default.homeDirectoryForCurrentUser

--- a/provider-swift/Sources/ProviderCore/Telemetry/TelemetryOverflowQueue.swift
+++ b/provider-swift/Sources/ProviderCore/Telemetry/TelemetryOverflowQueue.swift
@@ -5,13 +5,42 @@
 /// Size cap: 5 MB. On overflow, the oldest half of the file is discarded.
 ///
 /// The queue is intentionally simple: open-for-append for writes, read+rewrite
-/// for drains. It is NOT a cross-process durable queue -- one provider process
-/// owns the file. A crash mid-write may lose the last partial line; that's
-/// acceptable because telemetry is best-effort.
+/// for drains. TWO processes share the file: the daemon (panic hook pushes,
+/// TelemetryClient drains) and the persistent watchdog (crash-loop guard trip
+/// events, `KVBackendCrashLoopGuard`). A drain is a read-then-replace, so an
+/// unsynchronized watchdog push landing between the daemon's read and its
+/// replace would be silently clobbered — and the trip event is exactly the one
+/// operators alert on. Every mutation therefore takes an exclusive `flock` on
+/// a dedicated sidecar lock file (`<queue>.lock`) in addition to the
+/// in-process NSLock:
+///
+///   * the LOCK FILE, not the queue file, is flocked — a drain replaces the
+///     queue's inode (`replaceItemAt`), and a lock taken on the old inode
+///     would not exclude a writer that opened the path after the swap. The
+///     sidecar is created once and never replaced, so the lock identity is
+///     stable across drains.
+///   * `flock` over `NSFileCoordinator`: both processes are plain CLI
+///     processes on one machine writing one small file — flock is the
+///     smallest primitive that gives cross-process mutual exclusion, needs no
+///     coordination daemon, and (unlike a watchdog-suffixed second queue)
+///     leaves ONE file with ONE drain path instead of a merge-and-ordering
+///     question at every consumer.
+///   * fail-open: if the lock file cannot be opened or flocked, the mutation
+///     proceeds unlocked. Telemetry is best-effort; a lock failure must never
+///     make the daemon drop events it could have written, and the pre-lock
+///     behavior is the worst case.
+///
+/// A crash mid-write may lose the last partial line; that's acceptable
+/// because telemetry is best-effort.
 
 import Foundation
 #if canImport(os)
 import os
+#endif
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
 #endif
 
 // MARK: - Overflow Queue
@@ -40,12 +69,39 @@ public final class TelemetryOverflowQueue: @unchecked Sendable {
         }
     }
 
+    // MARK: - Cross-process lock
+
+    /// Acquire the exclusive cross-process lock (see the header). Returns the
+    /// open lock-file descriptor, or nil on failure (the caller proceeds
+    /// unlocked — fail-open). Caller must hold `lock` and must pass the
+    /// result to `releaseFileLock`.
+    private func acquireFileLock() -> Int32? {
+        ensureParentDirectory()
+        let lockPath = path.path + ".lock"
+        let fd = open(lockPath, O_CREAT | O_RDWR, 0o644)
+        guard fd >= 0 else { return nil }
+        guard flock(fd, LOCK_EX) == 0 else {
+            close(fd)
+            return nil
+        }
+        return fd
+    }
+
+    private func releaseFileLock(_ fd: Int32?) {
+        guard let fd else { return }
+        flock(fd, LOCK_UN)
+        close(fd)
+    }
+
     // MARK: - Push
 
-    /// Append an event to the disk queue. Thread-safe.
+    /// Append an event to the disk queue. Thread-safe within the process and
+    /// across processes (daemon + watchdog — see the header).
     public func push(_ event: TelemetryEvent) {
         lock.lock()
         defer { lock.unlock() }
+        let fileLock = acquireFileLock()
+        defer { releaseFileLock(fileLock) }
 
         guard let line = try? encoder.encode(event),
               let lineString = String(data: line, encoding: .utf8) else {
@@ -72,10 +128,15 @@ public final class TelemetryOverflowQueue: @unchecked Sendable {
     // MARK: - Drain
 
     /// Drain up to `limit` events from the head of the queue and rewrite the
-    /// rest back to disk. Returns the drained events. Thread-safe.
+    /// rest back to disk. Returns the drained events. Thread-safe within the
+    /// process and across processes: the read-then-replace runs under the
+    /// exclusive file lock, so a concurrent watchdog push cannot land between
+    /// the read and the replace and be clobbered.
     public func drain(limit: Int) -> [TelemetryEvent] {
         lock.lock()
         defer { lock.unlock() }
+        let fileLock = acquireFileLock()
+        defer { releaseFileLock(fileLock) }
 
         guard FileManager.default.fileExists(atPath: path.path) else {
             return []

--- a/provider-swift/Tests/ProviderCoreTests/BackendParityReportTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/BackendParityReportTests.swift
@@ -778,6 +778,105 @@ struct BackendParityReportTests {
         #expect(!asked.contains("NOT SUPPLIED"))
     }
 
+    // MARK: - Per-row evidence floor
+
+    @Test("one productive row out of three is below the evidence floor, not a PASS")
+    func partiallyFailedRunIsBelowTheEvidenceFloor() {
+        // The exact shape the review names: one prompt decoded, the other two
+        // failed IDENTICALLY on both arms. The matching submit_error rows
+        // used to count as row matches, so the criterion passed on almost
+        // zero evidence.
+        let failure = "submit_error: capacity refused the request"
+        func arm(_ selection: String) -> BackendParityObservation {
+            BackendParityObservation(
+                selection: selection, resolvedBackend: selection,
+                rows: [
+                    row("a", [1, 2, 3]),
+                    row("b", [], finish: failure),
+                    row("c", [], finish: failure),
+                ])
+        }
+        let result = BackendParityCriteria.tokenExactness(
+            baseline: arm("contiguous"), candidate: arm("paged"))
+        #expect(result.verdict == .unavailable)
+        #expect(result.verdict != .pass)
+        // The refusal names the count and the per-row failure shapes.
+        #expect(result.detail.contains("only 1 of 3"))
+        #expect(result.detail.contains(failure))
+        #expect(result.detail.contains("prompt 'b'"))
+        #expect(result.detail.contains("prompt 'c'"))
+        #expect(result.detail.contains("NOT agreement"))
+    }
+
+    @Test("a minority failed row is excluded and disclosed, not counted as a match")
+    func minorityFailureIsDisclosedButScored() {
+        let failure = "unterminated: stream ended without a finish reason"
+        func arm(_ selection: String) -> BackendParityObservation {
+            BackendParityObservation(
+                selection: selection, resolvedBackend: selection,
+                rows: [
+                    row("a", [1, 2, 3]),
+                    row("b", [4, 5]),
+                    row("c", [], finish: failure),
+                ])
+        }
+        let result = BackendParityCriteria.tokenExactness(
+            baseline: arm("contiguous"), candidate: arm("paged"))
+        // Majority-productive: still evaluable...
+        #expect(result.verdict == .pass)
+        // ...but scored over the OBSERVED rows only, with the exclusion named.
+        #expect(result.detail.contains("2 prompts, 5 generated token ids identical"))
+        #expect(result.detail.contains("1 of 3 row(s) EXCLUDED as non-observations"))
+        #expect(result.detail.contains(failure))
+        #expect(result.measurements["excludedRows"]?.contains("prompt 'c'") == true)
+    }
+
+    @Test("a both-empty row with MISMATCHED failure shapes is excluded, not a first flip")
+    func mismatchedFailureShapesAreNonObservationsNotDivergence() {
+        // Both arms generated nothing on prompt 'c' but failed differently.
+        // That row carries no token evidence in either direction — it must
+        // be excluded with both shapes named, never booked as a divergence.
+        func arm(_ selection: String, cFinish: String) -> BackendParityObservation {
+            BackendParityObservation(
+                selection: selection, resolvedBackend: selection,
+                rows: [
+                    row("a", [1, 2, 3]),
+                    row("b", [4, 5]),
+                    row("c", [], finish: cFinish),
+                ])
+        }
+        let result = BackendParityCriteria.tokenExactness(
+            baseline: arm("contiguous", cFinish: "submit_error: refused"),
+            candidate: arm("paged", cFinish: "unterminated"))
+        #expect(result.verdict == .pass)
+        #expect(result.detail.contains("submit_error: refused vs unterminated"))
+        #expect(result.measurements["firstFlip"] == nil)
+    }
+
+    @Test("a divergence among the observed rows still reports, with the exclusion noted")
+    func divergenceAmongObservedRowsCarriesTheExclusionNote() {
+        let failure = "submit_error: capacity refused the request"
+        func arm(_ selection: String, bTokens: [Int]) -> BackendParityObservation {
+            BackendParityObservation(
+                selection: selection, resolvedBackend: selection,
+                rows: [
+                    row("a", [1, 2, 3]),
+                    row("b", bTokens),
+                    row("c", [], finish: failure),
+                    row("d", [], finish: failure),
+                ])
+        }
+        // 2 of 4 rows observed: exactly half, so the floor does not fire —
+        // and one of the observed rows diverges.
+        let result = BackendParityCriteria.tokenExactness(
+            baseline: arm("contiguous", bTokens: [4, 5]),
+            candidate: arm("paged", bTokens: [4, 99]))
+        #expect(result.verdict == .unavailable)
+        #expect(result.detail.contains("prompt 'b' token 1"))
+        #expect(result.detail.contains("2 of 4 row(s) EXCLUDED"))
+        #expect(result.measurements["firstFlip"]?.contains("prompt 'b'") == true)
+    }
+
     @Test("token exactness NEVER fails: a divergence is UNAVAILABLE with the first flip")
     func tokenExactnessIsPassOnly() {
         // The incumbent fails free-running token exactness too — contiguous

--- a/provider-swift/Tests/ProviderCoreTests/BackendParityReportTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/BackendParityReportTests.swift
@@ -94,6 +94,7 @@ struct BackendParityReportTests {
         misses: Int = 1,
         tokensSaved: Int = 0,
         exact: Bool? = nil,
+        mismatchReason: String? = nil,
         comparedTokens: Int = 0,
         probeResolved: String? = nil
     ) -> BackendParityObservation {
@@ -115,6 +116,7 @@ struct BackendParityReportTests {
                 cacheMisses: misses,
                 cacheTokensSaved: tokensSaved,
                 adoptionTokenExact: exact,
+                adoptionMismatchReason: mismatchReason,
                 adoptionComparedTokens: comparedTokens,
                 probeResolvedBackend: probeResolved))
     }
@@ -189,7 +191,10 @@ struct BackendParityReportTests {
         // appear later, as the exact arm that proves the divergence is
         // asymmetric — exonerating, not accused — so assert on the clause
         // rather than on the bare substring.
-        #expect(inexactCandidate.detail.hasPrefix("adoption CHANGED THE ANSWER on paged:"))
+        #expect(inexactCandidate.detail.hasPrefix("adoption CHANGED THE ANSWER on paged"))
+        // No recorded reason falls back to the token-divergence phrasing —
+        // the only shape the oracle could see before terminals were judged.
+        #expect(inexactCandidate.detail.contains("paged (token streams diverged)"))
         #expect(!inexactCandidate.detail.contains("ANSWER on contiguous"))
 
         // The incumbent is not exempt: an inexact BASELINE is equally a FAIL,
@@ -197,7 +202,7 @@ struct BackendParityReportTests {
         let inexactBaseline = BackendParityCriteria.prefixReuse(
             baseline: arm("contiguous", exact: false), candidate: arm("paged", exact: true))
         #expect(inexactBaseline.verdict == .fail)
-        #expect(inexactBaseline.detail.hasPrefix("adoption CHANGED THE ANSWER on contiguous:"))
+        #expect(inexactBaseline.detail.hasPrefix("adoption CHANGED THE ANSWER on contiguous"))
 
         // Both exact: the criterion falls through to the savings comparison.
         let bothExact = BackendParityCriteria.prefixReuse(
@@ -211,6 +216,83 @@ struct BackendParityReportTests {
             baseline: arm("contiguous", exact: nil), candidate: arm("paged", exact: nil))
         #expect(unmeasured.verdict == .pass)
         #expect(!unmeasured.detail.contains("adoption CHANGED THE ANSWER"))
+    }
+
+    /// Exactness is a claim about the whole REQUEST OUTCOME. Before terminals
+    /// were judged, the same token IDs under `stop` vs `length` — or under an
+    /// `error(…)` that cut one stream short — recorded exact and let the
+    /// criterion PASS while adoption changed how the request ended.
+    @Test("same tokens with a different terminal are NOT exact, and the reason is named")
+    func terminalMismatchDefeatsExactness() {
+        typealias Harness = BackendParityHarness
+
+        // The clean case: identical tokens, identical clean terminal.
+        let clean = Harness.judgeAdoptionExactness(
+            coldTokens: [1, 2, 3], adoptedTokens: [1, 2, 3],
+            coldFinish: "stop", adoptedFinish: "stop")
+        #expect(clean.exact)
+        #expect(clean.mismatchReason == nil)
+
+        // Same tokens, different clean terminals: the request ENDED
+        // differently, so the comparison is not exact and says why.
+        let stopVsLength = Harness.judgeAdoptionExactness(
+            coldTokens: [1, 2, 3], adoptedTokens: [1, 2, 3],
+            coldFinish: "stop", adoptedFinish: "length")
+        #expect(!stopVsLength.exact)
+        #expect(stopVsLength.mismatchReason
+            == "terminal mismatch: cold finished 'stop', adopted finished 'length'")
+
+        // Same tokens, one arm cut short by machinery: the mismatch AND the
+        // unclean side are both named — an `error(…)` must never be
+        // summarized as a mere stop/length disagreement.
+        let errorArm = Harness.judgeAdoptionExactness(
+            coldTokens: [1, 2, 3], adoptedTokens: [1, 2, 3],
+            coldFinish: "stop", adoptedFinish: "error(pool exhausted)")
+        #expect(!errorArm.exact)
+        #expect(errorArm.mismatchReason?.contains("terminal mismatch") == true)
+        #expect(errorArm.mismatchReason?.contains(
+            "non-clean terminal on adopted ('error(pool exhausted)')") == true)
+
+        // Identical but UNCLEAN terminals: both streams are truncation
+        // artifacts, so their agreement proves nothing about adoption.
+        let bothUnclean = Harness.judgeAdoptionExactness(
+            coldTokens: [1, 2, 3], adoptedTokens: [1, 2, 3],
+            coldFinish: "error(watchdog)", adoptedFinish: "error(watchdog)")
+        #expect(!bothUnclean.exact)
+        #expect(bothUnclean.mismatchReason
+            == "non-clean terminal on both arms: 'error(watchdog)'")
+
+        // Diverging tokens keep their original phrasing; a simultaneous
+        // terminal mismatch is appended, not substituted.
+        let diverged = Harness.judgeAdoptionExactness(
+            coldTokens: [1, 2, 3], adoptedTokens: [1, 2, 9],
+            coldFinish: "stop", adoptedFinish: "length")
+        #expect(!diverged.exact)
+        #expect(diverged.mismatchReason?.hasPrefix("token streams diverged") == true)
+        #expect(diverged.mismatchReason?.contains("terminal mismatch") == true)
+
+        // `length` on BOTH arms is clean: hitting the same budget the same
+        // way is a valid comparison, not a truncation artifact.
+        let bothLength = Harness.judgeAdoptionExactness(
+            coldTokens: [1, 2, 3], adoptedTokens: [1, 2, 3],
+            coldFinish: "length", adoptedFinish: "length")
+        #expect(bothLength.exact)
+    }
+
+    @Test("the criterion detail discloses the recorded mismatch shape per arm")
+    func criterionDetailNamesTheMismatchShape() {
+        let verdict = BackendParityCriteria.prefixReuse(
+            baseline: prefixArm("contiguous", bound: 1536, saved: 26880, exact: true),
+            candidate: prefixArm(
+                "paged", bound: 1536, saved: 26880, exact: false,
+                mismatchReason: "terminal mismatch: cold finished 'stop', "
+                    + "adopted finished 'length'"))
+        #expect(verdict.verdict == .fail)
+        #expect(verdict.detail.contains(
+            "paged (terminal mismatch: cold finished 'stop', adopted finished 'length')"))
+        // A terminal-shaped mismatch is never excusable as precision drift;
+        // the wording that offers that excuse is scoped to token divergence.
+        #expect(verdict.detail.contains("token stream or terminal"))
     }
 
     /// A cold prefill and an adopted replay accumulate differently even when

--- a/provider-swift/Tests/ProviderCoreTests/BackendParityReportTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/BackendParityReportTests.swift
@@ -95,6 +95,7 @@ struct BackendParityReportTests {
         tokensSaved: Int = 0,
         exact: Bool? = nil,
         mismatchReason: String? = nil,
+        inconclusiveReason: String? = nil,
         comparedTokens: Int = 0,
         probeResolved: String? = nil
     ) -> BackendParityObservation {
@@ -117,6 +118,7 @@ struct BackendParityReportTests {
                 cacheTokensSaved: tokensSaved,
                 adoptionTokenExact: exact,
                 adoptionMismatchReason: mismatchReason,
+                adoptionInconclusiveReason: inconclusiveReason,
                 adoptionComparedTokens: comparedTokens,
                 probeResolvedBackend: probeResolved))
     }
@@ -230,17 +232,16 @@ struct BackendParityReportTests {
         let clean = Harness.judgeAdoptionExactness(
             coldTokens: [1, 2, 3], adoptedTokens: [1, 2, 3],
             coldFinish: "stop", adoptedFinish: "stop")
-        #expect(clean.exact)
-        #expect(clean.mismatchReason == nil)
+        #expect(clean == .exact)
 
         // Same tokens, different clean terminals: the request ENDED
         // differently, so the comparison is not exact and says why.
         let stopVsLength = Harness.judgeAdoptionExactness(
             coldTokens: [1, 2, 3], adoptedTokens: [1, 2, 3],
             coldFinish: "stop", adoptedFinish: "length")
-        #expect(!stopVsLength.exact)
-        #expect(stopVsLength.mismatchReason
-            == "terminal mismatch: cold finished 'stop', adopted finished 'length'")
+        #expect(stopVsLength
+            == .inexact(
+                reason: "terminal mismatch: cold finished 'stop', adopted finished 'length'"))
 
         // Same tokens, one arm cut short by machinery: the mismatch AND the
         // unclean side are both named — an `error(…)` must never be
@@ -248,35 +249,104 @@ struct BackendParityReportTests {
         let errorArm = Harness.judgeAdoptionExactness(
             coldTokens: [1, 2, 3], adoptedTokens: [1, 2, 3],
             coldFinish: "stop", adoptedFinish: "error(pool exhausted)")
-        #expect(!errorArm.exact)
-        #expect(errorArm.mismatchReason?.contains("terminal mismatch") == true)
-        #expect(errorArm.mismatchReason?.contains(
-            "non-clean terminal on adopted ('error(pool exhausted)')") == true)
-
-        // Identical but UNCLEAN terminals: both streams are truncation
-        // artifacts, so their agreement proves nothing about adoption.
-        let bothUnclean = Harness.judgeAdoptionExactness(
-            coldTokens: [1, 2, 3], adoptedTokens: [1, 2, 3],
-            coldFinish: "error(watchdog)", adoptedFinish: "error(watchdog)")
-        #expect(!bothUnclean.exact)
-        #expect(bothUnclean.mismatchReason
-            == "non-clean terminal on both arms: 'error(watchdog)'")
+        guard case .inexact(let errorReason) = errorArm else {
+            Issue.record("expected .inexact, got \(errorArm)")
+            return
+        }
+        #expect(errorReason.contains("terminal mismatch"))
+        #expect(errorReason.contains(
+            "non-clean terminal on adopted ('error(pool exhausted)')"))
 
         // Diverging tokens keep their original phrasing; a simultaneous
         // terminal mismatch is appended, not substituted.
         let diverged = Harness.judgeAdoptionExactness(
             coldTokens: [1, 2, 3], adoptedTokens: [1, 2, 9],
             coldFinish: "stop", adoptedFinish: "length")
-        #expect(!diverged.exact)
-        #expect(diverged.mismatchReason?.hasPrefix("token streams diverged") == true)
-        #expect(diverged.mismatchReason?.contains("terminal mismatch") == true)
+        guard case .inexact(let divergedReason) = diverged else {
+            Issue.record("expected .inexact, got \(diverged)")
+            return
+        }
+        #expect(divergedReason.hasPrefix("token streams diverged"))
+        #expect(divergedReason.contains("terminal mismatch"))
 
         // `length` on BOTH arms is clean: hitting the same budget the same
         // way is a valid comparison, not a truncation artifact.
         let bothLength = Harness.judgeAdoptionExactness(
             coldTokens: [1, 2, 3], adoptedTokens: [1, 2, 3],
             coldFinish: "length", adoptedFinish: "length")
-        #expect(bothLength.exact)
+        #expect(bothLength == .exact)
+    }
+
+    /// Two streams cut short IDENTICALLY by machinery prove nothing about
+    /// adoption in either direction: recording them as `exact = false` made
+    /// `prefixReuse` FAIL with "adoption CHANGED THE ANSWER" over a transient
+    /// watchdog kill that changed nothing observable. Identical failures are
+    /// a third state — not exact, not a mismatch, just no measurement.
+    @Test("identical failed runs are INCONCLUSIVE, not a mismatch — but real divergence still fails")
+    func identicalFailedAdoptionIsInconclusiveNotAMismatch() {
+        typealias Harness = BackendParityHarness
+
+        // Identical tokens, identical UNCLEAN terminal: inconclusive, with
+        // the shared failure named.
+        let bothUnclean = Harness.judgeAdoptionExactness(
+            coldTokens: [1, 2, 3], adoptedTokens: [1, 2, 3],
+            coldFinish: "error(watchdog)", adoptedFinish: "error(watchdog)")
+        #expect(bothUnclean
+            == .inconclusive(
+                reason: "both arms were cut short identically ('error(watchdog)'), so "
+                    + "the identical truncated streams prove nothing about adoption"))
+
+        // Identical tokens, DIFFERENT terminals (one unclean): still a real
+        // mismatch — adoption changed how the request ended. Unchanged.
+        let differentTerminals = Harness.judgeAdoptionExactness(
+            coldTokens: [1, 2, 3], adoptedTokens: [1, 2, 3],
+            coldFinish: "stop", adoptedFinish: "error(watchdog)")
+        guard case .inexact = differentTerminals else {
+            Issue.record("expected .inexact, got \(differentTerminals)")
+            return
+        }
+
+        // DIVERGING tokens under the same shared failure: the streams
+        // observably differ before the cut, so that stays a mismatch — the
+        // shared unclean terminal is disclosed, not excusing.
+        let divergedUnclean = Harness.judgeAdoptionExactness(
+            coldTokens: [1, 2, 3], adoptedTokens: [1, 9],
+            coldFinish: "error(watchdog)", adoptedFinish: "error(watchdog)")
+        guard case .inexact(let reason) = divergedUnclean else {
+            Issue.record("expected .inexact, got \(divergedUnclean)")
+            return
+        }
+        #expect(reason.hasPrefix("token streams diverged"))
+        #expect(reason.contains("non-clean terminal on both arms: 'error(watchdog)'"))
+    }
+
+    /// The criterion half of the tri-state: an inconclusive arm blocks the
+    /// verdict entirely — savings cannot be certified over a comparison that
+    /// proved nothing — and the report names the shared failure, distinct
+    /// from both PASS and FAIL.
+    @Test("an inconclusive adoption comparison makes prefix_reuse UNAVAILABLE, never FAIL")
+    func inconclusiveAdoptionIsUnavailableNotFail() {
+        let shared = "both arms were cut short identically ('error(watchdog)'), so "
+            + "the identical truncated streams prove nothing about adoption"
+        let verdict = BackendParityCriteria.prefixReuse(
+            baseline: prefixArm("contiguous", saved: 26880, exact: true),
+            candidate: prefixArm(
+                "paged", saved: 26880, inconclusiveReason: shared))
+        #expect(verdict.verdict == .unavailable)
+        #expect(verdict.detail.contains("paged (\(shared))"))
+        #expect(verdict.detail.contains("identical truncated streams prove nothing"))
+
+        // A genuine mismatch on the OTHER arm still outranks it: per-arm
+        // judgment against that arm's own cold request FAILs, and the detail
+        // reports the inconclusive arm instead of claiming symmetry.
+        let mixed = BackendParityCriteria.prefixReuse(
+            baseline: prefixArm("contiguous", saved: 26880, inconclusiveReason: shared),
+            candidate: prefixArm(
+                "paged", saved: 26880, exact: false,
+                mismatchReason: "token streams diverged"))
+        #expect(mixed.verdict == .fail)
+        #expect(mixed.detail.contains("INCONCLUSIVE"))
+        #expect(!mixed.detail.contains("SYMMETRIC"))
     }
 
     @Test("the criterion detail discloses the recorded mismatch shape per arm")
@@ -961,6 +1031,57 @@ struct BackendParityReportTests {
         #expect(result.verdict == .pass)
         #expect(result.detail.contains("submit_error: refused vs unterminated"))
         #expect(result.measurements["firstFlip"] == nil)
+    }
+
+    /// The exclusion predicate is "zero tokens AND failed terminals on BOTH
+    /// arms" — the failed half is load-bearing. One arm cleanly hitting EOS
+    /// with zero tokens while the other returned `submit_error` is a real
+    /// observed asymmetry: excluding it would let the run PASS while
+    /// claiming "finish reasons equal" about a row where they were not.
+    @Test("a clean zero-token arm against a failed arm is a divergence, not a non-observation")
+    func cleanVersusFailedEmptyRowIsCountedAsDivergence() {
+        func arm(_ selection: String, cFinish: String) -> BackendParityObservation {
+            BackendParityObservation(
+                selection: selection, resolvedBackend: selection,
+                rows: [
+                    row("a", [1, 2, 3]),
+                    row("b", [4, 5]),
+                    row("c", [], finish: cFinish),
+                ])
+        }
+        let result = BackendParityCriteria.tokenExactness(
+            baseline: arm("contiguous", cFinish: "stop"),
+            candidate: arm("paged", cFinish: "submit_error: pool exhausted"))
+        // Counted, and the finish-reason path reports it as the mismatch.
+        #expect(result.verdict == .unavailable)
+        #expect(result.detail.contains(
+            "prompt 'c' finish reason: stop vs submit_error: pool exhausted"))
+        // NOT excluded: the row is an observation.
+        #expect(!result.detail.contains("EXCLUDED"))
+        #expect(result.measurements["excludedRows"] == nil)
+    }
+
+    /// Both arms cleanly finishing `stop` with zero tokens (the model hit
+    /// EOS immediately, both sides) is a thin but valid matching
+    /// observation — agreement, not a non-observation.
+    @Test("a both-clean both-empty row is a matching observation, not an exclusion")
+    func bothCleanEmptyRowIsAMatchingObservation() {
+        func arm(_ selection: String) -> BackendParityObservation {
+            BackendParityObservation(
+                selection: selection, resolvedBackend: selection,
+                rows: [
+                    row("a", [1, 2, 3]),
+                    row("b", [4, 5]),
+                    row("c", [], finish: "stop"),
+                ])
+        }
+        let result = BackendParityCriteria.tokenExactness(
+            baseline: arm("contiguous"), candidate: arm("paged"))
+        #expect(result.verdict == .pass)
+        // All three rows scored — the clean-empty row counts as evidence.
+        #expect(result.detail.contains("3 prompts, 5 generated token ids identical"))
+        #expect(!result.detail.contains("EXCLUDED"))
+        #expect(result.measurements["excludedRows"] == nil)
     }
 
     @Test("a divergence among the observed rows still reports, with the exclusion noted")
@@ -1778,6 +1899,17 @@ struct BackendParityReportTests {
         ])
         #expect(criteria.allSatisfy { $0.verdict == .pass })
         #expect(BackendParityOutcome(criteria: criteria).exitStatus == 0)
+    }
+
+    /// Schema 3 is the wave that added the dtype-provenance fields
+    /// (`pagedPoolDType`, `candidatePoolDType`/`controlPoolDType` with the
+    /// same-dtype validity rule), `adoptionMismatchReason`, and the
+    /// tri-state adoption evidence (`adoptionInconclusiveReason`). Pinned so
+    /// the next field addition forces a deliberate bump instead of shipping
+    /// a new shape under an old label — version-keyed consumers gate on it.
+    @Test("the serialized shape changes of this wave carry schema version 3")
+    func schemaVersionCoversTheNewFields() {
+        #expect(BackendParityReport.currentSchemaVersion == 3)
     }
 
     @Test("the report round-trips through JSON with its verdicts intact")

--- a/provider-swift/Tests/ProviderCoreTests/BackendParityReportTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/BackendParityReportTests.swift
@@ -722,7 +722,8 @@ struct BackendParityReportTests {
     func controlRoundTrips() throws {
         let control = BackendParityReport.NumericsControl(
             perturbation: "paged pool dtype float16 -> float32",
-            tokenExact: false, detail: "diverged", firstFlip: "prompt 'a' token 1")
+            tokenExact: false, detail: "diverged", firstFlip: "prompt 'a' token 1",
+            candidatePoolDType: "float16", controlPoolDType: "float32")
         let report = BackendParityReport(
             modelID: "m", modelPath: "/tmp/m",
             arms: [baseline.arm, candidate.arm],
@@ -776,6 +777,115 @@ struct BackendParityReportTests {
         #expect(asked.contains("control (paged pool dtype float16 -> float32): NOT RUN"))
         #expect(asked.contains("the candidate arm did not serve paged rows"))
         #expect(!asked.contains("NOT SUPPLIED"))
+    }
+
+    // MARK: - Control dtype pinning and validity
+
+    @Test("the harness pins every engine to fp16 pages against ambient env dtype")
+    func harnessPinsCandidateDTypeAgainstAmbientEnvironment() {
+        // An operator (or a prior benchmark step) exporting
+        // DARKBLOOM_CBV2_PAGED_KV_DTYPE=float32 must NOT leak into the
+        // candidate arm: the fp32 control would then compare two identical
+        // fp32 engines and hold tautologically.
+        let ambient = [
+            "DARKBLOOM_CBV2_PAGED_KV_DTYPE": "float32",
+            "HOME": "/Users/operator",
+        ]
+        let candidateEnv = BackendParityHarness.engineEnvironment(
+            ambient: ambient, overrides: [:])
+        #expect(candidateEnv["DARKBLOOM_CBV2_PAGED_KV_DTYPE"] == "float16")
+        // The rest of the ambient environment passes through untouched.
+        #expect(candidateEnv["HOME"] == "/Users/operator")
+
+        // The fp32 control's explicit override still wins over the pin —
+        // the pin protects arms that did NOT ask, never one that did.
+        let controlEnv = BackendParityHarness.engineEnvironment(
+            ambient: ambient,
+            overrides: ["DARKBLOOM_CBV2_PAGED_KV_DTYPE": "float32"])
+        #expect(controlEnv["DARKBLOOM_CBV2_PAGED_KV_DTYPE"] == "float32")
+
+        // And with NO ambient dtype at all the pin still applies, so the
+        // candidate arm is fp16 by construction rather than by default.
+        let bare = BackendParityHarness.engineEnvironment(
+            ambient: ["HOME": "/Users/operator"], overrides: [:])
+        #expect(bare["DARKBLOOM_CBV2_PAGED_KV_DTYPE"] == "float16")
+    }
+
+    @Test("a control whose two arms resolved the SAME dtype is rejected at evaluation")
+    func sameDTypeControlIsRejectedAtEvaluation() {
+        // The artifact-level backstop: even a stored report from a harness
+        // that let ambient fp32 leak into the candidate must not have its
+        // "CONTROL HELD" quoted. Both dtypes are named in the refusal.
+        let tautology = BackendParityReport.NumericsControl(
+            perturbation: "paged pool dtype float16 -> float32",
+            tokenExact: true,
+            detail: "identical across 3 prompts",
+            candidatePoolDType: "float32", controlPoolDType: "float32")
+        let blocker = BackendParityCriteria.controlValidityBlocker(tautology)
+        #expect(blocker != nil)
+        #expect(blocker?.contains("candidate float32") == true)
+        #expect(blocker?.contains("control float32") == true)
+        #expect(blocker?.contains("tautology") == true)
+
+        let result = BackendParityCriteria.tokenExactness(
+            baseline: baseline, candidate: drifted(), control: tautology)
+        #expect(result.verdict == .unavailable)
+        #expect(result.detail.hasPrefix("CONTROL INVALID"))
+        #expect(!result.detail.contains("CONTROL HELD"))
+        #expect(result.measurements["control"]?.hasPrefix("INVALID") == true)
+        #expect(result.measurements["control"]?.contains("float32") == true)
+
+        // Discrimination: the ONLY change below is that the two arms carry
+        // DIFFERENT resolved dtypes — the same held control is then quoted.
+        let genuine = BackendParityReport.NumericsControl(
+            perturbation: "paged pool dtype float16 -> float32",
+            tokenExact: true,
+            detail: "identical across 3 prompts",
+            candidatePoolDType: "float16", controlPoolDType: "float32")
+        #expect(BackendParityCriteria.controlValidityBlocker(genuine) == nil)
+        let honored = BackendParityCriteria.tokenExactness(
+            baseline: baseline, candidate: drifted(), control: genuine)
+        #expect(honored.detail.hasPrefix("CONTROL HELD"))
+        #expect(honored.measurements["control"] == "TOKEN-EXACT")
+    }
+
+    @Test("artifacts that predate the dtype fields keep their controls")
+    func legacyControlWithoutDTypeFieldsIsNotRejected() {
+        // Absence of the record is not proof of a tautology: a report written
+        // before the fields existed stays exactly as trustworthy as it was.
+        let legacy = BackendParityReport.NumericsControl(
+            perturbation: "paged pool dtype float16 -> float32",
+            tokenExact: true, detail: "identical across 3 prompts")
+        #expect(BackendParityCriteria.controlValidityBlocker(legacy) == nil)
+        // One side recorded is still not a tautology finding.
+        let half = BackendParityReport.NumericsControl(
+            perturbation: "paged pool dtype float16 -> float32",
+            tokenExact: true, detail: "identical across 3 prompts",
+            controlPoolDType: "float32")
+        #expect(BackendParityCriteria.controlValidityBlocker(half) == nil)
+    }
+
+    @Test("the observation records the arm's RESOLVED pool dtype through JSON")
+    func observationCarriesResolvedPoolDType() throws {
+        let arm = BackendParityObservation(
+            selection: "paged", resolvedBackend: "paged",
+            pagedPoolDType: "float16",
+            rows: [row("a", [1, 2])])
+        let decoded = try JSONDecoder().decode(
+            BackendParityObservation.self, from: try JSONEncoder().encode(arm))
+        #expect(decoded.pagedPoolDType == "float16")
+
+        // Old artifacts without the field decode with nil, not a throw. The
+        // legacy shape is a REAL encoding minus the key, so this cannot
+        // drift from whatever else the coder requires.
+        var json = try #require(
+            JSONSerialization.jsonObject(with: try JSONEncoder().encode(arm))
+                as? [String: Any])
+        json.removeValue(forKey: "pagedPoolDType")
+        let legacy = try JSONDecoder().decode(
+            BackendParityObservation.self,
+            from: JSONSerialization.data(withJSONObject: json))
+        #expect(legacy.pagedPoolDType == nil)
     }
 
     // MARK: - Per-row evidence floor

--- a/provider-swift/Tests/ProviderCoreTests/DiagnosticsTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/DiagnosticsTests.swift
@@ -368,6 +368,38 @@ func slotPostureBuilderExpiresStaleFailure() {
     #expect(DaemonSlotPostureBuilder.failureMaxAgeSeconds == 3_600)
 }
 
+@Test("the expiry horizon follows the CONFIGURED idle timeout, not the fixed default")
+func slotPostureBuilderFailureMaxAgeFollowsIdleTimeout() {
+    // 0 = idle unload disabled: no era boundary exists, so there is no age
+    // past which "every real slot from the failure's era is gone" — the row
+    // only clears via a live slot, config removal, or a fresh outcome.
+    #expect(DaemonSlotPostureBuilder.failureMaxAge(idleTimeoutMins: 0) == nil)
+    // Above the default: a box that keeps slots for 4 h keeps evidence 4 h.
+    #expect(DaemonSlotPostureBuilder.failureMaxAge(idleTimeoutMins: 240) == 14_400.0)
+    // At/below the default: the wedge-scale floor holds — a 5-minute idle
+    // timeout must not flap a genuine failure out of `doctor` mid-session.
+    #expect(
+        DaemonSlotPostureBuilder.failureMaxAge(idleTimeoutMins: 5)
+            == DaemonSlotPostureBuilder.failureMaxAgeSeconds)
+    #expect(
+        DaemonSlotPostureBuilder.failureMaxAge(idleTimeoutMins: 60)
+            == DaemonSlotPostureBuilder.failureMaxAgeSeconds)
+
+    let trippedAt = 100_000.0
+    let failure = DaemonState.ModelLoadError(model: "m", message: "refused", at: trippedAt)
+    let build = { (maxAge: Double?, now: Double) in
+        DaemonSlotPostureBuilder.build(
+            live: [], requestedGlobal: "auto", requestedByModel: [:],
+            lastModelLoadError: failure, desiredModels: ["m"],
+            failureMaxAge: maxAge, now: now)
+    }
+    // nil horizon: a day-old failure still shows.
+    #expect(build(nil, trippedAt + 86_400).count == 1)
+    // A 4 h horizon: visible at 4 h, gone past it.
+    #expect(build(14_400, trippedAt + 14_400).count == 1)
+    #expect(build(14_400, trippedAt + 14_401).isEmpty)
+}
+
 @Test("a model that failed once and then loaded reports as serving, not failed")
 func slotPostureBuilderDropsSupersededLoadError() {
     let built = DaemonSlotPostureBuilder.build(

--- a/provider-swift/Tests/ProviderCoreTests/EngineV2PrefixCacheWiringTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/EngineV2PrefixCacheWiringTests.swift
@@ -232,3 +232,172 @@ struct EngineV2PrefixCacheUsageTests {
         #expect(ProviderLoop.injectCachedTokens(into: usageFrame, cachedTokens: 0) == usageFrame)
     }
 }
+
+// MARK: - fp32 paged pages: KV rate wiring
+
+/// Engine stub whose only job is to report a fixed byte capacity, so the
+/// heartbeat's rate→budget division is observable without a model.
+private final class CapacityStubEngine: CBv2Engine, @unchecked Sendable {
+    private let kvBytesCapacity: Int
+
+    init(kvBytesCapacity: Int) {
+        self.kvBytesCapacity = kvBytesCapacity
+    }
+
+    func submit(_ request: CBv2Request) throws -> AsyncStream<CBv2Event> {
+        let (stream, continuation) = AsyncStream<CBv2Event>.makeStream()
+        continuation.finish()
+        return stream
+    }
+
+    func cancel(_ id: CBv2RequestID) {}
+
+    func capacity() -> CBv2CapacitySnapshot {
+        CBv2CapacitySnapshot(
+            activeRequests: 0,
+            waitingRequests: 0,
+            kvBytesInUse: 0,
+            kvBytesCapacity: kvBytesCapacity,
+            activeTokens: 0)
+    }
+
+    func updateKVBytesCapacity(_ bytes: Int) {}
+    func shutdown() async {}
+}
+
+/// The fp32-page seam: `DARKBLOOM_CBV2_PAGED_KV_DTYPE=float32` doubles what a
+/// token costs in the pool, so the rate the slot hands `makeBridge` must
+/// double — and the heartbeat's advertised token budget must HALVE — or
+/// `BackendCapacity.Slots` being scheduler-authoritative lets the coordinator
+/// over-admit ~2x against a pool holding half the tokens.
+@Suite("EngineV2 fp32 paged pages: KV rate wiring")
+struct EngineV2FP32PagedRateTests {
+
+    @Test("processKVBytesPerToken doubles on fp32 pages and only there")
+    func processRateDoubling() {
+        // fp32 pages: flat 2x over the nominal rate.
+        #expect(EngineV2Factory.processKVBytesPerToken(
+            nominalFP16BytesPerToken: 100_000,
+            fp16FullKVBytesPerToken: 24_576,
+            fullRowsUseFP32: false,
+            pagedPoolDType: "float32"
+        ) == 200_000)
+        // fp16 pages and no dtype (contiguous): the base rate untouched.
+        #expect(EngineV2Factory.processKVBytesPerToken(
+            nominalFP16BytesPerToken: 100_000,
+            fp16FullKVBytesPerToken: 24_576,
+            fullRowsUseFP32: false,
+            pagedPoolDType: "float16"
+        ) == 100_000)
+        #expect(EngineV2Factory.processKVBytesPerToken(
+            nominalFP16BytesPerToken: 100_000,
+            fp16FullKVBytesPerToken: 24_576,
+            fullRowsUseFP32: false,
+            pagedPoolDType: nil
+        ) == 100_000)
+        // Contiguous GPT-OSS keeps the native-width adjustment.
+        #expect(EngineV2Factory.processKVBytesPerToken(
+            nominalFP16BytesPerToken: 100_000,
+            fp16FullKVBytesPerToken: 24_576,
+            fullRowsUseFP32: true,
+            pagedPoolDType: nil
+        ) == 124_576)
+        // Saturating, never trapping, on absurd rates.
+        #expect(EngineV2Factory.processKVBytesPerToken(
+            nominalFP16BytesPerToken: Int.max / 2 + 1,
+            fp16FullKVBytesPerToken: 0,
+            fullRowsUseFP32: false,
+            pagedPoolDType: "float32"
+        ) == Int.max)
+    }
+
+    @Test("the slot rate follows the CONSTRUCTED pool's dtype, not the request")
+    func slotRateFollowsPoolDType() {
+        // One owning full-attention layer: kvHeads * headDim * 2 (K+V) * 2
+        // bytes = 8 * 64 * 4 = 2048 fp16 full-row bytes per token.
+        let layerKinds = [
+            CBv2LayerKind(attention: .full, headDim: 64, kvHeads: 8, queryHeads: 16),
+            CBv2LayerKind(
+                attention: .slidingWindow(512), headDim: 64, kvHeads: 8, queryHeads: 16),
+        ]
+        let nominal = 100_000
+
+        // Paged pool built with fp32 pages: the whole row doubles.
+        #expect(EngineV2SlotFactory.slotKVBytesPerToken(
+            resolvedKind: .paged,
+            pagedPoolDType: "float32",
+            layerKinds: layerKinds,
+            nominalFP16BytesPerToken: nominal,
+            servingModelIsGPTOSS: false
+        ) == 200_000)
+
+        // Paged with default fp16 pages: nominal, unchanged.
+        #expect(EngineV2SlotFactory.slotKVBytesPerToken(
+            resolvedKind: .paged,
+            pagedPoolDType: "float16",
+            layerKinds: layerKinds,
+            nominalFP16BytesPerToken: nominal,
+            servingModelIsGPTOSS: false
+        ) == nominal)
+
+        // An fp32 REQUEST that degraded to contiguous has no pages to
+        // widen: the dtype is ignored on a contiguous build even if a
+        // stale value were threaded through.
+        #expect(EngineV2SlotFactory.slotKVBytesPerToken(
+            resolvedKind: .contiguous,
+            pagedPoolDType: "float32",
+            layerKinds: layerKinds,
+            nominalFP16BytesPerToken: nominal,
+            servingModelIsGPTOSS: false
+        ) == nominal)
+
+        // Contiguous GPT-OSS keeps the fp32 owning-full-row delta
+        // (native-width rate), exactly as before this seam existed.
+        #expect(EngineV2SlotFactory.slotKVBytesPerToken(
+            resolvedKind: .contiguous,
+            pagedPoolDType: nil,
+            layerKinds: layerKinds,
+            nominalFP16BytesPerToken: nominal,
+            servingModelIsGPTOSS: true
+        ) == nominal + 2048)
+
+        // Paged GPT-OSS never takes the native-width path (fp32 full rows
+        // are a contiguous-backend behavior).
+        #expect(EngineV2SlotFactory.slotKVBytesPerToken(
+            resolvedKind: .paged,
+            pagedPoolDType: "float16",
+            layerKinds: layerKinds,
+            nominalFP16BytesPerToken: nominal,
+            servingModelIsGPTOSS: true
+        ) == nominal)
+    }
+
+    @Test("a doubled rate halves the heartbeat's advertised token budget")
+    func doubledRateHalvesTokenBudget() async {
+        let capacityBytes = 8_000_000
+        let fp16Rate = 2_000
+
+        func budget(rate: Int) async -> (max: Int64, rate: Int64) {
+            let bridge = EngineV2Bridge(
+                engine: CapacityStubEngine(kvBytesCapacity: capacityBytes),
+                modelId: "gemma-4-26b-qat-4bit",
+                tokenizer: TokenizerHandle(PrefixStubTokenizer()),
+                eosTokenIds: [2],
+                kvBytesPerToken: rate,
+                kvBackendKind: .paged)
+            let slot = await bridge.backendSlotCapacity()
+            return (slot.activeTokenBudgetMax, slot.kvBytesPerToken)
+        }
+
+        let fp16 = await budget(rate: fp16Rate)
+        let fp32 = await budget(rate: EngineV2Factory.processKVBytesPerToken(
+            nominalFP16BytesPerToken: fp16Rate,
+            fp16FullKVBytesPerToken: 0,
+            fullRowsUseFP32: false,
+            pagedPoolDType: "float32"))
+
+        #expect(fp16.max == Int64(capacityBytes / fp16Rate))
+        #expect(fp32.rate == fp16.rate * 2)
+        #expect(fp32.max == fp16.max / 2, "fp32 pages hold half the tokens per byte grant")
+    }
+}

--- a/provider-swift/Tests/ProviderCoreTests/TelemetryOverflowQueueTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/TelemetryOverflowQueueTests.swift
@@ -1,0 +1,91 @@
+// Cross-process safety for the telemetry overflow queue.
+//
+// Two processes share the queue file: the daemon (panic hook pushes,
+// TelemetryClient drains) and the persistent watchdog (crash-loop guard trip
+// events). A drain is read-then-replace, so an unsynchronized push landing
+// between the read and the replace is silently clobbered. The fix is an
+// exclusive `flock` on a stable sidecar lock file around every mutation.
+//
+// A second process cannot be spawned cheaply in a unit test, but the race is
+// faithfully reproduced with two INDEPENDENT queue instances on one path:
+// each has its own in-process NSLock, so only the cross-process file lock
+// serializes them — exactly the watchdog/daemon topology.
+
+import Foundation
+import Testing
+
+@testable import ProviderCore
+
+@Suite("telemetry overflow queue: cross-process safety")
+struct TelemetryOverflowQueueCrossProcessTests {
+
+    private func tempQueuePath() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("telemetry-queue-\(UUID().uuidString).jsonl")
+    }
+
+    private func event(_ i: Int) -> TelemetryEvent {
+        TelemetryEvent(
+            source: .provider, severity: .info, kind: .log,
+            message: "event \(i)")
+    }
+
+    @Test("a push racing a drain from a SEPARATE instance is never clobbered")
+    func concurrentPushAndDrainLoseNothing() async {
+        let path = tempQueuePath()
+        defer {
+            try? FileManager.default.removeItem(at: path)
+            try? FileManager.default.removeItem(
+                at: URL(fileURLWithPath: path.path + ".lock"))
+        }
+        // Two instances on one path model the two processes: separate
+        // NSLocks, shared file — only the flock serializes them.
+        let daemon = TelemetryOverflowQueue(path: path)
+        let watchdog = TelemetryOverflowQueue(path: path)
+
+        let pushes = 200
+        let drained = await withTaskGroup(of: [TelemetryEvent].self) { group -> Int in
+            // The "watchdog": pushes under its own lock only.
+            group.addTask {
+                for i in 0 ..< pushes { watchdog.push(self.event(i)) }
+                return []
+            }
+            // The "daemon": drains concurrently in small bites — each drain
+            // is a full read-then-replace window a push could fall into.
+            group.addTask {
+                var got: [TelemetryEvent] = []
+                for _ in 0 ..< 50 {
+                    got += daemon.drain(limit: 7)
+                    await Task.yield()
+                }
+                return got
+            }
+            var total = 0
+            for await events in group { total += events.count }
+            return total
+        }
+
+        // Whatever was not drained mid-race must still be on disk.
+        let remaining = daemon.drain(limit: .max).count
+        #expect(
+            drained + remaining == pushes,
+            "pushed \(pushes), drained \(drained), remaining \(remaining) — a drain clobbered concurrent pushes")
+    }
+
+    @Test("drain returns events in push order and removes the file when empty")
+    func drainOrderAndCleanup() {
+        let path = tempQueuePath()
+        defer {
+            try? FileManager.default.removeItem(at: path)
+            try? FileManager.default.removeItem(
+                at: URL(fileURLWithPath: path.path + ".lock"))
+        }
+        let queue = TelemetryOverflowQueue(path: path)
+        for i in 0 ..< 5 { queue.push(event(i)) }
+        let first = queue.drain(limit: 2)
+        #expect(first.map(\.message) == ["event 0", "event 1"])
+        let rest = queue.drain(limit: 10)
+        #expect(rest.map(\.message) == ["event 2", "event 3", "event 4"])
+        #expect(!FileManager.default.fileExists(atPath: path.path))
+    }
+}

--- a/provider-swift/Tests/ProviderCoreTests/ThroughputSweepTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ThroughputSweepTests.swift
@@ -100,6 +100,48 @@ struct DecodeBandwidthModelTests {
     }
 }
 
+@Suite("throughput sweep: row aggregation")
+struct ThroughputSweepRowAggregationTests {
+
+    @Test("clean rows aggregate tokens and the slowest row's elapsed")
+    func cleanRowsAggregate() {
+        let cell = ThroughputSweep.aggregateRows([
+            .init(produced: 10, elapsed: .seconds(1)),
+            .init(produced: 12, elapsed: .seconds(3)),
+            .init(produced: 11, elapsed: .seconds(2)),
+        ])
+        #expect(cell.totalTokens == 33)
+        #expect(cell.maxElapsed == .seconds(3))
+        #expect(cell.submitFailure == nil)
+    }
+
+    @Test("ANY row whose submit threw poisons the cell: it is unmeasured, not a zero sample")
+    func submitFailurePoisonsCell() {
+        // The regression this pins: a B=8 cell where one row's
+        // `engine.submit` threw (admission/runtime capacity) used to come
+        // back as a MEASURED cell with a deflated token count, and an
+        // explicit-backend sweep exited 0 over a corrupted curve. The
+        // failure must surface so the caller records the cell in
+        // `decodeCoverage.unmeasured` and the release gate rejects the run.
+        let cell = ThroughputSweep.aggregateRows([
+            .init(produced: 10, elapsed: .seconds(1)),
+            .init(produced: 0, elapsed: .zero, submitFailure: "capacityExhausted"),
+            .init(produced: 12, elapsed: .seconds(2)),
+        ])
+        #expect(cell.submitFailure == "capacityExhausted")
+    }
+
+    @Test("the first failure is kept when several rows throw")
+    func firstFailureKept() {
+        let cell = ThroughputSweep.aggregateRows([
+            .init(produced: 0, elapsed: .zero, submitFailure: "first"),
+            .init(produced: 0, elapsed: .zero, submitFailure: "second"),
+        ])
+        #expect(cell.submitFailure == "first")
+        #expect(cell.totalTokens == 0)
+    }
+}
+
 @Suite("throughput sweep: report assembly + JSON")
 struct ThroughputSweepReportTests {
 

--- a/provider-swift/Tests/ProviderCoreTests/WatchdogCrashLoopGuardTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/WatchdogCrashLoopGuardTests.swift
@@ -421,6 +421,26 @@ struct KVBackendGuardStoreTests {
         #expect(KVBackendGuardStore.read(environment: env) == nil)
     }
 
+    @Test("a RELATIVE path override is rejected — the default path is used")
+    func relativeOverrideRejected() {
+        // A relative override resolves against each process's own CWD: the
+        // launchd-spawned watchdog (CWD `/`) and the daemon would silently
+        // agree on the ENV VALUE while reading and writing different files —
+        // the guard written by the watchdog would never reach the daemon.
+        let defaultPath = KVBackendGuardStore.path(environment: [:])
+        for relative in ["guard.json", "./guard.json", "../guard.json", "~/guard.json"] {
+            let resolved = KVBackendGuardStore.path(
+                environment: [KVBackendGuardStore.pathEnvKey: relative])
+            #expect(
+                resolved == defaultPath,
+                "relative override \(relative.debugDescription) must fall back to the default path")
+        }
+        // An absolute override is honored unchanged.
+        let absolute = KVBackendGuardStore.path(
+            environment: [KVBackendGuardStore.pathEnvKey: "/tmp/guard.json"])
+        #expect(absolute.path == "/tmp/guard.json")
+    }
+
     @Test("a corrupt/garbage file fails OPEN to no guard, not a crash")
     func corruptFailsOpen() throws {
         for garbage in ["", "not json at all", "{\"tripped_at\": \"words\"}", "[1,2,3]"] {


### PR DESCRIPTION
> **#590 is merged; this branch is rebased onto its squash.** The fix commits sit directly on `master` (`3eefaf1ed`), so the diff is exactly the work below: ten tracked review items — #593 round-5 (4), #590's final threads (4), #590's parity-harness integrity P1s (2) — plus three refinements this PR's own review added on top of the parity-evidence semantics (items 11–13, `a12fb9445`). None affects the flip, the crash-loop guard, or the CI gates.

## Before / after — behaviour

```mermaid
flowchart LR
  subgraph Before
    A1["relative DARKBLOOM_KV_BACKEND_GUARD"] --> B1["watchdog (CWD /) and daemon resolve DIFFERENT guard files"]
    C1["watchdog trips guard while daemon drains telemetry queue"] --> D1["drain's read-then-replace clobbers the trip event"]
    E1["race: primary's deterministic 400 controls the outcome"] --> F1["outcome metric books under the BACKUP's kv_backend"]
    G1["backup promoted via AcceptedCh, fails pre-content"] --> H1["exhaustion falls back to the PRIMARY's stale latch"]
    I1["idle_timeout_mins = 0 or 240"] --> J1["failed-slot row always expires at fixed 3600 s"]
    K1["engine.submit throws at B=8"] --> L1["zero-token cell counted as MEASURED; explicit sweep exits 0"]
    M1["parity probe: same tokens, stop vs error(...)"] --> N1["adoptionTokenExact = true; criterion can PASS"]
    O1["DARKBLOOM_CBV2_PAGED_KV_DTYPE=float32"] --> P1B["heartbeat advertises ~2x the tokens the fp32 pool holds; coordinator over-admits"]
    Q1B["ambient float32 dtype at harness launch"] --> R1B["candidate arm ALSO fp32; the fp16-to-fp32 control compares two identical engines and HOLDS tautologically"]
    S1B["1 of 3 parity prompts decodes; 2 fail identically on both arms"] --> T1B["matching submit_error rows count as agreement; criterion PASSes on one row"]
    U1B["one arm clean EOS with 0 tokens, other submit_error"] --> V1B["row excluded as a non-observation; run can PASS claiming finish reasons equal"]
    W1B["cold and adopted both cut short by the SAME error(...)"] --> X1B["adoptionTokenExact = false -> prefixReuse hard-FAILs as 'adoption changed the answer'"]
  end
  subgraph After
    A2["relative override"] --> B2["rejected — both processes use the default path"]
    C2["push/drain under exclusive flock on a stable sidecar"] --> D2["trip events survive concurrent drains"]
    E2["deterministic verdict latches"] --> F2["attribution FROZEN to the verdict slot; controlling 4xx books under the primary"]
    G2["live mismatch read saves the promotion"] --> H2["promoted backup's failure books under its own backend"]
    I2["horizon follows the configured idle timeout"] --> J2["0 = never expires by age; 240 min = 4 h; floor 1 h"]
    K2["submit throw poisons the cell"] --> L2["recorded unmeasured -> decodeCoverage fails the sweep"]
    M2["exactness judges the whole terminal outcome"] --> N2["mismatched/non-clean terminal = NOT exact, shape named in the criterion detail"]
    O2["slot rate follows the CONSTRUCTED pool's dtype"] --> P2B["fp32 doubles kv_bytes_per_token; advertised token budget halves"]
    Q2B["candidate pinned to fp16; both arms' RESOLVED dtypes recorded"] --> R2B["a same-dtype control is refused at measurement AND at evaluation, naming both dtypes"]
    S2B["a both-empty row with FAILED terminals on both arms is a non-observation"] --> T2B["excluded and disclosed; below half productive the criterion is UNAVAILABLE naming the failure shapes"]
    U2B["clean-vs-failed empty row stays IN"] --> V2B["reported as a finish-reason divergence; both-clean empty counts as agreement"]
    W2B["identical failed runs are a third state"] --> X2B["adoptionInconclusiveReason -> criterion UNAVAILABLE naming the shared failure, distinct from PASS and FAIL"]
  end
```

## Before / after — code

```mermaid
flowchart TB
  subgraph Before
    P1["KVBackendGuardStore.path: URL(fileURLWithPath: override)"]
    Q1["TelemetryOverflowQueue: NSLock only (single-process)"]
    R1["noteServingSlotFor: unconditional re-latch\nkvBackendAttribution mismatch: resolve, don't save"]
    S1["DaemonSlotPostureBuilder: fixed failureMaxAgeSeconds = 3600"]
    T1["ThroughputSweep row catch: RowMeasure(produced: 0)"]
    U1["prefix probe: adoptionTokenExact = tokens1 == tokens2\n(identical failures also record false; schemaVersion stays 2)"]
    V1["EngineV2SlotFactory: nativeKVBytesPerToken(...) -> makeBridge\n(processKVBytesPerToken had no caller)"]
    W1["buildEngine env: ambient merged with probe overrides only;\nno arm records its resolved pool dtype"]
    X1["zeroEvidenceReason: rows.allSatisfy(tokens.isEmpty) only;\nrowMismatch counts both-empty rows as matches"]
  end
  subgraph After
    P2["path(): honor override only if hasPrefix(/)"]
    Q2["acquireFileLock(): flock(LOCK_EX) on queue.lock around push + drain, fail-open"]
    R2["attributionLatchFrozen() guard + latchTerminalAttribution(provider)\nat latchDeterministicLoser's three latch sites;\nmismatch read saves unless frozen"]
    S2["failureMaxAge(idleTimeoutMins:) -> nil | max(cfg, 3600)\nthreaded from loopConfig.config.backend"]
    T2["RowMeasure.submitFailure + aggregateRows poisons the cell\n-> recordUnmeasured, sample skipped"]
    U2["judgeAdoptionExactness -> AdoptionExactness:\nexact | inexact(reason) | inconclusive(reason)\n-> PrefixReuse.adoptionInconclusiveReason -> UNAVAILABLE;\ncleanTerminals canonical on BackendParityCriteria;\ncurrentSchemaVersion = 3"]
    V2["slotKVBytesPerToken(kind, pagedPoolDType, ...)\n-> processKVBytesPerToken -> makeBridge"]
    W2["engineEnvironment: ambient < fp16 pin < probe override;\nObservation.pagedPoolDType + NumericsControl arm dtypes;\ncontrolValidityBlocker rejects same-dtype controls in evaluate"]
    X2["pairedRowEvidence: excluded only when both-empty AND\nboth terminals non-clean; clean-vs-failed stays a divergence;\nfloorBlocker (< half observable) -> UNAVAILABLE naming shapes"]
  end
```

## The ten fixes

1. **Relative `DARKBLOOM_KV_BACKEND_GUARD` rejected** (`KVBackendGuard.swift`). A relative override resolves against each process's own CWD — the launchd-spawned watchdog and the daemon would agree on the env value while writing different files. There is no shared CWD to absolutize against, so relative (incl. `~/`) overrides fall back to the default path.
2. **Cross-process-safe overflow queue** (`TelemetryOverflowQueue.swift`). The watchdog (guard trip events) and the daemon share the JSONL queue; a drain is read-then-replace, so an unsynchronized push in that window was silently clobbered. Every mutation now takes an exclusive `flock` on a stable sidecar lock file (`<queue>.lock` — the queue file itself changes inode on every drain, so it cannot carry the lock). Chosen over `NSFileCoordinator` (heavier machinery for two CLI processes and one small file) and over a watchdog-suffixed second queue (two files means a merge-and-ordering question at every consumer); fail-open so telemetry can never be blocked by its own lock.
3. **Deterministic verdict freezes the attribution latch** (`dispatch.go`, `kv_backend_metrics.go`). When the primary's deterministic 4xx/422/429 latches (`latchDeterministicLoser`), that verdict IS the terminal response regardless of the still-racing backup, so `latchTerminalAttribution` pins the kv_backend latch to the verdict slot at the latch site and `noteServingSlotFor` refuses to move it — the backup re-latch interaction from the #590 fix is now verdict-aware. A backup that goes on to WIN is unaffected (commit reads go through the live `d.pr`).
4. **Failed-slot expiry follows the configured idle timeout** (`DaemonStateFile.swift`, `ProviderLoop+Trust.swift`). The whole rationale for age-expiry is "the idle-unload horizon passed"; `failureMaxAge(idleTimeoutMins:)` now implements it for every configuration: 0 (unload disabled) → no expiry-by-age, above 60 min → use it, at/below → keep the one-hour wedge-scale floor.
5. **Promoted-backup latch save** (`kv_backend_metrics.go`, #590 thread at `:198`). A live attribution read through a mismatched `d.pr` is a promotion the latch missed (AcceptedCh/preamble outside the `noteServingSlot` choke point); the read now saves the resolution so the promoted slot's pre-content failure books under its own backend after the wait path clears `d.pr`. The save respects the freeze in (3).
6. **Submit-throw rows are unmeasured cells** (`ThroughputSweep.swift`, #590 thread at `:479`). A row whose `engine.submit` throws poisons its whole cell via `aggregateRows`: the cell feeds `decodeCoverage.unmeasured` (failing explicit-backend sweeps) instead of entering the curve as a zero-token measured sample.
7. **Adoption exactness compares terminal outcomes** (`BackendParityHarness.swift`, `BackendParityReport.swift`, #590 P1 at `:794`). Same token IDs with different finish reasons (`stop` vs `length`, `error(…)`, `terminal(…)`) recorded `adoptionTokenExact = true`, so the prefix-reuse criterion could PASS while adoption changed how the request ended. `judgeAdoptionExactness` now judges the whole outcome: a terminal mismatch or a non-clean terminal on either stream is NOT exact, the mismatch shape rides the observation (`adoptionMismatchReason`) and is disclosed per arm in the criterion detail — and a terminal-shaped mismatch is explicitly excluded from the symmetric precision-drift excuse. The clean-terminal allowlist is hoisted and shared with the fp32 numerics control.
8. **fp32 page width wired into the bridge's KV rate** (`EngineV2SlotFactory.swift`, #590 P2 at `EngineV2Factory+Production.swift:272`). `processKVBytesPerToken` existed with no production caller; under `DARKBLOOM_CBV2_PAGED_KV_DTYPE=float32` the heartbeat divided the pool's byte capacity by the fp16 rate and advertised ~2x the token budget the fp32 pool holds — and `BackendCapacity.Slots` is scheduler-authoritative. The slot factory now derives the rate from the CONSTRUCTED pool's dtype (`slotKVBytesPerToken`): fp32 doubles the rate and halves the advertised budget; fp16/default, contiguous (incl. the GPT-OSS native-width delta), and fp32-requests-that-degraded-to-contiguous are unchanged.
9. **Parity candidate's pool dtype pinned and recorded** (`BackendParityHarness.swift`, `BackendParityReport.swift`, #590 P1 at `:384`). An ambient `DARKBLOOM_CBV2_PAGED_KV_DTYPE=float32` leaked into the primary paged candidate, so the "float16 → float32" numerics control compared two identical fp32 engines — a tautological CONTROL HELD — and nothing recorded or validated the candidate's dtype. Three layers, none trusting the others: `buildEngine` pins every harness engine to fp16 pages (ambient < pin < probe override, in a pure testable `engineEnvironment` helper) so only the fp32 control differs; each arm's RESOLVED pool dtype (read off the constructed pool, never the env knob) is recorded on the observation and both arms' dtypes on the control; `probeNumericsControl` refuses a same-dtype pair at measurement time and `BackendParityCriteria.controlValidityBlocker` rejects it again at evaluation, naming both dtypes — so a stored artifact from a pre-pin harness can never have its CONTROL HELD quoted. Artifacts too old to carry the fields pass through unchanged.
10. **Partially-failed parity rows rejected from the agreement computation** (`BackendParityReport.swift`, #590 P1 at `:1486`). `zeroEvidenceReason` only refused the all-rows-empty case; with one productive prompt, the remaining rows' identical `submit_error`/`unterminated` shapes counted as row matches and the token-exactness criterion could PASS on almost zero evidence. A row with zero tokens on BOTH arms is now a non-observation: excluded from the agreement computation and disclosed (criterion detail + `excludedRows` measurement) with its failure shapes named. Below the minimum-evidence floor — fewer than half the rows productive — the criterion is UNAVAILABLE outright, naming the per-row failure shapes. One-sided emptiness stays in the comparison (a real asymmetry `rowMismatch` reports as divergence); the all-rows-empty path is unchanged.

## Three refinements from this PR's own review (`a12fb9445`)

11. **Clean-vs-failed zero-token rows are observations, not exclusions** (refines 10; review P2 at `BackendParityReport.swift:1670`). The exclusion predicate over-excluded: a row where one arm cleanly finished `stop` with zero tokens (immediate EOS) while the other returned `submit_error` is a real observed asymmetry, and removing it could let a run PASS while claiming "finish reasons equal". Exclusion now additionally requires FAILED terminals on both arms; clean-vs-failed rows stay in and `rowMismatch` reports the finish-reason divergence, and a both-clean both-empty row counts as a matching observation. The clean-terminal allowlist is hoisted to `BackendParityCriteria.cleanTerminals` as the single canonical definition (the harness aliases it).
12. **Identical failed adoption runs are inconclusive, not FAIL** (refines 7; review P2 at `BackendParityHarness.swift:1259`). Cold and adopted emitting identical tokens under the SAME non-clean terminal proved nothing, yet recorded `exact = false` and `prefixReuse` hard-FAILed it as "adoption changed the answer". `judgeAdoptionExactness` is now tri-state (`exact`/`inexact(reason)`/`inconclusive(reason)`); the inconclusive case rides the observation as `adoptionInconclusiveReason` (with `adoptionTokenExact` staying nil — the reason field separates "ran but proved nothing" from "never ran") and the criterion reports UNAVAILABLE naming the shared failure. Genuine mismatches — different terminals, or diverging tokens even under a shared failure — keep failing, and a real mismatch on the other arm still outranks an inconclusive one (disclosed instead of a false SYMMETRIC claim).
13. **Schema version bumped to 3** (review P2 at `BackendParityReport.swift:158`). The serialized shape grew this PR — `pagedPoolDType` on observations, `candidatePoolDType`/`controlPoolDType` with the same-dtype validity rule on the control, `adoptionMismatchReason`, and the new `adoptionInconclusiveReason` — while the artifact still claimed schema 2 ("adds `EXPECTED_SHORTFALL`"). One bump folds all of it, the version-history comment enumerates it, and a test pins the constant so the next shape change forces a deliberate bump.

## Verification

- Coordinator: `gofmt` clean, `go vet` clean, full `go test ./...` — green (one pre-existing `promptcontract` supervisor-timing flake, passes on retry, package untouched).
- Swift targeted filters: `TelemetryOverflowQueue|ThroughputSweep|KVBackendGuardStore|Posture|Diagnostics` (115 tests) and `Watchdog|CrashLoop|KVBackendGuard` (142 tests) — all pass.
- Round-2 fixes: `Parity|PrefixCache|fp32` (217 tests) — all pass; full `swift test` green (1928 tests, 199 suites) after merging the refreshed `paged-kv/completion` (incl. the master merge with #530's media fetch).
- Round-3 fixes (9, 10): `BackendParity` filter (80 tests) — all pass; one full `swift test` attempt run per wedge protocol.
- Round-4 refinements (11–13): `BackendParity` filter (85 tests) — all pass; full `swift test` green (1941 tests, 199 suites), no wedge.
- Post-squash rebase (after #590 merged): the five fix commits replayed cleanly onto `master` — the squash content is byte-identical to the completion tip this branch had merged, so there were zero conflicts. Re-verified on the rebased head: `gofmt`/`go vet`/`go test ./...` green, targeted filters `BackendParity` (80), `Watchdog|CrashLoop|KVBackendGuard` (142), `Diagnostics` (48) all pass, full `swift test` green (1936 tests, 199 suites).
- New tests: relative-override rejection; cross-instance push/drain race (two queue instances = two NSLocks, only the flock serializes — the exact watchdog/daemon topology); deterministic-verdict freeze, promotion save, and freeze-vs-save interaction (three Go tests on the speculative harness); idle-timeout horizon mapping + build() honoring nil/custom horizons; `aggregateRows` poisoning; terminal-mismatch exactness matrix (stop/length, error arm, both-unclean, diverged+mismatched) + criterion-detail disclosure; fp32 rate doubling, slot-rate dtype following, and budget halving through `backendSlotCapacity()`; ambient-fp32 pin precedence, same-dtype control rejection at evaluation (with the distinct-dtype discrimination twin), legacy-artifact passthrough, observation dtype JSON round-trip; evidence-floor refusal naming failure shapes, minority-exclusion disclosure, mismatched-failure-shape exclusion, and divergence-with-exclusion interplay; clean-vs-failed empty row counted as a finish-reason divergence, both-clean empty row scored as agreement, identical-failure inconclusiveness (judge tri-state matrix incl. diverged-under-shared-failure staying a mismatch), inconclusive-arm UNAVAILABLE plus the mixed inexact-vs-inconclusive precedence, and the schema-3 pin.

