### PR TITLE
Allow human-approved agents to operate production

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -167,8 +167,9 @@ make clean                    # remove built artifacts
 Canonical runbook: `docs/operations/coordinator-deploy.md`
 
 Production GCP deploys, VM/container/service/config/secret mutations, and traffic
-changes are human-only. Agents may prepare and push reviewed code when asked,
-and may perform read-only health inspection.
+changes require explicit human approval for the specific operation. A human
+operator or human-approved agent may execute them. Without that approval, agents
+may only prepare and push reviewed code and perform read-only health inspection.
 
 Current release-sensitive pieces:
 
@@ -180,14 +181,14 @@ Current release-sensitive pieces:
 - Provider update checks read the latest registered release from the store (CI registers via `POST /v1/releases`). The installer and `darkbloom update` hit `GET /v1/releases/latest`, which returns **404 when no release row exists** — a missing/mis-registered release row breaks installs and self-updates and is fixed by registering the release, not by bumping code. `LatestProviderVersion` in `coordinator/api/server.go` is only the no-release-row fallback for the version *display* path and must stay in sync with `ProviderCore.version`.
 - CI release workflow (`release-swift.yml`) signs binaries with Developer ID Application cert, notarizes with Apple, computes SHA-256 hashes after signing, embeds provisioning profile in .app bundle.
 
-Production coordinator build and human deploy:
+Production coordinator build and human-approved deploy:
 
 ```bash
 # The repository trigger builds/pushes the exact master commit. Direct local
 # gcloud builds submit is rejected by the production config.
 git push origin master
 gcloud builds list --project=darkbloom-mainnet --limit=5
-# The human container-swap procedure is in the runbook.
+# The human-approved container-swap procedure is in the runbook.
 curl https://api.darkbloom.dev/health
 ```
 

--- a/docs/developer/release.md
+++ b/docs/developer/release.md
@@ -31,9 +31,9 @@ verifier layout or be privileged-installed by CI/the ordinary installer.
 ## Coordinator release
 
 Production and dev both run on GCP in separate projects. Production is the
-human-operated `darkbloom-mainnet` GCE deployment; dev is `sepolia-ai`.
+approval-gated `darkbloom-mainnet` GCE deployment; dev is `sepolia-ai`.
 
-### Prod (GCP, human-only)
+### Prod (GCP, human approval required)
 
 ```bash
 git push origin master
@@ -43,8 +43,9 @@ gcloud builds list --project=darkbloom-mainnet --limit=5
 The repository trigger uses `deploy/gcp/cloudbuild-prod.yaml` and binds the
 uploaded source, OCI revision label, and image tag to `COMMIT_SHA` /
 `SHORT_SHA`. Direct `gcloud builds submit` from a local tree is rejected. The
-trigger builds and pushes only; a human performs the container swap from
-[`operations/coordinator-deploy.md`](../operations/coordinator-deploy.md).
+trigger builds and pushes only; a human operator or explicitly human-approved
+agent performs the container swap from
+[operations/coordinator-deploy.md](../operations/coordinator-deploy.md).
 
 ### Dev (GCP)
 

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -16,15 +16,17 @@ Runbooks are written for operators. For architecture and security context, see t
 | [`coordinator-deploy.md`](coordinator-deploy.md) | Build and deploy the coordinator (Go) and provider CLI (Swift) | Infra / release engineer |
 | [`dev-environment.md`](dev-environment.md) | Stand up and operate the GCP dev environment | Infra engineer |
 | [`model-migration.md`](model-migration.md) | Zero-downtime model alias / build cutover | Model ops / on-call |
-| [`state-export.md`](state-export.md) | Extract and rehydrate sealed coordinator state (`DAR-70`) | Infra engineer (human-only) |
-| [`eigencloud-to-gcp-migration.md`](eigencloud-to-gcp-migration.md) | Move prod from EigenCloud to a GCP Confidential VM | Infra engineer (human-only) |
+| [`state-export.md`](state-export.md) | Extract and rehydrate sealed coordinator state (`DAR-70`) | Infra engineer / human-approved agent |
+| [`eigencloud-to-gcp-migration.md`](eigencloud-to-gcp-migration.md) | Move prod from EigenCloud to a GCP Confidential VM | Infra engineer / human-approved agent |
 | [`m5-stress-runbook.md`](m5-stress-runbook.md) | Archived pre-v0.7.5 SSD soak; do not use for EngineV2 | Historical reference |
 
 ## Safety rules that apply to every runbook
 
 1. **Production GCP deploys, Secret Manager, VM/container/service/config,
-   database, DNS, traffic, and release registration are human-only.** AI agents
-   may prepare commands; a human executes anything that mutates prod.
+   database, DNS, traffic, and release registration require explicit human
+   approval for the specific operation.** A human operator or human-approved
+   agent may execute them. Without that approval, AI agents may only prepare
+   commands and perform read-only production inspection.
 2. **The code is the source of truth.** Claims cite canonical file paths and line ranges where possible.
 3. **Privacy model** (from [`docs/AGENTS.md`](../AGENTS.md)):
    - Consumer → coordinator: TLS by default; optional NaCl Box.

--- a/docs/operations/coordinator-deploy.md
+++ b/docs/operations/coordinator-deploy.md
@@ -342,11 +342,12 @@ sudo sh -c 'umask 077
 ### 3. Env changes (if any)
 
 The current host was observed with `/etc/d-inference` mounted as tmpfs, so most
-backups and the live file would disappear on reboot. A human must migrate it to
-the boot disk once before using the refresh script:
+backups and the live file would disappear on reboot. An operator with explicit
+human approval must migrate it to the boot disk once before using the refresh
+script:
 
 ```bash
