### PR TITLE
fix(api): honor reasoning_effort intent for service Qwen traffic

### DIFF
--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -1422,6 +1422,7 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	parsed := prelude.parsed
 	model := prelude.model
 	_, reasoningProvided := parsed["reasoning"]
+	reasoningEffort := effortString(parsed)
 
 	// Accept either chat completions format (messages) or Responses API format
 	// (input). Responses requests are lowered before the provider body is sealed.
@@ -1555,8 +1556,11 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	user := auth.UserFromContext(r.Context())
 	serviceChatConsumer := r.URL.Path == "/v1/chat/completions" &&
 		user != nil && user.Role == store.RoleService
+	if serviceChatConsumer && model == serviceReasoningOptInModel {
+		logServiceReasoningShape(s.logger, parsed, model)
+	}
 	rawBody, _, err = applyResolvedModelReasoningPolicy(
-		parsed, rawBody, model, serviceChatConsumer, reasoningProvided)
+		parsed, rawBody, model, serviceChatConsumer, reasoningProvided, reasoningEffort)
 	if err != nil {
 		writeJSON(w, http.StatusInternalServerError, errorResponse(
 			"server_error", "failed to prepare inference request"))
@@ -1660,7 +1664,7 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 		candidateBody, marshalErr := marshalForwardBody(candidateParsed)
 		if marshalErr == nil {
 			candidateBody, _, marshalErr = applyResolvedModelReasoningPolicy(
-				candidateParsed, candidateBody, candidateModel, serviceChatConsumer, reasoningProvided)
+				candidateParsed, candidateBody, candidateModel, serviceChatConsumer, reasoningProvided, reasoningEffort)
 		}
 		if marshalErr == nil && isResponsesAPI {
 			candidateBody, marshalErr = promptcontract.LowerProviderBody(
@@ -1869,7 +1873,7 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	onModelFallback := func(newModel string) bool {
 		body, _ := marshalForwardBody(parsed)
 		body, _, _ = applyResolvedModelReasoningPolicy(
-			parsed, body, newModel, serviceChatConsumer, reasoningProvided)
+			parsed, body, newModel, serviceChatConsumer, reasoningProvided, reasoningEffort)
 		return refreshForwardBody(body, newModel)
 	}
 	var preflightHandled bool

--- a/coordinator/api/reasoning_request_policy.go
+++ b/coordinator/api/reasoning_request_policy.go
@@ -1,24 +1,35 @@
 package api
 
+import (
+	"log/slog"
+	"strings"
+)
+
 const serviceReasoningOptInModel = "qwen3.6-35b-a3b-vl-mtp-mxfp8"
 
 // applyResolvedModelReasoningPolicy makes reasoning opt-in for service traffic
 // to the Qwen build. Gemma defaults thinking off, while the production Qwen
 // template defaults it on when reasoning is absent.
+//
+// OpenRouter does not forward the OpenRouter-style `reasoning` object to us,
+// but it does forward the OpenAI-style top-level `reasoning_effort` string, so
+// when `reasoning` is absent that string carries the caller's intent: absent
+// or "none" keeps thinking off, any other non-empty value turns it on.
 func applyResolvedModelReasoningPolicy(
 	parsed map[string]any,
 	rawBody []byte,
 	resolvedModel string,
 	serviceConsumer bool,
 	reasoningProvided bool,
+	reasoningEffort string,
 ) ([]byte, bool, error) {
 	if reasoningProvided {
 		return rawBody, false, nil
 	}
 
 	_, hasReasoning := parsed["reasoning"]
-	shouldDisable := serviceConsumer && resolvedModel == serviceReasoningOptInModel
-	if hasReasoning == shouldDisable {
+	shouldInject := serviceConsumer && resolvedModel == serviceReasoningOptInModel
+	if hasReasoning == shouldInject {
 		return rawBody, false, nil
 	}
 
@@ -26,8 +37,10 @@ func applyResolvedModelReasoningPolicy(
 	for key, value := range parsed {
 		updated[key] = value
 	}
-	if shouldDisable {
-		updated["reasoning"] = map[string]any{"enabled": false}
+	if shouldInject {
+		updated["reasoning"] = map[string]any{
+			"enabled": reasoningEffortRequestsThinking(reasoningEffort),
+		}
 	} else {
 		delete(updated, "reasoning")
 	}
@@ -36,10 +49,71 @@ func applyResolvedModelReasoningPolicy(
 	if err != nil {
 		return rawBody, false, err
 	}
-	if shouldDisable {
+	if shouldInject {
 		parsed["reasoning"] = updated["reasoning"]
 	} else {
 		delete(parsed, "reasoning")
 	}
 	return body, true, nil
+}
+
+// reasoningEffortRequestsThinking maps a top-level reasoning_effort string to
+// a thinking intent: absent/blank/"none" means off, anything else means on.
+func reasoningEffortRequestsThinking(effort string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(effort))
+	return normalized != "" && normalized != "none"
+}
+
+// logServiceReasoningShape emits one privacy-safe observability line per
+// service chat request that resolved to the reasoning-opt-in model, BEFORE the
+// policy mutates parsed, so we can see which reasoning intent shape OpenRouter
+// actually forwards. Only presence bits, booleans, and closed-set enums are
+// logged — never request content.
+func logServiceReasoningShape(logger *slog.Logger, parsed map[string]any, model string) {
+	reasoning, reasoningPresent := parsed["reasoning"]
+
+	var reasoningEnabled any = "absent"
+	if reasoningPresent {
+		reasoningEnabled = "non_bool"
+		if object, ok := reasoning.(map[string]any); ok {
+			if enabled, ok := object["enabled"].(bool); ok {
+				reasoningEnabled = enabled
+			}
+		}
+	}
+
+	effort := "absent"
+	if raw, present := parsed["reasoning_effort"]; present {
+		effort = "other"
+		if value, ok := raw.(string); ok {
+			switch normalized := strings.ToLower(strings.TrimSpace(value)); normalized {
+			case "none", "minimal", "low", "medium", "high", "xhigh", "max":
+				effort = normalized
+			}
+		}
+	}
+
+	injected := "none"
+	if !reasoningPresent {
+		if reasoningEffortRequestsThinking(effortString(parsed)) {
+			injected = "true"
+		} else {
+			injected = "false"
+		}
+	}
+
+	logger.Info("service reasoning shape",
+		"model", model,
+		"reasoning_present", reasoningPresent,
+		"reasoning_enabled", reasoningEnabled,
+		"reasoning_effort", effort,
+		"injected", injected,
+	)
+}
+
+// effortString extracts the top-level reasoning_effort as a string; non-string
+// values read as absent, matching the injection policy's view.
+func effortString(parsed map[string]any) string {
+	effort, _ := parsed["reasoning_effort"].(string)
+	return effort
 }

--- a/coordinator/api/reasoning_request_policy_test.go
+++ b/coordinator/api/reasoning_request_policy_test.go
@@ -73,7 +73,7 @@ func TestServiceReasoningPolicyProviderBody(t *testing.T) {
 		body []byte
 		err  error
 	}
-	results := make(chan providerResult, 7)
+	results := make(chan providerResult, 11)
 	go func() {
 		for {
 			_, data, readErr := conn.Read(ctx)
@@ -147,6 +147,10 @@ func TestServiceReasoningPolicyProviderBody(t *testing.T) {
 		{name: "service other model omission is unchanged", key: serviceKey, model: otherModel, wantModel: otherModel},
 		{name: "service alias resolved to Qwen disables reasoning", key: serviceKey, model: qwenAlias, wantReasoning: `{"enabled":false}`, wantModel: serviceReasoningOptInModel},
 		{name: "service Responses route remains unchanged", key: serviceKey, path: "/v1/responses", model: serviceReasoningOptInModel, responsesBody: true, wantModel: serviceReasoningOptInModel},
+		{name: "service Qwen effort high enables reasoning", key: serviceKey, model: serviceReasoningOptInModel, reasoning: `,"reasoning_effort":"high"`, wantReasoning: `{"enabled":true}`, wantModel: serviceReasoningOptInModel},
+		{name: "service Qwen effort none keeps reasoning disabled", key: serviceKey, model: serviceReasoningOptInModel, reasoning: `,"reasoning_effort":"none"`, wantReasoning: `{"enabled":false}`, wantModel: serviceReasoningOptInModel},
+		{name: "service Qwen explicit reasoning object wins over effort", key: serviceKey, model: serviceReasoningOptInModel, reasoning: `,"reasoning_effort":"high","reasoning":{"enabled":false}`, wantReasoning: `{"enabled":false}`, wantModel: serviceReasoningOptInModel},
+		{name: "non-service Qwen effort high is unchanged", key: "test-key", model: serviceReasoningOptInModel, reasoning: `,"reasoning_effort":"high"`, wantModel: serviceReasoningOptInModel},
 	}
 
 	for _, test := range tests {
@@ -332,10 +336,13 @@ func TestApplyResolvedModelReasoningPolicyPreservesExplicitValuesAndUntouchedByt
 		model    string
 		service  bool
 		provided bool
+		effort   string
 	}{
 		{name: "explicit null", body: `{"model":"qwen","reasoning":null}`, model: serviceReasoningOptInModel, service: true, provided: true},
 		{name: "explicit scalar", body: `{"model":"qwen","reasoning":"malformed"}`, model: serviceReasoningOptInModel, service: true, provided: true},
+		{name: "explicit object beats effort", body: `{"model":"qwen","reasoning":{"enabled":false},"reasoning_effort":"high"}`, model: serviceReasoningOptInModel, service: true, provided: true, effort: "high"},
 		{name: "non-service target", body: `{ "model" : "qwen" }`, model: serviceReasoningOptInModel},
+		{name: "non-service effort high", body: `{ "model" : "qwen" , "reasoning_effort" : "high" }`, model: serviceReasoningOptInModel, effort: "high"},
 		{name: "service other model", body: `{ "model" : "other" }`, model: "other", service: true},
 	}
 	for _, test := range tests {
@@ -345,7 +352,7 @@ func TestApplyResolvedModelReasoningPolicyPreservesExplicitValuesAndUntouchedByt
 				t.Fatal(err)
 			}
 			got, changed, err := applyResolvedModelReasoningPolicy(
-				parsed, []byte(test.body), test.model, test.service, test.provided)
+				parsed, []byte(test.body), test.model, test.service, test.provided, test.effort)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -354,6 +361,105 @@ func TestApplyResolvedModelReasoningPolicyPreservesExplicitValuesAndUntouchedByt
 			}
 			if string(got) != test.body {
 				t.Fatalf("body changed: got %q, want original %q", got, test.body)
+			}
+		})
+	}
+}
+
+func TestApplyResolvedModelReasoningPolicyEffortIntent(t *testing.T) {
+	tests := []struct {
+		effort      string
+		wantEnabled bool
+	}{
+		{effort: "", wantEnabled: false},
+		{effort: "none", wantEnabled: false},
+		{effort: " NONE ", wantEnabled: false},
+		{effort: "high", wantEnabled: true},
+		{effort: " Medium ", wantEnabled: true},
+		{effort: "unrecognized", wantEnabled: true},
+	}
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("effort=%q", test.effort), func(t *testing.T) {
+			parsed := map[string]any{"model": "qwen"}
+			body, changed, err := applyResolvedModelReasoningPolicy(
+				parsed, []byte(`{"model":"qwen"}`), serviceReasoningOptInModel, true, false, test.effort)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !changed {
+				t.Fatal("policy did not inject reasoning")
+			}
+			var fields struct {
+				Reasoning struct {
+					Enabled *bool `json:"enabled"`
+				} `json:"reasoning"`
+			}
+			if err := json.Unmarshal(body, &fields); err != nil {
+				t.Fatalf("decode injected body: %v\n%s", err, body)
+			}
+			if fields.Reasoning.Enabled == nil || *fields.Reasoning.Enabled != test.wantEnabled {
+				t.Fatalf("injected reasoning = %s, want enabled=%v", body, test.wantEnabled)
+			}
+		})
+	}
+}
+
+func TestLogServiceReasoningShapeClosedSet(t *testing.T) {
+	tests := []struct {
+		name   string
+		parsed map[string]any
+		want   []string
+	}{
+		{
+			name:   "absent shapes inject false",
+			parsed: map[string]any{"model": "qwen"},
+			want:   []string{"reasoning_present=false", "reasoning_enabled=absent", "reasoning_effort=absent", "injected=false"},
+		},
+		{
+			name:   "effort high injects true",
+			parsed: map[string]any{"model": "qwen", "reasoning_effort": " High "},
+			want:   []string{"reasoning_present=false", "reasoning_effort=high", "injected=true"},
+		},
+		{
+			name:   "free-form effort collapses to other",
+			parsed: map[string]any{"model": "qwen", "reasoning_effort": "secret-user-string"},
+			want:   []string{"reasoning_effort=other", "injected=true"},
+		},
+		{
+			name:   "non-string effort collapses to other and injects false",
+			parsed: map[string]any{"model": "qwen", "reasoning_effort": float64(3)},
+			want:   []string{"reasoning_effort=other", "injected=false"},
+		},
+		{
+			name:   "reasoning bool passes through and blocks injection",
+			parsed: map[string]any{"model": "qwen", "reasoning": map[string]any{"enabled": true}},
+			want:   []string{"reasoning_present=true", "reasoning_enabled=true", "injected=none"},
+		},
+		{
+			name:   "non-bool reasoning collapses to non_bool",
+			parsed: map[string]any{"model": "qwen", "reasoning": "malformed"},
+			want:   []string{"reasoning_present=true", "reasoning_enabled=non_bool", "injected=none"},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var buf strings.Builder
+			logger := slog.New(slog.NewTextHandler(&buf, nil))
+			logServiceReasoningShape(logger, test.parsed, serviceReasoningOptInModel)
+			line := buf.String()
+			if !strings.Contains(line, `msg="service reasoning shape"`) {
+				t.Fatalf("missing log message: %s", line)
+			}
+			if !strings.Contains(line, "model="+serviceReasoningOptInModel) {
+				t.Errorf("missing model field: %s", line)
+			}
+			for _, fragment := range test.want {
+				if !strings.Contains(line, fragment) {
+					t.Errorf("log line missing %q: %s", fragment, line)
+				}
+			}
+			if strings.Contains(line, "secret-user-string") {
+				t.Errorf("log line leaked raw request value: %s", line)
 			}
 		})
 	}


