### PR TITLE
fix(coordinator): price routing prefill with the measured rate, not the static one

### DIFF
--- a/coordinator/registry/long_prompt_test.go
+++ b/coordinator/registry/long_prompt_test.go
@@ -346,3 +346,55 @@ func TestReserveProviderLongPromptColdLoadNotAmplifiedAway(t *testing.T) {
 		t.Fatalf("cold breakdown sum %v != CostMs %v", sum, coldDec.CostMs)
 	}
 }
+
+// TestRoutingCostPrefersObservedOverStaticPrefill is the regression test for the
+// base routing cost term. TestLongPromptPrefersObservedOverStaticPrefill above
+// only exercises the long-prompt bias, which is OFF by default
+// (defaultLongPromptThresholdTokens == 0, and longPromptPenalty returns 0 at a
+// non-positive threshold). With the bias off, the prefill contribution to cost is
+// thisReqMs alone — so if thisReqMs reads the static snap.prefillTPS, the measured
+// prefill EWMA cannot influence provider selection at all on a default
+// configuration, and a box whose live prefill has degraded keeps winning on the
+// strength of its registration benchmark.
+//
+// Same fixture shape as the long-prompt test, with the threshold pinned OFF and a
+// prompt well below any bias.
+func TestRoutingCostPrefersObservedOverStaticPrefill(t *testing.T) {
+	origThreshold, origWeight := longPromptThresholdTokens, longPromptPrefillWeight
+	defer func() { longPromptThresholdTokens, longPromptPrefillWeight = origThreshold, origWeight }()
+	// Pin the documented default: the long-prompt bias contributes nothing, so
+	// only the base cost term can express the prefill difference.
+	SetLongPromptThreshold(0)
+
+	reg := New(testLogger())
+	model := "routing-cost-observed-prefill-model"
+	// Static says A is the fast box; the live measured PREFILL says A is degraded
+	// (200) and B is fast (2000). Both idle and equal on decode, so the prefill
+	// signal is the only thing that differs.
+	staticFast := makeTokenBudgetProvider(t, reg, "static-fast-observed-slow", model, 100, 0, 200_000, 100)
+	staticFast.mu.Lock()
+	staticFast.PrefillTPS = 2_000
+	staticFast.BackendCapacity.Slots[0].ObservedPrefillTPS = 200 // degraded live prefill
+	staticFast.mu.Unlock()
+	observedFast := makeTokenBudgetProvider(t, reg, "static-slow-observed-fast", model, 100, 0, 200_000, 100)
+	observedFast.mu.Lock()
+	observedFast.PrefillTPS = 400
+	observedFast.BackendCapacity.Slots[0].ObservedPrefillTPS = 2_000 // fast live prefill
+	observedFast.mu.Unlock()
+
+	sel, dec := reg.ReserveProviderEx(model, &PendingRequest{
+		RequestID: "routing-cost-observed", Model: model, EstimatedPromptTokens: 4_000, RequestedMaxTokens: 256,
+	})
+	if sel == nil {
+		t.Fatalf("returned nil provider; decision=%+v", dec)
+	}
+	if sel.ID != observedFast.ID {
+		t.Fatalf("selected %q, want observed-fastest %q — the base cost term must price prefill with resolvePrefillTPS, not the static snap.prefillTPS; decision=%+v",
+			sel.ID, observedFast.ID, dec)
+	}
+	// The cost-breakdown invariant must still hold after the hoist.
+	sum := dec.StateMs + dec.QueueMs + dec.PendingMs + dec.BacklogMs + dec.ThisReqMs + dec.HealthMs
+	if diff := sum - dec.CostMs; diff > 0.001 || diff < -0.001 {
+		t.Fatalf("breakdown sum %f != CostMs %f", sum, dec.CostMs)
+	}
+}

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -1579,7 +1579,14 @@ func (r *Registry) buildCandidateWithReason(snap routingSnapshot, pr *PendingReq
 	} else {
 		backlogMs = backlogTokenMs(snap.maxTokensPotential, waitingBacklogTokens, unaccountedPendingTokens, effectiveTPS)
 	}
