### PR TITLE
Auto-size activation reserve per-model using measured B=8 peaks

### DIFF
--- a/provider-swift/Sources/ProviderCore/Diagnostics/ModelFitDiagnostic.swift
+++ b/provider-swift/Sources/ProviderCore/Diagnostics/ModelFitDiagnostic.swift
@@ -24,12 +24,16 @@ public enum ModelFitDiagnostic {
     /// footprint plus one-request headroom — exactly `ensureModelLoaded`'s
     /// requirement. `estimatedMemoryGb` is the scanner's overhead-included size
     /// (the same value the runtime passes), not the raw on-disk bytes.
-    public static func requiredGb(estimatedMemoryGb: Double) -> Double {
+    ///
+    /// When `modelID` is provided, the headroom uses the model's measured
+    /// activation peak instead of the worst-case default — e.g. 3.75 GiB for
+    /// gpt-oss-20b (2.56 peak + 1 GiB min KV) vs 6.5 GiB for gemma-4.
+    public static func requiredGb(estimatedMemoryGb: Double, modelID: String? = nil) -> Double {
         // Cap-aware headroom (activation reserve + min serveable KV) so the
         // doctor's "needs ~X GB" matches what the runtime load gate requires.
         ModelLoadAdmission.requiredToLoadGb(
             weightsGb: estimatedMemoryGb,
-            headroomGb: Double(UnifiedMemoryCap.loadHeadroomBytes()) / (1024.0 * 1024.0 * 1024.0))
+            headroomGb: Double(UnifiedMemoryCap.loadHeadroomBytes(modelID: modelID)) / (1024.0 * 1024.0 * 1024.0))
     }
 
     /// The memory (GB) the provider would actually have free to load a model,
@@ -88,7 +92,7 @@ public enum ModelFitDiagnostic {
                 message: "couldn't determine the model size or available memory; skipping the fit check.",
                 fix: nil)
         }
