### PR TITLE
fix: remove hardcoded MDM API key default from Dockerfile

### DIFF
--- a/coordinator/Dockerfile
+++ b/coordinator/Dockerfile
@@ -72,7 +72,8 @@ RUN chmod +x /usr/local/bin/start.sh
 
 ENV EIGENINFERENCE_PORT=8080
 ENV EIGENINFERENCE_MDM_URL=https://localhost:9002
-ENV EIGENINFERENCE_MDM_API_KEY=eigeninference-micromdm-api
+# EIGENINFERENCE_MDM_API_KEY must be injected at runtime via GCP Secret Manager or --env flag.
+# Do NOT set a default here — a hardcoded value is a security risk (see issue #707).
 ENV EIGENINFERENCE_PROMPT_SIDECAR_BINARY=/usr/local/bin/promptsidecar
 
 EXPOSE 8080


### PR DESCRIPTION
Fixes #707.

## What this changes

Removes the hardcoded default MDM API key from `coordinator/Dockerfile`:

```dockerfile
-ENV EIGENINFERENCE_MDM_API_KEY=eigeninference-micromdm-api
```

It is replaced with a comment stating that the value must be injected at runtime, so the image no longer ships a working default baked into a public layer.

## Why

`eigeninference-micromdm-api` was set as an `ENV` default, which means it is baked into every image built from this Dockerfile and is readable by anyone who can pull the image (`docker history` / layer inspection). Combined with the MDM server URL published in `scripts/enroll-with-acme.mobileconfig` and the public SCEP challenge, that key is enough to talk to the MicroMDM API directly — querying enrolled device information across the provider fleet, issuing MDM commands within the granted AccessRights, or enrolling arbitrary devices.

## The key must be rotated

This value is permanently in the git history of this repository and in every previously published image layer. Removing it from the Dockerfile stops the bleeding for future builds but does **not** un-publish it. `eigeninference-micromdm-api` should be treated as compromised and rotated, regardless of whether production was already overriding it.

## Deployment requirement

Production deployments must inject `EIGENINFERENCE_MDM_API_KEY` at runtime via GCP Secret Manager, never in the image layer. The existing deploy path already supports this — `deploy/gcp/vm-startup.sh` and `deploy/gcp/refresh-env.sh` both fetch the value from the `eigeninference-micromdm-api-key` secret, and `deploy/gcp/prod/required-env-keys.txt` already lists `EIGENINFERENCE_MDM_API_KEY` as required. So GCP deployments are unaffected by this change; only environments that were silently relying on the image default will now need to supply the variable explicitly, which is the intended behavior.

## Remaining hardcoded fallbacks (not addressed here)

This PR is deliberately scoped to the Dockerfile, but the same literal still appears in two other places and the default is therefore still reachable at runtime:

- `coordinator/mdm/config.go:9` — `const defaultMDMApiKey = "eigeninference-micromdm-api"`, applied in `ReadConfig()` whenever the env var is empty. With this PR alone, an unset variable silently falls back to the compromised key instead of failing loudly.
- `coordinator/deploy/start.sh:52,69` — `"${MICROMDM_API_KEY:-eigeninference-micromdm-api}"` shell defaults passed to MicroMDM.

Suggestion 2 in issue #707 (a startup check that refuses to boot when the key is empty or matches the known default in non-dev environments) would close this properly. Happy to follow up with that in a separate PR, or fold it into this one if maintainers prefer a single change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/738"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790304309&installation_model_id=21733&pr_number=738&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F738&signature=0578a7d08ea0b1e2309a11b3b836f84de995d166aa9b839e91027ef18b990ae4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->