### PR TITLE
fix: honor disabled reasoning on Qwen3.6 35B

### DIFF
--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -835,6 +835,7 @@ func (s *Server) dispatchOneProvider(
 		ErrorCh:                make(chan protocol.InferenceErrorMessage, 1),
 		Timing:                 timing,
 	}
+	stampReasoningPolicy(pr, rawBody)
 
 	// Public inference routes (not self-route / prefer-owner) enforce the
 	// OpenRouter TTFT ceiling inside the scheduler. This makes the preflight
@@ -2009,6 +2010,7 @@ func (s *Server) handleStreamingResponseWithFirstChunk(w http.ResponseWriter, r 
 		} else {
 			if !sawResponsesAPI {
 				firstChunk = normalizeSSEChunk(firstChunk)
+				firstChunk = maybeStripReasoningSSE(firstChunk, pr.SuppressReasoningOutput)
 			}
 			firstChunk = rewriteChunkModel(firstChunk, pr)
 			fmt.Fprintf(w, "%s\n\n", firstChunk)
@@ -2157,6 +2159,7 @@ func (s *Server) handleStreamingResponseWithFirstChunk(w http.ResponseWriter, r 
 			}
 			if !sawResponsesAPI {
 				chunk = normalizeSSEChunk(chunk)
+				chunk = maybeStripReasoningSSE(chunk, pr.SuppressReasoningOutput)
 				// Hold the chunk carrying the terminal finish_reason so it can be
 				// corrected to "length" against the authoritative token counts at
 				// stream end (the provider engine always reports "stop").
@@ -2350,6 +2353,9 @@ func (s *Server) handleNonStreamingResponseWithFirstChunk(w http.ResponseWriter,
 							}
 							if objType == "chat.completion" {
 								normalizeCompleteChatResponse(obj, consumerModel(pr))
+								if pr.SuppressReasoningOutput {
+									stripReasoningFromCompleteResponse(obj)
+								}
 								// The provider engine reports "stop" even when generation
 								// hit the max-tokens bound — correct it from the
 								// authoritative token counts.
@@ -2415,6 +2421,9 @@ func (s *Server) handleNonStreamingResponseWithFirstChunk(w http.ResponseWriter,
 
 				// Fallback: SSE delta chunks — reconstruct into response.
 				msg := extractMessage(chunks)
+				if pr.SuppressReasoningOutput {
+					msg.Reasoning = ""
+				}
 				select {
 				case usage, ok := <-pr.CompleteCh:
 					if !ok {
@@ -3151,6 +3160,9 @@ func finalizeFinishChunk(obj map[string]any, usage protocol.UsageInfo, pr *regis
 	}
 	if pr.PublicModel != "" && pr.PublicModel != pr.Model {
 		obj["model"] = pr.PublicModel
+	}
+	if pr.SuppressReasoningOutput {
+		stripReasoningFromCompleteResponse(obj)
 	}
 	b, err := json.Marshal(obj)
 	if err != nil {
@@ -4009,6 +4021,7 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 		ErrorCh:              make(chan protocol.InferenceErrorMessage, 1),
 		Timing:               timing,
 	}
+	pr.SuppressReasoningOutput = parseReasoningRequest(parsed).SuppressOutput
 	// Public inference routes (not self-route / prefer-owner) enforce the
 	// OpenRouter TTFT ceiling inside the scheduler. This makes the preflight
 	// check authoritative: the router cannot select a provider whose estimated

--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -2403,6 +2403,9 @@ func (s *Server) handleNonStreamingResponseWithFirstChunk(w http.ResponseWriter,
 								// Native passthrough (object=="response"): the provider
 								// echoed the concrete build id; rewrite it to the public
 								// alias so the consumer never sees the quant/build.
+								if pr.SuppressReasoningOutput {
+									stripReasoningFromCompleteResponse(obj)
+								}
 								sanitizeCacheDetailIntoRawResponsesUsage(obj, completeUsage)
 								if pr.PublicModel != "" {
 									obj["model"] = consumerModel(pr)

--- a/coordinator/api/consumer_normalize_test.go
+++ b/coordinator/api/consumer_normalize_test.go
@@ -175,6 +175,14 @@ func TestNormalizeCompleteChatResponse(t *testing.T) {
 	if !strings.Contains(reasoning, "existing reasoning") || !strings.Contains(reasoning, "work through it") {
 		t.Fatalf("reasoning was not merged correctly: %q", reasoning)
 	}
+
+	stripReasoningFromCompleteResponse(resp)
+	if _, ok := message["reasoning"]; ok {
+		t.Fatalf("suppressed reasoning should be deleted: %#v", message)
+	}
+	if message["content"] != "4" {
+		t.Fatalf("content after suppress = %q, want 4", message["content"])
+	}
 }
 
 func TestNormalizeCompleteChatResponseNullContent(t *testing.T) {

--- a/coordinator/api/dispatch.go
+++ b/coordinator/api/dispatch.go
@@ -1051,6 +1051,7 @@ func (d *dispatchState) dispatchPrimary() dispatchOutcome {
 			ErrorCh:                make(chan protocol.InferenceErrorMessage, 1),
 			Timing:                 d.timing,
 		}
+		stampReasoningPolicy(queuePR, d.rawBody)
 		queuedReq := &registry.QueuedRequest{
 			RequestID:  d.requestID,
 			Model:      d.model,

--- a/coordinator/api/reasoning_request.go
+++ b/coordinator/api/reasoning_request.go
@@ -172,24 +172,48 @@ func stripReasoningFromSSEChunk(chunk string) string {
 }
 
 func stripReasoningFromCompleteResponse(obj map[string]any) {
-	choices, ok := obj["choices"].([]any)
+	if choices, ok := obj["choices"].([]any); ok {
+		for _, rawChoice := range choices {
+			choice, ok := rawChoice.(map[string]any)
+			if !ok {
+				continue
+			}
+			if message, ok := choice["message"].(map[string]any); ok {
+				delete(message, "reasoning")
+				delete(message, "reasoning_content")
+			}
+			if delta, ok := choice["delta"].(map[string]any); ok {
+				delete(delta, "reasoning")
+				delete(delta, "reasoning_content")
+			}
+		}
+	}
+	stripReasoningItemsFromOutput(obj)
+}
+
+// stripReasoningItemsFromOutput drops Responses-API reasoning items so a
+// native object=="response" passthrough cannot leak a think trace when
+// the caller disabled or excluded reasoning.
+func stripReasoningItemsFromOutput(obj map[string]any) {
+	output, ok := obj["output"].([]any)
 	if !ok {
 		return
 	}
-	for _, rawChoice := range choices {
-		choice, ok := rawChoice.(map[string]any)
+	filtered := make([]any, 0, len(output))
+	for _, raw := range output {
+		item, ok := raw.(map[string]any)
 		if !ok {
+			filtered = append(filtered, raw)
 			continue
 		}
-		if message, ok := choice["message"].(map[string]any); ok {
-			delete(message, "reasoning")
-			delete(message, "reasoning_content")
+		if typ, _ := item["type"].(string); typ == "reasoning" {
+			continue
 		}
-		if delta, ok := choice["delta"].(map[string]any); ok {
-			delete(delta, "reasoning")
-			delete(delta, "reasoning_content")
-		}
+		delete(item, "reasoning")
+		delete(item, "reasoning_content")
+		filtered = append(filtered, item)
 	}
+	obj["output"] = filtered
 }
 
 func stripReasoningFields(fields map[string]json.RawMessage) bool {

--- a/coordinator/api/reasoning_request.go
+++ b/coordinator/api/reasoning_request.go
@@ -1,0 +1,211 @@
+package api
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/eigeninference/d-inference/coordinator/registry"
+)
+
+// reasoningRequestPolicy is the coordinator-side decode of OpenRouter /
+// OpenAI reasoning controls. Qwen3.6's chat template thinks by default
+// unless enable_thinking is boolean false; OpenRouter disables reasoning
+// via several equivalent shapes (enabled=false, effort=none, max_tokens=0).
+// SuppressOutput is the consumer-visible contract: the reasoning field
+// length must be 0 when the caller disabled or excluded reasoning.
+type reasoningRequestPolicy struct {
+	ThinkingEnabled *bool
+	Effort          string
+	SuppressOutput  bool
+}
+
+func parseReasoningRequestFromBody(rawBody []byte) reasoningRequestPolicy {
+	parsed, err := decodeInferenceJSONObject(rawBody)
+	if err != nil {
+		return reasoningRequestPolicy{}
+	}
+	return parseReasoningRequest(parsed)
+}
+
+func parseReasoningRequest(parsed map[string]any) reasoningRequestPolicy {
+	var policy reasoningRequestPolicy
+	if parsed == nil {
+		return policy
+	}
+
+	if flag, ok := parsed["enable_thinking"].(bool); ok && !flag {
+		disabled := false
+		policy.ThinkingEnabled = &disabled
+	}
+	if kwargs, ok := parsed["chat_template_kwargs"].(map[string]any); ok {
+		if flag, ok := kwargs["enable_thinking"].(bool); ok && !flag {
+			disabled := false
+			policy.ThinkingEnabled = &disabled
+		}
+	}
+	if include, ok := parsed["include_reasoning"].(bool); ok && !include {
+		policy.SuppressOutput = true
+	}
+	if effort, ok := stringFromRequestValue(parsed["reasoning_effort"]); ok {
+		policy.Effort = effort
+		if isNoneReasoningEffort(effort) {
+			disabled := false
+			policy.ThinkingEnabled = &disabled
+		}
+	}
+	applyReasoningValue(parsed["reasoning"], &policy)
+	if policy.ThinkingEnabled != nil && !*policy.ThinkingEnabled {
+		policy.SuppressOutput = true
+	}
+	return policy
+}
+
+func stampReasoningPolicy(pr *registry.PendingRequest, rawBody []byte) {
+	if pr == nil {
+		return
+	}
+	pr.SuppressReasoningOutput = parseReasoningRequestFromBody(rawBody).SuppressOutput
+}
+
+func applyReasoningValue(value any, policy *reasoningRequestPolicy) {
+	switch typed := value.(type) {
+	case bool:
+		policy.ThinkingEnabled = &typed
+	case map[string]any:
+		if enabled, ok := typed["enabled"].(bool); ok {
+			policy.ThinkingEnabled = &enabled
+		}
+		if effort, ok := stringFromRequestValue(typed["effort"]); ok {
+			policy.Effort = effort
+			if isNoneReasoningEffort(effort) {
+				disabled := false
+				policy.ThinkingEnabled = &disabled
+			}
+		}
+		if exclude, ok := typed["exclude"].(bool); ok && exclude {
+			policy.SuppressOutput = true
+		}
+		if n, ok := intFromRequestValue(typed["max_tokens"]); ok && n == 0 {
+			disabled := false
+			policy.ThinkingEnabled = &disabled
+		}
+	}
+}
+
+func isNoneReasoningEffort(raw string) bool {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "none", "off", "disabled":
+		return true
+	default:
+		return false
+	}
+}
+
+func stringFromRequestValue(value any) (string, bool) {
+	text, ok := value.(string)
+	if !ok {
+		return "", false
+	}
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return "", false
+	}
+	return text, true
+}
+
+func stripReasoningFromSSEChunk(chunk string) string {
+	prefix := ""
+	line := chunk
+	if strings.HasPrefix(chunk, "data: ") {
+		prefix = "data: "
+		line = strings.TrimPrefix(chunk, "data: ")
+	}
+	if !strings.Contains(line, `"reasoning`) {
+		return chunk
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(line), &raw); err != nil {
+		return chunk
+	}
+	choicesRaw, ok := raw["choices"]
+	if !ok {
+		return chunk
+	}
+	var choices []map[string]json.RawMessage
+	if err := json.Unmarshal(choicesRaw, &choices); err != nil {
+		return chunk
+	}
+	changed := false
+	for i, choice := range choices {
+		for _, field := range []string{"delta", "message"} {
+			nestedRaw, ok := choice[field]
+			if !ok {
+				continue
+			}
+			var nested map[string]json.RawMessage
+			if err := json.Unmarshal(nestedRaw, &nested); err != nil {
+				continue
+			}
+			if stripReasoningFields(nested) {
+				encoded, err := json.Marshal(nested)
+				if err != nil {
+					continue
+				}
+				choices[i][field] = encoded
+				changed = true
+			}
+		}
+	}
+	if !changed {
+		return chunk
+	}
+	encodedChoices, err := json.Marshal(choices)
+	if err != nil {
+		return chunk
+	}
+	raw["choices"] = encodedChoices
+	out, err := json.Marshal(raw)
+	if err != nil {
+		return chunk
+	}
+	return prefix + string(out)
+}
+
+func stripReasoningFromCompleteResponse(obj map[string]any) {
+	choices, ok := obj["choices"].([]any)
+	if !ok {
+		return
+	}
+	for _, rawChoice := range choices {
+		choice, ok := rawChoice.(map[string]any)
+		if !ok {
+			continue
+		}
+		if message, ok := choice["message"].(map[string]any); ok {
+			delete(message, "reasoning")
+			delete(message, "reasoning_content")
+		}
+		if delta, ok := choice["delta"].(map[string]any); ok {
+			delete(delta, "reasoning")
+			delete(delta, "reasoning_content")
+		}
+	}
+}
+
+func stripReasoningFields(fields map[string]json.RawMessage) bool {
+	changed := false
+	for _, key := range []string{"reasoning", "reasoning_content"} {
+		if _, ok := fields[key]; ok {
+			delete(fields, key)
+			changed = true
+		}
+	}
+	return changed
+}
+
+func maybeStripReasoningSSE(chunk string, suppress bool) string {
+	if !suppress {
+		return chunk
+	}
+	return stripReasoningFromSSEChunk(chunk)
+}

--- a/coordinator/api/reasoning_request_test.go
+++ b/coordinator/api/reasoning_request_test.go
@@ -1,0 +1,138 @@
+package api
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/eigeninference/d-inference/coordinator/registry"
+)
+
+func TestParseReasoningRequestDisableShapes(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name     string
+		body     string
+		disabled bool
+		suppress bool
+	}{
+		{name: "unspecified", body: `{"model":"m","messages":[]}`, disabled: false, suppress: false},
+		{name: "enabled true", body: `{"reasoning":{"enabled":true}}`, disabled: false, suppress: false},
+		{name: "enabled false", body: `{"reasoning":{"enabled":false}}`, disabled: true, suppress: true},
+		{name: "effort none", body: `{"reasoning":{"effort":"none"}}`, disabled: true, suppress: true},
+		{name: "effort NONE", body: `{"reasoning":{"effort":"NONE"}}`, disabled: true, suppress: true},
+		{name: "reasoning_effort none", body: `{"reasoning_effort":"none"}`, disabled: true, suppress: true},
+		{name: "max_tokens 0", body: `{"reasoning":{"max_tokens":0}}`, disabled: true, suppress: true},
+		{name: "exclude true", body: `{"reasoning":{"exclude":true}}`, disabled: false, suppress: true},
+		{name: "include_reasoning false", body: `{"include_reasoning":false}`, disabled: false, suppress: true},
+		{name: "enable_thinking false", body: `{"enable_thinking":false}`, disabled: true, suppress: true},
+		{name: "chat_template_kwargs", body: `{"chat_template_kwargs":{"enable_thinking":false}}`, disabled: true, suppress: true},
+		{name: "reasoning bool false", body: `{"reasoning":false}`, disabled: true, suppress: true},
+		{name: "effort high", body: `{"reasoning":{"effort":"high"}}`, disabled: false, suppress: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			policy := parseReasoningRequestFromBody([]byte(tc.body))
+			gotDisabled := policy.ThinkingEnabled != nil && !*policy.ThinkingEnabled
+			if gotDisabled != tc.disabled {
+				t.Fatalf("disabled = %v, want %v (policy=%+v)", gotDisabled, tc.disabled, policy)
+			}
+			if policy.SuppressOutput != tc.suppress {
+				t.Fatalf("suppress = %v, want %v (policy=%+v)", policy.SuppressOutput, tc.suppress, policy)
+			}
+		})
+	}
+}
+
+func TestStripReasoningFromSSEChunk(t *testing.T) {
+	t.Parallel()
+	in := `data: {"choices":[{"delta":{"content":"hi","reasoning":"think","reasoning_content":"think"}}]}`
+	out := stripReasoningFromSSEChunk(in)
+	if strings.Contains(out, `"reasoning"`) || strings.Contains(out, `"reasoning_content"`) {
+		t.Fatalf("reasoning fields still present: %s", out)
+	}
+	if !strings.Contains(out, `"content":"hi"`) {
+		t.Fatalf("content was dropped: %s", out)
+	}
+	if !strings.HasPrefix(out, "data: ") {
+		t.Fatalf("data prefix lost: %s", out)
+	}
+}
+
+func TestStripReasoningFromCompleteResponse(t *testing.T) {
+	t.Parallel()
+	obj := map[string]any{
+		"choices": []any{
+			map[string]any{
+				"message": map[string]any{
+					"content":           "4",
+					"reasoning":         "2+2",
+					"reasoning_content": "2+2",
+				},
+			},
+		},
+	}
+	stripReasoningFromCompleteResponse(obj)
+	msg := obj["choices"].([]any)[0].(map[string]any)["message"].(map[string]any)
+	if _, ok := msg["reasoning"]; ok {
+		t.Fatal("reasoning should be deleted")
+	}
+	if _, ok := msg["reasoning_content"]; ok {
+		t.Fatal("reasoning_content should be deleted")
+	}
+	if msg["content"] != "4" {
+		t.Fatalf("content = %v", msg["content"])
+	}
+}
+
+func TestMaybeStripReasoningSSENoop(t *testing.T) {
+	t.Parallel()
+	in := `data: {"choices":[{"delta":{"reasoning":"x"}}]}`
+	if got := maybeStripReasoningSSE(in, false); got != in {
+		t.Fatalf("expected unchanged when suppress=false, got %s", got)
+	}
+}
+
+func TestNormalizeThenSuppressDropsAliasedReasoning(t *testing.T) {
+	t.Parallel()
+	in := `data: {"choices":[{"delta":{"reasoning_content":"leaked think"}}]}`
+	normalized := normalizeSSEChunk(in)
+	if !strings.Contains(normalized, `"reasoning"`) {
+		t.Fatalf("normalize should alias reasoning_content: %s", normalized)
+	}
+	stripped := maybeStripReasoningSSE(normalized, true)
+	if strings.Contains(stripped, `"reasoning"`) || strings.Contains(stripped, `"reasoning_content"`) {
+		t.Fatalf("suppressed chunk still has reasoning: %s", stripped)
+	}
+}
+
+func TestStampReasoningPolicy(t *testing.T) {
+	t.Parallel()
+	pr := &registry.PendingRequest{}
+	stampReasoningPolicy(pr, []byte(`{"reasoning":{"effort":"none"}}`))
+	if !pr.SuppressReasoningOutput {
+		t.Fatal("effort=none should stamp SuppressReasoningOutput")
+	}
+	pr2 := &registry.PendingRequest{}
+	stampReasoningPolicy(pr2, []byte(`{"reasoning":{"enabled":true}}`))
+	if pr2.SuppressReasoningOutput {
+		t.Fatal("enabled=true should not suppress")
+	}
+}
+
+func TestParseReasoningRequestPreservesJSONNumberZero(t *testing.T) {
+	t.Parallel()
+	raw := []byte(`{"reasoning":{"max_tokens":0}}`)
+	parsed, err := decodeInferenceJSONObject(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := parsed["reasoning"].(map[string]any)["max_tokens"].(json.Number); !ok {
+		t.Fatalf("max_tokens should stay json.Number, got %T", parsed["reasoning"].(map[string]any)["max_tokens"])
+	}
+	policy := parseReasoningRequest(parsed)
+	if policy.ThinkingEnabled == nil || *policy.ThinkingEnabled {
+		t.Fatalf("max_tokens 0 should disable thinking: %+v", policy)
+	}
+}

--- a/coordinator/api/reasoning_request_test.go
+++ b/coordinator/api/reasoning_request_test.go
@@ -23,6 +23,7 @@ func TestParseReasoningRequestDisableShapes(t *testing.T) {
 		{name: "effort NONE", body: `{"reasoning":{"effort":"NONE"}}`, disabled: true, suppress: true},
 		{name: "reasoning_effort none", body: `{"reasoning_effort":"none"}`, disabled: true, suppress: true},
 		{name: "max_tokens 0", body: `{"reasoning":{"max_tokens":0}}`, disabled: true, suppress: true},
+		{name: "max_tokens string 0", body: `{"reasoning":{"max_tokens":"0"}}`, disabled: true, suppress: true},
 		{name: "exclude true", body: `{"reasoning":{"exclude":true}}`, disabled: false, suppress: true},
 		{name: "include_reasoning false", body: `{"include_reasoning":false}`, disabled: false, suppress: true},
 		{name: "enable_thinking false", body: `{"enable_thinking":false}`, disabled: true, suppress: true},
@@ -104,6 +105,32 @@ func TestNormalizeThenSuppressDropsAliasedReasoning(t *testing.T) {
 	stripped := maybeStripReasoningSSE(normalized, true)
 	if strings.Contains(stripped, `"reasoning"`) || strings.Contains(stripped, `"reasoning_content"`) {
 		t.Fatalf("suppressed chunk still has reasoning: %s", stripped)
+	}
+}
+
+func TestStripReasoningFromNativeResponse(t *testing.T) {
+	t.Parallel()
+	obj := map[string]any{
+		"object": "response",
+		"output": []any{
+			map[string]any{"type": "reasoning", "id": "rs_1", "summary": []any{"think"}},
+			map[string]any{"type": "message", "content": "4", "reasoning": "2+2"},
+		},
+	}
+	stripReasoningFromCompleteResponse(obj)
+	output := obj["output"].([]any)
+	if len(output) != 1 {
+		t.Fatalf("output items = %d, want 1 message: %#v", len(output), output)
+	}
+	msg := output[0].(map[string]any)
+	if msg["type"] != "message" {
+		t.Fatalf("remaining item type = %v", msg["type"])
+	}
+	if _, ok := msg["reasoning"]; ok {
+		t.Fatal("message.reasoning should be deleted")
+	}
+	if msg["content"] != "4" {
+		t.Fatalf("content = %v", msg["content"])
 	}
 }
 

--- a/coordinator/api/request_introspection.go
+++ b/coordinator/api/request_introspection.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
 
 	"github.com/eigeninference/d-inference/coordinator/store"
@@ -52,6 +53,12 @@ func intFromRequestValue(v any) (int, bool) {
 			return 0, false
 		}
 		return int(n), true
+	case string:
+		n, err := strconv.Atoi(strings.TrimSpace(x))
+		if err != nil {
+			return 0, false
+		}
+		return n, true
 	default:
 		return 0, false
 	}

--- a/coordinator/api/responses_stream.go
+++ b/coordinator/api/responses_stream.go
@@ -205,7 +205,7 @@ func (e *responsesStreamEmitter) handleChunk(chunk string) {
 		if reasoning == "" {
 			reasoning = c.Delta.ReasoningContent
 		}
-		if reasoning != "" {
+		if reasoning != "" && (e.pr == nil || !e.pr.SuppressReasoningOutput) {
 			e.appendReasoning(reasoning)
 		}
 		if c.Delta.Content != "" {

--- a/coordinator/api/responses_stream_test.go
+++ b/coordinator/api/responses_stream_test.go
@@ -191,6 +191,44 @@ func TestResponsesStreamEmptyOutputSynthesizesMessage(t *testing.T) {
 	}
 }
 
+func TestResponsesStreamSuppressesReasoning(t *testing.T) {
+	rec := httptest.NewRecorder()
+	pr := &registry.PendingRequest{
+		RequestID:               "req-test",
+		RequestedMaxTokens:      100,
+		SuppressReasoningOutput: true,
+	}
+	e := newResponsesStreamEmitter(rec, rec, pr, "resp_test", 1700000000)
+	e.start()
+	e.handleChunk(`data: {"choices":[{"delta":{"reasoning":"secret think","content":"hi"}}]}`)
+	e.handleChunk(`data: {"choices":[{"delta":{},"finish_reason":"stop"}]}`)
+	e.finish(protocol.UsageInfo{PromptTokens: 5, CompletionTokens: 2})
+
+	events := parseSSEEvents(t, rec.Body.String())
+	for _, ev := range events {
+		if strings.Contains(ev.Type, "reasoning") {
+			t.Fatalf("suppressed stream leaked %s", ev.Type)
+		}
+	}
+	var completed map[string]any
+	for _, ev := range events {
+		if ev.Type == "response.completed" {
+			completed = ev.Data
+		}
+	}
+	if completed == nil {
+		t.Fatal("no response.completed event")
+	}
+	output := completed["response"].(map[string]any)["output"].([]any)
+	if len(output) != 1 {
+		t.Fatalf("output items = %d, want 1 message: %#v", len(output), output)
+	}
+	item := output[0].(map[string]any)
+	if item["type"] != "message" {
+		t.Fatalf("item type = %v, want message", item["type"])
+	}
+}
+
 func TestEffectiveFinishReasonTruncatedToolCalls(t *testing.T) {
 	usage := protocol.UsageInfo{PromptTokens: 5, CompletionTokens: 100}
 	if got := effectiveFinishReason("stop", true, usage, 100); got != "length" {

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -155,6 +155,12 @@ type PendingRequest struct {
 	// RequestedMaxTokens is the consumer's requested output budget (or a
 	// sensible default when omitted). It is used for backlog estimation.
 	RequestedMaxTokens int
+	// SuppressReasoningOutput is true when the caller disabled reasoning
+	// (enabled=false, effort=none, max_tokens=0) or asked to exclude the
+	// trace (exclude=true / include_reasoning=false). Response writers then
+	// drop reasoning / reasoning_content so a Qwen3.6 think-default cannot
+	// leak a non-empty reasoning field.
+	SuppressReasoningOutput bool
 	// MaxTTFTMs is an optional per-request TTFT ceiling in milliseconds.
 	// When > 0, the scheduler only selects providers whose estimated TTFT is
 	// <= MaxTTFTMs. Used by public inference routes to honor the public

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2VisionPrefill.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2VisionPrefill.swift
@@ -239,14 +239,23 @@ public enum EngineV2VisionPrefill {
     static func prepare(
         container: ModelContainer,
         request: OpenAIChatCompletionRequest,
-        reasoningEffort: String? = nil
+        reasoningControls: ReasoningControls = .unspecified
     ) async throws -> PreparedSubmission {
         // Same decode path as the legacy stream (same caps, same MediaError
         // surface). Inline video bytes stay in the UserInput's owned
         // memory-backed asset while processor preparation samples and
         // rasterizes its frames; no plaintext file exists to clean up.
+        //
+        // ReasoningControls MUST reach the processor template here.
+        // EigenLabs/Qwen3.6-35B-A3B-MLX-VL-4bit-g64-router8 thinks by
+        // default (`<think>\n`) unless `enable_thinking` is boolean false
+        // (official closed tail `<think>\n\n</think>\n\n`). Qwen VL freezes
+        // `CBv2PositionState` to this tokenized length — do not append a
+        // think-close after prepare.
         let userInput = try await MediaIngest.buildUserInput(
-            from: request, reasoningEffort: reasoningEffort)
+            from: request,
+            reasoningEffort: reasoningControls.effortForTemplate,
+            controls: reasoningControls)
         return try await container.perform(nonSendable: userInput) { ctx, userInput in
             let lmInput = try await ctx.processor.prepare(input: userInput)
             guard lmInput.image != nil || lmInput.video != nil else {
@@ -561,12 +570,13 @@ public enum EngineV2VisionPrefill {
 /// preparer so the full routing seam is exercisable without model weights.
 public struct EngineV2VisionPlumbing: Sendable {
     let prepare:
-        @Sendable (ModelContainer, OpenAIChatCompletionRequest, String?) async throws
+        @Sendable (ModelContainer, OpenAIChatCompletionRequest, ReasoningControls) async throws
             -> EngineV2VisionPrefill.PreparedSubmission
     let emitTelemetry: @Sendable (TelemetryEvent) -> Void
 
     init(
-        prepare: @escaping @Sendable (ModelContainer, OpenAIChatCompletionRequest, String?)
+        prepare:
+            @escaping @Sendable (ModelContainer, OpenAIChatCompletionRequest, ReasoningControls)
             async throws -> EngineV2VisionPrefill.PreparedSubmission,
         emitTelemetry: @escaping @Sendable (TelemetryEvent) -> Void
     ) {
@@ -575,9 +585,9 @@ public struct EngineV2VisionPlumbing: Sendable {
     }
 
     static let production = EngineV2VisionPlumbing(
-        prepare: { container, request, reasoningEffort in
+        prepare: { container, request, controls in
             try await EngineV2VisionPrefill.prepare(
-                container: container, request: request, reasoningEffort: reasoningEffort)
+                container: container, request: request, reasoningControls: controls)
         },
         emitTelemetry: { TelemetryClient.shared.emit($0) }
     )

--- a/provider-swift/Sources/ProviderCore/Inference/MediaIngest.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/MediaIngest.swift
@@ -261,6 +261,7 @@ public enum MediaIngest {
     static func buildUserInput(
         from request: OpenAIChatCompletionRequest,
         reasoningEffort: String? = nil,
+        controls: ReasoningControls = .unspecified,
         maxImagePixels: Int = Self.maxImagePixels,
         maxRequestImagePixels: Int = Self.maxRequestImagePixels,
         maxVideosPerRequest: Int = Self.maxVideosPerRequest,
@@ -292,7 +293,7 @@ public enum MediaIngest {
         return UserInput(
             chat: chatMessages,
             additionalContext: MultiModelBatchSchedulerEngine.templateAdditionalContext(
-                for: request, reasoningEffort: reasoningEffort))
+                for: request, reasoningEffort: reasoningEffort, controls: controls))
     }
 
 

--- a/provider-swift/Sources/ProviderCore/Inference/MultiModelBatchSchedulerEngine+Translation.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/MultiModelBatchSchedulerEngine+Translation.swift
@@ -16,14 +16,18 @@ extension MultiModelBatchSchedulerEngine {
 
     static func templateAdditionalContext(
         for request: OpenAIChatCompletionRequest,
-        reasoningEffort: String?
+        reasoningEffort: String?,
+        controls: ReasoningControls? = nil
     ) -> [String: any Sendable]? {
+        let resolved = (controls ?? .unspecified).merging(
+            requestEnabled: request.reasoning?.enabled,
+            effort: reasoningEffort)
         var context: [String: any Sendable] = [:]
-        if let reasoningEffort {
-            context["reasoning_effort"] = reasoningEffort
+        if let effort = resolved.effortForTemplate {
+            context["reasoning_effort"] = effort
         }
-        if let reasoningEnabled = request.reasoning?.enabled {
-            context["enable_thinking"] = reasoningEnabled
+        if let thinkingEnabled = resolved.thinkingEnabled {
+            context["enable_thinking"] = thinkingEnabled
         }
         return context.isEmpty ? nil : context
     }

--- a/provider-swift/Sources/ProviderCore/Inference/MultiModelBatchSchedulerEngine.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/MultiModelBatchSchedulerEngine.swift
@@ -77,6 +77,9 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
     /// allowed set is model-specific and lives in each model's Jinja
     /// template, so passing through is the format-agnostic choice.
     private let reasoningEffort: String?
+    /// Full OpenRouter reasoning decode (enabled / effort=none / max_tokens=0
+    /// / exclude). Drives `enable_thinking` and the thinking-off prompt closer.
+    private let reasoningControls: ReasoningControls
     /// Authenticated remote or configured local prefix-cache scope. Maps to
     /// `CBv2Request.cacheSalt` for both cache tiers.
     private let cacheScope: String
@@ -118,6 +121,7 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
         releaseModel: @escaping @Sendable (String) async -> Void = { _ in },
         defaultMaxTokens: Int = 4096,
         reasoningEffort: String? = nil,
+        reasoningControls: ReasoningControls = .unspecified,
         cacheScope: String = "",
         cacheEnabled: Bool = true,
         engineV2Logprobs: EngineV2LogprobsPlumbing? = nil,
@@ -131,6 +135,7 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
         self.releaseModel = releaseModel
         self.defaultMaxTokens = defaultMaxTokens
         self.reasoningEffort = reasoningEffort
+        self.reasoningControls = reasoningControls
         self.cacheScope = cacheScope
         self.cacheEnabled = cacheEnabled
         self.engineV2Logprobs = engineV2Logprobs
@@ -170,6 +175,7 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
         self.releaseModel = { _ in }
         self.defaultMaxTokens = defaultMaxTokens
         self.reasoningEffort = nil
+        self.reasoningControls = .unspecified
         self.cacheScope = ""
         self.cacheEnabled = true
         // The --local path serves SSE frames inside the upstream router, so
@@ -376,8 +382,16 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
                     // chat templating never renders tool specs, so the model
                     // is never prompted into tool-call syntax on either
                     // vision path.
+                    var visionPromptTokens = visionPrepared.promptTokens
+                    if reasoningControls.thinkingDisabled {
+                        visionPromptTokens = ReasoningPromptProbe.closeOpenThinkBlock(
+                            promptTokens: visionPromptTokens,
+                            encode: { tokenizer.inner.encode(text: $0, addSpecialTokens: false) },
+                            decodeTail: { tokenizer.inner.decode(tokenIds: $0, skipSpecialTokens: false) }
+                        )
+                    }
                     let upstream = await bridge.submitTokenized(
-                        promptTokens: visionPrepared.promptTokens,
+                        promptTokens: visionPromptTokens,
                         request: Self.translate(
                             openAIRequest: request, defaultMaxTokens: defaultMaxTokens,
                             logprobs: engineV2Logprobs != nil ? true : nil,
@@ -405,8 +419,9 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
                     let synthesizeThinkOpen = ReasoningPromptProbe.shouldSynthesizeThinkOpen(
                         reasoningParser: request.reasoningParser,
                         stream: request.stream,
-                        promptTokens: visionPrepared.promptTokens,
-                        decodeTail: { tokenizer.inner.decode(tokenIds: $0, skipSpecialTokens: false) }
+                        promptTokens: visionPromptTokens,
+                        decodeTail: { tokenizer.inner.decode(tokenIds: $0, skipSpecialTokens: false) },
+                        thinkingDisabled: reasoningControls.thinkingDisabled
                     )
                     return makeEventStream(
                         upstream: upstream,
@@ -511,7 +526,15 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
                 request: request,
                 tokenizer: tokenizer.inner,
                 modelType: modelType,
-                reasoningEffort: reasoningEffort)
+                reasoningEffort: reasoningEffort,
+                controls: reasoningControls)
+            if reasoningControls.thinkingDisabled {
+                promptTokens = ReasoningPromptProbe.closeOpenThinkBlock(
+                    promptTokens: promptTokens,
+                    encode: { tokenizer.inner.encode(text: $0, addSpecialTokens: false) },
+                    decodeTail: { tokenizer.inner.decode(tokenIds: $0, skipSpecialTokens: false) }
+                )
+            }
         } catch {
             emitToolConstraintTelemetry(
                 operation: "tool_constraint_compile_rejection",
@@ -531,7 +554,8 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
             reasoningParser: request.reasoningParser,
             stream: request.stream,
             promptTokens: promptTokens,
-            decodeTail: { tokenizer.inner.decode(tokenIds: $0, skipSpecialTokens: false) }
+            decodeTail: { tokenizer.inner.decode(tokenIds: $0, skipSpecialTokens: false) },
+            thinkingDisabled: reasoningControls.thinkingDisabled
         )
 
         // Resolve tool call format before submitting so a bad

--- a/provider-swift/Sources/ProviderCore/Inference/MultiModelBatchSchedulerEngine.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/MultiModelBatchSchedulerEngine.swift
@@ -197,6 +197,17 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
         self.allowInternalToolSchemaMetadata = false
     }
 
+    /// Merge sealed-body controls with the typed request so VL prepare and
+    /// the text-path closer see the same disable signal (`enabled=false`,
+    /// `effort=none`, out-of-band `reasoningEffort`).
+    private func resolvedReasoningControls(
+        for request: OpenAIChatCompletionRequest
+    ) -> ReasoningControls {
+        reasoningControls.merging(
+            requestEnabled: request.reasoning?.enabled,
+            effort: reasoningEffort)
+    }
+
     // MARK: - MLXServerEngine
 
     public func availableModels() async throws -> [MLXServerModel] {
@@ -359,8 +370,14 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
             if let bridge = engineV2Bridge {
                 let plumbing = engineV2Vision ?? .production
                 do {
+                    // Disable must be rendered by the VL chat template
+                    // (Qwen3.6: `enable_thinking=false` → closed think
+                    // block). Do not append think-close tokens after
+                    // prepare: Qwen VL freezes position IDs to that
+                    // tokenized length.
+                    let visionControls = resolvedReasoningControls(for: request)
                     let visionPrepared = try await plumbing.prepare(
-                        container, request, reasoningEffort)
+                        container, request, visionControls)
                     let visionRequestId = "req-\(UUID().uuidString.prefix(12))"
                     // Hand off memory accounting to the bridge BEFORE
                     // submit: the decode-phase peak this vision reservation
@@ -382,14 +399,7 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
                     // chat templating never renders tool specs, so the model
                     // is never prompted into tool-call syntax on either
                     // vision path.
-                    var visionPromptTokens = visionPrepared.promptTokens
-                    if reasoningControls.thinkingDisabled {
-                        visionPromptTokens = ReasoningPromptProbe.closeOpenThinkBlock(
-                            promptTokens: visionPromptTokens,
-                            encode: { tokenizer.inner.encode(text: $0, addSpecialTokens: false) },
-                            decodeTail: { tokenizer.inner.decode(tokenIds: $0, skipSpecialTokens: false) }
-                        )
-                    }
+                    let visionPromptTokens = visionPrepared.promptTokens
                     let upstream = await bridge.submitTokenized(
                         promptTokens: visionPromptTokens,
                         request: Self.translate(
@@ -421,7 +431,7 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
                         stream: request.stream,
                         promptTokens: visionPromptTokens,
                         decodeTail: { tokenizer.inner.decode(tokenIds: $0, skipSpecialTokens: false) },
-                        thinkingDisabled: reasoningControls.thinkingDisabled
+                        thinkingDisabled: visionControls.thinkingDisabled
                     )
                     return makeEventStream(
                         upstream: upstream,
@@ -519,7 +529,8 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
         }
 
         let toolSpecs = prepared.tools?.map { $0.toolSpec() }
-        let promptTokens: [Int]
+        let effectiveControls = resolvedReasoningControls(for: request)
+        var promptTokens: [Int]
         do {
             promptTokens = try ProviderPromptContractPipeline.tokenize(
                 prepared: prepared,
@@ -527,8 +538,8 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
                 tokenizer: tokenizer.inner,
                 modelType: modelType,
                 reasoningEffort: reasoningEffort,
-                controls: reasoningControls)
-            if reasoningControls.thinkingDisabled {
+                controls: effectiveControls)
+            if effectiveControls.thinkingDisabled {
                 promptTokens = ReasoningPromptProbe.closeOpenThinkBlock(
                     promptTokens: promptTokens,
                     encode: { tokenizer.inner.encode(text: $0, addSpecialTokens: false) },
@@ -555,7 +566,7 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
             stream: request.stream,
             promptTokens: promptTokens,
             decodeTail: { tokenizer.inner.decode(tokenIds: $0, skipSpecialTokens: false) },
-            thinkingDisabled: reasoningControls.thinkingDisabled
+            thinkingDisabled: effectiveControls.thinkingDisabled
         )
 
         // Resolve tool call format before submitting so a bad

--- a/provider-swift/Sources/ProviderCore/Inference/ProviderPromptContractPipeline.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/ProviderPromptContractPipeline.swift
@@ -9,14 +9,15 @@ enum ProviderPromptContractPipeline {
         modelType: String?
     ) throws -> [Int] {
         let request = try ProviderLoop.decodeOpenAIRequest(body)
-        let reasoningEffort = ProviderLoop.extractReasoningEffort(from: body)
+        let controls = ReasoningControls.parse(from: body)
         let prepared = try ToolChoicePromptPolicy.prepare(request)
         return try tokenize(
             prepared: prepared,
             request: request,
             tokenizer: tokenizer,
             modelType: modelType,
-            reasoningEffort: reasoningEffort)
+            reasoningEffort: controls.effortForTemplate,
+            controls: controls)
     }
 
     static func tokenize(
@@ -24,7 +25,8 @@ enum ProviderPromptContractPipeline {
         request: OpenAIChatCompletionRequest,
         tokenizer: any MLXLMCommon.Tokenizer,
         modelType: String?,
-        reasoningEffort: String?
+        reasoningEffort: String?,
+        controls: ReasoningControls = .unspecified
     ) throws -> [Int] {
         let messages = prepared.messages.map { $0.templateMessageDict() }
         let tools = prepared.tools?.map { $0.toolSpec() }
@@ -36,6 +38,7 @@ enum ProviderPromptContractPipeline {
             tools: ChatTemplateFixes.normalizeTools(tools, context: context),
             additionalContext: MultiModelBatchSchedulerEngine.templateAdditionalContext(
                 for: request,
-                reasoningEffort: reasoningEffort))
+                reasoningEffort: reasoningEffort,
+                controls: controls))
     }
 }

--- a/provider-swift/Sources/ProviderCore/Inference/ReasoningControls.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/ReasoningControls.swift
@@ -1,0 +1,159 @@
+// Copyright © 2026 Eigen Labs.
+//
+// OpenRouter / OpenAI reasoning-request normalization.
+//
+// Qwen3.6's published chat template (EigenLabs/Qwen3.6-35B-A3B-MLX-VL-4bit-g64-router8)
+// pre-opens `<think>` unless `enable_thinking` is defined AND boolean false:
+//
+//     {%- if enable_thinking is defined and enable_thinking is false %}
+//         {{- '<think>\n\n</think>\n\n' }}
+//     {%- else %}
+//         {{- '<think>\n' }}
+//     {%- endif %}
+//
+// OpenRouter's disable shapes are broader than `reasoning.enabled=false`.
+// This type is the single decode of every disable / exclude signal we accept
+// so the template switch, the prompt-tail closer, and the response strip
+// cannot drift.
+
+import Foundation
+
+struct ReasoningControls: Sendable, Equatable {
+    /// `nil` means the caller did not choose — the template keeps its default
+    /// (thinking ON for Qwen3.6).
+    var thinkingEnabled: Bool?
+    /// OpenRouter / OpenAI effort string (`low`/`medium`/`high`/`none`/…).
+    var effort: String?
+    /// Think internally but omit the trace from the response (`exclude: true`
+    /// or `include_reasoning: false`).
+    var excludeFromResponse: Bool
+
+    static let unspecified = ReasoningControls()
+
+    var thinkingDisabled: Bool { thinkingEnabled == false }
+
+    /// Drop `reasoning` / `reasoning_content` from the consumer-visible body.
+    var suppressOutput: Bool { thinkingDisabled || excludeFromResponse }
+
+    /// Effort value that is safe to inject into a chat template. `"none"` is
+    /// omitted — Harmony / gpt-oss templates do not define that level, and
+    /// disable is already expressed via `enable_thinking=false`.
+    var effortForTemplate: String? {
+        guard let effort, !Self.isNoneEffort(effort) else { return nil }
+        return effort
+    }
+
+    init(
+        thinkingEnabled: Bool? = nil,
+        effort: String? = nil,
+        excludeFromResponse: Bool = false
+    ) {
+        self.thinkingEnabled = thinkingEnabled
+        self.effort = effort
+        self.excludeFromResponse = excludeFromResponse
+    }
+
+    func merging(requestEnabled: Bool?, effort: String?) -> ReasoningControls {
+        var merged = self
+        if merged.thinkingEnabled == nil {
+            merged.thinkingEnabled = requestEnabled
+        }
+        if merged.effort == nil {
+            merged.effort = Self.trimmed(effort)
+        }
+        if let mergedEffort = merged.effort, Self.isNoneEffort(mergedEffort) {
+            merged.thinkingEnabled = false
+        }
+        return merged
+    }
+
+    static func parse(from data: Data) -> ReasoningControls {
+        guard let object = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any] else {
+            return .unspecified
+        }
+        return parse(object: object)
+    }
+
+    static func parse(object: [String: Any]) -> ReasoningControls {
+        var controls = ReasoningControls()
+
+        if let flag = object["enable_thinking"] as? Bool, flag == false {
+            controls.thinkingEnabled = false
+        }
+        if let kwargs = object["chat_template_kwargs"] as? [String: Any],
+            let flag = kwargs["enable_thinking"] as? Bool, flag == false
+        {
+            controls.thinkingEnabled = false
+        }
+
+        if let includeReasoning = object["include_reasoning"] as? Bool, includeReasoning == false {
+            controls.excludeFromResponse = true
+        }
+
+        if let effort = trimmed(object["reasoning_effort"] as? String) {
+            controls.effort = effort
+            if isNoneEffort(effort) {
+                controls.thinkingEnabled = false
+            }
+        }
+
+        applyReasoningValue(object["reasoning"], to: &controls)
+        return controls
+    }
+
+    static func isNoneEffort(_ raw: String) -> Bool {
+        switch raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+        case "none", "off", "disabled":
+            return true
+        default:
+            return false
+        }
+    }
+
+    private static func trimmed(_ raw: String?) -> String? {
+        guard let raw else { return nil }
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private static func applyReasoningValue(_ value: Any?, to controls: inout ReasoningControls) {
+        if let flag = value as? Bool {
+            controls.thinkingEnabled = flag
+            return
+        }
+        guard let object = value as? [String: Any] else { return }
+
+        if let enabled = object["enabled"] as? Bool {
+            controls.thinkingEnabled = enabled
+        }
+        if let effort = trimmed(object["effort"] as? String) {
+            controls.effort = effort
+            if isNoneEffort(effort) {
+                controls.thinkingEnabled = false
+            }
+        }
+        if let exclude = object["exclude"] as? Bool, exclude {
+            controls.excludeFromResponse = true
+        }
+        if maxTokensIsZero(object["max_tokens"]) {
+            controls.thinkingEnabled = false
+        }
+    }
+
+    private static func maxTokensIsZero(_ value: Any?) -> Bool {
+        switch value {
+        case let number as Int:
+            return number == 0
+        case let number as Int64:
+            return number == 0
+        case let number as Double:
+            return number == 0
+        case let number as NSNumber:
+            return number.intValue == 0 && number.doubleValue == 0
+        case let text as String:
+            return Int(text.trimmingCharacters(in: .whitespacesAndNewlines)) == 0
+        default:
+            return false
+        }
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Inference/ReasoningPromptProbe.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/ReasoningPromptProbe.swift
@@ -70,6 +70,10 @@ enum ReasoningPromptProbe {
     /// If thinking is disabled and the prompt tail is still inside an open
     /// think block, append the official close so the model continues in
     /// the answer channel instead of generating a reasoning trace.
+    ///
+    /// Text path only. Qwen VL freezes `CBv2PositionState` to the
+    /// processor token count — appending here would desync position IDs.
+    /// VL disable is rendered by the chat template (`enable_thinking=false`).
     static func closeOpenThinkBlock(
         promptTokens: [Int],
         encode: (String) -> [Int],

--- a/provider-swift/Sources/ProviderCore/Inference/ReasoningPromptProbe.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/ReasoningPromptProbe.swift
@@ -26,6 +26,13 @@ enum ReasoningPromptProbe {
     /// The synthetic opening marker injected into the event stream.
     static let thinkOpen = "<think>"
 
+    /// Tokens appended when thinking is disabled but the rendered prompt
+    /// still ends inside an open `<think>` (Jinja ignored `enable_thinking`,
+    /// or the disable shape never reached the template). Official Qwen3.6
+    /// thinking-off form is `<think>\n\n</think>\n\n`; prompts that already
+    /// end with `<think>\n` become that after this suffix.
+    static let thinkClose = "\n</think>\n\n"
+
     /// Prompt-tail tokens to decode for the probe. The open tag sits in
     /// the last few tokens of the rendered template
     /// (`<|im_start|>assistant\n<think>\n`), so 8 is generous while
@@ -50,12 +57,30 @@ enum ReasoningPromptProbe {
         reasoningParser: ReasoningParserFormat?,
         stream: Bool?,
         promptTokens: [Int],
-        decodeTail: ([Int]) -> String
+        decodeTail: ([Int]) -> String,
+        thinkingDisabled: Bool = false
     ) -> Bool {
+        guard !thinkingDisabled else { return false }
         guard reasoningParser == .qwen3 || reasoningParser == .deepseekR1 else { return false }
         guard stream == true else { return false }
         guard !promptTokens.isEmpty else { return false }
         return promptEndsInsideThinkBlock(decodeTail(Array(promptTokens.suffix(tailTokenCount))))
+    }
+
+    /// If thinking is disabled and the prompt tail is still inside an open
+    /// think block, append the official close so the model continues in
+    /// the answer channel instead of generating a reasoning trace.
+    static func closeOpenThinkBlock(
+        promptTokens: [Int],
+        encode: (String) -> [Int],
+        decodeTail: ([Int]) -> String
+    ) -> [Int] {
+        guard !promptTokens.isEmpty else { return promptTokens }
+        let tail = decodeTail(Array(promptTokens.suffix(tailTokenCount)))
+        guard promptEndsInsideThinkBlock(tail) else { return promptTokens }
+        let closeTokens = encode(thinkClose)
+        guard !closeTokens.isEmpty else { return promptTokens }
+        return promptTokens + closeTokens
     }
 
     /// True when the tail ends with an unclosed `<think>` (ignoring

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+InboundDecode.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+InboundDecode.swift
@@ -68,17 +68,20 @@ extension ProviderLoop {
     ///
     /// This lives outside `OpenAIChatCompletionRequest` (the upstream type
     /// doesn't model it), so we decode it directly. Returns a trimmed,
-    /// non-empty string or `nil`. The value is passed through verbatim —
-    /// the valid set (`low`/`medium`/`high` for gpt-oss; other models
-    /// differ) is enforced by each model's chat template, not here, so we
-    /// stay format-agnostic rather than hardcoding a per-model allowlist.
+    /// non-empty string or `nil`. `"none"` is omitted — that disable
+    /// signal is expressed via `enable_thinking=false` instead, and
+    /// Harmony templates do not define a `none` effort level.
+    /// Other values pass through verbatim so each model's chat template
+    /// can enforce its own allowlist.
     internal static func extractReasoningEffort(from data: Data) -> String? {
-        struct Probe: Decodable { let reasoning_effort: String? }
-        guard let probe = try? JSONDecoder().decode(Probe.self, from: data),
-              let raw = probe.reasoning_effort
-        else { return nil }
-        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
-        return trimmed.isEmpty ? nil : trimmed
+        extractReasoningControls(from: data).effortForTemplate
+    }
+
+    /// Full OpenRouter reasoning decode: `enabled`, `effort`, `max_tokens`,
+    /// `exclude`, top-level `enable_thinking` / `reasoning_effort`, and
+    /// `chat_template_kwargs.enable_thinking`.
+    internal static func extractReasoningControls(from data: Data) -> ReasoningControls {
+        ReasoningControls.parse(from: data)
     }
 
     /// OpenAI `logprobs` / `top_logprobs` for this request. Like
@@ -131,13 +134,14 @@ extension ProviderLoop {
     internal static func promptTokenFloor(
         request: OpenAIChatCompletionRequest,
         tokenizer: TokenizerHandle,
-        reasoningEffort: String?
+        reasoningEffort: String?,
+        controls: ReasoningControls = .unspecified
     ) -> Int {
         guard let prepared = try? ToolChoicePromptPolicy.prepare(request) else { return 0 }
         let messages = prepared.messages.map { $0.templateMessageDict() }
         let toolSpecs = prepared.tools?.map { $0.toolSpec() }
         let additionalContext = MultiModelBatchSchedulerEngine.templateAdditionalContext(
-            for: request, reasoningEffort: reasoningEffort)
+            for: request, reasoningEffort: reasoningEffort, controls: controls)
         // Must mirror the production tokenize path (sanitize JSON
         // null / Optional leaves) so this recount matches what was prefilled
         // and doesn't itself throw on a null-bearing request.

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+InferenceHandler.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+InferenceHandler.swift
@@ -221,13 +221,12 @@ extension ProviderLoop {
             return
         }
 
-        // `reasoning_effort` is not part of the upstream
-        // `OpenAIChatCompletionRequest` shape, so decode it directly from
-        // the request body and thread it into the chat template's render
-        // context below (see `MultiModelBatchSchedulerEngine`). gpt-oss /
-        // Harmony reads it to set the reasoning budget; other models
-        // ignore the extra template variable.
-        let reasoningEffort = Self.extractReasoningEffort(from: decryptedData)
+        // OpenRouter reasoning controls are not fully modeled on the
+        // upstream `OpenAIChatCompletionRequest` (only `enabled` is).
+        // Decode every disable/exclude shape from the sealed body and
+        // thread it into the chat template + thinking-off closer.
+        let reasoningControls = Self.extractReasoningControls(from: decryptedData)
+        let reasoningEffort = reasoningControls.effortForTemplate
         // Cache identity is coordinator-authored and authenticated outside the
         // sealed OpenAI body. Never trust caller-controlled prompt_cache_key/user
         // for remote cache partitioning. Legacy coordinators omit the outer
@@ -491,6 +490,7 @@ extension ProviderLoop {
                 releaseModel: { _ in },
                 defaultMaxTokens: Self.schedulerDefaultMaxTokens,
                 reasoningEffort: reasoningEffort,
+                reasoningControls: reasoningControls,
                 cacheScope: cacheScope,
                 cacheEnabled: remoteCache.cacheEnabled,
                 engineV2Logprobs: logprobsChannel.map {
@@ -695,9 +695,13 @@ extension ProviderLoop {
                             }
                         }
                         if let reasoning = parsed.reasoningDelta, !reasoning.isEmpty {
-                            fullResponseText += reasoning
-                            frameHadContent = true
-                            reasoningText += reasoning
+                            if reasoningControls.suppressOutput {
+                                frameToEmit = Self.stripReasoningFromStreamFrame(frameToEmit)
+                            } else {
+                                fullResponseText += reasoning
+                                frameHadContent = true
+                                reasoningText += reasoning
+                            }
                         }
                         if let toolCalls = parsed.toolCallsDelta, !toolCalls.isEmpty {
                             fullResponseText += Self.encodeToolCallsForHash(toolCalls)
@@ -857,7 +861,8 @@ extension ProviderLoop {
                 let terminal = partialUsage.cancelledTerminal(promptTokenFloor: Self.promptTokenFloor(
                     request: streamingRequest,
                     tokenizer: tokenizer,
-                    reasoningEffort: reasoningEffort
+                    reasoningEffort: reasoningEffort,
+                    controls: reasoningControls
                 ))
                 guard case .complete(let settledUsage) = terminal else {
                     // Cancelled with nothing delivered: 499 so the coordinator refunds.
@@ -912,7 +917,8 @@ extension ProviderLoop {
                     promptTokens = Self.promptTokenFloor(
                         request: streamingRequest,
                         tokenizer: tokenizer,
-                        reasoningEffort: reasoningEffort
+                        reasoningEffort: reasoningEffort,
+                        controls: reasoningControls
                     )
                     if promptTokens > 0 {
                         log.warning(

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+SSEParser.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+SSEParser.swift
@@ -198,6 +198,38 @@ extension ProviderLoop {
         return "data: \(json)\n\n"
     }
 
+    /// Drop `reasoning` / `reasoning_content` from an SSE frame when the
+    /// caller disabled or excluded reasoning. The hash domain then matches
+    /// the consumer-visible body.
+    internal static func stripReasoningFromStreamFrame(_ frame: String) -> String {
+        guard let payload = joinedDataPayload(frame),
+              let bytes = payload.data(using: .utf8),
+              var obj = (try? JSONSerialization.jsonObject(with: bytes)) as? [String: Any],
+              var choices = obj["choices"] as? [[String: Any]]
+        else {
+            return frame
+        }
+        var changed = false
+        for index in choices.indices {
+            for field in ["delta", "message"] {
+                guard var nested = choices[index][field] as? [String: Any] else { continue }
+                if nested.removeValue(forKey: "reasoning") != nil { changed = true }
+                if nested.removeValue(forKey: "reasoning_content") != nil { changed = true }
+                choices[index][field] = nested
+            }
+        }
+        guard changed else { return frame }
+        obj["choices"] = choices
+        guard let out = try? JSONSerialization.data(
+                withJSONObject: obj, options: [.sortedKeys, .withoutEscapingSlashes]
+              ),
+              let json = String(data: out, encoding: .utf8)
+        else {
+            return frame
+        }
+        return "data: \(json)\n\n"
+    }
+
     /// Inject `usage.prompt_tokens_details.cached_tokens` into a final SSE
     /// chunk that already carries a `usage` block — the OpenAI-standard
     /// surface for prompt-cache accounting, fed by the v2 engine's

--- a/provider-swift/Tests/ProviderCoreFoundationTests/Qwen36ThinkingTemplateTests.swift
+++ b/provider-swift/Tests/ProviderCoreFoundationTests/Qwen36ThinkingTemplateTests.swift
@@ -4,8 +4,9 @@ import Jinja
 @testable import ProviderCoreFoundation
 
 /// Pins the Qwen3.6 generation-prompt tail against the same Jinja engine
-/// the runtime tokenizer uses. The published EigenLabs artifact thinks
-/// unless `enable_thinking` is defined AND boolean false.
+/// the runtime tokenizer uses. Published artifact
+/// https://huggingface.co/EigenLabs/Qwen3.6-35B-A3B-MLX-VL-4bit-g64-router8
+/// thinks unless `enable_thinking` is defined AND boolean false.
 final class Qwen36ThinkingTemplateTests: XCTestCase {
 
     private let generationTail = """

--- a/provider-swift/Tests/ProviderCoreFoundationTests/Qwen36ThinkingTemplateTests.swift
+++ b/provider-swift/Tests/ProviderCoreFoundationTests/Qwen36ThinkingTemplateTests.swift
@@ -1,0 +1,65 @@
+import XCTest
+import Jinja
+
+@testable import ProviderCoreFoundation
+
+/// Pins the Qwen3.6 generation-prompt tail against the same Jinja engine
+/// the runtime tokenizer uses. The published EigenLabs artifact thinks
+/// unless `enable_thinking` is defined AND boolean false.
+final class Qwen36ThinkingTemplateTests: XCTestCase {
+
+    private let generationTail = """
+        {%- if add_generation_prompt %}
+            {{- '<|im_start|>assistant\\n' }}
+            {%- if enable_thinking is defined and enable_thinking is false %}
+                {{- '<think>\\n\\n</think>\\n\\n' }}
+            {%- else %}
+                {{- '<think>\\n' }}
+            {%- endif %}
+        {%- endif %}
+        """
+
+    func testDisabledThinkingClosesTheThinkBlock() throws {
+        let rendered = try render(enableThinking: false)
+        XCTAssertTrue(rendered.hasSuffix("<think>\n\n</think>\n\n"), rendered)
+        XCTAssertFalse(ReasoningPromptTail.endsInsideThinkBlock(rendered))
+    }
+
+    func testEnabledAndDefaultThinkingOpenTheThinkBlock() throws {
+        for enabled in [true, nil] as [Bool?] {
+            let rendered = try render(enableThinking: enabled)
+            XCTAssertTrue(
+                rendered.hasSuffix("<think>\n"),
+                "enable_thinking=\(String(describing: enabled)) rendered \(rendered)")
+            XCTAssertTrue(ReasoningPromptTail.endsInsideThinkBlock(rendered))
+        }
+    }
+}
+
+/// Mirrors `ReasoningPromptProbe.promptEndsInsideThinkBlock` so the
+/// Foundation-only suite can pin the Qwen3.6 tail without importing
+/// ProviderCore / MLX.
+enum ReasoningPromptTail {
+    static func endsInsideThinkBlock(_ tail: String) -> Bool {
+        var trimmed = Substring(tail)
+        while let last = trimmed.last, last.isWhitespace {
+            trimmed.removeLast()
+        }
+        return trimmed.hasSuffix("<think>")
+    }
+}
+
+extension Qwen36ThinkingTemplateTests {
+    fileprivate func render(enableThinking: Bool?) throws -> String {
+        let template = try Template(
+            normalizeSwiftJinjaTemplate(generationTail),
+            with: .init(lstripBlocks: true, trimBlocks: true))
+        var context: [String: Value] = [
+            "add_generation_prompt": .boolean(true),
+        ]
+        if let enableThinking {
+            context["enable_thinking"] = .boolean(enableThinking)
+        }
+        return try template.render(context)
+    }
+}

--- a/provider-swift/Tests/ProviderCoreTests/EngineV2VisionRoutingTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/EngineV2VisionRoutingTests.swift
@@ -218,13 +218,15 @@ private func makeRoutingEngine(
     bridge: EngineV2Bridge?,
     plumbing: EngineV2VisionPlumbing?,
     visionGate: VisionMemoryGate? = nil,
-    reasoningEffort: String? = nil
+    reasoningEffort: String? = nil,
+    reasoningControls: ReasoningControls = .unspecified,
+    tokenizer: TokenizerHandle = TokenizerHandle(VisionStubTokenizer())
 ) -> MultiModelBatchSchedulerEngine {
     MultiModelBatchSchedulerEngine(
         registryProvider: { @Sendable in
             [
                 "test/vlm-stub": .init(
-                    tokenizer: TokenizerHandle(VisionStubTokenizer()),
+                    tokenizer: tokenizer,
                     modelType: "gemma4",
                     container: container,
                     isVLM: true,
@@ -234,6 +236,7 @@ private func makeRoutingEngine(
         },
         defaultMaxTokens: 64,
         reasoningEffort: reasoningEffort,
+        reasoningControls: reasoningControls,
         engineV2Vision: plumbing
     )
 }
@@ -501,6 +504,15 @@ struct MediaKindClassificationTests {
         let input = try await MediaIngest.buildUserInput(
             from: request, reasoningEffort: "high")
         #expect(input.additionalContext?["reasoning_effort"] as? String == "high")
+    }
+
+    @Test("media processor honors sealed-body thinking disable")
+    func thinkingDisableTemplateContext() async throws {
+        let request = imageRequest()
+        let input = try await MediaIngest.buildUserInput(
+            from: request, controls: ReasoningControls(thinkingEnabled: false))
+        #expect(input.additionalContext?["enable_thinking"] as? Bool == false)
+        #expect(input.additionalContext?["reasoning_effort"] == nil)
     }
 
     @Test("image-only request has no video and classifies as .image")
@@ -1026,16 +1038,16 @@ struct EngineV2VisionRoutingTests {
         ]))
         let bridge = makeBridge(engine: engine)
         let (prepared, _) = makePreparedSubmission()
-        final class EffortBox: @unchecked Sendable {
+        final class ControlsBox: @unchecked Sendable {
             private let lock = NSLock()
-            private var value: String?
-            func set(_ newValue: String?) { lock.withLock { value = newValue } }
-            func get() -> String? { lock.withLock { value } }
+            private var value: ReasoningControls?
+            func set(_ newValue: ReasoningControls) { lock.withLock { value = newValue } }
+            func get() -> ReasoningControls? { lock.withLock { value } }
         }
-        let effort = EffortBox()
+        let box = ControlsBox()
         let plumbing = EngineV2VisionPlumbing(
-            prepare: { _, _, reasoningEffort in
-                effort.set(reasoningEffort)
+            prepare: { _, _, controls in
+                box.set(controls)
                 return prepared
             }, emitTelemetry: { _ in })
         let router = makeRoutingEngine(
@@ -1044,7 +1056,75 @@ struct EngineV2VisionRoutingTests {
 
         _ = try await collectContent(
             try await router.streamChatCompletion(request: imageRequest()))
-        #expect(effort.get() == "medium")
+        #expect(box.get()?.effortForTemplate == "medium")
+        #expect(box.get()?.thinkingDisabled == false)
+    }
+
+    @Test("vision plumbing receives thinking-disabled controls")
+    func visionPlumbingReceivesThinkingDisabled() async throws {
+        let engine = VisionScriptedEngine(script: .stream([
+            .finished(reason: .stop, usage: CBv2Usage(promptTokens: 6, completionTokens: 0))
+        ]))
+        let bridge = makeBridge(engine: engine)
+        let (prepared, _) = makePreparedSubmission()
+        final class ControlsBox: @unchecked Sendable {
+            private let lock = NSLock()
+            private var value: ReasoningControls?
+            func set(_ newValue: ReasoningControls) { lock.withLock { value = newValue } }
+            func get() -> ReasoningControls? { lock.withLock { value } }
+        }
+        let box = ControlsBox()
+        let plumbing = EngineV2VisionPlumbing(
+            prepare: { _, _, controls in
+                box.set(controls)
+                return prepared
+            }, emitTelemetry: { _ in })
+        let router = makeRoutingEngine(
+            container: makeStubContainer(), bridge: bridge, plumbing: plumbing,
+            reasoningControls: ReasoningControls(thinkingEnabled: false))
+
+        _ = try await collectContent(
+            try await router.streamChatCompletion(request: imageRequest()))
+        #expect(box.get()?.thinkingDisabled == true)
+    }
+
+    @Test("thinking-disabled vision submit keeps prepared token count")
+    func thinkingDisabledDoesNotAppendAfterVisionPrepare() async throws {
+        let engine = VisionScriptedEngine(script: .stream([
+            .finished(reason: .stop, usage: CBv2Usage(promptTokens: 6, completionTokens: 0))
+        ]))
+        let bridge = makeBridge(engine: engine)
+        let (prepared, _) = makePreparedSubmission()
+        let plumbing = EngineV2VisionPlumbing(
+            prepare: { _, _, _ in prepared },
+            emitTelemetry: { _ in })
+        // Tokenizer that would make closeOpenThinkBlock append tokens if
+        // the VL path still ran it after position freeze.
+        struct OpenThinkTokenizer: MLXLMCommon.Tokenizer {
+            func encode(text: String, addSpecialTokens: Bool) -> [Int] {
+                text.contains("</think>") ? [42, 43] : Array(repeating: 0, count: text.count)
+            }
+            func decode(tokenIds: [Int], skipSpecialTokens: Bool) -> String { "<think>\n" }
+            func convertTokenToId(_ token: String) -> Int? { nil }
+            func convertIdToToken(_ id: Int) -> String? { nil }
+            var bosToken: String? { nil }
+            var eosToken: String? { nil }
+            var unknownToken: String? { nil }
+            func applyChatTemplate(
+                messages: [[String: any Sendable]],
+                tools: [[String: any Sendable]]?,
+                additionalContext: [String: any Sendable]?
+            ) throws -> [Int] { [1, 2, 3] }
+        }
+        let router = makeRoutingEngine(
+            container: makeStubContainer(), bridge: bridge, plumbing: plumbing,
+            reasoningControls: ReasoningControls(thinkingEnabled: false),
+            tokenizer: TokenizerHandle(OpenThinkTokenizer()))
+
+        _ = try await collectContent(
+            try await router.streamChatCompletion(request: imageRequest()))
+        let submitted = try #require(engine.submitted.first)
+        #expect(submitted.promptTokens == prepared.promptTokens)
     }
 
     @Test("refusal on a video request tags media_kind video")

--- a/provider-swift/Tests/ProviderCoreTests/GemmaVLMVideoEngineV2LiveTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/GemmaVLMVideoEngineV2LiveTests.swift
@@ -280,9 +280,9 @@ struct GemmaVLMVideoEngineV2LiveTests {
     ) async throws -> (content: String, ttft: TimeInterval) {
         let recorder = VideoLiveRefusalRecorder()
         let plumbing = EngineV2VisionPlumbing(
-            prepare: { container, request, reasoningEffort in
+            prepare: { container, request, controls in
                 try await EngineV2VisionPrefill.prepare(
-                    container: container, request: request, reasoningEffort: reasoningEffort)
+                    container: container, request: request, reasoningControls: controls)
             },
             emitTelemetry: { recorder.append($0) }
         )

--- a/provider-swift/Tests/ProviderCoreTests/GemmaVLMVisionEngineV2LiveTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/GemmaVLMVisionEngineV2LiveTests.swift
@@ -171,9 +171,9 @@ struct GemmaVLMVisionEngineV2LiveTests {
     ) async throws -> String {
         let recorder = VisionLiveRefusalRecorder()
         let plumbing = EngineV2VisionPlumbing(
-            prepare: { container, request, reasoningEffort in
+            prepare: { container, request, controls in
                 try await EngineV2VisionPrefill.prepare(
-                    container: container, request: request, reasoningEffort: reasoningEffort)
+                    container: container, request: request, reasoningControls: controls)
             },
             emitTelemetry: { recorder.append($0) }
         )

--- a/provider-swift/Tests/ProviderCoreTests/InboundDecodeTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/InboundDecodeTests.swift
@@ -275,6 +275,13 @@ struct InboundDecodeTests {
         #expect(effort(#"{"model":"m","messages":[],"reasoning_effort":3}"#) == nil)
     }
 
+    @Test("reasoning.effort is extracted and none is omitted")
+    func nestedReasoningEffort() {
+        #expect(effort(#"{"model":"m","messages":[],"reasoning":{"effort":"high"}}"#) == "high")
+        #expect(effort(#"{"model":"m","messages":[],"reasoning":{"effort":"none"}}"#) == nil)
+        #expect(effort(#"{"model":"m","messages":[],"reasoning_effort":"none"}"#) == nil)
+    }
+
     // MARK: - logprobs / top_logprobs extraction
 
     private func logprobsSpec(_ json: String) -> (topLogprobs: Int?, requested: Bool)? {

--- a/provider-swift/Tests/ProviderCoreTests/MultiModelBatchSchedulerEngineTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/MultiModelBatchSchedulerEngineTests.swift
@@ -221,6 +221,19 @@ func templateContextComposesReasoningControls() {
     #expect(context?["reasoning_effort"] as? String == "high")
 }
 
+@Test("template context treats effort none as thinking off")
+func templateContextEffortNoneDisablesThinking() {
+    let request = OpenAIChatCompletionRequest(
+        model: "qwen3.6",
+        messages: [.init(role: .user, content: .text("hi"))])
+    let controls = ReasoningControls.parse(
+        from: Data(#"{"reasoning":{"effort":"none"}}"#.utf8))
+    let context = MultiModelBatchSchedulerEngine.templateAdditionalContext(
+        for: request, reasoningEffort: "none", controls: controls)
+    #expect(context?["enable_thinking"] as? Bool == false)
+    #expect(context?["reasoning_effort"] == nil)
+}
+
 // MARK: - Engine error mapping (P2 #6)
 //
 // Pins the `MultiModelBatchSchedulerEngineError.fromSchedulerMessage`

--- a/provider-swift/Tests/ProviderCoreTests/ProviderLoopStreamChunkTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ProviderLoopStreamChunkTests.swift
@@ -143,6 +143,19 @@ func parseStreamChunkExtractsBothDeltas() throws {
     #expect(parsed.reasoningDelta == "let me think...")
 }
 
+@Test("stripReasoningFromStreamFrame drops reasoning and keeps content")
+func stripReasoningFromStreamFrameKeepsContent() throws {
+    let frame = try encodeChunk(
+        content: "4",
+        reasoningContent: "2+2"
+    )
+    let stripped = ProviderLoop.stripReasoningFromStreamFrame(frame)
+    let parsed = try #require(ProviderLoop.parseStreamChunk(stripped))
+    #expect(parsed.contentDelta == "4")
+    #expect(parsed.reasoningDelta == nil)
+    #expect(!stripped.contains("reasoning"))
+}
+
 @Test("parseStreamChunk extracts finish_reason on terminal choice frame")
 func parseStreamChunkExtractsFinishReason() throws {
     let frame = try encodeChunk(finishReason: "stop")

--- a/provider-swift/Tests/ProviderCoreTests/Qwen36ProductionCanaryTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/Qwen36ProductionCanaryTests.swift
@@ -57,11 +57,11 @@ struct Qwen36ProductionCanaryTests {
             let visionScheduler = fixture.scheduler(
                 bundle: targetBundle,
                 vision: EngineV2VisionPlumbing(
-                    prepare: { container, request, reasoningEffort in
+                    prepare: { container, request, controls in
                         let prepared = try await EngineV2VisionPrefill.prepare(
                             container: container,
                             request: request,
-                            reasoningEffort: reasoningEffort)
+                            reasoningControls: controls)
                         visionProbe.recordPrepared(spanCount: prepared.spans.count)
                         return prepared
                     },

--- a/provider-swift/Tests/ProviderCoreTests/ReasoningControlsTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ReasoningControlsTests.swift
@@ -40,8 +40,11 @@ struct ReasoningControlsTests {
     func maxTokensZero() {
         let controls = ReasoningControls.parse(
             from: Data(#"{"reasoning":{"max_tokens":0}}"#.utf8))
+        let asString = ReasoningControls.parse(
+            from: Data(#"{"reasoning":{"max_tokens":"0"}}"#.utf8))
         #expect(controls.thinkingDisabled)
         #expect(controls.suppressOutput)
+        #expect(asString.thinkingDisabled)
     }
 
     @Test("exclude hides the trace without disabling thinking")

--- a/provider-swift/Tests/ProviderCoreTests/ReasoningControlsTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ReasoningControlsTests.swift
@@ -1,0 +1,108 @@
+import Foundation
+import MLXLMServer
+import Testing
+
+@testable import ProviderCore
+
+@Suite("OpenRouter reasoning controls")
+struct ReasoningControlsTests {
+
+    @Test("unspecified leaves thinking at the template default")
+    func unspecified() {
+        let controls = ReasoningControls.parse(from: Data(#"{"model":"m","messages":[]}"#.utf8))
+        #expect(controls.thinkingEnabled == nil)
+        #expect(!controls.thinkingDisabled)
+        #expect(!controls.suppressOutput)
+        #expect(controls.effortForTemplate == nil)
+    }
+
+    @Test("enabled false disables thinking and suppresses output")
+    func enabledFalse() {
+        let controls = ReasoningControls.parse(
+            from: Data(#"{"reasoning":{"enabled":false}}"#.utf8))
+        #expect(controls.thinkingDisabled)
+        #expect(controls.suppressOutput)
+    }
+
+    @Test("effort none disables thinking")
+    func effortNone() {
+        let object = ReasoningControls.parse(
+            from: Data(#"{"reasoning":{"effort":"none"}}"#.utf8))
+        let topLevel = ReasoningControls.parse(
+            from: Data(#"{"reasoning_effort":"NONE"}"#.utf8))
+        #expect(object.thinkingDisabled)
+        #expect(object.effortForTemplate == nil)
+        #expect(topLevel.thinkingDisabled)
+        #expect(topLevel.effortForTemplate == nil)
+    }
+
+    @Test("max_tokens 0 disables thinking")
+    func maxTokensZero() {
+        let controls = ReasoningControls.parse(
+            from: Data(#"{"reasoning":{"max_tokens":0}}"#.utf8))
+        #expect(controls.thinkingDisabled)
+        #expect(controls.suppressOutput)
+    }
+
+    @Test("exclude hides the trace without disabling thinking")
+    func excludeOnly() {
+        let controls = ReasoningControls.parse(
+            from: Data(#"{"reasoning":{"exclude":true}}"#.utf8))
+        #expect(!controls.thinkingDisabled)
+        #expect(controls.suppressOutput)
+    }
+
+    @Test("include_reasoning false is exclude, not disable")
+    func includeReasoningFalse() {
+        let controls = ReasoningControls.parse(
+            from: Data(#"{"include_reasoning":false}"#.utf8))
+        #expect(!controls.thinkingDisabled)
+        #expect(controls.suppressOutput)
+    }
+
+    @Test("chat_template_kwargs and top-level enable_thinking disable")
+    func templateKwargs() {
+        let kwargs = ReasoningControls.parse(
+            from: Data(#"{"chat_template_kwargs":{"enable_thinking":false}}"#.utf8))
+        let topLevel = ReasoningControls.parse(
+            from: Data(#"{"enable_thinking":false}"#.utf8))
+        #expect(kwargs.thinkingDisabled)
+        #expect(topLevel.thinkingDisabled)
+    }
+
+    @Test("boolean reasoning false disables")
+    func booleanFalse() {
+        let controls = ReasoningControls.parse(from: Data(#"{"reasoning":false}"#.utf8))
+        #expect(controls.thinkingDisabled)
+    }
+
+    @Test("high effort stays enabled and is forwarded to the template")
+    func highEffort() {
+        let controls = ReasoningControls.parse(
+            from: Data(#"{"reasoning":{"effort":"high","enabled":true}}"#.utf8))
+        #expect(controls.thinkingEnabled == true)
+        #expect(controls.effortForTemplate == "high")
+        #expect(!controls.suppressOutput)
+    }
+
+    @Test("template context maps every disable shape to enable_thinking false")
+    func templateContextDisableShapes() {
+        let request = OpenAIChatCompletionRequest(
+            model: "qwen3.6",
+            messages: [.init(role: .user, content: .text("hi"))])
+        let bodies = [
+            #"{"reasoning":{"enabled":false}}"#,
+            #"{"reasoning":{"effort":"none"}}"#,
+            #"{"reasoning":{"max_tokens":0}}"#,
+            #"{"reasoning_effort":"none"}"#,
+            #"{"enable_thinking":false}"#,
+        ]
+        for body in bodies {
+            let controls = ReasoningControls.parse(from: Data(body.utf8))
+            let context = MultiModelBatchSchedulerEngine.templateAdditionalContext(
+                for: request, reasoningEffort: nil, controls: controls)
+            #expect(context?["enable_thinking"] as? Bool == false, "body \(body)")
+            #expect(context?["reasoning_effort"] == nil, "none must not reach Harmony")
+        }
+    }
+}

--- a/provider-swift/Tests/ProviderCoreTests/ReasoningPromptProbeTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ReasoningPromptProbeTests.swift
@@ -89,6 +89,41 @@ struct ReasoningPromptProbeTests {
         #expect(!shouldInject(parser: .qwen3, tail: "<think>\n\n</think>\n\n"))
     }
 
+    @Test("thinking-disabled never injects even with an open think tail")
+    func disabledNeverInjects() {
+        #expect(!ReasoningPromptProbe.shouldSynthesizeThinkOpen(
+            reasoningParser: .qwen3,
+            stream: true,
+            promptTokens: [1, 2, 3],
+            decodeTail: { _ in Self.openThinkTail },
+            thinkingDisabled: true))
+    }
+
+    @Test("closeOpenThinkBlock appends the official close on an open tail")
+    func closeOpenThinkBlock() {
+        let open = Array(10..<18)
+        let closed = ReasoningPromptProbe.closeOpenThinkBlock(
+            promptTokens: open,
+            encode: { text in
+                #expect(text == ReasoningPromptProbe.thinkClose)
+                return [99, 100]
+            },
+            decodeTail: { _ in Self.openThinkTail }
+        )
+        #expect(closed == open + [99, 100])
+    }
+
+    @Test("closeOpenThinkBlock is a no-op on a pre-closed tail")
+    func closeAlreadyClosed() {
+        let tokens = [1, 2, 3]
+        let out = ReasoningPromptProbe.closeOpenThinkBlock(
+            promptTokens: tokens,
+            encode: { _ in [99] },
+            decodeTail: { _ in "<|im_start|>assistant\n<think>\n\n</think>\n\n" }
+        )
+        #expect(out == tokens)
+    }
+
     @Test("the probe decodes only a bounded prompt tail")
     func boundedTailDecode() {
         let tokens = Array(0..<4096)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

OpenRouter baseline tests fail on the latest Qwen3.6 35B VLM (`https://huggingface.co/EigenLabs/Qwen3.6-35B-A3B-MLX-VL-4bit-g64-router8`) with:

```json
{"__kind":"ERR","error":"Expected reasoning length to be at most 0, got 2134"}
```

The published `chat_template.jinja` thinks by default. It only skips thinking when `enable_thinking` is defined **and** boolean `false`:

```jinja
{%- if add_generation_prompt %}
    {{- '<|im_start|>assistant\n' }}
    {%- if enable_thinking is defined and enable_thinking is false %}
        {{- '<think>\n\n</think>\n\n' }}
    {%- else %}
        {{- '<think>\n' }}
    {%- endif %}
{%- endif %}
```

We only forwarded `reasoning.enabled`. OpenRouter disables reasoning via `effort: "none"`, `max_tokens: 0`, `enable_thinking: false`, and `chat_template_kwargs`. Those shapes left the prompt inside an open `<think>` block, so the model produced ~2k chars of reasoning and we aliased it onto `reasoning` / `reasoning_content`.

This checkpoint is a **VLM**. Image/text requests go through `EngineV2VisionPrefill` → the processor template, which previously received only `reasoningEffort` (nil for `"none"`). The production path never saw `enable_thinking=false`.

This change:

- Decodes every OpenRouter disable / exclude shape into one `ReasoningControls` / `reasoningRequestPolicy`
- Threads those controls into **VL prepare** so the processor renders the official closed think tail
- Closes a still-open `<think>` tail on the **text path only** (Qwen VL freezes `CBv2PositionState` to the processor token count — appending after prepare would desync position IDs)
- Strips `reasoning` / `reasoning_content` from chat completions, native `object=="response"` output items, and Responses SSE when reasoning is disabled or excluded

Coordinator-side strip lands immediately (no provider update required) so the OpenRouter length check goes to 0 even on a still-thinking fleet. Provider-side disable stops the model from thinking so we do not spend those tokens.

## Linked issue

OpenRouter partner baseline: disabled reasoning still returns a non-empty reasoning field on Qwen3.6 35B.

## Test plan

- [x] `go test ./api/ ./registry/`
- [x] Targeted: `TestParseReasoning*`, `TestStripReasoning*`, `TestMaybeStrip*`, `TestStampReasoning*`, `TestResponsesStreamSuppressesReasoning`
- [ ] Swift tests on macOS CI: `ReasoningControlsTests`, `Qwen36ThinkingTemplateTests`, `EngineV2VisionRoutingTests` (VL controls + no token-append after prepare)

## Components touched

- [x] coordinator (Go)
- [ ] provider (Rust, legacy)
- [x] provider-swift (Swift CLI)
- [ ] console-ui (Next.js)
- [ ] enclave (Swift)
- [ ] infra / CI / release
- [ ] docs

## Protocol / interface changes

- [x] No protocol/interface changes
- [ ] Yes — described above and matching side updated

Request JSON is unchanged. Response omits `reasoning` / `reasoning_content` (and Responses `type=reasoning` items) when the caller disabled or excluded reasoning.

## Behavior

```mermaid
flowchart LR
  subgraph Before
    A1["OpenRouter reasoning.effort=none"] --> B1["VL prepare gets effort=nil"]
    B1 --> C1["enable_thinking unset"]
    C1 --> D1["Qwen3.6 VL template pre-opens think"]
    D1 --> E1["2134 chars of reasoning"]
  end
  subgraph After
    A2["same disable / exclude shapes"] --> B2["ReasoningControls into VL prepare"]
    B2 --> C2["enable_thinking=false in processor template"]
    C2 --> D2["official closed think tail; no post-prepare append"]
    D2 --> E2["coordinator strips any leaked reasoning field"]
  end
```

## Code

```mermaid
flowchart LR
  subgraph Before
    P1["extractReasoningEffort"] --> V1["EngineV2VisionPrefill(effort String?)"]
    V1 --> T1["template sees no enable_thinking"]
    T1 --> S1["normalizeSSEChunk aliases reasoning_content"]
  end
  subgraph After
    P2["ReasoningControls.parse"] --> V2["VL prepare(controls)"]
    P2 --> T2["text tokenize + closeOpenThinkBlock"]
    V2 --> J2["processor template enable_thinking=false"]
    T2 --> S2["strip chat SSE / complete / native Responses"]
    J2 --> S2
  end
```

## Notes for reviewers

- `exclude: true` / `include_reasoning: false` still allow thinking; only the response field is removed.
- `effort: "none"` is not forwarded as `reasoning_effort` — Harmony templates do not define that level.
- Text-path closer appends `\n</think>\n\n` only when the decoded prompt suffix is still `<think>`. VL never uses that closer.
- Native `object=="response"` passthrough now drops `type=reasoning` output items when suppress is set.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0022a-c2a3-710c-ba99-e580f5821be6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0022a-c2a3-710c-ba99-e580f5821be6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/625"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789335551&installation_model_id=21733&pr_number=625&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F625&signature=89c68285c72384382772e021096dbb6de6ea408c5922600ea5e958f768aa5ffd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->