### PR TITLE
fix(api): emit canonical reasoning details

### DIFF
--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -2924,6 +2924,7 @@ func extractMessageWithReasoningPolicy(chunks []string, preferReasoningContent b
 	finishReason := ""
 	var reasoningDetails any
 	reasoningDetailsPresent := false
+	reasoningDetailsNull := false
 	// See toolCallAccumulator for the logical-call model (arrival order,
 	// non-unique wire indices, the maxLogicalToolCalls cap).
 	acc := newToolCallAccumulator()
@@ -3003,16 +3004,18 @@ func extractMessageWithReasoningPolicy(chunks []string, preferReasoningContent b
 					if json.Unmarshal(rawDetails, &details) != nil {
 						continue
 					}
-					if !reasoningDetailsPresent {
+					if !reasoningDetailsPresent || reasoningDetailsNull {
 						reasoningDetails = make([]json.RawMessage, 0, len(details))
 						reasoningDetailsPresent = true
+						reasoningDetailsNull = false
 					}
 					if accumulated, ok := reasoningDetails.([]json.RawMessage); ok {
 						reasoningDetails = append(accumulated, details...)
 					}
-				} else if !reasoningDetailsPresent {
+				} else if !reasoningDetailsPresent || reasoningDetailsNull {
 					reasoningDetails = json.RawMessage(append([]byte(nil), rawDetails...))
 					reasoningDetailsPresent = true
+					reasoningDetailsNull = bytes.Equal(trimmed, []byte("null"))
 				}
 			}
 			toolCalls := c.Delta.ToolCalls

--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -15,6 +15,7 @@ package api
 //   WebSocket. Providers are attested via Secure Enclave challenge-response.
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -2004,15 +2005,17 @@ func (s *Server) handleStreamingResponseWithFirstChunk(w http.ResponseWriter, r 
 		// at stream end instead of being emitted raw without reasoning_tokens.
 		if obj, isUsage := parseUsageOnlyStreamChunk(firstChunk); !sawResponsesAPI && isUsage {
 			pendingUsage = obj
-		} else if obj, isFinish := parseFinishStreamChunk(normalizeSSEChunk(firstChunk)); !sawResponsesAPI && isFinish {
-			pendingFinish = obj
 		} else {
 			if !sawResponsesAPI {
 				firstChunk = normalizeSSEChunk(firstChunk)
 			}
-			firstChunk = rewriteChunkModel(firstChunk, pr)
-			fmt.Fprintf(w, "%s\n\n", firstChunk)
-			flusher.Flush()
+			if obj, isFinish := parseFinishStreamChunk(firstChunk); !sawResponsesAPI && isFinish {
+				pendingFinish = obj
+			} else {
+				firstChunk = rewriteChunkModel(firstChunk, pr)
+				fmt.Fprintf(w, "%s\n\n", firstChunk)
+				flusher.Flush()
+			}
 		}
 	}
 
@@ -2413,8 +2416,13 @@ func (s *Server) handleNonStreamingResponseWithFirstChunk(w http.ResponseWriter,
 					}
 				}
 
