### PR TITLE
Enable default-on deadline admission for v0.8.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,37 @@
 # Changelog
 
-## Release candidate v0.8.11 (not shipped; 2026-08-24)
+## Release candidate v0.8.12 (not shipped; 2026-08-25)
 
-> **Release status:** planning and integration only. No `v0.8.11` tag, signed
-> provider bundle, release registration, coordinator deployment, or fleet
-> rollout exists. The checked-in provider source and coordinator fallback
-> constants are `0.8.11`; the latest shipped provider version and tag remain
-> `v0.8.10`.
+- **Default atomic first-token deadline admission on** — Explicit typed TOML is
+  authoritative: `"off"` disables and `"enforce"` enforces regardless of the
+  legacy environment. An absent key inherits that environment, where only exact
+  lowercase `off` disables and every other value securely enforces. Optional
+  serialization preserves absence. Edit `provider.toml` and use ordinary
+  `darkbloom restart` for rollback, restore, or legacy-environment inheritance;
+  the linked report gives the exact settings.
+- **Keep the safety envelope unchanged** — Forecasting still requires a
+  propagated deadline, an initialized isolated cold-prefill EWMA, a text-only
+  request, phase-specific rates, and an authoritative capacity-guaranteed
+  scheduler projection. Multimodal requests remain outside forecast admission.
+- **Keep cap-0 a functional serving rollback** —
+  `DARKBLOOM_CBV2_MAX_PARTIAL_PREFILLS=0` still restores unlimited partial
+  prefill interleave. That posture cannot produce the proven bounded projection,
+  so it bypasses forecast admission and uses ordinary submission while hard
+  absolute expiry remains active. It does not rewrite the deadline-mode setting.
+- Provider and coordinator fallback version authorities move together to
+  `0.8.12`; there is no new protocol.
+
+Release rationale, limitations, compatibility, and rollout gates:
+[`docs/reports/2026-08-25-v0.8.12-prefill-deadline-admission.md`](docs/reports/2026-08-25-v0.8.12-prefill-deadline-admission.md).
+
+## v0.8.11 (shipped; 2026-08-24)
+
+> **Post-publication status (2026-08-25):** `v0.8.11` was tagged, published, and
+> registered as the active provider release. The candidate notes below are
+> retained as the pre-publication decision record; their blocker/no-shipment
+> language describes the state when they were written. The shipped resolver
+> still defaulted atomic deadline admission to `off`; v0.8.12 is the activation
+> change.
 
 ### Candidate integration status
 
@@ -93,8 +118,8 @@
 
 ---
 
-The entries below are shipped releases. The latest shipped provider release at
-the time this candidate was recorded is `v0.8.10`.
+The entries below are earlier shipped releases. At the time the v0.8.11
+candidate notes above were recorded, the latest shipped provider was `v0.8.10`.
 
 ## v0.8.10 (2026-08-21)
 