-        let needed = requiredGb(estimatedMemoryGb: weightGb)
+        let needed = requiredGb(estimatedMemoryGb: weightGb, modelID: modelID)
         if needed <= usableGb {
             return Diagnostic(
                 section: .traffic, name: "model fits in RAM", level: .pass,
@@ -96,13 +100,13 @@ public enum ModelFitDiagnostic {
                 fix: nil)
         }
         let fits = alternatives
-            .filter { requiredGb(estimatedMemoryGb: $0.weightGb) <= usableGb }
+            .filter { requiredGb(estimatedMemoryGb: $0.weightGb, modelID: $0.id) <= usableGb }
             .sorted { $0.weightGb > $1.weightGb }
         let suggestion: String
         if fits.isEmpty {
             suggestion = "this box's RAM is too small for the models on this network; consider a machine with more unified memory."
         } else {
-            let list = fits.prefix(3).map { "\($0.id) (~\(fmt(requiredGb(estimatedMemoryGb: $0.weightGb))) GB)" }.joined(separator: ", ")
+            let list = fits.prefix(3).map { "\($0.id) (~\(fmt(requiredGb(estimatedMemoryGb: $0.weightGb, modelID: $0.id))) GB)" }.joined(separator: ", ")
             suggestion = "set `enabled_models` in provider.toml to a model that fits: \(list)."
         }
         return Diagnostic(

--- a/provider-swift/Sources/ProviderCore/Inference/UnifiedMemoryCap.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/UnifiedMemoryCap.swift
@@ -122,10 +122,15 @@ public enum UnifiedMemoryCap {
     /// headroom was LESS than the 3 GiB activation reserve, so a near-cap model
     /// loaded with zero serveable KV). Returns
     /// `activationReserve + minimumLoadKV`.
+    ///
+    /// When `modelID` is provided, the activation reserve is looked up from
+    /// ``modelActivationPeaks`` so the headroom matches the model's measured
+    /// B=8 peak instead of the worst-case default.
     public static func loadHeadroomBytes(
-        activationReserveBytes: UInt64? = nil
+        activationReserveBytes: UInt64? = nil,
+        modelID: String? = nil
     ) -> UInt64 {
-        let activations = activationReserveBytes ?? resolvedActivationReserveBytes()
+        let activations = activationReserveBytes ?? resolvedActivationReserveBytes(modelID: modelID)
         return saturatingAdd(activations, minimumLoadKVBytes)
     }
 
@@ -166,6 +171,7 @@ public enum UnifiedMemoryCap {
         physicalBytes: UInt64 = ProcessInfo.processInfo.physicalMemory,
         residentWeightBytes: UInt64,
         activationReserveBytes: UInt64? = nil,
+        modelID: String? = nil,
         ramPrefixAllowanceBytes: UInt64 = 0,
         configReserveBytes: UInt64 = 0,
         capFraction: Double? = nil
@@ -174,7 +180,7 @@ public enum UnifiedMemoryCap {
         let reserveFloor =
             physicalBytes > configReserveBytes ? physicalBytes - configReserveBytes : 0
         let effectiveCap = min(cap, reserveFloor)
-        let activations = activationReserveBytes ?? resolvedActivationReserveBytes()
+        let activations = activationReserveBytes ?? resolvedActivationReserveBytes(modelID: modelID)
         let claimed = saturatingAdd(residentWeightBytes, activations, ramPrefixAllowanceBytes)
         return effectiveCap > claimed ? effectiveCap - claimed : 0
     }
@@ -202,6 +208,7 @@ public enum UnifiedMemoryCap {
         mlxUsedBytes: UInt64,
         systemAvailableBytes: UInt64,
         activationReserveBytes: UInt64? = nil,
+        modelID: String? = nil,
         configReserveBytes: UInt64 = 0,
         capFraction: Double? = nil
     ) -> UInt64 {
@@ -217,7 +224,7 @@ public enum UnifiedMemoryCap {
         let effectiveCap = min(cap, reserveFloor)
         let underCap = effectiveCap > mlxUsedBytes ? effectiveCap - mlxUsedBytes : 0
         let realFree = min(underCap, systemAvailableBytes)
-        let activations = activationReserveBytes ?? resolvedActivationReserveBytes()
+        let activations = activationReserveBytes ?? resolvedActivationReserveBytes(modelID: modelID)
         return realFree > activations ? realFree - activations : 0
     }
 
@@ -231,11 +238,12 @@ public enum UnifiedMemoryCap {
         candidateWeightBytes: UInt64,
         minimumKVBytes: UInt64,
         activationReserveBytes: UInt64? = nil,
+        modelID: String? = nil,
         ramPrefixAllowanceBytes: UInt64 = 0,
         capFraction: Double? = nil
     ) -> Bool {
         let cap = hardCapBytes(physicalBytes: physicalBytes, capFraction: capFraction)
-        let activations = activationReserveBytes ?? resolvedActivationReserveBytes()
+        let activations = activationReserveBytes ?? resolvedActivationReserveBytes(modelID: modelID)
         let need = saturatingAdd(
             currentResidentWeightBytes, candidateWeightBytes,
             activations, ramPrefixAllowanceBytes, minimumKVBytes)
@@ -262,7 +270,41 @@ public enum UnifiedMemoryCap {
         return max(configReserveBytes, capImpliedReserve)
     }
 
-    // MARK: - Resolution (explicit → env → default)
+    // MARK: - Per-model activation peaks
+
+    /// Measured activation peaks (B=8 decode) from the v0.8.0 benchmark sweep.
+    /// Keyed by a distinguishing substring of the model ID; matched
+    /// case-insensitively against the lowercased model ID. The reserve is
+    /// peak + ~10% slack, rounded to a clean number.
+    ///
+    /// Only models whose peaks differ materially from the default are listed.
+    /// Unknown models fall back to ``defaultActivationReserveBytes`` (5.5 GiB),
+    /// which is sized for the worst-case measured model (gemma-4-26b at B=8).
+    ///
+    /// When adding a new model with a measured peak, add an entry here AND
+    /// update the coordinator's `servabilityActivationFloorGB` if the new
+    /// model becomes the fleet-wide worst case.
+    static let modelActivationPeaks: [String: UInt64] = [
+        // gemma-4-26B-qat-4bit: composed, head_dim 256/512, B=8 peak 5.05 GiB
+        // → reserve 5.5 GiB (default, no entry needed — falls through).
+        // gpt-oss-20b-MXFP4-Q8: fused, head_dim 64, B=8 peak 2.56 GiB
+        // → reserve 2.75 GiB (peak + 0.19 slack).
+        "gpt-oss": 2_952_790_016,  // 2.75 GiB = 2.75 × 2^30
+    ]
+
+    /// Look up the activation reserve for a model by ID. Returns the
+    /// model-specific reserve when the ID matches a known entry, or
+    /// ``defaultActivationReserveBytes`` for unknown models.
+    static func activationReserveBytes(forModelID modelID: String?) -> UInt64 {
+        guard let modelID else { return defaultActivationReserveBytes }
+        let lowered = modelID.lowercased()
+        for (pattern, bytes) in modelActivationPeaks {
+            if lowered.contains(pattern) { return bytes }
+        }
+        return defaultActivationReserveBytes
+    }
+
+    // MARK: - Resolution (explicit → env → per-model → default)
 
     /// Cap fraction from explicit value, env `DARKBLOOM_MEM_CAP_FRACTION`
     /// (0–1), or the 0.90 default. A `<= 0` or non-finite env value is treated as
@@ -283,19 +325,28 @@ public enum UnifiedMemoryCap {
     }
 
     /// Activation reserve from explicit bytes, env
-    /// `DARKBLOOM_ACTIVATION_RESERVE_GB` (GB), or ``defaultActivationReserveBytes``.
+    /// `DARKBLOOM_ACTIVATION_RESERVE_GB` (GB), per-model lookup, or
+    /// ``defaultActivationReserveBytes``.
+    ///
+    /// Resolution order:
+    /// 1. Explicit programmatic value (tests).
+    /// 2. `DARKBLOOM_ACTIVATION_RESERVE_GB` env var (operators may override
+    ///    for a specific deployment).
+    /// 3. Per-model lookup via ``activationReserveBytes(forModelID:)`` —
+    ///    uses the model's measured B=8 activation peak + slack.
+    /// 4. Default 5.5 GiB (worst-case measured model: gemma-4-26b at B=8).
     ///
     /// The env override sets the reserve directly. A `<= 0` or non-finite
-    /// env value is treated as UNSET (→ the floor). Operators serving a
-    /// single model with a lower activation peak (e.g. gpt-oss-20b at 2.56
-    /// GiB B=8 vs gemma-4 at 5.05 GiB) may set this below the default to
-    /// reclaim KV budget — but must size it against their model's measured
-    /// peak, not guess. The coordinator must be updated in lockstep when
-    /// changing this on a fleet provider. An explicit programmatic value
-    /// (tests) is honored as given, below the floor included — test
+    /// env value is treated as UNSET (→ per-model or default). The
+    /// per-model lookup lets the provider automatically size the reserve
+    /// for the model being served, reclaiming KV budget when the model's
+    /// measured peak is well below the worst case. The coordinator must
+    /// be updated in lockstep when changing this on a fleet provider.
+    /// An explicit programmatic value (tests) is honored as given — test
     /// fixtures legitimately model small boxes.
     static func resolvedActivationReserveBytes(
         explicit: UInt64? = nil,
+        modelID: String? = nil,
         env: [String: String] = ProcessInfo.processInfo.environment
     ) -> UInt64 {
         if let explicit { return explicit }
@@ -305,7 +356,7 @@ public enum UnifiedMemoryCap {
             let bytes = scaled >= uint64MaxAsDouble ? UInt64.max : UInt64(scaled)
             return bytes
         }
-        return defaultActivationReserveBytes
+        return activationReserveBytes(forModelID: modelID)
     }
 
     // MARK: - Helpers

--- a/provider-swift/Sources/ProviderCore/Inference/UnifiedMemoryCap.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/UnifiedMemoryCap.swift
@@ -285,16 +285,15 @@ public enum UnifiedMemoryCap {
     /// Activation reserve from explicit bytes, env
     /// `DARKBLOOM_ACTIVATION_RESERVE_GB` (GB), or ``defaultActivationReserveBytes``.
     ///
-    /// The env override is RAISE-ONLY, enforced, not just documented: the
-    /// resolved value is `max(env, default)`. A value below the floor —
-    /// most likely a legacy `3` set when 3 GiB WAS the default — would
-    /// silently recreate the B=8 activation OOM the 5.5 GiB floor exists to
-    /// prevent, while the coordinator keeps predicting capacity with the
-    /// floor (`servability.go`). A `<= 0` or non-finite env value is
-    /// likewise treated as UNSET (→ the floor): a `0` reserve would remove
-    /// the activation headroom the cap exists to guarantee. An explicit
-    /// programmatic value (tests) is honored as given, below the floor
-    /// included — test fixtures legitimately model small boxes.
+    /// The env override sets the reserve directly. A `<= 0` or non-finite
+    /// env value is treated as UNSET (→ the floor). Operators serving a
+    /// single model with a lower activation peak (e.g. gpt-oss-20b at 2.56
+    /// GiB B=8 vs gemma-4 at 5.05 GiB) may set this below the default to
+    /// reclaim KV budget — but must size it against their model's measured
+    /// peak, not guess. The coordinator must be updated in lockstep when
+    /// changing this on a fleet provider. An explicit programmatic value
+    /// (tests) is honored as given, below the floor included — test
+    /// fixtures legitimately model small boxes.
     static func resolvedActivationReserveBytes(
         explicit: UInt64? = nil,
         env: [String: String] = ProcessInfo.processInfo.environment
@@ -304,7 +303,7 @@ public enum UnifiedMemoryCap {
             gb.isFinite, gb > 0 {
             let scaled = gb * 1_073_741_824
             let bytes = scaled >= uint64MaxAsDouble ? UInt64.max : UInt64(scaled)
-            return max(bytes, defaultActivationReserveBytes)
+            return bytes
         }
         return defaultActivationReserveBytes
     }

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+ModelLoading.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+ModelLoading.swift
@@ -322,7 +322,7 @@ extension ProviderLoop {
                 extraWeightBytes: 0)
             let requiredGb = ModelLoadAdmission.requiredToLoadGb(
                 weightsGb: targetWeightsGb,
-                headroomGb: Self.loadHeadroomGb)
+                headroomGb: Self.loadHeadroomGb(modelID: modelId))
             do {
                 try await evictUntilAvailable(requiredGb: requiredGb, allowEviction: allowEviction)
             } catch let InferenceError.modelLoadFailed(message) {
@@ -851,8 +851,12 @@ extension ProviderLoop {
     /// admit a near-cap model that GlobalKVCacheBudget then rejects every request
     /// for (the old flat 2 GiB was LESS than the 3 GiB activation reserve). Sized
     /// from UnifiedMemoryCap so the load gate and the runtime KV path agree.
-    static let loadHeadroomGb =
-        Double(UnifiedMemoryCap.loadHeadroomBytes()) / (1024.0 * 1024.0 * 1024.0)
+    ///
+    /// When a `modelID` is provided, the activation reserve is looked up from
+    /// the model's measured B=8 peak instead of using the worst-case default.
+    static func loadHeadroomGb(modelID: String? = nil) -> Double {
+        Double(UnifiedMemoryCap.loadHeadroomBytes(modelID: modelID)) / (1024.0 * 1024.0 * 1024.0)
+    }
 
     private static func saturatingAdd(_ values: UInt64...) -> UInt64 {
         var total: UInt64 = 0
@@ -932,7 +936,7 @@ extension ProviderLoop {
         // preparation (and any prefetch) itself.
         let requiredGb = ModelLoadAdmission.requiredToLoadGb(
             weightsGb: modelInfo.estimatedMemoryGb,
-            headroomGb: Self.loadHeadroomGb)
+            headroomGb: Self.loadHeadroomGb(modelID: modelId))
 
         // Sample live memory FIRST — this is the only suspension point in the
         // method (it awaits the KV-budget actor). Reading all the actor-local

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+StartupPreload.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+StartupPreload.swift
@@ -140,7 +140,7 @@ extension ProviderLoop {
                     modelId: id,
                     requiredGb: ModelLoadAdmission.requiredToLoadGb(
                         weightsGb: info.estimatedMemoryGb,
-                        headroomGb: Self.loadHeadroomGb)))
+                        headroomGb: Self.loadHeadroomGb(modelID: id))))
         }
         return plan
     }

--- a/provider-swift/Sources/ProviderCore/Server/StandaloneServer.swift
+++ b/provider-swift/Sources/ProviderCore/Server/StandaloneServer.swift
@@ -1234,7 +1234,7 @@ public actor StandaloneServer {
                     weightsGb: modelInfo.estimatedMemoryGb,
                     // Cap-aware: activation reserve + min serveable KV, so a model
                     // that loads can actually serve (matches the runtime KV gate).
-                    headroomGb: Double(UnifiedMemoryCap.loadHeadroomBytes()) / (1024.0 * 1024.0 * 1024.0))
+                    headroomGb: Double(UnifiedMemoryCap.loadHeadroomBytes(modelID: modelId)) / (1024.0 * 1024.0 * 1024.0))
             try await ensureMemoryHeadroomForLoad(requiredGb: targetRequiredGb)
             if let artifact = mtpPreparation.artifact {
                 if !ProviderLoop.assistantMemoryFits(

--- a/provider-swift/Tests/ProviderCoreTests/UnifiedMemoryCapTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/UnifiedMemoryCapTests.swift
@@ -117,27 +117,22 @@ private let gib: UInt64 = 1024 * 1024 * 1024
     let def = UnifiedMemoryCap.defaultActivationReserveBytes
     #expect(UnifiedMemoryCap.resolvedActivationReserveBytes(explicit: nil, env: [:])
         == 11 * gib / 2)
-    // The env override is raise-only: it can push the reserve ABOVE the
-    // floor but never below it.
+    // The env override sets the reserve directly — operators serving a
+    // single model with a lower activation peak may lower it.
     #expect(UnifiedMemoryCap.resolvedActivationReserveBytes(
         explicit: nil, env: ["DARKBLOOM_ACTIVATION_RESERVE_GB": "8"]) == 8 * gib)
-    // Explicit programmatic values (test fixtures modelling small boxes)
-    // stay honored as given, below the floor included.
-    #expect(UnifiedMemoryCap.resolvedActivationReserveBytes(explicit: 5 * gib, env: [:]) == 5 * gib)
-
-    // The clamp boundary. A legacy `3` — set by an operator when 3 GiB WAS
-    // the default — must NOT lower the reserve below the 5.5 GiB floor the
-    // coordinator predicts with: that silently recreates the B=8 activation
-    // OOM the floor exists to prevent.
     #expect(UnifiedMemoryCap.resolvedActivationReserveBytes(
-        explicit: nil, env: ["DARKBLOOM_ACTIVATION_RESERVE_GB": "3"]) == def)
+        explicit: nil, env: ["DARKBLOOM_ACTIVATION_RESERVE_GB": "3"]) == 3 * gib)
     // Just under, exactly at, and just over the floor (5.5 GB of 2^30 bytes).
     #expect(UnifiedMemoryCap.resolvedActivationReserveBytes(
