### PR TITLE
feat(api): log service request shape telemetry

### DIFF
--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -29,6 +29,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/eigeninference/d-inference/coordinator/auth"
 	"github.com/eigeninference/d-inference/coordinator/internal/e2e"
 	"github.com/eigeninference/d-inference/coordinator/payments"
 	"github.com/eigeninference/d-inference/coordinator/promptcontract"
@@ -1611,6 +1612,25 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	requestedMaxTokens := estimateRequestedMaxTokens(parsed)
 	deadline := ttftDeadline(estimatedPromptTokens)
 	timing.ParsedAt = time.Now()
+
+	// Privacy-safe request-shape telemetry for service-role (aggregator)
+	// traffic: one INFO line per admitted chat-completions request, after
+	// alias resolution and before dispatch, joinable by trace_id against
+	// terminal outcomes (client_gone). Closed-set fields only — never prompt,
+	// message, or tool-schema content (see request_shape_telemetry.go).
+	if user := auth.UserFromContext(r.Context()); user != nil &&
+		user.Role == store.RoleService && !isResponsesAPI {
+		s.logger.Info("service request shape", serviceRequestShapeFields(parsed, requestShapeComputed{
+			traceID:               requestIDFromContext(r.Context()),
+			model:                 model,
+			publicModel:           publicModel,
+			stream:                stream,
+			estimatedPromptTokens: estimatedPromptTokens,
+			requestedMaxTokens:    requestedMaxTokens,
+			hasTools:              hasTools,
+			requiresVision:        requiresVision,
+		})...)
+	}
 	if s.shedIfModelRejected(w, r, parsed, policy, publicModel, model, stream, estimatedPromptTokens, requestedMaxTokens, requiresVision, hasTools) {
 		return
 	}