-# Human-only on the production VM. Preserve ownership and mode.
+# Human operator or explicitly human-approved agent only. Preserve ownership and mode.
 sudo install -d -m 0700 /var/lib/darkbloom-env
 sudo cp -p /etc/d-inference/env /var/lib/darkbloom-env/env
 sudo umount /etc/d-inference

--- a/docs/operations/dev-environment.md
+++ b/docs/operations/dev-environment.md
@@ -213,9 +213,9 @@ gcloud sql instances delete d-inference-dev-db --quiet
 
 ## What dev does *not* cover
 
-- **Production's manually managed container swap.** Dev uses a systemd restart;
-  production uses a human-controlled drain, fallback-container swap, and host
-  Caddy maintenance marker.
+- **Production's approval-gated container swap.** Dev uses a systemd restart;
+  production uses an explicitly human-approved drain, fallback-container swap,
+  and host Caddy maintenance marker.
 - **External user traffic.** Dev is team-only; admin emails are gated to `gajesh@eigenlabs.org` by default.
 - **In-memory mode data loss.** If `EIGENINFERENCE_DATABASE_URL` is unset, the coordinator resets state on every deploy. To re-register the current release and grant test credits after a redeploy, run `scripts/admin.sh EIGENINFERENCE_COORDINATOR_URL=https://api.dev.darkbloom.xyz releases latest`.
 

--- a/docs/operations/model-migration.md
+++ b/docs/operations/model-migration.md
@@ -2,7 +2,7 @@
 
 How to move a public model name from one build (quant) to another with **no downtime** and **without consumers ever seeing the quant** — using the model alias desired-build pointer and the provider's declarative self-reconcile.
 
-> **AI agents: do not run any of these against prod.** Publishing to R2, registering on the prod coordinator, and flipping a prod alias are human-only actions. Validate on a throwaway/dev coordinator first. This runbook is the hand-off.
+> **Production execution requires explicit human approval for the specific operation.** A human operator or human-approved agent may publish to R2, register on the prod coordinator, and flip a prod alias. Validate on a throwaway/dev coordinator first.
 
 ## How it works
 

--- a/docs/operations/state-export.md
+++ b/docs/operations/state-export.md
@@ -2,7 +2,7 @@
 
 How the admin-gated `/v1/admin/state-export` endpoint works end-to-end, and the exact operator flow to extract the TEE-sealed coordinator state and rehydrate it on a target machine (e.g. a GCP Confidential VM).
 
