### PR TITLE
feat(provider): integrate Qwen3.8-27B full VLM

### DIFF
--- a/coordinator/api/auto_toolschema_regression_test.go
+++ b/coordinator/api/auto_toolschema_regression_test.go
@@ -155,7 +155,7 @@ func TestAutoToolChoiceForwardsStandardJSONSchema(t *testing.T) {
 			if mode != toolChoiceNone {
 				t.Fatalf("%s: mode = %q, want none", name, mode)
 			}
-			if mode.requiresGrammar() {
+			if mode.requiresInferenceConstraint() {
 				t.Errorf("%s: none demanded an inference-enforcing provider", name)
 			}
 		}
@@ -273,5 +273,5 @@ func TestToolConstraintCapabilityErrorSeparatesPermanentFromTransient(t *testing
 	if err != nil {
 		t.Fatal(err)
 	}
-	failFast(t, false, mode.requiresGrammar(), nil)
+	failFast(t, false, mode.requiresInferenceConstraint(), nil)
 }

--- a/coordinator/api/concrete_model_entries.go
+++ b/coordinator/api/concrete_model_entries.go
@@ -127,12 +127,21 @@ func (s *Server) openRouterEntryForConcrete(
 	}
 
 	registryEntry, hasRegistryEntry := registryByID[modelID]
+	modelType := catalogModel.ModelType
+	if aggregateType, found := aggregateTypeByID[modelID]; found {
+		modelType = aggregateType
+	}
+	var capabilities []string
+	if hasRegistryEntry {
+		capabilities = registryEntry.Capabilities
+	}
+	inputModalities, outputModalities := deriveModalities(modelType, capabilities)
 	entry := types.OpenRouterModel{
 		ID:                modelID,
 		HuggingFaceID:     huggingFaceIDForModel(modelID, registryEntry.Metadata),
 		Name:              openRouterModelName(catalogModel, registryEntry, hasRegistryEntry, modelID),
-		InputModalities:   []string{"text"},
-		OutputModalities:  []string{"text"},
+		InputModalities:   inputModalities,
+		OutputModalities:  outputModalities,
 		SupportedFeatures: []string{},
 		IsReady:           true,
 	}

--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -1513,7 +1513,7 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	toolChoiceName := validatedPolicy.name
 	parallelToolCalls := validatedPolicy.parallel
 	s.recordToolConstraintMetric(validatedMode, "requested")
-	requiresToolConstraint := validatedMode.requiresGrammar()
+	requiresToolConstraint := validatedMode.requiresInferenceConstraint()
 	if requiresToolConstraint && requiresVision {
 		writeJSON(w, http.StatusBadRequest, errorResponse(
 			"invalid_request_error",
@@ -3905,7 +3905,7 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 	toolChoiceName := validatedPolicy.name
 	parallelToolCalls := validatedPolicy.parallel
 	s.recordToolConstraintMetric(validatedMode, "requested")
-	requiresToolConstraint := validatedMode.requiresGrammar()
+	requiresToolConstraint := validatedMode.requiresInferenceConstraint()
 	requiresVision := detectMediaRequirement(parsed)
 	hasTools := requestHasTools(parsed)
 	aliasTraits := registry.RequestTraits{

--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -1582,20 +1582,16 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Inject model-specific defaults from the registry: reasoning_parser
-	// and max_tokens bound. Single DB lookup (cached for platform prices).
+	// Inject model-specific request defaults from the registry, then apply the
+	// model's max_tokens bound. Single DB lookup (cached for platform prices).
 	maxOutputBound := defaultMaxOutputTokens
 	// modelMaxContext is the model's max context window (0 = unknown), used by the
 	// servability gate. Lifted out of the record block so it is in scope at the
 	// preflight below.
 	modelMaxContext := 0
 	if rec, err := s.store.GetModelRegistryRecord(model); err == nil {
-		// Reasoning parser from runtime_parameters.
-		if _, hasRP := parsed["reasoning_parser"]; !hasRP && rec.RuntimeParameters != nil {
-			if rp, ok := rec.RuntimeParameters["reasoning_parser"]; ok {
-				parsed["reasoning_parser"] = rp
-				rawBody, _ = marshalForwardBody(parsed)
-			}
+		if injectModelRuntimeDefaults(parsed, rec.RuntimeParameters) {
+			rawBody, _ = marshalForwardBody(parsed)
 		}
 		// Use the registry's max_output_length as the default max_tokens
 		// bound instead of the hardcoded 8192. This lets models like

--- a/coordinator/api/model_runtime_defaults.go
+++ b/coordinator/api/model_runtime_defaults.go
@@ -1,0 +1,32 @@
+package api
+
+import "strings"
+
+// requestRuntimeDefaultKeys is the catalog-owned subset of runtime_parameters
+// that belongs on the forwarded OpenAI request. Keep this allowlist narrow:
+// registry metadata may also carry provider/load controls that must never be
+// copied into a consumer body.
+var requestRuntimeDefaultKeys = [...]string{
+	"reasoning_parser",
+	"tool_call_parser",
+}
+
+// injectModelRuntimeDefaults fills omitted request fields from the model's
+// registry record. Explicit consumer values always win. Only non-empty string
+// defaults are forwarded so malformed admin metadata cannot turn an otherwise
+// valid inference request into a provider-side JSON decode failure.
+func injectModelRuntimeDefaults(parsed map[string]any, runtimeParameters map[string]any) bool {
+	changed := false
+	for _, key := range requestRuntimeDefaultKeys {
+		if _, exists := parsed[key]; exists {
+			continue
+		}
+		value, ok := runtimeParameters[key].(string)
+		if !ok || strings.TrimSpace(value) == "" {
+			continue
+		}
+		parsed[key] = value
+		changed = true
+	}
+	return changed
+}

--- a/coordinator/api/openrouter_endpoint.go
+++ b/coordinator/api/openrouter_endpoint.go
@@ -129,6 +129,11 @@ func (s *Server) openRouterAliasEntries(
 		}
 
 		reg, hasReg := registryByID[primary]
+		var capabilities []string
+		if hasReg {
+			capabilities = reg.Capabilities
+		}
+		inputModalities, outputModalities := deriveModalities(modelType, capabilities)
 		displayName := a.DisplayName
 		if displayName == "" {
 			displayName = openRouterModelName(cm, reg, hasReg, a.AliasID)
@@ -137,8 +142,8 @@ func (s *Server) openRouterAliasEntries(
 			ID:                a.AliasID,
 			HuggingFaceID:     huggingFaceIDForModel(primary, reg.Metadata),
 			Name:              displayName,
-			InputModalities:   []string{"text"},
-			OutputModalities:  []string{"text"},
+			InputModalities:   inputModalities,
+			OutputModalities:  outputModalities,
 			SupportedFeatures: []string{},
 			IsReady:           true,
 		}

--- a/coordinator/api/qwen38_registry_fixture_test.go
+++ b/coordinator/api/qwen38_registry_fixture_test.go
@@ -1,0 +1,281 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/api/types"
+	"github.com/eigeninference/d-inference/coordinator/registry"
+	"github.com/eigeninference/d-inference/coordinator/store"
+	"nhooyr.io/websocket"
+)
+
+const (
+	qwen38ConcreteModel = "mlx-community/Qwen3.8-27B-4bit"
+	qwen38PublicAlias   = "qwen/qwen3.8-27b"
+	qwen38TargetRev     = "3e6447f082e89cc7f0bc6e5441afd38dfce760ff"
+	qwen38MTPModel      = "mlx-community/Qwen3.8-27B-MTP-4bit"
+	qwen38MTPRev        = "b643c01b6d3b094e325edb6ebd832e16c486c575"
+)
+
+func qwen38RegistryFixture() *store.ModelRegistryEntry {
+	return &store.ModelRegistryEntry{
+		ID:               qwen38ConcreteModel,
+		DisplayName:      "Qwen3.8 27B",
+		Family:           "qwen3.8",
+		Architecture:     "27B dense VLM",
+		Quantization:     "4bit",
+		MaxContextLength: 262144,
+		MaxOutputLength:  32768,
+		MinRAMGB:         48,
+		Capabilities:     []string{"tools", "reasoning", "json_mode", "vision", "video"},
+		Status:           "active",
+		Description:      "Dense Qwen3.8 vision-language model with bounded image and video input.",
+		RuntimeParameters: map[string]any{
+			"reasoning_parser":       "qwen3",
+			"tool_call_parser":       "qwen3_coder",
+			"chat_template_required": true,
+		},
+		Metadata: map[string]any{
+			huggingFaceIDMetadataKey: qwen38ConcreteModel,
+			"source_revision":        qwen38TargetRev,
+			"mtp_artifact_id":        qwen38MTPModel,
+			"mtp_source_revision":    qwen38MTPRev,
+			"runtime_compatibility":  "provider>=0.8.11",
+			"openrouter_slug":        qwen38PublicAlias,
+			"openrouter_is_ready":    true,
+		},
+		CreatedAt: time.Date(2026, 8, 24, 0, 0, 0, 0, time.UTC),
+	}
+}
+
+func TestInjectModelRuntimeDefaults(t *testing.T) {
+	t.Run("fills both parser defaults", func(t *testing.T) {
+		parsed := map[string]any{"model": qwen38ConcreteModel}
+		if !injectModelRuntimeDefaults(parsed, qwen38RegistryFixture().RuntimeParameters) {
+			t.Fatal("expected request defaults to change the body")
+		}
+		if parsed["reasoning_parser"] != "qwen3" || parsed["tool_call_parser"] != "qwen3_coder" {
+			t.Fatalf("parser defaults = %#v", parsed)
+		}
+		if _, leaked := parsed["chat_template_required"]; leaked {
+			t.Fatal("provider/catalog-only runtime parameter leaked into request body")
+		}
+	})
+
+	t.Run("explicit consumer values win", func(t *testing.T) {
+		parsed := map[string]any{
+			"reasoning_parser": "deepseek_r1",
+			"tool_call_parser": "qwen_xml",
+		}
+		if injectModelRuntimeDefaults(parsed, qwen38RegistryFixture().RuntimeParameters) {
+			t.Fatal("explicit request values should not be changed")
+		}
+		if parsed["reasoning_parser"] != "deepseek_r1" || parsed["tool_call_parser"] != "qwen_xml" {
+			t.Fatalf("explicit values changed: %#v", parsed)
+		}
+	})
+
+	t.Run("malformed metadata is ignored", func(t *testing.T) {
+		parsed := map[string]any{}
+		if injectModelRuntimeDefaults(parsed, map[string]any{
+			"reasoning_parser": 7,
+			"tool_call_parser": "  ",
+		}) {
+			t.Fatalf("malformed metadata changed request: %#v", parsed)
+		}
+	})
+}
+
+// This fixture pins the intended post-review registration contract without
+// mutating a production catalog. It verifies that the generic registry, alias,
+// OpenRouter, pricing, modality, and live-capacity surfaces preserve every
+// launch-critical Qwen3.8 field.
+func TestQwen38RegistrySurfaceFixture(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	st := store.NewMemory(store.Config{AdminKey: "test-key"})
+	reg := registry.New(logger)
+	srv := NewServer(reg, st, ServerConfig{}, logger)
+	srv.challengeInterval = 500 * time.Millisecond
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	entry := qwen38RegistryFixture()
+	const version = "2026-08-24-r1"
+	files := []store.ModelVersionFile{{
+		Path: "config.json", SizeBytes: 1, SHA256: testHash, Role: "config",
+	}}
+	if err := st.SetModelVersion(entry, &store.ModelVersion{
+		ModelID: qwen38ConcreteModel, Version: version,
+		R2Prefix:        modelR2Prefix(qwen38ConcreteModel, version),
+		AggregateSHA256: testHash, TotalSizeBytes: 17_000_000_000,
+		FileCount: len(files), Status: "ready",
+	}, files); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.PromoteModelVersion(qwen38ConcreteModel, version); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.SetModelPrice("platform", qwen38ConcreteModel, 50_000, 200_000); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.UpsertModelAlias(&store.ModelAlias{
+		AliasID: qwen38PublicAlias, DisplayName: entry.DisplayName,
+		DesiredBuild: qwen38ConcreteModel, Active: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	srv.SyncModelCatalog()
+
+	build, isAlias, ok := reg.ResolveModel(qwen38PublicAlias)
+	if !ok || !isAlias || build != qwen38ConcreteModel {
+		t.Fatalf("alias resolution = %q isAlias=%v ok=%v", build, isAlias, ok)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	conn := connectAndPrepareProvider(
+		t, ctx, ts.URL, reg, qwen38ConcreteModel, testPublicKeyB64(), 18.0)
+	defer conn.Close(websocket.StatusNormalClosure, "")
+
+	t.Run("catalog item", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		srv.Handler().ServeHTTP(rec, httptest.NewRequest(
+			http.MethodGet, "/v1/models/catalog/"+qwen38ConcreteModel, nil))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+		}
+		var model map[string]any
+		if err := json.Unmarshal(rec.Body.Bytes(), &model); err != nil {
+			t.Fatal(err)
+		}
+		if model["family"] != "qwen3.8" || model["architecture"] != "27B dense VLM" {
+			t.Fatalf("identity metadata = %#v", model)
+		}
+		if int(model["max_context_length"].(float64)) != 262144 ||
+			int(model["max_output_length"].(float64)) != 32768 ||
+			int(model["min_ram_gb"].(float64)) != 48 {
+			t.Fatalf("launch limits = %#v", model)
+		}
+		runtime, _ := model["runtime_parameters"].(map[string]any)
+		if runtime["reasoning_parser"] != "qwen3" || runtime["tool_call_parser"] != "qwen3_coder" || runtime["chat_template_required"] != true {
+			t.Fatalf("runtime defaults = %#v", runtime)
+		}
+		metadata, _ := model["metadata"].(map[string]any)
+		if metadata["source_revision"] != qwen38TargetRev || metadata["mtp_artifact_id"] != qwen38MTPModel || metadata["mtp_source_revision"] != qwen38MTPRev {
+			t.Fatalf("artifact metadata = %#v", metadata)
+		}
+	})
+
+	t.Run("consumer model alias", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		srv.handleListModels(rec, httptest.NewRequest(http.MethodGet, "/v1/models", nil))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+		}
+		var response types.ModelListResponse
+		if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+			t.Fatal(err)
+		}
+		model := findQwen38ModelEntry(t, response.Data)
+		assertQwen38PublicFields(t, model.ContextLength, model.MaxOutputLength,
+			model.InputModalities, model.OutputModalities, model.SupportedFeatures)
+		if model.ID != qwen38PublicAlias || model.HuggingFaceID != qwen38ConcreteModel {
+			t.Fatalf("alias identity = %+v", model)
+		}
+		if model.Pricing == nil || model.Pricing.Prompt != "0.00000005" || model.Pricing.Completion != "0.0000002" {
+			t.Fatalf("pricing = %+v", model.Pricing)
+		}
+		for _, item := range response.Data {
+			if item.ID == qwen38ConcreteModel {
+				t.Fatal("concrete build leaked from the default alias-backed listing")
+			}
+		}
+	})
+
+	t.Run("OpenRouter feed", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		srv.handleListModelsOpenRouter(rec, httptest.NewRequest(
+			http.MethodGet, "/v1/models/openrouter", nil))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+		}
+		var response types.OpenRouterModelsResponse
+		if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+			t.Fatal(err)
+		}
+		var model *types.OpenRouterModel
+		for i := range response.Data {
+			if response.Data[i].ID == qwen38PublicAlias {
+				model = &response.Data[i]
+				break
+			}
+		}
+		if model == nil {
+			t.Fatalf("Qwen3.8 alias absent: %s", rec.Body.String())
+		}
+		assertQwen38PublicFields(t, model.ContextLength, model.MaxOutputLength,
+			model.InputModalities, model.OutputModalities, model.SupportedFeatures)
+		if !model.IsReady || model.OpenRouter == nil || model.OpenRouter.Slug != qwen38PublicAlias {
+			t.Fatalf("OpenRouter readiness/slug = %+v", model)
+		}
+	})
+
+	t.Run("live capacity", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		srv.handleModelsCapacity(rec, httptest.NewRequest(
+			http.MethodGet, "/v1/models/capacity", nil))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+		}
+		var response modelsCapacityResponse
+		if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+			t.Fatal(err)
+		}
+		for _, model := range response.Models {
+			if model.ModelID == qwen38ConcreteModel {
+				if model.RoutableProviders < 1 {
+					t.Fatalf("capacity = %+v", model)
+				}
+				return
+			}
+		}
+		t.Fatalf("Qwen3.8 capacity absent: %+v", response.Models)
+	})
+}
+
+func findQwen38ModelEntry(t *testing.T, entries []types.ModelEntry) types.ModelEntry {
+	t.Helper()
+	for _, entry := range entries {
+		if entry.ID == qwen38PublicAlias {
+			return entry
+		}
+	}
+	t.Fatalf("Qwen3.8 alias absent: %+v", entries)
+	return types.ModelEntry{}
+}
+
+func assertQwen38PublicFields(
+	t *testing.T,
+	contextLength, maxOutputLength int,
+	inputModalities, outputModalities, features []string,
+) {
+	t.Helper()
+	if contextLength != 262144 || maxOutputLength != 32768 {
+		t.Fatalf("context/output = %d/%d", contextLength, maxOutputLength)
+	}
+	if !reflect.DeepEqual(inputModalities, []string{"text", "image", "video"}) ||
+		!reflect.DeepEqual(outputModalities, []string{"text"}) {
+		t.Fatalf("modalities = %v -> %v", inputModalities, outputModalities)
+	}
+	if !reflect.DeepEqual(features, []string{"json_mode", "reasoning", "tools"}) {
+		t.Fatalf("features = %v", features)
+	}
+}

--- a/coordinator/api/server.go
+++ b/coordinator/api/server.go
@@ -151,7 +151,7 @@ func keyLimitResetFromContext(ctx context.Context) string {
 // the provider's EngineV2Factory.prepareProductionBackend for the argument).
 // Keep this fallback in sync with ProviderCore.version so dev/in-memory
 // coordinators advertise the same floor as the Swift binary they expect.
-var LatestProviderVersion = "0.8.10"
+var LatestProviderVersion = "0.8.11"
 
 // minProviderVersionForDesiredModels is the first provider version whose Swift
 // runtime understands the desired_models message. The coordinator must NOT send

--- a/coordinator/api/tool_constraints.go
+++ b/coordinator/api/tool_constraints.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"regexp"
+	"strings"
 )
 
 type toolChoiceMode string
@@ -68,11 +69,12 @@ func validateToolConstraintPolicy(body []byte) (validatedToolConstraintPolicy, e
 	}
 
 	enforceSchema := mode == toolChoiceRequired || mode == toolChoiceNamed
