### PR TITLE
fix(provider): stream Qwen3.6 reasoning deltas immediately — synthesize the template pre-opened <think>

### DIFF
--- a/provider-swift/Sources/ProviderCore/Inference/MultiModelBatchSchedulerEngine.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/MultiModelBatchSchedulerEngine.swift
@@ -396,12 +396,25 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
                         multimodal: visionPrepared.multimodalInput(),
                         mediaKind: visionPrepared.mediaKind
                     )
+                    // Qwen3.6/DeepSeek-style templates pre-open a <think>
+                    // block at the prompt tail (output carries only the
+                    // close). Without a synthesized open, the downstream
+                    // streaming think parser buffers the whole block —
+                    // TTFT becomes the full thinking duration. Same probe
+                    // as the text path below.
+                    let synthesizeThinkOpen = ReasoningPromptProbe.shouldSynthesizeThinkOpen(
+                        reasoningParser: request.reasoningParser,
+                        stream: request.stream,
+                        promptTokens: visionPrepared.promptTokens,
+                        decodeTail: { tokenizer.inner.decode(tokenIds: $0, skipSpecialTokens: false) }
+                    )
                     return makeEventStream(
                         upstream: upstream,
                         cancelUpstream: { await bridge.cancel(requestId: visionRequestId) },
                         toolHandler: nil,
                         prepared: prepared,
-                        releaseBox: releaseBox
+                        releaseBox: releaseBox,
+                        synthesizeThinkOpen: synthesizeThinkOpen
                     )
                 } catch is CancellationError {
                     // The CALLER went away mid-construction — that is not a
@@ -508,6 +521,19 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
             throw error
         }
 
+        // Qwen3.6/DeepSeek-style templates pre-open a <think> block at the
+        // prompt tail (the model's output carries only the close). Without a
+        // synthesized open, the downstream streaming think parser sits in its
+        // `undecided` state buffering the ENTIRE block — the consumer's first
+        // delta (TTFT) is delayed by the whole thinking duration. See
+        // `ReasoningPromptProbe`.
+        let synthesizeThinkOpen = ReasoningPromptProbe.shouldSynthesizeThinkOpen(
+            reasoningParser: request.reasoningParser,
+            stream: request.stream,
+            promptTokens: promptTokens,
+            decodeTail: { tokenizer.inner.decode(tokenIds: $0, skipSpecialTokens: false) }
+        )
+
         // Resolve tool call format before submitting so a bad
         // `tool_call_parser` value does not leave an orphaned request.
         let toolHandler: BatchedToolStreamHandler?
@@ -608,7 +634,8 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
             cancelUpstream: cancelUpstream,
             toolHandler: toolHandler,
             prepared: prepared,
-            releaseBox: releaseBox
+            releaseBox: releaseBox,
+            synthesizeThinkOpen: synthesizeThinkOpen
         )
     }
 
@@ -623,7 +650,8 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
         cancelUpstream: @escaping @Sendable () async -> Void,
         toolHandler: BatchedToolStreamHandler?,
         prepared: ToolChoicePromptPolicy.Prepared,
