### PR TITLE
fix(api): make Qwen reasoning opt-in for service traffic

### DIFF
--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -29,6 +29,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/eigeninference/d-inference/coordinator/auth"
 	"github.com/eigeninference/d-inference/coordinator/internal/e2e"
 	"github.com/eigeninference/d-inference/coordinator/payments"
 	"github.com/eigeninference/d-inference/coordinator/promptcontract"
@@ -1420,6 +1421,7 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	originalRawBody := prelude.originalRawBody
 	parsed := prelude.parsed
 	model := prelude.model
+	_, reasoningProvided := parsed["reasoning"]
 
 	// Accept either chat completions format (messages) or Responses API format
 	// (input). Responses requests are lowered before the provider body is sealed.
@@ -1550,6 +1552,16 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	model, rawBody = buildModel, resolvedBody
+	user := auth.UserFromContext(r.Context())
+	serviceChatConsumer := r.URL.Path == "/v1/chat/completions" &&
+		user != nil && user.Role == store.RoleService
+	rawBody, _, err = applyResolvedModelReasoningPolicy(
+		parsed, rawBody, model, serviceChatConsumer, reasoningProvided)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, errorResponse(
+			"server_error", "failed to prepare inference request"))
+		return
+	}
 
 	// Shared media/tools fail-fast. Chat completions additionally rejects media
 	// sent via the Responses API surface (input-without-messages), because the
@@ -1646,6 +1658,10 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 		}
 		candidateParsed["model"] = candidateModel
 		candidateBody, marshalErr := marshalForwardBody(candidateParsed)