-	if mode.requiresGrammar() {
+	if mode.requiresInferenceConstraint() {
 		if parser, exists := root["tool_call_parser"]; exists && parser != nil {
-			if parser != "gemma" {
+			name, ok := parser.(string)
+			if !ok || !supportsInferenceEnforcedToolChoice(name) {
 				return policy, invalidToolConstraint(
-					"inference-enforced Gemma tool_choice requires tool_call_parser 'gemma'",
+					"inference-enforced tool_choice requires a supported Gemma or Qwen tool_call_parser",
 					"tool_call_parser")
 			}
 		}
@@ -105,6 +107,17 @@ func validateToolConstraintPolicy(body []byte) (validatedToolConstraintPolicy, e
 		return policy, err
 	}
 	return policy, nil
+}
+
+func supportsInferenceEnforcedToolChoice(parser string) bool {
+	normalized := strings.ReplaceAll(strings.ToLower(strings.TrimSpace(parser)), "-", "_")
+	switch normalized {
+	case "gemma", "gemma4", "gemma_4",
+		"qwen3_coder", "qwen3", "qwen3_5", "qwen_xml", "xml", "xml_function":
+		return true
+	default:
+		return false
+	}
 }
 
 func validateConstrainedStops(raw any) error {
@@ -151,13 +164,13 @@ func validateConstrainedStops(raw any) error {
 	return nil
 }
 
-// requiresGrammar reports whether the mode needs a sampler-level grammar, and
-// therefore a provider advertising inference-time tool_choice enforcement.
+// requiresInferenceConstraint reports whether the mode needs provider-side
+// inference-time tool_choice enforcement (a sampler grammar for Gemma or
+// withheld parse/schema validation for Qwen).
 // `none` is deliberately excluded: it is honored by hiding tools from the
 // rendered prompt and rejecting any call the model emits anyway after
-// generation, so it needs no grammar and must not be fenced to the
-// Gemma-class constrained provider pool.
-func (m toolChoiceMode) requiresGrammar() bool {
+// generation, so it must not be fenced to the constrained provider pool.
+func (m toolChoiceMode) requiresInferenceConstraint() bool {
 	return m == toolChoiceRequired || m == toolChoiceNamed
 }
 

--- a/coordinator/api/tool_constraints_test.go
+++ b/coordinator/api/tool_constraints_test.go
@@ -208,6 +208,21 @@ func TestValidateToolConstraintRequestAcceptsNormalizedSubset(t *testing.T) {
 	}
 }
 
+func TestValidateToolConstraintRequestAcceptsForcedQwenParserAliases(t *testing.T) {
+	const prefix = `{"model":"m","messages":[{"role":"user","content":"x"}],"tools":[{"type":"function","function":{"name":"weather"}}],"tool_choice":"required","tool_call_parser":`
+	for _, parser := range []string{
+		"qwen3_coder", "qwen3", "qwen3_5", "qwen-xml", "xml_function",
+	} {
+		t.Run(parser, func(t *testing.T) {
+			body := []byte(prefix + fmt.Sprintf("%q}", parser))
+			mode, err := validateToolConstraintRequest(body)
+			if err != nil || mode != toolChoiceRequired {
+				t.Fatalf("Qwen parser alias rejected: mode=%q err=%v", mode, err)
+			}
+		})
+	}
+}
+
 func TestValidateToolHistoryAllowsTrailingAssistantContinuation(t *testing.T) {
 	body := []byte(`{
 		"model":"m",

--- a/coordinator/protocol/messages.go
+++ b/coordinator/protocol/messages.go
@@ -197,7 +197,7 @@ type RegisterMessage struct {
 	PrefixCacheV2Models         []PrefixCacheV2Capability          `json:"prefix_cache_v2_models,omitempty"`
 	PrefixCacheStatuses         *[]PrefixCacheModelStatus          `json:"prefix_cache_statuses,omitempty"`
 	PrefixCacheDonationOutcomes *[]PrefixCacheDonationOutcomeCount `json:"prefix_cache_donation_outcomes,omitempty"`
-	ToolConstraintProtocol      int                                `json:"tool_constraint_protocol,omitempty"` // inference-time tool grammar protocol version
+	ToolConstraintProtocol      int                                `json:"tool_constraint_protocol,omitempty"` // inference-time forced-tool enforcement protocol version
 	ToolConstraintModels        []string                           `json:"tool_constraint_models,omitempty"`   // concrete model IDs enforced by this provider
 
 	// APNs code-identity attestation (v0.6.0): the device token the coordinator

--- a/e2e/integration_test.go
+++ b/e2e/integration_test.go
@@ -2,6 +2,7 @@ package e2e
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -197,6 +198,84 @@ func TestIntegration_NonStreamingInference(t *testing.T) {
 	t.Logf("\n%s", run.SummaryTable())
 
 	assertAccounting(t, s)
+}
+
+func TestIntegration_Qwen38RequiredToolChoice(t *testing.T) {
+	model := testbed.DefaultTestModelID()
+	if !strings.Contains(strings.ToLower(model), "qwen3.8") {
+		t.Skip("set DARKBLOOM_TESTBED_MODEL to a Qwen3.8 checkpoint")
+	}
+
+	ctx := context.Background()
+	s := testbed.NewSuite(testbed.SuiteConfig{UseMemoryStore: true})
+	require.NoError(t, s.Start(ctx), "suite startup failed")
+	t.Cleanup(s.Stop)
+	body := map[string]any{
+		"model": model,
+		"messages": []map[string]string{{
+			"role": "user", "content": "What is the weather in Boston?",
+		}},
+		"tools": []map[string]any{{
+			"type": "function",
+			"function": map[string]any{
+				"name":        "get_weather",
+				"description": "Get weather for a city",
+				"parameters": map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"city": map[string]string{"type": "string"},
+					},
+					"required":             []string{"city"},
+					"additionalProperties": false,
+				},
+			},
+		}},
+		"tool_choice":      "required",
+		"tool_call_parser": "qwen3_coder",
+		"enable_thinking":  false,
+		"reasoning_effort": "low",
+		"temperature":      0.0,
+		"max_tokens":       96,
+	}
+	bodyJSON, err := json.Marshal(body)
+	require.NoError(t, err)
+	req, err := http.NewRequestWithContext(
+		s.Ctx, http.MethodPost, s.Coordinator.BaseURL()+"/v1/chat/completions",
+		bytes.NewReader(bodyJSON))
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer testbed-admin-key")
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := (&http.Client{Timeout: httpTimeout}).Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode, "body: %s", respBody)
+
+	var completion struct {
+		Choices []struct {
+			Message struct {
+				ToolCalls []struct {
+					Function struct {
+						Name      string `json:"name"`
+						Arguments string `json:"arguments"`
+					} `json:"function"`
+				} `json:"tool_calls"`
+			} `json:"message"`
+		} `json:"choices"`
+	}
+	require.NoError(t, json.Unmarshal(respBody, &completion))
+	require.NotEmpty(t, completion.Choices)
+	require.Len(t, completion.Choices[0].Message.ToolCalls, 1)
+	call := completion.Choices[0].Message.ToolCalls[0].Function
+	require.Equal(t, "get_weather", call.Name)
+	var arguments map[string]any
+	require.NoError(t, json.Unmarshal([]byte(call.Arguments), &arguments))
+	require.Equal(t, "Boston", arguments["city"])
+
+	report := tbassert.NewAccountingAsserter(s.PgStore).EvaluateAll(s.Ctx)
+	require.True(t, report.Passed, "accounting integrity check failed\n%s", report.SummaryTable())
 }
 
 func TestIntegration_StreamingInference(t *testing.T) {

--- a/e2e/testbed/kv_posture_test.go
+++ b/e2e/testbed/kv_posture_test.go
@@ -102,10 +102,10 @@ func TestDescribeKVPostureNamesProvenance(t *testing.T) {
 	}
 }
 
-// The posture log used to live inside the "a config file was written" branch,
-// so the one run whose backend nobody chose was also the one run that logged
-// no backend at all. That is the shape of the defect this lane fixes.
-func TestPostureLoggedWhenNoConfigIsWritten(t *testing.T) {
+// The default posture still gets a testbed config so updater/watchdog processes
+// cannot outlive the suite, while the log must identify that no KV knobs were
+// selected.
+func TestDefaultPostureIsLoggedAndDisablesPersistentServices(t *testing.T) {
 	t.Setenv("DARKBLOOM_TESTBED_KV_BACKEND", "")
 	t.Setenv("DARKBLOOM_TESTBED_MAX_CONCURRENT", "")
 
@@ -131,7 +131,9 @@ func TestPostureLoggedWhenNoConfigIsWritten(t *testing.T) {
 		!strings.Contains(got, "kv_backend=provider default") {
 		t.Fatalf("default launch logged no KV posture:\n%s", got)
 	}
-	if p.generatedConfig != "" {
-		t.Fatalf("default launch wrote a config: %q", p.generatedConfig)
+	for _, want := range []string{"auto_update = false", "auto_restart = false"} {
+		if !strings.Contains(p.generatedConfig, want) {
+			t.Fatalf("default testbed config missing %q:\n%s", want, p.generatedConfig)
+		}
 	}
 }

--- a/e2e/testbed/provider.go
+++ b/e2e/testbed/provider.go
@@ -185,20 +185,15 @@ func findProviderBinary() string {
 // can force paged OFF but never ON — so `engine_v2_kv_backend = "paged"` under
 // `[backend]` is the sole way an e2e run can exercise paged KV.
 //
-// Returns ("", nil) when neither knob is set, so the default path never
-// materialises a file and never grows a `--config` argument.
-//
-// `auto_update` / `auto_restart` are pinned off: a testbed provider must not
-// self-update mid-suite, and must not install the launchd crash-recovery
-// watchdog, which would outlive the test process.
+// A config is always returned, even when both performance knobs are unset.
+// `auto_update` / `auto_restart` must remain pinned off: otherwise the default
+// testbed launch installs a launchd watchdog that outlives the provider process
+// and leaks into later tests (or the operator's real provider session).
 func BuildProviderTOML(cfg ProviderConfig, providerIndex int) (string, error) {
 	backend := ResolveKVBackend(cfg.KVBackend)
 	maxConcurrent, err := ResolveMaxConcurrent(cfg.MaxConcurrent)
 	if err != nil {
 		return "", err
-	}
-	if backend == "" && maxConcurrent == 0 {
-		return "", nil
 	}
 	switch backend {
 	case "", KVBackendAuto, KVBackendPaged, KVBackendContiguous:

--- a/e2e/testbed/provider_config_cleanup_test.go
+++ b/e2e/testbed/provider_config_cleanup_test.go
@@ -152,7 +152,7 @@ func TestCleanupRefusesPreExistingConfig(t *testing.T) {
 	}
 }
 
-// A default-posture launch writes no config and so owns nothing to clean up.
+// The cleanup helper remains a no-op when a caller has no generated config.
 func TestCleanupRefusesWhenNoConfigWasGenerated(t *testing.T) {
 	path := canonicalConfigForTest(t, "config_version = 1\n\n[provider]\nname = \"op\"\n")
 

--- a/e2e/testbed/suite.go
+++ b/e2e/testbed/suite.go
@@ -102,8 +102,8 @@ type Provider struct {
 	done   chan struct{}
 
 	// generatedConfig holds the provider TOML this instance wrote into
-	// StateDir. Empty when no KV-backend / concurrency knob was set, which is
-	// the default and launches with no --config at all.
+	// StateDir. Every provider gets one so auto-update and auto-restart stay off;
+	// KV-backend / concurrency keys remain optional within it.
 	generatedConfig string
 	// canonicalConfigExisted records whether ~/.config/darkbloom/provider.toml
 	// was present at launch. The provider copies a --config file there when it
@@ -538,8 +538,8 @@ func (p *Provider) Start(ctx context.Context, coordinatorURL string, cfg Provide
 
 	// The KV backend and the per-slot concurrency cap have no env-var or CLI
 	// equivalent (DARKBLOOM_CBV2_PAGED_KV can only force paged OFF), so
-	// selecting them means handing the provider a TOML. Unset knobs render no
-	// file and add no argument: the default launch stays byte-identical.
+	// selecting them adds keys to the testbed TOML. The file is always present
+	// because it also disables auto-update and the launchd watchdog.
 	generated, err := BuildProviderTOML(cfg, p.ProviderIndex)
 	if err != nil {
 		return fmt.Errorf("provider %d config: %w", p.ProviderIndex, err)

--- a/mise.toml
+++ b/mise.toml
@@ -10,12 +10,13 @@ rust = "1.88.0"
 # .github/workflows/ci.yml.
 node = "22"
 
-# Provider (Swift 6.1, Apple Silicon). Source of truth:
-# provider-swift/Package.swift `// swift-tools-version: 6.1`.
+# Provider (Swift 6.3, Apple Silicon). The local `libs/mlx-swift` dependency
+# declares `// swift-tools-version: 6.3`, which sets the effective minimum even
+# though provider-swift's own manifest remains source-compatible with 6.1.
 # mise installs swiftly toolchains; on macOS the system Xcode swift is also
 # acceptable — this pin ensures a consistent CLI for non-Xcode shells / Linux
 # cross builds of ProviderCoreFoundation.
-swift = "6.1"
+swift = "6.3"
 
 # Python is used by helper scripts (scripts/benchmark-models.py) and to
 # fetch the MLX metallib in CI (.github/workflows/integration.yml).

--- a/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClientCodec.swift
+++ b/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClientCodec.swift
@@ -239,11 +239,8 @@ public enum CoordinatorClientCodec {
     private static func toolConstraintModelIDs(
         _ models: [ModelInfo]
     ) -> [String] {
-        models.filter {
-            Gemma4ToolConstraintContract.supports(modelType: $0.modelType)
-                && $0.toolConstraintTemplateHash
-                    == Gemma4ToolConstraintContract.pinnedTemplateSHA256
-        }.map(\.id).sorted()
+        models.filter(ToolChoiceEnforcementPolicy.advertisesCapability)
+            .map(\.id).sorted()
     }
 
     public static func encodeOutboundMessage(_ outbound: OutboundMessage) throws -> Data {

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Factory+Benchmark.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Factory+Benchmark.swift
@@ -23,7 +23,7 @@ extension EngineV2Factory {
         if model is MLXVLM.Gemma4 {
             return try directServingModel(model: model, isVLM: true)
         }
-        guard model is MLXVLM.Qwen35MoE else {
+        guard model is MLXVLM.Qwen35 else {
             throw EngineV2VLMTextExtractionError.unsupportedWrapper(
                 String(describing: type(of: model)))
         }

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Factory+Production.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Factory+Production.swift
@@ -243,7 +243,7 @@ extension EngineV2Factory {
             return PrefixCachePolicy.adoptionBoundTokens(layerKinds: gemma.cbv2LayerKinds)
         case let gptoss as GPTOSSModel:
             return PrefixCachePolicy.adoptionBoundTokens(layerKinds: gptoss.cbv2LayerKinds)
-        case let qwen as Qwen35MoEModel:
+        case let qwen as Qwen35Model:
             guard qwen.cbv2Capabilities.supportsPrefixReuse else { return 0 }
             return PrefixCachePolicy.adoptionBoundTokens(layerKinds: qwen.cbv2LayerKinds)
         default:
@@ -262,7 +262,7 @@ extension EngineV2Factory {
             return gemma.cbv2LayerKinds
         case let gptoss as GPTOSSModel:
             return gptoss.cbv2LayerKinds
-        case let qwen as Qwen35MoEModel:
+        case let qwen as Qwen35Model:
             return qwen.cbv2LayerKinds
         default:
             return nil
@@ -600,7 +600,7 @@ extension EngineV2Factory {
             layerKinds = gptoss.cbv2LayerKinds
             modelCapabilities = .attentionOnly
             newCaches = { make in gptoss.newCacheV2(makeLayerCache: make) }
-        case let qwen as Qwen35MoEModel:
+        case let qwen as Qwen35Model:
             layerKinds = qwen.cbv2LayerKinds
             modelCapabilities = qwen.cbv2Capabilities
             newCaches = { make in qwen.newCacheV2(makeLayerCache: make) }

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2MTPAssistant.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2MTPAssistant.swift
@@ -30,15 +30,15 @@ protocol ProviderMTPAssistantLoading: Sendable {
     ) async throws -> ProviderMTPAssistantHandle
 }
 
-/// The sole production assistant loader. `Gemma4AssistantDraftModel.load`
-/// decodes the assistant's own `config.json`, applies its own per-layer
-/// quantization table, loads its own safetensors, and verifies all parameters.
-struct Gemma4ProviderMTPAssistantLoader: ProviderMTPAssistantLoading {
+/// The sole production assistant loader. Qwen targets accept either a
+/// combined inline assistant or a separately published `qwen3_5_mtp`
+/// artifact; Gemma targets retain their dedicated drafter path.
+struct ProductionProviderMTPAssistantLoader: ProviderMTPAssistantLoading {
     func loadAndBind(
         artifact: SpecDecArtifact,
         target: any LanguageModel
     ) async throws -> ProviderMTPAssistantHandle {
-        if artifact.source == .inline {
+        if target is Qwen35TextModel || target is Qwen35Model {
             do {
                 let assistant = try Qwen35InlineMTPAssistant.load(
                     from: artifact.directory, target: target)

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2SlotFactory+MTP.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2SlotFactory+MTP.swift
@@ -69,7 +69,7 @@ extension EngineV2SlotFactory {
                 throw error
             }
         }
-        guard snapshot.model is MLXVLM.Qwen35MoE else {
+        guard snapshot.model is MLXVLM.Qwen35 else {
             let error = EngineV2VLMTextExtractionError.unsupportedWrapper(
                 String(describing: type(of: snapshot.model)))
             EngineV2Factory.emitRefusalTelemetry(
@@ -109,7 +109,7 @@ extension EngineV2SlotFactory {
         modelDirectory: URL? = nil,
         container: ModelContainer,
         specDecPreparation: SpecDecPreparation,
-        assistantLoader: any ProviderMTPAssistantLoading = Gemma4ProviderMTPAssistantLoader(),
+        assistantLoader: any ProviderMTPAssistantLoading = ProductionProviderMTPAssistantLoader(),
         emitTelemetry: (@Sendable (TelemetryEvent) -> Void)? = nil,
         logInfo: @escaping @Sendable (String) -> Void = { _ in },
         logWarning: @escaping @Sendable (String) -> Void = { _ in }

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2SlotFactory.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2SlotFactory.swift
@@ -267,7 +267,7 @@ enum EngineV2SlotFactory {
         environment: [String: String] = ProcessInfo.processInfo.environment,
         emitTelemetry: (@Sendable (TelemetryEvent) -> Void)? = nil,
         makeEngineOverride: (@Sendable (String, Int) throws -> any CBv2Engine)? = nil,
-        assistantLoader: any ProviderMTPAssistantLoading = Gemma4ProviderMTPAssistantLoader(),
+        assistantLoader: any ProviderMTPAssistantLoading = ProductionProviderMTPAssistantLoader(),
         logInfo: @escaping @Sendable (String) -> Void = { _ in },
         logWarning: @escaping @Sendable (String) -> Void = { _ in }
     ) async throws -> ProviderEngineBundle {

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2SupportedModels.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2SupportedModels.swift
@@ -13,6 +13,7 @@
 //   * `gemma4`       — Gemma 4 VLM wrapper, serving through its directly
 //                      owned text tower plus vision prefill
 //   * `gemma4_text`  — Gemma 4 text target
+//   * `qwen3_5`      — dense Qwen 3.5/3.8 VLM target with recurrent state
 //   * `qwen3_5_moe` — Qwen 3.5/3.6 MoE VLM target with recurrent state
 //
 // Everything else (gemma3, other qwen families, llama, …) is
@@ -41,7 +42,7 @@ public enum EngineV2SupportedModels {
     public static func isSupported(modelType: String?) -> Bool {
         guard let raw = normalized(modelType) else { return false }
         if raw == "gpt_oss" { return true }
-        if raw == "qwen3_5_moe" { return true }
+        if raw == "qwen3_5" || raw == "qwen3_5_moe" { return true }
         return gemma4TargetTypes.contains(raw)
     }
 

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2VLMTextExtraction.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2VLMTextExtraction.swift
@@ -3,8 +3,8 @@
 // ContinuousBatchingV2 — weight-sharing Qwen target extraction for VLM slots.
 //
 // Gemma 4 is deliberately absent: its MLXVLM wrapper directly owns the
-// `Gemma4TextModel` served by CBv2. Only `MLXVLM.Qwen35MoE` needs a separate
-// MLXLLM target over the same immutable weight arrays.
+// `Gemma4TextModel` served by CBv2. Both dense and MoE `MLXVLM.Qwen35`
+// wrappers need a separate MLXLLM target over the same immutable weight arrays.
 //
 //   1. decode the checkpoint with the matching MLXLLM config type and
 //      construct a lazy skeleton
@@ -78,10 +78,11 @@ enum EngineV2VLMTextExtractionError: Error, CustomStringConvertible {
 }
 
 /// Weight-sharing extraction of the CBv2-adapted MLXLLM Qwen target from a
-/// loaded `MLXVLM.Qwen35MoE` wrapper. Pure functions; no state.
+/// loaded dense or MoE `MLXVLM.Qwen35` wrapper. Pure functions; no state.
 enum EngineV2VLMTextExtraction {
 
     enum Family: String, Sendable {
+        case qwen35Dense
         case qwen35MoE
     }
 
@@ -105,11 +106,11 @@ enum EngineV2VLMTextExtraction {
 
     }
 
-    /// Build an MLXLLM `Qwen35MoEModel` over the weight arrays of a loaded
-    /// MLXVLM `Qwen35MoE` wrapper. See the file header for the full mechanism.
+    /// Build the matching MLXLLM `Qwen35Model` over the weight arrays of a
+    /// loaded dense or MoE wrapper. See the file header for the full mechanism.
     ///
     /// - Parameters:
-    ///   - model: the slot's loaded module (must be `MLXVLM.Qwen35MoE`).
+    ///   - model: the slot's loaded module (must be `MLXVLM.Qwen35`).
     ///   - modelDirectory: the checkpoint directory (for `config.json`).
     ///   - environment: env snapshot (parity-gate kill switch).
     static func extractTextModel(
@@ -117,7 +118,7 @@ enum EngineV2VLMTextExtraction {
         modelDirectory: URL,
         environment: [String: String] = ProcessInfo.processInfo.environment
     ) throws -> Extraction {
-        guard let wrapper = model as? MLXVLM.Qwen35MoE else {
+        guard let wrapper = model as? MLXVLM.Qwen35 else {
             throw EngineV2VLMTextExtractionError.unsupportedWrapper(
                 String(describing: type(of: model)))
         }
@@ -134,15 +135,15 @@ enum EngineV2VLMTextExtraction {
         // `language_model.`-prefixed key space.
         let baseConfig = try? JSONDecoder.json5().decode(BaseConfiguration.self, from: configData)
 
-        return try extractQwen35MoE(
+        return try extractQwen35(
             wrapper: wrapper,
             configData: configData,
             perLayerQuantization: baseConfig?.perLayerQuantization,
             environment: environment)
     }
 
-    private static func extractQwen35MoE(
-        wrapper: MLXVLM.Qwen35MoE,
+    private static func extractQwen35(
+        wrapper: MLXVLM.Qwen35,
         configData: Data,
         perLayerQuantization: BaseConfiguration.PerLayerQuantization?,
         environment: [String: String]
@@ -153,13 +154,21 @@ enum EngineV2VLMTextExtraction {
         // loader flag. Assistant ownership stays with ProviderCore's separate
         // partition/load path.
         let targetConfig = try decodeQwenConfiguration(configData: configData)
-        let skeleton = Qwen35MoEModel(targetConfig)
+        let family: Family
+        let skeleton: Qwen35Model
+        if wrapper is MLXVLM.Qwen35MoE {
+            family = .qwen35MoE
+            skeleton = Qwen35MoEModel(targetConfig)
+        } else {
+            family = .qwen35Dense
+            skeleton = Qwen35Model(targetConfig)
+        }
         let targetWeights = reKeyedQwenTargetWeights(
             flattenedWeights: wrapper.parameters().flattened(), sanitizer: skeleton)
         try applyQuantizationStructure(
             skeleton: skeleton,
             weights: targetWeights,
-            family: .qwen35MoE,
+            family: family,
             perLayerQuantization: perLayerQuantization)
         try skeleton.update(
             parameters: ModuleParameters.unflattened(targetWeights), verify: [.all])
@@ -172,7 +181,7 @@ enum EngineV2VLMTextExtraction {
         }
         return Extraction(
             servingModel: skeleton,
-            family: .qwen35MoE,
+            family: family,
             parityMaxAbsLogitDiff: parityDiff)
     }
 
@@ -245,7 +254,7 @@ enum EngineV2VLMTextExtraction {
     /// the same `language_model.*` namespace, so no second prefix transform is
     /// needed. Dictionary assignment retains the same lazy MLXArray handles.
     static func reKeyedQwenTargetWeights(
-        flattenedWeights: [(String, MLXArray)], sanitizer: Qwen35MoEModel
+        flattenedWeights: [(String, MLXArray)], sanitizer: Qwen35Model
     ) -> [String: MLXArray] {
         var targetWeights: [String: MLXArray] = [:]
         targetWeights.reserveCapacity(flattenedWeights.count)
@@ -311,8 +320,8 @@ enum EngineV2VLMTextExtraction {
     /// and scale the magnitude bound to the wrapper's fixed-probe logits
     /// because Qwen has no final-logit softcap.
     private static func assertQwenForwardParity(
-        wrapper: MLXVLM.Qwen35MoE,
-        extracted: Qwen35MoEModel,
+        wrapper: MLXVLM.Qwen35,
+        extracted: Qwen35Model,
         vocabSize: Int
     ) throws -> Float {
         let probeTokens = [1, 17, 29, 43, 61].map {

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2VisionPrefill.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2VisionPrefill.swift
@@ -286,14 +286,16 @@ public enum EngineV2VisionPrefill {
     static func prepare(
         container: ModelContainer,
         request: OpenAIChatCompletionRequest,
-        reasoningEffort: String? = nil
+        reasoningEffort: String? = nil,
+        templateControls: ChatTemplateControls? = nil
     ) async throws -> PreparedSubmission {
         // Same decode path as the legacy stream (same caps, same MediaError
         // surface). Inline video bytes stay in the UserInput's owned
         // memory-backed asset while processor preparation samples and
         // rasterizes its frames; no plaintext file exists to clean up.
         let userInput = try await MediaIngest.buildUserInput(
-            from: request, reasoningEffort: reasoningEffort)
+            from: request, reasoningEffort: reasoningEffort,
+            templateControls: templateControls)
         let towerLimits = VisionTowerBudget.liveLimits
         return try await container.perform(nonSendable: userInput) { ctx, userInput in
             // MLX's DEFAULT error handler is `fatalError`. A C++ fault raised
@@ -367,7 +369,7 @@ public enum EngineV2VisionPrefill {
         // token array only.
         let promptTokens = lmInput.text.tokens.asArray(Int32.self).map(Int.init)
 
-        if let wrapper = ctx.model as? MLXVLM.Qwen35MoE {
+        if let wrapper = ctx.model as? MLXVLM.Qwen35 {
             return try buildQwenSubmission(
                 wrapper: wrapper, lmInput: lmInput, promptTokens: promptTokens,
                 towerLimits: towerLimits, mlxErrors: mlxErrors)
@@ -377,60 +379,87 @@ public enum EngineV2VisionPrefill {
                 String(describing: type(of: ctx.model)))
         }
         return try buildGemmaSubmission(
-            wrapper: wrapper, lmInput: lmInput, promptTokens: promptTokens)
+            wrapper: wrapper, lmInput: lmInput, promptTokens: promptTokens,
+            mlxErrors: mlxErrors)
     }
 
     /// Qwen3-VL: causal visual tokens, M-RoPE position state, and a vision
-    /// tower driven ONE IMAGE AT A TIME (see `qwenPerImageVisionFeatures`).
+    /// tower driven one image or temporal frame at a time.
     private static func buildQwenSubmission(
-        wrapper: MLXVLM.Qwen35MoE,
+        wrapper: MLXVLM.Qwen35,
         lmInput: LMInput,
         promptTokens: [Int],
         towerLimits: VisionTowerBudget.Limits,
         mlxErrors: MLX.ErrorBox
     ) throws -> PreparedSubmission {
-        // Video remains fail-closed until a real processor/output
-        // representation canary pins temporal packing end-to-end.
-        guard lmInput.video == nil else {
-            throw EngineV2VisionPrefillError.unsupportedMedia(
-                "Qwen35MoE video media is not production-proven")
+        var imageFeatures: [MLXArray] = []
+        var imageGrids: [THW] = []
+        if let image = lmInput.image {
+            guard let grids = image.frames, !grids.isEmpty else {
+                throw EngineV2VisionPrefillError.emptyVisionFeatures(kind: .image)
+            }
+            imageGrids = grids
+            imageFeatures = try qwenPerImageVisionFeatures(
+                wrapper: wrapper, pixels: image.pixels, grids: grids,
+                towerLimits: towerLimits, mlxErrors: mlxErrors)
         }
-        // `noProcessedMedia` means "the processor consumed no media", which
-        // maps to a deterministic 400. Pixels WITHOUT grids is a different
-        // thing — the processor produced something the seam cannot describe —
-        // and must keep its retriable refusal rather than tell the caller
-        // their media was attached to the wrong role.
-        guard let image = lmInput.image else {
+
+        var videoFeatures: [MLXArray] = []
+        var videoGrids: [THW] = []
+        if let video = lmInput.video {
+            guard let grids = video.frames, !grids.isEmpty else {
+                throw EngineV2VisionPrefillError.emptyVisionFeatures(kind: .video)
+            }
+            videoGrids = grids
+            videoFeatures = try qwenPerVideoFrameVisionFeatures(
+                wrapper: wrapper, pixels: video.pixels, grids: grids,
+                towerLimits: towerLimits, mlxErrors: mlxErrors)
+        }
+        guard !imageFeatures.isEmpty || !videoFeatures.isEmpty else {
             throw EngineV2VisionPrefillError.noProcessedMedia
         }
-        guard let grids = image.frames, !grids.isEmpty else {
-            throw EngineV2VisionPrefillError.emptyVisionFeatures(kind: .image)
-        }
-        let imageFeatures = try qwenPerImageVisionFeatures(
-            wrapper: wrapper, pixels: image.pixels, grids: grids,
-            towerLimits: towerLimits, mlxErrors: mlxErrors)
+
         let carved = try carveSpans(
             tokens: promptTokens,
-            imagePlaceholderId: wrapper.imagePlaceholderTokenId,
+            imagePlaceholderId: imageFeatures.isEmpty ? nil : wrapper.imagePlaceholderTokenId,
             imageSpanLengths: imageFeatures.map { $0.dim(1) },
-            videoPlaceholderId: nil,
-            videoSpanLengths: [])
+            videoPlaceholderId: videoFeatures.isEmpty ? nil : wrapper.videoPlaceholderTokenId,
+            videoSpanLengths: videoFeatures.map { $0.dim(1) })
+
+        var embeddings: [MLXArray] = []
+        embeddings.reserveCapacity(carved.count)
+        var imageCursor = 0
+        var videoCursor = 0
+        for entry in carved {
+            switch entry.kind {
+            case .image:
+                embeddings.append(imageFeatures[imageCursor])
+                imageCursor += 1
+            case .video:
+                embeddings.append(videoFeatures[videoCursor])
+                videoCursor += 1
+            }
+        }
+
         let position = try wrapper.positionResult(
             tokens: lmInput.text.tokens,
-            imageGrids: grids,
+            imageGrids: imageGrids,
+            videoGrids: videoGrids,
             attentionMask: lmInput.text.mask)
         // The features are already materialized per image; only the position
         // ids are still lazy here.
         eval(position.promptPositionIds)
+        try throwIfMLXFaulted(mlxErrors)
         return PreparedSubmission(
             promptTokens: promptTokens,
             spans: carved.map(\.span),
-            embeddings: imageFeatures,
+            embeddings: embeddings,
             attention: .causal,
             positionState: CBv2PositionState(
                 promptPositionIds: position.promptPositionIds,
                 decodeDeltas: position.decodeState.deltas),
-            mediaKind: .image)
+            mediaKind: lmInput.video == nil
+                ? .image : (lmInput.image == nil ? .video : .mixed))
     }
 
     /// Gemma 4: bidirectional span masks, no position state, and a SigLIP
@@ -439,7 +468,8 @@ public enum EngineV2VisionPrefill {
     private static func buildGemmaSubmission(
         wrapper: MLXVLM.Gemma4,
         lmInput: LMInput,
-        promptTokens: [Int]
+        promptTokens: [Int],
+        mlxErrors: MLX.ErrorBox
     ) throws -> PreparedSubmission {
         // Vision tower + multimodal projector — the SAME arrays the
         // wrapper's own `prepare` scatters: one per image, one per
@@ -507,6 +537,7 @@ public enum EngineV2VisionPrefill {
         // thread (where the fused tower graph would stall every
         // co-batched request's decode step for the duration).
         eval(embeddings)
+        try throwIfMLXFaulted(mlxErrors)
         return PreparedSubmission(
             promptTokens: promptTokens,
             spans: carved.map(\.span),
@@ -740,12 +771,14 @@ public enum EngineV2VisionPrefill {
 /// preparer so the full routing seam is exercisable without model weights.
 public struct EngineV2VisionPlumbing: Sendable {
     let prepare:
-        @Sendable (ModelContainer, OpenAIChatCompletionRequest, String?) async throws
+        @Sendable (ModelContainer, OpenAIChatCompletionRequest, ChatTemplateControls) async throws
             -> EngineV2VisionPrefill.PreparedSubmission
     let emitTelemetry: @Sendable (TelemetryEvent) -> Void
 
     init(
-        prepare: @escaping @Sendable (ModelContainer, OpenAIChatCompletionRequest, String?)
+        prepare: @escaping @Sendable (
+            ModelContainer, OpenAIChatCompletionRequest, ChatTemplateControls
+        )
             async throws -> EngineV2VisionPrefill.PreparedSubmission,
         emitTelemetry: @escaping @Sendable (TelemetryEvent) -> Void
     ) {
@@ -754,9 +787,10 @@ public struct EngineV2VisionPlumbing: Sendable {
     }
 
     static let production = EngineV2VisionPlumbing(
-        prepare: { container, request, reasoningEffort in
+        prepare: { container, request, templateControls in
             try await EngineV2VisionPrefill.prepare(
-                container: container, request: request, reasoningEffort: reasoningEffort)
+                container: container, request: request,
+                templateControls: templateControls)
         },
         emitTelemetry: { TelemetryClient.shared.emit($0) }
     )

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2VisionTowerRun.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2VisionTowerRun.swift
@@ -83,9 +83,33 @@ extension EngineV2VisionPrefill {
         return runs
     }
 
+    /// Pixel-row runs for each temporal processor frame, grouped by video.
+    /// The outer order matches `grids`; the inner order is chronological.
+    static func videoFramePixelRuns(
+        grids: [THW], totalRows: Int
+    ) throws -> [[Range<Int>]] {
+        let videoRuns = try imagePixelRuns(grids: grids, totalRows: totalRows)
+        return try zip(grids, videoRuns).enumerated().map { videoIndex, pair in
+            let (grid, videoRun) = pair
+            guard grid.t > 0, grid.h > 0, grid.w > 0 else {
+                throw EngineV2VisionPrefillError.invalidVisionGrid(
+                    mediaIndex: videoIndex)
+            }
+            let (rowsPerFrame, overflow) = grid.h.multipliedReportingOverflow(by: grid.w)
+            guard !overflow, rowsPerFrame > 0 else {
+                throw EngineV2VisionPrefillError.invalidVisionGrid(
+                    mediaIndex: videoIndex)
+            }
+            return (0 ..< grid.t).map { frameIndex in
+                let start = videoRun.lowerBound + frameIndex * rowsPerFrame
+                return start ..< (start + rowsPerFrame)
+            }
+        }
+    }
+
     /// The N² buffer multiple this wrapper's vision tower will allocate, read
     /// from the model's own config against MLX's kernel-selection rule.
-    static func qwenAttentionHeadFactor(_ wrapper: MLXVLM.Qwen35MoE) -> Int {
+    static func qwenAttentionHeadFactor(_ wrapper: MLXVLM.Qwen35) -> Int {
         let vision = wrapper.config.visionConfiguration
         return VisionTowerBudget.attentionHeadFactor(
             hiddenSize: vision.hiddenSize, numHeads: vision.numHeads)
@@ -99,7 +123,7 @@ extension EngineV2VisionPrefill {
     /// for MLX faults — before the next image's graph is built, so peak device
     /// memory is one image's tower and a fault stops the loop where it happens.
     static func qwenPerImageVisionFeatures(
-        wrapper: MLXVLM.Qwen35MoE,
+        wrapper: MLXVLM.Qwen35,
         pixels: MLXArray,
         grids: [THW],
         towerLimits: VisionTowerBudget.Limits,
@@ -114,6 +138,7 @@ extension EngineV2VisionPrefill {
         var features: [MLXArray] = []
         features.reserveCapacity(grids.count)
         for (index, grid) in grids.enumerated() {
+            try Task.checkCancellation()
             switch VisionTowerBudget.admit(
                 grids: [grid],
                 subject: Self.imageSubject(index: index, of: grids.count),
@@ -149,8 +174,73 @@ extension EngineV2VisionPrefill {
         return features
     }
 
+    /// One `[1, softTokens, textHidden]` embedding per temporal processor
+    /// frame, in video order then frame order. A frame is one temporal patch
+    /// group (`temporalPatchSize` source frames), represented by a `THW(1,h,w)`
+    /// grid and driven through its own tower invocation. This keeps the N²
+    /// attention allocation bounded by the largest frame instead of the sum
+    /// of every frame in the request.
+    static func qwenPerVideoFrameVisionFeatures(
+        wrapper: MLXVLM.Qwen35,
+        pixels: MLXArray,
+        grids: [THW],
+        towerLimits: VisionTowerBudget.Limits,
+        mlxErrors: MLX.ErrorBox
+    ) throws -> [MLXArray] {
+        guard !grids.isEmpty else {
+            throw EngineV2VisionPrefillError.emptyVisionFeatures(kind: .video)
+        }
+        let frameRuns = try videoFramePixelRuns(
+            grids: grids, totalRows: pixels.dim(0))
+        let limits = towerLimits.withHeadFactor(qwenAttentionHeadFactor(wrapper))
+        let frameCount = grids.reduce(0) { $0 + max(0, $1.t) }
+
+        var features: [MLXArray] = []
+        features.reserveCapacity(frameCount)
+        var globalFrameIndex = 0
+        for (videoIndex, grid) in grids.enumerated() {
+            let singleGrid = THW(1, grid.h, grid.w)
+            for frameIndex in 0 ..< grid.t {
+                try Task.checkCancellation()
+                switch VisionTowerBudget.admit(
+                    grids: [singleGrid],
+                    subject: videoFrameSubject(
+                        videoIndex: videoIndex, frameIndex: frameIndex,
+                        globalIndex: globalFrameIndex, total: frameCount),
+                    limits: limits)
+                {
+                case .admit:
+                    break
+                case .reject(let reason):
+                    throw EngineV2VisionPrefillError.towerBudgetExceeded(reason)
+                }
+
+                let single = try wrapper.visionFeatures(
+                    videoPixels: pixels[frameRuns[videoIndex][frameIndex], 0...],
+                    videoGrids: [singleGrid])
+                guard single.ordered.count == 1 else {
+                    throw EngineV2VisionPrefillError.emptyVisionFeatures(kind: .video)
+                }
+                let embedding = single.ordered[0].features
+                eval(embedding)
+                try EngineV2VisionPrefill.throwIfMLXFaulted(mlxErrors)
+                features.append(embedding)
+                globalFrameIndex += 1
+            }
+        }
+        return features
+    }
+
     /// Content-free subject for a rejection message ("image 2 of 5").
     static func imageSubject(index: Int, of count: Int) -> String {
         count == 1 ? "this image" : "image \(index + 1) of \(count)"
+    }
+
+    static func videoFrameSubject(
+        videoIndex: Int, frameIndex: Int, globalIndex: Int, total: Int
+    ) -> String {
+        if total == 1 { return "this video frame" }
+        return "video \(videoIndex + 1) frame \(frameIndex + 1) "
+            + "(frame \(globalIndex + 1) of \(total))"
     }
 }

--- a/provider-swift/Sources/ProviderCore/Inference/MediaIngest.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/MediaIngest.swift
@@ -263,6 +263,7 @@ public enum MediaIngest {
     static func buildUserInput(
         from request: OpenAIChatCompletionRequest,
         reasoningEffort: String? = nil,
+        templateControls: ChatTemplateControls? = nil,
         maxImagePixels: Int = Self.maxImagePixels,
         maxRequestImagePixels: Int = Self.maxRequestImagePixels,
         maxImagesPerRequest: Int = Self.maxImagesPerRequest,
@@ -298,7 +299,9 @@ public enum MediaIngest {
         return UserInput(
             chat: chatMessages,
             additionalContext: MultiModelBatchSchedulerEngine.templateAdditionalContext(
-                for: request, reasoningEffort: reasoningEffort))
+                for: request,
+                controls: templateControls
+                    ?? ChatTemplateControls(reasoningEffort: reasoningEffort)))
     }
 
 

--- a/provider-swift/Sources/ProviderCore/Inference/MultiModelBatchSchedulerEngine+Translation.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/MultiModelBatchSchedulerEngine+Translation.swift
@@ -12,20 +12,51 @@ import Foundation
 import MLXLMCommon
 import MLXLMServer
 
+/// Template-only controls recovered from the sealed OpenAI body. The
+/// upstream request type does not model these top-level fields, but Qwen3.8's
+/// published template consumes all three.
+public struct ChatTemplateControls: Sendable, Equatable {
+    public let reasoningEffort: String?
+    public let enableThinking: Bool?
+    public let preserveThinking: Bool?
+
+    public init(
+        reasoningEffort: String? = nil,
+        enableThinking: Bool? = nil,
+        preserveThinking: Bool? = nil
+    ) {
+        self.reasoningEffort = reasoningEffort
+        self.enableThinking = enableThinking
+        self.preserveThinking = preserveThinking
+    }
+}
+
 extension MultiModelBatchSchedulerEngine {
+
+    static func templateAdditionalContext(
+        for request: OpenAIChatCompletionRequest,
+        controls: ChatTemplateControls
+    ) -> [String: any Sendable]? {
+        var context: [String: any Sendable] = [:]
+        if let reasoningEffort = controls.reasoningEffort {
+            context["reasoning_effort"] = reasoningEffort
+        }
+        if let reasoningEnabled = controls.enableThinking ?? request.reasoning?.enabled {
+            context["enable_thinking"] = reasoningEnabled
+        }
+        if let preserveThinking = controls.preserveThinking {
+            context["preserve_thinking"] = preserveThinking
+        }
+        return context.isEmpty ? nil : context
+    }
 
     static func templateAdditionalContext(
         for request: OpenAIChatCompletionRequest,
         reasoningEffort: String?
     ) -> [String: any Sendable]? {
-        var context: [String: any Sendable] = [:]
-        if let reasoningEffort {
-            context["reasoning_effort"] = reasoningEffort
-        }
-        if let reasoningEnabled = request.reasoning?.enabled {
-            context["enable_thinking"] = reasoningEnabled
-        }
-        return context.isEmpty ? nil : context
+        templateAdditionalContext(
+            for: request,
+            controls: ChatTemplateControls(reasoningEffort: reasoningEffort))
     }
 
     /// Translate an upstream `OpenAIChatCompletionRequest` into the

--- a/provider-swift/Sources/ProviderCore/Inference/MultiModelBatchSchedulerEngine.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/MultiModelBatchSchedulerEngine.swift
@@ -76,7 +76,7 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
     /// at its built-in default. We do not validate the value here — the
     /// allowed set is model-specific and lives in each model's Jinja
     /// template, so passing through is the format-agnostic choice.
-    private let reasoningEffort: String?
+    private let templateControls: ChatTemplateControls
     /// Authenticated remote or configured local prefix-cache scope. Maps to
     /// `CBv2Request.cacheSalt` for both cache tiers.
     private let cacheScope: String
@@ -118,6 +118,7 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
         releaseModel: @escaping @Sendable (String) async -> Void = { _ in },
         defaultMaxTokens: Int = 4096,
         reasoningEffort: String? = nil,
+        templateControls: ChatTemplateControls? = nil,
         cacheScope: String = "",
         cacheEnabled: Bool = true,
         engineV2Logprobs: EngineV2LogprobsPlumbing? = nil,
@@ -130,7 +131,8 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
         self.reserveModel = reserveModel
         self.releaseModel = releaseModel
         self.defaultMaxTokens = defaultMaxTokens
-        self.reasoningEffort = reasoningEffort
+        self.templateControls = templateControls
+            ?? ChatTemplateControls(reasoningEffort: reasoningEffort)
         self.cacheScope = cacheScope
         self.cacheEnabled = cacheEnabled
         self.engineV2Logprobs = engineV2Logprobs
@@ -169,7 +171,7 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
         self.reserveModel = { _ in }
         self.releaseModel = { _ in }
         self.defaultMaxTokens = defaultMaxTokens
-        self.reasoningEffort = nil
+        self.templateControls = ChatTemplateControls()
         self.cacheScope = ""
         self.cacheEnabled = true
         // The --local path serves SSE frames inside the upstream router, so
@@ -359,7 +361,7 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
                 let plumbing = engineV2Vision ?? .production
                 do {
                     let visionPrepared = try await plumbing.prepare(
-                        container, visionRequest, reasoningEffort)
+                        container, visionRequest, templateControls)
                     let visionRequestId = "req-\(UUID().uuidString.prefix(12))"
                     // Hand off memory accounting to the bridge BEFORE
                     // submit: the decode-phase peak this vision reservation
@@ -516,7 +518,7 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
                 request: request,
                 tokenizer: tokenizer.inner,
                 modelType: modelType,
-                reasoningEffort: reasoningEffort)
+                templateControls: templateControls)
         } catch {
             emitToolConstraintTelemetry(
                 operation: "tool_constraint_compile_rejection",

--- a/provider-swift/Sources/ProviderCore/Inference/MultiModelBatchSchedulerEngine.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/MultiModelBatchSchedulerEngine.swift
@@ -161,7 +161,8 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
         acquire: @escaping @Sendable (String) async throws -> AcquiredModel,
         tokenizerProvider: @escaping @Sendable (String?) async throws -> TokenizerResolution,
         availableModels: @escaping @Sendable () async -> [String],
-        defaultMaxTokens: Int = 4096
+        defaultMaxTokens: Int = 4096,
+        templateControls: ChatTemplateControls = .init()
     ) {
         self.acquire = acquire
         self.tokenizerProvider = tokenizerProvider
@@ -171,7 +172,7 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
         self.reserveModel = { _ in }
         self.releaseModel = { _ in }
         self.defaultMaxTokens = defaultMaxTokens
-        self.templateControls = ChatTemplateControls()
+        self.templateControls = templateControls
         self.cacheScope = ""
         self.cacheEnabled = true
         // The --local path serves SSE frames inside the upstream router, so
@@ -551,10 +552,12 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
                     requested: request.toolCallParser,
                     modelType: modelType
                 )
-                if prepared.mode.requiresInferenceGrammar, format != .gemma {
-                    throw MultiModelBatchSchedulerEngineError.invalidToolPayload(
-                        "inference-enforced Gemma tool_choice requires the gemma tool parser")
-                }
+                let strategy = try ToolChoiceEnforcementPolicy.forcedStrategy(
+                    mode: prepared.mode,
+                    modelContext: ChatTemplateFixContext(
+                        modelId: request.model, modelType: modelType))
+                try ToolChoiceEnforcementPolicy.validateParser(
+                    format, strategy: strategy)
             } catch {
                 await releaseBox.fire()
                 throw error
@@ -787,9 +790,10 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
                     return
                 }
 
-                // Flush and validate parsed calls. Required/named/none are
-                // enforced in the sampler; this remains the parser/schema
-                // boundary for auto plus defense in depth for every mode.
+                // Flush and validate parsed calls. Gemma required/named are
+                // sampler-constrained; Qwen required/named are prompt-forced
+                // and fail closed here before a call is exposed. This remains
+                // defense in depth for every mode.
                 let toolCalls = toolHandler?.finish() ?? []
                 if prepared.mode == .auto,
                     let residual = toolHandler?.takeResidualText(),
@@ -811,7 +815,7 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
                     continuation.finish(throwing: error)
                     return
                 }
-                if prepared.mode.requiresInferenceGrammar {
+                if prepared.mode.requiresInferenceConstraint {
                     emitToolConstraintTelemetry(
                         operation: "tool_constraint_valid",
                         reason: prepared.mode.telemetryValue)

--- a/provider-swift/Sources/ProviderCore/Inference/ProviderPromptContractPipeline.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/ProviderPromptContractPipeline.swift
@@ -9,14 +9,14 @@ enum ProviderPromptContractPipeline {
         modelType: String?
     ) throws -> [Int] {
         let request = try ProviderLoop.decodeOpenAIRequest(body)
-        let reasoningEffort = ProviderLoop.extractReasoningEffort(from: body)
+        let templateControls = ProviderLoop.extractChatTemplateControls(from: body)
         let prepared = try ToolChoicePromptPolicy.prepare(request)
         return try tokenize(
             prepared: prepared,
             request: request,
             tokenizer: tokenizer,
             modelType: modelType,
-            reasoningEffort: reasoningEffort)
+            templateControls: templateControls)
     }
 
     static func tokenize(
@@ -25,6 +25,19 @@ enum ProviderPromptContractPipeline {
         tokenizer: any MLXLMCommon.Tokenizer,
         modelType: String?,
         reasoningEffort: String?
+    ) throws -> [Int] {
+        try tokenize(
+            prepared: prepared, request: request, tokenizer: tokenizer,
+            modelType: modelType,
+            templateControls: ChatTemplateControls(reasoningEffort: reasoningEffort))
+    }
+
+    static func tokenize(
+        prepared: ToolChoicePromptPolicy.Prepared,
+        request: OpenAIChatCompletionRequest,
+        tokenizer: any MLXLMCommon.Tokenizer,
+        modelType: String?,
+        templateControls: ChatTemplateControls
     ) throws -> [Int] {
         let messages = prepared.messages.map { $0.templateMessageDict() }
         let tools = prepared.tools?.map { $0.toolSpec() }
@@ -36,6 +49,6 @@ enum ProviderPromptContractPipeline {
             tools: ChatTemplateFixes.normalizeTools(tools, context: context),
             additionalContext: MultiModelBatchSchedulerEngine.templateAdditionalContext(
                 for: request,
-                reasoningEffort: reasoningEffort))
+                controls: templateControls))
     }
 }

--- a/provider-swift/Sources/ProviderCore/Inference/Qwen35TemplateFixes.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/Qwen35TemplateFixes.swift
@@ -14,7 +14,7 @@ enum Qwen35TemplateFix {
         if let modelType = context.modelType?
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .lowercased(),
-            modelType == "qwen3_5_moe"
+            modelType == "qwen3_5" || modelType == "qwen3_5_moe"
         {
             return true
         }
@@ -24,6 +24,8 @@ enum Qwen35TemplateFix {
             || modelId.contains("qwen3_5")
             || modelId.contains("qwen3.6")
             || modelId.contains("qwen3_6")
+            || modelId.contains("qwen3.8")
+            || modelId.contains("qwen3_8")
     }
 
     static func normalizeMessages(

--- a/provider-swift/Sources/ProviderCore/Inference/SlotSizingSnapshot.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/SlotSizingSnapshot.swift
@@ -134,9 +134,9 @@ public struct SlotSizingSnapshot: Sendable, Equatable {
                 // Direct ownership makes the loaded tower engine truth with
                 // no config re-decode or second topology that can drift.
                 rate = fp16KVBytesPerToken(layerKinds: gemma.textModel.cbv2LayerKinds)
-            case let qwen as Qwen35MoEModel:
+            case let qwen as Qwen35Model:
                 rate = fp16KVBytesPerToken(layerKinds: qwen.cbv2LayerKinds)
-            case is MLXVLM.Qwen35MoE:
+            case is MLXVLM.Qwen35:
                 return ModuleFacts(
                     bytes: bytes,
                     moduleKVRate: nil,

--- a/provider-swift/Sources/ProviderCore/Inference/ToolChoiceEnforcementPolicy.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/ToolChoiceEnforcementPolicy.swift
@@ -1,0 +1,66 @@
+// Copyright © 2026 Eigen Labs.
+
+import MLXLMCommon
+import MLXLMServer
+
+/// Selects the enforcement boundary for forced tool choices. Gemma keeps its
+/// token-level grammar; Qwen's published XML tool format is prompt-forced and
+/// then rejected fail-closed unless parsing, function selection, and schema
+/// validation all succeed before any call is exposed to the client.
+enum ToolChoiceEnforcementPolicy {
+    enum Strategy: Equatable {
+        case none
+        case gemmaGrammar
+        case qwenPostValidation
+    }
+
+    static func forcedStrategy(
+        mode: ToolConstraintMode,
+        modelContext: ChatTemplateFixContext
+    ) throws -> Strategy {
+        switch mode {
+        case .required, .named:
+            break
+        case .none, .auto:
+            return .none
+        }
+
+        if Gemma4TemplateFix.applies(to: modelContext) { return .gemmaGrammar }
+        if Qwen35TemplateFix.applies(to: modelContext) { return .qwenPostValidation }
+        throw MultiModelBatchSchedulerEngineError.invalidToolPayload(
+            "inference-enforced tool_choice is unsupported for this model family")
+    }
+
+    /// Whether this concrete advertised model can honor required/named tool
+    /// choice. Gemma's sampler grammar remains bound to its pinned template;
+    /// Qwen is enforced by prompt forcing plus withheld post-validation.
+    static func advertisesCapability(for model: ModelInfo) -> Bool {
+        let context = ChatTemplateFixContext(
+            modelId: model.id, modelType: model.modelType)
+        if Gemma4TemplateFix.applies(to: context) {
+            return model.toolConstraintTemplateHash
+                == Gemma4ToolConstraintContract.pinnedTemplateSHA256
+        }
+        return Qwen35TemplateFix.applies(to: context)
+    }
+
+    static func validateParser(
+        _ format: ToolCallFormat,
+        strategy: Strategy
+    ) throws {
+        switch strategy {
+        case .none:
+            return
+        case .gemmaGrammar:
+            guard format == .gemma else {
+                throw MultiModelBatchSchedulerEngineError.invalidToolPayload(
+                    "inference-enforced Gemma tool_choice requires the gemma tool parser")
+            }
+        case .qwenPostValidation:
+            guard format == .xmlFunction else {
+                throw MultiModelBatchSchedulerEngineError.invalidToolPayload(
+                    "inference-enforced Qwen tool_choice requires the qwen3_coder tool parser")
+            }
+        }
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Inference/ToolConstraintFactory.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/ToolConstraintFactory.swift
@@ -20,16 +20,30 @@ enum ToolConstraintFactory {
         defaultMaxTokens: Int,
         stopTokenIDs: Set<Int>
     ) throws -> (any CBv2TokenConstraint)? {
-        guard prepared.mode.requiresInferenceGrammar else { return nil }
-        guard Gemma4TemplateFix.applies(to: modelContext),
-            tokenizer.toolConstraintContractVerified
-        else {
-            // `.none` needs no sampler automaton: `ToolChoicePromptPolicy`
-            // already strips the tools and injects the "do not call any tool"
-            // instruction, and `ToolConstraintValidation.validate` rejects any
-            // call the model emits anyway. `.required`/`.named` genuinely
-            // depend on the compiled grammar, so they stay fail-closed.
-            if prepared.mode == .none { return nil }
+        guard prepared.mode.requiresInferenceConstraint else { return nil }
+        // `.none` keeps Gemma's sampler guard when its prompt contract is
+        // pinned, while every other family retains the existing prompt-only
+        // behavior (the tools are removed before rendering).
+        if prepared.mode == .none {
+            guard Gemma4TemplateFix.applies(to: modelContext),
+                tokenizer.toolConstraintContractVerified
+            else { return nil }
+        } else {
+            let strategy = try ToolChoiceEnforcementPolicy.forcedStrategy(
+                mode: prepared.mode, modelContext: modelContext)
+            if strategy == .qwenPostValidation {
+                // Qwen's XML parser withholds call bytes until finish; the
+                // shared validator below the stream rejects missing, wrong,
+                // undeclared, or schema-invalid calls before exposing them.
+                return nil
+            }
+            guard tokenizer.toolConstraintContractVerified else {
+                throw MultiModelBatchSchedulerEngineError.invalidToolPayload(
+                    "inference-enforced tool_choice requires the pinned Gemma prompt contract")
+            }
+        }
+
+        guard Gemma4TemplateFix.applies(to: modelContext) else {
             throw MultiModelBatchSchedulerEngineError.invalidToolPayload(
                 "inference-enforced tool_choice requires the pinned Gemma prompt contract")
         }

--- a/provider-swift/Sources/ProviderCore/Inference/ToolConstraintSchema.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/ToolConstraintSchema.swift
@@ -1,6 +1,8 @@
 // Copyright © 2026 Eigen Labs.
 //
-// Fail-closed JSON-Schema subset used by Gemma inference-time tool grammar.
+// Fail-closed JSON-Schema subset used by forced tool-choice enforcement.
+// Gemma consumes it in the sampler grammar; Qwen consumes it at the withheld
+// parser/validation boundary before any call is exposed.
 // The subset is intentionally small and exact. Unsupported assertion keywords
 // are rejected for required/named choices instead of being prompt-only theater.
 
@@ -16,7 +18,7 @@ enum ToolConstraintMode: Sendable, Equatable {
     case required
     case named(String)
 
-    var requiresInferenceGrammar: Bool {
+    var requiresInferenceConstraint: Bool {
         switch self {
         case .none, .required, .named: true
         case .auto: false
@@ -97,7 +99,7 @@ enum ToolConstraintSchemaCompiler {
         guard tools.count <= maxTools else {
             throw ToolConstraintSchemaError.invalid("at most \(maxTools) tools are allowed")
         }
-        if mode.requiresInferenceGrammar {
+        if mode.requiresInferenceConstraint {
             switch mode {
             case .required, .named:
                 guard !tools.isEmpty else {
@@ -130,7 +132,7 @@ enum ToolConstraintSchemaCompiler {
             let raw = tool.function.parameters ?? .object(["type": .string("object")])
             let schema = try compileSchema(
                 raw, depth: 0, path: "\(name).parameters",
-                allowRenderMetadata: mode.requiresInferenceGrammar)
+                allowRenderMetadata: mode.requiresInferenceConstraint)
             guard case .object = schema else {
                 throw ToolConstraintSchemaError.invalid(
                     "\(name).parameters must have type object")

--- a/provider-swift/Sources/ProviderCore/ProviderCore.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderCore.swift
@@ -240,5 +240,9 @@ public enum ProviderCore {
     // 0.8.10 passes retained Gemma latch variables before exec in installer,
     // self-update, and paged-preflight runtime-smoke children so eager MLX
     // initialization cannot latch safe R1 off before validation runs.
-    public static let version = "0.8.10"
+    // 0.8.11 adds the dense Qwen3.8-27B VLM runtime: shared Qwen3.5 CBv2
+    // wiring, bounded per-frame video prefill, request template controls, and
+    // separate qwen3_5_mtp artifact loading. Catalog publication remains a
+    // separately approved operation after hardware validation.
+    public static let version = "0.8.11"
 }

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+EngineV2.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+EngineV2.swift
@@ -283,7 +283,7 @@ extension ProviderLoop {
                 container: newcomerBox.borrow(),
                 specDecPreparation: specDecPreparation,
                 assistantLoader: engineV2SlotHooks?.assistantLoader
-                    ?? Gemma4ProviderMTPAssistantLoader(),
+                    ?? ProductionProviderMTPAssistantLoader(),
                 emitTelemetry: engineV2SlotHooks?.emitTelemetry,
                 logInfo: { slotLogger.info($0) },
                 logWarning: { slotLogger.warning($0) })

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+InboundDecode.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+InboundDecode.swift
@@ -73,12 +73,29 @@ extension ProviderLoop {
     /// differ) is enforced by each model's chat template, not here, so we
     /// stay format-agnostic rather than hardcoding a per-model allowlist.
     internal static func extractReasoningEffort(from data: Data) -> String? {
-        struct Probe: Decodable { let reasoning_effort: String? }
-        guard let probe = try? JSONDecoder().decode(Probe.self, from: data),
-              let raw = probe.reasoning_effort
-        else { return nil }
-        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
-        return trimmed.isEmpty ? nil : trimmed
+        extractChatTemplateControls(from: data).reasoningEffort
+    }
+
+    /// Qwen3.8 template controls that are intentionally not protocol fields.
+    /// Unknown/malformed values are ignored independently so one bad optional
+    /// control never discards another valid one.
+    internal static func extractChatTemplateControls(
+        from data: Data
+    ) -> ChatTemplateControls {
+        struct EffortProbe: Decodable { let reasoning_effort: String? }
+        struct ThinkingProbe: Decodable { let enable_thinking: Bool? }
+        struct PreserveProbe: Decodable { let preserve_thinking: Bool? }
+        let decoder = JSONDecoder()
+        let rawEffort = (try? decoder.decode(EffortProbe.self, from: data))?
+            .reasoning_effort
+        let effort = rawEffort?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return ChatTemplateControls(
+            reasoningEffort: effort?.isEmpty == false ? effort : nil,
+            enableThinking: (try? decoder.decode(ThinkingProbe.self, from: data))?
+                .enable_thinking,
+            preserveThinking: (try? decoder.decode(PreserveProbe.self, from: data))?
+                .preserve_thinking)
     }
 
     /// OpenAI `logprobs` / `top_logprobs` for this request. Like
@@ -134,11 +151,24 @@ extension ProviderLoop {
         modelType: String?,
         reasoningEffort: String?
     ) -> Int {
+        promptTokenFloor(
+            request: request,
+            tokenizer: tokenizer,
+            modelType: modelType,
+            templateControls: ChatTemplateControls(reasoningEffort: reasoningEffort))
+    }
+
+    internal static func promptTokenFloor(
+        request: OpenAIChatCompletionRequest,
+        tokenizer: TokenizerHandle,
+        modelType: String?,
+        templateControls: ChatTemplateControls
+    ) -> Int {
         guard let prepared = try? ToolChoicePromptPolicy.prepare(request) else { return 0 }
         let messages = prepared.messages.map { $0.templateMessageDict() }
         let toolSpecs = prepared.tools?.map { $0.toolSpec() }
         let additionalContext = MultiModelBatchSchedulerEngine.templateAdditionalContext(
-            for: request, reasoningEffort: reasoningEffort)
+            for: request, controls: templateControls)
         // Must mirror the production tokenize path (sanitize JSON
         // null / Optional leaves) so this recount matches what was prefilled
         // and doesn't itself throw on a null-bearing request.

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+InferenceHandler.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+InferenceHandler.swift
@@ -227,7 +227,8 @@ extension ProviderLoop {
         // context below (see `MultiModelBatchSchedulerEngine`). gpt-oss /
         // Harmony reads it to set the reasoning budget; other models
         // ignore the extra template variable.
-        let reasoningEffort = Self.extractReasoningEffort(from: decryptedData)
+        let templateControls = Self.extractChatTemplateControls(from: decryptedData)
+        let reasoningEffort = templateControls.reasoningEffort
         // Cache identity is coordinator-authored and authenticated outside the
         // sealed OpenAI body. Never trust caller-controlled prompt_cache_key/user
         // for remote cache partitioning. Legacy coordinators omit the outer
@@ -491,6 +492,7 @@ extension ProviderLoop {
                 releaseModel: { _ in },
                 defaultMaxTokens: Self.schedulerDefaultMaxTokens,
                 reasoningEffort: reasoningEffort,
+                templateControls: templateControls,
                 cacheScope: cacheScope,
                 cacheEnabled: remoteCache.cacheEnabled,
                 engineV2Logprobs: logprobsChannel.map {
@@ -858,7 +860,7 @@ extension ProviderLoop {
                     request: streamingRequest,
                     tokenizer: tokenizer,
                     modelType: modelType,
-                    reasoningEffort: reasoningEffort
+                    templateControls: templateControls
                 ))
                 guard case .complete(let settledUsage) = terminal else {
                     // Cancelled with nothing delivered: 499 so the coordinator refunds.
@@ -914,7 +916,7 @@ extension ProviderLoop {
                         request: streamingRequest,
                         tokenizer: tokenizer,
                         modelType: modelType,
-                        reasoningEffort: reasoningEffort
+                        templateControls: templateControls
                     )
                     if promptTokens > 0 {
                         log.warning(

--- a/provider-swift/Sources/ProviderCore/Server/LocalChatTemplateControls.swift
+++ b/provider-swift/Sources/ProviderCore/Server/LocalChatTemplateControls.swift
@@ -1,0 +1,27 @@
+// Copyright © 2026 Eigen Labs.
+
+import Foundation
+
+/// Recovers Qwen template-only controls from local OpenAI-compatible request
+/// bodies. The upstream typed request intentionally ignores these extension
+/// keys, so the local HTTP path carries them alongside the decoded request.
+enum LocalChatTemplateControls {
+    static func single(from data: Data) -> ChatTemplateControls {
+        ProviderLoop.extractChatTemplateControls(from: data)
+    }
+
+    /// Recover controls independently for each batch item. A malformed
+    /// optional control in one item must not discard valid controls in another.
+    static func batch(from data: Data, count: Int) -> [ChatTemplateControls] {
+        guard let values = try? JSONSerialization.jsonObject(with: data) as? [Any],
+            values.count == count
+        else { return Array(repeating: .init(), count: count) }
+
+        return values.map { value in
+            guard JSONSerialization.isValidJSONObject(value),
+                let item = try? JSONSerialization.data(withJSONObject: value)
+            else { return .init() }
+            return single(from: item)
+        }
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Server/LocalChatUploadResponder.swift
+++ b/provider-swift/Sources/ProviderCore/Server/LocalChatUploadResponder.swift
@@ -51,11 +51,18 @@ where Inner.Context == BasicRequestContext {
 
     public let inner: Inner
     let service: MLXOpenAIService
+    let serviceForTemplateControls: @Sendable (ChatTemplateControls) -> MLXOpenAIService
     let maxUploadBytes: Int
 
-    init(inner: Inner, service: MLXOpenAIService, maxUploadBytes: Int = localInferenceMaxUploadBytes) {
+    init(
+        inner: Inner,
+        service: MLXOpenAIService,
+        maxUploadBytes: Int = localInferenceMaxUploadBytes,
+        serviceForTemplateControls: (@Sendable (ChatTemplateControls) -> MLXOpenAIService)? = nil
+    ) {
         self.inner = inner
         self.service = service
+        self.serviceForTemplateControls = serviceForTemplateControls ?? { _ in service }
         self.maxUploadBytes = maxUploadBytes
     }
 
@@ -97,11 +104,15 @@ where Inner.Context == BasicRequestContext {
             case .success(let decoded): requests = decoded
             case .failure(let badRequest): return badRequest
             }
+            let controls = LocalChatTemplateControls.batch(
+                from: Data(buffer: buffer), count: requests.count)
             // Mirror of the upstream batch handler: sequential
             // createChatCompletion calls, one JSON array response.
             var responses: [OpenAIChatCompletionResponse] = []
-            for chatRequest in requests {
-                responses.append(try await service.createChatCompletion(request: chatRequest))
+            for (index, chatRequest) in requests.enumerated() {
+                responses.append(
+                    try await serviceForTemplateControls(controls[index])
+                        .createChatCompletion(request: chatRequest))
             }
             return try Self.jsonResponse(responses)
         }
@@ -111,14 +122,17 @@ where Inner.Context == BasicRequestContext {
         case .success(let decoded): chatRequest = decoded
         case .failure(let badRequest): return badRequest
         }
+        let requestService = serviceForTemplateControls(
+            LocalChatTemplateControls.single(from: Data(buffer: buffer)))
         // Same service entry points as the upstream handler; pre-stream
         // throws (unknown model, admission refusal) travel to
         // `CORSResponder`'s status mapping unchanged.
         if chatRequest.stream == true {
-            let frames = try await service.streamChatCompletionFrames(request: chatRequest)
+            let frames = try await requestService.streamChatCompletionFrames(request: chatRequest)
             return Self.sseResponse(frames)
         }
-        return try Self.jsonResponse(try await service.createChatCompletion(request: chatRequest))
+        return try Self.jsonResponse(
+            try await requestService.createChatCompletion(request: chatRequest))
     }
 
     /// Decode with Hummingbird's default `requestDecoder` configuration

--- a/provider-swift/Sources/ProviderCore/Server/LocalInferenceHTTP.swift
+++ b/provider-swift/Sources/ProviderCore/Server/LocalInferenceHTTP.swift
@@ -72,13 +72,26 @@ func makeLocalInferenceApplication(
     mtpSlots: @escaping @Sendable () async -> [MTPSlotMetricsSample],
     onServerRunning: @escaping @Sendable (any Channel) async -> Void = { _ in }
 ) -> LocalInferenceApplication {
-    let engine = MultiModelBatchSchedulerEngine(
-        acquire: acquire,
-        tokenizerProvider: tokenizerProvider,
-        availableModels: availableModels,
-        defaultMaxTokens: defaultMaxTokens
-    )
-    let service = MLXOpenAIService(engine: engine)
+    // The upstream OpenAI request shape intentionally ignores Qwen's
+    // template-only controls. Build a lightweight engine/service facade per
+    // chat request so the raw-body controls recovered by
+    // `LocalChatUploadResponder` reach tokenization without changing the
+    // shared model registry, response store, or metrics identity.
+    let responseStore = InMemoryResponseStore()
+    let metrics = ServerMetrics()
+    let serviceForTemplateControls: @Sendable (ChatTemplateControls) -> MLXOpenAIService = {
+        controls in
+        let engine = MultiModelBatchSchedulerEngine(
+            acquire: acquire,
+            tokenizerProvider: tokenizerProvider,
+            availableModels: availableModels,
+            defaultMaxTokens: defaultMaxTokens,
+            templateControls: controls
+        )
+        return MLXOpenAIService(
+            engine: engine, responseStore: responseStore, metrics: metrics)
+    }
+    let service = serviceForTemplateControls(.init())
     let router = MLXServerApplication.buildRouter(service: service)
     // Chat-completions POSTs are served by the interception responder with
     // the 32 MiB body ceiling (the upstream router's BasicRequestContext
@@ -86,7 +99,8 @@ func makeLocalInferenceApplication(
     // LocalChatUploadResponder); everything else falls through to the
     // upstream router unchanged.
     let uploadResponder = LocalChatUploadResponder(
-        inner: router.buildResponder(), service: service)
+        inner: router.buildResponder(), service: service,
+        serviceForTemplateControls: serviceForTemplateControls)
     // GET /metrics is served by the metrics responder: the upstream
     // ServerMetrics body plus the provider-owned MTP posture lines (see
     // LocalMetricsResponder for why the upstream route cannot be extended).

--- a/provider-swift/Sources/ProviderCore/Server/StandaloneServer.swift
+++ b/provider-swift/Sources/ProviderCore/Server/StandaloneServer.swift
@@ -749,7 +749,7 @@ public actor StandaloneServer {
                 container: newcomerBox.borrow(),
                 specDecPreparation: specDecPreparation,
                 assistantLoader: v2TestHooks?.assistantLoader
-                    ?? Gemma4ProviderMTPAssistantLoader(),
+                    ?? ProductionProviderMTPAssistantLoader(),
                 emitTelemetry: v2TestHooks?.emitTelemetry,
                 logInfo: { standaloneLogger.info("\($0)") },
                 logWarning: { standaloneLogger.warning("\($0)") })

--- a/provider-swift/Sources/ProviderCore/SpecDec/SpecDecArtifactFunnel.swift
+++ b/provider-swift/Sources/ProviderCore/SpecDec/SpecDecArtifactFunnel.swift
@@ -151,7 +151,8 @@ actor SpecDecArtifactFunnel {
             return .init(artifact: nil, status: .disabled(.killSwitchDisabled, configured: true))
         }
         if Self.isQwen35Target(modelType: request.modelType),
-            let directory = request.modelDirectory
+            let directory = request.modelDirectory,
+            SpecDecStore.declaresInlineArtifact(directory: directory)
         {
             switch SpecDecStore.inspectInlineArtifact(directory: directory) {
             case .failure:
@@ -163,7 +164,9 @@ actor SpecDecArtifactFunnel {
                 return .init(artifact: artifact, status: .candidate(artifact))
             }
         }
-        guard Self.isGemma4Target(modelType: request.modelType) else {
+        guard Self.isGemma4Target(modelType: request.modelType)
+            || Self.isQwen35Target(modelType: request.modelType)
+        else {
             return .init(artifact: nil, status: .disabled(.targetUnsupported, configured: true))
         }
 
@@ -354,8 +357,10 @@ actor SpecDecArtifactFunnel {
     }
 
     static func isQwen35Target(modelType: String?) -> Bool {
-        modelType?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-            == "qwen3_5_moe"
+        guard let modelType = modelType?
+            .trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        else { return false }
+        return modelType == "qwen3_5" || modelType == "qwen3_5_moe"
     }
 
     static func killSwitchEnabled(environment: [String: String]) -> Bool {

--- a/provider-swift/Sources/ProviderCore/SpecDec/SpecDecStore.swift
+++ b/provider-swift/Sources/ProviderCore/SpecDec/SpecDecStore.swift
@@ -406,6 +406,21 @@ enum SpecDecStore {
                 inlineIndexSHA256: indexDigest))
     }
 
+    /// Cheap discriminator used before inline inspection. Ordinary Qwen
+    /// targets can pair with separately published MTP artifacts, so absence
+    /// of `mtplx_mtp.included=true` must fall through to the catalog resolver
+    /// without being logged as an invalid inline payload.
+    static func declaresInlineArtifact(directory: URL) -> Bool {
+        let configURL = directory.standardizedFileURL
+            .appendingPathComponent("config.json")
+        guard let data = try? Data(contentsOf: configURL),
+            data.count <= SpecDecLimits.maximumConfigBytes,
+            let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+            let inline = root["mtplx_mtp"] as? [String: Any]
+        else { return false }
+        return inline["included"] as? Bool == true
+    }
+
     private static func rejectInline(
         _ reason: String
     ) -> Result<SpecDecArtifact, InlineArtifactRejection> {

--- a/provider-swift/Tests/ProviderCoreTests/CoordinatorClientTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/CoordinatorClientTests.swift
@@ -80,7 +80,7 @@ import Testing
     #expect(withTok["apns_environment"] as? String == "production")
 }
 
-@Test func registrationAdvertisesExplicitGemmaToolConstraintModels() throws {
+@Test func registrationAdvertisesExplicitGemmaAndQwenToolConstraintModels() throws {
     let gemma = ModelInfo(
         id: "gemma-4-26b-qat-4bit",
         modelType: "gemma4_text",
@@ -114,12 +114,19 @@ import Testing
         sizeBytes: 1,
         estimatedMemoryGb: 1,
         toolConstraintTemplateHash: "wrong")
+    let qwen38 = ModelInfo(
+        id: "mlx-community/Qwen3.8-27B-4bit",
+        modelType: "qwen3_5",
+        parameters: 27_000_000_000,
+        quantization: "4bit",
+        sizeBytes: 1,
+        estimatedMemoryGb: 1)
     let config = CoordinatorClientConfig(
         url: "wss://api.dev.darkbloom.xyz/v1/providers/ws",
         hardware: clientSampleHardware(),
         models: [
             clientSampleModel(), gemma, typeOnlyGemma, misleadingID,
-            driftedTemplate,
+            driftedTemplate, qwen38,
         ],
         backendName: "mlx_swift_lm",
         publicKey: "cHVibGlj",
@@ -130,14 +137,16 @@ import Testing
     #expect(object["tool_constraint_protocol"] as? Int == 1)
     #expect(
         object["tool_constraint_models"] as? [String]
-            == [typeOnlyGemma.id, gemma.id].sorted())
+            == [typeOnlyGemma.id, gemma.id, qwen38.id].sorted())
 
     let decoded = try ProviderProtocolCodec.decodeProviderMessage(from: data)
     guard case .register(let registration) = decoded else {
         throw ClientTestFailure.unexpectedMessage
     }
     #expect(registration.toolConstraintProtocol == 1)
-    #expect(registration.toolConstraintModels == [typeOnlyGemma.id, gemma.id].sorted())
+    #expect(
+        registration.toolConstraintModels
+            == [typeOnlyGemma.id, gemma.id, qwen38.id].sorted())
 
     let ordinary = CoordinatorClientConfig(
         url: config.url,

--- a/provider-swift/Tests/ProviderCoreTests/EngineV2ProductionWiringTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/EngineV2ProductionWiringTests.swift
@@ -1408,6 +1408,76 @@ struct EngineV2RequestRoutingTests {
         #expect(engine.submitted.isEmpty)
     }
 
+    @Test("required Qwen tool choice is parsed and validated before exposure")
+    func requiredQwenToolChoiceUsesFailClosedPostValidation() async throws {
+        let engine = WiringScriptedEngine(script: .stream([
+            .delta(
+                text: "<tool_call>\n<function=get_weather>\n</function>\n</tool_call>",
+                tokens: [10], logprobs: nil),
+            .finished(
+                reason: .stop,
+                usage: CBv2Usage(promptTokens: 5, completionTokens: 1)),
+        ]))
+        let bridge = makeBridge(engine: engine)
+        let providerEngine = MultiModelBatchSchedulerEngine(
+            registryProvider: { @Sendable in
+                [
+                    "qwen3.8-27b-4bit": .init(
+                        tokenizer: TokenizerHandle(WiringStubTokenizer()),
+                        modelType: "qwen3_5",
+                        engineV2Bridge: bridge)
+                ]
+            })
+        let request = OpenAIChatCompletionRequest(
+            model: "qwen3.8-27b-4bit",
+            messages: [.init(role: .user, content: .text("weather"))],
+            tools: [.init(function: .init(name: "get_weather"))],
+            toolChoice: .mode(.required),
+            toolCallParser: "qwen3_coder")
+
+        let stream = try await providerEngine.streamChatCompletion(request: request)
+        var events: [MLXServerGenerationEvent] = []
+        for try await event in stream { events.append(event) }
+
+        #expect(events.contains { event in
+            guard case .toolCall(let call) = event else { return false }
+            return call.function.name == "get_weather"
+                && call.function.arguments.isEmpty
+        })
+        #expect(engine.submitted.count == 1)
+        #expect(engine.submitted[0].tokenConstraint == nil)
+    }
+
+    @Test("required Qwen tool choice rejects a non-XML parser before submit")
+    func requiredQwenToolChoiceRejectsParserOverride() async throws {
+        let engine = WiringScriptedEngine(script: .stream([]))
+        let bridge = makeBridge(engine: engine)
+        let providerEngine = MultiModelBatchSchedulerEngine(
+            registryProvider: { @Sendable in
+                [
+                    "qwen3.8-27b-4bit": .init(
+                        tokenizer: TokenizerHandle(WiringStubTokenizer()),
+                        modelType: "qwen3_5",
+                        engineV2Bridge: bridge)
+                ]
+            })
+        let request = OpenAIChatCompletionRequest(
+            model: "qwen3.8-27b-4bit",
+            messages: [.init(role: .user, content: .text("weather"))],
+            tools: [.init(function: .init(name: "get_weather"))],
+            toolChoice: .mode(.required),
+            toolCallParser: "json")
+
+        do {
+            _ = try await providerEngine.streamChatCompletion(request: request)
+            Issue.record("expected Qwen parser mismatch rejection")
+        } catch let error as MultiModelBatchSchedulerEngineError {
+            #expect(error == .invalidToolPayload(
+                "inference-enforced Qwen tool_choice requires the qwen3_coder tool parser"))
+        }
+        #expect(engine.submitted.isEmpty)
+    }
+
     @Test("auto mode returns malformed tagged output as visible text")
     func autoToolParseFallbackIsVisible() async throws {
         let malformed =

--- a/provider-swift/Tests/ProviderCoreTests/EngineV2VisionRoutingTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/EngineV2VisionRoutingTests.swift
@@ -1080,8 +1080,8 @@ struct EngineV2VisionRoutingTests {
         }
         let effort = EffortBox()
         let plumbing = EngineV2VisionPlumbing(
-            prepare: { _, _, reasoningEffort in
-                effort.set(reasoningEffort)
+            prepare: { _, _, templateControls in
+                effort.set(templateControls.reasoningEffort)
                 return prepared
             }, emitTelemetry: { _ in })
         let router = makeRoutingEngine(

--- a/provider-swift/Tests/ProviderCoreTests/GemmaVLMVideoEngineV2LiveTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/GemmaVLMVideoEngineV2LiveTests.swift
@@ -280,9 +280,10 @@ struct GemmaVLMVideoEngineV2LiveTests {
     ) async throws -> (content: String, ttft: TimeInterval) {
         let recorder = VideoLiveRefusalRecorder()
         let plumbing = EngineV2VisionPlumbing(
-            prepare: { container, request, reasoningEffort in
+            prepare: { container, request, templateControls in
                 try await EngineV2VisionPrefill.prepare(
-                    container: container, request: request, reasoningEffort: reasoningEffort)
+                    container: container, request: request,
+                    templateControls: templateControls)
             },
             emitTelemetry: { recorder.append($0) }
         )

--- a/provider-swift/Tests/ProviderCoreTests/GemmaVLMVisionEngineV2LiveTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/GemmaVLMVisionEngineV2LiveTests.swift
@@ -171,9 +171,10 @@ struct GemmaVLMVisionEngineV2LiveTests {
     ) async throws -> String {
         let recorder = VisionLiveRefusalRecorder()
         let plumbing = EngineV2VisionPlumbing(
-            prepare: { container, request, reasoningEffort in
+            prepare: { container, request, templateControls in
                 try await EngineV2VisionPrefill.prepare(
-                    container: container, request: request, reasoningEffort: reasoningEffort)
+                    container: container, request: request,
+                    templateControls: templateControls)
             },
             emitTelemetry: { recorder.append($0) }
         )

--- a/provider-swift/Tests/ProviderCoreTests/InboundDecodeTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/InboundDecodeTests.swift
@@ -275,6 +275,24 @@ struct InboundDecodeTests {
         #expect(effort(#"{"model":"m","messages":[],"reasoning_effort":3}"#) == nil)
     }
 
+    @Test("Qwen template controls are extracted independently")
+    func qwenTemplateControlsExtracted() {
+        let json = #"{"model":"m","messages":[],"reasoning_effort":" xhigh ","enable_thinking":false,"preserve_thinking":true}"#
+        let controls = ProviderLoop.extractChatTemplateControls(from: Data(json.utf8))
+        #expect(controls.reasoningEffort == "xhigh")
+        #expect(controls.enableThinking == false)
+        #expect(controls.preserveThinking == true)
+    }
+
+    @Test("one malformed template control does not discard the others")
+    func malformedQwenTemplateControlIsIsolated() {
+        let json = #"{"model":"m","messages":[],"reasoning_effort":3,"enable_thinking":true,"preserve_thinking":false}"#
+        let controls = ProviderLoop.extractChatTemplateControls(from: Data(json.utf8))
+        #expect(controls.reasoningEffort == nil)
+        #expect(controls.enableThinking == true)
+        #expect(controls.preserveThinking == false)
+    }
+
     // MARK: - logprobs / top_logprobs extraction
 
     private func logprobsSpec(_ json: String) -> (topLogprobs: Int?, requested: Bool)? {

--- a/provider-swift/Tests/ProviderCoreTests/MultiModelBatchSchedulerEngineTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/MultiModelBatchSchedulerEngineTests.swift
@@ -221,6 +221,26 @@ func templateContextComposesReasoningControls() {
     #expect(context?["reasoning_effort"] as? String == "high")
 }
 
+@Test("explicit Qwen controls override reasoning.enabled and preserve history")
+func templateContextForwardsQwenControls() {
+    let request = OpenAIChatCompletionRequest(
+        model: "qwen/qwen3.8-27b",
+        messages: [.init(role: .user, content: .text("hi"))],
+        reasoning: .init(enabled: true))
+
+    for effort in ["low", "medium", "xhigh"] {
+        let context = MultiModelBatchSchedulerEngine.templateAdditionalContext(
+            for: request,
+            controls: ChatTemplateControls(
+                reasoningEffort: effort,
+                enableThinking: false,
+                preserveThinking: true))
+        #expect(context?["reasoning_effort"] as? String == effort)
+        #expect(context?["enable_thinking"] as? Bool == false)
+        #expect(context?["preserve_thinking"] as? Bool == true)
+    }
+}
+
 // MARK: - Engine error mapping (P2 #6)
 //
 // Pins the `MultiModelBatchSchedulerEngineError.fromSchedulerMessage`

--- a/provider-swift/Tests/ProviderCoreTests/Qwen35TemplateFixesTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/Qwen35TemplateFixesTests.swift
@@ -55,7 +55,11 @@ struct Qwen35TemplateFixesTests {
         #expect(Qwen35TemplateFix.applies(
             to: .init(modelId: nil, modelType: "qwen3_5_moe")))
         #expect(Qwen35TemplateFix.applies(
+            to: .init(modelId: nil, modelType: "qwen3_5")))
+        #expect(Qwen35TemplateFix.applies(
             to: .init(modelId: "mlx-community/Qwen3.6-35B", modelType: nil)))
+        #expect(Qwen35TemplateFix.applies(
+            to: .init(modelId: "mlx-community/Qwen3.8-27B-4bit", modelType: nil)))
         #expect(!Qwen35TemplateFix.applies(
             to: .init(modelId: "qwen3-8b", modelType: "qwen3")))
         #expect(!Qwen35TemplateFix.applies(

--- a/provider-swift/Tests/ProviderCoreTests/Qwen36ProductionCanaryTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/Qwen36ProductionCanaryTests.swift
@@ -57,11 +57,11 @@ struct Qwen36ProductionCanaryTests {
             let visionScheduler = fixture.scheduler(
                 bundle: targetBundle,
                 vision: EngineV2VisionPlumbing(
-                    prepare: { container, request, reasoningEffort in
+                    prepare: { container, request, templateControls in
                         let prepared = try await EngineV2VisionPrefill.prepare(
                             container: container,
                             request: request,
-                            reasoningEffort: reasoningEffort)
+                            templateControls: templateControls)
                         visionProbe.recordPrepared(spanCount: prepared.spans.count)
                         return prepared
                     },

--- a/provider-swift/Tests/ProviderCoreTests/Qwen38ProductionCanaryFixture.swift
+++ b/provider-swift/Tests/ProviderCoreTests/Qwen38ProductionCanaryFixture.swift
@@ -1,0 +1,286 @@
+// Copyright © 2026 Eigen Labs.
+
+import Foundation
+import MLX
+import MLXLMCommon
+import MLXLMServer
+import Testing
+
+@testable import ProviderCore
+
+struct Qwen38ProductionCanaryFixture: @unchecked Sendable {
+    let modelDirectory: URL
+    let assistantDirectory: URL
+    let imageURL: URL
+    let videoURL: URL
+    let container: ModelContainer
+    let targetSizing: SlotSizingSnapshot
+    let tokenizer: TokenizerHandle
+    let assistantLayerCount: Int
+
+    func removeStagedAssistant() {
+        try? FileManager.default.removeItem(at: assistantDirectory)
+    }
+
+    func makeBundle(preparation: SpecDecPreparation) async throws -> ProviderEngineBundle {
+        let prepared = try await EngineV2SlotFactory.prepareProductionModel(
+            modelId: Qwen38ProductionCanary.targetModelID,
+            isVLM: true,
+            modelDirectory: modelDirectory,
+            container: container,
+            specDecPreparation: preparation)
+        let sizing = targetSizing.replacingAuxiliaryWeightBytes(prepared.assistantBytes)
+        let grant = Int(min(
+            UnifiedMemoryCap.kvBudgetBytes(
+                physicalBytes: ProcessInfo.processInfo.physicalMemory,
+                residentWeightBytes: UInt64(max(0, sizing.weightsBytes)),
+                configReserveBytes: 0),
+            UInt64(Int.max)))
+        do {
+            return try await EngineV2SlotFactory.makeProductionBundle(
+                modelId: Qwen38ProductionCanary.targetModelID,
+                modelType: Qwen38ProductionCanary.modelType,
+                isVLM: true,
+                modelDirectory: modelDirectory,
+                container: container,
+                tokenizer: tokenizer,
+                sizing: sizing,
+                kvBytesCapacity: grant,
+                maxConcurrentRequests: 2,
+                kvBudget: nil,
+                specDecPreparation: preparation,
+                preparedModel: prepared,
+                environment: [
+                    "DARKBLOOM_PREFIX_CACHE": "0",
+                    "DARKBLOOM_MTP_MAX_RECTANGULAR_TOKENS": "0",
+                ])
+        } catch {
+            prepared.assistant?.release()
+            MLX.Memory.clearCache()
+            throw error
+        }
+    }
+
+    func separateMTPPreparation() async -> SpecDecPreparation {
+        let store = FileManager.default.temporaryDirectory
+            .appendingPathComponent("qwen38-mtp-store-\(UUID().uuidString)")
+        let funnel = SpecDecArtifactFunnel(
+            resolver: SpecDecResolver(storeRoot: store),
+            catalog: nil)
+        let preparation = await funnel.prepare(.init(
+            modelId: Qwen38ProductionCanary.targetModelID,
+            modelType: Qwen38ProductionCanary.modelType,
+            enabled: true,
+            localPath: assistantDirectory.path,
+            modelDirectory: modelDirectory,
+            allowDownload: false,
+            environment: ["DARKBLOOM_CBV2_MTP": "1"]))
+        await funnel.shutdown()
+        try? FileManager.default.removeItem(at: store)
+        return preparation
+    }
+
+    func service(bundle: ProviderEngineBundle) -> MLXOpenAIService {
+        let entry = MultiModelBatchSchedulerEngine.ModelRegistryEntry(
+            tokenizer: tokenizer,
+            modelType: Qwen38ProductionCanary.modelType,
+            container: container,
+            isVLM: true,
+            engineV2Bridge: bundle.bridge)
+        let scheduler = MultiModelBatchSchedulerEngine(
+            registryProvider: { [entry] in
+                [Qwen38ProductionCanary.targetModelID: entry]
+            },
+            defaultMaxTokens: 512)
+        return MLXOpenAIService(engine: scheduler)
+    }
+
+    func baseRequest(
+        prompt: String,
+        maxTokens: Int = 64,
+        reasoning: Bool = false
+    ) -> OpenAIChatCompletionRequest {
+        OpenAIChatCompletionRequest(
+            model: Qwen38ProductionCanary.targetModelID,
+            messages: [.init(role: .user, content: .text(prompt))],
+            reasoning: .init(enabled: reasoning),
+            temperature: 0,
+            topP: 1,
+            topK: 0,
+            minP: 0,
+            maxTokens: maxTokens)
+    }
+
+    func checkText(using service: MLXOpenAIService) async throws {
+        let response = try await service.createChatCompletion(
+            request: baseRequest(prompt: "Reply exactly QWEN38_TEXT_OK and nothing else."))
+        #expect(responseText(response) == "QWEN38_TEXT_OK")
+        #expect(response.usage.promptTokens > 0)
+        #expect(response.usage.completionTokens > 0)
+    }
+
+    func checkStreaming(using service: MLXOpenAIService) async throws {
+        var request = baseRequest(prompt: "Reply exactly QWEN38_STREAM_OK and nothing else.")
+        request.stream = true
+        request.streamOptions = .init(includeUsage: true)
+        let frames = try await service.streamChatCompletionFrames(request: request)
+        var text = ""
+        var sawDone = false
+        var sawUsage = false
+        for try await frame in frames {
+            if frame == ServerSentEventEncoder.done {
+                sawDone = true
+                continue
+            }
+            guard frame.hasPrefix("data: ") else { continue }
+            let json = String(frame.dropFirst(6)).trimmingCharacters(in: .whitespacesAndNewlines)
+            guard let data = json.data(using: .utf8) else { continue }
+            let chunk = try JSONDecoder().decode(OpenAIChatCompletionChunk.self, from: data)
+            text += chunk.choices.first?.delta.content ?? ""
+            sawUsage = sawUsage || chunk.usage != nil
+        }
+        #expect(text.trimmingCharacters(in: .whitespacesAndNewlines) == "QWEN38_STREAM_OK")
+        #expect(sawDone)
+        #expect(sawUsage)
+    }
+
+    func checkJSON(using service: MLXOpenAIService) async throws {
+        var request = baseRequest(
+            prompt: #"Return exactly {"model":"qwen3.8","ok":true} and no markdown."#)
+        request.responseFormat = .jsonObject()
+        let response = try await service.createChatCompletion(request: request)
+        let text = responseText(response)
+        let object = try #require(
+            try JSONSerialization.jsonObject(with: Data(text.utf8)) as? [String: Any])
+        #expect(object["model"] as? String == "qwen3.8")
+        #expect(object["ok"] as? Bool == true)
+    }
+
+    func checkReasoning(using service: MLXOpenAIService) async throws {
+        var request = baseRequest(
+            prompt: "Compute 19 * 23. Put only the number in the final answer.",
+            maxTokens: 160,
+            reasoning: true)
+        request.reasoningParser = .qwen3
+        let response = try await service.createChatCompletion(request: request)
+        let message = try #require(response.choices.first?.message)
+        #expect(message.reasoningContent?.isEmpty == false)
+        #expect(responseText(response).contains("437"))
+    }
+
+    func checkRequiredTool(using service: MLXOpenAIService) async throws {
+        let schema: MLXLMCommon.JSONValue = .object([
+            "type": .string("object"),
+            "properties": .object([
+                "city": .object(["type": .string("string")])
+            ]),
+            "required": .array([.string("city")]),
+            "additionalProperties": .bool(false),
+        ])
+        var request = baseRequest(
+            prompt: "Call get_weather exactly once for Boston. Do not write prose.",
+            maxTokens: 96)
+        request.tools = [.init(function: .init(
+            name: "get_weather",
+            description: "Get the weather for a city.",
+            parameters: schema))]
+        request.toolChoice = .mode(.required)
+        request.toolCallParser = "qwen3_coder"
+        let response = try await service.createChatCompletion(request: request)
+        let calls = try #require(response.choices.first?.message.toolCalls)
+        let call = try #require(calls.first)
+        #expect(calls.count == 1)
+        #expect(call.function.name == "get_weather")
+        #expect(call.function.arguments.contains("Boston"))
+    }
+
+    func checkImage(using service: MLXOpenAIService) async throws {
+        let response = try await service.createChatCompletion(
+            request: mediaRequest(
+                prompt: "Identify the logo in the image. Include the letters MLX in the answer.",
+                parts: [.imageURL(try dataURI(imageURL, mime: "image/png"))]))
+        #expect(responseText(response).localizedCaseInsensitiveContains("MLX"))
+    }
+
+    func checkMultipleImages(using service: MLXOpenAIService) async throws {
+        let image = try dataURI(imageURL, mime: "image/png")
+        let response = try await service.createChatCompletion(
+            request: mediaRequest(
+                prompt: "How many images are attached? Reply with only the number.",
+                parts: [.imageURL(image), .imageURL(image)]))
+        #expect(responseText(response).trimmingCharacters(in: .whitespacesAndNewlines) == "2")
+    }
+
+    func checkVideo(using service: MLXOpenAIService) async throws {
+        let response = try await service.createChatCompletion(
+            request: mediaRequest(
+                prompt: "Describe the main test pattern in this video in a short phrase.",
+                parts: [.videoURL(try dataURI(videoURL, mime: "video/quicktime"))],
+                maxTokens: 96))
+        let text = responseText(response)
+        #expect(
+            text.localizedCaseInsensitiveContains("color bar")
+                || text.localizedCaseInsensitiveContains("colour bar"))
+    }
+
+    func checkMixedMedia(using service: MLXOpenAIService) async throws {
+        let image = try dataURI(imageURL, mime: "image/png")
+        let video = try dataURI(videoURL, mime: "video/quicktime")
+        let response = try await service.createChatCompletion(
+            request: mediaRequest(
+                prompt: "Name the image logo and the video's test pattern. Mention MLX and color bars.",
+                parts: [.imageURL(image), .videoURL(video)],
+                maxTokens: 128))
+        let text = responseText(response)
+        #expect(text.localizedCaseInsensitiveContains("MLX"))
+        #expect(
+            text.localizedCaseInsensitiveContains("color bar")
+                || text.localizedCaseInsensitiveContains("colour bar"))
+    }
+
+    func mediaRequest(
+        prompt: String,
+        parts: [OpenAIContentPart],
+        maxTokens: Int = 64
+    ) -> OpenAIChatCompletionRequest {
+        OpenAIChatCompletionRequest(
+            model: Qwen38ProductionCanary.targetModelID,
+            messages: [.init(
+                role: .user,
+                content: .parts([.text(prompt)] + parts))],
+            reasoning: .init(enabled: false),
+            temperature: 0,
+            topP: 1,
+            topK: 0,
+            minP: 0,
+            maxTokens: maxTokens)
+    }
+
+    func parityRequest() -> OpenAIChatCompletionRequest {
+        baseRequest(
+            prompt: "Explain speculative decoding, target verification, rejection rollback, and cache safety.",
+            maxTokens: Qwen38ProductionCanary.parityMaxTokens)
+    }
+
+    func tokenize(_ request: OpenAIChatCompletionRequest) throws -> [Int] {
+        let prepared = try ToolChoicePromptPolicy.prepare(request)
+        return try ProviderPromptContractPipeline.tokenize(
+            prepared: prepared,
+            request: request,
+            tokenizer: tokenizer.inner,
+            modelType: Qwen38ProductionCanary.modelType,
+            reasoningEffort: nil)
+    }
+
+    private func responseText(_ response: OpenAIChatCompletionResponse) -> String {
+        guard let content = response.choices.first?.message.content else { return "" }
+        if case .text(let text) = content {
+            return text.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        return ""
+    }
+
+    private func dataURI(_ url: URL, mime: String) throws -> String {
+        "data:\(mime);base64," + (try Data(contentsOf: url)).base64EncodedString()
+    }
+}

--- a/provider-swift/Tests/ProviderCoreTests/Qwen38ProductionCanarySupport.swift
+++ b/provider-swift/Tests/ProviderCoreTests/Qwen38ProductionCanarySupport.swift
@@ -1,0 +1,315 @@
+// Copyright © 2026 Eigen Labs.
+
+import Foundation
+import MLX
+import MLXLMCommon
+
+@testable import ProviderCore
+
+enum Qwen38ProductionCanary {
+    static let targetModelID = "mlx-community/Qwen3.8-27B-4bit"
+    static let assistantModelID = "mlx-community/Qwen3.8-27B-MTP-4bit"
+    static let modelType = "qwen3_5"
+    static let parityMaxTokens = 128
+    static let mtpWarmupMaxTokens = 24
+    static let parityRequestID = CBv2RequestID(0x5133_3800)
+    static let warmupRequestID = CBv2RequestID(0x5133_3801)
+
+    private static let liveGate = "DARKBLOOM_LIVE_MLX_TESTS"
+    private static let qwenGate = "DARKBLOOM_LIVE_MLX_QWEN38"
+    private static let mtpOnlyGate = "DARKBLOOM_LIVE_MLX_QWEN38_MTP_ONLY"
+    private static let targetPathOverride = "DARKBLOOM_LIVE_MLX_QWEN38_MODEL_PATH"
+    private static let assistantPathOverride = "DARKBLOOM_LIVE_MLX_QWEN38_MTP_PATH"
+    private static let imagePathOverride = "DARKBLOOM_LIVE_MLX_QWEN38_IMAGE_PATH"
+    private static let videoPathOverride = "DARKBLOOM_LIVE_MLX_QWEN38_VIDEO_PATH"
+
+    static var enabled: Bool {
+        let environment = ProcessInfo.processInfo.environment
+        return environment[liveGate] == "1" && environment[qwenGate] == "1"
+    }
+
+    static var mtpOnly: Bool {
+        ProcessInfo.processInfo.environment[mtpOnlyGate] == "1"
+    }
+
+    static var serialMTP: Bool {
+        let raw = ProcessInfo.processInfo.environment["DARKBLOOM_QWEN_MTP_SERIAL"] ?? ""
+        return ["1", "true", "yes", "on"].contains(raw.lowercased())
+    }
+
+    static func load() async throws -> Qwen38ProductionCanaryFixture {
+        guard HardwareDetector.totalMemoryGB() >= 48 else {
+            throw Qwen38ProductionCanaryError.insufficientMemory(HardwareDetector.totalMemoryGB())
+        }
+        guard LiveInferenceFixtures.ensureMetallibColocated() != nil else {
+            throw Qwen38ProductionCanaryError.missingMetallib
+        }
+
+        let environment = ProcessInfo.processInfo.environment
+        let target = try resolveArtifact(
+            override: environment[targetPathOverride], modelID: targetModelID)
+        let assistant = try resolveArtifact(
+            override: environment[assistantPathOverride], modelID: assistantModelID)
+        let assistantLayerCount = try mtpLayerCount(assistant)
+        guard assistantLayerCount == 1 else {
+            throw Qwen38ProductionCanaryError.invalidAssistantLayerCount(
+                assistant.path, assistantLayerCount)
+        }
+        let repositoryRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let image = URL(
+            fileURLWithPath: environment[imagePathOverride]
+                ?? repositoryRoot.appendingPathComponent("libs/mlx/docs/logo/mlx_logo.png").path)
+        let video = URL(
+            fileURLWithPath: environment[videoPathOverride]
+                ?? repositoryRoot.appendingPathComponent(
+                    "libs/mlx-swift-lm/Tests/MLXLMTests/Resources/1080p_30.mov").path)
+        guard FileManager.default.fileExists(atPath: image.path) else {
+            throw Qwen38ProductionCanaryError.missingMedia(image.path)
+        }
+        guard FileManager.default.fileExists(atPath: video.path) else {
+            throw Qwen38ProductionCanaryError.missingMedia(video.path)
+        }
+        guard ProviderLoop.modelIsVLM(at: target) else {
+            throw Qwen38ProductionCanaryError.notVLM(target.path)
+        }
+
+        let stagedAssistant = try stageAssistant(from: assistant)
+        LiveInferenceFixtures.applyMemoryBudget(maxBytes: 96 * 1024 * 1024 * 1024)
+        let container: ModelContainer
+        do {
+            container = try await ModelContainerLoading.loadContainer(from: target)
+        } catch {
+            try? FileManager.default.removeItem(at: stagedAssistant)
+            throw Qwen38ProductionCanaryError.stage(
+                "ModelContainerLoading.loadContainer", String(reflecting: error))
+        }
+        let sizing = await SlotSizingSnapshot.build(
+            container: container,
+            modelPath: target,
+            fallbackDefaultMaxTokens: 512)
+        let tokenizer = await container.perform { TokenizerHandle($0.tokenizer) }
+        return Qwen38ProductionCanaryFixture(
+            modelDirectory: target,
+            assistantDirectory: stagedAssistant,
+            imageURL: image,
+            videoURL: video,
+            container: container,
+            targetSizing: sizing,
+            tokenizer: tokenizer,
+            assistantLayerCount: assistantLayerCount)
+    }
+
+    static func resolveArtifact(override: String?, modelID: String) throws -> URL {
+        if let override, !override.isEmpty {
+            let url = URL(fileURLWithPath: override, isDirectory: true).standardizedFileURL
+            guard FileManager.default.fileExists(atPath: url.path) else {
+                throw Qwen38ProductionCanaryError.missingArtifact(modelID, url.path)
+            }
+            return url
+        }
+        guard let url = ModelScanner.resolveLocalPath(modelID: modelID) else {
+            throw Qwen38ProductionCanaryError.missingArtifact(modelID, "Hugging Face cache")
+        }
+        return url.standardizedFileURL
+    }
+
+    static func mtpLayerCount(_ artifact: URL) throws -> Int {
+        let configURL = artifact.appendingPathComponent("config.json")
+        let object = try JSONSerialization.jsonObject(with: Data(contentsOf: configURL))
+        guard
+            let config = object as? [String: Any],
+            let textConfig = config["text_config"] as? [String: Any],
+            let count = textConfig["mtp_num_hidden_layers"] as? Int
+        else {
+            throw Qwen38ProductionCanaryError.invalidAssistant(artifact.path)
+        }
+        return count
+    }
+
+    static func stageAssistant(from source: URL) throws -> URL {
+        let destination = FileManager.default.temporaryDirectory
+            .appendingPathComponent("qwen38-mtp-canary-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: destination, withIntermediateDirectories: true)
+        do {
+            let names = try FileManager.default.contentsOfDirectory(atPath: source.path)
+                .filter { $0 == "config.json" || $0.hasSuffix(".safetensors") }
+                .sorted()
+            guard names.contains("config.json"), names.contains(where: { $0.hasSuffix(".safetensors") }) else {
+                throw Qwen38ProductionCanaryError.invalidAssistant(source.path)
+            }
+            for name in names {
+                let resolved = source.appendingPathComponent(name).resolvingSymlinksInPath()
+                let staged = destination.appendingPathComponent(name)
+                do {
+                    try FileManager.default.linkItem(at: resolved, to: staged)
+                } catch {
+                    // A cache mounted on another volume cannot be hard-linked.
+                    // Foundation copyItem uses clonefile on APFS when possible,
+                    // preserving the regular-file trust boundary without
+                    // forcing a second physical copy of the large assistant.
+                    try FileManager.default.copyItem(at: resolved, to: staged)
+                }
+            }
+            return destination
+        } catch {
+            try? FileManager.default.removeItem(at: destination)
+            throw error
+        }
+    }
+
+    static func rawTokens(
+        bundle: ProviderEngineBundle,
+        promptTokens: [Int],
+        maxTokens: Int,
+        requestID: CBv2RequestID
+    ) async throws -> [Int] {
+        let ownedEngine = await bundle.bridge.ownedEngine
+        guard let engine = ownedEngine else {
+            throw Qwen38ProductionCanaryError.engineUnavailable
+        }
+        let stream = try engine.submit(CBv2Request(
+            id: requestID,
+            promptTokens: promptTokens,
+            sampling: CBv2SamplingParams(temperature: 0, topP: 1, topK: 0, minP: 0),
+            maxTokens: maxTokens,
+            stopTokens: await bundle.bridge.stopTokenIds,
+            prefixCacheEnabled: false))
+        var tokens: [Int] = []
+        var terminal: CBv2FinishReason?
+        for await event in stream {
+            switch event {
+            case .delta(_, let emitted, _): tokens.append(contentsOf: emitted)
+            case .finished(let reason, _): terminal = reason
+            }
+        }
+        guard !tokens.isEmpty else { throw Qwen38ProductionCanaryError.emptyGeneration }
+        guard let terminal else { throw Qwen38ProductionCanaryError.missingTerminal }
+        switch terminal {
+        case .stop, .length: return tokens
+        case .cancelled: throw Qwen38ProductionCanaryError.unexpectedTerminal("cancelled")
+        case .error(let message): throw Qwen38ProductionCanaryError.unexpectedTerminal(message)
+        case .terminal(let cause, let message):
+            throw Qwen38ProductionCanaryError.unexpectedTerminal("\(cause): \(message)")
+        }
+    }
+
+    static func timedRawTokens(
+        bundle: ProviderEngineBundle,
+        promptTokens: [Int],
+        maxTokens: Int,
+        requestID: CBv2RequestID
+    ) async throws -> (tokens: [Int], seconds: Double) {
+        let clock = ContinuousClock()
+        let started = clock.now
+        let tokens = try await rawTokens(
+            bundle: bundle,
+            promptTokens: promptTokens,
+            maxTokens: maxTokens,
+            requestID: requestID)
+        let elapsed = started.duration(to: clock.now).components
+        return (
+            tokens,
+            Double(elapsed.seconds)
+                + Double(elapsed.attoseconds) / 1_000_000_000_000_000_000)
+    }
+
+    static func waitForIdle(_ bridge: EngineV2Bridge) async throws -> CBv2CapacitySnapshot {
+        for _ in 0..<200 {
+            let snapshot = await bridge.capacitySnapshot()
+            if snapshot.activeRequests == 0 && snapshot.waitingRequests == 0
+                && snapshot.activeTokens == 0
+            {
+                return snapshot
+            }
+            try await Task.sleep(for: .milliseconds(50))
+        }
+        let snapshot = await bridge.capacitySnapshot()
+        throw Qwen38ProductionCanaryError.capacityDidNotDrain(
+            active: snapshot.activeRequests,
+            waiting: snapshot.waitingRequests,
+            tokens: snapshot.activeTokens)
+    }
+
+    static func retire(_ bundle: ProviderEngineBundle) async {
+        await bundle.bridge.shutdown()
+        bundle.releaseAssistant()
+        MLX.Stream().synchronize()
+        MLX.Memory.clearCache()
+    }
+
+    static func benchmarkDiagnostic(
+        target: (tokens: [Int], seconds: Double),
+        mtp: (tokens: [Int], seconds: Double),
+        proposed: Int,
+        accepted: Int
+    ) -> String {
+        let hardware = try? HardwareDetector.detect()
+        let targetTPS = Double(target.tokens.count) / target.seconds
+        let mtpTPS = Double(mtp.tokens.count) / mtp.seconds
+        let acceptance = proposed > 0 ? Double(accepted) / Double(proposed) : 0
+        return String(
+            format:
+                "QWEN38_CANARY chip=%@ ram_gb=%llu tokens=%d target_seconds=%.4f target_tps=%.3f mtp_seconds=%.4f mtp_tps=%.3f speedup=%.4fx mtp_acceptance=%.4f",
+            locale: Locale(identifier: "en_US_POSIX"),
+            hardware?.chipName ?? "unknown",
+            hardware?.memoryGb ?? HardwareDetector.totalMemoryGB(),
+            target.tokens.count,
+            target.seconds,
+            targetTPS,
+            mtp.seconds,
+            mtpTPS,
+            target.seconds / mtp.seconds,
+            acceptance)
+    }
+}
+
+enum Qwen38ProductionCanaryError: Error, CustomStringConvertible {
+    case missingArtifact(String, String)
+    case invalidAssistant(String)
+    case invalidAssistantLayerCount(String, Int)
+    case missingMedia(String)
+    case missingMetallib
+    case insufficientMemory(UInt64)
+    case notVLM(String)
+    case engineUnavailable
+    case emptyGeneration
+    case missingTerminal
+    case unexpectedTerminal(String)
+    case capacityDidNotDrain(active: Int, waiting: Int, tokens: Int)
+    case stage(String, String)
+
+    var description: String {
+        switch self {
+        case .missingArtifact(let id, let path):
+            "Qwen3.8 artifact \(id) is missing at \(path)"
+        case .invalidAssistant(let path):
+            "Qwen3.8 MTP artifact at \(path) lacks config.json or safetensors weights"
+        case .invalidAssistantLayerCount(let path, let count):
+            "Qwen3.8 MTP artifact at \(path) declares \(count) MTP layers; expected 1"
+        case .missingMedia(let path):
+            "Qwen3.8 canary media fixture is missing at \(path)"
+        case .missingMetallib:
+            "mlx.metallib is unavailable; run scripts/fetch-metallib.sh before the live canary"
+        case .insufficientMemory(let memory):
+            "Qwen3.8 canary requires at least 48 GiB unified memory; host reports \(memory) GiB"
+        case .notVLM(let path):
+            "Qwen3.8 artifact at \(path) does not declare vision_config"
+        case .engineUnavailable:
+            "production bundle released its EngineV2 before the canary submission"
+        case .emptyGeneration:
+            "production EngineV2 emitted no token IDs"
+        case .missingTerminal:
+            "production EngineV2 stream ended without a terminal event"
+        case .unexpectedTerminal(let reason):
+            "production EngineV2 ended unsuccessfully: \(reason)"
+        case .capacityDidNotDrain(let active, let waiting, let tokens):
+            "production EngineV2 capacity did not drain (active=\(active), waiting=\(waiting), tokens=\(tokens))"
+        case .stage(let stage, let detail):
+            "Qwen3.8 production canary failed during \(stage): \(detail)"
+        }
+    }
+}

--- a/provider-swift/Tests/ProviderCoreTests/Qwen38ProductionCanaryTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/Qwen38ProductionCanaryTests.swift
@@ -1,0 +1,141 @@
+// Copyright © 2026 Eigen Labs.
+
+import Foundation
+import MLX
+import MLXLMCommon
+import MLXLMServer
+import Testing
+
+@testable import ProviderCore
+
+/// Exact-artifact acceptance test for the Qwen3.8 launch pair.
+///
+/// This is intentionally opt-in: it loads roughly 17 GiB of target weights,
+/// exercises the real Metal vision path, then rebuilds the production bundle
+/// with the separate MTP artifact. The test resolves normal Hugging Face cache
+/// snapshots, but stages the assistant's config and weight as regular hard
+/// links because the production local-artifact trust boundary rejects symlinks.
+@Suite("Qwen3.8 production artifact canary", .serialized)
+struct Qwen38ProductionCanaryTests {
+    @Test(
+        "full VLM request surface and one-layer MTP remain target-authoritative",
+        .enabled(
+            if: Qwen38ProductionCanary.enabled,
+            "set DARKBLOOM_LIVE_MLX_TESTS=1 and DARKBLOOM_LIVE_MLX_QWEN38=1 to run the local real-artifact Qwen3.8 canary")
+    )
+    func fullVLMAndSeparateMTPArtifact() async throws {
+        let fixture = try await Qwen38ProductionCanary.load()
+        defer { fixture.removeStagedAssistant() }
+        #expect(fixture.assistantLayerCount == 1)
+
+        var liveBundle: ProviderEngineBundle?
+        do {
+            let targetBundle = try await fixture.makeBundle(
+                preparation: .init(
+                    artifact: nil,
+                    status: .disabled(.configDisabled, configured: false)))
+            liveBundle = targetBundle
+            let targetService = fixture.service(bundle: targetBundle)
+
+            if !Qwen38ProductionCanary.mtpOnly {
+                try await fixture.checkText(using: targetService)
+                try await fixture.checkStreaming(using: targetService)
+                try await fixture.checkJSON(using: targetService)
+                try await fixture.checkReasoning(using: targetService)
+                try await fixture.checkRequiredTool(using: targetService)
+                try await fixture.checkImage(using: targetService)
+                try await fixture.checkMultipleImages(using: targetService)
+                try await fixture.checkVideo(using: targetService)
+                try await fixture.checkMixedMedia(using: targetService)
+            }
+
+            let parityPrompt = try fixture.tokenize(fixture.parityRequest())
+            let targetRun = try await Qwen38ProductionCanary.timedRawTokens(
+                bundle: targetBundle,
+                promptTokens: parityPrompt,
+                maxTokens: Qwen38ProductionCanary.parityMaxTokens,
+                requestID: Qwen38ProductionCanary.parityRequestID)
+            #expect(targetRun.tokens.count > 32, "parity request did not exercise a long decode")
+
+            await Qwen38ProductionCanary.retire(targetBundle)
+            liveBundle = nil
+
+            let preparation = await fixture.separateMTPPreparation()
+            let artifact = try #require(
+                preparation.artifact,
+                "SpecDecArtifactFunnel did not resolve the staged Qwen3.8 MTP artifact")
+            #expect(artifact.source == .local)
+            #expect(preparation.status.configured)
+
+            let mtpBundle = try await fixture.makeBundle(preparation: preparation)
+            liveBundle = mtpBundle
+            let initialMTP = await mtpBundle.bridge.mtpStatusSnapshot()
+            #expect(initialMTP.configured)
+            #expect(initialMTP.active)
+            #expect(initialMTP.assistantSource == .local)
+            #expect(initialMTP.assistantResidentBytes > 0)
+            #expect(mtpBundle.assistantBytes > 0)
+
+            _ = try await Qwen38ProductionCanary.rawTokens(
+                bundle: mtpBundle,
+                promptTokens: parityPrompt,
+                maxTokens: Qwen38ProductionCanary.mtpWarmupMaxTokens,
+                requestID: Qwen38ProductionCanary.warmupRequestID)
+            _ = try await Qwen38ProductionCanary.waitForIdle(mtpBundle.bridge)
+
+            let mtpRun = try await Qwen38ProductionCanary.timedRawTokens(
+                bundle: mtpBundle,
+                promptTokens: parityPrompt,
+                maxTokens: Qwen38ProductionCanary.parityMaxTokens,
+                requestID: Qwen38ProductionCanary.parityRequestID)
+            if Qwen38ProductionCanary.serialMTP {
+                #expect(
+                    mtpRun.tokens == targetRun.tokens,
+                    "serial-oracle MTP changed greedy emitted token IDs")
+            } else {
+                #expect(
+                    mtpRun.tokens.count == targetRun.tokens.count,
+                    "rectangular MTP changed the requested decode length")
+            }
+
+            let mtp = await mtpBundle.bridge.mtpStatusSnapshot()
+            #expect(mtp.active)
+            #expect(mtp.proposedTokens > 0)
+            #expect(mtp.acceptedDraftTokens > 0)
+            if Qwen38ProductionCanary.serialMTP {
+                #expect(mtp.serialVerificationRounds > 0)
+                #expect(mtp.rectangularVerificationRounds == 0)
+                #expect(mtp.verificationMode == CBv2MTPVerificationMode.serialTarget.rawValue)
+            } else {
+                #expect(mtp.rectangularVerificationRounds > 0)
+                #expect(mtp.serialVerificationRounds == 0)
+                #expect(mtp.verificationMode == CBv2MTPVerificationMode.rectangular.rawValue)
+            }
+            // The one-layer artifact is recurrently applied for an adaptive
+            // multi-token draft. Layer depth and draft depth are distinct.
+            #expect((0 ... 4).contains(mtp.selectedDepth))
+            #expect(mtp.acceptanceByPosition.count <= 4)
+
+            print(Qwen38ProductionCanary.benchmarkDiagnostic(
+                target: targetRun,
+                mtp: mtpRun,
+                proposed: mtp.proposedTokens,
+                accepted: mtp.acceptedDraftTokens))
+
+            let drained = try await Qwen38ProductionCanary.waitForIdle(mtpBundle.bridge)
+            #expect(drained.activeRequests == 0)
+            #expect(drained.waitingRequests == 0)
+            #expect(drained.activeTokens == 0)
+            #expect(drained.kvBytesInUse == 0)
+            #expect(drained.kvBytesReserved == 0)
+
+            await Qwen38ProductionCanary.retire(mtpBundle)
+            liveBundle = nil
+        } catch {
+            if let liveBundle {
+                await Qwen38ProductionCanary.retire(liveBundle)
+            }
+            throw error
+        }
+    }
+}

--- a/provider-swift/Tests/ProviderCoreTests/QwenVLMTargetExtractionTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/QwenVLMTargetExtractionTests.swift
@@ -11,16 +11,17 @@ import Testing
 @testable import ProviderCore
 
 private func qwenTargetFixtureJSON(
+    modelType: String = "qwen3_5_moe",
     mtpLayers: Int = 1,
     fullAttentionInterval: Int = 1
 ) -> Data {
     Data(
         """
         {
-          "model_type": "qwen3_5_moe",
+          "model_type": "\(modelType)",
           "mtp_num_hidden_layers": \(mtpLayers),
           "text_config": {
-            "model_type": "qwen3_5_moe",
+            "model_type": "qwen3_5_text",
             "hidden_size": 64,
             "num_hidden_layers": 2,
             "intermediate_size": 128,
@@ -39,7 +40,7 @@ private func qwenTargetFixtureJSON(
             "mtp_num_hidden_layers": \(mtpLayers)
           },
           "vision_config": {
-            "model_type": "qwen3_5_moe",
+            "model_type": "\(modelType)",
             "depth": 1,
             "hidden_size": 64,
             "intermediate_size": 128,
@@ -220,20 +221,23 @@ struct QwenVLMTargetExtractionTests {
         #expect(defaultModule.bits == 4)
     }
 
-    @Test("plain Qwen wrapper is refused; only the combined MoE wrapper dispatches")
-    func plainQwenWrapperRefused() throws {
-        let configData = qwenTargetFixtureJSON()
+    @Test("dense Qwen wrapper dispatches to the shared CBv2 target seam")
+    func denseQwenWrapperDispatches() throws {
+        let configData = qwenTargetFixtureJSON(modelType: "qwen3_5")
         let wrapperConfig = try JSONDecoder.json5().decode(
             MLXVLM.Qwen35Configuration.self, from: configData)
         let directory = try qwenTargetFixtureDirectory(configData: configData)
         defer { try? FileManager.default.removeItem(at: directory) }
 
-        #expect(throws: EngineV2VLMTextExtractionError.self) {
-            _ = try EngineV2VLMTextExtraction.extractTextModel(
-                from: MLXVLM.Qwen35(wrapperConfig),
-                modelDirectory: directory,
-                environment: [EngineV2VLMTextExtraction.parityCheckFlag: "0"])
-        }
+        let extraction = try EngineV2VLMTextExtraction.extractTextModel(
+            from: MLXVLM.Qwen35(wrapperConfig),
+            modelDirectory: directory,
+            environment: [EngineV2VLMTextExtraction.parityCheckFlag: "0"])
+
+        #expect(extraction.family == .qwen35Dense)
+        #expect(extraction.servingModel is Qwen35Model)
+        #expect((extraction.servingModel is Qwen35MoEModel) == false)
+        #expect(extraction.parityMaxAbsLogitDiff == nil)
     }
 
     @Test("benchmark resolution uses the same extracted Qwen target")
@@ -252,8 +256,8 @@ struct QwenVLMTargetExtractionTests {
         #expect(serving is Qwen35MoEModel)
     }
 
-    @Test("production factory accepts only the wired Qwen MoE target family")
-    func factoryAcceptanceAndRefusal() throws {
+    @Test("production factory accepts dense and MoE through one Qwen target seam")
+    func factoryAcceptance() throws {
         let config = try EngineV2VLMTextExtraction.decodeQwenConfiguration(
             configData: qwenTargetFixtureJSON(fullAttentionInterval: 2))
         let target = Qwen35MoEModel(config)
@@ -269,13 +273,13 @@ struct QwenVLMTargetExtractionTests {
         #expect(prepared.modelCapabilities.supportsPrefixReuse == false)
         #expect(EngineV2Factory.adoptionBoundTokens(model: target) == 0)
 
-        #expect(throws: EngineV2ProductionError.self) {
-            _ = try EngineV2Factory.prepareProductionBackend(
-                model: Qwen35Model(config),
-                kvBytesCapacity: 1 << 20,
-                maxConcurrentRequests: 2,
-                kvBackend: EngineV2KVBackendSelection.contiguous)
-        }
+        let dense = try EngineV2Factory.prepareProductionBackend(
+            model: Qwen35Model(config),
+            kvBytesCapacity: 1 << 20,
+            maxConcurrentRequests: 2,
+            kvBackend: EngineV2KVBackendSelection.contiguous)
+        #expect(dense.layerKinds == prepared.layerKinds)
+        #expect(dense.modelCapabilities == prepared.modelCapabilities)
     }
 
     @Test("Qwen core capability veto forces paged selection to contiguous before preflight")
@@ -396,8 +400,44 @@ struct QwenVLMTargetExtractionTests {
         #expect(try config.cbv2RecurrentStateSpec().peakBytesPerRequest() == 193_167_360)
     }
 
+    @Test("Qwen3.8 dense topology derives measured KV and recurrent residency")
+    func qwen38DenseSizingFacts() throws {
+        let text: [String: Any] = [
+            "model_type": "qwen3_5_text",
+            "hidden_size": 5_120,
+            "num_hidden_layers": 64,
+            "num_attention_heads": 24,
+            "num_key_value_heads": 4,
+            "head_dim": 256,
+            "linear_num_value_heads": 48,
+            "linear_num_key_heads": 16,
+            "linear_key_head_dim": 128,
+            "linear_value_head_dim": 128,
+            "linear_conv_kernel_dim": 4,
+            "vocab_size": 248_320,
+            "full_attention_interval": 4,
+            "max_position_embeddings": 262_144,
+            "mtp_num_hidden_layers": 1,
+        ]
+        let data = try JSONSerialization.data(withJSONObject: [
+            "model_type": "qwen3_5",
+            "text_config": text,
+        ])
+        let config = try EngineV2VLMTextExtraction.decodeQwenTextConfiguration(
+            configData: data)
+
+        #expect(config.cbv2LayerKinds.count == 16)
+        #expect(
+            SlotSizingSnapshot.fp16KVBytesPerToken(layerKinds: config.cbv2LayerKinds)
+                == 65_536)
+        #expect(try config.cbv2RecurrentStateSpec().fixedBytesPerRequest() == 153_944_064)
+        #expect(try config.cbv2RecurrentStateSpec().peakBytesPerRequest() == 461_832_192)
+    }
+
     @Test("Qwen is advertised after target, vision, MTP, and cleanup canaries pass")
     func allowlistIsOpen() {
+        #expect(EngineV2SupportedModels.isSupported(modelType: "qwen3_5"))
+        #expect(EngineV2SupportedModels.isSupported(modelType: " QWEN3_5 "))
         #expect(EngineV2SupportedModels.isSupported(modelType: "qwen3_5_moe"))
         #expect(EngineV2SupportedModels.isSupported(modelType: " QWEN3_5_MOE "))
     }

--- a/provider-swift/Tests/ProviderCoreTests/SpecDecArtifactFunnelTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/SpecDecArtifactFunnelTests.swift
@@ -133,6 +133,15 @@ private func makeInlineQwenArtifact(includeMTP: Bool = true) throws -> URL {
     return root
 }
 
+private func makeDenseQwenTargetWithoutInlineMTP() throws -> URL {
+    let root = FileManager.default.temporaryDirectory
+        .appendingPathComponent("specdec-dense-qwen-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    try Data(#"{"model_type":"qwen3_5","text_config":{"model_type":"qwen3_5_text"}}"#.utf8)
+        .write(to: root.appendingPathComponent("config.json"))
+    return root
+}
+
 /// HF-cache-style copy of an inline Qwen artifact: the snapshot directory
 /// holds only RELATIVE symlinks into a sibling `blobs/` directory — the
 /// layout `hf download` materializes and the layout production checkpoints
@@ -245,6 +254,32 @@ struct SpecDecArtifactFunnelTests {
         #expect(prepared.artifact == nil)
         #expect(prepared.status.reason == .inlineArtifactInvalid)
         #expect(await catalog.calls == 0)
+    }
+
+    @Test("dense Qwen target without inline MTP falls through to catalog metadata")
+    func qwenStandaloneAssistantUsesCatalogPath() async throws {
+        let directory = try makeDenseQwenTargetWithoutInlineMTP()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let catalog = FunnelCatalog(funnelModel(id: "qwen/qwen3.8-27b"))
+        let prepared = await funnel(
+            catalog: catalog, root: FileManager.default.temporaryDirectory
+        ).prepare(
+            .init(
+                modelId: "qwen/qwen3.8-27b",
+                modelType: "qwen3_5",
+                enabled: true,
+                localPath: nil,
+                modelDirectory: directory,
+                allowDownload: true,
+                environment: [:]))
+
+        #expect(prepared.artifact == nil)
+        #expect(prepared.status.reason == .metadataMissing)
+        // The catalog refresh is deliberately deadline-bounded and may lose
+        // its race under concurrent test load. The stable contract is that a
+        // dense checkpoint without inline tensors reaches metadata handling
+        // rather than being rejected as an invalid inline artifact.
+        #expect(prepared.status.reason != .inlineArtifactInvalid)
     }
 
     @Test("HF-cache symlinked snapshot passes inspection and admits inline MTP")

--- a/provider-swift/Tests/ProviderCoreTests/StandaloneServerTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/StandaloneServerTests.swift
@@ -467,6 +467,34 @@ private func standaloneTestServer(models: [ModelInfo] = []) -> StandaloneServer 
 
 // MARK: - v0.7.5 one-engine: 32 MiB chat-route body ceiling
 
+@Test func localChatBatchRecoversQwenTemplateControlsPerItem() {
+    let body = Data(#"""
+    [
+        {"model":"qwen","messages":[],"reasoning_effort":" high ","enable_thinking":false,"preserve_thinking":true},
+        {"model":"qwen","messages":[],"reasoning_effort":3,"enable_thinking":true,"preserve_thinking":false}
+    ]
+    """#.utf8)
+
+    let controls = LocalChatTemplateControls.batch(from: body, count: 2)
+    #expect(controls.count == 2)
+    #expect(controls[0].reasoningEffort == "high")
+    #expect(controls[0].enableThinking == false)
+    #expect(controls[0].preserveThinking == true)
+    #expect(controls[1].reasoningEffort == nil)
+    #expect(controls[1].enableThinking == true)
+    #expect(controls[1].preserveThinking == false)
+}
+
+@Test func localChatBatchControlRecoveryFailsClosedOnShapeMismatch() {
+    let body = Data(#"[{"model":"qwen","messages":[],"enable_thinking":false}]"#.utf8)
+    let controls = LocalChatTemplateControls.batch(from: body, count: 2)
+    #expect(controls.count == 2)
+    #expect(controls.allSatisfy {
+        $0.reasoningEffort == nil && $0.enableThinking == nil
+            && $0.preserveThinking == nil
+    })
+}
+
 @Test func standaloneServerAcceptsChatBodiesPastTheOldTwoMiBLimit() async throws {
     // Regression for the known 413 backlog item: the upstream router's
     // BasicRequestContext pins Hummingbird's 2 MiB decode default, which

--- a/provider-swift/Tests/ProviderCoreTests/VisionTowerBudgetTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/VisionTowerBudgetTests.swift
@@ -315,6 +315,16 @@ struct EngineV2VisionPixelRunTests {
         #expect(runs == [0 ..< 50_176])
     }
 
+    @Test("video grids split into one chronological run per temporal group")
+    func videoFramesSplitExactly() throws {
+        let runs = try EngineV2VisionPrefill.videoFramePixelRuns(
+            grids: [THW(3, 2, 2), THW(2, 1, 3)], totalRows: 18)
+        #expect(runs == [
+            [0 ..< 4, 4 ..< 8, 8 ..< 12],
+            [12 ..< 15, 15 ..< 18],
+        ])
+    }
+
     @Test("grids that under-cover the tensor are refused")
     func underCoverageIsRefused() {
         #expect(throws: EngineV2VisionPrefillError.self) {


### PR DESCRIPTION
# Integrate Qwen3.8-27B full VLM into Darkbloom

## Summary

Integrates Qwen3.8-27B as a dense `qwen3_5` VLM across provider inference, request semantics, registry metadata, admission, and encrypted coordinator/provider E2E coverage.

Exact head: `c3a406726b29df478d223c163cd48824bd4b3d71`

Base: `080d7e66782b28ab038f34dfb5ce23469f19642b` (`master`)

Runtime dependency: [`Layr-Labs/mlx-swift-lm#118`](https://github.com/Layr-Labs/mlx-swift-lm/pull/118) at provisional reviewed commit `1abbe77c8de4791ae9a010de1e7d8b9e49028da7`. Before this draft becomes review-ready, update `libs/mlx-swift-lm` to the runtime PR's upstream merge commit and rerun the recursive-clone and CI gates.

## Before

```mermaid
flowchart LR
  A[Consumer request] --> B[Catalog and alias lookup]
  B --> C[Existing model-family admission]
  C --> D[Provider runtime]
  D --> E[Qwen3.8 dense VLM unsupported]

  F[Code] --> G[MoE-oriented Qwen extraction / CBv2 switches]
  G --> E
```

## After

```mermaid
flowchart LR
  A[Qwen3.8 manifest and alias] --> B[Provider advertises tools / reasoning / JSON / vision / video]
  B --> C[Coordinator applies parser defaults and capability admission]
  C --> D[X25519-encrypted request dispatch]
  D --> E[Dense Qwen3.8 VLM + CBv2 + optional MTP]
  E --> F[Encrypted streaming chunks + usage]
  F --> G[OpenAI-compatible response and billing]

  H[Code] --> I[Shared dense/MoE extraction and vision helpers]
  I --> E
  J[Registry/OpenRouter modality derivation] --> C
```

## Changes

### Provider

- Add dense Qwen3.8 extraction from the VLM wrapper, weight-space rekeying, quantization-structure application, and greedy wrapper/target parity validation.
- Share CBv2 model topology, cache, recurrent-state, prefix, packed-prefill, position-axis, and MTP seams across dense and MoE Qwen variants.
- Generalize Qwen vision prefill/tower code while retaining one-image-or-frame-per-tower invocation, pre-allocation Metal budget checks, per-eval MLX fault checks, causal spans, bounded video/media ingestion, and request-owned mRoPE state.
- Forward `reasoning_effort`, `enable_thinking`, and `preserve_thinking`; support required tool choice and Qwen parser aliases without adding protocol wire types.
- Require provider version `>= 0.8.11` for the registered model surface.

### Coordinator and API

- Apply only allowlisted omitted request defaults (`reasoning_parser`, `tool_call_parser`) from registry runtime parameters; explicit caller values always win and catalog-only fields cannot leak into provider requests.
- Derive OpenRouter input/output modalities for concrete models and aliases from effective model type plus registry capabilities instead of hardcoded text-only values.
- Add an exact Qwen3.8 registry fixture covering alias, capabilities, context/output limits, pricing, immutable revisions, parser defaults, version floor, OpenRouter modalities, and capacity surfaces.
- Add a real encrypted required-tool-choice E2E through coordinator and provider process boundaries.

### Production launch canary

- Add a gated, modular Apple Silicon canary for immutable target/MTP artifacts.
- Cover text, SSE with usage, JSON mode, reasoning/content separation, required tools, image, multiple images, video, mixed media, target-only fallback, MTP target authority, MTP metrics/residency, and post-request engine drain.

## Model contract

- Public alias: `qwen/qwen3.8-27b`
- Target: `mlx-community/Qwen3.8-27B-4bit` at `3e6447f082e89cc7f0bc6e5441afd38dfce760ff`
- MTP: `mlx-community/Qwen3.8-27B-MTP-4bit` at `b643c01b6d3b094e325edb6ebd832e16c486c575`
- Capabilities: tools, reasoning, JSON mode, vision, video
- Native context: 262,144 tokens
- Initial output cap: 32,768 tokens
- Launch RAM floor in the fixture: 48 GB (catalog promotion remains blocked on measurements for every intended hardware class)
- Target aggregate SHA-256: `eec38b3b23e4e3385c70beb6bee9472f19dbb4d508d27f2cdee433145cb5158e`
- MTP aggregate SHA-256: `1b84aa6096efad9cdaa40bfda3234887689a8bf91269a29012fa0cc8ddf1cda8`
- Generated manifest SHA-256 values: target `fab19f7234c1140eb9b6f9709448a770dccf628cacbf41e90f0707ffabb0d600`; MTP `7461ec0a9928560de6b0c4b4cd40dc330f5315c4a91ddfe25f47b6110ea383a3`

## Validation

Hardware: Apple M3 Max, 64 GB unified memory, macOS.

- `make coordinator-test`: all coordinator packages passed.
- `go test -race $(go list ./... | grep -v /e2e)`: passed.
- `golangci-lint run` at CI-pinned v2.1.6: 0 issues.
- `make provider-test`: 2,164 tests in 224 suites passed.
- `swift test` in `mlx-swift-lm`: 544 XCTest plus 860 Swift Testing cases passed.
- `./scripts/verify-prompt-parity.sh`: immutable manifests and shared vectors passed; 375/375 load requests succeeded at 25 QPS with zero errors/mismatches/restarts.
- Console UI: ESLint 0 errors, 56 files / 498 tests passed, Next.js production build passed (44 static pages).
- Coordinator host build, Linux/amd64 static cross-build, provider build, metallib staging, prompt-sidecar format/check/clippy/tests, release-integrity scripts, and benchmark-wrapper tests passed.
- A brand-new GitHub-origin recursive clone of `glg2672/d-inference:codex/feat/qwen38-27b` resolved all five exact gitlinks through their upstream URLs, remained source-clean, and built the coordinator and provider successfully.
- Real process-boundary E2E: Apple attestation, provider WebSocket registration, X25519 encrypted dispatch, required `get_weather` tool call for Boston, HTTP 200, streaming/accounting, and 100 microUSD cost/payout all passed.
- Full live Qwen3.8 request-surface canary passed in 201.635 s. Measured target `14.970 tok/s`; MTP `17.915 tok/s` (`1.1968x`) with `0.8235` acceptance and a clean engine drain.

Warnings were pre-existing and non-fatal (Swift dependency/deprecation warnings and 104 UI lint warnings). `npm install` reported 37 dependency advisories from the existing lockfile; the lockfile is unchanged by this PR.

## Remaining pre-merge gates

- [ ] Merge the runtime PR upstream and repin the root gitlink to its merge commit.
- [x] Push the provisional root branch and prove a fresh GitHub recursive clone resolves the exact gitlink.
- [ ] Run CI against that final merge pin.
- [ ] Add measured admission/TTFT/TPS/memory/vision/MTP evidence for any launch classes not represented by the 64 GB M3 Max run (notably 48 GB and 128 GB).
- [ ] Publish immutable target/MTP manifests and replace locally generated validation identifiers with approved CDN versions.

## Rollback and operations

Code rollback is a root-commit/gitlink revert. Operational rollback moves `qwen/qwen3.8-27b` away from the concrete build and disables its catalog status while retaining immutable manifests for reproducibility. This PR performs no model publishing, production registration, alias promotion, provider release, database mutation, or traffic change; all require post-review human approval.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/698"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790194378&installation_model_id=21733&pr_number=698&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F698&signature=a7e2641e0d9288f312ae3bb31b1089ae9a615cd0cd33cf89cda64534cda0cbab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->