### PR TITLE
chore(release): prepare provider v0.8.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,20 @@
 # Changelog
 
-## v0.8.7 (2026-08-20)
+## v0.8.8 (2026-08-21)
 
 ### Provider (Swift)
 
 #### Performance
 
-- **Small-batch quantized matvec (`qmv_wide`)** — Ports upstream MLX #3764 (`548dd80e`) into the Darkbloom MLX fork and regenerates MLX-Swift's embedded JIT Metal sources. On generation-15+ Apple GPUs, affine BF16 W4/W8 dense projections with `2 <= M < vector_limit` reuse each decoded weight group across the small activation-row tile; M=1 remains on QMV, matrix-sized inputs remain on QMM, and gathered expert projections are unchanged. Source-built metallib and release-artifact checks require representative W4/W8 ordinary and batched symbols. Local M4 Max directional medians preserved B=1 and improved Gemma B=4 aggregate decode 195.93→216.94 tok/s at 512 context (+10.72%) and 143.18→155.72 tok/s at 8K (+8.76%); B=2 was +4.49%/−1.00%. The attempted 32K comparison is intentionally unclaimed because both benchmark arms entered a persistent degraded host/device state.
+- **Default-on small-batch quantized matvec (`qmv_wide`)** — Ports upstream MLX #3764 (`548dd80e`) into the Darkbloom MLX fork and regenerates MLX-Swift's embedded JIT Metal sources. On generation-15+ Apple GPUs, affine BF16 W4/W8 dense projections with `2 <= M < vector_limit` reuse each decoded weight group across the small activation-row tile; M=1 remains on QMV, matrix-sized inputs remain on QMM, and gathered expert projections are unchanged. Source-built metallib and release-artifact checks require representative W4/W8 ordinary and batched symbols. Local M4 Max directional medians preserved B=1 and improved Gemma B=4 aggregate decode 195.93→216.94 tok/s at 512 context (+10.72%) and 143.18→155.72 tok/s at 8K (+8.76%); B=2 was +4.49%/−1.00%. The attempted 32K comparison is intentionally unclaimed because both benchmark arms entered a persistent degraded host/device state.
+
+#### Default posture
+
+- `qmv_wide` is an automatic Metal dispatcher route, not a beta flag: eligible generation-15+ affine `2 <= M < vector_limit` projections take it by default. Gemma layer-18 submission, coupled weighted-unsort/safe-R1, expert-tile trust, solo-prefill stripe, prompt narrowing, and packed-prefill defaults remain enabled for existing and new provider configurations.
+
+## v0.8.7 (2026-08-20)
+
+### Provider (Swift)
 
 #### Fixes
 