--- a/coordinator/api/request_shape_telemetry.go
+++ b/coordinator/api/request_shape_telemetry.go
@@ -1,0 +1,245 @@
+package api
+
+// request_shape_telemetry.go builds the privacy-safe "service request shape"
+// log line emitted once per admitted chat-completions request from a
+// service-role consumer (e.g. OpenRouter). The goal is to see exactly which
+// request shapes an upstream aggregator forwards — reasoning flags, sampling
+// knobs, tool/vision traits — and join them by trace_id against terminal
+// outcomes (client_gone / 504s) without ever logging prompt, message, or
+// tool-schema CONTENT.
+//
+// Privacy contract: every string field comes from a CLOSED SET. Unrecognized
+// consumer-supplied strings map to "other" — the raw value is never echoed.
+// Numeric sampling params are logged only when the consumer sent a JSON
+// number (never coerced from strings). Everything else is booleans, counts,
+// and already-derived values (model/build ids, token estimates).
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+// Closed-set enum values shared by the shape fields below.
+const (
+	shapeAbsent  = "absent"
+	shapeOther   = "other"
+	shapeTrue    = "true"
+	shapeFalse   = "false"
+	shapeNonBool = "non_bool"
+)
+
+// requestShapeComputed carries values handleChatCompletions has already
+// derived by the wiring point (post alias resolution, pre dispatch), so the
+// log line agrees with routing/billing instead of re-deriving them.
+type requestShapeComputed struct {
+	traceID               string
+	model                 string // resolved build id
+	publicModel           string // consumer-facing alias
+	stream                bool
+	estimatedPromptTokens int
+	requestedMaxTokens    int
+	hasTools              bool
+	requiresVision        bool
+}
+
+// serviceRequestShapeFields returns the alternating key/value slog args for
+// the "service request shape" INFO line. Pure: reads parsed, mutates nothing.
+//
+// temperature / top_p / presence_penalty / frequency_penalty are emitted only
+// when the request carried them as JSON numbers; otherwise the key is absent
+// from the line entirely.
+func serviceRequestShapeFields(parsed map[string]any, c requestShapeComputed) []any {
+	reasoning, reasoningPresent := parsed["reasoning"]
+	includeReasoning, includeReasoningPresent := parsed["include_reasoning"]
+	_, hasChatTemplateKwargs := parsed["chat_template_kwargs"]
+	_, seedPresent := parsed["seed"]
+	_, logprobsPresent := parsed["logprobs"]
+	responseFormat, responseFormatPresent := parsed["response_format"]
+
+	toolCount := 0
+	if tools, ok := parsed["tools"].([]any); ok {
+		toolCount = len(tools)
+	}
+	// n: the requested choice count when numeric, 0 when absent/non-numeric.
+	// (n > 1 is rejected before this point, so in practice 0 or 1.)
+	n, _ := intFromRequestValue(parsed["n"])
+
+	fields := make([]any, 0, 2*22)
+	fields = append(fields,
+		"trace_id", c.traceID,
+		"model", c.model,
+		"public_model", c.publicModel,
+		"stream", c.stream,
+		"reasoning_present", reasoningPresent,
+		"reasoning_enabled", normalizeReasoningEnabled(reasoning, reasoningPresent),
+		"reasoning_effort", normalizeReasoningEffort(parsed),
+		"include_reasoning", normalizeBoolTriState(includeReasoning, includeReasoningPresent),
+		"has_chat_template_kwargs", hasChatTemplateKwargs,
+		"estimated_prompt_tokens", c.estimatedPromptTokens,
+		"requested_max_tokens", c.requestedMaxTokens,
+		"has_tools", c.hasTools,
+		"tool_count", toolCount,
+		"requires_vision", c.requiresVision,
+		"n", n,
+		"response_format", normalizeResponseFormat(responseFormat, responseFormatPresent),
+	)
+	for _, p := range [...]struct {
+		key string
+		val any
+	}{
+		{"temperature", parsed["temperature"]},
+		{"top_p", parsed["top_p"]},
+		{"presence_penalty", parsed["presence_penalty"]},
+		{"frequency_penalty", parsed["frequency_penalty"]},
+	} {
+		if f, ok := jsonNumberValue(p.val); ok {
+			fields = append(fields, p.key, f)
+		}
+	}
+	fields = append(fields,
+		"seed_present", seedPresent,
+		"logprobs_present", logprobsPresent,
+	)
+	return fields
+}
+
+// normalizeReasoningEnabled classifies reasoning.enabled (the OpenRouter
+// unified-reasoning toggle): "true" / "false" for a JSON bool, "non_bool" for
+// any other present value, "absent" when the reasoning object or the enabled
+// key is missing. A non-object reasoning value has no enabled key → "absent"
+// (reasoning_present still records that the field was sent).
+func normalizeReasoningEnabled(reasoning any, present bool) string {
+	if !present {
+		return shapeAbsent
+	}
+	obj, ok := reasoning.(map[string]any)
+	if !ok {
+		return shapeAbsent
+	}
+	enabled, ok := obj["enabled"]
+	if !ok {
+		return shapeAbsent
+	}
+	if b, ok := enabled.(bool); ok {
+		if b {
+			return shapeTrue
+		}
+		return shapeFalse
+	}
+	return shapeNonBool
+}
+
+// normalizeReasoningEffort classifies the requested reasoning effort from
+// either surface — reasoning.effort (OpenRouter) with top-level
+// reasoning_effort (OpenAI) as fallback — into the closed set
+// none/minimal/low/medium/high/xhigh/max, "other" for any present but
+// unrecognized value (raw string never logged), "absent" when neither field
+// carries a value.
+func normalizeReasoningEffort(parsed map[string]any) string {
+	if obj, ok := parsed["reasoning"].(map[string]any); ok {
+		if effort, ok := obj["effort"]; ok {
+			return normalizeEffortValue(effort)
+		}
+	}
+	if effort, ok := parsed["reasoning_effort"]; ok {
+		return normalizeEffortValue(effort)
+	}
+	return shapeAbsent
+}
+
+func normalizeEffortValue(v any) string {
+	s, ok := v.(string)
+	if !ok {
+		return shapeOther
+	}
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "none":
+		return "none"
+	case "minimal":
+		return "minimal"
+	case "low":
+		return "low"
+	case "medium":
+		return "medium"
+	case "high":
+		return "high"
+	case "xhigh":
+		return "xhigh"
+	case "max":
+		return "max"
+	default:
+		return shapeOther
+	}
+}
+
+// normalizeBoolTriState classifies a bool-typed request field into
+// "true" / "false" / "absent". A present non-bool value is outside the
+// field's contract and collapses to "absent" rather than widening the set.
+func normalizeBoolTriState(v any, present bool) string {
+	if !present {
+		return shapeAbsent
+	}
+	if b, ok := v.(bool); ok {
+		if b {
+			return shapeTrue
+		}
+		return shapeFalse
+	}
+	return shapeAbsent
+}
+
+// normalizeResponseFormat classifies response_format into
+// json_schema/json_object/text (the OpenAI-defined types), "other" for any
+// present but unrecognized shape or type string, "absent" when missing.
+// Accepts both the object form {"type": "..."} and a bare type string.
+func normalizeResponseFormat(v any, present bool) string {
+	if !present {
+		return shapeAbsent
+	}
+	var typ string
+	switch x := v.(type) {
+	case map[string]any:
+		s, ok := x["type"].(string)
+		if !ok {
+			return shapeOther
+		}
+		typ = s
+	case string:
+		typ = x
+	default:
+		return shapeOther
+	}
+	switch strings.ToLower(strings.TrimSpace(typ)) {
+	case "json_schema":
+		return "json_schema"
+	case "json_object":
+		return "json_object"
+	case "text":
+		return "text"
+	default:
+		return shapeOther
+	}
+}
+
+// jsonNumberValue extracts a float64 from a value only when the request
+// carried a JSON number (json.Number under the prelude's UseNumber decoder;
+// float64/int accepted for robustness). Strings and other types are never
+// coerced — the field is then omitted from the log line.
+func jsonNumberValue(v any) (float64, bool) {
+	switch x := v.(type) {
+	case json.Number:
+		f, err := x.Float64()
+		if err != nil {
+			return 0, false
+		}
+		return f, true
+	case float64:
+		return x, true
+	case int:
+		return float64(x), true
+	case int64:
+		return float64(x), true
+	default:
+		return 0, false
+	}
+}

