### PR TITLE
fix(api): unfunded "prefer" self-route runs free on the owner's machine instead of 402

### DIFF
--- a/console-ui/__tests__/chat-error-message.test.ts
+++ b/console-ui/__tests__/chat-error-message.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { chatErrorMessage } from "@/lib/chat/errors";
+
+// Copy mapping for upstream chat failures. The 402 cases are the regression:
+// the console used to answer every payment error with "buy credits", including
+// the ones buying credits cannot fix.
+describe("chatErrorMessage", () => {
+  const body = (message: string, code?: string) =>
+    JSON.stringify({ error: { message, code } });
+
+  it("explains self-route machine states from the error code", () => {
+    expect(chatErrorMessage(503, body("...", "machine_offline"), { code: "machine_offline" }))
+      .toContain("Your machine is offline");
+    expect(chatErrorMessage(409, body("...", "no_linked_machine"), { code: "no_linked_machine" }))
+      .toContain("No machine linked");
+    expect(chatErrorMessage(429, body("...", "machine_busy"), { code: "machine_busy" }))
+      .toContain("Your machine is busy");
+  });
+
+  it("surfaces the coordinator's 402 explanation instead of a blanket credits pitch", () => {
+    const message =
+      "your machine cannot serve this request right now (offline, model not loaded, or below a required capability) and your balance is too low for the paid fallback — start your Darkbloom node and load the model, or add funds at /billing";
+    const out = chatErrorMessage(402, body(message, "insufficient_quota"), {
+      message,
+      code: "insufficient_quota",
+    });
+    expect(out).toContain("machine cannot serve this request");
+    expect(out).toContain("add funds at /billing");
+    expect(out.startsWith("Your machine")).toBe(true); // rendered as a sentence
+  });
+
+  it("keeps a spend-cap 402 pointed at the key, not at Billing", () => {
+    const message =
+      "API key spend limit reached (monthly cap $5.00, used $5.00) — raise this key's limit or use another key";
+    const out = chatErrorMessage(402, body(message, "insufficient_quota"), {
+      message,
+      code: "insufficient_quota",
+    });
+    expect(out).toBe(message);
+    expect(out).not.toContain("buy credits");
+  });
+
+  it("falls back to the credits pitch when the 402 carries no explanation", () => {
+    expect(chatErrorMessage(402, "{}", {})).toBe(
+      "Insufficient credits — buy credits in Billing to continue",
+    );
+  });
+
+  it("maps a queue-timeout 503 to the busy-network copy", () => {
+    const message = 'all providers for model "x" are at capacity (queue timeout)';
+    expect(chatErrorMessage(503, body(message), { message })).toBe(
+      "All providers are busy — please try again in a moment",
+    );
+  });
+
+  it("falls back to the raw body when the error object has no message", () => {
+    expect(chatErrorMessage(500, "upstream exploded", {})).toBe(
+      "Request failed (500): upstream exploded",
+    );
+  });
+});

--- a/console-ui/__tests__/chat-error-message.test.ts
+++ b/console-ui/__tests__/chat-error-message.test.ts
@@ -46,10 +46,26 @@ describe("chatErrorMessage", () => {
     );
   });
 
