### PR TITLE
chore(release): prepare provider v0.8.5 — Qwen3.6 speed stack (prefill tiles, MTP capture-verify, UAF fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,32 @@
 # Changelog
 
-## Unreleased (v0.8.4 candidate - provider)
+## Unreleased (v0.8.5 candidate - provider)
+
+### Provider (Swift)
+
+#### Performance
+
+- **Qwen3.6 E=256 expert-tile prefill route + fused gate_up** - Instantiates the Gemma4 descriptor/tile kernel family for Qwen's 256-expert shapes (mlx `d3c82db`), fuses the routed gate/up projection into one gather (`SwitchGLU(fuseGateUp: true)`, per-layer and per-load with heterogeneous-quantization split fallback across every checkpoint key space), and adds the opt-in `trust` refinement that skips the per-chunk retract drain. Measured on M4 Max, prod artifact: routed MoE block -26.3% at T=512; end-to-end prefill 1243→1364 tok/s default, 1433 with `trust` (+15.2%) at 8k; 2k +7.4%, 32k +6.6%. (#617, mlx-swift-lm#107)
+- **Qwen3.6 MTP: GDN capture-verify, target_prefix acceptance, single-forward drafts** *(behind the `mtp` beta flag, default off)* - Replaces the serial target verify (measured 0.70x vs MTP-off) with one `[1,1+k]` forward capturing per-position recurrent states (1.08x), lifts the `temperature == 0` eligibility gate via pre-sampled target-token acceptance (exact at any temperature; temp-0.7 speculates at 0.70-0.77 acceptance), and defers the draft pair to eliminate the second MTP-head forward + 286 MB lm_head re-read per round: **116.5 tok/s vs 104.8 MTP-off (1.11-1.13x) at 0.78 acceptance**, B=1 greedy, release, paired sessions. (#616, mlx-swift-lm#106/#108)
+- **mlx gpu::eval use-after-free fix** - A stale `MTL::CommandBuffer` captured across `eval_gpu` could crash any primitive that syncs mid-eval (deterministic SIGSEGV on the E=256 route; previously survived on allocator luck). (mlx#5/#7)
+
+#### Fixes
+
+- **Inline-MTP inspection resolves HF-cache symlinks and rejects loudly** - Symlinked snapshots (the standard HF `blobs/` layout) silently disabled inline MTP: `inspectInlineArtifact` required regular files and reported nothing. Inspection now resolves links and validates targets; every genuine rejection logs a concrete reason and path. Untrusted operator-path inspection stays symlink-rejecting. (#618)
+
+#### Observability
+
+- **MTP posture and acceptance on the local `/metrics` endpoint** - `mtp_enabled`, `mtp_active`, `mtp_rounds_total`, `mtp_tokens_proposed_total`, `mtp_tokens_accepted_total`, and `mtp_inactive_reason{model,reason}` (including `inline_artifact_invalid`) in both `--local` and unified serving modes - acceptance was previously observable only in Datadog Logs. (#619)
 
 ### Coordinator
 
 #### Fixes
 
-- **Expose exact Hugging Face repositories in model feeds** - Registry metadata can now override `hugging_face_id` independently of the internal routing ID. Both `/v1/models` and `/v1/models/openrouter` honor the override for concrete and aliased models, with an authenticated `hugging-face-id` admin action for existing registry rows.
+- **Expose exact Hugging Face repositories in model feeds** - Registry metadata can now override `hugging_face_id` independently of the internal routing ID. Both `/v1/models` and `/v1/models/openrouter` honor the override for concrete and aliased models, with an authenticated `hugging-face-id` admin action for existing registry rows. (#620)
+
+---
+
+## v0.8.4 (2026-08-13)
 
 ### Provider (Swift)
 

--- a/coordinator/api/server.go
+++ b/coordinator/api/server.go
@@ -151,7 +151,7 @@ func keyLimitResetFromContext(ctx context.Context) string {
 // the provider's EngineV2Factory.prepareProductionBackend for the argument).
 // Keep this fallback in sync with ProviderCore.version so dev/in-memory
 // coordinators advertise the same floor as the Swift binary they expect.
-var LatestProviderVersion = "0.8.4"
+var LatestProviderVersion = "0.8.5"
 
 // minProviderVersionForDesiredModels is the first provider version whose Swift
 // runtime understands the desired_models message. The coordinator must NOT send

--- a/provider-swift/Sources/ProviderCore/ProviderCore.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderCore.swift
@@ -214,5 +214,10 @@ public enum ProviderCore {
     // synthesizes the template's pre-opened <think> so the streaming parser
     // stops buffering the whole block (TTFT was 755ms + 12.5ms per
     // reasoning token; now first-token latency).
-    public static let version = "0.8.4"
+    // 0.8.5 ships the Qwen3.6 speed stack: E=256 expert-tile prefill route
+    // (+15% at 8k with trust) with fused gate_up, MTP GDN capture-verify +
+    // target_prefix + single-forward drafts (1.13x, behind the mtp beta
+    // flag), symlink-proof inline-MTP inspection, MTP /metrics counters,
+    // and hardened plaintext egress paths.
+    public static let version = "0.8.5"
 }


### PR DESCRIPTION
Release prep for **provider v0.8.5** — ships the Qwen3.6 speed stack (all engine work merged over the last day).

## Contents (fleet-effective)

| Change | Default state | Measured |
|---|---|---|
| E=256 expert-tile prefill + fused gate_up (#617, mlx-swift-lm#107, mlx#7) | **on** (tile route config-on, sync mode; `trust` opt-in) | 8k prefill 1243→1364 default / **1433 with trust (+15.2%)**; MoE block −26.3% @T=512 |
| MTP: GDN capture-verify + `target_prefix` + single-forward drafts (#616, mlx-swift-lm#106/#108) | **off** (`mtp` beta flag) | **116.5 vs 104.8 tok/s (1.11–1.13x)** B=1 greedy, a=0.78; temp-0.7 speculates (0.70–0.77) |
| mlx `gpu::eval` use-after-free fix (mlx#5/#7) | on | removes a latent crash prod Gemma survives on allocator luck |
| Symlink-proof inline-MTP inspection (#618) | on | HF-cache layouts stop silently disabling MTP |
| MTP `/metrics` counters (#619) | on | acceptance observable headless (`mtp_*`, `inline_artifact_invalid` visible) |
| Plaintext egress hardening (#612) | on | — |

## Changes in this PR

- `ProviderCore.version` → `0.8.5` (+ version-history comment)
- `coordinator/api/server.go` `LatestProviderVersion` → `0.8.5` (AGENTS.md sync rule; no-release-row display fallback only)
- `CHANGELOG.md`: v0.8.4 section closed out (dated 2026-08-13), new v0.8.5 candidate section with measured numbers

## Behavior / code

```mermaid
flowchart LR
  subgraph Before
    A1["fleet on v0.8.4"] --> B1["qwen3.6: prefill 1243 tok/s @8k<br/>MTP inert (serial verify + symlink bug)<br/>acceptance unobservable"]
  end
  subgraph After
    A2["fleet self-updates to v0.8.5"] --> B2["prefill +9.7% default / +15.2% trust<br/>MTP stack ready behind beta flag (1.13x, any-temp)<br/>metrics + fail-loud artifacts + UAF fixed"]
  end
```

## Verification

- CI green on master head `6f7960e` (provider tests + coordinator + UI); integration.yml green on master ×3
- This branch: `go build ./...` + coordinator version/release API tests green; `swift build --target ProviderCore` green
- All measurements: release builds, paired same-session A/Bs, APFS-cloned snapshot, MTP activation verified (method: `notes/qwen36-baseline-2026-08-13.md` on `perf/qwen36-baseline`)

## After merge

Tag `v0.8.5` on the merge commit → `release-swift.yml` (sign → notarize → hash → register) → prod-gate approval → fleet self-update. Then: flip the `mtp` beta flag on ONE canary provider and watch `mtp_acceptance_rate` via the new `/metrics` before any fleet-default change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/627"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789339685&installation_model_id=21733&pr_number=627&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F627&signature=54996ea3f8b71af1179fc22989f6e7b79e3adae7664628fcf922d7a8aa3da69e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->