### PR TITLE
fix: stop slow Qwen prefill from being counted as OpenRouter downtime

### DIFF
--- a/coordinator/registry/long_prompt_test.go
+++ b/coordinator/registry/long_prompt_test.go
@@ -346,3 +346,55 @@ func TestReserveProviderLongPromptColdLoadNotAmplifiedAway(t *testing.T) {
 		t.Fatalf("cold breakdown sum %v != CostMs %v", sum, coldDec.CostMs)
 	}
 }
+
+// TestRoutingCostPrefersObservedOverStaticPrefill is the regression test for the
+// base routing cost term. TestLongPromptPrefersObservedOverStaticPrefill above
+// only exercises the long-prompt bias, which is OFF by default
+// (defaultLongPromptThresholdTokens == 0, and longPromptPenalty returns 0 at a
+// non-positive threshold). With the bias off, the prefill contribution to cost is
+// thisReqMs alone — so if thisReqMs reads the static snap.prefillTPS, the measured
+// prefill EWMA cannot influence provider selection at all on a default
+// configuration, and a box whose live prefill has degraded keeps winning on the
+// strength of its registration benchmark.
+//
+// Same fixture shape as the long-prompt test, with the threshold pinned OFF and a
+// prompt well below any bias.
+func TestRoutingCostPrefersObservedOverStaticPrefill(t *testing.T) {
+	origThreshold, origWeight := longPromptThresholdTokens, longPromptPrefillWeight
+	defer func() { longPromptThresholdTokens, longPromptPrefillWeight = origThreshold, origWeight }()
+	// Pin the documented default: the long-prompt bias contributes nothing, so
+	// only the base cost term can express the prefill difference.
+	SetLongPromptThreshold(0)
+
+	reg := New(testLogger())
+	model := "routing-cost-observed-prefill-model"
+	// Static says A is the fast box; the live measured PREFILL says A is degraded
+	// (200) and B is fast (2000). Both idle and equal on decode, so the prefill
+	// signal is the only thing that differs.
+	staticFast := makeTokenBudgetProvider(t, reg, "static-fast-observed-slow", model, 100, 0, 200_000, 100)
+	staticFast.mu.Lock()
+	staticFast.PrefillTPS = 2_000
+	staticFast.BackendCapacity.Slots[0].ObservedPrefillTPS = 200 // degraded live prefill
+	staticFast.mu.Unlock()
+	observedFast := makeTokenBudgetProvider(t, reg, "static-slow-observed-fast", model, 100, 0, 200_000, 100)
+	observedFast.mu.Lock()
+	observedFast.PrefillTPS = 400
+	observedFast.BackendCapacity.Slots[0].ObservedPrefillTPS = 2_000 // fast live prefill
+	observedFast.mu.Unlock()
+
+	sel, dec := reg.ReserveProviderEx(model, &PendingRequest{
+		RequestID: "routing-cost-observed", Model: model, EstimatedPromptTokens: 4_000, RequestedMaxTokens: 256,
+	})
+	if sel == nil {
+		t.Fatalf("returned nil provider; decision=%+v", dec)
+	}
+	if sel.ID != observedFast.ID {
+		t.Fatalf("selected %q, want observed-fastest %q — the base cost term must price prefill with resolvePrefillTPS, not the static snap.prefillTPS; decision=%+v",
+			sel.ID, observedFast.ID, dec)
+	}
+	// The cost-breakdown invariant must still hold after the hoist.
+	sum := dec.StateMs + dec.QueueMs + dec.PendingMs + dec.BacklogMs + dec.ThisReqMs + dec.HealthMs
+	if diff := sum - dec.CostMs; diff > 0.001 || diff < -0.001 {
+		t.Fatalf("breakdown sum %f != CostMs %f", sum, dec.CostMs)
+	}
+}

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -1579,7 +1579,14 @@ func (r *Registry) buildCandidateWithReason(snap routingSnapshot, pr *PendingReq
 	} else {
 		backlogMs = backlogTokenMs(snap.maxTokensPotential, waitingBacklogTokens, unaccountedPendingTokens, effectiveTPS)
 	}
-	thisReqMs := float64(reqPrompt)/snap.prefillTPS*1000.0 + float64(reqMax)/effectiveTPS*1000.0
+	// Prefill resolves through resolvePrefillTPS for BOTH the base cost term and
+	// the long-prompt bias below, so provider ranking follows the live measured
+	// prefill EWMA when a slot reports one and only falls back to the static
+	// registration/x12 chain when it does not. Reading snap.prefillTPS directly
+	// here pinned the dominant prefill term to the static rate, which left a box
+	// whose measured prefill had degraded looking as cheap as its benchmark.
+	prefillTPS := resolvePrefillTPS(snap)
+	thisReqMs := float64(reqPrompt)/prefillTPS*1000.0 + float64(reqMax)/effectiveTPS*1000.0
 	// Long-prompt fastest-tier preference: amplify the first-token-blocking time
 	// for very long prompts so the provider that reaches first token soonest is
 	// strongly preferred, reducing pre-first-token client_gone. The amplified
