### PR TITLE
fix(api): honor every OpenRouter reasoning-disable spelling for hybrid-thinking models

### DIFF
--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -2441,12 +2441,6 @@ func (s *Server) handleNonStreamingResponseWithFirstChunk(w http.ResponseWriter,
 
 				// Fallback: SSE delta chunks — reconstruct into response.
 				msg := extractMessage(chunks)
-				// Reasoning was disabled or excluded: the reconstructed message
-				// (extractMessage already folded streamed reasoning deltas and
-				// raw <think> blocks into msg.Reasoning) must not return it.
-				if pr.SuppressReasoning {
-					msg.Reasoning = ""
-				}
 				select {
 				case usage, ok := <-pr.CompleteCh:
 					if !ok {
@@ -2454,6 +2448,17 @@ func (s *Server) handleNonStreamingResponseWithFirstChunk(w http.ResponseWriter,
 						s.updateInferenceRouteOutcomeForPending(pr, preResponseProviderIncompleteOutcome(pr))
 						writeJSON(w, http.StatusBadGateway, errorResponse("provider_error", "provider ended without completion"))
 						return
+					}
+					// Reasoning was disabled or excluded: the reconstructed
+					// message (extractMessage folded streamed reasoning deltas
+					// and raw <think> blocks into msg.Reasoning) must not
+					// return the text — but the token count is resolved FIRST
+					// so a legacy provider without a tokenizer-accurate
+					// ReasoningTokens keeps its text-based usage fallback.
+					// Exclude hides reasoning, it doesn't unbill it.
+					if pr.SuppressReasoning {
+						usage.ReasoningTokens = int(resolveReasoningTokens(usage, msg.Reasoning))
+						msg.Reasoning = ""
 					}
 					var resp any
 					if pr.IsResponsesAPI {

--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -3170,6 +3170,12 @@ func parseFinishStreamChunk(chunk string) (map[string]any, bool) {
 // doesn't distinguish natural stop from truncation). Also rewrites the build
 // id to the public alias. Returns "" if it can't be marshalled.
 func finalizeFinishChunk(obj map[string]any, usage protocol.UsageInfo, pr *registry.PendingRequest) string {
+	// The finish chunk is held BEFORE the relay loop's reasoning suppression
+	// runs, so a terminal chunk that carries both finish_reason and a trailing
+	// reasoning delta would otherwise leak that text at stream end.
+	if pr.SuppressReasoning {
+		stripReasoningFromCompleteResponse(obj)
+	}
 	if truncatedByMaxTokens(usage, pr.RequestedMaxTokens) {
 		if choices, ok := obj["choices"].([]any); ok {
 			for _, c := range choices {

--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -784,6 +784,7 @@ func (s *Server) dispatchOneProvider(
 	traits registry.RequestTraits,
 	allowedProviderSerials []string,
 	isResponsesAPI bool,
+	suppressReasoning bool,
 	policy selfRoutePolicy,
 	timing *registry.RequestTiming,
 	serviceReservation bool,
@@ -815,6 +816,7 @@ func (s *Server) dispatchOneProvider(
 		KeyLimitReset:          keyLimitResetFromContext(r.Context()),
 		ConsumerLocation:       consumerLocation,
 		IsResponsesAPI:         isResponsesAPI,
+		SuppressReasoning:      suppressReasoning,
 		EstimatedPromptTokens:  estimatedPromptTokens,
 		RequiresVision:         requiresVision,
 		Traits:                 traits,
@@ -1927,6 +1929,7 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 		toolChoiceName:         toolChoiceName,
 		parallelToolCalls:      parallelToolCalls,
 		isResponsesAPI:         isResponsesAPI,
+		suppressReasoning:      prelude.suppressReasoning,
 		stream:                 stream,
 		policy:                 policy,
 		allowedProviderSerials: allowedProviderSerials,
@@ -2009,6 +2012,12 @@ func (s *Server) handleStreamingResponseWithFirstChunk(w http.ResponseWriter, r 
 		} else {
 			if !sawResponsesAPI {
 				firstChunk = normalizeSSEChunk(firstChunk)
+				if pr.SuppressReasoning {
+					var drop bool
+					if firstChunk, drop = stripReasoningFromStreamChunk(firstChunk); drop {
+						continue
+					}
+				}
 			}
 			firstChunk = rewriteChunkModel(firstChunk, pr)
 			fmt.Fprintf(w, "%s\n\n", firstChunk)
@@ -2163,6 +2172,15 @@ func (s *Server) handleStreamingResponseWithFirstChunk(w http.ResponseWriter, r 
 				if obj, isFinish := parseFinishStreamChunk(chunk); isFinish {
 					pendingFinish = obj
 					continue
+				}
+				// Reasoning was disabled or excluded: reasoning deltas never
+				// reach the consumer (a reasoning-only chunk is skipped
+				// outright, a mixed chunk keeps its other fields).
+				if pr.SuppressReasoning {
+					var drop bool
+					if chunk, drop = stripReasoningFromStreamChunk(chunk); drop {
+						continue
+					}
 				}
 			}
 			chunk = rewriteChunkModel(chunk, pr)
@@ -2350,6 +2368,14 @@ func (s *Server) handleNonStreamingResponseWithFirstChunk(w http.ResponseWriter,
 							}
 							if objType == "chat.completion" {
 								normalizeCompleteChatResponse(obj, consumerModel(pr))
+								// Reasoning was disabled or excluded: strip the
+								// reasoning text (normalizeCompleteChatResponse
+								// already folded any raw <think> blocks into the
+								// reasoning field, so content stays clean). Usage
+								// token accounting is untouched.
+								if pr.SuppressReasoning {
+									stripReasoningFromCompleteResponse(obj)
+								}
 								// The provider engine reports "stop" even when generation
 								// hit the max-tokens bound — correct it from the
 								// authoritative token counts.
@@ -2415,6 +2441,12 @@ func (s *Server) handleNonStreamingResponseWithFirstChunk(w http.ResponseWriter,
 
 				// Fallback: SSE delta chunks — reconstruct into response.
 				msg := extractMessage(chunks)
+				// Reasoning was disabled or excluded: the reconstructed message
+				// (extractMessage already folded streamed reasoning deltas and
+				// raw <think> blocks into msg.Reasoning) must not return it.
+				if pr.SuppressReasoning {
+					msg.Reasoning = ""
+				}
 				select {
 				case usage, ok := <-pr.CompleteCh:
 					if !ok {
@@ -3987,6 +4019,7 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 		KeyLimitReset:          keyLimitResetFromContext(r.Context()),
 		ConsumerLocation:       consumerLocation,
 		ConsumerEndpoint:       consumerEndpoint,
+		SuppressReasoning:      prelude.suppressReasoning,
 		RequestedStopSequences: requestedStopSequences,
 		AllowedProviderSerials: allowedProviderSerials,
 		SelfRouteOnly:          policy.enabled,

--- a/coordinator/api/dispatch.go
+++ b/coordinator/api/dispatch.go
@@ -104,6 +104,7 @@ type dispatchState struct {
 	toolChoiceName         string
 	parallelToolCalls      bool
 	isResponsesAPI         bool
+	suppressReasoning      bool
 	stream                 bool
 	policy                 selfRoutePolicy
 	allowedProviderSerials []string
@@ -917,7 +918,7 @@ func (d *dispatchState) dispatchPrimary() dispatchOutcome {
 		r, d.model, d.publicModel, d.rawBody, d.consumerKey, d.consumerLocation, d.reservedMicroUSD,
 		d.estimatedPromptTokens, d.requestedMaxTokens, d.tokenAdmission, d.requiresVision,
 		d.traits(),
-		d.allowedProviderSerials, d.isResponsesAPI, d.policy, d.timing, d.serviceReservation, d.cachePlan, d.excludeProviders,
+		d.allowedProviderSerials, d.isResponsesAPI, d.suppressReasoning, d.policy, d.timing, d.serviceReservation, d.cachePlan, d.excludeProviders,
 		d.attempt,
 		func(provider *registry.Provider, pr *registry.PendingRequest, decision registry.RoutingDecision) {
 			routeProvider = provider
@@ -1028,6 +1029,7 @@ func (d *dispatchState) dispatchPrimary() dispatchOutcome {
 			KeyLimitReset:          keyLimitResetFromContext(r.Context()),
 			ConsumerLocation:       d.consumerLocation,
 			IsResponsesAPI:         d.isResponsesAPI,
+			SuppressReasoning:      d.suppressReasoning,
 			EstimatedPromptTokens:  d.estimatedPromptTokens,
 			RequiresVision:         d.requiresVision,
 			Traits:                 d.traits(),
@@ -1733,7 +1735,7 @@ func (d *dispatchState) runSpeculative() dispatchOutcome {
 			r, d.model, d.publicModel, d.rawBody, d.consumerKey, d.consumerLocation, d.reservedMicroUSD,
 			d.estimatedPromptTokens, d.requestedMaxTokens, d.tokenAdmission, d.requiresVision,
 			d.traits(),
-			d.allowedProviderSerials, d.isResponsesAPI, d.policy,
+			d.allowedProviderSerials, d.isResponsesAPI, d.suppressReasoning, d.policy,
 			&registry.RequestTiming{ReceivedAt: d.timing.ReceivedAt},
 			d.serviceReservation,
 			d.cachePlan,

--- a/coordinator/api/inference_preprocess.go
+++ b/coordinator/api/inference_preprocess.go
@@ -78,6 +78,10 @@ type inferencePrelude struct {
 	originalRawBody []byte
 	parsed          map[string]any
 	model           string
+	// suppressReasoning is true when the consumer disabled or excluded
+	// reasoning (see normalizeReasoningControls): the response writers must
+	// not return reasoning text for this request.
+	suppressReasoning bool
 }
 
 // parseInferencePrelude runs the request prelude shared verbatim by
@@ -123,6 +127,17 @@ func (s *Server) parseInferencePrelude(w http.ResponseWriter, r *http.Request) (
 		rawBody, _ = marshalForwardBody(parsed)
 	}
 
+	// Canonicalize every "reasoning off" spelling (reasoning.effort:"none",
+	// reasoning_effort:"none", thinking.type:"disabled", …) into the ONE
+	// shape providers decode — reasoning.enabled=false — before the body is
+	// sealed, so hybrid-thinking models (Qwen3.6) actually pre-close their
+	// think block instead of reasoning by default. Also flags requests whose
+	// responses must carry no reasoning text (disable + exclude semantics).
+	reasoningMutated, suppressReasoning := normalizeReasoningControls(parsed)
+	if reasoningMutated {
+		rawBody, _ = marshalForwardBody(parsed)
+	}
+
 	model, _ := parsed["model"].(string)
 	if model == "" {
 		writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request_error", "model is required", withParam("model")))
@@ -140,6 +155,7 @@ func (s *Server) parseInferencePrelude(w http.ResponseWriter, r *http.Request) (
 	return inferencePrelude{
 		rawBody: rawBody, originalRawBody: originalRawBody,
 		parsed: parsed, model: model,
+		suppressReasoning: suppressReasoning,
 	}, true
 }
 

--- a/coordinator/api/reasoning_controls.go
+++ b/coordinator/api/reasoning_controls.go
@@ -1,0 +1,239 @@
+package api
+
+// Reasoning on/off controls (OpenRouter #612 baseline: "reasoning disabled
+// but the endpoint still returns reasoning output").
+//
+// Providers decode exactly ONE reasoning switch from the sealed body:
+// `reasoning: {"enabled": <bool>}` — the Swift engine maps it to the
+// `enable_thinking` chat-template variable (Qwen3.6/Qwen3-style templates
+// pre-close the think block when it is false). But the OpenAI/OpenRouter
+// surface accepts several equivalent spellings of "reasoning off", and any
+// spelling the coordinator forwards un-normalized is silently ignored by the
+// template — a hybrid-thinking model such as Qwen3.6 then thinks by DEFAULT
+// and the consumer receives reasoning it explicitly disabled:
+//
+//   - reasoning: {"enabled": false}      (canonical — already honored)
+//   - reasoning: {"effort": "none"}      (OpenRouter's OpenAI-style disable)
+//   - reasoning_effort: "none"           (top-level OpenAI-style shorthand)
+//   - thinking: {"type": "disabled"}     (Anthropic /v1/messages)
+//
+// normalizeReasoningControls canonicalizes all of them into the one shape
+// providers decode, BEFORE the body is sealed — so the entire deployed fleet
+// honors the disable without a provider release. It also reports whether
+// reasoning text must be suppressed from the consumer-facing response:
+//
+//   - reasoning: {"exclude": true}       (generate internally, never return)
+//   - include_reasoning: false           (deprecated alias of exclude:true)
+//   - any disable spelling               (belt-and-braces: a model can still
+//     open its own <think> block despite a disabled-thinking prompt; the
+//     consumer asked for zero reasoning, so zero reasoning is returned)
+//
+// Suppression strips reasoning TEXT only. Usage token accounting
+// (completion_tokens_details.reasoning_tokens) is deliberately untouched:
+// generated reasoning tokens are billed whether or not they are returned.
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+// normalizeReasoningControls rewrites every documented "reasoning off"
+// spelling in a parsed request body into the canonical provider shape
+// `reasoning: {"enabled": false}`. It returns mutated=true when the body
+// changed (callers must re-marshal the forward body), and suppress=true when
+// reasoning text must not appear in the consumer-facing response.
+//
+// Precedence: an explicit `reasoning.enabled` boolean always wins over the
+// effort/thinking-derived spellings, matching OpenRouter's documented
+// semantics ("enabled: inferred from effort" — an explicit value is never
+// re-inferred).
+func normalizeReasoningControls(parsed map[string]any) (mutated, suppress bool) {
+	reasoning, _ := parsed["reasoning"].(map[string]any)
+
+	explicitEnabled, hasExplicit := false, false
+	if reasoning != nil {
+		if enabled, ok := reasoning["enabled"].(bool); ok {
+			explicitEnabled, hasExplicit = enabled, true
+		}
+		if exclude, ok := reasoning["exclude"].(bool); ok && exclude {
+			suppress = true
+		}
+	}
+	if include, ok := parsed["include_reasoning"].(bool); ok && !include {
+		suppress = true
+	}
+
+	disabled := hasExplicit && !explicitEnabled
+
+	// reasoning.effort: "none" — OpenRouter's OpenAI-style disable. The value
+	// is removed either way: no chat template accepts "none" as an effort
+	// level, and the canonical enabled=false below carries the semantics.
+	if effort, ok := reasoning["effort"].(string); ok && isNoneEffort(effort) {
+		if !hasExplicit {
+			disabled = true
+		}
+		delete(reasoning, "effort")
+		mutated = true
+	}
+	// Top-level reasoning_effort: "none" — the OpenAI shorthand. Removed so
+	// no template ever renders a literal "none" effort (gpt-oss renders the
+	// field verbatim into its system header).
+	if effort, ok := parsed["reasoning_effort"].(string); ok && isNoneEffort(effort) {
+		if !hasExplicit {
+			disabled = true
+		}
+		delete(parsed, "reasoning_effort")
+		mutated = true
+	}
+	// Anthropic thinking config (/v1/messages): {"type": "disabled"} turns
+	// extended thinking off; {"type": "enabled"} turns it on. The endpoint
+	// lowering clones unknown fields verbatim, so mapping here covers the
+	// lowered provider body too.
+	if thinking, ok := parsed["thinking"].(map[string]any); ok && !hasExplicit {
+		switch kind, _ := thinking["type"].(string); kind {
+		case "disabled":
+			disabled = true
+		case "enabled":
+			if setReasoningEnabled(parsed, reasoning, true) {
+				mutated = true
+			}
+		}
+	}
+
+	if disabled {
+		suppress = true
+		if setReasoningEnabled(parsed, reasoning, false) {
+			mutated = true
+		}
+	}
+	return mutated, suppress
+}
+
+// setReasoningEnabled writes the canonical `reasoning.enabled` value into the
+// body, creating the reasoning object when absent. Returns true when the body
+// actually changed.
+func setReasoningEnabled(parsed map[string]any, reasoning map[string]any, enabled bool) bool {
+	if reasoning == nil {
+		parsed["reasoning"] = map[string]any{"enabled": enabled}
+		return true
+	}
+	if current, ok := reasoning["enabled"].(bool); ok && current == enabled {
+		return false
+	}
+	reasoning["enabled"] = enabled
+	return true
+}
+
+// isNoneEffort reports whether a reasoning-effort string spells the
+// OpenRouter/OpenAI "disable reasoning entirely" level.
+func isNoneEffort(effort string) bool {
+	return strings.EqualFold(strings.TrimSpace(effort), "none")
+}
+
+// reasoningDeltaFields are the assistant-delta keys that carry reasoning TEXT
+// on the chat-completions wire (the coordinator emits both spellings — see
+// normalizeSSEChunk).
+var reasoningDeltaFields = []string{"reasoning", "reasoning_content"}
+
+// stripReasoningFromStreamChunk removes reasoning text fields from a
+// chat.completion.chunk SSE line. It returns the rewritten chunk and
+// drop=true when the chunk carried ONLY reasoning deltas — nothing a
+// suppressed-reasoning consumer needs — so the caller skips it entirely
+// (forwarding an empty {"delta":{}} frame for every hidden reasoning token
+// would leak the reasoning cadence and confuse strict SDK parsers).
+//
+// Chunks carrying anything else (role preamble, content, tool calls,
+// refusal, finish_reason, usage) are kept with just the reasoning fields
+// deleted. Non-chunk lines and unparsable payloads pass through untouched.
+func stripReasoningFromStreamChunk(chunk string) (string, bool) {
+	line := strings.TrimSpace(chunk)
+	if !strings.HasPrefix(line, "data: ") {
+		return chunk, false
+	}
+	payload := strings.TrimPrefix(line, "data: ")
+	// Cheap pre-filter: only pay for the JSON round-trip when a reasoning
+	// field can actually be present.
+	if !strings.Contains(payload, `"reasoning`) {
+		return chunk, false
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(payload), &raw); err != nil {
+		return chunk, false
+	}
+	choicesRaw, ok := raw["choices"]
+	if !ok {
+		return chunk, false
+	}
+	var choices []map[string]json.RawMessage
+	if err := json.Unmarshal(choicesRaw, &choices); err != nil {
+		return chunk, false
+	}
+
+	changed := false
+	reasoningOnly := len(choices) > 0
+	for i, choice := range choices {
+		if fr, ok := choice["finish_reason"]; ok && string(fr) != "null" {
+			reasoningOnly = false
+		}
+		deltaRaw, ok := choice["delta"]
+		if !ok {
+			reasoningOnly = false
+			continue
+		}
+		var delta map[string]json.RawMessage
+		if err := json.Unmarshal(deltaRaw, &delta); err != nil {
+			reasoningOnly = false
+			continue
+		}
+		for _, field := range reasoningDeltaFields {
+			if _, ok := delta[field]; ok {
+				delete(delta, field)
+				changed = true
+			}
+		}
+		if len(delta) > 0 {
+			reasoningOnly = false
+		}
+		choices[i]["delta"], _ = json.Marshal(delta)
+	}
+	if !changed {
+		return chunk, false
+	}
+	// A usage-bearing chunk is terminal accounting — never dropped.
+	if usage, ok := raw["usage"]; ok && string(usage) != "null" {
+		reasoningOnly = false
+	}
+	if reasoningOnly {
+		return "", true
+	}
+	raw["choices"], _ = json.Marshal(choices)
+	fixed, err := json.Marshal(raw)
+	if err != nil {
+		return chunk, false
+	}
+	return "data: " + string(fixed), false
+}
+
+// stripReasoningFromCompleteResponse removes reasoning text fields from a raw
+// chat.completion object's choices (both the message and delta shapes some
+// backends emit). Usage accounting is untouched.
+func stripReasoningFromCompleteResponse(obj map[string]any) {
+	choices, ok := obj["choices"].([]any)
+	if !ok {
+		return
+	}
+	for _, rawChoice := range choices {
+		choice, ok := rawChoice.(map[string]any)
+		if !ok {
+			continue
+		}
+		for _, key := range []string{"message", "delta"} {
+			if member, ok := choice[key].(map[string]any); ok {
+				for _, field := range reasoningDeltaFields {
+					delete(member, field)
+				}
+			}
+		}
+	}
+}

--- a/coordinator/api/reasoning_controls.go
+++ b/coordinator/api/reasoning_controls.go
@@ -65,10 +65,17 @@ func normalizeReasoningControls(parsed map[string]any) (mutated, suppress bool) 
 
 	disabled := hasExplicit && !explicitEnabled
 
+	// A concrete (non-"none") effort inside the reasoning object takes
+	// precedence over the legacy top-level shorthand per OpenRouter's
+	// parameter hierarchy, so a contradictory top-level "none" must not
+	// disable. Read before the deletes below can drop the key.
+	objectEffort, hasObjectEffort := reasoning["effort"].(string)
+	objectHasConcreteEffort := hasObjectEffort && !isNoneEffort(objectEffort)
+
 	// reasoning.effort: "none" — OpenRouter's OpenAI-style disable. The value
 	// is removed either way: no chat template accepts "none" as an effort
 	// level, and the canonical enabled=false below carries the semantics.
-	if effort, ok := reasoning["effort"].(string); ok && isNoneEffort(effort) {
+	if hasObjectEffort && isNoneEffort(objectEffort) {
 		if !hasExplicit {
 			disabled = true
 		}
@@ -79,7 +86,7 @@ func normalizeReasoningControls(parsed map[string]any) (mutated, suppress bool) 
 	// no template ever renders a literal "none" effort (gpt-oss renders the
 	// field verbatim into its system header).
 	if effort, ok := parsed["reasoning_effort"].(string); ok && isNoneEffort(effort) {
-		if !hasExplicit {
+		if !hasExplicit && !objectHasConcreteEffort {
 			disabled = true
 		}
 		delete(parsed, "reasoning_effort")
@@ -175,6 +182,21 @@ func stripReasoningFromStreamChunk(chunk string) (string, bool) {
 	for i, choice := range choices {
 		if fr, ok := choice["finish_reason"]; ok && string(fr) != "null" {
 			reasoningOnly = false
+		}
+		// Some backends emit message-shaped choices mid-stream; those carry
+		// a full assistant message and are never dropped, only stripped.
+		if messageRaw, ok := choice["message"]; ok {
+			reasoningOnly = false
+			var message map[string]json.RawMessage
+			if err := json.Unmarshal(messageRaw, &message); err == nil {
+				for _, field := range reasoningDeltaFields {
+					if _, ok := message[field]; ok {
+						delete(message, field)
+						changed = true
+					}
+				}
+				choices[i]["message"], _ = json.Marshal(message)
+			}
 		}
 		deltaRaw, ok := choice["delta"]
 		if !ok {

--- a/coordinator/api/reasoning_controls_test.go
+++ b/coordinator/api/reasoning_controls_test.go
@@ -379,6 +379,38 @@ func TestStreamingSuppressReasoning(t *testing.T) {
 	}
 }
 
+// A terminal chunk carrying BOTH finish_reason and a trailing reasoning delta
+// is held by the relay loop before suppression runs and re-emitted at stream
+// end — finalizeFinishChunk must strip it there.
+func TestStreamingSuppressReasoningOnHeldFinishChunk(t *testing.T) {
+	srv := newDeferredCommitTestServer(t)
+
+	pr := &registry.PendingRequest{
+		RequestID:         "suppress-reasoning-finish",
+		Model:             "m",
+		SuppressReasoning: true,
+		ChunkCh:           make(chan string, 4),
+		ErrorCh:           make(chan protocol.InferenceErrorMessage, 1),
+		CompleteCh:        make(chan protocol.UsageInfo, 1),
+	}
+	pr.ChunkCh <- `data: {"id":"c1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"ok"},"finish_reason":null}]}`
+	pr.ChunkCh <- `data: {"id":"c1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"reasoning_content":"terminal tail"},"finish_reason":"stop"}]}`
+	close(pr.ChunkCh)
+	pr.CompleteCh <- protocol.UsageInfo{PromptTokens: 1, CompletionTokens: 1}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	rec := httptest.NewRecorder()
+	srv.handleStreamingResponseWithFirstChunk(rec, req, pr, nil, false)
+
+	body := rec.Body.String()
+	if strings.Contains(body, "terminal tail") {
+		t.Errorf("reasoning text on the held finish chunk leaked:\n%s", body)
+	}
+	if !strings.Contains(body, `"finish_reason":"stop"`) {
+		t.Errorf("finish_reason missing from suppressed stream:\n%s", body)
+	}
+}
+
 // End-to-end through the non-streaming writer: the reconstructed message must
 // carry no reasoning field when suppression is on.
 func TestNonStreamingSuppressReasoning(t *testing.T) {

--- a/coordinator/api/reasoning_controls_test.go
+++ b/coordinator/api/reasoning_controls_test.go
@@ -168,6 +168,25 @@ func TestNormalizeReasoningControls(t *testing.T) {
 			wantSuppress: false,
 		},
 		{
+			// OpenRouter parameter hierarchy: the reasoning object's concrete
+			// effort wins over a contradictory legacy top-level "none".
+			name:         "concrete object effort wins over top-level effort none",
+			body:         `{"model":"m","reasoning":{"effort":"high"},"reasoning_effort":"none"}`,
+			wantMutated:  true, // the unusable top-level "none" is still removed
+			wantSuppress: false,
+			check: func(t *testing.T, parsed map[string]any) {
+				if _, ok := parsed["reasoning_effort"]; ok {
+					t.Error("top-level reasoning_effort \"none\" must be removed")
+				}
+				if effort := parsed["reasoning"].(map[string]any)["effort"]; effort != "high" {
+					t.Errorf("reasoning.effort = %v, want high", effort)
+				}
+				if _, ok := parsed["reasoning"].(map[string]any)["enabled"]; ok {
+					t.Error("a concrete object effort must not be rewritten into a disable")
+				}
+			},
+		},
+		{
 			name:         "non-boolean and null reasoning shapes are tolerated",
 			body:         `{"model":"m","reasoning":{"enabled":null,"effort":7,"exclude":"yes"},"reasoning_effort":3,"include_reasoning":null}`,
 			wantMutated:  false,
@@ -266,6 +285,10 @@ func TestStripReasoningFromStreamChunk(t *testing.T) {
 			want:  `data: {"choices":[{"index":0,"delta":{"content":"hi"},"finish_reason":null}]}`,
 		},
 		{
+			name:  "message-shaped choice is stripped but never dropped",
+			chunk: `data: {"choices":[{"index":0,"message":{"role":"assistant","content":"hi","reasoning":"deep thought","reasoning_content":"deep thought"},"finish_reason":null}]}`,
+		},
+		{
 			name:  "done terminator passes through untouched",
 			chunk: "data: [DONE]",
 			want:  "data: [DONE]",
@@ -293,10 +316,12 @@ func TestStripReasoningFromStreamChunk(t *testing.T) {
 				t.Fatalf("stripped chunk is not valid JSON: %v\n%s", err, got)
 			}
 			for _, choice := range obj["choices"].([]any) {
-				delta, _ := choice.(map[string]any)["delta"].(map[string]any)
-				for _, field := range reasoningDeltaFields {
-					if _, ok := delta[field]; ok {
-						t.Errorf("delta still carries %q: %s", field, got)
+				for _, key := range []string{"delta", "message"} {
+					member, _ := choice.(map[string]any)[key].(map[string]any)
+					for _, field := range reasoningDeltaFields {
+						if _, ok := member[field]; ok {
+							t.Errorf("%s still carries %q: %s", key, field, got)
+						}
 					}
 				}
 			}
@@ -449,6 +474,78 @@ func TestNonStreamingSuppressReasoning(t *testing.T) {
 		t.Errorf("message.reasoning present in suppressed response: %v", message)
 	}
 }
+
+// The Responses-API streaming emitter must not emit reasoning items or
+// summary events for a suppressed request, while finish() keeps the buffered
+// text so legacy providers (no tokenizer-accurate ReasoningTokens) still
+// report accurate usage.
+func TestResponsesStreamingSuppressReasoning(t *testing.T) {
+	pr := &registry.PendingRequest{
+		RequestID:         "suppress-reasoning-responses",
+		Model:             "m",
+		IsResponsesAPI:    true,
+		SuppressReasoning: true,
+	}
+	rec := httptest.NewRecorder()
+	emitter := newResponsesStreamEmitter(rec, noopFlusher{}, pr, "resp_x", 1)
+	emitter.start()
+	emitter.handleChunk(`data: {"choices":[{"index":0,"delta":{"reasoning_content":"hidden thought"},"finish_reason":null}]}`)
+	emitter.handleChunk(`data: {"choices":[{"index":0,"delta":{"content":"Visible"},"finish_reason":null}]}`)
+	emitter.handleChunk(`data: {"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`)
+	// Legacy usage: no provider-side reasoning count — finish() must fall
+	// back to the buffered (suppressed) text for the usage breakdown.
+	emitter.finish(protocol.UsageInfo{PromptTokens: 2, CompletionTokens: 6})
+
+	body := rec.Body.String()
+	if strings.Contains(body, "hidden thought") {
+		t.Errorf("reasoning text leaked into a suppressed Responses stream:\n%s", body)
+	}
+	if strings.Contains(body, "reasoning_summary") || strings.Contains(body, `"type":"reasoning"`) {
+		t.Errorf("reasoning events/items emitted on a suppressed Responses stream:\n%s", body)
+	}
+	if !strings.Contains(body, `"delta":"Visible"`) {
+		t.Errorf("content delta missing from suppressed Responses stream:\n%s", body)
+	}
+	if !strings.Contains(body, `"reasoning_tokens":6`) {
+		t.Errorf("legacy usage fallback lost under suppression:\n%s", body)
+	}
+}
+
+// The non-streaming SSE-reconstruction path must keep the legacy text-based
+// usage fallback: suppression hides the text, it does not unbill it.
+func TestNonStreamingSuppressReasoningKeepsLegacyUsageFallback(t *testing.T) {
+	srv := newDeferredCommitTestServer(t)
+
+	pr := &registry.PendingRequest{
+		RequestID:         "suppress-reasoning-legacy-usage",
+		Model:             "m",
+		SuppressReasoning: true,
+		ChunkCh:           make(chan string, 4),
+		ErrorCh:           make(chan protocol.InferenceErrorMessage, 1),
+		CompleteCh:        make(chan protocol.UsageInfo, 1),
+	}
+	pr.ChunkCh <- `data: {"id":"c1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"reasoning_content":"quiet"},"finish_reason":null}]}`
+	pr.ChunkCh <- `data: {"id":"c1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"ok"},"finish_reason":"stop"}]}`
+	close(pr.ChunkCh)
+	// Legacy provider: reasoning happened but ReasoningTokens is unreported.
+	pr.CompleteCh <- protocol.UsageInfo{PromptTokens: 3, CompletionTokens: 5}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	rec := httptest.NewRecorder()
+	srv.handleNonStreamingResponseWithFirstChunk(rec, req, pr, nil)
+
+	body := rec.Body.String()
+	if strings.Contains(body, "quiet") {
+		t.Errorf("reasoning text leaked:\n%s", body)
+	}
+	if !strings.Contains(body, `"reasoning_tokens":5`) {
+		t.Errorf("legacy text-based reasoning_tokens fallback lost under suppression:\n%s", body)
+	}
+}
+
+type noopFlusher struct{}
+
+func (noopFlusher) Flush() {}
 
 // The raw complete-object passthrough (provider returns one chat.completion
 // object instead of SSE deltas) must strip reasoning the same way.

--- a/coordinator/api/reasoning_controls_test.go
+++ b/coordinator/api/reasoning_controls_test.go
@@ -1,0 +1,449 @@
+package api
+
+// Reasoning-disable contract tests (OpenRouter baseline: "Expected reasoning
+// length to be at most 0"). Every documented spelling of "reasoning off" must
+// canonicalize into the ONE shape providers decode (reasoning.enabled=false),
+// and a disabled/excluded request's response must never carry reasoning text.
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+	"github.com/eigeninference/d-inference/coordinator/registry"
+)
+
+func parseTestBody(t *testing.T, body string) map[string]any {
+	t.Helper()
+	parsed, err := decodeInferenceJSONObject([]byte(body))
+	if err != nil {
+		t.Fatalf("unmarshal test body: %v", err)
+	}
+	return parsed
+}
+
+func reasoningEnabledValue(t *testing.T, parsed map[string]any) (bool, bool) {
+	t.Helper()
+	reasoning, ok := parsed["reasoning"].(map[string]any)
+	if !ok {
+		return false, false
+	}
+	enabled, ok := reasoning["enabled"].(bool)
+	return enabled, ok
+}
+
+func TestNormalizeReasoningControls(t *testing.T) {
+	cases := []struct {
+		name         string
+		body         string
+		wantMutated  bool
+		wantSuppress bool
+		// wantEnabled/wantEnabledSet describe reasoning.enabled after the call.
+		wantEnabled    bool
+		wantEnabledSet bool
+		check          func(t *testing.T, parsed map[string]any)
+	}{
+		{
+			name:           "canonical enabled=false passes through unmutated",
+			body:           `{"model":"m","reasoning":{"enabled":false}}`,
+			wantMutated:    false,
+			wantSuppress:   true,
+			wantEnabled:    false,
+			wantEnabledSet: true,
+		},
+		{
+			name:           "openrouter effort none disables",
+			body:           `{"model":"m","reasoning":{"effort":"none"}}`,
+			wantMutated:    true,
+			wantSuppress:   true,
+			wantEnabled:    false,
+			wantEnabledSet: true,
+			check: func(t *testing.T, parsed map[string]any) {
+				reasoning := parsed["reasoning"].(map[string]any)
+				if _, ok := reasoning["effort"]; ok {
+					t.Errorf("effort %q must be removed from the forwarded body", reasoning["effort"])
+				}
+			},
+		},
+		{
+			name:           "effort none is case- and whitespace-insensitive",
+			body:           `{"model":"m","reasoning":{"effort":" NONE "}}`,
+			wantMutated:    true,
+			wantSuppress:   true,
+			wantEnabled:    false,
+			wantEnabledSet: true,
+		},
+		{
+			name:           "top-level reasoning_effort none disables",
+			body:           `{"model":"m","reasoning_effort":"none"}`,
+			wantMutated:    true,
+			wantSuppress:   true,
+			wantEnabled:    false,
+			wantEnabledSet: true,
+			check: func(t *testing.T, parsed map[string]any) {
+				if _, ok := parsed["reasoning_effort"]; ok {
+					t.Error("reasoning_effort \"none\" must be removed from the forwarded body")
+				}
+			},
+		},
+		{
+			name:         "non-none efforts are untouched",
+			body:         `{"model":"m","reasoning_effort":"high","reasoning":{"effort":"high"}}`,
+			wantMutated:  false,
+			wantSuppress: false,
+			check: func(t *testing.T, parsed map[string]any) {
+				if parsed["reasoning_effort"] != "high" {
+					t.Errorf("reasoning_effort = %v, want high", parsed["reasoning_effort"])
+				}
+				if effort := parsed["reasoning"].(map[string]any)["effort"]; effort != "high" {
+					t.Errorf("reasoning.effort = %v, want high", effort)
+				}
+			},
+		},
+		{
+			name:           "explicit enabled=true wins over effort none",
+			body:           `{"model":"m","reasoning":{"enabled":true,"effort":"none"}}`,
+			wantMutated:    true, // the unusable "none" effort is still removed
+			wantSuppress:   false,
+			wantEnabled:    true,
+			wantEnabledSet: true,
+		},
+		{
+			name:           "explicit enabled=true wins over top-level effort none",
+			body:           `{"model":"m","reasoning":{"enabled":true},"reasoning_effort":"none"}`,
+			wantMutated:    true,
+			wantSuppress:   false,
+			wantEnabled:    true,
+			wantEnabledSet: true,
+		},
+		{
+			name:         "exclude=true suppresses without disabling",
+			body:         `{"model":"m","reasoning":{"exclude":true}}`,
+			wantMutated:  false,
+			wantSuppress: true,
+		},
+		{
+			name:         "include_reasoning=false suppresses without disabling",
+			body:         `{"model":"m","include_reasoning":false}`,
+			wantMutated:  false,
+			wantSuppress: true,
+		},
+		{
+			name:         "include_reasoning=true is a no-op",
+			body:         `{"model":"m","include_reasoning":true}`,
+			wantMutated:  false,
+			wantSuppress: false,
+		},
+		{
+			name:           "anthropic thinking disabled maps to enabled=false",
+			body:           `{"model":"m","thinking":{"type":"disabled"}}`,
+			wantMutated:    true,
+			wantSuppress:   true,
+			wantEnabled:    false,
+			wantEnabledSet: true,
+		},
+		{
+			name:           "anthropic thinking enabled maps to enabled=true",
+			body:           `{"model":"m","thinking":{"type":"enabled","budget_tokens":2048}}`,
+			wantMutated:    true,
+			wantSuppress:   false,
+			wantEnabled:    true,
+			wantEnabledSet: true,
+		},
+		{
+			name:           "explicit enabled=false wins over thinking enabled",
+			body:           `{"model":"m","reasoning":{"enabled":false},"thinking":{"type":"enabled"}}`,
+			wantMutated:    false,
+			wantSuppress:   true,
+			wantEnabled:    false,
+			wantEnabledSet: true,
+		},
+		{
+			name:         "no reasoning fields is a no-op",
+			body:         `{"model":"m","messages":[{"role":"user","content":"hi"}]}`,
+			wantMutated:  false,
+			wantSuppress: false,
+		},
+		{
+			name:         "non-boolean and null reasoning shapes are tolerated",
+			body:         `{"model":"m","reasoning":{"enabled":null,"effort":7,"exclude":"yes"},"reasoning_effort":3,"include_reasoning":null}`,
+			wantMutated:  false,
+			wantSuppress: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			parsed := parseTestBody(t, tc.body)
+			mutated, suppress := normalizeReasoningControls(parsed)
+			if mutated != tc.wantMutated {
+				t.Errorf("mutated = %v, want %v", mutated, tc.wantMutated)
+			}
+			if suppress != tc.wantSuppress {
+				t.Errorf("suppress = %v, want %v", suppress, tc.wantSuppress)
+			}
+			if tc.wantEnabledSet {
+				enabled, ok := reasoningEnabledValue(t, parsed)
+				if !ok {
+					t.Fatalf("reasoning.enabled missing after normalization: %v", parsed)
+				}
+				if enabled != tc.wantEnabled {
+					t.Errorf("reasoning.enabled = %v, want %v", enabled, tc.wantEnabled)
+				}
+			}
+			if tc.check != nil {
+				tc.check(t, parsed)
+			}
+
+			// Idempotence: the canonical body must not mutate again.
+			if mutatedAgain, suppressAgain := normalizeReasoningControls(parsed); mutatedAgain {
+				t.Error("second normalization pass mutated an already-canonical body")
+			} else if suppressAgain != suppress {
+				t.Errorf("second pass suppress = %v, want %v", suppressAgain, suppress)
+			}
+		})
+	}
+}
+
+// The canonical disable must survive the exact forward-body marshal providers
+// decode — reasoning.enabled=false is the ONLY switch the Swift engine reads.
+func TestNormalizeReasoningControlsForwardBody(t *testing.T) {
+	for _, body := range []string{
+		`{"model":"m","reasoning":{"effort":"none"}}`,
+		`{"model":"m","reasoning_effort":"none"}`,
+		`{"model":"m","thinking":{"type":"disabled"}}`,
+		`{"model":"m","reasoning":{"enabled":false}}`,
+	} {
+		parsed := parseTestBody(t, body)
+		normalizeReasoningControls(parsed)
+		forward, err := marshalForwardBody(parsed)
+		if err != nil {
+			t.Fatalf("marshalForwardBody: %v", err)
+		}
+		if !strings.Contains(string(forward), `"reasoning":{"enabled":false}`) {
+			t.Errorf("forward body for %s lacks the canonical disable: %s", body, forward)
+		}
+		if strings.Contains(string(forward), `"none"`) {
+			t.Errorf("forward body for %s still carries a \"none\" effort: %s", body, forward)
+		}
+	}
+}
+
+func TestStripReasoningFromStreamChunk(t *testing.T) {
+	cases := []struct {
+		name     string
+		chunk    string
+		want     string
+		wantDrop bool
+	}{
+		{
+			name:     "reasoning-only delta is dropped",
+			chunk:    `data: {"id":"c1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"reasoning":"thinking...","reasoning_content":"thinking..."},"finish_reason":null}]}`,
+			wantDrop: true,
+		},
+		{
+			name:  "mixed delta keeps content and loses reasoning",
+			chunk: `data: {"choices":[{"index":0,"delta":{"content":"Hello","reasoning_content":"hmm"},"finish_reason":null}]}`,
+		},
+		{
+			name:  "role preamble with empty reasoning fields is kept",
+			chunk: `data: {"choices":[{"index":0,"delta":{"role":"assistant","content":"","reasoning":"","reasoning_content":""},"finish_reason":null}]}`,
+		},
+		{
+			name:  "finish chunk with reasoning delta is kept",
+			chunk: `data: {"choices":[{"index":0,"delta":{"reasoning_content":"tail"},"finish_reason":"stop"}]}`,
+		},
+		{
+			name:  "usage-bearing reasoning chunk is kept",
+			chunk: `data: {"choices":[{"index":0,"delta":{"reasoning":"tail"},"finish_reason":null}],"usage":{"prompt_tokens":1,"completion_tokens":2,"total_tokens":3,"completion_tokens_details":{"reasoning_tokens":2}}}`,
+		},
+		{
+			name:  "content-only chunk passes through untouched",
+			chunk: `data: {"choices":[{"index":0,"delta":{"content":"hi"},"finish_reason":null}]}`,
+			want:  `data: {"choices":[{"index":0,"delta":{"content":"hi"},"finish_reason":null}]}`,
+		},
+		{
+			name:  "done terminator passes through untouched",
+			chunk: "data: [DONE]",
+			want:  "data: [DONE]",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, drop := stripReasoningFromStreamChunk(tc.chunk)
+			if drop != tc.wantDrop {
+				t.Fatalf("drop = %v, want %v (chunk %q)", drop, tc.wantDrop, got)
+			}
+			if tc.wantDrop {
+				return
+			}
+			if tc.want != "" && got != tc.want {
+				t.Fatalf("chunk rewritten unexpectedly:\n got: %s\nwant: %s", got, tc.want)
+			}
+			payload := strings.TrimPrefix(strings.TrimSpace(got), "data: ")
+			if payload == "[DONE]" {
+				return
+			}
+			var obj map[string]any
+			if err := json.Unmarshal([]byte(payload), &obj); err != nil {
+				t.Fatalf("stripped chunk is not valid JSON: %v\n%s", err, got)
+			}
+			for _, choice := range obj["choices"].([]any) {
+				delta, _ := choice.(map[string]any)["delta"].(map[string]any)
+				for _, field := range reasoningDeltaFields {
+					if _, ok := delta[field]; ok {
+						t.Errorf("delta still carries %q: %s", field, got)
+					}
+				}
+			}
+			// Usage accounting must survive suppression untouched.
+			if strings.Contains(tc.chunk, `"usage":{`) && !strings.Contains(got, `"reasoning_tokens":2`) {
+				t.Errorf("usage reasoning_tokens must be preserved: %s", got)
+			}
+		})
+	}
+}
+
+func TestStripReasoningFromCompleteResponse(t *testing.T) {
+	raw := `{"object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","content":"4","reasoning":"let me think","reasoning_content":"let me think"},"finish_reason":"stop"}],"usage":{"completion_tokens_details":{"reasoning_tokens":12}}}`
+	var obj map[string]any
+	if err := json.Unmarshal([]byte(raw), &obj); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	stripReasoningFromCompleteResponse(obj)
+	message := obj["choices"].([]any)[0].(map[string]any)["message"].(map[string]any)
+	if _, ok := message["reasoning"]; ok {
+		t.Error("message.reasoning must be removed")
+	}
+	if _, ok := message["reasoning_content"]; ok {
+		t.Error("message.reasoning_content must be removed")
+	}
+	if message["content"] != "4" {
+		t.Errorf("content = %v, want 4", message["content"])
+	}
+	details := obj["usage"].(map[string]any)["completion_tokens_details"].(map[string]any)
+	if details["reasoning_tokens"].(float64) != 12 {
+		t.Error("usage reasoning_tokens must be preserved")
+	}
+}
+
+// End-to-end through the chat SSE writer: a suppressed-reasoning stream must
+// deliver content, finish, and usage — and not one byte of reasoning text.
+func TestStreamingSuppressReasoning(t *testing.T) {
+	srv := newDeferredCommitTestServer(t)
+
+	pr := &registry.PendingRequest{
+		RequestID:         "suppress-reasoning-stream",
+		Model:             "m",
+		SuppressReasoning: true,
+		ChunkCh:           make(chan string, 8),
+		ErrorCh:           make(chan protocol.InferenceErrorMessage, 1),
+		CompleteCh:        make(chan protocol.UsageInfo, 1),
+	}
+	pr.ChunkCh <- `data: {"id":"c1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"reasoning_content":" and more"},"finish_reason":null}]}`
+	pr.ChunkCh <- `data: {"id":"c1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"The answer","reasoning_content":"overlap"},"finish_reason":null}]}`
+	pr.ChunkCh <- `data: {"id":"c1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`
+	pr.ChunkCh <- `data: {"id":"c1","object":"chat.completion.chunk","choices":[],"usage":{"prompt_tokens":5,"completion_tokens":9,"total_tokens":14,"completion_tokens_details":{"reasoning_tokens":7}}}`
+	close(pr.ChunkCh)
+	pr.CompleteCh <- protocol.UsageInfo{PromptTokens: 5, CompletionTokens: 9, ReasoningTokens: 7}
+
+	roleChunk := `data: {"id":"c1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}`
+	reasoningFirst := `data: {"id":"c1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"reasoning_content":"thinking hard"},"finish_reason":null}]}`
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	rec := httptest.NewRecorder()
+	srv.handleStreamingResponseWithFirstChunk(rec, req, pr, []string{roleChunk, reasoningFirst}, false)
+
+	body := rec.Body.String()
+	for _, leaked := range []string{"thinking hard", " and more", "overlap"} {
+		if strings.Contains(body, leaked) {
+			t.Errorf("reasoning text %q leaked into a suppressed stream:\n%s", leaked, body)
+		}
+	}
+	if !strings.Contains(body, `"content":"The answer"`) {
+		t.Errorf("content delta missing from suppressed stream:\n%s", body)
+	}
+	if !strings.Contains(body, `"role":"assistant"`) {
+		t.Errorf("role preamble missing from suppressed stream:\n%s", body)
+	}
+	if !strings.Contains(body, `"finish_reason":"stop"`) {
+		t.Errorf("finish chunk missing from suppressed stream:\n%s", body)
+	}
+	// Token accounting is unaffected by text suppression.
+	if !strings.Contains(body, `"reasoning_tokens":7`) {
+		t.Errorf("usage reasoning_tokens missing from suppressed stream:\n%s", body)
+	}
+}
+
+// End-to-end through the non-streaming writer: the reconstructed message must
+// carry no reasoning field when suppression is on.
+func TestNonStreamingSuppressReasoning(t *testing.T) {
+	srv := newDeferredCommitTestServer(t)
+
+	pr := &registry.PendingRequest{
+		RequestID:         "suppress-reasoning-nonstream",
+		Model:             "m",
+		SuppressReasoning: true,
+		ChunkCh:           make(chan string, 4),
+		ErrorCh:           make(chan protocol.InferenceErrorMessage, 1),
+		CompleteCh:        make(chan protocol.UsageInfo, 1),
+	}
+	pr.ChunkCh <- `data: {"id":"c1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"reasoning_content":"pondering"},"finish_reason":null}]}`
+	pr.ChunkCh <- `data: {"id":"c1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"42"},"finish_reason":"stop"}]}`
+	close(pr.ChunkCh)
+	pr.CompleteCh <- protocol.UsageInfo{PromptTokens: 3, CompletionTokens: 4, ReasoningTokens: 2}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	rec := httptest.NewRecorder()
+	srv.handleNonStreamingResponseWithFirstChunk(rec, req, pr, nil)
+
+	body := rec.Body.String()
+	if strings.Contains(body, "pondering") {
+		t.Errorf("reasoning text leaked into a suppressed non-streaming response:\n%s", body)
+	}
+	if !strings.Contains(body, `"content":"42"`) {
+		t.Errorf("content missing from suppressed non-streaming response:\n%s", body)
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("response is not valid JSON: %v", err)
+	}
+	message := resp["choices"].([]any)[0].(map[string]any)["message"].(map[string]any)
+	if _, ok := message["reasoning"]; ok {
+		t.Errorf("message.reasoning present in suppressed response: %v", message)
+	}
+}
+
+// The raw complete-object passthrough (provider returns one chat.completion
+// object instead of SSE deltas) must strip reasoning the same way.
+func TestNonStreamingPassthroughSuppressReasoning(t *testing.T) {
+	srv := newDeferredCommitTestServer(t)
+
+	pr := &registry.PendingRequest{
+		RequestID:         "suppress-reasoning-passthrough",
+		Model:             "m",
+		SuppressReasoning: true,
+		ChunkCh:           make(chan string, 2),
+		ErrorCh:           make(chan protocol.InferenceErrorMessage, 1),
+		CompleteCh:        make(chan protocol.UsageInfo, 1),
+	}
+	pr.ChunkCh <- `data: {"id":"c1","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","content":"done","reasoning_content":"chain of thought"},"finish_reason":"stop"}],"usage":{"prompt_tokens":2,"completion_tokens":3,"total_tokens":5}}`
+	close(pr.ChunkCh)
+	pr.CompleteCh <- protocol.UsageInfo{PromptTokens: 2, CompletionTokens: 3, ReasoningTokens: 1}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	rec := httptest.NewRecorder()
+	srv.handleNonStreamingResponseWithFirstChunk(rec, req, pr, nil)
+
+	body := rec.Body.String()
+	if strings.Contains(body, "chain of thought") {
+		t.Errorf("reasoning text leaked through the passthrough path:\n%s", body)
+	}
+	if !strings.Contains(body, `"content":"done"`) {
+		t.Errorf("content missing from passthrough response:\n%s", body)
+	}
+}

--- a/coordinator/api/responses_stream.go
+++ b/coordinator/api/responses_stream.go
@@ -206,7 +206,16 @@ func (e *responsesStreamEmitter) handleChunk(chunk string) {
 			reasoning = c.Delta.ReasoningContent
 		}
 		if reasoning != "" {
-			e.appendReasoning(reasoning)
+			if e.pr.SuppressReasoning {
+				// Reasoning was disabled or excluded: no reasoning item or
+				// summary event ever reaches the consumer. The text is still
+				// buffered so finish()'s resolveReasoningTokens keeps its
+				// legacy text-based fallback — exclude hides reasoning, it
+				// doesn't unbill it.
+				e.reasoningBuf.WriteString(reasoning)
+			} else {
+				e.appendReasoning(reasoning)
+			}
 		}
 		if c.Delta.Content != "" {
 			e.appendContent(c.Delta.Content)

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -100,6 +100,13 @@ type PendingRequest struct {
 	// the provider's chat-completions wire shape. Response writers translate
 	// chat output back to this endpoint's native JSON/SSE schema.
 	ConsumerEndpoint string
+	// SuppressReasoning marks a request whose consumer-facing response must
+	// not carry reasoning text: the consumer disabled reasoning (any spelling
+	// of reasoning.enabled=false / effort "none") or excluded it
+	// (reasoning.exclude=true / include_reasoning=false). Usage token counts
+	// are unaffected. Written by the consumer handler before the response
+	// writers run and read only on that same goroutine.
+	SuppressReasoning bool
 	// RequestedStopSequences is the caller-authored Anthropic stop allowlist.
 	// MatchedStopSequence is accepted from the provider only when it is a member
 	// of this list, then translated back into native /v1/messages responses.

--- a/provider-swift/Tests/ProviderCoreFoundationTests/ReasoningDisableRenderTests.swift
+++ b/provider-swift/Tests/ProviderCoreFoundationTests/ReasoningDisableRenderTests.swift
@@ -1,0 +1,89 @@
+import XCTest
+
+import Jinja
+
+@testable import ProviderCoreFoundation
+
+/// Pins the reasoning-disable render contract for Qwen3.6-style hybrid
+/// thinking templates (OpenRouter baseline: "Expected reasoning length to be
+/// at most 0").
+///
+/// The coordinator canonicalizes every "reasoning off" spelling into
+/// `reasoning: {"enabled": false}`, which the engine maps to the
+/// `enable_thinking` template variable. The template's disable branch is
+/// gated on the Jinja boolean-literal test:
+///
+///     {%- if enable_thinking is defined and enable_thinking is false %}
+///
+/// so the entire disable path hinges on swift-jinja (1) treating a Swift
+/// `Bool` in `additionalContext` as a Jinja boolean and (2) implementing the
+/// `is false` test against boolean literals. A Jinja engine bump that breaks
+/// either silently re-enables thinking fleet-wide — these tests fail first.
+final class ReasoningDisableRenderTests: XCTestCase {
+
+    /// The exact generation-prompt block of the Qwen3.6 chat template
+    /// (EigenLabs/Qwen3.6-35B-A3B-MLX-VL, mirrored in the registry build's
+    /// chat_template.jinja), reduced to the message loop + generation prompt.
+    private let qwen36GenerationPromptTemplate = """
+        {%- for message in messages %}
+            {%- if message.role == "user" %}
+                {{- '<|im_start|>' + message.role + '\\n' + message.content + '<|im_end|>' + '\\n' }}
+            {%- endif %}
+        {%- endfor %}
+        {%- if add_generation_prompt %}
+            {{- '<|im_start|>assistant\\n' }}
+            {%- if enable_thinking is defined and enable_thinking is false %}
+                {{- '<think>\\n\\n</think>\\n\\n' }}
+            {%- else %}
+                {{- '<think>\\n' }}
+            {%- endif %}
+        {%- endif %}
+        """
+
+    private func render(_ additionalContext: [String: Any?]) throws -> String {
+        let template = try Template(qwen36GenerationPromptTemplate)
+        var context: [String: Jinja.Value] = [
+            "messages": try Value(any: [["role": "user", "content": "hi"] as [String: Any]]),
+            "add_generation_prompt": .boolean(true),
+        ]
+        for (key, value) in additionalContext {
+            context[key] = try Value(any: value)
+        }
+        return try template.render(context)
+    }
+
+    func testEnableThinkingFalsePreClosesThinkBlock() throws {
+        let rendered = try render(["enable_thinking": false])
+        XCTAssertTrue(
+            rendered.hasSuffix("<|im_start|>assistant\n<think>\n\n</think>\n\n"),
+            "disabled thinking must render the pre-closed think block; got tail: \(rendered.suffix(64))")
+    }
+
+    func testEnableThinkingAbsentKeepsThinkingOn() throws {
+        let rendered = try render([:])
+        XCTAssertTrue(
+            rendered.hasSuffix("<|im_start|>assistant\n<think>\n"),
+            "hybrid templates think by default; got tail: \(rendered.suffix(64))")
+    }
+
+    func testEnableThinkingTrueKeepsThinkingOn() throws {
+        let rendered = try render(["enable_thinking": true])
+        XCTAssertTrue(
+            rendered.hasSuffix("<|im_start|>assistant\n<think>\n"),
+            "explicit enable must keep the open think block; got tail: \(rendered.suffix(64))")
+    }
+
+    /// The pre-closed (disabled) tail must never be mistaken for an open
+    /// think block by the synthetic `<think>` injection probe — the parser
+    /// would otherwise classify the whole answer as reasoning.
+    func testDisabledTailIsNotAnOpenThinkBlock() throws {
+        let rendered = try render(["enable_thinking": false])
+        var tail = Substring(rendered)
+        while let last = tail.last, last.isWhitespace {
+            tail.removeLast()
+        }
+        XCTAssertFalse(
+            tail.hasSuffix("<think>"),
+            "disabled tail must end with </think>, not an open <think>")
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Summary

OpenRouter's baseline tests flagged the Qwen3.6 35B endpoint: with reasoning disabled, responses still carried ~2K chars of reasoning (`Expected reasoning length to be at most 0, got 2134`).

**Root cause.** Providers decode exactly ONE reasoning switch from the sealed body — `reasoning: {"enabled": false}` — which the Swift engine maps to the `enable_thinking` chat-template variable. The Qwen3.6 template (`EigenLabs/Qwen3.6-35B-A3B-MLX-VL-4bit-g64-router8`, byte-identical to the registry build's `chat_template.jinja`) thinks **by default** and only pre-closes the think block on `enable_thinking is false`. That canonical spelling works end-to-end (verified by rendering the real shipped template through the pinned `swift-jinja` 2.3.5). But OpenRouter/OpenAI/Anthropic spell "reasoning off" several other ways, and every other spelling was forwarded un-normalized and silently ignored by the template, so the model reasoned anyway:

| Spelling | Before | After |
|---|---|---|
| `reasoning: {"enabled": false}` | honored | honored (unchanged) |
| `reasoning: {"effort": "none"}` (OpenRouter's OpenAI-style disable) | ignored → reasoning produced | canonicalized to `enabled:false` |
| `reasoning_effort: "none"` (top-level shorthand) | ignored → reasoning produced | canonicalized to `enabled:false` |
| `thinking: {"type": "disabled"}` (Anthropic `/v1/messages`) | ignored → reasoning produced | canonicalized to `enabled:false` |
| `reasoning: {"exclude": true}` / `include_reasoning: false` | ignored → reasoning returned | reasoning text stripped from the response (usage token counts intact) |

# What changed

- **`coordinator/api/reasoning_controls.go` (new)** — `normalizeReasoningControls` canonicalizes every disable spelling into `reasoning: {"enabled": false}` in the parsed body; explicit `reasoning.enabled` booleans always win, and a concrete `reasoning.effort` wins over a contradictory legacy top-level `reasoning_effort:"none"` (OpenRouter parameter hierarchy); `"none"` efforts are removed so no template ever renders a literal `none` effort level. Plus response-side helpers `stripReasoningFromStreamChunk` (skips reasoning-only SSE deltas, strips reasoning fields from mixed/`message`-shaped chunks, never touches finish/usage/role/tool chunks) and `stripReasoningFromCompleteResponse`.
- **`coordinator/api/inference_preprocess.go`** — the shared inference prelude (chat completions + Responses + completions + Anthropic messages) runs the normalization **before the body is sealed**, so the entire deployed provider fleet honors the disable with no provider release, and the prompt-sidecar/provider render parity is preserved (both sides only ever see the canonical shape).
- **`coordinator/registry/registry.go`** — new `PendingRequest.SuppressReasoning` flag.
- **`coordinator/api/consumer.go` + `coordinator/api/dispatch.go`** — flag threaded through primary/speculative/queued dispatch and the generic handler; suppression enforced in the chat SSE writer (both the held-first-chunks loop and the relay loop), in `finalizeFinishChunk` (a held terminal chunk carrying both `finish_reason` and a trailing reasoning delta is re-emitted at stream end after suppression ran — it is stripped at the re-emit point), and in both non-streaming paths (raw `chat.completion` passthrough + SSE reconstruction). Suppression also applies to *disabled* requests as belt-and-braces: even if the model opens its own `<think>` block despite the pre-closed prompt, the consumer who asked for zero reasoning gets zero reasoning.
- **`coordinator/api/responses_stream.go`** — the Responses-API streaming emitter honors `SuppressReasoning`: no reasoning item or `reasoning_summary_*` event is emitted, while the text is still buffered so usage accounting keeps its legacy text-based fallback.
- **Usage accounting is deliberately untouched everywhere**: `completion_tokens_details.reasoning_tokens` stays accurate under suppression (the reconstruction path resolves the token count *before* discarding the text) — exclude hides reasoning, it doesn't unbill it.
- **`provider-swift/Tests/ProviderCoreFoundationTests/ReasoningDisableRenderTests.swift` (new)** — pins the swift-jinja render contract the whole disable hinges on: `enable_thinking is defined and enable_thinking is false` with a Swift `Bool` must pre-close the think block (a Jinja engine bump that breaks the boolean-literal test would silently re-enable thinking fleet-wide).

# Behavior: before → after

```mermaid
flowchart LR
  subgraph Before
    A1["POST /v1/chat/completions<br/>reasoning: {effort: none}"] --> B1[coordinator forwards body verbatim]
    B1 --> C1["provider decodes reasoning.enabled = nil<br/>no enable_thinking in template context"]
    C1 --> D1["Qwen3.6 template defaults to<br/>…assistant\n&lt;think&gt;\n (thinking ON)"]
    D1 --> E1["response carries ~2K chars of reasoning<br/>baseline FAILS: expected ≤ 0, got 2134"]
  end
```

```mermaid
flowchart LR
  subgraph After
    A2["POST /v1/chat/completions<br/>reasoning: {effort: none} / reasoning_effort: none /<br/>thinking: {type: disabled} / enabled: false"] --> B2["normalizeReasoningControls<br/>canonical: reasoning: {enabled: false}"]
    B2 --> C2["provider decodes reasoning.enabled = false<br/>enable_thinking=false in template context"]
    C2 --> D2["template pre-closes the block:<br/>…assistant\n&lt;think&gt;\n\n&lt;/think&gt;\n\n (thinking OFF)"]
    D2 --> E2["SuppressReasoning writers strip any residual<br/>reasoning text (exclude:true uses the same path;<br/>chat SSE + non-streaming + Responses streaming)"]
    E2 --> F2["response: content only, reasoning length 0<br/>usage.reasoning_tokens still accurate"]
  end
```

# Code: before → after

```mermaid
flowchart LR
  subgraph Before
    P1[parseInferencePrelude] --> H1[handleChatCompletions / handleGenericInference]
    H1 --> S1["seal body (reasoning.effort/none et al. forwarded, unread)"]
    S1 --> W1["streaming + non-streaming + Responses writers<br/>forward reasoning deltas unconditionally"]
  end
```

```mermaid
flowchart LR
  subgraph After
    P2[parseInferencePrelude] --> N2["normalizeReasoningControls<br/>(reasoning_controls.go)"]
    N2 -->|"mutated → re-marshal rawBody"| S2["seal canonical body"]
    N2 -->|suppress| F2b["prelude.suppressReasoning → dispatchState →<br/>PendingRequest.SuppressReasoning<br/>(primary / speculative / queued / generic)"]
    F2b --> W2a["handleStreamingResponseWithFirstChunk:<br/>stripReasoningFromStreamChunk per chunk +<br/>finalizeFinishChunk strips held terminal chunk"]
    F2b --> W2b["handleNonStreamingResponseWithFirstChunk:<br/>stripReasoningFromCompleteResponse (passthrough) /<br/>resolve reasoning_tokens then clear msg.Reasoning (reconstruction)"]
    F2b --> W2c["responsesStreamEmitter.handleChunk:<br/>buffer reasoning for usage, emit nothing"]
  end
```

# Evidence

- Rendered the **actual shipped Qwen3.6 template** (fetched from `models.darkbloom.ai`, SHA-256-identical to the HF repo file) through the exact pinned `swift-jinja` 2.3.5 on Linux: `enable_thinking=false` (Swift Bool) → `<think>\n\n</think>\n\n` (disabled); key absent / `true` → `<think>\n` (thinking on). This proves the canonical spelling works and the failing spellings were the un-normalized ones.
- `go test ./...` in `coordinator/` — all packages green (api 115s, registry, promptcontract, protocol, …); `-race` clean on the writer-level suppression tests.
- New tests: `TestNormalizeReasoningControls` (16 spellings/precedence/idempotence cases), `TestNormalizeReasoningControlsForwardBody`, `TestStripReasoningFromStreamChunk` (incl. message-shaped chunks), `TestStripReasoningFromCompleteResponse`, and end-to-end writer tests `TestStreamingSuppressReasoning`, `TestStreamingSuppressReasoningOnHeldFinishChunk`, `TestNonStreamingSuppressReasoning`, `TestNonStreamingSuppressReasoningKeepsLegacyUsageFallback`, `TestNonStreamingPassthroughSuppressReasoning`, `TestResponsesStreamingSuppressReasoning`.
- Two independent review passes: correctness reviewer PASS (all dispatch/body paths traced, race-checked); edge-case reviewer's findings (Responses streaming gap, legacy-usage fallback, effort precedence, message-shaped chunks) all fixed with regression tests in the follow-up commits.

# Ops follow-up (not in this PR)

The registry entry for `qwen3.6-35b-a3b-vl-mtp-mxfp8` advertises `capabilities: ["chat","tools","vision"]` — no `reasoning`, so our OpenRouter feed's `supported_parameters` omits `reasoning`/`include_reasoning` even though the model reasons by default. After this deploys, the model should be granted the `reasoning` capability via `POST /v1/admin/models/qwen3.6-35b-a3b-vl-mtp-mxfp8/capabilities` (human-approved prod mutation) so OpenRouter lists the reasoning controls it now actually honors.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a00231-4c1b-7b6c-a5a6-2062d550d741?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a00231-4c1b-7b6c-a5a6-2062d550d741&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/626"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789337675&installation_model_id=21733&pr_number=626&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F626&signature=4fe3b7db7ccf054fd4ce6d22e9977bc5aec9086e017e0d2ba41d3cf772a0e0ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->