--- a/coordinator/api/request_shape_telemetry_test.go
+++ b/coordinator/api/request_shape_telemetry_test.go
@@ -1,0 +1,298 @@
+package api
+
+// Tests for the privacy-safe "service request shape" field builder
+// (request_shape_telemetry.go). The two properties defended:
+//
+//  1. Enum normalization: every string field lands in its closed set, with
+//     trim/case tolerance for recognized values.
+//  2. Privacy: an unrecognized consumer-supplied string maps to "other" and
+//     the raw value NEVER appears anywhere in the emitted fields.
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// parseShapeBody decodes a JSON body the way parseInferencePrelude does
+// (UseNumber), so tests exercise the same value types the handler sees.
+func parseShapeBody(t *testing.T, body string) map[string]any {
+	t.Helper()
+	dec := json.NewDecoder(bytes.NewReader([]byte(body)))
+	dec.UseNumber()
+	var parsed map[string]any
+	if err := dec.Decode(&parsed); err != nil {
+		t.Fatalf("parse body: %v", err)
+	}
+	return parsed
+}
+
+// fieldMap folds the alternating key/value slog args into a map and asserts
+// the list is well-formed (even length, string keys, no duplicate keys).
+func fieldMap(t *testing.T, fields []any) map[string]any {
+	t.Helper()
+	if len(fields)%2 != 0 {
+		t.Fatalf("odd field list length %d", len(fields))
+	}
+	m := make(map[string]any, len(fields)/2)
+	for i := 0; i < len(fields); i += 2 {
+		k, ok := fields[i].(string)
+		if !ok {
+			t.Fatalf("field key %d is %T, want string", i, fields[i])
+		}
+		if _, dup := m[k]; dup {
+			t.Fatalf("duplicate field key %q", k)
+		}
+		m[k] = fields[i+1]
+	}
+	return m
+}
+
+func shapeFields(t *testing.T, body string) map[string]any {
+	t.Helper()
+	return fieldMap(t, serviceRequestShapeFields(parseShapeBody(t, body), requestShapeComputed{
+		traceID:               "trace-1",
+		model:                 "build-model",
+		publicModel:           "public-model",
+		stream:                true,
+		estimatedPromptTokens: 100,
+		requestedMaxTokens:    2048,
+		hasTools:              false,
+		requiresVision:        false,
+	}))
+}
+
+func TestServiceRequestShapeFields_ReasoningEnabled(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want string
+	}{
+		{"true", `{"reasoning":{"enabled":true}}`, "true"},
+		{"false", `{"reasoning":{"enabled":false}}`, "false"},
+		{"non_bool string", `{"reasoning":{"enabled":"yes"}}`, "non_bool"},
+		{"non_bool number", `{"reasoning":{"enabled":1}}`, "non_bool"},
+		{"enabled key missing", `{"reasoning":{"effort":"high"}}`, "absent"},
+		{"reasoning missing", `{}`, "absent"},
+		{"reasoning not an object", `{"reasoning":true}`, "absent"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := shapeFields(t, tc.body)
+			if got["reasoning_enabled"] != tc.want {
+				t.Errorf("reasoning_enabled = %v, want %q", got["reasoning_enabled"], tc.want)
+			}
+		})
+	}
+
+	// reasoning_present tracks the key independently of shape.
+	if got := shapeFields(t, `{"reasoning":true}`); got["reasoning_present"] != true {
+		t.Errorf("reasoning_present = %v, want true for non-object reasoning", got["reasoning_present"])
+	}
+	if got := shapeFields(t, `{}`); got["reasoning_present"] != false {
+		t.Errorf("reasoning_present = %v, want false when missing", got["reasoning_present"])
+	}
+}
+
+func TestServiceRequestShapeFields_ReasoningEffort(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want string
+	}{
+		{"nested low", `{"reasoning":{"effort":"low"}}`, "low"},
+		{"nested trims and lowercases", `{"reasoning":{"effort":"  HIGH "}}`, "high"},
+		{"top-level medium", `{"reasoning_effort":"medium"}`, "medium"},
+		{"top-level mixed case", `{"reasoning_effort":"XHigh"}`, "xhigh"},
+		{"none", `{"reasoning_effort":"none"}`, "none"},
+		{"minimal", `{"reasoning_effort":"minimal"}`, "minimal"},
+		{"max", `{"reasoning_effort":"max"}`, "max"},
+		{"nested wins over top-level", `{"reasoning":{"effort":"low"},"reasoning_effort":"high"}`, "low"},
+		{"unknown string", `{"reasoning_effort":"turbo-secret-v2"}`, "other"},
+		{"non-string", `{"reasoning_effort":3}`, "other"},
+		{"nested non-string", `{"reasoning":{"effort":true}}`, "other"},
+		{"absent", `{}`, "absent"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := shapeFields(t, tc.body)
+			if got["reasoning_effort"] != tc.want {
+				t.Errorf("reasoning_effort = %v, want %q", got["reasoning_effort"], tc.want)
+			}
+		})
+	}
+}
+
+func TestServiceRequestShapeFields_IncludeReasoning(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want string
+	}{
+		{"true", `{"include_reasoning":true}`, "true"},
+		{"false", `{"include_reasoning":false}`, "false"},
+		{"absent", `{}`, "absent"},
+		{"non-bool collapses to absent", `{"include_reasoning":"true"}`, "absent"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := shapeFields(t, tc.body)
+			if got["include_reasoning"] != tc.want {
+				t.Errorf("include_reasoning = %v, want %q", got["include_reasoning"], tc.want)
+			}
+		})
+	}
+}
+
+func TestServiceRequestShapeFields_ResponseFormat(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want string
+	}{
+		{"json_schema object", `{"response_format":{"type":"json_schema","json_schema":{"name":"x"}}}`, "json_schema"},
+		{"json_object object", `{"response_format":{"type":"json_object"}}`, "json_object"},
+		{"text object", `{"response_format":{"type":"text"}}`, "text"},
+		{"bare string", `{"response_format":"json_object"}`, "json_object"},
+		{"case/space tolerant", `{"response_format":{"type":" JSON_SCHEMA "}}`, "json_schema"},
+		{"unknown type", `{"response_format":{"type":"grammar"}}`, "other"},
+		{"object without type", `{"response_format":{}}`, "other"},
+		{"non-string type", `{"response_format":{"type":7}}`, "other"},
+		{"unrecognized shape", `{"response_format":42}`, "other"},
+		{"absent", `{}`, "absent"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := shapeFields(t, tc.body)
+			if got["response_format"] != tc.want {
+				t.Errorf("response_format = %v, want %q", got["response_format"], tc.want)
+			}
+		})
+	}
+}
+
+func TestServiceRequestShapeFields_NumbersPassedThrough(t *testing.T) {
+	got := shapeFields(t, `{"temperature":0.7,"top_p":0.95,"presence_penalty":-1,"frequency_penalty":2}`)
+	for key, want := range map[string]float64{
+		"temperature":       0.7,
+		"top_p":             0.95,
+		"presence_penalty":  -1,
+		"frequency_penalty": 2,
+	} {
+		v, ok := got[key].(float64)
+		if !ok || v != want {
+			t.Errorf("%s = %v (%T), want %v", key, got[key], got[key], want)
+		}
+	}
+}
+
+func TestServiceRequestShapeFields_NonNumberSamplingParamsAbsent(t *testing.T) {
+	// String-typed (or otherwise non-number) sampling params must not appear
+	// at all — no coercion, no raw echo.
+	got := shapeFields(t, `{"temperature":"0.7","top_p":null,"presence_penalty":{"v":1}}`)
+	for _, key := range []string{"temperature", "top_p", "presence_penalty", "frequency_penalty"} {
+		if _, present := got[key]; present {
+			t.Errorf("%s present = %v, want key omitted", key, got[key])
+		}
+	}
+}
+
+func TestServiceRequestShapeFields_PresenceFlagsAndCounts(t *testing.T) {
+	got := shapeFields(t, `{
+		"seed": 42,
+		"logprobs": true,
+		"chat_template_kwargs": {"enable_thinking": false},
+		"tools": [{"type":"function"},{"type":"function"}],
+		"n": 1
+	}`)
+	for key, want := range map[string]any{
+		"seed_present":             true,
+		"logprobs_present":         true,
+		"has_chat_template_kwargs": true,
+		"tool_count":               2,
+		"n":                        1,
+	} {
+		if got[key] != want {
+			t.Errorf("%s = %v, want %v", key, got[key], want)
+		}
+	}
+
+	got = shapeFields(t, `{}`)
+	for key, want := range map[string]any{
+		"seed_present":             false,
+		"logprobs_present":         false,
+		"has_chat_template_kwargs": false,
+		"tool_count":               0,
+		"n":                        0,
+	} {
+		if got[key] != want {
+			t.Errorf("empty body: %s = %v, want %v", key, got[key], want)
+		}
+	}
+}
+
+func TestServiceRequestShapeFields_ComputedValuesEchoed(t *testing.T) {
+	fields := serviceRequestShapeFields(parseShapeBody(t, `{}`), requestShapeComputed{
+		traceID:               "trace-abc",
+		model:                 "qwen3-32b-fp8",
+		publicModel:           "qwen3-32b",
+		stream:                true,
+		estimatedPromptTokens: 1234,
+		requestedMaxTokens:    4096,
+		hasTools:              true,
+		requiresVision:        true,
+	})
+	got := fieldMap(t, fields)
+	for key, want := range map[string]any{
+		"trace_id":                "trace-abc",
+		"model":                   "qwen3-32b-fp8",
+		"public_model":            "qwen3-32b",
+		"stream":                  true,
+		"estimated_prompt_tokens": 1234,
+		"requested_max_tokens":    4096,
+		"has_tools":               true,
+		"requires_vision":         true,
+	} {
+		if got[key] != want {
+			t.Errorf("%s = %v, want %v", key, got[key], want)
+		}
+	}
+}
+
+// TestServiceRequestShapeFields_NoRawValueLeakage is the privacy contract:
+// distinctive consumer-supplied strings anywhere in the body must never
+// surface in the emitted fields.
+func TestServiceRequestShapeFields_NoRawValueLeakage(t *testing.T) {
+	const marker = "SECRET_MARKER_9f8e7d"
+	body := fmt.Sprintf(`{
+		"messages": [{"role":"user","content":"%[1]s"}],
+		"reasoning": {"effort":"%[1]s","enabled":"%[1]s"},
+		"reasoning_effort": "%[1]s",
+		"include_reasoning": "%[1]s",
+		"response_format": {"type":"%[1]s"},
+		"temperature": "%[1]s",
+		"chat_template_kwargs": {"key":"%[1]s"},
+		"tools": [{"type":"function","function":{"name":"%[1]s"}}],
+		"seed": "%[1]s",
+		"logprobs": "%[1]s"
+	}`, marker)
+	fields := serviceRequestShapeFields(parseShapeBody(t, body), requestShapeComputed{
+		traceID: "trace-1", model: "m", publicModel: "p",
+	})
+	rendered := fmt.Sprintf("%v", fields)
+	if strings.Contains(rendered, marker) {
+		t.Fatalf("raw consumer value leaked into shape fields: %s", rendered)
+	}
+	got := fieldMap(t, fields)
+	if got["reasoning_effort"] != "other" {
+		t.Errorf("reasoning_effort = %v, want other", got["reasoning_effort"])
+	}
+	if got["response_format"] != "other" {
+		t.Errorf("response_format = %v, want other", got["response_format"])
+	}
+	if got["reasoning_enabled"] != "non_bool" {
+		t.Errorf("reasoning_enabled = %v, want non_bool", got["reasoning_enabled"])
+	}
+}


