### PR TITLE
Add model supply-pressure dashboard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,46 @@ jobs:
           go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.6
           golangci-lint run
 
+  test-admin-ui:
+    name: Admin UI Tests
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: admin_test
+          POSTGRES_PASSWORD: admin_test
+          POSTGRES_DB: admin_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U admin_test -d admin_test"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      ADMIN_DB_URL: postgres://admin_test:admin_test@127.0.0.1:5432/admin_test
+      ADMIN_TEST_DATABASE_URL: postgres://admin_test:admin_test@127.0.0.1:5432/admin_test
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: admin-ui/package-lock.json
+      - name: Install dependencies
+        working-directory: admin-ui
+        run: npm ci
+      - name: Lint
+        working-directory: admin-ui
+        run: npm run lint
+      - name: Test
+        working-directory: admin-ui
+        run: npm test
+      - name: Build
+        working-directory: admin-ui
+        run: npm run build
+
   test-prompt-sidecar:
     name: Prompt Sidecar Tests
     runs-on: blacksmith-4vcpu-ubuntu-2404

--- a/admin-ui/src/app/supply/page.tsx
+++ b/admin-ui/src/app/supply/page.tsx
@@ -1,7 +1,7 @@
 import { DataTable, type Column } from "@/components/DataTable";
 import {
-  MachineSignal,
-  SupplyLossMeter,
+  DominantSignal,
+  SupplyRejectShareMeter,
   TTFTValue,
 } from "@/components/supply/SupplyPressureCells";
 import { StatCard } from "@/components/StatCard";