@@ -1594,7 +1601,7 @@ func (r *Registry) buildCandidateWithReason(snap routingSnapshot, pr *PendingReq
 	// the fastest warm provider. Folded into thisReqMs so the cost breakdown
 	// invariant (sum of terms == Total) holds. Returns 0 — and so leaves the cost
 	// byte-for-byte unchanged — for short prompts and when the knob is off.
-	prefillMs := float64(reqPrompt) / resolvePrefillTPS(snap) * 1000.0
+	prefillMs := float64(reqPrompt) / prefillTPS * 1000.0
 	ttftBlockMs := prefillMs
 	if !snap.modelLoaded {
 		// A cold provider must load before it can prefill; amplify its full

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge.swift
@@ -467,6 +467,23 @@ public actor EngineV2Bridge {
             return stream
         }
 
+        // Prefill deadline admission. Under FCFS prefill serialization every
+        // row ahead of this one finishes before it starts, so this request's
+        // time-to-first-token is the whole prefill queue, not its own prompt.
+        // Admitting a row that cannot make the consumer's TTFT budget converts
+        // a servable request into a timeout; refusing it yields the canonical
+        // queue-full string, which the coordinator classifies as retryable and
+        // re-dispatches to a different provider. Fails OPEN whenever the rate
+        // is unmeasured, so a fresh process never refuses on a guess.
+        if let refusal = prefillDeadlineRefusal(promptTokens: promptTokens.count) {
+            usageSignal?.finalizeLookup(
+                failure: .policy,
+                fallbackTier: ssdPrefixCache == nil ? .memory : .ssd)
+            continuation.yield(.error(refusal))
+            continuation.finish()
+            return stream
+        }
+
         // Translate with a PLACEHOLDER engine id — the real id is minted
         // below, AFTER the shared-budget await, in the same synchronous
         // stretch as `engine.submit` and the `idMap` registration. Validate
@@ -1367,6 +1384,79 @@ public actor EngineV2Bridge {
                 firstTokenAt: state.firstTokenAt)
         }
         return (prompt, completion, tps)
+    }
+
+    // MARK: - Prefill deadline admission
+
+    /// Consumer TTFT budget base (ms). Mirrors the coordinator's verified
+    /// OpenRouter SLA base (`registry/ttft_shadow.go`
+    /// `defaultTTFTDeadlineBaseMs`): observed cancels fit
+    /// `10_000 ms + 1 ms x prompt_tokens` at a median ratio of 1.002.
+    static let defaultPrefillDeadlineBaseMs = 10_000.0
+
+    /// Override / kill switch. A non-positive value disables the gate and
+    /// restores the accept-everything behaviour as the A/B control.
+    static let prefillDeadlineBaseMsKey = "DARKBLOOM_PREFILL_DEADLINE_BASE_MS"
+
+    static let resolvedPrefillDeadlineBaseMs: Double = {
+        guard let raw = ProcessInfo.processInfo.environment[prefillDeadlineBaseMsKey],
+            let value = Double(raw.trimmingCharacters(in: .whitespaces))
+        else { return defaultPrefillDeadlineBaseMs }
+        return value
+    }()
+
+    /// Pure verdict: can a row of `promptTokens` reach first token inside its
+    /// own budget, given `queuedAheadTokens` of prefill still to run before it?
+    ///
+    /// Budget is `baseMs + 1 ms x promptTokens`. Separated from the bridge so
+    /// the arithmetic is testable without an engine.
+    /// Returns `nil` when the row fits or when the inputs cannot support a
+    /// verdict (non-positive rate or disabled gate) — never refuse on a guess.
+    static func prefillDeadlineProjection(
+        queuedAheadTokens: Int,
+        promptTokens: Int,
+        prefillTps: Double,
+        baseMs: Double
+    ) -> (projectedMs: Double, budgetMs: Double)? {
+        guard promptTokens > 0, prefillTps > 0, baseMs > 0 else { return nil }
+        let projectedMs = Double(max(0, queuedAheadTokens) + promptTokens) / prefillTps * 1000.0
+        let budgetMs = baseMs + Double(promptTokens)
+        guard projectedMs > budgetMs else { return nil }
+        return (projectedMs, budgetMs)
+    }
+
+    /// Prompt tokens still unprocessed on rows that have not reached first
+    /// token. Elapsed time at the measured rate discounts what each has already
+    /// consumed, so a nearly-drained queue does not refuse its successor.
+    func queuedPrefillTokensAhead(now: ContinuousClock.Instant, prefillTps: Double) -> Int {
+        guard prefillTps > 0 else { return 0 }
+        var queued = 0
+        for state in active.values where state.firstTokenAt == nil {
+            let elapsed = WedgeMonitor.seconds(now - state.submittedAt)
+            let consumed = elapsed > 0 ? Int((elapsed * prefillTps).rounded(.down)) : 0
+            queued += max(0, state.promptTokens - consumed)
+        }
+        return queued
+    }
+
+    /// Refusal message for a row that cannot land in time, `nil` when it can
+    /// (or when we cannot tell).
+    func prefillDeadlineRefusal(promptTokens: Int) -> String? {
+        // Unmeasured rate: admit. The EWMA is cold-prefill-fed and starts at 0,
+        // so gating on a guess would refuse real traffic on a fresh process.
+        let tps = observedPrefillTpsEwma
+        guard tps > 0 else { return nil }
+        let queuedAhead = queuedPrefillTokensAhead(now: .now, prefillTps: tps)
+        guard let projection = Self.prefillDeadlineProjection(
+            queuedAheadTokens: queuedAhead,
+            promptTokens: promptTokens,
+            prefillTps: tps,
+            baseMs: Self.resolvedPrefillDeadlineBaseMs)
+        else { return nil }
+        return "token_budget_exhausted: request queue full, prefill deadline "
+            + "(projected \(Int(projection.projectedMs)) ms over budget "
+            + "\(Int(projection.budgetMs)) ms; \(queuedAhead) prompt tokens "
+            + "queued at \(Int(tps)) tok/s)"
     }
 
     // MARK: - Prefill sampling (observed_prefill_tps)

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge.swift
@@ -216,6 +216,11 @@ public actor EngineV2Bridge {
         var completionTokens: Int = 0
         var submittedAt: ContinuousClock.Instant
         var firstTokenAt: ContinuousClock.Instant?
+        /// No other row was still prefilling when this one was admitted, so
+        /// its submit→first-token window is its OWN prefill work rather than
+        /// time spent queued behind someone else. Only such rows may
+        /// calibrate `isolatedPrefillTpsEwma`.
+        let uncontendedAtSubmit: Bool
     }
 
     var active: [String: ActiveRequestState] = [:]
@@ -284,6 +289,24 @@ public actor EngineV2Bridge {
     /// the same plausibility bounds — see `recordPrefillSample`.
     var observedPrefillTpsEwma: Double = 0
     var prefillEwmaInitialized = false
+    /// Prefill rate measured with the queue wait EXCLUDED — fed only by rows
+    /// that found no other prefill in flight at submit, so the window is the
+    /// row's own service time.
+    ///
+    /// `observedPrefillTpsEwma` above is deliberately load-INCLUSIVE (its
+    /// window starts at admission, and the wire contract at
+    /// `protocol/messages.go:277` documents it that way), which makes it the
+    /// wrong denominator for a projection that adds an explicit queue term:
+    /// contention would be counted twice, inflating the estimate by ~(K+1)/2
+    /// at queue depth K and refusing rows that comfortably fit.
+    ///
+    /// This one is LOCAL ONLY. It is never reported on the wire, so no
+    /// coordinator or mixed-version-fleet compatibility surface is involved.
+    ///
+    /// Caveat: rows already in DECODE still share engine steps, so this is a
+    /// conservative approximation of a truly isolated rate, not a guarantee.
+    var isolatedPrefillTpsEwma: Double = 0
+    var isolatedPrefillEwmaInitialized = false
     /// Cold-start model load time (ms) for this slot, recorded by
     /// `ProviderLoop.ensureModelLoaded` once the load completes (the
     /// bridge exists before the load finishes, so this arrives post-init).
@@ -758,10 +781,14 @@ public actor EngineV2Bridge {
             return stream
         }
 
+        // Evaluated BEFORE this row joins `active`, so it describes the
+        // engine this row is entering, not one that already contains it.
+        let uncontendedAtSubmit = !active.values.contains { $0.firstTokenAt == nil }
         active[id] = ActiveRequestState(
             promptTokens: promptTokens.count,
             maxTokens: cbv2Request.maxTokens,
-            submittedAt: .now
+            submittedAt: .now,
+            uncontendedAtSubmit: uncontendedAtSubmit
         )
         idMap[id] = cbv2Id
         // Wedge instrumentation: the request is now in the engine's hands.
@@ -1381,7 +1408,8 @@ public actor EngineV2Bridge {
                 promptTokens: prompt,
                 usage: usage,
                 submittedAt: state.submittedAt,
-                firstTokenAt: state.firstTokenAt)
+                firstTokenAt: state.firstTokenAt,
+                uncontendedAtSubmit: state.uncontendedAtSubmit)
         }
         return (prompt, completion, tps)
     }
