### PR TITLE
fix(provider): honor enable_thinking disable paths for reasoning models

### DIFF
--- a/coordinator/promptsidecar/src/normalize.rs
+++ b/coordinator/promptsidecar/src/normalize.rs
@@ -53,24 +53,50 @@ pub fn normalize(
     }
 
     let mut additional_context = Map::new();
-    if let Some(effort) = body
+    let effort = body
         .get("reasoning_effort")
         .and_then(Value::as_str)
         .map(str::trim)
         .filter(|value| !value.is_empty())
-    {
+        .map(|value| value.to_owned());
+    if let Some(effort) = effort.as_deref() {
         additional_context.insert("reasoning_effort".into(), Value::String(effort.into()));
     }
+
+    // Precedence matches provider-swift templateAdditionalContext (#639 / PR #677):
+    // 1) nested reasoning.enabled  2) top-level / chat_template_kwargs enable_thinking
+    // 3) none-like reasoning_effort → false (not "minimal")
+    let mut enable_thinking: Option<bool> = None;
     match body.get("reasoning") {
         None | Some(Value::Null) => {}
         Some(Value::Object(reasoning)) => match reasoning.get("enabled") {
             None | Some(Value::Null) => {}
             Some(Value::Bool(enabled)) => {
-                additional_context.insert("enable_thinking".into(), Value::Bool(*enabled));
+                enable_thinking = Some(*enabled);
             }
             Some(_) => return Err(NormalizeError::InvalidMessages),
         },
         Some(_) => return Err(NormalizeError::InvalidMessages),
+    }
+    if enable_thinking.is_none() {
+        if let Some(Value::Bool(enabled)) = body.get("enable_thinking") {
+            enable_thinking = Some(*enabled);
+        } else if let Some(Value::Object(kwargs)) = body.get("chat_template_kwargs") {
+            if let Some(Value::Bool(enabled)) = kwargs.get("enable_thinking") {
+                enable_thinking = Some(*enabled);
+            }
+        }
+    }
+    if enable_thinking.is_none() {
+        if let Some(effort) = effort.as_deref() {
+            let lower = effort.to_ascii_lowercase();
+            if matches!(lower.as_str(), "none" | "off" | "0") {
+                enable_thinking = Some(false);
+            }
+        }
+    }
+    if let Some(enabled) = enable_thinking {
+        additional_context.insert("enable_thinking".into(), Value::Bool(enabled));
     }
 
     let mut normalized_body = Map::new();
@@ -1823,6 +1849,56 @@ mod tests {
         ] {
             assert!(normalize(body.as_object().unwrap().clone(), Some("gemma4_text")).is_err());
         }
+    }
+
+    #[test]
+    fn enable_thinking_matches_provider_precedence() {
+        // nested reasoning.enabled wins
+        let nested = json!({
+            "model": "fixture",
+            "messages": [{"role": "user", "content": "x"}],
+            "enable_thinking": false,
+            "reasoning": {"enabled": true},
+            "reasoning_effort": "none"
+        });
+        let n = normalize(nested.as_object().unwrap().clone(), None).unwrap();
+        assert_eq!(n.additional_context.get("enable_thinking"), Some(&Value::Bool(true)));
+
+        // top-level enable_thinking
+        let top = json!({
+            "model": "fixture",
+            "messages": [{"role": "user", "content": "x"}],
+            "enable_thinking": false
+        });
+        let t = normalize(top.as_object().unwrap().clone(), None).unwrap();
+        assert_eq!(t.additional_context.get("enable_thinking"), Some(&Value::Bool(false)));
+
+        // chat_template_kwargs
+        let kwargs = json!({
+            "model": "fixture",
+            "messages": [{"role": "user", "content": "x"}],
+            "chat_template_kwargs": {"enable_thinking": false}
+        });
+        let k = normalize(kwargs.as_object().unwrap().clone(), None).unwrap();
+        assert_eq!(k.additional_context.get("enable_thinking"), Some(&Value::Bool(false)));
+
+        // none effort disables; minimal does not
+        let none = json!({
+            "model": "fixture",
+            "messages": [{"role": "user", "content": "x"}],
+            "reasoning_effort": "none"
+        });
+        let no = normalize(none.as_object().unwrap().clone(), None).unwrap();
+        assert_eq!(no.additional_context.get("enable_thinking"), Some(&Value::Bool(false)));
+
+        let minimal = json!({
+            "model": "fixture",
+            "messages": [{"role": "user", "content": "x"}],
+            "reasoning_effort": "minimal"
+        });
+        let m = normalize(minimal.as_object().unwrap().clone(), None).unwrap();
+        assert!(m.additional_context.get("enable_thinking").is_none());
+        assert_eq!(m.additional_context.get("reasoning_effort"), Some(&Value::String("minimal".into())));
     }
 
     proptest! {

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2VisionPrefill.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2VisionPrefill.swift
@@ -286,14 +286,17 @@ public enum EngineV2VisionPrefill {
     static func prepare(
         container: ModelContainer,
         request: OpenAIChatCompletionRequest,
-        reasoningEffort: String? = nil
+        reasoningEffort: String? = nil,
+        enableThinkingOverride: Bool? = nil
     ) async throws -> PreparedSubmission {
         // Same decode path as the legacy stream (same caps, same MediaError
         // surface). Inline video bytes stay in the UserInput's owned
         // memory-backed asset while processor preparation samples and
         // rasterizes its frames; no plaintext file exists to clean up.
         let userInput = try await MediaIngest.buildUserInput(
-            from: request, reasoningEffort: reasoningEffort)
+            from: request,
+            reasoningEffort: reasoningEffort,
+            enableThinkingOverride: enableThinkingOverride)
         let towerLimits = VisionTowerBudget.liveLimits
         return try await container.perform(nonSendable: userInput) { ctx, userInput in
             // MLX's DEFAULT error handler is `fatalError`. A C++ fault raised
@@ -740,12 +743,12 @@ public enum EngineV2VisionPrefill {
 /// preparer so the full routing seam is exercisable without model weights.
 public struct EngineV2VisionPlumbing: Sendable {
     let prepare:
-        @Sendable (ModelContainer, OpenAIChatCompletionRequest, String?) async throws
+        @Sendable (ModelContainer, OpenAIChatCompletionRequest, String?, Bool?) async throws
             -> EngineV2VisionPrefill.PreparedSubmission
     let emitTelemetry: @Sendable (TelemetryEvent) -> Void
 
     init(
-        prepare: @escaping @Sendable (ModelContainer, OpenAIChatCompletionRequest, String?)
+        prepare: @escaping @Sendable (ModelContainer, OpenAIChatCompletionRequest, String?, Bool?)
             async throws -> EngineV2VisionPrefill.PreparedSubmission,
         emitTelemetry: @escaping @Sendable (TelemetryEvent) -> Void
     ) {
@@ -754,9 +757,12 @@ public struct EngineV2VisionPlumbing: Sendable {
     }
 
     static let production = EngineV2VisionPlumbing(
-        prepare: { container, request, reasoningEffort in
+        prepare: { container, request, reasoningEffort, enableThinkingOverride in
             try await EngineV2VisionPrefill.prepare(
-                container: container, request: request, reasoningEffort: reasoningEffort)
+                container: container,
+                request: request,
+                reasoningEffort: reasoningEffort,
+                enableThinkingOverride: enableThinkingOverride)
         },
         emitTelemetry: { TelemetryClient.shared.emit($0) }
     )

--- a/provider-swift/Sources/ProviderCore/Inference/MediaIngest.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/MediaIngest.swift
@@ -263,6 +263,7 @@ public enum MediaIngest {
     static func buildUserInput(
         from request: OpenAIChatCompletionRequest,
         reasoningEffort: String? = nil,
+        enableThinkingOverride: Bool? = nil,
         maxImagePixels: Int = Self.maxImagePixels,
         maxRequestImagePixels: Int = Self.maxRequestImagePixels,
         maxImagesPerRequest: Int = Self.maxImagesPerRequest,
@@ -298,7 +299,9 @@ public enum MediaIngest {
         return UserInput(
             chat: chatMessages,
             additionalContext: MultiModelBatchSchedulerEngine.templateAdditionalContext(
-                for: request, reasoningEffort: reasoningEffort))
+                for: request,
+                reasoningEffort: reasoningEffort,
+                enableThinkingOverride: enableThinkingOverride))
     }
 
 

--- a/provider-swift/Sources/ProviderCore/Inference/MultiModelBatchSchedulerEngine+Translation.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/MultiModelBatchSchedulerEngine+Translation.swift
@@ -14,16 +14,37 @@ import MLXLMServer
 
 extension MultiModelBatchSchedulerEngine {
 
+    /// Build chat-template `additionalContext` for reasoning / thinking controls.
+    ///
+    /// Priority for `enable_thinking`:
+    /// 1. Nested OpenAI `reasoning.enabled` on the decoded request shape
+    /// 2. `enableThinkingOverride` from sealed-body probes (top-level
+    ///    `enable_thinking`, `chat_template_kwargs.enable_thinking`)
+    /// 3. Soft map from `reasoning_effort` in {none, minimal, off, 0} → false
+    ///
+    /// Without (2)/(3), Qwen-native and “effort none” clients silently fail to
+    /// disable thinking (see Layr-Labs/d-inference#639).
     static func templateAdditionalContext(
         for request: OpenAIChatCompletionRequest,
-        reasoningEffort: String?
+        reasoningEffort: String?,
+        enableThinkingOverride: Bool? = nil
     ) -> [String: any Sendable]? {
         var context: [String: any Sendable] = [:]
         if let reasoningEffort {
             context["reasoning_effort"] = reasoningEffort
         }
-        if let reasoningEnabled = request.reasoning?.enabled {
-            context["enable_thinking"] = reasoningEnabled
+        var enableThinking = request.reasoning?.enabled
+        if enableThinking == nil {
+            enableThinking = enableThinkingOverride
+        }
+        if enableThinking == nil,
+           let effort = reasoningEffort?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased(),
+           ["none", "minimal", "off", "0"].contains(effort)
+        {
+            enableThinking = false
+        }
+        if let enableThinking {
+            context["enable_thinking"] = enableThinking
         }
         return context.isEmpty ? nil : context
     }

--- a/provider-swift/Sources/ProviderCore/Inference/MultiModelBatchSchedulerEngine+Translation.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/MultiModelBatchSchedulerEngine+Translation.swift
@@ -20,7 +20,8 @@ extension MultiModelBatchSchedulerEngine {
     /// 1. Nested OpenAI `reasoning.enabled` on the decoded request shape
     /// 2. `enableThinkingOverride` from sealed-body probes (top-level
     ///    `enable_thinking`, `chat_template_kwargs.enable_thinking`)
-    /// 3. Soft map from `reasoning_effort` in {none, minimal, off, 0} → false
+    /// 3. Soft map from `reasoning_effort` in {none, off, 0} → false
+    ///    (`minimal` is a *small* budget, not disabled — do not map it off)
     ///
     /// Without (2)/(3), Qwen-native and “effort none” clients silently fail to
     /// disable thinking (see Layr-Labs/d-inference#639).
@@ -39,7 +40,7 @@ extension MultiModelBatchSchedulerEngine {
         }
         if enableThinking == nil,
            let effort = reasoningEffort?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased(),
-           ["none", "minimal", "off", "0"].contains(effort)
+           Self.reasoningEffortDisablesThinking(effort)
         {
             enableThinking = false
         }
@@ -47,6 +48,11 @@ extension MultiModelBatchSchedulerEngine {
             context["enable_thinking"] = enableThinking
         }
         return context.isEmpty ? nil : context
+    }
+
+    /// Values that unambiguously mean "no reasoning", not a reduced budget.
+    static func reasoningEffortDisablesThinking(_ effort: String) -> Bool {
+        ["none", "off", "0"].contains(effort)
     }
 
     /// Translate an upstream `OpenAIChatCompletionRequest` into the

--- a/provider-swift/Sources/ProviderCore/Inference/MultiModelBatchSchedulerEngine.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/MultiModelBatchSchedulerEngine.swift
@@ -77,6 +77,9 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
     /// allowed set is model-specific and lives in each model's Jinja
     /// template, so passing through is the format-agnostic choice.
     private let reasoningEffort: String?
+    /// Sealed-body `enable_thinking` / `chat_template_kwargs.enable_thinking`
+    /// when nested `reasoning.enabled` is absent (issue #639).
+    private let enableThinkingOverride: Bool?
     /// Authenticated remote or configured local prefix-cache scope. Maps to
     /// `CBv2Request.cacheSalt` for both cache tiers.
     private let cacheScope: String
@@ -118,6 +121,7 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
         releaseModel: @escaping @Sendable (String) async -> Void = { _ in },
         defaultMaxTokens: Int = 4096,
         reasoningEffort: String? = nil,
+        enableThinkingOverride: Bool? = nil,
         cacheScope: String = "",
         cacheEnabled: Bool = true,
         engineV2Logprobs: EngineV2LogprobsPlumbing? = nil,
@@ -131,6 +135,7 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
         self.releaseModel = releaseModel
         self.defaultMaxTokens = defaultMaxTokens
         self.reasoningEffort = reasoningEffort
+        self.enableThinkingOverride = enableThinkingOverride
         self.cacheScope = cacheScope
         self.cacheEnabled = cacheEnabled
         self.engineV2Logprobs = engineV2Logprobs
@@ -170,6 +175,7 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
         self.releaseModel = { _ in }
         self.defaultMaxTokens = defaultMaxTokens
         self.reasoningEffort = nil
+        self.enableThinkingOverride = nil
         self.cacheScope = ""
         self.cacheEnabled = true
         // The --local path serves SSE frames inside the upstream router, so
@@ -516,7 +522,8 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
                 request: request,
                 tokenizer: tokenizer.inner,
                 modelType: modelType,
-                reasoningEffort: reasoningEffort)
+                reasoningEffort: reasoningEffort,
+                enableThinkingOverride: enableThinkingOverride)
         } catch {
             emitToolConstraintTelemetry(
                 operation: "tool_constraint_compile_rejection",

--- a/provider-swift/Sources/ProviderCore/Inference/MultiModelBatchSchedulerEngine.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/MultiModelBatchSchedulerEngine.swift
@@ -114,6 +114,15 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
     /// requests have no such trusted boundary and must reject that metadata.
     private let allowInternalToolSchemaMetadata: Bool
 
+    /// Constructor value, falling back to local-HTTP task-local controls.
+    private var effectiveReasoningEffort: String? {
+        reasoningEffort ?? ThinkingRequestControls.current?.reasoningEffort
+    }
+
+    private var effectiveEnableThinking: Bool? {
+        enableThinkingOverride ?? ThinkingRequestControls.current?.enableThinkingOverride
+    }
+
     public init(
         registryProvider: @escaping @Sendable () async -> Registry,
         ensureLoaded: @escaping @Sendable (String) async throws -> Void = { _ in },
@@ -365,7 +374,7 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
                 let plumbing = engineV2Vision ?? .production
                 do {
                     let visionPrepared = try await plumbing.prepare(
-                        container, visionRequest, reasoningEffort)
+                        container, visionRequest, effectiveReasoningEffort, effectiveEnableThinking)
                     let visionRequestId = "req-\(UUID().uuidString.prefix(12))"
                     // Hand off memory accounting to the bridge BEFORE
                     // submit: the decode-phase peak this vision reservation
@@ -522,8 +531,8 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
                 request: request,
                 tokenizer: tokenizer.inner,
                 modelType: modelType,
-                reasoningEffort: reasoningEffort,
-                enableThinkingOverride: enableThinkingOverride)
+                reasoningEffort: effectiveReasoningEffort,
+                enableThinkingOverride: effectiveEnableThinking)
         } catch {
             emitToolConstraintTelemetry(
                 operation: "tool_constraint_compile_rejection",

--- a/provider-swift/Sources/ProviderCore/Inference/ProviderPromptContractPipeline.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/ProviderPromptContractPipeline.swift
@@ -10,13 +10,15 @@ enum ProviderPromptContractPipeline {
     ) throws -> [Int] {
         let request = try ProviderLoop.decodeOpenAIRequest(body)
         let reasoningEffort = ProviderLoop.extractReasoningEffort(from: body)
+        let enableThinkingOverride = ProviderLoop.extractEnableThinking(from: body)
         let prepared = try ToolChoicePromptPolicy.prepare(request)
         return try tokenize(
             prepared: prepared,
             request: request,
             tokenizer: tokenizer,
             modelType: modelType,
-            reasoningEffort: reasoningEffort)
+            reasoningEffort: reasoningEffort,
+            enableThinkingOverride: enableThinkingOverride)
     }
 
     static func tokenize(
@@ -24,7 +26,8 @@ enum ProviderPromptContractPipeline {
         request: OpenAIChatCompletionRequest,
         tokenizer: any MLXLMCommon.Tokenizer,
         modelType: String?,
-        reasoningEffort: String?
+        reasoningEffort: String?,
+        enableThinkingOverride: Bool? = nil
     ) throws -> [Int] {
         let messages = prepared.messages.map { $0.templateMessageDict() }
         let tools = prepared.tools?.map { $0.toolSpec() }
@@ -36,6 +39,7 @@ enum ProviderPromptContractPipeline {
             tools: ChatTemplateFixes.normalizeTools(tools, context: context),
             additionalContext: MultiModelBatchSchedulerEngine.templateAdditionalContext(
                 for: request,
-                reasoningEffort: reasoningEffort))
+                reasoningEffort: reasoningEffort,
+                enableThinkingOverride: enableThinkingOverride))
     }
 }

--- a/provider-swift/Sources/ProviderCore/Inference/ThinkingRequestControls.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/ThinkingRequestControls.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+/// Per-request thinking controls for the **local HTTP** path.
+///
+/// Coordinator-bound requests construct a fresh `MultiModelBatchSchedulerEngine`
+/// with explicit `reasoningEffort` / `enableThinkingOverride`. The shared
+/// `--local` engine cannot carry those as constructor state, so
+/// `LocalChatUploadResponder` binds them on the task before entering the
+/// service (issue #639 / Codex review on PR #677).
+struct ThinkingRequestControls: Sendable {
+    var reasoningEffort: String?
+    var enableThinkingOverride: Bool?
+
+    @TaskLocal static var current: ThinkingRequestControls?
+}

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+InboundDecode.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+InboundDecode.swift
@@ -81,6 +81,32 @@ extension ProviderLoop {
         return trimmed.isEmpty ? nil : trimmed
     }
 
+    /// Probe thinking-disable flags that are **not** on the upstream
+    /// `OpenAIChatCompletionRequest` shape (only `reasoning.enabled` is).
+    ///
+    /// Order: top-level `enable_thinking`, then
+    /// `chat_template_kwargs.enable_thinking`. Used to populate template
+    /// context for Qwen-class models (issue #639).
+    internal static func extractEnableThinking(from data: Data) -> Bool? {
+        struct TopLevel: Decodable { let enable_thinking: Bool? }
+        struct KwargsProbe: Decodable {
+            struct ChatTemplateKwargs: Decodable { let enable_thinking: Bool? }
+            let chat_template_kwargs: ChatTemplateKwargs?
+        }
+        let decoder = JSONDecoder()
+        if let top = try? decoder.decode(TopLevel.self, from: data),
+           let value = top.enable_thinking
+        {
+            return value
+        }
+        if let kwargs = try? decoder.decode(KwargsProbe.self, from: data),
+           let value = kwargs.chat_template_kwargs?.enable_thinking
+        {
+            return value
+        }
+        return nil
+    }
+
     /// OpenAI `logprobs` / `top_logprobs` for this request. Like
     /// `reasoning_effort` and the cache scope, neither field is on the
     /// upstream `OpenAIChatCompletionRequest`, so decode them straight from

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+InboundDecode.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+InboundDecode.swift
@@ -158,13 +158,16 @@ extension ProviderLoop {
         request: OpenAIChatCompletionRequest,
         tokenizer: TokenizerHandle,
         modelType: String?,
-        reasoningEffort: String?
+        reasoningEffort: String?,
+        enableThinkingOverride: Bool? = nil
     ) -> Int {
         guard let prepared = try? ToolChoicePromptPolicy.prepare(request) else { return 0 }
         let messages = prepared.messages.map { $0.templateMessageDict() }
         let toolSpecs = prepared.tools?.map { $0.toolSpec() }
         let additionalContext = MultiModelBatchSchedulerEngine.templateAdditionalContext(
-            for: request, reasoningEffort: reasoningEffort)
+            for: request,
+            reasoningEffort: reasoningEffort,
+            enableThinkingOverride: enableThinkingOverride)
         // Must mirror the production tokenize path (sanitize JSON
         // null / Optional leaves) so this recount matches what was prefilled
         // and doesn't itself throw on a null-bearing request.

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+InferenceHandler.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+InferenceHandler.swift
@@ -860,7 +860,8 @@ extension ProviderLoop {
                     request: streamingRequest,
                     tokenizer: tokenizer,
                     modelType: modelType,
-                    reasoningEffort: reasoningEffort
+                    reasoningEffort: reasoningEffort,
+                    enableThinkingOverride: enableThinkingOverride
                 ))
                 guard case .complete(let settledUsage) = terminal else {
                     // Cancelled with nothing delivered: 499 so the coordinator refunds.
@@ -916,7 +917,8 @@ extension ProviderLoop {
                         request: streamingRequest,
                         tokenizer: tokenizer,
                         modelType: modelType,
-                        reasoningEffort: reasoningEffort
+                        reasoningEffort: reasoningEffort,
+                        enableThinkingOverride: enableThinkingOverride
                     )
                     if promptTokens > 0 {
                         log.warning(

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+InferenceHandler.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+InferenceHandler.swift
@@ -228,6 +228,7 @@ extension ProviderLoop {
         // Harmony reads it to set the reasoning budget; other models
         // ignore the extra template variable.
         let reasoningEffort = Self.extractReasoningEffort(from: decryptedData)
+        let enableThinkingOverride = Self.extractEnableThinking(from: decryptedData)
         // Cache identity is coordinator-authored and authenticated outside the
         // sealed OpenAI body. Never trust caller-controlled prompt_cache_key/user
         // for remote cache partitioning. Legacy coordinators omit the outer
@@ -491,6 +492,7 @@ extension ProviderLoop {
                 releaseModel: { _ in },
                 defaultMaxTokens: Self.schedulerDefaultMaxTokens,
                 reasoningEffort: reasoningEffort,
+                enableThinkingOverride: enableThinkingOverride,
                 cacheScope: cacheScope,
                 cacheEnabled: remoteCache.cacheEnabled,
                 engineV2Logprobs: logprobsChannel.map {

--- a/provider-swift/Sources/ProviderCore/Server/LocalChatUploadResponder.swift
+++ b/provider-swift/Sources/ProviderCore/Server/LocalChatUploadResponder.swift
@@ -99,6 +99,10 @@ where Inner.Context == BasicRequestContext {
             }
             // Mirror of the upstream batch handler: sequential
             // createChatCompletion calls, one JSON array response.
+            // Batch items share the outer body probe only for the array
+            // envelope; per-item thinking flags aren't re-extracted from
+            // each element (batch path is text-oriented). Prefer nested
+            // `reasoning.enabled` on each element when needed.
             var responses: [OpenAIChatCompletionResponse] = []
             for chatRequest in requests {
                 responses.append(try await service.createChatCompletion(request: chatRequest))
@@ -111,14 +115,23 @@ where Inner.Context == BasicRequestContext {
         case .success(let decoded): chatRequest = decoded
         case .failure(let badRequest): return badRequest
         }
-        // Same service entry points as the upstream handler; pre-stream
-        // throws (unknown model, admission refusal) travel to
-        // `CORSResponder`'s status mapping unchanged.
-        if chatRequest.stream == true {
-            let frames = try await service.streamChatCompletionFrames(request: chatRequest)
-            return Self.sseResponse(frames)
+        // Recover thinking controls dropped by the upstream OpenAI request
+        // shape (same sealed-body probes as the coordinator path — #639).
+        let bodyData = Data(buffer: buffer)
+        let thinkingControls = ThinkingRequestControls(
+            reasoningEffort: ProviderLoop.extractReasoningEffort(from: bodyData),
+            enableThinkingOverride: ProviderLoop.extractEnableThinking(from: bodyData)
+        )
+        return try await ThinkingRequestControls.$current.withValue(thinkingControls) {
+            // Same service entry points as the upstream handler; pre-stream
+            // throws (unknown model, admission refusal) travel to
+            // `CORSResponder`'s status mapping unchanged.
+            if chatRequest.stream == true {
+                let frames = try await service.streamChatCompletionFrames(request: chatRequest)
+                return Self.sseResponse(frames)
+            }
+            return try Self.jsonResponse(try await service.createChatCompletion(request: chatRequest))
         }
-        return try Self.jsonResponse(try await service.createChatCompletion(request: chatRequest))
     }
 
     /// Decode with Hummingbird's default `requestDecoder` configuration

--- a/provider-swift/Tests/ProviderCoreTests/EngineV2VisionRoutingTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/EngineV2VisionRoutingTests.swift
@@ -514,6 +514,17 @@ struct MediaKindClassificationTests {
         #expect(input.additionalContext?["reasoning_effort"] as? String == "high")
     }
 
+    @Test("media processor honors enableThinkingOverride when nested reasoning absent")
+    func enableThinkingOverrideTemplateContext() async throws {
+        let request = imageRequest()
+        let disabled = try await MediaIngest.buildUserInput(
+            from: request, enableThinkingOverride: false)
+        #expect(disabled.additionalContext?["enable_thinking"] as? Bool == false)
+        let enabled = try await MediaIngest.buildUserInput(
+            from: request, enableThinkingOverride: true)
+        #expect(enabled.additionalContext?["enable_thinking"] as? Bool == true)
+    }
+
     @Test("image-only request has no video and classifies as .image")
     func imageOnly() {
         #expect(!MediaIngest.hasVideo(imageRequest()))
@@ -739,7 +750,7 @@ struct EngineV2VisionRoutingTests {
         let (prepared, _) = makePreparedSubmission()
         let counter = PrepareCallCounter()
         let plumbing = EngineV2VisionPlumbing(
-            prepare: { _, _, _ in
+            prepare: { _, _, _, enableThinkingOverride in
                 counter.increment()
                 return prepared
             },
@@ -770,7 +781,7 @@ struct EngineV2VisionRoutingTests {
         let (prepared, _) = makePreparedSubmission()
         let capture = VisionRequestCapture()
         let plumbing = EngineV2VisionPlumbing(
-            prepare: { _, request, _ in
+            prepare: { _, request, _, enableThinkingOverride in
                 capture.record(request)
                 return prepared
             },
@@ -811,7 +822,7 @@ struct EngineV2VisionRoutingTests {
         let bridge = makeBridge(engine: engine)
         let (prepared, _) = makePreparedSubmission()
         let plumbing = EngineV2VisionPlumbing(
-            prepare: { _, _, _ in prepared },
+            prepare: { _, _, _, enableThinkingOverride in prepared },
             emitTelemetry: { _ in }
         )
         let router = makeRoutingEngine(
@@ -882,7 +893,7 @@ struct EngineV2VisionRoutingTests {
             kvBudget: budget
         )
         let plumbing = EngineV2VisionPlumbing(
-            prepare: { _, _, _ in prepared },
+            prepare: { _, _, _, enableThinkingOverride in prepared },
             emitTelemetry: { _ in }
         )
         let router = makeRoutingEngine(
@@ -916,7 +927,7 @@ struct EngineV2VisionRoutingTests {
         let bridge = makeBridge(engine: engine)
         let telemetry = VisionTelemetrySink()
         let plumbing = EngineV2VisionPlumbing(
-            prepare: { _, _, _ in throw PrepFailure() },
+            prepare: { _, _, _, enableThinkingOverride in throw PrepFailure() },
             emitTelemetry: telemetry.callback()
         )
         let router = makeRoutingEngine(
@@ -967,7 +978,7 @@ struct EngineV2VisionRoutingTests {
         let bridge = makeBridge(engine: engine)
         let telemetry = VisionTelemetrySink()
         let plumbing = EngineV2VisionPlumbing(
-            prepare: { _, _, _ in
+            prepare: { _, _, _, enableThinkingOverride in
                 throw MediaIngest.MediaError.mediaTooLarge("test-cap")
             },
             emitTelemetry: telemetry.callback()
@@ -1003,7 +1014,7 @@ struct EngineV2VisionRoutingTests {
         let bridge = makeBridge(engine: engine)
         let telemetry = VisionTelemetrySink()
         let plumbing = EngineV2VisionPlumbing(
-            prepare: { _, _, _ in throw EngineV2VisionPrefillError.noProcessedMedia },
+            prepare: { _, _, _, enableThinkingOverride in throw EngineV2VisionPrefillError.noProcessedMedia },
             emitTelemetry: telemetry.callback()
         )
         let router = makeRoutingEngine(
@@ -1038,7 +1049,7 @@ struct EngineV2VisionRoutingTests {
         let bridge = makeBridge(engine: engine)
         let telemetry = VisionTelemetrySink()
         let plumbing = EngineV2VisionPlumbing(
-            prepare: { _, _, _ in
+            prepare: { _, _, _, enableThinkingOverride in
                 throw EngineV2VisionPrefillError.unsupportedMedia(
                     "Qwen35MoE video media is not production-proven")
             },
@@ -1080,7 +1091,7 @@ struct EngineV2VisionRoutingTests {
         }
         let effort = EffortBox()
         let plumbing = EngineV2VisionPlumbing(
-            prepare: { _, _, reasoningEffort in
+            prepare: { _, _, reasoningEffort, enableThinkingOverride in
                 effort.set(reasoningEffort)
                 return prepared
             }, emitTelemetry: { _ in })
@@ -1100,7 +1111,7 @@ struct EngineV2VisionRoutingTests {
         let bridge = makeBridge(engine: engine)
         let telemetry = VisionTelemetrySink()
         let plumbing = EngineV2VisionPlumbing(
-            prepare: { _, _, _ in throw PrepFailure() },
+            prepare: { _, _, _, enableThinkingOverride in throw PrepFailure() },
             emitTelemetry: telemetry.callback()
         )
         let router = makeRoutingEngine(
@@ -1140,7 +1151,7 @@ struct EngineV2VisionRoutingTests {
         // preparer must not be consulted on the way to the backstop.
         let counter = PrepareCallCounter()
         let plumbing = EngineV2VisionPlumbing(
-            prepare: { _, _, _ in
+            prepare: { _, _, _, enableThinkingOverride in
                 counter.increment()
                 throw VisionStubProcessorError()
             },
@@ -1175,7 +1186,7 @@ struct EngineV2VisionRoutingTests {
         let (prepared, _) = makePreparedSubmission(mediaKind: .video)
         let counter = PrepareCallCounter()
         let plumbing = EngineV2VisionPlumbing(
-            prepare: { _, _, _ in
+            prepare: { _, _, _, enableThinkingOverride in
                 counter.increment()
                 return prepared
             },
@@ -1215,7 +1226,7 @@ struct EngineV2VisionRoutingTests {
         let bridge = makeBridge(engine: engine)
         let counter = PrepareCallCounter()
         let plumbing = EngineV2VisionPlumbing(
-            prepare: { _, _, _ in
+            prepare: { _, _, _, enableThinkingOverride in
                 counter.increment()
                 throw VisionStubProcessorError()
             },
@@ -1253,7 +1264,7 @@ struct EngineV2VisionRoutingTests {
         let bridge = makeBridge(engine: engine)
         let counter = PrepareCallCounter()
         let plumbing = EngineV2VisionPlumbing(
-            prepare: { _, _, _ in
+            prepare: { _, _, _, enableThinkingOverride in
                 counter.increment()
                 throw VisionStubProcessorError()
             },
@@ -1292,7 +1303,7 @@ struct EngineV2VisionRoutingTests {
         let bridge = makeBridge(engine: engine)
         let telemetry = VisionTelemetrySink()
         let plumbing = EngineV2VisionPlumbing(
-            prepare: { _, _, _ in throw CancellationError() },
+            prepare: { _, _, _, enableThinkingOverride in throw CancellationError() },
             emitTelemetry: telemetry.callback()
         )
         let releaseCount = PrepareCallCounter()
@@ -1346,7 +1357,7 @@ struct EngineV2VisionRoutingTests {
         let bridge = makeBridge(engine: engine)
         let (prepared, _) = makePreparedSubmission()
         let plumbing = EngineV2VisionPlumbing(
-            prepare: { _, _, _ in prepared },
+            prepare: { _, _, _, enableThinkingOverride in prepared },
             emitTelemetry: { _ in }
         )
         let router = makeRoutingEngine(

--- a/provider-swift/Tests/ProviderCoreTests/GemmaVLMVideoEngineV2LiveTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/GemmaVLMVideoEngineV2LiveTests.swift
@@ -280,9 +280,9 @@ struct GemmaVLMVideoEngineV2LiveTests {
     ) async throws -> (content: String, ttft: TimeInterval) {
         let recorder = VideoLiveRefusalRecorder()
         let plumbing = EngineV2VisionPlumbing(
-            prepare: { container, request, reasoningEffort in
+            prepare: { container, request, reasoningEffort, enableThinkingOverride in
                 try await EngineV2VisionPrefill.prepare(
-                    container: container, request: request, reasoningEffort: reasoningEffort)
+                    container: container, request: request, reasoningEffort: reasoningEffort, enableThinkingOverride: enableThinkingOverride)
             },
             emitTelemetry: { recorder.append($0) }
         )

--- a/provider-swift/Tests/ProviderCoreTests/GemmaVLMVisionEngineV2LiveTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/GemmaVLMVisionEngineV2LiveTests.swift
@@ -171,9 +171,9 @@ struct GemmaVLMVisionEngineV2LiveTests {
     ) async throws -> String {
         let recorder = VisionLiveRefusalRecorder()
         let plumbing = EngineV2VisionPlumbing(
-            prepare: { container, request, reasoningEffort in
+            prepare: { container, request, reasoningEffort, enableThinkingOverride in
                 try await EngineV2VisionPrefill.prepare(
-                    container: container, request: request, reasoningEffort: reasoningEffort)
+                    container: container, request: request, reasoningEffort: reasoningEffort, enableThinkingOverride: enableThinkingOverride)
             },
             emitTelemetry: { recorder.append($0) }
         )

--- a/provider-swift/Tests/ProviderCoreTests/MultiModelBatchSchedulerEngineTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/MultiModelBatchSchedulerEngineTests.swift
@@ -236,18 +236,23 @@ func templateContextHonorsEnableThinkingOverride() {
     #expect(enabled?["enable_thinking"] as? Bool == true)
 }
 
-@Test("template context maps reasoning_effort none/minimal/off to enable_thinking false")
+@Test("template context maps reasoning_effort none/off to enable_thinking false; minimal stays on")
 func templateContextMapsNoneEffortToDisableThinking() {
     let request = OpenAIChatCompletionRequest(
         model: "qwen",
         messages: [.init(role: .user, content: .text("hi"))])
 
-    for effort in ["none", "minimal", "off", "0", "NONE"] {
+    for effort in ["none", "off", "0", "NONE"] {
         let context = MultiModelBatchSchedulerEngine.templateAdditionalContext(
             for: request, reasoningEffort: effort)
         #expect(context?["enable_thinking"] as? Bool == false, "effort=\(effort)")
         #expect(context?["reasoning_effort"] as? String == effort)
     }
+
+    let minimal = MultiModelBatchSchedulerEngine.templateAdditionalContext(
+        for: request, reasoningEffort: "minimal")
+    #expect(minimal?["enable_thinking"] as? Bool == nil, "minimal must not force disable")
+    #expect(minimal?["reasoning_effort"] as? String == "minimal")
 }
 
 @Test("nested reasoning.enabled wins over enableThinkingOverride and none effort")

--- a/provider-swift/Tests/ProviderCoreTests/MultiModelBatchSchedulerEngineTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/MultiModelBatchSchedulerEngineTests.swift
@@ -221,6 +221,61 @@ func templateContextComposesReasoningControls() {
     #expect(context?["reasoning_effort"] as? String == "high")
 }
 
+@Test("template context honors enableThinkingOverride when reasoning.enabled absent")
+func templateContextHonorsEnableThinkingOverride() {
+    let request = OpenAIChatCompletionRequest(
+        model: "qwen",
+        messages: [.init(role: .user, content: .text("hi"))])
+
+    let disabled = MultiModelBatchSchedulerEngine.templateAdditionalContext(
+        for: request, reasoningEffort: nil, enableThinkingOverride: false)
+    let enabled = MultiModelBatchSchedulerEngine.templateAdditionalContext(
+        for: request, reasoningEffort: nil, enableThinkingOverride: true)
+
+    #expect(disabled?["enable_thinking"] as? Bool == false)
+    #expect(enabled?["enable_thinking"] as? Bool == true)
+}
+
+@Test("template context maps reasoning_effort none/minimal/off to enable_thinking false")
+func templateContextMapsNoneEffortToDisableThinking() {
+    let request = OpenAIChatCompletionRequest(
+        model: "qwen",
+        messages: [.init(role: .user, content: .text("hi"))])
+
+    for effort in ["none", "minimal", "off", "0", "NONE"] {
+        let context = MultiModelBatchSchedulerEngine.templateAdditionalContext(
+            for: request, reasoningEffort: effort)
+        #expect(context?["enable_thinking"] as? Bool == false, "effort=\(effort)")
+        #expect(context?["reasoning_effort"] as? String == effort)
+    }
+}
+
+@Test("nested reasoning.enabled wins over enableThinkingOverride and none effort")
+func nestedReasoningEnabledWins() {
+    let request = OpenAIChatCompletionRequest(
+        model: "qwen",
+        messages: [.init(role: .user, content: .text("hi"))],
+        reasoning: .init(enabled: true))
+
+    let context = MultiModelBatchSchedulerEngine.templateAdditionalContext(
+        for: request, reasoningEffort: "none", enableThinkingOverride: false)
+
+    #expect(context?["enable_thinking"] as? Bool == true)
+}
+
+@Test("extractEnableThinking reads top-level and chat_template_kwargs")
+func extractEnableThinkingFromBody() throws {
+    let top = #"{"model":"q","messages":[],"enable_thinking":false}"#.data(using: .utf8)!
+    #expect(ProviderLoop.extractEnableThinking(from: top) == false)
+
+    let kwargs = #"{"model":"q","messages":[],"chat_template_kwargs":{"enable_thinking":false}}"#
+        .data(using: .utf8)!
+    #expect(ProviderLoop.extractEnableThinking(from: kwargs) == false)
+
+    let missing = #"{"model":"q","messages":[]}"#.data(using: .utf8)!
+    #expect(ProviderLoop.extractEnableThinking(from: missing) == nil)
+}
+
 // MARK: - Engine error mapping (P2 #6)
 //
 // Pins the `MultiModelBatchSchedulerEngineError.fromSchedulerMessage`

--- a/provider-swift/Tests/ProviderCoreTests/Qwen36ProductionCanaryTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/Qwen36ProductionCanaryTests.swift
@@ -57,11 +57,11 @@ struct Qwen36ProductionCanaryTests {
             let visionScheduler = fixture.scheduler(
                 bundle: targetBundle,
                 vision: EngineV2VisionPlumbing(
-                    prepare: { container, request, reasoningEffort in
+                    prepare: { container, request, reasoningEffort, enableThinkingOverride in
                         let prepared = try await EngineV2VisionPrefill.prepare(
                             container: container,
                             request: request,
-                            reasoningEffort: reasoningEffort)
+                            reasoningEffort: reasoningEffort, enableThinkingOverride: enableThinkingOverride)
                         visionProbe.recordPrepared(spanCount: prepared.spans.count)
                         return prepared
                     },


### PR DESCRIPTION
## Summary

Reasoning models ignored common thinking-disable request shapes (`enable_thinking: false`, `chat_template_kwargs.enable_thinking`, `reasoning_effort: none|minimal|off`) because the chat-template context only set `enable_thinking` from nested `reasoning.enabled`.

This wires sealed-body probes (same pattern as `reasoning_effort` / logprobs) into template `additionalContext`, and soft-maps none-like effort values to `enable_thinking=false`. Nested `reasoning.enabled` still wins when present.

Closes #639

## Linked issue

Closes #639

## Test plan

- [x] Unit tests in `MultiModelBatchSchedulerEngineTests` for:
  - override when `reasoning.enabled` absent
  - effort `none`/`minimal`/`off`/`0` → disable
  - nested `reasoning.enabled` precedence
  - `extractEnableThinking` top-level + kwargs
- [ ] CI `swift test` (local ProviderCore build blocked on shallow `libs/mlx` submodule missing jaccl sources — full CI tree required)
- [ ] Optional live matrix on qwen3.6 / gpt-oss after merge (lab host)

## Components touched

- [ ] coordinator (Go)
- [ ] provider (Rust, legacy)
- [x] provider-swift (Swift CLI)
- [ ] console-ui (Next.js)
- [ ] enclave (Swift)
- [ ] infra / CI / release
- [ ] docs

## Protocol / interface changes

- [x] No protocol/interface changes
- [ ] Yes — described above and matching side updated

## Behavior diagrams

```mermaid
flowchart LR
  subgraph Before
    A1[client enable_thinking false] --> B1[decode OpenAIChatCompletionRequest]
    B1 --> C1[template context only reasoning.enabled]
    C1 --> D1[enable_thinking omitted]
    D1 --> E1[model still thinks]
  end
```

```mermaid
flowchart LR
  subgraph After
    A2[client enable_thinking false or effort none] --> B2[decode + sealed-body probes]
    B2 --> C2[template context enable_thinking false]
    C2 --> D2[chat template can disable thinking]
  end
```

## Code path

```mermaid
flowchart TD
  body[sealed body] --> effort[extractReasoningEffort]
  body --> think[extractEnableThinking]
  body --> req[OpenAIChatCompletionRequest]
  effort --> ctx[templateAdditionalContext]
  think --> ctx
  req --> ctx
  ctx --> jinja[applyChatTemplate additionalContext]
```

## Notes for reviewers

- Priority: `reasoning.enabled` > body override > effort none-map
- Does not claim gpt-oss can fully disable if the model family is always-on; it does stop silently dropping the disable signal into the template
- Follow-up: catalog capability flag + 400 on unsupported disable if maintainers want explicit errors (issue request items 2-3)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/677"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790041474&installation_model_id=21733&pr_number=677&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F677&signature=1c323bc6fe1a32dc88b6354d1f415e1b0d4e83e5d7bf9696e882b36318e0a6c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->