### PR TITLE
fix(store): skip completed usage totals backfill

### DIFF
--- a/coordinator/store/postgres.go
+++ b/coordinator/store/postgres.go
@@ -731,12 +731,6 @@ func (s *PostgresStore) migrate(ctx context.Context) error {
 			total_prompt_tokens BIGINT NOT NULL DEFAULT 0,
 			total_completion_tokens BIGINT NOT NULL DEFAULT 0
 		)`,
-		// Backfill from existing usage rows.  ON CONFLICT DO NOTHING makes
-		// this idempotent — only runs on first deploy.
-		`INSERT INTO usage_totals (id, total_requests, total_prompt_tokens, total_completion_tokens)
-		 SELECT 1, COUNT(*), COALESCE(SUM(prompt_tokens), 0), COALESCE(SUM(completion_tokens), 0)
-		 FROM usage
-		 ON CONFLICT (id) DO NOTHING`,
 
 		// Partial index for UsageLocationBuckets — only rows with a
 		// non-null request_location are ever queried.
@@ -1044,6 +1038,10 @@ func (s *PostgresStore) migrate(ctx context.Context) error {
 		if _, err := s.pool.Exec(ctx, m); err != nil {
 			return fmt.Errorf("migration failed: %w", err)
 		}
+	}
+
+	if err := s.migrateUsageTotals(ctx); err != nil {
+		return err
 	}
 
 	if err := s.migrateWithdrawableBalance(ctx); err != nil {

--- a/coordinator/store/postgres.go
+++ b/coordinator/store/postgres.go
@@ -731,6 +731,10 @@ func (s *PostgresStore) migrate(ctx context.Context) error {
 			total_prompt_tokens BIGINT NOT NULL DEFAULT 0,
 			total_completion_tokens BIGINT NOT NULL DEFAULT 0
 		)`,
+		`CREATE TABLE IF NOT EXISTS usage_totals_backfill_state (
+			id INTEGER PRIMARY KEY DEFAULT 1 CHECK (id = 1),
+			cutoff_id BIGINT NOT NULL
+		)`,
 
 		// Partial index for UsageLocationBuckets — only rows with a
 		// non-null request_location are ever queried.

--- a/coordinator/store/postgres_usage_totals_migration.go
+++ b/coordinator/store/postgres_usage_totals_migration.go
@@ -2,9 +2,12 @@ package store
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"time"
+
+	"github.com/jackc/pgx/v5"
 )
 
 const usageTotalsMigrationID = "backfill_usage_totals_v1"
@@ -13,8 +16,14 @@ type usageTotalsMigrationResult string
 
 const (
 	usageTotalsMigrationBackfilled usageTotalsMigrationResult = "backfilled"
+	usageTotalsMigrationPreserved  usageTotalsMigrationResult = "preserved_existing"
 	usageTotalsMigrationSkipped    usageTotalsMigrationResult = "already_applied"
 )
+
+type usageTotalsMigrationPreparation struct {
+	CutoffID int64
+	Result   usageTotalsMigrationResult
+}
 
 // migrateUsageTotals records startup observability around the one-time usage
 // aggregation without exposing usage values.
@@ -35,21 +44,201 @@ func (s *PostgresStore) migrateUsageTotals(ctx context.Context) error {
 	return nil
 }
 
-// applyUsageTotalsMigration checks the counter row before touching the usage
-// table. The old INSERT ... SELECT ... ON CONFLICT statement still evaluated
-// the full aggregate before discovering the conflict, so every restart scanned
-// all historical usage.
+// applyUsageTotalsMigration checks the durable marker and counter row before
+// touching usage. The old INSERT ... SELECT ... ON CONFLICT statement still
+// evaluated the full aggregate before discovering the conflict, so every
+// restart scanned all historical usage.
 //
