### PR TITLE
feat(provider): MTP posture and acceptance counters on the local /metrics endpoint

### DIFF
--- a/provider-swift/Sources/ProviderCore/ProviderLoop+LocalEndpoint.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+LocalEndpoint.swift
@@ -44,6 +44,10 @@ extension ProviderLoop {
                 guard let self else { return [] }
                 return await self.advertisedLocalModelIds()
             },
+            mtpSlots: { [weak self] in
+                guard let self else { return [] }
+                return await self.mtpSlotMetricsSamplesForLocal()
+            },
             // Fires only once OUR server has actually bound the socket — the
             // authoritative bind signal. We publish discovery here (never from a
             // best-effort HTTP probe that a foreign process on the same port
@@ -173,5 +177,18 @@ extension ProviderLoop {
     /// this provider is configured to serve, not just the resident subset.
     func advertisedLocalModelIds() -> [String] {
         advertisedModels.keys.sorted()
+    }
+
+    /// Per-resident-slot MTP posture for the unified local endpoint's
+    /// `/metrics` — the same bridge snapshot the capacity tick feeds into
+    /// `DaemonSlotPostureBuilder`, keyed by model id.
+    func mtpSlotMetricsSamplesForLocal() async -> [MTPSlotMetricsSample] {
+        var samples: [MTPSlotMetricsSample] = []
+        samples.reserveCapacity(modelSlots.count)
+        for (modelId, slot) in modelSlots.sorted(by: { $0.key < $1.key }) {
+            samples.append(
+                .init(model: modelId, snapshot: await slot.engineV2.mtpStatusSnapshot()))
+        }
+        return samples
     }
 }

--- a/provider-swift/Sources/ProviderCore/Server/LocalInferenceHTTP.swift
+++ b/provider-swift/Sources/ProviderCore/Server/LocalInferenceHTTP.swift
@@ -33,13 +33,15 @@ public struct LocalInferenceHTTPConfig: Sendable {
 }
 
 /// The concrete responder stack the local endpoint always uses:
-/// auth (outermost) → CORS → chat-upload interception (32 MiB body
-/// ceiling for the media-bearing chat routes, see
+/// auth (outermost) → CORS → MTP-augmented /metrics → chat-upload
+/// interception (32 MiB body ceiling for the media-bearing chat routes, see
 /// `LocalChatUploadResponder`) → upstream MLXLMServer router.
 public typealias LocalInferenceApplication =
     Application<
         LocalAuthResponder<
-            CORSResponder<LocalChatUploadResponder<RouterResponder<BasicRequestContext>>>>>
+            CORSResponder<
+                LocalMetricsResponder<
+                    LocalChatUploadResponder<RouterResponder<BasicRequestContext>>>>>>
 
 /// Builds the local OpenAI-compatible Hummingbird application from a model
 /// registry expressed as three closures. Shared by `StandaloneServer` and the
@@ -53,6 +55,9 @@ public typealias LocalInferenceApplication =
 ///   - tokenizerProvider: resolve a tokenizer for the token-utility endpoints.
 ///   - availableModels: the advertised `/v1/models` catalog (not just the
 ///     currently-resident subset — discovery clients call it before loading).
+///   - mtpSlots: per-slot MTP posture samples for the `/metrics` MTP lines
+///     (see `LocalMetricsResponder`) — the resident slots' bridge snapshots,
+///     empty when nothing is loaded.
 /// - Parameter onServerRunning: invoked by Hummingbird ONCE the socket is
 ///   actually bound and listening. This is the authoritative "we bound the port"
 ///   signal — used to write the discovery record only after a confirmed bind
