### PR TITLE
fix(provider): re-wire proactive MLX pool sweep + bound buffer cache to 8GiB

### DIFF
--- a/coordinator/api/provider.go
+++ b/coordinator/api/provider.go
@@ -509,11 +509,12 @@ func (s *Server) providerReadLoop(ctx context.Context, conn *websocket.Conn, pro
 				}
 			}
 			s.registry.Heartbeat(providerID, hbMsg)
-			// First-token-wedge observability (measurement only): surface the
-			// accepted engine-health signal as a Datadog counter. Use the
-			// registry snapshot, never the raw heartbeat: its slot model IDs have
-			// been constrained to this connection's coordinator-known inventory.
-			s.recordBackendWedgeTelemetry(provider.BackendCapacitySnapshot())
+			// Emit only from the accepted registry snapshot: malformed values
+			// have been clamped and slot model IDs constrained to this
+			// connection's coordinator-known inventory.
+			capacity := provider.BackendCapacitySnapshot()
+			s.recordBackendWedgeTelemetry(capacity)
+			s.recordMLXCacheTelemetry(providerID, capacity)
 			// W5 Fix 2 (2a): a late/changed APNs token carried in the heartbeat
 			// re-arms a code-identity challenge WITHOUT a reconnect.
 			s.maybeRearmCodeAttest(loopCtx, providerID, provider, hbMsg)

--- a/coordinator/api/provider_mlx_cache_telemetry.go
+++ b/coordinator/api/provider_mlx_cache_telemetry.go
@@ -1,0 +1,33 @@
+package api
+
+import "github.com/eigeninference/d-inference/coordinator/protocol"
+
+// recordMLXCacheTelemetry turns the provider heartbeat's allocator snapshot
+// into live Datadog gauges. Heartbeats are the durable operational path for
+// provider diagnostics; unlike the retired free-form telemetry client, they
+// carry no prompt or response data and continue flowing during normal serving.
+//
+// Cumulative reclaimer values are gauges rather than coordinator-side counters:
+// they reset when the provider process restarts, and Datadog can derive rates
+// without the coordinator maintaining per-provider delta state.
+func (s *Server) recordMLXCacheTelemetry(providerID string, capacity *protocol.BackendCapacity) {
+	if capacity == nil {
+		return
+	}
+
+	tags := []string{"provider_id:" + providerID}
+	s.ddGauge("provider.mlx_memory.active_gb", capacity.GPUMemoryActiveGB, tags)
+	s.ddGauge("provider.mlx_memory.peak_gb", capacity.GPUMemoryPeakGB, tags)
+	s.ddGauge("provider.mlx_memory.cache_gb", capacity.GPUMemoryCacheGB, tags)
+
+	reclaimer := capacity.MLXCacheReclaimer
+	if reclaimer == nil {
+		return
+	}
+	s.ddGauge("provider.mlx_cache.limit_bytes", float64(reclaimer.CacheLimitBytes), tags)
+	s.ddGauge("provider.mlx_cache.sweep_signals_total", float64(reclaimer.SweepSignals), tags)
+	s.ddGauge("provider.mlx_cache.reclaims_total", float64(reclaimer.Reclaims), tags)
+	s.ddGauge("provider.mlx_cache.reclaimed_bytes_total", float64(reclaimer.ReclaimedBytes), tags)
+	s.ddGauge("provider.mlx_cache.last_reclaimed_bytes", float64(reclaimer.LastReclaimedBytes), tags)
+	s.ddGauge("provider.mlx_cache.last_reclaim_duration_ms", float64(reclaimer.LastReclaimDurationMS), tags)
+}

--- a/coordinator/api/provider_mlx_cache_telemetry_test.go
+++ b/coordinator/api/provider_mlx_cache_telemetry_test.go
@@ -1,0 +1,63 @@
+package api
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+)
+
+func TestRecordMLXCacheTelemetryEmitsHeartbeatGauges(t *testing.T) {
+	collector := newUDPCollector(t)
+	defer collector.Close()
+	ddClient := newTestDD(t, collector)
+	defer ddClient.Close()
+
+	s := &Server{}
+	s.SetDatadog(ddClient)
+	s.recordMLXCacheTelemetry("provider-1", &protocol.BackendCapacity{
+		GPUMemoryActiveGB: 21,
+		GPUMemoryPeakGB:   31,
+		GPUMemoryCacheGB:  6,
+		MLXCacheReclaimer: &protocol.MLXCacheReclaimerTelemetry{
+			CacheLimitBytes:       8 << 30,
+			SweepSignals:          12,
+			Reclaims:              4,
+			ReclaimedBytes:        24 << 30,
+			LastReclaimedBytes:    6 << 30,
+			LastReclaimDurationMS: 17,
+		},
+	})
+	_ = ddClient.Statsd.Flush()
+	payload := strings.Join(collector.drain(), "\n")
+
+	for _, metric := range []string{
+		"provider.mlx_memory.active_gb",
+		"provider.mlx_memory.peak_gb",
+		"provider.mlx_memory.cache_gb",
+		"provider.mlx_cache.limit_bytes",
+		"provider.mlx_cache.sweep_signals_total",
+		"provider.mlx_cache.reclaims_total",
+		"provider.mlx_cache.reclaimed_bytes_total",
+		"provider.mlx_cache.last_reclaimed_bytes",
+		"provider.mlx_cache.last_reclaim_duration_ms",
+	} {
+		if !strings.Contains(payload, metric) {
+			t.Errorf("missing %s in DogStatsD payload: %s", metric, payload)
+		}
+	}
+	if !strings.Contains(payload, "provider_id:provider-1") {
+		t.Fatalf("allocator gauges must identify the provider: %s", payload)
+	}
+}
+
+func TestRecordMLXCacheTelemetryLegacyAndNilSafe(t *testing.T) {
+	s := &Server{}
+	// No Datadog client and no reclaimer block are both valid during rollout.
+	s.recordMLXCacheTelemetry("legacy", nil)
+	s.recordMLXCacheTelemetry("legacy", &protocol.BackendCapacity{
+		GPUMemoryActiveGB: 1,
+		GPUMemoryPeakGB:   2,
+		GPUMemoryCacheGB:  0.5,
+	})
+}

--- a/coordinator/cmd/promptsidecarloadproof/cold_start.go
+++ b/coordinator/cmd/promptsidecarloadproof/cold_start.go
@@ -12,12 +12,30 @@ import (
 	"github.com/eigeninference/d-inference/coordinator/promptcontract"
 )
 