-// The transaction-scoped advisory lock serializes concurrent coordinators
-// without blocking usage writers. Every later startup takes only that lock and
-// a primary-key existence check.
+// A fresh database uses a two-phase cutover. The prepare transaction briefly
+// fences inserts only while it captures the current maximum usage ID, creates
+// the zero counter, and persists that cutoff. Writers then resume immediately
+// and increment the counter while the historical range is aggregated. The
+// finalize transaction atomically adds that range and records completion.
+// Interrupted backfills resume from the durable cutoff without double-counting.
 func (s *PostgresStore) applyUsageTotalsMigration(ctx context.Context) (usageTotalsMigrationResult, error) {
+	preparation, err := s.prepareUsageTotalsMigration(ctx)
+	if err != nil {
+		return "", err
+	}
+	if preparation.Result != "" {
+		return preparation.Result, nil
+	}
+	return s.finalizeUsageTotalsMigration(ctx, preparation.CutoffID)
+}
+
+func (s *PostgresStore) prepareUsageTotalsMigration(ctx context.Context) (usageTotalsMigrationPreparation, error) {
 	tx, err := s.pool.Begin(ctx)
 	if err != nil {
-		return "", fmt.Errorf("begin: %w", err)
+		return usageTotalsMigrationPreparation{}, fmt.Errorf("begin preparation: %w", err)
 	}
 	defer tx.Rollback(ctx)
 
+	if err := acquireUsageTotalsMigrationLock(ctx, tx); err != nil {
+		return usageTotalsMigrationPreparation{}, err
+	}
+
+	var applied, counterExists bool
+	if err := tx.QueryRow(ctx,
+		`SELECT EXISTS (SELECT 1 FROM schema_migrations WHERE id = $1)`,
+		usageTotalsMigrationID,
+	).Scan(&applied); err != nil {
+		return usageTotalsMigrationPreparation{}, fmt.Errorf("check migration marker: %w", err)
+	}
+	if err := tx.QueryRow(ctx,
+		`SELECT EXISTS (SELECT 1 FROM usage_totals WHERE id = 1)`,
+	).Scan(&counterExists); err != nil {
+		return usageTotalsMigrationPreparation{}, fmt.Errorf("check counter row: %w", err)
+	}
+	if applied {
+		if !counterExists {
+			return usageTotalsMigrationPreparation{}, errors.New("migration marked applied but counter row is missing")
+		}
+		if err := tx.Commit(ctx); err != nil {
+			return usageTotalsMigrationPreparation{}, fmt.Errorf("commit skip: %w", err)
+		}
+		return usageTotalsMigrationPreparation{Result: usageTotalsMigrationSkipped}, nil
+	}
+
+	var cutoffID int64
+	err = tx.QueryRow(ctx,
+		`SELECT cutoff_id FROM usage_totals_backfill_state WHERE id = 1`,
+	).Scan(&cutoffID)
+	if err == nil {
+		if !counterExists {
+			return usageTotalsMigrationPreparation{}, errors.New("backfill checkpoint exists but counter row is missing")
+		}
+		if err := tx.Commit(ctx); err != nil {
+			return usageTotalsMigrationPreparation{}, fmt.Errorf("commit resumed preparation: %w", err)
+		}
+		return usageTotalsMigrationPreparation{CutoffID: cutoffID}, nil
+	}
+	if !errors.Is(err, pgx.ErrNoRows) {
+		return usageTotalsMigrationPreparation{}, fmt.Errorf("read backfill checkpoint: %w", err)
+	}
+
+	// Databases upgraded from the old inline migration already have an exact
+	// counter but no marker. Adopt it without rescanning usage.
+	if counterExists {
+		if _, err := tx.Exec(ctx,
+			`INSERT INTO schema_migrations (id) VALUES ($1)`,
+			usageTotalsMigrationID,
+		); err != nil {
+			return usageTotalsMigrationPreparation{}, fmt.Errorf("mark existing counter: %w", err)
+		}
+		if err := tx.Commit(ctx); err != nil {
+			return usageTotalsMigrationPreparation{}, fmt.Errorf("commit existing counter: %w", err)
+		}
+		return usageTotalsMigrationPreparation{Result: usageTotalsMigrationPreserved}, nil
+	}
+
+	// SHARE waits for existing inserts and prevents new ones only for the
+	// constant-time cutoff/counter/checkpoint transaction. The historical scan
+	// runs after commit and never holds this writer-conflicting lock.
+	if _, err := tx.Exec(ctx, `LOCK TABLE usage IN SHARE MODE`); err != nil {
+		return usageTotalsMigrationPreparation{}, fmt.Errorf("fence usage inserts: %w", err)
+	}
+	if err := tx.QueryRow(ctx, `SELECT COALESCE(MAX(id), 0) FROM usage`).Scan(&cutoffID); err != nil {
+		return usageTotalsMigrationPreparation{}, fmt.Errorf("capture usage cutoff: %w", err)
+	}
+	if _, err := tx.Exec(ctx, `INSERT INTO usage_totals (id) VALUES (1)`); err != nil {
+		return usageTotalsMigrationPreparation{}, fmt.Errorf("initialize counter row: %w", err)
+	}
+	if _, err := tx.Exec(ctx,
+		`INSERT INTO usage_totals_backfill_state (id, cutoff_id) VALUES (1, $1)`,
+		cutoffID,
+	); err != nil {
+		return usageTotalsMigrationPreparation{}, fmt.Errorf("persist backfill checkpoint: %w", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return usageTotalsMigrationPreparation{}, fmt.Errorf("commit preparation: %w", err)
+	}
+	return usageTotalsMigrationPreparation{CutoffID: cutoffID}, nil
+}
+
+func (s *PostgresStore) finalizeUsageTotalsMigration(
+	ctx context.Context,
+	expectedCutoffID int64,
+) (usageTotalsMigrationResult, error) {
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return "", fmt.Errorf("begin finalization: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	if err := acquireUsageTotalsMigrationLock(ctx, tx); err != nil {
+		return "", err
+	}
+
+	var applied bool
+	if err := tx.QueryRow(ctx,
+		`SELECT EXISTS (SELECT 1 FROM schema_migrations WHERE id = $1)`,
+		usageTotalsMigrationID,
+	).Scan(&applied); err != nil {
+		return "", fmt.Errorf("check final migration marker: %w", err)
+	}
+	if applied {
+		if err := tx.Commit(ctx); err != nil {
+			return "", fmt.Errorf("commit finalized skip: %w", err)
+		}
+		return usageTotalsMigrationSkipped, nil
+	}
+
+	var cutoffID int64
+	if err := tx.QueryRow(ctx,
+		`SELECT cutoff_id FROM usage_totals_backfill_state WHERE id = 1`,
+	).Scan(&cutoffID); err != nil {
+		return "", fmt.Errorf("read final backfill checkpoint: %w", err)
+	}
+	if cutoffID != expectedCutoffID {
+		return "", fmt.Errorf("backfill cutoff changed from %d to %d", expectedCutoffID, cutoffID)
+	}
+
+	var requests, promptTokens, completionTokens int64
+	if err := tx.QueryRow(ctx, `
+		SELECT
+			COUNT(*),
+			COALESCE(SUM(prompt_tokens), 0),
+			COALESCE(SUM(completion_tokens), 0)
+		FROM usage
+		WHERE id <= $1`,
+		cutoffID,
+	).Scan(&requests, &promptTokens, &completionTokens); err != nil {
+		return "", fmt.Errorf("aggregate historical usage: %w", err)
+	}
+	tag, err := tx.Exec(ctx, `
+		UPDATE usage_totals SET
+			total_requests = total_requests + $1,
+			total_prompt_tokens = total_prompt_tokens + $2,
+			total_completion_tokens = total_completion_tokens + $3
+		WHERE id = 1`,
+		requests, promptTokens, completionTokens,
+	)
+	if err != nil {
+		return "", fmt.Errorf("apply historical usage: %w", err)
+	}
+	if tag.RowsAffected() != 1 {
+		return "", fmt.Errorf("apply historical usage: updated %d rows, want 1", tag.RowsAffected())
+	}
+	if _, err := tx.Exec(ctx,
+		`INSERT INTO schema_migrations (id) VALUES ($1)`,
+		usageTotalsMigrationID,
+	); err != nil {
+		return "", fmt.Errorf("record migration marker: %w", err)
+	}
+	tag, err = tx.Exec(ctx, `DELETE FROM usage_totals_backfill_state WHERE id = 1`)
+	if err != nil {
+		return "", fmt.Errorf("clear backfill checkpoint: %w", err)
+	}
+	if tag.RowsAffected() != 1 {
+		return "", fmt.Errorf("clear backfill checkpoint: deleted %d rows, want 1", tag.RowsAffected())
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return "", fmt.Errorf("commit finalization: %w", err)
+	}
+	return usageTotalsMigrationBackfilled, nil
+}
+
+func acquireUsageTotalsMigrationLock(ctx context.Context, tx pgx.Tx) error {
 	if _, err := tx.Exec(ctx, `
 		SELECT pg_advisory_xact_lock(
 			hashtext(current_schema()),
@@ -57,44 +246,7 @@ func (s *PostgresStore) applyUsageTotalsMigration(ctx context.Context) (usageTot
 		)`,
 		usageTotalsMigrationID,
 	); err != nil {
-		return "", fmt.Errorf("acquire migration lock: %w", err)
+		return fmt.Errorf("acquire migration lock: %w", err)
 	}
-
-	var exists bool
-	if err := tx.QueryRow(ctx,
-		`SELECT EXISTS (SELECT 1 FROM usage_totals WHERE id = 1)`,
-	).Scan(&exists); err != nil {
-		return "", fmt.Errorf("check counter row: %w", err)
-	}
-	if exists {
-		if err := tx.Commit(ctx); err != nil {
-			return "", fmt.Errorf("commit skip: %w", err)
-		}
-		return usageTotalsMigrationSkipped, nil
-	}
-
-	tag, err := tx.Exec(ctx, `
-		INSERT INTO usage_totals (
-			id,
-			total_requests,
-			total_prompt_tokens,
-			total_completion_tokens
-		)
-		SELECT
-			1,
-			COUNT(*),
-			COALESCE(SUM(prompt_tokens), 0),
-			COALESCE(SUM(completion_tokens), 0)
-		FROM usage
-		ON CONFLICT (id) DO NOTHING`)
-	if err != nil {
-		return "", fmt.Errorf("aggregate usage: %w", err)
-	}
-	if tag.RowsAffected() != 1 {
-		return "", fmt.Errorf("initialize counter row: inserted %d rows, want 1", tag.RowsAffected())
-	}
-	if err := tx.Commit(ctx); err != nil {
-		return "", fmt.Errorf("commit backfill: %w", err)
-	}
-	return usageTotalsMigrationBackfilled, nil
+	return nil
 }

--- a/coordinator/store/postgres_usage_totals_migration.go
+++ b/coordinator/store/postgres_usage_totals_migration.go
@@ -1,0 +1,109 @@
+package store
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+)
+
+const usageTotalsMigrationID = "backfill_usage_totals_v1"
+
+type usageTotalsMigrationResult string
+
+const (
+	usageTotalsMigrationBackfilled usageTotalsMigrationResult = "backfilled"
+	usageTotalsMigrationSkipped    usageTotalsMigrationResult = "already_applied"
+)
+
+// migrateUsageTotals records startup observability around the one-time usage
+// aggregation without exposing usage values.
+func (s *PostgresStore) migrateUsageTotals(ctx context.Context) error {
+	started := time.Now()
+	result, err := s.applyUsageTotalsMigration(ctx)
+	if err != nil {
+		slog.Error("postgres migration failed",
+			"migration", usageTotalsMigrationID,
+			"result", "failed",
+			"duration_ms", time.Since(started).Milliseconds())
+		return fmt.Errorf("store: migrate usage totals: %w", err)
+	}
+	slog.Info("postgres migration completed",
+		"migration", usageTotalsMigrationID,
+		"result", string(result),
+		"duration_ms", time.Since(started).Milliseconds())
+	return nil
+}
+
+// applyUsageTotalsMigration checks the counter row before touching the usage
+// table. The old INSERT ... SELECT ... ON CONFLICT statement still evaluated
+// the full aggregate before discovering the conflict, so every restart scanned
+// all historical usage.
+//
+// The transaction-scoped advisory lock serializes concurrent coordinators. On
+// the first run, the table lock establishes an exact cutover: existing usage
+// writers finish before the aggregate snapshot, while new writers wait until
+// the counter row exists and can increment it. Every later startup takes only
+// the advisory lock and primary-key existence check.
+func (s *PostgresStore) applyUsageTotalsMigration(ctx context.Context) (usageTotalsMigrationResult, error) {
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return "", fmt.Errorf("begin: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	if _, err := tx.Exec(ctx, `
+		SELECT pg_advisory_xact_lock(
+			hashtext(current_schema()),
+			hashtext($1)
+		)`,
+		usageTotalsMigrationID,
+	); err != nil {
+		return "", fmt.Errorf("acquire migration lock: %w", err)
+	}
+
+	var exists bool
+	if err := tx.QueryRow(ctx,
+		`SELECT EXISTS (SELECT 1 FROM usage_totals WHERE id = 1)`,
+	).Scan(&exists); err != nil {
+		return "", fmt.Errorf("check counter row: %w", err)
+	}
+	if exists {
+		if err := tx.Commit(ctx); err != nil {
+			return "", fmt.Errorf("commit skip: %w", err)
+		}
+		return usageTotalsMigrationSkipped, nil
+	}
+
+	// Usage inserts take ROW EXCLUSIVE, which conflicts with SHARE. Once this
+	// lock is granted, the aggregate includes every committed insert and later
+	// inserts wait until the initialized counter row commits.
+	if _, err := tx.Exec(ctx, `LOCK TABLE usage IN SHARE MODE`); err != nil {
+		return "", fmt.Errorf("lock usage table: %w", err)
+	}
+
+	tag, err := tx.Exec(ctx, `
+		INSERT INTO usage_totals (
+			id,
+			total_requests,
+			total_prompt_tokens,
+			total_completion_tokens
+		)
+		SELECT
+			1,
+			COUNT(*),
+			COALESCE(SUM(prompt_tokens), 0),
+			COALESCE(SUM(completion_tokens), 0)
+		FROM usage
+		ON CONFLICT (id) DO NOTHING`)
+	if err != nil {
+		return "", fmt.Errorf("aggregate usage: %w", err)
+	}
+	if tag.RowsAffected() != 1 {
+		return "", fmt.Errorf("initialize counter row: inserted %d rows, want 1", tag.RowsAffected())
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return "", fmt.Errorf("commit backfill: %w", err)
+	}
+	return usageTotalsMigrationBackfilled, nil
+}

--- a/coordinator/store/postgres_usage_totals_migration.go
+++ b/coordinator/store/postgres_usage_totals_migration.go
@@ -40,11 +40,9 @@ func (s *PostgresStore) migrateUsageTotals(ctx context.Context) error {
 // the full aggregate before discovering the conflict, so every restart scanned
 // all historical usage.
 //
-// The transaction-scoped advisory lock serializes concurrent coordinators. On
-// the first run, the table lock establishes an exact cutover: existing usage
-// writers finish before the aggregate snapshot, while new writers wait until
-// the counter row exists and can increment it. Every later startup takes only
-// the advisory lock and primary-key existence check.
+// The transaction-scoped advisory lock serializes concurrent coordinators
+// without blocking usage writers. Every later startup takes only that lock and
+// a primary-key existence check.
 func (s *PostgresStore) applyUsageTotalsMigration(ctx context.Context) (usageTotalsMigrationResult, error) {
 	tx, err := s.pool.Begin(ctx)
 	if err != nil {
@@ -73,13 +71,6 @@ func (s *PostgresStore) applyUsageTotalsMigration(ctx context.Context) (usageTot
 			return "", fmt.Errorf("commit skip: %w", err)
 		}
 		return usageTotalsMigrationSkipped, nil
-	}
-
-	// Usage inserts take ROW EXCLUSIVE, which conflicts with SHARE. Once this
-	// lock is granted, the aggregate includes every committed insert and later
-	// inserts wait until the initialized counter row commits.
-	if _, err := tx.Exec(ctx, `LOCK TABLE usage IN SHARE MODE`); err != nil {
-		return "", fmt.Errorf("lock usage table: %w", err)
 	}
 
 	tag, err := tx.Exec(ctx, `

--- a/coordinator/store/postgres_usage_totals_migration_test.go
+++ b/coordinator/store/postgres_usage_totals_migration_test.go
@@ -1,0 +1,155 @@
+package store
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestMigrateNoUngatedUsageTotalsAggregation(t *testing.T) {
+	src, err := os.ReadFile("postgres.go")
+	if err != nil {
+		t.Fatalf("read postgres.go: %v", err)
+	}
+	if bytes.Contains(src, []byte("INSERT INTO usage_totals")) {
+		t.Fatal("usage_totals aggregation must not run in the unconditional startup statement list")
+	}
+}
+
+func TestUsageTotalsMigrationBackfillsOnceWithoutRescanningUsage(t *testing.T) {
+	databaseURL := newWithdrawableTestDatabase(t)
+	s := newWithdrawableMigrationStore(t, databaseURL)
+	prepareUsageTotalsMigrationSchema(t, s)
+	seedUsageForTotalsMigration(t, s, 10, 20)
+	seedUsageForTotalsMigration(t, s, 30, 40)
+
+	result, err := s.applyUsageTotalsMigration(context.Background())
+	if err != nil {
+		t.Fatalf("first migration: %v", err)
+	}
+	if result != usageTotalsMigrationBackfilled {
+		t.Fatalf("first result = %q, want %q", result, usageTotalsMigrationBackfilled)
+	}
+	assertUsageTotalsMigrationValues(t, s, 2, 40, 60)
+
+	// Hold ACCESS EXCLUSIVE on usage. Any SELECT against it must block, while
+	// the already-applied fast path should only inspect usage_totals.
+	lockTx, err := s.pool.Begin(context.Background())
+	if err != nil {
+		t.Fatalf("begin table lock: %v", err)
+	}
+	defer lockTx.Rollback(context.Background())
+	if _, err := lockTx.Exec(context.Background(), `LOCK TABLE usage IN ACCESS EXCLUSIVE MODE`); err != nil {
+		t.Fatalf("lock usage: %v", err)
+	}
+
+	restartCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	result, err = s.applyUsageTotalsMigration(restartCtx)
+	if err != nil {
+		t.Fatalf("restart migration touched locked usage table: %v", err)
+	}
+	if result != usageTotalsMigrationSkipped {
+		t.Fatalf("restart result = %q, want %q", result, usageTotalsMigrationSkipped)
+	}
+	assertUsageTotalsMigrationValues(t, s, 2, 40, 60)
+}
+
+func TestUsageTotalsMigrationSerializesConcurrentCoordinators(t *testing.T) {
+	databaseURL := newWithdrawableTestDatabase(t)
+	first := newWithdrawableMigrationStore(t, databaseURL)
+	second := newWithdrawableMigrationStore(t, databaseURL)
+	prepareUsageTotalsMigrationSchema(t, first)
+	seedUsageForTotalsMigration(t, first, 10, 20)
+	seedUsageForTotalsMigration(t, first, 30, 40)
+
+	start := make(chan struct{})
+	results := make(chan usageTotalsMigrationResult, 2)
+	errs := make(chan error, 2)
+	var wg sync.WaitGroup
+	for _, replica := range []*PostgresStore{first, second} {
+		wg.Add(1)
+		go func(s *PostgresStore) {
+			defer wg.Done()
+			<-start
+			result, err := s.applyUsageTotalsMigration(context.Background())
+			results <- result
+			errs <- err
+		}(replica)
+	}
+	close(start)
+	wg.Wait()
+	close(results)
+	close(errs)
+
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("concurrent migration: %v", err)
+		}
+	}
+	counts := map[usageTotalsMigrationResult]int{}
+	for result := range results {
+		counts[result]++
+	}
+	if counts[usageTotalsMigrationBackfilled] != 1 || counts[usageTotalsMigrationSkipped] != 1 {
+		t.Fatalf("concurrent results = %v, want one backfill and one skip", counts)
+	}
+	assertUsageTotalsMigrationValues(t, first, 2, 40, 60)
+}
+
+func prepareUsageTotalsMigrationSchema(t *testing.T, s *PostgresStore) {
+	t.Helper()
+	for _, statement := range []string{
+		`CREATE TABLE usage (
+			id BIGSERIAL PRIMARY KEY,
+			prompt_tokens INTEGER NOT NULL,
+			completion_tokens INTEGER NOT NULL
+		)`,
+		`CREATE TABLE usage_totals (
+			id INTEGER PRIMARY KEY DEFAULT 1 CHECK (id = 1),
+			total_requests BIGINT NOT NULL DEFAULT 0,
+			total_prompt_tokens BIGINT NOT NULL DEFAULT 0,
+			total_completion_tokens BIGINT NOT NULL DEFAULT 0
+		)`,
+	} {
+		if _, err := s.pool.Exec(context.Background(), statement); err != nil {
+			t.Fatalf("prepare usage totals migration schema: %v", err)
+		}
+	}
+}
+
+func seedUsageForTotalsMigration(t *testing.T, s *PostgresStore, promptTokens, completionTokens int) {
+	t.Helper()
+	if _, err := s.pool.Exec(context.Background(),
+		`INSERT INTO usage (prompt_tokens, completion_tokens) VALUES ($1, $2)`,
+		promptTokens, completionTokens,
+	); err != nil {
+		t.Fatalf("seed usage: %v", err)
+	}
+}
+
+func assertUsageTotalsMigrationValues(
+	t *testing.T,
+	s *PostgresStore,
+	requests, promptTokens, completionTokens int64,
+) {
+	t.Helper()
+	var gotRequests, gotPromptTokens, gotCompletionTokens int64
+	if err := s.pool.QueryRow(context.Background(), `
+		SELECT total_requests, total_prompt_tokens, total_completion_tokens
+		FROM usage_totals
+		WHERE id = 1`,
+	).Scan(&gotRequests, &gotPromptTokens, &gotCompletionTokens); err != nil {
+		t.Fatalf("read usage totals: %v", err)
+	}
+	if gotRequests != requests || gotPromptTokens != promptTokens || gotCompletionTokens != completionTokens {
+		t.Fatalf(
+			"usage totals = (%d, %d, %d), want (%d, %d, %d)",
+			gotRequests, gotPromptTokens, gotCompletionTokens,
+			requests, promptTokens, completionTokens,
+		)
+	}
+}

