### PR TITLE
Persist routing calibration telemetry for cost-model feedback

### DIFF
--- a/coordinator/api/admin_telemetry.go
+++ b/coordinator/api/admin_telemetry.go
@@ -117,6 +117,112 @@ func (s *Server) handleAdminRejectionsExport(w http.ResponseWriter, r *http.Requ
 	}
 }
 
+func (s *Server) handleAdminCandidates(w http.ResponseWriter, r *http.Request) {
+	if !s.requireAdminKey(w, r) {
+		return
+	}
+	records := filterCandidateRecords(
+		s.store.InferenceRouteCandidatesSince(parseSince(r)),
+		r.URL.Query().Get("provider"), r.URL.Query().Get("request_id"),
+	)
+	records = capRecords(records, parseLimit(r, defaultBrowseLimit))
+	writeJSON(w, http.StatusOK, map[string]any{
+		"object": "list",
+		"count":  len(records),
+		"data":   records,
+	})
+}
+
+func (s *Server) handleAdminCandidatesExport(w http.ResponseWriter, r *http.Request) {
+	if !s.requireAdminKey(w, r) {
+		return
+	}
+	records := filterCandidateRecords(
+		s.store.InferenceRouteCandidatesSince(parseSince(r)),
+		r.URL.Query().Get("provider"), r.URL.Query().Get("request_id"),
+	)
+	records = capRecords(records, parseLimit(r, 0))
+	format := exportFormat(r)
+	setExportHeaders(w, "candidates", format)
+	if format == "ndjson" {
+		if err := writeNDJSON(w, records); err != nil {
+			s.logger.Error("admin candidates ndjson export failed", "error", err)
+		}
+		return
+	}
+	if err := writeCandidateCSV(w, records); err != nil {
+		s.logger.Error("admin candidates csv export failed", "error", err)
+	}
+}
+
+func (s *Server) handleAdminCapacitySamples(w http.ResponseWriter, r *http.Request) {
+	if !s.requireAdminKey(w, r) {
+		return
+	}
+	records := filterCapacitySamples(
+		s.store.ProviderCapacitySamplesSince(parseSince(r)),
+		r.URL.Query().Get("provider"),
+	)
+	records = capRecords(records, parseLimit(r, defaultBrowseLimit))
+	writeJSON(w, http.StatusOK, map[string]any{
+		"object": "list",
+		"count":  len(records),
+		"data":   records,
+	})
+}
+
+func (s *Server) handleAdminCapacitySamplesExport(w http.ResponseWriter, r *http.Request) {
+	if !s.requireAdminKey(w, r) {
+		return
+	}
+	records := filterCapacitySamples(
+		s.store.ProviderCapacitySamplesSince(parseSince(r)),
+		r.URL.Query().Get("provider"),
+	)
+	records = capRecords(records, parseLimit(r, 0))
+	format := exportFormat(r)
+	setExportHeaders(w, "capacity-samples", format)
+	if format == "ndjson" {
+		if err := writeNDJSON(w, records); err != nil {
+			s.logger.Error("admin capacity samples ndjson export failed", "error", err)
+		}
+		return
+	}
+	if err := writeCapacitySampleCSV(w, records); err != nil {
+		s.logger.Error("admin capacity samples csv export failed", "error", err)
+	}
+}
+
+func filterCandidateRecords(records []store.InferenceRouteCandidateRecord, providerID, requestID string) []store.InferenceRouteCandidateRecord {
+	if providerID == "" && requestID == "" {
+		return records
+	}
+	out := make([]store.InferenceRouteCandidateRecord, 0, len(records))
+	for _, rec := range records {
+		if providerID != "" && rec.ProviderID != providerID {
+			continue
+		}
+		if requestID != "" && rec.RequestID != requestID {
+			continue
+		}
+		out = append(out, rec)
+	}
+	return out
+}
+
+func filterCapacitySamples(records []store.ProviderCapacitySample, providerID string) []store.ProviderCapacitySample {
+	if providerID == "" {
+		return records
+	}
+	out := make([]store.ProviderCapacitySample, 0, len(records))
+	for _, rec := range records {
+		if rec.ProviderID == providerID {
+			out = append(out, rec)
+		}
+	}
+	return out
+}
+
 // --- Request parsing helpers ---------------------------------------------
 
 // parseSince resolves the ?since= query parameter to an absolute lower-bound
@@ -293,6 +399,17 @@ var routeCSVHeader = []string{
 	"actual_ttft_ms", "dispatch_to_first_chunk_ms", "total_duration_ms",
 	"parse_ms", "reserve_ms", "route_ms", "encrypt_ms", "queue_wait_ms", "dispatch_ms",
 	"actual_decode_tps", "admitted_but_failed", "used_backup", "backup_won",
+	"capacity_rate_ms", "capacity_reject_rate", "affinity_tier", "affinity_discount_ms",
+	"media_fetch_ms", "cache_outcome", "cache_tier", "cached_tokens", "prefill_tokens_saved", "cache_stage_ms",
+	"client_outcome", "provider_outcome", "billing_outcome", "response_committed",
+	"is_final_attempt", "total_attempts",
+	"endpoint", "kv_backend", "kv_backend_fallback",
+	"free_for_load_gb", "wedge_suspected", "total_pending",
+	"effective_prefill_tps", "static_prefill_tps", "cache_estimated_ttft_saved_ms",
+	"near_tie_count", "tie_break_reason",
+	"shadow_would_shed", "shadow_idle_alternative", "shadow_estimate_ms", "shadow_deadline_ms",
+	"breaker_rejections", "soft_filter_rejections",
+	"terminal_source", "reserved_micro_usd", "settled_micro_usd", "overage_micro_usd", "refund_micro_usd",
 	"created_at", "updated_at",
 }
 
@@ -390,6 +507,44 @@ func routeCSVRow(rec store.InferenceRouteRecord) []string {
 		csvBool(rec.AdmittedButFailed),
 		csvBool(rec.UsedBackup),
 		csvBool(rec.BackupWon),
+		csvFloat(rec.CapacityRateMs),
+		csvFloat(rec.CapacityRejectRate),
+		rec.AffinityTier,
+		csvFloat(rec.AffinityDiscountMs),
+		csvFloat(rec.MediaFetchMs),
+		rec.CacheOutcome,
+		rec.CacheTier,
+		csvInt(rec.CachedTokens),
+		csvInt(rec.PrefillTokensSaved),
+		csvFloat(rec.CacheStageMs),
+		rec.ClientOutcome,
+		rec.ProviderOutcome,
+		rec.BillingOutcome,
+		csvBool(rec.ResponseCommitted),
+		csvBool(rec.IsFinalAttempt),
+		csvInt(rec.TotalAttempts),
+		rec.Endpoint,
+		rec.KVBackend,
+		rec.KVBackendFallback,
+		csvFloat(rec.FreeForLoadGB),
+		csvBool(rec.WedgeSuspected),
+		csvInt(rec.TotalPending),
+		csvFloat(rec.EffectivePrefillTPS),
+		csvFloat(rec.StaticPrefillTPS),
+		csvFloat(rec.CacheEstimatedTTFTSavedMs),
+		csvInt(rec.NearTieCount),
+		rec.TieBreakReason,
+		csvBool(rec.ShadowWouldShed),
+		csvBool(rec.ShadowIdleAlternative),
+		csvFloat(rec.ShadowEstimateMs),
+		csvFloat(rec.ShadowDeadlineMs),
+		csvInt(rec.BreakerRejections),
+		csvInt(rec.SoftFilterRejections),
+		rec.TerminalSource,
+		csvI64(rec.ReservedMicroUSD),
+		csvI64(rec.SettledMicroUSD),
+		csvI64(rec.OverageMicroUSD),
+		csvI64(rec.RefundMicroUSD),
 		csvTime(rec.CreatedAt),
 		csvTime(rec.UpdatedAt),
 	}
@@ -467,6 +622,77 @@ func rejectionCSVRow(rec store.RejectionRecord) []string {
 		csvI64(rec.OverBy),
 		csvTime(rec.CreatedAt),
 	}
+}
+
+var candidateCSVHeader = []string{
+	"request_id", "attempt", "provider_id", "rank", "selected", "eligible", "rejection_reason",
+	"cost_ms", "state_ms", "queue_ms", "pending_ms", "backlog_ms", "this_req_ms", "health_ms",
+	"capacity_rate_ms", "ttft_ms", "effective_queue", "effective_tps", "static_tps",
+	"effective_prefill_tps", "static_prefill_tps", "batch_size",
+	"chip_family", "hardware_tier", "memory_gb", "slot_state", "memory_pressure", "thermal_state",
+	"gpu_memory_active_gb", "free_for_load_gb", "wedge_suspected", "affinity_applied",
+	"affinity_discount_ms", "capacity_reject_rate", "created_at",
+}
+
+func writeCandidateCSV(w http.ResponseWriter, records []store.InferenceRouteCandidateRecord) error {
+	cw := csv.NewWriter(w)
+	if err := cw.Write(candidateCSVHeader); err != nil {
+		return err
+	}
+	for i := range records {
+		rec := records[i]
+		if err := cw.Write([]string{
+			rec.RequestID, csvInt(rec.Attempt), rec.ProviderID, csvInt(rec.Rank),
+			csvBool(rec.Selected), csvBool(rec.Eligible), rec.RejectionReason,
+			csvFloat(rec.CostMs), csvFloat(rec.StateMs), csvFloat(rec.QueueMs),
+			csvFloat(rec.PendingMs), csvFloat(rec.BacklogMs), csvFloat(rec.ThisReqMs), csvFloat(rec.HealthMs),
+			csvFloat(rec.CapacityRateMs), csvFloat(rec.TTFTMs), csvInt(rec.EffectiveQueue),
+			csvFloat(rec.EffectiveTPS), csvFloat(rec.StaticTPS),
+			csvFloat(rec.EffectivePrefillTPS), csvFloat(rec.StaticPrefillTPS), csvInt(rec.BatchSize),
+			rec.ChipFamily, rec.HardwareTier, csvInt(rec.MemoryGB), rec.SlotState,
+			csvFloat(rec.MemoryPressure), rec.ThermalState,
+			csvFloat(rec.GPUMemoryActiveGB), csvFloat(rec.FreeForLoadGB), csvBool(rec.WedgeSuspected),
+			csvBool(rec.AffinityApplied), csvFloat(rec.AffinityDiscountMs), csvFloat(rec.CapacityRejectRate),
+			csvTime(rec.CreatedAt),
+		}); err != nil {
+			return err
+		}
+	}
+	cw.Flush()
+	return cw.Error()
+}
+
+var capacitySampleCSVHeader = []string{
+	"provider_id", "provider_version", "provider_status", "provider_trust_level",
+	"hardware_chip_family", "hardware_tier", "memory_gb", "current_model",
+	"warm_model_count", "slot_count", "backend_running", "backend_waiting",
+	"observed_decode_tps", "active_token_budget_used", "active_token_budget_max",
+	"queued_token_budget", "memory_pressure", "cpu_usage", "thermal_state",
+	"gpu_memory_active_gb", "gpu_memory_peak_gb", "gpu_memory_cache_gb",
+	"free_for_load_gb", "wedge_suspected", "created_at",
+}
+
+func writeCapacitySampleCSV(w http.ResponseWriter, records []store.ProviderCapacitySample) error {
+	cw := csv.NewWriter(w)
+	if err := cw.Write(capacitySampleCSVHeader); err != nil {
+		return err
+	}
+	for i := range records {
+		rec := records[i]
+		if err := cw.Write([]string{
+			rec.ProviderID, rec.ProviderVersion, rec.ProviderStatus, rec.ProviderTrustLevel,
+			rec.HardwareChipFamily, rec.HardwareTier, csvInt(rec.MemoryGB), rec.CurrentModel,
+			csvInt(rec.WarmModelCount), csvInt(rec.SlotCount), csvInt(rec.BackendRunning), csvInt(rec.BackendWaiting),
+			csvFloat(rec.ObservedDecodeTPS), csvI64(rec.ActiveTokenUsed), csvI64(rec.ActiveTokenMax),
+			csvI64(rec.QueuedTokenBudget), csvFloat(rec.MemoryPressure), csvFloat(rec.CPUUsage), rec.ThermalState,
+			csvFloat(rec.GPUMemoryActiveGB), csvFloat(rec.GPUMemoryPeakGB), csvFloat(rec.GPUMemoryCacheGB),
+			csvFloat(rec.FreeForLoadGB), csvBool(rec.WedgeSuspected), csvTime(rec.CreatedAt),
+		}); err != nil {
+			return err
+		}
+	}
+	cw.Flush()
+	return cw.Error()
 }
 
 // --- scalar formatting ----------------------------------------------------

