### PR TITLE
perf(cbv2): default-on prefill stack — solo stripe, prompt narrowing, packed prefill (Qwen3.6), mean-TTFT cap

### DIFF
--- a/docs/reports/2026-08-19-solo-prefill-stripe-experiment.md
+++ b/docs/reports/2026-08-19-solo-prefill-stripe-experiment.md
@@ -68,3 +68,84 @@ The measured prefill levers of consequence remain LM-head narrowing (removes the
 [1,chunk,248320] logits transient — which striping *quadruples* to 970 MiB/chunk) and the
 attention L² term. Revisit striping after LM-head narrowing lands: the stripe's residual
 overhead-amortization win is additive and its main memory cost disappears.
+
+## Addendum (same day, later): verdict change — trust x stripe interaction
+
+The standalone-wash verdict above is superseded by a 2x2 at 8K (3 iters/cell, HPM):
+
+| cell | median TTFT | vs base |
+|---|---:|---:|
+| base (`=1`, 512) | 6208.7 ms | — |
+| stripe alone (`=1`) | 6639.4 ms | +6.9%* |
+| trust alone (512) | 6265.6 ms | +0.9%* |
+| **trust + stripe** | **5350.2 ms (~1,531 tok/s)** | **-13.8%** |
+
+*single-iteration battery-droop-affected cells (trust-512 climbed +11.7% within one
+invocation; stripe-alone ran last at 43% battery). The trust+stripe cell ran second,
+against the drift, with 2.8% spread — the robust result. Replicate plugged-in before PR.
+
+Mechanism — serial-bubble unmasking: per chunk, the 80 expert-descriptor drains and the
+chunk boundary (eval/submit) are bubbles in series. With drains on, boundaries are masked
+(stripe alone ≈ wash). Trust removes drains; the boundary cost is unmasked; the stripe
+removes 3/4 of the boundaries. Since #638 (trust default) merged upstream, THE fleet
+config is the right-hand column: solo stripe is worth ~-9% on top of trust, not the
+standalone ~0%.
+
+## Addendum: engagement verification
+
+- Production path proven striped: with a temporary env-gated plan log, a 4096-token
+  benchmark planned `[128]` (warm-up), then `[2048], [2048]` — admission AND running
+  paths striped. Debug print reverted before commit.
+- Expert-tile route statically verified at stripe width: the classifier explicitly
+  qualifies 16,384 assignments, and `max_tile_count = M/32 + E - 1` sizes descriptors
+  dynamically (767 at M=16,384) — no capacity cliff.
+- Both env echoes present in every arm JSON (`soloPrefillStripeTokens`, `SLICES`).
+
+## Addendum: multi-request prefill baseline (arrival-invariance, 4 x 8K, HPM)
+
+| arm | burst row-TTFTs (s) | aggregate prefill tok/s |
+|---|---|---:|
+| base (`=1`) | 24.98 / 24.98 / 24.98 / 24.98 | 1,312 |
+| trust | 24.12 / 24.12 / 24.12 / 24.12 | 1,359 |
+| solo reference | 6.2 (one request) | 1,319 (base) / 1,531 (trust+stripe) |
+
+Two structural findings (single iteration; charger attached mid-second-run):
+1. **4 concurrent prefills ≈ 1x aggregate throughput** (1,312 vs solo 1,319): rows run as
+   separate forwards, so weights re-stream per row per chunk. This is the quantified case
+   for packed prefill (`CBv2PackedPrefillSteppableModel` — Gemma conforms, Qwen cannot
+   until the recurrent prefill seam exists).
+2. **Every burst row's TTFT equals the makespan** (all finish at 24.98 s): the 512
+   interleave is fair and mean-TTFT-pessimal. FCFS run-to-completion would deliver
+   ~6.2/12.5/18.7/25.0 s at identical throughput — mean TTFT halved by policy alone.
+
+## Prefill roadmap (consolidated, dependency-ordered)
+
+1. **Rebase onto #638 (trust default — merged upstream)** and replicate trust x stripe
+   plugged-in; if -13.8% holds, promote `soloPrefillStripeTokens=2048` as the serving
+   default. Admission note: a request arriving mid-stripe waits one striped step
+   (~1.3-1.4 s worst case at 8K rates, vs ~0.4 s today) before normal interleaving
+   resumes — no queueing-policy change, no serialized prefill; Phase-2 yields shrink it.
+2. **Recurrent prefill seam in EngineLoopV2** — one refactor, three payoffs:
+   (a) **LM-head narrowing** (Qwen `.evaluationOnly`/`.lastPositionLogits`): ~-14% at 8K,
+   removes the 970 MiB/chunk logits transient striping amplifies;
+   (b) **packed prefill for Qwen**: closes the measured 4x-requests = 1x-throughput gap
+   (experts are weight-bandwidth-bound, so cohort weight sharing is the real lever);
+   (c) clean seam for stripe yield points.
+3. **Mean-TTFT scheduling policy**: cap concurrent partial prefills (FCFS-lean) — mean
+   TTFT ~halves at identical throughput per the measured all-rows-finish-together burst.
+4. **qL512 (#640)**: repair 4 review findings; measured +2.4% (8K) / +3.7% (32K).
+5. **Prefill-only stripe relaxation**: stripe when no decode row exists (multi-prefill).
+6. **Layer-quantum preemption (stripe-major Phase 2)**: yield to decode at layer-group
+   boundaries inside stripes; extends trust x stripe to busy providers (ITL bound
+   ~35-100 ms); the Gemma `PREFILL_CHUNK_EVAL` mechanism is the seam embryo.
+7. **Tiny-GEMM fusion**: GDN 4-into-1 input projection; router+shared-gate fusion
+   (35.8% of dense QMM dispatches carry 1.29% of the FLOPs).
+8. **GDN chunkwise-parallel scan** (~5-7%; requires tolerance-based parity, not bitwise).
+9. **Mask+softmax fused into the QK epilogue** (removes 2 of 6 score traversals;
+   641 GiB per 64K prefill).
+10. **Wavefront/concurrent dispatch**: GPU busy union == sum (zero overlap ever) at 24%
+    of peak — the structural 2x lever; needs MLX concurrent-encoding work.
+11. **Sparse prefill attention** for >=32K (probe-gated); tracer measures per-head mass
+    first. The only lever that beats the L^2 term at 64K+.
+12. **Prefix cache enablement** (product decision): hybrid GDN state makes cached
+    prefixes 3.8x smaller than an all-attention peer; off by default today.

--- a/docs/reports/2026-08-19-solo-prefill-stripe-experiment.md
+++ b/docs/reports/2026-08-19-solo-prefill-stripe-experiment.md
@@ -1,0 +1,70 @@
+# Solo-Prefill Stripe Experiment — 2026-08-19
+
+Feature branch: `perf/cbv2-stripe-major-prefill` (superproject) + `perf/cbv2-solo-prefill-stripe`
+(mlx-swift-lm). Opt-in scheduler feature + decision-grade A/B on the 2026-08-18 trace-report
+machine (M4 Max, Qwen3.6 35B-A3B, `--scheduler-prefill`, contiguous KV, cold prefills).
+
+## Feature
+
+`CBv2SchedulerConfig.soloPrefillStripeTokens` (env `DARKBLOOM_CBV2_SOLO_PREFILL_STRIPE`,
+default off): when exactly ONE live text request holds the scheduler's entire schedulable
+population (no decode-ready row, no other live running row, no waiter, no multimodal
+blocks), its prefill chunk — and when needed the step budget — extends from 512 to the
+stripe. KV-capacity failure on a striped chunk shrinks once to the plain chunk (running and
+admission paths); never preempts, never drops a step. Paged pool sizes
+`maxPrefillChunk = max(prefillChunkSize, stripe)` (lockstep). Benchmark JSON echoes the
+effective stripe. Tests: 10/10 new (`CBv2SoloStripeTests`, `CBv2SoloStripeEngineTests` —
+striped forward shapes, token-identical output), 153/153 pre-existing scheduler/parity/
+packed/prefix suites green.
+
+## Measurement rounds (all preserved under /tmp/stripe-major/results/)
+
+| Round | Posture | Status |
+|---|---|---|
+| 1 | battery LPM + concurrent compiles | **VOID** (compile contention, 3.4x slow controls) |
+| 2 "clean" | battery, Low Power Mode (`powermode 1`), quiet | valid **as LPM posture only** |
+| 3 "clean-ac" | battery, **High Power Mode** (`powermode 2`), quiet | **decision-grade** (anchor PASS) |
+
+Validity anchor: round-3 control 8K median **6330.3 ms** vs the 2026-08-18 plugged-in
+baseline **6406.8 ms** = −1.2% → posture parity proven. (Round-2 control was 13,136.7 ms =
+2.05x baseline: Low Power Mode halves effective GPU throughput on this workload.)
+
+## Results (medians of 3 cold iterations)
+
+| Posture | 8K stripe2048 vs control | 16K stripe2048 vs control |
+|---|---|---|
+| Low Power Mode | **+11.8% (regression)** | −2.3% (wash) |
+| High Power Mode | **−1.5% (wash;** spreads 2.2/3.3%) | **−3.9%** (suggestive; control spread 7.9%) |
+
+The LPM-only stripe first-iteration penalty (+23%/+14%) did not replicate under HPM
+(it1 fastest in 3/4 cells) — an LPM clock-ramp/JIT artifact, not an intrinsic stripe cost.
+
+## Why the predicted −10-15% did not appear (falsified assumption)
+
+The stripe estimate priced two effects as time: expert-tile occupancy (measured 57.6% at
+512-token chunks → ~100% at 2048) and 4x fewer full weight reads. Both are real as
+*counters* but nearly free as *time* on this workload: every layer touches ~all 256
+experts at either chunk size, so expert weight traffic per layer per token is unchanged,
+and the routed GEMMs are weight-bandwidth-bound — half-empty 32-row tiles idle ALUs the
+memory system was never feeding anyway, and "weight re-reads" are the GEMM operand
+streaming that already overlaps compute. What the stripe actually harvests is per-chunk
+fixed cost (80 expert-descriptor drains, routing sort chain, dispatch/launch, graph
+build): a few percent, matching observation. Tile occupancy is a compute-utilization
+metric; converting it to time requires the kernel to be ALU-bound, which this one is not.
+
+## Operational finding (fleet-relevant)
+
+Stripe benefit is **power-posture-dependent with opposite signs**: LPM machines regress
+~12% at 8K under striping while HPM machines see a wash-to-small-win. Any future
+enablement must not reach throttled/battery-saver providers. More broadly: **TTFT
+benchmarks on this class of hardware are invalid without recording power posture**
+(`pmset -g batt`, `powermode`) and reproducing a known anchor; Low Power Mode alone
+recreates a silent, stable 2x.
+
+## Recommendation
+
+Merge as default-off scheduler infrastructure (safe, gated, tested); do not auto-enable.
+The measured prefill levers of consequence remain LM-head narrowing (removes the
+[1,chunk,248320] logits transient — which striping *quadruples* to 970 MiB/chunk) and the
+attention L² term. Revisit striping after LM-head narrowing lands: the stripe's residual
+overhead-amortization win is additive and its main memory cost disappears.

--- a/docs/reports/2026-08-19-solo-prefill-stripe-experiment.md
+++ b/docs/reports/2026-08-19-solo-prefill-stripe-experiment.md
@@ -6,13 +6,21 @@ machine (M4 Max, Qwen3.6 35B-A3B, `--scheduler-prefill`, contiguous KV, cold pre
 
 ## Feature
 
-Canonical implementation: `libs/mlx-swift-lm/Libraries/MLXLMCommon/ContinuousBatchingV2/`
-`SchedulerV2.swift` (`plan()` solo gate, chunk caps, capacity shrink-retry),
-`CBv2Contracts.swift` (`CBv2SchedulerConfig`), and
-`provider-swift/Sources/ProviderCore/Inference/EngineV2Factory+Production.swift`
-(env resolution, defaults, paged-pool lockstep). Later addenda:
-`PrefillOutputV2.swift`/`SteppableAdapterV2.swift`/`EngineLoopV2.swift`
-(narrowing seam + packed executor), `Qwen35.swift` (conformances).
+Canonical implementation (line ranges as of mlx-swift-lm `3d7c459` /
+superproject `214f3dc98`; re-anchor by symbol if they drift):
+- `libs/mlx-swift-lm/.../ContinuousBatchingV2/SchedulerV2.swift:295-321` solo/policy
+  stripe gate; `:473-495` running-path capacity shrink-retry; `:574-583`
+  partial-prefill cap (fail-open for cap <= 0); `:611-640` admission shrink-retry.
+- `.../CBv2Contracts.swift` `CBv2SchedulerConfig.soloPrefillStripeTokens` /
+  `maxConcurrentPartialPrefills` field docs.
+- `.../PrefillOutputV2.swift:113-140` recurrent prefill seam protocols;
+  `SteppableAdapterV2.swift:95-150` adapter narrowing + fail-safe fallbacks;
+  `EngineLoopV2.swift:1283-1289` `targetForward(requirement:)`; `:1756-1768`
+  recurrent packed cohort execution.
+- `.../MLXLLM/Models/Qwen35.swift:1640-1680` Qwen narrowing + packed claims.
+- `provider-swift/.../EngineV2Factory+Production.swift:118` stripe serving
+  default (2048); `:819-825` injected-environment resolution of both knobs;
+  `:894-900` paged-pool lockstep `max(prefillChunkSize, stripe)`.
 
 `CBv2SchedulerConfig.soloPrefillStripeTokens` (env `DARKBLOOM_CBV2_SOLO_PREFILL_STRIPE`;
 **default ON at 2,048 since PR #646** — `EngineV2Factory.defaultSoloPrefillStripeTokens`,

--- a/docs/reports/2026-08-19-solo-prefill-stripe-experiment.md
+++ b/docs/reports/2026-08-19-solo-prefill-stripe-experiment.md
@@ -6,8 +6,19 @@ machine (M4 Max, Qwen3.6 35B-A3B, `--scheduler-prefill`, contiguous KV, cold pre
 
 ## Feature
 
-`CBv2SchedulerConfig.soloPrefillStripeTokens` (env `DARKBLOOM_CBV2_SOLO_PREFILL_STRIPE`,
-default off): when exactly ONE live text request holds the scheduler's entire schedulable
+Canonical implementation: `libs/mlx-swift-lm/Libraries/MLXLMCommon/ContinuousBatchingV2/`
+`SchedulerV2.swift` (`plan()` solo gate, chunk caps, capacity shrink-retry),
+`CBv2Contracts.swift` (`CBv2SchedulerConfig`), and
+`provider-swift/Sources/ProviderCore/Inference/EngineV2Factory+Production.swift`
+(env resolution, defaults, paged-pool lockstep). Later addenda:
+`PrefillOutputV2.swift`/`SteppableAdapterV2.swift`/`EngineLoopV2.swift`
+(narrowing seam + packed executor), `Qwen35.swift` (conformances).
+
+`CBv2SchedulerConfig.soloPrefillStripeTokens` (env `DARKBLOOM_CBV2_SOLO_PREFILL_STRIPE`;
+**default ON at 2,048 since PR #646** — `EngineV2Factory.defaultSoloPrefillStripeTokens`,
+`EngineV2Factory+Production.swift`; an explicit non-qualifying value such as `0` disarms,
+which throttled/Low-Power-Mode machines should export given the ~12% LPM regression
+below): when exactly ONE live text request holds the scheduler's entire schedulable
 population (no decode-ready row, no other live running row, no waiter, no multimodal
 blocks), its prefill chunk — and when needed the step budget — extends from 512 to the
 stripe. KV-capacity failure on a striped chunk shrinks once to the plain chunk (running and

--- a/docs/reports/clean-ac-control.json
+++ b/docs/reports/clean-ac-control.json
@@ -1,0 +1,78 @@
+{
+  "gemmaOptimizations" : {
+    "environment" : {
+      "DARKBLOOM_GEMMA4_PREFILL_CHUNK_EVAL" : "18",
+      "MLX_GATHER_QMM_EXPERT_SLICES" : "1",
+      "MLX_GEMMA4_FUSED_WEIGHTED_UNSORT" : "1"
+    },
+    "prefillLayer18" : true,
+    "weightedR1" : true
+  },
+  "iterations" : 3,
+  "kvBackend" : {
+    "resolved" : [
+      "contiguous"
+    ],
+    "selection" : "contiguous"
+  },
+  "modelID" : "EigenLabs\/Qwen3.6-35B-A3B-MLX-VL-4bit-g64-router8-mtp",
+  "modelPath" : "$HOME\/.cache\/huggingface\/hub\/models--EigenLabs--Qwen3.6-35B-A3B-MLX-VL-4bit-g64-router8-mtp\/snapshots\/baseline-work",
+  "promptLengths" : [
+    8192,
+    16384
+  ],
+  "samples" : [
+    {
+      "iteration" : 1,
+      "msPerPrefillToken" : 0.7516962113295079,
+      "promptTokens" : 8192,
+      "resolvedKVBackend" : "contiguous",
+      "strategy" : "cbv2",
+      "ttftMs" : 6157.143666999999
+    },
+    {
+      "iteration" : 2,
+      "msPerPrefillToken" : 0.7774827299475033,
+      "promptTokens" : 8192,
+      "resolvedKVBackend" : "contiguous",
+      "strategy" : "cbv2",
+      "ttftMs" : 6368.361041
+    },
+    {
+      "iteration" : 3,
+      "msPerPrefillToken" : 0.7728375350994996,
+      "promptTokens" : 8192,
+      "resolvedKVBackend" : "contiguous",
+      "strategy" : "cbv2",
+      "ttftMs" : 6330.312250000001
+    },
+    {
+      "iteration" : 1,
+      "msPerPrefillToken" : 0.8877067463224073,
+      "promptTokens" : 16384,
+      "resolvedKVBackend" : "contiguous",
+      "strategy" : "cbv2",
+      "ttftMs" : 14543.299625
+    },
+    {
+      "iteration" : 2,
+      "msPerPrefillToken" : 0.8456946708173106,
+      "promptTokens" : 16384,
+      "resolvedKVBackend" : "contiguous",
+      "strategy" : "cbv2",
+      "ttftMs" : 13855.015792
+    },
+    {
+      "iteration" : 3,
+      "msPerPrefillToken" : 0.9161677424769579,
+      "promptTokens" : 16384,
+      "resolvedKVBackend" : "contiguous",
+      "strategy" : "cbv2",
+      "ttftMs" : 15009.576125000001
+    }
+  ],
+  "schemaVersion" : 2,
+  "strategies" : [
+    "cbv2"
+  ]
+}

--- a/docs/reports/clean-ac-stripe2048.json
+++ b/docs/reports/clean-ac-stripe2048.json
@@ -1,0 +1,79 @@
+{
+  "gemmaOptimizations" : {
+    "environment" : {
+      "DARKBLOOM_GEMMA4_PREFILL_CHUNK_EVAL" : "18",
+      "MLX_GATHER_QMM_EXPERT_SLICES" : "1",
+      "MLX_GEMMA4_FUSED_WEIGHTED_UNSORT" : "1"
+    },
+    "prefillLayer18" : true,
+    "weightedR1" : true
+  },
+  "iterations" : 3,
+  "kvBackend" : {
+    "resolved" : [
+      "contiguous"
+    ],
+    "selection" : "contiguous"
+  },
+  "modelID" : "EigenLabs\/Qwen3.6-35B-A3B-MLX-VL-4bit-g64-router8-mtp",
+  "modelPath" : "$HOME\/.cache\/huggingface\/hub\/models--EigenLabs--Qwen3.6-35B-A3B-MLX-VL-4bit-g64-router8-mtp\/snapshots\/baseline-work",
+  "promptLengths" : [
+    8192,
+    16384
+  ],
+  "samples" : [
+    {
+      "iteration" : 1,
+      "msPerPrefillToken" : 0.7522627323892076,
+      "promptTokens" : 8192,
+      "resolvedKVBackend" : "contiguous",
+      "strategy" : "cbv2",
+      "ttftMs" : 6161.784041
+    },
+    {
+      "iteration" : 2,
+      "msPerPrefillToken" : 0.7691686149432304,
+      "promptTokens" : 8192,
+      "resolvedKVBackend" : "contiguous",
+      "strategy" : "cbv2",
+      "ttftMs" : 6300.260125000001
+    },
+    {
+      "iteration" : 3,
+      "msPerPrefillToken" : 0.7609145861311195,
+      "promptTokens" : 8192,
+      "resolvedKVBackend" : "contiguous",
+      "strategy" : "cbv2",
+      "ttftMs" : 6232.6513749999995
+    },
+    {
+      "iteration" : 1,
+      "msPerPrefillToken" : 0.8413852697918575,
+      "promptTokens" : 16384,
+      "resolvedKVBackend" : "contiguous",
+      "strategy" : "cbv2",
+      "ttftMs" : 13784.414875
+    },
+    {
+      "iteration" : 2,
+      "msPerPrefillToken" : 0.8607086308978821,
+      "promptTokens" : 16384,
+      "resolvedKVBackend" : "contiguous",
+      "strategy" : "cbv2",
+      "ttftMs" : 14100.989500000001
+    },
+    {
+      "iteration" : 3,
+      "msPerPrefillToken" : 0.8526892434230605,
+      "promptTokens" : 16384,
+      "resolvedKVBackend" : "contiguous",
+      "strategy" : "cbv2",
+      "ttftMs" : 13969.607875
+    }
+  ],
+  "schemaVersion" : 2,
+  "soloPrefillStripeTokens" : 2048,
+  "strategies" : [
+    "cbv2"
+  ]
+}

--- a/docs/reports/clean-control.json
+++ b/docs/reports/clean-control.json
@@ -1,0 +1,78 @@
+{
+  "gemmaOptimizations" : {
+    "environment" : {
+      "DARKBLOOM_GEMMA4_PREFILL_CHUNK_EVAL" : "18",
+      "MLX_GATHER_QMM_EXPERT_SLICES" : "1",
+      "MLX_GEMMA4_FUSED_WEIGHTED_UNSORT" : "1"
+    },
+    "prefillLayer18" : true,
+    "weightedR1" : true
+  },
+  "iterations" : 3,
+  "kvBackend" : {
+    "resolved" : [
+      "contiguous"
+    ],
+    "selection" : "contiguous"
+  },
+  "modelID" : "EigenLabs\/Qwen3.6-35B-A3B-MLX-VL-4bit-g64-router8-mtp",
+  "modelPath" : "$HOME\/.cache\/huggingface\/hub\/models--EigenLabs--Qwen3.6-35B-A3B-MLX-VL-4bit-g64-router8-mtp\/snapshots\/baseline-work",
+  "promptLengths" : [
+    8192,
+    16384
+  ],
+  "samples" : [
+    {
+      "iteration" : 1,
+      "msPerPrefillToken" : 1.618221111585887,
+      "promptTokens" : 8192,
+      "resolvedKVBackend" : "contiguous",
+      "strategy" : "cbv2",
+      "ttftMs" : 13254.849125
+    },
+    {
+      "iteration" : 2,
+      "msPerPrefillToken" : 1.6037988544744233,
+      "promptTokens" : 8192,
+      "resolvedKVBackend" : "contiguous",
+      "strategy" : "cbv2",
+      "ttftMs" : 13136.716417000001
+    },
+    {
+      "iteration" : 3,
+      "msPerPrefillToken" : 1.6007275414479307,
+      "promptTokens" : 8192,
+      "resolvedKVBackend" : "contiguous",
+      "strategy" : "cbv2",
+      "ttftMs" : 13111.559292
+    },
+    {
+      "iteration" : 1,
+      "msPerPrefillToken" : 1.7533773321735946,
+      "promptTokens" : 16384,
+      "resolvedKVBackend" : "contiguous",
+      "strategy" : "cbv2",
+      "ttftMs" : 28725.580833
+    },
+    {
+      "iteration" : 2,
+      "msPerPrefillToken" : 1.7567204851370324,
+      "promptTokens" : 16384,
+      "resolvedKVBackend" : "contiguous",
+      "strategy" : "cbv2",
+      "ttftMs" : 28780.351708000002
+    },
+    {
+      "iteration" : 3,
+      "msPerPrefillToken" : 1.7997212913996214,
+      "promptTokens" : 16384,
+      "resolvedKVBackend" : "contiguous",
+      "strategy" : "cbv2",
+      "ttftMs" : 29484.833917
+    }
+  ],
+  "schemaVersion" : 2,
+  "strategies" : [
+    "cbv2"
+  ]
+}

--- a/docs/reports/clean-stripe2048.json
+++ b/docs/reports/clean-stripe2048.json
@@ -1,0 +1,79 @@
+{
+  "gemmaOptimizations" : {
+    "environment" : {
+      "DARKBLOOM_GEMMA4_PREFILL_CHUNK_EVAL" : "18",
+      "MLX_GATHER_QMM_EXPERT_SLICES" : "1",
+      "MLX_GEMMA4_FUSED_WEIGHTED_UNSORT" : "1"
+    },
+    "prefillLayer18" : true,
+    "weightedR1" : true
+  },
+  "iterations" : 3,
+  "kvBackend" : {
+    "resolved" : [
+      "contiguous"
+    ],
+    "selection" : "contiguous"
+  },
+  "modelID" : "EigenLabs\/Qwen3.6-35B-A3B-MLX-VL-4bit-g64-router8-mtp",
+  "modelPath" : "$HOME\/.cache\/huggingface\/hub\/models--EigenLabs--Qwen3.6-35B-A3B-MLX-VL-4bit-g64-router8-mtp\/snapshots\/baseline-work",
+  "promptLengths" : [
+    8192,
+    16384
+  ],
+  "samples" : [
+    {
+      "iteration" : 1,
+      "msPerPrefillToken" : 2.2028151883774876,
+      "promptTokens" : 8192,
+      "resolvedKVBackend" : "contiguous",
+      "strategy" : "cbv2",
+      "ttftMs" : 18043.259208
+    },
+    {
+      "iteration" : 2,
+      "msPerPrefillToken" : 1.7845232928824322,
+      "promptTokens" : 8192,
+      "resolvedKVBackend" : "contiguous",
+      "strategy" : "cbv2",
+      "ttftMs" : 14617.030292000001
+    },
+    {
+      "iteration" : 3,
+      "msPerPrefillToken" : 1.7933426270296668,
+      "promptTokens" : 8192,
+      "resolvedKVBackend" : "contiguous",
+      "strategy" : "cbv2",
+      "ttftMs" : 14689.269458
+    },
+    {
+      "iteration" : 1,
+      "msPerPrefillToken" : 1.9515584396020265,
+      "promptTokens" : 16384,
+      "resolvedKVBackend" : "contiguous",
+      "strategy" : "cbv2",
+      "ttftMs" : 31972.381916
+    },
+    {
+      "iteration" : 2,
+      "msPerPrefillToken" : 1.7168363318684001,
+      "promptTokens" : 16384,
+      "resolvedKVBackend" : "contiguous",
+      "strategy" : "cbv2",
+      "ttftMs" : 28126.929625
+    },
+    {
+      "iteration" : 3,
+      "msPerPrefillToken" : 1.7045091278764575,
+      "promptTokens" : 16384,
+      "resolvedKVBackend" : "contiguous",
+      "strategy" : "cbv2",
+      "ttftMs" : 27924.973042
+    }
+  ],
+  "schemaVersion" : 2,
+  "soloPrefillStripeTokens" : 2048,
+  "strategies" : [
+    "cbv2"
+  ]
+}

--- a/docs/reports/m22-base-512.json
+++ b/docs/reports/m22-base-512.json
@@ -1,0 +1,53 @@
+{
+  "gemmaOptimizations" : {
+    "environment" : {
+      "DARKBLOOM_GEMMA4_PREFILL_CHUNK_EVAL" : "18",
+      "MLX_GATHER_QMM_EXPERT_SLICES" : "1",
+      "MLX_GEMMA4_FUSED_WEIGHTED_UNSORT" : "1"
+    },
+    "prefillLayer18" : true,
+    "weightedR1" : true
+  },
+  "iterations" : 3,
+  "kvBackend" : {
+    "resolved" : [
+      "contiguous"
+    ],
+    "selection" : "contiguous"
+  },
+  "modelID" : "EigenLabs\/Qwen3.6-35B-A3B-MLX-VL-4bit-g64-router8-mtp",
+  "modelPath" : "$HOME\/.cache\/huggingface\/hub\/models--EigenLabs--Qwen3.6-35B-A3B-MLX-VL-4bit-g64-router8-mtp\/snapshots\/baseline-work",
+  "promptLengths" : [
+    8192
+  ],
+  "samples" : [
+    {
+      "iteration" : 1,
+      "msPerPrefillToken" : 0.7589229031864241,
+      "promptTokens" : 8192,
+      "resolvedKVBackend" : "contiguous",
+      "strategy" : "cbv2",
+      "ttftMs" : 6216.3375
+    },
+    {
+      "iteration" : 2,
+      "msPerPrefillToken" : 0.7579948571602979,
+      "promptTokens" : 8192,
+      "resolvedKVBackend" : "contiguous",
+      "strategy" : "cbv2",
+      "ttftMs" : 6208.735875
+    },
+    {
+      "iteration" : 3,
+      "msPerPrefillToken" : 0.7572193718715663,
+      "promptTokens" : 8192,
+      "resolvedKVBackend" : "contiguous",
+      "strategy" : "cbv2",
+      "ttftMs" : 6202.3838749999995
+    }
+  ],
+  "schemaVersion" : 2,
+  "strategies" : [
+    "cbv2"
+  ]
+}

--- a/docs/reports/m22-stripe-2048.json
+++ b/docs/reports/m22-stripe-2048.json
@@ -1,0 +1,54 @@
+{
+  "gemmaOptimizations" : {
+    "environment" : {
+      "DARKBLOOM_GEMMA4_PREFILL_CHUNK_EVAL" : "18",
+      "MLX_GATHER_QMM_EXPERT_SLICES" : "1",
+      "MLX_GEMMA4_FUSED_WEIGHTED_UNSORT" : "1"
+    },
+    "prefillLayer18" : true,
+    "weightedR1" : true
+  },
+  "iterations" : 3,
+  "kvBackend" : {
+    "resolved" : [
+      "contiguous"
+    ],
+    "selection" : "contiguous"
+  },
+  "modelID" : "EigenLabs\/Qwen3.6-35B-A3B-MLX-VL-4bit-g64-router8-mtp",
+  "modelPath" : "$HOME\/.cache\/huggingface\/hub\/models--EigenLabs--Qwen3.6-35B-A3B-MLX-VL-4bit-g64-router8-mtp\/snapshots\/baseline-work",
+  "promptLengths" : [
+    8192
+  ],
+  "samples" : [
+    {
+      "iteration" : 1,
+      "msPerPrefillToken" : 0.8105735817360518,
+      "promptTokens" : 8192,
+      "resolvedKVBackend" : "contiguous",
+      "strategy" : "cbv2",
+      "ttftMs" : 6639.408208
+    },
+    {
+      "iteration" : 2,
+      "msPerPrefillToken" : 0.8103465999267488,
+      "promptTokens" : 8192,
+      "resolvedKVBackend" : "contiguous",
+      "strategy" : "cbv2",
+      "ttftMs" : 6637.549
+    },
+    {
+      "iteration" : 3,
+      "msPerPrefillToken" : 0.8221467413014284,
+      "promptTokens" : 8192,
+      "resolvedKVBackend" : "contiguous",
+      "strategy" : "cbv2",
+      "ttftMs" : 6734.203958
+    }
+  ],
+  "schemaVersion" : 2,
+  "soloPrefillStripeTokens" : 2048,
+  "strategies" : [
+    "cbv2"
+  ]
+}

--- a/docs/reports/m22-trust-512.json
+++ b/docs/reports/m22-trust-512.json
@@ -1,0 +1,53 @@
+{
+  "gemmaOptimizations" : {
+    "environment" : {
+      "DARKBLOOM_GEMMA4_PREFILL_CHUNK_EVAL" : "18",
+      "MLX_GATHER_QMM_EXPERT_SLICES" : "trust",
+      "MLX_GEMMA4_FUSED_WEIGHTED_UNSORT" : "1"
+    },
+    "prefillLayer18" : true,
+    "weightedR1" : true
+  },
+  "iterations" : 3,
+  "kvBackend" : {
+    "resolved" : [
+      "contiguous"
+    ],
+    "selection" : "contiguous"
+  },
+  "modelID" : "EigenLabs\/Qwen3.6-35B-A3B-MLX-VL-4bit-g64-router8-mtp",
+  "modelPath" : "$HOME\/.cache\/huggingface\/hub\/models--EigenLabs--Qwen3.6-35B-A3B-MLX-VL-4bit-g64-router8-mtp\/snapshots\/baseline-work",
+  "promptLengths" : [
+    8192
+  ],
+  "samples" : [
+    {
+      "iteration" : 1,
+      "msPerPrefillToken" : 0.7336960892442925,
+      "promptTokens" : 8192,
+      "resolvedKVBackend" : "contiguous",
+      "strategy" : "cbv2",
+      "ttftMs" : 6009.704667
+    },
+    {
+      "iteration" : 2,
+      "msPerPrefillToken" : 0.7649380722744475,
+      "promptTokens" : 8192,
+      "resolvedKVBackend" : "contiguous",
+      "strategy" : "cbv2",
+      "ttftMs" : 6265.60775
+    },
+    {
+      "iteration" : 3,
+      "msPerPrefillToken" : 0.8198551356366743,
+      "promptTokens" : 8192,
+      "resolvedKVBackend" : "contiguous",
+      "strategy" : "cbv2",
+      "ttftMs" : 6715.433416
+    }
+  ],
+  "schemaVersion" : 2,
+  "strategies" : [
+    "cbv2"
+  ]
+}

--- a/docs/reports/m22-trust-stripe.json
+++ b/docs/reports/m22-trust-stripe.json
@@ -1,0 +1,54 @@
+{
+  "gemmaOptimizations" : {
+    "environment" : {
+      "DARKBLOOM_GEMMA4_PREFILL_CHUNK_EVAL" : "18",
+      "MLX_GATHER_QMM_EXPERT_SLICES" : "trust",
+      "MLX_GEMMA4_FUSED_WEIGHTED_UNSORT" : "1"
+    },
+    "prefillLayer18" : true,
+    "weightedR1" : true
+  },
+  "iterations" : 3,
+  "kvBackend" : {
+    "resolved" : [
+      "contiguous"
+    ],
+    "selection" : "contiguous"
+  },
+  "modelID" : "EigenLabs\/Qwen3.6-35B-A3B-MLX-VL-4bit-g64-router8-mtp",
+  "modelPath" : "$HOME\/.cache\/huggingface\/hub\/models--EigenLabs--Qwen3.6-35B-A3B-MLX-VL-4bit-g64-router8-mtp\/snapshots\/baseline-work",
+  "promptLengths" : [
+    8192
+  ],
+  "samples" : [
+    {
+      "iteration" : 1,
+      "msPerPrefillToken" : 0.6531813627151751,
+      "promptTokens" : 8192,
+      "resolvedKVBackend" : "contiguous",
+      "strategy" : "cbv2",
+      "ttftMs" : 5350.208541999999
+    },
+    {
+      "iteration" : 2,
+      "msPerPrefillToken" : 0.6437972317177391,
+      "promptTokens" : 8192,
+      "resolvedKVBackend" : "contiguous",
+      "strategy" : "cbv2",
+      "ttftMs" : 5273.343125
+    },
+    {
+      "iteration" : 3,
+      "msPerPrefillToken" : 0.6620501312416066,
+      "promptTokens" : 8192,
+      "resolvedKVBackend" : "contiguous",
+      "strategy" : "cbv2",
+      "ttftMs" : 5422.8526249999995
+    }
+  ],
+  "schemaVersion" : 2,
+  "soloPrefillStripeTokens" : 2048,
+  "strategies" : [
+    "cbv2"
+  ]
+}

--- a/docs/reports/mr-base.json
+++ b/docs/reports/mr-base.json
@@ -1,0 +1,343 @@
+{
+  "arrivalMaxAttemptsPerSample" : 3,
+  "arrivalToleranceMs" : 5,
+  "decodeTokensPerRequest" : 8,
+  "gemmaOptimizations" : {
+    "environment" : {
+      "DARKBLOOM_GEMMA4_PREFILL_CHUNK_EVAL" : "18",
+      "MLX_GATHER_QMM_EXPERT_SLICES" : "1",
+      "MLX_GEMMA4_FUSED_WEIGHTED_UNSORT" : "1"
+    },
+    "prefillLayer18" : true,
+    "weightedR1" : true
+  },
+  "iterations" : 1,
+  "kvBackend" : {
+    "resolved" : [
+      "contiguous"
+    ],
+    "selection" : "contiguous"
+  },
+  "modelID" : "EigenLabs\/Qwen3.6-35B-A3B-MLX-VL-4bit-g64-router8-mtp",
+  "modelPath" : "$HOME\/.cache\/huggingface\/hub\/models--EigenLabs--Qwen3.6-35B-A3B-MLX-VL-4bit-g64-router8-mtp\/snapshots\/baseline-work",
+  "patterns" : [
+    {
+      "arrivalDelaysMs" : [
+        0,
+        0,
+        0,
+        0
+      ],
+      "arrivalWithinTolerance" : true,
+      "maxArrivalErrorMs" : 0.0195,
+      "measuredArrivalOffsetsMs" : [
+        0.008542,
+        0.014958,
+        0.017417,
+        0.0195
+      ],
+      "medianAggregateDecodeTokensPerSecond" : 211.18759973994358,
+      "medianMakespanMs" : 25114.431417,
+      "medianPerRequestDecodeTokensPerSecond" : 52.813862946759244,
+      "medianTTFTMs" : 24981.836353500003,
+      "name" : "burst",
+      "outputsMatchBurst" : true,
+      "outputsStableAcrossIterations" : true,
+      "samples" : [
+        {
+          "aggregateDecodeTokensPerSecond" : 211.18759973994358,
+          "discardedAttempts" : 0,
+          "endToEndTokensPerSecond" : 1.2741678068944515,
+          "iteration" : 1,
+          "makespanMs" : 25114.431417,
+          "maxArrivalErrorMs" : 0.0195,
+          "rows" : [
+            {
+              "arrivalErrorMs" : 0.008542,
+              "completedAtMs" : 25114.368333,
+              "decodeTokensPerSecond" : 52.82307889215877,
+              "generatedTokens" : 8,
+              "row" : 0,
+              "scheduledDelayMs" : 0,
+              "submittedAtMs" : 0.008542,
+              "tokenChecksum" : "0a4933f36a8ef728",
+              "ttftMs" : 24981.837291
+            },
+            {
+              "arrivalErrorMs" : 0.014958,
+              "completedAtMs" : 25114.41825,
+              "decodeTokensPerSecond" : 52.811256342066045,
+              "generatedTokens" : 8,
+              "row" : 1,
+              "scheduledDelayMs" : 0,
+              "submittedAtMs" : 0.014958,
+              "tokenChecksum" : "1275c6093e275968",
+              "ttftMs" : 24981.838875
+            },
+            {
+              "arrivalErrorMs" : 0.017417,
+              "completedAtMs" : 25114.38975,
+              "decodeTokensPerSecond" : 52.81646955145244,
+              "generatedTokens" : 8,
+              "row" : 2,
+              "scheduledDelayMs" : 0,
+              "submittedAtMs" : 0.017417,
+              "tokenChecksum" : "38f6e5dccc95ff9c",
+              "ttftMs" : 24981.835416
+            },
+            {
+              "arrivalErrorMs" : 0.0195,
+              "completedAtMs" : 25114.431417,
+              "decodeTokensPerSecond" : 52.79962148403927,
+              "generatedTokens" : 8,
+              "row" : 3,
+              "scheduledDelayMs" : 0,
+              "submittedAtMs" : 0.0195,
+              "tokenChecksum" : "86195786012be905",
+              "ttftMs" : 24981.833167
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "arrivalDelaysMs" : [
+        0,
+        25,
+        50,
+        75
+      ],
+      "arrivalWithinTolerance" : true,
+      "maxArrivalErrorMs" : 3.5,
+      "measuredArrivalOffsetsMs" : [
+        0.005625,
+        28.5,
+        52.910958,
+        78.461958
+      ],
+      "medianAggregateDecodeTokensPerSecond" : 20.005251978801997,
+      "medianMakespanMs" : 25134.343582999998,
+      "medianPerRequestDecodeTokensPerSecond" : 59.6909611567863,
+      "medianTTFTMs" : 24951.3736875,
+      "name" : "stagger-25ms",
+      "outputsMatchBurst" : true,
+      "outputsStableAcrossIterations" : true,
+      "samples" : [
+        {
+          "aggregateDecodeTokensPerSecond" : 20.005251978801997,
+          "discardedAttempts" : 0,
+          "endToEndTokensPerSecond" : 1.2731583736940595,
+          "iteration" : 1,
+          "makespanMs" : 25134.343582999998,
+          "maxArrivalErrorMs" : 3.5,
+          "rows" : [
+            {
+              "arrivalErrorMs" : 0.005625,
+              "completedAtMs" : 25131.050875,
+              "decodeTokensPerSecond" : 5.01311900299731,
+              "generatedTokens" : 8,
+              "row" : 0,
+              "scheduledDelayMs" : 0,
+              "submittedAtMs" : 0.005625,
+              "tokenChecksum" : "0a4933f36a8ef728",
+              "ttftMs" : 23734.703333
+            },
+            {
+              "arrivalErrorMs" : 3.5,
+              "completedAtMs" : 25134.313416,
+              "decodeTokensPerSecond" : 59.70554487612899,
+              "generatedTokens" : 8,
+              "row" : 1,
+              "scheduledDelayMs" : 25,
+              "submittedAtMs" : 28.5,
+              "tokenChecksum" : "1275c6093e275968",
+              "ttftMs" : 24988.559041
+            },
+            {
+              "arrivalErrorMs" : 2.910958000000001,
+              "completedAtMs" : 25134.333,
+              "decodeTokensPerSecond" : 59.696125231964224,
+              "generatedTokens" : 8,
+              "row" : 2,
+              "scheduledDelayMs" : 50,
+              "submittedAtMs" : 52.910958,
+              "tokenChecksum" : "38f6e5dccc95ff9c",
+              "ttftMs" : 24964.14875
+            },
+            {
+              "arrivalErrorMs" : 3.4619579999999956,
+              "completedAtMs" : 25134.343583,
+              "decodeTokensPerSecond" : 59.68579708160838,
+              "generatedTokens" : 8,
+              "row" : 3,
+              "scheduledDelayMs" : 75,
+              "submittedAtMs" : 78.461958,
+              "tokenChecksum" : "86195786012be905",
+              "ttftMs" : 24938.598625
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "arrivalDelaysMs" : [
+        0,
+        100,
+        200,
+        300
+      ],
+      "arrivalWithinTolerance" : true,
+      "maxArrivalErrorMs" : 3.2078329999999937,
+      "measuredArrivalOffsetsMs" : [
+        0.006583,
+        102.647166,
+        201.790833,
+        303.207833
+      ],
+      "medianAggregateDecodeTokensPerSecond" : 19.679383027839272,
+      "medianMakespanMs" : 26185.746000000003,
+      "medianPerRequestDecodeTokensPerSecond" : 57.60506970278729,
+      "medianTTFTMs" : 25811.7080835,
+      "name" : "stagger-100ms",
+      "outputsMatchBurst" : true,
+      "outputsStableAcrossIterations" : true,
+      "samples" : [
+        {
+          "aggregateDecodeTokensPerSecond" : 19.679383027839272,
+          "discardedAttempts" : 0,
+          "endToEndTokensPerSecond" : 1.222038890929439,
+          "iteration" : 1,
+          "makespanMs" : 26185.746000000003,
+          "maxArrivalErrorMs" : 3.2078329999999937,
+          "rows" : [
+            {
+              "arrivalErrorMs" : 0.006583,
+              "completedAtMs" : 26182.316333,
+              "decodeTokensPerSecond" : 4.93171584288605,
+              "generatedTokens" : 8,
+              "row" : 0,
+              "scheduledDelayMs" : 0,
+              "submittedAtMs" : 0.006583,
+              "tokenChecksum" : "0a4933f36a8ef728",
+              "ttftMs" : 24762.91975
+            },
+            {
+              "arrivalErrorMs" : 2.6471659999999986,
+              "completedAtMs" : 26185.702333,
+              "decodeTokensPerSecond" : 57.62038099386136,
+              "generatedTokens" : 8,
+              "row" : 1,
+              "scheduledDelayMs" : 100,
+              "submittedAtMs" : 102.647166,
+              "tokenChecksum" : "1275c6093e275968",
+              "ttftMs" : 25961.554667
+            },
+            {
+              "arrivalErrorMs" : 1.7908329999999921,
+              "completedAtMs" : 26185.716333,
+              "decodeTokensPerSecond" : 57.60921763283511,
+              "generatedTokens" : 8,
+              "row" : 2,
+              "scheduledDelayMs" : 200,
+              "submittedAtMs" : 201.790833,
+              "tokenChecksum" : "38f6e5dccc95ff9c",
+              "ttftMs" : 25862.414667
+            },
+            {
+              "arrivalErrorMs" : 3.2078329999999937,
+              "completedAtMs" : 26185.746,
+              "decodeTokensPerSecond" : 57.60092177273946,
+              "generatedTokens" : 8,
+              "row" : 3,
+              "scheduledDelayMs" : 300,
+              "submittedAtMs" : 303.207833,
+              "tokenChecksum" : "86195786012be905",
+              "ttftMs" : 25761.0015
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "arrivalDelaysMs" : [
+        0,
+        250,
+        500,
+        750
+      ],
+      "arrivalWithinTolerance" : true,
+      "maxArrivalErrorMs" : 4.959666999999996,
+      "measuredArrivalOffsetsMs" : [
+        0.008667,
+        254.959667,
+        500.234583,
+        752.996667
+      ],
+      "medianAggregateDecodeTokensPerSecond" : 12.277711754626424,
+      "medianMakespanMs" : 25610.701250000002,
+      "medianPerRequestDecodeTokensPerSecond" : 31.34040952918875,
+      "medianTTFTMs" : 24549.2136245,
+      "name" : "rolling-250ms",
+      "outputsMatchBurst" : true,
+      "outputsStableAcrossIterations" : true,
+      "samples" : [
+        {
+          "aggregateDecodeTokensPerSecond" : 12.277711754626424,
+          "discardedAttempts" : 0,
+          "endToEndTokensPerSecond" : 1.2494776963594465,
+          "iteration" : 1,
+          "makespanMs" : 25610.701250000002,
+          "maxArrivalErrorMs" : 4.959666999999996,
+          "rows" : [
+            {
+              "arrivalErrorMs" : 0.008667,
+              "completedAtMs" : 25581.236333,
+              "decodeTokensPerSecond" : 3.1096065797942543,
+              "generatedTokens" : 8,
+              "row" : 0,
+              "scheduledDelayMs" : 0,
+              "submittedAtMs" : 0.008667,
+              "tokenChecksum" : "0a4933f36a8ef728",
+              "ttftMs" : 23330.134416
+            },
+            {
+              "arrivalErrorMs" : 4.959666999999996,
+              "completedAtMs" : 25584.507917,
+              "decodeTokensPerSecond" : 7.272907995990171,
+              "generatedTokens" : 8,
+              "row" : 1,
+              "scheduledDelayMs" : 250,
+              "submittedAtMs" : 254.959667,
+              "tokenChecksum" : "1275c6093e275968",
+              "ttftMs" : 24367.061333
+            },
+            {
+              "arrivalErrorMs" : 0.23458299999998644,
+              "completedAtMs" : 25610.675417,
+              "decodeTokensPerSecond" : 55.419736735349346,
+              "generatedTokens" : 8,
+              "row" : 2,
+              "scheduledDelayMs" : 500,
+              "submittedAtMs" : 500.234583,
+              "tokenChecksum" : "38f6e5dccc95ff9c",
+              "ttftMs" : 24984.125917
+            },
+            {
+              "arrivalErrorMs" : 2.996667000000002,
+              "completedAtMs" : 25610.70125,
+              "decodeTokensPerSecond" : 55.40791106238733,
+              "generatedTokens" : 8,
+              "row" : 3,
+              "scheduledDelayMs" : 750,
+              "submittedAtMs" : 752.996667,
+              "tokenChecksum" : "86195786012be905",
+              "ttftMs" : 24731.365916
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "promptTokensPerRequest" : 8192,
+  "schemaVersion" : 4
+}

--- a/docs/reports/mr-trust.json
+++ b/docs/reports/mr-trust.json
@@ -1,0 +1,343 @@
+{
+  "arrivalMaxAttemptsPerSample" : 3,
+  "arrivalToleranceMs" : 5,
+  "decodeTokensPerRequest" : 8,
+  "gemmaOptimizations" : {
+    "environment" : {
+      "DARKBLOOM_GEMMA4_PREFILL_CHUNK_EVAL" : "18",
+      "MLX_GATHER_QMM_EXPERT_SLICES" : "trust",
+      "MLX_GEMMA4_FUSED_WEIGHTED_UNSORT" : "1"
+    },
+    "prefillLayer18" : true,
+    "weightedR1" : true
+  },
+  "iterations" : 1,
+  "kvBackend" : {
+    "resolved" : [
+      "contiguous"
+    ],
+    "selection" : "contiguous"
+  },
+  "modelID" : "EigenLabs\/Qwen3.6-35B-A3B-MLX-VL-4bit-g64-router8-mtp",
+  "modelPath" : "$HOME\/.cache\/huggingface\/hub\/models--EigenLabs--Qwen3.6-35B-A3B-MLX-VL-4bit-g64-router8-mtp\/snapshots\/baseline-work",
+  "patterns" : [
+    {
+      "arrivalDelaysMs" : [
+        0,
+        0,
+        0,
+        0
+      ],
+      "arrivalWithinTolerance" : true,
+      "maxArrivalErrorMs" : 0.01825,
+      "measuredArrivalOffsetsMs" : [
+        0.004958,
+        0.011708,
+        0.016125,
+        0.01825
+      ],
+      "medianAggregateDecodeTokensPerSecond" : 197.65932532871895,
+      "medianMakespanMs" : 24257.371166999998,
+      "medianPerRequestDecodeTokensPerSecond" : 49.431254806745784,
+      "medianTTFTMs" : 24115.6943335,
+      "name" : "burst",
+      "outputsMatchBurst" : true,
+      "outputsStableAcrossIterations" : true,
+      "samples" : [
+        {
+          "aggregateDecodeTokensPerSecond" : 197.65932532871895,
+          "discardedAttempts" : 0,
+          "endToEndTokensPerSecond" : 1.3191866414417224,
+          "iteration" : 1,
+          "makespanMs" : 24257.371166999998,
+          "maxArrivalErrorMs" : 0.01825,
+          "rows" : [
+            {
+              "arrivalErrorMs" : 0.004958,
+              "completedAtMs" : 24257.276208,
+              "decodeTokensPerSecond" : 49.44573695208411,
+              "generatedTokens" : 8,
+              "row" : 0,
+              "scheduledDelayMs" : 0,
+              "submittedAtMs" : 0.004958,
+              "tokenChecksum" : "0a4933f36a8ef728",
+              "ttftMs" : 24115.696959
+            },
+            {
+              "arrivalErrorMs" : 0.011708,
+              "completedAtMs" : 24257.31175,
+              "decodeTokensPerSecond" : 49.4386359422683,
+              "generatedTokens" : 8,
+              "row" : 1,
+              "scheduledDelayMs" : 0,
+              "submittedAtMs" : 0.011708,
+              "tokenChecksum" : "1275c6093e275968",
+              "ttftMs" : 24115.696625
+            },
+            {
+              "arrivalErrorMs" : 0.016125,
+              "completedAtMs" : 24257.347333,
+              "decodeTokensPerSecond" : 49.42387367122327,
+              "generatedTokens" : 8,
+              "row" : 2,
+              "scheduledDelayMs" : 0,
+              "submittedAtMs" : 0.016125,
+              "tokenChecksum" : "38f6e5dccc95ff9c",
+              "ttftMs" : 24115.692042
+            },
+            {
+              "arrivalErrorMs" : 0.01825,
+              "completedAtMs" : 24257.371167,
+              "decodeTokensPerSecond" : 49.41747666852674,
+              "generatedTokens" : 8,
+              "row" : 3,
+              "scheduledDelayMs" : 0,
+              "submittedAtMs" : 0.01825,
+              "tokenChecksum" : "86195786012be905",
+              "ttftMs" : 24115.69125
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "arrivalDelaysMs" : [
+        0,
+        25,
+        50,
+        75
+      ],
+      "arrivalWithinTolerance" : true,
+      "maxArrivalErrorMs" : 4.888249999999999,
+      "measuredArrivalOffsetsMs" : [
+        0.008625,
+        29.686833,
+        54.856292,
+        79.88825
+      ],
+      "medianAggregateDecodeTokensPerSecond" : 20.2557658221885,
+      "medianMakespanMs" : 24506.787458000003,
+      "medianPerRequestDecodeTokensPerSecond" : 59.16187746458088,
+      "medianTTFTMs" : 24321.0760205,
+      "name" : "stagger-25ms",
+      "outputsMatchBurst" : true,
+      "outputsStableAcrossIterations" : true,
+      "samples" : [
+        {
+          "aggregateDecodeTokensPerSecond" : 20.2557658221885,
+          "discardedAttempts" : 0,
+          "endToEndTokensPerSecond" : 1.305760702207172,
+          "iteration" : 1,
+          "makespanMs" : 24506.787458000003,
+          "maxArrivalErrorMs" : 4.888249999999999,
+          "rows" : [
+            {
+              "arrivalErrorMs" : 0.008625,
+              "completedAtMs" : 24503.462708,
+              "decodeTokensPerSecond" : 5.076144281702872,
+              "generatedTokens" : 8,
+              "row" : 0,
+              "scheduledDelayMs" : 0,
+              "submittedAtMs" : 0.008625,
+              "tokenChecksum" : "0a4933f36a8ef728",
+              "ttftMs" : 23124.448667
+            },
+            {
+              "arrivalErrorMs" : 4.686833,
+              "completedAtMs" : 24506.740375,
+              "decodeTokensPerSecond" : 59.2093439652902,
+              "generatedTokens" : 8,
+              "row" : 1,
+              "scheduledDelayMs" : 25,
+              "submittedAtMs" : 29.686833,
+              "tokenChecksum" : "1275c6093e275968",
+              "ttftMs" : 24358.761584
+            },
+            {
+              "arrivalErrorMs" : 4.856292000000003,
+              "completedAtMs" : 24506.772333,
+              "decodeTokensPerSecond" : 59.16749241946087,
+              "generatedTokens" : 8,
+              "row" : 2,
+              "scheduledDelayMs" : 50,
+              "submittedAtMs" : 54.856292,
+              "tokenChecksum" : "38f6e5dccc95ff9c",
+              "ttftMs" : 24333.591208
+            },
+            {
+              "arrivalErrorMs" : 4.888249999999999,
+              "completedAtMs" : 24506.787458,
+              "decodeTokensPerSecond" : 59.15626250970089,
+              "generatedTokens" : 8,
+              "row" : 3,
+              "scheduledDelayMs" : 75,
+              "submittedAtMs" : 79.88825,
+              "tokenChecksum" : "86195786012be905",
+              "ttftMs" : 24308.560833
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "arrivalDelaysMs" : [
+        0,
+        100,
+        200,
+        300
+      ],
+      "arrivalWithinTolerance" : true,
+      "maxArrivalErrorMs" : 4.1440000000000055,
+      "measuredArrivalOffsetsMs" : [
+        0.004708,
+        104.118916,
+        204.144,
+        304.116625
+      ],
+      "medianAggregateDecodeTokensPerSecond" : 15.217746250008593,
+      "medianMakespanMs" : 24636.604916,
+      "medianPerRequestDecodeTokensPerSecond" : 12.475830875132718,
+      "medianTTFTMs" : 23900.318792,
+      "name" : "stagger-100ms",
+      "outputsMatchBurst" : true,
+      "outputsStableAcrossIterations" : true,
+      "samples" : [
+        {
+          "aggregateDecodeTokensPerSecond" : 15.217746250008593,
+          "discardedAttempts" : 0,
+          "endToEndTokensPerSecond" : 1.2988802681662486,
+          "iteration" : 1,
+          "makespanMs" : 24636.604916,
+          "maxArrivalErrorMs" : 4.1440000000000055,
+          "rows" : [
+            {
+              "arrivalErrorMs" : 0.004708,
+              "completedAtMs" : 24612.307708,
+              "decodeTokensPerSecond" : 3.855346128863998,
+              "generatedTokens" : 8,
+              "row" : 0,
+              "scheduledDelayMs" : 0,
+              "submittedAtMs" : 0.004708,
+              "tokenChecksum" : "0a4933f36a8ef728",
+              "ttftMs" : 22796.636625
+            },
+            {
+              "arrivalErrorMs" : 4.118915999999999,
+              "completedAtMs" : 24615.536333,
+              "decodeTokensPerSecond" : 12.475968922332898,
+              "generatedTokens" : 8,
+              "row" : 1,
+              "scheduledDelayMs" : 100,
+              "submittedAtMs" : 104.118916,
+              "tokenChecksum" : "1275c6093e275968",
+              "ttftMs" : 23950.327084
+            },
+            {
+              "arrivalErrorMs" : 4.1440000000000055,
+              "completedAtMs" : 24615.547958,
+              "decodeTokensPerSecond" : 12.475692827932537,
+              "generatedTokens" : 8,
+              "row" : 2,
+              "scheduledDelayMs" : 200,
+              "submittedAtMs" : 204.144,
+              "tokenChecksum" : "38f6e5dccc95ff9c",
+              "ttftMs" : 23850.3105
+            },
+            {
+              "arrivalErrorMs" : 4.116624999999999,
+              "completedAtMs" : 24636.604916,
+              "decodeTokensPerSecond" : 55.905575483009194,
+              "generatedTokens" : 8,
+              "row" : 3,
+              "scheduledDelayMs" : 300,
+              "submittedAtMs" : 304.116625,
+              "tokenChecksum" : "86195786012be905",
+              "ttftMs" : 24207.270666
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "arrivalDelaysMs" : [
+        0,
+        250,
+        500,
+        750
+      ],
+      "arrivalWithinTolerance" : true,
+      "maxArrivalErrorMs" : 4.700124999999957,
+      "measuredArrivalOffsetsMs" : [
+        0.008209,
+        254.695834,
+        500.028125,
+        754.700125
+      ],
+      "medianAggregateDecodeTokensPerSecond" : 12.134967932120741,
+      "medianMakespanMs" : 25439.890959,
+      "medianPerRequestDecodeTokensPerSecond" : 28.45863863554035,
+      "medianTTFTMs" : 24349.546374999998,
+      "name" : "rolling-250ms",
+      "outputsMatchBurst" : true,
+      "outputsStableAcrossIterations" : true,
+      "samples" : [
+        {
+          "aggregateDecodeTokensPerSecond" : 12.134967932120741,
+          "discardedAttempts" : 0,
+          "endToEndTokensPerSecond" : 1.2578670266933356,
+          "iteration" : 1,
+          "makespanMs" : 25439.890959,
+          "maxArrivalErrorMs" : 4.700124999999957,
+          "rows" : [
+            {
+              "arrivalErrorMs" : 0.008209,
+              "completedAtMs" : 25407.230625,
+              "decodeTokensPerSecond" : 3.077302948667685,
+              "generatedTokens" : 8,
+              "row" : 0,
+              "scheduledDelayMs" : 0,
+              "submittedAtMs" : 0.008209,
+              "tokenChecksum" : "0a4933f36a8ef728",
+              "ttftMs" : 23132.497583
+            },
+            {
+              "arrivalErrorMs" : 4.695833999999991,
+              "completedAtMs" : 25411.045834,
+              "decodeTokensPerSecond" : 6.98430016626376,
+              "generatedTokens" : 8,
+              "row" : 1,
+              "scheduledDelayMs" : 250,
+              "submittedAtMs" : 254.695834,
+              "tokenChecksum" : "1275c6093e275968",
+              "ttftMs" : 24154.093541
+            },
+            {
+              "arrivalErrorMs" : 0.02812499999998863,
+              "completedAtMs" : 25439.868834,
+              "decodeTokensPerSecond" : 49.93710279225878,
+              "generatedTokens" : 8,
+              "row" : 2,
+              "scheduledDelayMs" : 500,
+              "submittedAtMs" : 500.028125,
+              "tokenChecksum" : "38f6e5dccc95ff9c",
+              "ttftMs" : 24799.65975
+            },
+            {
+              "arrivalErrorMs" : 4.700124999999957,
+              "completedAtMs" : 25439.890959,
+              "decodeTokensPerSecond" : 49.93297710481694,
+              "generatedTokens" : 8,
+              "row" : 3,
+              "scheduledDelayMs" : 750,
+              "submittedAtMs" : 754.700125,
+              "tokenChecksum" : "86195786012be905",
+              "ttftMs" : 24544.999209
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "promptTokensPerRequest" : 8192,
+  "schemaVersion" : 4
+}

--- a/provider-swift/Sources/ProviderBenchmark/SchedulerPrefillBenchmark.swift
+++ b/provider-swift/Sources/ProviderBenchmark/SchedulerPrefillBenchmark.swift
@@ -11,7 +11,9 @@ public struct SchedulerPrefillBenchmarkReport: Codable, Sendable {
     ///    UNVERSIONED payload predates the backend pin and cannot say which
     ///    backend it measured, so a gate must refuse it rather than assume.
     /// 2 adds required effective config-projected Gemma settings.
-    public static let currentSchemaVersion = 2
+    /// 3 adds `soloPrefillStripeTokens` — the effective solo-stripe posture
+    /// the measured engines were built with (nil/absent = plain 512 chunks).
+    public static let currentSchemaVersion = 3
 
     public struct Sample: Codable, Sendable {
         public let strategy: String

--- a/provider-swift/Sources/ProviderBenchmark/SchedulerPrefillBenchmark.swift
+++ b/provider-swift/Sources/ProviderBenchmark/SchedulerPrefillBenchmark.swift
@@ -37,6 +37,10 @@ public struct SchedulerPrefillBenchmarkReport: Codable, Sendable {
     public let gemmaOptimizations: BenchmarkGemmaOptimizations
     /// Selection versus the backends the measured engines were built with.
     public let kvBackend: BenchmarkKVBackend
+    /// Effective `DARKBLOOM_CBV2_SOLO_PREFILL_STRIPE` the measured engines
+    /// were built with (nil = plain 512-token chunks). Recorded so a stripe
+    /// arm can never masquerade as a plain-chunk baseline.
+    public let soloPrefillStripeTokens: Int?
     public let samples: [Sample]
 
     public func jsonString() throws -> String {
@@ -151,6 +155,8 @@ public enum SchedulerPrefillBenchmark {
                 settings: gemmaOptimizations),
             kvBackend: BenchmarkKVBackend(
                 selection: kvBackend.rawValue, resolved: resolved),
+            soloPrefillStripeTokens: EngineV2Factory.soloPrefillStripeTokens(
+                abovePlainChunk: CBv2SchedulerConfig().prefillChunkSize),
             samples: samples
         )
     }

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Factory+Production.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Factory+Production.swift
@@ -817,9 +817,10 @@ extension EngineV2Factory {
         var schedulerConfig = CBv2SchedulerConfig(
             maxConcurrentRequests: max(1, maxConcurrentRequests))
         schedulerConfig.soloPrefillStripeTokens = Self.soloPrefillStripeTokens(
-            abovePlainChunk: schedulerConfig.prefillChunkSize)
-        schedulerConfig.maxConcurrentPartialPrefills = ProcessInfo.processInfo
-            .environment["DARKBLOOM_CBV2_MAX_PARTIAL_PREFILLS"].flatMap(Int.init)
+            abovePlainChunk: schedulerConfig.prefillChunkSize,
+            environment: environment)
+        schedulerConfig.maxConcurrentPartialPrefills =
+            environment["DARKBLOOM_CBV2_MAX_PARTIAL_PREFILLS"].flatMap(Int.init)
             .flatMap { $0 > 0 ? $0 : nil }
 
         func contiguousPreparation() throws -> ProductionBackendPreparation {

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Factory+Production.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Factory+Production.swift
@@ -810,6 +810,9 @@ extension EngineV2Factory {
             maxConcurrentRequests: max(1, maxConcurrentRequests))
         schedulerConfig.soloPrefillStripeTokens = Self.soloPrefillStripeTokens(
             abovePlainChunk: schedulerConfig.prefillChunkSize)
+        schedulerConfig.maxConcurrentPartialPrefills = ProcessInfo.processInfo
+            .environment["DARKBLOOM_CBV2_MAX_PARTIAL_PREFILLS"].flatMap(Int.init)
+            .flatMap { $0 > 0 ? $0 : nil }
 
         func contiguousPreparation() throws -> ProductionBackendPreparation {
             let backend = CBv2ContiguousKVBackend(

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Factory+Production.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Factory+Production.swift
@@ -112,16 +112,24 @@ extension EngineV2Factory {
     /// that model family's routed experts off the tile route.
     public static let soloPrefillStripeKey = "DARKBLOOM_CBV2_SOLO_PREFILL_STRIPE"
 
-    /// Parse the solo-stripe env override. Values must exceed the plain
-    /// chunk size to arm; anything unparsable, non-positive, or not above
-    /// the plain chunk disarms (nil) so a stray export cannot shrink chunks.
+    /// Serving default for the solo-prefill stripe (tokens). 2,048 is the
+    /// largest expert-tile-qualified stripe (16,384 assignments at top-8)
+    /// and the measured winner with trust + prompt narrowing.
+    public static let defaultSoloPrefillStripeTokens = 2048
+
+    /// Resolve the solo-stripe setting: absent env -> the serving default;
+    /// an explicit value above the plain chunk overrides; any other
+    /// explicit value (`0`, garbage, <= plain chunk) DISARMS — the escape
+    /// hatch mirrors the `=1` drain-restore convention.
     public static func soloPrefillStripeTokens(
         abovePlainChunk plainChunk: Int,
         environment: [String: String] = ProcessInfo.processInfo.environment
     ) -> Int? {
-        guard let raw = environment[soloPrefillStripeKey],
-            let value = Int(raw), value > plainChunk
-        else { return nil }
+        guard let raw = environment[soloPrefillStripeKey] else {
+            return defaultSoloPrefillStripeTokens > plainChunk
+                ? defaultSoloPrefillStripeTokens : nil
+        }
+        guard let value = Int(raw), value > plainChunk else { return nil }
         return value
     }
 

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Factory+Production.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Factory+Production.swift
@@ -105,6 +105,26 @@ extension EngineV2Factory {
     }
 
 
+    /// Environment key arming the CBv2 solo-prefill stripe (tokens). See
+    /// `CBv2SchedulerConfig.soloPrefillStripeTokens` for semantics. 2,048 is
+    /// the largest expert-tile-qualified stripe for the E=256 top-8 MoE
+    /// geometry (16,384 assignments); larger values remain correct but drop
+    /// that model family's routed experts off the tile route.
+    public static let soloPrefillStripeKey = "DARKBLOOM_CBV2_SOLO_PREFILL_STRIPE"
+
+    /// Parse the solo-stripe env override. Values must exceed the plain
+    /// chunk size to arm; anything unparsable, non-positive, or not above
+    /// the plain chunk disarms (nil) so a stray export cannot shrink chunks.
+    public static func soloPrefillStripeTokens(
+        abovePlainChunk plainChunk: Int,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> Int? {
+        guard let raw = environment[soloPrefillStripeKey],
+            let value = Int(raw), value > plainChunk
+        else { return nil }
+        return value
+    }
+
     /// Clamp a KV admission ceiling to physical unified memory. A ceiling
     /// above physical RAM can only come from a mis-derivation upstream; the
     /// engine would then admit requests that can never fit. Pure/static so it
@@ -786,8 +806,10 @@ extension EngineV2Factory {
         // paged pool's `maxPrefillChunk` below AND is the instance the
         // engine runs on — `assembleProductionBuild` reads it back off the
         // preparation and sets only `enablePrefixCache`.
-        let schedulerConfig = CBv2SchedulerConfig(
+        var schedulerConfig = CBv2SchedulerConfig(
             maxConcurrentRequests: max(1, maxConcurrentRequests))
+        schedulerConfig.soloPrefillStripeTokens = Self.soloPrefillStripeTokens(
+            abovePlainChunk: schedulerConfig.prefillChunkSize)
 
         func contiguousPreparation() throws -> ProductionBackendPreparation {
             let backend = CBv2ContiguousKVBackend(
@@ -857,7 +879,13 @@ extension EngineV2Factory {
                             // value to `EngineV2`, copying it only to set
                             // `enablePrefixCache`. There is no second config
                             // left to drift from.
-                            maxPrefillChunk: schedulerConfig.prefillChunkSize,
+                            maxPrefillChunk: max(
+                                schedulerConfig.prefillChunkSize,
+                                // A solo stripe is a chunk the engine can
+                                // actually schedule, so the lockstep above
+                                // must cover it or a striped windowed-layer
+                                // update would trap the process.
+                                schedulerConfig.soloPrefillStripeTokens ?? 0),
                             nominalMaxSequenceLength: max(
                                 1, maxContextLength ?? 8192),
                             maxBufferLength: maxBufferLength),

--- a/provider-swift/Tests/ProviderCoreTests/EngineV2KVBackendGateTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/EngineV2KVBackendGateTests.swift
@@ -573,9 +573,15 @@ struct EngineV2KVBackendGateTests {
         // `assembleProductionBuild`; this pins the pool against it so a
         // re-introduced parallel constant fails here instead of aborting
         // the daemon under a long windowed prefill.
+        // The solo-prefill stripe (default-on) is a chunk the engine can
+        // actually schedule, so the lockstep covers max(chunk, stripe).
         #expect(
             paged.pool.config.maxPrefillChunk
-                == prepared.schedulerConfig.prefillChunkSize)
+                == max(
+                    prepared.schedulerConfig.prefillChunkSize,
+                    prepared.schedulerConfig.soloPrefillStripeTokens ?? 0))
+        #expect(prepared.schedulerConfig.soloPrefillStripeTokens
+            == EngineV2Factory.defaultSoloPrefillStripeTokens)
         #expect(prepared.schedulerConfig.maxConcurrentRequests == 2)
         // Prefix caching is the ONLY field assembly may still decide, and
         // it is off until a cache instance is supplied.

--- a/scripts/gemma_contbatch/config.py
+++ b/scripts/gemma_contbatch/config.py
@@ -22,7 +22,13 @@ from pathlib import Path
 #       whole run's population rather than the sweep's.
 #   5 — required effective config-projected Gemma settings, validated across
 #       all three subprocesses and pinned for baseline comparisons.
-SCHEMA_VERSION = 5
+#   6 — CBv2 prefill-stack default flip (solo stripe 2048 + prompt narrowing
+#       + packed prefill, d-inference#646): raw scheduler-prefill schema is 3
+#       and records `soloPrefillStripeTokens`. Pre-flip baselines measured
+#       plain 512-token chunks under identical-looking empty environments,
+#       so cross-flip deltas would misattribute the posture change as a code
+#       delta; the exact-match schema pin refuses them.
+SCHEMA_VERSION = 6
 
 
 DEFAULT_MODEL = "mlx-community/gemma-4-26B-A4B-it-qat-4bit"

--- a/scripts/gemma_contbatch/tests/fixtures.py
+++ b/scripts/gemma_contbatch/tests/fixtures.py
@@ -117,11 +117,13 @@ def scheduler_payload(
     the binary emits it.
     """
     return {
-        "schemaVersion": 2,
+        "schemaVersion": 3,
         "modelID": MODEL_ID,
         "modelPath": MODEL_PATH,
         "gemmaOptimizations": copy.deepcopy(GEMMA_OPTIMIZATIONS),
         "kvBackend": {"selection": selection, "resolved": [resolved]},
+        # Default-on solo-stripe posture, as the schema-3 binary emits it.
+        "soloPrefillStripeTokens": 2048,
         "samples": [
             {
                 "promptTokens": length,

--- a/scripts/gemma_contbatch/validation.py
+++ b/scripts/gemma_contbatch/validation.py
@@ -11,7 +11,7 @@ from .checks import assert_finite, require_positive
 
 RAW_SCHEMA_VERSIONS = {
     "throughput sweep": 5,
-    "scheduler prefill": 2,
+    "scheduler prefill": 3,
     "arrival invariance": 4,
 }
 


### PR DESCRIPTION
## What

CBv2 prefill stack, enabled by default, all levers individually escapable:

1. **Solo-prefill stripe** (default 2048): one live text request widens its chunk 512→2048. Escape: `DARKBLOOM_CBV2_SOLO_PREFILL_STRIPE=0`.
2. **Recurrent prompt narrowing** (Qwen LM head): intermediate chunks return a `[B,1]` handle, the frontier projects one row instead of `[1,512,248320]` (242.5 MiB/chunk). Escape: `DARKBLOOM_CBV2_PREFILL_NARROWING=0`.
3. **Packed prefill for Qwen3.6**: equal-length chunks from B requests run as one `[B,L]` forward (one weight stream per cohort; per-row recurrent state). Text-only v1.
4. **Mean-TTFT prefill serialization** (`DARKBLOOM_CBV2_MAX_PARTIAL_PREFILLS`, opt-in).

Companion mlx-swift-lm PR carries the engine/model changes; this PR wires env/defaults + pin.

## Measured (M4 Max, Qwen3.6 35B-A3B, HPM, 8K, 3-iter medians)

| config | TTFT | prefill tok/s |
|---|---:|---:|
| 2026-08-18 baseline (`=1`, 512) | 6406.8 ms | 1,279 |
| trust (#638) + stripe | 5306.3 ms | 1,544 |
| **+ narrowing (this stack, solo)** | **4636.9 ms** | **~1,766 (+38%)** |
| multi-request 4x8K aggregate (was 1,312) | — | **1,479-1,537 (+13-17%)** |

`outputsMatchBurst=true` on every arrival pattern (token-checksum parity across all levers). Tests: 16 feature + 166 regression suites green. Solo stripe regresses ~12% under Low Power Mode — throttled machines should export the stripe escape (documented in `docs/reports/2026-08-19-solo-prefill-stripe-experiment.md`).

## Behavior

```mermaid
flowchart LR
  subgraph Before
    A1[solo 8K prompt] --> B1[16x512 chunks - full logits each]
    A2[4x8K burst] --> B2[per-row forwards - 4x weight streams - all TTFTs = makespan]
  end
  subgraph After
    C1[solo 8K prompt] --> D1[4x2048 stripes - frontier-row-only projection]
    C2[4x8K burst] --> D2["packed [4,512] cohorts - one weight stream - +13-17% aggregate"]
    D1 --> E1[company arrives -> next plan is plain 512s]
  end
```

## Code

```mermaid
flowchart LR
  subgraph Before
    P1[plan: chunk=min(rem,512,budget)] --> F1[targetForward full logits] --> N1[engine slice]
  end
  subgraph After
    P2[plan: solo gate / partial-prefill cap] --> F2["targetForward(requirement:)"]
    F2 -->|CBv2RecurrentPrefillSteppableModel| M2[model narrows: B,1 handle or one-row LM head]
    F2 -->|fallback| N2[engine slice - byte-old]
    G2[packed executor] -->|recurrent group| F2
  end
```

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/646"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789777191&installation_model_id=21733&pr_number=646&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F646&signature=d2a910b69740df28e26094141a9f01dbc352c397062db2e637c1630da9fd4a7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->