### PR TITLE
feat(doctor): warn on competing local inference (ollama/ports)

### DIFF
--- a/provider-swift/Sources/darkbloom/Diagnostics/CompetingInferenceDiagnostics.swift
+++ b/provider-swift/Sources/darkbloom/Diagnostics/CompetingInferenceDiagnostics.swift
@@ -1,0 +1,82 @@
+import Foundation
+
+/// Snapshot of non-Darkbloom inference that can steal unified memory / ports.
+/// Injectable for pure unit tests (see `DoctorChecksTests`).
+struct LocalContentionSnapshot: Equatable, Sendable {
+    /// True if something is listening on Ollama's default port.
+    var ollamaPortListening: Bool
+    /// Short process name tokens observed (e.g. "ollama", "llama-server").
+    var competingProcessHints: [String]
+
+    static let empty = LocalContentionSnapshot(ollamaPortListening: false, competingProcessHints: [])
+
+    /// Best-effort live probe. Failures degrade to empty (no false WARNs).
+    static func live() -> LocalContentionSnapshot {
+        var ollama = false
+        var hints: [String] = []
+
+        // Port 11434 — Ollama default
+        if let out = runCapture("/usr/sbin/lsof", args: ["-nP", "-iTCP:11434", "-sTCP:LISTEN"]) {
+            if out.contains("LISTEN") {
+                ollama = true
+                if out.lowercased().contains("ollama") {
+                    hints.append("ollama")
+                }
+            }
+        }
+
+        // Process table hints (names only — no args, avoid leaking paths/keys)
+        if let ps = runCapture("/bin/ps", args: ["-axo", "comm="]) {
+            let lower = ps.lowercased()
+            let watch = ["ollama", "llama-server", "mlx_lm.server", "vllm", "text-generation-launcher"]
+            for name in watch where lower.contains(name) {
+                if !hints.contains(name) { hints.append(name) }
+            }
+        }
+
+        return LocalContentionSnapshot(
+            ollamaPortListening: ollama,
+            competingProcessHints: hints.sorted()
+        )
+    }
+
+    private static func runCapture(_ path: String, args: [String]) -> String? {
+        let p = Process()
+        p.executableURL = URL(fileURLWithPath: path)
+        p.arguments = args
+        let pipe = Pipe()
+        p.standardOutput = pipe
+        p.standardError = FileHandle.nullDevice
+        do {
+            try p.run()
+            p.waitUntilExit()
+        } catch {
+            return nil
+        }
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        return String(data: data, encoding: .utf8)
+    }
+}
+
+func competingInferenceCheck(_ snap: LocalContentionSnapshot) -> DoctorCheck {
+    if !snap.ollamaPortListening && snap.competingProcessHints.isEmpty {
+        return DoctorCheck(
+            name: "competing inference",
+            status: .pass,
+            detail: "no common local inference competitors detected"
+        )
+    }
+    var parts: [String] = []
+    if snap.ollamaPortListening {
+        parts.append("port 11434 LISTEN (Ollama default)")
+    }
+    if !snap.competingProcessHints.isEmpty {
+        parts.append("processes: " + snap.competingProcessHints.joined(separator: ", "))
+    }
+    return DoctorCheck(
+        name: "competing inference",
+        status: .warn,
+        detail: parts.joined(separator: "; ")
+            + " — can reduce usable RAM / deroute paid work on unified memory"
+    )
+}

--- a/provider-swift/Sources/darkbloom/DoctorCommand.swift
+++ b/provider-swift/Sources/darkbloom/DoctorCommand.swift
@@ -218,7 +218,8 @@ func bootSecurityActionGuide(_ bootSecurity: BootSecuritySnapshot) -> String? {
 
 func buildDoctorChecks(
     snapshot: RuntimeSnapshot,
-    bootSecurity: BootSecuritySnapshot = .live()
+    bootSecurity: BootSecuritySnapshot = .live(),
+    contention: LocalContentionSnapshot = .live()
 ) -> [DoctorCheck] {
     var checks: [DoctorCheck] = []
 
@@ -333,6 +334,9 @@ func buildDoctorChecks(
             detail: "could not compute"
         ))
     }
+
+    // Local coexistence: Ollama / other inference on unified memory (operator feedback).
+    checks.append(competingInferenceCheck(contention))
 
     return checks
 }