@@ -1442,9 +1470,14 @@ public actor EngineV2Bridge {
     /// Refusal message for a row that cannot land in time, `nil` when it can
     /// (or when we cannot tell).
     func prefillDeadlineRefusal(promptTokens: Int) -> String? {
-        // Unmeasured rate: admit. The EWMA is cold-prefill-fed and starts at 0,
-        // so gating on a guess would refuse real traffic on a fresh process.
-        let tps = observedPrefillTpsEwma
+        // Queue-EXCLUDED rate: the projection adds `queuedAhead` explicitly,
+        // so dividing by the load-inclusive `observedPrefillTpsEwma` would
+        // count contention twice (~(K+1)/2 overestimate at depth K) and refuse
+        // rows that fit. Unmeasured: admit — this EWMA is cold-prefill-fed AND
+        // uncontended-fed, so it starts at 0 and stays 0 on a box that has
+        // never seen an idle prefill. Gating on a guess would refuse real
+        // traffic on a fresh process.
+        let tps = isolatedPrefillTpsEwma
         guard tps > 0 else { return nil }
         let queuedAhead = queuedPrefillTokensAhead(now: .now, prefillTps: tps)
         guard let projection = Self.prefillDeadlineProjection(
@@ -1498,7 +1531,8 @@ public actor EngineV2Bridge {
         promptTokens: Int,
         usage: CBv2Usage,
         submittedAt: ContinuousClock.Instant,
-        firstTokenAt: ContinuousClock.Instant?
+        firstTokenAt: ContinuousClock.Instant?,
+        uncontendedAtSubmit: Bool
     ) {
         guard Self.isColdPrefillSample(usage: usage) else { return }
         guard let firstTokenAt else { return }
@@ -1513,6 +1547,15 @@ public actor EngineV2Bridge {
         } else {
             observedPrefillTpsEwma = tps
             prefillEwmaInitialized = true
+        }
+        // Queue-excluded companion: same sample, but only when nothing was
+        // prefilling ahead of this row. Drives the admission projection.
+        guard uncontendedAtSubmit else { return }
+        if isolatedPrefillEwmaInitialized {
+            isolatedPrefillTpsEwma = alpha * tps + (1 - alpha) * isolatedPrefillTpsEwma
+        } else {
+            isolatedPrefillTpsEwma = tps
+            isolatedPrefillEwmaInitialized = true
         }
     }
 

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Factory+Production.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Factory+Production.swift
@@ -117,6 +117,34 @@ extension EngineV2Factory {
     /// and the measured winner with trust + prompt narrowing.
     public static let defaultSoloPrefillStripeTokens = 2048
 
+    /// Env override for the concurrent-partial-prefill cap.
+    public static let maxPartialPrefillsKey = "DARKBLOOM_CBV2_MAX_PARTIAL_PREFILLS"
+
+    /// Serving default for the concurrent-partial-prefill cap.
+    ///
+    /// Unlimited partial prefills interleave every prompt at `prefillChunkSize`,
+    /// which is fair and mean-TTFT-pessimal: a burst of N prompts all finish at
+    /// the makespan instead of one after another, so they cross the consumer's
+    /// TTFT deadline together rather than most of them landing. Measured at 4x8K:
+    /// every row 24.98 s, against 6.2 s for the same prompt served alone.
+    /// Serialising prefill costs nothing in aggregate throughput (rows already run
+    /// as separate forwards) and additionally re-arms the solo stripe, which can
+    /// only engage when at most one prefill is in flight.
+    public static let defaultMaxConcurrentPartialPrefills = 1
+
+    /// Resolve the cap: absent env -> the serving default; an explicit positive
+    /// value overrides; any other explicit value (`0`, garbage) restores the
+    /// unlimited pre-fix behaviour as the A/B control and incident escape.
+    public static func maxConcurrentPartialPrefills(
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> Int? {
+        guard let raw = environment[maxPartialPrefillsKey] else {
+            return defaultMaxConcurrentPartialPrefills
+        }
+        guard let value = Int(raw), value > 0 else { return nil }
+        return value
+    }
+
     /// Resolve the solo-stripe setting: absent env -> the serving default;
     /// an explicit value above the plain chunk overrides; any other
     /// explicit value (`0`, garbage, <= plain chunk) DISARMS — the escape
@@ -820,8 +848,7 @@ extension EngineV2Factory {
             abovePlainChunk: schedulerConfig.prefillChunkSize,
             environment: environment)
         schedulerConfig.maxConcurrentPartialPrefills =
-            environment["DARKBLOOM_CBV2_MAX_PARTIAL_PREFILLS"].flatMap(Int.init)
-            .flatMap { $0 > 0 ? $0 : nil }
+            Self.maxConcurrentPartialPrefills(environment: environment)
 
         func contiguousPreparation() throws -> ProductionBackendPreparation {
             let backend = CBv2ContiguousKVBackend(

--- a/provider-swift/Tests/ProviderCoreTests/EngineV2PrefillSamplingTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/EngineV2PrefillSamplingTests.swift
@@ -209,3 +209,113 @@ struct EngineV2PrefillSamplingTests {
         #expect(await bridge.backendSlotCapacity().observedPrefillTps == 0)
     }
 }
+
+// MARK: - Queue-excluded companion EWMA
+
+/// `observedPrefillTpsEwma` above is load-INCLUSIVE by contract (window starts
+/// at admission; `protocol/messages.go:277`). The prefill-deadline gate adds an
+/// explicit queued-tokens term, so dividing by that rate counts contention
+/// twice. `isolatedPrefillTpsEwma` is the queue-excluded companion the gate
+/// divides by: same samples, but only from rows that were admitted with no
+/// other prefill in flight.
+@Suite("EngineV2 isolated prefill EWMA (queue-excluded)")
+struct EngineV2IsolatedPrefillSamplingTests {
+
+    private func makeBridge(_ engine: PrefillScriptEngine) -> EngineV2Bridge {
+        EngineV2Bridge(
+            engine: engine,
+            modelId: "gpt-oss-20b",
+            tokenizer: TokenizerHandle(PrefillStubTokenizer()),
+            eosTokenIds: [])
+    }
+
+    private func submit(
+        _ bridge: EngineV2Bridge, _ id: String
+    ) async -> Task<Void, Never> {
+        let stream = await bridge.submitTokenized(
+            promptTokens: Array(repeating: 7, count: 200),
+            request: ChatCompletionRequest(
+                model: "gpt-oss-20b",
+                messages: [ChatMessage(role: "user", content: "hi")]),
+            requestId: id)
+        return Task { for await _ in stream {} }
+    }
+
+    private func finish(_ continuation: AsyncStream<CBv2Event>.Continuation) {
+        continuation.yield(.delta(text: "x", tokens: [11], logprobs: nil))
+        continuation.yield(.finished(
+            reason: .stop, usage: CBv2Usage(promptTokens: 200, completionTokens: 1)))
+        continuation.finish()
+    }
+
+    @Test("a row admitted onto an idle engine feeds both EWMAs")
+    func uncontendedRowFeedsIsolatedEwma() async throws {
+        let engine = PrefillScriptEngine()
+        let bridge = makeBridge(engine)
+        #expect(await bridge.isolatedPrefillTpsEwma == 0)
+
+        let consumer = await submit(bridge, "solo")
+        await bridge.backdateSubmissionForTesting(
+            requestId: "solo", byMilliseconds: 50)
+        finish(try #require(engine.continuations.first))
+        _ = await consumer.value
+
+        #expect(await bridge.observedPrefillTpsEwma > 0)
+        #expect(await bridge.isolatedPrefillTpsEwma > 0)
+    }
+
+    /// The discriminating case. `second` is admitted while `first` is still
+    /// prefilling, so its submit→first-token window is mostly queue wait. That
+    /// sample is fine for the load-inclusive signal and must NOT calibrate the
+    /// rate the deadline projection divides by — feeding it there is exactly
+    /// the double-count this companion exists to remove.
+    @Test("a row admitted behind an in-flight prefill feeds only the load-inclusive EWMA")
+    func contendedRowIsExcluded() async throws {
+        let engine = PrefillScriptEngine()
+        let bridge = makeBridge(engine)
+
+        let firstConsumer = await submit(bridge, "first")
+        // `first` has not reached its first token, so `second` is contended.
+        let secondConsumer = await submit(bridge, "second")
+        #expect(engine.continuations.count == 2)
+
+        await bridge.backdateSubmissionForTesting(
+            requestId: "second", byMilliseconds: 50)
+        finish(engine.continuations[1])
+        _ = await secondConsumer.value
+
+        #expect(await bridge.observedPrefillTpsEwma > 0)
+        #expect(
+            await bridge.isolatedPrefillTpsEwma == 0,
+            "a queued row must not calibrate the queue-excluded rate")
+
+        // ...and the predicate discriminates rather than being off entirely:
+        // `first` WAS admitted onto an idle engine, so it still qualifies.
+        await bridge.backdateSubmissionForTesting(
+            requestId: "first", byMilliseconds: 50)
+        finish(engine.continuations[0])
+        _ = await firstConsumer.value
+        #expect(await bridge.isolatedPrefillTpsEwma > 0)
+    }
+
+    /// Fail-open: a box that has never seen an idle prefill has no
+    /// queue-excluded rate, so the gate must admit rather than guess.
+    @Test("the gate fails open while the isolated EWMA is unmeasured")
+    func gateFailsOpenWhileUnmeasured() async throws {
+        let engine = PrefillScriptEngine()
+        let bridge = makeBridge(engine)
+        let firstConsumer = await submit(bridge, "first")
+        let secondConsumer = await submit(bridge, "second")
+        await bridge.backdateSubmissionForTesting(
+            requestId: "second", byMilliseconds: 50)
+        finish(engine.continuations[1])
+        _ = await secondConsumer.value
+
+        // Load-inclusive rate is measured, queue-excluded is not.
+        #expect(await bridge.observedPrefillTpsEwma > 0)
+        #expect(await bridge.prefillDeadlineRefusal(promptTokens: 8192) == nil)
+
+        finish(engine.continuations[0])
+        _ = await firstConsumer.value
+    }
+}

--- a/provider-swift/Tests/ProviderCoreTests/EngineV2PrefillSamplingTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/EngineV2PrefillSamplingTests.swift
@@ -319,3 +319,80 @@ struct EngineV2IsolatedPrefillSamplingTests {
         _ = await firstConsumer.value
     }
 }
+
+
+/// End-to-end proof of the PR's central claim, through the real bridge: a box
+/// that has measured its own uncontended prefill rate admits the rows that can
+/// land inside the TTFT budget and refuses the one that cannot, instead of
+/// accepting all four and timing them all out.
+///
+/// Admission is observed via `engine.continuations`: an admitted row reaches
+/// `engine.submit` and creates one, a refused row returns before it. Consuming
+/// an admitted row's stream would block — it has no terminal event yet.
+@Suite("EngineV2 prefill deadline: end-to-end burst admission")
+struct EngineV2PrefillBurstAdmissionTests {
+
+    // Measured Qwen 3.6 35B solo 8K prefill (trust + stripe),
+    // docs/reports/2026-08-19-solo-prefill-stripe-experiment.md.
+    private let tps = 1531.0
+    private let prompt = 8192
+
+    @Test("three 8K rows are admitted and the fourth is refused")
+    func burstAdmitsThreeRefusesFourth() async throws {
+        let engine = PrefillScriptEngine()
+        let bridge = EngineV2Bridge(
+            engine: engine,
+            modelId: "qwen3.6-35b-a3b-vl-mtp-mxfp8",
+            tokenizer: TokenizerHandle(PrefillStubTokenizer()),
+            eosTokenIds: [])
+
+        func submit(_ id: String) async -> AsyncStream<GenerationEvent> {
+            await bridge.submitTokenized(
+                promptTokens: Array(repeating: 7, count: prompt),
+                request: ChatCompletionRequest(
+                    model: "qwen3.6-35b-a3b-vl-mtp-mxfp8",
+                    messages: [ChatMessage(role: "user", content: "hi")]),
+                requestId: id)
+        }
+
+        // 1. Arm the queue-excluded EWMA with ONE uncontended row whose window
+        //    puts it at the measured rate: 8192 tokens / 5350 ms ~= 1531 tok/s.
+        let warm = await submit("warm")
+        let warmConsumer = Task { for await _ in warm {} }
+        await bridge.backdateSubmissionForTesting(
+            requestId: "warm", byMilliseconds: 5_350)
+        let c0 = try #require(engine.continuations.first)
+        c0.yield(.delta(text: "x", tokens: [11], logprobs: nil))
+        c0.yield(.finished(
+            reason: .stop, usage: CBv2Usage(promptTokens: prompt, completionTokens: 1)))
+        c0.finish()
+        _ = await warmConsumer.value
+
+        let measured = await bridge.isolatedPrefillTpsEwma
+        #expect(measured > 1_400 && measured < 1_700, "armed at \(measured) tok/s")
+
+        // 2. Four concurrent 8K rows arrive, none reaching first token. Under
+        //    FCFS each waits for every row ahead of it.
+        var refused: [Int] = []
+        var refusalMessages: [String] = []
+        for row in 0 ..< 4 {
+            let before = engine.continuations.count
+            let stream = await submit("burst-\(row)")
+            if engine.continuations.count == before {
+                refused.append(row)
+                // A refused stream terminates immediately, so this cannot block.
+                for await event in stream {
+                    if case .error(let message) = event { refusalMessages.append(message) }
+                }
+            }
+        }
+
+        // budget = 10,000 + 8,192 = 18,192 ms; at 1531 tok/s the 4th row
+        // projects 32,768 / 1531 = 21,403 ms and cannot land.
+        #expect(refused == [3], "expected only the fourth row refused, got \(refused)")
+        let message = try #require(refusalMessages.first)
+        #expect(message.contains("token_budget_exhausted"),
+                "refusal must keep the retryable contract: \(message)")
+        #expect(message.contains("queue full"))
+    }
+}

--- a/provider-swift/Tests/ProviderCoreTests/EngineV2ProductionWiringTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/EngineV2ProductionWiringTests.swift
@@ -2186,3 +2186,96 @@ struct EngineV2KVBackendFallbackHeartbeatTests {
         #expect(EngineV2Bridge.heartbeatFallbackReason(nil) == nil)
     }
 }
+
+@Suite("Prefill deadline admission + FCFS prefill serialization")
+struct PrefillDeadlineAdmissionTests {
+
+    // The consumer budget mirrored from the coordinator's verified SLA base:
+    // 10_000 ms + 1 ms x prompt_tokens.
+    private let baseMs = EngineV2Bridge.defaultPrefillDeadlineBaseMs
+    // Measured best-case solo prefill rate for Qwen 3.6 35B at 8K (trust+stripe).
+    private let tps = 1531.0
+    private let prompt8K = 8192
+
+    @Test("an 8K row on an idle box is admitted")
+    func idleBoxAdmits() {
+        #expect(
+            EngineV2Bridge.prefillDeadlineProjection(
+                queuedAheadTokens: 0, promptTokens: prompt8K,
+                prefillTps: tps, baseMs: baseMs) == nil)
+    }
+
+    @Test("8K rows are admitted while the queue can still land them in time")
+    func admitsWhileTheQueueFits() {
+        for rowsAhead in 0 ... 2 {
+            #expect(
+                EngineV2Bridge.prefillDeadlineProjection(
+                    queuedAheadTokens: rowsAhead * prompt8K, promptTokens: prompt8K,
+                    prefillTps: tps, baseMs: baseMs) == nil,
+                "row behind \(rowsAhead) x 8K should still fit its budget")
+        }
+    }
+
+    /// The row this whole change exists for: four concurrent 8K prompts need
+    /// 4 x 8192 / 18.2 s = ~1,800 tok/s aggregate and the box measures 1,531.
+    /// It can never land, so it must be refused here and re-dispatched rather
+    /// than accepted and timed out.
+    @Test("the fourth concurrent 8K row is refused, not accepted and missed")
+    func refusesTheRowThatCannotLand() throws {
+        let projection = try #require(
+            EngineV2Bridge.prefillDeadlineProjection(
+                queuedAheadTokens: 3 * prompt8K, promptTokens: prompt8K,
+                prefillTps: tps, baseMs: baseMs))
+        #expect(projection.projectedMs > projection.budgetMs)
+        #expect(projection.budgetMs == baseMs + Double(prompt8K))
+    }
+
+    /// Head-of-line protection: a short prompt has a SMALLER budget, so it is
+    /// refused behind a long queue even though its own prefill is trivial.
+    @Test("a short prompt stuck behind long ones is refused")
+    func refusesShortPromptBehindLongQueue() {
+        #expect(
+            EngineV2Bridge.prefillDeadlineProjection(
+                queuedAheadTokens: 3 * prompt8K, promptTokens: 512,
+                prefillTps: tps, baseMs: baseMs) != nil)
+        // ...and is admitted immediately on an idle box.
+        #expect(
+            EngineV2Bridge.prefillDeadlineProjection(
+                queuedAheadTokens: 0, promptTokens: 512,
+                prefillTps: tps, baseMs: baseMs) == nil)
+    }
+
+    @Test("the gate fails open when it cannot form a verdict")
+    func failsOpen() {
+        // Unmeasured prefill rate (fresh process: the EWMA starts at 0).
+        #expect(
+            EngineV2Bridge.prefillDeadlineProjection(
+                queuedAheadTokens: 3 * prompt8K, promptTokens: prompt8K,
+                prefillTps: 0, baseMs: baseMs) == nil)
+        // Kill switch: a non-positive base disables the gate.
+        #expect(
+            EngineV2Bridge.prefillDeadlineProjection(
+                queuedAheadTokens: 3 * prompt8K, promptTokens: prompt8K,
+                prefillTps: tps, baseMs: 0) == nil)
+        // Degenerate prompt.
+        #expect(
+            EngineV2Bridge.prefillDeadlineProjection(
+                queuedAheadTokens: 3 * prompt8K, promptTokens: 0,
+                prefillTps: tps, baseMs: baseMs) == nil)
+    }
+
+    @Test("prefill serialization is the serving default, with an env escape")
+    func fcfsIsTheDefault() {
+        #expect(EngineV2Factory.maxConcurrentPartialPrefills(environment: [:]) == 1)
+        #expect(
+            EngineV2Factory.maxConcurrentPartialPrefills(
+                environment: [EngineV2Factory.maxPartialPrefillsKey: "3"]) == 3)
+        // Non-positive / unparseable restores the unlimited interleave.
+        for escape in ["0", "-1", "off"] {
+            #expect(
+                EngineV2Factory.maxConcurrentPartialPrefills(
+                    environment: [EngineV2Factory.maxPartialPrefillsKey: escape]) == nil,
+                "\(escape) should restore the pre-fix unlimited interleave")
+        }
+    }
+}

