### PR TITLE
Fix OpenRouter Hugging Face model IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased (v0.8.4 candidate - provider)
 
+### Coordinator
+
+#### Fixes
+
+- **Expose exact Hugging Face repositories in model feeds** - Registry metadata can now override `hugging_face_id` independently of the internal routing ID. Both `/v1/models` and `/v1/models/openrouter` honor the override for concrete and aliased models, with an authenticated `hugging-face-id` admin action for existing registry rows.
+
 ### Provider (Swift)
 
 #### Fixes

--- a/coordinator/api/model_alias_handlers_test.go
+++ b/coordinator/api/model_alias_handlers_test.go
@@ -152,6 +152,9 @@ func TestAliasModelEntriesHidesBuilds(t *testing.T) {
 	if len(entries) != 1 || entries[0].ID != "gemma-4-26b" {
 		t.Fatalf("expected one alias entry, got %+v", entries)
 	}
+	if entries[0].HuggingFaceID != aliasQAT {
+		t.Fatalf("alias hugging_face_id = %q, want primary build %q", entries[0].HuggingFaceID, aliasQAT)
+	}
 	// Capacity aggregates across desired + previous only (2 + 1 = 3 routable);
 	// retired builds are hide-only and must not count as active alias capacity.
 	if entries[0].Metadata.RoutableProviders != 3 || entries[0].Metadata.WarmProviders != 1 || !entries[0].Metadata.CanAccept {

--- a/coordinator/api/model_deprecation_test.go
+++ b/coordinator/api/model_deprecation_test.go
@@ -147,3 +147,72 @@ func TestAdminSetAndClearOpenRouterSlug(t *testing.T) {
 		t.Errorf("after clear, slug = %q, want the model id", got)
 	}
 }
+
+func TestAdminSetAndClearHuggingFaceID(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	st := store.NewMemory(store.Config{})
+	reg := registry.New(logger)
+	srv := NewServer(reg, st, ServerConfig{}, logger)
+	srv.SetAdminKey("admin-key")
+
+	const (
+		modelID       = "qwen3.6-35b-a3b-vl-mtp-mxfp8"
+		huggingFaceID = "EigenLabs/Qwen3.6-35B-A3B-MLX-VL-4bit-g64-router8"
+	)
+	entry := &store.ModelRegistryEntry{
+		ID: modelID, DisplayName: "Qwen3.6 35B A3B", Quantization: "4bit",
+		MaxContextLength: 262144, MaxOutputLength: 8192, MinRAMGB: 32, Status: "active",
+		Metadata: map[string]any{"tier": "test"},
+	}
+	files := []store.ModelVersionFile{{Path: "config.json", SizeBytes: 1, SHA256: testHash, Role: "config"}}
+	if err := st.SetModelVersion(entry, &store.ModelVersion{ModelID: modelID, Version: "v1", R2Prefix: modelR2Prefix(modelID, "v1"), AggregateSHA256: testHash, TotalSizeBytes: 1, FileCount: 1, Status: "ready"}, files); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.PromoteModelVersion(modelID, "v1"); err != nil {
+		t.Fatal(err)
+	}
+
+	call := func(body string) *httptest.ResponseRecorder {
+		var r *http.Request
+		if body == "" {
+			r = httptest.NewRequest(http.MethodPost, "/v1/admin/models/"+modelID+"/hugging-face-id", nil)
+		} else {
+			r = httptest.NewRequest(http.MethodPost, "/v1/admin/models/"+modelID+"/hugging-face-id", bytes.NewReader([]byte(body)))
+		}
+		r.Header.Set("Authorization", "Bearer admin-key")
+		rec := httptest.NewRecorder()
+		srv.Handler().ServeHTTP(rec, r)
+		return rec
+	}
+
+	if rec := call(`{"hugging_face_id":"  ` + huggingFaceID + `  "}`); rec.Code != http.StatusOK {
+		t.Fatalf("set Hugging Face ID status = %d body = %s", rec.Code, rec.Body.String())
+	}
+	rec1, err := st.GetModelRegistryRecord(modelID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rec1.Metadata[huggingFaceIDMetadataKey] != huggingFaceID {
+		t.Fatalf("metadata hugging_face_id = %v", rec1.Metadata[huggingFaceIDMetadataKey])
+	}
+	if got := huggingFaceIDForModel(modelID, rec1.Metadata); got != huggingFaceID {
+		t.Fatalf("feed hugging_face_id = %q, want %q", got, huggingFaceID)
+	}
+	if rec1.Metadata["tier"] != "test" {
+		t.Errorf("other metadata clobbered: %v", rec1.Metadata)
+	}
+
+	if rec := call(""); rec.Code != http.StatusOK {
+		t.Fatalf("clear Hugging Face ID status = %d body = %s", rec.Code, rec.Body.String())
+	}
+	rec2, err := st.GetModelRegistryRecord(modelID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, present := rec2.Metadata[huggingFaceIDMetadataKey]; present {
+		t.Errorf("hugging_face_id should be cleared, metadata = %v", rec2.Metadata)
+	}
+	if got := huggingFaceIDForModel(modelID, rec2.Metadata); got != modelID {
+		t.Errorf("after clear, hugging_face_id = %q, want model id %q", got, modelID)
+	}
+}

--- a/coordinator/api/model_registry_handlers.go
+++ b/coordinator/api/model_registry_handlers.go
@@ -382,6 +382,46 @@ func (s *Server) handleAdminModelRegistryAction(w http.ResponseWriter, r *http.R
 			resp["openrouter_slug"] = slug
 		}
 		writeJSON(w, http.StatusOK, resp)
+	case "hugging-face-id":
+		// Sets (or clears) the exact Hugging Face repository exposed in model
+		// feeds. Internal routing ids need not be valid Hugging Face paths.
+		var req struct {
+			HuggingFaceID string `json:"hugging_face_id"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil && err != io.EOF {
+			writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request_error", "invalid JSON: "+err.Error()))
+			return
+		}
+		huggingFaceID := strings.TrimSpace(req.HuggingFaceID)
+		rec, err := s.store.GetModelRegistryRecord(modelID)
+		if err != nil {
+			s.writeModelRegistryStoreError(w, "get model for hugging-face-id update", err)
+			return
+		}
+		entry := registryEntryFromRecord(rec)
+		meta := make(map[string]any, len(entry.Metadata))
+		for k, v := range entry.Metadata {
+			meta[k] = v
+		}
+		if huggingFaceID == "" {
+			delete(meta, huggingFaceIDMetadataKey)
+		} else {
+			meta[huggingFaceIDMetadataKey] = huggingFaceID
+		}
+		entry.Metadata = meta
+		if err := s.store.UpsertModelRegistryEntry(entry); err != nil {
+			s.writeModelRegistryStoreError(w, "update hugging-face-id", err)
+			return
+		}
+		s.SyncModelCatalog()
+		resp := map[string]any{"status": "updated", "model_id": modelID}
+		if huggingFaceID == "" {
+			resp["hugging_face_id"] = nil
+			resp["note"] = "Hugging Face ID cleared — feed falls back to the model id"
+		} else {
+			resp["hugging_face_id"] = huggingFaceID
+		}
+		writeJSON(w, http.StatusOK, resp)
 	default:
 		writeJSON(w, http.StatusNotFound, errorResponse("not_found", "model action not found"))
 	}
@@ -514,7 +554,7 @@ func parseAdminModelActionPath(p string) (string, string, bool) {
 	if rest == p || rest == "" {
 		return "", "", false
 	}
-	for _, action := range []string{"/promote", "/status", "/runtime-parameters", "/capabilities", "/deprecation", "/openrouter-slug"} {
+	for _, action := range []string{"/promote", "/status", "/runtime-parameters", "/capabilities", "/deprecation", "/openrouter-slug", "/hugging-face-id"} {
 		if strings.HasSuffix(rest, action) {
 			modelID, err := url.PathUnescape(strings.TrimSuffix(rest, action))
 			if err != nil {
@@ -797,7 +837,7 @@ func catalogModelFromRegistryRecord(rec *store.ModelRegistryRecord) map[string]a
 
 		// OpenRouter-shaped fields (mirrors /v1/models) for UI consistency.
 		"name":                          supported.DisplayName,
-		"hugging_face_id":               supported.ID,
+		"hugging_face_id":               huggingFaceIDForModel(supported.ID, rec.Metadata),
 		"input_modalities":              inputModalities,
 		"output_modalities":             outputModalities,
 		"supported_features":            supportedFeaturesFromCapabilities(rec.Capabilities),

--- a/coordinator/api/models_endpoints.go
+++ b/coordinator/api/models_endpoints.go
@@ -113,11 +113,12 @@ func (s *Server) aliasModelEntries(
 			CanAccept:         canAccept,
 		}
 		entry := types.ModelEntry{
-			ID:       a.AliasID,
-			Object:   "model",
-			OwnedBy:  "eigeninference",
-			Name:     displayName,
-			Metadata: metadata,
+			ID:            a.AliasID,
+			Object:        "model",
+			OwnedBy:       "eigeninference",
+			Name:          displayName,
+			HuggingFaceID: huggingFaceIDForModel(primary, reg.Metadata),
+			Metadata:      metadata,
 		}
 		// Pricing / context / features come from the primary build's registry
 		// entry. Quantization is intentionally left blank on the alias.
@@ -200,20 +201,20 @@ func (s *Server) listModelEntries(includeBuilds bool) ([]types.ModelEntry, error
 			metadata.DisplayName = cm.DisplayName
 		}
 
+		reg, hasReg := registryByID[m.ID]
 		entry := types.ModelEntry{
 			ID:            m.ID,
 			Object:        "model",
 			Created:       0,
 			OwnedBy:       "eigeninference",
 			Name:          metadata.DisplayName,
-			HuggingFaceID: m.ID, // model IDs are HuggingFace paths
+			HuggingFaceID: huggingFaceIDForModel(m.ID, reg.Metadata),
 			Metadata:      metadata,
 		}
 
 		// OpenRouter provider fields (quantization, per-token pricing, sampling
 		// params, and registry-sourced metadata), shared with the dedicated
 		// /v1/models/openrouter feed.
-		reg, hasReg := registryByID[m.ID]
 		s.openRouterModelFieldsFor(m.ID, m.Quantization, reg, hasReg).applyToModelEntry(&entry)
 
 		// Modalities are derived from the model's capabilities (text by default).

--- a/coordinator/api/openrouter_endpoint.go
+++ b/coordinator/api/openrouter_endpoint.go
@@ -72,7 +72,7 @@ func (s *Server) handleListModelsOpenRouter(w http.ResponseWriter, r *http.Reque
 		reg, hasReg := registryByID[id]
 		entry := types.OpenRouterModel{
 			ID:                id,
-			HuggingFaceID:     id, // our model IDs are HuggingFace paths
+			HuggingFaceID:     huggingFaceIDForModel(id, reg.Metadata),
 			Name:              openRouterModelName(cm, reg, hasReg, id),
 			InputModalities:   []string{"text"},
 			OutputModalities:  []string{"text"},
@@ -105,9 +105,9 @@ func (s *Server) handleListModelsOpenRouter(w http.ResponseWriter, r *http.Reque
 // is the ALIAS so the marketplace listing is stable across build migrations;
 // per-build fields (pricing, context, readiness) come from the alias's primary
 // build (the desired build when in catalog, else the previous build).
-// HuggingFaceID stays the primary build's real HF path — OpenRouter ingests it
-// for model metadata, and a fabricated path would break that; the routing name
-// consumers send/receive is still only ever the alias.
+// HuggingFaceID stays the primary build's configured HF path — OpenRouter
+// ingests it for model metadata, and a fabricated path would break that; the
+// routing name consumers send/receive is still only ever the alias.
 func (s *Server) openRouterAliasEntries(
 	catalogByID map[string]store.SupportedModel,
 	registryByID map[string]store.ModelRegistryEntry,
@@ -167,7 +167,7 @@ func (s *Server) openRouterAliasEntries(
 		}
 		entry := types.OpenRouterModel{
 			ID:                a.AliasID,
-			HuggingFaceID:     primary,
+			HuggingFaceID:     huggingFaceIDForModel(primary, reg.Metadata),
 			Name:              displayName,
 			InputModalities:   []string{"text"},
 			OutputModalities:  []string{"text"},

--- a/coordinator/api/openrouter_endpoint_test.go
+++ b/coordinator/api/openrouter_endpoint_test.go
@@ -31,19 +31,25 @@ func TestOpenRouterModelsEndpoint(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	const modelID = "mlx-community/Qwen3.5-9B-MLX-4bit"
+	const (
+		modelID       = "qwen3.6-35b-a3b-vl-mtp-mxfp8"
+		huggingFaceID = "EigenLabs/Qwen3.6-35B-A3B-MLX-VL-4bit-g64-router8"
+	)
 	entry := &store.ModelRegistryEntry{
 		ID:               modelID,
-		DisplayName:      "Qwen3.5 9B",
+		DisplayName:      "Qwen3.6 35B A3B",
 		Quantization:     "4bit",
 		MaxContextLength: 262144,
 		MaxOutputLength:  16384,
-		MinRAMGB:         16,
+		MinRAMGB:         32,
 		Capabilities:     []string{"tools", "reasoning"},
 		Status:           "active",
 		Description:      "Balanced general-purpose model.",
-		Metadata:         map[string]any{"openrouter_slug": "darkbloom/qwen3.5-9b"},
-		CreatedAt:        time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+		Metadata: map[string]any{
+			"openrouter_slug":        "darkbloom/qwen3.6-35b-a3b",
+			huggingFaceIDMetadataKey: huggingFaceID,
+		},
+		CreatedAt: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
 	}
 	version := &store.ModelVersion{ModelID: modelID, Version: "v1", R2Prefix: modelR2Prefix(modelID, "v1"), AggregateSHA256: testHash, TotalSizeBytes: 9_000_000_000, FileCount: 1, Status: "ready"}
 	files := []store.ModelVersionFile{{Path: "config.json", SizeBytes: 1, SHA256: testHash, Role: "config"}}
@@ -82,11 +88,11 @@ func TestOpenRouterModelsEndpoint(t *testing.T) {
 		t.Fatalf("model not in feed: %s", rec.Body.String())
 	}
 
-	if m.Name != "Qwen3.5 9B" {
+	if m.Name != "Qwen3.6 35B A3B" {
 		t.Errorf("name = %q", m.Name)
 	}
-	if m.HuggingFaceID != modelID {
-		t.Errorf("hugging_face_id = %q", m.HuggingFaceID)
+	if m.HuggingFaceID != huggingFaceID {
+		t.Errorf("hugging_face_id = %q, want %q", m.HuggingFaceID, huggingFaceID)
 	}
 	if m.Created != entry.CreatedAt.Unix() {
 		t.Errorf("created = %d, want %d", m.Created, entry.CreatedAt.Unix())
@@ -115,8 +121,8 @@ func TestOpenRouterModelsEndpoint(t *testing.T) {
 	if !m.IsReady {
 		t.Error("is_ready should be true for an active model")
 	}
-	if m.OpenRouter == nil || m.OpenRouter.Slug != "darkbloom/qwen3.5-9b" {
-		t.Errorf("slug = %+v, want darkbloom/qwen3.5-9b", m.OpenRouter)
+	if m.OpenRouter == nil || m.OpenRouter.Slug != "darkbloom/qwen3.6-35b-a3b" {
+		t.Errorf("slug = %+v, want darkbloom/qwen3.6-35b-a3b", m.OpenRouter)
 	}
 
 	// The pure feed must NOT carry the Darkbloom metadata block.
@@ -247,6 +253,16 @@ func TestOpenRouterModelsAliasEntriesHideBuilds(t *testing.T) {
 
 	seedActiveModel(t, st, aliasFP8, "Gemma 4 26B fp8")
 	seedActiveModel(t, st, aliasQAT, "Gemma 4 26B qat")
+	const aliasHuggingFaceID = "google/gemma-4-26b-it"
+	primaryRecord, err := st.GetModelRegistryRecord(aliasQAT)
+	if err != nil {
+		t.Fatal(err)
+	}
+	primaryEntry := registryEntryFromRecord(primaryRecord)
+	primaryEntry.Metadata = map[string]any{huggingFaceIDMetadataKey: aliasHuggingFaceID}
+	if err := st.UpsertModelRegistryEntry(primaryEntry); err != nil {
+		t.Fatal(err)
+	}
 	seedActiveModel(t, st, "mlx-community/unrelated-9b", "Unrelated 9B")
 	if err := st.UpsertModelAlias(&store.ModelAlias{
 		AliasID: "gemma-4-26b", DisplayName: "Gemma 4 26B", Active: true,
@@ -282,8 +298,8 @@ func TestOpenRouterModelsAliasEntriesHideBuilds(t *testing.T) {
 	if alias.OpenRouter == nil || alias.OpenRouter.Slug != "gemma-4-26b" {
 		t.Fatalf("alias slug = %+v, want gemma-4-26b", alias.OpenRouter)
 	}
-	if alias.HuggingFaceID != aliasQAT {
-		t.Fatalf("alias hugging_face_id = %q, want primary build", alias.HuggingFaceID)
+	if alias.HuggingFaceID != aliasHuggingFaceID {
+		t.Fatalf("alias hugging_face_id = %q, want %q", alias.HuggingFaceID, aliasHuggingFaceID)
 	}
 	// Member builds are hidden from the raw listing.
 	if _, leaked := byID[aliasFP8]; leaked {

--- a/coordinator/api/openrouter_listmodels_test.go
+++ b/coordinator/api/openrouter_listmodels_test.go
@@ -31,23 +31,29 @@ func TestListModelsOpenRouterFields(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	const modelID = "mlx-community/Qwen3.5-9B-MLX-4bit"
+	const (
+		modelID       = "qwen3.6-35b-a3b-vl-mtp-mxfp8"
+		huggingFaceID = "EigenLabs/Qwen3.6-35B-A3B-MLX-VL-4bit-g64-router8"
+	)
 
 	// Seed a rich registry entry + active version, then sync the routing catalog.
 	entry := &store.ModelRegistryEntry{
 		ID:               modelID,
-		DisplayName:      "Qwen3.5 9B",
+		DisplayName:      "Qwen3.6 35B A3B",
 		Family:           "qwen",
-		Architecture:     "9B dense",
+		Architecture:     "35B-A3B MoE",
 		Quantization:     "4bit",
 		MaxContextLength: 262144,
 		MaxOutputLength:  16384,
-		MinRAMGB:         16,
+		MinRAMGB:         32,
 		Capabilities:     []string{"tools", "reasoning"},
 		Status:           "active",
 		Description:      "Balanced general-purpose model.",
-		Metadata:         map[string]any{"deprecation_date": "2026-12-31"},
-		CreatedAt:        time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+		Metadata: map[string]any{
+			"deprecation_date":       "2026-12-31",
+			huggingFaceIDMetadataKey: huggingFaceID,
+		},
+		CreatedAt: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
 	}
 	version := &store.ModelVersion{ModelID: modelID, Version: "v1", R2Prefix: modelR2Prefix(modelID, "v1"), AggregateSHA256: testHash, TotalSizeBytes: 9_000_000_000, FileCount: 1, Status: "ready"}
 	files := []store.ModelVersionFile{{Path: "config.json", SizeBytes: 1, SHA256: testHash, Role: "config"}}
@@ -92,11 +98,11 @@ func TestListModelsOpenRouterFields(t *testing.T) {
 		t.Fatalf("model %q not in response: %s", modelID, rec.Body.String())
 	}
 
-	if entryOut.Name != "Qwen3.5 9B" {
-		t.Errorf("name = %q, want %q", entryOut.Name, "Qwen3.5 9B")
+	if entryOut.Name != "Qwen3.6 35B A3B" {
+		t.Errorf("name = %q, want %q", entryOut.Name, "Qwen3.6 35B A3B")
 	}
-	if entryOut.HuggingFaceID != modelID {
-		t.Errorf("hugging_face_id = %q, want %q", entryOut.HuggingFaceID, modelID)
+	if entryOut.HuggingFaceID != huggingFaceID {
+		t.Errorf("hugging_face_id = %q, want %q", entryOut.HuggingFaceID, huggingFaceID)
 	}
 	if entryOut.Created != entry.CreatedAt.Unix() {
 		t.Errorf("created = %d, want %d", entryOut.Created, entry.CreatedAt.Unix())

--- a/coordinator/api/openrouter_models.go
+++ b/coordinator/api/openrouter_models.go
@@ -331,13 +331,28 @@ func openRouterIsReady(meta map[string]any) bool {
 	return true
 }
 
+const huggingFaceIDMetadataKey = "hugging_face_id"
+
+// huggingFaceIDForModel returns the exact Hugging Face repository OpenRouter
+// should inspect. Most concrete model ids are already Hugging Face paths; an
+// explicit metadata value supports internal routing ids without conflating the
+// two identities.
+func huggingFaceIDForModel(modelID string, meta map[string]any) string {
+	if id, ok := meta[huggingFaceIDMetadataKey].(string); ok {
+		if id = strings.TrimSpace(id); id != "" {
+			return id
+		}
+	}
+	return modelID
+}
+
 // openRouterSlug returns the OpenRouter marketplace slug for a model: an
 // operator override from registry metadata ("openrouter_slug") if present,
 // otherwise the model id itself.
 //
 // OpenRouter's provider spec leaves the slug underspecified and its own example
-// sets slug == id, so the id (a globally-unique HuggingFace path) is a safe,
-// collision-free default. Operators map a model onto an existing marketplace
+// sets slug == id, so the globally unique model id is a safe, collision-free
+// default. Operators map a model onto an existing marketplace
 // slug (e.g. "qwen/qwen3.5-9b") explicitly via the openrouter_slug metadata
 // override / the admin openrouter-slug action.
 func openRouterSlug(modelID string, meta map[string]any) string {

--- a/docs/reference/model-registry-format.md
+++ b/docs/reference/model-registry-format.md
@@ -71,7 +71,7 @@ The publish script performs steps 1–3 and prints a sample `gh workflow run reg
 | `capabilities` | array | no | Capability strings |
 | `description` | string | no | |
 | `runtime_parameters` | object | no | Merged into provider request at dispatch |
-| `metadata` | object | no | Opaque metadata (deprecation date, OpenRouter slug, etc.) |
+| `metadata` | object | no | Opaque metadata (Hugging Face ID, deprecation date, OpenRouter slug, etc.) |
 | `promote` | bool | no | Immediately activate this version |
 | `input_price` | integer | yes | micro-USD per 1M tokens, > 0 |
 | `output_price` | integer | yes | micro-USD per 1M tokens, > 0 |
@@ -106,6 +106,12 @@ Stored as `ModelRegistryEntry` + `ModelVersion` + `ModelVersionFile` rows.
 | `description` | string | |
 | `runtime_parameters` | object | |
 | `metadata` | object | |
+
+When a concrete `model_id` is an internal routing identifier rather than a
+Hugging Face repository path, set `metadata.hugging_face_id` to the exact
+`owner/repository` identifier. `/v1/models` and `/v1/models/openrouter` emit
+that override as `hugging_face_id`; models without one continue to use
+`model_id`.
 
 Active versions are selected by `model_active_versions.model_version_id`. A model is routable when `model_registry.status IN ('active','beta')` AND `model_versions.status = 'ready'`.
 
@@ -155,6 +161,16 @@ The concrete build id is what is used for routing, billing, and serving; the pub
 | `capabilities` | `{ "capabilities": [...] }` | Replace capabilities wholesale |
 | `deprecation` | `{ "deprecation_date": "YYYY-MM-DD" }` | Set/clear deprecation metadata |
 | `openrouter-slug` | `{ "slug": "..." }` | Set/clear OpenRouter marketplace slug |
+| `hugging-face-id` | `{ "hugging_face_id": "owner/repository" }` | Set/clear the Hugging Face repository exposed by model feeds |
+
+For example, the Qwen3.6 internal build can be associated with its exact public
+artifact without changing the routing identifier:
+
+```json
+{
+  "hugging_face_id": "EigenLabs/Qwen3.6-35B-A3B-MLX-VL-4bit-g64-router8"
+}
+```
 
 ## Authentication for registry operations
 


### PR DESCRIPTION
## Summary

- add a registry metadata override for the exact Hugging Face repository behind an internal model ID
- emit the override from `/v1/models`, `/v1/models/openrouter`, catalog responses, and public alias entries
- add an authenticated `hugging-face-id` admin action for updating existing registry rows without changing routing IDs
- retain the current model-ID fallback for legacy rows

## Before

```mermaid
flowchart LR
  subgraph Behavior
    A[OpenRouter requests model list] --> B[Coordinator builds model entry]
    B --> C[hugging_face_id equals internal routing ID]
    C --> D[OpenRouter cannot resolve custom artifact]
  end

  subgraph Code
    E[handleListModelsOpenRouter] --> F[HuggingFaceID set to id or primary]
    G[handleListModels] --> H[HuggingFaceID set to model ID]
    F --> I[Registry metadata ignored]
    H --> I
  end
```

## After

```mermaid
flowchart LR
  subgraph Behavior
    A[Admin sets exact Hugging Face repository] --> B[metadata.hugging_face_id]
    C[OpenRouter requests model list] --> D[Coordinator builds raw or alias entry]
    B --> D
    D --> E[Exact EigenLabs repository returned]
    D --> F[Model ID fallback when override absent]
  end

  subgraph Code
    G[hugging-face-id admin action] --> H[Persist registry metadata]
    I[OpenRouter standard and catalog mappers] --> J[huggingFaceIDForModel]
    H --> J
    J --> K[Metadata override]
    J --> L[Concrete model ID fallback]
  end
```

## Qwen3.6 configuration after deploy

```http
POST /v1/admin/models/qwen3.6-35b-a3b-vl-mtp-mxfp8/hugging-face-id
Content-Type: application/json

{
  "hugging_face_id": "EigenLabs/Qwen3.6-35B-A3B-MLX-VL-4bit-g64-router8"
}
```

Production mutation remains a human-only post-deploy operation.

## Verification

- `cd coordinator && go test ./api`
- focused raw-model, alias, and admin-action model feed tests
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/620"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789254983&installation_model_id=21733&pr_number=620&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F620&signature=7b8f35daca4b1914509950b364b5f62dd88f7aa462e6a669c123efd4b7f87d1a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->