-> **AI agents must NOT run this against prod.** Enabling the endpoint, deploying the export build, and running the extraction are **human-only** actions. This doc prepares the commands; a human executes them.
+> **Production execution requires explicit human approval for the specific operation.** A human operator or human-approved agent may enable the endpoint, deploy the export build, and run the extraction. Without approval, this document is command preparation only.
 
 ## What this solves
 
@@ -43,7 +43,7 @@ age-keygen -o dar70-export-identity.txt
 
 Keep `dar70-export-identity.txt` (the private identity) offline. Only the `age1...` **public** recipient goes to the coordinator.
 
-### 1. Enable the endpoint on the source coordinator (human-only)
+### 1. Enable the endpoint on the source coordinator (human approval required)
 
 Set via the source coordinator's KMS/env and redeploy the build that contains the endpoint:
 
@@ -96,7 +96,7 @@ sudo chmod 600 /mnt/disks/userdata/micromdm/push.key
 
 Inject `MNEMONIC` (byte-identical) and the rest of the secret set into the target KMS/Secret Manager, then start the coordinator. **Do not start the coordinator before the tree is in place** — `start.sh` would generate fresh MicroMDM state and you would have to re-export.
 
-### 5. Disable the endpoint (human-only)
+### 5. Disable the endpoint (human approval required)
 
 Immediately after a successful extraction:
 

--- a/docs/releases/v0.8.0-notes.md
+++ b/docs/releases/v0.8.0-notes.md
@@ -493,9 +493,9 @@ production, investigation-only otherwise.
       past, and production hides it: production reads the releases table, so a
       stale fallback only misleads dev and in-memory coordinators.)
 - [x] Gate evidence recorded in `docs/reports/2026-07-25-paged-gate-results.md`
-- [ ] **Operator action §1 applied to `/etc/d-inference/env`** — human-approved,
-      not agent-applied. The chip-class-scoped solo seed does NOT reach the VM
-      through any automatic path.
+- [ ] **Operator action §1 applied to `/etc/d-inference/env`** — explicit human
+      approval required; a human-approved agent may apply it. The chip-class-
+      scoped solo seed does NOT reach the VM through any automatic path.
 - [ ] Fold this file into `CHANGELOG.md` at release time (that section is
       commit-derived and currently dated Apr 26 – May 25 2026)
 - [ ] Register the release row: `POST /v1/releases`. `GET /v1/releases/latest`


### PR DESCRIPTION
## Summary

- require explicit human approval for each production operation instead of requiring a human operator to execute it personally
- permit either a human operator or a human-approved agent to perform the approved mutation
- retain the preparation/read-only boundary for agents without explicit approval
- synchronize the canonical policy across deployment, model migration, state export, release, and historical rollout documentation

## Before

```mermaid
flowchart LR
  subgraph Behavior
    A[Production mutation requested] --> B{Executor is an agent?}
    B -->|Yes| C[Mutation blocked even with human approval]
    B -->|No| D[Human executes operation]
  end

  subgraph Policy_and_docs
    E[AGENTS.md: human-only] --> F[Operations README]
    F --> G[Deploy migration and export runbooks prohibit agent execution]
  end
```

## After

```mermaid
flowchart LR
  subgraph Behavior
    A[Production mutation requested] --> B{Explicit human approval for this operation?}
    B -->|No| C[Agent limited to preparation and read-only inspection]
    B -->|Yes| D[Human operator or human-approved agent executes]
  end

  subgraph Policy_and_docs
    E[AGENTS.md: operation-specific approval] --> F[Operations README]
    F --> G[Deploy migration export and release docs use the same rule]
  end
```

## Scope

Documentation and agent-policy change only. No production drain, deployment, configuration change, or other runtime mutation was performed.

## Verification

- `git diff --check`
- searched tracked operational documentation for stale `human-only`, production agent-prohibition, `human-controlled drain`, and `not agent-applied` wording; no matches
- pre-push checks passed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/622"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789257739&installation_model_id=21733&pr_number=622&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F622&signature=829090cb570740e2917e6d2d62f1785f167e1b8b7e0597548f9c772c2cbd6c75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->