### PR TITLE
Resolve the activation reserve per serving set (measured per-model floors) — fixes the unserveable 24 GB tier

### DIFF
--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -104,7 +104,7 @@ type routingSnapshot struct {
 	// binaryVersion is the provider's reported binary version (p.Version, read
 	// under p.mu at snapshot time; empty = unreported/legacy). Feeds the
 	// version-gated activation-reserve selection in the cold servability
-	// estimate (servabilityActivationFloorForVersion) so a mixed-version fleet
+	// estimate (servabilityActivationFloor) so a mixed-version fleet
 	// is charged the reserve each binary actually holds.
 	binaryVersion    string
 	slotState        string

--- a/coordinator/registry/servability.go
+++ b/coordinator/registry/servability.go
@@ -44,11 +44,12 @@ const (
 	// servabilityCapFraction mirrors the provider's UnifiedMemoryCap default
 	// (90% of physical memory usable for MLX).
 	servabilityCapFraction = 0.90
-	// servabilityActivationFloorGB mirrors the provider's activation reserve
-	// (UnifiedMemoryCap.defaultActivationReserveBytes, 5.5 GiB): the working
-	// set held back on top of weights before any KV cache. It is FLAT on the
-	// provider — every model, every attention posture, every batch — so it is
-	// flat here. It does not scale with anything.
+	// servabilityActivationFloorGB mirrors the provider's DEFAULT activation
+	// reserve (UnifiedMemoryCap.defaultActivationReserveBytes, 5.5 GiB): the
+	// working set held back on top of weights before any KV cache. On
+	// pre-per-model binaries it is FLAT — every model, every attention
+	// posture, every batch; on per-model binaries it is the fallback for
+	// models without a measured floor (servabilityModelActivationFloorsGB).
 	//
 	// 5.5 as of v0.8.0, moved in the SAME commit as the provider constant:
 	// the release ships decode batch 8 and the measured gemma-4 B=8
@@ -63,8 +64,11 @@ const (
 	// removed: the provider half it claimed to mirror was never wired, so the
 	// coordinator was charging for a reserve no provider ever held. See
 	// coldTokenBudgetEstimate's "Mirroring, not modelling" note before adding
-	// any term here. Moving the FLAT floor — what this change does — is the
-	// sanctioned shape; re-adding a model-dependent term is not.
+	// any term here. That note still governs: the per-model floors below are
+	// NOT a second opinion about prefill memory — they mirror the measured
+	// floors the provider's own UnifiedMemoryCap now holds, exactly as this
+	// flat constant mirrors its default. A term the provider does not hold
+	// remains unsanctioned.
 	servabilityActivationFloorGB = 5.5
 	// servabilityLegacyActivationFloorGB is the reserve a pre-0.8.0 provider
 	// actually holds (the old defaultActivationReserveBytes). During the
@@ -72,20 +76,54 @@ const (
 	// provider the reserve ITS binary holds — a flat 5.5 against a cold
 	// legacy box falsely 429s (prompt_too_long, terminal) a request sized
 	// between the two reserves that the legacy fleet could serve. See
-	// servabilityActivationFloorForVersion.
+	// servabilityActivationFloor.
 	servabilityLegacyActivationFloorGB = 3.0
 	// servabilityActivationFloorMinVersion is the first provider release
 	// whose UnifiedMemoryCap holds the 5.5 GiB reserve.
 	servabilityActivationFloorMinVersion = "0.8.0"
+	// servabilityPerModelFloorMinVersion is the first provider release whose
+	// UnifiedMemoryCap resolves the activation reserve from its serving set
+	// via the measured per-model floor table. PLACEHOLDER pending release:
+	// set to the version that ships the provider half of this change (the
+	// same commit — see servabilityModelActivationFloorsGB).
+	servabilityPerModelFloorMinVersion = "0.8.11"
 )
 
-// servabilityActivationFloorForVersion selects the activation reserve the
-// given provider binary actually holds. This is the same version-gated
-// selection shape as slotBudgetLayoutForVersion: the registry snapshot carries
-// the provider's reported binary version (p.Version → snap.binaryVersion), so
-// the cold estimate can mirror the right constant per provider — which is
-// what makes it converge to that provider's own warm report as the slot loads
-// (a legacy provider's active_token_budget_max reflects its 3 GiB reserve).
+// servabilityModelActivationFloorsGB mirrors the provider's measured
+// per-model activation floors (UnifiedMemoryCap.measuredActivationFloorsBytes);
+// the two tables MUST move in the same commit. Keys are catalog model ids,
+// EXACT match only — a hot-swapped build id ("gpt-oss-20b--r2"-style) misses
+// the table on BOTH sides in lockstep (no desync; the tier reverts to the
+// flat default until the new build is measured and added here).
+// gpt-oss-20b: measured B=8 activation peak 2.56 GiB eager / 3.20 GiB
+// compiled (fused SDPA, head_dim 64; same benchmark sweep that sized the
+// 5.5 GiB default off gemma-4's 5.05/5.34) + slack → 3.5.
+//
+// For a multi-model provider this figure is a LOWER bound on the reserve it
+// actually holds (its UnifiedMemoryCap takes the max over the whole serving
+// set, which the coordinator does not know) — the optimistic direction this
+// file sanctions: the worst case is a declined load — or a load that
+// succeeds and has its first submit rejected as a capacity 503 (clamp +
+// reroute) — both absorbed by the dispatch retry machinery, and the warm
+// report replaces the estimate once the slot loads.
+var servabilityModelActivationFloorsGB = map[string]float64{
+	"gpt-oss-20b": 3.5,
+}
+
+// servabilityActivationFloor selects the activation reserve the given
+// provider binary actually holds for the given model. This is the same
+// version-gated selection shape as slotBudgetLayoutForVersion: the registry
+// snapshot carries the provider's reported binary version (p.Version →
+// snap.binaryVersion) and the model being routed (snap.model), so the cold
+// estimate can mirror the right constant per provider — which is what makes
+// it converge to that provider's own warm report as the slot loads (a legacy
+// provider's active_token_budget_max reflects its 3 GiB reserve; a per-model
+// provider's reflects its serving-set floor).
+//
+// Three regimes: pre-0.8.0 binaries hold the legacy flat 3 GiB; 0.8.0 up to
+// (excluding) the per-model release hold the flat 5.5 GiB; per-model binaries
+// hold the measured floor for models in the mirrored table and the flat 5.5
+// otherwise.
 //
 // An EMPTY/unreported version fails toward the LEGACY (larger) budget, the
 // fail-open direction this file mandates: over-predicting a budget risks one
@@ -94,10 +132,16 @@ const (
 // also self-correcting — the fleet trends to ≥0.8.0 as it upgrades, and every
 // RESIDENT slot reports its real budget, which snapshotStructuralBudget
 // prefers over this estimate.
-func servabilityActivationFloorForVersion(version string) float64 {
+func servabilityActivationFloor(version, modelID string) float64 {
 	if version == "" ||
 		CompareVersions(version, servabilityActivationFloorMinVersion) < 0 {
 		return servabilityLegacyActivationFloorGB
+	}
+	if CompareVersions(version, servabilityPerModelFloorMinVersion) < 0 {
+		return servabilityActivationFloorGB
+	}
+	if floor, ok := servabilityModelActivationFloorsGB[modelID]; ok {
+		return floor
 	}
 	return servabilityActivationFloorGB
 }
@@ -138,12 +182,13 @@ type ServabilityVerdict struct {
 // paddedWeightsGB uses the same catalog→padded-GiB conversion the cold-load gate
 // uses (coldLoadCatalogGBToMemGiB). kvBytesPerToken prefers the provider-reported
 // per-model value, falling back to the kvCacheBytesPerToken default.
-// providerVersion selects the activation reserve THAT binary holds — 3 GiB
-// before 0.8.0, 5.5 GiB after (servabilityActivationFloorForVersion) — so a
-// mixed-version fleet is charged per-provider, not at the newest constant. The
-// estimate is deliberately OPTIMISTIC (uses only the activation reserve, not
-// the extra min-KV load floor) so the predictor errs toward serving. Returns 0
-// when the inputs are unusable or no headroom remains.
+// providerVersion and modelID select the activation reserve THAT binary holds
+// for THAT model — 3 GiB before 0.8.0, flat 5.5 GiB up to the per-model
+// release, then the measured per-model floor (servabilityActivationFloor) —
+// so a mixed-version fleet is charged per-provider, not at the newest
+// constant. The estimate is deliberately OPTIMISTIC (uses only the activation
+// reserve, not the extra min-KV load floor) so the predictor errs toward
+// serving. Returns 0 when the inputs are unusable or no headroom remains.
 //
 // # Mirroring, not modelling
 //
@@ -159,16 +204,18 @@ type ServabilityVerdict struct {
 // That is why there is no attention-posture term here. A composed-attention
 // model (gemma-4: head_dim 256 sliding / 512 full) really does materialise a
 // bigger prefill score tensor than a fused one (gpt-oss: head_dim 64, inside
-// MLX's fused-SDPA set), but the provider does not charge it — UnifiedMemoryCap
-// holds back 5.5 GiB either way. Charging it here made this gate strictly
-// TIGHTER than the gate it mirrors and 429'd prompts every provider in the
-// fleet could have served. Whether 5.5 GiB is the right number is the
+// MLX's fused-SDPA set), but the provider does not charge a posture term —
+// its reserve is the measured per-model floor (or the flat default), never a
+// shape estimate. Charging a term the provider does not hold made this gate
+// strictly TIGHTER than the gate it mirrors and 429'd prompts every provider
+// in the fleet could have served. Whether a floor is the right number is the
 // provider's question, answered in one place; a second opinion here can only
-// desync. Retune this ONLY when defaultActivationReserveBytes moves — as it
-// did for v0.8.0 (3 → 5.5, the measured B=8 activation peak) — and keep the
-// LEGACY constant beside it while any pre-move provider remains in the fleet:
-// convergence is per-provider, so the mirror must charge each binary the
-// reserve it actually holds (servabilityActivationFloorForVersion).
+// desync. Retune this ONLY when the provider's floors move — as they did for
+// v0.8.0 (3 → 5.5, the measured B=8 activation peak) and again when the
+// measured per-model table shipped — and keep the LEGACY constants beside it
+// while any pre-move provider remains in the fleet: convergence is
+// per-provider, so the mirror must charge each binary the reserve it actually
+// holds (servabilityActivationFloor).
 //
 // Being optimistic is the safe direction because the coordinator is not the
 // backstop. The provider is, and its checks are measurement-based, not
@@ -179,7 +226,7 @@ type ServabilityVerdict struct {
 // (liveKVHeadroomBytes). An over-generous estimate therefore costs a declined
 // load, which the dispatch path retries elsewhere — strictly better than a
 // terminal 429 on a request that was servable all along.
-func coldTokenBudgetEstimate(totalMemoryGB, modelSizeGB float64, kvBytesPerToken int64, providerVersion string) int64 {
+func coldTokenBudgetEstimate(totalMemoryGB, modelSizeGB float64, kvBytesPerToken int64, providerVersion, modelID string) int64 {
 	if totalMemoryGB <= 0 || modelSizeGB <= 0 {
 		return 0
 	}
@@ -193,7 +240,7 @@ func coldTokenBudgetEstimate(totalMemoryGB, modelSizeGB float64, kvBytesPerToken
 		kvpt = kvCacheBytesPerToken
 	}
 	postLoadBytes := postLoadGB * float64(bytesPerGB)
-	floorBytes := servabilityActivationFloorForVersion(providerVersion) * float64(bytesPerGB)
+	floorBytes := servabilityActivationFloor(providerVersion, modelID) * float64(bytesPerGB)
 	tokens := (postLoadBytes - floorBytes) / float64(kvpt)
 	if tokens <= 0 {
 		return 0
@@ -222,7 +269,8 @@ func snapshotStructuralBudget(snap routingSnapshot) (budget int64, known bool) {
 		return 0, false
 	}
 	return coldTokenBudgetEstimate(
-		snap.totalMemoryGB, snap.modelSizeGB, snap.kvBytesPerToken, snap.binaryVersion), true
+		snap.totalMemoryGB, snap.modelSizeGB, snap.kvBytesPerToken,
+		snap.binaryVersion, snap.model), true
 }
 
 // liveRemainingBudget is snapshotStructuralBudget minus the provider's CURRENTLY

--- a/coordinator/registry/servability_provider_fit_test.go
+++ b/coordinator/registry/servability_provider_fit_test.go
@@ -73,7 +73,7 @@ func TestProviderBudgetFitsColdLoadPostLoadBudget(t *testing.T) {
 
 	// Post-load budget per the provider's own headroom math:
 	// (0.90×48 − paddedWeights − 5.5 GiB activation floor) / 400000 B/token.
-	budget := coldTokenBudgetEstimate(snap.totalMemoryGB, snap.modelSizeGB, 0, snap.binaryVersion)
+	budget := coldTokenBudgetEstimate(snap.totalMemoryGB, snap.modelSizeGB, 0, snap.binaryVersion, snap.model)
 	if budget <= 0 || budget >= 30_000 {
 		t.Fatalf("cold post-load budget = %d, want a positive value below the 30k request", budget)
 	}
@@ -116,7 +116,7 @@ func TestPredictServableColdWeightFitInsufficientBudgetSheds(t *testing.T) {
 	model := "cold-budget-model"
 	// 28 GB weights on a 48 GB node running v0.8.0: min_ram 36 ≤ 48 passes the
 	// hardware gate, and the post-load budget is
-	// coldTokenBudgetEstimate(48, 28, 0, "0.8.0") = 17200
+	// coldTokenBudgetEstimate(48, 28, 0, "0.8.0", "") = 17200
 	// (see TestColdTokenBudgetEstimate case (b2)).
 	reg.SetModelCatalog([]CatalogEntry{{ID: model, SizeGB: 28, MinRAMGB: 36}})
 	cold := makeWarmPoolColdProvider(t, reg, "cold-48gb", model, 80, 48, 0)
@@ -124,7 +124,7 @@ func TestPredictServableColdWeightFitInsufficientBudgetSheds(t *testing.T) {
 	cold.Version = "0.8.0"
 	cold.mu.Unlock()
 
-	budget := coldTokenBudgetEstimate(48, 28, 0, "0.8.0")
+	budget := coldTokenBudgetEstimate(48, 28, 0, "0.8.0", "")
 	if budget <= 0 {
 		t.Fatalf("cold budget = %d, want > 0", budget)
 	}

--- a/coordinator/registry/servability_test.go
+++ b/coordinator/registry/servability_test.go
@@ -15,7 +15,7 @@ import "testing"
 //
 // with servabilityCapFraction=0.90, coldLoadCatalogGBToMemGiB≈
 // 1.1175870895385742, bytesPerGB=1<<30, and kvBytesPerToken<=0 → 400000.
-// floorGB is VERSION-GATED (servabilityActivationFloorForVersion): the floor
+// floorGB is VERSION-GATED (servabilityActivationFloor): the floor
 // moved 3.0 → 5.5 with the provider's v0.8.0 B=8 reserve raise, so a ≥0.8.0
 // provider's golden sits exactly 2.5*2^30/400000 = 6710.9 tokens below the
 // legacy one, and nothing else moves — flat stays flat. An empty/pre-0.8.0
@@ -38,10 +38,10 @@ func TestColdTokenBudgetEstimate(t *testing.T) {
 	// floor) — TIGHTER than the provider it claimed to mirror, on a model
 	// that materialises no score tensor at all. That gap is the defect.
 	const wantRoomy = int64(103854)
-	if got := coldTokenBudgetEstimate(64, 12, 400000, v080); got != wantRoomy {
+	if got := coldTokenBudgetEstimate(64, 12, 400000, v080, ""); got != wantRoomy {
 		t.Fatalf("roomy estimate = %d, want %d", got, wantRoomy)
 	}
-	if got := coldTokenBudgetEstimate(64, 12, 400000, v080); got <= 0 {
+	if got := coldTokenBudgetEstimate(64, 12, 400000, v080, ""); got <= 0 {
 		t.Fatalf("roomy estimate = %d, want > 0", got)
 	}
 
@@ -50,23 +50,23 @@ func TestColdTokenBudgetEstimate(t *testing.T) {
 	// = 6710.9 tokens higher — (47447529062.4 - 3221225472)/400000 = 110565.7.
 	// An EMPTY (unreported) version fails toward the same legacy budget: the
 	// larger estimate is the fail-open direction (see
-	// servabilityActivationFloorForVersion).
+	// servabilityActivationFloor).
 	const wantRoomyLegacy = int64(110565)
-	if got := coldTokenBudgetEstimate(64, 12, 400000, "0.7.12"); got != wantRoomyLegacy {
+	if got := coldTokenBudgetEstimate(64, 12, 400000, "0.7.12", ""); got != wantRoomyLegacy {
 		t.Fatalf("legacy roomy estimate = %d, want %d", got, wantRoomyLegacy)
 	}
-	if got := coldTokenBudgetEstimate(64, 12, 400000, ""); got != wantRoomyLegacy {
+	if got := coldTokenBudgetEstimate(64, 12, 400000, "", ""); got != wantRoomyLegacy {
 		t.Fatalf("unreported-version roomy estimate = %d, want %d (fail toward legacy)", got, wantRoomyLegacy)
 	}
 	// The gate is >= 0.8.0, not > 0.8.0, and later releases keep the floor.
-	if got := coldTokenBudgetEstimate(64, 12, 400000, "0.8.1"); got != wantRoomy {
+	if got := coldTokenBudgetEstimate(64, 12, 400000, "0.8.1", ""); got != wantRoomy {
 		t.Fatalf("post-0.8.0 estimate = %d, want %d", got, wantRoomy)
 	}
 
 	// (b) Tiny node: weights (padded) alone exceed 90% of the 8 GB cap, so
 	// there is no post-load memory at all, let alone room for the activation
 	// reserve → 0 (never negative).
-	if got := coldTokenBudgetEstimate(8, 12, 400000, v080); got != 0 {
+	if got := coldTokenBudgetEstimate(8, 12, 400000, v080, ""); got != 0 {
 		t.Fatalf("tiny-node estimate = %d, want 0 (weights exceed cap)", got)
 	}
 
@@ -79,7 +79,7 @@ func TestColdTokenBudgetEstimate(t *testing.T) {
 	// clamps it. Drop that guard and this returns a NEGATIVE budget, which
 	// PredictServable would publish as FleetMaxBudget. Distinct from (b): there
 	// the weights alone bust the cap and the reserve never enters it.
-	if got := coldTokenBudgetEstimate(20, 14, 400000, v080); got != 0 {
+	if got := coldTokenBudgetEstimate(20, 14, 400000, v080, ""); got != 0 {
 		t.Fatalf("reserve-bound estimate = %d, want 0 (weights fit, activation floor does not)", got)
 	}
 
@@ -90,12 +90,12 @@ func TestColdTokenBudgetEstimate(t *testing.T) {
 	//   padded    = 28 * 1.1175870895385742      = 31.292438507080078
 	//   postLoadGB= 0.90*48 - 31.292438507080078 = 11.907561492919925 GB
 	//   tokens    = (11.907561492919925*2^30 - 5905580032) / 400000 = 17200.17
-	if got := coldTokenBudgetEstimate(48, 28, 400000, v080); got != int64(17200) {
+	if got := coldTokenBudgetEstimate(48, 28, 400000, v080, ""); got != int64(17200) {
 		t.Fatalf("gemma-4-shaped estimate = %d, want 17200", got)
 	}
 	// The same box under a legacy binary: 3 GiB floor →
 	// (11.907561492919925*2^30 - 3221225472)/400000 = 23911.1.
-	if got := coldTokenBudgetEstimate(48, 28, 400000, "0.7.12"); got != int64(23911) {
+	if got := coldTokenBudgetEstimate(48, 28, 400000, "0.7.12", ""); got != int64(23911) {
 		t.Fatalf("legacy gemma-4-shaped estimate = %d, want 23911", got)
 	}
 
@@ -109,7 +109,7 @@ func TestColdTokenBudgetEstimate(t *testing.T) {
 	// total=24.95).
 	prev := int64(0)
 	for total := 20.0; total <= 30.0; total += 0.05 {
-		got := coldTokenBudgetEstimate(total, 1, 400000, v080)
+		got := coldTokenBudgetEstimate(total, 1, 400000, v080, "")
 		if prev > 0 {
 			if d := got - prev; d < 120 || d > 121 {
 				t.Fatalf("non-linear step at total=%.2f: %d after %d (delta %d, want 120-121)",
@@ -127,30 +127,30 @@ func TestColdTokenBudgetEstimate(t *testing.T) {
 	// (c) kvBytesPerToken <= 0 falls back to the kvCacheBytesPerToken default
 	// (400000): an unreported per-model KV cost must match the explicit default,
 	// for both a zero and a negative input.
-	explicit := coldTokenBudgetEstimate(64, 12, 400000, v080)
-	if got := coldTokenBudgetEstimate(64, 12, 0, v080); got != explicit {
+	explicit := coldTokenBudgetEstimate(64, 12, 400000, v080, "")
+	if got := coldTokenBudgetEstimate(64, 12, 0, v080, ""); got != explicit {
 		t.Fatalf("kvpt=0 fallback estimate = %d, want %d (== explicit 400000)", got, explicit)
 	}
-	if got := coldTokenBudgetEstimate(64, 12, -1, v080); got != explicit {
+	if got := coldTokenBudgetEstimate(64, 12, -1, v080, ""); got != explicit {
 		t.Fatalf("kvpt=-1 fallback estimate = %d, want %d (== explicit 400000)", got, explicit)
 	}
 	// A reported per-model KV cost is honored (and a cheaper per-token cost
 	// yields strictly more tokens), proving the parameter is actually used.
-	if got := coldTokenBudgetEstimate(64, 12, 200000, v080); got <= explicit {
+	if got := coldTokenBudgetEstimate(64, 12, 200000, v080, ""); got <= explicit {
 		t.Fatalf("cheaper kvpt estimate = %d, want > default-kvpt estimate %d", got, explicit)
 	}
 
 	// (d) Unusable inputs → 0 (gate disabled): no total memory, or no model size.
-	if got := coldTokenBudgetEstimate(0, 12, 400000, v080); got != 0 {
+	if got := coldTokenBudgetEstimate(0, 12, 400000, v080, ""); got != 0 {
 		t.Fatalf("totalMemoryGB<=0 estimate = %d, want 0", got)
 	}
-	if got := coldTokenBudgetEstimate(-1, 12, 400000, v080); got != 0 {
+	if got := coldTokenBudgetEstimate(-1, 12, 400000, v080, ""); got != 0 {
 		t.Fatalf("totalMemoryGB<0 estimate = %d, want 0", got)
 	}
-	if got := coldTokenBudgetEstimate(64, 0, 400000, v080); got != 0 {
+	if got := coldTokenBudgetEstimate(64, 0, 400000, v080, ""); got != 0 {
 		t.Fatalf("modelSizeGB<=0 estimate = %d, want 0", got)
 	}
-	if got := coldTokenBudgetEstimate(64, -1, 400000, v080); got != 0 {
+	if got := coldTokenBudgetEstimate(64, -1, 400000, v080, ""); got != 0 {
 		t.Fatalf("modelSizeGB<0 estimate = %d, want 0", got)
 	}
 }
@@ -193,7 +193,7 @@ func TestColdTokenBudgetMirrorsProviderReserveArithmetic(t *testing.T) {
 		// back only the flat floor for it, so the coordinator must too.
 		{"gemma-4-26b", "composed, head_dim 256/512", 128, 28},
 	} {
-		got := coldTokenBudgetEstimate(tc.totalMemoryGB, tc.modelSizeGB, 400000, "0.8.0")
+		got := coldTokenBudgetEstimate(tc.totalMemoryGB, tc.modelSizeGB, 400000, "0.8.0", "")
 		want := providerPostLoadTokenBudget(tc.totalMemoryGB, tc.modelSizeGB, 400000, 5.5)
 		if got != want {
 			t.Errorf("%s (%s): cold estimate = %d, want the provider's own post-load budget %d",
@@ -217,13 +217,13 @@ func TestColdTokenBudgetMirrorsProviderReserveArithmetic(t *testing.T) {
 	// a pre-0.8.0 provider against its 3 GiB gate.
 	for _, totalGB := range []float64{24, 36, 48, 64, 96, 128, 192, 512} {
 		for _, sizeGB := range []float64{1, 12, 20, 28, 40} {
-			got := coldTokenBudgetEstimate(totalGB, sizeGB, 400000, "0.8.0")
+			got := coldTokenBudgetEstimate(totalGB, sizeGB, 400000, "0.8.0", "")
 			want := providerPostLoadTokenBudget(totalGB, sizeGB, 400000, 5.5)
 			if got < want {
 				t.Fatalf("total=%.0fGB size=%.0fGB: cold estimate %d is TIGHTER than the provider's %d",
 					totalGB, sizeGB, got, want)
 			}
-			legacyGot := coldTokenBudgetEstimate(totalGB, sizeGB, 400000, "0.7.12")
+			legacyGot := coldTokenBudgetEstimate(totalGB, sizeGB, 400000, "0.7.12", "")
 			legacyWant := providerPostLoadTokenBudget(totalGB, sizeGB, 400000, 3.0)
 			if legacyGot < legacyWant {
 				t.Fatalf("total=%.0fGB size=%.0fGB: LEGACY cold estimate %d is TIGHTER than the pre-0.8.0 provider's %d",
@@ -287,12 +287,12 @@ func TestSnapshotStructuralBudget(t *testing.T) {
 	// Cold/on-disk with memory + size data: known, using the optimistic cold
 	// estimate. Unreported kvBytesPerToken falls back to the 400000 default;
 	// an unreported binaryVersion falls toward the legacy reserve.
-	wantCold := coldTokenBudgetEstimate(64, 12, 0, "")
+	wantCold := coldTokenBudgetEstimate(64, 12, 0, "", "")
 	if budget, known := snapshotStructuralBudget(routingSnapshot{totalMemoryGB: 64, modelSizeGB: 12}); !known || budget != wantCold {
 		t.Fatalf("cold-fitting = (%d, %v), want (%d, true)", budget, known, wantCold)
 	}
 	// A cold slot threads its reported per-model KV cost into the estimate.
-	wantColdKVPT := coldTokenBudgetEstimate(64, 12, 200000, "")
+	wantColdKVPT := coldTokenBudgetEstimate(64, 12, 200000, "", "")
 	if budget, known := snapshotStructuralBudget(routingSnapshot{
 		totalMemoryGB:   64,
 		modelSizeGB:     12,
@@ -303,7 +303,7 @@ func TestSnapshotStructuralBudget(t *testing.T) {
 	// A cold slot threads its provider's binary version into the estimate:
 	// a ≥0.8.0 binary is charged the 5.5 GiB reserve it actually holds,
 	// which lands strictly below the legacy default above.
-	wantColdV080 := coldTokenBudgetEstimate(64, 12, 0, "0.8.0")
+	wantColdV080 := coldTokenBudgetEstimate(64, 12, 0, "0.8.0", "")
 	if budget, known := snapshotStructuralBudget(routingSnapshot{
 		totalMemoryGB: 64,
 		modelSizeGB:   12,
@@ -512,8 +512,8 @@ func TestPredictServableMixedVersionFleetStagedRollout(t *testing.T) {
 	//   legacy (3 GiB reserve)  cold budget = 110565 tokens
 	//   v0.8.0 (5.5 GiB reserve) cold budget = 103854 tokens
 	// Request 105000 + 256 = 105256 sits strictly between the two.
-	legacyBudget := coldTokenBudgetEstimate(64, 12, 0, "0.7.12")
-	newBudget := coldTokenBudgetEstimate(64, 12, 0, "0.8.0")
+	legacyBudget := coldTokenBudgetEstimate(64, 12, 0, "0.7.12", "")
+	newBudget := coldTokenBudgetEstimate(64, 12, 0, "0.8.0", "")
 	const reqPrompt, reqMax = 105000, 256
 	if int64(reqPrompt+reqMax) <= newBudget || int64(reqPrompt+reqMax) > legacyBudget {
 		t.Fatalf("fixture broke: request %d must sit between new budget %d and legacy budget %d",
@@ -579,5 +579,64 @@ func TestPredictServableEmptyFleet(t *testing.T) {
 	}
 	if v.FleetMaxBudget != 0 {
 		t.Fatalf("FleetMaxBudget = %d, want 0", v.FleetMaxBudget)
+	}
+}
+
+// TestServabilityActivationFloorPerModel pins the (version, model)-gated floor
+// selection. Three regimes, mirroring what each provider binary actually holds
+// (UnifiedMemoryCap.resolvedActivationReserveBytes):
+//
+//   - < 0.8.0 (or unreported): the legacy flat 3 GiB reserve, any model.
+//   - 0.8.0 ..< perModel: the flat 5.5 GiB reserve, any model.
+//   - >= perModel: the measured per-model floor for models in the mirrored
+//     table (gpt-oss-20b: 3.5 = worst measured B=8 peak, 3.20 GiB compiled,
+//   - slack), the flat 5.5 otherwise. The table mirrors
+//     UnifiedMemoryCap.measuredActivationFloorsBytes and the two MUST move in
+//     the same commit.
+//
+// The per-model figure is a LOWER bound on the reserve a multi-model provider
+// holds (its UnifiedMemoryCap takes the max over its whole serving set, which
+// the coordinator does not know) — the optimistic direction this file
+// sanctions: worst case is a declined load the dispatch path retries, and the
+// warm report replaces the estimate as soon as the slot loads.
+func TestServabilityActivationFloorPerModel(t *testing.T) {
+	cases := []struct {
+		version, model string
+		want           float64
+	}{
+		{"", "gpt-oss-20b", 3.0},                                 // unreported → legacy floor
+		{"0.7.12", "gpt-oss-20b", 3.0},                           // legacy binary → legacy floor
+		{"0.8.0", "gpt-oss-20b", 5.5},                            // flat-floor binary, measured model
+		{"0.8.10", "gpt-oss-20b", 5.5},                           // last flat-floor release
+		{servabilityPerModelFloorMinVersion, "gpt-oss-20b", 3.5}, // measured floor
+		{servabilityPerModelFloorMinVersion, "gemma-4-26b", 5.5}, // unmeasured → flat
+		{servabilityPerModelFloorMinVersion, "", 5.5},            // unknown model → flat
+		{"0.9.0", "gpt-oss-20b", 3.5},                            // later releases keep the table
+	}
+	for _, tc := range cases {
+		if got := servabilityActivationFloor(tc.version, tc.model); got != tc.want {
+			t.Fatalf("servabilityActivationFloor(%q, %q) = %v, want %v",
+				tc.version, tc.model, got, tc.want)
+		}
+	}
+}
+
+// TestColdTokenBudgetEstimatePerModelFloor pins the cold estimate under the
+// per-model floor. Same roomy node as TestColdTokenBudgetEstimate (total=64,
+// size=12, kvpt=400000, postLoadB = 47447529062.4):
+//
+//	gpt-oss-20b @ perModel: (47447529062.4 - 3.5*2^30)/400000 = 109223.58
+//	unmeasured  @ perModel: (47447529062.4 - 5.5*2^30)/400000 = 103854.87
+func TestColdTokenBudgetEstimatePerModelFloor(t *testing.T) {
+	v := servabilityPerModelFloorMinVersion
+	if got := coldTokenBudgetEstimate(64, 12, 400000, v, "gpt-oss-20b"); got != int64(109223) {
+		t.Fatalf("per-model gpt-oss estimate = %d, want 109223", got)
+	}
+	if got := coldTokenBudgetEstimate(64, 12, 400000, v, "gemma-4-26b"); got != int64(103854) {
+		t.Fatalf("per-model unmeasured estimate = %d, want 103854 (flat floor)", got)
+	}
+	// A pre-perModel binary holds the FLAT reserve even for a measured model.
+	if got := coldTokenBudgetEstimate(64, 12, 400000, "0.8.10", "gpt-oss-20b"); got != int64(103854) {
+		t.Fatalf("pre-perModel gpt-oss estimate = %d, want 103854 (flat floor)", got)
 	}
 }

--- a/provider-swift/Sources/ProviderCore/Diagnostics/ModelFitDiagnostic.swift
+++ b/provider-swift/Sources/ProviderCore/Diagnostics/ModelFitDiagnostic.swift
@@ -24,12 +24,17 @@ public enum ModelFitDiagnostic {
     /// footprint plus one-request headroom — exactly `ensureModelLoaded`'s
     /// requirement. `estimatedMemoryGb` is the scanner's overhead-included size
     /// (the same value the runtime passes), not the raw on-disk bytes.
-    public static func requiredGb(estimatedMemoryGb: Double) -> Double {
+    /// `modelID` selects the model's measured activation floor
+    /// (`UnifiedMemoryCap.measuredActivationFloorsBytes`) — the requirement a
+    /// box serving ONLY this model faces, which is what a per-model fit
+    /// verdict asks; nil keeps the flat default.
+    public static func requiredGb(estimatedMemoryGb: Double, modelID: String? = nil) -> Double {
         // Cap-aware headroom (activation reserve + min serveable KV) so the
         // doctor's "needs ~X GB" matches what the runtime load gate requires.
         ModelLoadAdmission.requiredToLoadGb(
             weightsGb: estimatedMemoryGb,
-            headroomGb: Double(UnifiedMemoryCap.loadHeadroomBytes()) / (1024.0 * 1024.0 * 1024.0))
+            headroomGb: Double(UnifiedMemoryCap.loadHeadroomBytes(modelIDs: modelID.map { [$0] }))
+                / (1024.0 * 1024.0 * 1024.0))
     }
 
     /// The memory (GB) the provider would actually have free to load a model,
@@ -75,12 +80,17 @@ public enum ModelFitDiagnostic {
 
     /// Builds the traffic-readiness diagnostic for a single target model.
     /// `weightGb` is the model's overhead-included estimated size; `alternatives`
-    /// are locally-available models, used to suggest a fit.
+    /// are locally-available models, used to suggest a fit. `servingSetIDs` is
+    /// the box's ACTUAL serving set (the daemon's load gate carves the max
+    /// floor over that whole set, not the target's own) — pass it so the
+    /// verdict matches what the daemon enforces; nil falls back to the target
+    /// alone (a single-model box, where the two coincide).
     public static func diagnose(
         modelID: String,
         weightGb: Double,
         usableGb: Double,
-        alternatives: [ModelOption] = []
+        alternatives: [ModelOption] = [],
+        servingSetIDs: [String]? = nil
     ) -> Diagnostic {
         guard weightGb > 0, usableGb > 0 else {
             return Diagnostic(
@@ -88,21 +98,32 @@ public enum ModelFitDiagnostic {
                 message: "couldn't determine the model size or available memory; skipping the fit check.",
                 fix: nil)
         }
-        let needed = requiredGb(estimatedMemoryGb: weightGb)
+        // The daemon's requirement for THIS box: weights + headroom at the
+        // serving set's floor (ProviderLoop.loadHeadroomGb), never the
+        // target's solo floor when other enabled models pin a larger one. The
+        // target always joins the basis — the daemon's set includes whatever
+        // it is loading (max is idempotent, so a duplicate id is harmless).
+        let needed = ModelLoadAdmission.requiredToLoadGb(
+            weightsGb: weightGb,
+            headroomGb: Double(
+                UnifiedMemoryCap.loadHeadroomBytes(modelIDs: (servingSetIDs ?? []) + [modelID]))
+                / (1024.0 * 1024.0 * 1024.0))
         if needed <= usableGb {
             return Diagnostic(
                 section: .traffic, name: "model fits in RAM", level: .pass,
                 message: "\(modelID) needs ~\(fmt(needed)) GB; \(fmt(usableGb)) GB usable.",
                 fix: nil)
         }
+        // Each alternative is judged with ITS OWN activation floor — the
+        // suggestion models what `enabled_models = [candidate]` would require.
         let fits = alternatives
-            .filter { requiredGb(estimatedMemoryGb: $0.weightGb) <= usableGb }
+            .filter { requiredGb(estimatedMemoryGb: $0.weightGb, modelID: $0.id) <= usableGb }
             .sorted { $0.weightGb > $1.weightGb }
         let suggestion: String
         if fits.isEmpty {
             suggestion = "this box's RAM is too small for the models on this network; consider a machine with more unified memory."
         } else {
-            let list = fits.prefix(3).map { "\($0.id) (~\(fmt(requiredGb(estimatedMemoryGb: $0.weightGb))) GB)" }.joined(separator: ", ")
+            let list = fits.prefix(3).map { "\($0.id) (~\(fmt(requiredGb(estimatedMemoryGb: $0.weightGb, modelID: $0.id))) GB)" }.joined(separator: ", ")
             suggestion = "set `enabled_models` in provider.toml to a model that fits: \(list)."
         }
         return Diagnostic(

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Factory+Production.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Factory+Production.swift
@@ -869,7 +869,7 @@ extension EngineV2Factory {
                 maxConcurrentRequests: schedulerConfig.maxConcurrentRequests,
                 inputs: .init(
                     physicalMemoryBytes: ProcessInfo.processInfo.physicalMemory,
-                    liveKVHeadroomBytes: KVHeadroomProbe.measuredLiveKVHeadroomBytes,
+                    liveKVHeadroomBytes: KVHeadroomProbe.measuredLiveKVHeadroomBytes(),
                     maxBufferLength: maxBufferLength))
             switch decision {
             case .contiguous(let reason):

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2KVSizing.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2KVSizing.swift
@@ -36,6 +36,7 @@ enum EngineV2KVSizing {
         newModelWeightBytes: Int,
         coResidentWeightBytes: UInt64,
         existingEngineKVCapacities: [Int],
+        activationReserveBytes: UInt64? = nil,
         configReserveBytes: UInt64 = 0,
         physicalBytes: UInt64 = ProcessInfo.processInfo.physicalMemory
     ) -> Int {
@@ -43,6 +44,7 @@ enum EngineV2KVSizing {
             UInt64(max(0, newModelWeightBytes)), coResidentWeightBytes)
         let fleetBudget = UnifiedMemoryCap.kvBudgetBytes(
             physicalBytes: physicalBytes, residentWeightBytes: totalWeights,
+            activationReserveBytes: activationReserveBytes,
             configReserveBytes: configReserveBytes)
         let granted = existingEngineKVCapacities.reduce(UInt64(0)) {
             saturatingAdd($0, UInt64(max(0, $1)))
@@ -62,6 +64,7 @@ enum EngineV2KVSizing {
         grantedKVBytesCapacity: Int,
         totalResidentWeightBytes: UInt64,
         otherEngineKVCapacities: [Int],
+        activationReserveBytes: UInt64? = nil,
         configReserveBytes: UInt64 = 0,
         physicalBytes: UInt64 = ProcessInfo.processInfo.physicalMemory
     ) -> Int {
@@ -69,6 +72,7 @@ enum EngineV2KVSizing {
             newModelWeightBytes: 0,
             coResidentWeightBytes: totalResidentWeightBytes,
             existingEngineKVCapacities: otherEngineKVCapacities,
+            activationReserveBytes: activationReserveBytes,
             configReserveBytes: configReserveBytes,
             physicalBytes: physicalBytes)
         return min(max(0, grantedKVBytesCapacity), current)

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Runtime.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Runtime.swift
@@ -66,15 +66,22 @@ public actor EngineV2Runtime {
         public let totalResidentWeightBytes: UInt64
         /// Operator `memory_reserve_gb`, in bytes (see `EngineV2KVSizing`).
         public let configReserveBytes: UInt64
+        /// The serving set's resolved activation reserve
+        /// (`UnifiedMemoryCap.resolvedActivationReserveBytes(modelIDs:)`);
+        /// nil keeps the flat default. Must match what the grants were sized
+        /// with, or the heartbeat clamp disagrees with the grant it clamps.
+        public let activationReserveBytes: UInt64?
         /// Injectable for tests; the machine's real memory in production.
         public let physicalBytes: UInt64
 
         public init(
             totalResidentWeightBytes: UInt64,
+            activationReserveBytes: UInt64? = nil,
             configReserveBytes: UInt64 = 0,
             physicalBytes: UInt64 = ProcessInfo.processInfo.physicalMemory
         ) {
             self.totalResidentWeightBytes = totalResidentWeightBytes
+            self.activationReserveBytes = activationReserveBytes
             self.configReserveBytes = configReserveBytes
             self.physicalBytes = physicalBytes
         }
@@ -115,6 +122,7 @@ public actor EngineV2Runtime {
                     grantedKVBytesCapacity: grant,
                     totalResidentWeightBytes: fleetKV.totalResidentWeightBytes,
                     otherEngineKVCapacities: otherClaims,
+                    activationReserveBytes: fleetKV.activationReserveBytes,
                     configReserveBytes: fleetKV.configReserveBytes,
                     physicalBytes: fleetKV.physicalBytes)
             }

--- a/provider-swift/Sources/ProviderCore/Inference/GlobalKVCacheBudget.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/GlobalKVCacheBudget.swift
@@ -15,11 +15,18 @@ public actor GlobalKVCacheBudget {
     }
 
     /// Cap fraction and activation reserve are nil → ``UnifiedMemoryCap``
-    /// defaults (0.90 / env / 3 GiB floor). Held as overrides so tests can pin
-    /// them; production uses the defaults so this budget and the load gate share
-    /// one policy.
+    /// defaults (0.90 / env / the 5.5 GiB default floor). Held as overrides so
+    /// tests can pin them. `ProviderLoop` resolves the reserve for its serving
+    /// set (`UnifiedMemoryCap.resolvedActivationReserveBytes(modelIDs:)`) and
+    /// passes it here so this budget and its load gate share one policy;
+    /// `StandaloneServer` (local direct mode) deliberately keeps the flat
+    /// default throughout. The reserve is a `var` behind
+    /// ``setActivationReserveBytes(_:)`` because the serving set can change at
+    /// runtime (coordinator-driven prefetch advertises new builds); the owner
+    /// re-resolves and pushes the new value BEFORE the added model becomes
+    /// loadable.
     private let capFraction: Double?
-    private let activationReserveBytes: UInt64?
+    private var activationReserveBytes: UInt64?
     /// Operator-configured reserve (`memory_reserve_gb`, in bytes). Held back by
     /// the live KV gate just as the load gate holds it back, so runtime KV can't
     /// grow into memory the operator reserved. 0 = no extra reserve (cap only).
@@ -164,6 +171,18 @@ public actor GlobalKVCacheBudget {
             // Tests that don't pin a threshold should never trip the proactive
             // sweep on their tiny synthetic pools — keep the production default.
             proactiveThresholdBytes: KVPoolReclaimer.defaultProactiveThresholdBytes)
+    }
+
+    /// Replace the activation reserve this budget carves out of the cap.
+    /// Called by the owner when its advertised serving set changes (a
+    /// prefetch-verified build was advertised, or a superseded build dropped)
+    /// with the freshly resolved
+    /// `UnifiedMemoryCap.resolvedActivationReserveBytes(modelIDs:)` — the
+    /// raise must land BEFORE the added model becomes loadable so a decode
+    /// step of the new model can never run against the smaller reserve.
+    /// Passing nil restores the flat default resolution.
+    public func setActivationReserveBytes(_ bytes: UInt64?) {
+        activationReserveBytes = bytes
     }
 
     public func reserve(requestID: String, kvBytesPerToken: Int, tokenCount: Int) -> Bool {

--- a/provider-swift/Sources/ProviderCore/Inference/KVHeadroomProbe.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/KVHeadroomProbe.swift
@@ -18,11 +18,20 @@ public enum KVHeadroomProbe {
     /// (`active + cache`, reflecting every co-resident model's weights and
     /// KV) clamped to real OS-available memory. NO floor is applied, so it
     /// reports a true zero when the cap is already exhausted.
-    public static var measuredLiveKVHeadroomBytes: UInt64 {
+    /// `activationReserveBytes` is the reserve the caller's serving set
+    /// resolves to (`UnifiedMemoryCap.resolvedActivationReserveBytes
+    /// (modelIDs:)`); nil keeps the flat default. The load gate and this
+    /// measured guard MUST carve the same reserve, or a model the gate
+    /// admits at the serving-set floor is unloaded here against the larger
+    /// flat one — the admit-then-fail churn #653 removes.
+    public static func measuredLiveKVHeadroomBytes(
+        activationReserveBytes: UInt64? = nil
+    ) -> UInt64 {
         let mlxUsed = UInt64(max(0, MLX.GPU.activeMemory)) + UInt64(max(0, MLX.GPU.cacheMemory))
         return UnifiedMemoryCap.liveKVHeadroomBytes(
             mlxUsedBytes: mlxUsed,
-            systemAvailableBytes: SystemMemory.availableBytes() ?? .max)
+            systemAvailableBytes: SystemMemory.availableBytes() ?? .max,
+            activationReserveBytes: activationReserveBytes)
     }
 
     /// Post-load guard: true iff the freshly-loaded model leaves at least
@@ -32,9 +41,12 @@ public enum KVHeadroomProbe {
     /// shape). Trim the cold-load buffer pool (`MLX.Memory.clearCache()`)
     /// BEFORE probing, or transient load buffers false-reject a serveable
     /// model.
-    public static func hasServeableKVHeadroom() -> Bool {
+    public static func hasServeableKVHeadroom(
+        activationReserveBytes: UInt64? = nil
+    ) -> Bool {
         UnifiedMemoryCap.loadIsServeable(
-            measuredLiveKVHeadroomBytes: measuredLiveKVHeadroomBytes)
+            measuredLiveKVHeadroomBytes: measuredLiveKVHeadroomBytes(
+                activationReserveBytes: activationReserveBytes))
     }
 
     /// Post-BRIDGE serveable-KV verdict for a freshly-built slot.
@@ -57,17 +69,17 @@ public enum KVHeadroomProbe {
     public static func postBuildServeable(
         kvBackendKind: EngineV2KVBackendKind,
         pagedPoolBytes: UInt64,
-        measuredHeadroomBytes: @autoclosure () -> UInt64 = KVHeadroomProbe
-            .measuredLiveKVHeadroomBytes
+        activationReserveBytes: UInt64? = nil,
+        measuredHeadroomBytes: @autoclosure () -> UInt64? = nil
     ) -> Bool {
+        let measured = measuredHeadroomBytes()
+            ?? measuredLiveKVHeadroomBytes(activationReserveBytes: activationReserveBytes)
         switch kvBackendKind {
         case .paged:
             return pagedPoolBytes >= UnifiedMemoryCap.minimumLoadKVBytes
-                && UnifiedMemoryCap.loadIsServeable(
-                    measuredLiveKVHeadroomBytes: measuredHeadroomBytes())
+                && UnifiedMemoryCap.loadIsServeable(measuredLiveKVHeadroomBytes: measured)
         case .contiguous:
-            return UnifiedMemoryCap.loadIsServeable(
-                measuredLiveKVHeadroomBytes: measuredHeadroomBytes())
+            return UnifiedMemoryCap.loadIsServeable(measuredLiveKVHeadroomBytes: measured)
         }
     }
 }

--- a/provider-swift/Sources/ProviderCore/Inference/UnifiedMemoryCap.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/UnifiedMemoryCap.swift
@@ -34,10 +34,12 @@ public enum UnifiedMemoryCap {
     /// OS (e.g. an 8 GiB box gets a 6 GiB cap, not 7.2 GiB).
     static let minimumReserveBytes: UInt64 = 2 * 1024 * 1024 * 1024  // 2 GiB
 
-    /// The activation/working-memory reserve carved out INSIDE the cap — for
-    /// every model, every attention posture, every batch. FLAT. Nothing in
-    /// this type scales it; only an explicit operator or programmatic override
-    /// moves it (`DARKBLOOM_ACTIVATION_RESERVE_GB`, which may only RAISE it).
+    /// The DEFAULT activation/working-memory reserve carved out INSIDE the cap
+    /// — every attention posture, every batch, and every model that has no
+    /// measured floor of its own (``measuredActivationFloorsBytes``). Nothing
+    /// in this type SCALES it — resolution picks between measured constants —
+    /// and the operator env override (`DARKBLOOM_ACTIVATION_RESERVE_GB`) may
+    /// only RAISE the resolved floor, never lower it.
     ///
     /// 5.5 GiB as of v0.8.0, sized against the table below: this release
     /// raises the decode batch to 8, and the measured gemma-4 peak at B=8 is
@@ -64,7 +66,12 @@ public enum UnifiedMemoryCap {
     /// set, which no attention-shape estimate models: a `[rows, heads, C, kL]`
     /// score estimate predicts ~205 MB for the 3.40 GiB actually measured, and
     /// exactly 0 for the 2.20 GiB. Sizing the reserve off the score tensor
-    /// would track the smaller, better-behaved half of the cost.
+    /// would track the smaller, better-behaved half of the cost. That rules
+    /// out formulas, not measurements: the same sweep that sized this default
+    /// off gemma-4's peak measured gpt-oss-20b's, and
+    /// ``measuredActivationFloorsBytes`` carries those measured floors so a
+    /// provider serving ONLY measured models is not charged a reserve sized
+    /// for a model it can never run.
     ///
     /// This is also a FORWARD-LOOKING hold-back, not an accounting of live
     /// bytes. Transient growth during a step is already visible to
@@ -72,8 +79,8 @@ public enum UnifiedMemoryCap {
     /// reserve only has to keep the NEXT step's working set from crossing the
     /// cap. Retune it against a measurement, in one place, for the whole fleet
     /// — and mirror any change in `coordinator/registry/servability.go`
-    /// (`servabilityActivationFloorGB`), which predicts this exact arithmetic
-    /// for cold providers.
+    /// (`servabilityActivationFloorGB` / `servabilityModelActivationFloorsGB`),
+    /// which predicts this exact arithmetic for cold providers.
     ///
     /// KNOWN EXCEPTIONS, neither new nor yet measured as harmful. A composed
     /// attention model (head_dim outside MLX's fused-SDPA set {64, 80, 128})
@@ -98,6 +105,50 @@ public enum UnifiedMemoryCap {
     // the two MUST move in the same commit — see the doc comment above.
     static let defaultActivationReserveBytes: UInt64 = 11 * 1024 * 1024 * 1024 / 2
 
+    /// Measured per-model activation floors. The default above is sized for
+    /// the WORST measured model (gemma-4's 5.05 GiB B=8 peak); a model whose
+    /// measured peak sits far below it carries a floor of its own, so a
+    /// provider serving ONLY such models does not hold back memory sized for
+    /// a model it can never run. On the catalog's 24 GB gpt-oss tier that
+    /// difference is the whole margin: weights 13.5 + 5.5 + 1 = 20.0 GB
+    /// required exceeds what macOS can ever leave reclaimable on a 24 GB box,
+    /// while 13.5 + 3.5 + 1 = 18.0 fits — the flat default made that tier
+    /// show online and fail every request.
+    ///
+    /// Keyed by catalog model id, EXACT match only: a variant or new build id
+    /// without its own measurement falls back to the default — unmeasured
+    /// means unmeasured. Values cover the WORST measured execution path for
+    /// the model, eager or compiled, plus slack — the same basis the default
+    /// carries (gemma-4: max(5.05 eager, 5.34 compiled) → 5.5; gpt-oss-20b:
+    /// max(2.56 eager, 3.20 compiled) → 3.5), from the same sweep
+    /// (`libs/mlx-swift-lm/benchmarks/reports/`, `*-paged-gate-2026-07-09.md`,
+    /// run 2026-07-10; compiled figures are the `v2-compiled B=8`
+    /// peak-over-resident rows).
+    ///
+    /// Mirrored by coordinator/registry/servability.go
+    /// (`servabilityModelActivationFloorsGB` +
+    /// `servabilityPerModelFloorMinVersion`); the tables MUST move in the
+    /// same commit — see the doc comment on ``defaultActivationReserveBytes``.
+    static let measuredActivationFloorsBytes: [String: UInt64] = [
+        // Measured B=8 activation peak: 2.56 GiB eager, 3.20 GiB compiled
+        // (fused SDPA, head_dim 64). 3.5 = 3.20 + 0.30 slack.
+        "gpt-oss-20b": 7 * 1024 * 1024 * 1024 / 2
+    ]
+
+    /// The activation floor for a SERVING SET of models: the max of each
+    /// member's measured floor, with ``defaultActivationReserveBytes`` for any
+    /// unmeasured member — the reserve must cover every model that can run a
+    /// step, so a single unmeasured member pins the default. An EMPTY set is
+    /// an open world (no declared serving set) and takes the default.
+    static func activationFloorBytes(forModelIDs ids: [String]) -> UInt64 {
+        guard !ids.isEmpty else { return defaultActivationReserveBytes }
+        var floor: UInt64 = 0
+        for id in ids {
+            floor = max(floor, measuredActivationFloorsBytes[id] ?? defaultActivationReserveBytes)
+        }
+        return floor
+    }
+
     /// Minimum KV headroom (bytes) a freshly-loaded model must have under the cap
     /// to be worth loading — a model that loads but can serve no KV is useless.
     /// Small (1 GiB): the load gate only needs to guarantee the model can serve
@@ -121,11 +172,15 @@ public enum UnifiedMemoryCap {
     /// then rejects every request for (the load gate's old flat 2 GiB one-request
     /// headroom was LESS than the 3 GiB activation reserve, so a near-cap model
     /// loaded with zero serveable KV). Returns
-    /// `activationReserve + minimumLoadKV`.
+    /// `activationReserve + minimumLoadKV`. `modelIDs` is the serving set the
+    /// reserve must cover (see ``activationFloorBytes(forModelIDs:)``); nil
+    /// keeps the flat default.
     public static func loadHeadroomBytes(
-        activationReserveBytes: UInt64? = nil
+        activationReserveBytes: UInt64? = nil,
+        modelIDs: [String]? = nil
     ) -> UInt64 {
-        let activations = activationReserveBytes ?? resolvedActivationReserveBytes()
+        let activations =
+            activationReserveBytes ?? resolvedActivationReserveBytes(modelIDs: modelIDs)
         return saturatingAdd(activations, minimumLoadKVBytes)
     }
 
@@ -283,30 +338,36 @@ public enum UnifiedMemoryCap {
     }
 
     /// Activation reserve from explicit bytes, env
-    /// `DARKBLOOM_ACTIVATION_RESERVE_GB` (GB), or ``defaultActivationReserveBytes``.
+    /// `DARKBLOOM_ACTIVATION_RESERVE_GB` (GB), or the serving-set floor
+    /// (``activationFloorBytes(forModelIDs:)`` when `modelIDs` is given,
+    /// ``defaultActivationReserveBytes`` otherwise).
     ///
     /// The env override is RAISE-ONLY, enforced, not just documented: the
-    /// resolved value is `max(env, default)`. A value below the floor —
-    /// most likely a legacy `3` set when 3 GiB WAS the default — would
-    /// silently recreate the B=8 activation OOM the 5.5 GiB floor exists to
-    /// prevent, while the coordinator keeps predicting capacity with the
-    /// floor (`servability.go`). A `<= 0` or non-finite env value is
-    /// likewise treated as UNSET (→ the floor): a `0` reserve would remove
-    /// the activation headroom the cap exists to guarantee. An explicit
-    /// programmatic value (tests) is honored as given, below the floor
-    /// included — test fixtures legitimately model small boxes.
+    /// resolved value is `max(env, floor)` where the floor is the serving
+    /// set's. A value below the floor — most likely a legacy `3` set when
+    /// 3 GiB WAS the default — would silently recreate the B=8 activation
+    /// OOM the floor exists to prevent, while the coordinator keeps
+    /// predicting capacity with the floor (`servability.go`). A `<= 0` or
+    /// non-finite env value is likewise treated as UNSET (→ the floor): a
+    /// `0` reserve would remove the activation headroom the cap exists to
+    /// guarantee. An explicit programmatic value (tests) is honored as
+    /// given, below the floor included — test fixtures legitimately model
+    /// small boxes.
     static func resolvedActivationReserveBytes(
         explicit: UInt64? = nil,
-        env: [String: String] = ProcessInfo.processInfo.environment
+        env: [String: String] = ProcessInfo.processInfo.environment,
+        modelIDs: [String]? = nil
     ) -> UInt64 {
         if let explicit { return explicit }
+        let floor = modelIDs.map { activationFloorBytes(forModelIDs: $0) }
+            ?? defaultActivationReserveBytes
         if let raw = env["DARKBLOOM_ACTIVATION_RESERVE_GB"], let gb = Double(raw),
             gb.isFinite, gb > 0 {
             let scaled = gb * 1_073_741_824
             let bytes = scaled >= uint64MaxAsDouble ? UInt64.max : UInt64(scaled)
-            return max(bytes, defaultActivationReserveBytes)
+            return max(bytes, floor)
         }
-        return defaultActivationReserveBytes
+        return floor
     }
 
     // MARK: - Helpers

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+Capacity.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+Capacity.swift
@@ -100,6 +100,7 @@ extension ProviderLoop {
             let engineV2 = await engineV2Runtime.capacitySummary(
                 fleetKV: EngineV2Runtime.FleetKVContext(
                     totalResidentWeightBytes: totalResidentWeightBytes,
+                    activationReserveBytes: resolvedActivationReserveBytes,
                     configReserveBytes: Self.memoryReserveBytes(
                         forGiB: loopConfig.config.provider.memoryReserveGB),
                     physicalBytes: engineV2SlotHooks?.physicalMemoryBytes
@@ -140,6 +141,11 @@ extension ProviderLoop {
             systemAvailableBytes: SystemMemory.availableBytes() ?? .max,
             mlxUsedBytes: reclaimableMlx,
             reserveBytes: loadReserve,
+            // The serving set's resolved headroom (measured per-model floors),
+            // not the flat default — free_for_load_gb must mirror the load
+            // gate this box actually applies (ensureModelLoaded), or the
+            // coordinator's cold-load routing desyncs from it.
+            headroomGb: loadHeadroomGb,
             outstandingReservationBytes: outstandingKV)
         let reclaimer = kvBudget.cacheReclaimerTelemetrySnapshot()
         let reclaimerTelemetry = MLXCacheReclaimerTelemetry(

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+EngineV2.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+EngineV2.swift
@@ -166,6 +166,9 @@ extension ProviderLoop {
         return UnifiedMemoryCap.kvBudgetBytes(
             physicalBytes: physical,
             residentWeightBytes: totalWeights,
+            // The serving set's resolved reserve, so engine grants carve the
+            // same activation floor the load gate and runtime KV gate hold.
+            activationReserveBytes: resolvedActivationReserveBytes,
             configReserveBytes: Self.memoryReserveBytes(
                 forGiB: loopConfig.config.provider.memoryReserveGB))
     }

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+EngineV2Liveness.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+EngineV2Liveness.swift
@@ -224,7 +224,8 @@ extension ProviderLoop {
             MLX.Memory.clearCache()
             var postBuildServeable = KVHeadroomProbe.postBuildServeable(
                 kvBackendKind: newBridge.kvBackendKind,
-                pagedPoolBytes: await newBridge.kvBackendPoolBytes())
+                pagedPoolBytes: await newBridge.kvBackendPoolBytes(),
+                activationReserveBytes: resolvedActivationReserveBytes)
             // Scripted hook engines are not concrete EngineV2 instances and
             // cannot expose MTP metrics; their prepared bundle status is the
             // test seam's runtime truth. Production still requires live metrics.
@@ -264,7 +265,8 @@ extension ProviderLoop {
                 MLX.Memory.clearCache()
                 postBuildServeable = KVHeadroomProbe.postBuildServeable(
                     kvBackendKind: newBridge.kvBackendKind,
-                    pagedPoolBytes: await newBridge.kvBackendPoolBytes())
+                    pagedPoolBytes: await newBridge.kvBackendPoolBytes(),
+                    activationReserveBytes: resolvedActivationReserveBytes)
             }
             if !postBuildServeable {
                 await engineV2Runtime.unregister(modelId: modelId)

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+ModelLoading.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+ModelLoading.swift
@@ -322,7 +322,7 @@ extension ProviderLoop {
                 extraWeightBytes: 0)
             let requiredGb = ModelLoadAdmission.requiredToLoadGb(
                 weightsGb: targetWeightsGb,
-                headroomGb: Self.loadHeadroomGb)
+                headroomGb: loadHeadroomGb)
             do {
                 try await evictUntilAvailable(requiredGb: requiredGb, allowEviction: allowEviction)
             } catch let InferenceError.modelLoadFailed(message) {
@@ -474,10 +474,10 @@ extension ProviderLoop {
             // serveable model. Mirrors evictUntilAvailable / fastAdmissionReject's
             // clearCache-then-measure self-heal.
             MLX.Memory.clearCache()
-            if !KVHeadroomProbe.hasServeableKVHeadroom() {
+            if !KVHeadroomProbe.hasServeableKVHeadroom(activationReserveBytes: resolvedActivationReserveBytes) {
                 let headroomGb = String(
                     format: "%.1f",
-                    Double(KVHeadroomProbe.measuredLiveKVHeadroomBytes) / (1024.0 * 1024.0 * 1024.0))
+                    Double(KVHeadroomProbe.measuredLiveKVHeadroomBytes(activationReserveBytes: resolvedActivationReserveBytes)) / (1024.0 * 1024.0 * 1024.0))
                 let minGb = String(
                     format: "%.1f", Double(UnifiedMemoryCap.minimumLoadKVBytes) / (1024.0 * 1024.0 * 1024.0))
                 // Pre-shrink failure: no grants were mutated, so ordering is
@@ -579,7 +579,8 @@ extension ProviderLoop {
             MLX.Memory.clearCache()
             var postBridgeServeable = KVHeadroomProbe.postBuildServeable(
                 kvBackendKind: engineV2Bridge.kvBackendKind,
-                pagedPoolBytes: await engineV2Bridge.kvBackendPoolBytes())
+                pagedPoolBytes: await engineV2Bridge.kvBackendPoolBytes(),
+                activationReserveBytes: resolvedActivationReserveBytes)
             let runtimeMTPActive = await engineV2Bridge.mtpStatusSnapshot().active
             if engineBundle.mtpStatus.active,
                 !postBridgeServeable || !runtimeMTPActive
@@ -620,12 +621,13 @@ extension ProviderLoop {
                 MLX.Memory.clearCache()
                 postBridgeServeable = KVHeadroomProbe.postBuildServeable(
                     kvBackendKind: engineV2Bridge.kvBackendKind,
-                    pagedPoolBytes: await engineV2Bridge.kvBackendPoolBytes())
+                    pagedPoolBytes: await engineV2Bridge.kvBackendPoolBytes(),
+                    activationReserveBytes: resolvedActivationReserveBytes)
             }
             if !postBridgeServeable {
                 let headroomGb = String(
                     format: "%.1f",
-                    Double(KVHeadroomProbe.measuredLiveKVHeadroomBytes) / (1024.0 * 1024.0 * 1024.0))
+                    Double(KVHeadroomProbe.measuredLiveKVHeadroomBytes(activationReserveBytes: resolvedActivationReserveBytes)) / (1024.0 * 1024.0 * 1024.0))
                 // Retire the bridge, release the newcomer's weights, THEN
                 // regrow survivors — in that order (Codex review): regrowing
                 // while the aborted newcomer's weights are still resident
@@ -762,6 +764,10 @@ extension ProviderLoop {
         // load-admission counts as used — without this the box 503s every load
         // until restart.
         MLX.Memory.clearCache()
+        // The unloaded model can no longer run a step: the serving-set floor
+        // (advertised ∪ resident) may relax now — BEFORE the survivors regrow,
+        // so their new grants are sized against the reserve they'll live under.
+        await refreshActivationReserve()
         // Re-slice GROW the survivors: with this model's weights gone the
         // fleet KV budget rises, and the remaining engines take their new
         // fair shares (a lone survivor gets the FULL budget back).
@@ -846,13 +852,42 @@ extension ProviderLoop {
             outstandingReservationBytes: outstanding)
     }
 
+    /// The activation reserve resolved for the CURRENT serving set —
+    /// advertised models UNION resident slots (measured per-model floors, env
+    /// raise-only above them —
+    /// `UnifiedMemoryCap.resolvedActivationReserveBytes(modelIDs:)`).
+    /// Computed live so a prefetch-advertised build raises it the moment the
+    /// build joins the set. Resident slots are included because a
+    /// hard-swapped build leaves `advertisedModels` while its slot keeps
+    /// serving in-flight decodes (the lazy drop) — the reserve must keep
+    /// covering every model that can still run a step, so the relax lands
+    /// only after the retired slot actually unloads.
+    var resolvedActivationReserveBytes: UInt64 {
+        UnifiedMemoryCap.resolvedActivationReserveBytes(
+            modelIDs: Array(advertisedModels.keys) + Array(modelSlots.keys))
+    }
+
     /// Headroom (GB) reserved above the weights at load time. Must be at least
     /// the runtime activation reserve + a minimum serveable KV, or the gate would
     /// admit a near-cap model that GlobalKVCacheBudget then rejects every request
     /// for (the old flat 2 GiB was LESS than the 3 GiB activation reserve). Sized
-    /// from UnifiedMemoryCap so the load gate and the runtime KV path agree.
-    static let loadHeadroomGb =
-        Double(UnifiedMemoryCap.loadHeadroomBytes()) / (1024.0 * 1024.0 * 1024.0)
+    /// from UnifiedMemoryCap — including the serving set's measured per-model
+    /// floor — so the load gate and the runtime KV path agree. Computed, not
+    /// stored: the advertised set can change at runtime.
+    var loadHeadroomGb: Double {
+        Double(UnifiedMemoryCap.loadHeadroomBytes(
+            activationReserveBytes: resolvedActivationReserveBytes))
+            / (1024.0 * 1024.0 * 1024.0)
+    }
+
+    /// Push the reserve resolved for the CURRENT advertised set into the KV
+    /// budget actor. Call after every advertised-set mutation — for an ADD,
+    /// before the new model can be loaded, so its decode steps never run
+    /// against a reserve resolved without it; for a removal it lets the
+    /// reserve relax back to the remaining set's floor.
+    func refreshActivationReserve() async {
+        await kvBudget.setActivationReserveBytes(resolvedActivationReserveBytes)
+    }
 
     private static func saturatingAdd(_ values: UInt64...) -> UInt64 {
         var total: UInt64 = 0
@@ -932,7 +967,7 @@ extension ProviderLoop {
         // preparation (and any prefetch) itself.
         let requiredGb = ModelLoadAdmission.requiredToLoadGb(
             weightsGb: modelInfo.estimatedMemoryGb,
-            headroomGb: Self.loadHeadroomGb)
+            headroomGb: loadHeadroomGb)
 
         // Sample live memory FIRST — this is the only suspension point in the
         // method (it awaits the KV-budget actor). Reading all the actor-local

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+Prefetch.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+Prefetch.swift
@@ -213,10 +213,24 @@ extension ProviderLoop {
         // build can be held resident alongside the model currently being served
         // during a zero-downtime migration -- bounded by the configured hard
         // cap (`configuredMaxModelSlots`).
+        // Raise the runtime KV reserve for the grown serving set BEFORE the
+        // build joins `advertisedModels` (and so before it is announced or
+        // loadable) — a decode step of the new model must never run against a
+        // reserve resolved without it.
+        await kvBudget.setActivationReserveBytes(
+            UnifiedMemoryCap.resolvedActivationReserveBytes(
+                modelIDs: Array(advertisedModels.keys) + Array(modelSlots.keys) + [modelId]))
         advertisedModels[modelId] = info
         modelHashes[modelId] = hash
         liveModelHashes[modelId] = hash
         syncWarmModelState()
+        // Re-refresh AFTER the insert too: a concurrent refresh (idle unload,
+        // retire) interleaving in the pre-insert await computed WITHOUT the
+        // incoming id and could land last — this post-insert refresh, now
+        // resolving over the set that includes it, makes the final value
+        // authoritative either way (the pre-insert push handles raise-early,
+        // this one handles lost-update).
+        await refreshActivationReserve()
         logger.info("Prefetch verified \(modelId) (weight_hash=\(hash.prefix(16))); advertising (\(advertisedModels.count) model(s) total)")
         if let coordinatorClient {
             await coordinatorClient.updateModelWeightHashes(liveModelHashes)
@@ -249,6 +263,9 @@ extension ProviderLoop {
         modelHashes.removeValue(forKey: buildID)
         await coordinatorClient?.unadvertiseModel(buildID)
         syncWarmModelState()
+        // The shrunken set may carry a lower measured floor; let the runtime
+        // KV budget relax to it. (Raising happened on the add side.)
+        await refreshActivationReserve()
         logger.info("Hard swap: dropped superseded build \(buildID) from advertised set (\(advertisedModels.count) remaining)")
     }
 

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+StartupPreload.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+StartupPreload.swift
@@ -140,7 +140,7 @@ extension ProviderLoop {
                     modelId: id,
                     requiredGb: ModelLoadAdmission.requiredToLoadGb(
                         weightsGb: info.estimatedMemoryGb,
-                        headroomGb: Self.loadHeadroomGb)))
+                        headroomGb: loadHeadroomGb)))
         }
         return plan
     }
@@ -301,6 +301,9 @@ extension ProviderLoop {
     private func retireModelAfterFailedSelfTest(modelId: String) async {
         await unloadModel(modelId)
         advertisedModels.removeValue(forKey: modelId)
+        // The shrunken set may carry a lower measured activation floor; let
+        // the runtime KV budget relax to it.
+        await refreshActivationReserve()
         if let client = coordinatorClient {
             await client.unadvertiseModel(modelId)
             await client.forceReconnect()

--- a/provider-swift/Sources/ProviderCore/ProviderLoop.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop.swift
@@ -536,7 +536,13 @@ public actor ProviderLoop {
         // (loadReserveBytes = max(configReserve, physical − cap)) — so runtime KV
         // can't grow into memory the operator explicitly reserved once a model is
         // loaded. No-op when the configured reserve is ≤ the cap's implied reserve.
+        // The activation reserve is resolved for the advertised serving set
+        // (measured per-model floors; env raise-only above them) and re-pushed
+        // via refreshActivationReserve() whenever that set changes, so the
+        // runtime KV gate and the load gate always carve the same reserve.
         self.kvBudget = GlobalKVCacheBudget(
+            activationReserveBytes: UnifiedMemoryCap.resolvedActivationReserveBytes(
+                modelIDs: Array(advertised.keys)),
             configReserveBytes: Self.memoryReserveBytes(forGiB: config.config.provider.memoryReserveGB))
         // Sweep only the retired checkpoint tier's `darkbloom/kv` directory.
         // The EngineV2 SSD tier uses the separate `darkbloom/kv3` root,
@@ -548,6 +554,18 @@ public actor ProviderLoop {
         self.liveModelHashes = config.modelHashes
         self.modelHashFingerprints = config.modelHashFingerprints
         // Phase-1 complete — safe to touch self.logger now.
+        // Operator-visible record of the resolved floor: on a measured-only
+        // set this is the model's measured floor; ANY unmeasured id (a new
+        // build id included — exact match only) pins the flat default, which
+        // on small boxes is the difference between serving and not.
+        logger.info(
+            "Activation reserve resolved to "
+                + String(
+                    format: "%.1f",
+                    Double(
+                        UnifiedMemoryCap.resolvedActivationReserveBytes(
+                            modelIDs: Array(advertised.keys))) / (1024.0 * 1024.0 * 1024.0))
+                + " GiB for serving set [\(advertised.keys.sorted().joined(separator: ", "))]")
         if !unsupportedModelIds.isEmpty {
             logger.warning(
                 "Not advertising \(unsupportedModelIds.count) model(s) without a CBv2 adapter "

--- a/provider-swift/Sources/ProviderCore/Server/StandaloneServer.swift
+++ b/provider-swift/Sources/ProviderCore/Server/StandaloneServer.swift
@@ -1375,7 +1375,7 @@ public actor StandaloneServer {
             if !KVHeadroomProbe.hasServeableKVHeadroom() {
                 let headroomGb = String(
                     format: "%.1f",
-                    Double(KVHeadroomProbe.measuredLiveKVHeadroomBytes) / (1024.0 * 1024.0 * 1024.0))
+                    Double(KVHeadroomProbe.measuredLiveKVHeadroomBytes()) / (1024.0 * 1024.0 * 1024.0))
                 let minGb = String(
                     format: "%.1f", Double(UnifiedMemoryCap.minimumLoadKVBytes) / (1024.0 * 1024.0 * 1024.0))
                 // Pre-shrink failure: no grants were mutated, so ordering is
@@ -1468,7 +1468,7 @@ public actor StandaloneServer {
             if !postBridgeServeable {
                 let headroomGb = String(
                     format: "%.1f",
-                    Double(KVHeadroomProbe.measuredLiveKVHeadroomBytes) / (1024.0 * 1024.0 * 1024.0))
+                    Double(KVHeadroomProbe.measuredLiveKVHeadroomBytes()) / (1024.0 * 1024.0 * 1024.0))
                 // Retire the bridge, release the newcomer's weights, THEN
                 // regrow survivors — in that order (Codex review): regrowing
                 // while the aborted newcomer's weights are still resident

--- a/provider-swift/Sources/darkbloom/Diagnostics/DoctorRunner.swift
+++ b/provider-swift/Sources/darkbloom/Diagnostics/DoctorRunner.swift
@@ -107,10 +107,22 @@ enum DoctorRunner {
             let alternatives = allModels.map {
                 ModelFitDiagnostic.ModelOption(id: $0.id, weightGb: $0.estimatedMemoryGb)
             }
+            // The daemon's load gate holds the max activation floor over its
+            // WHOLE serving set (scan ∩ enabled_models; everything scanned
+            // when the filter is empty) — mirror that basis so this verdict
+            // cannot pass a target the daemon would still gate at a larger
+            // co-enabled model's floor. Alternatives keep their solo floors:
+            // each models `enabled_models = [candidate]`.
+            let enabled = snapshot.config.backend.enabledModels
+            let servingSetIDs: [String] =
+                enabled.isEmpty
+                ? allModels.map(\.id)
+                : allModels.map(\.id).filter(enabled.contains)
             if let targetID, let target = allModels.first(where: { $0.id == targetID }) {
                 out.append(ModelFitDiagnostic.diagnose(
                     modelID: targetID, weightGb: target.estimatedMemoryGb,
-                    usableGb: usableGb, alternatives: alternatives))
+                    usableGb: usableGb, alternatives: alternatives,
+                    servingSetIDs: servingSetIDs.isEmpty ? nil : servingSetIDs))
             } else if !alternatives.isEmpty {
                 // No specific/known target; check the largest local model fits.
                 if let biggest = alternatives.max(by: { $0.weightGb < $1.weightGb }) {

--- a/provider-swift/Tests/ProviderCoreTests/DiagnosticsTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/DiagnosticsTests.swift
@@ -571,3 +571,54 @@ struct DesiredModelsForPostureTests {
     #expect(WarmModelsFormat.mostRecentlyUsedLabel == "Most recently used")
     #expect(WarmModelsFormat.mostRecentlyUsedLabel != "Current model")
 }
+
+@Test func modelFitRequiredUsesPerModelActivationFloor() {
+    // gpt-oss-20b: padded weights 13.5 + (3.5 GiB measured floor + 1 GiB min
+    // serveable KV) = 18.0 — NOT 13.5 + 6.5 = 20.0 sized off gemma-4's B=8
+    // peak. The flat floor made every 24 GB catalog-tier box unserveable
+    // (#653): usable ≥ 20 GB needs ~22.7 GiB reclaimable out of 24.
+    #expect(abs(
+        ModelFitDiagnostic.requiredGb(estimatedMemoryGb: 13.5, modelID: "gpt-oss-20b") - 18.0)
+        < 0.01)
+    // Unmeasured model keeps the flat default: 28 + 6.5 = 34.5.
+    #expect(abs(
+        ModelFitDiagnostic.requiredGb(estimatedMemoryGb: 28.0, modelID: "gemma-4-26b") - 34.5)
+        < 0.01)
+    // No id → flat default (regression): 13.5 + 6.5 = 20.0.
+    #expect(abs(ModelFitDiagnostic.requiredGb(estimatedMemoryGb: 13.5) - 20.0) < 0.01)
+}
+
+@Test func modelFitVerdictReflectsPerModelFloor() {
+    // The #653 repro shape: 24 GB box, ~18.5 GB usable headless, gpt-oss-20b
+    // padded 13.53. Flat floor demanded 20.0 → permanent fail; the measured
+    // floor needs 18.03 → pass.
+    let d = ModelFitDiagnostic.diagnose(modelID: "gpt-oss-20b", weightGb: 13.53, usableGb: 18.5)
+    #expect(d.level == .pass)
+    // An unmeasured model on the same box still fails (25 + 6.5 = 31.5 > 18.5)
+    // AND the alternatives suggestion evaluates each candidate with ITS OWN
+    // floor — the suggestion models what enabled_models = [candidate] would do.
+    let alt = ModelFitDiagnostic.diagnose(
+        modelID: "gemma-4-26b", weightGb: 25.0, usableGb: 18.5,
+        alternatives: [.init(id: "gpt-oss-20b", weightGb: 13.53)])
+    #expect(alt.level == .fail)
+    #expect(alt.fix?.contains("gpt-oss-20b") == true)
+    #expect(alt.fix?.contains("18.0") == true)
+}
+
+@Test func modelFitVerdictUsesTheServingSetFloorNotTheTargetsOwn() {
+    // A multi-model box: enabled_models = [gpt-oss-20b, gemma-4-26b]. The
+    // daemon's load gate carves the max floor over the WHOLE set (6.5 GiB
+    // headroom), so gpt-oss needs 13.53 + 6.5 = 20.03 on this box even
+    // though its solo requirement is 18.03 — the verdict must say FAIL, not
+    // the false PASS a target-only floor would print (the doctor promise:
+    // never drift from what the daemon enforces).
+    let d = ModelFitDiagnostic.diagnose(
+        modelID: "gpt-oss-20b", weightGb: 13.53, usableGb: 18.5,
+        servingSetIDs: ["gpt-oss-20b", "gemma-4-26b"])
+    #expect(d.level == .fail)
+    // Same target, single-model set: back to the solo floor → pass.
+    let solo = ModelFitDiagnostic.diagnose(
+        modelID: "gpt-oss-20b", weightGb: 13.53, usableGb: 18.5,
+        servingSetIDs: ["gpt-oss-20b"])
+    #expect(solo.level == .pass)
+}

--- a/provider-swift/Tests/ProviderCoreTests/EngineV2ProductionWiringTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/EngineV2ProductionWiringTests.swift
@@ -982,9 +982,16 @@ struct EngineV2ReslicingWiringTests {
         // paged neighbour, whose identical regrow clamps to pool truth — it
         // takes every byte.
         await loop.unloadModel("gemma-4-26b-qat-4bit")
+        // With the unmeasured gemma gone, the surviving set is {gpt-oss-20b}
+        // and the activation reserve relaxes to its measured floor
+        // (unloadModel refreshes BEFORE the regrow) — the survivor's regrow
+        // is sized against that relaxed reserve, gaining the difference over
+        // the flat default.
         let regrowB = UnifiedMemoryCap.kvBudgetBytes(
             physicalBytes: wiringPhysicalBytes,
             residentWeightBytes: UInt64(sizingB.weightsBytes),
+            activationReserveBytes: UnifiedMemoryCap.resolvedActivationReserveBytes(
+                modelIDs: ["gpt-oss-20b"]),
             configReserveBytes: wiringReserveBytes)
         #expect(regrowB > UInt64(targetB))
         #expect(engineB.capacityUpdates.last == Int(regrowB))

--- a/provider-swift/Tests/ProviderCoreTests/GlobalKVCacheBudgetTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/GlobalKVCacheBudgetTests.swift
@@ -369,3 +369,25 @@ private func makeAuditBudget(
 
     #expect(log.operations().isEmpty, "audit fired despite interleaved successful commits")
 }
+
+@Test func globalKVCacheBudgetHonorsAReplacedActivationReserve() async {
+    // The serving set changes at runtime (prefetch advertises a build, a
+    // retired slot unloads) and ProviderLoop re-pushes the resolved reserve
+    // via setActivationReserveBytes — admission must follow the CURRENT
+    // value, not the construction-time one.
+    //
+    // 8 GiB box, capFraction 1.0 → hardCap = 8 − 2 (OS floor) = 6 GiB.
+    // With the flat 5.5 GiB reserve, headroom = 0.5 GiB → a 1 GiB
+    // reservation rejects. After the reserve relaxes to the measured
+    // 3.5 GiB floor, headroom = 2.5 GiB → the same reservation admits;
+    // raising it back to 5.5 rejects again.
+    let budget = GlobalKVCacheBudget(capFraction: 1.0, activationReserveBytes: 11 * gib / 2) {
+        GlobalKVCacheBudget.MemorySnapshot(total: 8 * gib, active: 0, cache: 0, systemAvailable: .max)
+    }
+    #expect(!(await budget.reserve(requestID: "a", kvBytesPerToken: Int(gib), tokenCount: 1)))
+    await budget.setActivationReserveBytes(7 * gib / 2)
+    #expect(await budget.reserve(requestID: "a", kvBytesPerToken: Int(gib), tokenCount: 1))
+    await budget.release(requestID: "a")
+    await budget.setActivationReserveBytes(11 * gib / 2)
+    #expect(!(await budget.reserve(requestID: "a", kvBytesPerToken: Int(gib), tokenCount: 1)))
+}

--- a/provider-swift/Tests/ProviderCoreTests/UnifiedMemoryCapTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/UnifiedMemoryCapTests.swift
@@ -440,3 +440,67 @@ private let gib: UInt64 = 1024 * 1024 * 1024
         physicalBytes: 128 * gib, currentResidentWeightBytes: .max,
         candidateWeightBytes: .max, minimumKVBytes: .max, activationReserveBytes: .max))
 }
+
+// MARK: - Per-model activation floors (measured table)
+
+@Test func activationFloorUsesMeasuredValueForSingleMeasuredModel() {
+    // gpt-oss-20b's worst measured B=8 activation peak is 3.20 GiB compiled
+    // (2.56 eager; same sweep that sized the 5.5 GiB default off gemma-4's
+    // 5.05/5.34); its floor is 3.5 GiB = 3.20 + slack.
+    #expect(
+        UnifiedMemoryCap.activationFloorBytes(forModelIDs: ["gpt-oss-20b"]) == 7 * gib / 2)
+}
+
+@Test func activationFloorFallsBackToDefaultForUnmeasuredModels() {
+    let def = UnifiedMemoryCap.defaultActivationReserveBytes
+    // Unmeasured model → the flat default.
+    #expect(UnifiedMemoryCap.activationFloorBytes(forModelIDs: ["gemma-4-26b"]) == def)
+    // Empty set = open world (no declared serving set) → the flat default.
+    #expect(UnifiedMemoryCap.activationFloorBytes(forModelIDs: []) == def)
+    // A set containing ANY unmeasured model takes the max — the reserve must
+    // cover every model that can run, so one unmeasured member pins the default.
+    #expect(
+        UnifiedMemoryCap.activationFloorBytes(forModelIDs: ["gpt-oss-20b", "gemma-4-26b"]) == def)
+}
+
+@Test func resolvedReserveUsesModelSetFloor() {
+    // Single measured model → its measured floor, not the flat default.
+    #expect(UnifiedMemoryCap.resolvedActivationReserveBytes(
+        explicit: nil, env: [:], modelIDs: ["gpt-oss-20b"]) == 7 * gib / 2)
+    // nil modelIDs → the pre-existing flat behavior (regression).
+    #expect(UnifiedMemoryCap.resolvedActivationReserveBytes(explicit: nil, env: [:])
+        == UnifiedMemoryCap.defaultActivationReserveBytes)
+}
+
+@Test func envReserveIsRaiseOnlyAgainstTheModelSetFloor() {
+    // env 2 < the 3.5 GiB gpt-oss floor → the floor wins. Raise-only holds for
+    // the SET floor for the same reason it holds for the flat default: a stale
+    // low env value must not silently recreate the B=8 activation OOM.
+    #expect(UnifiedMemoryCap.resolvedActivationReserveBytes(
+        explicit: nil, env: ["DARKBLOOM_ACTIVATION_RESERVE_GB": "2"],
+        modelIDs: ["gpt-oss-20b"]) == 7 * gib / 2)
+    // env 4 > the 3.5 GiB floor → env wins for the measured set…
+    #expect(UnifiedMemoryCap.resolvedActivationReserveBytes(
+        explicit: nil, env: ["DARKBLOOM_ACTIVATION_RESERVE_GB": "4"],
+        modelIDs: ["gpt-oss-20b"]) == 4 * gib)
+    // …while the SAME env value still cannot dip below the default for an
+    // unmeasured set (unchanged raise-only semantics there).
+    #expect(UnifiedMemoryCap.resolvedActivationReserveBytes(
+        explicit: nil, env: ["DARKBLOOM_ACTIVATION_RESERVE_GB": "4"],
+        modelIDs: ["gemma-4-26b"]) == UnifiedMemoryCap.defaultActivationReserveBytes)
+    // Explicit (tests) still beats everything, below the floor included.
+    #expect(UnifiedMemoryCap.resolvedActivationReserveBytes(
+        explicit: 1 * gib, env: [:], modelIDs: ["gpt-oss-20b"]) == 1 * gib)
+}
+
+@Test func loadHeadroomUsesModelSetFloor() {
+    // gpt-oss-only serving set: headroom = 3.5 GiB floor + 1 GiB min
+    // serveable KV = 4.5 GiB — down from the flat 5.5 + 1 = 6.5 GiB that made
+    // the catalog's own 24 GB tier unserveable (needs 13.5 + 6.5 = 20.0 GB
+    // while macOS can never leave that much reclaimable).
+    #expect(UnifiedMemoryCap.loadHeadroomBytes(modelIDs: ["gpt-oss-20b"])
+        == 7 * gib / 2 + UnifiedMemoryCap.minimumLoadKVBytes)
+    // No model context → the flat default (regression).
+    #expect(UnifiedMemoryCap.loadHeadroomBytes()
+        == UnifiedMemoryCap.defaultActivationReserveBytes + UnifiedMemoryCap.minimumLoadKVBytes)
+}


### PR DESCRIPTION
## Summary

Fixes #653: the flat 5.5 GiB activation reserve — sized against gemma-4-26b's measured B=8 peak — is charged to every model, including gpt-oss-20b whose worst measured B=8 peak is **3.20 GiB** (compiled; 2.56 eager — same sweep, `*-paged-gate-2026-07-09.md`). On the catalog's own `min_ram_gb: 24` tier that difference is the whole margin: `needs = 13.5 (padded weights) + 5.5 (reserve) + 1.0 (min KV) = 20.0 GB` requires ~22.7 GiB reclaimable out of 24 — below the macOS floor — so every 24 GB box **shows online and 429s every request, permanently** (verified live on an M4 Pro 24 GB: HTTP 429 in ~13 ms with `trust=hardware/online`; measurements in [the #653 corroboration comment](https://github.com/Layr-Labs/d-inference/issues/653#issuecomment-5384189907)).

The reserve stays **measurement-driven and raise-only** — both documented rationales survive — but resolves per serving set instead of one-size-fits-worst-model:

- `UnifiedMemoryCap.measuredActivationFloorsBytes`: measured per-model floors, catalog-id keyed, exact match only (`gpt-oss-20b: 3.5 GiB` = worst measured B=8 peak 3.20 compiled + 0.30 slack; the default's own basis covers gemma's 5.05 eager / 5.34 compiled). A serving set takes the **max** over members; any unmeasured member pins the flat 5.5 default.
- `DARKBLOOM_ACTIVATION_RESERVE_GB` stays **raise-only against the resolved floor** — the stale-legacy-`3` OOM scenario from the doc comment still cannot happen.
- The resolved reserve flows to **every** consumer in lockstep, so neither direction of the admit-then-reject trap can open:
  - load gate + startup preload + doctor (`ProviderLoop.loadHeadroomGb`, computed over the live set),
  - the **measured post-load / post-bridge serveability guards** (`KVHeadroomProbe` gains `activationReserveBytes`; without this the probe would unload the freshly-loaded model against the flat reserve — churn instead of serving),
  - `free_for_load_gb` reporting (`ProviderLoop+Capacity`),
  - runtime KV admission (`GlobalKVCacheBudget` gains an actor setter; re-pushed on every serving-set mutation),
  - **engine KV grants and the heartbeat budget clamp** (`fleetKVBudgetBytes`, `EngineV2KVSizing`, `FleetKVContext`) so `active_token_budget_max` warm reports converge with the coordinator's cold estimate.
- The floor resolves over **advertised ∪ resident** models: a hard-swapped build that leaves `advertisedModels` but is still draining decodes keeps pinning its floor until it actually unloads (`unloadModel` refreshes before survivors regrow); prefetch pushes the grown set's floor **before** the new build becomes advertised/loadable.
- Doctor's per-model verdict uses the box's **actual serving-set floor** (scan ∩ `enabled_models`), so it cannot print a PASS the daemon would still gate; the "alternatives that fit" suggestions keep each candidate's solo floor (they model `enabled_models = [candidate]`).
- Coordinator mirror (`servability.go`): `servabilityModelActivationFloorsGB` + a third version regime in `servabilityActivationFloor(version, modelID)`, following the staged-rollout shape the 3.0→5.5 move established. Per the file's "Mirroring, not modelling" note this is still a mirror; for a multi-model provider the per-model figure is a lower bound (optimistic — the sanctioned fail-open direction; warm reports take over as slots load).

**Effect on the 24 GB tier**: `needs` drops 20.0 → 18.0 GB. Headless steady-state usable measures ~16–18 GB on the repro box — tight but genuinely reachable, instead of arithmetically impossible. 32 GB boxes (#653's report) clear it comfortably.

## Scope and known limitations (deliberate, flagged for maintainers)

- **Build-id expiry**: floors are exact-match by catalog id. A hot-swapped build id (`gpt-oss-20b--r2`-style) misses both tables **in lockstep** (no cold/warm desync; the tier reverts to the flat default until the new build is measured). Documented in both tables; the provider logs the resolved floor + serving set at startup so operators can see it. A family mapping was deliberately not added — unmeasured means unmeasured.
- **Release coupling**: `servabilityPerModelFloorMinVersion = "0.8.11"` is a placeholder; the release shipping the provider half must be numbered exactly that (or the constant updated in the release commit). Note `CompareVersions` parses non-numeric segments as 0, so the shipped version constant must not carry a `-swift.N`-style suffix or the coordinator will charge the flat floor against a per-model binary (the unsanctioned tighter direction).
- **StandaloneServer (`--local` mode) keeps the flat default throughout** (its served set is operator-mutable at runtime via `setModels`, and it is not the fleet path); `EngineV2Factory+Production`'s paged pool sizing also keeps the flat probe default — conservative direction (smaller pool or contiguous fallback, never an OOM).

## Before / After

```mermaid
flowchart TB
  subgraph Before
    A1[request for gpt-oss-20b] --> B1["load gate: needs = weights 13.5 + FLAT 5.5 + 1.0 = 20.0 GB"]
    B1 --> C1{"usable ≥ 20.0?<br/>(24 GB box: max ~18)"}
    C1 -- never --> D1[429 capacity unavailable<br/>box online, serves nothing]
  end
  subgraph After
    A2[request for gpt-oss-20b] --> B2["load gate: needs = weights 13.5 + measured floor 3.5 + 1.0 = 18.0 GB"]
    B2 --> C2{"usable ≥ 18.0?"}
    C2 -- yes --> E2["model loads; post-load probe, KV grants,<br/>and runtime gate all carve the SAME 3.5"]
    C2 -- no --> D2[429 — genuinely out of memory]
  end
```

```mermaid
flowchart TB
  subgraph Code_Before["Code (before)"]
    F1["UnifiedMemoryCap.resolvedActivationReserveBytes()<br/>= max(env, flat 5.5)"] --> G1["loadHeadroomBytes()"]
    F1 --> H1["GlobalKVCacheBudget (nil → flat)"]
    F1 --> P1["KVHeadroomProbe (flat)"]
    F1 --> Q1["fleetKVBudgetBytes / EngineV2KVSizing (flat)"]
    G1 --> I1["ProviderLoop static loadHeadroomGb<br/>(baked at first use)"]
    J1["servabilityActivationFloorForVersion(version)<br/>3.0 | 5.5"] --> K1[coldTokenBudgetEstimate]
  end
  subgraph Code_After["Code (after)"]
    F2["measuredActivationFloorsBytes table<br/>+ activationFloorBytes(forModelIDs:)"] --> G2["resolvedActivationReserveBytes(modelIDs:)<br/>= max(env, set floor)"]
    G2 --> H2["ProviderLoop computed loadHeadroomGb /<br/>resolvedActivationReserveBytes<br/>(live advertised ∪ resident)"]
    H2 --> I2["GlobalKVCacheBudget.setActivationReserveBytes<br/>(pre-insert on prefetch; pre-regrow on unload)"]
    H2 --> P2["KVHeadroomProbe(activationReserveBytes:)<br/>post-load + post-bridge guards"]
    H2 --> Q2["fleetKVBudgetBytes / EngineV2KVSizing /<br/>FleetKVContext → grants + heartbeat clamp"]
    G2 --> L2["ModelFitDiagnostic.diagnose(servingSetIDs:)<br/>doctor verdict = daemon's floor;<br/>alternatives keep solo floors"]
    J2["servabilityActivationFloor(version, modelID)<br/>3.0 | 5.5 | table[model] ?? 5.5"] --> K2[coldTokenBudgetEstimate + snap.model]
  end
```

## Test plan

- `provider-swift`: `swift test` — **2162 tests / 223 suites green.** New tests pin: the floor table and max-over-set semantics, raise-only env against the set floor, `loadHeadroomBytes(modelIDs:)`, the doctor's 20.0→18.0 arithmetic and the 24 GB repro verdict flipping FAIL→PASS, the multi-model false-PASS regression (serving-set floor), per-alternative floors in the fix suggestion, and `GlobalKVCacheBudget.setActivationReserveBytes` flipping admission. One pre-existing re-slice wiring test's regrow expectation was updated to model the new relax-on-unload behavior (survivor regrows against the relaxed floor).
- `coordinator`: `go test ./...` — all packages green, `gofmt` clean. New tests pin all three version regimes of `servabilityActivationFloor` and the per-model cold-estimate goldens (109223 vs 103854 on the canonical roomy node); existing goldens unchanged (pre-per-model versions resolve identically for any model).
- Live repro data (24 GB M4 Pro, 0.8.10): doctor `needs ~20.0 / usable 14.5–16.1`; local-endpoint completion → HTTP 429 in 13 ms with trust online; `models list` EST MEM 13.5 for the same model. Logs uploaded via `darkbloom report` (2026-08-23).

Closes #653. Related: #675 (the surfaces-disagree side — `status` "Inference memory" is untouched here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/683"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790055755&installation_model_id=21733&pr_number=683&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F683&signature=1bb65cabb8581ba7b51a8c9565fdaad5f701921c53c04b8450af205cb6587b1a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->