### PR TITLE
fix(provider): inline MTP inspection resolves HF-cache symlinks and rejects loudly

### DIFF
--- a/provider-swift/Sources/ProviderCore/SpecDec/SpecDecArtifactFunnel.swift
+++ b/provider-swift/Sources/ProviderCore/SpecDec/SpecDecArtifactFunnel.swift
@@ -153,12 +153,15 @@ actor SpecDecArtifactFunnel {
         if Self.isQwen35Target(modelType: request.modelType),
             let directory = request.modelDirectory
         {
-            guard let artifact = SpecDecStore.inspectInlineArtifact(directory: directory) else {
+            switch SpecDecStore.inspectInlineArtifact(directory: directory) {
+            case .failure:
+                // The store already logged the concrete reason and file path.
                 return .init(
                     artifact: nil,
                     status: .disabled(.inlineArtifactInvalid, configured: true))
+            case .success(let artifact):
+                return .init(artifact: artifact, status: .candidate(artifact))
             }
-            return .init(artifact: artifact, status: .candidate(artifact))
         }
         guard Self.isGemma4Target(modelType: request.modelType) else {
             return .init(artifact: nil, status: .disabled(.targetUnsupported, configured: true))

--- a/provider-swift/Sources/ProviderCore/SpecDec/SpecDecStore.swift
+++ b/provider-swift/Sources/ProviderCore/SpecDec/SpecDecStore.swift
@@ -1,9 +1,11 @@
 import CryptoKit
 import Foundation
+import Logging
 import ProviderCoreFoundation
 
 enum SpecDecStore {
     static let manifestFileName = "manifest.json"
+    private static let logger = Logger(label: "darkbloom.SpecDecStore")
 
     private struct InlineWeightIndex: Decodable {
         let metadata: [String: Int64]?
@@ -23,6 +25,14 @@ enum SpecDecStore {
 
     struct VerificationError: Error, Sendable, CustomStringConvertible {
         let reason: MTPFallbackReason
+        let description: String
+    }
+
+    /// Inline-artifact inspection failure carrying the concrete reason and
+    /// file path. Inline MTP going missing silently poisons measurement and
+    /// serving sessions (the drafter simply never activates), so every
+    /// rejection is BOTH returned to the caller and logged at warning level.
+    struct InlineArtifactRejection: Error, Sendable, CustomStringConvertible {
         let description: String
     }
 
@@ -269,23 +279,66 @@ enum SpecDecStore {
     /// authenticates those files; this inspection pins the config + index,
     /// validates every selected key/path, and charges the index's declared
     /// MTP payload bytes rather than the whole 20 GiB checkpoint.
-    static func inspectInlineArtifact(directory: URL) -> SpecDecArtifact? {
+    ///
+    /// Symlinked members are RESOLVED, not rejected: HF-cache snapshots store
+    /// every shard as a symlink into `blobs/`, and that is the layout the
+    /// already-verified target checkpoint normally arrives in. (Operator
+    /// -provided local overrides — `inspectLocalArtifact` — still reject
+    /// symlinks: there the directory itself is untrusted input.) Every
+    /// rejection names its concrete reason and file path; nothing here fails
+    /// status-only.
+    static func inspectInlineArtifact(
+        directory: URL
+    ) -> Result<SpecDecArtifact, InlineArtifactRejection> {
         let directory = directory.standardizedFileURL
-        guard isDirectoryWithoutSymlink(directory) else { return nil }
+        guard isDirectoryResolvingSymlinks(directory) else {
+            return rejectInline(
+                "checkpoint directory is missing or not a directory: \(directory.path)")
+        }
         let configURL = directory.appendingPathComponent("config.json")
         let indexURL = directory.appendingPathComponent("model.safetensors.index.json")
-        guard let configSize = regularFileSize(configURL), configSize > 0,
-            configSize <= SpecDecLimits.maximumConfigBytes,
-            let indexSize = regularFileSize(indexURL), indexSize > 0,
-            indexSize <= UInt64(SpecDecLimits.maximumManifestBytes),
-            let configData = try? Data(contentsOf: configURL),
-            let indexData = try? Data(contentsOf: indexURL),
-            let root = try? JSONSerialization.jsonObject(with: configData) as? [String: Any],
-            let inline = root["mtplx_mtp"] as? [String: Any],
-            inline["included"] as? Bool == true,
-            root["mtplx_mtp_quantization"] as? [String: Any] != nil,
-            let index = try? JSONDecoder().decode(InlineWeightIndex.self, from: indexData)
-        else { return nil }
+        guard let configSize = resolvedRegularFileSize(configURL), configSize > 0 else {
+            return rejectInline(
+                "config.json is missing, empty, not a regular file, or a broken symlink: \(configURL.path)")
+        }
+        guard configSize <= SpecDecLimits.maximumConfigBytes else {
+            return rejectInline(
+                "config.json exceeds the \(SpecDecLimits.maximumConfigBytes)-byte cap: \(configURL.path)")
+        }
+        guard let indexSize = resolvedRegularFileSize(indexURL), indexSize > 0 else {
+            return rejectInline(
+                "model.safetensors.index.json is missing, empty, not a regular file, or a broken symlink: \(indexURL.path)")
+        }
+        guard indexSize <= UInt64(SpecDecLimits.maximumManifestBytes) else {
+            return rejectInline(
+                "model.safetensors.index.json exceeds the \(SpecDecLimits.maximumManifestBytes)-byte cap: \(indexURL.path)")
+        }
+        guard let configData = try? Data(contentsOf: configURL) else {
+            return rejectInline("config.json is unreadable: \(configURL.path)")
+        }
+        guard let indexData = try? Data(contentsOf: indexURL) else {
+            return rejectInline(
+                "model.safetensors.index.json is unreadable: \(indexURL.path)")
+        }
+        guard let root = try? JSONSerialization.jsonObject(with: configData) as? [String: Any]
+        else {
+            return rejectInline("config.json is not a JSON object: \(configURL.path)")
+        }
+        guard let inline = root["mtplx_mtp"] as? [String: Any],
+            inline["included"] as? Bool == true
+        else {
+            return rejectInline(
+                "config.json does not declare mtplx_mtp.included=true — not an inline-MTP checkpoint: \(configURL.path)")
+        }
+        guard root["mtplx_mtp_quantization"] as? [String: Any] != nil else {
+            return rejectInline(
+                "config.json is missing the mtplx_mtp_quantization object: \(configURL.path)")
+        }
+        guard let index = try? JSONDecoder().decode(InlineWeightIndex.self, from: indexData)
+        else {
+            return rejectInline(
+                "model.safetensors.index.json does not decode (weight_map): \(indexURL.path)")
+        }
 
         let prefix = (inline["prefix"] as? String) ?? "mtp."
         guard !prefix.isEmpty, prefix.utf8.count <= 128,
@@ -293,19 +346,40 @@ enum SpecDecStore {
                 (48...57).contains($0) || (65...90).contains($0) || (97...122).contains($0)
                     || $0 == 46 || $0 == 95
             })
-        else { return nil }
+        else {
+            return rejectInline(
+                "mtplx_mtp.prefix is empty, oversized, or carries disallowed characters: \(configURL.path)")
+        }
 
         var shardNames = Set<String>()
         var inlineCount = 0
         for (key, shard) in index.weightMap where key.hasPrefix(prefix) {
-            guard key.utf8.count <= 1024, shard == URL(fileURLWithPath: shard).lastPathComponent,
-                shard.hasSuffix(".safetensors"), shard.utf8.count <= SpecDecLimits.maximumFileNameBytes,
-                regularFileSize(directory.appendingPathComponent(shard)) != nil
-            else { return nil }
+            guard key.utf8.count <= 1024 else {
+                return rejectInline("inline tensor key exceeds 1024 bytes in \(indexURL.path)")
+            }
+            guard shard == URL(fileURLWithPath: shard).lastPathComponent,
+                shard.hasSuffix(".safetensors"),
+                shard.utf8.count <= SpecDecLimits.maximumFileNameBytes
+            else {
+                return rejectInline(
+                    "weight_map entry '\(key)' names an invalid shard '\(shard)' in \(indexURL.path)")
+            }
+            guard resolvedRegularFileSize(directory.appendingPathComponent(shard)) != nil
+            else {
+                return rejectInline(
+                    "inline shard is missing, not a regular file, or a broken symlink: \(directory.appendingPathComponent(shard).path)")
+            }
             inlineCount += 1
             shardNames.insert(shard)
         }
-        guard inlineCount > 0, inlineCount <= 512, !shardNames.isEmpty else { return nil }
+        guard inlineCount > 0 else {
+            return rejectInline(
+                "weight_map declares no tensors with prefix '\(prefix)': \(indexURL.path)")
+        }
+        guard inlineCount <= 512 else {
+            return rejectInline(
+                "weight_map declares \(inlineCount) inline tensors — above the 512 cap: \(indexURL.path)")
+        }
 
         guard let declaredBytes = inlineTensorBytes(
             directory: directory,
@@ -313,19 +387,30 @@ enum SpecDecStore {
             weightMap: index.weightMap),
             declaredBytes > 0,
             declaredBytes <= SpecDecLimits.maximumArtifactBytes
-        else { return nil }
+        else {
+            return rejectInline(
+                "inline tensor payload is unreadable or outside (0, \(SpecDecLimits.maximumArtifactBytes)] bytes (safetensors headers): \(directory.path)")
+        }
 
         let configDigest = sha256Hex(configData)
         let indexDigest = sha256Hex(indexData)
-        return SpecDecArtifact(
-            directory: directory,
-            source: .inline,
-            revision: "inline-\(configDigest.prefix(8))-\(indexDigest.prefix(8))",
-            artifactBytes: declaredBytes,
-            residentBytes: SpecDecLimits.residentEstimate(artifactBytes: declaredBytes),
-            manifestSHA256: nil,
-            localConfigSHA256: configDigest,
-            inlineIndexSHA256: indexDigest)
+        return .success(
+            SpecDecArtifact(
+                directory: directory,
+                source: .inline,
+                revision: "inline-\(configDigest.prefix(8))-\(indexDigest.prefix(8))",
+                artifactBytes: declaredBytes,
+                residentBytes: SpecDecLimits.residentEstimate(artifactBytes: declaredBytes),
+                manifestSHA256: nil,
+                localConfigSHA256: configDigest,
+                inlineIndexSHA256: indexDigest))
+    }
+
+    private static func rejectInline(
+        _ reason: String
+    ) -> Result<SpecDecArtifact, InlineArtifactRejection> {
+        logger.warning("inline MTP artifact rejected: \(reason)")
+        return .failure(InlineArtifactRejection(description: reason))
     }
 
     /// Sum only selected tensor payload ranges from safetensors headers. This
@@ -426,8 +511,14 @@ enum SpecDecStore {
             }
             return .resolved(refreshed)
         case .inline:
-            guard let refreshed = inspectInlineArtifact(directory: artifact.directory),
-                refreshed.directory == artifact.directory,
+            let refreshed: SpecDecArtifact
+            switch inspectInlineArtifact(directory: artifact.directory) {
+            case .failure(let rejection):
+                return .fallback(.inlineArtifactInvalid, detail: rejection.description)
+            case .success(let inspected):
+                refreshed = inspected
+            }
+            guard refreshed.directory == artifact.directory,
                 refreshed.artifactBytes == artifact.artifactBytes,
                 refreshed.residentBytes == artifact.residentBytes,
                 refreshed.revision == artifact.revision,
@@ -478,6 +569,29 @@ enum SpecDecStore {
             let number = attrs[.size] as? NSNumber
         else { return nil }
         return number.uint64Value
+    }
+
+    /// Size of a regular file, RESOLVING symlinks — `attributesOfItem` does
+    /// not follow a symlink in the last path component, so resolve first. A
+    /// broken link keeps its unresolvable component and the attribute read
+    /// then reports `.typeSymbolicLink` → nil. Used only by the inline
+    /// inspection path; local-override inspection stays symlink-rejecting.
+    private static func resolvedRegularFileSize(_ url: URL) -> UInt64? {
+        let resolved = url.resolvingSymlinksInPath()
+        guard let attrs = try? FileManager.default.attributesOfItem(atPath: resolved.path),
+            let type = attrs[.type] as? FileAttributeType, type == .typeRegular,
+            let number = attrs[.size] as? NSNumber
+        else { return nil }
+        return number.uint64Value
+    }
+
+    /// Directory check that FOLLOWS symlinks (inline inspection only).
+    private static func isDirectoryResolvingSymlinks(_ url: URL) -> Bool {
+        let resolved = url.resolvingSymlinksInPath()
+        guard let attrs = try? FileManager.default.attributesOfItem(atPath: resolved.path),
+            let type = attrs[.type] as? FileAttributeType
+        else { return false }
+        return type == .typeDirectory
     }
 
     private static func isSymbolicLink(_ url: URL) -> Bool {

--- a/provider-swift/Tests/ProviderCoreTests/SpecDecArtifactFunnelTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/SpecDecArtifactFunnelTests.swift
@@ -133,6 +133,29 @@ private func makeInlineQwenArtifact(includeMTP: Bool = true) throws -> URL {
     return root
 }
 
+/// HF-cache-style copy of an inline Qwen artifact: the snapshot directory
+/// holds only RELATIVE symlinks into a sibling `blobs/` directory — the
+/// layout `hf download` materializes and the layout production checkpoints
+/// actually load from. Returns (cacheRoot, snapshotDirectory).
+private func makeSymlinkedSnapshot(of real: URL) throws -> (root: URL, snapshot: URL) {
+    let root = FileManager.default.temporaryDirectory
+        .appendingPathComponent("specdec-hf-cache-\(UUID().uuidString)", isDirectory: true)
+    let blobs = root.appendingPathComponent("blobs", isDirectory: true)
+    let snapshot = root.appendingPathComponent("snapshots", isDirectory: true)
+        .appendingPathComponent("0123abcd", isDirectory: true)
+    try FileManager.default.createDirectory(at: blobs, withIntermediateDirectories: true)
+    try FileManager.default.createDirectory(at: snapshot, withIntermediateDirectories: true)
+    for name in try FileManager.default.contentsOfDirectory(atPath: real.path) {
+        try FileManager.default.copyItem(
+            at: real.appendingPathComponent(name),
+            to: blobs.appendingPathComponent("blob-\(name)"))
+        try FileManager.default.createSymbolicLink(
+            atPath: snapshot.appendingPathComponent(name).path,
+            withDestinationPath: "../../blobs/blob-\(name)")
+    }
+    return (root, snapshot)
+}
+
 @Suite("SpecDec production artifact funnel")
 struct SpecDecArtifactFunnelTests {
     private func funnel(catalog: FunnelCatalog, root: URL) -> SpecDecArtifactFunnel {
@@ -222,6 +245,114 @@ struct SpecDecArtifactFunnelTests {
         #expect(prepared.artifact == nil)
         #expect(prepared.status.reason == .inlineArtifactInvalid)
         #expect(await catalog.calls == 0)
+    }
+
+    @Test("HF-cache symlinked snapshot passes inspection and admits inline MTP")
+    func qwenSymlinkedSnapshotActivates() async throws {
+        let real = try makeInlineQwenArtifact()
+        defer { try? FileManager.default.removeItem(at: real) }
+        let (cacheRoot, snapshot) = try makeSymlinkedSnapshot(of: real)
+        defer { try? FileManager.default.removeItem(at: cacheRoot) }
+
+        // Regular-file baseline and symlinked snapshot must produce the SAME
+        // artifact facts — symlinks change the layout, not the payload.
+        let baseline = try SpecDecStore.inspectInlineArtifact(directory: real).get()
+        let inspected = try SpecDecStore.inspectInlineArtifact(directory: snapshot).get()
+        #expect(inspected.source == .inline)
+        #expect(inspected.artifactBytes == baseline.artifactBytes)
+        #expect(inspected.residentBytes == baseline.residentBytes)
+        #expect(inspected.revision == baseline.revision)
+        #expect(inspected.localConfigSHA256 == baseline.localConfigSHA256)
+        #expect(inspected.inlineIndexSHA256 == baseline.inlineIndexSHA256)
+
+        // The funnel admits the snapshot as a candidate — the admission gate
+        // the slot factory consumes…
+        let catalog = FunnelCatalog(nil)
+        let prepared = await funnel(
+            catalog: catalog, root: FileManager.default.temporaryDirectory
+        ).prepare(
+            .init(
+                modelId: "qwen3.6-35b-a3b-vl-mtp-mxfp8",
+                modelType: "qwen3_5_moe",
+                enabled: true,
+                localPath: nil,
+                modelDirectory: snapshot,
+                allowDownload: true,
+                environment: [:]))
+        let artifact = try #require(prepared.artifact)
+        #expect(prepared.status == .candidate(artifact))
+        #expect(await catalog.calls == 0)
+
+        // …and the pre-load revalidation gate (`EngineV2SlotFactory+MTP` runs
+        // `revalidateForLoad` immediately before assistant construction) also
+        // resolves, so nothing between admission and drafter build rejects
+        // the symlinked layout.
+        let revalidation = SpecDecStore.revalidateForLoad(artifact)
+        #expect(revalidation.artifact == artifact,
+            "revalidation must resolve the admitted artifact; got reason=\(String(describing: revalidation.reason)) detail=\(String(describing: revalidation.detail))")
+    }
+
+    @Test("broken symlinked shard is rejected with the concrete reason and path")
+    func qwenBrokenSymlinkRejectedLoudly() async throws {
+        let real = try makeInlineQwenArtifact()
+        defer { try? FileManager.default.removeItem(at: real) }
+        let (cacheRoot, snapshot) = try makeSymlinkedSnapshot(of: real)
+        defer { try? FileManager.default.removeItem(at: cacheRoot) }
+
+        // Break the shard link: point it at a blob that does not exist.
+        let shard = "model-00001-of-00001.safetensors"
+        let shardLink = snapshot.appendingPathComponent(shard)
+        try FileManager.default.removeItem(at: shardLink)
+        try FileManager.default.createSymbolicLink(
+            atPath: shardLink.path,
+            withDestinationPath: "../../blobs/deleted-blob")
+
+        // The inspection result names the failing file, not just a status.
+        switch SpecDecStore.inspectInlineArtifact(directory: snapshot) {
+        case .success:
+            Issue.record("broken symlinked shard must not pass inspection")
+        case .failure(let rejection):
+            #expect(rejection.description.contains("broken symlink"))
+            #expect(rejection.description.contains(shard))
+        }
+
+        // The funnel maps it to the existing fail-open status.
+        let catalog = FunnelCatalog(nil)
+        let prepared = await funnel(
+            catalog: catalog, root: FileManager.default.temporaryDirectory
+        ).prepare(
+            .init(
+                modelId: "qwen3.6-35b-a3b-vl-mtp-mxfp8",
+                modelType: "qwen3_5_moe",
+                enabled: true,
+                localPath: nil,
+                modelDirectory: snapshot,
+                allowDownload: true,
+                environment: [:]))
+        #expect(prepared.artifact == nil)
+        #expect(prepared.status.reason == .inlineArtifactInvalid)
+    }
+
+    @Test("regular-file inline inspection facts and revalidation are unchanged")
+    func qwenRegularFileInlineBehaviorUnchanged() throws {
+        let real = try makeInlineQwenArtifact()
+        defer { try? FileManager.default.removeItem(at: real) }
+        let artifact = try SpecDecStore.inspectInlineArtifact(directory: real).get()
+        #expect(artifact.source == .inline)
+        #expect(artifact.artifactBytes == 16)
+        #expect(artifact.inlineIndexSHA256 != nil)
+        #expect(SpecDecStore.revalidateForLoad(artifact).artifact == artifact)
+
+        // A checkpoint that does not carry inline MTP still reports the
+        // concrete reason instead of a bare nil.
+        let plain = try makeInlineQwenArtifact(includeMTP: false)
+        defer { try? FileManager.default.removeItem(at: plain) }
+        switch SpecDecStore.inspectInlineArtifact(directory: plain) {
+        case .success:
+            Issue.record("checkpoint without inline MTP tensors must not pass")
+        case .failure(let rejection):
+            #expect(rejection.description.contains("no tensors with prefix"))
+        }
     }
 
     @Test("non-Gemma target never resolves or loads an assistant")


### PR DESCRIPTION
## Problem

Bug 1 from Layr-Labs/mlx-swift-lm#106's **Discovered bugs**: `SpecDecStore.inspectInlineArtifact` required `regularFileSize` — which deliberately rejects symlinks — on the checkpoint directory, `config.json`, `model.safetensors.index.json`, and every selected shard. HF-cache snapshots materialize **all of those as symlinks** into `blobs/`, so on the layout production checkpoints actually arrive in, inline MTP was rejected with status `inline_artifact_invalid` and **zero log output**: the drafter silently never activates, the slot looks healthy, and `mtp_enabled` simply reads false.

This is not hypothetical: it silently poisoned a paired Qwen3.6 measurement session on 2026-08-13 (MTP-on runs were secretly MTP-off; the session was salvaged with APFS-cloned snapshots). It is also the only reason production dodged the 0.70x serial-verify regression fixed by mlx-swift-lm#106.

## Change

1. **Symlinks are resolved, not rejected** — inline inspection only. Directory, config, index, and shard checks resolve symlinks (`URL.resolvingSymlinksInPath`) and validate the resolved target (exists, regular file, size bounds). A broken link keeps its unresolvable component, fails the attribute read, and is rejected by name. Operator-provided local overrides (`inspectLocalArtifact`) still reject symlinks: there the directory itself is untrusted input; the inline directory is the already-verified target checkpoint.
2. **Fail-loud** — `inspectInlineArtifact` now returns `Result<SpecDecArtifact, InlineArtifactRejection>` where every rejection carries the concrete reason and file path, and is also logged at warning level (`darkbloom.SpecDecStore`). Both `inline_artifact_invalid` producers (funnel admission and the pre-load `revalidateForLoad` gate) now surface the reason; no status-only rejection remains.

## Behavior

```mermaid
flowchart LR
  subgraph Before
    A1["HF-cache snapshot<br/>(shards = symlinks into blobs/)"] --> B1["regularFileSize() rejects symlink"] --> C1["status inline_artifact_invalid<br/>ZERO log output<br/>MTP silently inert; measurements poisoned"]
  end
  subgraph After
    A2["HF-cache snapshot<br/>(shards = symlinks into blobs/)"] --> B2["resolve link -> validate target<br/>(exists, regular, size bounds)"] --> C2["valid: MTP activates<br/>broken/invalid: rejection names reason + path,<br/>logged at warning"]
  end
```

## Code

```mermaid
flowchart LR
  subgraph Before
    D1[SpecDecArtifactFunnel.prepare] -->|"inspectInlineArtifact -> SpecDecArtifact?"| E1["mega-guard, nil on ANY failure"]
    F1[SpecDecStore.revalidateForLoad] -->|same nil| E1
    E1 --> G1["disabled(.inlineArtifactInvalid) — reason lost"]
  end
  subgraph After
    D2[SpecDecArtifactFunnel.prepare] -->|"inspectInlineArtifact -> Result"| E2["per-check rejections via rejectInline()<br/>reason + path, logged (darkbloom.SpecDecStore)"]
    F2[SpecDecStore.revalidateForLoad] -->|"failure detail -> fallback(detail:)"| E2
    E2 --> H2["resolvedRegularFileSize / isDirectoryResolvingSymlinks<br/>(inline path only; local overrides stay symlink-rejecting)"]
  end
```

## Tests

`SpecDecArtifactFunnelTests` — 17 tests green (`swift test --filter SpecDecArtifactFunnelTests`), plus 81 tests across the 7 adjacent SpecDec/MTP suites (`SpecDec|ProviderMTPFactory|MTPPostureTelemetry`):

- **HF-cache symlinked snapshot passes inspection and admits inline MTP** — builds a real `blobs/` + `snapshots/<rev>/` layout with relative symlinks, then proves the full activation chain short of weight loading: direct inspection succeeds with facts byte-identical to the regular-file baseline (revision, payload bytes, config/index digests), the funnel admits it as `.candidate` (the status the slot factory consumes), and `revalidateForLoad` — the last gate before assistant construction in `EngineV2SlotFactory+MTP` — resolves.
- **Broken symlinked shard is rejected with the concrete reason and path** — the `Result` failure names `broken symlink` and the shard path; the funnel maps it to the existing fail-open `inline_artifact_invalid` status.
- **Regular-file inline inspection facts and revalidation are unchanged**, and a checkpoint without inline tensors reports `no tensors with prefix` instead of a bare nil.

Warning logs observed in the test run, e.g.:

```
warning darkbloom.SpecDecStore: inline MTP artifact rejected: inline shard is missing, not a regular file, or a broken symlink: …/snapshots/0123abcd/model-00001-of-00001.safetensors
```

Bug 2 from the same inventory (MTP acceptance unobservable outside Datadog Logs) is fixed separately in #619.