--- a/coordinator/api/server.go
+++ b/coordinator/api/server.go
@@ -151,7 +151,7 @@ func keyLimitResetFromContext(ctx context.Context) string {
 // the provider's EngineV2Factory.prepareProductionBackend for the argument).
 // Keep this fallback in sync with ProviderCore.version so dev/in-memory
 // coordinators advertise the same floor as the Swift binary they expect.
-var LatestProviderVersion = "0.8.7"
+var LatestProviderVersion = "0.8.8"
 
 // minProviderVersionForDesiredModels is the first provider version whose Swift
 // runtime understands the desired_models message. The coordinator must NOT send

--- a/provider-swift/Sources/ProviderCore/ProviderCore.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderCore.swift
@@ -228,5 +228,10 @@ public enum ProviderCore {
     // shipped from the v0.8.5 release branch but was absent from master and
     // therefore v0.8.6. Text-only system turns are folded into Qwen's required
     // leading system slot; structured/media system content remains fail-closed.
-    public static let version = "0.8.7"
+    // 0.8.8 enables the merged upstream qmv_wide route automatically for
+    // generation-15+ affine small-M projections. M=1 remains on ordinary QMV,
+    // matrix-sized inputs remain on QMM, and gathered expert projections are
+    // unchanged. Existing Gemma and CBv2 default-on optimization postures stay
+    // enabled; no beta flag or provider-config migration is required.
+    public static let version = "0.8.8"
 }


### PR DESCRIPTION
## Summary

Prepare the merged `qmv_wide` improvement for provider release v0.8.8:

- bump `ProviderCore.version` from `0.8.7` to `0.8.8`;
- bump coordinator `LatestProviderVersion` fallback in lockstep;
- move the already-merged `qmv_wide` changelog entry out of released v0.8.7 and into v0.8.8;
- document that the new route and the retained Gemma/CBv2 optimization stack are enabled by default;
- align packaged runtime-smoke and benchmark-report allowlists with default-on Qwen direct expert reduction, restoring the signed-child self-update gate on merged master.

This PR does not create or push the `v0.8.8` tag. After merge, the release operator can tag the exact reviewed merge commit; `release-swift.yml` will then enforce tag/source/binary/plist agreement before signing, notarizing, publishing, and registering the release.

## Before

```mermaid
flowchart LR
  subgraph Code[Code and release identity]
    A[master includes qmv_wide] --> B[ProviderCore.version = 0.8.7]
    B --> C[LatestProviderVersion = 0.8.7]
    C --> D[v0.8.8 tag integrity check would fail]
  end
  subgraph Behavior[Operator-visible outcome]
    E[qmv_wide code merged] --> F[No v0.8.8 source identity]
    F --> G[Cannot cut a source-consistent v0.8.8 bundle]
  end
```

## After

```mermaid
flowchart LR
  subgraph Code[Code and release identity]
    A[ProviderCore.version = 0.8.8] --> B[LatestProviderVersion = 0.8.8]
    B --> C[Built CLI reports 0.8.8]
    C --> D[v0.8.8 tag passes release integrity]
  end
  subgraph Behavior[Release and runtime outcome]
    E[Signed/notarized v0.8.8 bundle] --> F[Coordinator release registration]
    F --> G[Canary receives qmv_wide by default]
    G --> H[Eligible gen-15+ small-M affine projections reuse decoded weights]
    I[Gemma and CBv2 retained defaults] --> G
  end
  D --> E
```

## Default runtime posture

No new provider setting or migration is required:

| Improvement | v0.8.8 posture |
|---|---|
| `qmv_wide` | Automatic for generation-15+ affine `2 <= M < vector_limit`; no beta flag |
| M=1 dense QMV | Unchanged |
| Matrix-sized QMM | Unchanged |
| Gathered expert projections | Unchanged |
| Gemma layer-18 submission | Default on |
| Coupled weighted-unsort / safe-R1 | Default on; serving posture uses `trust` unless the operator explicitly restores drain mode |
| Expert-tile trust | Default serving posture |
| Solo-prefill stripe, prompt narrowing, packed prefill | Existing defaults remain enabled |

The automatic QMV dispatcher lives in merged MLX `darkbloom-base` `0a725e30`; merged MLX-Swift `606d28cf` pins that exact nested source and its regenerated JIT Metal strings. Root master already pins both through #655.

## Performance evidence carried into the release note

Local M4 Max directional medians, exact Gemma QAT4 snapshot, contiguous KV, MTP off:

| Context | Batch | Control agg TPS | qmv_wide agg TPS | Delta |
|---:|---:|---:|---:|---:|
| 512 | 1 | 101.53 | 101.32 | -0.20% |
| 512 | 2 | 152.70 | 159.55 | +4.49% |
| 512 | 4 | 195.93 | 216.94 | **+10.72%** |
| 8K | 1 | 84.62 | 84.70 | +0.10% |
| 8K | 2 | 127.69 | 126.41 | -1.00% |
| 8K | 4 | 143.18 | 155.72 | **+8.76%** |

The changelog deliberately does not claim a 32K result: those attempts entered a persistent degraded host/device state across both arms, including the unchanged B=1 sentinel.

## Verification

- `./scripts/check-release-version.sh v0.8.8 0.8.8`
  - `release version integrity: 0.8.8`
- `go test ./api -run 'TestLatestProviderVersion'`
  - passed
- `swift test --filter GemmaOptimizationConfigTests`
  - 18 tests in 2 suites passed
  - verifies missing and partial config sections default the selected stack on, serving defaults to trust, and explicit rollback values remain honored
- packaged runtime command:
  - `gemma-optimizations-runtime-smoke: ok`
  - `paged-kernel-runtime-smoke: ok`
- `make provider-test`
  - 2,109 tests in 215 suites passed
  - includes signed extracted-child runtime verification and exact default-posture JSON round-trip
- built debug CLI: `darkbloom --version` → `0.8.8`
- pre-push checks passed

## Post-merge release sequence

1. Wait for merged-master CI and Release Integrity to pass.
2. Tag the exact reviewed merge commit as `v0.8.8`.
3. Let `release-swift.yml` build, sign, notarize, staple, hash, publish, and register the release.
4. Verify `GET /v1/releases/latest` returns the registered v0.8.8 row; a missing row is fixed by registration, not another source bump.
5. Canary the signed artifact before broad rollout, with B=1 neutrality and sustained long-context behavior as explicit gates.

No production coordinator deployment or traffic change is part of this PR.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/656"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789935400&installation_model_id=21733&pr_number=656&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F656&signature=04033e66f901915ccaa545244714184652bc3512630c06c4781d06bd61388997"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->