### PR TITLE
fix(qwen): serve media without false TTFT shedding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,10 +26,13 @@
   `<|video_pad|>` run into per-frame spans. Image decode applies EXIF
   orientation on the full raster (not a JPEG thumbnail). Media requests
   default `enable_thinking=false` unless the client sets
-  `reasoning.enabled`. Qwen samples at most 16 video frames. Coordinator
-  remote-media fetch is bounded by the leftover first-content clock minus
-  an inference reserve, so a 15s origin download cannot expire the
-  OpenRouter-shaped 9s+1ms/token budget before the provider starts.
+  `reasoning.enabled`. Qwen decodes media once and uniformly samples at most
+  8 video frames at no more than 512² pixels each, bounding its unfused
+  vision score tensor to 512 MiB. Coordinator remote-media fetch is bounded
+  by the leftover first-content clock minus an inference reserve, and media
+  bypasses the text-only estimated-TTFT hard gate while retaining the same
+  request-absolute deadline. Its incomplete estimates do not train text TTFT
+  calibration or emit synthetic warm-pool pressure.
 
 Release rationale, limitations, compatibility, and rollout gates:
 [`docs/reports/2026-08-25-v0.8.12-prefill-deadline-admission.md`](docs/reports/2026-08-25-v0.8.12-prefill-deadline-admission.md).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,16 @@
   absolute expiry remains active. It does not rewrite the deadline-mode setting.
 - Provider and coordinator fallback version authorities move together to
   `0.8.12`; there is no new protocol.
+- **Qwen 3.5 video + grounded image captions** — Qwen vision prefill no
+  longer fail-closes video as `invalid media input`. The tower runs one
+  video (full T×H×W grid) at a time and carves the contiguous
+  `<|video_pad|>` run into per-frame spans. Image decode applies EXIF
+  orientation on the full raster (not a JPEG thumbnail). Media requests
+  default `enable_thinking=false` unless the client sets
+  `reasoning.enabled`. Qwen samples at most 16 video frames. Coordinator
+  remote-media fetch is bounded by the leftover first-content clock minus
+  an inference reserve, so a 15s origin download cannot expire the
+  OpenRouter-shaped 9s+1ms/token budget before the provider starts.
 
 Release rationale, limitations, compatibility, and rollout gates:
 [`docs/reports/2026-08-25-v0.8.12-prefill-deadline-admission.md`](docs/reports/2026-08-25-v0.8.12-prefill-deadline-admission.md).

--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -693,6 +693,17 @@ func ttftTooSlow(bestTTFT time.Duration, hasTTFT bool, threshold time.Duration) 
 	return hasTTFT && bestTTFT > threshold
 }
 
