### PR TITLE
fix(provider): accept fractional-second created_at in model manifests

### DIFF
--- a/provider-swift/Sources/ProviderCore/Models/ModelCatalogClient.swift
+++ b/provider-swift/Sources/ProviderCore/Models/ModelCatalogClient.swift
@@ -124,11 +124,33 @@ public struct ModelCatalogClient: Sendable {
         }
     }
 
+    /// `created_at` arrives in two shapes and both are live on paths this
+    /// decoder serves. The coordinator marshals a Go `time.Time`, which
+    /// RFC3339Nano-encodes with 1-9 fractional digits and omits the fraction
+    /// entirely when it is exactly zero; `darkbloom-publish` writes CDN
+    /// `manifest.json` through `JSONEncoder.iso8601`, which always truncates to
+    /// whole seconds. `.iso8601` decoding resolves against whichever Foundation
+    /// the host ships, so the accepted shape varies by macOS version -- parse
+    /// the wire format explicitly instead of inheriting the platform default.
     static let manifestDecoder: JSONDecoder = {
         let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .iso8601
+        decoder.dateDecodingStrategy = .custom { dateDecoder in
+            let container = try dateDecoder.singleValueContainer()
+            let text = try container.decode(String.self)
+            if let date = try? fractionalSecondsISO8601.parse(text) { return date }
+            if let date = try? wholeSecondsISO8601.parse(text) { return date }
+            throw DecodingError.dataCorruptedError(
+                in: container,
+                debugDescription: "expected an RFC 3339 timestamp, got \"\(text)\"")
+        }
         return decoder
     }()