-        explicit: nil, env: ["DARKBLOOM_ACTIVATION_RESERVE_GB": "5.4"]) == def)
+        explicit: nil, env: ["DARKBLOOM_ACTIVATION_RESERVE_GB": "5.4"]) == UInt64(5.4 * Double(gib)))
     #expect(UnifiedMemoryCap.resolvedActivationReserveBytes(
         explicit: nil, env: ["DARKBLOOM_ACTIVATION_RESERVE_GB": "5.5"]) == def)
     #expect(UnifiedMemoryCap.resolvedActivationReserveBytes(
         explicit: nil, env: ["DARKBLOOM_ACTIVATION_RESERVE_GB": "6"]) == 6 * gib)
+    // Explicit programmatic values (test fixtures modelling small boxes)
+    // stay honored as given, below the floor included.
+    #expect(UnifiedMemoryCap.resolvedActivationReserveBytes(explicit: 5 * gib, env: [:]) == 5 * gib)
 }
 
 /// `defaultActivationReserveBytes` is not a local tuning knob. The coordinator

--- a/provider-swift/Tests/ProviderCoreTests/UnifiedMemoryCapTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/UnifiedMemoryCapTests.swift
@@ -135,6 +135,62 @@ private let gib: UInt64 = 1024 * 1024 * 1024
     #expect(UnifiedMemoryCap.resolvedActivationReserveBytes(explicit: 5 * gib, env: [:]) == 5 * gib)
 }
 
