### PR TITLE
fix(install): put darkbloom on PATH for bash login shells

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
         run: |
           ./scripts/check-release-version.sh
           ./scripts/sync-install-embed.sh check
+          ./scripts/test-install-path.sh
           ./scripts/test-prod-env-refresh.sh
 
   test-coordinator:

--- a/coordinator/api/install.sh
+++ b/coordinator/api/install.sh
@@ -329,16 +329,6 @@ path_contains() {
     esac
 }
 
-strip_legacy_path_lines() {
-    local file=$1
-    local tmp
-    [ -f "$file" ] || return 0
-    tmp="${file}.darkbloom-path-$$"
-    grep -vE '\.dginf/bin|\.eigeninference/bin|alias eigeninf|alias dginf|# EigenInference$|# Darkbloom$' \
-        "$file" > "$tmp" || true
-    mv "$tmp" "$file"
-}
-
 ensure_trailing_newline() {
     local file=$1
     local last
@@ -349,23 +339,24 @@ ensure_trailing_newline() {
 
 ensure_path_in_file() {
     local file=$1
-    if [ -f "$file" ] && grep -q '\.darkbloom/bin' "$file" 2>/dev/null; then
+    local path_line='export PATH="$HOME/.darkbloom/bin:$PATH"'
+    if [ -f "$file" ] && grep -Fqx "$path_line" "$file" 2>/dev/null; then
         return 0
     fi
-    [ -f "$file" ] && strip_legacy_path_lines "$file"
     mkdir -p "$(dirname "$file")"
     ensure_trailing_newline "$file"
-    printf '\n# Darkbloom\nexport PATH="$HOME/.darkbloom/bin:$PATH"\n' >> "$file"
+    printf '\n# Darkbloom\n%s\n' "$path_line" >> "$file"
 }
 
 ensure_path_in_fish() {
     local file=$1
-    if [ -f "$file" ] && grep -q '\.darkbloom/bin' "$file" 2>/dev/null; then
+    local path_line='set -gx PATH "$HOME/.darkbloom/bin" $PATH'
+    if [ -f "$file" ] && grep -Fqx "$path_line" "$file" 2>/dev/null; then
         return 0
     fi
     mkdir -p "$(dirname "$file")"
     ensure_trailing_newline "$file"
-    printf '\n# Darkbloom\nset -gx PATH "$HOME/.darkbloom/bin" $PATH\n' >> "$file"
+    printf '\n# Darkbloom\n%s\n' "$path_line" >> "$file"
 }
 
 setup_path_symlinks() {

--- a/coordinator/api/install.sh
+++ b/coordinator/api/install.sh
@@ -29,6 +29,7 @@ DARKBLOOM_DESIGNATED_REQUIREMENT='anchor apple generic and identifier "io.darkbl
 DARKBLOOM_FAN_HELPER_REQUIREMENT='anchor apple generic and identifier "io.darkbloom.fan-helper" and certificate leaf[subject.OU] = "SLDQ2GJ6TL"'
 FAN_HELPER_REQUIREMENT="$DARKBLOOM_FAN_HELPER_REQUIREMENT"
 INSTALL_TEST_MODE=0
+PATH_SYMLINK_DIR=""
 
 fail_install() {
     echo "  ✗ $*" >&2
@@ -315,6 +316,121 @@ install_bundle_atomically() {
     rm -rf "$stage"
 }
 
+# PATH setup. `curl | bash` cannot change the parent shell, so the installer
+# (1) writes ~/.darkbloom/bin into every common startup file a new terminal
+# will actually read, and (2) tries a symlink into a directory already on
+# PATH (/usr/local/bin, Homebrew) so `darkbloom` works in the current
+# session when that write is allowed. Writing only ~/.zshrc left bash login
+# shells (macOS Terminal after chsh/bash) with "command not found".
+path_contains() {
+    case ":$PATH:" in
+        *":$1:"*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+strip_legacy_path_lines() {
+    local file=$1
+    local tmp
+    [ -f "$file" ] || return 0
+    tmp="${file}.darkbloom-path-$$"
+    grep -vE '\.dginf/bin|\.eigeninference/bin|alias eigeninf|alias dginf|# EigenInference$|# Darkbloom$' \
+        "$file" > "$tmp" || true
+    mv "$tmp" "$file"
+}
+
+ensure_trailing_newline() {
+    local file=$1
+    local last
+    [ -s "$file" ] || return 0
+    last=$(tail -c 1 "$file" 2>/dev/null || true)
+    [ -z "$last" ] || [ "$last" = $'\n' ] || printf '\n' >> "$file"
+}
+
+ensure_path_in_file() {
+    local file=$1
+    if [ -f "$file" ] && grep -q '\.darkbloom/bin' "$file" 2>/dev/null; then
+        return 0
+    fi
+    [ -f "$file" ] && strip_legacy_path_lines "$file"
+    mkdir -p "$(dirname "$file")"
+    ensure_trailing_newline "$file"
+    printf '\n# Darkbloom\nexport PATH="$HOME/.darkbloom/bin:$PATH"\n' >> "$file"
+}
+
+ensure_path_in_fish() {
+    local file=$1
+    if [ -f "$file" ] && grep -q '\.darkbloom/bin' "$file" 2>/dev/null; then
+        return 0
+    fi
+    mkdir -p "$(dirname "$file")"
+    ensure_trailing_newline "$file"
+    printf '\n# Darkbloom\nset -gx PATH "$HOME/.darkbloom/bin" $PATH\n' >> "$file"
+}
+
+setup_path_symlinks() {
+    PATH_SYMLINK_DIR=""
+    local candidates dest rest
+    if [ -n "${DARKBLOOM_PATH_LINK_CANDIDATES+x}" ]; then
+        candidates="$DARKBLOOM_PATH_LINK_CANDIDATES"
+    else
+        candidates="/usr/local/bin:/opt/homebrew/bin"
+    fi
+    rest="$candidates"
+    while [ -n "$rest" ]; do
+        dest="${rest%%:*}"
+        if [ "$rest" = "$dest" ]; then
+            rest=""
+        else
+            rest="${rest#*:}"
+        fi
+        [ -n "$dest" ] || continue
+        mkdir -p "$dest" 2>/dev/null || true
+        if [ -d "$dest" ] && [ -w "$dest" ] \
+            && ln -sfn "$BIN_DIR/darkbloom" "$dest/darkbloom" 2>/dev/null
+        then
+            if path_contains "$dest"; then
+                PATH_SYMLINK_DIR="$dest"
+                return 0
+            fi
+        fi
+    done
+}
+
+setup_shell_path() {
+    PATH_SYMLINK_DIR=""
+    mkdir -p "$BIN_DIR"
+    setup_path_symlinks
+
+    # zsh is the macOS default. Always create ~/.zshrc so a stock Terminal
+    # window finds darkbloom after install.
+    ensure_path_in_file "$HOME/.zshrc"
+    [ -f "$HOME/.zprofile" ] && ensure_path_in_file "$HOME/.zprofile"
+
+    # bash interactive (bash launched from zsh, Linux, some IDEs).
+    ensure_path_in_file "$HOME/.bashrc"
+
+    # bash login: macOS Terminal starts a login shell. That reads
+    # ~/.bash_profile, or ~/.profile when bash_profile is absent — never
+    # ~/.zshrc. Creating bash_profile when profile already exists would
+    # shadow profile, so prefer the file bash will actually load.
+    if [ -f "$HOME/.bash_profile" ]; then
+        ensure_path_in_file "$HOME/.bash_profile"
+        [ -f "$HOME/.profile" ] && ensure_path_in_file "$HOME/.profile"
+    elif [ -f "$HOME/.profile" ]; then
+        ensure_path_in_file "$HOME/.profile"
+    else
+        ensure_path_in_file "$HOME/.bash_profile"
+    fi
+
+    if [ -f "$HOME/.config/fish/config.fish" ] \
+        || [ "$(basename "${SHELL:-}")" = "fish" ]; then
+        ensure_path_in_fish "$HOME/.config/fish/config.fish"
+    fi
+
+    export PATH="$BIN_DIR:$PATH"
+}
+
 if [ "${1:-}" = "--verify-staged-app-signature-test" ]; then
     [ "$#" -eq 3 ] || {
         echo "usage: $0 --verify-staged-app-signature-test <app> <requirement>" >&2
@@ -332,6 +448,22 @@ if [ "${1:-}" = "--install-bundle-test" ]; then
     INSTALL_TEST_MODE=1
     if [ "$#" -eq 6 ]; then FAN_HELPER_REQUIREMENT=$6; fi
     install_bundle_atomically "$2" "$3" "$4" "$5"
+    exit $?
+fi
+
+if [ "${1:-}" = "--setup-path-test" ]; then
+    if [ -n "${2:-}" ]; then
+        HOME="$2"
+        INSTALL_DIR="$HOME/.darkbloom"
+        BIN_DIR="$INSTALL_DIR/bin"
+    fi
+    # Opt-in only: an unset override skips /usr/local/bin so CI never
+    # writes host PATH directories. Live installs use the default
+    # candidate list inside setup_shell_path.
+    if [ -z "${DARKBLOOM_PATH_LINK_CANDIDATES+x}" ]; then
+        DARKBLOOM_PATH_LINK_CANDIDATES=""
+    fi
+    setup_shell_path
     exit $?
 fi
 
@@ -420,32 +552,13 @@ fi
 rm -f "$TARBALL"
 echo "  Strict signature, runtime resources, and atomic swap verified ✓"
 
-# Make available in PATH. Try /usr/local/bin symlink, fall back to shell rc.
-if ln -sf "$BIN_DIR/darkbloom" /usr/local/bin/darkbloom 2>/dev/null; then
-    :
-fi
-RC="$HOME/.zshrc"
-if [ -f "$HOME/.bashrc" ] && [ ! -f "$HOME/.zshrc" ]; then
-    RC="$HOME/.bashrc"
-fi
-if ! grep -q "\.darkbloom/bin" "$RC" 2>/dev/null; then
-    sed -i '' '/\.dginf\/bin/d; /\.eigeninference\/bin/d; /alias eigeninf/d; /alias dginf/d; /# EigenInference/d; /# Darkbloom$/d' "$RC" 2>/dev/null || true
-    cat >> "$RC" << 'SHELL'
-
-# Darkbloom
-export PATH="$HOME/.darkbloom/bin:$PATH"
-SHELL
-fi
-export PATH="$BIN_DIR:$PATH"
-
-# Source rc so commands work in this shell. Disable -eu around it: rc files
-# may use unbound vars or shell-specific builtins that fail under bash strict.
-set +eu
-source "$RC" 2>/dev/null || true
-set -eu
-
+setup_shell_path
 echo "  Binaries installed ✓"
-echo "  Shortcut: darkbloom"
+if [ -n "$PATH_SYMLINK_DIR" ]; then
+    echo "  On PATH via $PATH_SYMLINK_DIR/darkbloom"
+else
+    echo "  Added ~/.darkbloom/bin to PATH in zsh/bash startup files"
+fi
 
 # ─── Migrate from old installs ───────────────────────────────
 # Migration chain: ~/.dginf → ~/.eigeninference → ~/.darkbloom
@@ -559,6 +672,10 @@ echo "║  Install complete                            ║"
 echo "╚══════════════════════════════════════════════╝"
 echo ""
 echo "  Next steps:"
+if [ -z "$PATH_SYMLINK_DIR" ]; then
+    echo "    export PATH=\"\$HOME/.darkbloom/bin:\$PATH\"   # this terminal"
+    echo ""
+fi
 echo "    darkbloom doctor             # verify the system is ready"
 echo "    darkbloom models catalog     # browse available models"
 echo "    darkbloom models download <id>"

--- a/coordinator/api/install.sh
+++ b/coordinator/api/install.sh
@@ -410,18 +410,20 @@ setup_shell_path() {
     # bash interactive (bash launched from zsh, Linux, some IDEs).
     ensure_path_in_file "$HOME/.bashrc"
 
-    # bash login: macOS Terminal starts a login shell. That reads
-    # ~/.bash_profile, or ~/.profile when bash_profile is absent — never
-    # ~/.zshrc. Creating bash_profile when profile already exists would
-    # shadow profile, so prefer the file bash will actually load.
+    # Bash login reads the first of ~/.bash_profile, ~/.bash_login,
+    # ~/.profile — never ~/.zshrc. Create bash_profile only when none of
+    # those exist, so we do not shadow an existing login file.
     if [ -f "$HOME/.bash_profile" ]; then
         ensure_path_in_file "$HOME/.bash_profile"
-        [ -f "$HOME/.profile" ] && ensure_path_in_file "$HOME/.profile"
+    elif [ -f "$HOME/.bash_login" ]; then
+        ensure_path_in_file "$HOME/.bash_login"
     elif [ -f "$HOME/.profile" ]; then
         ensure_path_in_file "$HOME/.profile"
     else
         ensure_path_in_file "$HOME/.bash_profile"
     fi
+    [ -f "$HOME/.bash_login" ] && ensure_path_in_file "$HOME/.bash_login"
+    [ -f "$HOME/.profile" ] && ensure_path_in_file "$HOME/.profile"
 
     if [ -f "$HOME/.config/fish/config.fish" ] \
         || [ "$(basename "${SHELL:-}")" = "fish" ]; then

--- a/coordinator/api/install_sh_test.go
+++ b/coordinator/api/install_sh_test.go
@@ -148,6 +148,30 @@ func TestInstallScriptTemplating(t *testing.T) {
 		}
 	})
 
+	t.Run("install.sh updates bash and zsh PATH files", func(t *testing.T) {
+		srv := newTestServerWithBaseURL(t, "https://api.dev.darkbloom.xyz")
+		defer srv.Close()
+
+		body := fetchInstallScript(t, srv.URL)
+		for _, required := range []string{
+			"setup_shell_path",
+			`ensure_path_in_file "$HOME/.zshrc"`,
+			`ensure_path_in_file "$HOME/.bashrc"`,
+			`ensure_path_in_file "$HOME/.bash_profile"`,
+			"--setup-path-test",
+			`export PATH="$HOME/.darkbloom/bin:$PATH"`,
+		} {
+			if !strings.Contains(body, required) {
+				t.Errorf("install.sh is missing PATH setup %q", required)
+			}
+		}
+		// The previous "write only ~/.zshrc when it exists" gate left bash
+		// login shells with command-not-found after a successful install.
+		if strings.Contains(body, `[ ! -f "$HOME/.zshrc" ]`) {
+			t.Error("install.sh still prefers .zshrc exclusively over bash login files")
+		}
+	})
+
 	t.Run("fan helper is verified but never privileged-installed", func(t *testing.T) {
 		srv := newTestServerWithBaseURL(t, "https://api.dev.darkbloom.xyz")
 		defer srv.Close()

--- a/docs/provider/installation.md
+++ b/docs/provider/installation.md
@@ -29,7 +29,8 @@ templating. `scripts/install.sh` is the sole editable source;
    `~/.zshrc`, `~/.bashrc`, and the bash login file bash will actually read
    (`~/.bash_profile`, else `~/.bash_login`, else `~/.profile`). `curl | bash`
    cannot change the current terminal; the installer also tries `/usr/local/bin`
-   and Homebrew's bin for a symlink already on `PATH`.
+   and Homebrew's bin for a symlink already on `PATH`
+   (`scripts/install.sh:340-424`).
 8. **Migrates legacy state** — copies tokens/keys from `~/.dginf` or
    `~/.eigeninference` if present.
 9. **Provisions Secure Enclave identity** — runs `darkbloom-enclave info`.

--- a/docs/provider/installation.md
+++ b/docs/provider/installation.md
@@ -26,7 +26,10 @@ templating. `scripts/install.sh` is the sole editable source;
    the binaries from `Darkbloom.app/Contents/MacOS/` when the `.app` bundle is
    used.
 7. **Updates `PATH`** — appends `export PATH="$HOME/.darkbloom/bin:$PATH"` to
-   `~/.zshrc` (or `~/.bashrc`).
+   `~/.zshrc`, `~/.bashrc`, and the bash login file (`~/.bash_profile`, or
+   `~/.profile` when that is what bash will read). `curl | bash` cannot change
+   the current terminal; the installer also tries `/usr/local/bin` and
+   Homebrew's bin for a symlink already on `PATH`.
 8. **Migrates legacy state** — copies tokens/keys from `~/.dginf` or
    `~/.eigeninference` if present.
 9. **Provisions Secure Enclave identity** — runs `darkbloom-enclave info`.
@@ -175,5 +178,5 @@ the profile.
 | `Error: Darkbloom requires macOS with Apple Silicon` | Wrong OS or architecture | Run on an Apple Silicon Mac |
 | `Bundle hash mismatch` | Corrupted download or tampered bundle | Re-run the installer; check `/v1/releases/latest` |
 | `Code signature could not be verified` | Binary unsigned or modified | Re-download from the coordinator |
-| `darkbloom: command not found` | `PATH` not updated | `source ~/.zshrc` or add `~/.darkbloom/bin` to `PATH` |
+| `darkbloom: command not found` | Current shell was not updated (`curl \| bash` cannot change it) | `export PATH="$HOME/.darkbloom/bin:$PATH"` or open a new terminal |
 | `Coordinator unreachable` | Firewall / DNS / coordinator maintenance | Check `curl https://api.darkbloom.dev/health` |

--- a/docs/provider/installation.md
+++ b/docs/provider/installation.md
@@ -179,5 +179,5 @@ the profile.
 | `Error: Darkbloom requires macOS with Apple Silicon` | Wrong OS or architecture | Run on an Apple Silicon Mac |
 | `Bundle hash mismatch` | Corrupted download or tampered bundle | Re-run the installer; check `/v1/releases/latest` |
 | `Code signature could not be verified` | Binary unsigned or modified | Re-download from the coordinator |
-| `darkbloom: command not found` | Current shell was not updated (`curl \| bash` cannot change it) | `export PATH="$HOME/.darkbloom/bin:$PATH"` or open a new terminal |
+| `darkbloom: command not found` | Current shell was not updated (`curl \| bash` cannot change it; `scripts/install.sh:319-424`) | `export PATH="$HOME/.darkbloom/bin:$PATH"` or open a new terminal |
 | `Coordinator unreachable` | Firewall / DNS / coordinator maintenance | Check `curl https://api.darkbloom.dev/health` |

--- a/docs/provider/installation.md
+++ b/docs/provider/installation.md
@@ -26,10 +26,10 @@ templating. `scripts/install.sh` is the sole editable source;
    the binaries from `Darkbloom.app/Contents/MacOS/` when the `.app` bundle is
    used.
 7. **Updates `PATH`** — appends `export PATH="$HOME/.darkbloom/bin:$PATH"` to
-   `~/.zshrc`, `~/.bashrc`, and the bash login file (`~/.bash_profile`, or
-   `~/.profile` when that is what bash will read). `curl | bash` cannot change
-   the current terminal; the installer also tries `/usr/local/bin` and
-   Homebrew's bin for a symlink already on `PATH`.
+   `~/.zshrc`, `~/.bashrc`, and the bash login file bash will actually read
+   (`~/.bash_profile`, else `~/.bash_login`, else `~/.profile`). `curl | bash`
+   cannot change the current terminal; the installer also tries `/usr/local/bin`
+   and Homebrew's bin for a symlink already on `PATH`.
 8. **Migrates legacy state** — copies tokens/keys from `~/.dginf` or
    `~/.eigeninference` if present.
 9. **Provisions Secure Enclave identity** — runs `darkbloom-enclave info`.

--- a/docs/provider/quickstart.md
+++ b/docs/provider/quickstart.md
@@ -36,7 +36,7 @@ The installer (`scripts/install.sh`):
 5. Adds `~/.darkbloom/bin` to your `PATH` in zsh and bash startup files. If
    this terminal still cannot find `darkbloom`, run
    `export PATH="$HOME/.darkbloom/bin:$PATH"` — `curl | bash` cannot change the
-   parent shell.
+   parent shell (`scripts/install.sh:340-424`).
 6. Provisions the Secure Enclave identity helper (`darkbloom-enclave`).
 7. Offers to install the MDM enrollment profile for hardware-trust attestation.
 

--- a/docs/provider/quickstart.md
+++ b/docs/provider/quickstart.md
@@ -33,7 +33,10 @@ The installer (`scripts/install.sh`):
 3. Verifies the bundle SHA-256, the binary SHA-256, and the `mlx.metallib` SHA-256
    against the coordinator's release record.
 4. Verifies the Apple Developer ID code signature.
-5. Adds `~/.darkbloom/bin` to your `PATH`.
+5. Adds `~/.darkbloom/bin` to your `PATH` in zsh and bash startup files. If
+   this terminal still cannot find `darkbloom`, run
+   `export PATH="$HOME/.darkbloom/bin:$PATH"` — `curl | bash` cannot change the
+   parent shell.
 6. Provisions the Secure Enclave identity helper (`darkbloom-enclave`).
 7. Offers to install the MDM enrollment profile for hardware-trust attestation.
 

--- a/docs/provider/troubleshooting.md
+++ b/docs/provider/troubleshooting.md
@@ -12,11 +12,12 @@ darkbloom logs --last 1h
 
 ### `darkbloom: command not found`
 
-The installer adds `~/.darkbloom/bin` to `~/.zshrc` (or `~/.bashrc`). Either open
-a new shell or run:
+The installer adds `~/.darkbloom/bin` to `~/.zshrc`, `~/.bashrc`, and the bash
+login file (`~/.bash_profile` or `~/.profile`). `curl | bash` cannot change the
+parent shell, so either open a new terminal or run:
 
 ```bash
-source ~/.zshrc
+export PATH="$HOME/.darkbloom/bin:$PATH"
 ```
 
 ### Bundle or binary hash mismatch

--- a/docs/provider/troubleshooting.md
+++ b/docs/provider/troubleshooting.md
@@ -13,7 +13,7 @@ darkbloom logs --last 1h
 ### `darkbloom: command not found`
 
 The installer adds `~/.darkbloom/bin` to `~/.zshrc`, `~/.bashrc`, and the bash
-login file (`~/.bash_profile` or `~/.profile`). `curl | bash` cannot change the
+login file (`~/.bash_profile`, else `~/.bash_login`, else `~/.profile`). `curl | bash` cannot change the
 parent shell, so either open a new terminal or run:
 
 ```bash

--- a/docs/provider/troubleshooting.md
+++ b/docs/provider/troubleshooting.md
@@ -13,8 +13,9 @@ darkbloom logs --last 1h
 ### `darkbloom: command not found`
 
 The installer adds `~/.darkbloom/bin` to `~/.zshrc`, `~/.bashrc`, and the bash
-login file (`~/.bash_profile`, else `~/.bash_login`, else `~/.profile`). `curl | bash` cannot change the
-parent shell, so either open a new terminal or run:
+login file (`~/.bash_profile`, else `~/.bash_login`, else `~/.profile`).
+`curl | bash` cannot change the parent shell, so either open a new terminal or
+run (`scripts/install.sh:340-424`):
 
 ```bash
 export PATH="$HOME/.darkbloom/bin:$PATH"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -329,16 +329,6 @@ path_contains() {
     esac
 }
 
-strip_legacy_path_lines() {
-    local file=$1
-    local tmp
-    [ -f "$file" ] || return 0
-    tmp="${file}.darkbloom-path-$$"
-    grep -vE '\.dginf/bin|\.eigeninference/bin|alias eigeninf|alias dginf|# EigenInference$|# Darkbloom$' \
-        "$file" > "$tmp" || true
-    mv "$tmp" "$file"
-}
-
 ensure_trailing_newline() {
     local file=$1
     local last
@@ -349,23 +339,24 @@ ensure_trailing_newline() {
 
 ensure_path_in_file() {
     local file=$1
-    if [ -f "$file" ] && grep -q '\.darkbloom/bin' "$file" 2>/dev/null; then
+    local path_line='export PATH="$HOME/.darkbloom/bin:$PATH"'
+    if [ -f "$file" ] && grep -Fqx "$path_line" "$file" 2>/dev/null; then
         return 0
     fi
-    [ -f "$file" ] && strip_legacy_path_lines "$file"
     mkdir -p "$(dirname "$file")"
     ensure_trailing_newline "$file"
-    printf '\n# Darkbloom\nexport PATH="$HOME/.darkbloom/bin:$PATH"\n' >> "$file"
+    printf '\n# Darkbloom\n%s\n' "$path_line" >> "$file"
 }
 
 ensure_path_in_fish() {
     local file=$1
-    if [ -f "$file" ] && grep -q '\.darkbloom/bin' "$file" 2>/dev/null; then
+    local path_line='set -gx PATH "$HOME/.darkbloom/bin" $PATH'
+    if [ -f "$file" ] && grep -Fqx "$path_line" "$file" 2>/dev/null; then
         return 0
     fi
     mkdir -p "$(dirname "$file")"
     ensure_trailing_newline "$file"
-    printf '\n# Darkbloom\nset -gx PATH "$HOME/.darkbloom/bin" $PATH\n' >> "$file"
+    printf '\n# Darkbloom\n%s\n' "$path_line" >> "$file"
 }
 
 setup_path_symlinks() {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -29,6 +29,7 @@ DARKBLOOM_DESIGNATED_REQUIREMENT='anchor apple generic and identifier "io.darkbl
 DARKBLOOM_FAN_HELPER_REQUIREMENT='anchor apple generic and identifier "io.darkbloom.fan-helper" and certificate leaf[subject.OU] = "SLDQ2GJ6TL"'
 FAN_HELPER_REQUIREMENT="$DARKBLOOM_FAN_HELPER_REQUIREMENT"
 INSTALL_TEST_MODE=0
+PATH_SYMLINK_DIR=""
 
 fail_install() {
     echo "  ✗ $*" >&2
@@ -315,6 +316,121 @@ install_bundle_atomically() {
     rm -rf "$stage"
 }
 
+# PATH setup. `curl | bash` cannot change the parent shell, so the installer
+# (1) writes ~/.darkbloom/bin into every common startup file a new terminal
+# will actually read, and (2) tries a symlink into a directory already on
+# PATH (/usr/local/bin, Homebrew) so `darkbloom` works in the current
+# session when that write is allowed. Writing only ~/.zshrc left bash login
+# shells (macOS Terminal after chsh/bash) with "command not found".
+path_contains() {
+    case ":$PATH:" in
+        *":$1:"*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+strip_legacy_path_lines() {
+    local file=$1
+    local tmp
+    [ -f "$file" ] || return 0
+    tmp="${file}.darkbloom-path-$$"
+    grep -vE '\.dginf/bin|\.eigeninference/bin|alias eigeninf|alias dginf|# EigenInference$|# Darkbloom$' \
+        "$file" > "$tmp" || true
+    mv "$tmp" "$file"
+}
+
+ensure_trailing_newline() {
+    local file=$1
+    local last
+    [ -s "$file" ] || return 0
+    last=$(tail -c 1 "$file" 2>/dev/null || true)
+    [ -z "$last" ] || [ "$last" = $'\n' ] || printf '\n' >> "$file"
+}
+
+ensure_path_in_file() {
+    local file=$1
+    if [ -f "$file" ] && grep -q '\.darkbloom/bin' "$file" 2>/dev/null; then
+        return 0
+    fi
+    [ -f "$file" ] && strip_legacy_path_lines "$file"
+    mkdir -p "$(dirname "$file")"
+    ensure_trailing_newline "$file"
+    printf '\n# Darkbloom\nexport PATH="$HOME/.darkbloom/bin:$PATH"\n' >> "$file"
+}
+
+ensure_path_in_fish() {
+    local file=$1
+    if [ -f "$file" ] && grep -q '\.darkbloom/bin' "$file" 2>/dev/null; then
+        return 0
+    fi
+    mkdir -p "$(dirname "$file")"
+    ensure_trailing_newline "$file"
+    printf '\n# Darkbloom\nset -gx PATH "$HOME/.darkbloom/bin" $PATH\n' >> "$file"
+}
+
+setup_path_symlinks() {
+    PATH_SYMLINK_DIR=""
+    local candidates dest rest
+    if [ -n "${DARKBLOOM_PATH_LINK_CANDIDATES+x}" ]; then
+        candidates="$DARKBLOOM_PATH_LINK_CANDIDATES"
+    else
+        candidates="/usr/local/bin:/opt/homebrew/bin"
+    fi
+    rest="$candidates"
+    while [ -n "$rest" ]; do
+        dest="${rest%%:*}"
+        if [ "$rest" = "$dest" ]; then
+            rest=""
+        else
+            rest="${rest#*:}"
+        fi
+        [ -n "$dest" ] || continue
+        mkdir -p "$dest" 2>/dev/null || true
+        if [ -d "$dest" ] && [ -w "$dest" ] \
+            && ln -sfn "$BIN_DIR/darkbloom" "$dest/darkbloom" 2>/dev/null
+        then
+            if path_contains "$dest"; then
+                PATH_SYMLINK_DIR="$dest"
+                return 0
+            fi
+        fi
+    done
+}
+
+setup_shell_path() {
+    PATH_SYMLINK_DIR=""
+    mkdir -p "$BIN_DIR"
+    setup_path_symlinks
+
+    # zsh is the macOS default. Always create ~/.zshrc so a stock Terminal
+    # window finds darkbloom after install.
+    ensure_path_in_file "$HOME/.zshrc"
+    [ -f "$HOME/.zprofile" ] && ensure_path_in_file "$HOME/.zprofile"
+
+    # bash interactive (bash launched from zsh, Linux, some IDEs).
+    ensure_path_in_file "$HOME/.bashrc"
+
+    # bash login: macOS Terminal starts a login shell. That reads
+    # ~/.bash_profile, or ~/.profile when bash_profile is absent — never
+    # ~/.zshrc. Creating bash_profile when profile already exists would
+    # shadow profile, so prefer the file bash will actually load.
+    if [ -f "$HOME/.bash_profile" ]; then
+        ensure_path_in_file "$HOME/.bash_profile"
+        [ -f "$HOME/.profile" ] && ensure_path_in_file "$HOME/.profile"
+    elif [ -f "$HOME/.profile" ]; then
+        ensure_path_in_file "$HOME/.profile"
+    else
+        ensure_path_in_file "$HOME/.bash_profile"
+    fi
+
+    if [ -f "$HOME/.config/fish/config.fish" ] \
+        || [ "$(basename "${SHELL:-}")" = "fish" ]; then
+        ensure_path_in_fish "$HOME/.config/fish/config.fish"
+    fi
+
+    export PATH="$BIN_DIR:$PATH"
+}
+
 if [ "${1:-}" = "--verify-staged-app-signature-test" ]; then
     [ "$#" -eq 3 ] || {
         echo "usage: $0 --verify-staged-app-signature-test <app> <requirement>" >&2
@@ -332,6 +448,22 @@ if [ "${1:-}" = "--install-bundle-test" ]; then
     INSTALL_TEST_MODE=1
     if [ "$#" -eq 6 ]; then FAN_HELPER_REQUIREMENT=$6; fi
     install_bundle_atomically "$2" "$3" "$4" "$5"
+    exit $?
+fi
+
+if [ "${1:-}" = "--setup-path-test" ]; then
+    if [ -n "${2:-}" ]; then
+        HOME="$2"
+        INSTALL_DIR="$HOME/.darkbloom"
+        BIN_DIR="$INSTALL_DIR/bin"
+    fi
+    # Opt-in only: an unset override skips /usr/local/bin so CI never
+    # writes host PATH directories. Live installs use the default
+    # candidate list inside setup_shell_path.
+    if [ -z "${DARKBLOOM_PATH_LINK_CANDIDATES+x}" ]; then
+        DARKBLOOM_PATH_LINK_CANDIDATES=""
+    fi
+    setup_shell_path
     exit $?
 fi
 
@@ -420,32 +552,13 @@ fi
 rm -f "$TARBALL"
 echo "  Strict signature, runtime resources, and atomic swap verified ✓"
 
-# Make available in PATH. Try /usr/local/bin symlink, fall back to shell rc.
-if ln -sf "$BIN_DIR/darkbloom" /usr/local/bin/darkbloom 2>/dev/null; then
-    :
-fi
-RC="$HOME/.zshrc"
-if [ -f "$HOME/.bashrc" ] && [ ! -f "$HOME/.zshrc" ]; then
-    RC="$HOME/.bashrc"
-fi
-if ! grep -q "\.darkbloom/bin" "$RC" 2>/dev/null; then
-    sed -i '' '/\.dginf\/bin/d; /\.eigeninference\/bin/d; /alias eigeninf/d; /alias dginf/d; /# EigenInference/d; /# Darkbloom$/d' "$RC" 2>/dev/null || true
-    cat >> "$RC" << 'SHELL'
-
-# Darkbloom
-export PATH="$HOME/.darkbloom/bin:$PATH"
-SHELL
-fi
-export PATH="$BIN_DIR:$PATH"
-
-# Source rc so commands work in this shell. Disable -eu around it: rc files
-# may use unbound vars or shell-specific builtins that fail under bash strict.
-set +eu
-source "$RC" 2>/dev/null || true
-set -eu
-
+setup_shell_path
 echo "  Binaries installed ✓"
-echo "  Shortcut: darkbloom"
+if [ -n "$PATH_SYMLINK_DIR" ]; then
+    echo "  On PATH via $PATH_SYMLINK_DIR/darkbloom"
+else
+    echo "  Added ~/.darkbloom/bin to PATH in zsh/bash startup files"
+fi
 
 # ─── Migrate from old installs ───────────────────────────────
 # Migration chain: ~/.dginf → ~/.eigeninference → ~/.darkbloom
@@ -559,6 +672,10 @@ echo "║  Install complete                            ║"
 echo "╚══════════════════════════════════════════════╝"
 echo ""
 echo "  Next steps:"
+if [ -z "$PATH_SYMLINK_DIR" ]; then
+    echo "    export PATH=\"\$HOME/.darkbloom/bin:\$PATH\"   # this terminal"
+    echo ""
+fi
 echo "    darkbloom doctor             # verify the system is ready"
 echo "    darkbloom models catalog     # browse available models"
 echo "    darkbloom models download <id>"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -410,18 +410,20 @@ setup_shell_path() {
     # bash interactive (bash launched from zsh, Linux, some IDEs).
     ensure_path_in_file "$HOME/.bashrc"
 
-    # bash login: macOS Terminal starts a login shell. That reads
-    # ~/.bash_profile, or ~/.profile when bash_profile is absent — never
-    # ~/.zshrc. Creating bash_profile when profile already exists would
-    # shadow profile, so prefer the file bash will actually load.
+    # Bash login reads the first of ~/.bash_profile, ~/.bash_login,
+    # ~/.profile — never ~/.zshrc. Create bash_profile only when none of
+    # those exist, so we do not shadow an existing login file.
     if [ -f "$HOME/.bash_profile" ]; then
         ensure_path_in_file "$HOME/.bash_profile"
-        [ -f "$HOME/.profile" ] && ensure_path_in_file "$HOME/.profile"
+    elif [ -f "$HOME/.bash_login" ]; then
+        ensure_path_in_file "$HOME/.bash_login"
     elif [ -f "$HOME/.profile" ]; then
         ensure_path_in_file "$HOME/.profile"
     else
         ensure_path_in_file "$HOME/.bash_profile"
     fi
+    [ -f "$HOME/.bash_login" ] && ensure_path_in_file "$HOME/.bash_login"
+    [ -f "$HOME/.profile" ] && ensure_path_in_file "$HOME/.profile"
 
     if [ -f "$HOME/.config/fish/config.fish" ] \
         || [ "$(basename "${SHELL:-}")" = "fish" ]; then

--- a/scripts/test-install-atomic.sh
+++ b/scripts/test-install-atomic.sh
@@ -419,4 +419,6 @@ run_install "$LEGACY" "$COORD_LEGACY_INSTALL"
 test -x "$COORD_LEGACY_INSTALL/bin/darkbloom"
 test ! -e "$COORD_LEGACY_INSTALL/Darkbloom.app/Contents/Helpers/darkbloom-fan-helper"
 
+"$REPO_ROOT/scripts/test-install-path.sh"
+
 echo "atomic installer tests passed"

--- a/scripts/test-install-path.sh
+++ b/scripts/test-install-path.sh
@@ -92,6 +92,19 @@ assert_file_has_path "$PROFILE_HOME/.profile"
 assert_file_missing "$PROFILE_HOME/.bash_profile"
 assert_command_on_path "$PROFILE_HOME" "$PROFILE_HOME/.profile"
 
+# --- Prefer existing ~/.bash_login over creating ~/.bash_profile -----------
+BASH_LOGIN="$ROOT/bash-login"
+mkdir -p "$BASH_LOGIN"
+printf '# existing bash_login\n' > "$BASH_LOGIN/.bash_login"
+seed_binary "$BASH_LOGIN"
+run_setup "$BASH_LOGIN"
+assert_file_has_path "$BASH_LOGIN/.bash_login"
+assert_file_missing "$BASH_LOGIN/.bash_profile"
+assert_command_on_path "$BASH_LOGIN" "$BASH_LOGIN/.bash_login"
+LOGIN2=$(HOME="$BASH_LOGIN" bash --login -c 'command -v darkbloom' 2>/dev/null || true)
+[ "$LOGIN2" = "$BASH_LOGIN/.darkbloom/bin/darkbloom" ] \
+    || fail "bash --login with only ~/.bash_login did not find darkbloom; got ${LOGIN2:-empty}"
+
 # --- Existing bash_profile + profile both get patched ----------------------
 BOTH="$ROOT/both"
 mkdir -p "$BOTH"

--- a/scripts/test-install-path.sh
+++ b/scripts/test-install-path.sh
@@ -1,0 +1,185 @@
+#!/bin/bash
+# Isolated PATH-setup tests for scripts/install.sh.
+# Reproduces the bash-login "command not found" after curl | bash and
+# checks zsh/fish/idempotency/symlink behavior without touching the host.
+set -euo pipefail
+
+REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd)
+INSTALLER="$REPO_ROOT/scripts/install.sh"
+"$REPO_ROOT/scripts/sync-install-embed.sh" check
+
+ROOT=$(mktemp -d "${TMPDIR:-/tmp}/darkbloom-install-path.XXXXXX")
+trap 'rm -rf "$ROOT"' EXIT
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+assert_file_has_path() {
+    local file=$1
+    [ -f "$file" ] || fail "expected $file to exist"
+    grep -q '\.darkbloom/bin' "$file" || fail "$file missing ~/.darkbloom/bin PATH entry"
+}
+
+assert_file_missing() {
+    local file=$1
+    [ ! -e "$file" ] || fail "expected $file to be absent"
+}
+
+assert_single_marker() {
+    local file=$1
+    local count
+    count=$(grep -c '# Darkbloom' "$file" || true)
+    [ "$count" = "1" ] || fail "$file has $count Darkbloom markers, want 1"
+}
+
+assert_command_on_path() {
+    local home=$1
+    local rc=$2
+    local found
+    found=$(HOME="$home" bash --noprofile --norc -c "set -euo pipefail; source \"$rc\"; command -v darkbloom") \
+        || fail "sourcing $rc did not put darkbloom on PATH"
+    [ "$found" = "$home/.darkbloom/bin/darkbloom" ] \
+        || fail "expected $home/.darkbloom/bin/darkbloom, got $found"
+}
+
+seed_binary() {
+    local home=$1
+    mkdir -p "$home/.darkbloom/bin"
+    printf '#!/bin/sh\necho darkbloom\n' > "$home/.darkbloom/bin/darkbloom"
+    chmod +x "$home/.darkbloom/bin/darkbloom"
+}
+
+run_setup() {
+    local home=$1
+    shift
+    HOME="$home" "$@" bash "$INSTALLER" --setup-path-test "$home"
+}
+
+# --- Tweet regression: zshrc exists, login shell is bash -------------------
+# Old installer wrote only ~/.zshrc when that file existed. A bash login
+# shell (macOS Terminal after chsh / Terminal.app → bash) never reads it.
+TWEET="$ROOT/tweet"
+mkdir -p "$TWEET"
+printf 'export HISTSIZE=500\n' > "$TWEET/.zshrc"
+seed_binary "$TWEET"
+run_setup "$TWEET"
+
+assert_file_has_path "$TWEET/.zshrc"
+assert_file_has_path "$TWEET/.bashrc"
+assert_file_has_path "$TWEET/.bash_profile"
+assert_file_missing "$TWEET/.profile"
+assert_single_marker "$TWEET/.zshrc"
+assert_single_marker "$TWEET/.bash_profile"
+assert_command_on_path "$TWEET" "$TWEET/.bash_profile"
+assert_command_on_path "$TWEET" "$TWEET/.bashrc"
+assert_command_on_path "$TWEET" "$TWEET/.zshrc"
+
+# bash --login reads .bash_profile, not .zshrc
+LOGIN_FOUND=$(HOME="$TWEET" bash --login -c 'command -v darkbloom' \
+    || true)
+[ "$LOGIN_FOUND" = "$TWEET/.darkbloom/bin/darkbloom" ] \
+    || fail "bash --login did not find darkbloom (tweet regression); got ${LOGIN_FOUND:-empty}"
+
+# --- Prefer existing ~/.profile over creating ~/.bash_profile --------------
+PROFILE_HOME="$ROOT/profile"
+mkdir -p "$PROFILE_HOME"
+printf '# existing profile\n' > "$PROFILE_HOME/.profile"
+seed_binary "$PROFILE_HOME"
+run_setup "$PROFILE_HOME"
+assert_file_has_path "$PROFILE_HOME/.profile"
+assert_file_missing "$PROFILE_HOME/.bash_profile"
+assert_command_on_path "$PROFILE_HOME" "$PROFILE_HOME/.profile"
+
+# --- Existing bash_profile + profile both get patched ----------------------
+BOTH="$ROOT/both"
+mkdir -p "$BOTH"
+printf '# bash_profile\n' > "$BOTH/.bash_profile"
+printf '# profile\n' > "$BOTH/.profile"
+seed_binary "$BOTH"
+run_setup "$BOTH"
+assert_file_has_path "$BOTH/.bash_profile"
+assert_file_has_path "$BOTH/.profile"
+
+# --- Existing zprofile is patched; we do not create one --------------------
+ZPROFILE="$ROOT/zprofile"
+mkdir -p "$ZPROFILE"
+printf 'eval true\n' > "$ZPROFILE/.zprofile"
+seed_binary "$ZPROFILE"
+run_setup "$ZPROFILE"
+assert_file_has_path "$ZPROFILE/.zprofile"
+assert_file_has_path "$ZPROFILE/.zshrc"
+
+# --- Fish config is patched when present -----------------------------------
+FISH="$ROOT/fish"
+mkdir -p "$FISH/.config/fish"
+printf '# fish\n' > "$FISH/.config/fish/config.fish"
+seed_binary "$FISH"
+run_setup "$FISH"
+assert_file_has_path "$FISH/.config/fish/config.fish"
+grep -q 'set -gx PATH' "$FISH/.config/fish/config.fish" \
+    || fail "fish config missing set -gx PATH"
+
+# --- Idempotent: second run does not duplicate -----------------------------
+run_setup "$TWEET"
+assert_single_marker "$TWEET/.zshrc"
+assert_single_marker "$TWEET/.bashrc"
+assert_single_marker "$TWEET/.bash_profile"
+
+# --- Legacy eigeninference lines are replaced ------------------------------
+LEGACY="$ROOT/legacy"
+mkdir -p "$LEGACY"
+cat > "$LEGACY/.zshrc" <<'RC'
+# EigenInference
+export PATH="$HOME/.eigeninference/bin:$PATH"
+alias eigeninf=eigeninference
+RC
+seed_binary "$LEGACY"
+run_setup "$LEGACY"
+assert_file_has_path "$LEGACY/.zshrc"
+assert_single_marker "$LEGACY/.zshrc"
+grep -q '\.eigeninference/bin' "$LEGACY/.zshrc" \
+    && fail "legacy eigeninference PATH survived"
+grep -q 'alias eigeninf' "$LEGACY/.zshrc" \
+    && fail "legacy eigeninf alias survived"
+
+# --- Symlink into a writable dir already on PATH ---------------------------
+LINK_HOME="$ROOT/link"
+LINK_BIN="$ROOT/path-bin"
+mkdir -p "$LINK_HOME" "$LINK_BIN"
+seed_binary "$LINK_HOME"
+DARKBLOOM_PATH_LINK_CANDIDATES="$LINK_BIN" \
+    PATH="$LINK_BIN:/usr/bin:/bin" \
+    run_setup "$LINK_HOME"
+[ -L "$LINK_BIN/darkbloom" ] || fail "expected symlink at $LINK_BIN/darkbloom"
+TARGET=$(readlink "$LINK_BIN/darkbloom")
+[ "$TARGET" = "$LINK_HOME/.darkbloom/bin/darkbloom" ] \
+    || fail "symlink target $TARGET"
+
+# Parent-equivalent PATH (inherited dirs only, no ~/.darkbloom/bin) finds it
+FOUND_VIA_LINK=$(PATH="$LINK_BIN:/usr/bin:/bin" command -v darkbloom) \
+    || fail "darkbloom not visible via PATH symlink"
+[ "$FOUND_VIA_LINK" = "$LINK_BIN/darkbloom" ] \
+    || fail "command -v resolved $FOUND_VIA_LINK"
+
+# --- Default --setup-path-test does not touch /usr/local/bin ---------------
+# Guard: if the host already has that name, don't require it absent; just
+# ensure this run did not create a symlink pointing at the fake home.
+HOST_LINK=/usr/local/bin/darkbloom
+BEFORE_HOST=""
+if [ -L "$HOST_LINK" ]; then
+    BEFORE_HOST=$(readlink "$HOST_LINK")
+fi
+SAFE="$ROOT/safe-host"
+seed_binary "$SAFE"
+run_setup "$SAFE"
+if [ -L "$HOST_LINK" ]; then
+    AFTER_HOST=$(readlink "$HOST_LINK")
+    [ "$AFTER_HOST" != "$SAFE/.darkbloom/bin/darkbloom" ] \
+        || fail "setup-path-test wrote host $HOST_LINK"
+    [ "$AFTER_HOST" = "$BEFORE_HOST" ] \
+        || fail "setup-path-test mutated host $HOST_LINK"
+fi
+
+echo "install path tests passed"

--- a/scripts/test-install-path.sh
+++ b/scripts/test-install-path.sh
@@ -18,8 +18,18 @@ fail() {
 
 assert_file_has_path() {
     local file=$1
+    local path_line='export PATH="$HOME/.darkbloom/bin:$PATH"'
     [ -f "$file" ] || fail "expected $file to exist"
-    grep -q '\.darkbloom/bin' "$file" || fail "$file missing ~/.darkbloom/bin PATH entry"
+    grep -Fqx "$path_line" "$file" \
+        || fail "$file missing active ~/.darkbloom/bin PATH export"
+}
+
+assert_fish_has_path() {
+    local file=$1
+    local path_line='set -gx PATH "$HOME/.darkbloom/bin" $PATH'
+    [ -f "$file" ] || fail "expected $file to exist"
+    grep -Fqx "$path_line" "$file" \
+        || fail "$file missing active ~/.darkbloom/bin fish PATH command"
 }
 
 assert_file_missing() {
@@ -32,6 +42,13 @@ assert_single_marker() {
     local count
     count=$(grep -c '# Darkbloom' "$file" || true)
     [ "$count" = "1" ] || fail "$file has $count Darkbloom markers, want 1"
+}
+
+file_mode() {
+    case "$(uname)" in
+        Darwin) stat -f '%Lp' "$1" ;;
+        *) stat -c '%a' "$1" ;;
+    esac
 }
 
 assert_command_on_path() {
@@ -76,11 +93,9 @@ assert_command_on_path "$TWEET" "$TWEET/.bash_profile"
 assert_command_on_path "$TWEET" "$TWEET/.bashrc"
 assert_command_on_path "$TWEET" "$TWEET/.zshrc"
 
-# bash --login reads .bash_profile, not .zshrc
-LOGIN_FOUND=$(HOME="$TWEET" bash --login -c 'command -v darkbloom' \
-    || true)
-[ "$LOGIN_FOUND" = "$TWEET/.darkbloom/bin/darkbloom" ] \
-    || fail "bash --login did not find darkbloom (tweet regression); got ${LOGIN_FOUND:-empty}"
+# The selected login file is sourced directly: host /etc/profile files can
+# overwrite HOME, which makes `bash --login` unsuitable for an isolated test.
+assert_file_missing "$TWEET/.bash_login"
 
 # --- Prefer existing ~/.profile over creating ~/.bash_profile --------------
 PROFILE_HOME="$ROOT/profile"
@@ -101,9 +116,6 @@ run_setup "$BASH_LOGIN"
 assert_file_has_path "$BASH_LOGIN/.bash_login"
 assert_file_missing "$BASH_LOGIN/.bash_profile"
 assert_command_on_path "$BASH_LOGIN" "$BASH_LOGIN/.bash_login"
-LOGIN2=$(HOME="$BASH_LOGIN" bash --login -c 'command -v darkbloom' 2>/dev/null || true)
-[ "$LOGIN2" = "$BASH_LOGIN/.darkbloom/bin/darkbloom" ] \
-    || fail "bash --login with only ~/.bash_login did not find darkbloom; got ${LOGIN2:-empty}"
 
 # --- Existing bash_profile + profile both get patched ----------------------
 BOTH="$ROOT/both"
@@ -130,9 +142,7 @@ mkdir -p "$FISH/.config/fish"
 printf '# fish\n' > "$FISH/.config/fish/config.fish"
 seed_binary "$FISH"
 run_setup "$FISH"
-assert_file_has_path "$FISH/.config/fish/config.fish"
-grep -q 'set -gx PATH' "$FISH/.config/fish/config.fish" \
-    || fail "fish config missing set -gx PATH"
+assert_fish_has_path "$FISH/.config/fish/config.fish"
 
 # --- Idempotent: second run does not duplicate -----------------------------
 run_setup "$TWEET"
@@ -140,7 +150,39 @@ assert_single_marker "$TWEET/.zshrc"
 assert_single_marker "$TWEET/.bashrc"
 assert_single_marker "$TWEET/.bash_profile"
 
-# --- Legacy eigeninference lines are replaced ------------------------------
+# --- A commented mention does not suppress the active managed export -------
+COMMENTED="$ROOT/commented"
+mkdir -p "$COMMENTED"
+cat > "$COMMENTED/.zshrc" <<'RC'
+# export PATH="$HOME/.darkbloom/bin:$PATH"
+# ~/.darkbloom/bin is installed by Darkbloom.
+RC
+seed_binary "$COMMENTED"
+run_setup "$COMMENTED"
+assert_file_has_path "$COMMENTED/.zshrc"
+assert_command_on_path "$COMMENTED" "$COMMENTED/.zshrc"
+[ "$(grep -Fxc 'export PATH="$HOME/.darkbloom/bin:$PATH"' "$COMMENTED/.zshrc")" = "1" ] \
+    || fail "commented PATH mention suppressed or duplicated the managed export"
+
+# --- Existing metadata and symlinked dotfiles are preserved ----------------
+METADATA="$ROOT/metadata"
+DOTFILES="$ROOT/dotfiles"
+mkdir -p "$METADATA" "$DOTFILES"
+printf 'export PRIVATE_SHELL_VALUE=secret\n' > "$DOTFILES/zshrc"
+chmod 0600 "$DOTFILES/zshrc"
+ln -s "$DOTFILES/zshrc" "$METADATA/.zshrc"
+seed_binary "$METADATA"
+run_setup "$METADATA"
+[ -L "$METADATA/.zshrc" ] || fail "installer replaced symlinked ~/.zshrc"
+[ "$(readlink "$METADATA/.zshrc")" = "$DOTFILES/zshrc" ] \
+    || fail "installer changed ~/.zshrc symlink target"
+[ "$(file_mode "$DOTFILES/zshrc")" = "600" ] \
+    || fail "installer changed ~/.zshrc target mode"
+grep -Fqx 'export PRIVATE_SHELL_VALUE=secret' "$DOTFILES/zshrc" \
+    || fail "installer lost existing shell configuration"
+assert_file_has_path "$METADATA/.zshrc"
+
+# --- Legacy lines remain intact; Darkbloom is prepended independently -------
 LEGACY="$ROOT/legacy"
 mkdir -p "$LEGACY"
 cat > "$LEGACY/.zshrc" <<'RC'
@@ -152,10 +194,10 @@ seed_binary "$LEGACY"
 run_setup "$LEGACY"
 assert_file_has_path "$LEGACY/.zshrc"
 assert_single_marker "$LEGACY/.zshrc"
-grep -q '\.eigeninference/bin' "$LEGACY/.zshrc" \
-    && fail "legacy eigeninference PATH survived"
-grep -q 'alias eigeninf' "$LEGACY/.zshrc" \
-    && fail "legacy eigeninf alias survived"
+grep -Fqx 'export PATH="$HOME/.eigeninference/bin:$PATH"' "$LEGACY/.zshrc" \
+    || fail "installer rewrote legacy PATH configuration"
+grep -Fqx 'alias eigeninf=eigeninference' "$LEGACY/.zshrc" \
+    || fail "installer rewrote legacy alias configuration"
 
 # --- Symlink into a writable dir already on PATH ---------------------------
 LINK_HOME="$ROOT/link"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`curl | bash` reported "Install complete" but did not put `darkbloom` on PATH for bash users. The installer only wrote `~/.zshrc` whenever that file existed, so a bash login shell never saw `~/.darkbloom/bin`.

The installer now appends an exact managed PATH command to zsh and bash startup files (including bash's login-file order: `~/.bash_profile`, else `~/.bash_login`, else `~/.profile`), tries a symlink into a directory already on PATH, and prints `export PATH=...` for the current terminal because a piped installer cannot mutate the parent shell. Existing file modes, symlink targets, contents, and legacy configuration remain intact.

## Linked issue

N/A — reported via public tweet (GUBA / @gubatron): `install.sh is broken, won't add darkbloom anywhere in the PATH`.

## Test plan

- [x] `./scripts/test-install-path.sh` — tweet regression, bash login-file precedence, fish, idempotency, commented PATH mentions, mode `0600`, symlink preservation, legacy configuration preservation, PATH symlink, and host `/usr/local/bin` isolation
- [x] `./scripts/check-release-version.sh && ./scripts/sync-install-embed.sh check && ./scripts/test-install-path.sh && ./scripts/test-prod-env-refresh.sh`
- [x] `cd coordinator && go test ./api/ -count=1 -run 'TestEmbeddedInstallerMatchesCanonicalSource|TestInstallScriptTemplating'`
- [x] `git diff --check && bash -n scripts/install.sh scripts/test-install-path.sh`
- [x] Two independent final-diff quality reviews (both PASS)

[Tweet: install.sh succeeds then bash command not found](https://cursor.com/agents/bc-5e2918ac-eb23-4514-a056-3991ce1968e5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftweet_install_path_not_found.png)

## Components touched

- [x] coordinator (Go)
- [ ] provider (Rust, legacy)
- [ ] provider-swift (Swift CLI)
- [ ] console-ui (Next.js)
- [ ] enclave (Swift)
- [x] infra / CI / release
- [x] docs

## Protocol / interface changes

- [x] No protocol/interface changes
- [ ] Yes — described above and matching side updated

## Behavior

```mermaid
flowchart LR
  subgraph Before
    B1["curl | bash"] --> B2["write PATH only to ~/.zshrc if it exists"]
    B2 --> B3["silent /usr/local/bin symlink"]
    B3 --> B4["Install complete"]
    B4 --> B5["bash login: command not found"]
  end
  subgraph After
    A1["curl | bash"] --> A2["append managed PATH command to zsh and bash startup files"]
    A2 --> A3["symlink into writable dir already on PATH"]
    A3 --> A4["Install complete + export PATH hint for this terminal"]
    A4 --> A5["new bash/zsh/fish terminals find darkbloom"]
  end
```

## Code

```mermaid
flowchart LR
  subgraph Before
    C1["inline install.sh PATH block"] --> C2{"~/.bashrc exists AND no ~/.zshrc?"}
    C2 -->|yes| C3["append to ~/.bashrc"]
    C2 -->|no| C4["append to ~/.zshrc only"]
  end
  subgraph After
    D1["setup_shell_path"] --> D2["ensure exact active PATH line"]
    D2 --> D3["append only; preserve metadata and symlinks"]
    D1 --> D4["bash_profile else bash_login else profile"]
    D1 --> D5["setup_path_symlinks"]
    D1 --> D6["isolated regression suite"]
  end
```

## Review feedback addressed

- Removed temporary-file filtering, eliminating metadata loss, symlink replacement, and partial-output replacement risks.
- Replaced substring detection with an exact active managed-line check.
- Added regression coverage for commented mentions, symlink targets, mode `0600`, and existing contents.
- Added canonical `scripts/install.sh` line citations to all new public behavior claims.
- Removed the host-dependent `bash --login` assertion that failed when runner `/etc/profile` overwrote `HOME`; direct sourcing still proves every selected login file exposes `darkbloom`.

## Notes for reviewers

- `scripts/install.sh` is canonical; `coordinator/api/install.sh` is the byte-identical embed.
- `--setup-path-test` refuses host PATH dirs unless `DARKBLOOM_PATH_LINK_CANDIDATES` is explicitly set, so CI cannot write `/usr/local/bin`.
- `curl | bash` cannot change the parent shell. Same-session use needs the printed `export` or a successful `/usr/local/bin` / Homebrew symlink.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5e2918ac-eb23-4514-a056-3991ce1968e5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5e2918ac-eb23-4514-a056-3991ce1968e5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/751"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790401113&installation_model_id=21733&pr_number=751&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F751&signature=824202090f3f7f6b0bc639e34935e07cab10fb775477e04e6eaa6197993e86e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->