@@ -18,10 +18,10 @@ function ModelCell({ model }: { model: SupplyPressureModel }) {
     <div className="min-w-56">
       <div className="font-medium">{model.displayName}</div>
       {model.displayName !== model.model && (
-        <div className="mono mt-0.5 text-[var(--text-faint)]">{model.model}</div>
+        <div className="mono mt-0.5 text-[var(--text-dim)]">{model.model}</div>
       )}
       {model.minRamGB !== null && model.minRamGB > 0 && (
-        <div className="mt-1 text-xs text-[var(--text-faint)]">
+        <div className="mt-1 text-xs text-[var(--text-dim)]">
           catalog minimum {formatNumber(model.minRamGB)} GB RAM
         </div>
       )}
@@ -33,7 +33,7 @@ function PressureCount({ value }: { value: number }) {
   return value > 0 ? (
     <span style={{ color: "var(--red)" }}>{formatNumber(value)}</span>
   ) : (
-    <span className="text-[var(--text-faint)]">0</span>
+    <span className="text-[var(--text-dim)]">0</span>
   );
 }
 
@@ -41,20 +41,20 @@ const COLUMNS: Column<SupplyPressureModel>[] = [
   { key: "model", header: "Model", render: (model) => <ModelCell model={model} /> },
   {
     key: "signal",
-    header: "Machine signal",
-    render: (model) => <MachineSignal model={model} />,
+    header: "Dominant signal",
+    render: (model) => <DominantSignal model={model} />,
   },
   {
-    key: "unserved1h",
-    header: "Unserved 1h",
+    key: "supplyRejects1h",
+    header: "Supply rejects 1h",
     align: "right",
-    render: (model) => <PressureCount value={model.unserved1h} />,
+    render: (model) => <PressureCount value={model.supplyRejects1h} />,
   },
   {
-    key: "unserved24h",
-    header: "Unserved 24h",
+    key: "supplyRejects24h",
+    header: "Supply rejects 24h",
     align: "right",
-    render: (model) => <PressureCount value={model.unserved24h} />,
+    render: (model) => <PressureCount value={model.supplyRejects24h} />,
   },
   {
     key: "served24h",
@@ -63,34 +63,37 @@ const COLUMNS: Column<SupplyPressureModel>[] = [
     render: (model) => formatNumber(model.served24h),
   },
   {
-    key: "lossRate",
-    header: "Supply loss",
+    key: "rejectShare",
+    header: "Reject share 24h",
     align: "right",
     render: (model) => (
-      <SupplyLossMeter unserved={model.unserved24h} served={model.served24h} />
+      <SupplyRejectShareMeter
+        rejected={model.supplyRejects24h}
+        served={model.served24h}
+      />
     ),
   },
   {
     key: "capacitySheds24h",
-    header: "Busy / queue",
+    header: "Busy / queue 24h",
     align: "right",
     render: (model) => <PressureCount value={model.capacitySheds24h} />,
   },
   {
     key: "latencySheds24h",
-    header: "TTFT / deadline",
+    header: "TTFT / deadline 24h",
     align: "right",
     render: (model) => <PressureCount value={model.latencySheds24h} />,
   },
   {
     key: "unavailableSheds24h",
-    header: "No provider",
+    header: "No provider 24h",
     align: "right",
     render: (model) => <PressureCount value={model.unavailableSheds24h} />,
   },
   {
     key: "actualTTFT",
-    header: "Observed p95 TTFT",
+    header: "Dispatch→content p95",
     align: "right",
     render: (model) => (
       <TTFTValue
@@ -101,7 +104,7 @@ const COLUMNS: Column<SupplyPressureModel>[] = [
   },
   {
     key: "rejectedTTFT",
-    header: "Rejected best p95",
+    header: "Rejected best p95 TTFT",
     align: "right",
     render: (model) => (
       <TTFTValue
@@ -112,7 +115,7 @@ const COLUMNS: Column<SupplyPressureModel>[] = [
   },
   {
     key: "hardwareMismatches24h",
-    header: "Needs larger RAM",
+    header: "Needs larger RAM 24h",
     align: "right",
     render: (model) => <PressureCount value={model.hardwareMismatches24h} />,
   },
@@ -147,31 +150,40 @@ export default async function SupplyPage() {
       <div>
         <h1 className="text-lg font-semibold">Supply pressure</h1>
         <p className="mt-1 text-sm text-[var(--text-dim)]">
-          Public-network demand lost to saturation, unavailable providers, or TTFT
-          deadlines. Exclusive self-route traffic and non-supply rejections are excluded.
+          Public-network requests rejected because of saturation, unavailable providers,
+          or TTFT deadlines. Exclusive self-route traffic and non-supply rejections are
+          excluded.
         </p>
       </div>
 
       <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
-        <StatCard label="Unserved (1h)" value={formatNumber(data.summary.unserved1h)} />
-        <StatCard label="Unserved (24h)" value={formatNumber(data.summary.unserved24h)} />
         <StatCard
-          label="Supply loss (24h)"
-          value={formatPercent(data.summary.supplyLossRate24h)}
+          label="Supply rejects (1h)"
+          value={formatNumber(data.summary.supplyRejects1h)}
         />
         <StatCard
-          label="Models pressured now"
+          label="Supply rejects (24h)"
+          value={formatNumber(data.summary.supplyRejects24h)}
+        />
+        <StatCard
+          label="Reject share (24h)"
+          value={formatPercent(data.summary.supplyRejectShare24h)}
+        />
+        <StatCard
+          label="Models with signals (1h)"
           value={formatNumber(data.summary.pressuredModels1h)}
         />
       </div>
 
       <div className="rounded-lg border border-[var(--border)] bg-[var(--bg-elevated)] p-4 text-sm text-[var(--text-dim)]">
         <span className="font-medium text-[var(--text)]">How to read this:</span>{" "}
-        <span className="text-[var(--red)]">Add machines</span> means capacity or queue
-        sheds dominate. <span className="text-[var(--amber)]">Warm / faster</span> means
-        TTFT or deadline sheds dominate. Model-too-large requests are reported separately
-        because adding more machines of the same size cannot serve them. P95 values use
-        the last hour when available, otherwise the last 24 hours.
+        Capacity rejects are the clearest signal to add machines. TTFT/deadline rejects
+        point to warmer or faster supply. No-eligible-provider signals can also reflect
+        offline, trust-gated, or cooling-down machines. Model-too-large requests are
+        separate because adding machines of the same size cannot serve them. Reject share
+        compares rejection rows with successful usage rows; retries can produce additional
+        rows. Dispatch→content p95 excludes queue time. P95 values use the last hour when
+        available, otherwise the last 24 hours.
       </div>
 
       <DataTable

--- a/admin-ui/src/app/supply/page.tsx
+++ b/admin-ui/src/app/supply/page.tsx
@@ -87,7 +87,7 @@ const COLUMNS: Column<SupplyPressureModel>[] = [
   },
   {
     key: "unavailableSheds24h",
-    header: "No provider 24h",
+    header: "No eligible provider 24h",
     align: "right",
     render: (model) => <PressureCount value={model.unavailableSheds24h} />,
   },

--- a/admin-ui/src/app/supply/page.tsx
+++ b/admin-ui/src/app/supply/page.tsx
@@ -1,0 +1,184 @@
+import { DataTable, type Column } from "@/components/DataTable";
+import {
+  MachineSignal,
+  SupplyLossMeter,
+  TTFTValue,
+} from "@/components/supply/SupplyPressureCells";
+import { StatCard } from "@/components/StatCard";
+import { isUndefinedTable } from "@/lib/db";
+import { formatNumber, formatPercent } from "@/lib/format";
+import { getSupplyPressure } from "@/lib/queries/supply";
+import type { SupplyPressureModel } from "@/lib/supply-pressure";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+function ModelCell({ model }: { model: SupplyPressureModel }) {
+  return (
+    <div className="min-w-56">
+      <div className="font-medium">{model.displayName}</div>
+      {model.displayName !== model.model && (
+        <div className="mono mt-0.5 text-[var(--text-faint)]">{model.model}</div>
+      )}
+      {model.minRamGB !== null && model.minRamGB > 0 && (
+        <div className="mt-1 text-xs text-[var(--text-faint)]">
+          catalog minimum {formatNumber(model.minRamGB)} GB RAM
+        </div>
+      )}
+    </div>
+  );
+}
+
+function PressureCount({ value }: { value: number }) {
+  return value > 0 ? (
+    <span style={{ color: "var(--red)" }}>{formatNumber(value)}</span>
+  ) : (
+    <span className="text-[var(--text-faint)]">0</span>
+  );
+}
+
+const COLUMNS: Column<SupplyPressureModel>[] = [
+  { key: "model", header: "Model", render: (model) => <ModelCell model={model} /> },
+  {
+    key: "signal",
+    header: "Machine signal",
+    render: (model) => <MachineSignal model={model} />,
+  },
+  {
+    key: "unserved1h",
+    header: "Unserved 1h",
+    align: "right",
+    render: (model) => <PressureCount value={model.unserved1h} />,
+  },
+  {
+    key: "unserved24h",
+    header: "Unserved 24h",
+    align: "right",
+    render: (model) => <PressureCount value={model.unserved24h} />,
+  },
+  {
+    key: "served24h",
+    header: "Served 24h",
+    align: "right",
+    render: (model) => formatNumber(model.served24h),
+  },
+  {
+    key: "lossRate",
+    header: "Supply loss",
+    align: "right",
+    render: (model) => (
+      <SupplyLossMeter unserved={model.unserved24h} served={model.served24h} />
+    ),
+  },
+  {
+    key: "capacitySheds24h",
+    header: "Busy / queue",
+    align: "right",
+    render: (model) => <PressureCount value={model.capacitySheds24h} />,
+  },
+  {
+    key: "latencySheds24h",
+    header: "TTFT / deadline",
+    align: "right",
+    render: (model) => <PressureCount value={model.latencySheds24h} />,
+  },
+  {
+    key: "unavailableSheds24h",
+    header: "No provider",
+    align: "right",
+    render: (model) => <PressureCount value={model.unavailableSheds24h} />,
+  },
+  {
+    key: "actualTTFT",
+    header: "Observed p95 TTFT",
+    align: "right",
+    render: (model) => (
+      <TTFTValue
+        current={model.actualTTFTP95Ms1h}
+        fallback={model.actualTTFTP95Ms24h}
+      />
+    ),
+  },
+  {
+    key: "rejectedTTFT",
+    header: "Rejected best p95",
+    align: "right",
+    render: (model) => (
+      <TTFTValue
+        current={model.rejectedTTFTP95Ms1h}
+        fallback={model.rejectedTTFTP95Ms24h}
+      />
+    ),
+  },
+  {
+    key: "hardwareMismatches24h",
+    header: "Needs larger RAM",
+    align: "right",
+    render: (model) => <PressureCount value={model.hardwareMismatches24h} />,
+  },
+];
+
+function NotDeployed() {
+  return (
+    <div className="space-y-4">
+      <h1 className="text-lg font-semibold">Supply pressure</h1>
+      <div className="rounded-lg border border-[var(--border)] bg-[var(--bg-elevated)] p-4 text-sm text-[var(--text-dim)]">
+        <div className="font-medium text-[var(--text)]">Supply telemetry not deployed yet</div>
+        <p className="mt-1">
+          The routing and rejection tables do not exist on the replica yet. This view will
+          populate after a coordinator with supply telemetry is deployed.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export default async function SupplyPage() {
+  let data;
+  try {
+    data = await getSupplyPressure();
+  } catch (error) {
+    if (isUndefinedTable(error)) return <NotDeployed />;
+    throw error;
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-lg font-semibold">Supply pressure</h1>
+        <p className="mt-1 text-sm text-[var(--text-dim)]">
+          Public-network demand lost to saturation, unavailable providers, or TTFT
+          deadlines. Exclusive self-route traffic and non-supply rejections are excluded.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+        <StatCard label="Unserved (1h)" value={formatNumber(data.summary.unserved1h)} />
+        <StatCard label="Unserved (24h)" value={formatNumber(data.summary.unserved24h)} />
+        <StatCard
+          label="Supply loss (24h)"
+          value={formatPercent(data.summary.supplyLossRate24h)}
+        />
+        <StatCard
+          label="Models pressured now"
+          value={formatNumber(data.summary.pressuredModels1h)}
+        />
+      </div>
+
+      <div className="rounded-lg border border-[var(--border)] bg-[var(--bg-elevated)] p-4 text-sm text-[var(--text-dim)]">
+        <span className="font-medium text-[var(--text)]">How to read this:</span>{" "}
+        <span className="text-[var(--red)]">Add machines</span> means capacity or queue
+        sheds dominate. <span className="text-[var(--amber)]">Warm / faster</span> means
+        TTFT or deadline sheds dominate. Model-too-large requests are reported separately
+        because adding more machines of the same size cannot serve them. P95 values use
+        the last hour when available, otherwise the last 24 hours.
+      </div>
+
+      <DataTable
+        columns={COLUMNS}
+        rows={data.models}
+        empty="No served traffic or supply-pressure signals in the last 24 hours."
+      />
+    </div>
+  );
+}

--- a/admin-ui/src/components/AppShell.tsx
+++ b/admin-ui/src/components/AppShell.tsx
@@ -8,6 +8,7 @@ const NAV: { href: string; label: string }[] = [
   { href: "/operators", label: "Operators" },
   { href: "/uptime", label: "Uptime" },
   { href: "/usage", label: "Usage" },
+  { href: "/supply", label: "Supply" },
   { href: "/billing", label: "Billing" },
   { href: "/earnings", label: "Earnings" },
   { href: "/api-keys", label: "API Keys" },

--- a/admin-ui/src/components/supply/SupplyPressureCells.tsx
+++ b/admin-ui/src/components/supply/SupplyPressureCells.tsx
@@ -1,16 +1,16 @@
 import { formatMilliseconds, formatPercent } from "@/lib/format";
 import {
-  getMachineRecommendation,
-  supplyLossRate,
+  getDominantSupplySignal,
+  supplyRejectShare,
   type SupplyPressureModel,
 } from "@/lib/supply-pressure";
 
-export function MachineSignal({ model }: { model: SupplyPressureModel }) {
-  const recommendation = getMachineRecommendation(model);
+export function DominantSignal({ model }: { model: SupplyPressureModel }) {
+  const signal = getDominantSupplySignal(model);
   const color =
-    recommendation.window === "1h"
+    signal.window === "1h"
       ? "var(--red)"
-      : recommendation.window === "24h"
+      : signal.window === "24h"
         ? "var(--amber)"
         : "var(--green)";
 
@@ -20,28 +20,28 @@ export function MachineSignal({ model }: { model: SupplyPressureModel }) {
         className="inline-flex rounded px-1.5 py-0.5 text-xs font-medium"
         style={{ background: "var(--bg-hover)", color }}
       >
-        {recommendation.label}
+        {signal.label}
       </span>
-      <div className="mt-1 text-xs text-[var(--text-faint)]">
-        {recommendation.window === "1h"
-          ? "active in the last hour"
-          : recommendation.window === "24h"
+      <div className="mt-1 text-xs text-[var(--text-dim)]">
+        {signal.window === "1h"
+          ? "seen in the last hour"
+          : signal.window === "24h"
             ? "seen in the last 24h"
-            : "no supply sheds in 24h"}
+            : "none in the last 24h"}
       </div>
     </div>
   );
 }
 
-export function SupplyLossMeter({
-  unserved,
+export function SupplyRejectShareMeter({
+  rejected,
   served,
 }: {
-  unserved: number;
+  rejected: number;
   served: number;
 }) {
-  const ratio = supplyLossRate(unserved, served);
-  if (ratio === null) return <span className="text-[var(--text-faint)]">—</span>;
+  const ratio = supplyRejectShare(rejected, served);
+  if (ratio === null) return <span className="text-[var(--text-dim)]">—</span>;
 
   const width = `${Math.min(100, Math.max(0, ratio * 100))}%`;
   const color = ratio >= 0.1 ? "var(--red)" : ratio > 0 ? "var(--amber)" : "var(--green)";
@@ -64,12 +64,12 @@ export function TTFTValue({
   fallback: number | null;
 }) {
   const value = current ?? fallback;
-  if (value === null) return <span className="text-[var(--text-faint)]">—</span>;
+  if (value === null) return <span className="text-[var(--text-dim)]">—</span>;
 
   return (
     <span className="whitespace-nowrap">
       {formatMilliseconds(value)}
-      <span className="ml-1 text-xs text-[var(--text-faint)]">
+      <span className="ml-1 text-xs text-[var(--text-dim)]">
         {current === null ? "24h" : "1h"}
       </span>
     </span>

--- a/admin-ui/src/components/supply/SupplyPressureCells.tsx
+++ b/admin-ui/src/components/supply/SupplyPressureCells.tsx
@@ -1,0 +1,77 @@
+import { formatMilliseconds, formatPercent } from "@/lib/format";
+import {
+  getMachineRecommendation,
+  supplyLossRate,
+  type SupplyPressureModel,
+} from "@/lib/supply-pressure";
+
+export function MachineSignal({ model }: { model: SupplyPressureModel }) {
+  const recommendation = getMachineRecommendation(model);
+  const color =
+    recommendation.window === "1h"
+      ? "var(--red)"
+      : recommendation.window === "24h"
+        ? "var(--amber)"
+        : "var(--green)";
+
+  return (
+    <div className="min-w-36">
+      <span
+        className="inline-flex rounded px-1.5 py-0.5 text-xs font-medium"
+        style={{ background: "var(--bg-hover)", color }}
+      >
+        {recommendation.label}
+      </span>
+      <div className="mt-1 text-xs text-[var(--text-faint)]">
+        {recommendation.window === "1h"
+          ? "active in the last hour"
+          : recommendation.window === "24h"
+            ? "seen in the last 24h"
+            : "no supply sheds in 24h"}
+      </div>
+    </div>
+  );
+}
+
+export function SupplyLossMeter({
+  unserved,
+  served,
+}: {
+  unserved: number;
+  served: number;
+}) {
+  const ratio = supplyLossRate(unserved, served);
+  if (ratio === null) return <span className="text-[var(--text-faint)]">—</span>;
+
+  const width = `${Math.min(100, Math.max(0, ratio * 100))}%`;
+  const color = ratio >= 0.1 ? "var(--red)" : ratio > 0 ? "var(--amber)" : "var(--green)";
+
+  return (
+    <div className="min-w-24">
+      <div className="text-right tabular-nums">{formatPercent(ratio)}</div>
+      <div className="mt-1 h-1.5 overflow-hidden rounded bg-[var(--bg-hover)]">
+        <div className="h-full rounded" style={{ width, background: color }} />
+      </div>
+    </div>
+  );
+}
+
+export function TTFTValue({
+  current,
+  fallback,
+}: {
+  current: number | null;
+  fallback: number | null;
+}) {
+  const value = current ?? fallback;
+  if (value === null) return <span className="text-[var(--text-faint)]">—</span>;
+
+  return (
+    <span className="whitespace-nowrap">
+      {formatMilliseconds(value)}
+      <span className="ml-1 text-xs text-[var(--text-faint)]">
+        {current === null ? "24h" : "1h"}
+      </span>
+    </span>
+  );
+}

--- a/admin-ui/src/lib/format.test.ts
+++ b/admin-ui/src/lib/format.test.ts
@@ -5,6 +5,8 @@ import {
   formatDateTime,
   formatRelative,
   formatDuration,
+  formatPercent,
+  formatMilliseconds,
   isOnline,
   truncate,
   ONLINE_WINDOW_SECONDS,
@@ -86,5 +88,20 @@ describe("formatDateTime", () => {
   it("renders an ISO-ish timestamp and dash for null", () => {
     expect(formatDateTime("2026-06-03T12:00:00.000Z")).toBe("2026-06-03 12:00:00Z");
     expect(formatDateTime(null)).toBe("—");
+  });
+});
+
+describe("supply-pressure formats", () => {
+  it("formats ratios as percentages", () => {
+    expect(formatPercent(0.1234)).toBe("12.3%");
+    expect(formatPercent(0)).toBe("0%");
+    expect(formatPercent(null)).toBe("—");
+  });
+
+  it("formats TTFT in milliseconds or seconds", () => {
+    expect(formatMilliseconds(842.4)).toBe("842 ms");
+    expect(formatMilliseconds(1_250)).toBe("1.3 s");
+    expect(formatMilliseconds(null)).toBe("—");
+    expect(formatMilliseconds(-1)).toBe("—");
   });
 });

--- a/admin-ui/src/lib/format.ts
+++ b/admin-ui/src/lib/format.ts
@@ -71,3 +71,18 @@ export function formatDuration(seconds: number | string | null | undefined): str
   const d = Math.floor(h / 24);
   return `${d}d ${h % 24}h`;
 }
+
+export function formatPercent(ratio: number | null | undefined): string {
+  if (ratio === null || ratio === undefined || !Number.isFinite(ratio)) return "—";
+  return new Intl.NumberFormat("en-US", {
+    style: "percent",
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 1,
+  }).format(ratio);
+}
+
+export function formatMilliseconds(ms: number | null | undefined): string {
+  if (ms === null || ms === undefined || !Number.isFinite(ms) || ms < 0) return "—";
+  if (ms < 1_000) return `${Math.round(ms)} ms`;
+  return `${(ms / 1_000).toFixed(1)} s`;
+}

--- a/admin-ui/src/lib/queries/supply-sql.test.ts
+++ b/admin-ui/src/lib/queries/supply-sql.test.ts
@@ -1,0 +1,120 @@
+import { Client } from "pg";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  CAPACITY_SHED_REASONS,
+  LATENCY_SHED_REASONS,
+  SUPPLY_SHED_REASONS,
+  TRACKED_SUPPLY_REASONS,
+} from "../supply-pressure";
+import { SUPPLY_PRESSURE_SQL } from "./supply-sql";
+
+const databaseURL = process.env.ADMIN_TEST_DATABASE_URL ?? "";
+const describeWithPostgres = databaseURL ? describe : describe.skip;
+
+interface SupplyQueryRow {
+  model: string;
+  display_name: string | null;
+  min_ram_gb: number | null;
+  supply_rejects_1h: string;
+  supply_rejects_24h: string;
+  capacity_sheds_1h: string;
+  capacity_sheds_24h: string;
+  latency_sheds_1h: string;
+  unavailable_sheds_1h: string;
+  hardware_mismatches_1h: string;
+  served_24h: string;
+  actual_ttft_p95_ms_1h: number | null;
+  actual_ttft_p95_ms_24h: number | null;
+  rejected_ttft_p95_ms_1h: number | null;
+}
+
+describeWithPostgres("supply-pressure PostgreSQL query", () => {
+  const client = new Client({ connectionString: databaseURL, ssl: false });
+
+  beforeAll(async () => {
+    await client.connect();
+    await client.query(`
+      CREATE TEMP TABLE request_rejections (
+        requested_model TEXT,
+        resolved_model TEXT,
+        reason_code TEXT,
+        best_ttft_ms DOUBLE PRECISION,
+        self_route_only BOOLEAN,
+        created_at TIMESTAMPTZ NOT NULL
+      );
+      CREATE TEMP TABLE inference_routes (
+        model TEXT NOT NULL,
+        final_status TEXT NOT NULL,
+        actual_ttft_ms DOUBLE PRECISION,
+        self_route_only BOOLEAN NOT NULL DEFAULT FALSE,
+        created_at TIMESTAMPTZ NOT NULL
+      );
+      CREATE TEMP TABLE model_registry (
+        id TEXT PRIMARY KEY,
+        display_name TEXT NOT NULL,
+        min_ram_gb INTEGER NOT NULL
+      );
+
+      INSERT INTO model_registry (id, display_name, min_ram_gb) VALUES
+        ('model-a', 'Model A', 64),
+        ('model-b', 'Model B', 32);
+
+      INSERT INTO request_rejections
+        (requested_model, resolved_model, reason_code, best_ttft_ms, self_route_only, created_at)
+      VALUES
+        ('model-a', 'model-a', 'capacity_exhausted', NULL, FALSE, now() - interval '10 minutes'),
+        ('model-a', 'model-a', 'queue_full', NULL, FALSE, now() - interval '2 hours'),
+        ('model-a', 'model-a', 'deadline_unreachable', 4000, FALSE, now() - interval '20 minutes'),
+        ('model-a', 'model-a', 'model_too_large', NULL, FALSE, now() - interval '30 minutes'),
+        ('model-a', 'model-a', 'queue_full', NULL, TRUE, now() - interval '5 minutes'),
+        ('oversized-only', 'oversized-only', 'oversized_request', NULL, FALSE, now() - interval '5 minutes'),
+        ('model-b', 'model-b', 'no_provider', NULL, FALSE, now() - interval '15 minutes'),
+        ('expired', 'expired', 'queue_full', NULL, FALSE, now() - interval '25 hours');
+
+      INSERT INTO inference_routes
+        (model, final_status, actual_ttft_ms, self_route_only, created_at)
+      VALUES
+        ('model-a', 'success', 100, FALSE, now() - interval '10 minutes'),
+        ('model-a', 'partial_success', 300, FALSE, now() - interval '20 minutes'),
+        ('model-a', 'success', 500, FALSE, now() - interval '2 hours'),
+        ('model-a', 'error', 9000, FALSE, now() - interval '5 minutes'),
+        ('model-a', 'success', 8000, TRUE, now() - interval '5 minutes'),
+        ('model-b', 'success', 200, FALSE, now() - interval '5 minutes'),
+        ('self-only', 'success', 700, TRUE, now() - interval '5 minutes'),
+        ('expired', 'success', 600, FALSE, now() - interval '25 hours');
+    `);
+  });
+
+  afterAll(async () => {
+    await client.end();
+  });
+
+  it("aggregates public supply rejects and successful route TTFT", async () => {
+    const result = await client.query<SupplyQueryRow>(SUPPLY_PRESSURE_SQL, [
+      [...CAPACITY_SHED_REASONS],
+      [...LATENCY_SHED_REASONS],
+      [...SUPPLY_SHED_REASONS],
+      [...TRACKED_SUPPLY_REASONS],
+    ]);
+
+    expect(result.rows.map((row) => row.model)).toEqual(["model-a", "model-b"]);
+
+    const model = result.rows[0];
+    expect(model).toMatchObject({
+      model: "model-a",
+      display_name: "Model A",
+      min_ram_gb: 64,
+      supply_rejects_1h: "2",
+      supply_rejects_24h: "3",
+      capacity_sheds_1h: "1",
+      capacity_sheds_24h: "2",
+      latency_sheds_1h: "1",
+      unavailable_sheds_1h: "0",
+      hardware_mismatches_1h: "1",
+      served_24h: "3",
+    });
+    expect(model.actual_ttft_p95_ms_1h).toBeCloseTo(290);
+    expect(model.actual_ttft_p95_ms_24h).toBeCloseTo(480);
+    expect(model.rejected_ttft_p95_ms_1h).toBe(4000);
+  });
+});

--- a/admin-ui/src/lib/queries/supply-sql.ts
+++ b/admin-ui/src/lib/queries/supply-sql.ts
@@ -1,0 +1,114 @@
+export const SUPPLY_PRESSURE_SQL = `
+  WITH rejection_events AS (
+    SELECT COALESCE(
+             NULLIF(resolved_model, ''),
+             NULLIF(requested_model, ''),
+             '(unknown)'
+           ) AS model,
+           reason_code,
+           best_ttft_ms,
+           created_at
+      FROM request_rejections
+     WHERE created_at >= now() - interval '24 hours'
+       AND COALESCE(self_route_only, false) = false
+       AND reason_code = ANY($4::text[])
+  ),
+  rejection_rollup AS (
+    SELECT model,
+           count(*) FILTER (
+             WHERE reason_code = ANY($3::text[])
+               AND created_at >= now() - interval '1 hour'
+           )::bigint AS supply_rejects_1h,
+           count(*) FILTER (
+             WHERE reason_code = ANY($3::text[])
+           )::bigint AS supply_rejects_24h,
+           count(*) FILTER (
+             WHERE reason_code = ANY($1::text[])
+               AND created_at >= now() - interval '1 hour'
+           )::bigint AS capacity_sheds_1h,
+           count(*) FILTER (
+             WHERE reason_code = ANY($1::text[])
+           )::bigint AS capacity_sheds_24h,
+           count(*) FILTER (
+             WHERE reason_code = ANY($2::text[])
+               AND created_at >= now() - interval '1 hour'
+           )::bigint AS latency_sheds_1h,
+           count(*) FILTER (
+             WHERE reason_code = ANY($2::text[])
+           )::bigint AS latency_sheds_24h,
+           count(*) FILTER (
+             WHERE reason_code = 'no_provider'
+               AND created_at >= now() - interval '1 hour'
+           )::bigint AS unavailable_sheds_1h,
+           count(*) FILTER (
+             WHERE reason_code = 'no_provider'
+           )::bigint AS unavailable_sheds_24h,
+           count(*) FILTER (
+             WHERE reason_code = 'model_too_large'
+               AND created_at >= now() - interval '1 hour'
+           )::bigint AS hardware_mismatches_1h,
+           count(*) FILTER (
+             WHERE reason_code = 'model_too_large'
+           )::bigint AS hardware_mismatches_24h,
+           percentile_cont(0.95) WITHIN GROUP (ORDER BY best_ttft_ms) FILTER (
+             WHERE reason_code = ANY($2::text[])
+               AND best_ttft_ms > 0
+               AND created_at >= now() - interval '1 hour'
+           ) AS rejected_ttft_p95_ms_1h,
+           percentile_cont(0.95) WITHIN GROUP (ORDER BY best_ttft_ms) FILTER (
+             WHERE reason_code = ANY($2::text[])
+               AND best_ttft_ms > 0
+           ) AS rejected_ttft_p95_ms_24h
+      FROM rejection_events
+     GROUP BY model
+  ),
+  route_rollup AS (
+    SELECT model,
+           count(*)::bigint AS served_24h,
+           percentile_cont(0.95) WITHIN GROUP (ORDER BY actual_ttft_ms) FILTER (
+             WHERE created_at >= now() - interval '1 hour'
+               AND actual_ttft_ms > 0
+           ) AS actual_ttft_p95_ms_1h,
+           percentile_cont(0.95) WITHIN GROUP (ORDER BY actual_ttft_ms) FILTER (
+             WHERE actual_ttft_ms > 0
+           ) AS actual_ttft_p95_ms_24h
+      FROM inference_routes
+     WHERE created_at >= now() - interval '24 hours'
+       AND model <> ''
+       AND COALESCE(self_route_only, false) = false
+       AND final_status IN ('success', 'partial_success')
+     GROUP BY model
+  ),
+  model_keys AS (
+    SELECT model FROM rejection_rollup
+    UNION
+    SELECT model FROM route_rollup
+  )
+  SELECT mk.model,
+         mr.display_name,
+         mr.min_ram_gb,
+         COALESCE(rr.supply_rejects_1h, 0)::bigint AS supply_rejects_1h,
+         COALESCE(rr.supply_rejects_24h, 0)::bigint AS supply_rejects_24h,
+         COALESCE(rr.capacity_sheds_1h, 0)::bigint AS capacity_sheds_1h,
+         COALESCE(rr.capacity_sheds_24h, 0)::bigint AS capacity_sheds_24h,
+         COALESCE(rr.latency_sheds_1h, 0)::bigint AS latency_sheds_1h,
+         COALESCE(rr.latency_sheds_24h, 0)::bigint AS latency_sheds_24h,
+         COALESCE(rr.unavailable_sheds_1h, 0)::bigint AS unavailable_sheds_1h,
+         COALESCE(rr.unavailable_sheds_24h, 0)::bigint AS unavailable_sheds_24h,
+         COALESCE(rr.hardware_mismatches_1h, 0)::bigint AS hardware_mismatches_1h,
+         COALESCE(rr.hardware_mismatches_24h, 0)::bigint AS hardware_mismatches_24h,
+         COALESCE(tr.served_24h, 0)::bigint AS served_24h,
+         tr.actual_ttft_p95_ms_1h,
+         tr.actual_ttft_p95_ms_24h,
+         rr.rejected_ttft_p95_ms_1h,
+         rr.rejected_ttft_p95_ms_24h
+    FROM model_keys mk
+    LEFT JOIN rejection_rollup rr USING (model)
+    LEFT JOIN route_rollup tr USING (model)
+    LEFT JOIN model_registry mr ON mr.id = mk.model
+   ORDER BY COALESCE(rr.supply_rejects_1h, 0) DESC,
+            COALESCE(rr.hardware_mismatches_1h, 0) DESC,
+            COALESCE(rr.supply_rejects_24h, 0) DESC,
+            COALESCE(tr.served_24h, 0) DESC,
+            mk.model
+`;

--- a/admin-ui/src/lib/queries/supply.ts
+++ b/admin-ui/src/lib/queries/supply.ts
@@ -1,0 +1,199 @@
+import "server-only";
+import { query } from "@/lib/db";
+import {
+  CAPACITY_SHED_REASONS,
+  LATENCY_SHED_REASONS,
+  SUPPLY_SHED_REASONS,
+  TRACKED_SUPPLY_REASONS,
+  summarizeSupplyPressure,
+  type SupplyPressureModel,
+  type SupplyPressureSummary,
+} from "@/lib/supply-pressure";
+
+interface RawSupplyPressureRow {
+  model: string;
+  display_name: string | null;
+  min_ram_gb: number | null;
+  unserved_1h: string;
+  unserved_24h: string;
+  capacity_sheds_1h: string;
+  capacity_sheds_24h: string;
+  latency_sheds_1h: string;
+  latency_sheds_24h: string;
+  unavailable_sheds_1h: string;
+  unavailable_sheds_24h: string;
+  hardware_mismatches_1h: string;
+  hardware_mismatches_24h: string;
+  served_24h: string;
+  actual_ttft_p95_ms_1h: number | null;
+  actual_ttft_p95_ms_24h: number | null;
+  rejected_ttft_p95_ms_1h: number | null;
+  rejected_ttft_p95_ms_24h: number | null;
+}
+
+export interface SupplyPressureOverview {
+  models: SupplyPressureModel[];
+  summary: SupplyPressureSummary;
+}
+
+const SUPPLY_PRESSURE_SQL = `
+  WITH rejection_events AS (
+    SELECT COALESCE(
+             NULLIF(resolved_model, ''),
+             NULLIF(requested_model, ''),
+             '(unknown)'
+           ) AS model,
+           reason_code,
+           best_ttft_ms,
+           created_at
+      FROM request_rejections
+     WHERE created_at >= now() - interval '24 hours'
+       AND COALESCE(self_route_only, false) = false
+       AND reason_code = ANY($4::text[])
+  ),
+  rejection_rollup AS (
+    SELECT model,
+           count(*) FILTER (
+             WHERE reason_code = ANY($3::text[])
+               AND created_at >= now() - interval '1 hour'
+           )::bigint AS unserved_1h,
+           count(*) FILTER (
+             WHERE reason_code = ANY($3::text[])
+           )::bigint AS unserved_24h,
+           count(*) FILTER (
+             WHERE reason_code = ANY($1::text[])
+               AND created_at >= now() - interval '1 hour'
+           )::bigint AS capacity_sheds_1h,
+           count(*) FILTER (
+             WHERE reason_code = ANY($1::text[])
+           )::bigint AS capacity_sheds_24h,
+           count(*) FILTER (
+             WHERE reason_code = ANY($2::text[])
+               AND created_at >= now() - interval '1 hour'
+           )::bigint AS latency_sheds_1h,
+           count(*) FILTER (
+             WHERE reason_code = ANY($2::text[])
+           )::bigint AS latency_sheds_24h,
+           count(*) FILTER (
+             WHERE reason_code = 'no_provider'
+               AND created_at >= now() - interval '1 hour'
+           )::bigint AS unavailable_sheds_1h,
+           count(*) FILTER (
+             WHERE reason_code = 'no_provider'
+           )::bigint AS unavailable_sheds_24h,
+           count(*) FILTER (
+             WHERE reason_code = 'model_too_large'
+               AND created_at >= now() - interval '1 hour'
+           )::bigint AS hardware_mismatches_1h,
+           count(*) FILTER (
+             WHERE reason_code = 'model_too_large'
+           )::bigint AS hardware_mismatches_24h,
+           percentile_cont(0.95) WITHIN GROUP (ORDER BY best_ttft_ms) FILTER (
+             WHERE reason_code = ANY($2::text[])
+               AND best_ttft_ms > 0
+               AND created_at >= now() - interval '1 hour'
+           ) AS rejected_ttft_p95_ms_1h,
+           percentile_cont(0.95) WITHIN GROUP (ORDER BY best_ttft_ms) FILTER (
+             WHERE reason_code = ANY($2::text[])
+               AND best_ttft_ms > 0
+           ) AS rejected_ttft_p95_ms_24h
+      FROM rejection_events
+     GROUP BY model
+  ),
+  usage_rollup AS (
+    SELECT model,
+           count(*)::bigint AS served_24h
+      FROM usage
+     WHERE created_at >= now() - interval '24 hours'
+       AND model <> ''
+     GROUP BY model
+  ),
+  ttft_rollup AS (
+    SELECT model,
+           percentile_cont(0.95) WITHIN GROUP (ORDER BY actual_ttft_ms) FILTER (
+             WHERE created_at >= now() - interval '1 hour'
+           ) AS actual_ttft_p95_ms_1h,
+           percentile_cont(0.95) WITHIN GROUP (ORDER BY actual_ttft_ms)
+             AS actual_ttft_p95_ms_24h
+      FROM inference_routes
+     WHERE created_at >= now() - interval '24 hours'
+       AND model <> ''
+       AND actual_ttft_ms > 0
+     GROUP BY model
+  ),
+  model_keys AS (
+    SELECT model FROM rejection_rollup
+    UNION
+    SELECT model FROM usage_rollup
+    UNION
+    SELECT model FROM ttft_rollup
+  )
+  SELECT mk.model,
+         mr.display_name,
+         mr.min_ram_gb,
+         COALESCE(rr.unserved_1h, 0)::bigint AS unserved_1h,
+         COALESCE(rr.unserved_24h, 0)::bigint AS unserved_24h,
+         COALESCE(rr.capacity_sheds_1h, 0)::bigint AS capacity_sheds_1h,
+         COALESCE(rr.capacity_sheds_24h, 0)::bigint AS capacity_sheds_24h,
+         COALESCE(rr.latency_sheds_1h, 0)::bigint AS latency_sheds_1h,
+         COALESCE(rr.latency_sheds_24h, 0)::bigint AS latency_sheds_24h,
+         COALESCE(rr.unavailable_sheds_1h, 0)::bigint AS unavailable_sheds_1h,
+         COALESCE(rr.unavailable_sheds_24h, 0)::bigint AS unavailable_sheds_24h,
+         COALESCE(rr.hardware_mismatches_1h, 0)::bigint AS hardware_mismatches_1h,
+         COALESCE(rr.hardware_mismatches_24h, 0)::bigint AS hardware_mismatches_24h,
+         COALESCE(ur.served_24h, 0)::bigint AS served_24h,
+         tr.actual_ttft_p95_ms_1h,
+         tr.actual_ttft_p95_ms_24h,
+         rr.rejected_ttft_p95_ms_1h,
+         rr.rejected_ttft_p95_ms_24h
+    FROM model_keys mk
+    LEFT JOIN rejection_rollup rr USING (model)
+    LEFT JOIN usage_rollup ur USING (model)
+    LEFT JOIN ttft_rollup tr USING (model)
+    LEFT JOIN model_registry mr ON mr.id = mk.model
+   ORDER BY COALESCE(rr.unserved_1h, 0) DESC,
+            COALESCE(rr.hardware_mismatches_1h, 0) DESC,
+            COALESCE(rr.unserved_24h, 0) DESC,
+            COALESCE(ur.served_24h, 0) DESC,
+            mk.model
+`;
+
+function numeric(value: string | number | null): number {
+  return value === null ? 0 : Number(value);
+}
+
+function optionalNumeric(value: string | number | null): number | null {
+  return value === null ? null : Number(value);
+}
+
+export async function getSupplyPressure(): Promise<SupplyPressureOverview> {
+  const rows = await query<RawSupplyPressureRow>(SUPPLY_PRESSURE_SQL, [
+    [...CAPACITY_SHED_REASONS],
+    [...LATENCY_SHED_REASONS],
+    [...SUPPLY_SHED_REASONS],
+    [...TRACKED_SUPPLY_REASONS],
+  ]);
+
+  const models = rows.map<SupplyPressureModel>((row) => ({
+    model: row.model,
+    displayName: row.display_name || row.model,
+    minRamGB: row.min_ram_gb,
+    unserved1h: numeric(row.unserved_1h),
+    unserved24h: numeric(row.unserved_24h),
+    capacitySheds1h: numeric(row.capacity_sheds_1h),
+    capacitySheds24h: numeric(row.capacity_sheds_24h),
+    latencySheds1h: numeric(row.latency_sheds_1h),
+    latencySheds24h: numeric(row.latency_sheds_24h),
+    unavailableSheds1h: numeric(row.unavailable_sheds_1h),
+    unavailableSheds24h: numeric(row.unavailable_sheds_24h),
+    hardwareMismatches1h: numeric(row.hardware_mismatches_1h),
+    hardwareMismatches24h: numeric(row.hardware_mismatches_24h),
+    served24h: numeric(row.served_24h),
+    actualTTFTP95Ms1h: optionalNumeric(row.actual_ttft_p95_ms_1h),
+    actualTTFTP95Ms24h: optionalNumeric(row.actual_ttft_p95_ms_24h),
+    rejectedTTFTP95Ms1h: optionalNumeric(row.rejected_ttft_p95_ms_1h),
+    rejectedTTFTP95Ms24h: optionalNumeric(row.rejected_ttft_p95_ms_24h),
+  }));
+
+  return { models, summary: summarizeSupplyPressure(models) };
+}

--- a/admin-ui/src/lib/queries/supply.ts
+++ b/admin-ui/src/lib/queries/supply.ts
@@ -1,5 +1,6 @@
 import "server-only";
 import { query } from "@/lib/db";
+import { SUPPLY_PRESSURE_SQL } from "@/lib/queries/supply-sql";
 import {
   CAPACITY_SHED_REASONS,
   LATENCY_SHED_REASONS,
@@ -35,129 +36,6 @@ export interface SupplyPressureOverview {
   models: SupplyPressureModel[];
   summary: SupplyPressureSummary;
 }
-
-const SUPPLY_PRESSURE_SQL = `
-  WITH rejection_events AS (
-    SELECT COALESCE(
-             NULLIF(resolved_model, ''),
-             NULLIF(requested_model, ''),
-             '(unknown)'
-           ) AS model,
-           reason_code,
-           best_ttft_ms,
-           created_at
-      FROM request_rejections
-     WHERE created_at >= now() - interval '24 hours'
-       AND COALESCE(self_route_only, false) = false
-       AND reason_code = ANY($4::text[])
-  ),
-  rejection_rollup AS (
-    SELECT model,
-           count(*) FILTER (
-             WHERE reason_code = ANY($3::text[])
-               AND created_at >= now() - interval '1 hour'
-           )::bigint AS supply_rejects_1h,
-           count(*) FILTER (
-             WHERE reason_code = ANY($3::text[])
-           )::bigint AS supply_rejects_24h,
-           count(*) FILTER (
-             WHERE reason_code = ANY($1::text[])
-               AND created_at >= now() - interval '1 hour'
-           )::bigint AS capacity_sheds_1h,
-           count(*) FILTER (
-             WHERE reason_code = ANY($1::text[])
-           )::bigint AS capacity_sheds_24h,
-           count(*) FILTER (
-             WHERE reason_code = ANY($2::text[])
-               AND created_at >= now() - interval '1 hour'
-           )::bigint AS latency_sheds_1h,
-           count(*) FILTER (
-             WHERE reason_code = ANY($2::text[])
-           )::bigint AS latency_sheds_24h,
-           count(*) FILTER (
-             WHERE reason_code = 'no_provider'
-               AND created_at >= now() - interval '1 hour'
-           )::bigint AS unavailable_sheds_1h,
-           count(*) FILTER (
-             WHERE reason_code = 'no_provider'
-           )::bigint AS unavailable_sheds_24h,
-           count(*) FILTER (
-             WHERE reason_code = 'model_too_large'
-               AND created_at >= now() - interval '1 hour'
-           )::bigint AS hardware_mismatches_1h,
-           count(*) FILTER (
-             WHERE reason_code = 'model_too_large'
-           )::bigint AS hardware_mismatches_24h,
-           percentile_cont(0.95) WITHIN GROUP (ORDER BY best_ttft_ms) FILTER (
-             WHERE reason_code = ANY($2::text[])
-               AND best_ttft_ms > 0
-               AND created_at >= now() - interval '1 hour'
-           ) AS rejected_ttft_p95_ms_1h,
-           percentile_cont(0.95) WITHIN GROUP (ORDER BY best_ttft_ms) FILTER (
-             WHERE reason_code = ANY($2::text[])
-               AND best_ttft_ms > 0
-           ) AS rejected_ttft_p95_ms_24h
-      FROM rejection_events
-     GROUP BY model
-  ),
-  usage_rollup AS (
-    SELECT model,
-           count(*)::bigint AS served_24h
-      FROM usage
-     WHERE created_at >= now() - interval '24 hours'
-       AND model <> ''
-     GROUP BY model
-  ),
-  ttft_rollup AS (
-    SELECT model,
-           percentile_cont(0.95) WITHIN GROUP (ORDER BY actual_ttft_ms) FILTER (
-             WHERE created_at >= now() - interval '1 hour'
-           ) AS actual_ttft_p95_ms_1h,
-           percentile_cont(0.95) WITHIN GROUP (ORDER BY actual_ttft_ms)
-             AS actual_ttft_p95_ms_24h
-      FROM inference_routes
-     WHERE created_at >= now() - interval '24 hours'
-       AND model <> ''
-       AND actual_ttft_ms > 0
-       AND COALESCE(self_route_only, false) = false
-     GROUP BY model
-  ),
-  model_keys AS (
-    SELECT model FROM rejection_rollup
-    UNION
-    SELECT model FROM usage_rollup
-    UNION
-    SELECT model FROM ttft_rollup
-  )
-  SELECT mk.model,
-         mr.display_name,
-         mr.min_ram_gb,
-         COALESCE(rr.supply_rejects_1h, 0)::bigint AS supply_rejects_1h,
-         COALESCE(rr.supply_rejects_24h, 0)::bigint AS supply_rejects_24h,
-         COALESCE(rr.capacity_sheds_1h, 0)::bigint AS capacity_sheds_1h,
-         COALESCE(rr.capacity_sheds_24h, 0)::bigint AS capacity_sheds_24h,
-         COALESCE(rr.latency_sheds_1h, 0)::bigint AS latency_sheds_1h,
-         COALESCE(rr.latency_sheds_24h, 0)::bigint AS latency_sheds_24h,
-         COALESCE(rr.unavailable_sheds_1h, 0)::bigint AS unavailable_sheds_1h,
-         COALESCE(rr.unavailable_sheds_24h, 0)::bigint AS unavailable_sheds_24h,
-         COALESCE(rr.hardware_mismatches_1h, 0)::bigint AS hardware_mismatches_1h,
-         COALESCE(rr.hardware_mismatches_24h, 0)::bigint AS hardware_mismatches_24h,
-         COALESCE(ur.served_24h, 0)::bigint AS served_24h,
-         tr.actual_ttft_p95_ms_1h,
-         tr.actual_ttft_p95_ms_24h,
-         rr.rejected_ttft_p95_ms_1h,
-         rr.rejected_ttft_p95_ms_24h
-    FROM model_keys mk
-    LEFT JOIN rejection_rollup rr USING (model)
-    LEFT JOIN usage_rollup ur USING (model)
-    LEFT JOIN ttft_rollup tr USING (model)
-    LEFT JOIN model_registry mr ON mr.id = mk.model
-   ORDER BY COALESCE(rr.supply_rejects_1h, 0) DESC,
-            COALESCE(rr.hardware_mismatches_1h, 0) DESC,
-            COALESCE(rr.supply_rejects_24h, 0) DESC,
-            COALESCE(ur.served_24h, 0) DESC,
-            mk.model
-`;
 
 function numeric(value: string | number | null): number {
   return value === null ? 0 : Number(value);

--- a/admin-ui/src/lib/queries/supply.ts
+++ b/admin-ui/src/lib/queries/supply.ts
@@ -14,8 +14,8 @@ interface RawSupplyPressureRow {
   model: string;
   display_name: string | null;
   min_ram_gb: number | null;
-  unserved_1h: string;
-  unserved_24h: string;
+  supply_rejects_1h: string;
+  supply_rejects_24h: string;
   capacity_sheds_1h: string;
   capacity_sheds_24h: string;
   latency_sheds_1h: string;
@@ -56,10 +56,10 @@ const SUPPLY_PRESSURE_SQL = `
            count(*) FILTER (
              WHERE reason_code = ANY($3::text[])
                AND created_at >= now() - interval '1 hour'
-           )::bigint AS unserved_1h,
+           )::bigint AS supply_rejects_1h,
            count(*) FILTER (
              WHERE reason_code = ANY($3::text[])
-           )::bigint AS unserved_24h,
+           )::bigint AS supply_rejects_24h,
            count(*) FILTER (
              WHERE reason_code = ANY($1::text[])
                AND created_at >= now() - interval '1 hour'
@@ -119,6 +119,7 @@ const SUPPLY_PRESSURE_SQL = `
      WHERE created_at >= now() - interval '24 hours'
        AND model <> ''
        AND actual_ttft_ms > 0
+       AND COALESCE(self_route_only, false) = false
      GROUP BY model
   ),
   model_keys AS (
@@ -131,8 +132,8 @@ const SUPPLY_PRESSURE_SQL = `
   SELECT mk.model,
          mr.display_name,
          mr.min_ram_gb,
-         COALESCE(rr.unserved_1h, 0)::bigint AS unserved_1h,
-         COALESCE(rr.unserved_24h, 0)::bigint AS unserved_24h,
+         COALESCE(rr.supply_rejects_1h, 0)::bigint AS supply_rejects_1h,
+         COALESCE(rr.supply_rejects_24h, 0)::bigint AS supply_rejects_24h,
          COALESCE(rr.capacity_sheds_1h, 0)::bigint AS capacity_sheds_1h,
          COALESCE(rr.capacity_sheds_24h, 0)::bigint AS capacity_sheds_24h,
          COALESCE(rr.latency_sheds_1h, 0)::bigint AS latency_sheds_1h,
@@ -151,9 +152,9 @@ const SUPPLY_PRESSURE_SQL = `
     LEFT JOIN usage_rollup ur USING (model)
     LEFT JOIN ttft_rollup tr USING (model)
     LEFT JOIN model_registry mr ON mr.id = mk.model
-   ORDER BY COALESCE(rr.unserved_1h, 0) DESC,
+   ORDER BY COALESCE(rr.supply_rejects_1h, 0) DESC,
             COALESCE(rr.hardware_mismatches_1h, 0) DESC,
-            COALESCE(rr.unserved_24h, 0) DESC,
+            COALESCE(rr.supply_rejects_24h, 0) DESC,
             COALESCE(ur.served_24h, 0) DESC,
             mk.model
 `;
@@ -178,8 +179,8 @@ export async function getSupplyPressure(): Promise<SupplyPressureOverview> {
     model: row.model,
     displayName: row.display_name || row.model,
     minRamGB: row.min_ram_gb,
-    unserved1h: numeric(row.unserved_1h),
-    unserved24h: numeric(row.unserved_24h),
+    supplyRejects1h: numeric(row.supply_rejects_1h),
+    supplyRejects24h: numeric(row.supply_rejects_24h),
     capacitySheds1h: numeric(row.capacity_sheds_1h),
     capacitySheds24h: numeric(row.capacity_sheds_24h),
     latencySheds1h: numeric(row.latency_sheds_1h),

--- a/admin-ui/src/lib/supply-pressure.test.ts
+++ b/admin-ui/src/lib/supply-pressure.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
   SUPPLY_SHED_REASONS,
-  getMachineRecommendation,
+  getDominantSupplySignal,
   summarizeSupplyPressure,
-  supplyLossRate,
+  supplyRejectShare,
   type SupplyPressureModel,
   type SupplySignalCounts,
 } from "./supply-pressure";
@@ -30,8 +30,8 @@ function model(
     ...EMPTY_SIGNALS,
     displayName: overrides.model,
     minRamGB: null,
-    unserved1h: 0,
-    unserved24h: 0,
+    supplyRejects1h: 0,
+    supplyRejects24h: 0,
     served24h: 0,
     actualTTFTP95Ms1h: null,
     actualTTFTP95Ms24h: null,
@@ -47,6 +47,7 @@ describe("supply rejection taxonomy", () => {
       "machine_busy",
       "queue_timeout",
       "queue_full",
+      "capacity_exhausted",
       "ttft_too_slow",
       "first_chunk_timeout",
       "deadline_unreachable",
@@ -57,75 +58,89 @@ describe("supply rejection taxonomy", () => {
   });
 });
 
-describe("getMachineRecommendation", () => {
+describe("getDominantSupplySignal", () => {
   it("uses active one-hour saturation ahead of older signals", () => {
     expect(
-      getMachineRecommendation(
+      getDominantSupplySignal(
         signals({
           capacitySheds1h: 3,
           capacitySheds24h: 3,
           unavailableSheds24h: 100,
         }),
       ),
-    ).toEqual({ kind: "add_machines", label: "Add machines", window: "1h" });
+    ).toEqual({ kind: "capacity", label: "Capacity rejects", window: "1h" });
   });
 
   it("falls back to the dominant 24-hour signal", () => {
     expect(
-      getMachineRecommendation(
+      getDominantSupplySignal(
         signals({
           capacitySheds24h: 2,
           latencySheds24h: 8,
           unavailableSheds24h: 1,
         }),
       ),
-    ).toEqual({ kind: "warm_or_faster", label: "Warm / faster", window: "24h" });
+    ).toEqual({ kind: "latency", label: "TTFT / deadline rejects", window: "24h" });
   });
 
   it("distinguishes machines that are too small from too few machines", () => {
     expect(
-      getMachineRecommendation(signals({ hardwareMismatches1h: 4 })),
-    ).toEqual({ kind: "larger_machines", label: "Larger RAM", window: "1h" });
+      getDominantSupplySignal(signals({ hardwareMismatches1h: 4 })),
+    ).toEqual({ kind: "hardware_mismatch", label: "Needs larger RAM", window: "1h" });
   });
 
-  it("reports no shortage when no tracked signal exists", () => {
-    expect(getMachineRecommendation(EMPTY_SIGNALS)).toEqual({
+  it("reports unavailable providers without asserting the cause", () => {
+    expect(
+      getDominantSupplySignal(signals({ unavailableSheds1h: 3 })),
+    ).toEqual({ kind: "unavailable", label: "No eligible provider", window: "1h" });
+  });
+
+  it("does not hide equal-strength hardware and capacity evidence", () => {
+    expect(
+      getDominantSupplySignal(
+        signals({ capacitySheds1h: 2, hardwareMismatches1h: 2 }),
+      ),
+    ).toEqual({ kind: "mixed", label: "Mixed signals", window: "1h" });
+  });
+
+  it("reports no tracked rejects when no signal exists", () => {
+    expect(getDominantSupplySignal(EMPTY_SIGNALS)).toEqual({
       kind: "none",
-      label: "No shortage",
+      label: "No tracked rejects",
       window: null,
     });
   });
 });
 
 describe("supply pressure summary", () => {
-  it("totals served and unserved demand and counts active models", () => {
+  it("totals served and rejected requests and counts recent signals", () => {
     const summary = summarizeSupplyPressure([
       model({
         model: "model-a",
-        unserved1h: 2,
-        unserved24h: 5,
+        supplyRejects1h: 2,
+        supplyRejects24h: 5,
         served24h: 15,
         capacitySheds1h: 2,
       }),
       model({
         model: "model-b",
-        unserved24h: 1,
+        supplyRejects24h: 1,
         served24h: 4,
         hardwareMismatches1h: 1,
       }),
     ]);
 
     expect(summary).toEqual({
-      unserved1h: 2,
-      unserved24h: 6,
+      supplyRejects1h: 2,
+      supplyRejects24h: 6,
       served24h: 19,
-      supplyLossRate24h: 0.24,
+      supplyRejectShare24h: 0.24,
       pressuredModels1h: 2,
     });
   });
 
-  it("returns no loss rate when there was no traffic", () => {
-    expect(supplyLossRate(0, 0)).toBeNull();
-    expect(supplyLossRate(2, 8)).toBe(0.2);
+  it("returns no reject share when there was no traffic", () => {
+    expect(supplyRejectShare(0, 0)).toBeNull();
+    expect(supplyRejectShare(2, 8)).toBe(0.2);
   });
 });

--- a/admin-ui/src/lib/supply-pressure.test.ts
+++ b/admin-ui/src/lib/supply-pressure.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+import {
+  SUPPLY_SHED_REASONS,
+  getMachineRecommendation,
+  summarizeSupplyPressure,
+  supplyLossRate,
+  type SupplyPressureModel,
+  type SupplySignalCounts,
+} from "./supply-pressure";
+
+const EMPTY_SIGNALS: SupplySignalCounts = {
+  capacitySheds1h: 0,
+  capacitySheds24h: 0,
+  latencySheds1h: 0,
+  latencySheds24h: 0,
+  unavailableSheds1h: 0,
+  unavailableSheds24h: 0,
+  hardwareMismatches1h: 0,
+  hardwareMismatches24h: 0,
+};
+
+function signals(overrides: Partial<SupplySignalCounts>): SupplySignalCounts {
+  return { ...EMPTY_SIGNALS, ...overrides };
+}
+
+function model(
+  overrides: Partial<SupplyPressureModel> & Pick<SupplyPressureModel, "model">,
+): SupplyPressureModel {
+  return {
+    ...EMPTY_SIGNALS,
+    displayName: overrides.model,
+    minRamGB: null,
+    unserved1h: 0,
+    unserved24h: 0,
+    served24h: 0,
+    actualTTFTP95Ms1h: null,
+    actualTTFTP95Ms24h: null,
+    rejectedTTFTP95Ms1h: null,
+    rejectedTTFTP95Ms24h: null,
+    ...overrides,
+  };
+}
+
+describe("supply rejection taxonomy", () => {
+  it("tracks saturation, availability, and latency loss without request-shape failures", () => {
+    expect(SUPPLY_SHED_REASONS).toEqual([
+      "machine_busy",
+      "queue_timeout",
+      "queue_full",
+      "ttft_too_slow",
+      "first_chunk_timeout",
+      "deadline_unreachable",
+      "no_provider",
+    ]);
+    expect(SUPPLY_SHED_REASONS).not.toContain("model_too_large");
+    expect(SUPPLY_SHED_REASONS).not.toContain("unservable_token_budget");
+  });
+});
+
+describe("getMachineRecommendation", () => {
+  it("uses active one-hour saturation ahead of older signals", () => {
+    expect(
+      getMachineRecommendation(
+        signals({
+          capacitySheds1h: 3,
+          capacitySheds24h: 3,
+          unavailableSheds24h: 100,
+        }),
+      ),
+    ).toEqual({ kind: "add_machines", label: "Add machines", window: "1h" });
+  });
+
+  it("falls back to the dominant 24-hour signal", () => {
+    expect(
+      getMachineRecommendation(
+        signals({
+          capacitySheds24h: 2,
+          latencySheds24h: 8,
+          unavailableSheds24h: 1,
+        }),
+      ),
+    ).toEqual({ kind: "warm_or_faster", label: "Warm / faster", window: "24h" });
+  });
+
+  it("distinguishes machines that are too small from too few machines", () => {
+    expect(
+      getMachineRecommendation(signals({ hardwareMismatches1h: 4 })),
+    ).toEqual({ kind: "larger_machines", label: "Larger RAM", window: "1h" });
+  });
+
+  it("reports no shortage when no tracked signal exists", () => {
+    expect(getMachineRecommendation(EMPTY_SIGNALS)).toEqual({
+      kind: "none",
+      label: "No shortage",
+      window: null,
+    });
+  });
+});
+
+describe("supply pressure summary", () => {
+  it("totals served and unserved demand and counts active models", () => {
+    const summary = summarizeSupplyPressure([
+      model({
+        model: "model-a",
+        unserved1h: 2,
+        unserved24h: 5,
+        served24h: 15,
+        capacitySheds1h: 2,
+      }),
+      model({
+        model: "model-b",
+        unserved24h: 1,
+        served24h: 4,
+        hardwareMismatches1h: 1,
+      }),
+    ]);
+
+    expect(summary).toEqual({
+      unserved1h: 2,
+      unserved24h: 6,
+      served24h: 19,
+      supplyLossRate24h: 0.24,
+      pressuredModels1h: 2,
+    });
+  });
+
+  it("returns no loss rate when there was no traffic", () => {
+    expect(supplyLossRate(0, 0)).toBeNull();
+    expect(supplyLossRate(2, 8)).toBe(0.2);
+  });
+});

--- a/admin-ui/src/lib/supply-pressure.ts
+++ b/admin-ui/src/lib/supply-pressure.ts
@@ -1,0 +1,160 @@
+export const CAPACITY_SHED_REASONS = [
+  "machine_busy",
+  "queue_timeout",
+  "queue_full",
+] as const;
+
+export const LATENCY_SHED_REASONS = [
+  "ttft_too_slow",
+  "first_chunk_timeout",
+  "deadline_unreachable",
+] as const;
+
+export const AVAILABILITY_SHED_REASONS = ["no_provider"] as const;
+export const HARDWARE_MISMATCH_REASONS = ["model_too_large"] as const;
+
+export const SUPPLY_SHED_REASONS = [
+  ...CAPACITY_SHED_REASONS,
+  ...LATENCY_SHED_REASONS,
+  ...AVAILABILITY_SHED_REASONS,
+] as const;
+
+export const TRACKED_SUPPLY_REASONS = [
+  ...SUPPLY_SHED_REASONS,
+  ...HARDWARE_MISMATCH_REASONS,
+] as const;
+
+export interface SupplySignalCounts {
+  capacitySheds1h: number;
+  capacitySheds24h: number;
+  latencySheds1h: number;
+  latencySheds24h: number;
+  unavailableSheds1h: number;
+  unavailableSheds24h: number;
+  hardwareMismatches1h: number;
+  hardwareMismatches24h: number;
+}
+
+export interface SupplyPressureModel extends SupplySignalCounts {
+  model: string;
+  displayName: string;
+  minRamGB: number | null;
+  unserved1h: number;
+  unserved24h: number;
+  served24h: number;
+  actualTTFTP95Ms1h: number | null;
+  actualTTFTP95Ms24h: number | null;
+  rejectedTTFTP95Ms1h: number | null;
+  rejectedTTFTP95Ms24h: number | null;
+}
+
+export interface SupplyPressureSummary {
+  unserved1h: number;
+  unserved24h: number;
+  served24h: number;
+  supplyLossRate24h: number | null;
+  pressuredModels1h: number;
+}
+
+export type MachineRecommendationKind =
+  | "add_machines"
+  | "warm_or_faster"
+  | "restore_supply"
+  | "larger_machines"
+  | "none";
+
+export interface MachineRecommendation {
+  kind: MachineRecommendationKind;
+  label: string;
+  window: "1h" | "24h" | null;
+}
+
+interface RankedSignal {
+  kind: Exclude<MachineRecommendationKind, "none">;
+  count1h: number;
+  count24h: number;
+}
+
+const LABELS: Record<Exclude<MachineRecommendationKind, "none">, string> = {
+  add_machines: "Add machines",
+  warm_or_faster: "Warm / faster",
+  restore_supply: "Restore / add supply",
+  larger_machines: "Larger RAM",
+};
+
+function rankedSignals(counts: SupplySignalCounts): RankedSignal[] {
+  return [
+    {
+      kind: "add_machines",
+      count1h: counts.capacitySheds1h,
+      count24h: counts.capacitySheds24h,
+    },
+    {
+      kind: "warm_or_faster",
+      count1h: counts.latencySheds1h,
+      count24h: counts.latencySheds24h,
+    },
+    {
+      kind: "restore_supply",
+      count1h: counts.unavailableSheds1h,
+      count24h: counts.unavailableSheds24h,
+    },
+    {
+      kind: "larger_machines",
+      count1h: counts.hardwareMismatches1h,
+      count24h: counts.hardwareMismatches24h,
+    },
+  ];
+}
+
+export function getMachineRecommendation(
+  counts: SupplySignalCounts,
+): MachineRecommendation {
+  const signals = rankedSignals(counts);
+  const window = signals.some((signal) => signal.count1h > 0) ? "1h" : "24h";
+  const countKey = window === "1h" ? "count1h" : "count24h";
+  const dominant = signals.reduce((best, signal) =>
+    signal[countKey] > best[countKey] ? signal : best,
+  );
+
+  if (dominant[countKey] === 0) {
+    return { kind: "none", label: "No shortage", window: null };
+  }
+  return {
+    kind: dominant.kind,
+    label: LABELS[dominant.kind],
+    window,
+  };
+}
+
+export function supplyLossRate(unserved: number, served: number): number | null {
+  const total = unserved + served;
+  return total > 0 ? unserved / total : null;
+}
+
+export function summarizeSupplyPressure(
+  models: SupplyPressureModel[],
+): SupplyPressureSummary {
+  const summary = models.reduce(
+    (acc, model) => {
+      acc.unserved1h += model.unserved1h;
+      acc.unserved24h += model.unserved24h;
+      acc.served24h += model.served24h;
+      if (model.unserved1h + model.hardwareMismatches1h > 0) {
+        acc.pressuredModels1h += 1;
+      }
+      return acc;
+    },
+    {
+      unserved1h: 0,
+      unserved24h: 0,
+      served24h: 0,
+      pressuredModels1h: 0,
+    },
+  );
+
+  return {
+    ...summary,
+    supplyLossRate24h: supplyLossRate(summary.unserved24h, summary.served24h),
+  };
+}

--- a/admin-ui/src/lib/supply-pressure.ts
+++ b/admin-ui/src/lib/supply-pressure.ts
@@ -2,6 +2,7 @@ export const CAPACITY_SHED_REASONS = [
   "machine_busy",
   "queue_timeout",
   "queue_full",
+  "capacity_exhausted",
 ] as const;
 
 export const LATENCY_SHED_REASONS = [
@@ -39,8 +40,8 @@ export interface SupplyPressureModel extends SupplySignalCounts {
   model: string;
   displayName: string;
   minRamGB: number | null;
-  unserved1h: number;
-  unserved24h: number;
+  supplyRejects1h: number;
+  supplyRejects24h: number;
   served24h: number;
   actualTTFTP95Ms1h: number | null;
   actualTTFTP95Ms24h: number | null;
@@ -49,77 +50,81 @@ export interface SupplyPressureModel extends SupplySignalCounts {
 }
 
 export interface SupplyPressureSummary {
-  unserved1h: number;
-  unserved24h: number;
+  supplyRejects1h: number;
+  supplyRejects24h: number;
   served24h: number;
-  supplyLossRate24h: number | null;
+  supplyRejectShare24h: number | null;
   pressuredModels1h: number;
 }
 
-export type MachineRecommendationKind =
-  | "add_machines"
-  | "warm_or_faster"
-  | "restore_supply"
-  | "larger_machines"
+export type DominantSupplySignalKind =
+  | "capacity"
+  | "latency"
+  | "unavailable"
+  | "hardware_mismatch"
+  | "mixed"
   | "none";
 
-export interface MachineRecommendation {
-  kind: MachineRecommendationKind;
+export interface DominantSupplySignal {
+  kind: DominantSupplySignalKind;
   label: string;
   window: "1h" | "24h" | null;
 }
 
 interface RankedSignal {
-  kind: Exclude<MachineRecommendationKind, "none">;
+  kind: Exclude<DominantSupplySignalKind, "mixed" | "none">;
   count1h: number;
   count24h: number;
 }
 
-const LABELS: Record<Exclude<MachineRecommendationKind, "none">, string> = {
-  add_machines: "Add machines",
-  warm_or_faster: "Warm / faster",
-  restore_supply: "Restore / add supply",
-  larger_machines: "Larger RAM",
+const LABELS: Record<Exclude<DominantSupplySignalKind, "mixed" | "none">, string> = {
+  capacity: "Capacity rejects",
+  latency: "TTFT / deadline rejects",
+  unavailable: "No eligible provider",
+  hardware_mismatch: "Needs larger RAM",
 };
 
 function rankedSignals(counts: SupplySignalCounts): RankedSignal[] {
   return [
     {
-      kind: "add_machines",
+      kind: "capacity",
       count1h: counts.capacitySheds1h,
       count24h: counts.capacitySheds24h,
     },
     {
-      kind: "warm_or_faster",
+      kind: "latency",
       count1h: counts.latencySheds1h,
       count24h: counts.latencySheds24h,
     },
     {
-      kind: "restore_supply",
+      kind: "unavailable",
       count1h: counts.unavailableSheds1h,
       count24h: counts.unavailableSheds24h,
     },
     {
-      kind: "larger_machines",
+      kind: "hardware_mismatch",
       count1h: counts.hardwareMismatches1h,
       count24h: counts.hardwareMismatches24h,
     },
   ];
 }
 
-export function getMachineRecommendation(
+export function getDominantSupplySignal(
   counts: SupplySignalCounts,
-): MachineRecommendation {
+): DominantSupplySignal {
   const signals = rankedSignals(counts);
   const window = signals.some((signal) => signal.count1h > 0) ? "1h" : "24h";
   const countKey = window === "1h" ? "count1h" : "count24h";
-  const dominant = signals.reduce((best, signal) =>
-    signal[countKey] > best[countKey] ? signal : best,
-  );
+  const topCount = Math.max(...signals.map((signal) => signal[countKey]));
 
-  if (dominant[countKey] === 0) {
-    return { kind: "none", label: "No shortage", window: null };
+  if (topCount === 0) {
+    return { kind: "none", label: "No tracked rejects", window: null };
   }
+  const leaders = signals.filter((signal) => signal[countKey] === topCount);
+  if (leaders.length > 1) {
+    return { kind: "mixed", label: "Mixed signals", window };
+  }
+  const dominant = leaders[0];
   return {
     kind: dominant.kind,
     label: LABELS[dominant.kind],
@@ -127,9 +132,9 @@ export function getMachineRecommendation(
   };
 }
 
-export function supplyLossRate(unserved: number, served: number): number | null {
-  const total = unserved + served;
-  return total > 0 ? unserved / total : null;
+export function supplyRejectShare(rejected: number, served: number): number | null {
+  const total = rejected + served;
+  return total > 0 ? rejected / total : null;
 }
 
 export function summarizeSupplyPressure(
@@ -137,17 +142,17 @@ export function summarizeSupplyPressure(
 ): SupplyPressureSummary {
   const summary = models.reduce(
     (acc, model) => {
-      acc.unserved1h += model.unserved1h;
-      acc.unserved24h += model.unserved24h;
+      acc.supplyRejects1h += model.supplyRejects1h;
+      acc.supplyRejects24h += model.supplyRejects24h;
       acc.served24h += model.served24h;
-      if (model.unserved1h + model.hardwareMismatches1h > 0) {
+      if (model.supplyRejects1h + model.hardwareMismatches1h > 0) {
         acc.pressuredModels1h += 1;
       }
       return acc;
     },
     {
-      unserved1h: 0,
-      unserved24h: 0,
+      supplyRejects1h: 0,
+      supplyRejects24h: 0,
       served24h: 0,
       pressuredModels1h: 0,
     },
@@ -155,6 +160,9 @@ export function summarizeSupplyPressure(
 
   return {
     ...summary,
-    supplyLossRate24h: supplyLossRate(summary.unserved24h, summary.served24h),
+    supplyRejectShare24h: supplyRejectShare(
+      summary.supplyRejects24h,
+      summary.served24h,
+    ),
   };
 }

--- a/coordinator/api/dispatch.go
+++ b/coordinator/api/dispatch.go
@@ -183,10 +183,11 @@ type dispatchState struct {
 	// later genuine provider fault has replaced it.
 	lastFailureDeadline bool
 	// unservable is set when the dispatch loop stops because the request cannot
-	// be served (deterministic-context rejection, or a transient that exhausted
-	// maxCapacityClassRetries). unservableReason preserves that distinction for
-	// the rejection ledger. The exhausted ladder then emits a single
-	// uptime-neutral 429 instead of retrying/5xx'ing.
+	// be served (deterministic-context rejection, or transient capacity that
+	// exhausted either eligible candidates or maxCapacityClassRetries).
+	// unservableReason preserves that distinction for the rejection ledger. The
+	// exhausted ladder then emits a single uptime-neutral 429 instead of
+	// retrying/5xx'ing.
 	unservable       bool
 	unservableReason string
 	// terminalClientError is set when a dispatched provider returned a DETERMINISTIC
@@ -1184,6 +1185,14 @@ func (d *dispatchState) dispatchPrimary() dispatchOutcome {
 			if d.lastErr == "" {
 				d.setLastError(dispatchErr, dispatchErrCode)
 			}
+			// A small fleet can run out of eligible candidates before reaching
+			// maxCapacityClassRetries. Preserve the same capacity_exhausted
+			// terminal used by the retry cap instead of falling through to the
+			// legacy unservable_token_budget bucket.
+			if d.classifyLastRejection() == rejectionTransientCapacity {
+				d.unservable = true
+				d.unservableReason = rejectionReasonCapacityExhausted
+			}
 			return outcomeFailFast
 		}
 		// No idle provider — try queueing.
@@ -1594,8 +1603,8 @@ const rejectionReasonTemplateRenderFailed = "template_render_failed"
 //     failover (the per-provider breaker quarantines a persistently-sick node).
 //
 // When it returns true it sets d.unservable + d.unservableReason so the exhausted
-// ladder emits exactly one uptime-neutral 429 (not a storm, not a raw 5xx). It is
-// A deadline refusal also returns false but remains the current terminal. It is a
+// ladder emits exactly one uptime-neutral 429 (not a storm, not a raw 5xx). A
+// deadline refusal also returns false but remains the current terminal. It is a
 // no-op (returns false, no counters) for non-capacity outcomes, so timeouts and
 // faults are unaffected.
 //
@@ -1637,11 +1646,7 @@ func (d *dispatchState) shouldStopFailover() bool {
 	// through the legacy capacity substrings, gets classified as a generic
 	// fault, and walks the unbounded fault-failover ladder to a final 503
 	// instead of the bounded capacity retries and uptime-neutral 429.
-	kind := classifyRejection(d.lastErrReason, d.lastErr, d.lastErrProviderBudget, d.modelMaxContext)
-	if kind != rejectionDeadlineUnreachable &&
-		d.lastErrTerminalCause == terminalCauseAdmissionTimeout {
-		kind = rejectionTransientCapacity
-	}
+	kind := d.classifyLastRejection()
 	switch kind {
 	case rejectionDeterministicUnservable:
 		d.s.ddIncr("routing.dispatch_to_capacity_503", []string{"model:" + d.model, "reason:deterministic"})
@@ -1666,6 +1671,20 @@ func (d *dispatchState) shouldStopFailover() bool {
 	default:
 		return false
 	}
+}
+
+func (d *dispatchState) classifyLastRejection() rejectionKind {
+	kind := classifyRejection(
+		d.lastErrReason,
+		d.lastErr,
+		d.lastErrProviderBudget,
+		d.modelMaxContext,
+	)
+	if kind != rejectionDeadlineUnreachable &&
+		d.lastErrTerminalCause == terminalCauseAdmissionTimeout {
+		return rejectionTransientCapacity
+	}
+	return kind
 }
 
 // latchJinjaTerminalReject latches the terminal 422 for a deterministic
@@ -3174,14 +3193,14 @@ exhausted:
 			// request-terminal precedence. Later neutral deadline/capacity
 			// refusals still own their own route rows but cannot hide the fault.
 		case exhaustedUnservable:
-			// The loop stopped early because no provider can serve this request
-			// (deterministic context overflow, or a capacity transient that
-			// exhausted maxCapacityClassRetries). We already know the verdict, so
-			// skip the quick-capacity probe and the 5xx→429 reclassification below:
-			// emit a single uptime-neutral 429. This is the proactive complement to
-			// the always-on backstop — it converts the request BEFORE storming the
-			// fleet, not after 64 attempts.
-			s.ddIncr("routing.oversized_request_rejected", []string{"model:" + d.model, "stage:dispatch"})
+			// The loop stopped early on either a deterministic context overflow
+			// or transient capacity exhaustion. Keep those metrics disjoint:
+			// only the former is an oversized request.
+			metric := "routing.oversized_request_rejected"
+			if reason == rejectionReasonCapacityExhausted {
+				metric = "routing.capacity_exhausted_rejected"
+			}
+			s.ddIncr(metric, []string{"model:" + d.model, "stage:dispatch"})
 		case exhaustedDeadline:
 			// Every refusal was health-neutral and did not consume the generic
 			// capacity retry cap. Once no untried candidate remains, expose one

--- a/coordinator/api/dispatch.go
+++ b/coordinator/api/dispatch.go
@@ -184,8 +184,9 @@ type dispatchState struct {
 	lastFailureDeadline bool
 	// unservable is set when the dispatch loop stops because the request cannot
 	// be served (deterministic-context rejection, or a transient that exhausted
-	// maxCapacityClassRetries). The exhausted ladder then emits a single
-	// uptime-neutral 429 with unservableReason instead of retrying/5xx'ing.
+	// maxCapacityClassRetries). unservableReason preserves that distinction for
+	// the rejection ledger. The exhausted ladder then emits a single
+	// uptime-neutral 429 instead of retrying/5xx'ing.
 	unservable       bool
 	unservableReason string
 	// terminalClientError is set when a dispatched provider returned a DETERMINISTIC
@@ -1550,12 +1551,15 @@ func (d *dispatchState) noteProviderError(provider *registry.Provider, pr *regis
 	return d.s.noteDispatchProviderError(provider, pr, statusCode, errStr, errReason, terminalCause, held)
 }
 
-// rejectionReasonOversized is the rejection-ledger reason_code for a request the
-// dispatch loop stopped because no provider can serve it (deterministic context
-// overflow, or a transient-capacity shortage that exhausted
-// maxCapacityClassRetries). Distinct from the preflight "context_exceeded" /
-// "prompt_too_long" and the legacy dispatch-exhausted "unservable_token_budget".
+// rejectionReasonOversized is the rejection-ledger reason_code for a
+// deterministic request-size failure discovered after dispatch.
 const rejectionReasonOversized = "oversized_request"
+
+// rejectionReasonCapacityExhausted identifies a transient provider-capacity
+// failure that persisted through the bounded failover ladder. Keeping it
+// separate from oversized_request lets supply planning distinguish "more
+// capacity may help" from "this request shape cannot fit."
+const rejectionReasonCapacityExhausted = "capacity_exhausted"
 
 // rejectionReasonDeadlineUnreachable is the rejection-ledger reason for a
 // request whose remaining absolute first-content budget was refused by one or
@@ -1655,7 +1659,7 @@ func (d *dispatchState) shouldStopFailover() bool {
 		d.capacityRetries++
 		if d.capacityRetries >= maxCapacityClassRetries {
 			d.unservable = true
-			d.unservableReason = rejectionReasonOversized
+			d.unservableReason = rejectionReasonCapacityExhausted
 			return true
 		}
 		return false

--- a/coordinator/api/dispatch_oversized_test.go
+++ b/coordinator/api/dispatch_oversized_test.go
@@ -124,7 +124,7 @@ func TestDispatch_TransientCapacity_StillFailsOver(t *testing.T) {
 // walk all maxDispatchAttempts=64). Five providers are present so the cap — not
 // candidate exhaustion — is what stops it.
 func TestDispatch_TransientCapacity_CappedRetries(t *testing.T) {
-	reg, _, ts := setupFailoverServer(t)
+	reg, st, ts := setupFailoverServer(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	defer cancel()
 
@@ -154,4 +154,16 @@ func TestDispatch_TransientCapacity_CappedRetries(t *testing.T) {
 		t.Errorf("total dispatches = %d, want %d (transient capacity must be capped, not stormed to %d)",
 			total, maxCapacityClassRetries, maxDispatchAttempts)
 	}
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		rejections := st.RejectionRecordsSince(time.Time{})
+		if len(rejections) > 0 {
+			if got := rejections[0].ReasonCode; got != rejectionReasonCapacityExhausted {
+				t.Fatalf("rejection reason = %q, want %q", got, rejectionReasonCapacityExhausted)
+			}
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("transient-capacity rejection was not recorded")
 }

--- a/coordinator/api/dispatch_oversized_test.go
+++ b/coordinator/api/dispatch_oversized_test.go
@@ -33,9 +33,15 @@ func rejectScript(errMsg string, status int) inferenceScript {
 // fleet (the prod storm: median 22 / max 63 attempts). Two providers are present
 // so a storm would be observable as >1 dispatch.
 func TestDispatch_DeterministicTokenBudget_StopsAfterOneAttempt(t *testing.T) {
-	reg, _, ts := setupFailoverServer(t)
+	reg, _, srv, ts := setupFailoverServerWithServer(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	defer cancel()
+
+	collector := newUDPCollector(t)
+	defer collector.Close()
+	ddClient := newTestDD(t, collector)
+	defer ddClient.Close()
+	srv.SetDatadog(ddClient)
 
 	model := "oversized-deterministic-model"
 	script := rejectScript("token_budget_exhausted: request exceeds batch token budget", http.StatusServiceUnavailable)
@@ -75,6 +81,14 @@ func TestDispatch_DeterministicTokenBudget_StopsAfterOneAttempt(t *testing.T) {
 	}
 	if total := pA.dispatchCount() + pB.dispatchCount(); total != 1 {
 		t.Errorf("total dispatches = %d, want 1 — a deterministic context rejection must STOP after the first attempt, not storm", total)
+	}
+	_ = ddClient.Statsd.Flush()
+	packets := collector.drain()
+	if !hasMetric(packets, "routing.oversized_request_rejected") {
+		t.Fatalf("deterministic oversize metric missing: %v", packets)
+	}
+	if hasMetric(packets, "routing.capacity_exhausted_rejected") {
+		t.Fatalf("deterministic oversize emitted capacity-exhausted metric: %v", packets)
 	}
 }
 
@@ -124,9 +138,15 @@ func TestDispatch_TransientCapacity_StillFailsOver(t *testing.T) {
 // walk all maxDispatchAttempts=64). Five providers are present so the cap — not
 // candidate exhaustion — is what stops it.
 func TestDispatch_TransientCapacity_CappedRetries(t *testing.T) {
-	reg, st, ts := setupFailoverServer(t)
+	reg, st, srv, ts := setupFailoverServerWithServer(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	defer cancel()
+
+	collector := newUDPCollector(t)
+	defer collector.Close()
+	ddClient := newTestDD(t, collector)
+	defer ddClient.Close()
+	srv.SetDatadog(ddClient)
 
 	model := "transient-capped-model"
 	script := rejectScript("server busy", http.StatusServiceUnavailable)
@@ -154,6 +174,66 @@ func TestDispatch_TransientCapacity_CappedRetries(t *testing.T) {
 		t.Errorf("total dispatches = %d, want %d (transient capacity must be capped, not stormed to %d)",
 			total, maxCapacityClassRetries, maxDispatchAttempts)
 	}
+	recorded := false
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		rejections := st.RejectionRecordsSince(time.Time{})
+		if len(rejections) > 0 {
+			if got := rejections[0].ReasonCode; got != rejectionReasonCapacityExhausted {
+				t.Fatalf("rejection reason = %q, want %q", got, rejectionReasonCapacityExhausted)
+			}
+			recorded = true
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if !recorded {
+		t.Fatal("transient-capacity rejection was not recorded")
+	}
+	_ = ddClient.Statsd.Flush()
+	packets := collector.drain()
+	if !hasMetric(packets, "routing.capacity_exhausted_rejected") {
+		t.Fatalf("capacity-exhausted metric missing: %v", packets)
+	}
+	if hasMetric(packets, "routing.oversized_request_rejected") {
+		t.Fatalf("transient capacity emitted oversized-request metric: %v", packets)
+	}
+}
+
+// A fleet with fewer providers than maxCapacityClassRetries exhausts candidates
+// before it reaches the retry cap. That is still capacity exhaustion and must
+// produce the same supply-pressure reason.
+func TestDispatch_TransientCapacity_CandidateExhaustion(t *testing.T) {
+	reg, st, ts := setupFailoverServer(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	model := "transient-small-fleet-model"
+	script := rejectScript("server busy", http.StatusServiceUnavailable)
+	const nProviders = maxCapacityClassRetries - 1
+	providers := make([]*failoverProvider, 0, nProviders)
+	for i := 0; i < nProviders; i++ {
+		providers = append(providers, startFailoverProvider(t, ctx, ts, reg, failoverProviderConfig{
+			Name: fmt.Sprintf("provider-%d", i), Version: "0.6.20", DecodeTPS: 100,
+			Models: []failoverModelSpec{{ID: model}}, Script: script,
+		}))
+	}
+
+	status, body, err := postChat(ctx, ts.URL, "test-key", buildChatBody(t, model, false, nil))
+	if err != nil {
+		t.Fatalf("chat request: %v", err)
+	}
+	if status != http.StatusTooManyRequests {
+		t.Fatalf("status = %d, want 429; body=%s", status, body)
+	}
+	total := 0
+	for _, provider := range providers {
+		total += provider.dispatchCount()
+	}
+	if total != nProviders {
+		t.Fatalf("total dispatches = %d, want %d", total, nProviders)
+	}
+
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
 		rejections := st.RejectionRecordsSince(time.Time{})
@@ -165,5 +245,5 @@ func TestDispatch_TransientCapacity_CappedRetries(t *testing.T) {
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
-	t.Fatal("transient-capacity rejection was not recorded")
+	t.Fatal("candidate-exhaustion rejection was not recorded")
 }

--- a/coordinator/api/dispatch_terminal_cause_test.go
+++ b/coordinator/api/dispatch_terminal_cause_test.go
@@ -58,6 +58,11 @@ func TestShouldStopFailover_TypedAdmissionTimeoutIsTransientCapacity(t *testing.
 	if !d.unservable {
 		t.Fatal("capacity-cap stop must latch unservable (the 429 path), not a fault 503")
 	}
+	if d.unservableReason != rejectionReasonCapacityExhausted {
+		t.Fatalf(
+			"capacity-cap reason = %q, want %q (must not look like request oversize)",
+			d.unservableReason, rejectionReasonCapacityExhausted)
+	}
 	if d.terminalClientError {
 		t.Fatal("admission_timeout is capacity, never a terminal client error")
 	}

--- a/coordinator/api/failover_integration_test.go
+++ b/coordinator/api/failover_integration_test.go
@@ -68,6 +68,12 @@ import (
 // mirroring setupTestServer / setupLoadTestServer.
 func setupFailoverServer(t *testing.T) (*registry.Registry, *store.MemoryStore, *httptest.Server) {
 	t.Helper()
+	reg, st, _, ts := setupFailoverServerWithServer(t)
+	return reg, st, ts
+}
+
+func setupFailoverServerWithServer(t *testing.T) (*registry.Registry, *store.MemoryStore, *Server, *httptest.Server) {
+	t.Helper()
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	st := store.NewMemory(store.Config{AdminKey: "test-key"})
 	reg := registry.New(logger)
@@ -75,7 +81,7 @@ func setupFailoverServer(t *testing.T) (*registry.Registry, *store.MemoryStore, 
 	srv.challengeInterval = 500 * time.Millisecond
 	ts := httptest.NewServer(srv.Handler())
 	t.Cleanup(ts.Close)
-	return reg, st, ts
+	return reg, st, srv, ts
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a read-only admin dashboard that ranks models by public-network supply pressure, with 1h/24h rejection counts, rejection share, measured dispatch-to-content TTFT, rejection-side TTFT, and evidence-based bottleneck labels. It also records bounded transient-capacity exhaustion separately from deterministic oversized requests, including when a small fleet runs out of candidates before the retry cap.

## Walkthrough

[supply-pressure-walkthrough.mp4](https://cursor.com/agents/bc-dddae3c8-783b-5fb6-ad11-aa535cde9bf3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsupply-pressure-walkthrough.mp4)

[Supply pressure dashboard showing per-model rejects, TTFT, and dominant signals](https://cursor.com/agents/bc-dddae3c8-783b-5fb6-ad11-aa535cde9bf3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsupply-pressure-final-state.png)

## Before

```mermaid
flowchart LR
  subgraph Behavior
    A[Inference traffic] --> B[Supply rejection or served request]
    B --> C[Telemetry stored in Postgres]
    C --> D[Operator runs manual queries]
    E[Transient capacity exhausted] --> F[oversized or generic token-budget bucket]
    G[Deterministic request too large] --> F
  end
  subgraph Code
    H[dispatchState.shouldStopFailover] --> F
    I[admin-ui navigation] --> J[Existing pages]
    J -. no supply aggregation .-> C
  end
```

## After

```mermaid
flowchart LR
  subgraph Behavior
    A[Public inference traffic] --> B[Supply rejection or successful route]
    B --> C[Supply page]
    C --> D[1h and 24h rejection summary]
    C --> E[Per-model ranking and TTFT]
    E --> F[Capacity / latency / availability / RAM signal]
    G[Transient capacity exhausted] --> H[capacity_exhausted]
    I[Deterministic request too large] --> J[oversized_request]
  end
  subgraph Code
    K[dispatchState classification] --> H
    L[SupplyPage] --> M[getSupplyPressure]
    M --> N[SUPPLY_PRESSURE_SQL]
    N --> O[(request_rejections)]
    N --> P[(inference_routes)]
    N --> Q[(model_registry)]
    M --> R[supply-pressure helpers]
    R --> S[SupplyPressureCells]
    S --> L
  end
```

## Linked issue

Slack request; no linked GitHub issue.

## Test plan

- [x] `cd admin-ui && npm test` (22 passed against isolated PostgreSQL 16)
- [x] `cd admin-ui && npm run lint`
- [x] `cd admin-ui && npm run build`
- [x] `cd coordinator && go test ./api/...` (99s, passed)
- [x] Execute the aggregation against isolated PostgreSQL 16
- [x] Open `/supply` in the browser and capture the rendered dashboard
- [x] Two independent full-diff reviews passed

## Components touched

- [x] admin-ui (Next.js)
- [x] coordinator (Go)
- [x] CI (isolated PostgreSQL regression lane for admin-ui)
- [ ] provider (Rust, legacy)
- [ ] provider-swift (Swift CLI)
- [ ] console-ui (Next.js)
- [ ] enclave (Swift)
- [ ] infra / release
- [ ] docs

## Protocol / interface changes

- [x] No protocol/interface changes
- [ ] Yes — described above and matching side updated

## Notes for reviewers

The view excludes exclusive self-route traffic, account limits, validation failures, and request-shape failures. Served counts and observed TTFT come from successful or partial-success `inference_routes`, keeping the rejection-share numerator and denominator in the same public-network scope. `model_too_large` remains separate because adding more machines of the same RAM tier cannot satisfy that demand. Historical `oversized_request` rows cannot be safely split; new transient exhaustion rows use `capacity_exhausted` after this coordinator change is deployed.

Feature checks pass, including the new Admin UI PostgreSQL lane, Coordinator tests/lint, E2E integration, and Vercel. The two unrelated red checks are the existing provider timing flake and Threat Model Review's invalid Anthropic credential.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://darkbloom.slack.com/archives/C0BRXUQ8DHB/p1787804900687679?thread_ts=1787804900.687679&cid=C0BRXUQ8DHB)

<div><a href="https://cursor.com/agents/bc-dddae3c8-783b-5fb6-ad11-aa535cde9bf3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dddae3c8-783b-5fb6-ad11-aa535cde9bf3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/753"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790402186&installation_model_id=21733&pr_number=753&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F753&signature=9103e297640d9098123406997406837d98f9b981bdc94ef3360b630ae3320471"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->