### PR TITLE
fix: keep first-token deadline request-absolute through accept

### DIFF
--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -138,25 +138,6 @@ func ttftDeadline(estimatedPromptTokens int) time.Duration {
 	return base + perToken
 }
 
-// firstTokenRemainingSince is the leftover request-absolute first-CONTENT
-// budget. OpenRouter cancels at ~10000ms + 1ms*tokens from request start; our
-// live deadline (prod 9s + 1ms*tokens) is the slack vs that clock. A zero
-// receivedAt falls back to the full deadline so unit tests that never stamp
-// RequestTiming keep the historical relative timers.
-func firstTokenRemainingSince(receivedAt time.Time, deadline time.Duration) time.Duration {
-	if deadline <= 0 {
-		return 0
-	}
-	if receivedAt.IsZero() {
-		return deadline
-	}
-	remaining := deadline - time.Since(receivedAt)
-	if remaining < 0 {
-		return 0
-	}
-	return remaining
-}
-
 // shedIfModelRejected answers a public/prefer-owner request with 429 +
 // Retry-After when its requested alias or resolved build is in the operator
 // reject set (EIGENINFERENCE_REJECT_MODELS). This is a deterministic
@@ -1039,7 +1020,14 @@ func (s *Server) dispatchOneProvider(
 	if pr.Timing != nil {
 		pr.Timing.DispatchedAt = time.Now()
 	}
-	if err := writeProviderInferenceRequest(r.Context(), provider, data); err != nil {
+	// Bound the provider write by the request-absolute first-token clock (see
+	// firstTokenWriteContext): a congested write lane must not silently eat
+	// the budget while the aggregator's cancel clock keeps running.
+	writeCtx, cancelWrite := firstTokenWriteContext(
+		r.Context(), timingReceivedAt(timing), ttftDeadline(estimatedPromptTokens))
+	writeErr := writeProviderInferenceRequest(writeCtx, provider, data)
+	cancelWrite()
+	if writeErr != nil {
 		s.registry.ForgetCacheAttempt(pr)
 		refundExtra()
 		cleanupPending()
@@ -4698,7 +4686,10 @@ reserveProvider:
 		return
 	}
 	timing.DispatchedAt = time.Now()
-	if err := writeProviderInferenceRequest(r.Context(), provider, data); err != nil {
+	writeCtx, cancelWrite := firstTokenWriteContext(r.Context(), timing.ReceivedAt, genericDeadline)
+	writeErr := writeProviderInferenceRequest(writeCtx, provider, data)
+	cancelWrite()
+	if writeErr != nil {
 		s.registry.ForgetCacheAttempt(pr)
 		cleanupPending()
 		refundExtra()
@@ -4725,6 +4716,21 @@ reserveProvider:
 	var firstChunk string
 	committed := false
 	accepted := false
+
+	// commitGenericChunk mirrors the ChunkCh arms' first-chunk bookkeeping
+	// (stamp actual_ttft_ms anchor, mark committed, record the capacity
+	// ACCEPT). Used when a buffered chunk is recovered from a timer arm — an
+	// on-time token and a zero-duration timer race in Go's select.
+	commitGenericChunk := func(chunk string) {
+		firstChunk = chunk
+		pr.MarkFirstChunkArrived()
+		pr.MarkFirstContentArrived()
+		pr.MarkContentCommitted()
+		if s.registry.RecordCapacityAccept(provider.ID, pr.Model) {
+			pr.MarkRateOutcomeCounted()
+		}
+		committed = true
+	}
 
 	select {
 	case <-pr.AcceptedCh:
@@ -4786,6 +4792,10 @@ reserveProvider:
 		s.writeGenericProviderError(w, errMsg)
 		return
 	case <-ttftTimer.C:
+		if chunk, ok := takeBufferedGenericChunk(pr); ok {
+			commitGenericChunk(chunk)
+			break
+		}
 		provider.RemovePending(requestID)
 		s.registry.SetProviderIdle(provider.ID)
 		s.sendProviderCancel(provider, requestID)
@@ -4812,7 +4822,8 @@ reserveProvider:
 	// and must not reset the budget to inferenceTimeout (10 minutes) —
 	// OpenRouter will 504 at ~10s+1ms/token if no real token arrives.
 	if accepted && !committed {
-		chunkTimer := time.NewTimer(firstTokenRemainingSince(timing.ReceivedAt, genericDeadline))
+		acceptedBudget := firstTokenRemainingSince(timing.ReceivedAt, genericDeadline)
+		chunkTimer := time.NewTimer(acceptedBudget)
 		select {
 		case chunk, ok := <-pr.ChunkCh:
 			chunkTimer.Stop()
@@ -4856,16 +4867,24 @@ reserveProvider:
 			s.writeGenericProviderError(w, errMsg)
 			return
 		case <-chunkTimer.C:
+			if chunk, ok := takeBufferedGenericChunk(pr); ok {
+				commitGenericChunk(chunk)
+				break
+			}
 			provider.RemovePending(requestID)
 			s.registry.SetProviderIdle(provider.ID)
 			s.sendProviderCancel(provider, requestID)
 			refundExtra()
 			refundReservation()
-			// Accepted-then-silent is a provider-at-fault 504 — feed the
-			// breaker (single-attempt path: no retry here, but repeated
-			// stalls must still accumulate into the routing cooldown). No
-			// provider message on this synthetic timeout, so errStr is "".
-			s.noteInferenceError(provider.ID, pr, http.StatusGatewayTimeout, "", "", "")
+			// Accepted-then-silent feeds the provider breaker ONLY when the
+			// provider was actually granted a provider-attributable window.
+			// A budget capped short by the request-absolute first-token clock
+			// is OUR deadline (queueing/admission before dispatch), not
+			// provider sickness — feeding it would quarantine a healthy cold
+			// provider (two 504 feeds in 60s cool the pair for 5 minutes).
+			if providerAttributableStall(acceptedBudget) {
+				s.noteInferenceError(provider.ID, pr, http.StatusGatewayTimeout, "", "", "")
+			}
 			s.ddIncr("inference.dispatches", []string{"status:timeout"})
 			s.updateInferenceRouteOutcomeForPending(pr, pendingRouteOutcome(pr, "timeout", "accepted_timeout", http.StatusGatewayTimeout))
 			s.writeFirstTokenTimeout(w, model, "provider accepted but timed out before first chunk")

--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -712,6 +712,18 @@ func (s *Server) estimateTTFTRetryAfter(model string, bestTTFT, threshold time.D
 	return seconds
 }
 
+// writeFirstTokenTimeout writes the OpenRouter-compatible retryable 429 used
+// when a request-absolute first-token clock expires after dispatch. Chat
+// exhausted already uses this shape (Retry-After + rate_limit_exceeded);
+// /v1/completions and /v1/messages must match so aggregators retry instead
+// of treating the timeout as a provider 504.
+func (s *Server) writeFirstTokenTimeout(w http.ResponseWriter, model, message string) {
+	retryAfter := s.estimateRetryAfter(model)
+	w.Header().Set("Retry-After", strconv.Itoa(retryAfter))
+	writeJSON(w, http.StatusTooManyRequests, errorResponse("rate_limit_exceeded",
+		message, withCode("rate_limit_exceeded")))
+}
+
 func (s *Server) writeTTFTTooSlow(w http.ResponseWriter, model, publicModel string, bestTTFT, threshold time.Duration) {
 	retryAfter := s.estimateTTFTRetryAfter(model, bestTTFT, threshold)
 	w.Header().Set("Retry-After", strconv.Itoa(retryAfter))
@@ -4781,8 +4793,7 @@ reserveProvider:
 		refundReservation()
 		s.ddIncr("inference.dispatches", []string{"status:timeout"})
 		s.updateInferenceRouteOutcomeForPending(pr, pendingRouteOutcome(pr, "timeout", "first_chunk_timeout", http.StatusGatewayTimeout))
-		statusCode, reason, _ := classifyExhaustedStatus(http.StatusGatewayTimeout, "")
-		writeJSON(w, statusCode, errorResponse(reason, "provider did not respond within TTFT deadline"))
+		s.writeFirstTokenTimeout(w, model, "provider did not respond within TTFT deadline")
 		return
 	case <-r.Context().Done():
 		ttftTimer.Stop()
@@ -4857,8 +4868,7 @@ reserveProvider:
 			s.noteInferenceError(provider.ID, pr, http.StatusGatewayTimeout, "", "", "")
 			s.ddIncr("inference.dispatches", []string{"status:timeout"})
 			s.updateInferenceRouteOutcomeForPending(pr, pendingRouteOutcome(pr, "timeout", "accepted_timeout", http.StatusGatewayTimeout))
-			statusCode, reason, _ := classifyExhaustedStatus(http.StatusGatewayTimeout, "")
-			writeJSON(w, statusCode, errorResponse(reason, "provider accepted but timed out before first chunk"))
+			s.writeFirstTokenTimeout(w, model, "provider accepted but timed out before first chunk")
 			return
 		case <-r.Context().Done():
 			chunkTimer.Stop()

--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -47,14 +47,14 @@ const (
 	// 10 minutes allows 32k tokens at ~55 tok/s on slower hardware.
 	inferenceTimeout = 600 * time.Second
 
-	// preambleContentTimeout is the budget from the first boilerplate chunk to
-	// the first CONTENT chunk when the TTFT deadline has already expired. A
-	// provider that produced only preamble (role delta / Responses lifecycle)
-	// has written ZERO bytes to the client, so a role-then-stall zombie must
-	// fail over instead of pinning the request for the full inferenceTimeout.
-	// 90s comfortably covers the measured pre-content tail (vision prefill is
-	// 6-30s); genuine cold model loads signal via AcceptedCh and keep the full
-	// inferenceTimeout.
+	// preambleContentTimeout is the relative cap from the first boilerplate
+	// chunk to the first CONTENT chunk. A provider that produced only preamble
+	// (role delta / Responses lifecycle) has written ZERO bytes to the client,
+	// so a role-then-stall zombie must fail over instead of pinning the request
+	// for the full inferenceTimeout. 90s covers the measured pre-content tail
+	// (vision prefill is 6-30s). When ReceivedAt is stamped this cap cannot
+	// exceed leftover request-absolute first-token budget: AcceptedCh is not a
+	// completion token and must not reset that clock.
 	preambleContentTimeout = 90 * time.Second
 
 	// chunkBufferSize is the channel buffer size for SSE chunks flowing from
@@ -135,6 +135,25 @@ func ttftDeadline(estimatedPromptTokens int) time.Duration {
 	base := time.Duration(ttftLiveDeadlineBaseMs) * time.Millisecond
 	perToken := time.Duration(estimatedPromptTokens) * time.Millisecond
 	return base + perToken
+}
+
+// firstTokenRemainingSince is the leftover request-absolute first-CONTENT
+// budget. OpenRouter cancels at ~10000ms + 1ms*tokens from request start; our
+// live deadline (prod 9s + 1ms*tokens) is the slack vs that clock. A zero
+// receivedAt falls back to the full deadline so unit tests that never stamp
+// RequestTiming keep the historical relative timers.
+func firstTokenRemainingSince(receivedAt time.Time, deadline time.Duration) time.Duration {
+	if deadline <= 0 {
+		return 0
+	}
+	if receivedAt.IsZero() {
+		return deadline
+	}
+	remaining := deadline - time.Since(receivedAt)
+	if remaining < 0 {
+		return 0
+	}
+	return remaining
 }
 
 // shedIfModelRejected answers a public/prefer-owner request with 429 +
@@ -4541,7 +4560,7 @@ reserveProvider:
 	// before committing. This mirrors the chat completions path but without
 	// speculative dispatch (single attempt). If the provider misses the
 	// TTFT deadline, the request fails instead of streaming forever.
-	ttftTimer := time.NewTimer(genericDeadline)
+	ttftTimer := time.NewTimer(firstTokenRemainingSince(timing.ReceivedAt, genericDeadline))
 	var firstChunk string
 	committed := false
 	accepted := false
@@ -4613,7 +4632,8 @@ reserveProvider:
 		refundReservation()
 		s.ddIncr("inference.dispatches", []string{"status:timeout"})
 		s.updateInferenceRouteOutcomeForPending(pr, pendingRouteOutcome(pr, "timeout", "first_chunk_timeout", http.StatusGatewayTimeout))
-		writeJSON(w, http.StatusGatewayTimeout, errorResponse("timeout", "provider did not respond within TTFT deadline"))
+		statusCode, reason, _ := classifyExhaustedStatus(http.StatusGatewayTimeout, "")
+		writeJSON(w, statusCode, errorResponse(reason, "provider did not respond within TTFT deadline"))
 		return
 	case <-r.Context().Done():
 		ttftTimer.Stop()
@@ -4627,9 +4647,12 @@ reserveProvider:
 		return
 	}
 
-	// If provider accepted (model reload), wait for first chunk with extended deadline.
+	// If provider accepted (model reload), keep waiting for first CONTENT
+	// on the same request-absolute first-token clock. Accept is not a token
+	// and must not reset the budget to inferenceTimeout (10 minutes) —
+	// OpenRouter will 504 at ~10s+1ms/token if no real token arrives.
 	if accepted && !committed {
-		chunkTimer := time.NewTimer(inferenceTimeout)
+		chunkTimer := time.NewTimer(firstTokenRemainingSince(timing.ReceivedAt, genericDeadline))
 		select {
 		case chunk, ok := <-pr.ChunkCh:
 			chunkTimer.Stop()
@@ -4685,7 +4708,8 @@ reserveProvider:
 			s.noteInferenceError(provider.ID, pr, http.StatusGatewayTimeout, "", "", "")
 			s.ddIncr("inference.dispatches", []string{"status:timeout"})
 			s.updateInferenceRouteOutcomeForPending(pr, pendingRouteOutcome(pr, "timeout", "accepted_timeout", http.StatusGatewayTimeout))
-			writeJSON(w, http.StatusGatewayTimeout, errorResponse("timeout", "provider accepted but timed out before first chunk"))
+			statusCode, reason, _ := classifyExhaustedStatus(http.StatusGatewayTimeout, "")
+			writeJSON(w, statusCode, errorResponse(reason, "provider accepted but timed out before first chunk"))
 			return
 		case <-r.Context().Done():
 			chunkTimer.Stop()

--- a/coordinator/api/dispatch.go
+++ b/coordinator/api/dispatch.go
@@ -232,6 +232,39 @@ func (d *dispatchState) traits() registry.RequestTraits {
 	}
 }
 
+// firstTokenRemaining is the leftover request-absolute first-CONTENT budget.
+// ok is false when ReceivedAt was never stamped; callers then keep the
+// historical relative timer (d.deadline / d.deadline-speculativeAt).
+func (d *dispatchState) firstTokenRemaining() (remaining time.Duration, ok bool) {
+	if d == nil || d.timing == nil || d.timing.ReceivedAt.IsZero() {
+		return 0, false
+	}
+	return firstTokenRemainingSince(d.timing.ReceivedAt, d.deadline), true
+}
+
+// firstTokenWait returns how long we may still wait for first CONTENT.
+// When the request clock is set this is leftover SLA from ReceivedAt,
+// never a fresh relative window. relativeFallback is the pre-clock
+// behavior (full deadline, leftover after speculative, or inferenceTimeout).
+func (d *dispatchState) firstTokenWait(relativeFallback time.Duration) time.Duration {
+	if remaining, ok := d.firstTokenRemaining(); ok {
+		return remaining
+	}
+	if relativeFallback < 0 {
+		return 0
+	}
+	return relativeFallback
+}
+
+func (d *dispatchState) firstTokenExpired() bool {
+	remaining, ok := d.firstTokenRemaining()
+	return ok && remaining == 0
+}
+
+func (d *dispatchState) canExtendPreambleLiveness() bool {
+	return d.firstTokenWait(preambleContentTimeout) > 0
+}
+
 func (d *dispatchState) excludedProviderIDs() []string {
 	ids := make([]string, 0, len(d.excludeProviders))
 	for id := range d.excludeProviders {
@@ -1533,7 +1566,8 @@ func (d *dispatchState) latchDeterministicLoser(provider *registry.Provider, msg
 
 // waitFirstChunk runs the speculative TTFT-aware first-chunk wait (the former
 // `firstChunkWait` labeled loop). It holds preamble chunks, commits on first
-// content, extends on AcceptedCh / preamble liveness, retries invisibly on
+// content, proceeds to waitAccepted on AcceptedCh / preamble liveness without
+// resetting the request-absolute first-token clock, retries invisibly on
 // provider error/timeout, and launches the speculative backup race when the
 // primary is slow. Returns outcomeCommitted (content / clean close), outcomeAccepted
 // (cold-load or preamble liveness — proceed to waitAccepted), outcomeRetry
@@ -1571,14 +1605,22 @@ func (d *dispatchState) waitFirstChunk() (outcome dispatchOutcome) {
 		}
 	}()
 
-	speculativeTimer := time.NewTimer(d.speculativeAt)
-	deadlineTimer := time.NewTimer(d.deadline)
+	deadlineWait := d.firstTokenWait(d.deadline)
+	specWait := d.speculativeAt
+	if _, ok := d.firstTokenRemaining(); ok {
+		if specWait <= 0 || specWait >= deadlineWait {
+			specWait = deadlineWait / 2
+		}
+	}
+	speculativeTimer := time.NewTimer(specWait)
+	deadlineTimer := time.NewTimer(deadlineWait)
 	d.accepted = false
 	// preambleLiveness distinguishes WHY the extended first-content wait was
-	// entered: a genuine AcceptedCh (cold model load — keeps the full
-	// inferenceTimeout) vs a held-boilerplate liveness extension past an
-	// expired TTFT deadline (zero bytes written to the client — bounded by
-	// preambleContentTimeout so a role-then-stall zombie fails over).
+	// entered: a genuine AcceptedCh (cold model load) vs a held-boilerplate
+	// liveness extension. Neither path may outrun the request-absolute
+	// first-token clock — OpenRouter 504s if no real token arrives in time.
+	// A preamble-then-stall with leftover budget is still bounded by
+	// preambleContentTimeout so a role-then-stall zombie fails over.
 	d.preambleLiveness = false
 
 	for {
@@ -1654,10 +1696,10 @@ func (d *dispatchState) waitFirstChunk() (outcome dispatchOutcome) {
 
 		case <-deadlineTimer.C:
 			speculativeTimer.Stop()
-			if len(d.heldChunks) > 0 {
+			if len(d.heldChunks) > 0 && d.canExtendPreambleLiveness() {
 				// Preamble liveness — the provider is alive but still in its
-				// pre-content phase. Fall through to the extended
-				// (preambleContentTimeout) wait instead of failing the attempt.
+				// pre-content phase. Fall through to waitAccepted, still
+				// bounded by leftover request-absolute first-token budget.
 				d.accepted = true
 				d.preambleLiveness = true
 				return outcomeAccepted
@@ -1801,7 +1843,7 @@ func (d *dispatchState) waitNoBackup() dispatchOutcome {
 	r := d.r
 	provider, pr := d.provider, d.pr
 
-	remainingDeadline := time.NewTimer(d.deadline - d.speculativeAt)
+	remainingDeadline := time.NewTimer(d.firstTokenWait(d.deadline - d.speculativeAt))
 	for {
 		select {
 		case chunk, ok := <-pr.ChunkCh:
@@ -1848,12 +1890,10 @@ func (d *dispatchState) waitNoBackup() dispatchOutcome {
 			d.pr = nil
 			return outcomeRetry
 		case <-remainingDeadline.C:
-			if len(d.heldChunks) > 0 {
-				// Liveness: the provider already produced its preamble —
-				// vision prefill / template render may legitimately
-				// exceed the TTFT deadline. Fall through to the
-				// extended (preambleContentTimeout) wait for first
-				// content, with ErrorCh still armed for retry.
+			if len(d.heldChunks) > 0 && d.canExtendPreambleLiveness() {
+				// Liveness: the provider already produced its preamble.
+				// Fall through to waitAccepted, still bounded by leftover
+				// request-absolute first-token budget.
 				d.accepted = true
 				d.preambleLiveness = true
 				return outcomeAccepted
@@ -1900,10 +1940,10 @@ func (d *dispatchState) runRace(backupProvider *registry.Provider, backupPR *reg
 	r := d.r
 	provider, pr := d.provider, d.pr
 
-	raceDeadline := time.NewTimer(d.deadline - d.speculativeAt)
+	raceDeadline := time.NewTimer(d.firstTokenWait(d.deadline - d.speculativeAt))
 	// One-shot extension: when the race deadline expires but a racer
-	// has shown liveness (preamble received), the race continues for
-	// the full inference window instead of failing the request.
+	// has shown liveness (preamble received), the race continues up to
+	// leftover first-token budget (capped by preambleContentTimeout).
 	raceExtended := false
 	// Preamble chunks from the backup are buffered separately —
 	// held chunks must never mix providers.
@@ -2000,7 +2040,8 @@ func (d *dispatchState) runRace(backupProvider *registry.Provider, backupPR *reg
 			return outcomeCommitted
 
 		case <-pr.AcceptedCh:
-			// Primary accepted (model reload). Cancel backup, extend deadline.
+			// Primary accepted (model reload). Cancel backup; first-token
+			// budget stays request-absolute in waitAccepted.
 			raceDeadline.Stop()
 			s.cancelDispatch(backupProvider, backupPR)
 			d.markSpeculativeLoser(backupPR)
@@ -2008,7 +2049,8 @@ func (d *dispatchState) runRace(backupProvider *registry.Provider, backupPR *reg
 			return outcomeAccepted
 
 		case <-backupPR.AcceptedCh:
-			// Backup accepted (model reload). Cancel primary, extend deadline.
+			// Backup accepted (model reload). Cancel primary; first-token
+			// budget stays request-absolute in waitAccepted.
 			raceDeadline.Stop()
 			s.cancelDispatch(provider, pr)
 			d.markSpeculativeLoser(pr)
@@ -2056,14 +2098,20 @@ func (d *dispatchState) runRace(backupProvider *registry.Provider, backupPR *reg
 		case <-raceDeadline.C:
 			if !raceExtended && (len(d.heldChunks) > 0 || len(backupHeld) > 0) {
 				// Liveness from at least one racer: don't fail at the
-				// TTFT deadline — extend once by the preamble-to-content
-				// budget (zero bytes have reached the client; a genuine
-				// cold load would have signalled AcceptedCh) and keep both
-				// racing for first content, with both error channels still
-				// armed for retry.
-				raceExtended = true
-				raceDeadline = time.NewTimer(preambleContentTimeout)
-				continue
+				// relative TTFT slice — extend once by leftover
+				// request-absolute first-token budget, capped by
+				// preambleContentTimeout (zero bytes have reached the
+				// client; a genuine cold load would have signalled
+				// AcceptedCh).
+				ext := d.firstTokenWait(preambleContentTimeout)
+				if ext > preambleContentTimeout {
+					ext = preambleContentTimeout
+				}
+				if ext > 0 {
+					raceExtended = true
+					raceDeadline = time.NewTimer(ext)
+					continue
+				}
 			}
 			// Both missed deadline. A racer that held preamble (role
 			// then stall) is a 504-shaped sickness — feed the breaker
@@ -2109,7 +2157,7 @@ func (d *dispatchState) runRace(backupProvider *registry.Provider, backupPR *reg
 func (d *dispatchState) raceBackupChunkClosedWaitPrimary(provider *registry.Provider, pr *registry.PendingRequest) dispatchOutcome {
 	s := d.s
 	r := d.r
-	remainingPrimary := time.NewTimer(d.deadline - d.speculativeAt)
+	remainingPrimary := time.NewTimer(d.firstTokenWait(d.deadline - d.speculativeAt))
 	for {
 		select {
 		case chunk, ok := <-pr.ChunkCh:
@@ -2161,9 +2209,9 @@ func (d *dispatchState) raceBackupChunkClosedWaitPrimary(provider *registry.Prov
 			d.requestID = ""
 			return outcomeRetry
 		case <-remainingPrimary.C:
-			if len(d.heldChunks) > 0 {
-				// Primary preamble liveness — extend to the
-				// preamble-to-content budget instead of failing.
+			if len(d.heldChunks) > 0 && d.canExtendPreambleLiveness() {
+				// Primary preamble liveness — continue in waitAccepted
+				// on leftover request-absolute first-token budget.
 				d.accepted = true
 				d.preambleLiveness = true
 				return outcomeAccepted
@@ -2210,7 +2258,7 @@ func (d *dispatchState) racePrimaryFailedWaitBackup(backupProvider *registry.Pro
 	// primary's 4xx/422/429, so the primary keeps the attribution even
 	// though the backup keeps racing (noteServingSlotFor's freeze rule).
 	d.noteServingSlotFor(backupPR)
-	backupDeadline := time.NewTimer(d.deadline - d.speculativeAt)
+	backupDeadline := time.NewTimer(d.firstTokenWait(d.deadline - d.speculativeAt))
 	for {
 		select {
 		case chunk, ok := <-backupPR.ChunkCh:
@@ -2271,9 +2319,9 @@ func (d *dispatchState) racePrimaryFailedWaitBackup(backupProvider *registry.Pro
 			d.pr = nil
 			return outcomeRetry
 		case <-backupDeadline.C:
-			if len(backupHeld) > 0 {
-				// Backup preamble liveness — promote it and extend
-				// by the preamble-to-content budget for first content.
+			if len(backupHeld) > 0 && d.canExtendPreambleLiveness() {
+				// Backup preamble liveness — promote it and continue
+				// in waitAccepted on leftover first-token budget.
 				backupPR.BackupWon = true
 				d.provider = backupProvider
 				d.pr = backupPR
@@ -2311,7 +2359,7 @@ func (d *dispatchState) racePrimaryFailedWaitBackup(backupProvider *registry.Pro
 func (d *dispatchState) raceBackupErrWaitPrimary(provider *registry.Provider, pr *registry.PendingRequest) dispatchOutcome {
 	s := d.s
 	r := d.r
-	primaryDeadline := time.NewTimer(d.deadline - d.speculativeAt)
+	primaryDeadline := time.NewTimer(d.firstTokenWait(d.deadline - d.speculativeAt))
 	for {
 		select {
 		case chunk, ok := <-pr.ChunkCh:
@@ -2357,9 +2405,9 @@ func (d *dispatchState) raceBackupErrWaitPrimary(provider *registry.Provider, pr
 			d.requestID = ""
 			return outcomeRetry
 		case <-primaryDeadline.C:
-			if len(d.heldChunks) > 0 {
-				// Primary preamble liveness — extend by the
-				// preamble-to-content budget instead of failing.
+			if len(d.heldChunks) > 0 && d.canExtendPreambleLiveness() {
+				// Primary preamble liveness — continue in waitAccepted
+				// on leftover request-absolute first-token budget.
 				d.accepted = true
 				d.preambleLiveness = true
 				return outcomeAccepted
@@ -2389,11 +2437,10 @@ func (d *dispatchState) raceBackupErrWaitPrimary(provider *registry.Provider, pr
 
 // waitAccepted runs the post-accept wait for first content (the former
 // `acceptedWait` loop). It is entered when the committed provider accepted or held
-// preamble but hasn't produced content yet. The budget depends on WHY we're here:
-// a genuine AcceptedCh (model reload — legitimately minutes) keeps the full
-// inferenceTimeout; a boilerplate-liveness extension past an expired TTFT deadline
-// gets only preambleContentTimeout (zero bytes written to the client, so a
-// preamble-then-stall provider must fail over instead of pinning for 10 minutes).
+// preamble but hasn't produced content yet. Accept is not a completion token:
+// the request-absolute first-token clock keeps running. preambleLiveness still
+// caps the wait at preambleContentTimeout so a role-then-stall zombie fails
+// over instead of pinning, but that cap cannot exceed leftover SLA.
 func (d *dispatchState) waitAccepted() (outcome dispatchOutcome) {
 	s := d.s
 	r := d.r
@@ -2428,6 +2475,9 @@ func (d *dispatchState) waitAccepted() (outcome dispatchOutcome) {
 	firstContentBudget := inferenceTimeout
 	if d.preambleLiveness {
 		firstContentBudget = preambleContentTimeout
+	}
+	if remaining, ok := d.firstTokenRemaining(); ok && remaining < firstContentBudget {
+		firstContentBudget = remaining
 	}
 	chunkTimer := time.NewTimer(firstContentBudget)
 	for {
@@ -2575,7 +2625,7 @@ func (d *dispatchState) run() {
 		// (it returns outcomeFailFast as soon as no eligible provider remains), so
 		// in practice the loop ends at exhaustion or success; maxDispatchAttempts
 		// is only a hot-loop ceiling and this is the wall-clock bound.
-		if attempt > 0 && r.Context().Err() != nil {
+		if attempt > 0 && (r.Context().Err() != nil || d.firstTokenExpired()) {
 			goto exhausted
 		}
 		// Each attempt holds preamble chunks from its own provider only.
@@ -2617,6 +2667,13 @@ func (d *dispatchState) run() {
 			"ttft_deadline_ms", d.deadline.Milliseconds(),
 			"speculative_at_ms", d.speculativeAt.Milliseconds(),
 		)
+
+		if d.firstTokenExpired() {
+			if d.lastErrCode == 0 {
+				d.setLastError("timeout waiting for first response", http.StatusGatewayTimeout)
+			}
+			goto exhausted
+		}
 
 		// ---- Speculative TTFT-aware first-chunk wait ----
 		switch d.waitFirstChunk() {

--- a/coordinator/api/dispatch.go
+++ b/coordinator/api/dispatch.go
@@ -232,98 +232,6 @@ func (d *dispatchState) traits() registry.RequestTraits {
 	}
 }
 
-// firstTokenRemaining is the leftover request-absolute first-CONTENT budget.
-// ok is false when ReceivedAt was never stamped; callers then keep the
-// historical relative timer (d.deadline / d.deadline-speculativeAt).
-func (d *dispatchState) firstTokenRemaining() (remaining time.Duration, ok bool) {
-	if d == nil || d.timing == nil || d.timing.ReceivedAt.IsZero() {
-		return 0, false
-	}
-	return firstTokenRemainingSince(d.timing.ReceivedAt, d.deadline), true
-}
-
-// firstTokenWait returns how long we may still wait for first CONTENT.
-// When the request clock is set this is leftover SLA from ReceivedAt,
-// never a fresh relative window. relativeFallback is the pre-clock
-// behavior (full deadline, leftover after speculative, or inferenceTimeout).
-func (d *dispatchState) firstTokenWait(relativeFallback time.Duration) time.Duration {
-	if remaining, ok := d.firstTokenRemaining(); ok {
-		return remaining
-	}
-	if relativeFallback < 0 {
-		return 0
-	}
-	return relativeFallback
-}
-
-func (d *dispatchState) firstTokenExpired() bool {
-	remaining, ok := d.firstTokenRemaining()
-	return ok && remaining == 0
-}
-
-func (d *dispatchState) canExtendPreambleLiveness() bool {
-	return d.firstTokenWait(preambleContentTimeout) > 0
-}
-
-// firstTokenSpeculativeWait is how long to wait before launching a backup.
-// With a request clock this is the leftover time until the absolute
-// speculative point (ReceivedAt + speculativeAt), not a fresh relative
-// delay. Past that point it is 0 so the backup starts immediately.
-func (d *dispatchState) firstTokenSpeculativeWait() time.Duration {
-	remaining, ok := d.firstTokenRemaining()
-	if !ok {
-		if d.speculativeAt < 0 {
-			return 0
-		}
-		return d.speculativeAt
-	}
-	if remaining <= 0 {
-		return 0
-	}
-	elapsed := d.deadline - remaining
-	if elapsed < 0 {
-		elapsed = 0
-	}
-	specWait := d.speculativeAt - elapsed
-	if specWait < 0 {
-		specWait = 0
-	}
-	if specWait > remaining {
-		specWait = remaining
-	}
-	return specWait
-}
-
-// abandonInflightForFirstTokenTimeout cancels a request already on the
-// wire when the request-absolute first-token clock is gone. Without this
-// the exhausted ladder refunds the client while the provider keeps
-// generating and can later settle an already-rejected request.
-func (d *dispatchState) abandonInflightForFirstTokenTimeout() {
-	if d == nil || d.provider == nil || d.pr == nil {
-		if d != nil && d.lastErrCode == 0 {
-			d.setLastError("timeout waiting for first response", http.StatusGatewayTimeout)
-		}
-		return
-	}
-	provider, pr := d.provider, d.pr
-	d.excludeProviders[provider.ID] = struct{}{}
-	d.s.registry.RecordWarmPoolTTFTMiss(d.model, d.deadline)
-	d.s.cancelDispatch(provider, pr)
-	if d.lastErrCode == 0 {
-		d.setLastError("timeout waiting for first response", http.StatusGatewayTimeout)
-	}
-	d.updateRoutingOutcomeForAttempt(
-		routingAttempt(provider, pr, d.requestID, d.attempt),
-		d.errorRoutingOutcomeFor(pr, "timeout", "first_chunk_timeout", http.StatusGatewayTimeout),
-	)
-	if d.s.metrics != nil {
-		d.s.metrics.IncCounter("inference_dispatches_total", MetricLabel{"result", "timeout"})
-	}
-	d.s.ddIncr("inference.dispatches", []string{"status:timeout"})
-	d.provider = nil
-	d.pr = nil
-}
-
 func (d *dispatchState) excludedProviderIDs() []string {
 	ids := make([]string, 0, len(d.excludeProviders))
 	for id := range d.excludeProviders {
@@ -1395,7 +1303,14 @@ func (d *dispatchState) dispatchPrimary() dispatchOutcome {
 			return outcomeRetry
 		}
 		d.pr.Timing.DispatchedAt = time.Now()
-		if err := writeProviderInferenceRequest(r.Context(), d.provider, data); err != nil {
+		// Bound the provider write by the request-absolute first-token clock:
+		// WriteText blocks until the frame is on the wire (write watchdog
+		// allows 5-30s per frame), so an unbounded write could eat the budget
+		// while the aggregator's cancel clock keeps running.
+		writeCtx, cancelWrite := firstTokenWriteContext(r.Context(), timingReceivedAt(d.timing), d.deadline)
+		writeErr := writeProviderInferenceRequest(writeCtx, d.provider, data)
+		cancelWrite()
+		if writeErr != nil {
 			s.registry.ForgetCacheAttempt(d.pr)
 			d.provider.RemovePending(d.requestID)
 			s.registry.SetProviderIdle(d.provider.ID)
@@ -1749,6 +1664,11 @@ func (d *dispatchState) waitFirstChunk() (outcome dispatchOutcome) {
 
 		case <-deadlineTimer.C:
 			speculativeTimer.Stop()
+			if chunk, ok := drainReadyFirstContent(pr, &d.heldChunks); ok {
+				d.commitFirstContent(pr, chunk)
+				d.committed = true
+				return outcomeCommitted
+			}
 			if len(d.heldChunks) > 0 && d.canExtendPreambleLiveness() {
 				// Preamble liveness — the provider is alive but still in its
 				// pre-content phase. Fall through to waitAccepted, still
@@ -1943,6 +1863,11 @@ func (d *dispatchState) waitNoBackup() dispatchOutcome {
 			d.pr = nil
 			return outcomeRetry
 		case <-remainingDeadline.C:
+			if chunk, ok := drainReadyFirstContent(pr, &d.heldChunks); ok {
+				d.commitFirstContent(pr, chunk)
+				d.committed = true
+				return outcomeCommitted
+			}
 			if len(d.heldChunks) > 0 && d.canExtendPreambleLiveness() {
 				// Liveness: the provider already produced its preamble.
 				// Fall through to waitAccepted, still bounded by leftover
@@ -1998,6 +1923,10 @@ func (d *dispatchState) runRace(backupProvider *registry.Provider, backupPR *reg
 	// has shown liveness (preamble received), the race continues up to
 	// leftover first-token budget (capped by preambleContentTimeout).
 	raceExtended := false
+	// extWindow is the wait actually granted by the one-shot liveness
+	// extension; the final-timeout breaker feeds are gated on it being a
+	// provider-attributable window (see providerAttributableStall).
+	var extWindow time.Duration
 	// Preamble chunks from the backup are buffered separately —
 	// held chunks must never mix providers.
 	var backupHeld []string
@@ -2149,6 +2078,31 @@ func (d *dispatchState) runRace(backupProvider *registry.Provider, backupPR *reg
 			return d.raceBackupErrWaitPrimary(provider, pr)
 
 		case <-raceDeadline.C:
+			// A token that is already buffered beats the timer: the backup is
+			// dispatched synchronously in runSpeculative, so an on-time primary
+			// token can be sitting in ChunkCh when a zero-leftover timer fires.
+			if chunk, ok := drainReadyFirstContent(pr, &d.heldChunks); ok {
+				s.cancelDispatch(backupProvider, backupPR)
+				d.markSpeculativeLoser(backupPR)
+				d.commitFirstContent(pr, chunk)
+				d.committed = true
+				return outcomeCommitted
+			}
+			if chunk, ok := drainReadyFirstContent(backupPR, &backupHeld); ok {
+				s.cancelDispatch(provider, pr)
+				s.ddIncr("inference.speculative_win", []string{"model:" + d.model})
+				s.registry.RecordWarmPoolSpeculativeWon(d.model)
+				d.markSpeculativeLoser(pr)
+				backupPR.BackupWon = true
+				d.provider = backupProvider
+				d.pr = backupPR
+				d.requestID = d.pr.RequestID
+				d.heldChunks = backupHeld
+				d.noteServingSlot()
+				d.commitFirstContent(d.pr, chunk)
+				d.committed = true
+				return outcomeCommitted
+			}
 			if !raceExtended && (len(d.heldChunks) > 0 || len(backupHeld) > 0) {
 				// Liveness from at least one racer: don't fail at the
 				// relative TTFT slice — extend once by leftover
@@ -2162,6 +2116,7 @@ func (d *dispatchState) runRace(backupProvider *registry.Provider, backupPR *reg
 				}
 				if ext > 0 {
 					raceExtended = true
+					extWindow = ext
 					raceDeadline = time.NewTimer(ext)
 					continue
 				}
@@ -2171,11 +2126,16 @@ func (d *dispatchState) runRace(backupProvider *registry.Provider, backupPR *reg
 			// before cancelling, mirroring the single-provider
 			// acceptedWait timeout path so a stalling provider/model
 			// (shape-keyed) trips its cooldown.
-			if len(d.heldChunks) > 0 {
-				s.noteInferenceError(provider.ID, pr, http.StatusGatewayTimeout, "", "", "")
-			}
-			if len(backupHeld) > 0 {
-				s.noteInferenceError(backupProvider.ID, backupPR, http.StatusGatewayTimeout, "", "", "")
+			// ... but ONLY when the extension actually granted the full
+			// provider-attributable window: an extension capped short by the
+			// request-absolute clock is OUR deadline, not provider sickness.
+			if providerAttributableStall(extWindow) {
+				if len(d.heldChunks) > 0 {
+					s.noteInferenceError(provider.ID, pr, http.StatusGatewayTimeout, "", "", "")
+				}
+				if len(backupHeld) > 0 {
+					s.noteInferenceError(backupProvider.ID, backupPR, http.StatusGatewayTimeout, "", "", "")
+				}
 			}
 			s.cancelDispatch(provider, pr)
 			s.registry.RecordWarmPoolTTFTMiss(d.model, d.deadline)
@@ -2262,6 +2222,11 @@ func (d *dispatchState) raceBackupChunkClosedWaitPrimary(provider *registry.Prov
 			d.requestID = ""
 			return outcomeRetry
 		case <-remainingPrimary.C:
+			if chunk, ok := drainReadyFirstContent(pr, &d.heldChunks); ok {
+				d.commitFirstContent(pr, chunk)
+				d.committed = true
+				return outcomeCommitted
+			}
 			if len(d.heldChunks) > 0 && d.canExtendPreambleLiveness() {
 				// Primary preamble liveness — continue in waitAccepted
 				// on leftover request-absolute first-token budget.
@@ -2372,6 +2337,16 @@ func (d *dispatchState) racePrimaryFailedWaitBackup(backupProvider *registry.Pro
 			d.pr = nil
 			return outcomeRetry
 		case <-backupDeadline.C:
+			if chunk, ok := drainReadyFirstContent(backupPR, &backupHeld); ok {
+				backupPR.BackupWon = true
+				d.provider = backupProvider
+				d.pr = backupPR
+				d.requestID = d.pr.RequestID
+				d.heldChunks = backupHeld
+				d.commitFirstContent(d.pr, chunk)
+				d.committed = true
+				return outcomeCommitted
+			}
 			if len(backupHeld) > 0 && d.canExtendPreambleLiveness() {
 				// Backup preamble liveness — promote it and continue
 				// in waitAccepted on leftover first-token budget.
@@ -2458,6 +2433,11 @@ func (d *dispatchState) raceBackupErrWaitPrimary(provider *registry.Provider, pr
 			d.requestID = ""
 			return outcomeRetry
 		case <-primaryDeadline.C:
+			if chunk, ok := drainReadyFirstContent(pr, &d.heldChunks); ok {
+				d.commitFirstContent(pr, chunk)
+				d.committed = true
+				return outcomeCommitted
+			}
 			if len(d.heldChunks) > 0 && d.canExtendPreambleLiveness() {
 				// Primary preamble liveness — continue in waitAccepted
 				// on leftover request-absolute first-token budget.
@@ -2611,15 +2591,23 @@ func (d *dispatchState) waitAccepted() (outcome dispatchOutcome) {
 			d.pr = nil
 			return outcomeRetry
 		case <-chunkTimer.C:
+			if chunk, ok := drainReadyFirstContent(pr, &d.heldChunks); ok {
+				d.commitFirstContent(pr, chunk)
+				d.committed = true
+				return outcomeCommitted
+			}
 			d.excludeProviders[provider.ID] = struct{}{}
 			s.registry.RecordWarmPoolTTFTMiss(d.model, firstContentBudget)
 			s.cancelDispatch(provider, pr)
-			// Accepted-then-silent (or preamble-then-stall) is a
-			// provider-at-fault 504 — feed the breaker so a provider
-			// that repeatedly acks and stalls enters cooldown instead
-			// of soaking retries forever. (504 is one of the breaker's
-			// counted codes; this arm is where those 504s originate.)
-			s.noteInferenceError(provider.ID, pr, http.StatusGatewayTimeout, "", "", "")
+			// Accepted-then-silent (or preamble-then-stall) feeds the
+			// breaker so a provider that repeatedly acks and stalls enters
+			// cooldown — but ONLY when the provider was actually granted a
+			// provider-attributable window. A budget capped short by the
+			// request-absolute first-token clock is OUR deadline (queueing,
+			// admission), not provider sickness.
+			if providerAttributableStall(firstContentBudget) {
+				s.noteInferenceError(provider.ID, pr, http.StatusGatewayTimeout, "", "", "")
+			}
 			d.setLastError("provider accepted but timed out before first chunk", http.StatusGatewayTimeout)
 			if d.preambleLiveness {
 				d.setLastError("provider sent preamble but stalled before first content", http.StatusGatewayTimeout)
@@ -2678,7 +2666,14 @@ func (d *dispatchState) run() {
 		// (it returns outcomeFailFast as soon as no eligible provider remains), so
 		// in practice the loop ends at exhaustion or success; maxDispatchAttempts
 		// is only a hot-loop ceiling and this is the wall-clock bound.
-		if attempt > 0 && (r.Context().Err() != nil || d.firstTokenExpired()) {
+		if attempt > 0 && r.Context().Err() != nil {
+			goto exhausted
+		}
+		if attempt > 0 && d.firstTokenExpired() {
+			// The request-absolute first-token budget is gone: the client must
+			// see the retryable 429 (synthetic 504 -> first_chunk_timeout), not
+			// whatever the last provider attempt happened to fail with.
+			d.setLastError("timeout waiting for first response", http.StatusGatewayTimeout)
 			goto exhausted
 		}
 		// Each attempt holds preamble chunks from its own provider only.
@@ -2722,6 +2717,13 @@ func (d *dispatchState) run() {
 		)
 
 		if d.firstTokenExpired() {
+			// A token that is already buffered beats the clock: deliver it
+			// instead of 429ing a request the provider answered on time.
+			if chunk, ok := drainReadyFirstContent(d.pr, &d.heldChunks); ok {
+				d.commitFirstContent(d.pr, chunk)
+				d.committed = true
+				break
+			}
 			d.abandonInflightForFirstTokenTimeout()
 			goto exhausted
 		}

--- a/coordinator/api/dispatch.go
+++ b/coordinator/api/dispatch.go
@@ -265,6 +265,65 @@ func (d *dispatchState) canExtendPreambleLiveness() bool {
 	return d.firstTokenWait(preambleContentTimeout) > 0
 }
 
+// firstTokenSpeculativeWait is how long to wait before launching a backup.
+// With a request clock this is the leftover time until the absolute
+// speculative point (ReceivedAt + speculativeAt), not a fresh relative
+// delay. Past that point it is 0 so the backup starts immediately.
+func (d *dispatchState) firstTokenSpeculativeWait() time.Duration {
+	remaining, ok := d.firstTokenRemaining()
+	if !ok {
+		if d.speculativeAt < 0 {
+			return 0
+		}
+		return d.speculativeAt
+	}
+	if remaining <= 0 {
+		return 0
+	}
+	elapsed := d.deadline - remaining
+	if elapsed < 0 {
+		elapsed = 0
+	}
+	specWait := d.speculativeAt - elapsed
+	if specWait < 0 {
+		specWait = 0
+	}
+	if specWait > remaining {
+		specWait = remaining
+	}
+	return specWait
+}
+
+// abandonInflightForFirstTokenTimeout cancels a request already on the
+// wire when the request-absolute first-token clock is gone. Without this
+// the exhausted ladder refunds the client while the provider keeps
+// generating and can later settle an already-rejected request.
+func (d *dispatchState) abandonInflightForFirstTokenTimeout() {
+	if d == nil || d.provider == nil || d.pr == nil {
+		if d != nil && d.lastErrCode == 0 {
+			d.setLastError("timeout waiting for first response", http.StatusGatewayTimeout)
+		}
+		return
+	}
+	provider, pr := d.provider, d.pr
+	d.excludeProviders[provider.ID] = struct{}{}
+	d.s.registry.RecordWarmPoolTTFTMiss(d.model, d.deadline)
+	d.s.cancelDispatch(provider, pr)
+	if d.lastErrCode == 0 {
+		d.setLastError("timeout waiting for first response", http.StatusGatewayTimeout)
+	}
+	d.updateRoutingOutcomeForAttempt(
+		routingAttempt(provider, pr, d.requestID, d.attempt),
+		d.errorRoutingOutcomeFor(pr, "timeout", "first_chunk_timeout", http.StatusGatewayTimeout),
+	)
+	if d.s.metrics != nil {
+		d.s.metrics.IncCounter("inference_dispatches_total", MetricLabel{"result", "timeout"})
+	}
+	d.s.ddIncr("inference.dispatches", []string{"status:timeout"})
+	d.provider = nil
+	d.pr = nil
+}
+
 func (d *dispatchState) excludedProviderIDs() []string {
 	ids := make([]string, 0, len(d.excludeProviders))
 	for id := range d.excludeProviders {
@@ -1606,13 +1665,7 @@ func (d *dispatchState) waitFirstChunk() (outcome dispatchOutcome) {
 	}()
 
 	deadlineWait := d.firstTokenWait(d.deadline)
-	specWait := d.speculativeAt
-	if _, ok := d.firstTokenRemaining(); ok {
-		if specWait <= 0 || specWait >= deadlineWait {
-			specWait = deadlineWait / 2
-		}
-	}
-	speculativeTimer := time.NewTimer(specWait)
+	speculativeTimer := time.NewTimer(d.firstTokenSpeculativeWait())
 	deadlineTimer := time.NewTimer(deadlineWait)
 	d.accepted = false
 	// preambleLiveness distinguishes WHY the extended first-content wait was
@@ -2669,9 +2722,7 @@ func (d *dispatchState) run() {
 		)
 
 		if d.firstTokenExpired() {
-			if d.lastErrCode == 0 {
-				d.setLastError("timeout waiting for first response", http.StatusGatewayTimeout)
-			}
+			d.abandonInflightForFirstTokenTimeout()
 			goto exhausted
 		}
 

--- a/coordinator/api/dispatch_first_token_deadline_test.go
+++ b/coordinator/api/dispatch_first_token_deadline_test.go
@@ -2,6 +2,9 @@ package api
 
 import (
 	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -139,5 +142,75 @@ func TestWaitFirstChunkAcceptDoesNotResetFirstTokenClock(t *testing.T) {
 	}
 	if elapsed < 100*time.Millisecond {
 		t.Fatalf("should have waited leftover first-token budget; elapsed=%s", elapsed)
+	}
+}
+
+func TestFirstTokenSpeculativeWaitUsesAbsoluteClock(t *testing.T) {
+	t.Parallel()
+	d := &dispatchState{
+		deadline:      9 * time.Second,
+		speculativeAt: 4500 * time.Millisecond,
+		timing:        &registry.RequestTiming{ReceivedAt: time.Now().Add(-4400 * time.Millisecond)},
+	}
+	got := d.firstTokenSpeculativeWait()
+	if got < 50*time.Millisecond || got > 200*time.Millisecond {
+		t.Fatalf("dispatch at 4.4s against 4.5s speculative point: wait=%s want ~100ms", got)
+	}
+
+	past := &dispatchState{
+		deadline:      9 * time.Second,
+		speculativeAt: 4500 * time.Millisecond,
+		timing:        &registry.RequestTiming{ReceivedAt: time.Now().Add(-5 * time.Second)},
+	}
+	if got := past.firstTokenSpeculativeWait(); got != 0 {
+		t.Fatalf("past speculative point: wait=%s want 0 (start backup now)", got)
+	}
+
+	relative := &dispatchState{deadline: 9 * time.Second, speculativeAt: 4500 * time.Millisecond}
+	if got := relative.firstTokenSpeculativeWait(); got != 4500*time.Millisecond {
+		t.Fatalf("unset ReceivedAt must keep relative speculativeAt: got %s", got)
+	}
+}
+
+func TestAbandonInflightCancelsDispatchedRequest(t *testing.T) {
+	d, pr := firstTokenWaitState(t, 15*time.Second, 9*time.Second)
+	provider := d.provider
+	if provider.GetPending(pr.RequestID) == nil {
+		t.Fatal("setup: request should be pending before abandon")
+	}
+	d.abandonInflightForFirstTokenTimeout()
+	if provider.GetPending(pr.RequestID) != nil {
+		t.Fatal("leftover-0 timeout must cancelDispatch the in-flight request")
+	}
+	if d.provider != nil || d.pr != nil {
+		t.Fatal("abandon must clear provider/pr so exhausted cannot settle the attempt")
+	}
+	if d.lastErrCode != http.StatusGatewayTimeout {
+		t.Fatalf("lastErrCode=%d want 504", d.lastErrCode)
+	}
+	if _, excluded := d.excludeProviders[provider.ID]; !excluded {
+		t.Fatal("abandoned provider must be excluded from further attempts")
+	}
+}
+
+func TestWriteFirstTokenTimeoutUsesOpenRouter429Contract(t *testing.T) {
+	s := newTestServerForDispatch(t)
+	rec := httptest.NewRecorder()
+	s.writeFirstTokenTimeout(rec, "m", "provider did not respond within TTFT deadline")
+	if rec.Code != http.StatusTooManyRequests {
+		t.Fatalf("status=%d want 429", rec.Code)
+	}
+	if rec.Header().Get("Retry-After") == "" {
+		t.Fatal("Retry-After header missing")
+	}
+	if _, err := strconv.Atoi(rec.Header().Get("Retry-After")); err != nil {
+		t.Fatalf("Retry-After=%q want integer seconds", rec.Header().Get("Retry-After"))
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "rate_limit_exceeded") {
+		t.Fatalf("body missing rate_limit_exceeded: %s", body)
+	}
+	if strings.Contains(body, "first_chunk_timeout") {
+		t.Fatalf("client body must not use first_chunk_timeout: %s", body)
 	}
 }

--- a/coordinator/api/dispatch_first_token_deadline_test.go
+++ b/coordinator/api/dispatch_first_token_deadline_test.go
@@ -1,0 +1,143 @@
+package api
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+	"github.com/eigeninference/d-inference/coordinator/registry"
+	"github.com/eigeninference/d-inference/coordinator/store"
+)
+
+func TestFirstTokenRemainingSince(t *testing.T) {
+	t.Parallel()
+	if got := firstTokenRemainingSince(time.Time{}, 9*time.Second); got != 9*time.Second {
+		t.Fatalf("zero receivedAt: got %s want 9s", got)
+	}
+	if got := firstTokenRemainingSince(time.Now(), 0); got != 0 {
+		t.Fatalf("zero deadline: got %s", got)
+	}
+	got := firstTokenRemainingSince(time.Now().Add(-8*time.Second), 9*time.Second)
+	if got < 500*time.Millisecond || got > 1500*time.Millisecond {
+		t.Fatalf("8s-old receive against 9s deadline: remaining=%s", got)
+	}
+	if got := firstTokenRemainingSince(time.Now().Add(-15*time.Second), 9*time.Second); got != 0 {
+		t.Fatalf("expired clock: got %s want 0", got)
+	}
+}
+
+func TestFirstTokenExpiredAndPreambleCap(t *testing.T) {
+	t.Parallel()
+	d := &dispatchState{
+		deadline: 9 * time.Second,
+		timing:   &registry.RequestTiming{ReceivedAt: time.Now().Add(-15 * time.Second)},
+	}
+	if !d.firstTokenExpired() {
+		t.Fatal("expected first-token clock to be expired")
+	}
+	if d.canExtendPreambleLiveness() {
+		t.Fatal("expired clock must not extend preamble liveness")
+	}
+	if remaining, ok := d.firstTokenRemaining(); !ok || remaining != 0 {
+		t.Fatalf("remaining=%s ok=%v", remaining, ok)
+	}
+
+	relative := &dispatchState{deadline: 9 * time.Second}
+	if relative.firstTokenExpired() {
+		t.Fatal("unset ReceivedAt must keep historical relative timers")
+	}
+	if got := relative.firstTokenWait(4 * time.Second); got != 4*time.Second {
+		t.Fatalf("relative fallback: got %s", got)
+	}
+}
+
+func firstTokenWaitState(t *testing.T, receivedAgo, deadline time.Duration) (*dispatchState, *registry.PendingRequest) {
+	t.Helper()
+	s := newTestServerForDispatch(t)
+	st, ok := s.store.(*store.MemoryStore)
+	if !ok {
+		t.Fatalf("store = %T", s.store)
+	}
+	const model = "first-token-deadline-model"
+	provider := s.registry.Register("first-token-provider", nil, &protocol.RegisterMessage{
+		Models: []protocol.ModelInfo{{ID: model, ModelType: "chat"}},
+	})
+	pr := &registry.PendingRequest{
+		RequestID:  "first-token-request",
+		Attempt:    0,
+		ProviderID: provider.ID,
+		Model:      model,
+		ChunkCh:    make(chan string, 1),
+		AcceptedCh: make(chan struct{}, 1),
+		CompleteCh: make(chan protocol.UsageInfo, 1),
+		ErrorCh:    make(chan protocol.InferenceErrorMessage, 1),
+		Timing:     &registry.RequestTiming{ReceivedAt: time.Now().Add(-receivedAgo)},
+	}
+	provider.AddPending(pr)
+	if err := st.RecordInferenceRoute(&store.InferenceRouteRecord{
+		RequestID:  pr.RequestID,
+		Attempt:    pr.Attempt,
+		ProviderID: provider.ID,
+		Model:      model,
+	}); err != nil {
+		t.Fatalf("record route: %v", err)
+	}
+	req, err := http.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	d := &dispatchState{
+		s:                 s,
+		r:                 req,
+		model:             model,
+		deadline:          deadline,
+		speculativeAt:     deadline / 2,
+		timing:            pr.Timing,
+		attempt:           0,
+		excludeProviders:  make(map[string]struct{}),
+		refundReservation: func() {},
+		provider:          provider,
+		pr:                pr,
+		requestID:         pr.RequestID,
+	}
+	return d, pr
+}
+
+func TestWaitAcceptedKeepsRequestAbsoluteDeadline(t *testing.T) {
+	d, _ := firstTokenWaitState(t, 8*time.Second, 9*time.Second)
+	start := time.Now()
+	got := d.waitAccepted()
+	elapsed := time.Since(start)
+	if got != outcomeRetry {
+		t.Fatalf("waitAccepted=%v want outcomeRetry", got)
+	}
+	if d.lastErrCode != http.StatusGatewayTimeout {
+		t.Fatalf("lastErrCode=%d want 504", d.lastErrCode)
+	}
+	if elapsed > 2*time.Second {
+		t.Fatalf("accepted wait used leftover SLA, but took %s (would be 600s before the fix)", elapsed)
+	}
+}
+
+func TestWaitFirstChunkAcceptDoesNotResetFirstTokenClock(t *testing.T) {
+	d, pr := firstTokenWaitState(t, 0, 200*time.Millisecond)
+	pr.AcceptedCh <- struct{}{}
+	start := time.Now()
+	if got := d.waitFirstChunk(); got != outcomeAccepted {
+		t.Fatalf("waitFirstChunk=%v want outcomeAccepted", got)
+	}
+	if got := d.waitAccepted(); got != outcomeRetry {
+		t.Fatalf("waitAccepted=%v want outcomeRetry", got)
+	}
+	elapsed := time.Since(start)
+	if d.lastErrCode != http.StatusGatewayTimeout {
+		t.Fatalf("lastErrCode=%d want 504", d.lastErrCode)
+	}
+	if elapsed > 1500*time.Millisecond {
+		t.Fatalf("accept must not grant inferenceTimeout; elapsed=%s", elapsed)
+	}
+	if elapsed < 100*time.Millisecond {
+		t.Fatalf("should have waited leftover first-token budget; elapsed=%s", elapsed)
+	}
+}

--- a/coordinator/api/first_token_clock.go
+++ b/coordinator/api/first_token_clock.go
@@ -1,0 +1,221 @@
+package api
+
+// The request-absolute first-token clock.
+//
+// OpenRouter (and OpenRouter-shaped aggregators) cancel a request when no REAL
+// completion token has arrived within ~10000ms + 1ms x prompt_tokens measured
+// from the moment THEY sent the request. An HTTP 200, an SSE `: keepalive`
+// comment, and a provider `inference_accepted` ack do not satisfy that rule.
+// Production evidence (2026-08-15): ~11k/day client_gone rows fit that line
+// within ±250ms while the coordinator was still waiting on a 600s post-accept
+// budget.
+//
+// Everything here derives from one clock: ReceivedAt + ttftDeadline(tokens)
+// (prod: 9s + 1ms/token — deliberately inside the aggregator's 10s slope).
+// Invariants:
+//
+//  1. No wait for first CONTENT may extend past the leftover clock — not
+//     accept, not preamble liveness, not a speculative race extension.
+//  2. Expiry of OUR clock is not provider sickness. Per-provider fault
+//     breakers may only be fed when the provider was actually granted a
+//     provider-attributable window (providerAttributableStall).
+//  3. The clock bounds blocking provider writes too (firstTokenWriteContext):
+//     a congested write lane must not eat the budget invisibly.
+//  4. A token that is already buffered beats the clock: deadline arms drain
+//     ChunkCh before declaring a timeout (drainReadyFirstContent), because a
+//     zero-duration timer and a ready chunk race in Go's select.
+//  5. When ReceivedAt was never stamped (unit tests), every helper falls back
+//     to the historical relative timers.
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/registry"
+)
+
+// firstTokenRemainingSince is the leftover request-absolute first-CONTENT
+// budget. A zero receivedAt falls back to the full deadline so callers that
+// never stamp RequestTiming keep the historical relative timers.
+func firstTokenRemainingSince(receivedAt time.Time, deadline time.Duration) time.Duration {
+	if deadline <= 0 {
+		return 0
+	}
+	if receivedAt.IsZero() {
+		return deadline
+	}
+	remaining := deadline - time.Since(receivedAt)
+	if remaining < 0 {
+		return 0
+	}
+	return remaining
+}
+
+// timingReceivedAt reads ReceivedAt from a possibly-nil RequestTiming.
+func timingReceivedAt(t *registry.RequestTiming) time.Time {
+	if t == nil {
+		return time.Time{}
+	}
+	return t.ReceivedAt
+}
+
+// firstTokenWriteContext bounds a provider write by the request-absolute
+// first-token deadline. Provider WriteText blocks until the frame is on the
+// wire and can wait behind an in-flight data write (the per-connection write
+// watchdog allows 5-30s per frame); without this bound the budget can expire
+// while the dispatch goroutine is still blocked on the write, letting the
+// aggregator cancel before the loop can shed with a 429. The write lane
+// honors context expiry without corrupting the connection (writeFrame never
+// passes the context to the underlying WebSocket write).
+func firstTokenWriteContext(ctx context.Context, receivedAt time.Time, deadline time.Duration) (context.Context, context.CancelFunc) {
+	if receivedAt.IsZero() || deadline <= 0 {
+		return ctx, func() {}
+	}
+	return context.WithDeadline(ctx, receivedAt.Add(deadline))
+}
+
+// providerAttributableStall reports whether a first-content timeout may feed
+// per-provider fault breakers. True only when the provider was actually
+// granted at least the preamble-content window and stayed silent. A wait
+// capped short by the request-absolute clock is OUR deadline (queueing,
+// admission, write congestion) — blaming it would quarantine healthy cold
+// providers (two 504-coded feeds within 60s cool a pair for five minutes).
+func providerAttributableStall(granted time.Duration) bool {
+	return granted >= preambleContentTimeout
+}
+
+// drainReadyFirstContent consumes chunks ALREADY buffered on pr.ChunkCh
+// without blocking. Boilerplate is held with the same cap semantics as the
+// live wait arms; the first CONTENT chunk is returned. Deadline arms call
+// this before declaring a first-token timeout: an on-time token that raced
+// the (possibly zero-duration) timer must win, not be cancelled. A closed
+// channel returns false — the timeout path's provider cleanup handles it.
+func drainReadyFirstContent(pr *registry.PendingRequest, held *[]string) (string, bool) {
+	if pr == nil {
+		return "", false
+	}
+	for {
+		select {
+		case chunk, ok := <-pr.ChunkCh:
+			if !ok {
+				return "", false
+			}
+			if held != nil && len(*held) < maxHeldBoilerplate && isBoilerplateChunk(chunk) {
+				*held = append(*held, chunk)
+				pr.MarkFirstChunkArrived()
+				continue
+			}
+			return chunk, true
+		default:
+			return "", false
+		}
+	}
+}
+
+// takeBufferedGenericChunk non-blockingly claims a chunk already buffered on
+// the generic (/v1/completions, /v1/messages) path, which has no preamble
+// filter — the first chunk of ANY kind commits.
+func takeBufferedGenericChunk(pr *registry.PendingRequest) (string, bool) {
+	select {
+	case chunk, ok := <-pr.ChunkCh:
+		if ok {
+			return chunk, true
+		}
+	default:
+	}
+	return "", false
+}
+
+// firstTokenRemaining is the leftover request-absolute first-CONTENT budget.
+// ok is false when ReceivedAt was never stamped; callers then keep the
+// historical relative timer (d.deadline / d.deadline-speculativeAt).
+func (d *dispatchState) firstTokenRemaining() (remaining time.Duration, ok bool) {
+	if d == nil || d.timing == nil || d.timing.ReceivedAt.IsZero() {
+		return 0, false
+	}
+	return firstTokenRemainingSince(d.timing.ReceivedAt, d.deadline), true
+}
+
+// firstTokenWait returns how long we may still wait for first CONTENT.
+// When the request clock is set this is leftover SLA from ReceivedAt,
+// never a fresh relative window. relativeFallback is the pre-clock
+// behavior (full deadline, leftover after speculative, or inferenceTimeout).
+func (d *dispatchState) firstTokenWait(relativeFallback time.Duration) time.Duration {
+	if remaining, ok := d.firstTokenRemaining(); ok {
+		return remaining
+	}
+	if relativeFallback < 0 {
+		return 0
+	}
+	return relativeFallback
+}
+
+func (d *dispatchState) firstTokenExpired() bool {
+	remaining, ok := d.firstTokenRemaining()
+	return ok && remaining == 0
+}
+
+func (d *dispatchState) canExtendPreambleLiveness() bool {
+	return d.firstTokenWait(preambleContentTimeout) > 0
+}
+
+// firstTokenSpeculativeWait is how long to wait before launching a backup.
+// With a request clock this is the leftover time until the absolute
+// speculative point (ReceivedAt + speculativeAt), not a fresh relative
+// delay. Past that point it is 0 so the backup starts immediately.
+func (d *dispatchState) firstTokenSpeculativeWait() time.Duration {
+	remaining, ok := d.firstTokenRemaining()
+	if !ok {
+		if d.speculativeAt < 0 {
+			return 0
+		}
+		return d.speculativeAt
+	}
+	if remaining <= 0 {
+		return 0
+	}
+	elapsed := d.deadline - remaining
+	if elapsed < 0 {
+		elapsed = 0
+	}
+	specWait := d.speculativeAt - elapsed
+	if specWait < 0 {
+		specWait = 0
+	}
+	if specWait > remaining {
+		specWait = remaining
+	}
+	return specWait
+}
+
+// abandonInflightForFirstTokenTimeout cancels a request already on the wire
+// when the request-absolute first-token clock is gone. Without this the
+// exhausted ladder refunds the client while the provider keeps generating,
+// retains the slot, and can later settle an already-rejected request. The
+// terminal cause is OUR clock, so the last error is overridden with the
+// synthetic 504 the exhausted ladder reclassifies to a retryable 429
+// (first_chunk_timeout) — never a leaked 5xx from a prior attempt.
+func (d *dispatchState) abandonInflightForFirstTokenTimeout() {
+	if d == nil {
+		return
+	}
+	d.setLastError("timeout waiting for first response", http.StatusGatewayTimeout)
+	if d.provider == nil || d.pr == nil {
+		return
+	}
+	provider, pr := d.provider, d.pr
+	d.excludeProviders[provider.ID] = struct{}{}
+	d.s.registry.RecordWarmPoolTTFTMiss(d.model, d.deadline)
+	d.s.cancelDispatch(provider, pr)
+	d.updateRoutingOutcomeForAttempt(
+		routingAttempt(provider, pr, d.requestID, d.attempt),
+		d.errorRoutingOutcomeFor(pr, "timeout", "first_chunk_timeout", http.StatusGatewayTimeout),
+	)
+	if d.s.metrics != nil {
+		d.s.metrics.IncCounter("inference_dispatches_total", MetricLabel{"result", "timeout"})
+	}
+	d.s.ddIncr("inference.dispatches", []string{"status:timeout"})
+	d.provider = nil
+	d.pr = nil
+}

--- a/coordinator/api/first_token_clock_test.go
+++ b/coordinator/api/first_token_clock_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -212,5 +213,87 @@ func TestWriteFirstTokenTimeoutUsesOpenRouter429Contract(t *testing.T) {
 	}
 	if strings.Contains(body, "first_chunk_timeout") {
 		t.Fatalf("client body must not use first_chunk_timeout: %s", body)
+	}
+}
+
+func TestProviderAttributableStall(t *testing.T) {
+	t.Parallel()
+	if providerAttributableStall(preambleContentTimeout - time.Second) {
+		t.Fatal("a wait capped below the preamble-content window is OUR clock, not provider fault")
+	}
+	if !providerAttributableStall(preambleContentTimeout) {
+		t.Fatal("a full preamble-content window of silence is provider-attributable")
+	}
+	if !providerAttributableStall(inferenceTimeout) {
+		t.Fatal("the historical uncapped accepted budget must stay provider-attributable")
+	}
+}
+
+func TestFirstTokenWriteContext(t *testing.T) {
+	t.Parallel()
+	base := context.Background()
+
+	ctx, cancel := firstTokenWriteContext(base, time.Time{}, 9*time.Second)
+	if _, ok := ctx.Deadline(); ok {
+		t.Fatal("zero receivedAt must pass the context through unbounded")
+	}
+	cancel()
+
+	receivedAt := time.Now().Add(-8 * time.Second)
+	ctx, cancel = firstTokenWriteContext(base, receivedAt, 9*time.Second)
+	defer cancel()
+	dl, ok := ctx.Deadline()
+	if !ok {
+		t.Fatal("request clock set: write context must carry the first-token deadline")
+	}
+	if want := receivedAt.Add(9 * time.Second); !dl.Equal(want) {
+		t.Fatalf("deadline=%s want %s", dl, want)
+	}
+
+	expired, cancelExpired := firstTokenWriteContext(base, time.Now().Add(-15*time.Second), 9*time.Second)
+	defer cancelExpired()
+	select {
+	case <-expired.Done():
+	case <-time.After(time.Second):
+		t.Fatal("an already-expired clock must yield an already-done write context")
+	}
+}
+
+func TestDrainReadyFirstContentPrefersBufferedToken(t *testing.T) {
+	t.Parallel()
+	pr := &registry.PendingRequest{ChunkCh: make(chan string, 2)}
+	var held []string
+	if _, ok := drainReadyFirstContent(pr, &held); ok {
+		t.Fatal("empty channel must not produce content")
+	}
+	pr.ChunkCh <- "hello-token"
+	chunk, ok := drainReadyFirstContent(pr, &held)
+	if !ok || chunk != "hello-token" {
+		t.Fatalf("drain=%q ok=%v want buffered token", chunk, ok)
+	}
+	closed := &registry.PendingRequest{ChunkCh: make(chan string)}
+	close(closed.ChunkCh)
+	if _, ok := drainReadyFirstContent(closed, &held); ok {
+		t.Fatal("closed channel must fall through to the timeout path")
+	}
+}
+
+func TestWaitFirstChunkDeliversBufferedTokenOnExpiredClock(t *testing.T) {
+	d, pr := firstTokenWaitState(t, 15*time.Second, 9*time.Second)
+	pr.ChunkCh <- "hello-token"
+	if got := d.waitFirstChunk(); got != outcomeCommitted {
+		t.Fatalf("waitFirstChunk=%v want outcomeCommitted — an on-time buffered token must beat the expired clock", got)
+	}
+	if !d.committed || d.firstChunk != "hello-token" {
+		t.Fatalf("committed=%v firstChunk=%q", d.committed, d.firstChunk)
+	}
+}
+
+func TestAbandonInflightOverridesStaleError(t *testing.T) {
+	d, _ := firstTokenWaitState(t, 15*time.Second, 9*time.Second)
+	d.setLastError("failed to send request to provider", http.StatusBadGateway)
+	d.abandonInflightForFirstTokenTimeout()
+	if d.lastErrCode != http.StatusGatewayTimeout {
+		t.Fatalf("lastErrCode=%d want the synthetic 504 (exhausted ladder remaps to 429), not a leaked 502", d.lastErrCode)
 	}
 }


### PR DESCRIPTION
## Summary

OpenRouter's first-token clock is `~10000ms + 1ms × prompt_tokens` from request send. A real completion token satisfies it; HTTP 200 and `: keepalive` do not. We armed a 9s+1ms timer after parse/reserve/route, then disarmed it on Swift's `inference_accepted` (ack-before-load) and waited up to `inferenceTimeout` (600s). They hung up and charted 504; we recorded `client_gone`.

This keeps the first-token deadline request-absolute from `ReceivedAt`. Accept and preamble liveness no longer reset that clock. Exhausted leftover surfaces as 429 `first_chunk_timeout` instead of sitting until OpenRouter 504s.

## Linked issue

No issue number. Follow-up to the OpenRouter 504 investigation (prod last-24h: ~11k `client_gone` rows fit `10000ms + tokens` ±250ms; our own `first_chunk_timeout` 504s were the smaller pile).

## Test plan

- [x] `gofmt -l` on the three touched files
- [x] `go test ./coordinator/api -count=1 -timeout 180s -run 'TestFirstToken|TestWaitAcceptedKeeps|TestWaitFirstChunkAccept|TestClassifyExhausted|TestDispatchTerminal|TestPrimaryFailureThenBackup|TestDispatch_MidLadderTTFT|TestTTFTTerminal|TestTypedProvider504|TestWaitFirstChunkDeferred'`
- [ ] CI `coordinator-test`

## Components touched

- [x] coordinator (Go)
- [ ] provider (Rust, legacy)
- [ ] provider-swift (Swift CLI)
- [ ] console-ui (Next.js)
- [ ] enclave (Swift)
- [ ] infra / CI / release
- [ ] docs

## Protocol / interface changes

- [x] No protocol/interface changes
- [ ] Yes — described above and matching side updated

## Notes for reviewers

- `ReceivedAt` unset keeps the historical relative timers so existing unit tests stay valid.
- Chat `waitFirstChunk` / race / no-backup waits use leftover. Speculative cannot fire after the absolute deadline.
- `AcceptedCh` still returns `outcomeAccepted`, but `waitAccepted` is capped by leftover (and `preambleContentTimeout` if that is smaller).
- After dispatch, leftover 0 synthesizes a first-chunk timeout and goes to the exhausted ladder. Failover also stops once leftover is gone.
- Generic `/v1/completions` and Anthropic use the same leftover clock after accept; those timeouts now go through `classifyExhaustedStatus` (client sees 429).
- Not in this PR: leftover-aware pre-queue shed (429 instead of queue-before-shed when leftover cannot cover predicted TTFT). Routing itself is not the 504 (immediate dispatch p50 8ms).

## Behavior

```mermaid
flowchart LR
  subgraph Before
    A1[OpenRouter request] --> B1[parse / reserve / route]
    B1 --> C1[arm 9s+1ms from wait start]
    C1 --> D1[inference_accepted]
    D1 --> E1[disarm timer, wait up to 600s]
    E1 --> F1[OpenRouter 504 at 10s+1ms/token]
    F1 --> G1[we record client_gone]
  end
  subgraph After
    A2[OpenRouter request] --> B2[stamp ReceivedAt]
    B2 --> C2[leftover = deadline - since ReceivedAt]
    C2 --> D2[inference_accepted]
    D2 --> E2[keep leftover clock]
    E2 --> F2{first token in leftover?}
    F2 -->|yes| G2[200 stream]
    F2 -->|no| H2[429 first_chunk_timeout]
  end
```

## Code

```mermaid
flowchart LR
  subgraph Before
    A1[waitFirstChunk] --> B1[NewTimer deadline]
    B1 --> C1[AcceptedCh]
    C1 --> D1[outcomeAccepted]
    D1 --> E1["waitAccepted(inferenceTimeout=600s)"]
    E1 --> F1[client_gone / 504]
  end
  subgraph After
    A2[firstTokenRemainingSince ReceivedAt] --> B2[waitFirstChunk leftover]
    B2 --> C2[AcceptedCh]
    C2 --> D2[outcomeAccepted]
    D2 --> E2["waitAccepted min leftover, preambleContentTimeout"]
    E2 --> F2[classifyExhaustedStatus]
    F2 --> G2[429 first_chunk_timeout]
  end
```

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/631"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789411837&installation_model_id=21733&pr_number=631&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F631&signature=d2586774c481c2cce022f18fe587dcc0619c7c3abbf22209cca8ca131761ceb5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->