### PR DESCRIPTION
## Summary

Adds privacy-safe request-shape telemetry for service-role chat-completions traffic: one INFO log line per admitted request with reasoning flags and non-prompt metadata. Log-only; zero inference behavior change.

Stacked on #633 (revert of #632) — base branch `revert/qwen-service-reasoning-default`.

## Why

Production probing proved OpenRouter strips `reasoning` controls before requests reach us (enable never arrives on the opt-out build; disable never arrives on the default-on build), but we cannot see *what they do forward* because request bodies are never logged. This telemetry closes that gap with closed-set, content-free fields, and lets us join `trace_id` → `inference_routes` to name the exact shape of every request OpenRouter charts as 504 (our `client_gone*` rows).

Current 504-proxy cohort on the live build (since 19:32 UTC): 554 requests, 98.6% carried reasoning, 62% reasoning-only, 554/554 past the `9s + 1ms×prompt` deadline.

## What is logged

`INFO msg="service request shape"` — gated on `RoleService` + `POST /v1/chat/completions` (Responses-API bodies excluded), emitted once after alias resolution:

`trace_id, model, public_model, stream, reasoning_present, reasoning_enabled (true|false|non_bool|absent), reasoning_effort (none|minimal|low|medium|high|xhigh|max|other|absent; nested reasoning.effort wins over top-level reasoning_effort), include_reasoning, has_chat_template_kwargs, estimated_prompt_tokens, requested_max_tokens, has_tools, tool_count, requires_vision, n, response_format (json_schema|json_object|text|other|absent), temperature/top_p/presence_penalty/frequency_penalty (only when JSON numbers), seed_present, logprobs_present`