-  it("maps a queue-timeout 503 to the busy-network copy", () => {
+  // The coordinator writes this verdict as a 429 + Retry-After, so a 503-only
+  // match left the copy unreachable in production.
+  it("maps a queue timeout to the busy-network copy on the 429 the coordinator sends", () => {
     const message = 'all providers for model "x" are at capacity (queue timeout)';
-    expect(chatErrorMessage(503, body(message), { message })).toBe(
-      "All providers are busy — please try again in a moment",
+    const busy = "All providers are busy — please try again in a moment";
+    expect(chatErrorMessage(429, body(message, "rate_limit_exceeded"), {
+      message,
+      code: "rate_limit_exceeded",
+    })).toBe(busy);
+    expect(chatErrorMessage(503, body(message), { message })).toBe(busy);
+  });
+
+  it("does not treat an inherited object key as a self-route code", () => {
+    // `code` is wire data; an object-literal lookup would return Object.prototype
+    // members and hand the UI a function typed as string.
+    expect(chatErrorMessage(500, "upstream exploded", { code: "toString" })).toBe(
+      "Request failed (500): upstream exploded",
+    );
+    expect(chatErrorMessage(500, "upstream exploded", { code: "constructor" })).toBe(
+      "Request failed (500): upstream exploded",
     );
   });
 

--- a/console-ui/package-lock.json
+++ b/console-ui/package-lock.json
@@ -2274,9 +2274,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2292,9 +2289,6 @@
       "integrity": "sha512-eIjcpx2fnnFSSkZDbTxy74KnokUXDjfoLClpWelfgHLf621aTqswhwXQ7GkD5K5rplrS6LZ/Bj+mVuvzluBOEg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2312,9 +2306,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2330,9 +2321,6 @@
       "integrity": "sha512-I3UgPds7G4ZYnTb/H+5GBGuUT2DhAk6j0mL6A4s63RjFs74wB2hOWP0vaxsK+3NJraExt3eYEPQ/UtT0x/64Nw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4181,9 +4169,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4201,9 +4186,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4221,9 +4203,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4241,9 +4220,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4261,9 +4237,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4281,9 +4254,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/console-ui/package-lock.json
+++ b/console-ui/package-lock.json
@@ -2274,6 +2274,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2289,6 +2292,9 @@
       "integrity": "sha512-eIjcpx2fnnFSSkZDbTxy74KnokUXDjfoLClpWelfgHLf621aTqswhwXQ7GkD5K5rplrS6LZ/Bj+mVuvzluBOEg==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2306,6 +2312,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2321,6 +2330,9 @@
       "integrity": "sha512-I3UgPds7G4ZYnTb/H+5GBGuUT2DhAk6j0mL6A4s63RjFs74wB2hOWP0vaxsK+3NJraExt3eYEPQ/UtT0x/64Nw==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4169,6 +4181,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4186,6 +4201,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4203,6 +4221,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4220,6 +4241,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4237,6 +4261,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4254,6 +4281,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/console-ui/src/lib/chat/errors.ts
+++ b/console-ui/src/lib/chat/errors.ts
@@ -8,16 +8,26 @@ export type UpstreamError = { message?: string; code?: string };
  * Self-route outcomes the coordinator names with a stable code. These are
  * deterministic states of the caller's own machine, so the console explains the
  * machine rather than echoing the API copy.
+ *
+ * A Map, not an object literal: `code` comes off the wire, and an object lookup
+ * would resolve inherited keys ("toString", "constructor") to a function the
+ * `string` type says is impossible.
  */
-const SELF_ROUTE_COPY: Record<string, string> = {
-  no_linked_machine:
+const SELF_ROUTE_COPY = new Map<string, string>([
+  [
+    "no_linked_machine",
     "No machine linked to your account — run `darkbloom login` on your Mac, then try again.",
-  machine_offline:
+  ],
+  [
+    "machine_offline",
     "Your machine is offline — start your Darkbloom node and try again. (Free-only self-route won't fall back to the paid network.)",
-  model_not_loaded:
+  ],
+  [
+    "model_not_loaded",
     "This model isn't loaded on your machine — load it on your node, then try again.",
-  machine_busy: "Your machine is busy — try again in a moment.",
-};
+  ],
+  ["machine_busy", "Your machine is busy — try again in a moment."],
+]);
 
 /** Server copy leads lower-case; the console renders it as a sentence. */
 function asSentence(text: string): string {
@@ -30,12 +40,19 @@ export function chatErrorMessage(
   rawBody: string,
   error?: UpstreamError,
 ): string {
-  const code = error?.code ?? "";
-  if (SELF_ROUTE_COPY[code]) {
-    return SELF_ROUTE_COPY[code];
+  const selfRouteCopy = SELF_ROUTE_COPY.get(error?.code ?? "");
+  if (selfRouteCopy) {
+    return selfRouteCopy;
   }
   const detail = (error?.message ?? "").trim();
-  if (status === 503 && (detail || rawBody).includes("queue timeout")) {
+  // The queue-timeout verdict ships as a 429 + Retry-After (the queue-wait
+  // failure in the coordinator's dispatch.go and consumer.go), not a 503 — this
+  // branch matched only 503 and so never fired. 503 stays accepted so the copy
+  // survives if that verdict ever moves back.
+  if (
+    (status === 429 || status === 503) &&
+    (detail || rawBody).includes("queue timeout")
+  ) {
     return "All providers are busy — please try again in a moment";
   }
   if (status === 402) {

--- a/console-ui/src/lib/chat/errors.ts
+++ b/console-ui/src/lib/chat/errors.ts
@@ -1,0 +1,52 @@
+// User-facing copy for upstream chat failures. Split out of stream.ts so the
+// mapping is unit-testable on its own (see __tests__/chat-error-message.test.ts).
+
+/** The OpenAI-shaped error object the coordinator returns on a failure. */
+export type UpstreamError = { message?: string; code?: string };
+
+/**
+ * Self-route outcomes the coordinator names with a stable code. These are
+ * deterministic states of the caller's own machine, so the console explains the
+ * machine rather than echoing the API copy.
+ */
+const SELF_ROUTE_COPY: Record<string, string> = {
+  no_linked_machine:
+    "No machine linked to your account — run `darkbloom login` on your Mac, then try again.",
+  machine_offline:
+    "Your machine is offline — start your Darkbloom node and try again. (Free-only self-route won't fall back to the paid network.)",
+  model_not_loaded:
+    "This model isn't loaded on your machine — load it on your node, then try again.",
+  machine_busy: "Your machine is busy — try again in a moment.",
+};
+
+/** Server copy leads lower-case; the console renders it as a sentence. */
+function asSentence(text: string): string {
+  return text.charAt(0).toUpperCase() + text.slice(1);
+}
+
+/** Map an upstream failure (status + error object + raw body) to display copy. */
+export function chatErrorMessage(
+  status: number,
+  rawBody: string,
+  error?: UpstreamError,
+): string {
+  const code = error?.code ?? "";
+  if (SELF_ROUTE_COPY[code]) {
+    return SELF_ROUTE_COPY[code];
+  }
+  const detail = (error?.message ?? "").trim();
+  if (status === 503 && (detail || rawBody).includes("queue timeout")) {
+    return "All providers are busy — please try again in a moment";
+  }
+  if (status === 402) {
+    // Every coordinator 402 already names the actual blocker and its fix: an
+    // exhausted per-key spend cap, a prompt that outruns the balance, or — with
+    // "My Machine" on — a machine that couldn't take the request while the
+    // balance couldn't fund the paid fallback. Collapsing all of those into
+    // "buy credits" points most of them at a page that cannot help.
+    return detail
+      ? asSentence(detail)
+      : "Insufficient credits — buy credits in Billing to continue";
+  }
+  return `Request failed (${status}): ${detail || rawBody}`;
+}

--- a/console-ui/src/lib/chat/stream.ts
+++ b/console-ui/src/lib/chat/stream.ts
@@ -22,32 +22,10 @@ import type {
   TrustMetadata,
 } from "../api/types";
 import { ThinkStreamParser } from "./think-parser";
+import { chatErrorMessage } from "./errors";
 import { readSsePayloads } from "./sse";
 
 type SealContext = { ephemPriv: Uint8Array; coordPub: Uint8Array };
-
-/** Map an upstream error (status + message + error code) to user-facing copy. */
-function chatErrorMessage(status: number, msg: string, code?: string): string {
-  if (code === "no_linked_machine") {
-    return "No machine linked to your account — run `darkbloom login` on your Mac, then try again.";
-  }
-  if (code === "machine_offline") {
-    return "Your machine is offline — start your Darkbloom node and try again. (Free-only self-route won't fall back to the paid network.)";
-  }
-  if (code === "model_not_loaded") {
-    return "This model isn't loaded on your machine — load it on your node, then try again.";
-  }
-  if (code === "machine_busy") {
-    return "Your machine is busy — try again in a moment.";
-  }
-  if (status === 503 && msg.includes("queue timeout")) {
-    return "All providers are busy — please try again in a moment";
-  }
-  if (status === 402) {
-    return "Insufficient credits — buy credits in Billing to continue";
-  }
-  return `Request failed (${status}): ${msg}`;
-}
 
 /** Extract the provider trust metadata advertised on the response headers. */
 function extractTrustMeta(res: Response): TrustMetadata {
@@ -185,9 +163,7 @@ export async function streamChat(
     }
     try {
       const errData = JSON.parse(text);
-      callbacks.onError(
-        chatErrorMessage(res.status, errData?.error?.message || text, errData?.error?.code),
-      );
+      callbacks.onError(chatErrorMessage(res.status, text, errData?.error));
     } catch {
       callbacks.onError(`Request failed (${res.status}): ${text}`);
     }

--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -1709,7 +1709,7 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 
 	// Pre-flight balance reservation + per-key spend cap (see
 	// reserveInferenceBalance). Self-route and a nil billing backend are free.
-	reservedMicroUSD, serviceReservation, reserveHandled := s.reserveInferenceBalance(w, r, parsed, balanceReservationParams{
+	reservation, reserveHandled := s.reserveInferenceBalance(w, r, parsed, balanceReservationParams{
 		model:                 model,
 		publicModel:           publicModel,
 		billingPromptTokens:   billingPromptTokens,
@@ -1718,11 +1718,16 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 		stream:                stream,
 		requiresVision:        requiresVision,
 		hasTools:              hasTools,
+		traits:                routingTraits,
 		policy:                policy,
 	})
 	if reserveHandled {
 		return
 	}
+	// A prefer request that could not fund the paid fallback now runs owned-only
+	// and free (unfundedPreferPolicy); adopt that policy before any gate reads it.
+	policy = reservation.policy
+	reservedMicroUSD, serviceReservation := reservation.microUSD, reservation.service
 	timing.ReservedAt = time.Now()
 
 	// Refund reservation on early errors (before inference starts).
@@ -4000,11 +4005,43 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 		return
 	}
 
+	lowerGenericBodyForModel := func(candidateModel string) ([]byte, []byte, error) {
+		candidateParsed := make(map[string]any, len(parsed))
+		for key, value := range parsed {
+			candidateParsed[key] = value
+		}
+		candidateParsed["model"] = candidateModel
+		endpointBody, _ := marshalForwardBody(candidateParsed)
+		inferenceBody, loweringErr := promptcontract.LowerProviderBody(
+			endpointKind, endpointBody)
+		if loweringErr != nil {
+			inferenceBody = endpointBody
+		}
+		return endpointBody, inferenceBody, loweringErr
+	}
+	routingTraitsForModel := func(candidateModel string) registry.RequestTraits {
+		_, candidateBody, _ := lowerGenericBodyForModel(candidateModel)
+		traits, _ := routingTraitsForProviderBody(
+			hasTools, candidateBody, requiresVision)
+		traits.RequiresToolConstraint = requiresToolConstraint
+		traits.ToolChoiceMode = string(validatedMode)
+		traits.ToolChoiceName = toolChoiceName
+		traits.ParallelToolCalls = parallelToolCalls
+		return traits
+	}
+	providerBodyErrorForModel := func(candidateModel string) error {
+		_, candidateBody, _ := lowerGenericBodyForModel(candidateModel)
+		_, sizeErr := routingTraitsForProviderBody(
+			hasTools, candidateBody, requiresVision)
+		return sizeErr
+	}
+	routingTraits := routingTraitsForModel(model)
+
 	// Pre-flight balance reservation + per-key spend cap (see
 	// reserveInferenceBalance). Self-route and a nil billing backend are free.
 	consumerKey := consumerKeyFromContext(r.Context())
 	consumerLocation := s.requestLocation(r)
-	reservedMicroUSD, serviceReservation, reserveHandled := s.reserveInferenceBalance(w, r, parsed, balanceReservationParams{
+	reservation, reserveHandled := s.reserveInferenceBalance(w, r, parsed, balanceReservationParams{
 		model:                 model,
 		publicModel:           publicModel,
 		billingPromptTokens:   billingPromptTokens,
@@ -4013,11 +4050,16 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 		stream:                stream,
 		requiresVision:        requiresVision,
 		hasTools:              hasTools,
+		traits:                routingTraits,
 		policy:                policy,
 	})
 	if reserveHandled {
 		return
 	}
+	// A prefer request that could not fund the paid fallback now runs owned-only
+	// and free (unfundedPreferPolicy); adopt that policy before any gate reads it.
+	policy = reservation.policy
+	reservedMicroUSD, serviceReservation := reservation.microUSD, reservation.service
 	refundReservation := func() {
 		if reservedMicroUSD > 0 {
 			s.releaseInitialReservation(consumerKey, model, reservedMicroUSD, serviceReservation)
@@ -4056,40 +4098,9 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 		return info
 	}
 
-	lowerGenericBodyForModel := func(candidateModel string) ([]byte, []byte, error) {
-		candidateParsed := make(map[string]any, len(parsed))
-		for key, value := range parsed {
-			candidateParsed[key] = value
-		}
-		candidateParsed["model"] = candidateModel
-		endpointBody, _ := marshalForwardBody(candidateParsed)
-		inferenceBody, loweringErr := promptcontract.LowerProviderBody(
-			endpointKind, endpointBody)
-		if loweringErr != nil {
-			inferenceBody = endpointBody
-		}
-		return endpointBody, inferenceBody, loweringErr
-	}
-	routingTraitsForModel := func(candidateModel string) registry.RequestTraits {
-		_, candidateBody, _ := lowerGenericBodyForModel(candidateModel)
-		traits, _ := routingTraitsForProviderBody(
-			hasTools, candidateBody, requiresVision)
-		traits.RequiresToolConstraint = requiresToolConstraint
-		traits.ToolChoiceMode = string(validatedMode)
-		traits.ToolChoiceName = toolChoiceName
-		traits.ParallelToolCalls = parallelToolCalls
-		return traits
-	}
-	providerBodyErrorForModel := func(candidateModel string) error {
-		_, candidateBody, _ := lowerGenericBodyForModel(candidateModel)
-		_, sizeErr := routingTraitsForProviderBody(
-			hasTools, candidateBody, requiresVision)
-		return sizeErr
-	}
 	var endpointBody, inferenceBody []byte
 	var loweringErr error
 	var providerBodyOverflowErr error
-	routingTraits := routingTraitsForModel(model)
 	refreshGenericBody := func(newModel string) bool {
 		endpointBody, inferenceBody, loweringErr = lowerGenericBodyForModel(newModel)
 		routingTraits, _ = routingTraitsForProviderBody(

--- a/coordinator/api/inference_admission.go
+++ b/coordinator/api/inference_admission.go
@@ -39,23 +39,44 @@ type balanceReservationParams struct {
 	stream                bool
 	requiresVision        bool
 	hasTools              bool
-	policy                selfRoutePolicy
+	// traits is the full routing trait set for this request. It is what decides
+	// whether an unfunded PREFER request can still run free on the caller's own
+	// machine (unfundedPreferPolicy), so it must be the same set admission uses
+	// — a partial reconstruction would call an owned machine serviceable for a
+	// shape routing would later refuse.
+	traits registry.RequestTraits
+	policy selfRoutePolicy
+}
+
+// balanceReservation is the outcome of the shared pre-flight reservation: the
+// amount held (0 on the free paths), whether it is a service-account hold, and
+// the self-route policy the REST of the request must run under. The policy is
+// returned rather than assumed because an unfunded PREFER request downgrades to
+// exclusive self-route here (see unfundedPreferPolicy) and every downstream
+// gate — catalog bypass, media egress, admission, dispatch, settlement — has to
+// observe that decision.
+type balanceReservation struct {
+	microUSD int64
+	service  bool
+	policy   selfRoutePolicy
 }
 
 // reserveInferenceBalance performs the shared pre-flight balance reservation +
-// per-key spend cap for both inference handlers. Self-route (policy.enabled) and
-// a nil billing backend skip it (the request is free). On a spend-cap or
-// insufficient-funds rejection it writes the exact terminal response and returns
-// handled=true; otherwise it returns the reserved amount and whether it was a
-// service-account reservation. The post-inference charge refunds any unused
-// portion; the routing estimate is kept separate so capacity checks aren't
-// over-inflated.
-func (s *Server) reserveInferenceBalance(w http.ResponseWriter, r *http.Request, parsed map[string]any, p balanceReservationParams) (reservedMicroUSD int64, serviceReservation bool, handled bool) {
+// per-key spend cap for both inference handlers. Exclusive self-route
+// (policy.enabled) and a nil billing backend skip it (the request is free), and
+// a PREFER request that cannot fund the paid fallback but owns a machine able
+// to serve it is downgraded to exclusive self-route instead of being rejected.
+// On a spend-cap or insufficient-funds rejection it writes the exact terminal
+// response and returns handled=true. The post-inference charge refunds any
+// unused portion; the routing estimate is kept separate so capacity checks
+// aren't over-inflated.
+func (s *Server) reserveInferenceBalance(w http.ResponseWriter, r *http.Request, parsed map[string]any, p balanceReservationParams) (balanceReservation, bool) {
 	// Self-route is free: skip the pre-flight balance reservation and the
 	// per-key spend cap entirely. A zero-balance owner must never be blocked
 	// from running on their own machine, and a self_route_only key never spends.
+	out := balanceReservation{policy: p.policy}
 	if s.billing == nil || p.policy.enabled {
-		return 0, false, false
+		return out, false
 	}
 	consumerKey := consumerKeyFromContext(r.Context())
 	// Normally the byte-count billing bound dominates the routing estimate. A
@@ -64,17 +85,21 @@ func (s *Server) reserveInferenceBalance(w http.ResponseWriter, r *http.Request,
 	// larger bound so a low-balance caller cannot trigger coordinator egress and
 	// only then fail the platform-price balance check.
 	reservationPromptTokens := max(p.billingPromptTokens, p.estimatedPromptTokens)
-	reservedMicroUSD = s.reservationCost(p.model, reservationPromptTokens, p.requestedMaxTokens)
-	// Per-key spend cap (phase 1) — checked before the reservation so a capped
-	// key never debits the account ledger.
-	if msg, ok := s.checkKeySpendCap(r.Context(), reservedMicroUSD); !ok {
+	reservedMicroUSD := s.reservationCost(p.model, reservationPromptTokens, p.requestedMaxTokens)
+	// An unfunded PREFER request keeps running when the caller's own machine can
+	// serve it; only a caller with no such machine sees the 402.
+	unfunded := func(reasonCode, errType, msg string) (balanceReservation, bool) {
+		if free, ok := s.unfundedPreferPolicy(p.model, p.traits, p.requiresVision, p.policy); ok {
+			out.policy = free
+			return out, false
+		}
 		s.recordRejection(rejectionInfo{
 			r:                     r,
 			stage:                 "balance",
-			reasonCode:            "insufficient_quota",
+			reasonCode:            reasonCode,
 			httpStatus:            http.StatusPaymentRequired,
 			keyID:                 keyIDFromContext(r.Context()),
-			consumerKeyHash:       store.HashKey(consumerKeyFromContext(r.Context())),
+			consumerKeyHash:       store.HashKey(consumerKey),
 			requestedModel:        p.publicModel,
 			resolvedModel:         p.model,
 			stream:                p.stream,
@@ -82,40 +107,29 @@ func (s *Server) reserveInferenceBalance(w http.ResponseWriter, r *http.Request,
 			requestedMaxTokens:    p.requestedMaxTokens,
 			requiresVision:        p.requiresVision,
 			hasTools:              p.hasTools,
+			selfRouteOnly:         p.policy.enabled,
+			preferOwner:           p.policy.prefer,
 			params:                rejectionSamplingParams(parsed),
 		})
-		writeJSON(w, http.StatusPaymentRequired, errorResponse("insufficient_quota", msg, withCode("insufficient_quota")))
-		return reservedMicroUSD, false, true
+		writeJSON(w, http.StatusPaymentRequired, errorResponse(errType, msg, withCode("insufficient_quota")))
+		return out, true
 	}
-	var err error
-	serviceReservation, err = s.reserveInitialBalance(consumerKey, p.model, reservedMicroUSD)
+	// Per-key spend cap (phase 1) — checked before the reservation so a capped
+	// key never debits the account ledger.
+	if msg, ok := s.checkKeySpendCap(r.Context(), reservedMicroUSD); !ok {
+		return unfunded("insufficient_quota", "insufficient_quota", msg)
+	}
+	serviceReservation, err := s.reserveInitialBalance(consumerKey, p.model, reservedMicroUSD)
 	if err != nil {
 		if errors.Is(err, store.ErrInsufficientBalance) {
-			s.recordRejection(rejectionInfo{
-				r:                     r,
-				stage:                 "balance",
-				reasonCode:            "insufficient_funds",
-				httpStatus:            http.StatusPaymentRequired,
-				keyID:                 keyIDFromContext(r.Context()),
-				consumerKeyHash:       store.HashKey(consumerKeyFromContext(r.Context())),
-				requestedModel:        p.publicModel,
-				resolvedModel:         p.model,
-				stream:                p.stream,
-				estimatedPromptTokens: p.estimatedPromptTokens,
-				requestedMaxTokens:    p.requestedMaxTokens,
-				requiresVision:        p.requiresVision,
-				hasTools:              p.hasTools,
-				params:                rejectionSamplingParams(parsed),
-			})
-			writeJSON(w, http.StatusPaymentRequired, errorResponse("insufficient_funds",
-				"your balance is too low for this request — add funds at /billing or lower max_tokens", withCode("insufficient_quota")))
-		} else {
-			s.logger.Error("balance reservation failed (DB error)", "consumer_key", consumerKey, "error", err)
-			s.writeServiceUnavailable(w, p.model)
+			return unfunded("insufficient_funds", "insufficient_funds", insufficientBalanceMessage(p.policy))
 		}
-		return reservedMicroUSD, serviceReservation, true
+		s.logger.Error("balance reservation failed (DB error)", "consumer_key", consumerKey, "error", err)
+		s.writeServiceUnavailable(w, p.model)
+		return out, true
 	}
-	return reservedMicroUSD, serviceReservation, false
+	out.microUSD, out.service = reservedMicroUSD, serviceReservation
+	return out, false
 }
 
 // topUpReservationForInlinedMedia re-reserves after remote media has been

--- a/coordinator/api/self_route.go
+++ b/coordinator/api/self_route.go
@@ -66,6 +66,51 @@ func (s *Server) resolveSelfRoutePolicy(r *http.Request) selfRoutePolicy {
 	return selfRoutePolicy{enabled: exclusive, prefer: prefer, ownerAccountID: owner}
 }
 
+// unfundedPreferPolicy decides what a PREFER request does when the account
+// cannot cover the up-front reservation (empty balance or an exhausted per-key
+// spend cap).
+//
+// PREFER reserves up front only because dispatch MIGHT land on a public
+// provider; the owned half of "my machine, else the paid fleet" is free and
+// costs the ledger nothing. Failing the whole request on that reservation is
+// what makes the console's "My Machine · Free, else paid" toggle answer
+// "Insufficient credits" to an owner whose idle Mac was sitting right there —
+// the exact opposite of what running a node is supposed to buy you.
+//
+// So when the money for the fallback isn't there, drop the FALLBACK rather than
+// the request: if the caller owns an online machine that can serve this exact
+// request shape, continue as EXCLUSIVE self-route (owned-only, free, no
+// reservation). Owned-only is what keeps this safe — an unfunded request can
+// then never reach a public provider, and settlement independently re-verifies
+// that the machine which served it is the caller's (handleComplete) before
+// settling at zero.
+//
+// Returns ok=false for a non-prefer policy or when no owned machine can serve,
+// leaving the caller to write the 402.
+func (s *Server) unfundedPreferPolicy(model string, traits registry.RequestTraits, requiresVision bool, policy selfRoutePolicy) (selfRoutePolicy, bool) {
+	if !policy.prefer || policy.ownerAccountID == "" {
+		return policy, false
+	}
+	if _, serves := s.registry.OwnedProviderSummary(
+		policy.ownerAccountID, model, traits, requiresVision); serves == 0 {
+		return policy, false
+	}
+	s.ddIncr("billing.unfunded_prefer_self_route", []string{"model:" + model})
+	return selfRoutePolicy{enabled: true, ownerAccountID: policy.ownerAccountID}, true
+}
+
+// insufficientBalanceMessage explains a 402 in the caller's terms. A PREFER
+// request only needs a balance for the paid fallback, and it reaches this point
+// solely because unfundedPreferPolicy already found no owned machine able to
+// serve it — so name both halves, since the actionable one is usually the
+// machine rather than the wallet.
+func insufficientBalanceMessage(policy selfRoutePolicy) string {
+	if policy.prefer {
+		return "your machine cannot serve this request right now (offline, model not loaded, or below a required capability) and your balance is too low for the paid fallback — start your Darkbloom node and load the model, or add funds at /billing"
+	}
+	return "your balance is too low for this request — add funds at /billing or lower max_tokens"
+}
+
 // selfRouteUnavailable reports whether a self-route request cannot proceed and,
 // when so, writes the precise terminal error. Self-route never falls back to
 // the paid fleet, so "can't serve" is an explicit failure rather than a

--- a/coordinator/api/self_route.go
+++ b/coordinator/api/self_route.go
@@ -96,6 +96,11 @@ func (s *Server) unfundedPreferPolicy(model string, traits registry.RequestTrait
 		return policy, false
 	}
 	s.ddIncr("billing.unfunded_prefer_self_route", []string{"model:" + model})
+	// Per-request breadcrumb: dispatch/rejection rows for this request will say
+	// self_route_only=true even though the header said prefer, so record the
+	// downgrade where support can correlate it.
+	s.logger.Info("unfunded prefer request downgraded to owned-only self-route",
+		"model", model, "owner_account", policy.ownerAccountID)
 	return selfRoutePolicy{enabled: true, ownerAccountID: policy.ownerAccountID}, true
 }
 

--- a/coordinator/api/self_route_test.go
+++ b/coordinator/api/self_route_test.go
@@ -560,6 +560,98 @@ func TestSelfRoute_PreferSpendCappedKeyRunsFreeOnOwnedMachine(t *testing.T) {
 	}
 }
 
+// sendGenericRoutedRequest posts a legacy /v1/completions request (the generic
+// handler shared with Anthropic /v1/messages) with an explicit X-Darkbloom-Route
+// value ("" = no header). Returns the HTTP status code.
+func sendGenericRoutedRequest(t *testing.T, ctx context.Context, tsURL, model, apiKey, route string) int {
+	t.Helper()
+	body := `{"model":"` + model + `","prompt":"hello","max_tokens":32,"stream":true}`
+	req, _ := http.NewRequestWithContext(ctx, http.MethodPost, tsURL+"/v1/completions", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+	if route != "" {
+		req.Header.Set("X-Darkbloom-Route", route)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("http request: %v", err)
+	}
+	defer resp.Body.Close()
+	io.ReadAll(resp.Body)
+	return resp.StatusCode
+}
+
+// TestSelfRoute_PreferUnfundedGenericPathRunsFreeOnOwnedMachine pins the same
+// unfunded-prefer downgrade on handleGenericInference (/v1/completions and
+// Anthropic /v1/messages): that handler takes the shared reservation but adopts
+// the downgraded policy into its OWN dispatch loop, so the chat-path test alone
+// would not catch a generic path that keeps routing under prefer semantics.
+func TestSelfRoute_PreferUnfundedGenericPathRunsFreeOnOwnedMachine(t *testing.T) {
+	srv, st, ledger := billingTestServer(t)
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	const owner = "prefer-unfunded-generic-owner"
+	raw, _, err := st.CreateAPIKey(owner, store.APIKeyCreate{Name: "mine"})
+	if err != nil {
+		t.Fatalf("CreateAPIKey: %v", err)
+	}
+	if bal := ledger.Balance(owner); bal != 0 {
+		t.Fatalf("precondition: owner balance = %d, want 0", bal)
+	}
+
+	model := "prefer-unfunded-generic-model"
+	conn, _, pubKey := setupProviderForBilling(t, ctx, ts, srv.registry, model)
+	defer conn.Close(websocket.StatusNormalClosure, "")
+	setOwnedProvider(srv, owner)
+
+	providerDone := serveOneInference(ctx, t, conn, pubKey, protocol.UsageInfo{PromptTokens: 100, CompletionTokens: 50})
+	if status := sendGenericRoutedRequest(t, ctx, ts.URL, model, raw, "prefer"); status != http.StatusOK {
+		t.Fatalf("unfunded prefer /v1/completions status = %d, want 200 (own machine serves it for free)", status)
+	}
+	<-providerDone
+	time.Sleep(300 * time.Millisecond)
+
+	if bal := ledger.Balance(owner); bal != 0 {
+		t.Errorf("owner balance = %d, want 0 (own machine must never charge)", bal)
+	}
+	earnings, _ := st.GetAccountEarnings(owner, 100)
+	if len(earnings) != 0 {
+		t.Errorf("provider earnings = %d, want 0 for a free owned route", len(earnings))
+	}
+}
+
+// TestSelfRoute_PreferUnfundedGenericPathWithoutOwnedMachineIsRejected is the
+// generic-path half of the free-ride invariant: an unfunded prefer caller on
+// /v1/completions whose only serving provider belongs to someone else must get
+// the 402, never a dispatch onto that provider.
+func TestSelfRoute_PreferUnfundedGenericPathWithoutOwnedMachineIsRejected(t *testing.T) {
+	srv, st, ledger := billingTestServer(t)
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	const caller = "prefer-unfunded-generic-machineless"
+	raw, _, err := st.CreateAPIKey(caller, store.APIKeyCreate{Name: "mine"})
+	if err != nil {
+		t.Fatalf("CreateAPIKey: %v", err)
+	}
+
+	model := "prefer-unfunded-generic-no-machine-model"
+	conn, _, _ := setupProviderForBilling(t, ctx, ts, srv.registry, model)
+	defer conn.Close(websocket.StatusNormalClosure, "")
+	setOwnedProvider(srv, "someone-else")
+
+	if status := sendGenericRoutedRequest(t, ctx, ts.URL, model, raw, "prefer"); status != http.StatusPaymentRequired {
+		t.Fatalf("unfunded prefer /v1/completions without an owned machine status = %d, want 402", status)
+	}
+	if entries := ledger.Usage(caller); len(entries) != 0 {
+		t.Errorf("usage entries = %d, want 0 (the public fleet must not serve an unfunded caller)", len(entries))
+	}
+}
+
 // TestSelfRoute_UnfundedFallbackDoesNotPayProvider is the Part 3 regression: a
 // FreeSelfRoute request whose ownership revalidation fails at settlement AND
 // whose owner has NO balance must not record paid usage or credit the provider

--- a/coordinator/api/self_route_test.go
+++ b/coordinator/api/self_route_test.go
@@ -362,9 +362,11 @@ func sendRoutedRequest(t *testing.T, ctx context.Context, tsURL, model, apiKey, 
 
 // TestSelfRoute_PreferFreeOnOwnedMachine: with X-Darkbloom-Route: prefer and a
 // funded owner whose own machine serves the request, the up-front reservation is
-// fully refunded (net free) and the provider accrues no payout. (prefer takes a
-// reservation up front so a paid fallback could settle, unlike exclusive
-// self-route which skips it — so the owner must have a balance.)
+// fully refunded (net free) and the provider accrues no payout. A FUNDED owner
+// keeps full prefer semantics — the reservation is taken so dispatch can still
+// fall back to the paid fleet mid-flight. (An owner who cannot fund it trades
+// that fallback for the free owned route instead; see
+// TestSelfRoute_PreferUnfundedRunsFreeOnOwnedMachine.)
 func TestSelfRoute_PreferFreeOnOwnedMachine(t *testing.T) {
 	srv, st, ledger := billingTestServer(t)
 	ts := httptest.NewServer(srv.Handler())
@@ -433,6 +435,128 @@ func TestSelfRoute_PreferFallsBackToPaid(t *testing.T) {
 
 	if bal := ledger.Balance(caller); bal >= initial {
 		t.Errorf("caller balance = %d, want < %d (paid fallback must charge)", bal, initial)
+	}
+}
+
+// TestSelfRoute_PreferUnfundedRunsFreeOnOwnedMachine is the regression for the
+// console "My Machine · Free, else paid" toggle answering "Insufficient
+// credits". prefer reserves up front so the PAID fallback could settle, which
+// used to 402 a zero-balance owner before routing ever looked at their machine.
+// The reservation exists only for the fallback, so when it can't be funded the
+// request drops the fallback (owned-only, free), not itself.
+func TestSelfRoute_PreferUnfundedRunsFreeOnOwnedMachine(t *testing.T) {
+	srv, st, ledger := billingTestServer(t)
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	const owner = "prefer-unfunded-owner"
+	raw, _, err := st.CreateAPIKey(owner, store.APIKeyCreate{Name: "mine"})
+	if err != nil {
+		t.Fatalf("CreateAPIKey: %v", err)
+	}
+	// Deliberately NOT credited: the whole point is that owning the machine is
+	// enough.
+	if bal := ledger.Balance(owner); bal != 0 {
+		t.Fatalf("precondition: owner balance = %d, want 0", bal)
+	}
+
+	model := "prefer-unfunded-model"
+	conn, _, pubKey := setupProviderForBilling(t, ctx, ts, srv.registry, model)
+	defer conn.Close(websocket.StatusNormalClosure, "")
+	setOwnedProvider(srv, owner)
+
+	providerDone := serveOneInference(ctx, t, conn, pubKey, protocol.UsageInfo{PromptTokens: 100, CompletionTokens: 50})
+	if status := sendRoutedRequest(t, ctx, ts.URL, model, raw, "prefer"); status != http.StatusOK {
+		t.Fatalf("unfunded prefer status = %d, want 200 (own machine serves it for free)", status)
+	}
+	<-providerDone
+	time.Sleep(300 * time.Millisecond)
+
+	if bal := ledger.Balance(owner); bal != 0 {
+		t.Errorf("owner balance = %d, want 0 (own machine must never charge)", bal)
+	}
+	usageEntries := ledger.Usage(owner)
+	if len(usageEntries) != 1 {
+		t.Fatalf("usage entries = %d, want 1 (zero-cost row for transparency)", len(usageEntries))
+	}
+	if usageEntries[0].CostMicroUSD != 0 {
+		t.Errorf("usage cost = %d, want 0 (free)", usageEntries[0].CostMicroUSD)
+	}
+	earnings, _ := st.GetAccountEarnings(owner, 100)
+	if len(earnings) != 0 {
+		t.Errorf("provider earnings = %d, want 0 for a free owned route", len(earnings))
+	}
+}
+
+// TestSelfRoute_PreferUnfundedWithoutOwnedMachineIsRejected is the other half of
+// the same rule: dropping the paid fallback is only safe because the request
+// becomes owned-only. A caller with no balance AND no machine able to serve must
+// still get a 402 — never a free ride on someone else's hardware.
+func TestSelfRoute_PreferUnfundedWithoutOwnedMachineIsRejected(t *testing.T) {
+	srv, st, ledger := billingTestServer(t)
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	const caller = "prefer-unfunded-machineless"
+	raw, _, err := st.CreateAPIKey(caller, store.APIKeyCreate{Name: "mine"})
+	if err != nil {
+		t.Fatalf("CreateAPIKey: %v", err)
+	}
+
+	model := "prefer-unfunded-no-machine-model"
+	// A perfectly good provider, owned by somebody else.
+	conn, _, _ := setupProviderForBilling(t, ctx, ts, srv.registry, model)
+	defer conn.Close(websocket.StatusNormalClosure, "")
+	setOwnedProvider(srv, "someone-else")
+
+	if status := sendRoutedRequest(t, ctx, ts.URL, model, raw, "prefer"); status != http.StatusPaymentRequired {
+		t.Fatalf("unfunded prefer without an owned machine status = %d, want 402", status)
+	}
+	// Nothing was served, so no usage may have been recorded against the caller.
+	if entries := ledger.Usage(caller); len(entries) != 0 {
+		t.Errorf("usage entries = %d, want 0 (the public fleet must not serve an unfunded caller)", len(entries))
+	}
+}
+
+// TestSelfRoute_PreferSpendCappedKeyRunsFreeOnOwnedMachine covers the other
+// funding gate: an exhausted per-key spend cap. The cap bounds what a key may
+// SPEND, and the owned route spends nothing, so a funded account whose key is
+// capped still reaches its own machine — matching self_route_only keys, which
+// bypass the cap outright.
+func TestSelfRoute_PreferSpendCappedKeyRunsFreeOnOwnedMachine(t *testing.T) {
+	srv, st, ledger := billingTestServer(t)
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	const owner = "prefer-capped-owner"
+	var spendCap int64 = 1 // 1 micro-USD: any real request exceeds it
+	raw, _, err := st.CreateAPIKey(owner, store.APIKeyCreate{Name: "capped", LimitMicroUSD: &spendCap})
+	if err != nil {
+		t.Fatalf("CreateAPIKey: %v", err)
+	}
+	_ = st.Credit(owner, 100_000_000, store.LedgerDeposit, "test-setup")
+	initial := ledger.Balance(owner)
+
+	model := "prefer-capped-model"
+	conn, _, pubKey := setupProviderForBilling(t, ctx, ts, srv.registry, model)
+	defer conn.Close(websocket.StatusNormalClosure, "")
+	setOwnedProvider(srv, owner)
+
+	providerDone := serveOneInference(ctx, t, conn, pubKey, protocol.UsageInfo{PromptTokens: 100, CompletionTokens: 50})
+	if status := sendRoutedRequest(t, ctx, ts.URL, model, raw, "prefer"); status != http.StatusOK {
+		t.Fatalf("spend-capped prefer status = %d, want 200 (own machine spends nothing)", status)
+	}
+	<-providerDone
+	time.Sleep(300 * time.Millisecond)
+
+	if bal := ledger.Balance(owner); bal != initial {
+		t.Errorf("owner balance = %d, want %d (free owned route must not debit)", bal, initial)
 	}
 }
 

--- a/docs/provider/self-route.md
+++ b/docs/provider/self-route.md
@@ -25,7 +25,7 @@ fallback); one is PREFER (owned-first, paid fallback so it's never a dead end):
 |---|---|---|---|
 | `X-Darkbloom-Route: self` header | Exclusive | Per request | Owned-only, free, no fallback. Invisible to the OpenAI body schema; works with any SDK (`extra_headers`). Never enters the (optionally sealed) body. |
 | API key `self_route_only: true` | Exclusive | Per key (hard ceiling) | Every request on the key is owned-only and free; it can never spend balance or reach the public fleet, regardless of header. |
-| `X-Darkbloom-Route: prefer` header | Prefer | Per request | Routes to your own machine whenever it can serve (free); falls back to the **paid** public fleet when it can't. Takes a normal reservation up front (refunded if your machine serves), so the account needs a balance. |
+| `X-Darkbloom-Route: prefer` header | Prefer | Per request | Routes to your own machine whenever it can serve (free); falls back to the **paid** public fleet when it can't. Takes a normal reservation up front (refunded if your machine serves) so the fallback can settle — but an account that can't fund it keeps the free half (see below) instead of being rejected. |
 
 ```bash
 # Strict free-or-error (exclusive):
@@ -53,9 +53,29 @@ The policy resolution is server-side in `coordinator/api/self_route.go:49-65`.
   can't serve you get an explicit error, never a charge. Works at zero balance.
 - **Prefer** (`prefer`): prioritizes your machine for free but never strands you
   — it falls back to the paid fleet. Because it might pay, it reserves up front
-  (refunded when your machine serves), so the account must hold a balance.
-  Routing relaxes the hardware-trust floor for your own (possibly un-enrolled)
-  machine only, never for public providers.
+  (refunded when your machine serves). Routing relaxes the hardware-trust floor
+  for your own (possibly un-enrolled) machine only, never for public providers.
+
+### Unfunded prefer keeps the free half
+
+The prefer reservation exists only so the **paid fallback** can settle; the
+owned half costs nothing. So when an account can't cover it — empty balance, or
+an exhausted per-key spend cap — the coordinator drops the *fallback*, not the
+request (`api/self_route.go:unfundedPreferPolicy`, called from
+`reserveInferenceBalance`):
+
+- If the caller owns an online machine that can serve this exact request shape
+  (`OwnedProviderSummary` with the full routing traits), the request continues as
+  **exclusive** self-route: owned-only, free, no reservation. Owned-only is what
+  makes this safe — an unfunded request can never reach a public provider, and
+  settlement independently re-verifies ownership before settling at zero.
+- Otherwise it is still a `402`, whose message names both halves ("your machine
+  cannot serve this request right now … and your balance is too low for the paid
+  fallback").
+
+Without this, the console's **My Machine** toggle answered "Insufficient
+credits" to an owner whose idle Mac was online and able to serve, because the
+reservation ran before routing ever looked at the machine.
 
 ## Ownership model (the crux)
 
@@ -100,7 +120,9 @@ These errors are written by `coordinator/api/self_route.go:73-101`.
 
 Self-route skips the pre-flight reservation, the per-key spend cap, the charge,
 the platform fee, and the provider payout — a zero-balance owner is never
-blocked. A **zero-cost usage row** is still recorded for transparency.
+blocked, whether the request arrived as exclusive self-route or as a prefer
+request that fell back to it. A **zero-cost usage row** is still recorded for
+transparency.
 
 At settlement, `handleComplete` **re-verifies** that the provider which actually
 served the completion is owned by the consumer (read from the serving provider

--- a/docs/provider/self-route.md
+++ b/docs/provider/self-route.md
@@ -45,7 +45,8 @@ In the console UI: the **My Machine** toggle in the chat composer sends
 `prefer` (prioritized, never stuck), and the **"My Machine only — free"**
 checkbox on an API key sets the strict `self_route_only` ceiling.
 
-The policy resolution is server-side in `coordinator/api/self_route.go:49-65`.
+The policy resolution is server-side in
+`coordinator/api/self_route.go:resolveSelfRoutePolicy`.
 
 ### Exclusive vs prefer
 
@@ -69,9 +70,11 @@ request (`api/self_route.go:unfundedPreferPolicy`, called from
   **exclusive** self-route: owned-only, free, no reservation. Owned-only is what
   makes this safe — an unfunded request can never reach a public provider, and
   settlement independently re-verifies ownership before settling at zero.
-- Otherwise it is still a `402`, whose message names both halves ("your machine
-  cannot serve this request right now … and your balance is too low for the paid
-  fallback").
+- Otherwise it is still a `402`. On the balance half the message names both
+  causes ("your machine cannot serve this request right now … and your balance
+  is too low for the paid fallback", `insufficientBalanceMessage`); on the
+  spend-cap half it stays the cap message from `checkKeySpendCap`, which already
+  names the key and its limit.
 
 Without this, the console's **My Machine** toggle answered "Insufficient
 credits" to an owner whose idle Mac was online and able to serve, because the
@@ -112,9 +115,13 @@ the **public** fleet on low trust.
 | No machine linked | 409 | `no_linked_machine` |
 | Machine(s) offline | 503 + Retry-After | `machine_offline` |
 | Online but model not loaded/in-catalog | 503 + Retry-After | `model_not_loaded` |
+| Model served, but not for this request shape (tools / vision) | 503 | `model_capability_unsupported` |
 | Owned machine busy (after queue) | 429 + Retry-After | `machine_busy` |
 
-These errors are written by `coordinator/api/self_route.go:73-101`.
+All but the last are written by
+`coordinator/api/self_route.go:selfRouteUnavailable`; `machine_busy` is the
+queue-wait verdict in `coordinator/api/dispatch.go` and
+`coordinator/api/consumer.go`.
 
 ## Billing
 
@@ -157,8 +164,9 @@ This adds a `private_only` field to the registration message, mirrored across
   `registry/scheduler.go` + `registry/registry.go` (owner filter, trust
   relaxation, `OwnedProviderSummary`, `private_only` gating),
   `store/{interface,memory,postgres}.go` (`self_route_only` API-key flag).
-- **Console UI:** `lib/api.ts` (header + error mapping + types), `lib/store.ts`
-  (`useMyMachine`), `app/api/chat/route.ts` (header forwarding),
-  `components/ChatInput.tsx` + `components/api-keys/{KeyForm,KeyCard}.tsx`.
+- **Console UI:** `lib/chat/stream.ts` (header), `lib/chat/errors.ts` (error
+  copy), `lib/api/types.ts` (types), `lib/store.ts` (`useMyMachine`),
+  `app/api/chat/route.ts` (header forwarding), `components/ChatInput.tsx` +
+  `components/api-keys/{KeyForm,KeyCard}.tsx`.
 - **Provider (Swift):** `Protocol/Messages.swift`, `Coordinator/CoordinatorClient*.swift`,
   `Config/ProviderConfig.swift`, `ProviderLoop.swift`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The console chat composer's **"My Machine · Free, else paid"** toggle answered `Insufficient credits — buy credits in Billing to continue` to owners whose own Mac was online, idle, and able to serve the request for free. The toggle sends `X-Darkbloom-Route: prefer`, and `prefer` took a full up-front ledger reservation so the *paid fallback* could settle — so a zero-balance (or spend-capped) owner was rejected with a 402 before routing ever looked at their machine. That reservation only exists for the fallback; the owned half costs the ledger nothing. This drops the **fallback** instead of the request: when the reservation can't be funded and the caller owns a machine that can serve this exact request shape, the request continues as exclusive self-route (owned-only, free, no reservation).

[Before/after: the new coordinator regression tests reproduce the 402 on the base commit and pass on this branch](https://cursor.com/agents/bc-191c28d0-bf39-59bf-8336-f1eeb6331aa6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fselfroute_prefer_402_before_after.png)

## Linked issue

Closes #

Reported in Slack `#support` — screenshot showed the toggle on (`Qwen 3.6 35B A3B`, "My Machine · Free, else paid") with the insufficient-credits toast.

## Behavior: before / after

```mermaid
flowchart TB
  subgraph Before["BEFORE — zero-balance owner, X-Darkbloom-Route: prefer"]
    B1["POST /v1/chat/completions<br/>X-Darkbloom-Route: prefer"] --> B2["resolveSelfRoutePolicy<br/>policy.prefer = true"]
    B2 --> B3["reserveInferenceBalance<br/>full up-front reservation for the paid fallback"]
    B3 -->|"ErrInsufficientBalance<br/>or spend cap"| B4["402 insufficient_funds<br/>'Insufficient credits'"]
    B4 -.->|"never consulted"| B5(["owner's Mac: online, idle,<br/>model loaded, would serve free"])
  end
```

```mermaid
flowchart TB
  subgraph After["AFTER — same request"]
    A1["POST /v1/chat/completions<br/>X-Darkbloom-Route: prefer"] --> A2["resolveSelfRoutePolicy<br/>policy.prefer = true"]
    A2 --> A3["reserveInferenceBalance"]
    A3 -->|funded| A4["reservation held<br/>prefer semantics unchanged:<br/>owned-first, paid fallback"]
    A3 -->|"ErrInsufficientBalance<br/>or spend cap"| A5{"unfundedPreferPolicy<br/>OwnedProviderSummary(owner, model,<br/>traits, requiresVision) > 0 ?"}
    A5 -->|yes| A6["policy → exclusive self-route<br/>owned-only · free · no reservation"]
    A5 -->|no| A7["402 — balance half names both causes;<br/>spend-cap half keeps the cap message"]
    A6 --> A8["200 · served by the owner's Mac<br/>zero-cost usage row · no payout"]
    A4 --> A9["200 · charged only if a public provider served it"]
  end
```

## Code: before / after

```mermaid
flowchart LR
  subgraph CodeBefore["BEFORE"]
    direction TB
    C1["handleChatCompletions /<br/>handleGenericInference"] --> C2["reserveInferenceBalance()<br/>returns (int64, bool, handled bool)"]
    C2 -->|"skip only when<br/>policy.enabled"| C3["writeJSON 402"]
    C2 --> C4["runInferenceAdmission(policy)"]
    C4 --> C5["dispatch (policy)"]
    C6["stream.ts: chatErrorMessage<br/>402 → 'buy credits'<br/>queue timeout matched 503 only"]
  end
  subgraph CodeAfter["AFTER"]
    direction TB
    D1["handleChatCompletions /<br/>handleGenericInference"] --> D2["reserveInferenceBalance()<br/>returns (balanceReservation, handled bool)<br/>+ traits in balanceReservationParams"]
    D2 -->|"unfunded && policy.prefer"| D3["unfundedPreferPolicy()<br/>self_route.go"]
    D3 -->|"owner can serve"| D4["balanceReservation.policy<br/>= exclusive, microUSD = 0"]
    D3 -->|"cannot"| D5["writeJSON 402<br/>insufficientBalanceMessage(policy)"]
    D2 --> D6["policy = reservation.policy<br/>(adopted before ANY downstream gate)"]
    D4 --> D6
    D6 --> D7["runInferenceAdmission(policy)<br/>→ exclusive branch, owned-only"]
    D7 --> D8["dispatch: SelfRouteOnly=true,<br/>FreeSelfRoute=true"]
    D9["lib/chat/errors.ts: chatErrorMessage<br/>402 → coordinator's own explanation<br/>queue timeout matches the real 429"]
  end
```

## Why this is safe

The downgrade is to **exclusive** self-route, not "free paid routing" — the resulting policy is byte-identical to an `X-Darkbloom-Route: self` request, so it inherits an already-tested path rather than a new one. `PendingRequest.SelfRouteOnly = true` makes the scheduler skip every provider the caller does not own (`scheduler.go:658`, re-checked under the provider lock at `:444`) across immediate dispatch, sequential retry, speculative backup, and the 120s queue + queue drain, so an unfunded request can never land on a public provider. Settlement independently re-verifies ownership (`handleComplete`) and falls back to **paid** on any mismatch, so a machine unlinked mid-flight still can't buy free inference. A caller with no owned machine able to serve keeps getting the 402.

Funded callers are untouched: they keep the reservation and full prefer semantics (owned-first with a live paid fallback if their machine fails mid-flight).

## Changes

**Coordinator (the fix)**
- `api/self_route.go` — `unfundedPreferPolicy` (the downgrade decision, a DogStatsD counter, and one correlation log line, since post-downgrade rows read `self_route_only=true` even though the header said `prefer`) and `insufficientBalanceMessage` (prefer-aware 402 copy).
- `api/inference_admission.go` — `reserveInferenceBalance` now returns a `balanceReservation` struct carrying the possibly-downgraded policy; `balanceReservationParams` gained the full `traits` set so the downgrade is judged against exactly what admission would admit.
- `api/consumer.go` — both handlers adopt `reservation.policy` before any downstream gate reads it. The generic handler's routing-trait closures were hoisted above the reservation (nothing in between mutates `parsed`, so the traits are identical).

**Console UI (error copy)**
- `src/lib/chat/errors.ts` (new) + `stream.ts` — `chatErrorMessage` extracted and unit-testable. A 402 now surfaces the coordinator's own explanation instead of answering every payment error with "buy credits", which is actively wrong for a spend-capped key. Two bugs found in review and fixed here: the queue-timeout branch guarded on 503 but the coordinator ships that verdict as a **429 + Retry-After**, so it never fired (pre-existing, carried over by the extraction); and the code→copy lookup was an object literal indexed with a wire-supplied `code`, so `code: "toString"` resolved an inherited function through a `string`-typed return — now a `Map`.

**Docs**
- `docs/provider/self-route.md` — documents the new rule, corrects the "prefer requires a balance" claim, and re-points the code references this change invalidated (line ranges → function names) plus three stale claims: the error table was missing `model_capability_unsupported` and mis-attributed `machine_busy`, and the console-ui bullet cited a `lib/api.ts` that no longer exists.

## Test plan

- [x] `cd coordinator && gofmt -l . && go vet ./... && go test ./... -count=1` — full suite green (`api` 118s). Race detector clean on the self-route/billing tests.
- [x] Five new Go tests in `coordinator/api/self_route_test.go`, exercised through the real HTTP path (`httptest.NewServer(srv.Handler())`) with a simulated provider over the WebSocket harness:
  - `TestSelfRoute_PreferUnfundedRunsFreeOnOwnedMachine` — zero balance + owned machine → 200, balance unchanged at 0, zero-cost usage row, no payout.
  - `TestSelfRoute_PreferSpendCappedKeyRunsFreeOnOwnedMachine` — funded account, exhausted per-key cap → 200, no debit.
  - `TestSelfRoute_PreferUnfundedWithoutOwnedMachineIsRejected` — zero balance, only a stranger's provider serves the model → 402, no usage recorded (the free-ride guard).
  - `TestSelfRoute_PreferUnfundedGenericPathRunsFreeOnOwnedMachine` / `...WithoutOwnedMachineIsRejected` — same two on `/v1/completions`, which routes through `handleGenericInference`'s separate dispatch loop.
- [x] Verified the three "should be free" tests **fail with exactly the reported 402** against base commit `9086a9dd` and pass on this branch (image above). The two guard tests pass on both, pinning pre-existing safety.
- [x] The queue-timeout status was confirmed empirically, not from reading: a real httptest coordinator was saturated on a dedicated model and returned `429` with `all providers for model "…" are at capacity (queue timeout)`.
- [x] `cd console-ui && npx eslint src/` — 0 errors, and the branch's own `security/detect-object-injection` warnings are gone (106 → 104). `npm test` — 57 files, 505 tests. `npm run build` — clean.
- [x] `console-ui/__tests__/chat-error-message.test.ts` covers the 402 copy (including that a spend-cap error is no longer rewritten into "buy credits"), the 429 queue-timeout mapping, and the inherited-key case.

## Components touched

- [x] coordinator (Go)
- [ ] provider (Rust, legacy)
- [ ] provider-swift (Swift CLI)
- [x] console-ui (Next.js)
- [ ] enclave (Swift)
- [ ] infra / CI / release
- [x] docs

## Protocol / interface changes

- [x] No protocol/interface changes

No WebSocket message, HTTP route, config key, or CLI flag changed. `X-Darkbloom-Route: prefer` keeps its documented meaning; only the unfunded outcome changes, and it changes from a terminal 402 to a served request, so no client can regress on it.

## Notes for reviewers

- **Deliberately conservative, left alone:** a few gates run *before* the reservation and therefore still evaluate under prefer semantics after a downgrade — the generic path's `IsModelInCatalog` check (an off-catalog owned model 404s on `/v1/completions` while chat serves it, a pre-existing ordering divergence between the handlers), `shedIfModelRejected`, and `topUpReservationForInlinedMedia`'s own 402 for a partially-funded prefer request whose remote media inflates the cost mid-handler. All of these reject rather than serve, so none is a security concern; the reported zero-balance case downgrades before any of them matter, and closing the media one would mean unwinding a held reservation mid-flight in the money path.
- **Alias resolution is already owner-first** (`ResolveModelConstrainedWithTraits`, registry.go:1889-1900), so the build the downgrade is judged against is the one the owner can serve whenever they can serve the alias at all — the decision can't be made against a stale build. `maybeFallbackAlias` is unreachable after the downgrade (the `policy.enabled` branch of `runInferenceAdmission` returns before any alias-fallback probe).
- **Minor side effect of the hoist:** the `X-Timing` reserve segment on the generic path now absorbs the body marshal + lower.
- Two pre-existing asymmetries the downgrade inherits unchanged: `selfRouteUnavailable` ignores `allowedProviderSerials`, and `shedIfModelRejected` sheds prefer before the downgrade can run. Both affect exclusive self-route identically today.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://darkbloom.slack.com/archives/C0B0JMULP3L/p1787321307627229?thread_ts=1787321307.627229&cid=C0B0JMULP3L)

<div><a href="https://cursor.com/agents/bc-191c28d0-bf39-59bf-8336-f1eeb6331aa6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-191c28d0-bf39-59bf-8336-f1eeb6331aa6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/662"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789972512&installation_model_id=21733&pr_number=662&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F662&signature=733a7c4f0336513b413780c32554ea12a5a2e3e43c8a9cee1f22f7beb738c244"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->