### PR TITLE
fix(api): expose image modality in OpenRouter model feed

### DIFF
--- a/coordinator/api/openrouter_endpoint.go
+++ b/coordinator/api/openrouter_endpoint.go
@@ -70,12 +70,17 @@ func (s *Server) handleListModelsOpenRouter(w http.ResponseWriter, r *http.Reque
 		}
 
 		reg, hasReg := registryByID[id]
+		var capabilities []string
+		if hasReg {
+			capabilities = reg.Capabilities
+		}
+		inputModalities, outputModalities := deriveModalities(modelType, capabilities)
 		entry := types.OpenRouterModel{
 			ID:                id,
 			HuggingFaceID:     id, // our model IDs are HuggingFace paths
 			Name:              openRouterModelName(cm, reg, hasReg, id),
-			InputModalities:   []string{"text"},
-			OutputModalities:  []string{"text"},
+			InputModalities:   inputModalities,
+			OutputModalities:  outputModalities,
 			SupportedFeatures: []string{},
 			IsReady:           true,
 		}
@@ -161,6 +166,11 @@ func (s *Server) openRouterAliasEntries(
 		}
 
 		reg, hasReg := registryByID[primary]
+		var capabilities []string
+		if hasReg {
+			capabilities = reg.Capabilities
+		}
+		inputModalities, outputModalities := deriveModalities(modelType, capabilities)
 		displayName := a.DisplayName
 		if displayName == "" {
 			displayName = openRouterModelName(cm, reg, hasReg, a.AliasID)
@@ -169,8 +179,8 @@ func (s *Server) openRouterAliasEntries(
 			ID:                a.AliasID,
 			HuggingFaceID:     primary,
 			Name:              displayName,
-			InputModalities:   []string{"text"},
-			OutputModalities:  []string{"text"},
+			InputModalities:   inputModalities,
+			OutputModalities:  outputModalities,
 			SupportedFeatures: []string{},
 			IsReady:           true,
 		}

--- a/coordinator/api/openrouter_endpoint_test.go
+++ b/coordinator/api/openrouter_endpoint_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 // TestOpenRouterModelsEndpoint verifies the dedicated /v1/models/openrouter feed
-// emits the pure OpenRouter schema: text modalities, slug, staging-based
+// emits the pure OpenRouter schema: catalog-derived modalities, slug, staging-based
 // is_ready, populated features, and no Darkbloom metadata block.
 func TestOpenRouterModelsEndpoint(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
@@ -39,7 +39,7 @@ func TestOpenRouterModelsEndpoint(t *testing.T) {
 		MaxContextLength: 262144,
 		MaxOutputLength:  16384,
 		MinRAMGB:         16,
-		Capabilities:     []string{"tools", "reasoning"},
+		Capabilities:     []string{"tools", "reasoning", "vision"},
 		Status:           "active",
 		Description:      "Balanced general-purpose model.",
 		Metadata:         map[string]any{"openrouter_slug": "darkbloom/qwen3.5-9b"},
@@ -91,8 +91,8 @@ func TestOpenRouterModelsEndpoint(t *testing.T) {
 	if m.Created != entry.CreatedAt.Unix() {
 		t.Errorf("created = %d, want %d", m.Created, entry.CreatedAt.Unix())
 	}
-	if len(m.InputModalities) != 1 || m.InputModalities[0] != "text" {
-		t.Errorf("input_modalities = %v, want [text]", m.InputModalities)
+	if len(m.InputModalities) != 2 || m.InputModalities[0] != "text" || m.InputModalities[1] != "image" {
+		t.Errorf("input_modalities = %v, want [text image]", m.InputModalities)
 	}
 	if len(m.OutputModalities) != 1 || m.OutputModalities[0] != "text" {
 		t.Errorf("output_modalities = %v, want [text]", m.OutputModalities)
@@ -248,6 +248,15 @@ func TestOpenRouterModelsAliasEntriesHideBuilds(t *testing.T) {
 	seedActiveModel(t, st, aliasFP8, "Gemma 4 26B fp8")
 	seedActiveModel(t, st, aliasQAT, "Gemma 4 26B qat")
 	seedActiveModel(t, st, "mlx-community/unrelated-9b", "Unrelated 9B")
+	primary, err := st.GetModelRegistryRecord(aliasQAT)
+	if err != nil {
+		t.Fatal(err)
+	}
+	primaryEntry := registryEntryFromRecord(primary)
+	primaryEntry.Capabilities = []string{"chat", "vision"}
+	if err := st.UpsertModelRegistryEntry(primaryEntry); err != nil {
+		t.Fatal(err)
+	}
 	if err := st.UpsertModelAlias(&store.ModelAlias{
 		AliasID: "gemma-4-26b", DisplayName: "Gemma 4 26B", Active: true,
 		DesiredBuild: aliasQAT, PreviousBuild: aliasFP8,
@@ -284,6 +293,9 @@ func TestOpenRouterModelsAliasEntriesHideBuilds(t *testing.T) {
 	}
 	if alias.HuggingFaceID != aliasQAT {
 		t.Fatalf("alias hugging_face_id = %q, want primary build", alias.HuggingFaceID)
+	}
+	if len(alias.InputModalities) != 2 || alias.InputModalities[0] != "text" || alias.InputModalities[1] != "image" {
+		t.Fatalf("alias input_modalities = %v, want [text image]", alias.InputModalities)
 	}
 	// Member builds are hidden from the raw listing.
 	if _, leaked := byID[aliasFP8]; leaked {


### PR DESCRIPTION
## Summary

- derive the dedicated OpenRouter feed modalities from registry capabilities
- advertise `image` input for vision-capable models such as Qwen 3.6
- keep raw entries and aliases consistent with the existing `/v1/models` mapping

## Before

### Behavior

```mermaid
flowchart LR
  A[OpenRouter polls /v1/models/openrouter] --> B[active vision model]
  B --> C[input_modalities: text only]
```

### Code

```mermaid
flowchart LR
  A[handleListModelsOpenRouter] --> B[hardcoded text arrays]
  C[openRouterAliasEntries] --> B
```

## After

### Behavior

```mermaid
flowchart LR
  A[OpenRouter polls /v1/models/openrouter] --> B[active vision model]
  B --> C[input_modalities: text + image]
  B --> D[output_modalities: text]
```

### Code

```mermaid
flowchart LR
  A[registry capabilities] --> B[deriveModalities]
  B --> C[raw OpenRouter entry]
  B --> D[alias OpenRouter entry]
```

## Verification

- `go test ./api -run TestOpenRouter -count=1`
- `go test ./...` (all packages passed except the pre-existing `promptcontract/TestSupervisorRestartsChildAndBecomesReady` timing flake; isolated test and full `./promptcontract` package passed on immediate rerun)
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/613"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789199774&installation_model_id=21733&pr_number=613&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F613&signature=630e38abf9431c1ca3f471ad41301b1de357b8d031d6ca65ad92d927730945f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->