### PR TITLE
Fix pipe-buffer deadlock in HardwareDetector/attestation subprocess calls

### DIFF
--- a/provider-swift/Sources/ProviderCore/Auth/Enrollment.swift
+++ b/provider-swift/Sources/ProviderCore/Auth/Enrollment.swift
@@ -28,16 +28,19 @@ public func macHardwareSerialNumber() -> String? {
     process.arguments = ["-c", "IOPlatformExpertDevice", "-d", "2"]
     let pipe = Pipe()
     process.standardOutput = pipe
-    process.standardError = Pipe()
+    process.standardError = FileHandle.nullDevice
 
     do {
         try process.run()
     } catch {
         return nil
     }
-    process.waitUntilExit()
-
+    // Drain stdout BEFORE waiting for exit. macOS pipe buffers hold only
+    // ~512 bytes and ioreg output far exceeds that, so waiting first
+    // deadlocks (child blocks in write(), parent blocks in waitUntilExit()).
+    // This is what leaves the serial number unavailable to attestation.
     let data = pipe.fileHandleForReading.readDataToEndOfFile()
+    process.waitUntilExit()
     guard let text = String(data: data, encoding: .utf8) else { return nil }
 
     for line in text.split(separator: "\n") {

--- a/provider-swift/Sources/ProviderCore/Hardware/HardwareDetector.swift
+++ b/provider-swift/Sources/ProviderCore/Hardware/HardwareDetector.swift
@@ -111,16 +111,21 @@ private func detectGPUInfo() throws -> (chipName: String, gpuCores: UInt32) {
 
     let pipe = Pipe()
     process.standardOutput = pipe
-    process.standardError = Pipe()
+    process.standardError = FileHandle.nullDevice
 
     try process.run()
+
+    // Drain stdout BEFORE waiting for exit. macOS pipe buffers hold only
+    // ~512 bytes and system_profiler output exceeds that, so waiting first
+    // deadlocks: the child blocks in write() while the parent blocks in
+    // waitUntilExit(). readDataToEndOfFile() reads until the child closes
+    // stdout, so it also serves as the join point; waitUntilExit() then reaps.
+    let data = pipe.fileHandleForReading.readDataToEndOfFile()
     process.waitUntilExit()
 
     guard process.terminationStatus == 0 else {
         return (fallbackChipName(), 0)
     }
-
-    let data = pipe.fileHandleForReading.readDataToEndOfFile()
 
     guard
         let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],

--- a/provider-swift/Sources/ProviderCore/Security/AttestationBuilder.swift
+++ b/provider-swift/Sources/ProviderCore/Security/AttestationBuilder.swift
@@ -346,9 +346,11 @@ private func detectChipName() -> String {
     process.standardError = Pipe()
 
     guard let _ = try? process.run() else { return "Unknown" }
-    process.waitUntilExit()
-
+    // Drain stdout BEFORE waiting for exit. macOS pipe buffers hold only ~512
+    // bytes; system_profiler output exceeds that, so waiting first deadlocks
+    // (child blocks in write(), parent blocks in waitUntilExit()).
     let data = pipe.fileHandleForReading.readDataToEndOfFile()
+    process.waitUntilExit()
     let output = String(data: data, encoding: .utf8) ?? ""
 
     for line in output.components(separatedBy: "\n") {
@@ -387,9 +389,12 @@ private func detectSerialNumberFromIOReg() -> String? {
     process.standardError = Pipe()
 
     guard let _ = try? process.run() else { return nil }
-    process.waitUntilExit()
-
+    // Drain stdout BEFORE waiting for exit. macOS pipe buffers hold only ~512
+    // bytes and ioreg output far exceeds that, so waiting first deadlocks
+    // (child blocks in write(), parent blocks in waitUntilExit()) — which is
+    // what leaves the serial number unavailable to attestation.
     let data = pipe.fileHandleForReading.readDataToEndOfFile()
+    process.waitUntilExit()
     let output = String(data: data, encoding: .utf8) ?? ""
     return parseSerialNumberFromIOReg(output)
 }
@@ -404,9 +409,10 @@ private func detectSerialNumberFromSystemProfiler() -> String? {
     process.standardError = Pipe()
 
     guard let _ = try? process.run() else { return nil }
-    process.waitUntilExit()
-
+    // Drain stdout before waiting to avoid the pipe-buffer deadlock
+    // (see detectSerialNumberFromIOReg above).
     let data = pipe.fileHandleForReading.readDataToEndOfFile()
+    process.waitUntilExit()
     let output = String(data: data, encoding: .utf8) ?? ""
 
     return parseSerialNumberFromSystemProfiler(output)

--- a/provider-swift/Sources/ProviderCore/Security/MDMEnrollment.swift
+++ b/provider-swift/Sources/ProviderCore/Security/MDMEnrollment.swift
@@ -108,12 +108,14 @@ public func checkMDMEnrollment(coordinatorURL: String? = nil) -> MDMEnrollmentSt
         logger.debug("profiles status failed to launch: \(error)")
         return .checkFailed
     }
-    process.waitUntilExit()
-
+    // Drain stdout BEFORE waiting for exit to avoid a pipe-buffer deadlock:
+    // macOS pipe buffers hold ~512 bytes, so a child that fills the buffer
+    // blocks in write() while the parent blocks in waitUntilExit().
     let output = String(
         data: outPipe.fileHandleForReading.readDataToEndOfFile(),
         encoding: .utf8
     ) ?? ""
+    process.waitUntilExit()
 
     if process.terminationStatus != 0
         && output.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {

--- a/provider-swift/Sources/ProviderCore/Security/SecurityFoundation.swift
+++ b/provider-swift/Sources/ProviderCore/Security/SecurityFoundation.swift
@@ -44,12 +44,29 @@ public struct SecurityCommandRunner: @unchecked Sendable {
         process.standardError = stderrPipe
 
         try process.run()
+
+        // Drain stdout and stderr concurrently BEFORE waiting for exit. macOS
+        // pipe buffers hold only ~512 bytes; if the child fills either pipe it
+        // blocks in write() while the parent blocks in waitUntilExit() — a
+        // deadlock. Reading both on separate queues also prevents one pipe
+        // filling while we block draining the other.
+        let outHandle = stdoutPipe.fileHandleForReading
+        let errHandle = stderrPipe.fileHandleForReading
+        var stdoutData = Data()
+        var stderrData = Data()
+        let readGroup = DispatchGroup()
+        let readQueue = DispatchQueue(label: "security.command.read", attributes: .concurrent)
+        readGroup.enter()
+        readQueue.async { stdoutData = outHandle.readDataToEndOfFile(); readGroup.leave() }
+        readGroup.enter()
+        readQueue.async { stderrData = errHandle.readDataToEndOfFile(); readGroup.leave() }
+        readGroup.wait()
         process.waitUntilExit()
 
         return SecurityCommandResult(
             terminationStatus: process.terminationStatus,
-            stdout: String(data: stdoutPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? "",
-            stderr: String(data: stderrPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+            stdout: String(data: stdoutData, encoding: .utf8) ?? "",
+            stderr: String(data: stderrData, encoding: .utf8) ?? ""
         )
     }
 }

--- a/provider-swift/Sources/ProviderCore/Security/SecurityFoundation.swift
+++ b/provider-swift/Sources/ProviderCore/Security/SecurityFoundation.swift
@@ -45,22 +45,13 @@ public struct SecurityCommandRunner: @unchecked Sendable {
 
         try process.run()
 
-        // Drain stdout and stderr concurrently BEFORE waiting for exit. macOS
-        // pipe buffers hold only ~512 bytes; if the child fills either pipe it
-        // blocks in write() while the parent blocks in waitUntilExit() — a
-        // deadlock. Reading both on separate queues also prevents one pipe
-        // filling while we block draining the other.
-        let outHandle = stdoutPipe.fileHandleForReading
-        let errHandle = stderrPipe.fileHandleForReading
-        var stdoutData = Data()
-        var stderrData = Data()
-        let readGroup = DispatchGroup()
-        let readQueue = DispatchQueue(label: "security.command.read", attributes: .concurrent)
-        readGroup.enter()
-        readQueue.async { stdoutData = outHandle.readDataToEndOfFile(); readGroup.leave() }
-        readGroup.enter()
-        readQueue.async { stderrData = errHandle.readDataToEndOfFile(); readGroup.leave() }
-        readGroup.wait()
+        // Drain the pipes BEFORE waiting for exit. macOS pipe buffers hold only
+        // ~512 bytes; a child that fills stdout blocks in write() while the
+        // parent blocks in waitUntilExit() — a deadlock. readDataToEndOfFile()
+        // reads until the child closes the stream, so draining stdout first
+        // also unblocks the child and lets it finish and close stderr.
+        let stdoutData = stdoutPipe.fileHandleForReading.readDataToEndOfFile()
+        let stderrData = stderrPipe.fileHandleForReading.readDataToEndOfFile()
         process.waitUntilExit()
 
         return SecurityCommandResult(

--- a/provider-swift/Sources/ProviderCore/Security/SecurityHardening.swift
+++ b/provider-swift/Sources/ProviderCore/Security/SecurityHardening.swift
@@ -102,9 +102,10 @@ public func checkRDMADisabled() -> Bool {
         logger.debug("RDMA check: rdma_ctl not available, assuming safe")
         return true
     }
-    process.waitUntilExit()
-
+    // Drain stdout before waiting to avoid a pipe-buffer deadlock (macOS pipe
+    // buffers are ~512B; waiting before reading hangs a child that fills them).
     let data = pipe.fileHandleForReading.readDataToEndOfFile()
+    process.waitUntilExit()
     let output = String(data: data, encoding: .utf8) ?? ""
     let disabled = output.trimmingCharacters(in: .whitespacesAndNewlines) == "disabled"
 
@@ -182,9 +183,10 @@ public func checkHardenedRuntimeEnabled() -> Bool {
         logger.warning("Hardened Runtime check: failed to run codesign: \(error)")
         return false
     }
-    process.waitUntilExit()
-
+    // codesign writes to stderr; drain it before waiting to avoid a
+    // pipe-buffer deadlock (macOS pipe buffers are ~512B).
     let data = errPipe.fileHandleForReading.readDataToEndOfFile()
+    process.waitUntilExit()
     let output = String(data: data, encoding: .utf8) ?? ""
 
     // Look for "flags=0x10000(runtime)" which indicates hardened runtime
@@ -243,13 +245,15 @@ public func verifyBundleSignature() throws {
         logger.warning("Could not verify bundle signature: \(error)")
         return // Don't fail if codesign isn't available
     }
+    // Drain stderr BEFORE waiting to avoid a pipe-buffer deadlock (codesign
+    // writes diagnostics to stderr; macOS pipe buffers are ~512B).
+    let errData = errPipe.fileHandleForReading.readDataToEndOfFile()
     process.waitUntilExit()
 
     if process.terminationStatus == 0 {
         logger.info("App bundle signature valid")
     } else {
-        let data = errPipe.fileHandleForReading.readDataToEndOfFile()
-        let stderr = String(data: data, encoding: .utf8) ?? "unknown error"
+        let stderr = String(data: errData, encoding: .utf8) ?? "unknown error"
         throw SecurityError.bundleSignatureInvalid(stderr)
     }
 }
@@ -396,9 +400,10 @@ public func systemVolumeHash() -> String? {
     } catch {
         return nil
     }
-    process.waitUntilExit()
-
+    // Drain stdout before waiting to avoid a pipe-buffer deadlock: diskutil
+    // output exceeds the ~512B macOS pipe buffer, so waiting first hangs.
     let data = pipe.fileHandleForReading.readDataToEndOfFile()
+    process.waitUntilExit()
     let output = String(data: data, encoding: .utf8) ?? ""
 
     // Extract hash from snapshot name: com.apple.os.update-<HASH>

--- a/provider-swift/Sources/ProviderCore/Service/LaunchAgent.swift
+++ b/provider-swift/Sources/ProviderCore/Service/LaunchAgent.swift
@@ -228,13 +228,14 @@ public enum LaunchAgent: Sendable {
         process.standardError = errPipe
 
         try process.run()
+
+        // Drain stderr before waiting to avoid a pipe-buffer deadlock
+        // (macOS pipe buffers are ~512B).
+        let stderrData = errPipe.fileHandleForReading.readDataToEndOfFile()
         process.waitUntilExit()
 
         if process.terminationStatus != 0 {
-            let stderr = String(
-                data: errPipe.fileHandleForReading.readDataToEndOfFile(),
-                encoding: .utf8
-            ) ?? ""
+            let stderr = String(data: stderrData, encoding: .utf8) ?? ""
             // Error 3 = "could not find service": the service vanished between
             // the isLoaded() check and here.
             if stderr.contains("3:") || stderr.contains("could not find service") {
@@ -460,13 +461,14 @@ public enum LaunchAgent: Sendable {
         bootstrap.standardError = errPipe
 
         try bootstrap.run()
+
+        // Drain stderr before waiting to avoid a pipe-buffer deadlock
+        // (macOS pipe buffers are ~512B).
+        let stderrData = errPipe.fileHandleForReading.readDataToEndOfFile()
         bootstrap.waitUntilExit()
 
         if bootstrap.terminationStatus != 0 {
-            let stderr = String(
-                data: errPipe.fileHandleForReading.readDataToEndOfFile(),
-                encoding: .utf8
-            ) ?? ""
+            let stderr = String(data: stderrData, encoding: .utf8) ?? ""
             // Error 37 = "already loaded" -- not a real failure.
             if !stderr.contains("37:") && !stderr.contains("already loaded") {
                 throw LaunchAgentError.bootstrapFailed(stderr.trimmingCharacters(in: .whitespacesAndNewlines))
@@ -491,13 +493,13 @@ public enum LaunchAgent: Sendable {
         } catch {
             throw LaunchAgentError.kickstartFailed("could not run launchctl kickstart: \(error.localizedDescription)")
         }
+        // Drain stderr before waiting to avoid a pipe-buffer deadlock
+        // (macOS pipe buffers are ~512B).
+        let kickstartErrData = kickstartErr.fileHandleForReading.readDataToEndOfFile()
         kickstart.waitUntilExit()
 
         if kickstart.terminationStatus != 0 {
-            let stderr = String(
-                data: kickstartErr.fileHandleForReading.readDataToEndOfFile(),
-                encoding: .utf8
-            ) ?? ""
+            let stderr = String(data: kickstartErrData, encoding: .utf8) ?? ""
             throw LaunchAgentError.kickstartFailed(stderr.trimmingCharacters(in: .whitespacesAndNewlines))
         }
     }
@@ -513,13 +515,14 @@ public enum LaunchAgent: Sendable {
         process.standardError = errPipe
 
         try process.run()
+
+        // Drain stderr before waiting to avoid a pipe-buffer deadlock
+        // (macOS pipe buffers are ~512B).
+        let stderrData = errPipe.fileHandleForReading.readDataToEndOfFile()
         process.waitUntilExit()
 
         if process.terminationStatus != 0 {
-            let stderr = String(
-                data: errPipe.fileHandleForReading.readDataToEndOfFile(),
-                encoding: .utf8
-            ) ?? ""
+            let stderr = String(data: stderrData, encoding: .utf8) ?? ""
             // Error 3 = "could not find service" -- already unloaded, not an error.
             if !stderr.contains("3:") && !stderr.contains("could not find service") {
                 throw LaunchAgentError.bootoutFailed(stderr.trimmingCharacters(in: .whitespacesAndNewlines))

--- a/provider-swift/Sources/darkbloom/Diagnostics/DoctorRunner.swift
+++ b/provider-swift/Sources/darkbloom/Diagnostics/DoctorRunner.swift
@@ -198,11 +198,13 @@ enum DoctorRunner {
         p.arguments = ["-g", "assertions"]
         let out = Pipe()
         p.standardOutput = out
-        p.standardError = Pipe()
+        p.standardError = FileHandle.nullDevice
         guard (try? p.run()) != nil else { return nil }
+        // Drain stdout before waiting to avoid a pipe-buffer deadlock
+        // (pmset output can exceed the ~512B macOS pipe buffer).
+        let data = out.fileHandleForReading.readDataToEndOfFile()
         p.waitUntilExit()
         guard p.terminationStatus == 0 else { return nil }
-        let data = out.fileHandleForReading.readDataToEndOfFile()
         guard let text = String(data: data, encoding: .utf8) else { return nil }
         // `PreventUserIdleSystemSleep` / `PreventSystemSleep` report 1 when an
         // assertion (e.g. caffeinate, an active inference) is holding the system


### PR DESCRIPTION
Fixes #689.

## Problem
`HardwareDetector` and the attestation/security posture code spawn subprocesses (`system_profiler`, `ioreg`, `diskutil`, `csrutil`, `codesign`) with a `Pipe` on stdout/stderr and call `Process.waitUntilExit()` **before reading the pipe**. macOS pipe buffers start at ~512 bytes; the child fills the buffer, blocks in `write()`, and never exits, while the parent blocks in `waitUntilExit()` — a deadlock.

- `detectGPUInfo()`'s `system_profiler SPDisplaysDataType -json` emits 1260 B with one built-in display → **every `login`/`start`/`doctor`/`verify`/`status` hangs on any Mac with a screen.** Headless Macs escape it (output < 512 B), which is why fleet testing misses it.
- The `ioreg` serial readers deadlock too, so even a healthy genuine provider can't complete attestation — `verify` shows `coordinator trust: local serial number unavailable`. So this blocks **earning**, not just diagnostics.

## Fix
Drain the pipe(s) **before** waiting, at every site. `readDataToEndOfFile()` blocks until the child closes the stream, so it also serves as the join point; `waitUntilExit()` then just reaps. Sites whose output is unused route to `FileHandle.nullDevice`. Reads stay sequential (draining the large stream first unblocks the child) to remain clean under Swift 6 strict concurrency.

### Sites changed
| File | Function(s) |
|---|---|
| `ProviderCore/Hardware/HardwareDetector.swift` | `detectGPUInfo` |
| `ProviderCore/Security/AttestationBuilder.swift` | `detectChipName`, `detectSerialNumberFromIOReg`, `detectSerialNumberFromSystemProfiler` |
| `ProviderCore/Auth/Enrollment.swift` | serial reader |
| `ProviderCore/Security/SecurityFoundation.swift` | `SecurityCommandRunner.live` |
| `ProviderCore/Security/SecurityHardening.swift` | RDMA / Hardened-Runtime / bundle-signature / system-volume checks |
| `ProviderCore/Security/MDMEnrollment.swift` | `profiles status` |
| `darkbloom/Diagnostics/DoctorRunner.swift` | `pmset` sleep check |
| `ProviderCore/Service/LaunchAgent.swift` | load / bootstrap / kickstart / unload |

## Testing
`swift build --target ProviderCore` → **Build complete!** (Swift 6.1 tools, full MLX submodules). The `SelfUpdaterTests` file has the same pattern (not changed here; test-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/690"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790132724&installation_model_id=21733&pr_number=690&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F690&signature=36e35873fae9447cbce4e9a6f1baa89894f7d98889b96aaea5c66cc5cdb98e0e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->