### PR TITLE
fix(provider): restore Qwen normalization for v0.8.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v0.8.7 (2026-08-20)
+
+### Provider (Swift)
+
+#### Fixes
+
+- **Restore Qwen3.5/3.6 system-history normalization** — The compatibility fix released on the `v0.8.5` branch was absent from master and therefore from `v0.8.6`, causing Qwen's published template to reject OpenAI-compatible histories with a late system turn (`System message must be at the beginning`). Production Qwen 422s rose from 3.46–4.95% on `v0.8.5` to 27.73–33.95% on `v0.8.6`. Text-only system turns are again folded into one leading system message before generic tool-history validation; structured/media system content remains fail-closed.
+
 ## v0.8.6 (2026-08-20)
 
 ### Provider (Swift)

--- a/coordinator/api/server.go
+++ b/coordinator/api/server.go
@@ -151,7 +151,7 @@ func keyLimitResetFromContext(ctx context.Context) string {
 // the provider's EngineV2Factory.prepareProductionBackend for the argument).
 // Keep this fallback in sync with ProviderCore.version so dev/in-memory
 // coordinators advertise the same floor as the Swift binary they expect.
-var LatestProviderVersion = "0.8.6"
+var LatestProviderVersion = "0.8.7"
 
 // minProviderVersionForDesiredModels is the first provider version whose Swift
 // runtime understands the desired_models message. The coordinator must NOT send

--- a/provider-swift/Sources/ProviderCore/Inference/ChatTemplateFixes.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/ChatTemplateFixes.swift
@@ -5,6 +5,7 @@
 // after the model family so future fixes do not bleed across templates.
 
 import Foundation
+import MLXLMServer
 
 struct ChatTemplateFixContext: Sendable {
     let modelId: String?
@@ -34,6 +35,17 @@ enum ChatTemplateFixes {
             return try Gemma4TemplateFix.normalizeMessages(normalized)
         }
         return normalized
+    }
+
+    /// Typed request path used by multimodal preparation. Other model-family
+    /// hooks operate on tokenizer dictionaries; Qwen's ordering repair must run
+    /// earlier because the vision processor renders directly from typed messages.
+    static func normalizeMessages(
+        _ messages: [OpenAIChatMessage],
+        context: ChatTemplateFixContext
+    ) -> [OpenAIChatMessage] {
+        guard Qwen35TemplateFix.applies(to: context) else { return messages }
+        return Qwen35TemplateFix.normalizeMessages(messages)
     }
 
     static func normalizeTools(

--- a/provider-swift/Sources/ProviderCore/Inference/ChatTemplateFixes.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/ChatTemplateFixes.swift
@@ -22,15 +22,18 @@ enum ChatTemplateFixes {
         context: ChatTemplateFixContext
     ) throws -> [[String: any Sendable]] {
         let sanitized = sanitizeJinjaMessages(messages)
-        try validateGenericToolHistory(sanitized)
+        let normalized = Qwen35TemplateFix.applies(to: context)
+            ? Qwen35TemplateFix.normalizeMessages(sanitized)
+            : sanitized
+        try validateGenericToolHistory(normalized)
 
         if GPTOSSHarmonyTemplateFix.applies(to: context) {
-            return try GPTOSSHarmonyTemplateFix.normalizeMessages(sanitized)
+            return try GPTOSSHarmonyTemplateFix.normalizeMessages(normalized)
         }
         if Gemma4TemplateFix.applies(to: context) {
-            return try Gemma4TemplateFix.normalizeMessages(sanitized)
+            return try Gemma4TemplateFix.normalizeMessages(normalized)
         }
-        return sanitized
+        return normalized
     }
 
     static func normalizeTools(

--- a/provider-swift/Sources/ProviderCore/Inference/MultiModelBatchSchedulerEngine+Registry.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/MultiModelBatchSchedulerEngine+Registry.swift
@@ -61,6 +61,19 @@ public extension MultiModelBatchSchedulerEngine {
         }
     }
 
+    /// Tokenizer plus the loaded model type used by token utility endpoints.
+    /// `/apply-template` needs both: model-family normalization must not depend
+    /// on a registry ID containing a recognizable family name.
+    struct TokenizerResolution: Sendable {
+        public let tokenizer: TokenizerHandle
+        public let modelType: String?
+
+        public init(tokenizer: TokenizerHandle, modelType: String?) {
+            self.tokenizer = tokenizer
+            self.modelType = modelType
+        }
+    }
+
     /// Snapshot type returned by `registryProvider`. Keyed by model id
     /// exactly as it appears in `OpenAIChatCompletionRequest.model`.
     typealias Registry = [String: ModelRegistryEntry]

--- a/provider-swift/Sources/ProviderCore/Inference/MultiModelBatchSchedulerEngine.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/MultiModelBatchSchedulerEngine.swift
@@ -47,7 +47,7 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
     /// `/apply-template`. When `acquire` is in use, this is the only
     /// way to find a tokenizer for the utility endpoints (since
     /// `registryProvider` is nil in that mode).
-    private let tokenizerProvider: (@Sendable (String?) async throws -> TokenizerHandle)?
+    private let tokenizerProvider: (@Sendable (String?) async throws -> TokenizerResolution)?
     /// Listing closure used by `availableModels()` when the engine was
     /// constructed via the atomic-`acquire` init. Returns the set of
     /// model IDs that should appear in `/v1/models`.
@@ -157,7 +157,7 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
     /// `/v1/models` discovery endpoint sees the full set (P2 #3).
     public init(
         acquire: @escaping @Sendable (String) async throws -> AcquiredModel,
-        tokenizerProvider: @escaping @Sendable (String?) async throws -> TokenizerHandle,
+        tokenizerProvider: @escaping @Sendable (String?) async throws -> TokenizerResolution,
         availableModels: @escaping @Sendable () async -> [String],
         defaultMaxTokens: Int = 4096
     ) {
@@ -266,6 +266,11 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
         // forwards, but media must first run the wrapper's vision tower and
         // splice its embeddings; token-only preparation would discard media.
         if isVLM, let container, MediaIngest.hasMedia(request) {
+            var visionRequest = request
+            visionRequest.messages = ChatTemplateFixes.normalizeMessages(
+                request.messages,
+                context: ChatTemplateFixContext(
+                    modelId: request.model, modelType: modelType))
             // `.auto` constrains nothing and `.none` hides the tools outright
             // (post-generation validation rejects any emitted call), so both
             // ride the media path unchanged. `.required`/`.named` need the
@@ -296,7 +301,7 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
             // if it won't fit we reject with a retryable error instead of OOMing.
             // Released on every exit.
             let mediaReqId = "vlm-\(UUID().uuidString.prefix(12))"
-            let projectedBytes = MediaIngest.projectedDecodeBytes(request)
+            let projectedBytes = MediaIngest.projectedDecodeBytes(visionRequest)
             // Scheduler-free vision gate (v0.7.5): the per-slot
             // `VisionMemoryGate` carries the slot's fp16 KV rate + context
             // window and reserves against the same shared budget the old
@@ -311,7 +316,7 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
             // output tokens would under-count the prompt + vision tokens that also
             // occupy KV.
             let kvTokens = MediaIngest.projectedKVTokens(
-                request, defaultMaxTokens: defaultMaxTokens,
+                visionRequest, defaultMaxTokens: defaultMaxTokens,
                 contextLength: mediaGate.contextLength)
             let mediaReserved = await mediaGate.reserve(
                 requestId: mediaReqId, mediaDecodeBytes: projectedBytes,
@@ -324,7 +329,7 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
                     + "(media decode ~\(mib) MiB + generation KV) — retry after capacity frees")
             }
             do {
-                try await MediaIngest.validateMedia(request)
+                try await MediaIngest.validateMedia(visionRequest)
             } catch {
                 await mediaGate.release(requestId: mediaReqId)
                 await releaseBox.fire()
@@ -354,7 +359,7 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
                 let plumbing = engineV2Vision ?? .production
                 do {
                     let visionPrepared = try await plumbing.prepare(
-                        container, request, reasoningEffort)
+                        container, visionRequest, reasoningEffort)
                     let visionRequestId = "req-\(UUID().uuidString.prefix(12))"
                     // Hand off memory accounting to the bridge BEFORE
                     // submit: the decode-phase peak this vision reservation
@@ -379,7 +384,7 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
                     let upstream = await bridge.submitTokenized(
                         promptTokens: visionPrepared.promptTokens,
                         request: Self.translate(
-                            openAIRequest: request, defaultMaxTokens: defaultMaxTokens,
+                            openAIRequest: visionRequest, defaultMaxTokens: defaultMaxTokens,
                             logprobs: engineV2Logprobs != nil ? true : nil,
                             topLogprobs: engineV2Logprobs?.topLogprobs,
                             logitBias: engineV2Sampling?.logitBias,
@@ -403,8 +408,8 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
                     // TTFT becomes the full thinking duration. Same probe
                     // as the text path below.
                     let synthesizeThinkOpen = ReasoningPromptProbe.shouldSynthesizeThinkOpen(
-                        reasoningParser: request.reasoningParser,
-                        stream: request.stream,
+                        reasoningParser: visionRequest.reasoningParser,
+                        stream: visionRequest.stream,
                         promptTokens: visionPrepared.promptTokens,
                         decodeTail: { tokenizer.inner.decode(tokenIds: $0, skipSpecialTokens: false) }
                     )
@@ -453,7 +458,7 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
                     }
                     await mediaGate.release(requestId: mediaReqId)
                     await releaseBox.fire()
-                    let mediaKind = EngineV2VisionPrefill.mediaKind(of: request)
+                    let mediaKind = EngineV2VisionPrefill.mediaKind(of: visionRequest)
                     plumbing.emitTelemetry(
                         EngineV2VisionPrefill.refusalTelemetryEvent(
                             modelId: modelId, mediaKind: mediaKind, error: visionError))
@@ -469,7 +474,7 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
                     // pre-content failover retries it invisibly elsewhere.
                     await mediaGate.release(requestId: mediaReqId)
                     await releaseBox.fire()
-                    let mediaKind = EngineV2VisionPrefill.mediaKind(of: request)
+                    let mediaKind = EngineV2VisionPrefill.mediaKind(of: visionRequest)
                     plumbing.emitTelemetry(
                         EngineV2VisionPrefill.refusalTelemetryEvent(
                             modelId: modelId, mediaKind: mediaKind, error: error))
@@ -842,8 +847,8 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
     }
 
     public func tokenize(_ request: TokenizeRequest) async throws -> TokenizeResponse {
-        let tokenizer = try await resolveTokenizer(modelId: request.model)
-        let tokens = tokenizer.inner.encode(
+        let resolved = try await resolveTokenizer(modelId: request.model)
+        let tokens = resolved.tokenizer.inner.encode(
             text: request.prompt,
             addSpecialTokens: request.addSpecialTokens ?? true
         )
@@ -851,8 +856,8 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
     }
 
     public func detokenize(_ request: DetokenizeRequest) async throws -> DetokenizeResponse {
-        let tokenizer = try await resolveTokenizer(modelId: request.model)
-        let text = tokenizer.inner.decode(
+        let resolved = try await resolveTokenizer(modelId: request.model)
+        let text = resolved.tokenizer.inner.decode(
             tokenIds: request.tokens,
             skipSpecialTokens: request.skipSpecialTokens ?? false
         )
@@ -860,13 +865,14 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
     }
 
     public func applyTemplate(_ request: ApplyTemplateRequest) async throws -> TokenizeResponse {
-        let tokenizer = try await resolveTokenizer(modelId: request.model)
+        let resolved = try await resolveTokenizer(modelId: request.model)
         let messages = request.messages.map { $0.templateMessageDict() }
         let tools = request.tools?.map { $0.toolSpec() }
         // Drop JSON `null` / `Optional` leaves the Jinja bridge
         // can't convert before rendering (mirrors `streamChatCompletion`).
-        let fixContext = ChatTemplateFixContext(modelId: request.model)
-        let tokens = try tokenizer.inner.applyChatTemplate(
+        let fixContext = ChatTemplateFixContext(
+            modelId: request.model, modelType: resolved.modelType)
+        let tokens = try resolved.tokenizer.inner.applyChatTemplate(
             messages: ChatTemplateFixes.normalizeMessages(messages, context: fixContext),
             tools: ChatTemplateFixes.normalizeTools(tools, context: fixContext),
             additionalContext: nil
@@ -879,13 +885,14 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
     /// Resolve the tokenizer for a request. If the request specifies a
     /// `model`, prefer that. Otherwise fall back to any resident model
     /// (sorted for determinism). Throws when no model is loaded.
-    private func resolveTokenizer(modelId: String?) async throws -> TokenizerHandle {
+    private func resolveTokenizer(modelId: String?) async throws -> TokenizerResolution {
         if let tokenizerProvider {
             return try await tokenizerProvider(modelId)
         }
         let registry = await (registryProvider?() ?? [:])
         if let modelId, let entry = registry[modelId] {
-            return entry.tokenizer
+            return TokenizerResolution(
+                tokenizer: entry.tokenizer, modelType: entry.modelType)
         }
         if let modelId, registry[modelId] == nil {
             throw MultiModelBatchSchedulerEngineError.modelNotLoaded(modelId)
@@ -893,7 +900,8 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
         if let firstKey = registry.keys.sorted().first,
             let entry = registry[firstKey]
         {
-            return entry.tokenizer
+            return TokenizerResolution(
+                tokenizer: entry.tokenizer, modelType: entry.modelType)
         }
         throw MultiModelBatchSchedulerEngineError.noModelLoadedForTokenization
     }

--- a/provider-swift/Sources/ProviderCore/Inference/Qwen35TemplateFixes.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/Qwen35TemplateFixes.swift
@@ -1,0 +1,84 @@
+// Copyright © 2026 Eigen Labs.
+//
+// Qwen 3.5/3.6's published chat template accepts a system message only at
+// messages[0]. OpenAI-compatible clients may legally append later system turns
+// to a conversation history. Fold those turns into one leading system message
+// before Jinja rendering instead of letting the template throw a deterministic
+// "System message must be at the beginning" error.
+
+import Foundation
+
+enum Qwen35TemplateFix {
+    static func applies(to context: ChatTemplateFixContext) -> Bool {
+        if let modelType = context.modelType?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased(),
+            modelType == "qwen3_5_moe"
+        {
+            return true
+        }
+
+        guard let modelId = context.modelId?.lowercased() else { return false }
+        return modelId.contains("qwen3.5")
+            || modelId.contains("qwen3_5")
+            || modelId.contains("qwen3.6")
+            || modelId.contains("qwen3_6")
+    }
+
+    static func normalizeMessages(
+        _ messages: [[String: any Sendable]]
+    ) -> [[String: any Sendable]] {
+        let systemIndices = messages.indices.filter {
+            (messages[$0]["role"] as? String) == "system"
+        }
+        guard let firstSystemIndex = systemIndices.first else { return messages }
+        guard systemIndices.count > 1 || firstSystemIndex != messages.startIndex else {
+            return messages
+        }
+
+        let nonSystemMessages = messages.filter {
+            ($0["role"] as? String) != "system"
+        }
+        if systemIndices.count == 1 {
+            return [messages[firstSystemIndex]] + nonSystemMessages
+        }
+
+        let systemMessages = systemIndices.map { messages[$0] }
+        var systemTexts: [String] = []
+        systemTexts.reserveCapacity(systemMessages.count)
+        for message in systemMessages {
+            guard let text = systemTextContent(message["content"]) else {
+                // Images, video, and unknown structured content are not safe to
+                // move into Qwen's leading system slot. Preserve the template's
+                // deterministic rejection instead of changing their semantics.
+                return messages
+            }
+            if !text.isEmpty { systemTexts.append(text) }
+        }
+
+        var mergedSystem = systemMessages[0]
+        mergedSystem["content"] = systemTexts.joined(separator: "\n\n")
+        return [mergedSystem] + nonSystemMessages
+    }
+
+    private static func systemTextContent(_ content: (any Sendable)?) -> String? {
+        guard let content else { return "" }
+        if let text = content as? String { return text }
+        guard let parts = content as? [any Sendable] else { return nil }
+
+        var text = ""
+        for part in parts {
+            guard let object = part as? [String: any Sendable],
+                  object["image"] == nil,
+                  object["image_url"] == nil,
+                  object["video"] == nil,
+                  object["video_url"] == nil,
+                  let partText = object["text"] as? String
+            else {
+                return nil
+            }
+            text += partText
+        }
+        return text
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Inference/Qwen35TemplateFixes.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/Qwen35TemplateFixes.swift
@@ -7,6 +7,7 @@
 // "System message must be at the beginning" error.
 
 import Foundation
+import MLXLMServer
 
 enum Qwen35TemplateFix {
     static func applies(to context: ChatTemplateFixContext) -> Bool {
@@ -59,6 +60,56 @@ enum Qwen35TemplateFix {
         var mergedSystem = systemMessages[0]
         mergedSystem["content"] = systemTexts.joined(separator: "\n\n")
         return [mergedSystem] + nonSystemMessages
+    }
+
+    /// Typed counterpart used by the multimodal path before `UserInput`
+    /// construction. It preserves user image/video parts byte-for-byte while
+    /// enforcing the same leading-system invariant as the dictionary/Jinja path.
+    static func normalizeMessages(
+        _ messages: [OpenAIChatMessage]
+    ) -> [OpenAIChatMessage] {
+        let systemIndices = messages.indices.filter {
+            messages[$0].role == .system
+        }
+        guard let firstSystemIndex = systemIndices.first else { return messages }
+        guard systemIndices.count > 1 || firstSystemIndex != messages.startIndex else {
+            return messages
+        }
+
+        let nonSystemMessages = messages.filter { $0.role != .system }
+        if systemIndices.count == 1 {
+            return [messages[firstSystemIndex]] + nonSystemMessages
+        }
+
+        let systemMessages = systemIndices.map { messages[$0] }
+        var systemTexts: [String] = []
+        systemTexts.reserveCapacity(systemMessages.count)
+        for message in systemMessages {
+            guard let text = systemTextContent(message.content) else {
+                return messages
+            }
+            if !text.isEmpty { systemTexts.append(text) }
+        }
+
+        var mergedSystem = systemMessages[0]
+        mergedSystem.content = .text(systemTexts.joined(separator: "\n\n"))
+        return [mergedSystem] + nonSystemMessages
+    }
+
+    private static func systemTextContent(_ content: OpenAIMessageContent) -> String? {
+        switch content {
+        case .text(let text):
+            return text
+        case .null:
+            return ""
+        case .parts(let parts):
+            var text = ""
+            for part in parts {
+                guard case .text(let partText) = part else { return nil }
+                text += partText
+            }
+            return text
+        }
     }
 
     private static func systemTextContent(_ content: (any Sendable)?) -> String? {

--- a/provider-swift/Sources/ProviderCore/ProviderCore.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderCore.swift
@@ -224,5 +224,9 @@ public enum ProviderCore {
     // and packed prefill — 8k cold prefill -27.6% (~1,766 tok/s, +38%) and
     // 4x8k aggregate +13-17% vs 0.8.5 defaults; plus the opt-in mean-TTFT
     // partial-prefill cap and adaptive persistent-history MTP (mtp beta).
-    public static let version = "0.8.6"
+    // 0.8.7 restores the Qwen3.5/3.6 late-system-message normalizer that
+    // shipped from the v0.8.5 release branch but was absent from master and
+    // therefore v0.8.6. Text-only system turns are folded into Qwen's required
+    // leading system slot; structured/media system content remains fail-closed.
+    public static let version = "0.8.7"
 }

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+InboundDecode.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+InboundDecode.swift
@@ -131,6 +131,7 @@ extension ProviderLoop {
     internal static func promptTokenFloor(
         request: OpenAIChatCompletionRequest,
         tokenizer: TokenizerHandle,
+        modelType: String?,
         reasoningEffort: String?
     ) -> Int {
         guard let prepared = try? ToolChoicePromptPolicy.prepare(request) else { return 0 }
@@ -141,7 +142,8 @@ extension ProviderLoop {
         // Must mirror the production tokenize path (sanitize JSON
         // null / Optional leaves) so this recount matches what was prefilled
         // and doesn't itself throw on a null-bearing request.
-        let fixContext = ChatTemplateFixContext(modelId: request.model)
+        let fixContext = ChatTemplateFixContext(
+            modelId: request.model, modelType: modelType)
         guard let ids = try? tokenizer.inner.applyChatTemplate(
             messages: ChatTemplateFixes.normalizeMessages(messages, context: fixContext),
             tools: ChatTemplateFixes.normalizeTools(toolSpecs, context: fixContext),

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+InferenceHandler.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+InferenceHandler.swift
@@ -857,6 +857,7 @@ extension ProviderLoop {
                 let terminal = partialUsage.cancelledTerminal(promptTokenFloor: Self.promptTokenFloor(
                     request: streamingRequest,
                     tokenizer: tokenizer,
+                    modelType: modelType,
                     reasoningEffort: reasoningEffort
                 ))
                 guard case .complete(let settledUsage) = terminal else {
@@ -912,6 +913,7 @@ extension ProviderLoop {
                     promptTokens = Self.promptTokenFloor(
                         request: streamingRequest,
                         tokenizer: tokenizer,
+                        modelType: modelType,
                         reasoningEffort: reasoningEffort
                     )
                     if promptTokens > 0 {

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+LocalEndpoint.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+LocalEndpoint.swift
@@ -158,17 +158,19 @@ extension ProviderLoop {
         localReservations.isReserved(modelId)
     }
 
-    /// Resolve a tokenizer for the local token-utility endpoints. Read-only, so
-    /// (unlike `acquireModelForLocal`) it takes no reservation.
-    func resolveTokenizerForLocal(_ modelId: String?) async throws -> TokenizerHandle {
+    /// Resolve tokenizer metadata for local token-utility endpoints. Read-only,
+    /// so (unlike `acquireModelForLocal`) it takes no reservation.
+    func resolveTokenizerForLocal(
+        _ modelId: String?
+    ) async throws -> MultiModelBatchSchedulerEngine.TokenizerResolution {
         if let modelId {
             guard let slot = modelSlots[modelId] else {
                 throw MultiModelBatchSchedulerEngineError.modelNotLoaded(modelId)
             }
-            return slot.tokenizer
+            return .init(tokenizer: slot.tokenizer, modelType: slot.modelType)
         }
         if let firstKey = modelSlots.keys.sorted().first, let slot = modelSlots[firstKey] {
-            return slot.tokenizer
+            return .init(tokenizer: slot.tokenizer, modelType: slot.modelType)
         }
         throw MultiModelBatchSchedulerEngineError.noModelLoadedForTokenization
     }

--- a/provider-swift/Sources/ProviderCore/Server/LocalInferenceHTTP.swift
+++ b/provider-swift/Sources/ProviderCore/Server/LocalInferenceHTTP.swift
@@ -52,7 +52,7 @@ public typealias LocalInferenceApplication =
 ///   - defaultMaxTokens: completion cap applied when a request omits `max_tokens`.
 ///   - acquire: ensure the model is loaded and return a reservation-held handle
 ///     (the release token is dropped by the engine when the request finishes).
-///   - tokenizerProvider: resolve a tokenizer for the token-utility endpoints.
+///   - tokenizerProvider: resolve tokenizer + loaded model type for token utilities.
 ///   - availableModels: the advertised `/v1/models` catalog (not just the
 ///     currently-resident subset — discovery clients call it before loading).
 ///   - mtpSlots: per-slot MTP posture samples for the `/metrics` MTP lines
@@ -67,7 +67,7 @@ func makeLocalInferenceApplication(
     config: LocalInferenceHTTPConfig,
     defaultMaxTokens: Int,
     acquire: @escaping @Sendable (String) async throws -> MultiModelBatchSchedulerEngine.AcquiredModel,
-    tokenizerProvider: @escaping @Sendable (String?) async throws -> TokenizerHandle,
+    tokenizerProvider: @escaping @Sendable (String?) async throws -> MultiModelBatchSchedulerEngine.TokenizerResolution,
     availableModels: @escaping @Sendable () async -> [String],
     mtpSlots: @escaping @Sendable () async -> [MTPSlotMetricsSample],
     onServerRunning: @escaping @Sendable (any Channel) async -> Void = { _ in }

--- a/provider-swift/Sources/ProviderCore/Server/StandaloneServer.swift
+++ b/provider-swift/Sources/ProviderCore/Server/StandaloneServer.swift
@@ -1083,14 +1083,16 @@ public actor StandaloneServer {
         )
     }
 
-    /// Resolve a tokenizer for the OpenAI token-utility endpoints
+    /// Resolve tokenizer metadata for the OpenAI token-utility endpoints
     /// (`/tokenize`, `/detokenize`, `/apply-template`). Unlike
     /// `acquireModel`, this does NOT bump a reservation: tokenizer
     /// access is read-only and finishes synchronously inside the
     /// upstream handler, so eviction races are not a concern.
-    func resolveTokenizer(_ modelId: String?) async throws -> TokenizerHandle {
+    func resolveTokenizer(
+        _ modelId: String?
+    ) async throws -> MultiModelBatchSchedulerEngine.TokenizerResolution {
         if let modelId, let slot = slots[modelId] {
-            return slot.tokenizer
+            return .init(tokenizer: slot.tokenizer, modelType: slot.modelType)
         }
         if let modelId, slots[modelId] == nil {
             throw MultiModelBatchSchedulerEngineError.modelNotLoaded(modelId)
@@ -1098,7 +1100,7 @@ public actor StandaloneServer {
         if let firstKey = slots.keys.sorted().first,
            let slot = slots[firstKey]
         {
-            return slot.tokenizer
+            return .init(tokenizer: slot.tokenizer, modelType: slot.modelType)
         }
         throw MultiModelBatchSchedulerEngineError.noModelLoadedForTokenization
     }

--- a/provider-swift/Tests/ProviderCoreTests/EngineV2CoResidencyLiveTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/EngineV2CoResidencyLiveTests.swift
@@ -395,8 +395,8 @@ struct EngineV2CoResidencyLiveTests {
     /// Tokenize a user turn with the LOADED model's tokenizer (chat template
     /// applied) — the same shape the production submit path produces.
     private func tokenize(_ text: String, loop: ProviderLoop) async throws -> [Int] {
-        let tokenizer = try await loop.resolveTokenizerForLocal(Self.gptossID)
-        return try tokenizer.inner.applyChatTemplate(
+        let resolved = try await loop.resolveTokenizerForLocal(Self.gptossID)
+        return try resolved.tokenizer.inner.applyChatTemplate(
             messages: [["role": "user", "content": text]],
             tools: nil, additionalContext: nil)
     }

--- a/provider-swift/Tests/ProviderCoreTests/EngineV2ProductionWiringTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/EngineV2ProductionWiringTests.swift
@@ -1674,7 +1674,9 @@ struct EngineV2RequestRoutingTests {
                     modelType: "gemma4",
                     engineV2Bridge: bridge)
             },
-            tokenizerProvider: { _ in TokenizerHandle(WiringStubTokenizer()) },
+            tokenizerProvider: { _ in .init(
+                tokenizer: TokenizerHandle(WiringStubTokenizer()),
+                modelType: "gemma4") },
             availableModels: { ["gemma-4-26b-qat-4bit"] }
         )
 
@@ -1701,7 +1703,9 @@ struct EngineV2RequestRoutingTests {
                     modelType: "gemma4",
                     engineV2Bridge: bridge)
             },
-            tokenizerProvider: { _ in TokenizerHandle(WiringStubTokenizer()) },
+            tokenizerProvider: { _ in .init(
+                tokenizer: TokenizerHandle(WiringStubTokenizer()),
+                modelType: "gemma4") },
             availableModels: { ["gemma-4-26b-qat-4bit"] }
         )
         let parameters: MLXLMCommon.JSONValue = .object([

--- a/provider-swift/Tests/ProviderCoreTests/EngineV2VisionRoutingTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/EngineV2VisionRoutingTests.swift
@@ -172,6 +172,16 @@ private final class PrepareCallCounter: @unchecked Sendable {
     func increment() { lock.withLock { _count += 1 } }
 }
 
+private final class VisionRequestCapture: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _messages: [OpenAIChatMessage]?
+    var messages: [OpenAIChatMessage]? { lock.withLock { _messages } }
+
+    func record(_ request: OpenAIChatCompletionRequest) {
+        lock.withLock { _messages = request.messages }
+    }
+}
+
 // MARK: - Harness
 
 /// One synthetic prepared submission: prompt `[7, 7, P, P, P, 8]` with a
@@ -217,6 +227,7 @@ private func makeRoutingEngine(
     container: ModelContainer?,
     bridge: EngineV2Bridge?,
     plumbing: EngineV2VisionPlumbing?,
+    modelType: String = "gemma4",
     visionGate: VisionMemoryGate? = nil,
     reasoningEffort: String? = nil
 ) -> MultiModelBatchSchedulerEngine {
@@ -225,7 +236,7 @@ private func makeRoutingEngine(
             [
                 "test/vlm-stub": .init(
                     tokenizer: TokenizerHandle(VisionStubTokenizer()),
-                    modelType: "gemma4",
+                    modelType: modelType,
                     container: container,
                     isVLM: true,
                     engineV2Bridge: bridge,
@@ -746,6 +757,41 @@ struct EngineV2VisionRoutingTests {
         let submitted = try #require(engine.submitted.first)
         #expect(submitted.promptTokens == prepared.promptTokens)
         #expect(try #require(submitted.multimodal).spans == prepared.spans)
+    }
+
+    @Test("Qwen media path normalizes late system turns before vision preparation")
+    func qwenMediaNormalizesLateSystemTurn() async throws {
+        let engine = VisionScriptedEngine(
+            script: .stream([
+                .delta(text: "ok", tokens: [10], logprobs: nil),
+                .finished(reason: .stop, usage: CBv2Usage(promptTokens: 6, completionTokens: 1)),
+            ]))
+        let bridge = makeBridge(engine: engine)
+        let (prepared, _) = makePreparedSubmission()
+        let capture = VisionRequestCapture()
+        let plumbing = EngineV2VisionPlumbing(
+            prepare: { _, request, _ in
+                capture.record(request)
+                return prepared
+            },
+            emitTelemetry: { _ in }
+        )
+        let router = makeRoutingEngine(
+            container: makeStubContainer(),
+            bridge: bridge,
+            plumbing: plumbing,
+            modelType: "qwen3_5_moe")
+        var request = imageRequest()
+        request.messages.append(.init(
+            role: .system, content: .text("late vision policy")))
+
+        let content = try await collectContent(
+            try await router.streamChatCompletion(request: request))
+        #expect(content == "ok")
+        let messages = try #require(capture.messages)
+        #expect(messages.map(\.role) == [.system, .user])
+        #expect(messages[0].content == .text("late vision policy"))
+        #expect(messages[1].content.hasMedia)
     }
 
     @Test("v2 success path releases the vision memory reservation exactly once")

--- a/provider-swift/Tests/ProviderCoreTests/Qwen35TemplateFixesTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/Qwen35TemplateFixesTests.swift
@@ -1,0 +1,160 @@
+import Testing
+
+@testable import ProviderCore
+
+@Suite("Qwen 3.5/3.6 template compatibility")
+struct Qwen35TemplateFixesTests {
+    private let qwenContext = ChatTemplateFixContext(
+        modelId: "qwen3.6-35b-a3b-vl-mtp-mxfp8",
+        modelType: "qwen3_5_moe")
+
+    private func message(
+        _ role: String,
+        _ content: String
+    ) -> [String: any Sendable] {
+        ["role": role, "content": content]
+    }
+
+    private func roles(_ messages: [[String: any Sendable]]) -> [String] {
+        messages.compactMap { $0["role"] as? String }
+    }
+
+    @Test func appliesOnlyToQwen35Family() {
+        #expect(Qwen35TemplateFix.applies(to: qwenContext))
+        #expect(Qwen35TemplateFix.applies(
+            to: .init(modelId: nil, modelType: "qwen3_5_moe")))
+        #expect(Qwen35TemplateFix.applies(
+            to: .init(modelId: "mlx-community/Qwen3.6-35B", modelType: nil)))
+        #expect(!Qwen35TemplateFix.applies(
+            to: .init(modelId: "qwen3-8b", modelType: "qwen3")))
+        #expect(!Qwen35TemplateFix.applies(
+            to: .init(modelId: "gemma-4-26b", modelType: "gemma4_text")))
+    }
+
+    @Test func movesSingleLateSystemMessageToBeginning() throws {
+        let normalized = try ChatTemplateFixes.normalizeMessages(
+            [
+                message("user", "first question"),
+                message("assistant", "first answer"),
+                message("system", "follow the updated policy"),
+                message("user", "next question"),
+            ],
+            context: qwenContext)
+
+        #expect(roles(normalized) == ["system", "user", "assistant", "user"])
+        #expect(normalized[0]["content"] as? String == "follow the updated policy")
+    }
+
+    @Test func mergesMultipleSystemMessagesInHistoryOrder() throws {
+        let normalized = try ChatTemplateFixes.normalizeMessages(
+            [
+                message("system", "base policy"),
+                message("user", "first question"),
+                message("system", "new restriction"),
+                message("assistant", "answer"),
+                message("system", "final reminder"),
+                message("user", "next question"),
+            ],
+            context: qwenContext)
+
+        #expect(roles(normalized) == ["system", "user", "assistant", "user"])
+        #expect(
+            normalized[0]["content"] as? String
+                == "base policy\n\nnew restriction\n\nfinal reminder")
+    }
+
+    @Test func normalizesBeforeGenericToolHistoryValidation() throws {
+        let toolCall: [String: any Sendable] = [
+            "id": "call-1",
+            "type": "function",
+            "function": [
+                "name": "lookup",
+                "arguments": [String: any Sendable](),
+            ] as [String: any Sendable],
+        ]
+        let assistant: [String: any Sendable] = [
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [toolCall] as [any Sendable],
+        ]
+        let toolResult: [String: any Sendable] = [
+            "role": "tool",
+            "content": "result",
+            "tool_call_id": "call-1",
+        ]
+
+        let normalized = try ChatTemplateFixes.normalizeMessages(
+            [
+                message("user", "look this up"),
+                assistant,
+                message("system", "use trusted sources"),
+                toolResult,
+            ],
+            context: qwenContext)
+
+        #expect(roles(normalized) == ["system", "user", "assistant", "tool"])
+    }
+
+    @Test func leavesVisionUserContentUntouched() throws {
+        let userContent: [any Sendable] = [
+            ["type": "text", "text": "describe this"] as [String: any Sendable],
+            [
+                "type": "image_url",
+                "image_url": ["url": "https://example.invalid/image.png"]
+                    as [String: any Sendable],
+            ] as [String: any Sendable],
+        ]
+        let user: [String: any Sendable] = ["role": "user", "content": userContent]
+
+        let normalized = try ChatTemplateFixes.normalizeMessages(
+            [user, message("system", "be concise")],
+            context: qwenContext)
+
+        #expect(roles(normalized) == ["system", "user"])
+        let normalizedContent = try #require(normalized[1]["content"] as? [any Sendable])
+        #expect(normalizedContent.count == 2)
+        #expect((normalizedContent[1] as? [String: any Sendable])?["type"] as? String == "image_url")
+    }
+
+    @Test func mergesTextPartSystemContent() throws {
+        let systemParts: [any Sendable] = [
+            ["type": "text", "text": "base "] as [String: any Sendable],
+            ["type": "text", "text": "policy"] as [String: any Sendable],
+        ]
+        let system: [String: any Sendable] = ["role": "system", "content": systemParts]
+
+        let normalized = try ChatTemplateFixes.normalizeMessages(
+            [system, message("user", "question"), message("system", "late reminder")],
+            context: qwenContext)
+
+        #expect(roles(normalized) == ["system", "user"])
+        #expect(normalized[0]["content"] as? String == "base policy\n\nlate reminder")
+    }
+
+    @Test func doesNotCoerceMediaSystemContent() throws {
+        let mediaContent: [any Sendable] = [
+            [
+                "type": "image_url",
+                "image_url": ["url": "https://example.invalid/system.png"]
+                    as [String: any Sendable],
+            ] as [String: any Sendable]
+        ]
+        let mediaSystem: [String: any Sendable] = [
+            "role": "system", "content": mediaContent,
+        ]
+
+        let normalized = try ChatTemplateFixes.normalizeMessages(
+            [message("system", "base"), message("user", "question"), mediaSystem],
+            context: qwenContext)
+
+        #expect(roles(normalized) == ["system", "user", "system"])
+    }
+
+    @Test func nonQwenHistoryIsNotReordered() throws {
+        let normalized = try ChatTemplateFixes.normalizeMessages(
+            [message("user", "question"), message("system", "late policy")],
+            context: .init(modelId: "gemma-4-26b", modelType: "gemma4_text"))
+
+        #expect(roles(normalized) == ["user", "system"])
+    }
+}

--- a/provider-swift/Tests/ProviderCoreTests/Qwen35TemplateFixesTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/Qwen35TemplateFixesTests.swift
@@ -1,6 +1,37 @@
 import Testing
+import MLXLMCommon
+import MLXLMServer
 
 @testable import ProviderCore
+
+private enum QwenTemplateTestError: Error {
+    case systemMessageNotFirst
+}
+
+private struct QwenSystemFirstTokenizer: MLXLMCommon.Tokenizer {
+    func encode(text: String, addSpecialTokens: Bool) -> [Int] {
+        Array(repeating: 0, count: text.count)
+    }
+
+    func decode(tokenIds: [Int], skipSpecialTokens: Bool) -> String { "" }
+    func convertTokenToId(_ token: String) -> Int? { nil }
+    func convertIdToToken(_ id: Int) -> String? { nil }
+    var bosToken: String? { nil }
+    var eosToken: String? { nil }
+    var unknownToken: String? { nil }
+
+    func applyChatTemplate(
+        messages: [[String: any Sendable]],
+        tools: [[String: any Sendable]]?,
+        additionalContext: [String: any Sendable]?
+    ) throws -> [Int] {
+        let roles = messages.compactMap { $0["role"] as? String }
+        guard roles.first == "system", !roles.dropFirst().contains("system") else {
+            throw QwenTemplateTestError.systemMessageNotFirst
+        }
+        return [1, 2, 3]
+    }
+}
 
 @Suite("Qwen 3.5/3.6 template compatibility")
 struct Qwen35TemplateFixesTests {
@@ -157,4 +188,56 @@ struct Qwen35TemplateFixesTests {
 
         #expect(roles(normalized) == ["user", "system"])
     }
+
+    @Test func typedMessagesPreserveVisionUserContent() throws {
+        let imagePart = OpenAIContentPart.imageURL("data:image/png;base64,AAAA")
+        let user = OpenAIChatMessage(
+            role: .user,
+            content: .parts([.text("describe this"), imagePart]))
+        let normalized = ChatTemplateFixes.normalizeMessages(
+            [user, .init(role: .system, content: .text("be concise"))],
+            context: qwenContext)
+
+        #expect(normalized.map(\.role) == [.system, .user])
+        #expect(normalized[0].content == .text("be concise"))
+        #expect(normalized[1].content == user.content)
+    }
+
+    @Test func applyTemplateUsesLoadedModelTypeForOpaqueID() async throws {
+        let engine = MultiModelBatchSchedulerEngine(
+            acquire: { modelId in
+                throw MultiModelBatchSchedulerEngineError.modelNotLoaded(modelId)
+            },
+            tokenizerProvider: { _ in
+                .init(
+                    tokenizer: TokenizerHandle(QwenSystemFirstTokenizer()),
+                    modelType: "qwen3_5_moe")
+            },
+            availableModels: { ["opaque-model"] })
+
+        let response = try await engine.applyTemplate(.init(
+            model: "opaque-model",
+            messages: [
+                .init(role: .user, content: .text("question")),
+                .init(role: .system, content: .text("late policy")),
+            ]))
+        #expect(response.tokens == [1, 2, 3])
+    }
+
+    @Test func promptTokenFloorUsesLoadedModelTypeForOpaqueID() {
+        let request = OpenAIChatCompletionRequest(
+            model: "opaque-model",
+            messages: [
+                .init(role: .user, content: .text("question")),
+                .init(role: .system, content: .text("late policy")),
+            ])
+
+        let floor = ProviderLoop.promptTokenFloor(
+            request: request,
+            tokenizer: TokenizerHandle(QwenSystemFirstTokenizer()),
+            modelType: "qwen3_5_moe",
+            reasoningEffort: nil)
+        #expect(floor == 3)
+    }
+
 }


### PR DESCRIPTION
## Summary

- restore the Qwen3.5/3.6 system-history normalizer that shipped on `release/v0.8.5` but never reached master
- fold text-only late/multiple system turns into Qwen's required leading system slot before generic tool-history validation
- normalize both text and multimodal serving paths while preserving user image/video parts byte-for-byte
- propagate loaded `model_type` through `/apply-template` and missing-usage prompt-floor reconstruction so correctness never depends on model-ID spelling
- preserve fail-closed behavior for structured/media system content and leave non-Qwen histories unchanged
- bump `ProviderCore.version` and the coordinator fallback to `0.8.7`

## Production incident

OpenRouter's last-30-minute sample after the `0.8.6` rollout:

| Model | Requests | 422s | Rate |
|---|---:|---:|---:|
| Qwen3.6 35B-A3B | 2,959 | 834 | **28.19%** |
| GPT-OSS 20B | 6,983 | 48 | 0.69% |
| Gemma 4 26B | 23,023 | 0 | 0% |

94.6% of all 422s were Qwen `jinja_template` failures. The same Qwen traffic was 3.46–4.95% on `0.8.5` versus 27.73–33.95% on `0.8.6`. Representative failures were tool-less, crossed many healthy providers, and terminated before first token with `failure_code=template_render`. Of a later 30-minute Qwen Jinja sample, 604 failures were text and 233 were vision requests.

Root cause: #629 targeted `release/v0.8.5`; master never received `Qwen35TemplateFix`, so `v0.8.6` regressed to passing late system turns directly into the published Qwen template, which requires the system message first.

## Before

```mermaid
flowchart LR
  subgraph Behavior
    A[OpenRouter history] --> B[Late system turn]
    B --> C[Qwen published template]
    C --> D[TemplateException]
    D --> E[HTTP 422 model_capability]
  end
  subgraph Code
    F[Text path] --> G[sanitize only]
    H[Vision path] --> I[original typed messages]
    J[apply-template / prompt floor] --> K[model id only]
    G --> C
    I --> C
    K --> C
  end
```

## After

```mermaid
flowchart LR
  subgraph Behavior
    A[OpenRouter history] --> B[Late or multiple text system turns]
    B --> C[One leading merged system turn]
    C --> D[Qwen template renders]
    D --> E[Inference proceeds]
  end
  subgraph Code
    F[Text dictionaries] --> G[Qwen35TemplateFix]
    H[Typed vision messages] --> G
    I[TokenizerResolution] --> J[model id + loaded model type]
    J --> K[apply-template / prompt floor]
    G --> D
    K --> D
    L[structured or media system content] --> M[preserve original order and fail closed]
  end
```

## Invariants

- Applies only to `qwen3_5_moe` / Qwen3.5 / Qwen3.6 identities.
- Preserves all non-system turn ordering.
- Merges text-only system turns in original history order.
- Preserves user image/video content on the multimodal path.
- Does not move or coerce structured/media system content.
- Runs before generic tool-result adjacency validation.
- `/apply-template` and prompt-floor recovery use the loaded model type even for opaque IDs.
- Non-Qwen histories remain unchanged.

## Version and rollout

- provider version: `0.8.7`
- coordinator no-release-row fallback: `0.8.7`
- after merge, tag the reviewed merge commit `v0.8.7` so `release-swift.yml` signs, notarizes, and registers a distinct release; do not replace the existing `0.8.6` artifact in place

## Verification

- `swift test --filter Qwen35TemplateFixesTests` — 11 tests passed
- `swift test --filter qwenMediaNormalizesLateSystemTurn` — actual vision routing regression passed
- `make provider-test` — 2,106 tests in 214 suites passed