--- a/provider-swift/Tests/ProviderCoreTests/EngineV2ProductionWiringTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/EngineV2ProductionWiringTests.swift
@@ -2279,3 +2279,99 @@ struct PrefillDeadlineAdmissionTests {
         }
     }
 }
+
+/// The projection adds an explicit `queuedAheadTokens` term, so it is only
+/// correct when divided by a QUEUE-EXCLUDED rate. `observedPrefillTpsEwma` is
+/// load-inclusive by contract (window = admission→first token;
+/// `protocol/messages.go:277`), and feeding it here counted contention twice.
+@Suite("Prefill deadline projection uses a queue-excluded rate")
+struct PrefillDeadlineRateSemanticsTests {
+
+    private let baseMs = EngineV2Bridge.defaultPrefillDeadlineBaseMs
+    /// Rate with the queue wait excluded — one row's own prefill work.
+    private let isolatedTps = 1200.0
+    private let prompt = 2000
+
+    /// Ground truth under FCFS prefill: a row behind `rowsAhead` peers of the
+    /// same size reaches first token after all of them plus itself.
+    private func trueTtftMs(rowsAhead: Int) -> Double {
+        Double((rowsAhead + 1) * prompt) / isolatedTps * 1000.0
+    }
+
+    /// The load-inclusive EWMA a box settles on while running at depth K: its
+    /// samples' windows already contain the queue wait.
+    private func loadInclusiveTps(rowsAhead: Int) -> Double {
+        2.0 * isolatedTps / Double(rowsAhead + 1)
+    }
+
+    @Test("fed a queue-excluded rate, the projection reproduces true TTFT")
+    func projectionMatchesTruth() throws {
+        for rowsAhead in 1 ... 7 {
+            let projection = EngineV2Bridge.prefillDeadlineProjection(
+                queuedAheadTokens: rowsAhead * prompt, promptTokens: prompt,
+                prefillTps: isolatedTps, baseMs: baseMs)
+            let expected = trueTtftMs(rowsAhead: rowsAhead)
+            // `nil` means "fits", i.e. the projection was <= budget.
+            let projected = projection?.projectedMs ?? expected
+            #expect(
+                abs(projected - expected) < 0.5,
+                "depth \(rowsAhead): projected \(projected) ms vs true \(expected) ms")
+        }
+    }
+
+    /// Regression: this is the defect. At depth 3 the row reaches first token
+    /// in 6,667 ms against a 12,000 ms budget — 56% of budget, comfortably
+    /// servable — yet the load-inclusive rate projected 13,333 ms and refused
+    /// it. Refusing a servable row is the `could_have_served` over-shed the
+    /// gate exists to avoid.
+    @Test("a row at 56% of budget is admitted at queue depth 3")
+    func admitsTheServableRowThatUsedToBeRefused() {
+        let rowsAhead = 3
+        let budgetMs = baseMs + Double(prompt)
+        #expect(trueTtftMs(rowsAhead: rowsAhead) < budgetMs)
+
+        #expect(
+            EngineV2Bridge.prefillDeadlineProjection(
+                queuedAheadTokens: rowsAhead * prompt, promptTokens: prompt,
+                prefillTps: isolatedTps, baseMs: baseMs) == nil,
+            "a row that lands at 56% of budget must be admitted")
+
+        // The pre-fix denominator refused exactly this row.
+        #expect(
+            EngineV2Bridge.prefillDeadlineProjection(
+                queuedAheadTokens: rowsAhead * prompt, promptTokens: prompt,
+                prefillTps: loadInclusiveTps(rowsAhead: rowsAhead), baseMs: baseMs) != nil,
+            "pins the regression: the load-inclusive rate refuses a servable row")
+    }
+
+    /// The error is not a constant offset — it grows with queue depth, so a
+    /// tuned base constant could never have absorbed it.
+    @Test("a load-inclusive rate inflates the projection by (K+1)/2")
+    func doubleCountScalesWithDepth() throws {
+        for rowsAhead in 3 ... 7 {
+            let inflated = try #require(
+                EngineV2Bridge.prefillDeadlineProjection(
+                    queuedAheadTokens: rowsAhead * prompt, promptTokens: prompt,
+                    prefillTps: loadInclusiveTps(rowsAhead: rowsAhead), baseMs: baseMs))
+            let ratio = inflated.projectedMs / trueTtftMs(rowsAhead: rowsAhead)
+            let expected = Double(rowsAhead + 1) / 2.0
+            #expect(
+                abs(ratio - expected) < 0.01,
+                "depth \(rowsAhead): inflation \(ratio)x, expected \(expected)x")
+        }
+    }
+
+    /// The genuinely-missing row must still be refused after the fix — the
+    /// change must not turn the gate off.
+    @Test("a row that truly cannot land is still refused")
+    func stillRefusesTheRowThatCannotLand() throws {
+        let rowsAhead = 7
+        let budgetMs = baseMs + Double(prompt)
+        #expect(trueTtftMs(rowsAhead: rowsAhead) > budgetMs)
+        let projection = try #require(
+            EngineV2Bridge.prefillDeadlineProjection(
+                queuedAheadTokens: rowsAhead * prompt, promptTokens: prompt,
+                prefillTps: isolatedTps, baseMs: baseMs))
+        #expect(projection.projectedMs > projection.budgetMs)
+    }
+}


