### PR TITLE
ci: restore CodeQL as a fail-closed gate on master

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,17 @@
+# Deliberately narrow: there is no catch-all owner, so this adds review
+# requests only on the CI and code-scanning config — not on every PR.
+#
+# Purpose is drift resistance. The CodeQL gate is enforced by required status
+# checks on master (ruleset "Branch Rules"), which is fail-closed against
+# *deleting* .github/workflows/codeql.yml — the contexts stop reporting and
+# nothing merges. It is NOT fail-closed against a PR that keeps the job names
+# but weakens what they scan (drops a matrix language, widens paths-ignore).
+# Owner review on these paths is the mitigation for that case.
+#
+# Note: ruleset "Branch Rules" currently has require_code_owner_review=false,
+# so these are review *requests*, not merge blockers. Flip that flag to make
+# them binding.
+
+/.github/workflows/    @Layr-Labs/darkbloom
+/.github/codeql/       @Layr-Labs/darkbloom
+/.github/dependabot.yml @Layr-Labs/darkbloom

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,29 @@
+name: darkbloom
+
+# Scope exclusions live here, NOT as `paths-ignore` on the workflow triggers —
+# a path-filtered job never reports its check context, and the analyze jobs are
+# required checks on master. See .github/workflows/codeql.yml.
+
+paths-ignore:
+  # Vendored upstream trees. libs/* are submodules (MLX and friends); we do not
+  # own that code and cannot fix findings in it.
+  - libs
+  # Build output and dependency trees.
+  - "**/node_modules"
+  - "**/.build"
+  - "**/.next"
+  - "**/target"
+  # Test fixtures: intentionally contain throwaway keys and crypto scaffolding
+  # that trips the credential queries.
+  - coordinator/internal/e2e/testdata
+
+# NOTE: for Swift, `paths-ignore` has limited effect. Swift is extracted by
+# tracing the compiler, so files the build compiles get extracted regardless —
+# meaning the weekly Swift run will surface findings from libs/mlx-swift and
+# libs/mlx-swift-lm alongside provider-swift's own. Dismiss those as
+# "used in tests"/"won't fix" per-alert; do not try to fix upstream MLX here.
+
+# Query suite is deliberately left at the default. `security-extended` roughly
+# doubles the alert count, and an alert flood on a freshly re-enabled gate is
+# how the gate ends up switched off again. Revisit once the 12-alert backlog
+# from the June 2026 snapshot is triaged to zero.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,143 @@
+name: CodeQL
+
+# CodeQL ran on this repo via GitHub "default setup" from 2026-04-14 to
+# 2026-06-16, then was switched off in the repo UI — silently, because default
+# setup keeps no config in git. Two months of PRs merged unscanned while the
+# Security tab still showed the June alert snapshot, which reads as "we scan"
+# to anyone auditing it.
+#
+# This is the advanced setup: the config lives in git, so disabling it takes a
+# reviewed PR on master. The jobs in `analyze` are registered as required
+# status checks on master (ruleset "Branch Rules"), which makes removal
+# fail-closed — delete this file and the required contexts never report, so
+# nothing merges.
+#
+# DO NOT add `paths` / `paths-ignore` filters to these triggers. A job that is
+# skipped by a path filter never reports its check context, and a required
+# context that never reports blocks the merge forever. Scope exclusions belong
+# in .github/codeql/codeql-config.yml instead.
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  schedule:
+    # Mondays 09:17 UTC. Catches drift on master (and runs the Swift job) even
+    # in a week where no PR happens to touch the affected language.
+    - cron: "17 9 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: codeql-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: CodeQL Analyze (${{ matrix.language }})
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 45
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+    strategy:
+      # One language failing must not cancel the others — a Rust extractor
+      # hiccup should not silently drop Go and TypeScript coverage.
+      fail-fast: false
+      matrix:
+        include:
+          # Workflow supply chain: pinned-action drift, untrusted checkout of
+          # PR head in the agent workflows, missing `permissions:` blocks.
+          - language: actions
+            build-mode: none
+          # coordinator/ + e2e/ live in the single root Go module.
+          - language: go
+            build-mode: autobuild
+          # console-ui/, admin-ui/, landing/.
+          - language: javascript-typescript
+            build-mode: none
+          # scripts/ benchmark + soak harnesses.
+          - language: python
+            build-mode: none
+          # coordinator/promptsidecar — parses untrusted prompt text.
+          - language: rust
+            build-mode: none
+    steps:
+      - name: Checkout
+        # Deliberately no `submodules: recursive`. libs/mlx, libs/mlx-swift and
+        # libs/mlx-swift-lm are vendored upstream trees; extracting them would
+        # bury first-party findings under third-party noise.
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set up Go
+        if: matrix.language == 'go'
+        # Go is the one language here using autobuild, so it needs the toolchain
+        # the module declares rather than whatever the runner image ships.
+        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
+        with:
+          go-version-file: go.mod
+          cache: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@faaa5d804fc648d0fdb28822a8e36cf7d0a6132c # v4.37.7
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          config-file: ./.github/codeql/codeql-config.yml
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@faaa5d804fc648d0fdb28822a8e36cf7d0a6132c # v4.37.7
+        with:
+          category: "/language:${{ matrix.language }}"
+
+  analyze-swift:
+    name: CodeQL Analyze (swift)
+    # Weekly and on demand only — never on pull_request, so this job is not a
+    # required check and cannot block a merge.
+    #
+    # provider-swift is the highest-value target in the repo (it decrypts
+    # prompts and holds the Secure Enclave key), but a cold build compiles the
+    # full Cmlx C++/Metal tree at ~20 min on a paid macOS runner, and CodeQL's
+    # autobuild is what failed here in June 2026 ("unsuccessful execution",
+    # 0 rules). Per-PR Swift analysis would make every PR slow and occasionally
+    # red, which is the fastest route back to someone disabling code scanning.
+    # Weekly + non-blocking keeps the coverage and drops that pressure.
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: blacksmith-12vcpu-macos-latest
+    timeout-minutes: 120
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          submodules: recursive
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@faaa5d804fc648d0fdb28822a8e36cf7d0a6132c # v4.37.7
+        with:
+          languages: swift
+          build-mode: manual
+          config-file: ./.github/codeql/codeql-config.yml
+
+      - name: Build provider-swift
+        working-directory: provider-swift
+        # Intentionally NOT restoring the SwiftPM cache that ci.yml uses. Swift
+        # is extracted by tracing real compiler invocations, so a warm .build
+        # would make this a no-op and yield an empty database ("no source code
+        # was seen"). The cold build is the point.
+        #
+        # No mlx.metallib staging either: the metallib is a runtime Metal
+        # artifact, needed to *run* the provider, not to compile it.
+        run: swift build
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@faaa5d804fc648d0fdb28822a8e36cf7d0a6132c # v4.37.7
+        with:
+          category: "/language:swift"

