### PR TITLE
Support concrete sources for OpenRouter aliases

### DIFF
--- a/coordinator/api/concrete_model_entries.go
+++ b/coordinator/api/concrete_model_entries.go
@@ -58,6 +58,60 @@ func (s *Server) modelEntryForConcrete(
 	return entry
 }
 
+// modelEntryForCatalogConcrete builds exact-retrieval metadata for an active
+// concrete model even when no provider is connected. Live counts remain zero;
+// the durable registry supplies identity, limits, pricing, and capabilities.
+func (s *Server) modelEntryForCatalogConcrete(
+	modelID string,
+	catalogByID map[string]store.SupportedModel,
+	registryByID map[string]store.ModelRegistryEntry,
+) (types.ModelEntry, bool) {
+	catalogModel, ok := catalogByID[modelID]
+	if !ok {
+		return types.ModelEntry{}, false
+	}
+	registryEntry, hasRegistryEntry := registryByID[modelID]
+	entry := s.modelEntryForConcrete(
+		registry.AggregateModel{
+			ID:           modelID,
+			ModelType:    catalogModel.ModelType,
+			Quantization: registryEntry.Quantization,
+		},
+		nil,
+		catalogModel,
+		true,
+		registryEntry,
+		hasRegistryEntry,
+	)
+	return entry, true
+}
+
+func (s *Server) openRouterAggregateTypeByID() map[string]string {
+	typesByID := make(map[string]string)
+	for _, model := range s.registry.ListModels() {
+		if model.ModelType != "" {
+			typesByID[model.ID] = model.ModelType
+		}
+	}
+	return typesByID
+}
+
+func concreteModelEligibleForOpenRouterFeed(
+	modelID string,
+	catalogByID map[string]store.SupportedModel,
+	aggregateTypeByID map[string]string,
+) bool {
+	catalogModel, ok := catalogByID[modelID]
+	if !ok {
+		return false
+	}
+	modelType := catalogModel.ModelType
+	if aggregateType, found := aggregateTypeByID[modelID]; found {
+		modelType = aggregateType
+	}
+	return !isNonTextModelType(modelType)
+}
+
 // openRouterEntryForConcrete builds the dedicated provider-feed representation
 // of one active concrete catalog model. It remains independently listed when an
 // OpenRouter-only alias clones it.
@@ -68,14 +122,7 @@ func (s *Server) openRouterEntryForConcrete(
 	aggregateTypeByID map[string]string,
 ) (types.OpenRouterModel, bool) {
 	catalogModel, ok := catalogByID[modelID]
-	if !ok {
-		return types.OpenRouterModel{}, false
-	}
-	modelType := catalogModel.ModelType
-	if aggregateType, found := aggregateTypeByID[modelID]; found {
-		modelType = aggregateType
-	}
-	if isNonTextModelType(modelType) {
+	if !ok || !concreteModelEligibleForOpenRouterFeed(modelID, catalogByID, aggregateTypeByID) {
 		return types.OpenRouterModel{}, false
 	}
 

--- a/coordinator/api/concrete_model_entries.go
+++ b/coordinator/api/concrete_model_entries.go
@@ -1,0 +1,101 @@
+package api
+
+import (
+	"github.com/eigeninference/d-inference/coordinator/api/types"
+	"github.com/eigeninference/d-inference/coordinator/registry"
+	"github.com/eigeninference/d-inference/coordinator/store"
+)
+
+// modelEntryForConcrete builds the consumer catalog representation of one
+// provider-advertised concrete model. Callers decide whether the entry is hidden
+// behind a standard rollout alias; OpenRouter-only aliases never hide it.
+func (s *Server) modelEntryForConcrete(
+	model registry.AggregateModel,
+	capacity *registry.ModelCapacity,
+	catalogModel store.SupportedModel,
+	inCatalog bool,
+	registryEntry store.ModelRegistryEntry,
+	hasRegistryEntry bool,
+) types.ModelEntry {
+	metadata := types.ModelMetadata{
+		ModelType:         model.ModelType,
+		Quantization:      model.Quantization,
+		ProviderCount:     model.Providers,
+		AttestedProviders: model.AttestedProviders,
+		TrustLevel:        string(model.TrustLevel),
+	}
+	if capacity != nil {
+		metadata.RoutableProviders = capacity.RoutableProviders
+		metadata.WarmProviders = capacity.WarmProviders
+		metadata.CanAccept = capacity.CanAccept
+	}
+	if model.Attestation != nil {
+		metadata.Attestation = &types.ModelAttestation{
+			SecureEnclave: model.Attestation.SecureEnclave,
+			SIPEnabled:    model.Attestation.SIPEnabled,
+			SecureBoot:    model.Attestation.SecureBoot,
+		}
+	}
+	if inCatalog && catalogModel.DisplayName != "" {
+		metadata.DisplayName = catalogModel.DisplayName
+	}
+
+	entry := types.ModelEntry{
+		ID:            model.ID,
+		Object:        "model",
+		OwnedBy:       "eigeninference",
+		Name:          metadata.DisplayName,
+		HuggingFaceID: huggingFaceIDForModel(model.ID, registryEntry.Metadata),
+		Metadata:      metadata,
+	}
+	s.openRouterModelFieldsFor(model.ID, model.Quantization, registryEntry, hasRegistryEntry).applyToModelEntry(&entry)
+
+	var capabilities []string
+	if hasRegistryEntry {
+		capabilities = registryEntry.Capabilities
+	}
+	entry.InputModalities, entry.OutputModalities = deriveModalities(model.ModelType, capabilities)
+	return entry
+}
+
+// openRouterEntryForConcrete builds the dedicated provider-feed representation
+// of one active concrete catalog model. It remains independently listed when an
+// OpenRouter-only alias clones it.
+func (s *Server) openRouterEntryForConcrete(
+	modelID string,
+	catalogByID map[string]store.SupportedModel,
+	registryByID map[string]store.ModelRegistryEntry,
+	aggregateTypeByID map[string]string,
+) (types.OpenRouterModel, bool) {
+	catalogModel, ok := catalogByID[modelID]
+	if !ok {
+		return types.OpenRouterModel{}, false
+	}
+	modelType := catalogModel.ModelType
+	if aggregateType, found := aggregateTypeByID[modelID]; found {
+		modelType = aggregateType
+	}
+	if isNonTextModelType(modelType) {
+		return types.OpenRouterModel{}, false
+	}
+
+	registryEntry, hasRegistryEntry := registryByID[modelID]
+	entry := types.OpenRouterModel{
+		ID:                modelID,
+		HuggingFaceID:     huggingFaceIDForModel(modelID, registryEntry.Metadata),
+		Name:              openRouterModelName(catalogModel, registryEntry, hasRegistryEntry, modelID),
+		InputModalities:   []string{"text"},
+		OutputModalities:  []string{"text"},
+		SupportedFeatures: []string{},
+		IsReady:           true,
+	}
+	s.openRouterModelFieldsFor(modelID, registryEntry.Quantization, registryEntry, hasRegistryEntry).applyToFeed(&entry)
+	if hasRegistryEntry {
+		entry.IsReady = openRouterIsReady(registryEntry.Metadata)
+		entry.OpenRouter = &types.OpenRouterSlug{Slug: openRouterSlug(modelID, registryEntry.Metadata)}
+	} else {
+		entry.OpenRouter = &types.OpenRouterSlug{Slug: openRouterSlug(modelID, nil)}
+	}
+	entry.Datacenters = s.modelDatacenters(modelID)
+	return entry, true
+}

--- a/coordinator/api/model_alias_handlers.go
+++ b/coordinator/api/model_alias_handlers.go
@@ -131,12 +131,32 @@ func (s *Server) handleModelAliasUpsert(w http.ResponseWriter, r *http.Request) 
 	if req.Active != nil {
 		active = *req.Active
 	}
+	retiredBuilds := retiredBuildsAfterUpsert(prior, req.DesiredBuild, req.PreviousBuild)
+	if active {
+		aliases, err := s.store.ListModelAliases()
+		if err != nil {
+			writeJSON(w, http.StatusInternalServerError, errorResponse("internal_error", "failed to validate alias members"))
+			return
+		}
+		members := make(map[string]struct{}, 2+len(retiredBuilds))
+		members[req.DesiredBuild] = struct{}{}
+		if req.PreviousBuild != "" {
+			members[req.PreviousBuild] = struct{}{}
+		}
+		for _, retired := range retiredBuilds {
+			members[retired] = struct{}{}
+		}
+		if clone, conflict := concreteOpenRouterAliasUsingBuild(aliases, members); conflict {
+			writeJSON(w, http.StatusConflict, errorResponse("invalid_request_error", "concrete model "+clone.SourceModel+" is pinned by OpenRouter alias "+clone.AliasID+"; delete or retarget that alias first"))
+			return
+		}
+	}
 	alias := &store.ModelAlias{
 		AliasID:       req.AliasID,
 		DisplayName:   req.DisplayName,
 		DesiredBuild:  req.DesiredBuild,
 		PreviousBuild: req.PreviousBuild,
-		RetiredBuilds: retiredBuildsAfterUpsert(prior, req.DesiredBuild, req.PreviousBuild),
+		RetiredBuilds: retiredBuilds,
 
 		Active: active,
 	}

--- a/coordinator/api/model_alias_handlers.go
+++ b/coordinator/api/model_alias_handlers.go
@@ -71,6 +71,9 @@ func (s *Server) handleModelAliasUpsert(w http.ResponseWriter, r *http.Request) 
 		writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request_error", "desired_build is required", withParam("desired_build")))
 		return
 	}
+	s.modelAliasMutationMu.Lock()
+	defer s.modelAliasMutationMu.Unlock()
+
 	// Namespace + takeover rules. Normally an alias id must not collide with a
 	// concrete model id (resolution would be ambiguous), and an alias may never
 	// name itself as a member. `takeover` is the deliberate exception for the

--- a/coordinator/api/model_alias_handlers_test.go
+++ b/coordinator/api/model_alias_handlers_test.go
@@ -151,7 +151,7 @@ func TestAliasModelEntriesHidesBuilds(t *testing.T) {
 		"gemma-4-26b-retired": {ModelID: "gemma-4-26b-retired", RoutableProviders: 10, WarmProviders: 10, CanAccept: true},
 	}
 
-	entries, hidden := srv.aliasModelEntries(capByModel, catalogByID, registryByID)
+	entries, hidden := srv.aliasModelEntries(capByModel, catalogByID, registryByID, nil)
 	if len(entries) != 1 || entries[0].ID != "gemma-4-26b" {
 		t.Fatalf("expected one alias entry, got %+v", entries)
 	}
@@ -203,7 +203,7 @@ func TestAliasModelEntriesDesiredNotInCatalog(t *testing.T) {
 		t.Fatal(err)
 	}
 	catalogByID := map[string]store.SupportedModel{aliasFP8: {ID: aliasFP8, Active: true, ModelType: "text"}}
-	entries, hidden := srv.aliasModelEntries(map[string]*registry.ModelCapacity{}, catalogByID, registryByID)
+	entries, hidden := srv.aliasModelEntries(map[string]*registry.ModelCapacity{}, catalogByID, registryByID, nil)
 	if len(entries) != 1 || entries[0].ID != "gemma-4-26b" {
 		t.Fatalf("only the alias with an in-catalog build should list, got %+v", entries)
 	}
@@ -984,7 +984,7 @@ func TestListModelsHidesRetiredAliasBuild(t *testing.T) {
 		t.Fatal(err)
 	}
 	catalogByID := map[string]store.SupportedModel{aliasFP8: {ID: aliasFP8, Active: true, ModelType: "text"}, aliasQAT: {ID: aliasQAT, Active: true, ModelType: "text"}}
-	_, hidden := srv.aliasModelEntries(map[string]*registry.ModelCapacity{}, catalogByID, registryByID)
+	_, hidden := srv.aliasModelEntries(map[string]*registry.ModelCapacity{}, catalogByID, registryByID, nil)
 	if _, ok := hidden[aliasFP8]; !ok {
 		t.Fatalf("retired build should be in the hidden set: %v", hidden)
 	}
@@ -1185,6 +1185,109 @@ func TestOpenRouterAliasClonesSourceEntry(t *testing.T) {
 	srv.Handler().ServeHTTP(deleteRec, deleteReq)
 	if deleteRec.Code != http.StatusOK || reg.IsAlias(paidAlias) {
 		t.Fatalf("delete OpenRouter alias: status=%d still_registered=%v body=%s", deleteRec.Code, reg.IsAlias(paidAlias), deleteRec.Body.String())
+	}
+}
+
+// A concrete source remains independently listed while its OpenRouter-only
+// clone shares routing, pricing, capacity, and every non-identity feed field.
+func TestOpenRouterAliasClonesConcreteModel(t *testing.T) {
+	t.Setenv("MODEL_REGISTRY_PUBLISHING_KEY", "publish-secret")
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	st := store.NewMemory(store.Config{})
+	reg := registry.New(logger)
+	srv := NewServer(reg, st, ServerConfig{}, logger)
+
+	const (
+		sourceID = "gpt-oss-20b"
+		aliasID  = "openai-gpt-oss-20b"
+		slug     = "openai/gpt-oss-20b"
+		hfID     = "openai/gpt-oss-20b"
+	)
+	seedActiveModel(t, st, sourceID, "GPT-OSS 20B")
+	if err := st.SetModelPrice("platform", sourceID, 20_000, 100_000); err != nil {
+		t.Fatal(err)
+	}
+	srv.SyncModelCatalog()
+
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	conn := connectAndPrepareProvider(t, ctx, ts.URL, reg, sourceID, testPublicKeyB64(), 50.0)
+	defer conn.Close(websocket.StatusNormalClosure, "")
+
+	body, _ := json.Marshal(map[string]any{
+		"id": aliasID, "source_model": sourceID,
+		"openrouter_slug": slug, "hugging_face_id": hfID,
+	})
+	req := httptest.NewRequest(http.MethodPost, "/v1/admin/models/openrouter-aliases", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer publish-secret")
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("create concrete-source OpenRouter alias: status=%d body=%s", rec.Code, rec.Body.String())
+	}
+
+	if build, isAlias, ok := reg.ResolveModel(aliasID); !ok || !isAlias || build != sourceID {
+		t.Fatalf("resolve clone = %q isAlias=%v ok=%v, want concrete source %q", build, isAlias, ok, sourceID)
+	}
+	if got := reg.PublicNameForBuild(sourceID); got != sourceID {
+		t.Fatalf("OpenRouter alias became canonical name: got %q want %q", got, sourceID)
+	}
+
+	listRec := httptest.NewRecorder()
+	srv.handleListModels(listRec, httptest.NewRequest(http.MethodGet, "/v1/models", nil))
+	if listRec.Code != http.StatusOK {
+		t.Fatalf("list status = %d body=%s", listRec.Code, listRec.Body.String())
+	}
+	var listResp types.ModelListResponse
+	if err := json.Unmarshal(listRec.Body.Bytes(), &listResp); err != nil {
+		t.Fatal(err)
+	}
+	listByID := make(map[string]types.ModelEntry, len(listResp.Data))
+	for _, model := range listResp.Data {
+		listByID[model.ID] = model
+	}
+	sourceModel, sourceOK := listByID[sourceID]
+	aliasModel, aliasOK := listByID[aliasID]
+	if !sourceOK || !aliasOK {
+		t.Fatalf("source and clone must both remain in /v1/models: %+v", listResp.Data)
+	}
+	if aliasModel.Pricing == nil || aliasModel.Pricing.Prompt != "0.00000002" || aliasModel.Pricing.Completion != "0.0000001" {
+		t.Fatalf("clone pricing = %+v", aliasModel.Pricing)
+	}
+	aliasModel.ID = sourceModel.ID
+	aliasModel.HuggingFaceID = sourceModel.HuggingFaceID
+	if !reflect.DeepEqual(aliasModel, sourceModel) {
+		t.Fatalf("main catalog clone differs beyond identities: source=%+v clone=%+v", sourceModel, aliasModel)
+	}
+
+	openRouterRec := httptest.NewRecorder()
+	srv.handleListModelsOpenRouter(openRouterRec, httptest.NewRequest(http.MethodGet, "/v1/models/openrouter", nil))
+	if openRouterRec.Code != http.StatusOK {
+		t.Fatalf("OpenRouter feed status = %d body=%s", openRouterRec.Code, openRouterRec.Body.String())
+	}
+	var openRouterResp types.OpenRouterModelsResponse
+	if err := json.Unmarshal(openRouterRec.Body.Bytes(), &openRouterResp); err != nil {
+		t.Fatal(err)
+	}
+	openRouterByID := make(map[string]types.OpenRouterModel, len(openRouterResp.Data))
+	for _, model := range openRouterResp.Data {
+		openRouterByID[model.ID] = model
+	}
+	sourceFeed, sourceOK := openRouterByID[sourceID]
+	aliasFeed, aliasOK := openRouterByID[aliasID]
+	if !sourceOK || !aliasOK {
+		t.Fatalf("source and clone must both remain in OpenRouter feed: %+v", openRouterResp.Data)
+	}
+	if aliasFeed.HuggingFaceID != hfID || aliasFeed.OpenRouter == nil || aliasFeed.OpenRouter.Slug != slug {
+		t.Fatalf("clone identities: hugging_face_id=%q openrouter=%+v", aliasFeed.HuggingFaceID, aliasFeed.OpenRouter)
+	}
+	aliasFeed.ID = sourceFeed.ID
+	aliasFeed.HuggingFaceID = sourceFeed.HuggingFaceID
+	aliasFeed.OpenRouter = sourceFeed.OpenRouter
+	if !reflect.DeepEqual(aliasFeed, sourceFeed) {
+		t.Fatalf("OpenRouter clone differs beyond identities: source=%+v clone=%+v", sourceFeed, aliasFeed)
 	}
 }
 

--- a/coordinator/api/model_alias_handlers_test.go
+++ b/coordinator/api/model_alias_handlers_test.go
@@ -1351,6 +1351,57 @@ func TestOpenRouterAliasClonesConcreteModel(t *testing.T) {
 	}
 }
 