--- a/provider-swift/Tests/DarkbloomCLITests/DoctorChecksTests.swift
+++ b/provider-swift/Tests/DarkbloomCLITests/DoctorChecksTests.swift
@@ -16,7 +16,8 @@ struct DoctorChecksTests {
         hardware: HardwareInfo? = nil,
         configFileExists: Bool = true,
         models: [ModelInfo] = [],
-        bootSecurity: BootSecuritySnapshot = .init(macOSMajorVersion: 26, sip: .enabled)
+        bootSecurity: BootSecuritySnapshot = .init(macOSMajorVersion: 26, sip: .enabled),
+        contention: LocalContentionSnapshot = .empty
     ) -> [DoctorCheck] {
         buildDoctorChecks(
             snapshot: RuntimeSnapshot(
@@ -31,7 +32,8 @@ struct DoctorChecksTests {
                 hardwareError: nil,
                 models: models
             ),
-            bootSecurity: bootSecurity
+            bootSecurity: bootSecurity,
+            contention: contention
         )
     }
 
@@ -44,7 +46,7 @@ struct DoctorChecksTests {
         #expect(checks(hardware: hardware).map(\.name) == [
             "hardware", "metal gpu", "config", "huggingface cache", "local mlx models",
             "macos", "sip", "rdma", "authenticated root", "hardened runtime", "debugger",
-            "binary hash",
+            "binary hash", "competing inference",
         ])
     }
 
@@ -89,5 +91,25 @@ struct DoctorChecksTests {
         #expect(CheckStatus.fail.marker == "[FAIL]")
         #expect(CheckStatus(.pass) == .pass)
         #expect(CheckStatus(.warn) == .warn)
+    }
+
+    @Test("competing inference warns on ollama port or known process hints")
+    func competingInferenceDiagnosis() {
+        let clear = checks(hardware: hardware, contention: .empty)
+        #expect(check(clear, "competing inference")?.status == .pass)
+
+        let ollama = checks(
+            hardware: hardware,
+            contention: .init(ollamaPortListening: true, competingProcessHints: ["ollama"])
+        )
+        #expect(check(ollama, "competing inference")?.status == .warn)
+        #expect(check(ollama, "competing inference")?.detail.contains("11434") == true)
+
+        let llama = checks(
+            hardware: hardware,
+            contention: .init(ollamaPortListening: false, competingProcessHints: ["llama-server"])
+        )
+        #expect(check(llama, "competing inference")?.status == .warn)
+        #expect(check(llama, "competing inference")?.detail.contains("llama-server") == true)
     }
 }


### PR DESCRIPTION
## Summary

`darkbloom doctor` did not surface common local competitors (Ollama on :11434, llama-server, etc.) that steal unified memory and contribute to “green doctor, no paid work” operator failures.

Adds an injectable `LocalContentionSnapshot` + `competing inference` check on the doctor backbone, with pure unit tests (empty / ollama port / process hints).

## Linked issue

Operator coexistence pain (no single upstream issue — multi-host feedback). Happy to link if maintainers prefer a tracking issue first.

## Test plan

- [x] `DoctorChecksTests` backbone includes `competing inference`
- [x] PASS when snapshot empty; WARN on 11434 LISTEN; WARN on llama-server hint
- [ ] CI Swift tests after workflow approval

## Components touched

- [x] provider-swift (Swift CLI)
- [ ] coordinator / console-ui / docs / infra

## Protocol / interface changes

- [x] No protocol/interface changes

## Behavior diagrams

```mermaid
flowchart LR
  subgraph Before
    A1[doctor] --> B1[local security + fit checks]
    B1 --> C1[PASS while ollama holds RAM]
  end
```

```mermaid
flowchart LR
  subgraph After
    A2[doctor] --> B2[existing checks]
    B2 --> C2[competing inference probe]
    C2 --> D2[WARN if 11434/ollama/llama-server]
  end
```

## Notes

- Live probe uses `lsof` + `ps` best-effort; probe failure → empty snapshot (no false WARN)
- Does not kill foreign processes — diagnose only
- Follow-up: wire into `DoctorRunner` economic diagnosis section if desired

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/678"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790041860&installation_model_id=21733&pr_number=678&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F678&signature=520404f88d2f26f8429ac0c972f567ac403042ecd9b7e19be1c9f0e2a3b33031"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->