--- a/docs/operations/code-scanning.md
+++ b/docs/operations/code-scanning.md
@@ -19,6 +19,19 @@ recorded that it had ever been on, or that it stopped. Consequences:
 
 Restored as advanced setup (config in git) in `ci/restore-codeql-gate`.
 
+### Don't confuse this with GitHub's "code quality" run
+
+Every PR also gets checks named `Analyze (go)`, `Analyze (javascript-typescript)`
+and `Analyze (python)` from a run titled **"Code Quality: PR #N"**, with
+`path: dynamic/github-code-scanning/codeql` and `event: dynamic`. That is
+GitHub's *code quality* feature — CodeQL-powered, no config in this repo, and
+it uploads **no security analyses** (nothing appeared under
+`/code-scanning/analyses` from it).
+
+It is easy to mistake those checks for security scanning, which is plausibly
+part of why the gap went unnoticed for two months. The security analyses are
+the ones whose `analysis_key` is `.github/workflows/codeql.yml:analyze`.
+
 ## What is scanned
 
 | Language | Build mode | Trigger | Required check | Covers |
@@ -85,6 +98,17 @@ gh api repos/Layr-Labs/d-inference/rulesets/15055885 \
 
 If the analyses query returns nothing newer than a week, the gate is broken
 regardless of what the Security tab shows. That is the check to automate next.
