### PR TITLE
perf(qwen): retain measured prefill optimizations on current master

### DIFF
--- a/docs/reports/2026-08-21-qwen-prefill-retained-optimizations.md
+++ b/docs/reports/2026-08-21-qwen-prefill-retained-optimizations.md
@@ -41,9 +41,18 @@ approximately `3.1e-6` for the small A/B projections.
 
 Qwen's sorted expert output is reduced through the inverse permutation directly
 into `[tokens, hidden]`, avoiding the `[tokens, topK, hidden]` assignment-order
-intermediate. This was positive only in a combined benchmark with router fusion,
-so this branch includes an explicit environment gate and a controlled isolated
-A/B is required before enabling it by default in production.
+intermediate. This remains behind `MLX_QWEN_DIRECT_EXPERT_REDUCTION` while full-model
+qualification is completed. A paired 25-sample primitive benchmark at the exact
+2048-token stripe geometry (`16,384 x 8 x 2,048` assignment tensor) measured:
+
+| Reduction | Median |
+|---|---:|
+| Legacy assignment tensor multiply + top-8 sum | 0.6389 ms |
+| Direct inverse-permutation weighted reduction | 0.3564 ms |
+| Primitive speedup | **1.793x (44.2% lower latency)** |
+
+This isolates a real local win. The expected full-model delta is smaller because
+expert projections dominate the MoE layer.
 
 ## Reverted / excluded
 

--- a/docs/reports/2026-08-21-qwen-prefill-retained-optimizations.md
+++ b/docs/reports/2026-08-21-qwen-prefill-retained-optimizations.md
@@ -42,8 +42,9 @@ approximately `3.1e-6` for the small A/B projections.
 Qwen's sorted expert output is reduced through the inverse permutation directly
 into `[tokens, hidden]`, avoiding the `[tokens, topK, hidden]` assignment-order
 intermediate. This is enabled by default. `MLX_QWEN_DIRECT_EXPERT_REDUCTION=0` restores
-the legacy assignment-tensor reduction for rollback and controlled A/B. A paired 25-sample primitive benchmark at the exact
-2048-token stripe geometry (`16,384 x 8 x 2,048` assignment tensor) measured:
+the legacy assignment-tensor reduction for rollback and controlled A/B. A paired 25-sample primitive benchmark at the exact 2,048-token stripe
+geometry measured the legacy tensor as `[2,048, 8, 2,048]`, flattened to
+`[16,384, 2,048]` for the direct path:
 
 | Reduction | Median |
 |---|---:|
@@ -53,6 +54,25 @@ the legacy assignment-tensor reduction for rollback and controlled A/B. A paired
 
 This isolates a real local win. The expected full-model delta is smaller because
 expert projections dominate the MoE layer.
+
+
+## Canonical implementation
+
+Line ranges are anchored to `mlx-swift-lm` branch `perf/qwen-prefill-retained` and should be
+re-anchored by symbol after later edits:
+
+- GDN projection topology, quantization guards, and fused projection:
+  `Libraries/MLXLLM/Models/Qwen35.swift:306-391`
+  (`exactQuantizedInputProjections`, `makeFusedInputProjection`, `projectInputs`).
+- Batched Qwen MoE flattening and direct-reduction caller:
+  `Libraries/MLXLLM/Models/Qwen35.swift:1190-1261`
+  (`qwen35FlattenMoEInputs`, `Qwen35SparseMoeBlock.callAsFunction`).
+- Default enablement and rollback parsing:
+  `Libraries/MLXLMCommon/SwitchLayers.swift:261-266`
+  (`qwenDirectExpertReductionEnabled`).
+- Exact production eligibility and legacy fallback:
+  `Libraries/MLXLMCommon/SwitchLayers.swift:493-581`
+  (`supportsWeightedExpertUnsort`, `callAndWeightedReduce`).
 
 ## Reverted / excluded
 

