### PR TITLE
Refresh Slack community invite URL

### DIFF
--- a/console-ui/src/components/community/CommunityLinks.test.tsx
+++ b/console-ui/src/components/community/CommunityLinks.test.tsx
@@ -11,6 +11,6 @@ describe("CommunityLinks", () => {
     render(<CommunityLinks />);
     const link = screen.getByLabelText("Join the Darkbloom Slack") as HTMLAnchorElement;
     expect(link.href).toBe(SLACK_INVITE_URL);
-    expect(link.href).toContain("zt-47hf6xy0n");
+    expect(link.href).toContain("zt-47wmq0xbr");
   });
 });

--- a/console-ui/src/components/community/SlackJoinPopup.test.tsx
+++ b/console-ui/src/components/community/SlackJoinPopup.test.tsx
@@ -35,7 +35,7 @@ describe("SlackJoinPopup", () => {
     );
     const link = screen.getByRole("link", { name: /Join Slack/i }) as HTMLAnchorElement;
     expect(link.href).toBe(SLACK_INVITE_URL);
-    expect(link.href).toContain("zt-47hf6xy0n");
+    expect(link.href).toContain("zt-47wmq0xbr");
   });
 
   it("stays hidden when not signed in", async () => {

--- a/console-ui/src/components/community/constants.ts
+++ b/console-ui/src/components/community/constants.ts
@@ -1,5 +1,5 @@
 export const SLACK_INVITE_URL =
-  "https://join.slack.com/t/darkbloom/shared_invite/zt-47hf6xy0n-_yQi1I7rowq6AMyUida4dg";
+  "https://join.slack.com/t/darkbloom/shared_invite/zt-47wmq0xbr-G_yu2R7kfdMZm50CARP~Ow";
 export const GITHUB_REPO_URL = "https://github.com/Layr-Labs/d-inference";
 
 // New key on purpose: signed-up users who dismissed the old provider-only


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The previous Darkbloom Slack invite expired. Point the console community Slack links at the current workspace invite so Join Slack / the sidebar icon still work.

## Linked issue

N/A — ops request to refresh the invite.

## Test plan

- [x] Updated `SLACK_INVITE_URL` in `console-ui/src/components/community/constants.ts`
- [x] Pinned CommunityLinks and SlackJoinPopup tests to `zt-47wmq0xbr`
- [x] `cd console-ui && npm test -- src/components/community` — 8/8 passed

## Components touched

- [ ] coordinator (Go)
- [ ] provider (Rust, legacy)
- [ ] provider-swift (Swift CLI)
- [x] console-ui (Next.js)
- [ ] enclave (Swift)
- [ ] infra / CI / release
- [ ] docs

## Protocol / interface changes

- [x] No protocol/interface changes

## Behavior

```mermaid
flowchart LR
 subgraph Before
  A1[User clicks Slack] --> B1[Expired invite zt-47hf6xy0n]
  B1 --> C1[Join fails]
 end
 subgraph After
  A2[User clicks Slack] --> B2[Current invite zt-47wmq0xbr]
  B2 --> C2[Join succeeds]
 end
```

## Code

```mermaid
flowchart LR
 subgraph Before
  D1[CommunityLinks / SlackJoinPopup] --> E1[constants.SLACK_INVITE_URL old]
 end
 subgraph After
  D2[CommunityLinks / SlackJoinPopup] --> E2[constants.SLACK_INVITE_URL new]
 end
```

## Notes for reviewers

Single-constant swap. Tests assert the new invite code so a stale URL cannot silently regress.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2740f17c-060e-485a-bc02-d788dd0a55ec?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2740f17c-060e-485a-bc02-d788dd0a55ec&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/750"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790399299&installation_model_id=21733&pr_number=750&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F750&signature=1ca1bf2e900514ca142174f035a9094a3ba05c9640d9d3338cc8f3a8fe3561d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->