### PR TITLE
fix(release): align packaged smoke with default Qwen reduction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,20 @@
 # Changelog
 
-## v0.8.7 (2026-08-20)
+## v0.8.8 (2026-08-21)
 
 ### Provider (Swift)
 
 #### Performance
 
-- **Small-batch quantized matvec (`qmv_wide`)** — Ports upstream MLX #3764 (`548dd80e`) into the Darkbloom MLX fork and regenerates MLX-Swift's embedded JIT Metal sources. On generation-15+ Apple GPUs, affine BF16 W4/W8 dense projections with `2 <= M < vector_limit` reuse each decoded weight group across the small activation-row tile; M=1 remains on QMV, matrix-sized inputs remain on QMM, and gathered expert projections are unchanged. Source-built metallib and release-artifact checks require representative W4/W8 ordinary and batched symbols. Local M4 Max directional medians preserved B=1 and improved Gemma B=4 aggregate decode 195.93→216.94 tok/s at 512 context (+10.72%) and 143.18→155.72 tok/s at 8K (+8.76%); B=2 was +4.49%/−1.00%. The attempted 32K comparison is intentionally unclaimed because both benchmark arms entered a persistent degraded host/device state.
+- **Default-on small-batch quantized matvec (`qmv_wide`)** — Ports upstream MLX #3764 (`548dd80e`) into the Darkbloom MLX fork and regenerates MLX-Swift's embedded JIT Metal sources. On generation-15+ Apple GPUs, affine BF16 W4/W8 dense projections with `2 <= M < vector_limit` reuse each decoded weight group across the small activation-row tile; M=1 remains on QMV, matrix-sized inputs remain on QMM, and gathered expert projections are unchanged. Source-built metallib and release-artifact checks require representative W4/W8 ordinary and batched symbols. Local M4 Max directional medians preserved B=1 and improved Gemma B=4 aggregate decode 195.93→216.94 tok/s at 512 context (+10.72%) and 143.18→155.72 tok/s at 8K (+8.76%); B=2 was +4.49%/−1.00%. The attempted 32K comparison is intentionally unclaimed because both benchmark arms entered a persistent degraded host/device state.
+
+#### Default posture
+
+- `qmv_wide` is an automatic Metal dispatcher route, not a beta flag: eligible generation-15+ affine `2 <= M < vector_limit` projections take it by default. Gemma layer-18 submission, coupled weighted-unsort/safe-R1, expert-tile trust, solo-prefill stripe, prompt narrowing, and packed-prefill defaults remain enabled for existing and new provider configurations.
+
+## v0.8.7 (2026-08-20)
+
+### Provider (Swift)
 
 #### Fixes
 