--- a/coordinator/api/admin_telemetry_route_test.go
+++ b/coordinator/api/admin_telemetry_route_test.go
@@ -29,6 +29,12 @@ func TestRouteCSVIncludesOutcomeFields(t *testing.T) {
 		AdmittedButFailed:      true,
 		UsedBackup:             true,
 		BackupWon:              true,
+		CapacityRateMs:         50,
+		AffinityTier:           "ssd",
+		CacheOutcome:           "hit",
+		ClientOutcome:          "completed",
+		ProviderOutcome:        "completed",
+		BillingOutcome:         "charged",
 	}
 	row := routeCSVRow(rec)
 	if len(routeCSVHeader) != len(row) {
@@ -38,13 +44,18 @@ func TestRouteCSVIncludesOutcomeFields(t *testing.T) {
 	for i, name := range routeCSVHeader {
 		values[name] = row[i]
 	}
-	for _, name := range []string{"final_status", "error_code", "error_class", "error_reason", "prompt_tokens", "completion_tokens", "reasoning_tokens", "cost_micro_usd", "actual_ttft_ms", "dispatch_to_first_chunk_ms", "total_duration_ms", "parse_ms", "reserve_ms", "route_ms", "encrypt_ms", "queue_wait_ms", "dispatch_ms", "actual_decode_tps", "admitted_but_failed", "used_backup", "backup_won"} {
+	for _, name := range []string{"final_status", "error_code", "error_class", "error_reason", "prompt_tokens", "completion_tokens", "reasoning_tokens", "cost_micro_usd", "actual_ttft_ms", "dispatch_to_first_chunk_ms", "total_duration_ms", "parse_ms", "reserve_ms", "route_ms", "encrypt_ms", "queue_wait_ms", "dispatch_ms", "actual_decode_tps", "admitted_but_failed", "used_backup", "backup_won", "capacity_rate_ms", "affinity_tier", "cache_outcome", "client_outcome", "provider_outcome", "billing_outcome"} {
 		if _, ok := values[name]; !ok {
 			t.Fatalf("route CSV missing %q", name)
 		}
 	}
 	if values["final_status"] != "partial_success" || values["error_code"] != "499" || values["error_reason"] != "cancelled" || values["used_backup"] != "true" || values["backup_won"] != "true" {
 		t.Fatalf("unexpected CSV outcome values: %+v", values)
+	}
+	for _, name := range []string{"endpoint", "kv_backend", "free_for_load_gb", "near_tie_count", "terminal_source", "reserved_micro_usd"} {
+		if _, ok := values[name]; !ok {
+			t.Fatalf("route CSV missing %q", name)
+		}
 	}
 }
 

--- a/coordinator/api/calibration_telemetry.go
+++ b/coordinator/api/calibration_telemetry.go
@@ -1,0 +1,312 @@
+package api
+
+import (
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+	"github.com/eigeninference/d-inference/coordinator/registry"
+	"github.com/eigeninference/d-inference/coordinator/store"
+)
+
+const capacitySampleInterval = time.Minute
+
+type capacitySampler struct {
+	mu       sync.Mutex
+	last     map[string]time.Time
+	interval time.Duration
+}
+
+func newCapacitySampler() *capacitySampler {
+	return &capacitySampler{
+		last:     make(map[string]time.Time),
+		interval: capacitySampleInterval,
+	}
+}
+
+func (c *capacitySampler) shouldSample(id string, now time.Time) bool {
+	if c == nil || id == "" {
+		return false
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if prev, ok := c.last[id]; ok && now.Sub(prev) < c.interval {
+		return false
+	}
+	c.last[id] = now
+	return true
+}
+
+func (s *Server) maybeRecordCapacitySample(provider *registry.Provider) {
+	if s == nil || s.store == nil || provider == nil {
+		return
+	}
+	if s.capacitySampler == nil {
+		s.capacitySampler = newCapacitySampler()
+	}
+	if !s.capacitySampler.shouldSample(provider.ID, time.Now()) {
+		return
+	}
+	sample := capacitySampleFromProvider(provider)
+	if sample == nil {
+		return
+	}
+	s.submitTelemetry("recordCapacitySample", func() {
+		_ = s.store.RecordProviderCapacitySample(sample)
+	})
+}
+
+func capacitySampleFromProvider(p *registry.Provider) *store.ProviderCapacitySample {
+	if p == nil {
+		return nil
+	}
+	p.Mu().Lock()
+	defer p.Mu().Unlock()
+	sample := &store.ProviderCapacitySample{
+		ProviderID:         p.ID,
+		ProviderVersion:    p.Version,
+		ProviderStatus:     string(p.Status),
+		ProviderTrustLevel: string(p.TrustLevel),
+		HardwareChipFamily: p.Hardware.ChipFamily,
+		HardwareTier:       p.Hardware.ChipTier,
+		MemoryGB:           p.Hardware.MemoryGB,
+		CurrentModel:       p.CurrentModel,
+		WarmModelCount:     len(p.WarmModels),
+		MemoryPressure:     p.SystemMetrics.MemoryPressure,
+		CPUUsage:           p.SystemMetrics.CPUUsage,
+		ThermalState:       p.SystemMetrics.ThermalState,
+		CreatedAt:          time.Now().UTC(),
+	}
+	if p.BackendCapacity != nil {
+		sample.SlotCount = len(p.BackendCapacity.Slots)
+		sample.GPUMemoryActiveGB = p.BackendCapacity.GPUMemoryActiveGB
+		sample.GPUMemoryPeakGB = p.BackendCapacity.GPUMemoryPeakGB
+		sample.GPUMemoryCacheGB = p.BackendCapacity.GPUMemoryCacheGB
+		if p.BackendCapacity.FreeForLoadGB != nil {
+			sample.FreeForLoadGB = *p.BackendCapacity.FreeForLoadGB
+		}
+		var decodeSum float64
+		var decodeN int
+		for _, slot := range p.BackendCapacity.Slots {
+			sample.BackendRunning += int(slot.NumRunning)
+			sample.BackendWaiting += int(slot.NumWaiting)
+			sample.ActiveTokenUsed += slot.ActiveTokenBudgetUsed
+			sample.ActiveTokenMax += slot.ActiveTokenBudgetMax
+			sample.QueuedTokenBudget += slot.QueuedTokenBudget
+			if slot.ObservedDecodeTPS > 0 {
+				decodeSum += slot.ObservedDecodeTPS
+				decodeN++
+			}
+			if slot.WedgeSuspected {
+				sample.WedgeSuspected = true
+			}
+		}
+		if decodeN > 0 {
+			sample.ObservedDecodeTPS = decodeSum / float64(decodeN)
+		}
+	}
+	return sample
+}
+
+func applyCacheUsageTelemetry(out *store.InferenceRouteOutcome, usage protocol.UsageInfo) {
+	if out == nil || usage.CacheOutcome == "" {
+		return
+	}
+	out.CacheOutcome = usage.CacheOutcome
+	out.CacheTier = usage.CacheTier
+	out.CachedTokens = usage.CachedTokens
+	out.PrefillTokensSaved = usage.PrefillTokensSaved
+	out.CacheStageMs = usage.CacheStageMs
+}
+
+func applyOutcomeDimensions(out *store.InferenceRouteOutcome) {
+	if out == nil || out.FinalStatus == "" {
+		return
+	}
+	switch out.FinalStatus {
+	case finalStatusSuccess:
+		out.ClientOutcome = "completed"
+		out.ProviderOutcome = "completed"
+		if out.CostMicroUSD == 0 {
+			out.BillingOutcome = "zero_cost"
+		} else {
+			out.BillingOutcome = "charged"
+		}
+		out.ResponseCommitted = true
+	case finalStatusPartialSuccess:
+		out.ResponseCommitted = true
+		switch out.ErrorClass {
+		case errorClassClientGoneAfterCommitCompleted:
+			out.ClientOutcome = "cancelled_after_commit"
+			out.ProviderOutcome = "completed"
+			out.BillingOutcome = "charged"
+		case "client_gone_after_commit_provider_error":
+			out.ClientOutcome = "cancelled_after_commit"
+			out.ProviderOutcome = "error"
+			out.BillingOutcome = "refunded"
+		case "no_terminal_after_cancel":
+			out.ClientOutcome = "cancelled_after_commit"
+			out.ProviderOutcome = "no_terminal"
+			out.BillingOutcome = "refunded"
+		case "provider_error_after_commit":
+			out.ClientOutcome = "partial"
+			out.ProviderOutcome = "error"
+			out.BillingOutcome = "refunded"
+		case "provider_disconnect_after_commit":
+			out.ClientOutcome = "partial"
+			out.ProviderOutcome = "disconnect"
+			out.BillingOutcome = "refunded"
+		case "stream_timeout_after_commit":
+			out.ClientOutcome = "partial"
+			out.ProviderOutcome = "timeout"
+			out.BillingOutcome = "refunded"
+		default:
+			out.ClientOutcome = "partial"
+			out.ProviderOutcome = "error"
+			out.BillingOutcome = "refunded"
+		}
+	case finalStatusCancelled:
+		out.ClientOutcome = "cancelled"
+		out.ProviderOutcome = "cancelled"
+		out.BillingOutcome = "refunded"
+	case finalStatusTimeout:
+		out.ClientOutcome = "timeout"
+		out.ProviderOutcome = "timeout"
+		out.BillingOutcome = "refunded"
+	case finalStatusError:
+		out.ClientOutcome = "error"
+		out.ProviderOutcome = "error"
+		out.BillingOutcome = "refunded"
+	}
+}
+
+func (s *Server) emitPredictionTelemetry(pr *registry.PendingRequest, out *store.InferenceRouteOutcome) {
+	if s == nil || pr == nil || out == nil {
+		return
+	}
+	tags := []string{}
+	if pr.Model != "" {
+		tags = append(tags, "model:"+pr.Model)
+	}
+	if pr.PredictedTTFTMs > 0 && out.ActualTTFTMs > 0 {
+		s.ddHistogram("routing.ttft_error_ms", out.ActualTTFTMs-pr.PredictedTTFTMs, tags)
+		s.ddHistogram("routing.ttft_ratio", out.ActualTTFTMs/pr.PredictedTTFTMs, tags)
+	}
+	if pr.PredictedEffectiveTPS > 0 && out.ActualDecodeTPS > 0 {
+		s.ddHistogram("routing.decode_tps_ratio", out.ActualDecodeTPS/pr.PredictedEffectiveTPS, tags)
+	}
+	if pr.PredictedCostMs > 0 && out.TotalDurationMs > 0 {
+		s.ddHistogram("routing.duration_vs_cost_ms", out.TotalDurationMs-pr.PredictedCostMs, tags)
+	}
+	if pr.EstimatedPromptTokens > 0 && out.PromptTokens > 0 {
+		s.ddHistogram("routing.prompt_token_estimate_error", float64(out.PromptTokens-pr.EstimatedPromptTokens), tags)
+	}
+}
+
+func routeCandidatesFromDecision(requestID string, attempt int, candidates []registry.RouteCandidateSnapshot) []store.InferenceRouteCandidateRecord {
+	if requestID == "" || len(candidates) == 0 {
+		return nil
+	}
+	now := time.Now().UTC()
+	out := make([]store.InferenceRouteCandidateRecord, 0, len(candidates))
+	for _, c := range candidates {
+		if c.ProviderID == "" {
+			continue
+		}
+		out = append(out, store.InferenceRouteCandidateRecord{
+			RequestID:           requestID,
+			Attempt:             attempt,
+			ProviderID:          c.ProviderID,
+			Rank:                c.Rank,
+			Selected:            c.Selected,
+			Eligible:            c.Eligible,
+			RejectionReason:     c.RejectionReason,
+			CostMs:              c.CostMs,
+			StateMs:             c.StateMs,
+			QueueMs:             c.QueueMs,
+			PendingMs:           c.PendingMs,
+			BacklogMs:           c.BacklogMs,
+			ThisReqMs:           c.ThisReqMs,
+			HealthMs:            c.HealthMs,
+			CapacityRateMs:      c.CapacityRateMs,
+			TTFTMs:              c.TTFTMs,
+			EffectiveQueue:      c.EffectiveQueue,
+			EffectiveTPS:        c.EffectiveTPS,
+			StaticTPS:           c.StaticTPS,
+			EffectivePrefillTPS: c.EffectivePrefillTPS,
+			StaticPrefillTPS:    c.StaticPrefillTPS,
+			BatchSize:           c.BatchSize,
+			ChipFamily:          c.ChipFamily,
+			HardwareTier:        c.HardwareTier,
+			MemoryGB:            c.MemoryGB,
+			SlotState:           c.SlotState,
+			MemoryPressure:      c.MemoryPressure,
+			ThermalState:        c.ThermalState,
+			GPUMemoryActiveGB:   c.GPUMemoryActiveGB,
+			FreeForLoadGB:       c.FreeForLoadGB,
+			WedgeSuspected:      c.WedgeSuspected,
+			AffinityApplied:     c.AffinityApplied,
+			AffinityDiscountMs:  c.AffinityDiscountMs,
+			CapacityRejectRate:  c.CapacityRejectRate,
+			CreatedAt:           now,
+		})
+	}
+	return out
+}
+
+func applyBillingSettlement(out *store.InferenceRouteOutcome, reserved, settled, overage, refund int64) {
+	if out == nil {
+		return
+	}
+	out.ReservedMicroUSD = reserved
+	out.SettledMicroUSD = settled
+	out.OverageMicroUSD = overage
+	out.RefundMicroUSD = refund
+}
+
+func terminalSourceFor(status, class string) string {
+	lowerClass := strings.ToLower(strings.TrimSpace(class))
+	switch {
+	case strings.Contains(lowerClass, "client_gone"):
+		return "client"
+	case strings.Contains(lowerClass, "speculative"):
+		return "coordinator"
+	case strings.EqualFold(strings.TrimSpace(status), finalStatusTimeout) || strings.Contains(lowerClass, "timeout"):
+		return "coordinator_timeout"
+	case strings.Contains(lowerClass, "provider"):
+		return "provider"
+	case strings.EqualFold(strings.TrimSpace(status), finalStatusSuccess):
+		return "provider"
+	case strings.EqualFold(strings.TrimSpace(status), finalStatusCancelled):
+		return "client"
+	default:
+		return "coordinator"
+	}
+}
+
+func coarseRegion(loc *store.ProviderLocation) string {
+	if loc == nil {
+		return ""
+	}
+	if loc.RegionCode != "" {
+		return loc.RegionCode
+	}
+	if loc.CountryCode != "" {
+		return loc.CountryCode
+	}
+	return loc.Region
+}
+
+func (d *dispatchState) telemetryEndpoint() string {
+	if d == nil {
+		return ""
+	}
+	if d.consumerEndpoint != "" {
+		return d.consumerEndpoint
+	}
+	if d.isResponsesAPI {
+		return "/v1/responses"
+	}
+	return "/v1/chat/completions"
+}

--- a/coordinator/api/calibration_telemetry_test.go
+++ b/coordinator/api/calibration_telemetry_test.go
@@ -77,6 +77,41 @@ func TestRouteCandidatesFromDecision(t *testing.T) {
 	if len(got) != 1 || got[0].RequestID != "req-1" || got[0].Attempt != 2 || got[0].ProviderID != "p1" {
 		t.Fatalf("converted = %+v", got)
 	}
+	if got := routeCandidatesFromDecision("", 0, []registry.RouteCandidateSnapshot{{ProviderID: "p1"}}); got != nil {
+		t.Fatalf("empty request id must drop candidates, got %+v", got)
+	}
+}
+
+func TestRecordRoutingDecisionPersistsCandidatesOnNilProvider(t *testing.T) {
+	srv, st := testServer(t)
+	d := &dispatchState{
+		s:     srv,
+		model: "fail-fast-model",
+		pr:    &registry.PendingRequest{RequestID: "req-fail-fast"},
+	}
+	d.recordRoutingDecision(registry.RoutingDecision{
+		Candidates: []registry.RouteCandidateSnapshot{{
+			ProviderID: "slow", Rank: -1, Eligible: false,
+			RejectionReason: store.CandidateRejectTTFT, CostMs: 90_000,
+		}},
+	}, errTTFTTooSlow, "")
+
+	deadline := time.Now().Add(2 * time.Second)
+	var got []store.InferenceRouteCandidateRecord
+	for time.Now().Before(deadline) {
+		got = st.InferenceRouteCandidatesSince(time.Time{})
+		if len(got) > 0 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if len(got) != 1 || got[0].RequestID != "req-fail-fast" || got[0].RejectionReason != store.CandidateRejectTTFT {
+		t.Fatalf("nil-provider candidates = %+v", got)
+	}
+	routes := st.InferenceRouteRecordsSince(time.Time{})
+	if len(routes) != 1 || routes[0].RequestID != "req-fail-fast" || routes[0].Outcome != "ttft_429" {
+		t.Fatalf("nil-provider route = %+v", routes)
+	}
 }
 
 func TestCandidateAndCapacityCSVHeaders(t *testing.T) {

--- a/coordinator/api/calibration_telemetry_test.go
+++ b/coordinator/api/calibration_telemetry_test.go
@@ -1,0 +1,169 @@
+package api
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+	"github.com/eigeninference/d-inference/coordinator/registry"
+	"github.com/eigeninference/d-inference/coordinator/store"
+)
+
+func TestApplyOutcomeDimensions(t *testing.T) {
+	success := &store.InferenceRouteOutcome{FinalStatus: finalStatusSuccess, CostMicroUSD: 12}
+	applyOutcomeDimensions(success)
+	if success.ClientOutcome != "completed" || success.ProviderOutcome != "completed" || success.BillingOutcome != "charged" || !success.ResponseCommitted {
+		t.Fatalf("success dimensions = %+v", success)
+	}
+
+	zero := &store.InferenceRouteOutcome{FinalStatus: finalStatusSuccess}
+	applyOutcomeDimensions(zero)
+	if zero.BillingOutcome != "zero_cost" {
+		t.Fatalf("zero-cost billing = %q", zero.BillingOutcome)
+	}
+
+	partial := &store.InferenceRouteOutcome{
+		FinalStatus: finalStatusPartialSuccess,
+		ErrorClass:  errorClassClientGoneAfterCommitCompleted,
+	}
+	applyOutcomeDimensions(partial)
+	if partial.ClientOutcome != "cancelled_after_commit" || partial.ProviderOutcome != "completed" || !partial.ResponseCommitted {
+		t.Fatalf("partial dimensions = %+v", partial)
+	}
+}
+
+func TestApplyCacheUsageTelemetry(t *testing.T) {
+	out := &store.InferenceRouteOutcome{}
+	applyCacheUsageTelemetry(out, protocol.UsageInfo{})
+	if out.CacheOutcome != "" {
+		t.Fatal("empty usage must not stamp cache outcome")
+	}
+	applyCacheUsageTelemetry(out, protocol.UsageInfo{
+		CacheOutcome: "hit", CacheTier: "ssd", CachedTokens: 64, PrefillTokensSaved: 48, CacheStageMs: 3,
+	})
+	if out.CacheOutcome != "hit" || out.CachedTokens != 64 || out.CacheStageMs != 3 {
+		t.Fatalf("cache usage = %+v", out)
+	}
+}
+
+func TestCapacitySamplerRateLimit(t *testing.T) {
+	c := newCapacitySampler()
+	c.interval = time.Hour
+	now := time.Now()
+	if !c.shouldSample("p1", now) {
+		t.Fatal("first sample must be allowed")
+	}
+	if c.shouldSample("p1", now.Add(time.Minute)) {
+		t.Fatal("second sample inside the interval must be denied")
+	}
+	if !c.shouldSample("p2", now) {
+		t.Fatal("a different provider must be sampled independently")
+	}
+	if !c.shouldSample("p1", now.Add(2*time.Hour)) {
+		t.Fatal("sample after the interval must be allowed")
+	}
+}
+
+func TestRouteCandidatesFromDecision(t *testing.T) {
+	got := routeCandidatesFromDecision("req-1", 2, []registry.RouteCandidateSnapshot{
+		{ProviderID: "p1", Rank: 0, Selected: true, Eligible: true, CostMs: 10, ChipFamily: "M4"},
+		{ProviderID: "", Rank: 1},
+	})
+	if len(got) != 1 || got[0].RequestID != "req-1" || got[0].Attempt != 2 || got[0].ProviderID != "p1" {
+		t.Fatalf("converted = %+v", got)
+	}
+}
+
+func TestCandidateAndCapacityCSVHeaders(t *testing.T) {
+	if err := writeCandidateCSV(httptest.NewRecorder(), nil); err != nil {
+		t.Fatalf("writeCandidateCSV: %v", err)
+	}
+	if err := writeCapacitySampleCSV(httptest.NewRecorder(), nil); err != nil {
+		t.Fatalf("writeCapacitySampleCSV: %v", err)
+	}
+	if len(candidateCSVHeader) == 0 || len(capacitySampleCSVHeader) == 0 {
+		t.Fatal("csv headers empty")
+	}
+}
+
+func TestTerminalSourceAndBillingHelpers(t *testing.T) {
+	if got := terminalSourceFor(finalStatusSuccess, ""); got != "provider" {
+		t.Fatalf("success source = %q", got)
+	}
+	if got := terminalSourceFor(finalStatusPartialSuccess, errorClassClientGoneAfterCommitCompleted); got != "client" {
+		t.Fatalf("client-gone source = %q", got)
+	}
+	if got := terminalSourceFor(finalStatusTimeout, "first_chunk_timeout"); got != "coordinator_timeout" {
+		t.Fatalf("timeout source = %q", got)
+	}
+	out := &store.InferenceRouteOutcome{}
+	applyBillingSettlement(out, 100, 80, 0, 20)
+	if out.ReservedMicroUSD != 100 || out.SettledMicroUSD != 80 || out.RefundMicroUSD != 20 {
+		t.Fatalf("billing = %+v", out)
+	}
+	if coarseRegion(&store.ProviderLocation{RegionCode: "CA", CountryCode: "US"}) != "CA" {
+		t.Fatal("coarse region should prefer region code")
+	}
+}
+
+func TestAdminCandidatesAndCapacitySampleEndpoints(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	st := store.NewMemory(store.Config{AdminKey: "test-key"})
+	reg := registry.New(logger)
+	srv := NewServer(reg, st, ServerConfig{AdminKey: "test-key"}, logger)
+	if err := st.RecordInferenceRouteCandidates([]store.InferenceRouteCandidateRecord{{
+		RequestID: "req-admin", Attempt: 0, ProviderID: "p1", Rank: 0, Selected: true, Eligible: true, CostMs: 900,
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.RecordProviderCapacitySample(&store.ProviderCapacitySample{
+		ProviderID: "p1", ObservedDecodeTPS: 33, MemoryGB: 64,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	ts := httptest.NewServer(srv.Handler())
+	t.Cleanup(ts.Close)
+
+	req, err := http.NewRequest(http.MethodGet, ts.URL+"/v1/admin/candidates?since=2006-01-02T15:04:05Z", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer test-key")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("candidates status = %d", resp.StatusCode)
+	}
+	var body struct {
+		Count int `json:"count"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatal(err)
+	}
+	if body.Count != 1 {
+		t.Fatalf("candidates count = %d, want 1", body.Count)
+	}
+
+	req, err = http.NewRequest(http.MethodGet, ts.URL+"/v1/admin/capacity-samples/export?format=csv&since=2006-01-02T15:04:05Z", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer test-key")
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("capacity export status = %d", resp.StatusCode)
+	}
+}

--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -921,18 +921,15 @@ func (s *Server) dispatchOneProvider(
 
 	provider, decision = s.registry.ReserveProviderEx(model, pr, excludeList()...)
 	if provider == nil {
-		// Providers serve this model but none can physically fit it: don't make
-		// the caller queue/retry for something that will never load.
+		// Keep pr so fail-fast telemetry can join candidate rows on
+		// PendingRequest.RequestID even when nobody is reserved.
 		if decision.CandidateCount == 0 && decision.CapacityRejections == 0 && decision.ModelTooLargeRejections > 0 {
-			return nil, nil, decision, errModelTooLarge, http.StatusServiceUnavailable
+			return nil, pr, decision, errModelTooLarge, http.StatusServiceUnavailable
 		}
-		// Providers are available but all exceed the TTFT ceiling. Fail fast
-		// with a retryable 429 rather than queueing or routing to a slow
-		// provider.
 		if decision.TTFTRejections > 0 {
-			return nil, nil, decision, errTTFTTooSlow, http.StatusTooManyRequests
+			return nil, pr, decision, errTTFTTooSlow, http.StatusTooManyRequests
 		}
-		return nil, nil, decision, "no provider available", http.StatusServiceUnavailable
+		return nil, pr, decision, "no provider available", http.StatusServiceUnavailable
 	}
 	pendingCleanup := true
 	cleanupPending := func() {

--- a/coordinator/api/dispatch.go
+++ b/coordinator/api/dispatch.go
@@ -2011,9 +2011,11 @@ func (d *dispatchState) runSpeculative() dispatchOutcome {
 	var backupProvider *registry.Provider
 	var attemptedBackupProvider *registry.Provider
 	var backupPR *registry.PendingRequest
+	var backupDecision registry.RoutingDecision
 	var backupErr string
 	var backupErrCode int
 	backupRouteRecorded := false
+	backupAttempted := false
 	backupRouteRequestID := ""
 	backupRouteAttempt := d.attempt
 
@@ -2040,7 +2042,8 @@ func (d *dispatchState) runSpeculative() dispatchOutcome {
 		}
 		backupExclude[provider.ID] = struct{}{}
 
-		backupProvider, backupPR, _, backupErr, backupErrCode = s.dispatchOneProvider(
+		backupAttempted = true
+		backupProvider, backupPR, backupDecision, backupErr, backupErrCode = s.dispatchOneProvider(
 			r, d.model, d.publicModel, d.rawBody, d.consumerKey, d.consumerLocation, d.reservedMicroUSD,
 			d.estimatedPromptTokens, d.requestedMaxTokens, d.tokenAdmission, d.requiresVision,
 			d.traits(),
@@ -2073,6 +2076,11 @@ func (d *dispatchState) runSpeculative() dispatchOutcome {
 		}
 		if backupRouteRecorded {
 			d.s.updateInferenceRouteOutcomeWithModel(backupRouteRequestID, backupRouteAttempt, d.model, d.errorRoutingOutcome("error", dispatchErrorClass(backupErr), backupErrCode))
+		} else if backupAttempted && backupPR != nil {
+			// Reserve returned no backup. Keep the minted request ID so the
+			// scored/rejected candidate rows still persist (ttft_429 /
+			// model_too_large / no_provider).
+			d.recordRoutingDecisionFor(nil, backupPR, backupPR.RequestID, d.attempt, backupDecision, backupErr, "")
 		}
 		// No backup available. Keep waiting for primary with remaining deadline.
 		s.logger.Info("speculative_dispatch_no_backup",

--- a/coordinator/api/dispatch.go
+++ b/coordinator/api/dispatch.go
@@ -387,39 +387,62 @@ func (d *dispatchState) recordRoutingDecisionFor(provider *registry.Provider, pr
 	}
 
 	record := &store.InferenceRouteRecord{
-		RequestID:               requestID,
-		Attempt:                 attempt,
-		ProviderID:              providerID,
-		Model:                   d.model,
-		PublicModel:             d.publicModel,
-		ConsumerKeyHash:         store.HashKey(d.consumerKey),
-		KeyID:                   keyID,
-		Outcome:                 outcome,
-		CostMs:                  decision.CostMs,
-		StateMs:                 decision.StateMs,
-		QueueMs:                 decision.QueueMs,
-		PendingMs:               decision.PendingMs,
-		BacklogMs:               decision.BacklogMs,
-		ThisReqMs:               decision.ThisReqMs,
-		HealthMs:                decision.HealthMs,
-		TTFTMs:                  decision.TTFTMs,
-		BestTTFTMs:              decision.BestTTFTMs,
-		EffectiveQueue:          decision.EffectiveQueue,
-		CandidateCount:          decision.CandidateCount,
-		CapacityRejections:      decision.CapacityRejections,
-		ModelTooLargeRejections: decision.ModelTooLargeRejections,
-		VisionRejections:        decision.VisionRejections,
-		TTFTRejections:          decision.TTFTRejections,
-		EffectiveTPS:            decision.EffectiveTPS,
-		StaticTPS:               decision.StaticTPS,
-		EstimatedPromptTokens:   d.estimatedPromptTokens,
-		RequestedMaxTokens:      d.requestedMaxTokens,
-		RequiresVision:          d.requiresVision,
-		HasTools:                d.hasTools,
-		SelfRouteOnly:           d.policy.enabled,
-		PreferOwner:             d.policy.prefer,
-		CreatedAt:               time.Now(),
-		UpdatedAt:               time.Now(),
+		RequestID:                 requestID,
+		Attempt:                   attempt,
+		ProviderID:                providerID,
+		Model:                     d.model,
+		PublicModel:               d.publicModel,
+		ConsumerKeyHash:           store.HashKey(d.consumerKey),
+		KeyID:                     keyID,
+		Outcome:                   outcome,
+		CostMs:                    decision.CostMs,
+		StateMs:                   decision.StateMs,
+		QueueMs:                   decision.QueueMs,
+		PendingMs:                 decision.PendingMs,
+		BacklogMs:                 decision.BacklogMs,
+		ThisReqMs:                 decision.ThisReqMs,
+		HealthMs:                  decision.HealthMs,
+		TTFTMs:                    decision.TTFTMs,
+		BestTTFTMs:                decision.BestTTFTMs,
+		EffectiveQueue:            decision.EffectiveQueue,
+		CandidateCount:            decision.CandidateCount,
+		CapacityRejections:        decision.CapacityRejections,
+		ModelTooLargeRejections:   decision.ModelTooLargeRejections,
+		VisionRejections:          decision.VisionRejections,
+		TTFTRejections:            decision.TTFTRejections,
+		EffectiveTPS:              decision.EffectiveTPS,
+		StaticTPS:                 decision.StaticTPS,
+		EstimatedPromptTokens:     d.estimatedPromptTokens,
+		RequestedMaxTokens:        d.requestedMaxTokens,
+		RequiresVision:            d.requiresVision,
+		HasTools:                  d.hasTools,
+		SelfRouteOnly:             d.policy.enabled,
+		PreferOwner:               d.policy.prefer,
+		CapacityRateMs:            decision.CapacityRateMs,
+		CapacityRejectRate:        decision.CapacityRejectRate,
+		AffinityTier:              decision.CacheTier,
+		AffinityDiscountMs:        decision.CacheDiscountMs,
+		Endpoint:                  d.telemetryEndpoint(),
+		FreeForLoadGB:             decision.FreeForLoadGB,
+		WedgeSuspected:            decision.WedgeSuspected,
+		TotalPending:              decision.TotalPending,
+		EffectivePrefillTPS:       decision.EffectivePrefillTPS,
+		StaticPrefillTPS:          decision.StaticPrefillTPS,
+		CacheEstimatedTTFTSavedMs: decision.CacheEstimatedTTFTSavedMs,
+		NearTieCount:              decision.NearTieCount,
+		TieBreakReason:            decision.TieBreakReason,
+		ShadowWouldShed:           decision.ShadowWouldShed,
+		ShadowIdleAlternative:     decision.ShadowIdleAlternativeExists,
+		ShadowEstimateMs:          decision.ShadowEstimateMs,
+		ShadowDeadlineMs:          decision.ShadowDeadlineMs,
+		BreakerRejections:         decision.BreakerRejections,
+		SoftFilterRejections:      decision.SoftFilterRejections,
+		CreatedAt:                 time.Now(),
+		UpdatedAt:                 time.Now(),
+	}
+
+	if d.consumerLocation != nil {
+		record.ConsumerRegion = coarseRegion(d.consumerLocation)
 	}
 
 	if provider != nil {
@@ -436,6 +459,7 @@ func (d *dispatchState) recordRoutingDecisionFor(provider *registry.Provider, pr
 		record.SystemMemoryPressure = provider.SystemMetrics.MemoryPressure
 		record.SystemCPUUsage = provider.SystemMetrics.CPUUsage
 		record.SystemThermalState = provider.SystemMetrics.ThermalState
+		loc := provider.Location
 		if cap := provider.BackendCapacity; cap != nil {
 			record.GPUMemoryActiveGB = cap.GPUMemoryActiveGB
 			record.GPUMemoryPeakGB = cap.GPUMemoryPeakGB
@@ -453,6 +477,12 @@ func (d *dispatchState) recordRoutingDecisionFor(provider *registry.Provider, pr
 			}
 		}
 		provider.Mu().Unlock()
+		record.ProviderRegion = coarseRegion(loc)
+		if d.s != nil {
+			attr := d.s.providerKVBackendAttribution(provider, d.model)
+			record.KVBackend = attr.Backend
+			record.KVBackendFallback = attr.Fallback
+		}
 	}
 
 	// Phase-0 shadow TTFT admission/spread metrics. No-op unless the request was
@@ -466,6 +496,7 @@ func (d *dispatchState) recordRoutingDecisionFor(provider *registry.Provider, pr
 		})
 	}
 
+	candidates := routeCandidatesFromDecision(requestID, attempt, decision.Candidates)
 	s.submitTelemetry("recordInferenceRoute", func() {
 		if err := s.store.RecordInferenceRoute(record); err != nil && s.logger != nil {
 			s.logger.Error("inference_routes record write failed",
@@ -476,6 +507,33 @@ func (d *dispatchState) recordRoutingDecisionFor(provider *registry.Provider, pr
 				"error", err,
 			)
 		}
+		if len(candidates) > 0 {
+			if err := s.store.RecordInferenceRouteCandidates(candidates); err != nil && s.logger != nil {
+				s.logger.Error("inference_route_candidates record write failed",
+					"request_id", requestID,
+					"attempt", attempt,
+					"count", len(candidates),
+					"error", err,
+				)
+			}
+		}
+	})
+}
+
+func (d *dispatchState) stampFinalAttempt() {
+	if d == nil || d.s == nil {
+		return
+	}
+	requestID := d.routingOutcomeKey()
+	if requestID == "" && d.pr != nil {
+		requestID = d.pr.RequestID
+	}
+	if requestID == "" {
+		return
+	}
+	d.s.updateInferenceRouteOutcomeWithModel(requestID, d.attempt, d.model, &store.InferenceRouteOutcome{
+		IsFinalAttempt: true,
+		TotalAttempts:  d.attempt + 1,
 	})
 }
 
@@ -514,6 +572,7 @@ func applyTimingDecomposition(out *store.InferenceRouteOutcome, t *registry.Requ
 	routeAnchor := t.ReservedAt
 	if !t.MediaFetchedAt.IsZero() {
 		routeAnchor = t.MediaFetchedAt
+		out.MediaFetchMs = timingMsBetween(t.ReservedAt, t.MediaFetchedAt)
 	}
 	out.RouteMs = timingMsBetween(routeAnchor, t.RoutedAt)
 	out.EncryptMs = timingMsBetween(t.RoutedAt, t.EncryptedAt)
@@ -3040,6 +3099,7 @@ func (d *dispatchState) waitAccepted() (outcome dispatchOutcome) {
 // range maxDispatchAttempts { ... }` block plus the post-loop !committed ladder,
 // attestation headers, timing header, settlement defer, and final response handoff.
 func (d *dispatchState) run() {
+	defer d.stampFinalAttempt()
 	s := d.s
 	w, r := d.w, d.r
 	d.preflightLegacyCacheBust()

--- a/coordinator/api/dispatch_ttft_terminal_test.go
+++ b/coordinator/api/dispatch_ttft_terminal_test.go
@@ -254,6 +254,22 @@ func TestDispatch_TTFTRejectAttempt0_SingleReservationAnd429(t *testing.T) {
 	if got := settleTTFT429Routes(t, st); got != 1 {
 		t.Errorf("ttft_429 route rows = %d, want exactly 1 (exactly one reservation scan)", got)
 	}
+	cands := st.InferenceRouteCandidatesSince(time.Time{})
+	if len(cands) == 0 {
+		t.Fatal("ttft_429 must persist rejected candidate rows; empty request_id drops them")
+	}
+	sawTTFT := false
+	for _, c := range cands {
+		if c.RequestID == "" {
+			t.Fatal("candidate request_id must be the minted PendingRequest id, not empty")
+		}
+		if c.RejectionReason == store.CandidateRejectTTFT {
+			sawTTFT = true
+		}
+	}
+	if !sawTTFT {
+		t.Fatalf("candidates = %+v, want a ttft rejection_reason", cands)
+	}
 }
 
 // TestTTFTTerminalRejectKillSwitch pins the env wiring: default ON, only an

--- a/coordinator/api/provider.go
+++ b/coordinator/api/provider.go
@@ -509,6 +509,7 @@ func (s *Server) providerReadLoop(ctx context.Context, conn *websocket.Conn, pro
 				}
 			}
 			s.registry.Heartbeat(providerID, hbMsg)
+			s.maybeRecordCapacitySample(provider)
 			// Emit only from the accepted registry snapshot: malformed values
 			// have been clamped and slot model IDs constrained to this
 			// connection's coordinator-known inventory.
@@ -634,10 +635,18 @@ func (s *Server) providerReadLoop(ctx context.Context, conn *websocket.Conn, pro
 				s.registry.MarkModelWarm(providerID, statusMsg.ModelID)
 				duration := s.registry.ClearPendingModelLoad(providerID, statusMsg.ModelID)
 				s.registry.RecordWarmPoolLoadResult(statusMsg.ModelID, true, duration)
+				if duration > 0 {
+					s.ddHistogram("routing.model_load_ms", float64(duration.Milliseconds()),
+						[]string{"model:" + statusMsg.ModelID, "outcome:succeeded"})
+				}
 				s.registry.DrainQueuedRequestsForModel(statusMsg.ModelID)
 			case protocol.LoadModelStatusFailed:
 				duration := s.registry.PendingModelLoadDuration(providerID, statusMsg.ModelID)
 				s.registry.RecordWarmPoolLoadResult(statusMsg.ModelID, false, duration)
+				if duration > 0 {
+					s.ddHistogram("routing.model_load_ms", float64(duration.Milliseconds()),
+						[]string{"model:" + statusMsg.ModelID, "outcome:failed"})
+				}
 				// Quantify WHY proactive loads are rejected. The reason
 				// is derived only from the existing error string (no new wire
 				// field). The proactive path's string is often a generic
@@ -1995,6 +2004,7 @@ func (s *Server) handleCompleteAt(
 	}
 
 	billingFinalized := true
+	reservedAtStart := pr.ReservedMicroUSD
 
 	// Settle billing against the pre-flight reservation. All balance
 	// mutations (overage charge, refund) happen inside the finalization
@@ -2191,6 +2201,13 @@ func (s *Server) handleCompleteAt(
 		// the provider completed and billing settled, but the client did not receive
 		// the full response.
 		outcome := completeRouteOutcome(pr, msg.Usage, totalCost, consumerGone)
+		overage, refund := int64(0), int64(0)
+		if totalCost > reservedAtStart {
+			overage = totalCost - reservedAtStart
+		} else if reservedAtStart > totalCost {
+			refund = reservedAtStart - totalCost
+		}
+		applyBillingSettlement(outcome, reservedAtStart, totalCost, overage, refund)
 		// Join only after both inputs are authoritative: cacheUsageValid was
 		// established from the terminal usage above, and completeRouteOutcome read
 		// the committed attempt's mutex-guarded first-content timestamp after the

--- a/coordinator/api/rejection_telemetry.go
+++ b/coordinator/api/rejection_telemetry.go
@@ -153,6 +153,9 @@ func (s *Server) recordRejection(info rejectionInfo) {
 		// A request could have produced output iff at least one provider could
 		// serve it right now. This is the headline "was the 'no' necessary?" flag.
 		rec.CouldHaveServed = rec.CandidateCount > 0
+		if resolvedModel != "" && reg != nil {
+			rec.WarmProviderExisted = reg.HasWarmProvider(resolvedModel)
+		}
 		_ = s.store.RecordRejection(rec)
 	})
 }

--- a/coordinator/api/route_outcome.go
+++ b/coordinator/api/route_outcome.go
@@ -150,6 +150,7 @@ func (s *Server) updateInferenceRouteOutcomeWithModel(requestID string, attempt 
 		return
 	}
 	s.emitInferenceErrorMetric(model, outcome)
+	applyOutcomeDimensions(outcome)
 	s.submitTelemetry("updateInferenceRoute", func() {
 		if err := s.store.UpdateInferenceRouteOutcome(requestID, attempt, outcome); err != nil && s.logger != nil {
 			s.logger.Error("inference_routes outcome update failed",
@@ -194,6 +195,7 @@ func (s *Server) updateInferenceRouteOutcomeForPending(pr *registry.PendingReque
 			s.emitCacheSelectionTerminal(pr, protocol.UsageInfo{}, false, false)
 		}
 	}
+	s.emitPredictionTelemetry(pr, outcome)
 	s.updateInferenceRouteOutcomeWithModel(pr.RequestID, pr.Attempt, pr.Model, outcome)
 }
 
@@ -203,10 +205,11 @@ func routeOutcome(status, class string, code int) *store.InferenceRouteOutcome {
 
 func routeOutcomeWithReason(status, class string, code int, providerReason, errorText string) *store.InferenceRouteOutcome {
 	return &store.InferenceRouteOutcome{
-		FinalStatus: status,
-		ErrorCode:   code,
-		ErrorClass:  class,
-		ErrorReason: inferenceErrorReason(providerReason, status, class, code, errorText),
+		FinalStatus:    status,
+		ErrorCode:      code,
+		ErrorClass:     class,
+		ErrorReason:    inferenceErrorReason(providerReason, status, class, code, errorText),
+		TerminalSource: terminalSourceFor(status, class),
 		// Terminal cancel/error/timeout rows deliver 0 tokens; force-persist that
 		// 0 (instead of leaving completion_tokens NULL) so the incident-majority
 		// 0-token cancels are visible. Success writes its real count separately
@@ -281,6 +284,7 @@ func applyAttemptUsage(out *store.InferenceRouteOutcome, usage *protocol.UsageIn
 	out.CompletionTokens = usage.CompletionTokens
 	out.CompletionTokensSet = true
 	out.ReasoningTokens = usage.ReasoningTokens
+	applyCacheUsageTelemetry(out, *usage)
 }
 
 func postCommitProviderErrorOutcome(pr *registry.PendingRequest, msg protocol.InferenceErrorMessage) *store.InferenceRouteOutcome {
@@ -383,10 +387,13 @@ func completeRouteOutcome(pr *registry.PendingRequest, usage protocol.UsageInfo,
 		CompletionTokensSet: true,
 		ReasoningTokens:     usage.ReasoningTokens,
 		CostMicroUSD:        costMicroUSD,
+		TerminalSource:      terminalSourceFor(status, errorClass),
+		SettledMicroUSD:     costMicroUSD,
 	}
 	if errorClass != "" {
 		out.ErrorReason = inferenceErrorReason("", status, errorClass, 0, "")
 	}
+	applyCacheUsageTelemetry(out, usage)
 	applyPendingRouteTelemetry(out, pr)
 	return out
 }
@@ -446,6 +453,9 @@ func applyPendingRouteTelemetry(out *store.InferenceRouteOutcome, pr *registry.P
 	}
 	out.UsedBackup = pr.UsedBackup
 	out.BackupWon = pr.BackupWon
+	if out.ReservedMicroUSD == 0 && pr.ReservedMicroUSD > 0 {
+		out.ReservedMicroUSD = pr.ReservedMicroUSD
+	}
 	if pr.Timing == nil {
 		return
 	}

--- a/coordinator/api/server.go
+++ b/coordinator/api/server.go
@@ -367,6 +367,9 @@ type Server struct {
 	// main.go wires it up.
 	emitter *telemetry.Emitter
 
+	// capacitySampler rate-limits request-independent heartbeat snapshots.
+	capacitySampler *capacitySampler
+
 	// dd is the Datadog integration client for DogStatsD metrics and
 	// Logs API event forwarding. Nil when DD is not configured.
 	dd *datadog.Client
@@ -732,6 +735,7 @@ func NewServer(reg *registry.Registry, st store.Store, cfg ServerConfig, logger 
 		zombieCanceller:          newZombieStreamCanceller(),
 		serviceReservations:      newServiceReservationManager(st, cfg.ServiceReservations),
 		routeTelemetry:           newTelemetrySink(logger, defaultTelemetrySinkCapacity, defaultTelemetrySinkWorkers),
+		capacitySampler:          newCapacitySampler(),
 		mediaResolver:            mediafetch.NewResolver(mediaFetchCfg, logger),
 		firstContentDeadlineBase: firstContentDeadlineBase,
 	}
@@ -1974,6 +1978,10 @@ func (s *Server) routes() {
 	s.mux.HandleFunc("GET /v1/admin/routes/export", s.handleAdminRoutesExport)
 	s.mux.HandleFunc("GET /v1/admin/rejections", s.handleAdminRejections)
 	s.mux.HandleFunc("GET /v1/admin/rejections/export", s.handleAdminRejectionsExport)
+	s.mux.HandleFunc("GET /v1/admin/candidates", s.handleAdminCandidates)
+	s.mux.HandleFunc("GET /v1/admin/candidates/export", s.handleAdminCandidatesExport)
+	s.mux.HandleFunc("GET /v1/admin/capacity-samples", s.handleAdminCapacitySamples)
+	s.mux.HandleFunc("GET /v1/admin/capacity-samples/export", s.handleAdminCapacitySamplesExport)
 
 	// Catch-all for unimplemented OpenAI-compatible endpoints.
 	// Registered last (old-style pattern) so explicit method+path routes

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -223,6 +223,12 @@ type PendingRequest struct {
 	UsedBackup bool
 	BackupWon  bool
 
+	// Predicted* are the scheduler estimates at reservation. Completion uses
+	// them to emit prediction-error histograms without re-reading the route row.
+	PredictedTTFTMs       float64
+	PredictedCostMs       float64
+	PredictedEffectiveTPS float64
+
 	// ReservedMicroUSD is the balance atomically debited at pre-flight.
 	// The post-inference charge adjusts for the difference between the
 	// actual cost and this reservation, preventing billing race conditions.
@@ -3714,6 +3720,18 @@ func (r *Registry) planModelLoadActions(queuedModels []string, now time.Time) []
 		actions = append(actions, modelLoadAction{providerID: providerID, modelID: model})
 	}
 	return actions
+}
+
+// HasWarmProvider reports whether any connected, publicly-routable provider
+// already has the model warm. Used by rejection telemetry for the
+// counterfactual "was the model already resident somewhere?" flag.
+func (r *Registry) HasWarmProvider(model string) bool {
+	if r == nil || model == "" {
+		return false
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.hasWarmProviderLocked(model, time.Now())
 }
 
 // hasWarmProviderLocked reports whether a connected provider already has the

--- a/coordinator/registry/route_candidate_snapshot.go
+++ b/coordinator/registry/route_candidate_snapshot.go
@@ -1,0 +1,209 @@
+package registry
+
+import (
+	"sort"
+)
+
+const (
+	maxPersistedCandidates = 24
+	maxPersistedRejected   = 8
+)
+
+// RouteCandidateSnapshot is the lock-copied, public view of one provider the
+// scheduler considered. It is safe to persist asynchronously: it holds no
+// pointers and no prompt content.
+type RouteCandidateSnapshot struct {
+	ProviderID          string
+	Rank                int
+	Selected            bool
+	Eligible            bool
+	RejectionReason     string
+	CostMs              float64
+	StateMs             float64
+	QueueMs             float64
+	PendingMs           float64
+	BacklogMs           float64
+	ThisReqMs           float64
+	HealthMs            float64
+	CapacityRateMs      float64
+	TTFTMs              float64
+	EffectiveQueue      int
+	EffectiveTPS        float64
+	StaticTPS           float64
+	EffectivePrefillTPS float64
+	StaticPrefillTPS    float64
+	BatchSize           int
+	ChipFamily          string
+	HardwareTier        string
+	MemoryGB            int
+	SlotState           string
+	MemoryPressure      float64
+	ThermalState        string
+	GPUMemoryActiveGB   float64
+	FreeForLoadGB       float64
+	WedgeSuspected      bool
+	AffinityApplied     bool
+	AffinityDiscountMs  float64
+	CapacityRejectRate  float64
+}
+
+func appendRejected(dst []rejectedCandidate, rec rejectedCandidate) []rejectedCandidate {
+	if len(dst) >= maxPersistedRejected*2 {
+		return dst
+	}
+	return append(dst, rec)
+}
+
+func snapshotRouteCandidates(winner *routingCandidate, scan candidateScan, reserved bool) []RouteCandidateSnapshot {
+	winnerID := providerIDOf(winner)
+	seen := make(map[string]struct{}, len(scan.pool)+len(scan.rejected))
+
+	eligible := make([]RouteCandidateSnapshot, 0, len(scan.pool))
+	for _, c := range scan.pool {
+		id := providerIDOf(c)
+		if id == "" {
+			continue
+		}
+		seen[id] = struct{}{}
+		eligible = append(eligible, candidateToSnapshot(c, "", true))
+	}
+	sort.SliceStable(eligible, func(i, j int) bool {
+		if eligible[i].CostMs == eligible[j].CostMs {
+			return eligible[i].ProviderID < eligible[j].ProviderID
+		}
+		return eligible[i].CostMs < eligible[j].CostMs
+	})
+
+	rejected := make([]RouteCandidateSnapshot, 0, len(scan.rejected))
+	for _, rec := range scan.rejected {
+		id := rejectedProviderID(rec)
+		if id == "" {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		if rec.candidate != nil {
+			rejected = append(rejected, candidateToSnapshot(rec.candidate, rec.reason, false))
+			continue
+		}
+		rejected = append(rejected, rejectedSnapToSnapshot(rec.snap, rec.reason))
+	}
+	if len(rejected) > maxPersistedRejected {
+		rejected = rejected[:maxPersistedRejected]
+	}
+
+	eligibleCap := maxPersistedCandidates - len(rejected)
+	if eligibleCap < 1 {
+		eligibleCap = 1
+	}
+	if len(eligible) > eligibleCap {
+		// Keep the winner even if it is not among the cheapest eligibleCap
+		// after a later admit re-check (reserved=false still ranks it).
+		kept := eligible[:eligibleCap]
+		if winnerID != "" {
+			found := false
+			for i := range kept {
+				if kept[i].ProviderID == winnerID {
+					found = true
+					break
+				}
+			}
+			if !found {
+				for i := range eligible {
+					if eligible[i].ProviderID == winnerID {
+						kept[len(kept)-1] = eligible[i]
+						break
+					}
+				}
+			}
+		}
+		eligible = kept
+	}
+
+	out := make([]RouteCandidateSnapshot, 0, len(eligible)+len(rejected))
+	for i := range eligible {
+		row := eligible[i]
+		row.Rank = i
+		if reserved && winnerID != "" && row.ProviderID == winnerID {
+			row.Selected = true
+		}
+		out = append(out, row)
+	}
+	for i := range rejected {
+		row := rejected[i]
+		row.Rank = -1
+		out = append(out, row)
+	}
+	return out
+}
+
+func providerIDOf(c *routingCandidate) string {
+	if c == nil || c.provider == nil {
+		return ""
+	}
+	return c.provider.ID
+}
+
+func rejectedProviderID(rec rejectedCandidate) string {
+	if id := providerIDOf(rec.candidate); id != "" {
+		return id
+	}
+	if rec.snap.provider != nil {
+		return rec.snap.provider.ID
+	}
+	return ""
+}
+
+func candidateToSnapshot(c *routingCandidate, reason string, eligible bool) RouteCandidateSnapshot {
+	snap := rejectedSnapToSnapshot(c.snapshot, reason)
+	snap.Eligible = eligible
+	snap.CostMs = c.costMs
+	snap.StateMs = c.breakdown.StateMs
+	snap.QueueMs = c.breakdown.QueueMs
+	snap.PendingMs = c.breakdown.PendingMs
+	snap.BacklogMs = c.breakdown.BacklogMs
+	snap.ThisReqMs = c.breakdown.ThisReqMs
+	snap.HealthMs = c.breakdown.HealthMs
+	snap.CapacityRateMs = c.breakdown.CapacityRateMs
+	snap.TTFTMs = c.breakdown.TTFTMs
+	snap.EffectiveQueue = c.effectiveQueue
+	snap.EffectiveTPS = c.effectiveTPS
+	snap.StaticTPS = c.snapshot.decodeTPS
+	snap.EffectivePrefillTPS = resolvePrefillTPS(c.snapshot)
+	snap.StaticPrefillTPS = c.snapshot.prefillTPS
+	snap.AffinityDiscountMs = c.breakdown.CacheDiscountMs
+	snap.AffinityApplied = c.breakdown.CacheDiscountMs > 0
+	snap.CapacityRejectRate = c.capacityRejectRate
+	if c.provider != nil {
+		snap.ProviderID = c.provider.ID
+	}
+	return snap
+}
+
+func rejectedSnapToSnapshot(snap routingSnapshot, reason string) RouteCandidateSnapshot {
+	out := RouteCandidateSnapshot{
+		Eligible:          false,
+		RejectionReason:   reason,
+		ChipFamily:        snap.chipFamily,
+		HardwareTier:      snap.hardwareTier,
+		MemoryGB:          snap.memoryGB,
+		SlotState:         snap.slotState,
+		MemoryPressure:    snap.systemMetrics.MemoryPressure,
+		ThermalState:      snap.systemMetrics.ThermalState,
+		GPUMemoryActiveGB: snap.gpuMemoryActiveGB,
+		BatchSize:         snap.backendRunning,
+		WedgeSuspected:    snap.wedgeSuspected,
+	}
+	if snap.provider != nil {
+		out.ProviderID = snap.provider.ID
+	}
+	if snap.freeForLoadGB != nil {
+		out.FreeForLoadGB = *snap.freeForLoadGB
+	}
+	if snap.memoryGB == 0 && snap.totalMemoryGB > 0 {
+		out.MemoryGB = int(snap.totalMemoryGB)
+	}
+	return out
+}

--- a/coordinator/registry/route_candidate_snapshot.go
+++ b/coordinator/registry/route_candidate_snapshot.go
@@ -2,6 +2,8 @@ package registry
 
 import (
 	"sort"
+
+	"github.com/eigeninference/d-inference/coordinator/store"
 )
 
 const (
@@ -48,9 +50,8 @@ type RouteCandidateSnapshot struct {
 }
 
 func appendRejected(dst []rejectedCandidate, rec rejectedCandidate) []rejectedCandidate {
-	if len(dst) >= maxPersistedRejected*2 {
-		return dst
-	}
+	// Persist cap is applied in snapshotRouteCandidates with priority so a
+	// fleet of catalog/liveness misses cannot starve TTFT/soft-filter rows.
 	return append(dst, rec)
 }
 
@@ -90,6 +91,13 @@ func snapshotRouteCandidates(winner *routingCandidate, scan candidateScan, reser
 		}
 		rejected = append(rejected, rejectedSnapToSnapshot(rec.snap, rec.reason))
 	}
+	sort.SliceStable(rejected, func(i, j int) bool {
+		pi, pj := rejectPersistPriority(rejected[i].RejectionReason), rejectPersistPriority(rejected[j].RejectionReason)
+		if pi != pj {
+			return pi < pj
+		}
+		return rejected[i].ProviderID < rejected[j].ProviderID
+	})
 	if len(rejected) > maxPersistedRejected {
 		rejected = rejected[:maxPersistedRejected]
 	}
@@ -137,6 +145,26 @@ func snapshotRouteCandidates(winner *routingCandidate, scan candidateScan, reser
 		out = append(out, row)
 	}
 	return out
+}
+
+// rejectPersistPriority ranks why a candidate lost for the persist cap.
+// Lower is kept first: scored/soft-filter/TTFT losses are the calibration
+// signal; catalog/liveness misses are fleet-sized noise.
+func rejectPersistPriority(reason string) int {
+	switch reason {
+	case store.CandidateRejectPreferOwner, store.CandidateRejectAvoidVersion, store.CandidateRejectMinDecodeTPS:
+		return 0
+	case store.CandidateRejectTTFT:
+		return 1
+	case store.CandidateRejectCapacity, store.CandidateRejectModelTooLarge, store.CandidateRejectVision,
+		store.CandidateRejectSlotCrashed, store.CandidateRejectSlotReloading, store.CandidateRejectThermalCritical:
+		return 2
+	case store.CandidateRejectLoadCooldown, store.CandidateRejectErrorCooldown, store.CandidateRejectCapacityCooldown,
+		store.CandidateRejectBreaker, store.CandidateRejectHealthEjection, store.CandidateRejectTrait:
+		return 3
+	default:
+		return 4
+	}
 }
 
 func providerIDOf(c *routingCandidate) string {

--- a/coordinator/registry/route_candidate_snapshot_test.go
+++ b/coordinator/registry/route_candidate_snapshot_test.go
@@ -1,0 +1,126 @@
+package registry
+
+import (
+	"testing"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+	"github.com/eigeninference/d-inference/coordinator/store"
+)
+
+func TestSnapshotRouteCandidatesRanksWinnerAndKeepsRejects(t *testing.T) {
+	cheap := &Provider{ID: "cheap"}
+	slow := &Provider{ID: "slow"}
+	full := &Provider{ID: "full"}
+	winner := &routingCandidate{
+		provider: cheap,
+		costMs:   800,
+		snapshot: routingSnapshot{
+			provider:       cheap,
+			chipFamily:     "M4",
+			hardwareTier:   "Max",
+			memoryGB:       64,
+			slotState:      "idle",
+			decodeTPS:      50,
+			backendRunning: 1,
+			systemMetrics:  protocol.SystemMetrics{MemoryPressure: 0.2, ThermalState: "nominal"},
+		},
+		effectiveQueue: 1,
+		effectiveTPS:   45,
+		breakdown:      costBreakdown{QueueMs: 100, ThisReqMs: 700, Total: 800},
+	}
+	loser := &routingCandidate{
+		provider: slow,
+		costMs:   2400,
+		snapshot: routingSnapshot{
+			provider:     slow,
+			chipFamily:   "M3",
+			hardwareTier: "Pro",
+			memoryGB:     36,
+			slotState:    "running",
+			decodeTPS:    20,
+		},
+		effectiveQueue: 3,
+		effectiveTPS:   12,
+		breakdown:      costBreakdown{HealthMs: 800, ThisReqMs: 1600, Total: 2400},
+	}
+	scan := candidateScan{
+		pool: []*routingCandidate{loser, winner},
+		rejected: []rejectedCandidate{{
+			snap: routingSnapshot{
+				provider:  full,
+				memoryGB:  24,
+				slotState: "running",
+			},
+			reason: store.CandidateRejectCapacity,
+		}},
+	}
+
+	got := snapshotRouteCandidates(winner, scan, true)
+	if len(got) != 3 {
+		t.Fatalf("snapshots = %d, want 3", len(got))
+	}
+	if got[0].ProviderID != "cheap" || got[0].Rank != 0 || !got[0].Selected || !got[0].Eligible {
+		t.Fatalf("winner row = %+v", got[0])
+	}
+	if got[1].ProviderID != "slow" || got[1].Rank != 1 || got[1].Selected {
+		t.Fatalf("runner-up row = %+v", got[1])
+	}
+	if got[2].ProviderID != "full" || got[2].Rank != -1 || got[2].Eligible || got[2].RejectionReason != store.CandidateRejectCapacity {
+		t.Fatalf("rejected row = %+v", got[2])
+	}
+
+	notReserved := snapshotRouteCandidates(winner, scan, false)
+	if notReserved[0].Selected {
+		t.Fatal("unreserved winner must not be marked selected")
+	}
+}
+
+func TestSnapshotRouteCandidatesEmpty(t *testing.T) {
+	if got := snapshotRouteCandidates(nil, candidateScan{}, false); len(got) != 0 {
+		t.Fatalf("empty scan snapshots = %d", len(got))
+	}
+}
+
+func TestSnapshotRouteCandidatesKeepsSoftFilterRejects(t *testing.T) {
+	owned := &Provider{ID: "owned"}
+	public := &Provider{ID: "public"}
+	winner := &routingCandidate{
+		provider:  owned,
+		costMs:    2000,
+		snapshot:  routingSnapshot{provider: owned, decodeTPS: 20},
+		breakdown: costBreakdown{Total: 2000},
+	}
+	filtered := &routingCandidate{
+		provider:  public,
+		costMs:    800,
+		snapshot:  routingSnapshot{provider: public, decodeTPS: 80},
+		breakdown: costBreakdown{Total: 800},
+	}
+	scan := candidateScan{
+		pool: []*routingCandidate{winner},
+		rejected: []rejectedCandidate{{
+			candidate: filtered,
+			snap:      filtered.snapshot,
+			reason:    store.CandidateRejectPreferOwner,
+		}},
+	}
+	got := snapshotRouteCandidates(winner, scan, true)
+	if len(got) != 2 {
+		t.Fatalf("snapshots = %d, want 2", len(got))
+	}
+	var sawSoft bool
+	for _, row := range got {
+		if row.ProviderID == "public" {
+			sawSoft = true
+			if row.Eligible || row.RejectionReason != store.CandidateRejectPreferOwner || row.CostMs != 800 {
+				t.Fatalf("soft-filtered row = %+v", row)
+			}
+		}
+		if row.ProviderID == "owned" && (!row.Selected || !row.Eligible) {
+			t.Fatalf("owned winner row = %+v", row)
+		}
+	}
+	if !sawSoft {
+		t.Fatal("soft-filtered public candidate missing")
+	}
+}

--- a/coordinator/registry/route_candidate_snapshot_test.go
+++ b/coordinator/registry/route_candidate_snapshot_test.go
@@ -124,3 +124,54 @@ func TestSnapshotRouteCandidatesKeepsSoftFilterRejects(t *testing.T) {
 		t.Fatal("soft-filtered public candidate missing")
 	}
 }
+
+func TestSnapshotRouteCandidatesPrefersInformativeRejects(t *testing.T) {
+	owned := &Provider{ID: "owned"}
+	public := &Provider{ID: "public"}
+	winner := &routingCandidate{
+		provider:  owned,
+		costMs:    2000,
+		snapshot:  routingSnapshot{provider: owned},
+		breakdown: costBreakdown{Total: 2000},
+	}
+	filtered := &routingCandidate{
+		provider:  public,
+		costMs:    800,
+		snapshot:  routingSnapshot{provider: public},
+		breakdown: costBreakdown{Total: 800},
+	}
+	scan := candidateScan{pool: []*routingCandidate{winner}}
+	for i := 0; i < 12; i++ {
+		p := &Provider{ID: string(rune('a'+i)) + "-catalog"}
+		scan.rejected = append(scan.rejected, rejectedCandidate{
+			snap:   routingSnapshot{provider: p},
+			reason: store.CandidateRejectCatalog,
+		})
+	}
+	scan.rejected = append(scan.rejected, rejectedCandidate{
+		candidate: filtered,
+		snap:      filtered.snapshot,
+		reason:    store.CandidateRejectPreferOwner,
+	})
+
+	got := snapshotRouteCandidates(winner, scan, true)
+	var sawSoft bool
+	rejected := 0
+	for _, row := range got {
+		if !row.Eligible {
+			rejected++
+		}
+		if row.ProviderID == "public" {
+			sawSoft = true
+			if row.RejectionReason != store.CandidateRejectPreferOwner || row.CostMs != 800 {
+				t.Fatalf("prefer_owner row = %+v", row)
+			}
+		}
+	}
+	if !sawSoft {
+		t.Fatalf("prefer_owner drop must survive a catalog flood; snapshots=%+v", got)
+	}
+	if rejected > maxPersistedRejected {
+		t.Fatalf("rejected rows = %d, want <= %d", rejected, maxPersistedRejected)
+	}
+}

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/eigeninference/d-inference/coordinator/env"
 	"github.com/eigeninference/d-inference/coordinator/protocol"
+	"github.com/eigeninference/d-inference/coordinator/store"
 )
 
 const (
@@ -98,9 +99,11 @@ const (
 )
 
 type routingSnapshot struct {
-	provider   *Provider
-	model      string
-	chipFamily string // hardware chip family (e.g. "M3"); keys the TTFT calibrator
+	provider     *Provider
+	model        string
+	chipFamily   string // hardware chip family (e.g. "M3"); keys the TTFT calibrator
+	hardwareTier string
+	memoryGB     int
 	// binaryVersion is the provider's reported binary version (p.Version, read
 	// under p.mu at snapshot time; empty = unreported/legacy). Feeds the
 	// version-gated activation-reserve selection in the cold servability
@@ -296,13 +299,11 @@ type RoutingDecision struct {
 	ThisReqMs  float64 // this request's prefill+decode contribution
 	HealthMs   float64 // memory/CPU/thermal/GPU-util contribution
 	// CapacityRateMs is the gray-box capacity-503 rate penalty added to the
-	// winner's cost (capacity_rate.go); 0 for healthy pairs. In-memory
-	// observability only — not persisted (inference_routes has no column and
-	// the schema is not altered for it).
+	// winner's cost (capacity_rate.go); 0 for healthy pairs.
 	CapacityRateMs float64
 	// CapacityRejectRate is the winner's windowed capacity-503 rate at
 	// selection time (rejects / (rejects + accepts)); 0 when no rejects are in
-	// the window. Same persistence note as CapacityRateMs.
+	// the window.
 	CapacityRejectRate float64
 	EffectiveQueue     int // max(pendingForModel, backendRunning+backendWaiting)
 	CandidateCount     int // total candidates that passed all gates
@@ -349,6 +350,25 @@ type RoutingDecision struct {
 	ShadowEstimateMs            float64
 	ShadowDeadlineMs            float64
 	ShadowOccupancy             int
+
+	// Winner admission/prefill snapshot at selection time.
+	FreeForLoadGB        float64
+	WedgeSuspected       bool
+	TotalPending         int
+	EffectivePrefillTPS  float64
+	StaticPrefillTPS     float64
+	NearTieCount         int
+	TieBreakReason       string
+	BreakerRejections    int
+	SoftFilterRejections int
+
+	// Candidates is the compact, lock-copied snapshot of scored and
+	// post-gate-rejected providers for this selection. Empty when the
+	// fleet scan produced nothing. Persistence is best-effort and off
+	// the request path. Rank is cost-order (0 = cheapest eligible);
+	// Selected is who was actually reserved (near-tie spread can pick
+	// a non-cheapest candidate).
+	Candidates []RouteCandidateSnapshot
 }
 
 // ReserveProvider selects a hardware-routable provider for the request and
@@ -397,7 +417,6 @@ func (r *Registry) ReserveProviderEx(model string, pr *PendingRequest, excludeID
 	}
 
 	r.mu.Lock()
-	defer r.mu.Unlock()
 	// Configuration can change while tracker hints are computed outside r.mu.
 	// Revalidate under the selection lock so an off transition is linearizable:
 	// once ConfigureCacheRouting(off) returns, no stale hint can receive a
@@ -408,17 +427,14 @@ func (r *Registry) ReserveProviderEx(model string, pr *PendingRequest, excludeID
 		pr.CacheSelectionMode = ""
 	}
 
-	selected, candidateCount, capacityRejections, tooLargeRejections, visionRejections, ttftRejections, bestTTFTMs := r.selectBestCandidateLockedFull(model, pr, excludeIDs...)
+	selected, scan := r.selectBestCandidateLockedFull(model, pr, excludeIDs...)
+	tally := scan.routingTally()
 	if selected == nil {
-		return nil, RoutingDecision{
-			Model:                   model,
-			CandidateCount:          candidateCount,
-			CapacityRejections:      capacityRejections,
-			ModelTooLargeRejections: tooLargeRejections,
-			VisionRejections:        visionRejections,
-			TTFTRejections:          ttftRejections,
-			BestTTFTMs:              bestTTFTMs,
-		}
+		decision := tally
+		decision.Model = model
+		r.mu.Unlock()
+		decision.Candidates = snapshotRouteCandidates(nil, scan, false)
+		return nil, decision
 	}
 
 	// Phase-0 shadow TTFT evaluation: computed here (r.mu held, no provider lock
@@ -434,7 +450,6 @@ func (r *Registry) ReserveProviderEx(model string, pr *PendingRequest, excludeID
 
 	p := selected.provider
 	p.mu.Lock()
-	defer p.mu.Unlock()
 
 	// Re-check capacity under the provider lock in case another goroutine
 	// changed the pending set between snapshot and reservation. relaxTrust
@@ -469,15 +484,12 @@ func (r *Registry) ReserveProviderEx(model string, pr *PendingRequest, excludeID
 	}
 	if !r.providerCanAdmitLockedEx(p, model, pr.Traits, relaxTrust, ignoreBreaker) ||
 		(pr.RequiresVision && !r.providerServesVisionModelLocked(p, model, relaxTrust)) {
-		return nil, RoutingDecision{
-			Model:                   model,
-			CandidateCount:          candidateCount,
-			CapacityRejections:      capacityRejections,
-			ModelTooLargeRejections: tooLargeRejections,
-			VisionRejections:        visionRejections,
-			TTFTRejections:          ttftRejections,
-			BestTTFTMs:              bestTTFTMs,
-		}
+		p.mu.Unlock()
+		r.mu.Unlock()
+		decision := tally
+		decision.Model = model
+		decision.Candidates = snapshotRouteCandidates(selected, scan, false)
+		return nil, decision
 	}
 
 	bd := selected.breakdown
@@ -513,34 +525,62 @@ func (r *Registry) ReserveProviderEx(model string, pr *PendingRequest, excludeID
 	if !pr.RequiresVision && bd.RawTTFTMs > 0 && bd.StateMs == 0 {
 		ttftCalibration.notePrediction(pr.RequestID, pr.Attempt, model, selected.snapshot.chipFamily, bd.RawTTFTMs)
 	}
-	decision := RoutingDecision{
-		ProviderID:                p.ID,
-		Model:                     model,
-		CostMs:                    bd.Total,
-		StateMs:                   bd.StateMs,
-		QueueMs:                   bd.QueueMs,
-		PendingMs:                 bd.PendingMs,
-		BacklogMs:                 bd.BacklogMs,
-		ThisReqMs:                 bd.ThisReqMs,
-		HealthMs:                  bd.HealthMs,
-		CapacityRateMs:            bd.CapacityRateMs,
-		CapacityRejectRate:        selected.capacityRejectRate,
-		EffectiveQueue:            selected.effectiveQueue,
-		CandidateCount:            candidateCount,
-		CapacityRejections:        capacityRejections,
-		ModelTooLargeRejections:   tooLargeRejections,
-		VisionRejections:          visionRejections,
-		TTFTRejections:            ttftRejections,
-		BestTTFTMs:                bestTTFTMs,
-		TTFTMs:                    bd.TTFTMs,
-		CacheTier:                 selected.cacheTier,
-		CacheDiscountMs:           bd.CacheDiscountMs,
-		CacheEstimatedTTFTSavedMs: selected.cacheEstimatedTTFTSavedMs,
-		EffectiveTPS:              selected.effectiveTPS,
-		StaticTPS:                 selected.snapshot.decodeTPS,
-	}
+	decision := tally
+	decision.ProviderID = p.ID
+	decision.Model = model
+	decision.CostMs = bd.Total
+	decision.StateMs = bd.StateMs
+	decision.QueueMs = bd.QueueMs
+	decision.PendingMs = bd.PendingMs
+	decision.BacklogMs = bd.BacklogMs
+	decision.ThisReqMs = bd.ThisReqMs
+	decision.HealthMs = bd.HealthMs
+	decision.CapacityRateMs = bd.CapacityRateMs
+	decision.CapacityRejectRate = selected.capacityRejectRate
+	decision.EffectiveQueue = selected.effectiveQueue
+	decision.TTFTMs = bd.TTFTMs
+	decision.CacheTier = selected.cacheTier
+	decision.CacheDiscountMs = bd.CacheDiscountMs
+	decision.CacheEstimatedTTFTSavedMs = selected.cacheEstimatedTTFTSavedMs
+	decision.EffectiveTPS = selected.effectiveTPS
+	decision.StaticTPS = selected.snapshot.decodeTPS
+	applyWinnerSnapshot(&decision, selected)
+	pr.PredictedTTFTMs = decision.TTFTMs
+	pr.PredictedCostMs = decision.CostMs
+	pr.PredictedEffectiveTPS = decision.EffectiveTPS
 	shadowEval.applyTo(&decision)
+	p.mu.Unlock()
+	r.mu.Unlock()
+	decision.Candidates = snapshotRouteCandidates(selected, scan, true)
 	return p, decision
+}
+
+func (scan candidateScan) routingTally() RoutingDecision {
+	return RoutingDecision{
+		CandidateCount:          scan.candidateCount,
+		CapacityRejections:      scan.capacityRejections,
+		ModelTooLargeRejections: scan.tooLargeRejections,
+		VisionRejections:        scan.visionRejections,
+		TTFTRejections:          scan.ttftRejections,
+		BestTTFTMs:              scan.bestTTFTMs,
+		BreakerRejections:       scan.breakerRejected,
+		SoftFilterRejections:    scan.softFilterRejections,
+		NearTieCount:            scan.nearTieCount,
+		TieBreakReason:          scan.tieBreakReason,
+	}
+}
+
+func applyWinnerSnapshot(decision *RoutingDecision, selected *routingCandidate) {
+	if decision == nil || selected == nil {
+		return
+	}
+	decision.TotalPending = selected.snapshot.totalPending
+	decision.WedgeSuspected = selected.snapshot.wedgeSuspected
+	if selected.snapshot.freeForLoadGB != nil {
+		decision.FreeForLoadGB = *selected.snapshot.freeForLoadGB
+	}
+	decision.EffectivePrefillTPS = resolvePrefillTPS(selected.snapshot)
+	decision.StaticPrefillTPS = selected.snapshot.prefillTPS
 }
 
 // selectBestCandidateLockedFull is the full-fidelity selection that
@@ -549,8 +589,8 @@ func (r *Registry) ReserveProviderEx(model string, pr *PendingRequest, excludeID
 // distinguish "no provider serves this model" from "every fitting
 // provider is over-subscribed", which is the difference between the
 // no_provider and over_capacity outcome counters.
-// Returns (winner, candidateCount, capacityRejections, modelTooLargeRejections,
-// visionRejections, ttftRejections, bestTTFTMs).
+// Returns (winner, scan) where scan carries the scored pool, post-gate
+// rejects, and the rejection tallies.
 //
 // FAIL-OPEN SAFETY VALVE: selection runs in two passes. Pass 1 honors the
 // per-provider node-health breaker. If pass 1 finds ZERO candidates AND the
@@ -564,19 +604,18 @@ func (r *Registry) ReserveProviderEx(model string, pr *PendingRequest, excludeID
 // when it yields a candidate, and its counters (not pass 1's) are returned so
 // metrics are never double-counted. This mirrors servability.go's fail-open
 // philosophy: when in doubt, keep serving.
-func (r *Registry) selectBestCandidateLockedFull(model string, pr *PendingRequest, excludeIDs ...string) (*routingCandidate, int, int, int, int, int, float64) {
-	winner, candidateCount, capacityRejections, tooLargeRejections, visionRejections, ttftRejections, bestTTFTMs, breakerRejected :=
-		r.selectBestCandidateScanLocked(model, pr, false, excludeIDs...)
-	if !shouldBypassBreakerFailOpen(winner, breakerRejected, capacityRejections, ttftRejections) {
-		return winner, candidateCount, capacityRejections, tooLargeRejections, visionRejections, ttftRejections, bestTTFTMs
+func (r *Registry) selectBestCandidateLockedFull(model string, pr *PendingRequest, excludeIDs ...string) (*routingCandidate, candidateScan) {
+	winner, scan := r.selectBestCandidateScanLocked(model, pr, false, excludeIDs...)
+	if !shouldBypassBreakerFailOpen(winner, scan.breakerRejected, scan.capacityRejections, scan.ttftRejections) {
+		return winner, scan
 	}
 	// The node-health breaker is the SOLE reason this request has no route: re-scan
 	// with the breaker bypassed. Use pass 2 only when it actually finds a candidate,
 	// so a genuinely empty fleet still reports pass 1's (accurate) counters.
-	if w2, cc2, cr2, tl2, vr2, tr2, bt2, _ := r.selectBestCandidateScanLocked(model, pr, true, excludeIDs...); w2 != nil {
-		return w2, cc2, cr2, tl2, vr2, tr2, bt2
+	if w2, scan2 := r.selectBestCandidateScanLocked(model, pr, true, excludeIDs...); w2 != nil {
+		return w2, scan2
 	}
-	return winner, candidateCount, capacityRejections, tooLargeRejections, visionRejections, ttftRejections, bestTTFTMs
+	return winner, scan
 }
 
 // shouldBypassBreakerFailOpen decides whether selection should retry with the
@@ -605,14 +644,27 @@ func shouldBypassBreakerFailOpen(winner *routingCandidate, breakerRejected, capa
 // idle-spread shadow scan (loadedIdleAlternativeExistsLocked) so the two can
 // never drift on which providers are routable.
 type candidateScan struct {
-	pool               []*routingCandidate
-	candidateCount     int
-	capacityRejections int
-	tooLargeRejections int
-	visionRejections   int
-	ttftRejections     int
-	bestTTFTMs         float64
-	breakerRejected    int
+	pool                 []*routingCandidate
+	rejected             []rejectedCandidate
+	candidateCount       int
+	capacityRejections   int
+	tooLargeRejections   int
+	visionRejections     int
+	ttftRejections       int
+	bestTTFTMs           float64
+	breakerRejected      int
+	softFilterRejections int
+	nearTieCount         int
+	tieBreakReason       string
+}
+
+// rejectedCandidate is a provider that passed structural gates but lost
+// a later admission/TTFT/vision gate. TTFT rejects keep their cost scores
+// so we can measure false-reject rate against the ceiling.
+type rejectedCandidate struct {
+	candidate *routingCandidate
+	snap      routingSnapshot
+	reason    string
 }
 
 // scanCandidatesLocked builds the eligible candidate pool for a request — every
@@ -643,6 +695,7 @@ func (r *Registry) scanCandidatesLocked(model string, pr *PendingRequest, ignore
 	// best) were dropped from the pool, making the queue-depth tie-
 	// break flaky under map iteration randomness.
 	candidates := make([]*routingCandidate, 0, len(r.providers))
+	rejected := make([]rejectedCandidate, 0)
 	candidateCount := 0
 	capacityRejections := 0
 	tooLargeRejections := 0
@@ -716,6 +769,19 @@ func (r *Registry) scanCandidatesLocked(model string, pr *PendingRequest, ignore
 					capacityRejections++
 				}
 			}
+			p.mu.Lock()
+			reason := r.routingGateRejectReasonLocked(p, model, pr.Traits, relaxTrust, now, ignoreProviderBreaker)
+			light := routingSnapshot{
+				provider:      p,
+				chipFamily:    p.Hardware.ChipFamily,
+				hardwareTier:  p.Hardware.ChipTier,
+				memoryGB:      p.Hardware.MemoryGB,
+				systemMetrics: p.SystemMetrics,
+			}
+			p.mu.Unlock()
+			if reason != "" {
+				rejected = appendRejected(rejected, rejectedCandidate{snap: light, reason: reason})
+			}
 			continue
 		}
 		// Vision gate: a media request must only go to a provider advertising a
@@ -730,6 +796,7 @@ func (r *Registry) scanCandidatesLocked(model string, pr *PendingRequest, ignore
 			p.mu.Unlock()
 			if !servesVision {
 				visionRejections++
+				rejected = appendRejected(rejected, rejectedCandidate{snap: snap, reason: store.CandidateRejectVision})
 				continue
 			}
 		}
@@ -738,10 +805,13 @@ func (r *Registry) scanCandidatesLocked(model string, pr *PendingRequest, ignore
 			switch reason {
 			case rejectCapacity:
 				capacityRejections++
+				rejected = appendRejected(rejected, rejectedCandidate{snap: snap, reason: store.CandidateRejectCapacity})
 			case rejectModelTooLarge:
 				tooLargeRejections++
+				rejected = appendRejected(rejected, rejectedCandidate{snap: snap, reason: store.CandidateRejectModelTooLarge})
 			case rejectVisionUnsupported:
 				visionRejections++
+				rejected = appendRejected(rejected, rejectedCandidate{snap: snap, reason: store.CandidateRejectVision})
 			}
 			continue
 		}
@@ -763,6 +833,7 @@ func (r *Registry) scanCandidatesLocked(model string, pr *PendingRequest, ignore
 		// not enforced on them (matching the preflight behavior).
 		if enforceTTFT && snap.hasBackendCapacity && candidate.breakdown.TTFTMs > pr.MaxTTFTMs {
 			ttftRejections++
+			rejected = appendRejected(rejected, rejectedCandidate{candidate: candidate, snap: snap, reason: store.CandidateRejectTTFT})
 			continue
 		}
 
@@ -794,6 +865,7 @@ func (r *Registry) scanCandidatesLocked(model string, pr *PendingRequest, ignore
 	// only; otherwise fall back to the full pool (a public provider, charged
 	// normally). Exclusive self-route already filtered to owned above.
 	pool := candidates
+	softReason := ""
 	if pr.PreferOwner {
 		owned := make([]*routingCandidate, 0, len(candidates))
 		for _, c := range candidates {
@@ -801,7 +873,10 @@ func (r *Registry) scanCandidatesLocked(model string, pr *PendingRequest, ignore
 				owned = append(owned, c)
 			}
 		}
-		if len(owned) > 0 {
+		if len(owned) > 0 && len(owned) < len(candidates) {
+			pool = owned
+			softReason = store.CandidateRejectPreferOwner
+		} else if len(owned) > 0 {
 			pool = owned
 		}
 	}
@@ -819,7 +894,10 @@ func (r *Registry) scanCandidatesLocked(model string, pr *PendingRequest, ignore
 				diverse = append(diverse, c)
 			}
 		}
-		if len(diverse) > 0 {
+		if len(diverse) > 0 && len(diverse) < len(pool) {
+			pool = diverse
+			softReason = store.CandidateRejectAvoidVersion
+		} else if len(diverse) > 0 {
 			pool = diverse
 		}
 	}
@@ -838,20 +916,46 @@ func (r *Registry) scanCandidatesLocked(model string, pr *PendingRequest, ignore
 				quality = append(quality, c)
 			}
 		}
-		if len(quality) > 0 {
+		if len(quality) > 0 && len(quality) < len(pool) {
+			pool = quality
+			softReason = store.CandidateRejectMinDecodeTPS
+		} else if len(quality) > 0 {
 			pool = quality
 		}
 	}
 
+	softFilterRejections := 0
+	if softReason != "" {
+		inPool := make(map[string]struct{}, len(pool))
+		for _, c := range pool {
+			if id := providerIDOf(c); id != "" {
+				inPool[id] = struct{}{}
+			}
+		}
+		for _, c := range candidates {
+			id := providerIDOf(c)
+			if id == "" {
+				continue
+			}
+			if _, ok := inPool[id]; ok {
+				continue
+			}
+			softFilterRejections++
+			rejected = appendRejected(rejected, rejectedCandidate{candidate: c, snap: c.snapshot, reason: softReason})
+		}
+	}
+
 	return candidateScan{
-		pool:               pool,
-		candidateCount:     candidateCount,
-		capacityRejections: capacityRejections,
-		tooLargeRejections: tooLargeRejections,
-		visionRejections:   visionRejections,
-		ttftRejections:     ttftRejections,
-		bestTTFTMs:         bestTTFTMs,
-		breakerRejected:    breakerRejected,
+		pool:                 pool,
+		rejected:             rejected,
+		candidateCount:       candidateCount,
+		capacityRejections:   capacityRejections,
+		tooLargeRejections:   tooLargeRejections,
+		visionRejections:     visionRejections,
+		ttftRejections:       ttftRejections,
+		bestTTFTMs:           bestTTFTMs,
+		breakerRejected:      breakerRejected,
+		softFilterRejections: softFilterRejections,
 	}
 }
 
@@ -862,19 +966,24 @@ func (r *Registry) scanCandidatesLocked(model string, pr *PendingRequest, ignore
 // breakerRejected (providers dropped while their breaker was OPEN) is the signal
 // selectBestCandidateLockedFull uses to decide whether a breaker-bypassed
 // fail-open re-scan could help, and is always 0 in that mode.
-func (r *Registry) selectBestCandidateScanLocked(model string, pr *PendingRequest, ignoreProviderBreaker bool, excludeIDs ...string) (*routingCandidate, int, int, int, int, int, float64, int) {
+func (r *Registry) selectBestCandidateScanLocked(model string, pr *PendingRequest, ignoreProviderBreaker bool, excludeIDs ...string) (*routingCandidate, candidateScan) {
 	scan := r.scanCandidatesLocked(model, pr, ignoreProviderBreaker, excludeIDs...)
 	if len(scan.pool) == 0 {
-		return nil, scan.candidateCount, scan.capacityRejections, scan.tooLargeRejections, scan.visionRejections, scan.ttftRejections, scan.bestTTFTMs, scan.breakerRejected
+		return nil, scan
 	}
-	pool := scan.pool
-	candidateCount := scan.candidateCount
-
-	winner := selectRoutingCandidate(pool, func(candidate *routingCandidate) float64 {
+	sel := selectRoutingCandidate(scan.pool, func(candidate *routingCandidate) float64 {
 		return candidate.costMs
 	})
-	r.logRoutingDecision(model, pr, winner, candidateCount)
-	return winner, candidateCount, scan.capacityRejections, scan.tooLargeRejections, scan.visionRejections, scan.ttftRejections, scan.bestTTFTMs, scan.breakerRejected
+	scan.nearTieCount = sel.nearTieCount
+	scan.tieBreakReason = sel.tieBreakReason
+	r.logRoutingDecision(model, pr, sel.winner, scan.candidateCount)
+	return sel.winner, scan
+}
+
+type routingSelection struct {
+	winner         *routingCandidate
+	nearTieCount   int
+	tieBreakReason string
 }
 
 // selectRoutingCandidate centralizes cost ranking, near-tie admission, and
@@ -882,9 +991,9 @@ func (r *Registry) selectBestCandidateScanLocked(model string, pr *PendingReques
 func selectRoutingCandidate(
 	pool []*routingCandidate,
 	cost func(*routingCandidate) float64,
-) *routingCandidate {
+) routingSelection {
 	if len(pool) == 0 {
-		return nil
+		return routingSelection{}
 	}
 	best := pool[0]
 	for _, candidate := range pool[1:] {
@@ -897,6 +1006,9 @@ func selectRoutingCandidate(
 		if math.Abs(cost(candidate)-cost(best)) <= nearTieCostWindowMs {
 			nearTies = append(nearTies, candidate)
 		}
+	}
+	if len(nearTies) == 1 {
+		return routingSelection{winner: best, nearTieCount: 1, tieBreakReason: "cost"}
 	}
 	winner := nearTies[0]
 	for _, candidate := range nearTies[1:] {
@@ -927,26 +1039,34 @@ func selectRoutingCandidate(
 	}
 	if hasCacheDiscount {
 		bestCost := cost(equivalent[0])
-		best := equivalent[:1]
+		bestEq := equivalent[:1]
 		for _, candidate := range equivalent[1:] {
 			candidateCost := cost(candidate)
 			switch {
 			case candidateCost < bestCost:
 				bestCost = candidateCost
-				best = []*routingCandidate{candidate}
+				bestEq = []*routingCandidate{candidate}
 			case candidateCost == bestCost:
-				best = append(best, candidate)
+				bestEq = append(bestEq, candidate)
 			}
 		}
-		if len(best) > 1 {
-			return best[rand.Intn(len(best))]
+		if len(bestEq) > 1 {
+			return routingSelection{
+				winner:         bestEq[rand.Intn(len(bestEq))],
+				nearTieCount:   len(nearTies),
+				tieBreakReason: "cache_discount",
+			}
 		}
-		return best[0]
+		return routingSelection{winner: bestEq[0], nearTieCount: len(nearTies), tieBreakReason: "cache_discount"}
 	}
 	if len(equivalent) > 1 {
-		return equivalent[rand.Intn(len(equivalent))]
+		return routingSelection{
+			winner:         equivalent[rand.Intn(len(equivalent))],
+			nearTieCount:   len(nearTies),
+			tieBreakReason: "random",
+		}
 	}
-	return winner
+	return routingSelection{winner: winner, nearTieCount: len(nearTies), tieBreakReason: "queue"}
 }
 
 func providerMatchesAllowedSerial(p *Provider, allowed map[string]struct{}) bool {
@@ -1193,6 +1313,42 @@ func (r *Registry) providerPassesRoutingGatesLockedEx(p *Provider, model string,
 	return true
 }
 
+// routingGateRejectReasonLocked returns the first structural gate that dropped
+// p. Caller holds r.mu and p.mu. Closed enum — never raw provider text.
+func (r *Registry) routingGateRejectReasonLocked(p *Provider, model string, traits RequestTraits, selfRouteOwner bool, now time.Time, ignoreProviderBreaker bool) string {
+	if !r.providerServesRoutableModelLocked(p, model, selfRouteOwner) {
+		return store.CandidateRejectCatalog
+	}
+	if r.dispatchLoadCooldownActiveLocked(p.ID, model, now) {
+		return store.CandidateRejectLoadCooldown
+	}
+	if r.inferenceErrorCooldownActiveLocked(p.ID, model, traits.CooldownShape(), now) {
+		return store.CandidateRejectErrorCooldown
+	}
+	if r.capacityCooldownActiveLocked(p.ID, model, now) {
+		return store.CandidateRejectCapacityCooldown
+	}
+	if !ignoreProviderBreaker && r.providerBreakerOpenLocked(p.ID, now) {
+		return store.CandidateRejectBreaker
+	}
+	if !ignoreProviderBreaker && healthEjectionEnabled() {
+		if sid := stableProviderIdentityLocked(p); sid != "" && r.healthEjectionOpenLocked(sid, now) {
+			return store.CandidateRejectHealthEjection
+		}
+	}
+	minTrust := r.MinTrustLevel
+	if selfRouteOwner {
+		minTrust = TrustNone
+	}
+	if !r.providerLivenessGateLocked(p, minTrust, selfRouteOwner, now) {
+		return store.CandidateRejectLiveness
+	}
+	if !r.providerEligibleForTraitsLocked(p, model, traits) {
+		return store.CandidateRejectTrait
+	}
+	return ""
+}
+
 // snapshotProviderLocked builds a routing snapshot for p, returning ok=false
 // when p fails any structural/privacy/capacity/trait gate. selfRouteOwner is
 // true when this is a self-route request and p is owned by the requesting
@@ -1227,6 +1383,8 @@ func (r *Registry) snapshotProviderLockedEx(p *Provider, model string, traits Re
 		provider:      p,
 		model:         model,
 		chipFamily:    p.Hardware.ChipFamily,
+		hardwareTier:  p.Hardware.ChipTier,
+		memoryGB:      p.Hardware.MemoryGB,
 		binaryVersion: p.Version,
 		slotState:     "unknown",
 		totalPending:  p.pendingCount(),

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -207,11 +207,11 @@ type routingCandidate struct {
 	cacheEstimatedTTFTSavedMs float64
 }
 
-// candidateRejection enumerates why a provider that passed structural
-// gates (status, trust, slot state, thermal) was nonetheless excluded
-// from selection. Used to populate RoutingDecision counters so callers
-// can distinguish "no provider serves this model" from "every fitting
-// provider is full".
+// candidateRejection enumerates why a provider that passed the routing
+// gates (catalog, cooldown, breaker, liveness, traits) was nonetheless
+// excluded from selection. Used to populate RoutingDecision counters so
+// callers can distinguish "no provider serves this model" from "every
+// fitting provider is full" and from unschedulable slot/thermal state.
 type candidateRejection int
 
 const (
@@ -227,6 +227,9 @@ const (
 	// this provider (until it loads a VLM build), so like rejectModelTooLarge it
 	// must NOT inflate the transient busy/429 signal.
 	rejectVisionUnsupported
+	rejectSlotCrashed
+	rejectSlotReloading
+	rejectThermalCritical
 )
 
 // modelMemoryHeadroomFactor is the FALLBACK multiple of the on-disk weight size
@@ -812,6 +815,12 @@ func (r *Registry) scanCandidatesLocked(model string, pr *PendingRequest, ignore
 			case rejectVisionUnsupported:
 				visionRejections++
 				rejected = appendRejected(rejected, rejectedCandidate{snap: snap, reason: store.CandidateRejectVision})
+			case rejectSlotCrashed:
+				rejected = appendRejected(rejected, rejectedCandidate{snap: snap, reason: store.CandidateRejectSlotCrashed})
+			case rejectSlotReloading:
+				rejected = appendRejected(rejected, rejectedCandidate{snap: snap, reason: store.CandidateRejectSlotReloading})
+			case rejectThermalCritical:
+				rejected = appendRejected(rejected, rejectedCandidate{snap: snap, reason: store.CandidateRejectThermalCritical})
 			}
 			continue
 		}
@@ -865,20 +874,20 @@ func (r *Registry) scanCandidatesLocked(model string, pr *PendingRequest, ignore
 	// only; otherwise fall back to the full pool (a public provider, charged
 	// normally). Exclusive self-route already filtered to owned above.
 	pool := candidates
-	softReason := ""
+	// First filter to drop a provider wins. Chaining PreferOwner → AvoidVersion
+	// → MinDecodeTPS must not relabel an earlier drop with a later reason
+	// (prod minDecodeTPS is 15, so a public machine dropped by prefer-owner
+	// was previously stamped min_decode_tps whenever the owned pool also
+	// shrank).
+	softDrops := make(map[string]string)
 	if pr.PreferOwner {
-		owned := make([]*routingCandidate, 0, len(candidates))
-		for _, c := range candidates {
+		owned := make([]*routingCandidate, 0, len(pool))
+		for _, c := range pool {
 			if providerOwnedBy(c.provider, pr.OwnerAccountID) {
 				owned = append(owned, c)
 			}
 		}
-		if len(owned) > 0 && len(owned) < len(candidates) {
-			pool = owned
-			softReason = store.CandidateRejectPreferOwner
-		} else if len(owned) > 0 {
-			pool = owned
-		}
+		pool = applySoftFilter(pool, owned, store.CandidateRejectPreferOwner, softDrops)
 	}
 
 	// Version-diverse retry (SOFT): when a previous attempt failed on a given
@@ -894,12 +903,7 @@ func (r *Registry) scanCandidatesLocked(model string, pr *PendingRequest, ignore
 				diverse = append(diverse, c)
 			}
 		}
-		if len(diverse) > 0 && len(diverse) < len(pool) {
-			pool = diverse
-			softReason = store.CandidateRejectAvoidVersion
-		} else if len(diverse) > 0 {
-			pool = diverse
-		}
+		pool = applySoftFilter(pool, diverse, store.CandidateRejectAvoidVersion, softDrops)
 	}
 
 	// Decode-floor quality preference (SOFT, Routing v2 W2): when a per-request
@@ -916,33 +920,18 @@ func (r *Registry) scanCandidatesLocked(model string, pr *PendingRequest, ignore
 				quality = append(quality, c)
 			}
 		}
-		if len(quality) > 0 && len(quality) < len(pool) {
-			pool = quality
-			softReason = store.CandidateRejectMinDecodeTPS
-		} else if len(quality) > 0 {
-			pool = quality
-		}
+		pool = applySoftFilter(pool, quality, store.CandidateRejectMinDecodeTPS, softDrops)
 	}
 
 	softFilterRejections := 0
-	if softReason != "" {
-		inPool := make(map[string]struct{}, len(pool))
-		for _, c := range pool {
-			if id := providerIDOf(c); id != "" {
-				inPool[id] = struct{}{}
-			}
+	for _, c := range candidates {
+		id := providerIDOf(c)
+		reason, ok := softDrops[id]
+		if !ok || reason == "" {
+			continue
 		}
-		for _, c := range candidates {
-			id := providerIDOf(c)
-			if id == "" {
-				continue
-			}
-			if _, ok := inPool[id]; ok {
-				continue
-			}
-			softFilterRejections++
-			rejected = appendRejected(rejected, rejectedCandidate{candidate: c, snap: c.snapshot, reason: softReason})
-		}
+		softFilterRejections++
+		rejected = appendRejected(rejected, rejectedCandidate{candidate: c, snap: c.snapshot, reason: reason})
 	}
 
 	return candidateScan{
@@ -978,6 +967,45 @@ func (r *Registry) selectBestCandidateScanLocked(model string, pr *PendingReques
 	scan.tieBreakReason = sel.tieBreakReason
 	r.logRoutingDecision(model, pr, sel.winner, scan.candidateCount)
 	return sel.winner, scan
+}
+
+// applySoftFilter keeps filtered when it is a non-empty subset (or equal),
+// otherwise fail-opens to pool. Drops are recorded under reason only for
+// providers this step actually removed; later filters must not overwrite.
+func applySoftFilter(pool, filtered []*routingCandidate, reason string, dropped map[string]string) []*routingCandidate {
+	if len(filtered) == 0 {
+		return pool
+	}
+	if len(filtered) < len(pool) {
+		recordSoftFilterDrops(pool, filtered, reason, dropped)
+		return filtered
+	}
+	return filtered
+}
+
+func recordSoftFilterDrops(before, after []*routingCandidate, reason string, dropped map[string]string) {
+	if reason == "" || dropped == nil {
+		return
+	}
+	kept := make(map[string]struct{}, len(after))
+	for _, c := range after {
+		if id := providerIDOf(c); id != "" {
+			kept[id] = struct{}{}
+		}
+	}
+	for _, c := range before {
+		id := providerIDOf(c)
+		if id == "" {
+			continue
+		}
+		if _, ok := kept[id]; ok {
+			continue
+		}
+		if _, already := dropped[id]; already {
+			continue
+		}
+		dropped[id] = reason
+	}
 }
 
 type routingSelection struct {
@@ -1677,14 +1705,21 @@ func committedTokenBudget(snap routingSnapshot) int64 {
 func (r *Registry) buildCandidateWithReason(snap routingSnapshot, pr *PendingRequest) (*routingCandidate, candidateRejection, bool) {
 	statePenalty, eligible := slotStatePenalty(snap.slotState)
 	if !eligible {
-		return nil, rejectNone, false
+		switch snap.slotState {
+		case "crashed":
+			return nil, rejectSlotCrashed, false
+		case "reloading":
+			return nil, rejectSlotReloading, false
+		default:
+			return nil, rejectNone, false
+		}
 	}
 	if !snap.hasHeadroom {
 		return nil, rejectCapacity, false
 	}
 
 	if snap.systemMetrics.ThermalState == "critical" {
-		return nil, rejectNone, false
+		return nil, rejectThermalCritical, false
 	}
 
 	reqMax := pr.RequestedMaxTokens

--- a/coordinator/registry/scheduler_test.go
+++ b/coordinator/registry/scheduler_test.go
@@ -1,6 +1,7 @@
 package registry
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -660,5 +661,43 @@ func TestReserveProviderExRecordsCrashedSlotReason(t *testing.T) {
 	}
 	if !sawCrashed {
 		t.Fatalf("crashed slot missing from candidates: %+v", decision.Candidates)
+	}
+}
+
+func TestReserveProviderExPersistsSoftRejectsDespiteCatalogFlood(t *testing.T) {
+	reg := New(testLogger())
+	model := "catalog-flood-model"
+	owned := makeSchedulerProvider(t, reg, "owned", model, 30)
+	public := makeSchedulerProvider(t, reg, "public", model, 30)
+	setProviderAccount(owned, "acct-A")
+	setProviderAccount(public, "acct-B")
+	for i := 0; i < 20; i++ {
+		makeSchedulerProvider(t, reg, fmt.Sprintf("other-%02d", i), "unrelated-model", 30)
+	}
+
+	req := &PendingRequest{
+		RequestID:             "catalog-flood",
+		Model:                 model,
+		EstimatedPromptTokens: 100,
+		RequestedMaxTokens:    128,
+		PreferOwner:           true,
+		OwnerAccountID:        "acct-A",
+	}
+	selected, decision := reg.ReserveProviderEx(model, req)
+	if selected == nil || selected.ID != owned.ID {
+		t.Fatalf("selected %v, want owned", selected)
+	}
+	var sawPublic bool
+	for _, c := range decision.Candidates {
+		if c.ProviderID != "public" {
+			continue
+		}
+		sawPublic = true
+		if c.Eligible || c.RejectionReason != store.CandidateRejectPreferOwner {
+			t.Fatalf("public row = %+v", c)
+		}
+	}
+	if !sawPublic {
+		t.Fatalf("prefer_owner drop missing after catalog flood; candidates=%+v", decision.Candidates)
 	}
 }

--- a/coordinator/registry/scheduler_test.go
+++ b/coordinator/registry/scheduler_test.go
@@ -3,6 +3,8 @@ package registry
 import (
 	"testing"
 	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/store"
 )
 
 func TestReserveProviderSkipsSelfSigned(t *testing.T) {
@@ -535,5 +537,128 @@ func TestReserveProviderAllowedProviderSerialsWithExclusion(t *testing.T) {
 	}
 	if decision.CandidateCount != 0 {
 		t.Fatalf("decision.CandidateCount=%d, want 0", decision.CandidateCount)
+	}
+}
+
+func TestApplySoftFilterRecordsFirstDropReason(t *testing.T) {
+	a := &routingCandidate{provider: &Provider{ID: "owned-fast"}}
+	b := &routingCandidate{provider: &Provider{ID: "owned-slow"}}
+	c := &routingCandidate{provider: &Provider{ID: "public-fast"}}
+	pool := []*routingCandidate{a, b, c}
+	dropped := map[string]string{}
+
+	pool = applySoftFilter(pool, []*routingCandidate{a, b}, store.CandidateRejectPreferOwner, dropped)
+	pool = applySoftFilter(pool, []*routingCandidate{a}, store.CandidateRejectMinDecodeTPS, dropped)
+
+	if dropped["public-fast"] != store.CandidateRejectPreferOwner {
+		t.Fatalf("public drop = %q, want prefer_owner (first filter), dropped=%v", dropped["public-fast"], dropped)
+	}
+	if dropped["owned-slow"] != store.CandidateRejectMinDecodeTPS {
+		t.Fatalf("slow owned drop = %q, want min_decode_tps, dropped=%v", dropped["owned-slow"], dropped)
+	}
+	if _, ok := dropped["owned-fast"]; ok {
+		t.Fatalf("survivor must not be recorded as dropped: %v", dropped)
+	}
+	if len(pool) != 1 || providerIDOf(pool[0]) != "owned-fast" {
+		t.Fatalf("pool after chained filters = %+v", pool)
+	}
+
+	beforeFailOpen := len(dropped)
+	kept := applySoftFilter(pool, nil, store.CandidateRejectAvoidVersion, dropped)
+	if len(kept) != 1 || providerIDOf(kept[0]) != "owned-fast" {
+		t.Fatal("empty filter must fail-open and keep the pool")
+	}
+	if len(dropped) != beforeFailOpen {
+		t.Fatalf("fail-open must not record drops, dropped=%v", dropped)
+	}
+}
+
+func TestReserveProviderExRecordsChainedSoftFilterReasons(t *testing.T) {
+	reg := New(testLogger())
+	model := "chained-soft-filter-model"
+
+	ownedFast := makeSchedulerProvider(t, reg, "owned-fast", model, 30)
+	ownedSlow := makeSchedulerProvider(t, reg, "owned-slow", model, 30)
+	ownedOld := makeSchedulerProvider(t, reg, "owned-old", model, 30)
+	publicFast := makeSchedulerProvider(t, reg, "public-fast", model, 30)
+	setProviderAccount(ownedFast, "acct-A")
+	setProviderAccount(ownedSlow, "acct-A")
+	setProviderAccount(ownedOld, "acct-A")
+	setProviderAccount(publicFast, "acct-B")
+	setProviderVersion(ownedFast, "0.6.30")
+	setProviderVersion(ownedSlow, "0.6.30")
+	setProviderVersion(ownedOld, "0.6.29")
+	setProviderVersion(publicFast, "0.6.30")
+	ownedSlow.mu.Lock()
+	ownedSlow.BackendCapacity.Slots[0].NumRunning = 5
+	ownedSlow.BackendCapacity.Slots[0].ObservedDecodeTPS = 8
+	ownedSlow.mu.Unlock()
+
+	req := &PendingRequest{
+		RequestID:             "chained-soft",
+		Model:                 model,
+		EstimatedPromptTokens: 100,
+		RequestedMaxTokens:    128,
+		PreferOwner:           true,
+		OwnerAccountID:        "acct-A",
+		MinDecodeTPS:          15,
+		Traits:                RequestTraits{AvoidVersion: "0.6.29"},
+	}
+	selected, decision := reg.ReserveProviderEx(model, req)
+	if selected == nil || selected.ID != ownedFast.ID {
+		t.Fatalf("selected %v, want owned-fast", selected)
+	}
+
+	reasonByID := map[string]string{}
+	for _, c := range decision.Candidates {
+		reasonByID[c.ProviderID] = c.RejectionReason
+		if c.ProviderID == "owned-fast" {
+			if !c.Eligible || !c.Selected {
+				t.Fatalf("owned-fast row = %+v", c)
+			}
+		}
+	}
+	if reasonByID["public-fast"] != store.CandidateRejectPreferOwner {
+		t.Fatalf("public-fast reason = %q, want prefer_owner; reasons=%v", reasonByID["public-fast"], reasonByID)
+	}
+	if reasonByID["owned-old"] != store.CandidateRejectAvoidVersion {
+		t.Fatalf("owned-old reason = %q, want avoid_version; reasons=%v", reasonByID["owned-old"], reasonByID)
+	}
+	if reasonByID["owned-slow"] != store.CandidateRejectMinDecodeTPS {
+		t.Fatalf("owned-slow reason = %q, want min_decode_tps; reasons=%v", reasonByID["owned-slow"], reasonByID)
+	}
+}
+
+func TestReserveProviderExRecordsCrashedSlotReason(t *testing.T) {
+	reg := New(testLogger())
+	model := "crashed-slot-reason-model"
+	good := makeSchedulerProvider(t, reg, "good", model, 30)
+	crashed := makeSchedulerProvider(t, reg, "crashed", model, 200)
+	crashed.mu.Lock()
+	crashed.BackendCapacity.Slots[0].State = "crashed"
+	crashed.mu.Unlock()
+
+	req := &PendingRequest{
+		RequestID:             "crash-reason",
+		Model:                 model,
+		EstimatedPromptTokens: 10,
+		RequestedMaxTokens:    32,
+	}
+	selected, decision := reg.ReserveProviderEx(model, req)
+	if selected == nil || selected.ID != good.ID {
+		t.Fatalf("selected %v, want good", selected)
+	}
+	var sawCrashed bool
+	for _, c := range decision.Candidates {
+		if c.ProviderID != "crashed" {
+			continue
+		}
+		sawCrashed = true
+		if c.Eligible || c.RejectionReason != store.CandidateRejectSlotCrashed {
+			t.Fatalf("crashed row = %+v", c)
+		}
+	}
+	if !sawCrashed {
+		t.Fatalf("crashed slot missing from candidates: %+v", decision.Candidates)
 	}
 }

--- a/coordinator/registry/scheduler_test.go
+++ b/coordinator/registry/scheduler_test.go
@@ -68,6 +68,33 @@ func TestReserveProviderExReturnsCostBreakdown(t *testing.T) {
 	if diff := sum - decision.CostMs; diff > 0.001 || diff < -0.001 {
 		t.Fatalf("breakdown sum %f != CostMs %f", sum, decision.CostMs)
 	}
+	if len(decision.Candidates) != 2 {
+		t.Fatalf("decision.Candidates=%d, want 2", len(decision.Candidates))
+	}
+	selectedCount := 0
+	var cheapest *RouteCandidateSnapshot
+	for i := range decision.Candidates {
+		c := decision.Candidates[i]
+		if c.Selected {
+			selectedCount++
+			if c.ProviderID != provider.ID || !c.Eligible {
+				t.Fatalf("selected candidate = %+v", c)
+			}
+		}
+		if c.Eligible && c.Rank == 0 {
+			row := c
+			cheapest = &row
+		}
+	}
+	if selectedCount != 1 {
+		t.Fatalf("selected candidates = %d, want 1", selectedCount)
+	}
+	if cheapest == nil || cheapest.CostMs > decision.CostMs+0.001 {
+		t.Fatalf("rank 0 must be the cheapest eligible candidate, got %+v cost=%f", cheapest, decision.CostMs)
+	}
+	if req.PredictedCostMs != decision.CostMs || req.PredictedEffectiveTPS != decision.EffectiveTPS {
+		t.Fatalf("pending predictions not stamped: cost=%f tps=%f", req.PredictedCostMs, req.PredictedEffectiveTPS)
+	}
 }
 
 func TestQuickCapacityCheckWithTTFTEstimatesBestEligibleProvider(t *testing.T) {

--- a/coordinator/store/calibration_postgres.go
+++ b/coordinator/store/calibration_postgres.go
@@ -1,0 +1,210 @@
+package store
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+const inferenceRouteCandidateColumns = `
+			request_id, attempt, provider_id, rank, selected, eligible, rejection_reason,
+			cost_ms, state_ms, queue_ms, pending_ms, backlog_ms, this_req_ms, health_ms,
+			capacity_rate_ms, ttft_ms, effective_queue, effective_tps, static_tps,
+			effective_prefill_tps, static_prefill_tps, batch_size,
+			chip_family, hardware_tier, memory_gb, slot_state, memory_pressure, thermal_state,
+			gpu_memory_active_gb, free_for_load_gb, wedge_suspected, affinity_applied,
+			affinity_discount_ms, capacity_reject_rate, created_at`
+
+func (s *PostgresStore) RecordInferenceRouteCandidates(records []InferenceRouteCandidateRecord) error {
+	if s == nil || s.pool == nil || len(records) == 0 {
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	now := time.Now().UTC()
+	for i := range records {
+		rec := records[i]
+		if rec.RequestID == "" || rec.ProviderID == "" {
+			continue
+		}
+		createdAt := rec.CreatedAt
+		if createdAt.IsZero() {
+			createdAt = now
+		}
+		if _, err := s.pool.Exec(ctx,
+			`INSERT INTO inference_route_candidates (
+				request_id, attempt, provider_id, rank, selected, eligible, rejection_reason,
+				cost_ms, state_ms, queue_ms, pending_ms, backlog_ms, this_req_ms, health_ms,
+				capacity_rate_ms, ttft_ms, effective_queue, effective_tps, static_tps,
+				effective_prefill_tps, static_prefill_tps, batch_size,
+				chip_family, hardware_tier, memory_gb, slot_state, memory_pressure, thermal_state,
+				gpu_memory_active_gb, free_for_load_gb, wedge_suspected, affinity_applied,
+				affinity_discount_ms, capacity_reject_rate, created_at
+			) VALUES (
+				$1, $2, $3, $4, $5, $6, $7,
+				$8, $9, $10, $11, $12, $13, $14,
+				$15, $16, $17, $18, $19,
+				$20, $21, $22,
+				$23, $24, $25, $26, $27, $28,
+				$29, $30, $31, $32,
+				$33, $34, $35
+			) ON CONFLICT (request_id, attempt, provider_id) DO UPDATE SET
+				rank = EXCLUDED.rank,
+				selected = EXCLUDED.selected,
+				eligible = EXCLUDED.eligible,
+				rejection_reason = EXCLUDED.rejection_reason,
+				cost_ms = EXCLUDED.cost_ms,
+				state_ms = EXCLUDED.state_ms,
+				queue_ms = EXCLUDED.queue_ms,
+				pending_ms = EXCLUDED.pending_ms,
+				backlog_ms = EXCLUDED.backlog_ms,
+				this_req_ms = EXCLUDED.this_req_ms,
+				health_ms = EXCLUDED.health_ms,
+				capacity_rate_ms = EXCLUDED.capacity_rate_ms,
+				ttft_ms = EXCLUDED.ttft_ms,
+				effective_queue = EXCLUDED.effective_queue,
+				effective_tps = EXCLUDED.effective_tps,
+				static_tps = EXCLUDED.static_tps,
+				effective_prefill_tps = EXCLUDED.effective_prefill_tps,
+				static_prefill_tps = EXCLUDED.static_prefill_tps,
+				batch_size = EXCLUDED.batch_size,
+				chip_family = EXCLUDED.chip_family,
+				hardware_tier = EXCLUDED.hardware_tier,
+				memory_gb = EXCLUDED.memory_gb,
+				slot_state = EXCLUDED.slot_state,
+				memory_pressure = EXCLUDED.memory_pressure,
+				thermal_state = EXCLUDED.thermal_state,
+				gpu_memory_active_gb = EXCLUDED.gpu_memory_active_gb,
+				free_for_load_gb = EXCLUDED.free_for_load_gb,
+				wedge_suspected = EXCLUDED.wedge_suspected,
+				affinity_applied = EXCLUDED.affinity_applied,
+				affinity_discount_ms = EXCLUDED.affinity_discount_ms,
+				capacity_reject_rate = EXCLUDED.capacity_reject_rate`,
+			rec.RequestID, rec.Attempt, rec.ProviderID, rec.Rank, rec.Selected, rec.Eligible, rec.RejectionReason,
+			rec.CostMs, rec.StateMs, rec.QueueMs, rec.PendingMs, rec.BacklogMs, rec.ThisReqMs, rec.HealthMs,
+			rec.CapacityRateMs, rec.TTFTMs, rec.EffectiveQueue, rec.EffectiveTPS, rec.StaticTPS,
+			rec.EffectivePrefillTPS, rec.StaticPrefillTPS, rec.BatchSize,
+			rec.ChipFamily, rec.HardwareTier, rec.MemoryGB, rec.SlotState, rec.MemoryPressure, rec.ThermalState,
+			rec.GPUMemoryActiveGB, rec.FreeForLoadGB, rec.WedgeSuspected, rec.AffinityApplied,
+			rec.AffinityDiscountMs, rec.CapacityRejectRate, createdAt,
+		); err != nil {
+			return fmt.Errorf("store: record inference route candidates: %w", err)
+		}
+	}
+	return nil
+}
+
+func (s *PostgresStore) InferenceRouteCandidatesSince(since time.Time) []InferenceRouteCandidateRecord {
+	if s == nil || s.pool == nil {
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	rows, err := s.pool.Query(ctx,
+		`SELECT `+inferenceRouteCandidateColumns+` FROM inference_route_candidates
+		 WHERE created_at >= $1 ORDER BY created_at DESC LIMIT $2`,
+		since, maxTelemetryReadRows)
+	if err != nil {
+		return nil
+	}
+	defer rows.Close()
+	var records []InferenceRouteCandidateRecord
+	for rows.Next() {
+		var r InferenceRouteCandidateRecord
+		if err := rows.Scan(
+			&r.RequestID, &r.Attempt, &r.ProviderID, &r.Rank, &r.Selected, &r.Eligible, &r.RejectionReason,
+			&r.CostMs, &r.StateMs, &r.QueueMs, &r.PendingMs, &r.BacklogMs, &r.ThisReqMs, &r.HealthMs,
+			&r.CapacityRateMs, &r.TTFTMs, &r.EffectiveQueue, &r.EffectiveTPS, &r.StaticTPS,
+			&r.EffectivePrefillTPS, &r.StaticPrefillTPS, &r.BatchSize,
+			&r.ChipFamily, &r.HardwareTier, &r.MemoryGB, &r.SlotState, &r.MemoryPressure, &r.ThermalState,
+			&r.GPUMemoryActiveGB, &r.FreeForLoadGB, &r.WedgeSuspected, &r.AffinityApplied,
+			&r.AffinityDiscountMs, &r.CapacityRejectRate, &r.CreatedAt,
+		); err != nil {
+			continue
+		}
+		records = append(records, r)
+	}
+	return records
+}
+
+func (s *PostgresStore) RecordProviderCapacitySample(record *ProviderCapacitySample) error {
+	if s == nil || s.pool == nil || record == nil || record.ProviderID == "" {
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	createdAt := record.CreatedAt
+	if createdAt.IsZero() {
+		createdAt = time.Now().UTC()
+	}
+	if _, err := s.pool.Exec(ctx,
+		`INSERT INTO provider_capacity_samples (
+			provider_id, provider_version, provider_status, provider_trust_level,
+			hardware_chip_family, hardware_tier, memory_gb, current_model,
+			warm_model_count, slot_count, backend_running, backend_waiting,
+			observed_decode_tps, active_token_budget_used, active_token_budget_max,
+			queued_token_budget, memory_pressure, cpu_usage, thermal_state,
+			gpu_memory_active_gb, gpu_memory_peak_gb, gpu_memory_cache_gb,
+			free_for_load_gb, wedge_suspected, created_at
+		) VALUES (
+			$1, $2, $3, $4,
+			$5, $6, $7, $8,
+			$9, $10, $11, $12,
+			$13, $14, $15,
+			$16, $17, $18, $19,
+			$20, $21, $22,
+			$23, $24, $25
+		)`,
+		record.ProviderID, record.ProviderVersion, record.ProviderStatus, record.ProviderTrustLevel,
+		record.HardwareChipFamily, record.HardwareTier, record.MemoryGB, record.CurrentModel,
+		record.WarmModelCount, record.SlotCount, record.BackendRunning, record.BackendWaiting,
+		record.ObservedDecodeTPS, record.ActiveTokenUsed, record.ActiveTokenMax,
+		record.QueuedTokenBudget, record.MemoryPressure, record.CPUUsage, record.ThermalState,
+		record.GPUMemoryActiveGB, record.GPUMemoryPeakGB, record.GPUMemoryCacheGB,
+		record.FreeForLoadGB, record.WedgeSuspected, createdAt,
+	); err != nil {
+		return fmt.Errorf("store: record provider capacity sample: %w", err)
+	}
+	return nil
+}
+
+func (s *PostgresStore) ProviderCapacitySamplesSince(since time.Time) []ProviderCapacitySample {
+	if s == nil || s.pool == nil {
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	rows, err := s.pool.Query(ctx,
+		`SELECT
+			provider_id, provider_version, provider_status, provider_trust_level,
+			hardware_chip_family, hardware_tier, memory_gb, current_model,
+			warm_model_count, slot_count, backend_running, backend_waiting,
+			observed_decode_tps, active_token_budget_used, active_token_budget_max,
+			queued_token_budget, memory_pressure, cpu_usage, thermal_state,
+			gpu_memory_active_gb, gpu_memory_peak_gb, gpu_memory_cache_gb,
+			free_for_load_gb, wedge_suspected, created_at
+		 FROM provider_capacity_samples
+		 WHERE created_at >= $1 ORDER BY created_at DESC LIMIT $2`,
+		since, maxTelemetryReadRows)
+	if err != nil {
+		return nil
+	}
+	defer rows.Close()
+	var records []ProviderCapacitySample
+	for rows.Next() {
+		var r ProviderCapacitySample
+		if err := rows.Scan(
+			&r.ProviderID, &r.ProviderVersion, &r.ProviderStatus, &r.ProviderTrustLevel,
+			&r.HardwareChipFamily, &r.HardwareTier, &r.MemoryGB, &r.CurrentModel,
+			&r.WarmModelCount, &r.SlotCount, &r.BackendRunning, &r.BackendWaiting,
+			&r.ObservedDecodeTPS, &r.ActiveTokenUsed, &r.ActiveTokenMax,
+			&r.QueuedTokenBudget, &r.MemoryPressure, &r.CPUUsage, &r.ThermalState,
+			&r.GPUMemoryActiveGB, &r.GPUMemoryPeakGB, &r.GPUMemoryCacheGB,
+			&r.FreeForLoadGB, &r.WedgeSuspected, &r.CreatedAt,
+		); err != nil {
+			continue
+		}
+		records = append(records, r)
+	}
+	return records
+}

--- a/coordinator/store/calibration_records.go
+++ b/coordinator/store/calibration_records.go
@@ -1,0 +1,100 @@
+package store
+
+import "time"
+
+// Candidate rejection reasons persisted on inference_route_candidates.
+// These are closed enums — never raw provider text.
+const (
+	CandidateRejectNone             = ""
+	CandidateRejectCapacity         = "capacity"
+	CandidateRejectModelTooLarge    = "model_too_large"
+	CandidateRejectVision           = "vision"
+	CandidateRejectTTFT             = "ttft"
+	CandidateRejectCatalog          = "catalog"
+	CandidateRejectLoadCooldown     = "load_cooldown"
+	CandidateRejectErrorCooldown    = "error_cooldown"
+	CandidateRejectCapacityCooldown = "capacity_cooldown"
+	CandidateRejectBreaker          = "breaker"
+	CandidateRejectHealthEjection   = "health_ejection"
+	CandidateRejectLiveness         = "liveness"
+	CandidateRejectTrait            = "trait"
+	CandidateRejectPreferOwner      = "prefer_owner"
+	CandidateRejectAvoidVersion     = "avoid_version"
+	CandidateRejectMinDecodeTPS     = "min_decode_tps"
+)
+
+// InferenceRouteCandidateRecord is one provider the scheduler considered for a
+// request attempt. Eligible rows carry the full cost breakdown so we can
+// measure ranking regret (winner vs runner-up). Ineligible rows record why a
+// machine that passed structural gates still lost before scoring or after a
+// TTFT ceiling. No prompt or response content.
+type InferenceRouteCandidateRecord struct {
+	RequestID       string `json:"request_id"`
+	Attempt         int    `json:"attempt"`
+	ProviderID      string `json:"provider_id"`
+	Rank            int    `json:"rank"` // 0 = cheapest eligible; -1 = ineligible
+	Selected        bool   `json:"selected"`
+	Eligible        bool   `json:"eligible"`
+	RejectionReason string `json:"rejection_reason,omitempty"`
+
+	CostMs              float64 `json:"cost_ms"`
+	StateMs             float64 `json:"state_ms"`
+	QueueMs             float64 `json:"queue_ms"`
+	PendingMs           float64 `json:"pending_ms"`
+	BacklogMs           float64 `json:"backlog_ms"`
+	ThisReqMs           float64 `json:"this_req_ms"`
+	HealthMs            float64 `json:"health_ms"`
+	CapacityRateMs      float64 `json:"capacity_rate_ms"`
+	TTFTMs              float64 `json:"ttft_ms"`
+	EffectiveQueue      int     `json:"effective_queue"`
+	EffectiveTPS        float64 `json:"effective_tps"`
+	StaticTPS           float64 `json:"static_tps"`
+	EffectivePrefillTPS float64 `json:"effective_prefill_tps"`
+	StaticPrefillTPS    float64 `json:"static_prefill_tps"`
+	BatchSize           int     `json:"batch_size"`
+	ChipFamily          string  `json:"chip_family,omitempty"`
+	HardwareTier        string  `json:"hardware_tier,omitempty"`
+	MemoryGB            int     `json:"memory_gb"`
+	SlotState           string  `json:"slot_state,omitempty"`
+	MemoryPressure      float64 `json:"memory_pressure"`
+	ThermalState        string  `json:"thermal_state,omitempty"`
+	GPUMemoryActiveGB   float64 `json:"gpu_memory_active_gb"`
+	FreeForLoadGB       float64 `json:"free_for_load_gb"`
+	WedgeSuspected      bool    `json:"wedge_suspected"`
+	AffinityApplied     bool    `json:"affinity_applied"`
+	AffinityDiscountMs  float64 `json:"affinity_discount_ms"`
+	CapacityRejectRate  float64 `json:"capacity_reject_rate"`
+
+	CreatedAt time.Time `json:"created_at"`
+}
+
+// ProviderCapacitySample is a request-independent heartbeat snapshot used to
+// fit TPS-vs-batch and health-vs-throughput curves. Sampled, not every
+// heartbeat. No prompt or response content.
+type ProviderCapacitySample struct {
+	ProviderID         string    `json:"provider_id"`
+	ProviderVersion    string    `json:"provider_version,omitempty"`
+	ProviderStatus     string    `json:"provider_status,omitempty"`
+	ProviderTrustLevel string    `json:"provider_trust_level,omitempty"`
+	HardwareChipFamily string    `json:"hardware_chip_family,omitempty"`
+	HardwareTier       string    `json:"hardware_tier,omitempty"`
+	MemoryGB           int       `json:"memory_gb"`
+	CurrentModel       string    `json:"current_model,omitempty"`
+	WarmModelCount     int       `json:"warm_model_count"`
+	SlotCount          int       `json:"slot_count"`
+	BackendRunning     int       `json:"backend_running"`
+	BackendWaiting     int       `json:"backend_waiting"`
+	ObservedDecodeTPS  float64   `json:"observed_decode_tps"`
+	ActiveTokenUsed    int64     `json:"active_token_budget_used"`
+	ActiveTokenMax     int64     `json:"active_token_budget_max"`
+	QueuedTokenBudget  int64     `json:"queued_token_budget"`
+	MemoryPressure     float64   `json:"memory_pressure"`
+	CPUUsage           float64   `json:"cpu_usage"`
+	ThermalState       string    `json:"thermal_state,omitempty"`
+	GPUMemoryActiveGB  float64   `json:"gpu_memory_active_gb"`
+	GPUMemoryPeakGB    float64   `json:"gpu_memory_peak_gb"`
+	GPUMemoryCacheGB   float64   `json:"gpu_memory_cache_gb"`
+	FreeForLoadGB      float64   `json:"free_for_load_gb"`
+	WedgeSuspected     bool      `json:"wedge_suspected"`
+	CreatedAt          time.Time `json:"created_at"`
+}

--- a/coordinator/store/calibration_records.go
+++ b/coordinator/store/calibration_records.go
@@ -21,6 +21,9 @@ const (
 	CandidateRejectPreferOwner      = "prefer_owner"
 	CandidateRejectAvoidVersion     = "avoid_version"
 	CandidateRejectMinDecodeTPS     = "min_decode_tps"
+	CandidateRejectSlotCrashed      = "slot_crashed"
+	CandidateRejectSlotReloading    = "slot_reloading"
+	CandidateRejectThermalCritical  = "thermal_critical"
 )
 
 // InferenceRouteCandidateRecord is one provider the scheduler considered for a

--- a/coordinator/store/calibration_telemetry_test.go
+++ b/coordinator/store/calibration_telemetry_test.go
@@ -1,0 +1,136 @@
+package store
+
+import (
+	"testing"
+	"time"
+)
+
+func TestRouteCandidatesAndCapacitySamples_Memory(t *testing.T) {
+	s := NewMemory(Config{})
+	testRouteCandidatesAndCapacitySamples(t, s)
+}
+
+func TestRouteCandidatesAndCapacitySamples_Postgres(t *testing.T) {
+	s := testPostgresStore(t)
+	testRouteCandidatesAndCapacitySamples(t, s)
+}
+
+func testRouteCandidatesAndCapacitySamples(t *testing.T, s Store) {
+	t.Helper()
+
+	cands := []InferenceRouteCandidateRecord{
+		{
+			RequestID: "req-cal-1", Attempt: 0, ProviderID: "p-win",
+			Rank: 0, Selected: true, Eligible: true,
+			CostMs: 1200, StateMs: 0, QueueMs: 300, EffectiveTPS: 40, BatchSize: 2,
+			ChipFamily: "M4", HardwareTier: "Max", MemoryGB: 64, SlotState: "running",
+		},
+		{
+			RequestID: "req-cal-1", Attempt: 0, ProviderID: "p-lose",
+			Rank: 1, Selected: false, Eligible: true,
+			CostMs: 1800, HealthMs: 400, EffectiveTPS: 28, BatchSize: 3,
+			ChipFamily: "M3", HardwareTier: "Pro", MemoryGB: 36, SlotState: "idle",
+		},
+		{
+			RequestID: "req-cal-1", Attempt: 0, ProviderID: "p-full",
+			Rank: -1, Selected: false, Eligible: false,
+			RejectionReason: CandidateRejectCapacity, MemoryGB: 24, SlotState: "running",
+		},
+	}
+	if err := s.RecordInferenceRouteCandidates(cands); err != nil {
+		t.Fatalf("RecordInferenceRouteCandidates: %v", err)
+	}
+	got := s.InferenceRouteCandidatesSince(time.Time{})
+	if len(got) != 3 {
+		t.Fatalf("candidates = %d, want 3", len(got))
+	}
+	foundWin := false
+	for _, rec := range got {
+		if rec.ProviderID == "p-win" {
+			foundWin = true
+			if !rec.Selected || rec.CostMs != 1200 || rec.ChipFamily != "M4" {
+				t.Fatalf("winner snapshot = %+v", rec)
+			}
+		}
+		if rec.ProviderID == "p-full" && rec.RejectionReason != CandidateRejectCapacity {
+			t.Fatalf("rejected reason = %q", rec.RejectionReason)
+		}
+	}
+	if !foundWin {
+		t.Fatal("winning candidate missing")
+	}
+
+	sample := &ProviderCapacitySample{
+		ProviderID:         "p-win",
+		ProviderVersion:    "0.8.13",
+		HardwareChipFamily: "M4",
+		HardwareTier:       "Max",
+		MemoryGB:           64,
+		BackendRunning:     2,
+		ObservedDecodeTPS:  41.5,
+		ThermalState:       "nominal",
+		WedgeSuspected:     false,
+	}
+	if err := s.RecordProviderCapacitySample(sample); err != nil {
+		t.Fatalf("RecordProviderCapacitySample: %v", err)
+	}
+	samples := s.ProviderCapacitySamplesSince(time.Time{})
+	if len(samples) != 1 {
+		t.Fatalf("capacity samples = %d, want 1", len(samples))
+	}
+	if samples[0].ProviderID != "p-win" || samples[0].ObservedDecodeTPS != 41.5 {
+		t.Fatalf("sample = %+v", samples[0])
+	}
+
+	// Upsert on the same (request, attempt, provider) must not duplicate.
+	cands[0].CostMs = 1100
+	if err := s.RecordInferenceRouteCandidates(cands[:1]); err != nil {
+		t.Fatalf("upsert candidates: %v", err)
+	}
+	got = s.InferenceRouteCandidatesSince(time.Time{})
+	if len(got) != 3 {
+		t.Fatalf("candidates after upsert = %d, want 3", len(got))
+	}
+	for _, rec := range got {
+		if rec.ProviderID == "p-win" && rec.CostMs != 1100 {
+			t.Fatalf("upserted winner cost = %f, want 1100", rec.CostMs)
+		}
+	}
+
+	old := s.InferenceRouteCandidatesSince(time.Now().Add(time.Hour))
+	if len(old) != 0 {
+		t.Fatalf("future candidate window = %d, want 0", len(old))
+	}
+}
+
+func TestMergeInferenceRouteOutcomeCacheAndDimensions(t *testing.T) {
+	dst := InferenceRouteOutcome{FinalStatus: "success"}
+	src := InferenceRouteOutcome{
+		CacheOutcome:       "hit",
+		CacheTier:          "ssd",
+		CachedTokens:       128,
+		PrefillTokensSaved: 96,
+		CacheStageMs:       4.5,
+		ClientOutcome:      "completed",
+		ProviderOutcome:    "completed",
+		BillingOutcome:     "charged",
+		ResponseCommitted:  true,
+		MediaFetchMs:       12,
+		IsFinalAttempt:     true,
+		TotalAttempts:      2,
+	}
+	mergeInferenceRouteOutcome(&dst, &src)
+	if dst.CacheOutcome != "hit" || dst.CachedTokens != 128 || dst.ClientOutcome != "completed" || dst.MediaFetchMs != 12 || dst.TotalAttempts != 2 {
+		t.Fatalf("merged = %+v", dst)
+	}
+	srcBill := InferenceRouteOutcome{ReservedMicroUSD: 10, SettledMicroUSD: 8, RefundMicroUSD: 2, TerminalSource: "provider"}
+	mergeInferenceRouteOutcome(&dst, &srcBill)
+	if dst.ReservedMicroUSD != 10 || dst.SettledMicroUSD != 8 || dst.RefundMicroUSD != 2 || dst.TerminalSource != "provider" {
+		t.Fatalf("billing merge = %+v", dst)
+	}
+	// Zero-value update must not erase cache telemetry.
+	mergeInferenceRouteOutcome(&dst, &InferenceRouteOutcome{FinalStatus: "success"})
+	if dst.CacheOutcome != "hit" || dst.ClientOutcome != "completed" {
+		t.Fatalf("zero merge erased cache/dimensions: %+v", dst)
+	}
+}

--- a/coordinator/store/harness_test.go
+++ b/coordinator/store/harness_test.go
@@ -48,6 +48,8 @@ func testPostgresStore(t *testing.T) *PostgresStore {
 		"stripe_withdrawals",
 		"provider_sessions",
 		"inference_routes",
+		"inference_route_candidates",
+		"provider_capacity_samples",
 		"request_rejections",
 		"provider_trust_reuse",
 		"provider_floor_draws",

--- a/coordinator/store/interface.go
+++ b/coordinator/store/interface.go
@@ -159,6 +159,25 @@ type InferenceRouteRecord struct {
 	ProviderRegion string `json:"provider_region,omitempty"`
 	ConsumerRegion string `json:"consumer_region,omitempty"`
 
+	// Decision-time extras that were previously computed and discarded.
+	Endpoint                  string  `json:"endpoint,omitempty"`
+	KVBackend                 string  `json:"kv_backend,omitempty"`
+	KVBackendFallback         string  `json:"kv_backend_fallback,omitempty"`
+	FreeForLoadGB             float64 `json:"free_for_load_gb"`
+	WedgeSuspected            bool    `json:"wedge_suspected"`
+	TotalPending              int     `json:"total_pending"`
+	EffectivePrefillTPS       float64 `json:"effective_prefill_tps"`
+	StaticPrefillTPS          float64 `json:"static_prefill_tps"`
+	CacheEstimatedTTFTSavedMs float64 `json:"cache_estimated_ttft_saved_ms"`
+	NearTieCount              int     `json:"near_tie_count"`
+	TieBreakReason            string  `json:"tie_break_reason,omitempty"`
+	ShadowWouldShed           bool    `json:"shadow_would_shed"`
+	ShadowIdleAlternative     bool    `json:"shadow_idle_alternative"`
+	ShadowEstimateMs          float64 `json:"shadow_estimate_ms"`
+	ShadowDeadlineMs          float64 `json:"shadow_deadline_ms"`
+	BreakerRejections         int     `json:"breaker_rejections"`
+	SoftFilterRejections      int     `json:"soft_filter_rejections"`
+
 	// Final outcome data, merged from InferenceRouteOutcome updates.
 	FinalStatus            string  `json:"final_status"`
 	ErrorCode              int     `json:"error_code"`
@@ -181,6 +200,31 @@ type InferenceRouteRecord struct {
 	AdmittedButFailed      bool    `json:"admitted_but_failed"`
 	UsedBackup             bool    `json:"used_backup"`
 	BackupWon              bool    `json:"backup_won"`
+
+	// Scheduler terms that were previously computed and discarded.
+	CapacityRateMs     float64 `json:"capacity_rate_ms"`
+	CapacityRejectRate float64 `json:"capacity_reject_rate"`
+	AffinityTier       string  `json:"affinity_tier,omitempty"`
+	AffinityDiscountMs float64 `json:"affinity_discount_ms"`
+
+	// Outcome extras merged from InferenceRouteOutcome.
+	MediaFetchMs       float64 `json:"media_fetch_ms"`
+	CacheOutcome       string  `json:"cache_outcome,omitempty"`
+	CacheTier          string  `json:"cache_tier,omitempty"`
+	CachedTokens       int     `json:"cached_tokens"`
+	PrefillTokensSaved int     `json:"prefill_tokens_saved"`
+	CacheStageMs       float64 `json:"cache_stage_ms"`
+	ClientOutcome      string  `json:"client_outcome,omitempty"`
+	ProviderOutcome    string  `json:"provider_outcome,omitempty"`
+	BillingOutcome     string  `json:"billing_outcome,omitempty"`
+	ResponseCommitted  bool    `json:"response_committed"`
+	IsFinalAttempt     bool    `json:"is_final_attempt"`
+	TotalAttempts      int     `json:"total_attempts"`
+	TerminalSource     string  `json:"terminal_source,omitempty"`
+	ReservedMicroUSD   int64   `json:"reserved_micro_usd"`
+	SettledMicroUSD    int64   `json:"settled_micro_usd"`
+	OverageMicroUSD    int64   `json:"overage_micro_usd"`
+	RefundMicroUSD     int64   `json:"refund_micro_usd"`
 
 	CreatedAt time.Time `json:"created_at"`
 	UpdatedAt time.Time `json:"updated_at"`
@@ -217,6 +261,24 @@ type InferenceRouteOutcome struct {
 	// Speculative/backup-race dispatch outcome.
 	UsedBackup bool `json:"used_backup"`
 	BackupWon  bool `json:"backup_won"`
+
+	MediaFetchMs       float64 `json:"media_fetch_ms"`
+	CacheOutcome       string  `json:"cache_outcome,omitempty"`
+	CacheTier          string  `json:"cache_tier,omitempty"`
+	CachedTokens       int     `json:"cached_tokens"`
+	PrefillTokensSaved int     `json:"prefill_tokens_saved"`
+	CacheStageMs       float64 `json:"cache_stage_ms"`
+	ClientOutcome      string  `json:"client_outcome,omitempty"`
+	ProviderOutcome    string  `json:"provider_outcome,omitempty"`
+	BillingOutcome     string  `json:"billing_outcome,omitempty"`
+	ResponseCommitted  bool    `json:"response_committed"`
+	IsFinalAttempt     bool    `json:"is_final_attempt"`
+	TotalAttempts      int     `json:"total_attempts"`
+	TerminalSource     string  `json:"terminal_source,omitempty"`
+	ReservedMicroUSD   int64   `json:"reserved_micro_usd"`
+	SettledMicroUSD    int64   `json:"settled_micro_usd"`
+	OverageMicroUSD    int64   `json:"overage_micro_usd"`
+	RefundMicroUSD     int64   `json:"refund_micro_usd"`
 
 	// CompletionTokensSet forces the completion_tokens column to be written from
 	// CompletionTokens even when it is 0. Without it, a terminal cancel/error/

--- a/coordinator/store/interface_domains.go
+++ b/coordinator/store/interface_domains.go
@@ -183,6 +183,22 @@ type TelemetryStore interface {
 	// RejectionRecordsSince returns rejection records created at or after the
 	// given time. Zero since returns all records.
 	RejectionRecordsSince(since time.Time) []RejectionRecord
+
+	// RecordInferenceRouteCandidates writes the scored/rejected candidate
+	// snapshots for one request attempt. Best-effort.
+	RecordInferenceRouteCandidates(records []InferenceRouteCandidateRecord) error
+
+	// InferenceRouteCandidatesSince returns candidate rows created at or after
+	// the given time. Zero since returns all records (capped).
+	InferenceRouteCandidatesSince(since time.Time) []InferenceRouteCandidateRecord
+
+	// RecordProviderCapacitySample writes one sampled heartbeat snapshot.
+	// Best-effort.
+	RecordProviderCapacitySample(record *ProviderCapacitySample) error
+
+	// ProviderCapacitySamplesSince returns capacity samples created at or after
+	// the given time. Zero since returns all records (capped).
+	ProviderCapacitySamplesSince(since time.Time) []ProviderCapacitySample
 }
 
 // LedgerStore is the double-entry balance ledger (all amounts in micro-USD).

--- a/coordinator/store/memory.go
+++ b/coordinator/store/memory.go
@@ -138,6 +138,11 @@ type MemoryStore struct {
 	// Rejected inbound inference requests (4xx/5xx) with servability snapshot.
 	inferenceRejections []RejectionRecord
 
+	// Per-candidate routing scores and sampled heartbeat snapshots.
+	inferenceRouteCandidates     []InferenceRouteCandidateRecord
+	inferenceRouteCandidateIndex map[string]int // request_id/attempt/provider_id
+	providerCapacitySamples      []ProviderCapacitySample
+
 	// Base rewards — per-epoch floor draws (idempotent on provider_key|epoch_id).
 	providerFloorDraws []ProviderFloorDraw
 	floorDrawSeq       int64
@@ -195,6 +200,9 @@ func NewMemory(scfg Config) *MemoryStore {
 		inferenceRouteIndex:           make(map[string]int),
 		inferenceRouteOutcomes:        make(map[string]InferenceRouteOutcome),
 		inferenceRejections:           make([]RejectionRecord, 0),
+		inferenceRouteCandidates:      make([]InferenceRouteCandidateRecord, 0),
+		inferenceRouteCandidateIndex:  make(map[string]int),
+		providerCapacitySamples:       make([]ProviderCapacitySample, 0),
 		providerFloorDraws:            make([]ProviderFloorDraw, 0),
 		floorDrawKeys:                 make(map[string]struct{}),
 	}
@@ -1017,6 +1025,90 @@ func (s *MemoryStore) RejectionRecordsSince(since time.Time) []RejectionRecord {
 	}
 	if out == nil {
 		return []RejectionRecord{}
+	}
+	return out
+}
+
+// RecordInferenceRouteCandidates writes scored/rejected candidate snapshots.
+func (s *MemoryStore) RecordInferenceRouteCandidates(records []InferenceRouteCandidateRecord) error {
+	if len(records) == 0 {
+		return nil
+	}
+	now := time.Now()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, rec := range records {
+		if rec.RequestID == "" || rec.ProviderID == "" {
+			continue
+		}
+		if rec.CreatedAt.IsZero() {
+			rec.CreatedAt = now
+		}
+		key := rec.RequestID + "/" + strconv.Itoa(rec.Attempt) + "/" + rec.ProviderID
+		if idx, ok := s.inferenceRouteCandidateIndex[key]; ok {
+			rec.CreatedAt = s.inferenceRouteCandidates[idx].CreatedAt
+			s.inferenceRouteCandidates[idx] = rec
+			continue
+		}
+		s.inferenceRouteCandidates = append(s.inferenceRouteCandidates, rec)
+		s.inferenceRouteCandidateIndex[key] = len(s.inferenceRouteCandidates) - 1
+	}
+	return nil
+}
+
+// InferenceRouteCandidatesSince returns candidate rows newest-first.
+func (s *MemoryStore) InferenceRouteCandidatesSince(since time.Time) []InferenceRouteCandidateRecord {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make([]InferenceRouteCandidateRecord, 0, len(s.inferenceRouteCandidates))
+	for i := len(s.inferenceRouteCandidates) - 1; i >= 0; i-- {
+		r := s.inferenceRouteCandidates[i]
+		if !since.IsZero() && r.CreatedAt.Before(since) {
+			continue
+		}
+		out = append(out, r)
+		if len(out) >= maxTelemetryReadRows {
+			break
+		}
+	}
+	if out == nil {
+		return []InferenceRouteCandidateRecord{}
+	}
+	return out
+}
+
+// RecordProviderCapacitySample writes one sampled heartbeat snapshot.
+func (s *MemoryStore) RecordProviderCapacitySample(record *ProviderCapacitySample) error {
+	if record == nil || record.ProviderID == "" {
+		return nil
+	}
+	rec := *record
+	if rec.CreatedAt.IsZero() {
+		rec.CreatedAt = time.Now()
+	}
+	s.mu.Lock()
+	s.providerCapacitySamples = append(s.providerCapacitySamples, rec)
+	s.mu.Unlock()
+	return nil
+}
+
+// ProviderCapacitySamplesSince returns capacity samples newest-first.
+func (s *MemoryStore) ProviderCapacitySamplesSince(since time.Time) []ProviderCapacitySample {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make([]ProviderCapacitySample, 0, len(s.providerCapacitySamples))
+	for i := len(s.providerCapacitySamples) - 1; i >= 0; i-- {
+		r := s.providerCapacitySamples[i]
+		if !since.IsZero() && r.CreatedAt.Before(since) {
+			continue
+		}
+		out = append(out, r)
+		if len(out) >= maxTelemetryReadRows {
+			break
+		}
+	}
+	if out == nil {
+		return []ProviderCapacitySample{}
 	}
 	return out
 }

--- a/coordinator/store/postgres.go
+++ b/coordinator/store/postgres.go
@@ -858,6 +858,44 @@ func (s *PostgresStore) migrate(ctx context.Context) error {
 			used_backup BOOL,
 			backup_won BOOL,
 			error_reason TEXT,
+			capacity_rate_ms DOUBLE PRECISION,
+			capacity_reject_rate DOUBLE PRECISION,
+			affinity_tier TEXT,
+			affinity_discount_ms DOUBLE PRECISION,
+			media_fetch_ms DOUBLE PRECISION,
+			cache_outcome TEXT,
+			cache_tier TEXT,
+			cached_tokens INTEGER,
+			prefill_tokens_saved INTEGER,
+			cache_stage_ms DOUBLE PRECISION,
+			client_outcome TEXT,
+			provider_outcome TEXT,
+			billing_outcome TEXT,
+			response_committed BOOL,
+			is_final_attempt BOOL,
+			total_attempts INTEGER,
+			endpoint TEXT,
+			kv_backend TEXT,
+			kv_backend_fallback TEXT,
+			free_for_load_gb DOUBLE PRECISION,
+			wedge_suspected BOOL,
+			total_pending INTEGER,
+			effective_prefill_tps DOUBLE PRECISION,
+			static_prefill_tps DOUBLE PRECISION,
+			cache_estimated_ttft_saved_ms DOUBLE PRECISION,
+			near_tie_count INTEGER,
+			tie_break_reason TEXT,
+			shadow_would_shed BOOL,
+			shadow_idle_alternative BOOL,
+			shadow_estimate_ms DOUBLE PRECISION,
+			shadow_deadline_ms DOUBLE PRECISION,
+			breaker_rejections INTEGER,
+			soft_filter_rejections INTEGER,
+			terminal_source TEXT,
+			reserved_micro_usd BIGINT,
+			settled_micro_usd BIGINT,
+			overage_micro_usd BIGINT,
+			refund_micro_usd BIGINT,
 			UNIQUE(request_id, attempt)
 		)`,
 		`CREATE INDEX IF NOT EXISTS idx_inference_routes_created ON inference_routes(created_at DESC)`,
@@ -903,6 +941,44 @@ func (s *PostgresStore) migrate(ctx context.Context) error {
 		// DAR-341: normalized provider/coordinator error reason. Nullable and
 		// appended so fresh DBs match upgraded DB column order for SELECT * scans.
 		`ALTER TABLE inference_routes ADD COLUMN IF NOT EXISTS error_reason TEXT`,
+		`ALTER TABLE inference_routes ADD COLUMN IF NOT EXISTS capacity_rate_ms DOUBLE PRECISION`,
+		`ALTER TABLE inference_routes ADD COLUMN IF NOT EXISTS capacity_reject_rate DOUBLE PRECISION`,
+		`ALTER TABLE inference_routes ADD COLUMN IF NOT EXISTS affinity_tier TEXT`,
+		`ALTER TABLE inference_routes ADD COLUMN IF NOT EXISTS affinity_discount_ms DOUBLE PRECISION`,
+		`ALTER TABLE inference_routes ADD COLUMN IF NOT EXISTS media_fetch_ms DOUBLE PRECISION`,
+		`ALTER TABLE inference_routes ADD COLUMN IF NOT EXISTS cache_outcome TEXT`,
+		`ALTER TABLE inference_routes ADD COLUMN IF NOT EXISTS cache_tier TEXT`,
+		`ALTER TABLE inference_routes ADD COLUMN IF NOT EXISTS cached_tokens INTEGER`,
+		`ALTER TABLE inference_routes ADD COLUMN IF NOT EXISTS prefill_tokens_saved INTEGER`,
+		`ALTER TABLE inference_routes ADD COLUMN IF NOT EXISTS cache_stage_ms DOUBLE PRECISION`,
+		`ALTER TABLE inference_routes ADD COLUMN IF NOT EXISTS client_outcome TEXT`,
+		`ALTER TABLE inference_routes ADD COLUMN IF NOT EXISTS provider_outcome TEXT`,
+		`ALTER TABLE inference_routes ADD COLUMN IF NOT EXISTS billing_outcome TEXT`,
+		`ALTER TABLE inference_routes ADD COLUMN IF NOT EXISTS response_committed BOOL`,
+		`ALTER TABLE inference_routes ADD COLUMN IF NOT EXISTS is_final_attempt BOOL`,
+		`ALTER TABLE inference_routes ADD COLUMN IF NOT EXISTS total_attempts INTEGER`,
+		`ALTER TABLE inference_routes ADD COLUMN IF NOT EXISTS endpoint TEXT`,
+		`ALTER TABLE inference_routes ADD COLUMN IF NOT EXISTS kv_backend TEXT`,
+		`ALTER TABLE inference_routes ADD COLUMN IF NOT EXISTS kv_backend_fallback TEXT`,
+		`ALTER TABLE inference_routes ADD COLUMN IF NOT EXISTS free_for_load_gb DOUBLE PRECISION`,
+		`ALTER TABLE inference_routes ADD COLUMN IF NOT EXISTS wedge_suspected BOOL`,
+		`ALTER TABLE inference_routes ADD COLUMN IF NOT EXISTS total_pending INTEGER`,
+		`ALTER TABLE inference_routes ADD COLUMN IF NOT EXISTS effective_prefill_tps DOUBLE PRECISION`,
+		`ALTER TABLE inference_routes ADD COLUMN IF NOT EXISTS static_prefill_tps DOUBLE PRECISION`,
+		`ALTER TABLE inference_routes ADD COLUMN IF NOT EXISTS cache_estimated_ttft_saved_ms DOUBLE PRECISION`,
+		`ALTER TABLE inference_routes ADD COLUMN IF NOT EXISTS near_tie_count INTEGER`,
+		`ALTER TABLE inference_routes ADD COLUMN IF NOT EXISTS tie_break_reason TEXT`,
+		`ALTER TABLE inference_routes ADD COLUMN IF NOT EXISTS shadow_would_shed BOOL`,
+		`ALTER TABLE inference_routes ADD COLUMN IF NOT EXISTS shadow_idle_alternative BOOL`,
+		`ALTER TABLE inference_routes ADD COLUMN IF NOT EXISTS shadow_estimate_ms DOUBLE PRECISION`,
+		`ALTER TABLE inference_routes ADD COLUMN IF NOT EXISTS shadow_deadline_ms DOUBLE PRECISION`,
+		`ALTER TABLE inference_routes ADD COLUMN IF NOT EXISTS breaker_rejections INTEGER`,
+		`ALTER TABLE inference_routes ADD COLUMN IF NOT EXISTS soft_filter_rejections INTEGER`,
+		`ALTER TABLE inference_routes ADD COLUMN IF NOT EXISTS terminal_source TEXT`,
+		`ALTER TABLE inference_routes ADD COLUMN IF NOT EXISTS reserved_micro_usd BIGINT`,
+		`ALTER TABLE inference_routes ADD COLUMN IF NOT EXISTS settled_micro_usd BIGINT`,
+		`ALTER TABLE inference_routes ADD COLUMN IF NOT EXISTS overage_micro_usd BIGINT`,
+		`ALTER TABLE inference_routes ADD COLUMN IF NOT EXISTS refund_micro_usd BIGINT`,
 		// Route keys are memory-only HMACs. Scrub legacy persisted SHA-256
 		// prompt-cache identifiers once. The trigger also clears writes from an
 		// older coordinator during blue-green overlap or emergency rollback while
@@ -959,6 +1035,84 @@ func (s *PostgresStore) migrate(ctx context.Context) error {
 		`CREATE INDEX IF NOT EXISTS idx_request_rejections_model ON request_rejections(resolved_model, created_at DESC)`,
 		`CREATE INDEX IF NOT EXISTS idx_request_rejections_status ON request_rejections(http_status, created_at DESC)`,
 		`CREATE INDEX IF NOT EXISTS idx_request_rejections_servable ON request_rejections(could_have_served, created_at DESC) WHERE could_have_served = true`,
+
+		// Per-candidate scheduler scores for ranking regret / cost-model
+		// calibration. One row per (attempt × considered provider).
+		`CREATE TABLE IF NOT EXISTS inference_route_candidates (
+			id BIGSERIAL PRIMARY KEY,
+			request_id TEXT NOT NULL,
+			attempt INTEGER NOT NULL,
+			provider_id TEXT NOT NULL,
+			rank INTEGER,
+			selected BOOL NOT NULL DEFAULT FALSE,
+			eligible BOOL NOT NULL DEFAULT FALSE,
+			rejection_reason TEXT,
+			cost_ms DOUBLE PRECISION,
+			state_ms DOUBLE PRECISION,
+			queue_ms DOUBLE PRECISION,
+			pending_ms DOUBLE PRECISION,
+			backlog_ms DOUBLE PRECISION,
+			this_req_ms DOUBLE PRECISION,
+			health_ms DOUBLE PRECISION,
+			capacity_rate_ms DOUBLE PRECISION,
+			ttft_ms DOUBLE PRECISION,
+			effective_queue INTEGER,
+			effective_tps DOUBLE PRECISION,
+			static_tps DOUBLE PRECISION,
+			batch_size INTEGER,
+			chip_family TEXT,
+			hardware_tier TEXT,
+			memory_gb INTEGER,
+			slot_state TEXT,
+			memory_pressure DOUBLE PRECISION,
+			thermal_state TEXT,
+			gpu_memory_active_gb DOUBLE PRECISION,
+			free_for_load_gb DOUBLE PRECISION,
+			wedge_suspected BOOL,
+			affinity_applied BOOL,
+			affinity_discount_ms DOUBLE PRECISION,
+			capacity_reject_rate DOUBLE PRECISION,
+			effective_prefill_tps DOUBLE PRECISION,
+			static_prefill_tps DOUBLE PRECISION,
+			created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			UNIQUE(request_id, attempt, provider_id)
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_inference_route_candidates_created ON inference_route_candidates(created_at DESC)`,
+		`CREATE INDEX IF NOT EXISTS idx_inference_route_candidates_request ON inference_route_candidates(request_id, attempt)`,
+		`ALTER TABLE inference_route_candidates ADD COLUMN IF NOT EXISTS effective_prefill_tps DOUBLE PRECISION`,
+		`ALTER TABLE inference_route_candidates ADD COLUMN IF NOT EXISTS static_prefill_tps DOUBLE PRECISION`,
+
+		// Sampled heartbeat snapshots, independent of requests.
+		`CREATE TABLE IF NOT EXISTS provider_capacity_samples (
+			id BIGSERIAL PRIMARY KEY,
+			provider_id TEXT NOT NULL,
+			provider_version TEXT,
+			provider_status TEXT,
+			provider_trust_level TEXT,
+			hardware_chip_family TEXT,
+			hardware_tier TEXT,
+			memory_gb INTEGER,
+			current_model TEXT,
+			warm_model_count INTEGER,
+			slot_count INTEGER,
+			backend_running INTEGER,
+			backend_waiting INTEGER,
+			observed_decode_tps DOUBLE PRECISION,
+			active_token_budget_used BIGINT,
+			active_token_budget_max BIGINT,
+			queued_token_budget BIGINT,
+			memory_pressure DOUBLE PRECISION,
+			cpu_usage DOUBLE PRECISION,
+			thermal_state TEXT,
+			gpu_memory_active_gb DOUBLE PRECISION,
+			gpu_memory_peak_gb DOUBLE PRECISION,
+			gpu_memory_cache_gb DOUBLE PRECISION,
+			free_for_load_gb DOUBLE PRECISION,
+			wedge_suspected BOOL,
+			created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_provider_capacity_samples_created ON provider_capacity_samples(created_at DESC)`,
+		`CREATE INDEX IF NOT EXISTS idx_provider_capacity_samples_provider ON provider_capacity_samples(provider_id, created_at DESC)`,
 
 		// APNs code-identity attestation reuse cache (W5 Fix 2). Persists the
 		// in-memory reuse cache so a blue-green deploy / restart does not wipe it
@@ -1672,7 +1826,15 @@ const inferenceRouteSelectColumns = `
 			created_at, updated_at,
 			provider_region, consumer_region,
 			parse_ms, reserve_ms, route_ms, encrypt_ms, queue_wait_ms, dispatch_ms, actual_decode_tps,
-			admitted_but_failed, used_backup, backup_won, error_reason`
+			admitted_but_failed, used_backup, backup_won, error_reason,
+			capacity_rate_ms, capacity_reject_rate, affinity_tier, affinity_discount_ms,
+			media_fetch_ms, cache_outcome, cache_tier, cached_tokens, prefill_tokens_saved, cache_stage_ms,
+			client_outcome, provider_outcome, billing_outcome, response_committed, is_final_attempt, total_attempts,
+			endpoint, kv_backend, kv_backend_fallback, free_for_load_gb, wedge_suspected, total_pending,
+			effective_prefill_tps, static_prefill_tps, cache_estimated_ttft_saved_ms,
+			near_tie_count, tie_break_reason, shadow_would_shed, shadow_idle_alternative,
+			shadow_estimate_ms, shadow_deadline_ms, breaker_rejections, soft_filter_rejections,
+			terminal_source, reserved_micro_usd, settled_micro_usd, overage_micro_usd, refund_micro_usd`
 
 // RecordInferenceRoute writes the routing decision snapshot for a request
 // attempt. Callers keep this best-effort by logging returned errors off the
@@ -1709,7 +1871,12 @@ func (s *PostgresStore) RecordInferenceRoute(record *InferenceRouteRecord) error
 			estimated_prompt_tokens, requested_max_tokens,
 			requires_vision, has_tools, self_route_only, prefer_owner,
 			created_at, updated_at,
-			provider_region, consumer_region, error_reason
+			provider_region, consumer_region, error_reason,
+			capacity_rate_ms, capacity_reject_rate, affinity_tier, affinity_discount_ms,
+			endpoint, kv_backend, kv_backend_fallback, free_for_load_gb, wedge_suspected, total_pending,
+			effective_prefill_tps, static_prefill_tps, cache_estimated_ttft_saved_ms,
+			near_tie_count, tie_break_reason, shadow_would_shed, shadow_idle_alternative,
+			shadow_estimate_ms, shadow_deadline_ms, breaker_rejections, soft_filter_rejections
 		) VALUES (
 			$1, $2, $3, $4, $5, $6, $7, $8,
 			$9, $10, $11, $12, $13, $14, $15, $16, $17,
@@ -1723,7 +1890,12 @@ func (s *PostgresStore) RecordInferenceRoute(record *InferenceRouteRecord) error
 			$47, $48,
 			$49, $50, $51, $52,
 			$53, $54,
-			$55, $56, $57
+			$55, $56, $57,
+			$58, $59, $60, $61,
+			$62, $63, $64, $65, $66, $67,
+			$68, $69, $70,
+			$71, $72, $73, $74,
+			$75, $76, $77, $78
 		) ON CONFLICT (request_id, attempt) DO UPDATE SET
 			provider_id = EXCLUDED.provider_id,
 			model = EXCLUDED.model,
@@ -1778,6 +1950,27 @@ func (s *PostgresStore) RecordInferenceRoute(record *InferenceRouteRecord) error
 			provider_region = EXCLUDED.provider_region,
 			consumer_region = EXCLUDED.consumer_region,
 			`+inferenceRouteErrorReasonUpsertAssignment+`,
+			capacity_rate_ms = EXCLUDED.capacity_rate_ms,
+			capacity_reject_rate = EXCLUDED.capacity_reject_rate,
+			affinity_tier = EXCLUDED.affinity_tier,
+			affinity_discount_ms = EXCLUDED.affinity_discount_ms,
+			endpoint = EXCLUDED.endpoint,
+			kv_backend = EXCLUDED.kv_backend,
+			kv_backend_fallback = EXCLUDED.kv_backend_fallback,
+			free_for_load_gb = EXCLUDED.free_for_load_gb,
+			wedge_suspected = EXCLUDED.wedge_suspected,
+			total_pending = EXCLUDED.total_pending,
+			effective_prefill_tps = EXCLUDED.effective_prefill_tps,
+			static_prefill_tps = EXCLUDED.static_prefill_tps,
+			cache_estimated_ttft_saved_ms = EXCLUDED.cache_estimated_ttft_saved_ms,
+			near_tie_count = EXCLUDED.near_tie_count,
+			tie_break_reason = EXCLUDED.tie_break_reason,
+			shadow_would_shed = EXCLUDED.shadow_would_shed,
+			shadow_idle_alternative = EXCLUDED.shadow_idle_alternative,
+			shadow_estimate_ms = EXCLUDED.shadow_estimate_ms,
+			shadow_deadline_ms = EXCLUDED.shadow_deadline_ms,
+			breaker_rejections = EXCLUDED.breaker_rejections,
+			soft_filter_rejections = EXCLUDED.soft_filter_rejections,
 			updated_at = EXCLUDED.updated_at`,
 		record.RequestID, record.Attempt, record.ProviderID, record.Model, record.PublicModel, record.ConsumerKeyHash, record.KeyID, record.Outcome,
 		record.CostMs, record.StateMs, record.QueueMs, record.PendingMs, record.BacklogMs, record.ThisReqMs, record.HealthMs, record.TTFTMs, record.BestTTFTMs,
@@ -1792,6 +1985,11 @@ func (s *PostgresStore) RecordInferenceRoute(record *InferenceRouteRecord) error
 		record.RequiresVision, record.HasTools, record.SelfRouteOnly, record.PreferOwner,
 		createdAt, updatedAt,
 		record.ProviderRegion, record.ConsumerRegion, record.ErrorReason,
+		record.CapacityRateMs, record.CapacityRejectRate, record.AffinityTier, record.AffinityDiscountMs,
+		record.Endpoint, record.KVBackend, record.KVBackendFallback, record.FreeForLoadGB, record.WedgeSuspected, record.TotalPending,
+		record.EffectivePrefillTPS, record.StaticPrefillTPS, record.CacheEstimatedTTFTSavedMs,
+		record.NearTieCount, record.TieBreakReason, record.ShadowWouldShed, record.ShadowIdleAlternative,
+		record.ShadowEstimateMs, record.ShadowDeadlineMs, record.BreakerRejections, record.SoftFilterRejections,
 	)
 	if err != nil {
 		return fmt.Errorf("store: record inference route: %w", err)
@@ -1837,6 +2035,23 @@ func (s *PostgresStore) UpdateInferenceRouteOutcome(requestID string, attempt in
 			admitted_but_failed = COALESCE(admitted_but_failed, FALSE) OR $21,
 			used_backup = COALESCE(used_backup, FALSE) OR $22,
 			backup_won = COALESCE(backup_won, FALSE) OR $23,
+			media_fetch_ms = CASE WHEN $25 <> 0 THEN $25 ELSE media_fetch_ms END,
+			cache_outcome = CASE WHEN $26 <> '' THEN $26 ELSE cache_outcome END,
+			cache_tier = CASE WHEN $26 <> '' THEN $27 ELSE cache_tier END,
+			cached_tokens = CASE WHEN $26 <> '' THEN $28 ELSE cached_tokens END,
+			prefill_tokens_saved = CASE WHEN $26 <> '' THEN $29 ELSE prefill_tokens_saved END,
+			cache_stage_ms = CASE WHEN $26 <> '' THEN $30 ELSE cache_stage_ms END,
+			client_outcome = CASE WHEN $31 <> '' THEN $31 ELSE client_outcome END,
+			provider_outcome = CASE WHEN $32 <> '' THEN $32 ELSE provider_outcome END,
+			billing_outcome = CASE WHEN $33 <> '' THEN $33 ELSE billing_outcome END,
+			response_committed = COALESCE(response_committed, FALSE) OR $34,
+			is_final_attempt = COALESCE(is_final_attempt, FALSE) OR $35,
+			total_attempts = CASE WHEN $36 <> 0 THEN $36 ELSE total_attempts END,
+			terminal_source = CASE WHEN $37 <> '' THEN $37 ELSE terminal_source END,
+			reserved_micro_usd = CASE WHEN $38 <> 0 THEN $38 ELSE reserved_micro_usd END,
+			settled_micro_usd = CASE WHEN $39 <> 0 THEN $39 ELSE settled_micro_usd END,
+			overage_micro_usd = CASE WHEN $40 <> 0 THEN $40 ELSE overage_micro_usd END,
+			refund_micro_usd = CASE WHEN $41 <> 0 THEN $41 ELSE refund_micro_usd END,
 			updated_at = NOW()
 		 WHERE request_id = $1 AND attempt = $2`,
 		requestID, attempt,
@@ -1845,6 +2060,9 @@ func (s *PostgresStore) UpdateInferenceRouteOutcome(requestID string, attempt in
 		outcome.ParseMs, outcome.ReserveMs, outcome.RouteMs, outcome.EncryptMs, outcome.QueueWaitMs, outcome.DispatchMs, outcome.ActualDecodeTPS,
 		outcome.AdmittedButFailed, outcome.UsedBackup, outcome.BackupWon,
 		outcome.CompletionTokensSet,
+		outcome.MediaFetchMs, outcome.CacheOutcome, outcome.CacheTier, outcome.CachedTokens, outcome.PrefillTokensSaved, outcome.CacheStageMs,
+		outcome.ClientOutcome, outcome.ProviderOutcome, outcome.BillingOutcome, outcome.ResponseCommitted, outcome.IsFinalAttempt, outcome.TotalAttempts,
+		outcome.TerminalSource, outcome.ReservedMicroUSD, outcome.SettledMicroUSD, outcome.OverageMicroUSD, outcome.RefundMicroUSD,
 	)
 	if err != nil {
 		return fmt.Errorf("store: update inference route outcome: %w", err)
@@ -1893,6 +2111,44 @@ func (s *PostgresStore) InferenceRouteRecordsSince(since time.Time) []InferenceR
 		var admittedButFailed *bool
 		var usedBackup *bool
 		var backupWon *bool
+		var capacityRateMs *float64
+		var capacityRejectRate *float64
+		var affinityTier *string
+		var affinityDiscountMs *float64
+		var mediaFetchMs *float64
+		var cacheOutcome *string
+		var cacheTier *string
+		var cachedTokens *int
+		var prefillTokensSaved *int
+		var cacheStageMs *float64
+		var clientOutcome *string
+		var providerOutcome *string
+		var billingOutcome *string
+		var responseCommitted *bool
+		var isFinalAttempt *bool
+		var totalAttempts *int
+		var endpoint *string
+		var kvBackend *string
+		var kvBackendFallback *string
+		var freeForLoadGB *float64
+		var wedgeSuspected *bool
+		var totalPending *int
+		var effectivePrefillTPS *float64
+		var staticPrefillTPS *float64
+		var cacheEstimatedTTFTSavedMs *float64
+		var nearTieCount *int
+		var tieBreakReason *string
+		var shadowWouldShed *bool
+		var shadowIdleAlternative *bool
+		var shadowEstimateMs *float64
+		var shadowDeadlineMs *float64
+		var breakerRejections *int
+		var softFilterRejections *int
+		var terminalSource *string
+		var reservedMicroUSD *int64
+		var settledMicroUSD *int64
+		var overageMicroUSD *int64
+		var refundMicroUSD *int64
 
 		if err := rows.Scan(
 			&id,
@@ -1913,6 +2169,14 @@ func (s *PostgresStore) InferenceRouteRecordsSince(since time.Time) []InferenceR
 			&providerRegion, &consumerRegion,
 			&parseMs, &reserveMs, &routeMs, &encryptMs, &queueWaitMs, &dispatchMs, &actualDecodeTPS,
 			&admittedButFailed, &usedBackup, &backupWon, &errorReason,
+			&capacityRateMs, &capacityRejectRate, &affinityTier, &affinityDiscountMs,
+			&mediaFetchMs, &cacheOutcome, &cacheTier, &cachedTokens, &prefillTokensSaved, &cacheStageMs,
+			&clientOutcome, &providerOutcome, &billingOutcome, &responseCommitted, &isFinalAttempt, &totalAttempts,
+			&endpoint, &kvBackend, &kvBackendFallback, &freeForLoadGB, &wedgeSuspected, &totalPending,
+			&effectivePrefillTPS, &staticPrefillTPS, &cacheEstimatedTTFTSavedMs,
+			&nearTieCount, &tieBreakReason, &shadowWouldShed, &shadowIdleAlternative,
+			&shadowEstimateMs, &shadowDeadlineMs, &breakerRejections, &softFilterRejections,
+			&terminalSource, &reservedMicroUSD, &settledMicroUSD, &overageMicroUSD, &refundMicroUSD,
 		); err != nil {
 			continue
 		}
@@ -1982,6 +2246,120 @@ func (s *PostgresStore) InferenceRouteRecordsSince(since time.Time) []InferenceR
 		}
 		if backupWon != nil {
 			outcome.BackupWon = *backupWon
+		}
+		if capacityRateMs != nil {
+			r.CapacityRateMs = *capacityRateMs
+		}
+		if capacityRejectRate != nil {
+			r.CapacityRejectRate = *capacityRejectRate
+		}
+		if affinityTier != nil {
+			r.AffinityTier = *affinityTier
+		}
+		if affinityDiscountMs != nil {
+			r.AffinityDiscountMs = *affinityDiscountMs
+		}
+		if mediaFetchMs != nil {
+			outcome.MediaFetchMs = *mediaFetchMs
+		}
+		if cacheOutcome != nil {
+			outcome.CacheOutcome = *cacheOutcome
+		}
+		if cacheTier != nil {
+			outcome.CacheTier = *cacheTier
+		}
+		if cachedTokens != nil {
+			outcome.CachedTokens = *cachedTokens
+		}
+		if prefillTokensSaved != nil {
+			outcome.PrefillTokensSaved = *prefillTokensSaved
+		}
+		if cacheStageMs != nil {
+			outcome.CacheStageMs = *cacheStageMs
+		}
+		if clientOutcome != nil {
+			outcome.ClientOutcome = *clientOutcome
+		}
+		if providerOutcome != nil {
+			outcome.ProviderOutcome = *providerOutcome
+		}
+		if billingOutcome != nil {
+			outcome.BillingOutcome = *billingOutcome
+		}
+		if responseCommitted != nil {
+			outcome.ResponseCommitted = *responseCommitted
+		}
+		if isFinalAttempt != nil {
+			outcome.IsFinalAttempt = *isFinalAttempt
+		}
+		if totalAttempts != nil {
+			outcome.TotalAttempts = *totalAttempts
+		}
+		if terminalSource != nil {
+			outcome.TerminalSource = *terminalSource
+		}
+		if reservedMicroUSD != nil {
+			outcome.ReservedMicroUSD = *reservedMicroUSD
+		}
+		if settledMicroUSD != nil {
+			outcome.SettledMicroUSD = *settledMicroUSD
+		}
+		if overageMicroUSD != nil {
+			outcome.OverageMicroUSD = *overageMicroUSD
+		}
+		if refundMicroUSD != nil {
+			outcome.RefundMicroUSD = *refundMicroUSD
+		}
+		if endpoint != nil {
+			r.Endpoint = *endpoint
+		}
+		if kvBackend != nil {
+			r.KVBackend = *kvBackend
+		}
+		if kvBackendFallback != nil {
+			r.KVBackendFallback = *kvBackendFallback
+		}
+		if freeForLoadGB != nil {
+			r.FreeForLoadGB = *freeForLoadGB
+		}
+		if wedgeSuspected != nil {
+			r.WedgeSuspected = *wedgeSuspected
+		}
+		if totalPending != nil {
+			r.TotalPending = *totalPending
+		}
+		if effectivePrefillTPS != nil {
+			r.EffectivePrefillTPS = *effectivePrefillTPS
+		}
+		if staticPrefillTPS != nil {
+			r.StaticPrefillTPS = *staticPrefillTPS
+		}
+		if cacheEstimatedTTFTSavedMs != nil {
+			r.CacheEstimatedTTFTSavedMs = *cacheEstimatedTTFTSavedMs
+		}
+		if nearTieCount != nil {
+			r.NearTieCount = *nearTieCount
+		}
+		if tieBreakReason != nil {
+			r.TieBreakReason = *tieBreakReason
+		}
+		if shadowWouldShed != nil {
+			r.ShadowWouldShed = *shadowWouldShed
+		}
+		if shadowIdleAlternative != nil {
+			r.ShadowIdleAlternative = *shadowIdleAlternative
+		}
+		if shadowEstimateMs != nil {
+			r.ShadowEstimateMs = *shadowEstimateMs
+		}
+		if shadowDeadlineMs != nil {
+			r.ShadowDeadlineMs = *shadowDeadlineMs
+		}
+		if breakerRejections != nil {
+			r.BreakerRejections = *breakerRejections
+		}
+		if softFilterRejections != nil {
+			r.SoftFilterRejections = *softFilterRejections
 		}
 		applyInferenceRouteOutcomeToRecord(&r, outcome)
 		records = append(records, r)

--- a/coordinator/store/route_telemetry.go
+++ b/coordinator/store/route_telemetry.go
@@ -78,6 +78,49 @@ func mergeInferenceRouteOutcome(dst *InferenceRouteOutcome, src *InferenceRouteO
 	if src.BackupWon {
 		dst.BackupWon = true
 	}
+	if src.MediaFetchMs != 0 {
+		dst.MediaFetchMs = src.MediaFetchMs
+	}
+	if src.CacheOutcome != "" {
+		dst.CacheOutcome = src.CacheOutcome
+		dst.CacheTier = src.CacheTier
+		dst.CachedTokens = src.CachedTokens
+		dst.PrefillTokensSaved = src.PrefillTokensSaved
+		dst.CacheStageMs = src.CacheStageMs
+	}
+	if src.ClientOutcome != "" {
+		dst.ClientOutcome = src.ClientOutcome
+	}
+	if src.ProviderOutcome != "" {
+		dst.ProviderOutcome = src.ProviderOutcome
+	}
+	if src.BillingOutcome != "" {
+		dst.BillingOutcome = src.BillingOutcome
+	}
+	if src.ResponseCommitted {
+		dst.ResponseCommitted = true
+	}
+	if src.IsFinalAttempt {
+		dst.IsFinalAttempt = true
+	}
+	if src.TotalAttempts != 0 {
+		dst.TotalAttempts = src.TotalAttempts
+	}
+	if src.TerminalSource != "" {
+		dst.TerminalSource = src.TerminalSource
+	}
+	if src.ReservedMicroUSD != 0 {
+		dst.ReservedMicroUSD = src.ReservedMicroUSD
+	}
+	if src.SettledMicroUSD != 0 {
+		dst.SettledMicroUSD = src.SettledMicroUSD
+	}
+	if src.OverageMicroUSD != 0 {
+		dst.OverageMicroUSD = src.OverageMicroUSD
+	}
+	if src.RefundMicroUSD != 0 {
+		dst.RefundMicroUSD = src.RefundMicroUSD
+	}
 }
 
 func applyInferenceRouteOutcomeToRecord(rec *InferenceRouteRecord, outcome InferenceRouteOutcome) {
@@ -105,4 +148,21 @@ func applyInferenceRouteOutcomeToRecord(rec *InferenceRouteRecord, outcome Infer
 	rec.AdmittedButFailed = outcome.AdmittedButFailed
 	rec.UsedBackup = outcome.UsedBackup
 	rec.BackupWon = outcome.BackupWon
+	rec.MediaFetchMs = outcome.MediaFetchMs
+	rec.CacheOutcome = outcome.CacheOutcome
+	rec.CacheTier = outcome.CacheTier
+	rec.CachedTokens = outcome.CachedTokens
+	rec.PrefillTokensSaved = outcome.PrefillTokensSaved
+	rec.CacheStageMs = outcome.CacheStageMs
+	rec.ClientOutcome = outcome.ClientOutcome
+	rec.ProviderOutcome = outcome.ProviderOutcome
+	rec.BillingOutcome = outcome.BillingOutcome
+	rec.ResponseCommitted = outcome.ResponseCommitted
+	rec.IsFinalAttempt = outcome.IsFinalAttempt
+	rec.TotalAttempts = outcome.TotalAttempts
+	rec.TerminalSource = outcome.TerminalSource
+	rec.ReservedMicroUSD = outcome.ReservedMicroUSD
+	rec.SettledMicroUSD = outcome.SettledMicroUSD
+	rec.OverageMicroUSD = outcome.OverageMicroUSD
+	rec.RefundMicroUSD = outcome.RefundMicroUSD
 }

--- a/docs/architecture/request-outcome-observability.md
+++ b/docs/architecture/request-outcome-observability.md
@@ -29,7 +29,7 @@ The model must answer three separate questions:
 | Client response relay | `coordinator/api/consumer.go` (`handleStreamingResponseWithFirstChunk`, `handleResponsesStreamingResponseWithFirstChunk`, `handleNonStreamingResponseWithFirstChunk`) | The relay can emit in-band provider errors, stream timeouts, or return on `r.Context().Done()` after response commit. These are client outcomes, but route final status can remain the earlier success written at commit time. |
 | Settlement after disconnect | `coordinator/api/settlement.go` (`holdForSettlement`, `claimSettlement`) | A post-commit client disconnect is parked so a late provider terminal can charge or refund correctly. Billing is handled, but the disconnect is not visible as a request outcome class such as `client_gone_after_commit_provider_completed` or `no_terminal_after_cancel`. |
 | Provider disconnect cleanup | `coordinator/registry/registry.go` (`Disconnect`) | Disconnect injects a provider error into pending requests and closes channels. The flow should classify pre-commit vs post-commit disconnects rather than letting a prewritten success stand. |
-| Generic endpoints | `coordinator/api/consumer.go` (`handleGenericInference`, `handleCompletions`, `handleAnthropicMessages`) | `/v1/completions` and `/v1/messages` use a direct single-attempt flow and do not call `recordRoutingDecision`, so they lack `inference_routes` rows and final outcome updates. |
+| Generic endpoints | `coordinator/api/consumer.go` (`handleGenericInference`) | `/v1/completions` and `/v1/messages` reuse the same `dispatchState` as chat, including `recordRoutingDecision` and outcome updates. The route row now also stores `endpoint`. |
 | Speculative backup dispatch | `coordinator/api/dispatch.go` (`runSpeculative`, `runRace`) | The primary route row is recorded by `dispatchPrimary`. A speculative backup can win and swap `d.requestID` to the backup job, but that backup can lack its own route row, making the final outcome update a no-op for the winning job. |
 | Provider aggregate stats | `coordinator/registry/reputation.go`, `coordinator/registry/registry.go` (`RecordJobSuccess`, `RecordJobFailure`), `coordinator/api/stats.go` | Provider aggregates track success/failure and latency but not client cancellations, post-commit drops, no-terminal-after-cancel, or disconnect counters. Client behavior and provider faults need separate counters. |
 | Rejection ledger | `coordinator/api/rejection_telemetry.go`, `coordinator/api/consumer.go`, `coordinator/api/server.go` rate-limit helpers | The rejection ledger is partially wired for inference validation, balance, and capacity exits. Some middleware and helper exits still return errors before full request-shape and servability metadata can be recorded. |
@@ -66,12 +66,12 @@ The route row should also persist the raw dimensions that explain the summary:
 
 | Field | Purpose |
 |---|---|
-| `client_outcome` | Client-visible terminal state independent of provider and billing. |
-| `provider_outcome` | Provider terminal state independent of client connection state. |
-| `billing_outcome` | Settlement result independent of client and provider status. |
+| `client_outcome` | Client-visible terminal state independent of provider and billing. **Persisted** on `inference_routes` and derived at outcome write from `final_status` + `error_class`. |
+| `provider_outcome` | Provider terminal state independent of client connection state. **Persisted** on `inference_routes`. |
+| `billing_outcome` | Settlement result independent of client and provider status. **Persisted** on `inference_routes`. |
 | `response_committed` | Whether headers or stream content were committed before the terminal outcome. |
-| `terminal_source` | Which subsystem produced the final transition: `client`, `provider`, `coordinator_timeout`, `settlement_grace`, `disconnect_cleanup`, `billing`. |
-| `endpoint` | The surface that received the request, so generic endpoints are not indistinguishable from chat completions. |
+| `terminal_source` | Which subsystem produced the final transition: `client`, `provider`, `coordinator_timeout`, `coordinator`. **Persisted** on `inference_routes`. |
+| `endpoint` | The surface that received the request, so generic endpoints are not indistinguishable from chat completions. **Persisted** on `inference_routes`. |
 | `client_request_id` | Stable HTTP request correlation ID from middleware, distinct from provider job IDs used by retry and backup attempts. |
 | `provider_request_id` | Provider job ID for the dispatched attempt. This is the current `PendingRequest.RequestID` used by route rows. |
 

--- a/docs/architecture/routing-telemetry-and-calibration.md
+++ b/docs/architecture/routing-telemetry-and-calibration.md
@@ -213,8 +213,9 @@ All already in `inference_routes`. These are the **inputs** the cost used.
 | **`used_backup`, `backup_won`** | Speculative/backup-race dispatch happens (`raceBackupErrWaitPrimary`) but its win/loss is invisible. Tells us if speculation helps. |
 | **`provider_region`, `consumer_region`** | "Closest machine" reasoning; geo-aware routing later. (Provider geo from registry; consumer geo already GeoIP-bucketed for usage.) |
 | **`admitted_but_failed`** (bool) + `provider_reported_free_gb` | Detect the coordinator-admits / provider-OOMs mismatch (§2). Calibrates `kvCacheBytesPerToken` and the 2.0-vs-3.0 headroom gap. |
-| **`prefix_cache_hit`, `prefix_cache_hit_tokens`** | Whether the provider actually reused KV/prefix cache. Validates cache-affinity routing. (Requires one new optional field on the provider `complete` message — only protocol touch in the whole plan, and it's additive.) |
-| **`is_final_attempt`, `total_attempts`** | Make retry chains queryable without window functions. |
+| **`prefix_cache_hit`, `prefix_cache_hit_tokens`** | **Done via existing `UsageInfo` fields** (`cache_outcome`, `cache_tier`, `cached_tokens`, `prefill_tokens_saved`, `cache_stage_ms`) persisted on the route outcome. No new protocol field. |
+| **`is_final_attempt`, `total_attempts`** | Make retry chains queryable without window functions. **Done** — stamped at dispatch `run()` tail. |
+| **`endpoint`, `kv_backend`, `free_for_load_gb`, `wedge_suspected`, `total_pending`, prefill TPS, near-tie audit, TTFT-shadow, billing settlement, `terminal_source`** | Decision/outcome extras that already existed in-process. Now persisted on the route row. |
 
 ### 4.7 Per-candidate scores — `inference_route_candidates` (Phase 2, the new ask)
 One row per provider the scheduler *considered* for an attempt. This is what lets
@@ -224,9 +225,8 @@ regret** analysis.
 | Field | Why |
 |-------|-----|
 | `route_id` (FK → `inference_routes.id`), `request_id`, `attempt` | Link to the parent decision. |
-| `provider_id`, `rank` (0 = winner) | Identify each candidate and its finishing position. |
-| `selected` (bool) | Was this the winner? |
-| `eligible` (bool), `rejection_reason` (`capacity`/`model_too_large`/`vision`/`ttft`/`thermal`/`trust`/`slot_state`/`none`) | **Why a candidate lost before scoring** — the per-machine mismatch. |
+| `provider_id`, `rank` (0 = cheapest eligible by cost), `selected` (who was reserved) | Rank is cost-order so regret is `selected` vs rank 0. Near-tie spread can reserve a non-cheapest candidate. |
+| `eligible` (bool), `rejection_reason` (`capacity`/`model_too_large`/`vision`/`ttft`/`catalog`/`breaker`/`liveness`/`trait`/`prefer_owner`/…) | **Why a candidate lost** — post-gate, structural, or soft-filter. |
 | `cost_ms` + full breakdown (`state_ms`,`queue_ms`,`pending_ms`,`backlog_ms`,`this_req_ms`,`health_ms`,`ttft_ms`) | The loser's score, term by term. "A won at 1.2s, B was 1.35s (its `backlog_ms` was 2× higher)." |
 | `effective_queue`, `effective_tps`, `static_tps`, `batch_size` | The loser's live state — needed to know if the model *correctly* ranked it. |
 | hardware snapshot (`chip_family`, `tier`, `memory_gb`, `slot_state`, mem pressure, thermal, gpu active) | Compare winner vs loser hardware; detect "we picked a worse machine." |
@@ -432,8 +432,8 @@ Rather than paging a giant JSON reply, **stream the rows straight to a file**:
 |-------|-------------|------|
 | **0 — done** | `inference_routes` table + two-phase write wired through dispatch/complete; memory+postgres stores; tests green. | shipped on this branch |
 | **1** | Add §4.6 gap fields (timing decomposition, actual queue wait, actual decode TPS, admit-but-failed, backup win/loss). **Add `request_rejections` table (§4.9) — the rejection / lost-demand ledger with counterfactual servability.** Add read endpoints (§6). | low-medium — additive columns + a `recordRejection(...)` helper called at each 4xx exit |
-| **2** | `inference_route_candidates` table + surface per-candidate scores from `selectBestCandidateLockedFull` (return the scored pool + rejections, not just the winner). Sampling controls. | medium — touches the hot scheduler path; must stay allocation-light and behind the existing `r.mu` |
-| **3** | `provider_capacity_samples` from heartbeats; offline calibration notebooks/SQL views; Datadog dashboard. | low — read-only analysis |
+| **2 — done** | `inference_route_candidates` table + surface per-candidate scores from `selectBestCandidateLockedFull` (return the scored pool + rejections, not just the winner). Winner + top eligible + post-gate/structural/soft-filter rejects persisted (capped). Rank is cost-order; `selected` is who we reserved. Admin JSON/CSV at `/v1/admin/candidates`. | shipped |
+| **3 — done** | `provider_capacity_samples` from heartbeats (1/min/provider) + admin JSON/CSV at `/v1/admin/capacity-samples`. Prediction-error DogStatsD histograms (`routing.ttft_error_ms`, `routing.decode_tps_ratio`, `routing.duration_vs_cost_ms`, `routing.prompt_token_estimate_error`) and `routing.model_load_ms`. Route-row extras: geo, kv_backend, prefill TPS, admission snapshot, near-tie audit, shadow TTFT, billing settlement, terminal_source, retry totals. | shipped |
 | **4** | Promote the worst-fitting constants to a DB-backed `routing_params[tier][model]` config the scheduler reads; close the loop. | higher — changes live routing; gate behind validation + rollback |
 
 ---

--- a/docs/architecture/routing-telemetry-and-calibration.md
+++ b/docs/architecture/routing-telemetry-and-calibration.md
@@ -224,9 +224,9 @@ regret** analysis.
 
 | Field | Why |
 |-------|-----|
-| `route_id` (FK → `inference_routes.id`), `request_id`, `attempt` | Link to the parent decision. |
+| `request_id`, `attempt`, `provider_id` | Join key to the parent `inference_routes` row. There is no `route_id` FK; attempts mint their own request IDs. |
 | `provider_id`, `rank` (0 = cheapest eligible by cost), `selected` (who was reserved) | Rank is cost-order so regret is `selected` vs rank 0. Near-tie spread can reserve a non-cheapest candidate. |
-| `eligible` (bool), `rejection_reason` (`capacity`/`model_too_large`/`vision`/`ttft`/`catalog`/`breaker`/`liveness`/`trait`/`prefer_owner`/…) | **Why a candidate lost** — post-gate, structural, or soft-filter. |
+| `eligible` (bool), `rejection_reason` (`capacity`/`model_too_large`/`vision`/`ttft`/`catalog`/`breaker`/`liveness`/`trait`/`prefer_owner`/`avoid_version`/`min_decode_tps`/`slot_crashed`/`slot_reloading`/`thermal_critical`/…) | **Why a candidate lost.** Soft-filter reasons are per-step (the filter that actually dropped the provider); later filters do not overwrite. Fail-fast `ttft_429` / `model_too_large` / `no_provider` still persist these rows — the minted `PendingRequest.RequestID` is kept even when no provider is reserved. |
 | `cost_ms` + full breakdown (`state_ms`,`queue_ms`,`pending_ms`,`backlog_ms`,`this_req_ms`,`health_ms`,`ttft_ms`) | The loser's score, term by term. "A won at 1.2s, B was 1.35s (its `backlog_ms` was 2× higher)." |
 | `effective_queue`, `effective_tps`, `static_tps`, `batch_size` | The loser's live state — needed to know if the model *correctly* ranked it. |
 | hardware snapshot (`chip_family`, `tier`, `memory_gb`, `slot_state`, mem pressure, thermal, gpu active) | Compare winner vs loser hardware; detect "we picked a worse machine." |
@@ -432,7 +432,7 @@ Rather than paging a giant JSON reply, **stream the rows straight to a file**:
 |-------|-------------|------|
 | **0 — done** | `inference_routes` table + two-phase write wired through dispatch/complete; memory+postgres stores; tests green. | shipped on this branch |
 | **1** | Add §4.6 gap fields (timing decomposition, actual queue wait, actual decode TPS, admit-but-failed, backup win/loss). **Add `request_rejections` table (§4.9) — the rejection / lost-demand ledger with counterfactual servability.** Add read endpoints (§6). | low-medium — additive columns + a `recordRejection(...)` helper called at each 4xx exit |
-| **2 — done** | `inference_route_candidates` table + surface per-candidate scores from `selectBestCandidateLockedFull` (return the scored pool + rejections, not just the winner). Winner + top eligible + post-gate/structural/soft-filter rejects persisted (capped). Rank is cost-order; `selected` is who we reserved. Admin JSON/CSV at `/v1/admin/candidates`. | shipped |
+| **2 — done** | `inference_route_candidates` table + scored pool + post-gate/structural/soft-filter rejects. Soft-filter `rejection_reason` is the filter that actually dropped the provider (chained PreferOwner → AvoidVersion → MinDecodeTPS). Fail-fast no-reserve paths keep the minted request ID so candidate rows persist. Rank is cost-order; `selected` is who we reserved. | shipped |
 | **3 — done** | `provider_capacity_samples` from heartbeats (1/min/provider) + admin JSON/CSV at `/v1/admin/capacity-samples`. Prediction-error DogStatsD histograms (`routing.ttft_error_ms`, `routing.decode_tps_ratio`, `routing.duration_vs_cost_ms`, `routing.prompt_token_estimate_error`) and `routing.model_load_ms`. Route-row extras: geo, kv_backend, prefill TPS, admission snapshot, near-tie audit, shadow TTFT, billing settlement, terminal_source, retry totals. | shipped |
 | **4** | Promote the worst-fitting constants to a DB-backed `routing_params[tier][model]` config the scheduler reads; close the loop. | higher — changes live routing; gate behind validation + rollback |
 

--- a/docs/architecture/routing-telemetry-and-calibration.md
+++ b/docs/architecture/routing-telemetry-and-calibration.md
@@ -236,7 +236,9 @@ regret** analysis.
 the winner was slow/failed, **would the runner-up have been faster?** If the #2
 candidate consistently beats the #1 we picked, the cost model is mis-ranking and
 we know exactly which term to fix. This is the highest-leverage analysis in the
-whole plan and is impossible without per-candidate rows.
+whole plan and is impossible without per-candidate rows. The persist cap (8
+rejects) keeps scored/soft-filter/TTFT losses first; catalog/liveness misses
+fill leftover slots so a large fleet cannot starve the calibration signal.
 
 ### 4.8 Fleet time-series — `provider_capacity_samples` (Phase 3, optional)
 Sampled heartbeat snapshots (e.g. 1/min/provider), independent of requests:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The scheduler is a hand-tuned cost model whose constants were fitted once on Qwen-7B. This PR records the inputs it saw, the decision it made (including losers), and what actually happened, so we can calibrate against real `gpt-oss-20b` / `gemma-4-26b` fleet data.

Client-supplied telemetry ingest stays disabled (410). This is coordinator-generated operational metadata only: no prompts, completions, raw IPs, or raw keys.

## Linked issue

N/A — first-principles expansion of existing routing telemetry.

## What we now capture

- **Per-candidate scores** (`inference_route_candidates`): cost breakdown for the scored pool, plus capped structural-gate and soft-filter rejects. Rank is cost-order (0 = cheapest); `selected` is who was actually reserved (near-tie spread can pick a non-cheapest machine). Soft-filter `rejection_reason` is the filter that actually dropped the provider (PreferOwner → AvoidVersion → MinDecodeTPS); later filters do not overwrite.
- **Reject persist priority**: the 8-row reject cap keeps scored/soft-filter/TTFT losses first. Catalog/liveness misses fill leftover slots, so a large fleet cannot starve the calibration signal.
- **Heartbeat time-series** (`provider_capacity_samples`): 1/min/provider snapshots for TPS-vs-batch and health-vs-throughput curves.
- **Route-row extras** that already existed in-process: geo, `kv_backend`, prefill TPS, `free_for_load_gb` / wedge / total pending, near-tie audit, TTFT shadow, cache usage, client/provider/billing outcomes, billing reservation vs settlement, `terminal_source`, retry totals.
- **Prediction-error DogStatsD**: `routing.ttft_error_ms`, `routing.ttft_ratio`, `routing.decode_tps_ratio`, `routing.duration_vs_cost_ms`, `routing.prompt_token_estimate_error`, `routing.model_load_ms`.
- Admin JSON/CSV: `GET /v1/admin/candidates` and `GET /v1/admin/capacity-samples` (+ `/export`).
- Unschedulable slot/thermal states now carry closed-enum reasons (`slot_crashed`, `slot_reloading`, `thermal_critical`) instead of being dropped silently.

## Test plan

- [x] `cd coordinator && go test ./store/ ./registry/ ./api/ -count=1 -timeout 180s`
- [x] `cd coordinator && go build ./...`
- [x] `gofmt` clean on changed Go files
- [x] Chained soft-filter reasons (`TestReserveProviderExRecordsChainedSoftFilterReasons`)
- [x] Fail-fast candidate persist (`TestDispatch_TTFTRejectAttempt0_SingleReservationAnd429`, `TestRecordRoutingDecisionPersistsCandidatesOnNilProvider`)
- [x] Catalog-flood reject priority (`TestSnapshotRouteCandidatesPrefersInformativeRejects`, `TestReserveProviderExPersistsSoftRejectsDespiteCatalogFlood`)
- [ ] Postgres store tests (`DATABASE_URL` not set in this environment; memory store covers the same interface)

## Components touched

- [x] coordinator (Go)
- [ ] provider (Rust, legacy)
- [ ] provider-swift (Swift CLI)
- [ ] console-ui (Next.js)
- [ ] enclave (Swift)
- [ ] infra / CI / release
- [x] docs

## Protocol / interface changes

- [x] No protocol/interface changes

Store schema + admin HTTP only. No provider WebSocket or console-ui protocol change. Client `POST /v1/telemetry/events` remains 410.

## Behavior

```mermaid
flowchart LR
  subgraph Before
    B1[request] --> B2[scheduler scores every candidate]
    B2 --> B3[losers discarded]
    B3 --> B4[winner row on inference_routes]
    B4 --> B5[heartbeats / geo / prefill / billing stay in memory]
    B6[ttft_429 / no_provider] --> B7[candidate rows dropped]
    B8[PreferOwner then MinDecodeTPS] --> B9[all drops labeled min_decode_tps]
    B10[8-row reject cap FIFO] --> B11[catalog misses starve TTFT/soft-filter]
  end
  subgraph After
    A1[request] --> A2[scheduler scores every candidate]
    A2 --> A3[winner + capped losers persisted]
    A3 --> A4[inference_routes extras + outcome dimensions]
    A5[heartbeat 1/min] --> A6[provider_capacity_samples]
    A4 --> A7[admin JSON/CSV + prediction-error metrics]
    A6 --> A7
    A8[ttft_429 / no_provider] --> A9[keep minted request_id + candidate rows]
    A10[chained soft filters] --> A11[first drop reason wins]
    A12[reject cap by priority] --> A13[soft-filter/TTFT kept ahead of catalog]
  end
```

## Code

```mermaid
flowchart TB
  subgraph BeforeCode
    C1[selectBestCandidateLockedFull] --> C2[return winner only]
    C2 --> C3[recordRoutingDecision writes winner]
    C4[Heartbeat] --> C5[in-memory registry]
    C6[dispatchOneProvider nil provider] --> C7[return nil pr]
    C8[one softReason last write] --> C9[wrong rejection_reason]
    C10[appendRejected FIFO 16] --> C11[catalog fills cap]
  end
  subgraph AfterCode
    D1[selectBestCandidateLockedFull] --> D2[candidateScan pool + rejects]
    D2 --> D3[snapshotRouteCandidates after r.mu Unlock]
    D3 --> D4[rejectPersistPriority then cap 8]
    D4 --> D5[recordRoutingDecision + RecordInferenceRouteCandidates]
    D6[Heartbeat] --> D7[maybeRecordCapacitySample]
    D7 --> D8[RecordProviderCapacitySample]
    D9[handleComplete / dispatch run] --> D10[cache / billing / terminal_source / is_final_attempt]
    D11[applySoftFilter per step] --> D12[dropped map first-reason-wins]
    D13[dispatchOneProvider nil provider] --> D14[return minted pr]
    D14 --> D5
    D5 --> D15["GET /v1/admin/candidates|capacity-samples"]
    D8 --> D15
    D10 --> D15
  end
```

## Notes for reviewers

- Rank 0 is the cheapest eligible candidate, not necessarily the reserved one. That is the regret signal.
- Candidate snapshots are copied after releasing `r.mu` so sort/alloc stays off the registry write lock.
- Writes stay `submitTelemetry` async + best-effort; a DB hiccup must not touch inference.
- Reject cap is 8 rows, ordered by calibration value (soft-filter / TTFT / capacity / cooldowns / catalog).
- Generic `/v1/completions` and `/v1/messages` already share `dispatchState`, so they get route rows; `endpoint` now distinguishes them.
- Fail-fast `ttft_429` / `model_too_large` / `no_provider` keep the minted `PendingRequest` so `inference_route_candidates` is not dropped for empty `request_id`. Speculative backup misses record the same way.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eee6019c-56e5-47d6-a4cd-7eae6d13908a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eee6019c-56e5-47d6-a4cd-7eae6d13908a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/755"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790403099&installation_model_id=21733&pr_number=755&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F755&signature=01537475bea0128722a10216fe90cbbe84a5627f218b23f699e712d17c41ab01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->