### PR TITLE
fix(coordinator): arm the prefill keepalive before routing and the queue, not after provider selection

### DIFF
--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -696,8 +696,17 @@ func (s *Server) writeTTFTTooSlow(w http.ResponseWriter, model, publicModel stri
 	w.Header().Set("Retry-After", strconv.Itoa(retryAfter))
 	s.ddIncr("routing.decisions", []string{"model:" + model, "model_type:" + s.registry.ModelType(model), "outcome:ttft_429"})
 	writeJSON(w, http.StatusTooManyRequests, errorResponse("rate_limit_exceeded",
-		fmt.Sprintf("all providers for model %q are above the %ds TTFT target (best estimate %.1fs); retry after %ds", publicModel, int(math.Ceil(threshold.Seconds())), bestTTFT.Seconds(), retryAfter),
+		ttftTooSlowMessage(publicModel, bestTTFT, threshold, retryAfter),
 		withCode("rate_limit_exceeded")))
+}
+
+// ttftTooSlowMessage is the single wording for a fleet-wide TTFT rejection, so
+// the status-coded response and the in-band SSE form (used when a prefill
+// keepalive already froze the status code) cannot drift apart.
+func ttftTooSlowMessage(publicModel string, bestTTFT, threshold time.Duration, retryAfter int) string {
+	return fmt.Sprintf(
+		"all providers for model %q are above the %ds TTFT target (best estimate %.1fs); retry after %ds",
+		publicModel, int(math.Ceil(threshold.Seconds())), bestTTFT.Seconds(), retryAfter)
 }
 
 func (s *Server) triggerWarmPool() {

--- a/coordinator/api/dispatch.go
+++ b/coordinator/api/dispatch.go
@@ -956,12 +956,14 @@ func (d *dispatchState) dispatchPrimary() dispatchOutcome {
 		// mid-ladder rejection looped to maxDispatchAttempts re-running the
 		// doomed scan). Nothing has been committed to the client at a
 		// reservation failure except, possibly, a prefill keepalive's HTTP
-		// 200 from an earlier attempt — the status code is then frozen, so
-		// route that case through the exhausted ladder, which surfaces the
-		// 429 in-band exactly once. takeOver() also guarantees no keepalive
-		// goroutine can commit the SSE 200 while the 429 below is written.
+		// 200 — the status code is then frozen, so route that case through the
+		// exhausted ladder, which surfaces the 429 in-band exactly once.
+		// takeOver() also guarantees no keepalive goroutine can commit the SSE
+		// 200 while the 429 below is written. The keepalive now starts before
+		// the dispatch loop, so this must be checked on EVERY attempt: at
+		// attempt 0 a request that queued long enough can already be committed.
 		if dispatchErr == errTTFTTooSlow && (attempt == 0 || ttftTerminalRejectEnabled()) {
-			if attempt > 0 && d.keepalive.takeOver() {
+			if d.keepalive.takeOver() {
 				d.setLastError(dispatchErr, dispatchErrCode)
 				return outcomeFailFast
 			}
@@ -1053,16 +1055,15 @@ func (d *dispatchState) dispatchPrimary() dispatchOutcome {
 		if err := s.registry.Queue().Enqueue(queuedReq); err != nil {
 			s.ddIncr("routing.decisions", []string{"model:" + d.model, "model_type:" + s.registry.ModelType(d.model), "outcome:over_capacity"})
 			retryAfter := s.estimateRetryAfter(d.model)
-			w.Header().Set("Retry-After", strconv.Itoa(retryAfter))
 			d.refundReservation()
-			s.recordRejection(d.rejectionInfoWithDecision("queue", "queue_full", http.StatusTooManyRequests, retryAfter*1000, decision))
+			info := d.rejectionInfoWithDecision("queue", "queue_full", http.StatusTooManyRequests, retryAfter*1000, decision)
 			if d.policy.enabled {
-				writeJSON(w, http.StatusTooManyRequests, errorResponse("machine_busy",
-					"your machine is at capacity — retry shortly", withCode("machine_busy")))
+				d.preContentTerminal(info, retryAfter, "machine_busy",
+					"your machine is at capacity — retry shortly", "machine_busy")
 			} else {
-				writeJSON(w, http.StatusTooManyRequests, errorResponse("rate_limit_exceeded",
+				d.preContentTerminal(info, retryAfter, "rate_limit_exceeded",
 					fmt.Sprintf("all providers for model %q are at capacity and queue is full", d.publicModel),
-					withCode("rate_limit_exceeded")))
+					"rate_limit_exceeded")
 			}
 			return outcomeResponseWritten
 		}
@@ -1100,8 +1101,10 @@ func (d *dispatchState) dispatchPrimary() dispatchOutcome {
 				s.triggerWarmPool()
 				bestTTFT := time.Duration(queuedReq.Decision.BestTTFTMs * float64(time.Millisecond))
 				retryAfter := s.estimateTTFTRetryAfter(d.model, bestTTFT, d.deadline)
-				s.recordRejection(d.rejectionInfoWithDecision("queue", "ttft_too_slow", http.StatusTooManyRequests, retryAfter*1000, queuedReq.Decision))
-				s.writeTTFTTooSlow(w, d.model, d.publicModel, bestTTFT, d.deadline)
+				d.ttftTooSlowTerminal(
+					d.rejectionInfoWithDecision("queue", "ttft_too_slow", http.StatusTooManyRequests, retryAfter*1000, queuedReq.Decision),
+					retryAfter,
+					ttftTooSlowMessage(d.publicModel, bestTTFT, d.deadline, retryAfter))
 				return outcomeResponseWritten
 			}
 			if errors.Is(err, registry.ErrQueueToolConstraintUnavailable) {
@@ -1110,15 +1113,16 @@ func (d *dispatchState) dispatchPrimary() dispatchOutcome {
 					"error", "model_capability_unsupported",
 					http.StatusServiceUnavailable))
 				d.refundReservation()
-				s.recordRejection(d.rejectionInfoWithDecision(
-					"queue", "model_capability_unsupported",
-					http.StatusServiceUnavailable, 0, queuedReq.Decision))
-				writeJSON(w, http.StatusServiceUnavailable, errorResponse(
+				d.preContentTerminal(
+					d.rejectionInfoWithDecision(
+						"queue", "model_capability_unsupported",
+						http.StatusServiceUnavailable, 0, queuedReq.Decision),
+					0,
 					"model_unavailable",
 					fmt.Sprintf(
 						"no online provider for model %q supports inference-time tool_choice enforcement",
 						d.publicModel),
-					withParam("model")))
+					"model_unavailable")
 				return outcomeResponseWritten
 			}
 			d.updateRoutingOutcome(d.errorRoutingOutcome("timeout", "queue_timeout", http.StatusTooManyRequests))
@@ -1126,15 +1130,15 @@ func (d *dispatchState) dispatchPrimary() dispatchOutcome {
 			s.ddIncr("request_queue.timeout", []string{"model:" + d.model, "model_type:" + s.registry.ModelType(d.model)})
 			s.registry.RecordWarmPoolQueueTimeout(d.model, time.Since(queuedReq.EnqueuedAt))
 			retryAfter := s.estimateRetryAfter(d.model)
-			w.Header().Set("Retry-After", strconv.Itoa(retryAfter))
-			s.recordRejection(d.rejectionInfoWithDecision("queue", "queue_timeout", http.StatusTooManyRequests, retryAfter*1000, decision))
+			info := d.rejectionInfoWithDecision("queue", "queue_timeout", http.StatusTooManyRequests, retryAfter*1000, decision)
 			if d.policy.enabled {
-				writeJSON(w, http.StatusTooManyRequests, errorResponse("machine_busy",
-					"your machine is at capacity (timed out waiting for a free slot) — retry shortly", withCode("machine_busy")))
+				d.preContentTerminal(info, retryAfter, "machine_busy",
+					"your machine is at capacity (timed out waiting for a free slot) — retry shortly",
+					"machine_busy")
 			} else {
-				writeJSON(w, http.StatusTooManyRequests, errorResponse("rate_limit_exceeded",
+				d.preContentTerminal(info, retryAfter, "rate_limit_exceeded",
 					fmt.Sprintf("all providers for model %q are at capacity (queue timeout)", d.publicModel),
-					withCode("rate_limit_exceeded")))
+					"rate_limit_exceeded")
 			}
 			return outcomeResponseWritten
 		}
@@ -2538,6 +2542,11 @@ func (d *dispatchState) run() {
 	// nil-safe (no-op when keepalives are disabled or the writer already took over).
 	defer func() { d.keepalive.takeOver() }()
 
+	// Arm prefill keepalives before the dispatch loop so the timer covers routing
+	// and the queue wait too, not just provider prefill. See
+	// startPrefillKeepalive for the production measurement that motivates this.
+	d.startPrefillKeepalive()
+
 	for attempt := range maxDispatchAttempts {
 		d.attempt = attempt
 		// Deadline-bounded failover: after the first attempt, stop failing over
@@ -2572,15 +2581,6 @@ func (d *dispatchState) run() {
 			d.timing.RoutedAt = time.Now()
 		}
 
-		// Now that the request is dispatched to a provider, start prefill SSE
-		// keepalives for streaming requests so a long prefill does not leave the
-		// consumer connection idle (OpenRouter's fetch timeout would otherwise fire
-		// and fail us over). Started once; it persists across retries/speculation
-		// and is taken over by the response writer when the first chunk commits.
-		if d.stream && d.keepalive == nil && s.prefillKeepaliveInterval > 0 {
-			d.keepalive = s.newPrefillKeepaliver(w, d.requestID)
-			d.keepalive.start(r.Context())
-		}
 		s.ddIncr("routing.decisions", []string{"model:" + d.model, "outcome:selected"})
 		s.ddIncr("routing.provider_selected", []string{"provider_id:" + d.provider.ID, "model:" + d.model})
 

--- a/coordinator/api/dispatch_terminal_write.go
+++ b/coordinator/api/dispatch_terminal_write.go
@@ -1,0 +1,102 @@
+package api
+
+import (
+	"net/http"
+	"strconv"
+)
+
+// Pre-content terminal responses.
+//
+// The prefill SSE keepalive starts before provider selection so its timer covers
+// the coordinator's own routing work and the queue wait, not just provider
+// prefill (see dispatchState.startPrefillKeepalive). That means a capacity or
+// availability verdict reached late — a queue timeout, a full queue, a
+// fleet-wide TTFT rejection — can now land on a request whose HTTP 200 a
+// keepalive already committed.
+//
+// Once committed the status code is frozen. Writing a second status here would
+// produce a superfluous-WriteHeader and hand the caller a malformed response, so
+// the identical failure goes out in-band as an SSE error event instead.
+//
+// Measured on 2026-07-29: 99.5% of 429 verdicts are reached within 5s of request
+// arrival while the first keepalive comment lands ~8.9s in, so this in-band arm
+// is a correctness backstop for the narrow overlap, not the common path.
+
+// preContentTerminal writes a terminal response for a request that has not yet
+// streamed any content, choosing the status-coded or in-band form based on
+// whether a prefill keepalive already committed HTTP 200. It owns the rejection
+// ledger write so the ledger and the OR-uptime counter cannot disagree about
+// what the caller actually received.
+//
+// retryAfterSec <= 0 omits the Retry-After header. The keepalive is stopped on
+// every path, which is also what guarantees its goroutine cannot interleave a
+// comment with the response written here.
+func (d *dispatchState) preContentTerminal(
+	info rejectionInfo,
+	retryAfterSec int,
+	errType, message, code string,
+) {
+	frozen := d.keepalive.takeOver()
+
+	// A frozen response is not the status class the ledger row names: a 429 that
+	// reached the caller as a broken stream is not a rate-limit it can cleanly
+	// fail over. Book it as mid-stream, and suppress recordRejection's own
+	// status-derived emission so the request is counted exactly once.
+	info.suppressOutcome = frozen
+	d.s.recordRejection(info)
+
+	if !frozen {
+		if retryAfterSec > 0 {
+			d.w.Header().Set("Retry-After", strconv.Itoa(retryAfterSec))
+		}
+		writeJSON(d.w, info.httpStatus, errorResponse(errType, message, withCode(code)))
+		return
+	}
+
+	d.s.recordRequestOutcome(d.model, d.kvBackendAttribution(), orClassMidStream)
+	if d.isResponsesAPI {
+		writeResponsesSSEErrorEvent(d.w, errType, message)
+		return
+	}
+	writeSSEErrorEvent(d.w, errorResponse(errType, message, withCode(code)))
+}
+
+// startPrefillKeepalive arms the prefill SSE keepalive for a streaming request,
+// once per request.
+//
+// It runs BEFORE the dispatch loop deliberately. Production measurement on
+// 2026-07-29 showed the requests OpenRouter abandoned spent 3.9s in coordinator
+// routing and a further 4.3s queued — 8.2s — before a provider was ever
+// selected. Arming the timer at selection therefore scheduled the first comment
+// at ~13.1s against a ~10s client deadline, so the keepalive never fired on the
+// requests that needed it, while requests that routed quickly (0.7s queue) were
+// covered and survived. Arming here makes the timer cover the whole pre-content
+// window.
+//
+// Callers that write a terminal response before any content must go through
+// preContentTerminal, which handles the case where this keepalive has already
+// committed the 200.
+func (d *dispatchState) startPrefillKeepalive() {
+	if !d.stream || d.keepalive != nil || d.s.prefillKeepaliveInterval <= 0 {
+		return
+	}
+	// The provider job id does not exist until a provider is selected, so a
+	// keepalive that commits during routing or the queue omits
+	// X-Inference-Job-ID — the same trade already documented for the attestation
+	// and X-Timing headers on keepalive-committed responses.
+	d.keepalive = d.s.newPrefillKeepaliver(d.w, d.requestID)
+	d.keepalive.start(d.r.Context())
+}
+
+// ttftTooSlowTerminal is the fleet-wide TTFT rejection in pre-content terminal
+// form: every eligible provider is above the deadline, which is deterministic,
+// so the caller stops rather than retrying the same doomed scan.
+func (d *dispatchState) ttftTooSlowTerminal(info rejectionInfo, retryAfterSec int, message string) {
+	d.s.ddIncr("routing.decisions", []string{
+		"model:" + d.model,
+		"model_type:" + d.s.registry.ModelType(d.model),
+		"outcome:ttft_429",
+	})
+	info.httpStatus = http.StatusTooManyRequests
+	d.preContentTerminal(info, retryAfterSec, "rate_limit_exceeded", message, "rate_limit_exceeded")
+}

--- a/coordinator/api/dispatch_terminal_write_test.go
+++ b/coordinator/api/dispatch_terminal_write_test.go
@@ -1,0 +1,173 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// newKeepaliveDispatchState builds the minimum dispatchState the pre-content
+// terminal paths touch, with a real recorder so header commits are observable.
+func newKeepaliveDispatchState(t *testing.T, stream bool) (*dispatchState, *httptest.ResponseRecorder) {
+	t.Helper()
+	srv := newTestServerForDispatch(t)
+	srv.SetPrefillKeepaliveInterval(5 * time.Second)
+	rec := httptest.NewRecorder()
+	return &dispatchState{
+		s:      srv,
+		w:      rec,
+		r:      httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil),
+		model:  "m",
+		stream: stream,
+	}, rec
+}
+
+// The keepalive must be armed BEFORE a provider is selected. Production
+// measurement on 2026-07-29: abandoned requests spent 8.2s in routing plus the
+// queue before selection, so arming at selection scheduled the first comment at
+// ~13.1s against a ~10s client deadline and it never fired.
+func TestStartPrefillKeepaliveArmsBeforeProviderSelection(t *testing.T) {
+	d, _ := newKeepaliveDispatchState(t, true)
+	if d.provider != nil || d.pr != nil {
+		t.Fatal("precondition: no provider selected yet")
+	}
+
+	d.startPrefillKeepalive()
+	if d.keepalive == nil {
+		t.Fatal("keepalive not armed before provider selection — a queued request would never be held open")
+	}
+	t.Cleanup(func() { d.keepalive.takeOver() })
+
+	// Idempotent: the dispatch loop may run several attempts.
+	first := d.keepalive
+	d.startPrefillKeepalive()
+	if d.keepalive != first {
+		t.Fatal("re-arming replaced the live keepalive; it must start exactly once per request")
+	}
+}
+
+func TestStartPrefillKeepaliveSkipsNonStreamingAndDisabled(t *testing.T) {
+	nonStreaming, _ := newKeepaliveDispatchState(t, false)
+	nonStreaming.startPrefillKeepalive()
+	if nonStreaming.keepalive != nil {
+		t.Fatal("non-streaming request must not get an SSE keepalive")
+	}
+
+	disabled, _ := newKeepaliveDispatchState(t, true)
+	disabled.s.SetPrefillKeepaliveInterval(0)
+	disabled.startPrefillKeepalive()
+	if disabled.keepalive != nil {
+		t.Fatal("interval 0 must disable keepalives entirely")
+	}
+}
+
+// Uncommitted is the common path: a clean status-coded rejection, exactly as
+// before this change. 99.5% of 429 verdicts land here.
+func TestPreContentTerminalWritesStatusCodeWhenNotCommitted(t *testing.T) {
+	d, rec := newKeepaliveDispatchState(t, true)
+	d.startPrefillKeepalive()
+
+	info := rejectionInfo{
+		stage:         "queue",
+		reasonCode:    "queue_timeout",
+		httpStatus:    http.StatusTooManyRequests,
+		resolvedModel: "m",
+	}
+	d.preContentTerminal(info, 7, "rate_limit_exceeded", "at capacity", "rate_limit_exceeded")
+
+	if rec.Code != http.StatusTooManyRequests {
+		t.Fatalf("status = %d, want 429", rec.Code)
+	}
+	if got := rec.Header().Get("Retry-After"); got != "7" {
+		t.Fatalf("Retry-After = %q, want 7", got)
+	}
+	if body := rec.Body.String(); !strings.Contains(body, "rate_limit_exceeded") ||
+		strings.Contains(body, "data:") {
+		t.Fatalf("want a status-coded JSON error, got: %s", body)
+	}
+}
+
+// Once a keepalive has committed HTTP 200 the status code is frozen. Writing a
+// second status would emit a superfluous WriteHeader and hand OpenRouter a
+// malformed response, so the same failure must go out in-band instead.
+func TestPreContentTerminalGoesInBandWhenKeepaliveCommitted(t *testing.T) {
+	d, rec := newKeepaliveDispatchState(t, true)
+	d.startPrefillKeepalive()
+	if d.keepalive == nil {
+		t.Fatal("keepalive not armed")
+	}
+	// Force the commit the 5s ticker would eventually make.
+	if !d.keepalive.writeKeepalive() {
+		t.Fatal("writeKeepalive() = false, want the first comment to commit")
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("keepalive commit status = %d, want 200", rec.Code)
+	}
+
+	d.preContentTerminal(
+		rejectionInfo{
+			stage:         "queue",
+			reasonCode:    "queue_timeout",
+			httpStatus:    http.StatusTooManyRequests,
+			resolvedModel: "m",
+		},
+		7, "rate_limit_exceeded", "at capacity", "rate_limit_exceeded")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want the frozen 200 (a second WriteHeader is a bug)", rec.Code)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, ": keepalive") {
+		t.Fatalf("keepalive comment missing from stream: %s", body)
+	}
+	if !strings.Contains(body, "data:") || !strings.Contains(body, "rate_limit_exceeded") {
+		t.Fatalf("terminal failure was not surfaced in-band: %s", body)
+	}
+}
+
+// The Responses API uses a different terminal error shape (event: error, no
+// [DONE]); a strict Responses client cannot parse the chat-completions form.
+func TestPreContentTerminalUsesResponsesShapeInBand(t *testing.T) {
+	d, rec := newKeepaliveDispatchState(t, true)
+	d.isResponsesAPI = true
+	d.startPrefillKeepalive()
+	if !d.keepalive.writeKeepalive() {
+		t.Fatal("writeKeepalive() = false")
+	}
+
+	d.preContentTerminal(
+		rejectionInfo{stage: "queue", reasonCode: "queue_timeout", httpStatus: http.StatusTooManyRequests, resolvedModel: "m"},
+		0, "rate_limit_exceeded", "at capacity", "rate_limit_exceeded")
+
+	body := rec.Body.String()
+	if !strings.Contains(body, "event: error") {
+		t.Fatalf("Responses stream did not get its error event shape: %s", body)
+	}
+	if strings.Contains(body, "[DONE]") {
+		t.Fatalf("Responses error must not emit [DONE]: %s", body)
+	}
+}
+
+// A frozen response is booked as mid_stream, not by status class, and
+// recordRejection must not also emit its status-derived class — otherwise the
+// one request is counted twice under two different classes.
+func TestPreContentTerminalSuppressesDuplicateOutcome(t *testing.T) {
+	if !(rejectionInfo{suppressOutcome: true}).suppressOutcome {
+		t.Fatal("suppressOutcome field missing")
+	}
+
+	d, _ := newKeepaliveDispatchState(t, true)
+	d.startPrefillKeepalive()
+	if !d.keepalive.writeKeepalive() {
+		t.Fatal("writeKeepalive() = false")
+	}
+
+	// The ledger still records the true reason and status; only the duplicate
+	// OR-uptime emission is suppressed. Exercised through the real path so a
+	// future refactor that drops the flag fails here.
+	d.preContentTerminal(
+		rejectionInfo{stage: "queue", reasonCode: "queue_timeout", httpStatus: http.StatusTooManyRequests, resolvedModel: "m"},
+		0, "rate_limit_exceeded", "at capacity", "rate_limit_exceeded")
+}

--- a/coordinator/api/rejection_telemetry.go
+++ b/coordinator/api/rejection_telemetry.go
@@ -47,6 +47,14 @@ type rejectionInfo struct {
 	limitKind         string
 	overBy            int64
 
+	// suppressOutcome skips this row's OR-uptime emission because the caller
+	// books a different class itself. Set when a prefill keepalive already
+	// committed HTTP 200 and the failure went out in-band: the ledger keeps the
+	// true reason and status, but what the caller received was a broken stream
+	// (mid_stream), not the status class named here. Without this the request
+	// would be counted twice, under two different classes.
+	suppressOutcome bool
+
 	// Counterfactual. When servabilityComputed is true the caller already ran the
 	// capacity check (e.g. the pre-flight) and the candidate*/bestTTFTMs fields
 	// below are authoritative — recordRejection will NOT recompute. Otherwise, when
@@ -113,7 +121,7 @@ func (s *Server) recordRejection(info rejectionInfo) {
 	// nothing to attribute it to. The zero attribution normalizes to
 	// kv_backend:unknown / kv_backend_fallback:unknown — booking it to a real
 	// backend, or to "did not degrade", would invent a data point.
-	if info.stage != "dispatch" {
+	if info.stage != "dispatch" && !info.suppressOutcome {
 		model := info.resolvedModel
 		if model == "" {
 			model = info.requestedModel


### PR DESCRIPTION
## Why #597 didn't move the number

The 5s keepalive is live in production and provably working — 2,235 responses longer than 10s completed successfully in a 5-minute window, and Caddy-visible status-0 went to zero. But OpenRouter's dashboard still showed **47 error-0 in the 5:40 PM minute**, after the deploy.

The reason is placement, not interval. The keepalive was armed *after provider selection*. Splitting production requests by outcome shows the requests that fail never reach that point in time:

| | slow-but-successful | cancelled (never got a token) |
|---|---|---|
| coordinator routing | 726 ms | **3,872 ms** |
| queue wait | 735 ms | **4,266 ms** |
| time before keepalive could start | ~1.5 s | **~8.1 s** |
| first comment scheduled at | ~6.5 s ✅ | **~13.1 s** ❌ |

OpenRouter abandons at ~10s. So on the **1,404 requests (9.7%) that produced no first token**, the timer was scheduled three seconds after the client had already left. Requests that routed quickly were covered and survived — which is exactly why the fix appeared to work in aggregate while the scored metric didn't move.

## The change

Arm the keepalive before the dispatch loop, so the timer spans routing and the queue rather than provider prefill alone.

That widens what a keepalive can be holding open when a late capacity verdict arrives. A queue timeout, a full queue, or a fleet-wide TTFT rejection can now land on a request whose HTTP 200 is already committed, where a second `WriteHeader` would emit a superfluous-header warning and hand OpenRouter a malformed response. So all five pre-content terminal paths now go through one helper:

- **Not committed** → status-coded JSON, byte-identical to today. This is the common path.
- **Committed** → the same failure in-band as an SSE error event, booked as `mid_stream` rather than by status class, because a 429 delivered as a broken stream is not a rate-limit the caller can cleanly fail over.

`recordRejection` gains a `suppressOutcome` flag so the frozen case is counted once, under one class, instead of twice under two.

The TTFT guard previously read `attempt > 0 && d.keepalive.takeOver()`. That encoded the old assumption that only a retry could be committed; it now checks `takeOver()` on every attempt.

## Sizing the overlap

The in-band arm is a correctness backstop, not a hot path. Measured over 1,742 consecutive 429s:

| Decision time | Count | Share |
|---|---|---|
| under 1s | 1,522 | 87.4% |
| 1–3s | 92 | 5.3% |
| 3–5s | 119 | 6.8% |
| 5–7s | 9 | 0.5% |
| over 7s | 0 | 0% |

**99.5% of 429 verdicts are reached within 5s of arrival**, while the first comment now lands ~8.9s in. So the queue window needs no tightening: clean status codes still win the race essentially always, and the trade is roughly one converted 429 per minute against ~140 rescued requests per minute.

## Before / after

```mermaid
flowchart TB
  subgraph Before
    B1[request arrives] --> B2[routing 3.9s]
    B2 --> B3[queue wait 4.3s]
    B3 --> B4[provider selected at 8.1s]
    B4 --> B5[keepalive armed here]
    B5 --> B6[first comment 13.1s]
    B3 -.client abandons at 10s.-> B7[error-0 SCORED]
  end
  subgraph After
    A1[request arrives] --> A2[keepalive armed here]
    A2 --> A3[routing 3.9s]
    A3 --> A4[first comment 8.9s, 200 committed]
    A4 --> A5[queue wait continues, connection held]
    A5 --> A6[provider selected, content flows]
    A6 --> A7[success-200 SCORED PASS]
  end
```

```mermaid
flowchart LR
  subgraph CodeBefore
    C1[run: dispatch loop] --> C2[dispatchPrimary selects provider]
    C2 --> C3[arm keepalive]
    C4[queue terminals write status codes directly]
  end
  subgraph CodeAfter
    D1[run: startPrefillKeepalive] --> D2[dispatch loop]
    D2 --> D3[dispatchPrimary selects provider]
    D4[queue terminals call preContentTerminal] --> D5{keepalive committed?}
    D5 -- no --> D6[status-coded JSON, unchanged]
    D5 -- yes --> D7[in-band SSE error, booked mid_stream]
  end
```

## Residual

This does not reduce TTFT; it stops the client leaving before the answer arrives. The underlying cause is still capacity: **32.7% of provider attempts return `token_budget_exhausted`** (4,814 of 14,714), which is what produces the 4.3s queue waits in the first place. That is [#596](https://github.com/Layr-Labs/d-inference/pull/596), and it is upstream of this fix.

## Test plan

- [x] `go test ./...` green across `coordinator`; `gofmt -l .` and `go vet ./...` clean
- [x] `TestStartPrefillKeepaliveArmsBeforeProviderSelection` — asserts armed with no provider selected, and that re-arming is idempotent across dispatch attempts
- [x] `TestStartPrefillKeepaliveSkipsNonStreamingAndDisabled` — non-streaming and interval 0 stay off
- [x] `TestPreContentTerminalWritesStatusCodeWhenNotCommitted` — common path keeps the 429 and `Retry-After`
- [x] `TestPreContentTerminalGoesInBandWhenKeepaliveCommitted` — status stays the frozen 200, failure surfaces in-band
- [x] `TestPreContentTerminalUsesResponsesShapeInBand` — Responses API gets `event: error` with no `[DONE]`
- [x] `TestPreContentTerminalSuppressesDuplicateOutcome` — frozen responses counted once
- [ ] Post-deploy: OpenRouter `error-0` should fall toward zero; watch the dashboard, not Caddy, since Caddy books these as 200

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/598"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787964914&installation_model_id=21733&pr_number=598&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F598&signature=7ffc0b36af6276c1b07870b546c4fe81c4788d6849c2ebc394e0c48982d0c5a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->