### PR TITLE
feat(coordinator): add OpenRouter-only model aliases

### DIFF
--- a/coordinator/api/model_alias_handlers.go
+++ b/coordinator/api/model_alias_handlers.go
@@ -19,6 +19,7 @@ type aliasUpsertRequest struct {
 	DesiredBuild  string `json:"desired_build"`
 	PreviousBuild string `json:"previous_build"`
 	Active        *bool  `json:"active"` // pointer so omission defaults to true
+
 	// Takeover lets a public alias adopt the name of an EXISTING concrete model,
 	// absorbing that same-named build as its previous_build (fallback). This is the
 	// only way to migrate a live public name (e.g. "gemma-4-26b") onto a new
@@ -49,8 +50,10 @@ func (s *Server) handleModelAliasUpsert(w http.ResponseWriter, r *http.Request) 
 	}
 
 	req.AliasID = strings.TrimSpace(req.AliasID)
+	req.DisplayName = strings.TrimSpace(req.DisplayName)
 	req.DesiredBuild = strings.TrimSpace(req.DesiredBuild)
 	req.PreviousBuild = strings.TrimSpace(req.PreviousBuild)
+
 	if req.AliasID == "" {
 		writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request_error", "alias_id is required", withParam("alias_id")))
 		return
@@ -75,6 +78,11 @@ func (s *Server) handleModelAliasUpsert(w http.ResponseWriter, r *http.Request) 
 	// model and absorbs that same-named build as its previous_build (fallback).
 	collidingRec, _ := s.store.GetModelRegistryRecord(req.AliasID)
 	idCollision := collidingRec != nil
+	prior := s.priorAlias(req.AliasID)
+	if prior != nil && prior.OpenRouterOnly {
+		writeJSON(w, http.StatusConflict, errorResponse("invalid_request_error", "alias_id belongs to the dedicated OpenRouter alias endpoint", withParam("alias_id")))
+		return
+	}
 
 	// desired_build can NEVER equal the alias name (that would alias to itself).
 	if req.DesiredBuild == req.AliasID {
@@ -128,9 +136,11 @@ func (s *Server) handleModelAliasUpsert(w http.ResponseWriter, r *http.Request) 
 		DisplayName:   req.DisplayName,
 		DesiredBuild:  req.DesiredBuild,
 		PreviousBuild: req.PreviousBuild,
-		RetiredBuilds: retiredBuildsAfterUpsert(s.priorAlias(req.AliasID), req.DesiredBuild, req.PreviousBuild),
-		Active:        active,
+		RetiredBuilds: retiredBuildsAfterUpsert(prior, req.DesiredBuild, req.PreviousBuild),
+
+		Active: active,
 	}
+
 	if err := s.store.UpsertModelAlias(alias); err != nil {
 		s.logger.Error("upsert model alias failed", "alias_id", req.AliasID, "error", err)
 		writeJSON(w, http.StatusInternalServerError, errorResponse("internal_error", "failed to save alias"))
@@ -201,7 +211,8 @@ func retiredBuildsAfterUpsert(prior *store.ModelAlias, newDesired, newPrevious s
 	return retired
 }
 
-// handleModelAliasList returns every configured alias. GET /v1/admin/models/aliases.
+// handleModelAliasList returns standard rollout aliases. OpenRouter-only feed
+// aliases have a dedicated management endpoint.
 func (s *Server) handleModelAliasList(w http.ResponseWriter, r *http.Request) {
 	if _, ok := s.requirePublishingAPIKey(w, r); !ok {
 		return
@@ -211,7 +222,14 @@ func (s *Server) handleModelAliasList(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusInternalServerError, errorResponse("internal_error", "failed to list aliases"))
 		return
 	}
-	writeJSON(w, http.StatusOK, map[string]any{"aliases": aliases})
+	standard := aliases[:0]
+	for _, alias := range aliases {
+		if !alias.OpenRouterOnly {
+			standard = append(standard, alias)
+		}
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"aliases": standard})
+
 }
 
 // handleModelAliasDelete removes an alias. DELETE /v1/admin/models/aliases/{aliasID}.
@@ -222,6 +240,13 @@ func (s *Server) handleModelAliasDelete(w http.ResponseWriter, r *http.Request) 
 	aliasID := strings.TrimSpace(r.PathValue("aliasID"))
 	if aliasID == "" {
 		writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request_error", "alias id is required"))
+		return
+	}
+	if alias, found, err := s.store.GetModelAlias(aliasID); err != nil {
+		writeJSON(w, http.StatusInternalServerError, errorResponse("internal_error", "failed to get alias"))
+		return
+	} else if found && alias.OpenRouterOnly {
+		writeJSON(w, http.StatusNotFound, errorResponse("invalid_request_error", "OpenRouter-only alias must be deleted through its dedicated endpoint"))
 		return
 	}
 	if err := s.store.DeleteModelAlias(aliasID); err != nil {

--- a/coordinator/api/model_alias_handlers_test.go
+++ b/coordinator/api/model_alias_handlers_test.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"reflect"
+
 	"strconv"
 	"strings"
 	"testing"
@@ -15,6 +17,7 @@ import (
 
 	"nhooyr.io/websocket"
 
+	"github.com/eigeninference/d-inference/coordinator/api/types"
 	"github.com/eigeninference/d-inference/coordinator/protocol"
 	"github.com/eigeninference/d-inference/coordinator/registry"
 	"github.com/eigeninference/d-inference/coordinator/store"
@@ -1040,5 +1043,177 @@ func TestModelAliasTakeoverOfConcreteID(t *testing.T) {
 	// fleet already serving the legacy build is NOT untrusted by the takeover.
 	if after := reg.CatalogWeightHash(legacyID); after != hashBefore {
 		t.Fatalf("takeover changed catalog hash for %s (%q -> %q) — would untrust the live fleet", legacyID, hashBefore, after)
+	}
+}
+
+// An OpenRouter-only alias clones every feed detail from a standard source
+// alias while overriding only id, marketplace slug, and Hugging Face identity.
+
+func TestOpenRouterAliasClonesSourceEntry(t *testing.T) {
+	t.Setenv("MODEL_REGISTRY_PUBLISHING_KEY", "publish-secret")
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	st := store.NewMemory(store.Config{})
+	reg := registry.New(logger)
+	srv := NewServer(reg, st, ServerConfig{}, logger)
+
+	seedActiveModel(t, st, aliasQAT, "Gemma 4 26B")
+	srv.SyncModelCatalog()
+
+	const (
+		baseAlias = "gemma-4-26b"
+		paidAlias = "gemma-4-26b-a4b-it"
+		paidSlug  = "google/gemma-4-26b-it"
+		paidHFID  = "google/gemma-4-26b-it"
+	)
+	post := func(path string, payload map[string]any) *httptest.ResponseRecorder {
+		t.Helper()
+		body, _ := json.Marshal(payload)
+		req := httptest.NewRequest(http.MethodPost, path, bytes.NewReader(body))
+		req.Header.Set("Authorization", "Bearer publish-secret")
+		rec := httptest.NewRecorder()
+		srv.Handler().ServeHTTP(rec, req)
+		return rec
+	}
+	if rec := post("/v1/admin/models/aliases", map[string]any{
+		"alias_id": baseAlias, "display_name": "Gemma 4 26B", "desired_build": aliasQAT,
+	}); rec.Code != http.StatusOK {
+		t.Fatalf("create source alias: status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if rec := post("/v1/admin/models/openrouter-aliases", map[string]any{
+		"id": paidAlias, "source_model": baseAlias,
+		"openrouter_slug": paidSlug, "hugging_face_id": paidHFID,
+	}); rec.Code != http.StatusOK {
+		t.Fatalf("create OpenRouter alias: status=%d body=%s", rec.Code, rec.Body.String())
+	}
+
+	saved, found, err := st.GetModelAlias(paidAlias)
+	if err != nil || !found || !saved.OpenRouterOnly || saved.SourceModel != baseAlias || saved.OpenRouterSlug != paidSlug || saved.HuggingFaceID != paidHFID {
+		t.Fatalf("stored OpenRouter alias = %+v found=%v err=%v", saved, found, err)
+	}
+	listAliasesReq := httptest.NewRequest(http.MethodGet, "/v1/admin/models/openrouter-aliases", nil)
+	listAliasesReq.Header.Set("Authorization", "Bearer publish-secret")
+	listAliasesRec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(listAliasesRec, listAliasesReq)
+	if listAliasesRec.Code != http.StatusOK {
+		t.Fatalf("list OpenRouter aliases: status=%d body=%s", listAliasesRec.Code, listAliasesRec.Body.String())
+	}
+	var aliasList struct {
+		Aliases []store.ModelAlias `json:"aliases"`
+	}
+	if err := json.Unmarshal(listAliasesRec.Body.Bytes(), &aliasList); err != nil || len(aliasList.Aliases) != 1 || aliasList.Aliases[0].AliasID != paidAlias {
+		t.Fatalf("OpenRouter alias list = %+v err=%v", aliasList.Aliases, err)
+	}
+
+	// OpenRouter can call either id; both resolve to the source alias's live build.
+	for _, alias := range []string{baseAlias, paidAlias} {
+		build, isAlias, ok := reg.ResolveModel(alias)
+		if !isAlias || !ok || build != aliasQAT {
+			t.Fatalf("resolve(%s) = %q isAlias=%v ok=%v, want %q", alias, build, isAlias, ok, aliasQAT)
+		}
+	}
+	if got := reg.PublicNameForBuild(aliasQAT); got != baseAlias {
+		t.Fatalf("PublicNameForBuild = %q, want source alias %s", got, baseAlias)
+	}
+
+	// The OpenRouter-only alias is intentionally absent from the normal catalog.
+	listRec := httptest.NewRecorder()
+	srv.handleListModels(listRec, httptest.NewRequest(http.MethodGet, "/v1/models", nil))
+	if listRec.Code != http.StatusOK {
+		t.Fatalf("list status = %d", listRec.Code)
+	}
+	var listResp types.ModelListResponse
+	if err := json.Unmarshal(listRec.Body.Bytes(), &listResp); err != nil {
+		t.Fatal(err)
+	}
+	listByID := make(map[string]types.ModelEntry, len(listResp.Data))
+	for _, m := range listResp.Data {
+		listByID[m.ID] = m
+	}
+	if _, ok := listByID[baseAlias]; !ok {
+		t.Fatalf("source alias missing from /v1/models: %+v", listResp.Data)
+	}
+	if _, leaked := listByID[paidAlias]; leaked {
+		t.Fatalf("OpenRouter-only alias leaked into /v1/models: %+v", listResp.Data)
+	}
+	if _, leaked := listByID[aliasQAT]; leaked {
+		t.Fatalf("shared build leaked into /v1/models: %+v", listResp.Data)
+	}
+
+	// The dedicated feed clone differs from its source only in the three public
+	// identities configured by the dedicated endpoint.
+	orRec := httptest.NewRecorder()
+	srv.handleListModelsOpenRouter(orRec, httptest.NewRequest(http.MethodGet, "/v1/models/openrouter", nil))
+	if orRec.Code != http.StatusOK {
+		t.Fatalf("openrouter feed status = %d body = %s", orRec.Code, orRec.Body.String())
+	}
+	var orResp types.OpenRouterModelsResponse
+	if err := json.Unmarshal(orRec.Body.Bytes(), &orResp); err != nil {
+		t.Fatal(err)
+	}
+	orByID := make(map[string]types.OpenRouterModel, len(orResp.Data))
+	for _, m := range orResp.Data {
+		orByID[m.ID] = m
+	}
+	baseFeed, baseOK := orByID[baseAlias]
+	paidFeed, paidOK := orByID[paidAlias]
+	if !baseOK || !paidOK {
+		t.Fatalf("aliases missing from OpenRouter feed: %+v", orResp.Data)
+	}
+	if paidFeed.OpenRouter == nil || paidFeed.OpenRouter.Slug != paidSlug || paidFeed.HuggingFaceID != paidHFID {
+		t.Fatalf("paid feed identities: slug=%+v hugging_face_id=%q", paidFeed.OpenRouter, paidFeed.HuggingFaceID)
+	}
+	paidFeed.ID = baseFeed.ID
+	paidFeed.HuggingFaceID = baseFeed.HuggingFaceID
+	paidFeed.OpenRouter = baseFeed.OpenRouter
+	if !reflect.DeepEqual(paidFeed, baseFeed) {
+		t.Fatalf("OpenRouter clone differs beyond identities: source=%+v clone=%+v", baseFeed, paidFeed)
+	}
+	if _, leaked := orByID[aliasQAT]; leaked {
+		t.Fatalf("shared build leaked into the OpenRouter feed: %+v", orResp.Data)
+	}
+	deleteReq := httptest.NewRequest(http.MethodDelete, "/v1/admin/models/openrouter-aliases/"+paidAlias, nil)
+	deleteReq.Header.Set("Authorization", "Bearer publish-secret")
+	deleteRec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(deleteRec, deleteReq)
+	if deleteRec.Code != http.StatusOK || reg.IsAlias(paidAlias) {
+		t.Fatalf("delete OpenRouter alias: status=%d still_registered=%v body=%s", deleteRec.Code, reg.IsAlias(paidAlias), deleteRec.Body.String())
+	}
+}
+
+func TestOpenRouterAliasFollowsSourceAliasBuildUpdate(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	st := store.NewMemory(store.Config{})
+	reg := registry.New(logger)
+	srv := NewServer(reg, st, ServerConfig{}, logger)
+
+	seedActiveModel(t, st, aliasQAT, "Gemma 4 26B QAT")
+	seedActiveModel(t, st, aliasFP8, "Gemma 4 26B FP8")
+	if err := st.UpsertModelAlias(&store.ModelAlias{
+		AliasID: "gemma-4-26b", DesiredBuild: aliasQAT, Active: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.UpsertModelAlias(&store.ModelAlias{
+		AliasID: "gemma-4-26b-paid", OpenRouterOnly: true,
+		SourceModel: "gemma-4-26b", OpenRouterSlug: "google/gemma-4-26b-it",
+		HuggingFaceID: "google/gemma-4-26b-it", Active: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	srv.SyncModelCatalog()
+	if build, _, ok := reg.ResolveModel("gemma-4-26b-paid"); !ok || build != aliasQAT {
+		t.Fatalf("initial OpenRouter alias resolve = %q ok=%v", build, ok)
+	}
+
+	// Move only the source alias. The OpenRouter clone follows without its own
+	// rollout update because sync resolves its route through SourceModel.
+	if err := st.UpsertModelAlias(&store.ModelAlias{
+		AliasID: "gemma-4-26b", DesiredBuild: aliasFP8, PreviousBuild: aliasQAT, Active: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	srv.SyncModelCatalog()
+	if build, _, ok := reg.ResolveModel("gemma-4-26b-paid"); !ok || build != aliasFP8 {
+		t.Fatalf("updated OpenRouter alias resolve = %q ok=%v, want source desired %q", build, ok, aliasFP8)
 	}
 }

--- a/coordinator/api/models_endpoints.go
+++ b/coordinator/api/models_endpoints.go
@@ -47,7 +47,8 @@ func (s *Server) aliasModelEntries(
 
 	entries := make([]types.ModelEntry, 0, len(aliases))
 	for _, a := range aliases {
-		if !a.Active || a.DesiredBuild == "" {
+		if !a.Active || a.OpenRouterOnly || a.DesiredBuild == "" {
+
 			continue
 		}
 		// A consumer must only ever see the alias, never a concrete build behind

--- a/coordinator/api/openrouter_alias_handlers.go
+++ b/coordinator/api/openrouter_alias_handlers.go
@@ -1,0 +1,152 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/eigeninference/d-inference/coordinator/store"
+)
+
+// openRouterAliasUpsertRequest configures one OpenRouter-only clone of an
+// existing standard model alias. OpenRouter sends ID to the inference API;
+// SourceModel supplies every non-identity feed field and the live routing target.
+type openRouterAliasUpsertRequest struct {
+	ID             string `json:"id"`
+	SourceModel    string `json:"source_model"`
+	OpenRouterSlug string `json:"openrouter_slug"`
+	HuggingFaceID  string `json:"hugging_face_id"`
+	Active         *bool  `json:"active"`
+}
+
+// handleOpenRouterAliasUpsert creates or replaces an OpenRouter-only alias.
+// POST /v1/admin/models/openrouter-aliases.
+func (s *Server) handleOpenRouterAliasUpsert(w http.ResponseWriter, r *http.Request) {
+	if _, ok := s.requirePublishingAPIKey(w, r); !ok {
+		return
+	}
+
+	var req openRouterAliasUpsertRequest
+	dec := json.NewDecoder(r.Body)
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request_error", "invalid JSON: "+err.Error()))
+		return
+	}
+	req.ID = strings.TrimSpace(req.ID)
+	req.SourceModel = strings.TrimSpace(req.SourceModel)
+	req.OpenRouterSlug = strings.TrimSpace(req.OpenRouterSlug)
+	req.HuggingFaceID = strings.TrimSpace(req.HuggingFaceID)
+
+	switch {
+	case req.ID == "":
+		writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request_error", "id is required", withParam("id")))
+		return
+	case len(req.ID) > maxAliasIDLength || !validRegistryIdentifier(req.ID, false):
+		writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request_error", "id may only contain letters, digits, '.', '_' and '-' (max 128 chars)", withParam("id")))
+		return
+	case req.SourceModel == "":
+		writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request_error", "source_model is required", withParam("source_model")))
+		return
+	case req.SourceModel == req.ID:
+		writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request_error", "source_model cannot equal id", withParam("source_model")))
+		return
+	case req.OpenRouterSlug == "":
+		writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request_error", "openrouter_slug is required", withParam("openrouter_slug")))
+		return
+	case req.HuggingFaceID == "":
+		writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request_error", "hugging_face_id is required", withParam("hugging_face_id")))
+		return
+	}
+
+	source, found, err := s.store.GetModelAlias(req.SourceModel)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, errorResponse("internal_error", "failed to get source alias"))
+		return
+	}
+	if !found || source.OpenRouterOnly || !source.Active || source.DesiredBuild == "" {
+		writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request_error", "source_model must be an active standard model alias", withParam("source_model")))
+		return
+	}
+	if rec, _ := s.store.GetModelRegistryRecord(req.ID); rec != nil {
+		writeJSON(w, http.StatusConflict, errorResponse("invalid_request_error", "id collides with an existing model id", withParam("id")))
+		return
+	}
+	if existing, exists, err := s.store.GetModelAlias(req.ID); err != nil {
+		writeJSON(w, http.StatusInternalServerError, errorResponse("internal_error", "failed to get alias"))
+		return
+	} else if exists && !existing.OpenRouterOnly {
+		writeJSON(w, http.StatusConflict, errorResponse("invalid_request_error", "id collides with an existing standard alias", withParam("id")))
+		return
+	}
+
+	active := true
+	if req.Active != nil {
+		active = *req.Active
+	}
+	alias := &store.ModelAlias{
+		AliasID:        req.ID,
+		OpenRouterOnly: true,
+		SourceModel:    req.SourceModel,
+		OpenRouterSlug: req.OpenRouterSlug,
+		HuggingFaceID:  req.HuggingFaceID,
+		Active:         active,
+	}
+	if err := s.store.UpsertModelAlias(alias); err != nil {
+		s.logger.Error("upsert OpenRouter alias failed", "alias_id", req.ID, "error", err)
+		writeJSON(w, http.StatusInternalServerError, errorResponse("internal_error", "failed to save OpenRouter alias"))
+		return
+	}
+	s.SyncModelCatalog()
+
+	saved, _, _ := s.store.GetModelAlias(req.ID)
+	writeJSON(w, http.StatusOK, map[string]any{"status": "ok", "alias": saved})
+}
+
+// handleOpenRouterAliasList lists only OpenRouter feed aliases.
+// GET /v1/admin/models/openrouter-aliases.
+func (s *Server) handleOpenRouterAliasList(w http.ResponseWriter, r *http.Request) {
+	if _, ok := s.requirePublishingAPIKey(w, r); !ok {
+		return
+	}
+	aliases, err := s.store.ListModelAliases()
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, errorResponse("internal_error", "failed to list OpenRouter aliases"))
+		return
+	}
+	out := aliases[:0]
+	for _, alias := range aliases {
+		if alias.OpenRouterOnly {
+			out = append(out, alias)
+		}
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"aliases": out})
+}
+
+// handleOpenRouterAliasDelete removes one OpenRouter feed alias.
+// DELETE /v1/admin/models/openrouter-aliases/{aliasID}.
+func (s *Server) handleOpenRouterAliasDelete(w http.ResponseWriter, r *http.Request) {
+	if _, ok := s.requirePublishingAPIKey(w, r); !ok {
+		return
+	}
+	aliasID := strings.TrimSpace(r.PathValue("aliasID"))
+	if aliasID == "" {
+		writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request_error", "alias id is required"))
+		return
+	}
+	alias, found, err := s.store.GetModelAlias(aliasID)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, errorResponse("internal_error", "failed to get OpenRouter alias"))
+		return
+	}
+	if !found || !alias.OpenRouterOnly {
+		writeJSON(w, http.StatusNotFound, errorResponse("invalid_request_error", "OpenRouter alias not found"))
+		return
+	}
+	if err := s.store.DeleteModelAlias(aliasID); err != nil {
+		writeJSON(w, http.StatusInternalServerError, errorResponse("internal_error", "failed to delete OpenRouter alias"))
+		return
+	}
+	s.SyncModelCatalog()
+	writeJSON(w, http.StatusOK, map[string]any{"status": "deleted", "id": aliasID})
+}

--- a/coordinator/api/openrouter_endpoint.go
+++ b/coordinator/api/openrouter_endpoint.go
@@ -122,15 +122,22 @@ func (s *Server) openRouterAliasEntries(
 	sort.Slice(aliases, func(i, j int) bool { return aliases[i].AliasID < aliases[j].AliasID })
 
 	entries := make([]types.OpenRouterModel, 0, len(aliases))
+	standardEntries := make(map[string]types.OpenRouterModel, len(aliases))
+	openRouterAliases := make([]store.ModelAlias, 0)
 	for _, a := range aliases {
-		if !a.Active || a.DesiredBuild == "" {
+		if !a.Active {
+			continue
+		}
+		if a.OpenRouterOnly {
+			openRouterAliases = append(openRouterAliases, a)
+			continue
+		}
+		if a.DesiredBuild == "" {
 			continue
 		}
 		// Never sell a raw build behind a public alias: hide EVERY build the
 		// alias references — desired, previous, AND the retired lineage — from
-		// the marketplace feed, even if the alias itself isn't listable right now
-		// (a retired build left registered would otherwise reappear as a sellable
-		// entry with no providers — a marketplace black-hole).
+		// the marketplace feed, even if the alias itself isn't listable right now.
 		hideAliasBuild(hidden, catalogByID, a.DesiredBuild)
 		hideAliasBuild(hidden, catalogByID, a.PreviousBuild)
 		for _, b := range a.RetiredBuilds {
@@ -146,7 +153,6 @@ func (s *Server) openRouterAliasEntries(
 			}
 		}
 		if len(members) == 0 {
-			// No in-catalog build backs this alias — nothing servable to list.
 			continue
 		}
 		primary := members[0]
@@ -174,8 +180,6 @@ func (s *Server) openRouterAliasEntries(
 			SupportedFeatures: []string{},
 			IsReady:           true,
 		}
-		// Per-build feed fields from the primary build's registry entry; the
-		// quantization is intentionally blank — an alias spans quants.
 		s.openRouterModelFieldsFor(primary, "", reg, hasReg).applyToFeed(&entry)
 		if hasReg {
 			entry.IsReady = openRouterIsReady(reg.Metadata)
@@ -184,9 +188,26 @@ func (s *Server) openRouterAliasEntries(
 			entry.OpenRouter = &types.OpenRouterSlug{Slug: openRouterSlug(a.AliasID, nil)}
 		}
 		entry.Datacenters = s.aliasDatacenters(members)
-
 		entries = append(entries, entry)
+		standardEntries[a.AliasID] = entry
 	}
+
+	// OpenRouter-only aliases clone the complete source entry, then replace only
+	// the three configured identities. This keeps pricing, limits, features,
+	// readiness, and datacenters exactly synchronized with the source alias.
+	for _, a := range openRouterAliases {
+		source, ok := standardEntries[a.SourceModel]
+		if !ok || a.OpenRouterSlug == "" || a.HuggingFaceID == "" {
+			s.logger.Warn("OpenRouter alias source or identities unavailable", "alias_id", a.AliasID, "source_model", a.SourceModel)
+			continue
+		}
+		clone := source
+		clone.ID = a.AliasID
+		clone.HuggingFaceID = a.HuggingFaceID
+		clone.OpenRouter = &types.OpenRouterSlug{Slug: a.OpenRouterSlug}
+		entries = append(entries, clone)
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].ID < entries[j].ID })
 	return entries, hidden
 }
 

--- a/coordinator/api/server.go
+++ b/coordinator/api/server.go
@@ -1029,10 +1029,9 @@ func (s *Server) SyncModelCatalog() {
 	s.invalidateCatalogCache()
 }
 
-// syncModelAliases loads public-alias → {desired, previous} build pointers from
-// the store into the registry so consumer requests for an alias (e.g.
-// "gemma-4-26b") resolve to a concrete build. Only active aliases with a
-// non-empty desired build are installed.
+// syncModelAliases loads standard rollout aliases first, then resolves
+// OpenRouter-only aliases through their source alias. The latter route requests
+// but do not participate in provider convergence or canonical public naming.
 func (s *Server) syncModelAliases() {
 	aliases, err := s.store.ListModelAliases()
 	if err != nil {
@@ -1041,7 +1040,7 @@ func (s *Server) syncModelAliases() {
 	}
 	resolved := make(map[string]registry.AliasTarget, len(aliases))
 	for _, a := range aliases {
-		if !a.Active || a.DesiredBuild == "" {
+		if !a.Active || a.OpenRouterOnly || a.DesiredBuild == "" {
 			continue
 		}
 		resolved[a.AliasID] = registry.AliasTarget{
@@ -1049,6 +1048,18 @@ func (s *Server) syncModelAliases() {
 			Previous: a.PreviousBuild,
 			Retired:  a.RetiredBuilds,
 		}
+	}
+	for _, a := range aliases {
+		if !a.Active || !a.OpenRouterOnly {
+			continue
+		}
+		target, ok := resolved[a.SourceModel]
+		if !ok {
+			s.logger.Warn("OpenRouter alias source is not an active standard alias", "alias_id", a.AliasID, "source_model", a.SourceModel)
+			continue
+		}
+		target.OpenRouterOnly = true
+		resolved[a.AliasID] = target
 	}
 	s.registry.SetModelAliases(resolved)
 	s.logger.Info("model aliases synced to registry", "active_aliases", len(resolved))
@@ -1861,6 +1872,11 @@ func (s *Server) routes() {
 	// (bare GET/POST/DELETE /v1/admin/models) was removed; the model_registry is
 	// the single source of truth. Use register + the per-model action endpoints.
 	s.mux.HandleFunc("POST /v1/admin/models/register", s.handleRegisterModel)
+	// OpenRouter-only feed aliases clone a standard alias while exposing custom
+	// provider id, marketplace slug, and Hugging Face identity.
+	s.mux.HandleFunc("GET /v1/admin/models/openrouter-aliases", s.handleOpenRouterAliasList)
+	s.mux.HandleFunc("POST /v1/admin/models/openrouter-aliases", s.handleOpenRouterAliasUpsert)
+	s.mux.HandleFunc("DELETE /v1/admin/models/openrouter-aliases/{aliasID}", s.handleOpenRouterAliasDelete)
 	// Public model aliases (stable names → concrete builds). More-specific
 	// patterns take precedence over the POST /v1/admin/models/ subtree below.
 	s.mux.HandleFunc("GET /v1/admin/models/aliases", s.handleModelAliasList)

--- a/coordinator/registry/alias_test.go
+++ b/coordinator/registry/alias_test.go
@@ -228,8 +228,10 @@ func TestResolveModelConstrainedNoFallbackWhenUnsatisfiable(t *testing.T) {
 func TestPublicNameForBuild(t *testing.T) {
 	reg := New(testLogger())
 	reg.SetModelAliases(map[string]AliasTarget{
-		"gemma-4-26b": {Desired: aliasQAT, Previous: aliasFP8},
+		"aaa-openrouter-clone": {Desired: aliasQAT, Previous: aliasFP8, OpenRouterOnly: true},
+		"gemma-4-26b":          {Desired: aliasQAT, Previous: aliasFP8},
 	})
+
 	if got := reg.PublicNameForBuild(aliasFP8); got != "gemma-4-26b" {
 		t.Fatalf("previous build should map to alias, got %q", got)
 	}
@@ -467,7 +469,8 @@ func TestDesiredModelsForProviderConservative(t *testing.T) {
 	registerProviderWithModel(reg, "p-fp8", aliasFP8) // advertises the previous build
 	registerProviderWithModel(reg, "p-none", "mlx-community/unrelated")
 	reg.SetModelAliases(map[string]AliasTarget{
-		"gemma-4-26b": {Desired: aliasQAT, Previous: aliasFP8},
+		"gemma-4-26b":      {Desired: aliasQAT, Previous: aliasFP8},
+		"gemma-4-26b-paid": {Desired: aliasQAT, Previous: aliasFP8, OpenRouterOnly: true},
 	})
 
 	// p-fp8 advertises the previous build → it is told the desired build.

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -1740,11 +1740,14 @@ func (r *Registry) SetModelCatalog(entries []CatalogEntry) {
 // Previous build during a staggered rollout. No weights, no ramp. Retired holds
 // former members (rotated out by later upserts) — never routed, but used to
 // recognize a returning provider that was offline through a retirement as part
-// of this alias's fleet so it still receives desired_models.
+// of this alias's fleet so it still receives desired_models. OpenRouterOnly
+// targets resolve requests but never drive provider convergence or canonical
+// build-to-public-name mapping.
 type AliasTarget struct {
-	Desired  string
-	Previous string
-	Retired  []string
+	Desired        string
+	Previous       string
+	Retired        []string
+	OpenRouterOnly bool
 }
 
 // SetModelAliases installs the public-alias → {desired, previous} mapping. Pass
@@ -1779,7 +1782,11 @@ func (r *Registry) PublicNameForBuild(buildID string) string {
 	defer r.mu.RUnlock()
 	best := ""
 	for alias, t := range r.modelAliases {
+		if t.OpenRouterOnly {
+			continue
+		}
 		if t.Desired == buildID || t.Previous == buildID {
+
 			if best == "" || alias < best {
 				best = alias
 			}
@@ -2160,8 +2167,11 @@ func (r *Registry) mergeProviderModels(
 	// the builds that actually PASS validation below, not from the raw message.
 	aliasTargets := make([]AliasTarget, 0, len(r.modelAliases))
 	for _, t := range r.modelAliases {
-		aliasTargets = append(aliasTargets, t)
+		if !t.OpenRouterOnly {
+			aliasTargets = append(aliasTargets, t)
+		}
 	}
+
 	r.mu.RUnlock()
 	if !ok {
 		return nil, nil
@@ -3303,9 +3313,10 @@ func (r *Registry) DesiredModelsForProvider(providerID string) []protocol.Desire
 
 	var entries []protocol.DesiredModelEntry
 	for alias, t := range r.modelAliases {
-		if t.Desired == "" {
+		if t.OpenRouterOnly || t.Desired == "" {
 			continue
 		}
+
 		_, hasDesired := advertised[t.Desired]
 		_, hasPrevious := advertised[t.Previous]
 		// A provider advertising only a RETIRED member (offline through a

--- a/coordinator/store/interface.go
+++ b/coordinator/store/interface.go
@@ -657,19 +657,22 @@ type ModelRegistryRecord struct {
 	Files         []ModelVersionFile `json:"files,omitempty"`
 }
 
-// ModelAlias is a stable, consumer-facing model name (e.g. "gemma-4-26b") that
-// resolves to a single DESIRED concrete registry build (a raw HuggingFace id
-// such as "mlx-community/gemma-4-26B-A4B-it-qat-4bit"), with an optional
-// PreviousBuild that stays acceptable while providers converge on the desired
-// one. Consumers only ever see the alias; the coordinator resolves it to a
-// concrete build for routing/billing. This is what makes a quant swap
-// (fp8 → qat-4bit) invisible to clients: a rollout is just setting DesiredBuild,
-// a revert is setting it back. There are no weights, ramps, or migrations.
+// ModelAlias has two forms. A standard alias is a stable consumer-facing name
+// resolving to one desired concrete build plus an optional previous build while
+// providers converge. An OpenRouter-only alias clones a standard SourceModel in
+// the provider feed and request router, but is hidden from the public catalog
+// and provider desired-state fanout. The split keeps marketplace identities
+// independent without duplicating pricing, capacity, or rollout configuration.
 type ModelAlias struct {
-	AliasID       string `json:"alias_id"`
-	DisplayName   string `json:"display_name"`
-	DesiredBuild  string `json:"desired_build"`            // the single build providers should converge to
-	PreviousBuild string `json:"previous_build,omitempty"` // still-acceptable during rollout; "" when none
+	AliasID        string `json:"alias_id"`
+	DisplayName    string `json:"display_name"`
+	OpenRouterOnly bool   `json:"openrouter_only,omitempty"` // feed-only clone; hidden from the public catalog and provider convergence
+	SourceModel    string `json:"source_model,omitempty"`    // standard alias cloned by an OpenRouter-only entry
+	OpenRouterSlug string `json:"openrouter_slug,omitempty"` // marketplace identity for an OpenRouter-only entry
+	HuggingFaceID  string `json:"hugging_face_id,omitempty"` // metadata repository for an OpenRouter-only entry
+	DesiredBuild   string `json:"desired_build"`             // the single build providers should converge to
+	PreviousBuild  string `json:"previous_build,omitempty"`  // still-acceptable during rollout; "" when none
+
 	// RetiredBuilds is the alias's lineage: former desired/previous builds
 	// rotated out by later upserts. Kept so a provider that was offline through
 	// a retirement (still advertising only a retired build) is recognized as

--- a/coordinator/store/model_alias_test.go
+++ b/coordinator/store/model_alias_test.go
@@ -6,12 +6,17 @@ func TestMemoryModelAliasRoundTrip(t *testing.T) {
 	st := NewMemory(Config{})
 
 	alias := &ModelAlias{
-		AliasID:       "gemma-4-26b",
-		DisplayName:   "Gemma 4 26B",
-		DesiredBuild:  "mlx-community/gemma-4-26B-A4B-it-qat-4bit",
-		PreviousBuild: "mlx-community/gemma-4-26b-a4b-it-fp8",
-		Active:        true,
+		AliasID:        "gemma-4-26b",
+		DisplayName:    "Gemma 4 26B",
+		OpenRouterOnly: true,
+		SourceModel:    "gemma-4-26b-source",
+		OpenRouterSlug: "google/gemma-4-26b-it",
+		HuggingFaceID:  "google/gemma-4-26b-it",
+		DesiredBuild:   "mlx-community/gemma-4-26B-A4B-it-qat-4bit",
+		PreviousBuild:  "mlx-community/gemma-4-26b-a4b-it-fp8",
+		Active:         true,
 	}
+
 	if err := st.UpsertModelAlias(alias); err != nil {
 		t.Fatal(err)
 	}
@@ -29,6 +34,10 @@ func TestMemoryModelAliasRoundTrip(t *testing.T) {
 	if got.PreviousBuild != "mlx-community/gemma-4-26b-a4b-it-fp8" {
 		t.Fatalf("previous_build mismatch: %q", got.PreviousBuild)
 	}
+	if !got.OpenRouterOnly || got.SourceModel != "gemma-4-26b-source" || got.OpenRouterSlug != "google/gemma-4-26b-it" || got.HuggingFaceID != "google/gemma-4-26b-it" {
+		t.Fatalf("OpenRouter identity mismatch: %+v", got)
+	}
+
 	if got.CreatedAt.IsZero() || got.UpdatedAt.IsZero() {
 		t.Fatalf("timestamps not set: %+v", got)
 	}

--- a/coordinator/store/postgres.go
+++ b/coordinator/store/postgres.go
@@ -497,6 +497,13 @@ func (s *PostgresStore) migrate(ctx context.Context) error {
 		// upserts, so a provider returning from a long offline period is still
 		// recognized as part of the alias's fleet.
 		`DO $$ BEGIN ALTER TABLE model_aliases ADD COLUMN IF NOT EXISTS retired_builds JSONB NOT NULL DEFAULT '[]'::jsonb; EXCEPTION WHEN others THEN NULL; END $$`,
+		// OpenRouter-only aliases clone an existing public alias in the provider
+		// feed while keeping an independent API id and marketplace identities.
+		`DO $$ BEGIN ALTER TABLE model_aliases ADD COLUMN IF NOT EXISTS openrouter_only BOOLEAN NOT NULL DEFAULT FALSE; EXCEPTION WHEN others THEN NULL; END $$`,
+		`DO $$ BEGIN ALTER TABLE model_aliases ADD COLUMN IF NOT EXISTS source_model TEXT NOT NULL DEFAULT ''; EXCEPTION WHEN others THEN NULL; END $$`,
+		`DO $$ BEGIN ALTER TABLE model_aliases ADD COLUMN IF NOT EXISTS openrouter_slug TEXT NOT NULL DEFAULT ''; EXCEPTION WHEN others THEN NULL; END $$`,
+		`DO $$ BEGIN ALTER TABLE model_aliases ADD COLUMN IF NOT EXISTS hugging_face_id TEXT NOT NULL DEFAULT ''; EXCEPTION WHEN others THEN NULL; END $$`,
+
 		// Backfill desired_build from the old `builds` JSON: pick the highest-weight
 		// active build of each alias that hasn't been migrated yet. DISTINCT ON keeps
 		// exactly one (highest-weight) build per alias so the UPDATE...FROM join is

--- a/coordinator/store/postgres_model_registry.go
+++ b/coordinator/store/postgres_model_registry.go
@@ -416,11 +416,12 @@ func (s *PostgresStore) UpsertModelAlias(alias *ModelAlias) error {
 		return fmt.Errorf("store: marshal retired builds: %w", err)
 	}
 	_, err = s.pool.Exec(ctx, `
-		INSERT INTO model_aliases (alias_id, display_name, desired_build, previous_build, retired_builds, active, created_at, updated_at)
-		VALUES ($1, $2, $3, $4, $5, $6, COALESCE(NULLIF($7::timestamptz, '0001-01-01 00:00:00+00'::timestamptz), NOW()), NOW())
+		INSERT INTO model_aliases (alias_id, display_name, openrouter_only, source_model, openrouter_slug, hugging_face_id, desired_build, previous_build, retired_builds, active, created_at, updated_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, COALESCE(NULLIF($11::timestamptz, '0001-01-01 00:00:00+00'::timestamptz), NOW()), NOW())
 		ON CONFLICT (alias_id) DO UPDATE SET
-		  display_name = $2, desired_build = $3, previous_build = $4, retired_builds = $5, active = $6, updated_at = NOW()`,
-		alias.AliasID, alias.DisplayName, alias.DesiredBuild, alias.PreviousBuild, retiredJSON, alias.Active, alias.CreatedAt)
+		  display_name = $2, openrouter_only = $3, source_model = $4, openrouter_slug = $5, hugging_face_id = $6, desired_build = $7, previous_build = $8, retired_builds = $9, active = $10, updated_at = NOW()`,
+		alias.AliasID, alias.DisplayName, alias.OpenRouterOnly, alias.SourceModel, alias.OpenRouterSlug, alias.HuggingFaceID, alias.DesiredBuild, alias.PreviousBuild, retiredJSON, alias.Active, alias.CreatedAt)
+
 	if err != nil {
 		return fmt.Errorf("store: upsert model alias: %w", err)
 	}
@@ -434,9 +435,10 @@ func (s *PostgresStore) GetModelAlias(aliasID string) (*ModelAlias, bool, error)
 	var a ModelAlias
 	var retiredJSON []byte
 	err := s.pool.QueryRow(ctx, `
-		SELECT alias_id, display_name, desired_build, previous_build, retired_builds, active, created_at, updated_at
+		SELECT alias_id, display_name, openrouter_only, source_model, openrouter_slug, hugging_face_id, desired_build, previous_build, retired_builds, active, created_at, updated_at
 		FROM model_aliases WHERE alias_id = $1`, aliasID).
-		Scan(&a.AliasID, &a.DisplayName, &a.DesiredBuild, &a.PreviousBuild, &retiredJSON, &a.Active, &a.CreatedAt, &a.UpdatedAt)
+		Scan(&a.AliasID, &a.DisplayName, &a.OpenRouterOnly, &a.SourceModel, &a.OpenRouterSlug, &a.HuggingFaceID, &a.DesiredBuild, &a.PreviousBuild, &retiredJSON, &a.Active, &a.CreatedAt, &a.UpdatedAt)
+
 	if err == pgx.ErrNoRows {
 		return nil, false, nil
 	}
@@ -468,8 +470,9 @@ func (s *PostgresStore) ListModelAliases() ([]ModelAlias, error) {
 	defer cancel()
 
 	rows, err := s.pool.Query(ctx, `
-		SELECT alias_id, display_name, desired_build, previous_build, retired_builds, active, created_at, updated_at
+		SELECT alias_id, display_name, openrouter_only, source_model, openrouter_slug, hugging_face_id, desired_build, previous_build, retired_builds, active, created_at, updated_at
 		FROM model_aliases ORDER BY alias_id`)
+
 	if err != nil {
 		return nil, fmt.Errorf("store: list model aliases: %w", err)
 	}
@@ -479,7 +482,8 @@ func (s *PostgresStore) ListModelAliases() ([]ModelAlias, error) {
 	for rows.Next() {
 		var a ModelAlias
 		var retiredJSON []byte
-		if err := rows.Scan(&a.AliasID, &a.DisplayName, &a.DesiredBuild, &a.PreviousBuild, &retiredJSON, &a.Active, &a.CreatedAt, &a.UpdatedAt); err != nil {
+		if err := rows.Scan(&a.AliasID, &a.DisplayName, &a.OpenRouterOnly, &a.SourceModel, &a.OpenRouterSlug, &a.HuggingFaceID, &a.DesiredBuild, &a.PreviousBuild, &retiredJSON, &a.Active, &a.CreatedAt, &a.UpdatedAt); err != nil {
+
 			return nil, fmt.Errorf("store: scan model alias: %w", err)
 		}
 		a.RetiredBuilds = unmarshalRetiredBuilds(retiredJSON)

--- a/docs/reference/model-registry-format.md
+++ b/docs/reference/model-registry-format.md
@@ -149,6 +149,31 @@ At request time, [`resolveRequestedModel`](../../coordinator/api/consumer.go) re
 
 The concrete build id is what is used for routing, billing, and serving; the public alias is echoed back to the consumer.
 
+## OpenRouter-only aliases
+
+OpenRouter feed clones are managed separately from rollout aliases:
+
+- `GET /v1/admin/models/openrouter-aliases`
+- `POST /v1/admin/models/openrouter-aliases`
+- `DELETE /v1/admin/models/openrouter-aliases/{id}`
+
+```json
+{
+  "id": "gemma-4-26b-a4b-it",
+  "source_model": "gemma-4-26b",
+  "openrouter_slug": "google/gemma-4-26b-it",
+  "hugging_face_id": "google/gemma-4-26b-it"
+}
+```
+
+`source_model` must be an active standard alias. The clone appears only in
+`GET /v1/models/openrouter`; it is omitted from the normal `GET /v1/models`
+catalog. OpenRouter can send the clone's `id` to the inference API, where it
+resolves through the source alias's current desired/previous build pointers.
+The source supplies pricing, context limits, features, readiness, datacenters,
+and every other feed field. Future source build migrations therefore update the
+clone automatically; only `id`, `openrouter.slug`, and `hugging_face_id` differ.
+
 ## Admin model actions
 
 `POST /v1/admin/models/{model_id}/{action}`


### PR DESCRIPTION
## Summary

- add dedicated CRUD endpoints for OpenRouter-only model aliases
- clone all non-identity feed fields from an active standard source alias
- allow independent `id`, `openrouter.slug`, and `hugging_face_id`
- route the custom id through the source alias's live desired/previous build pointers
- keep OpenRouter-only aliases out of `/v1/models`, canonical public naming, provider convergence, and hard-swap state
- persist the configuration in memory/Postgres and document the API

## API

```json
POST /v1/admin/models/openrouter-aliases
{
  "id": "gemma-4-26b-a4b-it",
  "source_model": "gemma-4-26b",
  "openrouter_slug": "google/gemma-4-26b-it",
  "hugging_face_id": "google/gemma-4-26b-it"
}
```

Also adds:

- `GET /v1/admin/models/openrouter-aliases`
- `DELETE /v1/admin/models/openrouter-aliases/{id}`

## Before

```mermaid
flowchart LR
  subgraph Behavior
    A["OpenRouter model feed"] --> B["gemma-4-26b only"]
    B --> C["Fixed id, slug, and Hugging Face identity"]
    D["Need a second marketplace identity"] --> E["No feed-only alias configuration"]
  end
  subgraph Code
    F["handleListModelsOpenRouter"] --> G["openRouterAliasEntries"]
    G --> H["Standard aliases"]
    H --> I["Concrete build metadata"]
  end
```

## After

```mermaid
flowchart LR
  subgraph Behavior
    A["POST OpenRouter alias"] --> B["Clone gemma-4-26b"]
    B --> C["Custom id, slug, and Hugging Face id"]
    C --> D["GET /v1/models/openrouter"]
    C --> E["OpenRouter request using custom id"]
    E --> F["Source alias current build"]
    F --> G["Existing provider fleet"]
    C -.-> H["Not listed by GET /v1/models"]
  end
  subgraph Code
    I["openrouter_alias_handlers"] --> J["ModelAlias persistence"]
    J --> K["syncModelAliases"]
    K --> L["Route-only AliasTarget"]
    J --> M["openRouterAliasEntries"]
    M --> N["Copy complete source entry"]
    N --> O["Override three identities"]
    L --> P["ResolveModel"]
  end
```

## Invariants

- source must be an active standard alias
- clone follows future source build migrations automatically
- pricing, context, features, readiness, and datacenters remain identical to the source
- OpenRouter-only aliases never enter provider `desired_models` or hard-swap logic
- `PublicNameForBuild` ignores OpenRouter-only aliases

## Verification

- `go test ./api ./registry ./store`
- focused CRUD/feed/routing/source-migration tests
- rebased onto current `origin/master`

No production mutation or deployment is included.