Privacy: every enum is a closed set; unknown strings map to `other`/`non_bool`; a dedicated regression plants a secret marker in every string slot and asserts it never appears in the rendered fields. No prompt, message, tool-schema, or free-text values are ever logged.

## Behavior

```mermaid
flowchart LR
  subgraph Before
    A1[Service chat request] --> B1[Admission and dispatch]
    B1 --> C1[No visibility into forwarded reasoning flags]
    C1 --> D1[504 correlation limited to route outcomes]
  end
  subgraph After
    A2[Service chat request] --> B2["INFO service request shape<br/>(closed-set fields, no content)"]
    B2 --> C2[Admission and dispatch unchanged]
    C2 --> D2[Join trace_id to inference_routes<br/>exact shape of every 504-charted request]
  end
```

## Code

```mermaid
flowchart LR
  subgraph BeforeCode
    F1[handleChatCompletions] --> G1[shedIfModelRejected -> dispatch]
  end
  subgraph AfterCode
    F2[handleChatCompletions] --> H2{RoleService && chat body?}
    H2 -- yes --> I2["serviceRequestShapeFields(parsed, computed)<br/>request_shape_telemetry.go"]
    I2 --> G2[shedIfModelRejected -> dispatch]
    H2 -- no --> G2
  end
```

## Verification

- [x] `gofmt -l coordinator/api/` clean; `go build ./coordinator/api` and `go vet ./coordinator/api` clean
- [x] `go test ./coordinator/api -run 'TestServiceRequestShapeFields' -count=1` → PASS (`ok … 1.007s`)
- [x] Full `go test ./coordinator/api -count=1` → PASS (result posted in PR comment)

## Rollout

Merge after #633. Deploying this build starts the monitoring; the first minutes of logs answer definitively which reasoning fields OpenRouter forwards.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/635"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789415485&installation_model_id=21733&pr_number=635&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F635&signature=c106c7200ab5bbe2be3da23db4243a5543e5510444cbd51a13da776e4e328cb5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->