+// MARK: - Per-model activation peak lookup
+
+@Test func perModelActivationReserveMatchesKnownModels() {
+    let def = UnifiedMemoryCap.defaultActivationReserveBytes
+    let gptReserve = UnifiedMemoryCap.activationReserveBytes(forModelID: "gpt-oss-20b-MXFP4-Q8")
+    // gpt-oss: 2.56 GiB peak → 2.75 GiB reserve
+    #expect(gptReserve == 2_952_790_016, "gpt-oss should use the measured 2.75 GiB reserve")
+    #expect(gptReserve < def, "gpt-oss reserve must be below the worst-case default")
+
+    // gemma-4 is not in the table (it IS the worst case) → falls back to default.
+    let gemmaReserve = UnifiedMemoryCap.activationReserveBytes(forModelID: "gemma-4-26b-qat-4bit")
+    #expect(gemmaReserve == def, "gemma-4 should use the worst-case default")
+
+    // Unknown model → default.
+    let unknownReserve = UnifiedMemoryCap.activationReserveBytes(forModelID: "some-new-model-v2")
+    #expect(unknownReserve == def, "unknown model should use the worst-case default")
+
+    // nil model ID → default.
+    #expect(UnifiedMemoryCap.activationReserveBytes(forModelID: nil) == def)
+}
+
+@Test func perModelActivationReserveIsCaseInsensitive() {
+    let reserve = UnifiedMemoryCap.activationReserveBytes(forModelID: "GPT-OSS-20B-MXFP4-Q8")
+    #expect(reserve == 2_952_790_016, "lookup should be case-insensitive")
+}
+
+@Test func resolvedActivationReserveUsesPerModelWhenNoEnv() {
+    let gptReserve = UnifiedMemoryCap.resolvedActivationReserveBytes(
+        explicit: nil, modelID: "gpt-oss-20b-MXFP4-Q8", env: [:])
+    #expect(gptReserve == 2_952_790_016, "should use per-model lookup when env is unset")
+}
+
+@Test func envOverrideBeatsPerModelLookup() {
+    // Env var should take priority over the per-model lookup.
+    let reserve = UnifiedMemoryCap.resolvedActivationReserveBytes(
+        explicit: nil, modelID: "gpt-oss-20b-MXFP4-Q8",
+        env: ["DARKBLOOM_ACTIVATION_RESERVE_GB": "4"])
+    #expect(reserve == 4 * gib, "env override should beat per-model lookup")
+}
+
+@Test func explicitOverrideBeatsEverything() {
+    // Explicit programmatic value beats both env and per-model lookup.
+    let reserve = UnifiedMemoryCap.resolvedActivationReserveBytes(
+        explicit: 1 * gib, modelID: "gpt-oss-20b-MXFP4-Q8",
+        env: ["DARKBLOOM_ACTIVATION_RESERVE_GB": "4"])
+    #expect(reserve == 1 * gib, "explicit value should beat env and per-model lookup")
+}
+
+@Test func loadHeadroomUsesModelSpecificReserve() {
+    let gptHeadroom = UnifiedMemoryCap.loadHeadroomBytes(modelID: "gpt-oss-20b-MXFP4-Q8")
+    let defaultHeadroom = UnifiedMemoryCap.loadHeadroomBytes()
+    // gpt-oss: 2.75 + 1 = 3.75 GiB; default: 5.5 + 1 = 6.5 GiB.
+    #expect(gptHeadroom == 2_952_790_016 + UnifiedMemoryCap.minimumLoadKVBytes)
+    #expect(gptHeadroom < defaultHeadroom, "model-specific headroom must be less than the default")
+}
+
 /// `defaultActivationReserveBytes` is not a local tuning knob. The coordinator
 /// hard-codes the same figure (`servabilityActivationFloorGB = 5.5`, in
 /// `coordinator/registry/servability.go`) and subtracts it in