### PR DESCRIPTION
## Summary

OpenRouter timeouts on Qwen 3.6 35B are being scored as 10-11% downtime. Three changes across the
two layers that produce them, none of which makes prefill faster:

1. **Coordinator** — routing cost priced the dominant prefill term from the STATIC rate, so the
   measured prefill EWMA could not influence provider selection at all.
2. **Provider** — concurrent prefills advance in lockstep, so every row in a burst finishes at the
   makespan and *none* land inside the deadline. Serialise them (FCFS).
3. **Provider** — refuse at submit any row that still cannot reach first token in time, so the
   coordinator re-dispatches it instead of the request timing out here.

Together these convert timeouts into either a served request or a re-dispatch. **Uptime accounting
is why that matters:** `docs/operations/coordinator-deploy.md:422-435` scores
`success / (success + error-0 + 5xx)` and **excludes 429/422/400**. A timeout counts against you; a
refusal does not.

## Linked issue

None open. Raised by Gajesh in Slack: OpenRouter timeouts on Qwen 3.6 35B marked as 10-11% downtime.

## Before / after

### 1. Coordinator: routing prices prefill statically

```mermaid
flowchart TB
  subgraph Before["Before: cost prices prefill statically"]
    direction TB
    R1["request, 4k prompt"] --> C1["routing cost = state + queue + pending + backlog + thisReqMs + health"]
    C1 --> P1["thisReqMs uses snap.prefillTPS<br/>static: registration benchmark, else decode x12"]
    P1 --> S1["A: static 1200, measured 120 (degraded under load)<br/>B: static 1200, measured 1200"]
    S1 --> W1["both priced identically, A selectable"]
    W1 --> T1["selected A: TTFTMs 20010<br/>BestTTFTMs 2010"]
    T1 --> D1["cost ranked on the STATIC rate,<br/>ceiling judges on the MEASURED one<br/>selection and admission disagree"]
  end
  subgraph After["After: cost prices prefill with the measured rate"]
    direction TB
    R2["request, 4k prompt"] --> C2["routing cost, same terms"]
    C2 --> P2["prefillTPS = resolvePrefillTPS(snap)<br/>observed EWMA when reported, else static chain"]
    P2 --> S2["A prices 10x more expensive than B"]
    S2 --> W2["selected B"]
    W2 --> T2["TTFT 3343ms, inside the 14000ms SLA for this prompt"]
  end
  Before ~~~ After
```

