### PR TITLE
fix(provider): normalize Qwen system histories

### DIFF
--- a/provider-swift/Sources/ProviderCore/Inference/ChatTemplateFixes.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/ChatTemplateFixes.swift
@@ -22,15 +22,18 @@ enum ChatTemplateFixes {
         context: ChatTemplateFixContext
     ) throws -> [[String: any Sendable]] {
         let sanitized = sanitizeJinjaMessages(messages)
-        try validateGenericToolHistory(sanitized)
+        let normalized = Qwen35TemplateFix.applies(to: context)
+            ? Qwen35TemplateFix.normalizeMessages(sanitized)
+            : sanitized
+        try validateGenericToolHistory(normalized)
 
         if GPTOSSHarmonyTemplateFix.applies(to: context) {
-            return try GPTOSSHarmonyTemplateFix.normalizeMessages(sanitized)
+            return try GPTOSSHarmonyTemplateFix.normalizeMessages(normalized)
         }
         if Gemma4TemplateFix.applies(to: context) {
-            return try Gemma4TemplateFix.normalizeMessages(sanitized)
+            return try Gemma4TemplateFix.normalizeMessages(normalized)
         }
-        return sanitized
+        return normalized
     }
 
     static func normalizeTools(

--- a/provider-swift/Sources/ProviderCore/Inference/Qwen35TemplateFixes.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/Qwen35TemplateFixes.swift
@@ -1,0 +1,84 @@
+// Copyright © 2026 Eigen Labs.
+//
+// Qwen 3.5/3.6's published chat template accepts a system message only at
+// messages[0]. OpenAI-compatible clients may legally append later system turns
+// to a conversation history. Fold those turns into one leading system message
+// before Jinja rendering instead of letting the template throw a deterministic
+// "System message must be at the beginning" error.
+
+import Foundation
+
+enum Qwen35TemplateFix {
+    static func applies(to context: ChatTemplateFixContext) -> Bool {
+        if let modelType = context.modelType?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased(),
+            modelType == "qwen3_5_moe"
+        {
+            return true
+        }
+
+        guard let modelId = context.modelId?.lowercased() else { return false }
+        return modelId.contains("qwen3.5")
+            || modelId.contains("qwen3_5")
+            || modelId.contains("qwen3.6")
+            || modelId.contains("qwen3_6")
+    }
+
+    static func normalizeMessages(
+        _ messages: [[String: any Sendable]]
+    ) -> [[String: any Sendable]] {
+        let systemIndices = messages.indices.filter {
+            (messages[$0]["role"] as? String) == "system"
+        }
+        guard let firstSystemIndex = systemIndices.first else { return messages }
+        guard systemIndices.count > 1 || firstSystemIndex != messages.startIndex else {
+            return messages
+        }
+
+        let nonSystemMessages = messages.filter {
+            ($0["role"] as? String) != "system"
+        }
+        if systemIndices.count == 1 {
+            return [messages[firstSystemIndex]] + nonSystemMessages
+        }
+
+        let systemMessages = systemIndices.map { messages[$0] }
+        var systemTexts: [String] = []
+        systemTexts.reserveCapacity(systemMessages.count)
+        for message in systemMessages {
+            guard let text = systemTextContent(message["content"]) else {
+                // Images, video, and unknown structured content are not safe to
+                // move into Qwen's leading system slot. Preserve the template's
+                // deterministic rejection instead of changing their semantics.
+                return messages
+            }
+            if !text.isEmpty { systemTexts.append(text) }
+        }
+
+        var mergedSystem = systemMessages[0]
+        mergedSystem["content"] = systemTexts.joined(separator: "\n\n")
+        return [mergedSystem] + nonSystemMessages
+    }
+
+    private static func systemTextContent(_ content: (any Sendable)?) -> String? {
+        guard let content else { return "" }
+        if let text = content as? String { return text }
+        guard let parts = content as? [any Sendable] else { return nil }
+
+        var text = ""
+        for part in parts {
+            guard let object = part as? [String: any Sendable],
+                  object["image"] == nil,
+                  object["image_url"] == nil,
+                  object["video"] == nil,
+                  object["video_url"] == nil,
+                  let partText = object["text"] as? String
+            else {
+                return nil
+            }
+            text += partText
+        }
+        return text
+    }
+}

--- a/provider-swift/Sources/ProviderCore/ProviderCore.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderCore.swift
@@ -218,6 +218,7 @@ public enum ProviderCore {
     // (+15% at 8k with trust) with fused gate_up, MTP GDN capture-verify +
     // target_prefix + single-forward drafts (1.13x, behind the mtp beta
     // flag), symlink-proof inline-MTP inspection, MTP /metrics counters,
-    // and hardened plaintext egress paths.
+    // hardened plaintext egress paths, and Qwen3.5/3.6 late-system history
+    // normalization before template rendering.
     public static let version = "0.8.5"
 }

--- a/provider-swift/Tests/ProviderCoreTests/Qwen35TemplateFixesTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/Qwen35TemplateFixesTests.swift
@@ -1,0 +1,160 @@
+import Testing
+
+@testable import ProviderCore
+
+@Suite("Qwen 3.5/3.6 template compatibility")
+struct Qwen35TemplateFixesTests {
+    private let qwenContext = ChatTemplateFixContext(
+        modelId: "qwen3.6-35b-a3b-vl-mtp-mxfp8",
+        modelType: "qwen3_5_moe")
+
+    private func message(
+        _ role: String,
+        _ content: String
+    ) -> [String: any Sendable] {
+        ["role": role, "content": content]
+    }
+
+    private func roles(_ messages: [[String: any Sendable]]) -> [String] {
+        messages.compactMap { $0["role"] as? String }
+    }
+
+    @Test func appliesOnlyToQwen35Family() {
+        #expect(Qwen35TemplateFix.applies(to: qwenContext))
+        #expect(Qwen35TemplateFix.applies(
+            to: .init(modelId: nil, modelType: "qwen3_5_moe")))
+        #expect(Qwen35TemplateFix.applies(
+            to: .init(modelId: "mlx-community/Qwen3.6-35B", modelType: nil)))
+        #expect(!Qwen35TemplateFix.applies(
+            to: .init(modelId: "qwen3-8b", modelType: "qwen3")))
+        #expect(!Qwen35TemplateFix.applies(
+            to: .init(modelId: "gemma-4-26b", modelType: "gemma4_text")))
+    }
+
+    @Test func movesSingleLateSystemMessageToBeginning() throws {
+        let normalized = try ChatTemplateFixes.normalizeMessages(
+            [
+                message("user", "first question"),
+                message("assistant", "first answer"),
+                message("system", "follow the updated policy"),
+                message("user", "next question"),
+            ],
+            context: qwenContext)
+
+        #expect(roles(normalized) == ["system", "user", "assistant", "user"])
+        #expect(normalized[0]["content"] as? String == "follow the updated policy")
+    }
+
+    @Test func mergesMultipleSystemMessagesInHistoryOrder() throws {
+        let normalized = try ChatTemplateFixes.normalizeMessages(
+            [
+                message("system", "base policy"),
+                message("user", "first question"),
+                message("system", "new restriction"),
+                message("assistant", "answer"),
+                message("system", "final reminder"),
+                message("user", "next question"),
+            ],
+            context: qwenContext)
+
+        #expect(roles(normalized) == ["system", "user", "assistant", "user"])
+        #expect(
+            normalized[0]["content"] as? String
+                == "base policy\n\nnew restriction\n\nfinal reminder")
+    }
+
+    @Test func normalizesBeforeGenericToolHistoryValidation() throws {
+        let toolCall: [String: any Sendable] = [
+            "id": "call-1",
+            "type": "function",
+            "function": [
+                "name": "lookup",
+                "arguments": [String: any Sendable](),
+            ] as [String: any Sendable],
+        ]
+        let assistant: [String: any Sendable] = [
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [toolCall] as [any Sendable],
+        ]
+        let toolResult: [String: any Sendable] = [
+            "role": "tool",
+            "content": "result",
+            "tool_call_id": "call-1",
+        ]
+
+        let normalized = try ChatTemplateFixes.normalizeMessages(
+            [
+                message("user", "look this up"),
+                assistant,
+                message("system", "use trusted sources"),
+                toolResult,
+            ],
+            context: qwenContext)
+
+        #expect(roles(normalized) == ["system", "user", "assistant", "tool"])
+    }
+
+    @Test func leavesVisionUserContentUntouched() throws {
+        let userContent: [any Sendable] = [
+            ["type": "text", "text": "describe this"] as [String: any Sendable],
+            [
+                "type": "image_url",
+                "image_url": ["url": "https://example.invalid/image.png"]
+                    as [String: any Sendable],
+            ] as [String: any Sendable],
+        ]
+        let user: [String: any Sendable] = ["role": "user", "content": userContent]
+
+        let normalized = try ChatTemplateFixes.normalizeMessages(
+            [user, message("system", "be concise")],
+            context: qwenContext)
+
+        #expect(roles(normalized) == ["system", "user"])
+        let normalizedContent = try #require(normalized[1]["content"] as? [any Sendable])
+        #expect(normalizedContent.count == 2)
+        #expect((normalizedContent[1] as? [String: any Sendable])?["type"] as? String == "image_url")
+    }
+
+    @Test func mergesTextPartSystemContent() throws {
+        let systemParts: [any Sendable] = [
+            ["type": "text", "text": "base "] as [String: any Sendable],
+            ["type": "text", "text": "policy"] as [String: any Sendable],
+        ]
+        let system: [String: any Sendable] = ["role": "system", "content": systemParts]
+
+        let normalized = try ChatTemplateFixes.normalizeMessages(
+            [system, message("user", "question"), message("system", "late reminder")],
+            context: qwenContext)
+
+        #expect(roles(normalized) == ["system", "user"])
+        #expect(normalized[0]["content"] as? String == "base policy\n\nlate reminder")
+    }
+
+    @Test func doesNotCoerceMediaSystemContent() throws {
+        let mediaContent: [any Sendable] = [
+            [
+                "type": "image_url",
+                "image_url": ["url": "https://example.invalid/system.png"]
+                    as [String: any Sendable],
+            ] as [String: any Sendable]
+        ]
+        let mediaSystem: [String: any Sendable] = [
+            "role": "system", "content": mediaContent,
+        ]
+
+        let normalized = try ChatTemplateFixes.normalizeMessages(
+            [message("system", "base"), message("user", "question"), mediaSystem],
+            context: qwenContext)
+
+        #expect(roles(normalized) == ["system", "user", "system"])
+    }
+
+    @Test func nonQwenHistoryIsNotReordered() throws {
+        let normalized = try ChatTemplateFixes.normalizeMessages(
+            [message("user", "question"), message("system", "late policy")],
+            context: .init(modelId: "gemma-4-26b", modelType: "gemma4_text"))
+
+        #expect(roles(normalized) == ["user", "system"])
+    }
+}


