### PR TITLE
fix(coordinator): learn a per-pair token-budget ceiling for the affine paged pool; split capacity rejections from unservable ones

### DIFF
--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -403,13 +403,19 @@ func (s *Server) noteInferenceError(providerID string, pr *registry.PendingReque
 			tripped = s.registry.RecordCapacityRejectLifecycle(providerID, pr.Model)
 		case s.isRequestShapeBatchBudgetReject(providerID, pr.Model, errStr, errReason):
 			tripped = s.registry.RecordCapacityRejectRequestShape(providerID, pr.Model)
-		default:
-			// Sized: the request's token demand plus the pair's reported
-			// used+queued is the exact commitment the provider refused, which
-			// is what the learned budget ceiling latches (registry/
+		case isTokenBudgetCapacityReject(errStr):
+			// Sized: the request's token demand on top of the commitment the
+			// pair was already holding is the exact level the provider refused,
+			// which is what the learned budget ceiling latches (registry/
 			// budget_ceiling.go) so the pair stops being re-selected at that
-			// level once the one-shot clamp releases.
+			// level once the one-shot clamp releases. Only the token-budget /
+			// KV vocabulary qualifies — a drain or an OOM is a real capacity
+			// shed whose commitment number would teach the ceiling nothing.
 			tripped = s.registry.RecordCapacityRejectSized(providerID, pr.Model, pr.RequestTokens())
+		default:
+			// Every other provider-indicting capacity shed: unchanged
+			// behaviour — clamp plus strike plus rate window, no ceiling.
+			tripped = s.registry.RecordCapacityReject(providerID, pr.Model)
 		}
 		if tripped {
 			s.ddIncr(metricCapacityCooldownTripped, []string{"provider_id:" + providerID, "model:" + pr.Model})

--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -411,7 +411,8 @@ func (s *Server) noteInferenceError(providerID string, pr *registry.PendingReque
 			// level once the one-shot clamp releases. Only the token-budget /
 			// KV vocabulary qualifies — a drain or an OOM is a real capacity
 			// shed whose commitment number would teach the ceiling nothing.
-			tripped = s.registry.RecordCapacityRejectSized(providerID, pr.Model, pr.RequestTokens())
+			tripped = s.registry.RecordCapacityRejectSized(
+				providerID, pr.Model, pr.RequestID, pr.RequestTokens())
 		default:
 			// Every other provider-indicting capacity shed: unchanged
 			// behaviour — clamp plus strike plus rate window, no ceiling.

--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -404,7 +404,12 @@ func (s *Server) noteInferenceError(providerID string, pr *registry.PendingReque
 		case s.isRequestShapeBatchBudgetReject(providerID, pr.Model, errStr, errReason):
 			tripped = s.registry.RecordCapacityRejectRequestShape(providerID, pr.Model)
 		default:
-			tripped = s.registry.RecordCapacityReject(providerID, pr.Model)
+			// Sized: the request's token demand plus the pair's reported
+			// used+queued is the exact commitment the provider refused, which
+			// is what the learned budget ceiling latches (registry/
+			// budget_ceiling.go) so the pair stops being re-selected at that
+			// level once the one-shot clamp releases.
+			tripped = s.registry.RecordCapacityRejectSized(providerID, pr.Model, pr.RequestTokens())
 		}
 		if tripped {
 			s.ddIncr(metricCapacityCooldownTripped, []string{"provider_id:" + providerID, "model:" + pr.Model})

--- a/coordinator/api/dispatch.go
+++ b/coordinator/api/dispatch.go
@@ -165,6 +165,14 @@ type dispatchState struct {
 	// uptime-neutral 429 with unservableReason instead of retrying/5xx'ing.
 	unservable       bool
 	unservableReason string
+	// lastDecision is the most recent scheduler decision that carried signal
+	// (a selection, or a scan that saw candidates / capacity rejections). The
+	// exhausted ladder reports its counters in the rejection ledger, so a
+	// "could_have_served" verdict is computed from what the scheduler actually
+	// saw instead of being hard-written to zero. Attempts whose scan found
+	// nothing at all do not overwrite it: an empty tail decision would erase
+	// the evidence of the providers earlier attempts really did try.
+	lastDecision registry.RoutingDecision
 	// terminalClientError is set when a dispatched provider returned a DETERMINISTIC
 	// client-shape 4xx (400/413/422/415 — invalid tool payload / role / response_format
 	// / unsupported media). That rejection is identical on every provider (the bad
@@ -781,6 +789,18 @@ func (d *dispatchState) rejectionInfo(stage, reason string, status, retryAfterMs
 	return info
 }
 
+// noteDecision latches a scheduler decision for the exhausted ladder's
+// rejection telemetry. Only decisions that carry signal are kept — a later
+// attempt whose scan found nothing (every provider already excluded, say) must
+// not erase what earlier attempts saw.
+func (d *dispatchState) noteDecision(decision registry.RoutingDecision) {
+	if decision.ProviderID != "" || decision.CandidateCount > 0 ||
+		decision.CapacityRejections > 0 || decision.ModelTooLargeRejections > 0 ||
+		decision.VisionRejections > 0 {
+		d.lastDecision = decision
+	}
+}
+
 func (d *dispatchState) rejectionInfoWithDecision(stage, reason string, status, retryAfterMs int, decision registry.RoutingDecision) rejectionInfo {
 	info := d.rejectionInfo(stage, reason, status, retryAfterMs)
 	info.servabilityComputed = true
@@ -789,6 +809,45 @@ func (d *dispatchState) rejectionInfoWithDecision(stage, reason string, status, 
 	info.modelTooLargeRejections = decision.ModelTooLargeRejections
 	info.visionRejections = decision.VisionRejections
 	info.bestTTFTMs = decision.BestTTFTMs
+	return info
+}
+
+// exhaustedRejectionInfo builds the rejection-ledger record for the exhausted
+// dispatch ladder's 429/503 exit. The counterfactual it carries is what
+// recordRejection turns into could_have_served, so the three exits must not
+// share one shape:
+//
+//   - CAPACITY RETRIES EXHAUSTED: the fleet could have served this request and
+//     was merely full. Report the scheduler's real counters, floored by the
+//     number of providers that actually capacity-rejected a dispatched attempt
+//     (each was by definition a candidate), so a decision that happened to
+//     carry no counters still cannot under-report below what the loop itself
+//     observed. This path previously hard-wrote candidateCount = 0, which
+//     booked every busy-fleet rejection as "could not have served" — the
+//     misreporting that sent the 2026-07 incident diagnosis down the wrong
+//     path for an hour.
+//   - DETERMINISTICALLY UNSERVABLE: candidates existed and every one of them
+//     would reject the same request identically, so zero is the honest answer
+//     and it is stated authoritatively (mirroring the preflight gate).
+//   - EVERYTHING ELSE: leave servabilityComputed false and let recordRejection
+//     compute the counterfactual itself off the request path.
+func (d *dispatchState) exhaustedRejectionInfo(reason string, statusCode, retryAfterMs int) rejectionInfo {
+	if !d.unservable {
+		return d.rejectionInfo("dispatch", reason, statusCode, retryAfterMs)
+	}
+	if reason != rejectionReasonCapacityRetriesExhausted {
+		info := d.rejectionInfo("dispatch", reason, statusCode, retryAfterMs)
+		info.servabilityComputed = true
+		info.candidateCount = 0
+		return info
+	}
+	info := d.rejectionInfoWithDecision("dispatch", reason, statusCode, retryAfterMs, d.lastDecision)
+	if info.candidateCount < d.capacityRetries {
+		info.candidateCount = d.capacityRetries
+	}
+	if info.capacityRejections < d.capacityRetries {
+		info.capacityRejections = d.capacityRetries
+	}
 	return info
 }
 
@@ -925,6 +984,7 @@ func (d *dispatchState) dispatchPrimary() dispatchOutcome {
 	)
 	d.dispatchErr = dispatchErr
 	d.dispatchErrCode = dispatchErrCode
+	d.noteDecision(decision)
 	if !routeRecorded {
 		d.recordRoutingDecision(decision, dispatchErr, "")
 	}
@@ -1340,12 +1400,31 @@ func (d *dispatchState) noteProviderError(provider *registry.Provider, pr *regis
 	return d.s.noteDispatchProviderError(provider, pr, statusCode, errStr, errReason, terminalCause, held)
 }
 
-// rejectionReasonOversized is the rejection-ledger reason_code for a request the
-// dispatch loop stopped because no provider can serve it (deterministic context
-// overflow, or a transient-capacity shortage that exhausted
-// maxCapacityClassRetries). Distinct from the preflight "context_exceeded" /
-// "prompt_too_long" and the legacy dispatch-exhausted "unservable_token_budget".
+// rejectionReasonOversized is the rejection-ledger reason_code for a request
+// the dispatch loop stopped because it is DETERMINISTICALLY unservable — a
+// context overflow that every provider in the fleet would reject identically.
+// Distinct from the preflight "context_exceeded" / "prompt_too_long" and the
+// legacy dispatch-exhausted "unservable_token_budget".
+//
+// Reserved for genuinely-unservable SHAPES. It used to double as the code for
+// a transient-capacity shortage that exhausted maxCapacityClassRetries, which
+// is a statement about the fleet being busy, not about the request — see
+// rejectionReasonCapacityRetriesExhausted.
 const rejectionReasonOversized = "oversized_request"
+
+// rejectionReasonCapacityRetriesExhausted is the rejection-ledger reason_code
+// for a request the dispatch loop stopped because it burned
+// maxCapacityClassRetries (3) TRANSIENT-capacity failovers. The three
+// providers it tried were candidates that were merely full; a fourth might
+// have served it, and the same request an hour later on an idle fleet
+// certainly would.
+//
+// Split out of rejectionReasonOversized deliberately. Conflating the two makes
+// a busy fleet indistinguishable from an unservable request in the rejection
+// ledger, which is precisely how the 2026-07 paged-rollout incident was
+// misdiagnosed: ~10% of traffic booked as "oversized_request" when the prompts
+// were ordinary and the boxes were simply out of KV pool.
+const rejectionReasonCapacityRetriesExhausted = "capacity_retries_exhausted"
 
 // rejectionReasonTemplateRenderFailed is the rejection-ledger reason_code for
 // a request the dispatch loop stopped because the model's chat template
@@ -1428,8 +1507,14 @@ func (d *dispatchState) shouldStopFailover() bool {
 		d.s.ddIncr("routing.dispatch_to_capacity_503", []string{"model:" + d.model, "reason:transient"})
 		d.capacityRetries++
 		if d.capacityRetries >= maxCapacityClassRetries {
+			// Out of retries, NOT out of servability: every one of these
+			// rejections came from a provider that was a real candidate and
+			// simply had no KV room right now. The ladder still stops (a
+			// fleet-wide transient must not storm 64 providers) and still
+			// emits the uptime-neutral 429, but under its own reason code so
+			// the ledger can tell a busy fleet from an unservable request.
 			d.unservable = true
-			d.unservableReason = rejectionReasonOversized
+			d.unservableReason = rejectionReasonCapacityRetriesExhausted
 			return true
 		}
 		return false
@@ -2656,16 +2741,26 @@ exhausted:
 			}
 			s.ddIncr("routing.client_error_passthrough", []string{"model:" + d.model, "code:" + strconv.Itoa(statusCode)})
 		} else if d.unservable {
-			// The loop stopped early because no provider can serve this request
-			// (deterministic context overflow, or a capacity transient that
-			// exhausted maxCapacityClassRetries). We already know the verdict, so
-			// skip the quick-capacity probe and the 5xx→429 reclassification below:
-			// emit a single uptime-neutral 429. This is the proactive complement to
-			// the always-on backstop — it converts the request BEFORE storming the
-			// fleet, not after 64 attempts.
+			// The loop stopped early: either no provider can serve this request
+			// (deterministic context overflow) or a capacity transient exhausted
+			// maxCapacityClassRetries. We already know the verdict, so skip the
+			// quick-capacity probe and the 5xx→429 reclassification below: emit a
+			// single uptime-neutral 429. This is the proactive complement to the
+			// always-on backstop — it converts the request BEFORE storming the
+			// fleet, not after 64 attempts. The two verdicts carry DIFFERENT
+			// reason codes and different metrics (an unservable shape is a
+			// property of the request; exhausted capacity retries are a property
+			// of the fleet), so the ledger and the dashboards can tell them apart.
 			statusCode = http.StatusTooManyRequests
-			reason = rejectionReasonOversized
-			s.ddIncr("routing.oversized_request_rejected", []string{"model:" + d.model, "stage:dispatch"})
+			reason = d.unservableReason
+			if reason == "" {
+				reason = rejectionReasonOversized
+			}
+			if reason == rejectionReasonCapacityRetriesExhausted {
+				s.ddIncr("routing.capacity_retries_exhausted", []string{"model:" + d.model, "stage:dispatch"})
+			} else {
+				s.ddIncr("routing.oversized_request_rejected", []string{"model:" + d.model, "stage:dispatch"})
+			}
 		} else if statusCode == 0 {
 			// Distinguish capacity exhaustion (429) from genuine unavailability (503).
 			// A quick capacity check tells us if providers exist but are full.
@@ -2716,16 +2811,7 @@ exhausted:
 		if statusCode == http.StatusTooManyRequests || statusCode == http.StatusServiceUnavailable {
 			retryAfter := s.estimateRetryAfter(d.model)
 			w.Header().Set("Retry-After", strconv.Itoa(retryAfter))
-			info := d.rejectionInfo("dispatch", reason, statusCode, retryAfter*1000)
-			if d.unservable {
-				// No provider could serve this request (it exceeds the model
-				// context, identical fleet-wide). Mark it not-servable so the
-				// rejection ledger's could_have_served reflects reality — candidates
-				// existed but every one would reject — mirroring the preflight gate.
-				info.servabilityComputed = true
-				info.candidateCount = 0
-			}
-			s.recordRejection(info)
+			s.recordRejection(d.exhaustedRejectionInfo(reason, statusCode, retryAfter*1000))
 		} else {
 			s.recordRejection(d.rejectionInfo("dispatch", reason, statusCode, 0))
 		}

--- a/coordinator/api/dispatch.go
+++ b/coordinator/api/dispatch.go
@@ -818,17 +818,28 @@ func (d *dispatchState) rejectionInfoWithDecision(stage, reason string, status, 
 // share one shape:
 //
 //   - CAPACITY RETRIES EXHAUSTED: the fleet could have served this request and
-//     was merely full. Report the scheduler's real counters, floored by the
-//     number of providers that actually capacity-rejected a dispatched attempt
-//     (each was by definition a candidate), so a decision that happened to
-//     carry no counters still cannot under-report below what the loop itself
-//     observed. This path previously hard-wrote candidateCount = 0, which
-//     booked every busy-fleet rejection as "could not have served" — the
-//     misreporting that sent the 2026-07 incident diagnosis down the wrong
-//     path for an hour.
+//     was merely full. Report the scheduler's real counters, with candidateCount
+//     floored by the number of providers that actually capacity-rejected a
+//     dispatched attempt — each of those was by definition a candidate when it
+//     was selected, so the floor cannot over-report, and it keeps a decision
+//     that happens to carry no counters from under-reporting below what the
+//     loop itself observed. This path previously hard-wrote candidateCount = 0,
+//     which booked every busy-fleet rejection as "could not have served" — the
+//     misreporting that sent the 2026-07 incident diagnosis down the wrong path
+//     for an hour.
+//
+//     capacityRejections is deliberately NOT floored the same way. It counts
+//     candidates the admission gate shed DURING SELECTION, never dispatched;
+//     d.capacityRetries counts providers that WERE dispatched and returned a
+//     capacity 503. Those are disjoint halves of the funnel, and maxing them
+//     into one field would reintroduce exactly the counter conflation this
+//     change exists to remove. The dispatched count is recoverable from
+//     candidateCount, which the floor makes honest.
+//
 //   - DETERMINISTICALLY UNSERVABLE: candidates existed and every one of them
 //     would reject the same request identically, so zero is the honest answer
 //     and it is stated authoritatively (mirroring the preflight gate).
+//
 //   - EVERYTHING ELSE: leave servabilityComputed false and let recordRejection
 //     compute the counterfactual itself off the request path.
 func (d *dispatchState) exhaustedRejectionInfo(reason string, statusCode, retryAfterMs int) rejectionInfo {
@@ -844,9 +855,6 @@ func (d *dispatchState) exhaustedRejectionInfo(reason string, statusCode, retryA
 	info := d.rejectionInfoWithDecision("dispatch", reason, statusCode, retryAfterMs, d.lastDecision)
 	if info.candidateCount < d.capacityRetries {
 		info.candidateCount = d.capacityRetries
-	}
-	if info.capacityRejections < d.capacityRetries {
-		info.capacityRejections = d.capacityRetries
 	}
 	return info
 }

--- a/coordinator/api/dispatch.go
+++ b/coordinator/api/dispatch.go
@@ -846,7 +846,11 @@ func (d *dispatchState) exhaustedRejectionInfo(reason string, statusCode, retryA
 	if !d.unservable {
 		return d.rejectionInfo("dispatch", reason, statusCode, retryAfterMs)
 	}
-	if reason != rejectionReasonCapacityRetriesExhausted {
+	// Branch on the LATCHED state, not on the reason parameter. They agree at
+	// the sole call site, but a future edit that passes a reason independently
+	// of d.unservableReason would silently fall back to candidateCount = 0 —
+	// the exact misreporting this split exists to remove.
+	if d.unservableReason != rejectionReasonCapacityRetriesExhausted {
 		info := d.rejectionInfo("dispatch", reason, statusCode, retryAfterMs)
 		info.servabilityComputed = true
 		info.candidateCount = 0

--- a/coordinator/api/dispatch_capacity_retries_test.go
+++ b/coordinator/api/dispatch_capacity_retries_test.go
@@ -48,17 +48,6 @@ func transientCapacityMsg() protocol.InferenceErrorMessage {
 	}
 }
 
-// The two verdicts must not share a reason code — the whole point of the
-// split is that a ledger query can separate them.
-func TestCapacityRetriesReasonIsDistinctFromOversized(t *testing.T) {
-	if rejectionReasonCapacityRetriesExhausted == rejectionReasonOversized {
-		t.Fatal("capacity exhaustion and unservable shapes must carry different reason codes")
-	}
-	if rejectionReasonCapacityRetriesExhausted == "" {
-		t.Fatal("the capacity reason code must be non-empty (it reaches the ledger verbatim)")
-	}
-}
-
 // Exhausting the transient-capacity retry budget latches the CAPACITY reason;
 // a deterministic context overflow still latches oversized_request. Same stop
 // behaviour, different verdict.
@@ -130,18 +119,22 @@ func TestExhaustedRejectionInfoCounterfactual(t *testing.T) {
 		}
 	})
 
-	t.Run("capacity path floors on providers that actually rejected", func(t *testing.T) {
+	t.Run("capacity path floors candidates on providers that actually rejected", func(t *testing.T) {
 		// A decision with no counters (every candidate already excluded on the
 		// final attempt) must not erase the fact that three providers were
-		// dispatched to and capacity-rejected.
+		// dispatched to and capacity-rejected. capacityRejections stays at the
+		// decision's value: it counts candidates shed DURING SELECTION, a
+		// disjoint population from providers that were dispatched and 503'd, and
+		// flooring it would rebuild the very counter conflation this split undoes.
 		d := exhaustedState(t, newTestServerForDispatch(t),
 			rejectionReasonCapacityRetriesExhausted, maxCapacityClassRetries, registry.RoutingDecision{})
 		info := d.exhaustedRejectionInfo(rejectionReasonCapacityRetriesExhausted, http.StatusTooManyRequests, 2000)
 		if info.candidateCount != maxCapacityClassRetries {
 			t.Fatalf("candidateCount = %d, want the observed floor %d", info.candidateCount, maxCapacityClassRetries)
 		}
-		if info.capacityRejections != maxCapacityClassRetries {
-			t.Fatalf("capacityRejections = %d, want the observed floor %d", info.capacityRejections, maxCapacityClassRetries)
+		if info.capacityRejections != 0 {
+			t.Fatalf("capacityRejections = %d, want the decision's own 0 (selection-stage counter, not a dispatch count)",
+				info.capacityRejections)
 		}
 	})
 

--- a/coordinator/api/dispatch_capacity_retries_test.go
+++ b/coordinator/api/dispatch_capacity_retries_test.go
@@ -1,0 +1,237 @@
+package api
+
+// Regression tests for the capacity-retries-exhausted split.
+//
+// Running out of maxCapacityClassRetries is evidence that the FLEET is busy,
+// not that the REQUEST is unservable. Until this change both verdicts wrote
+// reason_code "oversized_request", and the exhausted ladder hard-wrote
+// candidateCount = 0 into the rejection ledger — from which
+// recordRejection derives could_have_served. So every busy-fleet 429 was
+// booked as "zero candidates, could not have served" when in fact three
+// providers had been dispatched to and had merely been full. That misreporting
+// is what pointed the 2026-07 paged-rollout incident at prompt sizes for an
+// hour while the actual cause was KV pool exhaustion.
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+	"github.com/eigeninference/d-inference/coordinator/registry"
+	"github.com/eigeninference/d-inference/coordinator/store"
+)
+
+// exhaustedState builds the dispatchState the exhausted ladder reaches, with
+// the inbound request rejectionInfo reads its endpoint and key from.
+func exhaustedState(t *testing.T, s *Server, reason string, retries int, decision registry.RoutingDecision) *dispatchState {
+	t.Helper()
+	return &dispatchState{
+		s: s, r: httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil),
+		model: "m", publicModel: "m",
+		unservable:       reason != "",
+		unservableReason: reason,
+		capacityRetries:  retries,
+		lastDecision:     decision,
+	}
+}
+
+// transientCapacityMsg is a provider terminal of the shape the paged fleet
+// returns when its KV pool is full: a 503 whose text is capacity-class but
+// whose implied budget says nothing about the request being too big.
+func transientCapacityMsg() protocol.InferenceErrorMessage {
+	return protocol.InferenceErrorMessage{
+		RequestID:  "req-cap",
+		Error:      "request rejected: queue full",
+		StatusCode: 503,
+	}
+}
+
+// The two verdicts must not share a reason code — the whole point of the
+// split is that a ledger query can separate them.
+func TestCapacityRetriesReasonIsDistinctFromOversized(t *testing.T) {
+	if rejectionReasonCapacityRetriesExhausted == rejectionReasonOversized {
+		t.Fatal("capacity exhaustion and unservable shapes must carry different reason codes")
+	}
+	if rejectionReasonCapacityRetriesExhausted == "" {
+		t.Fatal("the capacity reason code must be non-empty (it reaches the ledger verbatim)")
+	}
+}
+
+// Exhausting the transient-capacity retry budget latches the CAPACITY reason;
+// a deterministic context overflow still latches oversized_request. Same stop
+// behaviour, different verdict.
+func TestShouldStopFailoverSplitsCapacityFromUnservable(t *testing.T) {
+	t.Run("transient capacity exhausts its retries", func(t *testing.T) {
+		d := &dispatchState{s: newTestServerForDispatch(t), model: "m"}
+		for i := 1; i < maxCapacityClassRetries; i++ {
+			d.setLastInferenceError(nil, transientCapacityMsg())
+			if d.shouldStopFailover() {
+				t.Fatalf("attempt %d: must keep failing over below the cap", i)
+			}
+		}
+		d.setLastInferenceError(nil, transientCapacityMsg())
+		if !d.shouldStopFailover() {
+			t.Fatal("must stop at maxCapacityClassRetries")
+		}
+		if !d.unservable {
+			t.Fatal("the stop must still latch the uptime-neutral 429 path")
+		}
+		if d.unservableReason != rejectionReasonCapacityRetriesExhausted {
+			t.Fatalf("reason = %q, want %q — a busy fleet is not an unservable request",
+				d.unservableReason, rejectionReasonCapacityRetriesExhausted)
+		}
+		if d.capacityRetries != maxCapacityClassRetries {
+			t.Fatalf("capacityRetries = %d, want %d", d.capacityRetries, maxCapacityClassRetries)
+		}
+	})
+
+	t.Run("deterministic overflow stays oversized_request", func(t *testing.T) {
+		d := &dispatchState{s: newTestServerForDispatch(t), model: "m"}
+		// Unknown budget + unknown context ⇒ a "batch token budget" reject is
+		// deterministic: every provider rejects it identically.
+		d.setLastInferenceError(nil, protocol.InferenceErrorMessage{
+			Error: "token_budget_exhausted: request exceeds batch token budget", StatusCode: 503,
+		})
+		if !d.shouldStopFailover() {
+			t.Fatal("a deterministic overflow must stop on the first occurrence")
+		}
+		if d.unservableReason != rejectionReasonOversized {
+			t.Fatalf("reason = %q, want %q — oversized_request stays reserved for unservable shapes",
+				d.unservableReason, rejectionReasonOversized)
+		}
+	})
+}
+
+// The exhausted ladder's ledger record must carry the counters the scheduler
+// actually produced on the capacity path, and an authoritative zero only on
+// the genuinely-unservable path.
+func TestExhaustedRejectionInfoCounterfactual(t *testing.T) {
+	decision := registry.RoutingDecision{
+		CandidateCount:     5,
+		CapacityRejections: 4,
+		BestTTFTMs:         1234,
+	}
+
+	t.Run("capacity path reports the real counts", func(t *testing.T) {
+		d := exhaustedState(t, newTestServerForDispatch(t),
+			rejectionReasonCapacityRetriesExhausted, maxCapacityClassRetries, decision)
+		info := d.exhaustedRejectionInfo(rejectionReasonCapacityRetriesExhausted, http.StatusTooManyRequests, 2000)
+		if !info.servabilityComputed {
+			t.Fatal("the caller already knows the counterfactual; it must not be recomputed")
+		}
+		if info.candidateCount != 5 || info.capacityRejections != 4 {
+			t.Fatalf("(candidates=%d, capacityRejections=%d), want (5, 4)",
+				info.candidateCount, info.capacityRejections)
+		}
+		if info.bestTTFTMs != 1234 {
+			t.Fatalf("bestTTFTMs = %v, want 1234", info.bestTTFTMs)
+		}
+	})
+
+	t.Run("capacity path floors on providers that actually rejected", func(t *testing.T) {
+		// A decision with no counters (every candidate already excluded on the
+		// final attempt) must not erase the fact that three providers were
+		// dispatched to and capacity-rejected.
+		d := exhaustedState(t, newTestServerForDispatch(t),
+			rejectionReasonCapacityRetriesExhausted, maxCapacityClassRetries, registry.RoutingDecision{})
+		info := d.exhaustedRejectionInfo(rejectionReasonCapacityRetriesExhausted, http.StatusTooManyRequests, 2000)
+		if info.candidateCount != maxCapacityClassRetries {
+			t.Fatalf("candidateCount = %d, want the observed floor %d", info.candidateCount, maxCapacityClassRetries)
+		}
+		if info.capacityRejections != maxCapacityClassRetries {
+			t.Fatalf("capacityRejections = %d, want the observed floor %d", info.capacityRejections, maxCapacityClassRetries)
+		}
+	})
+
+	t.Run("unservable path keeps its authoritative zero", func(t *testing.T) {
+		d := exhaustedState(t, newTestServerForDispatch(t), rejectionReasonOversized, 1, decision)
+		info := d.exhaustedRejectionInfo(rejectionReasonOversized, http.StatusTooManyRequests, 2000)
+		if !info.servabilityComputed || info.candidateCount != 0 {
+			t.Fatalf("(computed=%v, candidates=%d), want (true, 0) — every candidate would reject this shape",
+				info.servabilityComputed, info.candidateCount)
+		}
+	})
+
+	t.Run("non-unservable exits defer the counterfactual", func(t *testing.T) {
+		d := exhaustedState(t, newTestServerForDispatch(t), "", 0, decision)
+		info := d.exhaustedRejectionInfo("dispatch_exhausted", http.StatusServiceUnavailable, 0)
+		if info.servabilityComputed {
+			t.Fatal("a plain dispatch_exhausted exit must let recordRejection compute servability off the request path")
+		}
+	})
+}
+
+// The headline consequence, through the real ledger write: a capacity-exhausted
+// rejection must persist could_have_served = true, and an unservable one false.
+func TestRejectionLedgerCouldHaveServedSplit(t *testing.T) {
+	for _, tc := range []struct {
+		name            string
+		reason          string
+		wantCouldServe  bool
+		wantCandidates  int
+		wantCapRejected int
+	}{
+		{
+			name: "capacity exhausted", reason: rejectionReasonCapacityRetriesExhausted,
+			wantCouldServe: true, wantCandidates: 5, wantCapRejected: 4,
+		},
+		{
+			name: "unservable shape", reason: rejectionReasonOversized,
+			wantCouldServe: false, wantCandidates: 0, wantCapRejected: 0,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := newTestServerForDispatch(t)
+			d := exhaustedState(t, s, tc.reason, maxCapacityClassRetries,
+				registry.RoutingDecision{CandidateCount: 5, CapacityRejections: 4})
+			s.recordRejection(d.exhaustedRejectionInfo(tc.reason, http.StatusTooManyRequests, 2000))
+
+			rec := waitForRejection(t, s.store, tc.reason)
+			if rec.CouldHaveServed != tc.wantCouldServe {
+				t.Fatalf("could_have_served = %v, want %v", rec.CouldHaveServed, tc.wantCouldServe)
+			}
+			if rec.CandidateCount != tc.wantCandidates {
+				t.Fatalf("candidate_count = %d, want %d", rec.CandidateCount, tc.wantCandidates)
+			}
+			if rec.CapacityRejections != tc.wantCapRejected {
+				t.Fatalf("capacity_rejections = %d, want %d", rec.CapacityRejections, tc.wantCapRejected)
+			}
+		})
+	}
+}
+
+// noteDecision must not let a signal-free tail attempt erase what earlier
+// attempts saw — that erasure would reintroduce the zero-candidate report the
+// floor is only a backstop for.
+func TestNoteDecisionKeepsSignalBearingScan(t *testing.T) {
+	d := &dispatchState{s: newTestServerForDispatch(t), model: "m"}
+	d.noteDecision(registry.RoutingDecision{CandidateCount: 7, CapacityRejections: 2})
+	d.noteDecision(registry.RoutingDecision{})
+	if d.lastDecision.CandidateCount != 7 || d.lastDecision.CapacityRejections != 2 {
+		t.Fatalf("lastDecision = %+v, want the earlier signal-bearing scan retained", d.lastDecision)
+	}
+	d.noteDecision(registry.RoutingDecision{ProviderID: "p", CandidateCount: 1})
+	if d.lastDecision.ProviderID != "p" || d.lastDecision.CandidateCount != 1 {
+		t.Fatalf("lastDecision = %+v, want the newer signal-bearing scan", d.lastDecision)
+	}
+}
+
+// waitForRejection polls the rejection ledger for a record with the given
+// reason code. recordRejection writes on the telemetry sink, so the write is
+// asynchronous by design.
+func waitForRejection(t *testing.T, st store.Store, reason string) store.RejectionRecord {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		for _, rec := range st.RejectionRecordsSince(time.Time{}) {
+			if rec.ReasonCode == reason {
+				return rec
+			}
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("no rejection record with reason %q was persisted", reason)
+	return store.RejectionRecord{}
+}

--- a/coordinator/api/dispatch_capacity_retries_test.go
+++ b/coordinator/api/dispatch_capacity_retries_test.go
@@ -195,6 +195,44 @@ func TestRejectionLedgerCouldHaveServedSplit(t *testing.T) {
 	}
 }
 
+// The learned budget ceiling learns only from the TOKEN-BUDGET vocabulary. It
+// is a TTL-bounded derate of live headroom that survives reconnects, so unlike
+// the one-shot clamp (which every other provider-indicting capacity shed still
+// arms) it requires evidence about the quantity it derates. A drain for a
+// hot-swap update is the sharpest case: the box comes back healthy, but fault
+// identity is stable across the reconnect, so a ceiling latched off the drain
+// would follow it.
+func TestOnlyTokenBudgetRejectsTeachTheCeiling(t *testing.T) {
+	for name, tc := range map[string]struct {
+		errStr    string
+		wantLearn bool
+	}{
+		"token budget exhausted":   {"token_budget_exhausted: batch token budget full", true},
+		"kv headroom":              {"insufficient kv cache headroom for request", true},
+		"draining for update":      {"provider draining for update", false},
+		"out of memory":            {"out of memory loading model weights", false},
+		"insufficient memory":      {"insufficient memory: need 40 GB, have 12 GB", false},
+		"generic overload shed":    {"request rejected: queue full", false},
+		"context overflow (shape)": {"prompt exceeds context length", false},
+		"cold model miss":          {"model not loaded", false},
+	} {
+		t.Run(name, func(t *testing.T) {
+			// The narrow predicate must agree with the branch that uses it, and
+			// must never fire for a shape an earlier branch already claims.
+			got := isTokenBudgetCapacityReject(tc.errStr)
+			if isColdModelMissRejection(tc.errStr) || !isCapacityRejectStrike(tc.errStr) {
+				if got {
+					t.Fatalf("%q is claimed by an earlier branch; it must not also read as a token-budget reject", tc.errStr)
+				}
+				return
+			}
+			if got != tc.wantLearn {
+				t.Fatalf("isTokenBudgetCapacityReject(%q) = %v, want %v", tc.errStr, got, tc.wantLearn)
+			}
+		})
+	}
+}
+
 // noteDecision must not let a signal-free tail attempt erase what earlier
 // attempts saw — that erasure would reintroduce the zero-candidate report the
 // floor is only a backstop for.

--- a/coordinator/api/inference_failure_class.go
+++ b/coordinator/api/inference_failure_class.go
@@ -257,6 +257,43 @@ func isCapacityRejectStrike(errStr string) bool {
 	return true
 }
 
+// isTokenBudgetCapacityReject reports whether a capacity-class rejection is
+// specifically about the pair's TOKEN BUDGET or KV headroom — the only
+// vocabulary from which the failing commitment (used + queued + pending +
+// request) is a meaningful measurement.
+//
+// This is deliberately NARROWER than the armClamp gate the one-shot budget
+// clamp rides. The clamp is a boolean that a single fresher heartbeat releases;
+// the learned ceiling (registry/budget_ceiling.go) is a TTL-bounded derate of
+// the pair's live headroom that survives reconnects. Identical evidence, very
+// different blast radius, so the ceiling requires evidence that is actually
+// about the quantity it derates. A provider "draining" for a hot-swap update,
+// or refusing a model load for want of memory, is a real capacity statement and
+// still arms the clamp and the strike — but its commitment number would teach
+// the ceiling nothing, and a drain reject latching a ceiling would derate a box
+// that comes back healthy from an update (fault identity is stable across the
+// reconnect, so the ceiling would follow it).
+//
+// Callers gate on this AFTER isCapacityRejectStrike and after the cold-miss and
+// request-shape branches, so context-overflow and "not loaded" shapes never
+// reach here.
+func isTokenBudgetCapacityReject(errStr string) bool {
+	s := strings.ToLower(strings.TrimSpace(errStr))
+	s = strings.ReplaceAll(s, "’", "'")
+	for _, marker := range []string{
+		"token_budget_exhausted",
+		"token budget",
+		"kv cache headroom",
+		"kv headroom",
+		"insufficient kv",
+	} {
+		if strings.Contains(s, marker) {
+			return true
+		}
+	}
+	return false
+}
+
 // isColdModelMissRejection reports whether a capacity-class rejection is the
 // BENIGN cold "model not loaded" lifecycle miss (a lazy load on first touch),
 // as opposed to a genuine capacity/token-budget shed. Matching mirrors the

--- a/coordinator/api/server.go
+++ b/coordinator/api/server.go
@@ -1981,6 +1981,13 @@ func (s *Server) StartDDGaugeLoop(ctx context.Context) {
 			return
 		case <-ticker.C:
 			s.ddGauge("providers.online", float64(s.registry.OnlineCount()), nil)
+			// Learned token-budget ceilings currently holding a (provider,
+			// model) pair below its advertised budget (registry/
+			// budget_ceiling.go). A working mitigation shows a handful that
+			// decay; a starved fleet shows this climbing and staying. The
+			// per-latch log line cannot answer the "right now" question.
+			s.ddGauge("routing.budget_ceilings_latched",
+				float64(s.registry.BudgetCeilingsLatched()), nil)
 			// APNs code-identity coverage — watch this climb during the grace
 			// window before letting APNS_ENFORCE_AFTER pass.
 			codeAttested, _ := s.registry.CodeAttestationCoverage()

--- a/coordinator/registry/budget_ceiling.go
+++ b/coordinator/registry/budget_ceiling.go
@@ -38,13 +38,15 @@ import (
 // and per batch shape, so this does not model it. It MEASURES it. On a
 // capacity reject the coordinator knows the commitment that failed:
 //
-//	S = max(used + queued, pendingForModel − requestTokens) + requestTokens
+//	S = max(used + queued, otherPendingForModel) + requestTokens
 //
-// in the same units the admission gate charges. The max matters: the heartbeat
-// half (used+queued) lags a burst by up to one heartbeat interval, and the
-// coordinator's own pending half is exactly the coordinatorExtra term
-// freeMemoryAdmits adds for that reason. Learning off the heartbeat alone would
-// read used≈0 mid-burst and latch an order of magnitude too tight. Latching
+// in the same units the admission gate charges — its LHS reduces to exactly
+// this. The max matters: the heartbeat half (used+queued) lags a burst by up to
+// one heartbeat interval, and the coordinator's own pending half is precisely
+// the coordinatorExtra term freeMemoryAdmits adds for that reason. Learning off
+// the heartbeat alone would read used≈0 mid-burst and latch an order of
+// magnitude too tight. Both halves exclude the rejected request, whose demand
+// is then charged once on top. Latching
 //
 //	effectiveMax = min(advertised, S − budgetCeilingMarginTokens)
 //
@@ -347,6 +349,27 @@ func (r *Registry) budgetCeilingLocked(providerID, modelID string, advertised in
 		return e.tokens
 	}
 	return advertised
+}
+
+// BudgetCeilingsLatched counts the pairs currently held below their advertised
+// token budget by a live learned ceiling. This is the fleet-level derate state
+// that the per-latch log line cannot answer: "how many pairs are deselected
+// right now", which is what an operator needs mid-incident to tell a working
+// mitigation from a starved fleet. Polled onto a gauge by the api metrics loop.
+func (r *Registry) BudgetCeilingsLatched() int {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if !r.budgetCeilingCfg.Enabled {
+		return 0
+	}
+	now := time.Now()
+	n := 0
+	for _, e := range r.budgetCeilings {
+		if now.Before(e.latchedAt.Add(r.budgetCeilingCfg.TTL)) {
+			n++
+		}
+	}
+	return n
 }
 
 // BudgetCeiling reports the pair's learned effective token-budget ceiling and

--- a/coordinator/registry/budget_ceiling.go
+++ b/coordinator/registry/budget_ceiling.go
@@ -184,11 +184,22 @@ type budgetCeilingEntry struct {
 // already the binding term, which is the ordinary "the box is genuinely full"
 // case the queue path owns — and refreshing the TTL off it would extend a
 // derating window on evidence that did not produce it.
-func (r *Registry) recordBudgetCeilingLocked(key capacityRejectKey, observedCommitment, advertised int64, now time.Time) {
+func (r *Registry) recordBudgetCeilingLocked(key capacityRejectKey, observedCommitment, alreadyCommitted, advertised int64, now time.Time) {
 	if !r.budgetCeilingCfg.Enabled || observedCommitment <= 0 || advertised <= 0 {
 		return
 	}
 	learned := observedCommitment - budgetCeilingMarginTokens
+	// Never learn a ceiling BELOW what the pair reports it is already holding.
+	// The margin exists to push the next identical request off the boundary,
+	// but for a request smaller than the margin it would otherwise push the
+	// ceiling under the live commitment — a number the provider's own report
+	// contradicts, and one low enough to deselect the pair for every request
+	// size (which produces no accepts, so only the TTL could recover it). The
+	// gate still rejects the request that failed: any positive demand on top
+	// of a ceiling equal to the commitment does not fit.
+	if learned < alreadyCommitted {
+		learned = alreadyCommitted
+	}
 	if learned < budgetCeilingFloorTokens {
 		learned = budgetCeilingFloorTokens
 	}

--- a/coordinator/registry/budget_ceiling.go
+++ b/coordinator/registry/budget_ceiling.go
@@ -234,17 +234,29 @@ func (r *Registry) recordBudgetCeilingLocked(key capacityRejectKey, observedComm
 		}
 	}
 	// Ratchet: a live entry that already knows a ceiling at least this tight
-	// keeps it, TTL ANCHOR INCLUDED. A reject cannot widen — only accepts can,
-	// and only through the widen path below — so without the token half a
-	// reject arriving at high commitment (a busy box) would undo what a reject
-	// at low commitment (the same box, gray) taught. And without the latchedAt
-	// half, a non-tightening reject would refresh the TTL off evidence that
-	// did not produce the ceiling, extending the derating window for free. The
-	// reject does reset progress toward widening: it is direct evidence
-	// against the accepts that had accumulated.
+	// keeps it, TTL ANCHOR INCLUDED — but only while the live commitment has
+	// not falsified it. Three clauses, each load-bearing:
+	//
+	//   - live: an expired entry teaches nothing.
+	//   - prev.tokens <= learned: a reject cannot widen. Only accepts can, and
+	//     only through the widen path below. Without this, a reject arriving at
+	//     high commitment (a busy box) would undo what a reject at low
+	//     commitment (the same box, gray) taught.
+	//   - prev.tokens >= alreadyCommitted: a ceiling BELOW what this very
+	//     reject observed the pair holding is contradicted by direct
+	//     observation, not by an accept. Keeping it would strand the pair at a
+	//     level its own accounting disproves, with no accept able to widen it
+	//     because nothing fits. Re-latching at `learned` (which the floor above
+	//     already put at or above the observed commitment) is not "widening on
+	//     a reject" — it is refusing to hold a number that has been falsified.
+	//
+	// When the ratchet holds, the anchor is untouched: a non-tightening reject
+	// refreshing the TTL would extend a derating window on evidence that did
+	// not produce it. The reject does reset progress toward widening, being
+	// direct evidence against the accepts that had accumulated.
 	if prev, ok := r.budgetCeilings[key]; ok &&
 		now.Before(prev.latchedAt.Add(r.budgetCeilingCfg.TTL)) &&
-		prev.tokens <= learned {
+		prev.tokens <= learned && prev.tokens >= alreadyCommitted {
 		prev.acceptsSince = 0
 		return
 	}
@@ -283,6 +295,20 @@ func (r *Registry) noteBudgetCeilingAcceptLocked(providerID, modelID string, key
 	if e.acceptsSince < budgetCeilingWidenAccepts {
 		return
 	}
+	// Healed? Compare against what the pair advertises RIGHT NOW, not against
+	// the value at latch time — the advertised budget moves with residency and
+	// co-tenancy, and the entry only exists to hold the pair below it.
+	advertised, _ := r.providerBudgetCommitmentLocked(providerID, modelID)
+	if advertised <= 0 {
+		// No budget report for the pair (disconnected, slot gone, reconnect
+		// before the first heartbeat). There is nothing to widen TOWARD: the
+		// entry cannot gate a budgetless snapshot either way, and growing
+		// tokens against no reference would leave a meaningless number to be
+		// compared with the next real heartbeat. Hold the value and the
+		// accumulated progress; the TTL still bounds the entry.
+		e.acceptsSince = budgetCeilingWidenAccepts
+		return
+	}
 	e.acceptsSince = 0
 	step := e.tokens / budgetCeilingWidenDivisor
 	if step < budgetCeilingMarginTokens {
@@ -292,11 +318,7 @@ func (r *Registry) noteBudgetCeilingAcceptLocked(providerID, modelID string, key
 		step = budgetCeilingMarginTokens
 	}
 	e.tokens += step
-	// Healed? Compare against what the pair advertises RIGHT NOW, not against
-	// the value at latch time — the advertised budget moves with residency and
-	// co-tenancy, and the entry only exists to hold the pair below it.
-	advertised, _ := r.providerBudgetCommitmentLocked(providerID, modelID)
-	if advertised > 0 && e.tokens >= advertised {
+	if e.tokens >= advertised {
 		delete(r.budgetCeilings, key)
 		if r.logger != nil {
 			r.logger.Info("budget ceiling healed",

--- a/coordinator/registry/budget_ceiling.go
+++ b/coordinator/registry/budget_ceiling.go
@@ -1,0 +1,312 @@
+package registry
+
+import (
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/env"
+)
+
+// Learned effective token-budget ceiling — the DURABLE half of the gray-box
+// fix, sitting behind the one-shot clamp in budget_clamp.go.
+//
+// # Why the clamp alone is a treadmill
+//
+// The clamp is a boolean: one capacity-503 zeroes the pair's live headroom,
+// and release condition (a) — raw max − used − queued ≥
+// budgetClampReleaseMinHeadroomTokens — is satisfied by the very next
+// heartbeat WHENEVER THE ADVERTISED BUDGET IS STRUCTURALLY INFLATED. The pair
+// is then re-selected at the same commitment level, rejected again, clamped
+// again. One bounced request per heartbeat, indefinitely.
+//
+// v0.8.0 made that inflation structural rather than incidental. A paged slot
+// advertises poolBytes / kvBytesPerToken, where kvBytesPerToken is the
+// MARGINAL long-context rate over full-attention layers only. The paged pool's
+// real charge is AFFINE, not linear: PagedKVPool.pageDemand charges each
+// sliding-window layer a fixed ring of pages regardless of sequence length
+// (gemma-4: ~303 MiB per in-flight sequence, ≈15.5k tokens' worth at its
+// 20,480 B/token marginal rate) PLUS the marginal per-token cost. The wire
+// budget therefore over-states concurrent capacity by ~1.6× at batch 8: the
+// coordinator computes that 9 requests fit a 6 GiB pool that physically holds
+// 6, and requests 7–9 come back token_budget_exhausted. The heartbeat is not
+// stale — it is honestly reporting a number whose model of the pool is wrong.
+// No release condition phrased in terms of that number can ever break the
+// cycle.
+//
+// # What this learns instead
+//
+// The intercept is unknown to the coordinator and differs per box, per model
+// and per batch shape, so this does not model it. It MEASURES it. On a
+// capacity reject the coordinator knows the exact commitment that failed:
+//
+//	S = active_token_budget_used + queued_token_budget + requestTokens
+//
+// all three in the same units the admission gate itself uses. Latching
+//
+//	effectiveMax = min(advertised, S − budgetCeilingMarginTokens)
+//
+// is the weakest statement consistent with the evidence: "this pair could not
+// hold S". The next request at the same commitment is then DESELECTED BEFORE
+// DISPATCH — it takes the existing queue-before-shed spill and is served when
+// a slot frees — instead of being dispatched, rejected, retried three times
+// and 429'd. As the box drains, used+queued falls and the pair becomes
+// selectable again on its own, which is exactly the behaviour a full slot
+// should have. No modelling constant, no wire change, self-calibrating per box
+// and per model.
+//
+// # Strictly tighter, and it cannot over-admit
+//
+// The ceiling is applied as min(advertised, learned) at every read, so the
+// admission gate never believes a LARGER budget than the heartbeat advertises.
+// It composes with — it does not replace — the clamp: while a clamp holds, the
+// pair is FULL exactly as before (the boolean is the ceiling at its tightest);
+// once the clamp releases, the learned ceiling keeps the pair off the
+// commitment level that just failed. Every state of this machine is at least
+// as tight as the pre-change behaviour at the same instant.
+//
+// # Recovery, and why it cannot strand a slot
+//
+//   - Draining: a ceiling only deselects while used+queued+request exceeds it.
+//     A busy box that finishes work is re-selected with no state change at all.
+//   - Widening: every budgetCeilingWidenAccepts accepts for the pair widen the
+//     ceiling by 1/budgetCeilingWidenDivisor of its current value; once it
+//     reaches the advertised budget the entry is deleted and the pair is back
+//     on pure heartbeat semantics. Accepts are the only provider-side proof
+//     that more fits than we learned.
+//   - TTL: an entry never outlives latchedAt+TTL. This is the fail-open bound
+//     for the one case widening cannot reach — a ceiling low enough to
+//     deselect the pair for every request size, which produces no accepts and
+//     so cannot widen.
+//
+// # Scope
+//
+// Learning requires (a) a reject the api layer classified as indicting the
+// PROVIDER (the same armClamp gate the clamp uses — a request-deterministic
+// oversized prompt or a cold "not loaded" miss says nothing about budget
+// arithmetic), (b) a pair that actually advertises a token budget, and (c) a
+// known request size. Without a request size the commitment that failed is
+// unknown, so RecordCapacityReject (the unsized entry point) records a strike
+// and a clamp but learns nothing.
+//
+// Keyed by the STABLE fault identity like every sibling breaker, migrated on
+// identity rebind (migrateFaultStateLocked) and deliberately NOT cleared by
+// Disconnect — a reconnect must not shed a learned ceiling any more than it
+// sheds a cooldown. Map bounded by the same opportunistic >1024 sweep. All
+// state guarded by r.mu; routing-path reads happen under r.mu in either mode.
+const (
+	// envBudgetCeiling is the kill switch. Default ON; set to false/0 to
+	// restore pure clamp-only behaviour (advertised budget believed in full
+	// the moment the clamp releases).
+	envBudgetCeiling = "EIGENINFERENCE_BUDGET_CEILING"
+	// envBudgetCeilingTTLSecs caps how long a learned ceiling survives its
+	// last latch — the fail-open bound. Default 600s.
+	envBudgetCeilingTTLSecs = "EIGENINFERENCE_BUDGET_CEILING_TTL_SECONDS"
+)
+
+const (
+	// defaultBudgetCeilingTTL deliberately outlives defaultBudgetClampTTL: the
+	// clamp's job is to stop the bleeding for one heartbeat cycle, this one's
+	// is to survive the heartbeat that would otherwise re-inflate the budget.
+	// A TTL at or below the clamp's would reproduce the treadmill one cycle
+	// later.
+	defaultBudgetCeilingTTL = 10 * time.Minute
+	// budgetCeilingMarginTokens is subtracted from the observed failing
+	// commitment so the SAME request at the SAME commitment is deselected
+	// rather than landing exactly on the boundary. 1024 is the provider's own
+	// minimum serving budget (BatchScheduler+Telemetry floors tokenBudgetMax
+	// there), reused so the hysteresis is one provider-minimum wide instead of
+	// an invented number.
+	budgetCeilingMarginTokens = budgetClampReleaseMinHeadroomTokens
+	// budgetCeilingFloorTokens keeps a learned ceiling positive. Below the
+	// provider's own minimum serving budget the pair could not serve anything
+	// at all, and a zero/negative ceiling would be a permanent clamp wearing a
+	// different name.
+	budgetCeilingFloorTokens = budgetClampReleaseMinHeadroomTokens
+	// budgetCeilingWidenAccepts is how many accepts for the pair it takes to
+	// widen the ceiling one step. Accepts are cheap on a serving box (first
+	// content chunk and clean completion both count), so recovery from an
+	// over-tight learn is seconds, not minutes.
+	budgetCeilingWidenAccepts = 4
+	// budgetCeilingWidenDivisor sets the step size: each widen adds
+	// ceiling/budgetCeilingWidenDivisor, i.e. +25%. Geometric on purpose — the
+	// distance back to the advertised budget is multiplicative (the paged
+	// over-statement is a ratio), so a fixed token step would take
+	// unboundedly long from a heavily derated ceiling.
+	budgetCeilingWidenDivisor = 4
+)
+
+// budgetCeilingConfig carries the env-tunable ceiling parameters, read once at
+// Registry construction (coordinator restart applies changes), mirroring
+// budgetClampConfig.
+type budgetCeilingConfig struct {
+	// Enabled is the kill switch (EIGENINFERENCE_BUDGET_CEILING, default true).
+	Enabled bool
+	// TTL is the fail-open bound: a ceiling never outlives latchedAt+TTL.
+	TTL time.Duration
+}
+
+// loadBudgetCeilingConfig reads the EIGENINFERENCE_BUDGET_CEILING* env
+// tunables, clamping nonsensical values back to the defaults.
+func loadBudgetCeilingConfig() budgetCeilingConfig {
+	cfg := budgetCeilingConfig{
+		Enabled: env.EnvBool(envBudgetCeiling, true),
+		TTL:     time.Duration(env.EnvInt(envBudgetCeilingTTLSecs, int(defaultBudgetCeilingTTL/time.Second))) * time.Second,
+	}
+	if cfg.TTL <= 0 {
+		cfg.TTL = defaultBudgetCeilingTTL
+	}
+	return cfg
+}
+
+// budgetCeilingEntry is one pair's learned ceiling. Written ONLY under the
+// r.mu write lock (latched in recordCapacityReject, widened in
+// RecordCapacityAcceptOutcome); routing paths read it under r.mu in either
+// mode.
+type budgetCeilingEntry struct {
+	// tokens is the learned effective token-budget max. Readers apply
+	// min(advertised, tokens), so this is a ceiling ON TOP of the heartbeat,
+	// never a substitute that could exceed it.
+	tokens int64
+	// latchedAt is when the last TIGHTENING reject landed — the TTL anchor.
+	// Widening does not move it: widening is the healthy path, the TTL is the
+	// fail-open bound on the unhealthy one.
+	latchedAt time.Time
+	// acceptsSince counts accepts since the last latch or widen step.
+	acceptsSince int
+}
+
+// recordBudgetCeilingLocked latches (or tightens) the pair's learned ceiling
+// from a capacity reject observed at commitment observedCommitment, against
+// the budget the pair was advertising at the time. Caller holds the r.mu WRITE
+// lock (called from recordCapacityReject).
+//
+// Only TIGHTENING rejects (re)latch. A reject whose implied ceiling is at or
+// above the advertised budget teaches nothing — the advertised number was
+// already the binding term, which is the ordinary "the box is genuinely full"
+// case the queue path owns — and refreshing the TTL off it would extend a
+// derating window on evidence that did not produce it.
+func (r *Registry) recordBudgetCeilingLocked(key capacityRejectKey, observedCommitment, advertised int64, now time.Time) {
+	if !r.budgetCeilingCfg.Enabled || observedCommitment <= 0 || advertised <= 0 {
+		return
+	}
+	learned := observedCommitment - budgetCeilingMarginTokens
+	if learned < budgetCeilingFloorTokens {
+		learned = budgetCeilingFloorTokens
+	}
+	if learned >= advertised {
+		return
+	}
+	// Opportunistic sweep (mirrors the sibling clamp/cooldown maps):
+	// session-keyed entries for churned identities are never re-keyed, so
+	// bound the map by dropping expired ceilings once it grows.
+	if len(r.budgetCeilings) > 1024 {
+		for k, e := range r.budgetCeilings {
+			if !now.Before(e.latchedAt.Add(r.budgetCeilingCfg.TTL)) {
+				delete(r.budgetCeilings, k)
+			}
+		}
+	}
+	// Ratchet: a live entry that already knows a TIGHTER ceiling keeps it. A
+	// reject cannot widen — only accepts can, and only through the widen path
+	// below. Without this a reject arriving at high commitment (a busy box)
+	// would undo what a reject at low commitment (the same box, gray) taught.
+	if prev, ok := r.budgetCeilings[key]; ok &&
+		now.Before(prev.latchedAt.Add(r.budgetCeilingCfg.TTL)) &&
+		prev.tokens < learned {
+		learned = prev.tokens
+	}
+	r.budgetCeilings[key] = &budgetCeilingEntry{tokens: learned, latchedAt: now}
+}
+
+// noteBudgetCeilingAcceptLocked records one accept for the pair and widens the
+// learned ceiling once budgetCeilingWidenAccepts have landed since the last
+// latch or widen. A ceiling that has caught up with (or passed) the pair's
+// currently advertised budget is DELETED: the pair is healed and belongs back
+// on pure heartbeat semantics, and a lingering entry would keep pulling every
+// later accept onto the write lock. An expired entry is deleted for the same
+// reason. Caller holds the r.mu WRITE lock (called from
+// RecordCapacityAcceptOutcome).
+func (r *Registry) noteBudgetCeilingAcceptLocked(providerID, modelID string, key capacityRejectKey, now time.Time) {
+	e, ok := r.budgetCeilings[key]
+	if !ok {
+		return
+	}
+	if !now.Before(e.latchedAt.Add(r.budgetCeilingCfg.TTL)) {
+		delete(r.budgetCeilings, key)
+		return
+	}
+	e.acceptsSince++
+	if e.acceptsSince < budgetCeilingWidenAccepts {
+		return
+	}
+	e.acceptsSince = 0
+	step := e.tokens / budgetCeilingWidenDivisor
+	if step < budgetCeilingMarginTokens {
+		// Guarantee progress: a ceiling small enough that the geometric step
+		// rounds to less than the margin would otherwise widen by nothing and
+		// wait out the TTL.
+		step = budgetCeilingMarginTokens
+	}
+	e.tokens += step
+	// Healed? Compare against what the pair advertises RIGHT NOW, not against
+	// the value at latch time — the advertised budget moves with residency and
+	// co-tenancy, and the entry only exists to hold the pair below it.
+	advertised, _ := r.providerBudgetCommitmentLocked(providerID, modelID)
+	if advertised > 0 && e.tokens >= advertised {
+		delete(r.budgetCeilings, key)
+	}
+}
+
+// budgetCeilingLocked returns the token-budget max admission must use for the
+// pair: min(advertised, learned ceiling), or advertised when nothing is
+// learned / the entry expired / the tracker is disabled. READ-ONLY (no lazy
+// delete) — routing paths call it under r.mu held in either mode, mirroring
+// budgetClampActiveLocked.
+func (r *Registry) budgetCeilingLocked(providerID, modelID string, advertised int64, now time.Time) int64 {
+	if !r.budgetCeilingCfg.Enabled || advertised <= 0 {
+		return advertised
+	}
+	e, ok := r.budgetCeilings[capacityRejectKey{ProviderID: r.faultKeyLocked(providerID), ModelID: modelID}]
+	if !ok || !now.Before(e.latchedAt.Add(r.budgetCeilingCfg.TTL)) {
+		return advertised
+	}
+	if e.tokens < advertised {
+		return e.tokens
+	}
+	return advertised
+}
+
+// BudgetCeiling reports the pair's learned effective token-budget ceiling and
+// whether one is currently latched. Exposed for tests and observability; the
+// routing hot path uses budgetCeilingLocked under the already-held r.mu.
+func (r *Registry) BudgetCeiling(providerID, modelID string) (tokens int64, latched bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if !r.budgetCeilingCfg.Enabled {
+		return 0, false
+	}
+	e, ok := r.budgetCeilings[capacityRejectKey{ProviderID: r.faultKeyLocked(providerID), ModelID: modelID}]
+	if !ok || !time.Now().Before(e.latchedAt.Add(r.budgetCeilingCfg.TTL)) {
+		return 0, false
+	}
+	return e.tokens, true
+}
+
+// effectiveTokenBudgetMax is the token-budget ceiling every LIVE admission
+// reader must use in place of the raw heartbeat value: the learned ceiling
+// when one is latched and tighter, the advertised budget otherwise.
+//
+// Zero-value safe on purpose. A snapshot built outside snapshotProviderLocked
+// (tests, and any future construction site) carries learnedTokenBudgetMax == 0,
+// which reads as "nothing learned" rather than as a zero budget.
+//
+// STRUCTURAL readers must NOT use this. snapshotStructuralBudget feeds the
+// fleet-level servability shed (PredictServable), whose "no" is a terminal
+// 429; a learned ceiling is transient, per-box evidence about live capacity
+// and would turn a merely-derated fleet into prompt_too_long. Same split the
+// clamp already draws (see liveRemainingBudget).
+func effectiveTokenBudgetMax(snap routingSnapshot) int64 {
+	if snap.learnedTokenBudgetMax > 0 && snap.learnedTokenBudgetMax < snap.activeTokenBudgetMax {
+		return snap.learnedTokenBudgetMax
+	}
+	return snap.activeTokenBudgetMax
+}

--- a/coordinator/registry/budget_ceiling.go
+++ b/coordinator/registry/budget_ceiling.go
@@ -36,11 +36,15 @@ import (
 //
 // The intercept is unknown to the coordinator and differs per box, per model
 // and per batch shape, so this does not model it. It MEASURES it. On a
-// capacity reject the coordinator knows the exact commitment that failed:
+// capacity reject the coordinator knows the commitment that failed:
 //
-//	S = active_token_budget_used + queued_token_budget + requestTokens
+//	S = max(used + queued, pendingForModel − requestTokens) + requestTokens
 //
-// all three in the same units the admission gate itself uses. Latching
+// in the same units the admission gate charges. The max matters: the heartbeat
+// half (used+queued) lags a burst by up to one heartbeat interval, and the
+// coordinator's own pending half is exactly the coordinatorExtra term
+// freeMemoryAdmits adds for that reason. Learning off the heartbeat alone would
+// read used≈0 mid-burst and latch an order of magnitude too tight. Latching
 //
 //	effectiveMax = min(advertised, S − budgetCeilingMarginTokens)
 //
@@ -71,11 +75,17 @@ import (
 //     ceiling by 1/budgetCeilingWidenDivisor of its current value; once it
 //     reaches the advertised budget the entry is deleted and the pair is back
 //     on pure heartbeat semantics. Accepts are the only provider-side proof
-//     that more fits than we learned.
+//     that more fits than we learned. This route is only open when SOME request
+//     size still fits under the ceiling: it is fast for a pair whose traffic
+//     straddles the ceiling (~40 short requests to climb 1k→90k) and closed
+//     for a pair whose traffic is uniformly larger than it.
 //   - TTL: an entry never outlives latchedAt+TTL. This is the fail-open bound
-//     for the one case widening cannot reach — a ceiling low enough to
-//     deselect the pair for every request size, which produces no accepts and
-//     so cannot widen.
+//     for exactly the case widening cannot reach — a ceiling low enough to
+//     deselect the pair for every request size the model actually receives, so
+//     no accept can land. Such a pair is dark for the remainder of the TTL and
+//     nothing but the TTL recovers it, which is why non-tightening rejects must
+//     not refresh the anchor (see recordBudgetCeilingLocked) and why the
+//     latch/heal transitions are logged.
 //
 // # Scope
 //
@@ -189,21 +199,28 @@ func (r *Registry) recordBudgetCeilingLocked(key capacityRejectKey, observedComm
 		return
 	}
 	learned := observedCommitment - budgetCeilingMarginTokens
-	// Never learn a ceiling BELOW what the pair reports it is already holding.
-	// The margin exists to push the next identical request off the boundary,
-	// but for a request smaller than the margin it would otherwise push the
-	// ceiling under the live commitment — a number the provider's own report
-	// contradicts, and one low enough to deselect the pair for every request
-	// size (which produces no accepts, so only the TTL could recover it). The
-	// gate still rejects the request that failed: any positive demand on top
-	// of a ceiling equal to the commitment does not fit.
+	// Never learn a ceiling BELOW what the pair was already holding without
+	// this request. The margin exists to push the next identical request off
+	// the boundary, but for a request smaller than the margin it would
+	// otherwise push the ceiling under the live commitment — a number the
+	// pair's own accounting contradicts, and one low enough to deselect the
+	// pair for every request size (which produces no accepts, so only the TTL
+	// could recover it). The gate still rejects the request that failed: any
+	// positive demand on top of a ceiling equal to the base does not fit.
 	if learned < alreadyCommitted {
 		learned = alreadyCommitted
 	}
 	if learned < budgetCeilingFloorTokens {
 		learned = budgetCeilingFloorTokens
 	}
-	if learned >= advertised {
+	// A ceiling at or above the commitment that just failed changes no
+	// decision — the identical request at the identical commitment is
+	// re-admitted — and a ceiling at or above the advertised budget is
+	// dominated by the heartbeat. Either way the entry would gate nothing
+	// while still burning a TTL and the accept bookkeeping, so do not create
+	// one. (The first case is reachable only when the floor binds, i.e. the
+	// whole failing commitment was under one provider-minimum budget.)
+	if learned >= observedCommitment || learned >= advertised {
 		return
 	}
 	// Opportunistic sweep (mirrors the sibling clamp/cooldown maps):
@@ -216,16 +233,33 @@ func (r *Registry) recordBudgetCeilingLocked(key capacityRejectKey, observedComm
 			}
 		}
 	}
-	// Ratchet: a live entry that already knows a TIGHTER ceiling keeps it. A
-	// reject cannot widen — only accepts can, and only through the widen path
-	// below. Without this a reject arriving at high commitment (a busy box)
-	// would undo what a reject at low commitment (the same box, gray) taught.
+	// Ratchet: a live entry that already knows a ceiling at least this tight
+	// keeps it, TTL ANCHOR INCLUDED. A reject cannot widen — only accepts can,
+	// and only through the widen path below — so without the token half a
+	// reject arriving at high commitment (a busy box) would undo what a reject
+	// at low commitment (the same box, gray) taught. And without the latchedAt
+	// half, a non-tightening reject would refresh the TTL off evidence that
+	// did not produce the ceiling, extending the derating window for free. The
+	// reject does reset progress toward widening: it is direct evidence
+	// against the accepts that had accumulated.
 	if prev, ok := r.budgetCeilings[key]; ok &&
 		now.Before(prev.latchedAt.Add(r.budgetCeilingCfg.TTL)) &&
-		prev.tokens < learned {
-		learned = prev.tokens
+		prev.tokens <= learned {
+		prev.acceptsSince = 0
+		return
 	}
 	r.budgetCeilings[key] = &budgetCeilingEntry{tokens: learned, latchedAt: now}
+	if r.logger != nil {
+		// The only window into this mechanism during an incident: which pair,
+		// how far below its own advertised budget, and off what commitment.
+		r.logger.Warn("budget ceiling latched",
+			"provider_id", key.ProviderID,
+			"model", key.ModelID,
+			"learned_tokens", learned,
+			"advertised_tokens", advertised,
+			"failing_commitment_tokens", observedCommitment,
+			"latched_pairs", len(r.budgetCeilings))
+	}
 }
 
 // noteBudgetCeilingAcceptLocked records one accept for the pair and widens the
@@ -264,6 +298,13 @@ func (r *Registry) noteBudgetCeilingAcceptLocked(providerID, modelID string, key
 	advertised, _ := r.providerBudgetCommitmentLocked(providerID, modelID)
 	if advertised > 0 && e.tokens >= advertised {
 		delete(r.budgetCeilings, key)
+		if r.logger != nil {
+			r.logger.Info("budget ceiling healed",
+				"provider_id", key.ProviderID,
+				"model", key.ModelID,
+				"advertised_tokens", advertised,
+				"latched_pairs", len(r.budgetCeilings))
+		}
 	}
 }
 
@@ -300,24 +341,4 @@ func (r *Registry) BudgetCeiling(providerID, modelID string) (tokens int64, latc
 		return 0, false
 	}
 	return e.tokens, true
-}
-
-// effectiveTokenBudgetMax is the token-budget ceiling every LIVE admission
-// reader must use in place of the raw heartbeat value: the learned ceiling
-// when one is latched and tighter, the advertised budget otherwise.
-//
-// Zero-value safe on purpose. A snapshot built outside snapshotProviderLocked
-// (tests, and any future construction site) carries learnedTokenBudgetMax == 0,
-// which reads as "nothing learned" rather than as a zero budget.
-//
-// STRUCTURAL readers must NOT use this. snapshotStructuralBudget feeds the
-// fleet-level servability shed (PredictServable), whose "no" is a terminal
-// 429; a learned ceiling is transient, per-box evidence about live capacity
-// and would turn a merely-derated fleet into prompt_too_long. Same split the
-// clamp already draws (see liveRemainingBudget).
-func effectiveTokenBudgetMax(snap routingSnapshot) int64 {
-	if snap.learnedTokenBudgetMax > 0 && snap.learnedTokenBudgetMax < snap.activeTokenBudgetMax {
-		return snap.learnedTokenBudgetMax
-	}
-	return snap.activeTokenBudgetMax
 }

--- a/coordinator/registry/budget_ceiling_test.go
+++ b/coordinator/registry/budget_ceiling_test.go
@@ -190,12 +190,28 @@ func TestBudgetCeilingLatchBoundaries(t *testing.T) {
 	t.Run("floored at the provider minimum serving budget", func(t *testing.T) {
 		r := New(testLogger())
 		now := time.Now()
-		// A reject at a tiny commitment would imply a negative ceiling; a
-		// zero/negative ceiling is a permanent clamp wearing a different name.
-		r.recordBudgetCeilingLocked(key, 10, 0, 100_000, now)
+		// A reject at a small commitment would imply a ceiling below the
+		// provider's own minimum serving budget; a zero/negative ceiling is a
+		// permanent clamp wearing a different name. The floor still binds
+		// here, because the failing commitment is above it.
+		r.recordBudgetCeilingLocked(key, budgetCeilingFloorTokens+500, 0, 100_000, now)
 		got, latched := r.BudgetCeiling("box", model)
 		if !latched || got != budgetCeilingFloorTokens {
 			t.Fatalf("ceiling = (%d, %v), want (%d, true)", got, latched, budgetCeilingFloorTokens)
+		}
+	})
+
+	t.Run("no entry when the floor would gate nothing", func(t *testing.T) {
+		r := New(testLogger())
+		now := time.Now()
+		// The whole failing commitment fits under one provider-minimum budget,
+		// so the floored ceiling lands at or above it: the identical request at
+		// the identical commitment would be re-admitted. Such an entry gates
+		// nothing while still burning a TTL and the accept bookkeeping, so it
+		// must not be created at all.
+		r.recordBudgetCeilingLocked(key, budgetCeilingFloorTokens-1, 0, 100_000, now)
+		if _, latched := r.BudgetCeiling("box", model); latched {
+			t.Fatal("a ceiling that cannot gate the request that produced it must not be latched")
 		}
 	})
 
@@ -223,17 +239,27 @@ func TestBudgetCeilingLatchBoundaries(t *testing.T) {
 		}
 	})
 
-	t.Run("rejects ratchet down, never up", func(t *testing.T) {
+	t.Run("rejects ratchet down, never up, and do not refresh the TTL", func(t *testing.T) {
 		r := New(testLogger())
 		now := time.Now()
 		r.recordBudgetCeilingLocked(key, 50_000, 0, 1_000_000, now)
 		tight, _ := r.BudgetCeiling("box", model)
 		// A later reject at a HIGHER commitment (the box was busier) must not
 		// undo what the tighter one taught. Only accepts widen.
-		r.recordBudgetCeilingLocked(key, 900_000, 800_000, 1_000_000, now)
+		later := now.Add(time.Minute)
+		r.recordBudgetCeilingLocked(key, 900_000, 800_000, 1_000_000, later)
 		got, _ := r.BudgetCeiling("box", model)
 		if got != tight {
 			t.Fatalf("ceiling = %d after a looser reject, want the ratcheted %d", got, tight)
+		}
+		// …and it must not have moved the TTL anchor either. A derating window
+		// extended by evidence that did not produce the ceiling is how a
+		// bounded fail-open becomes an unbounded one.
+		r.mu.RLock()
+		anchor := r.budgetCeilings[key].latchedAt
+		r.mu.RUnlock()
+		if !anchor.Equal(now) {
+			t.Fatalf("TTL anchor = %v, want the original latch %v — a non-tightening reject must not refresh it", anchor, now)
 		}
 	})
 
@@ -335,26 +361,174 @@ func TestBudgetCeilingDeletedOnceHealed(t *testing.T) {
 // An identity rebind (session id → SE key → serial) must carry the TIGHTER
 // ceiling, not the fresher one. A rebind is not evidence about capacity, and
 // taking the later entry would let it widen a ceiling only accepts may widen.
+// Expiry decides FIRST though: an expired entry has no evidentiary standing on
+// either side, and comparing tokens blind would let an expired-but-tighter
+// source silently destroy a live destination (the survivor would carry the
+// source's stale anchor, so it would read as expired and gate nothing).
 func TestBudgetCeilingMigratesTighterOnIdentityRebind(t *testing.T) {
 	const model = "m"
-	r := New(testLogger())
-	now := time.Now()
+	oldKey := capacityRejectKey{ProviderID: "old", ModelID: model}
+	newKey := capacityRejectKey{ProviderID: "new", ModelID: model}
 
-	r.mu.Lock()
-	r.budgetCeilings[capacityRejectKey{ProviderID: "old", ModelID: model}] =
-		&budgetCeilingEntry{tokens: 20_000, latchedAt: now.Add(-time.Minute)}
-	r.budgetCeilings[capacityRejectKey{ProviderID: "new", ModelID: model}] =
-		&budgetCeilingEntry{tokens: 90_000, latchedAt: now}
-	r.migrateFaultStateLocked("old", "new")
-	got, ok := r.budgetCeilings[capacityRejectKey{ProviderID: "new", ModelID: model}]
-	_, oldStillThere := r.budgetCeilings[capacityRejectKey{ProviderID: "old", ModelID: model}]
-	r.mu.Unlock()
+	for name, tc := range map[string]struct {
+		source, dest *budgetCeilingEntry // nil = absent
+		wantTokens   int64               // 0 = nothing survives
+	}{
+		"tighter live source wins": {
+			source: &budgetCeilingEntry{tokens: 20_000}, dest: &budgetCeilingEntry{tokens: 90_000},
+			wantTokens: 20_000,
+		},
+		"tighter live destination is kept": {
+			source: &budgetCeilingEntry{tokens: 90_000}, dest: &budgetCeilingEntry{tokens: 20_000},
+			wantTokens: 20_000,
+		},
+		"expired source must not displace a live destination": {
+			source: &budgetCeilingEntry{tokens: 20_000, latchedAt: time.Now().Add(-time.Hour)},
+			dest:   &budgetCeilingEntry{tokens: 90_000},
+			// The tighter number is expired evidence: the live 90k stands.
+			wantTokens: 90_000,
+		},
+		"expired source alone is dropped": {
+			source:     &budgetCeilingEntry{tokens: 20_000, latchedAt: time.Now().Add(-time.Hour)},
+			wantTokens: 0,
+		},
+		"live source moves onto an empty key": {
+			source: &budgetCeilingEntry{tokens: 20_000}, wantTokens: 20_000,
+		},
+		"live source replaces an expired destination": {
+			source: &budgetCeilingEntry{tokens: 90_000},
+			dest:   &budgetCeilingEntry{tokens: 20_000, latchedAt: time.Now().Add(-time.Hour)},
+			// Looser, but it is the only entry with standing.
+			wantTokens: 90_000,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			r := New(testLogger())
+			now := time.Now()
+			r.mu.Lock()
+			defer r.mu.Unlock()
+			for key, e := range map[capacityRejectKey]*budgetCeilingEntry{oldKey: tc.source, newKey: tc.dest} {
+				if e == nil {
+					continue
+				}
+				if e.latchedAt.IsZero() {
+					e.latchedAt = now
+				}
+				r.budgetCeilings[key] = e
+			}
+			r.migrateFaultStateLocked("old", "new")
 
-	if !ok || got.tokens != 20_000 {
-		t.Fatalf("migrated ceiling = %v, want the tighter 20000", got)
+			if _, ok := r.budgetCeilings[oldKey]; ok {
+				t.Fatal("old-key entry must always be removed by the migration")
+			}
+			got, ok := r.budgetCeilings[newKey]
+			if tc.wantTokens == 0 {
+				if ok {
+					t.Fatalf("ceiling %d survived, want nothing to migrate", got.tokens)
+				}
+				return
+			}
+			if !ok || got.tokens != tc.wantTokens {
+				t.Fatalf("migrated ceiling = %v, want %d", got, tc.wantTokens)
+			}
+			// Whatever survived must still be able to gate: an entry whose
+			// anchor is already expired is indistinguishable from no entry.
+			if !now.Before(got.latchedAt.Add(r.budgetCeilingCfg.TTL)) {
+				t.Fatal("the surviving entry carries an expired anchor — it gates nothing")
+			}
+		})
 	}
-	if oldStillThere {
-		t.Fatal("old-key entry must be removed by the migration")
+}
+
+// THE STARVATION PATH, pinned. A ceiling low enough to deselect the pair for
+// EVERY request size the model receives produces no accepts, so widening is
+// unreachable and the TTL is the only recovery. That is the design's most
+// consequential failure mode: this test states it explicitly so nobody
+// discovers it in production, and pins the TTL as the bound on it.
+func TestBudgetCeilingStarvationRecoversOnlyOnTTL(t *testing.T) {
+	const model = "m"
+	r := New(testLogger())
+	// A model whose traffic is uniformly long: every request is ~20k tokens,
+	// so nothing fits under a ceiling learned near that size.
+	p := makeTokenBudgetProvider(t, r, "box", model, 100, 0, pagedAdvertisedTokens, 100)
+	sendBudgetHeartbeat(r, p.ID, model, 0, pagedAdvertisedTokens)
+
+	r.RecordCapacityRejectSized(p.ID, model, int(pagedRequestTokens))
+	learned, latched := r.BudgetCeiling(p.ID, model)
+	if !latched || learned >= pagedRequestTokens {
+		t.Fatalf("setup: ceiling = (%d, %v), want a latch below the %d request size",
+			learned, latched, pagedRequestTokens)
+	}
+	// Release the one-shot clamp so the CEILING is unambiguously what gates
+	// from here. The release accept is the straggler that was already in
+	// flight when the latch landed — one accept, three short of a widen step,
+	// and a dark pair cannot earn the other three.
+	r.RecordCapacityAccept(p.ID, model)
+	time.Sleep(2 * time.Millisecond)
+	sendBudgetHeartbeat(r, p.ID, model, 0, pagedAdvertisedTokens)
+	if r.BudgetClampActive(p.ID, model) {
+		t.Fatal("setup: the one-shot clamp must release, or it is the clamp under test and not the ceiling")
+	}
+
+	// Dark: the box is idle, nothing is committed, and it is STILL deselected —
+	// draining cannot help, because the ceiling is below one request.
+	if sel := reserveSized(r, model, "starved"); sel != nil {
+		t.Fatal("setup: a ceiling below one request size must deselect an idle pair")
+	}
+	// No dispatch ⇒ no accept ⇒ no widen. Even the accepts the widen path
+	// wants cannot be manufactured, which is the point.
+	if _, stillLatched := r.BudgetCeiling(p.ID, model); !stillLatched {
+		t.Fatal("nothing but the TTL may retire a starved ceiling")
+	}
+
+	ageBudgetCeiling(r, p.ID, model, r.budgetCeilingCfg.TTL+time.Second)
+	if _, stillLatched := r.BudgetCeiling(p.ID, model); stillLatched {
+		t.Fatal("the TTL is the fail-open bound on starvation; it must expire the ceiling")
+	}
+	if sel := reserveSized(r, model, "recovered"); sel == nil {
+		t.Fatal("pair must be selectable again once the ceiling expires")
+	}
+}
+
+// THE BURST. The heartbeat's committed figure lags by up to one heartbeat
+// interval, so a burst that the coordinator itself dispatched is invisible in
+// it. Learning off the heartbeat alone would read used≈0 mid-burst and latch a
+// ceiling an order of magnitude tighter than the evidence supports; the
+// commitment must therefore be max(heartbeat, coordinator pending), which is
+// the same quantity freeMemoryAdmits charges as coordinatorExtra.
+func TestBudgetCeilingLearnsFromInGapPendingNotJustTheHeartbeat(t *testing.T) {
+	const model = "m"
+	r := New(testLogger())
+	// Heartbeat says the box is EMPTY: used+queued = 0 at a huge advertised
+	// budget. This is the honest report from before the burst landed.
+	p := makeTokenBudgetProvider(t, r, "box", model, 100, 0, pagedAdvertisedTokens, 100)
+	sendBudgetHeartbeat(r, p.ID, model, 0, pagedAdvertisedTokens)
+
+	// Six ~20k requests dispatched inside the heartbeat gap. The coordinator
+	// knows about all of them; the provider's last report does not.
+	var burst int64
+	for i := 0; i < 6; i++ {
+		p.AddPending(&PendingRequest{
+			RequestID:             "burst-" + string(rune('a'+i)),
+			Model:                 model,
+			EstimatedPromptTokens: pagedRequestPrompt,
+			RequestedMaxTokens:    pagedRequestMaxTokens,
+		})
+		burst += pagedRequestTokens
+	}
+
+	// The sixth one comes back token_budget_exhausted: the affine pool is full.
+	r.RecordCapacityRejectSized(p.ID, model, int(pagedRequestTokens))
+
+	got, latched := r.BudgetCeiling(p.ID, model)
+	if !latched {
+		t.Fatal("a sized capacity reject must latch a ceiling")
+	}
+	// Heartbeat-only would have learned requestTokens − margin ≈ 19k. The
+	// honest commitment is the whole burst the coordinator had placed.
+	if want := burst - budgetCeilingMarginTokens; got != want {
+		t.Fatalf("ceiling = %d, want %d (the full in-gap commitment, not the %d a stale heartbeat implies)",
+			got, want, pagedRequestTokens-budgetCeilingMarginTokens)
 	}
 }
 

--- a/coordinator/registry/budget_ceiling_test.go
+++ b/coordinator/registry/budget_ceiling_test.go
@@ -1,0 +1,402 @@
+package registry
+
+import (
+	"testing"
+	"time"
+)
+
+// Tests for the learned effective token-budget ceiling (budget_ceiling.go).
+//
+// Regression suite for the v0.8.0 paged rollout: a paged slot advertises
+// poolBytes / kvBytesPerToken, where kvBytesPerToken is the MARGINAL
+// long-context rate, while the pool's real charge is AFFINE (a fixed
+// sliding-window ring per in-flight sequence plus the marginal per-token
+// cost). The advertised budget therefore over-states concurrent capacity by
+// ~1.6× at batch 8, which makes the one-shot clamp's release condition — raw
+// max − used − queued ≥ 1024 — true on the very next heartbeat, forever. The
+// clamp becomes a treadmill: bounce one request, release, bounce again.
+
+// Paged gemma-4 shape on a 96 GiB box: a 6 GiB pool at the slot's reported
+// 20,480 B/token marginal rate advertises ~314k tokens. Six ~20k-token
+// sequences (120k tokens of reported commitment) already exhaust it, because
+// each also costs a ~303 MiB ring the wire budget does not price.
+const (
+	pagedAdvertisedTokens = int64(314_572) // 6 GiB / 20,480 B per token
+	pagedCommittedTokens  = int64(120_000) // six in-flight ~20k sequences
+	pagedRequestPrompt    = 20_000
+	pagedRequestMaxTokens = 256
+)
+
+// pagedRequestTokens is what the seventh request asks for, in the same units
+// the admission gate speaks.
+const pagedRequestTokens = int64(pagedRequestPrompt + pagedRequestMaxTokens)
+
+// reserveSized runs the production reservation path once for a request of the
+// paged shape above and releases the reservation, returning the selected
+// provider (nil = no route).
+func reserveSized(r *Registry, model, requestID string) *Provider {
+	p, _ := r.ReserveProviderEx(model, &PendingRequest{
+		RequestID:             requestID,
+		Model:                 model,
+		EstimatedPromptTokens: pagedRequestPrompt,
+		RequestedMaxTokens:    pagedRequestMaxTokens,
+	})
+	if p != nil {
+		p.RemovePending(requestID)
+		r.SetProviderIdle(p.ID)
+	}
+	return p
+}
+
+// proveClampRelease delivers the clamp's two release conditions — an accept
+// and a strictly-fresher heartbeat with meaningful headroom — restating the
+// SAME inflated budget the provider reported before the reject. That is the
+// treadmill: the heartbeat is not stale, it is honestly reporting a number
+// whose model of the pool is wrong, so it always satisfies release.
+func proveClampRelease(t *testing.T, r *Registry, providerID, model string) {
+	t.Helper()
+	r.RecordCapacityAccept(providerID, model)
+	time.Sleep(2 * time.Millisecond)
+	sendBudgetHeartbeat(r, providerID, model, pagedCommittedTokens, pagedAdvertisedTokens)
+	if r.BudgetClampActive(providerID, model) {
+		t.Fatal("setup: the one-shot clamp must release here — that is the treadmill this test is about")
+	}
+}
+
+// ageBudgetCeiling rewinds the pair's ceiling latch by d (simulating TTL
+// passage without sleeping), keyed by the pair's CURRENT fault key.
+func ageBudgetCeiling(r *Registry, providerID, model string, d time.Duration) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	key := capacityRejectKey{ProviderID: r.faultKeyLocked(providerID), ModelID: model}
+	if e, ok := r.budgetCeilings[key]; ok {
+		e.latchedAt = e.latchedAt.Add(-d)
+	}
+}
+
+// THE TREADMILL. A pair whose advertised budget is structurally inflated
+// satisfies the clamp's release condition on the very next heartbeat, so
+// clamp-only behaviour re-selects it at the exact commitment that just failed —
+// one bounced request per heartbeat, indefinitely. The learned ceiling must
+// outlive the clamp and deselect the pair BEFORE dispatch, and must widen back
+// once the pair proves (through sustained accepts) that more fits.
+func TestBudgetCeilingBreaksTheClampTreadmill(t *testing.T) {
+	const model = "gemma-4-26b-qat-4bit"
+	r := New(testLogger())
+	p := makeTokenBudgetProvider(t, r, "paged-box", model, 100, pagedCommittedTokens, pagedAdvertisedTokens, 100)
+	sendBudgetHeartbeat(r, p.ID, model, pagedCommittedTokens, pagedAdvertisedTokens)
+
+	if sel := reserveSized(r, model, "seventh"); sel == nil {
+		t.Fatal("setup: the request must fit the ADVERTISED budget — that is why it is dispatched and then rejected")
+	}
+
+	// The provider rejects it: the pool is affine and physically full.
+	r.RecordCapacityRejectSized(p.ID, model, int(pagedRequestTokens))
+
+	wantCeiling := pagedCommittedTokens + pagedRequestTokens - budgetCeilingMarginTokens
+	gotCeiling, latched := r.BudgetCeiling(p.ID, model)
+	if !latched || gotCeiling != wantCeiling {
+		t.Fatalf("learned ceiling = (%d, latched=%v), want (%d, true) — min(advertised, used+queued+request-margin)",
+			gotCeiling, latched, wantCeiling)
+	}
+
+	// The clamp releases on the next heartbeat, exactly as it does in prod.
+	proveClampRelease(t, r, p.ID, model)
+
+	// THE ASSERTION. Same commitment, same request, released clamp: the pair
+	// must NOT be re-selected. The request falls to the queue-before-shed
+	// spill instead of being dispatched into a guaranteed rejection.
+	if sel := reserveSized(r, model, "eighth"); sel != nil {
+		t.Fatalf("pair %s re-selected at the same commitment after the clamp released — the treadmill is still running", sel.ID)
+	}
+
+	// Sustained accepts are the only provider-side proof that more fits than
+	// the reject taught us. One widen step must restore selection.
+	for i := 1; i < budgetCeilingWidenAccepts; i++ {
+		r.RecordCapacityAccept(p.ID, model)
+	}
+	widened, stillLatched := r.BudgetCeiling(p.ID, model)
+	if !stillLatched || widened <= wantCeiling {
+		t.Fatalf("ceiling after %d accepts = (%d, latched=%v), want a value above %d",
+			budgetCeilingWidenAccepts, widened, stillLatched, wantCeiling)
+	}
+	if widened < pagedCommittedTokens+pagedRequestTokens {
+		t.Fatalf("widen step too small: ceiling %d still below the %d commitment it must re-admit",
+			widened, pagedCommittedTokens+pagedRequestTokens)
+	}
+	if sel := reserveSized(r, model, "ninth"); sel == nil {
+		t.Fatal("pair must be selectable again once accepts widened the ceiling past the commitment")
+	}
+}
+
+// The kill switch restores exactly the pre-change behaviour: clamp releases,
+// pair is re-selected at the failing commitment. This is what the test above
+// is a fix for, pinned so the two cannot silently converge.
+func TestBudgetCeilingKillSwitchRestoresTreadmill(t *testing.T) {
+	const model = "gemma-4-26b-qat-4bit"
+	t.Setenv(envBudgetCeiling, "false")
+	r := New(testLogger())
+	p := makeTokenBudgetProvider(t, r, "paged-box", model, 100, pagedCommittedTokens, pagedAdvertisedTokens, 100)
+	sendBudgetHeartbeat(r, p.ID, model, pagedCommittedTokens, pagedAdvertisedTokens)
+
+	r.RecordCapacityRejectSized(p.ID, model, int(pagedRequestTokens))
+	if _, latched := r.BudgetCeiling(p.ID, model); latched {
+		t.Fatal("kill switch off must learn nothing")
+	}
+	proveClampRelease(t, r, p.ID, model)
+	if sel := reserveSized(r, model, "again"); sel == nil {
+		t.Fatal("with the ceiling disabled the pair must be re-selected — the documented pre-change behaviour")
+	}
+}
+
+// A learned ceiling can only ever TIGHTEN admission relative to the advertised
+// budget. It is applied as min(advertised, learned) at every read, so no state
+// of this machine can admit a request the raw heartbeat would have refused.
+func TestBudgetCeilingNeverExceedsAdvertised(t *testing.T) {
+	const model = "m"
+	r := New(testLogger())
+	key := capacityRejectKey{ProviderID: "box", ModelID: model}
+	now := time.Now()
+
+	// A ceiling learned against a large advertised budget must not survive as
+	// an over-statement once the pair advertises much less (co-tenancy, a
+	// smaller re-slice).
+	r.recordBudgetCeilingLocked(key, 200_000, 1_000_000, now)
+	if got := r.budgetCeilingLocked("box", model, 50_000, now); got != 50_000 {
+		t.Fatalf("effective max = %d, want the smaller advertised 50000 — the ceiling is a cap, not a substitute", got)
+	}
+	if got := r.budgetCeilingLocked("box", model, 1_000_000, now); got != 200_000-budgetCeilingMarginTokens {
+		t.Fatalf("effective max = %d, want the learned %d", got, 200_000-budgetCeilingMarginTokens)
+	}
+}
+
+// Boundary behaviour of the latch itself.
+func TestBudgetCeilingLatchBoundaries(t *testing.T) {
+	const model = "m"
+	key := capacityRejectKey{ProviderID: "box", ModelID: model}
+
+	t.Run("no latch when the implied ceiling is not tighter than advertised", func(t *testing.T) {
+		r := New(testLogger())
+		now := time.Now()
+		// The box rejected AT its advertised budget: the advertised number was
+		// already binding, so there is nothing to learn (ordinary fullness,
+		// owned by the queue path).
+		r.recordBudgetCeilingLocked(key, 100_000+budgetCeilingMarginTokens, 100_000, now)
+		if _, latched := r.BudgetCeiling("box", model); latched {
+			t.Fatal("a reject at or above the advertised budget must teach nothing")
+		}
+	})
+
+	t.Run("floored at the provider minimum serving budget", func(t *testing.T) {
+		r := New(testLogger())
+		now := time.Now()
+		// A reject at a tiny commitment would imply a negative ceiling; a
+		// zero/negative ceiling is a permanent clamp wearing a different name.
+		r.recordBudgetCeilingLocked(key, 10, 100_000, now)
+		got, latched := r.BudgetCeiling("box", model)
+		if !latched || got != budgetCeilingFloorTokens {
+			t.Fatalf("ceiling = (%d, %v), want (%d, true)", got, latched, budgetCeilingFloorTokens)
+		}
+	})
+
+	t.Run("rejects ratchet down, never up", func(t *testing.T) {
+		r := New(testLogger())
+		now := time.Now()
+		r.recordBudgetCeilingLocked(key, 50_000, 1_000_000, now)
+		tight, _ := r.BudgetCeiling("box", model)
+		// A later reject at a HIGHER commitment (the box was busier) must not
+		// undo what the tighter one taught. Only accepts widen.
+		r.recordBudgetCeilingLocked(key, 900_000, 1_000_000, now)
+		got, _ := r.BudgetCeiling("box", model)
+		if got != tight {
+			t.Fatalf("ceiling = %d after a looser reject, want the ratcheted %d", got, tight)
+		}
+	})
+
+	t.Run("unlearnable inputs are no-ops", func(t *testing.T) {
+		r := New(testLogger())
+		now := time.Now()
+		r.recordBudgetCeilingLocked(key, 0, 1_000_000, now)  // no request size
+		r.recordBudgetCeilingLocked(key, 50_000, 0, now)     // budgetless pair
+		r.recordBudgetCeilingLocked(key, -1, 1_000_000, now) // nonsense commitment
+		if _, latched := r.BudgetCeiling("box", model); latched {
+			t.Fatal("a ceiling cannot be learned without both a commitment and an advertised budget")
+		}
+	})
+
+	t.Run("TTL fails open", func(t *testing.T) {
+		r := New(testLogger())
+		p := makeTokenBudgetProvider(t, r, "box", model, 100, 0, 1_000_000, 100)
+		r.RecordCapacityRejectSized(p.ID, model, 50_000)
+		if _, latched := r.BudgetCeiling(p.ID, model); !latched {
+			t.Fatal("setup: ceiling must latch")
+		}
+		ageBudgetCeiling(r, p.ID, model, r.budgetCeilingCfg.TTL+time.Second)
+		if _, latched := r.BudgetCeiling(p.ID, model); latched {
+			t.Fatal("an expired ceiling must fail open — widening cannot rescue a ceiling that blocks every request size")
+		}
+		r.mu.RLock()
+		effective := r.budgetCeilingLocked(p.ID, model, 1_000_000, time.Now())
+		r.mu.RUnlock()
+		if effective != 1_000_000 {
+			t.Fatalf("expired ceiling still gating: effective max = %d, want the advertised 1000000", effective)
+		}
+	})
+}
+
+// The size-less entry point records a strike and a clamp but teaches nothing:
+// without the request size the commitment that failed is unknown, and a
+// ceiling learned from used+queued alone would be tighter than the evidence.
+func TestBudgetCeilingRequiresASizedReject(t *testing.T) {
+	const model = "m"
+	r := New(testLogger())
+	p := makeTokenBudgetProvider(t, r, "box", model, 100, 100_000, 1_000_000, 100)
+
+	r.RecordCapacityReject(p.ID, model)
+	if _, latched := r.BudgetCeiling(p.ID, model); latched {
+		t.Fatal("an unsized reject must not latch a ceiling")
+	}
+	if !r.BudgetClampActive(p.ID, model) {
+		t.Fatal("an unsized reject must still arm the one-shot clamp")
+	}
+}
+
+// Rejects that indict the REQUEST (an oversized prompt, a cold "not loaded"
+// miss, an admission timeout) say nothing about the pair's budget arithmetic
+// and must arm neither gray-box tracker — the same armClamp gate the clamp
+// already honours.
+func TestBudgetCeilingNotArmedByNonProviderRejects(t *testing.T) {
+	const model = "m"
+	for name, record := range map[string]func(*Registry, string){
+		"lifecycle":     func(r *Registry, id string) { r.RecordCapacityRejectLifecycle(id, model) },
+		"request_shape": func(r *Registry, id string) { r.RecordCapacityRejectRequestShape(id, model) },
+		"busy":          func(r *Registry, id string) { r.RecordCapacityRejectBusy(id, model) },
+	} {
+		t.Run(name, func(t *testing.T) {
+			r := New(testLogger())
+			p := makeTokenBudgetProvider(t, r, "box", model, 100, 100_000, 1_000_000, 100)
+			record(r, p.ID)
+			if _, latched := r.BudgetCeiling(p.ID, model); latched {
+				t.Fatalf("%s reject must not latch a budget ceiling", name)
+			}
+		})
+	}
+}
+
+// A ceiling that catches up with the advertised budget is DELETED, not left
+// pinned at parity: the pair is healed and belongs back on pure heartbeat
+// semantics, and a lingering entry keeps pulling every later accept onto the
+// registry write lock.
+func TestBudgetCeilingDeletedOnceHealed(t *testing.T) {
+	const model = "m"
+	r := New(testLogger())
+	p := makeTokenBudgetProvider(t, r, "box", model, 100, 0, 8_000, 100)
+	sendBudgetHeartbeat(r, p.ID, model, 0, 8_000)
+
+	r.RecordCapacityRejectSized(p.ID, model, 5_000)
+	if _, latched := r.BudgetCeiling(p.ID, model); !latched {
+		t.Fatal("setup: ceiling must latch below the 8000 advertised budget")
+	}
+	// Widen repeatedly; +25% per budgetCeilingWidenAccepts accepts reaches
+	// 8000 from 3976 in four steps.
+	for i := 0; i < 8*budgetCeilingWidenAccepts; i++ {
+		r.RecordCapacityAccept(p.ID, model)
+		if _, latched := r.BudgetCeiling(p.ID, model); !latched {
+			return // healed and deleted
+		}
+	}
+	t.Fatal("ceiling never healed back to the advertised budget under sustained accepts")
+}
+
+// An identity rebind (session id → SE key → serial) must carry the TIGHTER
+// ceiling, not the fresher one. A rebind is not evidence about capacity, and
+// taking the later entry would let it widen a ceiling only accepts may widen.
+func TestBudgetCeilingMigratesTighterOnIdentityRebind(t *testing.T) {
+	const model = "m"
+	r := New(testLogger())
+	now := time.Now()
+
+	r.mu.Lock()
+	r.budgetCeilings[capacityRejectKey{ProviderID: "old", ModelID: model}] =
+		&budgetCeilingEntry{tokens: 20_000, latchedAt: now.Add(-time.Minute)}
+	r.budgetCeilings[capacityRejectKey{ProviderID: "new", ModelID: model}] =
+		&budgetCeilingEntry{tokens: 90_000, latchedAt: now}
+	r.migrateFaultStateLocked("old", "new")
+	got, ok := r.budgetCeilings[capacityRejectKey{ProviderID: "new", ModelID: model}]
+	_, oldStillThere := r.budgetCeilings[capacityRejectKey{ProviderID: "old", ModelID: model}]
+	r.mu.Unlock()
+
+	if !ok || got.tokens != 20_000 {
+		t.Fatalf("migrated ceiling = %v, want the tighter 20000", got)
+	}
+	if oldStillThere {
+		t.Fatal("old-key entry must be removed by the migration")
+	}
+}
+
+// effectiveTokenBudgetMax is the single place the min(advertised, learned)
+// rule lives, and it must be zero-value safe: a snapshot built outside
+// snapshotProviderLocked carries learnedTokenBudgetMax == 0, which means
+// "nothing learned", never "zero budget".
+func TestEffectiveTokenBudgetMaxZeroValueSafe(t *testing.T) {
+	if got := effectiveTokenBudgetMax(routingSnapshot{activeTokenBudgetMax: 4096}); got != 4096 {
+		t.Fatalf("unlearned snapshot = %d, want the advertised 4096", got)
+	}
+	learned := routingSnapshot{activeTokenBudgetMax: 4096, learnedTokenBudgetMax: 1024}
+	if got := effectiveTokenBudgetMax(learned); got != 1024 {
+		t.Fatalf("learned snapshot = %d, want 1024", got)
+	}
+	wider := routingSnapshot{activeTokenBudgetMax: 4096, learnedTokenBudgetMax: 9999}
+	if got := effectiveTokenBudgetMax(wider); got != 4096 {
+		t.Fatalf("a learned value above the advertised budget must not widen it: got %d, want 4096", got)
+	}
+}
+
+// The ceiling is LIVE-semantics only. The structural ceiling feeds the
+// fleet-level servability shed, whose "no" is a terminal 429 — a transient,
+// per-box measurement must never reach it. Same split the clamp already draws.
+func TestBudgetCeilingDoesNotFeedStructuralShed(t *testing.T) {
+	snap := routingSnapshot{
+		activeTokenBudgetMax:  500_000,
+		activeTokenBudgetUsed: 100_000,
+		learnedTokenBudgetMax: 120_000,
+	}
+	structural, known := snapshotStructuralBudget(snap)
+	if !known || structural != 500_000 {
+		t.Fatalf("structural budget = (%d, %v), want the raw advertised (500000, true)", structural, known)
+	}
+	live, known := liveRemainingBudget(snap)
+	if !known || live != 20_000 {
+		t.Fatalf("live remaining = (%d, %v), want (20000, true) — learned ceiling minus committed", live, known)
+	}
+}
+
+// The admission gate must charge against the learned ceiling, not the raw
+// heartbeat max, and must still reject everything while the one-shot clamp
+// holds (the clamp is the tightest state of the same machine).
+func TestFreeMemoryAdmitsHonoursLearnedCeiling(t *testing.T) {
+	base := routingSnapshot{
+		modelLoaded:           true,
+		slotState:             "running",
+		activeTokenBudgetMax:  100_000,
+		activeTokenBudgetUsed: 40_000,
+		totalMemoryGB:         64,
+		modelSizeGB:           12,
+	}
+	if !freeMemoryAdmits(base, 1_000, 1_000) {
+		t.Fatal("setup: a 2k request must fit 60k of raw headroom")
+	}
+	learned := base
+	learned.learnedTokenBudgetMax = 41_000
+	if !freeMemoryAdmits(learned, 500, 500) {
+		t.Fatal("a 1k request must still fit a 41000 ceiling at 40000 committed")
+	}
+	if freeMemoryAdmits(learned, 1_000, 1_000) {
+		t.Fatal("a 2k request must NOT fit a 41000 ceiling at 40000 committed")
+	}
+	clamped := learned
+	clamped.budgetClamped = true
+	if freeMemoryAdmits(clamped, 1, 1) {
+		t.Fatal("an active clamp must still refuse everything")
+	}
+}

--- a/coordinator/registry/budget_ceiling_test.go
+++ b/coordinator/registry/budget_ceiling_test.go
@@ -93,7 +93,7 @@ func TestBudgetCeilingBreaksTheClampTreadmill(t *testing.T) {
 	}
 
 	// The provider rejects it: the pool is affine and physically full.
-	r.RecordCapacityRejectSized(p.ID, model, int(pagedRequestTokens))
+	r.RecordCapacityRejectSized(p.ID, model, "seventh", int(pagedRequestTokens))
 
 	wantCeiling := pagedCommittedTokens + pagedRequestTokens - budgetCeilingMarginTokens
 	gotCeiling, latched := r.BudgetCeiling(p.ID, model)
@@ -141,7 +141,7 @@ func TestBudgetCeilingKillSwitchRestoresTreadmill(t *testing.T) {
 	p := makeTokenBudgetProvider(t, r, "paged-box", model, 100, pagedCommittedTokens, pagedAdvertisedTokens, 100)
 	sendBudgetHeartbeat(r, p.ID, model, pagedCommittedTokens, pagedAdvertisedTokens)
 
-	r.RecordCapacityRejectSized(p.ID, model, int(pagedRequestTokens))
+	r.RecordCapacityRejectSized(p.ID, model, "seventh", int(pagedRequestTokens))
 	if _, latched := r.BudgetCeiling(p.ID, model); latched {
 		t.Fatal("kill switch off must learn nothing")
 	}
@@ -301,7 +301,7 @@ func TestBudgetCeilingLatchBoundaries(t *testing.T) {
 	t.Run("TTL fails open", func(t *testing.T) {
 		r := New(testLogger())
 		p := makeTokenBudgetProvider(t, r, "box", model, 100, 0, 1_000_000, 100)
-		r.RecordCapacityRejectSized(p.ID, model, 50_000)
+		r.RecordCapacityRejectSized(p.ID, model, "req", 50_000)
 		if _, latched := r.BudgetCeiling(p.ID, model); !latched {
 			t.Fatal("setup: ceiling must latch")
 		}
@@ -366,7 +366,7 @@ func TestBudgetCeilingDoesNotWidenWithoutABudgetReport(t *testing.T) {
 	const model = "m"
 	r := New(testLogger())
 	p := makeTokenBudgetProvider(t, r, "box", model, 100, 0, 100_000, 100)
-	r.RecordCapacityRejectSized(p.ID, model, 50_000)
+	r.RecordCapacityRejectSized(p.ID, model, "req", 50_000)
 	latchedTokens, latched := r.BudgetCeiling(p.ID, model)
 	if !latched {
 		t.Fatal("setup: ceiling must latch")
@@ -400,7 +400,7 @@ func TestBudgetCeilingDeletedOnceHealed(t *testing.T) {
 	p := makeTokenBudgetProvider(t, r, "box", model, 100, 0, 8_000, 100)
 	sendBudgetHeartbeat(r, p.ID, model, 0, 8_000)
 
-	r.RecordCapacityRejectSized(p.ID, model, 5_000)
+	r.RecordCapacityRejectSized(p.ID, model, "req", 5_000)
 	if _, latched := r.BudgetCeiling(p.ID, model); !latched {
 		t.Fatal("setup: ceiling must latch below the 8000 advertised budget")
 	}
@@ -449,6 +449,15 @@ func TestBudgetCeilingMigratesTighterOnIdentityRebind(t *testing.T) {
 			source:     &budgetCeilingEntry{tokens: 20_000, latchedAt: time.Now().Add(-time.Hour)},
 			wantTokens: 0,
 		},
+		"both expired: nothing worth migrating": {
+			source: &budgetCeilingEntry{tokens: 20_000, latchedAt: time.Now().Add(-time.Hour)},
+			dest:   &budgetCeilingEntry{tokens: 90_000, latchedAt: time.Now().Add(-time.Hour)},
+			// The expired DESTINATION is left in place rather than deleted —
+			// the migration only owns the source key. It gates nothing (every
+			// reader checks expiry) and the opportunistic sweep collects it, so
+			// the assertion below is on the effective ceiling, not on presence.
+			wantTokens: 0,
+		},
 		"live source moves onto an empty key": {
 			source: &budgetCeilingEntry{tokens: 20_000}, wantTokens: 20_000,
 		},
@@ -480,8 +489,11 @@ func TestBudgetCeilingMigratesTighterOnIdentityRebind(t *testing.T) {
 			}
 			got, ok := r.budgetCeilings[newKey]
 			if tc.wantTokens == 0 {
-				if ok {
-					t.Fatalf("ceiling %d survived, want nothing to migrate", got.tokens)
+				// Nothing with standing survived: either no entry at all, or
+				// an expired one the migration does not own and every reader
+				// ignores. Assert on the effect, not on map presence.
+				if ok && now.Before(got.latchedAt.Add(r.budgetCeilingCfg.TTL)) {
+					t.Fatalf("live ceiling %d survived, want nothing that can gate", got.tokens)
 				}
 				return
 			}
@@ -510,7 +522,7 @@ func TestBudgetCeilingStarvationRecoversOnlyOnTTL(t *testing.T) {
 	p := makeTokenBudgetProvider(t, r, "box", model, 100, 0, pagedAdvertisedTokens, 100)
 	sendBudgetHeartbeat(r, p.ID, model, 0, pagedAdvertisedTokens)
 
-	r.RecordCapacityRejectSized(p.ID, model, int(pagedRequestTokens))
+	r.RecordCapacityRejectSized(p.ID, model, "seventh", int(pagedRequestTokens))
 	learned, latched := r.BudgetCeiling(p.ID, model)
 	if !latched || learned >= pagedRequestTokens {
 		t.Fatalf("setup: ceiling = (%d, %v), want a latch below the %d request size",
@@ -563,7 +575,7 @@ func TestBudgetCeilingLearnsFromInGapPendingNotJustTheHeartbeat(t *testing.T) {
 
 	// Six ~20k requests dispatched inside the heartbeat gap. The coordinator
 	// knows about all of them; the provider's last report does not.
-	var burst int64
+	var others int64
 	for i := 0; i < 6; i++ {
 		p.AddPending(&PendingRequest{
 			RequestID:             "burst-" + string(rune('a'+i)),
@@ -571,21 +583,52 @@ func TestBudgetCeilingLearnsFromInGapPendingNotJustTheHeartbeat(t *testing.T) {
 			EstimatedPromptTokens: pagedRequestPrompt,
 			RequestedMaxTokens:    pagedRequestMaxTokens,
 		})
-		burst += pagedRequestTokens
+		others += pagedRequestTokens
 	}
 
-	// The sixth one comes back token_budget_exhausted: the affine pool is full.
-	r.RecordCapacityRejectSized(p.ID, model, int(pagedRequestTokens))
+	// A seventh comes back token_budget_exhausted: the affine pool is full. It
+	// is NOT in the pending set — handleInferenceError removes the request
+	// before the error reaches this classifier — so the pending sum is exactly
+	// the six others and the seventh's demand is charged on top. Passing its id
+	// keeps that true either way.
+	r.RecordCapacityRejectSized(p.ID, model, "seventh", int(pagedRequestTokens))
 
 	got, latched := r.BudgetCeiling(p.ID, model)
 	if !latched {
 		t.Fatal("a sized capacity reject must latch a ceiling")
 	}
 	// Heartbeat-only would have learned requestTokens − margin ≈ 19k. The
-	// honest commitment is the whole burst the coordinator had placed.
-	if want := burst - budgetCeilingMarginTokens; got != want {
+	// honest commitment is the whole burst the coordinator had placed plus the
+	// request that failed on top of it.
+	if want := others + pagedRequestTokens - budgetCeilingMarginTokens; got != want {
 		t.Fatalf("ceiling = %d, want %d (the full in-gap commitment, not the %d a stale heartbeat implies)",
 			got, want, pagedRequestTokens-budgetCeilingMarginTokens)
+	}
+
+	// And the exclusion must be by identity, not by size: if the terminal path
+	// had NOT yet removed the request, its own demand must still be charged
+	// exactly once rather than twice.
+	r2 := New(testLogger())
+	p2 := makeTokenBudgetProvider(t, r2, "box", model, 100, 0, pagedAdvertisedTokens, 100)
+	sendBudgetHeartbeat(r2, p2.ID, model, 0, pagedAdvertisedTokens)
+	for i := 0; i < 6; i++ {
+		p2.AddPending(&PendingRequest{
+			RequestID:             "burst-" + string(rune('a'+i)),
+			Model:                 model,
+			EstimatedPromptTokens: pagedRequestPrompt,
+			RequestedMaxTokens:    pagedRequestMaxTokens,
+		})
+	}
+	p2.AddPending(&PendingRequest{
+		RequestID:             "seventh",
+		Model:                 model,
+		EstimatedPromptTokens: pagedRequestPrompt,
+		RequestedMaxTokens:    pagedRequestMaxTokens,
+	})
+	r2.RecordCapacityRejectSized(p2.ID, model, "seventh", int(pagedRequestTokens))
+	if resident, _ := r2.BudgetCeiling(p2.ID, model); resident != got {
+		t.Fatalf("ceiling = %d with the rejected request still pending, want the same %d — the exclusion must be by id, not by arithmetic",
+			resident, got)
 	}
 }
 

--- a/coordinator/registry/budget_ceiling_test.go
+++ b/coordinator/registry/budget_ceiling_test.go
@@ -161,7 +161,7 @@ func TestBudgetCeilingNeverExceedsAdvertised(t *testing.T) {
 	// A ceiling learned against a large advertised budget must not survive as
 	// an over-statement once the pair advertises much less (co-tenancy, a
 	// smaller re-slice).
-	r.recordBudgetCeilingLocked(key, 200_000, 1_000_000, now)
+	r.recordBudgetCeilingLocked(key, 200_000, 0, 1_000_000, now)
 	if got := r.budgetCeilingLocked("box", model, 50_000, now); got != 50_000 {
 		t.Fatalf("effective max = %d, want the smaller advertised 50000 — the ceiling is a cap, not a substitute", got)
 	}
@@ -181,7 +181,7 @@ func TestBudgetCeilingLatchBoundaries(t *testing.T) {
 		// The box rejected AT its advertised budget: the advertised number was
 		// already binding, so there is nothing to learn (ordinary fullness,
 		// owned by the queue path).
-		r.recordBudgetCeilingLocked(key, 100_000+budgetCeilingMarginTokens, 100_000, now)
+		r.recordBudgetCeilingLocked(key, 100_000+budgetCeilingMarginTokens, 100_000, 100_000, now)
 		if _, latched := r.BudgetCeiling("box", model); latched {
 			t.Fatal("a reject at or above the advertised budget must teach nothing")
 		}
@@ -192,21 +192,45 @@ func TestBudgetCeilingLatchBoundaries(t *testing.T) {
 		now := time.Now()
 		// A reject at a tiny commitment would imply a negative ceiling; a
 		// zero/negative ceiling is a permanent clamp wearing a different name.
-		r.recordBudgetCeilingLocked(key, 10, 100_000, now)
+		r.recordBudgetCeilingLocked(key, 10, 0, 100_000, now)
 		got, latched := r.BudgetCeiling("box", model)
 		if !latched || got != budgetCeilingFloorTokens {
 			t.Fatalf("ceiling = (%d, %v), want (%d, true)", got, latched, budgetCeilingFloorTokens)
 		}
 	})
 
+	t.Run("never below what the pair reports it already holds", func(t *testing.T) {
+		r := New(testLogger())
+		now := time.Now()
+		// A sub-margin request rejected at 80k committed: the margin alone
+		// would push the ceiling under the live commitment, which the
+		// provider's own report contradicts and which would deselect the pair
+		// for every request size.
+		r.recordBudgetCeilingLocked(key, 80_000+100, 80_000, 1_000_000, now)
+		got, latched := r.BudgetCeiling("box", model)
+		if !latched || got != 80_000 {
+			t.Fatalf("ceiling = (%d, %v), want (80000, true)", got, latched)
+		}
+		// It still refuses the request that failed: any positive demand on
+		// top of a ceiling equal to the commitment does not fit.
+		snap := routingSnapshot{
+			activeTokenBudgetMax:  1_000_000,
+			activeTokenBudgetUsed: 80_000,
+			learnedTokenBudgetMax: got,
+		}
+		if freeMemoryAdmits(snap, 100, 0) {
+			t.Fatal("a ceiling equal to the commitment must still refuse the request that failed")
+		}
+	})
+
 	t.Run("rejects ratchet down, never up", func(t *testing.T) {
 		r := New(testLogger())
 		now := time.Now()
-		r.recordBudgetCeilingLocked(key, 50_000, 1_000_000, now)
+		r.recordBudgetCeilingLocked(key, 50_000, 0, 1_000_000, now)
 		tight, _ := r.BudgetCeiling("box", model)
 		// A later reject at a HIGHER commitment (the box was busier) must not
 		// undo what the tighter one taught. Only accepts widen.
-		r.recordBudgetCeilingLocked(key, 900_000, 1_000_000, now)
+		r.recordBudgetCeilingLocked(key, 900_000, 800_000, 1_000_000, now)
 		got, _ := r.BudgetCeiling("box", model)
 		if got != tight {
 			t.Fatalf("ceiling = %d after a looser reject, want the ratcheted %d", got, tight)
@@ -216,9 +240,9 @@ func TestBudgetCeilingLatchBoundaries(t *testing.T) {
 	t.Run("unlearnable inputs are no-ops", func(t *testing.T) {
 		r := New(testLogger())
 		now := time.Now()
-		r.recordBudgetCeilingLocked(key, 0, 1_000_000, now)  // no request size
-		r.recordBudgetCeilingLocked(key, 50_000, 0, now)     // budgetless pair
-		r.recordBudgetCeilingLocked(key, -1, 1_000_000, now) // nonsense commitment
+		r.recordBudgetCeilingLocked(key, 0, 0, 1_000_000, now)  // no request size
+		r.recordBudgetCeilingLocked(key, 50_000, 0, 0, now)     // budgetless pair
+		r.recordBudgetCeilingLocked(key, -1, 0, 1_000_000, now) // nonsense commitment
 		if _, latched := r.BudgetCeiling("box", model); latched {
 			t.Fatal("a ceiling cannot be learned without both a commitment and an advertised budget")
 		}

--- a/coordinator/registry/budget_ceiling_test.go
+++ b/coordinator/registry/budget_ceiling_test.go
@@ -3,6 +3,8 @@ package registry
 import (
 	"testing"
 	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
 )
 
 // Tests for the learned effective token-budget ceiling (budget_ceiling.go).
@@ -245,9 +247,12 @@ func TestBudgetCeilingLatchBoundaries(t *testing.T) {
 		r.recordBudgetCeilingLocked(key, 50_000, 0, 1_000_000, now)
 		tight, _ := r.BudgetCeiling("box", model)
 		// A later reject at a HIGHER commitment (the box was busier) must not
-		// undo what the tighter one taught. Only accepts widen.
+		// undo what the tighter one taught. Only accepts widen. The pair's
+		// observed commitment stays BELOW the learned ceiling here, so nothing
+		// falsifies it — see the falsification subtest below for the case where
+		// something does.
 		later := now.Add(time.Minute)
-		r.recordBudgetCeilingLocked(key, 900_000, 800_000, 1_000_000, later)
+		r.recordBudgetCeilingLocked(key, 60_000, 40_000, 1_000_000, later)
 		got, _ := r.BudgetCeiling("box", model)
 		if got != tight {
 			t.Fatalf("ceiling = %d after a looser reject, want the ratcheted %d", got, tight)
@@ -260,6 +265,25 @@ func TestBudgetCeilingLatchBoundaries(t *testing.T) {
 		r.mu.RUnlock()
 		if !anchor.Equal(now) {
 			t.Fatalf("TTL anchor = %v, want the original latch %v — a non-tightening reject must not refresh it", anchor, now)
+		}
+	})
+
+	t.Run("a ceiling the live commitment falsifies is not ratcheted", func(t *testing.T) {
+		r := New(testLogger())
+		now := time.Now()
+		// A tiny reject latches at the floor.
+		r.recordBudgetCeilingLocked(key, 1_200, 0, 1_000_000, now)
+		if got, _ := r.BudgetCeiling("box", model); got != budgetCeilingFloorTokens {
+			t.Fatalf("setup: ceiling = %d, want the floor %d", got, budgetCeilingFloorTokens)
+		}
+		// A later reject observes the pair HOLDING 80k. A 1024 ceiling is
+		// contradicted by that — direct observation, not an accept — and
+		// keeping it would strand the pair at a level nothing can widen
+		// because no request fits under it.
+		r.recordBudgetCeilingLocked(key, 80_100, 80_000, 1_000_000, now.Add(time.Minute))
+		got, latched := r.BudgetCeiling("box", model)
+		if !latched || got != 80_000 {
+			t.Fatalf("ceiling = (%d, %v), want (80000, true) — the observed live commitment is the ratchet floor", got, latched)
 		}
 	})
 
@@ -330,6 +354,39 @@ func TestBudgetCeilingNotArmedByNonProviderRejects(t *testing.T) {
 				t.Fatalf("%s reject must not latch a budget ceiling", name)
 			}
 		})
+	}
+}
+
+// Widening needs something to widen TOWARD. With no budget report for the pair
+// (disconnected, slot gone, reconnect before the first heartbeat) the entry
+// cannot gate anything either way, and growing its token value against no
+// reference would leave a meaningless number to be compared with the next real
+// heartbeat. Hold the value; the TTL still bounds the entry.
+func TestBudgetCeilingDoesNotWidenWithoutABudgetReport(t *testing.T) {
+	const model = "m"
+	r := New(testLogger())
+	p := makeTokenBudgetProvider(t, r, "box", model, 100, 0, 100_000, 100)
+	r.RecordCapacityRejectSized(p.ID, model, 50_000)
+	latchedTokens, latched := r.BudgetCeiling(p.ID, model)
+	if !latched {
+		t.Fatal("setup: ceiling must latch")
+	}
+
+	// The pair stops reporting a budget for the model entirely.
+	r.Heartbeat(p.ID, &protocol.HeartbeatMessage{
+		Type:            protocol.TypeHeartbeat,
+		Status:          "idle",
+		SystemMetrics:   protocol.SystemMetrics{MemoryPressure: 0.1, CPUUsage: 0.1, ThermalState: "nominal"},
+		BackendCapacity: &protocol.BackendCapacity{TotalMemoryGB: 64},
+	})
+
+	for i := 0; i < 4*budgetCeilingWidenAccepts; i++ {
+		r.RecordCapacityAccept(p.ID, model)
+	}
+	got, stillLatched := r.BudgetCeiling(p.ID, model)
+	if !stillLatched || got != latchedTokens {
+		t.Fatalf("ceiling = (%d, %v) after %d budgetless accepts, want the held (%d, true)",
+			got, stillLatched, 4*budgetCeilingWidenAccepts, latchedTokens)
 	}
 }
 

--- a/coordinator/registry/budget_clamp.go
+++ b/coordinator/registry/budget_clamp.go
@@ -53,6 +53,18 @@ import (
 // ~one bounced request per release cycle, and the capacity-rate penalty
 // (capacity_rate.go) keeps it deprioritized in between.
 //
+// ONE BOUNCED REQUEST PER CYCLE IS NOT ALWAYS CHEAP. Release condition (a) is
+// phrased in terms of the pair's ADVERTISED budget, so when that budget is
+// structurally inflated — as a paged slot's is, because its wire budget
+// linearises an affine pool charge (v0.8.0; see budget_ceiling.go) — the very
+// next heartbeat satisfies it and the cycle repeats every heartbeat forever.
+// The clamp is therefore paired with a LEARNED EFFECTIVE CEILING
+// (budget_ceiling.go) that outlives it: the clamp stops the bleeding for one
+// heartbeat cycle, the ceiling remembers the commitment level that failed so
+// the pair is deselected before dispatch instead of bounced again. The two are
+// armed from the same entry point and keyed identically; the clamp is the
+// tightest state of the same machine (headroom zero, release unproven).
+//
 // SCOPE: the clamp only gates slots that REPORT a token budget
 // (active_token_budget_max > 0) — it exists to override a stale budget, and
 // its release condition is budget-defined. Legacy providers without budget
@@ -167,29 +179,35 @@ func (r *Registry) recordBudgetClampLocked(key capacityRejectKey, budgetReported
 	r.budgetClamps[key] = &budgetClampEntry{clampedAt: now, budgetReported: budgetReported}
 }
 
-// providerReportsTokenBudgetLocked reports whether the provider's CURRENT
-// backend snapshot carries a token budget for the model (the arming-time input
-// to budgetClampEntry.budgetReported). A missing provider (the reject often
-// races the disconnect that caused it) or a missing/budgetless slot reads
-// false — the sticky-or in recordBudgetClampLocked keeps an identity's
-// demonstrated reporting from being downgraded by such a race. Caller holds
-// r.mu (either mode); takes p.mu internally (r.mu → p.mu lock order).
-func (r *Registry) providerReportsTokenBudgetLocked(providerID, modelID string) bool {
+// providerBudgetCommitmentLocked reads the pair's CURRENT advertised token
+// budget (active_token_budget_max) and the tokens already committed against it
+// (used + queued) from the live capacity snapshot. Both gray-box trackers read
+// it: advertised > 0 is the clamp's arming-time budgetReported input, and
+// committed is the base of the failing commitment the learned ceiling measures
+// (budget_ceiling.go).
+//
+// A missing provider (the reject often races the disconnect that caused it) or
+// a missing/budgetless slot reads zero — the sticky-or in
+// recordBudgetClampLocked keeps an identity's demonstrated reporting from being
+// downgraded by such a race, and a zero advertised budget makes the ceiling
+// unlearnable rather than wrong. Caller holds r.mu (either mode); takes p.mu
+// internally (r.mu → p.mu lock order).
+func (r *Registry) providerBudgetCommitmentLocked(providerID, modelID string) (advertised, committed int64) {
 	p := r.providers[providerID]
 	if p == nil {
-		return false
+		return 0, 0
 	}
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	if p.BackendCapacity == nil {
-		return false
+		return 0, 0
 	}
 	for _, slot := range p.BackendCapacity.Slots {
 		if slot.Model == modelID {
-			return slot.ActiveTokenBudgetMax > 0
+			return slot.ActiveTokenBudgetMax, slot.ActiveTokenBudgetUsed + slot.QueuedTokenBudget
 		}
 	}
-	return false
+	return 0, 0
 }
 
 // noteBudgetClampAcceptLocked records release condition (b): the pair accepted
@@ -266,30 +284,21 @@ func (r *Registry) budgetClampActiveLocked(providerID, modelID string, heartbeat
 	return !released
 }
 
-// providerBudgetSnapshotLocked reads the pair's live budget snapshot — the
-// heartbeat freshness anchor, the raw headroom (max - used - queued,
-// unclamped), and whether the current capacity report carries a budget for the
-// model at all. A missing provider or a missing/budgetless slot reads
-// zero/false. Caller holds r.mu (either mode); takes p.mu internally
-// (r.mu → p.mu lock order).
-func (r *Registry) providerBudgetSnapshotLocked(providerID, modelID string) (heartbeatAt time.Time, rawRemaining int64, budgetReported bool) {
-	p := r.providers[providerID]
-	if p == nil {
-		return time.Time{}, 0, false
+// providerBudgetSnapshotLocked reads the pair's live budget snapshot: the
+// heartbeat freshness anchor plus the same (advertised, committed) pair
+// providerBudgetCommitmentLocked returns. The clamp's two derived inputs fall
+// out of it — raw headroom is advertised − committed, and "the report carries
+// a budget at all" is advertised > 0. A missing provider or a
+// missing/budgetless slot reads zero. Caller holds r.mu (either mode); takes
+// p.mu internally (r.mu → p.mu lock order).
+func (r *Registry) providerBudgetSnapshotLocked(providerID, modelID string) (heartbeatAt time.Time, advertised, committed int64) {
+	if p := r.providers[providerID]; p != nil {
+		p.mu.Lock()
+		heartbeatAt = p.LastHeartbeat
+		p.mu.Unlock()
 	}
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	heartbeatAt = p.LastHeartbeat
-	if p.BackendCapacity != nil {
-		for _, slot := range p.BackendCapacity.Slots {
-			if slot.Model == modelID {
-				rawRemaining = slot.ActiveTokenBudgetMax - slot.ActiveTokenBudgetUsed - slot.QueuedTokenBudget
-				budgetReported = slot.ActiveTokenBudgetMax > 0
-				break
-			}
-		}
-	}
-	return heartbeatAt, rawRemaining, budgetReported
+	advertised, committed = r.providerBudgetCommitmentLocked(providerID, modelID)
+	return heartbeatAt, advertised, committed
 }
 
 // dropInactiveBudgetClampLocked deletes the pair's clamp entry when it can no
@@ -310,8 +319,8 @@ func (r *Registry) providerBudgetSnapshotLocked(providerID, modelID string) (hea
 // accept path (RecordCapacityAcceptOutcome); the heartbeat release sweep uses
 // the snapshot variant below. Caller holds the r.mu WRITE lock.
 func (r *Registry) dropInactiveBudgetClampLocked(providerID, modelID string, now time.Time) {
-	heartbeatAt, rawRemaining, budgetReported := r.providerBudgetSnapshotLocked(providerID, modelID)
-	r.dropInactiveBudgetClampSnapshotLocked(providerID, modelID, heartbeatAt, rawRemaining, budgetReported, now)
+	heartbeatAt, advertised, committed := r.providerBudgetSnapshotLocked(providerID, modelID)
+	r.dropInactiveBudgetClampSnapshotLocked(providerID, modelID, heartbeatAt, advertised-committed, advertised > 0, now)
 }
 
 // dropInactiveBudgetClampSnapshotLocked is dropInactiveBudgetClampLocked with
@@ -390,6 +399,6 @@ func (r *Registry) BudgetClampActive(providerID, modelID string) bool {
 	if r.providers[providerID] == nil {
 		return false
 	}
-	heartbeatAt, rawRemaining, budgetReported := r.providerBudgetSnapshotLocked(providerID, modelID)
-	return r.budgetClampActiveLocked(providerID, modelID, heartbeatAt, rawRemaining, budgetReported, time.Now())
+	heartbeatAt, advertised, committed := r.providerBudgetSnapshotLocked(providerID, modelID)
+	return r.budgetClampActiveLocked(providerID, modelID, heartbeatAt, advertised-committed, advertised > 0, time.Now())
 }

--- a/coordinator/registry/budget_clamp.go
+++ b/coordinator/registry/budget_clamp.go
@@ -211,9 +211,17 @@ func (r *Registry) providerBudgetCommitmentLocked(providerID, modelID string) (a
 // by default), so during a burst it can read near-zero while the box is
 // physically full. This is the term that closes that gap, and it is why the
 // learned budget ceiling measures max(heartbeat, coordinator) rather than
-// trusting the heartbeat alone. Caller holds the r.mu lock in either mode;
-// p.mu is acquired here.
-func (r *Registry) providerPendingTokensLocked(providerID, modelID string) int64 {
+// trusting the heartbeat alone.
+//
+// excludeRequestID drops one request from the sum, so a caller that charges a
+// request's demand separately cannot double-count it. Passing the rejected
+// request's id makes the total mean "everything else this pair is holding"
+// regardless of whether the terminal path has already removed it — today
+// handleInferenceError removes it before the error reaches the reject
+// classifier, but pinning the arithmetic to that ordering would put a
+// cross-file invariant between the coordinator and a correct measurement.
+// Caller holds the r.mu lock in either mode; p.mu is acquired here.
+func (r *Registry) providerPendingTokensLocked(providerID, modelID, excludeRequestID string) int64 {
 	p := r.providers[providerID]
 	if p == nil {
 		return 0
@@ -222,7 +230,7 @@ func (r *Registry) providerPendingTokensLocked(providerID, modelID string) int64
 	defer p.mu.Unlock()
 	var pending int64
 	for _, pr := range p.pendingReqs {
-		if pr.Model == modelID {
+		if pr.Model == modelID && pr.RequestID != excludeRequestID {
 			pending += int64(pendingTokenBudget(pr))
 		}
 	}

--- a/coordinator/registry/budget_clamp.go
+++ b/coordinator/registry/budget_clamp.go
@@ -210,6 +210,33 @@ func (r *Registry) providerBudgetCommitmentLocked(providerID, modelID string) (a
 	return 0, 0
 }
 
+// providerPendingTokensLocked sums the COORDINATOR's own view of the pair's
+// in-flight token demand: pendingTokenBudget over every pending request for the
+// model, the same aggregate snapshotProviderLocked stores as
+// pendingMaxTokens and the admission gate charges as coordinatorExtra.
+//
+// The heartbeat-only commitment above lags by up to one heartbeat interval (5s
+// by default), so during a burst it can read near-zero while the box is
+// physically full. This is the term that closes that gap, and it is why the
+// learned budget ceiling measures max(heartbeat, coordinator) rather than
+// trusting the heartbeat alone. Caller holds the r.mu lock in either mode;
+// p.mu is acquired here.
+func (r *Registry) providerPendingTokensLocked(providerID, modelID string) int64 {
+	p := r.providers[providerID]
+	if p == nil {
+		return 0
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	var pending int64
+	for _, pr := range p.pendingReqs {
+		if pr.Model == modelID {
+			pending += int64(pendingTokenBudget(pr))
+		}
+	}
+	return pending
+}
+
 // noteBudgetClampAcceptLocked records release condition (b): the pair accepted
 // work after the clamp. The entry is kept (not deleted) — release also needs a
 // strictly-fresher heartbeat with meaningful headroom, which the routing-path

--- a/coordinator/registry/budget_clamp.go
+++ b/coordinator/registry/budget_clamp.go
@@ -190,24 +190,16 @@ func (r *Registry) recordBudgetClampLocked(key capacityRejectKey, budgetReported
 // a missing/budgetless slot reads zero — the sticky-or in
 // recordBudgetClampLocked keeps an identity's demonstrated reporting from being
 // downgraded by such a race, and a zero advertised budget makes the ceiling
-// unlearnable rather than wrong. Caller holds r.mu (either mode); takes p.mu
-// internally (r.mu → p.mu lock order).
+// unlearnable rather than wrong.
+//
+// Thin wrapper over providerBudgetSnapshotLocked so the slot scan and the
+// heartbeat stamp stay in ONE p.mu critical section: Heartbeat writes
+// BackendCapacity and LastHeartbeat together, and a reader that took the lock
+// twice could pair one heartbeat's stamp with another's budget. Caller holds
+// r.mu (either mode); p.mu is taken inside (r.mu → p.mu lock order).
 func (r *Registry) providerBudgetCommitmentLocked(providerID, modelID string) (advertised, committed int64) {
-	p := r.providers[providerID]
-	if p == nil {
-		return 0, 0
-	}
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	if p.BackendCapacity == nil {
-		return 0, 0
-	}
-	for _, slot := range p.BackendCapacity.Slots {
-		if slot.Model == modelID {
-			return slot.ActiveTokenBudgetMax, slot.ActiveTokenBudgetUsed + slot.QueuedTokenBudget
-		}
-	}
-	return 0, 0
+	_, advertised, committed = r.providerBudgetSnapshotLocked(providerID, modelID)
+	return advertised, committed
 }
 
 // providerPendingTokensLocked sums the COORDINATOR's own view of the pair's
@@ -319,13 +311,26 @@ func (r *Registry) budgetClampActiveLocked(providerID, modelID string, heartbeat
 // missing/budgetless slot reads zero. Caller holds r.mu (either mode); takes
 // p.mu internally (r.mu → p.mu lock order).
 func (r *Registry) providerBudgetSnapshotLocked(providerID, modelID string) (heartbeatAt time.Time, advertised, committed int64) {
-	if p := r.providers[providerID]; p != nil {
-		p.mu.Lock()
-		heartbeatAt = p.LastHeartbeat
-		p.mu.Unlock()
+	p := r.providers[providerID]
+	if p == nil {
+		return time.Time{}, 0, 0
 	}
-	advertised, committed = r.providerBudgetCommitmentLocked(providerID, modelID)
-	return heartbeatAt, advertised, committed
+	// One critical section for all three: Heartbeat stamps LastHeartbeat and
+	// swaps BackendCapacity together, so splitting the read could attribute one
+	// heartbeat's freshness to another's budget — and the clamp's release proof
+	// is precisely "a heartbeat strictly newer than the clamp showed headroom".
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	heartbeatAt = p.LastHeartbeat
+	if p.BackendCapacity == nil {
+		return heartbeatAt, 0, 0
+	}
+	for _, slot := range p.BackendCapacity.Slots {
+		if slot.Model == modelID {
+			return heartbeatAt, slot.ActiveTokenBudgetMax, slot.ActiveTokenBudgetUsed + slot.QueuedTokenBudget
+		}
+	}
+	return heartbeatAt, 0, 0
 }
 
 // dropInactiveBudgetClampLocked deletes the pair's clamp entry when it can no

--- a/coordinator/registry/capacity_cooldown.go
+++ b/coordinator/registry/capacity_cooldown.go
@@ -170,20 +170,23 @@ type capacityRejectKey struct {
 // fleet-wide) must go to RecordCapacityRejectRequestShape so it arms NO
 // gray-box state at all.
 func (r *Registry) RecordCapacityReject(providerID, modelID string) (tripped bool) {
-	return r.recordCapacityReject(providerID, modelID, 0, true, true)
+	return r.recordCapacityReject(providerID, modelID, "", 0, true, true)
 }
 
 // RecordCapacityRejectSized is RecordCapacityReject with the rejected
-// request's token demand (prompt + max_tokens) attached — the production entry
-// point. The size is what turns the reject into a MEASUREMENT: together with
-// the pair's reported used+queued it fixes the exact commitment the provider
-// could not hold, which is what the learned effective ceiling latches
-// (budget_ceiling.go). Everything else is identical to RecordCapacityReject,
+// request's identity and token demand (prompt + max_tokens) attached — the
+// production entry point. The size is what turns the reject into a
+// MEASUREMENT: together with everything else the pair is holding it fixes the
+// commitment the provider could not hold, which is what the learned effective
+// ceiling latches (budget_ceiling.go). requestID lets that "everything else"
+// exclude this request by identity rather than by arithmetic, so the
+// measurement does not depend on whether the caller has already removed it
+// from the pending set. Everything else is identical to RecordCapacityReject,
 // which stays as the size-less form for callers (and tests) that only have the
 // pair: without a size the failing commitment is unknown, so those record a
 // strike and a clamp but teach the ceiling nothing.
-func (r *Registry) RecordCapacityRejectSized(providerID, modelID string, requestTokens int) (tripped bool) {
-	return r.recordCapacityReject(providerID, modelID, requestTokens, true, true)
+func (r *Registry) RecordCapacityRejectSized(providerID, modelID, requestID string, requestTokens int) (tripped bool) {
+	return r.recordCapacityReject(providerID, modelID, requestID, requestTokens, true, true)
 }
 
 // RecordCapacityRejectLifecycle records a BENIGN lifecycle capacity miss — a
@@ -206,7 +209,7 @@ func (r *Registry) RecordCapacityRejectSized(providerID, modelID string, request
 // "no model loaded" rejections here; genuine capacity/token-budget 503s go to
 // RecordCapacityReject and feed everything.
 func (r *Registry) RecordCapacityRejectLifecycle(providerID, modelID string) (tripped bool) {
-	return r.recordCapacityReject(providerID, modelID, 0, false, false)
+	return r.recordCapacityReject(providerID, modelID, "", 0, false, false)
 }
 
 // RecordCapacityRejectRequestShape records a capacity-vocabulary rejection the
@@ -227,7 +230,7 @@ func (r *Registry) RecordCapacityRejectLifecycle(providerID, modelID string) (tr
 // that safe for healthy pairs (threshold 5 in 60s with NO accept; any accept
 // resets the streak), a safety the clamp and rate window by design lack.
 func (r *Registry) RecordCapacityRejectRequestShape(providerID, modelID string) (tripped bool) {
-	return r.recordCapacityReject(providerID, modelID, 0, false, false)
+	return r.recordCapacityReject(providerID, modelID, "", 0, false, false)
 }
 
 // RecordCapacityRejectBusy records a typed admission-timeout capacity signal
@@ -244,7 +247,7 @@ func (r *Registry) RecordCapacityRejectRequestShape(providerID, modelID string) 
 // capacity-503 rate window (transient load would accumulate a false reject
 // rate against a healthy pair).
 func (r *Registry) RecordCapacityRejectBusy(providerID, modelID string) (tripped bool) {
-	return r.recordCapacityReject(providerID, modelID, 0, false, false)
+	return r.recordCapacityReject(providerID, modelID, "", 0, false, false)
 }
 
 // recordCapacityReject is the shared implementation. deratePair gates the
@@ -255,7 +258,7 @@ func (r *Registry) RecordCapacityRejectBusy(providerID, modelID string) (tripped
 // requestTokens is the rejected request's token demand (prompt + max_tokens),
 // or 0 when the caller does not know it; the ceiling can only learn from a
 // sized reject. The cooldown strike is fed on all paths.
-func (r *Registry) recordCapacityReject(providerID, modelID string, requestTokens int, deratePair, armClamp bool) (tripped bool) {
+func (r *Registry) recordCapacityReject(providerID, modelID, requestID string, requestTokens int, deratePair, armClamp bool) (tripped bool) {
 	if providerID == "" || modelID == "" {
 		return false
 	}
@@ -285,18 +288,19 @@ func (r *Registry) recordCapacityReject(providerID, modelID string, requestToken
 		// used+queued alone would be tighter than the evidence supports.
 		//
 		// The commitment must be measured in the SAME units freeMemoryAdmits
-		// charges, which is not the heartbeat alone: its LHS is
-		// used+queued+coordinatorExtra+request, where coordinatorExtra is the
-		// in-gap pending the heartbeat has not caught up to yet. Reconstruct
-		// that base as max(heartbeat committed, pending − this request) — the
-		// rejected request may or may not still be in the pending set at this
-		// point, so charging it once explicitly is the only way to avoid
-		// either double-counting it or missing it. Without the pending term a
-		// burst inside one 5s heartbeat window reads used≈0 and latches a
-		// ceiling an order of magnitude tighter than the evidence supports.
+		// charges, which is not the heartbeat alone: its LHS reduces to
+		// max(heartbeat committed, coordinator pending) + request, where the
+		// pending term is the in-gap demand the heartbeat has not caught up to
+		// yet. Both halves here mean "everything this pair holds EXCLUDING the
+		// rejected request", which is charged once on top — the pending sum
+		// skips it by id rather than subtracting its size, so the arithmetic
+		// is exact whether or not the terminal path has already removed it.
+		// Without the pending term a burst inside one 5s heartbeat window
+		// reads used≈0 and latches a ceiling an order of magnitude tighter
+		// than the evidence supports.
 		if requestTokens > 0 {
 			base := committed
-			if others := r.providerPendingTokensLocked(providerID, modelID) - int64(requestTokens); others > base {
+			if others := r.providerPendingTokensLocked(providerID, modelID, requestID); others > base {
 				base = others
 			}
 			r.recordBudgetCeilingLocked(clampKey, base+int64(requestTokens), base, advertised, now)

--- a/coordinator/registry/capacity_cooldown.go
+++ b/coordinator/registry/capacity_cooldown.go
@@ -170,7 +170,20 @@ type capacityRejectKey struct {
 // fleet-wide) must go to RecordCapacityRejectRequestShape so it arms NO
 // gray-box state at all.
 func (r *Registry) RecordCapacityReject(providerID, modelID string) (tripped bool) {
-	return r.recordCapacityReject(providerID, modelID, true, true)
+	return r.recordCapacityReject(providerID, modelID, 0, true, true)
+}
+
+// RecordCapacityRejectSized is RecordCapacityReject with the rejected
+// request's token demand (prompt + max_tokens) attached — the production entry
+// point. The size is what turns the reject into a MEASUREMENT: together with
+// the pair's reported used+queued it fixes the exact commitment the provider
+// could not hold, which is what the learned effective ceiling latches
+// (budget_ceiling.go). Everything else is identical to RecordCapacityReject,
+// which stays as the size-less form for callers (and tests) that only have the
+// pair: without a size the failing commitment is unknown, so those record a
+// strike and a clamp but teach the ceiling nothing.
+func (r *Registry) RecordCapacityRejectSized(providerID, modelID string, requestTokens int) (tripped bool) {
+	return r.recordCapacityReject(providerID, modelID, requestTokens, true, true)
 }
 
 // RecordCapacityRejectLifecycle records a BENIGN lifecycle capacity miss — a
@@ -193,7 +206,7 @@ func (r *Registry) RecordCapacityReject(providerID, modelID string) (tripped boo
 // "no model loaded" rejections here; genuine capacity/token-budget 503s go to
 // RecordCapacityReject and feed everything.
 func (r *Registry) RecordCapacityRejectLifecycle(providerID, modelID string) (tripped bool) {
-	return r.recordCapacityReject(providerID, modelID, false, false)
+	return r.recordCapacityReject(providerID, modelID, 0, false, false)
 }
 
 // RecordCapacityRejectRequestShape records a capacity-vocabulary rejection the
@@ -214,7 +227,7 @@ func (r *Registry) RecordCapacityRejectLifecycle(providerID, modelID string) (tr
 // that safe for healthy pairs (threshold 5 in 60s with NO accept; any accept
 // resets the streak), a safety the clamp and rate window by design lack.
 func (r *Registry) RecordCapacityRejectRequestShape(providerID, modelID string) (tripped bool) {
-	return r.recordCapacityReject(providerID, modelID, false, false)
+	return r.recordCapacityReject(providerID, modelID, 0, false, false)
 }
 
 // RecordCapacityRejectBusy records a typed admission-timeout capacity signal
@@ -231,15 +244,18 @@ func (r *Registry) RecordCapacityRejectRequestShape(providerID, modelID string) 
 // capacity-503 rate window (transient load would accumulate a false reject
 // rate against a healthy pair).
 func (r *Registry) RecordCapacityRejectBusy(providerID, modelID string) (tripped bool) {
-	return r.recordCapacityReject(providerID, modelID, false, false)
+	return r.recordCapacityReject(providerID, modelID, 0, false, false)
 }
 
 // recordCapacityReject is the shared implementation. deratePair gates the
 // gray-box capacity-503 rate window (true only for genuine capacity rejects);
-// armClamp gates the budget clamp (false only for request-deterministic
-// rejects, which indict the request rather than the provider). The cooldown
-// strike is fed on all paths.
-func (r *Registry) recordCapacityReject(providerID, modelID string, deratePair, armClamp bool) (tripped bool) {
+// armClamp gates BOTH budget trackers — the one-shot clamp (budget_clamp.go)
+// and the learned effective ceiling (budget_ceiling.go) — and is false only
+// for rejects that indict the request rather than the provider.
+// requestTokens is the rejected request's token demand (prompt + max_tokens),
+// or 0 when the caller does not know it; the ceiling can only learn from a
+// sized reject. The cooldown strike is fed on all paths.
+func (r *Registry) recordCapacityReject(providerID, modelID string, requestTokens int, deratePair, armClamp bool) (tripped bool) {
 	if providerID == "" || modelID == "" {
 		return false
 	}
@@ -260,7 +276,16 @@ func (r *Registry) recordCapacityReject(providerID, modelID string, deratePair, 
 	// prompt says nothing about the pair's budget honesty).
 	clampKey := capacityRejectKey{ProviderID: r.faultKeyLocked(providerID), ModelID: modelID}
 	if armClamp {
-		r.recordBudgetClampLocked(clampKey, r.providerReportsTokenBudgetLocked(providerID, modelID), now)
+		advertised, committed := r.providerBudgetCommitmentLocked(providerID, modelID)
+		r.recordBudgetClampLocked(clampKey, advertised > 0, now)
+		// Learned effective ceiling (budget_ceiling.go): the pair could not
+		// hold used+queued+requestTokens, whatever its heartbeat advertises.
+		// Sized rejects only — without the request size the failing
+		// commitment is unknown and a ceiling learned from used+queued alone
+		// would be tighter than the evidence supports.
+		if requestTokens > 0 {
+			r.recordBudgetCeilingLocked(clampKey, committed+int64(requestTokens), advertised, now)
+		}
 	}
 	if deratePair {
 		r.recordCapacityRateRejectLocked(clampKey, now)
@@ -411,10 +436,11 @@ func (r *Registry) RecordCapacityAcceptOutcome(providerID, modelID string, count
 		_, hasCooldown := r.capacityCooldowns[key]
 		_, hasTrips := r.capacityCooldownTrips[key]
 		_, hasClamp := r.budgetClamps[key]
+		_, hasCeiling := r.budgetCeilings[key]
 		_, hasNodeStreak := r.healthEjectionCapacityStreaks[key.ProviderID]
 		capacityTripped := r.healthEjectionLastTripCapacity[key.ProviderID]
 		r.mu.RUnlock()
-		if !hasStrikes && !hasCooldown && !hasTrips && !hasClamp && !hasNodeStreak && !capacityTripped {
+		if !hasStrikes && !hasCooldown && !hasTrips && !hasClamp && !hasCeiling && !hasNodeStreak && !capacityTripped {
 			return false
 		}
 	}
@@ -436,6 +462,13 @@ func (r *Registry) RecordCapacityAcceptOutcome(providerID, modelID string, count
 	if _, hasClamp := r.budgetClamps[key]; hasClamp {
 		r.noteBudgetClampAcceptLocked(key)
 		r.dropInactiveBudgetClampLocked(providerID, modelID, now)
+	}
+	// A learned effective ceiling (budget_ceiling.go) widens on SUSTAINED
+	// accepts — the only provider-side proof that more fits than the last
+	// reject taught us — and is deleted once it catches up with the pair's
+	// advertised budget.
+	if _, hasCeiling := r.budgetCeilings[key]; hasCeiling {
+		r.noteBudgetCeilingAcceptLocked(providerID, modelID, key, now)
 	}
 	if countRateOutcome {
 		rateOutcomeRecorded = r.recordCapacityRateAcceptLocked(key, now)

--- a/coordinator/registry/capacity_cooldown.go
+++ b/coordinator/registry/capacity_cooldown.go
@@ -279,12 +279,27 @@ func (r *Registry) recordCapacityReject(providerID, modelID string, requestToken
 		advertised, committed := r.providerBudgetCommitmentLocked(providerID, modelID)
 		r.recordBudgetClampLocked(clampKey, advertised > 0, now)
 		// Learned effective ceiling (budget_ceiling.go): the pair could not
-		// hold used+queued+requestTokens, whatever its heartbeat advertises.
-		// Sized rejects only — without the request size the failing
-		// commitment is unknown and a ceiling learned from used+queued alone
-		// would be tighter than the evidence supports.
+		// hold the commitment this request brought it to, whatever its
+		// heartbeat advertises. Sized rejects only — without the request size
+		// the failing commitment is unknown and a ceiling learned from
+		// used+queued alone would be tighter than the evidence supports.
+		//
+		// The commitment must be measured in the SAME units freeMemoryAdmits
+		// charges, which is not the heartbeat alone: its LHS is
+		// used+queued+coordinatorExtra+request, where coordinatorExtra is the
+		// in-gap pending the heartbeat has not caught up to yet. Reconstruct
+		// that base as max(heartbeat committed, pending − this request) — the
+		// rejected request may or may not still be in the pending set at this
+		// point, so charging it once explicitly is the only way to avoid
+		// either double-counting it or missing it. Without the pending term a
+		// burst inside one 5s heartbeat window reads used≈0 and latches a
+		// ceiling an order of magnitude tighter than the evidence supports.
 		if requestTokens > 0 {
-			r.recordBudgetCeilingLocked(clampKey, committed+int64(requestTokens), committed, advertised, now)
+			base := committed
+			if others := r.providerPendingTokensLocked(providerID, modelID) - int64(requestTokens); others > base {
+				base = others
+			}
+			r.recordBudgetCeilingLocked(clampKey, base+int64(requestTokens), base, advertised, now)
 		}
 	}
 	if deratePair {

--- a/coordinator/registry/capacity_cooldown.go
+++ b/coordinator/registry/capacity_cooldown.go
@@ -284,7 +284,7 @@ func (r *Registry) recordCapacityReject(providerID, modelID string, requestToken
 		// commitment is unknown and a ceiling learned from used+queued alone
 		// would be tighter than the evidence supports.
 		if requestTokens > 0 {
-			r.recordBudgetCeilingLocked(clampKey, committed+int64(requestTokens), advertised, now)
+			r.recordBudgetCeilingLocked(clampKey, committed+int64(requestTokens), committed, advertised, now)
 		}
 	}
 	if deratePair {

--- a/coordinator/registry/health_ejection.go
+++ b/coordinator/registry/health_ejection.go
@@ -308,21 +308,37 @@ func (r *Registry) migrateFaultStateLocked(oldKey, newKey string) {
 		}
 	}
 
-	// Learned effective token-budget ceilings: the TIGHTER ceiling wins, not
-	// the fresher one. A ceiling is a measured "this box could not hold S",
-	// and an identity rebind is not evidence against it — taking the later
-	// entry would let a rebind widen a ceiling that only accepts are allowed
-	// to widen. The winner keeps its own latchedAt (and so its own TTL), which
-	// is what eventually retires it.
+	// Learned effective token-budget ceilings: among LIVE entries the TIGHTER
+	// ceiling wins, not the fresher one. A ceiling is a measured "this box
+	// could not hold S", and an identity rebind is not evidence against it —
+	// taking the later entry would let a rebind widen a ceiling that only
+	// accepts are allowed to widen. The winner keeps its own latchedAt (and so
+	// its own TTL), which is what eventually retires it.
+	//
+	// Expiry is checked on BOTH sides, unlike the timestamp-ordered maps above
+	// where it falls out of the comparison for free. Compare tokens blind and
+	// an expired-but-tighter source silently destroys a live destination: the
+	// survivor carries the source's stale anchor, so it reads as expired and
+	// gates nothing. An expired entry has no evidentiary standing on either
+	// side, so it is simply dropped.
+	ceilingNow := time.Now()
+	ceilingLive := func(e *budgetCeilingEntry) bool {
+		return ceilingNow.Before(e.latchedAt.Add(r.budgetCeilingCfg.TTL))
+	}
 	for k, entry := range r.budgetCeilings {
-		if k.ProviderID == oldKey {
-			nk := k
-			nk.ProviderID = newKey
-			if cur, ok := r.budgetCeilings[nk]; !ok || entry.tokens < cur.tokens {
-				r.budgetCeilings[nk] = entry
-			}
-			delete(r.budgetCeilings, k)
+		if k.ProviderID != oldKey {
+			continue
 		}
+		nk := k
+		nk.ProviderID = newKey
+		delete(r.budgetCeilings, k)
+		if !ceilingLive(entry) {
+			continue
+		}
+		if cur, ok := r.budgetCeilings[nk]; ok && ceilingLive(cur) && cur.tokens <= entry.tokens {
+			continue
+		}
+		r.budgetCeilings[nk] = entry
 	}
 
 	// Capacity-503 rate windows: union the outcome slices chronologically. The

--- a/coordinator/registry/health_ejection.go
+++ b/coordinator/registry/health_ejection.go
@@ -308,6 +308,23 @@ func (r *Registry) migrateFaultStateLocked(oldKey, newKey string) {
 		}
 	}
 
+	// Learned effective token-budget ceilings: the TIGHTER ceiling wins, not
+	// the fresher one. A ceiling is a measured "this box could not hold S",
+	// and an identity rebind is not evidence against it — taking the later
+	// entry would let a rebind widen a ceiling that only accepts are allowed
+	// to widen. The winner keeps its own latchedAt (and so its own TTL), which
+	// is what eventually retires it.
+	for k, entry := range r.budgetCeilings {
+		if k.ProviderID == oldKey {
+			nk := k
+			nk.ProviderID = newKey
+			if cur, ok := r.budgetCeilings[nk]; !ok || entry.tokens < cur.tokens {
+				r.budgetCeilings[nk] = entry
+			}
+			delete(r.budgetCeilings, k)
+		}
+	}
+
 	// Capacity-503 rate windows: union the outcome slices chronologically. The
 	// large-map sweep uses the tail as the newest timestamp, so appending an older
 	// source history after a fresh destination would otherwise delete live state.

--- a/coordinator/registry/kv_backend.go
+++ b/coordinator/registry/kv_backend.go
@@ -280,18 +280,20 @@ func (p *Provider) kvBackendForModelLocked(model string) (obs slotKVBackend, obs
 // this purpose the paged answer is the conservative one: it produces the
 // SMALLER cold estimate.
 //
-// observed == false means no slot ever named a backend (a pre-0.8.0 provider,
-// or a box that has not loaded anything yet). Callers must leave their
-// estimate untouched in that case — an unobserved box is not a contiguous box.
+// A false answer covers both "observed contiguous" and "never observed" (a
+// pre-0.8.0 provider, or a box that has not loaded anything yet), and that
+// collapse is deliberate rather than a lost distinction: the sole reader clamps
+// on true and leaves its estimate untouched on false, which is the required
+// behaviour for an unobserved box as much as for a contiguous one. Returning a
+// tri-state would oblige every caller to re-derive that identity.
 // Caller must hold p.mu.
-func (p *Provider) runsPagedKVLocked() (paged, observed bool) {
+func (p *Provider) runsPagedKVLocked() bool {
 	for _, obs := range p.kvBackends {
-		observed = true
 		if obs.Kind == KVBackendPaged {
-			return true, true
+			return true
 		}
 	}
-	return false, observed
+	return false
 }
 
 // slotKVBackendObservation is the one lookup both dimensions come from.

--- a/coordinator/registry/kv_backend.go
+++ b/coordinator/registry/kv_backend.go
@@ -29,9 +29,39 @@ import (
 // a contiguous sample and shows a clean baseline composed entirely of old
 // providers — the specific failure mode the pointer type exists to prevent.
 //
-// MEASUREMENT ONLY. Nothing here is consulted by routing, admission, scoring or
-// shedding; the sole consumers are metric tags. Acting on the backend kind is a
-// separate change with its own review.
+// ROUTING READS THIS FILE — ONE READER, DELIBERATELY. It was MEASUREMENT ONLY
+// through v0.8.0 ("the sole consumers are metric tags"), on the reasoning that
+// acting on the backend kind deserved its own review. This is that review.
+//
+// The one reader is the COLD token-budget estimate (servability.go:
+// pagedColdTokenBudgetCeiling). Its premise — stated in
+// coldTokenBudgetEstimate's own doc — was that a cold provider's estimated
+// post-load budget converges to what the slot reports once warm, "because both
+// are the same subtraction". Paged broke that premise and nothing else: the
+// cold estimate computes a CONTIGUOUS-shaped logical grant (0.9×mem − weights
+// − reserve), while a paged slot's real ceiling is a separately-planned
+// physical pool bounded by min(8 GiB, RAM/16)
+// (PagedKVPhysicalCapacityPolicy.machineHardCapBytes) — an order of magnitude
+// smaller on a 96 GiB box. The estimate is not merely imprecise there; it
+// describes a different quantity.
+//
+// The reader is narrow by construction and cannot widen without a new
+// justification:
+//   - PROVIDER granularity, not slot, and only for this purpose. The cold
+//     estimate is for a model with NO slot on this box, so no slot-level
+//     observation for it can exist; what is being asked is "does this MACHINE
+//     serve paged", which its other slots answer.
+//   - Tri-state preserved. No observation at all leaves the estimate exactly
+//     as it is today. An unenrolled or pre-0.8.0 box is never guessed into a
+//     paged ceiling.
+//   - Strictly tighter, never looser. The clamp can only lower an estimate,
+//     and only when the slot reports a real per-token KV rate (see
+//     pagedColdTokenBudgetCeiling) — dividing a real byte bound by the generic
+//     kvCacheBytesPerToken placeholder would manufacture a token count ~20×
+//     below the truth and shed servable traffic.
+//
+// Everything else here remains measurement: nothing in this file is consulted
+// by scoring, live admission or shedding.
 
 // Metric-tag vocabulary. The first two are the shipped wire values; the rest
 // encode the states a two-value vocabulary cannot express.
@@ -234,6 +264,34 @@ func clampKVFallbackReason(reason string) string {
 func (p *Provider) kvBackendForModelLocked(model string) (obs slotKVBackend, observed bool) {
 	obs, observed = p.kvBackends[model]
 	return obs, observed
+}
+
+// runsPagedKVLocked reports whether this MACHINE serves the paged KV backend,
+// by asking every slot it has ever named. It is the cold token-budget
+// estimate's input: that estimate is for a model with no slot here, so no
+// slot-level answer for it can exist, and the question it actually needs
+// answered is about the box's pool arithmetic, not about one model.
+//
+// ANY paged slot makes the box paged. The backend is a box-level capability —
+// kernels preflighted once, a crash-loop guard and a kill switch that flip the
+// whole binary, a physical-capacity policy driven by the machine's RAM — so a
+// box serving paged for one model will plan a paged pool for the next.
+// Mixed-kind boxes exist during a staged rollout (a per-load degrade), and for
+// this purpose the paged answer is the conservative one: it produces the
+// SMALLER cold estimate.
+//
+// observed == false means no slot ever named a backend (a pre-0.8.0 provider,
+// or a box that has not loaded anything yet). Callers must leave their
+// estimate untouched in that case — an unobserved box is not a contiguous box.
+// Caller must hold p.mu.
+func (p *Provider) runsPagedKVLocked() (paged, observed bool) {
+	for _, obs := range p.kvBackends {
+		observed = true
+		if obs.Kind == KVBackendPaged {
+			return true, true
+		}
+	}
+	return false, observed
 }
 
 // slotKVBackendObservation is the one lookup both dimensions come from.

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -1453,6 +1453,18 @@ type Registry struct {
 	budgetClampCfg budgetClampConfig
 	budgetClamps   map[capacityRejectKey]*budgetClampEntry
 
+	// budgetCeilings implements the learned effective token-budget ceiling
+	// (budget_ceiling.go): the durable half of the gray-box fix. A capacity
+	// reject at a known commitment latches min(advertised, commitment −
+	// margin) as the budget admission may believe, so a pair whose advertised
+	// budget is STRUCTURALLY inflated (a paged slot linearising an affine pool
+	// charge) stops being re-selected at the level that just failed the moment
+	// the one-shot clamp releases. Widened back on sustained accepts,
+	// TTL-bounded. Keyed by stable fault identity; migrated on rebind; NOT
+	// cleared on Disconnect. Guarded by r.mu.
+	budgetCeilingCfg budgetCeilingConfig
+	budgetCeilings   map[capacityRejectKey]*budgetCeilingEntry
+
 	// capacityRateRejects / capacityRateAccepts implement the capacity-503
 	// rate penalty (capacity_rate.go): sliding windows of capacity rejects and
 	// served dispatches per (stable identity, model). Unlike every breaker
@@ -1584,6 +1596,8 @@ func New(logger *slog.Logger) *Registry {
 		capacityCooldownTrips:          make(map[capacityRejectKey]int),
 		budgetClampCfg:                 loadBudgetClampConfig(),
 		budgetClamps:                   make(map[capacityRejectKey]*budgetClampEntry),
+		budgetCeilingCfg:               loadBudgetCeilingConfig(),
+		budgetCeilings:                 make(map[capacityRejectKey]*budgetCeilingEntry),
 		capacityRateCfg:                loadCapacityRateConfig(),
 		capacityRateRejects:            make(map[capacityRejectKey][]time.Time),
 		capacityRateAccepts:            make(map[capacityRejectKey][]time.Time),

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -1296,7 +1296,7 @@ func (r *Registry) snapshotProviderLockedEx(p *Provider, model string, traits Re
 	snap.modelLoaded = slotStateModelLoaded(snap.slotState)
 	snap.availableOnDisk = !snap.modelLoaded
 	snap.fleetMedianTPS = r.tpsRegistry.Median(model, p.Hardware.ChipFamily)
-	snap.pagedKVBackend, _ = p.runsPagedKVLocked()
+	snap.pagedKVBackend = p.runsPagedKVLocked()
 
 	// Gray-box budget clamp (budget_clamp.go): when a capacity-503 has proven
 	// the pair's live gate is rejecting, admission must not believe the
@@ -2329,7 +2329,7 @@ func (r *Registry) quickCapacityCheck(model string, estimatedPromptTokens, reque
 		snap.modelLoaded = slotStateModelLoaded(snap.slotState)
 		snap.availableOnDisk = !snap.modelLoaded
 		snap.fleetMedianTPS = r.tpsRegistry.Median(model, p.Hardware.ChipFamily)
-		snap.pagedKVBackend, _ = p.runsPagedKVLocked()
+		snap.pagedKVBackend = p.runsPagedKVLocked()
 
 		// Gray-box budget clamp — same evaluation as snapshotProviderLockedEx
 		// (including the budgetless-snapshot hold for reconnecting sessions)

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -165,12 +165,28 @@ type routingSnapshot struct {
 	// telemetry keep reading the provider-reported truth. Only set when the
 	// slot reports a token budget (activeTokenBudgetMax > 0).
 	budgetClamped bool
+	// learnedTokenBudgetMax is the pair's learned effective token-budget
+	// ceiling (budget_ceiling.go): min(advertised, the commitment a capacity
+	// reject proved the pair could NOT hold). 0 = nothing learned, in which
+	// case admission uses activeTokenBudgetMax unchanged. LIVE readers go
+	// through effectiveTokenBudgetMax(snap), never this field directly; cost
+	// math, the structural servability ceiling and telemetry keep reading the
+	// raw provider-reported budget.
+	learnedTokenBudgetMax int64
 	// kvBytesPerToken is the provider-reported per-token KV-cache cost (bytes)
 	// for THIS model's slot (BackendSlotCapacity.KVBytesPerToken). 0 = unreported
 	// (callers fall back to the kvCacheBytesPerToken default). Used by the
 	// servability predictor to estimate a cold provider's post-load token budget
 	// the same way the provider does, instead of the fixed default.
-	kvBytesPerToken    int64
+	kvBytesPerToken int64
+	// pagedKVBackend is true when this MACHINE serves the paged KV backend —
+	// any slot it has named reports kv_backend=paged (kv_backend.go
+	// runsPagedKVLocked). False also covers "never observed", which leaves the
+	// cold estimate untouched: an unobserved box is not a contiguous box.
+	// Read ONLY by the paged cold token-budget ceiling
+	// (pagedColdTokenBudgetCeiling); routing, scoring and live admission never
+	// consult the backend kind.
+	pagedKVBackend     bool
 	fleetMedianTPS     float64
 	hasBackendCapacity bool // provider reports BackendCapacity; TTFT estimates are reliable
 
@@ -1280,6 +1296,7 @@ func (r *Registry) snapshotProviderLockedEx(p *Provider, model string, traits Re
 	snap.modelLoaded = slotStateModelLoaded(snap.slotState)
 	snap.availableOnDisk = !snap.modelLoaded
 	snap.fleetMedianTPS = r.tpsRegistry.Median(model, p.Hardware.ChipFamily)
+	snap.pagedKVBackend, _ = p.runsPagedKVLocked()
 
 	// Gray-box budget clamp (budget_clamp.go): when a capacity-503 has proven
 	// the pair's live gate is rejecting, admission must not believe the
@@ -1294,6 +1311,10 @@ func (r *Registry) snapshotProviderLockedEx(p *Provider, model string, traits Re
 	// are both held here (see lock discipline above).
 	rawRemaining := snap.activeTokenBudgetMax - snap.activeTokenBudgetUsed - snap.queuedTokenBudget
 	snap.budgetClamped = r.budgetClampActiveLocked(p.ID, model, p.LastHeartbeat, rawRemaining, snap.activeTokenBudgetMax > 0, now)
+	// Learned effective ceiling (budget_ceiling.go): outlives the clamp, so a
+	// pair whose advertised budget is structurally inflated stops being
+	// re-selected at the commitment level that just failed.
+	snap.learnedTokenBudgetMax = r.budgetCeilingLocked(p.ID, model, snap.activeTokenBudgetMax, now)
 
 	return snap, true
 }
@@ -1368,7 +1389,12 @@ func freeMemoryAdmits(snap routingSnapshot, reqPromptTokens, reqMaxTokens int) b
 		if coordinatorExtra < 0 {
 			coordinatorExtra = 0
 		}
-		if snap.activeTokenBudgetUsed+snap.queuedTokenBudget+coordinatorExtra+requestTokens > snap.activeTokenBudgetMax {
+		// effectiveTokenBudgetMax, not the raw heartbeat max: a learned
+		// ceiling (budget_ceiling.go) holds the pair below the commitment a
+		// capacity reject proved it could not hold. min(advertised, learned)
+		// by construction, so this can only ever admit LESS than the raw
+		// budget would.
+		if snap.activeTokenBudgetUsed+snap.queuedTokenBudget+coordinatorExtra+requestTokens > effectiveTokenBudgetMax(snap) {
 			return false
 		}
 		// The per-slot max encodes this model's own context/KV ceiling. Through
@@ -1485,6 +1511,18 @@ func fillSnapshotPendingAndPool(snap *routingSnapshot, p *Provider, model string
 }
 
 func pendingTokenBudget(pr *PendingRequest) int {
+	return pr.RequestTokens()
+}
+
+// RequestTokens is the request's token demand (prompt + max_tokens) under the
+// coordinator's routing normalization: a negative prompt estimate clamps to 0
+// and an unset max_tokens defaults to defaultRequestedMaxTokens. This is the
+// unit every budget check speaks — pending-budget accounting, the admission
+// gate's requestTokens, and the commitment a capacity reject teaches the
+// learned budget ceiling (budget_ceiling.go) — so it is exported rather than
+// recomputed by the api layer, where a divergent normalization would learn a
+// ceiling in units the gate does not use.
+func (pr *PendingRequest) RequestTokens() int {
 	if pr == nil {
 		return 0
 	}
@@ -2291,12 +2329,14 @@ func (r *Registry) quickCapacityCheck(model string, estimatedPromptTokens, reque
 		snap.modelLoaded = slotStateModelLoaded(snap.slotState)
 		snap.availableOnDisk = !snap.modelLoaded
 		snap.fleetMedianTPS = r.tpsRegistry.Median(model, p.Hardware.ChipFamily)
+		snap.pagedKVBackend, _ = p.runsPagedKVLocked()
 
 		// Gray-box budget clamp — same evaluation as snapshotProviderLockedEx
 		// (including the budgetless-snapshot hold for reconnecting sessions)
 		// so the preflight cannot report capacity that routing then refuses.
 		rawRemaining := snap.activeTokenBudgetMax - snap.activeTokenBudgetUsed - snap.queuedTokenBudget
 		snap.budgetClamped = r.budgetClampActiveLocked(p.ID, model, p.LastHeartbeat, rawRemaining, snap.activeTokenBudgetMax > 0, now)
+		snap.learnedTokenBudgetMax = r.budgetCeilingLocked(p.ID, model, snap.activeTokenBudgetMax, now)
 
 		p.mu.Unlock()
 

--- a/coordinator/registry/servability.go
+++ b/coordinator/registry/servability.go
@@ -250,10 +250,23 @@ func coldTokenBudgetEstimate(totalMemoryGB, modelSizeGB float64, kvBytesPerToken
 // paged BYTE bound by it would manufacture a token ceiling an order of
 // magnitude below the truth and shed traffic every provider could serve. The
 // caller therefore passes snap.kvBytesPerToken — the provider's own reported
-// rate for this model's slot, which a box that idle-unloaded the model still
-// reports — and this returns 0 (do not clamp) when it is absent. Same
-// tri-state discipline as kv_backend.go: an ambiguous input must never tighten
-// a gate whose "no" can be a terminal 429.
+// rate for this model's slot — and this returns 0 (do not clamp) when it is
+// absent. Same tri-state discipline as kv_backend.go: an ambiguous input must
+// never tighten a gate whose "no" can be a terminal 429.
+//
+// # Reach, stated honestly
+//
+// Requiring a real rate makes the clamp NARROW, because a provider only
+// reports a slot for a model it is holding: the 1h idle unload leaves
+// slots:[] (KVBackendPosture), so the ordinary cold box arrives here with no
+// rate and is not clamped. What remains is the slot that is present but
+// non-resident to snapshotStructuralBudget — state "reloading" (wedge-recovery
+// rebuild) or "crashed" (wedge suspected), reporting a live kvBytesPerToken
+// while its KV byte capacity has collapsed to zero, which is one of the same
+// wedge triggers (EngineV2Bridge+Capacity: budgetMax = reportedKVBytesCapacity
+// / kvBytesPerToken). That is a real state, but a rare one, so this clamp is
+// consistency hardening for the paged fleet — NOT a material share of the
+// warm-path oversized_request rejections the learned ceiling addresses.
 func pagedColdTokenBudgetCeiling(totalMemoryGB float64, kvBytesPerToken int64) int64 {
 	if totalMemoryGB <= 0 || kvBytesPerToken <= 0 {
 		return 0
@@ -267,6 +280,27 @@ func pagedColdTokenBudgetCeiling(totalMemoryGB float64, kvBytesPerToken int64) i
 		return 0
 	}
 	return tokens
+}
+
+// effectiveTokenBudgetMax is the token-budget ceiling every LIVE admission
+// reader must use in place of the raw heartbeat value: the learned ceiling
+// (budget_ceiling.go) when one is latched and tighter, the advertised budget
+// otherwise.
+//
+// Zero-value safe on purpose. A snapshot built outside snapshotProviderLocked
+// (tests, and any future construction site) carries learnedTokenBudgetMax == 0,
+// which reads as "nothing learned" rather than as a zero budget.
+//
+// STRUCTURAL readers must NOT use this. snapshotStructuralBudget feeds the
+// fleet-level servability shed (PredictServable), whose "no" is a terminal
+// 429; a learned ceiling is transient, per-box evidence about live capacity
+// and would turn a merely-derated fleet into prompt_too_long. Same split the
+// clamp already draws (see liveRemainingBudget).
+func effectiveTokenBudgetMax(snap routingSnapshot) int64 {
+	if snap.learnedTokenBudgetMax > 0 && snap.learnedTokenBudgetMax < snap.activeTokenBudgetMax {
+		return snap.learnedTokenBudgetMax
+	}
+	return snap.activeTokenBudgetMax
 }
 
 // snapshotStructuralBudget returns this provider's structural token-budget

--- a/coordinator/registry/servability.go
+++ b/coordinator/registry/servability.go
@@ -264,8 +264,13 @@ func coldTokenBudgetEstimate(totalMemoryGB, modelSizeGB float64, kvBytesPerToken
 // rebuild) or "crashed" (wedge suspected), reporting a live kvBytesPerToken
 // while its KV byte capacity has collapsed to zero, which is one of the same
 // wedge triggers (EngineV2Bridge+Capacity: budgetMax = reportedKVBytesCapacity
-// / kvBytesPerToken). That is a real state, but a rare one, so this clamp is
-// consistency hardening for the paged fleet — NOT a material share of the
+// / kvBytesPerToken). That is a real state, but a rare one.
+//
+// Narrower still: on that exact shape knownZeroTokenBudget already refuses the
+// box in LIVE admission (freeMemoryAdmits), so the only reader this clamp can
+// change is snapshotStructuralBudget → PredictServable. Its whole effect is to
+// move the fleet's terminal-429-versus-queue boundary onto the truth. So this
+// is consistency hardening for the paged fleet — NOT a material share of the
 // warm-path oversized_request rejections the learned ceiling addresses.
 func pagedColdTokenBudgetCeiling(totalMemoryGB float64, kvBytesPerToken int64) int64 {
 	if totalMemoryGB <= 0 || kvBytesPerToken <= 0 {

--- a/coordinator/registry/servability.go
+++ b/coordinator/registry/servability.go
@@ -77,6 +77,22 @@ const (
 	// servabilityActivationFloorMinVersion is the first provider release
 	// whose UnifiedMemoryCap holds the 5.5 GiB reserve.
 	servabilityActivationFloorMinVersion = "0.8.0"
+
+	// pagedPoolMachineCapGiB and pagedPoolMemoryDivisor mirror the provider's
+	// PagedKVPhysicalCapacityPolicy machine hard cap:
+	//
+	//	machineCap = min(absoluteHardCapBytes, physicalMemoryBytes / physicalMemoryDivisor)
+	//	           = min(8 GiB,               RAM / 16)
+	//
+	// It is an UPPER bound on a paged pool, not the pool: the real plan is the
+	// minimum of this, the useful-context demand, a quarter of live KV
+	// headroom, twice Metal's max buffer length, and the logical grant. Using
+	// the loosest of those terms keeps the mirror on the fail-open side, and
+	// keeps it to the two inputs the coordinator can actually see (the others
+	// are live provider-side measurements). Retune ONLY when
+	// PagedKVPhysicalCapacityPolicy moves.
+	pagedPoolMachineCapGiB = 8.0
+	pagedPoolMemoryDivisor = 16.0
 )
 
 // servabilityActivationFloorForVersion selects the activation reserve the
@@ -156,6 +172,18 @@ type ServabilityVerdict struct {
 // whenever it exists. So the cold estimate has to converge to the warm report as
 // the slot loads, and it does, because both are the same subtraction.
 //
+// ON A CONTIGUOUS SLOT. v0.8.0's paged backend breaks that convergence
+// premise: a paged slot's ceiling is not this subtraction at all but a
+// separately planned physical pool bounded by min(8 GiB, RAM/16)
+// (PagedKVPhysicalCapacityPolicy), an order of magnitude smaller on a large
+// box. This function is deliberately unchanged — it still faithfully mirrors
+// the CONTIGUOUS reserve arithmetic, which is the only thing it ever claimed
+// to do — and the paged case is a second ceiling applied on top of it in
+// snapshotStructuralBudget (pagedColdTokenBudgetCeiling). Keeping them
+// separate is the point: this function has exactly one referent, and a caller
+// that cannot tell which backend a box runs gets the contiguous answer, which
+// is the fail-open one.
+//
 // That is why there is no attention-posture term here. A composed-attention
 // model (gemma-4: head_dim 256 sliding / 512 full) really does materialise a
 // bigger prefill score tensor than a fused one (gpt-oss: head_dim 64, inside
@@ -201,6 +229,46 @@ func coldTokenBudgetEstimate(totalMemoryGB, modelSizeGB float64, kvBytesPerToken
 	return int64(tokens)
 }
 
+// pagedColdTokenBudgetCeiling is the largest token budget a PAGED slot on this
+// machine could offer for the model once loaded: the paged pool's machine hard
+// cap divided by the model's paged per-token cost.
+//
+// It exists because coldTokenBudgetEstimate's convergence premise — the cold
+// estimate and the warm report are "the same subtraction" — is false for
+// paged. The cold estimate computes the CONTIGUOUS logical grant
+// (0.9×mem − weights − activation reserve, tens of GiB), but a paged slot
+// never gets that: PagedKVPhysicalCapacityPolicy plans a separate physical
+// pool bounded by min(8 GiB, RAM/16), so on a 96 GiB box the cold estimate
+// over-states the warm report by roughly 10×. That gap admits long requests
+// onto cold paged boxes that then reject them at the first submit — the exact
+// admit→503 shape the cold budget check was added to close.
+//
+// A REAL per-token rate is required; there is no kvCacheBytesPerToken
+// fallback here, and that omission is the correctness condition rather than an
+// oversight. That constant (400 kB/token, measured on a CONTIGUOUS 7B cache)
+// is ~20× a composed-attention model's marginal paged rate, so dividing a
+// paged BYTE bound by it would manufacture a token ceiling an order of
+// magnitude below the truth and shed traffic every provider could serve. The
+// caller therefore passes snap.kvBytesPerToken — the provider's own reported
+// rate for this model's slot, which a box that idle-unloaded the model still
+// reports — and this returns 0 (do not clamp) when it is absent. Same
+// tri-state discipline as kv_backend.go: an ambiguous input must never tighten
+// a gate whose "no" can be a terminal 429.
+func pagedColdTokenBudgetCeiling(totalMemoryGB float64, kvBytesPerToken int64) int64 {
+	if totalMemoryGB <= 0 || kvBytesPerToken <= 0 {
+		return 0
+	}
+	poolBytes := totalMemoryGB * float64(bytesPerGB) / pagedPoolMemoryDivisor
+	if capBytes := pagedPoolMachineCapGiB * float64(bytesPerGB); poolBytes > capBytes {
+		poolBytes = capBytes
+	}
+	tokens := int64(poolBytes / float64(kvBytesPerToken))
+	if tokens <= 0 {
+		return 0
+	}
+	return tokens
+}
+
 // snapshotStructuralBudget returns this provider's structural token-budget
 // contribution for the model, and whether it is known. A resident slot uses the
 // provider-reported active_token_budget_max — which already nets out whatever
@@ -221,8 +289,21 @@ func snapshotStructuralBudget(snap routingSnapshot) (budget int64, known bool) {
 	if snap.totalMemoryGB <= 0 || snap.modelSizeGB <= 0 {
 		return 0, false
 	}
-	return coldTokenBudgetEstimate(
-		snap.totalMemoryGB, snap.modelSizeGB, snap.kvBytesPerToken, snap.binaryVersion), true
+	estimate := coldTokenBudgetEstimate(
+		snap.totalMemoryGB, snap.modelSizeGB, snap.kvBytesPerToken, snap.binaryVersion)
+	// Paged boxes get a second, physical ceiling: the contiguous-shaped
+	// subtraction above is not the quantity a paged slot will report once
+	// loaded (see pagedColdTokenBudgetCeiling). Take the tighter of the two —
+	// this can only ever lower the estimate, and only when the machine has
+	// actually been observed serving paged AND the slot reports a real
+	// per-token KV rate.
+	if snap.pagedKVBackend {
+		if ceiling := pagedColdTokenBudgetCeiling(
+			snap.totalMemoryGB, snap.kvBytesPerToken); ceiling > 0 && ceiling < estimate {
+			estimate = ceiling
+		}
+	}
+	return estimate, true
 }
 
 // liveRemainingBudget is snapshotStructuralBudget minus the provider's CURRENTLY
@@ -247,7 +328,12 @@ func liveRemainingBudget(snap routingSnapshot) (budget int64, known bool) {
 		if snap.budgetClamped {
 			return 0, true
 		}
-		rem := snap.activeTokenBudgetMax - snap.activeTokenBudgetUsed - snap.queuedTokenBudget
+		// Learned effective ceiling (budget_ceiling.go): the durable successor
+		// to the clamp. min(advertised, the commitment a capacity reject
+		// proved the pair could not hold), so the live headroom can only ever
+		// be SMALLER than the raw heartbeat's — never larger. Structural
+		// readers stay raw for the same reason the clamp does (see below).
+		rem := effectiveTokenBudgetMax(snap) - snap.activeTokenBudgetUsed - snap.queuedTokenBudget
 		if rem < 0 {
 			rem = 0
 		}

--- a/coordinator/registry/servability_paged_cold_test.go
+++ b/coordinator/registry/servability_paged_cold_test.go
@@ -29,14 +29,18 @@ const (
 	pagedProviderVersion     = "0.8.0"
 )
 
-// coldPagedSnapshot is a provider that has the model ON DISK with a
-// non-resident slot still in its capacity report — the state a box lands in
-// after the 1h idle unload, and the one where it reports a real per-token KV
-// rate for a model it is not currently serving.
+// coldPagedSnapshot is a provider whose slot for the model is present in the
+// capacity report but NOT resident to snapshotStructuralBudget — the
+// wedge-recovery window, where EngineV2Bridge reports state "reloading" with a
+// live kvBytesPerToken and a KV byte capacity that has collapsed to zero (so
+// activeTokenBudgetMax is 0). This is the one reachable shape that carries a
+// real per-token rate without a resident budget; the ordinary 1h idle unload
+// leaves slots:[] and therefore no rate at all. See the "Reach" note on
+// pagedColdTokenBudgetCeiling.
 func coldPagedSnapshot(paged bool) routingSnapshot {
 	return routingSnapshot{
 		binaryVersion:   pagedProviderVersion,
-		slotState:       "idle_shutdown",
+		slotState:       "reloading",
 		modelLoaded:     false,
 		availableOnDisk: true,
 		totalMemoryGB:   pagedBoxMemoryGB,
@@ -207,33 +211,32 @@ func TestPagedColdTokenBudgetCeilingBoundaries(t *testing.T) {
 
 // runsPagedKVLocked is the one routing reader of the KV-backend record. It
 // answers a MACHINE-level question, so any paged slot makes the box paged, and
-// "never observed" must stay distinct from "contiguous".
+// both "contiguous" and "never observed" must read false — the reader's
+// no-clamp branch is correct for either.
 func TestProviderRunsPagedKV(t *testing.T) {
 	paged, contiguous := KVBackendPaged, KVBackendContiguous
 	for name, tc := range map[string]struct {
-		slots        []protocol.BackendSlotCapacity
-		wantPaged    bool
-		wantObserved bool
+		slots     []protocol.BackendSlotCapacity
+		wantPaged bool
 	}{
-		"no slots":              {nil, false, false},
-		"slot names no backend": {[]protocol.BackendSlotCapacity{{Model: "a"}}, false, false},
+		"no slots":              {nil, false},
+		"slot names no backend": {[]protocol.BackendSlotCapacity{{Model: "a"}}, false},
 		"contiguous only": {[]protocol.BackendSlotCapacity{
-			{Model: "a", KVBackend: &contiguous}}, false, true},
+			{Model: "a", KVBackend: &contiguous}}, false},
 		"paged only": {[]protocol.BackendSlotCapacity{
-			{Model: "a", KVBackend: &paged}}, true, true},
+			{Model: "a", KVBackend: &paged}}, true},
 		"mixed box reads paged": {[]protocol.BackendSlotCapacity{
 			{Model: "a", KVBackend: &contiguous},
-			{Model: "b", KVBackend: &paged}}, true, true},
+			{Model: "b", KVBackend: &paged}}, true},
 	} {
 		t.Run(name, func(t *testing.T) {
 			p := &Provider{}
 			p.mu.Lock()
 			p.recordKVBackendsLocked(&protocol.BackendCapacity{Slots: tc.slots})
-			gotPaged, gotObserved := p.runsPagedKVLocked()
+			gotPaged := p.runsPagedKVLocked()
 			p.mu.Unlock()
-			if gotPaged != tc.wantPaged || gotObserved != tc.wantObserved {
-				t.Fatalf("(paged=%v, observed=%v), want (%v, %v)",
-					gotPaged, gotObserved, tc.wantPaged, tc.wantObserved)
+			if gotPaged != tc.wantPaged {
+				t.Fatalf("paged = %v, want %v", gotPaged, tc.wantPaged)
 			}
 		})
 	}
@@ -283,9 +286,13 @@ func TestMixedBackendFleetColdEstimates(t *testing.T) {
 	}
 }
 
-// sendColdBackendHeartbeat delivers a capacity report in which the model is
-// present but NOT resident (idle_shutdown — the state after the 1h idle
-// unload), naming the slot's KV backend and its real per-token KV cost.
+// sendColdBackendHeartbeat delivers a capacity report in which the model's slot
+// is present but NOT resident to the structural-budget reader: state
+// "reloading" (the wedge-recovery window EngineV2Bridge reports) with a real
+// per-token KV cost and a collapsed byte capacity, so activeTokenBudgetMax is
+// absent. This is the only shape a live provider emits that reaches the cold
+// branch with a usable KV rate — see the "Reach" note on
+// pagedColdTokenBudgetCeiling.
 func sendColdBackendHeartbeat(r *Registry, providerID, model, backend string) {
 	kind := backend
 	r.Heartbeat(providerID, &protocol.HeartbeatMessage{
@@ -298,7 +305,7 @@ func sendColdBackendHeartbeat(r *Registry, providerID, model, backend string) {
 			TotalMemoryGB: pagedBoxMemoryGB,
 			Slots: []protocol.BackendSlotCapacity{{
 				Model:           model,
-				State:           "idle_shutdown",
+				State:           "reloading",
 				KVBytesPerToken: pagedKVRateBytesPerToken,
 				KVBackend:       &kind,
 			}},

--- a/coordinator/registry/servability_paged_cold_test.go
+++ b/coordinator/registry/servability_paged_cold_test.go
@@ -1,0 +1,328 @@
+package registry
+
+import (
+	"testing"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+)
+
+// Tests for the paged cold token-budget ceiling (servability.go).
+//
+// coldTokenBudgetEstimate mirrors the provider's CONTIGUOUS reserve arithmetic
+// — 0.9×mem − padded weights − activation reserve — and its own doc argues
+// that the estimate converges to the warm report because "both are the same
+// subtraction". v0.8.0's paged backend breaks that premise: a paged slot's
+// ceiling is a separately planned physical pool bounded by
+// min(8 GiB, RAM/16) (PagedKVPhysicalCapacityPolicy), which on a 96 GiB box is
+// ~10× smaller than the contiguous grant. These tests pin the second ceiling
+// that closes the gap, and — just as importantly — pin the three cases where
+// it must NOT fire.
+
+// gemma-4 paged marginal KV rate: 20,480 B/token over the full-attention
+// layers. A 96 GiB box plans min(8 GiB, 96/16 = 6 GiB) of pool, so a paged
+// slot there tops out near 314k tokens whatever the contiguous subtraction
+// says.
+const (
+	pagedKVRateBytesPerToken = int64(20_480)
+	pagedBoxMemoryGB         = 96.0
+	pagedBoxModelSizeGB      = 12.0
+	pagedProviderVersion     = "0.8.0"
+)
+
+// coldPagedSnapshot is a provider that has the model ON DISK with a
+// non-resident slot still in its capacity report — the state a box lands in
+// after the 1h idle unload, and the one where it reports a real per-token KV
+// rate for a model it is not currently serving.
+func coldPagedSnapshot(paged bool) routingSnapshot {
+	return routingSnapshot{
+		binaryVersion:   pagedProviderVersion,
+		slotState:       "idle_shutdown",
+		modelLoaded:     false,
+		availableOnDisk: true,
+		totalMemoryGB:   pagedBoxMemoryGB,
+		modelSizeGB:     pagedBoxModelSizeGB,
+		kvBytesPerToken: pagedKVRateBytesPerToken,
+		pagedKVBackend:  paged,
+	}
+}
+
+// A paged box and a contiguous box of identical hardware, both cold for the
+// same model, must get DIFFERENT cold estimates: the contiguous box keeps the
+// logical-grant subtraction, the paged box is clamped to its pool ceiling.
+func TestColdBudgetEstimateSplitsByKVBackend(t *testing.T) {
+	contiguous, known := snapshotStructuralBudget(coldPagedSnapshot(false))
+	if !known {
+		t.Fatal("contiguous cold estimate must be known")
+	}
+	wantContiguous := coldTokenBudgetEstimate(
+		pagedBoxMemoryGB, pagedBoxModelSizeGB, pagedKVRateBytesPerToken, pagedProviderVersion)
+	if contiguous != wantContiguous {
+		t.Fatalf("contiguous cold estimate = %d, want the unchanged %d", contiguous, wantContiguous)
+	}
+
+	paged, known := snapshotStructuralBudget(coldPagedSnapshot(true))
+	if !known {
+		t.Fatal("paged cold estimate must be known")
+	}
+	wantPaged := pagedColdTokenBudgetCeiling(pagedBoxMemoryGB, pagedKVRateBytesPerToken)
+	if paged != wantPaged {
+		t.Fatalf("paged cold estimate = %d, want the pool ceiling %d", paged, wantPaged)
+	}
+
+	// The whole point: the two differ by roughly an order of magnitude, and
+	// the paged one is the tighter.
+	if paged >= contiguous {
+		t.Fatalf("paged estimate %d must be tighter than the contiguous %d", paged, contiguous)
+	}
+	if contiguous/paged < 5 {
+		t.Fatalf("paged clamp barely binds (%d vs %d) — the fixture no longer reproduces the gap", paged, contiguous)
+	}
+}
+
+// The clamp must never LOOSEN an estimate. When the contiguous subtraction is
+// already tighter than the pool ceiling (a small box, or the conservative
+// kvCacheBytesPerToken default at work), the existing estimate stands.
+func TestColdBudgetEstimateClampNeverLoosens(t *testing.T) {
+	// A weight-heavy box: the contiguous subtraction leaves under a GiB while
+	// the pool ceiling would allow twice that, so the clamp must not fire.
+	t.Run("contiguous grant already tighter than the pool", func(t *testing.T) {
+		snap := coldPagedSnapshot(true)
+		snap.totalMemoryGB = 32
+		snap.modelSizeGB = 20
+
+		contiguousOnly := snap
+		contiguousOnly.pagedKVBackend = false
+
+		paged, _ := snapshotStructuralBudget(snap)
+		contiguous, _ := snapshotStructuralBudget(contiguousOnly)
+		if paged != contiguous {
+			t.Fatalf("weight-heavy paged estimate = %d, want the unchanged %d — the clamp may only take the tighter branch",
+				paged, contiguous)
+		}
+		if ceiling := pagedColdTokenBudgetCeiling(32, pagedKVRateBytesPerToken); ceiling <= contiguous {
+			t.Fatalf("fixture no longer exercises the non-binding branch: ceiling %d <= estimate %d", ceiling, contiguous)
+		}
+	})
+
+	// The invariant, swept: for every box size and weight, the paged estimate
+	// is at most the contiguous one. This change can only ever tighten.
+	t.Run("invariant across the fleet", func(t *testing.T) {
+		for _, memGB := range []float64{16, 24, 32, 36, 48, 64, 96, 128, 192, 512} {
+			for _, sizeGB := range []float64{4, 12, 20, 40} {
+				snap := coldPagedSnapshot(true)
+				snap.totalMemoryGB, snap.modelSizeGB = memGB, sizeGB
+				contiguousOnly := snap
+				contiguousOnly.pagedKVBackend = false
+
+				paged, pagedKnown := snapshotStructuralBudget(snap)
+				contiguous, contiguousKnown := snapshotStructuralBudget(contiguousOnly)
+				if pagedKnown != contiguousKnown {
+					t.Fatalf("mem=%.0f size=%.0f: knownness diverged (%v vs %v)",
+						memGB, sizeGB, pagedKnown, contiguousKnown)
+				}
+				if paged > contiguous {
+					t.Fatalf("mem=%.0f size=%.0f: paged estimate %d LOOSER than contiguous %d",
+						memGB, sizeGB, paged, contiguous)
+				}
+			}
+		}
+	})
+}
+
+// Fail-open cases. Each of these must leave the estimate byte-identical to
+// today's, because acting on an ambiguous input here can produce a terminal
+// prompt_too_long 429.
+func TestColdBudgetEstimateClampFailsOpen(t *testing.T) {
+	baseline, _ := snapshotStructuralBudget(coldPagedSnapshot(false))
+
+	t.Run("no backend ever observed", func(t *testing.T) {
+		// A pre-0.8.0 provider, or a box that has loaded nothing yet.
+		// Unobserved is not contiguous, but it is certainly not paged.
+		snap := coldPagedSnapshot(false)
+		got, known := snapshotStructuralBudget(snap)
+		if !known || got != baseline {
+			t.Fatalf("unobserved-backend estimate = (%d, %v), want (%d, true)", got, known, baseline)
+		}
+	})
+
+	t.Run("paged but no reported KV rate", func(t *testing.T) {
+		// A truly cold box has no slot for the model and so reports no rate.
+		// Dividing the paged byte bound by the generic kvCacheBytesPerToken
+		// placeholder (400 kB/token, a contiguous 7B measurement) would be
+		// ~20× tighter than the truth, so the clamp must not fire at all.
+		snap := coldPagedSnapshot(true)
+		snap.kvBytesPerToken = 0
+		unratedBaseline := coldTokenBudgetEstimate(
+			pagedBoxMemoryGB, pagedBoxModelSizeGB, 0, pagedProviderVersion)
+		got, known := snapshotStructuralBudget(snap)
+		if !known || got != unratedBaseline {
+			t.Fatalf("unrated paged estimate = (%d, %v), want (%d, true)", got, known, unratedBaseline)
+		}
+	})
+
+	t.Run("resident slot keeps its reported budget", func(t *testing.T) {
+		// A warm paged slot reports its REAL ceiling; the estimate is not
+		// consulted at all and the clamp must not touch it.
+		snap := coldPagedSnapshot(true)
+		snap.modelLoaded = true
+		snap.slotState = "running"
+		snap.activeTokenBudgetMax = 314_572
+		got, known := snapshotStructuralBudget(snap)
+		if !known || got != 314_572 {
+			t.Fatalf("resident paged estimate = (%d, %v), want the reported (314572, true)", got, known)
+		}
+	})
+}
+
+// The mirrored pool arithmetic itself: min(8 GiB, RAM/16) / rate, with both
+// branches of the min exercised and every missing input failing open.
+func TestPagedColdTokenBudgetCeilingBoundaries(t *testing.T) {
+	const gib = float64(int64(1) << 30)
+
+	// RAM/16 binds below 128 GiB.
+	if got, want := pagedColdTokenBudgetCeiling(64, 20_480), int64(64*gib/16)/20_480; got != want {
+		t.Fatalf("64 GiB ceiling = %d, want %d (RAM/16 branch)", got, want)
+	}
+	// The 8 GiB absolute cap binds at and above 128 GiB.
+	if got, want := pagedColdTokenBudgetCeiling(512, 20_480), int64(8*gib)/20_480; got != want {
+		t.Fatalf("512 GiB ceiling = %d, want %d (absolute-cap branch)", got, want)
+	}
+	// Exactly at the crossover the two branches agree.
+	if pagedColdTokenBudgetCeiling(128, 20_480) != pagedColdTokenBudgetCeiling(512, 20_480) {
+		t.Fatal("128 GiB is the crossover: RAM/16 and the 8 GiB cap must agree there")
+	}
+	// Missing inputs fail open.
+	for name, got := range map[string]int64{
+		"no memory": pagedColdTokenBudgetCeiling(0, 20_480),
+		"no rate":   pagedColdTokenBudgetCeiling(96, 0),
+		"neg rate":  pagedColdTokenBudgetCeiling(96, -1),
+		"rate above the whole pool": pagedColdTokenBudgetCeiling(
+			96, int64(7*gib)),
+	} {
+		if got != 0 {
+			t.Fatalf("%s: ceiling = %d, want 0 (do not clamp)", name, got)
+		}
+	}
+}
+
+// runsPagedKVLocked is the one routing reader of the KV-backend record. It
+// answers a MACHINE-level question, so any paged slot makes the box paged, and
+// "never observed" must stay distinct from "contiguous".
+func TestProviderRunsPagedKV(t *testing.T) {
+	paged, contiguous := KVBackendPaged, KVBackendContiguous
+	for name, tc := range map[string]struct {
+		slots        []protocol.BackendSlotCapacity
+		wantPaged    bool
+		wantObserved bool
+	}{
+		"no slots":              {nil, false, false},
+		"slot names no backend": {[]protocol.BackendSlotCapacity{{Model: "a"}}, false, false},
+		"contiguous only": {[]protocol.BackendSlotCapacity{
+			{Model: "a", KVBackend: &contiguous}}, false, true},
+		"paged only": {[]protocol.BackendSlotCapacity{
+			{Model: "a", KVBackend: &paged}}, true, true},
+		"mixed box reads paged": {[]protocol.BackendSlotCapacity{
+			{Model: "a", KVBackend: &contiguous},
+			{Model: "b", KVBackend: &paged}}, true, true},
+	} {
+		t.Run(name, func(t *testing.T) {
+			p := &Provider{}
+			p.mu.Lock()
+			p.recordKVBackendsLocked(&protocol.BackendCapacity{Slots: tc.slots})
+			gotPaged, gotObserved := p.runsPagedKVLocked()
+			p.mu.Unlock()
+			if gotPaged != tc.wantPaged || gotObserved != tc.wantObserved {
+				t.Fatalf("(paged=%v, observed=%v), want (%v, %v)",
+					gotPaged, gotObserved, tc.wantPaged, tc.wantObserved)
+			}
+		})
+	}
+}
+
+// End-to-end through the real registry: two boxes of identical hardware, the
+// same model on disk and non-resident on both, differing only in the backend
+// their heartbeats name. The paged one must be structurally smaller, and the
+// contiguous one must be untouched by this change.
+func TestMixedBackendFleetColdEstimates(t *testing.T) {
+	const model = "gemma-4-26b-qat-4bit"
+	r := New(testLogger())
+	r.SetModelCatalog([]CatalogEntry{{ID: model, SizeGB: pagedBoxModelSizeGB, MinRAMGB: 24}})
+
+	pagedBox := makeSchedulerProvider(t, r, "paged-96", model, 100)
+	contiguousBox := makeSchedulerProvider(t, r, "contiguous-96", model, 100)
+	for _, p := range []*Provider{pagedBox, contiguousBox} {
+		p.mu.Lock()
+		p.Version = pagedProviderVersion
+		p.mu.Unlock()
+	}
+	sendColdBackendHeartbeat(r, pagedBox.ID, model, KVBackendPaged)
+	sendColdBackendHeartbeat(r, contiguousBox.ID, model, KVBackendContiguous)
+
+	pagedBudget := coldStructuralBudget(t, r, pagedBox, model)
+	contiguousBudget := coldStructuralBudget(t, r, contiguousBox, model)
+
+	wantContiguous := coldTokenBudgetEstimate(
+		pagedBoxMemoryGB, pagedBoxModelSizeGB, pagedKVRateBytesPerToken, pagedProviderVersion)
+	if contiguousBudget != wantContiguous {
+		t.Fatalf("contiguous box budget = %d, want the unchanged cold estimate %d", contiguousBudget, wantContiguous)
+	}
+	wantPaged := pagedColdTokenBudgetCeiling(pagedBoxMemoryGB, pagedKVRateBytesPerToken)
+	if pagedBudget != wantPaged {
+		t.Fatalf("paged box budget = %d, want the pool ceiling %d", pagedBudget, wantPaged)
+	}
+
+	// The fleet ceiling PredictServable computes is the max across providers,
+	// so a mixed fleet is still sized by its contiguous boxes — the clamp
+	// tightens per-provider admission without shedding fleet-wide.
+	v := r.PredictServable(model, 400_000, 400_000, 256, 0, RequestTraits{}, false)
+	if v.FleetMaxBudget != wantContiguous {
+		t.Fatalf("FleetMaxBudget = %d, want the contiguous box's %d", v.FleetMaxBudget, wantContiguous)
+	}
+	if !v.Servable {
+		t.Fatalf("mixed fleet must still serve a request the contiguous box can hold: %+v", v)
+	}
+}
+
+// sendColdBackendHeartbeat delivers a capacity report in which the model is
+// present but NOT resident (idle_shutdown — the state after the 1h idle
+// unload), naming the slot's KV backend and its real per-token KV cost.
+func sendColdBackendHeartbeat(r *Registry, providerID, model, backend string) {
+	kind := backend
+	r.Heartbeat(providerID, &protocol.HeartbeatMessage{
+		Type:   protocol.TypeHeartbeat,
+		Status: "idle",
+		SystemMetrics: protocol.SystemMetrics{
+			MemoryPressure: 0.1, CPUUsage: 0.1, ThermalState: "nominal",
+		},
+		BackendCapacity: &protocol.BackendCapacity{
+			TotalMemoryGB: pagedBoxMemoryGB,
+			Slots: []protocol.BackendSlotCapacity{{
+				Model:           model,
+				State:           "idle_shutdown",
+				KVBytesPerToken: pagedKVRateBytesPerToken,
+				KVBackend:       &kind,
+			}},
+		},
+	})
+}
+
+// coldStructuralBudget reads the provider's structural budget through the real
+// routing snapshot, so the test exercises the snapshot wiring rather than a
+// hand-built struct.
+func coldStructuralBudget(t *testing.T, r *Registry, p *Provider, model string) int64 {
+	t.Helper()
+	r.mu.RLock()
+	snap, ok := r.snapshotProviderLocked(p, model, RequestTraits{}, false)
+	r.mu.RUnlock()
+	if !ok {
+		t.Fatalf("provider %s failed the routing gates", p.ID)
+	}
+	if snap.modelLoaded {
+		t.Fatalf("provider %s must be COLD for %s (slot state %q)", p.ID, model, snap.slotState)
+	}
+	budget, known := snapshotStructuralBudget(snap)
+	if !known {
+		t.Fatalf("provider %s structural budget unknown", p.ID)
+	}
+	return budget
+}

--- a/docs/architecture/routing-telemetry-and-calibration.md
+++ b/docs/architecture/routing-telemetry-and-calibration.md
@@ -263,6 +263,15 @@ could have resulted in an output"). The funnel, grounded in code:
 | `rate_limit` | 429 | `rpm_exceeded`, `itpm_exceeded`, `otpm_exceeded`, `global_rate_limit` | `server.go:525,568,2174` |
 | `preflight_capacity` | 429/503 | `machine_busy` (all full), `no_provider` (none serve model), `model_too_large` | `consumer.go:1658-1714,4168-4204` |
 | `routing_ttft` | 429 | `ttft_429`, `queue_timeout` (also in `inference_routes`) | `dispatch.go:358-473` |
+| `dispatch` | 429/503 | `oversized_request` (deterministically unservable shape), `capacity_retries_exhausted` (busy fleet: the transient-capacity retry budget ran out), `unservable_token_budget`, `template_render_failed`, `client_error`, `dispatch_exhausted` | `dispatch.go` exhausted ladder |
+
+`oversized_request` and `capacity_retries_exhausted` used to be the same code, which
+made a busy fleet indistinguishable from an unservable request. They are the two
+verdicts of `shouldStopFailover` and they mean opposite things: the first is a
+property of the REQUEST (every provider rejects it identically), the second is a
+property of the FLEET at that moment. Only the first legitimately reports zero
+candidates; the second reports the real counters, so its `could_have_served` is
+normally **true**.
 
 **Request shape & params (non-private — no content):**
 `request_id`, `endpoint`, `ts`, `key_id`/`consumer_key_hash`, `client_class`


### PR DESCRIPTION
## The insight a reviewer needs first: the paged pool's charge is affine, not linear

A paged slot advertises its token budget as `poolBytes / kvBytesPerToken`, where `kvBytesPerToken` is the **marginal** long-context rate over full-attention layers only (20,480 B/token for gemma-4). But `PagedKVPool.pageDemand` charges every **sliding-window** layer a fixed `ringPageCount` — 97 pages for a 1,024-token window — *per in-flight sequence, regardless of how long that sequence is*. For gemma-4 that is a hidden **303 MiB intercept per concurrent request**, on top of the ~20,480 B per token.

So the real pool charge for `n` concurrent sequences of `t` tokens is

```
bytes(n, t) = n · 303 MiB + n · t · 20,480
```

while the wire budget models it as

```
bytes(n, t) = n · t · 20,480
```

The intercept is worth `303 MiB / 20,480 = 15,518 tokens per in-flight request` that the coordinator never sees. At batch 8 the advertised budget over-states concurrent capacity by roughly **1.6×**: the coordinator computes that 9 requests fit a 6 GiB pool that physically holds 6, and requests 7–9 come back `capacityExhausted`.

**Everything downstream follows from that one fact.** The heartbeat is not stale — it is honestly reporting a number whose *model of the pool* is wrong. Which means:

- Any release condition phrased in terms of that number is always satisfiable, so the budget clamp is a treadmill (Fix 1).
- Any request bounced by it is a *fleet-capacity* event, not an *unservable-request* event, and the ledger says the opposite (Fix 2).
- Any cold estimate that reproduces the contiguous subtraction is describing a different quantity than a paged slot will report (Fix 3).

Production today: ~10% of requests rejected as `oversized_request`, **35% of dispatches are retries**, 439 outright provider `token_budget_exhausted` failures.

### What this PR does not do

It does **not** raise the advertised budget. The pool is physically real and `canEverFit` (`AdmissionV2.swift:354-380`) is a hard gate; over-admitting converts uptime-neutral 429s into provider rejections and, past first content, in-band SSE errors. **Every change here is strictly tighter than current behaviour and cannot over-admit** — see the invariant section at the bottom. No Swift changes, no wire changes, no new modelling constant.

---

## Before / after — behaviour

```mermaid
flowchart TB
  subgraph Before["BEFORE — dispatch, reject, retry x3, 429"]
    direction TB
    B0["request arrives<br/>advertised budget says it fits"] --> B1["scheduler SELECTS the paged pair"]
    B1 --> B2["dispatch"]
    B2 --> B3["provider: token_budget_exhausted<br/>(affine pool is physically full)"]
    B3 --> B4["clamp arms: pair headroom = 0"]
    B4 --> B5["next heartbeat restates the INFLATED budget<br/>raw max - used - queued >= 1024 -> release (a)<br/>an in-flight accept -> release (b)"]
    B5 --> B6{"capacityRetries<br/>&lt; 3 ?"}
    B6 -- yes --> B1
    B6 -- no --> B7["429 reason=oversized_request<br/>ledger: candidate_count=0<br/>could_have_served=FALSE"]
    B7 --> B8["3 wasted dispatches, 3 provider rejections,<br/>a rejection row that blames the prompt"]
  end
```

```mermaid
flowchart TB
  subgraph After["AFTER — deselect before dispatch, queue, serve"]
    direction TB
    A0["request arrives"] --> A1{"used + queued + request<br/>&lt;= effective ceiling ?"}
    A1 -- "no (learned from the reject)" --> A2["pair DESELECTED at selection time<br/>counted as a capacity rejection"]
    A2 --> A3["queue-before-shed spill<br/>(inference_admission.go)"]
    A3 --> A4["slot frees -> used+queued drops<br/>-> pair fits again -> SERVED"]
    A3 -. "queue full / 120s timeout" .-> A5["429 reason=capacity_retries_exhausted<br/>ledger: real candidate + capacity counts<br/>could_have_served=TRUE"]
    A1 -- yes --> A6["dispatch"]
    A6 --> A7["served -> accepts widen the ceiling<br/>back toward the advertised budget"]
    A6 -. "still rejected" .-> A8["ceiling ratchets tighter<br/>(learns the real intercept)"]
  end
```

## Before / after — code

```mermaid
flowchart TB
  subgraph CB["BEFORE"]
    direction TB
    CB1["RecordCapacityReject(provider, model)"] --> CB2["recordBudgetClampLocked<br/>budgetClampEntry{clampedAt, acceptedSince,<br/>budgetReported} — a BOOLEAN"]
    CB2 --> CB3["snap.budgetClamped"]
    CB3 --> CB4["liveRemainingBudget -> 0<br/>freeMemoryAdmits -> false"]
    CB5["heartbeat + accept"] --> CB6["clamp released -> raw advertised budget believed again"]
    CB7["snapshotStructuralBudget (cold)"] --> CB8["coldTokenBudgetEstimate<br/>0.9*mem - weights - 5.5 GiB"]
    CB9["shouldStopFailover: capacityRetries == 3"] --> CB10["unservableReason = oversized_request"]
    CB10 --> CB11["exhausted tail hard-writes<br/>servabilityComputed=true; candidateCount=0"]
  end
```

```mermaid
flowchart TB
  subgraph CA["AFTER"]
    direction TB
    CA1["RecordCapacityRejectSized(provider, model, requestTokens)"] --> CA2["providerBudgetCommitmentLocked (heartbeat)<br/>+ providerPendingTokensLocked (in-gap)<br/>-> (advertised, base = max of the two)"]
    CA2 --> CA3["recordBudgetClampLocked (unchanged)"]
    CA2 --> CA4["recordBudgetCeilingLocked<br/>tokens = min(advertised, base+request-1024)<br/>ratchets DOWN only, TTL anchor held"]
    CA4 --> CA5["snap.learnedTokenBudgetMax"]
    CA5 --> CA6["effectiveTokenBudgetMax(snap)<br/>= min(advertised, learned)"]
    CA6 --> CA7["liveRemainingBudget / freeMemoryAdmits<br/>(LIVE readers only)"]
    CA8["RecordCapacityAcceptOutcome"] --> CA9["noteBudgetCeilingAcceptLocked<br/>+25% per 4 accepts, delete once healed"]
    CA10["snapshotStructuralBudget (cold)"] --> CA11["coldTokenBudgetEstimate (unchanged)"]
    CA11 --> CA12{"provider observed<br/>running paged<br/>AND slot reports a KV rate?"}
    CA12 -- yes --> CA13["min(estimate, pagedColdTokenBudgetCeiling)<br/>= min(8 GiB, RAM/16) / kvBytesPerToken"]
    CA12 -- no --> CA14["estimate unchanged (fail open)"]
    CA15["shouldStopFailover: capacityRetries == 3"] --> CA16["unservableReason =<br/>capacity_retries_exhausted"]
    CA16 --> CA17["exhaustedRejectionInfo<br/>real decision counters;<br/>candidateCount floored by capacityRetries"]
  end
```

---

## Fix 1 — the clamp learns a ceiling instead of flipping a boolean

`coordinator/registry/budget_ceiling.go` (new), read by `servability.go` and `scheduler.go`.

Today one capacity-503 zeroes a pair's live headroom, and release condition (a) at `budget_clamp.go:79-86` — `raw max − used − queued ≥ 1024` — is satisfied by the very next heartbeat *because the advertised budget is structurally inflated*. Bounce, release, bounce. Forever.

The intercept is unknown to the coordinator and differs per box, per model and per batch shape, so this does not model it — it **measures** it. On a capacity reject the coordinator knows the exact commitment that failed, in the same units its own admission gate uses:

```
base = max(used + queued,          // the provider's last heartbeat
           otherPendingForModel)   // the coordinator's own in-gap accounting
S            = base + requestTokens
effectiveMax = min(advertised, S − 1024)
```

That is the weakest statement consistent with the evidence: *this pair could not hold S*. The next request at the same commitment is deselected **before dispatch**, so it takes the existing queue-before-shed spill (`inference_admission.go:457-458`) and is served when a slot frees.

The `max` is load-bearing and was **wrong in the first revision of this PR** (caught in review). Heartbeats arrive every 5 s, so a burst the coordinator itself dispatched inside one gap is invisible in `used + queued`: the heartbeat honestly says ~0 while the box is physically full. Learning off that alone latches a ceiling an order of magnitude tighter than the evidence supports — a single 20 k request against a 314 k advertised budget would derate the pair ~16×, and on a model whose traffic is uniformly long that pair then goes dark for the whole TTL with no request small enough to earn a widen. The coordinator's pending total is exactly the `coordinatorExtra` term `freeMemoryAdmits` already adds to its LHS for this reason, so learning without it was measuring in different units than the gate charges in.

Both halves of that `max` mean *everything the pair holds except the request that failed*, whose demand is then charged once on top. The second revision of this PR got that by subtracting `requestTokens` from the pending sum, and **review caught that too**: `handleInferenceError` calls `RemovePending` as its first statement, before the error is ever pushed onto `ErrorCh`, so the rejected request is never in the pending set when the classifier runs and the sum already meant "the others". The subtraction made every learned ceiling exactly one request-slot too tight on the only path that executes — bounded and self-healing, but the same class of error the `max` exists to prevent. It now excludes the request **by identity**: `providerPendingTokensLocked` skips a request id and `RecordCapacityRejectSized` threads it through, which is exact under either call ordering. A measurement should not depend on a cross-file invariant about who deletes what first.

Design points:

- **Composes with the clamp, does not replace it.** While a clamp holds the pair is FULL exactly as before; the boolean is the ceiling at its tightest. The ceiling outlives it. Every state is at least as tight as today at the same instant.
- **Recovery has three paths, and they are not equally strong.** Draining re-selects a box that finishes work with no state change at all. Widening adds +25% per 4 accepts and deletes the entry once it reaches the advertised budget — but it needs *some* request small enough to fit under the ceiling, so it is fast for a pair whose traffic straddles the ceiling (~40 short requests to climb 1 k → 90 k) and **closed** for a pair whose traffic is uniformly larger than it. For that pair the 10-minute TTL is the only escape, and it is dark until then. `TestBudgetCeilingStarvationRecoversOnlyOnTTL` states that explicitly rather than leaving it to be discovered in production, and both the latch and the heal now emit a log line so the state is visible during an incident.
- **Ratchets down only, TTL anchor included, floored at the observed commitment.** A later reject at a *higher* commitment cannot undo what a tighter one taught (only accepts widen), and it does not refresh `latchedAt` either — a non-tightening reject extending the derating window would turn a bounded fail-open into an unbounded one. But the ratchet stops at the commitment the reject *observed the pair holding*: a ceiling below that is contradicted by direct observation rather than by an accept, and holding it would strand the pair at a level nothing can widen because nothing fits under it. Re-latching there is not widening on a reject; it is refusing to keep a falsified number.
- **No no-op latches.** If the floor would put the ceiling at or above the commitment that just failed, no entry is created: it would re-admit the identical request while still burning a TTL and the accept bookkeeping.
- **Learning requires a sized reject, and a narrower vocabulary than the clamp's.** `RecordCapacityReject` (the size-less form) still arms the clamp and the strike but teaches nothing — without the size the failing commitment is unknown. Request-deterministic / lifecycle / admission-timeout rejects arm neither tracker, via the existing `armClamp` gate. On top of that, only the **token-budget / KV vocabulary** (`isTokenBudgetCapacityReject`) reaches the sized entry point: a `draining` shed for a hot-swap update, or an OOM refusing a model load, is a real capacity statement and still arms the clamp, the strike and the rate window exactly as today — but its commitment number teaches the ceiling nothing, and because fault identity is stable across the reconnect a ceiling latched off a drain would follow a box that comes back healthy. The clamp is a boolean one heartbeat releases; the ceiling is a TTL-bounded derate that survives reconnects. Identical evidence, very different blast radius, so the ceiling gets the narrower gate.
- **The derate is observable as a level, not just as events.** The latch and the heal log, but a log line cannot answer the only question that matters mid-incident: *how many pairs are deselected right now, and is that number decaying?* `routing.budget_ceilings_latched` (registry `BudgetCeilingsLatched`, polled by the existing api metrics loop) is that gauge. A working mitigation shows a handful of pairs that decay; a starved fleet shows the count climbing and staying. This incident was misdiagnosed for an hour because the telemetry conflated two populations, so shipping the remedy without a gauge on its own blast radius would repeat the mistake in a new place.
- **Live readers only.** The structural ceiling (`snapshotStructuralBudget` → `PredictServable`) stays raw, exactly as the clamp already does: a transient per-box measurement must never produce a terminal `prompt_too_long` 429.
- Kill switch `EIGENINFERENCE_BUDGET_CEILING=false`, TTL `EIGENINFERENCE_BUDGET_CEILING_TTL_SECONDS`. Keyed by stable fault identity, bounded by the same >1024 sweep as its siblings. On identity rebind the **tighter live** entry wins: expiry is checked on both sides, because comparing token values blind lets an expired-but-tighter entry destroy a live one and the survivor then carries the stale anchor, so it gates nothing.

## Fix 2 — retry exhaustion is a fleet statement, not a request statement

`coordinator/api/dispatch.go`.

`shouldStopFailover` ran out of `maxCapacityClassRetries` (3) and latched `oversized_request` — the code reserved for genuinely-unservable shapes. Worse, the exhausted tail hard-wrote `servabilityComputed = true; candidateCount = 0`, and `rejection_telemetry.go:141-155` derives `CouldHaveServed = candidateCount > 0` from it. So every one of these rejections reported *zero candidates, could not have served*, when in fact three providers had been dispatched to and were merely full.

**This misreporting sent our incident diagnosis down the wrong path for an hour**, and is worth fixing on its own merits.

- New reason code `capacity_retries_exhausted`, distinct from `oversized_request`.
- New metric `routing.capacity_retries_exhausted` so the two are separately alertable; `routing.oversized_request_rejected` keeps its original meaning.
- New `exhaustedRejectionInfo` helper (also thins the exhausted tail) reports the real routing-decision counters, with `candidateCount` floored by `d.capacityRetries` — each of those rejections came from a provider that was by definition a candidate when it was selected, so a final scan that happened to carry no counters cannot under-report below what the loop itself observed.
- `capacityRejections` is deliberately **not** floored the same way. It counts candidates the admission gate shed *during selection*, never dispatched; `capacityRetries` counts providers that *were* dispatched and 503'd. Those are disjoint halves of the funnel, and maxing them into one field would rebuild exactly the counter conflation this fix exists to remove. (The first revision of this PR did that; caught in review.)
- `d.lastDecision` latches only decisions that carry signal, so a signal-free tail attempt cannot erase what earlier attempts saw.

## Fix 3 — the cold estimate is describing the wrong quantity on a paged box

`coordinator/registry/servability.go`, `coordinator/registry/kv_backend.go`.

`coldTokenBudgetEstimate`'s own doc at `:148-157` argues the cold estimate converges to the warm report "because both are the same subtraction". True on contiguous. False on paged: `PagedKVPhysicalCapacityPolicy` plans a *separate physical pool* bounded by `min(absoluteHardCapBytes, physicalMemoryBytes / physicalMemoryDivisor)` = `min(8 GiB, RAM/16)`. On a 96 GiB box the contiguous subtraction says ~3.4 M tokens where the paged slot will report ~314 k — roughly 10×. That doc is corrected in this PR rather than left to mislead the next reader.

`coldTokenBudgetEstimate` is left byte-identical (it still faithfully mirrors the contiguous reserve arithmetic, which is all it ever claimed to do). The paged case is a **second ceiling** applied on top in `snapshotStructuralBudget`, taking the tighter of the two.

Two gates, both fail-open:

1. **The machine must have been observed running paged.** `kv_backend.go` gains its first routing reader, `runsPagedKVLocked`. The file's `MEASUREMENT ONLY` banner is replaced with a deliberate, scoped justification: provider granularity (the cold model has no slot here, so the question is about the box's pool arithmetic), any paged slot makes the box paged (the backend is a box-level capability, and paged is the conservative answer). A false answer covers both "contiguous" and "never observed", which is correct for the sole reader — it clamps on true and leaves the estimate alone on false.
2. **The slot must report a real per-token KV rate.** There is deliberately **no** `kvCacheBytesPerToken` fallback: that constant is 400 kB/token measured on a *contiguous* 7B cache, ~20× a composed-attention model's marginal paged rate. Dividing a real paged byte bound by that placeholder would manufacture a token ceiling an order of magnitude below the truth and shed traffic every provider could serve.

A swept test asserts the paged estimate is never looser than the contiguous one across box sizes and model weights.

**Reach, stated honestly** (review corrected an overstatement here). Gate 2 is both the correctness condition *and* a severe narrowing, because providers only report a slot for a model they are holding. The 1 h idle unload leaves `slots: []` (`KVBackendPosture.swift`), so the ordinary cold box arrives with no KV rate and is never clamped — the first revision of this PR claimed otherwise, and its end-to-end fixture used a `state: "idle_shutdown"` that no current provider emits. What actually remains is the slot that is present but non-resident to `snapshotStructuralBudget`: state `"reloading"` (wedge-recovery rebuild) or `"crashed"` (wedge suspected), reporting a live `kvBytesPerToken` while `reportedKVBytesCapacity` has collapsed to zero — which is one of the same wedge triggers, so the states co-occur (`EngineV2Bridge+Capacity.swift:120`: `budgetMax = reportedKVBytesCapacity / kvBytesPerToken`). That is real, and the tests now use it, but it is rare.

Narrower still, on review: on that exact shape `knownZeroTokenBudget` (`scheduler.go:1380`) already refuses the box inside `freeMemoryAdmits`, so live admission never consults a cold estimate for it. The only reader this clamp can move is `snapshotStructuralBudget` → `PredictServable` — its entire observable effect is putting the fleet's terminal-429-versus-queue boundary on the truth. **Fix 3 is consistency hardening for the paged fleet, not a material share of the incident.** Fix 1 is where the incident lives.

---

## Why every change is strictly tighter, and cannot over-admit

| Change | Mechanism | Bound |
|---|---|---|
| Learned ceiling | Applied as `min(advertised, learned)` at every read (`effectiveTokenBudgetMax`) | Admission never believes a budget larger than the heartbeat's |
| Learned ceiling vs. the clamp | Clamp behaviour is untouched; the ceiling only applies *after* the clamp releases | No instant is looser than pre-change |
| Learned ceiling latch | `learned >= advertised` does not latch; rejects ratchet down only | A reject can never widen anything |
| Structural shed | `snapshotStructuralBudget` reads the raw advertised budget | No new terminal `prompt_too_long` |
| Reason-code split | Pure relabel + telemetry; identical stop behaviour and identical HTTP 429 | No routing change |
| Paged cold clamp | `min(existing estimate, pool ceiling)` | Can only lower an estimate, never raise one |
| Paged cold clamp gates | Requires an observed paged backend **and** a real KV rate | Ambiguous input leaves today's estimate byte-identical |

"Strictly tighter" is the safety property, but on a capacity-bound fleet it is also the risk: a correlated latch across many paged boxes for the same model darkens them simultaneously and pushes traffic onto the queue-before-shed path. That is why the ceiling is bounded three ways (drain, widen, TTL), why the kill switch exists, and why latch/heal are logged.

## Tests

New: `coordinator/registry/budget_ceiling_test.go`, `coordinator/registry/servability_paged_cold_test.go`, `coordinator/api/dispatch_capacity_retries_test.go`.

- **The treadmill, reproduced** (`TestBudgetCeilingBreaksTheClampTreadmill`): a paged-shaped pair advertising 314,572 tokens at 120,000 committed accepts a 20,256-token request, is rejected by the provider, releases the clamp on the next heartbeat restating the *same inflated budget*, and must **not** be re-selected at the same commitment — then must be selectable again once sustained accepts widen the ceiling. `TestBudgetCeilingKillSwitchRestoresTreadmill` pins the pre-change behaviour behind the kill switch so the two cannot silently converge.
- **The in-gap burst** (`TestBudgetCeilingLearnsFromInGapPendingNotJustTheHeartbeat`): a heartbeat reporting an empty box, six ~20 k requests placed by the coordinator inside the heartbeat gap, and a seventh rejected — the ceiling must be learned off the whole ~141 k commitment, not the ~19 k a stale heartbeat implies. The fixture models the production shape (the rejected request already removed from pending), and a second arm runs the same reject with it *still* resident to pin that the exclusion is by id: both must learn the identical ceiling.
- **The falsified ceiling** (`a ceiling the live commitment falsifies is not ratcheted`): a floor-level ceiling latched by a tiny reject, then a reject observing the pair holding 80 k — the ratchet must yield to the observation rather than strand the pair at 1,024 forever.
- **Narrowed learning scope** (`TestOnlyTokenBudgetRejectsTeachTheCeiling`): a table over the real classifier showing which capacity vocabularies teach the ceiling and which only arm the clamp, with a cross-check that no shape claimed by an earlier branch also reads as a token-budget reject.
- **The starvation path** (`TestBudgetCeilingStarvationRecoversOnlyOnTTL`): a ceiling below one request size, on a model whose traffic is uniformly that size, with the one-shot clamp explicitly released so the ceiling is unambiguously what gates. The pair is dark while idle, widening is unreachable, and only the TTL recovers it. The design's worst case, pinned.
- Latch boundaries: no-latch when not tighter than advertised, floor, no-op floor latch rejected, ratchet-down **and its TTL anchor**, unlearnable inputs, TTL fail-open, sized-reject requirement, non-provider rejects arm nothing, healed-entry deletion, `min(advertised, learned)` never widening, structural shed untouched, `freeMemoryAdmits` honouring the ceiling.
- Identity-rebind merge as a six-case table: tighter-live-source, tighter-live-destination, **expired source must not displace a live destination**, expired source alone dropped, live source onto an empty key, live source replacing an expired destination — plus an assertion that whatever survives can still actually gate.
- Fix 2: transient-vs-deterministic latching; `exhaustedRejectionInfo` counters on all four exits, including that `capacityRejections` keeps the decision's own value; and the headline consequence through the real ledger write — `could_have_served = true` for capacity exhaustion, `false` for an unservable shape.
- Fix 3: mixed-fleet through the real registry (paged and contiguous 96 GiB boxes, same model, same hardware, differing only in the backend their heartbeats name, using the `reloading`-slot shape a provider actually emits); a swept never-looser invariant; three fail-open cases; both branches of `min(8 GiB, RAM/16)` and the 128 GiB crossover; the `runsPagedKVLocked` table.

## Verification

```
cd coordinator && gofmt -l . && go vet ./... && go test ./...   # clean, all green
cd e2e && go build ./... && go vet ./...                        # clean
```

No Swift changes in this PR.

## Honest scope: this is mitigation, not recovered capacity

None of this creates a single token of KV. The pool is physically what it is; these three changes stop the coordinator from *lying to itself about it* and stop us from *burning dispatches discovering it*. My estimate of the ~10% rejection rate each removes is in the PR discussion — the short version is that Fix 1 does essentially all of the work by converting bounced dispatches into queue waits, Fix 2 removes none of it (it makes the remainder legible), and Fix 3 removes approximately none of it (see its reach note above).

**The real capacity is only recoverable provider-side**: either size the pool for the affine charge, or shrink the 1.5156× ring over-provision so the intercept stops costing 303 MiB per in-flight sequence. That is a separate change to `PagedKVPool` / `PagedKVPhysicalCapacityPolicy`.

**Do not merge** without the provider-side follow-up planned.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/596"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787957106&installation_model_id=21733&pr_number=596&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F596&signature=597113abe055399d6240e8d82b88164a6236677b78629d8ad784bdd11a734fbc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->