+// hardTTFTGateApplies reports whether the scheduler's token-prefill estimate is
+// authoritative enough to reject this request before dispatch. Media requests
+// run CPU decode plus a separate vision tower before text prefill; neither cost
+// exists in estimatedTTFTFromSnapshot, so treating that partial estimate as a
+// hard ceiling rejects healthy video/image requests on a number that cannot
+// predict their TTFT. They still use the best-available provider and remain
+// bounded by the same request-absolute first-content deadline.
+func (s *Server) hardTTFTGateApplies(requiresVision bool) bool {
+	return s.ttftHardReject && !requiresVision
+}
+
 func fasterTTFTEstimate(primaryModel string, primary time.Duration, alternateModel string, alternate time.Duration, alternateOK bool) (string, time.Duration) {
 	if alternateOK && alternate < primary {
 		return alternateModel, alternate
@@ -888,7 +899,7 @@ func (s *Server) dispatchOneProvider(
 	// dispatch serves the best-available provider instead of re-rejecting an
 	// over-threshold request the preflight already chose to soft-serve. (Mirrors
 	// queueMaxTTFTMs, which already returns 0 in soft mode.)
-	if !policy.enabled && !policy.prefer && s.ttftHardReject {
+	if !policy.enabled && !policy.prefer && s.hardTTFTGateApplies(requiresVision) {
 		pr.MaxTTFTMs = float64(requestDeadline.Milliseconds())
 	}
 	// Refresh immediately before reservation: every retry spends the same

--- a/coordinator/api/consumer_ttft_test.go
+++ b/coordinator/api/consumer_ttft_test.go
@@ -240,6 +240,50 @@ func TestTTFTSoftGateDoesNotShedAtDispatch(t *testing.T) {
 	}
 }
 
+func TestTTFTHardGateDoesNotRejectMediaOnTextOnlyEstimate(t *testing.T) {
+	srv, _ := testServer(t)
+	srv.SetTTFTHardReject(true)
+	warmCfg := registry.ReadConfig().WarmPool
+	warmCfg.Enabled = true
+	warmCfg.ObserveOnly = false
+	srv.registry.ConfigureWarmPool(warmCfg)
+	model := "media-estimate-is-partial"
+	srv.registry.SetModelCatalog([]registry.CatalogEntry{{ID: model, SizeGB: 1, MinRAMGB: 24}})
+	srv.registry.RecordWarmPoolSpeculativeStarted(model) // seed an observable bucket
+	p := registerBuildsProvider(srv, "vision-provider", model)
+	p.Mu().Lock()
+	p.DecodeTPS = 100
+	p.PrefillTPS = 0.2
+	p.Models[0].IsVision = true
+	p.Mu().Unlock()
+
+	body := strings.ReplaceAll(
+		`{"model":"MODEL","messages":[{"role":"user","content":[{"type":"text","text":"describe"},{"type":"image_url","image_url":{"url":"data:image/png;base64,iVBORw0KGgo="}}]}],"max_tokens":16}`,
+		"MODEL", model)
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer test-key")
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code == http.StatusTooManyRequests || strings.Contains(w.Body.String(), "TTFT target") {
+		t.Fatalf("hard gate used a text-only estimate to reject media: status=%d body=%s", w.Code, w.Body.String())
+	}
+	found := false
+	for _, snap := range srv.registry.TriggerWarmPool() {
+		if snap.Model != model {
+			continue
+		}
+		found = true
+		if snap.TTFTMisses != 0 {
+			t.Fatalf("media token proxy emitted %d synthetic warm-pool TTFT miss(es), want 0", snap.TTFTMisses)
+		}
+	}
+	if !found {
+		t.Fatal("warm-pool snapshot missing media model")
+	}
+}
+
 func TestMaybeFallbackAliasTTFTSwitchesToPrevious(t *testing.T) {
 	srv, _ := testServer(t)
 	publicModel := "public-ttft-alias"

--- a/coordinator/api/dispatch.go
+++ b/coordinator/api/dispatch.go
@@ -1213,13 +1213,14 @@ func (d *dispatchState) dispatchPrimary() dispatchOutcome {
 			PreferOwner:            d.policy.prefer,
 			OwnerAccountID:         d.policy.ownerAccountID,
 			FreeSelfRoute:          d.policy.enabled,
-			MaxTTFTMs:              queueMaxTTFTMs(d.policy, d.deadline, d.s.ttftHardReject),
-			MinDecodeTPS:           d.s.minDecodeTPS,
-			AcceptedCh:             make(chan struct{}, 1),
-			ChunkCh:                make(chan registry.ProviderChunk, chunkBufferSize),
-			CompleteCh:             make(chan protocol.UsageInfo, 1),
-			ErrorCh:                make(chan protocol.InferenceErrorMessage, 1),
-			Timing:                 d.timing,
+			MaxTTFTMs: queueMaxTTFTMs(
+				d.policy, d.deadline, d.s.hardTTFTGateApplies(d.requiresVision)),
+			MinDecodeTPS: d.s.minDecodeTPS,
+			AcceptedCh:   make(chan struct{}, 1),
+			ChunkCh:      make(chan registry.ProviderChunk, chunkBufferSize),
+			CompleteCh:   make(chan protocol.UsageInfo, 1),
+			ErrorCh:      make(chan protocol.InferenceErrorMessage, 1),
+			Timing:       d.timing,
 		}
 		d.configurePending(queuePR)
 		if receivedAt := timingReceivedAt(d.timing); !receivedAt.IsZero() {

--- a/coordinator/api/inference_admission.go
+++ b/coordinator/api/inference_admission.go
@@ -594,16 +594,19 @@ func (s *Server) runInferenceAdmission(w http.ResponseWriter, r *http.Request, p
 		}
 	}
 	if ttftTooSlow(bestTTFT, hasTTFT, ttftThreshold) {
-		if !s.ttftHardReject {
-			// Soft TTFT gate (default): a provider passed every routing and
-			// capacity gate, and pr.MaxTTFTMs is left 0 in soft mode, so the
-			// dispatch path serves the best-available provider instead of
-			// re-rejecting (P1 fix). Do NOT divert to an older alias build here
-			// (P2 fix) — the desired build is routable. A soft-serve over the
-			// deadline is still a TTFT near-miss, so feed the autoscaler so it
-			// grows warm capacity for this model.
-			s.registry.RecordWarmPoolTTFTMiss(model, ttftThreshold)
-			s.triggerWarmPool()
+		if !s.hardTTFTGateApplies(p.requiresVision) {
+			// Soft TTFT path: either global hard rejection is disabled (the
+			// default), or this is media whose decode+tower costs are absent
+			// from the token-prefill estimate. pr.MaxTTFTMs stays 0, so dispatch
+			// serves the best available provider while the request-absolute
+			// first-content clock remains authoritative. Do not divert a
+			// routable desired build to an older alias.
+			// Keep the text soft-gate pressure signal, but do not teach the warm
+			// pool from a media projection that omits decode and tower work.
+			if !p.requiresVision {
+				s.registry.RecordWarmPoolTTFTMiss(model, ttftThreshold)
+				s.triggerWarmPool()
+			}
 			s.ddIncr("routing.decisions", []string{"model:" + model, "model_type:" + s.registry.ModelType(model), "outcome:ttft_soft_served"})
 		} else if fallbackModel, _, _, _, fallbackTTFT, fallbackHasTTFT, switched := s.maybeFallbackAlias(parsed, aliasFallbackTTFT, publicModel, model, p.estimatedPromptTokens, p.requestedMaxTokens, ttftThreshold, fallbackTraits(model), p.requiresVision, p.allowedProviderSerials); switched {
 			model = fallbackModel

--- a/coordinator/api/media_resolve.go
+++ b/coordinator/api/media_resolve.go
@@ -135,6 +135,40 @@ func scanRemoteMediaRefs(parsed map[string]any) remoteMediaScan {
 	return scan
 }
 
+// mediaFetchInferenceReserve is leftover first-content time kept for the
+// provider after the coordinator inlines remote media. The mediafetch defaults
+// (15s/file, 25s total) are larger than the production first-content clock
+// (9s + 1ms/token), so an unbounded fetch can expire the clock before the
+// provider starts — the video-url eval failed as
+// "timeout waiting for first response (backup)" after a successful fetch.
+const mediaFetchInferenceReserve = 5 * time.Second
+
+// mediaFetchMinBudget is the smallest fetch window worth starting.
+const mediaFetchMinBudget = 500 * time.Millisecond
+
+// mediaFetchBudget returns how long Resolve may run against the request-absolute
+// first-content clock. bound=false means the clock was never stamped and the
+// caller must keep the historical unbounded (mediafetch-default) path.
+// bound=true and budget==0 means the leftover clock cannot both fetch and
+// produce first content — fail closed without starting a 15s download.
+func mediaFetchBudget(receivedAt time.Time, firstContentDeadline time.Duration) (budget time.Duration, bound bool) {
+	if receivedAt.IsZero() || firstContentDeadline <= 0 {
+		return 0, false
+	}
+	remaining := firstTokenRemainingSince(receivedAt, firstContentDeadline)
+	reserve := mediaFetchInferenceReserve
+	if half := firstContentDeadline / 2; half < reserve {
+		reserve = half
+	}
+	if reserve < mediaFetchMinBudget {
+		reserve = mediaFetchMinBudget
+	}
+	if remaining <= reserve+mediaFetchMinBudget {
+		return 0, true
+	}
+	return remaining - reserve, true
+}
+
 // mediaResolveMeta carries the request descriptors resolveRemoteMedia needs to
 // record rejection telemetry with the same fidelity as the surrounding gates,
 // plus the self-route context used to gate egress on serve-ability.
@@ -198,7 +232,23 @@ func (s *Server) resolveRemoteMedia(w http.ResponseWriter, r *http.Request, rawB
 	}
 
 	start := time.Now()
-	res, err := s.mediaResolver.Resolve(r.Context(), parsed)
+	resolveCtx := r.Context()
+	if receivedAt := timingReceivedAt(timing); !receivedAt.IsZero() {
+		deadline := s.FirstContentDeadline(meta.estimatedPromptTokens)
+		budget, bound := mediaFetchBudget(receivedAt, deadline)
+		if bound && budget <= 0 {
+			s.logger.Warn("remote media rejected", "code", "media_fetch_timeout", "status", http.StatusRequestTimeout)
+			s.mediaFetchRejected(w, r, parsed, meta, http.StatusRequestTimeout, "media_fetch_timeout",
+				"timed out fetching remote media")
+			return nil, false, false
+		}
+		if bound {
+			var cancel context.CancelFunc
+			resolveCtx, cancel = context.WithTimeout(r.Context(), budget)
+			defer cancel()
+		}
+	}
+	res, err := s.mediaResolver.Resolve(resolveCtx, parsed)
 	if err != nil {
 		if errors.Is(err, context.Canceled) {
 			// The client is gone. The caller still refunds the monetary reservation,

--- a/coordinator/api/media_resolve.go
+++ b/coordinator/api/media_resolve.go
@@ -216,6 +216,9 @@ func (s *Server) resolveRemoteMedia(w http.ResponseWriter, r *http.Request, rawB
 	if s.mediaResolver == nil || !s.mediaResolver.Enabled() {
 		return rawBody, false, true
 	}
+	if !mediafetch.HasRemoteMedia(parsed) {
+		return rawBody, false, true
+	}
 
 	// Self-route skips the balance reservation, so nothing has yet gated egress
 	// on serve-ability. Before fetching, confirm the owner has an online machine
@@ -224,7 +227,7 @@ func (s *Server) resolveRemoteMedia(w http.ResponseWriter, r *http.Request, rawB
 	// egress and only then get the self-route error. Only runs when a fetch would
 	// actually happen (remote media present); selfRouteUnavailable writes its own
 	// terminal response. The later runInferenceAdmission re-checks (idempotent).
-	if meta.selfRoute && mediafetch.HasRemoteMedia(parsed) {
+	if meta.selfRoute {
 		if s.selfRouteUnavailable(w, r, meta.ownerAccountID, meta.model,
 			meta.traits, meta.requiresVision) {
 			return nil, false, false

--- a/coordinator/api/media_resolve_test.go
+++ b/coordinator/api/media_resolve_test.go
@@ -138,9 +138,10 @@ func TestResolveRemoteMediaInlinesOnSuccess(t *testing.T) {
 
 func TestResolveRemoteMediaNoRemoteNoOp(t *testing.T) {
 	s := minimalMediaServer(mediafetch.DefaultConfig())
+	s.firstContentDeadlineBase = 5 * time.Second
 	raw, parsed := chatBodyBytes(t, "data:image/png;base64,iVBORw0KGgo=")
 	w := httptest.NewRecorder()
-	timing := &registry.RequestTiming{}
+	timing := &registry.RequestTiming{ReceivedAt: time.Now().Add(-15 * time.Second)}
 
 	out, inlined, ok := s.resolveRemoteMedia(w, plainReq(), raw, parsed, timing, testMeta())
 	if !ok || inlined || !bytes.Equal(out, raw) {

--- a/coordinator/api/media_resolve_test.go
+++ b/coordinator/api/media_resolve_test.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/eigeninference/d-inference/coordinator/mediafetch"
 	"github.com/eigeninference/d-inference/coordinator/registry"
@@ -147,6 +148,69 @@ func TestResolveRemoteMediaNoRemoteNoOp(t *testing.T) {
 	}
 	if !timing.MediaFetchedAt.IsZero() {
 		t.Error("MediaFetchedAt must stay zero when nothing was fetched")
+	}
+}
+
+func TestMediaFetchBudgetUnstampedKeepsHistoricalPath(t *testing.T) {
+	budget, bound := mediaFetchBudget(time.Time{}, 9*time.Second)
+	if bound || budget != 0 {
+		t.Fatalf("unstamped clock = (%s,%v), want unbounded", budget, bound)
+	}
+}
+
+func TestMediaFetchBudgetProductionLeavesInferenceReserve(t *testing.T) {
+	deadline := 9*time.Second + 1500*time.Millisecond
+	budget, bound := mediaFetchBudget(time.Now(), deadline)
+	if !bound {
+		t.Fatal("stamped production clock must bound the fetch")
+	}
+	// reserve = min(5s, 10.5s/2) = 5s; leftover ≈ 10.5s → budget ≈ 5.5s
+	if budget < 5*time.Second || budget > 6*time.Second {
+		t.Fatalf("production video budget = %s, want ~5.5s", budget)
+	}
+}
+
+func TestMediaFetchBudgetTestDefaultDeadlineStillFetches(t *testing.T) {
+	budget, bound := mediaFetchBudget(time.Now(), 5*time.Second)
+	if !bound {
+		t.Fatal("stamped 5s clock must still bound")
+	}
+	// reserve shrinks to deadline/2 = 2.5s so ordinary test servers still fetch
+	if budget < 2*time.Second || budget > 3*time.Second {
+		t.Fatalf("5s deadline budget = %s, want ~2.5s", budget)
+	}
+}
+
+func TestMediaFetchBudgetExpiredClockIsZero(t *testing.T) {
+	budget, bound := mediaFetchBudget(time.Now().Add(-15*time.Second), 9*time.Second)
+	if !bound || budget != 0 {
+		t.Fatalf("expired clock = (%s,%v), want 0+bound", budget, bound)
+	}
+}
+
+func TestResolveRemoteMediaExpiredFirstContentClockDoesNotFetch(t *testing.T) {
+	cfg := mediafetch.DefaultConfig()
+	cfg.AllowPrivateIPs = true
+	cfg.AllowNonStandardPorts = true
+	var hits int32
+	media := httptest.NewServer(pngHandler(t, &hits))
+	defer media.Close()
+
+	s := minimalMediaServer(cfg)
+	s.firstContentDeadlineBase = 9 * time.Second
+	raw, parsed := chatBodyBytes(t, media.URL+"/cat.png")
+	w := httptest.NewRecorder()
+	timing := &registry.RequestTiming{ReceivedAt: time.Now().Add(-15 * time.Second)}
+
+	out, _, ok := s.resolveRemoteMedia(w, plainReq(), raw, parsed, timing, testMeta())
+	if ok || out != nil {
+		t.Fatal("expired first-content clock must not fetch")
+	}
+	if atomic.LoadInt32(&hits) != 0 {
+		t.Fatalf("origin was fetched %d times", hits)
+	}
+	if w.Code != http.StatusRequestTimeout {
+		t.Fatalf("status=%d body=%s, want 408", w.Code, w.Body.String())
 	}
 }
 

--- a/coordinator/api/request_introspection.go
+++ b/coordinator/api/request_introspection.go
@@ -29,7 +29,9 @@ import (
 // bounded number of soft tokens (Gemma 4 caps around a few hundred per image)
 // regardless of the base64 byte length, so counting a `data:` URI as text
 // inflates the estimate by orders of magnitude — distorting routing admission and
-// over-reserving balance. These flat per-media costs keep both sane.
+// over-reserving balance. Qwen's serving cap (8 frames, 512² pixels, temporal
+// patch 2, spatial merge 2) is at most ~1024 video soft tokens, so 1500 remains
+// conservative. These flat per-media costs keep both sane.
 const (
 	imagePromptTokenCost = 300
 	videoPromptTokenCost = 1500

--- a/coordinator/mediafetch/fetch.go
+++ b/coordinator/mediafetch/fetch.go
@@ -128,8 +128,10 @@ func isRemoteMediaURL(s string) bool {
 	if len(t) < 7 {
 		return false
 	}
-	lower := strings.ToLower(t)
-	return strings.HasPrefix(lower, "http://") || strings.HasPrefix(lower, "https://")
+	if strings.EqualFold(t[:7], "http://") {
+		return true
+	}
+	return len(t) >= 8 && strings.EqualFold(t[:8], "https://")
 }
 
 // fetchOne downloads one media URL under the SSRF policy and size cap, validates

--- a/coordinator/mediafetch/ssrf_test.go
+++ b/coordinator/mediafetch/ssrf_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"net/netip"
 	"net/url"
+	"strings"
 	"testing"
 )
 
@@ -206,6 +207,18 @@ func TestIsRemoteMediaURL(t *testing.T) {
 		if got := isRemoteMediaURL(in); got != want {
 			t.Errorf("isRemoteMediaURL(%q) = %v, want %v", in, got, want)
 		}
+	}
+}
+
+func TestIsRemoteMediaURLDoesNotCopyInlinePayload(t *testing.T) {
+	inline := "data:video/quicktime;base64," + strings.Repeat("A", 1<<20)
+	if isRemoteMediaURL(inline) {
+		t.Fatal("inline video classified as remote")
+	}
+	if allocs := testing.AllocsPerRun(10, func() {
+		_ = isRemoteMediaURL(inline)
+	}); allocs != 0 {
+		t.Fatalf("inline URL classification allocations = %v, want 0", allocs)
 	}
 }
 

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -174,7 +174,9 @@ type PendingRequest struct {
 	// MaxTTFTMs is an optional per-request TTFT ceiling in milliseconds.
 	// When > 0, the scheduler only selects providers whose estimated TTFT is
 	// <= MaxTTFTMs. Used by public inference routes to honor the public
-	// TTFT target. Self-route / prefer-owner requests leave this at 0.
+	// TTFT target. Self-route / prefer-owner and vision requests leave this at
+	// 0; the scheduler also ignores an accidental ceiling on vision because its
+	// decode and tower work are absent from the text-prefill estimate.
 	MaxTTFTMs float64
 	// MinDecodeTPS is an optional per-request sustained-decode floor in tokens/sec
 	// (Routing v2 W2). When > 0, the scheduler PREFERS providers that would still

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -508,8 +508,9 @@ func (r *Registry) ReserveProviderEx(model string, pr *PendingRequest, excludeID
 	// observation (API layer, RecordTTFTObservation) can be joined to it.
 	// Warm-slot winners only (StateMs == 0): a cold dispatch's actual includes
 	// model-load time the flow estimate does not model, which would poison the
-	// ratio sample.
-	if bd.RawTTFTMs > 0 && bd.StateMs == 0 {
+	// ratio sample. Text only: media decode and vision-tower work are also absent
+	// from the projection and must not train the text-prefill calibrator.
+	if !pr.RequiresVision && bd.RawTTFTMs > 0 && bd.StateMs == 0 {
 		ttftCalibration.notePrediction(pr.RequestID, pr.Attempt, model, selected.snapshot.chipFamily, bd.RawTTFTMs)
 	}
 	decision := RoutingDecision{
@@ -650,7 +651,10 @@ func (r *Registry) scanCandidatesLocked(model string, pr *PendingRequest, ignore
 	bestTTFTMs := 0.0
 	breakerRejected := 0
 	now := time.Now()
-	enforceTTFT := pr.MaxTTFTMs > 0
+	// Vision preparation is absent from the token-prefill projection, so media
+	// estimates are advisory even if a caller accidentally supplies a ceiling.
+	// The request-absolute first-content deadline remains authoritative.
+	enforceTTFT := pr.MaxTTFTMs > 0 && !pr.RequiresVision
 	for _, p := range r.providers {
 		owned := providerOwnedBy(p, pr.OwnerAccountID)
 		// Exclusive self-route: restrict to the caller's own machines and never

--- a/coordinator/registry/scheduler_test.go
+++ b/coordinator/registry/scheduler_test.go
@@ -423,6 +423,44 @@ func TestReserveProviderReturnsTTFTRejectionsWhenAllTooSlow(t *testing.T) {
 	}
 }
 
+func TestReserveProviderVisionIgnoresTextOnlyTTFTCeiling(t *testing.T) {
+	reg := New(testLogger())
+	model := "vision-ttft-projection-incomplete"
+	p := makeSchedulerProvider(t, reg, "vision-provider", model, 100)
+	p.mu.Lock()
+	p.PrefillTPS = 0.2
+	p.Models[0].IsVision = true
+	p.mu.Unlock()
+
+	text := &PendingRequest{
+		RequestID:             "text-hard-gated",
+		Model:                 model,
+		EstimatedPromptTokens: 100,
+		RequestedMaxTokens:    128,
+		MaxTTFTMs:             10_000,
+	}
+	if selected, decision := reg.ReserveProviderEx(model, text); selected != nil || decision.TTFTRejections != 1 {
+		t.Fatalf("text request selected=%v decision=%+v, want one TTFT rejection", selected, decision)
+	}
+
+	media := &PendingRequest{
+		RequestID:             "media-advisory-only",
+		Model:                 model,
+		EstimatedPromptTokens: 100,
+		RequestedMaxTokens:    128,
+		MaxTTFTMs:             10_000,
+		RequiresVision:        true,
+	}
+	selected, decision := reg.ReserveProviderEx(model, media)
+	if selected == nil {
+		t.Fatalf("vision request rejected by incomplete TTFT projection: %+v", decision)
+	}
+	if decision.TTFTRejections != 0 {
+		t.Fatalf("vision TTFTRejections = %d, want 0", decision.TTFTRejections)
+	}
+	selected.RemovePending(media.RequestID)
+}
+
 func TestReserveProviderHonorsAllowedProviderSerials(t *testing.T) {
 	reg := New(testLogger())
 	model := "targeted-model"

--- a/coordinator/registry/ttft_calibration_scheduler_test.go
+++ b/coordinator/registry/ttft_calibration_scheduler_test.go
@@ -189,3 +189,29 @@ func TestTTFTCalibrationSkipsColdPredictions(t *testing.T) {
 		t.Fatal("cold-slot prediction must not be joinable")
 	}
 }
+
+func TestTTFTCalibrationSkipsVisionPredictions(t *testing.T) {
+	resetCalibrator(t)
+	reg := New(testLogger())
+	model := "calib-vision-model"
+	p := calibrationTestProvider(t, reg, "vision-box", model, 100, 100)
+	p.mu.Lock()
+	p.Models[0].IsVision = true
+	p.mu.Unlock()
+
+	req := &PendingRequest{
+		RequestID:             "vision-req",
+		Model:                 model,
+		EstimatedPromptTokens: 200,
+		RequestedMaxTokens:    128,
+		RequiresVision:        true,
+	}
+	selected, decision := reg.ReserveProviderEx(model, req)
+	if selected == nil {
+		t.Fatalf("vision reserve failed: %+v", decision)
+	}
+	if _, ok := RecordTTFTObservation(req.RequestID, req.Attempt, 2_000); ok {
+		t.Fatal("vision prediction must not train the text-prefill calibrator")
+	}
+	selected.RemovePending(req.RequestID)
+}

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2VisionPrefill.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2VisionPrefill.swift
@@ -58,8 +58,9 @@
 //      at every `eval` site (not just on block exit — the handler records and
 //      RETURNS), so an MLX fault becomes a Swift throw the catch arms above
 //      already handle: one failed request, not one dead provider.
-//   2. The Qwen tower is driven ONE IMAGE AT A TIME and each image is admitted
-//      against `MTLDevice.maxBufferLength` first (`VisionTowerBudget`), so the
+//   2. The Qwen tower is driven ONE IMAGE AT A TIME and ONE VIDEO AT A TIME
+//      (full T×H×W grid) and each subject is admitted against
+//      `MTLDevice.maxBufferLength` first (`VisionTowerBudget`), so the
 //      dominant fault — the tower's N×N attention intermediate growing
 //      quadratically in the request's TOTAL patch count — is neither produced
 //      nor left for the allocator to discover. See `EngineV2VisionTowerRun`.
@@ -380,8 +381,10 @@ public enum EngineV2VisionPrefill {
             wrapper: wrapper, lmInput: lmInput, promptTokens: promptTokens)
     }
 
-    /// Qwen3-VL: causal visual tokens, M-RoPE position state, and a vision
-    /// tower driven ONE IMAGE AT A TIME (see `qwenPerImageVisionFeatures`).
+    /// Qwen3-VL: causal visual tokens, M-RoPE position state, a vision tower
+    /// driven ONE IMAGE AT A TIME and ONE VIDEO AT A TIME (the full T×H×W
+    /// grid — never one temporal frame; that would break temporal packing).
+    /// See `qwenPerImageVisionFeatures` / `qwenPerVideoVisionFeatures`.
     private static func buildQwenSubmission(
         wrapper: MLXVLM.Qwen35MoE,
         lmInput: LMInput,
@@ -389,48 +392,84 @@ public enum EngineV2VisionPrefill {
         towerLimits: VisionTowerBudget.Limits,
         mlxErrors: MLX.ErrorBox
     ) throws -> PreparedSubmission {
-        // Video remains fail-closed until a real processor/output
-        // representation canary pins temporal packing end-to-end.
-        guard lmInput.video == nil else {
-            throw EngineV2VisionPrefillError.unsupportedMedia(
-                "Qwen35MoE video media is not production-proven")
-        }
         // `noProcessedMedia` means "the processor consumed no media", which
         // maps to a deterministic 400. Pixels WITHOUT grids is a different
         // thing — the processor produced something the seam cannot describe —
         // and must keep its retriable refusal rather than tell the caller
         // their media was attached to the wrong role.
-        guard let image = lmInput.image else {
+        var imageFeatures: [MLXArray] = []
+        var imageGrids: [THW] = []
+        if let image = lmInput.image {
+            guard let grids = image.frames, !grids.isEmpty else {
+                throw EngineV2VisionPrefillError.emptyVisionFeatures(kind: .image)
+            }
+            imageGrids = grids
+            imageFeatures = try qwenPerImageVisionFeatures(
+                wrapper: wrapper, pixels: image.pixels, grids: grids,
+                towerLimits: towerLimits, mlxErrors: mlxErrors)
+        }
+
+        var videoFeatures: [MLXArray] = []
+        var videoGrids: [THW] = []
+        if let video = lmInput.video {
+            guard let grids = video.frames, !grids.isEmpty else {
+                throw EngineV2VisionPrefillError.emptyVisionFeatures(kind: .video)
+            }
+            videoGrids = grids
+            videoFeatures = try qwenPerVideoVisionFeatures(
+                wrapper: wrapper, pixels: video.pixels, grids: grids,
+                towerLimits: towerLimits, mlxErrors: mlxErrors)
+        }
+        guard !imageFeatures.isEmpty || !videoFeatures.isEmpty else {
             throw EngineV2VisionPrefillError.noProcessedMedia
         }
-        guard let grids = image.frames, !grids.isEmpty else {
-            throw EngineV2VisionPrefillError.emptyVisionFeatures(kind: .image)
-        }
-        let imageFeatures = try qwenPerImageVisionFeatures(
-            wrapper: wrapper, pixels: image.pixels, grids: grids,
-            towerLimits: towerLimits, mlxErrors: mlxErrors)
+
         let carved = try carveSpans(
             tokens: promptTokens,
-            imagePlaceholderId: wrapper.imagePlaceholderTokenId,
+            imagePlaceholderId: imageFeatures.isEmpty
+                ? nil : wrapper.imagePlaceholderTokenId,
             imageSpanLengths: imageFeatures.map { $0.dim(1) },
-            videoPlaceholderId: nil,
-            videoSpanLengths: [])
+            videoPlaceholderId: videoFeatures.isEmpty
+                ? nil : wrapper.videoPlaceholderTokenId,
+            videoSpanLengths: videoFeatures.map { $0.dim(1) })
+
+        // Pair prompt-ordered spans back to their features. Qwen packs each
+        // video as ONE contiguous `video_pad` run of T×spatial tokens;
+        // `carveSpans` splits that run into adjacent per-frame spans that
+        // match the temporal slices `visionFeatures` already returns.
+        var embeddings: [MLXArray] = []
+        embeddings.reserveCapacity(carved.count)
+        var imageCursor = 0
+        var videoCursor = 0
+        for entry in carved {
+            switch entry.kind {
+            case .image:
+                embeddings.append(imageFeatures[imageCursor])
+                imageCursor += 1
+            case .video:
+                embeddings.append(videoFeatures[videoCursor])
+                videoCursor += 1
+            }
+        }
+
         let position = try wrapper.positionResult(
             tokens: lmInput.text.tokens,
-            imageGrids: grids,
+            imageGrids: imageGrids.isEmpty ? nil : imageGrids,
+            videoGrids: videoGrids.isEmpty ? nil : videoGrids,
             attentionMask: lmInput.text.mask)
-        // The features are already materialized per image; only the position
-        // ids are still lazy here.
+        // Features are already materialized per image/video; only the
+        // position ids are still lazy here.
         eval(position.promptPositionIds)
         return PreparedSubmission(
             promptTokens: promptTokens,
             spans: carved.map(\.span),
-            embeddings: imageFeatures,
+            embeddings: embeddings,
             attention: .causal,
             positionState: CBv2PositionState(
                 promptPositionIds: position.promptPositionIds,
                 decodeDeltas: position.decodeState.deltas),
-            mediaKind: .image)
+            mediaKind: lmInput.video == nil
+                ? .image : (lmInput.image == nil ? .video : .mixed))
     }
 
     /// Gemma 4: bidirectional span masks, no position state, and a SigLIP

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2VisionPrefill.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2VisionPrefill.swift
@@ -732,10 +732,9 @@ public enum EngineV2VisionPrefill {
     /// `EngineV2VisionPrefillError` (content-safe by construction — see the
     /// enum doc). Foreign throws (processor/MLX/media errors) carry
     /// `error_class` only: `MediaError.invalidURL`, for one, embeds up to
-    /// 200 chars of the request's URI, and relying on call-site ordering
-    /// (validateMedia running first) to keep such strings out of telemetry
-    /// would be one refactor away from a leak — the same defense-in-depth
-    /// stance as the bridge's engine-error telemetry.
+    /// 200 chars of the request's URI. The same throw now comes directly from
+    /// this preparer's single decode pass, so filtering by class is the
+    /// privacy boundary rather than call-site ordering.
     static func refusalTelemetryEvent(
         modelId: String, mediaKind: EngineV2MediaKind, error: Error
     ) -> TelemetryEvent {

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2VisionTowerRun.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2VisionTowerRun.swift
@@ -23,15 +23,18 @@
 //     limit, MLX's default error handler called `fatalError`, and the daemon
 //     died with every co-batched request on it.
 //
-// So the Qwen path here drives the tower ONE IMAGE AT A TIME and evaluates
-// each image's features before starting the next. Attention is block-diagonal
-// per image already, and every other stage of the tower (patch embed,
-// positional interpolation, rotary coordinates, layer norms, patch merge) is
-// per-token or per-grid, so a per-image call is MATHEMATICALLY equivalent to
-// the batched one — it only refuses to build the cross-image half of the
-// mask, which was always zeros doing nothing. (Bitwise equality is not
-// guaranteed: SDPA's reduction shape changes with N, so float reduction order
-// can differ.) Peak attention bytes go from `(Σᵢ nᵢ)²` to `maxᵢ nᵢ²`.
+// So the Qwen path here drives the tower ONE IMAGE AT A TIME (and ONE VIDEO
+// AT A TIME — the full T×H×W grid, never one temporal frame) and evaluates
+// each subject's features before starting the next. Attention is
+// block-diagonal per image already, and every other stage of the tower
+// (patch embed, positional interpolation, rotary coordinates, layer norms,
+// patch merge) is per-token or per-grid, so a per-image call is
+// MATHEMATICALLY equivalent to the batched one — it only refuses to build
+// the cross-image half of the mask, which was always zeros doing nothing.
+// (Bitwise equality is not guaranteed: SDPA's reduction shape changes with
+// N, so float reduction order can differ.) Peak attention bytes go from
+// `(Σᵢ nᵢ)²` to `maxᵢ nᵢ²`. Video must stay one tower call per clip:
+// splitting frames first drops temporal packing.
 //
 // Each image is also checked for MLX faults immediately after its `eval`.
 // `MLX.withError`'s handler RECORDS and RETURNS — the C++ op yields a
@@ -149,8 +152,64 @@ extension EngineV2VisionPrefill {
         return features
     }
 
+    /// One `[1, softTokens, textHidden]` embedding per sampled video frame,
+    /// produced by driving the Qwen3-VL tower once per VIDEO (the full T×H×W
+    /// grid). Splitting a clip into temporal frames BEFORE the tower would
+    /// drop `temporalPatchSize` packing and disagree with `positionResult`,
+    /// which treats each video as one visual-token run of T×spatial tokens.
+    ///
+    /// The seam then splits that one tower output into T frame embeddings;
+    /// `carveSpans` carves the matching adjacent spans out of the single
+    /// contiguous `<|video_pad|>` run the processor emitted.
+    static func qwenPerVideoVisionFeatures(
+        wrapper: MLXVLM.Qwen35MoE,
+        pixels: MLXArray,
+        grids: [THW],
+        towerLimits: VisionTowerBudget.Limits,
+        mlxErrors: MLX.ErrorBox
+    ) throws -> [MLXArray] {
+        guard !grids.isEmpty else {
+            throw EngineV2VisionPrefillError.emptyVisionFeatures(kind: .video)
+        }
+        let runs = try imagePixelRuns(grids: grids, totalRows: pixels.dim(0))
+        let limits = towerLimits.withHeadFactor(qwenAttentionHeadFactor(wrapper))
+
+        var features: [MLXArray] = []
+        features.reserveCapacity(grids.reduce(0) { $0 + max(0, $1.t) })
+        for (index, grid) in grids.enumerated() {
+            switch VisionTowerBudget.admit(
+                grids: [grid],
+                subject: Self.videoSubject(index: index, of: grids.count),
+                limits: limits)
+            {
+            case .admit:
+                break
+            case .reject(let reason):
+                throw EngineV2VisionPrefillError.towerBudgetExceeded(reason)
+            }
+
+            let single = try wrapper.visionFeatures(
+                videoPixels: pixels[runs[index], 0...], videoGrids: [grid])
+            guard single.ordered.count == grid.t, grid.t > 0 else {
+                throw EngineV2VisionPrefillError.emptyVisionFeatures(kind: .video)
+            }
+            for item in single.ordered {
+                let embedding = item.features
+                eval(embedding)
+                try EngineV2VisionPrefill.throwIfMLXFaulted(mlxErrors)
+                features.append(embedding)
+            }
+        }
+        return features
+    }
+
     /// Content-free subject for a rejection message ("image 2 of 5").
     static func imageSubject(index: Int, of count: Int) -> String {
         count == 1 ? "this image" : "image \(index + 1) of \(count)"
+    }
+
+    /// Content-free subject for a rejection message ("video 2 of 3").
+    static func videoSubject(index: Int, of count: Int) -> String {
+        count == 1 ? "this video" : "video \(index + 1) of \(count)"
     }
 }

--- a/provider-swift/Sources/ProviderCore/Inference/MediaIngest.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/MediaIngest.swift
@@ -18,6 +18,7 @@
 // → 4xx).
 
 import AVFoundation
+import CoreGraphics
 import CoreImage
 import Foundation
 import ImageIO
@@ -298,7 +299,7 @@ public enum MediaIngest {
         return UserInput(
             chat: chatMessages,
             additionalContext: MultiModelBatchSchedulerEngine.templateAdditionalContext(
-                for: request, reasoningEffort: reasoningEffort))
+                for: request, reasoningEffort: reasoningEffort, hasMedia: true))
     }
 
 
@@ -672,7 +673,27 @@ public enum MediaIngest {
             throw MediaError.mediaTooLarge(
                 "image is \(pixels) px; per-image cap is \(maxImagePixels) px")
         }
-        guard let image = CIImage(data: data) else {
+        // Full image at index 0 (never the EXIF thumbnail) with the file's
+        // orientation applied. `CIImage(data:)` skips EXIF rotation and can
+        // surface a JPEG thumbnail — both turn a real photograph into
+        // abstract pixels the model then confidently misdescribes.
+        let image: CIImage
+        if let src = CGImageSourceCreateWithData(
+            data as CFData, [kCGImageSourceShouldCache: true] as CFDictionary),
+            let cgImage = CGImageSourceCreateImageAtIndex(
+                src, 0, [kCGImageSourceShouldCache: true] as CFDictionary)
+        {
+            var decoded = CIImage(cgImage: cgImage)
+            if let props = CGImageSourceCopyPropertiesAtIndex(src, 0, nil) as? [CFString: Any],
+                let raw = props[kCGImagePropertyOrientation] as? UInt32,
+                let orientation = CGImagePropertyOrientation(rawValue: raw)
+            {
+                decoded = decoded.oriented(orientation)
+            }
+            image = normalizedExtent(decoded)
+        } else if let decoded = CIImage(data: data, options: [.applyOrientationProperty: true]) {
+            image = normalizedExtent(decoded)
+        } else {
             throw MediaError.imageDecodeFailed
         }
         // Backstop: if ImageIO couldn't size the header (imagePixelCount nil) but
@@ -684,6 +705,16 @@ public enum MediaIngest {
                 "image extent is \(extentPixels) px; per-image cap is \(maxImagePixels) px")
         }
         return .ciImage(image)
+    }
+
+    /// `oriented()` (and some ImageIO decodes) can leave a non-zero origin.
+    /// The Qwen processor sizes from `extent.size` but `asMLXArray` renders
+    /// `extent`; a shifted origin is a silent crop/empty-raster class of bugs.
+    private static func normalizedExtent(_ image: CIImage) -> CIImage {
+        let origin = image.extent.origin
+        guard origin != .zero else { return image }
+        return image.transformed(
+            by: CGAffineTransform(translationX: -origin.x, y: -origin.y))
     }
 
     /// Decode an inline MP4 or QuickTime video into an owned memory-backed `AVURLAsset`. The

--- a/provider-swift/Sources/ProviderCore/Inference/MediaIngest.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/MediaIngest.swift
@@ -5,8 +5,7 @@
 // Everything between an OpenAI request's inline `data:` media parts and a
 // model-ready `UserInput`: decode (CIImage / memory-backed AVFoundation assets),
 // decompression-bomb caps (per-image + per-request pixels, byte/second/
-// count limits), up-front validation (`validateMedia` — throws the 4xx
-// before any stream starts), memory projections for the vision gate
+// count limits), memory projections for the vision gate
 // (`projectedDecodeBytes` / `projectedKVTokens`), and media classification
 // (`hasMedia` / `hasVideo`).
 //
@@ -223,37 +222,6 @@ public enum MediaIngest {
         let maxOutput = max(0, resolveMaxOutputTokens(for: request, defaultMaxTokens: defaultMaxTokens))
         let (total, overflow) = promptTokens.addingReportingOverflow(maxOutput)
         return overflow ? Int.max : total
-    }
-
-    // MARK: - Up-front validation
-
-    /// Validate all inline media for a request UP FRONT, throwing `MediaError`
-    /// synchronously on any oversized/malformed/non-`data:` payload (or video-cap
-    /// violation). Callers MUST call this (and propagate the throw) BEFORE
-    /// returning a streaming response, so the correct 4xx is surfaced instead of
-    /// a 200 SSE body that only errors mid-iteration.
-    ///
-    /// This runs the decode path (`buildUserInput`) purely for its throwing
-    /// side-effects and discards the result. Inline-video bytes remain in the
-    /// returned input's owned memory-backed assets and are released with it;
-    /// they are never materialized on disk. The decode work is bounded by the
-    /// very caps it enforces (≤ per-image / aggregate pixels, ≤ byte cap), so
-    /// the up-front pass can't itself be a DoS, and the eventual rebuild in
-    /// the v2 media prefill re-validates identically.
-    public static func validateMedia(
-        _ request: OpenAIChatCompletionRequest,
-        maxImagePixels: Int = Self.maxImagePixels,
-        maxRequestImagePixels: Int = Self.maxRequestImagePixels,
-        maxImagesPerRequest: Int = Self.maxImagesPerRequest,
-        maxVideosPerRequest: Int = Self.maxVideosPerRequest,
-        maxRequestVideoFramePixels: Int = Self.maxRequestVideoFramePixels
-    ) async throws {
-        _ = try await buildUserInput(
-            from: request, maxImagePixels: maxImagePixels,
-            maxRequestImagePixels: maxRequestImagePixels,
-            maxImagesPerRequest: maxImagesPerRequest,
-            maxVideosPerRequest: maxVideosPerRequest,
-            maxRequestVideoFramePixels: maxRequestVideoFramePixels)
     }
 
     // MARK: - UserInput construction
@@ -543,14 +511,14 @@ public enum MediaIngest {
     /// HEADER pixel counts (no decode); when a header is unreadable the per-image
     /// cap is used as the worst case the media caps still admit.
     ///
-    /// The estimate is clamped to the SAME ceilings `validateMedia` enforces, so
+    /// The estimate is clamped to the SAME ceilings `buildUserInput` enforces, so
     /// it can never exceed what a maximally-large *valid* request consumes:
     ///   • image pixels are summed but clamped to the aggregate image cap
     ///     (`maxRequestImagePixels`) — a single oversized image, or many
     ///     unreadable-header images, can't project past the request-wide image
     ///     ceiling validation guarantees;
     ///   • videos are charged the aggregate per-request video-frame cap ONCE if
-    ///     any video is present — NOT per video. `validateMedia` bounds the SUM
+    ///     any video is present — NOT per video. `buildUserInput` bounds the SUM
     ///     of all videos' frame pixels by `maxRequestVideoFramePixels`, so
     ///     charging it per-video would over-reserve by the video count and could
     ///     falsely 503 a valid multi-video request.
@@ -591,7 +559,7 @@ public enum MediaIngest {
             }
         }
         // Clamp images to the request-wide aggregate cap, then add the video
-        // aggregate once. Both mirror validateMedia's ceilings exactly.
+        // aggregate once. Both mirror buildUserInput's ceilings exactly.
         var pixels = min(imagePixels, UInt64(max(0, maxRequestImagePixels)))
         if hasVideo {
             let (s, o) = pixels.addingReportingOverflow(UInt64(max(0, maxRequestVideoFramePixels)))

--- a/provider-swift/Sources/ProviderCore/Inference/MultiModelBatchSchedulerEngine+Translation.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/MultiModelBatchSchedulerEngine+Translation.swift
@@ -17,7 +17,8 @@ extension MultiModelBatchSchedulerEngine {
     static func templateAdditionalContext(
         for request: OpenAIChatCompletionRequest,
         reasoningEffort: String?,
-        modelType: String? = nil
+        modelType: String? = nil,
+        hasMedia: Bool = false
     ) -> [String: any Sendable]? {
         var context: [String: any Sendable] = [:]
         let fixContext = ChatTemplateFixContext(
@@ -31,6 +32,13 @@ extension MultiModelBatchSchedulerEngine {
         }
         if let reasoningEnabled = request.reasoning?.enabled {
             context["enable_thinking"] = reasoningEnabled
+        } else if hasMedia {
+            // Qwen 3.5/3.6 templates default thinking ON when this key is
+            // absent. A long ungrounded think block both misses vision
+            // captions (OpenRouter flower regex) and burns the first-content
+            // clock on video. Clients that want thinking send
+            // `reasoning.enabled`.
+            context["enable_thinking"] = false
         }
         return context.isEmpty ? nil : context
     }

--- a/provider-swift/Sources/ProviderCore/Inference/MultiModelBatchSchedulerEngine.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/MultiModelBatchSchedulerEngine.swift
@@ -295,13 +295,11 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
                 throw MultiModelBatchSchedulerEngineError.invalidToolPayload(
                     "inference-enforced tool_choice is not supported for multimodal requests")
             }
-            // Decode + validate inline media SYNCHRONOUSLY, before returning the
-            // stream. A MediaError (oversized/malformed/non-`data:` payload) thrown
-            // here propagates through this `async throws` to the caller — so both
-            // the buffered (non-streaming) and the SSE (streaming) HTTP paths, and
-            // the coordinator WebSocket path, surface the correct 4xx instead of a
-            // 200 with a truncated/error stream body. (Deferring the decode into
-            // the generation task would let the HTTP layer commit a 200 first.)
+            // Media is decoded exactly once by EngineV2VisionPrefill.prepare
+            // below, still synchronously inside this async-throws call before
+            // any stream is returned. Its MediaError therefore keeps the same
+            // clean pre-header 4xx contract without paying a second AVFoundation
+            // decode on the first-content critical path.
             // Reserve this vision request's unified memory against the 90% cap
             // BEFORE rasterizing. The vision path bypasses the batched
             // `submitTokenized` reservation, so it commits two kinds of memory the
@@ -352,18 +350,6 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
                     "insufficient global kv cache headroom for vision request "
                     + "(media decode ~\(mib) MiB + generation KV) — retry after capacity frees")
             }
-            let mediaValidationRequest = visionRequest
-            do {
-                try await raceFirstContentDeadline {
-                    try await MediaIngest.validateMedia(mediaValidationRequest)
-                }
-                try checkFirstContentDeadline()
-            } catch {
-                await mediaGate.release(requestId: mediaReqId)
-                await releaseBox.fire()
-                throw error
-            }
-
             // MEDIA → ENGINE V2: image, video, and mixed requests use the
             // wrapper's vision tower/projector, then prefill its same owned
             // text tower through CBv2. Per-image / per-video-frame embeddings
@@ -475,11 +461,10 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
                     await releaseBox.fire()
                     throw CancellationError()
                 } catch let mediaError as MediaIngest.MediaError {
-                    // Deterministic input fault (malformed/oversized media —
-                    // the same class `validateMedia` rejects above). Fails
-                    // identically on any provider, so it keeps its existing
-                    // 4xx mapping instead of becoming a misleading retriable
-                    // refusal.
+                    // Deterministic input fault from the preparer's single
+                    // decode pass. It fails identically on any provider, so it
+                    // keeps its 4xx mapping instead of becoming a misleading
+                    // retriable refusal.
                     await mediaGate.release(requestId: mediaReqId)
                     await releaseBox.fire()
                     throw mediaError
@@ -735,15 +720,6 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
             await releaseBox.fire()
             throw error
         }
-    }
-
-    private func raceFirstContentDeadline<T: Sendable>(
-        _ operation: @escaping @Sendable () async throws -> T
-    ) async throws -> T {
-        guard let firstContentDeadline else {
-            return try await operation()
-        }
-        return try await firstContentDeadline.race(operation)
     }
 
     /// Build the outer event stream only while the absolute pre-content

--- a/provider-swift/Tests/ProviderCoreTests/EngineV2VisionRoutingTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/EngineV2VisionRoutingTests.swift
@@ -31,7 +31,7 @@ import Testing
 @testable import ProviderCore
 
 // A real, round-trip-verified 1x1 PNG (red pixel) — same fixture as
-// MediaIngestTests; passes `validateMedia`'s real decode.
+// MediaIngestTests.
 private let tinyPNGDataURI =
     "data:image/png;base64,"
     + "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAAAXNSR0IArs4c6QAAAERl"
@@ -40,9 +40,7 @@ private let tinyPNGDataURI =
     + "AElFTkSuQmCC"
 
 // A real, round-trip-verified 64x64 H.264 mp4 (3 solid-gray frames) — same
-// fixture as MediaIngestTests; passes `validateMedia`'s real
-// AVFoundation metadata probe, so video-bearing requests reach the v2
-// routing branch in these tests.
+// fixture as MediaIngestTests.
 private let tinyMP4DataURI =
     "data:video/mp4;base64,"
     + "AAAAHGZ0eXBtcDQyAAAAAWlzb21tcDQxbXA0MgAAAAFtZGF0AAAAAAAAAK4AAAA7BgUyR1ZK3FxMQz+U78URPNFDqAEAAAMAAQMAAAMAAQIAAeYACwAAAwAA"
@@ -1138,7 +1136,6 @@ struct EngineV2VisionRoutingTests {
             container: makeStubContainer(),
             bridge: bridge, plumbing: plumbing)
 
-        // Real tinyMP4 so validateMedia passes and the preparer is reached.
         let request = imageRequest(parts: [
             .text("what happens in this clip?"), .videoURL(tinyMP4DataURI),
         ])
@@ -1216,9 +1213,8 @@ struct EngineV2VisionRoutingTests {
             container: makeStubContainer(),
             bridge: bridge, plumbing: plumbing)
 
-        // The real tinyMP4 passes `validateMedia`'s AVFoundation probe, so
-        // the request reaches the v2 branch (a pre-release draft gated video to legacy
-        // here; v0.7.5 routes it through the engine).
+        // A pre-release draft gated video to legacy here; v0.7.5 routes it
+        // through the engine.
         let request = imageRequest(parts: [
             .text("what happens in this clip?"), .videoURL(tinyMP4DataURI),
         ])
@@ -1240,14 +1236,15 @@ struct EngineV2VisionRoutingTests {
         #expect(visionEvents.first?.fields?["media_kind"]?.description == "video")
     }
 
-    @Test("garbage inline video still dies in validateMedia (4xx) before the preparer")
-    func garbageVideoRejectedBeforePreparer() async throws {
+    @Test("MediaError from the single v2 preparer remains a pre-stream 4xx")
+    func garbageVideoRejectedByPreparer() async throws {
         let engine = VisionScriptedEngine(script: .stream([]))
         let bridge = makeBridge(engine: engine)
         let counter = PrepareCallCounter()
         let plumbing = EngineV2VisionPlumbing(
-            prepare: { _, _, _ in
+            prepare: { _, request, _ in
                 counter.increment()
+                _ = try await MediaIngest.buildUserInput(from: request)
                 throw VisionStubProcessorError()
             },
             emitTelemetry: { _ in }
@@ -1255,9 +1252,9 @@ struct EngineV2VisionRoutingTests {
         let router = makeRoutingEngine(
             container: makeStubContainer(),
             bridge: bridge, plumbing: plumbing)
-        // The garbage inline video dies in `validateMedia` (a 400-class
-        // MediaError) BEFORE the v2 attempt — the preparer must not fire
-        // and the engine must stay untouched.
+        // The production preparer owns decode and model preparation in one
+        // pass. Its MediaError must escape this async-throws call before a
+        // stream is returned, and the engine must stay untouched.
         let request = imageRequest(parts: [
             .imageURL(tinyPNGDataURI), .videoURL("data:video/mp4;base64,AAAA"),
         ])
@@ -1270,7 +1267,7 @@ struct EngineV2VisionRoutingTests {
         } catch {
             Issue.record("expected MediaError, got \(error)")
         }
-        #expect(counter.count == 0)
+        #expect(counter.count == 1)
         #expect(engine.submitted.isEmpty)
     }
 

--- a/provider-swift/Tests/ProviderCoreTests/EngineV2VisionRoutingTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/EngineV2VisionRoutingTests.swift
@@ -478,6 +478,23 @@ struct EngineV2VisionSpanCarvingTests {
         }
     }
 
+    @Test("Qwen video: one contiguous video_pad run splits into adjacent frame spans")
+    func qwenContiguousVideoRun() throws {
+        // Qwen emits ONE run of T × spatial `video_pad` tokens. Two frames of
+        // 3 spatial tokens each is 6 adjacent pads — not Gemma's per-frame
+        // blocks with timestamps between them.
+        let tokens = [1, v, v, v, v, v, v, 9]
+        let carved = try EngineV2VisionPrefill.carveSpans(
+            tokens: tokens, imagePlaceholderId: nil, imageSpanLengths: [],
+            videoPlaceholderId: v, videoSpanLengths: [3, 3])
+        #expect(carved == [
+            EngineV2VisionPrefill.CarvedSpan(
+                kind: .video, span: CBv2ImageSpan(tokenOffset: 1, length: 3)),
+            EngineV2VisionPrefill.CarvedSpan(
+                kind: .video, span: CBv2ImageSpan(tokenOffset: 4, length: 3)),
+        ])
+    }
+
     @Test("a disabled kind's id is an ordinary token (mirrors the processor)")
     func disabledKindIgnored() throws {
         // No video features ⇒ the video id is not watched: a stray 991 in
@@ -504,6 +521,20 @@ struct MediaKindClassificationTests {
             let input = try await MediaIngest.buildUserInput(from: request)
             #expect(input.additionalContext?["enable_thinking"] as? Bool == enabled)
         }
+    }
+
+    @Test("media requests default thinking off unless the client asks")
+    func mediaDefaultsThinkingOff() async throws {
+        let request = imageRequest()
+        let input = try await MediaIngest.buildUserInput(from: request)
+        #expect(input.additionalContext?["enable_thinking"] as? Bool == false)
+
+        let text = MultiModelBatchSchedulerEngine.templateAdditionalContext(
+            for: OpenAIChatCompletionRequest(
+                model: "qwen3.5-35b-a3b",
+                messages: [.init(role: .user, content: .text("hi"))]),
+            reasoningEffort: nil)
+        #expect(text?["enable_thinking"] == nil)
     }
 
     @Test("media processor preserves out-of-band reasoning effort")
@@ -1032,7 +1063,7 @@ struct EngineV2VisionRoutingTests {
             })
     }
 
-    @Test("unsupported Qwen video maps to deterministic 400 without refusal telemetry")
+    @Test("injected unsupportedMedia maps to deterministic 400 without refusal telemetry")
     func unsupportedVideoMapsTo400() async throws {
         let engine = VisionScriptedEngine(script: .stream([]))
         let bridge = makeBridge(engine: engine)

--- a/provider-swift/Tests/ProviderCoreTests/GemmaVLMVideoEngineV2LiveTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/GemmaVLMVideoEngineV2LiveTests.swift
@@ -81,7 +81,7 @@ private struct VideoFixtureError: Error, CustomStringConvertible {
 /// ends at colors.count/fps, so a 4-frame 32 fps clip is 0.125 s (the
 /// Gemma4 sampler — `round(32/max(duration,1) × duration)` — then samples
 /// ~4 frames) and a 40-frame 1 fps clip is 40 s (sampled at the 32 cap).
-private func makeSolidColorClip(
+func makeSolidColorClip(
     colors: [(r: UInt8, g: UInt8, b: UInt8)],
     fps: Int32,
     width: Int = 128,
@@ -162,7 +162,7 @@ private func makeSolidColorClip(
     return try Data(contentsOf: url)
 }
 
-private func dataURI(forMP4 data: Data) -> String {
+func dataURI(forMP4 data: Data) -> String {
     "data:video/mp4;base64," + data.base64EncodedString()
 }
 

--- a/provider-swift/Tests/ProviderCoreTests/MediaIngestTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/MediaIngestTests.swift
@@ -1,4 +1,5 @@
 import AVFoundation
+import CoreGraphics
 import CoreImage
 import Foundation
 import ImageIO
@@ -149,6 +150,45 @@ func vlmDecodeImageGarbageThrows() {
     #expect(throws: MediaIngest.MediaError.self) {
         _ = try MediaIngest.decodeImage(garbage)
     }
+}
+
+@Test("decodeImageData applies EXIF orientation so the raster matches what the camera saw")
+func decodeImageAppliesExifOrientation() throws {
+    // 2×1: left red, right green. Orientation .right (EXIF 6) rotates 90° CW
+    // → 1×2 with red on top. Without applyOrientationProperty the model sees
+    // a sideways crop and hallucinates a different scene.
+    let colorSpace = CGColorSpaceCreateDeviceRGB()
+    var pixels: [UInt8] = [
+        255, 0, 0, 255,
+        0, 255, 0, 255,
+    ]
+    let provider = try #require(CGDataProvider(data: Data(pixels) as CFData))
+    let cgImage = try #require(
+        CGImage(
+            width: 2, height: 1,
+            bitsPerComponent: 8, bitsPerPixel: 32, bytesPerRow: 8,
+            space: colorSpace,
+            bitmapInfo: CGBitmapInfo(rawValue: CGImageAlphaInfo.premultipliedLast.rawValue),
+            provider: provider, decode: nil, shouldInterpolate: false,
+            intent: .defaultIntent))
+
+    let destData = NSMutableData()
+    let dest = try #require(
+        CGImageDestinationCreateWithData(
+            destData, UTType.jpeg.identifier as CFString, 1, nil))
+    CGImageDestinationAddImage(
+        dest, cgImage,
+        [kCGImagePropertyOrientation: CGImagePropertyOrientation.right.rawValue] as CFDictionary)
+    #expect(CGImageDestinationFinalize(dest))
+
+    let decoded = try MediaIngest.decodeImageData(destData as Data)
+    guard case .ciImage(let image) = decoded else {
+        Issue.record("expected .ciImage, got \(decoded)")
+        return
+    }
+    #expect(Int(image.extent.width.rounded()) == 1)
+    #expect(Int(image.extent.height.rounded()) == 2)
+    #expect(image.extent.origin == .zero)
 }
 
 // MARK: - decodeVideo

--- a/provider-swift/Tests/ProviderCoreTests/Qwen36ProductionCanaryTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/Qwen36ProductionCanaryTests.swift
@@ -53,12 +53,14 @@ struct Qwen36ProductionCanaryTests {
             let elapsed = startedAt.duration(to: .now)
             print("QWEN_VIDEO_CANARY request_elapsed=\(elapsed)")
 
+            let firstContentLatency = try #require(result.firstContentLatency)
+            #expect(firstContentLatency < .seconds(11))
             let groundedColors = result.text.lowercased()
                 .split(whereSeparator: { !$0.isLetter })
                 .map(String.init)
             #expect(groundedColors == ["red", "blue"])
             #expect(probe.preparedCount == 1)
-            #expect((1 ... Qwen3VLProcessor.maxVideoFrames).contains(probe.lastSpanCount))
+            #expect(probe.lastSpanCount == Qwen3VLProcessor.maxVideoFrames / 2)
             #expect(probe.refusalCount == 0)
             #expect(result.info?.completionTokens ?? 0 > 0)
             #expect(await fixture.kvBudget.outstandingReservedBytes() == 0)
@@ -366,11 +368,15 @@ private enum Qwen36ProductionCanary {
         _ engine: MultiModelBatchSchedulerEngine,
         request: OpenAIChatCompletionRequest
     ) async throws -> Qwen36ProductionCanaryServerResult {
+        let startedAt = ContinuousClock.now
         let stream = try await engine.streamChatCompletion(request: request)
         var result = Qwen36ProductionCanaryServerResult()
         for try await event in stream {
             switch event {
             case .content(let text):
+                if result.firstContentLatency == nil, !text.isEmpty {
+                    result.firstContentLatency = startedAt.duration(to: .now)
+                }
                 result.text += text
             case .toolCall(let call):
                 result.toolCalls.append(call)
@@ -624,7 +630,6 @@ private struct Qwen36ProductionCanaryFixture: @unchecked Sendable {
                             + "Reply with only the two lowercase color names."),
                     .videoURL(uri),
                 ]))],
-            reasoning: .init(enabled: false),
             temperature: 0,
             topP: 1,
             topK: 0,
@@ -755,6 +760,7 @@ private struct Qwen36ProductionCanaryServerResult {
     var text = ""
     var toolCalls: [ToolCall] = []
     var info: ServerGenerationInfo?
+    var firstContentLatency: Duration?
 }
 
 private struct Qwen36ProductionCanaryCancellationResult {

--- a/provider-swift/Tests/ProviderCoreTests/Qwen36ProductionCanaryTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/Qwen36ProductionCanaryTests.swift
@@ -4,12 +4,71 @@ import Foundation
 import MLX
 import MLXLMCommon
 import MLXLMServer
+import MLXVLM
 import Testing
 
 @testable import ProviderCore
 
 @Suite("Qwen3.6 production artifact canary", .serialized)
 struct Qwen36ProductionCanaryTests {
+    @Test(
+        "720p inline video serves through EngineV2 inside the 11-second clock",
+        .enabled(
+            if: Qwen36ProductionCanary.enabled,
+            "set DARKBLOOM_LIVE_MLX_TESTS=1 and DARKBLOOM_LIVE_MLX_QWEN36=1 to run the local real-artifact Qwen video canary")
+    )
+    func videoServesInsideFirstContentClock() async throws {
+        let fixture = try await Qwen36ProductionCanary.load()
+        let colors: [(r: UInt8, g: UInt8, b: UInt8)] = [
+            (255, 0, 0), (255, 0, 0), (255, 0, 0), (255, 0, 0), (255, 0, 0),
+            (0, 0, 255), (0, 0, 255), (0, 0, 255), (0, 0, 255), (0, 0, 255),
+        ]
+        let clip = try await makeSolidColorClip(
+            colors: colors, fps: 2, width: 1280, height: 720)
+        let bundle = try await fixture.makeBundle(
+            preparation: .init(
+                artifact: nil,
+                status: .disabled(.configDisabled, configured: false)))
+        do {
+            let probe = Qwen36ProductionCanaryVisionProbe()
+            let scheduler = fixture.scheduler(
+                bundle: bundle,
+                vision: EngineV2VisionPlumbing(
+                    prepare: { container, request, reasoningEffort in
+                        let prepared = try await EngineV2VisionPrefill.prepare(
+                            container: container,
+                            request: request,
+                            reasoningEffort: reasoningEffort)
+                        probe.recordPrepared(spanCount: prepared.spans.count)
+                        return prepared
+                    },
+                    emitTelemetry: { _ in probe.recordRefusal() }),
+                firstContentDeadline: FirstContentDeadline(
+                    relativeBudgetMilliseconds: 11_000))
+
+            let startedAt = ContinuousClock.now
+            let result = try await Qwen36ProductionCanary.collect(
+                scheduler,
+                request: fixture.videoRequest(dataURI(forMP4: clip)))
+            let elapsed = startedAt.duration(to: .now)
+            print("QWEN_VIDEO_CANARY request_elapsed=\(elapsed)")
+
+            let groundedColors = result.text.lowercased()
+                .split(whereSeparator: { !$0.isLetter })
+                .map(String.init)
+            #expect(groundedColors == ["red", "blue"])
+            #expect(probe.preparedCount == 1)
+            #expect((1 ... Qwen3VLProcessor.maxVideoFrames).contains(probe.lastSpanCount))
+            #expect(probe.refusalCount == 0)
+            #expect(result.info?.completionTokens ?? 0 > 0)
+            #expect(await fixture.kvBudget.outstandingReservedBytes() == 0)
+        } catch {
+            await Qwen36ProductionCanary.retire(bundle)
+            throw error
+        }
+        await Qwen36ProductionCanary.retire(bundle)
+    }
+
     @Test(
         "combined VLM and inline MTP serve through the production bundle",
         .enabled(
@@ -299,7 +358,8 @@ private enum Qwen36ProductionCanary {
             imageURL: imageURL,
             container: container,
             targetSizing: sizing,
-            tokenizer: tokenizer)
+            tokenizer: tokenizer,
+            kvBudget: GlobalKVCacheBudget())
     }
 
     static func collect(
@@ -432,6 +492,7 @@ private struct Qwen36ProductionCanaryFixture: @unchecked Sendable {
     let container: ModelContainer
     let targetSizing: SlotSizingSnapshot
     let tokenizer: TokenizerHandle
+    let kvBudget: GlobalKVCacheBudget
 
     func makeBundle(preparation: SpecDecPreparation) async throws -> ProviderEngineBundle {
         let prepared = try await EngineV2SlotFactory.prepareProductionModel(
@@ -458,7 +519,7 @@ private struct Qwen36ProductionCanaryFixture: @unchecked Sendable {
                 sizing: sizing,
                 kvBytesCapacity: grant,
                 maxConcurrentRequests: 2,
-                kvBudget: nil,
+                kvBudget: kvBudget,
                 specDecPreparation: preparation,
                 preparedModel: prepared,
                 environment: [
@@ -493,18 +554,24 @@ private struct Qwen36ProductionCanaryFixture: @unchecked Sendable {
 
     func scheduler(
         bundle: ProviderEngineBundle,
-        vision: EngineV2VisionPlumbing? = nil
+        vision: EngineV2VisionPlumbing? = nil,
+        firstContentDeadline: FirstContentDeadline? = nil
     ) -> MultiModelBatchSchedulerEngine {
         let entry = MultiModelBatchSchedulerEngine.ModelRegistryEntry(
             tokenizer: tokenizer,
             modelType: Qwen36ProductionCanary.modelType,
             container: container,
             isVLM: true,
-            engineV2Bridge: bundle.bridge)
+            engineV2Bridge: bundle.bridge,
+            visionGate: VisionMemoryGate(
+                kvBudget: kvBudget,
+                fp16KVBytesPerToken: targetSizing.fp16KVBytesPerToken,
+                contextLength: targetSizing.maxContextLength))
         return MultiModelBatchSchedulerEngine(
             registryProvider: { [entry] in [Qwen36ProductionCanary.modelID: entry] },
             defaultMaxTokens: 512,
-            engineV2Vision: vision)
+            engineV2Vision: vision,
+            firstContentDeadline: firstContentDeadline)
     }
 
     func textRequest() -> OpenAIChatCompletionRequest {
@@ -544,6 +611,25 @@ private struct Qwen36ProductionCanaryFixture: @unchecked Sendable {
             topK: 0,
             minP: 0,
             maxTokens: 128)
+    }
+
+    func videoRequest(_ uri: String) -> OpenAIChatCompletionRequest {
+        OpenAIChatCompletionRequest(
+            model: Qwen36ProductionCanary.modelID,
+            messages: [.init(
+                role: .user,
+                content: .parts([
+                    .text(
+                        "Name the two solid colors shown in order. "
+                            + "Reply with only the two lowercase color names."),
+                    .videoURL(uri),
+                ]))],
+            reasoning: .init(enabled: false),
+            temperature: 0,
+            topP: 1,
+            topK: 0,
+            minP: 0,
+            maxTokens: 32)
     }
 
     func toolRequest() -> OpenAIChatCompletionRequest {

--- a/provider-swift/Tests/ProviderCoreTests/VLMCapReservationTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/VLMCapReservationTests.swift
@@ -49,7 +49,7 @@ private let gib: UInt64 = 1024 * 1024 * 1024
 @Test func projectedDecodeBytesClampsImageSumToAggregateCap() {
     // Many unreadable-header images each charge the per-image cap; without the
     // aggregate clamp the sum would blow past the request-wide image ceiling
-    // validateMedia enforces. The projection must clamp to maxRequestImagePixels.
+    // buildUserInput enforces. The projection must clamp to maxRequestImagePixels.
     let uri = "data:image/png;base64,QUJD"  // unreadable -> per-image cap each
     let perImageCap = MediaIngest.maxImagePixels
     let aggCap = MediaIngest.maxRequestImagePixels
@@ -63,7 +63,7 @@ private let gib: UInt64 = 1024 * 1024 * 1024
 }
 
 @Test func projectedDecodeBytesChargesVideoAggregateOncePerRequest() {
-    // validateMedia caps the SUM of all videos' frame pixels by
+    // buildUserInput caps the SUM of all videos' frame pixels by
     // maxRequestVideoFramePixels — so the projection charges that aggregate ONCE
     // regardless of video count. Charging per-video would over-reserve by the
     // video count and could falsely 503 a valid multi-video request. (The URI is

--- a/provider-swift/Tests/ProviderCoreTests/VLMDecodeBombTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/VLMDecodeBombTests.swift
@@ -225,32 +225,27 @@ func vlmBuildUserInputRejectsAggregateBombBeforeDecode() async {
     }
 }
 
-@Test("validateMedia throws MediaError synchronously (before any stream is returned)")
-func vlmValidateMediaThrowsUpFront() async {
-    // The streaming HTTP path (sseResponse) returns a 200 SSE Response and only
-    // surfaces a generation error mid-iteration — too late for a 4xx. So the
-    // engine calls validateMedia(request) and propagates its throw BEFORE
-    // returning the stream. This asserts validateMedia actually throws on an
-    // oversized payload, so the engine's `try await` surfaces the MediaError to
-    // the HTTP/WS layer. Uses a small (fast-to-generate) bomb + a low injected
-    // cap rather than a real >100 Mpx image.
+@Test("buildUserInput throws MediaError before preparing model input")
+func vlmBuildUserInputThrowsUpFront() async {
+    // The engine awaits this decode inside its async-throws stream factory, so
+    // the MediaError reaches HTTP/WS before any stream is returned. Use a small
+    // bomb plus a low injected cap rather than a real >100 Mpx image.
     let uri = PNGBomb.dataURI(width: 2000, height: 2000)  // 4 Mpx
     let request = OpenAIChatCompletionRequest(
         model: "vlm",
         messages: [.init(role: .user, content: .parts([.imageURL(uri)]))])
     await expectMediaTooLarge {
-        try await MediaIngest.validateMedia(request, maxImagePixels: 1_000_000)
+        _ = try await MediaIngest.buildUserInput(
+            from: request, maxImagePixels: 1_000_000)
     }
 }
 
-@Test("validateMedia passes a within-cap request (no false positive)")
-func vlmValidateMediaAcceptsWithinCap() async throws {
-    // A normal small image must validate cleanly so genuine requests aren't
-    // rejected before they ever reach generation.
+@Test("buildUserInput accepts a within-cap request")
+func vlmBuildUserInputAcceptsWithinCap() async throws {
     let request = OpenAIChatCompletionRequest(
         model: "vlm",
         messages: [.init(role: .user, content: .parts([
             .text("describe"), .imageURL(PNGBomb.dataURI(width: 64, height: 64)),
         ]))])
-    try await MediaIngest.validateMedia(request)
+    _ = try await MediaIngest.buildUserInput(from: request)
 }

--- a/provider-swift/Tests/ProviderCoreTests/VisionTowerBudgetTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/VisionTowerBudgetTests.swift
@@ -26,6 +26,7 @@
 import Foundation
 import MLX
 import MLXLMCommon
+import MLXVLM
 import Testing
 
 @testable import ProviderCore
@@ -238,6 +239,27 @@ struct VisionTowerBudgetIncidentTests {
         #expect(
             VisionTowerBudget.attentionBytes(patches: 5_184, bytesPerSquaredPatch: 32)
                 < UInt64(1 << 30))
+    }
+
+    @Test("Qwen serving video cap bounds the unfused score tensor to 512 MiB")
+    func qwenVideoServingCapBoundsTower() {
+        #expect(Qwen3VLProcessor.maxVideoFrames == 8)
+        #expect(Qwen3VLProcessor.maxVideoFramePixels == 512 * 512)
+
+        // 512² / 16² = 1,024 spatial patches; temporal patch size 2 packs
+        // eight sampled frames into t=4, so N <= 4,096. Qwen's 72-dim heads
+        // take the 16-plane fallback: 4,096² × 16 × 2 bytes = 512 MiB.
+        let patches = (Qwen3VLProcessor.maxVideoFrames / 2)
+            * (Qwen3VLProcessor.maxVideoFramePixels / (16 * 16))
+        #expect(patches == 4_096)
+        #expect(
+            VisionTowerBudget.attentionBytes(
+                patches: patches, bytesPerSquaredPatch: 16 * 2)
+                == UInt64(512 * 1024 * 1024))
+        #expect(
+            VisionTowerBudget.admit(
+                patches: patches, subject: "this video",
+                limits: limits(headFactor: 16)) == .admit)
     }
 
     @Test("an unknown device limit fails open rather than refusing all media")

--- a/provider-swift/Tests/ProviderCoreTests/VisionTowerBudgetTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/VisionTowerBudgetTests.swift
@@ -342,6 +342,16 @@ struct EngineV2VisionPixelRunTests {
     func subjectsAreOperatorReadable() {
         #expect(EngineV2VisionPrefill.imageSubject(index: 0, of: 1) == "this image")
         #expect(EngineV2VisionPrefill.imageSubject(index: 3, of: 6) == "image 4 of 6")
+        #expect(EngineV2VisionPrefill.videoSubject(index: 0, of: 1) == "this video")
+        #expect(EngineV2VisionPrefill.videoSubject(index: 1, of: 3) == "video 2 of 3")
+    }
+
+    @Test("a T>1 video grid is one packed run, not per-frame slices")
+    func videoGridIsOneRun() throws {
+        // T=4, H=2, W=3 → 24 packed rows belonging to ONE video tower call.
+        let runs = try EngineV2VisionPrefill.imagePixelRuns(
+            grids: [THW(4, 2, 3)], totalRows: 24)
+        #expect(runs == [0 ..< 24])
     }
 }
 


### PR DESCRIPTION
## Summary
- Serve Qwen 3.5 video through EngineV2 instead of fail-closing it as `400 invalid media input`.
- Bound video processing to 8 sampled 512×512 frames, decode media once inside the reserved preparation path, and enforce the same cap for every video representation. This prevents the multi-GiB vision allocation behind the base64-video 502/provider death.
- Decode full image rasters with EXIF orientation and default `enable_thinking=false` for media unless reasoning was explicitly requested, fixing the base64-image grounding failure.
- Fetch remote media on the original request clock with an inference reserve. Treat media TTFT estimates as advisory at preflight, direct dispatch, and queue scheduling because the text-prefill projection omits media decode/tower work; retain the immutable absolute deadline.
- Keep incomplete media estimates out of text TTFT calibration and warm-pool pressure.
- Pin `libs/mlx-swift-lm` to [Layr-Labs/mlx-swift-lm#123](https://github.com/Layr-Labs/mlx-swift-lm/pull/123).

Both a coordinator deploy and provider publication are required for the complete production fix.

## Before

```mermaid
flowchart LR
  subgraph BeforeBehavior[Behavior]
    A1[Base64 video] --> A2[Qwen video fail-close or oversized tower]
    A2 --> A3[400 invalid media / provider death / edge 502]
    A4[Remote video] --> A5[1500-token text TTFT projection]
    A5 --> A6[Hard 10.5s gate]
    A6 --> A7[False 429 before dispatch]
    A8[Base64 image] --> A9[Decode path misses EXIF + thinking on]
    A9 --> A10[Slow, ungrounded caption]
  end
  subgraph BeforeCode[Code]
    B1[resolveRemoteMedia] --> B2[Independent fetch timeout]
    B3[runInferenceAdmission / dispatch / queue] --> B4[MaxTTFT enforced for media]
    B5[MediaIngest.validateMedia] --> B6[EngineV2 prepare decodes again]
    B7[buildQwenSubmission] --> B8[video unsupported]
  end
```

## After

```mermaid
flowchart LR
  subgraph AfterBehavior[Behavior]
    C1[Video URL or data URI] --> C2[Original request clock]
    C2 --> C3[Remote fetch only when needed, inference time reserved]
    C3 --> C4[Single decode, ≤8 frames at ≤512²]
    C4 --> C5[Per-video Qwen tower + spans + production memory gate]
    C5 --> C6[Grounded first content before absolute deadline]
    C7[Image data URI] --> C8[Full raster + EXIF]
    C8 --> C9[Thinking off unless requested]
  end
  subgraph AfterCode[Code]
    D1[mediaFetchBudget + HasRemoteMedia] --> D2[context bounded by remaining clock]
    D3[hardTTFTGateApplies] --> D4[preflight + direct + queue advisory for vision]
    D4 --> D5[scheduler defense; no calibration/warm-pool contamination]
    D6[EngineV2VisionPrefill] --> D7[qwenPerVideoVisionFeatures]
    D7 --> D8[carveSpans + bounded Qwen3VLProcessor]
  end
```

## Verification
- [x] `go test ./...`
- [x] `swift test` — 2,234 tests in 233 suites
- [x] `swift test --filter predecodedVideoHonorsMaximumFrameCount` in `mlx-swift-lm`
- [x] Regression coverage for media hard-gate bypass, queue scheduler defense, text-calibration isolation, warm-pool isolation, remote-only fetch budgeting, EXIF decode, single media decode, video spans, and 512 MiB tower bound
- [x] Exact local production Qwen3.5 35B artifact: 1280×720 inline QuickTime, strict `red blue` grounding, shared production memory ledger, reservation cleanup; request elapsed 1.544s under the 11s first-content deadline
- [ ] Re-run OpenRouter `input-video-base64`, `input-image-base64`, and `input-video-url` after coordinator deploy + provider publication