--- a/coordinator/store/postgres_usage_totals_migration_test.go
+++ b/coordinator/store/postgres_usage_totals_migration_test.go
@@ -3,8 +3,8 @@ package store
 import (
 	"bytes"
 	"context"
+	"errors"
 	"os"
-	"sync"
 	"testing"
 	"time"
 )
@@ -66,36 +66,40 @@ func TestUsageTotalsMigrationSerializesConcurrentCoordinators(t *testing.T) {
 	seedUsageForTotalsMigration(t, first, 10, 20)
 	seedUsageForTotalsMigration(t, first, 30, 40)
 
-	start := make(chan struct{})
-	results := make(chan usageTotalsMigrationResult, 2)
-	errs := make(chan error, 2)
-	var wg sync.WaitGroup
-	for _, replica := range []*PostgresStore{first, second} {
-		wg.Add(1)
-		go func(s *PostgresStore) {
-			defer wg.Done()
-			<-start
-			result, err := s.applyUsageTotalsMigration(context.Background())
-			results <- result
-			errs <- err
-		}(replica)
+	// Hold the exact migration advisory lock from a separate transaction. A
+	// contender must time out at lock acquisition rather than reaching the
+	// aggregate, proving the serialization does not depend on goroutine timing.
+	lockTx, err := first.pool.Begin(context.Background())
+	if err != nil {
+		t.Fatalf("begin advisory lock: %v", err)
 	}
-	close(start)
-	wg.Wait()
-	close(results)
-	close(errs)
+	defer lockTx.Rollback(context.Background())
+	if _, err := lockTx.Exec(context.Background(), `
+		SELECT pg_advisory_xact_lock(
+			hashtext(current_schema()),
+			hashtext($1)
+		)`,
+		usageTotalsMigrationID,
+	); err != nil {
+		t.Fatalf("hold advisory lock: %v", err)
+	}
 
-	for err := range errs {
-		if err != nil {
-			t.Fatalf("concurrent migration: %v", err)
-		}
+	blockedCtx, cancel := context.WithTimeout(context.Background(), 250*time.Millisecond)
+	defer cancel()
+	if _, err := second.applyUsageTotalsMigration(blockedCtx); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("contending migration error = %v, want context deadline at advisory lock", err)
 	}
-	counts := map[usageTotalsMigrationResult]int{}
-	for result := range results {
-		counts[result]++
+	if err := lockTx.Commit(context.Background()); err != nil {
+		t.Fatalf("release advisory lock: %v", err)
 	}
-	if counts[usageTotalsMigrationBackfilled] != 1 || counts[usageTotalsMigrationSkipped] != 1 {
-		t.Fatalf("concurrent results = %v, want one backfill and one skip", counts)
+
+	result, err := first.applyUsageTotalsMigration(context.Background())
+	if err != nil || result != usageTotalsMigrationBackfilled {
+		t.Fatalf("first migration after lock release = (%q, %v), want backfilled", result, err)
+	}
+	result, err = second.applyUsageTotalsMigration(context.Background())
+	if err != nil || result != usageTotalsMigrationSkipped {
+		t.Fatalf("second migration = (%q, %v), want already-applied", result, err)
 	}
 	assertUsageTotalsMigrationValues(t, first, 2, 40, 60)
 }

--- a/coordinator/store/postgres_usage_totals_migration_test.go
+++ b/coordinator/store/postgres_usage_totals_migration_test.go
@@ -58,6 +58,82 @@ func TestUsageTotalsMigrationBackfillsOnceWithoutRescanningUsage(t *testing.T) {
 	assertUsageTotalsMigrationValues(t, s, 2, 40, 60)
 }
 
+func TestUsageTotalsMigrationAdoptsExistingCounterWithoutScanningUsage(t *testing.T) {
+	databaseURL := newWithdrawableTestDatabase(t)
+	s := newWithdrawableMigrationStore(t, databaseURL)
+	prepareUsageTotalsMigrationSchema(t, s)
+	if _, err := s.pool.Exec(context.Background(), `
+		INSERT INTO usage_totals (
+			id,
+			total_requests,
+			total_prompt_tokens,
+			total_completion_tokens
+		) VALUES (1, 7, 80, 90)`); err != nil {
+		t.Fatalf("seed existing counter: %v", err)
+	}
+
+	lockTx, err := s.pool.Begin(context.Background())
+	if err != nil {
+		t.Fatalf("begin table lock: %v", err)
+	}
+	defer lockTx.Rollback(context.Background())
+	if _, err := lockTx.Exec(context.Background(), `LOCK TABLE usage IN ACCESS EXCLUSIVE MODE`); err != nil {
+		t.Fatalf("lock usage: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	result, err := s.applyUsageTotalsMigration(ctx)
+	if err != nil {
+		t.Fatalf("adopt existing counter touched locked usage table: %v", err)
+	}
+	if result != usageTotalsMigrationPreserved {
+		t.Fatalf("adoption result = %q, want %q", result, usageTotalsMigrationPreserved)
+	}
+	assertUsageTotalsMigrationValues(t, s, 7, 80, 90)
+}
+
+func TestUsageTotalsMigrationResumesAfterCutoverWithoutLosingNewWrites(t *testing.T) {
+	databaseURL := newWithdrawableTestDatabase(t)
+	first := newWithdrawableMigrationStore(t, databaseURL)
+	restart := newWithdrawableMigrationStore(t, databaseURL)
+	prepareUsageTotalsMigrationSchema(t, first)
+	seedUsageForTotalsMigration(t, first, 10, 20)
+	seedUsageForTotalsMigration(t, first, 30, 40)
+
+	preparation, err := first.prepareUsageTotalsMigration(context.Background())
+	if err != nil {
+		t.Fatalf("prepare migration: %v", err)
+	}
+	if preparation.Result != "" || preparation.CutoffID != 2 {
+		t.Fatalf("preparation = %+v, want pending cutoff 2", preparation)
+	}
+
+	// This is the production write shape: the row lands after the persisted
+	// cutoff and increments the now-present counter before historical finalize.
+	if _, err := first.pool.Exec(context.Background(), `
+		WITH ins AS (
+			INSERT INTO usage (prompt_tokens, completion_tokens)
+			VALUES (50, 60)
+		)
+		UPDATE usage_totals SET
+			total_requests = total_requests + 1,
+			total_prompt_tokens = total_prompt_tokens + 50,
+			total_completion_tokens = total_completion_tokens + 60
+		WHERE id = 1`); err != nil {
+		t.Fatalf("record post-cutoff usage: %v", err)
+	}
+
+	result, err := restart.applyUsageTotalsMigration(context.Background())
+	if err != nil {
+		t.Fatalf("resume migration: %v", err)
+	}
+	if result != usageTotalsMigrationBackfilled {
+		t.Fatalf("resume result = %q, want %q", result, usageTotalsMigrationBackfilled)
+	}
+	assertUsageTotalsMigrationValues(t, restart, 3, 90, 120)
+}
+
 func TestUsageTotalsMigrationSerializesConcurrentCoordinators(t *testing.T) {
 	databaseURL := newWithdrawableTestDatabase(t)
 	first := newWithdrawableMigrationStore(t, databaseURL)
@@ -107,6 +183,10 @@ func TestUsageTotalsMigrationSerializesConcurrentCoordinators(t *testing.T) {
 func prepareUsageTotalsMigrationSchema(t *testing.T, s *PostgresStore) {
 	t.Helper()
 	for _, statement := range []string{
+		`CREATE TABLE schema_migrations (
+			id TEXT PRIMARY KEY,
+			applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+		)`,
 		`CREATE TABLE usage (
 			id BIGSERIAL PRIMARY KEY,
 			prompt_tokens INTEGER NOT NULL,
@@ -117,6 +197,10 @@ func prepareUsageTotalsMigrationSchema(t *testing.T, s *PostgresStore) {
 			total_requests BIGINT NOT NULL DEFAULT 0,
 			total_prompt_tokens BIGINT NOT NULL DEFAULT 0,
 			total_completion_tokens BIGINT NOT NULL DEFAULT 0
+		)`,
+		`CREATE TABLE usage_totals_backfill_state (
+			id INTEGER PRIMARY KEY DEFAULT 1 CHECK (id = 1),
+			cutoff_id BIGINT NOT NULL
 		)`,
 	} {
 		if _, err := s.pool.Exec(context.Background(), statement); err != nil {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Make the `usage_totals` backfill genuinely one-time and lossless under concurrent writes. Existing deployments adopt the already-populated counter without scanning `usage`; fresh databases use a durable two-phase cutoff so the historical scan runs without holding a writer-blocking table lock.

## Linked issue

N/A

## Before

```mermaid
flowchart LR
  subgraph Behavior
    B1[Coordinator startup] --> B2[Aggregate every usage row]
    B2 --> B3[Discover usage_totals conflict]
    B3 --> B4[Bind HTTP listener late]
  end
  subgraph Code
    C1[NewPostgres] --> C2[migrate statement loop]
    C2 --> C3[INSERT SELECT FROM usage ON CONFLICT]
  end
```

## After

```mermaid
flowchart LR
  subgraph Behavior
    B1[Coordinator startup] --> B2{Applied marker or existing counter?}
    B2 -->|Yes| B3[Skip historical usage entirely]
    B2 -->|No| B4[Briefly fence inserts and persist max usage ID]
    B4 --> B5[Resume writers against zero counter]
    B5 --> B6[Aggregate only historical IDs]
    B6 --> B7[Atomically add baseline and mark complete]
    B3 --> B8[Continue startup]
    B7 --> B8
  end
  subgraph Code
    C1[NewPostgres] --> C2[migrateUsageTotals]
    C2 --> C3[prepareUsageTotalsMigration]
    C3 --> C4[usage_totals_backfill_state cutoff]
    C4 --> C5[finalizeUsageTotalsMigration]
    C5 --> C6[schema_migrations marker]
  end
```

## Test plan

- [x] `DATABASE_URL=... go test ./store -run 'Test(MigrateNoUngatedUsageTotalsAggregation|UsageTotalsMigration)' -count=10`
- [x] `DATABASE_URL=... go test ./store -count=1`
- [x] `go test -count=1 ./...`
- [x] `go vet ./store`

## Components touched

- [x] coordinator (Go)
- [ ] provider (Rust, legacy)
- [ ] provider-swift (Swift CLI)
- [ ] console-ui (Next.js)
- [ ] enclave (Swift)
- [ ] infra / CI / release
- [ ] docs

## Protocol / interface changes

- [x] No protocol/interface changes
- [ ] Yes — described above and matching side updated

## Notes for reviewers

The old `ON CONFLICT DO NOTHING` was not a fast path: PostgreSQL evaluated the aggregate source before checking the destination conflict. The new checkpoint captures a stable ID cutoff while inserts are fenced only for a primary-key `MAX(id)`, counter insert, and checkpoint insert. The full scan happens after writers resume; post-cutoff writes increment the live counter while finalization atomically adds only `id <= cutoff`. An interrupted process resumes from the checkpoint without double-counting.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-862f7f7c-32fb-47cb-8ff6-6331369ee388?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-862f7f7c-32fb-47cb-8ff6-6331369ee388&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/665"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789976772&installation_model_id=21733&pr_number=665&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F665&signature=dc1a1a886504d5700798108e3d2b54b4bdeeee0935f56473ae68d08fa0c85520"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->