### PR TITLE
fix: aggregate provider earnings dashboard windows

### DIFF
--- a/coordinator/api/me_handlers.go
+++ b/coordinator/api/me_handlers.go
@@ -162,26 +162,16 @@ func (s *Server) handleMySummary(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	recent, err := s.store.GetAccountEarnings(accountID, 5000)
+	now := time.Now()
+	windows, err := s.store.GetAccountEarningsWindows(
+		accountID,
+		now.Add(-24*time.Hour),
+		now.Add(-7*24*time.Hour),
+	)
 	if err != nil {
-		s.logger.Error("get account earnings failed", "error", err)
+		s.logger.Error("get account earnings windows failed", "error", err)
 		writeJSON(w, http.StatusInternalServerError, errorResponse("internal_error", "failed to fetch earnings"))
 		return
-	}
-	now := time.Now()
-	cutoff24h := now.Add(-24 * time.Hour)
-	cutoff7d := now.Add(-7 * 24 * time.Hour)
-	var last24Money, last7dMoney int64
-	var last24Jobs, last7dJobs int64
-	for _, e := range recent {
-		if e.CreatedAt.After(cutoff7d) {
-			last7dMoney += e.AmountMicroUSD
-			last7dJobs++
-			if e.CreatedAt.After(cutoff24h) {
-				last24Money += e.AmountMicroUSD
-				last24Jobs++
-			}
-		}
 	}
 
 	fleet, err := s.mergeFleet(r.Context(), accountID)
@@ -203,10 +193,10 @@ func (s *Server) handleMySummary(w http.ResponseWriter, r *http.Request) {
 		PayoutReady:                 user.StripeAccountStatus == "ready",
 		LifetimeMicroUSD:            summary.TotalMicroUSD,
 		LifetimeJobs:                summary.Count,
-		Last24hMicroUSD:             last24Money,
-		Last24hJobs:                 last24Jobs,
-		Last7dMicroUSD:              last7dMoney,
-		Last7dJobs:                  last7dJobs,
+		Last24hMicroUSD:             windows.Last24hMicroUSD,
+		Last24hJobs:                 windows.Last24hJobs,
+		Last7dMicroUSD:              windows.Last7dMicroUSD,
+		Last7dJobs:                  windows.Last7dJobs,
 		Counts:                      counts,
 		LatestProviderVersion:       s.latestReleasedVersion(),
 		MinProviderVersion:          s.minProviderVersion,

--- a/coordinator/api/me_summary_test.go
+++ b/coordinator/api/me_summary_test.go
@@ -1,0 +1,55 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/store"
+)
+
+func TestMySummaryAggregatesBeyondHistoryLimit(t *testing.T) {
+	srv, st := testServer(t)
+	const accountID = "acct-summary-window"
+	now := time.Now()
+
+	// The old handler loaded only the newest 5,000 rows before calculating its
+	// windows. Put 5,001 inference rows in the last 24 hours so that regression
+	// would undercount both dashboard windows.
+	for i := 0; i < 5001; i++ {
+		earning := &store.ProviderEarning{
+			AccountID:      accountID,
+			ProviderID:     "provider-1",
+			ProviderKey:    "provider-key-1",
+			JobID:          "job-" + string(rune(i)),
+			Model:          "qwen",
+			AmountMicroUSD: 1,
+			CreatedAt:      now.Add(-time.Hour),
+		}
+		if err := st.RecordProviderEarning(earning); err != nil {
+			t.Fatalf("RecordProviderEarning(%d): %v", i, err)
+		}
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/me/summary", nil)
+	req = withPrivyUser(req, &store.User{AccountID: accountID})
+	w := httptest.NewRecorder()
+	srv.handleMySummary(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", w.Code, w.Body.String())
+	}
+	var response mySummaryResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode summary: %v", err)
+	}
+
+	if response.Last24hJobs != 5001 || response.Last7dJobs != 5001 {
+		t.Fatalf("jobs = (%d, %d), want (5001, 5001)", response.Last24hJobs, response.Last7dJobs)
+	}
+	if response.Last24hMicroUSD != 5001 || response.Last7dMicroUSD != 5001 {
+		t.Fatalf("money = (%d, %d), want (5001, 5001)", response.Last24hMicroUSD, response.Last7dMicroUSD)
+	}
+}

--- a/coordinator/store/earnings_windows_test.go
+++ b/coordinator/store/earnings_windows_test.go
@@ -1,0 +1,39 @@
+package store
+
+import (
+	"testing"
+	"time"
+)
+
+func TestProviderEarningsWindowsIncludesAllRowsAndExcludesBaseRewardJobs(t *testing.T) {
+	s := NewMemory(Config{})
+	now := time.Now()
+	cutoff24h := now.Add(-24 * time.Hour)
+	cutoff7d := now.Add(-7 * 24 * time.Hour)
+
+	rows := []ProviderEarning{
+		{AccountID: "acct-windows", Model: "qwen", AmountMicroUSD: 100, CreatedAt: now.Add(-time.Hour)},
+		{AccountID: "acct-windows", Model: "base_reward", AmountMicroUSD: 200, CreatedAt: now.Add(-2 * time.Hour)},
+		{AccountID: "acct-windows", Model: "qwen", AmountMicroUSD: 300, CreatedAt: now.Add(-48 * time.Hour)},
+		{AccountID: "acct-windows", Model: "base_reward", AmountMicroUSD: 400, CreatedAt: now.Add(-48 * time.Hour)},
+		{AccountID: "acct-windows", Model: "qwen", AmountMicroUSD: 500, CreatedAt: now.Add(-8 * 24 * time.Hour)},
+		{AccountID: "other-account", Model: "qwen", AmountMicroUSD: 600, CreatedAt: now.Add(-time.Hour)},
+	}
+	for i := range rows {
+		if err := s.RecordProviderEarning(&rows[i]); err != nil {
+			t.Fatalf("RecordProviderEarning: %v", err)
+		}
+	}
+
+	windows, err := s.GetAccountEarningsWindows("acct-windows", cutoff24h, cutoff7d)
+	if err != nil {
+		t.Fatalf("GetAccountEarningsWindows: %v", err)
+	}
+
+	if windows.Last24hMicroUSD != 300 || windows.Last24hJobs != 1 {
+		t.Fatalf("last 24h = %+v, want money=300 jobs=1", windows)
+	}
+	if windows.Last7dMicroUSD != 1000 || windows.Last7dJobs != 2 {
+		t.Fatalf("last 7d = %+v, want money=1000 jobs=2", windows)
+	}
+}

--- a/coordinator/store/interface.go
+++ b/coordinator/store/interface.go
@@ -825,6 +825,16 @@ type ProviderEarningsSummary struct {
 	CompletionTokens int64 `json:"completion_tokens"`
 }
 
+// ProviderEarningsWindows contains complete account aggregates for the two
+// provider dashboard windows. Money includes base rewards; job counts count
+// inference work only.
+type ProviderEarningsWindows struct {
+	Last24hMicroUSD int64
+	Last24hJobs     int64
+	Last7dMicroUSD  int64
+	Last7dJobs      int64
+}
+
 // ProviderPayout records a provider payout event. This is separate from
 // account-linked provider earnings because some providers are paid directly
 // without being linked to a Privy account.

--- a/coordinator/store/interface_domains.go
+++ b/coordinator/store/interface_domains.go
@@ -518,6 +518,10 @@ type ProviderEarningsStore interface {
 	// GetAccountEarningsSummary returns lifetime aggregates for an account across all linked nodes.
 	GetAccountEarningsSummary(accountID string) (ProviderEarningsSummary, error)
 
+	// GetAccountEarningsWindows returns complete 24-hour and 7-day aggregates
+	// for an account. Money includes base rewards; job counts exclude them.
+	GetAccountEarningsWindows(accountID string, cutoff24h, cutoff7d time.Time) (ProviderEarningsWindows, error)
+
 	// RecordProviderPayout stores a payout record for a provider wallet.
 	RecordProviderPayout(payout *ProviderPayout) error
 

--- a/coordinator/store/memory_earnings_aggregates.go
+++ b/coordinator/store/memory_earnings_aggregates.go
@@ -1,0 +1,36 @@
+package store
+
+import "time"
+
+// GetAccountEarningsWindows returns complete dashboard aggregates without the
+// pagination limit used by GetAccountEarnings for history rendering.
+func (s *MemoryStore) GetAccountEarningsWindows(
+	accountID string,
+	cutoff24h, cutoff7d time.Time,
+) (ProviderEarningsWindows, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	var windows ProviderEarningsWindows
+	for i := range s.providerEarnings {
+		earning := &s.providerEarnings[i]
+		if earning.AccountID != accountID || earning.CreatedAt.Before(cutoff7d) {
+			continue
+		}
+
+		windows.Last7dMicroUSD += earning.AmountMicroUSD
+		if earning.Model != "base_reward" {
+			windows.Last7dJobs++
+		}
+		if earning.CreatedAt.Before(cutoff24h) {
+			continue
+		}
+
+		windows.Last24hMicroUSD += earning.AmountMicroUSD
+		if earning.Model != "base_reward" {
+			windows.Last24hJobs++
+		}
+	}
+
+	return windows, nil
+}

--- a/coordinator/store/postgres_earnings_aggregates.go
+++ b/coordinator/store/postgres_earnings_aggregates.go
@@ -1,0 +1,45 @@
+package store
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// GetAccountEarningsWindows returns complete dashboard aggregates in one SQL
+// query. The account/time index limits the scan to the seven-day window.
+func (s *PostgresStore) GetAccountEarningsWindows(
+	accountID string,
+	cutoff24h, cutoff7d time.Time,
+) (ProviderEarningsWindows, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	var windows ProviderEarningsWindows
+	err := s.pool.QueryRow(ctx, `
+		SELECT
+			COALESCE(SUM(amount_micro_usd) FILTER (
+				WHERE created_at >= $2
+			), 0),
+			COUNT(*) FILTER (
+				WHERE created_at >= $2 AND model <> 'base_reward'
+			),
+			COALESCE(SUM(amount_micro_usd), 0),
+			COUNT(*) FILTER (
+				WHERE model <> 'base_reward'
+			)
+		  FROM provider_earnings
+		 WHERE account_id = $1
+		   AND created_at >= $3`,
+		accountID, cutoff24h, cutoff7d,
+	).Scan(
+		&windows.Last24hMicroUSD,
+		&windows.Last24hJobs,
+		&windows.Last7dMicroUSD,
+		&windows.Last7dJobs,
+	)
+	if err != nil {
+		return ProviderEarningsWindows{}, fmt.Errorf("store: aggregate account earnings windows: %w", err)
+	}
+	return windows, nil
+}


### PR DESCRIPTION
## Summary

Fixes #761.

The provider dashboard's `/v1/me/summary` handler previously loaded only the newest 5,000 account earnings before calculating its 24-hour and 7-day totals. Accounts with more than 5,000 recent jobs were therefore undercounted. This change adds a store-level aggregate query for the complete windows, with matching in-memory behavior for tests and development.

## Behavior

```mermaid
flowchart LR
  subgraph Before
    B1[Dashboard] --> B2[GET /v1/me/summary]
    B2 --> B3[Load newest 5,000 earnings]
    B3 --> B4[Filter and sum in handler]
    B4 --> B5[24h / 7d totals capped at loaded rows]
  end
  subgraph After
    A1[Dashboard] --> A2[GET /v1/me/summary]
    A2 --> A3[Aggregate complete 7-day window]
    A3 --> A4[Split 24h and 7d totals]
    A4 --> A5[Accurate dashboard values]
  end
```

## Code

```mermaid
flowchart LR
  subgraph Before
    C1[handleMySummary] --> C2[GetAccountEarnings limit=5000]
    C2 --> C3[Loop over returned rows]
    C3 --> C4[Build response]
  end
  subgraph After
    D1[handleMySummary] --> D2[GetAccountEarningsWindows]
    D2 --> D3[Postgres SQL aggregate]
    D2 --> D4[Memory aggregate]
    D3 --> D5[Build response]
    D4 --> D5
  end
```

## Validation

- `mise exec -- go test ./...` (from `coordinator/`)
- `mise exec -- go vet ./...` (from `coordinator/`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/762"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790472598&installation_model_id=21733&pr_number=762&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F762&signature=f1847aef13f54eb187595f0d9b4a5c1e4a7567c286d373eb43dba3ff477e29d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->