### PR TITLE
fix(qwen): roll back v0.8.8 runtime regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v0.8.9 (2026-08-21)
+
+### Provider (Swift)
+
+#### Fixes
+
+- **Emergency Qwen3.6 runtime rollback** — Restores the v0.8.7 `mlx-swift-lm` pin (`ab73a827`) and removes v0.8.8's default-on GDN four-input projection fusion and direct weighted-expert reduction. In the fixed one-hour production comparison, Qwen success fell 85.52%→65.79%, p50 decode fell 38→26 tok/s, client timeouts approximately doubled, and the hard TTFT gate emitted 612 429s (602 marked counterfactually serveable). M1/M2 providers regressed even though they cannot use affine `qmv_wide`, isolating the Qwen runtime changes as the first rollback target. Gemma's merged `qmv_wide` MLX/MLX-Swift pins remain enabled for continued benefit and separate attribution.
+- **Restore the retained runtime-smoke contract** — Removes the retired Qwen process-global reduction key from serving projection, launchd passthrough, signed-child validation, and benchmark-report expectations. Provider artifact verification returns to the three retained Gemma controls.
+
 ## v0.8.8 (2026-08-21)
 
 ### Provider (Swift)

--- a/coordinator/api/server.go
+++ b/coordinator/api/server.go
@@ -151,7 +151,7 @@ func keyLimitResetFromContext(ctx context.Context) string {
 // the provider's EngineV2Factory.prepareProductionBackend for the argument).
 // Keep this fallback in sync with ProviderCore.version so dev/in-memory
 // coordinators advertise the same floor as the Swift binary they expect.
-var LatestProviderVersion = "0.8.8"
+var LatestProviderVersion = "0.8.9"
 
 // minProviderVersionForDesiredModels is the first provider version whose Swift
 // runtime understands the desired_models message. The coordinator must NOT send

--- a/docs/reports/2026-08-21-qwen-prefill-retained-optimizations.md
+++ b/docs/reports/2026-08-21-qwen-prefill-retained-optimizations.md
@@ -1,6 +1,7 @@
 # Qwen Prefill Retained Optimizations on Current Master
 
 **Date:** 2026-08-21  
+**Status:** Rolled back for v0.8.9 after v0.8.8 production decode and uptime regression; retained measurements remain prefill-only evidence.
 **Base:** `origin/master` at `937a8a1d1` (through PR #650)  
 **Branch:** `perf/qwen-prefill-retained`
 

--- a/provider-swift/Sources/ProviderCore/Config/GemmaOptimizationEnvironment.swift
+++ b/provider-swift/Sources/ProviderCore/Config/GemmaOptimizationEnvironment.swift
@@ -6,7 +6,6 @@ public enum GemmaOptimizationEnvironment {
     public static let prefillLayer18Key = "DARKBLOOM_GEMMA4_PREFILL_CHUNK_EVAL"
     public static let weightedUnsortKey = "MLX_GEMMA4_FUSED_WEIGHTED_UNSORT"
     public static let safeR1Key = "MLX_GATHER_QMM_EXPERT_SLICES"
-    public static let qwenDirectExpertReductionKey = "MLX_QWEN_DIRECT_EXPERT_REDUCTION"
     /// Serving default when the expert-slice route is ON: skip the
     /// descriptor-retract readback (no mid-eval stream drain). The tile grid
     /// is already over-dispatched; unused slots early-return.
@@ -58,13 +57,10 @@ public enum GemmaOptimizationEnvironment {
         } else {
             safeR1 = "0"
         }
-        let qwenDirectReduction = context == .serving
-            && getenv(qwenDirectExpertReductionKey) == "0" ? "0" : "1"
         return [
             prefillLayer18Key: settings.prefillLayer18 ? "18" : "0",
             weightedUnsortKey: weightedR1,
             safeR1Key: safeR1,
-            qwenDirectExpertReductionKey: qwenDirectReduction,
         ]
     }
 

--- a/provider-swift/Sources/ProviderCore/Inference/PackagedRuntimeSmoke.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/PackagedRuntimeSmoke.swift
@@ -104,7 +104,6 @@ public enum PackagedRuntimeSmoke {
             GemmaOptimizationEnvironment.prefillLayer18Key: "18",
             GemmaOptimizationEnvironment.weightedUnsortKey: "1",
             GemmaOptimizationEnvironment.safeR1Key: "1",
-            GemmaOptimizationEnvironment.qwenDirectExpertReductionKey: "1",
         ]
         guard projection == expected else {
             throw VerificationError.unexpectedProjection(projection)

--- a/provider-swift/Sources/ProviderCore/ProviderCore.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderCore.swift
@@ -233,5 +233,9 @@ public enum ProviderCore {
     // matrix-sized inputs remain on QMM, and gathered expert projections are
     // unchanged. Existing Gemma and CBv2 default-on optimization postures stay
     // enabled; no beta flag or provider-config migration is required.
-    public static let version = "0.8.8"
+    // 0.8.9 rolls Qwen3.6 execution back to the v0.8.7 mlx-swift-lm pin after
+    // v0.8.8's GDN input fusion/direct expert reduction reduced production
+    // decode throughput and triggered client timeouts. The Gemma qmv_wide
+    // MLX/MLX-Swift pins remain enabled.
+    public static let version = "0.8.9"
 }

--- a/provider-swift/Sources/ProviderCore/Service/LaunchAgent.swift
+++ b/provider-swift/Sources/ProviderCore/Service/LaunchAgent.swift
@@ -291,7 +291,6 @@ public enum LaunchAgent: Sendable {
         "DARKBLOOM_MLX_RESOURCE_DEBUG", "DARKBLOOM_CBV2_PAGED_KV",
         "DARKBLOOM_CBV2_MTP", "DARKBLOOM_MTP_MAX_RECTANGULAR_TOKENS",
         "DARKBLOOM_KV_BACKEND_GUARD",
-        GemmaOptimizationEnvironment.qwenDirectExpertReductionKey,
         "DARKBLOOM_MLX_CACHE_LIMIT_GB", "DARKBLOOM_MLX_MEMORY_RESERVE_GB",
     ]
 

--- a/provider-swift/Tests/ProviderCoreTests/GemmaOptimizationConfigTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/GemmaOptimizationConfigTests.swift
@@ -83,7 +83,6 @@ struct GemmaOptimizationEnvironmentTests {
         "DARKBLOOM_GEMMA4_PREFILL_CHUNK_EVAL",
         "MLX_GEMMA4_FUSED_WEIGHTED_UNSORT",
         "MLX_GATHER_QMM_EXPERT_SLICES",
-        "MLX_QWEN_DIRECT_EXPERT_REDUCTION",
     ]
 
     @Test("projection emits the selected controls")
@@ -96,7 +95,6 @@ struct GemmaOptimizationEnvironmentTests {
             "DARKBLOOM_GEMMA4_PREFILL_CHUNK_EVAL": "18",
             "MLX_GEMMA4_FUSED_WEIGHTED_UNSORT": "1",
             "MLX_GATHER_QMM_EXPERT_SLICES": "trust",
-            "MLX_QWEN_DIRECT_EXPERT_REDUCTION": "1",
         ])
 
         let disabled = GemmaOptimizationEnvironment.projection(
@@ -110,27 +108,7 @@ struct GemmaOptimizationEnvironmentTests {
             "DARKBLOOM_GEMMA4_PREFILL_CHUNK_EVAL": "0",
             "MLX_GEMMA4_FUSED_WEIGHTED_UNSORT": "0",
             "MLX_GATHER_QMM_EXPERT_SLICES": "0",
-            "MLX_QWEN_DIRECT_EXPERT_REDUCTION": "1",
         ])
-    }
-
-    @Test("Qwen direct reduction defaults on and honors serving rollback")
-    func qwenDirectReductionDefaultAndRollback() {
-        let enabled = GemmaOptimizationEnvironment.projection(
-            for: GemmaOptimizationSettings(), getenv: { _ in nil })
-        #expect(enabled[GemmaOptimizationEnvironment.qwenDirectExpertReductionKey] == "1")
-
-        let rolledBack = GemmaOptimizationEnvironment.projection(
-            for: GemmaOptimizationSettings(),
-            getenv: { key in
-                key == GemmaOptimizationEnvironment.qwenDirectExpertReductionKey ? "0" : nil
-            })
-        #expect(rolledBack[GemmaOptimizationEnvironment.qwenDirectExpertReductionKey] == "0")
-
-        let validation = GemmaOptimizationEnvironment.projection(
-            for: GemmaOptimizationSettings(), context: .retainedValidation,
-            getenv: { _ in "0" })
-        #expect(validation[GemmaOptimizationEnvironment.qwenDirectExpertReductionKey] == "1")
     }
 
     @Test("weighted unsort and safe R1 stay coupled on or off")
@@ -261,7 +239,6 @@ struct GemmaOptimizationEnvironmentTests {
             "DARKBLOOM_GEMMA4_PREFILL_CHUNK_EVAL": "0",
             "MLX_GEMMA4_FUSED_WEIGHTED_UNSORT": "1",
             "MLX_GATHER_QMM_EXPERT_SLICES": "trust",
-            "MLX_QWEN_DIRECT_EXPERT_REDUCTION": "1",
         ])
         // The application boundary must hand the environment exactly what
         // projection() reports, or the release matrix describes a dispatch