-				// Fallback: SSE delta chunks — reconstruct into response.
-				msg := extractMessage(chunks)
+				// Only reconstructed chat-completions use provider-canonical
+				// reasoning_content precedence. Responses and generic endpoints keep
+				// the historical reasoning-first extraction contract.
+				preferReasoningContent := !pr.IsResponsesAPI &&
+					pr.ConsumerEndpoint != completionsEndpoint &&
+					pr.ConsumerEndpoint != messagesEndpoint
+				msg := extractMessageWithReasoningPolicy(chunks, preferReasoningContent)
 				select {
 				case usage, ok := <-pr.CompleteCh:
 					if !ok {
@@ -2508,21 +2516,57 @@ func normalizeCompleteChatResponse(obj map[string]any, requestedModel string) {
 	if !ok {
 		return
 	}
-	for _, rawChoice := range choices {
+	for choicePosition, rawChoice := range choices {
 		choice, ok := rawChoice.(map[string]any)
 		if !ok {
 			continue
 		}
+		choiceIndex := normalizedChoiceIndex(choice["index"], choicePosition)
 		if message, ok := choice["message"].(map[string]any); ok {
-			normalizeCompleteMessage(message)
+			normalizeCompleteMessage(message, choiceIndex)
 		}
 		if delta, ok := choice["delta"].(map[string]any); ok {
-			normalizeCompleteMessage(delta)
+			normalizeCompleteMessage(delta, choiceIndex)
 		}
 	}
 }
 
-func normalizeCompleteMessage(message map[string]any) {
+func canonicalReasoningDetails(reasoning string, choiceIndex int) []types.ReasoningDetail {
+	return []types.ReasoningDetail{{
+		Type:   "reasoning.text",
+		Text:   reasoning,
+		ID:     "reasoning-text-" + strconv.Itoa(choiceIndex),
+		Format: "unknown",
+		Index:  0,
+	}}
+}
+
+func normalizedChoiceIndex(raw any, fallback int) int {
+	switch index := raw.(type) {
+	case int:
+		if index >= 0 {
+			return index
+		}
+	case int64:
+		converted := int(index)
+		if index >= 0 && int64(converted) == index {
+			return converted
+		}
+	case float64:
+		intLimit := math.Ldexp(1, strconv.IntSize-1)
+		if math.IsNaN(index) || math.IsInf(index, 0) || index < 0 || index >= intLimit || math.Trunc(index) != index {
+			break
+		}
+		return int(index)
+	case json.Number:
+		if parsed, err := strconv.ParseInt(index.String(), 10, strconv.IntSize); err == nil && parsed >= 0 {
+			return int(parsed)
+		}
+	}
+	return fallback
+}
+
+func normalizeCompleteMessage(message map[string]any, choiceIndex int) {
 	var extractedReasoning string
 	if content, ok := message["content"]; !ok || content == nil {
 		message["content"] = ""
@@ -2543,6 +2587,12 @@ func normalizeCompleteMessage(message map[string]any) {
 	}
 	if extractedReasoning != "" {
 		mergeReasoningField(message, extractedReasoning)
+	}
+	if reasoning, ok := message["reasoning"].(string); ok && reasoning != "" {
+		message["reasoning_content"] = reasoning
+		if _, hasDetails := message["reasoning_details"]; !hasDetails {
+			message["reasoning_details"] = canonicalReasoningDetails(reasoning, choiceIndex)
+		}
 	}
 	for _, key := range []string{"tool_calls", "refusal"} {
 		if v, ok := message[key]; ok && v == nil {
@@ -2607,8 +2657,9 @@ func normalizeSSEChunk(chunk string) string {
 		strings.Contains(line, `"reasoning_content":null`) ||
 		strings.Contains(line, `"refusal":null`) ||
 		strings.Contains(line, `"system_fingerprint":null`)
-	needsReasoningDedup := strings.Contains(line, `"reasoning_content"`)
-	if !needsNullFix && !needsReasoningDedup {
+	needsReasoningNormalization := strings.Contains(line, `"reasoning"`) ||
+		strings.Contains(line, `"reasoning_content"`)
+	if !needsNullFix && !needsReasoningNormalization {
 		return chunk
 	}
 
@@ -2636,32 +2687,53 @@ func normalizeSSEChunk(chunk string) string {
 				if deltaRaw, ok := choice["delta"]; ok {
 					var delta map[string]json.RawMessage
 					if err := json.Unmarshal(deltaRaw, &delta); err == nil {
+						deltaChanged := false
 						for _, field := range []string{"content", "reasoning_content", "reasoning", "refusal"} {
 							if v, ok := delta[field]; ok && string(v) == "null" {
 								delta[field] = json.RawMessage(`""`)
-								changed = true
+								deltaChanged = true
 							}
 						}
 						if v, ok := delta["tool_calls"]; ok && string(v) == "null" {
 							delta["tool_calls"] = json.RawMessage(`[]`)
-							changed = true
+							deltaChanged = true
 						}
-						// Emit BOTH "reasoning" and "reasoning_content" so both
-						// AI SDK (reads reasoning_content) and ForgeCode/other
-						// clients (reads reasoning) see reasoning tokens.
-						if _, hasR := delta["reasoning"]; hasR {
-							if _, hasRC := delta["reasoning_content"]; !hasRC {
-								// Only reasoning exists — copy to reasoning_content for AI SDK.
-								delta["reasoning_content"] = delta["reasoning"]
-								changed = true
+						// reasoning_content is provider-canonical for streaming deltas.
+						// If either alias is present, emit both with the same value, even
+						// when that value is empty; empty values never produce details.
+						reasoningRaw, hasReasoning := delta["reasoning"]
+						reasoningContentRaw, hasReasoningContent := delta["reasoning_content"]
+						reasoning := nonEmptyRawString(reasoningRaw)
+						reasoningContent := nonEmptyRawString(reasoningContentRaw)
+						chosenReasoning := reasoningContent
+						chosenRaw := reasoningContentRaw
+						if chosenReasoning == "" && reasoning != "" {
+							chosenReasoning = reasoning
+							chosenRaw = reasoningRaw
+						} else if chosenReasoning == "" && !hasReasoningContent {
+							chosenRaw = reasoningRaw
+						}
+						if hasReasoning || hasReasoningContent {
+							if !hasReasoning || !bytes.Equal(reasoningRaw, chosenRaw) {
+								delta["reasoning"] = chosenRaw
+								deltaChanged = true
 							}
-						} else if rc, hasRC := delta["reasoning_content"]; hasRC {
-							// Only reasoning_content exists — add reasoning alias.
-							delta["reasoning"] = rc
-							changed = true
+							if !hasReasoningContent || !bytes.Equal(reasoningContentRaw, chosenRaw) {
+								delta["reasoning_content"] = chosenRaw
+								deltaChanged = true
+							}
 						}
-						if changed {
+						if _, hasDetails := delta["reasoning_details"]; !hasDetails && chosenReasoning != "" {
+							choiceIndex := normalizedRawChoiceIndex(choice["index"], i)
+							details, err := json.Marshal(canonicalReasoningDetails(chosenReasoning, choiceIndex))
+							if err == nil {
+								delta["reasoning_details"] = details
+								deltaChanged = true
+							}
+						}
+						if deltaChanged {
 							choices[i]["delta"], _ = json.Marshal(delta)
+							changed = true
 						}
 					}
 				}
@@ -2681,6 +2753,26 @@ func normalizeSSEChunk(chunk string) string {
 		return chunk
 	}
 	return "data: " + string(out)
+}
+
+func nonEmptyRawString(raw json.RawMessage) string {
+	var value string
+	if len(raw) == 0 || json.Unmarshal(raw, &value) != nil {
+		return ""
+	}
+	return value
+}
+
+func normalizedRawChoiceIndex(raw json.RawMessage, fallback int) int {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 || trimmed[0] == '"' {
+		return fallback
+	}
+	var index json.Number
+	if json.Unmarshal(raw, &index) == nil {
+		return normalizedChoiceIndex(index, fallback)
+	}
+	return fallback
 }
 
 // maxLogicalToolCalls caps how many logical tool calls a single stream may
@@ -2812,18 +2904,26 @@ func (a *toolCallAccumulator) finalize() []map[string]any {
 // extractedMessage holds the reconstructed assistant message from SSE chunks,
 // including text content, reasoning, and any tool calls.
 type extractedMessage struct {
-	Content      string           `json:"content"`
-	Reasoning    string           `json:"reasoning,omitempty"`
-	ToolCalls    []map[string]any `json:"tool_calls,omitempty"`
-	FinishReason string           `json:"-"`
+	Content                 string           `json:"content"`
+	Reasoning               string           `json:"reasoning,omitempty"`
+	ReasoningDetails        any              `json:"reasoning_details,omitempty"`
+	ReasoningDetailsPresent bool             `json:"-"`
+	ToolCalls               []map[string]any `json:"tool_calls,omitempty"`
+	FinishReason            string           `json:"-"`
 }
 
-// extractMessage parses SSE data lines and reconstructs the full assistant
-// message from streaming chunks, including content, reasoning, and tool_calls.
+// extractMessage retains the historical reasoning-first behavior used by
+// Responses and generic endpoint fallbacks.
 func extractMessage(chunks []string) extractedMessage {
+	return extractMessageWithReasoningPolicy(chunks, false)
+}
+
+func extractMessageWithReasoningPolicy(chunks []string, preferReasoningContent bool) extractedMessage {
 	var contentBuilder strings.Builder
 	var reasoningBuilder strings.Builder
 	finishReason := ""
+	var reasoningDetails any
+	reasoningDetailsPresent := false
 	// See toolCallAccumulator for the logical-call model (arrival order,
 	// non-unique wire indices, the maxLogicalToolCalls cap).
 	acc := newToolCallAccumulator()
@@ -2849,12 +2949,14 @@ func extractMessage(chunks []string) extractedMessage {
 				Content          string                `json:"content"`
 				Reasoning        string                `json:"reasoning"`
 				ReasoningContent string                `json:"reasoning_content"`
+				ReasoningDetails json.RawMessage       `json:"reasoning_details"`
 				ToolCalls        []streamToolCallDelta `json:"tool_calls,omitempty"`
 			} `json:"delta"`
 			Message struct {
 				Content          string                `json:"content"`
 				Reasoning        string                `json:"reasoning"`
 				ReasoningContent string                `json:"reasoning_content"`
+				ReasoningDetails json.RawMessage       `json:"reasoning_details"`
 				ToolCalls        []streamToolCallDelta `json:"tool_calls,omitempty"`
 			} `json:"message"`
 			FinishReason *string `json:"finish_reason"`
@@ -2872,7 +2974,17 @@ func extractMessage(chunks []string) extractedMessage {
 			} else if c.Message.Content != "" {
 				contentBuilder.WriteString(c.Message.Content)
 			}
-			if c.Delta.Reasoning != "" {
+			if preferReasoningContent {
+				if c.Delta.ReasoningContent != "" {
+					reasoningBuilder.WriteString(c.Delta.ReasoningContent)
+				} else if c.Delta.Reasoning != "" {
+					reasoningBuilder.WriteString(c.Delta.Reasoning)
+				} else if c.Message.ReasoningContent != "" {
+					reasoningBuilder.WriteString(c.Message.ReasoningContent)
+				} else if c.Message.Reasoning != "" {
+					reasoningBuilder.WriteString(c.Message.Reasoning)
+				}
+			} else if c.Delta.Reasoning != "" {
 				reasoningBuilder.WriteString(c.Delta.Reasoning)
 			} else if c.Delta.ReasoningContent != "" {
 				reasoningBuilder.WriteString(c.Delta.ReasoningContent)
@@ -2880,6 +2992,28 @@ func extractMessage(chunks []string) extractedMessage {
 				reasoningBuilder.WriteString(c.Message.Reasoning)
 			} else if c.Message.ReasoningContent != "" {
 				reasoningBuilder.WriteString(c.Message.ReasoningContent)
+			}
+			for _, rawDetails := range []json.RawMessage{c.Delta.ReasoningDetails, c.Message.ReasoningDetails} {
+				trimmed := bytes.TrimSpace(rawDetails)
+				if len(trimmed) == 0 {
+					continue
+				}
+				if trimmed[0] == '[' {
+					var details []json.RawMessage
+					if json.Unmarshal(rawDetails, &details) != nil {
+						continue
+					}
+					if !reasoningDetailsPresent {
+						reasoningDetails = make([]json.RawMessage, 0, len(details))
+						reasoningDetailsPresent = true
+					}
+					if accumulated, ok := reasoningDetails.([]json.RawMessage); ok {
+						reasoningDetails = append(accumulated, details...)
+					}
+				} else if !reasoningDetailsPresent {
+					reasoningDetails = json.RawMessage(append([]byte(nil), rawDetails...))
+					reasoningDetailsPresent = true
+				}
 			}
 			toolCalls := c.Delta.ToolCalls
 			if len(toolCalls) == 0 {
@@ -2901,7 +3035,13 @@ func extractMessage(chunks []string) extractedMessage {
 			reasoning = extractedReasoning
 		}
 	}
-	msg := extractedMessage{Content: content, Reasoning: reasoning, FinishReason: finishReason}
+	msg := extractedMessage{
+		Content:                 content,
+		Reasoning:               reasoning,
+		ReasoningDetails:        reasoningDetails,
+		ReasoningDetailsPresent: reasoningDetailsPresent,
+		FinishReason:            finishReason,
+	}
 	if acc.droppedDeltas > 0 {
 		log.Printf("WARN: extractMessage: logical tool-call cap (%d) reached; dropped %d tool-call delta(s) from excess calls", maxLogicalToolCalls, acc.droppedDeltas)
 	}
@@ -3380,6 +3520,12 @@ func buildNonStreamingResponse(requestID, model string, msg extractedMessage, us
 	}
 	if msg.Reasoning != "" {
 		message.Reasoning = msg.Reasoning
+		message.ReasoningContent = msg.Reasoning
+	}
+	if msg.ReasoningDetailsPresent {
+		message.ReasoningDetails = msg.ReasoningDetails
+	} else if msg.Reasoning != "" {
+		message.ReasoningDetails = canonicalReasoningDetails(msg.Reasoning, 0)
 	}
 
 	if len(msg.ToolCalls) > 0 {

--- a/coordinator/api/consumer_normalize_test.go
+++ b/coordinator/api/consumer_normalize_test.go
@@ -477,6 +477,55 @@ func TestBuildNonStreamingResponsePreservesUpstreamReasoningDetails(t *testing.T
 	}
 }
 
+func TestExtractMessageReasoningDetailsNullPlaceholder(t *testing.T) {
+	t.Run("later arrays supersede null and accumulate", func(t *testing.T) {
+		msg := extractMessageWithReasoningPolicy([]string{
+			`data: {"choices":[{"delta":{"reasoning":"a","reasoning_details":null}}]}`,
+			`data: {"choices":[{"delta":{"reasoning":"b","reasoning_details":[{"type":"first"}]}}]}`,
+			`data: {"choices":[{"delta":{"reasoning":"c","reasoning_details":[{"type":"second"}]}}]}`,
+		}, true)
+		details, ok := msg.ReasoningDetails.([]json.RawMessage)
+		if !ok || len(details) != 2 {
+			t.Fatalf("accumulated reasoning_details = %#v, want two array items", msg.ReasoningDetails)
+		}
+		var first, second map[string]any
+		if err := json.Unmarshal(details[0], &first); err != nil {
+			t.Fatalf("decode first reasoning detail: %v", err)
+		}
+		if err := json.Unmarshal(details[1], &second); err != nil {
+			t.Fatalf("decode second reasoning detail: %v", err)
+		}
+		if first["type"] != "first" || second["type"] != "second" {
+			t.Fatalf("reasoning detail order changed: %#v %#v", first, second)
+		}
+	})
+
+	t.Run("lone null survives malformed later chunk", func(t *testing.T) {
+		msg := extractMessage([]string{
+			`data: {"choices":[{"delta":{"reasoning":"a","reasoning_details":null}}]}`,
+			`data: {"choices":[{"delta":{"reasoning":"b","reasoning_details":[}}]}`,
+		})
+		raw, ok := msg.ReasoningDetails.(json.RawMessage)
+		if !ok || string(raw) != "null" {
+			t.Fatalf("lone null reasoning_details = %#v", msg.ReasoningDetails)
+		}
+		chat := buildNonStreamingResponse("req-null", "test-model", msg, protocol.UsageInfo{}, 16, "", "")
+		wire, err := json.Marshal(chat)
+		if err != nil {
+			t.Fatalf("marshal null reasoning_details: %v", err)
+		}
+		var decoded map[string]any
+		if err := json.Unmarshal(wire, &decoded); err != nil {
+			t.Fatalf("decode null reasoning_details response: %v", err)
+		}
+		message := decoded["choices"].([]any)[0].(map[string]any)["message"].(map[string]any)
+		value, exists := message["reasoning_details"]
+		if !exists || value != nil {
+			t.Fatalf("null reasoning_details not preserved: %#v", message)
+		}
+	})
+}
+
 func TestExtractMessageReasoningPolicyByEndpoint(t *testing.T) {
 	chunks := []string{`data: {"choices":[{"delta":{"content":"answer","reasoning":"legacy","reasoning_content":"canonical"}}]}`}
 	responsesMessage := extractMessage(chunks)

--- a/coordinator/api/consumer_normalize_test.go
+++ b/coordinator/api/consumer_normalize_test.go
@@ -2,10 +2,14 @@ package api
 
 import (
 	"encoding/json"
+	"math"
+	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 
 	"github.com/eigeninference/d-inference/coordinator/api/types"
+	"github.com/eigeninference/d-inference/coordinator/protocol"
 )
 
 func TestExtractMessage(t *testing.T) {
@@ -165,15 +169,19 @@ func TestNormalizeCompleteChatResponse(t *testing.T) {
 	if message["content"] != "4" {
 		t.Fatalf("content = %q, want 4", message["content"])
 	}
-	if _, ok := message["reasoning_content"]; ok {
-		t.Fatalf("reasoning_content should be removed: %#v", message)
+	reasoning := message["reasoning"].(string)
+	if message["reasoning_content"] != reasoning {
+		t.Fatalf("reasoning_content = %v, want synchronized reasoning %q", message["reasoning_content"], reasoning)
 	}
 	if _, ok := message["tool_calls"]; ok {
 		t.Fatalf("null tool_calls should be removed: %#v", message)
 	}
-	reasoning := message["reasoning"].(string)
 	if !strings.Contains(reasoning, "existing reasoning") || !strings.Contains(reasoning, "work through it") {
 		t.Fatalf("reasoning was not merged correctly: %q", reasoning)
+	}
+	details := message["reasoning_details"].([]types.ReasoningDetail)
+	if len(details) != 1 || details[0].Text != reasoning || details[0].ID != "reasoning-text-0" {
+		t.Fatalf("reasoning_details = %#v, want full merged reasoning", details)
 	}
 }
 
@@ -195,6 +203,356 @@ func TestNormalizeCompleteChatResponseNullContent(t *testing.T) {
 	message := resp["choices"].([]any)[0].(map[string]any)["message"].(map[string]any)
 	if message["content"] != "" {
 		t.Fatalf("content = %v, want empty string", message["content"])
+	}
+}
+
+func TestNormalizeSSEChunkReasoningDetails(t *testing.T) {
+	parseDelta := func(t *testing.T, chunk string, choice int) map[string]any {
+		t.Helper()
+		var payload map[string]any
+		if err := json.Unmarshal([]byte(strings.TrimPrefix(normalizeSSEChunk(chunk), "data: ")), &payload); err != nil {
+			t.Fatalf("unmarshal normalized chunk: %v", err)
+		}
+		choices := payload["choices"].([]any)
+		return choices[choice].(map[string]any)["delta"].(map[string]any)
+	}
+	assertCanonical := func(t *testing.T, delta map[string]any, text, id string) {
+		t.Helper()
+		details, ok := delta["reasoning_details"].([]any)
+		if !ok || len(details) != 1 {
+			t.Fatalf("reasoning_details = %#v, want one detail", delta["reasoning_details"])
+		}
+		detail := details[0].(map[string]any)
+		if detail["type"] != "reasoning.text" || detail["text"] != text || detail["id"] != id || detail["format"] != "unknown" || detail["index"] != float64(0) || detail["signature"] != nil {
+			t.Fatalf("reasoning detail = %#v", detail)
+		}
+	}
+
+	t.Run("reasoning content alias gets canonical detail", func(t *testing.T) {
+		delta := parseDelta(t, `data: {"choices":[{"index":3,"delta":{"reasoning_content":"thinking"}}]}`, 0)
+		if delta["reasoning"] != "thinking" || delta["reasoning_content"] != "thinking" {
+			t.Fatalf("reasoning aliases not synchronized: %#v", delta)
+		}
+		assertCanonical(t, delta, "thinking", "reasoning-text-3")
+	})
+
+	t.Run("reasoning content wins conflicting aliases", func(t *testing.T) {
+		delta := parseDelta(t, `data: {"choices":[{"index":5,"delta":{"reasoning":"legacy","reasoning_content":"canonical"}}]}`, 0)
+		if delta["reasoning"] != "canonical" || delta["reasoning_content"] != "canonical" {
+			t.Fatalf("reasoning_content did not win alias conflict: %#v", delta)
+		}
+		assertCanonical(t, delta, "canonical", "reasoning-text-5")
+	})
+
+	t.Run("malformed aliases are forced to raw equality", func(t *testing.T) {
+		delta := parseDelta(t, `data: {"choices":[{"index":0,"delta":{"reasoning":{"unexpected":true},"reasoning_content":["opaque"]}}]}`, 0)
+		reasoning, err := json.Marshal(delta["reasoning"])
+		if err != nil {
+			t.Fatalf("marshal reasoning alias: %v", err)
+		}
+		reasoningContent, err := json.Marshal(delta["reasoning_content"])
+		if err != nil {
+			t.Fatalf("marshal reasoning_content alias: %v", err)
+		}
+		if string(reasoning) != string(reasoningContent) || string(reasoning) != `["opaque"]` {
+			t.Fatalf("malformed aliases differ: reasoning=%s reasoning_content=%s", reasoning, reasoningContent)
+		}
+		if _, ok := delta["reasoning_details"]; ok {
+			t.Fatalf("malformed reasoning created details: %#v", delta)
+		}
+	})
+
+	t.Run("invalid indexes fall back to distinct choice positions", func(t *testing.T) {
+		chunk := `data: {"choices":[{"index":-1,"delta":{"reasoning":"a"}},{"index":"9","delta":{"reasoning":"b"}},{"index":1.5,"delta":{"reasoning":"c"}}]}`
+		for choice, wantID := range []string{"reasoning-text-0", "reasoning-text-1", "reasoning-text-2"} {
+			delta := parseDelta(t, chunk, choice)
+			assertCanonical(t, delta, string(rune('a'+choice)), wantID)
+		}
+	})
+
+	t.Run("stable IDs across chunks and choices", func(t *testing.T) {
+		first := parseDelta(t, `data: {"choices":[{"index":2,"delta":{"reasoning":"a"}},{"index":7,"delta":{"reasoning":"b"}}]}`, 0)
+		second := parseDelta(t, `data: {"choices":[{"index":2,"delta":{"reasoning":"c"}},{"index":7,"delta":{"reasoning":"d"}}]}`, 0)
+		other := parseDelta(t, `data: {"choices":[{"index":2,"delta":{"reasoning":"a"}},{"index":7,"delta":{"reasoning":"b"}}]}`, 1)
+		assertCanonical(t, first, "a", "reasoning-text-2")
+		assertCanonical(t, second, "c", "reasoning-text-2")
+		assertCanonical(t, other, "b", "reasoning-text-7")
+	})
+
+	t.Run("existing details are preserved", func(t *testing.T) {
+		delta := parseDelta(t, `data: {"choices":[{"index":0,"delta":{"reasoning":"thinking","reasoning_details":[{"type":"provider.custom","data":{"opaque":true}}]}}]}`, 0)
+		details := delta["reasoning_details"].([]any)
+		detail := details[0].(map[string]any)
+		if len(details) != 1 || detail["type"] != "provider.custom" || detail["data"].(map[string]any)["opaque"] != true {
+			t.Fatalf("existing reasoning_details changed: %#v", details)
+		}
+	})
+
+	t.Run("empty reasoning synchronizes aliases without details", func(t *testing.T) {
+		for _, chunk := range []string{
+			`data: {"choices":[{"index":0,"delta":{"reasoning":""}}]}`,
+			`data: {"choices":[{"index":0,"delta":{"reasoning_content":null}}]}`,
+		} {
+			delta := parseDelta(t, chunk, 0)
+			if delta["reasoning"] != "" || delta["reasoning_content"] != "" {
+				t.Fatalf("empty reasoning aliases not synchronized: %#v", delta)
+			}
+			if _, ok := delta["reasoning_details"]; ok {
+				t.Fatalf("empty reasoning added details: %#v", delta)
+			}
+		}
+	})
+}
+
+func TestNormalizeCompleteChatResponseReasoningDetails(t *testing.T) {
+	existingDetails := []any{map[string]any{"type": "provider.custom", "opaque": "value"}}
+	resp := map[string]any{
+		"object": "chat.completion",
+		"choices": []any{
+			map[string]any{"index": float64(4), "message": map[string]any{"content": "answer", "reasoning": "full thought"}},
+			map[string]any{"index": float64(9), "message": map[string]any{"content": "answer", "reasoning_content": "provider thought", "reasoning_details": existingDetails}},
+			map[string]any{"index": float64(11), "message": map[string]any{"content": "answer", "reasoning": ""}},
+			map[string]any{"index": float64(12), "message": map[string]any{"content": "answer", "reasoning": "legacy", "reasoning_content": "canonical"}},
+		},
+	}
+
+	normalizeCompleteChatResponse(resp, "test-model")
+	choices := resp["choices"].([]any)
+	first := choices[0].(map[string]any)["message"].(map[string]any)
+	if first["reasoning_content"] != "full thought" {
+		t.Fatalf("reasoning aliases not synchronized: %#v", first)
+	}
+	firstDetail := first["reasoning_details"].([]types.ReasoningDetail)
+	if len(firstDetail) != 1 || firstDetail[0].Text != "full thought" || firstDetail[0].ID != "reasoning-text-4" || firstDetail[0].Signature != nil {
+		t.Fatalf("canonical reasoning_details = %#v", firstDetail)
+	}
+	second := choices[1].(map[string]any)["message"].(map[string]any)
+	if second["reasoning"] != "provider thought" || second["reasoning_content"] != "provider thought" {
+		t.Fatalf("reasoning aliases not synchronized: %#v", second)
+	}
+	preserved := second["reasoning_details"].([]any)
+	if len(preserved) != 1 || preserved[0].(map[string]any)["type"] != "provider.custom" || preserved[0].(map[string]any)["opaque"] != "value" {
+		t.Fatalf("existing reasoning_details changed: %#v", preserved)
+	}
+	third := choices[2].(map[string]any)["message"].(map[string]any)
+	if _, ok := third["reasoning_details"]; ok {
+		t.Fatalf("empty reasoning added details: %#v", third)
+	}
+	fourth := choices[3].(map[string]any)["message"].(map[string]any)
+	merged := "legacy\n\ncanonical"
+	if fourth["reasoning"] != merged || fourth["reasoning_content"] != merged {
+		t.Fatalf("complete aliases did not retain both values: %#v", fourth)
+	}
+	fourthDetail := fourth["reasoning_details"].([]types.ReasoningDetail)
+	if len(fourthDetail) != 1 || fourthDetail[0].Text != merged || fourthDetail[0].ID != "reasoning-text-12" {
+		t.Fatalf("conflicting alias details = %#v", fourthDetail)
+	}
+}
+
+func TestNormalizeCompleteChatResponseInvalidChoiceIndexes(t *testing.T) {
+	resp := map[string]any{
+		"object": "chat.completion",
+		"choices": []any{
+			map[string]any{"index": float64(-1), "message": map[string]any{"reasoning": "a"}},
+			map[string]any{"index": 1.5, "message": map[string]any{"reasoning": "b"}},
+			map[string]any{"index": math.NaN(), "message": map[string]any{"reasoning": "c"}},
+			map[string]any{"index": math.Inf(1), "message": map[string]any{"reasoning": "d"}},
+			map[string]any{"index": int64(-2), "message": map[string]any{"reasoning": "e"}},
+		},
+	}
+
+	normalizeCompleteChatResponse(resp, "test-model")
+	for position, rawChoice := range resp["choices"].([]any) {
+		message := rawChoice.(map[string]any)["message"].(map[string]any)
+		detail := message["reasoning_details"].([]types.ReasoningDetail)[0]
+		wantID := "reasoning-text-" + strconv.Itoa(position)
+		if detail.ID != wantID {
+			t.Fatalf("choice %d detail ID = %q, want %q", position, detail.ID, wantID)
+		}
+	}
+}
+
+func TestNormalizeCompleteChatResponseConflictPreservesResponsesReasoning(t *testing.T) {
+	resp := map[string]any{
+		"id":      "chatcmpl-conflict",
+		"object":  "chat.completion",
+		"created": float64(123),
+		"choices": []any{map[string]any{
+			"index": float64(0),
+			"message": map[string]any{
+				"content":           "answer",
+				"reasoning":         "legacy",
+				"reasoning_content": "canonical",
+			},
+			"finish_reason": "stop",
+		}},
+		"usage": map[string]any{},
+	}
+	normalizeCompleteChatResponse(resp, "test-model")
+
+	wire, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal normalized chat response: %v", err)
+	}
+	var chat types.ChatCompletionResponse
+	if err := json.Unmarshal(wire, &chat); err != nil {
+		t.Fatalf("decode normalized chat response: %v", err)
+	}
+	converted := chatCompletionToResponses(chat, "test-model", "", "")
+	reasoningItem := converted.Output[0].(map[string]any)
+	summary := reasoningItem["summary"].([]map[string]any)
+	if summary[0]["text"] != "legacy\n\ncanonical" {
+		t.Fatalf("Responses reasoning = %q, want old merged value", summary[0]["text"])
+	}
+	convertedWire, err := json.Marshal(converted)
+	if err != nil {
+		t.Fatalf("marshal Responses conversion: %v", err)
+	}
+	if strings.Contains(string(convertedWire), "reasoning_details") || strings.Contains(string(convertedWire), "reasoning_content") {
+		t.Fatalf("chat aliases leaked into Responses API wire: %s", convertedWire)
+	}
+}
+
+func TestBuildNonStreamingResponseReasoningDetailsWire(t *testing.T) {
+	chat := buildNonStreamingResponse(
+		"req-reasoning",
+		"test-model",
+		extractedMessage{Content: "answer", Reasoning: "full thought"},
+		protocol.UsageInfo{PromptTokens: 2, CompletionTokens: 3},
+		16,
+		"",
+		"",
+	)
+
+	wire, err := json.Marshal(chat)
+	if err != nil {
+		t.Fatalf("marshal reconstructed chat response: %v", err)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(wire, &decoded); err != nil {
+		t.Fatalf("unmarshal reconstructed chat response: %v", err)
+	}
+	message := decoded["choices"].([]any)[0].(map[string]any)["message"].(map[string]any)
+	if message["reasoning"] != "full thought" || message["reasoning_content"] != "full thought" {
+		t.Fatalf("reconstructed reasoning aliases = %#v", message)
+	}
+	detail := message["reasoning_details"].([]any)[0].(map[string]any)
+	if detail["type"] != "reasoning.text" || detail["text"] != "full thought" || detail["id"] != "reasoning-text-0" || detail["format"] != "unknown" || detail["index"] != float64(0) || detail["signature"] != nil {
+		t.Fatalf("reconstructed reasoning detail = %#v", detail)
+	}
+
+	responsesWire, err := json.Marshal(chatCompletionToResponses(chat, "test-model", "", ""))
+	if err != nil {
+		t.Fatalf("marshal converted Responses API result: %v", err)
+	}
+	if strings.Contains(string(responsesWire), "reasoning_details") || strings.Contains(string(responsesWire), "reasoning_content") {
+		t.Fatalf("chat aliases leaked into Responses API wire: %s", responsesWire)
+	}
+}
+
+func TestBuildNonStreamingResponsePreservesUpstreamReasoningDetails(t *testing.T) {
+	msg := extractMessageWithReasoningPolicy([]string{
+		`data: {"choices":[{"delta":{"reasoning":"legacy","reasoning_content":"canonical","reasoning_details":[{"type":"provider.custom","data":"first"}]}}]}`,
+		`data: {"choices":[{"message":{"reasoning_content":"next","reasoning_details":[{"type":"reasoning.encrypted","data":"second"}]}}]}`,
+	}, true)
+	if msg.Reasoning != "canonicalnext" {
+		t.Fatalf("reconstructed reasoning = %q, want reasoning_content precedence", msg.Reasoning)
+	}
+	chat := buildNonStreamingResponse("req-upstream-details", "test-model", msg, protocol.UsageInfo{}, 16, "", "")
+	wire, err := json.Marshal(chat)
+	if err != nil {
+		t.Fatalf("marshal reconstructed response: %v", err)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(wire, &decoded); err != nil {
+		t.Fatalf("decode reconstructed response: %v", err)
+	}
+	message := decoded["choices"].([]any)[0].(map[string]any)["message"].(map[string]any)
+	details := message["reasoning_details"].([]any)
+	if len(details) != 2 || details[0].(map[string]any)["type"] != "provider.custom" || details[1].(map[string]any)["type"] != "reasoning.encrypted" {
+		t.Fatalf("upstream reasoning_details not preserved in order: %#v", details)
+	}
+	if details[0].(map[string]any)["data"] != "first" || details[1].(map[string]any)["data"] != "second" {
+		t.Fatalf("upstream reasoning_details values changed: %#v", details)
+	}
+}
+
+func TestExtractMessageReasoningPolicyByEndpoint(t *testing.T) {
+	chunks := []string{`data: {"choices":[{"delta":{"content":"answer","reasoning":"legacy","reasoning_content":"canonical"}}]}`}
+	responsesMessage := extractMessage(chunks)
+	chatMessage := extractMessageWithReasoningPolicy(chunks, true)
+	if responsesMessage.Reasoning != "legacy" {
+		t.Fatalf("Responses fallback reasoning = %q, want historical reasoning alias", responsesMessage.Reasoning)
+	}
+	if chatMessage.Reasoning != "canonical" {
+		t.Fatalf("chat fallback reasoning = %q, want reasoning_content", chatMessage.Reasoning)
+	}
+
+	responses := buildResponsesResponse("req-policy", "test-model", responsesMessage, protocol.UsageInfo{}, 16, "", "")
+	responsesWire, err := json.Marshal(responses)
+	if err != nil {
+		t.Fatalf("marshal Responses fallback: %v", err)
+	}
+	if strings.Contains(string(responsesWire), "reasoning_content") || strings.Contains(string(responsesWire), "reasoning_details") {
+		t.Fatalf("chat fields leaked into Responses fallback: %s", responsesWire)
+	}
+	chat := buildNonStreamingResponse("req-policy", "test-model", chatMessage, protocol.UsageInfo{}, 16, "", "")
+	chatWire, err := json.Marshal(chat)
+	if err != nil {
+		t.Fatalf("marshal chat fallback: %v", err)
+	}
+	if !strings.Contains(string(chatWire), `"reasoning_content":"canonical"`) || !strings.Contains(string(chatWire), `"reasoning_details"`) {
+		t.Fatalf("chat fallback missing canonical reasoning fields: %s", chatWire)
+	}
+}
+
+func TestBuildNonStreamingResponsePreservesNonArrayReasoningDetails(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		raw  string
+	}{
+		{name: "null", raw: `null`},
+		{name: "object", raw: `{"type":"provider.custom","opaque":true}`},
+		{name: "scalar", raw: `"encrypted-token"`},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			chunk := `data: {"choices":[{"delta":{"reasoning":"thought","reasoning_details":` + tt.raw + `}}]}`
+			msg := extractMessage([]string{chunk})
+			if !msg.ReasoningDetailsPresent {
+				t.Fatal("reasoning_details key presence was lost")
+			}
+			chat := buildNonStreamingResponse("req-non-array", "test-model", msg, protocol.UsageInfo{}, 16, "", "")
+			wire, err := json.Marshal(chat)
+			if err != nil {
+				t.Fatalf("marshal reconstructed response: %v", err)
+			}
+			var decoded map[string]any
+			if err := json.Unmarshal(wire, &decoded); err != nil {
+				t.Fatalf("decode reconstructed response: %v", err)
+			}
+			message := decoded["choices"].([]any)[0].(map[string]any)["message"].(map[string]any)
+			value, ok := message["reasoning_details"]
+			if !ok {
+				t.Fatalf("reasoning_details missing from wire: %s", wire)
+			}
+			if tt.name == "object" {
+				var want any
+				if err := json.Unmarshal([]byte(tt.raw), &want); err != nil {
+					t.Fatalf("decode expected reasoning_details: %v", err)
+				}
+				if !reflect.DeepEqual(value, want) {
+					t.Fatalf("reasoning_details = %#v, want %#v", value, want)
+				}
+			} else {
+				got, err := json.Marshal(value)
+				if err != nil {
+					t.Fatalf("marshal preserved reasoning_details: %v", err)
+				}
+				if string(got) != tt.raw {
+					t.Fatalf("reasoning_details = %s, want %s", got, tt.raw)
+				}
+			}
+		})
 	}
 }
 

--- a/coordinator/api/types/types.go
+++ b/coordinator/api/types/types.go
@@ -15,12 +15,24 @@ import (
 
 // ── Chat completions ────────────────────────────────────────────────
 
+// ReasoningDetail is an OpenRouter-compatible reasoning item on a chat message.
+type ReasoningDetail struct {
+	Type      string `json:"type"`
+	Text      string `json:"text"`
+	ID        string `json:"id"`
+	Format    string `json:"format"`
+	Index     int    `json:"index"`
+	Signature any    `json:"signature"`
+}
+
 // ChatCompletionMessage is the assistant message in a chat completion choice.
 type ChatCompletionMessage struct {
-	Role      string           `json:"role"`
-	Content   string           `json:"content"`
-	Reasoning string           `json:"reasoning,omitempty"`
-	ToolCalls []map[string]any `json:"tool_calls,omitempty"`
+	Role             string           `json:"role"`
+	Content          string           `json:"content"`
+	Reasoning        string           `json:"reasoning,omitempty"`
+	ReasoningContent string           `json:"reasoning_content,omitempty"`
+	ReasoningDetails any              `json:"reasoning_details,omitempty"`
+	ToolCalls        []map[string]any `json:"tool_calls,omitempty"`
 }
 
 // ChatCompletionChoice is a single choice in a chat completion response.


### PR DESCRIPTION
## Summary

- emit OpenRouter-compatible `reasoning_details` for every `/v1/chat/completions` reasoning delta
- emit the same canonical shape for raw and reconstructed non-streaming chat responses
- preserve `reasoning` and `reasoning_content` compatibility aliases
- preserve existing provider `reasoning_details` values, including custom arrays, nulls, objects, and scalars
- keep Responses, Anthropic Messages, and legacy Completions endpoint wire shapes unchanged
- validate choice indexes and provide deterministic `reasoning-text-<choice-index>` IDs

## Production evidence

At 7:56 PM PDT, OpenRouter reported 317 success / 24 429 / 12 504. Darkbloom recorded exactly 317 Qwen successes, 24 Qwen 429s, 11 provider completions after client disconnect, and one pre-completion disconnect. The 11 completed outputs contained 2,600 reasoning tokens and zero visible content tokens. OpenRouter timed out reasoning-only streams despite Darkbloom emitting `reasoning` and `reasoning_content`; this adds its documented canonical `choices[].delta.reasoning_details` shape.

## Before

```mermaid
flowchart LR
  A[Qwen reasoning delta] --> B[reasoning + reasoning_content]
  B --> C[OpenRouter timeout tracker ignores output]
  C --> D[OpenRouter closes stream as 504]
  D --> E[Provider completes after client gone]
```

Code flow: `normalizeSSEChunk` synchronized two string aliases; reconstructed non-streaming messages exposed only `reasoning`.

## After

```mermaid
flowchart LR
  A[Qwen reasoning delta] --> B[Chat normalization]
  B --> C[reasoning + reasoning_content]
  B --> D[reasoning_details reasoning.text]
  C --> E[Existing clients]
  D --> F[OpenRouter canonical reasoning parser]
  F --> G[Stream remains active]
```

Code flow: streaming, raw-complete, and reconstructed chat responses share canonical detail construction; endpoint-specific conversion keeps non-chat schemas isolated.

## Verification

- focused reasoning normalization tests: passed
- `cd coordinator && go test ./api -count=1`: passed
- two independent delegated code reviews: passed
- `cd coordinator && go test ./... -count=1`: passed (24 packages; 3 packages with no tests)