--- a/coordinator/api/server.go
+++ b/coordinator/api/server.go
@@ -151,7 +151,7 @@ func keyLimitResetFromContext(ctx context.Context) string {
 // the provider's EngineV2Factory.prepareProductionBackend for the argument).
 // Keep this fallback in sync with ProviderCore.version so dev/in-memory
 // coordinators advertise the same floor as the Swift binary they expect.
-var LatestProviderVersion = "0.8.11"
+var LatestProviderVersion = "0.8.12"
 
 // minProviderVersionForDesiredModels is the first provider version whose Swift
 // runtime understands the desired_models message. The coordinator must NOT send

--- a/docs/reports/2026-08-25-v0.8.12-prefill-deadline-admission.md
+++ b/docs/reports/2026-08-25-v0.8.12-prefill-deadline-admission.md
@@ -1,0 +1,280 @@
+# v0.8.12 Default-On Prefill Deadline Admission
+
+Date: 2026-08-25
+Branch: `release/v0.8.12-deadline-admission`
+Status: implementation candidate; no tag, publication, deployment, or fleet
+mutation was performed by this change.
+
+## Decision
+
+v0.8.12 makes provider-side atomic first-token deadline admission the default
+for every request that satisfies the existing eligibility and proof
+requirements.
+
+Typed config is source-aware and authoritative when present:
+
+- explicit `[backend] prefill_deadline_mode = "off"` resolves `off`;
+- explicit `[backend] prefill_deadline_mode = "enforce"` resolves `enforce`;
+- an absent key inherits the legacy environment control, where only exact
+  lowercase `DARKBLOOM_PREFILL_DEADLINE_MODE=off` disables;
+- absent config plus missing, `enforce`, malformed, or empty environment
+  securely resolves `enforce`.
+
+Production config loading rejects an unknown typed value. The optional field
+preserves absence through TOML serialization, so merely reading and writing an
+existing config does not materialize an explicit policy.
+
+Effective forecast admission also requires the proven scheduler posture:
+`maxConcurrentPartialPrefills == 1`. Exact
+`DARKBLOOM_CBV2_MAX_PARTIAL_PREFILLS=0` restores unlimited partial-prefill
+interleave and therefore bypasses the bounded atomic forecast API. It leaves
+the resolved deadline mode unchanged, but requests use ordinary submission
+because unlimited interleave is outside the projection proof. Hard absolute
+expiry remains active.
+
+## Before
+
+```mermaid
+flowchart LR
+  subgraph BeforeBehavior["Behavior — v0.8.11"]
+    B0["No TOML deadline setting"] --> B1{"Environment is exact enforce?"}
+    B1 -->|yes| B2["Mode: enforce"]
+    B1 -->|"no: missing, off, or unknown"| B3["Mode: off"]
+    B2 --> B4{"Partial-prefill posture"}
+    B4 -->|"cap 1"| B5["Atomic forecast for otherwise eligible requests"]
+    B4 -->|"cap 0 / unlimited"| B6["Bridge still invokes atomic admission"]
+    B6 --> B9["SchedulerV2 projection returns unbounded because cap 1 is required"]
+    B9 --> B10["EngineLoop rejects deadline_unreachable"]
+    B3 --> B7["Ordinary submission"]
+    B5 --> B8["Hard absolute expiry remains active"]
+    B7 --> B8
+  end
+  subgraph BeforeCode["Code — v0.8.11"]
+    C1["ProcessInfo environment"] --> C2["PrefillDeadlineMode.resolve(environment:)"]
+    C2 --> C3["EngineV2Factory.makeBridge"]
+    C3 --> C6["EngineV2Bridge admission guard had no cap check"]
+    C6 --> C7["Atomic admission calls SchedulerV2 projection"]
+    C4["maxConcurrentPartialPrefills"] --> C7
+    C7 -->|"cap 1: bounded result"| C8["Admission can proceed"]
+    C7 -->|"cap 0: unbounded result"| C9["EngineLoop returns deadline_unreachable"]
+  end
+```
+
+## After
+
+```mermaid
+flowchart LR
+  subgraph AfterBehavior["Behavior — v0.8.12"]
+    A0{"TOML prefill_deadline_mode"}
+    A0 -->|"explicit off"| A1["Mode: off"]
+    A0 -->|"explicit enforce"| A2["Mode: enforce"]
+    A0 -->|absent| A3{"Legacy environment exact off?"}
+    A3 -->|yes| A1
+    A3 -->|"no: missing, enforce, malformed, or empty"| A2
+    A1 --> A4["Ordinary submission"]
+    A2 --> A5{"Partial-prefill posture"}
+    A5 -->|"cap 1"| A6["Atomic forecast for otherwise eligible requests"]
+    A5 -->|"cap 0 / unlimited"| A7["Bypass forecast; ordinary submission"]
+    A4 --> A8["Hard absolute expiry remains active"]
+    A6 --> A8
+    A7 --> A8
+  end
+  subgraph AfterCode["Code — v0.8.12"]
+    D1["BackendSettings.prefillDeadlineMode?"] --> D2["Absent stays nil and is omitted on serialization"]
+    D1 --> D3["PrefillDeadlineMode.resolve(configured:environment:)"]
+    D4["Legacy environment"] --> D3
+    D3 --> D5["EngineV2Factory.makeBridge resolved mode"]
+    D3 --> D6["EngineV2SlotFactory diagnostic"]
+    D7["maxConcurrentPartialPrefills"] --> D8["prefillDeadlineProjectionEnabled"]
+    D5 --> D9["EngineV2Bridge admission guard"]
+    D8 --> D9
+  end
+```
+
+## Why activation helps
+
+The provider cannot recover time already consumed by a queue it knows cannot
+meet the caller's first-content deadline. Atomic admission projects work
+through the candidate request's first token while holding the authoritative
+engine queue state. If that work cannot fit in the remaining budget, the
+provider returns typed `deadline_unreachable` capacity failure before the
+request enters a GPU prompt step. The coordinator can then try another
+eligible provider while budget remains; if no provider can serve, it returns
+the existing bounded retryable capacity response.
+
+This does **not** make prefill faster. It avoids spending scarce deadline and
+GPU capacity on work whose first token cannot arrive in time.
+
+## Evidence motivating the change
+
+The historical
+[`2026-08-24-qwen-openrouter-timeout-fix-and-release.md`](2026-08-24-qwen-openrouter-timeout-fix-and-release.md)
+recorded the evidence available before v0.8.11:
+
+- PR-reported production symptoms were approximately 10–11% Qwen OpenRouter
+  downtime and approximately 11,000 `client_gone` rows in 24 hours aligned with
+  the external first-content deadline.
+- An M4 Max Qwen run measured one 8K prefill at about 5.35 seconds and four
+  fairly interleaved 8K prefills at about 24.98 seconds each.
+- A deterministic scheduler simulation at the measured rate produced a
+  first-token staircase under serialized prefill and showed that rejecting the
+  fourth unreachable row would let the coordinator redispatch it instead of
+  waiting locally for timeout.
+
+The production counts were not re-queried for this patch, and the scheduler
+result is simulation rather than a signed candidate A/B. They establish the
+failure mechanism and motivation, not v0.8.12 rollout success. Default-on
+canary evidence remains a release gate.
+
+The v0.8.11 report intentionally remains a historical pre-release snapshot. It
+correctly says its inspected resolver defaulted admission to `off`; this
+v0.8.12 report is the activation addendum. Release prose is not evidence that
+the v0.8.11 runtime default was enabled.
+
+## Eligibility, bootstrap, and proof boundaries
+
+The mode flip does not broaden admission. The bridge constructs an atomic
+deadline policy only when all of the following are true:
+
+1. The coordinator propagated a positive remaining first-content budget and
+   the provider converted it once to an absolute monotonic deadline.
+2. The bridge has initialized its queue-excluded isolated cold-prefill EWMA.
+3. The request is text-only; multimodal requests remain excluded because token
+   count cannot safely price vision-tower work.
+4. The conservative prefill rate is finite and positive. It remains the
+   isolated EWMA with the existing fixed haircut; no static or registration
+   fallback rate is invented.
+5. Production scheduler configuration serializes partial prefill with cap `1`.
+   Cap `0`/unlimited and positive caps above `1` bypass forecast admission
+   rather than invoking a projection that cannot prove that posture.
+
+Bootstrap is deliberately fail-open at the forecast layer. A fresh model slot
+has no isolated prefill EWMA, so requests use ordinary submission until a
+successful cold, isolated, non-overlapped prefill produces a valid sample.
+Cache hits, failed requests, and work overlapping another prefill or decode do
+not initialize that scheduler rate. Absolute pre-submit expiry checks remain
+active whenever a deadline was propagated, including during bootstrap and when
+forecast mode is `off`.
+
+Once the bridge supplies a policy, the engine owns the proof:
+
+- prefix adoption, enqueue, the scheduler snapshot, projection, capacity
+  guarantee, verdict, and activation execute on the serialized engine queue;
+- the projection follows authoritative scheduler order through the target's
+  first-token step and charges already launched work without elapsed credit;
+- every projected phase needs its own conservative rate. Mixed prefill/decode
+  work with no initialized decode rate is unbounded; decode is never priced at
+  prefill throughput;
+- projected KV operations must be guaranteed by the authoritative capacity
+  ledger;
+- once the cap-1-compatible atomic path is entered, paused, unsupported
+  scheduler state, complexity-limit, or otherwise unprovable projections are
+  unbounded and fail closed as `deadline_unreachable`;
+- a rejected request is removed before any GPU forward and releases its
+  pre-submit resources.
+
+Atomic projection currently vouches only for serialized partial prefill
+(`maxConcurrentPartialPrefills == 1`). Cap `0` does not manufacture a proof or
+change `PrefillDeadlineMode`; production detects that configured posture before
+submission and skips forecast admission. This distinction preserves both
+requirements: cap `1` still fails closed for genuinely unbounded engine state,
+while cap `0` remains a functional serving rollback.
+
+## Mixed-version behavior
+
+v0.8.12 adds no protocol field or message:
+
+- v0.8.10-or-earlier coordinator + v0.8.12 provider: no propagated deadline
+  means no atomic forecast; ordinary compatibility behavior remains.
+- Deadline-aware coordinator + v0.8.11 provider: the older provider retains
+  its shipped mode resolution; the coordinator's absolute timeout,
+  cancellation, and pre-content retry remain authoritative.
+- Deadline-aware coordinator + v0.8.12 provider: eligible text requests use
+  atomic admission by default when partial-prefill cap `1` is configured.
+- Any coordinator + v0.8.12 provider with exact mode `off`: atomic forecast is
+  disabled immediately, while propagated absolute-expiry checks remain intact.
+- Any coordinator + v0.8.12 provider with cap `0`/unlimited: deadline mode can
+  still resolve to `enforce`, but forecast admission is bypassed because that
+  scheduler posture is outside the bounded proof. Ordinary serving and hard
+  absolute expiry remain active.
+
+No provider-version floor is introduced for this activation.
+
+## Release integrity and rollout gates
+
+Source authorities move together to `0.8.12`:
+
+- `ProviderCore.version`;
+- coordinator `LatestProviderVersion`.
+
+The release-integrity script and coordinator cross-language version test must
+both pass. Before publication:
+
+1. Run focused config parsing/serialization, resolver precedence,
+   production-factory wiring, atomic admission, FCFS cap-0, and
+   version-integrity tests.
+2. Run the complete provider and coordinator suites and production builds.
+3. Exercise old/new and new/old coordinator/provider combinations.
+4. On an owned Apple Silicon canary, prove default mode emits an early typed
+   refusal for an unreachable text request, starts no GPU prompt step, releases
+   reservations, and lets a coordinator with an eligible peer redispatch.
+5. Verify missing deadline, fresh-slot bootstrap, cache-hit-only bootstrap,
+   multimodal, missing decode-rate, unprovable capacity, and cap-0 postures
+   retain the documented behavior.
+6. On a canary, set `[backend] prefill_deadline_mode = "off"`, run ordinary
+   `darkbloom restart`, and confirm forecast admission is bypassed while
+   absolute expiry/coordinator cancellation remain active. Then set
+   `"enforce"`, restart normally, and confirm enforcement returns.
+7. Hold the dev canary and compare final success, bounded 429, 5xx,
+   `client_gone`, orphan-work, settlement, and provider-restart rates before
+   production publication.
+
+Rollback of release discovery or already installed binaries remains governed
+by the normal release runbook. The durable behavioral rollback is:
+
+```toml
+[backend]
+prefill_deadline_mode = "off"
+```
+
+Edit the active config (`~/.config/darkbloom/provider.toml` unless the service
+was installed with a custom `--config` path), save it, then run:
+
+```bash
+darkbloom restart
+```
+
+The provider rereads its config on ordinary restart.
+
+### Restore or inherit
+
+To force enforcement, including when an older installation persists legacy
+environment `off`, set:
+
+```toml
+[backend]
+prefill_deadline_mode = "enforce"
+```
+
+To inherit the legacy environment control again, remove
+`prefill_deadline_mode`. With no environment exact `off`, absence securely
+enforces. After any of these edits, run ordinary:
+
+```bash
+darkbloom restart
+```
+
+This rollback does not touch `DARKBLOOM_CBV2_MAX_PARTIAL_PREFILLS` or any other
+control. If cap `0` remains configured, deadline mode can resolve to `enforce`
+while forecast admission remains bypassed until cap `1` is restored.
+
+## Non-goals and known gaps
+
+- No claim that prefill throughput or first-token compute latency improves.
+- No multimodal forecast admission and no fallback service rates.
+- No change to coordinator deadlines, billing, routing prices, model weights,
+  prefix-cache policy, or wire protocol.
+- No provider-local post-submit deadline watchdog; coordinator cancellation
+  remains authoritative after submission.
+- No signed v0.8.12 artifact, live default-on production A/B, mixed-version
+  system run, or rollout observation is included in this source change.

--- a/docs/reports/2026-08-25-v0.8.12-prefill-deadline-admission.md
+++ b/docs/reports/2026-08-25-v0.8.12-prefill-deadline-admission.md
@@ -32,6 +32,123 @@ the resolved deadline mode unchanged, but requests use ordinary submission
 because unlimited interleave is outside the projection proof. Hard absolute
 expiry remains active.
 
+## Canonical implementation
+
+- **Typed policy and precedence.**
+  [`BackendSettings.prefillDeadlineMode`](../../provider-swift/Sources/ProviderCore/Config/ProviderConfig.swift#L171-L175)
+  is optional; its
+  [`CodingKeys` and decoder](../../provider-swift/Sources/ProviderCore/Config/ProviderConfig.swift#L243-L305)
+  preserve an absent key as `nil`, and
+  [`ConfigManager.load(from:)`](../../provider-swift/Sources/ProviderCore/Config/ProviderConfig.swift#L535-L550)
+  uses strict parsing; the
+  [`loadRuntimeSnapshot` production path](../../provider-swift/Sources/darkbloom/Darkbloom.swift#L113-L136)
+  selects it for every existing runtime config, while
+  [`ConfigManager.parseValidating` / `serialize`](../../provider-swift/Sources/ProviderCore/Config/ProviderConfig.swift#L618-L642)
+  provide the production rejection and TOML round trip.
+  [`PrefillDeadlineMode.resolve(configured:environment:)`](../../provider-swift/Sources/ProviderCore/Inference/PrefillDeadlineMode.swift#L3-L23)
+  implements configured-value authority and exact-lowercase environment
+  fallback. The omission, round-trip, invalid-value, and exhaustive precedence
+  contracts are pinned by
+  [`ConfigTests`](../../provider-swift/Tests/ProviderCoreTests/ConfigTests.swift#L43-L87),
+  [`ConfigValidationTests`](../../provider-swift/Tests/ProviderCoreTests/ConfigValidationTests.swift#L97-L108),
+  and
+  [`deadlineModeUsesSourceAwarePrecedence`](../../provider-swift/Tests/ProviderCoreTests/EngineV2ProductionWiringTests.swift#L2192-L2221).
+- **Production cap and mode wiring.**
+  Coordinator-connected serving hands
+  `loopConfig.config.backend.prefillDeadlineMode` through
+  [`ProviderLoop.makeEngineV2BundleForSlot`](../../provider-swift/Sources/ProviderCore/ProviderLoop+EngineV2.swift#L524-L605).
+  Local mode passes the same typed value through the
+  [`Start` CLI handoff](../../provider-swift/Sources/darkbloom/StartCommand+Modes.swift#L84-L104)
+  into
+  [`StandaloneServerConfig`](../../provider-swift/Sources/ProviderCore/Server/StandaloneServer.swift#L78-L114);
+  [`StandaloneServer.resliceAndBuildBundle`](../../provider-swift/Sources/ProviderCore/Server/StandaloneServer.swift#L735-L865)
+  then supplies it to the shared slot factory.
+  [`EngineV2Factory.maxConcurrentPartialPrefills` and `prefillDeadlineProjectionSupported`](../../provider-swift/Sources/ProviderCore/Inference/EngineV2Factory+Production.swift#L120-L154)
+  resolve cap `1` versus unlimited/unsupported postures, while
+  [`productionSchedulerConfig`](../../provider-swift/Sources/ProviderCore/Inference/EngineV2Factory+Production.swift#L172-L186)
+  installs that cap in the scheduler.
+  [`EngineV2Factory.makeBridge`](../../provider-swift/Sources/ProviderCore/Inference/EngineV2Config.swift#L150-L190)
+  resolves the typed mode and supplies the projection-capability guard;
+  [`EngineV2SlotFactory.makeProductionBundle`](../../provider-swift/Sources/ProviderCore/Inference/EngineV2SlotFactory.swift#L262-L288)
+  accepts the optional mode and runtime environment, then
+  [reports unsupported postures and constructs the bridge](../../provider-swift/Sources/ProviderCore/Inference/EngineV2SlotFactory.swift#L616-L654)
+  from those same inputs. The focused suite separately executes
+  [resolver precedence](../../provider-swift/Tests/ProviderCoreTests/EngineV2ProductionWiringTests.swift#L2192-L2221),
+  [direct `makeBridge` mode/cap wiring](../../provider-swift/Tests/ProviderCoreTests/EngineV2ProductionWiringTests.swift#L2223-L2280),
+  [cap parsing and scheduler configuration](../../provider-swift/Tests/ProviderCoreTests/EngineV2ProductionWiringTests.swift#L2282-L2333),
+  and the
+  [slot-factory bypass diagnostic](../../provider-swift/Tests/ProviderCoreTests/EngineV2ProductionWiringTests.swift#L2335-L2365);
+  those tests do not substitute for the wrapper handoffs cited above.
+- **Bridge eligibility and calibration.**
+  [`EngineV2Bridge.firstTokenDeadlineAdmission`](../../provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge.swift#L1037-L1070)
+  requires resolved `enforce`, the cap-compatible guard, a text-only request,
+  the anchored deadline, an initialized isolated prefill EWMA, and a finite
+  positive haircutted rate; decode uses its own independently observed rate.
+  Isolation is decided at the
+  [`engine-submit boundary`](../../provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge.swift#L819-L824)
+  and revoked on overlap by
+  [`isIsolatedPrefillSubmitBoundary` / `disqualifyOverlappedPrefillSamples`](../../provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge.swift#L1072-L1093);
+  [`finishAndEmit`](../../provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge.swift#L1666-L1722)
+  marks only natural `.stop` / `.length` terminals successful, and
+  [`recordFinish`](../../provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge.swift#L1785-L1829)
+  invokes
+  [`recordPrefillSample`](../../provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge.swift#L1848-L1905)
+  only behind that success guard; the sampler then admits only valid cold
+  prefills. The ordinary-submit bootstrap, mode-off, missing-deadline, and
+  multimodal cases are pinned by
+  [`failOpenCasesUseOrdinarySubmit`](../../provider-swift/Tests/ProviderCoreTests/EngineV2PrefillSamplingTests.swift#L768-L838).
+- **Atomic scheduler verdict.**
+  [`SchedulerV2.firstTokenWorkProjection`](https://github.com/Layr-Labs/mlx-swift-lm/blob/52c2396d00f28533fbbbc2261d749949d10590df/Libraries/MLXLMCommon/ContinuousBatchingV2/FirstTokenDeadlineAdmissionV2.swift#L200-L225)
+  requires cap `1`; it charges launched work without elapsed credit and follows
+  authoritative running-then-waiting order through the target's complete
+  first-token step
+  ([in-flight charge](https://github.com/Layr-Labs/mlx-swift-lm/blob/52c2396d00f28533fbbbc2261d749949d10590df/Libraries/MLXLMCommon/ContinuousBatchingV2/FirstTokenDeadlineAdmissionV2.swift#L568-L630),
+  [ordered projection](https://github.com/Layr-Labs/mlx-swift-lm/blob/52c2396d00f28533fbbbc2261d749949d10590df/Libraries/MLXLMCommon/ContinuousBatchingV2/FirstTokenDeadlineAdmissionV2.swift#L757-L948)).
+  [`EngineLoopV2.enqueueForFirstTokenDeadline`](https://github.com/Layr-Labs/mlx-swift-lm/blob/52c2396d00f28533fbbbc2261d749949d10590df/Libraries/MLXLMCommon/ContinuousBatchingV2/EngineLoopV2.swift#L1279-L1478)
+  serializes enqueue, prefix preview, projection, deadline verdict, rejection,
+  and activation; its
+  [`firstTokenProjectedWork`](https://github.com/Layr-Labs/mlx-swift-lm/blob/52c2396d00f28533fbbbc2261d749949d10590df/Libraries/MLXLMCommon/ContinuousBatchingV2/EngineLoopV2.swift#L1521-L1585)
+  requires capacity-ledger guarantees and a valid rate for each projected
+  phase. Unbounded or over-budget work returns typed
+  `deadlineUnreachable` and is
+  [discarded before GPU work](https://github.com/Layr-Labs/mlx-swift-lm/blob/52c2396d00f28533fbbbc2261d749949d10590df/Libraries/MLXLMCommon/ContinuousBatchingV2/EngineLoopV2.swift#L1589-L1601).
+  Deterministic engine tests pin
+  [no-forward rejection](https://github.com/Layr-Labs/mlx-swift-lm/blob/52c2396d00f28533fbbbc2261d749949d10590df/Tests/MLXLMTests/CBv2FirstTokenDeadlineAdmissionTests.swift#L514-L542),
+  [absolute queue-wait accounting](https://github.com/Layr-Labs/mlx-swift-lm/blob/52c2396d00f28533fbbbc2261d749949d10590df/Tests/MLXLMTests/CBv2FirstTokenDeadlineAdmissionTests.swift#L643-L681),
+  and
+  [separate mixed-phase rates](https://github.com/Layr-Labs/mlx-swift-lm/blob/52c2396d00f28533fbbbc2261d749949d10590df/Tests/MLXLMTests/CBv2FirstTokenDeadlineAdmissionTests.swift#L793-L874).
+- **Coordinator failover.**
+  `deadline_unreachable` is explicitly
+  [provider-health neutral](../../coordinator/api/route_outcome.go#L93-L104).
+  The pre-content error path
+  [excludes the failed provider and retries](../../coordinator/api/dispatch.go#L1833-L1863),
+  while
+  [`noteProviderError`](../../coordinator/api/dispatch.go#L1511-L1549)
+  withholds neutral refusals from breakers and capacity trackers.
+  [`shouldStopFailover`](../../coordinator/api/dispatch.go#L1571-L1663)
+  keeps trying untried providers without consuming the generic capacity retry
+  cap. Each attempt refreshes the same absolute clock through
+  [`PendingRequest.RefreshFirstContentBudget`](../../coordinator/registry/registry.go#L499-L520),
+  and the provider writer
+  [recomputes the remaining wire budget at dequeue](../../coordinator/api/provider_wire.go#L80-L107).
+  Candidate exhaustion resolves to one retryable 429 with `Retry-After` in the
+  [`exhausted` terminal](../../coordinator/api/dispatch.go#L3148-L3256).
+  Integration tests pin
+  [distinct-provider retry with decreasing budgets](../../coordinator/api/deadline_unreachable_integration_test.go#L155-L236),
+  [health neutrality](../../coordinator/api/dispatch_nonfault_breaker_test.go#L130-L153),
+  and
+  [single-429 exhaustion](../../coordinator/api/deadline_unreachable_integration_test.go#L293-L384).
+- **Hard expiry and cap-zero rollback.**
+  [`FirstContentDeadline`](../../provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClientTypes.swift#L10-L48)
+  anchors the relative wire budget once to a monotonic instant.
+  [`EngineV2Bridge.checkFirstContentDeadline`](../../provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge.swift#L1157-L1191)
+  remains independent of forecast mode and is called at the final
+  [post-suspension pre-submit boundary](../../provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge.swift#L808-L817).
+  Tests prove cap `0` uses ordinary submission while preserving expiry
+  ([`capZeroUsesOrdinarySubmission`](../../provider-swift/Tests/ProviderCoreTests/EngineV2PrefillSamplingTests.swift#L663-L697))
+  and that every forecast fail-open branch still rejects expired work
+  ([`expiredRequestsNeverFailOpen`](../../provider-swift/Tests/ProviderCoreTests/EngineV2PrefillSamplingTests.swift#L840-L885)).
+
 ## Before
 
 ```mermaid
@@ -204,11 +321,15 @@ No provider-version floor is introduced for this activation.
 
 Source authorities move together to `0.8.12`:
 
-- `ProviderCore.version`;
-- coordinator `LatestProviderVersion`.
+- [`ProviderCore.version`](../../provider-swift/Sources/ProviderCore/ProviderCore.swift#L243-L251);
+- coordinator
+  [`LatestProviderVersion`](../../coordinator/api/server.go#L142-L154).
 
-The release-integrity script and coordinator cross-language version test must
-both pass. Before publication:
+The
+[release-integrity script](../../scripts/check-release-version.sh#L20-L53)
+and coordinator
+[cross-language version test](../../coordinator/api/provider_version_sync_test.go#L23-L61)
+must both pass. Before publication:
 
 1. Run focused config parsing/serialization, resolver precedence,
    production-factory wiring, atomic admission, FCFS cap-0, and

--- a/provider-swift/Sources/ProviderCore/Config/ProviderConfig.swift
+++ b/provider-swift/Sources/ProviderCore/Config/ProviderConfig.swift
@@ -168,6 +168,11 @@ public struct BackendSettings: Sendable, Equatable, Codable {
     /// resolution/load is fail-open: any failure means plain decode, never a
     /// slot failure. `DARKBLOOM_CBV2_MTP` remains the engine-side kill switch.
     public var mtp: Bool
+    /// Explicit provider-side atomic first-token deadline policy. Nil means the
+    /// key was absent, so runtime resolution inherits the legacy environment
+    /// control and otherwise securely enforces. Optional encoding preserves
+    /// that source distinction instead of materializing an explicit default.
+    public var prefillDeadlineMode: PrefillDeadlineMode?
     /// Optional local drafter directory override (`mtp_drafter_path` under
     /// `[backend]`) — the canary path: `config.json` + `*.safetensors`, no R2
     /// involved. Takes precedence over the `spec_dec` download when set. nil
@@ -213,6 +218,7 @@ public struct BackendSettings: Sendable, Equatable, Codable {
         startupSelftest: Bool = true,
         startupSelftestFailClosed: Bool = false,
         mtp: Bool = false,
+        prefillDeadlineMode: PrefillDeadlineMode? = nil,
         mtpDrafterPath: String? = nil
     ) {
         self.port = port
@@ -230,6 +236,7 @@ public struct BackendSettings: Sendable, Equatable, Codable {
         self.startupSelftest = startupSelftest
         self.startupSelftestFailClosed = startupSelftestFailClosed
         self.mtp = mtp
+        self.prefillDeadlineMode = prefillDeadlineMode
         self.mtpDrafterPath = mtpDrafterPath
     }
 
@@ -249,6 +256,7 @@ public struct BackendSettings: Sendable, Equatable, Codable {
         case startupSelftest = "startup_selftest"
         case startupSelftestFailClosed = "startup_selftest_fail_closed"
         case mtp
+        case prefillDeadlineMode = "prefill_deadline_mode"
         case mtpDrafterPath = "mtp_drafter_path"
     }
 
@@ -290,6 +298,10 @@ public struct BackendSettings: Sendable, Equatable, Codable {
         self.startupSelftestFailClosed =
             try container.decodeIfPresent(Bool.self, forKey: .startupSelftestFailClosed) ?? false
         self.mtp = try container.decodeIfPresent(Bool.self, forKey: .mtp) ?? false
+        self.prefillDeadlineMode =
+            try container.decodeIfPresent(
+                PrefillDeadlineMode.self,
+                forKey: .prefillDeadlineMode)
         self.mtpDrafterPath = try container.decodeIfPresent(String.self, forKey: .mtpDrafterPath)
         // Retired keys: presence-only scan so startup can WARN (values are
         // ignored; an old provider.toml must keep loading cleanly).

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge.swift
@@ -175,9 +175,15 @@ public actor EngineV2Bridge {
     let stopTokenIds: Set<Int>
     let defaultMaxTokens: Int
     let maxConcurrentRequests: Int
-    /// Release-candidate gate for atomic first-token deadline admission.
+    /// Operational control for atomic first-token deadline admission.
     /// Parsed once per bridge so runtime behavior cannot change mid-request.
     let prefillDeadlineMode: PrefillDeadlineMode
+    /// Whether the configured scheduler posture can produce the bounded,
+    /// authoritative first-token projection required by atomic admission.
+    /// Production enables this only for serialized partial prefill (cap 1).
+    /// Explicit cap 0/unlimited therefore keeps serving through ordinary
+    /// submission while the hard absolute-expiry checks remain authoritative.
+    let prefillDeadlineProjectionEnabled: Bool
     /// Per-token KV byte cost for bytes→tokens capacity derivation
     /// (0 = unknown; capacity then falls back to the engine's token counts).
     /// This is the resolved native serving rate. Contiguous GPT-OSS adds the
@@ -372,6 +378,7 @@ public actor EngineV2Bridge {
         defaultMaxTokens: Int = 4096,
         maxConcurrentRequests: Int = 4,
         prefillDeadlineMode: PrefillDeadlineMode = PrefillDeadlineMode.resolve(),
+        prefillDeadlineProjectionEnabled: Bool = true,
         kvBytesPerToken: Int = 0,
         fixedRequestBytes: Int = 0,
         auxiliaryBytesPerToken: Int = 0,
@@ -400,6 +407,7 @@ public actor EngineV2Bridge {
         self.defaultMaxTokens = defaultMaxTokens
         self.maxConcurrentRequests = maxConcurrentRequests
         self.prefillDeadlineMode = prefillDeadlineMode
+        self.prefillDeadlineProjectionEnabled = prefillDeadlineProjectionEnabled
         self.kvBytesPerToken = kvBytesPerToken
         self.fixedRequestBytes = max(0, fixedRequestBytes)
         self.auxiliaryBytesPerToken = max(0, auxiliaryBytesPerToken)
@@ -1035,6 +1043,7 @@ public actor EngineV2Bridge {
         isMultimodal: Bool
     ) -> CBv2FirstTokenDeadlineAdmission? {
         guard prefillDeadlineMode == .enforce,
+            prefillDeadlineProjectionEnabled,
             !isMultimodal,
             let deadline,
             isolatedPrefillEwmaInitialized

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Config.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Config.swift
@@ -154,6 +154,9 @@ public enum EngineV2Factory {
         extraEOSTokens: [String] = [],
         defaultMaxTokens: Int = 4096,
         maxConcurrentRequests: Int = 4,
+        prefillDeadlineMode: PrefillDeadlineMode? = nil,
+        runtimePolicyEnvironment: [String: String] =
+            ProcessInfo.processInfo.environment,
         kvBytesPerToken: Int = 0,
         auxiliaryBytesPerToken: Int = 0,
         auxiliaryTokenGranularity: Int = 1,
@@ -179,6 +182,12 @@ public enum EngineV2Factory {
                 extraEOSTokens: extraEOSTokens,
                 defaultMaxTokens: defaultMaxTokens,
                 maxConcurrentRequests: maxConcurrentRequests,
+                prefillDeadlineMode: PrefillDeadlineMode.resolve(
+                    configured: prefillDeadlineMode,
+                    environment: runtimePolicyEnvironment),
+                prefillDeadlineProjectionEnabled:
+                    prefillDeadlineProjectionSupported(
+                        environment: runtimePolicyEnvironment),
                 kvBytesPerToken: kvBytesPerToken,
                 fixedRequestBytes: build.fixedRequestBytes,
                 auxiliaryBytesPerToken: auxiliaryBytesPerToken,

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Factory+Production.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Factory+Production.swift
@@ -142,6 +142,17 @@ extension EngineV2Factory {
         return value
     }
 
+    /// Atomic first-token projection is proven only for serialized partial
+    /// prefill. Cap 0/unlimited is a serving rollback, so production must skip
+    /// the bounded forecast API rather than ask it to fail closed on an
+    /// unsupported scheduler posture. Positive caps above one are likewise
+    /// outside the current proof.
+    static func prefillDeadlineProjectionSupported(
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> Bool {
+        maxConcurrentPartialPrefills(environment: environment) == 1
+    }
+
     /// Resolve the solo-stripe setting: absent env -> the serving default;
     /// an explicit value above the plain chunk overrides; any other
     /// explicit value (`0`, garbage, <= plain chunk) DISARMS — the escape

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2SlotFactory.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2SlotFactory.swift
@@ -140,6 +140,17 @@ struct GemmaOptimizationReport: Sendable, Equatable {
 
 enum EngineV2SlotFactory {
 
+    static func shouldLogPrefillDeadlineProjectionBypass(
+        configuredMode: PrefillDeadlineMode?,
+        environment: [String: String]
+    ) -> Bool {
+        PrefillDeadlineMode.resolve(
+            configured: configuredMode,
+            environment: environment) == .enforce
+            && !EngineV2Factory.prefillDeadlineProjectionSupported(
+                environment: environment)
+    }
+
     /// Narrow assembly seams for production-order regression tests. Normal
     /// callers use the empty value and execute only concrete production code.
     struct AssemblyOverrides {
@@ -190,8 +201,9 @@ enum EngineV2SlotFactory {
     ///     their ledger).
     ///   - weightHash: the slot's verified weight hash binding for SSD
     ///     artifacts. Nil or blank disables reusable SSD caching.
-    ///   - environment: prefix-cache policy environment
-    ///     (`DARKBLOOM_PREFIX_CACHE*`); injectable for tests.
+    ///   - environment: runtime policy environment (including prefix-cache,
+    ///     MTP, KV-backend, and prefill-deadline controls); injectable for
+    ///     tests.
     ///   - emitTelemetry: injectable sink (tests); nil ⇒ shared client.
     ///   - makeEngineOverride: scripted engine builder for tests
     ///     ((modelId, engine capacity) — mirrors
@@ -213,6 +225,7 @@ enum EngineV2SlotFactory {
         kvBudget: GlobalKVCacheBudget?,
         kvBackendConfig: String = "auto",
         kvBackendConfigByModel: [String: String] = [:],
+        prefillDeadlineMode: PrefillDeadlineMode? = nil,
         weightHash: String? = nil,
         environment: [String: String] = ProcessInfo.processInfo.environment,
         emitTelemetry: (@Sendable (TelemetryEvent) -> Void)? = nil,
@@ -233,6 +246,7 @@ enum EngineV2SlotFactory {
             kvBudget: kvBudget,
             kvBackendConfig: kvBackendConfig,
             kvBackendConfigByModel: kvBackendConfigByModel,
+            prefillDeadlineMode: prefillDeadlineMode,
             weightHash: weightHash,
             specDecPreparation: SpecDecPreparation(
                 artifact: nil,
@@ -260,6 +274,7 @@ enum EngineV2SlotFactory {
         kvBudget: GlobalKVCacheBudget?,
         kvBackendConfig: String = "auto",
         kvBackendConfigByModel: [String: String] = [:],
+        prefillDeadlineMode: PrefillDeadlineMode? = nil,
         weightHash: String? = nil,
         specDecPreparation: SpecDecPreparation,
         preparedModel: EngineV2PreparedModel? = nil,
@@ -598,6 +613,20 @@ enum EngineV2SlotFactory {
             throw EngineV2ProductionError.noKVHeadroom
         }
 
+        let resolvedPartialPrefillCap =
+            EngineV2Factory.maxConcurrentPartialPrefills(
+                environment: environment)
+        if shouldLogPrefillDeadlineProjectionBypass(
+            configuredMode: prefillDeadlineMode,
+            environment: environment)
+        {
+            logInfo(
+                "engine_v2_prefill_deadline model_id=\(modelId) "
+                    + "effective=ordinary_submit "
+                    + "reason=partial_prefill_projection_unsupported "
+                    + "max_concurrent_partial_prefills="
+                    + (resolvedPartialPrefillCap.map(String.init) ?? "unlimited"))
+        }
 
         let bridge = try EngineV2Factory.makeBridge(
             modelId: modelId,
@@ -606,6 +635,8 @@ enum EngineV2SlotFactory {
             extraEOSTokens: snapshot.extraEOSTokens,
             defaultMaxTokens: sizing.defaultMaxTokens,
             maxConcurrentRequests: maxConcurrentRequests,
+            prefillDeadlineMode: prefillDeadlineMode,
+            runtimePolicyEnvironment: environment,
             kvBytesPerToken: processKVBytesPerToken,
             auxiliaryBytesPerToken: assistantStateBytesPerToken,
             auxiliaryTokenGranularity: assistantStateTokenGranularity,

--- a/provider-swift/Sources/ProviderCore/Inference/PrefillDeadlineMode.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/PrefillDeadlineMode.swift
@@ -2,19 +2,23 @@ import Foundation
 
 /// Controls provider-side first-token deadline admission.
 ///
-/// The release-candidate default is deliberately fail-open. Only the exact
-/// `enforce` value enables atomic engine admission; missing or unknown values
-/// preserve ordinary submission.
-public enum PrefillDeadlineMode: String, Sendable, Equatable {
+/// Explicit typed config is authoritative. Only an absent config value falls
+/// back to the legacy environment control, where exact lowercase `off`
+/// disables and every other value securely enforces. Effective forecast
+/// admission separately requires a projection-compatible scheduler posture.
+public enum PrefillDeadlineMode: String, Sendable, Equatable, Codable {
     public static let environmentKey = "DARKBLOOM_PREFILL_DEADLINE_MODE"
 
     case off
     case enforce
 
     public static func resolve(
+        configured: PrefillDeadlineMode? = nil,
         environment: [String: String] = ProcessInfo.processInfo.environment
     ) -> PrefillDeadlineMode {
-        guard let rawValue = environment[environmentKey] else { return .off }
-        return PrefillDeadlineMode(rawValue: rawValue) ?? .off
+        if let configured {
+            return configured
+        }
+        return environment[environmentKey] == off.rawValue ? .off : .enforce
     }
 }

--- a/provider-swift/Sources/ProviderCore/ProviderCore.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderCore.swift
@@ -243,5 +243,10 @@ public enum ProviderCore {
     // 0.8.11 conserves the first-content deadline end to end, rejects
     // unreachable work before the client clock expires, and defaults CBv2
     // partial-prefill scheduling to FCFS with an explicit cap-zero rollback.
-    public static let version = "0.8.11"
+    // 0.8.12 makes atomic first-token deadline admission the secure provider
+    // default for eligible text requests. Exact
+    // DARKBLOOM_PREFILL_DEADLINE_MODE=off is the direct forecast rollback;
+    // FCFS cap zero restores unlimited interleave and necessarily bypasses the
+    // bounded forecast while preserving hard absolute expiry.
+    public static let version = "0.8.12"
 }

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+EngineV2.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+EngineV2.swift
@@ -554,6 +554,8 @@ extension ProviderLoop {
                 extraEOSTokens: hooks.extraEOSTokens,
                 defaultMaxTokens: sizing.defaultMaxTokens,
                 maxConcurrentRequests: maxConcurrent,
+                prefillDeadlineMode:
+                    loopConfig.config.backend.prefillDeadlineMode,
                 kvBytesPerToken: sizing.fp16KVBytesPerToken,
                 kvBudget: kvBudget,
                 emitTelemetry: hooks.emitTelemetry,
@@ -592,6 +594,8 @@ extension ProviderLoop {
                 kvBudget: kvBudget,
                 kvBackendConfig: loopConfig.config.backend.engineV2KVBackend,
                 kvBackendConfigByModel: loopConfig.config.backend.engineV2KVBackendByModel,
+                prefillDeadlineMode:
+                    loopConfig.config.backend.prefillDeadlineMode,
                 // SSD-tier metadata binding: the verified hash for the bytes
                 // this slot loaded (nil/blank disables reusable SSD caching).
                 weightHash: cacheEligibleWeightHash,

--- a/provider-swift/Sources/ProviderCore/Server/StandaloneServer.swift
+++ b/provider-swift/Sources/ProviderCore/Server/StandaloneServer.swift
@@ -79,6 +79,7 @@ public struct StandaloneServerConfig: Sendable {
     public let engineV2KVBackend: String
     /// Per-model overrides (`engine_v2_kv_backend_by_model`).
     public let engineV2KVBackendByModel: [String: String]
+    public let prefillDeadlineMode: PrefillDeadlineMode?
     /// MTP beta configuration. Defaults off; the CLI/config owner passes these
     /// through when standalone MTP is intentionally enabled.
     public let mtp: Bool
@@ -94,6 +95,7 @@ public struct StandaloneServerConfig: Sendable {
         engineV2MaxConcurrentByModel: [String: UInt64] = [:],
         engineV2KVBackend: String = "auto",
         engineV2KVBackendByModel: [String: String] = [:],
+        prefillDeadlineMode: PrefillDeadlineMode? = nil,
         mtp: Bool = false,
         mtpDrafterPath: String? = nil
     ) {
@@ -106,6 +108,7 @@ public struct StandaloneServerConfig: Sendable {
         self.engineV2MaxConcurrentByModel = engineV2MaxConcurrentByModel
         self.engineV2KVBackend = engineV2KVBackend
         self.engineV2KVBackendByModel = engineV2KVBackendByModel
+        self.prefillDeadlineMode = prefillDeadlineMode
         self.mtp = mtp
         self.mtpDrafterPath = mtpDrafterPath
     }
@@ -852,6 +855,7 @@ public actor StandaloneServer {
                 kvBudget: kvBudget,
                 kvBackendConfig: config.engineV2KVBackend,
                 kvBackendConfigByModel: config.engineV2KVBackendByModel,
+                prefillDeadlineMode: config.prefillDeadlineMode,
                 weightHash: cacheEligibleWeightHash,
                 specDecPreparation: specDecPreparation,
                 preparedModel: prepared,

--- a/provider-swift/Sources/darkbloom/StartCommand+Modes.swift
+++ b/provider-swift/Sources/darkbloom/StartCommand+Modes.swift
@@ -95,6 +95,7 @@ extension Start {
                 engineV2MaxConcurrentByModel: config.backend.engineV2MaxConcurrentByModel,
                 engineV2KVBackend: config.backend.engineV2KVBackend,
                 engineV2KVBackendByModel: config.backend.engineV2KVBackendByModel,
+                prefillDeadlineMode: config.backend.prefillDeadlineMode,
                 mtp: config.backend.mtp,
                 mtpDrafterPath: config.backend.mtpDrafterPath
             ),

--- a/provider-swift/Tests/ProviderCoreTests/ConfigTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ConfigTests.swift
@@ -40,6 +40,53 @@ import Testing
     #expect(decoded.backend.maxModelSlots == 5)
 }
 
+@Test func prefillDeadlineModePreservesAbsentInheritance() throws {
+    let config = ConfigManager.parse("""
+    [provider]
+    name = "test-provider"
+    """)
+    #expect(config.backend.prefillDeadlineMode == nil)
+    #expect(
+        PrefillDeadlineMode.resolve(
+            configured: config.backend.prefillDeadlineMode,
+            environment: [:]) == .enforce)
+
+    let serialized = ConfigManager.serialize(config)
+    #expect(!serialized.contains("prefill_deadline_mode"))
+    #expect(ConfigManager.parse(serialized).backend.prefillDeadlineMode == nil)
+}
+
+@Test func prefillDeadlineModeParsesAndSerializes() throws {
+    let disabled = ConfigManager.parse("""
+    [backend]
+    prefill_deadline_mode = "off"
+    """)
+    #expect(disabled.backend.prefillDeadlineMode == .off)
+    let enforced = ConfigManager.parse("""
+    [backend]
+    prefill_deadline_mode = "enforce"
+    """)
+    #expect(enforced.backend.prefillDeadlineMode == .enforce)
+
+    let original = ProviderConfig(
+        provider: ProviderSettings(name: "test-provider"),
+        backend: BackendSettings(prefillDeadlineMode: .off),
+        coordinator: CoordinatorSettings())
+    let serialized = ConfigManager.serialize(original)
+    #expect(serialized.contains("prefill_deadline_mode = 'off'"))
+    #expect(
+        ConfigManager.parse(serialized).backend.prefillDeadlineMode == .off)
+
+    let enforcing = ProviderConfig(
+        provider: ProviderSettings(name: "test-provider"),
+        backend: BackendSettings(prefillDeadlineMode: .enforce),
+        coordinator: CoordinatorSettings())
+    let enforcingTOML = ConfigManager.serialize(enforcing)
+    #expect(enforcingTOML.contains("prefill_deadline_mode = 'enforce'"))
+    #expect(
+        ConfigManager.parse(enforcingTOML).backend.prefillDeadlineMode == .enforce)
+}
+
 // v0.8.0 removed KV quantization from the product. Effectively every
 // provider.toml in the field carries `kv_quant` because the serializer used
 // to round-trip it, so an UPGRADING provider must load such a config without

--- a/provider-swift/Tests/ProviderCoreTests/ConfigValidationTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ConfigValidationTests.swift
@@ -94,6 +94,19 @@ struct ConfigValidationTests {
         }
     }
 
+    @Test("parseValidating rejects an unknown prefill deadline mode")
+    func parseValidatingRejectsUnknownPrefillDeadlineMode() throws {
+        do {
+            _ = try ConfigManager.parseValidating("""
+                [backend]
+                prefill_deadline_mode = "disabled"
+                """)
+            Issue.record("unknown prefill deadline mode must not decode")
+        } catch ConfigError.parseFailed(let detail) {
+            #expect(!detail.isEmpty)
+        }
+    }
+
     // MARK: - file-loading boundary
 
     @Test("a malformed existing config file fails loading loudly")

--- a/provider-swift/Tests/ProviderCoreTests/EngineV2PrefillSamplingTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/EngineV2PrefillSamplingTests.swift
@@ -520,6 +520,26 @@ struct EngineV2FirstTokenDeadlineAdmissionTests {
             kvBudget: budget)
     }
 
+    private func makeProductionBridge(
+        engine: PrefillScriptEngine,
+        configuredMode: PrefillDeadlineMode? = nil,
+        environment: [String: String]
+    ) throws -> EngineV2Bridge {
+        try EngineV2Factory.makeBridge(
+            modelId: "gpt-oss-20b",
+            tokenizer: TokenizerHandle(PrefillStubTokenizer()),
+            eosTokenIds: [],
+            prefillDeadlineMode: configuredMode,
+            runtimePolicyEnvironment: environment,
+            makeEngine: {
+                EngineV2Factory.ProductionBuild(
+                    engine: engine,
+                    fixedRequestBytes: 0,
+                    kvBackendKind: .contiguous,
+                    kvBackendFallbackReason: nil)
+            })
+    }
+
     private func ampleBudget() -> GlobalKVCacheBudget {
         let gib: UInt64 = 1_073_741_824
         return GlobalKVCacheBudget(
@@ -603,7 +623,14 @@ struct EngineV2FirstTokenDeadlineAdmissionTests {
     @Test("enforce mode carries absolute monotonic deadline and conservative phase rates")
     func enforceUsesAtomicAdmission() async throws {
         let engine = PrefillScriptEngine()
-        let bridge = makeBridge(engine: engine, mode: .enforce)
+        let bridge = try makeProductionBridge(
+            engine: engine,
+            environment: [
+                PrefillDeadlineMode.environmentKey: "enforce",
+                EngineV2Factory.maxPartialPrefillsKey: "1",
+            ])
+        #expect(await bridge.prefillDeadlineMode == .enforce)
+        #expect(await bridge.prefillDeadlineProjectionEnabled)
         let measured = try await measureColdPrefillRate(
             bridge: bridge,
             engine: engine)
@@ -631,6 +658,42 @@ struct EngineV2FirstTokenDeadlineAdmissionTests {
         #expect(engine.ordinarySubmissionCount == 1)
         #expect(await bridge._testLivePumpCount() == 1)
         try await finishLatestSubmission(stream, engine: engine)
+    }
+
+    @Test("cap zero bypasses atomic forecast but preserves serving and hard expiry")
+    func capZeroUsesOrdinarySubmission() async throws {
+        let engine = PrefillScriptEngine()
+        let bridge = try makeProductionBridge(
+            engine: engine,
+            environment: [
+                PrefillDeadlineMode.environmentKey: "enforce",
+                EngineV2Factory.maxPartialPrefillsKey: "0",
+            ])
+        #expect(await bridge.prefillDeadlineMode == .enforce)
+        #expect(!(await bridge.prefillDeadlineProjectionEnabled))
+        _ = try await measureColdPrefillRate(bridge: bridge, engine: engine)
+        engine.setDeadlineBehavior(.reject)
+
+        let liveDeadline = deadline()
+        let stream = try await bridge.submitTokenized(
+            promptTokens: promptTokens,
+            request: request,
+            requestId: "cap-zero-serving-rollback",
+            firstContentDeadline: liveDeadline)
+        #expect(engine.deadlineAdmissions.isEmpty)
+        #expect(engine.ordinarySubmissionCount == 2)
+        try await finishLatestSubmission(stream, engine: engine)
+
+        let expired = deadline(budgetMilliseconds: 0, elapsedMilliseconds: 1)
+        await #expect(throws: PreContentDeadlineFailure.deadlineUnreachable) {
+            _ = try await bridge.submitTokenized(
+                promptTokens: promptTokens,
+                request: request,
+                requestId: "cap-zero-expired",
+                firstContentDeadline: expired)
+        }
+        #expect(engine.deadlineAdmissions.isEmpty)
+        #expect(engine.ordinarySubmissionCount == 2)
     }
 
     @Test("deadline policy supplies independently observed decode rate")
@@ -705,7 +768,14 @@ struct EngineV2FirstTokenDeadlineAdmissionTests {
     @Test("live off, missing deadline, unmeasured rate, and multimodal requests fail open")
     func failOpenCasesUseOrdinarySubmit() async throws {
         let offEngine = PrefillScriptEngine()
-        let offBridge = makeBridge(engine: offEngine, mode: .off)
+        let offBridge = try makeProductionBridge(
+            engine: offEngine,
+            configuredMode: .off,
+            environment: [
+                EngineV2Factory.maxPartialPrefillsKey: "1",
+            ])
+        #expect(await offBridge.prefillDeadlineMode == .off)
+        #expect(await offBridge.prefillDeadlineProjectionEnabled)
         _ = try await measureColdPrefillRate(bridge: offBridge, engine: offEngine)
         offEngine.setDeadlineBehavior(.reject)
         let offStream = try await offBridge.submitTokenized(

--- a/provider-swift/Tests/ProviderCoreTests/EngineV2ProductionWiringTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/EngineV2ProductionWiringTests.swift
@@ -2189,27 +2189,94 @@ struct EngineV2KVBackendFallbackHeartbeatTests {
 
 @Suite("Prefill deadline and FCFS production configuration")
 struct PrefillDeadlineProductionConfigTests {
-    @Test("deadline enforcement is off by default and for invalid values")
-    func deadlineModeDefaultsOff() {
-        #expect(PrefillDeadlineMode.resolve(environment: [:]) == .off)
-        for invalid in ["", "ENFORCE", "true", "1", "garbage"] {
-            #expect(
-                PrefillDeadlineMode.resolve(environment: [
-                    PrefillDeadlineMode.environmentKey: invalid
-                ]) == .off)
+    @Test("deadline mode exhaustively resolves config authority and environment inheritance")
+    func deadlineModeUsesSourceAwarePrecedence() {
+        let configuredCases: [(name: String, value: PrefillDeadlineMode?)] = [
+            ("absent", nil),
+            ("enforce", .enforce),
+            ("off", .off),
+        ]
+        let environmentCases: [(name: String, value: String?)] = [
+            ("missing", nil),
+            ("off", "off"),
+            ("enforce", "enforce"),
+            ("malformed", "garbage"),
+            ("empty", ""),
+        ]
+        for configuredCase in configuredCases {
+            for environmentCase in environmentCases {
+                let environment = environmentCase.value.map {
+                    [PrefillDeadlineMode.environmentKey: $0]
+                } ?? [:]
+                let expected: PrefillDeadlineMode =
+                    configuredCase.value
+                    ?? (environmentCase.value == "off" ? .off : .enforce)
+                #expect(
+                    PrefillDeadlineMode.resolve(
+                        configured: configuredCase.value,
+                        environment: environment) == expected,
+                    "configured=\(configuredCase.name), env=\(environmentCase.name)")
+            }
         }
     }
 
-    @Test("deadline mode accepts only exact off and enforce values")
-    func deadlineModeParsesExplicitValues() {
-        #expect(
-            PrefillDeadlineMode.resolve(environment: [
-                PrefillDeadlineMode.environmentKey: "off"
-            ]) == .off)
-        #expect(
-            PrefillDeadlineMode.resolve(environment: [
-                PrefillDeadlineMode.environmentKey: "enforce"
-            ]) == .enforce)
+    @Test("production bridge carries mode and scheduler projection compatibility")
+    func productionBridgeResolvesDeadlineEnvironment() async throws {
+        let configuredCases: [PrefillDeadlineMode?] = [
+            nil, .enforce, .off,
+        ]
+        let environmentCases: [String?] = [
+            nil, "off", "enforce", "invalid", "",
+        ]
+
+        for configuredMode in configuredCases {
+            for environmentValue in environmentCases {
+                let environment = environmentValue.map {
+                    [PrefillDeadlineMode.environmentKey: $0]
+                } ?? [:]
+                let expectedMode =
+                    configuredMode
+                    ?? (environmentValue == "off"
+                        ? PrefillDeadlineMode.off : .enforce)
+                let bridge = try EngineV2Factory.makeBridge(
+                    modelId: "deadline-mode-wiring",
+                    tokenizer: TokenizerHandle(WiringStubTokenizer()),
+                    eosTokenIds: [2],
+                    prefillDeadlineMode: configuredMode,
+                    runtimePolicyEnvironment: environment,
+                    makeEngine: {
+                        EngineV2Factory.ProductionBuild(
+                            engine: WiringScriptedEngine(script: .manual),
+                            fixedRequestBytes: 0,
+                            kvBackendKind: .contiguous,
+                            kvBackendFallbackReason: nil)
+                    })
+                #expect(await bridge.prefillDeadlineMode == expectedMode)
+                #expect(await bridge.prefillDeadlineProjectionEnabled)
+                await bridge.shutdown()
+            }
+        }
+
+        for cap in ["0", "2"] {
+            let bridge = try EngineV2Factory.makeBridge(
+                modelId: "deadline-cap-wiring",
+                tokenizer: TokenizerHandle(WiringStubTokenizer()),
+                eosTokenIds: [2],
+                prefillDeadlineMode: .enforce,
+                runtimePolicyEnvironment: [
+                    EngineV2Factory.maxPartialPrefillsKey: cap
+                ],
+                makeEngine: {
+                    EngineV2Factory.ProductionBuild(
+                        engine: WiringScriptedEngine(script: .manual),
+                        fixedRequestBytes: 0,
+                        kvBackendKind: .contiguous,
+                        kvBackendFallbackReason: nil)
+                })
+            #expect(await bridge.prefillDeadlineMode == .enforce)
+            #expect(!(await bridge.prefillDeadlineProjectionEnabled))
+            await bridge.shutdown()
+        }
     }
 
     @Test("partial-prefill cap defaults to one with zero as rollback")
@@ -2240,5 +2307,60 @@ struct PrefillDeadlineProductionConfigTests {
                     ]) == nil,
                 "\(unlimited) should preserve unlimited partial prefills")
         }
+    }
+
+    @Test("cap zero disables forecast compatibility without rewriting deadline mode")
+    func capZeroDisablesForecastCompatibility() {
+        let fcfsRollback = [
+            EngineV2Factory.maxPartialPrefillsKey: "0"
+        ]
+        #expect(
+            EngineV2Factory.maxConcurrentPartialPrefills(environment: fcfsRollback) == nil)
+        #expect(PrefillDeadlineMode.resolve(environment: fcfsRollback) == .enforce)
+        #expect(
+            !EngineV2Factory.prefillDeadlineProjectionSupported(
+                environment: fcfsRollback))
+
+        let deadlineRollback = [
+            PrefillDeadlineMode.environmentKey: "off"
+        ]
+        #expect(
+            EngineV2Factory.maxConcurrentPartialPrefills(environment: deadlineRollback) == 1)
+        #expect(PrefillDeadlineMode.resolve(environment: deadlineRollback) == .off)
+        #expect(
+            EngineV2Factory.prefillDeadlineProjectionSupported(
+                environment: deadlineRollback))
+    }
+
+    @Test("projection bypass diagnostic uses the configured mode")
+    func projectionBypassDiagnosticUsesConfiguredMode() {
+        let unsupportedWithStaleEnforce = [
+            PrefillDeadlineMode.environmentKey: "enforce",
+            EngineV2Factory.maxPartialPrefillsKey: "0",
+        ]
+        #expect(
+            !EngineV2SlotFactory.shouldLogPrefillDeadlineProjectionBypass(
+                configuredMode: .off,
+                environment: unsupportedWithStaleEnforce))
+        #expect(
+            EngineV2SlotFactory.shouldLogPrefillDeadlineProjectionBypass(
+                configuredMode: .enforce,
+                environment: unsupportedWithStaleEnforce))
+        #expect(
+            !EngineV2SlotFactory.shouldLogPrefillDeadlineProjectionBypass(
+                configuredMode: .enforce,
+                environment: [:]))
+        let unsupportedWithLegacyOff = [
+            PrefillDeadlineMode.environmentKey: "off",
+            EngineV2Factory.maxPartialPrefillsKey: "0",
+        ]
+        #expect(
+            !EngineV2SlotFactory.shouldLogPrefillDeadlineProjectionBypass(
+                configuredMode: nil,
+                environment: unsupportedWithLegacyOff))
+        #expect(
+            EngineV2SlotFactory.shouldLogPrefillDeadlineProjectionBypass(
+                configuredMode: .enforce,
+                environment: unsupportedWithLegacyOff))
     }
 }

--- a/provider-swift/Tests/ProviderCoreTests/LaunchAgentRestartTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/LaunchAgentRestartTests.swift
@@ -64,7 +64,46 @@ struct LaunchAgentEnvironmentTests {
         ])
         #expect(out.isEmpty)
         #expect(EngineV2Factory.maxConcurrentPartialPrefills(environment: out) == 1)
-        #expect(PrefillDeadlineMode.resolve(environment: out) == .off)
+        #expect(PrefillDeadlineMode.resolve(environment: out) == .enforce)
+    }
+
+    @Test func sourceAwareResolutionMatchesForegroundAndLaunchd() {
+        let configuredCases: [(name: String, value: PrefillDeadlineMode?)] = [
+            ("absent", nil),
+            ("enforce", .enforce),
+            ("off", .off),
+        ]
+        let environmentCases: [(name: String, value: String?)] = [
+            ("missing", nil),
+            ("off", "off"),
+            ("enforce", "enforce"),
+            ("malformed", "garbage"),
+            ("empty", ""),
+        ]
+        for configuredCase in configuredCases {
+            for environmentCase in environmentCases {
+                let foreground = environmentCase.value.map {
+                    [PrefillDeadlineMode.environmentKey: $0]
+                } ?? [:]
+                let launchd = LaunchAgent.passthroughEnvironment(from: foreground)
+                let expected: PrefillDeadlineMode =
+                    configuredCase.value
+                    ?? (environmentCase.value == "off" ? .off : .enforce)
+                #expect(
+                    PrefillDeadlineMode.resolve(
+                        configured: configuredCase.value,
+                        environment: foreground) == expected,
+                    "foreground configured=\(configuredCase.name), env=\(environmentCase.name)")
+                #expect(
+                    PrefillDeadlineMode.resolve(
+                        configured: configuredCase.value,
+                        environment: launchd) == expected,
+                    "launchd configured=\(configuredCase.name), env=\(environmentCase.name)")
+                if environmentCase.name == "empty" {
+                    #expect(launchd[PrefillDeadlineMode.environmentKey] == nil)
+                }
+            }
+        }
     }
 
     @Test func forwardsPrefillOperationalControlsUnchanged() {
@@ -81,7 +120,7 @@ struct LaunchAgentEnvironmentTests {
         #expect(PrefillDeadlineMode.resolve(environment: out) == .enforce)
     }
 
-    @Test func preservesMalformedNonEmptyControlsForRuntimeFailOpen() {
+    @Test func preservesMalformedNonEmptyControlsForRuntimeSecureDefault() {
         let out = LaunchAgent.passthroughEnvironment(from: [
             EngineV2Factory.maxPartialPrefillsKey: "not-an-integer",
             PrefillDeadlineMode.environmentKey: "invalid",
@@ -91,7 +130,7 @@ struct LaunchAgentEnvironmentTests {
             PrefillDeadlineMode.environmentKey: "invalid",
         ])
         #expect(EngineV2Factory.maxConcurrentPartialPrefills(environment: out) == nil)
-        #expect(PrefillDeadlineMode.resolve(environment: out) == .off)
+        #expect(PrefillDeadlineMode.resolve(environment: out) == .enforce)
     }
 
     @Test func forwardsResourceDebugOptOutToDaemon() {


### PR DESCRIPTION
## Summary

- Makes v0.8.12 provider-side atomic first-token deadline admission secure and default-on for eligible requests.
- Returns early, health-neutral `deadline_unreachable` before GPU prompt work so the coordinator can retry another provider.
- Adds optional typed TOML rollback with explicit config authority and legacy environment fallback when the key is absent.
- Makes cap `0` bypass the unsupported atomic forecast while preserving ordinary submission and hard absolute expiry.
- Synchronizes provider/coordinator versions and release documentation at `0.8.12`.

## Before

```mermaid
flowchart LR
  subgraph BeforeBehavior["Behavior — v0.8.11"]
    B0["No TOML deadline setting"] --> B1{"Environment is exact enforce?"}
    B1 -->|yes| B2["Mode: enforce"]
    B1 -->|"no: missing, off, or unknown"| B3["Mode: off"]
    B2 --> B4{"Partial-prefill posture"}
    B4 -->|"cap 1"| B5["Atomic forecast for otherwise eligible requests"]
    B4 -->|"cap 0 / unlimited"| B6["Bridge still invokes atomic admission"]
    B6 --> B9["SchedulerV2 projection returns unbounded because cap 1 is required"]
    B9 --> B10["EngineLoop rejects deadline_unreachable"]
    B3 --> B7["Ordinary submission"]
    B5 --> B8["Hard absolute expiry remains active"]
    B7 --> B8
  end
  subgraph BeforeCode["Code — v0.8.11"]
    C1["ProcessInfo environment"] --> C2["PrefillDeadlineMode.resolve(environment:)"]
    C2 --> C3["EngineV2Factory.makeBridge"]
    C3 --> C6["EngineV2Bridge admission guard had no cap check"]
    C6 --> C7["Atomic admission calls SchedulerV2 projection"]
    C4["maxConcurrentPartialPrefills"] --> C7
    C7 -->|"cap 1: bounded result"| C8["Admission can proceed"]
    C7 -->|"cap 0: unbounded result"| C9["EngineLoop returns deadline_unreachable"]
  end
```

## After

```mermaid
flowchart LR
  subgraph AfterBehavior["Behavior — v0.8.12"]
    A0{"TOML prefill_deadline_mode"}
    A0 -->|"explicit off"| A1["Mode: off"]
    A0 -->|"explicit enforce"| A2["Mode: enforce"]
    A0 -->|absent| A3{"Legacy environment exact off?"}
    A3 -->|yes| A1
    A3 -->|"no: missing, enforce, malformed, or empty"| A2
    A1 --> A4["Ordinary submission"]
    A2 --> A5{"Partial-prefill posture"}
    A5 -->|"cap 1"| A6["Atomic forecast for otherwise eligible requests"]
    A5 -->|"cap 0 / unlimited"| A7["Bypass forecast; ordinary submission"]
    A4 --> A8["Hard absolute expiry remains active"]
    A6 --> A8
    A7 --> A8
  end
  subgraph AfterCode["Code — v0.8.12"]
    D1["BackendSettings.prefillDeadlineMode?"] --> D2["Absent stays nil and is omitted on serialization"]
    D1 --> D3["PrefillDeadlineMode.resolve(configured:environment:)"]
    D4["Legacy environment"] --> D3
    D3 --> D5["EngineV2Factory.makeBridge resolved mode"]
    D3 --> D6["EngineV2SlotFactory diagnostic"]
    D7["maxConcurrentPartialPrefills"] --> D8["prefillDeadlineProjectionEnabled"]
    D5 --> D9["EngineV2Bridge admission guard"]
    D8 --> D9
  end
```

## Test plan

### Completed local gates

- [x] Full coordinator suite
- [x] Full provider suite — 2,222 tests
- [x] Nested CBv2 suite — 27 tests
- [x] Version/release/installer parity
- [x] Focused config/cap matrix

### Publication gates

- [ ] Signed artifact
- [ ] Mixed-version E2E
- [ ] Apple Silicon default-on/rollback canary
- [ ] Live telemetry observation

This PR prepares but does not publish v0.8.12.

## Rollback

Set the authoritative typed policy in the active provider config:

```toml
[backend]
prefill_deadline_mode = "off"
```

Then perform an ordinary restart:

```bash
darkbloom restart
```

Explicit TOML is authoritative over the legacy environment. The cap-0 forecast bypass is independent: it preserves hard expiry and does not rewrite the configured deadline mode.

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/726"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790249398&installation_model_id=21733&pr_number=726&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F726&signature=794c2275286aaf66fa91713c0cfe72fdfbb7142ef2d6a02846149803104b47f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->