+
+Baseline from the first advanced-setup run (PR #644, 2026-08-19) — a later run
+reporting materially fewer rules means coverage silently narrowed:
+
+| Category | Rules | vs June default setup |
+|---|---|---|
+| `/language:actions` | 17 | 17 |
+| `/language:python` | 43 | 43 |
+| `/language:javascript-typescript` | 87 | 86 |
+| `/language:go` | 34 | 34 |
+| `/language:rust` | 25 | never ran |
 
 ## Alert backlog
 

--- a/docs/operations/code-scanning.md
+++ b/docs/operations/code-scanning.md
@@ -1,0 +1,112 @@
+# Code scanning (CodeQL)
+
+Static analysis gate for the repo. Config: [`.github/workflows/codeql.yml`](../../.github/workflows/codeql.yml)
+and [`.github/codeql/codeql-config.yml`](../../.github/codeql/codeql-config.yml).
+
+## History
+
+CodeQL ran via GitHub **default setup** (a UI toggle, no config in git) from
+**2026-04-14** to **2026-06-16**, then was switched off. Nothing in the repo
+recorded that it had ever been on, or that it stopped. Consequences:
+
+- Two months of merges (Jun–Aug 2026) went unscanned.
+- The Security tab kept serving the June snapshot — 12 open alerts — so the
+  repo still *looked* scanned. For audit purposes this is worse than never
+  having enabled it: it invites a reviewer to trust a stale result.
+- Swift never worked under default setup. Every Swift analysis recorded
+  `"unsuccessful execution", rules_count: 0` — autobuild could not build the
+  package. Likely the reason the whole setup was abandoned.
+
+Restored as advanced setup (config in git) in `ci/restore-codeql-gate`.
+
+## What is scanned
+
+| Language | Build mode | Trigger | Required check | Covers |
+|---|---|---|---|---|
+| `actions` | none | PR + push + weekly | yes | `.github/workflows/**` supply chain |
+| `go` | autobuild | PR + push + weekly | yes | `coordinator/`, `e2e/` (one root module) |
+| `javascript-typescript` | none | PR + push + weekly | yes | `console-ui/`, `admin-ui/`, `landing/` |
+| `python` | none | PR + push + weekly | yes | `scripts/` harnesses |
+| `rust` | none | PR + push + weekly | yes | `coordinator/promptsidecar` |
+| `swift` | manual | **weekly + dispatch only** | no | `provider-swift/` |
+
+`libs/*` submodules are excluded — vendored upstream MLX, not ours to fix.
+
+### Why Swift is weekly and non-blocking
+
+`provider-swift` is the highest-value target in the repo: it decrypts consumer
+prompts and holds the Secure Enclave key. It is also the most expensive thing
+to analyze — a cold build compiles the full Cmlx C++/Metal tree, ~20 min on a
+paid `blacksmith-12vcpu-macos-latest` runner, and Swift extraction requires a
+cold build (a warm `.build` produces an empty database, since extraction traces
+real compiler invocations).
+
+Per-PR Swift analysis would add ~30–45 min of macOS runner time to every PR and
+reintroduce the exact failure that killed the June setup. A slow, occasionally
+red required check is the most reliable way to get code scanning disabled again.
+Weekly keeps the coverage; non-blocking keeps the pressure off.
+
+**This is a real gap**: a Swift regression can merge on Monday and go unflagged
+until the following Monday. Accepted deliberately. Revisit by making the build
+reliable and cached-but-traceable first, then promote to per-PR.
+
+## Why it can't be silently switched off again
+
+Three layers, in order of strength:
+
+1. **Config in git.** Advanced setup, not the UI toggle. Turning it off means a
+   PR against `master`, which needs 1 approval, thread resolution, and signed
+   commits (ruleset "Branch Rules"). It shows up in `git log`.
+2. **Fail-closed required checks.** The five `analyze` jobs are required status
+   checks on `master`. Delete the workflow and those contexts never report, so
+   *nothing merges* until someone restores it or an admin edits the ruleset.
+   This is why the workflow carries no `paths`/`paths-ignore` filters — a
+   path-skipped job also never reports, which would deadlock every doc-only PR.
+3. **Owner review on the config paths.** Required checks are fail-closed
+   against deletion but not against a PR that keeps the job names while
+   weakening coverage (dropping a matrix language, widening `paths-ignore`).
+   `.github/CODEOWNERS` routes those paths to `@Layr-Labs/darkbloom`.
+
+### Verifying the gate is live
+
+```bash
+# Advanced setup in use, default setup off:
+gh api repos/Layr-Labs/d-inference/code-scanning/default-setup -q .state   # not-configured
+
+# Most recent analysis per language on master — all should be recent:
+gh api 'repos/Layr-Labs/d-inference/code-scanning/analyses?ref=refs/heads/master&per_page=20' \
+  -q '.[] | "\(.created_at[0:10]) \(.category) results=\(.results_count) err=\(.error)"'
+
+# Required contexts include the CodeQL jobs:
+gh api repos/Layr-Labs/d-inference/rulesets/15055885 \
+  -q '.rules[] | select(.type=="required_status_checks")
+      | .parameters.required_status_checks[].context'
+```
+
+If the analyses query returns nothing newer than a week, the gate is broken
+regardless of what the Security tab shows. That is the check to automate next.
+
+## Alert backlog
+
+12 alerts are open, frozen at the 2026-06-16 snapshot and **unverified against
+current code**. Triage is deliberately out of scope of the re-enablement so the
+first fresh run can re-baseline them.
+
+| # | Severity | Rule | Location |
+|---|---|---|---|
+| 74 | high | `actions/untrusted-checkout/high` | `.github/workflows/codex.yml:59` |
+| 69 | high | `go/disabled-certificate-check` | `coordinator/mdm/mdm.go:120` |
+| 8, 9, 10 | high | `js/clear-text-storage-of-sensitive-data` | `console-ui/src/hooks/useAuth.ts:26,47,78` |
+| ×7 | medium | `actions/missing-workflow-permissions` | `benchmarks`, `ci`, `claude`, `codex`, `integration` |
+
+The 7 medium alerts are mechanical: five workflows have no top-level
+`permissions:` block, so they inherit the repo default token scope.
+
+## Maintenance
+
+Actions are pinned by SHA. `.github/dependabot.yml` covers `gomod` and `npm`
+but **not** `github-actions`, so `github/codeql-action` pins do not
+auto-update. GitHub deprecates old `codeql-action` majors and eventually
+hard-fails them; when that notice arrives, bump the two pinned SHAs in
+`codeql.yml` together. Adding a `github-actions` dependabot ecosystem would
+automate this at the cost of more PR volume.


### PR DESCRIPTION
## Why

CodeQL ran on this repo via GitHub **default setup** from **2026-04-14** to **2026-06-16**, then was switched off in the repo UI. Default setup keeps no config in git, so nothing recorded that it had ever been on, or that it stopped:

- ~2 months of merges (Jun 16 → today) went **unscanned**.
- The Security tab kept serving the June snapshot — 12 open alerts, 4 high — so the repo still *looked* scanned. For audit purposes that's worse than never enabling it: it invites a reviewer to trust a stale result.
- Swift **never worked** under default setup. Every Swift analysis recorded `"unsuccessful execution", rules_count: 0` — autobuild couldn't build the package. Probably why the whole thing was abandoned.

Verified current state before this PR:

```
$ gh api repos/Layr-Labs/d-inference/code-scanning/default-setup -q .state
not-configured
$ gh api '.../code-scanning/analyses?ref=refs/heads/master&per_page=1' -q '.[0].created_at'
2026-06-15T23:25:03Z
```

No other SAST exists either — no gosec, semgrep, trivy, govulncheck, snyk, or osv-scanner anywhere in `.github/`.

## What changed

Advanced setup, config in git.

| Language | Build mode | Trigger | Required check | Covers |
|---|---|---|---|---|
| `actions` | none | PR + push + weekly | yes | `.github/workflows/**` supply chain |
| `go` | autobuild | PR + push + weekly | yes | `coordinator/`, `e2e/` (one root module) |
| `javascript-typescript` | none | PR + push + weekly | yes | `console-ui/`, `admin-ui/`, `landing/` |
| `python` | none | PR + push + weekly | yes | `scripts/` harnesses |
| `rust` | none | PR + push + weekly | yes | `coordinator/promptsidecar` |
| `swift` | manual | **weekly + dispatch only** | no | `provider-swift/` |

- `.github/workflows/codeql.yml` — `codeql-action` pinned by SHA (v4.37.7), matching repo convention.
- `.github/codeql/codeql-config.yml` — excludes vendored `libs/*` submodules, build output, e2e crypto testdata. Query suite left at **default** on purpose; `security-extended` roughly doubles alert count and an alert flood on a freshly re-enabled gate is how it gets switched off again.
- `.github/CODEOWNERS` — narrow, **no catch-all** (so no new review requests on ordinary PRs); owner review on the CI/code-scanning config paths only.
- `docs/operations/code-scanning.md` — coverage table, the Swift tradeoff, how the gate resists removal, verification commands, and the 12-alert backlog.

## Behavior: before / after

```mermaid
flowchart TB
  subgraph Before["Before — default setup, switched off 2026-06-16"]
    direction TB
    B1[PR opened] --> B2["required checks:<br/>Coordinator Tests / Lint<br/>Provider Tests<br/>Console UI Lint &amp; Build<br/>E2E Integration"]
    B2 --> B3{all green?}
    B3 -->|yes| B4[merge to master]
    B3 -->|no| B5[blocked]
    B4 --> B6["no static analysis<br/>anywhere in the pipeline"]
    B7["Security tab<br/>12 open alerts<br/>frozen at 2026-06-16"] -.->|"stale, reads as<br/>'we scan'"| B6
  end
  subgraph After["After — advanced setup, config in git"]
    direction TB
    A1[PR opened] --> A2[existing 5 required checks]
    A1 --> A3["CodeQL Analyze x5<br/>actions - go - js/ts<br/>python - rust"]
    A2 --> A4{all green?}
    A3 --> A4
    A4 -->|yes| A5[merge to master]
    A4 -->|no| A6[blocked]
    A5 --> A7["alerts uploaded per<br/>language category"]
    A8["weekly cron Mon 09:17 UTC"] --> A9["CodeQL Analyze swift<br/>cold build, non-blocking"]
    A9 --> A7
  end
```

## Code: before / after

```mermaid
flowchart LR
  subgraph CBefore["Before"]
    direction TB
    C1["(no codeql config in repo)"]
    C2["GitHub UI toggle<br/>default-setup: off"]
    C3["ruleset 15055885<br/>5 required contexts"]
    C1 ~~~ C2 ~~~ C3
  end
  subgraph CAfter["After"]
    direction TB
    D1[".github/workflows/codeql.yml"] --> D2["job analyze<br/>matrix: 5 langs<br/>fail-fast: false"]
    D1 --> D3["job analyze-swift<br/>if: schedule or dispatch"]
    D2 --> D4["init@v4.37.7 pinned"]
    D3 --> D4
    D4 --> D5[".github/codeql/codeql-config.yml<br/>paths-ignore libs, build output"]
    D5 --> D6["analyze@v4.37.7<br/>category /language:*"]
    D7[".github/CODEOWNERS<br/>.github/workflows + codeql"] -.->|"review request<br/>on config edits"| D1
    D8["ruleset 15055885<br/>+5 CodeQL contexts<br/>(applied after merge)"] -.->|"fail-closed:<br/>no file = no report = no merge"| D2
  end
```

## Design decisions worth reviewing

**1. Swift is weekly and non-blocking.** `provider-swift` decrypts consumer prompts and holds the Secure Enclave key — the highest-value target here. It's also the most expensive to analyze: a cold build compiles the full Cmlx C++/Metal tree (~20 min on `blacksmith-12vcpu-macos-latest`), and Swift extraction *requires* a cold build because it traces real compiler invocations — restoring the SwiftPM cache that `ci.yml` uses would make `swift build` a no-op and yield an empty database. Per-PR Swift would add ~30–45 min of paid macOS time to every PR and reintroduce the exact failure that killed the June setup.

This is a **real gap**: a Swift regression can merge Monday and go unflagged until the next Monday. Accepted deliberately, documented, and revisitable.

**2. No `paths`/`paths-ignore` on the triggers.** A path-skipped job never reports its check context, and a required context that never reports blocks the merge *forever* — a doc-only PR would deadlock. Cost: every PR runs 5 cheap ubuntu jobs. Scope exclusions live in the config file instead. This is also what makes removal fail-closed.

**3. No `submodules: recursive` on the ubuntu jobs.** `libs/mlx*` are vendored upstream trees; extracting them would bury first-party findings. The Swift job needs them to build, and `paths-ignore` has limited effect on traced compilation, so the weekly Swift run will surface upstream MLX findings — noted in the config file.

## Follow-ups (not in this PR)

- **Triage the 12-alert backlog** once a fresh run re-baselines it. 4 high: `actions/untrusted-checkout/high` (`codex.yml:59`), `go/disabled-certificate-check` (`coordinator/mdm/mdm.go:120`), 3× `js/clear-text-storage-of-sensitive-data` (`console-ui/src/hooks/useAuth.ts`). The 7 mediums are mechanical — 5 workflows have no top-level `permissions:` block.
- **Required status checks**: the 5 `CodeQL Analyze (...)` contexts get added to ruleset `15055885` **after** this merges. Deliberately not before — with 100 open PRs, a required context that doesn't exist on their branches blocks all of them.
- `.github/dependabot.yml` has no `github-actions` ecosystem, so the pinned `codeql-action` SHAs won't auto-update.

## Test plan

- `actionlint` clean against the repo's blacksmith runner-label vocabulary (`.github/actionlint.yaml`).
- Both YAML files parse.
- The real test is this PR's own checks: all 5 `CodeQL Analyze (...)` jobs must go green here before merge. `rust` is the unproven one — it was never analyzed under default setup (listed as available, but no analysis records exist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/644"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789761276&installation_model_id=21733&pr_number=644&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F644&signature=5305019ff2b30a444854c426be5270950043b8298bd2fb3346c3a9469153b561"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->