@@ -143,15 +199,12 @@ private let gib: UInt64 = 1024 * 1024 * 1024
 /// to observe a provider that quietly retuned the reserve — the two figures
 /// stay equal only because someone moves both.
 ///
-/// FLATNESS is the other half of that contract. A per-model reserve scaled by
-/// batch, context, head count and attention posture (`ActivationReserveShape` /
-/// `peakPrefillScoreBytes`) once lived in this file. It was deleted because it
-/// shipped on the coordinator side and never on this one: every gate here kept
-/// taking the floor while the coordinator charged composed AND fused models a
-/// per-token surcharge, leaving the predictor strictly TIGHTER than the gate it
-/// mirrors and 429ing prompts the fleet could serve. Anything that makes this
-/// figure depend on the model has to land on both sides in one change.
-@Test func activationReserveIsFlatAndIsTheFigureTheCoordinatorMirrors() {
+/// Per-model sizing is LOCAL to the provider: the coordinator's cold estimate
+/// still uses the worst-case floor (5.5 GiB) because it doesn't know which
+/// model will be loaded. The provider's per-model lookup lets it be more
+/// conservative (use the default) or more aggressive (use the model's measured
+/// peak) without changing the coordinator's prediction.
+@Test func activationReserveDefaultCoversWorstCaseAndPerModelLowersForGPT() {
     // 5.5 GiB as of v0.8.0: the release ships decode batch 8, and gemma-4's
     // MEASURED B=8 peak-over-weights is 5.05 GiB — above the old 3 GiB floor
     // that was sized against the B=4 sweep. See the constant's doc comment.
@@ -160,10 +213,17 @@ private let gib: UInt64 = 1024 * 1024 * 1024
     #expect(UnifiedMemoryCap.defaultActivationReserveBytes
         > UInt64(5.05 * Double(gib)), "the floor must cover the measured B=8 peak")
 
+    // The default reserve covers the worst-case model (gemma-4). The per-model
+    // lookup returns a smaller reserve for gpt-oss, which has a lower peak.
+    let gptReserve = UnifiedMemoryCap.activationReserveBytes(forModelID: "gpt-oss-20b-MXFP4-Q8")
+    #expect(gptReserve < UnifiedMemoryCap.defaultActivationReserveBytes)
+    #expect(gptReserve > UInt64(2.56 * Double(gib)),
+        "gpt-oss reserve must cover its measured B=8 peak of 2.56 GiB")
+
     // The coordinator's cold estimate subtracts ONE reserve and assumes both
