### PR TITLE
chore(release): prepare Qwen media fixes for v0.8.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,13 @@
   bypasses the text-only estimated-TTFT hard gate while retaining the same
   request-absolute deadline. Its incomplete estimates do not train text TTFT
   calibration or emit synthetic warm-pool pressure.
-- **Current MLX-LM main pin** — `libs/mlx-swift-lm` advances to `23c287c`,
+- **Current MLX-LM main pin** — `libs/mlx-swift-lm` advances to `fe01df9`,
   containing the merged Qwen prefill/decode optimization
   ([mlx-swift-lm#120](https://github.com/Layr-Labs/mlx-swift-lm/pull/120))
   and bounded video-tower input fix
-  ([mlx-swift-lm#123](https://github.com/Layr-Labs/mlx-swift-lm/pull/123)).
+  ([mlx-swift-lm#123](https://github.com/Layr-Labs/mlx-swift-lm/pull/123)),
+  plus Qwen3-VL 30B-A3B support
+  ([mlx-swift-lm#122](https://github.com/Layr-Labs/mlx-swift-lm/pull/122)).
 - Provider and coordinator fallback version authorities move together to
   `0.8.13`; there is no new protocol.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,32 @@
 # Changelog
 
-## Release candidate v0.8.12 (not shipped; 2026-08-25)
+## Release candidate v0.8.13 (not shipped; 2026-08-25)
+
+- **Qwen 3.5 video + grounded image captions** — Qwen vision prefill no
+  longer fail-closes video as `invalid media input`. The tower runs one
+  video (full T×H×W grid) at a time and carves the contiguous
+  `<|video_pad|>` run into per-frame spans. Image decode applies EXIF
+  orientation on the full raster (not a JPEG thumbnail). Media requests
+  default `enable_thinking=false` unless the client sets
+  `reasoning.enabled`. Qwen decodes media once and uniformly samples at most
+  8 video frames at no more than 512² pixels each, bounding its unfused
+  vision score tensor to 512 MiB. Coordinator remote-media fetch is bounded
+  by the leftover first-content clock minus an inference reserve, and media
+  bypasses the text-only estimated-TTFT hard gate while retaining the same
+  request-absolute deadline. Its incomplete estimates do not train text TTFT
+  calibration or emit synthetic warm-pool pressure.
+- **Current MLX-LM main pin** — `libs/mlx-swift-lm` advances to `23c287c`,
+  containing the merged Qwen prefill/decode optimization
+  ([mlx-swift-lm#120](https://github.com/Layr-Labs/mlx-swift-lm/pull/120))
+  and bounded video-tower input fix
+  ([mlx-swift-lm#123](https://github.com/Layr-Labs/mlx-swift-lm/pull/123)).
+- Provider and coordinator fallback version authorities move together to
+  `0.8.13`; there is no new protocol.
+
+## v0.8.12 (shipped; 2026-08-25)
+
+> **Post-publication status:** `v0.8.12` was tagged, published, and registered
+> before the Qwen media fixes above. Those fixes therefore ship in v0.8.13.
 
 - **Default atomic first-token deadline admission on** — Explicit typed TOML is
   authoritative: `"off"` disables and `"enforce"` enforces regardless of the
@@ -20,19 +46,6 @@
   absolute expiry remains active. It does not rewrite the deadline-mode setting.
 - Provider and coordinator fallback version authorities move together to
   `0.8.12`; there is no new protocol.
-- **Qwen 3.5 video + grounded image captions** — Qwen vision prefill no
-  longer fail-closes video as `invalid media input`. The tower runs one
-  video (full T×H×W grid) at a time and carves the contiguous
-  `<|video_pad|>` run into per-frame spans. Image decode applies EXIF
-  orientation on the full raster (not a JPEG thumbnail). Media requests
-  default `enable_thinking=false` unless the client sets
-  `reasoning.enabled`. Qwen decodes media once and uniformly samples at most
-  8 video frames at no more than 512² pixels each, bounding its unfused
-  vision score tensor to 512 MiB. Coordinator remote-media fetch is bounded
-  by the leftover first-content clock minus an inference reserve, and media
-  bypasses the text-only estimated-TTFT hard gate while retaining the same
-  request-absolute deadline. Its incomplete estimates do not train text TTFT
-  calibration or emit synthetic warm-pool pressure.
 
 Release rationale, limitations, compatibility, and rollout gates:
 [`docs/reports/2026-08-25-v0.8.12-prefill-deadline-admission.md`](docs/reports/2026-08-25-v0.8.12-prefill-deadline-admission.md).

--- a/coordinator/api/server.go
+++ b/coordinator/api/server.go
@@ -151,7 +151,7 @@ func keyLimitResetFromContext(ctx context.Context) string {
 // the provider's EngineV2Factory.prepareProductionBackend for the argument).
 // Keep this fallback in sync with ProviderCore.version so dev/in-memory
 // coordinators advertise the same floor as the Swift binary they expect.
-var LatestProviderVersion = "0.8.12"
+var LatestProviderVersion = "0.8.13"
 
 // minProviderVersionForDesiredModels is the first provider version whose Swift
 // runtime understands the desired_models message. The coordinator must NOT send

--- a/provider-swift/Sources/ProviderCore/ProviderCore.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderCore.swift
@@ -248,5 +248,7 @@ public enum ProviderCore {
     // DARKBLOOM_PREFILL_DEADLINE_MODE=off is the direct forecast rollback;
     // FCFS cap zero restores unlimited interleave and necessarily bypasses the
     // bounded forecast while preserving hard absolute expiry.
-    public static let version = "0.8.12"
+    // 0.8.13 serves Qwen image/video requests through the bounded vision path,
+    // including single-decode media ingest and first-content-safe video caps.
+    public static let version = "0.8.13"
 }

--- a/provider-swift/Tests/ProviderCoreTests/GemmaToolConstraintTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/GemmaToolConstraintTests.swift
@@ -114,7 +114,7 @@ private struct WideConstraintTokenizer: MLXLMCommon.Tokenizer {
     }
 }
 
-@Suite("Gemma CBv2 tool constraints")
+@Suite("Gemma CBv2 tool constraints", .serialized)
 struct GemmaToolConstraintTests {
     private static let realGemmaModelID =
         "mlx-community/gemma-4-26B-A4B-it-qat-4bit"


### PR DESCRIPTION
## Summary
- Bump `ProviderCore.version` and the coordinator fallback together from `0.8.12` to `0.8.13`, avoiding reuse of the already-published v0.8.12 identity.
- Repin `libs/mlx-swift-lm` to latest `main` at `fe01df9`, which contains merged [mlx-swift-lm#120](https://github.com/Layr-Labs/mlx-swift-lm/pull/120), [mlx-swift-lm#123](https://github.com/Layr-Labs/mlx-swift-lm/pull/123), and [mlx-swift-lm#122](https://github.com/Layr-Labs/mlx-swift-lm/pull/122).
- Move the Qwen media notes into the correct v0.8.13 changelog section and serialize the resource-sensitive Gemma grammar suite so its 2-second wall-clock assertion is not raced by 64 sibling tests.

## Before

```mermaid
flowchart LR
  subgraph BeforeBehavior[Behavior]
    A1[Media fixes merged] --> A2[Source still says v0.8.12]
    A2 --> A3[Release identity already published]
    A3 --> A4[Fixed provider cannot be safely published as a new release]
  end
  subgraph BeforeCode[Code]
    B1[ProviderCore.version 0.8.12] --> B2[Release workflow resolves 0.8.12]
    B3[Coordinator fallback 0.8.12] --> B2
    B4[mlx-swift-lm feature commit 70f8c79] --> B5[Not pinned to merged main]
    B6[Gemma timing suite parallel] --> B7[Wall-clock assertion can race sibling tests]
  end
```

## After

```mermaid
flowchart LR
  subgraph AfterBehavior[Behavior]
    C1[Media fixes merged] --> C2[Source identifies v0.8.13]
    C2 --> C3[Release workflow builds a fresh artifact]
    C3 --> C4[v0.8.13 can be signed, registered, and offered to providers]
  end
  subgraph AfterCode[Code]
    D1[ProviderCore.version 0.8.13] --> D2[Release integrity check]
    D3[Coordinator fallback 0.8.13] --> D2
    D4[mlx-swift-lm main fe01df9] --> D5[Merged Qwen optimization, bounded video input, and Qwen3-VL MoE support]
    D6[Serialized Gemma suite] --> D7[Timing assertion retains its bound without sibling contention]
  end
```

## Verification
- [x] `./scripts/check-release-version.sh 0.8.13`
- [x] `cd coordinator && go test ./... -timeout=10m`
- [x] `cd provider-swift && swift test` — 2,234 tests in 233 suites
- [x] `cd libs/mlx-swift-lm && swift test --filter predecodedVideoHonorsMaximumFrameCount`
- [x] `cd libs/mlx-swift-lm && swift test --filter Qwen3VLMoETests` — 9 tests
- [x] Production Qwen 3.5 35B 720p inline-video canary — grounded `red blue`, 1.686s request elapsed inside the 11s first-content clock
- [x] Independent defect-first review — no findings

This PR prepares v0.8.13; it does not create or publish the release.