+		if marshalErr == nil {
+			candidateBody, _, marshalErr = applyResolvedModelReasoningPolicy(
+				candidateParsed, candidateBody, candidateModel, serviceChatConsumer, reasoningProvided)
+		}
 		if marshalErr == nil && isResponsesAPI {
 			candidateBody, marshalErr = promptcontract.LowerProviderBody(
 				promptcontract.EndpointResponses, candidateBody)
@@ -1852,6 +1868,8 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	// pre-extraction behavior.
 	onModelFallback := func(newModel string) bool {
 		body, _ := marshalForwardBody(parsed)
+		body, _, _ = applyResolvedModelReasoningPolicy(
+			parsed, body, newModel, serviceChatConsumer, reasoningProvided)
 		return refreshForwardBody(body, newModel)
 	}
 	var preflightHandled bool

--- a/coordinator/api/reasoning_request_policy.go
+++ b/coordinator/api/reasoning_request_policy.go
@@ -1,0 +1,45 @@
+package api
+
+const serviceReasoningOptInModel = "qwen3.6-35b-a3b-vl-mtp-mxfp8"
+
+// applyResolvedModelReasoningPolicy makes reasoning opt-in for service traffic
+// to the Qwen build. Gemma defaults thinking off, while the production Qwen
+// template defaults it on when reasoning is absent.
+func applyResolvedModelReasoningPolicy(
+	parsed map[string]any,
+	rawBody []byte,
+	resolvedModel string,
+	serviceConsumer bool,
+	reasoningProvided bool,
+) ([]byte, bool, error) {
+	if reasoningProvided {
+		return rawBody, false, nil
+	}
+
+	_, hasReasoning := parsed["reasoning"]
+	shouldDisable := serviceConsumer && resolvedModel == serviceReasoningOptInModel
+	if hasReasoning == shouldDisable {
+		return rawBody, false, nil
+	}
+
+	updated := make(map[string]any, len(parsed)+1)
+	for key, value := range parsed {
+		updated[key] = value
+	}
+	if shouldDisable {
+		updated["reasoning"] = map[string]any{"enabled": false}
+	} else {
+		delete(updated, "reasoning")
+	}
+
+	body, err := marshalForwardBody(updated)
+	if err != nil {
+		return rawBody, false, err
+	}
+	if shouldDisable {
+		parsed["reasoning"] = updated["reasoning"]
+	} else {
+		delete(parsed, "reasoning")
+	}
+	return body, true, nil
+}

--- a/coordinator/api/reasoning_request_policy_test.go
+++ b/coordinator/api/reasoning_request_policy_test.go
@@ -1,0 +1,360 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/internal/e2e"
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+	"github.com/eigeninference/d-inference/coordinator/registry"
+	"github.com/eigeninference/d-inference/coordinator/store"
+	"nhooyr.io/websocket"
+)
+
+func TestServiceReasoningPolicyProviderBody(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	st := store.NewMemory(store.Config{AdminKey: "test-key"})
+	reg := registry.New(logger)
+	srv := NewServer(reg, st, ServerConfig{}, logger)
+	srv.challengeInterval = 200 * time.Millisecond
+
+	const serviceAccount = "service-reasoning-test"
+	if err := st.CreateUser(&store.User{
+		AccountID:   serviceAccount,
+		PrivyUserID: "did:privy:" + serviceAccount,
+		Role:        store.RoleService,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	serviceKey, _, err := st.CreateAPIKey(serviceAccount, store.APIKeyCreate{Name: "reasoning-test"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := st.Credit(serviceAccount, 100_000_000, store.LedgerDeposit, "reasoning-test"); err != nil {
+		t.Fatal(err)
+	}
+
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	publicKey := testPublicKeyB64()
+	value, ok := testProviderKeys.Load(publicKey)
+	if !ok {
+		t.Fatalf("missing cached provider keypair for %q", publicKey)
+	}
+	keypair := value.(testProviderKeyPair)
+	const otherModel = "reasoning-policy-other-model"
+	const qwenAlias = "reasoning-policy-qwen-alias"
+	conn := connectProvider(t, ctx, ts.URL, []protocol.ModelInfo{
+		{ID: serviceReasoningOptInModel},
+		{ID: otherModel},
+	}, publicKey)
+	defer conn.Close(websocket.StatusNormalClosure, "")
+	reg.SetModelAliases(map[string]registry.AliasTarget{
+		qwenAlias: {Desired: serviceReasoningOptInModel},
+	})
+	for _, id := range reg.ProviderIDs() {
+		reg.SetTrustLevel(id, registry.TrustHardware)
+		reg.RecordChallengeSuccess(id)
+	}
+
+	type providerResult struct {
+		body []byte
+		err  error
+	}
+	results := make(chan providerResult, 7)
+	go func() {
+		for {
+			_, data, readErr := conn.Read(ctx)
+			if readErr != nil {
+				results <- providerResult{err: readErr}
+				return
+			}
+			var envelope struct {
+				Type string `json:"type"`
+			}
+			if unmarshalErr := json.Unmarshal(data, &envelope); unmarshalErr != nil {
+				results <- providerResult{err: unmarshalErr}
+				return
+			}
+			if envelope.Type == protocol.TypeAttestationChallenge {
+				if writeErr := conn.Write(ctx, websocket.MessageText, makeValidChallengeResponse(data, publicKey)); writeErr != nil {
+					results <- providerResult{err: writeErr}
+					return
+				}
+				continue
+			}
+			if envelope.Type != protocol.TypeInferenceRequest {
+				continue
+			}
+
+			var request protocol.InferenceRequestMessage
+			if unmarshalErr := json.Unmarshal(data, &request); unmarshalErr != nil {
+				results <- providerResult{err: unmarshalErr}
+				return
+			}
+			if request.EncryptedBody == nil {
+				results <- providerResult{err: errMissingEncryptedProviderBody}
+				return
+			}
+			decrypted, decryptErr := e2e.DecryptWithPrivateKey(&e2e.EncryptedPayload{
+				EphemeralPublicKey: request.EncryptedBody.EphemeralPublicKey,
+				Ciphertext:         request.EncryptedBody.Ciphertext,
+			}, keypair.private)
+			results <- providerResult{body: decrypted, err: decryptErr}
+			if decryptErr != nil {
+				return
+			}
+
+			writeEncryptedTestChunk(t, ctx, conn, request, publicKey,
+				`data: {"id":"chatcmpl-reasoning-policy","choices":[{"delta":{"content":"ok"},"finish_reason":"stop"}]}`+"\n\n")
+			complete, _ := json.Marshal(protocol.InferenceCompleteMessage{
+				Type:      protocol.TypeInferenceComplete,
+				RequestID: request.RequestID,
+				Usage:     protocol.UsageInfo{PromptTokens: 5, CompletionTokens: 1},
+			})
+			if writeErr := conn.Write(ctx, websocket.MessageText, complete); writeErr != nil {
+				return
+			}
+		}
+	}()
+
+	tests := []struct {
+		name          string
+		key           string
+		path          string
+		model         string
+		reasoning     string
+		responsesBody bool
+		wantReasoning string
+		wantModel     string
+	}{
+		{name: "service Qwen omission disables reasoning", key: serviceKey, model: serviceReasoningOptInModel, wantReasoning: `{"enabled":false}`, wantModel: serviceReasoningOptInModel},
+		{name: "service Qwen explicit true is preserved", key: serviceKey, model: serviceReasoningOptInModel, reasoning: `,"reasoning":{"enabled":true}`, wantReasoning: `{"enabled":true}`, wantModel: serviceReasoningOptInModel},
+		{name: "service Qwen explicit false is preserved", key: serviceKey, model: serviceReasoningOptInModel, reasoning: `,"reasoning":{"enabled":false}`, wantReasoning: `{"enabled":false}`, wantModel: serviceReasoningOptInModel},
+		{name: "non-service Qwen omission is unchanged", key: "test-key", model: serviceReasoningOptInModel, wantModel: serviceReasoningOptInModel},
+		{name: "service other model omission is unchanged", key: serviceKey, model: otherModel, wantModel: otherModel},
+		{name: "service alias resolved to Qwen disables reasoning", key: serviceKey, model: qwenAlias, wantReasoning: `{"enabled":false}`, wantModel: serviceReasoningOptInModel},
+		{name: "service Responses route remains unchanged", key: serviceKey, path: "/v1/responses", model: serviceReasoningOptInModel, responsesBody: true, wantModel: serviceReasoningOptInModel},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			path := test.path
+			if path == "" {
+				path = "/v1/chat/completions"
+			}
+			requestBody := fmt.Sprintf(
+				`{"model":%q,"messages":[{"role":"user","content":"hello"}],"stream":true,"max_tokens":32%s}`,
+				test.model, test.reasoning)
+			if test.responsesBody {
+				requestBody = fmt.Sprintf(
+					`{"model":%q,"input":"hello","stream":true,"max_output_tokens":32}`,
+					test.model)
+			}
+			request, requestErr := http.NewRequestWithContext(
+				ctx, http.MethodPost, ts.URL+path, strings.NewReader(requestBody))
+			if requestErr != nil {
+				t.Fatal(requestErr)
+			}
+			request.Header.Set("Authorization", "Bearer "+test.key)
+			response, requestErr := http.DefaultClient.Do(request)
+			if requestErr != nil {
+				t.Fatal(requestErr)
+			}
+			responseBody, readErr := io.ReadAll(response.Body)
+			response.Body.Close()
+			if readErr != nil {
+				t.Fatal(readErr)
+			}
+			if response.StatusCode != http.StatusOK {
+				t.Fatalf("status = %d, want 200: %s", response.StatusCode, responseBody)
+			}
+
+			var result providerResult
+			select {
+			case result = <-results:
+			case <-time.After(5 * time.Second):
+				t.Fatal("timed out waiting for provider body")
+			}
+			if result.err != nil {
+				t.Fatalf("decrypt provider body: %v", result.err)
+			}
+			var fields map[string]json.RawMessage
+			if unmarshalErr := json.Unmarshal(result.body, &fields); unmarshalErr != nil {
+				t.Fatalf("decode provider body: %v\n%s", unmarshalErr, result.body)
+			}
+			var gotModel string
+			if unmarshalErr := json.Unmarshal(fields["model"], &gotModel); unmarshalErr != nil {
+				t.Fatalf("decode provider model: %v", unmarshalErr)
+			}
+			if gotModel != test.wantModel {
+				t.Errorf("provider model = %q, want %q", gotModel, test.wantModel)
+			}
+			gotReasoning, exists := fields["reasoning"]
+			if test.wantReasoning == "" {
+				if exists {
+					t.Errorf("provider body unexpectedly contains reasoning: %s", gotReasoning)
+				}
+			} else if !exists || string(gotReasoning) != test.wantReasoning {
+				t.Errorf("provider reasoning = %s (exists=%v), want %s", gotReasoning, exists, test.wantReasoning)
+			}
+		})
+	}
+}
+
+func TestServiceReasoningPolicyTracksAliasCapacityFallback(t *testing.T) {
+	tests := []struct {
+		name          string
+		desiredModel  string
+		previousModel string
+		wantReasoning string
+	}{
+		{
+			name:          "fallback away from Qwen removes injected default",
+			desiredModel:  serviceReasoningOptInModel,
+			previousModel: "reasoning-fallback-other",
+		},
+		{
+			name:          "fallback toward Qwen injects default",
+			desiredModel:  "reasoning-fallback-other",
+			previousModel: serviceReasoningOptInModel,
+			wantReasoning: `{"enabled":false}`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+			st := store.NewMemory(store.Config{AdminKey: "test-key"})
+			reg := registry.New(logger)
+			srv := NewServer(reg, st, ServerConfig{}, logger)
+			srv.challengeInterval = 30 * time.Second
+
+			const serviceAccount = "service-reasoning-fallback"
+			if err := st.CreateUser(&store.User{
+				AccountID:   serviceAccount,
+				PrivyUserID: "did:privy:" + serviceAccount,
+				Role:        store.RoleService,
+			}); err != nil {
+				t.Fatal(err)
+			}
+			serviceKey, _, err := st.CreateAPIKey(serviceAccount, store.APIKeyCreate{Name: "reasoning-fallback"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := st.Credit(serviceAccount, 100_000_000, store.LedgerDeposit, "reasoning-fallback"); err != nil {
+				t.Fatal(err)
+			}
+
+			ts := httptest.NewServer(srv.Handler())
+			t.Cleanup(ts.Close)
+			ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+			defer cancel()
+
+			registerBuildsProvider(srv, "reasoning-fallback-desired", test.desiredModel)
+			desired := reg.GetProvider("reasoning-fallback-desired")
+			desired.Mu().Lock()
+			desired.BackendCapacity.Slots[0].ActiveTokenBudgetUsed = 1_000
+			desired.BackendCapacity.Slots[0].ActiveTokenBudgetMax = 1_000
+			desired.Mu().Unlock()
+
+			previous := startFailoverProvider(t, ctx, ts, reg, failoverProviderConfig{
+				Name:      "reasoning-fallback-previous",
+				Version:   "0.6.4",
+				DecodeTPS: 100,
+				Models:    []failoverModelSpec{{ID: test.previousModel}},
+				Script:    fullServeScript(test.previousModel),
+			})
+			const alias = "reasoning-policy-fallback-alias"
+			reg.SetModelAliases(map[string]registry.AliasTarget{
+				alias: {Desired: test.desiredModel, Previous: test.previousModel},
+			})
+
+			requestBody := fmt.Sprintf(
+				`{"model":%q,"messages":[{"role":"user","content":"hello"}],"stream":true,"max_tokens":32}`,
+				alias)
+			status, responseBody, err := postChat(ctx, ts.URL, serviceKey, requestBody)
+			if err != nil {
+				t.Fatalf("chat request: %v", err)
+			}
+			if status != http.StatusOK {
+				t.Fatalf("status = %d, want 200: %s", status, responseBody)
+			}
+
+			var providerBody []byte
+			select {
+			case providerBody = <-previous.bodies:
+			case <-time.After(5 * time.Second):
+				t.Fatal("previous provider never received fallback dispatch")
+			}
+			if providerBody == nil {
+				t.Fatal("previous provider could not decrypt fallback body")
+			}
+			var fields map[string]json.RawMessage
+			if err := json.Unmarshal(providerBody, &fields); err != nil {
+				t.Fatalf("decode provider body: %v\n%s", err, providerBody)
+			}
+			var gotModel string
+			if err := json.Unmarshal(fields["model"], &gotModel); err != nil {
+				t.Fatal(err)
+			}
+			if gotModel != test.previousModel {
+				t.Errorf("provider model = %q, want fallback model %q", gotModel, test.previousModel)
+			}
+			gotReasoning, exists := fields["reasoning"]
+			if test.wantReasoning == "" {
+				if exists {
+					t.Errorf("fallback provider body retained reasoning: %s", gotReasoning)
+				}
+			} else if !exists || string(gotReasoning) != test.wantReasoning {
+				t.Errorf("fallback provider reasoning = %s (exists=%v), want %s", gotReasoning, exists, test.wantReasoning)
+			}
+		})
+	}
+}
+
+func TestApplyResolvedModelReasoningPolicyPreservesExplicitValuesAndUntouchedBytes(t *testing.T) {
+	tests := []struct {
+		name     string
+		body     string
+		model    string
+		service  bool
+		provided bool
+	}{
+		{name: "explicit null", body: `{"model":"qwen","reasoning":null}`, model: serviceReasoningOptInModel, service: true, provided: true},
+		{name: "explicit scalar", body: `{"model":"qwen","reasoning":"malformed"}`, model: serviceReasoningOptInModel, service: true, provided: true},
+		{name: "non-service target", body: `{ "model" : "qwen" }`, model: serviceReasoningOptInModel},
+		{name: "service other model", body: `{ "model" : "other" }`, model: "other", service: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			parsed, err := decodeInferenceJSONObject([]byte(test.body))
+			if err != nil {
+				t.Fatal(err)
+			}
+			got, changed, err := applyResolvedModelReasoningPolicy(
+				parsed, []byte(test.body), test.model, test.service, test.provided)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if changed {
+				t.Fatal("policy reported a mutation")
+			}
+			if string(got) != test.body {
+				t.Fatalf("body changed: got %q, want original %q", got, test.body)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Service-authenticated chat callers commonly omit top-level `reasoning`. For the resolved `qwen3.6-35b-a3b-vl-mtp-mxfp8` build, the Qwen chat template interprets that omission as reasoning enabled, opens `<think>`, and can stream reasoning fields while `delta.content` remains empty. Upstreams that define first-visible output as content then hit their first-visible timeout.

This change makes reasoning opt-in for that service-traffic case. `handleChatCompletions` now applies `applyResolvedModelReasoningPolicy` after alias resolution and whenever routing evaluates or switches the final concrete build, inserting `{"enabled":false}` only when the caller omitted `reasoning`.

## Exact scope

The policy applies only when all four conditions are true:

- the authenticated context user has `RoleService`;
- the endpoint is `POST /v1/chat/completions`;
- the resolved concrete model is exactly `qwen3.6-35b-a3b-vl-mtp-mxfp8`; and
- top-level `reasoning` was absent from the original request.

There is no provider code change, model manifest/registry change, chat-template change, or model-artifact change. The external API schema is unchanged; this is coordinator-side provider-request normalization.

## Preservation and alias fallback rules

- Explicit top-level `reasoning` always wins. `true`, `false`, `null`, and other explicitly supplied values bypass the policy unchanged.
- Non-service callers, other endpoints (including `/v1/responses`), and other resolved models retain existing behavior.
- When the policy has nothing to change, it returns the original raw bytes rather than remarshal the request.
- Candidate and alias-fallback bodies are derived from the final concrete model. A fallback **away from Qwen** removes only the coordinator-injected default; a fallback **toward Qwen** injects `{"enabled":false}` when the original request omitted reasoning. The model and reasoning fields sent on the encrypted provider wire therefore stay aligned with the actual selected build.

## Before

```mermaid
flowchart TD
  subgraph CodeBefore["Code control flow — before"]
    A["RoleService POST /v1/chat/completions<br/>top-level reasoning absent"] --> B["handleChatCompletions"]
    B --> C["resolveRequestedModel<br/>concrete qwen3.6-35b-a3b-vl-mtp-mxfp8"]
    C --> D["No resolved-model reasoning policy"]
    D --> E["Provider body remains unchanged"]
    E --> F["Encrypted provider request"]
  end

  subgraph BehaviorBefore["User-visible behavior — before"]
    F --> G["Qwen template defaults open &lt;think&gt;"]
    G --> H["Stream carries reasoning fields<br/>while delta.content is empty"]
    H --> I["Upstream waits for first visible content"]
    I --> J["Upstream first-visible timeout"]
  end
```

## After

```mermaid
flowchart TD
  subgraph CodeAfter["Code control flow — after"]
    A["POST /v1/chat/completions"] --> B["handleChatCompletions reads authenticated context role<br/>and resolves the concrete model"]
    B --> C["applyResolvedModelReasoningPolicy"]
    C --> D{"Was top-level reasoning explicitly supplied?"}
    D -- Yes --> E["Explicit-reasoning bypass<br/>preserve caller value unchanged"]
    D -- No --> F{"RoleService and final model is<br/>qwen3.6-35b-a3b-vl-mtp-mxfp8?"}
    F -- Yes --> G["Inject reasoning.enabled=false"]
    F -- No --> H["Leave unaffected request unchanged"]
    E --> I["providerBodyForModel / onModelFallback<br/>track candidate or fallback final concrete model"]
    G --> I
    H --> I
    I --> J["Final Qwen + omission: inject false<br/>Final non-Qwen + omission: remove only policy injection<br/>Explicit reasoning: bypass remains unchanged"]
    J --> K["Encrypted provider request"]
  end

  subgraph BehaviorAfter["User-visible behavior — after"]
    K --> L["Qwen reasoning is disabled by default<br/>for the scoped service request"]
    L --> M["Qwen emits delta.content"]
    M --> N["Upstream receives first visible content"]
  end
```

## Verification

- [x] `go test ./coordinator/api -run '^(TestServiceReasoningPolicyProviderBody|TestServiceReasoningPolicyTracksAliasCapacityFallback|TestApplyResolvedModelReasoningPolicyPreservesExplicitValuesAndUntouchedBytes)$' -count=1 -v`
  - **PASS** — `ok github.com/eigeninference/d-inference/coordinator/api 1.270s`
  - The decrypted provider-wire assertions include fallback away from Qwen (reasoning removed) and fallback toward Qwen (`enabled=false` injected).
- [x] `go test ./coordinator/api -count=1`
  - **PASS** — `ok github.com/eigeninference/d-inference/coordinator/api 116.688s`

## Components touched

- [x] coordinator (Go)
- [ ] provider-swift (Swift CLI)
- [ ] console-ui (Next.js)
- [ ] infra / CI / release
- [ ] docs

## Protocol / interface changes

- [x] No protocol/schema or external API interface changes; only the scoped coordinator normalization described above.

## Rollout

Production is unchanged until this PR is separately approved, merged, and deployed through the production process. No production deploy has occurred as part of this change.