+func TestOpenRouterAliasConcreteRetrievalWithoutProviders(t *testing.T) {
+	t.Setenv("MODEL_REGISTRY_PUBLISHING_KEY", "publish-secret")
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	st := store.NewMemory(store.Config{})
+	srv := NewServer(registry.New(logger), st, ServerConfig{}, logger)
+
+	const (
+		sourceID = "gpt-oss-20b"
+		aliasID  = "openai-gpt-oss-20b"
+		hfID     = "openai/gpt-oss-20b"
+	)
+	seedActiveModel(t, st, sourceID, "GPT-OSS 20B")
+	if err := st.SetModelPrice("platform", sourceID, 20_000, 100_000); err != nil {
+		t.Fatal(err)
+	}
+	srv.SyncModelCatalog()
+
+	body, _ := json.Marshal(map[string]any{
+		"id": aliasID, "source_model": sourceID,
+		"openrouter_slug": "openai/gpt-oss-20b", "hugging_face_id": hfID,
+	})
+	createReq := httptest.NewRequest(http.MethodPost, "/v1/admin/models/openrouter-aliases", bytes.NewReader(body))
+	createReq.Header.Set("Authorization", "Bearer publish-secret")
+	createRec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(createRec, createReq)
+	if createRec.Code != http.StatusOK {
+		t.Fatalf("create concrete clone: status=%d body=%s", createRec.Code, createRec.Body.String())
+	}
+
+	retrieveReq := httptest.NewRequest(http.MethodGet, "/v1/models/"+aliasID, nil)
+	retrieveReq.SetPathValue("id", aliasID)
+	retrieveRec := httptest.NewRecorder()
+	srv.handleGetModel(retrieveRec, retrieveReq)
+	if retrieveRec.Code != http.StatusOK {
+		t.Fatalf("retrieve zero-provider concrete clone: status=%d body=%s", retrieveRec.Code, retrieveRec.Body.String())
+	}
+	var retrieved types.ModelEntry
+	if err := json.Unmarshal(retrieveRec.Body.Bytes(), &retrieved); err != nil {
+		t.Fatal(err)
+	}
+	if retrieved.ID != aliasID || retrieved.HuggingFaceID != hfID {
+		t.Fatalf("retrieved identities: %+v", retrieved)
+	}
+	if retrieved.Pricing == nil || retrieved.Pricing.Prompt != "0.00000002" || retrieved.Pricing.Completion != "0.0000001" {
+		t.Fatalf("retrieved pricing: %+v", retrieved.Pricing)
+	}
+	if retrieved.Metadata.ProviderCount != 0 || retrieved.Metadata.RoutableProviders != 0 {
+		t.Fatalf("zero-provider metadata: %+v", retrieved.Metadata)
+	}
+}
+
 func TestOpenRouterAliasRejectsCoveredConcreteModel(t *testing.T) {
 	t.Setenv("MODEL_REGISTRY_PUBLISHING_KEY", "publish-secret")
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))