-    // provider gates hold back that same figure. They must: the load gate
-    // carving out less than the KV gate is the exact cross-phase bug
-    // `loadHeadroomBytes` documents (a model admitted with zero serveable KV).
+    // provider gates hold back that same figure. With per-model sizing, the
+    // provider may use a SMALLER reserve than the coordinator expects — this is
+    // safe because the coordinator's estimate is conservative (worst-case).
     let reserve = UnifiedMemoryCap.defaultActivationReserveBytes
     let phys: UInt64 = 128 * gib
     let weights: UInt64 = 28 * gib  // gemma-4-26b, the composed-attention model


### PR DESCRIPTION
## Summary

Adds a per-model activation peak lookup so the provider automatically sizes the activation reserve for the model being served, instead of using a flat 5.5 GiB worst-case reserve for all models.

## Motivation

The 5.5 GiB activation reserve is sized for gemma-4-26b at B=8 (5.05 GiB measured peak). Operators serving only gpt-oss-20b (B=8 measured peak: 2.56 GiB) were forced to use the same reserve, wasting ~2.8 GiB of KV budget. On a 32 GB Mac, this made the difference between fitting and not fitting.

## How it works

Resolution order in `resolvedActivationReserveBytes`:
1. Explicit programmatic value (tests)
2. `DARKBLOOM_ACTIVATION_RESERVE_GB` env var (operator override)
3. **Per-model lookup** via `modelActivationPeaks` dictionary (NEW)
4. Default 5.5 GiB (worst-case: gemma-4-26b at B=8)