### 2. Provider: concurrent prefills all miss together

```mermaid
flowchart TB
  subgraph Before["Before: 4 concurrent 8K prompts, budget 18,192 ms each"]
    direction TB
    A1["4 rows arrive"] --> B1["maxConcurrentPartialPrefills = nil<br/>fair 512-token interleave"]
    B1 --> C1["all 4 rows advance together"]
    C1 --> D1["every row finishes at the makespan<br/>21,403 ms each"]
    D1 --> E1["0 of 4 land, 4 time out<br/>OpenRouter counts downtime"]
  end
  subgraph After["After: serialise, then refuse what still cannot land"]
    direction TB
    A2["4 rows arrive"] --> B2["maxConcurrentPartialPrefills = 1<br/>FCFS, solo stripe re-arms"]
    B2 --> G2{"projected TTFT vs<br/>10,000 ms + 1 ms x prompt"}
    G2 -->|"rows 1-3 fit"| C2["served here<br/>5,351 / 10,702 / 16,052 ms"]
    G2 -->|"row 4 cannot"| R2["refused at submit, 429 transient"]
    R2 --> S2["coordinator re-dispatches<br/>fleet is ~53% idle"]
    C2 --> E2["0 time out"]
    S2 --> E2
  end
  Before ~~~ After
```

### Code