--- a/coordinator/api/model_alias_handlers_test.go
+++ b/coordinator/api/model_alias_handlers_test.go
@@ -12,6 +12,7 @@ import (
 
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -40,6 +41,47 @@ func seedActiveModel(t *testing.T, st store.Store, modelID, displayName string) 
 	if err := st.PromoteModelVersion(modelID, "v1"); err != nil {
 		t.Fatal(err)
 	}
+}
+
+type aliasMutationRaceStore struct {
+	store.Store
+	mu      sync.Mutex
+	armed   bool
+	calls   int
+	release chan struct{}
+	once    sync.Once
+}
+
+func (s *aliasMutationRaceStore) arm() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.armed = true
+	s.calls = 0
+	s.release = make(chan struct{})
+	s.once = sync.Once{}
+}
+
+func (s *aliasMutationRaceStore) ListModelAliases() ([]store.ModelAlias, error) {
+	aliases, err := s.Store.ListModelAliases()
+	s.mu.Lock()
+	if !s.armed {
+		s.mu.Unlock()
+		return aliases, err
+	}
+	s.calls++
+	call := s.calls
+	if call == 2 {
+		s.once.Do(func() { close(s.release) })
+	}
+	release := s.release
+	s.mu.Unlock()
+	if call <= 2 {
+		select {
+		case <-release:
+		case <-time.After(100 * time.Millisecond):
+		}
+	}
+	return aliases, err
 }
 
 const (
@@ -1140,6 +1182,21 @@ func TestOpenRouterAliasClonesSourceEntry(t *testing.T) {
 		t.Fatalf("shared build leaked into /v1/models: %+v", listResp.Data)
 	}
 
+	retrieveReq := httptest.NewRequest(http.MethodGet, "/v1/models/"+paidAlias, nil)
+	retrieveReq.SetPathValue("id", paidAlias)
+	retrieveRec := httptest.NewRecorder()
+	srv.handleGetModel(retrieveRec, retrieveReq)
+	if retrieveRec.Code != http.StatusOK {
+		t.Fatalf("retrieve hidden OpenRouter alias: status=%d body=%s", retrieveRec.Code, retrieveRec.Body.String())
+	}
+	var retrieved types.ModelEntry
+	if err := json.Unmarshal(retrieveRec.Body.Bytes(), &retrieved); err != nil {
+		t.Fatal(err)
+	}
+	if retrieved.ID != paidAlias || retrieved.HuggingFaceID != paidHFID {
+		t.Fatalf("retrieved alias identities: %+v", retrieved)
+	}
+
 	// The dedicated feed clone differs from its source only in the three public
 	// identities configured by the dedicated endpoint.
 	orRec := httptest.NewRecorder()
@@ -1250,6 +1307,21 @@ func TestOpenRouterAliasClonesConcreteModel(t *testing.T) {
 		t.Fatalf("source pricing = %+v", sourceModel.Pricing)
 	}
 
+	retrieveReq := httptest.NewRequest(http.MethodGet, "/v1/models/"+aliasID, nil)
+	retrieveReq.SetPathValue("id", aliasID)
+	retrieveRec := httptest.NewRecorder()
+	srv.handleGetModel(retrieveRec, retrieveReq)
+	if retrieveRec.Code != http.StatusOK {
+		t.Fatalf("retrieve hidden concrete-source alias: status=%d body=%s", retrieveRec.Code, retrieveRec.Body.String())
+	}
+	var retrieved types.ModelEntry
+	if err := json.Unmarshal(retrieveRec.Body.Bytes(), &retrieved); err != nil {
+		t.Fatal(err)
+	}
+	if retrieved.ID != aliasID || retrieved.HuggingFaceID != hfID || !reflect.DeepEqual(retrieved.Pricing, sourceModel.Pricing) {
+		t.Fatalf("retrieved concrete-source alias: %+v", retrieved)
+	}
+
 	openRouterRec := httptest.NewRecorder()
 	srv.handleListModelsOpenRouter(openRouterRec, httptest.NewRequest(http.MethodGet, "/v1/models/openrouter", nil))
 	if openRouterRec.Code != http.StatusOK {
@@ -1307,6 +1379,47 @@ func TestOpenRouterAliasRejectsCoveredConcreteModel(t *testing.T) {
 	}
 	if _, found, err := st.GetModelAlias("openai-gpt-oss-20b"); err != nil || found {
 		t.Fatalf("rejected clone persisted: found=%v err=%v", found, err)
+	}
+}
+
+func TestOpenRouterAliasUsesConcreteModelShadowedByInactiveAlias(t *testing.T) {
+	t.Setenv("MODEL_REGISTRY_PUBLISHING_KEY", "publish-secret")
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	st := store.NewMemory(store.Config{})
+	reg := registry.New(logger)
+	srv := NewServer(reg, st, ServerConfig{}, logger)
+
+	const (
+		sourceID = "gpt-oss-20b"
+		cloneID  = "openai-gpt-oss-20b"
+	)
+	seedActiveModel(t, st, sourceID, "GPT-OSS 20B")
+	seedActiveModel(t, st, "gpt-oss-20b-v2", "GPT-OSS 20B v2")
+	if err := st.UpsertModelAlias(&store.ModelAlias{
+		AliasID: sourceID, DesiredBuild: "gpt-oss-20b-v2",
+		PreviousBuild: sourceID, Active: false,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	srv.SyncModelCatalog()
+
+	body, _ := json.Marshal(map[string]any{
+		"id": cloneID, "source_model": sourceID,
+		"openrouter_slug": "openai/gpt-oss-20b", "hugging_face_id": "openai/gpt-oss-20b",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/v1/admin/models/openrouter-aliases", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer publish-secret")
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("create clone from concrete model shadowed by inactive alias: status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	saved, found, err := st.GetModelAlias(cloneID)
+	if err != nil || !found || saved.SourceKind != store.ModelAliasSourceConcrete {
+		t.Fatalf("stored source kind: alias=%+v found=%v err=%v", saved, found, err)
+	}
+	if build, isAlias, ok := reg.ResolveModel(cloneID); !ok || !isAlias || build != sourceID {
+		t.Fatalf("concrete clone resolve: build=%q isAlias=%v ok=%v", build, isAlias, ok)
 	}
 }
 
@@ -1372,6 +1485,58 @@ func TestStandardAliasCoversEveryBuildState(t *testing.T) {
 				t.Fatalf("%s build was not covered: %+v", name, alias)
 			}
 		})
+	}
+}
+
+func TestAliasMutationEndpointsSerializeOwnershipChecks(t *testing.T) {
+	t.Setenv("MODEL_REGISTRY_PUBLISHING_KEY", "publish-secret")
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	memoryStore := store.NewMemory(store.Config{})
+	raceStore := &aliasMutationRaceStore{Store: memoryStore}
+	srv := NewServer(registry.New(logger), raceStore, ServerConfig{}, logger)
+
+	const sourceID = "gpt-oss-20b"
+	seedActiveModel(t, raceStore, sourceID, "GPT-OSS 20B")
+	srv.SyncModelCatalog()
+	raceStore.arm()
+
+	start := make(chan struct{})
+	statuses := make(chan int, 2)
+	post := func(path string, payload map[string]any) {
+		<-start
+		body, _ := json.Marshal(payload)
+		req := httptest.NewRequest(http.MethodPost, path, bytes.NewReader(body))
+		req.Header.Set("Authorization", "Bearer publish-secret")
+		rec := httptest.NewRecorder()
+		srv.Handler().ServeHTTP(rec, req)
+		statuses <- rec.Code
+	}
+	go post("/v1/admin/models/openrouter-aliases", map[string]any{
+		"id": "openai-gpt-oss-20b", "source_model": sourceID,
+		"openrouter_slug": "openai/gpt-oss-20b", "hugging_face_id": "openai/gpt-oss-20b",
+	})
+	go post("/v1/admin/models/aliases", map[string]any{
+		"alias_id": "gpt-oss-public", "desired_build": sourceID,
+	})
+	close(start)
+
+	successes, conflicts := 0, 0
+	for range 2 {
+		switch status := <-statuses; status {
+		case http.StatusOK:
+			successes++
+		case http.StatusConflict:
+			conflicts++
+		default:
+			t.Fatalf("unexpected concurrent mutation status: %d", status)
+		}
+	}
+	if successes != 1 || conflicts != 1 {
+		t.Fatalf("concurrent mutations: successes=%d conflicts=%d", successes, conflicts)
+	}
+	aliases, err := memoryStore.ListModelAliases()
+	if err != nil || len(aliases) != 1 {
+		t.Fatalf("persisted aliases after concurrent mutations: aliases=%+v err=%v", aliases, err)
 	}
 }
 

--- a/coordinator/api/model_alias_handlers_test.go
+++ b/coordinator/api/model_alias_handlers_test.go
@@ -151,7 +151,7 @@ func TestAliasModelEntriesHidesBuilds(t *testing.T) {
 		"gemma-4-26b-retired": {ModelID: "gemma-4-26b-retired", RoutableProviders: 10, WarmProviders: 10, CanAccept: true},
 	}
 
-	entries, hidden := srv.aliasModelEntries(capByModel, catalogByID, registryByID, nil)
+	entries, hidden := srv.aliasModelEntries(capByModel, catalogByID, registryByID)
 	if len(entries) != 1 || entries[0].ID != "gemma-4-26b" {
 		t.Fatalf("expected one alias entry, got %+v", entries)
 	}
@@ -203,7 +203,7 @@ func TestAliasModelEntriesDesiredNotInCatalog(t *testing.T) {
 		t.Fatal(err)
 	}
 	catalogByID := map[string]store.SupportedModel{aliasFP8: {ID: aliasFP8, Active: true, ModelType: "text"}}
-	entries, hidden := srv.aliasModelEntries(map[string]*registry.ModelCapacity{}, catalogByID, registryByID, nil)
+	entries, hidden := srv.aliasModelEntries(map[string]*registry.ModelCapacity{}, catalogByID, registryByID)
 	if len(entries) != 1 || entries[0].ID != "gemma-4-26b" {
 		t.Fatalf("only the alias with an in-catalog build should list, got %+v", entries)
 	}
@@ -984,7 +984,7 @@ func TestListModelsHidesRetiredAliasBuild(t *testing.T) {
 		t.Fatal(err)
 	}
 	catalogByID := map[string]store.SupportedModel{aliasFP8: {ID: aliasFP8, Active: true, ModelType: "text"}, aliasQAT: {ID: aliasQAT, Active: true, ModelType: "text"}}
-	_, hidden := srv.aliasModelEntries(map[string]*registry.ModelCapacity{}, catalogByID, registryByID, nil)
+	_, hidden := srv.aliasModelEntries(map[string]*registry.ModelCapacity{}, catalogByID, registryByID)
 	if _, ok := hidden[aliasFP8]; !ok {
 		t.Fatalf("retired build should be in the hidden set: %v", hidden)
 	}
@@ -1115,8 +1115,8 @@ func TestOpenRouterAliasClonesSourceEntry(t *testing.T) {
 		t.Fatalf("PublicNameForBuild = %q, want source alias %s", got, baseAlias)
 	}
 
-	// The OpenRouter-only alias is discoverable in the normal catalog and
-	// differs from its source only in the identities that schema exposes.
+	// OpenRouter-only aliases remain callable but are not advertised in the
+	// standard consumer catalog.
 	listRec := httptest.NewRecorder()
 	srv.handleListModels(listRec, httptest.NewRequest(http.MethodGet, "/v1/models", nil))
 	if listRec.Code != http.StatusOK {
@@ -1130,18 +1130,11 @@ func TestOpenRouterAliasClonesSourceEntry(t *testing.T) {
 	for _, m := range listResp.Data {
 		listByID[m.ID] = m
 	}
-	baseModel, baseOK := listByID[baseAlias]
-	paidModel, paidOK := listByID[paidAlias]
-	if !baseOK || !paidOK {
-		t.Fatalf("aliases missing from /v1/models: %+v", listResp.Data)
+	if _, baseOK := listByID[baseAlias]; !baseOK {
+		t.Fatalf("standard source alias missing from /v1/models: %+v", listResp.Data)
 	}
-	if paidModel.HuggingFaceID != paidHFID {
-		t.Fatalf("paid model hugging_face_id = %q, want %q", paidModel.HuggingFaceID, paidHFID)
-	}
-	paidModel.ID = baseModel.ID
-	paidModel.HuggingFaceID = baseModel.HuggingFaceID
-	if !reflect.DeepEqual(paidModel, baseModel) {
-		t.Fatalf("main catalog clone differs beyond identities: source=%+v clone=%+v", baseModel, paidModel)
+	if _, leaked := listByID[paidAlias]; leaked {
+		t.Fatalf("OpenRouter-only alias leaked into /v1/models: %+v", listResp.Data)
 	}
 	if _, leaked := listByID[aliasQAT]; leaked {
 		t.Fatalf("shared build leaked into /v1/models: %+v", listResp.Data)
@@ -1249,17 +1242,12 @@ func TestOpenRouterAliasClonesConcreteModel(t *testing.T) {
 		listByID[model.ID] = model
 	}
 	sourceModel, sourceOK := listByID[sourceID]
-	aliasModel, aliasOK := listByID[aliasID]
-	if !sourceOK || !aliasOK {
-		t.Fatalf("source and clone must both remain in /v1/models: %+v", listResp.Data)
+	_, aliasLeaked := listByID[aliasID]
+	if !sourceOK || aliasLeaked {
+		t.Fatalf("standard catalog must list only the concrete source: %+v", listResp.Data)
 	}
-	if aliasModel.Pricing == nil || aliasModel.Pricing.Prompt != "0.00000002" || aliasModel.Pricing.Completion != "0.0000001" {
-		t.Fatalf("clone pricing = %+v", aliasModel.Pricing)
-	}
-	aliasModel.ID = sourceModel.ID
-	aliasModel.HuggingFaceID = sourceModel.HuggingFaceID
-	if !reflect.DeepEqual(aliasModel, sourceModel) {
-		t.Fatalf("main catalog clone differs beyond identities: source=%+v clone=%+v", sourceModel, aliasModel)
+	if sourceModel.Pricing == nil || sourceModel.Pricing.Prompt != "0.00000002" || sourceModel.Pricing.Completion != "0.0000001" {
+		t.Fatalf("source pricing = %+v", sourceModel.Pricing)
 	}
 
 	openRouterRec := httptest.NewRecorder()
@@ -1288,6 +1276,102 @@ func TestOpenRouterAliasClonesConcreteModel(t *testing.T) {
 	aliasFeed.OpenRouter = sourceFeed.OpenRouter
 	if !reflect.DeepEqual(aliasFeed, sourceFeed) {
 		t.Fatalf("OpenRouter clone differs beyond identities: source=%+v clone=%+v", sourceFeed, aliasFeed)
+	}
+}
+
+func TestOpenRouterAliasRejectsCoveredConcreteModel(t *testing.T) {
+	t.Setenv("MODEL_REGISTRY_PUBLISHING_KEY", "publish-secret")
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	st := store.NewMemory(store.Config{})
+	srv := NewServer(registry.New(logger), st, ServerConfig{}, logger)
+
+	const sourceID = "gpt-oss-20b"
+	seedActiveModel(t, st, sourceID, "GPT-OSS 20B")
+	if err := st.UpsertModelAlias(&store.ModelAlias{
+		AliasID: "gpt-oss-public", DesiredBuild: sourceID, Active: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	srv.SyncModelCatalog()
+
+	body, _ := json.Marshal(map[string]any{
+		"id": "openai-gpt-oss-20b", "source_model": sourceID,
+		"openrouter_slug": "openai/gpt-oss-20b", "hugging_face_id": "openai/gpt-oss-20b",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/v1/admin/models/openrouter-aliases", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer publish-secret")
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusConflict || !strings.Contains(rec.Body.String(), "covered by standard alias gpt-oss-public") {
+		t.Fatalf("covered concrete source: status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if _, found, err := st.GetModelAlias("openai-gpt-oss-20b"); err != nil || found {
+		t.Fatalf("rejected clone persisted: found=%v err=%v", found, err)
+	}
+}
+
+func TestStandardAliasRejectsConcreteSourceTakeover(t *testing.T) {
+	t.Setenv("MODEL_REGISTRY_PUBLISHING_KEY", "publish-secret")
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	st := store.NewMemory(store.Config{})
+	reg := registry.New(logger)
+	srv := NewServer(reg, st, ServerConfig{}, logger)
+
+	const (
+		sourceID      = "gpt-oss-20b"
+		replacementID = "gpt-oss-20b-v2"
+		cloneID       = "openai-gpt-oss-20b"
+	)
+	seedActiveModel(t, st, sourceID, "GPT-OSS 20B")
+	seedActiveModel(t, st, replacementID, "GPT-OSS 20B v2")
+	srv.SyncModelCatalog()
+
+	post := func(path string, payload map[string]any) *httptest.ResponseRecorder {
+		t.Helper()
+		body, _ := json.Marshal(payload)
+		req := httptest.NewRequest(http.MethodPost, path, bytes.NewReader(body))
+		req.Header.Set("Authorization", "Bearer publish-secret")
+		rec := httptest.NewRecorder()
+		srv.Handler().ServeHTTP(rec, req)
+		return rec
+	}
+	if rec := post("/v1/admin/models/openrouter-aliases", map[string]any{
+		"id": cloneID, "source_model": sourceID,
+		"openrouter_slug": "openai/gpt-oss-20b", "hugging_face_id": "openai/gpt-oss-20b",
+	}); rec.Code != http.StatusOK {
+		t.Fatalf("create concrete clone: status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	saved, found, err := st.GetModelAlias(cloneID)
+	if err != nil || !found || saved.SourceKind != store.ModelAliasSourceConcrete {
+		t.Fatalf("stored source kind: alias=%+v found=%v err=%v", saved, found, err)
+	}
+
+	rec := post("/v1/admin/models/aliases", map[string]any{
+		"alias_id": sourceID, "desired_build": replacementID,
+		"previous_build": sourceID, "takeover": true,
+	})
+	if rec.Code != http.StatusConflict || !strings.Contains(rec.Body.String(), "pinned by OpenRouter alias "+cloneID) {
+		t.Fatalf("takeover conflict: status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if build, isAlias, ok := reg.ResolveModel(cloneID); !ok || !isAlias || build != sourceID {
+		t.Fatalf("clone retargeted after rejected takeover: build=%q isAlias=%v ok=%v", build, isAlias, ok)
+	}
+	if _, found, err := st.GetModelAlias(sourceID); err != nil || found {
+		t.Fatalf("rejected takeover persisted: found=%v err=%v", found, err)
+	}
+}
+
+func TestStandardAliasCoversEveryBuildState(t *testing.T) {
+	for name, alias := range map[string]store.ModelAlias{
+		"desired":  {Active: true, DesiredBuild: "source"},
+		"previous": {Active: true, PreviousBuild: "source"},
+		"retired":  {Active: true, RetiredBuilds: []string{"source"}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if !standardAliasCoversBuild(alias, "source") {
+				t.Fatalf("%s build was not covered: %+v", name, alias)
+			}
+		})
 	}
 }
 

--- a/coordinator/api/models_endpoints.go
+++ b/coordinator/api/models_endpoints.go
@@ -23,17 +23,14 @@ func hideAliasBuild(hidden map[string]struct{}, catalogByID map[string]store.Sup
 	}
 }
 
-// aliasModelEntries builds the consumer-facing /v1/models entries for active
-// standard aliases and their OpenRouter-only clones, and returns the set of
-// underlying build ids standard aliases cover. Standard aliases hide every
-// desired, previous, and retired build from the default listing. OpenRouter-only
-// aliases clone either a standard alias or a concrete entry without hiding or
-// changing the canonical name of their source.
+// aliasModelEntries builds consumer-facing /v1/models entries for active
+// standard aliases and returns the concrete build ids they hide. OpenRouter-only
+// aliases are deliberately excluded; they are discoverable only through the
+// dedicated /v1/models/openrouter marketplace feed.
 func (s *Server) aliasModelEntries(
 	capByModel map[string]*registry.ModelCapacity,
 	catalogByID map[string]store.SupportedModel,
 	registryByID map[string]store.ModelRegistryEntry,
-	concreteEntries map[string]types.ModelEntry,
 ) ([]types.ModelEntry, map[string]struct{}) {
 	hidden := make(map[string]struct{})
 	aliases, err := s.store.ListModelAliases()
@@ -43,7 +40,6 @@ func (s *Server) aliasModelEntries(
 	}
 
 	entries := make([]types.ModelEntry, 0, len(aliases))
-	standardEntries := make(map[string]types.ModelEntry, len(aliases))
 	for _, a := range aliases {
 		if !a.Active || a.OpenRouterOnly || a.DesiredBuild == "" {
 			continue
@@ -132,29 +128,8 @@ func (s *Server) aliasModelEntries(
 		}
 		entry.InputModalities, entry.OutputModalities = deriveModalities(cm.ModelType, caps)
 		entries = append(entries, entry)
-		standardEntries[a.AliasID] = entry
 	}
 
-	// OpenRouter-only aliases are valid inference names but never own or hide
-	// their source. Clone a standard rollout alias when present; otherwise clone
-	// an independently-listed concrete catalog model.
-	for _, a := range aliases {
-		if !a.Active || !a.OpenRouterOnly {
-			continue
-		}
-		source, ok := standardEntries[a.SourceModel]
-		if !ok {
-			source, ok = concreteEntries[a.SourceModel]
-		}
-		if !ok || a.OpenRouterSlug == "" || a.HuggingFaceID == "" {
-			s.logger.Warn("model registry: OpenRouter alias source or identities unavailable", "alias_id", a.AliasID, "source_model", a.SourceModel)
-			continue
-		}
-		clone := source
-		clone.ID = a.AliasID
-		clone.HuggingFaceID = a.HuggingFaceID
-		entries = append(entries, clone)
-	}
 	return entries, hidden
 }
 
@@ -196,12 +171,7 @@ func (s *Server) listModelEntries(includeBuilds bool) ([]types.ModelEntry, error
 		concreteOrder = append(concreteOrder, model.ID)
 	}
 
-	aliasEntries, hiddenBuilds := s.aliasModelEntries(
-		capByModel,
-		catalogByID,
-		registryByID,
-		concreteEntries,
-	)
+	aliasEntries, hiddenBuilds := s.aliasModelEntries(capByModel, catalogByID, registryByID)
 	data := make([]types.ModelEntry, 0, len(concreteEntries)+len(aliasEntries))
 	data = append(data, aliasEntries...)
 	for _, modelID := range concreteOrder {

--- a/coordinator/api/models_endpoints.go
+++ b/coordinator/api/models_endpoints.go
@@ -318,8 +318,8 @@ func ownedModelEntry(m registry.AggregateModel) types.ModelEntry {
 
 // handleGetModel handles GET /v1/models/{id...} — the OpenAI "retrieve model"
 // endpoint. Model IDs may contain slashes (HuggingFace paths), hence the
-// wildcard path segment. Hidden quant builds are retrievable by their exact
-// id, matching the behavior of requesting one for inference.
+// wildcard path segment. Hidden quant builds and marketplace-only OpenRouter
+// aliases remain retrievable by exact id for inference-client parity.
 func (s *Server) handleGetModel(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
 	// Self-route requests retrieve from their owned live models (mirrors
@@ -347,6 +347,23 @@ func (s *Server) handleGetModel(w http.ResponseWriter, r *http.Request) {
 	for _, entry := range data {
 		if entry.ID == id {
 			writeJSON(w, http.StatusOK, entry)
+			return
+		}
+	}
+	alias, found, aliasErr := s.store.GetModelAlias(id)
+	if aliasErr != nil {
+		s.logger.Error("model registry: failed to retrieve model alias", "model", id, "error", aliasErr)
+		writeJSON(w, http.StatusInternalServerError, errorResponse("internal_error", "failed to retrieve model"))
+		return
+	}
+	if found && alias.Active && alias.OpenRouterOnly {
+		for _, source := range data {
+			if source.ID != alias.SourceModel {
+				continue
+			}
+			source.ID = alias.AliasID
+			source.HuggingFaceID = alias.HuggingFaceID
+			writeJSON(w, http.StatusOK, source)
 			return
 		}
 	}

--- a/coordinator/api/models_endpoints.go
+++ b/coordinator/api/models_endpoints.go
@@ -25,19 +25,15 @@ func hideAliasBuild(hidden map[string]struct{}, catalogByID map[string]store.Sup
 
 // aliasModelEntries builds the consumer-facing /v1/models entries for active
 // standard aliases and their OpenRouter-only clones, and returns the set of
-// underlying build ids those aliases cover (so the caller can hide them from
-// the default listing). The hidden set covers EVERY build a standard alias
-// references — desired, previous, and the retired lineage — so a concrete
-// quant build never appears as its own entry once it is behind an alias. Each
-// standard alias derives its metadata from its primary build — the desired
-// build, or the previous build if the desired one isn't in the catalog yet —
-// and aggregates live capacity across the desired and previous builds.
-// OpenRouter-only aliases clone that complete source entry and override only
-// their consumer-facing id and Hugging Face identity.
+// underlying build ids standard aliases cover. Standard aliases hide every
+// desired, previous, and retired build from the default listing. OpenRouter-only
+// aliases clone either a standard alias or a concrete entry without hiding or
+// changing the canonical name of their source.
 func (s *Server) aliasModelEntries(
 	capByModel map[string]*registry.ModelCapacity,
 	catalogByID map[string]store.SupportedModel,
 	registryByID map[string]store.ModelRegistryEntry,
+	concreteEntries map[string]types.ModelEntry,
 ) ([]types.ModelEntry, map[string]struct{}) {
 	hidden := make(map[string]struct{})
 	aliases, err := s.store.ListModelAliases()
@@ -139,14 +135,17 @@ func (s *Server) aliasModelEntries(
 		standardEntries[a.AliasID] = entry
 	}
 
-	// OpenRouter-only aliases are already valid inference names. Surface them
-	// in the main catalog by cloning their standard source entry, without
-	// turning them into provider-convergence or canonical-naming aliases.
+	// OpenRouter-only aliases are valid inference names but never own or hide
+	// their source. Clone a standard rollout alias when present; otherwise clone
+	// an independently-listed concrete catalog model.
 	for _, a := range aliases {
 		if !a.Active || !a.OpenRouterOnly {
 			continue
 		}
 		source, ok := standardEntries[a.SourceModel]
+		if !ok {
+			source, ok = concreteEntries[a.SourceModel]
+		}
 		if !ok || a.OpenRouterSlug == "" || a.HuggingFaceID == "" {
 			s.logger.Warn("model registry: OpenRouter alias source or identities unavailable", "alias_id", a.AliasID, "source_model", a.SourceModel)
 			continue
@@ -165,89 +164,52 @@ func (s *Server) aliasModelEntries(
 func (s *Server) listModelEntries(includeBuilds bool) ([]types.ModelEntry, error) {
 	models := s.registry.ListModels()
 
-	// Build a lookup of capacity data keyed by model ID.
 	capacities := s.registry.ModelCapacitySnapshot()
 	capByModel := make(map[string]*registry.ModelCapacity, len(capacities))
 	for i := range capacities {
 		capByModel[capacities[i].ModelID] = &capacities[i]
 	}
 
-	// Filter to only show models from the active catalog, and capture the richer
-	// registry entries used to populate the OpenRouter provider fields. These
-	// lookups are shared with the dedicated /v1/models/openrouter feed.
 	catalogByID, registryByID, err := s.activeCatalogLookups()
 	if err != nil {
 		return nil, err
 	}
 
-	// Public aliases are the consumer-facing model names; their underlying
-	// quant builds are hidden by default so consumers never see the quant.
-	aliasEntries, hiddenBuilds := s.aliasModelEntries(capByModel, catalogByID, registryByID)
-
-	data := make([]types.ModelEntry, 0, len(models)+len(aliasEntries))
-	data = append(data, aliasEntries...)
-	for _, m := range models {
-		cm, inCatalog := catalogByID[m.ID]
+	// Build each concrete entry once. OpenRouter-only aliases may clone these
+	// entries, while standard aliases independently decide which builds to hide.
+	concreteEntries := make(map[string]types.ModelEntry, len(models))
+	concreteOrder := make([]string, 0, len(models))
+	for _, model := range models {
+		catalogModel, inCatalog := catalogByID[model.ID]
 		if len(catalogByID) > 0 && !inCatalog {
 			continue
 		}
-		if _, hidden := hiddenBuilds[m.ID]; hidden && !includeBuilds {
-			continue
-		}
-		metadata := types.ModelMetadata{
-			ModelType:         m.ModelType,
-			Quantization:      m.Quantization,
-			ProviderCount:     m.Providers,
-			AttestedProviders: m.AttestedProviders,
-			TrustLevel:        string(m.TrustLevel),
-		}
-		// Add capacity fields from live snapshot.
-		if cap, ok := capByModel[m.ID]; ok {
-			metadata.RoutableProviders = cap.RoutableProviders
-			metadata.WarmProviders = cap.WarmProviders
-			metadata.CanAccept = cap.CanAccept
-		} else {
-			metadata.RoutableProviders = 0
-			metadata.WarmProviders = 0
-			metadata.CanAccept = false
-		}
-		if m.Attestation != nil {
-			metadata.Attestation = &types.ModelAttestation{
-				SecureEnclave: m.Attestation.SecureEnclave,
-				SIPEnabled:    m.Attestation.SIPEnabled,
-				SecureBoot:    m.Attestation.SecureBoot,
-			}
-		}
-		if inCatalog && cm.DisplayName != "" {
-			metadata.DisplayName = cm.DisplayName
-		}
-
-		reg, hasReg := registryByID[m.ID]
-		entry := types.ModelEntry{
-			ID:            m.ID,
-			Object:        "model",
-			Created:       0,
-			OwnedBy:       "eigeninference",
-			Name:          metadata.DisplayName,
-			HuggingFaceID: huggingFaceIDForModel(m.ID, reg.Metadata),
-			Metadata:      metadata,
-		}
-
-		// OpenRouter provider fields (quantization, per-token pricing, sampling
-		// params, and registry-sourced metadata), shared with the dedicated
-		// /v1/models/openrouter feed.
-		s.openRouterModelFieldsFor(m.ID, m.Quantization, reg, hasReg).applyToModelEntry(&entry)
-
-		// Modalities are derived from the model's capabilities (text by default).
-		var caps []string
-		if hasReg {
-			caps = reg.Capabilities
-		}
-		entry.InputModalities, entry.OutputModalities = deriveModalities(m.ModelType, caps)
-
-		data = append(data, entry)
+		registryEntry, hasRegistryEntry := registryByID[model.ID]
+		concreteEntries[model.ID] = s.modelEntryForConcrete(
+			model,
+			capByModel[model.ID],
+			catalogModel,
+			inCatalog,
+			registryEntry,
+			hasRegistryEntry,
+		)
+		concreteOrder = append(concreteOrder, model.ID)
 	}
 
+	aliasEntries, hiddenBuilds := s.aliasModelEntries(
+		capByModel,
+		catalogByID,
+		registryByID,
+		concreteEntries,
+	)
+	data := make([]types.ModelEntry, 0, len(concreteEntries)+len(aliasEntries))
+	data = append(data, aliasEntries...)
+	for _, modelID := range concreteOrder {
+		if _, hidden := hiddenBuilds[modelID]; hidden && !includeBuilds {
+			continue
+		}
+		data = append(data, concreteEntries[modelID])
+	}
 	return data, nil
 }
 

--- a/coordinator/api/models_endpoints.go
+++ b/coordinator/api/models_endpoints.go
@@ -357,13 +357,28 @@ func (s *Server) handleGetModel(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if found && alias.Active && alias.OpenRouterOnly {
-		for _, source := range data {
-			if source.ID != alias.SourceModel {
-				continue
+		var sourceEntry types.ModelEntry
+		sourceFound := false
+		for _, entry := range data {
+			if entry.ID == alias.SourceModel {
+				sourceEntry = entry
+				sourceFound = true
+				break
 			}
-			source.ID = alias.AliasID
-			source.HuggingFaceID = alias.HuggingFaceID
-			writeJSON(w, http.StatusOK, source)
+		}
+		if !sourceFound && openRouterAliasUsesConcreteSource(*alias) {
+			catalogByID, registryByID, catalogErr := s.activeCatalogLookups()
+			if catalogErr != nil {
+				s.logger.Error("model registry: failed to retrieve concrete alias source", "model", id, "source_model", alias.SourceModel, "error", catalogErr)
+				writeJSON(w, http.StatusInternalServerError, errorResponse("internal_error", "failed to retrieve model"))
+				return
+			}
+			sourceEntry, sourceFound = s.modelEntryForCatalogConcrete(alias.SourceModel, catalogByID, registryByID)
+		}
+		if sourceFound {
+			sourceEntry.ID = alias.AliasID
+			sourceEntry.HuggingFaceID = alias.HuggingFaceID
+			writeJSON(w, http.StatusOK, sourceEntry)
 			return
 		}
 	}

--- a/coordinator/api/openrouter_alias_handlers.go
+++ b/coordinator/api/openrouter_alias_handlers.go
@@ -9,8 +9,8 @@ import (
 )
 
 // openRouterAliasUpsertRequest configures one OpenRouter-only clone of an
-// existing standard model alias. OpenRouter sends ID to the inference API;
-// SourceModel supplies every non-identity feed field and the live routing target.
+// existing standard alias or concrete catalog model. OpenRouter sends ID to the
+// inference API; SourceModel supplies every non-identity feed field and routing.
 type openRouterAliasUpsertRequest struct {
 	ID             string `json:"id"`
 	SourceModel    string `json:"source_model"`
@@ -61,11 +61,20 @@ func (s *Server) handleOpenRouterAliasUpsert(w http.ResponseWriter, r *http.Requ
 
 	source, found, err := s.store.GetModelAlias(req.SourceModel)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, errorResponse("internal_error", "failed to get source alias"))
+		writeJSON(w, http.StatusInternalServerError, errorResponse("internal_error", "failed to get source model"))
 		return
 	}
-	if !found || source.OpenRouterOnly || !source.Active || source.DesiredBuild == "" {
-		writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request_error", "source_model must be an active standard model alias", withParam("source_model")))
+	sourceAvailable := found && !source.OpenRouterOnly && source.Active && source.DesiredBuild != ""
+	if !found {
+		catalogByID, _, catalogErr := s.activeCatalogLookups()
+		if catalogErr != nil {
+			writeJSON(w, http.StatusInternalServerError, errorResponse("internal_error", "failed to get source model"))
+			return
+		}
+		_, sourceAvailable = catalogByID[req.SourceModel]
+	}
+	if !sourceAvailable {
+		writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request_error", "source_model must be an active standard alias or concrete catalog model", withParam("source_model")))
 		return
 	}
 	if rec, _ := s.store.GetModelRegistryRecord(req.ID); rec != nil {

--- a/coordinator/api/openrouter_alias_handlers.go
+++ b/coordinator/api/openrouter_alias_handlers.go
@@ -59,6 +59,7 @@ func (s *Server) handleOpenRouterAliasUpsert(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
+	sourceKind := store.ModelAliasSourceAlias
 	source, found, err := s.store.GetModelAlias(req.SourceModel)
 	if err != nil {
 		writeJSON(w, http.StatusInternalServerError, errorResponse("internal_error", "failed to get source model"))
@@ -66,12 +67,24 @@ func (s *Server) handleOpenRouterAliasUpsert(w http.ResponseWriter, r *http.Requ
 	}
 	sourceAvailable := found && !source.OpenRouterOnly && source.Active && source.DesiredBuild != ""
 	if !found {
+		sourceKind = store.ModelAliasSourceConcrete
 		catalogByID, _, catalogErr := s.activeCatalogLookups()
 		if catalogErr != nil {
 			writeJSON(w, http.StatusInternalServerError, errorResponse("internal_error", "failed to get source model"))
 			return
 		}
 		_, sourceAvailable = catalogByID[req.SourceModel]
+		if sourceAvailable {
+			aliases, listErr := s.store.ListModelAliases()
+			if listErr != nil {
+				writeJSON(w, http.StatusInternalServerError, errorResponse("internal_error", "failed to validate source model"))
+				return
+			}
+			if coveringAlias, covered := standardAliasCoveringBuild(aliases, req.SourceModel); covered {
+				writeJSON(w, http.StatusConflict, errorResponse("invalid_request_error", "concrete source_model is covered by standard alias "+coveringAlias+"; use that alias as source_model", withParam("source_model")))
+				return
+			}
+		}
 	}
 	if !sourceAvailable {
 		writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request_error", "source_model must be an active standard alias or concrete catalog model", withParam("source_model")))
@@ -97,6 +110,7 @@ func (s *Server) handleOpenRouterAliasUpsert(w http.ResponseWriter, r *http.Requ
 		AliasID:        req.ID,
 		OpenRouterOnly: true,
 		SourceModel:    req.SourceModel,
+		SourceKind:     sourceKind,
 		OpenRouterSlug: req.OpenRouterSlug,
 		HuggingFaceID:  req.HuggingFaceID,
 		Active:         active,

--- a/coordinator/api/openrouter_alias_handlers.go
+++ b/coordinator/api/openrouter_alias_handlers.go
@@ -75,7 +75,12 @@ func (s *Server) handleOpenRouterAliasUpsert(w http.ResponseWriter, r *http.Requ
 			writeJSON(w, http.StatusInternalServerError, errorResponse("internal_error", "failed to get source model"))
 			return
 		}
-		_, sourceAvailable = catalogByID[req.SourceModel]
+		_, concreteFound := catalogByID[req.SourceModel]
+		if concreteFound && !concreteModelEligibleForOpenRouterFeed(req.SourceModel, catalogByID, s.openRouterAggregateTypeByID()) {
+			writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request_error", "concrete source_model is not eligible for the OpenRouter text feed", withParam("source_model")))
+			return
+		}
+		sourceAvailable = concreteFound
 		if sourceAvailable {
 			aliases, listErr := s.store.ListModelAliases()
 			if listErr != nil {

--- a/coordinator/api/openrouter_alias_handlers.go
+++ b/coordinator/api/openrouter_alias_handlers.go
@@ -58,6 +58,8 @@ func (s *Server) handleOpenRouterAliasUpsert(w http.ResponseWriter, r *http.Requ
 		writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request_error", "hugging_face_id is required", withParam("hugging_face_id")))
 		return
 	}
+	s.modelAliasMutationMu.Lock()
+	defer s.modelAliasMutationMu.Unlock()
 
 	sourceKind := store.ModelAliasSourceAlias
 	source, found, err := s.store.GetModelAlias(req.SourceModel)
@@ -66,7 +68,7 @@ func (s *Server) handleOpenRouterAliasUpsert(w http.ResponseWriter, r *http.Requ
 		return
 	}
 	sourceAvailable := found && !source.OpenRouterOnly && source.Active && source.DesiredBuild != ""
-	if !found {
+	if !sourceAvailable {
 		sourceKind = store.ModelAliasSourceConcrete
 		catalogByID, _, catalogErr := s.activeCatalogLookups()
 		if catalogErr != nil {

--- a/coordinator/api/openrouter_alias_invariants.go
+++ b/coordinator/api/openrouter_alias_invariants.go
@@ -1,0 +1,46 @@
+package api
+
+import "github.com/eigeninference/d-inference/coordinator/store"
+
+// openRouterAliasUsesConcreteSource preserves the legacy meaning of an empty
+// source_kind: OpenRouter aliases created before source kinds were persisted
+// always cloned a standard alias.
+func openRouterAliasUsesConcreteSource(alias store.ModelAlias) bool {
+	return alias.SourceKind == store.ModelAliasSourceConcrete
+}
+
+func standardAliasCoversBuild(alias store.ModelAlias, buildID string) bool {
+	if !alias.Active || alias.OpenRouterOnly || buildID == "" {
+		return false
+	}
+	if alias.DesiredBuild == buildID || alias.PreviousBuild == buildID {
+		return true
+	}
+	for _, retired := range alias.RetiredBuilds {
+		if retired == buildID {
+			return true
+		}
+	}
+	return false
+}
+
+func standardAliasCoveringBuild(aliases []store.ModelAlias, buildID string) (string, bool) {
+	for _, alias := range aliases {
+		if standardAliasCoversBuild(alias, buildID) {
+			return alias.AliasID, true
+		}
+	}
+	return "", false
+}
+
+func concreteOpenRouterAliasUsingBuild(aliases []store.ModelAlias, builds map[string]struct{}) (store.ModelAlias, bool) {
+	for _, alias := range aliases {
+		if !alias.Active || !alias.OpenRouterOnly || !openRouterAliasUsesConcreteSource(alias) {
+			continue
+		}
+		if _, covered := builds[alias.SourceModel]; covered {
+			return alias, true
+		}
+	}
+	return store.ModelAlias{}, false
+}

--- a/coordinator/api/openrouter_endpoint.go
+++ b/coordinator/api/openrouter_endpoint.go
@@ -28,15 +28,9 @@ func (s *Server) handleListModelsOpenRouter(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	// Provider-reported model types (when any provider is online) let us
-	// exclude non-text models even though the registry currently stores every
-	// model as "text".
-	aggTypeByID := make(map[string]string)
-	for _, m := range s.registry.ListModels() {
-		if m.ModelType != "" {
-			aggTypeByID[m.ID] = m.ModelType
-		}
-	}
+	// Provider-reported model types override the catalog's text fallback so
+	// known non-text models never enter the OpenRouter provider feed.
+	aggTypeByID := s.openRouterAggregateTypeByID()
 
 	// Public aliases get the same treatment as /v1/models: the alias is the
 	// purchasable entry and its member builds are hidden, so the marketplace

--- a/coordinator/api/openrouter_endpoint.go
+++ b/coordinator/api/openrouter_endpoint.go
@@ -57,42 +57,10 @@ func (s *Server) handleListModelsOpenRouter(w http.ResponseWriter, r *http.Reque
 		if _, hidden := hiddenBuilds[id]; hidden {
 			continue
 		}
-		cm := catalogByID[id]
-		// Text-only feed: prefer the provider-reported type, fall back to the
-		// catalog type. Excludes only known non-text modalities
-		// (embedding/tts/image/audio/rerank); text/chat/unknown stay listed.
-		modelType := cm.ModelType
-		if at, ok := aggTypeByID[id]; ok {
-			modelType = at
-		}
-		if isNonTextModelType(modelType) {
+		entry, ok := s.openRouterEntryForConcrete(id, catalogByID, registryByID, aggTypeByID)
+		if !ok {
 			continue
 		}
-
-		reg, hasReg := registryByID[id]
-		entry := types.OpenRouterModel{
-			ID:                id,
-			HuggingFaceID:     huggingFaceIDForModel(id, reg.Metadata),
-			Name:              openRouterModelName(cm, reg, hasReg, id),
-			InputModalities:   []string{"text"},
-			OutputModalities:  []string{"text"},
-			SupportedFeatures: []string{},
-			IsReady:           true,
-		}
-		// Quantization comes from the registry entry (the catalog row carries
-		// none); legacy rows simply omit it.
-		s.openRouterModelFieldsFor(id, reg.Quantization, reg, hasReg).applyToFeed(&entry)
-
-		// is_ready is a launch/staging flag and the slug is per-model; both
-		// come from registry metadata (defaults apply for legacy rows).
-		if hasReg {
-			entry.IsReady = openRouterIsReady(reg.Metadata)
-			entry.OpenRouter = &types.OpenRouterSlug{Slug: openRouterSlug(id, reg.Metadata)}
-		} else {
-			entry.OpenRouter = &types.OpenRouterSlug{Slug: openRouterSlug(id, nil)}
-		}
-		entry.Datacenters = s.modelDatacenters(id)
-
 		data = append(data, entry)
 	}
 
@@ -193,10 +161,13 @@ func (s *Server) openRouterAliasEntries(
 	}
 
 	// OpenRouter-only aliases clone the complete source entry, then replace only
-	// the three configured identities. This keeps pricing, limits, features,
-	// readiness, and datacenters exactly synchronized with the source alias.
+	// the three configured identities. Standard sources carry rollout behavior;
+	// concrete sources remain independently listed and route directly.
 	for _, a := range openRouterAliases {
 		source, ok := standardEntries[a.SourceModel]
+		if !ok {
+			source, ok = s.openRouterEntryForConcrete(a.SourceModel, catalogByID, registryByID, aggTypeByID)
+		}
 		if !ok || a.OpenRouterSlug == "" || a.HuggingFaceID == "" {
 			s.logger.Warn("OpenRouter alias source or identities unavailable", "alias_id", a.AliasID, "source_model", a.SourceModel)
 			continue

--- a/coordinator/api/openrouter_endpoint.go
+++ b/coordinator/api/openrouter_endpoint.go
@@ -161,12 +161,15 @@ func (s *Server) openRouterAliasEntries(
 	}
 
 	// OpenRouter-only aliases clone the complete source entry, then replace only
-	// the three configured identities. Standard sources carry rollout behavior;
-	// concrete sources remain independently listed and route directly.
+	// the three configured identities. Persisted source kind prevents a later
+	// standard-alias mutation from changing concrete-source routing or feeds.
 	for _, a := range openRouterAliases {
-		source, ok := standardEntries[a.SourceModel]
-		if !ok {
+		var source types.OpenRouterModel
+		var ok bool
+		if openRouterAliasUsesConcreteSource(a) {
 			source, ok = s.openRouterEntryForConcrete(a.SourceModel, catalogByID, registryByID, aggTypeByID)
+		} else {
+			source, ok = standardEntries[a.SourceModel]
 		}
 		if !ok || a.OpenRouterSlug == "" || a.HuggingFaceID == "" {
 			s.logger.Warn("OpenRouter alias source or identities unavailable", "alias_id", a.AliasID, "source_model", a.SourceModel)

--- a/coordinator/api/openrouter_endpoint_test.go
+++ b/coordinator/api/openrouter_endpoint_test.go
@@ -357,3 +357,19 @@ func TestOpenRouterModelsHidesRetiredAliasBuild(t *testing.T) {
 		t.Fatalf("alias gemma-4-26b missing from OpenRouter feed: %+v", resp.Data)
 	}
 }
+
+func TestConcreteModelEligibleForOpenRouterFeed(t *testing.T) {
+	const modelID = "model"
+	catalog := map[string]store.SupportedModel{
+		modelID: {ID: modelID, ModelType: "text", Active: true},
+	}
+	if !concreteModelEligibleForOpenRouterFeed(modelID, catalog, nil) {
+		t.Fatal("text catalog model without providers should be feed-eligible")
+	}
+	if concreteModelEligibleForOpenRouterFeed(modelID, catalog, map[string]string{modelID: "embedding"}) {
+		t.Fatal("provider-reported non-text model should not be feed-eligible")
+	}
+	if concreteModelEligibleForOpenRouterFeed("missing", catalog, nil) {
+		t.Fatal("missing catalog model should not be feed-eligible")
+	}
+}

--- a/coordinator/api/server.go
+++ b/coordinator/api/server.go
@@ -1025,20 +1025,27 @@ func (s *Server) SyncModelCatalog() {
 	s.registry.SetModelCatalog(entries)
 	s.logger.Info("model registry catalog synced to registry", "active_models", len(entries))
 
-	s.syncModelAliases()
+	s.syncModelAliases(registryRows)
 	s.invalidateCatalogCache()
 }
 
 // syncModelAliases loads standard rollout aliases first, then resolves
-// OpenRouter-only aliases through their source alias. The latter route requests
-// but do not participate in provider convergence or canonical public naming.
-func (s *Server) syncModelAliases() {
+// OpenRouter-only aliases through either a standard alias or an active concrete
+// catalog model. OpenRouter-only targets route requests but do not participate
+// in provider convergence or canonical public naming.
+func (s *Server) syncModelAliases(registryRows []store.ModelRegistryRecord) {
 	aliases, err := s.store.ListModelAliases()
 	if err != nil {
 		s.logger.Error("model alias sync failed", "error", err)
 		return
 	}
 	resolved := make(map[string]registry.AliasTarget, len(aliases))
+	activeConcreteModels := make(map[string]struct{}, len(registryRows))
+	for _, row := range registryRows {
+		if row.ActiveVersion != nil {
+			activeConcreteModels[row.ID] = struct{}{}
+		}
+	}
 	for _, a := range aliases {
 		if !a.Active || a.OpenRouterOnly || a.DesiredBuild == "" {
 			continue
@@ -1055,7 +1062,13 @@ func (s *Server) syncModelAliases() {
 		}
 		target, ok := resolved[a.SourceModel]
 		if !ok {
-			s.logger.Warn("OpenRouter alias source is not an active standard alias", "alias_id", a.AliasID, "source_model", a.SourceModel)
+			if _, concrete := activeConcreteModels[a.SourceModel]; concrete {
+				target = registry.AliasTarget{Desired: a.SourceModel}
+				ok = true
+			}
+		}
+		if !ok {
+			s.logger.Warn("OpenRouter alias source is unavailable", "alias_id", a.AliasID, "source_model", a.SourceModel)
 			continue
 		}
 		target.OpenRouterOnly = true

--- a/coordinator/api/server.go
+++ b/coordinator/api/server.go
@@ -181,6 +181,7 @@ type Server struct {
 	baseRewards                   *baserewards.Engine
 	logger                        *slog.Logger
 	mux                           *http.ServeMux
+	modelAliasMutationMu          sync.Mutex          // serializes cross-endpoint alias validation + persistence
 	challengeInterval             time.Duration       // 0 means use DefaultChallengeInterval
 	skipChallenge                 bool                // if true, skip attestation challenges entirely (testing only)
 	allowDuplicateProviderSerials bool                // in-process multi-provider testbed only

--- a/coordinator/api/server.go
+++ b/coordinator/api/server.go
@@ -1060,12 +1060,14 @@ func (s *Server) syncModelAliases(registryRows []store.ModelRegistryRecord) {
 		if !a.Active || !a.OpenRouterOnly {
 			continue
 		}
-		target, ok := resolved[a.SourceModel]
-		if !ok {
-			if _, concrete := activeConcreteModels[a.SourceModel]; concrete {
+		var target registry.AliasTarget
+		var ok bool
+		if openRouterAliasUsesConcreteSource(a) {
+			if _, ok = activeConcreteModels[a.SourceModel]; ok {
 				target = registry.AliasTarget{Desired: a.SourceModel}
-				ok = true
 			}
+		} else {
+			target, ok = resolved[a.SourceModel]
 		}
 		if !ok {
 			s.logger.Warn("OpenRouter alias source is unavailable", "alias_id", a.AliasID, "source_model", a.SourceModel)

--- a/coordinator/store/interface.go
+++ b/coordinator/store/interface.go
@@ -657,6 +657,16 @@ type ModelRegistryRecord struct {
 	Files         []ModelVersionFile `json:"files,omitempty"`
 }
 
+type ModelAliasSourceKind string
+
+const (
+	// ModelAliasSourceAlias follows an active standard alias's rollout pointers.
+	// It is also the backward-compatible meaning of an empty source_kind.
+	ModelAliasSourceAlias ModelAliasSourceKind = "standard_alias"
+	// ModelAliasSourceConcrete pins routing and feed cloning to one concrete model.
+	ModelAliasSourceConcrete ModelAliasSourceKind = "concrete_model"
+)
+
 // ModelAlias has two forms. A standard alias is a stable consumer-facing name
 // resolving to one desired concrete build plus an optional previous build while
 // providers converge. An OpenRouter-only alias clones either a standard alias or
@@ -664,14 +674,15 @@ type ModelRegistryRecord struct {
 // It never drives provider convergence, hides its source, or becomes the
 // canonical public name for a concrete build.
 type ModelAlias struct {
-	AliasID        string `json:"alias_id"`
-	DisplayName    string `json:"display_name"`
-	OpenRouterOnly bool   `json:"openrouter_only,omitempty"` // marketplace clone; excluded from provider convergence and canonical naming
-	SourceModel    string `json:"source_model,omitempty"`    // standard alias or concrete catalog model cloned by an OpenRouter-only entry
-	OpenRouterSlug string `json:"openrouter_slug,omitempty"` // marketplace identity for an OpenRouter-only entry
-	HuggingFaceID  string `json:"hugging_face_id,omitempty"` // metadata repository for an OpenRouter-only entry
-	DesiredBuild   string `json:"desired_build"`             // the single build providers should converge to
-	PreviousBuild  string `json:"previous_build,omitempty"`  // still-acceptable during rollout; "" when none
+	AliasID        string               `json:"alias_id"`
+	DisplayName    string               `json:"display_name"`
+	OpenRouterOnly bool                 `json:"openrouter_only,omitempty"` // marketplace clone; excluded from provider convergence and canonical naming
+	SourceModel    string               `json:"source_model,omitempty"`    // standard alias or concrete catalog model cloned by an OpenRouter-only entry
+	SourceKind     ModelAliasSourceKind `json:"source_kind,omitempty"`     // source identity semantics; empty legacy values mean standard_alias
+	OpenRouterSlug string               `json:"openrouter_slug,omitempty"` // marketplace identity for an OpenRouter-only entry
+	HuggingFaceID  string               `json:"hugging_face_id,omitempty"` // metadata repository for an OpenRouter-only entry
+	DesiredBuild   string               `json:"desired_build"`             // the single build providers should converge to
+	PreviousBuild  string               `json:"previous_build,omitempty"`  // still-acceptable during rollout; "" when none
 
 	// RetiredBuilds is the alias's lineage: former desired/previous builds
 	// rotated out by later upserts. Kept so a provider that was offline through

--- a/coordinator/store/interface.go
+++ b/coordinator/store/interface.go
@@ -659,15 +659,15 @@ type ModelRegistryRecord struct {
 
 // ModelAlias has two forms. A standard alias is a stable consumer-facing name
 // resolving to one desired concrete build plus an optional previous build while
-// providers converge. An OpenRouter-only alias clones a standard SourceModel in
-// the provider feed and request router, but is hidden from the public catalog
-// and provider desired-state fanout. The split keeps marketplace identities
-// independent without duplicating pricing, capacity, or rollout configuration.
+// providers converge. An OpenRouter-only alias clones either a standard alias or
+// an active concrete catalog model for marketplace identity and request routing.
+// It never drives provider convergence, hides its source, or becomes the
+// canonical public name for a concrete build.
 type ModelAlias struct {
 	AliasID        string `json:"alias_id"`
 	DisplayName    string `json:"display_name"`
-	OpenRouterOnly bool   `json:"openrouter_only,omitempty"` // feed-only clone; hidden from the public catalog and provider convergence
-	SourceModel    string `json:"source_model,omitempty"`    // standard alias cloned by an OpenRouter-only entry
+	OpenRouterOnly bool   `json:"openrouter_only,omitempty"` // marketplace clone; excluded from provider convergence and canonical naming
+	SourceModel    string `json:"source_model,omitempty"`    // standard alias or concrete catalog model cloned by an OpenRouter-only entry
 	OpenRouterSlug string `json:"openrouter_slug,omitempty"` // marketplace identity for an OpenRouter-only entry
 	HuggingFaceID  string `json:"hugging_face_id,omitempty"` // metadata repository for an OpenRouter-only entry
 	DesiredBuild   string `json:"desired_build"`             // the single build providers should converge to

--- a/coordinator/store/model_alias_test.go
+++ b/coordinator/store/model_alias_test.go
@@ -10,6 +10,7 @@ func TestMemoryModelAliasRoundTrip(t *testing.T) {
 		DisplayName:    "Gemma 4 26B",
 		OpenRouterOnly: true,
 		SourceModel:    "gemma-4-26b-source",
+		SourceKind:     ModelAliasSourceAlias,
 		OpenRouterSlug: "google/gemma-4-26b-it",
 		HuggingFaceID:  "google/gemma-4-26b-it",
 		DesiredBuild:   "mlx-community/gemma-4-26B-A4B-it-qat-4bit",
@@ -34,7 +35,7 @@ func TestMemoryModelAliasRoundTrip(t *testing.T) {
 	if got.PreviousBuild != "mlx-community/gemma-4-26b-a4b-it-fp8" {
 		t.Fatalf("previous_build mismatch: %q", got.PreviousBuild)
 	}
-	if !got.OpenRouterOnly || got.SourceModel != "gemma-4-26b-source" || got.OpenRouterSlug != "google/gemma-4-26b-it" || got.HuggingFaceID != "google/gemma-4-26b-it" {
+	if !got.OpenRouterOnly || got.SourceModel != "gemma-4-26b-source" || got.SourceKind != ModelAliasSourceAlias || got.OpenRouterSlug != "google/gemma-4-26b-it" || got.HuggingFaceID != "google/gemma-4-26b-it" {
 		t.Fatalf("OpenRouter identity mismatch: %+v", got)
 	}
 

--- a/coordinator/store/postgres.go
+++ b/coordinator/store/postgres.go
@@ -497,10 +497,12 @@ func (s *PostgresStore) migrate(ctx context.Context) error {
 		// upserts, so a provider returning from a long offline period is still
 		// recognized as part of the alias's fleet.
 		`DO $$ BEGIN ALTER TABLE model_aliases ADD COLUMN IF NOT EXISTS retired_builds JSONB NOT NULL DEFAULT '[]'::jsonb; EXCEPTION WHEN others THEN NULL; END $$`,
-		// OpenRouter-only aliases clone an existing public alias in the provider
-		// feed while keeping an independent API id and marketplace identities.
+		// OpenRouter-only aliases clone an existing public alias or concrete model
+		// while keeping an independent API id and marketplace identities. Existing
+		// rows predate source_kind and therefore retain standard-alias semantics.
 		`DO $$ BEGIN ALTER TABLE model_aliases ADD COLUMN IF NOT EXISTS openrouter_only BOOLEAN NOT NULL DEFAULT FALSE; EXCEPTION WHEN others THEN NULL; END $$`,
 		`DO $$ BEGIN ALTER TABLE model_aliases ADD COLUMN IF NOT EXISTS source_model TEXT NOT NULL DEFAULT ''; EXCEPTION WHEN others THEN NULL; END $$`,
+		`DO $$ BEGIN ALTER TABLE model_aliases ADD COLUMN IF NOT EXISTS source_kind TEXT NOT NULL DEFAULT 'standard_alias'; EXCEPTION WHEN others THEN NULL; END $$`,
 		`DO $$ BEGIN ALTER TABLE model_aliases ADD COLUMN IF NOT EXISTS openrouter_slug TEXT NOT NULL DEFAULT ''; EXCEPTION WHEN others THEN NULL; END $$`,
 		`DO $$ BEGIN ALTER TABLE model_aliases ADD COLUMN IF NOT EXISTS hugging_face_id TEXT NOT NULL DEFAULT ''; EXCEPTION WHEN others THEN NULL; END $$`,
 

--- a/coordinator/store/postgres_model_registry.go
+++ b/coordinator/store/postgres_model_registry.go
@@ -407,6 +407,11 @@ func (s *PostgresStore) UpsertModelAlias(alias *ModelAlias) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
+	sourceKind := alias.SourceKind
+	if sourceKind == "" {
+		sourceKind = ModelAliasSourceAlias
+	}
+
 	retired := alias.RetiredBuilds
 	if retired == nil {
 		retired = []string{}
@@ -416,11 +421,11 @@ func (s *PostgresStore) UpsertModelAlias(alias *ModelAlias) error {
 		return fmt.Errorf("store: marshal retired builds: %w", err)
 	}
 	_, err = s.pool.Exec(ctx, `
-		INSERT INTO model_aliases (alias_id, display_name, openrouter_only, source_model, openrouter_slug, hugging_face_id, desired_build, previous_build, retired_builds, active, created_at, updated_at)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, COALESCE(NULLIF($11::timestamptz, '0001-01-01 00:00:00+00'::timestamptz), NOW()), NOW())
+		INSERT INTO model_aliases (alias_id, display_name, openrouter_only, source_model, source_kind, openrouter_slug, hugging_face_id, desired_build, previous_build, retired_builds, active, created_at, updated_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, COALESCE(NULLIF($12::timestamptz, '0001-01-01 00:00:00+00'::timestamptz), NOW()), NOW())
 		ON CONFLICT (alias_id) DO UPDATE SET
-		  display_name = $2, openrouter_only = $3, source_model = $4, openrouter_slug = $5, hugging_face_id = $6, desired_build = $7, previous_build = $8, retired_builds = $9, active = $10, updated_at = NOW()`,
-		alias.AliasID, alias.DisplayName, alias.OpenRouterOnly, alias.SourceModel, alias.OpenRouterSlug, alias.HuggingFaceID, alias.DesiredBuild, alias.PreviousBuild, retiredJSON, alias.Active, alias.CreatedAt)
+		  display_name = $2, openrouter_only = $3, source_model = $4, source_kind = $5, openrouter_slug = $6, hugging_face_id = $7, desired_build = $8, previous_build = $9, retired_builds = $10, active = $11, updated_at = NOW()`,
+		alias.AliasID, alias.DisplayName, alias.OpenRouterOnly, alias.SourceModel, sourceKind, alias.OpenRouterSlug, alias.HuggingFaceID, alias.DesiredBuild, alias.PreviousBuild, retiredJSON, alias.Active, alias.CreatedAt)
 
 	if err != nil {
 		return fmt.Errorf("store: upsert model alias: %w", err)
@@ -435,9 +440,9 @@ func (s *PostgresStore) GetModelAlias(aliasID string) (*ModelAlias, bool, error)
 	var a ModelAlias
 	var retiredJSON []byte
 	err := s.pool.QueryRow(ctx, `
-		SELECT alias_id, display_name, openrouter_only, source_model, openrouter_slug, hugging_face_id, desired_build, previous_build, retired_builds, active, created_at, updated_at
+		SELECT alias_id, display_name, openrouter_only, source_model, source_kind, openrouter_slug, hugging_face_id, desired_build, previous_build, retired_builds, active, created_at, updated_at
 		FROM model_aliases WHERE alias_id = $1`, aliasID).
-		Scan(&a.AliasID, &a.DisplayName, &a.OpenRouterOnly, &a.SourceModel, &a.OpenRouterSlug, &a.HuggingFaceID, &a.DesiredBuild, &a.PreviousBuild, &retiredJSON, &a.Active, &a.CreatedAt, &a.UpdatedAt)
+		Scan(&a.AliasID, &a.DisplayName, &a.OpenRouterOnly, &a.SourceModel, &a.SourceKind, &a.OpenRouterSlug, &a.HuggingFaceID, &a.DesiredBuild, &a.PreviousBuild, &retiredJSON, &a.Active, &a.CreatedAt, &a.UpdatedAt)
 
 	if err == pgx.ErrNoRows {
 		return nil, false, nil
@@ -470,7 +475,7 @@ func (s *PostgresStore) ListModelAliases() ([]ModelAlias, error) {
 	defer cancel()
 
 	rows, err := s.pool.Query(ctx, `
-		SELECT alias_id, display_name, openrouter_only, source_model, openrouter_slug, hugging_face_id, desired_build, previous_build, retired_builds, active, created_at, updated_at
+		SELECT alias_id, display_name, openrouter_only, source_model, source_kind, openrouter_slug, hugging_face_id, desired_build, previous_build, retired_builds, active, created_at, updated_at
 		FROM model_aliases ORDER BY alias_id`)
 
 	if err != nil {
@@ -482,7 +487,7 @@ func (s *PostgresStore) ListModelAliases() ([]ModelAlias, error) {
 	for rows.Next() {
 		var a ModelAlias
 		var retiredJSON []byte
-		if err := rows.Scan(&a.AliasID, &a.DisplayName, &a.OpenRouterOnly, &a.SourceModel, &a.OpenRouterSlug, &a.HuggingFaceID, &a.DesiredBuild, &a.PreviousBuild, &retiredJSON, &a.Active, &a.CreatedAt, &a.UpdatedAt); err != nil {
+		if err := rows.Scan(&a.AliasID, &a.DisplayName, &a.OpenRouterOnly, &a.SourceModel, &a.SourceKind, &a.OpenRouterSlug, &a.HuggingFaceID, &a.DesiredBuild, &a.PreviousBuild, &retiredJSON, &a.Active, &a.CreatedAt, &a.UpdatedAt); err != nil {
 
 			return nil, fmt.Errorf("store: scan model alias: %w", err)
 		}

--- a/docs/reference/model-registry-format.md
+++ b/docs/reference/model-registry-format.md
@@ -166,14 +166,16 @@ OpenRouter feed clones are managed separately from rollout aliases:
 }
 ```
 
-`source_model` must be an active standard alias. The clone appears in both
-`GET /v1/models/openrouter` and the normal `GET /v1/models` catalog. OpenRouter
-and ordinary consumers can send the clone's `id` to the inference API, where it
-resolves through the source alias's current desired/previous build pointers.
-The source supplies pricing, context limits, features, readiness, capacity,
-datacenters, and every other applicable response field. Future source build
-migrations therefore update the clone automatically; only `id`,
-`openrouter.slug`, and `hugging_face_id` differ where those fields are exposed.
+`source_model` must be either an active standard alias or an active concrete
+catalog model. A standard-alias source follows its desired/previous rollout
+pointers. A concrete source routes directly to that model and remains listed
+beside the clone; the OpenRouter-only alias never drives provider convergence,
+hides its source, or becomes the source build's canonical public name.
+
+The clone appears in both `GET /v1/models/openrouter` and the normal
+`GET /v1/models` catalog. The source supplies pricing, context limits, features,
+readiness, capacity, datacenters, and every other applicable response field;
+only `id`, `openrouter.slug`, and `hugging_face_id` differ where exposed.
 
 ## Admin model actions
 

--- a/docs/reference/model-registry-format.md
+++ b/docs/reference/model-registry-format.md
@@ -167,35 +167,38 @@ OpenRouter feed clones are managed separately from rollout aliases:
 ```
 
 `source_model` must be either an active standard alias or an active concrete
-catalog model. A standard-alias source follows its desired/previous rollout
-pointers. A concrete source routes directly to that model and remains listed
-beside the clone in the dedicated feed; the OpenRouter-only alias never drives
-provider convergence, hides its source, or becomes the source build's canonical
-public name.
+model eligible for the text-only OpenRouter feed. A standard-alias source follows
+its desired/previous rollout pointers. A concrete source routes directly to that
+model and remains listed beside the clone in the dedicated feed; the
+OpenRouter-only alias never drives provider convergence, hides its source, or
+becomes the source build's canonical public name.
 
 The clone appears only in `GET /v1/models/openrouter`; it is intentionally
 omitted from the normal `GET /v1/models` list but remains retrievable through
-`GET /v1/models/{id}` for inference-client validation. The source supplies
-pricing, context limits, features, readiness, capacity, datacenters, and every
-other applicable response field. Only `id`, `openrouter.slug`, and
-`hugging_face_id` differ where exposed.
+`GET /v1/models/{id}` for inference-client validation, including while its
+concrete source has zero connected providers. The source supplies pricing,
+context limits, features, readiness, capacity, datacenters, and every other
+applicable response field. Only `id`, `openrouter.slug`, and `hugging_face_id`
+differ where exposed.
 
 Canonical enforcement:
 
-- Serialized source validation, source-kind persistence, and covered-build
-  rejection:
-  [`openrouter_alias_handlers.go:61-124`](../../coordinator/api/openrouter_alias_handlers.go#L61-L124).
+- Serialized source validation, feed-eligibility checks, source-kind persistence,
+  and covered-build rejection:
+  [`openrouter_alias_handlers.go:61-129`](../../coordinator/api/openrouter_alias_handlers.go#L61-L129).
 - The serialized reverse guard preventing a later standard alias from covering
   a pinned concrete source:
   [`model_alias_handlers.go:74-171`](../../coordinator/api/model_alias_handlers.go#L74-L171).
 - Request-routing resolution without provider convergence or canonical-name
   ownership:
   [`server.go:1037-1078`](../../coordinator/api/server.go#L1037-L1078).
+- Durable concrete metadata and the shared feed-eligibility rule:
+  [`concrete_model_entries.go:61-147`](../../coordinator/api/concrete_model_entries.go#L61-L147).
 - Standard-list exclusion, exact-id retrieval, and dedicated OpenRouter-feed
   cloning:
   [`models_endpoints.go:26-49`](../../coordinator/api/models_endpoints.go#L26-L49),
-  [`models_endpoints.go:319-370`](../../coordinator/api/models_endpoints.go#L319-L370),
-  and [`openrouter_endpoint.go:163-183`](../../coordinator/api/openrouter_endpoint.go#L163-L183).
+  [`models_endpoints.go:319-384`](../../coordinator/api/models_endpoints.go#L319-L384),
+  and [`openrouter_endpoint.go:157-177`](../../coordinator/api/openrouter_endpoint.go#L157-L177).
 
 ## Admin model actions
 

--- a/docs/reference/model-registry-format.md
+++ b/docs/reference/model-registry-format.md
@@ -169,13 +169,29 @@ OpenRouter feed clones are managed separately from rollout aliases:
 `source_model` must be either an active standard alias or an active concrete
 catalog model. A standard-alias source follows its desired/previous rollout
 pointers. A concrete source routes directly to that model and remains listed
-beside the clone; the OpenRouter-only alias never drives provider convergence,
-hides its source, or becomes the source build's canonical public name.
+beside the clone in the dedicated feed; the OpenRouter-only alias never drives
+provider convergence, hides its source, or becomes the source build's canonical
+public name.
 
-The clone appears in both `GET /v1/models/openrouter` and the normal
-`GET /v1/models` catalog. The source supplies pricing, context limits, features,
-readiness, capacity, datacenters, and every other applicable response field;
-only `id`, `openrouter.slug`, and `hugging_face_id` differ where exposed.
+The clone appears only in `GET /v1/models/openrouter`; it is intentionally
+omitted from the normal `GET /v1/models` catalog. The source supplies pricing,
+context limits, features, readiness, capacity, datacenters, and every other
+applicable response field. Only `id`, `openrouter.slug`, and `hugging_face_id`
+differ where exposed.
+
+Canonical enforcement:
+
+- Source validation, source-kind persistence, and the covered-build rejection:
+  [`openrouter_alias_handlers.go:62-117`](../../coordinator/api/openrouter_alias_handlers.go#L62-L117).
+- The reverse guard preventing a later standard alias from covering a pinned
+  concrete source:
+  [`model_alias_handlers.go:134-153`](../../coordinator/api/model_alias_handlers.go#L134-L153).
+- Request-routing resolution without provider convergence or canonical-name
+  ownership:
+  [`server.go:1036-1077`](../../coordinator/api/server.go#L1036-L1077).
+- Standard-catalog exclusion and dedicated OpenRouter-feed cloning:
+  [`models_endpoints.go:26-49`](../../coordinator/api/models_endpoints.go#L26-L49) and
+  [`openrouter_endpoint.go:163-183`](../../coordinator/api/openrouter_endpoint.go#L163-L183).
 
 ## Admin model actions
 

--- a/docs/reference/model-registry-format.md
+++ b/docs/reference/model-registry-format.md
@@ -174,24 +174,28 @@ provider convergence, hides its source, or becomes the source build's canonical
 public name.
 
 The clone appears only in `GET /v1/models/openrouter`; it is intentionally
-omitted from the normal `GET /v1/models` catalog. The source supplies pricing,
-context limits, features, readiness, capacity, datacenters, and every other
-applicable response field. Only `id`, `openrouter.slug`, and `hugging_face_id`
-differ where exposed.
+omitted from the normal `GET /v1/models` list but remains retrievable through
+`GET /v1/models/{id}` for inference-client validation. The source supplies
+pricing, context limits, features, readiness, capacity, datacenters, and every
+other applicable response field. Only `id`, `openrouter.slug`, and
+`hugging_face_id` differ where exposed.
 
 Canonical enforcement:
 
-- Source validation, source-kind persistence, and the covered-build rejection:
-  [`openrouter_alias_handlers.go:62-117`](../../coordinator/api/openrouter_alias_handlers.go#L62-L117).
-- The reverse guard preventing a later standard alias from covering a pinned
-  concrete source:
-  [`model_alias_handlers.go:134-153`](../../coordinator/api/model_alias_handlers.go#L134-L153).
+- Serialized source validation, source-kind persistence, and covered-build
+  rejection:
+  [`openrouter_alias_handlers.go:61-124`](../../coordinator/api/openrouter_alias_handlers.go#L61-L124).
+- The serialized reverse guard preventing a later standard alias from covering
+  a pinned concrete source:
+  [`model_alias_handlers.go:74-171`](../../coordinator/api/model_alias_handlers.go#L74-L171).
 - Request-routing resolution without provider convergence or canonical-name
   ownership:
-  [`server.go:1036-1077`](../../coordinator/api/server.go#L1036-L1077).
-- Standard-catalog exclusion and dedicated OpenRouter-feed cloning:
-  [`models_endpoints.go:26-49`](../../coordinator/api/models_endpoints.go#L26-L49) and
-  [`openrouter_endpoint.go:163-183`](../../coordinator/api/openrouter_endpoint.go#L163-L183).
+  [`server.go:1037-1078`](../../coordinator/api/server.go#L1037-L1078).
+- Standard-list exclusion, exact-id retrieval, and dedicated OpenRouter-feed
+  cloning:
+  [`models_endpoints.go:26-49`](../../coordinator/api/models_endpoints.go#L26-L49),
+  [`models_endpoints.go:319-370`](../../coordinator/api/models_endpoints.go#L319-L370),
+  and [`openrouter_endpoint.go:163-183`](../../coordinator/api/openrouter_endpoint.go#L163-L183).
 
 ## Admin model actions
 


### PR DESCRIPTION
## Summary

- allow OpenRouter-only aliases to clone an active, text-feed-eligible concrete catalog model as well as a standard rollout alias
- persist source kind so later alias takeovers cannot silently retarget a concrete-source clone
- serialize both alias mutation endpoints and reject ownership conflicts in both directions
- expose OpenRouter-only aliases only through `/v1/models/openrouter`; omit them from the `/v1/models` list while preserving exact `GET /v1/models/{id}` retrieval, including at zero connected providers
- share source pricing, limits, features, readiness, capacity, and datacenters in the dedicated feed

## Before

```mermaid
flowchart LR
  subgraph Behavior
    A[Create OpenRouter alias] --> B{Source type}
    B -->|Standard alias| C[Alias created]
    B -->|Concrete model| D[400 invalid source]
    C --> E[Alias also exposed in standard catalog]
  end
  subgraph Code
    F[handleOpenRouterAliasUpsert] --> G[GetModelAlias only]
    H[syncModelAliases] --> I[Resolve standard targets only]
    J[Both catalog builders] --> K[Clone standardEntries]
  end
```

## After

```mermaid
flowchart LR
  subgraph Behavior
    A[Create OpenRouter alias] --> B{Persisted source kind}
    B -->|Standard alias| C[Follow desired and previous builds]
    B -->|Eligible concrete model| D[Route directly to concrete build]
    D --> E[Concrete source remains listed]
    C --> F[Dedicated OpenRouter feed]
    D --> F
    F --> G[Source and clone listed]
    H[Standard model list] --> I[OpenRouter clone omitted]
    J[Retrieve exact clone ID] --> K[Catalog metadata returned without live provider]
  end
  subgraph Code
    L[Alias mutation mutex] --> M[Validate ownership and feed eligibility]
    M --> N[Persist source_kind]
    N --> O[syncModelAliases]
    O --> P[OpenRouterOnly AliasTarget]
    P --> Q[No convergence or canonical-name ownership]
    N --> R[Dedicated feed clone builder]
    S[handleGetModel] --> T[Durable concrete entry builder]
  end
```

## Verification

- `go test ./api ./store -run 'Test(OpenRouterAlias|StandardAlias|AliasMutationEndpoints|ConcreteModelEligible|MemoryModelAliasRoundTrip)' -count=1`
- `go test ./...` — 24 packages passed; 3 packages have no tests
