### PR TITLE
fix(v0.8.1): preserve explicit paged concurrency

### DIFF
--- a/provider-swift/Sources/ProviderCore/Config/ConcurrencyDefaultMigration.swift
+++ b/provider-swift/Sources/ProviderCore/Config/ConcurrencyDefaultMigration.swift
@@ -1,4 +1,5 @@
 import Foundation
+import TOMLKit
 
 /// One `provider.toml` schema upgrade: a `config_version` bump plus, for
 /// exactly ONE cap value, a rewrite of `engine_v2_max_concurrent`.
@@ -75,10 +76,11 @@ public enum ConcurrencyDefaultMigration {
     /// `engine_v2_max_concurrent = 8` is byte-identical whether v0.8.0
     /// GENERATED that 8 or an operator read the v0.8.0 notes and typed it
     /// deliberately — v0.8.0's own migration wrote a durable 8. This step
-    /// therefore WILL silently reset a deliberate 8. Three things bound it: the
-    /// exact-value match means no other cap is touched, `RetiredKnobWarnings`
-    /// announces the change on the startup surface every serve mode uses, and
-    /// the version-2 stamp spends the evidence once — from it on, 8 means 8.
+    /// therefore resets a deliberate 8 unless the box also explicitly selects
+    /// paged, the one distinguishable posture where B=8 remains the measured
+    /// optimum. The exact-value match protects every other cap, the startup
+    /// warning announces a migrated 8, and the version-2 stamp spends the
+    /// evidence once — from it on, 8 means 8.
     public static let v081ConcurrencyRevert = ConcurrencyMigrationStep(
         fromVersion: 1,
         toVersion: 2,
@@ -105,23 +107,26 @@ public enum ConcurrencyDefaultMigration {
 
     // MARK: - Decode-time half
 
-    /// The cap a decoded config should serve, given the stamp and cap actually
-    /// on disk, plus the steps that were applied to get there.
+    /// The cap a decoded config should serve, given the stamp, cap, and
+    /// box-wide KV backend actually on disk, plus the steps that were applied
+    /// to get there.
     ///
     /// Chains: each step whose `fromVersion` matches the running version
     /// advances it, and rewrites the cap only when the cap also matches
     /// exactly. A step whose version matches but whose cap does not still
     /// advances the version — the file IS that schema generation, it just holds
-    /// an operator value that generation must not touch.
+    /// an operator value that generation must not touch. Explicit paged keeps
+    /// B=8 because that backend's measured batch curve still justifies it.
     public static func resolvedCap(
-        onDiskVersion: Int?, cap: UInt64
+        onDiskVersion: Int?, cap: UInt64, kvBackend: String
     ) -> (cap: UInt64, applied: [ConcurrencyMigrationStep]) {
         var running = onDiskVersion
         var value = cap
         var applied: [ConcurrencyMigrationStep] = []
+        let preservesPagedCap = isExplicitPaged(kvBackend)
         for step in steps where step.fromVersion == running {
             running = step.toVersion
-            guard value == step.fromCap else { continue }
+            guard !preservesPagedCap, value == step.fromCap else { continue }
             value = step.toCap
             applied.append(step)
         }
@@ -136,6 +141,32 @@ public enum ConcurrencyDefaultMigration {
         public let text: String
         /// The cap-bearing steps applied. Empty when only the stamp moved.
         public let applied: [ConcurrencyMigrationStep]
+    }
+
+    private struct MigrationDocument: Decodable {
+        struct Backend: Decodable {
+            let kvBackend: String?
+
+            enum CodingKeys: String, CodingKey {
+                case kvBackend = "engine_v2_kv_backend"
+            }
+        }
+
+        let backend: Backend?
+    }
+
+    private static func preservesExplicitPagedCap(in content: String) -> Bool {
+        guard
+            let document = try? TOMLDecoder().decode(
+                MigrationDocument.self, from: content)
+        else { return false }
+        return isExplicitPaged(document.backend?.kvBackend)
+    }
+
+    private static func isExplicitPaged(_ value: String?) -> Bool {
+        value?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased() == "paged"
     }
 
     /// Detects a `config_version` ASSIGNMENT — line-anchored, so a `#` comment
@@ -156,21 +187,15 @@ public enum ConcurrencyDefaultMigration {
         #"(?m)^([ \t]*config_version[ \t]*=[ \t]*)(\d+)((?:[ \t]*[#;].*)?)[ \t]*$"#
 
     /// Matches ONLY a whole `engine_v2_max_concurrent` assignment line holding
-    /// `cap` — anchored to the full line so it cannot touch
-    /// `[backend.engine_v2_max_concurrent_by_model]` or a matching number
-    /// inside it. Captures the leading indentation and an optional trailing
-    /// inline comment with its leading whitespace (`#` per TOML; `;` accepted
-    /// too, since a file carrying one never parses anyway and rewriting it
-    /// loses nothing), so the rewrite preserves both.
-    ///
-    /// Parameterized by the from-value rather than pinned to one constant: each
-    /// step names the cap it migrates, and a future step will name a different
-    /// one.
-    static func assignmentPattern(cap: UInt64) -> String {
-        #"(?m)^([ \t]*)engine_v2_max_concurrent[ \t]*=[ \t]*"#
-            + "\(cap)"
-            + #"((?:[ \t]*[#;].*)?)[ \t]*$"#
-    }
+    /// a TOML integer — anchored to the full line so it cannot touch
+    /// `[backend.engine_v2_max_concurrent_by_model]` or a number inside it.
+    /// Group 1 is indentation, group 2 is the integer token, and group 3 is an
+    /// optional trailing inline comment. The token accepts every TOML integer
+    /// spelling that can encode the generated cap (`+8`, `0x8`, `0o10`,
+    /// `0b1000`, and underscore-separated digits), so the text rewrite cannot
+    /// disagree with the decoder's semantic UInt64 value.
+    static let assignmentPattern =
+        #"(?m)^([ \t]*)engine_v2_max_concurrent[ \t]*=[ \t]*([+-]?(?:0[xX][0-9A-Fa-f](?:_?[0-9A-Fa-f])*|0[oO][0-7](?:_?[0-7])*|0[bB][01](?:_?[01])*|[0-9](?:_?[0-9])*))((?:[ \t]*[#;].*)?)[ \t]*$"#
 
     /// Bring `content` up to ``ProviderConfig/currentConfigVersion``.
     ///
@@ -200,9 +225,12 @@ public enum ConcurrencyDefaultMigration {
         var text = content
         var running = onDiskVersion
         var applied: [ConcurrencyMigrationStep] = []
+        let preservesPagedCap = preservesExplicitPagedCap(in: content)
         for step in steps where step.fromVersion == running {
             running = step.toVersion
-            guard let rewritten = rewriteAssignment(in: text, from: step.fromCap, to: step.toCap)
+            guard !preservesPagedCap,
+                let rewritten = rewriteAssignment(
+                    in: text, from: step.fromCap, to: step.toCap)
             else { continue }
             text = rewritten
             applied.append(step)
@@ -250,7 +278,7 @@ public enum ConcurrencyDefaultMigration {
     /// assignment is present (different value, already rewritten, or the key is
     /// absent) — the caller's signal that only the stamp needs to move.
     static func rewriteAssignment(in content: String, from: UInt64, to: UInt64) -> String? {
-        guard let regex = try? NSRegularExpression(pattern: assignmentPattern(cap: from)) else {
+        guard let regex = try? NSRegularExpression(pattern: assignmentPattern) else {
             return nil
         }
         let full = NSRange(content.startIndex..<content.endIndex, in: content)
@@ -258,10 +286,38 @@ public enum ConcurrencyDefaultMigration {
             let lineRange = Range(match.range(at: 0), in: content)
         else { return nil }
         let group = captureReader(match: match, in: content)
+        guard parseTOMLUnsignedInteger(group(2)) == from else { return nil }
         var rewritten = content
         rewritten.replaceSubrange(
-            lineRange, with: group(1) + "engine_v2_max_concurrent = \(to)" + group(2))
+            lineRange, with: group(1) + "engine_v2_max_concurrent = \(to)" + group(3))
         return rewritten
+    }
+
+    private static func parseTOMLUnsignedInteger(_ token: Substring) -> UInt64? {
+        var literal = String(token).replacingOccurrences(of: "_", with: "")
+        guard !literal.hasPrefix("-") else { return nil }
+        if literal.hasPrefix("+") {
+            literal.removeFirst()
+        }
+
+        let lower = literal.lowercased()
+        let radix: Int
+        let digits: Substring
+        if lower.hasPrefix("0x") {
+            radix = 16
+            digits = literal.dropFirst(2)
+        } else if lower.hasPrefix("0o") {
+            radix = 8
+            digits = literal.dropFirst(2)
+        } else if lower.hasPrefix("0b") {
+            radix = 2
+            digits = literal.dropFirst(2)
+        } else {
+            radix = 10
+            digits = literal[...]
+            guard digits.count == 1 || digits.first != "0" else { return nil }
+        }
+        return UInt64(digits, radix: radix)
     }
 
     /// Capture-group text, empty for groups that did not participate.

--- a/provider-swift/Sources/ProviderCore/Config/ProviderConfig.swift
+++ b/provider-swift/Sources/ProviderCore/Config/ProviderConfig.swift
@@ -393,20 +393,24 @@ public struct ProviderConfig: Sendable, Equatable, Codable {
         // One-time concurrency-default migrations, selected by the stamp the
         // file carries.
         //
-        // Deliberately narrow: a step fires only on the EXACT cap the matching
-        // release generated, so an operator who picked any other value in
-        // range is never rewritten. The unavoidable casualty is a deliberate
+        // Deliberately narrow: a step fires only on the exact cap the release
+        // generated, so an operator who picked any other value in range is
+        // never rewritten. The unavoidable casualty is a deliberate
         // cap that happens to equal the one being migrated away from — see
         // `ConcurrencyDefaultMigration.v081ConcurrencyRevert`, which is honest
         // about the fact that v0.8.1's 8 -> 4 step cannot tell a generated 8
-        // from a chosen one. It runs once, is announced by
-        // `RetiredKnobWarnings`, and sticks the moment it is re-set.
+        // from a chosen one. Explicit paged is the exception: its backend
+        // selection is distinguishable and its measured optimum remains B=8,
+        // so the migration preserves it. Any migrated cap runs once, is
+        // announced by `RetiredKnobWarnings`, and sticks when re-set.
         //
         // The predicate is shared with the on-disk rewrite so this in-memory
         // change and the durable text surgery cannot disagree.
         let onDiskVersion = try container.decodeIfPresent(Int.self, forKey: .configVersion)
         let migrated = ConcurrencyDefaultMigration.resolvedCap(
-            onDiskVersion: onDiskVersion, cap: backend.engineV2MaxConcurrent)
+            onDiskVersion: onDiskVersion,
+            cap: backend.engineV2MaxConcurrent,
+            kvBackend: backend.engineV2KVBackend)
         backend.engineV2MaxConcurrent = migrated.cap
         self.appliedMigrations = migrated.applied.map(\.id)
         self.backend = backend

--- a/provider-swift/Tests/DarkbloomCLITests/ConfigVersionStampTests.swift
+++ b/provider-swift/Tests/DarkbloomCLITests/ConfigVersionStampTests.swift
@@ -68,6 +68,30 @@ struct ConfigVersionStampTests {
         }
     }
 
+    @Test("explicit paged keeps B=8 while the file is re-dated")
+    func preservesExplicitPagedEight() throws {
+        try withTempConfig(
+            """
+            config_version = 1
+            [provider]
+            name = "test-provider"
+
+            [backend]
+            engine_v2_max_concurrent = 8
+            engine_v2_kv_backend = "paged"
+            """
+        ) { path in
+            #expect(migrateConfigSchema(in: path).isEmpty)
+            let text = try read(path)
+            #expect(text.hasPrefix("config_version = 2\n"))
+            #expect(text.contains("engine_v2_max_concurrent = 8"))
+
+            let config = try ConfigManager.load(from: path)
+            #expect(config.backend.engineV2MaxConcurrent == 8)
+            #expect(config.appliedMigrations.isEmpty)
+        }
+    }
+
     /// The re-stamp is unconditional on an out-of-date file. If it only landed
     /// when the concurrency line changed, a config holding `= 6` would stay at
     /// version 1, and an operator later editing it to 8 would be migrated —
@@ -272,7 +296,7 @@ struct ConfigVersionStampTests {
     /// landed, and boot 2+ honored the literal. The comment must also SURVIVE
     /// the rewrite: text surgery exists precisely to preserve operator prose.
     @Test(
-        "a generated 8 with a trailing inline comment is rewritten, comment preserved",
+        "a generated 8 in any TOML integer spelling is rewritten, comment preserved",
         arguments: [
             ("engine_v2_max_concurrent = 8 # raised by the v0.8.0 upgrade",
              "engine_v2_max_concurrent = 4 # raised by the v0.8.0 upgrade"),
@@ -284,6 +308,15 @@ struct ConfigVersionStampTests {
             // Indentation is preserved too.
             ("  engine_v2_max_concurrent = 8",
              "  engine_v2_max_concurrent = 4"),
+            // Alternate valid TOML integer spellings decode to the same UInt64.
+            ("engine_v2_max_concurrent = +8",
+             "engine_v2_max_concurrent = 4"),
+            ("engine_v2_max_concurrent = 0x8",
+             "engine_v2_max_concurrent = 4"),
+            ("engine_v2_max_concurrent = 0o10",
+             "engine_v2_max_concurrent = 4"),
+            ("engine_v2_max_concurrent = 0b1000",
+             "engine_v2_max_concurrent = 4"),
             // No comment at all — the original shape keeps working.
             ("engine_v2_max_concurrent = 8",
              "engine_v2_max_concurrent = 4"),

--- a/provider-swift/Tests/ProviderCoreTests/EngineV2BridgeTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/EngineV2BridgeTests.swift
@@ -1490,10 +1490,10 @@ struct EngineV2FailLoudFactoryTests {
             from: Data(#"{"engine_v2": false}"#.utf8)
         )
         #expect(off.retiredKeysPresent == ["engine_v2"])
-        // New concurrency keys: default 8 as of v0.8.0 (raised with the
-        // `.auto` paged flip — see ConfigTests), per-model override map.
+        // New concurrency keys: default 4 as of v0.8.1 (the contiguous
+        // batch-curve knee — see ConfigTests), per-model override map.
         let absent = try decoder.decode(BackendSettings.self, from: Data(#"{}"#.utf8))
-        #expect(absent.engineV2MaxConcurrent == 8)
+        #expect(absent.engineV2MaxConcurrent == BackendSettings.defaultEngineV2MaxConcurrent)
         #expect(absent.engineV2MaxConcurrentByModel.isEmpty)
         let configured = try decoder.decode(
             BackendSettings.self,
@@ -1524,10 +1524,10 @@ struct EngineV2FailLoudFactoryTests {
         #expect(config.backend.engineV2MaxConcurrentByModel == [
             "gemma-4-26b-qat-4bit": 2, "gpt-oss-20b": 8,
         ])
-        // Defaults when the keys are absent. A pre-v0.8.0 file instead carries
-        // a serialized `= 4`, which ConfigTests covers separately.
+        // Missing keys use the shared v0.8.1 default. A pre-v0.8.0 file
+        // instead carries a serialized `= 4`, covered in ConfigTests.
         let defaults = ConfigManager.parse("[provider]\nname = \"cfg-test\"\n")
-        #expect(defaults.backend.engineV2MaxConcurrent == 8)
+        #expect(defaults.backend.engineV2MaxConcurrent == BackendSettings.defaultEngineV2MaxConcurrent)
         #expect(defaults.backend.engineV2MaxConcurrentByModel.isEmpty)
     }
 


### PR DESCRIPTION
## Summary

- Preserve `engine_v2_max_concurrent = 8` during the v1 → v2 config migration when the provider explicitly selects `engine_v2_kv_backend = "paged"`.
- Continue migrating generated/default `auto` and contiguous configurations from 8 → 4.
- Parse the assignment through TOMLKit before rewriting, so all valid TOML integer spellings behave consistently and comments remain intact.
- Update the two stale release assertions that still expected the retired v0.8.0 default of 8.

This closes the two blockers found in the merged v0.8.1 PR review: explicit paged boxes no longer lose their measured B=8 optimum, and non-decimal TOML values no longer produce a one-boot in-memory/on-disk mismatch.

## Before

```mermaid
flowchart LR
  A[provider.toml: config_version 1, cap 8] --> B[ProviderConfig.init]
  B --> C[resolvedCap always returns 4]
  C --> D[Explicit paged box serves B=4]
  A --> E[migrateConfigSchema regex]
  E --> F{decimal 8 matched?}
  F -- yes --> G[rewrite 4 and stamp v2]
  F -- no --> H[stamp v2, leave alternate integer spelling]
  H --> I[next boot decodes 8]
```

## After

```mermaid
flowchart LR
  A[provider.toml: config_version 1, cap 8] --> B[TOMLKit semantic decode]
  B --> C{explicit paged backend?}
  C -- yes --> D[keep B=8]
  C -- no: auto or contiguous --> E[migrate to B=4]
  D --> F[migrateConfigSchema stamps v2 without cap rewrite]
  E --> G[migrateConfigSchema rewrites decoded cap and stamps v2]
  F --> H[next boot remains B=8]
  G --> I[next boot remains B=4]
```

## Verification

- `swift test` — 1,949 Swift Testing tests across 199 suites passed; 82 XCTest tests passed.
- `./scripts/check-release-version.sh 0.8.1`
- `swift build -c release --product darkbloom`
- `.build/release/darkbloom --version` → `0.8.1`
- `.build/release/darkbloom runtime-smoke` → `paged-kernel-runtime-smoke: ok`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/601"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787972313&installation_model_id=21733&pr_number=601&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F601&signature=f6ed8e13af6355bf60732888b8412c79166cbd3546363ad172c52d7f35f4dced"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->