--- a/docs/reports/2026-08-21-qwen-prefill-retained-optimizations.md
+++ b/docs/reports/2026-08-21-qwen-prefill-retained-optimizations.md
@@ -1,0 +1,86 @@
+# Qwen Prefill Retained Optimizations on Current Master
+
+**Date:** 2026-08-21  
+**Base:** `origin/master` at `937a8a1d1` (through PR #650)  
+**Branch:** `perf/qwen-prefill-retained`
+
+## Purpose
+
+The earlier `perf/splitd-megakernel-prefill` branch combined confirmed wins,
+insufficiently isolated candidates, and rejected experiments on top of the
+pre-merge PR #646 history. This branch is rebuilt from current master and keeps
+only the post-#646 optimizations with positive speed evidence.
+
+## Retained
+
+### GDN 4-in-1 input projection fusion
+
+The 30 GDN layers replace four quantized input projections:
+
+```text
+2048 -> 8192  qkv
+2048 -> 4096  z
+2048 -> 32    beta
+2048 -> 32    decay
+```
+
+with one `2048 -> 12,352` quantized projection followed by views.
+
+Measured progression on the earlier qualification branch:
+
+| Prompt | Before | After | TTFT reduction |
+|---|---:|---:|---:|
+| 8K | 5,171.09 ms | 4,645.78 ms | 10.2% |
+| 16K | 11,416.72 ms | 10,729.91 ms | 6.0% |
+| 32K | 28,529.06 ms | 26,681.86 ms | 6.5% |
+
+The dedicated packed-W4 parity test measured zero difference for QKV/Z and
+approximately `3.1e-6` for the small A/B projections.
+
+### Direct weighted expert unsort reduction
+
+Qwen's sorted expert output is reduced through the inverse permutation directly
+into `[tokens, hidden]`, avoiding the `[tokens, topK, hidden]` assignment-order
+intermediate. This was positive only in a combined benchmark with router fusion,
+so this branch includes an explicit environment gate and a controlled isolated
+A/B is required before enabling it by default in production.
+
+## Reverted / excluded
+
+### D=256 Steel attention
+
+Excluded from this branch. Numerical correctness was established, but speed was
+not isolated in an adjacent, stable-power A/B. Earlier D=256 fused experiments
+also showed that bounded memory does not imply a speed win. It may be
+requalified separately.
+
+### Router + shared-expert gate fusion
+
+Excluded. Its measured step was a wash: about 1.8% slower at 8K and only
+0.7-0.8% faster at 16K/32K. That does not meet the bar for an always-on change.
+
+### MoE Mega-Kernel and GateUp+SwiGLU fusions
+
+All source experiments were reverted. The full one-threadgroup kernel destroyed
+Down output-column parallelism. The two correctly wired GateUp+SwiGLU candidates
+also regressed in paired microbenchmarks:
+
+| Candidate | Discrete | Fused | Result |
+|---|---:|---:|---:|
+| Two FP32 accumulators | 1.7977 ms | 3.0785 ms | 71.2% slower |
+| BF16-staged Gate tile | 1.8257 ms | 2.9847 ms | 63.5% slower |
+
+No Mega-Kernel code is present in the retained branch.
+
+## PR scope
+
+This master-based branch is intended to produce focused PRs:
+
+1. `mlx-swift-lm`: GDN 4-in-1 fusion and parity test.
+2. `mlx-swift-lm`: direct expert reduction behind an isolated qualification
+   gate, retained only if the new A/B is positive.
+3. Superproject: pin the qualified `mlx-swift-lm` commit and add production
+   benchmark evidence.
+
+The PR description must include before/after Mermaid diagrams for both behavior
+and code flow.

--- a/docs/reports/2026-08-21-qwen-prefill-retained-optimizations.md
+++ b/docs/reports/2026-08-21-qwen-prefill-retained-optimizations.md
@@ -35,7 +35,7 @@ Measured progression on the earlier qualification branch:
 | 32K | 28,529.06 ms | 26,681.86 ms | 6.5% |
 
 The dedicated packed-W4 parity test measured zero difference for QKV/Z and
-approximately `3.1e-6` for the small A/B projections.
+below `4.6e-6` for the small A/B projections.
 
 ### Direct weighted expert unsort reduction
 
@@ -61,7 +61,7 @@ expert projections dominate the MoE layer.
 Line ranges are anchored to `mlx-swift-lm` branch `perf/qwen-prefill-retained` and should be
 re-anchored by symbol after later edits:
 
-- GDN projection topology, quantization guards, and fused projection:
+- GDN projection inference-only quantization guards and fused projection:
   `Libraries/MLXLLM/Models/Qwen35.swift:306-396`
   (`exactQuantizedInputProjections`, `makeFusedInputProjection`, `projectInputs`).
 - Batched Qwen MoE flattening and direct-reduction caller:

--- a/docs/reports/2026-08-21-qwen-prefill-retained-optimizations.md
+++ b/docs/reports/2026-08-21-qwen-prefill-retained-optimizations.md
@@ -58,14 +58,14 @@ expert projections dominate the MoE layer.
 
 ## Canonical implementation
 
-Line ranges are anchored to `mlx-swift-lm` branch `perf/qwen-prefill-retained` and should be
+Line ranges are anchored to `mlx-swift-lm` merged commit `1483827b6c39e219685e0b5f3cf52b18a167ec00` and should be
 re-anchored by symbol after later edits:
 
 - GDN projection inference-only quantization guards and fused projection:
-  `Libraries/MLXLLM/Models/Qwen35.swift:306-396`
+  `Libraries/MLXLLM/Models/Qwen35.swift:306-516`
   (`exactQuantizedInputProjections`, `makeFusedInputProjection`, `projectInputs`).
 - Batched Qwen MoE flattening and direct-reduction caller:
-  `Libraries/MLXLLM/Models/Qwen35.swift:1195-1266`
+  `Libraries/MLXLLM/Models/Qwen35.swift:1311-1382`
   (`qwen35FlattenMoEInputs`, `Qwen35SparseMoeBlock.callAsFunction`).
 - Default enablement and rollback parsing:
   `Libraries/MLXLMCommon/SwitchLayers.swift:261-266`

--- a/docs/reports/2026-08-21-qwen-prefill-retained-optimizations.md
+++ b/docs/reports/2026-08-21-qwen-prefill-retained-optimizations.md
@@ -62,10 +62,10 @@ Line ranges are anchored to `mlx-swift-lm` branch `perf/qwen-prefill-retained` a
 re-anchored by symbol after later edits:
 
 - GDN projection topology, quantization guards, and fused projection:
-  `Libraries/MLXLLM/Models/Qwen35.swift:306-391`
+  `Libraries/MLXLLM/Models/Qwen35.swift:306-396`
   (`exactQuantizedInputProjections`, `makeFusedInputProjection`, `projectInputs`).
 - Batched Qwen MoE flattening and direct-reduction caller:
-  `Libraries/MLXLLM/Models/Qwen35.swift:1190-1261`
+  `Libraries/MLXLLM/Models/Qwen35.swift:1195-1266`
   (`qwen35FlattenMoEInputs`, `Qwen35SparseMoeBlock.callAsFunction`).
 - Default enablement and rollback parsing:
   `Libraries/MLXLMCommon/SwitchLayers.swift:261-266`

--- a/docs/reports/2026-08-21-qwen-prefill-retained-optimizations.md
+++ b/docs/reports/2026-08-21-qwen-prefill-retained-optimizations.md
@@ -41,8 +41,8 @@ approximately `3.1e-6` for the small A/B projections.
 
 Qwen's sorted expert output is reduced through the inverse permutation directly
 into `[tokens, hidden]`, avoiding the `[tokens, topK, hidden]` assignment-order
-intermediate. This remains behind `MLX_QWEN_DIRECT_EXPERT_REDUCTION` while full-model
-qualification is completed. A paired 25-sample primitive benchmark at the exact
+intermediate. This is enabled by default. `MLX_QWEN_DIRECT_EXPERT_REDUCTION=0` restores
+the legacy assignment-tensor reduction for rollback and controlled A/B. A paired 25-sample primitive benchmark at the exact
 2048-token stripe geometry (`16,384 x 8 x 2,048` assignment tensor) measured:
 
 | Reduction | Median |
@@ -86,8 +86,8 @@ No Mega-Kernel code is present in the retained branch.
 This master-based branch is intended to produce focused PRs:
 
 1. `mlx-swift-lm`: GDN 4-in-1 fusion and parity test.
-2. `mlx-swift-lm`: direct expert reduction behind an isolated qualification
-   gate, retained only if the new A/B is positive.
+2. `mlx-swift-lm`: default-on direct expert reduction with an explicit rollback
+   environment switch.
 3. Superproject: pin the qualified `mlx-swift-lm` commit and add production
    benchmark evidence.
 

--- a/docs/reports/2026-08-21-qwen-prefill-retained-pr-body.md
+++ b/docs/reports/2026-08-21-qwen-prefill-retained-pr-body.md
@@ -7,7 +7,7 @@ router fusion, and the rejected MoE Mega-Kernel experiments.
 Retained:
 
 - fuse the four GDN input projections into one quantized QMM;
-- add Qwen direct sorted-expert weighted reduction behind a qualification flag;
+- enable Qwen direct sorted-expert weighted reduction by default with an explicit rollback flag;
 - include parity and isolated performance tests.
 
 ## Before
@@ -44,7 +44,7 @@ flowchart LR
   subgraph Code_after[Code]
     Q2[Qwen35GatedDeltaNet.projectInputs] --> Fused[QuantizedLinear fused weights/scales/biases]
     Fused --> Views[QKV / Z / beta / decay views]
-    S2[SwitchGLU.callAndWeightedReduce] --> Gate{Qwen qualification flag}
+    S2[SwitchGLU.callAndWeightedReduce] --> Gate{Exact Qwen production shape}
     Gate -->|on and exact production shape| Direct[weightedExpertUnsort]
     Gate -->|otherwise| Legacy2[legacy fallback]
   end

--- a/docs/reports/2026-08-21-qwen-prefill-retained-pr-body.md
+++ b/docs/reports/2026-08-21-qwen-prefill-retained-pr-body.md
@@ -50,6 +50,13 @@ flowchart LR
   end
 ```
 
+## Canonical implementation
+
+- GDN fusion: `mlx-swift-lm/Libraries/MLXLLM/Models/Qwen35.swift:306-391`
+- Batched MoE flattening/caller: `mlx-swift-lm/Libraries/MLXLLM/Models/Qwen35.swift:1190-1261`
+- Direct-reduction default/rollback: `mlx-swift-lm/Libraries/MLXLMCommon/SwitchLayers.swift:261-266`
+- Eligibility/fallback: `mlx-swift-lm/Libraries/MLXLMCommon/SwitchLayers.swift:493-581`
+
 ## Evidence
 
 - GDN fusion parity: QKV/Z exact; A/B max difference approximately `4.1e-6`.

--- a/docs/reports/2026-08-21-qwen-prefill-retained-pr-body.md
+++ b/docs/reports/2026-08-21-qwen-prefill-retained-pr-body.md
@@ -52,8 +52,8 @@ flowchart LR
 
 ## Canonical implementation
 
-- GDN fusion: `mlx-swift-lm/Libraries/MLXLLM/Models/Qwen35.swift:306-391`
-- Batched MoE flattening/caller: `mlx-swift-lm/Libraries/MLXLLM/Models/Qwen35.swift:1190-1261`
+- GDN fusion: `mlx-swift-lm/Libraries/MLXLLM/Models/Qwen35.swift:306-396`
+- Batched MoE flattening/caller: `mlx-swift-lm/Libraries/MLXLLM/Models/Qwen35.swift:1195-1266`
 - Direct-reduction default/rollback: `mlx-swift-lm/Libraries/MLXLMCommon/SwitchLayers.swift:261-266`
 - Eligibility/fallback: `mlx-swift-lm/Libraries/MLXLMCommon/SwitchLayers.swift:493-581`
 

--- a/docs/reports/2026-08-21-qwen-prefill-retained-pr-body.md
+++ b/docs/reports/2026-08-21-qwen-prefill-retained-pr-body.md
@@ -1,0 +1,64 @@
+## Summary
+
+Rebases the retained Qwen prefill improvements onto current master after PRs
+#646-#650. It intentionally excludes the unqualified D=256 attention path,
+router fusion, and the rejected MoE Mega-Kernel experiments.
+
+Retained:
+
+- fuse the four GDN input projections into one quantized QMM;
+- add Qwen direct sorted-expert weighted reduction behind a qualification flag;
+- include parity and isolated performance tests.
+
+## Before
+
+```mermaid
+flowchart LR
+  subgraph Behavior_before[Behavior]
+    P1[Prompt chunk] --> G1[30 GDN layers]
+    G1 --> A1[4 input QMMs per GDN layer]
+    P1 --> M1[40 MoE layers]
+    M1 --> U1[Unsort to tokens x topK x hidden]
+    U1 --> R1[Multiply routing weights and reduce]
+  end
+  subgraph Code_before[Code]
+    Q1[Qwen35GatedDeltaNet] --> QKV[inProjQKV]
+    Q1 --> Z[inProjZ]
+    Q1 --> B[inProjB]
+    Q1 --> A[inProjA]
+    S1[SwitchGLU.callAndWeightedReduce] --> Legacy[scatterUnsort + weightedExpertSum]
+  end
+```
+
+## After
+
+```mermaid
+flowchart LR
+  subgraph Behavior_after[Behavior]
+    P2[Prompt chunk] --> G2[30 GDN layers]
+    G2 --> A2[1 fused 2048-to-12352 QMM per GDN layer]
+    P2 --> M2[40 MoE layers]
+    M2 --> R2[Optional direct inverse-permutation weighted reduction]
+    R2 --> O2[tokens x hidden]
+  end
+  subgraph Code_after[Code]
+    Q2[Qwen35GatedDeltaNet.projectInputs] --> Fused[QuantizedLinear fused weights/scales/biases]
+    Fused --> Views[QKV / Z / beta / decay views]
+    S2[SwitchGLU.callAndWeightedReduce] --> Gate{Qwen qualification flag}
+    Gate -->|on and exact production shape| Direct[weightedExpertUnsort]
+    Gate -->|otherwise| Legacy2[legacy fallback]
+  end
+```
+
+## Evidence
+
+- GDN fusion parity: QKV/Z exact; A/B max difference approximately `4.1e-6`.
+- Historical GDN step A/B: 10.2% lower TTFT at 8K, 6.0% at 16K, 6.5% at 32K.
+- Direct expert reduction isolated primitive benchmark: 0.6389 ms -> 0.3564 ms,
+  1.793x speedup at 2,048-token stripe geometry.
+
+## Excluded
+
+- D=256 Steel attention: correctness passed, speed not isolated under stable posture.
+- Router/shared-gate fusion: wash/regression at 8K.
+- MoE Mega-Kernel/GateUp+SwiGLU fusion: 63.5-71.2% slower in paired tests.

--- a/docs/reports/2026-08-21-qwen-prefill-retained-pr-body.md
+++ b/docs/reports/2026-08-21-qwen-prefill-retained-pr-body.md
@@ -52,8 +52,8 @@ flowchart LR
 
 ## Canonical implementation
 
-- GDN fusion: `mlx-swift-lm/Libraries/MLXLLM/Models/Qwen35.swift:306-396`
-- Batched MoE flattening/caller: `mlx-swift-lm/Libraries/MLXLLM/Models/Qwen35.swift:1195-1266`
+- GDN fusion: `mlx-swift-lm/Libraries/MLXLLM/Models/Qwen35.swift:306-516`
+- Batched MoE flattening/caller: `mlx-swift-lm/Libraries/MLXLLM/Models/Qwen35.swift:1311-1382`
 - Direct-reduction default/rollback: `mlx-swift-lm/Libraries/MLXLMCommon/SwitchLayers.swift:261-266`
 - Eligibility/fallback: `mlx-swift-lm/Libraries/MLXLMCommon/SwitchLayers.swift:493-581`
 

--- a/provider-swift/Sources/ProviderCore/Config/GemmaOptimizationEnvironment.swift
+++ b/provider-swift/Sources/ProviderCore/Config/GemmaOptimizationEnvironment.swift
@@ -6,6 +6,7 @@ public enum GemmaOptimizationEnvironment {
     public static let prefillLayer18Key = "DARKBLOOM_GEMMA4_PREFILL_CHUNK_EVAL"
     public static let weightedUnsortKey = "MLX_GEMMA4_FUSED_WEIGHTED_UNSORT"
     public static let safeR1Key = "MLX_GATHER_QMM_EXPERT_SLICES"
+    public static let qwenDirectExpertReductionKey = "MLX_QWEN_DIRECT_EXPERT_REDUCTION"
     /// Serving default when the expert-slice route is ON: skip the
     /// descriptor-retract readback (no mid-eval stream drain). The tile grid
     /// is already over-dispatched; unused slots early-return.
@@ -57,10 +58,13 @@ public enum GemmaOptimizationEnvironment {
         } else {
             safeR1 = "0"
         }
+        let qwenDirectReduction = context == .serving
+            && getenv(qwenDirectExpertReductionKey) == "0" ? "0" : "1"
         return [
             prefillLayer18Key: settings.prefillLayer18 ? "18" : "0",
             weightedUnsortKey: weightedR1,
             safeR1Key: safeR1,
+            qwenDirectExpertReductionKey: qwenDirectReduction,
         ]
     }
 

--- a/provider-swift/Sources/ProviderCore/Service/LaunchAgent.swift
+++ b/provider-swift/Sources/ProviderCore/Service/LaunchAgent.swift
@@ -285,6 +285,7 @@ public enum LaunchAgent: Sendable {
         "DARKBLOOM_MLX_RESOURCE_DEBUG", "DARKBLOOM_CBV2_PAGED_KV",
         "DARKBLOOM_CBV2_MTP", "DARKBLOOM_MTP_MAX_RECTANGULAR_TOKENS",
         "DARKBLOOM_KV_BACKEND_GUARD",
+        GemmaOptimizationEnvironment.qwenDirectExpertReductionKey,
     ]
 
     /// Build the daemon `EnvironmentVariables` map from a source environment,

--- a/provider-swift/Tests/ProviderCoreTests/GemmaOptimizationConfigTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/GemmaOptimizationConfigTests.swift
@@ -83,9 +83,10 @@ struct GemmaOptimizationEnvironmentTests {
         "DARKBLOOM_GEMMA4_PREFILL_CHUNK_EVAL",
         "MLX_GEMMA4_FUSED_WEIGHTED_UNSORT",
         "MLX_GATHER_QMM_EXPERT_SLICES",
+        "MLX_QWEN_DIRECT_EXPERT_REDUCTION",
     ]
 
-    @Test("projection emits exactly the three selected controls")
+    @Test("projection emits the selected controls")
     func exactProjection() {
         let enabled = GemmaOptimizationEnvironment.projection(
             for: GemmaOptimizationSettings(),
@@ -95,6 +96,7 @@ struct GemmaOptimizationEnvironmentTests {
             "DARKBLOOM_GEMMA4_PREFILL_CHUNK_EVAL": "18",
             "MLX_GEMMA4_FUSED_WEIGHTED_UNSORT": "1",
             "MLX_GATHER_QMM_EXPERT_SLICES": "trust",
+            "MLX_QWEN_DIRECT_EXPERT_REDUCTION": "1",
         ])
 
         let disabled = GemmaOptimizationEnvironment.projection(
@@ -108,7 +110,27 @@ struct GemmaOptimizationEnvironmentTests {
             "DARKBLOOM_GEMMA4_PREFILL_CHUNK_EVAL": "0",
             "MLX_GEMMA4_FUSED_WEIGHTED_UNSORT": "0",
             "MLX_GATHER_QMM_EXPERT_SLICES": "0",
+            "MLX_QWEN_DIRECT_EXPERT_REDUCTION": "1",
         ])
+    }
+
+    @Test("Qwen direct reduction defaults on and honors serving rollback")
+    func qwenDirectReductionDefaultAndRollback() {
+        let enabled = GemmaOptimizationEnvironment.projection(
+            for: GemmaOptimizationSettings(), getenv: { _ in nil })
+        #expect(enabled[GemmaOptimizationEnvironment.qwenDirectExpertReductionKey] == "1")
+
+        let rolledBack = GemmaOptimizationEnvironment.projection(
+            for: GemmaOptimizationSettings(),
+            getenv: { key in
+                key == GemmaOptimizationEnvironment.qwenDirectExpertReductionKey ? "0" : nil
+            })
+        #expect(rolledBack[GemmaOptimizationEnvironment.qwenDirectExpertReductionKey] == "0")
+
+        let validation = GemmaOptimizationEnvironment.projection(
+            for: GemmaOptimizationSettings(), context: .retainedValidation,
+            getenv: { _ in "0" })
+        #expect(validation[GemmaOptimizationEnvironment.qwenDirectExpertReductionKey] == "1")
     }
 
     @Test("weighted unsort and safe R1 stay coupled on or off")
@@ -239,6 +261,7 @@ struct GemmaOptimizationEnvironmentTests {
             "DARKBLOOM_GEMMA4_PREFILL_CHUNK_EVAL": "0",
             "MLX_GEMMA4_FUSED_WEIGHTED_UNSORT": "1",
             "MLX_GATHER_QMM_EXPERT_SLICES": "trust",
+            "MLX_QWEN_DIRECT_EXPERT_REDUCTION": "1",
         ])
         // The application boundary must hand the environment exactly what
         // projection() reports, or the release matrix describes a dispatch

--- a/provider-swift/Tests/ProviderCoreTests/LaunchAgentRestartTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/LaunchAgentRestartTests.swift
@@ -83,6 +83,14 @@ struct LaunchAgentEnvironmentTests {
         #expect(out == ["DARKBLOOM_MTP_MAX_RECTANGULAR_TOKENS": "4"])
     }
 
+    @Test func forwardsQwenDirectReductionRollbackToDaemon() {
+        let out = LaunchAgent.passthroughEnvironment(from: [
+            GemmaOptimizationEnvironment.qwenDirectExpertReductionKey: "0",
+            "PATH": "/usr/bin",
+        ])
+        #expect(out == [GemmaOptimizationEnvironment.qwenDirectExpertReductionKey: "0"])
+    }
+
     @Test func excludesConfigBackedGemmaControlsFromDaemonEnvironment() {
         let out = LaunchAgent.passthroughEnvironment(from: [
             "DARKBLOOM_PREFIX_CACHE": "0",


### PR DESCRIPTION
## Dependency

- `Layr-Labs/mlx-swift-lm#112` is merged.
- This PR pins upstream `mlx-swift-lm/main` commit `1483827b6c39e219685e0b5f3cf52b18a167ec00`.

## Summary

Rebases the retained Qwen prefill improvements onto current master after PRs
#646-#650. It intentionally excludes the unqualified D=256 attention path,
router fusion, and the rejected MoE Mega-Kernel experiments.

Retained:

- fuse the four GDN input projections into one quantized QMM;
- enable Qwen direct sorted-expert weighted reduction by default with an explicit rollback flag;
- include parity and isolated performance tests.

## Before

```mermaid
flowchart LR
  subgraph Behavior_before[Behavior]
    P1[Prompt chunk] --> G1[30 GDN layers]
    G1 --> A1[4 input QMMs per GDN layer]
    P1 --> M1[40 MoE layers]
    M1 --> U1[Unsort to tokens x topK x hidden]
    U1 --> R1[Multiply routing weights and reduce]
  end
  subgraph Code_before[Code]
    Q1[Qwen35GatedDeltaNet] --> QKV[inProjQKV]
    Q1 --> Z[inProjZ]
    Q1 --> B[inProjB]
    Q1 --> A[inProjA]
    S1[SwitchGLU.callAndWeightedReduce] --> Legacy[scatterUnsort + weightedExpertSum]
  end
```

## After

```mermaid
flowchart LR
  subgraph Behavior_after[Behavior]
    P2[Prompt chunk] --> G2[30 GDN layers]
    G2 --> A2[1 fused 2048-to-12352 QMM per GDN layer]
    P2 --> M2[40 MoE layers]
    M2 --> R2[Optional direct inverse-permutation weighted reduction]
    R2 --> O2[tokens x hidden]
  end
  subgraph Code_after[Code]
    Q2[Qwen35GatedDeltaNet.projectInputs] --> Fused[QuantizedLinear fused weights/scales/biases]
    Fused --> Views[QKV / Z / beta / decay views]
    S2[SwitchGLU.callAndWeightedReduce] --> Gate{Exact Qwen production shape}
    Gate -->|on and exact production shape| Direct[weightedExpertUnsort]
    Gate -->|otherwise| Legacy2[legacy fallback]
  end
```

## Canonical implementation

- GDN fusion: `mlx-swift-lm/Libraries/MLXLLM/Models/Qwen35.swift:306-516`
- Batched MoE flattening/caller: `mlx-swift-lm/Libraries/MLXLLM/Models/Qwen35.swift:1311-1382`
- Direct-reduction default/rollback: `mlx-swift-lm/Libraries/MLXLMCommon/SwitchLayers.swift:261-266`
- Eligibility/fallback: `mlx-swift-lm/Libraries/MLXLMCommon/SwitchLayers.swift:493-581`

## Evidence

- GDN fusion parity: QKV/Z exact; A/B max difference approximately `4.1e-6`.
- Historical GDN step A/B: 10.2% lower TTFT at 8K, 6.0% at 16K, 6.5% at 32K.
- Direct expert reduction isolated primitive benchmark: 0.6389 ms -> 0.3564 ms,
  1.793x speedup at 2,048-token stripe geometry.

## Excluded

- D=256 Steel attention: correctness passed, speed not isolated under stable posture.
- Router/shared-gate fusion: wash/regression at 8K.
- MoE Mega-Kernel/GateUp+SwiGLU fusion: 63.5-71.2% slower in paired tests.

## Validation on merged pin

- GDN parity/topology/adapter/training/invalidation tests: 8/8 pass in the dependency
- SwitchGLU tests: 4/4 pass in the dependency
- provider environment/launchd tests: 24/24 pass
- provider release build: pass
- direct reduction primitive: 1.793x isolated speedup at `[2,048,8,2,048]` stripe geometry

## Rollback

`MLX_QWEN_DIRECT_EXPERT_REDUCTION=0` is projected and persisted into the launchd plist, restoring legacy expert reduction.
