### PR TITLE
chore(release): prepare provider v0.8.4 — Qwen3.6 reasoning-streaming TTFT fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Changelog
 
-## Unreleased (v0.8.3 candidate - provider)
+## Unreleased (v0.8.4 candidate - provider)
+
+### Provider (Swift)
+
+#### Fixes
+
+- **Stream Qwen3.6 reasoning deltas immediately (TTFT fix)** - Qwen3.6-style chat templates pre-open the `<think>` block at the prompt tail, so model output carries only the closing tag and the streaming think parser buffered the entire block before emitting anything: measured prod TTFT was `755ms + 12.51ms x reasoning_tokens` (r = 0.9878) while the first byte arrived in ~76ms. The engine now probes the rendered prompt tail (`ReasoningPromptProbe`) and injects one synthetic `<think>` open ahead of model output — gated on an active think-format parser and streaming — so `reasoning_content` streams per chunk and TTFT reflects real first-token latency. Text and VLM paths; the marker never reaches the prompt, the consumer, or the TB-007 hash domain. (#614)
+
+---
+
+## v0.8.3 (2026-08-12)
 
 ### Provider (Swift)
 

--- a/coordinator/api/server.go
+++ b/coordinator/api/server.go
@@ -151,7 +151,7 @@ func keyLimitResetFromContext(ctx context.Context) string {
 // the provider's EngineV2Factory.prepareProductionBackend for the argument).
 // Keep this fallback in sync with ProviderCore.version so dev/in-memory
 // coordinators advertise the same floor as the Swift binary they expect.
-var LatestProviderVersion = "0.8.3"
+var LatestProviderVersion = "0.8.4"
 
 // minProviderVersionForDesiredModels is the first provider version whose Swift
 // runtime understands the desired_models message. The coordinator must NOT send

--- a/provider-swift/Sources/ProviderCore/ProviderCore.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderCore.swift
@@ -210,5 +210,9 @@ public enum ProviderCore {
     // 0.8.3 adds Qwen3.6-35B-A3B text, image, and tool serving with request-owned
     // recurrent/mRoPE state and exact serial verification of its inline MTP.
     // Unsupported Qwen paths remain fail-closed pending dedicated canaries.
-    public static let version = "0.8.3"
+    // 0.8.4 streams Qwen3.6 reasoning deltas immediately: the engine
+    // synthesizes the template's pre-opened <think> so the streaming parser
+    // stops buffering the whole block (TTFT was 755ms + 12.5ms per
+    // reasoning token; now first-token latency).
+    public static let version = "0.8.4"
 }


### PR DESCRIPTION
Release prep for **provider v0.8.4** — ships the Qwen3.6 reasoning-streaming TTFT fix (#614, already on master).

## Changes

- `ProviderCore.version`: `0.8.3` → `0.8.4` (+ version-history comment).
- `coordinator/api/server.go` `LatestProviderVersion`: `0.8.3` → `0.8.4` (no-release-row fallback; kept in sync per AGENTS.md).
- `CHANGELOG.md`: dates the v0.8.3 section (2026-08-12), adds the v0.8.4 candidate entry for #614.

No behavior change beyond the advertised version; the fix itself merged in #614.

## Behavior — before / after

```mermaid
flowchart LR
  subgraph Before
    A1["fleet on v0.8.3"] --> B1["Qwen3.6 streams: think block buffered<br/>TTFT = 755ms + 12.5ms x reasoning_tokens"]
  end
  subgraph After
    A2["tag v0.8.4 on merged master"] --> B2["release-swift.yml: build, sign, notarize,<br/>register via POST /v1/releases"] --> C2["installers + self-update serve v0.8.4<br/>reasoning streams per chunk, TTFT = first token"]
  end
```

## Code — before / after

```mermaid
flowchart LR
  subgraph Before
    V1["ProviderCore.version = 0.8.3<br/>LatestProviderVersion = 0.8.3<br/>CHANGELOG: unreleased v0.8.3 candidate"]
  end
  subgraph After
    V2["ProviderCore.version = 0.8.4<br/>LatestProviderVersion = 0.8.4<br/>CHANGELOG: v0.8.3 dated + v0.8.4 candidate (#614)"]
  end
```

## Release steps after merge

1. Tag the merge commit: `git tag v0.8.4 <merge-sha> && git push origin v0.8.4` — triggers `release-swift.yml` (sign → notarize → SHA-256 after signing → `POST /v1/releases`).
2. Verify `GET /v1/releases/latest` returns 0.8.4 (a missing release row breaks installs/self-updates — fixed by registering, not by code).
3. Fleet picks it up via self-update; prod TTFT for `qwen3.6-35b-a3b-vl-mtp-mxfp8` should collapse from `755ms + 12.5ms x reasoning_tokens` to warm first-token (~455–800 ms) — observable in `d_inference.inference.ttft_ms` (Datadog) and `inference_routes.actual_ttft_ms`.

## Verification

- `cd coordinator && go build ./...` + version/release API tests green.
- `swift build --target ProviderCore` green.
- Underlying fix verified in #614: 2054-test provider suite, wiring/injection tests, streaming-contract pin, prod TTFT regression evidence.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/615"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789232836&installation_model_id=21733&pr_number=615&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F615&signature=2481ad239838ad7abe2cb0a192725fe826a6f5e305e3e7f947eb42b3cdfbca7b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->