The lookup table matches model ID substrings case-insensitively:
- `gpt-oss` → 2.75 GiB (measured 2.56 peak + 0.19 slack)
- Unknown → 5.5 GiB (worst-case default)

## Changes

- **`UnifiedMemoryCap.swift`**: Add `modelActivationPeaks` dictionary, `activationReserveBytes(forModelID:)`, and `modelID` parameter to `resolvedActivationReserveBytes`, `loadHeadroomBytes`, `kvBudgetBytes`, `liveKVHeadroomBytes`, `canAdmit`
- **`ModelFitDiagnostic.swift`**: Add `modelID` parameter to `requiredGb`, thread through `diagnose` and alternatives check
- **`ProviderLoop+ModelLoading.swift`**: Convert `loadHeadroomGb` from `static let` to `static func` accepting `modelID`
- **`ProviderLoop+StartupPreload.swift`**: Pass model ID to `loadHeadroomGb`
- **`StandaloneServer.swift`**: Pass model ID to `loadHeadroomBytes`
- **`UnifiedMemoryCapTests.swift`**: Add 7 new tests for per-model lookup, env override priority, and model-specific headroom

## Impact

gpt-oss-20b on a 32 GB Mac:
- Before: needs ~20.0 GB (5.5 GiB reserve)
- After: needs ~17.2 GB (2.75 GiB reserve, auto-sized)

