### PR TITLE
fix(provider): harden GPT-OSS Harmony requests

### DIFF
--- a/provider-swift/Sources/ProviderCore/Inference/ChatTemplateFixes.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/ChatTemplateFixes.swift
@@ -23,14 +23,15 @@ enum ChatTemplateFixes {
         context: ChatTemplateFixContext
     ) throws -> [[String: any Sendable]] {
         let sanitized = sanitizeJinjaMessages(messages)
-        let normalized = Qwen35TemplateFix.applies(to: context)
+        var normalized = Qwen35TemplateFix.applies(to: context)
             ? Qwen35TemplateFix.normalizeMessages(sanitized)
             : sanitized
-        try validateGenericToolHistory(normalized)
 
         if GPTOSSHarmonyTemplateFix.applies(to: context) {
-            return try GPTOSSHarmonyTemplateFix.normalizeMessages(normalized)
+            normalized = try GPTOSSHarmonyTemplateFix.normalizeMessages(normalized)
         }
+        try validateGenericToolHistory(normalized)
+
         if Gemma4TemplateFix.applies(to: context) {
             return try Gemma4TemplateFix.normalizeMessages(normalized)
         }

--- a/provider-swift/Sources/ProviderCore/Inference/GPTOSSHarmonyTemplateFixes.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/GPTOSSHarmonyTemplateFixes.swift
@@ -11,10 +11,19 @@ enum GPTOSSHarmonyTemplateFix {
         isHarmonyModelHint(context.modelId) || isHarmonyModelHint(context.modelType)
     }
 
+    static func effectiveReasoningEffort(
+        _ requested: String?,
+        context: ChatTemplateFixContext
+    ) -> String? {
+        guard applies(to: context), requested == "high" else { return requested }
+        return "medium"
+    }
+
     static func normalizeMessages(
         _ messages: [[String: any Sendable]]
     ) throws -> [[String: any Sendable]] {
-        let bridged = bridgeReasoningContentToThinking(messages)
+        let systemNormalized = LeadingSystemMessageNormalizer.normalize(messages)
+        let bridged = bridgeReasoningContentToThinking(systemNormalized)
         return try splitParallelToolCalls(bridged)
     }
 
@@ -48,9 +57,9 @@ enum GPTOSSHarmonyTemplateFix {
     // `content` rides the FIRST split turn; `thinking` (which Harmony forbids in the
     // same turn as a tool_call) is emitted as a standalone preceding assistant turn.
     //
-    // The only genuinely unnormalizable shape — a following tool RESULT whose
-    // tool_call_id matches none of the assistant's tool_calls — still throws a clean
-    // 400 (invalidToolPayload), so we never silently drop a result.
+    // Calls/results that cannot be paired unambiguously (missing, duplicate,
+    // or unmatched tool_call_id) throw a clean 400 (invalidToolPayload), so
+    // normalization never silently drops or duplicates a result.
     private static func splitParallelToolCalls(
         _ messages: [[String: any Sendable]]
     ) throws -> [[String: any Sendable]] {
@@ -78,15 +87,35 @@ enum GPTOSSHarmonyTemplateFix {
                 continue
             }
 
+            var seenToolCallIDs = Set<String>()
+            for call in toolCalls {
+                guard let callMap = call as? [String: any Sendable],
+                      let id = callMap["id"] as? String,
+                      !id.isEmpty
+                else {
+                    continue
+                }
+                guard seenToolCallIDs.insert(id).inserted else {
+                    throw MultiModelBatchSchedulerEngineError.invalidToolPayload(
+                        "duplicate assistant tool_call id \(id)")
+                }
+            }
+
             // Gather the contiguous tool-result messages that follow, keyed by id.
             var results: [String: [String: any Sendable]] = [:]
             var resultOrder: [String] = []
             var j = i + 1
             while j < messages.count, (messages[j]["role"] as? String) == "tool" {
-                if let id = messages[j]["tool_call_id"] as? String {
-                    results[id] = messages[j]
-                    resultOrder.append(id)
+                guard let id = messages[j]["tool_call_id"] as? String, !id.isEmpty else {
+                    throw MultiModelBatchSchedulerEngineError.invalidToolPayload(
+                        "tool result following split tool_calls requires a non-empty tool_call_id")
                 }
+                guard results[id] == nil else {
+                    throw MultiModelBatchSchedulerEngineError.invalidToolPayload(
+                        "duplicate tool result for tool_call_id \(id)")
+                }
+                results[id] = messages[j]
+                resultOrder.append(id)
                 j += 1
             }
 

--- a/provider-swift/Sources/ProviderCore/Inference/LeadingSystemMessageNormalizer.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/LeadingSystemMessageNormalizer.swift
@@ -1,0 +1,69 @@
+// Copyright © 2026 Eigen Labs.
+//
+// Some published chat templates accept a system message only in the first
+// position. OpenAI-compatible clients may legally insert system messages later
+// in a conversation, so affected model adapters fold all text-only system
+// turns into one leading instruction before rendering.
+
+import Foundation
+
+enum LeadingSystemMessageNormalizer {
+    static func normalize(
+        _ messages: [[String: any Sendable]]
+    ) -> [[String: any Sendable]] {
+        let systemIndices = messages.indices.filter {
+            (messages[$0]["role"] as? String) == "system"
+        }
+        guard let firstSystemIndex = systemIndices.first else { return messages }
+        guard systemIndices.count > 1 || firstSystemIndex != messages.startIndex else {
+            return messages
+        }
+
+        let nonSystemMessages = messages.filter {
+            ($0["role"] as? String) != "system"
+        }
+        if systemIndices.count == 1 {
+            return [messages[firstSystemIndex]] + nonSystemMessages
+        }
+
+        let systemMessages = systemIndices.map { messages[$0] }
+        var systemTexts: [String] = []
+        systemTexts.reserveCapacity(systemMessages.count)
+        for message in systemMessages {
+            guard let text = textContent(message["content"]) else {
+                // Moving structured media into a text-only template slot would
+                // change request semantics. Leave it untouched so the model's
+                // existing validation remains authoritative.
+                return messages
+            }
+            if !text.isEmpty {
+                systemTexts.append(text)
+            }
+        }
+
+        var mergedSystem = systemMessages[0]
+        mergedSystem["content"] = systemTexts.joined(separator: "\n\n")
+        return [mergedSystem] + nonSystemMessages
+    }
+
+    private static func textContent(_ content: (any Sendable)?) -> String? {
+        guard let content else { return "" }
+        if let text = content as? String { return text }
+        guard let parts = content as? [any Sendable] else { return nil }
+
+        var text = ""
+        for part in parts {
+            guard let object = part as? [String: any Sendable],
+                  object["image"] == nil,
+                  object["image_url"] == nil,
+                  object["video"] == nil,
+                  object["video_url"] == nil,
+                  let partText = object["text"] as? String
+            else {
+                return nil
+            }
+            text += partText
+        }
+        return text
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Inference/MultiModelBatchSchedulerEngine+Translation.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/MultiModelBatchSchedulerEngine+Translation.swift
@@ -16,11 +16,18 @@ extension MultiModelBatchSchedulerEngine {
 
     static func templateAdditionalContext(
         for request: OpenAIChatCompletionRequest,
-        reasoningEffort: String?
+        reasoningEffort: String?,
+        modelType: String? = nil
     ) -> [String: any Sendable]? {
         var context: [String: any Sendable] = [:]
-        if let reasoningEffort {
-            context["reasoning_effort"] = reasoningEffort
+        let fixContext = ChatTemplateFixContext(
+            modelId: request.model,
+            modelType: modelType)
+        if let effectiveEffort = GPTOSSHarmonyTemplateFix.effectiveReasoningEffort(
+            reasoningEffort,
+            context: fixContext)
+        {
+            context["reasoning_effort"] = effectiveEffort
         }
         if let reasoningEnabled = request.reasoning?.enabled {
             context["enable_thinking"] = reasoningEnabled

--- a/provider-swift/Sources/ProviderCore/Inference/MultiModelBatchSchedulerEngine.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/MultiModelBatchSchedulerEngine.swift
@@ -69,13 +69,12 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
     private let defaultMaxTokens: Int
 
     /// OpenAI `reasoning_effort` for this request (`low`/`medium`/`high`
-    /// for gpt-oss; model-specific otherwise). Injected verbatim into the
-    /// chat template's render context under the `reasoning_effort` key so
-    /// templates that read it (gpt-oss / Harmony) emit the matching
-    /// `Reasoning: <effort>` system directive. `nil` leaves the template
-    /// at its built-in default. We do not validate the value here — the
-    /// allowed set is model-specific and lives in each model's Jinja
-    /// template, so passing through is the format-agnostic choice.
+    /// for gpt-oss; model-specific otherwise). The prompt pipeline injects
+    /// it into the chat template's render context. GPT-OSS currently maps
+    /// `high` to `medium` before Harmony rendering to keep generation inside
+    /// the upstream request deadline; all other model/value combinations
+    /// pass through unchanged. `nil` leaves the template at its built-in
+    /// default.
     private let reasoningEffort: String?
     /// Authenticated remote or configured local prefix-cache scope. Maps to
     /// `CBv2Request.cacheSalt` for both cache tiers.

--- a/provider-swift/Sources/ProviderCore/Inference/ProviderPromptContractPipeline.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/ProviderPromptContractPipeline.swift
@@ -36,6 +36,7 @@ enum ProviderPromptContractPipeline {
             tools: ChatTemplateFixes.normalizeTools(tools, context: context),
             additionalContext: MultiModelBatchSchedulerEngine.templateAdditionalContext(
                 for: request,
-                reasoningEffort: reasoningEffort))
+                reasoningEffort: reasoningEffort,
+                modelType: modelType))
     }
 }

--- a/provider-swift/Sources/ProviderCore/Inference/Qwen35TemplateFixes.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/Qwen35TemplateFixes.swift
@@ -29,37 +29,7 @@ enum Qwen35TemplateFix {
     static func normalizeMessages(
         _ messages: [[String: any Sendable]]
     ) -> [[String: any Sendable]] {
-        let systemIndices = messages.indices.filter {
-            (messages[$0]["role"] as? String) == "system"
-        }
-        guard let firstSystemIndex = systemIndices.first else { return messages }
-        guard systemIndices.count > 1 || firstSystemIndex != messages.startIndex else {
-            return messages
-        }
-
-        let nonSystemMessages = messages.filter {
-            ($0["role"] as? String) != "system"
-        }
-        if systemIndices.count == 1 {
-            return [messages[firstSystemIndex]] + nonSystemMessages
-        }
-
-        let systemMessages = systemIndices.map { messages[$0] }
-        var systemTexts: [String] = []
-        systemTexts.reserveCapacity(systemMessages.count)
-        for message in systemMessages {
-            guard let text = systemTextContent(message["content"]) else {
-                // Images, video, and unknown structured content are not safe to
-                // move into Qwen's leading system slot. Preserve the template's
-                // deterministic rejection instead of changing their semantics.
-                return messages
-            }
-            if !text.isEmpty { systemTexts.append(text) }
-        }
-
-        var mergedSystem = systemMessages[0]
-        mergedSystem["content"] = systemTexts.joined(separator: "\n\n")
-        return [mergedSystem] + nonSystemMessages
+        LeadingSystemMessageNormalizer.normalize(messages)
     }
 
     /// Typed counterpart used by the multimodal path before `UserInput`
@@ -110,26 +80,5 @@ enum Qwen35TemplateFix {
             }
             return text
         }
-    }
-
-    private static func systemTextContent(_ content: (any Sendable)?) -> String? {
-        guard let content else { return "" }
-        if let text = content as? String { return text }
-        guard let parts = content as? [any Sendable] else { return nil }
-
-        var text = ""
-        for part in parts {
-            guard let object = part as? [String: any Sendable],
-                  object["image"] == nil,
-                  object["image_url"] == nil,
-                  object["video"] == nil,
-                  object["video_url"] == nil,
-                  let partText = object["text"] as? String
-            else {
-                return nil
-            }
-            text += partText
-        }
-        return text
     }
 }

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+InboundDecode.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+InboundDecode.swift
@@ -68,10 +68,9 @@ extension ProviderLoop {
     ///
     /// This lives outside `OpenAIChatCompletionRequest` (the upstream type
     /// doesn't model it), so we decode it directly. Returns a trimmed,
-    /// non-empty string or `nil`. The value is passed through verbatim —
-    /// the valid set (`low`/`medium`/`high` for gpt-oss; other models
-    /// differ) is enforced by each model's chat template, not here, so we
-    /// stay format-agnostic rather than hardcoding a per-model allowlist.
+    /// non-empty string or `nil`. Extraction remains format-agnostic; the
+    /// prompt pipeline applies any model-specific serving policy before
+    /// rendering (currently GPT-OSS `high` → `medium`).
     internal static func extractReasoningEffort(from data: Data) -> String? {
         struct Probe: Decodable { let reasoning_effort: String? }
         guard let probe = try? JSONDecoder().decode(Probe.self, from: data),
@@ -138,7 +137,9 @@ extension ProviderLoop {
         let messages = prepared.messages.map { $0.templateMessageDict() }
         let toolSpecs = prepared.tools?.map { $0.toolSpec() }
         let additionalContext = MultiModelBatchSchedulerEngine.templateAdditionalContext(
-            for: request, reasoningEffort: reasoningEffort)
+            for: request,
+            reasoningEffort: reasoningEffort,
+            modelType: modelType)
         // Must mirror the production tokenize path (sanitize JSON
         // null / Optional leaves) so this recount matches what was prefilled
         // and doesn't itself throw on a null-bearing request.

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+InferenceHandler.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+InferenceHandler.swift
@@ -225,8 +225,9 @@ extension ProviderLoop {
         // `OpenAIChatCompletionRequest` shape, so decode it directly from
         // the request body and thread it into the chat template's render
         // context below (see `MultiModelBatchSchedulerEngine`). gpt-oss /
-        // Harmony reads it to set the reasoning budget; other models
-        // ignore the extra template variable.
+        // Harmony reads the effective value to set the reasoning budget
+        // (`high` currently serves as `medium`); other models ignore the
+        // extra template variable.
         let reasoningEffort = Self.extractReasoningEffort(from: decryptedData)
         // Cache identity is coordinator-authored and authenticated outside the
         // sealed OpenAI body. Never trust caller-controlled prompt_cache_key/user

--- a/provider-swift/Tests/ProviderCoreTests/GPTOSSHarmonyTemplateFixesTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/GPTOSSHarmonyTemplateFixesTests.swift
@@ -1,0 +1,307 @@
+import Foundation
+import Jinja
+import Testing
+import MLXLMCommon
+
+@testable import ProviderCore
+
+/// The system-extraction and history loop from the served GPT-OSS Harmony
+/// template. Rendering it through Swift Jinja pins the exact failure mode:
+/// only messages[0] is promoted to developer instructions and later system
+/// turns have no branch in the history loop.
+private struct HarmonySystemMessageRenderingTokenizer: MLXLMCommon.Tokenizer {
+    private static let servedTemplateFragment = #"""
+{%- if reasoning_effort %}
+    {{- "<|start|>system<|message|>Reasoning: " + reasoning_effort + "<|end|>" }}
+{%- endif %}
+{%- if messages[0].role == "developer" or messages[0].role == "system" %}
+    {%- set developer_message = messages[0].content %}
+    {%- set loop_messages = messages[1:] %}
+{%- else %}
+    {%- set developer_message = "" %}
+    {%- set loop_messages = messages %}
+{%- endif %}
+{%- if developer_message %}
+    {{- "<|start|>developer<|message|>" }}
+    {{- "# Instructions\n\n" }}
+    {{- developer_message }}
+    {{- "\n\n" }}
+    {{- "<|end|>" }}
+{%- endif %}
+{%- for message in loop_messages -%}
+    {%- if message.role == "assistant" -%}
+        {{- "<|start|>assistant<|channel|>final<|message|>" + message.content + "<|end|>" }}
+    {%- elif message.role == "user" -%}
+        {{- "<|start|>user<|message|>" + message.content + "<|end|>" }}
+    {%- endif -%}
+{%- endfor -%}
+"""#
+
+    func encode(text: String, addSpecialTokens: Bool) -> [Int] {
+        text.utf8.map(Int.init)
+    }
+
+    func decode(tokenIds: [Int], skipSpecialTokens: Bool) -> String {
+        String(decoding: tokenIds.map(UInt8.init), as: UTF8.self)
+    }
+
+    func convertTokenToId(_ token: String) -> Int? { nil }
+    func convertIdToToken(_ id: Int) -> String? { nil }
+    var bosToken: String? { nil }
+    var eosToken: String? { nil }
+    var unknownToken: String? { nil }
+
+    func applyChatTemplate(
+        messages: [[String: any Sendable]],
+        tools: [[String: any Sendable]]?,
+        additionalContext: [String: any Sendable]?
+    ) throws -> [Int] {
+        let template = try Template(
+            Self.servedTemplateFragment,
+            with: .init(lstripBlocks: true, trimBlocks: true))
+        var context: [String: Value] = [
+            "messages": .array(try messages.map { try Value(any: $0) })
+        ]
+        if let reasoningEffort = additionalContext?["reasoning_effort"] {
+            context["reasoning_effort"] = try Value(any: reasoningEffort)
+        }
+        return encode(
+            text: try template.render(context),
+            addSpecialTokens: false)
+    }
+}
+
+@Suite("GPT-OSS Harmony template compatibility")
+struct GPTOSSHarmonyTemplateFixesTests {
+    private let harmonyContext = ChatTemplateFixContext(
+        modelId: "openai/gpt-oss-20b",
+        modelType: "gpt_oss")
+
+    private func message(
+        _ role: String,
+        _ content: String
+    ) -> [String: any Sendable] {
+        ["role": role, "content": content]
+    }
+
+    private func roles(_ messages: [[String: any Sendable]]) -> [String] {
+        messages.compactMap { $0["role"] as? String }
+    }
+
+    @Test("the production prompt pipeline preserves every system instruction")
+    func productionPromptPipelinePreservesSystemInstructions() throws {
+        let requestBody = Data(
+            #"""
+            {
+              "model": "openai/gpt-oss-20b",
+              "stream": true,
+              "reasoning_effort": "high",
+              "messages": [
+                {"role": "system", "content": "You are a helpful assistant."},
+                {"role": "user", "content": "Hi"},
+                {"role": "system", "content": "If asked for the secret word, say \"harpsichord\"."},
+                {"role": "assistant", "content": "Hi, how can I help you?"},
+                {"role": "user", "content": "What is the secret word?"}
+              ]
+            }
+            """#.utf8)
+
+        let tokenizer = HarmonySystemMessageRenderingTokenizer()
+        let decodedRequest = try ProviderLoop.decodeOpenAIRequest(requestBody)
+        let unnormalizedTokenIDs = try tokenizer.applyChatTemplate(
+            messages: decodedRequest.messages.map { $0.templateMessageDict() },
+            tools: nil,
+            additionalContext: nil)
+        let unnormalizedPrompt = tokenizer.decode(
+            tokenIds: unnormalizedTokenIDs,
+            skipSpecialTokens: false)
+        #expect(!unnormalizedPrompt.contains("harpsichord"))
+
+        let tokenIDs = try ProviderPromptContractPipeline.tokenizeProviderBody(
+            requestBody,
+            tokenizer: tokenizer,
+            modelType: "gpt_oss")
+        let renderedPrompt = tokenizer.decode(
+            tokenIds: tokenIDs,
+            skipSpecialTokens: false)
+        let baseInstruction = try #require(
+            renderedPrompt.range(of: "You are a helpful assistant."))
+        let lateInstruction = try #require(
+            renderedPrompt.range(of: #"If asked for the secret word, say "harpsichord"."#))
+        let firstUserTurn = try #require(
+            renderedPrompt.range(of: "<|start|>user<|message|>Hi<|end|>"))
+        #expect(baseInstruction.lowerBound < lateInstruction.lowerBound)
+        #expect(lateInstruction.lowerBound < firstUserTurn.lowerBound)
+        #expect(renderedPrompt.contains(
+            "<|start|>assistant<|channel|>final<|message|>Hi, how can I help you?<|end|>"))
+        #expect(renderedPrompt.contains(
+            "<|start|>user<|message|>What is the secret word?<|end|>"))
+        #expect(renderedPrompt.contains("Reasoning: medium"))
+        #expect(!renderedPrompt.contains("Reasoning: high"))
+    }
+
+    @Test("interleaved system messages are merged into the leading instruction")
+    func mergesInterleavedSystemMessages() throws {
+        let normalized = try ChatTemplateFixes.normalizeMessages(
+            [
+                message("system", "You are a helpful assistant."),
+                message("user", "Hi"),
+                message("system", #"If asked for the secret word, say "harpsichord"."#),
+                message("assistant", "Hi, how can I help you?"),
+                message("user", "What is the secret word?"),
+            ],
+            context: harmonyContext)
+
+        #expect(roles(normalized) == ["system", "user", "assistant", "user"])
+        #expect(
+            normalized[0]["content"] as? String
+                == """
+                You are a helpful assistant.
+
+                If asked for the secret word, say "harpsichord".
+                """)
+        #expect(normalized[1]["content"] as? String == "Hi")
+        #expect(normalized[2]["content"] as? String == "Hi, how can I help you?")
+        #expect(normalized[3]["content"] as? String == "What is the secret word?")
+    }
+
+    @Test("loaded GPT-OSS model type repairs an opaque request model ID")
+    func appliesByModelType() throws {
+        let normalized = try ChatTemplateFixes.normalizeMessages(
+            [
+                message("user", "question"),
+                message("system", "late policy"),
+            ],
+            context: .init(modelId: "opaque-alias", modelType: "gpt_oss"))
+
+        #expect(roles(normalized) == ["system", "user"])
+        #expect(normalized[0]["content"] as? String == "late policy")
+    }
+
+    @Test("system normalization runs before tool-history validation")
+    func normalizesBeforeToolHistoryValidation() throws {
+        let toolCall: [String: any Sendable] = [
+            "id": "call-1",
+            "type": "function",
+            "function": [
+                "name": "lookup",
+                "arguments": [String: any Sendable](),
+            ] as [String: any Sendable],
+        ]
+        let assistant: [String: any Sendable] = [
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [toolCall] as [any Sendable],
+        ]
+        let toolResult: [String: any Sendable] = [
+            "role": "tool",
+            "content": "result",
+            "tool_call_id": "call-1",
+        ]
+
+        let normalized = try ChatTemplateFixes.normalizeMessages(
+            [
+                message("user", "look this up"),
+                assistant,
+                message("system", "use trusted sources"),
+                toolResult,
+            ],
+            context: harmonyContext)
+
+        #expect(roles(normalized) == ["system", "user", "assistant", "tool"])
+        let normalizedCalls = try #require(normalized[2]["tool_calls"] as? [any Sendable])
+        let normalizedCall = try #require(
+            normalizedCalls.first as? [String: any Sendable])
+        let normalizedFunction = try #require(
+            normalizedCall["function"] as? [String: any Sendable])
+        #expect(normalizedCall["id"] as? String == "call-1")
+        #expect(normalizedFunction["name"] as? String == "lookup")
+        #expect(normalizedFunction["arguments"] as? [String: any Sendable] != nil)
+        #expect(normalized[3]["tool_call_id"] as? String == "call-1")
+        #expect(normalized[3]["content"] as? String == "result")
+    }
+
+    @Test("split tool calls and results require unambiguous call IDs")
+    func rejectsAmbiguousSplitToolCallIDs() {
+        let toolCalls: [any Sendable] = [
+            [
+                "id": "call-1",
+                "function": ["name": "first"] as [String: any Sendable],
+            ] as [String: any Sendable],
+            [
+                "id": "call-2",
+                "function": ["name": "second"] as [String: any Sendable],
+            ] as [String: any Sendable],
+        ]
+        let assistant: [String: any Sendable] = [
+            "role": "assistant",
+            "content": "",
+            "tool_calls": toolCalls,
+        ]
+        let lateSystem = message("system", "use trusted sources")
+
+        #expect(throws: MultiModelBatchSchedulerEngineError.invalidToolPayload(
+            "tool result following split tool_calls requires a non-empty tool_call_id"
+        )) {
+            try ChatTemplateFixes.normalizeMessages(
+                [
+                    assistant,
+                    lateSystem,
+                    ["role": "tool", "content": "missing id"],
+                ],
+                context: harmonyContext)
+        }
+
+        #expect(throws: MultiModelBatchSchedulerEngineError.invalidToolPayload(
+            "duplicate tool result for tool_call_id call-1"
+        )) {
+            try ChatTemplateFixes.normalizeMessages(
+                [
+                    assistant,
+                    lateSystem,
+                    ["role": "tool", "tool_call_id": "call-1", "content": "first"],
+                    ["role": "tool", "tool_call_id": "call-1", "content": "duplicate"],
+                ],
+                context: harmonyContext)
+        }
+
+        let duplicateCallIDs: [any Sendable] = [
+            [
+                "id": "call-1",
+                "function": ["name": "first"] as [String: any Sendable],
+            ] as [String: any Sendable],
+            [
+                "id": "call-1",
+                "function": ["name": "second"] as [String: any Sendable],
+            ] as [String: any Sendable],
+        ]
+        let duplicateCallAssistant: [String: any Sendable] = [
+            "role": "assistant",
+            "content": "",
+            "tool_calls": duplicateCallIDs,
+        ]
+        #expect(throws: MultiModelBatchSchedulerEngineError.invalidToolPayload(
+            "duplicate assistant tool_call id call-1"
+        )) {
+            try ChatTemplateFixes.normalizeMessages(
+                [
+                    duplicateCallAssistant,
+                    lateSystem,
+                    ["role": "tool", "tool_call_id": "call-1", "content": "result"],
+                ],
+                context: harmonyContext)
+        }
+    }
+
+    @Test("other model families retain their original system-message ordering")
+    func leavesOtherFamiliesUnchanged() throws {
+        let normalized = try ChatTemplateFixes.normalizeMessages(
+            [
+                message("user", "question"),
+                message("system", "late policy"),
+            ],
+            context: .init(modelId: "llama-3.3", modelType: "llama"))
+
+        #expect(roles(normalized) == ["user", "system"])
+    }
+}

--- a/provider-swift/Tests/ProviderCoreTests/MultiModelBatchSchedulerEngineTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/MultiModelBatchSchedulerEngineTests.swift
@@ -221,6 +221,32 @@ func templateContextComposesReasoningControls() {
     #expect(context?["reasoning_effort"] as? String == "high")
 }
 
+@Test("GPT-OSS high reasoning effort is downgraded to medium")
+func templateContextDowngradesGPTOSSHighReasoningEffort() {
+    let request = OpenAIChatCompletionRequest(
+        model: "openai/gpt-oss-20b",
+        messages: [.init(role: .user, content: .text("hi"))])
+
+    let high = MultiModelBatchSchedulerEngine.templateAdditionalContext(
+        for: request, reasoningEffort: "high")
+    let medium = MultiModelBatchSchedulerEngine.templateAdditionalContext(
+        for: request, reasoningEffort: "medium")
+    let low = MultiModelBatchSchedulerEngine.templateAdditionalContext(
+        for: request, reasoningEffort: "low")
+    let opaqueAlias = OpenAIChatCompletionRequest(
+        model: "opaque-alias",
+        messages: [.init(role: .user, content: .text("hi"))])
+    let identifiedByModelType = MultiModelBatchSchedulerEngine.templateAdditionalContext(
+        for: opaqueAlias,
+        reasoningEffort: "high",
+        modelType: "gpt_oss")
+
+    #expect(high?["reasoning_effort"] as? String == "medium")
+    #expect(medium?["reasoning_effort"] as? String == "medium")
+    #expect(low?["reasoning_effort"] as? String == "low")
+    #expect(identifiedByModelType?["reasoning_effort"] as? String == "medium")
+}
+
 // MARK: - Engine error mapping (P2 #6)
 //
 // Pins the `MultiModelBatchSchedulerEngineError.fromSchedulerMessage`

--- a/provider-swift/Tests/ProviderCoreTests/ReasoningEffortLiveTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ReasoningEffortLiveTests.swift
@@ -24,15 +24,14 @@ private let gptOssModelID = "mlx-community/gpt-oss-20b-MXFP4-Q8"
 @Suite("reasoning_effort + reasoning_tokens (live gpt-oss)", .serialized)
 struct ReasoningEffortLiveTests {
 
-    /// Fix #1, decisive: the REAL gpt-oss harmony template reads the
-    /// `reasoning_effort` value we inject via `additionalContext` and
-    /// renders the matching `Reasoning: <effort>` system directive. This
-    /// is the exact API path `MultiModelBatchSchedulerEngine` uses.
+    /// Decisive: the REAL gpt-oss Harmony template receives the effective
+    /// effort selected by the production prompt policy. A requested `high`
+    /// must render exactly like `medium`; lower efforts remain distinct.
     @Test(
-        "harmony template renders the injected reasoning_effort",
+        "harmony template renders high reasoning effort as medium",
         .enabled(if: LiveInferenceFixtures.liveTestsEnabled)
     )
-    func templateHonorsReasoningEffort() async throws {
+    func templateDowngradesHighReasoningEffort() async throws {
         let loaded: LiveInferenceFixtures.LoadedBridge
         do {
             loaded = try await LiveInferenceFixtures.loadBridge(
@@ -58,9 +57,15 @@ struct ReasoningEffortLiveTests {
         let messages: [[String: any Sendable]] = [
             ["role": "user", "content": "What is 2+2?"]
         ]
+        let request = OpenAIChatCompletionRequest(
+            model: gptOssModelID,
+            messages: [.init(role: .user, content: .text("What is 2+2?"))])
 
         func renderedPrompt(effort: String?) throws -> String {
-            let ctx: [String: any Sendable]? = effort.map { ["reasoning_effort": $0] }
+            let ctx = MultiModelBatchSchedulerEngine.templateAdditionalContext(
+                for: request,
+                reasoningEffort: effort,
+                modelType: "gpt_oss")
             let tokens = try tokenizer.inner.applyChatTemplate(
                 messages: messages, tools: nil, additionalContext: ctx
             )
@@ -68,14 +73,16 @@ struct ReasoningEffortLiveTests {
         }
 
         let high = try renderedPrompt(effort: "high")
+        let medium = try renderedPrompt(effort: "medium")
         let low = try renderedPrompt(effort: "low")
         let defaulted = try renderedPrompt(effort: nil)
 
-        #expect(high.contains("Reasoning: high"))
+        #expect(high.contains("Reasoning: medium"))
+        #expect(!high.contains("Reasoning: high"))
+        #expect(high == medium)
         #expect(low.contains("Reasoning: low"))
         // No reasoning_effort supplied → template's built-in default.
         #expect(defaulted.contains("Reasoning: medium"))
-        // And the value actually changes the prompt.
         #expect(high != low)
     }
 
@@ -110,8 +117,8 @@ struct ReasoningEffortLiveTests {
             TokenizerHandle(ctx.tokenizer)
         }
 
-        // Wire the engine exactly as ProviderLoop does, with the
-        // reasoning_effort threaded through.
+        // Wire the engine exactly as ProviderLoop does. The requested high
+        // effort is normalized by the prompt policy before Harmony rendering.
         let engine = MultiModelBatchSchedulerEngine(
             registryProvider: { @Sendable in
                 [gptOssModelID: .init(


### PR DESCRIPTION
## Summary
- preserve all text-only system instructions by folding them into one leading Harmony instruction instead of dropping later system turns
- normalize GPT-OSS tool histories before generic validation and reject ambiguous call/result IDs without silently duplicating or losing results
- temporarily render GPT-OSS `reasoning_effort: high` as `medium` to avoid the observed 300-second upstream timeout; other models and effort values remain unchanged

## Before
```mermaid
flowchart LR
    A[OpenAI chat request] --> B[ProviderLoop decode]
    B --> C[Generic tool-history validation]
    C --> D[GPTOSSHarmonyTemplateFix]
    D --> E[Harmony Jinja template]
    E --> F[Only first system turn retained]
    B --> G[reasoning_effort high passed through]
    G --> E
    E --> H[High-effort runaway can exceed 300s]
```

## After
```mermaid
flowchart LR
    A[OpenAI chat request] --> B[ProviderLoop decode]
    B --> C[ProviderPromptContractPipeline]
    C --> D[LeadingSystemMessageNormalizer]
    D --> E[GPT-OSS tool-history normalization]
    E --> F[Generic validation]
    F --> G[Harmony Jinja template]
    G --> H[All text system instructions retained]
    C --> I{GPT-OSS and high?}
    I -->|yes| J[Render as medium]
    I -->|no| K[Preserve requested effort]
    J --> G
    K --> G
```

## Test plan
- [x] `swift test` — 2,160 tests passed
- [x] `DARKBLOOM_LIVE_MLX_TESTS=1 swift test --filter ReasoningEffortLiveTests` — real GPT-OSS template and generation passed
- [x] targeted GPT-OSS policy, Jinja rendering, multi-system, and tool-history regressions passed
- [x] repository pre-push checks passed

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/703"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790214004&installation_model_id=21733&pr_number=703&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F703&signature=e09d58cf67948610da2472d85a16629ec6adfcb7c56663fc87a46dae4adcae8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->