### PR TITLE
ci(security): add CodeQL advanced setup

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,123 @@
+name: CodeQL
+
+# Advanced setup, replacing GitHub's default setup for this repo.
+#
+# Two reasons this exists as a workflow rather than a settings toggle:
+#
+#   1. Coverage. Default setup cannot analyze Rust at all (the API rejects it:
+#      only actions, c-cpp, csharp, go, java-kotlin, javascript-typescript,
+#      python, ruby and swift are accepted), and in practice it was only
+#      running go, javascript-typescript and python — leaving provider-swift
+#      (the largest Swift surface in the repo) and coordinator/promptsidecar
+#      unanalyzed.
+#   2. Requireability. Default setup dispatched conditionally, so some PRs got
+#      no CodeQL run at all. A required status check that never reports blocks
+#      a PR forever, so the gate could not be made mandatory. Every job here
+#      runs on every pull_request, which is what makes it safe to require.
+
+on:
+  push:
+    branches: [master, main]
+  pull_request:
+  schedule:
+    # Weekly full-tree scan so alerts don't go stale between releases.
+    - cron: '27 4 * * 1'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: codeql-${{ github.workflow }}-${{ github.ref }}
+  # Superseded PR pushes are cancelled; the newer run reports the check.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  analyze:
+    name: CodeQL Analyze (${{ matrix.language }})
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 60
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: go
+            build-mode: autobuild
+          - language: javascript-typescript
+            build-mode: none
+          - language: python
+            build-mode: none
+          - language: rust
+            build-mode: none
+          - language: actions
+            build-mode: none
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      # autobuild for Go needs the toolchain go.mod pins, not the runner default.
+      - name: Set up Go
+        if: matrix.language == 'go'
+        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
+        with:
+          go-version-file: go.mod
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@42947a340483f03ba47bb1a039b2c519aab3df85 # v3.37.8
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@42947a340483f03ba47bb1a039b2c519aab3df85 # v3.37.8
+        with:
+          category: /language:${{ matrix.language }}
+
+  analyze-swift:
+    # Separate from the matrix above: the Swift extractor has to observe a real
+    # compile, and provider-swift only builds on macOS with the MLX submodules
+    # checked out.
+    name: CodeQL Analyze (swift)
+    runs-on: blacksmith-12vcpu-macos-latest
+    timeout-minutes: 90
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    steps:
+      - name: Checkout (with submodules)
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          submodules: recursive
+
+      - name: Show toolchain versions
+        run: |
+          set -euo pipefail
+          swift --version
+          xcodebuild -version
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@42947a340483f03ba47bb1a039b2c519aab3df85 # v3.37.8
+        with:
+          languages: swift
+          build-mode: manual
+
+      # Debug rather than release: the extractor only needs to watch the
+      # compiler, and release adds optimization time the scan doesn't use.
+      - name: Build provider-swift
+        working-directory: provider-swift
+        run: |
+          set -euo pipefail
+          swift build --product darkbloom
+          swift build --product darkbloom-enclave
+          swift build --product darkbloom-fan-helper
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@42947a340483f03ba47bb1a039b2c519aab3df85 # v3.37.8
+        with:
+          category: /language:swift


### PR DESCRIPTION
## Summary

Replaces GitHub's CodeQL **default setup** with an advanced-setup workflow for this repo. Two independent problems with the current state:

**Coverage.** Default setup cannot analyze Rust at all — the API rejects it outright (`rust is not a possible value`; the accepted set is `actions, c-cpp, csharp, go, java-kotlin, javascript-typescript, python, ruby, swift`). And in practice it was only dispatching `go`, `javascript-typescript` and `python`, so two significant surfaces have gone unanalyzed:

- `provider-swift` — 7,216,720 bytes of Swift, the second-largest language in the repo. Last CodeQL analysis was **2026-06-16**, on #363, despite active work on the macOS app since.
- `coordinator/promptsidecar` — Rust, never covered.
- `actions` — workflow analysis, only intermittent. Relevant given there's an open high alert of exactly this class (`actions/untrusted-checkout/high` in `codex.yml:59`).

**Requireability.** Default setup dispatched conditionally — #704, for one, received zero CodeQL runs. A required status check that never reports blocks a PR forever, so the gate could not safely be made mandatory. Every job here runs on every `pull_request`, which is the precondition for requiring it.

Also runs on push to `master` and weekly, so alerts don't go stale between releases.

## Test plan

The point of this PR is that its own checks are the test. What to look for:

- [ ] Six `CodeQL Analyze (...)` checks appear and pass: `go`, `javascript-typescript`, `python`, `rust`, `actions`, `swift`
- [ ] `CodeQL Analyze (swift)` completes on macOS with submodules — this is the job most likely to need iteration
- [ ] `CodeQL Analyze (rust)` succeeds with `build-mode: none`; if the extractor demands a compile, it becomes `manual` with `cargo build`
- [ ] No duplicate/conflicting analyses against default setup's `/language:*` categories

## Follow-ups (not in this PR)

1. **Disable default setup for this repo.** It's currently enforced by org security configuration `203317`, which locks repo-level changes (`Code scanning default setup cannot be modified. This setting is controlled by organization administrators.`). `allow_advanced` is already `true`, so an org admin can switch this repo to advanced. Until that happens, `go`/`javascript-typescript`/`python` are analyzed twice.
2. **Then make these required status checks** on ruleset `15055885`. It currently has no `required_status_checks` rule at all, which is why a red security check didn't block #718. Deliberately excluded from any future required set: `Threat Model Review` (failing 100% since 2026-07-31 on an expired API key — would block every merge) and `E2E Benchmarks` (never completes; conclusion is always `null`).
3. **Triage the 12 open code scanning alerts** (5 high, 7 medium, oldest 2026-04-14) and the 51 Dependabot alerts on `master` (7 critical, 24 high).

Deliberately kept the default query suite rather than `security-extended`, to avoid a flood of new alerts obscuring whether the workflow itself is sound. Worth revisiting once this is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/729"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790278066&installation_model_id=21733&pr_number=729&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F729&signature=8849cdc0c9ce1f84fa48b05bca58f00e80386c2559fe52fa2a504d7030d6e26a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->