### PR TITLE
feat(provider): ship Qwen3.6 VLM with inline MTP in v0.8.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,20 @@
 # Changelog
 
-## Unreleased (v0.8.2 candidate — provider)
+## Unreleased (v0.8.3 candidate - provider)
+
+### Provider (Swift)
+
+#### Features
+
+- **Qwen3.6-35B-A3B VLM with inline MTP** - Adds production-path text, image, and tool inference for the combined Qwen artifact. The runtime preserves request-owned recurrent and three-axis mRoPE state, causal vision attention, exact rollback, and source-matched target/assistant memory accounting. MTP remains depth-one, serial, and exact-target-verified; video, prefix reuse, paged KV, compiled decode, packed prefill, and rectangular MTP remain fail-closed.
+
+#### Release Safety
+
+- The model is registered as beta/ready without an alias or active-version promotion. Provider rollout and model promotion remain separate reviewed operations after the signed `v0.8.3` bundle passes a controlled fleet canary.
+
+---
+
+## v0.8.2 (2026-08-10)
 
 ### Provider (Swift)
 

--- a/coordinator/api/server.go
+++ b/coordinator/api/server.go
@@ -151,7 +151,7 @@ func keyLimitResetFromContext(ctx context.Context) string {
 // the provider's EngineV2Factory.prepareProductionBackend for the argument).
 // Keep this fallback in sync with ProviderCore.version so dev/in-memory
 // coordinators advertise the same floor as the Swift binary they expect.
-var LatestProviderVersion = "0.8.2"
+var LatestProviderVersion = "0.8.3"
 
 // minProviderVersionForDesiredModels is the first provider version whose Swift
 // runtime understands the desired_models message. The coordinator must NOT send

--- a/provider-swift/Sources/ProviderBenchmark/ArrivalInvarianceBenchmark.swift
+++ b/provider-swift/Sources/ProviderBenchmark/ArrivalInvarianceBenchmark.swift
@@ -208,6 +208,7 @@ public enum ArrivalInvarianceBenchmark {
         let engineParts = try await makeEngine(
             container: container,
             isVLM: isVLM,
+            modelDirectory: modelDirectory,
             weightBytes: facts.weightBytes,
             maxConcurrentRequests: patterns.map(\.delaysMs.count).max() ?? 1,
             kvBackend: kvBackend
@@ -510,6 +511,7 @@ public enum ArrivalInvarianceBenchmark {
     private static func makeEngine(
         container: ModelContainer,
         isVLM: Bool,
+        modelDirectory: URL,
         weightBytes: Int,
         maxConcurrentRequests: Int,
         kvBackend: EngineV2KVBackendSelection
@@ -529,7 +531,8 @@ public enum ArrivalInvarianceBenchmark {
         return try await container.perform { context -> EngineParts in
             let servingModel = try EngineV2Factory.benchmarkServingModel(
                 model: context.model,
-                isVLM: isVLM
+                isVLM: isVLM,
+                modelDirectory: modelDirectory
             )
             let build = try EngineV2Factory.makeProductionBuild(
                 model: servingModel,

--- a/provider-swift/Sources/ProviderBenchmark/BackendParityHarness.swift
+++ b/provider-swift/Sources/ProviderBenchmark/BackendParityHarness.swift
@@ -128,7 +128,7 @@ public enum BackendParityHarness {
             let seed = ctx.tokenizer.encode(
                 text: ThroughputSweep.seedText, addSpecialTokens: false)
             let servingModel = try EngineV2Factory.benchmarkServingModel(
-                model: ctx.model, isVLM: isVLM)
+                model: ctx.model, isVLM: isVLM, modelDirectory: modelDirectory)
 
             // Both halves of the packed-prefill gate are consulted by the
             // engine loop; only the model half is publicly readable, so read

--- a/provider-swift/Sources/ProviderBenchmark/MTPProductionSession.swift
+++ b/provider-swift/Sources/ProviderBenchmark/MTPProductionSession.swift
@@ -106,7 +106,8 @@ public final class MTPProductionModelBundle: @unchecked Sendable {
             convertTokenToID: { snapshot.tokenizer.convertTokenToId($0) })
         let servingModel = try EngineV2Factory.benchmarkServingModel(
             model: snapshot.model,
-            isVLM: isVLM)
+            isVLM: isVLM,
+            modelDirectory: targetDirectory)
         guard let target = servingModel as? any Gemma4MTPTarget else {
             throw MTPBenchmarkError.mtpRequestedButInactive(
                 "target model \(type(of: servingModel)) is not Gemma4MTPTarget")

--- a/provider-swift/Sources/ProviderBenchmark/SchedulerPrefillBenchmark.swift
+++ b/provider-swift/Sources/ProviderBenchmark/SchedulerPrefillBenchmark.swift
@@ -113,6 +113,7 @@ public enum SchedulerPrefillBenchmark {
             iteration: 0,
             weightBytes: facts.weightBytes,
             isVLM: isVLM,
+            modelDirectory: modelDirectory,
             kvBackend: kvBackend
         )
 
@@ -127,6 +128,7 @@ public enum SchedulerPrefillBenchmark {
                     iteration: iteration,
                     weightBytes: facts.weightBytes,
                     isVLM: isVLM,
+                    modelDirectory: modelDirectory,
                     kvBackend: kvBackend
                 )
                 if !resolved.contains(sample.resolvedKVBackend) {
@@ -160,6 +162,7 @@ public enum SchedulerPrefillBenchmark {
         iteration: Int,
         weightBytes: Int,
         isVLM: Bool,
+        modelDirectory: URL,
         kvBackend: EngineV2KVBackendSelection
     ) async throws -> SchedulerPrefillBenchmarkReport.Sample {
         // Same KV-ceiling derivation as a single-model serving slot; far
@@ -181,7 +184,7 @@ public enum SchedulerPrefillBenchmark {
         // to have been honoured.
         let parts = try await container.perform { ctx -> EngineParts in
             let servingModel = try EngineV2Factory.benchmarkServingModel(
-                model: ctx.model, isVLM: isVLM)
+                model: ctx.model, isVLM: isVLM, modelDirectory: modelDirectory)
             let build = try EngineV2Factory.makeProductionBuild(
                 model: servingModel,
                 tokenizer: ctx.tokenizer,

--- a/provider-swift/Sources/ProviderBenchmark/ThroughputSweep.swift
+++ b/provider-swift/Sources/ProviderBenchmark/ThroughputSweep.swift
@@ -117,6 +117,7 @@ public enum ThroughputSweep {
             iterations: decodeIterations,
             weightBytes: facts.weightBytes,
             isVLM: isVLM,
+            modelDirectory: modelDirectory,
             kvBackend: kvBackend
         )
         let decode = decodeOutcome.samples
@@ -328,6 +329,7 @@ public enum ThroughputSweep {
         iterations: Int,
         weightBytes: Int,
         isVLM: Bool,
+        modelDirectory: URL,
         kvBackend: EngineV2KVBackendSelection
     ) async -> DecodeOutcome {
         let sizes = batchSizes.filter { $0 > 0 }.sorted()
@@ -345,7 +347,7 @@ public enum ThroughputSweep {
         let warmUp = await runDecodeBatch(
             container: container, modelID: modelID, baseTokens: baseTokens,
             batchSize: 1, decodeTokens: 4, promptLen: promptLen, weightBytes: weightBytes,
-            isVLM: isVLM, kvBackend: kvBackend)
+            isVLM: isVLM, modelDirectory: modelDirectory, kvBackend: kvBackend)
         // The warm-up is the FIRST cell to hit a refused paged selection, so
         // it carries the reason even when the sized cells below fail
         // identically. Keep it: an operator should not have to infer the
@@ -357,7 +359,8 @@ public enum ThroughputSweep {
                 let (totalTokens, maxElapsed, resolved, failure, submitFailure) = await runDecodeBatch(
                     container: container, modelID: modelID, baseTokens: baseTokens,
                     batchSize: batchSize, decodeTokens: genTokens, promptLen: promptLen,
-                    weightBytes: weightBytes, isVLM: isVLM, kvBackend: kvBackend)
+                    weightBytes: weightBytes, isVLM: isVLM,
+                    modelDirectory: modelDirectory, kvBackend: kvBackend)
                 if outcome.record(resolved), let resolved {
                     log("  engine resolved kv backend: \(resolved)")
                 }
@@ -418,6 +421,7 @@ public enum ThroughputSweep {
         promptLen: Int,
         weightBytes: Int,
         isVLM: Bool,
+        modelDirectory: URL,
         kvBackend: EngineV2KVBackendSelection
     ) async -> (
         totalTokens: Int, maxElapsed: Duration, resolvedBackend: String?,
@@ -443,7 +447,7 @@ public enum ThroughputSweep {
                 // Serving-model resolution matches production: VLM checkpoints
                 // use the exact text tower owned by the loaded wrapper.
                 let servingModel = try EngineV2Factory.benchmarkServingModel(
-                    model: ctx.model, isVLM: isVLM)
+                    model: ctx.model, isVLM: isVLM, modelDirectory: modelDirectory)
                 // `makeProductionBuild` is the construction
                 // `makeProductionEngine` wraps, and additionally hands back the
                 // backend kind the engine actually resolved to — the fact a

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge+Capacity.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge+Capacity.swift
@@ -56,8 +56,26 @@ extension EngineV2Bridge {
         // Worst-case potential is bridge bookkeeping (the snapshot has no
         // per-request max-token view); active tokens are engine truth.
         var maxTokensPotential: Int64 = 0
+        var committedBytes = 0
+        var committedBytesOverflow = false
         for state in active.values {
-            maxTokensPotential += Int64(state.promptTokens + state.maxTokens)
+            let (tokens, tokenOverflow) = state.promptTokens.addingReportingOverflow(
+                state.maxTokens)
+            if tokenOverflow {
+                maxTokensPotential = Int64.max
+                committedBytesOverflow = true
+                continue
+            }
+            let (nextPotential, potentialOverflow) = maxTokensPotential.addingReportingOverflow(
+                Int64(tokens))
+            maxTokensPotential = potentialOverflow ? Int64.max : nextPotential
+            if let bytes = requestReservationBytes(tokenCount: tokens) {
+                let (next, overflow) = committedBytes.addingReportingOverflow(bytes)
+                committedBytes = next
+                committedBytesOverflow = committedBytesOverflow || overflow
+            } else {
+                committedBytesOverflow = true
+            }
         }
 
         // Budget fields — SEMANTICS ALIGNED WITH THE LEGACY SCHEDULER
@@ -81,24 +99,29 @@ extension EngineV2Bridge {
         //   activeTokens          ← snapshot.activeTokens (ENGINE TRUTH: the
         //                           real KV-resident token count)
         //   maxTokensPotential    ← Σ(prompt + maxTokens)  (worst case)
-        //   activeTokenBudgetUsed ← Σ(prompt + maxTokens)  (the committed
-        //                           reservation the admission gate must see —
-        //                           conservative for sliding-window models,
-        //                           whose engine ledger plateaus per layer)
-        //   activeTokenBudgetMax  ← min(kvBytesCapacity, live fleet clamp) /
-        //                           resolved native rate (the engine's
-        //                           admission ceiling
-        //                           in tokens, clamped to the sizing
-        //                           function's CURRENT answer when the caller
-        //                           supplies fleet context — see the doc
-        //                           comment above; 0 when the rate is
-        //                           unknown ⇒ the coordinator's budget gate
-        //                           disengages rather than trusting an
-        //                           invented budget)
+        //   activeTokenBudgetUsed ← ceil(byte-exact active commitments /
+        //                           resolved native rate), including recurrent
+        //                           and assistant allocation overhead
+        //   activeTokenBudgetMax  ← (min(kvBytesCapacity, live fleet clamp) −
+        //                           worst-case fixed/block overhead for every
+        //                           still-available concurrency slot) / rate
+        //                           (0 when the rate or arithmetic is unknown)
         //   queuedTokenBudget     ← 0 (engine-WAITING requests are already
         //                           inside the committed sum above — the
         //                           bridge does not split running/waiting)
-        let budgetUsed = maxTokensPotential
+        // Coordinator requests are expressed in ordinary tokens. Convert the
+        // provider's byte-exact commitments back through the advertised rate;
+        // rounding up preserves fixed recurrent and assistant allocation blocks.
+        let budgetUsed: Int64
+        if kvBytesPerToken > 0 {
+            let (roundedBytes, roundingOverflow) = committedBytes.addingReportingOverflow(
+                kvBytesPerToken - 1)
+            budgetUsed = committedBytesOverflow || roundingOverflow
+                ? Int64.max
+                : Int64(roundedBytes / kvBytesPerToken)
+        } else {
+            budgetUsed = maxTokensPotential
+        }
         // Physical backend truth binds the advertised capacity from below
         // the admission ledger: on the PAGED backend a re-slice GROW moves
         // only the ledger — the construction-fixed pool is what actually
@@ -117,8 +140,23 @@ extension EngineV2Bridge {
         } else {
             reportedKVBytesCapacity = boundedKVBytesCapacity
         }
-        let budgetMax: Int64 =
-            kvBytesPerToken > 0 ? Int64(reportedKVBytesCapacity / kvBytesPerToken) : 0
+        let prospectiveRequests = max(0, maxConcurrentRequests - active.count)
+        let prospectiveOverheadBytes: Int?
+        if let perRequestOverhead = maximumRequestOverheadBytes() {
+            let (bytes, overflow) = perRequestOverhead.multipliedReportingOverflow(
+                by: prospectiveRequests)
+            prospectiveOverheadBytes = overflow ? nil : bytes
+        } else {
+            prospectiveOverheadBytes = nil
+        }
+        let budgetMax: Int64
+        if kvBytesPerToken > 0, let prospectiveOverheadBytes {
+            budgetMax = Int64(
+                max(0, reportedKVBytesCapacity - prospectiveOverheadBytes)
+                    / kvBytesPerToken)
+        } else {
+            budgetMax = 0
+        }
 
         let state: String
         if recoveryReloading {

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge.swift
@@ -162,8 +162,9 @@ public actor EngineV2Bridge {
     /// paged slots remain fp16. Heartbeats and process-wide reservations use
     /// the same value so neither can overstate capacity.
     let kvBytesPerToken: Int
-    /// Fixed request-owned residency outside attention KV (Qwen recurrent
-    /// conv/SSM state). Zero preserves the historical attention-only charge.
+    /// Peak request-owned residency outside attention KV (Qwen recurrent
+    /// committed + transactional conv/SSM generations). Zero preserves the
+    /// historical attention-only charge.
     let fixedRequestBytes: Int
     /// Assistant-cache allocation geometry. The per-token rate includes target
     /// KV and assistant logical rows; these fields account for the assistant's

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge.swift
@@ -162,6 +162,9 @@ public actor EngineV2Bridge {
     /// paged slots remain fp16. Heartbeats and process-wide reservations use
     /// the same value so neither can overstate capacity.
     let kvBytesPerToken: Int
+    /// Fixed request-owned residency outside attention KV (Qwen recurrent
+    /// conv/SSM state). Zero preserves the historical attention-only charge.
+    let fixedRequestBytes: Int
     /// Process-wide KV reservation ledger shared by every EngineV2 slot.
     /// When set (production), each v2 submission must RESERVE its worst-case
     /// KV footprint here BEFORE it is handed to the engine — the reservation
@@ -309,6 +312,7 @@ public actor EngineV2Bridge {
         defaultMaxTokens: Int = 4096,
         maxConcurrentRequests: Int = 4,
         kvBytesPerToken: Int = 0,
+        fixedRequestBytes: Int = 0,
         kvBudget: GlobalKVCacheBudget? = nil,
         ssdPrefixCache: SSDPrefixCache? = nil,
         prefixCacheStatus: PrefixCacheModelStatus? = nil,
@@ -332,6 +336,7 @@ public actor EngineV2Bridge {
         self.defaultMaxTokens = defaultMaxTokens
         self.maxConcurrentRequests = maxConcurrentRequests
         self.kvBytesPerToken = kvBytesPerToken
+        self.fixedRequestBytes = max(0, fixedRequestBytes)
         self.kvBudget = kvBudget
         self.ssdPrefixCache = ssdPrefixCache
         self.prefixCacheBaseStatus = prefixCacheStatus ?? PrefixCacheModelStatus(
@@ -422,6 +427,7 @@ public actor EngineV2Bridge {
         logprobsChannel: EngineV2LogprobsChannel? = nil,
         usageSignal: EngineV2RequestUsageSignal? = nil,
         multimodal: CBv2MultimodalInput? = nil,
+        positionState: CBv2PositionState? = nil,
         mediaKind: EngineV2MediaKind? = nil,
         tokenConstraint: (any CBv2TokenConstraint)? = nil
     ) async -> AsyncStream<GenerationEvent> {
@@ -462,6 +468,7 @@ public actor EngineV2Bridge {
             multimodal: multimodal,
             tokenConstraint: tokenConstraint
         )
+        cbv2Request.positionState = positionState ?? multimodal?.positionState
         let (worstCaseTokens, tokenCountOverflow) = promptTokens.count.addingReportingOverflow(
             cbv2Request.maxTokens)
         guard !tokenCountOverflow else {
@@ -585,20 +592,18 @@ public actor EngineV2Bridge {
         // headroom on every reserve, so the window closes the moment the
         // paged slot serves anything. Before D1 paged was stricter here and
         // paid for it by making the second model unloadable.
-        if kvBackendKind == .contiguous, let kvBudget, kvBytesPerToken > 0,
-            cbv2Request.maxTokens > 0
+        if kvBackendKind == .contiguous, let kvBudget,
+            (kvBytesPerToken > 0 || fixedRequestBytes > 0), cbv2Request.maxTokens > 0
         {
-            sharedKVReserved = await kvBudget.reserve(
-                requestID: id, kvBytesPerToken: kvBytesPerToken, tokenCount: worstCaseTokens)
+            sharedKVReserved = await reserveSharedRequestBytes(
+                budget: kvBudget, requestID: id, tokenCount: worstCaseTokens)
             if !sharedKVReserved, ssdStaged, let prefixCacheReceiptID {
                 // Optional adoption may be the only reason R no longer fits:
                 // retire S synchronously, then retry the full cold request R.
                 await ssdPrefixCache?.abandonStaging(requestID: prefixCacheReceiptID)
                 ssdStaged = false
-                sharedKVReserved = await kvBudget.reserve(
-                    requestID: id,
-                    kvBytesPerToken: kvBytesPerToken,
-                    tokenCount: worstCaseTokens)
+                sharedKVReserved = await reserveSharedRequestBytes(
+                    budget: kvBudget, requestID: id, tokenCount: worstCaseTokens)
                 if sharedKVReserved {
                     emitPrefixCacheColdFallback(
                         requestId: id,
@@ -756,6 +761,23 @@ public actor EngineV2Bridge {
             }
         }
         return stream
+    }
+
+    private func reserveSharedRequestBytes(
+        budget: GlobalKVCacheBudget, requestID: String, tokenCount: Int
+    ) async -> Bool {
+        let tokenBytes: UInt64
+        if kvBytesPerToken > 0 {
+            let (product, overflow) = UInt64(kvBytesPerToken).multipliedReportingOverflow(
+                by: UInt64(tokenCount))
+            guard !overflow else { return false }
+            tokenBytes = product
+        } else {
+            tokenBytes = 0
+        }
+        let (total, overflow) = tokenBytes.addingReportingOverflow(UInt64(fixedRequestBytes))
+        guard !overflow, total > 0 else { return false }
+        return await budget.reserveBytes(requestID: requestID, bytes: total)
     }
 
     // MARK: - Cancel / shutdown

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge.swift
@@ -165,6 +165,12 @@ public actor EngineV2Bridge {
     /// Fixed request-owned residency outside attention KV (Qwen recurrent
     /// conv/SSM state). Zero preserves the historical attention-only charge.
     let fixedRequestBytes: Int
+    /// Assistant-cache allocation geometry. The per-token rate includes target
+    /// KV and assistant logical rows; these fields account for the assistant's
+    /// block-rounded physical allocation and staged proposal high-water mark.
+    let auxiliaryBytesPerToken: Int
+    let auxiliaryTokenGranularity: Int
+    let auxiliaryTokenAllocationPadding: Int
     /// Process-wide KV reservation ledger shared by every EngineV2 slot.
     /// When set (production), each v2 submission must RESERVE its worst-case
     /// KV footprint here BEFORE it is handed to the engine — the reservation
@@ -313,6 +319,9 @@ public actor EngineV2Bridge {
         maxConcurrentRequests: Int = 4,
         kvBytesPerToken: Int = 0,
         fixedRequestBytes: Int = 0,
+        auxiliaryBytesPerToken: Int = 0,
+        auxiliaryTokenGranularity: Int = 1,
+        auxiliaryTokenAllocationPadding: Int = 0,
         kvBudget: GlobalKVCacheBudget? = nil,
         ssdPrefixCache: SSDPrefixCache? = nil,
         prefixCacheStatus: PrefixCacheModelStatus? = nil,
@@ -337,6 +346,10 @@ public actor EngineV2Bridge {
         self.maxConcurrentRequests = maxConcurrentRequests
         self.kvBytesPerToken = kvBytesPerToken
         self.fixedRequestBytes = max(0, fixedRequestBytes)
+        self.auxiliaryBytesPerToken = max(0, auxiliaryBytesPerToken)
+        self.auxiliaryTokenGranularity = max(1, auxiliaryTokenGranularity)
+        self.auxiliaryTokenAllocationPadding = max(
+            0, auxiliaryTokenAllocationPadding)
         self.kvBudget = kvBudget
         self.ssdPrefixCache = ssdPrefixCache
         self.prefixCacheBaseStatus = prefixCacheStatus ?? PrefixCacheModelStatus(
@@ -549,7 +562,8 @@ public actor EngineV2Bridge {
         cbv2Request.prefixCacheReceiptID = prefixCacheReceiptID
 
         // SHARED-BUDGET ADMISSION GATE: reserve this request's worst-case KV
-        // footprint (prompt + maxTokens at the resolved native serving rate)
+        // footprint (target KV plus fixed recurrent and block-rounded assistant
+        // state for prompt + maxTokens)
         // in the process-wide ledger BEFORE handing the
         // request to the engine. The engine's private byte ledger
         // (`AdmissionV2`, sized to its own `kvBytesCapacity`) only knows its
@@ -766,18 +780,48 @@ public actor EngineV2Bridge {
     private func reserveSharedRequestBytes(
         budget: GlobalKVCacheBudget, requestID: String, tokenCount: Int
     ) async -> Bool {
-        let tokenBytes: UInt64
-        if kvBytesPerToken > 0 {
-            let (product, overflow) = UInt64(kvBytesPerToken).multipliedReportingOverflow(
-                by: UInt64(tokenCount))
-            guard !overflow else { return false }
-            tokenBytes = product
-        } else {
-            tokenBytes = 0
+        guard let total = requestReservationBytes(tokenCount: tokenCount), total > 0 else {
+            return false
         }
-        let (total, overflow) = tokenBytes.addingReportingOverflow(UInt64(fixedRequestBytes))
-        guard !overflow, total > 0 else { return false }
-        return await budget.reserveBytes(requestID: requestID, bytes: total)
+        return await budget.reserveBytes(requestID: requestID, bytes: UInt64(total))
+    }
+
+    func requestReservationBytes(tokenCount: Int) -> Int? {
+        guard tokenCount >= 0 else { return nil }
+        let targetRate = max(0, kvBytesPerToken - auxiliaryBytesPerToken)
+        let (targetBytes, targetOverflow) = targetRate.multipliedReportingOverflow(
+            by: tokenCount)
+        let (paddedTokens, paddingOverflow) = tokenCount.addingReportingOverflow(
+            auxiliaryTokenAllocationPadding)
+        guard !targetOverflow, !paddingOverflow else { return nil }
+        let auxiliaryTokens: Int
+        if auxiliaryBytesPerToken == 0 || paddedTokens == 0 {
+            auxiliaryTokens = 0
+        } else {
+            let (bumped, bumpOverflow) = paddedTokens.addingReportingOverflow(
+                auxiliaryTokenGranularity - 1)
+            guard !bumpOverflow else { return nil }
+            auxiliaryTokens = (bumped / auxiliaryTokenGranularity)
+                * auxiliaryTokenGranularity
+        }
+        let (auxiliaryBytes, auxiliaryOverflow) = auxiliaryBytesPerToken
+            .multipliedReportingOverflow(by: auxiliaryTokens)
+        guard !auxiliaryOverflow else { return nil }
+        let (variableBytes, variableOverflow) = targetBytes.addingReportingOverflow(
+            auxiliaryBytes)
+        let (total, totalOverflow) = variableBytes.addingReportingOverflow(fixedRequestBytes)
+        return variableOverflow || totalOverflow ? nil : total
+    }
+
+    func maximumRequestOverheadBytes() -> Int? {
+        let (extraAuxiliaryTokens, tokenOverflow) = (auxiliaryTokenGranularity - 1)
+            .addingReportingOverflow(auxiliaryTokenAllocationPadding)
+        guard !tokenOverflow else { return nil }
+        let (auxiliaryOverhead, auxiliaryOverflow) = auxiliaryBytesPerToken
+            .multipliedReportingOverflow(by: max(0, extraAuxiliaryTokens))
+        let (total, totalOverflow) = fixedRequestBytes.addingReportingOverflow(
+            auxiliaryOverhead)
+        return auxiliaryOverflow || totalOverflow ? nil : total
     }
 
     // MARK: - Cancel / shutdown

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Config.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Config.swift
@@ -156,6 +156,9 @@ public enum EngineV2Factory {
         maxConcurrentRequests: Int = 4,
         kvBytesPerToken: Int = 0,
         fixedRequestBytes: Int = 0,
+        auxiliaryBytesPerToken: Int = 0,
+        auxiliaryTokenGranularity: Int = 1,
+        auxiliaryTokenAllocationPadding: Int = 0,
         kvBudget: GlobalKVCacheBudget? = nil,
         ssdPrefixCache: SSDPrefixCache? = nil,
         prefixCacheStatus: PrefixCacheModelStatus? = nil,
@@ -179,6 +182,9 @@ public enum EngineV2Factory {
                 maxConcurrentRequests: maxConcurrentRequests,
                 kvBytesPerToken: kvBytesPerToken,
                 fixedRequestBytes: fixedRequestBytes,
+                auxiliaryBytesPerToken: auxiliaryBytesPerToken,
+                auxiliaryTokenGranularity: auxiliaryTokenGranularity,
+                auxiliaryTokenAllocationPadding: auxiliaryTokenAllocationPadding,
                 kvBudget: kvBudget,
                 // SSD offload tier handle (v0.7.5): the bridge drives the
                 // pre-submit staging hook + release backstops + shutdown

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Config.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Config.swift
@@ -83,6 +83,9 @@ public enum EngineV2RefusalReason: String, Sendable {
     /// (`EngineV2ProductionError.unsupportedModel`) — should be unreachable
     /// behind the scan-time supported-set gate; kept as loud insurance.
     case unsupportedModel = "unsupported_model"
+    /// Qwen VLM target extraction failed (config decode, weight re-key,
+    /// strict parameter verification, or the forward-parity gate).
+    case vlmExtractionFailed = "vlm_extraction_failed"
     /// A load-time KV re-slice would push some co-resident slot below the
     /// minimum serviceable grant (`EngineV2KVSizing` floor).
     case resliceFloor = "reslice_floor"
@@ -114,6 +117,8 @@ public enum EngineV2RefusalReason: String, Sendable {
             return .noKVHeadroom
         case EngineV2ProductionError.unsupportedModel:
             return .unsupportedModel
+        case is EngineV2VLMTextExtractionError:
+            return .vlmExtractionFailed
         case EngineV2ProductionError.pagedUnavailable:
             return .pagedBackendUnavailable
         case EngineV2ProductionError.invalidPagedPoolDType:
@@ -150,6 +155,7 @@ public enum EngineV2Factory {
         defaultMaxTokens: Int = 4096,
         maxConcurrentRequests: Int = 4,
         kvBytesPerToken: Int = 0,
+        fixedRequestBytes: Int = 0,
         kvBudget: GlobalKVCacheBudget? = nil,
         ssdPrefixCache: SSDPrefixCache? = nil,
         prefixCacheStatus: PrefixCacheModelStatus? = nil,
@@ -172,6 +178,7 @@ public enum EngineV2Factory {
                 defaultMaxTokens: defaultMaxTokens,
                 maxConcurrentRequests: maxConcurrentRequests,
                 kvBytesPerToken: kvBytesPerToken,
+                fixedRequestBytes: fixedRequestBytes,
                 kvBudget: kvBudget,
                 // SSD offload tier handle (v0.7.5): the bridge drives the
                 // pre-submit staging hook + release backstops + shutdown

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Factory+Benchmark.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Factory+Benchmark.swift
@@ -4,7 +4,9 @@
 // in production. Gemma 4 VLM checkpoints expose their directly owned
 // `Gemma4TextModel`; no extraction, re-keying, or second module is involved.
 
+import Foundation
 import MLXLMCommon
+import MLXVLM
 
 extension EngineV2Factory {
 
@@ -13,8 +15,23 @@ extension EngineV2Factory {
     /// Gemma 4 VLM checkpoints.
     public static func benchmarkServingModel(
         model: any LanguageModel,
-        isVLM: Bool
+        isVLM: Bool,
+        modelDirectory: URL? = nil,
+        environment: [String: String] = ProcessInfo.processInfo.environment
     ) throws -> any LanguageModel {
-        try directServingModel(model: model, isVLM: isVLM)
+        guard isVLM else { return model }
+        if model is MLXVLM.Gemma4 {
+            return try directServingModel(model: model, isVLM: true)
+        }
+        guard model is MLXVLM.Qwen35MoE else {
+            throw EngineV2VLMTextExtractionError.unsupportedWrapper(
+                String(describing: type(of: model)))
+        }
+        guard let modelDirectory else {
+            throw EngineV2VLMTextExtractionError.missingModelDirectory
+        }
+        return try EngineV2VLMTextExtraction.extractTextModel(
+            from: model, modelDirectory: modelDirectory, environment: environment
+        ).servingModel
     }
 }

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Factory+Benchmark.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Factory+Benchmark.swift
@@ -16,7 +16,7 @@ extension EngineV2Factory {
     public static func benchmarkServingModel(
         model: any LanguageModel,
         isVLM: Bool,
-        modelDirectory: URL? = nil,
+        modelDirectory: URL?,
         environment: [String: String] = ProcessInfo.processInfo.environment
     ) throws -> any LanguageModel {
         guard isVLM else { return model }

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Factory+Production.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Factory+Production.swift
@@ -215,6 +215,9 @@ extension EngineV2Factory {
             return PrefixCachePolicy.adoptionBoundTokens(layerKinds: gemma.cbv2LayerKinds)
         case let gptoss as GPTOSSModel:
             return PrefixCachePolicy.adoptionBoundTokens(layerKinds: gptoss.cbv2LayerKinds)
+        case let qwen as Qwen35MoEModel:
+            guard qwen.cbv2Capabilities.supportsPrefixReuse else { return 0 }
+            return PrefixCachePolicy.adoptionBoundTokens(layerKinds: qwen.cbv2LayerKinds)
         default:
             return 0
         }
@@ -231,6 +234,8 @@ extension EngineV2Factory {
             return gemma.cbv2LayerKinds
         case let gptoss as GPTOSSModel:
             return gptoss.cbv2LayerKinds
+        case let qwen as Qwen35MoEModel:
+            return qwen.cbv2LayerKinds
         default:
             return nil
         }
@@ -400,6 +405,7 @@ extension EngineV2Factory {
     /// so provider capability follows the backend that will actually serve.
     final class ProductionBackendPreparation {
         let layerKinds: [CBv2LayerKind]
+        let modelCapabilities: CBv2ModelCapabilities
         let kind: EngineV2KVBackendKind
         let fallbackReason: String?
         /// The ONE scheduler config of this build. Constructed in
@@ -423,6 +429,7 @@ extension EngineV2Factory {
             model: any LanguageModel,
             maxConcurrentRequests: Int,
             layerKinds: [CBv2LayerKind],
+            modelCapabilities: CBv2ModelCapabilities,
             backend: CBv2KVBackend,
             caches: [any CBv2AttendingLayerCache],
             kind: EngineV2KVBackendKind,
@@ -433,6 +440,7 @@ extension EngineV2Factory {
             self.modelIdentity = ObjectIdentifier(model)
             self.maxConcurrentRequests = max(1, maxConcurrentRequests)
             self.layerKinds = layerKinds
+            self.modelCapabilities = modelCapabilities
             self.backend = backend
             self.caches = caches
             self.kind = kind
@@ -545,16 +553,23 @@ extension EngineV2Factory {
         // sinks-activation probe inside it (one host readback per layer,
         // at build time — never on the step path).
         let layerKinds: [CBv2LayerKind]
+        let modelCapabilities: CBv2ModelCapabilities
         let newCaches:
             ((Int, CBv2LayerKind) -> any CBv2AttendingLayerCache)
                 throws -> [any CBv2AttendingLayerCache]
         switch model {
         case let gemma as Gemma4TextModel:
             layerKinds = gemma.cbv2LayerKinds
+            modelCapabilities = .attentionOnly
             newCaches = { make in try gemma.newCacheV2(makeLayerCache: make) }
         case let gptoss as GPTOSSModel:
             layerKinds = gptoss.cbv2LayerKinds
+            modelCapabilities = .attentionOnly
             newCaches = { make in gptoss.newCacheV2(makeLayerCache: make) }
+        case let qwen as Qwen35MoEModel:
+            layerKinds = qwen.cbv2LayerKinds
+            modelCapabilities = qwen.cbv2Capabilities
+            newCaches = { make in qwen.newCacheV2(makeLayerCache: make) }
         default:
             throw EngineV2ProductionError.unsupportedModel(
                 String(describing: type(of: model)))
@@ -645,6 +660,10 @@ extension EngineV2Factory {
         case .auto: resolvedKind = .contiguous
         }
         var fallbackReason: String?
+        if resolvedKind == .paged, !modelCapabilities.supportsPagedKV {
+            resolvedKind = .contiguous
+            fallbackReason = "model_capability"
+        }
         // DEGRADE, not refuse — even on an explicit paged selection. This
         // is the branch that must never be collapsed into the failure
         // handling below: the kill switch says "DO NOT do what you asked",
@@ -774,6 +793,7 @@ extension EngineV2Factory {
                 model: model,
                 maxConcurrentRequests: maxConcurrentRequests,
                 layerKinds: layerKinds,
+                modelCapabilities: modelCapabilities,
                 backend: backend,
                 caches: caches,
                 kind: .contiguous,
@@ -853,6 +873,7 @@ extension EngineV2Factory {
                         model: model,
                         maxConcurrentRequests: maxConcurrentRequests,
                         layerKinds: layerKinds,
+                        modelCapabilities: modelCapabilities,
                         backend: paged,
                         caches: caches,
                         kind: .paged,
@@ -921,6 +942,8 @@ extension EngineV2Factory {
         let (backend, caches) = try preparedBackend.consume(
             model: model,
             maxConcurrentRequests: maxConcurrentRequests)
+        let effectivePrefixCache = preparedBackend.modelCapabilities.supportsPrefixReuse
+            ? prefixCache : nil
         // The ONE config, read back off the preparation. `consume` has
         // already refused a `maxConcurrentRequests` that differs from the
         // prepared one, so the only field this phase may decide is
@@ -930,7 +953,7 @@ extension EngineV2Factory {
         // `prefillChunkSize` above all, reaches the engine byte-identical
         // to what the paged pool's `maxPrefillChunk` was sized from.
         var schedulerConfig = preparedBackend.schedulerConfig
-        schedulerConfig.enablePrefixCache = prefixCache != nil
+        schedulerConfig.enablePrefixCache = effectivePrefixCache != nil
         return ProductionBuild(
             engine: makeEngineV2(
                 model: model,
@@ -939,7 +962,7 @@ extension EngineV2Factory {
                 backend: backend,
                 caches: caches,
                 schedulerConfig: schedulerConfig,
-                prefixCache: prefixCache,
+                prefixCache: effectivePrefixCache,
                 // New monotonic phase leases are on by default
                 // (`useLegacyRequestTimeout` defaults false). The ONLY override
                 // is the emergency rollback kill-switch below — production never

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2MTPAssistant.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2MTPAssistant.swift
@@ -38,6 +38,21 @@ struct Gemma4ProviderMTPAssistantLoader: ProviderMTPAssistantLoading {
         artifact: SpecDecArtifact,
         target: any LanguageModel
     ) async throws -> ProviderMTPAssistantHandle {
+        if artifact.source == .inline {
+            do {
+                let assistant = try Qwen35InlineMTPAssistant.load(
+                    from: artifact.directory, target: target)
+                return ProviderMTPAssistantHandle(owner: assistant, drafter: assistant)
+            } catch let error as ProviderMTPAssistantLoadError {
+                throw error
+            } catch let error as Qwen35InlineMTPError {
+                throw ProviderMTPAssistantLoadError.loadFailed(
+                    error.localizedDescription)
+            } catch {
+                throw ProviderMTPAssistantLoadError.loadFailed(String(describing: error))
+            }
+        }
+
         guard let gemmaTarget = target as? Gemma4TextModel else {
             throw ProviderMTPAssistantLoadError.targetIncompatible(
                 String(describing: type(of: target)))
@@ -58,4 +73,14 @@ struct Gemma4ProviderMTPAssistantLoader: ProviderMTPAssistantLoading {
             throw ProviderMTPAssistantLoadError.bindFailed(String(describing: error))
         }
     }
+}
+
+func providerMTPVerificationPolicy(
+    for drafter: (any CBv2MTPDrafter)?,
+    automaticRectangularTokens: Int
+) -> (mode: CBv2MTPVerificationMode, automaticRectangularTokens: Int) {
+    guard let required = drafter?.requiredVerificationMode else {
+        return (.automatic, automaticRectangularTokens)
+    }
+    return (required, required == .automatic ? automaticRectangularTokens : 0)
 }

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2SlotFactory+MTP.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2SlotFactory+MTP.swift
@@ -1,3 +1,4 @@
+import Foundation
 import MLXLMCommon
 import MLXVLM
 

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2SlotFactory+MTP.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2SlotFactory+MTP.swift
@@ -1,4 +1,5 @@
 import MLXLMCommon
+import MLXVLM
 
 /// Model handle + EOS config snapshot pulled out of `ModelContainer.perform`.
 /// The module crosses container isolation once and is then engine-thread owned.
@@ -8,7 +9,7 @@ struct EngineV2ModelSnapshot: @unchecked Sendable {
     let extraEOSTokens: [String]
 }
 
-/// Direct serving-target resolution plus fail-open assistant preparation,
+/// Serving-target resolution plus fail-open assistant preparation,
 /// completed before KV re-slicing so sizing uses retained assistant bytes.
 struct EngineV2PreparedModel: @unchecked Sendable {
     let snapshot: EngineV2ModelSnapshot
@@ -44,22 +45,57 @@ extension EngineV2SlotFactory {
     private static func servingModel(
         modelId: String,
         isVLM: Bool,
+        modelDirectory: URL?,
         snapshot: EngineV2ModelSnapshot,
         emitTelemetry: (@Sendable (TelemetryEvent) -> Void)?,
         logInfo: @escaping @Sendable (String) -> Void
     ) throws -> any LanguageModel {
         guard isVLM else { return snapshot.model }
+        if snapshot.model is MLXVLM.Gemma4 {
+            do {
+                let target = try EngineV2Factory.directServingModel(
+                    model: snapshot.model, isVLM: true)
+                logInfo(
+                    "engine_v2: \(modelId) using the Gemma 4 VLM-owned text tower "
+                        + "directly (shared identity and residency)")
+                return target
+            } catch {
+                EngineV2Factory.emitRefusalTelemetry(
+                    modelId: modelId,
+                    reason: EngineV2RefusalReason.classify(error),
+                    error: error,
+                    emitTelemetry: emitTelemetry)
+                throw error
+            }
+        }
+        guard snapshot.model is MLXVLM.Qwen35MoE else {
+            let error = EngineV2VLMTextExtractionError.unsupportedWrapper(
+                String(describing: type(of: snapshot.model)))
+            EngineV2Factory.emitRefusalTelemetry(
+                modelId: modelId, reason: .vlmExtractionFailed,
+                error: error, emitTelemetry: emitTelemetry)
+            throw error
+        }
+        guard let modelDirectory else {
+            let error = EngineV2VLMTextExtractionError.missingModelDirectory
+            EngineV2Factory.emitRefusalTelemetry(
+                modelId: modelId, reason: .vlmExtractionFailed,
+                error: error, emitTelemetry: emitTelemetry)
+            throw error
+        }
         do {
-            let target = try EngineV2Factory.directServingModel(
-                model: snapshot.model, isVLM: true)
-            logInfo(
-                "engine_v2: \(modelId) using the Gemma 4 VLM-owned text tower "
-                    + "directly (shared identity and residency)")
-            return target
+            let extraction = try EngineV2VLMTextExtraction.extractTextModel(
+                from: snapshot.model, modelDirectory: modelDirectory)
+            if let parityDiff = extraction.parityMaxAbsLogitDiff {
+                logInfo(
+                    "engine_v2: \(modelId) Qwen VLM extraction passed the "
+                        + "load-time parity gate (max |Δlogit| \(parityDiff))")
+            }
+            return extraction.servingModel
         } catch {
             EngineV2Factory.emitRefusalTelemetry(
                 modelId: modelId,
-                reason: EngineV2RefusalReason.classify(error),
+                reason: .vlmExtractionFailed,
                 error: error,
                 emitTelemetry: emitTelemetry)
             throw error
@@ -69,6 +105,7 @@ extension EngineV2SlotFactory {
     static func prepareProductionModel(
         modelId: String,
         isVLM: Bool,
+        modelDirectory: URL? = nil,
         container: ModelContainer,
         specDecPreparation: SpecDecPreparation,
         assistantLoader: any ProviderMTPAssistantLoading = Gemma4ProviderMTPAssistantLoader(),
@@ -80,6 +117,7 @@ extension EngineV2SlotFactory {
         let servingModel = try servingModel(
             modelId: modelId,
             isVLM: isVLM,
+            modelDirectory: modelDirectory,
             snapshot: snapshot,
             emitTelemetry: emitTelemetry,
             logInfo: logInfo)
@@ -137,6 +175,7 @@ extension EngineV2SlotFactory {
     static func prepareRecoveryModel(
         modelId: String,
         isVLM: Bool,
+        modelDirectory: URL? = nil,
         container: ModelContainer,
         previousArtifact: SpecDecArtifact?,
         previousStatus: MTPActivationStatus,
@@ -175,6 +214,7 @@ extension EngineV2SlotFactory {
             let target = try servingModel(
                 modelId: modelId,
                 isVLM: isVLM,
+                modelDirectory: modelDirectory,
                 snapshot: snapshot,
                 emitTelemetry: emitTelemetry,
                 logInfo: logInfo)
@@ -190,6 +230,7 @@ extension EngineV2SlotFactory {
         let target = try servingModel(
             modelId: modelId,
             isVLM: isVLM,
+            modelDirectory: modelDirectory,
             snapshot: snapshot,
             emitTelemetry: emitTelemetry,
             logInfo: logInfo)

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2SlotFactory.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2SlotFactory.swift
@@ -599,7 +599,7 @@ enum EngineV2SlotFactory {
             // Keep the process-wide admission gate aligned with EngineV2's
             // request-owned recurrent-state charge. Invalid geometry must
             // refuse the load rather than advertise capacity that cannot fit.
-            fixedRequestBytes = try recurrent.cbv2RecurrentStateSpec.fixedBytesPerRequest()
+            fixedRequestBytes = try recurrent.cbv2RecurrentStateSpec.peakBytesPerRequest()
         } else {
             fixedRequestBytes = 0
         }

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2SlotFactory.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2SlotFactory.swift
@@ -584,6 +584,10 @@ enum EngineV2SlotFactory {
             targetKVBytesPerToken = sizing.fp16KVBytesPerToken
         }
         let assistantStateBytesPerToken = assistantHandle?.drafter?.requestStateBytesPerToken ?? 0
+        let assistantStateTokenGranularity =
+            assistantHandle?.drafter?.requestStateTokenGranularity ?? 1
+        let assistantStateTokenAllocationPadding =
+            assistantHandle?.drafter?.requestStateTokenAllocationPadding ?? 0
         let (processKVBytesPerToken, processRateOverflow) = targetKVBytesPerToken
             .addingReportingOverflow(assistantStateBytesPerToken)
         guard !processRateOverflow else {
@@ -609,6 +613,9 @@ enum EngineV2SlotFactory {
             maxConcurrentRequests: maxConcurrentRequests,
             kvBytesPerToken: processKVBytesPerToken,
             fixedRequestBytes: fixedRequestBytes,
+            auxiliaryBytesPerToken: assistantStateBytesPerToken,
+            auxiliaryTokenGranularity: assistantStateTokenGranularity,
+            auxiliaryTokenAllocationPadding: assistantStateTokenAllocationPadding,
             // Shared KV ledger: v2 submissions RESERVE their worst-case
             // KV here before engine admission (process-wide gate) and the
             // reservation is what the model-LOAD gate subtracts.

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2SlotFactory.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2SlotFactory.swift
@@ -316,6 +316,7 @@ enum EngineV2SlotFactory {
             prepared = try await prepareProductionModel(
                 modelId: modelId,
                 isVLM: isVLM,
+                modelDirectory: modelDirectory,
                 container: container,
                 specDecPreparation: SpecDecPreparation(
                     artifact: nil, status: specDecPreparation.status),
@@ -327,6 +328,7 @@ enum EngineV2SlotFactory {
             prepared = try await prepareProductionModel(
                 modelId: modelId,
                 isVLM: isVLM,
+                modelDirectory: modelDirectory,
                 container: container,
                 specDecPreparation: specDecPreparation,
                 assistantLoader: assistantLoader,
@@ -340,11 +342,14 @@ enum EngineV2SlotFactory {
         let mtpStatus = prepared.mtpStatus
         let automaticRectangularTokens = MTPAutomaticVerificationPolicy.maxRectangularTokens(
             environment: environment)
+        let mtpVerification = providerMTPVerificationPolicy(
+            for: assistantHandle?.drafter,
+            automaticRectangularTokens: automaticRectangularTokens)
         let mtpConfig = CBv2MTPConfig(
             enabled: assistantHandle != nil,
             fixedDraftTokens: MTPAutomaticVerificationPolicy.initialDraftTokens,
-            verificationMode: .automatic,
-            maxAutomaticRectangularTokens: automaticRectangularTokens)
+            verificationMode: mtpVerification.mode,
+            maxAutomaticRectangularTokens: mtpVerification.automaticRectangularTokens)
         // Same model-specific EOS augmentation as always (GPT-OSS/Harmony
         // adds its generation-config action stops) — from the
         // scheduler-free policy home.
@@ -407,6 +412,14 @@ enum EngineV2SlotFactory {
         if makeEngineOverride != nil {
             cacheConstructionStatus = PrefixCacheConstructionStatus(
                 state: .disabled, reason: .unsupportedBackend)
+        } else if let preparedBackend,
+            !preparedBackend.modelCapabilities.supportsPrefixReuse
+        {
+            // Recurrent targets require more than attention KV to restore a
+            // request. Do not construct a cache the engine will later strip:
+            // the bridge must never retain or stage an incomplete snapshot.
+            cacheConstructionStatus = PrefixCacheConstructionStatus(
+                state: .disabled, reason: .unsupportedLayout)
         } else if PrefixCachePolicy.isEnabled(environment: environment) {
             if let preparedBackend,
                 !PrefixCachePolicy.adoptionIsExact(
@@ -559,16 +572,32 @@ enum EngineV2SlotFactory {
             }
         }
 
-        let processKVBytesPerToken: Int
+        let targetKVBytesPerToken: Int
         if let preparedBackend {
-            processKVBytesPerToken = slotKVBytesPerToken(
+            targetKVBytesPerToken = slotKVBytesPerToken(
                 resolvedKind: preparedBackend.kind,
                 pagedPoolDType: preparedBackend.pagedPoolDType,
                 layerKinds: preparedBackend.layerKinds,
                 nominalFP16BytesPerToken: sizing.fp16KVBytesPerToken,
                 servingModelIsGPTOSS: servingModel is GPTOSSModel)
         } else {
-            processKVBytesPerToken = sizing.fp16KVBytesPerToken
+            targetKVBytesPerToken = sizing.fp16KVBytesPerToken
+        }
+        let assistantStateBytesPerToken = assistantHandle?.drafter?.requestStateBytesPerToken ?? 0
+        let (processKVBytesPerToken, processRateOverflow) = targetKVBytesPerToken
+            .addingReportingOverflow(assistantStateBytesPerToken)
+        guard !processRateOverflow else {
+            throw EngineV2ProductionError.noKVHeadroom
+        }
+
+        let fixedRequestBytes: Int
+        if let recurrent = servingModel as? any CBv2RecurrentLanguageModelForwardable {
+            // Keep the process-wide admission gate aligned with EngineV2's
+            // request-owned recurrent-state charge. Invalid geometry must
+            // refuse the load rather than advertise capacity that cannot fit.
+            fixedRequestBytes = try recurrent.cbv2RecurrentStateSpec.fixedBytesPerRequest()
+        } else {
+            fixedRequestBytes = 0
         }
 
         let bridge = try EngineV2Factory.makeBridge(
@@ -579,6 +608,7 @@ enum EngineV2SlotFactory {
             defaultMaxTokens: sizing.defaultMaxTokens,
             maxConcurrentRequests: maxConcurrentRequests,
             kvBytesPerToken: processKVBytesPerToken,
+            fixedRequestBytes: fixedRequestBytes,
             // Shared KV ledger: v2 submissions RESERVE their worst-case
             // KV here before engine admission (process-wide gate) and the
             // reservation is what the model-LOAD gate subtracts.

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2SupportedModels.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2SupportedModels.swift
@@ -13,8 +13,9 @@
 //   * `gemma4`       — Gemma 4 VLM wrapper, serving through its directly
 //                      owned text tower plus vision prefill
 //   * `gemma4_text`  — Gemma 4 text target
+//   * `qwen3_5_moe` — Qwen 3.5/3.6 MoE VLM target with recurrent state
 //
-// Everything else (gemma3, qwen*, llama, …) has no CBv2 adapter: it is
+// Everything else (gemma3, other qwen families, llama, …) is
 // dropped from the advertised set at startup and at prefetch-verify time
 // (WARN log), so the coordinator never routes to it. A load request for an
 // unsupported id (stale catalog) then fails the advertised-set guard in
@@ -40,6 +41,7 @@ public enum EngineV2SupportedModels {
     public static func isSupported(modelType: String?) -> Bool {
         guard let raw = normalized(modelType) else { return false }
         if raw == "gpt_oss" { return true }
+        if raw == "qwen3_5_moe" { return true }
         return gemma4TargetTypes.contains(raw)
     }
 

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2VLMTextExtraction.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2VLMTextExtraction.swift
@@ -1,0 +1,380 @@
+// Copyright © 2026 Eigen Labs.
+//
+// ContinuousBatchingV2 — weight-sharing Qwen target extraction for VLM slots.
+//
+// Gemma 4 is deliberately absent: its MLXVLM wrapper directly owns the
+// `Gemma4TextModel` served by CBv2. Only `MLXVLM.Qwen35MoE` needs a separate
+// MLXLLM target over the same immutable weight arrays.
+//
+//   1. decode the checkpoint with the matching MLXLLM config type and
+//      construct a lazy skeleton
+//      (nothing is materialized — MLXArray init is lazy until eval);
+//   2. re-apply the checkpoint's quantization STRUCTURE to the skeleton the
+//      exact way `loadWeights` did for the wrapper (scales-presence gate +
+//      the same per-layer table from `BaseConfiguration`, whose keys live in
+//      the checkpoint's `language_model.`-prefixed key space);
+//   3. retain only the wrapper's live `language_model.*` target tree, run the
+//      target sanitizer, and
+//      `update(parameters:verify:[.all])` — missing/extra/mis-shaped keys
+//      all THROW, which the engine factory catches as the standard
+//      `engine_v2_refusal` ERROR + load failure (never silent wrongness);
+//   4. run a tiny forward through BOTH the wrapper's text path and the
+//      extracted model and require cross-containment of each side's greedy
+//      argmax in the other side's top-5, plus a bounded max |Δlogit| — a
+//      load-time backstop against catastrophic extraction bugs (see
+//      `assertForwardParity`; Qwen uses a fixed-probe containment guard with
+//      a scale-relative logit bound; env
+//      `DARKBLOOM_ENGINE_V2_VLM_PARITY_CHECK=0` skips).
+//
+// The result is a SEPARATE module instance (own norms/rope/layer objects)
+// sharing only the immutable parameter arrays — zero extra weight memory,
+// and no module-level mutable state shared with the wrapper, which is what
+// makes the Qwen3.5-mrope class of cross-path state corruption structurally
+// impossible here. Concurrency: the legacy vision forward (wrapper) and v2
+// text forward (extracted model) may interleave on the same arrays; both
+// are read-only over the parameters (forward passes never mutate weights)
+// and each path owns its private KV caches.
+
+import Foundation
+import MLX
+import MLXLLM
+import MLXLMCommon
+import MLXNN
+import MLXVLM
+
+/// Failure modes of Qwen VLM text-model extraction. Every case lands in
+/// `EngineV2Factory.makeBridge`'s catch → ERROR `engine_v2_refusal`
+/// telemetry + load refusal. The messages are operator-facing (they ride
+/// the telemetry `error` field), so they say exactly what to look at.
+enum EngineV2VLMTextExtractionError: Error, CustomStringConvertible {
+    /// The loaded module is not a VLM wrapper this extraction understands.
+    case unsupportedWrapper(String)
+    /// The slot factory could not hand us the model directory (needed for
+    /// `config.json`).
+    case missingModelDirectory
+    /// `config.json` was unreadable or had no decodable `text_config`.
+    case invalidConfig(String)
+    /// The checkpoint has quantized weights but no `quantization` block in
+    /// `config.json` to derive the skeleton's quantization structure from.
+    case missingQuantizationConfig
+    /// The load-time forward parity gate failed: the extracted text model
+    /// disagrees with the wrapper's own text path on the same weights.
+    case parityMismatch(String)
+
+    var description: String {
+        switch self {
+        case .unsupportedWrapper(let type):
+            return "engine_v2 vlm extraction: unsupported VLM wrapper \(type)"
+        case .missingModelDirectory:
+            return "engine_v2 vlm extraction: model directory unavailable for config.json"
+        case .invalidConfig(let detail):
+            return "engine_v2 vlm extraction: config.json unusable (\(detail))"
+        case .missingQuantizationConfig:
+            return "engine_v2 vlm extraction: quantized weights but no quantization block in config.json"
+        case .parityMismatch(let detail):
+            return "engine_v2 vlm extraction: wrapper/extracted forward parity failed (\(detail))"
+        }
+    }
+}
+
+/// Weight-sharing extraction of the CBv2-adapted MLXLLM Qwen target from a
+/// loaded `MLXVLM.Qwen35MoE` wrapper. Pure functions; no state.
+enum EngineV2VLMTextExtraction {
+
+    enum Family: String, Sendable {
+        case qwen35MoE
+    }
+
+    /// Env kill switch for the load-time forward parity gate ("0"/"false"/
+    /// "no"/"off" disables). Default ON — the check is one tiny prefill at
+    /// model-load time and is the backstop against silent architecture
+    /// drift between MLXVLM's inline text model and MLXLLM's.
+    static let parityCheckFlag = "DARKBLOOM_ENGINE_V2_VLM_PARITY_CHECK"
+
+    /// Checkpoint key-space prefix of the wrapper's language model. Both the
+    /// parameter tree and the per-layer quantization table use it.
+    private static let languageModelPrefix = "language_model."
+
+    /// Result of one extraction: the CBv2-adapted text model (sharing the
+    /// wrapper's weight arrays) plus the parity probe's max |Δlogit| for the
+    /// slot factory's log line (nil when the parity gate was disabled).
+    struct Extraction {
+        let servingModel: any LanguageModel
+        let family: Family
+        let parityMaxAbsLogitDiff: Float?
+
+    }
+
+    /// Build an MLXLLM `Qwen35MoEModel` over the weight arrays of a loaded
+    /// MLXVLM `Qwen35MoE` wrapper. See the file header for the full mechanism.
+    ///
+    /// - Parameters:
+    ///   - model: the slot's loaded module (must be `MLXVLM.Qwen35MoE`).
+    ///   - modelDirectory: the checkpoint directory (for `config.json`).
+    ///   - environment: env snapshot (parity-gate kill switch).
+    static func extractTextModel(
+        from model: any LanguageModel,
+        modelDirectory: URL,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) throws -> Extraction {
+        guard let wrapper = model as? MLXVLM.Qwen35MoE else {
+            throw EngineV2VLMTextExtractionError.unsupportedWrapper(
+                String(describing: type(of: model)))
+        }
+        let configURL = modelDirectory.appendingPathComponent("config.json")
+        let configData: Data
+        do {
+            configData = try Data(contentsOf: configURL)
+        } catch {
+            throw EngineV2VLMTextExtractionError.invalidConfig(
+                "read \(configURL.path): \(error)")
+        }
+        // Quantization table: `BaseConfiguration` holds the checkpoint-wide
+        // default plus the per-layer overrides, keyed in the checkpoint's
+        // `language_model.`-prefixed key space.
+        let baseConfig = try? JSONDecoder.json5().decode(BaseConfiguration.self, from: configData)
+
+        return try extractQwen35MoE(
+            wrapper: wrapper,
+            configData: configData,
+            perLayerQuantization: baseConfig?.perLayerQuantization,
+            environment: environment)
+    }
+
+    private static func extractQwen35MoE(
+        wrapper: MLXVLM.Qwen35MoE,
+        configData: Data,
+        perLayerQuantization: BaseConfiguration.PerLayerQuantization?,
+        environment: [String: String]
+    ) throws -> Extraction {
+        // The combined artifact may declare and carry inline `mtp.*` tensors.
+        // This module is the serving TARGET only: force the MLXLLM skeleton's
+        // optional inline head off independently of the process-global MTP
+        // loader flag. Assistant ownership stays with ProviderCore's separate
+        // partition/load path.
+        let targetConfig = try decodeQwenConfiguration(configData: configData)
+        let skeleton = Qwen35MoEModel(targetConfig)
+        let targetWeights = reKeyedQwenTargetWeights(
+            flattenedWeights: wrapper.parameters().flattened(), sanitizer: skeleton)
+        try applyQuantizationStructure(
+            skeleton: skeleton,
+            weights: targetWeights,
+            family: .qwen35MoE,
+            perLayerQuantization: perLayerQuantization)
+        try skeleton.update(
+            parameters: ModuleParameters.unflattened(targetWeights), verify: [.all])
+
+        let parityDiff = try runParityGateIfEnabled(environment: environment) {
+            try assertQwenForwardParity(
+                wrapper: wrapper,
+                extracted: skeleton,
+                vocabSize: skeleton.vocabularySize)
+        }
+        return Extraction(
+            servingModel: skeleton,
+            family: .qwen35MoE,
+            parityMaxAbsLogitDiff: parityDiff)
+    }
+
+    private static func runParityGateIfEnabled(
+        environment: [String: String],
+        _ check: () throws -> Float
+    ) throws -> Float? {
+        guard parityCheckEnabled(environment: environment) else { return nil }
+        defer {
+            MLX.Stream().synchronize()
+            MLX.Memory.clearCache()
+        }
+        return try check()
+    }
+
+    // MARK: - Steps
+
+    /// Decode the top-level Qwen target configuration using MLXLLM's type,
+    /// after disabling the optional inline MTP module in a copied JSON object.
+    /// The checkpoint and loaded wrapper are never mutated.
+    static func decodeQwenConfiguration(configData: Data) throws -> MLXLLM.Qwen35Configuration {
+        var root = try configurationObject(configData: configData)
+        if var textConfig = root["text_config"] as? [String: Any] {
+            textConfig["mtp_num_hidden_layers"] = 0
+            root["text_config"] = textConfig
+        } else {
+            root["mtp_num_hidden_layers"] = 0
+        }
+        do {
+            let targetData = try JSONSerialization.data(withJSONObject: root)
+            return try JSONDecoder.json5().decode(
+                MLXLLM.Qwen35Configuration.self, from: targetData)
+        } catch {
+            throw EngineV2VLMTextExtractionError.invalidConfig("decode Qwen target config: \(error)")
+        }
+    }
+
+    /// Config-only Qwen text decode for sizing. Uses MLXLLM's text config
+    /// type directly and never constructs a module skeleton.
+    static func decodeQwenTextConfiguration(configData: Data) throws -> Qwen35TextConfiguration {
+        let root = try configurationObject(configData: configData)
+        let textJSON = (root["text_config"] as? [String: Any]) ?? root
+        do {
+            let textData = try JSONSerialization.data(withJSONObject: textJSON)
+            return try JSONDecoder.json5().decode(Qwen35TextConfiguration.self, from: textData)
+        } catch {
+            throw EngineV2VLMTextExtractionError.invalidConfig("decode Qwen text_config: \(error)")
+        }
+    }
+
+    private static func configurationObject(configData: Data) throws -> [String: Any] {
+        do {
+            guard
+                let parsed = try JSONSerialization.jsonObject(with: configData)
+                    as? [String: Any]
+            else {
+                throw EngineV2VLMTextExtractionError.invalidConfig("config.json is not an object")
+            }
+            return parsed
+        } catch let error as EngineV2VLMTextExtractionError {
+            throw error
+        } catch {
+            throw EngineV2VLMTextExtractionError.invalidConfig("parse config.json: \(error)")
+        }
+    }
+
+    /// Select only the live target arrays from Qwen's wrapper parameter tree.
+    /// `mtp.*` is top-level and therefore excluded; vision parameters are
+    /// under `vision_tower.*` and excluded too. The MLXLLM Qwen target keeps
+    /// the same `language_model.*` namespace, so no second prefix transform is
+    /// needed. Dictionary assignment retains the same lazy MLXArray handles.
+    static func reKeyedQwenTargetWeights(
+        flattenedWeights: [(String, MLXArray)], sanitizer: Qwen35MoEModel
+    ) -> [String: MLXArray] {
+        var targetWeights: [String: MLXArray] = [:]
+        targetWeights.reserveCapacity(flattenedWeights.count)
+        for (key, value) in flattenedWeights where key.hasPrefix(languageModelPrefix) {
+            targetWeights[key] = value
+        }
+        return sanitizer.sanitize(weights: targetWeights)
+    }
+
+    /// Mirror `loadWeights`' quantization pass onto the skeleton: a module is
+    /// quantized iff the (re-keyed, live) weights carry `<path>.scales`, with
+    /// (groupSize, bits, mode) resolved from the checkpoint's per-layer table
+    /// under the module's `language_model.`-prefixed checkpoint key — the
+    /// exact lookup the wrapper's own load performed, so the two module trees
+    /// can never disagree on quantization structure. All arrays involved stay
+    /// lazy; `update(parameters:)` replaces them before anything evaluates.
+    static func applyQuantizationStructure<Model: Module>(
+        skeleton: Model,
+        weights: [String: MLXArray],
+        family: Family,
+        perLayerQuantization: BaseConfiguration.PerLayerQuantization?
+    ) throws {
+        let hasQuantizedWeights = weights.keys.contains { $0.hasSuffix(".scales") }
+        guard hasQuantizedWeights else { return }
+        guard let perLayerQuantization else {
+            throw EngineV2VLMTextExtractionError.missingQuantizationConfig
+        }
+        quantize(model: skeleton) { path, _ in
+            guard weights["\(path).scales"] != nil else { return nil }
+            return quantization(
+                targetPath: path,
+                family: family,
+                perLayerQuantization: perLayerQuantization)?.asTuple
+        }
+    }
+
+    /// Resolve the checkpoint quantization table in the Qwen wrapper's
+    /// unchanged `language_model.*` key space.
+    static func quantization(
+        targetPath: String,
+        family: Family,
+        perLayerQuantization: BaseConfiguration.PerLayerQuantization
+    ) -> BaseConfiguration.Quantization? {
+        _ = family
+        return perLayerQuantization.quantization(layer: targetPath)
+    }
+
+    // MARK: - Parity gate
+
+    static func parityCheckEnabled(environment: [String: String]) -> Bool {
+        guard
+            let raw = environment[parityCheckFlag]?
+                .trimmingCharacters(in: .whitespaces).lowercased(), !raw.isEmpty
+        else { return true }
+        return !["0", "false", "no", "off"].contains(raw)
+    }
+
+    /// Top-k window for the bidirectional argmax-containment check.
+    static let parityTopK = 5
+    /// Qwen text-only mRoPE uses three identical position axes, so the
+    /// wrapper and MLXLLM target should be substantially closer than the
+    /// known Gemma implementation split. Keep the top-k catastrophe guard,
+    /// and scale the magnitude bound to the wrapper's fixed-probe logits
+    /// because Qwen has no final-logit softcap.
+    private static func assertQwenForwardParity(
+        wrapper: MLXVLM.Qwen35MoE,
+        extracted: Qwen35MoEModel,
+        vocabSize: Int
+    ) throws -> Float {
+        let probeTokens = [1, 17, 29, 43, 61].map {
+            min($0, max(0, vocabSize - 1))
+        }
+        let inputs = MLXArray(probeTokens.map(Int32.init)).expandedDimensions(axis: 0)
+        let wrapperLogits = wrapper(inputs, cache: nil).asType(.float32)
+        let extractedLogits = extracted(inputs, cache: nil).asType(.float32)
+        let wrapperMaxMagnitude = MLX.abs(wrapperLogits).max()
+        eval(wrapperMaxMagnitude)
+        let maxAbsDiffLimit = max(
+            2,
+            wrapperMaxMagnitude.item(Float.self) * 0.25)
+        return try assertParity(
+            wrapperLogits: wrapperLogits,
+            extractedLogits: extractedLogits,
+            positions: probeTokens.count,
+            maxAbsDiffLimit: maxAbsDiffLimit)
+    }
+
+    private static func assertParity(
+        wrapperLogits: MLXArray,
+        extractedLogits: MLXArray,
+        positions: Int,
+        maxAbsDiffLimit: Float
+    ) throws -> Float {
+
+        let k = parityTopK
+        // Top-k token ids per position, [1, L, k] (unordered within k).
+        let wrapperTopK = argPartition(-wrapperLogits, kth: k - 1, axis: -1)[.ellipsis, ..<k]
+        let extractedTopK = argPartition(-extractedLogits, kth: k - 1, axis: -1)[.ellipsis, ..<k]
+        let wrapperArgmax = argMax(wrapperLogits, axis: -1)
+        let extractedArgmax = argMax(extractedLogits, axis: -1)
+        let maxAbsDiff = MLX.abs(wrapperLogits - extractedLogits).max()
+        eval(wrapperTopK, extractedTopK, wrapperArgmax, extractedArgmax, maxAbsDiff)
+
+        let wrapperIds = wrapperArgmax.asArray(Int32.self)
+        let extractedIds = extractedArgmax.asArray(Int32.self)
+        let wrapperTop = wrapperTopK.asArray(Int32.self)  // row-major [L × k]
+        let extractedTop = extractedTopK.asArray(Int32.self)
+        let diff = maxAbsDiff.item(Float.self)
+
+        for position in 0 ..< positions {
+            let window = position * k ..< (position + 1) * k
+            let wrapperWindow = Set(wrapperTop[window])
+            let extractedWindow = Set(extractedTop[window])
+            guard extractedWindow.contains(wrapperIds[position]),
+                wrapperWindow.contains(extractedIds[position])
+            else {
+                throw EngineV2VLMTextExtractionError.parityMismatch(
+                    "top-\(k) containment failed at position \(position): "
+                        + "wrapper argmax \(wrapperIds[position]) vs extracted top-\(k) "
+                        + "\(extractedWindow.sorted()); extracted argmax "
+                        + "\(extractedIds[position]) vs wrapper top-\(k) "
+                        + "\(wrapperWindow.sorted()); maxAbsLogitDiff=\(diff)")
+            }
+        }
+        guard diff <= maxAbsDiffLimit else {
+            throw EngineV2VLMTextExtractionError.parityMismatch(
+                "max |Δlogit| \(diff) exceeds \(maxAbsDiffLimit) "
+                    + "(argmax containment held — distributions drifted)")
+        }
+        return diff
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2VisionPrefill.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2VisionPrefill.swift
@@ -47,7 +47,8 @@
 // failover reroutes the request invisibly. There is NO legacy fallback for
 // media on a v2-bridged slot (the pre-release `engine_v2_vision_fallback` WARN
 // is gone with it). Deterministic input faults (`MediaError` — malformed/
-// oversized media) keep their 4xx mapping and are not refusals.
+// oversized media, or an intentionally unsupported family/media pairing) keep
+// their 4xx mapping and are not refusals.
 //
 // BACKEND NOTE: CBv2 multimodal prefill requires a KV backend whose layer
 // caches AFFIRM `CBv2MultimodalSpanCapableCache.honorsSpanMaskContexts`;
@@ -81,14 +82,15 @@ public enum EngineV2MediaKind: String, Sendable {
 
 /// Construction failures of the v2 media-prefill submission. Every case is
 /// caught by the scheduler engine and REFUSED loudly (ERROR telemetry + a
-/// retriable 503; the coordinator reroutes) — except `noProcessedMedia`,
-/// which is a deterministic request shape mapped to a 400 client fault (see
-/// its doc). Messages are operator-facing — they ride the telemetry `error`
-/// field and the client-facing rejection message, and must never embed
-/// prompt or media content.
+/// retriable 503; the coordinator reroutes) except deterministic request
+/// shapes (`noProcessedMedia` and `unsupportedMedia`), which map to 400.
+/// Messages are operator-facing and must never embed prompt or media content.
 enum EngineV2VisionPrefillError: Error, CustomStringConvertible {
     /// The slot's loaded module is not a supported Gemma 4 or Qwen wrapper.
     case unsupportedVLM(String)
+    /// The loaded family intentionally rejects this media shape on every
+    /// provider, so rerouting cannot make the request serveable.
+    case unsupportedMedia(String)
     /// The processor produced neither image nor video pixels for a media
     /// request — every media part sits on a non-user role, which
     /// `buildUserInput` drops (identically on the legacy path). This shape
@@ -126,6 +128,8 @@ enum EngineV2VisionPrefillError: Error, CustomStringConvertible {
         switch self {
         case .unsupportedVLM(let type):
             return "engine_v2 media prefill: unsupported VLM wrapper \(type)"
+        case .unsupportedMedia(let detail):
+            return "engine_v2 media prefill: unsupported media \(detail)"
         case .noProcessedMedia:
             return "engine_v2 media prefill: processor produced no image or video pixels"
         case .emptyVisionFeatures(let kind):
@@ -235,7 +239,8 @@ public enum EngineV2VisionPrefill {
     /// its 4xx mapping) and `CancellationError` (the caller went away).
     static func prepare(
         container: ModelContainer,
-        request: OpenAIChatCompletionRequest
+        request: OpenAIChatCompletionRequest,
+        reasoningEffort: String? = nil
     ) async throws -> PreparedSubmission {
         // Same decode path as the legacy stream (same caps, same MediaError
         // surface). Keep temporary video files alive through processor
@@ -244,7 +249,7 @@ public enum EngineV2VisionPrefill {
         var tempFiles: [URL] = []
         defer { for url in tempFiles { try? FileManager.default.removeItem(at: url) } }
         let userInput = try await MediaIngest.buildUserInput(
-            from: request, tempFiles: &tempFiles)
+            from: request, tempFiles: &tempFiles, reasoningEffort: reasoningEffort)
         return try await container.perform(nonSendable: userInput) { ctx, userInput in
             let lmInput = try await ctx.processor.prepare(input: userInput)
             guard lmInput.image != nil || lmInput.video != nil else {
@@ -259,7 +264,7 @@ public enum EngineV2VisionPrefill {
                 // Video remains fail-closed until a real processor/output
                 // representation canary pins temporal packing end-to-end.
                 guard lmInput.video == nil else {
-                    throw EngineV2VisionPrefillError.unsupportedVLM(
+                    throw EngineV2VisionPrefillError.unsupportedMedia(
                         "Qwen35MoE video media is not production-proven")
                 }
                 guard let image = lmInput.image else {
@@ -559,12 +564,12 @@ public enum EngineV2VisionPrefill {
 /// preparer so the full routing seam is exercisable without model weights.
 public struct EngineV2VisionPlumbing: Sendable {
     let prepare:
-        @Sendable (ModelContainer, OpenAIChatCompletionRequest) async throws
+        @Sendable (ModelContainer, OpenAIChatCompletionRequest, String?) async throws
             -> EngineV2VisionPrefill.PreparedSubmission
     let emitTelemetry: @Sendable (TelemetryEvent) -> Void
 
     init(
-        prepare: @escaping @Sendable (ModelContainer, OpenAIChatCompletionRequest)
+        prepare: @escaping @Sendable (ModelContainer, OpenAIChatCompletionRequest, String?)
             async throws -> EngineV2VisionPrefill.PreparedSubmission,
         emitTelemetry: @escaping @Sendable (TelemetryEvent) -> Void
     ) {
@@ -573,8 +578,9 @@ public struct EngineV2VisionPlumbing: Sendable {
     }
 
     static let production = EngineV2VisionPlumbing(
-        prepare: { container, request in
-            try await EngineV2VisionPrefill.prepare(container: container, request: request)
+        prepare: { container, request, reasoningEffort in
+            try await EngineV2VisionPrefill.prepare(
+                container: container, request: request, reasoningEffort: reasoningEffort)
         },
         emitTelemetry: { TelemetryClient.shared.emit($0) }
     )

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2VisionPrefill.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2VisionPrefill.swift
@@ -87,9 +87,8 @@ public enum EngineV2MediaKind: String, Sendable {
 /// field and the client-facing rejection message, and must never embed
 /// prompt or media content.
 enum EngineV2VisionPrefillError: Error, CustomStringConvertible {
-    /// The slot's loaded module is not the MLXVLM Gemma4 wrapper, the only
-    /// VLM whose directly owned text tower and media seam CBv2 supports.
-    case notGemmaVLM(String)
+    /// The slot's loaded module is not a supported Gemma 4 or Qwen wrapper.
+    case unsupportedVLM(String)
     /// The processor produced neither image nor video pixels for a media
     /// request — every media part sits on a non-user role, which
     /// `buildUserInput` drops (identically on the legacy path). This shape
@@ -125,7 +124,7 @@ enum EngineV2VisionPrefillError: Error, CustomStringConvertible {
 
     var description: String {
         switch self {
-        case .notGemmaVLM(let type):
+        case .unsupportedVLM(let type):
             return "engine_v2 media prefill: unsupported VLM wrapper \(type)"
         case .noProcessedMedia:
             return "engine_v2 media prefill: processor produced no image or video pixels"
@@ -192,8 +191,24 @@ public enum EngineV2VisionPrefill {
         public let promptTokens: [Int]
         public let spans: [CBv2ImageSpan]
         public let embeddings: [MLXArray]
+        public let attention: CBv2MultimodalAttention
+        public let positionState: CBv2PositionState?
         /// Coarse request shape (image / video / mixed) for telemetry.
         public let mediaKind: EngineV2MediaKind
+
+        public init(
+            promptTokens: [Int], spans: [CBv2ImageSpan], embeddings: [MLXArray],
+            attention: CBv2MultimodalAttention = .bidirectionalSpans,
+            positionState: CBv2PositionState? = nil,
+            mediaKind: EngineV2MediaKind
+        ) {
+            self.promptTokens = promptTokens
+            self.spans = spans
+            self.embeddings = embeddings
+            self.attention = attention
+            self.positionState = positionState
+            self.mediaKind = mediaKind
+        }
 
         /// The engine-facing input. The closure returns the precomputed
         /// arrays — the contract's "typically it returns precomputed
@@ -201,7 +216,10 @@ public enum EngineV2VisionPrefill {
         /// vision work.
         public func multimodalInput() -> CBv2MultimodalInput {
             let arrays = embeddings
-            return CBv2MultimodalInput(spans: spans) { arrays }
+            return CBv2MultimodalInput(
+                spans: spans, attention: attention,
+                positionState: positionState
+            ) { arrays }
         }
     }
 
@@ -219,21 +237,15 @@ public enum EngineV2VisionPrefill {
         container: ModelContainer,
         request: OpenAIChatCompletionRequest
     ) async throws -> PreparedSubmission {
-        try await container.perform { ctx in
-            guard let wrapper = ctx.model as? MLXVLM.Gemma4 else {
-                throw EngineV2VisionPrefillError.notGemmaVLM(
-                    String(describing: type(of: ctx.model)))
-            }
-            // Same decode path as the legacy stream (same caps, same
-            // MediaError surface). Inline videos are written to temp files
-            // for AVFoundation; `processor.prepare` consumes them fully
-            // (frame sampling, resize, and rasterization all happen inside
-            // it), so they are removed when this closure exits — on every
-            // path.
-            var tempFiles: [URL] = []
-            defer { for url in tempFiles { try? FileManager.default.removeItem(at: url) } }
-            let userInput = try await MediaIngest.buildUserInput(
-                from: request, tempFiles: &tempFiles)
+        // Same decode path as the legacy stream (same caps, same MediaError
+        // surface). Keep temporary video files alive through processor
+        // preparation; the processor fully consumes them under container
+        // isolation before this scope exits.
+        var tempFiles: [URL] = []
+        defer { for url in tempFiles { try? FileManager.default.removeItem(at: url) } }
+        let userInput = try await MediaIngest.buildUserInput(
+            from: request, tempFiles: &tempFiles)
+        return try await container.perform(nonSendable: userInput) { ctx, userInput in
             let lmInput = try await ctx.processor.prepare(input: userInput)
             guard lmInput.image != nil || lmInput.video != nil else {
                 throw EngineV2VisionPrefillError.noProcessedMedia
@@ -242,6 +254,49 @@ public enum EngineV2VisionPrefill {
             // [1, L] → [Int]. Forces evaluation of the (tiny, host-built)
             // token array only.
             let promptTokens = lmInput.text.tokens.asArray(Int32.self).map(Int.init)
+
+            if let wrapper = ctx.model as? MLXVLM.Qwen35MoE {
+                // Video remains fail-closed until a real processor/output
+                // representation canary pins temporal packing end-to-end.
+                guard lmInput.video == nil else {
+                    throw EngineV2VisionPrefillError.unsupportedVLM(
+                        "Qwen35MoE video media is not production-proven")
+                }
+                guard let image = lmInput.image else {
+                    throw EngineV2VisionPrefillError.noProcessedMedia
+                }
+                let features = try wrapper.visionFeatures(
+                    imagePixels: image.pixels, imageGrids: image.frames)
+                let imageFeatures = features.ordered.map(\.features)
+                guard !imageFeatures.isEmpty else {
+                    throw EngineV2VisionPrefillError.emptyVisionFeatures(kind: .image)
+                }
+                let carved = try carveSpans(
+                    tokens: promptTokens,
+                    imagePlaceholderId: wrapper.imagePlaceholderTokenId,
+                    imageSpanLengths: imageFeatures.map { $0.dim(1) },
+                    videoPlaceholderId: nil,
+                    videoSpanLengths: [])
+                let position = try wrapper.positionResult(
+                    tokens: lmInput.text.tokens,
+                    imageGrids: image.frames,
+                    attentionMask: lmInput.text.mask)
+                eval(imageFeatures + [position.promptPositionIds])
+                return PreparedSubmission(
+                    promptTokens: promptTokens,
+                    spans: carved.map(\.span),
+                    embeddings: imageFeatures,
+                    attention: .causal,
+                    positionState: CBv2PositionState(
+                        promptPositionIds: position.promptPositionIds,
+                        decodeDeltas: position.decodeState.deltas),
+                    mediaKind: .image)
+            }
+
+            guard let wrapper = ctx.model as? MLXVLM.Gemma4 else {
+                throw EngineV2VisionPrefillError.unsupportedVLM(
+                    String(describing: type(of: ctx.model)))
+            }
 
             // Vision tower + multimodal projector — the SAME arrays the
             // wrapper's own `prepare` scatters: one per image, one per
@@ -313,6 +368,8 @@ public enum EngineV2VisionPrefill {
                 promptTokens: promptTokens,
                 spans: carved.map(\.span),
                 embeddings: embeddings,
+                attention: .bidirectionalSpans,
+                positionState: nil,
                 mediaKind: lmInput.video == nil
                     ? .image : (lmInput.image == nil ? .video : .mixed))
         }

--- a/provider-swift/Sources/ProviderCore/Inference/MediaIngest.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/MediaIngest.swift
@@ -261,7 +261,10 @@ public enum MediaIngest {
                 chatMessages.append(.tool(text))
             }
         }
-        return UserInput(chat: chatMessages)
+        return UserInput(
+            chat: chatMessages,
+            additionalContext: MultiModelBatchSchedulerEngine.templateAdditionalContext(
+                for: request, reasoningEffort: nil))
     }
 
     /// Convenience overload that discards temp-file tracking. Used by

--- a/provider-swift/Sources/ProviderCore/Inference/MediaIngest.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/MediaIngest.swift
@@ -233,6 +233,7 @@ public enum MediaIngest {
     static func buildUserInput(
         from request: OpenAIChatCompletionRequest,
         tempFiles: inout [URL],
+        reasoningEffort: String? = nil,
         maxImagePixels: Int = Self.maxImagePixels,
         maxRequestImagePixels: Int = Self.maxRequestImagePixels,
         maxVideosPerRequest: Int = Self.maxVideosPerRequest,
@@ -264,13 +265,14 @@ public enum MediaIngest {
         return UserInput(
             chat: chatMessages,
             additionalContext: MultiModelBatchSchedulerEngine.templateAdditionalContext(
-                for: request, reasoningEffort: nil))
+                for: request, reasoningEffort: reasoningEffort))
     }
 
     /// Convenience overload that discards temp-file tracking. Used by
     /// tests that pass only base64/url images (no inline videos).
     static func buildUserInput(
         from request: OpenAIChatCompletionRequest,
+        reasoningEffort: String? = nil,
         maxImagePixels: Int = Self.maxImagePixels,
         maxRequestImagePixels: Int = Self.maxRequestImagePixels,
         maxVideosPerRequest: Int = Self.maxVideosPerRequest,
@@ -278,7 +280,8 @@ public enum MediaIngest {
     ) async throws -> UserInput {
         var sink: [URL] = []
         return try await buildUserInput(
-            from: request, tempFiles: &sink, maxImagePixels: maxImagePixels,
+            from: request, tempFiles: &sink, reasoningEffort: reasoningEffort,
+            maxImagePixels: maxImagePixels,
             maxRequestImagePixels: maxRequestImagePixels,
             maxVideosPerRequest: maxVideosPerRequest,
             maxRequestVideoFramePixels: maxRequestVideoFramePixels)

--- a/provider-swift/Sources/ProviderCore/Inference/MultiModelBatchSchedulerEngine.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/MultiModelBatchSchedulerEngine.swift
@@ -343,16 +343,18 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
             // coordinator's pre-content failover reroutes invisibly. The
             // legacy wrapper path below is NOT reachable for media on a
             // v2-bridged slot anymore (the pre-release silent fallback is gone).
-            // Three throws are NOT refusals: `CancellationError` (the
+            // Four throws are NOT refusals: `CancellationError` (the
             // caller went away — propagate, 499), `MediaError`
             // (deterministic input fault — keeps its 4xx mapping), and
             // `noProcessedMedia` (media on non-user roles only — a
             // deterministic 400; rerouting would fail identically
-            // everywhere).
+            // everywhere), plus `unsupportedMedia` (the loaded family rejects
+            // this shape on every equivalent provider).
             if let bridge = engineV2Bridge {
                 let plumbing = engineV2Vision ?? .production
                 do {
-                    let visionPrepared = try await plumbing.prepare(container, request)
+                    let visionPrepared = try await plumbing.prepare(
+                        container, request, reasoningEffort)
                     let visionRequestId = "req-\(UUID().uuidString.prefix(12))"
                     // Hand off memory accounting to the bridge BEFORE
                     // submit: the decode-phase peak this vision reservation
@@ -429,6 +431,24 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
                     throw MultiModelBatchSchedulerEngineError.multimodalRejected(
                         "multimodal_rejected: media parts must be attached to user "
                             + "messages; none of this request's media was consumable")
+                } catch let visionError as EngineV2VisionPrefillError {
+                    if case .unsupportedMedia(let detail) = visionError {
+                        await mediaGate.release(requestId: mediaReqId)
+                        await releaseBox.fire()
+                        throw MultiModelBatchSchedulerEngineError.multimodalRejected(
+                            "multimodal_rejected: \(detail)")
+                    }
+                    await mediaGate.release(requestId: mediaReqId)
+                    await releaseBox.fire()
+                    let mediaKind = EngineV2VisionPrefill.mediaKind(of: request)
+                    plumbing.emitTelemetry(
+                        EngineV2VisionPrefill.refusalTelemetryEvent(
+                            modelId: modelId, mediaKind: mediaKind, error: visionError))
+                    throw MultiModelBatchSchedulerEngineError.requestRejected(
+                        "engine_v2 media prefill construction failed "
+                            + "(media=\(mediaKind.rawValue)): "
+                            + EngineV2VisionPrefill.refusalDetail(for: visionError)
+                            + " — request not started; retry on another provider")
                 } catch {
                     // REFUSAL: v2 media-prefill construction failed on this
                     // provider. ERROR telemetry (media-kind tagged) + 503 —

--- a/provider-swift/Sources/ProviderCore/Inference/SlotSizingSnapshot.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/SlotSizingSnapshot.swift
@@ -116,6 +116,7 @@ public struct SlotSizingSnapshot: Sendable, Equatable {
         struct ModuleFacts: @unchecked Sendable {
             let bytes: Int
             let moduleKVRate: Int?
+            let isQwenVLMWrapper: Bool
         }
         let facts = await container.perform { ctx -> ModuleFacts in
             let bytes = ctx.model.parameters().flattened().reduce(0) { $0 + $1.1.nbytes }
@@ -133,10 +134,20 @@ public struct SlotSizingSnapshot: Sendable, Equatable {
                 // Direct ownership makes the loaded tower engine truth with
                 // no config re-decode or second topology that can drift.
                 rate = fp16KVBytesPerToken(layerKinds: gemma.textModel.cbv2LayerKinds)
+            case let qwen as Qwen35MoEModel:
+                rate = fp16KVBytesPerToken(layerKinds: qwen.cbv2LayerKinds)
+            case is MLXVLM.Qwen35MoE:
+                return ModuleFacts(
+                    bytes: bytes,
+                    moduleKVRate: nil,
+                    isQwenVLMWrapper: true)
             default:
                 rate = nil
             }
-            return ModuleFacts(bytes: bytes, moduleKVRate: rate)
+            return ModuleFacts(
+                bytes: bytes,
+                moduleKVRate: rate,
+                isQwenVLMWrapper: false)
         }
 
         // Architecture metadata (context window + non-CBv2 fallback rate)
@@ -150,6 +161,9 @@ public struct SlotSizingSnapshot: Sendable, Equatable {
         }
 
         var kvRate = facts.moduleKVRate ?? 0
+        if kvRate <= 0, facts.isQwenVLMWrapper, let modelPath {
+            kvRate = qwenVLMTextKVRate(modelDirectory: modelPath) ?? 0
+        }
         if kvRate <= 0 {
             // Non-CBv2 module: fall back to the config-parse figure so
             // callers that only need a rough rate still get one. Such a
@@ -207,4 +221,14 @@ public struct SlotSizingSnapshot: Sendable, Equatable {
         return total
     }
 
+    static func qwenVLMTextKVRate(modelDirectory: URL) -> Int? {
+        let configURL = modelDirectory.appendingPathComponent("config.json")
+        guard let configData = try? Data(contentsOf: configURL) else { return nil }
+        guard let textConfig = try? EngineV2VLMTextExtraction.decodeQwenTextConfiguration(
+            configData: configData)
+        else { return nil }
+        // Config-only sizing must not instantiate a target module: that would
+        // allocate a second skeleton before extraction.
+        return fp16KVBytesPerToken(layerKinds: textConfig.cbv2LayerKinds)
+    }
 }

--- a/provider-swift/Sources/ProviderCore/ProviderCore.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderCore.swift
@@ -207,5 +207,8 @@ public enum ProviderCore {
     // both default-on and durably rollbackable through provider config. VLM,
     // CBv2, media prefill, and MTP share the canonical Gemma text tower, and
     // serve/benchmark startup projects config before the first MLX access.
-    public static let version = "0.8.2"
+    // 0.8.3 adds Qwen3.6-35B-A3B text, image, and tool serving with request-owned
+    // recurrent/mRoPE state and exact serial verification of its inline MTP.
+    // Unsupported Qwen paths remain fail-closed pending dedicated canaries.
+    public static let version = "0.8.3"
 }

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+EngineV2.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+EngineV2.swift
@@ -279,6 +279,7 @@ extension ProviderLoop {
             prepared = try await EngineV2SlotFactory.prepareProductionModel(
                 modelId: modelId,
                 isVLM: isVLM,
+                modelDirectory: modelDirectory,
                 container: newcomerBox.borrow(),
                 specDecPreparation: specDecPreparation,
                 assistantLoader: engineV2SlotHooks?.assistantLoader
@@ -485,10 +486,8 @@ extension ProviderLoop {
     /// factory emits the ERROR `engine_v2_refusal` event first) — the
     /// caller unloads and maps to 503. There is no legacy path.
     ///
-    /// VLM slots: every production Gemma 4 checkpoint ships a vision tower,
-    /// so the loaded MLXVLM wrapper directly exposes its owned MLXLLM text
-    /// tower to CBv2. Text, image, video, mixed, and MTP requests therefore
-    /// share one language-model identity; media prefills use
+    /// VLM slots: Gemma 4 serves its directly owned MLXLLM text tower; Qwen
+    /// serves the extracted weight-sharing target. Media prefills use
     /// `EngineV2VisionPrefill` (construction failures refuse loudly with 503;
     /// see `MultiModelBatchSchedulerEngine.streamChatCompletion`).
     ///

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+EngineV2Liveness.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+EngineV2Liveness.swift
@@ -187,6 +187,7 @@ extension ProviderLoop {
             var prepared = try await EngineV2SlotFactory.prepareRecoveryModel(
                 modelId: modelId,
                 isVLM: slot.isVLM,
+                modelDirectory: modelDirectory,
                 container: slot.container,
                 previousArtifact: slot.engineBundle.mtpArtifact,
                 previousStatus: slot.engineBundle.mtpStatus,

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+MTP.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+MTP.swift
@@ -14,6 +14,7 @@ extension ProviderLoop {
             SpecDecArtifactFunnel.killSwitchEnabled(
                 environment: ProcessInfo.processInfo.environment),
             let modelId = advertisedModels.values
+                // Inline Qwen assistants need no catalog prewarm.
                 .filter({ EngineV2SupportedModels.isGemma4Target(modelType: $0.modelType) })
                 .map(\.id)
                 .sorted()
@@ -35,6 +36,7 @@ extension ProviderLoop {
     func specDecPreparation(
         modelId: String,
         modelInfo: ModelInfo,
+        modelDirectory: URL? = nil,
         allowDownload: Bool = true
     ) async -> SpecDecPreparation {
         let prepared = await specDecFunnel.prepare(
@@ -43,6 +45,7 @@ extension ProviderLoop {
                 modelType: modelInfo.modelType,
                 enabled: loopConfig.config.backend.mtp,
                 localPath: loopConfig.config.backend.mtpDrafterPath,
+                modelDirectory: modelDirectory,
                 allowDownload: allowDownload,
                 environment: ProcessInfo.processInfo.environment))
         let reason = prepared.status.reason?.rawValue ?? "ready"

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+ModelLoading.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+ModelLoading.swift
@@ -238,7 +238,7 @@ extension ProviderLoop {
             )
         }
         var mtpPreparation = await specDecPreparation(
-            modelId: modelId, modelInfo: modelInfo)
+            modelId: modelId, modelInfo: modelInfo, modelDirectory: modelPath)
 
         // Re-check residency and in-flight loads after the preparation await:
         // a concurrent request for the same cold model can pass the checks
@@ -557,9 +557,9 @@ extension ProviderLoop {
 
             // Post-BRIDGE measured-headroom re-guard (v0.7.3, kept): engine
             // construction can retain additional load-time memory beyond the
-            // weights the check above measured. VLM slots reuse the wrapper's
-            // directly owned text tower; no extraction copy is built. Re-measure
-            // so a box whose full load-time footprint leaves no serveable KV
+            // weights the check above measured. Gemma VLM slots reuse their
+            // directly owned text tower; Qwen adds only a weight-sharing target
+            // module. Re-measure so a box whose full load-time footprint leaves no serveable KV
             // unloads and 503s instead of advertising a model whose every
             // request the shared KV gate rejects — the v0.7.2 black-hole shape.
             // BACKEND-AWARE: a PAGED slot's slabs are committed lazily at

--- a/provider-swift/Sources/ProviderCore/Server/StandaloneServer+MTP.swift
+++ b/provider-swift/Sources/ProviderCore/Server/StandaloneServer+MTP.swift
@@ -2,7 +2,7 @@ import Foundation
 
 extension StandaloneServer {
     func specDecPreparation(
-        modelId: String, modelInfo: ModelInfo
+        modelId: String, modelInfo: ModelInfo, modelDirectory: URL? = nil
     ) async -> SpecDecPreparation {
         await specDecFunnel.prepare(
             .init(
@@ -10,6 +10,7 @@ extension StandaloneServer {
                 modelType: modelInfo.modelType,
                 enabled: config.mtp,
                 localPath: config.mtpDrafterPath,
+                modelDirectory: modelDirectory,
                 // `darkbloom start --local` is coordinator-independent. Only an
                 // explicit operator-provided path may activate MTP here.
                 allowDownload: false,

--- a/provider-swift/Sources/ProviderCore/Server/StandaloneServer.swift
+++ b/provider-swift/Sources/ProviderCore/Server/StandaloneServer.swift
@@ -711,6 +711,7 @@ public actor StandaloneServer {
             prepared = try await EngineV2SlotFactory.prepareProductionModel(
                 modelId: modelId,
                 isVLM: isVLM,
+                modelDirectory: modelDirectory,
                 container: newcomerBox.borrow(),
                 specDecPreparation: specDecPreparation,
                 assistantLoader: v2TestHooks?.assistantLoader
@@ -1177,7 +1178,7 @@ public actor StandaloneServer {
             throw StandaloneServerError.modelNotFound(modelId)
         }
         var mtpPreparation = await specDecPreparation(
-            modelId: modelId, modelInfo: modelInfo)
+            modelId: modelId, modelInfo: modelInfo, modelDirectory: modelPath)
 
         // Re-check residency and in-flight loads after the preparation await:
         // a concurrent request for the same cold model can pass the checks

--- a/provider-swift/Sources/ProviderCore/SpecDec/SpecDecArtifactFunnel.swift
+++ b/provider-swift/Sources/ProviderCore/SpecDec/SpecDecArtifactFunnel.swift
@@ -55,8 +55,30 @@ actor SpecDecArtifactFunnel {
         let modelType: String?
         let enabled: Bool
         let localPath: String?
+        /// Already-verified target checkpoint directory. Qwen combined
+        /// artifacts may carry their assistant inline in the same indexed
+        /// shards; nil preserves the external Gemma assistant flow.
+        let modelDirectory: URL?
         let allowDownload: Bool
         let environment: [String: String]
+
+        init(
+            modelId: String,
+            modelType: String?,
+            enabled: Bool,
+            localPath: String?,
+            modelDirectory: URL? = nil,
+            allowDownload: Bool,
+            environment: [String: String]
+        ) {
+            self.modelId = modelId
+            self.modelType = modelType
+            self.enabled = enabled
+            self.localPath = localPath
+            self.modelDirectory = modelDirectory
+            self.allowDownload = allowDownload
+            self.environment = environment
+        }
     }
 
     private let resolver: SpecDecResolver
@@ -127,6 +149,16 @@ actor SpecDecArtifactFunnel {
         }
         guard Self.killSwitchEnabled(environment: request.environment) else {
             return .init(artifact: nil, status: .disabled(.killSwitchDisabled, configured: true))
+        }
+        if Self.isQwen35Target(modelType: request.modelType),
+            let directory = request.modelDirectory
+        {
+            guard let artifact = SpecDecStore.inspectInlineArtifact(directory: directory) else {
+                return .init(
+                    artifact: nil,
+                    status: .disabled(.inlineArtifactInvalid, configured: true))
+            }
+            return .init(artifact: artifact, status: .candidate(artifact))
         }
         guard Self.isGemma4Target(modelType: request.modelType) else {
             return .init(artifact: nil, status: .disabled(.targetUnsupported, configured: true))
@@ -316,6 +348,11 @@ actor SpecDecArtifactFunnel {
 
     static func isGemma4Target(modelType: String?) -> Bool {
         EngineV2SupportedModels.isGemma4Target(modelType: modelType)
+    }
+
+    static func isQwen35Target(modelType: String?) -> Bool {
+        modelType?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+            == "qwen3_5_moe"
     }
 
     static func killSwitchEnabled(environment: [String: String]) -> Bool {

--- a/provider-swift/Sources/ProviderCore/SpecDec/SpecDecStore.swift
+++ b/provider-swift/Sources/ProviderCore/SpecDec/SpecDecStore.swift
@@ -5,6 +5,16 @@ import ProviderCoreFoundation
 enum SpecDecStore {
     static let manifestFileName = "manifest.json"
 
+    private struct InlineWeightIndex: Decodable {
+        let metadata: [String: Int64]?
+        let weightMap: [String: String]
+
+        enum CodingKeys: String, CodingKey {
+            case metadata = "metadata"
+            case weightMap = "weight_map"
+        }
+    }
+
     struct Verification: Sendable {
         let manifest: ModelManifest
         let manifestSHA256: String
@@ -254,6 +264,117 @@ enum SpecDecStore {
             localConfigSHA256: configDigest)
     }
 
+    /// Inspect an inline Qwen MTP payload without copying or re-hashing the
+    /// combined target shards. The target model manifest/weight hash already
+    /// authenticates those files; this inspection pins the config + index,
+    /// validates every selected key/path, and charges the index's declared
+    /// MTP payload bytes rather than the whole 20 GiB checkpoint.
+    static func inspectInlineArtifact(directory: URL) -> SpecDecArtifact? {
+        let directory = directory.standardizedFileURL
+        guard isDirectoryWithoutSymlink(directory) else { return nil }
+        let configURL = directory.appendingPathComponent("config.json")
+        let indexURL = directory.appendingPathComponent("model.safetensors.index.json")
+        guard let configSize = regularFileSize(configURL), configSize > 0,
+            configSize <= SpecDecLimits.maximumConfigBytes,
+            let indexSize = regularFileSize(indexURL), indexSize > 0,
+            indexSize <= UInt64(SpecDecLimits.maximumManifestBytes),
+            let configData = try? Data(contentsOf: configURL),
+            let indexData = try? Data(contentsOf: indexURL),
+            let root = try? JSONSerialization.jsonObject(with: configData) as? [String: Any],
+            let inline = root["mtplx_mtp"] as? [String: Any],
+            inline["included"] as? Bool == true,
+            root["mtplx_mtp_quantization"] as? [String: Any] != nil,
+            let index = try? JSONDecoder().decode(InlineWeightIndex.self, from: indexData)
+        else { return nil }
+
+        let prefix = (inline["prefix"] as? String) ?? "mtp."
+        guard !prefix.isEmpty, prefix.utf8.count <= 128,
+            prefix.utf8.allSatisfy({
+                (48...57).contains($0) || (65...90).contains($0) || (97...122).contains($0)
+                    || $0 == 46 || $0 == 95
+            })
+        else { return nil }
+
+        var shardNames = Set<String>()
+        var inlineCount = 0
+        for (key, shard) in index.weightMap where key.hasPrefix(prefix) {
+            guard key.utf8.count <= 1024, shard == URL(fileURLWithPath: shard).lastPathComponent,
+                shard.hasSuffix(".safetensors"), shard.utf8.count <= SpecDecLimits.maximumFileNameBytes,
+                regularFileSize(directory.appendingPathComponent(shard)) != nil
+            else { return nil }
+            inlineCount += 1
+            shardNames.insert(shard)
+        }
+        guard inlineCount > 0, inlineCount <= 512, !shardNames.isEmpty else { return nil }
+
+        guard let declaredBytes = inlineTensorBytes(
+            directory: directory,
+            prefix: prefix,
+            weightMap: index.weightMap),
+            declaredBytes > 0,
+            declaredBytes <= SpecDecLimits.maximumArtifactBytes
+        else { return nil }
+
+        let configDigest = sha256Hex(configData)
+        let indexDigest = sha256Hex(indexData)
+        return SpecDecArtifact(
+            directory: directory,
+            source: .inline,
+            revision: "inline-\(configDigest.prefix(8))-\(indexDigest.prefix(8))",
+            artifactBytes: declaredBytes,
+            residentBytes: SpecDecLimits.residentEstimate(artifactBytes: declaredBytes),
+            manifestSHA256: nil,
+            localConfigSHA256: configDigest,
+            inlineIndexSHA256: indexDigest)
+    }
+
+    /// Sum only selected tensor payload ranges from safetensors headers. This
+    /// reads at most 16 MiB of metadata per shard and never maps/evaluates the
+    /// multi-GiB target arrays merely to size the inline assistant.
+    private static func inlineTensorBytes(
+        directory: URL,
+        prefix: String,
+        weightMap: [String: String]
+    ) -> UInt64? {
+        let selected = weightMap.filter { $0.key.hasPrefix(prefix) }
+        var headers: [String: [String: Any]] = [:]
+        var total: UInt64 = 0
+        for (key, shard) in selected {
+            let header: [String: Any]
+            if let cached = headers[shard] {
+                header = cached
+            } else {
+                let url = directory.appendingPathComponent(shard)
+                guard let handle = try? FileHandle(forReadingFrom: url) else { return nil }
+                defer { try? handle.close() }
+                guard let lengthData = try? handle.read(upToCount: 8),
+                    lengthData.count == 8
+                else { return nil }
+                let headerLength = lengthData.withUnsafeBytes { raw -> UInt64 in
+                    raw.loadUnaligned(as: UInt64.self).littleEndian
+                }
+                guard headerLength > 0, headerLength <= 16 * 1024 * 1024,
+                    let data = try? handle.read(upToCount: Int(headerLength)),
+                    data.count == Int(headerLength),
+                    let object = try? JSONSerialization.jsonObject(with: data)
+                        as? [String: Any]
+                else { return nil }
+                headers[shard] = object
+                header = object
+            }
+            guard let entry = header[key] as? [String: Any],
+                let offsets = entry["data_offsets"] as? [NSNumber], offsets.count == 2
+            else { return nil }
+            let start = offsets[0].uint64Value
+            let end = offsets[1].uint64Value
+            guard end > start else { return nil }
+            let (sum, overflow) = total.addingReportingOverflow(end - start)
+            guard !overflow else { return nil }
+            total = sum
+        }
+        return total
+    }
+
     /// Re-inspect the exact bytes immediately before assistant construction.
     /// Catalog artifacts are verified against their retained immutable trust
     /// reference; mutable local overrides must still match the inspected size
@@ -302,6 +423,20 @@ enum SpecDecStore {
                 return .fallback(
                     .localArtifactInvalid,
                     detail: "local assistant changed after admission")
+            }
+            return .resolved(refreshed)
+        case .inline:
+            guard let refreshed = inspectInlineArtifact(directory: artifact.directory),
+                refreshed.directory == artifact.directory,
+                refreshed.artifactBytes == artifact.artifactBytes,
+                refreshed.residentBytes == artifact.residentBytes,
+                refreshed.revision == artifact.revision,
+                refreshed.localConfigSHA256 == artifact.localConfigSHA256,
+                refreshed.inlineIndexSHA256 == artifact.inlineIndexSHA256
+            else {
+                return .fallback(
+                    .inlineArtifactInvalid,
+                    detail: "inline assistant metadata changed after admission")
             }
             return .resolved(refreshed)
         }

--- a/provider-swift/Sources/ProviderCore/SpecDec/SpecDecTypes.swift
+++ b/provider-swift/Sources/ProviderCore/SpecDec/SpecDecTypes.swift
@@ -31,6 +31,7 @@ public enum MTPFallbackReason: String, Sendable, Equatable {
     case assistantResliceFloor = "assistant_reslice_floor"
     case assistantPostBuildHeadroom = "assistant_post_build_headroom"
     case engineInactive = "engine_inactive"
+    case inlineArtifactInvalid = "inline_artifact_invalid"
     /// ENABLED BUT INERT — the one reason that is not a load failure. The
     /// drafter loaded, the engine reports MTP active, and yet not one round
     /// has run because every planned row was skipped as `kv_unsupported`
@@ -46,6 +47,7 @@ public enum MTPFallbackReason: String, Sendable, Equatable {
 public enum SpecDecArtifactSource: String, Sendable, Equatable {
     case local
     case catalog
+    case inline
 }
 
 /// A verified assistant directory and the facts used before model admission.
@@ -62,6 +64,10 @@ struct SpecDecArtifact: Sendable, Equatable {
     /// Full local config digest retained separately from the display revision;
     /// the revision intentionally contains only a short, non-secret prefix.
     let localConfigSHA256: String?
+    /// Digest of the combined checkpoint's safetensors index for an inline
+    /// assistant. The target artifact's ordinary integrity verification owns
+    /// the shard bytes; this pins the exact MTP tensor-to-shard selection.
+    let inlineIndexSHA256: String?
     /// Catalog artifacts retain the complete immutable trust reference used to
     /// verify them. Local operator overrides intentionally have no catalog trust.
     let catalogReference: SpecDecArtifactReference?
@@ -75,6 +81,7 @@ struct SpecDecArtifact: Sendable, Equatable {
         manifestSHA256: String?,
         localWeightSHA256: [String: String]? = nil,
         localConfigSHA256: String? = nil,
+        inlineIndexSHA256: String? = nil,
         catalogReference: SpecDecArtifactReference? = nil
     ) {
         self.directory = directory
@@ -85,6 +92,7 @@ struct SpecDecArtifact: Sendable, Equatable {
         self.manifestSHA256 = manifestSHA256
         self.localWeightSHA256 = localWeightSHA256
         self.localConfigSHA256 = localConfigSHA256
+        self.inlineIndexSHA256 = inlineIndexSHA256
         self.catalogReference = catalogReference
     }
 }

--- a/provider-swift/Tests/ProviderCoreTests/EngineV2BridgeTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/EngineV2BridgeTests.swift
@@ -228,6 +228,10 @@ private func makeBridge(
     extraEOSTokens: [String] = [],
     defaultMaxTokens: Int = 4096,
     kvBytesPerToken: Int = 0,
+    fixedRequestBytes: Int = 0,
+    auxiliaryBytesPerToken: Int = 0,
+    auxiliaryTokenGranularity: Int = 1,
+    auxiliaryTokenAllocationPadding: Int = 0,
     kvBudget: GlobalKVCacheBudget? = nil,
     ssdPrefixCache: SSDPrefixCache? = nil,
     kvBackendKind: EngineV2KVBackendKind = .contiguous,
@@ -242,6 +246,10 @@ private func makeBridge(
         defaultMaxTokens: defaultMaxTokens,
         maxConcurrentRequests: 4,
         kvBytesPerToken: kvBytesPerToken,
+        fixedRequestBytes: fixedRequestBytes,
+        auxiliaryBytesPerToken: auxiliaryBytesPerToken,
+        auxiliaryTokenGranularity: auxiliaryTokenGranularity,
+        auxiliaryTokenAllocationPadding: auxiliaryTokenAllocationPadding,
         kvBudget: kvBudget,
         ssdPrefixCache: ssdPrefixCache,
         kvBackendKind: kvBackendKind,
@@ -1147,6 +1155,31 @@ struct EngineV2CapacityTests {
         #expect(slot.activeTokens == 17)
         #expect(slot.activeTokenBudgetUsed == 0)
         #expect(slot.activeTokenBudgetMax == 0)
+    }
+
+    @Test("fixed and block-rounded request bytes are reflected in heartbeat tokens")
+    func fixedAndAuxiliaryHeartbeatAccounting() async {
+        let engine = ScriptedCBv2Engine(
+            script: .manual,
+            capacity: CBv2CapacitySnapshot(
+                activeRequests: 1, waitingRequests: 0, kvBytesInUse: 0,
+                kvBytesCapacity: 40_000, activeTokens: 1))
+        let bridge = makeBridge(
+            engine: engine,
+            kvBytesPerToken: 100,
+            fixedRequestBytes: 250,
+            auxiliaryBytesPerToken: 20,
+            auxiliaryTokenGranularity: 4,
+            auxiliaryTokenAllocationPadding: 1)
+        _ = await bridge.submitTokenized(
+            promptTokens: [1], request: makeRequest(maxTokens: 4),
+            requestId: "req-fixed-aux")
+
+        #expect(await bridge.requestReservationBytes(tokenCount: 5) == 810)
+        let slot = await bridge.backendSlotCapacity()
+        #expect(slot.maxTokensPotential == 5)
+        #expect(slot.activeTokenBudgetUsed == 9)
+        #expect(slot.activeTokenBudgetMax == 390)
     }
 
     @Test("finished requests release their committed budget from the heartbeat")

--- a/provider-swift/Tests/ProviderCoreTests/EngineV2VisionRoutingTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/EngineV2VisionRoutingTests.swift
@@ -217,7 +217,8 @@ private func makeRoutingEngine(
     container: ModelContainer?,
     bridge: EngineV2Bridge?,
     plumbing: EngineV2VisionPlumbing?,
-    visionGate: VisionMemoryGate? = nil
+    visionGate: VisionMemoryGate? = nil,
+    reasoningEffort: String? = nil
 ) -> MultiModelBatchSchedulerEngine {
     MultiModelBatchSchedulerEngine(
         registryProvider: { @Sendable in
@@ -232,6 +233,7 @@ private func makeRoutingEngine(
             ]
         },
         defaultMaxTokens: 64,
+        reasoningEffort: reasoningEffort,
         engineV2Vision: plumbing
     )
 }
@@ -493,6 +495,14 @@ struct MediaKindClassificationTests {
         }
     }
 
+    @Test("media processor preserves out-of-band reasoning effort")
+    func reasoningEffortTemplateContext() async throws {
+        let request = imageRequest()
+        let input = try await MediaIngest.buildUserInput(
+            from: request, reasoningEffort: "high")
+        #expect(input.additionalContext?["reasoning_effort"] as? String == "high")
+    }
+
     @Test("image-only request has no video and classifies as .image")
     func imageOnly() {
         #expect(!MediaIngest.hasVideo(imageRequest()))
@@ -718,7 +728,7 @@ struct EngineV2VisionRoutingTests {
         let (prepared, _) = makePreparedSubmission()
         let counter = PrepareCallCounter()
         let plumbing = EngineV2VisionPlumbing(
-            prepare: { _, _ in
+            prepare: { _, _, _ in
                 counter.increment()
                 return prepared
             },
@@ -755,7 +765,7 @@ struct EngineV2VisionRoutingTests {
         let bridge = makeBridge(engine: engine)
         let (prepared, _) = makePreparedSubmission()
         let plumbing = EngineV2VisionPlumbing(
-            prepare: { _, _ in prepared },
+            prepare: { _, _, _ in prepared },
             emitTelemetry: { _ in }
         )
         let router = makeRoutingEngine(
@@ -826,7 +836,7 @@ struct EngineV2VisionRoutingTests {
             kvBudget: budget
         )
         let plumbing = EngineV2VisionPlumbing(
-            prepare: { _, _ in prepared },
+            prepare: { _, _, _ in prepared },
             emitTelemetry: { _ in }
         )
         let router = makeRoutingEngine(
@@ -860,7 +870,7 @@ struct EngineV2VisionRoutingTests {
         let bridge = makeBridge(engine: engine)
         let telemetry = VisionTelemetrySink()
         let plumbing = EngineV2VisionPlumbing(
-            prepare: { _, _ in throw PrepFailure() },
+            prepare: { _, _, _ in throw PrepFailure() },
             emitTelemetry: telemetry.callback()
         )
         let router = makeRoutingEngine(
@@ -911,7 +921,7 @@ struct EngineV2VisionRoutingTests {
         let bridge = makeBridge(engine: engine)
         let telemetry = VisionTelemetrySink()
         let plumbing = EngineV2VisionPlumbing(
-            prepare: { _, _ in
+            prepare: { _, _, _ in
                 throw MediaIngest.MediaError.mediaTooLarge("test-cap")
             },
             emitTelemetry: telemetry.callback()
@@ -947,7 +957,7 @@ struct EngineV2VisionRoutingTests {
         let bridge = makeBridge(engine: engine)
         let telemetry = VisionTelemetrySink()
         let plumbing = EngineV2VisionPlumbing(
-            prepare: { _, _ in throw EngineV2VisionPrefillError.noProcessedMedia },
+            prepare: { _, _, _ in throw EngineV2VisionPrefillError.noProcessedMedia },
             emitTelemetry: telemetry.callback()
         )
         let router = makeRoutingEngine(
@@ -976,6 +986,67 @@ struct EngineV2VisionRoutingTests {
             })
     }
 
+    @Test("unsupported Qwen video maps to deterministic 400 without refusal telemetry")
+    func unsupportedVideoMapsTo400() async throws {
+        let engine = VisionScriptedEngine(script: .stream([]))
+        let bridge = makeBridge(engine: engine)
+        let telemetry = VisionTelemetrySink()
+        let plumbing = EngineV2VisionPlumbing(
+            prepare: { _, _, _ in
+                throw EngineV2VisionPrefillError.unsupportedMedia(
+                    "Qwen35MoE video media is not production-proven")
+            },
+            emitTelemetry: telemetry.callback())
+        let router = makeRoutingEngine(
+            container: makeStubContainer(), bridge: bridge, plumbing: plumbing)
+
+        do {
+            _ = try await collectContent(
+                try await router.streamChatCompletion(request: imageRequest()))
+            Issue.record("expected multimodalRejected throw")
+        } catch let error as MultiModelBatchSchedulerEngineError {
+            guard case .multimodalRejected(let message) = error else {
+                Issue.record("expected .multimodalRejected, got \(error)")
+                return
+            }
+            #expect(message.contains("video media is not production-proven"))
+            #expect(ProviderLoop.mapInferenceErrorToStatus(error) == 400)
+        }
+        #expect(engine.submitted.isEmpty)
+        #expect(
+            telemetry.events.allSatisfy {
+                $0.fields?["operation"]?.description != "engine_v2_vision_refusal"
+            })
+    }
+
+    @Test("vision plumbing receives out-of-band reasoning effort")
+    func visionPlumbingReceivesReasoningEffort() async throws {
+        let engine = VisionScriptedEngine(script: .stream([
+            .finished(reason: .stop, usage: CBv2Usage(promptTokens: 6, completionTokens: 0))
+        ]))
+        let bridge = makeBridge(engine: engine)
+        let (prepared, _) = makePreparedSubmission()
+        final class EffortBox: @unchecked Sendable {
+            private let lock = NSLock()
+            private var value: String?
+            func set(_ newValue: String?) { lock.withLock { value = newValue } }
+            func get() -> String? { lock.withLock { value } }
+        }
+        let effort = EffortBox()
+        let plumbing = EngineV2VisionPlumbing(
+            prepare: { _, _, reasoningEffort in
+                effort.set(reasoningEffort)
+                return prepared
+            }, emitTelemetry: { _ in })
+        let router = makeRoutingEngine(
+            container: makeStubContainer(), bridge: bridge, plumbing: plumbing,
+            reasoningEffort: "medium")
+
+        _ = try await collectContent(
+            try await router.streamChatCompletion(request: imageRequest()))
+        #expect(effort.get() == "medium")
+    }
+
     @Test("refusal on a video request tags media_kind video")
     func refusalTagsVideoKind() async throws {
         struct PrepFailure: Error {}
@@ -983,7 +1054,7 @@ struct EngineV2VisionRoutingTests {
         let bridge = makeBridge(engine: engine)
         let telemetry = VisionTelemetrySink()
         let plumbing = EngineV2VisionPlumbing(
-            prepare: { _, _ in throw PrepFailure() },
+            prepare: { _, _, _ in throw PrepFailure() },
             emitTelemetry: telemetry.callback()
         )
         let router = makeRoutingEngine(
@@ -1023,7 +1094,7 @@ struct EngineV2VisionRoutingTests {
         // preparer must not be consulted on the way to the backstop.
         let counter = PrepareCallCounter()
         let plumbing = EngineV2VisionPlumbing(
-            prepare: { _, _ in
+            prepare: { _, _, _ in
                 counter.increment()
                 throw VisionStubProcessorError()
             },
@@ -1058,7 +1129,7 @@ struct EngineV2VisionRoutingTests {
         let (prepared, _) = makePreparedSubmission(mediaKind: .video)
         let counter = PrepareCallCounter()
         let plumbing = EngineV2VisionPlumbing(
-            prepare: { _, _ in
+            prepare: { _, _, _ in
                 counter.increment()
                 return prepared
             },
@@ -1098,7 +1169,7 @@ struct EngineV2VisionRoutingTests {
         let bridge = makeBridge(engine: engine)
         let counter = PrepareCallCounter()
         let plumbing = EngineV2VisionPlumbing(
-            prepare: { _, _ in
+            prepare: { _, _, _ in
                 counter.increment()
                 throw VisionStubProcessorError()
             },
@@ -1136,7 +1207,7 @@ struct EngineV2VisionRoutingTests {
         let bridge = makeBridge(engine: engine)
         let counter = PrepareCallCounter()
         let plumbing = EngineV2VisionPlumbing(
-            prepare: { _, _ in
+            prepare: { _, _, _ in
                 counter.increment()
                 throw VisionStubProcessorError()
             },
@@ -1175,7 +1246,7 @@ struct EngineV2VisionRoutingTests {
         let bridge = makeBridge(engine: engine)
         let telemetry = VisionTelemetrySink()
         let plumbing = EngineV2VisionPlumbing(
-            prepare: { _, _ in throw CancellationError() },
+            prepare: { _, _, _ in throw CancellationError() },
             emitTelemetry: telemetry.callback()
         )
         let releaseCount = PrepareCallCounter()
@@ -1229,7 +1300,7 @@ struct EngineV2VisionRoutingTests {
         let bridge = makeBridge(engine: engine)
         let (prepared, _) = makePreparedSubmission()
         let plumbing = EngineV2VisionPlumbing(
-            prepare: { _, _ in prepared },
+            prepare: { _, _, _ in prepared },
             emitTelemetry: { _ in }
         )
         let router = makeRoutingEngine(

--- a/provider-swift/Tests/ProviderCoreTests/EngineV2VisionRoutingTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/EngineV2VisionRoutingTests.swift
@@ -682,7 +682,7 @@ struct Qwen35CBv2FixedRequestAccountingTests {
             })
         let bridge = makeBridge(
             engine: engine,
-            fixedRequestBytes: 64_389_120,
+            fixedRequestBytes: 193_167_360,
             kvBudget: budget)
         let stream = await bridge.submitTokenized(
             promptTokens: [1],
@@ -691,7 +691,7 @@ struct Qwen35CBv2FixedRequestAccountingTests {
                 messages: [ChatMessage(role: "user", content: "x")],
                 max_tokens: 1),
             requestId: "qwen-fixed-accounting")
-        #expect(await budget.outstandingReservedBytes() == 64_389_120)
+        #expect(await budget.outstandingReservedBytes() == 193_167_360)
         let consumer = Task {
             for await _ in stream {}
         }

--- a/provider-swift/Tests/ProviderCoreTests/EngineV2VisionRoutingTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/EngineV2VisionRoutingTests.swift
@@ -63,15 +63,20 @@ private final class VisionScriptedEngine: CBv2Engine, @unchecked Sendable {
     enum Script {
         case throwOnSubmit(any Error)
         case stream([CBv2Event])
+        case manual
     }
 
     private let lock = NSLock()
     private let script: Script
     private var _submitted: [CBv2Request] = []
+    private var _manualContinuation: AsyncStream<CBv2Event>.Continuation?
 
     init(script: Script) { self.script = script }
 
     var submitted: [CBv2Request] { lock.withLock { _submitted } }
+    var manualContinuation: AsyncStream<CBv2Event>.Continuation? {
+        lock.withLock { _manualContinuation }
+    }
 
     func submit(_ request: CBv2Request) throws -> AsyncStream<CBv2Event> {
         lock.withLock { _submitted.append(request) }
@@ -82,6 +87,10 @@ private final class VisionScriptedEngine: CBv2Engine, @unchecked Sendable {
             let (stream, continuation) = AsyncStream<CBv2Event>.makeStream()
             for event in events { continuation.yield(event) }
             continuation.finish()
+            return stream
+        case .manual:
+            let (stream, continuation) = AsyncStream<CBv2Event>.makeStream()
+            lock.withLock { _manualContinuation = continuation }
             return stream
         }
     }
@@ -177,19 +186,25 @@ private func makePreparedSubmission(
         promptTokens: [7, 7, 990, 990, 990, 8],
         spans: [CBv2ImageSpan(tokenOffset: 2, length: 3)],
         embeddings: [embedding],
+        attention: .bidirectionalSpans,
+        positionState: nil,
         mediaKind: mediaKind
     )
     return (submission, embedding)
 }
 
 private func makeBridge(
-    engine: VisionScriptedEngine, telemetry: VisionTelemetrySink? = nil
+    engine: VisionScriptedEngine, fixedRequestBytes: Int = 0,
+    kvBudget: GlobalKVCacheBudget? = nil, telemetry: VisionTelemetrySink? = nil
 ) -> EngineV2Bridge {
     EngineV2Bridge(
         engine: engine,
         modelId: "test/vlm-stub",
         tokenizer: TokenizerHandle(VisionStubTokenizer()),
         eosTokenIds: [2],
+        kvBytesPerToken: 0,
+        fixedRequestBytes: fixedRequestBytes,
+        kvBudget: kvBudget,
         emitTelemetry: telemetry?.callback()
     )
 }
@@ -468,6 +483,16 @@ struct EngineV2VisionSpanCarvingTests {
 
 @Suite("MediaIngest.hasVideo + EngineV2VisionPrefill.mediaKind")
 struct MediaKindClassificationTests {
+    @Test("media processor receives the request's reasoning template switch")
+    func reasoningTemplateContext() async throws {
+        for enabled in [false, true] {
+            var request = imageRequest()
+            request.reasoning = OpenAIReasoningConfig(enabled: enabled)
+            let input = try await MediaIngest.buildUserInput(from: request)
+            #expect(input.additionalContext?["enable_thinking"] as? Bool == enabled)
+        }
+    }
+
     @Test("image-only request has no video and classifies as .image")
     func imageOnly() {
         #expect(!MediaIngest.hasVideo(imageRequest()))
@@ -570,6 +595,45 @@ struct EngineV2BridgeMultimodalTests {
         #expect(visionEvents.first?.requestId == "req-vision-1")
     }
 
+    @Test("Qwen position state rides the multimodal input into CBv2Request")
+    func qwenPositionStatePassthrough() async throws {
+        let engine = VisionScriptedEngine(
+            script: .stream([
+                .finished(
+                    reason: .stop,
+                    usage: CBv2Usage(promptTokens: 3, completionTokens: 0))
+            ]))
+        let bridge = makeBridge(engine: engine)
+        let positions = CBv2PositionState(
+            promptPositionIds: MLXArray([
+                Int32(0), 1, 2,
+                0, 4, 5,
+                0, 7, 8,
+            ]).reshaped([3, 1, 3]),
+            decodeDeltas: [-2])
+        let input = CBv2MultimodalInput(
+            spans: [CBv2ImageSpan(tokenOffset: 1, length: 1)],
+            attention: .causal,
+            positionState: positions
+        ) { [MLXArray.ones([1, 1, 4])] }
+        let stream = await bridge.submitTokenized(
+            promptTokens: [1, 990, 2],
+            request: ChatCompletionRequest(
+                model: "test/vlm-stub",
+                messages: [ChatMessage(role: "user", content: "x")],
+                max_tokens: 1),
+            requestId: "qwen-position-passthrough",
+            multimodal: input,
+            mediaKind: .image)
+        for await _ in stream {}
+
+        let submitted = try #require(engine.submitted.first)
+        let submittedPositions = try #require(submitted.positionState)
+        #expect(submitted.multimodal?.attention == .causal)
+        #expect(submittedPositions.decodeDeltas == [-2])
+        #expect(submittedPositions.promptLength == 3)
+    }
+
     @Test("text submit keeps multimodal nil and emits no vision telemetry")
     func textSubmitUnchanged() async throws {
         let engine = VisionScriptedEngine(
@@ -591,6 +655,44 @@ struct EngineV2BridgeMultimodalTests {
             telemetry.events.allSatisfy {
                 $0.fields?["operation"]?.description != "engine_v2_vision"
             })
+    }
+}
+
+@Suite("Qwen35 CBv2 fixed request accounting")
+struct Qwen35CBv2FixedRequestAccountingTests {
+    @Test("fixed recurrent bytes reserve exactly and release at terminal")
+    func exactReservationAndRelease() async {
+        let engine = VisionScriptedEngine(script: .manual)
+        let budget = GlobalKVCacheBudget(
+            capFraction: 0.9, activationReserveBytes: 0,
+            memorySnapshot: {
+                .init(
+                    total: 64 * 1024 * 1024 * 1024,
+                    active: 0, cache: 0, systemAvailable: .max)
+            })
+        let bridge = makeBridge(
+            engine: engine,
+            fixedRequestBytes: 64_389_120,
+            kvBudget: budget)
+        let stream = await bridge.submitTokenized(
+            promptTokens: [1],
+            request: ChatCompletionRequest(
+                model: "test/vlm-stub",
+                messages: [ChatMessage(role: "user", content: "x")],
+                max_tokens: 1),
+            requestId: "qwen-fixed-accounting")
+        #expect(await budget.outstandingReservedBytes() == 64_389_120)
+        let consumer = Task {
+            for await _ in stream {}
+        }
+        engine.manualContinuation?.yield(
+            .finished(
+                reason: .stop,
+                usage: CBv2Usage(promptTokens: 1, completionTokens: 0)))
+        engine.manualContinuation?.finish()
+        _ = await consumer.value
+        #expect(await budget.outstandingReservedBytes() == 0)
+        #expect(engine.submitted.count == 1)
     }
 }
 

--- a/provider-swift/Tests/ProviderCoreTests/GemmaVLMVideoEngineV2LiveTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/GemmaVLMVideoEngineV2LiveTests.swift
@@ -280,8 +280,9 @@ struct GemmaVLMVideoEngineV2LiveTests {
     ) async throws -> (content: String, ttft: TimeInterval) {
         let recorder = VideoLiveRefusalRecorder()
         let plumbing = EngineV2VisionPlumbing(
-            prepare: { container, request in
-                try await EngineV2VisionPrefill.prepare(container: container, request: request)
+            prepare: { container, request, reasoningEffort in
+                try await EngineV2VisionPrefill.prepare(
+                    container: container, request: request, reasoningEffort: reasoningEffort)
             },
             emitTelemetry: { recorder.append($0) }
         )

--- a/provider-swift/Tests/ProviderCoreTests/GemmaVLMVisionEngineV2LiveTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/GemmaVLMVisionEngineV2LiveTests.swift
@@ -171,8 +171,9 @@ struct GemmaVLMVisionEngineV2LiveTests {
     ) async throws -> String {
         let recorder = VisionLiveRefusalRecorder()
         let plumbing = EngineV2VisionPlumbing(
-            prepare: { container, request in
-                try await EngineV2VisionPrefill.prepare(container: container, request: request)
+            prepare: { container, request, reasoningEffort in
+                try await EngineV2VisionPrefill.prepare(
+                    container: container, request: request, reasoningEffort: reasoningEffort)
             },
             emitTelemetry: { recorder.append($0) }
         )

--- a/provider-swift/Tests/ProviderCoreTests/PagedDivergenceProbeTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/PagedDivergenceProbeTests.swift
@@ -293,7 +293,7 @@ struct PagedDivergenceProbeTests {
         }
         let box = try await container.perform { ctx -> Box in
             let serving = try EngineV2Factory.benchmarkServingModel(
-                model: ctx.model, isVLM: isVLM)
+                model: ctx.model, isVLM: isVLM, modelDirectory: directory)
             guard let kinds = EngineV2Factory.cbv2LayerKinds(model: serving) else {
                 throw LiveFixtureSkip.modelNotInCache("no cbv2 layer kinds for \(modelID)")
             }

--- a/provider-swift/Tests/ProviderCoreTests/ProviderMTPFactoryTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ProviderMTPFactoryTests.swift
@@ -160,7 +160,7 @@ private func mtpCatalogArtifact() throws -> SpecDecArtifact {
 }
 
 private final class MTPFactoryPrepared: CBv2MTPPreparedCapture {}
-private final class MTPFactoryDrafter: CBv2MTPDrafter, @unchecked Sendable {
+private class MTPFactoryDrafter: CBv2MTPDrafter, @unchecked Sendable {
     func prepare(rows: [CBv2MTPRowCapture]) -> CBv2MTPPreparedCapture {
         MTPFactoryPrepared()
     }
@@ -350,6 +350,30 @@ struct ProviderMTPFactoryTests {
             #expect(prepared.assistantBytes == 0)
             #expect(prepared.mtpStatus.reason == failure.reason)
         }
+    }
+
+    @Test("drafter-required verification policy disables rectangular scoring")
+    func requiredVerificationPolicy() {
+        final class SerialDrafter: CBv2MTPDrafter {
+            var requiredVerificationMode: CBv2MTPVerificationMode? { .serialTarget }
+            func prepare(rows: [CBv2MTPRowCapture]) -> CBv2MTPPreparedCapture {
+                MTPFactoryPrepared()
+            }
+            func draftStep(
+                tokens: MLXArray, hidden: MLXArray, prepared: CBv2MTPPreparedCapture
+            ) -> (tokens: MLXArray, hidden: MLXArray) {
+                (tokens, hidden)
+            }
+        }
+        let policy = providerMTPVerificationPolicy(
+            for: SerialDrafter(), automaticRectangularTokens: 8)
+        #expect(policy.mode == .serialTarget)
+        #expect(policy.automaticRectangularTokens == 0)
+
+        let automatic = providerMTPVerificationPolicy(
+            for: MTPFactoryDrafter(), automaticRectangularTokens: 8)
+        #expect(automatic.mode == .automatic)
+        #expect(automatic.automaticRectangularTokens == 8)
     }
 
     @Test("cached catalog bytes are revalidated on every load and rebuild")

--- a/provider-swift/Tests/ProviderCoreTests/Qwen36ProductionCanaryTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/Qwen36ProductionCanaryTests.swift
@@ -57,10 +57,11 @@ struct Qwen36ProductionCanaryTests {
             let visionScheduler = fixture.scheduler(
                 bundle: targetBundle,
                 vision: EngineV2VisionPlumbing(
-                    prepare: { container, request in
+                    prepare: { container, request, reasoningEffort in
                         let prepared = try await EngineV2VisionPrefill.prepare(
                             container: container,
-                            request: request)
+                            request: request,
+                            reasoningEffort: reasoningEffort)
                         visionProbe.recordPrepared(spanCount: prepared.spans.count)
                         return prepared
                     },

--- a/provider-swift/Tests/ProviderCoreTests/Qwen36ProductionCanaryTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/Qwen36ProductionCanaryTests.swift
@@ -1,0 +1,656 @@
+// Copyright © 2026 Eigen Labs.
+
+import Foundation
+import MLX
+import MLXLMCommon
+import MLXLMServer
+import Testing
+
+@testable import ProviderCore
+
+@Suite("Qwen3.6 production artifact canary", .serialized)
+struct Qwen36ProductionCanaryTests {
+    @Test(
+        "combined VLM and inline MTP serve through the production bundle",
+        .enabled(
+            if: Qwen36ProductionCanary.enabled,
+            "set DARKBLOOM_LIVE_MLX_TESTS=1 and DARKBLOOM_LIVE_MLX_QWEN36=1 to run the local real-artifact Qwen3.6 production canary")
+    )
+    func combinedVLMAndInlineMTPProductionBundle() async throws {
+        let fixture = try await Qwen36ProductionCanary.load()
+        var liveBundle: ProviderEngineBundle?
+
+        do {
+            let targetBundle: ProviderEngineBundle
+            do {
+                targetBundle = try await fixture.makeBundle(
+                    preparation: .init(
+                        artifact: nil,
+                        status: .disabled(.configDisabled, configured: false)))
+            } catch {
+                throw Qwen36ProductionCanaryError.stage(
+                    "target-only EngineV2SlotFactory production bundle",
+                    String(reflecting: error))
+            }
+            liveBundle = targetBundle
+            let targetStatus = await targetBundle.bridge.mtpStatusSnapshot()
+            #expect(!targetStatus.configured)
+            #expect(!targetStatus.active)
+
+            let scheduler = fixture.scheduler(bundle: targetBundle)
+            let text: Qwen36ProductionCanaryServerResult
+            do {
+                text = try await Qwen36ProductionCanary.collect(
+                    scheduler,
+                    request: fixture.textRequest())
+            } catch {
+                throw Qwen36ProductionCanaryError.stage(
+                    "target-only scheduler text request", String(reflecting: error))
+            }
+            #expect(text.text.trimmingCharacters(in: .whitespacesAndNewlines)
+                == #"{"sum":423,"check":"ok"}"#)
+            let textUsage = try #require(text.info, "text canary emitted no terminal usage")
+            #expect(textUsage.promptTokens > 0)
+            #expect(textUsage.completionTokens > 0)
+
+            let visionProbe = Qwen36ProductionCanaryVisionProbe()
+            let visionScheduler = fixture.scheduler(
+                bundle: targetBundle,
+                vision: EngineV2VisionPlumbing(
+                    prepare: { container, request in
+                        let prepared = try await EngineV2VisionPrefill.prepare(
+                            container: container,
+                            request: request)
+                        visionProbe.recordPrepared(spanCount: prepared.spans.count)
+                        return prepared
+                    },
+                    emitTelemetry: { _ in visionProbe.recordRefusal() }))
+            let stepsBeforeVision = await targetBundle.bridge.capacitySnapshot().stepsExecuted
+            let vision: Qwen36ProductionCanaryServerResult
+            do {
+                vision = try await Qwen36ProductionCanary.collect(
+                    visionScheduler,
+                    request: try fixture.imageRequest())
+            } catch {
+                throw Qwen36ProductionCanaryError.stage(
+                    "target-only scheduler EngineV2VisionPrefill image request",
+                    String(reflecting: error))
+            }
+            #expect(vision.text.contains("ORCHID-7319"))
+            #expect(vision.text.contains("27"))
+            #expect(vision.text.contains("CYAN TRIANGLE"))
+            #expect(visionProbe.preparedCount == 1)
+            #expect(visionProbe.lastSpanCount > 0)
+            #expect(visionProbe.refusalCount == 0)
+            let visionUsage = try #require(vision.info, "image canary emitted no terminal usage")
+            #expect(visionUsage.promptTokens > 0)
+            #expect(visionUsage.completionTokens > 0)
+            let stepsAfterVision = await targetBundle.bridge.capacitySnapshot().stepsExecuted
+            #expect(stepsAfterVision > stepsBeforeVision, "vision request never entered EngineV2")
+
+            let tool = try await Qwen36ProductionCanary.collect(
+                scheduler,
+                request: fixture.toolRequest())
+            let toolCall = try #require(tool.toolCalls.first, "Qwen emitted no parsed tool call")
+            #expect(tool.toolCalls.count == 1)
+            #expect(toolCall.function.name == "record_canary")
+            #expect(toolCall.function.arguments["code"] == .string("ORCHID-7319"))
+            #expect(toolCall.function.arguments["count"] == .int(27))
+
+            async let alpha = Qwen36ProductionCanary.collect(
+                scheduler,
+                request: fixture.concurrentRequest(
+                    messages: [
+                        .init(role: .system, content: .text("Obey the requested exact output.")),
+                        .init(role: .user, content: .text("Reply exactly ALPHA-17")),
+                    ]))
+            async let beta = Qwen36ProductionCanary.collect(
+                scheduler,
+                request: fixture.concurrentRequest(
+                    messages: [
+                        .init(role: .system, content: .text("Obey the requested exact output.")),
+                        .init(role: .user, content: .text("Remember BETA but do not answer yet.")),
+                        .init(role: .assistant, content: .text("Understood.")),
+                        .init(role: .user, content: .text("Reply exactly BETA-29")),
+                    ]))
+            let (alphaResult, betaResult) = try await (alpha, beta)
+            #expect(alphaResult.text.trimmingCharacters(in: .whitespacesAndNewlines) == "ALPHA-17")
+            #expect(betaResult.text.trimmingCharacters(in: .whitespacesAndNewlines) == "BETA-29")
+            #expect(alphaResult.info?.completionTokens ?? 0 > 0)
+            #expect(betaResult.info?.completionTokens ?? 0 > 0)
+            _ = try await Qwen36ProductionCanary.waitForIdle(targetBundle.bridge)
+
+            let parityPrompt = try fixture.tokenize(fixture.parityRequest())
+            let targetTokens = try await Qwen36ProductionCanary.rawTokens(
+                bundle: targetBundle,
+                promptTokens: parityPrompt,
+                maxTokens: Qwen36ProductionCanary.parityMaxTokens)
+            #expect(targetTokens.count > 32, "parity prompt did not exercise a long decode")
+
+            await Qwen36ProductionCanary.retire(targetBundle)
+            liveBundle = nil
+
+            let inlinePreparation = await fixture.inlinePreparation()
+            let artifact = try #require(
+                inlinePreparation.artifact,
+                "SpecDecArtifactFunnel did not resolve the inline MTP payload")
+            #expect(artifact.source == .inline)
+            #expect(inlinePreparation.status.source == .inline)
+            #expect(inlinePreparation.status.configured)
+            #expect(artifact.directory == fixture.modelDirectory.standardizedFileURL)
+
+            let mtpBundle = try await fixture.makeBundle(preparation: inlinePreparation)
+            liveBundle = mtpBundle
+            let initialMTP = await mtpBundle.bridge.mtpStatusSnapshot()
+            #expect(initialMTP.configured)
+            #expect(initialMTP.active)
+            #expect(initialMTP.assistantSource == .inline)
+            #expect(initialMTP.assistantResidentBytes > 0)
+            #expect(mtpBundle.assistantBytes > 0)
+            #expect(
+                await mtpBundle.bridge.kvBytesPerToken
+                    == fixture.targetSizing.fp16KVBytesPerToken + 2_048)
+
+            let mtpTokens = try await Qwen36ProductionCanary.rawTokens(
+                bundle: mtpBundle,
+                promptTokens: parityPrompt,
+                maxTokens: Qwen36ProductionCanary.parityMaxTokens)
+            #expect(mtpTokens == targetTokens, "MTP changed greedy emitted token IDs")
+            let mtp = await mtpBundle.bridge.mtpStatusSnapshot()
+            #expect(mtp.active)
+            #expect(mtp.proposedTokens > 0)
+            #expect(mtp.acceptedDraftTokens > 0)
+            #expect(mtp.proposedTokens > mtp.acceptedDraftTokens, "parity run exercised no rejection")
+            #expect(mtp.serialVerificationRounds > 0)
+            #expect(mtp.rectangularVerificationRounds == 0)
+            #expect(mtp.rounds > 0)
+
+            let cancellation = try await fixture.cancelAfterFirstDelta(bundle: mtpBundle)
+            #expect(cancellation.sawDelta)
+            #expect(cancellation.error == "request cancelled")
+            #expect(cancellation.promptTokens > 0)
+            let drained = try await Qwen36ProductionCanary.waitForIdle(mtpBundle.bridge)
+            #expect(drained.activeRequests == 0)
+            #expect(drained.waitingRequests == 0)
+            #expect(drained.activeTokens == 0)
+            #expect(drained.kvBytesInUse == 0, "recurrent/KV request state remained charged")
+            #expect(drained.kvBytesReserved == 0, "request reservation remained charged")
+            let drainedSlot = await mtpBundle.bridge.backendSlotCapacity()
+            #expect(drainedSlot.numRunning == 0)
+            #expect(drainedSlot.numWaiting == 0)
+            #expect(drainedSlot.activeTokenBudgetUsed == 0)
+            #expect(drainedSlot.maxTokensPotential == 0)
+
+            await Qwen36ProductionCanary.retire(mtpBundle)
+            liveBundle = nil
+        } catch {
+            if let liveBundle {
+                await Qwen36ProductionCanary.retire(liveBundle)
+            }
+            throw error
+        }
+    }
+}
+
+private enum Qwen36ProductionCanary {
+    static let modelID = "qwen3.6-35b-a3b-vl-mtp-production-canary"
+    static let modelType = "qwen3_5_moe"
+    static let parityMaxTokens = 192
+
+    private static let liveGate = "DARKBLOOM_LIVE_MLX_TESTS"
+    private static let qwenGate = "DARKBLOOM_LIVE_MLX_QWEN36"
+    private static let modelPathOverride = "DARKBLOOM_LIVE_MLX_QWEN36_MODEL_PATH"
+    private static let imagePathOverride = "DARKBLOOM_LIVE_MLX_QWEN36_IMAGE_PATH"
+    private static let defaultModelPath =
+        "/var/folders/hv/5779vnmn5c564l3tdknlf4x80000gp/T/opencode/"
+        + "Qwen3.6-35B-A3B-MLX-VL-4bit-g64-router8-mtp-work"
+    private static let defaultImagePath =
+        "/var/folders/hv/5779vnmn5c564l3tdknlf4x80000gp/T/opencode/qwen36-vlm-proof.png"
+
+    static var enabled: Bool {
+        let environment = ProcessInfo.processInfo.environment
+        return environment[liveGate] == "1" && environment[qwenGate] == "1"
+    }
+
+    static func load() async throws -> Qwen36ProductionCanaryFixture {
+        let environment = ProcessInfo.processInfo.environment
+        let modelDirectory = URL(
+            fileURLWithPath: environment[modelPathOverride] ?? defaultModelPath,
+            isDirectory: true).standardizedFileURL
+        let imageURL = URL(
+            fileURLWithPath: environment[imagePathOverride] ?? defaultImagePath,
+            isDirectory: false).standardizedFileURL
+        guard FileManager.default.fileExists(atPath: modelDirectory.path) else {
+            throw Qwen36ProductionCanaryError.missingArtifact(modelDirectory.path)
+        }
+        guard FileManager.default.fileExists(atPath: imageURL.path) else {
+            throw Qwen36ProductionCanaryError.missingImage(imageURL.path)
+        }
+        guard LiveInferenceFixtures.ensureMetallibColocated() != nil else {
+            throw Qwen36ProductionCanaryError.missingMetallib
+        }
+
+        LiveInferenceFixtures.applyMemoryBudget(maxBytes: 96 * 1024 * 1024 * 1024)
+        let container: ModelContainer
+        do {
+            container = try await ModelContainerLoading.loadContainer(from: modelDirectory)
+        } catch {
+            throw Qwen36ProductionCanaryError.stage(
+                "ModelContainerLoading.loadContainer", String(reflecting: error))
+        }
+        guard ProviderLoop.modelIsVLM(at: modelDirectory) else {
+            throw Qwen36ProductionCanaryError.notVLM(modelDirectory.path)
+        }
+        let sizing = await SlotSizingSnapshot.build(
+            container: container,
+            modelPath: modelDirectory,
+            fallbackDefaultMaxTokens: 512)
+        let tokenizer = await container.perform { TokenizerHandle($0.tokenizer) }
+        return Qwen36ProductionCanaryFixture(
+            modelDirectory: modelDirectory,
+            imageURL: imageURL,
+            container: container,
+            targetSizing: sizing,
+            tokenizer: tokenizer)
+    }
+
+    static func collect(
+        _ engine: MultiModelBatchSchedulerEngine,
+        request: OpenAIChatCompletionRequest
+    ) async throws -> Qwen36ProductionCanaryServerResult {
+        let stream = try await engine.streamChatCompletion(request: request)
+        var result = Qwen36ProductionCanaryServerResult()
+        for try await event in stream {
+            switch event {
+            case .content(let text):
+                result.text += text
+            case .toolCall(let call):
+                result.toolCalls.append(call)
+            case .info(let info):
+                result.info = info
+            }
+        }
+        return result
+    }
+
+    static func rawTokens(
+        bundle: ProviderEngineBundle,
+        promptTokens: [Int],
+        maxTokens: Int
+    ) async throws -> [Int] {
+        let ownedEngine = await bundle.bridge.ownedEngine
+        guard let engine = ownedEngine else {
+            throw Qwen36ProductionCanaryError.engineUnavailable
+        }
+        let stopTokens = await bundle.bridge.stopTokenIds
+        let stream = try engine.submit(CBv2Request(
+            id: CBv2RequestID(0x5133_3600),
+            promptTokens: promptTokens,
+            sampling: CBv2SamplingParams(
+                temperature: 0,
+                topP: 1,
+                topK: 0,
+                minP: 0),
+            maxTokens: maxTokens,
+            stopTokens: stopTokens,
+            prefixCacheEnabled: false))
+        var tokens: [Int] = []
+        var terminal: CBv2FinishReason?
+        for await event in stream {
+            switch event {
+            case .delta(_, let emitted, _):
+                tokens.append(contentsOf: emitted)
+            case .finished(let reason, _):
+                terminal = reason
+            }
+        }
+        guard !tokens.isEmpty else { throw Qwen36ProductionCanaryError.emptyGeneration }
+        guard let terminal else { throw Qwen36ProductionCanaryError.missingTerminal }
+        switch terminal {
+        case .stop, .length:
+            return tokens
+        case .cancelled:
+            throw Qwen36ProductionCanaryError.unexpectedTerminal("cancelled")
+        case .error(let message):
+            throw Qwen36ProductionCanaryError.unexpectedTerminal(message)
+        case .terminal(let cause, let message):
+            throw Qwen36ProductionCanaryError.unexpectedTerminal(
+                "\(cause): \(message)")
+        }
+    }
+
+    static func waitForIdle(_ bridge: EngineV2Bridge) async throws -> CBv2CapacitySnapshot {
+        for _ in 0..<200 {
+            let snapshot = await bridge.capacitySnapshot()
+            if snapshot.activeRequests == 0 && snapshot.waitingRequests == 0
+                && snapshot.activeTokens == 0
+            {
+                return snapshot
+            }
+            try await Task.sleep(for: .milliseconds(50))
+        }
+        let snapshot = await bridge.capacitySnapshot()
+        throw Qwen36ProductionCanaryError.capacityDidNotDrain(
+            active: snapshot.activeRequests,
+            waiting: snapshot.waitingRequests,
+            tokens: snapshot.activeTokens)
+    }
+
+    static func retire(_ bundle: ProviderEngineBundle) async {
+        await bundle.bridge.shutdown()
+        bundle.releaseAssistant()
+        MLX.Stream().synchronize()
+        MLX.Memory.clearCache()
+    }
+}
+
+private struct Qwen36ProductionCanaryFixture: @unchecked Sendable {
+    let modelDirectory: URL
+    let imageURL: URL
+    let container: ModelContainer
+    let targetSizing: SlotSizingSnapshot
+    let tokenizer: TokenizerHandle
+
+    func makeBundle(preparation: SpecDecPreparation) async throws -> ProviderEngineBundle {
+        let prepared = try await EngineV2SlotFactory.prepareProductionModel(
+            modelId: Qwen36ProductionCanary.modelID,
+            isVLM: true,
+            modelDirectory: modelDirectory,
+            container: container,
+            specDecPreparation: preparation)
+        let sizing = targetSizing.replacingAuxiliaryWeightBytes(prepared.assistantBytes)
+        let grant = Int(min(
+            UnifiedMemoryCap.kvBudgetBytes(
+                physicalBytes: ProcessInfo.processInfo.physicalMemory,
+                residentWeightBytes: UInt64(max(0, sizing.weightsBytes)),
+                configReserveBytes: 0),
+            UInt64(Int.max)))
+        do {
+            return try await EngineV2SlotFactory.makeProductionBundle(
+                modelId: Qwen36ProductionCanary.modelID,
+                modelType: Qwen36ProductionCanary.modelType,
+                isVLM: true,
+                modelDirectory: modelDirectory,
+                container: container,
+                tokenizer: tokenizer,
+                sizing: sizing,
+                kvBytesCapacity: grant,
+                maxConcurrentRequests: 2,
+                kvBudget: nil,
+                specDecPreparation: preparation,
+                preparedModel: prepared,
+                environment: [
+                    "DARKBLOOM_PREFIX_CACHE": "0",
+                    "DARKBLOOM_MTP_MAX_RECTANGULAR_TOKENS": "0",
+                ])
+        } catch {
+            prepared.assistant?.release()
+            MLX.Memory.clearCache()
+            throw error
+        }
+    }
+
+    func inlinePreparation() async -> SpecDecPreparation {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("qwen36-production-canary-\(UUID().uuidString)")
+        let funnel = SpecDecArtifactFunnel(
+            resolver: SpecDecResolver(storeRoot: root),
+            catalog: nil)
+        let preparation = await funnel.prepare(.init(
+            modelId: Qwen36ProductionCanary.modelID,
+            modelType: Qwen36ProductionCanary.modelType,
+            enabled: true,
+            localPath: nil,
+            modelDirectory: modelDirectory,
+            allowDownload: false,
+            environment: ["DARKBLOOM_CBV2_MTP": "1"]))
+        await funnel.shutdown()
+        try? FileManager.default.removeItem(at: root)
+        return preparation
+    }
+
+    func scheduler(
+        bundle: ProviderEngineBundle,
+        vision: EngineV2VisionPlumbing? = nil
+    ) -> MultiModelBatchSchedulerEngine {
+        let entry = MultiModelBatchSchedulerEngine.ModelRegistryEntry(
+            tokenizer: tokenizer,
+            modelType: Qwen36ProductionCanary.modelType,
+            container: container,
+            isVLM: true,
+            engineV2Bridge: bundle.bridge)
+        return MultiModelBatchSchedulerEngine(
+            registryProvider: { [entry] in [Qwen36ProductionCanary.modelID: entry] },
+            defaultMaxTokens: 512,
+            engineV2Vision: vision)
+    }
+
+    func textRequest() -> OpenAIChatCompletionRequest {
+        OpenAIChatCompletionRequest(
+            model: Qwen36ProductionCanary.modelID,
+            messages: [.init(
+                role: .user,
+                content: .text(
+                    "Compute 137 + 286. Return exactly "
+                        + #"{"sum":423,"check":"ok"}"#
+                        + " and nothing else."))],
+            reasoning: .init(enabled: false),
+            temperature: 0,
+            topP: 1,
+            topK: 0,
+            minP: 0,
+            maxTokens: 64)
+    }
+
+    func imageRequest() throws -> OpenAIChatCompletionRequest {
+        let data = try Data(contentsOf: imageURL)
+        let uri = "data:image/png;base64," + data.base64EncodedString()
+        return OpenAIChatCompletionRequest(
+            model: Qwen36ProductionCanary.modelID,
+            messages: [.init(
+                role: .user,
+                content: .parts([
+                    .text(
+                        "Read the image and return exactly one compact JSON object with keys "
+                            + "code, count, target, shapes, and colors. Preserve code and target "
+                            + "exactly; use lowercase arrays in left-to-right order. Output JSON only."),
+                    .imageURL(uri),
+                ]))],
+            reasoning: .init(enabled: false),
+            temperature: 0,
+            topP: 1,
+            topK: 0,
+            minP: 0,
+            maxTokens: 128)
+    }
+
+    func toolRequest() -> OpenAIChatCompletionRequest {
+        let schema: MLXLMCommon.JSONValue = .object([
+            "type": .string("object"),
+            "properties": .object([
+                "code": .object(["type": .string("string")]),
+                "count": .object(["type": .string("integer")]),
+            ]),
+            "required": .array([.string("code"), .string("count")]),
+            "additionalProperties": .bool(false),
+        ])
+        return OpenAIChatCompletionRequest(
+            model: Qwen36ProductionCanary.modelID,
+            messages: [.init(
+                role: .user,
+                content: .text(
+                    "Call record_canary exactly once with code ORCHID-7319 and count 27. "
+                        + "Do not write prose."))],
+            tools: [.init(function: .init(
+                name: "record_canary",
+                description: "Record the deterministic production canary values.",
+                parameters: schema))],
+            toolChoice: .mode(.auto),
+            toolCallParser: "qwen_xml",
+            reasoning: .init(enabled: false),
+            temperature: 0,
+            topP: 1,
+            topK: 0,
+            minP: 0,
+            maxTokens: 96)
+    }
+
+    func concurrentRequest(messages: [OpenAIChatMessage]) -> OpenAIChatCompletionRequest {
+        OpenAIChatCompletionRequest(
+            model: Qwen36ProductionCanary.modelID,
+            messages: messages,
+            reasoning: .init(enabled: false),
+            temperature: 0,
+            topP: 1,
+            topK: 0,
+            minP: 0,
+            maxTokens: 16)
+    }
+
+    func parityRequest() -> OpenAIChatCompletionRequest {
+        OpenAIChatCompletionRequest(
+            model: Qwen36ProductionCanary.modelID,
+            messages: [.init(
+                role: .user,
+                content: .text(
+                    "Explain speculative decoding. Give a precise technical explanation covering "
+                        + "draft proposals, target verification, rejection rollback, cache safety, "
+                        + "and why greedy token identity must match target-only decoding."))],
+            reasoning: .init(enabled: false),
+            temperature: 0,
+            topP: 1,
+            topK: 0,
+            minP: 0,
+            maxTokens: Qwen36ProductionCanary.parityMaxTokens)
+    }
+
+    func tokenize(_ request: OpenAIChatCompletionRequest) throws -> [Int] {
+        let prepared = try ToolChoicePromptPolicy.prepare(request)
+        return try ProviderPromptContractPipeline.tokenize(
+            prepared: prepared,
+            request: request,
+            tokenizer: tokenizer.inner,
+            modelType: Qwen36ProductionCanary.modelType,
+            reasoningEffort: nil)
+    }
+
+    func cancelAfterFirstDelta(
+        bundle: ProviderEngineBundle
+    ) async throws -> Qwen36ProductionCanaryCancellationResult {
+        let openAIRequest = OpenAIChatCompletionRequest(
+            model: Qwen36ProductionCanary.modelID,
+            messages: [.init(
+                role: .user,
+                content: .text(
+                    "Write a detailed 500-token explanation of deterministic distributed systems "
+                        + "testing. Continue until the output limit and do not end early."))],
+            reasoning: .init(enabled: false),
+            temperature: 0,
+            topP: 1,
+            topK: 0,
+            minP: 0,
+            maxTokens: 512)
+        let promptTokens = try tokenize(openAIRequest)
+        let request = MultiModelBatchSchedulerEngine.translate(
+            openAIRequest: openAIRequest,
+            defaultMaxTokens: 512)
+        let requestID = "qwen36-cancellation-canary"
+        let stream = await bundle.bridge.submitTokenized(
+            promptTokens: promptTokens,
+            request: request,
+            requestId: requestID,
+            cacheEnabled: false)
+        var result = Qwen36ProductionCanaryCancellationResult()
+        for await event in stream {
+            switch event {
+            case .chunk:
+                if !result.sawDelta {
+                    result.sawDelta = true
+                    await bundle.bridge.cancel(requestId: requestID)
+                }
+            case .info(let prompt, let completion, _, _):
+                result.promptTokens = prompt
+                result.completionTokens = completion
+            case .error(let message):
+                result.error = message
+            case .terminal(let cause, let message, let prompt, let completion):
+                result.promptTokens = prompt
+                result.completionTokens = completion
+                result.error = "\(cause.rawValue): \(message)"
+            }
+        }
+        return result
+    }
+}
+
+private struct Qwen36ProductionCanaryServerResult {
+    var text = ""
+    var toolCalls: [ToolCall] = []
+    var info: ServerGenerationInfo?
+}
+
+private struct Qwen36ProductionCanaryCancellationResult {
+    var sawDelta = false
+    var promptTokens = 0
+    var completionTokens = 0
+    var error: String?
+}
+
+private final class Qwen36ProductionCanaryVisionProbe: @unchecked Sendable {
+    private let lock = NSLock()
+    private var state = (prepared: 0, spans: 0, refusals: 0)
+
+    var preparedCount: Int { lock.withLock { state.prepared } }
+    var lastSpanCount: Int { lock.withLock { state.spans } }
+    var refusalCount: Int { lock.withLock { state.refusals } }
+
+    func recordPrepared(spanCount: Int) {
+        lock.withLock {
+            state.prepared += 1
+            state.spans = spanCount
+        }
+    }
+
+    func recordRefusal() {
+        lock.withLock { state.refusals += 1 }
+    }
+}
+
+private enum Qwen36ProductionCanaryError: Error, CustomStringConvertible {
+    case missingArtifact(String)
+    case missingImage(String)
+    case missingMetallib
+    case notVLM(String)
+    case engineUnavailable
+    case emptyGeneration
+    case missingTerminal
+    case unexpectedTerminal(String)
+    case capacityDidNotDrain(active: Int, waiting: Int, tokens: Int)
+    case stage(String, String)
+
+    var description: String {
+        switch self {
+        case .missingArtifact(let path):
+            "Qwen3.6 artifact is missing at \(path)"
+        case .missingImage(let path):
+            "Qwen3.6 proof image is missing at \(path)"
+        case .missingMetallib:
+            "mlx.metallib is unavailable; run scripts/fetch-metallib.sh before the live canary"
+        case .notVLM(let path):
+            "Qwen3.6 artifact at \(path) does not declare vision_config"
+        case .engineUnavailable:
+            "production bundle released its EngineV2 before the canary submission"
+        case .emptyGeneration:
+            "production EngineV2 emitted no token IDs"
+        case .missingTerminal:
+            "production EngineV2 stream ended without a terminal event"
+        case .unexpectedTerminal(let reason):
+            "production EngineV2 ended unsuccessfully: \(reason)"
+        case .capacityDidNotDrain(let active, let waiting, let tokens):
+            "production EngineV2 capacity did not drain (active=\(active), waiting=\(waiting), "
+                + "tokens=\(tokens))"
+        case .stage(let stage, let detail):
+            "Qwen3.6 production canary failed during \(stage): \(detail)"
+        }
+    }
+}

--- a/provider-swift/Tests/ProviderCoreTests/QwenVLMTargetExtractionTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/QwenVLMTargetExtractionTests.swift
@@ -393,6 +393,7 @@ struct QwenVLMTargetExtractionTests {
             SlotSizingSnapshot.fp16KVBytesPerToken(layerKinds: config.cbv2LayerKinds)
                 == 20_480)
         #expect(try config.cbv2RecurrentStateSpec().fixedBytesPerRequest() == 64_389_120)
+        #expect(try config.cbv2RecurrentStateSpec().peakBytesPerRequest() == 193_167_360)
     }
 
     @Test("Qwen is advertised after target, vision, MTP, and cleanup canaries pass")

--- a/provider-swift/Tests/ProviderCoreTests/QwenVLMTargetExtractionTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/QwenVLMTargetExtractionTests.swift
@@ -260,9 +260,10 @@ struct QwenVLMTargetExtractionTests {
         let prepared = try EngineV2Factory.prepareProductionBackend(
             model: target,
             kvBytesCapacity: 1 << 20,
-            kvBackend: .contiguous)
+            maxConcurrentRequests: 2,
+            kvBackend: EngineV2KVBackendSelection.contiguous)
 
-        #expect(prepared.kind == .contiguous)
+        #expect(prepared.kind == EngineV2KVBackendKind.contiguous)
         #expect(prepared.layerKinds.count == 1)
         #expect(prepared.layerKinds.first?.modelLayerIndex == 1)
         #expect(prepared.modelCapabilities.supportsPrefixReuse == false)
@@ -272,7 +273,8 @@ struct QwenVLMTargetExtractionTests {
             _ = try EngineV2Factory.prepareProductionBackend(
                 model: Qwen35Model(config),
                 kvBytesCapacity: 1 << 20,
-                kvBackend: .contiguous)
+                maxConcurrentRequests: 2,
+                kvBackend: EngineV2KVBackendSelection.contiguous)
         }
     }
 
@@ -284,10 +286,11 @@ struct QwenVLMTargetExtractionTests {
         let prepared = try EngineV2Factory.prepareProductionBackend(
             model: Qwen35MoEModel(config),
             kvBytesCapacity: 1 << 20,
-            kvBackend: .paged,
+            maxConcurrentRequests: 2,
+            kvBackend: EngineV2KVBackendSelection.paged,
             pagedPreflightOverride: { _ in preflightCalled = true })
 
-        #expect(prepared.kind == .contiguous)
+        #expect(prepared.kind == EngineV2KVBackendKind.contiguous)
         #expect(prepared.fallbackReason == "model_capability")
         #expect(preflightCalled == false)
     }

--- a/provider-swift/Tests/ProviderCoreTests/QwenVLMTargetExtractionTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/QwenVLMTargetExtractionTests.swift
@@ -1,0 +1,400 @@
+// Copyright © 2026 Eigen Labs.
+
+import Foundation
+import MLX
+import MLXLLM
+import MLXLMCommon
+import MLXNN
+import MLXVLM
+import Testing
+
+@testable import ProviderCore
+
+private func qwenTargetFixtureJSON(
+    mtpLayers: Int = 1,
+    fullAttentionInterval: Int = 1
+) -> Data {
+    Data(
+        """
+        {
+          "model_type": "qwen3_5_moe",
+          "mtp_num_hidden_layers": \(mtpLayers),
+          "text_config": {
+            "model_type": "qwen3_5_moe",
+            "hidden_size": 64,
+            "num_hidden_layers": 2,
+            "intermediate_size": 128,
+            "num_attention_heads": 1,
+            "num_key_value_heads": 1,
+            "head_dim": 64,
+            "linear_num_value_heads": 1,
+            "linear_num_key_heads": 1,
+            "linear_key_head_dim": 64,
+            "linear_value_head_dim": 64,
+            "linear_conv_kernel_dim": 4,
+            "vocab_size": 64,
+            "full_attention_interval": \(fullAttentionInterval),
+            "num_experts": 0,
+            "num_experts_per_tok": 0,
+            "mtp_num_hidden_layers": \(mtpLayers)
+          },
+          "vision_config": {
+            "model_type": "qwen3_5_moe",
+            "depth": 1,
+            "hidden_size": 64,
+            "intermediate_size": 128,
+            "out_hidden_size": 64,
+            "num_heads": 1,
+            "patch_size": 16,
+            "spatial_merge_size": 1,
+            "temporal_patch_size": 1,
+            "num_position_embeddings": 8
+          }
+        }
+        """.utf8)
+}
+
+private func qwenTargetFixtureDirectory(configData: Data) throws -> URL {
+    let directory = FileManager.default.temporaryDirectory
+        .appendingPathComponent("qwen-target-extraction-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    try configData.write(to: directory.appendingPathComponent("config.json"))
+    return directory
+}
+
+private struct QwenExtractionProcessorError: Error {}
+
+private struct QwenExtractionProcessor: UserInputProcessor {
+    func prepare(input: UserInput) async throws -> LMInput {
+        throw QwenExtractionProcessorError()
+    }
+}
+
+private final class QwenPrefixCacheConstructionProbe: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _calls = 0
+
+    func record() { lock.withLock { _calls += 1 } }
+    var calls: Int { lock.withLock { _calls } }
+}
+
+@Suite("Qwen VLM target-only extraction", .serialized)
+struct QwenVLMTargetExtractionTests {
+    @Test("Qwen config decodes through MLXLLM and target skeleton omits inline MTP")
+    func qwenConfigBuildsTargetOnlySkeleton() throws {
+        let previousMTPState = _qwen35MTPEnabled
+        _qwen35MTPEnabled = true
+        defer { _qwen35MTPEnabled = previousMTPState }
+        let config = try EngineV2VLMTextExtraction.decodeQwenConfiguration(
+            configData: qwenTargetFixtureJSON(mtpLayers: 1))
+        let target = Qwen35MoEModel(config)
+
+        #expect(target.parameters().flattened().contains { $0.0.contains("mtp.") } == false)
+        #expect(target.vocabularySize == 64)
+    }
+
+    @Test("Qwen wrapper dispatches to a strict, weight-sharing MLXLLM target")
+    func qwenWrapperDispatchAndStrictUpdate() throws {
+        let configData = qwenTargetFixtureJSON(mtpLayers: 1)
+        let wrapperConfig = try JSONDecoder.json5().decode(
+            MLXVLM.Qwen35Configuration.self, from: configData)
+        let wrapper = MLXVLM.Qwen35MoE(wrapperConfig)
+        let directory = try qwenTargetFixtureDirectory(configData: configData)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let extraction = try EngineV2VLMTextExtraction.extractTextModel(
+            from: wrapper,
+            modelDirectory: directory,
+            environment: [EngineV2VLMTextExtraction.parityCheckFlag: "0"])
+
+        #expect(extraction.family == .qwen35MoE)
+        #expect(extraction.servingModel is Qwen35MoEModel)
+        #expect(extraction.parityMaxAbsLogitDiff == nil)
+        #expect(
+            extraction.servingModel.parameters().flattened().contains {
+                $0.0.hasPrefix("vision_tower.") || $0.0.hasPrefix("mtp.")
+            } == false)
+        let sourceParameters = Dictionary(
+            uniqueKeysWithValues: wrapper.parameters().flattened().filter {
+                $0.0.hasPrefix("language_model.")
+            })
+        for (key, targetArray) in extraction.servingModel.parameters().flattened() {
+            let sourceArray = try #require(sourceParameters[key], "missing source array for \(key)")
+            // Module.update keeps the target's Swift MLXArray wrapper stable and
+            // repoints its core array context via _updateInternal. Object identity
+            // is therefore intentionally different even though no tensor payload
+            // is copied. The mapping test below pins source-handle identity before
+            // update; this loop pins the strict installed parameter set.
+            #expect(targetArray.shape == sourceArray.shape, "shape drift for \(key)")
+            #expect(targetArray.dtype == sourceArray.dtype, "dtype drift for \(key)")
+            #expect(
+                MLX.all(targetArray .== sourceArray).item(Bool.self),
+                "installed value drift for \(key)")
+        }
+    }
+
+    @Test("Qwen key mapping retains only live language target arrays")
+    func qwenTargetKeyMapping() throws {
+        let config = try EngineV2VLMTextExtraction.decodeQwenConfiguration(
+            configData: qwenTargetFixtureJSON())
+        let target = Qwen35MoEModel(config)
+        let language = MLXArray([Float(1), Float(2)])
+        let mapped = EngineV2VLMTextExtraction.reKeyedQwenTargetWeights(
+            flattenedWeights: [
+                ("language_model.model.norm.weight", language),
+                ("mtp.norm.weight", MLXArray([Float(3)])),
+                ("vision_tower.blocks.0.weight", MLXArray([Float(4)])),
+            ],
+            sanitizer: target)
+
+        #expect(mapped.keys.sorted() == ["language_model.model.norm.weight"])
+        #expect(mapped["language_model.model.norm.weight"] === language)
+        #expect(mapped["language_model.model.norm.weight"]?.asArray(Float.self) == [1, 2])
+    }
+
+    @Test("Qwen mixed quantization lookup uses the undoubled wrapper path")
+    func qwenMixedQuantizationSelection() throws {
+        let defaultQuantization = BaseConfiguration.Quantization(groupSize: 64, bits: 4)
+        let override = BaseConfiguration.Quantization(groupSize: 32, bits: 8)
+        let table = BaseConfiguration.PerLayerQuantization(
+            quantization: defaultQuantization,
+            perLayerQuantization: [
+                "language_model.model.layers.1.self_attn.q_proj": .quantize(override),
+                "language_model.model.layers.0.linear_attn.in_proj_qkv": .skip,
+            ])
+
+        let qwenOverride = EngineV2VLMTextExtraction.quantization(
+            targetPath: "language_model.model.layers.1.self_attn.q_proj",
+            family: .qwen35MoE,
+            perLayerQuantization: table)
+        #expect(qwenOverride?.groupSize == 32)
+        #expect(qwenOverride?.bits == 8)
+        #expect(
+            EngineV2VLMTextExtraction.quantization(
+                targetPath: "language_model.model.layers.0.linear_attn.in_proj_qkv",
+                family: .qwen35MoE,
+                perLayerQuantization: table) == nil)
+        #expect(
+            EngineV2VLMTextExtraction.quantization(
+                targetPath: "language_model.lm_head",
+                family: .qwen35MoE,
+                perLayerQuantization: table)?.bits == 4)
+
+    }
+
+    @Test("Qwen skeleton reproduces default, override, and skipped quantized modules")
+    func qwenMixedQuantizationStructure() throws {
+        let config = try EngineV2VLMTextExtraction.decodeQwenConfiguration(
+            configData: qwenTargetFixtureJSON(fullAttentionInterval: 1))
+        let target = Qwen35MoEModel(config)
+        let overridePath = "language_model.model.layers.0.self_attn.q_proj"
+        let skippedPath = "language_model.model.layers.1.self_attn.q_proj"
+        let defaultPath = "language_model.lm_head"
+        let table = BaseConfiguration.PerLayerQuantization(
+            quantization: .init(groupSize: 64, bits: 4),
+            perLayerQuantization: [
+                overridePath: .quantize(.init(groupSize: 32, bits: 8)),
+                skippedPath: .skip,
+            ])
+
+        try EngineV2VLMTextExtraction.applyQuantizationStructure(
+            skeleton: target,
+            weights: [
+                "\(overridePath).scales": MLXArray.ones([1]),
+                "\(skippedPath).scales": MLXArray.ones([1]),
+                "\(defaultPath).scales": MLXArray.ones([1]),
+            ],
+            family: .qwen35MoE,
+            perLayerQuantization: table)
+
+        let override = try #require(
+            target.namedModules().first { $0.0 == overridePath }?.1 as? QuantizedLinear)
+        #expect(override.groupSize == 32)
+        #expect(override.bits == 8)
+        #expect(
+            (target.namedModules().first { $0.0 == skippedPath }?.1 is QuantizedLinear)
+                == false)
+        let defaultModule = try #require(
+            target.namedModules().first { $0.0 == defaultPath }?.1 as? QuantizedLinear)
+        #expect(defaultModule.groupSize == 64)
+        #expect(defaultModule.bits == 4)
+    }
+
+    @Test("plain Qwen wrapper is refused; only the combined MoE wrapper dispatches")
+    func plainQwenWrapperRefused() throws {
+        let configData = qwenTargetFixtureJSON()
+        let wrapperConfig = try JSONDecoder.json5().decode(
+            MLXVLM.Qwen35Configuration.self, from: configData)
+        let directory = try qwenTargetFixtureDirectory(configData: configData)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        #expect(throws: EngineV2VLMTextExtractionError.self) {
+            _ = try EngineV2VLMTextExtraction.extractTextModel(
+                from: MLXVLM.Qwen35(wrapperConfig),
+                modelDirectory: directory,
+                environment: [EngineV2VLMTextExtraction.parityCheckFlag: "0"])
+        }
+    }
+
+    @Test("benchmark resolution uses the same extracted Qwen target")
+    func benchmarkServingModelUsesQwenExtraction() throws {
+        let configData = qwenTargetFixtureJSON()
+        let wrapperConfig = try JSONDecoder.json5().decode(
+            MLXVLM.Qwen35Configuration.self, from: configData)
+        let directory = try qwenTargetFixtureDirectory(configData: configData)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let serving = try EngineV2Factory.benchmarkServingModel(
+            model: MLXVLM.Qwen35MoE(wrapperConfig),
+            isVLM: true,
+            modelDirectory: directory,
+            environment: [EngineV2VLMTextExtraction.parityCheckFlag: "0"])
+        #expect(serving is Qwen35MoEModel)
+    }
+
+    @Test("production factory accepts only the wired Qwen MoE target family")
+    func factoryAcceptanceAndRefusal() throws {
+        let config = try EngineV2VLMTextExtraction.decodeQwenConfiguration(
+            configData: qwenTargetFixtureJSON(fullAttentionInterval: 2))
+        let target = Qwen35MoEModel(config)
+        let prepared = try EngineV2Factory.prepareProductionBackend(
+            model: target,
+            kvBytesCapacity: 1 << 20,
+            kvBackend: .contiguous)
+
+        #expect(prepared.kind == .contiguous)
+        #expect(prepared.layerKinds.count == 1)
+        #expect(prepared.layerKinds.first?.modelLayerIndex == 1)
+        #expect(prepared.modelCapabilities.supportsPrefixReuse == false)
+        #expect(EngineV2Factory.adoptionBoundTokens(model: target) == 0)
+
+        #expect(throws: EngineV2ProductionError.self) {
+            _ = try EngineV2Factory.prepareProductionBackend(
+                model: Qwen35Model(config),
+                kvBytesCapacity: 1 << 20,
+                kvBackend: .contiguous)
+        }
+    }
+
+    @Test("Qwen core capability veto forces paged selection to contiguous before preflight")
+    func pagedCapabilityVeto() throws {
+        let config = try EngineV2VLMTextExtraction.decodeQwenConfiguration(
+            configData: qwenTargetFixtureJSON(fullAttentionInterval: 2))
+        var preflightCalled = false
+        let prepared = try EngineV2Factory.prepareProductionBackend(
+            model: Qwen35MoEModel(config),
+            kvBytesCapacity: 1 << 20,
+            kvBackend: .paged,
+            pagedPreflightOverride: { _ in preflightCalled = true })
+
+        #expect(prepared.kind == .contiguous)
+        #expect(prepared.fallbackReason == "model_capability")
+        #expect(preflightCalled == false)
+    }
+
+    @Test("Qwen recurrent target never constructs or retains an SSD prefix cache")
+    func recurrentTargetSkipsPrefixCacheConstruction() async throws {
+        let config = try EngineV2VLMTextExtraction.decodeQwenConfiguration(
+            configData: qwenTargetFixtureJSON(fullAttentionInterval: 2))
+        let target = Qwen35MoEModel(config)
+        let tokenizer = StubBridgeTokenizer()
+        let container = ModelContainer(
+            context: ModelContext(
+                configuration: ModelConfiguration(id: "tiny/qwen"),
+                model: target,
+                processor: QwenExtractionProcessor(),
+                tokenizer: tokenizer))
+        let prepared = EngineV2PreparedModel(
+            snapshot: EngineV2ModelSnapshot(
+                model: target, eosTokenIds: [1], extraEOSTokens: []),
+            servingModel: target,
+            assistant: nil,
+            mtpStatus: .disabled(.configDisabled, configured: false),
+            mtpArtifact: nil)
+        let probe = QwenPrefixCacheConstructionProbe()
+
+        let bundle = try await EngineV2SlotFactory.makeProductionBundle(
+            modelId: "tiny-qwen",
+            modelType: "qwen3_5_moe",
+            isVLM: false,
+            modelDirectory: nil,
+            container: container,
+            tokenizer: TokenizerHandle(tokenizer),
+            sizing: SlotSizingSnapshot(
+                weightsBytes: 1,
+                fp16KVBytesPerToken: 256,
+                maxContextLength: 2_048,
+                defaultMaxTokens: 32),
+            kvBytesCapacity: 8 << 20,
+            maxConcurrentRequests: 2,
+            kvBudget: nil,
+            weightHash: String(repeating: "a", count: 64),
+            specDecPreparation: .init(
+                artifact: nil,
+                status: .disabled(.configDisabled, configured: false)),
+            preparedModel: prepared,
+            assemblyOverrides: .init(
+                promptContractID: "tiny-qwen-contract",
+                makePrefixCache: { _, _ in
+                    probe.record()
+                    return nil
+                }),
+            environment: ["DARKBLOOM_PREFIX_CACHE": "1"])
+
+        #expect(probe.calls == 0)
+        #expect(bundle.bridge.ssdPrefixCache == nil)
+        let status = bundle.bridge.prefixCacheModelStatus()
+        #expect(status.state == .disabled)
+        #expect(status.reason == .unsupportedLayout)
+        await bundle.bridge.shutdown()
+    }
+
+    @Test("Qwen VLM sizing counts only full-attention KV rows")
+    func qwenSizingUsesCompactAttentionLayout() throws {
+        let configData = qwenTargetFixtureJSON(fullAttentionInterval: 2)
+        let directory = try qwenTargetFixtureDirectory(configData: configData)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        // One of two layers owns attention KV: 2(K+V) * 1 head * 64 dim * 2-byte fp16.
+        #expect(SlotSizingSnapshot.qwenVLMTextKVRate(modelDirectory: directory) == 256)
+    }
+
+    @Test("production Qwen config sizes attention KV and fixed recurrent residency separately")
+    func productionQwenSizingFacts() throws {
+        var text: [String: Any] = [
+            "model_type": "qwen3_5_moe",
+            "hidden_size": 2048,
+            "num_hidden_layers": 40,
+            "num_attention_heads": 16,
+            "num_key_value_heads": 2,
+            "head_dim": 256,
+            "linear_num_value_heads": 32,
+            "linear_num_key_heads": 16,
+            "linear_key_head_dim": 128,
+            "linear_value_head_dim": 128,
+            "linear_conv_kernel_dim": 4,
+            "vocab_size": 248_320,
+            "full_attention_interval": 4,
+        ]
+        text["num_experts"] = 256
+        text["num_experts_per_tok"] = 8
+        let data = try JSONSerialization.data(withJSONObject: [
+            "model_type": "qwen3_5_moe",
+            "text_config": text,
+        ])
+        let config = try EngineV2VLMTextExtraction.decodeQwenTextConfiguration(
+            configData: data)
+
+        #expect(config.cbv2LayerKinds.count == 10)
+        #expect(
+            SlotSizingSnapshot.fp16KVBytesPerToken(layerKinds: config.cbv2LayerKinds)
+                == 20_480)
+        #expect(try config.cbv2RecurrentStateSpec().fixedBytesPerRequest() == 64_389_120)
+    }
+
+    @Test("Qwen is advertised after target, vision, MTP, and cleanup canaries pass")
+    func allowlistIsOpen() {
+        #expect(EngineV2SupportedModels.isSupported(modelType: "qwen3_5_moe"))
+        #expect(EngineV2SupportedModels.isSupported(modelType: " QWEN3_5_MOE "))
+    }
+}

--- a/provider-swift/Tests/ProviderCoreTests/SpecDecArtifactFunnelTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/SpecDecArtifactFunnelTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import MLX
 import Testing
 @testable import ProviderCore
 
@@ -107,6 +108,31 @@ private func makeLocalAssistant() throws -> URL {
     return root
 }
 
+private func makeInlineQwenArtifact(includeMTP: Bool = true) throws -> URL {
+    let root = FileManager.default.temporaryDirectory
+        .appendingPathComponent("specdec-inline-qwen-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    try Data(
+        """
+        {
+          "model_type": "qwen3_5_moe",
+          "mtplx_mtp": {"included": true, "prefix": "mtp.", "block_size": 3},
+          "mtplx_mtp_quantization": {}
+        }
+        """.utf8
+    ).write(to: root.appendingPathComponent("config.json"))
+    let shard = "model-00001-of-00001.safetensors"
+    let key = includeMTP ? "mtp.norm.weight" : "language_model.model.norm.weight"
+    try MLX.save(
+        arrays: [key: MLXArray([Float(1), Float(2), Float(3), Float(4)])],
+        url: root.appendingPathComponent(shard))
+    let index = try JSONSerialization.data(withJSONObject: [
+        "weight_map": [key: shard]
+    ])
+    try index.write(to: root.appendingPathComponent("model.safetensors.index.json"))
+    return root
+}
+
 @Suite("SpecDec production artifact funnel")
 struct SpecDecArtifactFunnelTests {
     private func funnel(catalog: FunnelCatalog, root: URL) -> SpecDecArtifactFunnel {
@@ -148,6 +174,53 @@ struct SpecDecArtifactFunnelTests {
                 localPath: "/definitely/missing", allowDownload: true, environment: [:]))
         #expect(prepared.artifact == nil)
         #expect(prepared.status.reason == .localArtifactInvalid)
+        #expect(await catalog.calls == 0)
+    }
+
+    @Test("Qwen combined checkpoint resolves its indexed MTP payload inline")
+    func qwenInlineArtifactResolvesWithoutCatalog() async throws {
+        let directory = try makeInlineQwenArtifact()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let catalog = FunnelCatalog(nil)
+        let prepared = await funnel(
+            catalog: catalog, root: FileManager.default.temporaryDirectory
+        ).prepare(
+            .init(
+                modelId: "qwen3.6-35b-a3b-vl-mtp-mxfp8",
+                modelType: "qwen3_5_moe",
+                enabled: true,
+                localPath: nil,
+                modelDirectory: directory,
+                allowDownload: true,
+                environment: [:]))
+
+        let artifact = try #require(prepared.artifact)
+        #expect(artifact.source == .inline)
+        #expect(artifact.artifactBytes == 16)
+        #expect(artifact.inlineIndexSHA256 != nil)
+        #expect(prepared.status == .candidate(artifact))
+        #expect(await catalog.calls == 0)
+    }
+
+    @Test("Qwen checkpoint without indexed MTP fails open before catalog")
+    func qwenInvalidInlineArtifactFallsBack() async throws {
+        let directory = try makeInlineQwenArtifact(includeMTP: false)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let catalog = FunnelCatalog(funnelModel())
+        let prepared = await funnel(
+            catalog: catalog, root: FileManager.default.temporaryDirectory
+        ).prepare(
+            .init(
+                modelId: "qwen3.6-35b-a3b-vl-mtp-mxfp8",
+                modelType: "qwen3_5_moe",
+                enabled: true,
+                localPath: nil,
+                modelDirectory: directory,
+                allowDownload: true,
+                environment: [:]))
+
+        #expect(prepared.artifact == nil)
+        #expect(prepared.status.reason == .inlineArtifactInvalid)
         #expect(await catalog.calls == 0)
     }
 


### PR DESCRIPTION
## Summary

- serve the combined Qwen3.6-35B-A3B VLM + inline MTP artifact through the production EngineV2 provider path
- preserve request-owned recurrent and 3-axis mRoPE state, causal vision, exact rollback, and truthful target/assistant memory accounting
- pin the reusable runtime implementation from Layr-Labs/mlx-swift-lm#104
- synchronize the provider and coordinator fallback versions at `0.8.3`

Depends on https://github.com/Layr-Labs/mlx-swift-lm/pull/104. The gitlink intentionally points at that PR's current head, `a4fc0447c1af635276dae40ef6662bb78cc38bb0`, and will be updated if review changes it.

## Before

### Behavior

```mermaid
flowchart LR
  A[Qwen3.6 text, image, or tool request] --> B[Provider model-family gate]
  B --> C[Qwen family unsupported]
  C --> D[Request cannot use production EngineV2 slot]
```

### Code

```mermaid
flowchart LR
  A[ProviderLoop / StandaloneServer] --> B[EngineV2SlotFactory]
  B --> C[Gemma direct tower or generic model]
  C --> D[No Qwen VLM target extraction]
  D --> E[No inline Qwen MTP bundle]
```

## After

### Behavior

```mermaid
flowchart LR
  A[Qwen3.6 request] --> B{Input traits}
  B -->|text| C[Request-owned recurrent state]
  B -->|image| D[Causal vision + request-owned 3-axis mRoPE]
  B -->|tool| E[Qwen XML tool parsing]
  C --> F[Inline MTP depth 1]
  D --> F
  E --> F
  F --> G[Serial exact target verification]
  G --> H[Stream output + truthful usage/accounting]
  B -->|video or unsupported optimization| I[Fail closed]
```

### Code

```mermaid
flowchart LR
  A[ProviderLoop / StandaloneServer] --> B[EngineV2VisionPrefill]
  B --> C[EngineV2VLMTextExtraction]
  C --> D[EngineV2SlotFactory]
  D --> E[SpecDecArtifactFunnel / SpecDecStore]
  E --> F[Qwen target + inline MTP assistant]
  F --> G[EngineV2Bridge admission and lifecycle]
```

## Safety Boundary

- video remains unsupported
- Qwen prefix reuse, paged KV, compiled decode, packed prefill, and rectangular MTP remain disabled
- MTP is fixed to speculative depth 1, batch 1, and serial target verification
- the model remains beta/ready with no alias or active-version promotion
- this PR does not create a tag, dispatch the release workflow, deploy provider traffic, or promote the model

## Artifact Evidence

- Hugging Face revision: `73a03825c2226177f3e679210965dba3508cdee8`
- R2 prefix: `v2/qwen3.6-35b-a3b-vl-mtp-mxfp8--943d60189096/2026-08-11-r1`
- aggregate manifest SHA-256: `d932e96b00404b0575fff47e2dac8ed113056b3f22d0040c3c8d3f9ef25b09ed`
- registry version id: `8`, status beta/ready, `promote=false`
- prior real-model production-path canary covered text, pixel-grounded image output, tool calls, unequal-history concurrency, cancellation cleanup, usage, and exact 192-token target/MTP parity

## Verification

- `swift build --target ProviderCore --jobs 1` (rerun after review-fix pin)
- `swift test --jobs 1 --filter QwenVLMTargetExtractionTests` (13 passed)
- `swift test --jobs 1 --filter 'QwenVLMTargetExtractionTests|EngineV2VisionRoutingTests|ProviderMTPFactoryTests|SpecDecArtifactFunnelTests|EngineV2ProductionWiringTests'` (122 passed against `a4fc044`)
- `./scripts/check-release-version.sh 0.8.3`
- `git diff --check origin/master...HEAD`

A fresh packaged/live canary is intentionally deferred until both linked PRs are reviewed and merged and a signed/notarized candidate exists.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/611"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789162956&installation_model_id=21733&pr_number=611&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F611&signature=4228977a1c5bbcade13b678c10e15b2832a605c10ef05c432e8584ea8138d1d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
