### PR TITLE
fix(tools): stop auto tool_choice rejecting standard JSON Schema (#561 regression)

### DIFF
--- a/coordinator/api/auto_toolschema_regression_test.go
+++ b/coordinator/api/auto_toolschema_regression_test.go
@@ -183,27 +183,27 @@ func TestAutoToolSchemaReachesRoutingOverHTTP(t *testing.T) {
 }
 
 // The capability verdict has to tell a client whether retrying can ever help.
-// "This model is served but nobody enforces tool_choice" is permanent; only a
-// model the fleet does not serve at all is a retryable capacity condition. And
-// `none`, which needs no enforcement, must clear both gates.
+// "This model is served but no build of it EVER enforces tool_choice" is
+// permanent (400); a model the fleet does not serve at all, or an enforcing
+// provider that is merely trust-lapsed right now, is a retryable condition
+// (503). And `none`, which needs no enforcement, must clear both gates.
 func TestToolConstraintCapabilityErrorSeparatesPermanentFromTransient(t *testing.T) {
 	const model = "gpt-oss-20b"
-	failFast := func(t *testing.T, hasTools, requiresConstraint, withProvider bool) *httptest.ResponseRecorder {
+	failFast := func(
+		t *testing.T,
+		hasTools, requiresConstraint bool,
+		configure func(*registry.Provider),
+	) *httptest.ResponseRecorder {
 		t.Helper()
 		srv, _ := testServer(t)
 		srv.registry.SetModelCatalog([]registry.CatalogEntry{{ID: model}})
-		if withProvider {
-			// Above the tools floor but advertising no tool-constraint
-			// protocol: the fleet serves the model, nobody enforces on it.
-			provider := registerBuildsProvider(srv, "serving-provider", model)
-			provider.Mu().Lock()
-			provider.Version = "0.6.5"
-			provider.Mu().Unlock()
+		if configure != nil {
+			configure(registerBuildsProvider(srv, "serving-provider", model))
 		}
 		response := httptest.NewRecorder()
 		handled := srv.visionToolsFailFast(
 			response, model, model, false, hasTools, requiresConstraint,
-			false, selfRoutePolicy{}, nil)
+			"required", false, selfRoutePolicy{}, nil)
 		if requiresConstraint && !handled {
 			t.Fatal("incapable constrained request was allowed into the queue")
 		}
@@ -214,7 +214,13 @@ func TestToolConstraintCapabilityErrorSeparatesPermanentFromTransient(t *testing
 		return response
 	}
 
-	served := failFast(t, true, true, true)
+	// Above the tools floor but advertising no tool-constraint protocol: the
+	// fleet serves the model, nobody ever enforces on it — permanent.
+	served := failFast(t, true, true, func(p *registry.Provider) {
+		p.Mu().Lock()
+		p.Version = "0.6.5"
+		p.Mu().Unlock()
+	})
 	if served.Code != http.StatusBadRequest ||
 		!strings.Contains(served.Body.String(),
 			"inference-enforced tool_choice (required/named) is not supported") {
@@ -222,12 +228,33 @@ func TestToolConstraintCapabilityErrorSeparatesPermanentFromTransient(t *testing
 			served.Code, served.Body.String())
 	}
 
-	absent := failFast(t, false, true, false)
+	absent := failFast(t, false, true, nil)
 	if absent.Code != http.StatusServiceUnavailable ||
 		!strings.Contains(absent.Body.String(),
 			"advertises inference-time tool_choice enforcement") {
 		t.Fatalf("absent model lost its retryable capacity error: %d %s",
 			absent.Code, absent.Body.String())
+	}
+
+	// A provider that ADVERTISES enforcement (protocol v1 + the concrete
+	// model) but sits below the registry's trust minimum is transiently
+	// unroutable — an outage, not an incapability. The verdict must stay
+	// retryable (503); reporting the permanent 400 would tell clients this
+	// model can never enforce tool_choice while the fleet is merely
+	// re-attesting.
+	lapsed := failFast(t, false, true, func(p *registry.Provider) {
+		p.Mu().Lock()
+		p.Version = "0.7.10"
+		p.ToolConstraintProtocol = registry.ToolConstraintProtocolV1
+		p.ToolConstraintModels = map[string]struct{}{model: {}}
+		p.TrustLevel = registry.TrustSelfSigned
+		p.Mu().Unlock()
+	})
+	if lapsed.Code != http.StatusServiceUnavailable ||
+		!strings.Contains(lapsed.Body.String(),
+			"advertises inference-time tool_choice enforcement") {
+		t.Fatalf("transient trust lapse reported as permanent incapability: %d %s",
+			lapsed.Code, lapsed.Body.String())
 	}
 
 	// tool_choice "none" derives requiresToolConstraint=false, so a model with
@@ -237,5 +264,5 @@ func TestToolConstraintCapabilityErrorSeparatesPermanentFromTransient(t *testing
 	if err != nil {
 		t.Fatal(err)
 	}
-	failFast(t, false, mode.requiresGrammar(), false)
+	failFast(t, false, mode.requiresGrammar(), nil)
 }

--- a/coordinator/api/auto_toolschema_regression_test.go
+++ b/coordinator/api/auto_toolschema_regression_test.go
@@ -1,0 +1,241 @@
+package api
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/eigeninference/d-inference/coordinator/registry"
+)
+
+// autoStandardSchemaCorpus is the set of JSON-Schema constructs #561 started
+// rejecting for every model. They are all emitted by mainstream SDKs (pydantic
+// and zod hoist definitions into `$defs`/`$ref`; unions become anyOf/oneOf),
+// and they are all decidable by the post-generation validator that auto and
+// none actually use — so the pre-flight must forward them untouched. The value
+// is the property schema placed under a single declared tool; constrained is
+// the status the grammar-compiled modes still reject it with.
+var autoStandardSchemaCorpus = map[string]struct {
+	property    string
+	constrained int
+}{
+	"anyOf string|object": {`{"anyOf":[{"type":"string"},
+		{"type":"object","properties":{"source":{"type":"string"}}}]}`,
+		http.StatusUnprocessableEntity},
+	"oneOf string|integer": {`{"oneOf":[{"type":"string"},{"type":"integer"}]}`,
+		http.StatusUnprocessableEntity},
+	"patternProperties": {`{"type":"object","patternProperties":{"^[A-Z_]+$":{"type":"string"}}}`,
+		http.StatusUnprocessableEntity},
+	"pattern": {`{"type":"string","pattern":"^[a-f0-9]{8}$"}`,
+		http.StatusUnprocessableEntity},
+	"if/then": {`{"type":"object","if":{"required":["a"]},"then":{"required":["b"]}}`,
+		http.StatusUnprocessableEntity},
+	"dependentRequired": {`{"type":"object","dependentRequired":{"credit_card":["billing_address"]}}`,
+		http.StatusUnprocessableEntity},
+	"propertyNames": {`{"type":"object","propertyNames":{"pattern":"^[a-z]+$"}}`,
+		http.StatusUnprocessableEntity},
+	"unevaluatedProperties": {`{"type":"object","unevaluatedProperties":false}`,
+		http.StatusUnprocessableEntity},
+	"multi-type": {`{"type":["string","integer"]}`,
+		http.StatusUnprocessableEntity},
+	// A typeless mixed enum reaches the constrained compiler's finite-value
+	// check rather than its keyword allowlist, so it fails as a malformed
+	// request (400) instead of an uncompilable one (422).
+	"typeless mixed enum": {`{"enum":["a",1]}`, http.StatusBadRequest},
+}
+
+// autoStandardSchemaBody wraps a property schema in a full chat-completions
+// request for the given tool_choice. `$defs`/`$ref` needs a sibling on the
+// parameters root, so it is spelled separately below.
+func autoStandardSchemaBody(model, choice, property string) string {
+	return fmt.Sprintf(`{"model":%q,"messages":[{"role":"user","content":"x"}],
+		"tool_choice":%q,
+		"tools":[{"type":"function","function":{"name":"set_config_value","parameters":
+		{"type":"object","properties":{"value":%s},"required":["value"]}}}]}`,
+		model, choice, property)
+}
+
+const autoRefDefsBody = `{"model":%q,"messages":[{"role":"user","content":"x"}],
+	"tool_choice":%q,
+	"tools":[{"type":"function","function":{"name":"f","parameters":
+	{"type":"object","$defs":{"P":{"type":"string"}},
+	"properties":{"p":{"$ref":"#/$defs/P"}}}}}]}`
+
+// #561 regression. `auto` compiles no inference grammar — ToolConstraintFactory
+// returns nil for it and the provider validates emitted calls against the full
+// JSON Schema afterwards. The coordinator therefore has no grammar-feasibility
+// question to answer at admission time, and must forward standard JSON Schema
+// for EVERY model. Only the genuinely grammar-compiled modes fail closed.
+func TestAutoToolChoiceForwardsStandardJSONSchema(t *testing.T) {
+	// Model-blind: the pre-flight never saw a model, so a Gemma-class name must
+	// not be what makes a schema legal.
+	models := []string{"gpt-oss-20b", "gemma-4-26b", "totally-made-up"}
+
+	t.Run("accepted under auto", func(t *testing.T) {
+		for name, schema := range autoStandardSchemaCorpus {
+			for _, model := range models {
+				body := autoStandardSchemaBody(model, "auto", schema.property)
+				if _, err := validateToolConstraintRequest([]byte(body)); err != nil {
+					t.Errorf("%s rejected for model %q: %v", name, model, err)
+				}
+			}
+		}
+		for _, model := range models {
+			body := fmt.Sprintf(autoRefDefsBody, model, "auto")
+			if _, err := validateToolConstraintRequest([]byte(body)); err != nil {
+				t.Errorf("$defs/$ref rejected for model %q: %v", model, err)
+			}
+		}
+	})
+
+	// The constrained modes DO compile a grammar, so their allowlist stays
+	// fail-closed on exactly these constructs. That asymmetry is the point.
+	t.Run("still rejected under required", func(t *testing.T) {
+		reject := func(name string, body []byte, want int) {
+			t.Helper()
+			_, err := validateToolConstraintRequest(body)
+			var typed *toolConstraintRequestError
+			if !errors.As(err, &typed) || typed.status != want {
+				t.Errorf("%s in constrained mode: %T %v, want status %d",
+					name, err, err, want)
+			}
+		}
+		for name, schema := range autoStandardSchemaCorpus {
+			reject(name,
+				[]byte(autoStandardSchemaBody("gpt-oss-20b", "required", schema.property)),
+				schema.constrained)
+		}
+		reject("$defs/$ref",
+			[]byte(fmt.Sprintf(autoRefDefsBody, "gpt-oss-20b", "required")),
+			http.StatusUnprocessableEntity)
+	})
+
+	// The one rejection that survives in the non-grammar modes: the caller
+	// cannot plant the coordinator's own normalization marker. Validation runs
+	// on the pre-normalization body, so any occurrence is forged.
+	t.Run("forged reserved metadata still rejected", func(t *testing.T) {
+		for _, choice := range []string{"auto", "none"} {
+			body := autoStandardSchemaBody("gpt-oss-20b", choice,
+				`{"type":"string","x-darkbloom-original-boolean-schema":true}`)
+			_, err := validateToolConstraintRequest([]byte(body))
+			var typed *toolConstraintRequestError
+			if !errors.As(err, &typed) || typed.status != http.StatusBadRequest {
+				t.Errorf("%s accepted forged reserved metadata: %T %v", choice, err, err)
+			}
+		}
+	})
+
+	// `none` is honored by hiding tools from the prompt and rejecting any call
+	// the model emits anyway — no sampler grammar, so no Gemma-only fence.
+	t.Run("none needs no grammar", func(t *testing.T) {
+		bodies := map[string]string{
+			"with tools": `{"model":"gpt-oss-20b","messages":[{"role":"user","content":"x"}],
+				"tool_choice":"none",
+				"tools":[{"type":"function","function":{"name":"f","parameters":{"type":"object"}}}]}`,
+			"without tools": `{"model":"gpt-oss-20b",
+				"messages":[{"role":"user","content":"x"}],"tool_choice":"none"}`,
+		}
+		for name, body := range bodies {
+			mode, err := validateToolConstraintRequest([]byte(body))
+			if err != nil {
+				t.Fatalf("%s: %v", name, err)
+			}
+			if mode != toolChoiceNone {
+				t.Fatalf("%s: mode = %q, want none", name, mode)
+			}
+			if mode.requiresGrammar() {
+				t.Errorf("%s: none demanded an inference-enforcing provider", name)
+			}
+		}
+	})
+}
+
+// End-to-end through the real HTTP handler with a non-Gemma model that has no
+// constraint-capable provider (the production gpt-oss-20b situation). The union
+// and $ref shapes must clear admission and be answered by the ROUTING
+// capability gate, never by a 422 schema verdict the auto path never needed.
+func TestAutoToolSchemaReachesRoutingOverHTTP(t *testing.T) {
+	srv, _ := testServer(t)
+	srv.registry.SetModelCatalog([]registry.CatalogEntry{{ID: "gpt-oss-20b"}})
+
+	bodies := map[string]string{
+		"anyOf union": autoStandardSchemaBody("gpt-oss-20b", "auto",
+			autoStandardSchemaCorpus["anyOf string|object"].property),
+		"$defs/$ref": fmt.Sprintf(autoRefDefsBody, "gpt-oss-20b", "auto"),
+	}
+	for name, body := range bodies {
+		t.Run(name, func(t *testing.T) {
+			request := httptest.NewRequest(
+				http.MethodPost, "/v1/chat/completions", strings.NewReader(body))
+			request.Header.Set("Authorization", "Bearer test-key")
+			response := httptest.NewRecorder()
+			srv.Handler().ServeHTTP(response, request)
+			if response.Code != http.StatusServiceUnavailable ||
+				!strings.Contains(response.Body.String(), "supports tool calls") {
+				t.Fatalf("auto request did not reach the routing gate: %d %s",
+					response.Code, response.Body.String())
+			}
+		})
+	}
+}
+
+// The capability verdict has to tell a client whether retrying can ever help.
+// "This model is served but nobody enforces tool_choice" is permanent; only a
+// model the fleet does not serve at all is a retryable capacity condition. And
+// `none`, which needs no enforcement, must clear both gates.
+func TestToolConstraintCapabilityErrorSeparatesPermanentFromTransient(t *testing.T) {
+	const model = "gpt-oss-20b"
+	failFast := func(t *testing.T, hasTools, requiresConstraint, withProvider bool) *httptest.ResponseRecorder {
+		t.Helper()
+		srv, _ := testServer(t)
+		srv.registry.SetModelCatalog([]registry.CatalogEntry{{ID: model}})
+		if withProvider {
+			// Above the tools floor but advertising no tool-constraint
+			// protocol: the fleet serves the model, nobody enforces on it.
+			provider := registerBuildsProvider(srv, "serving-provider", model)
+			provider.Mu().Lock()
+			provider.Version = "0.6.5"
+			provider.Mu().Unlock()
+		}
+		response := httptest.NewRecorder()
+		handled := srv.visionToolsFailFast(
+			response, model, model, false, hasTools, requiresConstraint,
+			false, selfRoutePolicy{}, nil)
+		if requiresConstraint && !handled {
+			t.Fatal("incapable constrained request was allowed into the queue")
+		}
+		if !requiresConstraint && handled {
+			t.Fatalf("unconstrained request was blocked: %d %s",
+				response.Code, response.Body.String())
+		}
+		return response
+	}
+
+	served := failFast(t, true, true, true)
+	if served.Code != http.StatusBadRequest ||
+		!strings.Contains(served.Body.String(),
+			"inference-enforced tool_choice (required/named) is not supported") {
+		t.Fatalf("permanent incapability reported as capacity: %d %s",
+			served.Code, served.Body.String())
+	}
+
+	absent := failFast(t, false, true, false)
+	if absent.Code != http.StatusServiceUnavailable ||
+		!strings.Contains(absent.Body.String(),
+			"advertises inference-time tool_choice enforcement") {
+		t.Fatalf("absent model lost its retryable capacity error: %d %s",
+			absent.Code, absent.Body.String())
+	}
+
+	// tool_choice "none" derives requiresToolConstraint=false, so a model with
+	// no enforcing provider at all still serves it.
+	mode, err := validateToolConstraintRequest([]byte(
+		`{"model":"gpt-oss-20b","messages":[{"role":"user","content":"x"}],"tool_choice":"none"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	failFast(t, false, mode.requiresGrammar(), false)
+}

--- a/coordinator/api/auto_toolschema_regression_test.go
+++ b/coordinator/api/auto_toolschema_regression_test.go
@@ -117,13 +117,22 @@ func TestAutoToolChoiceForwardsStandardJSONSchema(t *testing.T) {
 	// cannot plant the coordinator's own normalization marker. Validation runs
 	// on the pre-normalization body, so any occurrence is forged.
 	t.Run("forged reserved metadata still rejected", func(t *testing.T) {
-		for _, choice := range []string{"auto", "none"} {
-			body := autoStandardSchemaBody("gpt-oss-20b", choice,
-				`{"type":"string","x-darkbloom-original-boolean-schema":true}`)
-			_, err := validateToolConstraintRequest([]byte(body))
-			var typed *toolConstraintRequestError
-			if !errors.As(err, &typed) || typed.status != http.StatusBadRequest {
-				t.Errorf("%s accepted forged reserved metadata: %T %v", choice, err, err)
+		// The multi-concrete `type` array beside an author combinator is the
+		// collapse-only normalization path — the guard must still descend the
+		// author's anyOf and catch a marker planted inside it.
+		for name, property := range map[string]string{
+			"bare marker": `{"type":"string","x-darkbloom-original-boolean-schema":true}`,
+			"marker inside author anyOf on a type-array node": `{"type":["string","object"],
+				"anyOf":[{"type":"string","x-darkbloom-original-boolean-schema":true}]}`,
+		} {
+			for _, choice := range []string{"auto", "none"} {
+				body := autoStandardSchemaBody("gpt-oss-20b", choice, property)
+				_, err := validateToolConstraintRequest([]byte(body))
+				var typed *toolConstraintRequestError
+				if !errors.As(err, &typed) || typed.status != http.StatusBadRequest {
+					t.Errorf("%s/%s accepted forged reserved metadata: %T %v",
+						choice, name, err, err)
+				}
 			}
 		}
 	})

--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -1553,7 +1553,7 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	// sent via the Responses API surface (input-without-messages), because the
 	// Responses→chat lowering doesn't carry image/video parts through.
 	if s.visionToolsFailFast(w, model, publicModel, requiresVision, hasTools,
-		requiresToolConstraint,
+		requiresToolConstraint, string(validatedMode),
 		input != nil && len(messages) == 0, policy, allowedProviderSerials) {
 		return
 	}
@@ -3791,7 +3791,7 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 	// Anthropic bodies share the top-level "tools" field; neither has the
 	// Responses-API media surface, so rejectResponsesMedia is false here.
 	if s.visionToolsFailFast(w, model, publicModel, requiresVision, hasTools,
-		requiresToolConstraint,
+		requiresToolConstraint, string(validatedMode),
 		false, policy, allowedProviderSerials) {
 		return
 	}

--- a/coordinator/api/inference_preprocess.go
+++ b/coordinator/api/inference_preprocess.go
@@ -18,6 +18,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+
+	"github.com/eigeninference/d-inference/coordinator/registry"
 )
 
 // maxInferenceBodyBytes caps the plaintext inference request body. Without it
@@ -195,6 +197,7 @@ func (s *Server) visionToolsFailFast(
 	w http.ResponseWriter,
 	model, publicModel string,
 	requiresVision, hasTools, requiresToolConstraint bool,
+	toolChoiceMode string,
 	rejectResponsesMedia bool,
 	policy selfRoutePolicy,
 	allowedProviderSerials []string,
@@ -225,15 +228,23 @@ func (s *Server) visionToolsFailFast(
 		}
 	}
 	// Tools fail-fast (mirrors the vision gate): when every constraint-eligible
-	// provider serving this model is trait-gated — below the tools version floor
-	// or advertising a broken chat-template render — the request can never
-	// route. Without this gate it passes the trait-blind QuickCapacityCheck
-	// preflight, queues for up to 120s, and dies with a misleading capacity 429.
+	// provider serving this model is trait-gated — below the tools version floor,
+	// below the mode-specific floor (tool_choice "none" needs the v0.7.10
+	// prompt-side policy that hides declared tools), or advertising a broken
+	// chat-template render — the request can never route. Without this gate it
+	// passes the trait-blind QuickCapacityCheck preflight, queues for up to 120s,
+	// and dies with a misleading capacity 429. The traits here must match what
+	// the scheduler enforces at dispatch or the fail-fast and the queue disagree.
 	// Constrained to allowedProviderSerials so a public tool-capable provider
 	// can't satisfy an allowlist-pinned request. The inference-time constraint
 	// gate below is owner-aware so self-route checks only owned machines while
 	// prefer-owner checks both the owned pool and its public fallback.
-	if hasTools && !policy.enabled && !policy.prefer && !s.registry.HasToolCapableProviderForModel(model, allowedProviderSerials...) {
+	if hasTools && !policy.enabled && !policy.prefer &&
+		!s.registry.HasToolCapableProviderForTraits(
+			model,
+			registry.RequestTraits{HasTools: true, ToolChoiceMode: toolChoiceMode},
+			allowedProviderSerials...,
+		) {
 		writeJSON(w, http.StatusServiceUnavailable, errorResponse("model_unavailable",
 			fmt.Sprintf("no online provider for model %q supports tool calls (requires provider >= 0.6.3 with a healthy chat template) — providers may still be updating", publicModel),
 			withParam("model")))
@@ -247,15 +258,21 @@ func (s *Server) visionToolsFailFast(
 			policy.prefer,
 			allowedProviderSerials...,
 		) {
-		// Distinguish "nobody serves this model right now" (retryable capacity,
-		// 503) from "the fleet serves this model but no build of it enforces
-		// tool_choice at inference time" — the latter is a permanent per-model
-		// incapability, and dressing it as model_unavailable sends clients into
-		// a retry loop that can never succeed. Owner-scoped routing (self-route
-		// / prefer) is not expressible as a serial set here, so those paths keep
+		// Distinguish "nobody can enforce this right now" (retryable, 503) from
+		// "no build of this model will EVER enforce tool_choice" (permanent,
+		// 400). The permanent verdict requires BOTH: the fleet serves the model
+		// AND zero registered online providers even ADVERTISE the constraint
+		// capability for it. The advertisement scan deliberately ignores trust
+		// minimums and attestation freshness — a trust-lapsed or
+		// freshness-expired enforcing provider is a transient outage, not a
+		// permanent incapability, and must stay retryable — while dressing a
+		// true incapability as model_unavailable would send clients into a
+		// retry loop that can never succeed. Owner-scoped routing (self-route /
+		// prefer) is not expressible as a serial set here, so those paths keep
 		// the conservative 503.
 		if !policy.enabled && !policy.prefer &&
-			s.registry.HasProviderForModel(model, allowedProviderSerials...) {
+			s.registry.HasProviderForModel(model, allowedProviderSerials...) &&
+			!s.registry.HasProviderAdvertisingToolConstraint(model, allowedProviderSerials...) {
 			writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request_error",
 				fmt.Sprintf("inference-enforced tool_choice (required/named) is not supported for model %q", publicModel),
 				withParam("tool_choice")))

--- a/coordinator/api/inference_preprocess.go
+++ b/coordinator/api/inference_preprocess.go
@@ -247,6 +247,20 @@ func (s *Server) visionToolsFailFast(
 			policy.prefer,
 			allowedProviderSerials...,
 		) {
+		// Distinguish "nobody serves this model right now" (retryable capacity,
+		// 503) from "the fleet serves this model but no build of it enforces
+		// tool_choice at inference time" — the latter is a permanent per-model
+		// incapability, and dressing it as model_unavailable sends clients into
+		// a retry loop that can never succeed. Owner-scoped routing (self-route
+		// / prefer) is not expressible as a serial set here, so those paths keep
+		// the conservative 503.
+		if !policy.enabled && !policy.prefer &&
+			s.registry.HasProviderForModel(model, allowedProviderSerials...) {
+			writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request_error",
+				fmt.Sprintf("inference-enforced tool_choice (required/named) is not supported for model %q", publicModel),
+				withParam("tool_choice")))
+			return true
+		}
 		writeJSON(w, http.StatusServiceUnavailable, errorResponse("model_unavailable",
 			fmt.Sprintf("no online provider for model %q advertises inference-time tool_choice enforcement", publicModel),
 			withParam("model")))

--- a/coordinator/api/tool_constraint_http_test.go
+++ b/coordinator/api/tool_constraint_http_test.go
@@ -111,6 +111,7 @@ func TestPreferOwnerConstraintFailsBeforeQueueWithoutCapableFallback(t *testing.
 		false,
 		true,
 		true,
+		"required",
 		false,
 		selfRoutePolicy{prefer: true, ownerAccountID: "owner"},
 		nil,

--- a/coordinator/api/tool_constraint_http_test.go
+++ b/coordinator/api/tool_constraint_http_test.go
@@ -35,6 +35,16 @@ func TestToolConstraintValidationRunsThroughEveryHTTPShape(t *testing.T) {
 			"uses oneOf",
 		},
 		{
+			// #561: the same union that fails closed in constrained mode must
+			// clear admission under auto and be answered by routing, not by a
+			// 422 schema verdict the auto path never needed.
+			"chat auto union reaches model resolution",
+			"/v1/chat/completions",
+			`{"model":"m","messages":[{"role":"user","content":"x"}],"tools":[{"type":"function","function":{"name":"f","parameters":{"type":"object","properties":{"x":{"anyOf":[{"type":"string"},{"type":"object"}]}}}}}],"tool_choice":"auto"}`,
+			http.StatusServiceUnavailable,
+			"supports tool calls",
+		},
+		{
 			"chat constrained multimodal",
 			"/v1/chat/completions",
 			`{"model":"m","messages":[{"role":"user","content":[{"type":"text","text":"x"},{"type":"image_url","image_url":{"url":"data:image/png;base64,AA=="}}]}],"tools":[{"type":"function","function":{"name":"safe","parameters":{"type":"object"}}}],"tool_choice":"required"}`,

--- a/coordinator/api/tool_constraints.go
+++ b/coordinator/api/tool_constraints.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net/http"
 	"regexp"
-	"strings"
 )
 
 type toolChoiceMode string
@@ -31,9 +30,10 @@ var toolFunctionNamePattern = regexp.MustCompile(`^[a-zA-Z0-9_-]{1,64}$`)
 const (
 	maxConstrainedStopSequences = 4
 	maxConstrainedStopBytes     = 256
-	maxSafeAutoPatternBytes     = 128
-	maxSafeAutoPatternCount     = 32
-	maxAutoPatternDepth         = 32
+	// Recursion bound for the reserved-metadata walk. Exceeding it stops the
+	// descent without rejecting: the walk is a forgery guard, not a schema
+	// feasibility check, so a legitimately deep schema must still be accepted.
+	maxReservedMetadataDepth = 32
 )
 
 type validatedToolConstraintPolicy struct {
@@ -86,8 +86,12 @@ func validateToolConstraintPolicy(body []byte) (validatedToolConstraintPolicy, e
 			return policy, err
 		}
 	}
+	// The constrained path already sees the reserved marker through
+	// validateConstrainedSchema, which enforces its canonical form; the
+	// standalone forgery walk therefore covers exactly the modes that path
+	// skips — auto and none.
 	tools, err := validateDeclaredTools(
-		root["tools"], enforceSchema, selected, mode == toolChoiceAuto)
+		root["tools"], enforceSchema, selected, !enforceSchema)
 	if err != nil {
 		return policy, err
 	}
@@ -151,8 +155,14 @@ func validateConstrainedStops(raw any) error {
 	return nil
 }
 
+// requiresGrammar reports whether the mode needs a sampler-level grammar, and
+// therefore a provider advertising inference-time tool_choice enforcement.
+// `none` is deliberately excluded: it is honored by hiding tools from the
+// rendered prompt and rejecting any call the model emits anyway after
+// generation, so it needs no grammar and must not be fenced to the
+// Gemma-class constrained provider pool.
 func (m toolChoiceMode) requiresGrammar() bool {
-	return m == toolChoiceNone || m == toolChoiceRequired || m == toolChoiceNamed
+	return m == toolChoiceRequired || m == toolChoiceNamed
 }
 
 func parseToolChoice(raw any) (toolChoiceMode, string, error) {
@@ -215,7 +225,7 @@ func validateDeclaredTools(
 	raw any,
 	enforceSchema bool,
 	selected string,
-	validateAutoPatterns bool,
+	checkReservedMetadata bool,
 ) (map[string]map[string]any, error) {
 	if raw == nil {
 		return nil, nil
@@ -255,8 +265,8 @@ func validateDeclaredTools(
 				if _, duplicate := tools[name]; duplicate {
 					return nil, invalidToolConstraint("tool function names must be unique", "tools")
 				}
-				if validateAutoPatterns && parameters != nil {
-					if err := validateAutoSchemaPatterns(parameters, 0); err != nil {
+				if checkReservedMetadata && parameters != nil {
+					if err := rejectReservedSchemaMetadata(parameters, 0); err != nil {
 						return nil, err
 					}
 				}
@@ -282,8 +292,8 @@ func validateDeclaredTools(
 		if parameters == nil {
 			parameters = map[string]any{"type": "object"}
 		}
-		if validateAutoPatterns {
-			if err := validateAutoSchemaPatterns(parameters, 0); err != nil {
+		if checkReservedMetadata {
+			if err := rejectReservedSchemaMetadata(parameters, 0); err != nil {
 				return nil, err
 			}
 		}
@@ -304,24 +314,6 @@ func validateDeclaredTools(
 		tools[name] = function
 	}
 	return tools, nil
-}
-
-func validateAutoFiniteNumberIdentity(schema map[string]any) error {
-	var values []any
-	if constant, exists := schema["const"]; exists {
-		values = append(values, constant)
-	}
-	if enumeration, ok := schema["enum"].([]any); ok {
-		values = append(values, enumeration...)
-	}
-	for _, value := range values {
-		number, ok := value.(json.Number)
-		if ok && !constrainedJSONInteger(number) {
-			return unsupportedToolConstraint(
-				"auto numeric enum/const values require an exactly representable integer")
-		}
-	}
-	return nil
 }
 
 // representableToolSpelling mirrors the provider's
@@ -345,14 +337,27 @@ func representableToolSpelling(tool map[string]any) (name string, parameters any
 	return "", nil, false
 }
 
-func validateAutoSchemaPatterns(schema any, depth int) error {
-	if depth > maxAutoPatternDepth {
-		return unsupportedToolConstraint("auto tool schema exceeds pattern-validation depth")
+// rejectReservedSchemaMetadata walks a declared tool schema looking for the
+// coordinator's own normalization marker. NormalizeToolSchemas stamps
+// originalBooleanSchemaKey onto schemas it rewrites so the provider can
+// restore the original allow/deny-all semantics after generation; a caller
+// that plants the key itself would forge that decision. Validation runs on
+// the pre-normalization body (consumer.go's originalRawBody), so any
+// occurrence here is client-supplied and must be refused.
+//
+// This is deliberately NOT a grammar-feasibility check. Auto and none never
+// compile a sampler grammar — their tool calls are checked post-generation by
+// the provider's JSON-Schema validator, which handles anyOf/oneOf/$ref/
+// pattern/if-then natively — so every other JSON-Schema construct passes
+// through untouched.
+func rejectReservedSchemaMetadata(schema any, depth int) error {
+	if depth > maxReservedMetadataDepth {
+		return nil
 	}
 	switch value := schema.(type) {
 	case []any:
 		for _, child := range value {
-			if err := validateAutoSchemaPatterns(child, depth+1); err != nil {
+			if err := rejectReservedSchemaMetadata(child, depth+1); err != nil {
 				return err
 			}
 		}
@@ -360,115 +365,6 @@ func validateAutoSchemaPatterns(schema any, depth int) error {
 		if _, forged := value[originalBooleanSchemaKey]; forged {
 			return invalidToolConstraint(
 				"tool schema contains reserved internal metadata", "tools")
-		}
-		for _, keyword := range []string{"$ref", "$dynamicRef", "$recursiveRef"} {
-			if _, hasReference := value[keyword]; hasReference {
-				return unsupportedToolConstraint(
-					"auto tool schemas do not support schema references")
-			}
-		}
-		for _, keyword := range []string{"if", "then", "else"} {
-			if _, conditional := value[keyword]; conditional {
-				return unsupportedToolConstraint(
-					"auto tool schemas do not support conditional assertions")
-			}
-		}
-		for _, keyword := range []string{
-			"dependentSchemas", "dependentRequired", "dependencies", "propertyNames",
-			"unevaluatedItems", "unevaluatedProperties",
-		} {
-			if _, unsupported := value[keyword]; unsupported {
-				return unsupportedToolConstraint(
-					"auto tool schemas do not support dependency, property-name, or unevaluated assertions")
-			}
-		}
-		if err := validateAutoFiniteNumberIdentity(value); err != nil {
-			return err
-		}
-		// A typeless node with mixed-type const/enum values (e.g.
-		// `{"enum":["a",1]}`) or assertions spanning multiple type families
-		// (e.g. `{"minimum":5,"minLength":2}`) has no single renderable type:
-		// normalization would have to pick one and silently break the rest
-		// post-generation. Fail early instead, mirroring the multi-type
-		// union policy.
-		if _, hasType := value["type"]; !hasType {
-			if concrete, _, ok := finiteValueTypes(value); ok {
-				if len(concrete) > 1 {
-					return unsupportedToolConstraint(
-						"auto tool schemas require an explicit type for mixed-type enum/const values")
-				}
-			} else if typelessAssertionFamiliesAmbiguous(value) {
-				return unsupportedToolConstraint(
-					"auto tool schemas require an explicit type when assertions cannot determine one")
-			}
-		}
-		if rawTypes, ok := value["type"].([]any); ok {
-			concrete := make(map[string]struct{}, len(rawTypes))
-			for _, rawType := range rawTypes {
-				member, ok := rawType.(string)
-				if !ok {
-					return unsupportedToolConstraint(
-						"auto tool schema type arrays must contain strings")
-				}
-				member = strings.ToLower(member)
-				if member != "null" {
-					concrete[member] = struct{}{}
-				}
-			}
-			if len(concrete) > 1 {
-				return unsupportedToolConstraint(
-					"auto tool schemas support only one concrete type plus null")
-			}
-		}
-		for _, keyword := range []string{"anyOf", "oneOf"} {
-			variants, ok := value[keyword].([]any)
-			if !ok {
-				continue
-			}
-			concrete := make(map[string]struct{})
-			for _, rawVariant := range variants {
-				variant, ok := rawVariant.(map[string]any)
-				if !ok {
-					return unsupportedToolConstraint(
-						"auto tool schema union members must be objects")
-				}
-				members, err := autoConcreteSchemaTypes(variant["type"])
-				if err != nil {
-					return unsupportedToolConstraint(
-						"auto tool schema union members require an explicit type")
-				}
-				for member := range members {
-					concrete[member] = struct{}{}
-				}
-			}
-			if len(concrete) > 1 {
-				return unsupportedToolConstraint(
-					"auto tool schemas do not support multi-type anyOf/oneOf unions")
-			}
-		}
-		if raw, exists := value["pattern"]; exists {
-			pattern, ok := raw.(string)
-			if !ok || !safeAutoSchemaPattern(pattern) {
-				return unsupportedToolConstraint(
-					"auto tool schemas support only bounded literal pattern and patternProperties assertions")
-			}
-		}
-		if raw, exists := value["patternProperties"]; exists {
-			patterns, ok := raw.(map[string]any)
-			if !ok {
-				return unsupportedToolConstraint(
-					"auto tool schema patternProperties must be an object")
-			}
-			if len(patterns) > maxSafeAutoPatternCount {
-				return unsupportedToolConstraint(
-					"auto tool schema has too many patternProperties assertions")
-			}
-			for pattern := range patterns {
-				if !safeAutoSchemaPattern(pattern) {
-					return unsupportedToolConstraint(
-						"auto tool schemas support only bounded literal pattern and patternProperties assertions")
-				}
-			}
 		}
 		for _, key := range []string{
 			"additionalProperties", "additionalItems", "contains", "contentSchema",
@@ -479,7 +375,7 @@ func validateAutoSchemaPatterns(schema any, depth int) error {
 			if !exists {
 				continue
 			}
-			if err := validateAutoSchemaPatterns(child, depth+1); err != nil {
+			if err := rejectReservedSchemaMetadata(child, depth+1); err != nil {
 				return err
 			}
 		}
@@ -489,22 +385,23 @@ func validateAutoSchemaPatterns(schema any, depth int) error {
 				continue
 			}
 			for _, child := range children {
-				if err := validateAutoSchemaPatterns(child, depth+1); err != nil {
+				if err := rejectReservedSchemaMetadata(child, depth+1); err != nil {
 					return err
 				}
 			}
 		}
+		// `items` is a schema in draft 2020-12 and a tuple in draft-07. The
+		// tuple array is a container, not a schema node, so it must not
+		// consume a level of the depth budget the way a nested schema does.
 		if items, exists := value["items"]; exists {
 			if tuple, ok := items.([]any); ok {
 				for _, child := range tuple {
-					if err := validateAutoSchemaPatterns(child, depth+1); err != nil {
+					if err := rejectReservedSchemaMetadata(child, depth+1); err != nil {
 						return err
 					}
 				}
-			} else {
-				if err := validateAutoSchemaPatterns(items, depth+1); err != nil {
-					return err
-				}
+			} else if err := rejectReservedSchemaMetadata(items, depth+1); err != nil {
+				return err
 			}
 		}
 		for _, key := range []string{
@@ -516,46 +413,13 @@ func validateAutoSchemaPatterns(schema any, depth int) error {
 				continue
 			}
 			for _, child := range children {
-				if err := validateAutoSchemaPatterns(child, depth+1); err != nil {
+				if err := rejectReservedSchemaMetadata(child, depth+1); err != nil {
 					return err
 				}
 			}
 		}
 	}
 	return nil
-}
-
-func autoConcreteSchemaTypes(raw any) (map[string]struct{}, error) {
-	concrete := make(map[string]struct{})
-	switch value := raw.(type) {
-	case string:
-		if member := strings.ToLower(value); member != "null" {
-			concrete[member] = struct{}{}
-		}
-	case []any:
-		for _, rawMember := range value {
-			member, ok := rawMember.(string)
-			if !ok {
-				return nil, fmt.Errorf("schema type member is not a string")
-			}
-			if member = strings.ToLower(member); member != "null" {
-				concrete[member] = struct{}{}
-			}
-		}
-	default:
-		return nil, fmt.Errorf("schema type is missing")
-	}
-	return concrete, nil
-}
-
-func safeAutoSchemaPattern(pattern string) bool {
-	if len([]byte(pattern)) > maxSafeAutoPatternBytes {
-		return false
-	}
-	literal := pattern
-	literal = strings.TrimPrefix(literal, "^")
-	literal = strings.TrimSuffix(literal, "$")
-	return !strings.ContainsAny(literal, `\.^$|?*+()[]{}`)
 }
 
 func invalidToolConstraint(message, param string) error {

--- a/coordinator/api/tool_constraints.go
+++ b/coordinator/api/tool_constraints.go
@@ -345,8 +345,9 @@ func representableToolSpelling(tool map[string]any) (name string, parameters any
 // compile a sampler grammar — their tool calls are checked post-generation by
 // the provider's JSON-Schema validator, which enforces allOf/anyOf/oneOf/not/
 // enum/const/pattern/patternProperties/if-then-else/dependentRequired/
-// dependentSchemas/propertyNames and treats $ref nodes and the unevaluated*
-// assertions as not-asserted — so every other JSON-Schema construct passes
+// dependentSchemas/propertyNames. Unresolvable ($ref) and annotation-dependent
+// (unevaluated*) assertions are not-asserted — though author-written siblings
+// beside a $ref stay enforced — so every other JSON-Schema construct passes
 // through untouched.
 //
 // Depth bound: the walk must scan at least as deep as every walker that can

--- a/coordinator/api/tool_constraints.go
+++ b/coordinator/api/tool_constraints.go
@@ -30,10 +30,6 @@ var toolFunctionNamePattern = regexp.MustCompile(`^[a-zA-Z0-9_-]{1,64}$`)
 const (
 	maxConstrainedStopSequences = 4
 	maxConstrainedStopBytes     = 256
-	// Recursion bound for the reserved-metadata walk. Exceeding it stops the
-	// descent without rejecting: the walk is a forgery guard, not a schema
-	// feasibility check, so a legitimately deep schema must still be accepted.
-	maxReservedMetadataDepth = 32
 )
 
 type validatedToolConstraintPolicy struct {
@@ -347,12 +343,27 @@ func representableToolSpelling(tool map[string]any) (name string, parameters any
 //
 // This is deliberately NOT a grammar-feasibility check. Auto and none never
 // compile a sampler grammar — their tool calls are checked post-generation by
-// the provider's JSON-Schema validator, which handles anyOf/oneOf/$ref/
-// pattern/if-then natively — so every other JSON-Schema construct passes
+// the provider's JSON-Schema validator, which enforces allOf/anyOf/oneOf/not/
+// enum/const/pattern/patternProperties/if-then-else/dependentRequired/
+// dependentSchemas/propertyNames and treats $ref nodes and the unevaluated*
+// assertions as not-asserted — so every other JSON-Schema construct passes
 // through untouched.
+//
+// Depth bound: the walk must scan at least as deep as every walker that can
+// LIFT a marker upward. NormalizeToolSchemas descends to maxToolSchemaDepth
+// and constantMarkedCombinator folds marker-only combinator nodes toward the
+// root, so a forged marker below the scan horizon could otherwise surface as
+// shallow, coordinator-vouched metadata — and the provider trusts vouched
+// bodies (its own byte-scan only guards unvouched ones). A schema deeper than
+// the horizon therefore cannot be vouched marker-free and is rejected: the
+// bound fails CLOSED, and it is maxToolSchemaDepth itself so the two walks
+// can never drift. Schemas past that depth do not occur in practice (the
+// pre-#603 scan rejected everything past depth 32 and no legitimate traffic
+// ever hit it).
 func rejectReservedSchemaMetadata(schema any, depth int) error {
-	if depth > maxReservedMetadataDepth {
-		return nil
+	if depth > maxToolSchemaDepth {
+		return invalidToolConstraint(
+			"tool schema exceeds the reserved-metadata scan depth", "tools")
 	}
 	switch value := schema.(type) {
 	case []any:

--- a/coordinator/api/tool_constraints_test.go
+++ b/coordinator/api/tool_constraints_test.go
@@ -637,14 +637,18 @@ func TestReservedMetadataWalkDoesNotChargeDepthForTupleContainers(t *testing.T) 
 	}
 }
 
-// Running out of depth budget is an UNDECIDABLE result, not a violation: the
-// walk only ever asserts "a reserved marker was found here". A schema too deep
-// to finish walking (or a malformed nest of bare arrays) must still be
-// forwarded — this is exactly the class of pre-flight guess that broke #561.
-func TestReservedMetadataWalkForwardsSchemasDeeperThanItsBudget(t *testing.T) {
-	var items any = map[string]any{"type": "string", "pattern": "^city$"}
+// A forged reserved marker used to hide below the old depth-32 scan horizon:
+// NormalizeToolSchemas walks to maxToolSchemaDepth and
+// constantMarkedCombinator folds marker-only combinators toward the root, so
+// a marker planted at depth 33-63 escaped the fail-open guard and could then
+// surface as shallow, coordinator-vouched metadata the provider trusts. The
+// guard now scans the normalizer's full budget and must catch it.
+func TestReservedMetadataGuardScansToNormalizerDepth(t *testing.T) {
+	var node any = map[string]any{
+		"type": "string", originalBooleanSchemaKey: true,
+	}
 	for range 40 {
-		items = []any{items}
+		node = map[string]any{"anyOf": []any{node}}
 	}
 	body, err := json.Marshal(map[string]any{
 		"model":    "m",
@@ -652,10 +656,8 @@ func TestReservedMetadataWalkForwardsSchemasDeeperThanItsBudget(t *testing.T) {
 		"tools": []any{map[string]any{
 			"type": "function",
 			"function": map[string]any{
-				"name": "lookup",
-				"parameters": map[string]any{
-					"type": "array", "items": items,
-				},
+				"name":       "lookup",
+				"parameters": node,
 			},
 		}},
 		"tool_choice": "auto",
@@ -663,8 +665,56 @@ func TestReservedMetadataWalkForwardsSchemasDeeperThanItsBudget(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := validateToolConstraintRequest(body); err != nil {
-		t.Fatalf("schema beyond the walk's depth bound was rejected: %v", err)
+	_, verr := validateToolConstraintRequest(body)
+	var typed *toolConstraintRequestError
+	if !errors.As(verr, &typed) || typed.status != http.StatusBadRequest ||
+		!strings.Contains(typed.message, "reserved internal metadata") {
+		t.Fatalf("forged marker below the old scan horizon escaped: %T %v", verr, verr)
+	}
+}
+
+// The depth bound fails CLOSED: a schema too deep to finish scanning cannot
+// be vouched marker-free (the normalizer walks exactly as deep and folds
+// marker-only combinators upward from anywhere it reaches), so it is rejected
+// rather than forwarded. Clean schemas within the normalizer's budget still
+// pass untouched.
+func TestReservedMetadataWalkRejectsSchemasDeeperThanNormalizerBudget(t *testing.T) {
+	nest := func(levels int) any {
+		var node any = map[string]any{"type": "string", "pattern": "^city$"}
+		for range levels {
+			node = map[string]any{"anyOf": []any{node}}
+		}
+		return node
+	}
+	body := func(parameters any) []byte {
+		encoded, err := json.Marshal(map[string]any{
+			"model":    "m",
+			"messages": []any{map[string]any{"role": "user", "content": "x"}},
+			"tools": []any{map[string]any{
+				"type": "function",
+				"function": map[string]any{
+					"name":       "lookup",
+					"parameters": parameters,
+				},
+			}},
+			"tool_choice": "auto",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return encoded
+	}
+	// Leaf at depth maxToolSchemaDepth — the deepest node the scan still
+	// covers. Clean, so forwarded.
+	if _, err := validateToolConstraintRequest(body(nest(maxToolSchemaDepth))); err != nil {
+		t.Fatalf("clean schema within the scan depth was rejected: %v", err)
+	}
+	// Past the budget: undecidable, therefore rejected (400), never vouched.
+	_, err := validateToolConstraintRequest(body(nest(maxToolSchemaDepth + 6)))
+	var typed *toolConstraintRequestError
+	if !errors.As(err, &typed) || typed.status != http.StatusBadRequest ||
+		!strings.Contains(typed.message, "reserved-metadata scan depth") {
+		t.Fatalf("schema beyond the scan depth was not rejected: %T %v", err, err)
 	}
 }
 

--- a/coordinator/api/tool_constraints_test.go
+++ b/coordinator/api/tool_constraints_test.go
@@ -256,8 +256,12 @@ func TestNamedToolChoiceValidatesOnlySelectedSchema(t *testing.T) {
 	}
 }
 
-func TestAutoToolChoiceRejectsUnsupportedRegexBeforeDispatch(t *testing.T) {
-	body := func(pattern string) []byte {
+// Auto never compiles a sampler grammar: its tool calls are checked after
+// generation by a validator that implements `pattern` natively. Any regex the
+// caller writes must therefore forward untouched. Only the grammar-compiled
+// modes fail closed on it.
+func TestAutoToolChoiceForwardsArbitraryRegexPatterns(t *testing.T) {
+	body := func(choice, pattern string) []byte {
 		return []byte(fmt.Sprintf(`{
 			"model":"m",
 			"messages":[{"role":"user","content":"x"}],
@@ -267,33 +271,48 @@ func TestAutoToolChoiceRejectsUnsupportedRegexBeforeDispatch(t *testing.T) {
 					"code":{"type":"string","pattern":%q}
 				}}
 			}}],
-			"tool_choice":"auto"
-		}`, pattern))
+			"tool_choice":%q
+		}`, pattern, choice))
 	}