--- a/provider-swift/Tests/ProviderCoreTests/GemmaOptimizationReportingTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/GemmaOptimizationReportingTests.swift
@@ -72,10 +72,9 @@ struct PackagedRetainedGemmaSmokeTests {
         GemmaOptimizationEnvironment.prefillLayer18Key: "18",
         GemmaOptimizationEnvironment.weightedUnsortKey: "1",
         GemmaOptimizationEnvironment.safeR1Key: "1",
-        GemmaOptimizationEnvironment.qwenDirectExpertReductionKey: "1",
     ]
 
-    @Test("synthetic retained config has an exact four-key projection")
+    @Test("synthetic retained config has an exact three-key projection")
     func exactProjectionAndNoRejectedKeys() throws {
         let config = try PackagedRuntimeSmoke.retainedConfiguration()
         // Mirror verifyGemmaOptimizations: the smoke validates the retained

--- a/provider-swift/Tests/ProviderCoreTests/LaunchAgentRestartTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/LaunchAgentRestartTests.swift
@@ -83,14 +83,6 @@ struct LaunchAgentEnvironmentTests {
         #expect(out == ["DARKBLOOM_MTP_MAX_RECTANGULAR_TOKENS": "4"])
     }
 
-    @Test func forwardsQwenDirectReductionRollbackToDaemon() {
-        let out = LaunchAgent.passthroughEnvironment(from: [
-            GemmaOptimizationEnvironment.qwenDirectExpertReductionKey: "0",
-            "PATH": "/usr/bin",
-        ])
-        #expect(out == [GemmaOptimizationEnvironment.qwenDirectExpertReductionKey: "0"])
-    }
-
     @Test func excludesConfigBackedGemmaControlsFromDaemonEnvironment() {
         let out = LaunchAgent.passthroughEnvironment(from: [
             "DARKBLOOM_PREFIX_CACHE": "0",

--- a/provider-swift/Tests/ProviderCoreTests/ThroughputSweepTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ThroughputSweepTests.swift
@@ -237,7 +237,6 @@ struct ThroughputSweepReportTests {
             GemmaOptimizationEnvironment.prefillLayer18Key: "18",
             GemmaOptimizationEnvironment.weightedUnsortKey: "1",
             GemmaOptimizationEnvironment.safeR1Key: "trust",
-            GemmaOptimizationEnvironment.qwenDirectExpertReductionKey: "1",
         ])
         #expect(decoded.schemaVersion == ThroughputSweepReport.currentSchemaVersion)
     }


### PR DESCRIPTION
## Summary

Prepare provider v0.8.9 as a targeted rollback of the Qwen3.6 runtime changes introduced in v0.8.8 while retaining Gemma's merged `qmv_wide` improvement.

- pin `libs/mlx-swift-lm` from `1483827` back to the v0.8.7 runtime `ab73a827`;
- remove process-global default enablement and launchd passthrough for Qwen direct expert reduction;
- restore signed runtime-smoke/report expectations to the three retained Gemma controls;
- bump `ProviderCore.version` and coordinator `LatestProviderVersion` to 0.8.9;
- record the production incident and rollback in the changelog/report status.

MLX and MLX-Swift remain pinned at `0a725e30` / `606d28cf`, so `qmv_wide` remains enabled for Gemma and independently observable after rollback.

## Incident evidence

Fixed one-hour production windows around the first v0.8.8 route:

| Qwen metric | Before | After | Change |
|---|---:|---:|---:|
| Success rate | 85.52% | 65.79% | **-19.73 points** |
| p50 decode TPS | 38 | 26 | **-31.6%** |
| p25 decode TPS | 24 | 16 | **-33.3%** |
| Routing TPS estimate | 75.71 | 45.77 | **-39.5%** |
| Queue timeouts | 0 | 73 | regression |
| First-chunk timeouts | 2 | 10 | 5x |
| Provider errors | 31 | 69 | 2.2x |

The post-release workload was easier (average prompt 3,205→1,468 tokens and output 400→198), so request-shape drift does not explain slower decode.

The rejection ledger recorded 612 post-release Qwen `ttft_too_slow` 429s; 602 were marked `could_have_served=true`. M1/M2 providers also regressed even though they cannot use generation-15+ affine `qmv_wide`, excluding QMV-wide as the sole cause and making Qwen PR #112 the first rollback target.

## Before

```mermaid
flowchart LR
  subgraph Code[Code path in v0.8.8]
    A[Qwen forward] --> B[30 GDN layers]
    B --> C[prepareFusedInputProjection every forward]
    C --> D[Lazy 4-in-1 quantized projection]
    A --> E[SwitchGLU caller]
    E --> F[isProductionPrefill hardcoded true]
    F --> G[Default direct expert reduction]
  end
  subgraph Behavior[Production behavior]
    H[Provider updates] --> I[First-request fusion and memory pressure]
    D --> J[Small-M decode regression]
    G --> J
    J --> K[Observed TPS falls]
    K --> L[504/client_gone and TTFT 429 amplification]
  end
  C --> I
```

## After

```mermaid
flowchart LR
  subgraph Code[Code path in v0.8.9]
    A[Qwen forward] --> B[v0.8.7 mlx-swift-lm ab73a827]
    B --> C[Separate proven QKV/Z/B/A projections]
    B --> D[Legacy weighted expert reduction]
    E[MLX qmv_wide pins] --> F[Remain available for Gemma]
  end
  subgraph Behavior[Expected recovery]
    C --> G[No lazy 30-layer fusion on first request]
    C --> H[No per-token fusion eligibility traversal]
    D --> I[Known Qwen decode behavior restored]
    G --> J[Decode TPS and first-chunk reliability recover]
    H --> J
    I --> J
  end
```

## Paired local Qwen validation

Production Qwen artifact `EigenLabs/Qwen3.6-35B-A3B-MLX-VL-4bit-g64-router8-mtp`; source-matched release binaries/metallibs; contiguous KV; 128 generated tokens per sequence. Both arms retain identical QMV-wide MLX/MLX-Swift pins, isolating `mlx-swift-lm` PR #112.

| Context | Batch | v0.8.8 agg TPS | v0.8.9 agg TPS | Delta |
|---:|---:|---:|---:|---:|
| 512 | 1 | 100.28 | 112.63 | **+12.31%** |
| 512 | 2 | 164.84 | 178.62 | **+8.36%** |
| 512 | 4 | 238.50 | 252.48 | **+5.86%** |
| 8K | 1 | 95.15 | 101.17 | **+6.33%** |
| 8K | 2 | 139.89 | 149.98 | **+7.21%** |
| 8K | 4 | 205.99 | 217.89 | **+5.78%** |

Rollback wins every measured cell. B=1 improvement is especially important because it matches the production cross-generation regression and does not depend on batch stationarity.

## Verification

- Focused config/report/launch/runtime-smoke suites: **70 tests in 13 suites passed**.
- `make provider-test`: **2,118 tests in 217 suites passed**.
- Source-matched release build and `mlx.metallib` succeeded.
- Release runtime smoke:
  - `gemma-optimizations-runtime-smoke: ok`
  - `paged-kernel-runtime-smoke: ok`
- `./scripts/check-release-version.sh v0.8.9 0.8.9`: passed.
- Built CLI reports `0.8.9`.
- Pre-push checks passed.

## Scope

- No coordinator TTFT/admission-policy change is combined with this rollback.
- No Gemma optimization is disabled.
- No MLX/MLX-Swift pin is changed.
- Historical prefill measurements remain documented but are explicitly marked prefill-only and rolled back for production decode safety.

## Post-merge

Tag the exact reviewed merge commit as `v0.8.9`, publish through the signed/notarized provider workflow, and watch Qwen five-minute success, `client_gone`, provider failure, TTFT-429, and p50 decode TPS cells before any future Qwen optimization is reintroduced.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/659"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789944878&installation_model_id=21733&pr_number=659&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F659&signature=c40c43e2fabf8cfdefd96a52b70f3e44a77e0ea671085b5ed6aadec6083a023a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->