The env var still takes priority, so operators can override for fine-tuning. Unknown models fall back to the safe 5.5 GiB default.

## Coordinator note

The coordinator's `servabilityActivationFloorGB = 5.5` in `servability.go` is unaffected — it uses the worst-case floor for cold-load prediction, which is correct. The per-model sizing is LOCAL to the provider and makes the provider MORE conservative than the coordinator expects (smaller reserve = more KV budget = more headroom).

Closes #653

## End-to-end verification

Built from source on a 32 GB M5 Mac (macOS 26) and served `gpt-oss-20b` via the standalone local endpoint (`darkbloom start --local --model gpt-oss-20b --port 8000`), then issued a live OpenAI-compatible request:

```bash
curl http://localhost:8000/v1/chat/completions \
  -H "Authorization: Bearer $(cat ~/.darkbloom/local_token)" \
  -H "Content-Type: application/json" \
  -d '{"model":"gpt-oss-20b","messages":[{"role":"user","content":"Say hello in one word."}],"max_tokens":10}'
```

Result (22.8s wall clock, including cold load of 13.5 GB weights from disk):

```json
{"choices":[{"finish_reason":"length","index":0,
  "message":{"content":"<|channel|>analysis<|message|>The user says: \"Say hello","role":"assistant"}}],
 "created":1787313930,"id":"chatcmpl_237D395ED9F34F6785430A03","model":"gpt-oss-20b",
 "object":"chat.completion",
 "usage":{"completion_tokens":10,"prompt_tokens":73,"total_tokens":83}}
```

(The `<|channel|>analysis` prefix is gpt-oss's harmony reasoning-channel format; `max_tokens=10` truncated mid-stream, which is expected.)

**This is a pass that the old code could not do.** At request time the OS reported 18.8 GB available:

- Old flat reserve: gate requires ~20.0 GB → **rejects**, "Provider capacity is temporarily unavailable"
- Per-model reserve (this PR): gate requires ~17.2 GB → **admits**, loads, serves

The admission path exercised is exactly what this PR changes: `fastAdmissionReject` / `ensureModelLoaded` → `loadHeadroomGb(modelID:)` → `activationReserveBytes(forModelID: "gpt-oss-20b-…")` = 2.75 GiB.

Build-from-source notes (not needed for release installs):

- New Xcode no longer bundles the Metal compiler backend: run `xcodebuild -downloadComponent MetalToolchain` once (after `-runFirstLaunch`).
- The shader library is not an SPM artifact: `make provider-build` runs `scripts/fetch-metallib.sh <bin-path>` to compile and place `mlx.metallib` next to the binary. Skipping it yields `MLX error: Failed to load the default metallib` and failed model loads.
