### PR TITLE
fix(installer): seed MLX latches before runtime smoke

### DIFF
--- a/.github/workflows/release-swift.yml
+++ b/.github/workflows/release-swift.yml
@@ -499,6 +499,9 @@ jobs:
           # existing GPT-OSS paged-kernel shapes. The v0.7.6 artifact still
           # fails here because its resource bundle is absent.
           PRE_SIGN_SMOKE_OUTPUT=$(DARKBLOOM_NO_UPDATE_CHECK=1 \
+            DARKBLOOM_GEMMA4_PREFILL_CHUNK_EVAL=18 \
+            MLX_GEMMA4_FUSED_WEIGHTED_UNSORT=1 \
+            MLX_GATHER_QMM_EXPERT_SLICES=1 \
             "$APP/Contents/MacOS/$CLI_NAME" runtime-smoke)
           printf '%s\n' "$PRE_SIGN_SMOKE_OUTPUT"
           printf '%s\n' "$PRE_SIGN_SMOKE_OUTPUT" \
@@ -753,6 +756,9 @@ jobs:
           codesign --verify --deep --strict --verbose=2 \
             "$SMOKE_ROOT/Darkbloom.app"
           FINAL_SMOKE_OUTPUT=$(DARKBLOOM_NO_UPDATE_CHECK=1 \
+            DARKBLOOM_GEMMA4_PREFILL_CHUNK_EVAL=18 \
+            MLX_GEMMA4_FUSED_WEIGHTED_UNSORT=1 \
+            MLX_GATHER_QMM_EXPERT_SLICES=1 \
             "$SMOKE_ROOT/Darkbloom.app/Contents/MacOS/$CLI_NAME" runtime-smoke)
           printf '%s\n' "$FINAL_SMOKE_OUTPUT"
           printf '%s\n' "$FINAL_SMOKE_OUTPUT" \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v0.8.10 (2026-08-21)
+
+### Provider (Swift)
+
+#### Fixes
+
+- **Seed retained optimization latches before packaged-child exec** — The v0.8.9 curl installer could download and verify the signed bundle but reject it with `safe R1 was not latched as requested` on hosts where MLX initialized Metal before `runtime-smoke.run()`. Installer, self-updater, and paged preflight children now receive the exact retained three-key environment (`DARKBLOOM_GEMMA4_PREFILL_CHUNK_EVAL=18`, `MLX_GEMMA4_FUSED_WEIGHTED_UNSORT=1`, `MLX_GATHER_QMM_EXPERT_SLICES=1`) at process launch, while the child still poisons/reapplies/verifies the values and AOT kernels. Existing installations remain untouched on any failed verification.
+
 ## v0.8.9 (2026-08-21)
 
 ### Provider (Swift)

--- a/coordinator/api/install.sh
+++ b/coordinator/api/install.sh
@@ -161,7 +161,11 @@ verify_staged_app() {
             return 1
         }
 