-        releaseBox: OneShotRelease
+        releaseBox: OneShotRelease,
+        synthesizeThinkOpen: Bool = false
     ) -> AsyncThrowingStream<MLXServerGenerationEvent, Error> {
         AsyncThrowingStream { continuation in
             let task = Task {
@@ -639,6 +667,18 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
                 // throw instead of being flattened into a string by `failed`.
                 var failedTerminal: MultiModelBatchSchedulerEngineError?
                 startedAt = Date()
+
+                // Synthetic <think> open (see `ReasoningPromptProbe`): the
+                // rendered prompt already opened a think block, so hand the
+                // downstream streaming parser the marker it will never see
+                // in model output. The parser consumes it as a pure state
+                // transition — no SSE frame reaches the consumer — and then
+                // streams reasoning deltas incrementally instead of
+                // buffering until `</think>`. Deliberately BYPASSES the
+                // tool handler: the marker is not model output.
+                if synthesizeThinkOpen {
+                    continuation.yield(.content(ReasoningPromptProbe.thinkOpen))
+                }
 
                 for await event in upstream {
                     if Task.isCancelled {

--- a/provider-swift/Sources/ProviderCore/Inference/ReasoningPromptProbe.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/ReasoningPromptProbe.swift
@@ -1,0 +1,73 @@
+// Copyright © 2026 Eigen Labs.
+//
+// Detects prompts whose rendered chat template ends INSIDE an open
+// <think> block. Qwen3.6 / DeepSeek-R1-style templates append
+// `<think>\n` after the assistant header, so the model's OUTPUT carries
+// only the closing `</think>` — never the opening tag.
+//
+// Why this matters for TTFT: the streaming think parser
+// (`StreamingThinkReasoningParser`, MLXLMServer) can only stream
+// reasoning deltas incrementally once it has SEEN an opening tag.
+// Close-only output leaves it in its `undecided` state, where every
+// token buffers until `</think>` arrives — the consumer's first delta
+// (and thus TTFT) is delayed by the ENTIRE thinking duration.
+//
+// The fix: when the rendered prompt pre-opens a think block AND a
+// think-format reasoning parser will consume this stream, the engine
+// injects one synthetic `.content("<think>")` event ahead of the
+// model's output (`MultiModelBatchSchedulerEngine.makeEventStream`).
+// The parser consumes the marker as a pure state transition — nothing
+// is emitted downstream — then streams `reasoning_content` deltas
+// token-by-token.
+
+import MLXLMServer
+
+enum ReasoningPromptProbe {
+    /// The synthetic opening marker injected into the event stream.
+    static let thinkOpen = "<think>"
+
+    /// Prompt-tail tokens to decode for the probe. The open tag sits in
+    /// the last few tokens of the rendered template
+    /// (`<|im_start|>assistant\n<think>\n`), so 8 is generous while
+    /// keeping the decode O(1) regardless of prompt length.
+    static let tailTokenCount = 8
+
+    /// Whether the engine should inject a synthetic `<think>` open ahead
+    /// of the model's output for this request.
+    ///
+    /// Gates, in order:
+    /// - A think-format parser (`.qwen3` / `.deepseekR1`) must be active
+    ///   downstream. A `.none`/unset parser passes chunks through
+    ///   verbatim, so an injected marker would leak to the consumer as
+    ///   literal content. (The coordinator path always sets the parser —
+    ///   `ProviderLoop.inferReasoningParser` fills nil.)
+    /// - Streaming only. The non-streaming collector's `ReasoningParser`
+    ///   already classifies close-only output correctly at completion;
+    ///   only the streaming path suffers the buffering.
+    /// - The rendered prompt's decoded tail must end inside an open
+    ///   think block.
+    static func shouldSynthesizeThinkOpen(
+        reasoningParser: ReasoningParserFormat?,
+        stream: Bool?,
+        promptTokens: [Int],
+        decodeTail: ([Int]) -> String
+    ) -> Bool {
+        guard reasoningParser == .qwen3 || reasoningParser == .deepseekR1 else { return false }
+        guard stream == true else { return false }
+        guard !promptTokens.isEmpty else { return false }
+        return promptEndsInsideThinkBlock(decodeTail(Array(promptTokens.suffix(tailTokenCount))))
+    }
+
+    /// True when the tail ends with an unclosed `<think>` (ignoring
+    /// trailing whitespace). A template that embeds a pre-CLOSED empty
+    /// block (`<think>\n\n</think>` — thinking disabled) ends with
+    /// `</think>` and is correctly rejected: `"</think>"` does not have
+    /// the suffix `"<think>"`.
+    static func promptEndsInsideThinkBlock(_ tail: String) -> Bool {
+        var trimmed = Substring(tail)
+        while let last = trimmed.last, last.isWhitespace {
+            trimmed.removeLast()
+        }
+        return trimmed.hasSuffix(thinkOpen)
+    }
+}

--- a/provider-swift/Tests/ProviderCoreTests/EngineV2ProductionWiringTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/EngineV2ProductionWiringTests.swift
@@ -117,6 +117,11 @@ private final class WiringScriptedEngine: CBv2Engine, @unchecked Sendable {
 
 private struct WiringStubTokenizer: MLXLMCommon.Tokenizer {
     var templateTokens: [Int] = [1, 2, 3, 4, 5]
+    /// When set, `decode` returns this verbatim — lets the think-open
+    /// injection tests simulate a Qwen3.6-style rendered prompt tail
+    /// (`…assistant\n<think>\n`) without touching the default per-id
+    /// behavior the logprob assertions rely on.
+    var decodeOverride: String?
 
     func encode(text: String, addSpecialTokens: Bool) -> [Int] {
         Array(repeating: 0, count: text.count)
@@ -124,7 +129,8 @@ private struct WiringStubTokenizer: MLXLMCommon.Tokenizer {
     /// Deterministic per-id text ("t<id>") so logprob-entry conversion is
     /// assertable (mirrors the EngineV2BridgeTests stub).
     func decode(tokenIds: [Int], skipSpecialTokens: Bool) -> String {
-        tokenIds.map { "t\($0)" }.joined()
+        if let decodeOverride { return decodeOverride }
+        return tokenIds.map { "t\($0)" }.joined()
     }
     func convertTokenToId(_ token: String) -> Int? { ["</s>": 2][token] }
     func convertIdToToken(_ id: Int) -> String? {
@@ -1246,6 +1252,80 @@ struct EngineV2RequestRoutingTests {
         #expect(events.last == .info(prompt: 5, completion: 2))
         #expect(engine.submitted.count == 1)
         #expect(engine.submitted[0].promptTokens == [1, 2, 3, 4, 5])
+    }
+
+    /// Builds a provider engine whose stub tokenizer "renders" the given
+    /// prompt tail, backed by a scripted close-only (Qwen3.6-style)
+    /// thinking stream.
+    private func makeThinkProbeEngine(
+        decodedTail: String
+    ) -> (WiringScriptedEngine, MultiModelBatchSchedulerEngine) {
+        let engine = WiringScriptedEngine(script: .stream([
+            .delta(text: "step one ", tokens: [10], logprobs: nil),
+            .delta(text: "step two</think>Answer", tokens: [11], logprobs: nil),
+            .finished(reason: .stop, usage: CBv2Usage(promptTokens: 5, completionTokens: 2)),
+        ]))
+        let bridge = makeBridge(engine: engine, modelId: "qwen3.6-test")
+        let providerEngine = MultiModelBatchSchedulerEngine(
+            registryProvider: { @Sendable in
+                [
+                    "qwen3.6-test": .init(
+                        tokenizer: TokenizerHandle(
+                            WiringStubTokenizer(decodeOverride: decodedTail)),
+                        modelType: "qwen3_next",
+                        engineV2Bridge: bridge)
+                ]
+            })
+        return (engine, providerEngine)
+    }
+
+    @Test("a pre-opened think prompt injects a synthetic <think> ahead of close-only output")
+    func preOpenedThinkPromptInjectsSyntheticOpen() async throws {
+        let (engine, providerEngine) = makeThinkProbeEngine(
+            decodedTail: "<|im_start|>assistant\n<think>\n")
+        var request = makeOpenAIRequest(model: "qwen3.6-test")
+        request.stream = true
+        request.reasoningParser = .qwen3
+
+        let stream = try await providerEngine.streamChatCompletion(request: request)
+        let events = try await recordServerStream(stream)
+        // The marker precedes the model's output; the downstream streaming
+        // think parser consumes it as a state transition and then streams
+        // each reasoning delta the moment it arrives (the TTFT fix).
+        #expect(events == [
+            .content("<think>"),
+            .content("step one "),
+            .content("step two</think>Answer"),
+            .info(prompt: 5, completion: 2),
+        ])
+        // The marker is synthetic — it must never reach the engine/prompt.
+        #expect(engine.submitted.count == 1)
+    }
+
+    @Test("no injection without a pre-opened think tail")
+    func plainPromptTailDoesNotInject() async throws {
+        let (_, providerEngine) = makeThinkProbeEngine(
+            decodedTail: "<|im_start|>assistant\n")
+        var request = makeOpenAIRequest(model: "qwen3.6-test")
+        request.stream = true
+        request.reasoningParser = .qwen3
+
+        let stream = try await providerEngine.streamChatCompletion(request: request)
+        let events = try await recordServerStream(stream)
+        #expect(events.first == .content("step one "))
+    }
+
+    @Test("no injection for a non-think reasoning parser even with a pre-opened tail")
+    func nonThinkParserDoesNotInject() async throws {
+        let (_, providerEngine) = makeThinkProbeEngine(
+            decodedTail: "<|im_start|>assistant\n<think>\n")
+        var request = makeOpenAIRequest(model: "qwen3.6-test")
+        request.stream = true
+        request.reasoningParser = .gemma4
+
+        let stream = try await providerEngine.streamChatCompletion(request: request)
+        let events = try await recordServerStream(stream)
+        #expect(events.first == .content("step one "))
     }
 
     @Test("required tool choice installs a CBv2 grammar before submission")

--- a/provider-swift/Tests/ProviderCoreTests/ReasoningPromptProbeTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ReasoningPromptProbeTests.swift
@@ -1,0 +1,107 @@
+import Foundation
+import MLXLMServer
+import Testing
+
+@testable import ProviderCore
+
+/// `ReasoningPromptProbe` — the detection behind the synthetic `<think>`
+/// open injection (Qwen3.6 TTFT fix).
+///
+/// Qwen3.6/DeepSeek-style chat templates pre-open a think block at the
+/// prompt tail, so the model's output carries only `</think>`. The
+/// streaming think parser buffers close-only output in its `undecided`
+/// state until the close arrives — TTFT then equals the entire thinking
+/// duration. The probe decides when the engine may inject a synthetic
+/// opening marker so reasoning streams incrementally instead.
+@Suite("Reasoning prompt probe")
+struct ReasoningPromptProbeTests {
+
+    // MARK: - Tail detection
+
+    @Test("a Qwen3.6-style generation prompt tail ends inside an open think block")
+    func qwenTailDetected() {
+        #expect(ReasoningPromptProbe.promptEndsInsideThinkBlock(
+            "<|im_start|>assistant\n<think>\n"))
+        #expect(ReasoningPromptProbe.promptEndsInsideThinkBlock("<think>"))
+        // Trailing whitespace variants the tokenizer may render.
+        #expect(ReasoningPromptProbe.promptEndsInsideThinkBlock("<think>\n\n"))
+        #expect(ReasoningPromptProbe.promptEndsInsideThinkBlock("<think> \t\n"))
+    }
+
+    @Test("a pre-closed (thinking disabled) block is rejected")
+    func preClosedBlockRejected() {
+        // Thinking-off templates embed an EMPTY closed block in the prompt;
+        // the output is pure content and must stream as content.
+        #expect(!ReasoningPromptProbe.promptEndsInsideThinkBlock(
+            "<|im_start|>assistant\n<think>\n\n</think>\n\n"))
+        #expect(!ReasoningPromptProbe.promptEndsInsideThinkBlock("</think>"))
+    }
+
+    @Test("prompts without a think tail are rejected")
+    func plainTailsRejected() {
+        #expect(!ReasoningPromptProbe.promptEndsInsideThinkBlock(""))
+        #expect(!ReasoningPromptProbe.promptEndsInsideThinkBlock("<|im_start|>assistant\n"))
+        // An open tag mid-tail followed by other text is not "ends inside".
+        #expect(!ReasoningPromptProbe.promptEndsInsideThinkBlock("<think>\nalready reasoning"))
+    }
+
+    // MARK: - Injection gating
+
+    private static let openThinkTail = "<|im_start|>assistant\n<think>\n"
+
+    private func shouldInject(
+        parser: ReasoningParserFormat?,
+        stream: Bool? = true,
+        tokens: [Int] = [1, 2, 3],
+        tail: String = Self.openThinkTail
+    ) -> Bool {
+        ReasoningPromptProbe.shouldSynthesizeThinkOpen(
+            reasoningParser: parser,
+            stream: stream,
+            promptTokens: tokens,
+            decodeTail: { _ in tail }
+        )
+    }
+
+    @Test("only think-format parsers inject")
+    func parserGate() {
+        #expect(shouldInject(parser: .qwen3))
+        #expect(shouldInject(parser: .deepseekR1))
+        // A verbatim/none parser would leak the literal marker to consumers.
+        #expect(!shouldInject(parser: ReasoningParserFormat.none))
+        #expect(!shouldInject(parser: nil))
+        #expect(!shouldInject(parser: .harmony))
+        #expect(!shouldInject(parser: .gemma4))
+    }
+
+    @Test("only streaming requests inject")
+    func streamGate() {
+        // Non-streaming collection classifies close-only output correctly
+        // at completion; injection is a streaming-only concern.
+        #expect(!shouldInject(parser: .qwen3, stream: false))
+        #expect(!shouldInject(parser: .qwen3, stream: nil))
+    }
+
+    @Test("an empty prompt or a non-think tail never injects")
+    func tailGate() {
+        #expect(!shouldInject(parser: .qwen3, tokens: []))
+        #expect(!shouldInject(parser: .qwen3, tail: "<|im_start|>assistant\n"))
+        #expect(!shouldInject(parser: .qwen3, tail: "<think>\n\n</think>\n\n"))
+    }
+
+    @Test("the probe decodes only a bounded prompt tail")
+    func boundedTailDecode() {
+        let tokens = Array(0..<4096)
+        var seen: [Int]?
+        _ = ReasoningPromptProbe.shouldSynthesizeThinkOpen(
+            reasoningParser: .qwen3,
+            stream: true,
+            promptTokens: tokens,
+            decodeTail: { ids in
+                seen = ids
+                return Self.openThinkTail
+            }
+        )
+        #expect(seen == Array(tokens.suffix(ReasoningPromptProbe.tailTokenCount)))
+    }
+}

--- a/provider-swift/Tests/ProviderCoreTests/ThinkStreamingLatencyTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ThinkStreamingLatencyTests.swift
@@ -1,0 +1,109 @@
+import Foundation
+import MLXLMServer
+import Testing
+
+@testable import ProviderCore
+
+/// Pins the SSE contract the synthetic `<think>` injection relies on
+/// (Qwen3.6 TTFT fix): once the streaming think parser has seen an
+/// opening tag, every reasoning delta streams the moment it arrives —
+/// as `reasoning_content` — instead of buffering until `</think>`.
+///
+/// This is the ProviderCore-side guard: the parser itself lives in the
+/// mlx-swift-lm submodule, so a pin here fails loudly if a submodule
+/// bump ever regresses incremental reasoning streaming.
+@Suite("Think streaming latency contract")
+struct ThinkStreamingLatencyTests {
+
+    /// Minimal engine emitting a scripted event sequence.
+    private struct ScriptedEngine: MLXServerEngine {
+        let events: [MLXServerGenerationEvent]
+
+        func availableModels() async throws -> [MLXServerModel] { [] }
+        func streamChatCompletion(
+            request: OpenAIChatCompletionRequest
+        ) async throws -> AsyncThrowingStream<MLXServerGenerationEvent, Error> {
+            AsyncThrowingStream { continuation in
+                for event in events { continuation.yield(event) }
+                continuation.finish()
+            }
+        }
+        func tokenize(_ request: TokenizeRequest) async throws -> TokenizeResponse {
+            TokenizeResponse(tokens: [])
+        }
+        func detokenize(_ request: DetokenizeRequest) async throws -> DetokenizeResponse {
+            DetokenizeResponse(text: "")
+        }
+        func applyTemplate(_ request: ApplyTemplateRequest) async throws -> TokenizeResponse {
+            TokenizeResponse(tokens: [])
+        }
+    }
+
+    private func collectFrames(
+        events: [MLXServerGenerationEvent]
+    ) async throws -> [String] {
+        let service = MLXOpenAIService(engine: ScriptedEngine(events: events))
+        var request = OpenAIChatCompletionRequest(
+            model: "qwen3.6-test",
+            messages: [OpenAIChatMessage(role: .user, content: .text("hi"))]
+        )
+        request.stream = true
+        request.reasoningParser = .qwen3
+        var frames: [String] = []
+        for try await frame in try await service.streamChatCompletionFrames(request: request) {
+            frames.append(frame)
+        }
+        return frames
+    }
+
+    @Test("after a synthetic <think> open, each reasoning delta streams as it arrives")
+    func reasoningStreamsIncrementally() async throws {
+        // The injected marker, then the model's close-only thinking output
+        // split across chunks — exactly what the engine emits for a
+        // Qwen3.6 request whose template pre-opened the think block.
+        let frames = try await collectFrames(events: [
+            .content("<think>"),
+            .content("step one "),
+            .content("step two "),
+            .content("step three</think>Answer"),
+            .info(.init(
+                promptTokens: 5, completionTokens: 4,
+                promptTime: 0, generationTime: 0, stopReason: "stop")),
+        ])
+
+        // Reasoning must arrive across MULTIPLE frames (incremental), not
+        // one buffered flush after the close.
+        let reasoningFrames = frames.filter { $0.contains("\"reasoning_content\"") }
+        #expect(reasoningFrames.count >= 2)
+        // The first reasoning delta precedes the visible answer.
+        let firstReasoning = frames.firstIndex { $0.contains("\"reasoning_content\"") }
+        let answer = frames.firstIndex { $0.contains("Answer") }
+        #expect(firstReasoning != nil && answer != nil)
+        if let firstReasoning, let answer {
+            #expect(firstReasoning < answer)
+        }
+        // Neither marker ever reaches a consumer.
+        let joined = frames.joined()
+        #expect(!joined.contains("<think>"))
+        #expect(!joined.contains("</think>"))
+    }
+
+    @Test("without an opening tag, close-only reasoning buffers until the close (the bug the injection fixes)")
+    func closeOnlyStillBuffersWithoutOpen() async throws {
+        // Documents WHY the engine injects: this is upstream's behavior
+        // when no opening tag is ever seen. If a submodule bump makes the
+        // parser stream close-only output incrementally on its own, this
+        // fails and the injection (ReasoningPromptProbe) can be removed.
+        let frames = try await collectFrames(events: [
+            .content("step one "),
+            .content("step two "),
+            .content("step three</think>Answer"),
+            .info(.init(
+                promptTokens: 5, completionTokens: 4,
+                promptTime: 0, generationTime: 0, stopReason: "stop")),
+        ])
+
+        let reasoningFrames = frames.filter { $0.contains("\"reasoning_content\"") }
+        #expect(reasoningFrames.count == 1)
+    }
+}


### PR DESCRIPTION
## Problem

Qwen3.6-style chat templates **pre-open** a `<think>` block at the prompt tail (`<|im_start|>assistant\n<think>\n`), so model output carries only the closing `</think>`. The streaming think parser (`StreamingThinkReasoningParser`, mlx-swift-lm) can only stream reasoning incrementally after seeing an **opening** tag — close-only output leaves it in its `undecided` state, buffering the entire think block. The consumer's first delta (and the coordinator's `actual_ttft_ms`) is therefore delayed by the **whole thinking duration**.

**Prod evidence** (read replica, SELECT-only, last 14d):
- qwen3.6-35b-a3b-vl-mtp-mxfp8: `actual_ttft_ms = 755 + 12.51 x reasoning_tokens`, **r = 0.9878** — 12.51 ms/token = 1/(80 tok/s), i.e. TTFT is literally the think-block decode time. First **byte** (role preamble) lands in ~76 ms.
- Control gpt-oss-20b (Harmony parser, streams analysis live): slope **0.22 ms/token, r = 0.046** (n = 269k).
- Burst-flush corroboration: 852 visible tokens "delivered" in 610 ms post-TTFT at a measured 79 tok/s decode — impossible unless pre-decoded tokens flushed after `</think>`.

The coordinator already counts a non-empty `reasoning_content` delta as first content (`isBoilerplateChunk`), so streaming reasoning fixes TTFT end to end with no coordinator change.

## Fix

Provider-swift only — **no submodule bump**. After rendering the prompt, the engine probes the decoded prompt tail for an unclosed `<think>` (`ReasoningPromptProbe`) and injects one synthetic `.content("<think>")` event ahead of model output, on both the text and VLM media paths. The downstream parser consumes the marker as a pure state transition (no SSE frame reaches the consumer) and then streams `reasoning_content` deltas per chunk.

Gates (all must hold):
- a think-format parser (`.qwen3` / `.deepseekR1`) is active — a `.none`/unset parser would pass the literal marker through to consumers (the coordinator path always sets the parser via `ProviderLoop.inferReasoningParser`);
- `stream == true` — the non-streaming collector's `ReasoningParser` already classifies close-only output correctly at completion;
- the decoded tail (last 8 tokens, O(1) regardless of prompt length) ends with an unclosed `<think>`. A pre-CLOSED thinking-off block (`<think>\n\n</think>`) is rejected by construction.

The marker never reaches the engine, the prompt, or any consumer; the TB-007 hash domain (content + reasoning_content) is unchanged. Bonus: a stream cancelled mid-think now settles with its buffered text classified as *reasoning* (open-tag state) instead of dumping it as visible content.

## Behavior — before / after

```mermaid
flowchart LR
  subgraph Before
    A1["request (stream)"] --> B1["prompt renders<br/>...assistant + open think"] --> C1["parser undecided:<br/>buffers EVERY token"] --> D1["close tag arrives:<br/>one giant reasoning delta + answer<br/>TTFT = 755ms + 12.5ms x reasoning_tokens"]
  end
  subgraph After
    A2["request (stream)"] --> B2["prompt renders<br/>...assistant + open think"] --> C2["engine injects synthetic open<br/>parser enters reasoning state"] --> D2["each reasoning delta streams on arrival<br/>TTFT = first token (~455-800ms warm)"]
  end
```

## Code — before / after

```mermaid
flowchart LR
  subgraph Before
    T1["streamChatCompletion<br/>tokenize to promptTokens"] --> S1["bridge.submitTokenized"] --> M1["makeEventStream<br/>chunk to content"] --> P1["MLXOpenAIService<br/>StreamingThinkReasoningParser<br/>undecided: buffer until close"]
  end
  subgraph After
    T2["streamChatCompletion<br/>tokenize to promptTokens"] --> R2["ReasoningPromptProbe<br/>shouldSynthesizeThinkOpen<br/>(parser + stream + decoded tail)"] --> S2["bridge.submitTokenized"] --> M2["makeEventStream<br/>yields synthetic think-open first<br/>then chunk to content"] --> P2["MLXOpenAIService<br/>parser flips to reasoning<br/>streams deltas incrementally"]
  end
```

## Tests

- `ReasoningPromptProbeTests` — tail detection (Qwen tail, pre-closed block, plain tails), all injection gates, bounded tail decode.
- `EngineV2ProductionWiringTests` — end-to-end wiring: synthetic open precedes close-only output; no injection without a think tail; no injection for a non-think parser.
- `ThinkStreamingLatencyTests` — pins the SSE contract the injection relies on: after an open, each reasoning delta streams as its own `reasoning_content` frame; and documents the buggy buffering when no open is seen (fails loudly if a future submodule bump changes either, signalling the probe can be removed).

**Verification:** `make provider-test` — 2054 tests / 212 suites green.

## Residual scope

- `darkbloom local` without an explicit `reasoning_parser` keeps the old buffering (gate requires a set parser; the coordinator path always sets one).
- Fleet needs a provider release to pick this up; the cold-load TTFT facet is handled separately by the warm-pool env change (`fix/qwen36-ttft-admission`).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/614"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789232050&installation_model_id=21733&pr_number=614&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F614&signature=8c5b482b4075a8df6e64752648cf763a3c8041f88e232df877d70e7a4f9c2bca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->