+
+    /// Value types rather than `ISO8601DateFormatter`: they are `Sendable` (this
+    /// decoder is shared across concurrent downloads) and they retain sub-
+    /// millisecond precision, which the formatter truncates.
+    private static let fractionalSecondsISO8601 = Date.ISO8601FormatStyle(includingFractionalSeconds: true)
+    private static let wholeSecondsISO8601 = Date.ISO8601FormatStyle(includingFractionalSeconds: false)
 
     private static func escapeModelIDForPath(_ modelID: String) -> String? {
         var allowed = CharacterSet.urlPathAllowed

--- a/provider-swift/Tests/ProviderCoreTests/ModelCatalogTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ModelCatalogTests.swift
@@ -156,6 +156,111 @@ struct ModelCatalogTests {
         #expect(RegistryURLProtocol.lastPath == "/v1/models/catalog/manifest/org%2Fmodel%2Fwith%2Fslash")
     }
 
+    // MARK: - created_at wire shapes (#673)
+
+    /// Minimal registry manifest in the coordinator's wire shape, with a
+    /// caller-supplied `created_at` so each case exercises one timestamp form.
+    private static func manifestJSON(createdAt: String) -> Data {
+        Data("""
+        {
+          "schema_version": 1,
+          "model_id": "gpt-oss-20b",
+          "version": "2026-05-25",
+          "r2_prefix": "v2/gpt-oss-20b/2026-05-25",
+          "aggregate_sha256": "\(String(repeating: "a", count: 64))",
+          "total_size_bytes": 16738,
+          "file_count": 1,
+          "files": [
+            {
+              "path": "chat_template.jinja",
+              "size_bytes": 16738,
+              "sha256": "\(String(repeating: "b", count: 64))",
+              "role": "template"
+            }
+          ],
+          "created_at": "\(createdAt)"
+        }
+        """.utf8)
+    }
+
+    /// Regression for #673: every model download failed at the manifest hop.
+    /// `2026-05-25T22:46:27.580497Z` is the literal `created_at` the production
+    /// coordinator serves for `gpt-oss-20b`; all five live manifests carry a
+    /// fractional part, so this was a total download outage, not a flake.
+    ///
+    /// `JSONDecoder.DateDecodingStrategy.iso8601` resolves against whichever
+    /// Foundation the host ships: the pre-fix decoder rejects this payload on
+    /// macOS 15.4.1 and accepts it on macOS 26.2, so this test only fails
+    /// without the fix on the former. Pinning the parse is the actual fix --
+    /// the wire contract stops depending on the provider's macOS version.
+    @Test("fetchManifest decodes the coordinator's fractional-second created_at")
+    func fetchManifestDecodesFractionalSeconds() async throws {
+        RegistryURLProtocol.manifestData = Self.manifestJSON(
+            createdAt: "2026-05-25T22:46:27.580497Z")
+        RegistryURLProtocol.files = [:]
+
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [RegistryURLProtocol.self]
+        let client = ModelCatalogClient(
+            coordinatorURL: "https://coord.example.test",
+            urlSession: URLSession(configuration: config))
+
+        let manifest = try await client.fetchManifest(modelID: "gpt-oss-20b")
+        #expect(manifest.modelID == "gpt-oss-20b")
+        #expect(abs(manifest.createdAt.timeIntervalSince1970 - 1_779_749_187.580497) < 0.000_001)
+    }
+
+    /// Go's RFC3339Nano emits 1-9 fractional digits and strips trailing zeros,
+    /// so a timestamp landing exactly on a whole second serializes with no
+    /// fraction at all. A decoder pinned to `.withFractionalSeconds` would take
+    /// the common case and reject that one, trading a constant failure for an
+    /// intermittent one. Both shapes have to parse.
+    @Test("manifest decoder accepts whole seconds and 1-9 fractional digits")
+    func manifestDecoderAcceptsEveryRFC3339NanoShape() throws {
+        let shapes: [(text: String, epoch: TimeInterval)] = [
+            ("2026-05-25T22:46:27Z", 1_779_749_187),
+            ("2026-05-25T22:46:27.5Z", 1_779_749_187.5),
+            ("2026-05-25T22:46:27.58Z", 1_779_749_187.58),
+            ("2026-05-25T22:46:27.580Z", 1_779_749_187.58),
+            ("2026-05-25T22:46:27.580497Z", 1_779_749_187.580497),
+            ("2026-05-25T22:46:27.580497123Z", 1_779_749_187.580497123),
+            ("2026-05-25T22:46:27+00:00", 1_779_749_187),
+            ("2026-05-25T22:46:27.580497+00:00", 1_779_749_187.580497),
+        ]
+        for shape in shapes {
+            let manifest = try ModelCatalogClient.manifestDecoder.decode(
+                ModelManifest.self, from: Self.manifestJSON(createdAt: shape.text))
+            #expect(
+                abs(manifest.createdAt.timeIntervalSince1970 - shape.epoch) < 0.000_001,
+                "created_at \(shape.text) did not decode to \(shape.epoch)")
+        }
+    }
+
+    /// `ISO8601DateFormatter` truncates to milliseconds, which would silently
+    /// round the microseconds every live manifest carries. A tolerance tighter
+    /// than one millisecond keeps a formatter-based strategy from creeping back.
+    @Test("manifest decoder preserves sub-millisecond precision")
+    func manifestDecoderPreservesSubMillisecondPrecision() throws {
+        let manifest = try ModelCatalogClient.manifestDecoder.decode(
+            ModelManifest.self,
+            from: Self.manifestJSON(createdAt: "2026-05-25T22:46:27.580497Z"))
+        #expect(
+            abs(manifest.createdAt.timeIntervalSince1970 - 1_779_749_187.580497) < 0.000_000_5)
+    }
+
+    /// Tolerating two shapes must not mean tolerating anything: a `created_at`
+    /// that is not RFC 3339 still has to fail loudly rather than decode to some
+    /// default instant.
+    @Test("manifest decoder rejects a created_at that is not RFC 3339")
+    func manifestDecoderRejectsNonRFC3339CreatedAt() {
+        #expect(throws: (any Error).self) {
+            try ModelCatalogClient.manifestDecoder.decode(
+                ModelManifest.self,
+                from: Self.manifestJSON(createdAt: "25/05/2026 22:46:27"))
+        }
+    }
+
+
     @Test("catalog streaming accepts the exact response-byte boundary")
     func catalogResponseExactBoundary() async throws {
         let base = Data(#"{"models":[]}"#.utf8)


### PR DESCRIPTION
## Summary

`ModelCatalogClient.manifestDecoder` decoded `created_at` with `JSONDecoder`'s `.iso8601` strategy, which resolves against whatever Foundation the host ships. On macOS 15.x that rejects fractional seconds, and the coordinator marshals `created_at` from a Go `time.Time`, so every live manifest carries them. Result: every model download failed at the manifest hop before a byte transferred. This parses the wire format explicitly instead, accepting both whole-second and fractional-second RFC 3339.

## Linked issue

Closes #673

## Before / after

Behavior:

```mermaid
flowchart TB
  subgraph Before["Before: every download aborts at the manifest hop"]
    direction TB
    A1["darkbloom start, pick a model"] --> B1["GET /v1/models/catalog"]
    B1 -->|"int epoch, decodes"| C1["GET /v1/models/catalog/manifest/:id"]
    C1 --> D1{"JSONDecoder .iso8601 meets<br/>created_at 2026-05-25T22:46:27.580497Z"}
    D1 -->|"macOS 15.x"| E1["reject: could not decode catalog response<br/>download aborts, 0 bytes transferred"]
    D1 -->|"macOS 26.x"| F1["accept: download proceeds"]
  end
  subgraph After["After: the parse no longer depends on the host"]
    direction TB
    A2["darkbloom start, pick a model"] --> C2["GET /v1/models/catalog/manifest/:id"]
    C2 --> D2{"explicit RFC 3339 parse"}
    D2 -->|"fractional or whole seconds"| F2["download proceeds on every macOS"]
    D2 -->|"anything else"| E2["DecodingError naming the value"]
  end
  Before ~~~ After
```

Code:

```mermaid
flowchart TB
  subgraph CodeBefore["Before: ModelCatalogClient.manifestDecoder"]
    direction TB
    X1["dateDecodingStrategy = .iso8601"] --> Y1["host Foundation decides which shapes parse"]
    Y1 --> Z1["macOS 15.x: whole seconds only"]
    Y1 --> Z2["macOS 26.x: whole + fractional"]
  end
  subgraph CodeAfter["After: ModelCatalogClient.manifestDecoder"]
    direction TB
    X2["dateDecodingStrategy = .custom"] --> P1["ISO8601FormatStyle(includingFractionalSeconds: true)"]
    P1 -->|"no match"| P2["ISO8601FormatStyle(includingFractionalSeconds: false)"]
    P1 -->|"match"| OK["Date"]
    P2 -->|"match"| OK
    P2 -->|"no match"| P3["DecodingError.dataCorrupted"]
  end
  CodeBefore ~~~ CodeAfter
```

All four call sites of the shared decoder pick this up: `fetchManifest` (coordinator manifest), `ModelDownloader+Download.swift:77` (CDN `manifest.json`), `SpecDecStore.swift:86` and `SpecDecResolver.swift:346` (drafter manifests).

## Test plan

- [x] `swift test --filter ModelCatalogTests` — **24 tests in the suite pass, 0 failures** (6.271s). That is the 20 already on master plus the 4 added here.
- [x] `swift build --target ProviderCore` builds clean (147.7s), no warnings or errors in the changed file.
- [x] Compiles under Swift 6 language mode with strict concurrency; `Date.ISO8601FormatStyle` satisfies `Sendable`.

How the test run was obtained, since it is not the plain command: this machine has Command Line Tools without full Xcode, so `swift test` needs the swift-testing framework pointed at explicitly, and two test targets that are built entirely on `XCTest` (`ProviderCoreFoundationTests`, `DarkbloomPublishTests`) plus one XCTest file in `ProviderCoreTests` (`JinjaSanitizationTests.swift`) cannot link at all. Those were excluded locally and reverted afterwards; none is touched by this PR, and the suite under test ran unmodified:

```
swift test --filter ModelCatalogTests \
  -Xswiftc -F -Xswiftc /Library/Developer/CommandLineTools/Library/Developer/Frameworks \
  -Xlinker -F -Xlinker /Library/Developer/CommandLineTools/Library/Developer/Frameworks \
  -Xlinker -rpath -Xlinker /Library/Developer/CommandLineTools/Library/Developer/Frameworks \
  -Xlinker -rpath -Xlinker /Library/Developer/CommandLineTools/Library/Developer/usr/lib
```

Four new tests in `ModelCatalogTests.swift`:

- `fetchManifestDecodesFractionalSeconds` walks the real HTTP path via `RegistryURLProtocol`, using the literal `created_at` production serves for `gpt-oss-20b`
- `manifestDecoderAcceptsEveryRFC3339NanoShape` covers whole seconds and 1-9 fractional digits, both `Z` and `+00:00`
- `manifestDecoderPreservesSubMillisecondPrecision` pins the microseconds
- `manifestDecoderRejectsNonRFC3339CreatedAt` keeps the decoder from getting permissive

Confirmed against the live coordinator that all five manifests carry microsecond fractions (`gpt-oss-20b` at `.580497Z`, `qwen3.6-35b-a3b-vl-mtp-mxfp8` at `.184276Z`, the three `gemma-4-26b` variants likewise), so on an affected host this is a total download outage rather than a flake.

Worth stating plainly: the regression test fails without the fix on macOS 15.4.1 and passes without it on macOS 26.2, because the pre-fix decoder already accepts both shapes there. That split is the defect. CI runs `macos-latest`, so it could not have caught this, and it will not fail on this PR's absence either.

## Components touched

- [ ] coordinator (Go)
- [ ] provider (Rust, legacy)
- [x] provider-swift (Swift CLI)
- [ ] console-ui (Next.js)
- [ ] enclave (Swift)
- [ ] infra / CI / release
- [ ] docs

## Protocol / interface changes

- [x] No protocol/interface changes

The wire format is untouched. This makes the client accept what the coordinator already emits.

## Notes for reviewers

- **Why not `ISO8601DateFormatter`.** #673 suggests `[.withInternetDateTime, .withFractionalSeconds]`, but that combination rejects input with no fraction, so it would swap a constant failure for an intermittent one. Go's RFC3339Nano strips trailing zeros, and `darkbloom-publish` writes CDN `manifest.json` through `JSONEncoder.iso8601`, which always truncates to whole seconds. Both shapes are live, so the decoder has to take both. `Date.ISO8601FormatStyle` is also a `Sendable` value type, which matters for a static decoder shared across concurrent downloads, and it keeps microseconds the formatter truncates to milliseconds (`1779749187.580497` vs `1779749187.58`).
- **Why the existing test missed it.** `fetchManifestDecodesRegistryRoute` builds its fixture with `JSONEncoder.iso8601` and `Date(timeIntervalSince1970: 0)`, so it round-trips through the same library and only ever exercises the one shape that already worked. The new tests use literal wire bytes instead.
- Happy to target a milestone if you tell me which release this should land in.