-    DARKBLOOM_NO_UPDATE_CHECK=1 "$executable" runtime-smoke >/dev/null \
+    DARKBLOOM_NO_UPDATE_CHECK=1 \
+        DARKBLOOM_GEMMA4_PREFILL_CHUNK_EVAL=18 \
+        MLX_GEMMA4_FUSED_WEIGHTED_UNSORT=1 \
+        MLX_GATHER_QMM_EXPERT_SLICES=1 \
+        "$executable" runtime-smoke >/dev/null \
         || {
             fail_install "Packaged paged-kernel runtime smoke failed."
             return 1

--- a/coordinator/api/server.go
+++ b/coordinator/api/server.go
@@ -151,7 +151,7 @@ func keyLimitResetFromContext(ctx context.Context) string {
 // the provider's EngineV2Factory.prepareProductionBackend for the argument).
 // Keep this fallback in sync with ProviderCore.version so dev/in-memory
 // coordinators advertise the same floor as the Swift binary they expect.
-var LatestProviderVersion = "0.8.9"
+var LatestProviderVersion = "0.8.10"
 
 // minProviderVersionForDesiredModels is the first provider version whose Swift
 // runtime understands the desired_models message. The coordinator must NOT send

--- a/provider-swift/Sources/ProviderCore/Inference/PackagedRuntimeSmoke.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/PackagedRuntimeSmoke.swift
@@ -66,6 +66,16 @@ public enum PackagedRuntimeSmoke {
         return projection
     }
 
+    /// Seed the process-global MLX latch variables before command parsing can
+    /// trigger any eager Metal access. This is the bootstrap boundary used by
+    /// a v0.8.10 child launched from an older updater that cannot provide the
+    /// new pre-exec environment itself.
+    public static func seedRetainedValidationEnvironment() throws {
+        let config = try retainedConfiguration()
+        try GemmaOptimizationEnvironment.apply(
+            config.gemmaOptimizations, context: .retainedValidation)
+    }
+
     public static func verifyGemmaOptimizations() throws {
         let config = try retainedConfiguration()
         let projection = try retainedValidationEnvironment()

--- a/provider-swift/Sources/ProviderCore/Inference/PackagedRuntimeSmoke.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/PackagedRuntimeSmoke.swift
@@ -57,12 +57,18 @@ public enum PackagedRuntimeSmoke {
     /// would project as `trust`) must not leak into the expected safe-R1
     /// value and fail the smoke — the gate validates the retained config,
     /// not the launching environment.
-    public static func verifyGemmaOptimizations() throws {
+    public static func retainedValidationEnvironment() throws -> [String: String] {
         let config = try retainedConfiguration()
         let projection = GemmaOptimizationEnvironment.projection(
             for: config.gemmaOptimizations,
             context: .retainedValidation)
         try validateRetainedProjection(projection)
+        return projection
+    }
+
+    public static func verifyGemmaOptimizations() throws {
+        let config = try retainedConfiguration()
+        let projection = try retainedValidationEnvironment()
 
         for key in projection.keys {
             _ = setenv(key, "poisoned-by-runtime-smoke", 1)

--- a/provider-swift/Sources/ProviderCore/Inference/PagedKernelPreflight.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/PagedKernelPreflight.swift
@@ -71,10 +71,12 @@ enum PagedKernelPreflight {
         timeout: TimeInterval
     ) throws {
         do {
+            var environment = try PackagedRuntimeSmoke.retainedValidationEnvironment()
+            environment["DARKBLOOM_NO_UPDATE_CHECK"] = "1"
             try BoundedProcess.run(
                 executableURL,
                 arguments: ["runtime-smoke"] + shapes.map(\.argumentValue),
-                environment: ["DARKBLOOM_NO_UPDATE_CHECK": "1"],
+                environment: environment,
                 timeout: timeout,
                 // The child's own message is the diagnosis. A missing
                 // SwiftPM resource bundle beside a relocated binary is a

--- a/provider-swift/Sources/ProviderCore/ProviderCore.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderCore.swift
@@ -237,5 +237,8 @@ public enum ProviderCore {
     // v0.8.8's GDN input fusion/direct expert reduction reduced production
     // decode throughput and triggered client timeouts. The Gemma qmv_wide
     // MLX/MLX-Swift pins remain enabled.
-    public static let version = "0.8.9"
+    // 0.8.10 passes retained Gemma latch variables before exec in installer,
+    // self-update, and paged-preflight runtime-smoke children so eager MLX
+    // initialization cannot latch safe R1 off before validation runs.
+    public static let version = "0.8.10"
 }

--- a/provider-swift/Sources/ProviderCore/Update/SelfUpdater.swift
+++ b/provider-swift/Sources/ProviderCore/Update/SelfUpdater.swift
@@ -1158,10 +1158,12 @@ public struct SelfUpdater: Sendable {
         // The signed child must prove the production TOML projection,
         // overwrite precedence, early safe-R1 latch, and packaged AOT before
         // it reaches the existing paged-kernel GPU smoke.
+        var smokeEnvironment = try PackagedRuntimeSmoke.retainedValidationEnvironment()
+        smokeEnvironment["DARKBLOOM_NO_UPDATE_CHECK"] = "1"
         let smokeOutput = try BoundedProcess.runCapturingStandardOutput(
             executable,
             arguments: ["runtime-smoke"],
-            environment: ["DARKBLOOM_NO_UPDATE_CHECK": "1"],
+            environment: smokeEnvironment,
             timeout: Self.artifactVerificationTimeout)
         guard PackagedRuntimeSmoke.containsGemmaOptimizationSuccessMarker(smokeOutput)
         else {

--- a/provider-swift/Sources/darkbloom/main.swift
+++ b/provider-swift/Sources/darkbloom/main.swift
@@ -12,6 +12,17 @@ import ProviderCore
 
 let rawArgs = Array(CommandLine.arguments.dropFirst())
 
+// An installed pre-v0.8.10 updater cannot seed the new packaged-smoke latch
+// environment. Bootstrap it in the candidate itself before command parsing or
+// AppKit hosting can cause a first MLX/Metal touch.
+if rawArgs.first == "runtime-smoke" {
+    do {
+        try PackagedRuntimeSmoke.seedRetainedValidationEnvironment()
+    } catch {
+        Darkbloom.exit(withError: error)
+    }
+}
+
 #if os(macOS)
 if ProviderAppKitHost.shouldHost(rawArgs) {
     // Takes over the main thread with the AppKit run loop and never returns.

--- a/provider-swift/Tests/ProviderCoreTests/GemmaOptimizationReportingTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/GemmaOptimizationReportingTests.swift
@@ -76,12 +76,9 @@ struct PackagedRetainedGemmaSmokeTests {
 
     @Test("synthetic retained config has an exact three-key projection")
     func exactProjectionAndNoRejectedKeys() throws {
-        let config = try PackagedRuntimeSmoke.retainedConfiguration()
-        // Mirror verifyGemmaOptimizations: the smoke validates the retained
-        // config hermetically, never the launching environment.
-        let decodedProjection = GemmaOptimizationEnvironment.projection(
-            for: config.gemmaOptimizations,
-            context: .retainedValidation)
+        // This exact projection is passed before exec and revalidated inside
+        // the child, so eager MLX initialization cannot latch stale values.
+        let decodedProjection = try PackagedRuntimeSmoke.retainedValidationEnvironment()
         #expect(decodedProjection == expectedProjection)
         try PackagedRuntimeSmoke.validateRetainedProjection(decodedProjection)
         #expect(

--- a/provider-swift/Tests/ProviderCoreTests/SelfUpdaterTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/SelfUpdaterTests.swift
@@ -514,6 +514,25 @@ struct SelfUpdaterTests {
         return (tarball, release, install)
     }
 
+    @Test("v0.8.9 parent can bootstrap a v0.8.10 runtime-smoke child")
+    func oldParentBootstrapsCandidateSmoke() throws {
+        _ = LiveInferenceFixtures.ensureMetallibColocated()
+        let executable = try debugBuildProduct("darkbloom")
+        let output = try BoundedProcess.runCapturingStandardOutput(
+            executable,
+            arguments: ["runtime-smoke"],
+            environment: [
+                "DARKBLOOM_NO_UPDATE_CHECK": "1",
+                GemmaOptimizationEnvironment.prefillLayer18Key: "0",
+                GemmaOptimizationEnvironment.weightedUnsortKey: "0",
+                GemmaOptimizationEnvironment.safeR1Key: "0",
+            ],
+            timeout: 30)
+        #expect(PackagedRuntimeSmoke.containsGemmaOptimizationSuccessMarker(output))
+        #expect(String(data: output, encoding: .utf8)?.contains(
+            "paged-kernel-runtime-smoke: ok") == true)
+    }
+
     @Test("signed extracted child proves retained Gemma marker before staging succeeds")
     func signedAppRunsRealVerification() throws {
         _ = LiveInferenceFixtures.ensureMetallibColocated()

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -161,7 +161,11 @@ verify_staged_app() {
             return 1
         }
 
-    DARKBLOOM_NO_UPDATE_CHECK=1 "$executable" runtime-smoke >/dev/null \
+    DARKBLOOM_NO_UPDATE_CHECK=1 \
+        DARKBLOOM_GEMMA4_PREFILL_CHUNK_EVAL=18 \
+        MLX_GEMMA4_FUSED_WEIGHTED_UNSORT=1 \
+        MLX_GATHER_QMM_EXPERT_SLICES=1 \
+        "$executable" runtime-smoke >/dev/null \
         || {
             fail_install "Packaged paged-kernel runtime smoke failed."
             return 1

--- a/scripts/test-install-atomic.sh
+++ b/scripts/test-install-atomic.sh
@@ -24,6 +24,13 @@ int main(int argc, char **argv) {
         fputs(fan_capability, stderr);
         return 0;
     }
+    const char *chunk_eval = getenv("DARKBLOOM_GEMMA4_PREFILL_CHUNK_EVAL");
+    const char *weighted = getenv("MLX_GEMMA4_FUSED_WEIGHTED_UNSORT");
+    const char *safe_r1 = getenv("MLX_GATHER_QMM_EXPERT_SLICES");
+    if (chunk_eval == NULL || strcmp(chunk_eval, "18") != 0) return 4;
+    if (weighted == NULL || strcmp(weighted, "1") != 0) return 5;
+    if (safe_r1 == NULL || strcmp(safe_r1, "1") != 0) return 6;
+
     char resolved[PATH_MAX];
     if (realpath(argv[0], resolved) == NULL) return 2;
     char first[PATH_MAX], second[PATH_MAX], third[PATH_MAX];
@@ -345,7 +352,11 @@ test -f "$INSTALL/Darkbloom.app/sentinel"
 
 run_install "$VALID" "$INSTALL"
 test ! -f "$INSTALL/Darkbloom.app/sentinel"
-DARKBLOOM_NO_UPDATE_CHECK=1 "$INSTALL/bin/darkbloom" runtime-smoke
+DARKBLOOM_NO_UPDATE_CHECK=1 \
+    DARKBLOOM_GEMMA4_PREFILL_CHUNK_EVAL=18 \
+    MLX_GEMMA4_FUSED_WEIGHTED_UNSORT=1 \
+    MLX_GATHER_QMM_EXPERT_SLICES=1 \
+    "$INSTALL/bin/darkbloom" runtime-smoke
 INSTALLED_FAN_HELPER="$INSTALL/Darkbloom.app/Contents/Helpers/darkbloom-fan-helper"
 INSTALLED_FAN_MARKER="$INSTALL/Darkbloom.app/Contents/Resources/darkbloom-runtime-capabilities/fan-helper-v1"
 test -f "$INSTALLED_FAN_HELPER"
@@ -371,7 +382,11 @@ if run_install "$TAMPERED" "$INSTALL"; then
     echo "tampered signed app unexpectedly installed" >&2
     exit 1
 fi
-DARKBLOOM_NO_UPDATE_CHECK=1 "$INSTALL/bin/darkbloom" runtime-smoke
+DARKBLOOM_NO_UPDATE_CHECK=1 \
+    DARKBLOOM_GEMMA4_PREFILL_CHUNK_EVAL=18 \
+    MLX_GEMMA4_FUSED_WEIGHTED_UNSORT=1 \
+    MLX_GATHER_QMM_EXPERT_SLICES=1 \
+    "$INSTALL/bin/darkbloom" runtime-smoke
 
 INSTALLER="$REPO_ROOT/coordinator/api/install.sh"
 COORD_INSTALL="$ROOT/coordinator-install"


### PR DESCRIPTION
## Summary

Prepare v0.8.10 to fix packaged v0.8.9 installs failing after successful download/hash/signature verification with:

```text
Error: safe R1 was not latched as requested
✗ Packaged paged-kernel runtime smoke failed.
Existing installation was left unchanged.
```

The smoke command projected `MLX_GATHER_QMM_EXPERT_SLICES=1` inside `runtime-smoke.run()`. On affected Macs, MLX initialized its process-global Metal `Device` before that method, permanently latching the route as not requested. The installer correctly failed closed, but users could not install or update.

This hotfix passes the exact retained three-key environment before `exec` in every packaged-child path—curl installer, self-updater, and paged preflight—while preserving the in-child poison/reapply/environment/AOT verification.

## Before

```mermaid
flowchart LR
  subgraph Code[Code path]
    A[Installer execs signed child] --> B[MLX module/process initialization]
    B --> C[Metal Device may initialize]
    C --> D[safe-R1 requested=false latched]
    D --> E[runtime-smoke.run sets env]
    E --> F[Too late for process-global Device]
  end
  subgraph Behavior[User outcome]
    F --> G[safe R1 not latched]
    G --> H[Packaged smoke exits 1]
    H --> I[Install rejected; old install preserved]
  end
```

## After

```mermaid
flowchart LR
  subgraph Code[Code path]
    A[Parent derives retained validation environment] --> B[Set three latch variables before exec]
    B --> C[Signed child starts]
    C --> D[MLX Metal Device initializes with safe R1 requested]
    D --> E[Child poisons and reapplies retained projection]
    E --> F[Validate env, AOT kernels, counters, paged kernel]
  end
  subgraph Behavior[User outcome]
    F --> G[Runtime smoke succeeds]
    G --> H[Complete signed app stages atomically]
    H --> I[Install/update proceeds]
  end
```

## Pre-exec contract

Every runtime-smoke child now begins with:

```text
DARKBLOOM_GEMMA4_PREFILL_CHUNK_EVAL=18
MLX_GEMMA4_FUSED_WEIGHTED_UNSORT=1
MLX_GATHER_QMM_EXPERT_SLICES=1
DARKBLOOM_NO_UPDATE_CHECK=1
```

Swift paths derive the first three keys from `PackagedRuntimeSmoke.retainedValidationEnvironment()` rather than duplicating values. The shell installer uses the same fixed retained release contract. `scripts/install.sh` and `coordinator/api/install.sh` remain byte-identical.

## Scope

- No Qwen rollback behavior changes from v0.8.9.
- No `qmv_wide`, model, routing, admission, or coordinator runtime change.
- No smoke weakening or skip.
- Existing installations remain untouched on any verification failure.
- Version source and coordinator fallback advance to 0.8.10.

## Verification

- `scripts/test-install-atomic.sh`: passed; the packaged fixture now exits nonzero unless all three latch variables exist before exec.
- `make provider-test`: **2,118 tests in 217 suites passed**.
- Signed-child self-update runtime verification passed.
- Release build passed.
- Source-matched metallib staged successfully.
- Release runtime smoke:
  - `gemma-optimizations-runtime-smoke: ok`
  - `paged-kernel-runtime-smoke: ok`
- `check-release-version.sh v0.8.10 0.8.10`: passed.
- Built CLI reports `0.8.10`.
- Installer embed parity and pre-push checks passed.

## Post-merge

Tag the exact merge commit as `v0.8.10`, publish through the signed/notarized release workflow, and verify a fresh curl install plus self-update before broader rollout conclusions.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/663"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789973249&installation_model_id=21733&pr_number=663&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F663&signature=308a2a7f8c64a88e503ec571c83094174f7380e4909f281d4f162969bec8fc27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->