-	thisReqMs := float64(reqPrompt)/snap.prefillTPS*1000.0 + float64(reqMax)/effectiveTPS*1000.0
+	// Prefill resolves through resolvePrefillTPS for BOTH the base cost term and
+	// the long-prompt bias below, so provider ranking follows the live measured
+	// prefill EWMA when a slot reports one and only falls back to the static
+	// registration/x12 chain when it does not. Reading snap.prefillTPS directly
+	// here pinned the dominant prefill term to the static rate, which left a box
+	// whose measured prefill had degraded looking as cheap as its benchmark.
+	prefillTPS := resolvePrefillTPS(snap)
+	thisReqMs := float64(reqPrompt)/prefillTPS*1000.0 + float64(reqMax)/effectiveTPS*1000.0
 	// Long-prompt fastest-tier preference: amplify the first-token-blocking time
 	// for very long prompts so the provider that reaches first token soonest is
 	// strongly preferred, reducing pre-first-token client_gone. The amplified
@@ -1594,7 +1601,7 @@ func (r *Registry) buildCandidateWithReason(snap routingSnapshot, pr *PendingReq
 	// the fastest warm provider. Folded into thisReqMs so the cost breakdown
 	// invariant (sum of terms == Total) holds. Returns 0 — and so leaves the cost
 	// byte-for-byte unchanged — for short prompts and when the knob is off.
-	prefillMs := float64(reqPrompt) / resolvePrefillTPS(snap) * 1000.0
+	prefillMs := float64(reqPrompt) / prefillTPS * 1000.0
 	ttftBlockMs := prefillMs
 	if !snap.modelLoaded {
 		// A cold provider must load before it can prefill; amplify its full


### PR DESCRIPTION
## Summary

`buildCandidateWithReason` priced the dominant prefill term of the routing cost from `snap.prefillTPS`, the static chain (registration benchmark, else `decode x prefillToDecodeRatio`). Every other prefill computation in the same file already resolves through `resolvePrefillTPS`, which prefers the per-slot observed prefill EWMA. The base cost term did not, so the router could select a provider it concurrently estimated would miss the deadline. This hoists `resolvePrefillTPS` once and uses it for both terms.

## Linked issue

None open for this. Related to the OpenRouter prefill-timeout thread; happy to file one if you want it tracked separately.

## Before / after

Behavior:

```mermaid
flowchart TB
  subgraph Before["Before: cost prices prefill statically"]
    direction TB
    R1["request, 4k prompt"] --> C1["routing cost = state + queue + pending + backlog + thisReqMs + health"]
    C1 --> P1["thisReqMs uses snap.prefillTPS<br/>static: registration benchmark, else decode x12"]
    P1 --> S1["A: static 1200, measured 120 (degraded under load)<br/>B: static 1200, measured 1200"]
    S1 --> W1["both priced identically, A selectable"]
    W1 --> T1["selected A: TTFTMs 20010<br/>BestTTFTMs 2010"]
    T1 --> D1["soft gate does not shed<br/>request runs long, OpenRouter times out"]
  end
  subgraph After["After: cost prices prefill with the measured rate"]
    direction TB
    R2["request, 4k prompt"] --> C2["routing cost, same terms"]
    C2 --> P2["prefillTPS = resolvePrefillTPS(snap)<br/>observed EWMA when reported, else static chain"]
    P2 --> S2["A prices 10x more expensive than B"]
    S2 --> W2["selected B"]
    W2 --> T2["TTFT 3343ms, inside the 14000ms SLA for this prompt"]
  end
  Before ~~~ After
```

Code:

```mermaid
flowchart TB
  subgraph CodeBefore["Before: buildCandidateWithReason"]
    direction TB
    A1["thisReqMs := reqPrompt / snap.prefillTPS"] --> A2["STATIC only"]
    B1["prefillMs := reqPrompt / resolvePrefillTPS(snap)"] --> B2["measured-preferred"]
    B2 --> B3["longPromptPenalty(...)"]
    B3 --> B4["returns 0 when threshold <= 0<br/>DEFAULT is 0, so this path is inert"]
    A2 --> OUT1["cost ranking sees static prefill only"]
    B4 --> OUT1
  end
  subgraph CodeAfter["After: buildCandidateWithReason"]
    direction TB
    X1["prefillTPS := resolvePrefillTPS(snap)"] --> X2["thisReqMs uses prefillTPS"]
    X1 --> X3["prefillMs uses prefillTPS"]
    X2 --> OUT2["cost ranking follows measured prefill<br/>even with the long-prompt bias off"]
    X3 --> OUT2
  end
  CodeBefore ~~~ CodeAfter
```

## Why the measured signal was inert by default

`resolvePrefillTPS` reaches routing through exactly two paths, and on a default configuration neither could change the winner:

- `ttftMsFromSnapshot` feeds the per-request TTFT ceiling, but that ceiling is a **soft gate by default** (`api/server.go:247`; `queueMaxTTFTMs` returns 0 at `api/dispatch.go:309-311`, so `enforceTTFT` is false at `registry/scheduler.go:653`). Nothing is dropped on it.
- The long-prompt bias at `registry/scheduler.go:1601` does use the measured rate, but `longPromptPenalty` returns 0 when `longPromptThresholdTokens <= 0`, and `defaultLongPromptThresholdTokens` is **0** (`registry/scheduler.go:1886`).

So the observed EWMA reached the estimate but never the cost that picks the provider. Since the provider-side EWMA is load-inclusive (`EngineV2Bridge.swift` records window = first token minus submit, so engine queue wait is included) while the static rate never moves, the gap is widest exactly under load.

## Measured effect

Sweep over prompt sizes 500-16000 and measured/static prefill ratios 0.1-1.0, two otherwise identical providers, long-prompt bias at its default (off):

| | result |
|---|---|
| scenarios where selection changes | **36 / 36** |
| pre-fix picks breaching the ~10s SLA base while a compliant provider was available | **10 / 36 (28%)** |
| worst pre-fix pick | **133343 ms vs 13343 ms available (10.0x)** |

The regression test shows the same thing concretely: pre-fix the selected candidate carries `TTFTMs: 20010` against `BestTTFTMs: 2010`.

**Scope, stated plainly.** This removes the misroute class of timeouts, where a compliant provider existed and the router did not choose it. It does not help when the whole fleet is slow, which is a provider-side prefill problem and not something routing can fix.

## Test plan

- [x] `go test ./registry/ -run TestRoutingCostPrefersObservedOverStaticPrefill -count=1` passes with the fix
- [x] **Fails without the fix**, selecting `static-fast-observed-slow`, which is the regression this guards
- [x] `go test ./...` across the coordinator: **24 packages ok, 0 failures**
- [x] `gofmt -l coordinator/registry/` clean

The new test deliberately pins `SetLongPromptThreshold(0)`, the documented default, so it exercises the base cost term alone. `TestLongPromptPrefersObservedOverStaticPrefill` next to it sets a positive threshold and therefore only ever covered the bias path.

## Components touched

- [x] coordinator (Go)
- [ ] provider (Rust, legacy)
- [ ] provider-swift (Swift CLI)
- [ ] console-ui (Next.js)
- [ ] enclave (Swift)
- [ ] infra / CI / release
- [ ] docs

## Protocol / interface changes

- [x] No protocol/interface changes

## Notes for reviewers

- **This changes routing cost**, so it changes provider selection whenever a slot's measured prefill differs from its static rate. That is the intent, and it matches what the long-prompt comment at `registry/scheduler.go:1594-1600` already says ranking should do. If pinning the base term to the static rate was deliberate, say so and I will close this.
- Behavior is unchanged for any slot that does not report `observed_prefill_tps`: `resolvePrefillTPS` falls back to `snap.prefillTPS`, so the old value is used exactly.
- **`registry/scheduler.go:1728-1729` looks stale.** It says `observedPrefillTPS stays 0 until providers ship the W1 measurement, so on today's fleet this is a no-op`. That comment is from 2026-06-16 (#383); the provider shipped the measurement on 2026-07-09 in #522, and sends it at `EngineV2Bridge+Capacity.swift:188`. I left it alone to keep this diff to one change. Worth a follow-up, and worth confirming against live telemetry that slots actually report non-zero, since `Types.swift:663` uses `encodeIfNonZero` and the EWMA only takes cold-prefill samples.
- **Not included on purpose:** enforcing the TTFT ceiling when the estimate is measurement-backed. That would turn a doomed request into a fast 429 instead of a timeout, which may matter more for the downtime accounting than routing does, but it is an admission-policy change and I cannot verify how OpenRouter counts a 429 versus a timeout. Happy to open it separately if that is the direction you want.
- `thisReqMs` still has no `<= 0` guard on the divisor, where `ttftMsFromSnapshot` clamps to 1.0. Not reachable today (`resolvedDecodeTPS` floors at 1.0), so I left it out of this diff.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/680"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790042737&installation_model_id=21733&pr_number=680&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F680&signature=d8aa8b0463fc2adf51594885420625c179d4a354cbd2bace3bac5a7d83060e5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->