### PR TITLE
chore(release): prepare provider v0.8.6 — default-on CBv2 prefill stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,24 @@
 # Changelog
 
-## Unreleased (v0.8.5 candidate - provider)
+## v0.8.6 (2026-08-20)
+
+### Provider (Swift)
+
+#### Performance
+
+- **CBv2 prefill stack, default-on** — Cold prefill 6,406.8 → 4,636.9 ms at 8K on the M4 Max prod artifact (**~1,766 tok/s, +38% vs v0.8.5 defaults**); 4×8K burst aggregate 1,312 → ~1,500 tok/s (+13–17%) with token-checksum parity across every arrival pattern. Four independently escapable levers (#646, mlx-swift-lm#111):
+  - *Expert-tile `trust` serving default* — skips the per-chunk descriptor retract drain (80 stream drains/chunk); exact `MLX_GATHER_QMM_EXPERT_SLICES=1` restores the drain posture. (#638)
+  - *Solo-prefill stripe (2048)* — when exactly one live text request holds the scheduler, its chunk widens 512→2048 (weights streamed 4× less often, full 32-row expert tiles). Armed per-plan; any company disarms to plain 512s; KV-capacity failure shrinks once, never preempts; the stripe budget belongs exclusively to the armed row. `DARKBLOOM_CBV2_SOLO_PREFILL_STRIPE=0` disarms. **Known trade: ~12% TTFT regression under Low Power Mode — throttled/battery providers should export the escape.**
+  - *Recurrent prompt narrowing (Qwen LM head)* — intermediate chunks return a one-element handle instead of the `[1,512,248320]` logits tensor (242.5 MiB/chunk); the frontier chunk norms + projects exactly one row. `DARKBLOOM_CBV2_PREFILL_NARROWING=0` restores byte-old behavior.
+  - *Packed prefill (Qwen3.6)* — equal-length prompt chunks from concurrent requests run as one `[B,L]` forward with per-row recurrent state (one weight stream per cohort; text-only v1).
+- **Mean-TTFT prefill serialization** *(opt-in)* — `DARKBLOOM_CBV2_MAX_PARTIAL_PREFILLS=1` caps rows receiving prompt work per step (FCFS): burst TTFTs become a staircase instead of everyone waiting for the makespan. Paused rows hold no slot (a stalled consumer cannot head-of-line block admission). (#646)
+- **Adaptive persistent-history MTP promoted onto master** *(still behind the `mtp` beta flag)* — the v0.8.5-described capture-verify stack's adaptive width selection and persistent head KV now ship in the release pin. (#641, mlx-swift-lm#110)
+
+#### Benchmarks / Tooling
+
+- Scheduler-prefill report schema 3 (records the effective stripe posture); Gemma contbatch wrapper schema 6 — baseline pins refuse pre-default-flip reports so the posture change can never masquerade as a code delta. 14 review-hardening scheduler fixes with regression tests; measurement methodology + posture discipline in `docs/reports/2026-08-19-solo-prefill-stripe-experiment.md`. (#646)
+
+## v0.8.5 (2026-08-14)
 
 ### Provider (Swift)
 

--- a/coordinator/api/server.go
+++ b/coordinator/api/server.go
@@ -151,7 +151,7 @@ func keyLimitResetFromContext(ctx context.Context) string {
 // the provider's EngineV2Factory.prepareProductionBackend for the argument).
 // Keep this fallback in sync with ProviderCore.version so dev/in-memory
 // coordinators advertise the same floor as the Swift binary they expect.
-var LatestProviderVersion = "0.8.5"
+var LatestProviderVersion = "0.8.6"
 
 // minProviderVersionForDesiredModels is the first provider version whose Swift
 // runtime understands the desired_models message. The coordinator must NOT send

--- a/provider-swift/Sources/ProviderCore/ProviderCore.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderCore.swift
@@ -219,5 +219,10 @@ public enum ProviderCore {
     // target_prefix + single-forward drafts (1.13x, behind the mtp beta
     // flag), symlink-proof inline-MTP inspection, MTP /metrics counters,
     // and hardened plaintext egress paths.
-    public static let version = "0.8.5"
+    // 0.8.6 ships the default-on CBv2 prefill stack: expert-tile trust
+    // serving default, solo-prefill stripe (2048), Qwen prompt narrowing,
+    // and packed prefill — 8k cold prefill -27.6% (~1,766 tok/s, +38%) and
+    // 4x8k aggregate +13-17% vs 0.8.5 defaults; plus the opt-in mean-TTFT
+    // partial-prefill cap and adaptive persistent-history MTP (mtp beta).
+    public static let version = "0.8.6"
 }


### PR DESCRIPTION
Release prep for provider **v0.8.6** — the default-on CBv2 prefill stack.

## What
- `ProviderCore.version` 0.8.5 → **0.8.6** (+ version-history comment)
- `LatestProviderVersion` fallback in `coordinator/api/server.go` → 0.8.6 (display-path sync per AGENTS.md)
- CHANGELOG: v0.8.6 section (retitles the shipped v0.8.5 "Unreleased" section with its tag date)

## What v0.8.6 ships (already merged: #638, #641, #646 / mlx-swift-lm#111)
| lever | default | escape |
|---|---|---|
| expert-tile trust | on | `MLX_GATHER_QMM_EXPERT_SLICES=1` |
| solo-prefill stripe (2048) | on | `DARKBLOOM_CBV2_SOLO_PREFILL_STRIPE=0` |
| Qwen prompt narrowing | on | `DARKBLOOM_CBV2_PREFILL_NARROWING=0` |
| packed prefill (Qwen3.6, text) | on | capability-gated |
| mean-TTFT partial-prefill cap | **off (opt-in)** | `DARKBLOOM_CBV2_MAX_PARTIAL_PREFILLS` |

Measured (M4 Max, prod artifact): solo 8K TTFT **6406.8 → 4636.9 ms (~1,766 tok/s, +38%)**; 4×8K burst aggregate **+13–17%** with token-checksum parity. Known trade in release notes: ~12% stripe regression under Low Power Mode (escape documented).

```mermaid
flowchart LR
  subgraph Before[v0.8.5 fleet]
    A1[8K cold prefill] --> B1[512 chunks + drains + full logits<br/>6407 ms, 1279 tok/s]
  end
  subgraph After[v0.8.6 fleet]
    A2[8K cold prefill] --> B2[trust + stripe + narrowing + packed<br/>4637 ms, ~1766 tok/s]
  end
```

## Post-merge release steps
1. Tag the merge commit `v0.8.6` → `release-swift.yml` builds/signs/notarizes and registers via `POST /v1/releases` (hashes computed after signing).
2. Live checks on one provider: stock launch arms trust+stripe+narrowing+packed; each escape restores old behavior through launchd rewrite.
3. Fleet notes: LPM/battery operators export `DARKBLOOM_CBV2_SOLO_PREFILL_STRIPE=0`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/648"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789836281&installation_model_id=21733&pr_number=648&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F648&signature=3308303c223008a2e8029de8771fb4c894a1ace5f5abdaf7ed24062d2cdde7b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->