### PR TITLE
docs: propose Darkbloom sandbox platform

### DIFF
--- a/docs/reports/2026-08-22-sandbox-economics.md
+++ b/docs/reports/2026-08-22-sandbox-economics.md
@@ -1,0 +1,433 @@
+# Sandbox economics and pricing
+
+Status: **proposed model; rate card requires measured alpha data**
+
+Date: 2026-08-22
+
+Parent plan: [Darkbloom sandbox platform plan](2026-08-22-sandbox-platform-plan.md)
+
+User experience: [Provider and developer experience](2026-08-22-sandbox-user-experience.md)
+
+## 1. Bottom line
+
+Darkbloom can compete with E2B's public CPU/RAM rates on hardware economics.
+Electricity is not the limiting cost. At a modeled 90 W active draw and the May
+2026 U.S. average commercial electricity price, power is about **$0.012 per
+host-hour**. Hardware amortization, utilization, provider reliability, support,
+and startup latency matter much more.
+
+A representative 10-vCPU/48-GiB allocatable Mac host produces **$1.2816 per
+fully allocated hour** at E2B's published resource rates. Under the disclosed
+sample assumptions below, the host costs **$0.18–$0.43 per billable host-hour**
+at 75%–25% utilization. At 50% utilization the modeled cost is **$0.242/hour**.
+
+That does not mean Darkbloom should sell macOS at Linux parity. macOS supply,
+chip selection, GUI automation, and exclusive-host guarantees are
+differentiated. The recommended launch price is:
+
+- Linux at the E2B resource benchmark;
+- standard macOS at **1.5×** the resource benchmark;
+- computer-use macOS at **1.875×** before video egress;
+- exact-chip selection as a visible supply premium; and
+- timing-sensitive GPU/CPU as a whole-host quote, never a fictional fractional
+  GPU reservation.
+
+There is no 24-hour compute floor in this model. Stopped sandboxes incur
+retained-storage charges only.
+
+## 2. External price benchmark
+
+As checked on 2026-08-22, E2B publishes:
+
+| Resource | Per second | Per hour |
+|---|---:|---:|
+| vCPU | $0.000014 | **$0.0504** |
+| RAM GiB | $0.0000045 | **$0.0162** |
+
+Sources:
+
+- [E2B sandbox price calculation](https://e2b.dev/docs/faq/calculate-sandbox-price)
+- [E2B billing](https://e2b.dev/docs/billing)
+- [E2B pricing](https://www.e2b.dev/pricing)
+
+E2B charges while a sandbox is running and includes a plan-dependent disk
+allowance. Its Pro plan also has a fixed subscription fee. The comparison below
+uses only public usage rates because Darkbloom's differentiated Mac product
+should not depend on a subscription floor to make a job economical.
+
+A vCPU is not a standardized unit of performance across Apple performance and
+efficiency cores, cloud x86, and oversubscribed hosts. E2B is a price benchmark,
+not a claim of equal per-vCPU speed. Darkbloom must publish chip and benchmark
+class with each quote.
+
+## 3. First-principles host-cost model
+
+For one host:
+
+```text
+active_host_cost_per_hour =
+    (purchase_price - salvage_value)
+      / (economic_life_hours × billable_utilization)
+  + active_power_kW × electricity_price_per_kWh
+  + network_facility_and_wear_per_active_hour
+  + expected_failure_and_support_cost_per_active_hour
+```
+
+Definitions:
+
+- **Billable utilization** is the fraction of calendar hours that produce
+  settled compute revenue. It is not CPU utilization inside a running VM.
+- **Economic life** ends when the machine is replaced for reliability or
+  product competitiveness, even if it still boots.
+- **Host cost** must be compared with the full CPU+RAM bundle. Assigning every
+  dollar to CPU and then charging memory again double-counts cost.
+- Payment processing, control-plane compute, taxes, refunds, fraud, support,
+  and corporate overhead belong in platform margin, not in electricity.
+
+## 4. Worked Mac example
+
+This is a sensitivity model, not a hardware quote.
+
+| Input | Assumption | Basis |
+|---|---:|---|
+| Host purchase price | $2,500 | Replace with actual delivered price |
+| Salvage value | $0 | Conservative |
+| Economic life | 3 years / 26,280 hours | Planning assumption |
+| Allocatable vCPU | 10 | Leaves 2–4 physical cores for host duties depending on SKU |
+| Allocatable memory | 48 GiB | Leaves 16 GiB on a 64-GiB host |
+| Average active draw | 90 W | Modeled between Apple's 5 W idle and 140 W maximum data |
+| Electricity | $0.1354/kWh | U.S. commercial average, May 2026 |
+| Network/facility/SSD/failure placeholder | $0.04/active hour | Must be replaced by observed provider cost |
+
+Apple publishes 5 W idle and 140 W maximum power for a 64-GiB M4 Pro Mac mini
+configuration. The 90 W row is deliberately a model input, not a claim that
+every workload consumes 90 W. Source:
+[Apple Mac mini power consumption](https://support.apple.com/en-us/103253).
+
+The U.S. Energy Information Administration reports a May 2026 average
+commercial price of 13.54 cents/kWh. Source:
+[EIA Electricity Monthly Update](https://www.eia.gov/electricity/monthly/update/end-use.php).
+
+### 4.1 Cost sensitivity
+
+| Billable utilization | Amortization per active hour | Power | Other placeholder | Total active host cost |
+|---:|---:|---:|---:|---:|
+| 25% | $0.3805 | $0.0122 | $0.0400 | **$0.4327** |
+| 50% | $0.1903 | $0.0122 | $0.0400 | **$0.2424** |
+| 75% | $0.1268 | $0.0122 | $0.0400 | **$0.1790** |
+
+If the full host cost were divided only by ten allocatable vCPUs, it would be
+1.79–4.33 cents per vCPU-hour across this utilization range. That number is
+useful as an upper bound on CPU cost but is not a valid standalone rate because
+the same machine also sells memory.
+
+### 4.2 Revenue at the E2B benchmark
+
+```text
+10 vCPU × $0.0504/hour       = $0.5040/hour
+48 GiB × $0.0162/GiB-hour   = $0.7776/hour
+------------------------------------------------
+full host resource revenue  = $1.2816/hour
+```
+
+| Billable utilization | Modeled cost | Benchmark revenue | Gross headroom before platform overhead |
+|---:|---:|---:|---:|
+| 25% | $0.4327 | $1.2816 | **66.2%** |
+| 50% | $0.2424 | $1.2816 | **81.1%** |
+| 75% | $0.1790 | $1.2816 | **86.0%** |
+
+The headroom is not net profit. It must fund:
+
+- provider payout and platform margin;
+- unused resource fragments between sandbox shapes;
+- failed boots and non-billable preparation;
+- image distribution and snapshot transfer;
+- relays/TURN and internet egress;
+- Stripe and fraud loss;
+- support and provider operations;
+- warranty failures and spare capacity; and
+- taxes and legal/compliance work.
+
+Even after those deductions, electricity is visibly not the economic blocker.
+
+### 4.3 Provider break-even illustration
+
+If a provider receives 70% of E2B-benchmark resource revenue:
+
+```text
+provider revenue at full allocation = $1.2816 × 70% = $0.89712/active hour
+```
+
+With the same $2,500 host, three-year life, 90 W power, and $0.04/hour
+placeholder, the modeled capital break-even utilization is about **11.3%**.
+This is a sensitivity result, not a promised return. A provider with expensive
+power, managed hosting, financing, labor, poor reliability, or a shorter
+replacement cycle has a higher threshold.
+
+## 5. Recommended launch rate card
+
+Keep one composable formula:
+
+```text
+charge =
+  runtime_seconds × (
+      vCPU_count × vCPU_rate
+    + memory_GiB × memory_rate
+    + OS_scarcity_premium
+    + chip_premium
+    + computer_use_premium
+    + exclusive_host_premium
+  )
+  + successful_boot_fee
+  + retained_byte_seconds × storage_rate
+  + metered_network_egress
+```
+
+All dimensions appear in the quote. No multiplier is hidden after execution.
+
+### 5.1 Base resource rates
+
+| Product | vCPU-hour | GiB-hour | Rationale |
+|---|---:|---:|---|
+| Linux Sandbox | $0.0504 | $0.0162 | Match E2B's public usage benchmark |
+| macOS Sandbox | Base × 1.5 total | Base × 1.5 total | Scarcity and Apple-specific capability |
+| macOS Computer | Base × 1.875 total | Base × 1.875 total | macOS 1.5× plus 25% GUI/driver capacity premium |
+
+The implementation should store separate base and premium line items even when
+the launch UI presents a multiplier. This allows chip and computer-use supply
+to move independently later.
+
+### 5.2 Example hourly prices
+
+| Shape | Base CPU+RAM | Linux | macOS 1.5× | macOS Computer 1.875× |
+|---|---:|---:|---:|---:|
+| 4 vCPU / 8 GiB | $0.3312 | $0.3312 | **$0.4968** | **$0.6210** |
+| 6 vCPU / 16 GiB | $0.5616 | $0.5616 | **$0.8424** | **$1.0530** |
+| 8 vCPU / 32 GiB | $0.9216 | $0.9216 | **$1.3824** | **$1.7280** |
+| 10 vCPU / 48 GiB host | $1.2816 | $1.2816 | **$1.9224** | **$2.4030** |
+
+A 15-minute 4-vCPU/8-GiB macOS command has a maximum compute hold of
+**$0.1242** before any successful boot fee or network egress.
+
+### 5.3 Exact-chip premium
+
+Exact-chip selection is a supply constraint, not a cosmetic label.
+
+Recommended alpha policy:
+
+- no premium for a portable minimum benchmark class;
+- 10–40% of base CPU+RAM price for an exact scarce chip, bounded by the
+  provider's posted offer and displayed before creation; and
+- no claim or price for a chip that has not passed Darkbloom's benchmark and
+  attestation checks.
+
+An `M5` request is therefore a hard filter with an explicit quote, not an
+assumption about current availability.
+
+### 5.4 Exclusive host and GPU
+
+Virtualization.framework does not expose fractional GPU partitioning or vCPU
+core pinning. Price timing-sensitive work as a host reservation:
+
+```text
+exclusive price =
+  max(full allocatable host resource quote, provider exclusive floor)
+  + 20% exclusivity premium
+```
+
+The host must drain inference and every other sandbox before the reservation
+starts. The quote names the physical chip and benchmark result. "20 GPU cores"
+describes hardware; it does not promise 20 isolated guest GPU cores.
+
+Do not offer an SLA for guest Metal compute until the specific application is
+benchmarked. Apple's macOS guest uses a paravirtualized graphics path rather
+than true device passthrough, and exposed capabilities can differ from the host.
+
+### 5.5 Boot fee
+
+Preparation consumes provider resources before compute billing begins. Use a
+small successful boot fee only if alpha measurements show it is necessary:
+
+- warm boot: zero or minimal fee;
+- cold base-image download: developer sees the fee in advance;
+- failed prepare/boot: zero charge; and
+- provider payout only after guest readiness.
+
+Do not recover failed-start cost through an opaque minimum command charge.
+
+## 6. Storage economics
+
+The developer selects a 25- or 50-GiB logical quota. Sparse unused bytes cost
+nothing and should not be billed as if written.
+
+Recommended alpha storage policy:
+
+- base images: free to the developer and not counted as tenant storage;
+- workspace while compute is running: included up to the selected quota;
+- stopped/retained workspace: **$0.08 per actual encrypted GiB-month**;
+- transfer/replication: included within a published monthly allowance, then
+  passed through; and
+- deletion: billing ends when key wrappers are tombstoned, not when background
+  ciphertext reclamation finishes.
+
+At that rate:
+
+| Actual retained bytes | Monthly charge |
+|---:|---:|
+| 5 GiB | $0.40 |
+| 25 GiB | $2.00 |
+| 50 GiB | $4.00 |
+
+The rate is intentionally above raw SSD depreciation because it also funds
+reservation, verification, encrypted snapshot movement, host churn, and a
+portable recovery copy.
+
+For comparison, a hypothetical $200 2-TB SSD amortized over 36 months at 50%
+sold utilization costs roughly **$0.0056/GiB-month** before writes, failures,
+replication, transfer, and operations. Raw media is not the expensive part;
+durability and availability are.
+
+Storage payout should use verified unique byte-seconds:
+
+```text
+provider_storage_payout =
+  verified_unique_encrypted_bytes
+  × retained_seconds
+  × provider_storage_rate
+```
+
+Do not pay for logical sparse size, duplicate chunks, base images, orphaned
+ciphertext without a live wrapper, or bytes beyond the provider's accepted
+retention reservation.
+
+## 7. Platform and provider split
+
+The inference alpha's zero platform fee in
+`coordinator/payments/pricing.go` should not leak into sandbox pricing.
+Sandboxes have different capital, relay, support, and failure costs.
+
+Recommended starting split:
+
+| Charge | Provider | Darkbloom before external costs |
+|---|---:|---:|
+| Compute and OS/chip/computer premium | 70% | 30% |
+| Successful boot fee | 80% | 20% |
+| Retained storage | 70% | 30% |
+| Network egress | Pass-through net of processing | No margin initially |
+
+Use per-provider overrides to bootstrap scarce supply, but keep the developer
+rate deterministic for an accepted quote. Providers set a reserve price;
+developers do not participate in a live auction.
+
+At the E2B benchmark, 70% gives the representative fully allocated host
+$0.8971/hour. At the proposed 1.5× macOS rate it gives
+**$1.3457/hour**. The provider's statement must show gross charge, platform
+fee, refunds, and net payout.
+
+## 8. Utilization strategy
+
+The largest economic risk is idle capacity, not electricity. Improve
+utilization in this order:
+
+1. keep the global macOS launch cap at two until demand is observed;
+2. prebuild a small set of fixed shapes to reduce memory fragmentation;
+3. prefer a verified sticky host only after hard eligibility checks;
+4. let inference and sandbox workloads coexist only after measured isolation;
+5. use provider posted availability windows;
+6. offer stopped storage without holding compute capacity; and
+7. add hosts only when queue latency and rejected demand justify them.
+
+Do not discount below cost merely to fill a machine. A provider reserve price
+and platform minimum margin are both hard scheduling filters.
+
+## 9. Linux position
+
+Commodity Linux is a tighter market than macOS. Darkbloom can match E2B if
+providers have low-cost or already-owned hardware and sufficient utilization,
+but price alone is not a durable advantage.
+
+Launch Linux at the public E2B resource rates and compete on:
+
+- one API across Linux and macOS;
+- chip/host selection;
+- provider marketplace supply;
+- encrypted sticky state;
+- explicit exclusive-host reservations; and
+- integrated computer-use products.
+
+Firecracker's low per-VM overhead improves density, but the production host
+still needs memory reserves, a jailer, kernels, storage, networking, and spare
+capacity. Do not put Firecracker's published sub-5-MiB VMM overhead into a
+pricing model as if it were total sandbox memory.
+
+## 10. Metering rules
+
+Compute billing starts at `ready`, not when image download begins. It stops at
+the earliest of:
+
+- durable `stopped`;
+- `deleted`;
+- command/sandbox deadline;
+- coordinator loss-of-heartbeat cutoff; or
+- terminal host failure.
+
+Meter in bounded slices, for example 30 seconds, but price to the exact observed
+millisecond or second using integer arithmetic. The slice is a persistence and
+recovery unit, not a rounding license.
+
+The coordinator places a maximum hold and settles:
+
+```text
+settlement =
+  min(observed_billable_duration, quoted_maximum_duration)
+  × immutable_quote_rates
+  + accepted_storage
+  + accepted_egress
+```
+
+Unused hold is released. Duplicate usage heartbeats and coordinator restarts
+cannot duplicate a settlement. No meter may continue indefinitely because a
+provider omitted a stop event.
+
+## 11. Measurements required before locking prices
+
+The Phase 0 proof must report:
+
+- delivered hardware price, warranty, expected replacement life, and salvage;
+- idle, one-VM, two-VM, build, GUI, and exclusive-host wall power;
+- host CPU/memory reserves;
+- cold and warm boot p50/p95/p99;
+- failed-boot rate and retry cost;
+- shape-specific fragmentation;
+- snapshot read/write amplification and SSD wear;
+- image/snapshot transfer and TURN egress;
+- provider and coordinator support burden;
+- uptime, command success, and checkpoint success;
+- actual billable utilization; and
+- developer willingness to pay by product/chip.
+
+Update the sample model with those measurements. If measured 25th-percentile
+provider margin is negative after platform fees and failure cost, raise the
+rate or reject that offer; do not rely on fleet averages to hide an
+uneconomical provider.
+
+## 12. Go/no-go economics
+
+Proceed from private alpha only if all are true:
+
+1. standard macOS sells with positive provider and platform contribution at
+   25% billable utilization;
+2. failed starts and refunds consume less than 10% of gross sandbox revenue;
+3. sticky retention saves more startup cost/latency than its transfer and
+   storage expense;
+4. the two-slot cap has enough observed demand to justify another host;
+5. developer quotes remain competitive with E2B for Linux and visibly valuable
+   for macOS; and
+6. exclusive-host pricing covers the full displaced inference and sandbox
+   opportunity cost.
+
+The economic thesis is therefore testable: Darkbloom does not need cheaper
+electricity than cloud vendors. It needs adequate utilization, reliable hosts,
+honest resource guarantees, and a premium for capabilities E2B does not
+currently expose.
+

--- a/docs/reports/2026-08-22-sandbox-economics.md
+++ b/docs/reports/2026-08-22-sandbox-economics.md
@@ -242,19 +242,28 @@ Virtualization.framework does not expose fractional GPU partitioning or vCPU
 core pinning. Price timing-sensitive work as a host reservation:
 
 ```text
-exclusive gross price =
+gross floor from provider reserve =
+  ceil_div(provider exclusive net floor microUSD × 10,000, provider share bps)
+
+exclusive gross price microUSD =
   max(
-    full allocatable host resource quote × 1.20,
-    provider exclusive net floor / provider compute share
+    ceil_div(full host quote microUSD × 12,000, 10,000),
+    gross floor from provider reserve
   )
 ```
 
 The host must drain inference and every other sandbox before the reservation
 starts. Grossing up the provider's net floor by the quoted provider share
 guarantees settlement cannot fall below that floor; comparing a gross developer
-price directly with a net provider floor would be invalid. The quote names the
-physical chip and benchmark result. "20 GPU cores" describes hardware; it does
-not promise 20 isolated guest GPU cores.
+price directly with a net provider floor would be invalid. Every division uses
+ceiling semantics in integer micro-USD. The scheduler selects the smallest
+gross integer whose actual ledger payout, after the ledger's normal
+round-down, is at least the provider floor. For example, a 340,000-micro-USD net
+floor at a 7,000-bps share requires 485,715 micro-USD gross, whose rounded-down
+payout is 340,000 micro-USD.
+
+The quote names the physical chip and benchmark result. "20 GPU cores"
+describes hardware; it does not promise 20 isolated guest GPU cores.
 
 Do not offer an SLA for guest Metal compute until the specific application is
 benchmarked. Apple's macOS guest uses a paravirtualized graphics path rather

--- a/docs/reports/2026-08-22-sandbox-economics.md
+++ b/docs/reports/2026-08-22-sandbox-economics.md
@@ -11,15 +11,16 @@ User experience: [Provider and developer experience](2026-08-22-sandbox-user-exp
 ## 1. Bottom line
 
 Darkbloom can compete with E2B's public CPU/RAM rates on hardware economics.
-Electricity is not the limiting cost. At a modeled 90 W active draw and the May
-2026 U.S. average commercial electricity price, power is about **$0.012 per
-host-hour**. Hardware amortization, utilization, provider reliability, support,
-and startup latency matter much more.
+Electricity is not the limiting cost. At a modeled 90 W active/5 W idle draw,
+50% billable utilization, and the May 2026 U.S. average commercial electricity
+price, power is about **$0.013 per billable host-hour**. Hardware amortization,
+utilization, provider reliability, support, and startup latency matter much
+more.
 
 A representative 10-vCPU/48-GiB allocatable Mac host produces **$1.2816 per
 fully allocated hour** at E2B's published resource rates. Under the disclosed
-sample assumptions below, the host costs **$0.18–$0.43 per billable host-hour**
-at 75%–25% utilization. At 50% utilization the modeled cost is **$0.242/hour**.
+sample assumptions below, the host costs **$0.18–$0.44 per billable host-hour**
+at 75%–25% utilization. At 50% utilization the modeled cost is **$0.243/hour**.
 
 That does not mean Darkbloom should sell macOS at Linux parity. macOS supply,
 chip selection, GUI automation, and exclusive-host guarantees are
@@ -65,12 +66,16 @@ class with each quote.
 For one host:
 
 ```text
-active_host_cost_per_hour =
+billable_host_cost_per_hour =
     (purchase_price - salvage_value)
       / (economic_life_hours × billable_utilization)
-  + active_power_kW × electricity_price_per_kWh
-  + network_facility_and_wear_per_active_hour
-  + expected_failure_and_support_cost_per_active_hour
+  + (
+      billable_utilization × active_power_kW
+      + (1 - billable_utilization) × idle_power_kW
+    ) / billable_utilization
+      × electricity_price_per_kWh
+  + fixed_host_cost_per_calendar_hour / billable_utilization
+  + variable_network_wear_and_failure_cost_per_billable_hour
 ```
 
 Definitions:
@@ -81,6 +86,8 @@ Definitions:
   product competitiveness, even if it still boots.
 - **Host cost** must be compared with the full CPU+RAM bundle. Assigning every
   dollar to CPU and then charging memory again double-counts cost.
+- **Fixed calendar cost** includes rack rent, base internet, and labor that
+  continues while idle; dividing by utilization prevents it from disappearing.
 - Payment processing, control-plane compute, taxes, refunds, fraud, support,
   and corporate overhead belong in platform margin, not in electricity.
 
@@ -96,8 +103,10 @@ This is a sensitivity model, not a hardware quote.
 | Allocatable vCPU | 10 | Leaves 2–4 physical cores for host duties depending on SKU |
 | Allocatable memory | 48 GiB | Leaves 16 GiB on a 64-GiB host |
 | Average active draw | 90 W | Modeled between Apple's 5 W idle and 140 W maximum data |
+| Idle draw | 5 W | Apple's published idle figure for the cited configuration |
 | Electricity | $0.1354/kWh | U.S. commercial average, May 2026 |
-| Network/facility/SSD/failure placeholder | $0.04/active hour | Must be replaced by observed provider cost |
+| Fixed host cost | $0/calendar hour | Not assumed; plug in rack/base internet/labor |
+| Variable network/SSD/failure placeholder | $0.04/billable hour | Must be replaced by observed provider cost |
 
 Apple publishes 5 W idle and 140 W maximum power for a 64-GiB M4 Pro Mac mini
 configuration. The 90 W row is deliberately a model input, not a claim that
@@ -106,18 +115,18 @@ every workload consumes 90 W. Source:
 
 The U.S. Energy Information Administration reports a May 2026 average
 commercial price of 13.54 cents/kWh. Source:
-[EIA Electricity Monthly Update](https://www.eia.gov/electricity/monthly/update/end-use.php).
+[EIA Electric Power Monthly, table 5.3](https://www.eia.gov/electricity/monthly/epm_table_grapher.php?t=epmt_5_3).
 
 ### 4.1 Cost sensitivity
 
-| Billable utilization | Amortization per active hour | Power | Other placeholder | Total active host cost |
+| Billable utilization | Amortization per billable hour | Power | Other placeholder | Total cost per billable hour |
 |---:|---:|---:|---:|---:|
-| 25% | $0.3805 | $0.0122 | $0.0400 | **$0.4327** |
-| 50% | $0.1903 | $0.0122 | $0.0400 | **$0.2424** |
-| 75% | $0.1268 | $0.0122 | $0.0400 | **$0.1790** |
+| 25% | $0.3805 | $0.0142 | $0.0400 | **$0.4347** |
+| 50% | $0.1903 | $0.0129 | $0.0400 | **$0.2431** |
+| 75% | $0.1268 | $0.0124 | $0.0400 | **$0.1793** |
 
 If the full host cost were divided only by ten allocatable vCPUs, it would be
-1.79–4.33 cents per vCPU-hour across this utilization range. That number is
+1.79–4.35 cents per vCPU-hour across this utilization range. That number is
 useful as an upper bound on CPU cost but is not a valid standalone rate because
 the same machine also sells memory.
 
@@ -132,9 +141,9 @@ full host resource revenue  = $1.2816/hour
 
 | Billable utilization | Modeled cost | Benchmark revenue | Gross headroom before platform overhead |
 |---:|---:|---:|---:|
-| 25% | $0.4327 | $1.2816 | **66.2%** |
-| 50% | $0.2424 | $1.2816 | **81.1%** |
-| 75% | $0.1790 | $1.2816 | **86.0%** |
+| 25% | $0.4347 | $1.2816 | **66.1%** |
+| 50% | $0.2431 | $1.2816 | **81.0%** |
+| 75% | $0.1793 | $1.2816 | **86.0%** |
 
 The headroom is not net profit. It must fund:
 
@@ -155,11 +164,12 @@ Even after those deductions, electricity is visibly not the economic blocker.
 If a provider receives 70% of E2B-benchmark resource revenue:
 
 ```text
-provider revenue at full allocation = $1.2816 × 70% = $0.89712/active hour
+provider revenue at full allocation = $1.2816 × 70% = $0.89712/billable hour
 ```
 
-With the same $2,500 host, three-year life, 90 W power, and $0.04/hour
-placeholder, the modeled capital break-even utilization is about **11.3%**.
+With the same $2,500 host, three-year life, 90 W active/5 W idle power, and
+$0.04/hour placeholder, the modeled capital break-even utilization is about
+**11.3%**.
 This is a sensitivity result, not a promised return. A provider with expensive
 power, managed hosting, financing, labor, poor reliability, or a shorter
 replacement cycle has a higher threshold.
@@ -206,8 +216,10 @@ to move independently later.
 | 8 vCPU / 32 GiB | $0.9216 | $0.9216 | **$1.3824** | **$1.7280** |
 | 10 vCPU / 48 GiB host | $1.2816 | $1.2816 | **$1.9224** | **$2.4030** |
 
-A 15-minute 4-vCPU/8-GiB macOS command has a maximum compute hold of
-**$0.1242** before any successful boot fee or network egress.
+A 15-minute 4-vCPU/8-GiB macOS billable window costs at most **$0.1242**.
+Its one-minute shutdown guard adds at most **$0.0083**, so the compute hold is
+**$0.1325** before any successful boot fee, retained storage, tax, or capped
+network egress. The guard accepts no new user work.
 
 ### 5.3 Exact-chip premium
 
@@ -255,28 +267,48 @@ small successful boot fee only if alpha measurements show it is necessary:
 
 Do not recover failed-start cost through an opaque minimum command charge.
 
+### 5.6 Failure allocation
+
+| Event | Developer | Provider | Darkbloom |
+|---|---|---|---|
+| Provider/image fails before ready | No compute or boot charge | No payout | Absorbs control-plane/transfer cost |
+| Platform image is invalid fleet-wide | No charge | Optional measured transfer reimbursement | Absorbs fault and remediation |
+| Developer cancels during preparation | Pays only a disclosed cancellation fee, initially $0 | No compute; boot fee only if already ready | Releases holds |
+| Host fails after ready, before command dispatch | Pays observed ready time only | Receives share of settled ready time | Refunds unused hold |
+| Command outcome is ambiguous after dispatch | Pays no later than lease/heartbeat cutoff | Receives only settled observed usage | Marks `lost`; no replay |
+| Successful boot then immediate developer stop | Pays ready time plus quoted boot fee | Receives boot/compute shares | No clawback absent provider fault |
+
+Provider reserve prices are named **net payouts per shape**. Eligibility requires
+the quoted provider share to meet that floor; a provider does not compare a
+whole-host gross floor with one small sandbox's net payout.
+
 ## 6. Storage economics
 
-The developer selects a 25- or 50-GiB logical quota. Sparse unused bytes cost
+The developer selects a 25- or 50-GiB workspace quota. The macOS VM also has a
+larger sparse boot disk cloned from the platform image. Sparse unused bytes cost
 nothing and should not be billed as if written.
 
 Recommended alpha storage policy:
 
 - base images: free to the developer and not counted as tenant storage;
-- workspace while compute is running: included up to the selected quota;
-- stopped/retained workspace: **$0.08 per actual encrypted GiB-month**;
+- boot-delta and workspace bytes while compute is running: included;
+- Phase 2 durable object storage for stopped boot/workspace state:
+  **$0.08 per actual encrypted GiB-month**, allocated to Darkbloom/object-store
+  cost rather than the host provider;
+- Phase 3 verified local sticky-cache add-on:
+  **$0.04 per actual encrypted GiB-month**, with a provider cache payout;
 - transfer/replication: included within a published monthly allowance, then
   passed through; and
-- deletion: billing ends when key wrappers are tombstoned, not when background
-  ciphertext reclamation finishes.
+- deletion: billing ends when active key wrappers are tombstoned, while
+  ciphertext and backup wrappers expire under the published retention policy.
 
-At that rate:
+At those rates:
 
-| Actual retained bytes | Monthly charge |
-|---:|---:|
-| 5 GiB | $0.40 |
-| 25 GiB | $2.00 |
-| 50 GiB | $4.00 |
+| Actual retained bytes | Durable only | Durable + sticky |
+|---:|---:|---:|
+| 5 GiB | $0.40 | $0.60 |
+| 25 GiB | $2.00 | $3.00 |
+| 50 GiB | $4.00 | $6.00 |
 
 The rate is intentionally above raw SSD depreciation because it also funds
 reservation, verification, encrypted snapshot movement, host churn, and a
@@ -287,18 +319,19 @@ sold utilization costs roughly **$0.0056/GiB-month** before writes, failures,
 replication, transfer, and operations. Raw media is not the expensive part;
 durability and availability are.
 
-Storage payout should use verified unique byte-seconds:
+The optional sticky-cache payout should use verified unique byte-seconds:
 
 ```text
-provider_storage_payout =
+provider_cache_payout =
   verified_unique_encrypted_bytes
   × retained_seconds
-  × provider_storage_rate
+  × provider_cache_rate
 ```
 
 Do not pay for logical sparse size, duplicate chunks, base images, orphaned
 ciphertext without a live wrapper, or bytes beyond the provider's accepted
-retention reservation.
+cache reservation. Phase 2 durable replicas in the platform object store do not
+create a host-provider payout.
 
 ## 7. Platform and provider split
 
@@ -312,12 +345,13 @@ Recommended starting split:
 |---|---:|---:|
 | Compute and OS/chip/computer premium | 70% | 30% |
 | Successful boot fee | 80% | 20% |
-| Retained storage | 70% | 30% |
+| Phase 2 durable object storage | 0% | 100% before object-store cost |
+| Phase 3 sticky-cache add-on | 70% | 30% |
 | Network egress | Pass-through net of processing | No margin initially |
 
 Use per-provider overrides to bootstrap scarce supply, but keep the developer
-rate deterministic for an accepted quote. Providers set a reserve price;
-developers do not participate in a live auction.
+rate deterministic for an accepted quote. Providers set a net reserve payout
+per named shape; developers do not participate in a live auction.
 
 At the E2B benchmark, 70% gives the representative fully allocated host
 $0.8971/hour. At the proposed 1.5× macOS rate it gives
@@ -362,24 +396,29 @@ pricing model as if it were total sandbox memory.
 
 ## 10. Metering rules
 
-Compute billing starts at `ready`, not when image download begins. It stops at
-the earliest of:
-
-- durable `stopped`;
-- `deleted`;
-- command/sandbox deadline;
-- coordinator loss-of-heartbeat cutoff; or
-- terminal host failure.
+Compute billing starts at `ready`, not when image download begins. It ends at
+durable daemon-confirmed `execution_halted_at`, bounded by the earliest
+sandbox/idle/lease/heartbeat/failure stop plus the pre-funded one-minute guard.
+A command deadline is process-only: the sandbox can return to `ready`, so the
+compute meter continues until idle or sandbox/lease stop. Snapshot
+encryption/upload occurs after execution halts and is not compute-billed.
 
 Meter in bounded slices, for example 30 seconds, but price to the exact observed
 millisecond or second using integer arithmetic. The slice is a persistence and
 recovery unit, not a rounding license.
 
-The coordinator places a maximum hold and settles:
+Queueing places no hold. Admission holds the 15-minute billable window,
+one-minute shutdown guard, maximum boot fee, tax, selected 24-hour storage/cache
+authorization, and an explicit egress cap. With a 100-GiB sparse boot disk and
+25-GiB workspace, the worst-case 125 GiB of tenant-written retained state adds
+a **$0.3333** durable-storage hold plus **$0.1667** when sticky cache is
+selected; settlement still uses actual unique bytes.
+
+The coordinator settles:
 
 ```text
 settlement =
-  min(observed_billable_duration, quoted_maximum_duration)
+  min(ready_to_execution_halted_duration, billable_window_plus_guard)
   × immutable_quote_rates
   + accepted_storage
   + accepted_egress
@@ -388,6 +427,14 @@ settlement =
 Unused hold is released. Duplicate usage heartbeats and coordinator restarts
 cannot duplicate a settlement. No meter may continue indefinitely because a
 provider omitted a stop event.
+
+Renewal first settles prior usage, then checks `settled spend + all open holds`
+against account/key/project limits, places the next hold, and only then extends
+the lease. If renewal fails, the daemon accepts no new work, records
+`execution_halted_at` inside the funded guard, then checkpoints as a
+non-compute operation. Storage authorization renews separately while stopped;
+an unpaid sandbox enters a bounded deletion grace period with no compute
+capacity.
 
 ## 11. Measurements required before locking prices
 
@@ -430,4 +477,3 @@ The economic thesis is therefore testable: Darkbloom does not need cheaper
 electricity than cloud vendors. It needs adequate utilization, reliable hosts,
 honest resource guarantees, and a premium for capabilities E2B does not
 currently expose.
-

--- a/docs/reports/2026-08-22-sandbox-economics.md
+++ b/docs/reports/2026-08-22-sandbox-economics.md
@@ -242,14 +242,19 @@ Virtualization.framework does not expose fractional GPU partitioning or vCPU
 core pinning. Price timing-sensitive work as a host reservation:
 
 ```text
-exclusive price =
-  max(full allocatable host resource quote, provider exclusive floor)
-  + 20% exclusivity premium
+exclusive gross price =
+  max(
+    full allocatable host resource quote × 1.20,
+    provider exclusive net floor / provider compute share
+  )
 ```
 
 The host must drain inference and every other sandbox before the reservation
-starts. The quote names the physical chip and benchmark result. "20 GPU cores"
-describes hardware; it does not promise 20 isolated guest GPU cores.
+starts. Grossing up the provider's net floor by the quoted provider share
+guarantees settlement cannot fall below that floor; comparing a gross developer
+price directly with a net provider floor would be invalid. The quote names the
+physical chip and benchmark result. "20 GPU cores" describes hardware; it does
+not promise 20 isolated guest GPU cores.
 
 Do not offer an SLA for guest Metal compute until the specific application is
 benchmarked. Apple's macOS guest uses a paravirtualized graphics path rather
@@ -274,8 +279,8 @@ Do not recover failed-start cost through an opaque minimum command charge.
 | Provider/image fails before ready | No compute or boot charge | No payout | Absorbs control-plane/transfer cost |
 | Platform image is invalid fleet-wide | No charge | Optional measured transfer reimbursement | Absorbs fault and remediation |
 | Developer cancels during preparation | Pays only a disclosed cancellation fee, initially $0 | No compute; boot fee only if already ready | Releases holds |
-| Host fails after ready, before command dispatch | Pays observed ready time only | Receives share of settled ready time | Refunds unused hold |
-| Command outcome is ambiguous after dispatch | Pays no later than lease/heartbeat cutoff | Receives only settled observed usage | Marks `lost`; no replay |
+| Host fails after ready, before command dispatch | Pays observed ready time through bounded `metering_ended_at` | Receives share of settled ready time | Refunds unused hold; retains slot fence until safe |
+| Command outcome is ambiguous after dispatch | Pays no later than bounded `metering_ended_at` | Receives only settled observed usage | Marks command `lost`; no replay |
 | Successful boot then immediate developer stop | Pays ready time plus quoted boot fee | Receives boot/compute shares | No clawback absent provider fault |
 
 Provider reserve prices are named **net payouts per shape**. Eligibility requires
@@ -366,7 +371,9 @@ utilization in this order:
 1. keep the global macOS launch cap at two until demand is observed;
 2. prebuild a small set of fixed shapes to reduce memory fragmentation;
 3. prefer a verified sticky host only after hard eligibility checks;
-4. let inference and sandbox workloads coexist only after measured isolation;
+4. keep alpha sandbox hosts in fenced `sandbox_dedicated` mode; consider mixed
+   inference/sandbox operation only after an atomic shared resource arbiter and
+   measured isolation;
 5. use provider posted availability windows;
 6. offer stopped storage without holding compute capacity; and
 7. add hosts only when queue latency and rejected demand justify them.
@@ -397,11 +404,16 @@ pricing model as if it were total sandbox memory.
 ## 10. Metering rules
 
 Compute billing starts at `ready`, not when image download begins. It ends at
-durable daemon-confirmed `execution_halted_at`, bounded by the earliest
-sandbox/idle/lease/heartbeat/failure stop plus the pre-funded one-minute guard.
+durable `metering_ended_at`. On normal shutdown that is the earlier of
+daemon-confirmed `execution_halted_at` and the funded cap. If the host
+disappears, `execution_halted_at` remains null and the coordinator uses the
+earliest missing-heartbeat cutoff, capacity-lease expiry, or funded cap, with a
+recorded `metering_end_reason`. That conservative billing cutoff does not prove
+the VM stopped or release its global slot before the fencing guard expires.
+
 A command deadline is process-only: the sandbox can return to `ready`, so the
 compute meter continues until idle or sandbox/lease stop. Snapshot
-encryption/upload occurs after execution halts and is not compute-billed.
+encryption/upload occurs after a confirmed halt and is not compute-billed.
 
 Meter in bounded slices, for example 30 seconds, but price to the exact observed
 millisecond or second using integer arithmetic. The slice is a persistence and
@@ -418,7 +430,7 @@ The coordinator settles:
 
 ```text
 settlement =
-  min(ready_to_execution_halted_duration, billable_window_plus_guard)
+  min(ready_to_metering_ended_duration, billable_window_plus_guard)
   × immutable_quote_rates
   + accepted_storage
   + accepted_egress
@@ -431,10 +443,11 @@ provider omitted a stop event.
 Renewal first settles prior usage, then checks `settled spend + all open holds`
 against account/key/project limits, places the next hold, and only then extends
 the lease. If renewal fails, the daemon accepts no new work, records
-`execution_halted_at` inside the funded guard, then checkpoints as a
-non-compute operation. Storage authorization renews separately while stopped;
-an unpaid sandbox enters a bounded deletion grace period with no compute
-capacity.
+`execution_halted_at` and `metering_ended_at` inside the funded guard, then
+checkpoints as a non-compute operation. If the daemon is gone, the coordinator
+records only the bounded fallback `metering_ended_at`. Storage authorization
+renews separately while stopped; an unpaid sandbox enters a bounded deletion
+grace period with no compute capacity.
 
 ## 11. Measurements required before locking prices
 
@@ -471,7 +484,8 @@ Proceed from private alpha only if all are true:
 5. developer quotes remain competitive with E2B for Linux and visibly valuable
    for macOS; and
 6. exclusive-host pricing covers the full displaced inference and sandbox
-   opportunity cost.
+   opportunity cost and grosses every provider net floor up by the applicable
+   provider share.
 
 The economic thesis is therefore testable: Darkbloom does not need cheaper
 electricity than cloud vendors. It needs adequate utilization, reliable hosts,

--- a/docs/reports/2026-08-22-sandbox-platform-plan.md
+++ b/docs/reports/2026-08-22-sandbox-platform-plan.md
@@ -10,8 +10,9 @@ Companion documents:
 - [Economics and pricing](2026-08-22-sandbox-economics.md)
 
 This plan deliberately excludes legal and licensing analysis. It defines the
-product and engineering shape Darkbloom can build after legal review is handled
-separately.
+product and engineering shape. A named legal owner must sign off on macOS/Xcode
+image distribution and provider-hosted VM access before the private alpha;
+engineering does not infer that approval from this document.
 
 ## 1. Decision
 
@@ -21,7 +22,7 @@ and attestation foundations. Give sandboxes their own host daemon, WebSocket
 protocol, scheduler, state machine, durable reservations, usage records, and
 rate cards.
 
-Launch three products behind one API:
+Target three products behind one API:
 
 | Product | Isolation substrate | Initial use | Relative position |
 |---|---|---|---|
@@ -39,35 +40,48 @@ without changing the developer contract.
 The private alpha has these hard constraints:
 
 1. The platform admits at most **two running macOS sandboxes globally**. This is
-   an explicit coordinator limit, not an undocumented operator convention.
+   an explicit coordinator capacity lease limit, not an undocumented operator
+   convention.
 2. Each command has a **15-minute maximum execution time**. Sandbox retention
    and command execution are separate clocks.
-3. A sandbox gets a **25 GiB logical disk** by default or **50 GiB** when
-   requested.
-4. Access is permissioned for both developers and providers.
-5. Alpha workloads must not rely on the provider being unable to inspect a
+3. Active compute is authorized in renewable leases of at most **15 minutes**.
+   A sandbox checkpoints and stops before an unfunded lease expires.
+4. A macOS VM uses a sufficiently large sparse boot disk cloned from the signed
+   template. The developer separately gets a **25 GiB workspace quota** by
+   default or **50 GiB** when requested.
+5. Access is permissioned for both developers and providers.
+6. Alpha workloads must not rely on the provider being unable to inspect a
    running VM. Persistent tenant data is encrypted at rest, but the host owner
    remains inside the runtime trust boundary.
-6. CPU, memory, chip family, disk, cache retention, and exclusivity are explicit
+7. CPU, memory, chip family, workspace, cache retention, and exclusivity are explicit
    quote dimensions.
-7. A normal sandbox receives no fractional GPU guarantee. Timing-sensitive CPU
+8. A normal sandbox receives no fractional GPU guarantee. Timing-sensitive CPU
    or GPU work uses an exclusive-host product.
-8. Compute is metered only while a sandbox is ready or executing. A retained,
-   stopped sandbox pays storage but not a 24-hour compute minimum.
+9. Compute is metered from `ready` through daemon-confirmed
+   `execution_halted_at`, including at most the pre-funded shutdown guard. New
+   user work is accepted only in `ready`/`executing`. A retained, stopped
+   sandbox pays storage but not a 24-hour compute minimum.
 
 ### GitHub Actions caveat
 
 "No secrets" and an arbitrary GitHub Actions runner are incompatible. A runner
-uses short-lived registration credentials and can receive `GITHUB_TOKEN`,
-repository credentials, and configured job secrets. The alpha can support:
+uses short-lived registration credentials and receives a `GITHUB_TOKEN`; public
+repositories can still expose repository/environment secrets, OIDC identity,
+write permissions, reusable workflows, or privileged `pull_request_target`
+behavior. A provider can read ephemeral credentials and alter build results.
 
-- public repositories whose workflows receive no user-configured secrets; and
-- an explicitly labeled **no durable secrets** mode using one-time,
-  tightly-scoped registration credentials.
+The alpha runner gate therefore requires an approved workflow commit SHA,
+read-only token permissions, no OIDC, no repository/environment secrets, no
+release/deploy/signing jobs, no unapproved reusable workflow, and no
+`pull_request_target`. The GitHub App rejects a job when it cannot prove those
+conditions. Jobs use GitHub's
+[JIT runner configuration API](https://docs.github.com/en/rest/actions/self-hosted-runners)
+and an explicitly labeled **no durable secrets, host-trusted integrity** mode.
 
-Private-repository runners and workflows with valuable credentials remain
-disabled until the runtime threat model changes. Short-lived credentials reduce
-blast radius; they do not make an untrusted host confidential.
+Private repositories and workflows with valuable credentials remain disabled
+until the runtime threat model changes. Short-lived credentials reduce blast
+radius; they do not make an untrusted host confidential or its output
+trustworthy.
 
 ## 3. First-principles constraints
 
@@ -106,9 +120,11 @@ performance and no co-tenant.
 ### 3.5 Side effects prevent transparent retry
 
 The scheduler may fail over while preparing or booting a sandbox, before a
-command is accepted. Once a command starts, replaying it on another machine may
-duplicate deployments, purchases, or writes. A lost executing command therefore
-ends as `lost`; recovery resumes from the latest durable checkpoint only after
+command is dispatched. Once a command frame may have reached the host,
+replaying it on another machine may duplicate deployments, purchases, or
+writes. The host durably records acceptance before spawning the process. Any
+post-dispatch ambiguity is `lost` unless reconciliation proves the process
+never started. Recovery resumes from the latest durable checkpoint only after
 an explicit developer action.
 
 ## 4. System boundary
@@ -139,9 +155,17 @@ inference provider WebSocket writer: file transfer and desktop frames could
 otherwise block inference control traffic.
 
 The target data path establishes an ephemeral SDK-to-guest session key. The
-relay sees routing metadata and ciphertext, not command output, uploaded files,
-or screenshots. This keeps the coordinator out of tenant content, although it
-does not remove the host owner from the trust boundary.
+coordinator issues a short-lived signed grant binding sandbox generation,
+session ID, scopes, expiry, and the SDK's ephemeral X25519 public key. The guest
+returns an ephemeral public key through the attested host connection. Directional
+AEAD keys are derived over the transcript; every frame authenticates the
+session ID, direction, and monotonic counter. Reconnect creates a new grant and
+key, and duplicate counters fail closed.
+
+The relay sees routing metadata and ciphertext, not command output, uploaded
+files, or screenshots. The host owns the guest and can still inspect or
+interpose on the session; this encryption excludes the coordinator relay, not
+the provider.
 
 ## 5. Reuse and separation in the current repository
 
@@ -214,6 +238,40 @@ without supplying a capability needed for the proposed alpha.
 It runs as a signed, hardened daemon under a dedicated host account. It opens no
 public inbound port; all control connections originate outbound.
 
+#### Release and code identity
+
+The sandbox host is split into:
+
+- a persistent `darkbloom-sandboxd` LaunchDaemon for VM, disk, packet-gateway,
+  and control-plane work; and
+- `DarkbloomSandboxAttestation.app` (`io.darkbloom.sandbox-attestation`) as a
+  LaunchAgent in a continuously logged-in Aqua session, solely for APNs token
+  registration and challenge delivery.
+
+The daemon profile grants `com.apple.security.virtualization`, outbound network
+access, a sandbox-specific keychain access group, and only the file access
+needed for its image/cache volume. The Aqua bridge profile grants APNs and no VM
+or tenant-disk access. They authenticate each other over XPC by audit token,
+Developer ID team, bundle/designated requirement, and nonce-bound messages.
+The bridge forwards encrypted challenges; the daemon owns the sandbox-specific
+Secure Enclave identity and response key.
+
+APNs on macOS requires an Aqua GUI login session. The dedicated sandbox account
+must therefore remain logged in, even on an otherwise headless Mac. No manual
+GUI interaction is required after bootstrap, but loss of that session/token
+makes the host ineligible for new or renewed capacity leases. The coordinator
+binds the sandbox identity to the already enrolled physical machine and does
+not reuse the inference private key.
+
+The release workflow signs the nested daemon, XPC boundary, and app; embeds
+their distinct provisioning profiles; notarizes the final bundle; and computes
+hashes after signing. APNs code attestation covers the complete signed manifest.
+The installer verifies and installs the LaunchDaemon/LaunchAgent separately.
+Upgrade drains first; rollback accepts only a still-supported signed manifest.
+An independent sandbox protocol/version floor gates eligibility. These steps
+require coordinated changes to the release workflow, installer, release
+manifest, coordinator version gate, and uninstall path.
+
 ### 6.2 Linux
 
 Use [Firecracker](https://firecracker-microvm.github.io/) through its jailer on
@@ -249,12 +307,18 @@ publishes a final quote within centrally configured price bands.
 For launch, expose a small number of fixed shapes rather than arbitrary
 combinations:
 
-| Shape | vCPU | Memory | Disk | Intended use |
+| Shape | vCPU | Memory | Workspace | Intended use |
 |---|---:|---:|---:|---|
 | `macos-s` | 4 | 8 GiB | 25 GiB | Builds and tests |
 | `macos-m` | 6 | 16 GiB | 25 GiB | Xcode and moderate parallelism |
 | `macos-l` | 8 | 32 GiB | 50 GiB | Large builds on eligible hosts |
 | `macos-exclusive` | Host capacity | Host capacity | 50 GiB | Timing-sensitive CPU/GPU |
+
+Every macOS shape also receives a sparse boot disk cloned from the compatible
+signed template; use 100 GiB as the proof default until measured image/update
+requirements set the production minimum. The 25/50 GiB number is a separate
+workspace quota, not the whole macOS disk. Tenant system changes consume
+copy-on-write boot-disk extents and count toward retained bytes.
 
 The scheduler validates each shape against the selected host. It never
 oversubscribes memory. Shared CPU may be scheduled, but the exclusive shape
@@ -269,20 +333,44 @@ the matching posted premium. A portable request should prefer
 
 ### 8.1 Layering
 
-Each sandbox consists of:
+Each macOS sandbox consists of:
 
-1. a read-only, content-addressed base image signed by Darkbloom;
-2. a tenant workspace overlay retained for the sandbox lifetime; and
-3. a per-run scratch overlay discarded on reset or failure.
+1. an immutable, content-addressed template artifact signed by Darkbloom;
+2. a writable sparse boot-disk clone created from that template;
+3. unique `VZMacMachineIdentifier` and auxiliary storage;
+4. a separate 25/50 GiB workspace data disk; and
+5. a per-run scratch area discarded on reset or failure.
 
-Base images are public and deduplicated. Tenant overlays are never shared.
-APFS clone semantics are a local optimization on macOS, not part of the
-portable image format. Linux uses immutable rootfs layers plus a writable block
-overlay.
+The template is immutable, but the disk attached to
+`VZDiskImageStorageDeviceAttachment` is a normal local writable image.
+Virtualization.framework does not consume an encrypted chunk manifest as a
+random-access disk. Before boot, the daemon verifies and materializes a
+VZ-compatible sparse image on its encrypted APFS volume. After a clean stop, it
+chunks changed boot/workspace extents, encrypts them, commits a new manifest,
+and removes the materialized files when they are no longer a warm local cache.
 
-The 25/50 GiB selection is a logical quota. Billing for retained cache uses
-actual unique encrypted bytes, rounded in documented units, rather than the
-maximum sparse-disk size.
+Base images are public and deduplicated. Tenant boot deltas and workspaces are
+never shared. APFS clones accelerate local creation, but the portable format is
+an authenticated chunk tree plus the portable VM configuration needed to
+reconstruct local disk images. Linux uses immutable rootfs layers plus a writable
+block overlay.
+
+The 25/50 GiB selection is the workspace logical quota. Billing for retained
+state uses actual unique encrypted boot-delta and workspace bytes, rounded in
+documented units, rather than sparse-disk capacities.
+
+macOS updates occur in the base-image pipeline, not ad hoc in tenant VMs.
+Retained configuration includes `VZMacMachineIdentifier`, auxiliary-storage
+bytes, hardware model, guest version, and disk manifest. Same-host resume
+preserves them. On macOS 15 and later, moving the VM to another physical Mac can
+still create a new host-Secure-Enclave-derived Apple VM identity/UDID and
+require Apple-account reauthentication. The alpha therefore prohibits signed-in
+Apple IDs, signing certificates, notarization, and workflows that depend on
+stable Apple-service identity.
+
+Migration is stopped-only, filters for a host that supports the saved hardware
+model, and surfaces any host-derived identity change. There is no live
+migration and no promise that every Apple service survives a host move.
 
 ### 8.2 Key hierarchy
 
@@ -291,26 +379,47 @@ flowchart TD
   SE["Attested Secure Enclave P-256 key"] -->|"ECIES unwrap"| HK["Host cache KEK"]
   HK -->|"unwrap"| DEK["Per-sandbox DEK"]
   Recovery["Tenant or platform recovery key"] -->|"second wrapped copy"| DEK
-  DEK -->|"AEAD per chunk + metadata AAD"| Overlay["Encrypted workspace overlay"]
-  DEK -->|"AEAD per chunk + metadata AAD"| Snapshot["Encrypted portable snapshot"]
+  DEK -->|"AEAD + manifest binding"| Boot["Encrypted boot-delta chunks"]
+  DEK -->|"AEAD + manifest binding"| Workspace["Encrypted workspace chunks"]
+  Boot --> Object["Dedicated ciphertext object store"]
+  Workspace --> Object
 ```
 
 - Generate a random 256-bit DEK per sandbox generation.
-- Encrypt overlay chunks with AES-256-GCM or XChaCha20-Poly1305 using unique
-  nonces and authenticated metadata containing sandbox ID, generation, chunk
-  index, and image-manifest hash.
+- Encrypt chunks with AES-256-GCM or XChaCha20-Poly1305 using unique nonces and
+  authenticated metadata containing sandbox ID, generation, disk role, chunk
+  index, and parent-manifest hash.
+- Commit chunk hashes into an authenticated, versioned Merkle manifest. The
+  store accepts a generation only with compare-and-swap against its parent, so
+  rollback, omission, reordering, and split-brain writers fail closed.
 - Wrap the DEK to the host Secure Enclave-backed KEK for local sticky-cache
   access.
-- Store a second wrapped DEK under a tenant-controlled key or a platform
-  recovery KMS key. Without this second wrapper, a host-bound cache is not
-  portable and host loss permanently destroys the sandbox.
-- Delete all wrappers when a sandbox is destroyed; garbage-collect ciphertext
-  asynchronously.
+- Store ciphertext and manifests in a dedicated sandbox object bucket, separate
+  from model/release objects. Require object versioning, bounded backup
+  retention, integrity checks, and at least two failure-independent copies
+  before a checkpoint is called durable.
+- Give a selected host short-lived object credentials scoped to one sandbox
+  generation and operation. It cannot list another tenant's prefix or replace
+  the committed manifest root.
+- Offer two recovery modes. `platform-managed` wraps the DEK under a
+  per-sandbox recovery key protected by platform KMS; Darkbloom can authorize
+  decryption. `tenant-managed` wraps to a client key and requires that key on
+  resume; Darkbloom cannot recover a lost client key.
+- On deletion, revoke authorization and delete active host/recovery wrappers
+  immediately. Ciphertext and backup wrappers age out under the published
+  object/database backup retention; do not claim instantaneous cryptographic
+  erasure for platform-managed recovery.
 
 The existing provider cache proves the core ECIES wrapping primitive, but
 sandbox keys need a distinct domain label, KEK, storage namespace, and audit
 trail. Reusing a cryptographic primitive is acceptable; reusing key material
 across products is not.
+
+The Secure Enclave private key is non-exportable. The unwrapped host KEK and
+per-sandbox DEK are plaintext in daemon memory while serving, and a malicious
+host can extract them or inspect the running guest. The guarantee is that raw
+keys are not persisted unwrapped and offline cache/object theft does not reveal
+tenant bytes.
 
 For local disks, use an encrypted APFS volume owned by the sandbox daemon in
 addition to chunk-level encryption for persisted snapshots. Keep it unmounted
@@ -326,19 +435,36 @@ reliability, and price checks. It never overrides those checks.
 If the sticky host is offline:
 
 1. select another eligible host;
-2. transfer the encrypted snapshot;
-3. rewrap the DEK to the new host after attestation; and
-4. boot from the restored overlay.
+2. fetch the encrypted snapshot from the dedicated object store;
+3. authorize recovery according to the chosen recovery mode;
+4. rewrap the DEK to the new attested sandbox-host key;
+5. verify the manifest and materialize compatible local disk images; and
+6. boot with preserved portable configuration and report any host-derived
+   identity change.
 
 The quote shows whether startup is expected to be warm or cold. Failed image
 preparation is not billable.
 
 ## 9. Network and guest agent
 
-The default network policy is outbound NAT with:
+Do not use `VZNATNetworkDeviceAttachment` for multi-tenant policy; it does not
+provide the required per-VM destination filter. Attach each VM through
+`VZFileHandleNetworkDeviceAttachment` to a dedicated, signed packet-gateway
+helper. The helper receives raw Ethernet frames over a connected datagram
+socket and implements DHCP, DNS forwarding, stateful TCP/UDP NAT, destination
+filtering, and byte/connection rate limits per sandbox.
+
+The gateway is default-deny until the sandbox policy and fencing token are
+installed. It evaluates the destination IP on every packet, so DNS rebinding
+cannot bypass private-range blocks. IPv6 remains disabled until equivalent
+filtering exists. If the helper, daemon, policy lease, or socket dies, guest
+networking fails closed. No `pf` rule shared with the provider's normal network
+is the primary isolation boundary.
+
+The default network policy permits outbound public internet with:
 
 - provider LAN, RFC1918, link-local, metadata, and host-management ranges
-  blocked outside the guest;
+  blocked in the packet gateway;
 - no unsolicited inbound connectivity;
 - DNS and byte-count metadata retained, but no payload logging;
 - optional destination allowlists for CI jobs; and
@@ -347,7 +473,8 @@ The default network policy is outbound NAT with:
 The guest agent is part of every signed base image. It:
 
 - establishes an authenticated vsock/virtio-socket channel to the host daemon;
-- proves the expected image and agent version;
+- reports the expected image and agent version in a host-verified readiness
+  handshake;
 - creates command processes under the unprivileged sandbox user;
 - streams stdout/stderr and exit status;
 - enforces command deadlines in addition to host/coordinator deadlines;
@@ -358,6 +485,11 @@ The guest agent is part of every signed base image. It:
 The host daemon treats every guest message as untrusted. Length limits,
 deadlines, finite state checks, and per-session flow control apply before data
 reaches the coordinator relay.
+
+Virtualization.framework does not remotely attest arbitrary macOS guest boot.
+The host verifies signed image bytes before materialization and checks the guest
+agent handshake; this is not measured boot. The provider controls that host and
+can forge or interpose on the handshake.
 
 ## 10. Computer-use tier
 
@@ -374,6 +506,10 @@ code-signed driver identity. Accessibility and Screen Recording permissions
 must survive image cloning and driver upgrades; this is an explicit proof gate,
 not an assumption.
 
+Cua Driver's product telemetry is disabled in the image and its telemetry
+destinations are blocked by the guest egress policy. Tests verify both after
+every driver update.
+
 The public surface exposes screenshots, pointer/keyboard actions, window
 metadata, and an optional interactive stream. Driver RPC stays on the
 guest-agent channel and is never exposed directly to the internet. Interactive
@@ -386,33 +522,102 @@ window titles.
 
 ## 11. Lifecycle and failure semantics
 
+A quote is a separate expiring object, not a sandbox state. A queued create
+holds neither host capacity nor funds. When capacity becomes available, the
+coordinator revalidates the quote and balance atomically; an expired quote
+returns `QUOTE_EXPIRED` unless the caller explicitly allowed requoting.
+
 ```mermaid
 stateDiagram-v2
-  [*] --> quoted
-  quoted --> reserving: create + durable hold
-  reserving --> preparing: host reserved
+  [*] --> queued: create
+  queued --> reserving: quote valid + capacity available
+  queued --> cancelled: cancel or queue deadline
+  reserving --> preparing: funds and capacity leased
   preparing --> booting: image ready
-  booting --> ready: guest attested
+  booting --> ready: guest readiness confirmed
   ready --> executing: command accepted
-  executing --> ready: command completed
-  executing --> stopping: timeout or cancel
-  ready --> checkpointing: pause
+  executing --> ready: command completed, timed out, or cancelled
+  executing --> stopping: sandbox cancel or compute lease expiry
+  ready --> stopping: pause, idle, or lease expiry
+  stopping --> checkpointing: execution halted + retention requested
+  stopping --> deleting: ephemeral or delete
   checkpointing --> stopped: durable snapshot committed
-  stopped --> preparing: resume
+  checkpointing --> stopped_local: durable upload failed
+  stopped_local --> checkpointing: retry upload
+  stopped_local --> stopped: grace expiry + prior snapshot
+  stopped_local --> lost: grace expiry + no prior snapshot
+  stopped --> preparing: resume leases acquired
+  stopped_local --> preparing: same-host resume leases acquired
   ready --> deleting: delete or expiry
   stopped --> deleting: delete or expiry
+  stopped_local --> deleting: delete or expiry
   deleting --> deleted: keys and records tombstoned
   reserving --> failed
   preparing --> failed
   booting --> failed
-  executing --> lost: host lost after acceptance
+  executing --> lost: execution outcome unknown
+  cancelled --> [*]
   failed --> [*]
   deleted --> [*]
   lost --> [*]
 ```
 
 State transitions are compare-and-swap operations in Postgres with monotonic
-generation numbers. Commands have independent IDs and idempotency keys.
+generation numbers. The alpha permits one active command per sandbox; a second
+command returns `409 COMMAND_ACTIVE`. This keeps sandbox `executing` canonical.
+Parallel commands can later use an active-command count without changing each
+command's state machine.
+
+`failed` applies to a first create that never became ready. A resume
+preparation/boot failure releases the new leases and returns to the prior
+`stopped` generation; it never destroys the last durable snapshot.
+
+Commands have independent IDs, idempotency keys, and durable states:
+
+```text
+created → dispatching → accepted → running
+                                ↘ succeeded | failed | timed_out | cancelled
+                  dispatch ambiguity → reconciling → not_started | lost
+```
+
+The host persists `(sandbox_generation, command_id, fencing_token, accepted)`
+before process spawn, then acknowledges. After reconnect, the coordinator asks
+for that durable operation record. A command is safe to dispatch elsewhere only
+when the host proves `not_started`; any unresolved post-send ambiguity is
+`lost`, even if the coordinator never received acceptance.
+
+Two leases are distinct:
+
+- A **developer compute lease** authorizes at most 15 minutes of ready/executing
+  user work plus a separately itemized, pre-funded 60-second shutdown guard.
+- A **capacity lease** is a short renewable host/global-slot fence, initially
+  60 seconds and renewed every 20 seconds, carrying coordinator epoch,
+  sandbox generation, and a monotonic fencing token.
+
+The daemon rejects stale tokens and starts no work whose capacity lease cannot
+cover startup. A command's timeout must fit inside the remaining 15-minute
+billable window; the 60-second guard accepts no new user work. At billable
+expiry the daemon terminates processes and durably reports
+`execution_halted_at` after the VM is paused/stopped. Compute metering ends at
+that timestamp, bounded by the pre-funded guard.
+
+Snapshot encryption/upload then runs as a separately bounded, non-compute
+storage operation. Success reaches `stopped`; failure reaches `stopped_local`,
+which retains a same-host encrypted disk but makes no portable-durability claim.
+Retrying upload remains non-compute. Resuming from either stopped state acquires
+fresh balance and capacity leases; `stopped_local` can resume only on that host.
+Host loss from `stopped_local` loses the uncommitted generation. This state has
+a short platform-funded recovery grace, initially 10 minutes; expiry discards
+the failed local generation and falls back to the previous durable snapshot, or
+becomes `lost` when none exists.
+
+For capacity fencing, the daemon uses the shorter of signed wall-clock expiry
+and the received lease duration on a monotonic clock and fails closed on
+coordinator partition, Aqua-session loss, sleep, restart, or renewal failure.
+The coordinator does not reassign a global macOS slot until the old lease
+expires plus the measured clock-skew/stop guard or the old daemon proves
+execution halted. A malicious host can violate local execution rules; it cannot
+obtain a second billable fenced lease.
 
 Deadlines exist at three layers:
 
@@ -420,13 +625,30 @@ Deadlines exist at three layers:
 2. host daemon VM/process deadline; and
 3. guest agent process deadline.
 
-The earliest deadline wins. Timeout sends graceful termination, waits a short
-fixed grace period, then force-stops the process or VM. Metering stops no later
-than the coordinator's observed terminal deadline.
+The earliest deadline wins. A command timeout terminates that process and
+returns the sandbox to `ready` while funded time remains. Sandbox/lease timeout
+terminates all processes, waits a fixed grace period, force-stops the VM, and
+records `execution_halted_at`. Checkpoint upload does not extend compute
+billing.
 
-Before `ready`, host failure releases the reservation and permits another host
-attempt within the create deadline. After command acceptance, host failure
-returns `lost` and never silently replays the command.
+Before command dispatch, host failure releases the lease and permits another
+host attempt after fencing safety. After dispatch, the command reconciliation
+rules above apply and never silently replay side effects.
+
+Canonical error and settlement behavior:
+
+| Code | Result | Charge |
+|---|---|---|
+| `QUOTE_EXPIRED` | Queue/admission stops; caller requotes | None |
+| `QUEUE_TIMEOUT` | Sandbox becomes `cancelled` | None |
+| `PREPARE_FAILED` | Sandbox becomes `failed` | None |
+| `BOOT_FAILED` | Sandbox becomes `failed` | None |
+| `COMMAND_DISPATCH_UNKNOWN` | Reconcile, then `not_started` or `lost` | Observed compute through halt; no duplicated command |
+| `COMMAND_TIMEOUT` | Command `timed_out`; sandbox returns ready if funded time remains | Compute continues only until idle/lease stop |
+| `CHECKPOINT_FAILED` | Sandbox becomes `stopped_local`; retry or same-host resume | Compute ended at `execution_halted_at`; no durable-storage charge for failed generation |
+| `LEASE_EXPIRED` | Fail-closed halt; sandbox checkpoints or becomes `stopped_local`/`lost` | Capped by billable window plus pre-funded guard |
+| `HOST_LOST` | Pre-dispatch retry after fence; post-dispatch `lost` | No later than heartbeat cutoff |
+| `INSUFFICIENT_BALANCE` | Renewal/create rejected; controlled stop | Existing authorized lease only |
 
 ## 12. Scheduling
 
@@ -435,18 +657,21 @@ Scheduling is filter-then-rank:
 1. Filter for permission, trust, daemon/runtime version, OS image, chip
    requirement, computer-use capability, region, egress policy, disk, vCPU,
    memory, exclusivity, and posted-price ceiling.
-2. Atomically reserve host resources and a global macOS slot.
+2. Atomically acquire host resources and a global macOS capacity lease with a
+   new fencing token.
 3. Rank eligible offers by final quoted price plus measured startup,
    reliability, load, and cache-miss costs.
 4. Add a bounded sticky-cache preference.
 5. Use random spread only among near-equal candidates.
 
-The reservation record includes every resource deducted from host capacity.
+The capacity-lease record includes every resource deducted from host capacity,
+`lease_until`, coordinator epoch, sandbox generation, and fencing token.
 Disconnect, preparation failure, timeout, cancellation, daemon restart, and
 coordinator recovery all converge on the same idempotent release path.
 
-The global two-macOS limit is checked in the same transaction as the sandbox
-state transition. A process-local counter is insufficient.
+The global two-macOS limit is acquired in the same transaction as the lease and
+sandbox state transition. Expired/stale holders cannot renew or mutate state.
+A process-local counter or a durable row without host fencing is insufficient.
 
 ## 13. Billing and settlement
 
@@ -456,26 +681,43 @@ short validity window and contains:
 - compute rate by vCPU-second and GiB-second;
 - chip, computer-use, and exclusivity premiums;
 - successful boot fee, if any;
-- retained-storage rate;
+- durable-storage and optional sticky-cache rates;
 - expected warm/cold startup;
-- maximum command hold; and
+- compute-lease duration, idle-stop policy, and maximum hold;
+- explicit network-egress cap; and
 - platform fee and taxes where applicable.
 
-Creation places a durable balance hold for the quoted maximum. Settlement uses
-coordinator-observed state plus bounded provider usage heartbeats:
+Queueing places no hold. Admission places a durable balance hold for the
+15-minute billable compute window, 60-second shutdown guard, maximum successful
+boot fee, taxes, 24-hour retained-storage authorization, optional sticky-cache
+add-on, and caller-selected egress cap. A lease renewal atomically settles prior
+usage, verifies project spend as `settled + open holds`, places the next hold,
+and only then extends host execution.
+
+Ready sandboxes auto-pause after two idle minutes by default; the caller may
+choose a shorter idle timeout or explicitly renew up to the product limit. A
+command timeout must fit inside the remaining billable window. The shutdown
+guard funds termination only and accepts no new command. Retention is a
+stopped-state storage clock, not permission to bill 24 ready hours.
+
+Settlement uses coordinator-observed state plus bounded provider usage
+heartbeats:
 
 - no charge for a sandbox that never reaches `ready`;
 - an optional boot fee only after successful guest readiness;
-- compute from `ready` until `stopped`, `deleted`, or the terminal deadline;
+- compute from `ready` through durable daemon-confirmed
+  `execution_halted_at`, capped by the billable window plus shutdown guard;
 - storage by actual retained encrypted bytes over time;
-- no compute charge while stopped;
+- no compute charge while checkpointing, `stopped_local`, or `stopped`;
 - no charge after a missing heartbeat grace limit; and
 - automatic release/refund of unused hold.
 
 Provider earnings and the platform fee settle atomically with the consumer
 debit. Use new sandbox ledger entry types and usage tables; inference's alpha
 `platformFeePercent` remains unrelated. Stripe Connect remains the provider
-withdrawal rail.
+withdrawal rail. Phase 2 durable object-storage revenue pays platform/object
+store cost and creates no host storage payout. Phase 3 sticky-cache add-on
+revenue alone earns the selected host a verified byte-second payout.
 
 See [Economics and pricing](2026-08-22-sandbox-economics.md) for the unit model
 and recommended launch bands.
@@ -488,12 +730,29 @@ Add focused store domains instead of extending the inference usage model:
 |---|---|
 | `sandbox_hosts` | Attested host identity and durable operator ownership |
 | `sandbox_offers` | Runtime capabilities, posted rates, and availability |
+| `sandbox_key_policies` | Per-API-key product, resource, egress, viewer, and spend limits |
 | `sandboxes` | Owner, desired shape, lifecycle state, generation, and expiry |
-| `sandbox_reservations` | Durable balance and host-resource holds |
+| `sandbox_balance_holds` | Durable consumer authorization by quote and lease |
+| `sandbox_capacity_leases` | Host/global-slot resources, expiry, epoch, and fence |
 | `sandbox_commands` | Idempotency, acceptance, deadline, and terminal outcome |
-| `sandbox_snapshots` | Manifest, encrypted bytes, wrappers, and cache locations |
+| `sandbox_snapshots` | Manifest, identity/config, encrypted bytes, and cache locations |
+| `sandbox_key_wrappers` | Host and recovery wrappers with generation/revocation |
 | `sandbox_usage_slices` | Bounded compute/storage meter intervals |
 | `sandbox_settlements` | Atomic consumer debit, provider earning, and fee |
+
+The current inference API-key schema does not express simultaneous daily/monthly
+sandbox spend, product, resource, egress, computer-use, or viewer scopes. The
+new policy domain is keyed by API-key ID and enforced on quote, create, lease
+renewal, command, file, computer-use, and viewer endpoints. Open holds count
+toward every spend check.
+
+No sandbox policy means deny. Every quote, session grant, and compute lease
+binds the policy revision that authorized it. Admission and every renewal
+revalidate the current revision. Revoking the API key or policy immediately
+invalidates queued quotes, closes viewer/data grants, rejects new operations,
+terminates an active command, and starts the funded shutdown path; host cleanup
+control remains available to the coordinator. A less-permissive policy update
+uses the same fail-closed behavior.
 
 Memory-store implementations support local tests. Production requires Postgres;
 a coordinator must refuse sandbox serving when only the memory store is
@@ -548,11 +807,13 @@ Provider to coordinator:
 - `sandbox_command_exit`
 - `sandbox_checkpoint_status`
 - `sandbox_usage_heartbeat`
+- `sandbox_operation_snapshot`
 - `sandbox_failure`
 
 Coordinator to provider:
 
 - `sandbox_prepare`
+- `sandbox_lease_renew`
 - `sandbox_command`
 - `sandbox_cancel_command`
 - `sandbox_checkpoint`
@@ -560,10 +821,23 @@ Coordinator to provider:
 - `sandbox_delete`
 - `sandbox_drain`
 
-Every message includes host ID, sandbox ID, sandbox generation, operation ID,
-protocol version, and monotonic sequence where relevant. Unknown future fields
-are ignored; unknown message types fail closed. Payload sizes are bounded before
-full decode. Command/file/desktop data uses a separate framed stream.
+Connection-level messages carry protocol version, authenticated host ID,
+coordinator epoch, connection epoch, and per-direction sequence. Registration
+has no sandbox fields. Sandbox-operation messages additionally require sandbox
+ID, sandbox generation, operation ID, and fencing token. Heartbeats carry a
+bounded summary of active lease IDs/tokens for reconciliation.
+
+The receiver persists the highest contiguous sequence/operation result, rejects
+stale fencing tokens, ignores exact duplicates, and requests replay for a
+bounded gap. Reconnect creates a new connection epoch and begins with operation
+reconciliation before new dispatch. Unknown future fields are ignored; unknown
+message types, oversized payloads, invalid transitions, and unbounded gaps fail
+closed.
+
+Command/file/desktop data uses a separate framed protocol with session grant,
+direction, counter, flow-control credit, and terminal acknowledgement. Canonical
+fixtures must round-trip through Go and Swift for host control and through
+TypeScript, Python, Swift, and the Linux guest agent for the data protocol.
 
 ## 17. Verification strategy
 
@@ -578,8 +852,17 @@ claims to support.
 - Property/state-machine tests covering invalid and duplicate transitions.
 - Concurrent reservation tests proving no third macOS sandbox can pass the
   global limit.
+- Capacity-lease tests across partition, coordinator failover, host sleep,
+  clock skew, stale fencing token, and reconnect.
 - Crash-recovery tests between hold, host reservation, ready, settlement, and
   release.
+- Compute-lease renewal and insufficient-balance tests proving the daemon stops
+  before authorization expires.
+- Full 15-minute command plus shutdown-guard tests proving user work cannot
+  consume the guard and compute ends at `execution_halted_at`.
+- Command dispatch/ack crash tests proving ambiguous side effects become
+  `lost`, never a transparent retry.
+- API-key/policy absence, revision, downgrade, and mid-command revocation tests.
 - Protocol symmetry fixtures decoded in both Go and Swift.
 - Exact micro-USD billing tests across rounding and deadline boundaries.
 
@@ -590,10 +873,20 @@ claims to support.
 - Cold and sticky-cache boot latency distributions.
 - CPU, memory, disk, network, and host-overhead measurements for every shape.
 - Host-path, LAN, metadata, and cross-sandbox access denial.
+- Packet-gateway tests for IPv4 private/link-local ranges, DNS rebinding,
+  malformed frames, helper crash, stale policy, rule cleanup, and disabled IPv6.
 - Encrypted-overlay tamper, wrong-key, replay, deletion, and host-migration
   tests.
+- Object-store outage, partial materialization, manifest rollback, backup
+  retention, `stopped_local`, and both recovery-mode tests.
+- Fresh machine/auxiliary identity on create, preserved portable configuration,
+  and surfaced host-derived identity change on stopped migration.
+- Signed bundle, provisioning profile, entitlement, APNs challenge, installer,
+  Aqua-session/XPC loss, drain-upgrade, and rollback verification.
 - Power-loss simulation while writing a snapshot.
-- Public-repository GitHub Actions workflow with secrets disabled.
+- Approved-SHA public GitHub workflow with read-only token; explicit rejection
+  of OIDC, secrets, write permissions, release/deploy/signing,
+  `pull_request_target`, and unapproved reusable workflows.
 
 ### Computer use
 
@@ -602,6 +895,7 @@ claims to support.
 - Confirmation that the driver cannot reach the provider desktop.
 - Confirmation that screenshots and input text do not enter coordinator logs or
   telemetry.
+- Confirmation that Cua product telemetry is disabled and egress-blocked.
 
 ### Linux
 
@@ -611,6 +905,17 @@ claims to support.
 
 ## 18. Delivery sequence and gates
 
+| Capability | First phase |
+|---|---:|
+| Local two-VM substrate proof | 0 |
+| Durable quotes, holds, leases, fencing, and protocol | 1 |
+| Permissioned macOS command/file API | 2 |
+| Encrypted portable persistence and pause/resume | 2 |
+| Sticky-cache marketplace and provider cache earnings | 3 |
+| Policy-gated GitHub JIT runners | 3 |
+| macOS computer use | 4 |
+| Linux Firecracker sandbox | 5 |
+
 ### Phase 0 — substrate proof
 
 Build a local, single-host macOS harness using a pinned Lume commit:
@@ -619,41 +924,49 @@ Build a local, single-host macOS harness using a pinned Lume commit:
 2. boot two isolated VMs;
 3. run commands through a guest agent;
 4. enforce a 15-minute deadline;
-5. stop, clone, and restore encrypted workspace state;
-6. measure cold/warm startup and host overhead; and
-7. run Cua Driver inside one guest.
+5. materialize, stop, encrypt, and restore boot/workspace disk state;
+6. prove fail-closed per-VM packet-gateway isolation;
+7. measure cold/warm startup and host overhead; and
+8. run Cua Driver inside one guest with telemetry disabled.
 
-Gate: proceed only if the VM can be lifecycle-managed without host GUI
-interaction, encrypted state survives restart, two guests remain isolated, and
-TCC state is reproducible. Record measured limits instead of projecting them.
+Gate: proceed only if the VM can be lifecycle-managed without manual host-GUI
+interaction after bootstrap while the required Aqua session remains logged in,
+encrypted state survives restart, two guests remain isolated, and network/TCC
+state is reproducible. Record measured limits instead of projecting them.
 
 ### Phase 1 — durable sandbox control plane
 
-Implement sandbox tables, state transitions, quotes, durable holds, settlement,
-host registration, the dedicated protocol, atomic two-slot admission, and API
-idempotency.
+Implement sandbox tables, canonical state/command transitions, quotes, durable
+balance holds, compute and fenced capacity leases, settlement, host
+registration, the dedicated protocol, atomic two-slot admission, API-key
+sandbox policies, and API idempotency.
 
 Gate: restart and concurrency tests prove there is no double allocation,
-double charge, leaked hold, or third macOS admission.
+double charge, leaked hold, unfunded execution, stale-fence mutation, or third
+billable macOS admission.
 
 ### Phase 2 — permissioned macOS command alpha
 
 Ship the signed sandbox daemon, VZ runtime adapter, guest agent, base-image
-pipeline, command/file API, egress isolation, fixed shapes, 25/50 GiB disks,
-timeouts, and provider drain controls.
+pipeline, command/file API, egress isolation, fixed shapes, 25/50 GiB workspace,
+encrypted boot/workspace snapshots, dual recovery modes, portable restore,
+retained-storage metering, timeouts, and provider drain controls.
 
 Gate: the full developer journey works on two real VMs, failed starts are free,
-timeouts stop both work and billing, and host loss produces the documented
-non-replayed `lost` result.
+command timeouts stop the process, lease expiry durably halts execution and
+billing before checkpoint upload, pause/resume restores exact bytes, and host
+loss produces the documented non-replayed `lost` result. The named legal owner
+must record launch approval before this phase serves external developers.
 
-### Phase 3 — sticky encrypted persistence
+### Phase 3 — sticky cache and GitHub Actions
 
-Add chunk manifests, dual-wrapped DEKs, retained storage metering, cache-aware
-scheduling, portable restore, garbage collection, and provider cache earnings.
+Add cache-aware scheduling, local cache earnings, garbage collection, measured
+warm-start pricing, and the policy-enforcing GitHub App/JIT runner integration.
 
 Gate: tamper and wrong-host unwrap fail closed; migration restores exact bytes;
 deleted sandboxes have no usable key wrapper; measured warm-start savings exceed
-the added cache cost.
+the added cache cost; and disallowed GitHub permissions/events/workflows are
+rejected before a runner credential is created.
 
 ### Phase 4 — macOS Computer
 
@@ -696,19 +1009,24 @@ These defaults make the plan executable without hiding product decisions:
 
 | Decision | Proposed default |
 |---|---|
-| macOS alpha capacity | Two running sandboxes globally |
+| macOS alpha capacity | Two valid running capacity leases globally |
 | Command deadline | 15 minutes, lower caller value allowed |
+| Compute lease | 15 billable minutes plus 60-second pre-funded shutdown guard |
+| Ready idle timeout | 2 minutes, then checkpoint and stop |
 | Retention | 24 hours by default; developer may delete earlier |
 | Compute while stopped | Not billed |
-| Disk | 25 GiB default, 50 GiB option |
+| macOS boot disk | 100 GiB sparse proof default; measured before launch |
+| Workspace | 25 GiB default, 50 GiB option |
 | Workloads | Permissioned, public/no-durable-secret jobs |
 | macOS substrate | Pinned Lume proof, then retain or replace behind adapter |
 | Linux substrate | Firecracker+jailer |
 | Normal GPU claim | None |
 | Timing-sensitive tier | Exclusive whole host |
 | Provider data access claim | Host is trusted in alpha |
-| Cache key recovery | Dual wrap required before portable persistence |
+| macOS host session | Dedicated Aqua account remains logged in for APNs |
+| Recovery | Platform-managed default; tenant-managed option |
 | Pricing | Resource rates plus explicit premiums; no hidden 24-hour floor |
+| External alpha gate | Recorded legal owner approval |
 
 ## 21. Source snapshot
 
@@ -716,9 +1034,10 @@ External behavior and prices change. These sources were checked on 2026-08-22:
 
 - [Apple Virtualization framework](https://developer.apple.com/documentation/virtualization)
 - [VZVirtualMachineConfiguration](https://developer.apple.com/documentation/virtualization/vzvirtualmachineconfiguration)
+- [VZFileHandleNetworkDeviceAttachment](https://developer.apple.com/documentation/virtualization/vzfilehandlenetworkdeviceattachment)
 - [Cua repository](https://github.com/trycua/cua)
 - [Lume documentation](https://cua.ai/docs/lume/guide/getting-started/installation)
 - [Cua Driver documentation](https://cua.ai/docs/how-to-guides/driver/install)
 - [Firecracker architecture](https://firecracker-microvm.github.io/)
+- [GitHub JIT runner configuration](https://docs.github.com/en/rest/actions/self-hosted-runners)
 - [Tart license](https://github.com/openai/tart/blob/main/LICENSE)
-

--- a/docs/reports/2026-08-22-sandbox-platform-plan.md
+++ b/docs/reports/2026-08-22-sandbox-platform-plan.md
@@ -57,24 +57,28 @@ The private alpha has these hard constraints:
    quote dimensions.
 8. A normal sandbox receives no fractional GPU guarantee. Timing-sensitive CPU
    or GPU work uses an exclusive-host product.
-9. Compute is metered from `ready` through daemon-confirmed
-   `execution_halted_at`, including at most the pre-funded shutdown guard. New
-   user work is accepted only in `ready`/`executing`. A retained, stopped
-   sandbox pays storage but not a 24-hour compute minimum.
+9. Compute is metered from `ready` through durable `metering_ended_at`, normally
+   backed by daemon-confirmed `execution_halted_at` and otherwise by a bounded
+   host-loss cutoff, including at most the pre-funded shutdown guard. New user
+   work is accepted only in `ready`/`executing`. A retained, stopped sandbox
+   pays storage but not a 24-hour compute minimum.
 
 ### GitHub Actions caveat
 
 "No secrets" and an arbitrary GitHub Actions runner are incompatible. A runner
 uses short-lived registration credentials and receives a `GITHUB_TOKEN`; public
-repositories can still expose repository/environment secrets, OIDC identity,
-write permissions, reusable workflows, or privileged `pull_request_target`
-behavior. A provider can read ephemeral credentials and alter build results.
+repositories can still expose organization/repository/environment secrets,
+inherited reusable-workflow secrets, OIDC identity, write permissions, or
+privileged `pull_request_target` behavior. A provider can read ephemeral
+credentials and alter build results.
 
 The alpha runner gate therefore requires an approved workflow commit SHA,
-read-only token permissions, no OIDC, no repository/environment secrets, no
+read-only token permissions, no OIDC, no organization/repository/environment
+secrets, no `secrets: inherit` or `${{ secrets.* }}` references, no
 release/deploy/signing jobs, no unapproved reusable workflow, and no
-`pull_request_target`. The GitHub App rejects a job when it cannot prove those
-conditions. Jobs use GitHub's
+`pull_request_target`. Actions and reusable workflows must be allowlisted and
+pinned to immutable SHAs. The GitHub App resolves the effective workflow graph
+and rejects a job when it cannot prove those conditions. Jobs use GitHub's
 [JIT runner configuration API](https://docs.github.com/en/rest/actions/self-hosted-runners)
 and an explicitly labeled **no durable secrets, host-trusted integrity** mode.
 
@@ -200,6 +204,12 @@ and key-wrapping primitives into a small Swift module consumed by both
 `ProviderCore` and the new sandbox daemon. The two daemons remain separate
 processes so a VM lifecycle failure cannot terminate inference.
 
+The only shared scheduling primitive is a small physical-host workload arbiter
+keyed by the enrolled hardware identity. It owns mutually exclusive
+`inference`, `draining`, and `sandbox_dedicated` mode leases. Both routing
+chokepoints must consult it atomically; neither scheduler imports the other.
+There is no mixed inference/sandbox host mode in the private alpha.
+
 ## 6. Host runtime
 
 ### 6.1 macOS
@@ -263,14 +273,30 @@ makes the host ineligible for new or renewed capacity leases. The coordinator
 binds the sandbox identity to the already enrolled physical machine and does
 not reuse the inference private key.
 
-The release workflow signs the nested daemon, XPC boundary, and app; embeds
-their distinct provisioning profiles; notarizes the final bundle; and computes
-hashes after signing. APNs code attestation covers the complete signed manifest.
+APNs proves that the bridge has Darkbloom's App ID, Team ID, and push
+entitlement; it does **not** bind an exact `cdhash` or nested daemon/helper
+bytes. The release workflow therefore signs every component, computes
+post-signing hashes and code-directory identities, and signs a release manifest
+containing those values.
+
+For each APNs-delivered nonce, the genuine bridge verifies the running daemon's
+XPC audit token and code signature, verifies installed helper/app bytes against
+that Darkbloom-signed manifest, and forwards the encrypted nonce only to that
+peer together with the verified manifest digest and observed daemon code
+identity. The daemon decrypts the nonce and uses its sandbox-specific Secure
+Enclave key to sign a canonical response binding those values, its public key,
+the daemon WebSocket session key, and connection epoch. The coordinator verifies
+the nonce, signature, blessed manifest digest, and connection binding before
+issuing or renewing capacity. This combined APNs-plus-manifest protocol covers
+the installed release; APNs alone does not. A malicious host root remains inside
+the alpha trust boundary and can subvert local inspection, so this is code-drift
+detection rather than confidential execution.
+
 The installer verifies and installs the LaunchDaemon/LaunchAgent separately.
 Upgrade drains first; rollback accepts only a still-supported signed manifest.
-An independent sandbox protocol/version floor gates eligibility. These steps
-require coordinated changes to the release workflow, installer, release
-manifest, coordinator version gate, and uninstall path.
+An independent sandbox protocol/version and manifest floor gates eligibility.
+These steps require coordinated changes to the release workflow, installer,
+release manifest, coordinator version gate, and uninstall path.
 
 ### 6.2 Linux
 
@@ -321,9 +347,12 @@ workspace quota, not the whole macOS disk. Tenant system changes consume
 copy-on-write boot-disk extents and count toward retained bytes.
 
 The scheduler validates each shape against the selected host. It never
-oversubscribes memory. Shared CPU may be scheduled, but the exclusive shape
-admits no other sandbox or inference workload on that host for the reservation
-window.
+oversubscribes memory. In the private alpha, enabling sandbox service first
+drains inference and atomically acquires the physical host's
+`sandbox_dedicated` workload-mode lease. Standard shapes may share that
+sandbox-only host. The exclusive shape admits no other sandbox for its
+reservation window. A future mixed mode requires a shared resource arbiter and
+measured interference limits; independent capacity counters are insufficient.
 
 An exact chip request such as `chip.name = "M5"` is a hard filter and carries
 the matching posted premium. A portable request should prefer
@@ -355,6 +384,13 @@ an authenticated chunk tree plus the portable VM configuration needed to
 reconstruct local disk images. Linux uses immutable rootfs layers plus a writable
 block overlay.
 
+The portable encrypted generation has four tenant roles: `boot_delta`,
+`workspace`, `auxiliary_storage`, and `vm_configuration`. Auxiliary-storage
+bytes, machine identifiers, hardware model, guest version, and other sensitive
+VM configuration are encrypted under the sandbox DEK. Only the minimum
+non-secret compatibility index needed to find an eligible host remains outside
+that ciphertext.
+
 The 25/50 GiB selection is the workspace logical quota. Billing for retained
 state uses actual unique encrypted boot-delta and workspace bytes, rounded in
 documented units, rather than sparse-disk capacities.
@@ -381,14 +417,18 @@ flowchart TD
   Recovery["Tenant or platform recovery key"] -->|"second wrapped copy"| DEK
   DEK -->|"AEAD + manifest binding"| Boot["Encrypted boot-delta chunks"]
   DEK -->|"AEAD + manifest binding"| Workspace["Encrypted workspace chunks"]
+  DEK -->|"AEAD + manifest binding"| Auxiliary["Encrypted auxiliary storage"]
+  DEK -->|"AEAD + manifest binding"| Config["Encrypted VM configuration"]
   Boot --> Object["Dedicated ciphertext object store"]
   Workspace --> Object
+  Auxiliary --> Object
+  Config --> Object
 ```
 
 - Generate a random 256-bit DEK per sandbox generation.
-- Encrypt chunks with AES-256-GCM or XChaCha20-Poly1305 using unique nonces and
-  authenticated metadata containing sandbox ID, generation, disk role, chunk
-  index, and parent-manifest hash.
+- Encrypt chunks and configuration records with AES-256-GCM or
+  XChaCha20-Poly1305 using unique nonces and authenticated metadata containing
+  sandbox ID, generation, role, chunk/record index, and parent-manifest hash.
 - Commit chunk hashes into an authenticated, versioned Merkle manifest. The
   store accepts a generation only with compare-and-swap against its parent, so
   rollback, omission, reordering, and split-brain writers fail closed.
@@ -539,27 +579,29 @@ stateDiagram-v2
   executing --> ready: command completed, timed out, or cancelled
   executing --> stopping: sandbox cancel or compute lease expiry
   ready --> stopping: pause, idle, or lease expiry
+  executing --> recovering: host unreachable + fence expires
+  ready --> recovering: host unreachable + fence expires
   stopping --> checkpointing: execution halted + retention requested
   stopping --> deleting: ephemeral or delete
+  stopping --> recovering: host disappears before halt confirmation
   checkpointing --> stopped: durable snapshot committed
   checkpointing --> stopped_local: durable upload failed
   stopped_local --> checkpointing: retry upload
-  stopped_local --> stopped: grace expiry + prior snapshot
-  stopped_local --> lost: grace expiry + no prior snapshot
+  stopped_local --> recovering: host lost or grace expires
+  recovering --> stopped: prior durable snapshot selected
+  recovering --> unrecoverable: no durable snapshot
   stopped --> preparing: resume leases acquired
   stopped_local --> preparing: same-host resume leases acquired
-  ready --> deleting: delete or expiry
   stopped --> deleting: delete or expiry
   stopped_local --> deleting: delete or expiry
+  unrecoverable --> deleting: delete or expiry
   deleting --> deleted: keys and records tombstoned
   reserving --> failed
   preparing --> failed
   booting --> failed
-  executing --> lost: execution outcome unknown
   cancelled --> [*]
   failed --> [*]
   deleted --> [*]
-  lost --> [*]
 ```
 
 State transitions are compare-and-swap operations in Postgres with monotonic
@@ -572,7 +614,16 @@ command's state machine.
 preparation/boot failure releases the new leases and returns to the prior
 `stopped` generation; it never destroys the last durable snapshot.
 
-Commands have independent IDs, idempotency keys, and durable states:
+`lost` is a **command outcome**, not a sandbox lifecycle state. After host loss,
+the sandbox enters `recovering` only after its meter is closed and its old fence
+can no longer renew. If a prior durable generation exists, recovery selects it
+and reaches `stopped` while recording that the newer generation and any
+in-flight command were lost. Without a durable generation it becomes
+`unrecoverable`, which preserves an auditable tombstone and permits deletion
+but cannot resume.
+
+Commands have independent IDs, scoped idempotency keys, opaque request
+commitments, and durable states:
 
 ```text
 created → dispatching → accepted → running
@@ -580,11 +631,22 @@ created → dispatching → accepted → running
                   dispatch ambiguity → reconciling → not_started | lost
 ```
 
-The host persists `(sandbox_generation, command_id, fencing_token, accepted)`
-before process spawn, then acknowledges. After reconnect, the coordinator asks
-for that durable operation record. A command is safe to dispatch elsewhere only
-when the host proves `not_started`; any unresolved post-send ambiguity is
-`lost`, even if the coordinator never received acceptance.
+An idempotency key is unique within `(project_id, sandbox_id,
+sandbox_generation)`. The SDK derives an opaque HMAC commitment over every
+behavior-affecting command field using a domain-separated key derived from the
+developer API key, so the coordinator can compare retries without storing
+command plaintext or a dictionary-testable unsalted hash. Reusing the key with
+the same commitment returns the original command; reusing it with a different
+commitment returns `409 IDEMPOTENCY_KEY_REUSED`.
+
+Before process spawn, both coordinator and host durably persist the scope,
+idempotency key, commitment, command ID, fencing token, and acceptance state.
+Host records survive reconnect and coordinator recovery for the lifetime of the
+sandbox generation, so a new command ID cannot bypass deduplication. After
+reconnect, the coordinator asks for that durable operation record. A command is
+safe to dispatch elsewhere only when the host proves `not_started`; any
+unresolved post-send ambiguity is `lost`, even if the coordinator never
+received acceptance.
 
 Two leases are distinct:
 
@@ -598,18 +660,28 @@ The daemon rejects stale tokens and starts no work whose capacity lease cannot
 cover startup. A command's timeout must fit inside the remaining 15-minute
 billable window; the 60-second guard accepts no new user work. At billable
 expiry the daemon terminates processes and durably reports
-`execution_halted_at` after the VM is paused/stopped. Compute metering ends at
-that timestamp, bounded by the pre-funded guard.
+`execution_halted_at` after the VM is paused/stopped.
+
+`metering_ended_at` is the canonical settlement endpoint. On a normal stop it
+equals the earlier of daemon-confirmed `execution_halted_at` and the funded
+cap. If the daemon disappears, `execution_halted_at` remains null and the
+coordinator durably sets `metering_ended_at` to the earliest of the missing-
+heartbeat cutoff, capacity-lease expiry, and funded cap, with
+`metering_end_reason` recording the source. The provider receives no payout
+after that cutoff. This billing cutoff does not prove execution halted and does
+not release the global slot early; reassignment still waits for fencing expiry
+plus the stop/skew guard.
 
 Snapshot encryption/upload then runs as a separately bounded, non-compute
-storage operation. Success reaches `stopped`; failure reaches `stopped_local`,
-which retains a same-host encrypted disk but makes no portable-durability claim.
-Retrying upload remains non-compute. Resuming from either stopped state acquires
-fresh balance and capacity leases; `stopped_local` can resume only on that host.
-Host loss from `stopped_local` loses the uncommitted generation. This state has
-a short platform-funded recovery grace, initially 10 minutes; expiry discards
-the failed local generation and falls back to the previous durable snapshot, or
-becomes `lost` when none exists.
+storage operation after a confirmed halt. Success reaches `stopped`; failure
+reaches `stopped_local`, which retains a same-host encrypted disk but makes no
+portable-durability claim. Retrying upload remains non-compute. Resuming from
+either stopped state acquires fresh balance and capacity leases;
+`stopped_local` can resume only on that host. Host loss from `stopped_local`
+loses the uncommitted generation. This state has a short platform-funded
+recovery grace, initially 10 minutes; expiry enters `recovering`, discards the
+failed local generation, and falls back to the previous durable snapshot or
+becomes `unrecoverable` when none exists.
 
 For capacity fencing, the daemon uses the shorter of signed wall-clock expiry
 and the received lease duration on a monotonic clock and fails closed on
@@ -628,8 +700,11 @@ Deadlines exist at three layers:
 The earliest deadline wins. A command timeout terminates that process and
 returns the sandbox to `ready` while funded time remains. Sandbox/lease timeout
 terminates all processes, waits a fixed grace period, force-stops the VM, and
-records `execution_halted_at`. Checkpoint upload does not extend compute
-billing.
+records `execution_halted_at` and `metering_ended_at`. Active delete follows
+this same stopping path before entering `deleting`. If the host is unreachable,
+the coordinator uses the bounded fallback meter cutoff above and waits for
+fencing safety instead of claiming a confirmed halt. Checkpoint upload does not
+extend compute billing.
 
 Before command dispatch, host failure releases the lease and permits another
 host attempt after fencing safety. After dispatch, the command reconciliation
@@ -643,11 +718,11 @@ Canonical error and settlement behavior:
 | `QUEUE_TIMEOUT` | Sandbox becomes `cancelled` | None |
 | `PREPARE_FAILED` | Sandbox becomes `failed` | None |
 | `BOOT_FAILED` | Sandbox becomes `failed` | None |
-| `COMMAND_DISPATCH_UNKNOWN` | Reconcile, then `not_started` or `lost` | Observed compute through halt; no duplicated command |
+| `COMMAND_DISPATCH_UNKNOWN` | Reconcile, then `not_started` or `lost` | Observed compute through `metering_ended_at`; no duplicated command |
 | `COMMAND_TIMEOUT` | Command `timed_out`; sandbox returns ready if funded time remains | Compute continues only until idle/lease stop |
-| `CHECKPOINT_FAILED` | Sandbox becomes `stopped_local`; retry or same-host resume | Compute ended at `execution_halted_at`; no durable-storage charge for failed generation |
-| `LEASE_EXPIRED` | Fail-closed halt; sandbox checkpoints or becomes `stopped_local`/`lost` | Capped by billable window plus pre-funded guard |
-| `HOST_LOST` | Pre-dispatch retry after fence; post-dispatch `lost` | No later than heartbeat cutoff |
+| `CHECKPOINT_FAILED` | Sandbox becomes `stopped_local`; retry or same-host resume | Compute already ended at `metering_ended_at`; no durable-storage charge for failed generation |
+| `LEASE_EXPIRED` | Fail-closed halt; sandbox checkpoints, becomes `stopped_local`, or enters recovery after host loss | Capped by billable window plus pre-funded guard |
+| `HOST_LOST` | Pre-dispatch retry after fence; in-flight command becomes `lost`; sandbox recovers a prior generation or becomes `unrecoverable` | Ends at bounded `metering_ended_at`; slot remains fenced until safe |
 | `INSUFFICIENT_BALANCE` | Renewal/create rejected; controlled stop | Existing authorized lease only |
 
 ## 12. Scheduling
@@ -657,12 +732,14 @@ Scheduling is filter-then-rank:
 1. Filter for permission, trust, daemon/runtime version, OS image, chip
    requirement, computer-use capability, region, egress policy, disk, vCPU,
    memory, exclusivity, and posted-price ceiling.
-2. Atomically acquire host resources and a global macOS capacity lease with a
-   new fencing token.
-3. Rank eligible offers by final quoted price plus measured startup,
+2. Rank eligible offers by final quoted price plus measured startup,
    reliability, load, and cache-miss costs.
-4. Add a bounded sticky-cache preference.
-5. Use random spread only among near-equal candidates.
+3. Add a bounded sticky-cache preference and random spread only among
+   near-equal candidates.
+4. Atomically acquire the selected host resources, physical-host workload mode,
+   and global macOS capacity lease with a new fencing token.
+5. If that compare-and-swap loses a race, refresh candidates and rerank; never
+   reserve an unranked host merely because it was observed first.
 
 The capacity-lease record includes every resource deducted from host capacity,
 `lease_until`, coordinator epoch, sandbox generation, and fencing token.
@@ -672,6 +749,9 @@ coordinator recovery all converge on the same idempotent release path.
 The global two-macOS limit is acquired in the same transaction as the lease and
 sandbox state transition. Expired/stale holders cannot renew or mutate state.
 A process-local counter or a durable row without host fencing is insufficient.
+The physical-host mode lease is acquired in that transaction as well. Inference
+routing refuses a host in `sandbox_dedicated` mode, and sandbox admission
+refuses a host until inference has drained and released `inference` mode.
 
 ## 13. Billing and settlement
 
@@ -705,8 +785,9 @@ heartbeats:
 
 - no charge for a sandbox that never reaches `ready`;
 - an optional boot fee only after successful guest readiness;
-- compute from `ready` through durable daemon-confirmed
-  `execution_halted_at`, capped by the billable window plus shutdown guard;
+- compute from `ready` through durable `metering_ended_at`, normally backed by
+  daemon-confirmed `execution_halted_at` and otherwise by the bounded
+  host-loss cutoff, capped by the billable window plus shutdown guard;
 - storage by actual retained encrypted bytes over time;
 - no compute charge while checkpointing, `stopped_local`, or `stopped`;
 - no charge after a missing heartbeat grace limit; and
@@ -730,6 +811,7 @@ Add focused store domains instead of extending the inference usage model:
 |---|---|
 | `sandbox_hosts` | Attested host identity and durable operator ownership |
 | `sandbox_offers` | Runtime capabilities, posted rates, and availability |
+| `host_workload_leases` | Physical-host inference/draining/sandbox mode fence |
 | `sandbox_key_policies` | Per-API-key product, resource, egress, viewer, and spend limits |
 | `sandboxes` | Owner, desired shape, lifecycle state, generation, and expiry |
 | `sandbox_balance_holds` | Durable consumer authorization by quote and lease |
@@ -801,6 +883,8 @@ Provider to coordinator:
 
 - `sandbox_host_register`
 - `sandbox_host_heartbeat`
+- `sandbox_apns_token_update`
+- `sandbox_code_attestation_response`
 - `sandbox_prepare_status`
 - `sandbox_ready`
 - `sandbox_command_accepted`
@@ -812,6 +896,7 @@ Provider to coordinator:
 
 Coordinator to provider:
 
+- `sandbox_code_attestation_status`
 - `sandbox_prepare`
 - `sandbox_lease_renew`
 - `sandbox_command`
@@ -823,9 +908,20 @@ Coordinator to provider:
 
 Connection-level messages carry protocol version, authenticated host ID,
 coordinator epoch, connection epoch, and per-direction sequence. Registration
-has no sandbox fields. Sandbox-operation messages additionally require sandbox
-ID, sandbox generation, operation ID, and fencing token. Heartbeats carry a
-bounded summary of active lease IDs/tokens for reconciliation.
+has no sandbox-operation fields and carries the current APNs token/environment,
+release-manifest digest, daemon session key, and physical-host workload mode.
+Token rotation uses `sandbox_apns_token_update`. The coordinator sends an
+encrypted `sandbox_code_attestation_challenge` through APNs, not through the
+WebSocket. The bridge/daemon returns the nonce-bound
+`sandbox_code_attestation_response` over the authenticated WebSocket, and the
+coordinator returns `sandbox_code_attestation_status`. Reconnect, token
+rotation, manifest change, Aqua-session recovery, and periodic expiry all force
+a fresh exchange; failure prevents lease issue/renewal.
+
+Sandbox-operation messages additionally require sandbox ID, sandbox generation,
+operation ID, and fencing token. Command messages also carry the scoped
+idempotency key and opaque request commitment. Heartbeats carry a bounded
+summary of active lease IDs/tokens for reconciliation.
 
 The receiver persists the highest contiguous sequence/operation result, rejects
 stale fencing tokens, ignores exact duplicates, and requests replay for a
@@ -854,14 +950,21 @@ claims to support.
   global limit.
 - Capacity-lease tests across partition, coordinator failover, host sleep,
   clock skew, stale fencing token, and reconnect.
+- Physical-host mode tests proving inference cannot route while sandbox mode is
+  active and sandbox mode cannot activate until inference drains.
 - Crash-recovery tests between hold, host reservation, ready, settlement, and
   release.
 - Compute-lease renewal and insufficient-balance tests proving the daemon stops
   before authorization expires.
 - Full 15-minute command plus shutdown-guard tests proving user work cannot
-  consume the guard and compute ends at `execution_halted_at`.
+  consume the guard and normal compute ends at confirmed
+  `execution_halted_at`/`metering_ended_at`.
 - Command dispatch/ack crash tests proving ambiguous side effects become
   `lost`, never a transparent retry.
+- Command idempotency tests for same-key replay, mismatched commitment,
+  coordinator recovery, and a changed command ID.
+- Host-loss settlement tests proving fallback `metering_ended_at` closes
+  billing without falsely setting `execution_halted_at` or releasing a fence.
 - API-key/policy absence, revision, downgrade, and mid-command revocation tests.
 - Protocol symmetry fixtures decoded in both Go and Swift.
 - Exact micro-USD billing tests across rounding and deadline boundaries.
@@ -875,14 +978,15 @@ claims to support.
 - Host-path, LAN, metadata, and cross-sandbox access denial.
 - Packet-gateway tests for IPv4 private/link-local ranges, DNS rebinding,
   malformed frames, helper crash, stale policy, rule cleanup, and disabled IPv6.
-- Encrypted-overlay tamper, wrong-key, replay, deletion, and host-migration
-  tests.
+- Encrypted boot/workspace/auxiliary/configuration tamper, wrong-key, replay,
+  deletion, and host-migration tests.
 - Object-store outage, partial materialization, manifest rollback, backup
   retention, `stopped_local`, and both recovery-mode tests.
 - Fresh machine/auxiliary identity on create, preserved portable configuration,
   and surfaced host-derived identity change on stopped migration.
-- Signed bundle, provisioning profile, entitlement, APNs challenge, installer,
-  Aqua-session/XPC loss, drain-upgrade, and rollback verification.
+- Signed bundle, provisioning profile, entitlement, APNs challenge,
+  audit-token peer binding, blessed-manifest mismatch, token rotation,
+  installer, Aqua-session/XPC loss, drain-upgrade, and rollback verification.
 - Power-loss simulation while writing a snapshot.
 - Approved-SHA public GitHub workflow with read-only token; explicit rejection
   of OIDC, secrets, write permissions, release/deploy/signing,
@@ -939,7 +1043,8 @@ state is reproducible. Record measured limits instead of projecting them.
 Implement sandbox tables, canonical state/command transitions, quotes, durable
 balance holds, compute and fenced capacity leases, settlement, host
 registration, the dedicated protocol, atomic two-slot admission, API-key
-sandbox policies, and API idempotency.
+sandbox policies, scoped command idempotency, and the physical-host workload
+mode fence.
 
 Gate: restart and concurrency tests prove there is no double allocation,
 double charge, leaked hold, unfunded execution, stale-fence mutation, or third
@@ -949,14 +1054,17 @@ billable macOS admission.
 
 Ship the signed sandbox daemon, VZ runtime adapter, guest agent, base-image
 pipeline, command/file API, egress isolation, fixed shapes, 25/50 GiB workspace,
-encrypted boot/workspace snapshots, dual recovery modes, portable restore,
-retained-storage metering, timeouts, and provider drain controls.
+encrypted boot/workspace/auxiliary/configuration snapshots, dual recovery modes,
+portable restore, retained-storage metering, timeouts, provider drain controls,
+and dedicated sandbox-host mode. Mixed inference/sandbox operation remains
+disabled.
 
 Gate: the full developer journey works on two real VMs, failed starts are free,
 command timeouts stop the process, lease expiry durably halts execution and
 billing before checkpoint upload, pause/resume restores exact bytes, and host
-loss produces the documented non-replayed `lost` result. The named legal owner
-must record launch approval before this phase serves external developers.
+loss produces the documented non-replayed in-flight command `lost` result. The
+named legal owner must record launch approval before this phase serves external
+developers.
 
 ### Phase 3 — sticky cache and GitHub Actions
 
@@ -1022,6 +1130,7 @@ These defaults make the plan executable without hiding product decisions:
 | Linux substrate | Firecracker+jailer |
 | Normal GPU claim | None |
 | Timing-sensitive tier | Exclusive whole host |
+| Host coexistence | Sandbox-dedicated mode; inference drained and fenced out |
 | Provider data access claim | Host is trusted in alpha |
 | macOS host session | Dedicated Aqua account remains logged in for APNs |
 | Recovery | Platform-managed default; tenant-managed option |

--- a/docs/reports/2026-08-22-sandbox-platform-plan.md
+++ b/docs/reports/2026-08-22-sandbox-platform-plan.md
@@ -579,11 +579,13 @@ stateDiagram-v2
   executing --> ready: command completed, timed out, or cancelled
   executing --> stopping: sandbox cancel or compute lease expiry
   ready --> stopping: pause, idle, or lease expiry
-  executing --> recovering: host unreachable + fence expires
-  ready --> recovering: host unreachable + fence expires
+  executing --> fence_wait: unconfirmed host-loss cutoff
+  ready --> fence_wait: unconfirmed host-loss cutoff
   stopping --> checkpointing: execution halted + retention requested
   stopping --> deleting: ephemeral or delete
-  stopping --> recovering: host disappears before halt confirmation
+  stopping --> fence_wait: host-loss cutoff before halt confirmation
+  fence_wait --> stopping: same fenced host reconnects for cleanup
+  fence_wait --> recovering: capacity fence expires
   checkpointing --> stopped: durable snapshot committed
   checkpointing --> stopped_local: durable upload failed
   stopped_local --> checkpointing: retry upload
@@ -615,12 +617,22 @@ preparation/boot failure releases the new leases and returns to the prior
 `stopped` generation; it never destroys the last durable snapshot.
 
 `lost` is a **command outcome**, not a sandbox lifecycle state. After host loss,
-the sandbox enters `recovering` only after its meter is closed and its old fence
-can no longer renew. If a prior durable generation exists, recovery selects it
-and reaches `stopped` while recording that the newer generation and any
-in-flight command were lost. Without a durable generation it becomes
-`unrecoverable`, which preserves an auditable tombstone and permits deletion
-but cannot resume.
+the sandbox immediately enters `fence_wait` when an unconfirmed host-loss
+cutoff closes its meter. That state rejects new work and visibly means "billing
+ended, execution not yet proven halted." It enters `recovering` only after its
+old capacity fence can no longer renew. If a prior durable generation exists,
+recovery selects it and reaches `stopped` while recording that the newer
+generation and any unresolved in-flight command were lost. Without a durable
+generation it becomes `unrecoverable`, which preserves an auditable tombstone
+and permits deletion but cannot resume.
+
+If the same attested daemon reconnects during `fence_wait`, it must present the
+same host workload lease, sandbox generation, fencing token, and durable
+operation log. Reconnect never reopens the settled compute lease or accepts new
+work. The coordinator reconciles a provable command terminal record, otherwise
+keeps it `reconciling`, and commands cleanup-only stop/checkpoint/delete. A
+different host or stale token cannot claim the generation. If cleanup does not
+complete before fencing safety, the sandbox proceeds to `recovering`.
 
 Commands have independent IDs, scoped idempotency keys, opaque request
 commitments, and durable states:
@@ -631,13 +643,23 @@ created → dispatching → accepted → running
                   dispatch ambiguity → reconciling → not_started | lost
 ```
 
-An idempotency key is unique within `(project_id, sandbox_id,
-sandbox_generation)`. The SDK derives an opaque HMAC commitment over every
-behavior-affecting command field using a domain-separated key derived from the
-developer API key, so the coordinator can compare retries without storing
-command plaintext or a dictionary-testable unsalted hash. Reusing the key with
-the same commitment returns the original command; reusing it with a different
-commitment returns `409 IDEMPOTENCY_KEY_REUSED`.
+An idempotency key is unique within `(api_key_id, sandbox_id,
+sandbox_generation)`. The SDK serializes every behavior-affecting command field
+with versioned RFC 8949 deterministic CBOR: map keys sorted canonically,
+integers in declared units, byte payloads represented by content digests, and
+absent values distinct from null/empty values. It then derives an opaque
+HMAC-SHA256 commitment using a domain-separated key derived from that developer
+API key. The coordinator can compare retries without storing command plaintext
+or a dictionary-testable unsalted hash. Reusing the key with the same
+commitment returns the original command; reusing it with a different commitment
+returns `409 IDEMPOTENCY_KEY_REUSED`.
+
+API-key rotation intentionally opens a new idempotency namespace; it cannot
+cause a false mismatch against the old key. A caller rotating credentials must
+query the original command ID before deciding to dispatch under the new key,
+because cross-key deduplication is not promised. TypeScript, Python, Swift, and
+guest implementations share canonical fixtures so the same command bytes
+produce the same commitment.
 
 Before process spawn, both coordinator and host durably persist the scope,
 idempotency key, commitment, command ID, fencing token, and acceptance state.
@@ -668,9 +690,10 @@ cap. If the daemon disappears, `execution_halted_at` remains null and the
 coordinator durably sets `metering_ended_at` to the earliest of the missing-
 heartbeat cutoff, capacity-lease expiry, and funded cap, with
 `metering_end_reason` recording the source. The provider receives no payout
-after that cutoff. This billing cutoff does not prove execution halted and does
-not release the global slot early; reassignment still waits for fencing expiry
-plus the stop/skew guard.
+after that cutoff. The sandbox enters `fence_wait` at the same transition. This
+billing cutoff does not prove execution halted and does not release the global
+slot early; reassignment still waits for fencing expiry plus the stop/skew
+guard.
 
 Snapshot encryption/upload then runs as a separately bounded, non-compute
 storage operation after a confirmed halt. Success reaches `stopped`; failure
@@ -722,7 +745,7 @@ Canonical error and settlement behavior:
 | `COMMAND_TIMEOUT` | Command `timed_out`; sandbox returns ready if funded time remains | Compute continues only until idle/lease stop |
 | `CHECKPOINT_FAILED` | Sandbox becomes `stopped_local`; retry or same-host resume | Compute already ended at `metering_ended_at`; no durable-storage charge for failed generation |
 | `LEASE_EXPIRED` | Fail-closed halt; sandbox checkpoints, becomes `stopped_local`, or enters recovery after host loss | Capped by billable window plus pre-funded guard |
-| `HOST_LOST` | Pre-dispatch retry after fence; in-flight command becomes `lost`; sandbox recovers a prior generation or becomes `unrecoverable` | Ends at bounded `metering_ended_at`; slot remains fenced until safe |
+| `HOST_LOST` | Enter `fence_wait`; reconcile same-host return or, after fence expiry, recover a prior generation / become `unrecoverable`; unresolved command becomes `lost` | Ends at bounded `metering_ended_at`; slot remains fenced until safe |
 | `INSUFFICIENT_BALANCE` | Renewal/create rejected; controlled stop | Existing authorized lease only |
 
 ## 12. Scheduling
@@ -962,9 +985,11 @@ claims to support.
 - Command dispatch/ack crash tests proving ambiguous side effects become
   `lost`, never a transparent retry.
 - Command idempotency tests for same-key replay, mismatched commitment,
-  coordinator recovery, and a changed command ID.
+  coordinator recovery, API-key rotation namespace, deterministic cross-SDK
+  serialization, and a changed command ID.
 - Host-loss settlement tests proving fallback `metering_ended_at` closes
-  billing without falsely setting `execution_halted_at` or releasing a fence.
+  billing, enters `fence_wait`, reconciles only the same fenced host, and does
+  not falsely set `execution_halted_at` or release a fence.
 - API-key/policy absence, revision, downgrade, and mid-command revocation tests.
 - Protocol symmetry fixtures decoded in both Go and Swift.
 - Exact micro-USD billing tests across rounding and deadline boundaries.

--- a/docs/reports/2026-08-22-sandbox-platform-plan.md
+++ b/docs/reports/2026-08-22-sandbox-platform-plan.md
@@ -1,0 +1,724 @@
+# Darkbloom sandbox platform plan
+
+Status: **proposed for review; no sandbox product is implemented yet**
+
+Date: 2026-08-22
+
+Companion documents:
+
+- [Provider and developer experience](2026-08-22-sandbox-user-experience.md)
+- [Economics and pricing](2026-08-22-sandbox-economics.md)
+
+This plan deliberately excludes legal and licensing analysis. It defines the
+product and engineering shape Darkbloom can build after legal review is handled
+separately.
+
+## 1. Decision
+
+Build a sandbox plane next to the inference plane, not inside it. Reuse
+Darkbloom's identity, account balance, deposits, payouts, provider enrollment,
+and attestation foundations. Give sandboxes their own host daemon, WebSocket
+protocol, scheduler, state machine, durable reservations, usage records, and
+rate cards.
+
+Launch three products behind one API:
+
+| Product | Isolation substrate | Initial use | Relative position |
+|---|---|---|---|
+| Linux Sandbox | Firecracker microVM on Linux/KVM | Agents, tests, builds, general code execution | Commodity, E2B-priced |
+| macOS Sandbox | One macOS VM per sandbox on Apple Virtualization.framework | Xcode, Apple-platform builds, public CI jobs | Scarce premium |
+| macOS Computer | macOS Sandbox plus a guest-local computer-use driver | GUI automation and agent evaluation | Highest premium |
+
+Start implementation with the macOS command sandbox. It is the differentiated
+product and validates the hardest host, image, and Secure Enclave constraints.
+Keep the common API runtime-neutral so the Linux Firecracker adapter can follow
+without changing the developer contract.
+
+## 2. Launch contract
+
+The private alpha has these hard constraints:
+
+1. The platform admits at most **two running macOS sandboxes globally**. This is
+   an explicit coordinator limit, not an undocumented operator convention.
+2. Each command has a **15-minute maximum execution time**. Sandbox retention
+   and command execution are separate clocks.
+3. A sandbox gets a **25 GiB logical disk** by default or **50 GiB** when
+   requested.
+4. Access is permissioned for both developers and providers.
+5. Alpha workloads must not rely on the provider being unable to inspect a
+   running VM. Persistent tenant data is encrypted at rest, but the host owner
+   remains inside the runtime trust boundary.
+6. CPU, memory, chip family, disk, cache retention, and exclusivity are explicit
+   quote dimensions.
+7. A normal sandbox receives no fractional GPU guarantee. Timing-sensitive CPU
+   or GPU work uses an exclusive-host product.
+8. Compute is metered only while a sandbox is ready or executing. A retained,
+   stopped sandbox pays storage but not a 24-hour compute minimum.
+
+### GitHub Actions caveat
+
+"No secrets" and an arbitrary GitHub Actions runner are incompatible. A runner
+uses short-lived registration credentials and can receive `GITHUB_TOKEN`,
+repository credentials, and configured job secrets. The alpha can support:
+
+- public repositories whose workflows receive no user-configured secrets; and
+- an explicitly labeled **no durable secrets** mode using one-time,
+  tightly-scoped registration credentials.
+
+Private-repository runners and workflows with valuable credentials remain
+disabled until the runtime threat model changes. Short-lived credentials reduce
+blast radius; they do not make an untrusted host confidential.
+
+## 3. First-principles constraints
+
+### 3.1 A macOS user account is not a tenant boundary
+
+App Sandbox constrains a signed app. A separate Unix user constrains ordinary
+filesystem access. Neither gives arbitrary, adversarial child code a separate
+kernel. The tenant boundary must therefore be a VM, with one guest per active
+sandbox. A dedicated host user can still reduce accidental host access by the
+sandbox daemon, but it is defense in depth rather than the product boundary.
+
+### 3.2 Computer use is a privileged guest capability, not isolation
+
+Cua Driver has screen-recording and input-control privileges. It must run only
+inside the tenant's VM. Running it on the provider's host would turn a guest
+feature into host compromise by design. The VM provides isolation; the driver
+provides automation.
+
+### 3.3 Secure Enclave protects keys, not running plaintext
+
+Bulk disks are encrypted with symmetric data-encryption keys. A Secure Enclave
+P-256 key wraps those keys; it does not encrypt 25–50 GiB directly. When the VM
+is running, plaintext necessarily exists in guest memory and storage blocks are
+decrypted for use. Secure Enclave key custody protects stopped images and cache
+files from offline theft, but it does not provide confidential computing
+against the machine owner.
+
+### 3.4 Resource labels must describe enforceable guarantees
+
+Virtualization.framework can configure guest vCPU count and memory size, but its
+public API does not pin vCPUs to specific performance cores or partition the
+Apple GPU. A "reserved GPU" label on a shared Mac would be false. The defensible
+timing-sensitive tier is exclusive use of the whole host, with measured chip
+performance and no co-tenant.
+
+### 3.5 Side effects prevent transparent retry
+
+The scheduler may fail over while preparing or booting a sandbox, before a
+command is accepted. Once a command starts, replaying it on another machine may
+duplicate deployments, purchases, or writes. A lost executing command therefore
+ends as `lost`; recovery resumes from the latest durable checkpoint only after
+an explicit developer action.
+
+## 4. System boundary
+
+```mermaid
+flowchart LR
+  Dev["Developer CLI / SDK"] --> API["Sandbox HTTP API"]
+  API --> Auth["Existing auth and accounts"]
+  API --> Control["Sandbox control service"]
+  Control --> Registry["Sandbox host registry"]
+  Control --> Billing["Durable holds and usage settlement"]
+  Registry --> Scheduler["Sandbox scheduler"]
+  Scheduler --> HostWS["Dedicated sandbox host WebSocket"]
+  HostWS --> MacDaemon["darkbloom-sandboxd on macOS"]
+  HostWS --> LinuxDaemon["darkbloom-sandboxd on Linux"]
+  MacDaemon --> VZ["Virtualization.framework runtime"]
+  LinuxDaemon --> FC["Firecracker runtime"]
+  VZ --> Guest["Guest agent"]
+  FC --> Guest
+  Dev <-->|"encrypted command/file stream"| Guest
+  Guest --> CUA["Guest-local computer-use driver"]
+```
+
+The coordinator owns identity, policy, quotes, admission, lifecycle intent,
+metering, and settlement. A dedicated sandbox relay carries bounded session
+streams for providers behind NAT during the alpha. It must not share the
+inference provider WebSocket writer: file transfer and desktop frames could
+otherwise block inference control traffic.
+
+The target data path establishes an ephemeral SDK-to-guest session key. The
+relay sees routing metadata and ciphertext, not command output, uploaded files,
+or screenshots. This keeps the coordinator out of tenant content, although it
+does not remove the host owner from the trust boundary.
+
+## 5. Reuse and separation in the current repository
+
+### Reuse
+
+- API-key and account authentication from `coordinator/auth/`,
+  `coordinator/api/`, and `coordinator/store/`.
+- The micro-USD double-entry ledger in `coordinator/payments/` and
+  `coordinator/store/`.
+- Stripe deposits and Connect payouts in `coordinator/billing/`.
+- Provider device linking, enrollment, hardware description, and attestation
+  concepts from `coordinator/api/provider.go`, `coordinator/attestation/`, and
+  `provider-swift/Sources/ProviderCore/Security/`.
+- The existing Secure Enclave ECIES key-wrapping pattern in
+  `provider-swift/Sources/ProviderCore/KVCache/SecureEnclaveKeyWrappingService.swift`.
+
+### Do not reuse
+
+- The inference `registry.Registry` or model scheduler for sandbox hosts.
+- Token pricing in `coordinator/payments/pricing.go`.
+- Inference usage rows as sandbox usage rows.
+- `serviceReservationManager` in `coordinator/api/reservations.go`; its
+  outstanding holds are process-local and cannot safely cover long-lived
+  sandboxes across coordinator restarts.
+- The inference provider WebSocket protocol in
+  `coordinator/protocol/messages.go` as an unstructured catch-all.
+- `ProviderCore` as the sandbox daemon's dependency. It pulls in MLX and
+  inference code that a virtualization daemon does not need.
+
+The first shared-code refactor should extract provider identity, attestation,
+and key-wrapping primitives into a small Swift module consumed by both
+`ProviderCore` and the new sandbox daemon. The two daemons remain separate
+processes so a VM lifecycle failure cannot terminate inference.
+
+## 6. Host runtime
+
+### 6.1 macOS
+
+Use Apple's Virtualization.framework as the production substrate. It exposes
+the VM configuration, CPU, memory, storage, networking, graphics, and macOS
+platform objects needed by this product.
+
+Use [Lume](https://github.com/trycua/cua/tree/main/libs/lume) as the first
+proof substrate because it is MIT-licensed, exercises the same framework, and
+already handles macOS image installation and unattended guest setup. Pin an
+audited commit and hide it behind a narrow `VirtualMachineRuntime` interface.
+After measurement, either:
+
+1. retain the audited Lume core if its lifecycle and embedding surface are
+   stable; or
+2. replace the adapter with a small direct Virtualization.framework
+   implementation that covers only create, start, stop, pause, disk attach,
+   network attach, and display.
+
+Do not start with Tart. It solves similar VM management problems but adds an
+[FSL-1.1-ALv2 commercial licensing surface](https://github.com/openai/tart/blob/main/LICENSE)
+without supplying a capability needed for the proposed alpha.
+
+`darkbloom-sandboxd` owns:
+
+- host registration, health, capacity, and drain state;
+- image verification and cache accounting;
+- atomic resource and disk reservation;
+- VM lifecycle and crash cleanup;
+- the guest-agent transport;
+- deadline enforcement;
+- usage heartbeats; and
+- deletion of ephemeral overlays and key material.
+
+It runs as a signed, hardened daemon under a dedicated host account. It opens no
+public inbound port; all control connections originate outbound.
+
+### 6.2 Linux
+
+Use [Firecracker](https://firecracker-microvm.github.io/) through its jailer on
+Linux/KVM. Each sandbox gets a guest kernel, root filesystem, cgroup limits,
+network namespace, seccomp-constrained VMM, and a vsock guest-agent channel.
+
+Do not use a plain Docker container as the public multi-tenant boundary. OCI
+images remain the developer packaging format, but the host converts or mounts
+their filesystem as a Firecracker root disk.
+
+The Linux and macOS runtimes implement the same lifecycle interface. Platform
+differences remain capabilities rather than forks in the public API.
+
+## 7. Resource model
+
+Every host advertises:
+
+- operating systems and guest versions;
+- machine model, chip name, chip family, chip tier, and measured benchmark
+  class;
+- physical performance/efficiency core counts and allocatable vCPUs;
+- total and allocatable memory;
+- graphics/computer-use support;
+- active, reserved, and maximum sandbox slots;
+- free image-cache and workspace bytes;
+- network region and egress policy;
+- daemon version and runtime version; and
+- attestation and code-identity status.
+
+Every offer defines a posted minimum price and hard capacity. The coordinator
+publishes a final quote within centrally configured price bands.
+
+For launch, expose a small number of fixed shapes rather than arbitrary
+combinations:
+
+| Shape | vCPU | Memory | Disk | Intended use |
+|---|---:|---:|---:|---|
+| `macos-s` | 4 | 8 GiB | 25 GiB | Builds and tests |
+| `macos-m` | 6 | 16 GiB | 25 GiB | Xcode and moderate parallelism |
+| `macos-l` | 8 | 32 GiB | 50 GiB | Large builds on eligible hosts |
+| `macos-exclusive` | Host capacity | Host capacity | 50 GiB | Timing-sensitive CPU/GPU |
+
+The scheduler validates each shape against the selected host. It never
+oversubscribes memory. Shared CPU may be scheduled, but the exclusive shape
+admits no other sandbox or inference workload on that host for the reservation
+window.
+
+An exact chip request such as `chip.name = "M5"` is a hard filter and carries
+the matching posted premium. A portable request should prefer
+`chip.minimum_benchmark_class` so future chips can satisfy it.
+
+## 8. Image and storage architecture
+
+### 8.1 Layering
+
+Each sandbox consists of:
+
+1. a read-only, content-addressed base image signed by Darkbloom;
+2. a tenant workspace overlay retained for the sandbox lifetime; and
+3. a per-run scratch overlay discarded on reset or failure.
+
+Base images are public and deduplicated. Tenant overlays are never shared.
+APFS clone semantics are a local optimization on macOS, not part of the
+portable image format. Linux uses immutable rootfs layers plus a writable block
+overlay.
+
+The 25/50 GiB selection is a logical quota. Billing for retained cache uses
+actual unique encrypted bytes, rounded in documented units, rather than the
+maximum sparse-disk size.
+
+### 8.2 Key hierarchy
+
+```mermaid
+flowchart TD
+  SE["Attested Secure Enclave P-256 key"] -->|"ECIES unwrap"| HK["Host cache KEK"]
+  HK -->|"unwrap"| DEK["Per-sandbox DEK"]
+  Recovery["Tenant or platform recovery key"] -->|"second wrapped copy"| DEK
+  DEK -->|"AEAD per chunk + metadata AAD"| Overlay["Encrypted workspace overlay"]
+  DEK -->|"AEAD per chunk + metadata AAD"| Snapshot["Encrypted portable snapshot"]
+```
+
+- Generate a random 256-bit DEK per sandbox generation.
+- Encrypt overlay chunks with AES-256-GCM or XChaCha20-Poly1305 using unique
+  nonces and authenticated metadata containing sandbox ID, generation, chunk
+  index, and image-manifest hash.
+- Wrap the DEK to the host Secure Enclave-backed KEK for local sticky-cache
+  access.
+- Store a second wrapped DEK under a tenant-controlled key or a platform
+  recovery KMS key. Without this second wrapper, a host-bound cache is not
+  portable and host loss permanently destroys the sandbox.
+- Delete all wrappers when a sandbox is destroyed; garbage-collect ciphertext
+  asynchronously.
+
+The existing provider cache proves the core ECIES wrapping primitive, but
+sandbox keys need a distinct domain label, KEK, storage namespace, and audit
+trail. Reusing a cryptographic primitive is acceptable; reusing key material
+across products is not.
+
+For local disks, use an encrypted APFS volume owned by the sandbox daemon in
+addition to chunk-level encryption for persisted snapshots. Keep it unmounted
+when the daemon is not serving. This is at-rest protection, not a claim that
+host root cannot inspect a running VM.
+
+### 8.3 Sticky placement
+
+A retained sandbox records which hosts hold verified encrypted chunks. A cache
+hit is a bounded scheduling preference after trust, capability, resource,
+reliability, and price checks. It never overrides those checks.
+
+If the sticky host is offline:
+
+1. select another eligible host;
+2. transfer the encrypted snapshot;
+3. rewrap the DEK to the new host after attestation; and
+4. boot from the restored overlay.
+
+The quote shows whether startup is expected to be warm or cold. Failed image
+preparation is not billable.
+
+## 9. Network and guest agent
+
+The default network policy is outbound NAT with:
+
+- provider LAN, RFC1918, link-local, metadata, and host-management ranges
+  blocked outside the guest;
+- no unsolicited inbound connectivity;
+- DNS and byte-count metadata retained, but no payload logging;
+- optional destination allowlists for CI jobs; and
+- explicit bandwidth and connection limits.
+
+The guest agent is part of every signed base image. It:
+
+- establishes an authenticated vsock/virtio-socket channel to the host daemon;
+- proves the expected image and agent version;
+- creates command processes under the unprivileged sandbox user;
+- streams stdout/stderr and exit status;
+- enforces command deadlines in addition to host/coordinator deadlines;
+- performs bounded file upload/download;
+- reports disk and process health; and
+- coordinates clean checkpoint and shutdown.
+
+The host daemon treats every guest message as untrusted. Length limits,
+deadlines, finite state checks, and per-session flow control apply before data
+reaches the coordinator relay.
+
+## 10. Computer-use tier
+
+Use Cua's open-source stack as an implementation input:
+
+- [Lume](https://cua.ai/docs/lume/guide/getting-started/installation) for the
+  VM proof;
+- [Cua Driver](https://cua.ai/docs/how-to-guides/driver/install) inside the
+  guest for screen and input operations; and
+- Cua's sandbox SDK semantics as one reference for the Darkbloom SDK.
+
+The computer image has a dedicated logged-in guest user and a stable,
+code-signed driver identity. Accessibility and Screen Recording permissions
+must survive image cloning and driver upgrades; this is an explicit proof gate,
+not an assumption.
+
+The public surface exposes screenshots, pointer/keyboard actions, window
+metadata, and an optional interactive stream. Driver RPC stays on the
+guest-agent channel and is never exposed directly to the internet. Interactive
+video uses WebRTC with TURN fallback; command-style screenshots may use the
+encrypted sandbox relay.
+
+Computer-use sessions are one-to-one with VMs. The service stores timing,
+status, and byte counts but not screenshots, typed text, clipboard contents, or
+window titles.
+
+## 11. Lifecycle and failure semantics
+
+```mermaid
+stateDiagram-v2
+  [*] --> quoted
+  quoted --> reserving: create + durable hold
+  reserving --> preparing: host reserved
+  preparing --> booting: image ready
+  booting --> ready: guest attested
+  ready --> executing: command accepted
+  executing --> ready: command completed
+  executing --> stopping: timeout or cancel
+  ready --> checkpointing: pause
+  checkpointing --> stopped: durable snapshot committed
+  stopped --> preparing: resume
+  ready --> deleting: delete or expiry
+  stopped --> deleting: delete or expiry
+  deleting --> deleted: keys and records tombstoned
+  reserving --> failed
+  preparing --> failed
+  booting --> failed
+  executing --> lost: host lost after acceptance
+  failed --> [*]
+  deleted --> [*]
+  lost --> [*]
+```
+
+State transitions are compare-and-swap operations in Postgres with monotonic
+generation numbers. Commands have independent IDs and idempotency keys.
+
+Deadlines exist at three layers:
+
+1. coordinator lifecycle deadline;
+2. host daemon VM/process deadline; and
+3. guest agent process deadline.
+
+The earliest deadline wins. Timeout sends graceful termination, waits a short
+fixed grace period, then force-stops the process or VM. Metering stops no later
+than the coordinator's observed terminal deadline.
+
+Before `ready`, host failure releases the reservation and permits another host
+attempt within the create deadline. After command acceptance, host failure
+returns `lost` and never silently replays the command.
+
+## 12. Scheduling
+
+Scheduling is filter-then-rank:
+
+1. Filter for permission, trust, daemon/runtime version, OS image, chip
+   requirement, computer-use capability, region, egress policy, disk, vCPU,
+   memory, exclusivity, and posted-price ceiling.
+2. Atomically reserve host resources and a global macOS slot.
+3. Rank eligible offers by final quoted price plus measured startup,
+   reliability, load, and cache-miss costs.
+4. Add a bounded sticky-cache preference.
+5. Use random spread only among near-equal candidates.
+
+The reservation record includes every resource deducted from host capacity.
+Disconnect, preparation failure, timeout, cancellation, daemon restart, and
+coordinator recovery all converge on the same idempotent release path.
+
+The global two-macOS limit is checked in the same transaction as the sandbox
+state transition. A process-local counter is insufficient.
+
+## 13. Billing and settlement
+
+The developer requests a quote before creation. The quote is immutable for its
+short validity window and contains:
+
+- compute rate by vCPU-second and GiB-second;
+- chip, computer-use, and exclusivity premiums;
+- successful boot fee, if any;
+- retained-storage rate;
+- expected warm/cold startup;
+- maximum command hold; and
+- platform fee and taxes where applicable.
+
+Creation places a durable balance hold for the quoted maximum. Settlement uses
+coordinator-observed state plus bounded provider usage heartbeats:
+
+- no charge for a sandbox that never reaches `ready`;
+- an optional boot fee only after successful guest readiness;
+- compute from `ready` until `stopped`, `deleted`, or the terminal deadline;
+- storage by actual retained encrypted bytes over time;
+- no compute charge while stopped;
+- no charge after a missing heartbeat grace limit; and
+- automatic release/refund of unused hold.
+
+Provider earnings and the platform fee settle atomically with the consumer
+debit. Use new sandbox ledger entry types and usage tables; inference's alpha
+`platformFeePercent` remains unrelated. Stripe Connect remains the provider
+withdrawal rail.
+
+See [Economics and pricing](2026-08-22-sandbox-economics.md) for the unit model
+and recommended launch bands.
+
+## 14. Persistence model
+
+Add focused store domains instead of extending the inference usage model:
+
+| Record | Purpose |
+|---|---|
+| `sandbox_hosts` | Attested host identity and durable operator ownership |
+| `sandbox_offers` | Runtime capabilities, posted rates, and availability |
+| `sandboxes` | Owner, desired shape, lifecycle state, generation, and expiry |
+| `sandbox_reservations` | Durable balance and host-resource holds |
+| `sandbox_commands` | Idempotency, acceptance, deadline, and terminal outcome |
+| `sandbox_snapshots` | Manifest, encrypted bytes, wrappers, and cache locations |
+| `sandbox_usage_slices` | Bounded compute/storage meter intervals |
+| `sandbox_settlements` | Atomic consumer debit, provider earning, and fee |
+
+Memory-store implementations support local tests. Production requires Postgres;
+a coordinator must refuse sandbox serving when only the memory store is
+configured.
+
+## 15. Proposed repository layout
+
+```text
+coordinator/
+  sandbox/                 lifecycle service and state transitions
+  sandboxbilling/          quotes, durable holds, metering, settlement
+  sandboxregistry/         host state, reservations, scheduler
+  protocol/
+    sandbox_messages.go    dedicated sandbox wire types
+  api/
+    sandbox_handlers.go    authenticated developer API
+    sandbox_provider.go    sandbox host WebSocket endpoint
+
+provider-swift/
+  Sources/
+    ProviderSecurity/      extracted attestation and key wrapping
+    SandboxCore/           host state, images, guest transport, metering
+    SandboxRuntimeVZ/      Virtualization.framework adapter
+    darkbloom-sandboxd/    minimal daemon entry point
+    darkbloom-guest-agent/ guest command and file service
+
+sandbox-linux/
+  cmd/darkbloom-sandboxd/  Linux host daemon
+  firecracker/             jailer/runtime adapter
+  guestagent/              Linux guest build
+
+sdk/
+  typescript/              public sandbox SDK
+  python/                  public sandbox SDK
+```
+
+The exact Linux language should be selected after the macOS protocol is stable.
+The protocol and state machine come first; duplicating orchestration logic
+across Swift and Go/Rust does not.
+
+## 16. Wire protocol
+
+Use a dedicated provider endpoint and tagged messages mirrored in Go and Swift:
+
+Provider to coordinator:
+
+- `sandbox_host_register`
+- `sandbox_host_heartbeat`
+- `sandbox_prepare_status`
+- `sandbox_ready`
+- `sandbox_command_accepted`
+- `sandbox_command_exit`
+- `sandbox_checkpoint_status`
+- `sandbox_usage_heartbeat`
+- `sandbox_failure`
+
+Coordinator to provider:
+
+- `sandbox_prepare`
+- `sandbox_command`
+- `sandbox_cancel_command`
+- `sandbox_checkpoint`
+- `sandbox_stop`
+- `sandbox_delete`
+- `sandbox_drain`
+
+Every message includes host ID, sandbox ID, sandbox generation, operation ID,
+protocol version, and monotonic sequence where relevant. Unknown future fields
+are ignored; unknown message types fail closed. Payload sizes are bounded before
+full decode. Command/file/desktop data uses a separate framed stream.
+
+## 17. Verification strategy
+
+Every phase ships automated tests plus a live-isolated test on the substrate it
+claims to support.
+
+### Control plane
+
+- HTTP tests through `httptest.Server`, including auth, idempotency, quotes,
+  limits, and status codes.
+- Memory and throwaway-Postgres tests for every sandbox store operation.
+- Property/state-machine tests covering invalid and duplicate transitions.
+- Concurrent reservation tests proving no third macOS sandbox can pass the
+  global limit.
+- Crash-recovery tests between hold, host reservation, ready, settlement, and
+  release.
+- Protocol symmetry fixtures decoded in both Go and Swift.
+- Exact micro-USD billing tests across rounding and deadline boundaries.
+
+### macOS host
+
+- A real Apple Silicon VM for create, boot, guest handshake, command, timeout,
+  cancel, checkpoint, resume, delete, and daemon restart.
+- Cold and sticky-cache boot latency distributions.
+- CPU, memory, disk, network, and host-overhead measurements for every shape.
+- Host-path, LAN, metadata, and cross-sandbox access denial.
+- Encrypted-overlay tamper, wrong-key, replay, deletion, and host-migration
+  tests.
+- Power-loss simulation while writing a snapshot.
+- Public-repository GitHub Actions workflow with secrets disabled.
+
+### Computer use
+
+- Cua Driver installation and TCC persistence across clone, reboot, and update.
+- Screenshot, click, type, scroll, cancel, and session teardown in a real guest.
+- Confirmation that the driver cannot reach the provider desktop.
+- Confirmation that screenshots and input text do not enter coordinator logs or
+  telemetry.
+
+### Linux
+
+- Firecracker jailer with real KVM, not a mocked runtime.
+- Escape-oriented tests for mounts, devices, namespaces, network, and vsock.
+- OCI-to-rootfs build reproducibility and signature verification.
+
+## 18. Delivery sequence and gates
+
+### Phase 0 — substrate proof
+
+Build a local, single-host macOS harness using a pinned Lume commit:
+
+1. create a signed base image;
+2. boot two isolated VMs;
+3. run commands through a guest agent;
+4. enforce a 15-minute deadline;
+5. stop, clone, and restore encrypted workspace state;
+6. measure cold/warm startup and host overhead; and
+7. run Cua Driver inside one guest.
+
+Gate: proceed only if the VM can be lifecycle-managed without host GUI
+interaction, encrypted state survives restart, two guests remain isolated, and
+TCC state is reproducible. Record measured limits instead of projecting them.
+
+### Phase 1 — durable sandbox control plane
+
+Implement sandbox tables, state transitions, quotes, durable holds, settlement,
+host registration, the dedicated protocol, atomic two-slot admission, and API
+idempotency.
+
+Gate: restart and concurrency tests prove there is no double allocation,
+double charge, leaked hold, or third macOS admission.
+
+### Phase 2 — permissioned macOS command alpha
+
+Ship the signed sandbox daemon, VZ runtime adapter, guest agent, base-image
+pipeline, command/file API, egress isolation, fixed shapes, 25/50 GiB disks,
+timeouts, and provider drain controls.
+
+Gate: the full developer journey works on two real VMs, failed starts are free,
+timeouts stop both work and billing, and host loss produces the documented
+non-replayed `lost` result.
+
+### Phase 3 — sticky encrypted persistence
+
+Add chunk manifests, dual-wrapped DEKs, retained storage metering, cache-aware
+scheduling, portable restore, garbage collection, and provider cache earnings.
+
+Gate: tamper and wrong-host unwrap fail closed; migration restores exact bytes;
+deleted sandboxes have no usable key wrapper; measured warm-start savings exceed
+the added cache cost.
+
+### Phase 4 — macOS Computer
+
+Add the guest Cua Driver, computer RPC, WebRTC/TURN interactive transport,
+privacy-safe telemetry, and GUI-specific pricing.
+
+Gate: all computer-use actions stay inside the guest, TCC survives the supported
+image lifecycle, and neither coordinator nor provider product logs retain
+screen/input content.
+
+### Phase 5 — Linux Sandbox
+
+Implement the Firecracker host adapter and OCI image builder against the stable
+public API and state machine.
+
+Gate: real-KVM isolation, lifecycle, billing, checkpoint, and network tests pass
+with the same observable semantics as macOS where capabilities overlap.
+
+## 19. Launch observability
+
+Collect only content-free operational fields:
+
+- quote, admission, queue, preparation, boot, ready, command, checkpoint, and
+  deletion latency;
+- outcome and failure-class counters;
+- allocated vCPU/GiB/disk and active slot gauges;
+- encrypted bytes transferred and retained;
+- warm/cold cache outcome;
+- usage/hold/settlement/refund amounts;
+- provider reliability and daemon/runtime versions; and
+- computer stream frame/byte counts without frame contents.
+
+Never collect command text, environment values, stdout/stderr, uploaded file
+names or bytes, screenshots, typed text, clipboard contents, or window titles.
+The telemetry allowlist remains the privacy backstop.
+
+## 20. Defaults to approve
+
+These defaults make the plan executable without hiding product decisions:
+
+| Decision | Proposed default |
+|---|---|
+| macOS alpha capacity | Two running sandboxes globally |
+| Command deadline | 15 minutes, lower caller value allowed |
+| Retention | 24 hours by default; developer may delete earlier |
+| Compute while stopped | Not billed |
+| Disk | 25 GiB default, 50 GiB option |
+| Workloads | Permissioned, public/no-durable-secret jobs |
+| macOS substrate | Pinned Lume proof, then retain or replace behind adapter |
+| Linux substrate | Firecracker+jailer |
+| Normal GPU claim | None |
+| Timing-sensitive tier | Exclusive whole host |
+| Provider data access claim | Host is trusted in alpha |
+| Cache key recovery | Dual wrap required before portable persistence |
+| Pricing | Resource rates plus explicit premiums; no hidden 24-hour floor |
+
+## 21. Source snapshot
+
+External behavior and prices change. These sources were checked on 2026-08-22:
+
+- [Apple Virtualization framework](https://developer.apple.com/documentation/virtualization)
+- [VZVirtualMachineConfiguration](https://developer.apple.com/documentation/virtualization/vzvirtualmachineconfiguration)
+- [Cua repository](https://github.com/trycua/cua)
+- [Lume documentation](https://cua.ai/docs/lume/guide/getting-started/installation)
+- [Cua Driver documentation](https://cua.ai/docs/how-to-guides/driver/install)
+- [Firecracker architecture](https://firecracker-microvm.github.io/)
+- [Tart license](https://github.com/openai/tart/blob/main/LICENSE)
+

--- a/docs/reports/2026-08-22-sandbox-user-experience.md
+++ b/docs/reports/2026-08-22-sandbox-user-experience.md
@@ -218,9 +218,10 @@ Command behavior is explicit:
 - the alpha allows one active command per sandbox;
 - a command must fit inside the funded compute lease or atomically renew it
   before dispatch;
-- idempotency keys are scoped to project, sandbox, and generation; an exact
-  retry returns the original command, while changed command fields with the
-  same key return `409 IDEMPOTENCY_KEY_REUSED`;
+- idempotency keys are scoped to API key, sandbox, and generation; SDKs use one
+  versioned deterministic-CBOR serialization, an exact retry returns the
+  original command, and changed command fields with the same key return
+  `409 IDEMPOTENCY_KEY_REUSED`;
 - the terminal result is `succeeded`, `failed`, `timed_out`, `cancelled`, or
   `lost`; and
 - `lost` means a dispatched command may have produced side effects and its
@@ -231,6 +232,10 @@ checkpoint and make that decision with application-specific idempotency.
 Command timeout/cancel terminates the process and returns the sandbox to
 `ready` if funded user-work time remains; compute then continues only until the
 idle timeout or lease stop.
+
+Rotating an API key creates a new idempotency namespace. Before retrying an
+ambiguous command with the replacement key, the developer queries the original
+command ID; cross-key deduplication is not implied.
 
 The default ready-idle timeout is two minutes. The SDK can explicitly renew:
 
@@ -246,8 +251,10 @@ new durable hold, then extends execution. Failure halts the VM inside the
 already funded one-minute shutdown guard. Snapshot encryption/upload happens
 after confirmed `execution_halted_at` and is not compute-billed. If the host
 disappears instead, the coordinator closes billing at bounded
-`metering_ended_at`, leaves `execution_halted_at` null, and waits for the
-capacity fence to expire before recovery or reassignment.
+`metering_ended_at`, leaves `execution_halted_at` null, immediately displays
+`fence_wait`, and waits for the capacity fence to expire before recovery or
+reassignment. A same-host reconnect can reconcile and perform cleanup but
+cannot reopen billing or accept work under the old lease.
 
 ### 1.5 Files
 
@@ -687,8 +694,9 @@ Drain behavior:
 `disable` without a drain is rejected while commands execute unless the
 provider passes an explicit emergency flag. Emergency stop produces `lost`
 outcomes for ambiguous in-flight commands, closes billing at bounded
-`metering_ended_at`, then leaves the sandbox to recover its prior durable
-generation or become `unrecoverable`. It lowers provider reliability.
+`metering_ended_at`, enters `fence_wait` until the old lease is fenced out, then
+leaves the sandbox to recover its prior durable generation or become
+`unrecoverable`. It lowers provider reliability.
 
 Daemon upgrades use the same drain contract. Existing encrypted snapshots stay
 versioned; an upgrade cannot silently rewrite their format.
@@ -726,6 +734,7 @@ views use the same canonical sandbox states:
 | `checkpointing` | Execution halted; durable upload in progress | No compute meter; snapshot not yet durable |
 | `stopped` | No compute charge | Resources released; storage retained |
 | `stopped_local` | Durable upload failed; same-host recovery only | CPU/memory released; local encrypted disk retained |
+| `fence_wait` | Billing ended; halt is not yet proven | No new work; same fenced host may reconnect for reconciliation/cleanup |
 | `recovering` | Host/generation loss is being reconciled | Old fence expired; prior durable generation being selected |
 | `unrecoverable` | No durable generation can resume | Auditable tombstone remains; delete is allowed |
 | `deleting` | Irreversible cleanup | Keys tombstoned, bytes reclaiming |

--- a/docs/reports/2026-08-22-sandbox-user-experience.md
+++ b/docs/reports/2026-08-22-sandbox-user-experience.md
@@ -199,6 +199,7 @@ const result = await sandbox.commands.run({
     CI: "true",
   },
   timeoutMs: 10 * 60 * 1000,
+  idempotencyKey: crypto.randomUUID(),
   onStdout: (chunk) => process.stdout.write(chunk),
   onStderr: (chunk) => process.stderr.write(chunk),
 });
@@ -217,6 +218,9 @@ Command behavior is explicit:
 - the alpha allows one active command per sandbox;
 - a command must fit inside the funded compute lease or atomically renew it
   before dispatch;
+- idempotency keys are scoped to project, sandbox, and generation; an exact
+  retry returns the original command, while changed command fields with the
+  same key return `409 IDEMPOTENCY_KEY_REUSED`;
 - the terminal result is `succeeded`, `failed`, `timed_out`, `cancelled`, or
   `lost`; and
 - `lost` means a dispatched command may have produced side effects and its
@@ -240,7 +244,10 @@ await sandbox.renewComputeLease({
 Renewal settles prior usage, checks settled spend plus every open hold, places a
 new durable hold, then extends execution. Failure halts the VM inside the
 already funded one-minute shutdown guard. Snapshot encryption/upload happens
-after `execution_halted_at` and is not compute-billed.
+after confirmed `execution_halted_at` and is not compute-billed. If the host
+disappears instead, the coordinator closes billing at bounded
+`metering_ended_at`, leaves `execution_halted_at` null, and waits for the
+capacity fence to expire before recovery or reassignment.
 
 ### 1.5 Files
 
@@ -298,7 +305,8 @@ is billed, no durable-storage charge settles for that generation, and the
 developer may retry upload or acquire fresh leases for same-host resume. Host
 loss can destroy that uncommitted generation. A 10-minute platform-funded grace
 then discards it and falls back to the prior durable snapshot, or reports
-`lost` when no prior generation exists.
+`unrecoverable` when no prior generation exists. Any in-flight command may
+separately have the terminal outcome `lost`.
 
 The dashboard shows the sparse boot image, logical workspace quota, boot-delta
 bytes, and actual encrypted retained bytes separately. Increasing the workspace
@@ -346,10 +354,13 @@ and destroys it afterward.
 This mode still handles a short-lived GitHub credential. The guarantee is **no
 durable developer secrets and host-trusted integrity**, not literally zero
 credentials. The GitHub App requires an approved workflow commit SHA,
-read-only `GITHUB_TOKEN`, no OIDC, no repository/environment secrets, no
-release/deploy/signing job, no `pull_request_target`, and no unapproved reusable
-workflow. It rejects jobs whose effective policy cannot be proven before asking
-GitHub for JIT configuration.
+read-only `GITHUB_TOKEN`, no OIDC, no
+organization/repository/environment secrets, no `secrets: inherit` or
+`${{ secrets.* }}` references, no release/deploy/signing job, no
+`pull_request_target`, and no unapproved reusable workflow or action. Every
+action and reusable workflow must be pinned to an approved immutable SHA. It
+rejects jobs whose fully resolved workflow graph cannot prove those conditions
+before asking GitHub for JIT configuration.
 
 Private source remains outside the alpha contract. The host provider can still
 read the ephemeral runner token, alter source or outputs, and forge a successful
@@ -416,6 +427,8 @@ Each command response includes a machine-readable usage summary:
   "usage": {
     "compute_lease_id": "scl_01K...",
     "execution_halted_at": null,
+    "metering_ended_at": null,
+    "metering_end_reason": null,
     "ready_ms": 631442,
     "cpu_count": 4,
     "memory_mib": 8192,
@@ -429,11 +442,13 @@ Each command response includes a machine-readable usage summary:
 ```
 
 The numbers are informational until the matching immutable settlement ID is
-present. A project may set `maxTotalMicroUSD` on create. The coordinator checks
-settled usage plus all open compute/storage/egress holds atomically, refuses a
-renewal that would cross the bound, and checkpoints/stops before the current
-funded lease expires. It does not merely block the next command while idle
-compute keeps accruing.
+present. Final settlement always has `metering_ended_at`; normal shutdown also
+has `execution_halted_at`, while host-loss settlement records a bounded
+`metering_end_reason` without pretending the daemon confirmed a stop. A project
+may set `maxTotalMicroUSD` on create. The coordinator checks settled usage plus
+all open compute/storage/egress holds atomically, refuses a renewal that would
+cross the bound, and checkpoints/stops before the current funded lease expires.
+It does not merely block the next command while idle compute keeps accruing.
 
 ### 1.10 Developer dashboard
 
@@ -472,6 +487,7 @@ The doctor reports pass/fail for:
 - encrypted APFS workspace;
 - outbound coordinator and relay connectivity;
 - image signature verification;
+- blessed release-manifest and running daemon code-identity verification;
 - network isolation rules;
 - power/sleep settings;
 - guest image compatibility; and
@@ -530,14 +546,17 @@ darkbloom sandbox host enable
 
 `prefetch` downloads a signed, content-addressed base image and verifies it
 before advertisement. `benchmark` measures boot, CPU, disk, network, and
-checkpoint performance and assigns a benchmark class. `enable` launches the
-separate `darkbloom-sandboxd` service and registers offers.
+checkpoint performance and assigns a benchmark class. `enable` first drains
+inference on that physical Mac, then atomically acquires its
+`sandbox_dedicated` workload-mode lease before launching the separate
+`darkbloom-sandboxd` service and registering offers.
 
-The inference provider may keep running. Capacity accounting subtracts explicit
-host reserves, and exclusive-host offers require inference to drain before a
-sandbox can be accepted. If reliable coexistence cannot be demonstrated, the
-product requires dedicated sandbox hosts instead of pretending isolation is
-free.
+Inference does not keep serving on an alpha sandbox host. The inference routing
+gate rejects a machine in `sandbox_dedicated` mode, and sandbox admission
+rejects one until inference has drained and released its mode lease. A future
+mixed mode requires an atomic cross-plane resource arbiter plus measured
+interference limits; subtracting two independent capacity counters is not
+sufficient.
 
 ### 2.4 Normal job lifecycle
 
@@ -582,6 +601,7 @@ The daemon accepts resources only with a current capacity lease and fencing
 token, and releases them through one idempotent cleanup path. It stops before a
 lease expires and refuses a new job when:
 
+- the physical host lacks a current `sandbox_dedicated` workload-mode lease;
 - free memory or disk is below the declared reserve;
 - the host is thermally constrained or sleeping;
 - image/key verification fails;
@@ -666,7 +686,9 @@ Drain behavior:
 
 `disable` without a drain is rejected while commands execute unless the
 provider passes an explicit emergency flag. Emergency stop produces `lost`
-outcomes, stops billing at the coordinator deadline, and lowers reliability.
+outcomes for ambiguous in-flight commands, closes billing at bounded
+`metering_ended_at`, then leaves the sandbox to recover its prior durable
+generation or become `unrecoverable`. It lowers provider reliability.
 
 Daemon upgrades use the same drain contract. Existing encrypted snapshots stay
 versioned; an upgrade cannot silently rewrite their format.
@@ -704,11 +726,17 @@ views use the same canonical sandbox states:
 | `checkpointing` | Execution halted; durable upload in progress | No compute meter; snapshot not yet durable |
 | `stopped` | No compute charge | Resources released; storage retained |
 | `stopped_local` | Durable upload failed; same-host recovery only | CPU/memory released; local encrypted disk retained |
+| `recovering` | Host/generation loss is being reconciled | Old fence expired; prior durable generation being selected |
+| `unrecoverable` | No durable generation can resume | Auditable tombstone remains; delete is allowed |
 | `deleting` | Irreversible cleanup | Keys tombstoned, bytes reclaiming |
 | `failed` | Never became usable | Pre-ready terminal failure; no compute |
 | `cancelled` | Queue/create cancelled before use | No charge or host lease |
-| `lost` | Dispatched side effects may have occurred | Outcome cannot be reconciled |
 | `deleted` | Resource gone | No remaining billable retention |
+
+`lost` remains a terminal **command** outcome: dispatch may have produced side
+effects, but the result cannot be reconciled. It never prevents sandbox
+cleanup. The sandbox either recovers a prior durable generation or becomes
+`unrecoverable`.
 
 Errors carry:
 

--- a/docs/reports/2026-08-22-sandbox-user-experience.md
+++ b/docs/reports/2026-08-22-sandbox-user-experience.md
@@ -1,0 +1,609 @@
+# Sandbox provider and developer experience
+
+Status: **proposed product contract**
+
+Date: 2026-08-22
+
+Parent plan: [Darkbloom sandbox platform plan](2026-08-22-sandbox-platform-plan.md)
+
+Pricing model: [Sandbox economics and pricing](2026-08-22-sandbox-economics.md)
+
+The target is E2B-like ergonomics: one authenticated create call, streamed
+commands, simple files, explicit persistence, and deterministic teardown. The
+macOS-specific scarcity, chip selection, host trust, and computer-use features
+stay visible instead of being hidden behind a generic "container" label.
+
+All commands and API names below are proposed, not currently implemented.
+
+## 1. Developer experience
+
+### 1.1 Onboarding
+
+The developer:
+
+1. joins the permissioned alpha;
+2. creates a scoped API key in the Darkbloom console;
+3. funds the existing USD balance;
+4. selects an allowed workload policy; and
+5. installs either `@darkbloom/sandbox` or `darkbloom-sandbox`.
+
+The key can be restricted by:
+
+- maximum spend per day and month;
+- allowed sandbox products and images;
+- maximum vCPU, memory, and concurrent sandboxes;
+- allowed egress policy;
+- computer-use access; and
+- expiration.
+
+The console labels the alpha accurately:
+
+> Host-trusted alpha. Persistent disks are encrypted at rest. Do not place
+> credentials or private data in this sandbox; the machine owner is part of the
+> runtime trust boundary.
+
+There is no vague "secure" badge that implies confidential execution.
+
+### 1.2 Quote before create
+
+The developer can request a quote without consuming capacity:
+
+```bash
+npx @darkbloom/sandbox quote \
+  --os macos \
+  --image macos-xcode-26 \
+  --cpu 4 \
+  --memory 8GiB \
+  --disk 25GiB \
+  --chip-family M4 \
+  --retention 24h
+```
+
+Example response:
+
+```text
+Product          macOS Sandbox
+Eligible hosts   3
+Expected start   warm, 8–20s
+CPU              $0.2016/4-vCPU-hour
+Memory           $0.1296/8-GiB-hour
+macOS premium    $0.1656/hour
+Storage          25 GiB included while running
+Retained storage metered by actual encrypted bytes
+Maximum hold     $0.1242 for a 15-minute command
+Quote expires    2026-08-22T23:35:00Z
+```
+
+The response separates resource rates and premiums. It also states whether the
+startup estimate assumes a sticky cache hit. Quotes use integer micro-USD
+internally; displayed decimals never drive settlement.
+
+If an exact processor matters:
+
+```bash
+npx @darkbloom/sandbox quote --os macos --chip-name M5 --exclusive-host
+```
+
+An exact chip is a hard filter. If none is online, the result says so; the
+scheduler never silently substitutes another processor.
+
+### 1.3 Create and wait
+
+TypeScript:
+
+```ts
+import { Sandbox } from "@darkbloom/sandbox";
+
+const sandbox = await Sandbox.create({
+  image: "macos-xcode-26",
+  resources: {
+    cpuCount: 4,
+    memoryMiB: 8192,
+    diskGiB: 25,
+  },
+  chip: {
+    minimumFamily: "M4",
+  },
+  retentionSeconds: 24 * 60 * 60,
+  commandTimeoutMs: 15 * 60 * 1000,
+  cache: "sticky",
+  idempotencyKey: crypto.randomUUID(),
+});
+
+await sandbox.waitUntilReady();
+```
+
+Python:
+
+```python
+from darkbloom_sandbox import Sandbox
+
+sandbox = Sandbox.create(
+    image="macos-xcode-26",
+    cpu_count=4,
+    memory_mib=8192,
+    disk_gib=25,
+    minimum_chip_family="M4",
+    retention_seconds=24 * 60 * 60,
+    command_timeout_seconds=15 * 60,
+    cache="sticky",
+    idempotency_key="build-2841",
+)
+
+sandbox.wait_until_ready()
+```
+
+The create operation returns immediately with:
+
+- sandbox ID and generation;
+- current state;
+- immutable quote ID;
+- selected product and shape;
+- retention expiry;
+- maximum command timeout;
+- host region and attestation status; and
+- a content-free startup event stream.
+
+The SDK handles `quoted → reserving → preparing → booting → ready`. It does not
+hide queueing or retry forever. If the two-slot macOS launch limit is full, the
+caller chooses:
+
+- `queue: true` with a deadline; or
+- immediate `429` with `Retry-After`.
+
+Insufficient balance returns `402`. An impossible shape or chip request returns
+`422`. No eligible provider returns `503`. Reusing an idempotency key returns
+the original sandbox instead of creating or charging twice.
+
+### 1.4 Run commands
+
+```ts
+const result = await sandbox.commands.run({
+  command: "swift",
+  args: ["test", "--parallel"],
+  cwd: "/workspace/repo",
+  env: {
+    CI: "true",
+  },
+  timeoutMs: 10 * 60 * 1000,
+  onStdout: (chunk) => process.stdout.write(chunk),
+  onStderr: (chunk) => process.stderr.write(chunk),
+});
+
+console.log(result.exitCode, result.durationMs);
+```
+
+Command behavior is explicit:
+
+- `command` and `args` avoid shell interpolation by default;
+- `shell: true` is opt-in;
+- stdout and stderr are separate ordered streams;
+- client disconnect does not silently replay the command;
+- cancellation is idempotent;
+- caller timeouts may be lower than 15 minutes but never higher;
+- the terminal result is `succeeded`, `failed`, `timed_out`, `cancelled`, or
+  `lost`; and
+- `lost` means the host disappeared after accepting side effects.
+
+The SDK never turns `lost` into a retry. The developer may restore the latest
+checkpoint and make that decision with application-specific idempotency.
+
+### 1.5 Files
+
+Small files use the SDK directly:
+
+```ts
+await sandbox.files.write("/workspace/repo/config.json", configBytes);
+const junit = await sandbox.files.read("/workspace/repo/.build/test.xml");
+```
+
+Directories and large artifacts use a manifest plus resumable chunks:
+
+```ts
+await sandbox.files.uploadDirectory("./", "/workspace/repo", {
+  exclude: [".git", "node_modules", ".env"],
+});
+
+await sandbox.files.downloadDirectory(
+  "/workspace/repo/.build/artifacts",
+  "./artifacts",
+);
+```
+
+The default excludes known credential files and asks for explicit confirmation
+before uploading them. This is a guardrail, not a security boundary. File
+contents travel on the encrypted session stream and never enter coordinator
+logs.
+
+Uploads are content-addressed within the sandbox generation so retries do not
+duplicate bytes. Paths are normalized in the guest agent, traversal is denied,
+symlinks do not escape the workspace root, and individual/aggregate byte limits
+are enforced.
+
+### 1.6 Pause, resume, reset, and delete
+
+```ts
+await sandbox.pause();
+await sandbox.resume();
+await sandbox.reset({ preserveWorkspace: true });
+await sandbox.kill();
+```
+
+Semantics:
+
+| Action | Compute billing | Storage | Result |
+|---|---|---|---|
+| `pause` | Stops after durable checkpoint | Retained | VM stops; workspace can resume |
+| `resume` | Starts at `ready` | Retained | Sticky host preferred, not guaranteed |
+| `reset` | Continues while ready | Optional | Scratch layer replaced |
+| `kill` | Stops | Deleted | Key wrappers tombstoned; irreversible |
+| Retention expiry | Stops | Deleted | Same cleanup path as `kill` |
+
+The dashboard shows logical disk quota and actual encrypted retained bytes
+separately. Increasing 25 GiB to 50 GiB is allowed only while stopped and after
+a fresh quote. Shrinking is not supported initially.
+
+### 1.7 GitHub Actions
+
+The safe initial workflow is a Darkbloom GitHub App for allowlisted public
+repositories:
+
+```mermaid
+sequenceDiagram
+  participant GH as GitHub
+  participant DB as Darkbloom control plane
+  participant VM as Ephemeral macOS VM
+  GH->>DB: workflow_job queued webhook
+  DB->>DB: policy and budget check
+  DB->>VM: create sandbox
+  DB->>GH: request one-time JIT runner config
+  DB->>VM: deliver config on encrypted session
+  VM->>GH: run one public/no-user-secret job
+  VM->>DB: terminal status
+  DB->>VM: destroy scratch state
+```
+
+The developer installs the GitHub App, selects public repositories, chooses a
+shape/chip policy, and sets a spend cap. Darkbloom creates one ephemeral runner
+per job and destroys it afterward.
+
+This mode still handles a short-lived GitHub credential. The guarantee is **no
+durable developer secrets**, not literally zero credentials. Workflows that
+request repository/environment secrets or private source remain outside the
+alpha contract.
+
+### 1.8 Computer use
+
+For an approved project:
+
+```ts
+const sandbox = await Sandbox.create({
+  image: "macos-computer-26",
+  resources: { cpuCount: 6, memoryMiB: 16384, diskGiB: 50 },
+  computerUse: true,
+  retentionSeconds: 60 * 60,
+});
+
+await sandbox.waitUntilReady();
+
+const computer = await sandbox.computer.connect();
+const frame = await computer.screenshot();
+await computer.click({ x: 620, y: 410 });
+await computer.type({ text: "hello from the agent" });
+await computer.key({ key: "ENTER" });
+```
+
+The same session can issue shell commands and computer actions. Coordinates are
+bound to a reported display size and frame generation so stale screenshots do
+not produce accidental clicks after a resize.
+
+Developers can request a one-time interactive viewer URL. It:
+
+- expires quickly;
+- requires project authentication;
+- displays a visible recording/automation indicator;
+- supports view-only or input-enabled scope;
+- has a kill control independent of the agent; and
+- does not pass through the provider's desktop.
+
+Screenshots and typed text are not included in usage telemetry. The developer
+decides whether their own application records them.
+
+### 1.9 Billing experience
+
+The project page shows:
+
+- active compute by sandbox and command;
+- retained encrypted bytes;
+- boot, chip, computer-use, and exclusive-host premiums;
+- current durable hold;
+- settled amount;
+- refund/release amount;
+- provider and platform split where disclosure is appropriate; and
+- daily/monthly budget progress.
+
+Each command response includes a machine-readable usage summary:
+
+```json
+{
+  "usage": {
+    "ready_ms": 631442,
+    "cpu_count": 4,
+    "memory_mib": 8192,
+    "retained_byte_seconds": 0,
+    "boot_fee_micro_usd": 0,
+    "compute_micro_usd": 58093,
+    "premium_micro_usd": 29046,
+    "total_micro_usd": 87139
+  }
+}
+```
+
+The numbers are informational until the matching immutable settlement ID is
+present. A project may set `maxTotalMicroUSD` on create; the coordinator stops
+new commands before the bound can be exceeded.
+
+### 1.10 Developer dashboard
+
+The first console surface needs only:
+
+- sandboxes list with state, image, shape, chip, region, cost, and expiry;
+- create/quote form;
+- command status and content-free lifecycle events;
+- pause, resume, and delete controls;
+- cache/storage usage;
+- budget and usage history;
+- API keys and policy scopes; and
+- a computer viewer for the GUI tier.
+
+Command output belongs in the SDK/CLI stream, not persistent console logs.
+
+## 2. Provider experience
+
+### 2.1 Eligibility and doctor
+
+The existing Darkbloom provider installs the sandbox host component from a
+signed release, then runs:
+
+```bash
+darkbloom sandbox host doctor
+```
+
+The doctor reports pass/fail for:
+
+- supported Apple Silicon and macOS host version;
+- Virtualization.framework entitlement and a real VM start probe;
+- Secure Enclave key load, unwrap self-test, and code identity;
+- available CPU, memory, and disk after host reserves;
+- encrypted APFS workspace;
+- outbound coordinator and relay connectivity;
+- image signature verification;
+- network isolation rules;
+- power/sleep settings;
+- guest image compatibility; and
+- Cua/TCC readiness if computer use is enabled.
+
+It prints exact remediation for failed checks and never advertises capacity
+until all mandatory checks pass.
+
+### 2.2 Configure an offer
+
+```bash
+darkbloom sandbox host configure \
+  --macos-slots 2 \
+  --host-memory-reserve 12GiB \
+  --host-cpu-reserve 2 \
+  --workspace 500GiB \
+  --cache 300GiB \
+  --allow-images macos-xcode-26,macos-computer-26 \
+  --minimum-compute-price 0.70/hour \
+  --minimum-storage-price 0.06/GiB-month
+```
+
+The CLI auto-detects and signs machine model, chip, core topology, memory, and
+runtime versions. Providers cannot claim an M5 while running another chip.
+
+Configuration distinguishes:
+
+- maximum active VM slots;
+- allocatable vCPU and memory;
+- bytes reserved for the host;
+- workspace versus base-image cache;
+- accepted images and workload policy;
+- ordinary versus exclusive-host availability;
+- computer-use capability; and
+- posted minimum prices.
+
+The coordinator rejects an offer that exceeds measured capacity or violates
+platform price bands. No provider needs to bid on individual jobs during the
+alpha.
+
+### 2.3 Preflight and enable
+
+```bash
+darkbloom sandbox host prefetch macos-xcode-26
+darkbloom sandbox host benchmark
+darkbloom sandbox host enable
+```
+
+`prefetch` downloads a signed, content-addressed base image and verifies it
+before advertisement. `benchmark` measures boot, CPU, disk, network, and
+checkpoint performance and assigns a benchmark class. `enable` launches the
+separate `darkbloom-sandboxd` service and registers offers.
+
+The inference provider may keep running. Capacity accounting subtracts explicit
+host reserves, and exclusive-host offers require inference to drain before a
+sandbox can be accepted. If reliable coexistence cannot be demonstrated, the
+product requires dedicated sandbox hosts instead of pretending isolation is
+free.
+
+### 2.4 Normal job lifecycle
+
+```mermaid
+sequenceDiagram
+  participant C as Coordinator
+  participant H as Sandbox host daemon
+  participant V as Guest VM
+  C->>H: reserve and prepare
+  H->>H: verify image, disk, key wrapper, resources
+  H-->>C: preparation accepted
+  H->>V: boot
+  V-->>H: signed guest-agent hello
+  H-->>C: ready
+  C->>H: command metadata + encrypted stream binding
+  H->>V: bounded command
+  V-->>H: exit and usage
+  H-->>C: terminal outcome
+  C->>H: checkpoint, stop, or delete
+```
+
+The provider sees:
+
+- sandbox ID;
+- product, image, shape, and policy class;
+- allocated resources and expected retention;
+- lifecycle state and health;
+- network and storage byte counts;
+- current and accrued payout; and
+- failure class with actionable host diagnostics.
+
+The normal UI does not display command text, environment values, output,
+filenames, screenshots, clipboard data, or typed text. The host owner remains
+technically trusted in alpha, but the product must not make inspection a
+feature.
+
+### 2.5 Capacity and host safety
+
+The daemon reserves resources before boot and releases them through one
+idempotent cleanup path. It refuses a new job when:
+
+- free memory or disk is below the declared reserve;
+- the host is thermally constrained or sleeping;
+- image/key verification fails;
+- a prior VM is not cleanly accounted for;
+- network isolation is unhealthy;
+- the daemon or guest image is below the required version;
+- the provider is draining; or
+- an exclusive reservation conflicts with any workload.
+
+The provider can impose local hard limits stricter than the coordinator offer.
+The coordinator treats a mismatch as unavailable capacity, not as permission to
+overcommit.
+
+### 2.6 Cache and storage earnings
+
+The host page shows:
+
+- base-image bytes, which are platform infrastructure and not tenant-billable;
+- encrypted tenant bytes by sandbox ID only;
+- retention expiry;
+- cache hits, misses, transfer bytes, and restore latency;
+- storage payout accrued by byte-second; and
+- pending garbage collection.
+
+Providers never receive the tenant DEK in exportable form. Unwrap occurs through
+the signed daemon's Secure Enclave key path. Deleting a sandbox removes its
+local wrapped DEK before asynchronous ciphertext reclamation.
+
+Sticky cache is opt-in capacity. A provider may lower its cache limit or stop
+accepting new retained data, but already sold retention remains reserved until
+expiry or successful migration.
+
+### 2.7 Earnings and payout
+
+Example status:
+
+```text
+Sandbox host          online, attested
+Running               1 / 2 macOS slots
+Reserved              4 vCPU, 8 GiB, 25 GiB
+Exclusive host        available after inference drain
+Tenant cache          118.4 GiB / 300 GiB
+Today compute         $8.42
+Today storage         $0.31
+Pending settlement    $0.18
+Withdrawable          $27.56
+Reliability           99.96%
+```
+
+Compute payout accrues only for coordinator-observed billable states. Storage
+payout accrues for verified retained bytes. A sandbox that fails before ready
+earns no compute; a successful cold boot may earn the quoted boot fee.
+
+Settlement lands in the existing provider balance and withdraws through Stripe
+Connect. The statement separates gross developer charge, Darkbloom platform
+fee, adjustments/refunds, and provider net.
+
+### 2.8 Drain and maintenance
+
+```bash
+darkbloom sandbox host drain --deadline 30m
+darkbloom sandbox host status
+darkbloom sandbox host disable
+```
+
+Drain behavior:
+
+1. stop advertising new offers;
+2. let executing commands finish within their existing deadline;
+3. checkpoint retained sandboxes;
+4. migrate portable retained images where capacity exists;
+5. stop remaining VMs;
+6. report zero reservations; and
+7. permit upgrade or reboot.
+
+`disable` without a drain is rejected while commands execute unless the
+provider passes an explicit emergency flag. Emergency stop produces `lost`
+outcomes, stops billing at the coordinator deadline, and lowers reliability.
+
+Daemon upgrades use the same drain contract. Existing encrypted snapshots stay
+versioned; an upgrade cannot silently rewrite their format.
+
+### 2.9 Provider dashboard
+
+The minimum provider surface contains:
+
+- attestation and daemon/runtime health;
+- slot and resource allocation;
+- active lifecycle states;
+- image and tenant-cache usage;
+- benchmark and thermal status;
+- compute/storage earnings;
+- failure classes and recovery actions;
+- drain/update controls; and
+- privacy-safe usage history.
+
+CLI parity comes first so a headless Mac can operate without the console.
+
+## 3. Shared state and error language
+
+Developer and provider views use the same canonical states:
+
+| State | Developer meaning | Provider meaning |
+|---|---|---|
+| `queued` | Waiting for eligible capacity | No host reservation yet |
+| `preparing` | Image/state being placed | Resources atomically reserved |
+| `booting` | Guest starting | VM created; guest agent not ready |
+| `ready` | Commands accepted | Compute meter active |
+| `executing` | One or more commands running | Deadline and process tracked |
+| `checkpointing` | Pause in progress | Snapshot not yet durable |
+| `stopped` | No compute charge | Resources released; storage retained |
+| `deleting` | Irreversible cleanup | Keys tombstoned, bytes reclaiming |
+| `failed` | Never became usable | Pre-ready terminal failure; no compute |
+| `lost` | Side effects may have occurred | Host lost after command acceptance |
+| `deleted` | Resource gone | No remaining billable retention |
+
+Errors carry:
+
+- stable machine code;
+- safe human message;
+- retryability;
+- whether side effects may have occurred;
+- whether any charge settled;
+- operation and settlement IDs; and
+- `Retry-After` when capacity is the only blocker.
+
+This common language is more important than hiding platform differences. It
+lets SDKs, the console, providers, and support reason about the same event
+without parsing logs.
+

--- a/docs/reports/2026-08-22-sandbox-user-experience.md
+++ b/docs/reports/2026-08-22-sandbox-user-experience.md
@@ -36,6 +36,17 @@ The key can be restricted by:
 - computer-use access; and
 - expiration.
 
+These controls require a new sandbox policy record keyed by API-key ID; the
+current inference model allowlist/spend fields are not treated as sufficient.
+Every quote, create, lease renewal, command, file, computer, and viewer request
+enforces that record.
+
+An API key with no sandbox policy is denied. Quotes and session grants display
+the authorizing policy revision. Key/policy revocation invalidates queued
+quotes, closes viewer/data sessions, rejects new operations, terminates an
+active command, and starts the funded shutdown path; it never leaves an
+unfunded ready VM running.
+
 The console labels the alpha accurately:
 
 > Host-trusted alpha. Persistent disks are encrypted at rest. Do not place
@@ -54,8 +65,10 @@ npx @darkbloom/sandbox quote \
   --image macos-xcode-26 \
   --cpu 4 \
   --memory 8GiB \
-  --disk 25GiB \
+  --workspace 25GiB \
   --chip-family M4 \
+  --compute-lease 15m \
+  --idle-timeout 2m \
   --retention 24h
 ```
 
@@ -68,9 +81,13 @@ Expected start   warm, 8–20s
 CPU              $0.2016/4-vCPU-hour
 Memory           $0.1296/8-GiB-hour
 macOS premium    $0.1656/hour
-Storage          25 GiB included while running
-Retained storage metered by actual encrypted bytes
-Maximum hold     $0.1242 for a 15-minute command
+Workspace        25 GiB included while running
+User-work hold   $0.1242 for a 15-minute billable window
+Shutdown guard   $0.0083 for one minute; no new work
+Durable storage  $0.3333 maximum for 24h/125 GiB
+Sticky cache     $0.1667 maximum for 24h/125 GiB
+Network cap      $0.0000; egress disabled for this quote
+Maximum hold     $0.6325 before tax
 Quote expires    2026-08-22T23:35:00Z
 ```
 
@@ -99,13 +116,17 @@ const sandbox = await Sandbox.create({
   resources: {
     cpuCount: 4,
     memoryMiB: 8192,
-    diskGiB: 25,
+    workspaceGiB: 25,
   },
   chip: {
     minimumFamily: "M4",
   },
+  computeLeaseSeconds: 15 * 60,
+  idleTimeoutSeconds: 2 * 60,
   retentionSeconds: 24 * 60 * 60,
   commandTimeoutMs: 15 * 60 * 1000,
+  networkEgressLimitBytes: 0,
+  recovery: "platform-managed",
   cache: "sticky",
   idempotencyKey: crypto.randomUUID(),
 });
@@ -122,10 +143,14 @@ sandbox = Sandbox.create(
     image="macos-xcode-26",
     cpu_count=4,
     memory_mib=8192,
-    disk_gib=25,
+    workspace_gib=25,
     minimum_chip_family="M4",
+    compute_lease_seconds=15 * 60,
+    idle_timeout_seconds=2 * 60,
     retention_seconds=24 * 60 * 60,
     command_timeout_seconds=15 * 60,
+    network_egress_limit_bytes=0,
+    recovery="platform-managed",
     cache="sticky",
     idempotency_key="build-2841",
 )
@@ -139,14 +164,17 @@ The create operation returns immediately with:
 - current state;
 - immutable quote ID;
 - selected product and shape;
+- compute-lease and idle-stop expiry;
 - retention expiry;
+- recovery mode;
 - maximum command timeout;
 - host region and attestation status; and
 - a content-free startup event stream.
 
-The SDK handles `quoted → reserving → preparing → booting → ready`. It does not
-hide queueing or retry forever. If the two-slot macOS launch limit is full, the
-caller chooses:
+The SDK obtains a quote, then handles
+`queued → reserving → preparing → booting → ready`. It does not hide queueing
+or retry forever. If the two-slot macOS launch limit is full, the caller
+chooses:
 
 - `queue: true` with a deadline; or
 - immediate `429` with `Retry-After`.
@@ -154,6 +182,11 @@ caller chooses:
 Insufficient balance returns `402`. An impossible shape or chip request returns
 `422`. No eligible provider returns `503`. Reusing an idempotency key returns
 the original sandbox instead of creating or charging twice.
+
+Queueing holds neither funds nor host capacity. At admission the coordinator
+revalidates quote expiry and balance atomically. An expired quote returns
+`QUOTE_EXPIRED`; the SDK never accepts a higher replacement price unless the
+caller opted into a stated ceiling.
 
 ### 1.4 Run commands
 
@@ -181,12 +214,33 @@ Command behavior is explicit:
 - client disconnect does not silently replay the command;
 - cancellation is idempotent;
 - caller timeouts may be lower than 15 minutes but never higher;
+- the alpha allows one active command per sandbox;
+- a command must fit inside the funded compute lease or atomically renew it
+  before dispatch;
 - the terminal result is `succeeded`, `failed`, `timed_out`, `cancelled`, or
   `lost`; and
-- `lost` means the host disappeared after accepting side effects.
+- `lost` means a dispatched command may have produced side effects and its
+  outcome cannot be proven.
 
 The SDK never turns `lost` into a retry. The developer may restore the latest
 checkpoint and make that decision with application-specific idempotency.
+Command timeout/cancel terminates the process and returns the sandbox to
+`ready` if funded user-work time remains; compute then continues only until the
+idle timeout or lease stop.
+
+The default ready-idle timeout is two minutes. The SDK can explicitly renew:
+
+```ts
+await sandbox.renewComputeLease({
+  seconds: 15 * 60,
+  maxAdditionalMicroUSD: 132_480,
+});
+```
+
+Renewal settles prior usage, checks settled spend plus every open hold, places a
+new durable hold, then extends execution. Failure halts the VM inside the
+already funded one-minute shutdown guard. Snapshot encryption/upload happens
+after `execution_halted_at` and is not compute-billed.
 
 ### 1.5 Files
 
@@ -233,19 +287,39 @@ Semantics:
 
 | Action | Compute billing | Storage | Result |
 |---|---|---|---|
-| `pause` | Stops after durable checkpoint | Retained | VM stops; workspace can resume |
+| `pause` | Stops at `execution_halted_at` | Upload continues without compute billing | VM halts, then boot/workspace state checkpoints |
 | `resume` | Starts at `ready` | Retained | Sticky host preferred, not guaranteed |
 | `reset` | Continues while ready | Optional | Scratch layer replaced |
-| `kill` | Stops | Deleted | Key wrappers tombstoned; irreversible |
+| `kill` | Stops | Access revoked | Active wrappers tombstoned; irreversible via API |
 | Retention expiry | Stops | Deleted | Same cleanup path as `kill` |
 
-The dashboard shows logical disk quota and actual encrypted retained bytes
-separately. Increasing 25 GiB to 50 GiB is allowed only while stopped and after
-a fresh quote. Shrinking is not supported initially.
+If durable upload fails after the VM halts, state is `stopped_local`: no compute
+is billed, no durable-storage charge settles for that generation, and the
+developer may retry upload or acquire fresh leases for same-host resume. Host
+loss can destroy that uncommitted generation. A 10-minute platform-funded grace
+then discards it and falls back to the prior durable snapshot, or reports
+`lost` when no prior generation exists.
+
+The dashboard shows the sparse boot image, logical workspace quota, boot-delta
+bytes, and actual encrypted retained bytes separately. Increasing the workspace
+from 25 GiB to 50 GiB is allowed only while stopped and after a fresh quote.
+Shrinking is not supported initially.
+
+`platform-managed` recovery lets Darkbloom authorize restore through its KMS;
+the console states that the platform can decrypt. `tenant-managed` recovery
+requires a client-held key on every non-sticky resume and cannot be recovered by
+support. Deletion revokes active authorization immediately, while ciphertext
+and backup wrappers expire under the displayed backup-retention policy rather
+than an instant-erasure promise.
+
+Cross-host restore preserves disk/configuration bytes but may change the
+host-derived Apple VM identity and require Apple-service reauthentication. The
+alpha forbids signed-in Apple IDs, signing certificates, notarization, and any
+workflow that requires stable Apple-service identity.
 
 ### 1.7 GitHub Actions
 
-The safe initial workflow is a Darkbloom GitHub App for allowlisted public
+The Phase 3 runner workflow is a Darkbloom GitHub App for allowlisted public
 repositories:
 
 ```mermaid
@@ -254,7 +328,7 @@ sequenceDiagram
   participant DB as Darkbloom control plane
   participant VM as Ephemeral macOS VM
   GH->>DB: workflow_job queued webhook
-  DB->>DB: policy and budget check
+  DB->>DB: approved SHA, permissions, event, and budget check
   DB->>VM: create sandbox
   DB->>GH: request one-time JIT runner config
   DB->>VM: deliver config on encrypted session
@@ -265,12 +339,22 @@ sequenceDiagram
 
 The developer installs the GitHub App, selects public repositories, chooses a
 shape/chip policy, and sets a spend cap. Darkbloom creates one ephemeral runner
-per job and destroys it afterward.
+per job through GitHub's
+[JIT runner configuration API](https://docs.github.com/en/rest/actions/self-hosted-runners)
+and destroys it afterward.
 
 This mode still handles a short-lived GitHub credential. The guarantee is **no
-durable developer secrets**, not literally zero credentials. Workflows that
-request repository/environment secrets or private source remain outside the
-alpha contract.
+durable developer secrets and host-trusted integrity**, not literally zero
+credentials. The GitHub App requires an approved workflow commit SHA,
+read-only `GITHUB_TOKEN`, no OIDC, no repository/environment secrets, no
+release/deploy/signing job, no `pull_request_target`, and no unapproved reusable
+workflow. It rejects jobs whose effective policy cannot be proven before asking
+GitHub for JIT configuration.
+
+Private source remains outside the alpha contract. The host provider can still
+read the ephemeral runner token, alter source or outputs, and forge a successful
+test result. This tier is not suitable for release artifacts, signing, deploys,
+or security-sensitive merge gates.
 
 ### 1.8 Computer use
 
@@ -279,8 +363,10 @@ For an approved project:
 ```ts
 const sandbox = await Sandbox.create({
   image: "macos-computer-26",
-  resources: { cpuCount: 6, memoryMiB: 16384, diskGiB: 50 },
+  resources: { cpuCount: 6, memoryMiB: 16384, workspaceGiB: 50 },
   computerUse: true,
+  computeLeaseSeconds: 15 * 60,
+  idleTimeoutSeconds: 2 * 60,
   retentionSeconds: 60 * 60,
 });
 
@@ -307,7 +393,8 @@ Developers can request a one-time interactive viewer URL. It:
 - does not pass through the provider's desktop.
 
 Screenshots and typed text are not included in usage telemetry. The developer
-decides whether their own application records them.
+decides whether their own application records them. Cua product telemetry is
+disabled in the guest image and blocked by its egress policy.
 
 ### 1.9 Billing experience
 
@@ -327,6 +414,8 @@ Each command response includes a machine-readable usage summary:
 ```json
 {
   "usage": {
+    "compute_lease_id": "scl_01K...",
+    "execution_halted_at": null,
     "ready_ms": 631442,
     "cpu_count": 4,
     "memory_mib": 8192,
@@ -340,8 +429,11 @@ Each command response includes a machine-readable usage summary:
 ```
 
 The numbers are informational until the matching immutable settlement ID is
-present. A project may set `maxTotalMicroUSD` on create; the coordinator stops
-new commands before the bound can be exceeded.
+present. A project may set `maxTotalMicroUSD` on create. The coordinator checks
+settled usage plus all open compute/storage/egress holds atomically, refuses a
+renewal that would cross the bound, and checkpoints/stops before the current
+funded lease expires. It does not merely block the next command while idle
+compute keeps accruing.
 
 ### 1.10 Developer dashboard
 
@@ -374,6 +466,8 @@ The doctor reports pass/fail for:
 - supported Apple Silicon and macOS host version;
 - Virtualization.framework entitlement and a real VM start probe;
 - Secure Enclave key load, unwrap self-test, and code identity;
+- continuously logged-in dedicated Aqua session, APNs token, and authenticated
+  LaunchAgent-to-LaunchDaemon XPC;
 - available CPU, memory, and disk after host reserves;
 - encrypted APFS workspace;
 - outbound coordinator and relay connectivity;
@@ -384,7 +478,9 @@ The doctor reports pass/fail for:
 - Cua/TCC readiness if computer use is enabled.
 
 It prints exact remediation for failed checks and never advertises capacity
-until all mandatory checks pass.
+until all mandatory checks pass. The Mac may be physically headless, but the
+dedicated account must retain an Aqua login session for APNs; losing it drains
+lease eligibility.
 
 ### 2.2 Configure an offer
 
@@ -393,11 +489,11 @@ darkbloom sandbox host configure \
   --macos-slots 2 \
   --host-memory-reserve 12GiB \
   --host-cpu-reserve 2 \
-  --workspace 500GiB \
+  --workspace-capacity 500GiB \
   --cache 300GiB \
   --allow-images macos-xcode-26,macos-computer-26 \
-  --minimum-compute-price 0.70/hour \
-  --minimum-storage-price 0.06/GiB-month
+  --minimum-net-compute-price macos-s=0.34/hour \
+  --minimum-net-cache-price 0.025/GiB-month
 ```
 
 The CLI auto-detects and signs machine model, chip, core topology, memory, and
@@ -417,6 +513,12 @@ Configuration distinguishes:
 The coordinator rejects an offer that exceeds measured capacity or violates
 platform price bands. No provider needs to bid on individual jobs during the
 alpha.
+
+Provider floors are **net payouts for a named shape**, not gross developer
+prices or ambiguous whole-host rates. At the proposed $0.4968/hour gross
+`macos-s` price and 70% provider share, the provider receives $0.34776/hour, so
+the example $0.34 floor is eligible. The quote and provider statement show
+gross price, provider net, platform fee, and any failure adjustment.
 
 ### 2.3 Preflight and enable
 
@@ -448,13 +550,15 @@ sequenceDiagram
   H->>H: verify image, disk, key wrapper, resources
   H-->>C: preparation accepted
   H->>V: boot
-  V-->>H: signed guest-agent hello
+  V-->>H: host-verified guest readiness hello
   H-->>C: ready
   C->>H: command metadata + encrypted stream binding
   H->>V: bounded command
   V-->>H: exit and usage
   H-->>C: terminal outcome
-  C->>H: checkpoint, stop, or delete
+  C->>H: pause, lease stop, or delete
+  H-->>C: execution_halted_at
+  H->>H: bounded non-compute checkpoint upload
 ```
 
 The provider sees:
@@ -474,8 +578,9 @@ feature.
 
 ### 2.5 Capacity and host safety
 
-The daemon reserves resources before boot and releases them through one
-idempotent cleanup path. It refuses a new job when:
+The daemon accepts resources only with a current capacity lease and fencing
+token, and releases them through one idempotent cleanup path. It stops before a
+lease expires and refuses a new job when:
 
 - free memory or disk is below the declared reserve;
 - the host is thermally constrained or sleeping;
@@ -490,22 +595,27 @@ The provider can impose local hard limits stricter than the coordinator offer.
 The coordinator treats a mismatch as unavailable capacity, not as permission to
 overcommit.
 
-### 2.6 Cache and storage earnings
+### 2.6 Sticky-cache earnings
 
-The host page shows:
+Phase 2 durable snapshots live in the platform object store and pay no host
+storage share. In Phase 3 a provider may sell an optional verified local
+sticky-cache copy. The host page then shows:
 
 - base-image bytes, which are platform infrastructure and not tenant-billable;
 - encrypted tenant bytes by sandbox ID only;
 - retention expiry;
 - cache hits, misses, transfer bytes, and restore latency;
-- storage payout accrued by byte-second; and
+- sticky-cache payout accrued by verified byte-second; and
 - pending garbage collection.
 
-Providers never receive the tenant DEK in exportable form. Unwrap occurs through
-the signed daemon's Secure Enclave key path. Deleting a sandbox removes its
-local wrapped DEK before asynchronous ciphertext reclamation.
+The provider's Secure Enclave private key is non-exportable, but unwrap returns
+the host KEK/tenant DEK to signed daemon memory while serving. A malicious host
+can extract those plaintext keys or inspect the guest. Deleting a sandbox
+revokes the local wrapper immediately; ciphertext and backup wrappers follow
+the disclosed retention policy.
 
-Sticky cache is opt-in capacity. A provider may lower its cache limit or stop
+Sticky cache is opt-in capacity with a separate developer add-on. A provider
+may lower its cache limit or stop
 accepting new retained data, but already sold retention remains reserved until
 expiry or successful migration.
 
@@ -516,19 +626,21 @@ Example status:
 ```text
 Sandbox host          online, attested
 Running               1 / 2 macOS slots
-Reserved              4 vCPU, 8 GiB, 25 GiB
+Reserved              4 vCPU, 8 GiB, 25 GiB workspace
+Capacity lease        valid, renews in 18s
 Exclusive host        available after inference drain
 Tenant cache          118.4 GiB / 300 GiB
 Today compute         $8.42
-Today storage         $0.31
+Today sticky cache    $0.31
 Pending settlement    $0.18
 Withdrawable          $27.56
 Reliability           99.96%
 ```
 
-Compute payout accrues only for coordinator-observed billable states. Storage
-payout accrues for verified retained bytes. A sandbox that fails before ready
-earns no compute; a successful cold boot may earn the quoted boot fee.
+Compute payout accrues only for coordinator-observed billable states. Sticky
+cache payout accrues only for a verified Phase 3 local copy; the platform pays
+the Phase 2 durable object-store bill. A sandbox that fails before ready earns
+no compute; a successful cold boot may earn the quoted boot fee.
 
 Settlement lands in the existing provider balance and withdraws through Stripe
 Connect. The statement separates gross developer charge, Darkbloom platform
@@ -568,7 +680,7 @@ The minimum provider surface contains:
 - active lifecycle states;
 - image and tenant-cache usage;
 - benchmark and thermal status;
-- compute/storage earnings;
+- compute/sticky-cache earnings;
 - failure classes and recovery actions;
 - drain/update controls; and
 - privacy-safe usage history.
@@ -577,20 +689,25 @@ CLI parity comes first so a headless Mac can operate without the console.
 
 ## 3. Shared state and error language
 
-Developer and provider views use the same canonical states:
+The quote is an expiring object, not a sandbox state. Developer and provider
+views use the same canonical sandbox states:
 
 | State | Developer meaning | Provider meaning |
 |---|---|---|
 | `queued` | Waiting for eligible capacity | No host reservation yet |
-| `preparing` | Image/state being placed | Resources atomically reserved |
+| `reserving` | Admission is committing | Balance hold and fenced capacity lease are atomic |
+| `preparing` | Image/state being placed | Resources leased; disks materializing |
 | `booting` | Guest starting | VM created; guest agent not ready |
-| `ready` | Commands accepted | Compute meter active |
-| `executing` | One or more commands running | Deadline and process tracked |
-| `checkpointing` | Pause in progress | Snapshot not yet durable |
+| `ready` | One command can be accepted | Funded compute lease and meter active |
+| `executing` | The single alpha command may have side effects | Acceptance, deadline, and process tracked |
+| `stopping` | Idle, sandbox cancel, or lease stop in progress | New work rejected; grace then force-stop |
+| `checkpointing` | Execution halted; durable upload in progress | No compute meter; snapshot not yet durable |
 | `stopped` | No compute charge | Resources released; storage retained |
+| `stopped_local` | Durable upload failed; same-host recovery only | CPU/memory released; local encrypted disk retained |
 | `deleting` | Irreversible cleanup | Keys tombstoned, bytes reclaiming |
 | `failed` | Never became usable | Pre-ready terminal failure; no compute |
-| `lost` | Side effects may have occurred | Host lost after command acceptance |
+| `cancelled` | Queue/create cancelled before use | No charge or host lease |
+| `lost` | Dispatched side effects may have occurred | Outcome cannot be reconciled |
 | `deleted` | Resource gone | No remaining billable retention |
 
 Errors carry:
@@ -605,5 +722,5 @@ Errors carry:
 
 This common language is more important than hiding platform differences. It
 lets SDKs, the console, providers, and support reason about the same event
-without parsing logs.
-
+without parsing logs. The authoritative transition and settlement table is in
+[Lifecycle and failure semantics](2026-08-22-sandbox-platform-plan.md#11-lifecycle-and-failure-semantics).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Documents the proposed Darkbloom sandbox product before implementation. The proposal separates the sandbox plane from inference, defines macOS/Linux/computer-use products, records the provider and developer journeys, and gives a first-principles pricing model against E2B's public rates. The final revision adds fenced global/physical-host admission, explicit host-loss `fence_wait` and bounded metering, encrypted VM auxiliary/configuration state, deterministic scoped command idempotency, explicit APNs-plus-release-manifest attestation, dedicated alpha sandbox hosts, and integer-safe provider floor pricing.

### Before

```mermaid
flowchart LR
  Idea[Sandbox idea] --> Conversation[Research and conversation only]
  Conversation --> Gap[No reviewable lifecycle, UX, or economic contract]
```

### After

```mermaid
flowchart LR
  Proposal[Sandbox proposal] --> Architecture[Platform architecture and delivery gates]
  Proposal --> UX[Developer and provider UX]
  Proposal --> Economics[Economics and pricing model]
```

### Code boundary before

```mermaid
flowchart LR
  Existing[Existing inference packages] --> Missing[No documented sandbox boundary]
```

### Code boundary after

```mermaid
flowchart LR
  Shared[Auth, ledger, payouts, attestation] --> Foundations[Shared foundations]
  Foundations --> Plane[Dedicated sandbox control, billing, registry, and protocol]
  Plane --> Mac[macOS Virtualization.framework host runtime]
  Plane --> Linux[Linux Firecracker host runtime]
  Arbiter[Physical-host workload arbiter] --> Shared
```

[Proposed sandbox platform flow](https://cursor.com/agents/bc-01a02b07-37a6-7249-a03e-522cbc288fad/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsandbox_platform_architecture.png)

## Linked issue

N/A — planning request.

## Test plan

- [x] Validate Markdown formatting, whitespace, and internal links.
- [x] Validate external links, Mermaid blocks, and documented arithmetic.
- [x] Run independent correctness and quality reviews.

## Components touched

- [ ] coordinator (Go)
- [ ] provider (Rust, legacy)
- [ ] provider-swift (Swift CLI)
- [ ] console-ui (Next.js)
- [ ] enclave (Swift)
- [ ] infra / CI / release
- [x] docs

## Protocol / interface changes

- [x] No protocol/interface changes
- [ ] Yes — described above and matching side updated

## Notes for reviewers

This is a proposed plan, not a claim that sandbox functionality exists. Legal and Apple licensing analysis is deliberately out of scope. The documents explicitly treat providers as part of the runtime trust boundary during the no-durable-secrets alpha, prohibit mixed inference/sandbox operation initially, and do not promise fractional GPU isolation on macOS.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a02b07-37a6-7249-a03e-522cbc288fad?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a02b07-37a6-7249-a03e-522cbc288fad&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/669"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790033218&installation_model_id=21733&pr_number=669&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F669&signature=ed7e37d25630d06eba1dd560573dae1fca790acb237095dbdedb37b97cb295c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->