--- a/coordinator/api/server.go
+++ b/coordinator/api/server.go
@@ -151,7 +151,7 @@ func keyLimitResetFromContext(ctx context.Context) string {
 // the provider's EngineV2Factory.prepareProductionBackend for the argument).
 // Keep this fallback in sync with ProviderCore.version so dev/in-memory
 // coordinators advertise the same floor as the Swift binary they expect.
-var LatestProviderVersion = "0.8.7"
+var LatestProviderVersion = "0.8.8"
 
 // minProviderVersionForDesiredModels is the first provider version whose Swift
 // runtime understands the desired_models message. The coordinator must NOT send

--- a/provider-swift/Sources/ProviderCore/Inference/PackagedRuntimeSmoke.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/PackagedRuntimeSmoke.swift
@@ -104,6 +104,7 @@ public enum PackagedRuntimeSmoke {
             GemmaOptimizationEnvironment.prefillLayer18Key: "18",
             GemmaOptimizationEnvironment.weightedUnsortKey: "1",
             GemmaOptimizationEnvironment.safeR1Key: "1",
+            GemmaOptimizationEnvironment.qwenDirectExpertReductionKey: "1",
         ]
         guard projection == expected else {
             throw VerificationError.unexpectedProjection(projection)

--- a/provider-swift/Sources/ProviderCore/ProviderCore.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderCore.swift
@@ -228,5 +228,10 @@ public enum ProviderCore {
     // shipped from the v0.8.5 release branch but was absent from master and
     // therefore v0.8.6. Text-only system turns are folded into Qwen's required
     // leading system slot; structured/media system content remains fail-closed.
-    public static let version = "0.8.7"
+    // 0.8.8 enables the merged upstream qmv_wide route automatically for
+    // generation-15+ affine small-M projections. M=1 remains on ordinary QMV,
+    // matrix-sized inputs remain on QMM, and gathered expert projections are
+    // unchanged. Existing Gemma and CBv2 default-on optimization postures stay
+    // enabled; no beta flag or provider-config migration is required.
+    public static let version = "0.8.8"
 }

--- a/provider-swift/Tests/ProviderCoreTests/GemmaOptimizationReportingTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/GemmaOptimizationReportingTests.swift
@@ -72,9 +72,10 @@ struct PackagedRetainedGemmaSmokeTests {
         GemmaOptimizationEnvironment.prefillLayer18Key: "18",
         GemmaOptimizationEnvironment.weightedUnsortKey: "1",
         GemmaOptimizationEnvironment.safeR1Key: "1",
+        GemmaOptimizationEnvironment.qwenDirectExpertReductionKey: "1",
     ]
 
-    @Test("synthetic retained config has an exact three-key projection")
+    @Test("synthetic retained config has an exact four-key projection")
     func exactProjectionAndNoRejectedKeys() throws {
         let config = try PackagedRuntimeSmoke.retainedConfiguration()
         // Mirror verifyGemmaOptimizations: the smoke validates the retained

--- a/provider-swift/Tests/ProviderCoreTests/SelfUpdaterTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/SelfUpdaterTests.swift
@@ -527,12 +527,16 @@ struct SelfUpdaterTests {
         let (validTar, validRelease, install) = try makeSignedRuntimeFixture(
             root: root.appendingPathComponent("valid", isDirectory: true),
             includeResource: true)
-        guard case .success(let staged) = updater.stageSignedBundleForTesting(
+        let validResult = updater.stageSignedBundleForTesting(
             from: validTar,
             release: validRelease,
             installDir: install)
-        else {
-            Issue.record("real signed/runtime marker verification failed")
+        guard case .success(let staged) = validResult else {
+            guard case .failure(let error) = validResult else {
+                Issue.record("real signed/runtime marker verification returned an unknown result")
+                return
+            }
+            Issue.record("real signed/runtime marker verification failed: \(error)")
             return
         }
         staged.discard()

--- a/provider-swift/Tests/ProviderCoreTests/ThroughputSweepTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ThroughputSweepTests.swift
@@ -237,6 +237,7 @@ struct ThroughputSweepReportTests {
             GemmaOptimizationEnvironment.prefillLayer18Key: "18",
             GemmaOptimizationEnvironment.weightedUnsortKey: "1",
             GemmaOptimizationEnvironment.safeR1Key: "trust",
+            GemmaOptimizationEnvironment.qwenDirectExpertReductionKey: "1",
         ])
         #expect(decoded.schemaVersion == ThroughputSweepReport.currentSchemaVersion)
     }


### PR DESCRIPTION
## Summary

Fix the v0.8.8 signed-artifact gate after default-on Qwen direct expert reduction added a fourth projected optimization key.

The merged runtime projection already emits `MLX_QWEN_DIRECT_EXPERT_REDUCTION=1` in retained validation. `PackagedRuntimeSmoke` and two exact report/smoke expectations still allowlisted only the prior three keys, causing the signed extracted-child self-update test and packaged `darkbloom runtime-smoke` command to fail closed.

This follow-up aligns the release gate with the actual default-on projection and improves the signed-child failure diagnostic to include the underlying `UpdateError`.

## Before

```mermaid
flowchart LR
  subgraph Code[Code]
    A[retained-validation projection] --> B[4 keys including Qwen direct reduction]
    B --> C[PackagedRuntimeSmoke expected 3 keys]
    C --> D[unexpectedProjection]
  end
  subgraph Behavior[Release outcome]
    D --> E[runtime-smoke exits 1]
    E --> F[signed artifact staging rejected]
    F --> G[Provider CI fails]
  end
```

## After

```mermaid
flowchart LR
  subgraph Code[Code]
    A[retained-validation projection] --> B[4 default-on keys]
    B --> C[PackagedRuntimeSmoke expected 4 keys]
    C --> D[Benchmark/report expectations match]
  end
  subgraph Behavior[Release outcome]
    D --> E[Gemma optimization marker emitted]
    E --> F[Paged kernel smoke passes]
    F --> G[Signed artifact staging succeeds]
  end
```

## Default posture retained

- Gemma layer-18 submission: on
- weighted unsort + safe R1: on
- Qwen direct expert reduction: on
- retained validation remains hermetic and ignores inherited operator overrides
- explicit serving rollback for Qwen direct reduction remains available through the existing environment control

## Verification

- `darkbloom runtime-smoke`
  - `gemma-optimizations-runtime-smoke: ok`
  - `paged-kernel-runtime-smoke: ok`
- `make provider-test`
  - 2,109 tests in 215 suites passed
  - signed extracted-child runtime verification passed
  - throughput report JSON default-posture round-trip passed
- pre-push checks passed

This must merge before tagging v0.8.8. No production deployment or tag is included in this PR.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/657"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789936911&installation_model_id=21733&pr_number=657&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F657&signature=88140a095ed2f6d6485e9f0aaf9a6cfd877e475417f7d7b46561dc01885b45a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->