### PR TITLE
fix(provider): drain work before lifecycle actions

### DIFF
--- a/provider-swift/Sources/ProviderCore/ProviderLoop+AutoUpdate.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+AutoUpdate.swift
@@ -159,7 +159,7 @@ extension ProviderLoop {
     /// enter the `.installing` phase — still serving while the new bundle
     /// downloads and stages.
     private func claimUpdateStart(updater: SelfUpdater) -> Bool {
-        guard updatePhase == .idle, !isShuttingDown else { return false }
+        guard updatePhase == .idle, !isShuttingDown, !isOperatorDraining else { return false }
         do {
             let session = try updater.beginUpdateSession(
                 operation: "background-auto-update",
@@ -194,12 +194,17 @@ extension ProviderLoop {
         updateSession?.release()
         updateSession = nil
 
-        if let entries = deferredDesiredModels {
-            deferredDesiredModels = nil
-            if let send = outboundSend {
-                logger.info("Replaying desired_models deferred during update drain (\(entries.count) entr(ies))")
-                await reconcileDesiredModels(entries, send: send)
-            }
+        await replayDeferredDesiredModels(after: "update drain")
+    }
+
+    /// Restore the latest declarative model plan after any drain that returns
+    /// to serving. Both update and operator drains share this queue.
+    internal func replayDeferredDesiredModels(after drain: String) async {
+        guard let entries = deferredDesiredModels else { return }
+        deferredDesiredModels = nil
+        if let send = outboundSend {
+            logger.info("Replaying desired_models deferred during \(drain) (\(entries.count) entr(ies))")
+            await reconcileDesiredModels(entries, send: send)
         }
     }
 

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+InferenceHandler.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+InferenceHandler.swift
@@ -31,6 +31,9 @@ extension ProviderLoop {
     /// synchronous + actor-isolated, so the authoritative call is atomic with the
     /// registration that follows (no suspension in between).
     internal var isDrainingForUpdate: Bool { updatePhase == .draining }
+    internal var isDrainingForLifecycle: Bool {
+        isDrainingForUpdate || isOperatorDraining
+    }
 
     /// Coordinator admission: sends the 503 reroute and returns true if the
     /// request must be dropped because we're draining.
@@ -39,7 +42,7 @@ extension ProviderLoop {
         send: SendHandle,
         lookupReceiptFinalizer: PrefixCacheLookupReceiptFinalizer
     ) -> Bool {
-        guard isDrainingForUpdate else { return false }
+        guard isDrainingForLifecycle else { return false }
         lookupReceiptFinalizer.sendTerminal(
             .inferenceError(
                 requestId: requestId,
@@ -59,7 +62,7 @@ extension ProviderLoop {
         if isShuttingDown {
             throw MultiModelBatchSchedulerEngineError.queueFull("provider shutting down")
         }
-        if isDrainingForUpdate {
+        if isDrainingForLifecycle {
             throw MultiModelBatchSchedulerEngineError.queueFull(providerDrainingForUpdateReason)
         }
     }

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+OperatorDrain.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+OperatorDrain.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+extension ProviderLoop {
+    /// Default deadline shared by the daemon and the operator CLI. Ten minutes
+    /// covers long generations without letting a wedged request leave a command
+    /// waiting forever.
+    public static let operatorDrainTimeout: Duration = .seconds(600)
+
+    /// Close admission, let paid work finish, then close the coordinator so the
+    /// normal `run()` teardown can release models and exit. The event loop stays
+    /// alive during the wait, which is required for active streams to complete
+    /// and for newly routed work to receive the retryable 503 drain response.
+    public func requestOperatorShutdown(
+        timeout: Duration = ProviderLoop.operatorDrainTimeout
+    ) async -> OperatorDrainController.Outcome {
+        guard coordinatorClient != nil else { return .unavailable }
+
+        let me = self
+        let controller = OperatorDrainController(
+            dependencies: .init(
+                begin: { await me.beginOperatorDrain() },
+                waitForDrain: { duration in
+                    await me.waitForInflightDrain(timeout: duration)
+                },
+                resume: { await me.resumeAfterOperatorDrainTimeout() },
+                finishShutdown: { await me.finishOperatorShutdown() }
+            ),
+            timeout: timeout
+        )
+        return await controller.run()
+    }
+
+    private func beginOperatorDrain() -> Bool {
+        guard !isShuttingDown,
+              !isOperatorDraining,
+              updatePhase == .idle
+        else { return false }
+
+        isOperatorDraining = true
+        logger.info("Operator drain started; refusing new work while active inference finishes")
+        writeDaemonState()
+        return true
+    }
+
+    private func resumeAfterOperatorDrainTimeout() async {
+        guard isOperatorDraining, !isShuttingDown else { return }
+        isOperatorDraining = false
+        logger.warning("Operator drain timed out; restart cancelled and admission reopened")
+        writeDaemonState()
+        await replayDeferredDesiredModels(after: "operator drain")
+    }
+
+    private func finishOperatorShutdown() async {
+        guard isOperatorDraining else { return }
+        // Keep the admission gate closed across the coordinator shutdown await.
+        // No request can enter between the final zero-count observation and the
+        // WebSocket close.
+        isShuttingDown = true
+        writeDaemonState()
+        logger.info("Operator drain complete; closing coordinator connection")
+        await coordinatorClient?.shutdown()
+    }
+}

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+Prefetch.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+Prefetch.swift
@@ -52,7 +52,7 @@ extension ProviderLoop {
                 error: "provider is shutting down"))
             return
         }
-        if isDrainingForUpdate {
+        if isDrainingForLifecycle {
             sendDrainingPrefetchFailure(modelId: modelId, send: send)
             return
         }

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+Preload.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+Preload.swift
@@ -35,7 +35,7 @@ extension ProviderLoop {
             ))
             return
         }
-        if isDrainingForUpdate {
+        if isDrainingForLifecycle {
             sendDrainingLoadModelFailure(modelId: modelId, send: send)
             return
         }

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+Serve.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+Serve.swift
@@ -270,7 +270,7 @@ extension ProviderLoop {
                     handleLoadModelRequest(modelId: modelId, send: send)
 
                 case .prefetchModel(let modelId, let priority):
-                    if isDrainingForUpdate {
+                    if isDrainingForLifecycle {
                         sendDrainingPrefetchFailure(modelId: modelId, send: send)
                     } else {
                         staleDesiredPrefetches.remove(modelId)
@@ -278,13 +278,13 @@ extension ProviderLoop {
                     }
 
                 case .desiredModels(let entries):
-                    if isDrainingForUpdate {
+                    if isDrainingForLifecycle {
                         // Keep only the latest push (desired state is
-                        // declarative). A successful restart makes it moot —
-                        // registration receives fresh desired state — but an
-                        // aborted restart replays it via resumeServingAfterUpdate.
+                        // declarative). A successful restart makes it moot,
+                        // since registration receives fresh desired state. An
+                        // aborted drain replays it before normal serving resumes.
                         deferredDesiredModels = entries
-                        logger.info("Deferring desired_models during update drain (\(entries.count) entr(ies)); replayed if the restart is aborted")
+                        logger.info("Deferring desired_models during lifecycle drain (\(entries.count) entr(ies)); replayed if the drain is aborted")
                     } else {
                         await reconcileDesiredModels(entries, send: send)
                     }

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+Trust.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+Trust.swift
@@ -56,6 +56,11 @@ extension ProviderLoop {
                     gpuMemoryCacheGb: $0.gpuMemoryCacheGb)
             },
             lastModelLoadError: lastModelLoadError,
+            lifecycle: DaemonState.Lifecycle(
+                phase: isShuttingDown ? .shuttingDown
+                    : (isOperatorDraining ? .draining : .serving),
+                inflightRequests: requestToModel.count + localReservations.totalInFlight
+            ),
             // Joined at WRITE time, not at sample time: a refused explicit
             // paged request builds no engine, so its only trace is
             // `lastModelLoadError` — and `recordModelLoadError` writes the

--- a/provider-swift/Sources/ProviderCore/ProviderLoop.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop.swift
@@ -226,6 +226,9 @@ public actor ProviderLoop {
     internal var loadGateWaiters: [CheckedContinuation<Void, Never>] = []
     internal var isLoadingAny: Bool = false
     internal var isShuttingDown: Bool = false
+    /// True while a manual stop/restart is waiting for paid work to finish.
+    /// Unlike auto-update, a timeout reopens admission instead of cancelling.
+    internal var isOperatorDraining: Bool = false
 
     /// Phase of a graceful auto-update cycle. Drives admission: in `.draining`
     /// we refuse new requests (503 reroute) so in-flight work can finish before

--- a/provider-swift/Sources/ProviderCore/Service/DaemonStateFile.swift
+++ b/provider-swift/Sources/ProviderCore/Service/DaemonStateFile.swift
@@ -37,6 +37,9 @@ public struct DaemonState: Codable, Sendable, Equatable {
     public var system: SystemInfo?
     public var capacity: Capacity?
     public var lastModelLoadError: ModelLoadError?
+    /// Optional for compatibility with state files written before operator
+    /// drains were exposed in local status.
+    public var lifecycle: Lifecycle?
     /// Per-slot KV-backend and MTP posture, one entry per model this daemon
     /// has an engine for, plus one synthetic entry for a model whose load
     /// FAILED (`kvBackend == nil`, `loadError != nil`) — a refused explicit
@@ -188,6 +191,22 @@ public struct DaemonState: Codable, Sendable, Equatable {
         }
     }
 
+    public struct Lifecycle: Codable, Sendable, Equatable {
+        public enum Phase: String, Codable, Sendable {
+            case serving
+            case draining
+            case shuttingDown = "shutting_down"
+        }
+
+        public var phase: Phase
+        public var inflightRequests: Int
+
+        public init(phase: Phase, inflightRequests: Int) {
+            self.phase = phase
+            self.inflightRequests = max(0, inflightRequests)
+        }
+    }
+
     public init(
         schema: Int = DaemonState.currentSchema,
         pid: Int32,
@@ -203,6 +222,7 @@ public struct DaemonState: Codable, Sendable, Equatable {
         system: SystemInfo? = nil,
         capacity: Capacity? = nil,
         lastModelLoadError: ModelLoadError? = nil,
+        lifecycle: Lifecycle? = nil,
         slots: [SlotPosture]? = nil,
         connectivity: Connectivity? = nil
     ) {
@@ -220,6 +240,7 @@ public struct DaemonState: Codable, Sendable, Equatable {
         self.system = system
         self.capacity = capacity
         self.lastModelLoadError = lastModelLoadError
+        self.lifecycle = lifecycle
         self.slots = slots
         self.connectivity = connectivity
     }

--- a/provider-swift/Sources/ProviderCore/Service/LaunchAgent.swift
+++ b/provider-swift/Sources/ProviderCore/Service/LaunchAgent.swift
@@ -425,6 +425,9 @@ public enum LaunchAgent: Sendable {
             "StandardErrorPath": logPath,
             "ProcessType": "Interactive",
             "Nice": -5,
+            // Give macOS-initiated termination the same budget as the daemon's
+            // operator drain. Normal CLI actions signal and wait before bootout.
+            "ExitTimeOut": 600,
         ]
 
         // launchd does NOT inherit the installing shell's environment, so any
@@ -541,6 +544,7 @@ public enum LaunchAgentError: Error, CustomStringConvertible, Sendable {
     case bootstrapFailed(String)
     case bootoutFailed(String)
     case kickstartFailed(String)
+    case signalFailed(String)
     case disableFailed(String)
     case notInstalled
 
@@ -552,6 +556,8 @@ public enum LaunchAgentError: Error, CustomStringConvertible, Sendable {
             return "launchctl bootout failed: \(detail)"
         case .kickstartFailed(let detail):
             return "launchctl kickstart failed: \(detail)"
+        case .signalFailed(let detail):
+            return "could not ask the provider to drain: \(detail)"
         case .disableFailed(let detail):
             return "launchctl disable failed (the provider may auto-start again at next login): \(detail)"
         case .notInstalled:

--- a/provider-swift/Sources/ProviderCore/Service/OperatorDrainController.swift
+++ b/provider-swift/Sources/ProviderCore/Service/OperatorDrainController.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+/// Runs one operator-requested provider drain.
+///
+/// Manual administration is deliberately safer than auto-update. If paid work
+/// does not finish before the deadline, the provider reopens admission and the
+/// CLI action fails. It never force-cancels inference on the operator's behalf.
+public struct OperatorDrainController: Sendable {
+    public enum Outcome: Sendable, Equatable {
+        case unavailable
+        case busy
+        case drained
+        case timedOut
+    }
+
+    public struct Dependencies: Sendable {
+        /// Claims the lifecycle gate and closes admission. Returns false if an
+        /// update, shutdown, or another operator drain already owns it.
+        public var begin: @Sendable () async -> Bool
+        /// Waits for coordinator and local inference to finish.
+        public var waitForDrain: @Sendable (Duration) async -> Bool
+        /// Reopens admission after a timeout.
+        public var resume: @Sendable () async -> Void
+        /// Closes the coordinator only after the in-flight count reaches zero.
+        public var finishShutdown: @Sendable () async -> Void
+
+        public init(
+            begin: @escaping @Sendable () async -> Bool,
+            waitForDrain: @escaping @Sendable (Duration) async -> Bool,
+            resume: @escaping @Sendable () async -> Void,
+            finishShutdown: @escaping @Sendable () async -> Void
+        ) {
+            self.begin = begin
+            self.waitForDrain = waitForDrain
+            self.resume = resume
+            self.finishShutdown = finishShutdown
+        }
+    }
+
+    private let dependencies: Dependencies
+    private let timeout: Duration
+
+    public init(dependencies: Dependencies, timeout: Duration) {
+        self.dependencies = dependencies
+        self.timeout = timeout
+    }
+
+    public func run() async -> Outcome {
+        guard await dependencies.begin() else { return .busy }
+        guard await dependencies.waitForDrain(timeout) else {
+            await dependencies.resume()
+            return .timedOut
+        }
+        await dependencies.finishShutdown()
+        return .drained
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Service/ProcessLifecycle.swift
+++ b/provider-swift/Sources/ProviderCore/Service/ProcessLifecycle.swift
@@ -220,6 +220,26 @@ public enum ProcessLifecycle {
         return !identity.isCurrent()
     }
 
+    /// Wait for one exact process identity to disappear. This never signals or
+    /// force-kills the process.
+    public static func waitForExit(
+        _ identity: ProcessIdentity,
+        timeout: Duration
+    ) async -> Bool {
+        guard identity.isCurrent() else { return true }
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: timeout)
+        while identity.isCurrent() {
+            if Task.isCancelled || clock.now >= deadline { return false }
+            do {
+                try await Task.sleep(for: .milliseconds(100))
+            } catch {
+                return false
+            }
+        }
+        return true
+    }
+
     // MARK: - Internals
 
     private static func readPID(at url: URL) -> Int32? {

--- a/provider-swift/Sources/ProviderCore/Service/ProviderLaunchSnapshot.swift
+++ b/provider-swift/Sources/ProviderCore/Service/ProviderLaunchSnapshot.swift
@@ -26,13 +26,40 @@ public struct ProviderLaunchSnapshot: Codable, Sendable, Equatable {
 }
 
 extension LaunchAgent {
-    public static func launchSnapshot() -> ProviderLaunchSnapshot? {
-        for label in supportedLabels {
+    /// SIGINFO is ignored by older macOS provider builds, so a new CLI cannot
+    /// accidentally terminate an old daemon that lacks operator drain support.
+    static let operatorDrainSignal = "SIGINFO"
+
+    /// One snapshot per loaded canonical or legacy provider job. A loaded job
+    /// may have no live process, in which case `process` is nil.
+    public static func launchSnapshots() -> [ProviderLaunchSnapshot] {
+        supportedLabels.compactMap { label in
             let output = LaunchctlControl.printOutput(label: label)
-            guard output.succeeded else { continue }
+            guard output.succeeded else { return nil }
             return parseLaunchSnapshot(label: label, output: output.stdout)
         }
-        return nil
+    }
+
+    public static func launchSnapshot() -> ProviderLaunchSnapshot? {
+        launchSnapshots().first
+    }
+
+    /// Send the backward-safe operator signal through launchd, targeting the
+    /// loaded job rather than an untrusted PID read from disk. The caller still
+    /// waits on the captured `ProcessIdentity`, so a later launch cannot be
+    /// mistaken for completion of the process that was asked to drain.
+    public static func requestGracefulExit(label: String) throws {
+        guard supportedLabels.contains(label) else {
+            throw LaunchAgentError.signalFailed("unsupported service label \(label)")
+        }
+        let result = LaunchctlControl.run(
+            ["kill", operatorDrainSignal, LaunchctlControl.target(label: label)],
+            captureStderr: true
+        )
+        guard result.succeeded else {
+            throw LaunchAgentError.signalFailed(
+                result.stderr.trimmingCharacters(in: .whitespacesAndNewlines))
+        }
     }
 
     static func parseLaunchSnapshot(

--- a/provider-swift/Sources/darkbloom/ProviderAppKitHost.swift
+++ b/provider-swift/Sources/darkbloom/ProviderAppKitHost.swift
@@ -43,6 +43,9 @@ enum ProviderAppKitHost {
 @MainActor
 final class ProviderAppDelegate: NSObject, NSApplicationDelegate {
     private let args: [String]
+    private var serveTask: Task<Void, Never>?
+    private var signalSources: [DispatchSourceSignal] = []
+    private var terminationRequested = false
 
     init(args: [String]) {
         self.args = args
@@ -59,8 +62,9 @@ final class ProviderAppDelegate: NSObject, NSApplicationDelegate {
         // (apsd redacts the payload as <private> and keeps no cleartext copy —
         // verified on macOS 26.4, see docs/apns-code-attestation-design.md).
         NSApplication.shared.registerForRemoteNotifications()
+        installShutdownSignalSources()
         let args = self.args
-        Task {
+        serveTask = Task {
             do {
                 let command = try Darkbloom.parseAsRoot(args)
                 if let asyncCommand = command as? AsyncParsableCommand {
@@ -70,9 +74,62 @@ final class ProviderAppDelegate: NSObject, NSApplicationDelegate {
                     var cmd = command
                     try cmd.run()
                 }
-                exit(0)
+                if terminationRequested {
+                    NSApp.reply(toApplicationShouldTerminate: true)
+                } else {
+                    exit(0)
+                }
             } catch {
                 Darkbloom.exit(withError: error)
+            }
+        }
+    }
+
+    func applicationShouldTerminate(_: NSApplication) -> NSApplication.TerminateReply {
+        guard !terminationRequested else { return .terminateLater }
+        terminationRequested = true
+        requestGracefulShutdown(replyToAppKit: true)
+        return .terminateLater
+    }
+
+    private func installShutdownSignalSources() {
+        // SIGINFO is the launchd operator-drain protocol. Its default action is
+        // discard, which makes a new CLI safe against an older daemon. TERM and
+        // INT cover ordinary process and AppKit shutdown requests.
+        for signalNumber in [SIGINFO, SIGTERM, SIGINT] {
+            signal(signalNumber, SIG_IGN)
+            let source = DispatchSource.makeSignalSource(
+                signal: signalNumber,
+                queue: .main
+            )
+            source.setEventHandler { [weak self] in
+                self?.requestGracefulShutdown(replyToAppKit: false)
+            }
+            source.resume()
+            signalSources.append(source)
+        }
+    }
+
+    private func requestGracefulShutdown(replyToAppKit: Bool) {
+        Task {
+            let outcome = await ProviderTerminationRelay.shared.request()
+            switch outcome {
+            case .unavailable:
+                // Startup has not installed a ProviderLoop yet, so no paid
+                // coordinator request can be active. Cancel normal startup.
+                serveTask?.cancel()
+                if replyToAppKit {
+                    NSApp.reply(toApplicationShouldTerminate: true)
+                }
+            case .busy, .timedOut:
+                if replyToAppKit {
+                    terminationRequested = false
+                    NSApp.reply(toApplicationShouldTerminate: false)
+                }
+            case .drained:
+                // ProviderLoop has closed its coordinator. Its normal teardown
+                // now returns the serve task, which exits or replies to AppKit.
+                break
             }
         }
     }

--- a/provider-swift/Sources/darkbloom/ProviderDrainClient.swift
+++ b/provider-swift/Sources/darkbloom/ProviderDrainClient.swift
@@ -1,0 +1,86 @@
+import Foundation
+import ProviderCore
+
+struct ProviderDrainClient: Sendable {
+    enum Outcome: Sendable, Equatable {
+        case notRunning
+        case drained
+        case timedOut([ProcessIdentity])
+    }
+
+    struct Dependencies: Sendable {
+        var snapshots: @Sendable () -> [ProviderLaunchSnapshot]
+        var signal: @Sendable (String) throws -> Void
+        var waitForExit: @Sendable (ProcessIdentity, Duration) async -> Bool
+
+        static let live = Dependencies(
+            snapshots: { LaunchAgent.launchSnapshots() },
+            signal: { try LaunchAgent.requestGracefulExit(label: $0) },
+            waitForExit: { identity, timeout in
+                await ProcessLifecycle.waitForExit(identity, timeout: timeout)
+            }
+        )
+    }
+
+    private let dependencies: Dependencies
+
+    init(dependencies: Dependencies = .live) {
+        self.dependencies = dependencies
+    }
+
+    /// Ask every loaded provider job to drain, then wait for the exact captured
+    /// process identities to exit. No timeout path sends SIGKILL.
+    func drain(
+        timeout: Duration = ProviderLoop.operatorDrainTimeout + .seconds(2)
+    ) async throws -> Outcome {
+        let running = dependencies.snapshots().compactMap { snapshot -> (String, ProcessIdentity)? in
+            guard let process = snapshot.process else { return nil }
+            return (snapshot.label, process)
+        }
+        guard !running.isEmpty else { return .notRunning }
+
+        for (label, _) in running {
+            try dependencies.signal(label)
+        }
+
+        let timedOut = await withTaskGroup(of: ProcessIdentity?.self) { group in
+            for (_, identity) in running {
+                group.addTask {
+                    await dependencies.waitForExit(identity, timeout) ? nil : identity
+                }
+            }
+            var identities: [ProcessIdentity] = []
+            for await identity in group {
+                if let identity { identities.append(identity) }
+            }
+            return identities.sorted { $0.pid < $1.pid }
+        }
+
+        return timedOut.isEmpty ? .drained : .timedOut(timedOut)
+    }
+}
+
+enum ProviderDrainCommandError: Error, CustomStringConvertible {
+    case timedOut([ProcessIdentity])
+
+    var description: String {
+        switch self {
+        case .timedOut(let identities):
+            let pids = identities.map { String($0.pid) }.joined(separator: ", ")
+            return "active requests did not finish within 600 seconds (provider PID \(pids)); action cancelled and serving resumed"
+        }
+    }
+}
+
+@discardableResult
+func drainProviderBeforeLifecycleAction(
+    _ action: String,
+    client: ProviderDrainClient = ProviderDrainClient()
+) async throws -> ProviderDrainClient.Outcome {
+    print("Draining active requests before \(action)...")
+    let outcome = try await client.drain()
+    if case .timedOut(let identities) = outcome {
+        throw ProviderDrainCommandError.timedOut(identities)
+    }
+    return outcome
+}

--- a/provider-swift/Sources/darkbloom/ProviderTerminationRelay.swift
+++ b/provider-swift/Sources/darkbloom/ProviderTerminationRelay.swift
@@ -1,0 +1,38 @@
+import Foundation
+import ProviderCore
+
+/// Bridges AppKit process signals to the currently running `ProviderLoop`.
+/// Keeping the handler in an actor makes repeated SIGTERM/SIGINT deliveries
+/// coalesce onto one drain attempt.
+actor ProviderTerminationRelay {
+    static let shared = ProviderTerminationRelay()
+
+    typealias Handler = @Sendable () async -> OperatorDrainController.Outcome
+
+    private var handler: Handler?
+    private var active: (id: UUID, task: Task<OperatorDrainController.Outcome, Never>)?
+
+    func install(_ handler: @escaping Handler) {
+        self.handler = handler
+    }
+
+    func uninstall() {
+        handler = nil
+    }
+
+    func request() async -> OperatorDrainController.Outcome {
+        if let active {
+            return await active.task.value
+        }
+        guard let handler else { return .unavailable }
+
+        let id = UUID()
+        let task = Task { await handler() }
+        active = (id, task)
+        let outcome = await task.value
+        if active?.id == id {
+            active = nil
+        }
+        return outcome
+    }
+}

--- a/provider-swift/Sources/darkbloom/RestartCommand.swift
+++ b/provider-swift/Sources/darkbloom/RestartCommand.swift
@@ -20,6 +20,12 @@ struct Restart: AsyncParsableCommand {
     mutating func run() async throws {
         let wasLoaded = LaunchAgent.isLoaded()
         do {
+            _ = try await drainProviderBeforeLifecycleAction("restarting")
+        } catch {
+            printError("Restart cancelled: \(error)")
+            throw ExitCode.failure
+        }
+        do {
             try LaunchAgent.restart()
         } catch LaunchAgentError.notInstalled {
             printError("Provider is not running. Start it with `darkbloom start`.")

--- a/provider-swift/Sources/darkbloom/StartCommand+Daemon.swift
+++ b/provider-swift/Sources/darkbloom/StartCommand+Daemon.swift
@@ -41,6 +41,15 @@ extension Start {
             throw ExitCode.failure
         }
 
+        if LaunchAgent.isAnySupportedLabelLoaded() {
+            do {
+                _ = try await drainProviderBeforeLifecycleAction("replacing the running service")
+            } catch {
+                printError("Start cancelled: \(error)")
+                throw ExitCode.failure
+            }
+        }
+
         try LaunchAgent.installAndStart(
             coordinatorURL: coordinatorURL,
             models: selectedModelIDs,

--- a/provider-swift/Sources/darkbloom/StartCommand+Modes.swift
+++ b/provider-swift/Sources/darkbloom/StartCommand+Modes.swift
@@ -407,8 +407,17 @@ extension Start {
     }
 
     private func runProviderLoopWithFanLease(_ loop: ProviderLoop) async throws {
-        try await withFanActivityLease(providerVersion: ProviderCore.version) {
-            try await loop.run()
+        await ProviderTerminationRelay.shared.install {
+            await loop.requestOperatorShutdown()
+        }
+        do {
+            try await withFanActivityLease(providerVersion: ProviderCore.version) {
+                try await loop.run()
+            }
+            await ProviderTerminationRelay.shared.uninstall()
+        } catch {
+            await ProviderTerminationRelay.shared.uninstall()
+            throw error
         }
     }
 

--- a/provider-swift/Sources/darkbloom/StatusCommand.swift
+++ b/provider-swift/Sources/darkbloom/StatusCommand.swift
@@ -119,6 +119,10 @@ struct Status: AsyncParsableCommand {
         print("Warm models: \(WarmModelsFormat.warmModelsLine(warmModels: state.warmModels, currentModel: state.currentModel))")
         print("\(WarmModelsFormat.mostRecentlyUsedLabel): \(WarmModelsFormat.mostRecentlyUsedLine(currentModel: state.currentModel))")
         print("Requests served: \(state.stats.requestsServed)  |  tokens: \(state.stats.tokensGenerated)")
+        if state.lifecycle?.phase == .draining {
+            let count = state.lifecycle?.inflightRequests ?? 0
+            print("Drain: active (\(count) request\(count == 1 ? "" : "s") remaining)")
+        }
         if let err = state.lastModelLoadError {
             print("Last model-load error: \(err.model): \(err.message)")
         }

--- a/provider-swift/Sources/darkbloom/StopCommand.swift
+++ b/provider-swift/Sources/darkbloom/StopCommand.swift
@@ -13,13 +13,19 @@ struct Stop: AsyncParsableCommand {
     mutating func run() async throws {
         let wasLoaded = LaunchAgent.isLoaded()
 
-        // Disarm crash recovery FIRST so the watchdog can't relaunch what we're
-        // stopping, and drop its timer so the next start gets a fresh grace
-        // window (uninstall additionally deletes its plist). Best-effort.
+        do {
+            try await WatchdogDrainTransaction().run {
+                _ = try await drainProviderBeforeLifecycleAction("stopping")
+            }
+        } catch {
+            printError("Stop cancelled: \(error)")
+            throw ExitCode.failure
+        }
+
+        // The transaction already disarmed crash recovery before the provider
+        // exited. Delete its plist only after a successful drain.
         if uninstall {
             try? WatchdogAgent.uninstall()
-        } else {
-            try? WatchdogAgent.stop()
         }
         try? FileManager.default.removeItem(at: WatchdogStateStore.path())
 

--- a/provider-swift/Sources/darkbloom/WatchdogDrainTransaction.swift
+++ b/provider-swift/Sources/darkbloom/WatchdogDrainTransaction.swift
@@ -1,0 +1,67 @@
+import Foundation
+import ProviderCore
+
+/// Prevents the crash watchdog from relaunching a provider that intentionally
+/// exits after a successful operator drain. A failed drain restores the prior
+/// watchdog job before the stop command returns an error.
+struct WatchdogDrainTransaction: Sendable {
+    struct Snapshot: Sendable, Equatable {
+        let wasLoaded: Bool
+        let configPath: URL?
+    }
+
+    struct Dependencies: Sendable {
+        var snapshot: @Sendable () -> Snapshot
+        var disarm: @Sendable () throws -> Void
+        var rearm: @Sendable (URL?) throws -> Void
+
+        static let live = Dependencies(
+            snapshot: {
+                Snapshot(
+                    wasLoaded: WatchdogAgent.isLoaded(),
+                    configPath: WatchdogAgent.installedConfigPath()
+                )
+            },
+            disarm: { try WatchdogAgent.stop() },
+            rearm: { try WatchdogAgent.installAndStart(configPath: $0) }
+        )
+    }
+
+    enum TransactionError: Error, CustomStringConvertible {
+        case restoreFailed(drain: String, restore: String)
+
+        var description: String {
+            switch self {
+            case .restoreFailed(let drain, let restore):
+                return "\(drain); crash recovery could not be restored: \(restore)"
+            }
+        }
+    }
+
+    private let dependencies: Dependencies
+
+    init(dependencies: Dependencies = .live) {
+        self.dependencies = dependencies
+    }
+
+    func run(
+        drain: @escaping @Sendable () async throws -> Void
+    ) async throws {
+        let snapshot = dependencies.snapshot()
+        try dependencies.disarm()
+        do {
+            try await drain()
+        } catch {
+            guard snapshot.wasLoaded else { throw error }
+            do {
+                try dependencies.rearm(snapshot.configPath)
+            } catch let restoreError {
+                throw TransactionError.restoreFailed(
+                    drain: String(describing: error),
+                    restore: String(describing: restoreError)
+                )
+            }
+            throw error
+        }
+    }
+}

--- a/provider-swift/Tests/DarkbloomCLITests/ProviderDrainClientTests.swift
+++ b/provider-swift/Tests/DarkbloomCLITests/ProviderDrainClientTests.swift
@@ -1,0 +1,104 @@
+import Foundation
+import Testing
+@testable import ProviderCore
+@testable import darkbloom
+
+private final class LockedDrainCalls: @unchecked Sendable {
+    private let lock = NSLock()
+    private var labels: [String] = []
+    private var waits: [Int32] = []
+
+    func signal(_ label: String) {
+        lock.withLock { labels.append(label) }
+    }
+
+    func wait(_ pid: Int32) {
+        lock.withLock { waits.append(pid) }
+    }
+
+    func snapshot() -> (labels: [String], waits: [Int32]) {
+        lock.withLock { (labels, waits) }
+    }
+}
+
+@Suite("Provider drain client")
+struct ProviderDrainClientTests {
+    @Test("loaded job without a process needs no signal")
+    func noRunningProcess() async throws {
+        let calls = LockedDrainCalls()
+        let client = ProviderDrainClient(dependencies: .init(
+            snapshots: {
+                [ProviderLaunchSnapshot(label: LaunchAgent.label, runs: 1, process: nil)]
+            },
+            signal: { calls.signal($0) },
+            waitForExit: { identity, _ in calls.wait(identity.pid); return true }
+        ))
+
+        #expect(try await client.drain(timeout: .milliseconds(1)) == .notRunning)
+        #expect(calls.snapshot().labels.isEmpty)
+        #expect(calls.snapshot().waits.isEmpty)
+    }
+
+    @Test("all launchd provider identities drain before success")
+    func drainsEveryLoadedProvider() async throws {
+        let calls = LockedDrainCalls()
+        let first = ProcessIdentity(pid: 41, startTimeMicros: 1)
+        let second = ProcessIdentity(pid: 42, startTimeMicros: 2)
+        let client = ProviderDrainClient(dependencies: .init(
+            snapshots: {
+                [
+                    ProviderLaunchSnapshot(label: LaunchAgent.label, runs: 1, process: first),
+                    ProviderLaunchSnapshot(label: "dev.darkbloom.provider", runs: 1, process: second),
+                ]
+            },
+            signal: { calls.signal($0) },
+            waitForExit: { identity, _ in calls.wait(identity.pid); return true }
+        ))
+
+        #expect(try await client.drain(timeout: .milliseconds(1)) == .drained)
+        #expect(Set(calls.snapshot().labels) == Set([LaunchAgent.label, "dev.darkbloom.provider"]))
+        #expect(Set(calls.snapshot().waits) == Set([first.pid, second.pid]))
+    }
+
+    @Test("timeout reports the exact process and never force kills")
+    func timeoutReportsIdentity() async throws {
+        let identity = ProcessIdentity(pid: 77, startTimeMicros: 9)
+        let client = ProviderDrainClient(dependencies: .init(
+            snapshots: {
+                [ProviderLaunchSnapshot(label: LaunchAgent.label, runs: 1, process: identity)]
+            },
+            signal: { _ in },
+            waitForExit: { _, _ in false }
+        ))
+
+        #expect(
+            try await client.drain(timeout: .milliseconds(1))
+                == .timedOut([identity]))
+    }
+}
+
+private actor RelayCallCounter {
+    private var count = 0
+    func increment() { count += 1 }
+    func value() -> Int { count }
+}
+
+@Suite("Provider termination relay")
+struct ProviderTerminationRelayTests {
+    @Test("concurrent signals share one drain")
+    func coalescesSignals() async {
+        let relay = ProviderTerminationRelay()
+        let calls = RelayCallCounter()
+        await relay.install {
+            await calls.increment()
+            try? await Task.sleep(for: .milliseconds(30))
+            return .drained
+        }
+
+        async let first = relay.request()
+        async let second = relay.request()
+        #expect(await first == .drained)
+        #expect(await second == .drained)
+        #expect(await calls.value() == 1)
+    }
+}

--- a/provider-swift/Tests/DarkbloomCLITests/WatchdogDrainTransactionTests.swift
+++ b/provider-swift/Tests/DarkbloomCLITests/WatchdogDrainTransactionTests.swift
@@ -1,0 +1,85 @@
+import Foundation
+import Testing
+@testable import darkbloom
+
+private final class LockedWatchdogEvents: @unchecked Sendable {
+    private let lock = NSLock()
+    private var events: [String] = []
+
+    func record(_ event: String) {
+        lock.withLock { events.append(event) }
+    }
+
+    func snapshot() -> [String] {
+        lock.withLock { events }
+    }
+}
+
+private enum TestDrainError: Error {
+    case timedOut
+}
+
+@Suite("Watchdog drain transaction")
+struct WatchdogDrainTransactionTests {
+    @Test("watchdog is disarmed before a successful drain")
+    func disarmsBeforeDrain() async throws {
+        let events = LockedWatchdogEvents()
+        let transaction = WatchdogDrainTransaction(dependencies: .init(
+            snapshot: {
+                events.record("snapshot")
+                return .init(wasLoaded: true, configPath: nil)
+            },
+            disarm: { events.record("disarm") },
+            rearm: { _ in events.record("rearm") }
+        ))
+
+        try await transaction.run {
+            events.record("drain")
+        }
+
+        #expect(events.snapshot() == ["snapshot", "disarm", "drain"])
+    }
+
+    @Test("failed drain restores a previously loaded watchdog")
+    func restoresAfterFailure() async {
+        let events = LockedWatchdogEvents()
+        let config = URL(fileURLWithPath: "/tmp/provider.toml")
+        let transaction = WatchdogDrainTransaction(dependencies: .init(
+            snapshot: {
+                events.record("snapshot")
+                return .init(wasLoaded: true, configPath: config)
+            },
+            disarm: { events.record("disarm") },
+            rearm: { path in
+                #expect(path == config)
+                events.record("rearm")
+            }
+        ))
+
+        await #expect(throws: TestDrainError.timedOut) {
+            try await transaction.run {
+                events.record("drain")
+                throw TestDrainError.timedOut
+            }
+        }
+        #expect(events.snapshot() == ["snapshot", "disarm", "drain", "rearm"])
+    }
+
+    @Test("failed drain does not create a watchdog that was not loaded")
+    func leavesOptOutAlone() async {
+        let events = LockedWatchdogEvents()
+        let transaction = WatchdogDrainTransaction(dependencies: .init(
+            snapshot: { .init(wasLoaded: false, configPath: nil) },
+            disarm: { events.record("disarm") },
+            rearm: { _ in events.record("rearm") }
+        ))
+
+        await #expect(throws: TestDrainError.timedOut) {
+            try await transaction.run {
+                events.record("drain")
+                throw TestDrainError.timedOut
+            }
+        }
+        #expect(events.snapshot() == ["disarm", "drain"])
+    }
+}

--- a/provider-swift/Tests/ProviderCoreTests/LaunchAgentRestartTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/LaunchAgentRestartTests.swift
@@ -23,6 +23,18 @@ struct LaunchAgentRestartTests {
         #expect(message.contains("boom"))
     }
 
+    @Test("signalFailed explains that the drain request failed")
+    func signalFailedDescription() {
+        let message = LaunchAgentError.signalFailed("boom").description
+        #expect(message.contains("drain"))
+        #expect(message.contains("boom"))
+    }
+
+    @Test("operator drain uses the backward-safe macOS signal")
+    func operatorDrainSignal() {
+        #expect(LaunchAgent.operatorDrainSignal == "SIGINFO")
+    }
+
     // `darkbloom stop` must persistently disable the agent (launchctl disable)
     // in addition to bootout: bootout only affects the current login session,
     // and the plist left on disk (RunAtLoad=true) would otherwise restart the
@@ -167,6 +179,7 @@ struct LaunchAgentServicePlistTests {
         // APNs) with no human; KeepAlive stays false to avoid racing the self-updater.
         #expect(plist["RunAtLoad"] as? Bool == true)
         #expect(plist["KeepAlive"] as? Bool == false)
+        #expect(plist["ExitTimeOut"] as? Int == 600)
         #expect((plist["EnvironmentVariables"] as? [String: String]) == ["DARKBLOOM_PREFIX_CACHE": "0"])
     }
 

--- a/provider-swift/Tests/ProviderCoreTests/OperatorDrainControllerTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/OperatorDrainControllerTests.swift
@@ -1,0 +1,63 @@
+import Foundation
+import Testing
+@testable import ProviderCore
+
+private actor DrainEventRecorder {
+    private var values: [String] = []
+    func record(_ value: String) { values.append(value) }
+    func snapshot() -> [String] { values }
+}
+
+@Suite("Operator drain controller")
+struct OperatorDrainControllerTests {
+    @Test("clean drain closes the coordinator after work reaches zero")
+    func cleanDrain() async {
+        let recorder = DrainEventRecorder()
+        let controller = OperatorDrainController(
+            dependencies: .init(
+                begin: { await recorder.record("begin"); return true },
+                waitForDrain: { _ in await recorder.record("wait"); return true },
+                resume: { await recorder.record("resume") },
+                finishShutdown: { await recorder.record("shutdown") }
+            ),
+            timeout: .seconds(1)
+        )
+
+        #expect(await controller.run() == .drained)
+        #expect(await recorder.snapshot() == ["begin", "wait", "shutdown"])
+    }
+
+    @Test("timeout reopens admission and never shuts down")
+    func timeoutResumes() async {
+        let recorder = DrainEventRecorder()
+        let controller = OperatorDrainController(
+            dependencies: .init(
+                begin: { await recorder.record("begin"); return true },
+                waitForDrain: { _ in await recorder.record("wait"); return false },
+                resume: { await recorder.record("resume") },
+                finishShutdown: { await recorder.record("shutdown") }
+            ),
+            timeout: .milliseconds(1)
+        )
+
+        #expect(await controller.run() == .timedOut)
+        #expect(await recorder.snapshot() == ["begin", "wait", "resume"])
+    }
+
+    @Test("busy lifecycle does not wait, resume, or shut down")
+    func busyDoesNothing() async {
+        let recorder = DrainEventRecorder()
+        let controller = OperatorDrainController(
+            dependencies: .init(
+                begin: { await recorder.record("begin"); return false },
+                waitForDrain: { _ in await recorder.record("wait"); return true },
+                resume: { await recorder.record("resume") },
+                finishShutdown: { await recorder.record("shutdown") }
+            ),
+            timeout: .seconds(1)
+        )
+
+        #expect(await controller.run() == .busy)
+        #expect(await recorder.snapshot() == ["begin"])
+    }
+}

--- a/provider-swift/Tests/ProviderCoreTests/ProcessLifecycleTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ProcessLifecycleTests.swift
@@ -112,4 +112,21 @@ struct ProcessLifecycleTests {
         #expect(telemetryPurgeCount == 0)
         #expect(videoPurgeCount == 0)
     }
+
+    @Test("wait-for-exit accepts an already stale process identity")
+    func waitForStaleIdentity() async {
+        let stale = ProcessIdentity(pid: 999_999, startTimeMicros: 1)
+        #expect(await ProcessLifecycle.waitForExit(stale, timeout: .seconds(1)))
+    }
+
+    @Test("wait-for-exit times out without terminating the exact live process")
+    func waitForLiveIdentityTimesOut() async throws {
+        let pid = ProcessInfo.processInfo.processIdentifier
+        let current = try #require(ProcessIdentity.read(pid: pid))
+        #expect(await ProcessLifecycle.waitForExit(
+            current,
+            timeout: .milliseconds(1)
+        ) == false)
+        #expect(current.isCurrent())
+    }
 }


### PR DESCRIPTION
Fixes #685.

Related to #392. This is a fresh implementation against current `master`.

Manual `darkbloom restart`, `stop`, and replacement `start` operations could terminate the launchd daemon while paid inference was active. Auto-update already had a drain gate, but the operator CLI bypassed it.

This change makes manual lifecycle actions wait for active work without adopting auto-update's force-cancel policy:

- The CLI sends a backward-safe macOS `SIGINFO` request through launchd. Older daemons ignore this signal instead of exiting.
- The live `ProviderLoop` closes admission, returns the existing retryable 503 response for newly routed work, and lets active coordinator and local requests finish.
- The CLI waits for the exact captured process identity before changing the launchd job.
- A 10 minute timeout cancels the operator action and reopens admission. Manual administration never force-cancels inference.
- Repeated shutdown requests share one drain attempt.
- `stop` disarms the crash watchdog before the provider exits, then restores it if draining fails.
- Local status reports the drain phase and remaining request count.
- Auto-update keeps its existing bounded force-cancel policy.

### Before

```mermaid
flowchart LR
  A[Operator runs start, stop, or restart] --> B[CLI calls LaunchAgent lifecycle method]
  B --> C[launchctl terminates the daemon]
  C --> D[Active paid inference can be interrupted]
  B -. code path .-> E[StartCommand, StopCommand, or RestartCommand]
  E --> F[LaunchAgent installAndStart, stop, or restart]
```

### After

```mermaid
flowchart LR
  A[Operator runs start, stop, or restart] --> B[ProviderDrainClient captures launchd process identity]
  B --> C[LaunchAgent sends SIGINFO]
  C --> D[ProviderTerminationRelay calls ProviderLoop requestOperatorShutdown]
  D --> E[Admission gate rejects new work with retryable 503]
  E --> F{Active requests reach zero?}
  F -->|Yes| G[Coordinator closes and exact process exits]
  G --> H[CLI performs requested launchd action]
  F -->|No, after 10 minutes| I[Admission reopens and CLI action is cancelled]
  J[StopCommand] --> K[WatchdogDrainTransaction disarms recovery first]
  K -->|Drain fails| L[Restore prior watchdog configuration]
```

### Tests

- `swift test --scratch-path /tmp/d-inference-operator-drain-build --filter 'ProcessLifecycleTests|ProviderDrainClientTests|ProviderTerminationRelayTests|OperatorDrainControllerTests|WatchdogDrainTransactionTests|LaunchAgentServicePlistTests|LaunchAgentRestartTests'`
- 39 tests passed across eight suites.
- A full `swift test --skip-build` run reached the hardware suites but could not continue in this checkout because the default MLX Metal library is not installed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/687"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790095382&installation_model_id=21733&pr_number=687&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F687&signature=79c5df128b9ae9b8e3aaf7d83eb2bda19be51faabc0c22f5f3c6f3e72afb84e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->