```mermaid
flowchart TB
  subgraph CodeBefore["Before: buildCandidateWithReason"]
    direction TB
    A1["thisReqMs := reqPrompt / snap.prefillTPS"] --> A2["STATIC only"]
    B1["prefillMs := reqPrompt / resolvePrefillTPS(snap)"] --> B2["measured-preferred"]
    B2 --> B3["longPromptPenalty(...)"]
    B3 --> B4["returns 0 when threshold <= 0<br/>DEFAULT is 0, so this path is inert"]
    A2 --> OUT1["cost ranking sees static prefill only"]
    B4 --> OUT1
  end
  subgraph CodeAfter["After: buildCandidateWithReason"]
    direction TB
    X1["prefillTPS := resolvePrefillTPS(snap)"] --> X2["thisReqMs uses prefillTPS"]
    X1 --> X3["prefillMs uses prefillTPS"]
    X2 --> OUT2["cost ranking follows measured prefill<br/>even with the long-prompt bias off"]
    X3 --> OUT2
  end
  CodeBefore ~~~ CodeAfter
```

```mermaid
flowchart TB
  subgraph CodeBefore["Before"]
    direction TB
    X1["EngineV2Factory+Production:822<br/>maxConcurrentPartialPrefills = env only"] --> Y1["nil in production, nothing sets the env"]
    Z1["EngineV2Bridge.submitTokenized"] --> W1["duplicate guard, then admit"]
    V1["observedPrefillTpsEwma<br/>load-INCLUSIVE (admission to first token)"] --> U1["only consumer is the wire payload"]
  end
  subgraph CodeAfter["After"]
    direction TB
    X2["EngineV2Factory.maxConcurrentPartialPrefills(environment:)"] --> Y2["default 1, env overrides, 0 restores unlimited"]
    Z2["EngineV2Bridge.submitTokenized"] --> P1["prefillDeadlineRefusal(promptTokens:)"]
    P1 --> P0["isolatedPrefillTpsEwma<br/>queue-EXCLUDED: fed only by rows<br/>admitted with no prefill in flight"]
    P0 --> P2["queuedPrefillTokensAhead x elapsed discount"]
    P2 --> P3["prefillDeadlineProjection (pure, unit-tested)"]
    P3 -->|"fits, or rate unmeasured"| W2["admit"]
    P3 -->|"over budget"| R3["yield token_budget_exhausted: request queue full"]
  end
  CodeBefore ~~~ CodeAfter
```

## Defect A — the measured prefill rate never reached provider selection

`registry/scheduler.go:1582` divided the dominant prefill term by the static `snap.prefillTPS`,
while the adjacent long-prompt term at `:1597` deliberately used `resolvePrefillTPS` (the measured
EWMA when a slot reports one). `resolvePrefillTPS` reaches routing through exactly two paths:

- `ttftMsFromSnapshot` feeds the per-request TTFT ceiling. That ceiling **is** enforced in
  production: `deploy/environments/prod.env:87` sets `EIGENINFERENCE_TTFT_HARD_REJECT=true` (base
  9000 ms at `:88`), and self-route is header/key driven (`api/self_route.go:51-66`) so it is
  zero-valued for OpenRouter traffic — `queueMaxTTFTMs` (`api/dispatch.go:305-314`) therefore
  returns the deadline and candidates **are** dropped at `registry/scheduler.go:760-763`. So the
  ceiling was already judging on the measured rate while the cost ranked on the static one:
  selection and admission used two different models of the same provider.
  (`prod.env:1-5` self-describes as a sanitized reference; `/etc/d-inference/env` is authoritative,
  so worth confirming on the VM.)
- The long-prompt bias at `:1601` does use the measured rate, but `longPromptPenalty` returns 0
  when `longPromptThresholdTokens <= 0`, and `defaultLongPromptThresholdTokens` is **0** (`:1886`).

Sweep over prompt sizes 500-16000 and measured/static ratios 0.1-1.0, two otherwise identical
providers, long-prompt bias at its default (off):

| | result |
|---|---|
| scenarios where selection changes | **36 / 36** |
| pre-fix picks breaching the ~10s SLA base while a compliant provider was available | **10 / 36 (28%)** |
| worst pre-fix pick | **133,343 ms vs 13,343 ms available (10.0x)** |

Pre-fix the selected candidate carries `TTFTMs: 20010` against `BestTTFTMs: 2010`.

**Scope:** this removes the misroute class only — where a compliant provider existed and the router
did not pick it. It does not help when the whole fleet is slow.

## Defect B — a burst of prefills all miss together

Prefill throughput is not the binding constraint. A solo 8K prompt is ~5.4 s against an ~18.2 s
budget (`registry/ttft_shadow.go:69-73`, `10000 + 1 ms x prompt_tokens`). Four concurrent 8K
prompts are ~25 s **each**, because the fair 512-token interleave advances all rows together and
every one finishes at the makespan.

Against `docs/reports/2026-08-19-solo-prefill-stripe-experiment.md`:

| case | TTFT | vs budget |
|---|---|---|
| solo 8K (`:91-111`, trust + stripe) | 5,350 ms | lands, 3x headroom |
| 4x8K concurrent (`:113-128`) | 24,980 ms each | all four miss |

