### PR TITLE
Revert "Revert Qwen service reasoning opt-in (#633)"

### DIFF
--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -29,6 +29,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/eigeninference/d-inference/coordinator/auth"
 	"github.com/eigeninference/d-inference/coordinator/internal/e2e"
 	"github.com/eigeninference/d-inference/coordinator/payments"
 	"github.com/eigeninference/d-inference/coordinator/promptcontract"
@@ -1420,6 +1421,7 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	originalRawBody := prelude.originalRawBody
 	parsed := prelude.parsed
 	model := prelude.model
+	_, reasoningProvided := parsed["reasoning"]
 
 	// Accept either chat completions format (messages) or Responses API format
 	// (input). Responses requests are lowered before the provider body is sealed.
@@ -1550,6 +1552,16 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	model, rawBody = buildModel, resolvedBody
+	user := auth.UserFromContext(r.Context())
+	serviceChatConsumer := r.URL.Path == "/v1/chat/completions" &&
+		user != nil && user.Role == store.RoleService
+	rawBody, _, err = applyResolvedModelReasoningPolicy(
+		parsed, rawBody, model, serviceChatConsumer, reasoningProvided)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, errorResponse(
+			"server_error", "failed to prepare inference request"))
+		return
+	}
 
 	// Shared media/tools fail-fast. Chat completions additionally rejects media
 	// sent via the Responses API surface (input-without-messages), because the
@@ -1646,6 +1658,10 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 		}
 		candidateParsed["model"] = candidateModel
 		candidateBody, marshalErr := marshalForwardBody(candidateParsed)
