### PR TITLE
Add DogStatsD histograms for X-Timing latency decomposition

### DIFF
--- a/coordinator/api/route_outcome.go
+++ b/coordinator/api/route_outcome.go
@@ -150,6 +150,7 @@ func (s *Server) updateInferenceRouteOutcomeWithModel(requestID string, attempt 
 		return
 	}
 	s.emitInferenceErrorMetric(model, outcome)
+	s.emitTimingDecompositionMetric(model, outcome.FinalStatus, outcome)
 	s.submitTelemetry("updateInferenceRoute", func() {
 		if err := s.store.UpdateInferenceRouteOutcome(requestID, attempt, outcome); err != nil && s.logger != nil {
 			s.logger.Error("inference_routes outcome update failed",

--- a/coordinator/api/route_outcome_test.go
+++ b/coordinator/api/route_outcome_test.go
@@ -173,3 +173,65 @@ func TestSpeculativeLoserOutcome(t *testing.T) {
 		t.Fatal("speculative loser outcome must not set backup_won")
 	}
 }
+
+func TestTimingDecompositionMetricEmitsSegments(t *testing.T) {
+	collector := newUDPCollector(t)
+	defer collector.Close()
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	srv := NewServer(registry.New(logger), store.NewMemory(store.Config{}), ServerConfig{}, logger)
+	ddClient := newTestDD(t, collector)
+	defer ddClient.Close()
+	srv.SetDatadog(ddClient)
+
+	srv.updateInferenceRouteOutcomeWithModel("req-timing", 1, "gpt-oss-20b", &store.InferenceRouteOutcome{
+		FinalStatus:     "success",
+		ParseMs:         1.5,
+		ReserveMs:       2,
+		RouteMs:         3,
+		EncryptMs:       0, // not measured -> no sample
+		QueueWaitMs:     4,
+		DispatchMs:      5,
+		TotalDurationMs: 20,
+	})
+
+	_ = ddClient.Statsd.Flush()
+	packets := collector.drain()
+	for _, seg := range []string{"parse_ms", "reserve_ms", "route_ms", "queue_wait_ms", "dispatch_ms", "total_duration_ms"} {
+		metrics := findMetrics(packets, metricTimingSegmentPrefix+seg)
+		if len(metrics) == 0 {
+			t.Fatalf("missing %s%s metric; packets=%v", metricTimingSegmentPrefix, seg, packets)
+		}
+		if !hasMetric(metrics, "model:gpt-oss-20b") || !hasMetric(metrics, "final_status:success") {
+			t.Fatalf("missing tags on %s; packets=%v", seg, metrics)
+		}
+	}
+	if metrics := findMetrics(packets, metricTimingSegmentPrefix+"encrypt_ms"); len(metrics) != 0 {
+		t.Fatalf("unmeasured segment must not emit a zero sample; packets=%v", metrics)
+	}
+}
+
+func TestTimingDecompositionMetricSkipsCommitPrefill(t *testing.T) {
+	collector := newUDPCollector(t)
+	defer collector.Close()
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	srv := NewServer(registry.New(logger), store.NewMemory(store.Config{}), ServerConfig{}, logger)
+	ddClient := newTestDD(t, collector)
+	defer ddClient.Close()
+	srv.SetDatadog(ddClient)
+
+	// Commit-time pre-fill writes carry the decomposition but no FinalStatus;
+	// emitting there would double-count a successful request (once at commit,
+	// once at terminal).
+	srv.updateInferenceRouteOutcomeWithModel("req-prefill", 1, "gpt-oss-20b", &store.InferenceRouteOutcome{
+		ParseMs:         1.5,
+		TotalDurationMs: 20,
+	})
+
+	_ = ddClient.Statsd.Flush()
+	packets := collector.drain()
+	if metrics := findMetrics(packets, metricTimingSegmentPrefix); len(metrics) != 0 {
+		t.Fatalf("commit pre-fill must not emit timing metrics; packets=%v", metrics)
+	}
+}

--- a/coordinator/api/timing_metrics.go
+++ b/coordinator/api/timing_metrics.go
@@ -1,0 +1,59 @@
+package api
+
+import (
+	"github.com/eigeninference/d-inference/coordinator/store"
+)
+
+// Coordinator-side latency-decomposition histograms (DogStatsD).
+//
+// The ParseMs..DispatchMs segments were computed per request
+// (applyTimingDecomposition) and persisted on inference_routes, and surfaced
+// to the consumer as the X-Timing response header — but neither is groupable
+// on a live dashboard: the header is per-client, the column needs a Postgres
+// query. inference.ttft_ms / inference.decode_tps (kv_backend_metrics.go)
+// cover only the dispatch→first-content and decode windows, and only for
+// provider-completed requests.
+//
+// This emits each segment as d_inference.inference.timing.<segment>_ms at the
+// single store-submit funnel every terminal outcome flows through
+// (updateInferenceRouteOutcomeWithModel), taking the value from the SAME
+// outcome struct that is persisted — no new measurement, so the metric and
+// the inference_routes column cannot disagree. Commit-time pre-fill writes
+// (FinalStatus empty) are skipped so a successful request is counted once,
+// at its terminal outcome; terminal outcomes that never measured a segment
+// (zero) are skipped rather than recorded as zero samples, which would drag
+// percentiles toward the floor.
+//
+// final_status is a tag (bounded vocabulary: success, partial_success,
+// error, cancelled, timeout) so segment breakdowns for FAILED requests —
+// which the X-Timing header never surfaces — are separable from successes.
+const metricTimingSegmentPrefix = "inference.timing."
+
+// emitTimingDecompositionMetric records the per-request latency-decomposition
+// histograms. Guards run BEFORE any tag construction: an unconfigured
+// Datadog (every test, every dev coordinator) must not pay per-completion
+// allocations for metrics that go nowhere.
+func (s *Server) emitTimingDecompositionMetric(model, finalStatus string, outcome *store.InferenceRouteOutcome) {
+	if s == nil || s.dd == nil || outcome == nil || finalStatus == "" {
+		return
+	}
+	segments := [...]struct {
+		name  string
+		value float64
+	}{
+		{"parse_ms", outcome.ParseMs},
+		{"reserve_ms", outcome.ReserveMs},
+		{"route_ms", outcome.RouteMs},
+		{"encrypt_ms", outcome.EncryptMs},
+		{"queue_wait_ms", outcome.QueueWaitMs},
+		{"dispatch_ms", outcome.DispatchMs},
+		{"total_duration_ms", outcome.TotalDurationMs},
+	}
+	tags := []string{"model:" + model, "final_status:" + finalStatus}
+	for _, seg := range segments {
+		if !usableMetricSample(seg.value) {
+			continue
+		}
+		s.ddHistogram(metricTimingSegmentPrefix+seg.name, seg.value, tags)
+	}
+}


### PR DESCRIPTION
## Summary

The coordinator computes a full per-request latency decomposition (parse / reserve / route / encrypt / queue-wait / dispatch / total) via `applyTimingDecomposition`, persists it on `inference_routes`, and surfaces it per-client as the `X-Timing` response header — but none of those paths put the segments on a live, groupable dashboard. This PR emits each segment as a DogStatsD histogram at the single store-submit funnel every terminal outcome already flows through.

## What's added

- `d_inference.inference.timing.<segment>_ms` histograms — one per decomposition segment:
  `parse_ms`, `reserve_ms`, `route_ms`, `encrypt_ms`, `queue_wait_ms`, `dispatch_ms`, `total_duration_ms`
- Emitted in `updateInferenceRouteOutcomeWithModel` (route_outcome.go), the funnel all five terminal/commit outcome writers converge on
- **No new measurement**: values are read from the same `InferenceRouteOutcome` struct that is persisted to `inference_routes`, so the metric and the column cannot disagree (same doctrine as `inference.ttft_ms` / `inference.decode_tps` in `kv_backend_metrics.go`)
- **Terminal outcomes only**: commit-time pre-fill writes (`FinalStatus` empty) are skipped so a successful request is counted exactly once (once at commit + once at terminal would double-count)
- **Zero segments emit no sample** rather than a zero sample, which would drag percentiles toward the floor (mirrors `usableMetricSample` in `kv_backend_metrics.go`)
- Tags: `model:<model>` + `final_status:<status>` (bounded vocabulary: success / partial_success / error / cancelled / timeout) — so **failed-request segment breakdowns, which `X-Timing` never surfaces, become separable from successes** on dashboards
- The `s.dd == nil` guard runs before tag construction, so an unconfigured Datadog (every test, every dev coordinator) pays nothing per completion

## Not included (deliberately)

- **`provider_us` / TTFT**: already covered by `inference.ttft_ms` (kv_backend_metrics.go)
- **`media_fetch_us`**: already covered by `inference.media_fetch.duration_ms` (media_resolve.go)
- **`kv_backend` segmentation**: this change doesn't add the `kv_backend` tag to timing segments — those belong to the Gate G5 paged-KV rollout dashboards; adding it here would duplicate the attribution machinery for marginal gain. Can be a follow-up if a per-backend segment breakdown is wanted.

## Testing

- `TestTimingDecompositionMetricEmitsSegments` — verifies each segment histogram arrives with `model:` and `final_status:` tags via the UDP collector, and that an unmeasured (zero) segment emits no packet
- `TestTimingDecompositionMetricSkipsCommitPrefill` — verifies commit-time pre-fill writes (no `FinalStatus`) do not emit timing metrics (no double-count on success)
- Full pre-push checklist green: `go test -race ./api/... -count=1` (142s) ✓, `gofmt -l .` clean ✓, `golangci-lint run ./api/...` 0 issues ✓

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/723"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790239409&installation_model_id=21733&pr_number=723&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F723&signature=d18941afadbfda3b4ed3a5bef1940b8550d178095618d7c2c410012124656db7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->