### PR TITLE
fix(provider): stop one oversized vision request from killing the daemon

### DIFF
--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2VisionPrefill.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2VisionPrefill.swift
@@ -49,6 +49,20 @@
 // oversized media, or an intentionally unsupported family/media pairing) keep
 // their 4xx mapping and are not refusals.
 //
+// FAIL-LOUD REQUIRES SURVIVING (v0.8.10): a refusal contract is only worth
+// what the process is worth, and MLX's default error handler is `fatalError`
+// — a C++ fault under this file used to kill the daemon outright, with every
+// co-batched request on it. Two changes close that:
+//
+//   1. `prepare` runs under `MLX.withError`, so an MLX fault becomes a Swift
+//      throw the catch arms above already handle (one failed request, not one
+//      dead provider).
+//   2. The Qwen tower is driven ONE IMAGE AT A TIME and each image is admitted
+//      against `MTLDevice.maxBufferLength` first (`VisionTowerBudget`), so the
+//      dominant fault — the tower's dense `[1, N, N]` attention mask growing
+//      quadratically in the request's TOTAL patch count — is neither produced
+//      nor left for the allocator to discover. See `EngineV2VisionTowerRun`.
+//
 // BACKEND NOTE: CBv2 multimodal prefill requires a KV backend whose layer
 // caches AFFIRM `CBv2MultimodalSpanCapableCache.honorsSpanMaskContexts`;
 // one that does not vouch rejects at submit with