### PR DESCRIPTION
## Summary

- add a Qwen 3.5/3.6-specific chat-template normalization hook
- move a single late `system` turn to the beginning
- merge multiple text-only system turns in history order
- normalize before generic tool-history validation so valid tool-result histories remain valid
- preserve non-Qwen histories and fail closed for media/unknown structured system content

Production evidence: Qwen 3.6 returned 265 deterministic `template_render_failed` 422s in the observed hour across 18-19 healthy v0.8.4 providers. The published template raises `System message must be at the beginning.` for any later system turn.

## Before

```mermaid
flowchart LR
  A[OpenAI history with late system turn] --> B[ChatTemplateFixes sanitize]
  B --> C[Qwen Jinja render]
  C --> D[TemplateException]
  D --> E[HTTP 422 template_render_failed]
```

Code flow: `ChatTemplateFixes.normalizeMessages` validated the original order and passed Qwen histories through unchanged.

## After

```mermaid
flowchart LR
  A[OpenAI history with late system turn] --> B[ChatTemplateFixes sanitize]
  B --> C[Qwen35TemplateFix normalize]
  C --> D[One leading system turn]
  D --> E[Generic tool-history validation]
  E --> F[Qwen Jinja render]
  F --> G[Inference proceeds]
```

Code flow: `Qwen35TemplateFix` is gated by model ID/type, folds text-only system turns into the leading slot, retains all non-system turns in order, and leaves unsupported media system content unchanged so the existing deterministic rejection remains fail-closed.

## Verification

- `swift test --filter Qwen35TemplateFixesTests` — 8 tests passed
- `make provider-test` — 2,098 tests passed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/629"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789344818&installation_model_id=21733&pr_number=629&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F629&signature=41e3afde37ea935af789a295dfc250c19ab0232171c5254ae4ed1441ffb83169"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->