@@ -64,6 +69,7 @@ func makeLocalInferenceApplication(
     acquire: @escaping @Sendable (String) async throws -> MultiModelBatchSchedulerEngine.AcquiredModel,
     tokenizerProvider: @escaping @Sendable (String?) async throws -> TokenizerHandle,
     availableModels: @escaping @Sendable () async -> [String],
+    mtpSlots: @escaping @Sendable () async -> [MTPSlotMetricsSample],
     onServerRunning: @escaping @Sendable (any Channel) async -> Void = { _ in }
 ) -> LocalInferenceApplication {
     let engine = MultiModelBatchSchedulerEngine(
@@ -81,7 +87,12 @@ func makeLocalInferenceApplication(
     // upstream router unchanged.
     let uploadResponder = LocalChatUploadResponder(
         inner: router.buildResponder(), service: service)
-    let corsResponder = CORSResponder(inner: uploadResponder)
+    // GET /metrics is served by the metrics responder: the upstream
+    // ServerMetrics body plus the provider-owned MTP posture lines (see
+    // LocalMetricsResponder for why the upstream route cannot be extended).
+    let metricsResponder = LocalMetricsResponder(
+        inner: uploadResponder, service: service, mtpSlots: mtpSlots)
+    let corsResponder = CORSResponder(inner: metricsResponder)
     // Auth is the outermost layer so an unauthenticated request is rejected
     // before reaching the engine. Pass-through when no token is configured.
     let authedResponder = LocalAuthResponder(inner: corsResponder, token: config.authToken)

--- a/provider-swift/Sources/ProviderCore/Server/LocalMetricsResponder.swift
+++ b/provider-swift/Sources/ProviderCore/Server/LocalMetricsResponder.swift
@@ -1,0 +1,145 @@
+// Copyright © 2026 Eigen Labs.
+//
+// Provider-local MTP observability on the local `/metrics` endpoint.
+//
+// WHY THIS EXISTS: the MTP acceptance/proposed/accepted counters live in the
+// engine (`CBv2MTPMetrics`, polled via `EngineV2Bridge.mtpStatusSnapshot()`)
+// and until now surfaced ONLY through the `engine_v2_slot_posture` telemetry
+// event — i.e. Datadog Logs. A headless operator (sandboxes have no os_log
+// store access) had no way to observe whether MTP is producing drafts, what
+// the acceptance ratio is, or that MTP silently never activated (e.g.
+// `inline_artifact_invalid` on a symlinked HF snapshot). `/metrics` is the
+// provider-local operator surface, so the posture trio the daemon state and
+// telemetry already agreed on (`mtp_enabled` / `mtp_active` /
+// `mtp_inactive_reason`) plus the cumulative counters are appended here.
+//
+// The upstream `/metrics` handler lives in `MLXLMServer`
+// (`ServerMetrics.prometheusText()`), whose router is already built when the
+// provider wraps it — the same reason `LocalChatUploadResponder` exists. This
+// responder therefore serves GET `/metrics` itself: the upstream body (same
+// public `MLXOpenAIService.prometheusMetrics()` entry point the upstream
+// handler calls) plus the provider-owned MTP lines, in the same Prometheus
+// text style. Everything else forwards to the wrapped router unchanged.
+//
+// Deliberately NOT touched: the coordinator telemetry wire types. Those are
+// mirrored in Go/Swift/TS and adding fields there is a three-language sync;
+// `/metrics` is provider-local and free to carry the full posture.
+
+import Foundation
+import Hummingbird
+import MLXLMServer
+import NIOCore
+
+/// One slot's MTP posture sample for the local `/metrics` endpoint —
+/// `EngineV2Bridge.mtpStatusSnapshot()` keyed by the registry's model id,
+/// the same pairing `DaemonSlotPostureBuilder.LiveSlot` uses.
+public struct MTPSlotMetricsSample: Sendable {
+    let model: String
+    let snapshot: ProviderMTPStatusSnapshot
+
+    init(model: String, snapshot: ProviderMTPStatusSnapshot) {
+        self.model = model
+        self.snapshot = snapshot
+    }
+}
+
+/// Renders the provider-owned MTP lines appended to the upstream
+/// `ServerMetrics.prometheusText()` body, following its `# TYPE` + bare-line
+/// convention. Counters are CUMULATIVE per slot lifetime — the standard
+/// counter contract, matching the slot-posture telemetry event — so any
+/// scraper can difference two samples; the acceptance ratio is
+/// `mtp_tokens_accepted_total / mtp_tokens_proposed_total`.
+enum MTPPrometheusRenderer {
+    static func render(_ slots: [MTPSlotMetricsSample]) -> String {
+        guard !slots.isEmpty else { return "" }
+        var out = ""
+        // One `# TYPE` header per family with every slot's sample beneath it,
+        // as the Prometheus text format requires.
+        func family(
+            _ name: String, _ type: String,
+            _ sample: (MTPSlotMetricsSample) -> String?
+        ) {
+            let lines = slots.compactMap(sample)
+            guard !lines.isEmpty else { return }
+            out += "# TYPE \(name) \(type)\n"
+            for line in lines { out += line + "\n" }
+        }
+        func label(_ sample: MTPSlotMetricsSample) -> String {
+            "model=\"\(escapeLabel(sample.model))\""
+        }
+        family("mtp_enabled", "gauge") {
+            "mtp_enabled{\(label($0))} \($0.snapshot.configured ? 1 : 0)"
+        }
+        family("mtp_active", "gauge") {
+            "mtp_active{\(label($0))} \($0.snapshot.active ? 1 : 0)"
+        }
+        family("mtp_rounds_total", "counter") {
+            "mtp_rounds_total{\(label($0))} \($0.snapshot.rounds)"
+        }
+        family("mtp_tokens_proposed_total", "counter") {
+            "mtp_tokens_proposed_total{\(label($0))} \($0.snapshot.proposedTokens)"
+        }
+        family("mtp_tokens_accepted_total", "counter") {
+            "mtp_tokens_accepted_total{\(label($0))} \($0.snapshot.acceptedDraftTokens)"
+        }
+        // Present whenever MTP is not PRODUCTIVELY running — the same
+        // omitted-when-healthy contract as the telemetry field, and the line
+        // that makes a silently-disabled drafter (`inline_artifact_invalid`,
+        // `inert_kv_unsupported`, …) operationally visible.
+        family("mtp_inactive_reason", "gauge") { sample in
+            guard let reason = sample.snapshot.fallbackReason?.rawValue else { return nil }
+            return "mtp_inactive_reason{\(label(sample)),reason=\"\(escapeLabel(reason))\"} 1"
+        }
+        return out
+    }
+
+    /// Prometheus text-format label escaping: backslash, quote, newline.
+    static func escapeLabel(_ value: String) -> String {
+        var escaped = ""
+        escaped.reserveCapacity(value.utf8.count)
+        for character in value {
+            switch character {
+            case "\\": escaped += "\\\\"
+            case "\"": escaped += "\\\""
+            case "\n": escaped += "\\n"
+            default: escaped.append(character)
+            }
+        }
+        return escaped
+    }
+}
+
+/// Serves GET `/metrics` itself (upstream body + MTP posture lines) and
+/// forwards every other request to the wrapped upstream router. Sits INSIDE
+/// `CORSResponder` so its response carries the CORS header, exactly like
+/// `LocalChatUploadResponder`.
+public struct LocalMetricsResponder<Inner: HTTPResponder>: HTTPResponder
+where Inner.Context == BasicRequestContext {
+    public typealias Context = BasicRequestContext
+
+    public let inner: Inner
+    let service: MLXOpenAIService
+    let mtpSlots: @Sendable () async -> [MTPSlotMetricsSample]
+
+    init(
+        inner: Inner,
+        service: MLXOpenAIService,
+        mtpSlots: @escaping @Sendable () async -> [MTPSlotMetricsSample]
+    ) {
+        self.inner = inner
+        self.service = service
+        self.mtpSlots = mtpSlots
+    }
+
+    public func respond(to request: Request, context: Context) async throws -> Response {
+        guard request.method == .get, request.uri.path == "/metrics" else {
+            return try await inner.respond(to: request, context: context)
+        }
+        let body = await service.prometheusMetrics()
+            + MTPPrometheusRenderer.render(await mtpSlots())
+        return Response(
+            status: .ok,
+            headers: [.contentType: "text/plain; charset=utf-8"],
+            body: .init(byteBuffer: ByteBuffer(string: body)))
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Server/LocalMetricsResponder.swift
+++ b/provider-swift/Sources/ProviderCore/Server/LocalMetricsResponder.swift
@@ -93,6 +93,23 @@ enum MTPPrometheusRenderer {
         return out
     }
 
+    /// Joins the upstream exposition body and the rendered MTP block with
+    /// exactly one newline at the seam. The upstream body's trailing newline
+    /// is an implementation detail of `ServerMetrics.prometheusText()` (a
+    /// blank line before its closing delimiter); relying on it silently would
+    /// let a submodule bump glue the upstream's final sample and our first
+    /// `# TYPE` header into one invalid line (e.g.
+    /// `mlx_server_uptime_seconds 12# TYPE mtp_enabled gauge`), which makes
+    /// Prometheus reject the whole scrape. An empty MTP block leaves the
+    /// upstream body byte-identical; an empty upstream body yields the MTP
+    /// block alone. `render` already terminates every line, so the joined
+    /// body keeps the single trailing newline the text format expects.
+    static func joinedBody(upstream: String, mtp: String) -> String {
+        guard !mtp.isEmpty else { return upstream }
+        guard !upstream.isEmpty else { return mtp }
+        return upstream.hasSuffix("\n") ? upstream + mtp : upstream + "\n" + mtp
+    }
+
     /// Prometheus text-format label escaping: backslash, quote, newline.
     static func escapeLabel(_ value: String) -> String {
         var escaped = ""
@@ -135,8 +152,9 @@ where Inner.Context == BasicRequestContext {
         guard request.method == .get, request.uri.path == "/metrics" else {
             return try await inner.respond(to: request, context: context)
         }
-        let body = await service.prometheusMetrics()
-            + MTPPrometheusRenderer.render(await mtpSlots())
+        let body = MTPPrometheusRenderer.joinedBody(
+            upstream: await service.prometheusMetrics(),
+            mtp: MTPPrometheusRenderer.render(await mtpSlots()))
         return Response(
             status: .ok,
             headers: [.contentType: "text/plain; charset=utf-8"],

--- a/provider-swift/Sources/ProviderCore/Server/StandaloneServer+HTTP.swift
+++ b/provider-swift/Sources/ProviderCore/Server/StandaloneServer+HTTP.swift
@@ -72,6 +72,10 @@ extension StandaloneServer {
                 guard let self else { return [] }
                 return await self.advertisedModelIds()
             },
+            mtpSlots: { [weak self] in
+                guard let self else { return [] }
+                return await self.mtpSlotMetricsSamples()
+            },
             onServerRunning: { [weak self] _ in
                 await self?.markBound()
             }

--- a/provider-swift/Sources/ProviderCore/Server/StandaloneServer.swift
+++ b/provider-swift/Sources/ProviderCore/Server/StandaloneServer.swift
@@ -1112,6 +1112,20 @@ public actor StandaloneServer {
         slots.keys.filter { !evictingModels.contains($0) }.sorted()
     }
 
+    /// Per-resident-slot MTP posture for the local `/metrics` endpoint —
+    /// the same bridge snapshot the capacity tick feeds into
+    /// `DaemonSlotPostureBuilder`, keyed by the registry's model id.
+    func mtpSlotMetricsSamples() async -> [MTPSlotMetricsSample] {
+        var samples: [MTPSlotMetricsSample] = []
+        samples.reserveCapacity(slots.count)
+        for (modelId, slot) in slots.sorted(by: { $0.key < $1.key })
+        where !evictingModels.contains(modelId) {
+            samples.append(
+                .init(model: modelId, snapshot: await slot.bridge.mtpStatusSnapshot()))
+        }
+        return samples
+    }
+
     /// Sorted list of model ids the provider advertises in
     /// `/v1/models`. This is the catalog the operator configured the
     /// provider to serve (passed at init or via ``setModels(_:)``),

--- a/provider-swift/Tests/ProviderCoreTests/StandaloneServerTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/StandaloneServerTests.swift
@@ -1041,3 +1041,97 @@ private final class StandaloneAlivenessTrail: @unchecked Sendable {
     #expect(await server.debugEngineKVGrant(modelId: "gemma-4-26b-qat-4bit") == grantA0)
     #expect(await server.debugEngineKVGrant(modelId: "gpt-oss-20b") == nil)
 }
+
+// MARK: - /metrics MTP posture (provider-local observability)
+//
+// The MTP acceptance counters exist in-engine (`CBv2MTPMetrics`) and in the
+// `engine_v2_slot_posture` telemetry event, but until now the local
+// `/metrics` endpoint carried none of them — a headless operator could not
+// observe acceptance, or that MTP silently never activated
+// (`inline_artifact_invalid`). These tests pin the provider-owned lines.
+
+private func stubActiveMTPSnapshot(
+    rounds: Int, proposed: Int, accepted: Int
+) -> ProviderMTPStatusSnapshot {
+    var metrics = CBv2MTPMetrics()
+    metrics.active = true
+    metrics.rounds = rounds
+    metrics.draftedTokens = proposed
+    metrics.acceptedTokens = accepted
+    let status = MTPActivationStatus(
+        configured: true, active: true, reason: nil, source: .inline,
+        revision: "inline-test", artifactBytes: 1024, assistantBytes: 512)
+    return ProviderMTPStatusSnapshot(status: status, metrics: metrics)
+}
+
+@Test func mtpPrometheusRendererEmitsPostureAndCounters() {
+    let active = stubActiveMTPSnapshot(rounds: 7, proposed: 21, accepted: 14)
+    let disabled = ProviderMTPStatusSnapshot(
+        status: .disabled(.inlineArtifactInvalid, configured: true), metrics: nil)
+    let text = MTPPrometheusRenderer.render([
+        .init(model: "qwen3.6-35b-a3b-vl-mtp-mxfp8", snapshot: active),
+        .init(model: "gemma-4\"quoted\\name", snapshot: disabled),
+    ])
+    #expect(text.contains("# TYPE mtp_enabled gauge"))
+    #expect(text.contains(#"mtp_enabled{model="qwen3.6-35b-a3b-vl-mtp-mxfp8"} 1"#))
+    #expect(text.contains(#"mtp_active{model="qwen3.6-35b-a3b-vl-mtp-mxfp8"} 1"#))
+    #expect(text.contains(#"mtp_rounds_total{model="qwen3.6-35b-a3b-vl-mtp-mxfp8"} 7"#))
+    #expect(text.contains(#"mtp_tokens_proposed_total{model="qwen3.6-35b-a3b-vl-mtp-mxfp8"} 21"#))
+    #expect(text.contains(#"mtp_tokens_accepted_total{model="qwen3.6-35b-a3b-vl-mtp-mxfp8"} 14"#))
+    // A silently-disabled drafter is visible with its concrete reason —
+    // the operational hole this endpoint change exists to close…
+    #expect(text.contains(#"reason="inline_artifact_invalid"} 1"#))
+    #expect(text.contains(#"mtp_active{model="gemma-4\"quoted\\name"} 0"#))
+    // …its label values are Prometheus-escaped…
+    #expect(text.contains(#"model="gemma-4\"quoted\\name""#))
+    // …and the healthy slot carries no inactive-reason line (omitted when
+    // productively running, matching the telemetry contract).
+    #expect(!text.contains(#"mtp_inactive_reason{model="qwen3.6-35b-a3b-vl-mtp-mxfp8""#))
+    // No slots -> no MTP lines at all: the upstream body stays byte-identical.
+    #expect(MTPPrometheusRenderer.render([]).isEmpty)
+}
+
+@Test func localMetricsEndpointAppendsMTPLinesToUpstreamBody() async throws {
+    let snapshot = stubActiveMTPSnapshot(rounds: 3, proposed: 9, accepted: 6)
+    let app = makeLocalInferenceApplication(
+        config: .init(host: "127.0.0.1", port: 0, authToken: nil),
+        defaultMaxTokens: 128,
+        acquire: { modelId in
+            throw MultiModelBatchSchedulerEngineError.modelNotLoaded(modelId)
+        },
+        tokenizerProvider: { _ in
+            throw MultiModelBatchSchedulerEngineError.noModelLoadedForTokenization
+        },
+        availableModels: { [] },
+        mtpSlots: { [.init(model: "qwen3.6-35b-a3b-vl-mtp-mxfp8", snapshot: snapshot)] }
+    )
+    try await app.test(.router) { client in
+        try await client.execute(uri: "/metrics", method: .get) { response in
+            #expect(response.status == .ok)
+            #expect(response.headers[.contentType] == "text/plain; charset=utf-8")
+            let body = String(buffer: response.body)
+            // The upstream ServerMetrics body is intact…
+            #expect(body.contains("mlx_server_requests_total"))
+            #expect(body.contains("mlx_server_uptime_seconds"))
+            // …and the provider MTP lines ride behind it.
+            #expect(body.contains(#"mtp_enabled{model="qwen3.6-35b-a3b-vl-mtp-mxfp8"} 1"#))
+            #expect(body.contains(#"mtp_rounds_total{model="qwen3.6-35b-a3b-vl-mtp-mxfp8"} 3"#))
+            #expect(body.contains(#"mtp_tokens_proposed_total{model="qwen3.6-35b-a3b-vl-mtp-mxfp8"} 9"#))
+            #expect(body.contains(#"mtp_tokens_accepted_total{model="qwen3.6-35b-a3b-vl-mtp-mxfp8"} 6"#))
+        }
+    }
+}
+
+@Test func standaloneServerMetricsWithoutSlotsServesUpstreamBodyOnly() async throws {
+    let server = standaloneTestServer()
+    let app = server.makeApplication()
+    try await app.test(.router) { client in
+        try await client.execute(uri: "/metrics", method: .get) { response in
+            #expect(response.status == .ok)
+            let body = String(buffer: response.body)
+            #expect(body.contains("mlx_server_requests_total"))
+            #expect(!body.contains("mtp_"), "no resident slots -> no MTP lines")
+        }
+    }
+    _ = server
+}

--- a/provider-swift/Tests/ProviderCoreTests/StandaloneServerTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/StandaloneServerTests.swift
@@ -1064,6 +1064,25 @@ private func stubActiveMTPSnapshot(
     return ProviderMTPStatusSnapshot(status: status, metrics: metrics)
 }
 
+/// Line-level Prometheus text-format shape check. Substring assertions alone
+/// cannot catch a malformed concat seam (an upstream sample glued to the
+/// first MTP header, `mlx_server_uptime_seconds 12# TYPE mtp_enabled gauge`),
+/// so every non-empty line must be a `# TYPE`/`# HELP` header or a complete
+/// `name{labels} value` sample.
+private func expectPrometheusShapedLines(
+    _ body: String, sourceLocation: SourceLocation = #_sourceLocation
+) {
+    let shape =
+        #/^(?:# (?:TYPE|HELP) .+|[a-zA-Z_:][a-zA-Z0-9_:]*(?:\{[^}]*\})? -?(?:[0-9][0-9eE+\-.]*|Inf|NaN))$/#
+    for line in body.split(separator: "\n", omittingEmptySubsequences: false)
+    where !line.isEmpty {
+        #expect(
+            line.wholeMatch(of: shape) != nil,
+            "malformed Prometheus line: \(line.debugDescription)",
+            sourceLocation: sourceLocation)
+    }
+}
+
 @Test func mtpPrometheusRendererEmitsPostureAndCounters() {
     let active = stubActiveMTPSnapshot(rounds: 7, proposed: 21, accepted: 14)
     let disabled = ProviderMTPStatusSnapshot(
@@ -1089,6 +1108,32 @@ private func stubActiveMTPSnapshot(
     #expect(!text.contains(#"mtp_inactive_reason{model="qwen3.6-35b-a3b-vl-mtp-mxfp8""#))
     // No slots -> no MTP lines at all: the upstream body stays byte-identical.
     #expect(MTPPrometheusRenderer.render([]).isEmpty)
+}
+
+@Test func metricsBodyJoinGuaranteesNewlineBetweenUpstreamAndMTPBlock() {
+    let snapshot = stubActiveMTPSnapshot(rounds: 1, proposed: 2, accepted: 1)
+    let mtp = MTPPrometheusRenderer.render([.init(model: "m", snapshot: snapshot)])
+    // REGRESSION: an upstream body WITHOUT a trailing newline plus a resident
+    // slot must never glue the final upstream sample and the first MTP
+    // `# TYPE` header into one line — the shape that makes Prometheus reject
+    // the entire scrape.
+    let joined = MTPPrometheusRenderer.joinedBody(
+        upstream: "mlx_server_uptime_seconds 12", mtp: mtp)
+    #expect(joined.firstMatch(of: #/[0-9]# TYPE/#) == nil)
+    #expect(joined.contains("mlx_server_uptime_seconds 12\n# TYPE mtp_enabled gauge\n"))
+    expectPrometheusShapedLines(joined)
+    // Exactly one separator: an already-terminated upstream body gains no
+    // blank line…
+    let terminated = MTPPrometheusRenderer.joinedBody(
+        upstream: "mlx_server_uptime_seconds 12\n", mtp: mtp)
+    #expect(terminated == joined)
+    #expect(!terminated.contains("\n\n"))
+    // …the body keeps the single trailing newline the text format expects…
+    #expect(joined.hasSuffix("\n") && !joined.hasSuffix("\n\n"))
+    // …an empty upstream body yields the MTP block alone…
+    #expect(MTPPrometheusRenderer.joinedBody(upstream: "", mtp: mtp) == mtp)
+    // …and no MTP block leaves the upstream body byte-identical.
+    #expect(MTPPrometheusRenderer.joinedBody(upstream: "up 1", mtp: "") == "up 1")
 }
 
 @Test func localMetricsEndpointAppendsMTPLinesToUpstreamBody() async throws {
@@ -1118,6 +1163,12 @@ private func stubActiveMTPSnapshot(
             #expect(body.contains(#"mtp_rounds_total{model="qwen3.6-35b-a3b-vl-mtp-mxfp8"} 3"#))
             #expect(body.contains(#"mtp_tokens_proposed_total{model="qwen3.6-35b-a3b-vl-mtp-mxfp8"} 9"#))
             #expect(body.contains(#"mtp_tokens_accepted_total{model="qwen3.6-35b-a3b-vl-mtp-mxfp8"} 6"#))
+            // …with every line individually well-formed: the upstream/MTP
+            // seam must never fuse a sample and a `# TYPE` header (the
+            // substring checks above would not notice).
+            expectPrometheusShapedLines(body)
+            #expect(body.firstMatch(of: #/[0-9]# TYPE/#) == nil)
+            #expect(body.hasSuffix("\n") && !body.hasSuffix("\n\n"))
         }
     }
 }
@@ -1131,6 +1182,7 @@ private func stubActiveMTPSnapshot(
             let body = String(buffer: response.body)
             #expect(body.contains("mlx_server_requests_total"))
             #expect(!body.contains("mtp_"), "no resident slots -> no MTP lines")
+            expectPrometheusShapedLines(body)
         }
     }
     _ = server


### PR DESCRIPTION
## Problem

Bug 2 from Layr-Labs/mlx-swift-lm#106's **Discovered bugs**: MTP acceptance is unobservable outside Datadog Logs. The counters exist in-engine (`CBv2MTPMetrics`, polled via `EngineV2Bridge.mtpStatusSnapshot()`), but the only surface was the `engine_v2_slot_posture` telemetry event → Datadog Logs. The provider's local HTTP server exposes `/metrics` with **no MTP counters at all**, and the os_log store is inaccessible in sandboxes — so a headless operator could not observe whether MTP is producing drafts, what the acceptance ratio is, or that MTP silently never activated (`inline_artifact_invalid`, the sibling bug fixed in #618; `inert_kv_unsupported`; …).

## Change

`/metrics` now appends provider-owned per-model lines behind the upstream `MLXLMServer` body, in the same Prometheus text style (`# TYPE` + bare lines):

```
mtp_enabled{model="…"} 0|1
mtp_active{model="…"} 0|1
mtp_rounds_total{model="…"} N
mtp_tokens_proposed_total{model="…"} N
mtp_tokens_accepted_total{model="…"} N
mtp_inactive_reason{model="…",reason="inline_artifact_invalid"} 1   # omitted when productively running
```

Counters are cumulative per slot lifetime (standard counter contract, matching the telemetry event); acceptance rate = `accepted_total / proposed_total`. `mtp_inactive_reason` carries the existing `MTPFallbackReason` enum — the same status `inline_artifact_invalid` rides in — so a silently-disabled drafter is operationally visible.

Mechanics: the upstream `/metrics` route lives in `MLXLMServer` (`ServerMetrics.prometheusText()`), whose router is already built when the provider wraps it — so a new `LocalMetricsResponder` serves GET `/metrics` itself (same public `MLXOpenAIService.prometheusMetrics()` entry point + the MTP lines), exactly the interception pattern `LocalChatUploadResponder` established. Wired through **both** local endpoints via a `mtpSlots` closure: the `StandaloneServer` slot cache (`--local`) and the unified `ProviderLoop.modelSlots` (`--local-endpoint`) — the same bridge snapshot the capacity tick already feeds into `DaemonSlotPostureBuilder`, so `/metrics`, daemon-state, and telemetry cannot describe a slot differently.

Deliberately **not** touched: the coordinator telemetry wire types (Go/Swift/TS three-language sync — out of scope); the daemon-state `SlotPosture` already carries `mtpEnabled`/`mtpActive`/`mtpInactiveReason`, so `darkbloom status` needed no change.

## Behavior

```mermaid
flowchart LR
  subgraph Before
    A1["CBv2MTPMetrics (in-engine)"] --> B1["engine_v2_slot_posture event"] --> C1["Datadog Logs ONLY<br/>headless/sandboxed operator: blind<br/>silently-disabled MTP invisible"]
    D1["GET /metrics"] --> E1["upstream mlx_server_* counters only"]
  end
  subgraph After
    A2["CBv2MTPMetrics (in-engine)"] --> B2["engine_v2_slot_posture event -> Datadog (unchanged)"]
    A2 --> D2["GET /metrics"] --> E2["mlx_server_* body +<br/>mtp_enabled / mtp_active / mtp_rounds_total /<br/>mtp_tokens_proposed_total / mtp_tokens_accepted_total /<br/>mtp_inactive_reason{reason=…}"]
  end
```

## Code

```mermaid
flowchart LR
  subgraph Before
    R1["auth -> CORS -> chat-upload -> upstream router"] --> M1["/metrics = ServerMetrics.prometheusText() verbatim"]
  end
  subgraph After
    R2["auth -> CORS -> LocalMetricsResponder -> chat-upload -> upstream router"] --> M2["/metrics = prometheusMetrics() + MTPPrometheusRenderer.render(mtpSlots())"]
    S2[StandaloneServer.mtpSlotMetricsSamples] --> M2
    P2[ProviderLoop.mtpSlotMetricsSamplesForLocal] --> M2
  end
```

## Pin independence (#616)

Pure provider-swift change, based on `master` (which already carries the #616 pin bump to mlx-swift-lm `d06da67`). It uses no field introduced by mlx-swift-lm#106 — `CBv2MTPMetrics.rounds/draftedTokens/acceptedTokens/active` and `MLXOpenAIService.prometheusMetrics()` all predate it — so it also compiles against the pre-#106 pin (`c04afb4`); no availability gating needed.

## Tests

Targeted filters green (`swift test`, debug, with source-matched metallib per `make provider-test`):

- `mtpPrometheusRendererEmitsPostureAndCounters` — stubbed active snapshot (7 rounds, 21 proposed, 14 accepted) and a stubbed `inline_artifact_invalid` slot: all six families render, healthy slots omit `mtp_inactive_reason`, label values are Prometheus-escaped, empty slot list renders nothing (upstream body stays byte-identical).
- `localMetricsEndpointAppendsMTPLinesToUpstreamBody` — full responder stack via `makeLocalInferenceApplication` with a stubbed `mtpSlots` closure: GET `/metrics` returns 200 `text/plain`, the upstream `mlx_server_*` body intact, and the stubbed counters (3/9/6) appear.
- `standaloneServerMetricsWithoutSlotsServesUpstreamBodyOnly` — cold standalone server: upstream body only, no `mtp_` lines.
- Plus the 16-test standalone-server/CORS/auth/upload filter unchanged.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/619"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789253660&installation_model_id=21733&pr_number=619&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F619&signature=a8d396d00b8ded8bad26f2d1686dcce4b1f881192afd8c7887259713fd6cf650"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->