This is roadmap item 3 from that report (`:153-154`, "cap concurrent partial prefills (FCFS-lean)
— mean TTFT ~halves"). The mechanism already exists as opt-in
`DARKBLOOM_CBV2_MAX_PARTIAL_PREFILLS=1`, shipped in **#646** (`CHANGELOG.md:51`); this defaults it
on and adds the admission half that closes the row FCFS alone still cannot save.

## What changed

- **`registry/scheduler.go`** — hoist `resolvePrefillTPS(snap)` into a local and use it for both
  the base cost term and the long-prompt bias. Behaviour is unchanged for any slot that does not
  report `observed_prefill_tps`: the resolver falls back to `snap.prefillTPS` exactly as before.
- **`EngineV2Factory+Production.swift`** — `maxConcurrentPartialPrefills` now defaults to `1`
  through a resolver mirroring the existing `soloPrefillStripeTokens` one at `:113-132`.
  `DARKBLOOM_CBV2_MAX_PARTIAL_PREFILLS` still overrides and `0`/unparseable restores the previous
  unlimited interleave as the A/B control. This also re-arms the solo stripe under concurrency
  (`SchedulerV2.swift:301-315`), which today disarms as soon as a second request is in flight.
- **`EngineV2Bridge.swift`** — a deadline check at submit, before any reservation, reusing the
  existing `token_budget_exhausted:` contract. Split into a pure
  `prefillDeadlineProjection(queuedAheadTokens:promptTokens:prefillTps:baseMs:)` plus a queue scan
  that discounts elapsed time. **Fails open** when the rate is unmeasured, and
  `DARKBLOOM_PREFILL_DEADLINE_BASE_MS=0` disables it entirely.
- **`EngineV2Bridge.swift`** (2nd commit) — `isolatedPrefillTpsEwma`, a queue-excluded companion to
  `observedPrefillTpsEwma`, fed by the same samples but only from rows admitted with no other
  prefill in flight. The projection divides by this one. **Local to the bridge** — the wire payload
  still reports the load-inclusive `observed_prefill_tps` unchanged, so there is no protocol change
  and nothing to coordinate across a mixed-version fleet.

## Test plan

- [x] `go test ./registry/ -run TestRoutingCostPrefersObservedOverStaticPrefill -count=1` passes,
      and **fails without the fix**, selecting `static-fast-observed-slow`. It pins
      `SetLongPromptThreshold(0)` — the documented default — so it exercises the base cost term
      alone; the neighbouring `TestLongPromptPrefersObservedOverStaticPrefill` sets a positive
      threshold and only ever covered the bias path.
- [x] 6 tests for the admission gate: idle-box admit, admits while the queue still fits, the
      fourth-row refusal, head-of-line protection for a short prompt behind long ones, all three
      fail-open paths, and the FCFS default plus its env escapes.
- [x] 7 tests for the rate semantics. 4 pure-arithmetic: a queue-excluded rate makes the projection
      reproduce true TTFT exactly; a row at 56% of budget is admitted at depth 3; the load-inclusive
      inflation is (K+1)/2 so no base constant could have absorbed it; a genuinely-missing row is
      still refused. 3 behavioural, driving the real actor: an idle-admitted row feeds both EWMAs,
      a row admitted behind an in-flight prefill feeds only the load-inclusive one, and the gate
      fails open while the queue-excluded rate is unmeasured.
- [x] **18/18 pass** across the prefill sampling + deadline suites.
- [x] End-to-end simulation against the **real `SchedulerV2`** (public `enqueue`/`plan`, no mock),
      4 x 8192 concurrent, converted to wall clock at the measured 1,531 tok/s:

```
BEFORE (maxConcurrentPartialPrefills = nil)
  rows finish at step 15 each -> TTFT 21,403 ms   budget 18,192 ms   0/4 land

AFTER (maxConcurrentPartialPrefills = 1)
  row 0  step  3   TTFT  5,351 ms   LANDS
  row 1  step  7   TTFT 10,702 ms   LANDS
  row 2  step 11   TTFT 16,052 ms   LANDS
  row 3  step 15   TTFT 21,403 ms   TIMES OUT

COMPOSED (with the admission gate)
  rows 0-2 admitted and land; row 3 refused at submit -> re-dispatched
  0 timed out
```

  Total prefill tokens are identical in both arms (32,768) — **aggregate throughput is unchanged**,
  which was the pass/fail condition for the serialisation half.

### Not done

**The real-model benchmark has not been run.** `darkbloom benchmark --scheduler-prefill` at 4 x 8K
needs the 35B weights and this machine is a 16 GB M1 Pro — the model cannot load. The simulation
drives the real scheduler and the arithmetic is against your measured numbers, but the end-to-end
wall-clock claim is unverified on hardware. Worth replicating plugged in: Low Power Mode is a
documented ~2x prefill regression that already voided one measurement round (`2026-08-19-...:39-58`).

### Pre-existing failures (verified, not caused by this change)

Measured by diffing the failing-test SET against a `HEAD` baseline rather than counting failures:
**17 failures under an `EngineV2|PrefillDeadline` filter, byte-identical with and without this
change**, all GPU-memory limits on a 16 GB box ("safe pool 0 B is below the 1048576 B serviceability
floor"). Separately:

- `slotBuildAlwaysBuildsRegistersAndStreams` fails with `Fatal error: Index out of range` and takes
  the whole test process down with signal 5. Identical at `080d7e66`, i.e. before this branch, so
  `swift test` needs `--skip` for it. Worth a look independently of this PR.
- `TestSupervisorRestartsChildAndBecomesReady` (`coordinator/promptcontract`) fails on a startup
  deadline. This branch does not touch that package.

## Components touched

- [x] coordinator (Go)
- [ ] provider (Rust, legacy)
- [x] provider-swift (Swift CLI)
- [ ] console-ui (Next.js)
- [ ] enclave (Swift)
- [ ] infra / CI / release
- [ ] docs

## Protocol / interface changes

- [x] No protocol/interface changes

The refusal reuses the existing `token_budget_exhausted:` string contract that
`MultiModelBatchSchedulerEngineError.fromSchedulerMessage` already classifies
(`MultiModelBatchSchedulerEngineError.swift:150-151`, `contains("queue full")` -> `.queueFull` ->
429 + Retry-After). `observed_prefill_tps` keeps its documented load-inclusive semantics
(`protocol/messages.go:277`).

## Notes for reviewers

- **Correction (2nd commit).** The first version of this PR double-counted queue wait, and the note
  that used to sit here claimed it did not. `observed_prefill_tps` is `firstToken - submit`, so it
  already contains queue wait. The projection then added `queuedPrefillTokensAhead` on top and
  divided by that same deflated rate, inflating the estimate by **(K+1)/2 at queue depth K**. At
  depth 3 it projected 13,333 ms for a row that lands in 6,667 ms against a 12,000 ms budget and
  refused it. Fixed by dividing by a queue-excluded rate.
- **This changes provider selection** whenever a slot's measured prefill differs from its static
  rate. That is the intent, and it matches what the long-prompt comment at `:1594-1600` already
  says ranking should do. If pinning the base term to the static rate was deliberate, say so and I
  will drop that commit.
- **This changes admission behaviour**, so a busy provider now refuses work it previously accepted.
  The message carries the projected and budget figures, so a provider refusing a large share of
  traffic is visible as mis-sized rather than protective.
- **A refusal gets three re-dispatch attempts, not unlimited.** `maxCapacityClassRetries = 3`
  (`api/consumer.go:88`) bounds the capacity-class ladder; after three the dispatch exhausts and the
  request errors. So this converts a timeout into a success only while a willing provider is found
  within three tries. `docs/reports/2026-07-25-prefill-and-fleet-performance-findings.md:99-106`
  records ~50% of machines serving nothing as a standing condition (52.9 / 52.9 / 55.4 / 64.1% over
  four days), and `/v1/models/capacity` currently shows Qwen at 137 routable / 91 warm / 36 active /
  **0 queued** — so that holds today. Under a fleet-wide saturation it would not, and the failure
  mode changes from slow-and-timing-out to fast-and-erroring.
- Admission latency for a request arriving mid-prefill rises to ~1.3-1.4 s worst case at 8K rates
  versus ~0.4 s today (`2026-08-19-...:141-146`). Deliberate trade for mean TTFT.
- **`registry/scheduler.go:1728-1729` looks stale.** It says `observedPrefillTPS stays 0 until
  providers ship the W1 measurement, so on today's fleet this is a no-op`. That is from 2026-06-16
  (#383); the provider shipped it 2026-07-09 in #522 and sends it at
  `EngineV2Bridge+Capacity.swift:188`. Left alone to keep the diff tight — worth confirming against
  live telemetry that slots report non-zero, since `Types.swift:663` uses `encodeIfNonZero` and the
  EWMA only takes cold-prefill samples.
- **On the #646 point:** change 2 is a default flip of the feature you already shipped, not a new
  one. You mentioned finding an issue with it — I went through the three cap sites
  (`SchedulerV2.swift:305, 431, 612`) and could not spot it, and my evidence is a simulation driving
  the planner, so anything downstream of that (real kernels, paused-row accounting, hardware) is
  outside what I tested. If you can point me at the issue I would rather fix it here than have you
  spend review time on a broken premise.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/681"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790051157&installation_model_id=21733&pr_number=681&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F681&signature=bec42c804fee861a175ca85ed61cd28b2d5036dbcfec532afdb3dd9afba6ba79"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
