### PR TITLE
Recover M4 fan helper after transient sensor faults

### DIFF
--- a/docs/architecture/components/provider.md
+++ b/docs/architecture/components/provider.md
@@ -58,8 +58,11 @@ enable` copies the independently signed executable to
 The helper accepts an activity lease only from the exact Darkbloom Developer ID
 team and provider signing identifier. It receives no prompts, model data,
 credentials, or network access. Lease expiry, XPC invalidation, sleep, thermal
-pressure, and write failures restore macOS automatic fan mode. The boundary is
-defined in `DarkbloomFanProtocol/FanIPC.swift`, `DarkbloomFanService/`, and
+pressure, invalid sensors, and write failures restore macOS automatic fan mode.
+The helper rejects leases until fan and GPU-sensor discovery is ready, retries
+transient discovery in-process, and uses the same bounded verified Auto restore
+for live rollback and startup journal recovery. The boundary is defined in
+`DarkbloomFanProtocol/FanIPC.swift`, `DarkbloomFanService/`, and
 `DarkbloomFanHelper/FanXPCService.swift`.
 
 ## Privacy-relevant boundaries

--- a/docs/provider/fan-control.md
+++ b/docs/provider/fan-control.md
@@ -94,6 +94,24 @@ journal and restores those fans before accepting a new lease. `Ftst` is cleared
 only when Darkbloom recorded possible ownership. The journal implementation is in
 `DarkbloomFanService/FanDurableFile.swift` and `FanOwnershipRecovery.swift`.
 
+Auto restoration uses a bounded write-and-readback loop shared by live rollback
+and startup journal recovery. Each pass requests Auto for every unresolved fan,
+releases an owned `Ftst` gate, and then rechecks any fan whose firmware state had
+not converged. The ownership journal remains until every tracked state is
+verified.
+
+GPU discovery is also recoverable. The helper rejects provider leases while fan
+or sensor discovery is incomplete and retries discovery every five seconds. A
+runtime invalid sensor first revokes the lease and restores Auto; only after that
+restore succeeds can a fresh inventory omit the bad key and accept a new lease.
+At least half of the chip-family catalog and half of the durable last-known-good
+sensor set must remain. This prevents a transient SMC snapshot from leaving a
+live helper permanently `unsupported` or lowering its quorum after restart.
+
+`darkbloom fan status --json` exposes `hardwareReady`, `recoveryPending`,
+`discoveryError`, and `quarantinedSensorKeys`. The last failure is retained
+across helper restarts and cleared after a healthy policy tick.
+
 Darkbloom refuses to take over a fan or global `Ftst` gate already held by
 another fan-control application. Stop that application and restore its Auto mode
 before enabling Darkbloom.
@@ -108,6 +126,8 @@ Explicit enablement creates only these root-owned files:
 | `/Library/LaunchDaemons/io.darkbloom.fan.plist` | System launchd job |
 | `/Library/Application Support/Darkbloom/fan-policy.json` | Validated policy and provider UID |
 | `/Library/Application Support/Darkbloom/fan-session.json` | Crash-recovery ownership journal, present only while control may be active |
+| `/Library/Application Support/Darkbloom/fan-last-failure.json` | Bounded diagnostic record, removed after recovery or disable |
+| `/Library/Application Support/Darkbloom/fan-sensor-baseline.json` | Durable last-known-good sensor set used to preserve recovery quorum |
 
 The helper links only the fan core, XPC protocol, Foundation, IOKit, and Security.
 It has no coordinator client, network code, provider credentials, model access,
@@ -119,6 +139,11 @@ The signed application bundle contains a dormant helper, but the unprivileged
 self-updater never replaces the root-installed copy. A compatible helper keeps
 working; a protocol mismatch grants no lease and leaves the fans in Auto. Run
 `sudo darkbloom fan enable` again to install a newer bundled helper.
+
+The recovery changes use local fan protocol v2. A v2 provider deliberately
+cannot renew a lease on the original v1 helper, because v1 lacks the restore and
+rediscovery guarantees above. The `fan-helper-v1` bundle capability marker is
+unchanged: it identifies the signed helper artifact, not its local XPC protocol.
 
 The release workflow, installer, and self-updater require agreement between the
 CLI capability string, sealed `fan-helper-v1` marker, nested executable mode, and
@@ -134,7 +159,7 @@ were detected. Do not describe a machine family as validated until a real-device
 test has covered engage, release, provider stop, sleep/wake, helper restart, and
 uninstall restoration.
 
-Current v0.7.9 evidence:
+Current evidence:
 
 | Hardware | Validation |
 |---|---|

--- a/docs/threat-model.yaml
+++ b/docs/threat-model.yaml
@@ -2314,6 +2314,7 @@ threats:
     adversaries: [ADV-001]
     affected_assets: [A-014]
     affected_files:
+      - provider-swift/Sources/DarkbloomFanCore/FanAutomaticRestore.swift
       - provider-swift/Sources/DarkbloomFanCore/FanController.swift
       - provider-swift/Sources/DarkbloomFanHelper/FanDaemon.swift
       - provider-swift/Sources/DarkbloomFanService/FanOwnershipRecovery.swift
@@ -2329,6 +2330,11 @@ threats:
       - description: >
           Signal shutdown, sleep, administrator disable, and uninstall restore and
           verify Auto. Uninstall refuses to delete recovery state if restoration fails.
+        status: implemented
+      - description: >
+          Live rollback and startup reconciliation share a bounded verified retry
+          loop, retain unresolved ownership, and recheck fan modes after releasing an
+          owned Ftst gate so asynchronous firmware transitions can converge.
         status: implemented
     open_findings: []
     severity: high
@@ -2386,6 +2392,12 @@ threats:
       - description: >
           Takeover never lowers the existing target; serious/critical macOS thermal
           pressure, invalid readings, or control failures restore system Auto.
+        status: implemented
+      - description: >
+          Incomplete discovery rejects leases and retries in-process. A runtime invalid
+          sensor revokes the lease and restores Auto before rediscovery can quarantine
+          it; a fresh lease requires both the chip-family catalog quorum and the
+          root-owned last-known-good sensor-set quorum to remain healthy across restart.
         status: implemented
     open_findings: []
     severity: medium

--- a/provider-swift/Sources/DarkbloomFanCore/FanAutomaticRestore.swift
+++ b/provider-swift/Sources/DarkbloomFanCore/FanAutomaticRestore.swift
@@ -1,0 +1,239 @@
+import Foundation
+
+public struct FanAutomaticRestoreOutcome: Equatable, Sendable {
+    public let unresolvedFanIndices: [Int]
+    public let ownsFtst: Bool
+    public let failures: [FanRollbackFailure]
+
+    public init(
+        unresolvedFanIndices: [Int],
+        ownsFtst: Bool,
+        failures: [FanRollbackFailure]
+    ) {
+        self.unresolvedFanIndices = Array(Set(unresolvedFanIndices)).sorted()
+        self.ownsFtst = ownsFtst
+        self.failures = failures
+    }
+}
+
+/// Restores every tracked fan and the optional global force-test gate with a
+/// shared, bounded retry budget. Each round attempts fan Auto first and Ftst
+/// release second. A later round then re-verifies fans after macOS has had an
+/// opportunity to reclaim them.
+public enum FanAutomaticRestore {
+    public static func verifyAutomatic(
+        backend: any SMCBackend,
+        fans: [FanCapability],
+        timing: FanControlTiming = .production
+    ) -> [FanRollbackFailure] {
+        var unresolved: [Int: FanCapability] = [:]
+        for fan in fans {
+            unresolved[fan.index] = fan
+        }
+        var errors: [Int: FanRollbackError] = [:]
+        var terminal = Set<Int>()
+
+        for attempt in 0..<timing.automaticRestoreAttempts {
+            for fan in unresolved.values.sorted(by: { $0.index < $1.index })
+                where !terminal.contains(fan.index)
+            {
+                do {
+                    let raw = try backend.read(fan.modeKey).uint8()
+                    guard FanMode(rawValue: raw).isAutomatic else {
+                        throw FanRollbackError.modeNotAutomatic(rawValue: raw)
+                    }
+                    unresolved.removeValue(forKey: fan.index)
+                    errors.removeValue(forKey: fan.index)
+                } catch {
+                    let normalized = normalize(error)
+                    errors[fan.index] = normalized
+                    if !isRetryable(normalized) {
+                        terminal.insert(fan.index)
+                    }
+                }
+            }
+            if unresolved.isEmpty || terminal.count == unresolved.count {
+                break
+            }
+            if attempt + 1 < timing.automaticRestoreAttempts {
+                timing.sleep(timing.retryDelaySeconds)
+            }
+        }
+        return unresolved.keys.sorted().map { index in
+            FanRollbackFailure(
+                fanIndex: index,
+                step: .restoreMode,
+                error: errors[index] ?? .modeNotAutomatic(rawValue: 1)
+            )
+        }
+    }
+
+    public static func run(
+        backend: any SMCBackend,
+        fans: [FanCapability],
+        ftstKey: SMCKey?,
+        ownsFtst: Bool,
+        timing: FanControlTiming = .production
+    ) -> FanAutomaticRestoreOutcome {
+        var unresolvedFans: [Int: FanCapability] = [:]
+        var fanErrors: [Int: FanRollbackError] = [:]
+        var terminalFans = Set<Int>()
+        for fan in fans {
+            unresolvedFans[fan.index] = fan
+        }
+
+        var unresolvedFtst = ownsFtst
+        var ftstError: FanRollbackError?
+        var terminalFtst = false
+
+        for attempt in 0..<timing.automaticRestoreAttempts {
+            for fan in unresolvedFans.values.sorted(by: { $0.index < $1.index })
+                where !terminalFans.contains(fan.index)
+            {
+                do {
+                    try backend.write(
+                        fan.modeKey,
+                        bytes: [FanMode.automatic.rawValue]
+                    )
+                    let raw = try backend.read(fan.modeKey).uint8()
+                    guard FanMode(rawValue: raw).isAutomatic else {
+                        throw FanRollbackError.modeNotAutomatic(rawValue: raw)
+                    }
+                    unresolvedFans.removeValue(forKey: fan.index)
+                    fanErrors.removeValue(forKey: fan.index)
+                    clearTargetBestEffort(backend: backend, fan: fan)
+                } catch {
+                    let normalized = normalize(error)
+                    fanErrors[fan.index] = normalized
+                    if !isRetryable(normalized) {
+                        terminalFans.insert(fan.index)
+                    }
+                }
+            }
+
+            var releasedFtstThisRound = false
+            if unresolvedFtst, !terminalFtst {
+                if let ftstKey {
+                    do {
+                        try backend.write(ftstKey, bytes: [0])
+                        let raw = try backend.read(ftstKey).uint8()
+                        guard raw == 0 else {
+                            throw FanRollbackError.ftstStillSet(rawValue: raw)
+                        }
+                        unresolvedFtst = false
+                        ftstError = nil
+                        releasedFtstThisRound = true
+                    } catch {
+                        let normalized = normalize(error)
+                        ftstError = normalized
+                        terminalFtst = !isRetryable(normalized)
+                    }
+                } else {
+                    ftstError = .smc(.keyNotFound("Ftst"))
+                    terminalFtst = true
+                }
+            }
+
+            if releasedFtstThisRound {
+                timing.sleep(timing.ftstSettleSeconds)
+                for fan in fans.sorted(by: { $0.index < $1.index }) {
+                    do {
+                        let raw = try backend.read(fan.modeKey).uint8()
+                        guard FanMode(rawValue: raw).isAutomatic else {
+                            throw FanRollbackError.modeNotAutomatic(rawValue: raw)
+                        }
+                        unresolvedFans.removeValue(forKey: fan.index)
+                        fanErrors.removeValue(forKey: fan.index)
+                        terminalFans.remove(fan.index)
+                        clearTargetBestEffort(backend: backend, fan: fan)
+                    } catch {
+                        let normalized = normalize(error)
+                        unresolvedFans[fan.index] = fan
+                        fanErrors[fan.index] = normalized
+                        if isRetryable(normalized) {
+                            terminalFans.remove(fan.index)
+                        } else {
+                            terminalFans.insert(fan.index)
+                        }
+                    }
+                }
+            }
+
+            if unresolvedFans.isEmpty, !unresolvedFtst {
+                break
+            }
+            if terminalFans.count == unresolvedFans.count,
+               !unresolvedFtst || terminalFtst
+            {
+                break
+            }
+            if attempt + 1 < timing.automaticRestoreAttempts {
+                timing.sleep(timing.retryDelaySeconds)
+            }
+        }
+
+        var failures = unresolvedFans.keys.sorted().map { index in
+            FanRollbackFailure(
+                fanIndex: index,
+                step: .restoreMode,
+                error: fanErrors[index] ?? .modeNotAutomatic(rawValue: 1)
+            )
+        }
+        if unresolvedFtst {
+            failures.append(FanRollbackFailure(
+                fanIndex: nil,
+                step: .clearFtst,
+                error: ftstError ?? .ftstStillSet(rawValue: 1)
+            ))
+        }
+        var retainedFanIndices = Set(unresolvedFans.keys)
+        if unresolvedFtst {
+            retainedFanIndices.formUnion(fans.map(\.index))
+        }
+        return FanAutomaticRestoreOutcome(
+            unresolvedFanIndices: Array(retainedFanIndices),
+            ownsFtst: unresolvedFtst,
+            failures: failures
+        )
+    }
+
+    private static func clearTargetBestEffort(
+        backend: any SMCBackend,
+        fan: FanCapability
+    ) {
+        guard let zero = try? SMCValue.float32Bytes(0, key: fan.targetKey) else {
+            return
+        }
+        try? backend.write(fan.targetKey, bytes: zero)
+    }
+
+    private static func normalize(_ error: Error) -> FanRollbackError {
+        if let error = error as? FanRollbackError { return error }
+        if let error = error as? FanHardwareError { return .hardware(error) }
+        if let error = error as? SMCError { return .smc(error) }
+        if let error = error as? FanControllerError {
+            switch error {
+            case .hardware(let hardware): return .hardware(hardware)
+            case .smc(let smc): return .smc(smc)
+            default: return .smc(.injectedFailure(error.description))
+            }
+        }
+        return .smc(.injectedFailure(String(describing: error)))
+    }
+
+    private static func isRetryable(_ error: FanRollbackError) -> Bool {
+        switch error {
+        case .modeNotAutomatic, .ftstStillSet:
+            return true
+        case .smc(let error):
+            switch error {
+            case .callFailed, .firmwareRejected, .injectedFailure:
+                return true
+            default:
+                return false
+            }
+        case .hardware, .persistence:
+            return false
+        }
+    }
+}

--- a/provider-swift/Sources/DarkbloomFanCore/FanController.swift
+++ b/provider-swift/Sources/DarkbloomFanCore/FanController.swift
@@ -4,6 +4,7 @@ public struct FanControlTiming: Sendable {
     public let ftstSettleSeconds: TimeInterval
     public let retryDelaySeconds: TimeInterval
     public let manualModeAttempts: Int
+    public let automaticRestoreAttempts: Int
     public let verificationAttempts: Int
     public let sleep: @Sendable (TimeInterval) -> Void
 
@@ -11,6 +12,7 @@ public struct FanControlTiming: Sendable {
         ftstSettleSeconds: TimeInterval = 0.5,
         retryDelaySeconds: TimeInterval = 0.1,
         manualModeAttempts: Int = 100,
+        automaticRestoreAttempts: Int = 50,
         verificationAttempts: Int = 3,
         sleep: @escaping @Sendable (TimeInterval) -> Void = {
             Thread.sleep(forTimeInterval: $0)
@@ -19,10 +21,12 @@ public struct FanControlTiming: Sendable {
         precondition(ftstSettleSeconds >= 0)
         precondition(retryDelaySeconds >= 0)
         precondition(manualModeAttempts > 0)
+        precondition(automaticRestoreAttempts > 0)
         precondition(verificationAttempts > 0)
         self.ftstSettleSeconds = ftstSettleSeconds
         self.retryDelaySeconds = retryDelaySeconds
         self.manualModeAttempts = manualModeAttempts
+        self.automaticRestoreAttempts = automaticRestoreAttempts
         self.verificationAttempts = verificationAttempts
         self.sleep = sleep
     }
@@ -357,7 +361,11 @@ public actor TransactionalFanController {
         guard isControlling else {
             throw FanControllerError.notControlling
         }
-        guard !possiblyControlledFans.isEmpty else {
+        guard !possiblyControlledFans.isEmpty,
+              possiblyControlledFans.keys.allSatisfy({
+                  targetRPMByFan[$0] != nil
+              })
+        else {
             let failures = restoreTrackedState(recordOwnership: recordOwnership)
             if !failures.isEmpty {
                 throw FanControllerError.rollbackFailed(
@@ -369,9 +377,6 @@ public actor TransactionalFanController {
         }
 
         do {
-            for fan in possiblyControlledFans.values where targetRPMByFan[fan.index] == nil {
-                throw FanControllerError.incompleteSession(index: fan.index)
-            }
             // Sleep can reset Ftst even before the per-fan mode read changes.
             // Reassert a gate that this session already owns before touching
             // individual modes.
@@ -616,62 +621,23 @@ public actor TransactionalFanController {
     private func restoreTrackedState(
         recordOwnership: @Sendable (FanControlOwnership) throws -> Void = { _ in }
     ) -> [FanRollbackFailure] {
-        var failures: [FanRollbackFailure] = []
-        var stillUncertain: [Int: FanCapability] = [:]
-
-        for fan in possiblyControlledFans.values.sorted(by: { $0.index < $1.index }) {
-            do {
-                try backend.write(fan.modeKey, bytes: [FanMode.automatic.rawValue])
-                let raw = try readUI8(fan.modeKey)
-                guard FanMode(rawValue: raw).isAutomatic else {
-                    throw FanRollbackError.modeNotAutomatic(rawValue: raw)
-                }
-                // Auto mode is authoritative. Clearing the stale manual target
-                // is best-effort defense against a later accidental mode toggle;
-                // failure here must not turn a verified Auto restore into error.
-                if let zero = try? SMCValue.float32Bytes(0, key: fan.targetKey) {
-                    try? backend.write(fan.targetKey, bytes: zero)
-                }
-            } catch {
-                let rollbackError = normalizeRollback(error)
-                failures.append(FanRollbackFailure(
-                    fanIndex: fan.index,
-                    step: .restoreMode,
-                    error: rollbackError
-                ))
-                stillUncertain[fan.index] = fan
-            }
-        }
-
-        var ftstStillUncertain = false
-        if mayOwnFtst, let ftstKey = inventory.ftstKey {
-            do {
-                try backend.write(ftstKey, bytes: [0])
-                let raw = try readUI8(ftstKey)
-                guard raw == 0 else {
-                    throw FanRollbackError.ftstStillSet(rawValue: raw)
-                }
-            } catch {
-                failures.append(FanRollbackFailure(
-                    fanIndex: nil,
-                    step: .clearFtst,
-                    error: normalizeRollback(error)
-                ))
-                ftstStillUncertain = true
-            }
-        } else if mayOwnFtst {
-            failures.append(FanRollbackFailure(
-                fanIndex: nil,
-                step: .clearFtst,
-                error: .smc(.keyNotFound("Ftst"))
-            ))
-            ftstStillUncertain = true
+        let outcome = FanAutomaticRestore.run(
+            backend: backend,
+            fans: Array(possiblyControlledFans.values),
+            ftstKey: inventory.ftstKey,
+            ownsFtst: mayOwnFtst,
+            timing: timing
+        )
+        var failures = outcome.failures
+        let unresolvedFans = Set(outcome.unresolvedFanIndices)
+        let stillUncertain = possiblyControlledFans.filter {
+            unresolvedFans.contains($0.key)
         }
 
         do {
             try recordOwnership(FanControlOwnership(
                 fanIndices: Array(stillUncertain.keys),
-                ownsFtst: ftstStillUncertain
+                ownsFtst: outcome.ownsFtst
             ))
         } catch {
             failures.append(FanRollbackFailure(
@@ -685,7 +651,7 @@ public actor TransactionalFanController {
         }
         possiblyControlledFans = stillUncertain
         targetRPMByFan = targetRPMByFan.filter { stillUncertain[$0.key] != nil }
-        mayOwnFtst = ftstStillUncertain
+        mayOwnFtst = outcome.ownsFtst
         return failures
     }
 
@@ -747,17 +713,4 @@ public actor TransactionalFanController {
         return .smc(.injectedFailure(String(describing: error)))
     }
 
-    private func normalizeRollback(_ error: Error) -> FanRollbackError {
-        if let error = error as? FanRollbackError { return error }
-        if let error = error as? FanControllerError {
-            switch error {
-            case .smc(let smcError): return .smc(smcError)
-            case .hardware(let hardwareError): return .hardware(hardwareError)
-            default: return .smc(.injectedFailure(error.description))
-            }
-        }
-        if let error = error as? FanHardwareError { return .hardware(error) }
-        if let error = error as? SMCError { return .smc(error) }
-        return .smc(.injectedFailure(String(describing: error)))
-    }
 }

--- a/provider-swift/Sources/DarkbloomFanCore/FanHardware.swift
+++ b/provider-swift/Sources/DarkbloomFanCore/FanHardware.swift
@@ -208,6 +208,11 @@ public enum GPUTemperatureCatalog {
             return []
         }
     }
+
+    public static func minimumReadyCount(for family: FanChipFamily) -> Int {
+        let count = keys(for: family).count
+        return count == 0 ? 1 : max(1, (count + 1) / 2)
+    }
 }
 
 public enum FanChipIdentity {

--- a/provider-swift/Sources/DarkbloomFanHelper/FanDaemon.swift
+++ b/provider-swift/Sources/DarkbloomFanHelper/FanDaemon.swift
@@ -10,23 +10,28 @@ import Darwin
 
 private enum FanDaemonError: Error {
     case automaticRestoreFailed
+    case controlAuthorizationChanged
 }
 
 actor FanDaemon {
     typealias Uptime = @Sendable () -> TimeInterval
+    typealias DiscoverInventory = @Sendable () throws -> FanInventory
+    typealias ControllerFactory = @Sendable (FanInventory) -> TransactionalFanController
     private static let maintenanceIntervalSeconds: TimeInterval = 5
 
     private let logger = Logger(subsystem: "io.darkbloom.fan", category: "daemon")
     private let configuration: FanServiceConfiguration
     private let paths: FanServicePaths
     private let backend: any SMCBackend
-    private let inventory: FanInventory
     private let reader: FanHardwareReader
-    private let controller: TransactionalFanController
     private let uptime: Uptime
     private let journalOwner: (uid: uid_t, gid: gid_t)?
     private let requireRootJournalOwnership: Bool
-    private let recordOwnership: @Sendable (FanControlOwnership) throws -> Void
+    private let discoverInventory: DiscoverInventory
+    private let controllerFactory: ControllerFactory
+
+    private var controller: TransactionalFanController
+    private var hardwareRecovery: FanHardwareRecovery
 
     private var policy: FanPolicyStateMachine
     private var pollTask: Task<Void, Never>?
@@ -38,6 +43,8 @@ actor FanDaemon {
     private var gpuTemperatureC: Double?
     private var fanReadings: [FanReading] = []
     private var lastError: String?
+    private var persistedLastError: String?
+    private var failureFileMayExist: Bool
     private var lastMaintenanceAt: TimeInterval = 0
 
     init(
@@ -49,31 +56,42 @@ actor FanDaemon {
         controller: TransactionalFanController,
         uptime: @escaping Uptime = { ProcessInfo.processInfo.systemUptime },
         journalOwner: (uid: uid_t, gid: gid_t)? = (0, 0),
-        requireRootJournalOwnership: Bool = true
+        requireRootJournalOwnership: Bool = true,
+        discoverInventory: DiscoverInventory? = nil,
+        controllerFactory: ControllerFactory? = nil,
+        baselineSensorKeys: [SMCKey] = [],
+        initialLastError: String? = nil,
+        initialPersistedLastError: String? = nil,
+        initialFailureFileMayExist: Bool = false,
+        initialDiscoveryError: String? = nil
     ) {
         self.configuration = configuration
         self.paths = paths
         self.backend = backend
-        self.inventory = inventory
         self.reader = reader
         self.controller = controller
+        self.hardwareRecovery = FanHardwareRecovery(
+            inventory: inventory,
+            initialError: initialDiscoveryError,
+            baselineSensorKeys: baselineSensorKeys
+        )
         self.uptime = uptime
         self.journalOwner = journalOwner
         self.requireRootJournalOwnership = requireRootJournalOwnership
-        let journalURL = paths.sessionJournal
-        self.recordOwnership = { ownership in
-            try FanDurableFile.writeJSON(
-                FanSessionJournal(
-                    fanIndices: ownership.fanIndices,
-                    ownsFtst: ownership.ownsFtst
-                ),
-                to: journalURL,
-                permissions: 0o600,
-                owner: journalOwner
+        self.discoverInventory = discoverInventory ?? {
+            try reader.discover()
+        }
+        self.controllerFactory = controllerFactory ?? { refreshedInventory in
+            TransactionalFanController(
+                backend: backend,
+                inventory: refreshedInventory
             )
         }
         self.policy = FanPolicyStateMachine(configuration: configuration.policy)
         self.mode = configuration.enabled ? .waitingForProvider : .disabled
+        self.lastError = initialLastError
+        self.persistedLastError = initialPersistedLastError
+        self.failureFileMayExist = initialFailureFileMayExist
     }
 
     func start() {
@@ -109,6 +127,9 @@ actor FanDaemon {
         }
         guard providerVersion.utf8.count <= 64 else {
             return FanIPCReply(ok: false, message: "provider version is invalid")
+        }
+        guard hardwareReady else {
+            return FanIPCReply(ok: false, message: hardwareReadinessMessage)
         }
         leaseSessionID = sessionID
         leaseExpiresAt = uptime() + FanIPC.leaseDurationSeconds
@@ -149,8 +170,8 @@ actor FanDaemon {
             configuredUID: configuration.configuredUID,
             providerActive: providerLeaseActive,
             mode: mode,
-            chip: inventory.chipFamily.rawValue,
-            gpuSensorKeys: inventory.gpuTemperatureKeys.map(\.rawValue),
+            chip: hardwareRecovery.inventory.chipFamily.rawValue,
+            gpuSensorKeys: hardwareRecovery.inventory.gpuTemperatureKeys.map(\.rawValue),
             gpuTemperatureC: gpuTemperatureC,
             triggerTemperatureC: configuration.policy.triggerCelsius,
             releaseTemperatureC: configuration.policy.releaseCelsius,
@@ -165,7 +186,14 @@ actor FanDaemon {
                     mode: describe(reading.mode)
                 )
             },
-            lastError: lastError
+            lastError: lastError,
+            hardwareReady: hardwareReady,
+            recoveryPending: hardwareRecovery.recoveryPending
+                || hardwareRecovery.baselineNeedsPersistence,
+            discoveryError: hardwareRecovery.discoveryError,
+            quarantinedSensorKeys: hardwareRecovery.quarantinedSensorKeys
+                .map(\.rawValue)
+                .sorted()
         )
     }
 
@@ -190,6 +218,7 @@ actor FanDaemon {
         powerSuspended = false
         leaseSessionID = nil
         leaseExpiresAt = 0
+        hardwareRecovery.markWake()
         mode = effectiveEnabled ? .waitingForProvider : .disabled
     }
 
@@ -203,26 +232,49 @@ actor FanDaemon {
 
     func tick() async {
         guard effectiveEnabled else {
-            mode = await restoreAutomatic(reason: "fan control disabled")
-                ? .disabled : .error
+            let restored = await restoreAutomatic(reason: "fan control disabled")
+            mode = restored ? .disabled : .error
+            if restored {
+                clearLastError()
+            }
             return
         }
-        guard !inventory.fans.isEmpty, !inventory.gpuTemperatureKeys.isEmpty else {
-            mode = await restoreAutomatic(
-                reason: "fan hardware or GPU sensors unavailable"
-            ) ? .unsupported : .error
-            return
-        }
-        if (!providerLeaseActive || mode == .error), await hasPossibleOwnership {
+        if (!providerLeaseActive || mode == .error || hardwareRecovery.discoveryRequired),
+           await hasPossibleOwnership
+        {
             mode = await restoreAutomatic(reason: "retrying automatic restoration")
                 ? (providerLeaseActive ? .waitingForTemperature : .waitingForProvider)
                 : .error
             return
         }
+        if hardwareRecovery.discoveryRequired {
+            await refreshHardwareIfDue()
+        }
+        guard hardwareRecovery.hardwareReady else {
+            let message = hardwareReadinessMessage
+            setLastError(message)
+            mode = .unsupported
+            return
+        }
+        persistSensorBaselineIfNeeded()
+        guard hardwareReady else {
+            mode = .error
+            return
+        }
 
         do {
-            fanReadings = try reader.fanReadings(in: inventory)
-            let temperatures = try reader.gpuTemperatures(in: inventory)
+            fanReadings = try reader.fanReadings(in: hardwareRecovery.inventory)
+            let temperatures: [GPUTemperatureReading]
+            do {
+                temperatures = try reader.gpuTemperatures(
+                    in: hardwareRecovery.inventory
+                )
+            } catch {
+                hardwareRecovery.markSensorFailure(error)
+                leaseSessionID = nil
+                leaseExpiresAt = 0
+                throw error
+            }
             gpuTemperatureC = temperatures.map(\.celsius).max()
 
             if ProcessInfo.processInfo.thermalState == .serious
@@ -240,9 +292,10 @@ actor FanDaemon {
                 controlHealthy: true
             ))
             try await apply(action)
-            lastError = nil
+            clearLastError()
         } catch {
-            lastError = String(describing: error)
+            let message = String(describing: error)
+            setLastError(message)
             logger.error("fan policy tick failed: \(String(describing: error), privacy: .public)")
             _ = await restoreAutomatic(reason: "fan policy failure")
             mode = .error
@@ -255,10 +308,14 @@ actor FanDaemon {
             mode = serviceMode(for: reason)
         case .engage(let speedPercent, _):
             do {
+                let lease = leaseSessionID
+                try await requireControlAuthorization(lease)
+                let recordOwnership = ownershipRecorder()
                 let session = try await controller.engage(
                     speedPercent: speedPercent,
                     recordOwnership: recordOwnership
                 )
+                try await requireControlAuthorization(lease)
                 try persistOwnership(session)
                 lastMaintenanceAt = uptime()
                 mode = .manual
@@ -270,15 +327,20 @@ actor FanDaemon {
             }
         case .maintain:
             if uptime() - lastMaintenanceAt >= Self.maintenanceIntervalSeconds {
+                let lease = leaseSessionID
+                try await requireControlAuthorization(lease)
+                let recordOwnership = ownershipRecorder()
                 // Refresh the journal with current ownership. The controller
                 // widens Ftst ownership only after it observes the gate free,
                 // immediately before a possible write.
                 if let currentSession = await controller.currentSession() {
                     try persistOwnership(currentSession)
                 }
+                try await requireControlAuthorization(lease)
                 let session = try await controller.maintain(
                     recordOwnership: recordOwnership
                 )
+                try await requireControlAuthorization(lease)
                 try persistOwnership(session)
                 lastMaintenanceAt = uptime()
             }
@@ -292,15 +354,10 @@ actor FanDaemon {
     }
 
     private func persistOwnership(_ session: FanControlSession) throws {
-        try FanDurableFile.writeJSON(
-            FanSessionJournal(
-                fanIndices: session.targetRPMByFan.keys.map { $0 },
-                ownsFtst: session.ownsFtst
-            ),
-            to: paths.sessionJournal,
-            permissions: 0o600,
-            owner: journalOwner
-        )
+        try ownershipRecorder()(FanControlOwnership(
+            fanIndices: session.targetRPMByFan.keys.map { $0 },
+            ownsFtst: session.ownsFtst
+        ))
     }
 
     private func restoreAutomatic(reason: String) async -> Bool {
@@ -315,13 +372,14 @@ actor FanDaemon {
         }
         do {
             if await controller.isControlling {
+                let recordOwnership = ownershipRecorder()
                 try await controller.restoreAutomatic(
                     recordOwnership: recordOwnership
                 )
             } else {
                 try FanOwnershipRecovery.reconcile(
                     backend: backend,
-                    inventory: inventory,
+                    inventory: hardwareRecovery.inventory,
                     journalURL: paths.sessionJournal,
                     requireRootOwnership: requireRootJournalOwnership,
                     journalOwner: journalOwner
@@ -335,9 +393,33 @@ actor FanDaemon {
             logger.info("restored automatic fan control: \(reason, privacy: .public)")
             return true
         } catch {
-            lastError = "automatic restore failed: \(error)"
+            setLastError("automatic restore failed: \(error)")
             logger.fault("automatic fan restore failed: \(String(describing: error), privacy: .public)")
             return false
+        }
+    }
+
+    private func ownershipRecorder()
+        -> @Sendable (FanControlOwnership) throws -> Void
+    {
+        let journalURL = paths.sessionJournal
+        let owner = journalOwner
+        let expectedFanIndices = hardwareRecovery.inventory.fans
+            .map(\.index)
+            .sorted()
+        return { ownership in
+            try FanDurableFile.writeJSON(
+                FanSessionJournal(
+                    fanIndices: ownership.fanIndices,
+                    ownsFtst: ownership.ownsFtst,
+                    verifyAllFans: true,
+                    verificationFanIndices: expectedFanIndices,
+                    minimumVerificationFanCount: expectedFanIndices.count
+                ),
+                to: journalURL,
+                permissions: 0o600,
+                owner: owner
+            )
         }
     }
 
@@ -345,6 +427,112 @@ actor FanDaemon {
         get async {
             await controller.isControlling
                 || FileManager.default.fileExists(atPath: paths.sessionJournal.path)
+        }
+    }
+
+    private var hardwareReady: Bool {
+        hardwareRecovery.hardwareReady
+            && !hardwareRecovery.baselineNeedsPersistence
+    }
+
+    private var hardwareReadinessMessage: String {
+        if hardwareRecovery.hardwareReady,
+           hardwareRecovery.baselineNeedsPersistence
+        {
+            return "fan sensor baseline is not durable; retrying"
+        }
+        return hardwareRecovery.readinessMessage
+    }
+
+    private func requireControlAuthorization(_ expectedLease: UUID?) async throws {
+        guard let expectedLease,
+              leaseSessionID == expectedLease,
+              providerLeaseActive,
+              hardwareReady
+        else {
+            guard await restoreAutomatic(
+                reason: "provider authorization changed during fan control"
+            ) else {
+                throw FanDaemonError.automaticRestoreFailed
+            }
+            throw FanDaemonError.controlAuthorizationChanged
+        }
+    }
+
+    private func refreshHardwareIfDue() async {
+        let now = uptime()
+        guard hardwareRecovery.beginDiscoveryIfDue(now: now) else {
+            return
+        }
+        guard !(await controller.isControlling),
+              !FileManager.default.fileExists(atPath: paths.sessionJournal.path)
+        else {
+            return
+        }
+
+        do {
+            let refreshed = try discoverInventory()
+            let ready = hardwareRecovery.apply(refreshed)
+            controller = controllerFactory(refreshed)
+            fanReadings = []
+            gpuTemperatureC = nil
+
+            guard ready else { return }
+            mode = .waitingForProvider
+            logger.notice(
+                "fan hardware discovery recovered with \(refreshed.gpuTemperatureKeys.count, privacy: .public) GPU sensors"
+            )
+        } catch {
+            hardwareRecovery.recordDiscoveryFailure(error)
+        }
+    }
+
+    private func setLastError(_ message: String) {
+        lastError = message
+        guard persistedLastError != message else { return }
+        failureFileMayExist = true
+        do {
+            try FanDurableFile.writeJSON(
+                FanLastFailure(message: message),
+                to: paths.lastFailure,
+                permissions: 0o600,
+                owner: journalOwner
+            )
+            persistedLastError = message
+        } catch {
+            persistedLastError = nil
+        }
+    }
+
+    private func clearLastError() {
+        guard lastError != nil || failureFileMayExist else { return }
+        lastError = nil
+        guard failureFileMayExist else {
+            persistedLastError = nil
+            return
+        }
+        persistedLastError = nil
+        do {
+            try FanDurableFile.remove(paths.lastFailure)
+            failureFileMayExist = false
+        } catch {
+            // Keep the persistence marker so the next healthy tick retries
+            // removal without continuing to surface a resolved active error.
+        }
+    }
+
+    private func persistSensorBaselineIfNeeded() {
+        guard hardwareRecovery.baselineNeedsPersistence else { return }
+        do {
+            try FanDurableFile.writeJSON(
+                hardwareRecovery.sensorBaseline,
+                to: paths.sensorBaseline,
+                permissions: 0o600,
+                owner: journalOwner
+            )
+            hardwareRecovery.markBaselinePersisted()
+        } catch {
+            setLastError("could not persist fan sensor baseline: \(error)")
         }
     }
 

--- a/provider-swift/Sources/DarkbloomFanHelper/FanHardwareRecovery.swift
+++ b/provider-swift/Sources/DarkbloomFanHelper/FanHardwareRecovery.swift
@@ -1,0 +1,189 @@
+import DarkbloomFanCore
+import DarkbloomFanService
+import Foundation
+
+struct FanHardwareRecovery {
+    static let retryIntervalSeconds: TimeInterval = 5
+
+    private(set) var inventory: FanInventory
+    private(set) var discoveryRequired: Bool
+    private(set) var discoveryError: String?
+    private(set) var quarantinedSensorKeys: Set<SMCKey> = []
+    private(set) var baselineNeedsPersistence: Bool
+    private var baselineSensorKeys: Set<SMCKey>
+    private var minimumSensorCount: Int
+    private var lastDiscoveryAt = -Double.infinity
+
+    init(
+        inventory: FanInventory,
+        initialError: String?,
+        baselineSensorKeys: [SMCKey] = []
+    ) {
+        let persistedBaseline = Set(baselineSensorKeys)
+        let catalogMinimum = GPUTemperatureCatalog.minimumReadyCount(
+            for: inventory.chipFamily
+        )
+        let baselineMinimum = persistedBaseline.isEmpty
+            ? 1
+            : max(1, (persistedBaseline.count + 1) / 2)
+        let minimumSensorCount = max(catalogMinimum, baselineMinimum)
+        let discoveredKeys = Set(inventory.gpuTemperatureKeys)
+        let requiredOverlap = persistedBaseline.isEmpty
+            ? 0
+            : baselineMinimum
+        let initialQuorum = discoveredKeys.count >= minimumSensorCount
+            && discoveredKeys.intersection(persistedBaseline).count
+                >= requiredOverlap
+
+        self.inventory = inventory
+        self.discoveryError = initialError
+        self.discoveryRequired = initialError != nil
+            || inventory.fans.isEmpty
+            || !initialQuorum
+        self.minimumSensorCount = minimumSensorCount
+        self.baselineSensorKeys = persistedBaseline
+        if initialQuorum {
+            self.baselineSensorKeys.formUnion(discoveredKeys)
+        }
+        self.baselineNeedsPersistence = initialQuorum
+            && self.baselineSensorKeys != persistedBaseline
+    }
+
+    var hardwareReady: Bool {
+        !discoveryRequired
+            && !inventory.fans.isEmpty
+            && inventory.gpuTemperatureKeys.count >= minimumSensorCount
+    }
+
+    var recoveryPending: Bool {
+        discoveryRequired
+            && !GPUTemperatureCatalog.keys(for: inventory.chipFamily).isEmpty
+    }
+
+    var readinessMessage: String {
+        if inventory.fans.isEmpty {
+            if recoveryPending {
+                return "fan hardware discovery found no controllable fans; retrying"
+            }
+            return "fan control unsupported: this Mac reports no controllable fans"
+        }
+        let catalog = GPUTemperatureCatalog.keys(for: inventory.chipFamily)
+        if catalog.isEmpty {
+            return "fan control unsupported: no GPU sensor catalog exists for \(inventory.chipFamily.rawValue)"
+        }
+        if let discoveryError {
+            return discoveryError
+        }
+        let overlap = Set(inventory.gpuTemperatureKeys)
+            .intersection(baselineSensorKeys)
+            .count
+        let requiredOverlap = baselineSensorKeys.isEmpty
+            ? 0
+            : max(1, (baselineSensorKeys.count + 1) / 2)
+        return "GPU sensors are not ready (count \(inventory.gpuTemperatureKeys.count)/\(minimumSensorCount), baseline overlap \(overlap)/\(requiredOverlap)); discovery will retry"
+    }
+
+    mutating func markSensorFailure(_ error: Error) {
+        if let key = Self.sensorKey(from: error) {
+            quarantinedSensorKeys.insert(key)
+        }
+        discoveryRequired = true
+        lastDiscoveryAt = -Double.infinity
+        discoveryError = "GPU sensor read failed: \(error); restoring Auto before rediscovery"
+    }
+
+    mutating func markWake() {
+        discoveryRequired = true
+        lastDiscoveryAt = -Double.infinity
+        discoveryError = "GPU sensor discovery is refreshing after system wake"
+    }
+
+    mutating func beginDiscoveryIfDue(now: TimeInterval) -> Bool {
+        guard discoveryRequired,
+              now - lastDiscoveryAt >= Self.retryIntervalSeconds
+        else {
+            return false
+        }
+        lastDiscoveryAt = now
+        return true
+    }
+
+    @discardableResult
+    mutating func apply(_ refreshed: FanInventory) -> Bool {
+        let refreshedKeys = Set(refreshed.gpuTemperatureKeys)
+        let requiredOverlap = baselineSensorKeys.isEmpty
+            ? 0
+            : max(1, (baselineSensorKeys.count + 1) / 2)
+        inventory = refreshed
+
+        guard !refreshed.fans.isEmpty,
+              refreshedKeys.count >= minimumSensorCount,
+              refreshedKeys.intersection(baselineSensorKeys).count
+                >= requiredOverlap
+        else {
+            discoveryRequired = true
+            discoveryError = nil
+            discoveryError = readinessMessage
+            return false
+        }
+
+        quarantinedSensorKeys = Set(quarantinedSensorKeys.filter {
+            !refreshedKeys.contains($0)
+        })
+        let priorBaseline = baselineSensorKeys
+        baselineSensorKeys.formUnion(refreshedKeys)
+        minimumSensorCount = max(
+            minimumSensorCount,
+            max(1, (baselineSensorKeys.count + 1) / 2)
+        )
+        baselineNeedsPersistence = baselineNeedsPersistence
+            || baselineSensorKeys != priorBaseline
+        discoveryRequired = false
+        discoveryError = nil
+        return true
+    }
+
+    mutating func recordDiscoveryFailure(_ error: Error) {
+        discoveryRequired = true
+        discoveryError = "fan hardware discovery failed: \(error); retrying"
+    }
+
+    var sensorBaseline: FanSensorBaseline {
+        FanSensorBaseline(
+            chipFamily: inventory.chipFamily,
+            sensorKeys: Array(baselineSensorKeys)
+        )
+    }
+
+    mutating func markBaselinePersisted() {
+        baselineNeedsPersistence = false
+    }
+
+    private static func sensorKey(from error: Error) -> SMCKey? {
+        if let hardware = error as? FanHardwareError {
+            switch hardware {
+            case .invalidTemperature(let key, _):
+                return key
+            case .backend(let smc):
+                return sensorKey(from: smc)
+            default:
+                return nil
+            }
+        }
+        guard let smc = error as? SMCError else { return nil }
+        switch smc {
+        case .callFailed(_, let key, _), .notPrivileged(_, let key):
+            return key
+        case .keyNotFound(let key),
+             .firmwareRejected(_, let key, _),
+             .invalidDataSize(let key, _),
+             .dataLengthMismatch(let key, _, _),
+             .typeMismatch(let key, _, _),
+             .unsupportedDataType(let key, _),
+             .nonFiniteValue(let key):
+            return key
+        default:
+            return nil
+        }
+    }
+}

--- a/provider-swift/Sources/DarkbloomFanHelper/FanStartupRecovery.swift
+++ b/provider-swift/Sources/DarkbloomFanHelper/FanStartupRecovery.swift
@@ -1,0 +1,51 @@
+import DarkbloomFanCore
+import DarkbloomFanService
+import Foundation
+
+struct FanStartupState {
+    let recoveryInventory: FanInventory
+    let sensorBaseline: FanSensorBaseline?
+}
+
+enum FanStartupRecovery {
+    static func prepare(
+        backend: any SMCBackend,
+        reader: FanHardwareReader,
+        paths: FanServicePaths,
+        brandString: String? = nil,
+        requireRootOwnership: Bool = true,
+        journalOwner: (uid: uid_t, gid: gid_t)? = (0, 0),
+        timing: FanControlTiming = .production
+    ) throws -> FanStartupState {
+        let recoveryInventory = try reader.discoverForRecovery(
+            brandString: brandString
+        )
+        try FanOwnershipRecovery.reconcile(
+            backend: backend,
+            inventory: recoveryInventory,
+            journalURL: paths.sessionJournal,
+            requireRootOwnership: requireRootOwnership,
+            journalOwner: journalOwner,
+            timing: timing
+        )
+
+        let baseline = FileManager.default.fileExists(
+            atPath: paths.sensorBaseline.path
+        ) ? try FanDurableFile.readJSON(
+            FanSensorBaseline.self,
+            from: paths.sensorBaseline,
+            requireRootOwnership: requireRootOwnership
+        ) : nil
+        if let baseline,
+           baseline.chipFamily != recoveryInventory.chipFamily
+        {
+            throw FanDurableFileError.unsafeFile(
+                "fan sensor baseline chip \(baseline.chipFamily.rawValue) does not match \(recoveryInventory.chipFamily.rawValue)"
+            )
+        }
+        return FanStartupState(
+            recoveryInventory: recoveryInventory,
+            sensorBaseline: baseline
+        )
+    }
+}

--- a/provider-swift/Sources/DarkbloomFanHelper/FanXPCService.swift
+++ b/provider-swift/Sources/DarkbloomFanHelper/FanXPCService.swift
@@ -123,7 +123,7 @@ final class FanXPCSession: NSObject, DarkbloomFanHelperProtocol, @unchecked Send
             return try FanIPCCoding.encode(value)
         } catch {
             return Data(
-                #"{"ok":false,"message":"fan helper encoding failure","helperVersion":"1","protocolVersion":1}"#.utf8
+                #"{"ok":false,"message":"fan helper encoding failure","helperVersion":"2","protocolVersion":2}"#.utf8
             )
         }
     }

--- a/provider-swift/Sources/DarkbloomFanHelper/main.swift
+++ b/provider-swift/Sources/DarkbloomFanHelper/main.swift
@@ -21,16 +21,52 @@ guard FanCodeRequirements.ownIdentityIsProduction else {
 
 let paths = FanServicePaths.production
 do {
+    var failureFileMayExist = FileManager.default.fileExists(
+        atPath: paths.lastFailure.path
+    )
+    let previousFailure = try? FanDurableFile.readJSON(
+        FanLastFailure.self,
+        from: paths.lastFailure
+    )
     let backend = try AppleSMCBackend()
     let reader = FanHardwareReader(backend: backend)
-    let recoveryInventory = try reader.discoverForRecovery()
-
-    try FanOwnershipRecovery.reconcile(
+    let startup = try FanStartupRecovery.prepare(
         backend: backend,
-        inventory: recoveryInventory,
-        journalURL: paths.sessionJournal
+        reader: reader,
+        paths: paths
     )
-    let inventory = try reader.discover()
+    let recoveryInventory = startup.recoveryInventory
+    let sensorBaseline = startup.sensorBaseline
+    let inventory: FanInventory
+    let discoveryError: String?
+    do {
+        let discovered = try reader.discover()
+        inventory = discovered
+        if discovered.fans.isEmpty {
+            discoveryError = "fan hardware discovery found no controllable fans"
+        } else if discovered.gpuTemperatureKeys.isEmpty {
+            discoveryError = "GPU sensor discovery returned no plausible readings; retrying in the helper"
+        } else {
+            discoveryError = nil
+        }
+    } catch {
+        inventory = recoveryInventory
+        discoveryError = "fan hardware discovery failed: \(error); retrying in the helper"
+    }
+    var persistedFailure = previousFailure?.message
+    if let discoveryError {
+        failureFileMayExist = true
+        do {
+            try FanDurableFile.writeJSON(
+                FanLastFailure(message: discoveryError),
+                to: paths.lastFailure,
+                permissions: 0o600
+            )
+            persistedFailure = discoveryError
+        } catch {
+            persistedFailure = previousFailure?.message
+        }
+    }
 
     let configuration: FanServiceConfiguration
     do {
@@ -67,7 +103,14 @@ do {
         backend: backend,
         inventory: inventory,
         reader: reader,
-        controller: controller
+        controller: controller,
+        baselineSensorKeys: sensorBaseline?.chipFamily == inventory.chipFamily
+            ? sensorBaseline?.sensorKeys ?? []
+            : [],
+        initialLastError: discoveryError ?? previousFailure?.message,
+        initialPersistedLastError: persistedFailure,
+        initialFailureFileMayExist: failureFileMayExist,
+        initialDiscoveryError: discoveryError
     )
     let xpcService = FanXPCService(
         daemon: daemon,
@@ -99,6 +142,11 @@ do {
         RunLoop.main.run()
     }
 } catch {
+    try? FanDurableFile.writeJSON(
+        FanLastFailure(message: "fan helper startup failed: \(error)"),
+        to: paths.lastFailure,
+        permissions: 0o600
+    )
     logger.fault("fan helper startup failed: \(String(describing: error), privacy: .public)")
     exit(1)
 }

--- a/provider-swift/Sources/DarkbloomFanProtocol/FanIPC.swift
+++ b/provider-swift/Sources/DarkbloomFanProtocol/FanIPC.swift
@@ -2,8 +2,8 @@ import Foundation
 
 public enum FanIPC {
     public static let machServiceName = "io.darkbloom.fan"
-    public static let protocolVersion = 1
-    public static let helperVersion = "1"
+    public static let protocolVersion = 2
+    public static let helperVersion = "2"
     public static let helperIdentifier = "io.darkbloom.fan-helper"
     public static let providerIdentifier = "io.darkbloom.provider"
     public static let teamID = "SLDQ2GJ6TL"
@@ -96,6 +96,10 @@ public struct FanServiceStatus: Codable, Equatable, Sendable {
     public let speedPercent: Double
     public let fans: [FanServiceFanStatus]
     public let lastError: String?
+    public let hardwareReady: Bool?
+    public let recoveryPending: Bool?
+    public let discoveryError: String?
+    public let quarantinedSensorKeys: [String]?
     public let updatedAt: Date
 
     public init(
@@ -113,6 +117,10 @@ public struct FanServiceStatus: Codable, Equatable, Sendable {
         speedPercent: Double,
         fans: [FanServiceFanStatus],
         lastError: String?,
+        hardwareReady: Bool? = nil,
+        recoveryPending: Bool? = nil,
+        discoveryError: String? = nil,
+        quarantinedSensorKeys: [String]? = nil,
         updatedAt: Date = Date()
     ) {
         self.helperVersion = helperVersion
@@ -129,6 +137,10 @@ public struct FanServiceStatus: Codable, Equatable, Sendable {
         self.speedPercent = speedPercent
         self.fans = fans
         self.lastError = lastError
+        self.hardwareReady = hardwareReady
+        self.recoveryPending = recoveryPending
+        self.discoveryError = discoveryError
+        self.quarantinedSensorKeys = quarantinedSensorKeys
         self.updatedAt = updatedAt
     }
 }

--- a/provider-swift/Sources/DarkbloomFanService/FanOwnershipRecovery.swift
+++ b/provider-swift/Sources/DarkbloomFanService/FanOwnershipRecovery.swift
@@ -20,7 +20,8 @@ public enum FanOwnershipRecovery {
         inventory: FanInventory,
         journalURL: URL,
         requireRootOwnership: Bool = true,
-        journalOwner: (uid: uid_t, gid: gid_t)? = (0, 0)
+        journalOwner: (uid: uid_t, gid: gid_t)? = (0, 0),
+        timing: FanControlTiming = .production
     ) throws {
         guard FileManager.default.fileExists(atPath: journalURL.path) else {
             return
@@ -30,54 +31,162 @@ public enum FanOwnershipRecovery {
             from: journalURL,
             requireRootOwnership: requireRootOwnership
         )
-
+        let legacyFtstJournal = journal.ownsFtst
+            && !journal.verifyAllFans
+            && journal.verificationFanIndices.isEmpty
+            && journal.minimumVerificationFanCount == 0
+        let verifyAllFans = journal.verifyAllFans
+            || journal.ownsFtst
+            || !journal.verificationFanIndices.isEmpty
+            || journal.minimumVerificationFanCount > 0
+        var pendingVerification = Set(journal.verificationFanIndices)
+        var minimumVerificationFanCount = journal.minimumVerificationFanCount
+        if verifyAllFans {
+            if legacyFtstJournal {
+                minimumVerificationFanCount = max(
+                    minimumVerificationFanCount,
+                    2
+                )
+            }
+            let knownIndices = Set(journal.fanIndices).union(pendingVerification)
+            if let maximumIndex = knownIndices.max() {
+                minimumVerificationFanCount = max(
+                    minimumVerificationFanCount,
+                    maximumIndex + 1
+                )
+            }
+            if !inventory.fans.isEmpty {
+                minimumVerificationFanCount = max(
+                    minimumVerificationFanCount,
+                    inventory.fans.count
+                )
+            }
+            if minimumVerificationFanCount == 0 {
+                // Vulnerable v1 Ftst-only journals lost their prior fan set.
+                // Validated M3/M4 Max hardware has two fans; requiring two is
+                // conservative for unknown legacy state and never authorizes a
+                // write by itself.
+                minimumVerificationFanCount = 2
+            }
+        }
+        if verifyAllFans, inventory.fans.isEmpty {
+            let gateOutcome = FanAutomaticRestore.run(
+                backend: backend,
+                fans: [],
+                ftstKey: inventory.ftstKey,
+                ownsFtst: journal.ownsFtst,
+                timing: timing
+            )
+            var failures = gateOutcome.failures
+            failures.append(FanRollbackFailure(
+                fanIndex: nil,
+                step: .restoreMode,
+                error: .smc(.injectedFailure(
+                    "fan inventory is unavailable; full Auto verification is pending"
+                ))
+            ))
+            try FanDurableFile.writeJSON(
+                FanSessionJournal(
+                    fanIndices: journal.fanIndices,
+                    ownsFtst: gateOutcome.ownsFtst,
+                    verifyAllFans: true,
+                    verificationFanIndices: Array(pendingVerification),
+                    minimumVerificationFanCount: minimumVerificationFanCount
+                ),
+                to: journalURL,
+                permissions: 0o600,
+                owner: journalOwner
+            )
+            throw FanOwnershipRecoveryError(failures: failures)
+        }
         var failures: [FanRollbackFailure] = []
-        var unresolvedFans: [Int] = []
-        for index in journal.fanIndices {
-            do {
-                guard let fan = inventory.fans.first(where: { $0.index == index }) else {
-                    throw FanControllerError.noFans
-                }
-                try backend.write(fan.modeKey, bytes: [FanMode.automatic.rawValue])
-                let rawMode = try backend.read(fan.modeKey).uint8()
-                guard FanMode(rawValue: rawMode).isAutomatic else {
-                    throw FanRollbackError.modeNotAutomatic(rawValue: rawMode)
-                }
-                if let zero = try? SMCValue.float32Bytes(0, key: fan.targetKey) {
-                    try? backend.write(fan.targetKey, bytes: zero)
-                }
-            } catch {
-                unresolvedFans.append(index)
+        var unresolvedFans = Set<Int>()
+        var recoverableFans: [FanCapability] = []
+        var recoveryIndices = Set(journal.fanIndices)
+        if journal.ownsFtst {
+            // v1 helpers could narrow fanIndices to empty after an immediate
+            // pre-release Auto readback while retaining Ftst ownership. Treat
+            // every discovered fan as possibly controlled during migration so
+            // Ftst release is always followed by complete fan verification.
+            recoveryIndices.formUnion(inventory.fans.map(\.index))
+        }
+        for index in recoveryIndices.sorted() {
+            guard let fan = inventory.fans.first(where: { $0.index == index }) else {
+                unresolvedFans.insert(index)
                 failures.append(FanRollbackFailure(
                     fanIndex: index,
                     step: .restoreMode,
-                    error: recoveryError(error)
+                    error: .smc(.injectedFailure(FanControllerError.noFans.description))
                 ))
+                continue
+            }
+            recoverableFans.append(fan)
+        }
+
+        let outcome = FanAutomaticRestore.run(
+            backend: backend,
+            fans: recoverableFans,
+            ftstKey: inventory.ftstKey,
+            ownsFtst: journal.ownsFtst,
+            timing: timing
+        )
+        unresolvedFans.formUnion(outcome.unresolvedFanIndices)
+        failures.append(contentsOf: outcome.failures)
+
+        if verifyAllFans, !outcome.ownsFtst {
+            let inventoryIndices = Set(inventory.fans.map(\.index))
+            for index in pendingVerification
+                where !inventoryIndices.contains(index)
+            {
+                failures.append(FanRollbackFailure(
+                    fanIndex: index,
+                    step: .restoreMode,
+                    error: .smc(.injectedFailure(
+                        "fan \(index) is unavailable for pending Auto verification"
+                    ))
+                ))
+            }
+            let verificationFailures = FanAutomaticRestore.verifyAutomatic(
+                backend: backend,
+                fans: inventory.fans,
+                timing: timing
+            )
+            failures.append(contentsOf: verificationFailures)
+            let failedVerificationIndices = Set(
+                verificationFailures.compactMap(\.fanIndex)
+            )
+            pendingVerification.subtract(
+                inventoryIndices.subtracting(failedVerificationIndices)
+            )
+            for failure in verificationFailures {
+                if let index = failure.fanIndex,
+                   recoveryIndices.contains(index)
+                {
+                    unresolvedFans.insert(index)
+                } else if let index = failure.fanIndex {
+                    pendingVerification.insert(index)
+                }
             }
         }
 
-        var unresolvedFtst = false
-        if journal.ownsFtst, let ftstKey = inventory.ftstKey {
-            do {
-                try backend.write(ftstKey, bytes: [0])
-                let value = try backend.read(ftstKey).uint8()
-                guard value == 0 else {
-                    throw FanRollbackError.ftstStillSet(rawValue: value)
-                }
-            } catch {
-                unresolvedFtst = true
-                failures.append(FanRollbackFailure(
-                    fanIndex: nil,
-                    step: .clearFtst,
-                    error: recoveryError(error)
-                ))
-            }
-        } else if journal.ownsFtst {
-            unresolvedFtst = true
+        if verifyAllFans,
+           inventory.fans.count < minimumVerificationFanCount
+        {
             failures.append(FanRollbackFailure(
                 fanIndex: nil,
-                step: .clearFtst,
-                error: .smc(.keyNotFound("Ftst"))
+                step: .restoreMode,
+                error: .smc(.injectedFailure(
+                    "fan inventory is incomplete (\(inventory.fans.count)/\(minimumVerificationFanCount))"
+                ))
+            ))
+        }
+        if failures.isEmpty, !pendingVerification.isEmpty {
+            failures.append(FanRollbackFailure(
+                fanIndex: nil,
+                step: .restoreMode,
+                error: .smc(.injectedFailure(
+                    "full fan Auto verification is still pending"
+                ))
             ))
         }
 
@@ -87,8 +196,11 @@ public enum FanOwnershipRecovery {
         }
         try FanDurableFile.writeJSON(
             FanSessionJournal(
-                fanIndices: unresolvedFans,
-                ownsFtst: unresolvedFtst
+                fanIndices: Array(unresolvedFans),
+                ownsFtst: outcome.ownsFtst,
+                verifyAllFans: verifyAllFans,
+                verificationFanIndices: Array(pendingVerification),
+                minimumVerificationFanCount: minimumVerificationFanCount
             ),
             to: journalURL,
             permissions: 0o600,
@@ -97,17 +209,4 @@ public enum FanOwnershipRecovery {
         throw FanOwnershipRecoveryError(failures: failures)
     }
 
-    private static func recoveryError(_ error: Error) -> FanRollbackError {
-        if let error = error as? FanRollbackError { return error }
-        if let error = error as? FanHardwareError { return .hardware(error) }
-        if let error = error as? SMCError { return .smc(error) }
-        if let error = error as? FanControllerError {
-            switch error {
-            case .hardware(let hardware): return .hardware(hardware)
-            case .smc(let smc): return .smc(smc)
-            default: return .smc(.injectedFailure(error.description))
-            }
-        }
-        return .smc(.injectedFailure(String(describing: error)))
-    }
 }

--- a/provider-swift/Sources/DarkbloomFanService/FanServiceConfiguration.swift
+++ b/provider-swift/Sources/DarkbloomFanService/FanServiceConfiguration.swift
@@ -79,33 +79,210 @@ public struct FanServicePaths: Equatable, Sendable {
     public let launchDaemonPlist: URL
     public let configuration: URL
     public let sessionJournal: URL
+    public let lastFailure: URL
+    public let sensorBaseline: URL
 
     public init(
         helper: URL,
         launchDaemonPlist: URL,
         configuration: URL,
-        sessionJournal: URL
+        sessionJournal: URL,
+        lastFailure: URL? = nil,
+        sensorBaseline: URL? = nil
     ) {
         self.helper = helper
         self.launchDaemonPlist = launchDaemonPlist
         self.configuration = configuration
         self.sessionJournal = sessionJournal
+        self.lastFailure = lastFailure
+            ?? sessionJournal.deletingLastPathComponent()
+            .appendingPathComponent("fan-last-failure.json")
+        self.sensorBaseline = sensorBaseline
+            ?? sessionJournal.deletingLastPathComponent()
+            .appendingPathComponent("fan-sensor-baseline.json")
     }
 
     public static let production = FanServicePaths(
         helper: URL(fileURLWithPath: "/Library/PrivilegedHelperTools/io.darkbloom.fan-helper"),
         launchDaemonPlist: URL(fileURLWithPath: "/Library/LaunchDaemons/io.darkbloom.fan.plist"),
         configuration: URL(fileURLWithPath: "/Library/Application Support/Darkbloom/fan-policy.json"),
-        sessionJournal: URL(fileURLWithPath: "/Library/Application Support/Darkbloom/fan-session.json")
+        sessionJournal: URL(fileURLWithPath: "/Library/Application Support/Darkbloom/fan-session.json"),
+        lastFailure: URL(fileURLWithPath: "/Library/Application Support/Darkbloom/fan-last-failure.json"),
+        sensorBaseline: URL(fileURLWithPath: "/Library/Application Support/Darkbloom/fan-sensor-baseline.json")
     )
 }
 
 public struct FanSessionJournal: Equatable, Codable, Sendable {
     public let fanIndices: [Int]
     public let ownsFtst: Bool
+    public let verifyAllFans: Bool
+    public let verificationFanIndices: [Int]
+    public let minimumVerificationFanCount: Int
 
-    public init(fanIndices: [Int], ownsFtst: Bool) {
+    public init(
+        fanIndices: [Int],
+        ownsFtst: Bool,
+        verifyAllFans: Bool = false,
+        verificationFanIndices: [Int] = [],
+        minimumVerificationFanCount: Int = 0
+    ) {
         self.fanIndices = Array(Set(fanIndices)).sorted()
         self.ownsFtst = ownsFtst
+        self.verifyAllFans = verifyAllFans
+        self.verificationFanIndices = Array(Set(
+            verificationFanIndices
+        )).sorted()
+        self.minimumVerificationFanCount = max(
+            0,
+            minimumVerificationFanCount
+        )
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case fanIndices
+        case ownsFtst
+        case verifyAllFans
+        case verificationFanIndices
+        case minimumVerificationFanCount
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let fanIndices = try container.decode([Int].self, forKey: .fanIndices)
+        let verificationFanIndices = try container.decodeIfPresent(
+            [Int].self,
+            forKey: .verificationFanIndices
+        ) ?? []
+        let minimumVerificationFanCount = try container.decodeIfPresent(
+            Int.self,
+            forKey: .minimumVerificationFanCount
+        ) ?? 0
+        guard fanIndices.allSatisfy({
+            (0..<FanHardwareReader.maximumSupportedFans).contains($0)
+        }),
+        verificationFanIndices.allSatisfy({
+            (0..<FanHardwareReader.maximumSupportedFans).contains($0)
+        }),
+        (0...FanHardwareReader.maximumSupportedFans).contains(
+            minimumVerificationFanCount
+        )
+        else {
+            throw DecodingError.dataCorruptedError(
+                forKey: .fanIndices,
+                in: container,
+                debugDescription: "fan ownership journal bounds are invalid"
+            )
+        }
+        self.init(
+            fanIndices: fanIndices,
+            ownsFtst: try container.decode(Bool.self, forKey: .ownsFtst),
+            verifyAllFans: try container.decodeIfPresent(
+                Bool.self,
+                forKey: .verifyAllFans
+            ) ?? false,
+            verificationFanIndices: verificationFanIndices,
+            minimumVerificationFanCount: minimumVerificationFanCount
+        )
+    }
+}
+
+public struct FanLastFailure: Equatable, Codable, Sendable {
+    public static let schemaVersion = 1
+    private static let maximumMessageCharacters = 4_096
+
+    public let schema: Int
+    public let message: String
+    public let occurredAt: Date
+
+    public init(message: String, occurredAt: Date = Date()) {
+        self.schema = Self.schemaVersion
+        self.message = String(message.prefix(Self.maximumMessageCharacters))
+        self.occurredAt = occurredAt
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case schema
+        case message
+        case occurredAt = "occurred_at"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let schema = try container.decode(Int.self, forKey: .schema)
+        guard schema == Self.schemaVersion else {
+            throw DecodingError.dataCorruptedError(
+                forKey: .schema,
+                in: container,
+                debugDescription: "unsupported fan failure schema \(schema)"
+            )
+        }
+        let message = try container.decode(String.self, forKey: .message)
+        guard !message.isEmpty, message.count <= Self.maximumMessageCharacters else {
+            throw DecodingError.dataCorruptedError(
+                forKey: .message,
+                in: container,
+                debugDescription: "fan failure message is invalid"
+            )
+        }
+        self.schema = schema
+        self.message = message
+        self.occurredAt = try container.decode(Date.self, forKey: .occurredAt)
+    }
+}
+
+public struct FanSensorBaseline: Equatable, Codable, Sendable {
+    public static let schemaVersion = 1
+
+    public let schema: Int
+    public let chipFamily: FanChipFamily
+    public let sensorKeys: [SMCKey]
+
+    public init(chipFamily: FanChipFamily, sensorKeys: [SMCKey]) {
+        self.schema = Self.schemaVersion
+        self.chipFamily = chipFamily
+        self.sensorKeys = Array(Set(sensorKeys)).sorted {
+            $0.rawValue < $1.rawValue
+        }
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case schema
+        case chipFamily = "chip_family"
+        case sensorKeys = "sensor_keys"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let schema = try container.decode(Int.self, forKey: .schema)
+        guard schema == Self.schemaVersion else {
+            throw DecodingError.dataCorruptedError(
+                forKey: .schema,
+                in: container,
+                debugDescription: "unsupported fan sensor baseline schema \(schema)"
+            )
+        }
+        let chipFamily = try container.decode(
+            FanChipFamily.self,
+            forKey: .chipFamily
+        )
+        let sensorKeys = try container.decode(
+            [SMCKey].self,
+            forKey: .sensorKeys
+        )
+        let unique = Set(sensorKeys)
+        let catalog = Set(GPUTemperatureCatalog.keys(for: chipFamily))
+        guard !unique.isEmpty,
+              unique.count == sensorKeys.count,
+              unique.isSubset(of: catalog)
+        else {
+            throw DecodingError.dataCorruptedError(
+                forKey: .sensorKeys,
+                in: container,
+                debugDescription: "fan sensor baseline is invalid"
+            )
+        }
+        self.schema = schema
+        self.chipFamily = chipFamily
+        self.sensorKeys = sensorKeys.sorted { $0.rawValue < $1.rawValue }
     }
 }

--- a/provider-swift/Sources/darkbloom/Fan/FanCommand.swift
+++ b/provider-swift/Sources/darkbloom/Fan/FanCommand.swift
@@ -134,6 +134,18 @@ extension Fan {
                 if let temperature = helper.gpuTemperatureC {
                     Swift.print("GPU: \(format(temperature)) C")
                 }
+                if helper.hardwareReady == false {
+                    Swift.print(
+                        helper.recoveryPending == true
+                            ? "Hardware readiness: recovering"
+                            : "Hardware readiness: unsupported"
+                    )
+                }
+                if let quarantined = helper.quarantinedSensorKeys,
+                   !quarantined.isEmpty
+                {
+                    Swift.print("Quarantined GPU sensors: \(quarantined.joined(separator: ", "))")
+                }
                 if let error = helper.lastError {
                     Swift.print("Last error: \(error)")
                 }

--- a/provider-swift/Sources/darkbloom/Fan/FanServiceManager.swift
+++ b/provider-swift/Sources/darkbloom/Fan/FanServiceManager.swift
@@ -89,7 +89,10 @@ struct FanServiceManager {
             try bootstrap()
             try kickstart()
 
-            for _ in 0..<30 {
+            var lastReadinessError: String?
+            // Discovery retries every five seconds. Give the helper enough
+            // time for two fresh SMC snapshots before treating startup as bad.
+            for _ in 0..<120 {
                 if let status = try? FanHelperClient().status() {
                     guard status.enabled,
                           status.configuredUID == configuredUID,
@@ -99,12 +102,21 @@ struct FanServiceManager {
                             "helper status does not match the installed policy"
                         )
                     }
+                    if status.hardwareReady == false {
+                        lastReadinessError = status.discoveryError
+                            ?? status.lastError
+                            ?? "fan hardware discovery is not ready"
+                        Thread.sleep(forTimeInterval: 0.1)
+                        continue
+                    }
                     return status
                 }
                 Thread.sleep(forTimeInterval: 0.1)
             }
             throw FanServiceManagerError.launchctlFailed(
-                "helper started but did not answer status"
+                lastReadinessError.map {
+                    "helper started but fan hardware was not ready: \($0)"
+                } ?? "helper started but did not answer status"
             )
         } catch {
             let enableError = error
@@ -273,6 +285,7 @@ struct FanServiceManager {
             }
             try bootoutWithRetries()
             try setLabelEnabled(false)
+            try? FanDurableFile.remove(paths.lastFailure)
             return
         }
 
@@ -294,6 +307,7 @@ struct FanServiceManager {
             try bootoutWithRetries()
         }
         try setLabelEnabled(false)
+        try? FanDurableFile.remove(paths.lastFailure)
     }
 
     func uninstall() throws {
@@ -306,6 +320,8 @@ struct FanServiceManager {
         try FanDurableFile.remove(paths.launchDaemonPlist)
         try FanDurableFile.remove(paths.helper)
         try FanDurableFile.remove(paths.configuration)
+        try FanDurableFile.remove(paths.lastFailure)
+        try FanDurableFile.remove(paths.sensorBaseline)
     }
 
     func isInstalled() -> Bool {
@@ -358,6 +374,14 @@ struct FanServiceManager {
         guard !hardware.inventory.gpuTemperatureKeys.isEmpty else {
             throw FanServiceManagerError.unsupported(
                 "no validated GPU temperature sensor was found for \(hardware.inventory.chipFamily.rawValue)"
+            )
+        }
+        let requiredSensors = GPUTemperatureCatalog.minimumReadyCount(
+            for: hardware.inventory.chipFamily
+        )
+        guard hardware.inventory.gpuTemperatureKeys.count >= requiredSensors else {
+            throw FanServiceManagerError.unsupported(
+                "only \(hardware.inventory.gpuTemperatureKeys.count)/\(requiredSensors) required GPU sensors were ready for \(hardware.inventory.chipFamily.rawValue)"
             )
         }
         return hardware

--- a/provider-swift/Tests/DarkbloomFanCoreTests/FanControllerTests.swift
+++ b/provider-swift/Tests/DarkbloomFanCoreTests/FanControllerTests.swift
@@ -12,6 +12,7 @@ struct FanControllerTests {
             ftstSettleSeconds: 0,
             retryDelaySeconds: 0,
             manualModeAttempts: 3,
+            automaticRestoreAttempts: 1,
             verificationAttempts: 2,
             sleep: { _ in }
         )
@@ -179,6 +180,7 @@ struct FanControllerTests {
                 ftstSettleSeconds: 0,
                 retryDelaySeconds: 0,
                 manualModeAttempts: 1,
+                automaticRestoreAttempts: 1,
                 verificationAttempts: 1,
                 sleep: { _ in }
             )
@@ -686,13 +688,59 @@ struct FanControllerTests {
         #expect(failures.contains(where: { $0.step == .clearFtst }))
         #expect((await controller.currentSession())?.ownsFtst == true)
         #expect(recorder.values.last == FanControlOwnership(
-            fanIndices: [],
+            fanIndices: [0],
             ownsFtst: true
         ))
 
         try await controller.restoreAutomatic()
         #expect(try backend.uint8("Ftst") == 0)
         #expect(await controller.currentSession() == nil)
+    }
+
+    @Test("automatic restore retries stale M4 mode and Ftst readback")
+    func automaticRestoreRetriesStaleReadback() async throws {
+        let backend = makeFanBackend(fanCount: 1)
+        backend.queue([
+            .failBefore(.firmwareRejected(
+                operation: .writeBytes,
+                key: "F0Md",
+                result: 0x82
+            )),
+            .succeed,
+        ], for: "F0Md")
+        let controller = try makeController(
+            backend: backend,
+            timing: FanControlTiming(
+                ftstSettleSeconds: 0,
+                retryDelaySeconds: 0,
+                manualModeAttempts: 3,
+                automaticRestoreAttempts: 3,
+                verificationAttempts: 1,
+                sleep: { _ in }
+            )
+        )
+        let session = try await controller.engage(speedPercent: 80)
+        #expect(session.ownsFtst)
+
+        backend.queue([.replace([1]), .succeed], for: "F0Md")
+        backend.queue([.replace([1]), .succeed], for: "Ftst")
+        backend.installWriteHook { key, bytes in
+            if key == "Ftst", bytes == [0] {
+                backend.setUI8("F0Md", FanMode.manual.rawValue)
+            }
+        }
+
+        try await controller.restoreAutomatic()
+
+        #expect(try backend.uint8("F0Md") == FanMode.automatic.rawValue)
+        #expect(try backend.uint8("Ftst") == 0)
+        #expect(await controller.currentSession() == nil)
+        #expect(backend.operations.filter {
+            $0 == .write("F0Md", [FanMode.automatic.rawValue])
+        }.count == 3)
+        #expect(backend.operations.filter {
+            $0 == .write("Ftst", [0])
+        }.count == 2)
     }
 
     @Test("maintain never treats orphaned Ftst uncertainty as a healthy session")

--- a/provider-swift/Tests/DarkbloomFanCoreTests/FanHardwareTests.swift
+++ b/provider-swift/Tests/DarkbloomFanCoreTests/FanHardwareTests.swift
@@ -20,6 +20,9 @@ struct FanHardwareTests {
         #expect(GPUTemperatureCatalog.keys(for: .m4).contains("Tg1U"))
         #expect(GPUTemperatureCatalog.keys(for: .m5).contains("Tg1g"))
         #expect(GPUTemperatureCatalog.keys(for: .unknown).isEmpty)
+        #expect(GPUTemperatureCatalog.minimumReadyCount(for: .m4) == 5)
+        #expect(GPUTemperatureCatalog.minimumReadyCount(for: .m3) == 4)
+        #expect(GPUTemperatureCatalog.minimumReadyCount(for: .unknown) == 1)
     }
 
     @Test("discovers all required fan keys and uppercase mode keys")

--- a/provider-swift/Tests/DarkbloomFanHelperTests/FanDaemonTests.swift
+++ b/provider-swift/Tests/DarkbloomFanHelperTests/FanDaemonTests.swift
@@ -6,6 +6,11 @@ import Testing
 
 @testable import DarkbloomFanHelper
 
+private let m4MaxGPUKeys: [SMCKey] = [
+    "Tg0G", "Tg0H", "Tg1U", "Tg1k",
+    "Tg0K", "Tg0L", "Tg0d", "Tg0e",
+]
+
 @Suite("Fan helper daemon")
 struct FanDaemonTests {
     @Test("provider lease is required and disconnect restores Auto")
@@ -37,6 +42,9 @@ struct FanDaemonTests {
             requireRootOwnership: false
         )
         #expect(!journal.ownsFtst)
+        #expect(journal.verifyAllFans)
+        #expect(journal.verificationFanIndices == [0])
+        #expect(journal.minimumVerificationFanCount == 1)
 
         await harness.daemon.sessionInvalidated(session)
         #expect(harness.backend.byte("F0Md") == 0)
@@ -71,13 +79,13 @@ struct FanDaemonTests {
         #expect(!(await harness.daemon.status()).providerActive)
     }
 
-    @Test("protocol mismatch never grants a lease")
-    func protocolMismatch() async throws {
+    @Test("legacy helper protocol never grants a lease")
+    func legacyProtocolMismatch() async throws {
         let harness = try makeHarness()
         defer { try? FileManager.default.removeItem(at: harness.root) }
         let reply = await harness.daemon.renewLease(
             sessionID: UUID(),
-            protocolVersion: FanIPC.protocolVersion + 1,
+            protocolVersion: FanIPC.protocolVersion - 1,
             providerVersion: "0.7.9"
         )
         #expect(!reply.ok)
@@ -180,6 +188,263 @@ struct FanDaemonTests {
             requireRootOwnership: false
         )
         #expect(journal.ownsFtst)
+        #expect(journal.verifyAllFans)
+        #expect(journal.verificationFanIndices == [0])
+        #expect(journal.minimumVerificationFanCount == 1)
+    }
+
+    @Test("M4 Max invalid sensor restores Auto, rediscovers, and reacquires lease")
+    func m4MaxInvalidSensorRecovery() async throws {
+        let harness = try makeHarness(
+            inventoryGPUKeys: m4MaxGPUKeys,
+            backendGPUKeys: m4MaxGPUKeys
+        )
+        defer { try? FileManager.default.removeItem(at: harness.root) }
+        harness.backend.rejectNextManualWrite()
+
+        let firstLease = await harness.daemon.renewLease(
+            sessionID: UUID(),
+            protocolVersion: FanIPC.protocolVersion,
+            providerVersion: "0.7.10"
+        )
+        #expect(firstLease.ok)
+        await harness.daemon.tick()
+        #expect((await harness.daemon.status()).mode == .manual)
+        #expect(harness.backend.byte("Ftst") == 1)
+
+        harness.backend.setNumber("Tg1k", to: -4)
+        await harness.daemon.tick()
+
+        let failed = await harness.daemon.status()
+        #expect(failed.mode == .error)
+        #expect(!failed.providerActive)
+        #expect(failed.recoveryPending == true)
+        #expect(failed.quarantinedSensorKeys == ["Tg1k"])
+        #expect(harness.backend.byte("F0Md") == FanMode.automatic.rawValue)
+        #expect(harness.backend.byte("Ftst") == 0)
+
+        harness.clock.advance(by: 5)
+        await harness.daemon.tick()
+        let recovered = await harness.daemon.status()
+        #expect(recovered.hardwareReady == true)
+        #expect(recovered.mode == .waitingForProvider)
+        #expect(recovered.gpuSensorKeys.count == 7)
+        #expect(!recovered.gpuSensorKeys.contains("Tg1k"))
+
+        let renewed = await harness.daemon.renewLease(
+            sessionID: UUID(),
+            protocolVersion: FanIPC.protocolVersion,
+            providerVersion: "0.7.10"
+        )
+        #expect(renewed.ok)
+        await harness.daemon.tick()
+        #expect((await harness.daemon.status()).mode == .manual)
+        #expect(harness.backend.byte("F0Md") == FanMode.manual.rawValue)
+    }
+
+    @Test("empty startup inventory rejects leases until sensors recover")
+    func emptyStartupInventoryRediscovery() async throws {
+        let harness = try makeHarness(
+            inventoryGPUKeys: [],
+            backendGPUKeys: m4MaxGPUKeys,
+            initialDiscoveryError: "GPU sensor discovery returned no plausible readings"
+        )
+        defer { try? FileManager.default.removeItem(at: harness.root) }
+        for key in m4MaxGPUKeys {
+            harness.backend.setNumber(key, to: -4)
+        }
+
+        let rejected = await harness.daemon.renewLease(
+            sessionID: UUID(),
+            protocolVersion: FanIPC.protocolVersion,
+            providerVersion: "0.7.10"
+        )
+        #expect(!rejected.ok)
+        #expect(rejected.message?.contains("GPU sensor discovery") == true)
+
+        await harness.daemon.tick()
+        let unavailable = await harness.daemon.status()
+        #expect(unavailable.mode == .unsupported)
+        #expect(unavailable.hardwareReady == false)
+        #expect(unavailable.recoveryPending == true)
+        #expect(unavailable.lastError != nil)
+        #expect(FileManager.default.fileExists(atPath: harness.paths.lastFailure.path))
+
+        for key in m4MaxGPUKeys {
+            harness.backend.setNumber(key, to: 50)
+        }
+        harness.clock.advance(by: 5)
+        await harness.daemon.tick()
+
+        let recovered = await harness.daemon.status()
+        #expect(recovered.hardwareReady == true)
+        #expect(recovered.recoveryPending == false)
+        #expect(recovered.gpuSensorKeys == m4MaxGPUKeys.map(\.rawValue))
+        #expect(recovered.lastError == nil)
+        #expect(!FileManager.default.fileExists(atPath: harness.paths.lastFailure.path))
+
+        let accepted = await harness.daemon.renewLease(
+            sessionID: UUID(),
+            protocolVersion: FanIPC.protocolVersion,
+            providerVersion: "0.7.10"
+        )
+        #expect(accepted.ok)
+        await harness.daemon.tick()
+        #expect((await harness.daemon.status()).mode == .manual)
+    }
+
+    @Test("restart cannot lower the durable M4 sensor quorum")
+    func restartPreservesSensorQuorum() async throws {
+        let reducedKeys = Array(m4MaxGPUKeys.prefix(3)) + ["Tg0j", "Tg0k"]
+        let harness = try makeHarness(
+            inventoryGPUKeys: reducedKeys,
+            backendGPUKeys: reducedKeys,
+            baselineSensorKeys: m4MaxGPUKeys
+        )
+        defer { try? FileManager.default.removeItem(at: harness.root) }
+
+        let rejected = await harness.daemon.renewLease(
+            sessionID: UUID(),
+            protocolVersion: FanIPC.protocolVersion,
+            providerVersion: "0.7.10"
+        )
+
+        #expect(!rejected.ok)
+        let status = await harness.daemon.status()
+        #expect(status.hardwareReady == false)
+        #expect(status.recoveryPending == true)
+    }
+
+    @Test("first lease waits for a durable sensor baseline")
+    func leaseWaitsForSensorBaseline() async throws {
+        let harness = try makeHarness(baselineSensorKeys: [])
+        defer { try? FileManager.default.removeItem(at: harness.root) }
+
+        let beforePersistence = await harness.daemon.renewLease(
+            sessionID: UUID(),
+            protocolVersion: FanIPC.protocolVersion,
+            providerVersion: "0.7.10"
+        )
+        #expect(!beforePersistence.ok)
+        #expect(beforePersistence.message?.contains("not durable") == true)
+
+        await harness.daemon.tick()
+        #expect(FileManager.default.fileExists(
+            atPath: harness.paths.sensorBaseline.path
+        ))
+
+        let afterPersistence = await harness.daemon.renewLease(
+            sessionID: UUID(),
+            protocolVersion: FanIPC.protocolVersion,
+            providerVersion: "0.7.10"
+        )
+        #expect(afterPersistence.ok)
+    }
+
+    @Test("startup restores journal before rejecting a corrupt sensor baseline")
+    func startupRecoveryPrecedesBaselineValidation() throws {
+        let harness = try makeHarness()
+        defer { try? FileManager.default.removeItem(at: harness.root) }
+        harness.backend.setByte("F0Md", to: FanMode.manual.rawValue)
+        harness.backend.setByte("Ftst", to: 1)
+        try FanDurableFile.writeJSON(
+            FanSessionJournal(
+                fanIndices: [0],
+                ownsFtst: true,
+                verifyAllFans: true,
+                verificationFanIndices: [0],
+                minimumVerificationFanCount: 1
+            ),
+            to: harness.paths.sessionJournal,
+            permissions: 0o600,
+            owner: nil
+        )
+        try FanDurableFile.writeData(
+            Data("{}".utf8),
+            to: harness.paths.sensorBaseline,
+            permissions: 0o600,
+            owner: nil
+        )
+        let reader = FanHardwareReader(backend: harness.backend)
+
+        #expect(throws: (any Error).self) {
+            _ = try FanStartupRecovery.prepare(
+                backend: harness.backend,
+                reader: reader,
+                paths: harness.paths,
+                brandString: "Apple M4 Max",
+                requireRootOwnership: false,
+                journalOwner: nil,
+                timing: FanControlTiming(
+                    ftstSettleSeconds: 0,
+                    retryDelaySeconds: 0,
+                    manualModeAttempts: 1,
+                    automaticRestoreAttempts: 1,
+                    verificationAttempts: 1,
+                    sleep: { _ in }
+                )
+            )
+        }
+
+        #expect(harness.backend.byte("F0Md") == FanMode.automatic.rawValue)
+        #expect(harness.backend.byte("Ftst") == 0)
+        #expect(!FileManager.default.fileExists(
+            atPath: harness.paths.sessionJournal.path
+        ))
+    }
+
+    @Test("missing GPU key revokes the lease and enters rediscovery")
+    func missingSensorRecovery() async throws {
+        let harness = try makeHarness()
+        defer { try? FileManager.default.removeItem(at: harness.root) }
+        _ = await harness.daemon.renewLease(
+            sessionID: UUID(),
+            protocolVersion: FanIPC.protocolVersion,
+            providerVersion: "0.7.10"
+        )
+        await harness.daemon.tick()
+        #expect((await harness.daemon.status()).mode == .manual)
+
+        harness.backend.removeNumber("Tg1k")
+        await harness.daemon.tick()
+
+        let failed = await harness.daemon.status()
+        #expect(failed.mode == .error)
+        #expect(!failed.providerActive)
+        #expect(failed.recoveryPending == true)
+        #expect(failed.quarantinedSensorKeys == ["Tg1k"])
+
+        harness.clock.advance(by: 5)
+        await harness.daemon.tick()
+        let recovered = await harness.daemon.status()
+        #expect(recovered.hardwareReady == true)
+        #expect(recovered.gpuSensorKeys.count == 7)
+    }
+
+    @Test("lease expiry during a slow engage restores Auto")
+    func leaseExpiresDuringEngage() async throws {
+        let harness = try makeHarness()
+        defer { try? FileManager.default.removeItem(at: harness.root) }
+        let entered = DispatchSemaphore(value: 0)
+        let release = DispatchSemaphore(value: 0)
+        harness.backend.blockNextManualWrite(entered: entered, release: release)
+        _ = await harness.daemon.renewLease(
+            sessionID: UUID(),
+            protocolVersion: FanIPC.protocolVersion,
+            providerVersion: "0.7.10"
+        )
+
+        let daemon = harness.daemon
+        let tick = Task { await daemon.tick() }
+        #expect(await waitForSemaphore(entered, timeout: .now() + 2) == .success)
+        harness.clock.advance(by: FanIPC.leaseDurationSeconds + 1)
+        release.signal()
+        await tick.value
+
+        let status = await harness.daemon.status()
+        #expect(!status.providerActive)
+        #expect(harness.backend.byte("F0Md") == FanMode.automatic.rawValue)
+        #expect(!FileManager.default.fileExists(atPath: harness.paths.sessionJournal.path))
     }
 
     @Test("maintenance never journals or clears a foreign Ftst gate")
@@ -214,7 +479,13 @@ private struct FanDaemonHarness {
     let clock: TestUptime
 }
 
-private func makeHarness() throws -> FanDaemonHarness {
+private func makeHarness(
+    inventoryGPUKeys: [SMCKey] = m4MaxGPUKeys,
+    backendGPUKeys: [SMCKey] = m4MaxGPUKeys,
+    baselineSensorKeys: [SMCKey] = m4MaxGPUKeys,
+    initialLastError: String? = nil,
+    initialDiscoveryError: String? = nil
+) throws -> FanDaemonHarness {
     let root = FileManager.default.temporaryDirectory
         .appendingPathComponent("fan-daemon-test-\(UUID().uuidString)")
     try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
@@ -224,7 +495,10 @@ private func makeHarness() throws -> FanDaemonHarness {
         configuration: root.appendingPathComponent("policy.json"),
         sessionJournal: root.appendingPathComponent("session.json")
     )
-    let backend = DaemonBackend(journalURL: paths.sessionJournal)
+    let backend = DaemonBackend(
+        journalURL: paths.sessionJournal,
+        gpuKeys: backendGPUKeys
+    )
     let inventory = FanInventory(
         chipFamily: .m4,
         fans: [FanCapability(
@@ -235,20 +509,22 @@ private func makeHarness() throws -> FanDaemonHarness {
             targetKey: "F0Tg",
             modeKey: "F0Md"
         )],
-        gpuTemperatureKeys: ["Tg1U"],
+        gpuTemperatureKeys: inventoryGPUKeys,
         ftstKey: "Ftst"
     )
     let reader = FanHardwareReader(backend: backend)
+    let timing = FanControlTiming(
+        ftstSettleSeconds: 0,
+        retryDelaySeconds: 0,
+        manualModeAttempts: 2,
+        automaticRestoreAttempts: 1,
+        verificationAttempts: 1,
+        sleep: { _ in }
+    )
     let controller = TransactionalFanController(
         backend: backend,
         inventory: inventory,
-        timing: FanControlTiming(
-            ftstSettleSeconds: 0,
-            retryDelaySeconds: 0,
-            manualModeAttempts: 2,
-            verificationAttempts: 1,
-            sleep: { _ in }
-        )
+        timing: timing
     )
     let clock = TestUptime()
     let configuration = FanServiceConfiguration(
@@ -272,7 +548,20 @@ private func makeHarness() throws -> FanDaemonHarness {
         controller: controller,
         uptime: { clock.value },
         journalOwner: nil,
-        requireRootJournalOwnership: false
+        requireRootJournalOwnership: false,
+        discoverInventory: {
+            try reader.discover(brandString: "Apple M4 Max")
+        },
+        controllerFactory: { refreshedInventory in
+            TransactionalFanController(
+                backend: backend,
+                inventory: refreshedInventory,
+                timing: timing
+            )
+        },
+        baselineSensorKeys: baselineSensorKeys,
+        initialLastError: initialLastError,
+        initialDiscoveryError: initialDiscoveryError
     )
     return FanDaemonHarness(
         root: root,
@@ -303,29 +592,39 @@ private final class TestUptime: @unchecked Sendable {
 private final class DaemonBackend: SMCBackend, @unchecked Sendable {
     private let lock = NSLock()
     private let journalURL: URL
-    private var numbers: [SMCKey: Double] = [
-        "F0Ac": 0,
-        "F0Mn": 1_350,
-        "F0Mx": 5_000,
-        "F0Tg": 0,
-        "Tg1U": 50,
-    ]
-    private var bytes: [SMCKey: UInt8] = ["F0Md": 0, "Ftst": 0]
+    private var numbers: [SMCKey: Double]
+    private var bytes: [SMCKey: UInt8] = ["FNum": 1, "F0Md": 0, "Ftst": 0]
     private(set) var journalExistedBeforeFirstManualWrite = false
     private(set) var journalClaimedFtstBeforeFirstFtstWrite = false
     private var failAutomaticRestore = false
     private var rejectManualWrite = false
     private var claimFtstOnManualRejection = false
+    private var blockedManualWrite: (
+        entered: DispatchSemaphore,
+        release: DispatchSemaphore
+    )?
 
-    init(journalURL: URL) {
+    init(journalURL: URL, gpuKeys: [SMCKey]) {
         self.journalURL = journalURL
+        self.numbers = [
+            "F0Ac": 0,
+            "F0Mn": 1_350,
+            "F0Mx": 5_000,
+            "F0Tg": 0,
+        ]
+        for key in gpuKeys {
+            numbers[key] = 50
+        }
     }
 
     func keyInfo(for key: SMCKey) throws -> SMCKeyInfo {
         if bytes[key] != nil {
             return SMCKeyInfo(dataSize: 1, dataType: try SMCDataType("ui8 "))
         }
-        return SMCKeyInfo(dataSize: 4, dataType: try SMCDataType("flt "))
+        if numbers[key] != nil {
+            return SMCKeyInfo(dataSize: 4, dataType: try SMCDataType("flt "))
+        }
+        throw SMCError.keyNotFound(key)
     }
 
     func read(_ key: SMCKey) throws -> SMCValue {
@@ -338,7 +637,9 @@ private final class DaemonBackend: SMCBackend, @unchecked Sendable {
                 bytes: [byte]
             )
         }
-        let value = numbers[key] ?? 0
+        guard let value = numbers[key] else {
+            throw SMCError.keyNotFound(key)
+        }
         return try SMCValue(
             key: key,
             info: SMCKeyInfo(dataSize: 4, dataType: try SMCDataType("flt ")),
@@ -350,6 +651,11 @@ private final class DaemonBackend: SMCBackend, @unchecked Sendable {
         lock.lock()
         defer { lock.unlock() }
         if bytes[key] != nil {
+            if key == "F0Md", raw[0] == 1, let blockedManualWrite {
+                self.blockedManualWrite = nil
+                blockedManualWrite.entered.signal()
+                blockedManualWrite.release.wait()
+            }
             if key == "F0Md", raw[0] == 1, rejectManualWrite {
                 rejectManualWrite = false
                 if claimFtstOnManualRejection {
@@ -410,10 +716,42 @@ private final class DaemonBackend: SMCBackend, @unchecked Sendable {
         lock.unlock()
     }
 
+    func setNumber(_ key: SMCKey, to value: Double) {
+        lock.lock()
+        numbers[key] = value
+        lock.unlock()
+    }
+
+    func removeNumber(_ key: SMCKey) {
+        lock.lock()
+        numbers.removeValue(forKey: key)
+        lock.unlock()
+    }
+
     func rejectNextManualWrite(claimingFtst: Bool = false) {
         lock.lock()
         rejectManualWrite = true
         claimFtstOnManualRejection = claimingFtst
         lock.unlock()
+    }
+
+    func blockNextManualWrite(
+        entered: DispatchSemaphore,
+        release: DispatchSemaphore
+    ) {
+        lock.lock()
+        blockedManualWrite = (entered, release)
+        lock.unlock()
+    }
+}
+
+private func waitForSemaphore(
+    _ semaphore: DispatchSemaphore,
+    timeout: DispatchTime
+) async -> DispatchTimeoutResult {
+    await withCheckedContinuation { continuation in
+        DispatchQueue.global().async {
+            continuation.resume(returning: semaphore.wait(timeout: timeout))
+        }
     }
 }

--- a/provider-swift/Tests/DarkbloomFanServiceTests/FanServiceTests.swift
+++ b/provider-swift/Tests/DarkbloomFanServiceTests/FanServiceTests.swift
@@ -108,7 +108,7 @@ struct FanServiceTests {
         }
     }
 
-    @Test("startup reconciliation restores only journaled fans and Ftst")
+    @Test("Ftst startup reconciliation verifies every fan")
     func journalRecovery() throws {
         let backend = RecoveryBackend()
         let inventory = recoveryInventory()
@@ -128,12 +128,325 @@ struct FanServiceTests {
             backend: backend,
             inventory: inventory,
             journalURL: journal,
-            requireRootOwnership: false
+            requireRootOwnership: false,
+            timing: recoveryTestTiming()
         )
 
         #expect(backend.byte(for: "F0Md") == 0)
-        #expect(backend.byte(for: "F1Md") == 1)
+        #expect(backend.byte(for: "F1Md") == 0)
         #expect(backend.byte(for: "Ftst") == 0)
+        #expect(!FileManager.default.fileExists(atPath: journal.path))
+    }
+
+    @Test("legacy Ftst-only journal restores every discovered fan")
+    func legacyFtstOnlyJournalRecovery() throws {
+        let backend = RecoveryBackend()
+        let inventory = recoveryInventory()
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("fan-recovery-legacy-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let journal = directory.appendingPathComponent("session.json")
+        try FanDurableFile.writeJSON(
+            FanSessionJournal(fanIndices: [], ownsFtst: true),
+            to: journal,
+            permissions: 0o600,
+            owner: nil
+        )
+
+        try FanOwnershipRecovery.reconcile(
+            backend: backend,
+            inventory: inventory,
+            journalURL: journal,
+            requireRootOwnership: false,
+            journalOwner: nil,
+            timing: recoveryTestTiming()
+        )
+
+        #expect(backend.byte(for: "F0Md") == 0)
+        #expect(backend.byte(for: "F1Md") == 0)
+        #expect(backend.byte(for: "Ftst") == 0)
+        #expect(!FileManager.default.fileExists(atPath: journal.path))
+    }
+
+    @Test("legacy one-fan Ftst journal remains conservative")
+    func legacyOneFanJournalRecovery() throws {
+        let backend = RecoveryBackend()
+        let fullInventory = recoveryInventory()
+        let inventory = FanInventory(
+            chipFamily: fullInventory.chipFamily,
+            fans: [fullInventory.fans[0]],
+            gpuTemperatureKeys: [],
+            ftstKey: fullInventory.ftstKey
+        )
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("fan-recovery-one-fan-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let journal = directory.appendingPathComponent("session.json")
+        try FanDurableFile.writeJSON(
+            FanSessionJournal(fanIndices: [0], ownsFtst: true),
+            to: journal,
+            permissions: 0o600,
+            owner: nil
+        )
+
+        #expect(throws: FanOwnershipRecoveryError.self) {
+            try FanOwnershipRecovery.reconcile(
+                backend: backend,
+                inventory: inventory,
+                journalURL: journal,
+                requireRootOwnership: false,
+                journalOwner: nil,
+                timing: recoveryTestTiming()
+            )
+        }
+
+        #expect(backend.byte(for: "F0Md") == 0)
+        #expect(backend.byte(for: "Ftst") == 0)
+        #expect(FileManager.default.fileExists(atPath: journal.path))
+    }
+
+    @Test("v2 one-fan Ftst journal records its hardware count")
+    func v2OneFanJournalRecovery() throws {
+        let backend = RecoveryBackend()
+        let fullInventory = recoveryInventory()
+        let inventory = FanInventory(
+            chipFamily: fullInventory.chipFamily,
+            fans: [fullInventory.fans[0]],
+            gpuTemperatureKeys: [],
+            ftstKey: fullInventory.ftstKey
+        )
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("fan-recovery-v2-one-fan-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let journal = directory.appendingPathComponent("session.json")
+        try FanDurableFile.writeJSON(
+            FanSessionJournal(
+                fanIndices: [0],
+                ownsFtst: true,
+                verifyAllFans: true,
+                verificationFanIndices: [0],
+                minimumVerificationFanCount: 1
+            ),
+            to: journal,
+            permissions: 0o600,
+            owner: nil
+        )
+
+        try FanOwnershipRecovery.reconcile(
+            backend: backend,
+            inventory: inventory,
+            journalURL: journal,
+            requireRootOwnership: false,
+            journalOwner: nil,
+            timing: recoveryTestTiming()
+        )
+
+        #expect(backend.byte(for: "F0Md") == 0)
+        #expect(backend.byte(for: "Ftst") == 0)
+        #expect(!FileManager.default.fileExists(atPath: journal.path))
+    }
+
+    @Test("Ftst-only journal waits for fan inventory before verification")
+    func legacyJournalWaitsForFanDiscovery() throws {
+        let backend = RecoveryBackend()
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("fan-recovery-empty-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let journal = directory.appendingPathComponent("session.json")
+        try FanDurableFile.writeJSON(
+            FanSessionJournal(fanIndices: [], ownsFtst: true),
+            to: journal,
+            permissions: 0o600,
+            owner: nil
+        )
+        let emptyInventory = FanInventory(
+            chipFamily: .m4,
+            fans: [],
+            gpuTemperatureKeys: [],
+            ftstKey: "Ftst"
+        )
+
+        #expect(throws: FanOwnershipRecoveryError.self) {
+            try FanOwnershipRecovery.reconcile(
+                backend: backend,
+                inventory: emptyInventory,
+                journalURL: journal,
+                requireRootOwnership: false,
+                journalOwner: nil,
+                timing: recoveryTestTiming()
+            )
+        }
+        #expect(backend.byte(for: "Ftst") == 0)
+        let pending = try FanDurableFile.readJSON(
+            FanSessionJournal.self,
+            from: journal,
+            requireRootOwnership: false
+        )
+        #expect(pending.fanIndices.isEmpty)
+        #expect(!pending.ownsFtst)
+        #expect(pending.verifyAllFans)
+        #expect(pending.minimumVerificationFanCount == 2)
+
+        let fullInventory = recoveryInventory()
+        let partialInventory = FanInventory(
+            chipFamily: fullInventory.chipFamily,
+            fans: [fullInventory.fans[0]],
+            gpuTemperatureKeys: [],
+            ftstKey: fullInventory.ftstKey
+        )
+        backend.setByte("F0Md", to: 0)
+        #expect(throws: FanOwnershipRecoveryError.self) {
+            try FanOwnershipRecovery.reconcile(
+                backend: backend,
+                inventory: partialInventory,
+                journalURL: journal,
+                requireRootOwnership: false,
+                journalOwner: nil,
+                timing: recoveryTestTiming()
+            )
+        }
+        #expect(FileManager.default.fileExists(atPath: journal.path))
+
+        backend.setByte("F0Md", to: 1)
+        backend.setByte("Ftst", to: 1)
+        #expect(throws: FanOwnershipRecoveryError.self) {
+            try FanOwnershipRecovery.reconcile(
+                backend: backend,
+                inventory: fullInventory,
+                journalURL: journal,
+                requireRootOwnership: false,
+                journalOwner: nil,
+                timing: recoveryTestTiming()
+            )
+        }
+        #expect(backend.byte(for: "F0Md") == 1)
+        #expect(backend.byte(for: "F1Md") == 1)
+        #expect(backend.byte(for: "Ftst") == 1)
+
+        backend.setByte("Ftst", to: 0)
+        backend.setByte("F0Md", to: 0)
+        backend.setByte("F1Md", to: 0)
+        try FanOwnershipRecovery.reconcile(
+            backend: backend,
+            inventory: fullInventory,
+            journalURL: journal,
+            requireRootOwnership: false,
+            journalOwner: nil,
+            timing: recoveryTestTiming()
+        )
+        #expect(backend.byte(for: "F0Md") == 0)
+        #expect(backend.byte(for: "F1Md") == 0)
+        #expect(!FileManager.default.fileExists(atPath: journal.path))
+    }
+
+    @Test("verification marker retains a tracked fan missing from partial discovery")
+    func verificationMarkerSurvivesPartialDiscovery() throws {
+        let backend = RecoveryBackend()
+        backend.setByte("F0Md", to: 0)
+        let inventory = recoveryInventory()
+        let partialInventory = FanInventory(
+            chipFamily: inventory.chipFamily,
+            fans: [inventory.fans[0]],
+            gpuTemperatureKeys: [],
+            ftstKey: inventory.ftstKey
+        )
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("fan-recovery-partial-inventory-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let journal = directory.appendingPathComponent("session.json")
+        try FanDurableFile.writeJSON(
+            FanSessionJournal(
+                fanIndices: [1],
+                ownsFtst: false,
+                verifyAllFans: true
+            ),
+            to: journal,
+            permissions: 0o600,
+            owner: nil
+        )
+
+        #expect(throws: FanOwnershipRecoveryError.self) {
+            try FanOwnershipRecovery.reconcile(
+                backend: backend,
+                inventory: partialInventory,
+                journalURL: journal,
+                requireRootOwnership: false,
+                journalOwner: nil,
+                timing: recoveryTestTiming()
+            )
+        }
+        let pending = try FanDurableFile.readJSON(
+            FanSessionJournal.self,
+            from: journal,
+            requireRootOwnership: false
+        )
+        #expect(pending.fanIndices == [1])
+        #expect(pending.verifyAllFans)
+
+        try FanOwnershipRecovery.reconcile(
+            backend: backend,
+            inventory: inventory,
+            journalURL: journal,
+            requireRootOwnership: false,
+            journalOwner: nil,
+            timing: recoveryTestTiming()
+        )
+        #expect(backend.byte(for: "F1Md") == 0)
+        #expect(!FileManager.default.fileExists(atPath: journal.path))
+    }
+
+    @Test("verification marker retries writes for tracked fans")
+    func verificationMarkerRetriesTrackedFan() throws {
+        let backend = RecoveryBackend(staleAutomaticReadbacks: 1)
+        let fullInventory = recoveryInventory()
+        let inventory = FanInventory(
+            chipFamily: fullInventory.chipFamily,
+            fans: [fullInventory.fans[0]],
+            gpuTemperatureKeys: [],
+            ftstKey: fullInventory.ftstKey
+        )
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("fan-recovery-tracked-retry-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let journal = directory.appendingPathComponent("session.json")
+        try FanDurableFile.writeJSON(
+            FanSessionJournal(
+                fanIndices: [0],
+                ownsFtst: false,
+                verifyAllFans: true
+            ),
+            to: journal,
+            permissions: 0o600,
+            owner: nil
+        )
+
+        #expect(throws: FanOwnershipRecoveryError.self) {
+            try FanOwnershipRecovery.reconcile(
+                backend: backend,
+                inventory: inventory,
+                journalURL: journal,
+                requireRootOwnership: false,
+                journalOwner: nil,
+                timing: recoveryTestTiming()
+            )
+        }
+        #expect(backend.byte(for: "F0Md") == 1)
+
+        try FanOwnershipRecovery.reconcile(
+            backend: backend,
+            inventory: inventory,
+            journalURL: journal,
+            requireRootOwnership: false,
+            journalOwner: nil,
+            timing: recoveryTestTiming()
+        )
+        #expect(backend.byte(for: "F0Md") == 0)
         #expect(!FileManager.default.fileExists(atPath: journal.path))
     }
 
@@ -185,7 +498,8 @@ struct FanServiceTests {
                 inventory: inventory,
                 journalURL: journal,
                 requireRootOwnership: false,
-                journalOwner: nil
+                journalOwner: nil,
+                timing: recoveryTestTiming()
             )
         }
         #expect(backend.byte(for: "F0Md") == 1)
@@ -198,6 +512,87 @@ struct FanServiceTests {
         )
         #expect(unresolved.fanIndices == [0])
         #expect(!unresolved.ownsFtst)
+    }
+
+    @Test("startup recovery retries stale M4 mode and Ftst readback")
+    func recoveryRetriesStaleReadback() throws {
+        let backend = RecoveryBackend(
+            staleAutomaticReadbacks: 2,
+            staleFtstReadbacks: 2
+        )
+        let inventory = recoveryInventory()
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("fan-recovery-retry-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let journal = directory.appendingPathComponent("session.json")
+        try FanDurableFile.writeJSON(
+            FanSessionJournal(fanIndices: [0], ownsFtst: true),
+            to: journal,
+            permissions: 0o600,
+            owner: nil
+        )
+
+        try FanOwnershipRecovery.reconcile(
+            backend: backend,
+            inventory: inventory,
+            journalURL: journal,
+            requireRootOwnership: false,
+            journalOwner: nil,
+            timing: recoveryTestTiming(attempts: 3)
+        )
+
+        #expect(backend.byte(for: "F0Md") == 0)
+        #expect(backend.byte(for: "Ftst") == 0)
+        #expect(!FileManager.default.fileExists(atPath: journal.path))
+        #expect(backend.writes(to: "F0Md", value: 0) == 3)
+        #expect(backend.writes(to: "Ftst", value: 0) == 3)
+    }
+
+    @Test("new status decoder accepts protocol v1 payloads")
+    func statusBackwardCompatibility() throws {
+        let data = Data(#"{"helperVersion":"1","protocolVersion":1,"enabled":true,"configuredUID":502,"providerActive":false,"mode":"unsupported","chip":"M4","gpuSensorKeys":[],"gpuTemperatureC":null,"triggerTemperatureC":45,"releaseTemperatureC":40,"speedPercent":80,"fans":[],"lastError":null,"updatedAt":0}"#.utf8)
+
+        let status = try FanIPCCoding.decode(FanServiceStatus.self, from: data)
+
+        #expect(status.mode == .unsupported)
+        #expect(status.hardwareReady == nil)
+        #expect(status.recoveryPending == nil)
+        #expect(status.discoveryError == nil)
+        #expect(status.quarantinedSensorKeys == nil)
+    }
+
+    @Test("sensor baseline round-trips only catalog keys")
+    func sensorBaselineValidation() throws {
+        let baseline = FanSensorBaseline(
+            chipFamily: .m4,
+            sensorKeys: ["Tg1k", "Tg1U"]
+        )
+        let encoded = try JSONEncoder().encode(baseline)
+        let decoded = try JSONDecoder().decode(
+            FanSensorBaseline.self,
+            from: encoded
+        )
+        #expect(decoded == baseline)
+
+        let invalid = Data(#"{"schema":1,"chip_family":"M4","sensor_keys":[{"rawValue":"Nope"}]}"#.utf8)
+        #expect(throws: DecodingError.self) {
+            _ = try JSONDecoder().decode(FanSensorBaseline.self, from: invalid)
+        }
+    }
+
+    @Test("legacy ownership journal defaults full verification off")
+    func legacyJournalDecoding() throws {
+        let data = Data(#"{"fanIndices":[],"ownsFtst":true}"#.utf8)
+        let journal = try JSONDecoder().decode(
+            FanSessionJournal.self,
+            from: data
+        )
+        #expect(journal.fanIndices.isEmpty)
+        #expect(journal.ownsFtst)
+        #expect(!journal.verifyAllFans)
+        #expect(journal.verificationFanIndices.isEmpty)
+        #expect(journal.minimumVerificationFanCount == 0)
     }
 }
 
@@ -223,9 +618,18 @@ private final class RecoveryBackend: SMCBackend, @unchecked Sendable {
     private let lock = NSLock()
     private var values: [SMCKey: UInt8] = ["F0Md": 1, "F1Md": 1, "Ftst": 1]
     private let failFanZeroRestore: Bool
+    private var staleAutomaticReadbacks: Int
+    private var staleFtstReadbacks: Int
+    private var recordedWrites: [(SMCKey, UInt8)] = []
 
-    init(failFanZeroRestore: Bool = false) {
+    init(
+        failFanZeroRestore: Bool = false,
+        staleAutomaticReadbacks: Int = 0,
+        staleFtstReadbacks: Int = 0
+    ) {
         self.failFanZeroRestore = failFanZeroRestore
+        self.staleAutomaticReadbacks = staleAutomaticReadbacks
+        self.staleFtstReadbacks = staleFtstReadbacks
     }
 
     func keyInfo(for _: SMCKey) throws -> SMCKeyInfo {
@@ -244,9 +648,20 @@ private final class RecoveryBackend: SMCBackend, @unchecked Sendable {
 
     func write(_ key: SMCKey, bytes: [UInt8]) throws {
         lock.lock()
+        recordedWrites.append((key, bytes[0]))
         if failFanZeroRestore, key == "F0Md", bytes[0] == 0 {
             lock.unlock()
             throw SMCError.injectedFailure("fan zero restore failed")
+        }
+        if key == "F0Md", bytes[0] == 0, staleAutomaticReadbacks > 0 {
+            staleAutomaticReadbacks -= 1
+            lock.unlock()
+            return
+        }
+        if key == "Ftst", bytes[0] == 0, staleFtstReadbacks > 0 {
+            staleFtstReadbacks -= 1
+            lock.unlock()
+            return
         }
         values[key] = bytes[0]
         lock.unlock()
@@ -257,4 +672,27 @@ private final class RecoveryBackend: SMCBackend, @unchecked Sendable {
         defer { lock.unlock() }
         return values[key]
     }
+
+    func setByte(_ key: SMCKey, to value: UInt8) {
+        lock.lock()
+        values[key] = value
+        lock.unlock()
+    }
+
+    func writes(to key: SMCKey, value: UInt8) -> Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return recordedWrites.filter { $0.0 == key && $0.1 == value }.count
+    }
+}
+
+private func recoveryTestTiming(attempts: Int = 1) -> FanControlTiming {
+    FanControlTiming(
+        ftstSettleSeconds: 0,
+        retryDelaySeconds: 0,
+        manualModeAttempts: 1,
+        automaticRestoreAttempts: attempts,
+        verificationAttempts: 1,
+        sleep: { _ in }
+    )
 }


### PR DESCRIPTION
## Summary

Recover the privileged fan helper after transient M4 GPU sensor faults instead
of retaining an empty process-lifetime hardware inventory. The helper now fails
closed to macOS Auto, revokes the active provider lease, retries bounded hardware
discovery, quarantines an invalid sensor key, and accepts a fresh lease only after
the fan and sensor inventory satisfies a durable readiness baseline.

This also strengthens automatic restoration and crash-journal handling so every
possibly controlled fan and the optional `Ftst` gate remain tracked until Auto
mode is verified.

## Linked issue

Closes #551

## Root cause and behavior

`FanDaemon` previously stored a single immutable `FanInventory` and controller
for its entire process lifetime. After an implausible reading such as the reported
`Tg1k = -4 C`, the fail-safe could restore or restart into an empty inventory,
classify the hardware as permanently unsupported, and never retry discovery even
after the sensor recovered.

The recovery path in this PR:

- revokes the lease when a sensor disappears or becomes implausible;
- restores fan modes and `Ftst` with bounded verification retries;
- retries hardware discovery with backoff while remaining fail-closed;
- quarantines the failed key while retaining a minimum validated sensor quorum;
- persists a sensor baseline so restart cannot silently lower that quorum;
- replaces the inventory and controller only after rediscovery is ready;
- exposes hardware readiness, pending recovery, discovery errors, and quarantined
  keys in helper status;
- preserves conservative recovery semantics for legacy ownership journals;
- clears an orphaned Ftst-only controller session instead of maintaining it
  without a stored target.

## Test plan

- [x] `cd provider-swift && swift test --filter DarkbloomFan`
  - 99 tests across 6 suites passed.
- [x] Exact regression:
  `M4 Max invalid sensor restores Auto, rediscovers, and reacquires lease`.
- [x] Empty startup inventory rejects leases until rediscovery succeeds.
- [x] Missing sensors revoke the lease and enter rediscovery.
- [x] Automatic restoration retries stale M4 fan-mode and `Ftst` readback.
- [x] Legacy one-fan journals remain conservative; v2 journals retain an
  explicit expected inventory count.
- [x] Integrated cleanly onto current `master` at
  `f2a6eda215d87316a2265c33deb65f5525ef7c0d`.

No locally built helper was installed on provider hardware. Production validation
still requires the normal Eigen Labs signed and notarized release path.

## Components touched

- [ ] coordinator (Go)
- [ ] provider (Rust, legacy)
- [x] provider-swift (Swift CLI)
- [ ] console-ui (Next.js)
- [ ] enclave (Swift)
- [ ] infra / CI / release
- [x] docs

## Protocol / interface changes

- [ ] No protocol/interface changes
- [x] Yes - the private provider-to-helper XPC protocol is incremented and both
  ends are updated in `provider-swift`. Status decoding remains compatible with
  protocol-v1 payloads, while a legacy helper cannot receive a control lease from
  the upgraded provider.

## Notes for reviewers

The implementation originated from the existing unmerged
`cursor/fix-m4-fan-recovery-67ec` branch and was rebased as one focused commit
onto current master. Two additional corrections were made during validation:

1. An Ftst-only uncertain session now restores tracked state and returns
   `notControlling` instead of failing with `incompleteSession`.
2. The startup-order regression fixture uses an explicit v2 one-fan journal,
   preserving the separate fail-closed expectation for ambiguous legacy journals.

The production helper runs as root and requires the repository's Developer ID
signature. This PR does not change release versions or create a release.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/599"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787965504&installation_model_id=21733&pr_number=599&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F599&signature=7672443d1af87c4b790af0c19dc6dfab531580ec2ec31047e1b68b9c8eeb3882"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->