-const coldBurstPerContract = 16
+const (
+	coldBurstPerContract = 16
+	coldStartPlanTimeout = 30 * time.Second
+)
 
 type coldProbe struct {
 	vector              planVector
 	exactMatch          bool
 	expectDynamicReject bool
+}
+
+func coldStartSupervisorConfig(
+	args arguments,
+	socketPath string,
+	maxLoadedContracts, maxConcurrency int,
+) promptcontract.SupervisorConfig {
+	config := proofSupervisorConfig(
+		args, socketPath, maxLoadedContracts, maxConcurrency)
+	// This phase proves cold-load singleflight, byte-exact plans, bounded RSS,
+	// and no child restart. Keep the production one-second request timeout for
+	// the later warm 25-QPS proof; cold tokenizer construction is CPU-speed
+	// dependent and has exceeded one second on otherwise healthy 4-vCPU runners.
+	config.RequestTimeout = coldStartPlanTimeout
+	return config
 }
 
 func runColdStartProof(
@@ -30,7 +48,7 @@ func runColdStartProof(
 	if len(inventory.Contracts) < 2 {
 		return summary, errors.New("cold-start proof requires at least two real contracts")
 	}
-	config := proofSupervisorConfig(
+	config := coldStartSupervisorConfig(
 		args,
 		filepath.Join(runtimeRoot, "promptsidecar-cold.sock"),
 		len(inventory.Contracts)-1,

--- a/coordinator/cmd/promptsidecarloadproof/cold_start_test.go
+++ b/coordinator/cmd/promptsidecarloadproof/cold_start_test.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestColdStartSupervisorConfigOnlyExtendsPlanTimeout(t *testing.T) {
+	args := arguments{
+		BinaryPath:   "/tmp/promptsidecar",
+		ArtifactRoot: "/tmp/prompt-artifacts",
+		MaxRSSMiB:    1024,
+	}
+	const socketPath = "/tmp/promptsidecar.sock"
+	production := proofSupervisorConfig(args, socketPath, 3, coldBurstPerContract)
+	cold := coldStartSupervisorConfig(args, socketPath, 3, coldBurstPerContract)
+
+	if production.RequestTimeout != time.Second {
+		t.Fatalf("production proof request timeout = %s, want 1s", production.RequestTimeout)
+	}
+	if cold.RequestTimeout != coldStartPlanTimeout {
+		t.Fatalf("cold-start request timeout = %s, want %s", cold.RequestTimeout, coldStartPlanTimeout)
+	}
+
+	cold.RequestTimeout = production.RequestTimeout
+	if !reflect.DeepEqual(cold, production) {
+		t.Fatal("cold-start proof changed supervisor settings beyond RequestTimeout")
+	}
+}

--- a/coordinator/protocol/messages.go
+++ b/coordinator/protocol/messages.go
@@ -360,6 +360,19 @@ type BackendSlotCapacity struct {
 	IdleClearInFlightMs        int64   `json:"idle_clear_in_flight_ms,omitempty"`        // ms the current idle GPU drain+clearCache has run for this slot; seconds-range = clearCache/IOKit race
 }
 
+// MLXCacheReclaimerTelemetry reports cumulative provider allocator-reclaim
+// counters. Values reset on provider process restart. Reclaimed byte deltas are
+// best-effort observations around MLX clearCache; active allocations are never
+// included.
+type MLXCacheReclaimerTelemetry struct {
+	CacheLimitBytes       uint64 `json:"cache_limit_bytes"`
+	SweepSignals          uint64 `json:"sweep_signals"`
+	Reclaims              uint64 `json:"reclaims"`
+	ReclaimedBytes        uint64 `json:"reclaimed_bytes"`
+	LastReclaimedBytes    uint64 `json:"last_reclaimed_bytes"`
+	LastReclaimDurationMS uint64 `json:"last_reclaim_duration_ms"`
+}
+
 // BackendCapacity describes the aggregate capacity across all backend slots
 // on a provider. Reported in heartbeats so the coordinator can make informed
 // routing decisions based on actual GPU utilization rather than hardcoded limits.
@@ -377,6 +390,8 @@ type BackendCapacity struct {
 	// re-derives free memory). A pointer so a legacy provider that doesn't report
 	// it is nil (→ coordinator falls back to the total-memory heuristic).
 	FreeForLoadGB *float64 `json:"free_for_load_gb,omitempty"`
+	// MLXCacheReclaimer is nil for providers predating allocator telemetry.
+	MLXCacheReclaimer *MLXCacheReclaimerTelemetry `json:"mlx_cache_reclaimer,omitempty"`
 }
 
 // SystemMetrics contains live resource utilization reported by a provider.

--- a/coordinator/protocol/messages_backend_capacity_test.go
+++ b/coordinator/protocol/messages_backend_capacity_test.go
@@ -107,6 +107,14 @@ func TestBackendCapacityMarshalRoundtrip(t *testing.T) {
 		GPUMemoryPeakGB:   52.1,
 		GPUMemoryCacheGB:  8.3,
 		TotalMemoryGB:     128,
+		MLXCacheReclaimer: &MLXCacheReclaimerTelemetry{
+			CacheLimitBytes:       8 << 30,
+			SweepSignals:          12,
+			Reclaims:              4,
+			ReclaimedBytes:        24 << 30,
+			LastReclaimedBytes:    6 << 30,
+			LastReclaimDurationMS: 17,
+		},
 	}
 
 	data, err := json.Marshal(cap)
@@ -136,6 +144,18 @@ func TestBackendCapacityMarshalRoundtrip(t *testing.T) {
 	}
 	if decoded.TotalMemoryGB != 128 {
 		t.Errorf("total_memory_gb = %f, want 128", decoded.TotalMemoryGB)
+	}
+	if decoded.MLXCacheReclaimer == nil {
+		t.Fatal("mlx_cache_reclaimer should survive roundtrip")
+	}
+	if got := decoded.MLXCacheReclaimer.CacheLimitBytes; got != 8<<30 {
+		t.Errorf("cache_limit_bytes = %d, want %d", got, uint64(8<<30))
+	}
+	if got := decoded.MLXCacheReclaimer.Reclaims; got != 4 {
+		t.Errorf("reclaims = %d, want 4", got)
+	}
+	if got := decoded.MLXCacheReclaimer.LastReclaimDurationMS; got != 17 {
+		t.Errorf("last_reclaim_duration_ms = %d, want 17", got)
 	}
 }
 

--- a/coordinator/registry/heartbeat_model_state.go
+++ b/coordinator/registry/heartbeat_model_state.go
@@ -58,6 +58,8 @@ func canonicalHeartbeatModelState(
 		freeForLoadGB := *reportedCapacity.FreeForLoadGB
 		capacity.FreeForLoadGB = &freeForLoadGB
 	}
+	capacity.MLXCacheReclaimer = cloneMLXCacheReclaimerTelemetry(
+		reportedCapacity.MLXCacheReclaimer)
 	if reportedCapacity.Slots != nil {
 		slotLimit := len(reportedCapacity.Slots)
 		if slotLimit > len(accepted) {
@@ -105,6 +107,8 @@ func (p *Provider) BackendCapacitySnapshot() *protocol.BackendCapacity {
 		freeForLoadGB := *p.BackendCapacity.FreeForLoadGB
 		capacity.FreeForLoadGB = &freeForLoadGB
 	}
+	capacity.MLXCacheReclaimer = cloneMLXCacheReclaimerTelemetry(
+		p.BackendCapacity.MLXCacheReclaimer)
 	if p.BackendCapacity.Slots != nil {
 		capacity.Slots = make([]protocol.BackendSlotCapacity, len(p.BackendCapacity.Slots))
 		for index, retainedSlot := range p.BackendCapacity.Slots {
@@ -121,4 +125,14 @@ func (p *Provider) BackendCapacitySnapshot() *protocol.BackendCapacity {
 		}
 	}
 	return &capacity
+}
+
+func cloneMLXCacheReclaimerTelemetry(
+	in *protocol.MLXCacheReclaimerTelemetry,
+) *protocol.MLXCacheReclaimerTelemetry {
+	if in == nil {
+		return nil
+	}
+	copy := *in
+	return &copy
 }

--- a/coordinator/registry/registry_heartbeat_test.go
+++ b/coordinator/registry/registry_heartbeat_test.go
@@ -296,13 +296,19 @@ func TestHeartbeatDropsUnregisteredModelIdentifiersBeforeStateAndMetrics(t *test
 	knownKVBackend := KVBackendPaged
 	unknownKVBackend := KVBackendContiguous
 	freeForLoadGB := 24.0
+	reclaimerTelemetry := &protocol.MLXCacheReclaimerTelemetry{
+		CacheLimitBytes: 8 << 30,
+		SweepSignals:    12,
+		Reclaims:        4,
+	}
 	hb := &protocol.HeartbeatMessage{
 		Type:        protocol.TypeHeartbeat,
 		Status:      "serving",
 		ActiveModel: &activeModel,
 		WarmModels:  []string{knownModel, leakSentinel, knownModel},
 		BackendCapacity: &protocol.BackendCapacity{
-			FreeForLoadGB: &freeForLoadGB,
+			FreeForLoadGB:     &freeForLoadGB,
+			MLXCacheReclaimer: reclaimerTelemetry,
 			Slots: []protocol.BackendSlotCapacity{
 				{
 					Model:             leakSentinel,
@@ -351,6 +357,9 @@ func TestHeartbeatDropsUnregisteredModelIdentifiersBeforeStateAndMetrics(t *test
 	if strings.Contains(snapshot.Slots[0].Model, leakSentinel) {
 		t.Fatalf("unknown model reached public capacity snapshot: %+v", snapshot)
 	}
+	if snapshot.MLXCacheReclaimer == nil || snapshot.MLXCacheReclaimer.Reclaims != 4 {
+		t.Fatalf("public reclaimer telemetry snapshot = %+v, want 4 reclaims", snapshot.MLXCacheReclaimer)
+	}
 
 	if got := reg.tpsRegistry.Median(leakSentinel, msg.Hardware.ChipFamily); got != 0 {
 		t.Fatalf("unknown model TPS = %v, want no sample", got)
@@ -381,6 +390,8 @@ func TestHeartbeatDropsUnregisteredModelIdentifiersBeforeStateAndMetrics(t *test
 	hb.BackendCapacity.Slots[1].Model = leakSentinel
 	snapshot.Slots[0].Model = leakSentinel
 	freeForLoadGB = 1
+	reclaimerTelemetry.Reclaims = 99
+	snapshot.MLXCacheReclaimer.Reclaims = 88
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	if len(p.WarmModels) != 1 || p.WarmModels[0] != knownModel || p.BackendCapacity.Slots[0].Model != knownModel {
@@ -388,6 +399,9 @@ func TestHeartbeatDropsUnregisteredModelIdentifiersBeforeStateAndMetrics(t *test
 	}
 	if got := *p.BackendCapacity.FreeForLoadGB; got != 24 {
 		t.Fatalf("retained free_for_load_gb = %v after decoded value changed, want 24", got)
+	}
+	if got := p.BackendCapacity.MLXCacheReclaimer.Reclaims; got != 4 {
+		t.Fatalf("retained mlx cache reclaims = %d after source/snapshot mutation, want 4", got)
 	}
 }
 

--- a/docs/reference/protocol-messages.md
+++ b/docs/reference/protocol-messages.md
@@ -294,13 +294,16 @@ Go: [`BackendCapacity`](../../coordinator/protocol/messages.go); Swift: `Backend
 | `gpu_memory_peak_gb` | number |
 | `gpu_memory_cache_gb` | number |
 | `total_memory_gb` | number |
-| `free_for_load_gb` | number |
+| `free_for_load_gb` | number, optional |
 | `mlx_cache_reclaimer` | [`MLXCacheReclaimerTelemetry`](#mlxcachereclaimertelemetry), optional |
 
 ### `MLXCacheReclaimerTelemetry`
 
 Allocator telemetry carried by instrumented providers. Counters are cumulative
 for one provider process and reset on restart; older providers omit the object.
+
+Canonical wire definitions: `coordinator/protocol/messages.go:363-394` and
+`provider-swift/Sources/ProviderCore/Protocol/Types.swift:707-802`.
 
 | Field | Type | Notes |
 |---|---|---|
@@ -312,7 +315,8 @@ for one provider process and reset on restart; older providers omit the object.
 | `last_reclaim_duration_ms` | integer | Blocking synchronize + clear duration |
 
 The coordinator publishes these heartbeat values as Datadog gauges under
-`provider.mlx_memory.*` and `provider.mlx_cache.*`, tagged by `provider_id`.
+`provider.mlx_memory.*` and `provider.mlx_cache.*`, tagged by `provider_id`
+(`coordinator/api/provider_mlx_cache_telemetry.go:13-32`).
 
 ### `BackendSlotCapacity`
 

--- a/docs/reference/protocol-messages.md
+++ b/docs/reference/protocol-messages.md
@@ -294,6 +294,25 @@ Go: [`BackendCapacity`](../../coordinator/protocol/messages.go); Swift: `Backend
 | `gpu_memory_peak_gb` | number |
 | `gpu_memory_cache_gb` | number |
 | `total_memory_gb` | number |
+| `free_for_load_gb` | number |
+| `mlx_cache_reclaimer` | [`MLXCacheReclaimerTelemetry`](#mlxcachereclaimertelemetry), optional |
+
+### `MLXCacheReclaimerTelemetry`
+
+Allocator telemetry carried by instrumented providers. Counters are cumulative
+for one provider process and reset on restart; older providers omit the object.
+
+| Field | Type | Notes |
+|---|---|---|
+| `cache_limit_bytes` | integer | Configured MLX reusable-buffer cache ceiling |
+| `sweep_signals` | integer | Periodic proactive sweep signals received |
+| `reclaims` | integer | `clearCache()` operations actually performed |
+| `reclaimed_bytes` | integer | Cumulative observed cache reduction |
+| `last_reclaimed_bytes` | integer | Observed reduction around the latest reclaim |
+| `last_reclaim_duration_ms` | integer | Blocking synchronize + clear duration |
+
+The coordinator publishes these heartbeat values as Datadog gauges under
+`provider.mlx_memory.*` and `provider.mlx_cache.*`, tagged by `provider_id`.
 
 ### `BackendSlotCapacity`
 

--- a/provider-swift/Sources/ProviderCore/Inference/GlobalKVCacheBudget.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/GlobalKVCacheBudget.swift
@@ -418,6 +418,13 @@ public actor GlobalKVCacheBudget {
         reclaimer.scheduleSweep()
     }
 
+    /// Heartbeat-facing cumulative reclaim counters. The snapshot is lock-backed
+    /// and never hops the reclaimer actor, so a GPU synchronize already running
+    /// there cannot delay capacity reporting or request admission.
+    nonisolated func cacheReclaimerTelemetrySnapshot() -> KVPoolReclaimer.TelemetrySnapshot {
+        reclaimer.telemetrySnapshot()
+    }
+
     private func availableReservationBytes() -> UInt64 {
         let snap = memorySnapshot()
         let mlxUsed = Self.saturatingAdd(snap.active, snap.cache)

--- a/provider-swift/Sources/ProviderCore/Inference/GlobalKVCacheBudget.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/GlobalKVCacheBudget.swift
@@ -407,23 +407,13 @@ public actor GlobalKVCacheBudget {
         rejectionStreakStart = nil
     }
 
-    /// Signal the off-actor reclaimer to flush the reclaimable MLX pool for a
-    /// shortfall observed by the scheduler's token-budget gate. Non-blocking and
-    /// `nonisolated` (it touches no actor state — only the immutable reclaimer),
-    /// so the caller doesn't even hop this actor: the GPU sync runs on the
-    /// reclaimer, never here (it used to run inline as a blocking synchronize,
-    /// which wedged the admission actor). The reclaimer gates on whether the pool
-    /// can cover the shortfall and rate-limits, so this is an unconditional
-    /// fire-and-forget.
-    public nonisolated func reclaimForShortfall(_ shortfall: UInt64) {
-        guard shortfall > 0 else { return }
-        reclaimer.scheduleReclaim(shortfall: shortfall)
-    }
-
     /// Trigger a proactive, rate-limited, threshold-gated background sweep of the
     /// reclaimable MLX pool so admission headroom stays healthy under sustained
-    /// load without any inline flush. Non-blocking and `nonisolated`. Called
-    /// periodically by the scheduler watchdog while a model is loaded.
+    /// load without any inline flush, and freed KV/activation buffers are
+    /// returned to the OS instead of accumulating below the cache limit.
+    /// Non-blocking and `nonisolated` (it touches no actor state — only the
+    /// immutable reclaimer). Driven periodically by ProviderLoop's
+    /// capacity-refresh tick and StandaloneServer's sweep task.
     public nonisolated func proactiveReclaimSweep() {
         reclaimer.scheduleSweep()
     }

--- a/provider-swift/Sources/ProviderCore/Inference/KVPoolReclaimer.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/KVPoolReclaimer.swift
@@ -48,6 +48,15 @@ actor KVPoolReclaimer {
     /// Total flushes performed (test observability).
     private(set) var reclaimCount = 0
 
+    /// Total sweep signals received, counted BEFORE the threshold gate —
+    /// wiring observability, so the periodic drivers (ProviderLoop's
+    /// capacity-refresh tick, StandaloneServer's sweep task) can be asserted
+    /// to actually signal this reclaimer without needing a multi-GiB real
+    /// MLX pool in the test process. The v0.7.5 regression this guards
+    /// against: the sweep's only caller was deleted with the legacy engine
+    /// and the pool grew unbounded in the field.
+    private(set) var sweepSignalCount = 0
+
     static let defaultMinInterval: Duration = .seconds(1)
     /// 2 GiB: a pool this large is materially eating admission headroom; below it
     /// the on-pressure path (which gates on the exact shortfall) handles flushing.
@@ -98,6 +107,7 @@ actor KVPoolReclaimer {
     /// headroom healthy under sustained load so most admissions never near-miss.
     @discardableResult
     func sweep() -> Bool {
+        sweepSignalCount += 1
         guard reclaimableBytes() >= proactiveThresholdBytes else { return false }
         return flushIfDue()
     }

--- a/provider-swift/Sources/ProviderCore/Inference/KVPoolReclaimer.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/KVPoolReclaimer.swift
@@ -27,6 +27,56 @@ import Foundation
 import MLX
 
 actor KVPoolReclaimer {
+    /// Cumulative allocator-reclaim telemetry sampled by the provider heartbeat.
+    /// Counts reset on process restart; byte deltas are best-effort observations
+    /// around `clearCache()` because inference may allocate concurrently.
+    struct TelemetrySnapshot: Equatable, Sendable {
+        let sweepSignals: UInt64
+        let reclaims: UInt64
+        let reclaimedBytes: UInt64
+        let lastReclaimedBytes: UInt64
+        let lastReclaimDurationMs: UInt64
+    }
+
+    /// Lock-backed so heartbeat sampling never queues behind this actor while
+    /// `clearCache()` is synchronously waiting for the GPU. The reclaimer actor
+    /// remains the sole writer; the lock only provides a non-blocking read path.
+    private final class TelemetryStore: @unchecked Sendable {
+        private let lock = NSLock()
+        private var sweepSignals: UInt64 = 0
+        private var reclaims: UInt64 = 0
+        private var reclaimedBytes: UInt64 = 0
+        private var lastReclaimedBytes: UInt64 = 0
+        private var lastReclaimDurationMs: UInt64 = 0
+
+        func recordSweepSignal() {
+            lock.lock()
+            defer { lock.unlock() }
+            if sweepSignals < .max { sweepSignals += 1 }
+        }
+
+        func recordReclaim(reclaimed: UInt64, durationMs: UInt64) {
+            lock.lock()
+            defer { lock.unlock() }
+            if reclaims < .max { reclaims += 1 }
+            let (newTotal, overflow) = reclaimedBytes.addingReportingOverflow(reclaimed)
+            reclaimedBytes = overflow ? .max : newTotal
+            lastReclaimedBytes = reclaimed
+            lastReclaimDurationMs = durationMs
+        }
+
+        func snapshot() -> TelemetrySnapshot {
+            lock.lock()
+            defer { lock.unlock() }
+            return TelemetrySnapshot(
+                sweepSignals: sweepSignals,
+                reclaims: reclaims,
+                reclaimedBytes: reclaimedBytes,
+                lastReclaimedBytes: lastReclaimedBytes,
+                lastReclaimDurationMs: lastReclaimDurationMs)
+        }
+    }
+
     /// The blocking GPU flush. Injected so tests can observe invocations
     /// (count/timing) deterministically without a GPU. Production fences async
     /// GPU completion before freeing buffers (matches the engine reclaim paths /
@@ -45,17 +95,12 @@ actor KVPoolReclaimer {
     private let proactiveThresholdBytes: UInt64
     private var lastReclaimAt: ContinuousClock.Instant?
 
-    /// Total flushes performed (test observability).
-    private(set) var reclaimCount = 0
+    private let telemetry = TelemetryStore()
 
-    /// Total sweep signals received, counted BEFORE the threshold gate —
-    /// wiring observability, so the periodic drivers (ProviderLoop's
-    /// capacity-refresh tick, StandaloneServer's sweep task) can be asserted
-    /// to actually signal this reclaimer without needing a multi-GiB real
-    /// MLX pool in the test process. The v0.7.5 regression this guards
-    /// against: the sweep's only caller was deleted with the legacy engine
-    /// and the pool grew unbounded in the field.
-    private(set) var sweepSignalCount = 0
+    /// Compatibility/debug accessors. Production heartbeat reads the same store
+    /// through nonisolated `telemetrySnapshot()` and never waits on this actor.
+    var reclaimCount: UInt64 { telemetry.snapshot().reclaims }
+    var sweepSignalCount: UInt64 { telemetry.snapshot().sweepSignals }
 
     static let defaultMinInterval: Duration = .seconds(1)
     /// 2 GiB: a pool this large is materially eating admission headroom; below it
@@ -108,17 +153,31 @@ actor KVPoolReclaimer {
     /// headroom healthy under sustained load so most admissions never near-miss.
     @discardableResult
     func sweep() -> Bool {
-        sweepSignalCount += 1
+        telemetry.recordSweepSignal()
         guard reclaimableBytes() >= proactiveThresholdBytes else { return false }
         return flushIfDue()
+    }
+
+    nonisolated func telemetrySnapshot() -> TelemetrySnapshot {
+        telemetry.snapshot()
     }
 
     private func flushIfDue() -> Bool {
         let now = ContinuousClock.now
         if let last = lastReclaimAt, now - last < minInterval { return false }
         lastReclaimAt = now
+
+        let cacheBefore = reclaimableBytes()
+        let startedAt = ContinuousClock.now
         clearCache()
-        reclaimCount += 1
+        let elapsed = ContinuousClock.now - startedAt
+        let cacheAfter = reclaimableBytes()
+        let reclaimed = cacheBefore > cacheAfter ? cacheBefore - cacheAfter : 0
+        let elapsedMs = Double(elapsed.components.seconds) * 1_000
+            + Double(elapsed.components.attoseconds) / 1e15
+        telemetry.recordReclaim(
+            reclaimed: reclaimed,
+            durationMs: UInt64(max(0, elapsedMs.rounded())))
         return true
     }
 }

--- a/provider-swift/Sources/ProviderCore/Inference/KVPoolReclaimer.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/KVPoolReclaimer.swift
@@ -83,8 +83,9 @@ actor KVPoolReclaimer {
         Task { await self.reclaimIfNeeded(shortfall: shortfall) }
     }
 
-    /// Proactive signal from the periodic scheduler watchdog. Non-isolated, same
-    /// contract as `scheduleReclaim`.
+    /// Proactive signal from the periodic drivers (ProviderLoop's
+    /// capacity-refresh tick, StandaloneServer's sweep task). Non-isolated,
+    /// same contract as `scheduleReclaim`.
     nonisolated func scheduleSweep() {
         Task { await self.sweep() }
     }

--- a/provider-swift/Sources/ProviderCore/Inference/MLXMemoryGuard.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/MLXMemoryGuard.swift
@@ -104,6 +104,16 @@ public enum MLXMemoryGuard {
     // Set once per process; loadModel runs many times, so guard with lock + flag.
     private static let lock = NSLock()
     nonisolated(unsafe) private static var configured = false
+    nonisolated(unsafe) private static var configuredLimits: Limits?
+
+    /// The limits actually selected by `configureOnce`, without touching MLX
+    /// globals. Capacity telemetry uses this snapshot because reading
+    /// `Memory.cacheLimit` can initialize the Metal backend in no-GPU tests.
+    static func configuredLimitsSnapshot() -> Limits? {
+        lock.lock()
+        defer { lock.unlock() }
+        return configuredLimits
+    }
 
     /// Set the MLX ceiling once per process (idempotent). `apply` is injectable
     /// for tests so they avoid touching real MLX globals.
@@ -130,6 +140,9 @@ public enum MLXMemoryGuard {
             physicalBytes: physicalBytes,
             reserveBytes: resolvedReserveBytes(explicit: reserveBytes),
             cacheCapBytes: resolvedCacheCapBytes(explicit: cacheCapBytes))
+        lock.lock()
+        configuredLimits = limits
+        lock.unlock()
         apply(limits)
         log?(limits)
         return limits
@@ -139,6 +152,7 @@ public enum MLXMemoryGuard {
     static func _resetForTest() {
         lock.lock()
         configured = false
+        configuredLimits = nil
         lock.unlock()
     }
 }

--- a/provider-swift/Sources/ProviderCore/Inference/MLXMemoryGuard.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/MLXMemoryGuard.swift
@@ -14,6 +14,18 @@ public enum MLXMemoryGuard {
     /// than the per-request load reserve (4 GB): this is the whole-machine ceiling.
     public static let defaultReserveGB: UInt64 = 6
 
+    /// Absolute ceiling (GiB) on MLX's reusable buffer pool. The pool's useful
+    /// reuse set is bounded by the WORKLOAD — per-step activation churn (~5.5
+    /// GiB measured peak at B=8) plus KV-growth churn — not by machine size.
+    /// The previous policy (cache = 0.75 × memoryLimit alone) let a 512 GB Mac
+    /// Studio park ~380 GB of freed buffers: every completed request's KV and
+    /// activation buffers accumulated below that limit and were never returned
+    /// to the OS (observed in the field as 377 GB of Metal allocation for a
+    /// ~21 GB model). 8 GiB keeps steady-state buffer reuse while bounding the
+    /// hoard on every machine size; `DARKBLOOM_MLX_CACHE_LIMIT_GB` overrides in
+    /// either direction (floored at 1 GiB, capped at the memory limit).
+    public static let defaultCacheLimitGB: UInt64 = 8
+
     /// Floor so a tiny/misreported machine never gets a pathological limit.
     static let minimumLimitBytes = 2 * 1024 * 1024 * 1024  // 2 GiB
 
@@ -23,18 +35,22 @@ public enum MLXMemoryGuard {
     }
 
     /// Pure sizing policy. memoryLimit = max(floor, physical − reserve);
-    /// cacheLimit = memoryLimit × cacheFraction (bounds the reusable pool so
-    /// freed buffers return to the OS; 0.75 keeps reuse/perf while helping).
+    /// cacheLimit = min(memoryLimit × cacheFraction, cacheCapBytes), floored at
+    /// 1 GiB so buffer reuse survives a pathological override. The fraction
+    /// scales the pool down on small machines; the absolute cap bounds it on
+    /// big ones (see `defaultCacheLimitGB`).
     static func recommendedLimits(
         physicalBytes: UInt64,
         reserveBytes: UInt64,
-        cacheFraction: Double = 0.75
+        cacheFraction: Double = 0.75,
+        cacheCapBytes: UInt64 = MLXMemoryGuard.defaultCacheLimitGB * 1_073_741_824
     ) -> Limits {
         let physical = Int(min(physicalBytes, UInt64(Int.max)))
         let reserve = Int(min(reserveBytes, UInt64(Int.max)))
         let limit = max(minimumLimitBytes, physical > reserve ? physical - reserve : minimumLimitBytes)
         let fraction = cacheFraction.isFinite ? min(1.0, max(0.0, cacheFraction)) : 0.75
-        let cache = max(minimumLimitBytes / 2, Int(Double(limit) * fraction))
+        let cap = Int(min(cacheCapBytes, UInt64(Int.max)))
+        let cache = max(minimumLimitBytes / 2, min(Int(Double(limit) * fraction), cap))
         return Limits(memoryLimitBytes: limit, cacheLimitBytes: min(cache, limit))
     }
 
@@ -57,6 +73,22 @@ public enum MLXMemoryGuard {
         return saturatingGiBToBytes(defaultReserveGB)
     }
 
+    /// Cache cap in BYTES from explicit (bytes), env DARKBLOOM_MLX_CACHE_LIMIT_GB
+    /// (GB), or default. Same saturation care as `resolvedReserveBytes` — a huge
+    /// finite override must clamp, never trap. Zero is accepted and lands on the
+    /// 1 GiB floor in `recommendedLimits`.
+    static func resolvedCacheCapBytes(
+        explicit: UInt64?,
+        env: [String: String] = ProcessInfo.processInfo.environment
+    ) -> UInt64 {
+        if let explicit { return explicit }
+        if let raw = env["DARKBLOOM_MLX_CACHE_LIMIT_GB"], let gb = Double(raw), gb >= 0, gb.isFinite {
+            let scaled = gb * 1_073_741_824
+            return scaled >= uint64MaxAsDouble ? UInt64.max : UInt64(scaled)
+        }
+        return saturatingGiBToBytes(defaultCacheLimitGB)
+    }
+
     /// `Double(UInt64.max)` rounded to the nearest representable Double — exactly
     /// 2^64 (one more than `UInt64.max`). Used as the saturation threshold so a
     /// `>= uint64MaxAsDouble` comparison catches every value that would trap on
@@ -77,6 +109,7 @@ public enum MLXMemoryGuard {
     @discardableResult
     public static func configureOnce(
         reserveBytes: UInt64? = nil,
+        cacheCapBytes: UInt64? = nil,
         physicalBytes: UInt64 = ProcessInfo.processInfo.physicalMemory,
         apply: (Limits) -> Void = { limits in
             Memory.memoryLimit = limits.memoryLimitBytes
@@ -94,7 +127,8 @@ public enum MLXMemoryGuard {
 
         let limits = recommendedLimits(
             physicalBytes: physicalBytes,
-            reserveBytes: resolvedReserveBytes(explicit: reserveBytes))
+            reserveBytes: resolvedReserveBytes(explicit: reserveBytes),
+            cacheCapBytes: resolvedCacheCapBytes(explicit: cacheCapBytes))
         apply(limits)
         log?(limits)
         return limits

--- a/provider-swift/Sources/ProviderCore/Inference/MLXMemoryGuard.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/MLXMemoryGuard.swift
@@ -23,7 +23,8 @@ public enum MLXMemoryGuard {
     /// to the OS (observed in the field as 377 GB of Metal allocation for a
     /// ~21 GB model). 8 GiB keeps steady-state buffer reuse while bounding the
     /// hoard on every machine size; `DARKBLOOM_MLX_CACHE_LIMIT_GB` overrides in
-    /// either direction (floored at 1 GiB, capped at the memory limit).
+    /// either direction (floored at 1 GiB, bounded above by cacheFraction ×
+    /// memoryLimit — a raise can restore the old pool size, not exceed it).
     public static let defaultCacheLimitGB: UInt64 = 8
 
     /// Floor so a tiny/misreported machine never gets a pathological limit.

--- a/provider-swift/Sources/ProviderCore/Protocol/Types.swift
+++ b/provider-swift/Sources/ProviderCore/Protocol/Types.swift
@@ -704,6 +704,43 @@ public struct BackendSlotCapacity: Codable, Sendable, Equatable {
     }
 }
 
+/// Cumulative MLX buffer-pool reclaim telemetry. Counters reset when the
+/// provider process restarts. Byte deltas are observed immediately around
+/// `Memory.clearCache()` and therefore exclude active allocations.
+public struct MLXCacheReclaimerTelemetry: Codable, Sendable, Equatable {
+    public var cacheLimitBytes: UInt64
+    public var sweepSignals: UInt64
+    public var reclaims: UInt64
+    public var reclaimedBytes: UInt64
+    public var lastReclaimedBytes: UInt64
+    public var lastReclaimDurationMs: UInt64
+
+    enum CodingKeys: String, CodingKey {
+        case cacheLimitBytes = "cache_limit_bytes"
+        case sweepSignals = "sweep_signals"
+        case reclaims
+        case reclaimedBytes = "reclaimed_bytes"
+        case lastReclaimedBytes = "last_reclaimed_bytes"
+        case lastReclaimDurationMs = "last_reclaim_duration_ms"
+    }
+
+    public init(
+        cacheLimitBytes: UInt64,
+        sweepSignals: UInt64,
+        reclaims: UInt64,
+        reclaimedBytes: UInt64,
+        lastReclaimedBytes: UInt64,
+        lastReclaimDurationMs: UInt64
+    ) {
+        self.cacheLimitBytes = cacheLimitBytes
+        self.sweepSignals = sweepSignals
+        self.reclaims = reclaims
+        self.reclaimedBytes = reclaimedBytes
+        self.lastReclaimedBytes = lastReclaimedBytes
+        self.lastReclaimDurationMs = lastReclaimDurationMs
+    }
+}
+
 public struct BackendCapacity: Codable, Sendable, Equatable {
     public var slots: [BackendSlotCapacity]
     public var gpuMemoryActiveGb: Double
@@ -718,6 +755,9 @@ public struct BackendCapacity: Codable, Sendable, Equatable {
     /// re-deriving free memory from the gpu/total figures. 0 means "cannot load
     /// anything new right now".
     public var freeForLoadGb: Double
+    /// Optional so coordinators and tooling can distinguish providers with the
+    /// reclaimer instrumentation from older providers whose counters are unknown.
+    public var mlxCacheReclaimer: MLXCacheReclaimerTelemetry?
 
     enum CodingKeys: String, CodingKey {
         case slots
@@ -726,6 +766,7 @@ public struct BackendCapacity: Codable, Sendable, Equatable {
         case gpuMemoryCacheGb = "gpu_memory_cache_gb"
         case totalMemoryGb = "total_memory_gb"
         case freeForLoadGb = "free_for_load_gb"
+        case mlxCacheReclaimer = "mlx_cache_reclaimer"
     }
 
     public init(
@@ -734,7 +775,8 @@ public struct BackendCapacity: Codable, Sendable, Equatable {
         gpuMemoryPeakGb: Double,
         gpuMemoryCacheGb: Double,
         totalMemoryGb: Double,
-        freeForLoadGb: Double = 0
+        freeForLoadGb: Double = 0,
+        mlxCacheReclaimer: MLXCacheReclaimerTelemetry? = nil
     ) {
         self.slots = slots
         self.gpuMemoryActiveGb = gpuMemoryActiveGb
@@ -742,10 +784,11 @@ public struct BackendCapacity: Codable, Sendable, Equatable {
         self.gpuMemoryCacheGb = gpuMemoryCacheGb
         self.totalMemoryGb = totalMemoryGb
         self.freeForLoadGb = freeForLoadGb
+        self.mlxCacheReclaimer = mlxCacheReclaimer
     }
 
-    // Explicit decode so older payloads without `free_for_load_gb` still decode
-    // (defaults to 0). Encoding stays synthesized and always emits the field.
+    // Explicit decode so older payloads without `free_for_load_gb` or
+    // `mlx_cache_reclaimer` still decode. Encoding stays synthesized.
     public init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
         self.slots = try c.decode([BackendSlotCapacity].self, forKey: .slots)
@@ -754,6 +797,8 @@ public struct BackendCapacity: Codable, Sendable, Equatable {
         self.gpuMemoryCacheGb = try c.decode(Double.self, forKey: .gpuMemoryCacheGb)
         self.totalMemoryGb = try c.decode(Double.self, forKey: .totalMemoryGb)
         self.freeForLoadGb = try c.decodeIfPresent(Double.self, forKey: .freeForLoadGb) ?? 0
+        self.mlxCacheReclaimer = try c.decodeIfPresent(
+            MLXCacheReclaimerTelemetry.self, forKey: .mlxCacheReclaimer)
     }
 }
 

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+Capacity.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+Capacity.swift
@@ -124,7 +124,10 @@ extension ProviderLoop {
         // is in flight we treat NOTHING as reclaimable (conservative, never
         // advertises an actively-served model's weights as free); only when fully
         // idle do we assume idle models can be evicted.
-        let mlxUsed = UInt64(max(0, MLX.GPU.activeMemory)) + UInt64(max(0, MLX.GPU.cacheMemory))
+        let mlxActiveBytes = UInt64(max(0, MLX.GPU.activeMemory))
+        let mlxPeakBytes = UInt64(max(0, MLX.GPU.peakMemory))
+        let mlxCacheBytes = UInt64(max(0, MLX.GPU.cacheMemory))
+        let mlxUsed = mlxActiveBytes + mlxCacheBytes
         let reclaimableMlx: UInt64 = hasInflightWork ? 0 : mlxUsed
         let loadReserve = UnifiedMemoryCap.loadReserveBytes(
             configReserveBytes: Self.memoryReserveBytes(forGiB: loopConfig.config.provider.memoryReserveGB))
@@ -138,14 +141,24 @@ extension ProviderLoop {
             mlxUsedBytes: reclaimableMlx,
             reserveBytes: loadReserve,
             outstandingReservationBytes: outstandingKV)
+        let reclaimer = kvBudget.cacheReclaimerTelemetrySnapshot()
+        let reclaimerTelemetry = MLXCacheReclaimerTelemetry(
+            cacheLimitBytes: UInt64(max(
+                0, MLXMemoryGuard.configuredLimitsSnapshot()?.cacheLimitBytes ?? 0)),
+            sweepSignals: reclaimer.sweepSignals,
+            reclaims: reclaimer.reclaims,
+            reclaimedBytes: reclaimer.reclaimedBytes,
+            lastReclaimedBytes: reclaimer.lastReclaimedBytes,
+            lastReclaimDurationMs: reclaimer.lastReclaimDurationMs)
 
         state.backendCapacity = BackendCapacity(
             slots: allSlots,
-            gpuMemoryActiveGb: Double(MLX.GPU.activeMemory) / gbDivisor,
-            gpuMemoryPeakGb: Double(MLX.GPU.peakMemory) / gbDivisor,
-            gpuMemoryCacheGb: Double(MLX.GPU.cacheMemory) / gbDivisor,
+            gpuMemoryActiveGb: Double(mlxActiveBytes) / gbDivisor,
+            gpuMemoryPeakGb: Double(mlxPeakBytes) / gbDivisor,
+            gpuMemoryCacheGb: Double(mlxCacheBytes) / gbDivisor,
             totalMemoryGb: Double(totalMem) / gbDivisor,
-            freeForLoadGb: freeForLoadGb
+            freeForLoadGb: freeForLoadGb,
+            mlxCacheReclaimer: reclaimerTelemetry
         )
         state.inferenceActive = totalActive > 0
         let loadedSlots = modelSlots.compactMap { modelId, slot

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+Capacity.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+Capacity.swift
@@ -52,6 +52,16 @@ extension ProviderLoop {
 
     /// One capacity-monitor tick, isolated on the loop actor.
     internal func capacityRefreshTick() async {
+        // Proactive trim of the MLX reclaimable buffer pool (DAR-338). Freed
+        // KV/activation buffers otherwise sit in MLX's cache up to the cache
+        // limit and are never returned to the OS — under sustained serving the
+        // pool grows monotonically (each completed request parks its buffers)
+        // until macOS memory pressure fires. The legacy engine's liveness
+        // watchdog drove this sweep every 2s until the v0.7.5 engine deletion
+        // removed it with its host; this tick is that watchdog's documented
+        // successor. Non-blocking: only signals the off-actor reclaimer
+        // (rate-limited, threshold-gated); the GPU sync never runs here.
+        kvBudget.proactiveReclaimSweep()
         await updateAggregateCapacity()
         await recoverWedgedEngineV2Slots()
         writeDaemonState()

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+Testing.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+Testing.swift
@@ -108,6 +108,14 @@ extension ProviderLoop {
         loadedModelsPersistenceEnabled = url != nil
     }
 
+    /// Test seam: redirect `writeDaemonState()` to a temp path. Per-loop and
+    /// race-free, unlike a `DARKBLOOM_STATE_FILE` setenv, which is process
+    /// global and can route a concurrently running suite's daemon-state
+    /// write into this test's file (suites run in parallel).
+    func setDaemonStateFileForTesting(_ url: URL?) {
+        daemonStateFileOverride = url
+    }
+
     /// Test seam: toggle the persistence gate independently of the path
     /// override (pins the "inert unless serving" guard).
     func setLoadedModelsPersistenceEnabledForTesting(_ enabled: Bool) {

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+Trust.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+Trust.swift
@@ -24,7 +24,9 @@ extension ProviderLoop {
     /// Best-effort and cheap; safe to call from the trust handler and the
     /// periodic capacity loop.
     internal func writeDaemonState() {
-        DaemonStateFile.write(currentDaemonState())
+        DaemonStateFile.write(
+            currentDaemonState(),
+            to: daemonStateFileOverride ?? DaemonStateFile.path())
     }
 
     /// The snapshot `writeDaemonState` persists. Split out so a test can

--- a/provider-swift/Sources/ProviderCore/ProviderLoop.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop.swift
@@ -372,6 +372,14 @@ public actor ProviderLoop {
     /// (default: `LoadedModelsStore.path()`).
     internal var loadedModelsFileOverride: URL?
 
+    /// Test seam: overrides the daemon-state file `writeDaemonState()`
+    /// persists to (default: `DaemonStateFile.path()`). Per-loop, unlike the
+    /// process-global `DARKBLOOM_STATE_FILE` env var — two suites mutating
+    /// that env concurrently can route one another's writes into each
+    /// other's temp files (swift-testing runs suites in parallel;
+    /// `.serialized` only orders tests WITHIN a suite).
+    internal var daemonStateFileOverride: URL?
+
     /// Gate on the loaded-models persistence writes. `run()` flips it on at
     /// startup; it stays FALSE for `ProviderLoop` instances that never serve
     /// (unit tests exercising load/unload paths), so an unrelated test can

--- a/provider-swift/Sources/ProviderCore/Server/StandaloneServer.swift
+++ b/provider-swift/Sources/ProviderCore/Server/StandaloneServer.swift
@@ -216,6 +216,17 @@ public actor StandaloneServer {
     private var models: [ModelInfo]
     private var serverTask: Task<Void, Never>?
     private var shutdownTask: Task<Void, Never>?
+    /// Periodic driver for the proactive MLX buffer-pool sweep. ProviderLoop
+    /// drives the same sweep from its capacity-refresh tick; the standalone
+    /// path has no such tick, so it runs its own. Without one, freed
+    /// KV/activation buffers accumulate in MLX's cache under sustained local
+    /// serving and are only returned to the OS on unload/shutdown.
+    private var kvSweepTask: Task<Void, Never>?
+    /// Sweep cadence. Fixed (ProviderLoop derives its cadence from
+    /// heartbeat/2; there is no heartbeat here); the reclaimer itself
+    /// rate-limits and threshold-gates, so this only bounds reaction
+    /// latency. Tests lower it via `setKVSweepIntervalForTesting`.
+    private var kvSweepInterval: Duration = .seconds(5)
     private enum LifecycleState {
         case stopped
         case running
@@ -324,6 +335,15 @@ public actor StandaloneServer {
                 self.markBindFailed()
             }
         }
+        kvSweepTask?.cancel()
+        let sweepInterval = kvSweepInterval
+        kvSweepTask = Task { [kvBudget] in
+            while !Task.isCancelled {
+                try? await taskSleep(sweepInterval)
+                if Task.isCancelled { break }
+                kvBudget.proactiveReclaimSweep()
+            }
+        }
         lifecycleState = .running
     }
 
@@ -396,6 +416,8 @@ public actor StandaloneServer {
     }
 
     private func finishShutdown(serviceTask: Task<Void, Never>?) async {
+        kvSweepTask?.cancel()
+        kvSweepTask = nil
         serviceTask?.cancel()
         _ = await serviceTask?.value
         await specDecFunnel.shutdown()
@@ -441,6 +463,18 @@ public actor StandaloneServer {
 
     func debugOutstandingKVReservationBytes() async -> UInt64 {
         await kvBudget.outstandingReservedBytes()
+    }
+
+    /// Sweep signals the budget's reclaimer has received — wiring assertion
+    /// seam for the periodic `kvSweepTask` (see `KVPoolReclaimer.sweepSignalCount`).
+    func debugKVSweepSignalCount() async -> Int {
+        await kvBudget.reclaimerForTesting.sweepSignalCount
+    }
+
+    /// Lower the sweep cadence so a wiring test observes a signal without
+    /// waiting out the production interval. Call before `start()`.
+    func setKVSweepIntervalForTesting(_ interval: Duration) {
+        kvSweepInterval = interval
     }
 
     func reservePendingLoadForTesting(requestID: String, bytes: UInt64) async {

--- a/provider-swift/Sources/ProviderCore/Server/StandaloneServer.swift
+++ b/provider-swift/Sources/ProviderCore/Server/StandaloneServer.swift
@@ -467,7 +467,7 @@ public actor StandaloneServer {
 
     /// Sweep signals the budget's reclaimer has received — wiring assertion
     /// seam for the periodic `kvSweepTask` (see `KVPoolReclaimer.sweepSignalCount`).
-    func debugKVSweepSignalCount() async -> Int {
+    func debugKVSweepSignalCount() async -> UInt64 {
         await kvBudget.reclaimerForTesting.sweepSignalCount
     }
 

--- a/provider-swift/Sources/ProviderCore/Service/LaunchAgent.swift
+++ b/provider-swift/Sources/ProviderCore/Service/LaunchAgent.swift
@@ -280,12 +280,19 @@ public enum LaunchAgent: Sendable {
     /// override that did not reach the launchd jobs would split them across
     /// two files — the watchdog tripping one path while the daemon and the
     /// operator's clear verb read another.
+    /// `DARKBLOOM_MLX_CACHE_LIMIT_GB` / `DARKBLOOM_MLX_MEMORY_RESERVE_GB`:
+    /// the `MLXMemoryGuard` operator knobs (buffer-pool cap and whole-machine
+    /// memory ceiling reserve). The daemon is where they matter — a shell
+    /// export that did not reach launchd would silently no-op in the normal
+    /// `darkbloom start` deployment, leaving the advertised recovery lever
+    /// (e.g. raising the cache cap after the 8 GiB default) foreground-only.
     static let passthroughEnvKeys = [
         "DARKBLOOM_PREFIX_CACHE",
         "DARKBLOOM_MLX_RESOURCE_DEBUG", "DARKBLOOM_CBV2_PAGED_KV",
         "DARKBLOOM_CBV2_MTP", "DARKBLOOM_MTP_MAX_RECTANGULAR_TOKENS",
         "DARKBLOOM_KV_BACKEND_GUARD",
         GemmaOptimizationEnvironment.qwenDirectExpertReductionKey,
+        "DARKBLOOM_MLX_CACHE_LIMIT_GB", "DARKBLOOM_MLX_MEMORY_RESERVE_GB",
     ]
 
     /// Build the daemon `EnvironmentVariables` map from a source environment,

--- a/provider-swift/Tests/ProviderCoreTests/EngineV2ProductionWiringTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/EngineV2ProductionWiringTests.swift
@@ -2005,18 +2005,17 @@ struct EngineV2RuntimeGuardTests {
         // the state file immediately, and the join turns that record into a
         // slot entry rather than leaving doctor to guess from absence.
         // `recordModelLoadError` writes the REAL state file, so redirect it
-        // (this suite is `.serialized` and nothing else reads the default
-        // path) — then read the bytes back, which is the actual contract:
-        // the CLI decodes this file, it does not call into the daemon.
+        // through the per-loop seam (a process-global DARKBLOOM_STATE_FILE
+        // setenv would race concurrently running suites' daemon-state
+        // writes into this file) — then read the bytes back, which is the
+        // actual contract: the CLI decodes this file, it does not call
+        // into the daemon.
         let stateURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("dstate-refused-\(UUID().uuidString).json")
-        setenv("DARKBLOOM_STATE_FILE", stateURL.path, 1)
-        defer {
-            unsetenv("DARKBLOOM_STATE_FILE")
-            try? FileManager.default.removeItem(at: stateURL)
-        }
+        defer { try? FileManager.default.removeItem(at: stateURL) }
 
         let loop = try makeWiringLoop(kvBackend: "paged")
+        await loop.setDaemonStateFileForTesting(stateURL)
         await loop.recordModelLoadError(
             model: "gemma-4-26b-qat-4bit",
             message: "Model 'gemma-4-26b-qat-4bit' loaded but its v2 engine construction "

--- a/provider-swift/Tests/ProviderCoreTests/GlobalKVCacheBudgetSelfHealTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/GlobalKVCacheBudgetSelfHealTests.swift
@@ -69,7 +69,10 @@ private let gib: UInt64 = 1024 * 1024 * 1024
     #expect(!admitted)                                   // rejected on current snapshot
     #expect(elapsed < .milliseconds(250))                // returned well before the 0.5s flush
     #expect(spy.completedCount == 0)                     // flush not finished when reserve returned
-    #expect(await eventually(timeout: .seconds(3)) { spy.completedCount == 1 })  // it did run, off-actor
+    // This is eventual liveness, not the fast-return SLA above. Swift Testing
+    // runs ~2k tests concurrently in CI, so the fire-and-forget task can be
+    // scheduler-starved for several seconds without blocking the budget actor.
+    #expect(await eventually(timeout: .seconds(10)) { spy.completedCount == 1 })
 }
 
 @Test func admissionAdmitsImmediatelyWhenItFitsWithoutAnyFlush() async {

--- a/provider-swift/Tests/ProviderCoreTests/KVPoolReclaimerTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/KVPoolReclaimerTests.swift
@@ -1,3 +1,4 @@
+import Dispatch
 import Foundation
 import Testing
 @testable import ProviderCore
@@ -96,6 +97,60 @@ struct KVPoolReclaimerTests {
         #expect(await reclaimer.reclaimCount == 1)
     }
 
+    @Test("telemetry records reclaim volume and blocking duration")
+    func telemetryRecordsObservedReclaim() async {
+        let spy = ReclaimSpy(reclaimable: 3 * gib)
+        let reclaimer = KVPoolReclaimer(
+            clearCache: {
+                Thread.sleep(forTimeInterval: 0.005)
+                spy.clear()
+            },
+            reclaimableBytes: { spy.reclaimable },
+            minInterval: .zero,
+            proactiveThresholdBytes: 2 * gib)
+
+        #expect(await reclaimer.sweep())
+        let telemetry = reclaimer.telemetrySnapshot()
+        #expect(telemetry.sweepSignals == 1)
+        #expect(telemetry.reclaims == 1)
+        #expect(telemetry.reclaimedBytes == 3 * gib)
+        #expect(telemetry.lastReclaimedBytes == 3 * gib)
+        #expect(telemetry.lastReclaimDurationMs >= 1)
+    }
+
+    @Test("heartbeat telemetry snapshot never waits for a blocking GPU clear")
+    func telemetrySnapshotDoesNotWaitForClear() async {
+        let gate = BlockingReclaimGate()
+        let spy = ReclaimSpy(reclaimable: 3 * gib)
+        let reclaimer = KVPoolReclaimer(
+            clearCache: {
+                gate.enterClear()
+                spy.clear()
+            },
+            reclaimableBytes: { spy.reclaimable },
+            minInterval: .zero,
+            proactiveThresholdBytes: 2 * gib)
+
+        let reclaim = Task { await reclaimer.sweep() }
+        #expect(gate.waitUntilClearStarted())
+        let failsafe = Task {
+            try? await taskSleep(.milliseconds(250))
+            gate.releaseClear()
+        }
+
+        let startedAt = ContinuousClock.now
+        let duringClear = reclaimer.telemetrySnapshot()
+        let snapshotLatency = ContinuousClock.now - startedAt
+        gate.releaseClear()
+        failsafe.cancel()
+
+        #expect(snapshotLatency < .milliseconds(100))
+        #expect(duringClear.sweepSignals == 1)
+        #expect(duringClear.reclaims == 0)
+        #expect(await reclaim.value)
+        #expect(reclaimer.telemetrySnapshot().reclaims == 1)
+    }
+
     @Test("sweep signals are counted even when the threshold gate skips the flush")
     func sweepSignalCountTracksWiring() async {
         // `sweepSignalCount` is the wiring seam the periodic drivers
@@ -144,6 +199,7 @@ private final class ReclaimSpy: @unchecked Sendable {
     private var _reclaimable: UInt64
     private var _clearCount = 0
 
+
     init(reclaimable: UInt64, shrinkOnClear: Bool = true) {
         self._reclaimable = reclaimable
         self.shrinkOnClear = shrinkOnClear
@@ -163,5 +219,29 @@ private final class ReclaimSpy: @unchecked Sendable {
 
     var clearCount: Int {
         lock.lock(); defer { lock.unlock() }; return _clearCount
+    }
+}
+
+private final class BlockingReclaimGate: @unchecked Sendable {
+    private let started = DispatchSemaphore(value: 0)
+    private let release = DispatchSemaphore(value: 0)
+    private let lock = NSLock()
+    private var released = false
+
+    func enterClear() {
+        started.signal()
+        release.wait()
+    }
+
+    func waitUntilClearStarted() -> Bool {
+        started.wait(timeout: .now() + 2) == .success
+    }
+
+    func releaseClear() {
+        lock.lock()
+        defer { lock.unlock() }
+        guard !released else { return }
+        released = true
+        release.signal()
     }
 }

--- a/provider-swift/Tests/ProviderCoreTests/KVPoolReclaimerTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/KVPoolReclaimerTests.swift
@@ -96,6 +96,31 @@ struct KVPoolReclaimerTests {
         #expect(await reclaimer.reclaimCount == 1)
     }
 
+    @Test("sweep signals are counted even when the threshold gate skips the flush")
+    func sweepSignalCountTracksWiring() async {
+        // `sweepSignalCount` is the wiring seam the periodic drivers
+        // (ProviderLoop capacity tick, StandaloneServer sweep task) are
+        // asserted through — it must tick on EVERY signal, flushed or gated,
+        // or a test-process pool below the threshold would hide a lost caller
+        // (the v0.7.5 regression this observability exists for).
+        let spy = ReclaimSpy(reclaimable: 0)
+        let reclaimer = KVPoolReclaimer(
+            clearCache: { spy.clear() },
+            reclaimableBytes: { spy.reclaimable },
+            minInterval: .zero,
+            proactiveThresholdBytes: 2 * gib)
+
+        #expect(await reclaimer.sweepSignalCount == 0)
+        #expect(!(await reclaimer.sweep()))              // empty pool: flush gated out…
+        #expect(await reclaimer.sweepSignalCount == 1)   // …but the signal is counted
+        #expect(await reclaimer.reclaimCount == 0)
+
+        spy.reclaimable = 3 * gib
+        #expect(await reclaimer.sweep())
+        #expect(await reclaimer.sweepSignalCount == 2)
+        #expect(await reclaimer.reclaimCount == 1)
+    }
+
     @Test("the on-pressure and proactive paths share one rate-limit window")
     func sweepAndReclaimShareRateLimit() async {
         let spy = ReclaimSpy(reclaimable: 4 * gib, shrinkOnClear: false)

--- a/provider-swift/Tests/ProviderCoreTests/KVPoolSweepWiringTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/KVPoolSweepWiringTests.swift
@@ -58,11 +58,18 @@ struct KVPoolSweepWiringTests {
         #expect(signalled, "start() must spawn the periodic sweep task")
 
         // The sweep task dies with the server: after stop(), the signal
-        // count must go quiet (one in-flight signal may still land).
-        let after = await server.debugKVSweepSignalCount()
-        try await taskSleep(.milliseconds(100))
-        let later = await server.debugKVSweepSignalCount()
-        #expect(later <= after + 1, "the sweep task must stop with the server")
+        // stream quiesces. Already-spawned fire-and-forget signal tasks may
+        // still land right after stop, so poll until the count holds still
+        // for 100ms — ten idle sweep cycles at this test's 10ms cadence, so
+        // a still-alive task cannot fake it — rather than assuming a fixed
+        // in-flight allowance.
+        let quiesced = await pollUntil {
+            let before = await server.debugKVSweepSignalCount()
+            try? await taskSleep(.milliseconds(100))
+            let after = await server.debugKVSweepSignalCount()
+            return before == after
+        }
+        #expect(quiesced, "the sweep task must stop with the server")
     }
 }
 

--- a/provider-swift/Tests/ProviderCoreTests/KVPoolSweepWiringTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/KVPoolSweepWiringTests.swift
@@ -1,0 +1,104 @@
+// Copyright © 2026 Eigen Labs.
+//
+// Regression tests for the post-v0.7.5 MLX buffer-pool leak: the proactive
+// KV-pool sweep (DAR-338) was driven by the legacy engine's liveness
+// watchdog, and the v0.7.5 legacy-engine deletion removed that watchdog —
+// the sweep's ONLY caller — leaving `proactiveReclaimSweep()` dead code.
+// Under sustained serving nothing returned freed KV/activation buffers to
+// the OS: MLX's cache grew toward the cache limit (0.75 × RAM at the time,
+// ~380 GB allowed on a 512 GB Mac Studio — observed in the field as 377 GB
+// of Metal allocation for a ~21 GB model) and only macOS memory pressure
+// ever trimmed it.
+//
+// These tests pin the two periodic drivers that now exist:
+//   * `ProviderLoop.capacityRefreshTick` — the fleet-serving path;
+//   * `StandaloneServer`'s sweep task — the local-serving path.
+// Both are asserted through `KVPoolReclaimer.sweepSignalCount`, which counts
+// sweep signals BEFORE the threshold gate, so no multi-GiB real MLX pool is
+// needed in the test process.
+
+import Foundation
+import Testing
+
+@testable import ProviderCore
+
+@Suite("KV pool sweep wiring", .serialized)
+struct KVPoolSweepWiringTests {
+
+    @Test("ProviderLoop.capacityRefreshTick signals the proactive pool sweep")
+    func capacityTickSignalsSweep() async throws {
+        // The tick also writes the daemon state file; redirect it (same
+        // pattern as EngineV2ProductionWiringTests — serialized suite,
+        // nothing else reads the default path).
+        let stateURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("dstate-sweep-\(UUID().uuidString).json")
+        setenv("DARKBLOOM_STATE_FILE", stateURL.path, 1)
+        defer {
+            unsetenv("DARKBLOOM_STATE_FILE")
+            try? FileManager.default.removeItem(at: stateURL)
+        }
+
+        let loop = try makeSweepWiringLoop()
+        let reclaimer = await loop.kvBudgetForTesting().reclaimerForTesting
+        #expect(await reclaimer.sweepSignalCount == 0)
+
+        await loop.capacityRefreshTick()
+
+        // `scheduleSweep` is fire-and-forget (it only spawns a task); poll
+        // until the signal lands on the reclaimer actor.
+        let signalled = await pollUntil { await reclaimer.sweepSignalCount > 0 }
+        #expect(signalled, "the capacity tick must signal the proactive pool sweep")
+    }
+
+    @Test("StandaloneServer.start spawns the periodic pool sweep")
+    func standaloneStartSpawnsSweep() async throws {
+        let server = StandaloneServer(config: StandaloneServerConfig(port: 0))
+        await server.setKVSweepIntervalForTesting(.milliseconds(10))
+        try await server.start()
+
+        let signalled = await pollUntil { await server.debugKVSweepSignalCount() > 0 }
+        await server.stop()
+        #expect(signalled, "start() must spawn the periodic sweep task")
+
+        // The sweep task dies with the server: after stop(), the signal
+        // count must go quiet (one in-flight signal may still land).
+        let after = await server.debugKVSweepSignalCount()
+        try await taskSleep(.milliseconds(100))
+        let later = await server.debugKVSweepSignalCount()
+        #expect(later <= after + 1, "the sweep task must stop with the server")
+    }
+}
+
+private func makeSweepWiringLoop() throws -> ProviderLoop {
+    let config = ProviderLoopConfig(
+        coordinatorURL: "ws://127.0.0.1:0/ignored",
+        hardware: HardwareInfo(
+            machineModel: "Mac16,5", chipName: "Apple M4 Max", chipFamily: .m4, chipTier: .max,
+            memoryGb: 128, memoryAvailableGb: 124,
+            cpuCores: CpuCores(total: 16, performance: 12, efficiency: 4),
+            gpuCores: 40, memoryBandwidthGbs: 546
+        ),
+        models: [],
+        config: ProviderConfig(
+            provider: ProviderSettings(name: "kv-sweep-wiring-test", memoryReserveGB: 1),
+            backend: BackendSettings(idleTimeoutMins: 0, maxModelSlots: 3),
+            coordinator: CoordinatorSettings(heartbeatIntervalSecs: 60)
+        )
+    )
+    return try ProviderLoop(config: config, purgeLegacyFiles: false, attestationSigner: nil)
+}
+
+/// Poll `condition` until true or the timeout elapses. Returns the final
+/// verdict — polling, not sleeping a fixed amount, keeps the pass fast and
+/// the failure bounded.
+private func pollUntil(
+    timeout: Duration = .seconds(5),
+    _ condition: () async -> Bool
+) async -> Bool {
+    let deadline = ContinuousClock.now.advanced(by: timeout)
+    while ContinuousClock.now < deadline {
+        if await condition() { return true }
+        try? await taskSleep(.milliseconds(10))
+    }
+    return await condition()
+}

--- a/provider-swift/Tests/ProviderCoreTests/KVPoolSweepWiringTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/KVPoolSweepWiringTests.swift
@@ -22,23 +22,20 @@ import Testing
 
 @testable import ProviderCore
 
-@Suite("KV pool sweep wiring", .serialized)
+@Suite("KV pool sweep wiring")
 struct KVPoolSweepWiringTests {
 
     @Test("ProviderLoop.capacityRefreshTick signals the proactive pool sweep")
     func capacityTickSignalsSweep() async throws {
-        // The tick also writes the daemon state file; redirect it (same
-        // pattern as EngineV2ProductionWiringTests — serialized suite,
-        // nothing else reads the default path).
+        // The tick also writes the daemon state file; redirect it through the
+        // per-loop seam (NOT the process-global DARKBLOOM_STATE_FILE env var,
+        // which races concurrently running suites).
         let stateURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("dstate-sweep-\(UUID().uuidString).json")
-        setenv("DARKBLOOM_STATE_FILE", stateURL.path, 1)
-        defer {
-            unsetenv("DARKBLOOM_STATE_FILE")
-            try? FileManager.default.removeItem(at: stateURL)
-        }
+        defer { try? FileManager.default.removeItem(at: stateURL) }
 
         let loop = try makeSweepWiringLoop()
+        await loop.setDaemonStateFileForTesting(stateURL)
         let reclaimer = await loop.kvBudgetForTesting().reclaimerForTesting
         #expect(await reclaimer.sweepSignalCount == 0)
 

--- a/provider-swift/Tests/ProviderCoreTests/KVPoolSweepWiringTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/KVPoolSweepWiringTests.swift
@@ -45,6 +45,14 @@ struct KVPoolSweepWiringTests {
         // until the signal lands on the reclaimer actor.
         let signalled = await pollUntil { await reclaimer.sweepSignalCount > 0 }
         #expect(signalled, "the capacity tick must signal the proactive pool sweep")
+
+        // The next capacity sample exports the reclaimer counters on the
+        // heartbeat wire. This pins the operational telemetry path, not merely
+        // the internal caller.
+        await loop.updateAggregateCapacity()
+        let capacity = try #require(await loop.backendCapacityForTesting())
+        let telemetry = try #require(capacity.mlxCacheReclaimer)
+        #expect(telemetry.sweepSignals > 0)
     }
 
     @Test("StandaloneServer.start spawns the periodic pool sweep")

--- a/provider-swift/Tests/ProviderCoreTests/LaunchAgentRestartTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/LaunchAgentRestartTests.swift
@@ -126,6 +126,22 @@ struct LaunchAgentEnvironmentTests {
         }
     }
 
+    @Test func forwardsMLXMemoryGuardKnobsToDaemon() {
+        // The MLXMemoryGuard operator knobs only matter in the launchd
+        // daemon (the normal `darkbloom start` mode). Without passthrough, a
+        // shell export of the cache cap — the advertised recovery lever for
+        // the 8 GiB buffer-pool default — would silently no-op there.
+        let out = LaunchAgent.passthroughEnvironment(from: [
+            "DARKBLOOM_MLX_CACHE_LIMIT_GB": "32",
+            "DARKBLOOM_MLX_MEMORY_RESERVE_GB": "12",
+            "PATH": "/usr/bin",
+        ])
+        #expect(out == [
+            "DARKBLOOM_MLX_CACHE_LIMIT_GB": "32",
+            "DARKBLOOM_MLX_MEMORY_RESERVE_GB": "12",
+        ])
+    }
+
     @Test func forwardsKVBackendGuardPathToDaemonAndWatchdog() {
         // The crash-loop guard record has one writer (the launchd watchdog)
         // and several readers (the launchd daemon's engine factory, a

--- a/provider-swift/Tests/ProviderCoreTests/MLXMemoryGuardTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/MLXMemoryGuardTests.swift
@@ -166,6 +166,8 @@ struct MLXMemoryGuardConfigureOnceTests {
             apply: { applied.append($0) })
         #expect(limits?.cacheLimitBytes == 2 * gib)
         #expect(applied.first?.cacheLimitBytes == 2 * gib)
+        #expect(MLXMemoryGuard.configuredLimitsSnapshot() == limits)
         MLXMemoryGuard._resetForTest()
+        #expect(MLXMemoryGuard.configuredLimitsSnapshot() == nil)
     }
 }

--- a/provider-swift/Tests/ProviderCoreTests/MLXMemoryGuardTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/MLXMemoryGuardTests.swift
@@ -128,21 +128,44 @@ private let gib = 1024 * 1024 * 1024
         explicit: nil, env: ["DARKBLOOM_MLX_MEMORY_RESERVE_GB": "0"]) == 0)
 }
 
-@Test func mlxGuardConfigureOnceAppliesExactlyOnce() {
-    MLXMemoryGuard._resetForTest()
-    var applied: [MLXMemoryGuard.Limits] = []
-    let first = MLXMemoryGuard.configureOnce(
-        reserveBytes: UInt64(6 * gib),
-        physicalBytes: UInt64(32 * gib),
-        apply: { applied.append($0) })
-    let second = MLXMemoryGuard.configureOnce(
-        reserveBytes: UInt64(6 * gib),
-        physicalBytes: UInt64(32 * gib),
-        apply: { applied.append($0) })
+/// Serialized: both tests reset + trip the process-global once-flag, so
+/// running them in parallel would race `configured` and flake.
+@Suite("MLXMemoryGuard.configureOnce", .serialized)
+struct MLXMemoryGuardConfigureOnceTests {
 
-    #expect(first != nil)
-    #expect(second == nil, "second call must be a no-op (ceiling set once per process)")
-    #expect(applied.count == 1)
-    #expect(applied.first?.memoryLimitBytes == 26 * gib)
-    MLXMemoryGuard._resetForTest()
+    @Test func mlxGuardConfigureOnceAppliesExactlyOnce() {
+        MLXMemoryGuard._resetForTest()
+        var applied: [MLXMemoryGuard.Limits] = []
+        let first = MLXMemoryGuard.configureOnce(
+            reserveBytes: UInt64(6 * gib),
+            physicalBytes: UInt64(32 * gib),
+            apply: { applied.append($0) })
+        let second = MLXMemoryGuard.configureOnce(
+            reserveBytes: UInt64(6 * gib),
+            physicalBytes: UInt64(32 * gib),
+            apply: { applied.append($0) })
+
+        #expect(first != nil)
+        #expect(second == nil, "second call must be a no-op (ceiling set once per process)")
+        #expect(applied.count == 1)
+        #expect(applied.first?.memoryLimitBytes == 26 * gib)
+        MLXMemoryGuard._resetForTest()
+    }
+
+    @Test func mlxGuardConfigureOnceThreadsTheCacheCapThrough() {
+        // Pins the configureOnce → recommendedLimits(cacheCapBytes:) composition:
+        // dropping the argument would silently fall back to the default cap
+        // (the values coincide) and only the override path would break — the
+        // shape of bug a defaulted parameter invites.
+        MLXMemoryGuard._resetForTest()
+        var applied: [MLXMemoryGuard.Limits] = []
+        let limits = MLXMemoryGuard.configureOnce(
+            reserveBytes: UInt64(6 * gib),
+            cacheCapBytes: UInt64(2 * gib),
+            physicalBytes: UInt64(64 * gib),
+            apply: { applied.append($0) })
+        #expect(limits?.cacheLimitBytes == 2 * gib)
+        #expect(applied.first?.cacheLimitBytes == 2 * gib)
+        MLXMemoryGuard._resetForTest()
+    }
 }

--- a/provider-swift/Tests/ProviderCoreTests/MLXMemoryGuardTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/MLXMemoryGuardTests.swift
@@ -8,9 +8,71 @@ private let gib = 1024 * 1024 * 1024
     let limits = MLXMemoryGuard.recommendedLimits(
         physicalBytes: UInt64(64 * gib), reserveBytes: UInt64(6 * gib))
     #expect(limits.memoryLimitBytes == 58 * gib)
-    // cache fraction 0.75 of the ceiling, never above it.
-    #expect(limits.cacheLimitBytes == Int(Double(58 * gib) * 0.75))
+    // The absolute cache cap binds well below the 0.75 fraction here
+    // (0.75 × 58 GiB = 43.5 GiB of allowed hoard was the field bug).
+    #expect(limits.cacheLimitBytes == 8 * gib)
     #expect(limits.cacheLimitBytes <= limits.memoryLimitBytes)
+}
+
+@Test func mlxGuardCacheCapBoundsBigMachines() {
+    // The field incident: a 512 GB Mac Studio serving a ~21 GB model
+    // accumulated ~377 GB of freed buffers in MLX's cache — exactly the
+    // old 0.75 × (512 − 6) GiB ≈ 379.5 GiB allowance. The absolute cap
+    // must bound the pool by WORKLOAD, not machine size.
+    let limits = MLXMemoryGuard.recommendedLimits(
+        physicalBytes: UInt64(512 * gib), reserveBytes: UInt64(6 * gib))
+    #expect(limits.memoryLimitBytes == 506 * gib)
+    #expect(limits.cacheLimitBytes == Int(MLXMemoryGuard.defaultCacheLimitGB) * gib)
+}
+
+@Test func mlxGuardCacheFractionStillBindsSmallMachines() {
+    // 16 GiB box: 0.75 × (16 − 6) GiB = 7.5 GiB < the 8 GiB absolute cap,
+    // so the proportional scale-down still governs small machines.
+    let limits = MLXMemoryGuard.recommendedLimits(
+        physicalBytes: UInt64(16 * gib), reserveBytes: UInt64(6 * gib))
+    #expect(limits.memoryLimitBytes == 10 * gib)
+    #expect(limits.cacheLimitBytes == Int(Double(10 * gib) * 0.75))
+}
+
+@Test func mlxGuardCacheCapOverridesClampToFloorAndCeiling() {
+    // A raised cap is honored up to the fraction bound (an operator can
+    // restore bigger pools), never past the memory limit.
+    let raised = MLXMemoryGuard.recommendedLimits(
+        physicalBytes: UInt64(512 * gib), reserveBytes: UInt64(6 * gib),
+        cacheCapBytes: UInt64(64 * gib))
+    #expect(raised.cacheLimitBytes == 64 * gib)
+
+    // A zero/tiny cap lands on the 1 GiB floor so buffer reuse survives a
+    // pathological override.
+    let floored = MLXMemoryGuard.recommendedLimits(
+        physicalBytes: UInt64(64 * gib), reserveBytes: UInt64(6 * gib),
+        cacheCapBytes: 0)
+    #expect(floored.cacheLimitBytes == MLXMemoryGuard.minimumLimitBytes / 2)
+
+    // A huge cap can never push the cache past the memory limit itself.
+    let huge = MLXMemoryGuard.recommendedLimits(
+        physicalBytes: UInt64(16 * gib), reserveBytes: UInt64(6 * gib),
+        cacheFraction: 1.0, cacheCapBytes: UInt64.max)
+    #expect(huge.cacheLimitBytes <= huge.memoryLimitBytes)
+}
+
+@Test func mlxGuardCacheCapResolutionPrefersExplicitThenEnvThenDefault() {
+    #expect(MLXMemoryGuard.resolvedCacheCapBytes(explicit: UInt64(3 * gib), env: [:]) == UInt64(3 * gib))
+    #expect(MLXMemoryGuard.resolvedCacheCapBytes(
+        explicit: nil, env: ["DARKBLOOM_MLX_CACHE_LIMIT_GB": "32"]) == UInt64(32) * 1_073_741_824)
+    #expect(MLXMemoryGuard.resolvedCacheCapBytes(explicit: nil, env: [:])
+        == MLXMemoryGuard.defaultCacheLimitGB * 1_073_741_824)
+    // Garbage env falls back to the default rather than crashing.
+    #expect(MLXMemoryGuard.resolvedCacheCapBytes(
+        explicit: nil, env: ["DARKBLOOM_MLX_CACHE_LIMIT_GB": "not-a-number"])
+        == MLXMemoryGuard.defaultCacheLimitGB * 1_073_741_824)
+    // Same saturation contract as the reserve: a huge finite override clamps,
+    // never traps (the configureOnce-crash class the reserve fix covered).
+    #expect(MLXMemoryGuard.resolvedCacheCapBytes(
+        explicit: nil, env: ["DARKBLOOM_MLX_CACHE_LIMIT_GB": "1e308"]) == UInt64.max)
+    // Zero is honored (lands on the 1 GiB floor in recommendedLimits).
+    #expect(MLXMemoryGuard.resolvedCacheCapBytes(
+        explicit: nil, env: ["DARKBLOOM_MLX_CACHE_LIMIT_GB": "0"]) == 0)
 }
 
 @Test func mlxGuardNeverExceedsPhysicalRAM() {

--- a/provider-swift/Tests/ProviderCoreTests/MediaIngestTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/MediaIngestTests.swift
@@ -162,8 +162,9 @@ func vlmDecodeVideoDataURIStaysInMemory() async throws {
             .filter { $0.hasPrefix("vlm-") && $0.hasSuffix(".mp4") })
 
     // A real, probeable 64x64 video passes the limits and stays owned by the
-    // memory-backed resource loader. The before/after assertion locks out the
-    // exact plaintext temp-file path this replaced.
+    // memory-backed resource loader. Assert only that decode creates no new
+    // plaintext file: another parallel suite may legitimately delete a stale
+    // pre-existing `vlm-*.mp4` between these snapshots.
     let (video, framePixels) = try await MediaIngest.decodeVideo(tinyMP4DataURI)
     guard case .memoryBacked(let memoryAsset) = video else {
         Issue.record("expected .memoryBacked, got \(video)")
@@ -175,7 +176,8 @@ func vlmDecodeVideoDataURIStaysInMemory() async throws {
     let newTempFiles = try Set(
         fileManager.contentsOfDirectory(atPath: tempDirectory.path)
             .filter { $0.hasPrefix("vlm-") && $0.hasSuffix(".mp4") })
-    #expect(newTempFiles == oldTempFiles)
+    let createdTempFiles = newTempFiles.subtracting(oldTempFiles)
+    #expect(createdTempFiles.isEmpty, "decodeVideo created plaintext temp files: \(createdTempFiles)")
 }
 
 @Test("decodeVideo accepts the coordinator's video/quicktime data URI contract")

--- a/provider-swift/Tests/ProviderCoreTests/ModelLoadAdmissionTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ModelLoadAdmissionTests.swift
@@ -201,14 +201,21 @@ private let gib: UInt64 = 1024 * 1024 * 1024
 // MARK: - BackendCapacity wire compatibility
 
 @Test func backendCapacityRoundTripsFreeForLoad() throws {
+    let telemetry = MLXCacheReclaimerTelemetry(
+        cacheLimitBytes: 8 * gib, sweepSignals: 12, reclaims: 4,
+        reclaimedBytes: 24 * gib, lastReclaimedBytes: 6 * gib,
+        lastReclaimDurationMs: 17)
     let cap = BackendCapacity(
         slots: [], gpuMemoryActiveGb: 1, gpuMemoryPeakGb: 2,
-        gpuMemoryCacheGb: 0.5, totalMemoryGb: 64, freeForLoadGb: 17.5)
+        gpuMemoryCacheGb: 0.5, totalMemoryGb: 64, freeForLoadGb: 17.5,
+        mlxCacheReclaimer: telemetry)
     let data = try JSONEncoder().encode(cap)
     #expect(String(decoding: data, as: UTF8.self).contains("free_for_load_gb"))
+    #expect(String(decoding: data, as: UTF8.self).contains("mlx_cache_reclaimer"))
     let decoded = try JSONDecoder().decode(BackendCapacity.self, from: data)
     #expect(decoded == cap)
     #expect(abs(decoded.freeForLoadGb - 17.5) < 0.001)
+    #expect(decoded.mlxCacheReclaimer == telemetry)
 }
 
 @Test func backendCapacityDecodesLegacyWithoutFreeForLoad() throws {
@@ -216,4 +223,5 @@ private let gib: UInt64 = 1024 * 1024 * 1024
     let decoded = try JSONDecoder().decode(BackendCapacity.self, from: Data(legacy.utf8))
     #expect(decoded.freeForLoadGb == 0, "legacy payload defaults to 0, no throw")
     #expect(abs(decoded.totalMemoryGb - 64) < 0.001)
+    #expect(decoded.mlxCacheReclaimer == nil, "legacy payload has no reclaimer telemetry")
 }

--- a/provider-swift/Tests/ProviderCoreTests/ProtocolTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ProtocolTests.swift
@@ -1085,7 +1085,14 @@ import Testing
             gpuMemoryActiveGb: 5.5,
             gpuMemoryPeakGb: 6.5,
             gpuMemoryCacheGb: 1.5,
-            totalMemoryGb: 36
+            totalMemoryGb: 36,
+            mlxCacheReclaimer: MLXCacheReclaimerTelemetry(
+                cacheLimitBytes: 8 * 1024 * 1024 * 1024,
+                sweepSignals: 12,
+                reclaims: 4,
+                reclaimedBytes: 24 * 1024 * 1024 * 1024,
+                lastReclaimedBytes: 6 * 1024 * 1024 * 1024,
+                lastReclaimDurationMs: 17)
         )
     ))
 
@@ -1093,11 +1100,18 @@ import Testing
     let object = try jsonObject(data)
     let capacity = object["backend_capacity"] as? [String: Any]
     let slot = (capacity?["slots"] as? [[String: Any]])?.first
+    let reclaimer = capacity?["mlx_cache_reclaimer"] as? [String: Any]
 
     #expect(capacity?["gpu_memory_active_gb"] as? Double == 5.5)
     #expect(capacity?["gpu_memory_peak_gb"] as? Double == 6.5)
     #expect(capacity?["gpu_memory_cache_gb"] as? Double == 1.5)
     #expect(capacity?["total_memory_gb"] as? Double == 36)
+    #expect((reclaimer?["cache_limit_bytes"] as? NSNumber)?.uint64Value == UInt64(8) * 1024 * 1024 * 1024)
+    #expect(reclaimer?["sweep_signals"] as? Int == 12)
+    #expect(reclaimer?["reclaims"] as? Int == 4)
+    #expect((reclaimer?["reclaimed_bytes"] as? NSNumber)?.uint64Value == UInt64(24) * 1024 * 1024 * 1024)
+    #expect((reclaimer?["last_reclaimed_bytes"] as? NSNumber)?.uint64Value == UInt64(6) * 1024 * 1024 * 1024)
+    #expect(reclaimer?["last_reclaim_duration_ms"] as? Int == 17)
     #expect(slot?["num_running"] as? Int == 1)
     #expect(slot?["num_waiting"] as? Int == 2)
     #expect(slot?["active_tokens"] as? Int == 3000)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Summary

Fixes the unbounded MLX Metal allocation growth reported under sustained serving (377GB allocated for a ~21GB model after an hour of ~5 req/min; also the fill-to-top-then-drop-to-65GB sawtooth). Two compounding defects, both provider-side:

1. **The periodic cache sweep has been dead code since v0.7.5.** DAR-338 (#413) added `KVPoolReclaimer` + `GlobalKVCacheBudget.proactiveReclaimSweep()`, driven every 2s by the legacy `BatchScheduler` liveness watchdog. The v0.7.5 legacy-engine deletion (#522) removed that watchdog — the sweep's **only caller**. Since then nothing periodically returned freed KV/activation buffers to the OS; the only remaining trims were failed-admission reclaims (never fire on big machines with huge headroom) and macOS memory-pressure events (fire only when the whole machine is already full — the observed sawtooth).
2. **The cache limit was sized to RAM, not the workload.** `MLXMemoryGuard` set `cacheLimit = 0.75 × (physical − 6GB)` — ~379.5GB of allowed buffer hoard on a 512GB Mac Studio, matching the observed 377GB almost exactly. Every completed request's freed KV/activation buffers parked there; nothing below that limit ever evicted them.

## What changed

- `ProviderLoop.capacityRefreshTick` (the documented successor of the legacy watchdog tick; runs at heartbeat/2 = 2s at the default 5s heartbeat — the legacy cadence) now drives `proactiveReclaimSweep()`. Non-blocking: it only signals the off-actor reclaimer, which stays rate-limited (1/s) and threshold-gated (2GiB), so the DAR-338 "never block the admission actor" invariant is preserved.
- `StandaloneServer` (local serving; no capacity tick) runs its own 5s sweep task, spawned in `start()` and cancelled in shutdown.
- `MLXMemoryGuard.cacheLimit` gains an absolute cap: `min(0.75 × memoryLimit, 8GiB)`. 8GiB covers the measured ~5.5GiB B=8 per-step activation reuse set with slack; the 0.75 fraction still governs small machines (< ~17GB RAM). `DARKBLOOM_MLX_CACHE_LIMIT_GB` overrides in either direction (1GiB floor, bounded above by 0.75 × memoryLimit, trap-free saturation like the reserve override).
- `DARKBLOOM_MLX_CACHE_LIMIT_GB` and the pre-existing `DARKBLOOM_MLX_MEMORY_RESERVE_GB` are now in `LaunchAgent.passthroughEnvKeys` — without that, the advertised recovery lever silently no-oped in the normal `darkbloom start` launchd mode (review finding).
- Deleted `reclaimForShortfall` (dead since the same v0.7.5 deletion; the failed-commit path signals the reclaimer internally).
- Added `KVPoolReclaimer.sweepSignalCount` (counts sweep signals before the threshold gate) so wiring tests fail if a sweep driver is ever lost again — the exact regression class that caused this incident.
- Added heartbeat-safe allocator telemetry: configured cache limit, sweep signals, actual reclaims, cumulative/last reclaimed bytes, and last synchronize+clear duration. The provider samples a lock-backed snapshot without waiting behind a blocking GPU clear; the coordinator emits `provider.mlx_memory.*` and `provider.mlx_cache.*` Datadog gauges tagged by provider.
- Test-infra: new per-loop `daemonStateFileOverride` seam replaces the process-global `DARKBLOOM_STATE_FILE` setenv in tests (suites run in parallel; two setenv mutators could route each other's daemon-state writes into the wrong temp file — review finding).

## Behavior: before → after

```mermaid
flowchart LR
 subgraph Before
 A1[sustained serving] --> B1[request completes:<br/>KV + activation buffers freed] --> C1[parked in MLX cache<br/>limit = 0.75 × RAM ≈ 380GB on 512GB]
 C1 --> D1{any trim?}
 D1 -- proactive sweep --> E1[DEAD: only caller deleted in v0.7.5]
 D1 -- admission near-miss --> F1[never fires: huge headroom]
 D1 -- macOS memory pressure --> G1[fires only when machine is FULL<br/>→ fill-to-top / 65GB sawtooth]
 C1 --> H1[cache grows without bound:<br/>377GB for a 21GB model]
 end
```

```mermaid
flowchart LR
 subgraph After
 A2[sustained serving] --> B2[request completes:<br/>buffers freed] --> C2[MLX cache bounded:<br/>min 0.75 × limit, 8GiB abs cap]
 C2 --> D2[capacity tick every 2s /<br/>standalone task every 5s] --> E2[proactiveReclaimSweep:<br/>rate-limited, ≥2GiB gated] --> F2[pool returned to OS<br/>within seconds]
 C2 --> G2[worst-case resident hoard ≤ 8GiB<br/>allocator-enforced, even between sweeps]
 F2 --> H2[heartbeat exposes cache/reclaim health<br/>to Datadog for soak + canary validation]
 end
```

## Code: before → after

```mermaid
flowchart LR
 subgraph Before
 W1[BatchScheduler liveness watchdog 2s<br/>DELETED v0.7.5] -.removed caller.-> S1[GlobalKVCacheBudget<br/>.proactiveReclaimSweep — dead]
 S1 -.-> R1[KVPoolReclaimer.sweep]
 M1[MLXMemoryGuard.configureOnce] --> L1[cacheLimit = 0.75 × memoryLimit]
 end
```

```mermaid
flowchart LR
 subgraph After
 T2[ProviderLoop.capacityRefreshTick] --> S2[kvBudget.proactiveReclaimSweep]
 U2[StandaloneServer kvSweepTask 5s] --> S2
 S2 --> R2[KVPoolReclaimer.sweep<br/>sweepSignalCount++ → gate → flush]
 M2[MLXMemoryGuard.configureOnce] --> L2["cacheLimit = min(0.75 × memoryLimit, 8GiB)<br/>DARKBLOOM_MLX_CACHE_LIMIT_GB override"]
 EV2[darkbloom start shell env] -- passthroughEnvKeys --> LD2[launchd daemon plist<br/>knob reaches the fleet mode]
 R2 --> TS2[lock-backed telemetry snapshot<br/>never waits behind GPU clear]
 TS2 --> HB2[BackendCapacity.mlx_cache_reclaimer]
 HB2 --> DD2[coordinator Datadog gauges]
 end
```

## Test plan

- [x] `MLXMemoryGuardTests`: absolute cap binds on big machines (512GB → 8GiB, the field shape), fraction still binds on small ones (16GB → 7.5GiB), override floor/ceiling clamps, env resolution incl. the trap-free saturation contract, and the `configureOnce → cacheCapBytes` composition (once-flag tests serialized — they share process-global state).
- [x] `KVPoolReclaimerTests`: `sweepSignalCount` ticks on every signal, flushed or gated; reclaim byte/duration accounting is pinned; heartbeat sampling is proven not to wait behind a blocking GPU clear.
- [x] `KVPoolSweepWiringTests` (new, regression for the lost-caller class): `ProviderLoop.capacityRefreshTick` signals the sweep; `StandaloneServer.start()` spawns the periodic sweep and it quiesces after `stop()`.
- [x] `LaunchAgentRestartTests`: the two memory-guard knobs pass through to the daemon plist.
- [x] Two independent adversarial reviews (concurrency/arithmetic/regressions + design/tests/coordinator-symmetry): both PASS on production code; all flagged test-hygiene items fixed (setenv race → per-loop seam, quiescence assertion, stale docs, launchd passthrough).
- [x] Targeted Swift telemetry/wiring suite: 17 tests pass on macOS with the source-matched metallib.
- [x] `make provider-build` and `make coordinator-test` pass; coordinator includes protocol, registry-copy, and DogStatsD emission coverage.
- [x] Full `make provider-test`: all 2,120 tests in 217 suites pass after rebasing onto latest `master`.
- [x] CI flake hardening: the media in-memory test rejects newly-created plaintext temp files without failing when another suite removes stale files; the sidecar cold-load singleflight proof uses a 30s correctness timeout while the later production-style warm 25-QPS proof keeps the 1s request SLA.

## Components touched

- [x] provider-swift (Swift CLI)
- [x] coordinator (backward-compatible heartbeat decode + Datadog gauges)

## Protocol / interface changes

- [x] Backward-compatible heartbeat extension: optional `backend_capacity.mlx_cache_reclaimer`; older providers omit it and continue decoding/routing unchanged.
- [x] New optional env var `DARKBLOOM_MLX_CACHE_LIMIT_GB`; no request/response API or config-file changes.

## Notes for reviewers

- The sweep's flush is the same `Stream().synchronize()` + `clearCache()` DAR-338 shipped, still exclusively on the `KVPoolReclaimer` actor — never on the budget actor or the loop actor. The tick call is fire-and-forget.
- The 2GiB proactive threshold and 1/s rate limit are unchanged from the design that ran in production on the legacy engine. Note the B=8 churn set (~5.5GiB) now exceeds the 2GiB threshold, so under sustained load the sweep flushes the hot pool ~every 2s — the same posture the pre-v0.7.5 fleet ran (at B=4); both reviewers recommend a decode-TPS spot-check in the next `make e2e-benchmark` run as follow-up validation, not a code change.
- Raising `DARKBLOOM_MLX_CACHE_LIMIT_GB` restores pre-fix pool sizes if an operator ever needs it (bounded by `0.75 × memoryLimit`), and now actually reaches the launchd daemon.
- Coordinator routing arithmetic is unchanged: `servability.go` still mirrors only the activation floor and `freeMemoryAdmits` still consumes provider-measured `free_for_load_gb`. The coordinator change is measurement-only: decode the optional reclaimer block, retain it in detached registry snapshots, and emit live Datadog gauges.
- Reclaimer counters reset on provider restart. They are gauges, not coordinator-maintained counters, so Datadog can derive rates without cross-session delta state.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://darkbloom.slack.com/archives/C0B0CAQC8P5/p1787283266707159?thread_ts=1787283266.707159&cid=C0B0CAQC8P5)

<div><a href="https://cursor.com/agents/bc-5b6ace34-742c-503b-bab3-d35f1221e7c8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5b6ace34-742c-503b-bab3-d35f1221e7c8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/652"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789893076&installation_model_id=21733&pr_number=652&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F652&signature=7b61aaf5c9d36d3c0e73ca04976b3f50c2d9cb28310a5d3f13c388062bc46080"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
