### PR TITLE
fix(fleet): make "connected but not advertising" explainable

### DIFF
--- a/console-ui/src/app/providers/dashboard/fixes-coverage.test.ts
+++ b/console-ui/src/app/providers/dashboard/fixes-coverage.test.ts
@@ -35,6 +35,7 @@ const MODEL_BLOCKERS: RoutingBlocker[] = [
   "model_not_in_catalog",
   "model_weight_hash_mismatch",
   "model_template_render_broken",
+  "model_requires_dedicated_box",
 ];
 
 describe("every routing blocker is actionable", () => {
@@ -58,6 +59,7 @@ describe("every routing blocker is actionable", () => {
           {
             id: "some/model-with:colons",
             publicly_listed: false,
+            routable: false,
             owner_routable: false,
             blockers: [blocker],
           },

--- a/console-ui/src/app/providers/dashboard/fixes-coverage.test.ts
+++ b/console-ui/src/app/providers/dashboard/fixes-coverage.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+
+import { routingWarnings } from "../routing-blockers";
+import type { RoutingBlocker } from "../types";
+import { hasFix, resolveFix } from "./fixes";
+import { makeProvider, makeRouting } from "./testFixtures";
+
+// fixes.ts states the invariant "every warning id produced by computeWarnings()
+// must have an entry here" but the test enforcing it never existed. This is it,
+// for the routing verdict — the one warning family whose ids are generated
+// rather than hand-written, and therefore the one that can silently grow past
+// the fix table.
+
+const MACHINE_BLOCKERS: RoutingBlocker[] = [
+  "offline",
+  "untrusted",
+  "private_only",
+  "trust_below_minimum",
+  "runtime_hash_mismatch",
+  "attestation_challenge_never_passed",
+  "attestation_challenge_stale",
+  "no_encryption_key",
+  "unsupported_backend",
+  "unencrypted_response_chunks",
+  "runtime_manifest_unchecked",
+  "sip_unverified",
+  "code_attestation_missing",
+  "privacy_capabilities_missing",
+  "privacy_capabilities_incomplete",
+  "no_models_registered",
+  "no_routable_models",
+];
+
+const MODEL_BLOCKERS: RoutingBlocker[] = [
+  "model_not_in_catalog",
+  "model_weight_hash_mismatch",
+  "model_template_render_broken",
+];
+
+describe("every routing blocker is actionable", () => {
+  it.each(MACHINE_BLOCKERS)("machine blocker %s has an explicit fix", (blocker) => {
+    const p = makeProvider({
+      status: "serving",
+      online: true,
+      routing: makeRouting({ routable: false, blockers: [blocker], models: [] }),
+    });
+    const warnings = routingWarnings(p)!;
+    expect(warnings).toHaveLength(1);
+    expect(hasFix(warnings[0].id)).toBe(true);
+  });
+
+  it.each(MODEL_BLOCKERS)("model blocker %s has an explicit fix", (blocker) => {
+    const p = makeProvider({
+      status: "serving",
+      online: true,
+      routing: makeRouting({
+        models: [
+          {
+            id: "some/model-with:colons",
+            publicly_listed: false,
+            owner_routable: false,
+            blockers: [blocker],
+          },
+        ],
+      }),
+    });
+    const warnings = routingWarnings(p)!;
+    expect(warnings).toHaveLength(1);
+    // Model ids can contain colons; the fix lookup must still resolve.
+    expect(hasFix(warnings[0].id)).toBe(true);
+    expect(resolveFix(warnings[0].id).label).not.toBe("View setup guide");
+  });
+
+  it("falls back to the generic fix for an id it has never seen", () => {
+    expect(resolveFix("routing:some_future_blocker").label).toBe("View setup guide");
+  });
+});

--- a/console-ui/src/app/providers/dashboard/fixes.ts
+++ b/console-ui/src/app/providers/dashboard/fixes.ts
@@ -248,6 +248,11 @@ const FIX_TABLE: Record<string, FixAction> = {
     command: "darkbloom models pull",
     note: "The chat template failed its render self-check, so every request shape is fenced away.",
   },
+  "routing:model:model_requires_dedicated_box": {
+    kind: "guidance",
+    label: "Serve only this model",
+    note: "Remove the other model families from `enabled_models` and restart, or accept that this build stays unrouted on a mixed box.",
+  },
 };
 
 /**

--- a/console-ui/src/app/providers/dashboard/fixes.ts
+++ b/console-ui/src/app/providers/dashboard/fixes.ts
@@ -132,7 +132,136 @@ const FIX_TABLE: Record<string, FixAction> = {
     label: "No action needed",
     note: "Routing starts within ~5 minutes of the first attestation challenge.",
   },
+
+  // ── Coordinator routing verdict ────────────────────────────────────────
+  // One entry per RoutingBlocker the coordinator can report (see
+  // coordinator/registry/routing_diagnostics.go). Per-model blockers are keyed
+  // without the model id; resolveFix strips it.
+  "routing:offline": {
+    kind: "command",
+    label: "Start the provider",
+    command: "darkbloom start",
+  },
+  "routing:untrusted": {
+    kind: "command",
+    label: "Restart & re-link",
+    command: "darkbloom restart && darkbloom login",
+    note: "Clears the untrust, then re-attests this device.",
+  },
+  "routing:private_only": {
+    kind: "guidance",
+    label: "Intentional — private mode",
+    note: "Disable private-only mode if you want this machine to earn from public network traffic.",
+  },
+  "routing:trust_below_minimum": {
+    kind: "link",
+    label: "Complete hardware attestation",
+    href: "/providers/setup",
+    note: "The network requires MDM enrollment + Apple Device Attestation.",
+  },
+  "routing:runtime_hash_mismatch": {
+    kind: "command",
+    label: "Reinstall",
+    command: INSTALL_COMMAND,
+    note: "Replaces a self-updated or partial bundle with a manifest-matching one.",
+  },
+  "routing:attestation_challenge_never_passed": {
+    kind: "guidance",
+    label: "No action needed",
+    note: "Routing starts within ~5 minutes of the first attestation challenge.",
+  },
+  "routing:attestation_challenge_stale": {
+    kind: "command",
+    label: "Force a fresh handshake",
+    command: "darkbloom restart",
+    note: "Re-runs the attestation challenge so routing can resume.",
+  },
+  "routing:no_encryption_key": {
+    kind: "command",
+    label: "Restart the provider",
+    command: "darkbloom restart",
+    note: "Republishes this machine's end-to-end encryption key.",
+  },
+  "routing:unsupported_backend": {
+    kind: "command",
+    label: "Reinstall",
+    command: INSTALL_COMMAND,
+  },
+  "routing:unencrypted_response_chunks": {
+    kind: "command",
+    label: "Reinstall",
+    command: INSTALL_COMMAND,
+  },
+  "routing:runtime_manifest_unchecked": {
+    kind: "command",
+    label: "Reinstall",
+    command: INSTALL_COMMAND,
+    note: "Installs a build the coordinator can match to a registered release.",
+  },
+  "routing:sip_unverified": {
+    kind: "guidance",
+    label: "Re-enable SIP",
+    note: "Boot into Recovery, run `csrutil enable`, reboot, then `darkbloom restart`.",
+  },
+  "routing:code_attestation_missing": {
+    kind: "guidance",
+    label: "Keep the Mac awake",
+    note: "Code-identity attestation completes over an APNs push; it needs the Mac awake and reachable.",
+  },
+  "routing:privacy_capabilities_missing": {
+    kind: "command",
+    label: "Reinstall",
+    command: INSTALL_COMMAND,
+  },
+  "routing:privacy_capabilities_incomplete": {
+    kind: "command",
+    label: "Restart the provider",
+    command: "darkbloom restart",
+    note: "If it persists after a restart, reinstall with the official installer.",
+  },
+  "routing:no_models_registered": {
+    kind: "command",
+    label: "Check local models",
+    command: "darkbloom models",
+    note: "Confirm the weights finished downloading and that `enabled_models` is not filtering them out, then `darkbloom restart`.",
+  },
+  "routing:no_routable_models": {
+    kind: "link",
+    label: "Add an approved model",
+    href: "/models",
+    note: "Download a catalog model, then run `darkbloom restart`.",
+  },
+  "routing:model:model_not_in_catalog": {
+    kind: "guidance",
+    label: "Local-only model",
+    note: "Still available to your own self-route requests; public traffic only reaches catalog models.",
+  },
+  "routing:model:model_weight_hash_mismatch": {
+    kind: "command",
+    label: "Re-download the model",
+    command: "darkbloom models pull",
+    note: "Local weights differ from the published build.",
+  },
+  "routing:model:model_template_render_broken": {
+    kind: "command",
+    label: "Re-download the model",
+    command: "darkbloom models pull",
+    note: "The chat template failed its render self-check, so every request shape is fenced away.",
+  },
 };
+
+/**
+ * Per-model warning ids embed the model id (`routing:model:<id>:<blocker>`)
+ * so each row is distinct in the feed. Fixes are per-blocker, so strip the
+ * model id before the lookup.
+ */
+function normalizeWarningId(warningId: string): string {
+  const prefix = "routing:model:";
+  if (!warningId.startsWith(prefix)) return warningId;
+  const lastColon = warningId.lastIndexOf(":");
+  if (lastColon <= prefix.length - 1) return warningId;
+  return prefix + warningId.slice(lastColon + 1);
+}
 
 /** Safe fallback so an unmapped warning still points somewhere useful. */
 export const GENERIC_FIX: FixAction = {
@@ -143,12 +272,12 @@ export const GENERIC_FIX: FixAction = {
 
 /** Resolve a warning id to its fix, falling back to a generic link. */
 export function resolveFix(warningId: string): FixAction {
-  return FIX_TABLE[warningId] ?? GENERIC_FIX;
+  return FIX_TABLE[normalizeWarningId(warningId)] ?? GENERIC_FIX;
 }
 
 /** Whether a warning id has an explicit (non-fallback) fix. */
 export function hasFix(warningId: string): boolean {
-  return warningId in FIX_TABLE;
+  return normalizeWarningId(warningId) in FIX_TABLE;
 }
 
 export { FIX_TABLE };

--- a/console-ui/src/app/providers/dashboard/routing-blockers.test.ts
+++ b/console-ui/src/app/providers/dashboard/routing-blockers.test.ts
@@ -69,15 +69,93 @@ describe("coordinator routing verdict", () => {
     expect(warnings.some((w) => w.id === "no_catalog_models")).toBe(false);
   });
 
+  it("keeps an earning machine earning when one extra build is stranded", () => {
+    // A catalog re-publish is enough to strand a local build. Rendering the
+    // whole card as "not earning" for that would contradict the very verdict
+    // this module exists to trust.
+    const p = makeProvider({
+      ...serving,
+      routing: makeRouting({
+        models: [
+          { id: "good-build", publicly_listed: true, routable: true, owner_routable: true },
+          {
+            id: "stale-build",
+            publicly_listed: false,
+            routable: false,
+            owner_routable: false,
+            blockers: ["model_weight_hash_mismatch"],
+          },
+        ],
+      }),
+    });
+    const warnings = computeWarnings(p, ctx);
+    const stranded = warnings.find(
+      (w) => w.id === "routing:model:stale-build:model_weight_hash_mismatch"
+    );
+    expect(stranded!.severity).toBe("degrading");
+    expect(deriveRouting(p, warnings)).not.toBe("blocked");
+  });
+
+  it("escalates per-model exclusions to blocking when nothing is routable", () => {
+    const p = makeProvider({
+      ...serving,
+      routing: makeRouting({
+        advertising: false,
+        routable: false,
+        owner_routable: false,
+        blockers: ["no_routable_models"],
+        models: [
+          {
+            id: "stale-build",
+            publicly_listed: false,
+            routable: false,
+            owner_routable: false,
+            blockers: ["model_weight_hash_mismatch"],
+          },
+        ],
+      }),
+    });
+    const warnings = computeWarnings(p, ctx);
+    const stranded = warnings.find(
+      (w) => w.id === "routing:model:stale-build:model_weight_hash_mismatch"
+    );
+    expect(stranded!.severity).toBe("blocking");
+    expect(deriveRouting(p, warnings)).toBe("blocked");
+  });
+
+  it("reports a dedicated-box exclusion with the model named", () => {
+    const p = makeProvider({
+      ...serving,
+      routing: makeRouting({
+        models: [
+          { id: "gpt-oss-20b", publicly_listed: true, routable: true, owner_routable: true },
+          {
+            id: "gemma-4-26b-qat-4bit",
+            publicly_listed: true,
+            routable: false,
+            owner_routable: true,
+            blockers: ["model_requires_dedicated_box"],
+          },
+        ],
+      }),
+    });
+    const warning = computeWarnings(p, ctx).find(
+      (w) => w.id === "routing:model:gemma-4-26b-qat-4bit:model_requires_dedicated_box"
+    );
+    expect(warning).toBeTruthy();
+    expect(warning!.title).toContain("gemma-4-26b-qat-4bit");
+  });
+
   it("reports per-model exclusions even when the machine itself is routable", () => {
     const p = makeProvider({
       ...serving,
       routing: makeRouting({
         models: [
-          { id: "good-build", publicly_listed: true, owner_routable: true },
+          { id: "good-build", publicly_listed: true, routable: true, owner_routable: true },
           {
             id: "stale-build",
             publicly_listed: false,
+            routable: false,
             owner_routable: false,
             blockers: ["model_weight_hash_mismatch"],
           },
@@ -100,6 +178,7 @@ describe("coordinator routing verdict", () => {
           {
             id: "my-local-build",
             publicly_listed: false,
+            routable: false,
             owner_routable: true,
             blockers: ["model_not_in_catalog"],
           },
@@ -131,14 +210,20 @@ describe("coordinator routing verdict", () => {
   });
 
   it("prefers the version remedy over the generic hash remedy below the floor", () => {
+    // The coordinator clears BOTH runtime flags for a below-floor machine, so
+    // both blockers arrive and both are red herrings.
     const p = makeProvider({
       ...serving,
       version: "0.7.0",
-      routing: makeRouting({ routable: false, blockers: ["runtime_hash_mismatch"] }),
+      routing: makeRouting({
+        routable: false,
+        blockers: ["runtime_hash_mismatch", "runtime_manifest_unchecked"],
+      }),
     });
     const warnings = computeWarnings(p, ctx);
     expect(warnings.some((w) => w.id === "version_below_min")).toBe(true);
     expect(warnings.some((w) => w.id === "routing:runtime_hash_mismatch")).toBe(false);
+    expect(warnings.some((w) => w.id === "routing:runtime_manifest_unchecked")).toBe(false);
   });
 
   it("still reports the hash mismatch when the version is current", () => {

--- a/console-ui/src/app/providers/dashboard/routing-blockers.test.ts
+++ b/console-ui/src/app/providers/dashboard/routing-blockers.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from "vitest";
+
+import { routingWarnings } from "../routing-blockers";
+import { computeWarnings } from "../warnings";
+import { deriveRouting } from "./routing";
+import { makeProvider, makeRouting } from "./testFixtures";
+
+const ctx = {
+  latest_provider_version: "0.8.9",
+  min_provider_version: "0.8.0",
+  heartbeat_timeout_seconds: 90,
+  challenge_max_age_seconds: 360,
+};
+
+const serving = {
+  status: "serving" as const,
+  online: true,
+  version: "0.8.9",
+  models: [{ id: "gemma-4-26b-qat-4bit" }],
+};
+
+describe("coordinator routing verdict", () => {
+  it("produces no routing warnings for a healthy machine", () => {
+    const p = makeProvider({ ...serving, routing: makeRouting() });
+    expect(routingWarnings(p)).toEqual([]);
+    expect(deriveRouting(p, computeWarnings(p, ctx))).toBe("routable");
+  });
+
+  it("returns null when the coordinator reported no verdict, so the caller falls back", () => {
+    expect(routingWarnings(makeProvider(serving))).toBeNull();
+  });
+
+  it("surfaces gates the old dashboard could not see at all", () => {
+    for (const blocker of [
+      "sip_unverified",
+      "privacy_capabilities_incomplete",
+      "code_attestation_missing",
+      "runtime_manifest_unchecked",
+      "unencrypted_response_chunks",
+    ] as const) {
+      const p = makeProvider({
+        ...serving,
+        routing: makeRouting({ routable: false, blockers: [blocker] }),
+      });
+      const warnings = computeWarnings(p, ctx);
+      const found = warnings.find((w) => w.id === `routing:${blocker}`);
+      expect(found, blocker).toBeTruthy();
+      expect(found!.severity).toBe("blocking");
+      expect(found!.detail.length).toBeGreaterThan(20);
+      expect(deriveRouting(p, warnings)).toBe("blocked");
+    }
+  });
+
+  it("reports an empty model list as its own distinct reason", () => {
+    const p = makeProvider({
+      ...serving,
+      models: [],
+      routing: makeRouting({
+        advertising: false,
+        routable: false,
+        owner_routable: false,
+        blockers: ["no_models_registered"],
+        models: [],
+      }),
+    });
+    const warnings = computeWarnings(p, ctx);
+    expect(warnings.some((w) => w.id === "routing:no_models_registered")).toBe(true);
+    // The legacy client-side guess must not also fire.
+    expect(warnings.some((w) => w.id === "no_catalog_models")).toBe(false);
+  });
+
+  it("reports per-model exclusions even when the machine itself is routable", () => {
+    const p = makeProvider({
+      ...serving,
+      routing: makeRouting({
+        models: [
+          { id: "good-build", publicly_listed: true, owner_routable: true },
+          {
+            id: "stale-build",
+            publicly_listed: false,
+            owner_routable: false,
+            blockers: ["model_weight_hash_mismatch"],
+          },
+        ],
+      }),
+    });
+    const warnings = computeWarnings(p, ctx);
+    const modelWarning = warnings.find(
+      (w) => w.id === "routing:model:stale-build:model_weight_hash_mismatch"
+    );
+    expect(modelWarning).toBeTruthy();
+    expect(modelWarning!.title).toContain("stale-build");
+  });
+
+  it("treats an off-catalog local model as informational, not blocking", () => {
+    const p = makeProvider({
+      ...serving,
+      routing: makeRouting({
+        models: [
+          {
+            id: "my-local-build",
+            publicly_listed: false,
+            owner_routable: true,
+            blockers: ["model_not_in_catalog"],
+          },
+        ],
+      }),
+    });
+    const warnings = computeWarnings(p, ctx);
+    const w = warnings.find(
+      (x) => x.id === "routing:model:my-local-build:model_not_in_catalog"
+    );
+    expect(w!.severity).toBe("info");
+    expect(deriveRouting(p, warnings)).not.toBe("blocked");
+  });
+
+  it("does not duplicate the offline warning for an offline machine", () => {
+    const p = makeProvider({
+      status: "offline",
+      online: false,
+      routing: makeRouting({
+        advertising: false,
+        routable: false,
+        owner_routable: false,
+        blockers: ["offline"],
+        models: [],
+      }),
+    });
+    const warnings = computeWarnings(p, ctx);
+    expect(warnings.filter((w) => w.title.toLowerCase().includes("offline"))).toHaveLength(1);
+  });
+
+  it("prefers the version remedy over the generic hash remedy below the floor", () => {
+    const p = makeProvider({
+      ...serving,
+      version: "0.7.0",
+      routing: makeRouting({ routable: false, blockers: ["runtime_hash_mismatch"] }),
+    });
+    const warnings = computeWarnings(p, ctx);
+    expect(warnings.some((w) => w.id === "version_below_min")).toBe(true);
+    expect(warnings.some((w) => w.id === "routing:runtime_hash_mismatch")).toBe(false);
+  });
+
+  it("still reports the hash mismatch when the version is current", () => {
+    const p = makeProvider({
+      ...serving,
+      routing: makeRouting({ routable: false, blockers: ["runtime_hash_mismatch"] }),
+    });
+    expect(
+      computeWarnings(p, ctx).some((w) => w.id === "routing:runtime_hash_mismatch")
+    ).toBe(true);
+  });
+});
+
+describe("legacy fallback (coordinator without a routing verdict)", () => {
+  it("keeps reporting the four gates the old response exposed", () => {
+    const p = makeProvider({
+      status: "serving",
+      online: true,
+      version: "0.8.9",
+      runtime_verified: false,
+      trust_level: "self_signed",
+      models: [],
+      last_challenge_verified: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+    });
+    const ids = computeWarnings(p, ctx).map((w) => w.id);
+    expect(ids).toContain("runtime_unverified");
+    expect(ids).toContain("challenge_stale");
+    expect(ids).toContain("trust_self_signed");
+    expect(ids).toContain("no_catalog_models");
+  });
+});

--- a/console-ui/src/app/providers/dashboard/testFixtures.ts
+++ b/console-ui/src/app/providers/dashboard/testFixtures.ts
@@ -12,7 +12,12 @@ export function makeRouting(
     routable: true,
     owner_routable: true,
     models: [
-      { id: "gemma-4-26b-qat-4bit", publicly_listed: true, owner_routable: true },
+      {
+        id: "gemma-4-26b-qat-4bit",
+        publicly_listed: true,
+        routable: true,
+        owner_routable: true,
+      },
     ],
     challenge_max_age_seconds: 960,
     ...overrides,

--- a/console-ui/src/app/providers/dashboard/testFixtures.ts
+++ b/console-ui/src/app/providers/dashboard/testFixtures.ts
@@ -1,7 +1,23 @@
 // Shared test fixtures for the provider dashboard. Builds a fully-populated
 // MyProvider so individual tests only override the few fields they exercise.
 
-import type { MyProvider, MyReputation } from "../types";
+import type { MyProvider, MyProviderRouting, MyReputation } from "../types";
+
+/** A coordinator routing verdict for a fully-healthy machine. */
+export function makeRouting(
+  overrides: Partial<MyProviderRouting> = {}
+): MyProviderRouting {
+  return {
+    advertising: true,
+    routable: true,
+    owner_routable: true,
+    models: [
+      { id: "gemma-4-26b-qat-4bit", publicly_listed: true, owner_routable: true },
+    ],
+    challenge_max_age_seconds: 960,
+    ...overrides,
+  };
+}
 
 export function makeReputation(overrides: Partial<MyReputation> = {}): MyReputation {
   return {

--- a/console-ui/src/app/providers/routing-blockers.ts
+++ b/console-ui/src/app/providers/routing-blockers.ts
@@ -1,0 +1,173 @@
+// Renders the coordinator's routing verdict as dashboard warnings.
+//
+// Every gate here used to be re-derived client-side from a handful of exposed
+// booleans, which could only ever approximate the real decision — and silently
+// said nothing at all about the gates that were never exposed (SIP
+// verification, privacy capabilities, code attestation, per-model weight-hash
+// and template-render exclusions). A machine could be fenced by any of those
+// while the dashboard showed a clean card.
+//
+// The coordinator now reports its own verdict on `MyProvider.routing`, so this
+// module only has to translate it. No gate logic lives here.
+
+import type { MyProvider, RoutingBlocker } from "./types";
+import type { Warning, WarningSeverity } from "./warnings";
+
+interface BlockerCopy {
+  title: string;
+  detail: string;
+  severity?: WarningSeverity;
+}
+
+const BLOCKER_COPY: Record<RoutingBlocker, BlockerCopy> = {
+  offline: {
+    title: "Offline",
+    detail:
+      "The coordinator has no live connection to this machine. Start the provider with `darkbloom start`.",
+  },
+  untrusted: {
+    title: "Marked untrusted by attestation",
+    detail:
+      "The coordinator rejected this machine's attestation and is not routing to it. Restart the provider and re-link the device.",
+  },
+  private_only: {
+    title: "Private-only mode",
+    detail:
+      "This machine only serves your own self-route traffic, so it is not counted in the public catalog and does not earn from network requests.",
+    severity: "info",
+  },
+  trust_below_minimum: {
+    title: "Trust level below the routing threshold",
+    detail:
+      "The network requires hardware-attested machines. Complete MDM enrollment + Apple Device Attestation to start receiving requests.",
+  },
+  runtime_hash_mismatch: {
+    title: "Runtime hash mismatch",
+    detail:
+      "This machine's runtime hashes match no registered release — most often a self-updated or partially-installed bundle. Reinstall with the official installer to restore eligibility.",
+  },
+  attestation_challenge_never_passed: {
+    title: "Awaiting first attestation challenge",
+    detail:
+      "The machine is connected but has not completed a challenge handshake yet. Routing normally starts within ~5 minutes.",
+    severity: "info",
+  },
+  attestation_challenge_stale: {
+    title: "Attestation challenge stale",
+    detail:
+      "The last passing challenge is older than the freshness window, so the coordinator has dropped this machine from routing until a fresh handshake completes. Check that the Mac stays awake and the WebSocket is not being interrupted.",
+  },
+  no_encryption_key: {
+    title: "No end-to-end encryption key published",
+    detail:
+      "The machine has not published an X25519 public key, so no request can be encrypted to it. Restart the provider.",
+  },
+  unsupported_backend: {
+    title: "Inference backend no longer routable",
+    detail:
+      "This machine reports a retired inference backend. Reinstall with the latest installer.",
+  },
+  unencrypted_response_chunks: {
+    title: "Response chunks are not encrypted",
+    detail:
+      "The machine did not advertise encrypted streaming chunks, which the network requires. Reinstall with the latest installer.",
+  },
+  runtime_manifest_unchecked: {
+    title: "Runtime not verified against a release manifest",
+    detail:
+      "The coordinator could not match this machine's runtime to a registered release. Reinstall with the official installer.",
+  },
+  sip_unverified: {
+    title: "System Integrity Protection not confirmed",
+    detail:
+      "The last attestation challenge did not confirm SIP. Re-enable SIP (`csrutil enable` from Recovery) and restart the provider.",
+  },
+  code_attestation_missing: {
+    title: "Code-identity attestation incomplete",
+    detail:
+      "The machine has not completed the APNs code-identity handshake. Keep the Mac awake and reachable so the coordinator can complete it.",
+  },
+  privacy_capabilities_missing: {
+    title: "Privacy capabilities not reported",
+    detail:
+      "The machine did not report its privacy capabilities, which the network requires before any prompt is routed to it. Reinstall with the latest installer.",
+  },
+  privacy_capabilities_incomplete: {
+    title: "A required privacy capability is disabled",
+    detail:
+      "One of the required hardening capabilities (in-process backend, proxy disabled, anti-debug, core dumps disabled, scrubbed environment) is off. Restart the provider; if it persists, reinstall.",
+  },
+  no_models_registered: {
+    title: "No models registered with the coordinator",
+    detail:
+      "This machine advertised an empty model list. Check that the weights finished downloading, that `enabled_models` is not filtering everything out, and that the model's architecture is supported by this provider version.",
+  },
+  no_routable_models: {
+    title: "Every registered model was excluded",
+    detail:
+      "The machine registered models but none of them are routable. See the per-model reasons below.",
+  },
+  model_not_in_catalog: {
+    title: "Model not in the published catalog",
+    detail:
+      "The coordinator does not publish this model, so public traffic is never routed to it. It remains available to your own self-route requests.",
+    severity: "info",
+  },
+  model_weight_hash_mismatch: {
+    title: "Model weight hash does not match the catalog",
+    detail:
+      "The local weights differ from the published build. Re-download the model with `darkbloom models pull` and restart the provider.",
+  },
+  model_template_render_broken: {
+    title: "Chat template failed its render self-check",
+    detail:
+      "The provider could not render this model's chat template, so the coordinator fences every request shape away from it. Re-download the model.",
+  },
+};
+
+function warningFor(blocker: RoutingBlocker, idPrefix: string, suffix = ""): Warning {
+  const copy = BLOCKER_COPY[blocker];
+  if (!copy) {
+    return {
+      id: `${idPrefix}${blocker}`,
+      severity: "blocking",
+      title: "Excluded from routing",
+      detail: `The coordinator reported "${blocker}".`,
+    };
+  }
+  return {
+    id: `${idPrefix}${blocker}`,
+    severity: copy.severity ?? "blocking",
+    title: copy.title + suffix,
+    detail: copy.detail,
+  };
+}
+
+/**
+ * Warnings for a machine whose coordinator reported a routing verdict.
+ * Returns null when the coordinator did not (older build), so the caller can
+ * fall back to its local approximation.
+ */
+export function routingWarnings(p: MyProvider): Warning[] | null {
+  const routing = p.routing;
+  if (!routing) return null;
+
+  const out: Warning[] = [];
+  for (const blocker of routing.blockers ?? []) {
+    out.push(warningFor(blocker, "routing:"));
+  }
+
+  // Per-model exclusions matter even when the machine itself is routable: one
+  // stale build among several is exactly the case a machine-level verdict
+  // hides.
+  const seen = new Set<string>();
+  for (const model of routing.models ?? []) {
+    for (const blocker of model.blockers ?? []) {
+      const key = `${blocker}:${model.id}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      out.push(warningFor(blocker, `routing:model:${model.id}:`, ` — ${model.id}`));
+    }
+  }
+  return out;
+}

--- a/console-ui/src/app/providers/routing-blockers.ts
+++ b/console-ui/src/app/providers/routing-blockers.ts
@@ -123,21 +123,33 @@ const BLOCKER_COPY: Record<RoutingBlocker, BlockerCopy> = {
     detail:
       "The provider could not render this model's chat template, so the coordinator fences every request shape away from it. Re-download the model.",
   },
+  model_requires_dedicated_box: {
+    title: "Model routes only to dedicated machines",
+    detail:
+      "This model is reserved for machines that serve nothing else, and this one also serves other model families. Restrict it to this model to receive that traffic.",
+  },
 };
 
-function warningFor(blocker: RoutingBlocker, idPrefix: string, suffix = ""): Warning {
+function warningFor(
+  blocker: RoutingBlocker,
+  idPrefix: string,
+  { suffix = "", severity }: { suffix?: string; severity?: WarningSeverity } = {}
+): Warning {
   const copy = BLOCKER_COPY[blocker];
   if (!copy) {
     return {
       id: `${idPrefix}${blocker}`,
-      severity: "blocking",
+      severity: severity ?? "blocking",
       title: "Excluded from routing",
       detail: `The coordinator reported "${blocker}".`,
     };
   }
   return {
     id: `${idPrefix}${blocker}`,
-    severity: copy.severity ?? "blocking",
+    // An explicitly informational blocker stays informational; otherwise the
+    // caller decides, because whether a model-level exclusion stops the
+    // machine earning depends on the machine's other models.
+    severity: copy.severity ?? severity ?? "blocking",
     title: copy.title + suffix,
     detail: copy.detail,
   };
@@ -159,14 +171,22 @@ export function routingWarnings(p: MyProvider): Warning[] | null {
 
   // Per-model exclusions matter even when the machine itself is routable: one
   // stale build among several is exactly the case a machine-level verdict
-  // hides.
+  // hides. But they are NOT blocking while other builds still serve — a
+  // machine that is earning must not render as "not earning" because a
+  // catalog re-publish stranded one extra local build.
+  const modelSeverity: WarningSeverity = routing.routable ? "degrading" : "blocking";
   const seen = new Set<string>();
   for (const model of routing.models ?? []) {
     for (const blocker of model.blockers ?? []) {
       const key = `${blocker}:${model.id}`;
       if (seen.has(key)) continue;
       seen.add(key);
-      out.push(warningFor(blocker, `routing:model:${model.id}:`, ` — ${model.id}`));
+      out.push(
+        warningFor(blocker, `routing:model:${model.id}:`, {
+          suffix: ` — ${model.id}`,
+          severity: modelSeverity,
+        })
+      );
     }
   }
   return out;

--- a/console-ui/src/app/providers/types.ts
+++ b/console-ui/src/app/providers/types.ts
@@ -89,6 +89,52 @@ export interface MyReputation {
   challenges_failed: number;
 }
 
+/**
+ * Closed set of reasons the coordinator excluded a machine (or one of its
+ * models) from routing. Mirrors `RoutingBlocker` in
+ * coordinator/registry/routing_diagnostics.go — the Go side owns the strings.
+ */
+export type RoutingBlocker =
+  | "offline"
+  | "untrusted"
+  | "private_only"
+  | "trust_below_minimum"
+  | "runtime_hash_mismatch"
+  | "attestation_challenge_never_passed"
+  | "attestation_challenge_stale"
+  | "no_encryption_key"
+  | "unsupported_backend"
+  | "unencrypted_response_chunks"
+  | "runtime_manifest_unchecked"
+  | "sip_unverified"
+  | "code_attestation_missing"
+  | "privacy_capabilities_missing"
+  | "privacy_capabilities_incomplete"
+  | "no_models_registered"
+  | "no_routable_models"
+  | "model_not_in_catalog"
+  | "model_weight_hash_mismatch"
+  | "model_template_render_broken";
+
+export interface MyModelRouting {
+  id: string;
+  publicly_listed: boolean;
+  owner_routable: boolean;
+  blockers?: RoutingBlocker[];
+}
+
+export interface MyProviderRouting {
+  /** Counted into the public /v1/models catalog. */
+  advertising: boolean;
+  /** Public traffic can actually be dispatched here. Implies `advertising`. */
+  routable: boolean;
+  /** The owner's own self-route can reach it. */
+  owner_routable: boolean;
+  blockers?: RoutingBlocker[];
+  models?: MyModelRouting[];
+  challenge_max_age_seconds: number;
+}
+
 export interface MyProvider {
   id: string;
   account_id: string;
@@ -127,6 +173,11 @@ export interface MyProvider {
 
   last_challenge_verified?: string;
   failed_challenges: number;
+
+  // The coordinator's own routing verdict. Optional only for coordinators that
+  // predate it; when present it is authoritative and the client must not
+  // re-derive the gates it covers.
+  routing?: MyProviderRouting;
 
   system_metrics?: MySystemMetrics;
   backend_capacity?: MyBackendCapacity;

--- a/console-ui/src/app/providers/types.ts
+++ b/console-ui/src/app/providers/types.ts
@@ -114,11 +114,14 @@ export type RoutingBlocker =
   | "no_routable_models"
   | "model_not_in_catalog"
   | "model_weight_hash_mismatch"
-  | "model_template_render_broken";
+  | "model_template_render_broken"
+  | "model_requires_dedicated_box";
 
 export interface MyModelRouting {
   id: string;
   publicly_listed: boolean;
+  /** Public traffic can actually be dispatched to this build. */
+  routable: boolean;
   owner_routable: boolean;
   blockers?: RoutingBlocker[];
 }

--- a/console-ui/src/app/providers/warnings.ts
+++ b/console-ui/src/app/providers/warnings.ts
@@ -235,12 +235,17 @@ export function computeWarnings(
     });
   }
 
-  // A machine below the version floor is derouted by setting its runtime flag
-  // false, so the server's verdict says "runtime hash mismatch". The version
-  // warning above is the same fact with the actionable remedy, so don't also
-  // tell the operator to chase a hash.
+  // A machine below the version floor is derouted by clearing BOTH runtime
+  // flags, so the server's verdict says "runtime hash mismatch" and/or
+  // "runtime not verified against a release manifest". The version warning
+  // above is the same fact with the actionable remedy, so don't also send the
+  // operator chasing a hash.
   if (out.some((w) => w.id === "version_below_min")) {
-    return out.filter((w) => w.id !== "routing:runtime_hash_mismatch");
+    return out.filter(
+      (w) =>
+        w.id !== "routing:runtime_hash_mismatch" &&
+        w.id !== "routing:runtime_manifest_unchecked"
+    );
   }
   return out;
 }

--- a/console-ui/src/app/providers/warnings.ts
+++ b/console-ui/src/app/providers/warnings.ts
@@ -6,9 +6,17 @@
 //   - degrading: machine still routable but fewer requests / lower priority
 //   - info: configuration issue worth surfacing (e.g. payout setup)
 //
-// Keep this in sync with coordinator/internal/registry/registry.go scoring
-// rules and FindProviderWithTrust exclusion checks.
+// ROUTING GATES ARE NOT DERIVED HERE. The coordinator reports its own verdict
+// on `p.routing` (see coordinator/registry/routing_diagnostics.go) and
+// `routingWarnings` renders it verbatim. This file only owns the signals the
+// coordinator does not decide: liveness, thermals, memory pressure,
+// reputation, version currency, and payout setup.
+//
+// `legacyRoutingWarnings` is the transitional approximation used when the
+// coordinator predates the `routing` field. It is a strict subset of what the
+// server reports and should be deleted once no deployed coordinator omits it.
 
+import { routingWarnings } from "./routing-blockers";
 import type { MyProvider, MyProvidersResponse } from "./types";
 
 export type WarningSeverity = "blocking" | "degrading" | "info";
@@ -67,14 +75,19 @@ export function computeWarnings(
     });
   }
 
-  if (!p.runtime_verified) {
-    out.push({
-      id: "runtime_unverified",
-      severity: "blocking",
-      title: "Runtime hash mismatch",
-      detail:
-        "Provider runtime hashes do not match the known-good manifest. Reinstall with the latest installer to restore eligibility.",
-    });
+  // The coordinator's own verdict on every routing gate, or a local
+  // approximation when talking to a coordinator that predates it.
+  const serverRouting = routingWarnings(p);
+  const offline = p.status === "offline" || p.status === "never_seen";
+  if (serverRouting) {
+    // An offline machine already has its own warning above; the server's
+    // `offline` blocker would just duplicate it.
+    for (const w of serverRouting) {
+      if (offline && w.id === "routing:offline") continue;
+      out.push(w);
+    }
+  } else {
+    out.push(...legacyRoutingWarnings(p, ctx));
   }
 
   if (
@@ -101,54 +114,6 @@ export function computeWarnings(
       detail:
         "Health factor is zero; the coordinator will not route work. Cool the machine and ensure adequate ventilation.",
     });
-  }
-
-  // Stale attestation challenge: the coordinator excludes providers whose
-  // last challenge is older than `challenge_max_age_seconds` (typically 6 min).
-  if (
-    p.last_challenge_verified &&
-    p.status !== "offline" &&
-    p.status !== "untrusted" &&
-    p.status !== "never_seen"
-  ) {
-    const ageSec = (Date.now() - new Date(p.last_challenge_verified).getTime()) / 1000;
-    if (Number.isFinite(ageSec) && ageSec > (ctx.challenge_max_age_seconds || 360)) {
-      out.push({
-        id: "challenge_stale",
-        severity: "blocking",
-        title: "Attestation challenge stale",
-        detail: `Last challenge verified ${Math.round(ageSec / 60)} minutes ago. The coordinator drops providers from routing until a fresh handshake completes.`,
-      });
-    }
-  }
-
-  // Trust below the routing threshold. In production the coordinator's
-  // MinTrustLevel is "hardware", so anything below that gets ZERO requests
-  // (not just a reduced multiplier). We surface it as blocking and tell the
-  // user how to upgrade.
-  if (
-    p.trust_level !== "hardware" &&
-    p.status !== "offline" &&
-    p.status !== "untrusted" &&
-    p.status !== "never_seen"
-  ) {
-    if (p.trust_level === "self_signed") {
-      out.push({
-        id: "trust_self_signed",
-        severity: "blocking",
-        title: "Self-signed trust below routing threshold",
-        detail:
-          "The network requires hardware-attested machines. Complete MDM enrollment + Apple Device Attestation to start receiving requests.",
-      });
-    } else {
-      out.push({
-        id: "trust_none",
-        severity: "blocking",
-        title: "No attestation below routing threshold",
-        detail:
-          "This machine hasn't supplied a Secure Enclave attestation. Re-run the installer to register an SE-bound identity, then re-link the device.",
-      });
-    }
   }
 
   // Degrading: routable, but fewer / lower-quality requests.
@@ -235,26 +200,6 @@ export function computeWarnings(
     }
   }
 
-  // No catalog models: provider is online and trusted but didn't pass any
-  // models through the coordinator's catalog filter (either none of its
-  // models are in the catalog, or weight hashes mismatched). Routing
-  // requires `model in p.Models`, so this is effectively blocking even
-  // though scoring doesn't zero it out.
-  if (
-    p.models.length === 0 &&
-    p.status !== "offline" &&
-    p.status !== "untrusted" &&
-    p.status !== "never_seen"
-  ) {
-    out.push({
-      id: "no_catalog_models",
-      severity: "blocking",
-      title: "No catalog models served",
-      detail:
-        "None of this machine's local models matched the coordinator catalog (or weight hashes did not match). Download an approved model and restart the provider.",
-    });
-  }
-
   // Info: configuration to fix.
   if (
     !p.account_id &&
@@ -290,15 +235,82 @@ export function computeWarnings(
     });
   }
 
-  // Visibility check: if the machine should appear in the public marketplace
-  // (online + hardware trust) but isn't routable due to a stale challenge.
-  if (
-    p.status !== "offline" &&
-    p.status !== "untrusted" &&
-    p.status !== "never_seen" &&
-    p.trust_level === "hardware" &&
-    !p.last_challenge_verified
-  ) {
+  // A machine below the version floor is derouted by setting its runtime flag
+  // false, so the server's verdict says "runtime hash mismatch". The version
+  // warning above is the same fact with the actionable remedy, so don't also
+  // tell the operator to chase a hash.
+  if (out.some((w) => w.id === "version_below_min")) {
+    return out.filter((w) => w.id !== "routing:runtime_hash_mismatch");
+  }
+  return out;
+}
+
+/**
+ * Client-side approximation of the coordinator's routing gates, used ONLY when
+ * the coordinator did not report its own verdict. It covers the four gates the
+ * old response made visible; the server reports fifteen.
+ */
+function legacyRoutingWarnings(
+  p: MyProvider,
+  ctx: Pick<MyProvidersResponse, "challenge_max_age_seconds">
+): Warning[] {
+  const out: Warning[] = [];
+  const connected =
+    p.status !== "offline" && p.status !== "untrusted" && p.status !== "never_seen";
+
+  if (!p.runtime_verified) {
+    out.push({
+      id: "runtime_unverified",
+      severity: "blocking",
+      title: "Runtime hash mismatch",
+      detail:
+        "Provider runtime hashes do not match the known-good manifest. Reinstall with the latest installer to restore eligibility.",
+    });
+  }
+
+  if (p.last_challenge_verified && connected) {
+    const ageSec = (Date.now() - new Date(p.last_challenge_verified).getTime()) / 1000;
+    if (Number.isFinite(ageSec) && ageSec > (ctx.challenge_max_age_seconds || 360)) {
+      out.push({
+        id: "challenge_stale",
+        severity: "blocking",
+        title: "Attestation challenge stale",
+        detail: `Last challenge verified ${Math.round(ageSec / 60)} minutes ago. The coordinator drops providers from routing until a fresh handshake completes.`,
+      });
+    }
+  }
+
+  if (connected && p.trust_level !== "hardware") {
+    out.push(
+      p.trust_level === "self_signed"
+        ? {
+            id: "trust_self_signed",
+            severity: "blocking",
+            title: "Self-signed trust below routing threshold",
+            detail:
+              "The network requires hardware-attested machines. Complete MDM enrollment + Apple Device Attestation to start receiving requests.",
+          }
+        : {
+            id: "trust_none",
+            severity: "blocking",
+            title: "No attestation below routing threshold",
+            detail:
+              "This machine hasn't supplied a Secure Enclave attestation. Re-run the installer to register an SE-bound identity, then re-link the device.",
+          }
+    );
+  }
+
+  if (connected && p.models.length === 0) {
+    out.push({
+      id: "no_catalog_models",
+      severity: "blocking",
+      title: "No catalog models served",
+      detail:
+        "None of this machine's local models matched the coordinator catalog (or weight hashes did not match). Download an approved model and restart the provider.",
+    });
+  }
+
+  if (connected && p.trust_level === "hardware" && !p.last_challenge_verified) {
     out.push({
       id: "no_challenge_yet",
       severity: "info",

--- a/coordinator/api/me_handlers.go
+++ b/coordinator/api/me_handlers.go
@@ -374,7 +374,10 @@ func (s *Server) handleMyProviders(w http.ResponseWriter, r *http.Request) {
 		LatestProviderVersion: s.latestReleasedVersion(),
 		MinProviderVersion:    s.minProviderVersion,
 		HeartbeatTimeoutSec:   90,
-		ChallengeMaxAgeSec:    int((6 * time.Minute).Seconds()),
+		// The window routing actually enforces. A second, tighter copy used to
+		// live here, so a card could warn "challenge stale" at 8 minutes while
+		// the coordinator was still happily routing.
+		ChallengeMaxAgeSec: int(registry.ChallengeFreshnessMaxAge.Seconds()),
 	}
 	writeJSON(w, http.StatusOK, resp)
 }

--- a/coordinator/api/me_handlers.go
+++ b/coordinator/api/me_handlers.go
@@ -92,6 +92,12 @@ type myProvider struct {
 	LastChallengeVerified *time.Time `json:"last_challenge_verified,omitempty"`
 	FailedChallenges      int        `json:"failed_challenges"`
 
+	// Routing is the coordinator's own verdict on whether this machine is
+	// advertising, and the specific gates blocking it when it is not. Computed
+	// from the same predicates the router uses, so it can never claim the
+	// machine is serving when it is fenced (or the reverse).
+	Routing *registry.ProviderRoutingDiagnostics `json:"routing,omitempty"`
+
 	// Live snapshot (only set when the machine is currently connected)
 	SystemMetrics   *protocol.SystemMetrics   `json:"system_metrics,omitempty"`
 	BackendCapacity *protocol.BackendCapacity `json:"backend_capacity,omitempty"`
@@ -297,6 +303,7 @@ func (s *Server) mergeFleet(ctx context.Context, accountID string) ([]myProvider
 	deduped := dedupeRecordsByIdentity(records)
 	seenIDs := make(map[string]bool, len(deduped))
 	seenLive := make(map[string]bool)
+	now := time.Now()
 	out := make([]myProvider, 0, len(deduped))
 	for i := range deduped {
 		// Prefer session-ID match; fall back to identity (serial/SE key)
@@ -306,6 +313,7 @@ func (s *Server) mergeFleet(ctx context.Context, accountID string) ([]myProvider
 			live = liveByIdentity[recordIdentity(&deduped[i])]
 		}
 		mp := buildMyProvider(&deduped[i], live)
+		s.attachRoutingDiagnostics(&mp, live, now)
 		out = append(out, mp)
 		seenIDs[deduped[i].ID] = true
 		if live != nil {
@@ -319,9 +327,29 @@ func (s *Server) mergeFleet(ctx context.Context, accountID string) ([]myProvider
 		if liveMatchesEmittedIdentity(p, out) {
 			continue
 		}
-		out = append(out, buildMyProvider(nil, p))
+		mp := buildMyProvider(nil, p)
+		s.attachRoutingDiagnostics(&mp, p, now)
+		out = append(out, mp)
 	}
 	return out, nil
+}
+
+// attachRoutingDiagnostics asks the registry why this machine is (or is not)
+// advertising, so the owner sees the coordinator's ACTUAL verdict instead of
+// inferring it from a handful of green booleans. Offline machines get a
+// synthetic offline verdict — there is no live provider to interrogate, and
+// omitting the field entirely would read as "no problems".
+func (s *Server) attachRoutingDiagnostics(
+	mp *myProvider, live *registry.Provider, now time.Time,
+) {
+	if live == nil {
+		mp.Routing = &registry.ProviderRoutingDiagnostics{
+			Blockers:               []registry.RoutingBlocker{registry.BlockerOffline},
+			ChallengeMaxAgeSeconds: int(registry.ChallengeFreshnessMaxAge.Seconds()),
+		}
+		return
+	}
+	mp.Routing = s.registry.RoutingDiagnostics(live.ID, now)
 }
 
 func (s *Server) handleMyProviders(w http.ResponseWriter, r *http.Request) {

--- a/coordinator/api/me_handlers.go
+++ b/coordinator/api/me_handlers.go
@@ -245,10 +245,23 @@ func tallyCounts(c *myFleetCounts, mp *myProvider, minVersion string) {
 	}
 }
 
-// needsAttention is the server-side mirror of the client warning logic. It's
-// only used for the summary count, not for individual warning text. The UI
-// renders detailed warnings from the per-machine payload.
+// needsAttention drives the dashboard header count. When the coordinator has
+// a routing verdict for the machine it defers to it, so the header and the
+// per-machine card cannot disagree — a machine the router is fencing counts,
+// and one it is happily serving does not. The checks below it are the older
+// approximation, kept for machines with no live verdict (offline rows) and for
+// the two facts routing does not cover: challenge failures and version
+// currency.
 func needsAttention(mp *myProvider, minVersion string) bool {
+	if minVersion != "" && mp.Version != "" && semverLess(mp.Version, minVersion) {
+		return true
+	}
+	if mp.FailedChallenges > 0 {
+		return true
+	}
+	if mp.Routing != nil {
+		return !mp.Routing.Routable
+	}
 	if mp.Status == string(registry.StatusUntrusted) {
 		return true
 	}
@@ -259,12 +272,6 @@ func needsAttention(mp *myProvider, minVersion string) bool {
 		return true
 	}
 	if mp.TrustLevel != string(registry.TrustHardware) {
-		return true
-	}
-	if mp.FailedChallenges > 0 {
-		return true
-	}
-	if minVersion != "" && mp.Version != "" && semverLess(mp.Version, minVersion) {
 		return true
 	}
 	return false

--- a/coordinator/api/me_routing_diagnostics_test.go
+++ b/coordinator/api/me_routing_diagnostics_test.go
@@ -1,0 +1,219 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+	"github.com/eigeninference/d-inference/coordinator/registry"
+)
+
+// GET /v1/me/providers must tell an owner why a machine is not advertising.
+// Before this existed the response carried a dozen green booleans and no
+// verdict, so a fenced node looked identical to a healthy one — the
+// "trust=hardware, challenges passing, model warm, doctor 30 PASS / 0 FAIL,
+// still serving nothing" report.
+//
+// These assert on the DECODED WIRE JSON, not the Go struct, so the field names
+// the console UI and `darkbloom doctor` key off are pinned.
+
+type wireModelRouting struct {
+	ID             string   `json:"id"`
+	PubliclyListed bool     `json:"publicly_listed"`
+	OwnerRoutable  bool     `json:"owner_routable"`
+	Blockers       []string `json:"blockers"`
+}
+
+type wireRouting struct {
+	Advertising            bool               `json:"advertising"`
+	Routable               bool               `json:"routable"`
+	OwnerRoutable          bool               `json:"owner_routable"`
+	Blockers               []string           `json:"blockers"`
+	Models                 []wireModelRouting `json:"models"`
+	ChallengeMaxAgeSeconds int                `json:"challenge_max_age_seconds"`
+}
+
+type wireProvider struct {
+	ID              string       `json:"id"`
+	Status          string       `json:"status"`
+	RuntimeVerified bool         `json:"runtime_verified"`
+	Routing         *wireRouting `json:"routing"`
+}
+
+type wireProvidersResponse struct {
+	Providers []wireProvider `json:"providers"`
+}
+
+const routingTestModel = "gemma-4-26b-qat-4bit"
+
+// registerRoutableProvider puts a fully-healthy live provider in the registry.
+func registerRoutableProvider(t *testing.T, srv *Server, id, accountID string) *registry.Provider {
+	t.Helper()
+	p := srv.registry.Register(id, nil, &protocol.RegisterMessage{
+		Type:                    protocol.TypeRegister,
+		Hardware:                protocol.Hardware{MachineModel: "Mac15,8", MemoryGB: 64},
+		Models:                  []protocol.ModelInfo{{ID: routingTestModel, ModelType: "chat"}},
+		Backend:                 registry.BackendMLXSwift,
+		PublicKey:               "fX6XYH7p2hmM3ogeXaAsY+p8M6UKD1df/LJUN9Nj9Nw=",
+		EncryptedResponseChunks: true,
+		PrivacyCapabilities: &protocol.PrivacyCapabilities{
+			TextBackendInprocess: true,
+			TextProxyDisabled:    true,
+			AntiDebugEnabled:     true,
+			CoreDumpsDisabled:    true,
+			EnvScrubbed:          true,
+		},
+	})
+	p.Mu().Lock()
+	p.AccountID = accountID
+	p.TrustLevel = registry.TrustHardware
+	p.RuntimeVerified = true
+	p.RuntimeManifestChecked = true
+	p.ChallengeVerifiedSIP = true
+	p.LastChallengeVerified = time.Now()
+	p.Mu().Unlock()
+	return p
+}
+
+func fetchMyProviders(t *testing.T, srv *Server, accountID string) wireProvidersResponse {
+	t.Helper()
+	w := httptest.NewRecorder()
+	srv.handleMyProviders(w, reqWithUser(http.MethodGet, "/v1/me/providers", "", accountID))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", w.Code, w.Body.String())
+	}
+	var resp wireProvidersResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v\nbody: %s", err, w.Body.String())
+	}
+	return resp
+}
+
+func TestMyProviders_HealthyMachineReportsAdvertising(t *testing.T) {
+	srv, _ := newKeyTestServer(t)
+	srv.registry.MinTrustLevel = registry.TrustHardware
+	registerRoutableProvider(t, srv, "p1", "acct-1")
+
+	resp := fetchMyProviders(t, srv, "acct-1")
+	if len(resp.Providers) != 1 {
+		t.Fatalf("providers = %d, want 1", len(resp.Providers))
+	}
+	routing := resp.Providers[0].Routing
+	if routing == nil {
+		t.Fatal("response carries no routing verdict")
+	}
+	if !routing.Advertising || !routing.Routable || !routing.OwnerRoutable {
+		t.Fatalf("healthy machine reported %+v", routing)
+	}
+	if len(routing.Blockers) != 0 {
+		t.Fatalf("healthy machine reported blockers %v", routing.Blockers)
+	}
+	if routing.ChallengeMaxAgeSeconds != int(registry.ChallengeFreshnessMaxAge.Seconds()) {
+		t.Fatalf("challenge_max_age_seconds = %d, want %d",
+			routing.ChallengeMaxAgeSeconds, int(registry.ChallengeFreshnessMaxAge.Seconds()))
+	}
+	if len(routing.Models) != 1 || !routing.Models[0].PubliclyListed {
+		t.Fatalf("model rows = %+v", routing.Models)
+	}
+}
+
+// The reported shape: every legacy field green, nothing served.
+func TestMyProviders_GreenDashboardButFencedExplainsWhy(t *testing.T) {
+	cases := []struct {
+		name    string
+		break_  func(p *registry.Provider)
+		blocker string
+	}{
+		{"stale challenge", func(p *registry.Provider) {
+			p.LastChallengeVerified = time.Now().Add(-registry.ChallengeFreshnessMaxAge - time.Minute)
+		}, "attestation_challenge_stale"},
+		{"sip unverified", func(p *registry.Provider) { p.ChallengeVerifiedSIP = false }, "sip_unverified"},
+		{"manifest unchecked", func(p *registry.Provider) { p.RuntimeManifestChecked = false }, "runtime_manifest_unchecked"},
+		{"runtime mismatch", func(p *registry.Provider) { p.RuntimeVerified = false }, "runtime_hash_mismatch"},
+		{"no models", func(p *registry.Provider) { p.Models = nil }, "no_models_registered"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv, _ := newKeyTestServer(t)
+			srv.registry.MinTrustLevel = registry.TrustHardware
+			p := registerRoutableProvider(t, srv, "p1", "acct-1")
+			p.Mu().Lock()
+			tc.break_(p)
+			p.Mu().Unlock()
+
+			routing := fetchMyProviders(t, srv, "acct-1").Providers[0].Routing
+			if routing == nil {
+				t.Fatal("response carries no routing verdict")
+			}
+			// `routable`, not `advertising`: the public catalog deliberately
+			// omits the runtime-hash and challenge-freshness gates, so a fenced
+			// machine can still be counted there.
+			if routing.Routable {
+				t.Fatalf("fenced machine reported as routable: %+v", routing)
+			}
+			found := false
+			for _, b := range routing.Blockers {
+				if b == tc.blocker {
+					found = true
+				}
+			}
+			if !found {
+				t.Fatalf("blockers = %v, want to contain %q", routing.Blockers, tc.blocker)
+			}
+		})
+	}
+}
+
+// A stale-hash catalog build is dropped per MODEL, so the machine-level
+// verdict has to point at the model rows rather than claim the machine is fine.
+func TestMyProviders_PerModelBlockersAreReported(t *testing.T) {
+	srv, _ := newKeyTestServer(t)
+	srv.registry.MinTrustLevel = registry.TrustHardware
+	p := registerRoutableProvider(t, srv, "p1", "acct-1")
+	p.Mu().Lock()
+	p.Models = []protocol.ModelInfo{{ID: routingTestModel, WeightHash: "stale"}}
+	p.Mu().Unlock()
+	srv.registry.SetModelCatalog([]registry.CatalogEntry{
+		{ID: routingTestModel, WeightHash: "expected"},
+	})
+
+	routing := fetchMyProviders(t, srv, "acct-1").Providers[0].Routing
+	if routing.Advertising || routing.Routable {
+		t.Fatalf("machine with only a stale-hash build must not advertise: %+v", routing)
+	}
+	if len(routing.Blockers) != 1 || routing.Blockers[0] != "no_routable_models" {
+		t.Fatalf("machine blockers = %v, want [no_routable_models]", routing.Blockers)
+	}
+	if len(routing.Models) != 1 {
+		t.Fatalf("model rows = %+v", routing.Models)
+	}
+	m := routing.Models[0]
+	if m.PubliclyListed || len(m.Blockers) != 1 || m.Blockers[0] != "model_weight_hash_mismatch" {
+		t.Fatalf("model row = %+v", m)
+	}
+}
+
+// An offline machine must not read as "no problems" just because there is no
+// live provider to interrogate.
+func TestMyProviders_OfflineMachineReportsOffline(t *testing.T) {
+	srv, st := newKeyTestServer(t)
+	seedProviderRecord(t, st, "p-old", "SER-OLD", "acct-1")
+
+	resp := fetchMyProviders(t, srv, "acct-1")
+	if len(resp.Providers) != 1 {
+		t.Fatalf("providers = %d, want 1", len(resp.Providers))
+	}
+	routing := resp.Providers[0].Routing
+	if routing == nil {
+		t.Fatal("offline machine carries no routing verdict")
+	}
+	if routing.Advertising || routing.Routable {
+		t.Fatal("offline machine reported as advertising")
+	}
+	if len(routing.Blockers) != 1 || routing.Blockers[0] != "offline" {
+		t.Fatalf("blockers = %v, want [offline]", routing.Blockers)
+	}
+}

--- a/coordinator/api/me_routing_diagnostics_test.go
+++ b/coordinator/api/me_routing_diagnostics_test.go
@@ -196,6 +196,56 @@ func TestMyProviders_PerModelBlockersAreReported(t *testing.T) {
 	}
 }
 
+// The dashboard header count and the per-machine card must not disagree: a
+// machine the router is happily serving cannot be in the "needs attention"
+// tally, and one it is fencing must be.
+func TestNeedsAttentionFollowsTheRoutingVerdict(t *testing.T) {
+	routable := &registry.ProviderRoutingDiagnostics{Advertising: true, Routable: true}
+	fenced := &registry.ProviderRoutingDiagnostics{
+		Advertising: true,
+		Blockers:    []registry.RoutingBlocker{registry.BlockerChallengeStale},
+	}
+	base := myProvider{
+		Status:          string(registry.StatusOnline),
+		TrustLevel:      string(registry.TrustHardware),
+		RuntimeVerified: true,
+		Version:         "0.8.9",
+	}
+
+	healthy := base
+	healthy.Routing = routable
+	if needsAttention(&healthy, "0.8.0") {
+		t.Fatal("a routable machine must not be counted as needing attention")
+	}
+
+	fencedProvider := base
+	fencedProvider.Routing = fenced
+	if !needsAttention(&fencedProvider, "0.8.0") {
+		t.Fatal("a fenced machine must be counted as needing attention")
+	}
+
+	// Facts routing does not cover still count, verdict or not.
+	stale := base
+	stale.Routing = routable
+	stale.Version = "0.7.0"
+	if !needsAttention(&stale, "0.8.0") {
+		t.Fatal("a below-floor version must count even when routing looks fine")
+	}
+	failing := base
+	failing.Routing = routable
+	failing.FailedChallenges = 2
+	if !needsAttention(&failing, "0.8.0") {
+		t.Fatal("failed challenges must count even when routing looks fine")
+	}
+
+	// No verdict (offline row): the older approximation still applies.
+	offline := base
+	offline.Status = "offline"
+	if !needsAttention(&offline, "0.8.0") {
+		t.Fatal("an offline machine with no verdict must still count")
+	}
+}
+
 // An offline machine must not read as "no problems" just because there is no
 // live provider to interrogate.
 func TestMyProviders_OfflineMachineReportsOffline(t *testing.T) {

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -655,42 +655,13 @@ type Provider struct {
 }
 
 // providerSupportsPrivateTextLocked is the SINGLE routing chokepoint for
-// private/text traffic. It is a method on *Registry (not a free function) so the
-// APNs code-identity gate can consult the live rollout policy
-// (codeAttestationEnforcedLocked) rather than a value stamped at registration —
-// that is what lets the grace→enforce deadline flip without a reconnect. Callers
+// private/text traffic. The gate itself lives in
+// providerPrivateTextBlockerLocked (routing_diagnostics.go), which returns the
+// reason it refused; this is the boolean view of the same decision, so the
+// operator-facing diagnostic and the routing decision cannot disagree. Callers
 // hold r.mu (every call site is inside an r-locked Registry method).
 func (r *Registry) providerSupportsPrivateTextLocked(p *Provider) bool {
-	if p.PublicKey == "" || !privateTextBackendSupported(p.Backend) || !p.EncryptedResponseChunks {
-		return false
-	}
-	if !p.RuntimeManifestChecked {
-		return false
-	}
-	// Require coordinator-verified SIP (from attestation challenge) rather
-	// than trusting the provider's self-reported SIPEnabled field.
-	if !p.ChallengeVerifiedSIP {
-		return false
-	}
-	// v0.6.0 APNs code-identity gate — the SINGLE chokepoint, no self-route
-	// exemption (gate everyone). Enforced only once configured AND past the grace
-	// deadline, so the fleet keeps routing through the rollout; fail-closed after.
-	if r.codeAttestationEnforcedLocked() && !p.CodeAttested {
-		return false
-	}
-	caps := p.PrivacyCapabilities
-	if caps == nil {
-		return false
-	}
-	// Only mlx-swift is routable (enforced by privateTextBackendSupported above).
-	// Python-specific caps (PythonRuntimeLocked, DangerousModulesBlocked) are
-	// retained in the protocol struct for wire backward compat but are no longer
-	// required for routing.
-	return caps.TextBackendInprocess &&
-		caps.TextProxyDisabled &&
-		caps.AntiDebugEnabled &&
-		caps.CoreDumpsDisabled &&
-		caps.EnvScrubbed
+	return r.providerPrivateTextBlockerLocked(p) == ""
 }
 
 func privateTextBackendSupported(backend string) bool {
@@ -4319,14 +4290,17 @@ func (r *Registry) ListModels() []AggregateModel {
 	// offering the same model ID should be counted together regardless of
 	// minor metadata differences.
 	agg := make(map[string]*modelAgg)
+	now := time.Now()
 	for _, p := range r.providers {
 		p.mu.Lock()
-		status := p.Status
 		trust := p.TrustLevel
 		attested := p.Attested
 		attestResult := p.AttestationResult
-		privateReady := r.providerSupportsPrivateTextLocked(p)
-		privateOnly := p.PrivateOnly
+		// The per-provider listing gate (online, not private-only, trust floor,
+		// private-text ready) lives in one place so the operator-facing
+		// "why isn't my machine advertising" diagnostic reports exactly what
+		// this loop decided.
+		listable := r.publicListingBlockerLocked(p, now) == ""
 		// p.Models is replaced copy-on-write by UpdateModelWeightHashes (which
 		// holds only p.mu, not r.mu), so snapshot it here under p.mu rather than
 		// ranging the field after unlock.
@@ -4334,15 +4308,7 @@ func (r *Registry) ListModels() []AggregateModel {
 		copy(models, p.Models)
 		p.mu.Unlock()
 
-		if status == StatusOffline || status == StatusUntrusted {
-			continue
-		}
-		// Private-only providers serve only their owner's self-route traffic, so
-		// they must not appear in or inflate the public /v1/models aggregation.
-		if privateOnly {
-			continue
-		}
-		if !r.trustMeetsMinimum(trust) || !privateReady {
+		if !listable {
 			continue
 		}
 		for _, m := range models {
@@ -4412,13 +4378,13 @@ func (r *Registry) OwnedModels(accountID string) []AggregateModel {
 	defer r.mu.RUnlock()
 	for _, p := range r.providers {
 		p.mu.Lock()
+		// The owner self-route relaxes the trust floor and private-only
+		// admission (an owner may route to their own un-enrolled Mac) but keeps
+		// every privacy-critical gate. That is exactly
+		// providerLivenessGateLocked's TrustNone/allowPrivate configuration, so
+		// use it rather than a second copy that can drift.
 		eligible := p.AccountID == accountID &&
-			p.Status != StatusOffline &&
-			p.Status != StatusUntrusted &&
-			p.RuntimeVerified &&
-			r.providerSupportsPrivateTextLocked(p) &&
-			!p.LastChallengeVerified.IsZero() &&
-			now.Sub(p.LastChallengeVerified) <= challengeFreshnessMaxAge
+			r.providerLivenessGateLocked(p, TrustNone, true, now)
 		if !eligible {
 			p.mu.Unlock()
 			continue

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -4290,7 +4290,6 @@ func (r *Registry) ListModels() []AggregateModel {
 	// offering the same model ID should be counted together regardless of
 	// minor metadata differences.
 	agg := make(map[string]*modelAgg)
-	now := time.Now()
 	for _, p := range r.providers {
 		p.mu.Lock()
 		trust := p.TrustLevel
@@ -4300,7 +4299,7 @@ func (r *Registry) ListModels() []AggregateModel {
 		// private-text ready) lives in one place so the operator-facing
 		// "why isn't my machine advertising" diagnostic reports exactly what
 		// this loop decided.
-		listable := r.publicListingBlockerLocked(p, now) == ""
+		listable := r.publicListingBlockerLocked(p) == ""
 		// p.Models is replaced copy-on-write by UpdateModelWeightHashes (which
 		// holds only p.mu, not r.mu), so snapshot it here under p.mu rather than
 		// ranging the field after unlock.

--- a/coordinator/registry/routing_diagnostics.go
+++ b/coordinator/registry/routing_diagnostics.go
@@ -69,6 +69,7 @@ const (
 	BlockerModelNotInCatalog         RoutingBlocker = "model_not_in_catalog"
 	BlockerModelWeightHashMismatch   RoutingBlocker = "model_weight_hash_mismatch"
 	BlockerModelTemplateRenderBroken RoutingBlocker = "model_template_render_broken"
+	BlockerModelDedicatedBoxOnly     RoutingBlocker = "model_requires_dedicated_box"
 )
 
 // Description is a one-line, content-free explanation with the remediation an
@@ -115,6 +116,8 @@ func (b RoutingBlocker) Description() string {
 		return "this model's weight hash does not match the catalog entry; re-download the model"
 	case BlockerModelTemplateRenderBroken:
 		return "this model's chat template failed the provider's render self-check"
+	case BlockerModelDedicatedBoxOnly:
+		return "this model only routes to machines dedicated to it; this machine also serves other model families"
 	default:
 		return string(b)
 	}
@@ -127,6 +130,10 @@ type ModelRoutingDiagnostics struct {
 	// PubliclyListed reports whether this model contributes to the public
 	// /v1/models aggregation from this provider.
 	PubliclyListed bool `json:"publicly_listed"`
+	// Routable reports whether public traffic can actually be dispatched to
+	// this build. Stricter than PubliclyListed: the catalog aggregation does
+	// not apply the template-render or dedicated-box gates that dispatch does.
+	Routable bool `json:"routable"`
 	// OwnerRoutable reports whether the owner's self-route can reach it.
 	OwnerRoutable bool             `json:"owner_routable"`
 	Blockers      []RoutingBlocker `json:"blockers,omitempty"`
@@ -187,7 +194,7 @@ func (r *Registry) routingDiagnosticsLocked(p *Provider, now time.Time) *Provide
 	//   listing  — what ListModels counts into the public catalog
 	//   dispatch — what public traffic must pass to actually land here
 	//   owner    — the owner's self-route (relaxed trust, privacy intact)
-	listingBlocker := r.publicListingBlockerLocked(p, now)
+	listingBlocker := r.publicListingBlockerLocked(p)
 	dispatchBlocker := r.providerLivenessBlockerLocked(p, r.MinTrustLevel, false, now)
 	ownerBlocker := r.providerLivenessBlockerLocked(p, TrustNone, true, now)
 	// Dispatch first: it is the stricter gate and the actionable one. The
@@ -202,22 +209,32 @@ func (r *Registry) routingDiagnosticsLocked(p *Provider, now time.Time) *Provide
 	}
 
 	diag.Models = make([]ModelRoutingDiagnostics, 0, len(p.Models))
-	publicModels, ownerModels := 0, 0
+	listedModels, routableModels, ownerModels := 0, 0, 0
 	for _, m := range p.Models {
 		if m.ID == "" {
 			continue
 		}
 		md := ModelRoutingDiagnostics{ID: m.ID}
-		md.Blockers = r.modelBlockersLocked(m)
-		// Public listing applies the catalog gate but NOT the template-render
-		// gate (ListModels intentionally leaves render-broken builds visible
-		// in the aggregate); the owner list applies both.
+		md.Blockers = r.modelBlockersLocked(p, m)
+		// Three gates over the same build, because the coordinator applies
+		// three. The public catalog checks only the catalog; DISPATCH also
+		// fences a render-broken build (every request shape —
+		// providerEligibleForTraitsLocked) and a build a dedicated-box rule
+		// reserves for machines that serve nothing else; the owner path takes
+		// the catalog exemption for local builds but keeps the render gate.
 		md.PubliclyListed = listingBlocker == "" && r.modelAllowedByCatalogLocked(m)
+		md.Routable = md.PubliclyListed &&
+			dispatchBlocker == "" &&
+			!templateRenderBroken(m) &&
+			!r.providerExcludedByDedicatedRuleLocked(p, m.ID)
 		md.OwnerRoutable = ownerBlocker == "" &&
 			r.modelServableForOwnerLocked(m) &&
 			!templateRenderBroken(m)
 		if md.PubliclyListed {
-			publicModels++
+			listedModels++
+		}
+		if md.Routable {
+			routableModels++
 		}
 		if md.OwnerRoutable {
 			ownerModels++
@@ -226,10 +243,15 @@ func (r *Registry) routingDiagnosticsLocked(p *Provider, now time.Time) *Provide
 	}
 	sort.Slice(diag.Models, func(i, j int) bool { return diag.Models[i].ID < diag.Models[j].ID })
 
-	diag.Advertising = listingBlocker == "" && publicModels > 0
-	diag.Routable = dispatchBlocker == "" && publicModels > 0
+	diag.Advertising = listingBlocker == "" && listedModels > 0
+	diag.Routable = dispatchBlocker == "" && routableModels > 0
 	diag.OwnerRoutable = ownerModels > 0
-	if len(diag.Blockers) == 0 && publicModels == 0 {
+	// "Every build was excluded" is a distinct, separately-actionable fact
+	// from "the machine itself is fenced" — report it whenever the machine
+	// itself is not the reason the catalog is empty, even if a dispatch gate
+	// is ALSO failing. Otherwise an operator clears the machine-level blocker
+	// and lands right back on an empty catalog.
+	if listingBlocker == "" && listedModels == 0 {
 		diag.Blockers = append(diag.Blockers, BlockerNoRoutableModels)
 	}
 	return diag
@@ -250,7 +272,7 @@ func appendBlocker(blockers []RoutingBlocker, b RoutingBlocker) []RoutingBlocker
 
 // modelBlockersLocked lists the per-model exclusions for a build the provider
 // registered. Caller holds r.mu and p.mu.
-func (r *Registry) modelBlockersLocked(m protocol.ModelInfo) []RoutingBlocker {
+func (r *Registry) modelBlockersLocked(p *Provider, m protocol.ModelInfo) []RoutingBlocker {
 	var blockers []RoutingBlocker
 	if r.modelCatalog != nil {
 		entry, tracked := r.modelCatalog[m.ID]
@@ -263,6 +285,12 @@ func (r *Registry) modelBlockersLocked(m protocol.ModelInfo) []RoutingBlocker {
 	}
 	if templateRenderBroken(m) {
 		blockers = append(blockers, BlockerModelTemplateRenderBroken)
+	}
+	// Dedicated-box isolation is on by default in production for the
+	// gemma-4 family, so "why does my mixed box get no gemma-4 traffic" is a
+	// question this has to answer or it answers nothing.
+	if r.providerExcludedByDedicatedRuleLocked(p, m.ID) {
+		blockers = append(blockers, BlockerModelDedicatedBoxOnly)
 	}
 	return blockers
 }
@@ -279,9 +307,9 @@ func templateRenderBroken(m protocol.ModelInfo) bool {
 //
 // It deliberately omits the runtime-verified and challenge-freshness checks of
 // the full liveness gate: the public catalog answers "who could serve this
-// model", while dispatch re-applies the stricter gate per request. Caller
-// holds r.mu and p.mu.
-func (r *Registry) publicListingBlockerLocked(p *Provider, now time.Time) RoutingBlocker {
+// model", while dispatch re-applies the stricter gate per request. That is why
+// it takes no clock. Caller holds r.mu and p.mu.
+func (r *Registry) publicListingBlockerLocked(p *Provider) RoutingBlocker {
 	if blocker := statusBlocker(p); blocker != "" {
 		return blocker
 	}
@@ -312,7 +340,11 @@ func (r *Registry) providerLivenessBlockerLocked(
 	if p.PrivateOnly && !allowPrivate {
 		return BlockerPrivateOnly
 	}
-	if trustRank(p.TrustLevel) < trustRank(minTrust) {
+	// `trustRank` returns -1 for an unrecognised level, and a restored store
+	// row can carry one (`RestoreProviderState` assigns the persisted string
+	// verbatim). Clamping the FLOOR at 0 keeps a caller that asked for no
+	// trust requirement — the owner self-route — from silently acquiring one.
+	if trustRank(p.TrustLevel) < max(trustRank(minTrust), 0) {
 		return BlockerTrustBelowMinimum
 	}
 	if !p.RuntimeVerified {

--- a/coordinator/registry/routing_diagnostics.go
+++ b/coordinator/registry/routing_diagnostics.go
@@ -1,0 +1,388 @@
+package registry
+
+import (
+	"sort"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+)
+
+// routing_diagnostics.go answers one operator question the coordinator could
+// previously only answer to itself: "my machine says online, hardware-trusted,
+// challenges passing, model warm, doctor all green — why is it serving
+// nothing?"
+//
+// Whether a connected provider advertises is the conjunction of roughly a
+// dozen independent gates spread across the liveness core
+// (`providerLivenessGateLocked`), the private-text chokepoint
+// (`providerSupportsPrivateTextLocked`), the public listing filter
+// (`ListModels`), and the per-model catalog / template gates. Exactly ONE of
+// them — the runtime hash — reaches the operator, as a banner. The rest fail
+// silently, so a fenced machine looks identical to a healthy one from the
+// outside, and "88 connected / 85 advertising" has no drill-down.
+//
+// The fix is not a parallel re-implementation of those gates (that would drift
+// the first time someone edited one of them). Each gate here is the SINGLE
+// implementation, returning the reason it refused; the boolean predicates the
+// router actually calls are one-line delegates that ask whether the reason is
+// empty. A diagnostic and a routing decision cannot disagree because they are
+// the same code.
+
+// ChallengeFreshnessMaxAge is how stale a provider's last PASSING attestation
+// challenge may be before routing fences it. Challenges run every 5 minutes,
+// so this tolerates two consecutive misses. Exported because the owner
+// dashboard renders "N of M minutes" against it and must not hardcode a second
+// copy of the number.
+const ChallengeFreshnessMaxAge = 16 * time.Minute
+
+// RoutingBlocker is a closed, operator-facing reason a provider or one of its
+// models is excluded from routing. Values are stable wire strings: the console
+// UI and `darkbloom doctor` map them to remediation text, so renaming one is a
+// breaking change.
+type RoutingBlocker string
+
+const (
+	// Liveness core.
+	BlockerOffline           RoutingBlocker = "offline"
+	BlockerUntrusted         RoutingBlocker = "untrusted"
+	BlockerPrivateOnly       RoutingBlocker = "private_only"
+	BlockerTrustBelowMinimum RoutingBlocker = "trust_below_minimum"
+	BlockerRuntimeUnverified RoutingBlocker = "runtime_hash_mismatch"
+	BlockerChallengeNever    RoutingBlocker = "attestation_challenge_never_passed"
+	BlockerChallengeStale    RoutingBlocker = "attestation_challenge_stale"
+
+	// Private-text chokepoint.
+	BlockerNoEncryptionKey          RoutingBlocker = "no_encryption_key"
+	BlockerUnsupportedBackend       RoutingBlocker = "unsupported_backend"
+	BlockerUnencryptedChunks        RoutingBlocker = "unencrypted_response_chunks"
+	BlockerRuntimeManifestUnchecked RoutingBlocker = "runtime_manifest_unchecked"
+	BlockerSIPUnverified            RoutingBlocker = "sip_unverified"
+	BlockerCodeAttestationMissing   RoutingBlocker = "code_attestation_missing"
+	BlockerPrivacyCapsMissing       RoutingBlocker = "privacy_capabilities_missing"
+	BlockerPrivacyCapsIncomplete    RoutingBlocker = "privacy_capabilities_incomplete"
+
+	// Inventory.
+	BlockerNoModelsRegistered RoutingBlocker = "no_models_registered"
+	BlockerNoRoutableModels   RoutingBlocker = "no_routable_models"
+
+	// Per-model.
+	BlockerModelNotInCatalog         RoutingBlocker = "model_not_in_catalog"
+	BlockerModelWeightHashMismatch   RoutingBlocker = "model_weight_hash_mismatch"
+	BlockerModelTemplateRenderBroken RoutingBlocker = "model_template_render_broken"
+)
+
+// Description is a one-line, content-free explanation with the remediation an
+// operator can act on. Never embeds request data — only fixed text.
+func (b RoutingBlocker) Description() string {
+	switch b {
+	case BlockerOffline:
+		return "the machine is not connected to the coordinator"
+	case BlockerUntrusted:
+		return "the machine was marked untrusted by attestation and is excluded from routing"
+	case BlockerPrivateOnly:
+		return "the machine is in private-only mode, so it serves only its owner's self-route traffic"
+	case BlockerTrustBelowMinimum:
+		return "the machine's trust level is below this network's minimum; complete MDM enrollment"
+	case BlockerRuntimeUnverified:
+		return "the machine's runtime hashes do not match any registered release; reinstall from the official installer"
+	case BlockerChallengeNever:
+		return "the machine has not yet passed an attestation challenge"
+	case BlockerChallengeStale:
+		return "the machine's last passing attestation challenge is older than the freshness window"
+	case BlockerNoEncryptionKey:
+		return "the machine has not published an end-to-end encryption public key"
+	case BlockerUnsupportedBackend:
+		return "the machine reports an inference backend that is no longer routable"
+	case BlockerUnencryptedChunks:
+		return "the machine does not encrypt streamed response chunks"
+	case BlockerRuntimeManifestUnchecked:
+		return "the coordinator has not verified this machine's runtime against a release manifest"
+	case BlockerSIPUnverified:
+		return "System Integrity Protection was not confirmed by the last attestation challenge"
+	case BlockerCodeAttestationMissing:
+		return "the machine has not completed code-identity attestation"
+	case BlockerPrivacyCapsMissing:
+		return "the machine did not report its privacy capabilities"
+	case BlockerPrivacyCapsIncomplete:
+		return "one or more required privacy capabilities are disabled on the machine"
+	case BlockerNoModelsRegistered:
+		return "the machine registered no models; check enabled_models and that the weights finished downloading"
+	case BlockerNoRoutableModels:
+		return "every model the machine registered was excluded — see the per-model reasons"
+	case BlockerModelNotInCatalog:
+		return "this model is not in the coordinator's published catalog"
+	case BlockerModelWeightHashMismatch:
+		return "this model's weight hash does not match the catalog entry; re-download the model"
+	case BlockerModelTemplateRenderBroken:
+		return "this model's chat template failed the provider's render self-check"
+	default:
+		return string(b)
+	}
+}
+
+// ModelRoutingDiagnostics is the routing verdict for one model a provider
+// registered.
+type ModelRoutingDiagnostics struct {
+	ID string `json:"id"`
+	// PubliclyListed reports whether this model contributes to the public
+	// /v1/models aggregation from this provider.
+	PubliclyListed bool `json:"publicly_listed"`
+	// OwnerRoutable reports whether the owner's self-route can reach it.
+	OwnerRoutable bool             `json:"owner_routable"`
+	Blockers      []RoutingBlocker `json:"blockers,omitempty"`
+}
+
+// ProviderRoutingDiagnostics is the coordinator's own answer to "is this
+// machine serving, and if not, why not".
+//
+// Advertising and Routable are deliberately separate, because the coordinator
+// really does treat them separately: the public catalog answers "who could
+// serve this model" and omits the runtime-hash and challenge-freshness gates,
+// while dispatch applies them per request. A machine can therefore be counted
+// as advertising and still receive nothing — which is precisely the state that
+// reads as healthy from every existing surface.
+type ProviderRoutingDiagnostics struct {
+	// Advertising is true when the machine currently contributes at least one
+	// model to the public /v1/models aggregation. This is the "advertising"
+	// half of the network page's connected/advertising counts.
+	Advertising bool `json:"advertising"`
+	// Routable is true when public traffic can actually be dispatched to the
+	// machine: the full liveness gate plus at least one catalog-allowed model.
+	// Routable implies Advertising; the reverse does not hold.
+	Routable bool `json:"routable"`
+	// OwnerRoutable is true when the owner's own self-route requests can reach
+	// the machine for at least one model.
+	OwnerRoutable bool `json:"owner_routable"`
+	// Blockers are the machine-level reasons traffic is not reaching it, in
+	// the order the router evaluates them. Empty when routable.
+	Blockers []RoutingBlocker          `json:"blockers,omitempty"`
+	Models   []ModelRoutingDiagnostics `json:"models,omitempty"`
+	// ChallengeMaxAgeSeconds is the freshness window behind
+	// BlockerChallengeStale, so a client can render "N of M minutes".
+	ChallengeMaxAgeSeconds int `json:"challenge_max_age_seconds"`
+}
+
+// RoutingDiagnostics returns the coordinator's routing verdict for one live
+// provider, or nil when the id is not connected. Safe to call from HTTP
+// handlers; takes r.mu and p.mu internally.
+func (r *Registry) RoutingDiagnostics(providerID string, now time.Time) *ProviderRoutingDiagnostics {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	p, ok := r.providers[providerID]
+	if !ok {
+		return nil
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return r.routingDiagnosticsLocked(p, now)
+}
+
+// routingDiagnosticsLocked builds the verdict. Caller holds r.mu and p.mu.
+func (r *Registry) routingDiagnosticsLocked(p *Provider, now time.Time) *ProviderRoutingDiagnostics {
+	diag := &ProviderRoutingDiagnostics{
+		ChallengeMaxAgeSeconds: int(ChallengeFreshnessMaxAge.Seconds()),
+	}
+
+	// Three verdicts over the same machine, each with its own gate set:
+	//   listing  — what ListModels counts into the public catalog
+	//   dispatch — what public traffic must pass to actually land here
+	//   owner    — the owner's self-route (relaxed trust, privacy intact)
+	listingBlocker := r.publicListingBlockerLocked(p, now)
+	dispatchBlocker := r.providerLivenessBlockerLocked(p, r.MinTrustLevel, false, now)
+	ownerBlocker := r.providerLivenessBlockerLocked(p, TrustNone, true, now)
+	// Dispatch first: it is the stricter gate and the actionable one. The
+	// listing blocker only differs when the two disagree about which gate
+	// failed first, and then it is worth reporting both.
+	diag.Blockers = appendBlocker(diag.Blockers, dispatchBlocker)
+	diag.Blockers = appendBlocker(diag.Blockers, listingBlocker)
+
+	if len(p.Models) == 0 {
+		diag.Blockers = append(diag.Blockers, BlockerNoModelsRegistered)
+		return diag
+	}
+
+	diag.Models = make([]ModelRoutingDiagnostics, 0, len(p.Models))
+	publicModels, ownerModels := 0, 0
+	for _, m := range p.Models {
+		if m.ID == "" {
+			continue
+		}
+		md := ModelRoutingDiagnostics{ID: m.ID}
+		md.Blockers = r.modelBlockersLocked(m)
+		// Public listing applies the catalog gate but NOT the template-render
+		// gate (ListModels intentionally leaves render-broken builds visible
+		// in the aggregate); the owner list applies both.
+		md.PubliclyListed = listingBlocker == "" && r.modelAllowedByCatalogLocked(m)
+		md.OwnerRoutable = ownerBlocker == "" &&
+			r.modelServableForOwnerLocked(m) &&
+			!templateRenderBroken(m)
+		if md.PubliclyListed {
+			publicModels++
+		}
+		if md.OwnerRoutable {
+			ownerModels++
+		}
+		diag.Models = append(diag.Models, md)
+	}
+	sort.Slice(diag.Models, func(i, j int) bool { return diag.Models[i].ID < diag.Models[j].ID })
+
+	diag.Advertising = listingBlocker == "" && publicModels > 0
+	diag.Routable = dispatchBlocker == "" && publicModels > 0
+	diag.OwnerRoutable = ownerModels > 0
+	if len(diag.Blockers) == 0 && publicModels == 0 {
+		diag.Blockers = append(diag.Blockers, BlockerNoRoutableModels)
+	}
+	return diag
+}
+
+// appendBlocker adds a non-empty blocker unless it is already present.
+func appendBlocker(blockers []RoutingBlocker, b RoutingBlocker) []RoutingBlocker {
+	if b == "" {
+		return blockers
+	}
+	for _, existing := range blockers {
+		if existing == b {
+			return blockers
+		}
+	}
+	return append(blockers, b)
+}
+
+// modelBlockersLocked lists the per-model exclusions for a build the provider
+// registered. Caller holds r.mu and p.mu.
+func (r *Registry) modelBlockersLocked(m protocol.ModelInfo) []RoutingBlocker {
+	var blockers []RoutingBlocker
+	if r.modelCatalog != nil {
+		entry, tracked := r.modelCatalog[m.ID]
+		switch {
+		case !tracked:
+			blockers = append(blockers, BlockerModelNotInCatalog)
+		case entry.WeightHash != "" && m.WeightHash != "" && m.WeightHash != entry.WeightHash:
+			blockers = append(blockers, BlockerModelWeightHashMismatch)
+		}
+	}
+	if templateRenderBroken(m) {
+		blockers = append(blockers, BlockerModelTemplateRenderBroken)
+	}
+	return blockers
+}
+
+// templateRenderBroken reports an EXPLICIT render-check failure. A nil field
+// (pre-0.6.5 providers, no opinion) is not a failure — matching dispatch.
+func templateRenderBroken(m protocol.ModelInfo) bool {
+	return m.TemplateRenderOK != nil && !*m.TemplateRenderOK
+}
+
+// publicListingBlockerLocked is the SINGLE implementation of the per-provider
+// gate `ListModels` applies before counting a machine's models into the public
+// aggregation. Returns "" when the machine may contribute.
+//
+// It deliberately omits the runtime-verified and challenge-freshness checks of
+// the full liveness gate: the public catalog answers "who could serve this
+// model", while dispatch re-applies the stricter gate per request. Caller
+// holds r.mu and p.mu.
+func (r *Registry) publicListingBlockerLocked(p *Provider, now time.Time) RoutingBlocker {
+	if blocker := statusBlocker(p); blocker != "" {
+		return blocker
+	}
+	// Private-only machines serve only their owner's self-route traffic, so
+	// they must not appear in or inflate the public aggregation.
+	if p.PrivateOnly {
+		return BlockerPrivateOnly
+	}
+	if !r.trustMeetsMinimum(p.TrustLevel) {
+		return BlockerTrustBelowMinimum
+	}
+	return r.providerPrivateTextBlockerLocked(p)
+}
+
+// providerLivenessBlockerLocked is the SINGLE implementation of the
+// liveness/trust/privacy core shared by every provider-eligibility decision
+// (see routing_eligibility.go for the callers and the ordering rationale). It
+// returns the first gate that refused, or "" when the provider passes.
+//
+// minTrust is the trust floor to enforce; allowPrivate admits an otherwise
+// private-only machine. Caller holds r.mu and p.mu.
+func (r *Registry) providerLivenessBlockerLocked(
+	p *Provider, minTrust TrustLevel, allowPrivate bool, now time.Time,
+) RoutingBlocker {
+	if blocker := statusBlocker(p); blocker != "" {
+		return blocker
+	}
+	if p.PrivateOnly && !allowPrivate {
+		return BlockerPrivateOnly
+	}
+	if trustRank(p.TrustLevel) < trustRank(minTrust) {
+		return BlockerTrustBelowMinimum
+	}
+	if !p.RuntimeVerified {
+		return BlockerRuntimeUnverified
+	}
+	if blocker := r.providerPrivateTextBlockerLocked(p); blocker != "" {
+		return blocker
+	}
+	if p.LastChallengeVerified.IsZero() {
+		return BlockerChallengeNever
+	}
+	if now.Sub(p.LastChallengeVerified) > ChallengeFreshnessMaxAge {
+		return BlockerChallengeStale
+	}
+	return ""
+}
+
+// providerPrivateTextBlockerLocked is the SINGLE implementation of the
+// private/text routing chokepoint. It is a method on *Registry (not a free
+// function) so the APNs code-identity gate can consult the live rollout policy
+// (codeAttestationEnforcedLocked) rather than a value stamped at registration
+// — that is what lets the grace→enforce deadline flip without a reconnect.
+// Caller holds r.mu and p.mu.
+func (r *Registry) providerPrivateTextBlockerLocked(p *Provider) RoutingBlocker {
+	if p.PublicKey == "" {
+		return BlockerNoEncryptionKey
+	}
+	if !privateTextBackendSupported(p.Backend) {
+		return BlockerUnsupportedBackend
+	}
+	if !p.EncryptedResponseChunks {
+		return BlockerUnencryptedChunks
+	}
+	if !p.RuntimeManifestChecked {
+		return BlockerRuntimeManifestUnchecked
+	}
+	// Require coordinator-verified SIP (from the attestation challenge) rather
+	// than trusting the provider's self-reported SIPEnabled field.
+	if !p.ChallengeVerifiedSIP {
+		return BlockerSIPUnverified
+	}
+	// v0.6.0 APNs code-identity gate — the SINGLE chokepoint, no self-route
+	// exemption (gate everyone). Enforced only once configured AND past the
+	// grace deadline, so the fleet keeps routing through the rollout;
+	// fail-closed after.
+	if r.codeAttestationEnforcedLocked() && !p.CodeAttested {
+		return BlockerCodeAttestationMissing
+	}
+	caps := p.PrivacyCapabilities
+	if caps == nil {
+		return BlockerPrivacyCapsMissing
+	}
+	// Only mlx-swift is routable (enforced by privateTextBackendSupported
+	// above). Python-specific caps (PythonRuntimeLocked,
+	// DangerousModulesBlocked) are retained in the protocol struct for wire
+	// backward compat but are no longer required for routing.
+	if !caps.TextBackendInprocess || !caps.TextProxyDisabled ||
+		!caps.AntiDebugEnabled || !caps.CoreDumpsDisabled || !caps.EnvScrubbed {
+		return BlockerPrivacyCapsIncomplete
+	}
+	return ""
+}
+
+func statusBlocker(p *Provider) RoutingBlocker {
+	switch p.Status {
+	case StatusOffline:
+		return BlockerOffline
+	case StatusUntrusted:
+		return BlockerUntrusted
+	default:
+		return ""
+	}
+}

--- a/coordinator/registry/routing_diagnostics_test.go
+++ b/coordinator/registry/routing_diagnostics_test.go
@@ -1,0 +1,360 @@
+package registry
+
+import (
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+)
+
+// The whole point of routing_diagnostics.go is that the reason a machine is
+// fenced and the decision to fence it are the SAME code. These tests hold that
+// line: the first suite proves the boolean predicates and the blocker
+// functions cannot disagree under any single-gate mutation, and the second
+// proves the reported verdict matches what `ListModels` / `OwnedModels`
+// actually did.
+
+// routableProvider registers a provider that passes every gate.
+func routableProvider(t *testing.T, r *Registry, id, model string) *Provider {
+	t.Helper()
+	msg := testRegisterMessage()
+	msg.Models = []protocol.ModelInfo{{ID: model, ModelType: "chat", Quantization: "4bit"}}
+	p := r.Register(id, nil, msg)
+	p.mu.Lock()
+	p.AccountID = "acct-1"
+	p.TrustLevel = TrustHardware
+	p.RuntimeVerified = true
+	p.RuntimeManifestChecked = true
+	p.ChallengeVerifiedSIP = true
+	p.LastChallengeVerified = time.Now()
+	p.mu.Unlock()
+	return p
+}
+
+// gateMutation breaks exactly one gate on an otherwise-routable provider.
+type gateMutation struct {
+	name    string
+	apply   func(p *Provider)
+	blocker RoutingBlocker
+}
+
+func singleGateMutations() []gateMutation {
+	return []gateMutation{
+		{"none", func(p *Provider) {}, ""},
+		{"offline", func(p *Provider) { p.Status = StatusOffline }, BlockerOffline},
+		{"untrusted", func(p *Provider) { p.Status = StatusUntrusted }, BlockerUntrusted},
+		{"private_only", func(p *Provider) { p.PrivateOnly = true }, BlockerPrivateOnly},
+		{"trust_none", func(p *Provider) { p.TrustLevel = TrustNone }, BlockerTrustBelowMinimum},
+		{"runtime_unverified", func(p *Provider) { p.RuntimeVerified = false }, BlockerRuntimeUnverified},
+		{"no_public_key", func(p *Provider) { p.PublicKey = "" }, BlockerNoEncryptionKey},
+		{"bad_backend", func(p *Provider) { p.Backend = "python-mlx" }, BlockerUnsupportedBackend},
+		{"plaintext_chunks", func(p *Provider) { p.EncryptedResponseChunks = false }, BlockerUnencryptedChunks},
+		{"manifest_unchecked", func(p *Provider) { p.RuntimeManifestChecked = false }, BlockerRuntimeManifestUnchecked},
+		{"sip_unverified", func(p *Provider) { p.ChallengeVerifiedSIP = false }, BlockerSIPUnverified},
+		{"caps_missing", func(p *Provider) { p.PrivacyCapabilities = nil }, BlockerPrivacyCapsMissing},
+		{"caps_incomplete", func(p *Provider) { p.PrivacyCapabilities.AntiDebugEnabled = false }, BlockerPrivacyCapsIncomplete},
+		{"challenge_never", func(p *Provider) { p.LastChallengeVerified = time.Time{} }, BlockerChallengeNever},
+		{"challenge_stale", func(p *Provider) {
+			p.LastChallengeVerified = time.Now().Add(-ChallengeFreshnessMaxAge - time.Minute)
+		}, BlockerChallengeStale},
+	}
+}
+
+func TestLivenessBlockerMatchesLivenessGate(t *testing.T) {
+	for _, mutation := range singleGateMutations() {
+		t.Run(mutation.name, func(t *testing.T) {
+			r := New(testLogger())
+			r.MinTrustLevel = TrustHardware
+			p := routableProvider(t, r, "p1", gemmaBuild)
+
+			p.mu.Lock()
+			mutation.apply(p)
+			p.mu.Unlock()
+
+			now := time.Now()
+			r.mu.RLock()
+			p.mu.Lock()
+			blocker := r.providerLivenessBlockerLocked(p, r.MinTrustLevel, false, now)
+			gate := r.providerLivenessGateLocked(p, r.MinTrustLevel, false, now)
+			p.mu.Unlock()
+			r.mu.RUnlock()
+
+			if blocker != mutation.blocker {
+				t.Fatalf("blocker = %q, want %q", blocker, mutation.blocker)
+			}
+			// The invariant that makes the diagnostic trustworthy.
+			if gate != (blocker == "") {
+				t.Fatalf("gate = %v but blocker = %q — the diagnostic and the router disagree", gate, blocker)
+			}
+		})
+	}
+}
+
+func TestPrivateTextBlockerMatchesPrivateTextPredicate(t *testing.T) {
+	for _, mutation := range singleGateMutations() {
+		t.Run(mutation.name, func(t *testing.T) {
+			r := New(testLogger())
+			r.MinTrustLevel = TrustHardware
+			p := routableProvider(t, r, "p1", gemmaBuild)
+
+			p.mu.Lock()
+			mutation.apply(p)
+			p.mu.Unlock()
+
+			r.mu.RLock()
+			p.mu.Lock()
+			blocker := r.providerPrivateTextBlockerLocked(p)
+			supported := r.providerSupportsPrivateTextLocked(p)
+			p.mu.Unlock()
+			r.mu.RUnlock()
+
+			if supported != (blocker == "") {
+				t.Fatalf("providerSupportsPrivateTextLocked = %v but blocker = %q", supported, blocker)
+			}
+		})
+	}
+}
+
+// TestAdvertisingMatchesListModels is the assertion an operator actually cares
+// about: whatever the diagnostic says must be what the coordinator did. It
+// pins BOTH verdicts against their real implementations — `Advertising`
+// against `ListModels`, `Routable` against the production reservation path —
+// so a future edit to either gate that forgets the diagnostic fails here.
+func TestAdvertisingMatchesListModels(t *testing.T) {
+	for _, mutation := range singleGateMutations() {
+		t.Run(mutation.name, func(t *testing.T) {
+			r := New(testLogger())
+			r.MinTrustLevel = TrustHardware
+			p := routableProvider(t, r, "p1", gemmaBuild)
+
+			p.mu.Lock()
+			mutation.apply(p)
+			p.mu.Unlock()
+
+			listed := false
+			for _, m := range r.ListModels() {
+				if m.ID == gemmaBuild && m.Providers > 0 {
+					listed = true
+				}
+			}
+			diag := r.RoutingDiagnostics("p1", time.Now())
+			if diag == nil {
+				t.Fatal("RoutingDiagnostics returned nil for a connected provider")
+			}
+			if diag.Advertising != listed {
+				t.Fatalf("Advertising = %v but ListModels listed = %v (blockers %v)",
+					diag.Advertising, listed, diag.Blockers)
+			}
+			// Routable is the strictly stronger claim.
+			if diag.Routable && !diag.Advertising {
+				t.Fatalf("Routable without Advertising (blockers %v)", diag.Blockers)
+			}
+			// Whatever we claim is unroutable must actually be unroutable on
+			// the production reservation path.
+			reserved := findRoutableProvider(r, gemmaBuild) != nil
+			if !diag.Routable && reserved {
+				t.Fatalf("reported unroutable (%v) but ReserveProviderEx selected it", diag.Blockers)
+			}
+			if mutation.name == "none" && !reserved {
+				t.Fatal("a fully-healthy provider must be reservable")
+			}
+			if !diag.Routable && len(diag.Blockers) == 0 {
+				t.Fatal("unroutable provider reported no reason")
+			}
+			if diag.Routable && len(diag.Blockers) != 0 {
+				t.Fatalf("routable provider reported blockers %v", diag.Blockers)
+			}
+		})
+	}
+}
+
+func TestOwnerRoutableMatchesOwnedModels(t *testing.T) {
+	for _, mutation := range singleGateMutations() {
+		t.Run(mutation.name, func(t *testing.T) {
+			r := New(testLogger())
+			r.MinTrustLevel = TrustHardware
+			p := routableProvider(t, r, "p1", gemmaBuild)
+
+			p.mu.Lock()
+			mutation.apply(p)
+			p.mu.Unlock()
+
+			owned := false
+			for _, m := range r.OwnedModels("acct-1") {
+				if m.ID == gemmaBuild {
+					owned = true
+				}
+			}
+			diag := r.RoutingDiagnostics("p1", time.Now())
+			if diag.OwnerRoutable != owned {
+				t.Fatalf("OwnerRoutable = %v but OwnedModels listed = %v (blockers %v)",
+					diag.OwnerRoutable, owned, diag.Blockers)
+			}
+		})
+	}
+}
+
+// A machine that passes every machine-level gate but registered nothing is the
+// exact "green dashboard, empty catalog" shape operators report.
+func TestNoModelsRegisteredIsReported(t *testing.T) {
+	r := New(testLogger())
+	r.MinTrustLevel = TrustHardware
+	p := routableProvider(t, r, "p1", gemmaBuild)
+	p.mu.Lock()
+	p.Models = nil
+	p.mu.Unlock()
+
+	diag := r.RoutingDiagnostics("p1", time.Now())
+	if diag.Advertising || diag.Routable {
+		t.Fatal("a provider with no models must not report as advertising or routable")
+	}
+	if len(diag.Blockers) != 1 || diag.Blockers[0] != BlockerNoModelsRegistered {
+		t.Fatalf("blockers = %v, want [%s]", diag.Blockers, BlockerNoModelsRegistered)
+	}
+}
+
+// The asymmetry that makes this whole file necessary: the public catalog does
+// NOT apply the runtime-hash or challenge-freshness gates, so a fenced machine
+// still shows up in /v1/models. Reporting only "advertising" would tell that
+// operator everything is fine.
+func TestAdvertisingCanBeTrueWhileUnroutable(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		apply   func(p *Provider)
+		blocker RoutingBlocker
+	}{
+		{"runtime unverified", func(p *Provider) { p.RuntimeVerified = false }, BlockerRuntimeUnverified},
+		{"challenge stale", func(p *Provider) {
+			p.LastChallengeVerified = time.Now().Add(-ChallengeFreshnessMaxAge - time.Minute)
+		}, BlockerChallengeStale},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			r := New(testLogger())
+			r.MinTrustLevel = TrustHardware
+			p := routableProvider(t, r, "p1", gemmaBuild)
+			p.mu.Lock()
+			tc.apply(p)
+			p.mu.Unlock()
+
+			diag := r.RoutingDiagnostics("p1", time.Now())
+			if !diag.Advertising {
+				t.Fatal("expected the machine to still be counted in the public catalog")
+			}
+			if diag.Routable {
+				t.Fatal("expected the machine to be unroutable")
+			}
+			if len(diag.Blockers) != 1 || diag.Blockers[0] != tc.blocker {
+				t.Fatalf("blockers = %v, want [%s]", diag.Blockers, tc.blocker)
+			}
+			if findRoutableProvider(r, gemmaBuild) != nil {
+				t.Fatal("the production reservation path selected a fenced provider")
+			}
+		})
+	}
+}
+
+func TestModelBlockersReportCatalogExclusions(t *testing.T) {
+	r := New(testLogger())
+	r.MinTrustLevel = TrustHardware
+	p := routableProvider(t, r, "p1", gemmaBuild)
+
+	renderBroken := false
+	p.mu.Lock()
+	p.Models = []protocol.ModelInfo{
+		{ID: gemmaBuild, WeightHash: "goodhash"},
+		{ID: qwenBuild, WeightHash: "wronghash"},
+		{ID: gemmaBuildSmol, WeightHash: "smolhash", TemplateRenderOK: &renderBroken},
+		{ID: "some-unpublished-build"},
+	}
+	p.mu.Unlock()
+	r.SetModelCatalog([]CatalogEntry{
+		{ID: gemmaBuild, WeightHash: "goodhash"},
+		{ID: qwenBuild, WeightHash: "righthash"},
+		{ID: gemmaBuildSmol, WeightHash: "smolhash"},
+	})
+
+	diag := r.RoutingDiagnostics("p1", time.Now())
+	byID := make(map[string]ModelRoutingDiagnostics, len(diag.Models))
+	for _, m := range diag.Models {
+		byID[m.ID] = m
+	}
+
+	if got := byID[gemmaBuild]; !got.PubliclyListed || !got.OwnerRoutable || len(got.Blockers) != 0 {
+		t.Fatalf("healthy build reported %+v", got)
+	}
+	if got := byID[qwenBuild]; got.PubliclyListed ||
+		len(got.Blockers) != 1 || got.Blockers[0] != BlockerModelWeightHashMismatch {
+		t.Fatalf("stale-hash build reported %+v", got)
+	}
+	if got := byID[gemmaBuildSmol]; got.OwnerRoutable ||
+		len(got.Blockers) != 1 || got.Blockers[0] != BlockerModelTemplateRenderBroken {
+		t.Fatalf("render-broken build reported %+v", got)
+	}
+	if got := byID["some-unpublished-build"]; got.PubliclyListed ||
+		len(got.Blockers) != 1 || got.Blockers[0] != BlockerModelNotInCatalog {
+		t.Fatalf("off-catalog build reported %+v", got)
+	}
+	// The machine still advertises, because one build survived.
+	if !diag.Advertising {
+		t.Fatalf("machine with one healthy build must advertise (blockers %v)", diag.Blockers)
+	}
+}
+
+// Every model excluded is a distinct shape from no models at all: the machine
+// registered inventory, so the reason lives on the per-model rows.
+func TestEveryModelExcludedReportsNoRoutableModels(t *testing.T) {
+	r := New(testLogger())
+	r.MinTrustLevel = TrustHardware
+	p := routableProvider(t, r, "p1", gemmaBuild)
+	p.mu.Lock()
+	p.Models = []protocol.ModelInfo{{ID: "unpublished-a"}, {ID: "unpublished-b"}}
+	p.mu.Unlock()
+	r.SetModelCatalog([]CatalogEntry{{ID: gemmaBuild}})
+
+	diag := r.RoutingDiagnostics("p1", time.Now())
+	if diag.Advertising || diag.Routable {
+		t.Fatal("no catalog-allowed build must not advertise or be routable")
+	}
+	if len(diag.Blockers) != 1 || diag.Blockers[0] != BlockerNoRoutableModels {
+		t.Fatalf("blockers = %v, want [%s]", diag.Blockers, BlockerNoRoutableModels)
+	}
+	if len(diag.Models) != 2 {
+		t.Fatalf("expected per-model rows for both builds, got %d", len(diag.Models))
+	}
+}
+
+func TestRoutingDiagnosticsUnknownProvider(t *testing.T) {
+	r := New(testLogger())
+	if diag := r.RoutingDiagnostics("nope", time.Now()); diag != nil {
+		t.Fatalf("expected nil for an unknown provider, got %+v", diag)
+	}
+}
+
+func TestEveryBlockerHasRemediationText(t *testing.T) {
+	all := []RoutingBlocker{
+		BlockerOffline, BlockerUntrusted, BlockerPrivateOnly, BlockerTrustBelowMinimum,
+		BlockerRuntimeUnverified, BlockerChallengeNever, BlockerChallengeStale,
+		BlockerNoEncryptionKey, BlockerUnsupportedBackend, BlockerUnencryptedChunks,
+		BlockerRuntimeManifestUnchecked, BlockerSIPUnverified, BlockerCodeAttestationMissing,
+		BlockerPrivacyCapsMissing, BlockerPrivacyCapsIncomplete,
+		BlockerNoModelsRegistered, BlockerNoRoutableModels,
+		BlockerModelNotInCatalog, BlockerModelWeightHashMismatch,
+		BlockerModelTemplateRenderBroken,
+	}
+	for _, b := range all {
+		if got := b.Description(); got == "" || got == string(b) {
+			t.Fatalf("blocker %q has no operator-facing description", b)
+		}
+	}
+}
+
+func TestChallengeFreshnessWindowIsReported(t *testing.T) {
+	r := New(testLogger())
+	r.MinTrustLevel = TrustHardware
+	routableProvider(t, r, "p1", gemmaBuild)
+	diag := r.RoutingDiagnostics("p1", time.Now())
+	if diag.ChallengeMaxAgeSeconds != int(ChallengeFreshnessMaxAge.Seconds()) {
+		t.Fatalf("ChallengeMaxAgeSeconds = %d, want %d",
+			diag.ChallengeMaxAgeSeconds, int(ChallengeFreshnessMaxAge.Seconds()))
+	}
+}

--- a/coordinator/registry/routing_diagnostics_test.go
+++ b/coordinator/registry/routing_diagnostics_test.go
@@ -32,31 +32,48 @@ func routableProvider(t *testing.T, r *Registry, id, model string) *Provider {
 }
 
 // gateMutation breaks exactly one gate on an otherwise-routable provider.
+// `arm` handles gates that live on registry policy rather than provider state.
 type gateMutation struct {
 	name    string
 	apply   func(p *Provider)
 	blocker RoutingBlocker
+	arm     func(r *Registry)
 }
 
 func singleGateMutations() []gateMutation {
 	return []gateMutation{
-		{"none", func(p *Provider) {}, ""},
-		{"offline", func(p *Provider) { p.Status = StatusOffline }, BlockerOffline},
-		{"untrusted", func(p *Provider) { p.Status = StatusUntrusted }, BlockerUntrusted},
-		{"private_only", func(p *Provider) { p.PrivateOnly = true }, BlockerPrivateOnly},
-		{"trust_none", func(p *Provider) { p.TrustLevel = TrustNone }, BlockerTrustBelowMinimum},
-		{"runtime_unverified", func(p *Provider) { p.RuntimeVerified = false }, BlockerRuntimeUnverified},
-		{"no_public_key", func(p *Provider) { p.PublicKey = "" }, BlockerNoEncryptionKey},
-		{"bad_backend", func(p *Provider) { p.Backend = "python-mlx" }, BlockerUnsupportedBackend},
-		{"plaintext_chunks", func(p *Provider) { p.EncryptedResponseChunks = false }, BlockerUnencryptedChunks},
-		{"manifest_unchecked", func(p *Provider) { p.RuntimeManifestChecked = false }, BlockerRuntimeManifestUnchecked},
-		{"sip_unverified", func(p *Provider) { p.ChallengeVerifiedSIP = false }, BlockerSIPUnverified},
-		{"caps_missing", func(p *Provider) { p.PrivacyCapabilities = nil }, BlockerPrivacyCapsMissing},
-		{"caps_incomplete", func(p *Provider) { p.PrivacyCapabilities.AntiDebugEnabled = false }, BlockerPrivacyCapsIncomplete},
-		{"challenge_never", func(p *Provider) { p.LastChallengeVerified = time.Time{} }, BlockerChallengeNever},
+		{"none", func(p *Provider) {}, "", nil},
+		{"offline", func(p *Provider) { p.Status = StatusOffline }, BlockerOffline, nil},
+		{"untrusted", func(p *Provider) { p.Status = StatusUntrusted }, BlockerUntrusted, nil},
+		{"private_only", func(p *Provider) { p.PrivateOnly = true }, BlockerPrivateOnly, nil},
+		{"trust_none", func(p *Provider) { p.TrustLevel = TrustNone }, BlockerTrustBelowMinimum, nil},
+		{"runtime_unverified", func(p *Provider) { p.RuntimeVerified = false }, BlockerRuntimeUnverified, nil},
+		{"no_public_key", func(p *Provider) { p.PublicKey = "" }, BlockerNoEncryptionKey, nil},
+		{"bad_backend", func(p *Provider) { p.Backend = "python-mlx" }, BlockerUnsupportedBackend, nil},
+		{"plaintext_chunks", func(p *Provider) { p.EncryptedResponseChunks = false }, BlockerUnencryptedChunks, nil},
+		{"manifest_unchecked", func(p *Provider) { p.RuntimeManifestChecked = false }, BlockerRuntimeManifestUnchecked, nil},
+		{"sip_unverified", func(p *Provider) { p.ChallengeVerifiedSIP = false }, BlockerSIPUnverified, nil},
+		{"caps_missing", func(p *Provider) { p.PrivacyCapabilities = nil }, BlockerPrivacyCapsMissing, nil},
+		{"caps_incomplete", func(p *Provider) { p.PrivacyCapabilities.AntiDebugEnabled = false }, BlockerPrivacyCapsIncomplete, nil},
+		{"challenge_never", func(p *Provider) { p.LastChallengeVerified = time.Time{} }, BlockerChallengeNever, nil},
 		{"challenge_stale", func(p *Provider) {
 			p.LastChallengeVerified = time.Now().Add(-ChallengeFreshnessMaxAge - time.Minute)
-		}, BlockerChallengeStale},
+		}, BlockerChallengeStale, nil},
+		{
+			name:    "code_attestation_missing",
+			apply:   func(p *Provider) { p.CodeAttested = false },
+			blocker: BlockerCodeAttestationMissing,
+			arm: func(r *Registry) {
+				r.SetCodeAttestationPolicy(true, time.Now().Add(-time.Hour))
+			},
+		},
+		{
+			// `trustRank` returns -1 for an unrecognised level, which a
+			// restored store row can carry verbatim.
+			name:    "unrecognised_trust",
+			apply:   func(p *Provider) { p.TrustLevel = TrustLevel("bogus") },
+			blocker: BlockerTrustBelowMinimum,
+		},
 	}
 }
 
@@ -66,6 +83,9 @@ func TestLivenessBlockerMatchesLivenessGate(t *testing.T) {
 			r := New(testLogger())
 			r.MinTrustLevel = TrustHardware
 			p := routableProvider(t, r, "p1", gemmaBuild)
+			if mutation.arm != nil {
+				mutation.arm(r)
+			}
 
 			p.mu.Lock()
 			mutation.apply(p)
@@ -96,6 +116,9 @@ func TestPrivateTextBlockerMatchesPrivateTextPredicate(t *testing.T) {
 			r := New(testLogger())
 			r.MinTrustLevel = TrustHardware
 			p := routableProvider(t, r, "p1", gemmaBuild)
+			if mutation.arm != nil {
+				mutation.arm(r)
+			}
 
 			p.mu.Lock()
 			mutation.apply(p)
@@ -111,8 +134,30 @@ func TestPrivateTextBlockerMatchesPrivateTextPredicate(t *testing.T) {
 			if supported != (blocker == "") {
 				t.Fatalf("providerSupportsPrivateTextLocked = %v but blocker = %q", supported, blocker)
 			}
+			// Which gate refused, not just that one did. Without this the
+			// suite would pass if two gates were transposed.
+			if privateTextBlockers[mutation.blocker] && blocker != mutation.blocker {
+				t.Fatalf("blocker = %q, want %q", blocker, mutation.blocker)
+			}
+			if !privateTextBlockers[mutation.blocker] && blocker != "" {
+				t.Fatalf("blocker = %q, want the private-text gate to pass", blocker)
+			}
 		})
 	}
+}
+
+// The subset of gates the private-text chokepoint owns. Anything else in the
+// mutation matrix is checked by an earlier or later gate, so the chokepoint
+// must report clean for it.
+var privateTextBlockers = map[RoutingBlocker]bool{
+	BlockerNoEncryptionKey:          true,
+	BlockerUnsupportedBackend:       true,
+	BlockerUnencryptedChunks:        true,
+	BlockerRuntimeManifestUnchecked: true,
+	BlockerSIPUnverified:            true,
+	BlockerCodeAttestationMissing:   true,
+	BlockerPrivacyCapsMissing:       true,
+	BlockerPrivacyCapsIncomplete:    true,
 }
 
 // TestAdvertisingMatchesListModels is the assertion an operator actually cares
@@ -126,6 +171,9 @@ func TestAdvertisingMatchesListModels(t *testing.T) {
 			r := New(testLogger())
 			r.MinTrustLevel = TrustHardware
 			p := routableProvider(t, r, "p1", gemmaBuild)
+			if mutation.arm != nil {
+				mutation.arm(r)
+			}
 
 			p.mu.Lock()
 			mutation.apply(p)
@@ -149,11 +197,14 @@ func TestAdvertisingMatchesListModels(t *testing.T) {
 			if diag.Routable && !diag.Advertising {
 				t.Fatalf("Routable without Advertising (blockers %v)", diag.Blockers)
 			}
-			// Whatever we claim is unroutable must actually be unroutable on
-			// the production reservation path.
+			// BOTH directions against the production reservation path. The
+			// one-sided version of this assertion is what let an
+			// over-optimistic verdict ship: `Routable` must not claim more
+			// than dispatch delivers, and must not claim less either.
 			reserved := findRoutableProvider(r, gemmaBuild) != nil
-			if !diag.Routable && reserved {
-				t.Fatalf("reported unroutable (%v) but ReserveProviderEx selected it", diag.Blockers)
+			if diag.Routable != reserved {
+				t.Fatalf("Routable = %v but ReserveProviderEx selected = %v (blockers %v)",
+					diag.Routable, reserved, diag.Blockers)
 			}
 			if mutation.name == "none" && !reserved {
 				t.Fatal("a fully-healthy provider must be reservable")
@@ -174,6 +225,9 @@ func TestOwnerRoutableMatchesOwnedModels(t *testing.T) {
 			r := New(testLogger())
 			r.MinTrustLevel = TrustHardware
 			p := routableProvider(t, r, "p1", gemmaBuild)
+			if mutation.arm != nil {
+				mutation.arm(r)
+			}
 
 			p.mu.Lock()
 			mutation.apply(p)
@@ -323,6 +377,99 @@ func TestEveryModelExcludedReportsNoRoutableModels(t *testing.T) {
 	}
 }
 
+// A render-broken build is fenced for EVERY request shape at dispatch
+// (`providerEligibleForTraitsLocked`) while still being counted in the public
+// catalog. Reporting it as routable would be the exact lie this file exists to
+// prevent.
+func TestRenderBrokenOnlyMachineIsNotRoutable(t *testing.T) {
+	r := New(testLogger())
+	r.MinTrustLevel = TrustHardware
+	p := routableProvider(t, r, "p1", gemmaBuild)
+	renderBroken := false
+	p.mu.Lock()
+	p.Models = []protocol.ModelInfo{{ID: gemmaBuild, TemplateRenderOK: &renderBroken}}
+	p.mu.Unlock()
+
+	diag := r.RoutingDiagnostics("p1", time.Now())
+	if !diag.Advertising {
+		t.Fatal("the public catalog does apply the render gate, so it should still list")
+	}
+	if diag.Routable {
+		t.Fatalf("a render-broken-only machine must not report routable (%+v)", diag.Models)
+	}
+	if findRoutableProvider(r, gemmaBuild) != nil {
+		t.Fatal("the production reservation path selected a render-broken build")
+	}
+	if len(diag.Models) != 1 || diag.Models[0].Routable {
+		t.Fatalf("model row = %+v", diag.Models)
+	}
+}
+
+// Dedicated-box isolation is enabled by default in production for the gemma-4
+// family, so a mixed box gets no gemma-4 traffic. It has to say so.
+func TestDedicatedRuleExclusionIsReported(t *testing.T) {
+	r := New(testLogger())
+	r.MinTrustLevel = TrustHardware
+	r.SetDedicatedModels([]string{"gemma-4"})
+	p := routableProvider(t, r, "p1", gemmaBuild)
+	p.mu.Lock()
+	p.Models = []protocol.ModelInfo{{ID: gemmaBuild}, {ID: qwenBuild}}
+	p.mu.Unlock()
+
+	diag := r.RoutingDiagnostics("p1", time.Now())
+	byID := make(map[string]ModelRoutingDiagnostics, len(diag.Models))
+	for _, m := range diag.Models {
+		byID[m.ID] = m
+	}
+	gemma := byID[gemmaBuild]
+	if gemma.Routable {
+		t.Fatalf("a mixed box must not report the dedicated build as routable: %+v", gemma)
+	}
+	found := false
+	for _, b := range gemma.Blockers {
+		if b == BlockerModelDedicatedBoxOnly {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("blockers = %v, want to contain %s", gemma.Blockers, BlockerModelDedicatedBoxOnly)
+	}
+	if findRoutableProvider(r, gemmaBuild) != nil {
+		t.Fatal("the production reservation path selected a non-dedicated box")
+	}
+	// The non-dedicated build on the same box is unaffected.
+	if !byID[qwenBuild].Routable {
+		t.Fatalf("the non-dedicated build must still route: %+v", byID[qwenBuild])
+	}
+	if !diag.Routable {
+		t.Fatal("a machine with one routable build is routable")
+	}
+}
+
+// An empty catalog and a machine-level fence are separate facts with separate
+// remedies; reporting only the first one sends the operator back to square one
+// after they fix it.
+func TestEmptyCatalogIsReportedAlongsideADispatchBlocker(t *testing.T) {
+	r := New(testLogger())
+	r.MinTrustLevel = TrustHardware
+	p := routableProvider(t, r, "p1", gemmaBuild)
+	p.mu.Lock()
+	p.RuntimeVerified = false
+	p.Models = []protocol.ModelInfo{{ID: "unpublished"}}
+	p.mu.Unlock()
+	r.SetModelCatalog([]CatalogEntry{{ID: gemmaBuild}})
+
+	diag := r.RoutingDiagnostics("p1", time.Now())
+	var sawRuntime, sawEmpty bool
+	for _, b := range diag.Blockers {
+		sawRuntime = sawRuntime || b == BlockerRuntimeUnverified
+		sawEmpty = sawEmpty || b == BlockerNoRoutableModels
+	}
+	if !sawRuntime || !sawEmpty {
+		t.Fatalf("blockers = %v, want both the runtime fence and the empty catalog", diag.Blockers)
+	}
+}
+
 func TestRoutingDiagnosticsUnknownProvider(t *testing.T) {
 	r := New(testLogger())
 	if diag := r.RoutingDiagnostics("nope", time.Now()); diag != nil {
@@ -339,7 +486,7 @@ func TestEveryBlockerHasRemediationText(t *testing.T) {
 		BlockerPrivacyCapsMissing, BlockerPrivacyCapsIncomplete,
 		BlockerNoModelsRegistered, BlockerNoRoutableModels,
 		BlockerModelNotInCatalog, BlockerModelWeightHashMismatch,
-		BlockerModelTemplateRenderBroken,
+		BlockerModelTemplateRenderBroken, BlockerModelDedicatedBoxOnly,
 	}
 	for _, b := range all {
 		if got := b.Description(); got == "" || got == string(b) {

--- a/coordinator/registry/routing_eligibility.go
+++ b/coordinator/registry/routing_eligibility.go
@@ -40,26 +40,13 @@ import "time"
 // applies, so plaintext is never exposed and only the genuinely-signed provider
 // binary serves. This is exactly the set of gates publiclyRoutableLocked
 // enforces. Caller holds r.mu and p.mu.
+//
+// The gate itself lives in providerLivenessBlockerLocked
+// (routing_diagnostics.go), which returns the reason it refused; this is the
+// boolean view of the same decision, so what an operator is told and what the
+// router did cannot disagree.
 func (r *Registry) providerLivenessGateLocked(p *Provider, minTrust TrustLevel, allowPrivate bool, now time.Time) bool {
-	if p.Status == StatusOffline || p.Status == StatusUntrusted {
-		return false
-	}
-	if p.PrivateOnly && !allowPrivate {
-		return false
-	}
-	if trustRank(p.TrustLevel) < trustRank(minTrust) {
-		return false
-	}
-	if !p.RuntimeVerified {
-		return false
-	}
-	if !r.providerSupportsPrivateTextLocked(p) {
-		return false
-	}
-	if p.LastChallengeVerified.IsZero() || now.Sub(p.LastChallengeVerified) > challengeFreshnessMaxAge {
-		return false
-	}
-	return true
+	return r.providerLivenessBlockerLocked(p, minTrust, allowPrivate, now) == ""
 }
 
 // providerServesRoutableModelLocked reports whether the provider advertises a

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -27,15 +27,14 @@ const (
 	// slow-provider decode, so the cost function actually spreads load
 	// across the fleet. Wider tie window admits more candidates to the
 	// queue-depth tie-break + random distribution.
-	queueDepthPenaltyMs      = 3_000.0
-	totalPendingPenaltyMs    = 750.0
-	memoryPressurePenaltyMs  = 4_000.0
-	cpuUsagePenaltyMs        = 1_500.0
-	gpuUtilizationPenaltyMs  = 5_000.0
-	thermalPenaltyFairMs     = 2_000.0
-	thermalPenaltySeriousMs  = 8_000.0
-	nearTieCostWindowMs      = 3_000.0
-	challengeFreshnessMaxAge = 16 * time.Minute
+	queueDepthPenaltyMs     = 3_000.0
+	totalPendingPenaltyMs   = 750.0
+	memoryPressurePenaltyMs = 4_000.0
+	cpuUsagePenaltyMs       = 1_500.0
+	gpuUtilizationPenaltyMs = 5_000.0
+	thermalPenaltyFairMs    = 2_000.0
+	thermalPenaltySeriousMs = 8_000.0
+	nearTieCostWindowMs     = 3_000.0
 
 	// kvCacheBytesPerToken is a per-token KV-cache size estimate used by
 	// the free-memory admission gate.
@@ -1033,7 +1032,7 @@ func (r *Registry) OwnedProviderSummary(accountID, model string, traits RequestT
 			p.RuntimeVerified &&
 			r.providerSupportsPrivateTextLocked(p) &&
 			!p.LastChallengeVerified.IsZero() &&
-			now.Sub(p.LastChallengeVerified) <= challengeFreshnessMaxAge
+			now.Sub(p.LastChallengeVerified) <= ChallengeFreshnessMaxAge
 		p.mu.Unlock()
 		if serves {
 			servesModel++

--- a/coordinator/registry/warm_pool_controller.go
+++ b/coordinator/registry/warm_pool_controller.go
@@ -700,7 +700,7 @@ func (r *Registry) warmPoolCandidateReasonLocked(p *Provider, model string, now 
 	if trustRank(p.TrustLevel) < trustRank(r.MinTrustLevel) || !p.RuntimeVerified || !r.providerSupportsPrivateTextLocked(p) {
 		return warmPoolCandidate{}, warmColdTrust
 	}
-	if p.LastChallengeVerified.IsZero() || now.Sub(p.LastChallengeVerified) > challengeFreshnessMaxAge {
+	if p.LastChallengeVerified.IsZero() || now.Sub(p.LastChallengeVerified) > ChallengeFreshnessMaxAge {
 		return warmPoolCandidate{}, warmColdStaleChallenge
 	}
 	if !r.providerServesCatalogModelLocked(p, model) {

--- a/coordinator/registry/warm_pool_controller_test.go
+++ b/coordinator/registry/warm_pool_controller_test.go
@@ -515,7 +515,7 @@ func TestWarmPoolSkipsIneligibleProviders(t *testing.T) {
 	untrusted.Status = StatusUntrusted
 	untrusted.mu.Unlock()
 	stale.mu.Lock()
-	// Stale beyond challengeFreshnessMaxAge (16m as of W5b Fix 4) so the warm-pool
+	// Stale beyond ChallengeFreshnessMaxAge (16m as of W5b Fix 4) so the warm-pool
 	// controller treats this provider's attestation as expired and skips it.
 	stale.LastChallengeVerified = time.Now().Add(-20 * time.Minute)
 	stale.mu.Unlock()

--- a/provider-swift/Sources/ProviderCore/Update/InstallLocation.swift
+++ b/provider-swift/Sources/ProviderCore/Update/InstallLocation.swift
@@ -1,0 +1,93 @@
+// Copyright © 2026 Eigen Labs.
+//
+// Where is this process actually running from?
+//
+// The updater stages a new bundle into a side directory, verifies it, and only
+// then renames it into the live layout. Nothing is supposed to EXECUTE from a
+// side directory — but nothing checked, and a provider that ends up doing so
+// is stranded in a way no existing surface reveals:
+//
+//   * `SelfUpdater.resolvedInstallRoot()` derives the install root from the
+//     running executable's path, so a process running out of
+//     `~/.darkbloom/.update-staging-<uuid>/Darkbloom.app/Contents/MacOS/` will
+//     treat the STAGING directory as its install root and stage, commit, and
+//     roll back inside it forever. The real install is never repaired.
+//
+//   * `BinaryHasher.locateMetallib()` resolves `mlx.metallib` next to the
+//     running executable, so the coordinator receives the staging tree's
+//     hashes, they match no registered release, and the machine is derouted
+//     with `runtime_verified=false` while still connected and heartbeating.
+//
+// The result is a node that reports online, hardware-trusted, challenge-
+// passing and locally healthy while serving nothing, and whose only apparent
+// escape is a full reinstall. This type is the check that names it. It is pure
+// path arithmetic over the executable path, so `doctor` can run it without the
+// daemon and tests can run it without a filesystem.
+
+import Foundation
+
+public enum InstallLocation {
+
+    /// Directory-name prefixes the updater uses for trees that are, by
+    /// construction, transient: they exist only between the steps of an
+    /// install and are renamed or deleted when it finishes. Must stay in sync
+    /// with `SelfUpdater.stagingDirPrefix`, `UpdateRecoveryStore`'s rollback
+    /// and restore staging names, and `UpdateInstallLayout`'s predecessor
+    /// staging name.
+    public static let transientDirPrefixes = [
+        ".update-staging-",
+        ".update-backup-",
+        ".rollback-staging-",
+        ".recovery-restore-",
+        ".predecessor-next-",
+    ]
+
+    public enum Verdict: Sendable, Equatable {
+        /// Running from a normal install layout.
+        case live
+        /// Running from inside a transient update directory. `directory` is
+        /// the offending path component (never a full path — it embeds only a
+        /// prefix and a UUID).
+        case transient(directory: String)
+
+        public var isTransient: Bool {
+            if case .transient = self { return true }
+            return false
+        }
+    }
+
+    /// Classify an executable path. Symlinks are resolved first: invoked as
+    /// plain `darkbloom` the path is the `/usr/local/bin` PATH symlink, which
+    /// says nothing about where the bytes live — the same resolution
+    /// `SelfUpdater.installRoot(forExecutablePath:)` performs before deriving
+    /// the install root, so the two agree about what "here" means.
+    public static func classify(executablePath: String) -> Verdict {
+        let resolved = URL(fileURLWithPath: executablePath).resolvingSymlinksInPath()
+        for component in resolved.pathComponents {
+            for prefix in transientDirPrefixes where component.hasPrefix(prefix) {
+                return .transient(directory: component)
+            }
+        }
+        return .live
+    }
+
+    /// Classify the running process.
+    public static func current(
+        executablePath: String? = Bundle.main.executablePath
+    ) -> Verdict {
+        guard let executablePath else { return .live }
+        return classify(executablePath: executablePath)
+    }
+
+    /// Operator-facing explanation for a transient verdict, or nil when the
+    /// install location is fine. Content-free: the only interpolation is the
+    /// directory name, which is a fixed prefix plus a UUID.
+    public static func remediation(for verdict: Verdict) -> String? {
+        guard case .transient(let directory) = verdict else { return nil }
+        return "running from the transient update directory \(directory) instead of the "
+            + "live install. An update staged a bundle here and never finished swapping it "
+            + "in, so this process reports the staged tree's runtime hashes — which match "
+            + "no registered release — and the coordinator will not route to it. Reinstall "
+            + "with the official installer to restore the live layout."
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Update/InstallLocation.swift
+++ b/provider-swift/Sources/ProviderCore/Update/InstallLocation.swift
@@ -30,16 +30,18 @@ public enum InstallLocation {
 
     /// Directory-name prefixes the updater uses for trees that are, by
     /// construction, transient: they exist only between the steps of an
-    /// install and are renamed or deleted when it finishes. Must stay in sync
-    /// with `SelfUpdater.stagingDirPrefix`, `UpdateRecoveryStore`'s rollback
-    /// and restore staging names, and `UpdateInstallLayout`'s predecessor
-    /// staging name.
+    /// install and are renamed or deleted when it finishes.
+    ///
+    /// Where a constant already exists it is referenced rather than copied, so
+    /// renaming one cannot leave a hole here. The remaining literals are the
+    /// names built inline at their single construction site; each cites it.
     public static let transientDirPrefixes = [
-        ".update-staging-",
-        ".update-backup-",
-        ".rollback-staging-",
-        ".recovery-restore-",
-        ".predecessor-next-",
+        SelfUpdater.stagingDirPrefix,  // SelfUpdater.stageBundle
+        UpdateRecoveryStore.staleAppAsidePrefix,  // stale-app retirement, via atomicRemove
+        ".update-backup-",  // SelfUpdater backup swap
+        ".rollback-staging-",  // UpdateRecoveryStore.rollbackToPredecessor
+        ".recovery-restore-",  // UpdateRecoveryStore.restore
+        ".predecessor-next-",  // UpdateInstallLayout.snapshotLiveAsPredecessor
     ]
 
     public enum Verdict: Sendable, Equatable {

--- a/provider-swift/Sources/ProviderCore/Update/SelfUpdater.swift
+++ b/provider-swift/Sources/ProviderCore/Update/SelfUpdater.swift
@@ -361,7 +361,9 @@ public struct SelfUpdater: Sendable {
     /// Directory-name prefixes for staged bundles and commit backups inside
     /// the darkbloom root. Dot-prefixed so they stay out of the visible
     /// layout; cleaned up on the next staging pass if a crash orphans them.
-    private static let stagingDirPrefix = ".update-staging-"
+    /// Referenced by `InstallLocation.transientDirPrefixes`, which must be
+    /// able to recognise a process running out of a staging tree.
+    static let stagingDirPrefix = ".update-staging-"
     private static let artifactVerificationTimeout: TimeInterval = 120
 
     private struct ArtifactVerificationPolicy {

--- a/provider-swift/Sources/darkbloom/DoctorCommand.swift
+++ b/provider-swift/Sources/darkbloom/DoctorCommand.swift
@@ -259,6 +259,17 @@ func buildDoctorChecks(
         detail: snapshot.configFileExists ? "loaded" : "missing, defaults are in memory only"
     ))
 
+    // A binary executing out of an update-staging tree reports that tree's
+    // runtime hashes, matches no registered release, and is silently derouted
+    // while every other local check stays green. FAIL, so `doctor` can never
+    // report all-clear on a machine the coordinator has fenced for it.
+    let installLocation = InstallLocation.current()
+    checks.append(.init(
+        name: "install location",
+        status: installLocation.isTransient ? .fail : .pass,
+        detail: InstallLocation.remediation(for: installLocation) ?? "live install layout"
+    ))
+
     if let cacheDir = ModelScanner.defaultCacheDirectory(),
        FileManager.default.fileExists(atPath: cacheDir.path) {
         checks.append(.init(

--- a/provider-swift/Sources/darkbloom/StartCommand+Modes.swift
+++ b/provider-swift/Sources/darkbloom/StartCommand+Modes.swift
@@ -150,6 +150,16 @@ extension Start {
     ) async throws {
         warnBootSecurity(snapshot: bootSecuritySnapshot, coordinatorEnforced: true)
 
+        // THIS is the process launchd actually runs, and therefore the one a
+        // failed update can strand inside a staging tree. `runPreflightChecks`
+        // only guards the parent that WRITES the plist; without this check the
+        // stranded daemon would keep heartbeating, keep passing challenges,
+        // and keep being derouted for runtime hashes it can never match.
+        if let remediation = InstallLocation.remediation(for: InstallLocation.current()) {
+            printError("This provider is \(remediation)")
+            throw ExitCode.failure
+        }
+
         let selectedModels: [ModelInfo]
         if !model.isEmpty {
             selectedModels = advertisedModels(from: snapshot.models, config: config, modelOverrides: model)

--- a/provider-swift/Sources/darkbloom/StartCommand+Preflight.swift
+++ b/provider-swift/Sources/darkbloom/StartCommand+Preflight.swift
@@ -14,6 +14,16 @@ extension Start {
     internal func runPreflightChecks(snapshot: RuntimeSnapshot) throws {
         warnBootSecurity(coordinatorEnforced: true)
 
+        // Serving from an update-staging tree produces a node that looks
+        // healthy locally and is derouted by the coordinator for runtime
+        // hashes that match no release — with no local symptom to chase. Refuse
+        // before we burn a model download and hours of apparent uptime on it.
+        let installLocation = InstallLocation.current()
+        if let remediation = InstallLocation.remediation(for: installLocation) {
+            printError("This provider is \(remediation)")
+            throw ExitCode.failure
+        }
+
         let debuggerAttached = checkDebuggerAttached()
         if debuggerAttached {
             printError("A debugger is attached. The coordinator will reject this provider.")

--- a/provider-swift/Tests/DarkbloomCLITests/DoctorChecksTests.swift
+++ b/provider-swift/Tests/DarkbloomCLITests/DoctorChecksTests.swift
@@ -42,10 +42,21 @@ struct DoctorChecksTests {
     @Test("check backbone includes local posture but leaves Secure Boot to MDM")
     func stableBackbone() {
         #expect(checks(hardware: hardware).map(\.name) == [
-            "hardware", "metal gpu", "config", "huggingface cache", "local mlx models",
-            "macos", "sip", "rdma", "authenticated root", "hardened runtime", "debugger",
-            "binary hash",
+            "hardware", "metal gpu", "config", "install location", "huggingface cache",
+            "local mlx models", "macos", "sip", "rdma", "authenticated root",
+            "hardened runtime", "debugger", "binary hash",
         ])
+    }
+
+    /// A provider running from its live layout must not be told it is
+    /// stranded; the test binary itself is the live case. The transient case
+    /// is pinned in `InstallLocationTests` against synthetic paths, because
+    /// the check reads the RUNNING executable and a test cannot move itself.
+    @Test("install location passes for a normally-installed binary")
+    func installLocationCheck() {
+        let check = check(checks(hardware: hardware), "install location")
+        #expect(check?.status == .pass)
+        #expect(check?.detail == "live install layout")
     }
 
     @Test("snapshot checks retain their existing status mapping")

--- a/provider-swift/Tests/ProviderCoreTests/InstallLocationTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/InstallLocationTests.swift
@@ -79,19 +79,41 @@ struct InstallLocationTests {
         #expect(InstallLocation.Verdict.transient(directory: ".update-backup-1").isTransient)
     }
 
-    /// The prefixes must cover every transient directory the updater actually
-    /// creates. This is the list as of v0.8.9; adding one to the updater
-    /// without adding it here reopens the hole.
-    @Test("the prefix list covers every updater-created transient directory")
-    func prefixesCoverTheUpdater() {
+    /// The list must cover every transient directory the updater creates.
+    /// Where the updater owns a named constant, this asserts against THAT
+    /// constant rather than a copy of the string — a duplicated literal would
+    /// only be comparing the implementation to itself.
+    @Test("the prefix list references the updater's own constants")
+    func prefixesReferenceUpdaterConstants() {
+        #expect(InstallLocation.transientDirPrefixes.contains(SelfUpdater.stagingDirPrefix))
+        #expect(
+            InstallLocation.transientDirPrefixes.contains(
+                UpdateRecoveryStore.staleAppAsidePrefix))
+    }
+
+    /// The inline-constructed names, each with its single construction site.
+    /// Adding one to the updater without adding it here reopens the hole; the
+    /// literals are unavoidable because the updater builds them inline.
+    @Test("the prefix list covers the inline-constructed transient directories")
+    func prefixesCoverInlineNames() {
         for prefix in [
-            ".update-staging-",  // SelfUpdater.stagingDirPrefix
             ".update-backup-",  // SelfUpdater backup swap
-            ".rollback-staging-",  // UpdateRecoveryStore rollback
-            ".recovery-restore-",  // UpdateRecoveryStore restore
-            ".predecessor-next-",  // UpdateInstallLayout predecessor snapshot
+            ".rollback-staging-",  // UpdateRecoveryStore.rollbackToPredecessor
+            ".recovery-restore-",  // UpdateRecoveryStore.restore
+            ".predecessor-next-",  // UpdateInstallLayout.snapshotLiveAsPredecessor
         ] {
             #expect(InstallLocation.transientDirPrefixes.contains(prefix), prefix)
         }
+    }
+
+    /// The stale-app aside prefix was missing from the first version of this
+    /// list, so pin the behaviour that depends on it.
+    @Test("a process inside a retired stale-app directory is caught")
+    func staleAppAsideIsCaught() {
+        let directory = "\(UpdateRecoveryStore.staleAppAsidePrefix)7E4A5C1D"
+        let path = "/Users/tim/.darkbloom/\(directory)/Darkbloom.app/Contents/MacOS/darkbloom"
+        #expect(
+            InstallLocation.classify(executablePath: path)
+                == .transient(directory: directory))
     }
 }

--- a/provider-swift/Tests/ProviderCoreTests/InstallLocationTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/InstallLocationTests.swift
@@ -1,0 +1,97 @@
+// Copyright © 2026 Eigen Labs.
+//
+// A 0.8.7 → 0.8.9 auto-update left a provider's daemon executing out of an
+// `.update-staging-*` bundle. Every local surface stayed green — the daemon
+// ran, heartbeats flowed, attestation challenges passed, `doctor` reported 30
+// PASS / 0 FAIL — while the coordinator derouted the machine because the
+// staged tree's `mlx.metallib` hash matched no registered release. There was
+// no check anywhere that a provider is running from the live install.
+//
+// These pin the classifier that check is built on.
+
+import Foundation
+import Testing
+
+@testable import ProviderCore
+
+private let liveApp = "/Users/tim/.darkbloom/Darkbloom.app/Contents/MacOS/darkbloom"
+private let liveFlat = "/Users/tim/.darkbloom/bin/darkbloom"
+
+@Suite("InstallLocation")
+struct InstallLocationTests {
+
+    @Test("a normal .app install is live")
+    func appLayoutIsLive() {
+        #expect(InstallLocation.classify(executablePath: liveApp) == .live)
+    }
+
+    @Test("a normal flat install is live")
+    func flatLayoutIsLive() {
+        #expect(InstallLocation.classify(executablePath: liveFlat) == .live)
+    }
+
+    @Test("every transient update directory is caught, at any depth")
+    func transientDirectoriesAreCaught() {
+        for prefix in InstallLocation.transientDirPrefixes {
+            let directory = "\(prefix)7E4A5C1D-0B2F-4A9E-9C3D-1F2E3D4C5B6A"
+            let path = "/Users/tim/.darkbloom/\(directory)/Darkbloom.app/Contents/MacOS/darkbloom"
+            #expect(
+                InstallLocation.classify(executablePath: path)
+                    == .transient(directory: directory),
+                "prefix \(prefix)")
+        }
+    }
+
+    @Test("the flat layout inside a staging tree is caught too")
+    func transientFlatLayout() {
+        let directory = ".update-staging-7E4A5C1D"
+        let path = "/Users/tim/.darkbloom/\(directory)/bin/darkbloom"
+        #expect(
+            InstallLocation.classify(executablePath: path)
+                == .transient(directory: directory))
+    }
+
+    @Test("a directory that merely resembles a staging name is left alone")
+    func lookalikeDirectoriesAreLive() {
+        for name in ["update-staging-x", "darkbloom-update-staging-x", ".updates", ".update"] {
+            let path = "/Users/tim/\(name)/bin/darkbloom"
+            #expect(InstallLocation.classify(executablePath: path) == .live, name)
+        }
+    }
+
+    @Test("a nil executable path degrades to live rather than blocking startup")
+    func nilExecutablePathIsLive() {
+        #expect(InstallLocation.current(executablePath: nil) == .live)
+    }
+
+    @Test("remediation names the directory and is silent for a live install")
+    func remediationText() throws {
+        #expect(InstallLocation.remediation(for: .live) == nil)
+        let text = try #require(
+            InstallLocation.remediation(for: .transient(directory: ".update-staging-abc")))
+        #expect(text.contains(".update-staging-abc"))
+        #expect(text.lowercased().contains("reinstall"))
+    }
+
+    @Test("isTransient matches the case it names")
+    func isTransient() {
+        #expect(!InstallLocation.Verdict.live.isTransient)
+        #expect(InstallLocation.Verdict.transient(directory: ".update-backup-1").isTransient)
+    }
+
+    /// The prefixes must cover every transient directory the updater actually
+    /// creates. This is the list as of v0.8.9; adding one to the updater
+    /// without adding it here reopens the hole.
+    @Test("the prefix list covers every updater-created transient directory")
+    func prefixesCoverTheUpdater() {
+        for prefix in [
+            ".update-staging-",  // SelfUpdater.stagingDirPrefix
+            ".update-backup-",  // SelfUpdater backup swap
+            ".rollback-staging-",  // UpdateRecoveryStore rollback
+            ".recovery-restore-",  // UpdateRecoveryStore restore
+            ".predecessor-next-",  // UpdateInstallLayout predecessor snapshot
+        ] {
+            #expect(InstallLocation.transientDirPrefixes.contains(prefix), prefix)
+        }
+    }
+}

--- a/provider-swift/Tests/ProviderCoreTests/InstallLocationTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/InstallLocationTests.swift
@@ -55,7 +55,7 @@ struct InstallLocationTests {
     func lookalikeDirectoriesAreLive() {
         for name in ["update-staging-x", "darkbloom-update-staging-x", ".updates", ".update"] {
             let path = "/Users/tim/\(name)/bin/darkbloom"
-            #expect(InstallLocation.classify(executablePath: path) == .live, name)
+            #expect(InstallLocation.classify(executablePath: path) == .live, "\(name)")
         }
     }
 
@@ -102,7 +102,7 @@ struct InstallLocationTests {
             ".recovery-restore-",  // UpdateRecoveryStore.restore
             ".predecessor-next-",  // UpdateInstallLayout.snapshotLiveAsPredecessor
         ] {
-            #expect(InstallLocation.transientDirPrefixes.contains(prefix), prefix)
+            #expect(InstallLocation.transientDirPrefixes.contains(prefix), "\(prefix)")
         }
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## The incident

A provider reported a node that served **zero requests for hours** while every surface said it was healthy:

- `trust=hardware`, online, proofs `mdm+mda`, attestation challenges answered every 5 minutes
- `darkbloom doctor`: **30 PASS / 0 FAIL**
- `qwen3.6-35b-a3b-vl-mtp-mxfp8` warm, `preload_models` / `enabled_models` set
- clean 0.8.9 reinstall done, hash `02bab0f4…c0e2cab5`, the runtime-mismatch banner cleared

…and yet: the node's `/v1/models` was empty and self-test requests returned `model_not_loaded`, 20+ minutes after the trust grant. The network page said **88 connected / 85 advertising** with no way to learn which three or why. They also saw four provider identities minted in one day by the update churn.

Three asks, answered below: **(a)** why is the catalog record empty when everything is green, **(b)** how do I force a re-sync without another reinstall, **(c)** the updater failure mode will strand any auto-updating provider.

## (a) Why the record was empty — and why nothing said so

Whether a connected provider advertises is the conjunction of **~15 independent gates** spread across four call sites:

| Layer | Gates |
|---|---|
| Liveness core (`providerLivenessGateLocked`) | status, private-only, trust floor, `runtime_verified`, challenge freshness ≤ 16 min |
| Private-text chokepoint (`providerSupportsPrivateTextLocked`) | encryption key, backend support, encrypted chunks, `runtime_manifest_checked`, coordinator-verified SIP, code attestation, five privacy capabilities |
| Public listing (`ListModels`) | its own subset of the above |
| Per model | catalog membership, weight-hash match, `template_render_ok`, dedicated-box isolation |

**Exactly one of them reached the operator** — the runtime hash, as a UI banner. The rest failed silently. `doctor` is provider-side and cannot see any of them, which is why it reported 30 PASS / 0 FAIL on a fenced machine.

Worse, the gates are asymmetric in ways that hide the problem: **`ListModels` does not apply the `runtime_verified` or challenge-freshness checks that dispatch applies**, and it does not apply the per-model template-render or dedicated-box gates either. A machine can therefore be *counted as advertising* on the network page and still receive nothing.

Two things were also worth answering directly:

- **Four identities in one day is expected, not a symptom.** `provider_id` is a fresh UUID per WebSocket connection (`coordinator/api/provider.go:125`); stable identity is serial / Secure Enclave key / account (`stableProviderIdentityLocked`). Four IDs means four reconnects from the update churn, not four registrations competing. Live duplicates are already evicted by serial (`DisconnectDuplicatesBySerial`).
- **Warm ≠ advertised.** Advertising comes from the register-time `models[]` list; heartbeats can only *filter* that set (`canonicalHeartbeatModelState`), never add to it. A locally-warm model that never made it into registration is invisible to the coordinator.

## The fix — the coordinator reports its own verdict

`GET /v1/me/providers` now carries a `routing` block per machine:

```json
"routing": {
  "advertising": true,
  "routable": false,
  "owner_routable": false,
  "blockers": ["attestation_challenge_stale"],
  "models": [
    {"id": "qwen3.6-35b-a3b-vl-mtp-mxfp8", "publicly_listed": false,
     "routable": false, "owner_routable": false,
     "blockers": ["model_weight_hash_mismatch"]}
  ],
  "challenge_max_age_seconds": 960
}
```

`advertising` and `routable` are separate on purpose — that is the asymmetry above, made visible rather than papered over. `routable` applies the gates dispatch applies, including the per-model template-render and dedicated-box fences.

**It cannot drift from the router, because it is not a second implementation.** Each gate now has one body that returns the reason it refused; the booleans the router calls are one-line delegates asking whether that reason is empty:

```go
func (r *Registry) providerSupportsPrivateTextLocked(p *Provider) bool {
	return r.providerPrivateTextBlockerLocked(p) == ""
}
```

`ListModels`' per-provider filter moves into the same shared `publicListingBlockerLocked`, and `OwnedModels` drops its hand-rolled copy of the liveness gate.

## (b) Forcing a re-sync

With the verdict exposed, "force a re-sync" stops being a guess. Every blocker maps to a specific remedy in the console (`darkbloom restart` for a stale challenge, `darkbloom models pull` for a weight-hash mismatch, `csrutil enable` for SIP, and so on) — no identity-burning reinstall. Note that the machine-level state was never sticky: a runtime mismatch does not blacklist a serial or SE key; registration re-evaluates `RuntimeVerified` from scratch.

## (c) The updater failure mode

Confirmed and fixed. Two pieces of the provider derive their world from the running executable's own path, and both go wrong at once when that path is a staging tree:

- `SelfUpdater.resolvedInstallRoot()` walks up from the executable, so the **staging directory becomes the install root** — every subsequent stage, commit and rollback happens inside it and the real install is never repaired. Self-perpetuating.
- `BinaryHasher.locateMetallib()` resolves `mlx.metallib` next to the executable, so the coordinator receives the staged tree's hashes, they match no release, and the node is derouted while still connected.

`InstallLocation` classifies the running executable against the six transient directories the updater creates, referencing `SelfUpdater.stagingDirPrefix` and `UpdateRecoveryStore.staleAppAsidePrefix` directly rather than copying the strings. `doctor` now **FAILS** on a transient verdict, and both `darkbloom start` entry points refuse — including `runForeground`, the process launchd actually runs and therefore the only one a failed update can strand.

## Before / after

```mermaid
flowchart TB
  subgraph Before["BEFORE"]
    direction TB
    B1["operator: node serves nothing"] --> B2["darkbloom doctor"]
    B2 --> B3["30 PASS / 0 FAIL<br/>(no coordinator gate is visible here)"]
    B1 --> B4["console dashboard"]
    B4 --> B5["derives 4 of ~15 gates from<br/>exposed booleans"]
    B5 --> B6["verdict: ROUTABLE<br/>2 informational notes"]
    B1 --> B7["network page"]
    B7 --> B8["88 connected / 85 advertising<br/>no drill-down"]
    B3 --> B9["only remaining move:<br/>full reinstall (new identity)"]
    B6 --> B9
    B8 --> B9
  end
```

```mermaid
flowchart TB
  subgraph After["AFTER"]
    direction TB
    A1["operator: node serves nothing"] --> A2["GET /v1/me/providers"]
    A2 --> A3["registry.RoutingDiagnostics<br/>(same predicates the router uses)"]
    A3 --> A4["advertising: true<br/>routable: false<br/>owner_routable: false"]
    A3 --> A5["blockers:<br/>attestation_challenge_stale"]
    A3 --> A6["per model:<br/>qwen → weight_hash_mismatch<br/>gemma → template_render_broken<br/>local → not_in_catalog"]
    A4 --> A7["console verdict: BLOCKED<br/>each row with a copyable fix"]
    A5 --> A7
    A6 --> A7
    A1 --> A8["darkbloom doctor"]
    A8 --> A9["[FAIL] install location:<br/>running from .update-staging-…"]
  end
```

Code-level delta:

```mermaid
flowchart LR
  subgraph CB["Before"]
    C1["providerSupportsPrivateTextLocked<br/>(7 gates, bool)"]
    C2["providerLivenessGateLocked<br/>(6 gates, bool)"]
    C3["ListModels<br/>(inline copy of 4 gates)"]
    C4["OwnedModels<br/>(inline copy of 6 gates)"]
    C5["warnings.ts<br/>(TS re-derivation of 4 gates)"]
  end
  subgraph CA["After"]
    D1["providerPrivateTextBlockerLocked<br/>→ RoutingBlocker"]
    D2["providerLivenessBlockerLocked<br/>→ RoutingBlocker"]
    D3["publicListingBlockerLocked<br/>→ RoutingBlocker"]
    D5["modelBlockersLocked<br/>→ catalog / hash / template / dedicated"]
    D1 --> D2 --> D4["RoutingDiagnostics"]
    D3 --> D4
    D5 --> D4
    D1 -.delegate.-> E1["providerSupportsPrivateTextLocked (bool)"]
    D2 -.delegate.-> E2["providerLivenessGateLocked (bool)"]
    D3 -.-> E3[ListModels]
    E2 -.-> E4[OwnedModels]
    D4 --> F1["/v1/me/providers .routing"]
    F1 --> F2["routing-blockers.ts + fixes.ts"]
  end
```

## Verification

**Coordinator** (`go test ./...`, full suite green, `-race` clean). The drift tests mutate one gate at a time across a 17-case matrix — including code attestation and an unrecognised trust level — and assert the diagnostic agrees with `ListModels`, with `OwnedModels`, and with the production `ReserveProviderEx` path **in both directions**, so neither an over- nor under-optimistic verdict can ship. HTTP-level tests decode the wire JSON so the field names the UI keys off are pinned.

**Console UI** (533 vitest tests, 0 eslint errors, `next build` clean). Includes the fix-table coverage test `fixes.ts` has always claimed to have: every blocker must resolve to an explicit remedy, not the generic fallback.

Driving the console from the **real bytes** a live coordinator emits for the reported machine shape — online, hardware trust, runtime verified, zero failed challenges, model warm:

[GET /v1/me/providers routing block from a live coordinator](https://cursor.com/agents/bc-08c3df13-d956-5fba-9a68-59ffb1ccd7e1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Frouting_verdict_api_response_v2.png)

[Dashboard output for the same machine, before and after](https://cursor.com/agents/bc-08c3df13-d956-5fba-9a68-59ffb1ccd7e1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Frouting_verdict_dashboard_before_after_v2.png)

The dashboard went from **ROUTABLE** with two informational notes to **BLOCKED** with the stale challenge, the Qwen build's weight-hash mismatch, and the Gemma build's failed template render — each with the command that fixes it.

**Provider.** MLX needs Metal, so `swift test` runs on the macOS CI runner; the pure classifier was additionally compiled and executed here against a copy with only the two constant references substituted for their literals:

[install-location classifier verification](https://cursor.com/agents/bc-08c3df13-d956-5fba-9a68-59ffb1ccd7e1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Finstall_location_check_v2.png)

## Follow-ups (not in this PR)

- `revalidateConnectedProvidersAgainstRuntimePolicy` says it deroutes "until the next successful challenge re-verifies it", but when the manifest is withdrawn (`knownRuntimeManifest == nil`) the challenge handler's re-verification block is skipped entirely, so nothing can restore `RuntimeVerified` short of a reconnect. Unreachable in prod today (a manifest is always configured) but the comment promises a recovery path that does not exist.
- `Register` does not reject an empty model id, so `ListModels` can emit an `{"id": ""}` row that the diagnostic (correctly) skips. Best fixed at registration.
- The server-side `needsAttention` count on `/v1/me/summary` still uses the old approximation and never consults `mp.Routing`, so the header count and the per-card verdict can disagree — the same class of inconsistency this PR removes on the client.
- The provider reports advertising state only at register / `models_update`. A `darkbloom models refresh` verb that re-sends `models_update` on demand would give operators a re-sync that costs neither a reconnect nor a reinstall.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://darkbloom.slack.com/archives/C0B0CAQC8P5/p1787343622971919?thread_ts=1787343622.971919&cid=C0B0CAQC8P5)

<div><a href="https://cursor.com/agents/bc-08c3df13-d956-5fba-9a68-59ffb1ccd7e1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-08c3df13-d956-5fba-9a68-59ffb1ccd7e1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/664"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789973642&installation_model_id=21733&pr_number=664&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F664&signature=1653e8512cbc24c15dc382e23a9ead39f8686299accf4e4fc7c094ae6e16aac6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->