-	if _, err := validateToolConstraintRequest(body("^city$")); err != nil {
-		t.Fatalf("bounded literal pattern rejected: %v", err)
+	for _, pattern := range []string{"^city$", "^[a-z]+$", `^[a-f0-9]{8}$`, `\d{3}-\d{4}`} {
+		if _, err := validateToolConstraintRequest(body("auto", pattern)); err != nil {
+			t.Fatalf("auto rejected regex %q: %v", pattern, err)
+		}
 	}
-	_, err := validateToolConstraintRequest(body("^[a-z]+$"))
+	_, err := validateToolConstraintRequest(body("required", "^[a-z]+$"))
 	var typed *toolConstraintRequestError
 	if !errors.As(err, &typed) || typed.status != http.StatusUnprocessableEntity {
-		t.Fatalf("unsupported regex was not rejected before dispatch: %T %v", err, err)
+		t.Fatalf("constrained mode accepted an uncompilable regex: %T %v", err, err)
 	}
 }
 
-func TestAutoPatternValidationDistinguishesSchemaKeywordsFromPropertyNames(t *testing.T) {
-	body := []byte(`{
-		"model":"m",
-		"messages":[{"role":"user","content":"x"}],
-		"tools":[{"type":"function","function":{
-			"name":"lookup",
-			"parameters":{"type":"object","properties":{
-				"pattern":{"type":"string","pattern":"^city$"}
-			}}
-		}}],
-		"tool_choice":"auto"
-	}`)
-	if _, err := validateToolConstraintRequest(body); err != nil {
-		t.Fatalf("property named pattern was treated as a schema keyword: %v", err)
+// The reserved-metadata walk descends schema *keyword* containers. A property
+// literally named after a keyword lives under `properties` and is a schema in
+// its own right — it must be traversed as one, and its name must never make
+// the parent look like it carries that keyword.
+func TestReservedMetadataWalkDistinguishesSchemaKeywordsFromPropertyNames(t *testing.T) {
+	body := func(inner string) []byte {
+		return []byte(fmt.Sprintf(`{
+			"model":"m",
+			"messages":[{"role":"user","content":"x"}],
+			"tools":[{"type":"function","function":{
+				"name":"lookup",
+				"parameters":{"type":"object","properties":{
+					"pattern":{"type":"string"},
+					"if":{"type":"object","properties":{"x":%s}}
+				}}
+			}}],
+			"tool_choice":"auto"
+		}`, inner))
+	}
+	if _, err := validateToolConstraintRequest(body(`{"type":"string"}`)); err != nil {
+		t.Fatalf("properties named after schema keywords rejected: %v", err)
+	}
+	forged := body(`{"type":"string","x-darkbloom-original-boolean-schema":true}`)
+	_, err := validateToolConstraintRequest(forged)
+	var typed *toolConstraintRequestError
+	if !errors.As(err, &typed) || typed.status != http.StatusBadRequest {
+		t.Fatalf("forged marker under a keyword-named property escaped: %T %v", err, err)
 	}
 }
 
@@ -319,7 +338,10 @@ func TestAutoToolChoiceRejectsForgedBooleanSchemaMetadata(t *testing.T) {
 	}
 }
 
-func TestAutoToolChoiceRejectsUnsupportedSemanticSchemasBeforeDispatch(t *testing.T) {
+// Every construct here is decidable by the post-generation JSON-Schema
+// validator that auto and none actually use, so the pre-flight must forward
+// them verbatim instead of guessing at grammar feasibility it never needs.
+func TestAutoToolChoiceAcceptsStandardJSONSchemaConstructs(t *testing.T) {
 	schemas := map[string]any{
 		"multi-type union": map[string]any{
 			"type": []any{"string", "integer"},
@@ -395,32 +417,31 @@ func TestAutoToolChoiceRejectsUnsupportedSemanticSchemasBeforeDispatch(t *testin
 		},
 	}
 	for name, propertySchema := range schemas {
-		t.Run(name, func(t *testing.T) {
-			body, err := json.Marshal(map[string]any{
-				"model":    "m",
-				"messages": []any{map[string]any{"role": "user", "content": "x"}},
-				"tools": []any{map[string]any{
-					"type": "function",
-					"function": map[string]any{
-						"name": "lookup",
-						"parameters": map[string]any{
-							"type":       "object",
-							"properties": map[string]any{"value": propertySchema},
+		for _, choice := range []string{"auto", "none"} {
+			t.Run(name+"/"+choice, func(t *testing.T) {
+				body, err := json.Marshal(map[string]any{
+					"model":    "m",
+					"messages": []any{map[string]any{"role": "user", "content": "x"}},
+					"tools": []any{map[string]any{
+						"type": "function",
+						"function": map[string]any{
+							"name": "lookup",
+							"parameters": map[string]any{
+								"type":       "object",
+								"properties": map[string]any{"value": propertySchema},
+							},
 						},
-					},
-				}},
-				"tool_choice": "auto",
+					}},
+					"tool_choice": choice,
+				})
+				if err != nil {
+					t.Fatal(err)
+				}
+				if _, err := validateToolConstraintRequest(body); err != nil {
+					t.Fatalf("standard JSON-Schema construct rejected: %v", err)
+				}
 			})
-			if err != nil {
-				t.Fatal(err)
-			}
-			_, validationErr := validateToolConstraintRequest(body)
-			var typed *toolConstraintRequestError
-			if !errors.As(validationErr, &typed) ||
-				typed.status != http.StatusUnprocessableEntity {
-				t.Fatalf("unsupported auto schema accepted: %T %v", validationErr, validationErr)
-			}
-		})
+		}
 	}
 }
 
@@ -483,10 +504,12 @@ func TestAutoToolChoiceValidatesRepresentableAlternateSpellings(t *testing.T) {
 		"bad top-level name": `{"name":"bad name","parameters":{"type":"object"}}`,
 		"duplicate across spellings": `{"name":"lookup","parameters":{"type":"object"}},
 			{"type":"function","function":{"name":"lookup"}}`,
-		"ref in top-level parameters": `{"name":"probe","parameters":{
-			"type":"object","properties":{"v":{"$ref":"#/$defs/x"}}}}`,
-		"ref in custom input_schema": `{"type":"custom","name":"probe","input_schema":{
-			"type":"object","properties":{"v":{"$ref":"#/$defs/x"}}}}`,
+		"forged marker in top-level parameters": `{"name":"probe","parameters":{
+			"type":"object","properties":{"v":{"type":"string",
+			"x-darkbloom-original-boolean-schema":true}}}}`,
+		"forged marker in custom input_schema": `{"type":"custom","name":"probe","input_schema":{
+			"type":"object","properties":{"v":{"type":"string",
+			"x-darkbloom-original-boolean-schema":true}}}}`,
 	}
 	for name, entry := range rejected {
 		t.Run(name, func(t *testing.T) {
@@ -506,8 +529,10 @@ func TestAutoToolChoiceValidatesRepresentableAlternateSpellings(t *testing.T) {
 		"model":"m",
 		"messages":[{"role":"user","content":"x"}],
 		"tools":[
-			{"name":"flat_spelling","parameters":{"type":"object"}},
-			{"type":"custom","name":"anthropic_spelling","input_schema":{"type":"object"}}
+			{"name":"flat_spelling","parameters":{"type":"object",
+				"$defs":{"P":{"type":"string"}},"properties":{"p":{"$ref":"#/$defs/P"}}}},
+			{"type":"custom","name":"anthropic_spelling","input_schema":{
+				"type":"object","properties":{"v":{"anyOf":[{"type":"string"},{"type":"integer"}]}}}}
 		],
 		"tool_choice":"auto"
 	}`)
@@ -568,38 +593,55 @@ func TestAutoToolChoiceAcceptsSupportedDecimalMultipleSchemas(t *testing.T) {
 	}
 }
 
-func TestAutoPatternValidationDoesNotDoubleCountTupleContainers(t *testing.T) {
-	var item any = map[string]any{"type": "string", "pattern": "^city$"}
-	for range 17 {
-		item = map[string]any{
-			"type":  "array",
-			"items": []any{item},
+// A draft-07 tuple `items` array is a container, not a schema node. Charging
+// it a level would halve the reachable depth and let a forged marker hide one
+// nest deeper than the budget suggests.
+func TestReservedMetadataWalkDoesNotChargeDepthForTupleContainers(t *testing.T) {
+	nest := func(leaf any, levels int) any {
+		item := leaf
+		for range levels {
+			item = map[string]any{"type": "array", "items": []any{item}}
 		}
+		return item
 	}
-	body, err := json.Marshal(map[string]any{
-		"model":    "m",
-		"messages": []any{map[string]any{"role": "user", "content": "x"}},
-		"tools": []any{map[string]any{
-			"type": "function",
-			"function": map[string]any{
-				"name": "lookup",
-				"parameters": map[string]any{
-					"type":       "object",
-					"properties": map[string]any{"value": item},
+	body := func(leaf any) []byte {
+		encoded, err := json.Marshal(map[string]any{
+			"model":    "m",
+			"messages": []any{map[string]any{"role": "user", "content": "x"}},
+			"tools": []any{map[string]any{
+				"type": "function",
+				"function": map[string]any{
+					"name": "lookup",
+					"parameters": map[string]any{
+						"type":       "object",
+						"properties": map[string]any{"value": nest(leaf, 17)},
+					},
 				},
-			},
-		}},
-		"tool_choice": "auto",
-	})
-	if err != nil {
-		t.Fatal(err)
+			}},
+			"tool_choice": "auto",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return encoded
 	}
-	if _, err := validateToolConstraintRequest(body); err != nil {
-		t.Fatalf("tuple schema containers consumed pattern depth: %v", err)
+	clean := map[string]any{"type": "string", "pattern": "^city$"}
+	if _, err := validateToolConstraintRequest(body(clean)); err != nil {
+		t.Fatalf("deep tuple schema rejected: %v", err)
+	}
+	forged := map[string]any{"type": "string", originalBooleanSchemaKey: true}
+	_, err := validateToolConstraintRequest(body(forged))
+	var typed *toolConstraintRequestError
+	if !errors.As(err, &typed) || typed.status != http.StatusBadRequest {
+		t.Fatalf("tuple containers consumed the metadata walk's depth: %T %v", err, err)
 	}
 }
 
-func TestAutoPatternValidationBoundsMalformedNestedTupleArrays(t *testing.T) {
+// Running out of depth budget is an UNDECIDABLE result, not a violation: the
+// walk only ever asserts "a reserved marker was found here". A schema too deep
+// to finish walking (or a malformed nest of bare arrays) must still be
+// forwarded — this is exactly the class of pre-flight guess that broke #561.
+func TestReservedMetadataWalkForwardsSchemasDeeperThanItsBudget(t *testing.T) {
 	var items any = map[string]any{"type": "string", "pattern": "^city$"}
 	for range 40 {
 		items = []any{items}
@@ -621,8 +663,8 @@ func TestAutoPatternValidationBoundsMalformedNestedTupleArrays(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := validateToolConstraintRequest(body); err == nil {
-		t.Fatal("malformed nested tuple arrays bypassed pattern depth bound")
+	if _, err := validateToolConstraintRequest(body); err != nil {
+		t.Fatalf("schema beyond the walk's depth bound was rejected: %v", err)
 	}
 }
 
@@ -750,23 +792,31 @@ func TestValidateToolConstraintRequestAcceptsMathematicalIntegerFiniteValues(t *
 	}
 }
 
-func TestValidateToolConstraintRequestRejectsInexactAutoFiniteValues(t *testing.T) {
-	body := []byte(`{
-		"model":"m",
-		"messages":[{"role":"user","content":"x"}],
-		"tools":[{"type":"function","function":{
-			"name":"calculate",
-			"parameters":{"type":"object","properties":{
-				"value":{"type":"number","enum":[0.10000000000000001]}
-			}}
-		}}],
-		"tool_choice":"auto"
-	}`)
-	_, err := validateToolConstraintRequest(body)
+// Exact float representability only matters when the value has to survive a
+// round trip through the provider's grammar compiler. Auto never builds one,
+// so the literal forwards verbatim; only the constrained modes fail closed.
+func TestInexactFiniteValuesFailOnlyInConstrainedModes(t *testing.T) {
+	body := func(choice string) []byte {
+		return []byte(fmt.Sprintf(`{
+			"model":"m",
+			"messages":[{"role":"user","content":"x"}],
+			"tools":[{"type":"function","function":{
+				"name":"calculate",
+				"parameters":{"type":"object","properties":{
+					"value":{"type":"number","enum":[0.10000000000000001]}
+				}}
+			}}],
+			"tool_choice":%q
+		}`, choice))
+	}
+	if _, err := validateToolConstraintRequest(body("auto")); err != nil {
+		t.Fatalf("auto rejected an inexact finite value: %v", err)
+	}
+	_, err := validateToolConstraintRequest(body("required"))
 	var typed *toolConstraintRequestError
 	if !errors.As(err, &typed) ||
 		typed.status != http.StatusUnprocessableEntity {
-		t.Fatalf("inexact auto finite value accepted: %T %v", err, err)
+		t.Fatalf("constrained mode accepted an inexact finite value: %T %v", err, err)
 	}
 }
 

--- a/coordinator/api/toolschema.go
+++ b/coordinator/api/toolschema.go
@@ -358,6 +358,28 @@ func injectDefaultTypesIntoSchema(dict map[string]any, depth int, changed *bool,
 					dict["nullable"] = true
 				}
 			}
+			// A multi-concrete array (`["string","integer"]`) declares a real
+			// union the single render type cannot carry: the render pipeline
+			// needs one `value['type'] | upper` string, but the provider's
+			// post-generation validator enforces what is on the wire, so
+			// keeping only the first member would reject schema-valid
+			// emissions of every other branch. JSON Schema defines the array
+			// form as exactly an anyOf of its single types, so the surviving
+			// concrete members are mirrored into `anyOf` — that survives the
+			// wire, and the validator prefers union branches over the sibling
+			// render type. A node that already carries a combinator keeps the
+			// conjunctive semantics its author wrote (layering a second union
+			// would change them); that pathological shape stays knowingly
+			// narrowed to the first member. Mirrors: null member → `nullable`
+			// (above), concrete members → `anyOf` (here).
+			if concrete := distinctConcreteTypeMembers(members); len(concrete) >= 2 &&
+				!hasSchemaUnionKey(dict) {
+				union := make([]any, len(concrete))
+				for i, m := range concrete {
+					union[i] = map[string]any{"type": m}
+				}
+				dict["anyOf"] = union
+			}
 			dict["type"] = collapsedType(members, dict)
 			*changed = true
 		}
@@ -554,6 +576,30 @@ func typeStringMembers(t any) []string {
 		}
 	}
 	return members
+}
+
+// distinctConcreteTypeMembers returns the distinct non-"null" members of an
+// array-form `type` in first-appearance order. Members arrive lowercased from
+// typeStringMembers, so distinctness is case-insensitive by construction.
+func distinctConcreteTypeMembers(members []string) []string {
+	concrete := make([]string, 0, len(members))
+	for _, m := range members {
+		if m != "null" && !slices.Contains(concrete, m) {
+			concrete = append(concrete, m)
+		}
+	}
+	return concrete
+}
+
+// hasSchemaUnionKey reports whether the node carries any combinator key
+// (anyOf/oneOf/allOf), regardless of the value's shape.
+func hasSchemaUnionKey(dict map[string]any) bool {
+	for _, key := range schemaUnionKeys {
+		if _, ok := dict[key]; ok {
+			return true
+		}
+	}
+	return false
 }
 
 // collapsedType collapses a non-string `type` value (pre-extracted string

--- a/coordinator/api/toolschema_nullable_test.go
+++ b/coordinator/api/toolschema_nullable_test.go
@@ -20,6 +20,11 @@ func TestNormalizeToolSchemas_CollapsesNullableArrayTypeToConcreteMember(t *test
 	if city["nullable"] != true {
 		t.Errorf("city nullable = %v, want true", city["nullable"])
 	}
+	// The nullable pair has ONE concrete member — no union to preserve, so no
+	// anyOf is synthesized (the parity corpus pins this byte shape).
+	if _, ok := city["anyOf"]; ok {
+		t.Errorf("city anyOf = %v, want absent for single-concrete pair", city["anyOf"])
+	}
 	if req, ok := tsnParams(t, out)["required"].([]any); !ok || len(req) != 1 || req[0] != "city" {
 		t.Errorf("required = %v, want [city]", tsnParams(t, out)["required"])
 	}
@@ -219,5 +224,103 @@ func TestNormalizeToolSchemas_PreservesBooleanSchemaSemantics(t *testing.T) {
 		if got, ok := schema[originalBooleanSchemaKey].(bool); !ok || got != want {
 			t.Fatalf("%s marker = %#v, want %v", name, schema[originalBooleanSchemaKey], want)
 		}
+	}
+}
+
+// tsnAnyOfTypes asserts the node's anyOf is a list of bare {"type": ...}
+// members and returns the member types in order.
+func tsnAnyOfTypes(t *testing.T, node map[string]any, what string) []string {
+	t.Helper()
+	variants, ok := node["anyOf"].([]any)
+	if !ok {
+		t.Fatalf("%s anyOf = %#v, want array", what, node["anyOf"])
+	}
+	types := make([]string, 0, len(variants))
+	for i, v := range variants {
+		member := tsnMap(t, v, what+".anyOf member")
+		if len(member) != 1 {
+			t.Fatalf("%s anyOf[%d] = %v, want bare type-only schema", what, i, member)
+		}
+		types = append(types, tsnType(t, member, what+".anyOf member"))
+	}
+	return types
+}
+
+// Swift: multiConcreteTypeArrayPreservedViaAnyOf
+func TestNormalizeToolSchemas_MultiConcreteTypeArrayPreservedViaAnyOf(t *testing.T) {
+	body := []byte(`{"tools":[{"type":"function","function":{"name":"f",
+	  "parameters":{"type":"object","properties":{
+	    "id":{"type":["string","integer"]}}}}}]}`)
+
+	id := tsnMap(t, tsnProps(t, NormalizeToolSchemas(body))["id"], "id")
+	if got := tsnType(t, id, "id"); got != "string" {
+		t.Errorf("id type = %q, want first concrete member string", got)
+	}
+	if got := tsnAnyOfTypes(t, id, "id"); len(got) != 2 || got[0] != "string" || got[1] != "integer" {
+		t.Errorf("id anyOf types = %v, want [string integer]", got)
+	}
+	if _, ok := id["nullable"]; ok {
+		t.Errorf("id nullable = %v, want absent without a null member", id["nullable"])
+	}
+}
+
+// Swift: multiConcreteNullableTypeArrayKeepsNullAndUnion
+func TestNormalizeToolSchemas_MultiConcreteNullableTypeArrayKeepsNullAndUnion(t *testing.T) {
+	body := []byte(`{"tools":[{"type":"function","function":{"name":"f",
+	  "parameters":{"type":"object","properties":{
+	    "id":{"type":["integer","string","null"]}}}}}]}`)
+
+	id := tsnMap(t, tsnProps(t, NormalizeToolSchemas(body))["id"], "id")
+	if got := tsnType(t, id, "id"); got != "integer" {
+		t.Errorf("id type = %q, want first concrete member integer", got)
+	}
+	if id["nullable"] != true {
+		t.Errorf("id nullable = %v, want true", id["nullable"])
+	}
+	// The null member rides the nullable side-channel, never the union.
+	if got := tsnAnyOfTypes(t, id, "id"); len(got) != 2 || got[0] != "integer" || got[1] != "string" {
+		t.Errorf("id anyOf types = %v, want [integer string]", got)
+	}
+}
+
+// Swift: multiConcreteTypeArrayWithExistingCombinatorCollapsesOnly
+func TestNormalizeToolSchemas_MultiConcreteTypeArrayWithExistingCombinatorCollapsesOnly(t *testing.T) {
+	body := []byte(`{"tools":[{"type":"function","function":{"name":"f",
+	  "parameters":{"type":"object","properties":{
+	    "v":{"type":["string","integer"],"anyOf":[{"minLength":1}]},
+	    "w":{"type":["string","integer"],"allOf":[{"minLength":1}]}}}}}]}`)
+
+	props := tsnProps(t, NormalizeToolSchemas(body))
+	v := tsnMap(t, props["v"], "v")
+	if got := tsnType(t, v, "v"); got != "string" {
+		t.Errorf("v type = %q, want string", got)
+	}
+	// The author's combinator keeps its written semantics: no second union is
+	// layered on, and the existing member survives (type-injected only).
+	variants, ok := v["anyOf"].([]any)
+	if !ok || len(variants) != 1 {
+		t.Fatalf("v anyOf = %#v, want the single authored member", v["anyOf"])
+	}
+	if member := tsnMap(t, variants[0], "v.anyOf[0]"); member["minLength"] == nil {
+		t.Errorf("v anyOf[0] = %v, want the authored minLength member", member)
+	}
+	w := tsnMap(t, props["w"], "w")
+	if _, ok := w["anyOf"]; ok {
+		t.Errorf("w anyOf = %v, want absent beside authored allOf", w["anyOf"])
+	}
+}
+
+// Swift: duplicateTypeMembersDedupedCaseInsensitively
+func TestNormalizeToolSchemas_DuplicateTypeMembersDedupedCaseInsensitively(t *testing.T) {
+	body := []byte(`{"tools":[{"type":"function","function":{"name":"f",
+	  "parameters":{"type":"object","properties":{
+	    "id":{"type":["string","STRING","integer"]}}}}}]}`)
+
+	id := tsnMap(t, tsnProps(t, NormalizeToolSchemas(body))["id"], "id")
+	if got := tsnType(t, id, "id"); got != "string" {
+		t.Errorf("id type = %q, want string", got)
+	}
+	if got := tsnAnyOfTypes(t, id, "id"); len(got) != 2 || got[0] != "string" || got[1] != "integer" {
+		t.Errorf("id anyOf types = %v, want deduped [string integer]", got)
 	}
 }

--- a/coordinator/api/toolschema_shapes_test.go
+++ b/coordinator/api/toolschema_shapes_test.go
@@ -251,7 +251,8 @@ func TestNormalizeToolSchemas_NullSchemasPreservedAcrossShapes(t *testing.T) {
 func TestNormalizeToolSchemas_AllShapesIdempotentAndNumbersSurvive(t *testing.T) {
 	body := []byte(`{"model":"m","max_tokens":9007199254740993,"tools":[` +
 		`{"type":"function","function":{"name":"chat","parameters":` +
-		`{"properties":{"a":{"type":["integer","null"],"default":9007199254740993}}}}},` +
+		`{"properties":{"a":{"type":["integer","null"],"default":9007199254740993},` +
+		`"u":{"type":["string","integer","null"]}}}}},` +
 		`{"type":"function","name":"flat","parameters":` +
 		`{"properties":{"b":{"enum":["x"],"default":0.30000000000000004}}}},` +
 		`{"name":"anthropic","input_schema":` +
@@ -280,6 +281,16 @@ func TestNormalizeToolSchemas_AllShapesIdempotentAndNumbersSurvive(t *testing.T)
 	a := tsnMap(t, tsnMap(t, tsnMap(t, tsnMap(t, tsnMap(t, tools[0], "tools[0]")["function"], "function")["parameters"], "chat parameters")["properties"], "chat properties")["a"], "a")
 	if got := tsnType(t, a, "a"); got != "integer" || a["nullable"] != true {
 		t.Errorf("chat a = type %q nullable %v, want integer/true", got, a["nullable"])
+	}
+	// The multi-concrete union is preserved via anyOf AND survives the second
+	// pass unchanged (the injected members are already normal-form, and the
+	// node now carries a type string plus an anyOf, so no rewrite re-fires).
+	u := tsnMap(t, tsnMap(t, tsnMap(t, tsnMap(t, tsnMap(t, tools[0], "tools[0]")["function"], "function")["parameters"], "chat parameters")["properties"], "chat properties")["u"], "u")
+	if got := tsnType(t, u, "u"); got != "string" || u["nullable"] != true {
+		t.Errorf("chat u = type %q nullable %v, want string/true", got, u["nullable"])
+	}
+	if got := tsnAnyOfTypes(t, u, "u"); len(got) != 2 || got[0] != "string" || got[1] != "integer" {
+		t.Errorf("chat u anyOf types = %v, want [string integer]", got)
 	}
 	b := tsnMap(t, tsnMap(t, tsnMap(t, tsnMap(t, tools[1], "tools[1]")["parameters"], "flat parameters")["properties"], "flat properties")["b"], "b")
 	if got := tsnType(t, b, "b"); got != "string" {

--- a/coordinator/promptsidecar/src/normalize.rs
+++ b/coordinator/promptsidecar/src/normalize.rs
@@ -35,7 +35,6 @@ pub fn normalize(
         .ok_or(NormalizeError::MissingModel)?
         .to_owned();
 
-    validate_raw_auto_tool_schemas(&body)?;
     normalize_tool_parameter_types(&mut body);
     normalize_legacy_function_calls(&mut body)?;
     let mut messages = template_messages(&body)?;
@@ -270,25 +269,6 @@ fn validate_function_definition(
         Some(_) => return Err(NormalizeError::InvalidTools),
     }
     Ok(function.clone())
-}
-
-fn validate_raw_auto_tool_schemas(body: &Map<String, Value>) -> Result<(), NormalizeError> {
-    let choice = body.get("tool_choice");
-    let mode = choice.and_then(Value::as_str).or_else(|| {
-        choice
-            .and_then(Value::as_object)
-            .and_then(|object| object.get("type"))
-            .and_then(Value::as_str)
-    });
-    if choice.is_some() && mode != Some("auto") {
-        return Ok(());
-    }
-    let tools = body
-        .get("tools")
-        .and_then(Value::as_array)
-        .map(Vec::as_slice)
-        .unwrap_or_default();
-    crate::tool_constraint::validate_auto_tool_patterns(tools)
 }
 
 fn normalize_legacy_function_calls(body: &mut Map<String, Value>) -> Result<(), NormalizeError> {
@@ -673,49 +653,10 @@ fn assertion_family_types(object: &Map<String, Value>) -> HashSet<&'static str> 
         .collect()
 }
 
-/// Whether a typeless node's assertions cannot determine a single renderable
-/// type: either its assertion keywords span more than one type family (e.g.
-/// `{"minimum":5,"minLength":2}`) or its only assertion is `not` (e.g.
-/// `{"not":{"type":"string"}}`, which accepts every non-string — no injected
-/// type can preserve that, and the string default would make the schema
-/// unsatisfiable). Callers reject these before normalization. Structural,
-/// union, or finite-value evidence takes priority.
-pub(crate) fn typeless_assertion_families_ambiguous(object: &Map<String, Value>) -> bool {
-    for key in [
-        "properties",
-        "patternProperties",
-        "additionalProperties",
-        "items",
-        "prefixItems",
-    ] {
-        if object.contains_key(key) {
-            return false;
-        }
-    }
-    for key in ["anyOf", "oneOf", "allOf"] {
-        if let Some(variants) = object.get(key).and_then(Value::as_array)
-            && variants.iter().any(|variant| {
-                variant
-                    .as_object()
-                    .and_then(|variant| variant.get("type"))
-                    .and_then(Value::as_str)
-                    .is_some_and(|kind| kind != "null")
-            })
-        {
-            return false;
-        }
-    }
-    let families = assertion_family_types(object);
-    if families.len() > 1 {
-        return true;
-    }
-    families.is_empty() && object.contains_key("not")
-}
-
 /// JSON type names of a node's const/enum values: the set of concrete
 /// (non-null) member types plus whether null appears. `None` when the node
 /// carries no const and no non-empty enum array.
-pub(crate) fn finite_value_types(object: &Map<String, Value>) -> Option<(HashSet<String>, bool)> {
+fn finite_value_types(object: &Map<String, Value>) -> Option<(HashSet<String>, bool)> {
     let values: Vec<&Value> = if let Some(constant) = object.get("const") {
         vec![constant]
     } else if let Some(members) = object.get("enum").and_then(Value::as_array) {
@@ -1390,79 +1331,6 @@ mod tests {
     }
 
     #[test]
-    fn typeless_mixed_assertion_families_are_rejected_before_normalization() {
-        for value in [
-            json!({"minimum":5,"minLength":2}),
-            json!({"not":{"type":"string"}}),
-        ] {
-            let body = json!({
-                "model":"gemma-4-fixture",
-                "messages":[{"role":"user","content":"x"}],
-                "tools":[{"type":"function","function":{
-                    "name":"pick",
-                    "parameters":{"type":"object","properties":{"value":value}}
-                }}],
-                "tool_choice":"auto"
-            });
-            assert!(normalize(body.as_object().unwrap().clone(), Some("gemma4_text")).is_err());
-        }
-    }
-
-    #[test]
-    fn typeless_mixed_finite_values_are_rejected_before_normalization() {
-        for value in [json!({"enum":["a",1]}), json!({"enum":[true,"on"]})] {
-            let body = json!({
-                "model":"gemma-4-fixture",
-                "messages":[{"role":"user","content":"x"}],
-                "tools":[{"type":"function","function":{
-                    "name":"pick",
-                    "parameters":{"type":"object","properties":{"value":value}}
-                }}],
-                "tool_choice":"auto"
-            });
-            assert!(normalize(body.as_object().unwrap().clone(), Some("gemma4_text")).is_err());
-        }
-    }
-
-    #[test]
-    fn unevaluated_assertions_are_rejected_before_inference() {
-        for value in [
-            json!({"type":"object","unevaluatedProperties":false}),
-            json!({"type":"array","items":{"type":"string"},"unevaluatedItems":false}),
-        ] {
-            let body = json!({
-                "model":"gemma-4-fixture",
-                "messages":[{"role":"user","content":"x"}],
-                "tools":[{"type":"function","function":{
-                    "name":"pick",
-                    "parameters":{"type":"object","properties":{"value":value}}
-                }}],
-                "tool_choice":"auto"
-            });
-            assert!(normalize(body.as_object().unwrap().clone(), Some("gemma4_text")).is_err());
-        }
-    }
-
-    #[test]
-    fn dynamic_and_recursive_references_are_rejected_before_inference() {
-        for value in [
-            json!({"$dynamicRef":"#address"}),
-            json!({"$recursiveRef":"#"}),
-        ] {
-            let body = json!({
-                "model":"gemma-4-fixture",
-                "messages":[{"role":"user","content":"x"}],
-                "tools":[{"type":"function","function":{
-                    "name":"pick",
-                    "parameters":{"type":"object","properties":{"value":value}}
-                }}],
-                "tool_choice":"auto"
-            });
-            assert!(normalize(body.as_object().unwrap().clone(), Some("gemma4_text")).is_err());
-        }
-    }
-
-    #[test]
     fn rejects_shapes_the_swift_request_decoder_rejects() {
         for body in [
             json!({
@@ -1574,9 +1442,11 @@ mod tests {
     }
 
     #[test]
-    fn auto_regex_support_is_rejected_before_inference() {
-        let body = |pattern: &str| {
-            json!({
+    fn auto_regex_patterns_survive_normalization() {
+        // `auto` never compiles a sampler grammar, so an arbitrary regex is a
+        // post-generation assertion the provider validator evaluates itself.
+        for pattern in ["^city$", "^[a-z]+$", "(?i)\\p{L}{2,}|[0-9]{3}"] {
+            let body = json!({
                 "model":"gemma-4-fixture",
                 "messages":[{"role":"user","content":"x"}],
                 "tools":[{"type":"function","function":{
@@ -1586,60 +1456,16 @@ mod tests {
                     }}
                 }}],
                 "tool_choice":"auto"
-            })
-        };
-        assert!(
-            normalize(
-                body("^city$").as_object().unwrap().clone(),
-                Some("gemma4_text")
-            )
-            .is_ok()
-        );
-        assert!(
-            normalize(
-                body("^[a-z]+$").as_object().unwrap().clone(),
-                Some("gemma4_text")
-            )
-            .is_err()
-        );
-    }
-
-    #[test]
-    fn auto_pattern_validation_distinguishes_keywords_from_property_names() {
-        let body = json!({
-            "model":"gemma-4-fixture",
-            "messages":[{"role":"user","content":"x"}],
-            "tools":[{"type":"function","function":{
-                "name":"lookup",
-                "parameters":{"type":"object","properties":{
-                    "pattern":{"type":"string","pattern":"^city$"}
-                }}
-            }}],
-            "tool_choice":"auto"
-        });
-        assert!(normalize(body.as_object().unwrap().clone(), Some("gemma4_text")).is_ok());
-    }
-
-    #[test]
-    fn auto_pattern_validation_does_not_double_count_tuple_containers() {
-        let mut item = json!({"type":"string","pattern":"^city$"});
-        for _ in 0..17 {
-            item = json!({"type":"array","items":[item]});
+            });
+            assert!(
+                normalize(body.as_object().unwrap().clone(), Some("gemma4_text")).is_ok(),
+                "{pattern}"
+            );
         }
-        let body = json!({
-            "model":"gemma-4-fixture",
-            "messages":[{"role":"user","content":"x"}],
-            "tools":[{"type":"function","function":{
-                "name":"lookup",
-                "parameters":{"type":"object","properties":{"value":item}}
-            }}],
-            "tool_choice":"auto"
-        });
-        assert!(normalize(body.as_object().unwrap().clone(), Some("gemma4_text")).is_ok());
     }
 
     #[test]
-    fn auto_pattern_validation_bounds_malformed_nested_tuple_arrays() {
+    fn auto_accepts_deeply_nested_tuple_containers() {
         let mut items = json!({"type":"string","pattern":"^city$"});
         for _ in 0..40 {
             items = json!([items]);
@@ -1653,15 +1479,29 @@ mod tests {
             }}],
             "tool_choice":"auto"
         });
-        assert!(normalize(body.as_object().unwrap().clone(), Some("gemma4_text")).is_err());
+        assert!(normalize(body.as_object().unwrap().clone(), Some("gemma4_text")).is_ok());
     }
 
+    // `auto` compiles no inference grammar: every one of these constructs is
+    // enforced post-generation by the provider's JSON Schema validator, so
+    // prompt normalization must pass them through untouched instead of
+    // rejecting the request. Regression guard for the #561 pre-flight scan.
     #[test]
-    fn unsupported_auto_semantics_fail_before_render_normalization() {
+    fn auto_accepts_standard_json_schema_constructs() {
         for property_schema in [
             json!({"type":["string","integer"]}),
+            json!({"anyOf":[{"type":"string"},{"type":"integer"}]}),
             json!({"oneOf":[{"type":"string"},{"type":"integer"}]}),
             json!({"$ref":"#/$defs/Address"}),
+            json!({"$dynamicRef":"#address"}),
+            json!({"$recursiveRef":"#"}),
+            json!({"minimum":5,"minLength":2}),
+            json!({"not":{"type":"string"}}),
+            json!({"enum":["a",1]}),
+            json!({"enum":[true,"on"]}),
+            json!({"type":"number","enum":[0.1]}),
+            json!({"type":"object","unevaluatedProperties":false}),
+            json!({"type":"array","items":{"type":"string"},"unevaluatedItems":false}),
             json!({
                 "if":{"properties":{"kind":{"const":"business"}}},
                 "then":{"required":["tax_id"]}
@@ -1698,12 +1538,51 @@ mod tests {
                 }}],
                 "tool_choice":"auto"
             });
-            assert!(normalize(body.as_object().unwrap().clone(), Some("gemma4_text")).is_err());
+            assert!(
+                normalize(body.as_object().unwrap().clone(), Some("gemma4_text")).is_ok(),
+                "{body}"
+            );
         }
     }
 
     #[test]
-    fn supported_decimal_multiple_schemas_survive_preflight() {
+    fn auto_union_and_pattern_properties_normalize_for_rendering() {
+        let body = json!({
+            "model":"gemma-4-fixture",
+            "messages":[{"role":"user","content":"x"}],
+            "tools":[{"type":"function","function":{
+                "name":"lookup",
+                "parameters":{"type":"object","properties":{
+                    "value":{"anyOf":[
+                        {"type":"string"},
+                        {"type":"integer"},
+                        {"type":"object","properties":{"id":{"type":"string"}}}
+                    ]},
+                    "headers":{
+                        "type":"object",
+                        "patternProperties":{
+                            "^x-[A-Za-z0-9-]+$":{"type":"string"}
+                        }
+                    }
+                }}
+            }}],
+            "tool_choice":"auto"
+        });
+        let normalized = normalize(body.as_object().unwrap().clone(), Some("gemma4_text"))
+            .expect("union and patternProperties are auto-legal");
+        let properties = &normalized.tools.unwrap()[0]["function"]["parameters"]["properties"];
+        // The union survives; the render type is the first concrete branch and
+        // the multi-type members stay in `anyOf` for post-generation checking.
+        assert_eq!(properties["value"]["type"], "string");
+        assert_eq!(properties["value"]["anyOf"][1]["type"], "integer");
+        assert_eq!(
+            properties["headers"]["patternProperties"]["^x-[A-Za-z0-9-]+$"]["type"],
+            "string"
+        );
+    }
+
+    #[test]
+    fn supported_decimal_multiple_schemas_survive_normalization() {
         for multiple in [
             json!(1),
             json!(0.1),

--- a/coordinator/promptsidecar/src/normalize.rs
+++ b/coordinator/promptsidecar/src/normalize.rs
@@ -434,6 +434,41 @@ fn inject_schema_types(node: &mut Value, positional: bool) {
         {
             object.insert("nullable".into(), Value::Bool(true));
         }
+        // A multi-concrete array (`["string","integer"]`) declares a real
+        // union the single render type cannot carry: the render pipeline
+        // needs one `value['type'] | upper` string, but the provider's
+        // post-generation validator enforces what is on the wire, so keeping
+        // only the first member would reject schema-valid emissions of every
+        // other branch. JSON Schema defines the array form as exactly an
+        // anyOf of its single types, so the surviving concrete members are
+        // mirrored into `anyOf` — that survives the wire, and the validator
+        // prefers union branches over the sibling render type. A node that
+        // already carries a combinator keeps the conjunctive semantics its
+        // author wrote (layering a second union would change them); that
+        // pathological shape stays knowingly narrowed to the first member.
+        // Mirrors: null member → `nullable` (above), concrete members →
+        // `anyOf` (here).
+        let mut concrete = Vec::new();
+        for member in &members {
+            if member != "null" && !concrete.contains(member) {
+                concrete.push(member.clone());
+            }
+        }
+        if concrete.len() >= 2
+            && !["anyOf", "oneOf", "allOf"]
+                .iter()
+                .any(|key| object.contains_key(*key))
+        {
+            object.insert(
+                "anyOf".into(),
+                Value::Array(
+                    concrete
+                        .iter()
+                        .map(|member| json!({ "type": member }))
+                        .collect(),
+                ),
+            );
+        }
         object.insert(
             "type".into(),
             Value::String(
@@ -1439,6 +1474,111 @@ mod tests {
         assert_eq!(value["type"], "string");
         assert_eq!(value["nullable"], true);
         assert!(properties["explicit"].get("nullable").is_none());
+    }
+
+    fn normalized_property(schema: Value, name: &str) -> Value {
+        let body = json!({
+            "model":"gemma-4-fixture",
+            "messages":[{"role":"user","content":"x"}],
+            "tools":[{"type":"function","function":{
+                "name":"f",
+                "parameters":{"type":"object","properties":{name: schema}}
+            }}]
+        });
+        let normalized = normalize(body.as_object().unwrap().clone(), Some("gemma4_text")).unwrap();
+        normalized.tools.unwrap()[0]["function"]["parameters"]["properties"][name].clone()
+    }
+
+    // Go: TestNormalizeToolSchemas_MultiConcreteTypeArrayPreservedViaAnyOf
+    // Swift: multiConcreteTypeArrayPreservedViaAnyOf
+    #[test]
+    fn multi_concrete_type_array_preserved_via_any_of() {
+        assert_eq!(
+            normalized_property(json!({"type":["string","integer"]}), "id"),
+            json!({"type":"string","anyOf":[{"type":"string"},{"type":"integer"}]})
+        );
+    }
+
+    // Go: TestNormalizeToolSchemas_MultiConcreteNullableTypeArrayKeepsNullAndUnion
+    // Swift: multiConcreteNullableTypeArrayKeepsNullAndUnion
+    #[test]
+    fn multi_concrete_nullable_type_array_keeps_null_and_union() {
+        // The null member rides the nullable side-channel, never the union.
+        assert_eq!(
+            normalized_property(json!({"type":["integer","string","null"]}), "id"),
+            json!({
+                "type":"integer",
+                "nullable":true,
+                "anyOf":[{"type":"integer"},{"type":"string"}]
+            })
+        );
+    }
+
+    // Go: TestNormalizeToolSchemas_CollapsesNullableArrayTypeToConcreteMember
+    // Swift: collapsesNullableArrayTypeToConcreteMember — a single-concrete
+    // nullable pair synthesizes NO anyOf (the parity corpus pins this shape).
+    #[test]
+    fn single_concrete_nullable_pair_gets_no_any_of() {
+        assert_eq!(
+            normalized_property(json!({"type":["string","null"]}), "city"),
+            json!({"type":"string","nullable":true})
+        );
+    }
+
+    // Go: TestNormalizeToolSchemas_MultiConcreteTypeArrayWithExistingCombinatorCollapsesOnly
+    // Swift: multiConcreteTypeArrayWithExistingCombinatorCollapsesOnly
+    #[test]
+    fn multi_concrete_type_array_with_existing_combinator_collapses_only() {
+        // The author's combinator keeps its written semantics: no second
+        // union is layered on; the authored member survives (type-injected
+        // only) and the type still collapses to the first concrete member.
+        let v = normalized_property(
+            json!({"type":["string","integer"],"anyOf":[{"minLength":1}]}),
+            "v",
+        );
+        assert_eq!(v["type"], "string");
+        let variants = v["anyOf"].as_array().unwrap();
+        assert_eq!(variants.len(), 1);
+        assert_eq!(variants[0]["minLength"], 1);
+
+        let w = normalized_property(
+            json!({"type":["string","integer"],"allOf":[{"minLength":1}]}),
+            "w",
+        );
+        assert!(w.get("anyOf").is_none());
+        assert_eq!(w["type"], "string");
+    }
+
+    // Go: TestNormalizeToolSchemas_DuplicateTypeMembersDedupedCaseInsensitively
+    // Swift: duplicateTypeMembersDedupedCaseInsensitively
+    #[test]
+    fn duplicate_type_members_deduped_case_insensitively() {
+        assert_eq!(
+            normalized_property(json!({"type":["string","STRING","integer"]}), "id"),
+            json!({"type":"string","anyOf":[{"type":"string"},{"type":"integer"}]})
+        );
+    }
+
+    // Go: TestNormalizeToolSchemas_AllShapesIdempotentAndNumbersSurvive
+    // Swift: multiConcreteUnionInjectionIsIdempotent
+    #[test]
+    fn multi_concrete_union_injection_is_idempotent() {
+        let mut node = json!({"type":["string","integer","null"]});
+        inject_schema_types(&mut node, true);
+        let once = node.clone();
+        // The rewritten node has a string type (the collapse branch cannot
+        // re-fire) and carries an anyOf (a second union cannot be layered),
+        // and the injected members are already normal-form.
+        inject_schema_types(&mut node, true);
+        assert_eq!(node, once);
+        assert_eq!(
+            once,
+            json!({
+                "type":"string",
+                "nullable":true,
+                "anyOf":[{"type":"string"},{"type":"integer"}]
+            })
+        );
     }
 
     #[test]

--- a/coordinator/promptsidecar/src/tool_constraint.rs
+++ b/coordinator/promptsidecar/src/tool_constraint.rs
@@ -6,9 +6,6 @@ const MAX_ARRAY_ITEMS: usize = 16;
 const MAX_GRAMMAR_COMPLEXITY: usize = 50_000;
 const SCHEMA_FIXED_COST: usize = 8;
 const NULLABLE_BRANCH_COST: usize = 4;
-const MAX_SAFE_AUTO_PATTERN_BYTES: usize = 128;
-const MAX_SAFE_AUTO_PATTERN_COUNT: usize = 32;
-const MAX_AUTO_PATTERN_DEPTH: usize = 32;
 const STRING_DELIMITERS: [&str; 6] = [
     r#"<|"|>"#,
     "<escape>",
@@ -27,20 +24,6 @@ pub(crate) fn validate_selected_constrained_tool(
     selected: &str,
 ) -> Result<(), NormalizeError> {
     validate_constrained_tools_for(tools, Some(selected))
-}
-
-pub(crate) fn validate_auto_tool_patterns(tools: &[Value]) -> Result<(), NormalizeError> {
-    for tool in tools {
-        let parameters = tool
-            .as_object()
-            .and_then(|tool| tool.get("function"))
-            .and_then(Value::as_object)
-            .and_then(|function| function.get("parameters"));
-        if let Some(parameters) = parameters {
-            validate_auto_schema_patterns(parameters, 0)?;
-        }
-    }
-    Ok(())
 }
 
 fn validate_constrained_tools_for(
@@ -201,207 +184,6 @@ fn validate_constrained_schema(
     Ok(())
 }
 
-fn validate_auto_schema_patterns(schema: &Value, depth: usize) -> Result<(), NormalizeError> {
-    if depth > MAX_AUTO_PATTERN_DEPTH {
-        return Err(NormalizeError::InvalidTools);
-    }
-    match schema {
-        Value::Array(values) => {
-            for child in values {
-                validate_auto_schema_patterns(child, depth + 1)?;
-            }
-        }
-        Value::Object(object) => {
-            if ["$ref", "$dynamicRef", "$recursiveRef"]
-                .iter()
-                .any(|keyword| object.contains_key(*keyword))
-            {
-                return Err(NormalizeError::InvalidTools);
-            }
-            if ["if", "then", "else"]
-                .iter()
-                .any(|keyword| object.contains_key(*keyword))
-            {
-                return Err(NormalizeError::InvalidTools);
-            }
-            if [
-                "dependentSchemas",
-                "dependentRequired",
-                "dependencies",
-                "propertyNames",
-                "unevaluatedItems",
-                "unevaluatedProperties",
-            ]
-            .iter()
-            .any(|keyword| object.contains_key(*keyword))
-            {
-                return Err(NormalizeError::InvalidTools);
-            }
-            if !auto_finite_number_identity_is_exact(object) {
-                return Err(NormalizeError::InvalidTools);
-            }
-            // Mixed-type const/enum or mixed-family assertions on a typeless
-            // node have no single renderable type; normalization would
-            // silently break every member outside its picked type. Mirrors
-            // the multi-type union policy.
-            if !object.contains_key("type") {
-                if let Some((concrete, _)) = crate::normalize::finite_value_types(object) {
-                    if concrete.len() > 1 {
-                        return Err(NormalizeError::InvalidTools);
-                    }
-                } else if crate::normalize::typeless_assertion_families_ambiguous(object) {
-                    return Err(NormalizeError::InvalidTools);
-                }
-            }
-            if let Some(types) = object.get("type").and_then(Value::as_array) {
-                let mut concrete = std::collections::HashSet::new();
-                for raw_type in types {
-                    let raw_type = raw_type.as_str().ok_or(NormalizeError::InvalidTools)?;
-                    if !raw_type.eq_ignore_ascii_case("null") {
-                        concrete.insert(raw_type.to_ascii_lowercase());
-                    }
-                }
-                if concrete.len() > 1 {
-                    return Err(NormalizeError::InvalidTools);
-                }
-            }
-            for keyword in ["anyOf", "oneOf"] {
-                let Some(variants) = object.get(keyword).and_then(Value::as_array) else {
-                    continue;
-                };
-                let mut concrete = std::collections::HashSet::new();
-                for variant in variants {
-                    let variant = variant.as_object().ok_or(NormalizeError::InvalidTools)?;
-                    let members = raw_schema_concrete_types(
-                        variant.get("type").ok_or(NormalizeError::InvalidTools)?,
-                    )?;
-                    concrete.extend(members);
-                }
-                if concrete.len() > 1 {
-                    return Err(NormalizeError::InvalidTools);
-                }
-            }
-            if let Some(pattern) = object.get("pattern") {
-                let pattern = pattern.as_str().ok_or(NormalizeError::InvalidTools)?;
-                if !safe_auto_schema_pattern(pattern) {
-                    return Err(NormalizeError::InvalidTools);
-                }
-            }
-            if let Some(patterns) = object.get("patternProperties") {
-                let patterns = patterns.as_object().ok_or(NormalizeError::InvalidTools)?;
-                if patterns.len() > MAX_SAFE_AUTO_PATTERN_COUNT {
-                    return Err(NormalizeError::InvalidTools);
-                }
-                if patterns
-                    .keys()
-                    .any(|pattern| !safe_auto_schema_pattern(pattern))
-                {
-                    return Err(NormalizeError::InvalidTools);
-                }
-            }
-            for key in [
-                "additionalProperties",
-                "additionalItems",
-                "contains",
-                "contentSchema",
-                "if",
-                "then",
-                "else",
-                "not",
-                "propertyNames",
-                "unevaluatedItems",
-                "unevaluatedProperties",
-            ] {
-                if let Some(child) = object.get(key) {
-                    validate_auto_schema_patterns(child, depth + 1)?;
-                }
-            }
-            for key in ["allOf", "anyOf", "oneOf", "prefixItems"] {
-                if let Some(children) = object.get(key).and_then(Value::as_array) {
-                    for child in children {
-                        validate_auto_schema_patterns(child, depth + 1)?;
-                    }
-                }
-            }
-            if let Some(items) = object.get("items") {
-                if let Some(tuple) = items.as_array() {
-                    for child in tuple {
-                        validate_auto_schema_patterns(child, depth + 1)?;
-                    }
-                } else {
-                    validate_auto_schema_patterns(items, depth + 1)?;
-                }
-            }
-            for key in [
-                "properties",
-                "patternProperties",
-                "dependentSchemas",
-                "dependencies",
-                "definitions",
-                "$defs",
-            ] {
-                if let Some(children) = object.get(key).and_then(Value::as_object) {
-                    for child in children.values() {
-                        validate_auto_schema_patterns(child, depth + 1)?;
-                    }
-                }
-            }
-        }
-        _ => {}
-    }
-    Ok(())
-}
-
-fn raw_schema_concrete_types(
-    raw: &Value,
-) -> Result<std::collections::HashSet<String>, NormalizeError> {
-    let mut concrete = std::collections::HashSet::new();
-    match raw {
-        Value::String(member) => {
-            if !member.eq_ignore_ascii_case("null") {
-                concrete.insert(member.to_ascii_lowercase());
-            }
-        }
-        Value::Array(members) => {
-            for member in members {
-                let member = member.as_str().ok_or(NormalizeError::InvalidTools)?;
-                if !member.eq_ignore_ascii_case("null") {
-                    concrete.insert(member.to_ascii_lowercase());
-                }
-            }
-        }
-        _ => return Err(NormalizeError::InvalidTools),
-    }
-    Ok(concrete)
-}
-
-fn safe_auto_schema_pattern(pattern: &str) -> bool {
-    if pattern.len() > MAX_SAFE_AUTO_PATTERN_BYTES {
-        return false;
-    }
-    let literal = pattern.strip_prefix('^').unwrap_or(pattern);
-    let literal = literal.strip_suffix('$').unwrap_or(literal);
-    !literal.bytes().any(|byte| {
-        matches!(
-            byte,
-            b'\\'
-                | b'.'
-                | b'^'
-                | b'$'
-                | b'|'
-                | b'?'
-                | b'*'
-                | b'+'
-                | b'('
-                | b')'
-                | b'['
-                | b']'
-                | b'{'
-                | b'}'
-        )
-    })
-}
-
 fn validate_finite_values(
     schema: &serde_json::Map<String, Value>,
     kind: &str,
@@ -450,18 +232,6 @@ fn validate_finite_values(
         }
     }
     Ok(())
-}
-
-fn auto_finite_number_identity_is_exact(schema: &serde_json::Map<String, Value>) -> bool {
-    let constant = schema.get("const").into_iter();
-    let enumeration = schema
-        .get("enum")
-        .and_then(Value::as_array)
-        .into_iter()
-        .flatten();
-    constant
-        .chain(enumeration)
-        .all(|value| !value.is_number() || json_number_is_integer(value))
 }
 
 fn json_number_is_integer(value: &Value) -> bool {
@@ -788,26 +558,6 @@ mod tests {
             .expect("integer tool schema");
             assert!(validate_constrained_tools(&tools).is_ok(), "{literal}");
         }
-    }
-
-    #[test]
-    fn rejects_inexact_auto_finite_values() {
-        let tools = vec![json!({
-            "type": "function",
-            "function": {
-                "name": "calculate",
-                "parameters": {
-                    "type": "object",
-                    "properties": {
-                        "value": {
-                            "type": "number",
-                            "enum": [0.1_f64]
-                        }
-                    }
-                }
-            }
-        })];
-        assert!(validate_auto_tool_patterns(&tools).is_err());
     }
 
     #[test]

--- a/coordinator/registry/dedicated_models.go
+++ b/coordinator/registry/dedicated_models.go
@@ -140,3 +140,37 @@ func (r *Registry) HasProviderForModel(model string, allowedSerials ...string) b
 	}
 	return false
 }
+
+// HasProviderAdvertisingToolConstraint reports whether any online,
+// non-untrusted provider advertising a catalog-allowed build of the resolved
+// model id ALSO advertises inference-time tool_choice enforcement for it
+// (tool-constraint protocol v1 with the concrete model listed). It mirrors
+// HasProviderForModel's gate set exactly — status, catalog membership, serial
+// allowlist — and deliberately IGNORES trust minimums, attestation freshness,
+// and capacity: it answers "can this fleet EVER enforce tool_choice for this
+// model", not "can it right now". The consumer uses it to split the permanent
+// 400 ("no build of this model enforces tool_choice") from the transient 503;
+// a trust-lapsed or freshness-expired enforcing provider is a transient
+// outage that belongs to the retryable 503 arm.
+func (r *Registry) HasProviderAdvertisingToolConstraint(model string, allowedSerials ...string) bool {
+	allowedSet := make(map[string]struct{}, len(allowedSerials))
+	for _, s := range allowedSerials {
+		allowedSet[s] = struct{}{}
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	for _, p := range r.providers {
+		if len(allowedSet) > 0 && !providerMatchesAllowedSerial(p, allowedSet) {
+			continue
+		}
+		p.mu.Lock()
+		eligible := p.Status != StatusOffline && p.Status != StatusUntrusted &&
+			r.providerServesCatalogModelLocked(p, model) &&
+			providerSupportsToolConstraintLocked(p, model)
+		p.mu.Unlock()
+		if eligible {
+			return true
+		}
+	}
+	return false
+}

--- a/coordinator/registry/request_traits.go
+++ b/coordinator/registry/request_traits.go
@@ -78,6 +78,16 @@ var capabilityVersionFloors = map[string]string{
 	"tools": "0.6.3",
 }
 
+// toolChoiceNonePromptPolicyFloor is the minimum provider version that honors
+// tool_choice "none" on a request that DECLARES tools. Honoring `none` is
+// prompt-side: ToolChoicePromptPolicy hides the declared tools from the
+// rendered prompt and injects the no-tool instruction, and that policy first
+// shipped in provider v0.7.10 (#538). An older provider renders the tools
+// verbatim and can emit a tool call DESPITE the caller's explicit `none`; the
+// fleet-wide minimum version (prod 0.7.5) does not cover it. Tool-less `none`
+// requests need no floor: with nothing declared there is nothing to render.
+const toolChoiceNonePromptPolicyFloor = "0.7.10"
+
 // CompareVersions compares two dotted numeric versions, returning -1 when
 // a < b, 0 when equal, +1 when a > b. It is deliberately tolerant: a leading
 // "v"/"V" is stripped, segments compare numerically ("0.6.10" > "0.6.3"),
@@ -142,6 +152,12 @@ func (r *Registry) providerMeetsTraitFloorsLocked(p *Provider, t RequestTraits) 
 	if t.HasTools {
 		if floor := capabilityVersionFloors["tools"]; floor != "" {
 			if p.Version == "" || CompareVersions(p.Version, floor) < 0 {
+				return false
+			}
+		}
+		if t.ToolChoiceMode == "none" {
+			if p.Version == "" ||
+				CompareVersions(p.Version, toolChoiceNonePromptPolicyFloor) < 0 {
 				return false
 			}
 		}
@@ -213,6 +229,19 @@ func (r *Registry) providerEligibleForTraitsLocked(p *Provider, model string, t 
 // unrelated public provider and fail later with a misleading error.
 func (r *Registry) HasToolCapableProviderForModel(model string, allowedSerials ...string) bool {
 	traits := RequestTraits{HasTools: true}
+	return r.hasToolCapableProviderForModel(
+		model, traits, "", false, false, nil, allowedSerials...)
+}
+
+// HasToolCapableProviderForTraits is HasToolCapableProviderForModel with the
+// caller's full request traits, so trait-scoped floors beyond the plain tools
+// floor (today: the tool_choice "none" prompt-policy floor) participate in the
+// consumer's fail-fast. Without it a request whose WHOLE pool is below a
+// mode-specific floor would pass the trait-blind fail-fast, queue for up to
+// 120s, and die with a misleading capacity 429.
+func (r *Registry) HasToolCapableProviderForTraits(
+	model string, traits RequestTraits, allowedSerials ...string,
+) bool {
 	return r.hasToolCapableProviderForModel(
 		model, traits, "", false, false, nil, allowedSerials...)
 }

--- a/coordinator/registry/request_traits.go
+++ b/coordinator/registry/request_traits.go
@@ -18,10 +18,13 @@ type RequestTraits struct {
 	// therefore gated by capabilityVersionFloors and by the per-model
 	// template_render_ok advertisement.
 	HasTools bool
-	// RequiresToolConstraint is true for none/required/exact named choices.
-	// These requests route only to providers that explicitly advertise the
-	// concrete model under tool-constraint protocol v1. Auto remains valid on
-	// the ordinary tools floor for mixed-version compatibility.
+	// RequiresToolConstraint is true for required/exact-named choices — the
+	// modes that compile a sampler grammar. These requests route only to
+	// providers that explicitly advertise the concrete model under
+	// tool-constraint protocol v1. Auto and none remain valid on the ordinary
+	// tools floor: auto is unconstrained, and none is honored by hiding tools
+	// from the prompt plus post-generation rejection, neither of which needs
+	// an enforcing sampler.
 	RequiresToolConstraint bool
 	// Responses output policy, carried with the request so lifecycle snapshots
 	// echo what was actually enforced instead of hardcoded auto/parallel=true.

--- a/coordinator/registry/tool_constraints_test.go
+++ b/coordinator/registry/tool_constraints_test.go
@@ -520,3 +520,40 @@ func TestAliasResolutionFallsBackToConstraintCapablePreviousBuild(t *testing.T) 
 		t.Fatalf("ordinary alias resolved to %q ok=%v, want desired %q", build, ok, desired)
 	}
 }
+
+// tool_choice "none" is honored PROMPT-SIDE: ToolChoicePromptPolicy hides the
+// declared tools from the rendered prompt and injects the no-tool
+// instruction, and that policy first shipped in provider v0.7.10 (#538). A
+// tool-declaring `none` request must never route to an older provider — it
+// renders the tools verbatim and can emit a call despite the caller's
+// explicit `none`; the fleet-wide minimum version does not cover this. Other
+// modes and tool-less `none` are untouched by the floor.
+func TestToolChoiceNoneRequiresPromptPolicyVersionFloor(t *testing.T) {
+	reg := New(testLogger())
+	model := "none-floor-model"
+	provider := makeSchedulerProvider(t, reg, "provider", model, 100)
+	setProviderVersion(provider, "0.7.9")
+
+	noneTraits := RequestTraits{HasTools: true, ToolChoiceMode: "none"}
+	if reg.HasToolCapableProviderForTraits(model, noneTraits) {
+		t.Fatal("0.7.9 pre-dates ToolChoicePromptPolicy and must not serve tools + none")
+	}
+	if !reg.HasToolCapableProviderForTraits(
+		model, RequestTraits{HasTools: true, ToolChoiceMode: "auto"}) {
+		t.Fatal("auto at 0.7.9 must be unaffected by the none floor")
+	}
+	if !reg.HasToolCapableProviderForTraits(
+		model, RequestTraits{HasTools: true, ToolChoiceMode: "required"}) {
+		t.Fatal("required at 0.7.9 must be unaffected by the none floor")
+	}
+	// Tool-less none: nothing is declared, so there is nothing to hide.
+	if !reg.HasToolCapableProviderForTraits(
+		model, RequestTraits{ToolChoiceMode: "none"}) {
+		t.Fatal("tool-less none must not be version-fenced")
+	}
+
+	setProviderVersion(provider, "0.7.10")
+	if !reg.HasToolCapableProviderForTraits(model, noneTraits) {
+		t.Fatal("0.7.10 ships the prompt policy and must serve tools + none")
+	}
+}

--- a/docs/reports/2026-07-30-auto-tool-schema-rejection-root-cause.md
+++ b/docs/reports/2026-07-30-auto-tool-schema-rejection-root-cause.md
@@ -1,0 +1,208 @@
+# Root cause: `tool_choice:"auto"` rejects standard JSON-Schema tool definitions for every model
+
+Status: fixed. See the "Fix as shipped" section at the bottom.
+Regression tests: `coordinator/api/auto_toolschema_regression_test.go`,
+`provider-swift/Tests/ProviderCoreTests/GemmaToolConstraintTests.swift`,
+`coordinator/promptsidecar/src/normalize.rs`.
+
+## Summary
+
+The reported 422 is real and reproduces, but the Slack diagnosis is incomplete in
+three ways:
+
+1. It is **not** an anyOf/oneOf bug. `anyOf`/`oneOf` is one of at least five
+   rejection classes in the same scan; `$ref`/`$defs` (every Pydantic- or
+   Zod-generated tool schema) and regex `pattern`/`patternProperties`
+   (Brandon's reproduced case) are equally fatal.
+2. The proposed fix — defer the scan past `resolveRequestedModel` and gate it on
+   provider constrained-decoding capability — is **not sufficient**. The same
+   scan exists provider-side in `ToolChoicePromptPolicy.prepare`, also
+   model-blind, also shipped in v0.7.12. Gating only the coordinator moves the
+   failure from a pre-dispatch 422 to a post-dispatch `invalidToolPayload`.
+3. The scan has **no technical justification in `auto` mode at all**.
+   `ToolConstraintFactory.make` returns `nil` for `.auto` — auto never compiles
+   an inference grammar — and the post-generation validator that auto actually
+   uses (`validateJSONSchema`) implements `anyOf`, `oneOf`, `allOf`, `not`,
+   `pattern`, and `patternProperties` correctly.
+
+Root cause, stated once: **#561 promoted the constrained-decoding grammar's
+expressiveness limits into a global admission policy for `tool_choice:"auto"`,
+on both sides of the wire, for a mode that never builds a grammar.**
+
+## Regression window
+
+| | |
+|---|---|
+| Introduced by | `613ab6043` — `feat(tools): enforce Gemma tool choices at inference (#561)`, 2026-07-22 |
+| First shipped | `78701be8c` — v0.7.12 (`LatestProviderVersion` 0.7.11 → 0.7.12), same day |
+| Last good | v0.7.11 |
+| Reported on | v0.7.15 |
+
+`coordinator/api/tool_constraints.go` and
+`provider-swift/.../ToolConstraintValidation.swift` were both **created** by
+#561 (`git log --follow`). Before it, no auto-mode tool-schema validator existed
+in either process, so these schemas forwarded untouched.
+
+## Code path
+
+```mermaid
+flowchart TB
+  subgraph Before["Before #561 (≤ v0.7.11)"]
+    B1[POST /v1/chat/completions<br/>tools with anyOf / $ref / pattern] --> B2[NormalizeToolSchemas<br/>nullable-union collapse only]
+    B2 --> B3[resolveRequestedModel]
+    B3 --> B4[dispatch to provider]
+    B4 --> B5[200 tool call]
+  end
+  subgraph After["After #561 (≥ v0.7.12)"]
+    A1[POST /v1/chat/completions<br/>same body] --> A2["validateToolConstraintPolicy<br/>consumer.go:1493"]
+    A2 --> A3{"mode == auto?<br/>tool_constraints.go:90"}
+    A3 -->|yes| A4["validateAutoSchemaPatterns<br/>tool_constraints.go:348-526"]
+    A4 --> A5[422 unprocessable_entity]
+    A3 -->|no| A6["resolveRequestedModel<br/>consumer.go:1524"]
+    A4 -.->|if coordinator check were removed| A7["provider ToolChoicePromptPolicy.prepare:30<br/>validateAutoSchemas"]
+    A7 --> A8[invalidToolPayload]
+  end
+```
+
+Two properties make it model-blind:
+
+- **Ordering.** `validateToolConstraintPolicy` runs at `consumer.go:1493`;
+  `resolveRequestedModel` at `consumer.go:1524`. The validator cannot know the
+  model, let alone the provider's capability. Same shape in the generic handler
+  (`consumer.go:3635`) covering `/v1/completions` and `/v1/messages`.
+- **Gate predicate.** `validateDeclaredTools(root["tools"], enforceSchema,
+  selected, mode == toolChoiceAuto)` — the auto scan is switched on by the
+  *tool_choice literal alone*.
+
+Provider-side mirror, equally model-blind:
+`MultiModelBatchSchedulerEngine.swift:247` → `ToolChoicePromptPolicy.prepare` →
+`case nil, .mode(.auto): try ToolConstraintValidation.validateAutoSchemas(...)`.
+That is the universal per-request path for every model on the box.
+
+## Why the scan is unjustified for `auto`
+
+`ToolConstraintFactory.make` (`ToolConstraintFactory.swift:22-46`):
+
+```swift
+guard prepared.mode.requiresInferenceGrammar else { return nil }
+switch prepared.mode {
+case .auto:  return nil      // auto never constrains the sampler
+case .none:  return GemmaNoToolTokenConstraint(...)
+case .required, .named: ...
+}
+```
+
+Auto's only schema consumer is post-generation validation in
+`ToolConstraintValidation.validate`:
+
+- `prepared.compiledTools` is built with `try?` in the auto branch. The
+  compiler's keyword allowlist (`ToolConstraintSchema.swift:256-264`) excludes
+  `anyOf`/`oneOf`/`pattern`/`patternProperties`/`$ref`, so any such schema fails
+  to compile → `nil`.
+- With `compiledTools == nil` the validator falls back to `validateJSONSchema`,
+  which handles `allOf` (:197), `anyOf` (:204), `oneOf` (:211), `not` (:218),
+  `patternProperties` (:262-287) and `pattern` (:367) with correct semantics.
+
+So a multi-type union is fully supported by the code path auto actually reaches.
+The pre-flight rejection is pure collateral damage.
+
+The one class with a real argument is regex `pattern`/`patternProperties`:
+`safePatternMatches` fails **closed** on non-literal patterns, so a valid model
+emission would be rejected post-generation. The correct remedy is to not enforce
+that assertion, not to refuse the request.
+`$ref`/`if`/`dependentSchemas`/`unevaluated*` are simply ignored by
+`validateJSONSchema` — under-enforcement, not breakage.
+
+## Observed behavior (from the repro test)
+
+Validator-level, model-blind:
+
+| schema construct under `tool_choice:"auto"` | result |
+|---|---|
+| `anyOf:[{string},{object}]` (issue repro) | 422 `multi-type anyOf/oneOf unions` |
+| `oneOf:[{string},{integer}]` | 422 same |
+| `patternProperties:{"^[A-Z_]+$":…}` | 422 `bounded literal pattern…` |
+| `pattern:"^[a-f0-9]{8}$"` | 422 same |
+| `$defs` + `$ref` (Pydantic/Zod output) | 422 `schema references` |
+| `if`/`then` | 422 `conditional assertions` |
+| `anyOf:[{string},{null}]` | passes (null is dropped before the count) |
+| same union with `tool_choice:"none"` | passes — the scan is skipped entirely |
+
+Same union body under `model` = `gpt-oss-20b`, `gemma-4-26b`, `totally-made-up`:
+identical 422. `NormalizeToolSchemas` does not rescue it — it stamps a `type` on
+the parent node and leaves the `anyOf` array intact.
+
+End-to-end over the real handler, with no provider registered: the union body
+422s **before** the model/provider gates, while the tool-less control body
+reaches them. That is direct proof the rejection precedes model resolution.
+
+## Two adjacent defects found while tracing
+
+**A. `tool_choice:"none"` requires a Gemma-class provider.**
+`requiresGrammar()` returns true for `none`, which feeds
+`RequestTraits.RequiresToolConstraint` → `visionToolsFailFast` →
+503 `no online provider … advertises inference-time tool_choice enforcement`.
+Only Gemma-4 builds with the pinned template hash advertise the capability
+(`CoordinatorClientCodec.toolConstraintModelIDs`). Reproduced: a request with
+`tool_choice:"none"` and **zero tools declared** 503s on `gpt-oss-20b`. There is
+nothing to enforce; `prepare` already handles `none` by dropping tools and
+adding an instruction.
+
+**B. The scan/enforcement gating is exactly inverted.**
+`auto` needs no grammar and gets the strictest schema scan; `none` needs a
+grammar and skips the scan entirely (`enforceSchema` is
+`required || named`, and `validateAutoPatterns` is `mode == auto`).
+
+**C.** The `required`/`named` 503 in the Slack thread is expected given the
+capability advertisement, but `model_unavailable` is the wrong code for a
+permanent per-model incapability. It should be a 400 with a stable reason, not a
+retryable 503.
+
+## Fix as shipped
+
+The auto scan is deleted from all three mirrors rather than gated: `auto` compiles
+no grammar, so there is no grammar-feasibility question to answer at admission.
+
+| Mirror | Removed | Kept |
+|---|---|---|
+| `coordinator/api/tool_constraints.go` | `validateAutoSchemaPatterns`, `validateAutoFiniteNumberIdentity`, `autoConcreteSchemaTypes`, `safeAutoSchemaPattern` and their limits | new `rejectReservedSchemaMetadata` — the client-forgery guard for `x-darkbloom-original-boolean-schema`, now covering `auto` **and** `none` (`none` previously had no guard) |
+| `provider-swift/.../ToolConstraintValidation.swift` | `autoSchemaIsSupported` and its private helpers | `rejectReservedSchemaMetadata`, active only when `allowInternalSchemaMetadata == false` (the standalone-server path) |
+| `coordinator/promptsidecar/src/tool_constraint.rs` | `validate_auto_tool_patterns`, `validate_auto_schema_patterns`, `raw_schema_concrete_types`, `safe_auto_schema_pattern`, `auto_finite_number_identity_is_exact` | nothing new — the sidecar receives the already-normalized body, where the marker is legitimate |
+
+Both metadata walks are depth-bounded and, on exceeding the bound, stop descending
+instead of rejecting: the guard must never fail a schema for anything but the marker.
+They also walk schema *positions* only, so a tool that declares a property literally
+named after the marker is not mistaken for a forgery.
+
+Post-generation validation, `ToolConstraintValidation.validateJSONSchema`:
+`safePatternMatches -> Bool` became `patternAssertionSatisfied -> Bool?`. `nil` means
+"cannot evaluate", and only a decisive `false` may reject. An undecidable
+`patternProperties` key additionally suppresses the `additionalProperties` fallback
+for that property, so `additionalProperties: false` plus an unevaluatable regex can
+no longer reject a valid call. An over-count of `patternProperties` degrades to
+not-enforced instead of rejecting.
+
+`tool_choice:"none"`: `requiresGrammar()` is now `required || named`.
+`ToolConstraintFactory.make` returns `nil` for `.none` off the pinned Gemma contract
+instead of throwing, and the engine's multimodal guard admits `.none`. A
+Gemma-capable provider still installs `GemmaNoToolTokenConstraint`; everyone else
+honors `none` by hiding the tools and rejecting any emitted call after generation.
+
+Capability error: `visionToolsFailFast` returns 400 `invalid_request_error`
+(`param: tool_choice`) when the fleet serves the model but no build enforces
+`tool_choice`, and keeps the 503 `model_unavailable` only when nothing serves the
+model. Owner-scoped routing (self-route / prefer) is not expressible as a serial set
+there, so those paths stay on the conservative 503.
+
+Unchanged: `required`/`named` keep their fail-closed compile-time validation in all
+three languages. Every construct in the table above still 422s under `required`.
+
+### Rollout note
+
+Providers on v0.7.12–v0.7.15 still carry the provider-side scan. Until the fleet
+updates, a union/`$ref` schema that now clears coordinator admission is rejected by
+a stale provider with `invalidToolPayload`. That maps to HTTP 400, which
+`isTerminalClientErrorCode` (coordinator/api/dispatch.go:702) treats as a
+deterministic client-shape rejection — returned once, no failover, no reputation
+damage. So the worst case during rollout is the same failed request with a different
+message; it self-heals as providers update.

--- a/docs/reports/2026-07-30-auto-tool-schema-rejection-root-cause.md
+++ b/docs/reports/2026-07-30-auto-tool-schema-rejection-root-cause.md
@@ -206,3 +206,33 @@ a stale provider with `invalidToolPayload`. That maps to HTTP 400, which
 deterministic client-shape rejection — returned once, no failover, no reputation
 damage. So the worst case during rollout is the same failed request with a different
 message; it self-heals as providers update.
+
+## Review follow-ups (PR #603)
+
+Codex review surfaced five gaps in the first cut; all five were verified real and fixed:
+
+1. **Normalization vs post-generation validation.** `NormalizeToolSchemas` stamps a
+   render `type` (first union branch / first finite value / `"string"` for `$ref`-only
+   nodes) and COLLAPSES multi-concrete `type` arrays, so the provider's validator was
+   enforcing constraints the author never wrote. Fixes: multi-concrete arrays now mirror
+   their members into `anyOf` (all three normalizers; `["x","null"]` pairs byte-identical
+   to before, parity vectors untouched); the Swift validator treats `$ref`-bearing nodes
+   as not-asserted, and a satisfied `anyOf`/`oneOf` or matched `const`/`enum` suppresses
+   the sibling render type (`allOf` stays conjunctive).
+2. **`tool_choice:"none"` version floor.** Tool-hiding shipped in v0.7.10
+   (`ToolChoicePromptPolicy`, #538) but prod routes ≥0.7.5. A tools-declaring `none`
+   request now routes only to ≥0.7.10 (`toolChoiceNonePromptPolicyFloor`), and the
+   consumer fail-fast uses `HasToolCapableProviderForTraits` so a whole pool below the
+   floor 503s instead of dying in the queue.
+3. **Previously unenforced keywords.** `if`/`then`/`else`, `dependentRequired`,
+   `dependentSchemas`, `propertyNames` are now enforced post-generation (decidable from
+   the instance alone). `unevaluated*`/`contentSchema` stay not-asserted, and the code
+   comments now say exactly that.
+4. **400 vs 503.** The permanent-incapability 400 additionally requires
+   `!HasProviderAdvertisingToolConstraint` — an advertisement-only scan that ignores
+   trust/freshness — so a trust-lapsed enforcing fleet stays a retryable 503.
+5. **Reserved-metadata fold window.** The guards now scan to the normalizer's own
+   traversal budget and FAIL CLOSED beyond it (Go: `maxToolSchemaDepth` = 64; Swift:
+   walk bound with rejection). Previously a forged marker at depth 33–63 escaped the
+   32-deep fail-open walk and `constantMarkedCombinator` folded it into shallow,
+   coordinator-vouched metadata.

--- a/provider-swift/Sources/ProviderCore/Inference/MultiModelBatchSchedulerEngine.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/MultiModelBatchSchedulerEngine.swift
@@ -268,7 +268,11 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
         // must pass through THIS branch first (the text tokenization below
         // silently discards image parts; media must never reach it).
         if isVLM, let container, MediaIngest.hasMedia(request) {
-            guard prepared.mode == .auto else {
+            // `.auto` constrains nothing and `.none` hides the tools outright
+            // (post-generation validation rejects any emitted call), so both
+            // ride the media path unchanged. `.required`/`.named` need the
+            // token automaton this path cannot install.
+            guard prepared.mode == .auto || prepared.mode == .none else {
                 await releaseBox.fire()
                 throw MultiModelBatchSchedulerEngineError.invalidToolPayload(
                     "inference-enforced tool_choice is not supported for multimodal requests")

--- a/provider-swift/Sources/ProviderCore/Inference/ToolChoicePromptPolicy.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/ToolChoicePromptPolicy.swift
@@ -27,7 +27,7 @@ enum ToolChoicePromptPolicy {
         let allowsParallelCalls = request.parallelToolCalls ?? true
         switch request.toolChoice {
         case nil, .mode(.auto):
-            try ToolConstraintValidation.validateAutoSchemas(
+            try ToolConstraintValidation.rejectReservedSchemaMetadata(
                 request.tools,
                 allowInternalSchemaMetadata: allowInternalSchemaMetadata)
             return Prepared(

--- a/provider-swift/Sources/ProviderCore/Inference/ToolConstraintFactory.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/ToolConstraintFactory.swift
@@ -24,6 +24,12 @@ enum ToolConstraintFactory {
         guard Gemma4TemplateFix.applies(to: modelContext),
             tokenizer.toolConstraintContractVerified
         else {
+            // `.none` needs no sampler automaton: `ToolChoicePromptPolicy`
+            // already strips the tools and injects the "do not call any tool"
+            // instruction, and `ToolConstraintValidation.validate` rejects any
+            // call the model emits anyway. `.required`/`.named` genuinely
+            // depend on the compiled grammar, so they stay fail-closed.
+            if prepared.mode == .none { return nil }
             throw MultiModelBatchSchedulerEngineError.invalidToolPayload(
                 "inference-enforced tool_choice requires the pinned Gemma prompt contract")
         }

--- a/provider-swift/Sources/ProviderCore/Inference/ToolConstraintValidation.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/ToolConstraintValidation.swift
@@ -264,18 +264,19 @@ enum ToolConstraintValidation {
             return accepts
         }
 
-        // This validator does not resolve references, so a node carrying
-        // `$ref`/`$dynamicRef`/`$recursiveRef` has an unknown true constraint
-        // set: its siblings — including the render `type` the normalizer
-        // injects so templates can subscript `value['type']` — belong to
-        // whatever the reference resolves to. Enforcing them here would
-        // reject emissions the REFERENCED schema accepts, so the node is
-        // entirely not-asserted, like an undecidable `pattern`.
-        if object["$ref"] != nil || object["$dynamicRef"] != nil
+        // This validator does not resolve references, so the `$ref`/
+        // `$dynamicRef`/`$recursiveRef` assertion itself is not-asserted.
+        // Sibling assertions are conjunctive with the reference (draft
+        // 2019-09+), so everything the AUTHOR wrote beside it — const, enum,
+        // combinators, bounds, properties — is still enforced below; skipping
+        // them would let a schema-violating call through merely because a
+        // reference sat beside the constraint. The one exception is the
+        // sibling `type`: the normalizer injects a render type onto typeless
+        // nodes (a bare `{"$ref":…}` becomes `type:"string"` even when the
+        // referenced schema is an object), so on a ref-bearing node `type`
+        // cannot be attributed to the author and is not enforced.
+        let refBearing = object["$ref"] != nil || object["$dynamicRef"] != nil
             || object["$recursiveRef"] != nil
-        {
-            return true
-        }
 
         // Finite-value identity subsumes typing: a typeless `{"enum":["a",1]}`
         // gets render type "string" injected from its first member, yet 1 is
@@ -349,7 +350,7 @@ enum ToolConstraintValidation {
         {
             return true
         }
-        if !unionAsserted, !finiteMatched {
+        if !unionAsserted, !finiteMatched, !refBearing {
             let types = schemaTypes(object["type"])
             if !types.isEmpty,
                 !types.contains(where: { matches(value, type: $0) })

--- a/provider-swift/Sources/ProviderCore/Inference/ToolConstraintValidation.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/ToolConstraintValidation.swift
@@ -104,11 +104,23 @@ enum ToolConstraintValidation {
         guard !allowInternalSchemaMetadata else { return }
         for tool in tools ?? [] {
             guard let parameters = tool.function.parameters else { continue }
-            guard !containsReservedSchemaMetadata(parameters, depth: 0) else {
+            switch scanReservedSchemaMetadata(parameters, depth: 0) {
+            case .clean:
+                continue
+            case .marker:
                 throw MultiModelBatchSchedulerEngineError.invalidToolPayload(
                     "tool schema contains reserved internal metadata")
+            case .beyondWalkBound:
+                throw MultiModelBatchSchedulerEngineError.invalidToolPayload(
+                    "tool schema exceeds the reserved-metadata scan depth")
             }
         }
+    }
+
+    private enum ReservedMetadataScan {
+        case clean
+        case marker
+        case beyondWalkBound
     }
 
     /// Schema-position walk: only nodes that ARE schemas are inspected. A map
@@ -117,22 +129,30 @@ enum ToolConstraintValidation {
     /// as a schema itself, so a tool that legitimately declares a property
     /// named after the marker is not mistaken for a forgery.
     ///
-    /// Bounded walk: beyond `maxMetadataWalkDepth` we stop descending rather
-    /// than reject — nesting depth alone is not forgery, and this guard must
-    /// never reject a schema for anything but the marker itself.
-    private static func containsReservedSchemaMetadata(
+    /// Fail-closed walk bound: the normalizer's marker-folding walk
+    /// (`constantMarkedCombinator`) is depth-unbounded, so a guard that
+    /// silently stopped scanning below its own horizon could vouch for a
+    /// schema whose forged marker later folds upward into a shallow position
+    /// downstream consumers trust. A schema too deep to scan cannot be
+    /// vouched marker-free, so a container beyond `maxMetadataWalkDepth`
+    /// rejects instead of passing unscanned; scalars cannot carry the marker
+    /// and stay clean at any depth.
+    private static func scanReservedSchemaMetadata(
         _ schema: ToolArgumentJSONValue,
         depth: Int
-    ) -> Bool {
-        guard depth <= maxMetadataWalkDepth else { return false }
+    ) -> ReservedMetadataScan {
         switch schema {
         case .array(let values):
-            return values.contains {
-                containsReservedSchemaMetadata($0, depth: depth + 1)
+            guard depth <= maxMetadataWalkDepth else { return .beyondWalkBound }
+            for child in values {
+                let scan = scanReservedSchemaMetadata(child, depth: depth + 1)
+                if scan != .clean { return scan }
             }
+            return .clean
         case .object(let object):
+            guard depth <= maxMetadataWalkDepth else { return .beyondWalkBound }
             if object[ToolSchemaNormalization.originalBooleanSchemaKey] != nil {
-                return true
+                return .marker
             }
             for key in [
                 "additionalProperties", "additionalItems", "contains",
@@ -140,27 +160,27 @@ enum ToolConstraintValidation {
                 "unevaluatedItems", "unevaluatedProperties", "items",
                 "allOf", "anyOf", "oneOf", "prefixItems",
             ] {
-                if let child = object[key],
-                    containsReservedSchemaMetadata(child, depth: depth + 1)
-                {
-                    return true
+                if let child = object[key] {
+                    let scan = scanReservedSchemaMetadata(
+                        child, depth: depth + 1)
+                    if scan != .clean { return scan }
                 }
             }
             for key in [
                 "properties", "patternProperties", "dependentSchemas",
                 "dependencies", "definitions", "$defs",
             ] {
-                if case .object(let children)? = object[key],
-                    children.values.contains(where: {
-                        containsReservedSchemaMetadata($0, depth: depth + 1)
-                    })
-                {
-                    return true
+                if case .object(let children)? = object[key] {
+                    for child in children.values {
+                        let scan = scanReservedSchemaMetadata(
+                            child, depth: depth + 1)
+                        if scan != .clean { return scan }
+                    }
                 }
             }
-            return false
+            return .clean
         default:
-            return false
+            return .clean
         }
     }
 
@@ -244,15 +264,32 @@ enum ToolConstraintValidation {
             return accepts
         }
 
-        if let constant = object["const"],
-            !jsonSchemaEqual(value, constant)
+        // This validator does not resolve references, so a node carrying
+        // `$ref`/`$dynamicRef`/`$recursiveRef` has an unknown true constraint
+        // set: its siblings — including the render `type` the normalizer
+        // injects so templates can subscript `value['type']` — belong to
+        // whatever the reference resolves to. Enforcing them here would
+        // reject emissions the REFERENCED schema accepts, so the node is
+        // entirely not-asserted, like an undecidable `pattern`.
+        if object["$ref"] != nil || object["$dynamicRef"] != nil
+            || object["$recursiveRef"] != nil
         {
-            return false
+            return true
         }
-        if case .array(let values)? = object["enum"],
-            !values.contains(where: { jsonSchemaEqual(value, $0) })
-        {
-            return false
+
+        // Finite-value identity subsumes typing: a typeless `{"enum":["a",1]}`
+        // gets render type "string" injected from its first member, yet 1 is
+        // still a schema-valid emission. A matched `const`/`enum` therefore
+        // suppresses the sibling `type` assertion below.
+        var finiteMatched = false
+        if let constant = object["const"] {
+            guard jsonSchemaEqual(value, constant) else { return false }
+            finiteMatched = true
+        }
+        if case .array(let values)? = object["enum"] {
+            guard values.contains(where: { jsonSchemaEqual(value, $0) })
+            else { return false }
+            finiteMatched = true
         }
         if case .array(let variants)? = object["allOf"],
             !variants.allSatisfy({
@@ -261,24 +298,49 @@ enum ToolConstraintValidation {
         {
             return false
         }
-        if case .array(let variants)? = object["anyOf"],
-            !variants.contains(where: {
+        // A satisfied non-empty `anyOf`/`oneOf` already enforced each
+        // branch's own `type` assertion. The sibling `type` on such nodes is
+        // (in every coordinator-normalized body) the render type injected
+        // from the FIRST branch; enforcing it conjunctively would veto every
+        // schema-valid emission from the other branches. `allOf` is NOT
+        // exempted: its branches are conjunctive, so a type derived from
+        // branch one is implied by the conjunction anyway.
+        var unionAsserted = false
+        if case .array(let variants)? = object["anyOf"] {
+            guard variants.contains(where: {
                 validateJSONSchema(value, schema: $0, depth: depth + 1)
-            })
-        {
-            return false
+            }) else { return false }
+            unionAsserted = true
         }
-        if case .array(let variants)? = object["oneOf"],
-            variants.filter({
+        if case .array(let variants)? = object["oneOf"] {
+            guard variants.filter({
                 validateJSONSchema(value, schema: $0, depth: depth + 1)
-            }).count != 1
-        {
-            return false
+            }).count == 1 else { return false }
+            unionAsserted = true
         }
         if let negated = object["not"],
             validateJSONSchema(value, schema: negated, depth: depth + 1)
         {
             return false
+        }
+        // `if`/`then`/`else` are fully decidable from the instance alone, so
+        // the auto path enforces them. `unevaluatedItems`/
+        // `unevaluatedProperties`/`contentSchema` need annotation tracking
+        // this validator does not do and stay not-asserted.
+        if let condition = object["if"] {
+            if validateJSONSchema(value, schema: condition, depth: depth + 1) {
+                if let consequent = object["then"],
+                    !validateJSONSchema(
+                        value, schema: consequent, depth: depth + 1)
+                {
+                    return false
+                }
+            } else if let alternative = object["else"],
+                !validateJSONSchema(
+                    value, schema: alternative, depth: depth + 1)
+            {
+                return false
+            }
         }
 
         if value == .null,
@@ -287,9 +349,13 @@ enum ToolConstraintValidation {
         {
             return true
         }
-        let types = schemaTypes(object["type"])
-        if !types.isEmpty, !types.contains(where: { matches(value, type: $0) }) {
-            return false
+        if !unionAsserted, !finiteMatched {
+            let types = schemaTypes(object["type"])
+            if !types.isEmpty,
+                !types.contains(where: { matches(value, type: $0) })
+            {
+                return false
+            }
         }
 
         switch value {
@@ -307,6 +373,42 @@ enum ToolConstraintValidation {
                     else {
                         return false
                     }
+                }
+            }
+            // `dependentRequired`, `dependentSchemas`, and `propertyNames`
+            // are fully decidable from the instance alone, so the auto path
+            // enforces them. A `dependentRequired` entry whose value is not
+            // an array, or a listed name that is not a string, is not an
+            // intelligible constraint and is not-asserted (skipped), never a
+            // rejection.
+            if case .object(let dependents)? = object["dependentRequired"] {
+                for (trigger, names) in dependents
+                where presentKeys.contains(unicodeScalarIdentity(trigger)) {
+                    guard case .array(let required) = names else { continue }
+                    for member in required {
+                        guard case .string(let name) = member else { continue }
+                        if !presentKeys.contains(unicodeScalarIdentity(name)) {
+                            return false
+                        }
+                    }
+                }
+            }
+            if case .object(let dependents)? = object["dependentSchemas"] {
+                for (trigger, subschema) in dependents
+                where presentKeys.contains(unicodeScalarIdentity(trigger)) {
+                    if !validateJSONSchema(
+                        .object(values), schema: subschema, depth: depth + 1)
+                    {
+                        return false
+                    }
+                }
+            }
+            if let names = object["propertyNames"] {
+                for key in values.keys
+                where !validateJSONSchema(
+                    .string(key), schema: names, depth: depth + 1)
+                {
+                    return false
                 }
             }
             let properties: [String: ToolArgumentJSONValue]

--- a/provider-swift/Sources/ProviderCore/Inference/ToolConstraintValidation.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/ToolConstraintValidation.swift
@@ -25,6 +25,7 @@ enum ToolConstraintValidation {
     private static let maxSafePatternBytes = 128
     private static let maxSafePatternCount = 32
     private static let maxSafePatternInputBytes = 16 * 1024
+    private static let maxMetadataWalkDepth = 32
     private static let exactDoubleIntegerLimit = 9_007_199_254_740_992.0
 
     static func validate(
@@ -86,21 +87,80 @@ enum ToolConstraintValidation {
         }
     }
 
-    static func validateAutoSchemas(
+    /// Reserved-metadata forgery guard for untrusted payloads. The
+    /// `originalBooleanSchemaKey` marker is injected by our own normalizer, so
+    /// a client that sends it is forging internal state.
+    ///
+    /// This is deliberately NOT a grammar-feasibility check: `auto` never
+    /// compiles an inference grammar (`ToolConstraintFactory.make` returns nil
+    /// for `.auto`), so every JSON-Schema construct `validateJSONSchema`
+    /// understands — unions, `$ref`/`$defs`, `pattern`, `if`/`then` — stays
+    /// admissible. Coordinator-fed bodies arrive already normalized and
+    /// legitimately carry the marker, hence the opt-out.
+    static func rejectReservedSchemaMetadata(
         _ tools: [OpenAITool]?,
         allowInternalSchemaMetadata: Bool = true
     ) throws {
+        guard !allowInternalSchemaMetadata else { return }
         for tool in tools ?? [] {
             guard let parameters = tool.function.parameters else { continue }
-            guard autoSchemaIsSupported(
-                parameters,
-                depth: 0,
-                allowInternalSchemaMetadata: allowInternalSchemaMetadata)
-            else {
+            guard !containsReservedSchemaMetadata(parameters, depth: 0) else {
                 throw MultiModelBatchSchedulerEngineError.invalidToolPayload(
-                    "auto tool schema uses unsupported assertions or reserved metadata"
-                )
+                    "tool schema contains reserved internal metadata")
             }
+        }
+    }
+
+    /// Schema-position walk: only nodes that ARE schemas are inspected. A map
+    /// whose *keys* are user-chosen names — `properties`, `patternProperties`,
+    /// `definitions`, `$defs` — is descended through its values, never treated
+    /// as a schema itself, so a tool that legitimately declares a property
+    /// named after the marker is not mistaken for a forgery.
+    ///
+    /// Bounded walk: beyond `maxMetadataWalkDepth` we stop descending rather
+    /// than reject — nesting depth alone is not forgery, and this guard must
+    /// never reject a schema for anything but the marker itself.
+    private static func containsReservedSchemaMetadata(
+        _ schema: ToolArgumentJSONValue,
+        depth: Int
+    ) -> Bool {
+        guard depth <= maxMetadataWalkDepth else { return false }
+        switch schema {
+        case .array(let values):
+            return values.contains {
+                containsReservedSchemaMetadata($0, depth: depth + 1)
+            }
+        case .object(let object):
+            if object[ToolSchemaNormalization.originalBooleanSchemaKey] != nil {
+                return true
+            }
+            for key in [
+                "additionalProperties", "additionalItems", "contains",
+                "contentSchema", "if", "then", "else", "not", "propertyNames",
+                "unevaluatedItems", "unevaluatedProperties", "items",
+                "allOf", "anyOf", "oneOf", "prefixItems",
+            ] {
+                if let child = object[key],
+                    containsReservedSchemaMetadata(child, depth: depth + 1)
+                {
+                    return true
+                }
+            }
+            for key in [
+                "properties", "patternProperties", "dependentSchemas",
+                "dependencies", "definitions", "$defs",
+            ] {
+                if case .object(let children)? = object[key],
+                    children.values.contains(where: {
+                        containsReservedSchemaMetadata($0, depth: depth + 1)
+                    })
+                {
+                    return true
+                }
+            }
+            return false
+        default:
+            return false
         }
     }
 
@@ -264,7 +324,14 @@ enum ToolConstraintValidation {
             } else {
                 patterns = [:]
             }
-            guard patterns.count <= maxSafePatternCount else { return false }
+            // INVARIANT: an assertion this validator declines to evaluate is
+            // never allowed to fail a schema-valid tool call. `auto` has no
+            // pre-flight feasibility gate, so an unevaluatable
+            // `patternProperties` entry goes UNENFORCED — and so does the
+            // `additionalProperties` fallback for that property, which would
+            // otherwise reject a name that might have matched the pattern we
+            // could not decide.
+            let enforcePatterns = patterns.count <= maxSafePatternCount
             for (name, child) in values {
                 let nameIdentity = unicodeScalarIdentity(name)
                 if let schema = declared[nameIdentity],
@@ -272,13 +339,25 @@ enum ToolConstraintValidation {
                 {
                     return false
                 }
-                let matching = patterns.filter { safePatternMatches(name, pattern: $0.key) }
+                var matching: [ToolArgumentJSONValue] = []
+                var undecided = !enforcePatterns
+                if enforcePatterns {
+                    for (pattern, patternSchema) in patterns {
+                        guard let matched = patternAssertionSatisfied(
+                            name, pattern: pattern)
+                        else {
+                            undecided = true
+                            continue
+                        }
+                        if matched { matching.append(patternSchema) }
+                    }
+                }
                 if matching.contains(where: {
-                    !validateJSONSchema(child, schema: $0.value, depth: depth + 1)
+                    !validateJSONSchema(child, schema: $0, depth: depth + 1)
                 }) {
                     return false
                 }
-                if declared[nameIdentity] == nil, matching.isEmpty,
+                if declared[nameIdentity] == nil, matching.isEmpty, !undecided,
                     let additional = object["additionalProperties"],
                     !validateJSONSchema(child, schema: additional, depth: depth + 1)
                 {
@@ -365,7 +444,7 @@ enum ToolConstraintValidation {
                 return false
             }
             if case .string(let pattern)? = object["pattern"],
-                !safePatternMatches(string, pattern: pattern)
+                patternAssertionSatisfied(string, pattern: pattern) == false
             {
                 return false
             }
@@ -380,22 +459,30 @@ enum ToolConstraintValidation {
         }
     }
 
+    /// Tri-state pattern assertion: `true` = the value matches, `false` = the
+    /// value decisively does not match, `nil` = the assertion CANNOT be
+    /// evaluated here and is therefore NOT ASSERTED. Only a decisive `false`
+    /// may reject — `auto` no longer pre-screens tool schemas for grammar
+    /// feasibility, so a regex outside this subset must leave an otherwise
+    /// schema-valid tool call intact.
+    ///
     /// Linear-time subset for post-generation `auto` validation. Foundation's
     /// backtracking regex engine can spend unbounded CPU on user-controlled
     /// schemas. Literal contains/prefix/suffix/exact patterns cover the common
-    /// JSON-Schema cases while regex metacharacters fail closed.
+    /// JSON-Schema cases; anything else — and any oversized input — is
+    /// undecided rather than failed.
     ///
     /// Comparison is by Unicode scalar sequence: Swift `String` equality and
     /// prefix/suffix/contains use canonical equivalence, but JSON Schema regex
     /// matching does not normalize, so a precomposed `^é$` must not match a
     /// generated decomposed `e\u{301}`.
-    private static func safePatternMatches(
+    private static func patternAssertionSatisfied(
         _ value: String,
         pattern: String
-    ) -> Bool {
+    ) -> Bool? {
         guard value.utf8.count <= maxSafePatternInputBytes,
             let components = safePatternComponents(pattern)
-        else { return false }
+        else { return nil }
         let candidate = unicodeScalarIdentity(value)
         let literal = unicodeScalarIdentity(components.literal)
         switch (components.anchoredStart, components.anchoredEnd) {
@@ -425,248 +512,6 @@ enum ToolConstraintValidation {
             }
         }
         return false
-    }
-
-    private static func autoSchemaIsSupported(
-        _ schema: ToolArgumentJSONValue,
-        depth: Int,
-        allowInternalSchemaMetadata: Bool
-    ) -> Bool {
-        guard depth <= 32 else { return false }
-        switch schema {
-        case .array(let values):
-            return values.allSatisfy {
-                autoSchemaIsSupported(
-                    $0,
-                    depth: depth + 1,
-                    allowInternalSchemaMetadata: allowInternalSchemaMetadata)
-            }
-        case .object(let object):
-            if !allowInternalSchemaMetadata,
-                object[ToolSchemaNormalization.originalBooleanSchemaKey] != nil
-            {
-                return false
-            }
-            if object["$ref"] != nil
-                || object["$dynamicRef"] != nil
-                || object["$recursiveRef"] != nil
-                || object["if"] != nil
-                || object["then"] != nil
-                || object["else"] != nil
-                || object["dependentSchemas"] != nil
-                || object["dependentRequired"] != nil
-                || object["dependencies"] != nil
-                || object["propertyNames"] != nil
-                || object["unevaluatedItems"] != nil
-                || object["unevaluatedProperties"] != nil
-            {
-                return false
-            }
-            if !autoFiniteNumberIdentityIsExact(object) {
-                return false
-            }
-            // Mixed-type const/enum or mixed-family assertions on a typeless
-            // node have no single renderable type; normalization would
-            // silently break every member outside its picked type. Mirrors
-            // the multi-type union policy.
-            if object["type"] == nil {
-                if let concrete = finiteAutoValueTypes(object) {
-                    if concrete.count > 1 { return false }
-                } else if typelessAssertionFamiliesAmbiguous(object) {
-                    return false
-                }
-            }
-            if case .array(let rawTypes)? = object["type"] {
-                var concrete = Set<String>()
-                for rawType in rawTypes {
-                    guard case .string(let rawType) = rawType else { return false }
-                    if rawType.lowercased() != "null" {
-                        concrete.insert(rawType.lowercased())
-                    }
-                }
-                if concrete.count > 1 { return false }
-            }
-            for keyword in ["anyOf", "oneOf"] {
-                guard case .array(let variants)? = object[keyword] else { continue }
-                var concrete = Set<String>()
-                for variant in variants {
-                    guard case .object(let variant) = variant else { return false }
-                    let declared = schemaTypes(variant["type"])
-                    if declared.isEmpty { return false }
-                    let members = declared
-                        .filter { $0 != "null" }
-                    concrete.formUnion(members)
-                }
-                if concrete.count > 1 { return false }
-            }
-            if let pattern = object["pattern"] {
-                guard case .string(let pattern) = pattern,
-                    safePatternComponents(pattern) != nil
-                else { return false }
-            }
-            if let patternProperties = object["patternProperties"] {
-                guard case .object(let patterns) = patternProperties,
-                    patterns.count <= maxSafePatternCount,
-                    patterns.keys.allSatisfy({
-                        safePatternComponents($0) != nil
-                    })
-                else { return false }
-            }
-            for key in [
-                "additionalProperties", "additionalItems", "contains", "contentSchema",
-                "if", "then", "else", "not", "propertyNames",
-                "unevaluatedItems", "unevaluatedProperties",
-            ] {
-                if let child = object[key],
-                    !autoSchemaIsSupported(
-                        child,
-                        depth: depth + 1,
-                        allowInternalSchemaMetadata: allowInternalSchemaMetadata)
-                {
-                    return false
-                }
-            }
-            for key in ["allOf", "anyOf", "oneOf", "prefixItems"] {
-                if case .array(let children)? = object[key],
-                    !children.allSatisfy({
-                        autoSchemaIsSupported(
-                            $0,
-                            depth: depth + 1,
-                            allowInternalSchemaMetadata: allowInternalSchemaMetadata)
-                    })
-                {
-                    return false
-                }
-            }
-            if let items = object["items"] {
-                if case .array(let tuple) = items {
-                    if !tuple.allSatisfy({
-                        autoSchemaIsSupported(
-                            $0,
-                            depth: depth + 1,
-                            allowInternalSchemaMetadata: allowInternalSchemaMetadata)
-                    }) {
-                        return false
-                    }
-                } else if !autoSchemaIsSupported(
-                    items,
-                    depth: depth + 1,
-                    allowInternalSchemaMetadata: allowInternalSchemaMetadata)
-                {
-                    return false
-                }
-            }
-            for key in [
-                "properties", "patternProperties", "definitions", "$defs",
-            ] {
-                if case .object(let children)? = object[key],
-                    !children.values.allSatisfy({
-                        autoSchemaIsSupported(
-                            $0,
-                            depth: depth + 1,
-                            allowInternalSchemaMetadata: allowInternalSchemaMetadata)
-                    })
-                {
-                    return false
-                }
-            }
-            return true
-        default:
-            return true
-        }
-    }
-
-    private static func autoFiniteNumberIdentityIsExact(
-        _ schema: [String: ToolArgumentJSONValue]
-    ) -> Bool {
-        var values: [ToolArgumentJSONValue] = []
-        if let constant = schema["const"] {
-            values.append(constant)
-        }
-        if case .array(let enumeration)? = schema["enum"] {
-            values.append(contentsOf: enumeration)
-        }
-        return values.allSatisfy {
-            switch $0 {
-            case .double(let value):
-                value.isFinite
-                    && value.rounded() == value
-                    && abs(value) < exactDoubleIntegerLimit
-            default:
-                true
-            }
-        }
-    }
-
-    /// Whether a typeless node's assertions cannot determine a single
-    /// renderable type: either its assertion keywords span more than one type
-    /// family (e.g. `{"minimum":5,"minLength":2}`) or its only assertion is
-    /// `not` (e.g. `{"not":{"type":"string"}}`, which accepts every
-    /// non-string — no injected type can preserve that, and the string
-    /// default would make the schema unsatisfiable). Structural, union, or
-    /// finite-value evidence takes priority.
-    private static func typelessAssertionFamiliesAmbiguous(
-        _ object: [String: ToolArgumentJSONValue]
-    ) -> Bool {
-        for key in [
-            "properties", "patternProperties", "additionalProperties",
-            "items", "prefixItems",
-        ] where object[key] != nil {
-            return false
-        }
-        for key in ["anyOf", "oneOf", "allOf"] {
-            guard case .array(let variants)? = object[key] else { continue }
-            let hasConcreteMember = variants.contains { variant in
-                if case .object(let variant) = variant,
-                    case .string(let kind)? = variant["type"],
-                    kind != "null"
-                {
-                    return true
-                }
-                return false
-            }
-            if hasConcreteMember { return false }
-        }
-        var families = Set<String>()
-        for (keyword, family) in ToolSchemaNormalization.assertionFamilyByKeyword
-        where object[keyword] != nil {
-            families.insert(family)
-        }
-        if families.count > 1 { return true }
-        return families.isEmpty && object["not"] != nil
-    }
-
-    /// Concrete (non-null) JSON type names of a node's const/enum values.
-    /// nil when the node carries no const and no enum array.
-    private static func finiteAutoValueTypes(
-        _ object: [String: ToolArgumentJSONValue]
-    ) -> Set<String>? {
-        let values: [ToolArgumentJSONValue]
-        if let constant = object["const"] {
-            values = [constant]
-        } else if case .array(let members)? = object["enum"] {
-            values = members
-        } else {
-            return nil
-        }
-        var concrete = Set<String>()
-        for value in values {
-            switch value {
-            case .null:
-                continue
-            case .bool:
-                concrete.insert("boolean")
-            case .int, .double:
-                concrete.insert("number")
-            case .string:
-                concrete.insert("string")
-            case .array:
-                concrete.insert("array")
-            case .object:
-                concrete.insert("object")
-            }
-        }
-        return concrete
     }
 
     private static func safePatternComponents(

--- a/provider-swift/Sources/ProviderCore/Inference/ToolSchemaNormalization.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/ToolSchemaNormalization.swift
@@ -182,6 +182,29 @@ enum ToolSchemaNormalization {
                 dict["nullable"] as? Bool != true {
                 dict["nullable"] = true
             }
+            // A multi-concrete array (`["string","integer"]`) declares a real
+            // union the single render type cannot carry: the render pipeline
+            // needs one `value['type'] | upper` string, but the
+            // post-generation validator enforces what is on the wire, so
+            // keeping only the first member would reject schema-valid
+            // emissions of every other branch. JSON Schema defines the array
+            // form as exactly an anyOf of its single types, so the surviving
+            // concrete members are mirrored into `anyOf` — that survives the
+            // wire, and the validator prefers union branches over the sibling
+            // render type. A node that already carries a combinator keeps the
+            // conjunctive semantics its author wrote (layering a second union
+            // would change them); that pathological shape stays knowingly
+            // narrowed to the first member. Mirrors: null member → `nullable`
+            // (above), concrete members → `anyOf` (here).
+            var concrete = [String]()
+            for member in members where member != "null" && !concrete.contains(member) {
+                concrete.append(member)
+            }
+            if concrete.count >= 2,
+                dict["anyOf"] == nil, dict["oneOf"] == nil, dict["allOf"] == nil
+            {
+                dict["anyOf"] = concrete.map { ["type": $0] as [String: Any] }
+            }
             dict["type"] = collapsedType(members: members, in: dict)
         }
 

--- a/provider-swift/Tests/ProviderCoreTests/EngineV2ProductionWiringTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/EngineV2ProductionWiringTests.swift
@@ -1470,22 +1470,67 @@ struct EngineV2RequestRoutingTests {
                         engineV2Bridge: bridge)
                 ]
             })
+        for choice: OpenAIToolChoice in [
+            .mode(.required), .function(name: "calculate"),
+        ] {
+            let request = OpenAIChatCompletionRequest(
+                model: "gemma-4-26b-qat-4bit",
+                messages: [.init(
+                    role: .user,
+                    content: .parts([
+                        .text("describe"),
+                        .imageURL("data:image/png;base64,AA=="),
+                    ]))],
+                tools: [.init(function: .init(name: "calculate"))],
+                toolChoice: choice)
+
+            do {
+                _ = try await providerEngine.streamChatCompletion(request: request)
+                Issue.record("expected forced multimodal tool choice rejection")
+            } catch let error as MultiModelBatchSchedulerEngineError {
+                #expect(error == .invalidToolPayload(
+                    "inference-enforced tool_choice is not supported for multimodal requests"))
+            }
+        }
+        #expect(engine.submitted.isEmpty)
+    }
+
+    @Test("tool choice none is admitted on the multimodal path")
+    func noneToolChoiceIsAdmittedForMultimodalRequest() async throws {
+        let engine = WiringScriptedEngine(script: .stream([]))
+        let bridge = makeBridge(engine: engine)
+        let providerEngine = MultiModelBatchSchedulerEngine(
+            registryProvider: { @Sendable in
+                [
+                    "gemma-4-26b-qat-4bit": .init(
+                        tokenizer: TokenizerHandle(WiringStubTokenizer()),
+                        modelType: "gemma4",
+                        container: makeStubContainer(),
+                        isVLM: true,
+                        engineV2Bridge: bridge)
+                ]
+            })
         let request = OpenAIChatCompletionRequest(
             model: "gemma-4-26b-qat-4bit",
             messages: [.init(
                 role: .user,
-                content: .parts([.text("describe"), .imageURL("data:image/png;base64,AA==")]))],
+                content: .parts([
+                    .text("describe"),
+                    .imageURL("data:image/png;base64,AA=="),
+                ]))],
             tools: [.init(function: .init(name: "calculate"))],
-            toolChoice: .mode(.required))
+            toolChoice: .mode(.none))
 
+        // `none` hides the tools from the prompt and is enforced after
+        // generation, so the media path constrains nothing and must admit it.
+        // The request gets far enough to decode the (deliberately truncated)
+        // PNG payload, which is exactly the step past the tool-choice guard.
         do {
             _ = try await providerEngine.streamChatCompletion(request: request)
-            Issue.record("expected forced multimodal tool choice rejection")
-        } catch let error as MultiModelBatchSchedulerEngineError {
-            #expect(error == .invalidToolPayload(
-                "inference-enforced tool_choice is not supported for multimodal requests"))
+            Issue.record("expected the stub media payload to fail decoding")
+        } catch let error as MediaIngest.MediaError {
+            #expect(error.description == "failed to decode image data into a CIImage")
         }
-        #expect(engine.submitted.isEmpty)
     }
 
     @Test("coordinator path threads cacheScope and logprobs plumbing into the bridge")

--- a/provider-swift/Tests/ProviderCoreTests/GemmaToolConstraintTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/GemmaToolConstraintTests.swift
@@ -1045,6 +1045,10 @@ struct GemmaToolConstraintTests {
                             "type": .string("integer"), "minimum": .int(10),
                         ]),
                     ]),
+                    // Sibling render type pins the REAL wire shape: the
+                    // normalizer injects the FIRST branch's type so templates
+                    // can subscript `value['type']`.
+                    "type": .string("string"),
                 ]),
             ]),
             "required": .array([.string("value")]),
@@ -1081,8 +1085,273 @@ struct GemmaToolConstraintTests {
         }
     }
 
-    @Test("auto admits dependentSchemas while required stays fail-closed")
-    func dependentSchemasAreAdmittedUnderAuto() throws {
+    @Test("auto leaves $ref-bearing nodes entirely unasserted")
+    func autoRefBearingNodeIsNotAsserted() throws {
+        // The normalizer stamps `type: "string"` on $ref-only nodes so
+        // templates can subscript the render type; the validator cannot
+        // resolve the reference, so the injected type must not veto an
+        // emission the REFERENCED schema accepts.
+        let parameters: MLXLMCommon.JSONValue = .object([
+            "type": .string("object"),
+            "properties": .object([
+                "p": .object([
+                    "$ref": .string("#/$defs/P"),
+                    "type": .string("string"),
+                ]),
+            ]),
+            "$defs": .object([
+                "P": .object(["type": .string("object")]),
+            ]),
+        ])
+        let prepared = try ToolChoicePromptPolicy.prepare(
+            request(
+                choice: .mode(.auto),
+                tools: [tool(parameters: parameters)]))
+        #expect(prepared.compiledTools == nil)
+        try ToolConstraintValidation.validate([
+            .init(function: .init(
+                name: "weather",
+                arguments: ["p": .object(["street": .string("Main")])])),
+        ], prepared: prepared)
+    }
+
+    @Test("injected union render type does not veto non-first branches")
+    func autoInjectedUnionRenderTypeDoesNotVetoBranches() throws {
+        // The normalized wire shape: the sibling `type` is the render type
+        // injected from the FIRST union branch.
+        let parameters: MLXLMCommon.JSONValue = .object([
+            "type": .string("object"),
+            "properties": .object([
+                "value": .object([
+                    "anyOf": .array([
+                        .object(["type": .string("string")]),
+                        .object([
+                            "type": .string("integer"), "minimum": .int(10),
+                        ]),
+                    ]),
+                    "type": .string("string"),
+                ]),
+            ]),
+        ])
+        let prepared = try ToolChoicePromptPolicy.prepare(
+            request(
+                choice: .mode(.auto),
+                tools: [tool(parameters: parameters)]))
+        for value: MLXLMCommon.JSONValue in [.string("ok"), .int(11)] {
+            try ToolConstraintValidation.validate([
+                .init(function: .init(
+                    name: "weather", arguments: ["value": value])),
+            ], prepared: prepared)
+        }
+        // Branch assertions still bite: no branch admits 9 or a bool.
+        for value: MLXLMCommon.JSONValue in [.int(9), .bool(true)] {
+            #expect(
+                throws: MultiModelBatchSchedulerEngineError.self, "\(value)"
+            ) {
+                try ToolConstraintValidation.validate([
+                    .init(function: .init(
+                        name: "weather", arguments: ["value": value])),
+                ], prepared: prepared)
+            }
+        }
+    }
+
+    @Test("normalized mixed-type enum accepts every member")
+    func autoNormalizedMixedEnumAcceptsEveryMember() throws {
+        // A typeless {"enum":["a",1]} gets render type "string" injected
+        // from its first member; finite-value identity subsumes typing.
+        let parameters: MLXLMCommon.JSONValue = .object([
+            "type": .string("object"),
+            "properties": .object([
+                "value": .object([
+                    "enum": .array([.string("a"), .int(1)]),
+                    "type": .string("string"),
+                ]),
+            ]),
+        ])
+        let prepared = try ToolChoicePromptPolicy.prepare(
+            request(
+                choice: .mode(.auto),
+                tools: [tool(parameters: parameters)]))
+        for value: MLXLMCommon.JSONValue in [.string("a"), .int(1)] {
+            try ToolConstraintValidation.validate([
+                .init(function: .init(
+                    name: "weather", arguments: ["value": value])),
+            ], prepared: prepared)
+        }
+        for value: MLXLMCommon.JSONValue in [.int(2), .string("b")] {
+            #expect(
+                throws: MultiModelBatchSchedulerEngineError.self, "\(value)"
+            ) {
+                try ToolConstraintValidation.validate([
+                    .init(function: .init(
+                        name: "weather", arguments: ["value": value])),
+                ], prepared: prepared)
+            }
+        }
+    }
+
+    @Test("auto enforces if/then/else")
+    func autoIfThenElseIsEnforced() throws {
+        let parameters: MLXLMCommon.JSONValue = .object([
+            "type": .string("object"),
+            "properties": .object([
+                "credit_card": .object(["type": .string("string")]),
+                "billing_address": .object(["type": .string("string")]),
+            ]),
+            "if": .object(["required": .array([.string("credit_card")])]),
+            "then": .object([
+                "required": .array([.string("billing_address")]),
+            ]),
+        ])
+        let prepared = try ToolChoicePromptPolicy.prepare(
+            request(
+                choice: .mode(.auto),
+                tools: [tool(parameters: parameters)]))
+        #expect(throws: MultiModelBatchSchedulerEngineError.self) {
+            try ToolConstraintValidation.validate([
+                .init(function: .init(
+                    name: "weather",
+                    arguments: ["credit_card": .string("4111")])),
+            ], prepared: prepared)
+        }
+        try ToolConstraintValidation.validate([
+            .init(function: .init(
+                name: "weather",
+                arguments: [
+                    "credit_card": .string("4111"),
+                    "billing_address": .string("1 Main St"),
+                ])),
+        ], prepared: prepared)
+        try ToolConstraintValidation.validate([
+            .init(function: .init(name: "weather", arguments: [:])),
+        ], prepared: prepared)
+
+        let withElse: MLXLMCommon.JSONValue = .object([
+            "type": .string("object"),
+            "properties": .object([
+                "card": .object(["type": .string("string")]),
+                "cash": .object(["type": .string("string")]),
+            ]),
+            "if": .object(["required": .array([.string("card")])]),
+            "else": .object(["required": .array([.string("cash")])]),
+        ])
+        let preparedElse = try ToolChoicePromptPolicy.prepare(
+            request(
+                choice: .mode(.auto),
+                tools: [tool(parameters: withElse)]))
+        try ToolConstraintValidation.validate([
+            .init(function: .init(
+                name: "weather", arguments: ["card": .string("visa")])),
+        ], prepared: preparedElse)
+        try ToolConstraintValidation.validate([
+            .init(function: .init(
+                name: "weather", arguments: ["cash": .string("20")])),
+        ], prepared: preparedElse)
+        #expect(throws: MultiModelBatchSchedulerEngineError.self) {
+            try ToolConstraintValidation.validate([
+                .init(function: .init(name: "weather", arguments: [:])),
+            ], prepared: preparedElse)
+        }
+    }
+
+    @Test("auto enforces dependentRequired")
+    func autoDependentRequiredIsEnforced() throws {
+        let parameters: MLXLMCommon.JSONValue = .object([
+            "type": .string("object"),
+            "properties": .object([
+                "credit_card": .object(["type": .string("string")]),
+                "billing_address": .object(["type": .string("string")]),
+            ]),
+            "dependentRequired": .object([
+                "credit_card": .array([.string("billing_address")]),
+            ]),
+        ])
+        let prepared = try ToolChoicePromptPolicy.prepare(
+            request(
+                choice: .mode(.auto),
+                tools: [tool(parameters: parameters)]))
+        #expect(throws: MultiModelBatchSchedulerEngineError.self) {
+            try ToolConstraintValidation.validate([
+                .init(function: .init(
+                    name: "weather",
+                    arguments: ["credit_card": .string("4111")])),
+            ], prepared: prepared)
+        }
+        try ToolConstraintValidation.validate([
+            .init(function: .init(
+                name: "weather",
+                arguments: [
+                    "credit_card": .string("4111"),
+                    "billing_address": .string("1 Main St"),
+                ])),
+        ], prepared: prepared)
+        try ToolConstraintValidation.validate([
+            .init(function: .init(name: "weather", arguments: [:])),
+        ], prepared: prepared)
+    }
+
+    @Test("auto propertyNames enforces literal-safe assertions on keys")
+    func autoPropertyNamesMaxLengthRejectsLongKey() throws {
+        let parameters: MLXLMCommon.JSONValue = .object([
+            "type": .string("object"),
+            "propertyNames": .object(["maxLength": .int(3)]),
+            "additionalProperties": .bool(true),
+        ])
+        let prepared = try ToolChoicePromptPolicy.prepare(
+            request(
+                choice: .mode(.auto),
+                tools: [tool(parameters: parameters)]))
+        try ToolConstraintValidation.validate([
+            .init(function: .init(
+                name: "weather", arguments: ["abc": .int(1)])),
+        ], prepared: prepared)
+        #expect(throws: MultiModelBatchSchedulerEngineError.self) {
+            try ToolConstraintValidation.validate([
+                .init(function: .init(
+                    name: "weather", arguments: ["toolong": .int(1)])),
+            ], prepared: prepared)
+        }
+    }
+
+    @Test("allOf does not suppress the sibling type assertion")
+    func autoAllOfDoesNotSuppressSiblingType() throws {
+        // allOf branches are conjunctive, so a render type derived from
+        // branch one is implied by the conjunction; no exemption applies.
+        for branch: MLXLMCommon.JSONValue in [
+            .object(["type": .string("string")]),
+            .object(["minimum": .int(0)]),
+        ] {
+            let parameters: MLXLMCommon.JSONValue = .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "value": .object([
+                        "allOf": .array([branch]),
+                        "type": .string("string"),
+                    ]),
+                ]),
+            ])
+            let prepared = try ToolChoicePromptPolicy.prepare(
+                request(
+                    choice: .mode(.auto),
+                    tools: [tool(parameters: parameters)]))
+            try ToolConstraintValidation.validate([
+                .init(function: .init(
+                    name: "weather", arguments: ["value": .string("ok")])),
+            ], prepared: prepared)
+            #expect(
+                throws: MultiModelBatchSchedulerEngineError.self, "\(branch)"
+            ) {
+                try ToolConstraintValidation.validate([
+                    .init(function: .init(
+                        name: "weather", arguments: ["value": .int(5)])),
+                ], prepared: prepared)
+            }
+        }
+    }
+
+    @Test("auto enforces dependentSchemas while required stays fail-closed")
+    func dependentSchemasAreEnforcedUnderAuto() throws {
         let parameters: MLXLMCommon.JSONValue = .object([
             "type": .string("object"),
             "properties": .object([
@@ -1100,10 +1369,20 @@ struct GemmaToolConstraintTests {
                 choice: .mode(.auto),
                 tools: [tool(parameters: parameters)]))
         #expect(prepared.compiledTools == nil)
+        #expect(throws: MultiModelBatchSchedulerEngineError.self) {
+            try ToolConstraintValidation.validate([
+                .init(function: .init(
+                    name: "weather",
+                    arguments: ["credit_card": .string("4111")])),
+            ], prepared: prepared)
+        }
         try ToolConstraintValidation.validate([
             .init(function: .init(
                 name: "weather",
-                arguments: ["credit_card": .string("4111")])),
+                arguments: [
+                    "credit_card": .string("4111"),
+                    "billing_address": .string("1 Main St"),
+                ])),
         ], prepared: prepared)
         #expect(throws: MultiModelBatchSchedulerEngineError.self) {
             _ = try ToolChoicePromptPolicy.prepare(
@@ -1113,8 +1392,8 @@ struct GemmaToolConstraintTests {
         }
     }
 
-    @Test("auto admits propertyNames while required stays fail-closed")
-    func propertyNamesIsAdmittedUnderAuto() throws {
+    @Test("auto enforces propertyNames while required stays fail-closed")
+    func propertyNamesIsEnforcedUnderAuto() throws {
         let parameters: MLXLMCommon.JSONValue = .object([
             "type": .string("object"),
             "propertyNames": .object([
@@ -1129,8 +1408,14 @@ struct GemmaToolConstraintTests {
         #expect(prepared.compiledTools == nil)
         try ToolConstraintValidation.validate([
             .init(function: .init(
-                name: "weather", arguments: ["anything": .int(1)])),
+                name: "weather", arguments: ["allowed": .int(1)])),
         ], prepared: prepared)
+        #expect(throws: MultiModelBatchSchedulerEngineError.self) {
+            try ToolConstraintValidation.validate([
+                .init(function: .init(
+                    name: "weather", arguments: ["anything": .int(1)])),
+            ], prepared: prepared)
+        }
         #expect(throws: MultiModelBatchSchedulerEngineError.self) {
             _ = try ToolChoicePromptPolicy.prepare(
                 request(
@@ -1193,25 +1478,46 @@ struct GemmaToolConstraintTests {
         }
     }
 
-    @Test("reserved-metadata walk is depth-bounded and never rejects on depth")
-    func reservedMetadataWalkIsDepthBounded() throws {
-        var items: MLXLMCommon.JSONValue = .object([
+    @Test("reserved-metadata walk fails closed beyond its depth bound")
+    func reservedMetadataWalkFailsClosedBeyondBound() throws {
+        // Within the bound, nesting depth alone is not forgery.
+        var shallow: MLXLMCommon.JSONValue = .object([
             "type": .string("string"),
             "pattern": .string("^city$"),
         ])
-        for _ in 0 ..< 40 {
-            items = .array([items])
+        for _ in 0 ..< 20 {
+            shallow = .array([shallow])
         }
-        // Nesting depth alone is not forgery: the bounded walk stops
-        // descending instead of rejecting.
         _ = try ToolChoicePromptPolicy.prepare(
             request(
                 choice: .mode(.auto),
                 tools: [tool(parameters: .object([
                     "type": .string("array"),
-                    "items": items,
+                    "items": shallow,
                 ]))]),
             allowInternalSchemaMetadata: false)
+
+        // Beyond the bound the guard rejects rather than vouching for
+        // content it never scanned: the normalizer's marker-folding walk is
+        // depth-unbounded, so a forged marker below the guard's horizon
+        // would otherwise fold upward into vouched shallow metadata.
+        var forged: MLXLMCommon.JSONValue = .object([
+            "type": .string("string"),
+            ToolSchemaNormalization.originalBooleanSchemaKey: .bool(true),
+        ])
+        for _ in 0 ..< 40 {
+            forged = .array([forged])
+        }
+        #expect(throws: MultiModelBatchSchedulerEngineError.self) {
+            _ = try ToolChoicePromptPolicy.prepare(
+                request(
+                    choice: .mode(.auto),
+                    tools: [tool(parameters: .object([
+                        "type": .string("array"),
+                        "items": forged,
+                    ]))]),
+                allowInternalSchemaMetadata: false)
+        }
 
         // A marker inside the bound is still forgery.
         var nested: MLXLMCommon.JSONValue = .object([

--- a/provider-swift/Tests/ProviderCoreTests/GemmaToolConstraintTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/GemmaToolConstraintTests.swift
@@ -334,6 +334,65 @@ struct GemmaToolConstraintTests {
         #expect(rejected)
     }
 
+    @Test("tool_choice none needs no sampler grammar off the Gemma contract")
+    func noneDoesNotRequireGemmaContract() throws {
+        let noneRequest = request(choice: .mode(.none))
+        let nonePrepared = try ToolChoicePromptPolicy.prepare(noneRequest)
+        // `none` is honored by hiding the tools plus post-generation
+        // rejection, so no automaton is needed off the pinned contract.
+        #expect(nonePrepared.tools == nil)
+        let offContract = try ToolConstraintFactory.make(
+            prepared: nonePrepared,
+            request: noneRequest,
+            tokenizer: tokenizer,
+            modelContext: .init(modelId: "llama-3-test", modelType: "llama"),
+            defaultMaxTokens: 128,
+            stopTokenIDs: [128])
+        #expect(offContract == nil)
+        let unverified = try ToolConstraintFactory.make(
+            prepared: nonePrepared,
+            request: noneRequest,
+            tokenizer: TokenizerHandle(ASCIIConstraintTokenizer()),
+            modelContext: .init(
+                modelId: noneRequest.model, modelType: "gemma4_text"),
+            defaultMaxTokens: 128,
+            stopTokenIDs: [128])
+        #expect(unverified == nil)
+        #expect(throws: MultiModelBatchSchedulerEngineError.self) {
+            try ToolConstraintValidation.validate([
+                .init(function: .init(
+                    name: "weather", arguments: ["city": .string("Paris")])),
+            ], prepared: nonePrepared)
+        }
+
+        // Grammar-compiled modes stay fail-closed off the contract.
+        for choice in [OpenAIToolChoice.mode(.required), .function(name: "weather")] {
+            let forced = request(choice: choice)
+            let prepared = try ToolChoicePromptPolicy.prepare(forced)
+            #expect(throws: MultiModelBatchSchedulerEngineError.self, "\(choice)") {
+                _ = try ToolConstraintFactory.make(
+                    prepared: prepared,
+                    request: forced,
+                    tokenizer: self.tokenizer,
+                    modelContext: .init(
+                        modelId: "llama-3-test", modelType: "llama"),
+                    defaultMaxTokens: 128,
+                    stopTokenIDs: [128])
+            }
+        }
+
+        // A Gemma-capable model keeps the real no-tool automaton.
+        let onContract = try ToolConstraintFactory.make(
+            prepared: nonePrepared,
+            request: noneRequest,
+            tokenizer: tokenizer,
+            modelContext: .init(
+                modelId: noneRequest.model, modelType: "gemma4_text"),
+            defaultMaxTokens: 128,
+            stopTokenIDs: [128])
+        #expect(onContract is GemmaNoToolTokenConstraint)
+    }
+
     @Test("unsupported constrained schema fails before engine submission")
     func unsupportedSchemaFailsClosed() {
         let unsupported: MLXLMCommon.JSONValue = .object([
@@ -740,8 +799,8 @@ struct GemmaToolConstraintTests {
         }
     }
 
-    @Test("auto finite decimals fail before rounded identity comparison")
-    func autoFiniteDecimalsAreRejected() throws {
+    @Test("auto admits finite decimal enums and enforces them post-generation")
+    func autoFiniteDecimalsAreAdmitted() throws {
         let body = """
             {
               "model":"gemma-4-test",
@@ -761,8 +820,21 @@ struct GemmaToolConstraintTests {
         let decoded = try JSONDecoder().decode(
             OpenAIChatCompletionRequest.self,
             from: Data(body.utf8))
+        // `auto` compiles no grammar, so exact-render feasibility is
+        // irrelevant: the decimal enum survives to the post-generation
+        // validator, which compares JSON numbers mathematically.
+        let prepared = try ToolChoicePromptPolicy.prepare(decoded)
+        #expect(prepared.compiledTools == nil)
+        try ToolConstraintValidation.validate([
+            .init(function: .init(
+                name: "calculate",
+                arguments: ["value": .double(0.10000000000000001)])),
+        ], prepared: prepared)
         #expect(throws: MultiModelBatchSchedulerEngineError.self) {
-            _ = try ToolChoicePromptPolicy.prepare(decoded)
+            try ToolConstraintValidation.validate([
+                .init(function: .init(
+                    name: "calculate", arguments: ["value": .double(0.5)])),
+            ], prepared: prepared)
         }
     }
 
@@ -817,6 +889,10 @@ struct GemmaToolConstraintTests {
             ], prepared: broadPrepared)
         }
 
+        // An unevaluatable regex must not reject. `auto` no longer pre-screens
+        // schemas, so `patternProperties` the validator cannot decide goes
+        // unenforced — and the `additionalProperties: false` fallback goes with
+        // it, because the property might have matched the undecided pattern.
         let unsafePatternSchema: MLXLMCommon.JSONValue = .object([
             "type": .string("object"),
             "patternProperties": .object([
@@ -824,36 +900,60 @@ struct GemmaToolConstraintTests {
             ]),
             "additionalProperties": .bool(false),
         ])
-        #expect(throws: MultiModelBatchSchedulerEngineError.self) {
-            _ = try ToolChoicePromptPolicy.prepare(
-                request(
-                    choice: .mode(.auto),
-                    tools: [tool(parameters: unsafePatternSchema)],
-                    parallel: false))
+        let unsafePrepared = try ToolChoicePromptPolicy.prepare(
+            request(
+                choice: .mode(.auto),
+                tools: [tool(parameters: unsafePatternSchema)],
+                parallel: false))
+        #expect(unsafePrepared.compiledTools == nil)
+        for name in ["aaa", "zzz"] {
+            try ToolConstraintValidation.validate([
+                .init(function: .init(
+                    name: "weather", arguments: [name: .string("ok")])),
+            ], prepared: unsafePrepared)
         }
     }
 
-    @Test("unsupported auto regex fails before inference")
-    func unsupportedAutoRegexFailsDuringPreparation() {
+    @Test("auto does not assert a regex the validator cannot evaluate")
+    func unevaluatableAutoRegexIsNotAsserted() throws {
         let parameters: MLXLMCommon.JSONValue = .object([
             "type": .string("object"),
             "properties": .object([
                 "code": .object([
                     "type": .string("string"),
                     "pattern": .string("^[a-z]+$"),
+                    "minLength": .int(2),
                 ]),
             ]),
         ])
-        #expect(throws: MultiModelBatchSchedulerEngineError.self) {
-            _ = try ToolChoicePromptPolicy.prepare(
-                request(
-                    choice: .mode(.auto),
-                    tools: [tool(parameters: parameters)]))
+        let prepared = try ToolChoicePromptPolicy.prepare(
+            request(
+                choice: .mode(.auto),
+                tools: [tool(parameters: parameters)]))
+        #expect(prepared.compiledTools == nil)
+        // The literal-pattern subset cannot decide a character class, and an
+        // undecided assertion is NOT asserted — never a failure.
+        for value in ["abc", "ABC-123"] {
+            try ToolConstraintValidation.validate([
+                .init(function: .init(
+                    name: "weather", arguments: ["code": .string(value)])),
+            ], prepared: prepared)
+        }
+        // Decidable assertions on the same node still bite.
+        for invalid: MLXLMCommon.JSONValue in [.string("a"), .int(7)] {
+            #expect(
+                throws: MultiModelBatchSchedulerEngineError.self, "\(invalid)"
+            ) {
+                try ToolConstraintValidation.validate([
+                    .init(function: .init(
+                        name: "weather", arguments: ["code": invalid])),
+                ], prepared: prepared)
+            }
         }
     }
 
-    @Test("unsupported auto semantics fail before inference")
-    func unsupportedAutoSemanticsFailDuringPreparation() {
+    @Test("auto admits every standard JSON-Schema construct unchanged")
+    func standardAutoSchemasPrepareSuccessfully() throws {
         let schemas: [MLXLMCommon.JSONValue] = [
             .object([
                 "type": .array([.string("string"), .string("integer")]),
@@ -918,17 +1018,71 @@ struct GemmaToolConstraintTests {
                 "type": .string("object"),
                 "properties": .object(["value": schema]),
             ])
-            #expect(throws: MultiModelBatchSchedulerEngineError.self) {
-                _ = try ToolChoicePromptPolicy.prepare(
-                    request(
-                        choice: .mode(.auto),
-                        tools: [tool(parameters: parameters)]))
-            }
+            let prepared = try ToolChoicePromptPolicy.prepare(
+                request(
+                    choice: .mode(.auto),
+                    tools: [tool(parameters: parameters)]))
+            // `auto` has no grammar, so the schema must reach the
+            // post-generation validator byte-for-byte.
+            #expect(
+                prepared.tools?.first?.function.parameters == parameters,
+                "\(schema)")
+            #expect(prepared.compiledTools == nil, "\(schema)")
         }
     }
 
-    @Test("dependent schemas fail before invalid tool calls can pass")
-    func dependentSchemasFailBeforeInference() {
+    @Test("auto validates multi-type anyOf branches post-generation")
+    func autoMultiTypeAnyOfValidatesEitherBranch() throws {
+        let parameters: MLXLMCommon.JSONValue = .object([
+            "type": .string("object"),
+            "properties": .object([
+                "value": .object([
+                    "anyOf": .array([
+                        .object([
+                            "type": .string("string"), "minLength": .int(2),
+                        ]),
+                        .object([
+                            "type": .string("integer"), "minimum": .int(10),
+                        ]),
+                    ]),
+                ]),
+            ]),
+            "required": .array([.string("value")]),
+            "additionalProperties": .bool(false),
+        ])
+        let prepared = try ToolChoicePromptPolicy.prepare(
+            request(
+                choice: .mode(.auto),
+                tools: [tool(parameters: parameters)]))
+        #expect(prepared.compiledTools == nil)
+        for value: MLXLMCommon.JSONValue in [.string("ok"), .int(11)] {
+            try ToolConstraintValidation.validate([
+                .init(function: .init(
+                    name: "weather", arguments: ["value": value])),
+            ], prepared: prepared)
+        }
+        for value: MLXLMCommon.JSONValue in [.string("x"), .int(9), .bool(true)] {
+            #expect(
+                throws: MultiModelBatchSchedulerEngineError.self, "\(value)"
+            ) {
+                try ToolConstraintValidation.validate([
+                    .init(function: .init(
+                        name: "weather", arguments: ["value": value])),
+                ], prepared: prepared)
+            }
+        }
+        // `required` still compiles a real grammar and still fails closed on
+        // the multi-type union.
+        #expect(throws: MultiModelBatchSchedulerEngineError.self) {
+            _ = try ToolChoicePromptPolicy.prepare(
+                request(
+                    choice: .mode(.required),
+                    tools: [tool(parameters: parameters)]))
+        }
+    }
+
+    @Test("auto admits dependentSchemas while required stays fail-closed")
+    func dependentSchemasAreAdmittedUnderAuto() throws {
         let parameters: MLXLMCommon.JSONValue = .object([
             "type": .string("object"),
             "properties": .object([
@@ -941,16 +1095,26 @@ struct GemmaToolConstraintTests {
                 ]),
             ]),
         ])
+        let prepared = try ToolChoicePromptPolicy.prepare(
+            request(
+                choice: .mode(.auto),
+                tools: [tool(parameters: parameters)]))
+        #expect(prepared.compiledTools == nil)
+        try ToolConstraintValidation.validate([
+            .init(function: .init(
+                name: "weather",
+                arguments: ["credit_card": .string("4111")])),
+        ], prepared: prepared)
         #expect(throws: MultiModelBatchSchedulerEngineError.self) {
             _ = try ToolChoicePromptPolicy.prepare(
                 request(
-                    choice: .mode(.auto),
+                    choice: .mode(.required),
                     tools: [tool(parameters: parameters)]))
         }
     }
 
-    @Test("propertyNames fails before invalid tool calls can pass")
-    func propertyNamesFailsBeforeInference() {
+    @Test("auto admits propertyNames while required stays fail-closed")
+    func propertyNamesIsAdmittedUnderAuto() throws {
         let parameters: MLXLMCommon.JSONValue = .object([
             "type": .string("object"),
             "propertyNames": .object([
@@ -958,10 +1122,19 @@ struct GemmaToolConstraintTests {
             ]),
             "additionalProperties": .bool(true),
         ])
+        let prepared = try ToolChoicePromptPolicy.prepare(
+            request(
+                choice: .mode(.auto),
+                tools: [tool(parameters: parameters)]))
+        #expect(prepared.compiledTools == nil)
+        try ToolConstraintValidation.validate([
+            .init(function: .init(
+                name: "weather", arguments: ["anything": .int(1)])),
+        ], prepared: prepared)
         #expect(throws: MultiModelBatchSchedulerEngineError.self) {
             _ = try ToolChoicePromptPolicy.prepare(
                 request(
-                    choice: .mode(.auto),
+                    choice: .mode(.required),
                     tools: [tool(parameters: parameters)]))
         }
     }
@@ -1004,36 +1177,24 @@ struct GemmaToolConstraintTests {
                 ]),
             ]),
         ])
-        _ = try ToolChoicePromptPolicy.prepare(
+        let prepared = try ToolChoicePromptPolicy.prepare(
             request(
                 choice: .mode(.auto),
                 tools: [tool(parameters: parameters)]))
-    }
-
-    @Test("auto pattern depth does not count tuple containers")
-    func autoPatternTupleContainerDepth() throws {
-        var item: MLXLMCommon.JSONValue = .object([
-            "type": .string("string"),
-            "pattern": .string("^city$"),
-        ])
-        for _ in 0 ..< 17 {
-            item = .object([
-                "type": .string("array"),
-                "items": .array([item]),
-            ])
+        try ToolConstraintValidation.validate([
+            .init(function: .init(
+                name: "weather", arguments: ["pattern": .string("city")])),
+        ], prepared: prepared)
+        #expect(throws: MultiModelBatchSchedulerEngineError.self) {
+            try ToolConstraintValidation.validate([
+                .init(function: .init(
+                    name: "weather", arguments: ["pattern": .string("other")])),
+            ], prepared: prepared)
         }
-        let parameters: MLXLMCommon.JSONValue = .object([
-            "type": .string("object"),
-            "properties": .object(["value": item]),
-        ])
-        _ = try ToolChoicePromptPolicy.prepare(
-            request(
-                choice: .mode(.auto),
-                tools: [tool(parameters: parameters)]))
     }
 
-    @Test("auto pattern depth bounds malformed nested tuple arrays")
-    func autoPatternMalformedTupleDepthIsBounded() {
+    @Test("reserved-metadata walk is depth-bounded and never rejects on depth")
+    func reservedMetadataWalkIsDepthBounded() throws {
         var items: MLXLMCommon.JSONValue = .object([
             "type": .string("string"),
             "pattern": .string("^city$"),
@@ -1041,15 +1202,37 @@ struct GemmaToolConstraintTests {
         for _ in 0 ..< 40 {
             items = .array([items])
         }
-        let parameters: MLXLMCommon.JSONValue = .object([
-            "type": .string("array"),
-            "items": items,
+        // Nesting depth alone is not forgery: the bounded walk stops
+        // descending instead of rejecting.
+        _ = try ToolChoicePromptPolicy.prepare(
+            request(
+                choice: .mode(.auto),
+                tools: [tool(parameters: .object([
+                    "type": .string("array"),
+                    "items": items,
+                ]))]),
+            allowInternalSchemaMetadata: false)
+
+        // A marker inside the bound is still forgery.
+        var nested: MLXLMCommon.JSONValue = .object([
+            "type": .string("string"),
+            ToolSchemaNormalization.originalBooleanSchemaKey: .bool(true),
         ])
+        for _ in 0 ..< 4 {
+            nested = .object([
+                "type": .string("array"),
+                "items": nested,
+            ])
+        }
         #expect(throws: MultiModelBatchSchedulerEngineError.self) {
             _ = try ToolChoicePromptPolicy.prepare(
                 request(
                     choice: .mode(.auto),
-                    tools: [tool(parameters: parameters)]))
+                    tools: [tool(parameters: .object([
+                        "type": .string("object"),
+                        "properties": .object(["value": nested]),
+                    ]))]),
+                allowInternalSchemaMetadata: false)
         }
     }
 

--- a/provider-swift/Tests/ProviderCoreTests/GemmaToolConstraintTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/GemmaToolConstraintTests.swift
@@ -1085,12 +1085,14 @@ struct GemmaToolConstraintTests {
         }
     }
 
-    @Test("auto leaves $ref-bearing nodes entirely unasserted")
-    func autoRefBearingNodeIsNotAsserted() throws {
+    @Test("auto: $ref suppresses only the injected type, not author siblings")
+    func autoRefBearingNodeEnforcesAuthorSiblings() throws {
         // The normalizer stamps `type: "string"` on $ref-only nodes so
         // templates can subscript the render type; the validator cannot
-        // resolve the reference, so the injected type must not veto an
-        // emission the REFERENCED schema accepts.
+        // resolve the reference, so that injected type must not veto an
+        // emission the REFERENCED schema accepts. Author-written siblings
+        // are conjunctive with the reference (draft 2019-09+) and stay
+        // enforced — a $ref beside a const must not disable the const.
         let parameters: MLXLMCommon.JSONValue = .object([
             "type": .string("object"),
             "properties": .object([
@@ -1098,9 +1100,15 @@ struct GemmaToolConstraintTests {
                     "$ref": .string("#/$defs/P"),
                     "type": .string("string"),
                 ]),
+                "mode": .object([
+                    "$ref": .string("#/$defs/M"),
+                    "enum": .array([.string("fast"), .string("safe")]),
+                    "type": .string("string"),
+                ]),
             ]),
             "$defs": .object([
                 "P": .object(["type": .string("object")]),
+                "M": .object(["type": .string("string")]),
             ]),
         ])
         let prepared = try ToolChoicePromptPolicy.prepare(
@@ -1108,11 +1116,26 @@ struct GemmaToolConstraintTests {
                 choice: .mode(.auto),
                 tools: [tool(parameters: parameters)]))
         #expect(prepared.compiledTools == nil)
+        // Injected type suppressed: an object emission for `p` passes.
         try ToolConstraintValidation.validate([
             .init(function: .init(
                 name: "weather",
-                arguments: ["p": .object(["street": .string("Main")])])),
+                arguments: [
+                    "p": .object(["street": .string("Main")]),
+                    "mode": .string("fast"),
+                ])),
         ], prepared: prepared)
+        // Author enum beside the $ref still bites.
+        #expect(throws: MultiModelBatchSchedulerEngineError.self) {
+            try ToolConstraintValidation.validate([
+                .init(function: .init(
+                    name: "weather",
+                    arguments: [
+                        "p": .string("ok"),
+                        "mode": .string("reckless"),
+                    ])),
+            ], prepared: prepared)
+        }
     }
 
     @Test("injected union render type does not veto non-first branches")

--- a/provider-swift/Tests/ProviderCoreTests/ToolSchemaNormalizationTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ToolSchemaNormalizationTests.swift
@@ -166,6 +166,9 @@ extension ToolSchemaNormalizationTests {
         #expect(city["type"] as? String == "string")
         // Nullability preserved losslessly via the template-supported key.
         #expect(city["nullable"] as? Bool == true)
+        // The nullable pair has ONE concrete member — no union to preserve,
+        // so no anyOf is synthesized (the parity corpus pins this shape).
+        #expect(city["anyOf"] == nil)
     }
 
     @Test func nullableUnionOverridesExplicitFalse() throws {
@@ -310,5 +313,109 @@ extension ToolSchemaNormalizationTests {
         let addl = try #require((props["kv"] as? [String: Any])?["additionalProperties"] as? [String: Any])
         #expect(addl["type"] as? String == "number")
         #expect(addl["nullable"] as? Bool == true)
+    }
+
+    private func anyOfTypes(_ node: [String: Any]) -> [String]? {
+        (node["anyOf"] as? [[String: Any]])?.compactMap { member in
+            member.count == 1 ? member["type"] as? String : nil
+        }
+    }
+
+    // Go: TestNormalizeToolSchemas_MultiConcreteTypeArrayPreservedViaAnyOf
+    @Test func multiConcreteTypeArrayPreservedViaAnyOf() throws {
+        let body = #"""
+        {"tools":[{"type":"function","function":{"name":"f",
+          "parameters":{"type":"object","properties":{
+            "id":{"type":["string","integer"]}}}}}]}
+        """#.data(using: .utf8)!
+
+        let props = try #require(
+            toolParams(ToolSchemaNormalization.ensureParameterTypes(in: body))["properties"]
+                as? [String: Any])
+        let id = try #require(props["id"] as? [String: Any])
+        #expect(id["type"] as? String == "string")
+        #expect(anyOfTypes(id) == ["string", "integer"])
+        #expect(id["nullable"] == nil)
+    }
+
+    // Go: TestNormalizeToolSchemas_MultiConcreteNullableTypeArrayKeepsNullAndUnion
+    @Test func multiConcreteNullableTypeArrayKeepsNullAndUnion() throws {
+        let body = #"""
+        {"tools":[{"type":"function","function":{"name":"f",
+          "parameters":{"type":"object","properties":{
+            "id":{"type":["integer","string","null"]}}}}}]}
+        """#.data(using: .utf8)!
+
+        let props = try #require(
+            toolParams(ToolSchemaNormalization.ensureParameterTypes(in: body))["properties"]
+                as? [String: Any])
+        let id = try #require(props["id"] as? [String: Any])
+        #expect(id["type"] as? String == "integer")
+        #expect(id["nullable"] as? Bool == true)
+        // The null member rides the nullable side-channel, never the union.
+        #expect(anyOfTypes(id) == ["integer", "string"])
+    }
+
+    // Go: TestNormalizeToolSchemas_MultiConcreteTypeArrayWithExistingCombinatorCollapsesOnly
+    @Test func multiConcreteTypeArrayWithExistingCombinatorCollapsesOnly() throws {
+        let body = #"""
+        {"tools":[{"type":"function","function":{"name":"f",
+          "parameters":{"type":"object","properties":{
+            "v":{"type":["string","integer"],"anyOf":[{"minLength":1}]},
+            "w":{"type":["string","integer"],"allOf":[{"minLength":1}]}}}}}]}
+        """#.data(using: .utf8)!
+
+        let props = try #require(
+            toolParams(ToolSchemaNormalization.ensureParameterTypes(in: body))["properties"]
+                as? [String: Any])
+        // The author's combinator keeps its written semantics: no second
+        // union is layered on; the authored member survives (type-injected
+        // only) and the type still collapses to the first concrete member.
+        let v = try #require(props["v"] as? [String: Any])
+        #expect(v["type"] as? String == "string")
+        let variants = try #require(v["anyOf"] as? [[String: Any]])
+        #expect(variants.count == 1)
+        #expect(variants.first?["minLength"] as? Int == 1)
+        let w = try #require(props["w"] as? [String: Any])
+        #expect(w["anyOf"] == nil)
+        #expect(w["type"] as? String == "string")
+    }
+
+    // Go: TestNormalizeToolSchemas_DuplicateTypeMembersDedupedCaseInsensitively
+    @Test func duplicateTypeMembersDedupedCaseInsensitively() throws {
+        let body = #"""
+        {"tools":[{"type":"function","function":{"name":"f",
+          "parameters":{"type":"object","properties":{
+            "id":{"type":["string","STRING","integer"]}}}}}]}
+        """#.data(using: .utf8)!
+
+        let props = try #require(
+            toolParams(ToolSchemaNormalization.ensureParameterTypes(in: body))["properties"]
+                as? [String: Any])
+        let id = try #require(props["id"] as? [String: Any])
+        #expect(id["type"] as? String == "string")
+        #expect(anyOfTypes(id) == ["string", "integer"])
+    }
+
+    // Go: TestNormalizeToolSchemas_AllShapesIdempotentAndNumbersSurvive
+    // Rust: multi_concrete_union_injection_is_idempotent
+    @Test func multiConcreteUnionInjectionIsIdempotent() throws {
+        // The rewritten node has a string type (the collapse branch cannot
+        // re-fire) and carries an anyOf (a second union cannot be layered),
+        // so the second pass is a no-op.
+        let body = #"""
+        {"tools":[{"type":"function","function":{"name":"f",
+          "parameters":{"type":"object","properties":{
+            "id":{"type":["string","integer","null"]}}}}}]}
+        """#.data(using: .utf8)!
+
+        let once = ToolSchemaNormalization.ensureParameterTypes(in: body)
+        let twice = ToolSchemaNormalization.ensureParameterTypes(in: once)
+        #expect(parse(once) as NSDictionary == parse(twice) as NSDictionary)
+        let props = try #require(toolParams(once)["properties"] as? [String: Any])
+        let id = try #require(props["id"] as? [String: Any])
+        #expect(id["type"] as? String == "string")
+        #expect(id["nullable"] as? Bool == true)
+        #expect(anyOfTypes(id) == ["string", "integer"])
     }
 }


### PR DESCRIPTION

## Review follow-ups (second commit)

All five Codex findings were verified real and fixed in the follow-up commit:

| Finding | Fix |
|---|---|
| P1 — normalizer-injected render types broke post-generation validation of admitted schemas | Multi-concrete `type` arrays now mirror into `anyOf` in all three normalizers (nullable pairs byte-identical; prompt-parity vectors untouched). Swift validator: `$ref` nodes not-asserted; satisfied `anyOf`/`oneOf` or matched `const`/`enum` suppresses the sibling render type; `allOf` stays conjunctive. |
| P1 — `none` routed to providers that predate tool-hiding | `toolChoiceNonePromptPolicyFloor = "0.7.10"` (tool-hiding shipped in v0.7.10, prod floor is 0.7.5); fail-fast goes through `HasToolCapableProviderForTraits` so a below-floor pool 503s instead of queue-timing-out. |
| P1 — `if/then`, `dependentRequired`, `dependentSchemas`, `propertyNames` silently unenforced | Now enforced post-generation (decidable from the instance alone). `unevaluated*`/`contentSchema` stay not-asserted; comments state the split exactly. |
| P2 — 400 fired for transiently unroutable enforcing fleets | New `HasProviderAdvertisingToolConstraint` (advertisement-only, ignores trust/freshness); 400 requires fleet-serves-model AND zero advertisers; everything else stays 503. |
| P2 — forged marker fold-window at depth 33–63 | Guards scan to the normalizer's own budget (`maxToolSchemaDepth` = 64) and fail closed beyond it, in Go and Swift. |

Re-verified after the follow-ups: Go 24/24 packages (`-count=1`), Rust 78 tests, Swift 1962 tests / 199 suites. Smoke: issue body still clears admission; forged marker at depth 40 → 400; clean depth-40 schema passes; `["string","integer"]` normalizes to `type:"string"` + `anyOf` mirror.
