### PR TITLE
fix: add RAM preflight check to install.sh — prevent silent enrollment of underpowered machines

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -358,10 +358,49 @@ if [ "$(uname -m)" != "arm64" ]; then
 fi
 
 CHIP=$(sysctl -n machdep.cpu.brand_string 2>/dev/null || echo "Apple Silicon")
-MEM=$(sysctl -n hw.memsize 2>/dev/null | awk '{printf "%.0f", $1/1073741824}')
+MEM_BYTES=$(sysctl -n hw.memsize 2>/dev/null || echo 0)
+MEM=$((MEM_BYTES / 1073741824))
 MACOS=$(sw_vers -productVersion 2>/dev/null || echo "?")
 echo "  $CHIP · ${MEM}GB · macOS $MACOS"
 echo ""
+
+# ─── RAM preflight check ─────────────────────────────────────
+# The smallest model on the network currently needs ~30 GB of weights in
+# unified memory.  After subtracting ~4 GB for macOS and background
+# processes, a machine needs at least ~34-36 GB total to reliably serve.
+# Without this gate, underpowered machines complete the full install +
+# MDM enrollment flow, appear "online", but silently fail every inference
+# request — discoverable only via `darkbloom doctor`.
+#
+# Thresholds:
+#   <24 GB total  → hard-fail (cannot serve any current model)
+#   <36 GB total  → warn      (may work for smaller models, not the default)
+USABLE_GB=$((MEM > 4 ? MEM - 4 : 0))
+MIN_MODEL_GB=30  # approximate weight size of the current default model
+
+if [ "$MEM" -lt 24 ]; then
+    echo "  ✗ This Mac has ${MEM} GB RAM (~${USABLE_GB} GB usable after OS overhead)."
+    echo "    The smallest model on the network needs ~${MIN_MODEL_GB} GB."
+    echo "    A Mac with at least 36 GB unified memory is required to serve inference."
+    echo ""
+    echo "    Darkbloom cannot run on this hardware. No files were modified."
+    exit 1
+elif [ "$MEM" -lt 36 ]; then
+    echo "  ⚠ This Mac has ${MEM} GB RAM (~${USABLE_GB} GB usable after OS overhead)."
+    echo "    The default model needs ~${MIN_MODEL_GB} GB. You may experience load failures"
+    echo "    under memory pressure. A Mac with 36 GB+ unified memory is recommended."
+    echo ""
+    if [ "$INTERACTIVE" = true ]; then
+        printf "  Continue anyway? [y/N] "
+        read -r REPLY
+        case "$REPLY" in
+            [yY]*) echo "  Continuing..." ;;
+            *)     echo "  Aborted."; exit 1 ;;
+        esac
+    else
+        echo "  Continuing (non-interactive). Run 'darkbloom doctor' after install to verify."
+    fi
+fi
 
 # ─── Step 1: Fetch latest release ────────────────────────────
 echo "→ [1/5] Fetching latest release from $COORD_URL ..."


### PR DESCRIPTION
## Summary

- Add a RAM preflight gate to `scripts/install.sh` that checks total unified memory before downloading binaries or initiating enrollment
- Hard-fails at <24 GB (cannot serve any current model on the network)
- Warns at <36 GB with interactive confirmation prompt (non-interactive mode continues with a warning)

## Problem

Machines with insufficient RAM (e.g., 16 GB) currently complete the full install + MDM enrollment flow, appear "online" on the network, but silently fail every inference request because the default model (~30.3 GB) cannot fit in memory. The only way to discover this is by manually running `darkbloom doctor`:

```
TRAFFIC READINESS   (can this box actually serve?)
  [FAIL] model fits in RAM — qwen3.6-35b-a3b-vl-mtp-mxfp8 needs ~30.3 GB
         but only 12.5 GB is usable — it will show online but every request fails to load.
```

See #736 for the full issue writeup.

## What this PR does NOT cover

This is a minimal shell-level fix for the install script only. A complete fix would also need:

1. **`StartCommand+Preflight.swift`** — raise the 8 GB hard-fail threshold to match the actual minimum model requirement
2. **`EnrollCommand.swift`** — add a RAM check before initiating MDM device attestation
3. **Coordinator-side admission** — the coordinator's `scheduler_memory_admission` could reject registration from underpowered machines

Those changes require Swift/Go modifications and are better scoped as follow-up work.

## Test plan

- [ ] Run `install.sh` on a Mac with <24 GB RAM — verify it exits with a clear error message
- [ ] Run `install.sh` on a Mac with 24-35 GB RAM — verify warning is shown and interactive prompt works
- [ ] Run `install.sh` on a Mac with 36+ GB RAM — verify no warning, install proceeds normally
- [ ] Run piped (`curl | bash`) on a <36 GB Mac — verify non-interactive path prints warning but continues
- [ ] Verify `scripts/sync-install-embed.sh` correctly propagates the change to `coordinator/api/install.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/737"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790303363&installation_model_id=21733&pr_number=737&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F737&signature=71e08330a1fd90829127a4ea7af9f75b9efb944b962e6f2985854b4a8f8a8998"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->