+		if marshalErr == nil {
+			candidateBody, _, marshalErr = applyResolvedModelReasoningPolicy(
+				candidateParsed, candidateBody, candidateModel, serviceChatConsumer, reasoningProvided)
+		}
 		if marshalErr == nil && isResponsesAPI {
 			candidateBody, marshalErr = promptcontract.LowerProviderBody(
 				promptcontract.EndpointResponses, candidateBody)
@@ -1852,6 +1868,8 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	// pre-extraction behavior.
 	onModelFallback := func(newModel string) bool {
 		body, _ := marshalForwardBody(parsed)
+		body, _, _ = applyResolvedModelReasoningPolicy(
+			parsed, body, newModel, serviceChatConsumer, reasoningProvided)
 		return refreshForwardBody(body, newModel)
 	}
 	var preflightHandled bool

--- a/coordinator/api/reasoning_request_policy.go
+++ b/coordinator/api/reasoning_request_policy.go
@@ -1,0 +1,45 @@
+package api
+
+const serviceReasoningOptInModel = "qwen3.6-35b-a3b-vl-mtp-mxfp8"
+
+// applyResolvedModelReasoningPolicy makes reasoning opt-in for service traffic
+// to the Qwen build. Gemma defaults thinking off, while the production Qwen
+// template defaults it on when reasoning is absent.
+func applyResolvedModelReasoningPolicy(
+	parsed map[string]any,
+	rawBody []byte,
+	resolvedModel string,
+	serviceConsumer bool,
+	reasoningProvided bool,
+) ([]byte, bool, error) {
+	if reasoningProvided {
+		return rawBody, false, nil
+	}
+
+	_, hasReasoning := parsed["reasoning"]
+	shouldDisable := serviceConsumer && resolvedModel == serviceReasoningOptInModel
+	if hasReasoning == shouldDisable {
+		return rawBody, false, nil
+	}
+
+	updated := make(map[string]any, len(parsed)+1)
+	for key, value := range parsed {
+		updated[key] = value
+	}
+	if shouldDisable {
+		updated["reasoning"] = map[string]any{"enabled": false}
+	} else {
+		delete(updated, "reasoning")
+	}
+
+	body, err := marshalForwardBody(updated)
+	if err != nil {
+		return rawBody, false, err
+	}
+	if shouldDisable {
+		parsed["reasoning"] = updated["reasoning"]
+	} else {
+		delete(parsed, "reasoning")
+	}
+	return body, true, nil
+}

--- a/coordinator/api/reasoning_request_policy_test.go
+++ b/coordinator/api/reasoning_request_policy_test.go
@@ -1,0 +1,360 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/internal/e2e"
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+	"github.com/eigeninference/d-inference/coordinator/registry"
+	"github.com/eigeninference/d-inference/coordinator/store"
+	"nhooyr.io/websocket"
+)
+
+func TestServiceReasoningPolicyProviderBody(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	st := store.NewMemory(store.Config{AdminKey: "test-key"})
+	reg := registry.New(logger)
+	srv := NewServer(reg, st, ServerConfig{}, logger)
+	srv.challengeInterval = 200 * time.Millisecond
+
+	const serviceAccount = "service-reasoning-test"
+	if err := st.CreateUser(&store.User{
+		AccountID:   serviceAccount,
+		PrivyUserID: "did:privy:" + serviceAccount,
+		Role:        store.RoleService,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	serviceKey, _, err := st.CreateAPIKey(serviceAccount, store.APIKeyCreate{Name: "reasoning-test"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := st.Credit(serviceAccount, 100_000_000, store.LedgerDeposit, "reasoning-test"); err != nil {
+		t.Fatal(err)
+	}
+
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	publicKey := testPublicKeyB64()
+	value, ok := testProviderKeys.Load(publicKey)
+	if !ok {
+		t.Fatalf("missing cached provider keypair for %q", publicKey)
+	}
+	keypair := value.(testProviderKeyPair)
+	const otherModel = "reasoning-policy-other-model"
+	const qwenAlias = "reasoning-policy-qwen-alias"
+	conn := connectProvider(t, ctx, ts.URL, []protocol.ModelInfo{
+		{ID: serviceReasoningOptInModel},
+		{ID: otherModel},
+	}, publicKey)
+	defer conn.Close(websocket.StatusNormalClosure, "")
+	reg.SetModelAliases(map[string]registry.AliasTarget{
+		qwenAlias: {Desired: serviceReasoningOptInModel},
+	})
+	for _, id := range reg.ProviderIDs() {
+		reg.SetTrustLevel(id, registry.TrustHardware)
+		reg.RecordChallengeSuccess(id)
+	}
+
+	type providerResult struct {
+		body []byte
+		err  error
+	}
+	results := make(chan providerResult, 7)
+	go func() {
+		for {
+			_, data, readErr := conn.Read(ctx)
+			if readErr != nil {
+				results <- providerResult{err: readErr}
+				return
+			}
+			var envelope struct {
+				Type string `json:"type"`
+			}
+			if unmarshalErr := json.Unmarshal(data, &envelope); unmarshalErr != nil {
+				results <- providerResult{err: unmarshalErr}
+				return
+			}
+			if envelope.Type == protocol.TypeAttestationChallenge {
+				if writeErr := conn.Write(ctx, websocket.MessageText, makeValidChallengeResponse(data, publicKey)); writeErr != nil {
+					results <- providerResult{err: writeErr}
+					return
+				}
+				continue
+			}
+			if envelope.Type != protocol.TypeInferenceRequest {
+				continue
+			}
+
+			var request protocol.InferenceRequestMessage
+			if unmarshalErr := json.Unmarshal(data, &request); unmarshalErr != nil {
+				results <- providerResult{err: unmarshalErr}
+				return
+			}
+			if request.EncryptedBody == nil {
+				results <- providerResult{err: errMissingEncryptedProviderBody}
+				return
+			}
+			decrypted, decryptErr := e2e.DecryptWithPrivateKey(&e2e.EncryptedPayload{
+				EphemeralPublicKey: request.EncryptedBody.EphemeralPublicKey,
+				Ciphertext:         request.EncryptedBody.Ciphertext,
+			}, keypair.private)
+			results <- providerResult{body: decrypted, err: decryptErr}
+			if decryptErr != nil {
+				return
+			}
+
+			writeEncryptedTestChunk(t, ctx, conn, request, publicKey,
+				`data: {"id":"chatcmpl-reasoning-policy","choices":[{"delta":{"content":"ok"},"finish_reason":"stop"}]}`+"\n\n")
+			complete, _ := json.Marshal(protocol.InferenceCompleteMessage{
+				Type:      protocol.TypeInferenceComplete,
+				RequestID: request.RequestID,
+				Usage:     protocol.UsageInfo{PromptTokens: 5, CompletionTokens: 1},
+			})
+			if writeErr := conn.Write(ctx, websocket.MessageText, complete); writeErr != nil {
+				return
+			}
+		}
+	}()
+
+	tests := []struct {
+		name          string
+		key           string
+		path          string
+		model         string
+		reasoning     string
+		responsesBody bool
+		wantReasoning string
+		wantModel     string
+	}{
+		{name: "service Qwen omission disables reasoning", key: serviceKey, model: serviceReasoningOptInModel, wantReasoning: `{"enabled":false}`, wantModel: serviceReasoningOptInModel},
+		{name: "service Qwen explicit true is preserved", key: serviceKey, model: serviceReasoningOptInModel, reasoning: `,"reasoning":{"enabled":true}`, wantReasoning: `{"enabled":true}`, wantModel: serviceReasoningOptInModel},
+		{name: "service Qwen explicit false is preserved", key: serviceKey, model: serviceReasoningOptInModel, reasoning: `,"reasoning":{"enabled":false}`, wantReasoning: `{"enabled":false}`, wantModel: serviceReasoningOptInModel},
+		{name: "non-service Qwen omission is unchanged", key: "test-key", model: serviceReasoningOptInModel, wantModel: serviceReasoningOptInModel},
+		{name: "service other model omission is unchanged", key: serviceKey, model: otherModel, wantModel: otherModel},
+		{name: "service alias resolved to Qwen disables reasoning", key: serviceKey, model: qwenAlias, wantReasoning: `{"enabled":false}`, wantModel: serviceReasoningOptInModel},
+		{name: "service Responses route remains unchanged", key: serviceKey, path: "/v1/responses", model: serviceReasoningOptInModel, responsesBody: true, wantModel: serviceReasoningOptInModel},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			path := test.path
+			if path == "" {
+				path = "/v1/chat/completions"
+			}
+			requestBody := fmt.Sprintf(
+				`{"model":%q,"messages":[{"role":"user","content":"hello"}],"stream":true,"max_tokens":32%s}`,
+				test.model, test.reasoning)
+			if test.responsesBody {
+				requestBody = fmt.Sprintf(
+					`{"model":%q,"input":"hello","stream":true,"max_output_tokens":32}`,
+					test.model)
+			}
+			request, requestErr := http.NewRequestWithContext(
+				ctx, http.MethodPost, ts.URL+path, strings.NewReader(requestBody))
+			if requestErr != nil {
+				t.Fatal(requestErr)
+			}
+			request.Header.Set("Authorization", "Bearer "+test.key)
+			response, requestErr := http.DefaultClient.Do(request)
+			if requestErr != nil {
+				t.Fatal(requestErr)
+			}
+			responseBody, readErr := io.ReadAll(response.Body)
+			response.Body.Close()
+			if readErr != nil {
+				t.Fatal(readErr)
+			}
+			if response.StatusCode != http.StatusOK {
+				t.Fatalf("status = %d, want 200: %s", response.StatusCode, responseBody)
+			}
+
+			var result providerResult
+			select {
+			case result = <-results:
+			case <-time.After(5 * time.Second):
+				t.Fatal("timed out waiting for provider body")
+			}
+			if result.err != nil {
+				t.Fatalf("decrypt provider body: %v", result.err)
+			}
+			var fields map[string]json.RawMessage
+			if unmarshalErr := json.Unmarshal(result.body, &fields); unmarshalErr != nil {
+				t.Fatalf("decode provider body: %v\n%s", unmarshalErr, result.body)
+			}
+			var gotModel string
+			if unmarshalErr := json.Unmarshal(fields["model"], &gotModel); unmarshalErr != nil {
+				t.Fatalf("decode provider model: %v", unmarshalErr)
+			}
+			if gotModel != test.wantModel {
+				t.Errorf("provider model = %q, want %q", gotModel, test.wantModel)
+			}
+			gotReasoning, exists := fields["reasoning"]
+			if test.wantReasoning == "" {
+				if exists {
+					t.Errorf("provider body unexpectedly contains reasoning: %s", gotReasoning)
+				}
+			} else if !exists || string(gotReasoning) != test.wantReasoning {
+				t.Errorf("provider reasoning = %s (exists=%v), want %s", gotReasoning, exists, test.wantReasoning)
+			}
+		})
+	}
+}
+
+func TestServiceReasoningPolicyTracksAliasCapacityFallback(t *testing.T) {
+	tests := []struct {
+		name          string
+		desiredModel  string
+		previousModel string
+		wantReasoning string
+	}{
+		{
+			name:          "fallback away from Qwen removes injected default",
+			desiredModel:  serviceReasoningOptInModel,
+			previousModel: "reasoning-fallback-other",
+		},
+		{
+			name:          "fallback toward Qwen injects default",
+			desiredModel:  "reasoning-fallback-other",
+			previousModel: serviceReasoningOptInModel,
+			wantReasoning: `{"enabled":false}`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+			st := store.NewMemory(store.Config{AdminKey: "test-key"})
+			reg := registry.New(logger)
+			srv := NewServer(reg, st, ServerConfig{}, logger)
+			srv.challengeInterval = 30 * time.Second
+
+			const serviceAccount = "service-reasoning-fallback"
+			if err := st.CreateUser(&store.User{
+				AccountID:   serviceAccount,
+				PrivyUserID: "did:privy:" + serviceAccount,
+				Role:        store.RoleService,
+			}); err != nil {
+				t.Fatal(err)
+			}
+			serviceKey, _, err := st.CreateAPIKey(serviceAccount, store.APIKeyCreate{Name: "reasoning-fallback"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := st.Credit(serviceAccount, 100_000_000, store.LedgerDeposit, "reasoning-fallback"); err != nil {
+				t.Fatal(err)
+			}
+
+			ts := httptest.NewServer(srv.Handler())
+			t.Cleanup(ts.Close)
+			ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+			defer cancel()
+
+			registerBuildsProvider(srv, "reasoning-fallback-desired", test.desiredModel)
+			desired := reg.GetProvider("reasoning-fallback-desired")
+			desired.Mu().Lock()
+			desired.BackendCapacity.Slots[0].ActiveTokenBudgetUsed = 1_000
+			desired.BackendCapacity.Slots[0].ActiveTokenBudgetMax = 1_000
+			desired.Mu().Unlock()
+
+			previous := startFailoverProvider(t, ctx, ts, reg, failoverProviderConfig{
+				Name:      "reasoning-fallback-previous",
+				Version:   "0.6.4",
+				DecodeTPS: 100,
+				Models:    []failoverModelSpec{{ID: test.previousModel}},
+				Script:    fullServeScript(test.previousModel),
+			})
+			const alias = "reasoning-policy-fallback-alias"
+			reg.SetModelAliases(map[string]registry.AliasTarget{
+				alias: {Desired: test.desiredModel, Previous: test.previousModel},
+			})
+
+			requestBody := fmt.Sprintf(
+				`{"model":%q,"messages":[{"role":"user","content":"hello"}],"stream":true,"max_tokens":32}`,
+				alias)
+			status, responseBody, err := postChat(ctx, ts.URL, serviceKey, requestBody)
+			if err != nil {
+				t.Fatalf("chat request: %v", err)
+			}
+			if status != http.StatusOK {
+				t.Fatalf("status = %d, want 200: %s", status, responseBody)
+			}
+
+			var providerBody []byte
+			select {
+			case providerBody = <-previous.bodies:
+			case <-time.After(5 * time.Second):
+				t.Fatal("previous provider never received fallback dispatch")
+			}
+			if providerBody == nil {
+				t.Fatal("previous provider could not decrypt fallback body")
+			}
+			var fields map[string]json.RawMessage
+			if err := json.Unmarshal(providerBody, &fields); err != nil {
+				t.Fatalf("decode provider body: %v\n%s", err, providerBody)
+			}
+			var gotModel string
+			if err := json.Unmarshal(fields["model"], &gotModel); err != nil {
+				t.Fatal(err)
+			}
+			if gotModel != test.previousModel {
+				t.Errorf("provider model = %q, want fallback model %q", gotModel, test.previousModel)
+			}
+			gotReasoning, exists := fields["reasoning"]
+			if test.wantReasoning == "" {
+				if exists {
+					t.Errorf("fallback provider body retained reasoning: %s", gotReasoning)
+				}
+			} else if !exists || string(gotReasoning) != test.wantReasoning {
+				t.Errorf("fallback provider reasoning = %s (exists=%v), want %s", gotReasoning, exists, test.wantReasoning)
+			}
+		})
+	}
+}
+
+func TestApplyResolvedModelReasoningPolicyPreservesExplicitValuesAndUntouchedBytes(t *testing.T) {
+	tests := []struct {
+		name     string
+		body     string
+		model    string
+		service  bool
+		provided bool
+	}{
+		{name: "explicit null", body: `{"model":"qwen","reasoning":null}`, model: serviceReasoningOptInModel, service: true, provided: true},
+		{name: "explicit scalar", body: `{"model":"qwen","reasoning":"malformed"}`, model: serviceReasoningOptInModel, service: true, provided: true},
+		{name: "non-service target", body: `{ "model" : "qwen" }`, model: serviceReasoningOptInModel},
+		{name: "service other model", body: `{ "model" : "other" }`, model: "other", service: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			parsed, err := decodeInferenceJSONObject([]byte(test.body))
+			if err != nil {
+				t.Fatal(err)
+			}
+			got, changed, err := applyResolvedModelReasoningPolicy(
+				parsed, []byte(test.body), test.model, test.service, test.provided)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if changed {
+				t.Fatal("policy reported a mutation")
+			}
+			if string(got) != test.body {
+				t.Fatalf("body changed: got %q, want original %q", got, test.body)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Reverts merged #633 by reverting its master commit `abd2c4ee40b149117539663ba1c16d2f023c4fd3`, restoring the three affected coordinator API files exactly to #632 commit `0e0c803799580f6c1e28483cefbb0f2f9ae9a3fc`.

Production already runs the #632 image `0e0c803` with 241 providers, so this aligns `master` with production. The restored policy only injects `reasoning.enabled=false` when reasoning is omitted on `RoleService` chat traffic resolved to the Qwen build. Explicit reasoning values remain untouched, including the original request bytes.

## Before — master after #633

```mermaid
flowchart LR
  subgraph Behavior
    B1[RoleService chat request] --> B2[Qwen with reasoning omitted]
    B2 --> B3[Coordinator forwards omission unchanged]
    B3 --> B4[Qwen template defaults thinking ON]
    B4 --> B5[OpenRouter gets reasoning-only stream]
    B5 --> B6[No delta.content before timeout]
    B6 --> B7[504]
  end

  subgraph Code
    C1[Resolve primary model] --> C2[No reasoning policy helper]
    C2 --> C3[Primary body unchanged]
    C2 --> C4[Candidate body unchanged]
    C2 --> C5[Alias fallback body unchanged]
  end
```

## After — restored #632

```mermaid
flowchart LR
  subgraph Behavior
    A1[RoleService chat request] --> A2[Qwen with reasoning omitted]
    A2 --> A3[Inject reasoning enabled false]
    A3 --> A4[Qwen emits answer tokens directly]
    A4 --> A5[delta.content arrives early]
  end

  subgraph Code
    D1[Restore applyResolvedModelReasoningPolicy] --> D2{Explicit reasoning provided?}
    D2 -- Yes --> D3[Keep value and original bytes untouched]
    D2 -- No --> D4{RoleService chat and Qwen?}
    D4 -- Yes --> D5[Inject enabled false]
    D4 -- No --> D6[Keep omission]
    D5 --> D7[Apply after primary resolution]
    D5 --> D8[Apply to candidate provider body]
    D5 --> D9[Apply during alias capacity fallback]
  end
```

## Verification

- `git diff --check origin/master..HEAD`
- `git diff --exit-code 0e0c803799580f6c1e28483cefbb0f2f9ae9a3fc HEAD -- coordinator/api/consumer.go coordinator/api/reasoning_request_policy.go coordinator/api/reasoning_request_policy_test.go`
- `go test ./coordinator/api -run '^(TestServiceReasoningPolicyProviderBody|TestServiceReasoningPolicyTracksAliasCapacityFallback|TestApplyResolvedModelReasoningPolicyPreservesExplicitValuesAndUntouchedBytes)$' -count=1`