### PR DESCRIPTION
# Summary

Service chat traffic that resolves to the Qwen opt-in model (`qwen3.6-35b-a3b-vl-mtp-mxfp8`) could never enable thinking after #632: whenever the OpenRouter-style `reasoning` object was absent, the coordinator injected `{"reasoning":{"enabled":false}}` unconditionally — and in production it is **always** absent, because OpenRouter strips it. This PR makes the injected value follow the caller's top-level `reasoning_effort` intent (which OpenRouter *does* forward) and adds a privacy-safe telemetry line that reveals the exact reasoning shape OpenRouter puts on the wire.

# Production evidence: OpenRouter strips the `reasoning` object in both directions

Direct-vs-OpenRouter probes against **both** deployed builds isolate OpenRouter as the stripping hop:

- **Opt-out build (#632 image)** — `{"reasoning":{"enabled":true}}` sent through OpenRouter: the enable **never arrives**; the coordinator sees `reasoning` absent and injects `enabled:false`, so thinking cannot be turned on at all.
- **Default-on build (pre-#632)** — `{"reasoning":{"enabled":false}}` sent through OpenRouter: the disable **never arrives**; the chat template's default (thinking on) always wins.
- The identical requests sent **directly** to the coordinator behave as expected on both builds, confirming the object is dropped between OpenRouter and us — in both directions.

OpenRouter does forward the OpenAI-style top-level `reasoning_effort` string, so when `reasoning` is absent that string carries the caller's intent.

# New absent-`reasoning` mapping

Applies only to service consumers whose request resolved to the Qwen opt-in model, and only when the `reasoning` object is absent:

| incoming shape | injected |
| --- | --- |
| `reasoning_effort` absent / blank / `none` | `{"reasoning":{"enabled":false}}` |
| any other non-empty effort (`low`, `medium`, `high`, …, even unrecognized) | `{"reasoning":{"enabled":true}}` |
| explicit `reasoning` object present | **always wins** — policy never touches it |

# Telemetry: `service reasoning shape`

One privacy-safe INFO line per service chat request that resolved to the opt-in model, emitted **before** the policy mutates the request (`logServiceReasoningShape`):

- `model` — resolved model id
- `reasoning_present` — bool
- `reasoning_enabled` — `true` / `false` / `non_bool` / `absent`
- `reasoning_effort` — closed set: `absent`, `none`, `minimal`, `low`, `medium`, `high`, `xhigh`, `max`, `other`
- `injected` — `true` / `false` / `none`

No request content is ever logged: free-form or non-string values collapse to `other` / `non_bool`, and a test asserts raw values cannot leak into the line.

# Before / after

**Before — #632 behavior + code flow.** OpenRouter strips the reasoning object; the coordinator injects `enabled:false` whenever it is absent, so no opt-in is possible:

```mermaid
flowchart TB
  subgraph BeforeBehavior["Before — behavior"]
    A1["Caller opts in:<br/>reasoning.enabled=true or reasoning_effort=high"] --> B1["OpenRouter strips reasoning object<br/>(both directions), forwards reasoning_effort"]
    B1 --> C1{"coordinator sees<br/>reasoning object?"}
    C1 -- "never (stripped)" --> D1["inject reasoning.enabled=false<br/>unconditionally"]
    D1 --> E1["Thinking always OFF —<br/>no opt-in possible"]
  end
  subgraph BeforeCode["Before — code flow"]
    F1["handleChatCompletions"] --> G1["applyResolvedModelReasoningPolicy(parsed, body,<br/>model, serviceConsumer, reasoningProvided)"]
    G1 --> H1{"service && model == qwen opt-in<br/>&& reasoning absent?"}
    H1 -- yes --> I1["updated.reasoning = {enabled: false}"]
    H1 -- no --> J1["body untouched"]
  end
```

**After — effort-aware policy + shape telemetry.** The forwarded `reasoning_effort` is honored; telemetry proves the actual wire shape:

```mermaid
flowchart TB
  subgraph AfterBehavior["After — behavior"]
    A2["Caller opts in via reasoning_effort<br/>(the field OpenRouter forwards)"] --> B2["OpenRouter forwards reasoning_effort"]
    B2 --> C2{"reasoning object present?"}
    C2 -- yes --> D2["explicit object wins — untouched"]
    C2 -- no --> E2{"reasoning_effort?"}
    E2 -- "absent / blank / none" --> F2["inject enabled=false<br/>(thinking off)"]
    E2 -- "any other effort" --> G2["inject enabled=true<br/>(thinking ON — opt-in works)"]
    B2 --> H2["INFO service reasoning shape<br/>(presence bits + closed-set enums only)"]
  end
  subgraph AfterCode["After — code flow"]
    I2["handleChatCompletions"] --> J2["effortString(parsed)"]
    I2 --> K2["logServiceReasoningShape(logger, parsed, model)<br/>before any mutation"]
    I2 --> L2["applyResolvedModelReasoningPolicy(parsed, body, model,<br/>serviceConsumer, reasoningProvided, reasoningEffort)"]
    L2 --> M2{"service && model == qwen opt-in<br/>&& reasoning absent?"}
    M2 -- yes --> N2["updated.reasoning = {enabled:<br/>reasoningEffortRequestsThinking(effort)}"]
    M2 -- no --> O2["body untouched"]
  end
```

# Verification

```console
$ gofmt -l coordinator/api
(no output — clean)

$ go test ./coordinator/api -run 'TestServiceReasoningPolicyProviderBody|TestApplyResolvedModelReasoningPolicyPreservesExplicitValuesAndUntouchedBytes|TestApplyResolvedModelReasoningPolicyEffortIntent|TestLogServiceReasoningShapeClosedSet' -count=1
ok      github.com/eigeninference/d-inference/coordinator/api  1.413s

$ go test ./coordinator/api -count=1
ok      github.com/eigeninference/d-inference/coordinator/api  116.267s
```

Focused suite covers: 11 end-to-end provider-body subtests (4 new: effort `high` enables reasoning, effort `none` keeps it disabled, explicit reasoning object wins over effort, non-service effort traffic untouched), 2 new explicit-value/untouched-bytes cases, 6 effort→intent mapping cases (including whitespace/case normalization and unrecognized efforts), and 6 closed-set log-shape cases (including the no-content-leak assertion).

# Rollout

- Production is currently **rolled back to the pre-#632 build (`9a31fc5`)**, so service Qwen traffic has thinking on by default again.
- The #632 image is parked as `coordinator_qwenfix_20260815-193037`.
- This PR is the **re-deploy candidate**: once deployed, the `service reasoning shape` telemetry will reveal the exact wire shape OpenRouter forwards (whether a `reasoning` object ever appears, and the real distribution of `reasoning_effort`), validating the mapping against live traffic.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/634"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789415019&installation_model_id=21733&pr_number=634&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F634&signature=37f0997b2a721168b39ceba325c1be65a4d16902308a7046f4ddf348d55a66c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->