@@ -122,6 +136,26 @@ enum EngineV2VisionPrefillError: Error, CustomStringConvertible {
     /// A vision feature has a non-positive soft-token length.
     case invalidFeatureLength(
         kind: EngineV2VisionPrefill.SpanKind, mediaIndex: Int, length: Int)
+    /// A processor grid has a non-positive or unrepresentable patch count, so
+    /// its pixel rows cannot be located in the packed tensor.
+    case invalidVisionGrid(mediaIndex: Int)
+    /// The processor's grids do not tile its packed pixel tensor exactly.
+    /// Slicing on that disagreement would feed one image's pixels through
+    /// another image's grid, so the prefill refuses instead.
+    case visionPixelRunMismatch(expected: Int, actual: Int)
+    /// The vision tower's projected activation would exceed what this GPU can
+    /// allocate, predicted from the processor's grids BEFORE any tower work.
+    /// Device-dependent, so it refuses retriably: a machine with a larger
+    /// `MTLDevice.maxBufferLength` can serve the same request. The detail is
+    /// built from integers and literals only (`VisionTowerBudget`).
+    case towerBudgetExceeded(String)
+    /// MLX refused an allocation the vision tower asked for. Carries only the
+    /// two integers MLX itself reported — never its message — so the enum's
+    /// content-safe-by-construction invariant survives a foreign fault.
+    case towerAllocationRefused(requestedBytes: UInt64, limitBytes: UInt64)
+    /// MLX raised a fault the tower could not attribute to an allocation.
+    /// Content-free by construction: the stage name is a literal.
+    case towerFault(stage: String)
 
     var description: String {
         switch self {
@@ -148,6 +182,18 @@ enum EngineV2VisionPrefillError: Error, CustomStringConvertible {
         case .invalidFeatureLength(let kind, let index, let length):
             return "engine_v2 media prefill: \(kind.noun) \(index) produced an invalid "
                 + "soft-token count \(length)"
+        case .invalidVisionGrid(let index):
+            return "engine_v2 media prefill: image \(index) has an unusable patch grid"
+        case .visionPixelRunMismatch(let expected, let actual):
+            return "engine_v2 media prefill: image grids cover \(actual) of \(expected) "
+                + "packed pixel rows"
+        case .towerBudgetExceeded(let detail):
+            return "engine_v2 media prefill: \(detail)"
+        case .towerAllocationRefused(let requested, let limit):
+            return "engine_v2 media prefill: the vision tower asked MLX for \(requested) B "
+                + "in one buffer, above this GPU's \(limit) B limit"
+        case .towerFault(let stage):
+            return "engine_v2 media prefill: MLX raised a fault during \(stage)"
         }
     }
 }
@@ -247,134 +293,224 @@ public enum EngineV2VisionPrefill {
         // rasterizes its frames; no plaintext file exists to clean up.
         let userInput = try await MediaIngest.buildUserInput(
             from: request, reasoningEffort: reasoningEffort)
+        let towerLimits = VisionTowerBudget.liveLimits()
         return try await container.perform(nonSendable: userInput) { ctx, userInput in
-            let lmInput = try await ctx.processor.prepare(input: userInput)
-            guard lmInput.image != nil || lmInput.video != nil else {
-                throw EngineV2VisionPrefillError.noProcessedMedia
+            // MLX's DEFAULT error handler is `fatalError`. A C++ fault raised
+            // anywhere under this closure — most consequentially an allocation
+            // the Metal allocator refuses because it exceeds
+            // `MTLDevice.maxBufferLength` — therefore used to kill the whole
+            // provider process, taking every co-batched request with it and
+            // leaving a stale pid file behind (v0.8.7, 8 crashes in 9 hours on
+            // one node). `withError` installs a task-local handler for the
+            // duration of the prefill, so the same fault becomes a Swift throw
+            // that the scheduler's existing catch arms turn into one failed
+            // request. It is the LAST line of defence: `VisionTowerBudget`
+            // refuses the predictable cases deterministically, up front.
+            do {
+                return try await MLX.withError {
+                    try await Self.buildSubmission(
+                        ctx: ctx, userInput: userInput, towerLimits: towerLimits)
+                }
+            } catch let mlxError as MLX.MLXError {
+                throw Self.visionPrefillError(for: mlxError)
             }
-
-            // [1, L] → [Int]. Forces evaluation of the (tiny, host-built)
-            // token array only.
-            let promptTokens = lmInput.text.tokens.asArray(Int32.self).map(Int.init)
-
-            if let wrapper = ctx.model as? MLXVLM.Qwen35MoE {
-                // Video remains fail-closed until a real processor/output
-                // representation canary pins temporal packing end-to-end.
-                guard lmInput.video == nil else {
-                    throw EngineV2VisionPrefillError.unsupportedMedia(
-                        "Qwen35MoE video media is not production-proven")
-                }
-                guard let image = lmInput.image else {
-                    throw EngineV2VisionPrefillError.noProcessedMedia
-                }
-                let features = try wrapper.visionFeatures(
-                    imagePixels: image.pixels, imageGrids: image.frames)
-                let imageFeatures = features.ordered.map(\.features)
-                guard !imageFeatures.isEmpty else {
-                    throw EngineV2VisionPrefillError.emptyVisionFeatures(kind: .image)
-                }
-                let carved = try carveSpans(
-                    tokens: promptTokens,
-                    imagePlaceholderId: wrapper.imagePlaceholderTokenId,
-                    imageSpanLengths: imageFeatures.map { $0.dim(1) },
-                    videoPlaceholderId: nil,
-                    videoSpanLengths: [])
-                let position = try wrapper.positionResult(
-                    tokens: lmInput.text.tokens,
-                    imageGrids: image.frames,
-                    attentionMask: lmInput.text.mask)
-                eval(imageFeatures + [position.promptPositionIds])
-                return PreparedSubmission(
-                    promptTokens: promptTokens,
-                    spans: carved.map(\.span),
-                    embeddings: imageFeatures,
-                    attention: .causal,
-                    positionState: CBv2PositionState(
-                        promptPositionIds: position.promptPositionIds,
-                        decodeDeltas: position.decodeState.deltas),
-                    mediaKind: .image)
-            }
-
-            guard let wrapper = ctx.model as? MLXVLM.Gemma4 else {
-                throw EngineV2VisionPrefillError.unsupportedVLM(
-                    String(describing: type(of: ctx.model)))
-            }
-
-            // Vision tower + multimodal projector — the SAME arrays the
-            // wrapper's own `prepare` scatters: one per image, one per
-            // sampled video frame (the video seam applies the per-frame
-            // video patch budget, ~70 soft tokens per frame vs 280 per
-            // image).
-            var imageFeatures: [MLXArray] = []
-            if let image = lmInput.image {
-                imageFeatures = wrapper.perImageVisionFeatures(
-                    pixels: image.pixels, frames: image.frames)
-                guard !imageFeatures.isEmpty else {
-                    throw EngineV2VisionPrefillError.emptyVisionFeatures(kind: .image)
-                }
-            }
-            var videoFeatures: [MLXArray] = []
-            var videoPlaceholderId: Int?
-            if let video = lmInput.video {
-                guard let videoId = wrapper.videoPlaceholderTokenId else {
-                    throw EngineV2VisionPrefillError.videoPlaceholderUnavailable
-                }
-                videoPlaceholderId = videoId
-                videoFeatures = wrapper.perVideoFrameVisionFeatures(
-                    pixels: video.pixels, frames: video.frames)
-                guard !videoFeatures.isEmpty else {
-                    throw EngineV2VisionPrefillError.emptyVisionFeatures(kind: .video)
-                }
-            }
-
-            // A kind's placeholder id is watched ONLY when that kind has
-            // features — mirroring the processor, which expands a
-            // placeholder only when it produced the matching pixels (a
-            // stray placeholder id of an absent kind stays an ordinary
-            // embedded token on both paths).
-            let carved = try carveSpans(
-                tokens: promptTokens,
-                imagePlaceholderId: imageFeatures.isEmpty
-                    ? nil : wrapper.imagePlaceholderTokenId,
-                imageSpanLengths: imageFeatures.map { $0.dim(1) },
-                videoPlaceholderId: videoPlaceholderId,
-                videoSpanLengths: videoFeatures.map { $0.dim(1) })
-
-            // Pair prompt-ordered spans back to their features. `carveSpans`
-            // consumed each kind's features strictly in prompt order, so
-            // walking its output with per-kind cursors reproduces the exact
-            // pairing (interleaved image/video requests keep their
-            // interleave; the engine receives spans and embeddings as
-            // parallel arrays).
-            var embeddings: [MLXArray] = []
-            embeddings.reserveCapacity(carved.count)
-            var imageCursor = 0
-            var videoCursor = 0
-            for entry in carved {
-                switch entry.kind {
-                case .image:
-                    embeddings.append(imageFeatures[imageCursor])
-                    imageCursor += 1
-                case .video:
-                    embeddings.append(videoFeatures[videoCursor])
-                    videoCursor += 1
-                }
-            }
-
-            // Materialize the tower output HERE — on the request's task,
-            // under container isolation — not lazily on the engine's step
-            // thread (where the fused tower graph would stall every
-            // co-batched request's decode step for the duration).
-            eval(embeddings)
-            return PreparedSubmission(
-                promptTokens: promptTokens,
-                spans: carved.map(\.span),
-                embeddings: embeddings,
-                attention: .bidirectionalSpans,
-                positionState: nil,
-                mediaKind: lmInput.video == nil
-                    ? .image : (lmInput.image == nil ? .video : .mixed))
         }
+    }
+
+    /// Run the processor, then dispatch to the loaded family's builder. Runs
+    /// under the container's serial isolation, with MLX faults routed into
+    /// Swift throws by the caller.
+    private static func buildSubmission(
+        ctx: ModelContext,
+        userInput: UserInput,
+        towerLimits: VisionTowerBudget.Limits
+    ) async throws -> PreparedSubmission {
+        let lmInput = try await ctx.processor.prepare(input: userInput)
+        guard lmInput.image != nil || lmInput.video != nil else {
+            throw EngineV2VisionPrefillError.noProcessedMedia
+        }
+
+        // [1, L] → [Int]. Forces evaluation of the (tiny, host-built)
+        // token array only.
+        let promptTokens = lmInput.text.tokens.asArray(Int32.self).map(Int.init)
+
+        if let wrapper = ctx.model as? MLXVLM.Qwen35MoE {
+            return try buildQwenSubmission(
+                wrapper: wrapper, lmInput: lmInput, promptTokens: promptTokens,
+                towerLimits: towerLimits)
+        }
+        guard let wrapper = ctx.model as? MLXVLM.Gemma4 else {
+            throw EngineV2VisionPrefillError.unsupportedVLM(
+                String(describing: type(of: ctx.model)))
+        }
+        return try buildGemmaSubmission(
+            wrapper: wrapper, lmInput: lmInput, promptTokens: promptTokens)
+    }
+
+    /// Qwen3-VL: causal visual tokens, M-RoPE position state, and a vision
+    /// tower driven ONE IMAGE AT A TIME (see `qwenPerImageVisionFeatures`).
+    private static func buildQwenSubmission(
+        wrapper: MLXVLM.Qwen35MoE,
+        lmInput: LMInput,
+        promptTokens: [Int],
+        towerLimits: VisionTowerBudget.Limits
+    ) throws -> PreparedSubmission {
+        // Video remains fail-closed until a real processor/output
+        // representation canary pins temporal packing end-to-end.
+        guard lmInput.video == nil else {
+            throw EngineV2VisionPrefillError.unsupportedMedia(
+                "Qwen35MoE video media is not production-proven")
+        }
+        guard let image = lmInput.image, let grids = image.frames, !grids.isEmpty else {
+            throw EngineV2VisionPrefillError.noProcessedMedia
+        }
+        let imageFeatures = try qwenPerImageVisionFeatures(
+            wrapper: wrapper, pixels: image.pixels, grids: grids, towerLimits: towerLimits)
+        let carved = try carveSpans(
+            tokens: promptTokens,
+            imagePlaceholderId: wrapper.imagePlaceholderTokenId,
+            imageSpanLengths: imageFeatures.map { $0.dim(1) },
+            videoPlaceholderId: nil,
+            videoSpanLengths: [])
+        let position = try wrapper.positionResult(
+            tokens: lmInput.text.tokens,
+            imageGrids: grids,
+            attentionMask: lmInput.text.mask)
+        // The features are already materialized per image; only the position
+        // ids are still lazy here.
+        eval(position.promptPositionIds)
+        return PreparedSubmission(
+            promptTokens: promptTokens,
+            spans: carved.map(\.span),
+            embeddings: imageFeatures,
+            attention: .causal,
+            positionState: CBv2PositionState(
+                promptPositionIds: position.promptPositionIds,
+                decodeDeltas: position.decodeState.deltas),
+            mediaKind: .image)
+    }
+
+    /// Gemma 4: bidirectional span masks, no position state, and a SigLIP
+    /// tower whose own seam already forwards one image (or one sampled video
+    /// frame) at a time with a fixed per-image patch count.
+    private static func buildGemmaSubmission(
+        wrapper: MLXVLM.Gemma4,
+        lmInput: LMInput,
+        promptTokens: [Int]
+    ) throws -> PreparedSubmission {
+        // Vision tower + multimodal projector — the SAME arrays the
+        // wrapper's own `prepare` scatters: one per image, one per
+        // sampled video frame (the video seam applies the per-frame
+        // video patch budget, ~70 soft tokens per frame vs 280 per
+        // image).
+        var imageFeatures: [MLXArray] = []
+        if let image = lmInput.image {
+            imageFeatures = wrapper.perImageVisionFeatures(
+                pixels: image.pixels, frames: image.frames)
+            guard !imageFeatures.isEmpty else {
+                throw EngineV2VisionPrefillError.emptyVisionFeatures(kind: .image)
+            }
+        }
+        var videoFeatures: [MLXArray] = []
+        var videoPlaceholderId: Int?
+        if let video = lmInput.video {
+            guard let videoId = wrapper.videoPlaceholderTokenId else {
+                throw EngineV2VisionPrefillError.videoPlaceholderUnavailable
+            }
+            videoPlaceholderId = videoId
+            videoFeatures = wrapper.perVideoFrameVisionFeatures(
+                pixels: video.pixels, frames: video.frames)
+            guard !videoFeatures.isEmpty else {
+                throw EngineV2VisionPrefillError.emptyVisionFeatures(kind: .video)
+            }
+        }
+
+        // A kind's placeholder id is watched ONLY when that kind has
+        // features — mirroring the processor, which expands a
+        // placeholder only when it produced the matching pixels (a
+        // stray placeholder id of an absent kind stays an ordinary
+        // embedded token on both paths).
+        let carved = try carveSpans(
+            tokens: promptTokens,
+            imagePlaceholderId: imageFeatures.isEmpty
+                ? nil : wrapper.imagePlaceholderTokenId,
+            imageSpanLengths: imageFeatures.map { $0.dim(1) },
+            videoPlaceholderId: videoPlaceholderId,
+            videoSpanLengths: videoFeatures.map { $0.dim(1) })
+
+        // Pair prompt-ordered spans back to their features. `carveSpans`
+        // consumed each kind's features strictly in prompt order, so
+        // walking its output with per-kind cursors reproduces the exact
+        // pairing (interleaved image/video requests keep their
+        // interleave; the engine receives spans and embeddings as
+        // parallel arrays).
+        var embeddings: [MLXArray] = []
+        embeddings.reserveCapacity(carved.count)
+        var imageCursor = 0
+        var videoCursor = 0
+        for entry in carved {
+            switch entry.kind {
+            case .image:
+                embeddings.append(imageFeatures[imageCursor])
+                imageCursor += 1
+            case .video:
+                embeddings.append(videoFeatures[videoCursor])
+                videoCursor += 1
+            }
+        }
+
+        // Materialize the tower output HERE — on the request's task,
+        // under container isolation — not lazily on the engine's step
+        // thread (where the fused tower graph would stall every
+        // co-batched request's decode step for the duration).
+        eval(embeddings)
+        return PreparedSubmission(
+            promptTokens: promptTokens,
+            spans: carved.map(\.span),
+            embeddings: embeddings,
+            attention: .bidirectionalSpans,
+            positionState: nil,
+            mediaKind: lmInput.video == nil
+                ? .image : (lmInput.image == nil ? .video : .mixed))
+    }
+
+    /// Translate an MLX fault into the prefill's content-safe vocabulary.
+    ///
+    /// MLX's message is produced entirely by its own C++ (shapes and byte
+    /// counts; no request data is ever interpolated into it), but the
+    /// `EngineV2VisionPrefillError` contract is that a case is content-safe
+    /// BY CONSTRUCTION, not by trusting a foreign string. So the allocation
+    /// refusal — the one MLX fault an operator actually needs numbers for —
+    /// carries the two integers MLX reported and nothing else, and every
+    /// other fault degrades to a stage label.
+    static func visionPrefillError(for error: MLX.MLXError) -> EngineV2VisionPrefillError {
+        guard case .caught(let message) = error else {
+            return .towerFault(stage: "vision prefill")
+        }
+        if message.contains("[metal::malloc]"),
+            let (requested, limit) = firstTwoIntegers(in: message)
+        {
+            return .towerAllocationRefused(requestedBytes: requested, limitBytes: limit)
+        }
+        return .towerFault(stage: "vision prefill")
+    }
+
+    /// The first two decimal integer runs in `text`, or nil.
+    static func firstTwoIntegers(in text: String) -> (UInt64, UInt64)? {
+        var found: [UInt64] = []
+        var current = ""
+        for character in text {
+            if character.isASCII, character.isNumber {
+                current.append(character)
+                continue
+            }
+            if let value = UInt64(current) { found.append(value) }
+            current = ""
+            if found.count == 2 { break }
+        }
+        if found.count < 2, let value = UInt64(current) { found.append(value) }
+        guard found.count == 2 else { return nil }
+        return (found[0], found[1])
     }
 
     /// Carve one span per image and per sampled video frame out of the

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2VisionPrefill.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2VisionPrefill.swift
@@ -49,17 +49,18 @@
 // oversized media, or an intentionally unsupported family/media pairing) keep
 // their 4xx mapping and are not refusals.
 //
-// FAIL-LOUD REQUIRES SURVIVING (v0.8.10): a refusal contract is only worth
-// what the process is worth, and MLX's default error handler is `fatalError`
-// — a C++ fault under this file used to kill the daemon outright, with every
+// FAIL-LOUD REQUIRES SURVIVING: a refusal contract is only worth what the
+// process is worth, and MLX's default error handler is `fatalError` — a C++
+// fault under this file used to kill the daemon outright, with every
 // co-batched request on it. Two changes close that:
 //
-//   1. `prepare` runs under `MLX.withError`, so an MLX fault becomes a Swift
-//      throw the catch arms above already handle (one failed request, not one
-//      dead provider).
+//   1. `prepare` runs under `MLX.withError`, and the recorded fault is checked
+//      at every `eval` site (not just on block exit — the handler records and
+//      RETURNS), so an MLX fault becomes a Swift throw the catch arms above
+//      already handle: one failed request, not one dead provider.
 //   2. The Qwen tower is driven ONE IMAGE AT A TIME and each image is admitted
 //      against `MTLDevice.maxBufferLength` first (`VisionTowerBudget`), so the
-//      dominant fault — the tower's dense `[1, N, N]` attention mask growing
+//      dominant fault — the tower's N×N attention intermediate growing
 //      quadratically in the request's TOTAL patch count — is neither produced
 //      nor left for the allocator to discover. See `EngineV2VisionTowerRun`.
 //
@@ -293,7 +294,7 @@ public enum EngineV2VisionPrefill {
         // rasterizes its frames; no plaintext file exists to clean up.
         let userInput = try await MediaIngest.buildUserInput(
             from: request, reasoningEffort: reasoningEffort)
-        let towerLimits = VisionTowerBudget.liveLimits()
+        let towerLimits = VisionTowerBudget.liveLimits
         return try await container.perform(nonSendable: userInput) { ctx, userInput in
             // MLX's DEFAULT error handler is `fatalError`. A C++ fault raised
             // anywhere under this closure — most consequentially an allocation
@@ -306,15 +307,45 @@ public enum EngineV2VisionPrefill {
             // that the scheduler's existing catch arms turn into one failed
             // request. It is the LAST line of defence: `VisionTowerBudget`
             // refuses the predictable cases deterministically, up front.
+            //
+            // The handler RECORDS and RETURNS — it does not unwind — so the
+            // box is threaded down to every `eval` site and checked there
+            // (`throwIfMLXFaulted`) rather than only on block exit. Checking
+            // only on exit would let the code run on after a refused
+            // allocation and let a later Swift throw hide the real cause.
             do {
-                return try await MLX.withError {
-                    try await Self.buildSubmission(
-                        ctx: ctx, userInput: userInput, towerLimits: towerLimits)
+                return try await MLX.withError { (mlxErrors: MLX.ErrorBox) in
+                    let submission = try await Self.buildSubmission(
+                        ctx: ctx, userInput: userInput, towerLimits: towerLimits,
+                        mlxErrors: mlxErrors)
+                    try Self.throwIfMLXFaulted(mlxErrors)
+                    return submission
                 }
             } catch let mlxError as MLX.MLXError {
                 throw Self.visionPrefillError(for: mlxError)
             }
         }
+    }
+
+    /// Convert a recorded MLX fault into our own vocabulary and throw it.
+    ///
+    /// `MLX.ErrorBox.check()` throws the raw `MLXError`, which would reach the
+    /// scheduler's generic catch as a foreign error and lose its numbers to
+    /// the telemetry privacy filter. Translating here keeps the operator-facing
+    /// byte counts while the enum stays content-safe by construction.
+    static func throwIfMLXFaulted(_ box: MLX.ErrorBox) throws {
+        if let error = translatedFault(box.firstError) { throw error }
+    }
+
+    /// The pure half of ``throwIfMLXFaulted(_:)`` — `MLX.ErrorBox` has no
+    /// public initializer, so the translation lives here where tests can
+    /// reach it.
+    static func translatedFault(_ recorded: Error?) -> Error? {
+        guard let recorded else { return nil }
+        if let mlxError = recorded as? MLX.MLXError {
+            return visionPrefillError(for: mlxError)
+        }
+        return recorded
     }
 
     /// Run the processor, then dispatch to the loaded family's builder. Runs
@@ -323,12 +354,14 @@ public enum EngineV2VisionPrefill {
     private static func buildSubmission(
         ctx: ModelContext,
         userInput: UserInput,
-        towerLimits: VisionTowerBudget.Limits
+        towerLimits: VisionTowerBudget.Limits,
+        mlxErrors: MLX.ErrorBox
     ) async throws -> PreparedSubmission {
         let lmInput = try await ctx.processor.prepare(input: userInput)
         guard lmInput.image != nil || lmInput.video != nil else {
             throw EngineV2VisionPrefillError.noProcessedMedia
         }
+        try throwIfMLXFaulted(mlxErrors)
 
         // [1, L] → [Int]. Forces evaluation of the (tiny, host-built)
         // token array only.
@@ -337,7 +370,7 @@ public enum EngineV2VisionPrefill {
         if let wrapper = ctx.model as? MLXVLM.Qwen35MoE {
             return try buildQwenSubmission(
                 wrapper: wrapper, lmInput: lmInput, promptTokens: promptTokens,
-                towerLimits: towerLimits)
+                towerLimits: towerLimits, mlxErrors: mlxErrors)
         }
         guard let wrapper = ctx.model as? MLXVLM.Gemma4 else {
             throw EngineV2VisionPrefillError.unsupportedVLM(
@@ -353,7 +386,8 @@ public enum EngineV2VisionPrefill {
         wrapper: MLXVLM.Qwen35MoE,
         lmInput: LMInput,
         promptTokens: [Int],
-        towerLimits: VisionTowerBudget.Limits
+        towerLimits: VisionTowerBudget.Limits,
+        mlxErrors: MLX.ErrorBox
     ) throws -> PreparedSubmission {
         // Video remains fail-closed until a real processor/output
         // representation canary pins temporal packing end-to-end.
@@ -361,11 +395,20 @@ public enum EngineV2VisionPrefill {
             throw EngineV2VisionPrefillError.unsupportedMedia(
                 "Qwen35MoE video media is not production-proven")
         }
-        guard let image = lmInput.image, let grids = image.frames, !grids.isEmpty else {
+        // `noProcessedMedia` means "the processor consumed no media", which
+        // maps to a deterministic 400. Pixels WITHOUT grids is a different
+        // thing — the processor produced something the seam cannot describe —
+        // and must keep its retriable refusal rather than tell the caller
+        // their media was attached to the wrong role.
+        guard let image = lmInput.image else {
             throw EngineV2VisionPrefillError.noProcessedMedia
         }
+        guard let grids = image.frames, !grids.isEmpty else {
+            throw EngineV2VisionPrefillError.emptyVisionFeatures(kind: .image)
+        }
         let imageFeatures = try qwenPerImageVisionFeatures(
-            wrapper: wrapper, pixels: image.pixels, grids: grids, towerLimits: towerLimits)
+            wrapper: wrapper, pixels: image.pixels, grids: grids,
+            towerLimits: towerLimits, mlxErrors: mlxErrors)
         let carved = try carveSpans(
             tokens: promptTokens,
             imagePlaceholderId: wrapper.imagePlaceholderTokenId,

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2VisionTowerRun.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2VisionTowerRun.swift
@@ -14,22 +14,31 @@
 //     (`visionFeatureList` loops `0 ..< B` internally) with a fixed patch
 //     count per image, so its activation cost is linear in the image count.
 //
-//   * Qwen3-VL's tower runs whatever it is handed as ONE sequence, and
-//     expresses the per-image block-diagonal attention with a DENSE
-//     `ones([1, N, N])` additive mask over the CONCATENATED patch stream.
-//     Handing it the whole request made peak memory quadratic in the total
-//     image count: six max-resolution images asked Metal for a 278 GiB mask
-//     against a 38.9 GiB per-buffer limit, MLX's default error handler called
-//     `fatalError`, and the daemon died with every co-batched request on it.
+//   * Qwen3-VL's tower runs whatever it is handed as ONE sequence, with an
+//     N×N attention intermediate over the CONCATENATED patch stream (a dense
+//     `ones([1, N, N])` mask, plus a `[1, H, N, N]` score tensor whenever MLX
+//     cannot fuse the head dim — see `VisionTowerBudget`). Handing it the
+//     whole request made peak memory quadratic in the total image count: the
+//     reported node asked Metal for 277.6 GiB against a 38.9 GiB per-buffer
+//     limit, MLX's default error handler called `fatalError`, and the daemon
+//     died with every co-batched request on it.
 //
 // So the Qwen path here drives the tower ONE IMAGE AT A TIME and evaluates
 // each image's features before starting the next. Attention is block-diagonal
 // per image already, and every other stage of the tower (patch embed,
 // positional interpolation, rotary coordinates, layer norms, patch merge) is
-// per-token or per-grid, so a per-image call is numerically identical to the
-// batched one — it only refuses to build the cross-image half of the mask,
-// which was always zeros doing nothing. Peak mask bytes go from
-// `(Σᵢ nᵢ)² × 2` to `maxᵢ nᵢ² × 2`.
+// per-token or per-grid, so a per-image call is MATHEMATICALLY equivalent to
+// the batched one — it only refuses to build the cross-image half of the
+// mask, which was always zeros doing nothing. (Bitwise equality is not
+// guaranteed: SDPA's reduction shape changes with N, so float reduction order
+// can differ.) Peak attention bytes go from `(Σᵢ nᵢ)²` to `maxᵢ nᵢ²`.
+//
+// Each image is also checked for MLX faults immediately after its `eval`.
+// `MLX.withError`'s handler RECORDS and RETURNS — the C++ op yields a
+// degenerate array and Swift keeps going — so without a per-image check a
+// failed image would be followed by n−1 more full tower passes on a GPU that
+// just refused an allocation, all while holding the model container's lock,
+// and any later Swift throw would mask the allocation error entirely.
 
 import Foundation
 import MLX
@@ -41,9 +50,11 @@ extension EngineV2VisionPrefill {
     /// The pixel rows belonging to each grid in a processor's packed image
     /// tensor, in grid order.
     ///
-    /// `QwenVL.patchify` emits `[t·h·w, patchDim]` per image and the processor
-    /// concatenates them along axis 0, so grid `i` owns a contiguous run of
-    /// `grid.product` rows. Pure arithmetic — no MLX, fully unit-testable.
+    /// `QwenVL.patchify` emits `[t·h·w, patchDim]` per image (temporal padding
+    /// happens inside it and is already reflected in `gridT`) and the
+    /// processor concatenates them along axis 0, so grid `i` owns a contiguous
+    /// run of `grid.product` rows. Pure arithmetic — no MLX, fully
+    /// unit-testable.
     ///
     /// Throws when a grid is degenerate or when the runs do not tile `totalRows`
     /// exactly; either means the processor and the tower disagree about the
@@ -60,7 +71,7 @@ extension EngineV2VisionPrefill {
             let (end, overflow) = offset.addingReportingOverflow(rows)
             guard !overflow, end <= totalRows else {
                 throw EngineV2VisionPrefillError.visionPixelRunMismatch(
-                    expected: totalRows, actual: offset)
+                    expected: totalRows, actual: overflow ? Int.max : end)
             }
             runs.append(offset ..< end)
             offset = end
@@ -72,23 +83,33 @@ extension EngineV2VisionPrefill {
         return runs
     }
 
+    /// The N² buffer multiple this wrapper's vision tower will allocate, read
+    /// from the model's own config against MLX's kernel-selection rule.
+    static func qwenAttentionHeadFactor(_ wrapper: MLXVLM.Qwen35MoE) -> Int {
+        let vision = wrapper.config.visionConfiguration
+        return VisionTowerBudget.attentionHeadFactor(
+            hiddenSize: vision.hiddenSize, numHeads: vision.numHeads)
+    }
+
     /// One `[1, softTokens, textHidden]` embedding per image, in prompt order,
     /// produced by driving the Qwen3-VL tower once per image.
     ///
     /// Each image is admitted against the device's Metal buffer ceiling BEFORE
-    /// its graph is built (`VisionTowerBudget`), and evaluated before the next
-    /// image's graph is built, so peak device memory is one image's tower —
-    /// never the request's.
+    /// its graph is built (`VisionTowerBudget`), and evaluated — and checked
+    /// for MLX faults — before the next image's graph is built, so peak device
+    /// memory is one image's tower and a fault stops the loop where it happens.
     static func qwenPerImageVisionFeatures(
         wrapper: MLXVLM.Qwen35MoE,
         pixels: MLXArray,
         grids: [THW],
-        towerLimits: VisionTowerBudget.Limits
+        towerLimits: VisionTowerBudget.Limits,
+        mlxErrors: MLX.ErrorBox
     ) throws -> [MLXArray] {
         guard !grids.isEmpty else {
             throw EngineV2VisionPrefillError.emptyVisionFeatures(kind: .image)
         }
         let runs = try imagePixelRuns(grids: grids, totalRows: pixels.dim(0))
+        let limits = towerLimits.withHeadFactor(qwenAttentionHeadFactor(wrapper))
 
         var features: [MLXArray] = []
         features.reserveCapacity(grids.count)
@@ -96,7 +117,7 @@ extension EngineV2VisionPrefill {
             switch VisionTowerBudget.admit(
                 grids: [grid],
                 subject: Self.imageSubject(index: index, of: grids.count),
-                limits: towerLimits)
+                limits: limits)
             {
             case .admit:
                 break
@@ -117,9 +138,12 @@ extension EngineV2VisionPrefill {
             }
             let embedding = single.ordered[0].features
             // Materialize before building the next image's graph. Without this
-            // every image's mask would be live in one `eval`, restoring the
-            // aggregate peak this loop exists to remove.
+            // every image's attention buffer would be live in one `eval`,
+            // restoring the aggregate peak this loop exists to remove.
             eval(embedding)
+            // And stop HERE if MLX refused: the recorded error would otherwise
+            // survive only until some later Swift throw overwrote the story.
+            try EngineV2VisionPrefill.throwIfMLXFaulted(mlxErrors)
             features.append(embedding)
         }
         return features

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2VisionTowerRun.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2VisionTowerRun.swift
@@ -1,0 +1,132 @@
+// Copyright © 2026 Eigen Labs.
+//
+// Vision-tower invocation for the v2 media prefill.
+//
+// `EngineV2VisionPrefill` owns orchestration (decode → processor → tower →
+// span carving); this file owns exactly one step of it: turning a processor's
+// packed pixels + grids into one soft-token embedding array per image, for
+// each supported VLM family.
+//
+// The two families need opposite handling, and getting that wrong is what
+// produced the v0.8.7 provider crashes:
+//
+//   * Gemma 4's SigLIP tower already runs ONE image per forward pass
+//     (`visionFeatureList` loops `0 ..< B` internally) with a fixed patch
+//     count per image, so its activation cost is linear in the image count.
+//
+//   * Qwen3-VL's tower runs whatever it is handed as ONE sequence, and
+//     expresses the per-image block-diagonal attention with a DENSE
+//     `ones([1, N, N])` additive mask over the CONCATENATED patch stream.
+//     Handing it the whole request made peak memory quadratic in the total
+//     image count: six max-resolution images asked Metal for a 278 GiB mask
+//     against a 38.9 GiB per-buffer limit, MLX's default error handler called
+//     `fatalError`, and the daemon died with every co-batched request on it.
+//
+// So the Qwen path here drives the tower ONE IMAGE AT A TIME and evaluates
+// each image's features before starting the next. Attention is block-diagonal
+// per image already, and every other stage of the tower (patch embed,
+// positional interpolation, rotary coordinates, layer norms, patch merge) is
+// per-token or per-grid, so a per-image call is numerically identical to the
+// batched one — it only refuses to build the cross-image half of the mask,
+// which was always zeros doing nothing. Peak mask bytes go from
+// `(Σᵢ nᵢ)² × 2` to `maxᵢ nᵢ² × 2`.
+
+import Foundation
+import MLX
+import MLXLMCommon
+import MLXVLM
+
+extension EngineV2VisionPrefill {
+
+    /// The pixel rows belonging to each grid in a processor's packed image
+    /// tensor, in grid order.
+    ///
+    /// `QwenVL.patchify` emits `[t·h·w, patchDim]` per image and the processor
+    /// concatenates them along axis 0, so grid `i` owns a contiguous run of
+    /// `grid.product` rows. Pure arithmetic — no MLX, fully unit-testable.
+    ///
+    /// Throws when a grid is degenerate or when the runs do not tile `totalRows`
+    /// exactly; either means the processor and the tower disagree about the
+    /// request's shape, and slicing on a disagreement would silently feed one
+    /// image's pixels into another image's grid.
+    static func imagePixelRuns(grids: [THW], totalRows: Int) throws -> [Range<Int>] {
+        var runs: [Range<Int>] = []
+        runs.reserveCapacity(grids.count)
+        var offset = 0
+        for (index, grid) in grids.enumerated() {
+            guard let rows = VisionTowerBudget.patchCount(grid), rows > 0 else {
+                throw EngineV2VisionPrefillError.invalidVisionGrid(mediaIndex: index)
+            }
+            let (end, overflow) = offset.addingReportingOverflow(rows)
+            guard !overflow, end <= totalRows else {
+                throw EngineV2VisionPrefillError.visionPixelRunMismatch(
+                    expected: totalRows, actual: offset)
+            }
+            runs.append(offset ..< end)
+            offset = end
+        }
+        guard offset == totalRows else {
+            throw EngineV2VisionPrefillError.visionPixelRunMismatch(
+                expected: totalRows, actual: offset)
+        }
+        return runs
+    }
+
+    /// One `[1, softTokens, textHidden]` embedding per image, in prompt order,
+    /// produced by driving the Qwen3-VL tower once per image.
+    ///
+    /// Each image is admitted against the device's Metal buffer ceiling BEFORE
+    /// its graph is built (`VisionTowerBudget`), and evaluated before the next
+    /// image's graph is built, so peak device memory is one image's tower —
+    /// never the request's.
+    static func qwenPerImageVisionFeatures(
+        wrapper: MLXVLM.Qwen35MoE,
+        pixels: MLXArray,
+        grids: [THW],
+        towerLimits: VisionTowerBudget.Limits
+    ) throws -> [MLXArray] {
+        guard !grids.isEmpty else {
+            throw EngineV2VisionPrefillError.emptyVisionFeatures(kind: .image)
+        }
+        let runs = try imagePixelRuns(grids: grids, totalRows: pixels.dim(0))
+
+        var features: [MLXArray] = []
+        features.reserveCapacity(grids.count)
+        for (index, grid) in grids.enumerated() {
+            switch VisionTowerBudget.admit(
+                grids: [grid],
+                subject: Self.imageSubject(index: index, of: grids.count),
+                limits: towerLimits)
+            {
+            case .admit:
+                break
+            case .reject(let reason):
+                // Refuse RETRIABLY. The bound is `MTLDevice.maxBufferLength`,
+                // which scales with the machine, so the same request can
+                // succeed on a larger node — the coordinator's pre-content
+                // failover is the right place to find one. A 4xx here would
+                // tell the caller their image is invalid when it is only too
+                // large for THIS box.
+                throw EngineV2VisionPrefillError.towerBudgetExceeded(reason)
+            }
+
+            let single = try wrapper.visionFeatures(
+                imagePixels: pixels[runs[index], 0...], imageGrids: [grid])
+            guard single.ordered.count == 1 else {
+                throw EngineV2VisionPrefillError.emptyVisionFeatures(kind: .image)
+            }
+            let embedding = single.ordered[0].features
+            // Materialize before building the next image's graph. Without this
+            // every image's mask would be live in one `eval`, restoring the
+            // aggregate peak this loop exists to remove.
+            eval(embedding)
+            features.append(embedding)
+        }
+        return features
+    }
+
+    /// Content-free subject for a rejection message ("image 2 of 5").
+    static func imageSubject(index: Int, of count: Int) -> String {
+        count == 1 ? "this image" : "image \(index + 1) of \(count)"
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Inference/VisionTowerBudget.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/VisionTowerBudget.swift
@@ -1,0 +1,202 @@
+// Copyright © 2026 Eigen Labs.
+//
+// Metal buffer admission for the VLM vision tower.
+//
+// The Qwen3-VL vision tower expresses its per-image attention with a DENSE
+// additive mask — `ones([1, N, N])` in `Qwen3VLVision.Attention` — where N is
+// the total patch count of everything handed to ONE tower call. That single
+// buffer is the largest allocation anywhere on the vision path and it grows
+// quadratically, so the whole question of whether a media request fits on the
+// GPU reduces to one number: the patch count of a tower call.
+//
+// Metal answers that question exactly. `MTLDevice.maxBufferLength` is a hard
+// per-allocation ceiling (38.9 GiB on an M2 Ultra, ~1/4 of a machine's RAM on
+// Apple silicon); `MetalAllocator::malloc` compares against it BEFORE
+// allocating and throws. So the admissible patch count is a closed form:
+//
+//     N_max = floor(sqrt(maxBufferLength / maskElementBytes))
+//
+// This type computes that bound and the projected mask size for a set of
+// grids. It is pure arithmetic over `THW` grids the processor has already
+// produced, which makes the decision deterministic, testable without a GPU,
+// and knowable BEFORE any tower work runs.
+//
+// WHY THIS EXISTS AT ALL: a mask that exceeds the ceiling is not a recoverable
+// allocation failure. MLX routes the C++ `std::runtime_error` to its error
+// handler, whose default is `fatalError` — one oversized request used to take
+// the whole provider process down with every co-batched request on it. The
+// callers pair this gate with `MLX.withError` so neither the predictable case
+// (rejected here, deterministically, with a 4xx) nor the unpredictable one
+// (thrown by MLX, refused with a 503) can trap the process.
+
+import Foundation
+import MLX
+import MLXLMCommon
+
+/// Admission arithmetic for one vision-tower invocation.
+///
+/// Pure functions; no state. Every entry point takes its limits explicitly so
+/// tests pin behaviour without a Metal device.
+enum VisionTowerBudget {
+
+    /// Bytes per element of the tower's dense attention mask.
+    ///
+    /// The mask is built with `dtype: queries.dtype`, i.e. the vision tower's
+    /// activation dtype, which is 16-bit (bf16/fp16) in every shipping
+    /// checkpoint — including the MXFP8 Qwen builds, whose quantization
+    /// applies to weights, not activations. Verified against production crash
+    /// reports: a 298,090,824,192-byte refusal is exactly 386,064² × 2.
+    static let maskElementBytes = 2
+
+    /// Hard ceilings for one tower call.
+    struct Limits: Sendable, Equatable {
+        /// `MTLDevice.maxBufferLength` — the largest single allocation Metal
+        /// will accept. Non-positive means "unknown", which disables the gate
+        /// (fail open; `MLX.withError` remains the backstop).
+        let maxBufferBytes: Int
+        /// Bytes per mask element.
+        let maskElementBytes: Int
+        /// Operator ceiling on patches per tower call, or nil for none.
+        /// Applied on top of the device bound, never above it.
+        let operatorMaxPatches: Int?
+
+        init(maxBufferBytes: Int, maskElementBytes: Int, operatorMaxPatches: Int? = nil) {
+            self.maxBufferBytes = maxBufferBytes
+            self.maskElementBytes = maskElementBytes
+            self.operatorMaxPatches = operatorMaxPatches
+        }
+    }
+
+    enum Decision: Sendable, Equatable {
+        case admit
+        /// Operator-facing, content-free reason. Never embeds prompt or media
+        /// bytes — only patch counts and byte budgets.
+        case reject(String)
+    }
+
+    /// Live device limits. Reads Metal once per call; callers resolve them
+    /// outside hot loops.
+    static func liveLimits(
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> Limits {
+        Limits(
+            maxBufferBytes: MLX.GPU.deviceInfo().maxBufferSize,
+            maskElementBytes: maskElementBytes,
+            operatorMaxPatches: operatorPatchCeiling(environment: environment))
+    }
+
+    /// `DARKBLOOM_VISION_MAX_TOWER_PATCHES` — a LOWER-ONLY operator ceiling on
+    /// patches per tower call.
+    ///
+    /// Lower-only by construction: `maxAdmissiblePatches` takes the min of
+    /// this and the device bound, so the override can tighten admission on a
+    /// memory-pressured box but can never talk the gate into a patch count
+    /// Metal would refuse. Non-numeric or non-positive values are ignored.
+    static func operatorPatchCeiling(
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> Int? {
+        guard let raw = environment["DARKBLOOM_VISION_MAX_TOWER_PATCHES"],
+            let value = Int(raw), value > 0
+        else { return nil }
+        return value
+    }
+
+    /// Patches in one grid (`t × h × w`), or nil on overflow.
+    static func patchCount(_ grid: THW) -> Int? {
+        let (spatial, spatialOverflow) = grid.h.multipliedReportingOverflow(by: grid.w)
+        guard !spatialOverflow else { return nil }
+        let (total, temporalOverflow) = spatial.multipliedReportingOverflow(by: grid.t)
+        guard !temporalOverflow else { return nil }
+        return total >= 0 ? total : nil
+    }
+
+    /// Patches across every grid handed to ONE tower call, or nil on overflow.
+    static func totalPatchCount(_ grids: [THW]) -> Int? {
+        var total = 0
+        for grid in grids {
+            guard let count = patchCount(grid) else { return nil }
+            let (next, overflow) = total.addingReportingOverflow(count)
+            guard !overflow else { return nil }
+            total = next
+        }
+        return total
+    }
+
+    /// Bytes of the dense `[1, N, N]` attention mask, saturating at `.max`.
+    static func maskBytes(patches: Int, elementBytes: Int) -> UInt64 {
+        guard patches > 0, elementBytes > 0 else { return 0 }
+        let n = UInt64(patches)
+        let (square, squareOverflow) = n.multipliedReportingOverflow(by: n)
+        guard !squareOverflow else { return .max }
+        let (bytes, bytesOverflow) = square.multipliedReportingOverflow(by: UInt64(elementBytes))
+        return bytesOverflow ? .max : bytes
+    }
+
+    /// Largest patch count whose mask still fits, or nil when unbounded
+    /// (device limit unknown and no operator ceiling).
+    static func maxAdmissiblePatches(_ limits: Limits) -> Int? {
+        var bound: Int?
+        if limits.maxBufferBytes > 0, limits.maskElementBytes > 0 {
+            bound = integerSquareRoot(UInt64(limits.maxBufferBytes) / UInt64(limits.maskElementBytes))
+        }
+        if let ceiling = limits.operatorMaxPatches {
+            bound = bound.map { min($0, ceiling) } ?? ceiling
+        }
+        return bound
+    }
+
+    /// Decide whether one tower call over `grids` can allocate its mask.
+    ///
+    /// `subject` names what is being admitted in the rejection message
+    /// (e.g. `"image 2 of 5"`), so an operator reading a 4xx knows which part
+    /// of the request to shrink.
+    static func admit(grids: [THW], subject: String, limits: Limits) -> Decision {
+        guard let patches = totalPatchCount(grids) else {
+            return .reject(
+                "\(subject) has an unrepresentable patch grid "
+                    + "(\(grids.count) grid(s) overflowed 64-bit patch arithmetic)")
+        }
+        return admit(patches: patches, subject: subject, limits: limits)
+    }
+
+    /// Patch-count form of ``admit(grids:subject:limits:)``.
+    static func admit(patches: Int, subject: String, limits: Limits) -> Decision {
+        guard patches > 0 else { return .admit }
+        // Unknown device limit and no operator ceiling: fail OPEN. Refusing
+        // every media request because Metal introspection failed would be a
+        // worse outcome than the `MLX.withError` backstop the callers install.
+        guard let ceiling = maxAdmissiblePatches(limits) else { return .admit }
+        guard patches > ceiling else { return .admit }
+
+        let projected = maskBytes(patches: patches, elementBytes: limits.maskElementBytes)
+        return .reject(
+            "\(subject) resolves to \(patches) vision patches, above this GPU's limit of "
+                + "\(ceiling); its attention mask alone would need "
+                + "\(formatGiB(projected)) in one Metal buffer "
+                + "(max \(formatGiB(UInt64(max(0, limits.maxBufferBytes)))))"
+                + " — send a smaller image")
+    }
+
+    /// Integer square root by Newton's method. Exact for every `UInt64`; the
+    /// `Double`-then-`sqrt` shortcut loses precision above 2^53 and can round
+    /// the bound UP into an allocation Metal refuses.
+    static func integerSquareRoot(_ value: UInt64) -> Int {
+        guard value > 0 else { return 0 }
+        var estimate = UInt64(Double(value).squareRoot())
+        // Newton's method converges from either side depending on the seed's
+        // rounding; clamp both directions so the result is the exact floor.
+        while estimate > 0, estimate > value / estimate {
+            estimate = (estimate + value / estimate) / 2
+        }
+        while (estimate + 1) <= value / (estimate + 1) {
+            estimate += 1
+        }
+        return estimate > UInt64(Int.max) ? Int.max : Int(estimate)
+    }
+
+    private static func formatGiB(_ bytes: UInt64) -> String {
+        if bytes == .max { return "an unrepresentable number of bytes" }
+        let gib = Double(bytes) / Double(1 << 30)
+        return String(format: "%.1f GiB", gib)
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Inference/VisionTowerBudget.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/VisionTowerBudget.swift
@@ -2,32 +2,46 @@
 //
 // Metal buffer admission for the VLM vision tower.
 //
-// The Qwen3-VL vision tower expresses its per-image attention with a DENSE
-// additive mask — `ones([1, N, N])` in `Qwen3VLVision.Attention` — where N is
-// the total patch count of everything handed to ONE tower call. That single
-// buffer is the largest allocation anywhere on the vision path and it grows
-// quadratically, so the whole question of whether a media request fits on the
-// GPU reduces to one number: the patch count of a tower call.
+// The Qwen3-VL vision tower attends over N patches with an N×N-shaped
+// intermediate, where N is the patch count of everything handed to ONE tower
+// call. That intermediate is the largest allocation anywhere on the vision
+// path and it grows quadratically, so whether a media request fits on the GPU
+// reduces to one number: the patch count of a tower call.
 //
-// Metal answers that question exactly. `MTLDevice.maxBufferLength` is a hard
-// per-allocation ceiling (38.9 GiB on an M2 Ultra, ~1/4 of a machine's RAM on
-// Apple silicon); `MetalAllocator::malloc` compares against it BEFORE
-// allocating and throws. So the admissible patch count is a closed form:
+// WHICH N×N buffer is the largest depends on which SDPA kernel MLX picks, and
+// the difference is a factor of the head count:
 //
-//     N_max = floor(sqrt(maxBufferLength / maskElementBytes))
+//   * `Qwen3VLVision.Attention` always materializes a dense additive mask,
+//     `ones([1, N, N])`, to express its per-image block-diagonal attention.
+//   * MLX's FUSED full-attention kernel accepts only head dims 64, 80 and 128
+//     (`sdpa_full_supported_head_dim`, backend/metal/
+//     scaled_dot_product_attention.cpp). With one of those the mask is the
+//     peak and the factor is 1.
+//   * Otherwise MLX falls back to the unfused path, which materializes the
+//     score tensor `matmul(q, kᵀ)` at `[1, H, N, N]` (fast.cpp) — H times the
+//     mask. On a 16-head tower that is a 16× larger peak.
 //
-// This type computes that bound and the projected mask size for a set of
-// grids. It is pure arithmetic over `THW` grids the processor has already
+// So the factor is read from the model's own vision config against MLX's own
+// kernel-selection rule rather than assumed. Nothing here guesses.
+//
+// Metal then answers the question exactly. `MTLDevice.maxBufferLength` is a
+// hard per-allocation ceiling (38.9 GiB on an M2 Ultra, ~1/4 of a machine's
+// RAM on Apple silicon); `MetalAllocator::malloc` compares against it BEFORE
+// allocating and throws. The admissible patch count is a closed form:
+//
+//     N_max = floor(sqrt(maxBufferLength / (headFactor × elementBytes)))
+//
+// This type is pure arithmetic over `THW` grids the processor has already
 // produced, which makes the decision deterministic, testable without a GPU,
 // and knowable BEFORE any tower work runs.
 //
-// WHY THIS EXISTS AT ALL: a mask that exceeds the ceiling is not a recoverable
-// allocation failure. MLX routes the C++ `std::runtime_error` to its error
-// handler, whose default is `fatalError` — one oversized request used to take
-// the whole provider process down with every co-batched request on it. The
-// callers pair this gate with `MLX.withError` so neither the predictable case
-// (rejected here, deterministically, with a 4xx) nor the unpredictable one
-// (thrown by MLX, refused with a 503) can trap the process.
+// WHY THIS EXISTS AT ALL: an allocation over the ceiling is not a recoverable
+// failure. MLX routes the C++ `std::runtime_error` to its error handler, whose
+// default is `fatalError` — one oversized request used to take the whole
+// provider process down with every co-batched request on it. This gate is the
+// cheap deterministic half of the answer; `MLX.withError` at the call site is
+// the guarantee, because the gate models the dominant buffer and not every
+// transient MLX allocates.
 
 import Foundation
 import MLX
@@ -39,14 +53,35 @@ import MLXLMCommon
 /// tests pin behaviour without a Metal device.
 enum VisionTowerBudget {
 
-    /// Bytes per element of the tower's dense attention mask.
+    /// Bytes per element of the tower's N×N attention intermediates.
     ///
-    /// The mask is built with `dtype: queries.dtype`, i.e. the vision tower's
-    /// activation dtype, which is 16-bit (bf16/fp16) in every shipping
-    /// checkpoint — including the MXFP8 Qwen builds, whose quantization
-    /// applies to weights, not activations. Verified against production crash
-    /// reports: a 298,090,824,192-byte refusal is exactly 386,064² × 2.
-    static let maskElementBytes = 2
+    /// They are built at `queries.dtype`, i.e. the vision tower's activation
+    /// dtype, which is 16-bit (bf16/fp16) in every shipping checkpoint —
+    /// including the MXFP8 Qwen builds, whose quantization applies to weights,
+    /// not activations. Verified against production crash reports: a
+    /// 298,090,824,192-byte refusal is exactly 386,064² × 2 (mask, factor 1)
+    /// or 96,516² × 16 × 2 (scores, factor 16).
+    static let attentionElementBytes = 2
+
+    /// Head dims MLX's fused full-attention kernel accepts. Mirrors
+    /// `sdpa_full_supported_head_dim` in
+    /// `mlx/backend/metal/scaled_dot_product_attention.cpp`. The vision tower's
+    /// query length is always > 8, so the vector kernel (which accepts a
+    /// different set) can never apply.
+    static let fusedAttentionHeadDims: Set<Int> = [64, 80, 128]
+
+    /// The multiple of N² the tower's largest attention buffer occupies: 1
+    /// when MLX takes the fused kernel and only the additive mask is
+    /// materialized, `numHeads` when it falls back and materializes the score
+    /// tensor. Fails CLOSED on a nonsensical config (treats it as the fallback
+    /// path) — over-tightening costs a retriable refusal, under-tightening
+    /// costs the process.
+    static func attentionHeadFactor(hiddenSize: Int, numHeads: Int) -> Int {
+        guard numHeads > 0, hiddenSize > 0, hiddenSize % numHeads == 0 else {
+            return max(1, numHeads)
+        }
+        return fusedAttentionHeadDims.contains(hiddenSize / numHeads) ? 1 : numHeads
+    }
 
     /// Hard ceilings for one tower call.
     struct Limits: Sendable, Equatable {
@@ -54,16 +89,37 @@ enum VisionTowerBudget {
         /// will accept. Non-positive means "unknown", which disables the gate
         /// (fail open; `MLX.withError` remains the backstop).
         let maxBufferBytes: Int
-        /// Bytes per mask element.
-        let maskElementBytes: Int
+        /// Bytes per element of the N×N attention intermediate.
+        let attentionElementBytes: Int
+        /// How many N² planes the peak buffer holds — see
+        /// ``attentionHeadFactor(hiddenSize:numHeads:)``.
+        let headFactor: Int
         /// Operator ceiling on patches per tower call, or nil for none.
         /// Applied on top of the device bound, never above it.
         let operatorMaxPatches: Int?
 
-        init(maxBufferBytes: Int, maskElementBytes: Int, operatorMaxPatches: Int? = nil) {
+        init(
+            maxBufferBytes: Int,
+            attentionElementBytes: Int,
+            headFactor: Int,
+            operatorMaxPatches: Int? = nil
+        ) {
             self.maxBufferBytes = maxBufferBytes
-            self.maskElementBytes = maskElementBytes
+            self.attentionElementBytes = attentionElementBytes
+            self.headFactor = max(1, headFactor)
             self.operatorMaxPatches = operatorMaxPatches
+        }
+
+        /// Bytes per N² element once the head factor is folded in.
+        var bytesPerSquaredPatch: Int { attentionElementBytes * headFactor }
+
+        /// The same limits with a different head factor.
+        func withHeadFactor(_ factor: Int) -> Limits {
+            Limits(
+                maxBufferBytes: maxBufferBytes,
+                attentionElementBytes: attentionElementBytes,
+                headFactor: factor,
+                operatorMaxPatches: operatorMaxPatches)
         }
     }
 
@@ -74,14 +130,21 @@ enum VisionTowerBudget {
         case reject(String)
     }
 
-    /// Live device limits. Reads Metal once per call; callers resolve them
-    /// outside hot loops.
-    static func liveLimits(
+    /// Live device limits, with a head factor of 1 (the fused-kernel case).
+    /// Callers refine it per model with ``Limits/withHeadFactor(_:)``.
+    ///
+    /// Metal introspection and the env read are process-lifetime constants, so
+    /// they are resolved once rather than on every media request.
+    static let liveLimits: Limits = resolveLiveLimits()
+
+    static func resolveLiveLimits(
+        maxBufferBytes: Int = MLX.GPU.deviceInfo().maxBufferSize,
         environment: [String: String] = ProcessInfo.processInfo.environment
     ) -> Limits {
         Limits(
-            maxBufferBytes: MLX.GPU.deviceInfo().maxBufferSize,
-            maskElementBytes: maskElementBytes,
+            maxBufferBytes: maxBufferBytes,
+            attentionElementBytes: attentionElementBytes,
+            headFactor: 1,
             operatorMaxPatches: operatorPatchCeiling(environment: environment))
     }
 
@@ -122,22 +185,24 @@ enum VisionTowerBudget {
         return total
     }
 
-    /// Bytes of the dense `[1, N, N]` attention mask, saturating at `.max`.
-    static func maskBytes(patches: Int, elementBytes: Int) -> UInt64 {
-        guard patches > 0, elementBytes > 0 else { return 0 }
+    /// Bytes of the peak N×N attention buffer, saturating at `.max`.
+    static func attentionBytes(patches: Int, bytesPerSquaredPatch: Int) -> UInt64 {
+        guard patches > 0, bytesPerSquaredPatch > 0 else { return 0 }
         let n = UInt64(patches)
         let (square, squareOverflow) = n.multipliedReportingOverflow(by: n)
         guard !squareOverflow else { return .max }
-        let (bytes, bytesOverflow) = square.multipliedReportingOverflow(by: UInt64(elementBytes))
+        let (bytes, bytesOverflow) = square.multipliedReportingOverflow(
+            by: UInt64(bytesPerSquaredPatch))
         return bytesOverflow ? .max : bytes
     }
 
-    /// Largest patch count whose mask still fits, or nil when unbounded
-    /// (device limit unknown and no operator ceiling).
+    /// Largest patch count whose peak attention buffer still fits, or nil when
+    /// unbounded (device limit unknown and no operator ceiling).
     static func maxAdmissiblePatches(_ limits: Limits) -> Int? {
         var bound: Int?
-        if limits.maxBufferBytes > 0, limits.maskElementBytes > 0 {
-            bound = integerSquareRoot(UInt64(limits.maxBufferBytes) / UInt64(limits.maskElementBytes))
+        let perSquare = limits.bytesPerSquaredPatch
+        if limits.maxBufferBytes > 0, perSquare > 0 {
+            bound = integerSquareRoot(UInt64(limits.maxBufferBytes) / UInt64(perSquare))
         }
         if let ceiling = limits.operatorMaxPatches {
             bound = bound.map { min($0, ceiling) } ?? ceiling
@@ -168,13 +233,14 @@ enum VisionTowerBudget {
         guard let ceiling = maxAdmissiblePatches(limits) else { return .admit }
         guard patches > ceiling else { return .admit }
 
-        let projected = maskBytes(patches: patches, elementBytes: limits.maskElementBytes)
-        return .reject(
-            "\(subject) resolves to \(patches) vision patches, above this GPU's limit of "
-                + "\(ceiling); its attention mask alone would need "
-                + "\(formatGiB(projected)) in one Metal buffer "
-                + "(max \(formatGiB(UInt64(max(0, limits.maxBufferBytes)))))"
-                + " — send a smaller image")
+        let projected = attentionBytes(
+            patches: patches, bytesPerSquaredPatch: limits.bytesPerSquaredPatch)
+        var reason = "\(subject) resolves to \(patches) vision patches, above this GPU's limit of "
+            + "\(ceiling); its attention would need \(formatGiB(projected)) in one Metal buffer"
+        if limits.maxBufferBytes > 0 {
+            reason += " (max \(formatGiB(UInt64(limits.maxBufferBytes))))"
+        }
+        return .reject(reason + " — send a smaller image")
     }
 
     /// Integer square root by Newton's method. Exact for every `UInt64`; the

--- a/provider-swift/Tests/ProviderCoreTests/QwenPerImageVisionEquivalenceTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/QwenPerImageVisionEquivalenceTests.swift
@@ -1,0 +1,147 @@
+// Copyright © 2026 Eigen Labs.
+//
+// The correctness argument for the v0.8.7 vision fix is one claim: driving the
+// Qwen3-VL tower once per image produces the same features as driving it once
+// over the concatenated patch stream. Attention is block-diagonal per image
+// and every other stage is per-token or per-grid, so the cross-image half of
+// the mask was always zeros doing nothing — but "always zeros" is an argument,
+// and this is the measurement.
+//
+// Live-gated on real weights (the tower cannot be exercised without them),
+// following the same env gates as the Qwen3.6 production canary:
+//
+//   DARKBLOOM_LIVE_MLX_TESTS=1 DARKBLOOM_LIVE_MLX_QWEN36=1 swift test \
+//     --filter QwenPerImageVisionEquivalence
+//
+// Override the artifact paths with DARKBLOOM_LIVE_MLX_QWEN36_MODEL_PATH and
+// DARKBLOOM_LIVE_MLX_QWEN36_IMAGE_PATH.
+
+import CoreImage
+import Foundation
+import MLX
+import MLXLMCommon
+import MLXVLM
+import Testing
+
+@testable import ProviderCore
+
+private enum QwenVisionEquivalenceFixture {
+    static let modelPathOverride = "DARKBLOOM_LIVE_MLX_QWEN36_MODEL_PATH"
+    static let imagePathOverride = "DARKBLOOM_LIVE_MLX_QWEN36_IMAGE_PATH"
+    static let defaultModelPath =
+        "/var/folders/hv/5779vnmn5c564l3tdknlf4x80000gp/T/opencode/"
+        + "Qwen3.6-35B-A3B-MLX-VL-4bit-g64-router8-mtp-work"
+    static let defaultImagePath =
+        "/var/folders/hv/5779vnmn5c564l3tdknlf4x80000gp/T/opencode/qwen36-vlm-proof.png"
+
+    static var enabled: Bool {
+        let environment = ProcessInfo.processInfo.environment
+        return environment["DARKBLOOM_LIVE_MLX_TESTS"] == "1"
+            && environment["DARKBLOOM_LIVE_MLX_QWEN36"] == "1"
+    }
+
+    static var modelDirectory: URL {
+        URL(
+            fileURLWithPath: ProcessInfo.processInfo.environment[modelPathOverride]
+                ?? defaultModelPath,
+            isDirectory: true
+        ).standardizedFileURL
+    }
+
+    static var imageURL: URL {
+        URL(
+            fileURLWithPath: ProcessInfo.processInfo.environment[imagePathOverride]
+                ?? defaultImagePath,
+            isDirectory: false
+        ).standardizedFileURL
+    }
+}
+
+@Suite("QwenPerImageVisionEquivalence", .serialized)
+struct QwenPerImageVisionEquivalenceTests {
+
+    @Test(
+        "per-image tower features match the batched ones for a multi-image request",
+        .enabled(
+            if: QwenVisionEquivalenceFixture.enabled,
+            "set DARKBLOOM_LIVE_MLX_TESTS=1 and DARKBLOOM_LIVE_MLX_QWEN36=1 to run the real-artifact Qwen vision equivalence check")
+    )
+    func perImageMatchesBatched() async throws {
+        #expect(LiveInferenceFixtures.ensureMetallibColocated() != nil)
+        let container = try await ModelContainerLoading.loadContainer(
+            from: QwenVisionEquivalenceFixture.modelDirectory)
+
+        // Three copies of the canary image: enough for the concatenated stream
+        // to differ from any single image, small enough to run anywhere.
+        let imageData = try Data(contentsOf: QwenVisionEquivalenceFixture.imageURL)
+        let ciImage = try #require(CIImage(data: imageData))
+        let userInput = UserInput(
+            chat: [.user("describe these", images: (0 ..< 3).map { _ in .ciImage(ciImage) })])
+
+        try await container.perform(nonSendable: userInput) { ctx, userInput in
+            let wrapper = try #require(
+                ctx.model as? MLXVLM.Qwen35MoE,
+                "the live artifact must load as Qwen35MoE for this check to mean anything")
+            let lmInput = try await ctx.processor.prepare(input: userInput)
+            let image = try #require(lmInput.image, "processor produced no image pixels")
+            let grids = try #require(image.frames, "processor produced no image grids")
+            #expect(grids.count == 3)
+
+            // The path the provider used to take: one tower call, every image
+            // concatenated.
+            let batched = try wrapper.visionFeatures(
+                imagePixels: image.pixels, imageGrids: grids
+            ).ordered.map(\.features)
+            eval(batched)
+
+            // The path it takes now.
+            let perImage = try MLX.withError { (box: MLX.ErrorBox) in
+                try EngineV2VisionPrefill.qwenPerImageVisionFeatures(
+                    wrapper: wrapper,
+                    pixels: image.pixels,
+                    grids: grids,
+                    towerLimits: VisionTowerBudget.liveLimits,
+                    mlxErrors: box)
+            }
+
+            #expect(perImage.count == batched.count)
+            for (index, (lhs, rhs)) in zip(perImage, batched).enumerated() {
+                #expect(lhs.shape == rhs.shape, "image \(index) shape")
+                let delta = MLX.abs(
+                    lhs.asType(.float32) - rhs.asType(.float32)
+                ).max().item(Float.self)
+                // Bitwise equality is not promised: SDPA's reduction shape
+                // changes with N, so float reduction order can differ. A
+                // tolerance well inside bf16's ~3-decimal-digit resolution is
+                // the strongest claim that survives that.
+                #expect(delta < 5e-3, "image \(index) max abs delta \(delta)")
+            }
+        }
+    }
+
+    @Test(
+        "the head factor read from the live config matches MLX's kernel rule",
+        .enabled(
+            if: QwenVisionEquivalenceFixture.enabled,
+            "set DARKBLOOM_LIVE_MLX_TESTS=1 and DARKBLOOM_LIVE_MLX_QWEN36=1 to inspect the real vision config")
+    )
+    func headFactorMatchesTheLiveConfig() async throws {
+        let container = try await ModelContainerLoading.loadContainer(
+            from: QwenVisionEquivalenceFixture.modelDirectory)
+        try await container.perform { ctx in
+            let wrapper = try #require(ctx.model as? MLXVLM.Qwen35MoE)
+            let vision = wrapper.config.visionConfiguration
+            let headDim = vision.hiddenSize / max(1, vision.numHeads)
+            let factor = EngineV2VisionPrefill.qwenAttentionHeadFactor(wrapper)
+            // Documents whichever the shipping checkpoint actually is, and
+            // fails loudly if the two ever disagree.
+            if VisionTowerBudget.fusedAttentionHeadDims.contains(headDim) {
+                #expect(factor == 1, "head dim \(headDim) is fusable but factor is \(factor)")
+            } else {
+                #expect(
+                    factor == vision.numHeads,
+                    "head dim \(headDim) is not fusable but factor is \(factor)")
+            }
+        }
+    }
+}

--- a/provider-swift/Tests/ProviderCoreTests/VisionTowerBudgetTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/VisionTowerBudgetTests.swift
@@ -9,11 +9,17 @@
 //   allocate 298090824192 bytes which is greater than the maximum allowed
 //   buffer size of 41747087360 bytes.
 //
-// 298,090,824,192 = 386,064² × 2 — the Qwen3-VL vision tower's dense
-// `ones([1, N, N])` bf16 attention mask over the CONCATENATED patch stream of
-// every image in one request. These tests pin the arithmetic that predicts it,
-// the per-image slicing that stops the request from ever producing it, and the
-// MLX-fault translation that keeps a residual fault from killing the process.
+// That is an N×N attention intermediate in the Qwen3-VL vision tower over the
+// CONCATENATED patch stream of every image in one request. Which intermediate
+// depends on the head dim: with MLX's fused kernel the peak is the dense
+// `ones([1, N, N])` mask (386,064² × 2 bytes); without it MLX materializes the
+// score tensor at `[1, H, N, N]` (96,516² × 16 × 2 — the same number, because
+// 16 is a perfect square). The budget reads the factor from the model config
+// rather than guessing, so both readings are handled.
+//
+// These pin the arithmetic that predicts it, the per-image slicing that stops
+// the request from ever producing it, and the MLX-fault translation that keeps
+// a residual fault from killing the process.
 //
 // All pure arithmetic: no GPU, no weights, no network.
 
@@ -27,20 +33,30 @@ import Testing
 /// The two numbers from the production crash report.
 private let m2UltraMaxBufferBytes = 41_747_087_360
 private let crashRequestedBytes: UInt64 = 298_090_824_192
-/// `sqrt(298_090_824_192 / 2)` — the request's total patch count.
+/// `sqrt(298_090_824_192 / 2)` — the request's patch count under the
+/// fused-kernel (mask) reading.
 private let crashPatchCount = 386_064
-/// One image at Qwen3-VL's default `max_pixels` (16384 · 28 · 28 pixels over
-/// 14×14 patches) — the largest single image the processor can emit.
-private let maxResolutionImagePatches = 65_536
+/// One image at the processor's `maxPixels` (16384 · 28 · 28 = 12,845,056)
+/// over 16×16 patches — the largest single image `smart_resize` can emit for
+/// the shipping Qwen3-VL preprocessor config.
+private let maxResolutionImagePatches = 50_176
 
 private func limits(
     maxBufferBytes: Int = m2UltraMaxBufferBytes,
+    headFactor: Int = 1,
     operatorMaxPatches: Int? = nil
 ) -> VisionTowerBudget.Limits {
     VisionTowerBudget.Limits(
         maxBufferBytes: maxBufferBytes,
-        maskElementBytes: VisionTowerBudget.maskElementBytes,
+        attentionElementBytes: VisionTowerBudget.attentionElementBytes,
+        headFactor: headFactor,
         operatorMaxPatches: operatorMaxPatches)
+}
+
+/// A square grid with (approximately) `patches` patches.
+private func grid(patches: Int) -> THW {
+    let side = Int(Double(patches).squareRoot().rounded(.down))
+    return THW(1, side, side)
 }
 
 @Suite("VisionTowerBudget arithmetic")
@@ -63,23 +79,29 @@ struct VisionTowerBudgetArithmeticTests {
         #expect(VisionTowerBudget.integerSquareRoot(.max) == Int(UInt32.max))
     }
 
-    @Test("mask bytes reproduce the production crash number exactly")
-    func maskBytesMatchTheCrash() {
+    @Test("both readings of the production crash number are reproduced exactly")
+    func attentionBytesMatchTheCrash() {
+        // Fused kernel: the [1, N, N] mask is the peak.
         #expect(
-            VisionTowerBudget.maskBytes(patches: crashPatchCount, elementBytes: 2)
+            VisionTowerBudget.attentionBytes(patches: crashPatchCount, bytesPerSquaredPatch: 2)
+                == crashRequestedBytes)
+        // Fallback: the [1, 16, N, N] score tensor is the peak, at a quarter
+        // of the patch count.
+        #expect(
+            VisionTowerBudget.attentionBytes(patches: 96_516, bytesPerSquaredPatch: 32)
                 == crashRequestedBytes)
     }
 
-    @Test("mask bytes saturate instead of trapping")
-    func maskBytesSaturate() {
-        #expect(VisionTowerBudget.maskBytes(patches: 0, elementBytes: 2) == 0)
-        #expect(VisionTowerBudget.maskBytes(patches: -4, elementBytes: 2) == 0)
-        #expect(VisionTowerBudget.maskBytes(patches: Int.max, elementBytes: 2) == .max)
+    @Test("attention bytes saturate instead of trapping")
+    func attentionBytesSaturate() {
+        #expect(VisionTowerBudget.attentionBytes(patches: 0, bytesPerSquaredPatch: 2) == 0)
+        #expect(VisionTowerBudget.attentionBytes(patches: -4, bytesPerSquaredPatch: 2) == 0)
+        #expect(VisionTowerBudget.attentionBytes(patches: Int.max, bytesPerSquaredPatch: 2) == .max)
     }
 
     @Test("patch counts come from the grid product and reject overflow")
     func patchCounts() {
-        #expect(VisionTowerBudget.patchCount(THW(1, 256, 256)) == 65_536)
+        #expect(VisionTowerBudget.patchCount(THW(1, 224, 224)) == 50_176)
         #expect(VisionTowerBudget.patchCount(THW(3, 32, 32)) == 3_072)
         #expect(VisionTowerBudget.patchCount(THW(1, Int.max, 2)) == nil)
         #expect(VisionTowerBudget.totalPatchCount([THW(1, 4, 4), THW(2, 4, 4)]) == 48)
@@ -87,18 +109,135 @@ struct VisionTowerBudgetArithmeticTests {
         #expect(
             VisionTowerBudget.totalPatchCount([THW(1, Int.max, 1), THW(1, Int.max, 1)]) == nil)
     }
+}
 
-    @Test("the M2 Ultra admits at most 144,476 patches in one tower call")
-    func maxAdmissiblePatchesOnM2Ultra() throws {
-        let ceiling = try #require(VisionTowerBudget.maxAdmissiblePatches(limits()))
-        #expect(ceiling == 144_476)
-        // The bound is tight in both directions against Metal's own check.
+@Suite("VisionTowerBudget head factor")
+struct VisionTowerHeadFactorTests {
+
+    @Test("MLX's fused head dims cost one N² plane")
+    func fusedHeadDimsCostOnePlane() {
+        for headDim in [64, 80, 128] {
+            let heads = 16
+            #expect(
+                VisionTowerBudget.attentionHeadFactor(
+                    hiddenSize: headDim * heads, numHeads: heads) == 1,
+                "head dim \(headDim)")
+        }
+    }
+
+    @Test("a head dim MLX cannot fuse costs one plane PER HEAD")
+    func fallbackHeadDimsCostAPlanePerHead() {
+        // Qwen3-VL's shipping vision tower: hidden 1152 / 16 heads = 72, which
+        // is not in {64, 80, 128}, so MLX materializes [1, 16, N, N].
+        #expect(VisionTowerBudget.attentionHeadFactor(hiddenSize: 1152, numHeads: 16) == 16)
+        #expect(VisionTowerBudget.attentionHeadFactor(hiddenSize: 1536, numHeads: 16) == 16)
+    }
+
+    @Test("a nonsensical config fails closed, never open")
+    func nonsensicalConfigFailsClosed() {
+        #expect(VisionTowerBudget.attentionHeadFactor(hiddenSize: 0, numHeads: 16) == 16)
+        #expect(VisionTowerBudget.attentionHeadFactor(hiddenSize: 1000, numHeads: 16) == 16)
+        #expect(VisionTowerBudget.attentionHeadFactor(hiddenSize: 1024, numHeads: 0) == 1)
+        #expect(VisionTowerBudget.attentionHeadFactor(hiddenSize: 1024, numHeads: -4) == 1)
+    }
+
+    @Test("the head factor tightens the ceiling by exactly its square root")
+    func headFactorTightensTheCeiling() throws {
+        let fused = try #require(VisionTowerBudget.maxAdmissiblePatches(limits()))
+        let fallback = try #require(
+            VisionTowerBudget.maxAdmissiblePatches(limits(headFactor: 16)))
+        #expect(fused == 144_476)
+        #expect(fallback == 36_119)
+        #expect(fallback * 4 <= fused && (fallback + 1) * 4 > fused)
+    }
+
+    @Test("the limits carrier folds the factor into its per-N² byte cost")
+    func limitsFoldTheFactor() {
+        #expect(limits(headFactor: 1).bytesPerSquaredPatch == 2)
+        #expect(limits(headFactor: 16).bytesPerSquaredPatch == 32)
+        #expect(limits().withHeadFactor(16).bytesPerSquaredPatch == 32)
+        // A factor below 1 is meaningless and must not widen the bound.
+        #expect(limits(headFactor: 0).bytesPerSquaredPatch == 2)
+    }
+}
+
+@Suite("VisionTowerBudget admission — the reported incident")
+struct VisionTowerBudgetIncidentTests {
+
+    /// The whole fix in one assertion: the batched call the provider used to
+    /// make is refused, and every image of that SAME request is admitted once
+    /// the tower is driven per image.
+    @Test("batching six max-resolution images overflows; per-image does not")
+    func perImageRemovesTheAggregateBlowup() {
+        let grids = Array(repeating: grid(patches: maxResolutionImagePatches), count: 6)
+        let aggregate = VisionTowerBudget.totalPatchCount(grids)
+        #expect(aggregate == 6 * maxResolutionImagePatches)
+
+        // Before: one tower call over the concatenated stream.
+        guard case .reject(let reason) = VisionTowerBudget.admit(
+            grids: grids, subject: "this request", limits: limits())
+        else {
+            Issue.record("batched six-image call must be refused on an M2 Ultra")
+            return
+        }
+        #expect(reason.contains("301056"))
+        #expect(reason.contains("144476"))
+
+        // After: one tower call per image.
+        for (index, g) in grids.enumerated() {
+            let subject = EngineV2VisionPrefill.imageSubject(index: index, of: grids.count)
+            #expect(
+                VisionTowerBudget.admit(grids: [g], subject: subject, limits: limits())
+                    == .admit)
+        }
+    }
+
+    @Test("the crash's own patch count is refused with both numbers in the reason")
+    func crashPatchCountIsRefused() {
+        guard case .reject(let reason) = VisionTowerBudget.admit(
+            patches: crashPatchCount, subject: "image 1 of 6", limits: limits())
+        else {
+            Issue.record("the production crash's patch count must be refused")
+            return
+        }
+        #expect(reason.contains("image 1 of 6"))
+        #expect(reason.contains("\(crashPatchCount)"))
+        #expect(reason.contains("277.6 GiB"))
+        #expect(reason.contains("38.9 GiB"))
+    }
+
+    /// Under the fallback reading, a single max-resolution image genuinely
+    /// cannot be served on an M2 Ultra — it needs 80 GiB against a 38.9 GiB
+    /// ceiling. The gate must say so rather than let the allocator find out.
+    @Test("a max-resolution image on a fallback-kernel tower is refused")
+    func fallbackKernelRefusesAMaxResolutionImage() {
+        let fallback = limits(headFactor: 16)
+        guard case .reject = VisionTowerBudget.admit(
+            patches: maxResolutionImagePatches, subject: "this image", limits: fallback)
+        else {
+            Issue.record("50,176 patches × 16 heads cannot fit a 38.9 GiB buffer")
+            return
+        }
+        // The same image is fine once it is under the tighter ceiling.
         #expect(
-            VisionTowerBudget.maskBytes(patches: ceiling, elementBytes: 2)
-                <= UInt64(m2UltraMaxBufferBytes))
+            VisionTowerBudget.admit(patches: 36_119, subject: "this image", limits: fallback)
+                == .admit)
+    }
+
+    @Test("ordinary images stay far under the bound on either kernel")
+    func ordinaryImagesAdmit() {
+        // A ~1150×1150 photo resolves to a 72×72 patch grid — 5,184 patches.
+        let photo = THW(1, 72, 72)
+        for factor in [1, 16] {
+            #expect(
+                VisionTowerBudget.admit(
+                    grids: [photo], subject: "photo", limits: limits(headFactor: factor))
+                    == .admit,
+                "head factor \(factor)")
+        }
         #expect(
-            VisionTowerBudget.maskBytes(patches: ceiling + 1, elementBytes: 2)
-                > UInt64(m2UltraMaxBufferBytes))
+            VisionTowerBudget.attentionBytes(patches: 5_184, bytesPerSquaredPatch: 32)
+                < UInt64(1 << 30))
     }
 
     @Test("an unknown device limit fails open rather than refusing all media")
@@ -108,6 +247,19 @@ struct VisionTowerBudgetArithmeticTests {
         #expect(
             VisionTowerBudget.admit(patches: crashPatchCount, subject: "x", limits: unknown)
                 == .admit)
+    }
+
+    @Test("with only an operator ceiling the reason omits a bogus device limit")
+    func reasonOmitsUnknownDeviceLimit() {
+        guard case .reject(let reason) = VisionTowerBudget.admit(
+            patches: 10_000, subject: "this image",
+            limits: limits(maxBufferBytes: 0, operatorMaxPatches: 4_096))
+        else {
+            Issue.record("an operator ceiling must still refuse")
+            return
+        }
+        #expect(!reason.contains("0.0 GiB"))
+        #expect(reason.contains("4096"))
     }
 
     @Test("the operator ceiling can only lower the device bound")
@@ -132,80 +284,6 @@ struct VisionTowerBudgetArithmeticTests {
         #expect(read("-1") == nil)
         #expect(read("many") == nil)
         #expect(VisionTowerBudget.operatorPatchCeiling(environment: [:]) == nil)
-    }
-}
-
-@Suite("VisionTowerBudget admission — the reported incident")
-struct VisionTowerBudgetIncidentTests {
-
-    /// The whole fix in one assertion: the batched call the provider used to
-    /// make is refused, and every image of that SAME request is admitted once
-    /// the tower is driven per image.
-    @Test("batching six max-resolution images overflows; per-image does not")
-    func perImageRemovesTheAggregateBlowup() {
-        let grids = Array(repeating: THW(1, 256, 256), count: 6)
-        let aggregate = VisionTowerBudget.totalPatchCount(grids)
-        #expect(aggregate == 6 * maxResolutionImagePatches)
-
-        // Before: one tower call over the concatenated stream.
-        guard case .reject(let reason) = VisionTowerBudget.admit(
-            grids: grids, subject: "this request", limits: limits())
-        else {
-            Issue.record("batched six-image call must be refused on an M2 Ultra")
-            return
-        }
-        #expect(reason.contains("393216"))
-        #expect(reason.contains("144476"))
-
-        // After: one tower call per image.
-        for (index, grid) in grids.enumerated() {
-            let subject = EngineV2VisionPrefill.imageSubject(index: index, of: grids.count)
-            #expect(
-                VisionTowerBudget.admit(grids: [grid], subject: subject, limits: limits())
-                    == .admit)
-        }
-    }
-
-    @Test("the crash's own patch count is refused with both numbers in the reason")
-    func crashPatchCountIsRefused() {
-        guard case .reject(let reason) = VisionTowerBudget.admit(
-            patches: crashPatchCount, subject: "image 1 of 6", limits: limits())
-        else {
-            Issue.record("the production crash's patch count must be refused")
-            return
-        }
-        #expect(reason.contains("image 1 of 6"))
-        #expect(reason.contains("\(crashPatchCount)"))
-        #expect(reason.contains("277.6 GiB"))
-        #expect(reason.contains("38.9 GiB"))
-    }
-
-    @Test("two max-resolution images already overflow when batched")
-    func twoImagesAlreadyOverflow() {
-        // 2 × 65,536 = 131,072 patches → 32 GiB mask, still under the buffer
-        // cap; 3 × 65,536 = 196,608 → 72 GiB, over it. The reported 40.5 GiB
-        // refusal sits between the two, which is why the crashes started as
-        // soon as multi-image traffic did.
-        let two = Array(repeating: THW(1, 256, 256), count: 2)
-        let three = Array(repeating: THW(1, 256, 256), count: 3)
-        #expect(VisionTowerBudget.admit(grids: two, subject: "two", limits: limits()) == .admit)
-        guard case .reject = VisionTowerBudget.admit(
-            grids: three, subject: "three", limits: limits())
-        else {
-            Issue.record("three max-resolution images must be refused when batched")
-            return
-        }
-    }
-
-    @Test("ordinary images stay far under the bound")
-    func ordinaryImagesAdmit() {
-        // A ~1024×1024 photo resolves to a 72×72 patch grid — 5,184 patches,
-        // a 51 MiB mask. Three orders of magnitude of headroom.
-        let grid = THW(1, 72, 72)
-        #expect(
-            VisionTowerBudget.admit(grids: [grid], subject: "photo", limits: limits()) == .admit)
-        #expect(
-            VisionTowerBudget.maskBytes(patches: 5_184, elementBytes: 2) < UInt64(64 << 20))
     }
 
     @Test("an unrepresentable grid is refused, never silently truncated")
@@ -233,8 +311,8 @@ struct EngineV2VisionPixelRunTests {
     @Test("a single image owns the whole tensor")
     func singleImageRun() throws {
         let runs = try EngineV2VisionPrefill.imagePixelRuns(
-            grids: [THW(1, 256, 256)], totalRows: 65_536)
-        #expect(runs == [0 ..< 65_536])
+            grids: [THW(1, 224, 224)], totalRows: 50_176)
+        #expect(runs == [0 ..< 50_176])
     }
 
     @Test("grids that under-cover the tensor are refused")
@@ -324,5 +402,32 @@ struct EngineV2VisionMLXFaultTests {
         let text = String(describing: error)
         #expect(text.contains("298090824192"))
         #expect(text.contains("41747087360"))
+    }
+
+    /// A recorded MLX fault must surface as OUR error, not the raw `MLXError`
+    /// — otherwise the telemetry privacy filter drops the byte counts and the
+    /// operator is told only "MLX.MLXError".
+    @Test("a recorded fault is translated, not passed through")
+    func recordedFaultIsTranslated() {
+        #expect(EngineV2VisionPrefill.translatedFault(nil) == nil)
+
+        let recorded = MLX.MLXError.caught(
+            "[metal::malloc] Attempting to allocate 100 bytes which is greater than "
+                + "the maximum allowed buffer size of 50 bytes.")
+        guard let translated = EngineV2VisionPrefill.translatedFault(recorded)
+            as? EngineV2VisionPrefillError,
+            case .towerAllocationRefused(let requested, let limit) = translated
+        else {
+            Issue.record("a recorded allocation refusal must translate to our own case")
+            return
+        }
+        #expect(requested == 100)
+        #expect(limit == 50)
+    }
+
+    @Test("a non-MLX recorded error is passed through unchanged")
+    func nonMLXFaultPassesThrough() {
+        struct Marker: Error, Equatable {}
+        #expect(EngineV2VisionPrefill.translatedFault(Marker()) as? Marker == Marker())
     }
 }

--- a/provider-swift/Tests/ProviderCoreTests/VisionTowerBudgetTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/VisionTowerBudgetTests.swift
@@ -1,0 +1,328 @@
+// Copyright © 2026 Eigen Labs.
+//
+// Regression tests for the v0.8.7 vision-prefill process kill.
+//
+// A Mac Studio M2 Ultra serving `qwen3.6-35b-a3b-vl-mtp-mxfp8` died 8 times in
+// 9 hours with:
+//
+//   MLX/ErrorHandler.swift:345: Fatal error: [metal::malloc] Attempting to
+//   allocate 298090824192 bytes which is greater than the maximum allowed
+//   buffer size of 41747087360 bytes.
+//
+// 298,090,824,192 = 386,064² × 2 — the Qwen3-VL vision tower's dense
+// `ones([1, N, N])` bf16 attention mask over the CONCATENATED patch stream of
+// every image in one request. These tests pin the arithmetic that predicts it,
+// the per-image slicing that stops the request from ever producing it, and the
+// MLX-fault translation that keeps a residual fault from killing the process.
+//
+// All pure arithmetic: no GPU, no weights, no network.
+
+import Foundation
+import MLX
+import MLXLMCommon
+import Testing
+
+@testable import ProviderCore
+
+/// The two numbers from the production crash report.
+private let m2UltraMaxBufferBytes = 41_747_087_360
+private let crashRequestedBytes: UInt64 = 298_090_824_192
+/// `sqrt(298_090_824_192 / 2)` — the request's total patch count.
+private let crashPatchCount = 386_064
+/// One image at Qwen3-VL's default `max_pixels` (16384 · 28 · 28 pixels over
+/// 14×14 patches) — the largest single image the processor can emit.
+private let maxResolutionImagePatches = 65_536
+
+private func limits(
+    maxBufferBytes: Int = m2UltraMaxBufferBytes,
+    operatorMaxPatches: Int? = nil
+) -> VisionTowerBudget.Limits {
+    VisionTowerBudget.Limits(
+        maxBufferBytes: maxBufferBytes,
+        maskElementBytes: VisionTowerBudget.maskElementBytes,
+        operatorMaxPatches: operatorMaxPatches)
+}
+
+@Suite("VisionTowerBudget arithmetic")
+struct VisionTowerBudgetArithmeticTests {
+
+    @Test("integer square root is the exact floor, including past 2^53")
+    func integerSquareRootIsExact() {
+        #expect(VisionTowerBudget.integerSquareRoot(0) == 0)
+        #expect(VisionTowerBudget.integerSquareRoot(1) == 1)
+        #expect(VisionTowerBudget.integerSquareRoot(3) == 1)
+        #expect(VisionTowerBudget.integerSquareRoot(4) == 2)
+        #expect(VisionTowerBudget.integerSquareRoot(8) == 2)
+        #expect(VisionTowerBudget.integerSquareRoot(9) == 3)
+        #expect(VisionTowerBudget.integerSquareRoot(24) == 4)
+        // Past 2^53, where `Double(v).squareRoot()` alone can round UP and
+        // hand back a bound Metal would refuse.
+        let big: UInt64 = 1 << 60
+        #expect(VisionTowerBudget.integerSquareRoot(big) == 1 << 30)
+        #expect(VisionTowerBudget.integerSquareRoot(big - 1) == (1 << 30) - 1)
+        #expect(VisionTowerBudget.integerSquareRoot(.max) == Int(UInt32.max))
+    }
+
+    @Test("mask bytes reproduce the production crash number exactly")
+    func maskBytesMatchTheCrash() {
+        #expect(
+            VisionTowerBudget.maskBytes(patches: crashPatchCount, elementBytes: 2)
+                == crashRequestedBytes)
+    }
+
+    @Test("mask bytes saturate instead of trapping")
+    func maskBytesSaturate() {
+        #expect(VisionTowerBudget.maskBytes(patches: 0, elementBytes: 2) == 0)
+        #expect(VisionTowerBudget.maskBytes(patches: -4, elementBytes: 2) == 0)
+        #expect(VisionTowerBudget.maskBytes(patches: Int.max, elementBytes: 2) == .max)
+    }
+
+    @Test("patch counts come from the grid product and reject overflow")
+    func patchCounts() {
+        #expect(VisionTowerBudget.patchCount(THW(1, 256, 256)) == 65_536)
+        #expect(VisionTowerBudget.patchCount(THW(3, 32, 32)) == 3_072)
+        #expect(VisionTowerBudget.patchCount(THW(1, Int.max, 2)) == nil)
+        #expect(VisionTowerBudget.totalPatchCount([THW(1, 4, 4), THW(2, 4, 4)]) == 48)
+        #expect(VisionTowerBudget.totalPatchCount([]) == 0)
+        #expect(
+            VisionTowerBudget.totalPatchCount([THW(1, Int.max, 1), THW(1, Int.max, 1)]) == nil)
+    }
+
+    @Test("the M2 Ultra admits at most 144,476 patches in one tower call")
+    func maxAdmissiblePatchesOnM2Ultra() throws {
+        let ceiling = try #require(VisionTowerBudget.maxAdmissiblePatches(limits()))
+        #expect(ceiling == 144_476)
+        // The bound is tight in both directions against Metal's own check.
+        #expect(
+            VisionTowerBudget.maskBytes(patches: ceiling, elementBytes: 2)
+                <= UInt64(m2UltraMaxBufferBytes))
+        #expect(
+            VisionTowerBudget.maskBytes(patches: ceiling + 1, elementBytes: 2)
+                > UInt64(m2UltraMaxBufferBytes))
+    }
+
+    @Test("an unknown device limit fails open rather than refusing all media")
+    func unknownDeviceLimitFailsOpen() {
+        let unknown = limits(maxBufferBytes: 0)
+        #expect(VisionTowerBudget.maxAdmissiblePatches(unknown) == nil)
+        #expect(
+            VisionTowerBudget.admit(patches: crashPatchCount, subject: "x", limits: unknown)
+                == .admit)
+    }
+
+    @Test("the operator ceiling can only lower the device bound")
+    func operatorCeilingIsLowerOnly() throws {
+        let tightened = try #require(
+            VisionTowerBudget.maxAdmissiblePatches(limits(operatorMaxPatches: 4_096)))
+        #expect(tightened == 4_096)
+        // A ceiling above the device bound is ignored: the min() keeps Metal's.
+        let loosened = try #require(
+            VisionTowerBudget.maxAdmissiblePatches(limits(operatorMaxPatches: 10_000_000)))
+        #expect(loosened == 144_476)
+    }
+
+    @Test("the operator ceiling only parses positive integers")
+    func operatorCeilingParsing() {
+        let read = { (value: String) in
+            VisionTowerBudget.operatorPatchCeiling(
+                environment: ["DARKBLOOM_VISION_MAX_TOWER_PATCHES": value])
+        }
+        #expect(read("8192") == 8_192)
+        #expect(read("0") == nil)
+        #expect(read("-1") == nil)
+        #expect(read("many") == nil)
+        #expect(VisionTowerBudget.operatorPatchCeiling(environment: [:]) == nil)
+    }
+}
+
+@Suite("VisionTowerBudget admission — the reported incident")
+struct VisionTowerBudgetIncidentTests {
+
+    /// The whole fix in one assertion: the batched call the provider used to
+    /// make is refused, and every image of that SAME request is admitted once
+    /// the tower is driven per image.
+    @Test("batching six max-resolution images overflows; per-image does not")
+    func perImageRemovesTheAggregateBlowup() {
+        let grids = Array(repeating: THW(1, 256, 256), count: 6)
+        let aggregate = VisionTowerBudget.totalPatchCount(grids)
+        #expect(aggregate == 6 * maxResolutionImagePatches)
+
+        // Before: one tower call over the concatenated stream.
+        guard case .reject(let reason) = VisionTowerBudget.admit(
+            grids: grids, subject: "this request", limits: limits())
+        else {
+            Issue.record("batched six-image call must be refused on an M2 Ultra")
+            return
+        }
+        #expect(reason.contains("393216"))
+        #expect(reason.contains("144476"))
+
+        // After: one tower call per image.
+        for (index, grid) in grids.enumerated() {
+            let subject = EngineV2VisionPrefill.imageSubject(index: index, of: grids.count)
+            #expect(
+                VisionTowerBudget.admit(grids: [grid], subject: subject, limits: limits())
+                    == .admit)
+        }
+    }
+
+    @Test("the crash's own patch count is refused with both numbers in the reason")
+    func crashPatchCountIsRefused() {
+        guard case .reject(let reason) = VisionTowerBudget.admit(
+            patches: crashPatchCount, subject: "image 1 of 6", limits: limits())
+        else {
+            Issue.record("the production crash's patch count must be refused")
+            return
+        }
+        #expect(reason.contains("image 1 of 6"))
+        #expect(reason.contains("\(crashPatchCount)"))
+        #expect(reason.contains("277.6 GiB"))
+        #expect(reason.contains("38.9 GiB"))
+    }
+
+    @Test("two max-resolution images already overflow when batched")
+    func twoImagesAlreadyOverflow() {
+        // 2 × 65,536 = 131,072 patches → 32 GiB mask, still under the buffer
+        // cap; 3 × 65,536 = 196,608 → 72 GiB, over it. The reported 40.5 GiB
+        // refusal sits between the two, which is why the crashes started as
+        // soon as multi-image traffic did.
+        let two = Array(repeating: THW(1, 256, 256), count: 2)
+        let three = Array(repeating: THW(1, 256, 256), count: 3)
+        #expect(VisionTowerBudget.admit(grids: two, subject: "two", limits: limits()) == .admit)
+        guard case .reject = VisionTowerBudget.admit(
+            grids: three, subject: "three", limits: limits())
+        else {
+            Issue.record("three max-resolution images must be refused when batched")
+            return
+        }
+    }
+
+    @Test("ordinary images stay far under the bound")
+    func ordinaryImagesAdmit() {
+        // A ~1024×1024 photo resolves to a 72×72 patch grid — 5,184 patches,
+        // a 51 MiB mask. Three orders of magnitude of headroom.
+        let grid = THW(1, 72, 72)
+        #expect(
+            VisionTowerBudget.admit(grids: [grid], subject: "photo", limits: limits()) == .admit)
+        #expect(
+            VisionTowerBudget.maskBytes(patches: 5_184, elementBytes: 2) < UInt64(64 << 20))
+    }
+
+    @Test("an unrepresentable grid is refused, never silently truncated")
+    func overflowingGridIsRefused() {
+        guard case .reject(let reason) = VisionTowerBudget.admit(
+            grids: [THW(1, Int.max, 4)], subject: "image 1 of 1", limits: limits())
+        else {
+            Issue.record("an overflowing grid must be refused")
+            return
+        }
+        #expect(reason.contains("unrepresentable"))
+    }
+}
+
+@Suite("EngineV2VisionPrefill per-image pixel slicing")
+struct EngineV2VisionPixelRunTests {
+
+    @Test("grids tile the packed pixel tensor in prompt order")
+    func runsTileExactly() throws {
+        let grids = [THW(1, 4, 4), THW(1, 2, 2), THW(2, 3, 3)]
+        let runs = try EngineV2VisionPrefill.imagePixelRuns(grids: grids, totalRows: 16 + 4 + 18)
+        #expect(runs == [0 ..< 16, 16 ..< 20, 20 ..< 38])
+    }
+
+    @Test("a single image owns the whole tensor")
+    func singleImageRun() throws {
+        let runs = try EngineV2VisionPrefill.imagePixelRuns(
+            grids: [THW(1, 256, 256)], totalRows: 65_536)
+        #expect(runs == [0 ..< 65_536])
+    }
+
+    @Test("grids that under-cover the tensor are refused")
+    func underCoverageIsRefused() {
+        #expect(throws: EngineV2VisionPrefillError.self) {
+            _ = try EngineV2VisionPrefill.imagePixelRuns(
+                grids: [THW(1, 2, 2)], totalRows: 8)
+        }
+    }
+
+    @Test("grids that over-run the tensor are refused")
+    func overRunIsRefused() {
+        #expect(throws: EngineV2VisionPrefillError.self) {
+            _ = try EngineV2VisionPrefill.imagePixelRuns(
+                grids: [THW(1, 2, 2), THW(1, 2, 2)], totalRows: 6)
+        }
+    }
+
+    @Test("a degenerate grid is refused before it can slice zero rows")
+    func degenerateGridIsRefused() {
+        #expect(throws: EngineV2VisionPrefillError.self) {
+            _ = try EngineV2VisionPrefill.imagePixelRuns(grids: [THW(1, 0, 4)], totalRows: 0)
+        }
+    }
+
+    @Test("subjects name the image being refused")
+    func subjectsAreOperatorReadable() {
+        #expect(EngineV2VisionPrefill.imageSubject(index: 0, of: 1) == "this image")
+        #expect(EngineV2VisionPrefill.imageSubject(index: 3, of: 6) == "image 4 of 6")
+    }
+}
+
+@Suite("EngineV2VisionPrefill MLX fault translation")
+struct EngineV2VisionMLXFaultTests {
+
+    @Test("the production metal::malloc message yields both byte counts")
+    func metalMallocMessageIsParsed() {
+        let message =
+            "[metal::malloc] Attempting to allocate 298090824192 bytes which is greater than "
+            + "the maximum allowed buffer size of 41747087360 bytes."
+        guard case .towerAllocationRefused(let requested, let limit) =
+            EngineV2VisionPrefill.visionPrefillError(for: .caught(message))
+        else {
+            Issue.record("a metal::malloc refusal must carry its two byte counts")
+            return
+        }
+        #expect(requested == crashRequestedBytes)
+        #expect(limit == UInt64(m2UltraMaxBufferBytes))
+    }
+
+    @Test("an unrelated MLX fault degrades to a content-free stage label")
+    func unrelatedFaultIsStageOnly() {
+        guard case .towerFault =
+            EngineV2VisionPrefill.visionPrefillError(for: .caught("broadcast shapes 2,5 3,5"))
+        else {
+            Issue.record("a non-allocation MLX fault must not claim to be one")
+            return
+        }
+    }
+
+    @Test("a malformed allocation message does not invent numbers")
+    func malformedAllocationMessageIsStageOnly() {
+        guard case .towerFault =
+            EngineV2VisionPrefill.visionPrefillError(for: .caught("[metal::malloc] refused"))
+        else {
+            Issue.record("an unparseable allocation message must degrade to a stage label")
+            return
+        }
+    }
+
+    @Test("integer extraction takes the first two runs and stops")
+    func integerExtraction() throws {
+        let pair = try #require(EngineV2VisionPrefill.firstTwoIntegers(in: "a 12 b 34 c 56"))
+        #expect(pair.0 == 12)
+        #expect(pair.1 == 34)
+        #expect(EngineV2VisionPrefill.firstTwoIntegers(in: "only 7") == nil)
+        // A run flush at end-of-string still counts.
+        let trailing = try #require(EngineV2VisionPrefill.firstTwoIntegers(in: "7 then 8"))
+        #expect(trailing.0 == 7)
+        #expect(trailing.1 == 8)
+    }
+
+    @Test("the refusal description reports bytes without any request content")
+    func refusalDescriptionIsContentFree() {
+        let error = EngineV2VisionPrefillError.towerAllocationRefused(
+            requestedBytes: crashRequestedBytes, limitBytes: UInt64(m2UltraMaxBufferBytes))
+        let text = String(describing: error)
+        #expect(text.contains("298090824192"))
+        #expect(text.contains("41747087360"))
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## The incident

A Mac Studio M2 Ultra (64 GB, macOS 26.5.1) serving `qwen3.6-35b-a3b-vl-mtp-mxfp8` on provider **v0.8.7** stopped **8 times in 9 hours**, with the gap between crashes shrinking from 6h45m to 34m as vision traffic grew. Every crash report shows the same faulting thread and the same fatal error:

```
MLX/ErrorHandler.swift:345: Fatal error: [metal::malloc] Attempting to allocate
298090824192 bytes which is greater than the maximum allowed buffer size of
41747087360 bytes.

ProviderLoop.handleInferenceRequest
  → MLXOpenAIService.streamChatCompletionFrames
    → MultiModelBatchSchedulerEngine.streamChatCompletion
      → EngineV2VisionPrefill.prepare
        → mlx_eval → _mlx_error → assertionFailure → SIGTRAP
```

Requested sizes across the 8 crashes: 40.5 GiB (×3), 65.8, 131.9, 175.8, 198.4, 277.6 GiB. Device max buffer: 38.9 GiB. Each crash killed the daemon with every co-batched request on it, left a stale `daemon-state.json` / `provider.pid`, and cost ~5 minutes of watchdog downtime — about 45 minutes total that day.

## Root cause

The Qwen3-VL vision tower attends over N patches with an **N×N-shaped intermediate**, where N is the patch count of *everything handed to one tower call*. `EngineV2VisionPrefill` handed it every image in the request concatenated, so peak device memory was **quadratic in the image count**.

Which N×N buffer is the peak depends on which SDPA kernel MLX picks, and the difference is a factor of the head count:

- `Qwen3VLVision.Attention` always materializes a dense additive mask, `ones([1, N, N])`, to express its per-image block-diagonal attention (`libs/mlx-swift-lm/Libraries/MLXVLM/Models/Qwen3VL.swift:542`).
- MLX's fused full-attention kernel accepts only head dims 64, 80 and 128 (`sdpa_full_supported_head_dim`, `mlx/backend/metal/scaled_dot_product_attention.cpp:625`). With one of those, the mask is the peak.
- Otherwise MLX falls back to the unfused path, which materializes `matmul(q, kᵀ)` at `[1, H, N, N]` (`mlx/fast.cpp:733`) — H times larger.

The crash number is consistent with **both**, because 16 is a perfect square:

```
298,090,824,192  =  386,064² × 2        (mask,   N = 386,064)
                 =  96,516² × 16 × 2    (scores, N =  96,516)
```

Rather than pick a reading, this PR **reads the factor from the model's own vision config against MLX's own kernel-selection rule**, so the fleet is protected either way.

Two independent faults compounded it, exactly as the operator diagnosed:

1. The prefill computes a buffer size from the request and never bounds it by the device maximum.
2. MLX's error handler defaults to `fatalError` (`ErrorHandler.swift:345`), so an allocation the C++ allocator rejects **before allocating anything** takes down the whole process instead of one request.

Answering the operator's two questions directly: **no**, the allocation does not scale with `engine_v2_max_concurrent` — it is per-request, so lowering it to 1 would not have helped; and **no**, the coordinator does not bound image dimensions before dispatch — the provider is the only place that knows the GPU's buffer limit.

## The fix — three layers, all provider-side

**1. Drive the Qwen tower one image at a time** (`EngineV2VisionTowerRun.swift`)

Attention is *already* block-diagonal per image, and every other stage of the tower (patch embed, positional interpolation, rotary coordinates, layer norms, patch merge) is per-token or per-grid. Looping is therefore **mathematically equivalent** — it just never allocates the cross-image half of the mask, which was always zeros doing nothing. (Bitwise equality is not promised: SDPA's reduction shape changes with N, so float reduction order can differ.) Each image's features are evaluated, and checked for MLX faults, before the next image's graph is built.

Peak attention bytes: `(Σᵢ nᵢ)²` → `(maxᵢ nᵢ)²`.

Gemma 4's SigLIP tower already loops `0 ..< B` internally (`visionFeatureList`); Qwen was the outlier.

**2. Admit against the device's real limit before doing any work** (`VisionTowerBudget.swift`)

`MTLDevice.maxBufferLength` is a hard per-allocation ceiling and `MetalAllocator::malloc` checks it *before* allocating, so the admissible patch count is closed form:

```
N_max = floor(sqrt(maxBufferLength / (headFactor × elementBytes)))
```

On an M2 Ultra that is 144,476 patches with the fused kernel and 36,119 with the fallback. Computed from the processor's `[THW]` grids and the model config — deterministic, GPU-free, testable. Over-budget images refuse **retriably** (`.requestRejected` → 503): the bound scales with the machine, so a larger node can serve the same request and the coordinator's pre-content failover should look for one. `DARKBLOOM_VISION_MAX_TOWER_PATCHES` tightens the bound only.

**3. Contain MLX faults instead of dying from them** (`EngineV2VisionPrefill.prepare`)

The prefill runs under `MLX.withError`. Critically, that handler **records and returns** — it does not unwind — so the error box is threaded to every `eval` site and checked there rather than only on block exit. Without that, a refused allocation on image 1 would be followed by n−1 more full tower passes on a GPU that had just failed, all under the model container's lock, and any later Swift throw would silently replace the allocation error with a misleading one.

Allocation refusals are translated into `towerAllocationRefused(requestedBytes:limitBytes:)` — the two integers MLX reported and **nothing else**, so the error enum's content-safe-by-construction invariant survives a foreign fault.

Also: `prepare` is split into a thin dispatcher plus `buildQwenSubmission` / `buildGemmaSubmission`, and tower invocation moves into its own file.

## Before / after

```mermaid
flowchart TB
  subgraph Before["BEFORE — v0.8.7"]
    direction TB
    B1["POST /v1/chat/completions<br/>multiple images"] --> B2[MediaIngest.buildUserInput<br/>pixel caps only]
    B2 --> B3["Qwen3VLProcessor.prepare<br/>concatenates ALL images<br/>into one packed tensor"]
    B3 --> B4["EngineV2VisionPrefill.prepare<br/>ONE visionFeatures call<br/>with every grid"]
    B4 --> B5["Qwen3VLVision.Attention<br/>N×N intermediate over the<br/>whole concatenated stream"]
    B5 --> B6["eval → metal::malloc<br/>277.6 GiB &gt; 38.9 GiB limit"]
    B6 --> B7["MLX ErrorHandler.dispatch<br/>no handler installed"]
    B7 --> B8["fatalError → SIGTRAP"]
    B8 --> B9["PROVIDER PROCESS DEAD<br/>all co-batched requests lost<br/>stale pid file, 5-min watchdog gap"]
  end
```

```mermaid
flowchart TB
  subgraph After["AFTER"]
    direction TB
    A1["POST /v1/chat/completions<br/>multiple images"] --> A2[MediaIngest.buildUserInput]
    A2 --> A3["Qwen3VLProcessor.prepare<br/>same packed tensor + grids"]
    A3 --> A4["EngineV2VisionPrefill.prepare<br/>wrapped in MLX.withError"]
    A4 --> A5["qwenPerImageVisionFeatures<br/>headFactor from the model config"]
    A5 --> A6{"VisionTowerBudget.admit<br/>per image"}
    A6 -->|admit| A7["visionFeatures(one image)<br/>eval → check the error box<br/>→ next image"]
    A7 --> A8["spans carved → CBv2 submit<br/>200 OK, request served"]
    A6 -->|"too large for THIS GPU"| A9["towerBudgetExceeded<br/>503 → coordinator reroutes<br/>to a larger node"]
    A7 -.->|"residual MLX fault"| A10["towerAllocationRefused(bytes, limit)<br/>503, loop stops at the fault"]
    A10 -.-> A11["PROVIDER STAYS UP"]
    A9 -.-> A11
  end
```

Code-level delta:

```mermaid
flowchart LR
  subgraph CodeBefore["Before"]
    P1["EngineV2VisionPrefill.prepare<br/>(one 130-line closure)"] --> P2["wrapper.visionFeatures(<br/>allPixels, allGrids)"]
    P2 --> P3["eval(imageFeatures + positionIds)"]
  end
  subgraph CodeAfter["After"]
    Q1["prepare<br/>(MLX.withError + dispatch)"] --> Q2[buildSubmission]
    Q2 --> Q3[buildQwenSubmission]
    Q2 --> Q4[buildGemmaSubmission]
    Q3 --> Q5["qwenPerImageVisionFeatures<br/>(EngineV2VisionTowerRun)"]
    Q5 --> Q6[imagePixelRuns]
    Q5 --> Q7["VisionTowerBudget.admit<br/>+ attentionHeadFactor"]
    Q5 --> Q8["visionFeatures(one image)<br/>eval + throwIfMLXFaulted<br/>× image count"]
    Q1 --> Q9["visionPrefillError(for: MLXError)"]
  end
```

## Verification

`VisionTowerBudgetTests.swift` adds 28 tests over the admission arithmetic, the head-factor derivation, the per-image slicing, and the MLX-fault translation, pinned to the production crash numbers. `QwenPerImageVisionEquivalenceTests.swift` adds the measurement behind the correctness claim: a live-gated test that runs the same three-image request through the batched seam and through `qwenPerImageVisionFeatures` and compares features elementwise, plus a companion asserting the head factor derived from the live config agrees with MLX's rule. Both run in CI on the macOS runner (`swift test`); the live pair needs `DARKBLOOM_LIVE_MLX_TESTS=1 DARKBLOOM_LIVE_MLX_QWEN36=1` and real weights.

Because MLX needs Metal, the arithmetic was additionally compiled and **executed** on this Linux agent against a byte-identical copy of `VisionTowerBudget.swift` with only `MLX`/`MLXLMCommon` stubbed:

[swift run Verify — all vision tower budget checks pass](https://cursor.com/agents/bc-08c3df13-d956-5fba-9a68-59ffb1ccd7e1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fvision_budget_verification_v2.png)

Highlights: both readings of the crash byte count round-trip exactly; the head factor is derived from the config rather than assumed; the M2 Ultra ceilings (144,476 / 36,119 patches) are tight in both directions against Metal's own check; and the before/after table shows the batched call refused while every image of the same request is admitted per-image.

## Not in scope (flagged for follow-up)

- `MediaIngest.visionTokensPerImage = 1024` is a Gemma-4-derived figure. A max-resolution Qwen3-VL image is ~12,544 soft tokens, so the vision gate's KV pre-reservation under-charges Qwen by an order of magnitude. It is bounded by the context clamp and re-reserved with real token counts at `submitTokenized`, so it is an admission-accuracy gap rather than a crash, but it should be made family-aware.
- `MediaIngest` caps aggregate *pixels* (384 MP) but not image *count*, so a legal request can drive many sequential tower calls under the container lock before the token budget rejects it at submit. Worth an explicit per-request image cap.
- The dense mask itself is a library-level wart: for a single segment the mask is entirely zeros, and in general the tower should loop over `cuSeqlens` segments (or pass `mask: .none`) rather than materialize `[1, N, N]`. That fix belongs in `Layr-Labs/mlx-swift-lm`; this PR removes the provider's contribution to it.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://darkbloom.slack.com/archives/C0B0CAQC8P5/p1787343622971919?thread_ts=1787343622.971919&cid=C0B0CAQC8P5)

<div><a href="https://cursor.com/agents/bc-08c3df13-d956-5fba-9a68-59ffb1ccd7e1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-08c3df13-d956-5fba-9a68-59ffb1ccd7e1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/660"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789972236&installation_model_id=21733&pr_number=660&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F660&signature=73280808bd3671e22f03465044c15432c219c9e082388656525be531e1d14721"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->