### PR TITLE
feat(api): expose OpenRouter aliases in model catalog

### DIFF
--- a/coordinator/api/model_alias_handlers_test.go
+++ b/coordinator/api/model_alias_handlers_test.go
@@ -1046,8 +1046,8 @@ func TestModelAliasTakeoverOfConcreteID(t *testing.T) {
 	}
 }
 
-// An OpenRouter-only alias clones every feed detail from a standard source
-// alias while overriding only id, marketplace slug, and Hugging Face identity.
+// An OpenRouter-only alias clones every model-list and dedicated-feed detail
+// from a standard source alias while overriding its configured identities.
 
 func TestOpenRouterAliasClonesSourceEntry(t *testing.T) {
 	t.Setenv("MODEL_REGISTRY_PUBLISHING_KEY", "publish-secret")
@@ -1115,7 +1115,8 @@ func TestOpenRouterAliasClonesSourceEntry(t *testing.T) {
 		t.Fatalf("PublicNameForBuild = %q, want source alias %s", got, baseAlias)
 	}
 
-	// The OpenRouter-only alias is intentionally absent from the normal catalog.
+	// The OpenRouter-only alias is discoverable in the normal catalog and
+	// differs from its source only in the identities that schema exposes.
 	listRec := httptest.NewRecorder()
 	srv.handleListModels(listRec, httptest.NewRequest(http.MethodGet, "/v1/models", nil))
 	if listRec.Code != http.StatusOK {
@@ -1129,11 +1130,18 @@ func TestOpenRouterAliasClonesSourceEntry(t *testing.T) {
 	for _, m := range listResp.Data {
 		listByID[m.ID] = m
 	}
-	if _, ok := listByID[baseAlias]; !ok {
-		t.Fatalf("source alias missing from /v1/models: %+v", listResp.Data)
+	baseModel, baseOK := listByID[baseAlias]
+	paidModel, paidOK := listByID[paidAlias]
+	if !baseOK || !paidOK {
+		t.Fatalf("aliases missing from /v1/models: %+v", listResp.Data)
 	}
-	if _, leaked := listByID[paidAlias]; leaked {
-		t.Fatalf("OpenRouter-only alias leaked into /v1/models: %+v", listResp.Data)
+	if paidModel.HuggingFaceID != paidHFID {
+		t.Fatalf("paid model hugging_face_id = %q, want %q", paidModel.HuggingFaceID, paidHFID)
+	}
+	paidModel.ID = baseModel.ID
+	paidModel.HuggingFaceID = baseModel.HuggingFaceID
+	if !reflect.DeepEqual(paidModel, baseModel) {
+		t.Fatalf("main catalog clone differs beyond identities: source=%+v clone=%+v", baseModel, paidModel)
 	}
 	if _, leaked := listByID[aliasQAT]; leaked {
 		t.Fatalf("shared build leaked into /v1/models: %+v", listResp.Data)

--- a/coordinator/api/models_endpoints.go
+++ b/coordinator/api/models_endpoints.go
@@ -24,15 +24,16 @@ func hideAliasBuild(hidden map[string]struct{}, catalogByID map[string]store.Sup
 }
 
 // aliasModelEntries builds the consumer-facing /v1/models entries for active
-// public aliases and returns the set of underlying build ids those aliases
-// cover (so the caller can hide them from the default listing). The hidden set
-// covers EVERY build an alias references — desired, previous, and the retired
-// lineage — so a concrete quant build never appears as its own entry once it is
-// behind an alias. Each alias entry derives its metadata from its primary build
-// — the desired build, or the previous build if the desired one isn't in the
-// catalog yet — and aggregates live capacity across the desired and previous
-// builds so the alias's routable/warm counts reflect every quant currently
-// serving it (retired builds are hide-only and never contribute capacity).
+// standard aliases and their OpenRouter-only clones, and returns the set of
+// underlying build ids those aliases cover (so the caller can hide them from
+// the default listing). The hidden set covers EVERY build a standard alias
+// references — desired, previous, and the retired lineage — so a concrete
+// quant build never appears as its own entry once it is behind an alias. Each
+// standard alias derives its metadata from its primary build — the desired
+// build, or the previous build if the desired one isn't in the catalog yet —
+// and aggregates live capacity across the desired and previous builds.
+// OpenRouter-only aliases clone that complete source entry and override only
+// their consumer-facing id and Hugging Face identity.
 func (s *Server) aliasModelEntries(
 	capByModel map[string]*registry.ModelCapacity,
 	catalogByID map[string]store.SupportedModel,
@@ -46,9 +47,9 @@ func (s *Server) aliasModelEntries(
 	}
 
 	entries := make([]types.ModelEntry, 0, len(aliases))
+	standardEntries := make(map[string]types.ModelEntry, len(aliases))
 	for _, a := range aliases {
 		if !a.Active || a.OpenRouterOnly || a.DesiredBuild == "" {
-
 			continue
 		}
 		// A consumer must only ever see the alias, never a concrete build behind
@@ -135,6 +136,25 @@ func (s *Server) aliasModelEntries(
 		}
 		entry.InputModalities, entry.OutputModalities = deriveModalities(cm.ModelType, caps)
 		entries = append(entries, entry)
+		standardEntries[a.AliasID] = entry
+	}
+
+	// OpenRouter-only aliases are already valid inference names. Surface them
+	// in the main catalog by cloning their standard source entry, without
+	// turning them into provider-convergence or canonical-naming aliases.
+	for _, a := range aliases {
+		if !a.Active || !a.OpenRouterOnly {
+			continue
+		}
+		source, ok := standardEntries[a.SourceModel]
+		if !ok || a.OpenRouterSlug == "" || a.HuggingFaceID == "" {
+			s.logger.Warn("model registry: OpenRouter alias source or identities unavailable", "alias_id", a.AliasID, "source_model", a.SourceModel)
+			continue
+		}
+		clone := source
+		clone.ID = a.AliasID
+		clone.HuggingFaceID = a.HuggingFaceID
+		entries = append(entries, clone)
 	}
 	return entries, hidden
 }

--- a/docs/reference/model-registry-format.md
+++ b/docs/reference/model-registry-format.md
@@ -166,13 +166,14 @@ OpenRouter feed clones are managed separately from rollout aliases:
 }
 ```
 
-`source_model` must be an active standard alias. The clone appears only in
-`GET /v1/models/openrouter`; it is omitted from the normal `GET /v1/models`
-catalog. OpenRouter can send the clone's `id` to the inference API, where it
+`source_model` must be an active standard alias. The clone appears in both
+`GET /v1/models/openrouter` and the normal `GET /v1/models` catalog. OpenRouter
+and ordinary consumers can send the clone's `id` to the inference API, where it
 resolves through the source alias's current desired/previous build pointers.
-The source supplies pricing, context limits, features, readiness, datacenters,
-and every other feed field. Future source build migrations therefore update the
-clone automatically; only `id`, `openrouter.slug`, and `hugging_face_id` differ.
+The source supplies pricing, context limits, features, readiness, capacity,
+datacenters, and every other applicable response field. Future source build
+migrations therefore update the clone automatically; only `id`,
+`openrouter.slug`, and `hugging_face_id` differ where those fields are exposed.
 
 ## Admin model actions
 


### PR DESCRIPTION
## Summary

- surface active OpenRouter-only aliases in `GET /v1/models`
- clone the source alias metadata while overriding `id` and `hugging_face_id`
- keep provider convergence, canonical naming, warm-pool behavior, and model swaps unchanged
- update the model-registry contract and alias regression coverage

## Before

```mermaid
flowchart LR
  subgraph Behavior
    A[GET /v1/models] --> B[Standard aliases only]
    C[OpenRouter-only alias] --> D[Hidden from main catalog]
    D --> E[Inference accepts an undiscoverable ID]
  end
  subgraph Code
    F[aliasModelEntries] --> G[Skip OpenRouterOnly entries]
    G --> H[listModelEntries]
    H --> I[ModelListResponse]
  end
```

## After

```mermaid
flowchart LR
  subgraph Behavior
    A[GET /v1/models] --> B[Standard source alias]
    A --> C[OpenRouter-only clone]
    B --> D[Source desired or previous build]
    C --> D
    D --> E[Existing provider fleet]
  end
  subgraph Code
    F[aliasModelEntries] --> G[Build standardEntries lookup]
    G --> H[Clone source ModelEntry]
    H --> I[Override id and hugging_face_id]
    I --> J[listModelEntries]
    K[syncModelAliases] --> L[OpenRouterOnly remains route-only]
  end
```

## Invariants

- OpenRouter-only aliases remain excluded from provider desired-state convergence and canonical build naming.
- The clone inherits pricing, context limits, capabilities, modalities, and live capacity from its standard source alias.
- Concrete builds behind the source alias remain hidden from the default catalog.
- `GET /v1/models/{id}` inherits the same visibility through the shared model-entry builder.

## Verification

- `go test ./api -run 'TestOpenRouterAliasClonesSourceEntry|TestOpenRouterAliasFollowsSourceAliasBuildUpdate' -count=1`
- `go test ./api -count=1`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/649"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789837523&installation_model_id=21733&pr_number=649&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F649&signature=c9c1287d5fefb91e162db9a986eaec13757b1893297edcb53c27cd7a8ac411f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->