### PR TITLE
Add optional DuckDB and Rill local analytics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 .PHONY: help \
         coordinator-test coordinator-build coordinator-build-linux coordinator \
         prompt-sidecar-format prompt-sidecar-check prompt-sidecar-test prompt-sidecar-build prompt-sidecar \
+        analytics-install analytics-test analytics-run \
         provider-build provider-test provider benchmark-gemma-contbatch benchmark-wrapper-test \
         ui-install ui-build ui-lint ui-test ui \
         e2e-integration e2e-benchmark e2e \
@@ -41,6 +42,18 @@ prompt-sidecar-build: ## Build the Rust sidecar for the host platform
 	cd coordinator/promptsidecar && cargo build --locked --release --bin promptsidecar
 
 prompt-sidecar: prompt-sidecar-format prompt-sidecar-check prompt-sidecar-test prompt-sidecar-build ## Format + lint + test + build Rust sidecar
+
+# ---- Local analytics (Python + DuckDB) -------------------------------------
+
+analytics-install: ## Install the local analytics processor into analytics/.venv
+	python3 -m venv analytics/.venv
+	analytics/.venv/bin/pip install -e ./analytics
+
+analytics-test: analytics-install ## Run local analytics processor tests
+	PYTHONPATH=analytics/tests analytics/.venv/bin/python -m unittest discover -s analytics/tests -v
+
+analytics-run: analytics-install ## Convert eligible local event hours to Parquet
+	analytics/.venv/bin/darkbloom-analytics run
 
 # ---- Provider (Swift, Apple Silicon) --------------------------------------
 

--- a/analytics/README.md
+++ b/analytics/README.md
@@ -1,0 +1,72 @@
+# Darkbloom local analytics
+
+This directory contains the short-lived, downstream analytics process. It is
+separate from the Swift inference provider and is the only component that uses
+DuckDB.
+
+## Local setup
+
+Enable the provider's privacy-safe terminal events in `provider.toml`:
+
+```toml
+[analytics]
+enabled = true
+```
+
+Install the processor in an isolated environment and initialize the workspace:
+
+```bash
+cd analytics
+python3 -m venv .venv
+.venv/bin/pip install -e .
+.venv/bin/darkbloom-analytics init
+```
+
+Run one conversion pass:
+
+```bash
+.venv/bin/darkbloom-analytics run
+```
+
+The command is intentionally short-lived. `init` generates a five-minute,
+background-priority launchd definition at:
+
+```text
+~/.darkbloom/analytics/launchd/dev.darkbloom.analytics.plist
+```
+
+Install it when you are ready to schedule processing:
+
+```bash
+cp ~/.darkbloom/analytics/launchd/dev.darkbloom.analytics.plist \
+  ~/Library/LaunchAgents/dev.darkbloom.analytics.plist
+launchctl bootstrap gui/$(id -u) \
+  ~/Library/LaunchAgents/dev.darkbloom.analytics.plist
+```
+
+A missed invocation is harmless; the next run discovers all eligible completed
+UTC hours and processing is idempotent.
+
+Start Rill against the installed project after installing the Rill CLI:
+
+```bash
+rill start ~/.darkbloom/analytics/rill
+```
+
+The Rill `jobs_all` model unions completed job Parquet with finalized recent
+NDJSON using `processor-state.json` as a mutually exclusive watermark.
+
+## Retention defaults
+
+- Finalized NDJSON: 3 days
+- Job-level Parquet: 90 days
+- Hourly rollups: retained
+
+The provider never deletes normal analytics history. Retention, validation,
+quarantine, Parquet generation, and Rill files all belong to this module.
+
+## Test
+
+```bash
+.venv/bin/python -m unittest discover -s tests -v
+```

--- a/analytics/pyproject.toml
+++ b/analytics/pyproject.toml
@@ -1,0 +1,16 @@
+[build-system]
+requires = ["hatchling>=1.27"]
+build-backend = "hatchling.build"
+
+[project]
+name = "darkbloom-local-analytics"
+version = "0.1.0"
+description = "Short-lived local NDJSON to Parquet processor for Darkbloom"
+requires-python = ">=3.11"
+dependencies = ["duckdb>=1.4,<2"]
+
+[project.scripts]
+darkbloom-analytics = "darkbloom_analytics.cli:main"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/darkbloom_analytics"]

--- a/analytics/src/darkbloom_analytics/__init__.py
+++ b/analytics/src/darkbloom_analytics/__init__.py
@@ -1,0 +1,3 @@
+"""Darkbloom's local, short-lived analytics processor."""
+
+__version__ = "0.1.0"

--- a/analytics/src/darkbloom_analytics/cli.py
+++ b/analytics/src/darkbloom_analytics/cli.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from .processor import Processor, ProcessorConfig
+
+
+def parser() -> argparse.ArgumentParser:
+    result = argparse.ArgumentParser(
+        prog="darkbloom-analytics",
+        description="Convert finalized Darkbloom job events into local Parquet analytics.",
+    )
+    result.add_argument(
+        "--root",
+        type=Path,
+        default=Path.home() / ".darkbloom" / "analytics",
+        help="Analytics workspace (default: ~/.darkbloom/analytics)",
+    )
+    subcommands = result.add_subparsers(dest="command", required=True)
+    subcommands.add_parser("init", help="Create the workspace and install the Rill project")
+    subcommands.add_parser("run", help="Process all eligible completed UTC hours and exit")
+    subcommands.add_parser("status", help="Print processor state as JSON")
+    return result
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parser().parse_args(argv)
+    processor = Processor(ProcessorConfig(root=args.root))
+    try:
+        if args.command == "init":
+            processor.initialize()
+            print(f"Initialized {processor.root}")
+        elif args.command == "run":
+            result = processor.run()
+            print(json.dumps({
+                "processed_hours": result.processed_hours,
+                "quarantined_files": result.quarantined_files,
+            }, indent=2))
+        else:
+            print(json.dumps(processor.status(), indent=2, sort_keys=True))
+    except Exception as exc:
+        print(f"darkbloom-analytics: {type(exc).__name__}: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/analytics/src/darkbloom_analytics/processor.py
+++ b/analytics/src/darkbloom_analytics/processor.py
@@ -1,0 +1,324 @@
+from __future__ import annotations
+
+import datetime as dt
+import json
+import os
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+import duckdb
+
+from .schema import ValidatedEvent, ValidationError, validate_event
+from .workspace import Workspace
+
+
+@dataclass(frozen=True)
+class ProcessorConfig:
+    root: Path
+    completion_grace: dt.timedelta = dt.timedelta(minutes=5)
+    raw_retention: dt.timedelta = dt.timedelta(days=3)
+    jobs_retention: dt.timedelta = dt.timedelta(days=90)
+    memory_limit: str = "256MB"
+
+
+@dataclass(frozen=True)
+class RunResult:
+    processed_hours: tuple[str, ...]
+    quarantined_files: tuple[str, ...]
+
+
+class Processor:
+    def __init__(self, config: ProcessorConfig):
+        self.config = config
+        self.root = config.root.expanduser().resolve()
+        self.workspace = Workspace(self.root, config.memory_limit)
+
+    def initialize(self) -> None:
+        self.workspace.initialize()
+
+    def run(self, *, now: dt.datetime | None = None) -> RunResult:
+        self.initialize()
+        try:
+            return self._run_initialized(now=now)
+        except Exception as exc:
+            self._record_error(exc)
+            raise
+
+    def _run_initialized(self, *, now: dt.datetime | None = None) -> RunResult:
+        now = (now or dt.datetime.now(dt.UTC)).astimezone(dt.UTC)
+        cutoff = now - self.config.completion_grace
+        records_by_hour: dict[dt.datetime, list[tuple[Path, ValidatedEvent]]] = {}
+        quarantined: list[str] = []
+
+        for path in sorted((self.root / "events/ready").glob("**/*.jsonl")):
+            if path.name.startswith("_"):
+                continue
+            try:
+                records = list(self._read_segment(path))
+            except (OSError, json.JSONDecodeError, ValidationError) as exc:
+                quarantined.append(str(self._quarantine(path, exc)))
+                continue
+            for record in records:
+                records_by_hour.setdefault(record.hour, []).append((path, record))
+
+        processed: list[str] = []
+        for hour in sorted(records_by_hour):
+            if hour + dt.timedelta(hours=1) > cutoff:
+                continue
+            self._process_hour(hour, records_by_hour[hour])
+            processed.append(_hour_key(hour))
+
+        self._advance_coverage(
+            records_by_hour,
+            cutoff,
+            now,
+            allow_advance=not quarantined,
+        )
+        self._apply_retention(now)
+        return RunResult(tuple(processed), tuple(quarantined))
+
+    def status(self) -> dict:
+        self.initialize()
+        return json.loads((self.root / "state/processor-state.json").read_text())
+
+    def _read_segment(self, path: Path) -> Iterable[ValidatedEvent]:
+        seen: set[str] = set()
+        with path.open("r", encoding="utf-8") as stream:
+            for number, line in enumerate(stream, start=1):
+                if not line.endswith("\n"):
+                    raise ValidationError(f"line {number} is not newline-terminated")
+                value = json.loads(line)
+                event = validate_event(value)
+                event_id = event.value["event_id"]
+                if event_id in seen:
+                    raise ValidationError(f"duplicate event_id on line {number}")
+                seen.add(event_id)
+                yield event
+
+    def _process_hour(
+        self,
+        hour: dt.datetime,
+        records: list[tuple[Path, ValidatedEvent]],
+    ) -> None:
+        event_ids: set[str] = set()
+        for _, event in records:
+            if event.value["event_id"] in event_ids:
+                raise ValidationError(f"duplicate event_id in hour {_hour_key(hour)}")
+            event_ids.add(event.value["event_id"])
+
+        day = hour.strftime("%Y-%m-%d")
+        hour_number = hour.strftime("%H")
+        jobs_dir = self.root / f"parquet/jobs/date={day}/hour={hour_number}"
+        rollups_dir = self.root / f"parquet/hourly-rollups/date={day}/hour={hour_number}"
+        jobs_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+        rollups_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+        input_files = sorted({str(path.relative_to(self.root)) for path, _ in records})
+        manifest_path = self.root / f"state/manifests/{hour.strftime('%Y%m%dT%H0000Z')}.json"
+        if manifest_path.exists() and (jobs_dir / "jobs.parquet").exists() and (rollups_dir / "rollup.parquet").exists():
+            existing = json.loads(manifest_path.read_text())
+            if existing.get("input_files") == input_files and existing.get("input_records") == len(records):
+                return
+        token = f"{hour.strftime('%Y%m%dT%H%M%SZ')}-{os.getpid()}"
+        normalized = self.root / f"tmp/{token}.jsonl"
+        jobs_temp = self.root / f"tmp/{token}-jobs.parquet"
+        rollup_temp = self.root / f"tmp/{token}-rollup.parquet"
+
+        with normalized.open("w", encoding="utf-8") as stream:
+            for _, event in sorted(records, key=lambda item: item[1].event_at):
+                json.dump(event.value, stream, separators=(",", ":"), sort_keys=True)
+                stream.write("\n")
+        normalized.chmod(0o600)
+
+        connection = duckdb.connect(":memory:")
+        try:
+            connection.execute("SET threads = 1")
+            connection.execute(f"SET memory_limit = '{_sql_literal(self.config.memory_limit)}'")
+            connection.execute("SET preserve_insertion_order = false")
+            connection.execute(f"SET temp_directory = '{_sql_literal(str(self.root / 'tmp'))}'")
+            connection.execute(
+                f"""
+                CREATE TABLE jobs AS
+                SELECT
+                    schema_version::INTEGER AS schema_version,
+                    event_id::VARCHAR AS event_id,
+                    event_at::TIMESTAMPTZ AS event_at,
+                    event_name::VARCHAR AS event_name,
+                    process_epoch::VARCHAR AS process_epoch,
+                    job_id::VARCHAR AS job_id,
+                    trace_id::VARCHAR AS trace_id,
+                    serving_mode::VARCHAR AS serving_mode,
+                    model::VARCHAR AS model,
+                    outcome::VARCHAR AS outcome,
+                    error_class::VARCHAR AS error_class,
+                    streaming::BOOLEAN AS streaming,
+                    prompt_tokens::BIGINT AS prompt_tokens,
+                    completion_tokens::BIGINT AS completion_tokens,
+                    cached_prompt_tokens::BIGINT AS cached_prompt_tokens,
+                    queue_ms::DOUBLE AS queue_ms,
+                    ttft_ms::DOUBLE AS ttft_ms,
+                    total_ms::DOUBLE AS total_ms,
+                    decode_tps::DOUBLE AS decode_tps,
+                    earned_micro_usd::BIGINT AS earned_micro_usd,
+                    kv_backend::VARCHAR AS kv_backend,
+                    mtp_active::BOOLEAN AS mtp_active
+                FROM read_json_auto('{_sql_literal(str(normalized))}', maximum_object_size=1048576)
+                """
+            )
+            count, distinct_count = connection.execute(
+                "SELECT count(*), count(DISTINCT event_id) FROM jobs"
+            ).fetchone()
+            if count != len(records) or distinct_count != count:
+                raise ValidationError("DuckDB row-count or event-id validation failed")
+            connection.execute(
+                f"COPY jobs TO '{_sql_literal(str(jobs_temp))}' "
+                "(FORMAT PARQUET, COMPRESSION ZSTD)"
+            )
+            connection.execute(
+                f"""
+                COPY (
+                    SELECT
+                        date_trunc('hour', event_at) AS hour_start,
+                        model,
+                        serving_mode,
+                        outcome,
+                        kv_backend,
+                        mtp_active,
+                        count(*)::BIGINT AS jobs,
+                        sum(prompt_tokens)::HUGEINT AS prompt_tokens,
+                        sum(completion_tokens)::HUGEINT AS completion_tokens,
+                        sum(cached_prompt_tokens)::HUGEINT AS cached_prompt_tokens,
+                        sum(coalesce(earned_micro_usd, 0))::HUGEINT AS earned_micro_usd,
+                        count(*) FILTER (WHERE outcome = 'failed')::BIGINT AS errors,
+                        count(*) FILTER (WHERE outcome = 'cancelled')::BIGINT AS cancellations,
+                        sum(coalesce(ttft_ms, 0))::DOUBLE AS ttft_sum_ms,
+                        sum(total_ms)::DOUBLE AS total_duration_sum_ms
+                    FROM jobs
+                    GROUP BY ALL
+                ) TO '{_sql_literal(str(rollup_temp))}'
+                (FORMAT PARQUET, COMPRESSION ZSTD)
+                """
+            )
+            rollup_count = connection.execute(
+                "SELECT count(*) FROM read_parquet(?)", [str(rollup_temp)]
+            ).fetchone()[0]
+        except Exception:
+            jobs_temp.unlink(missing_ok=True)
+            rollup_temp.unlink(missing_ok=True)
+            raise
+        finally:
+            connection.close()
+            normalized.unlink(missing_ok=True)
+
+        os.replace(jobs_temp, jobs_dir / "jobs.parquet")
+        os.replace(rollup_temp, rollups_dir / "rollup.parquet")
+        (jobs_dir / "jobs.parquet").chmod(0o600)
+        (rollups_dir / "rollup.parquet").chmod(0o600)
+        manifest = {
+            "schema_version": 1,
+            "hour_start": _iso(hour),
+            "hour_end": _iso(hour + dt.timedelta(hours=1)),
+            "input_files": input_files,
+            "input_records": len(records),
+            "job_output_records": len(records),
+            "rollup_output_records": rollup_count,
+            "completed_at": _iso(dt.datetime.now(dt.UTC)),
+        }
+        self.workspace.write_json_atomic(
+            manifest_path,
+            manifest,
+        )
+
+    def _advance_coverage(
+        self,
+        records_by_hour: dict[dt.datetime, list[tuple[Path, ValidatedEvent]]],
+        cutoff: dt.datetime,
+        now: dt.datetime,
+        *,
+        allow_advance: bool,
+    ) -> None:
+        state_path = self.root / "state/processor-state.json"
+        state = json.loads(state_path.read_text())
+        current = dt.datetime.fromisoformat(
+            state["hourly_covered_through"].replace("Z", "+00:00")
+        )
+        target = cutoff.replace(minute=0, second=0, microsecond=0)
+        eligible = {hour for hour in records_by_hour if hour < target}
+        complete = all(
+            (self.root / f"parquet/jobs/date={hour:%Y-%m-%d}/hour={hour:%H}/jobs.parquet").exists()
+            and (self.root / f"parquet/hourly-rollups/date={hour:%Y-%m-%d}/hour={hour:%H}/rollup.parquet").exists()
+            for hour in eligible
+        )
+        if allow_advance and complete:
+            current = max(current, target)
+        state.update(
+            {
+                "updated_at": _iso(now),
+                "hourly_covered_through": _iso(current),
+                "last_success_at": _iso(now),
+                "last_error": None,
+            }
+        )
+        self.workspace.write_json_atomic(state_path, state)
+
+    def _quarantine(self, path: Path, error: Exception) -> Path:
+        directory = self.root / "events/quarantine"
+        destination = directory / path.name
+        if destination.exists():
+            destination = directory / f"{path.stem}-{os.getpid()}{path.suffix}"
+        shutil.move(path, destination)
+        self.workspace.write_json_atomic(
+            destination.with_suffix(destination.suffix + ".error.json"),
+            {
+                "schema_version": 1,
+                "quarantined_at": _iso(dt.datetime.now(dt.UTC)),
+                "source": str(path),
+                "error_class": type(error).__name__,
+                "message": str(error)[:1024],
+            },
+        )
+        return destination
+
+    def _record_error(self, error: Exception) -> None:
+        state_path = self.root / "state/processor-state.json"
+        try:
+            state = json.loads(state_path.read_text())
+            state.update(
+                {
+                    "updated_at": _iso(dt.datetime.now(dt.UTC)),
+                    "last_error": {
+                        "error_class": type(error).__name__,
+                        "message": str(error)[:1024],
+                    },
+                }
+            )
+            self.workspace.write_json_atomic(state_path, state)
+        except Exception:
+            pass
+
+    def _apply_retention(self, now: dt.datetime) -> None:
+        raw_cutoff = now - self.config.raw_retention
+        for path in (self.root / "events/ready").glob("**/*.jsonl"):
+            modified = dt.datetime.fromtimestamp(path.stat().st_mtime, dt.UTC)
+            if modified < raw_cutoff:
+                path.unlink(missing_ok=True)
+        jobs_cutoff = now - self.config.jobs_retention
+        for path in (self.root / "parquet/jobs").glob("date=*/hour=*/jobs.parquet"):
+            try:
+                day = dt.date.fromisoformat(path.parents[1].name.removeprefix("date="))
+            except ValueError:
+                continue
+            if day < jobs_cutoff.date():
+                path.unlink(missing_ok=True)
+
+def _iso(value: dt.datetime) -> str:
+    return value.astimezone(dt.UTC).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def _hour_key(value: dt.datetime) -> str:
+    return value.strftime("%Y-%m-%dT%H:00:00Z")
+
+
+def _sql_literal(value: str) -> str:
+    return value.replace("'", "''")

--- a/analytics/src/darkbloom_analytics/rill/dashboards/darkbloom_jobs.yaml
+++ b/analytics/src/darkbloom_analytics/rill/dashboards/darkbloom_jobs.yaml
@@ -1,0 +1,24 @@
+type: explore
+display_name: Darkbloom Recent Jobs
+metrics_view: darkbloom_jobs
+
+dimensions: '*'
+measures: '*'
+defaults:
+  measures:
+    - jobs
+    - successful_jobs
+    - failed_jobs
+    - prompt_tokens
+    - completion_tokens
+    - average_ttft_ms
+    - p95_ttft_ms
+    - average_total_ms
+    - average_decode_tps
+  dimensions:
+    - model
+    - serving_mode
+    - outcome
+    - error_class
+    - streaming
+  time_range: P1D

--- a/analytics/src/darkbloom_analytics/rill/dashboards/darkbloom_overview.yaml
+++ b/analytics/src/darkbloom_analytics/rill/dashboards/darkbloom_overview.yaml
@@ -1,0 +1,22 @@
+type: explore
+display_name: Darkbloom Overview
+metrics_view: darkbloom_overview
+
+dimensions: '*'
+measures: '*'
+defaults:
+  measures:
+    - jobs
+    - prompt_tokens
+    - completion_tokens
+    - errors
+    - cancellations
+    - average_total_ms
+    - earned_usd
+  dimensions:
+    - model
+    - serving_mode
+    - outcome
+    - kv_backend
+    - mtp_active
+  time_range: P30D

--- a/analytics/src/darkbloom_analytics/rill/metrics/darkbloom_jobs.yaml
+++ b/analytics/src/darkbloom_analytics/rill/metrics/darkbloom_jobs.yaml
@@ -1,0 +1,46 @@
+version: 1
+type: metrics_view
+model: jobs_all
+timeseries: event_at
+smallest_time_grain: second
+
+dimensions:
+  - column: model
+  - column: serving_mode
+  - column: outcome
+  - column: error_class
+  - column: kv_backend
+  - column: mtp_active
+  - column: streaming
+
+measures:
+  - name: jobs
+    label: Jobs
+    expression: count(*)
+  - name: successful_jobs
+    label: Successful jobs
+    expression: count(*) FILTER (WHERE outcome = 'success')
+  - name: failed_jobs
+    label: Failed jobs
+    expression: count(*) FILTER (WHERE outcome = 'failed')
+  - name: prompt_tokens
+    label: Prompt tokens
+    expression: sum(prompt_tokens)
+  - name: completion_tokens
+    label: Completion tokens
+    expression: sum(completion_tokens)
+  - name: average_ttft_ms
+    label: Average TTFT (ms)
+    expression: avg(ttft_ms)
+  - name: p95_ttft_ms
+    label: P95 TTFT (ms)
+    expression: quantile_cont(ttft_ms, 0.95)
+  - name: average_total_ms
+    label: Average total latency (ms)
+    expression: avg(total_ms)
+  - name: average_decode_tps
+    label: Average decode tokens/sec
+    expression: avg(decode_tps)
+  - name: earned_usd
+    label: Earned (USD)
+    expression: sum(earned_micro_usd) / 1000000.0

--- a/analytics/src/darkbloom_analytics/rill/metrics/darkbloom_overview.yaml
+++ b/analytics/src/darkbloom_analytics/rill/metrics/darkbloom_overview.yaml
@@ -1,0 +1,35 @@
+version: 1
+type: metrics_view
+model: hourly_rollups
+timeseries: hour_start
+smallest_time_grain: hour
+
+dimensions:
+  - column: model
+  - column: serving_mode
+  - column: outcome
+  - column: kv_backend
+  - column: mtp_active
+
+measures:
+  - name: jobs
+    label: Jobs
+    expression: sum(jobs)
+  - name: prompt_tokens
+    label: Prompt tokens
+    expression: sum(prompt_tokens)
+  - name: completion_tokens
+    label: Completion tokens
+    expression: sum(completion_tokens)
+  - name: errors
+    label: Errors
+    expression: sum(errors)
+  - name: cancellations
+    label: Cancellations
+    expression: sum(cancellations)
+  - name: average_total_ms
+    label: Average total latency (ms)
+    expression: sum(total_duration_sum_ms) / nullif(sum(jobs), 0)
+  - name: earned_usd
+    label: Earned (USD)
+    expression: sum(earned_micro_usd) / 1000000.0

--- a/analytics/src/darkbloom_analytics/rill/models/analytics_coverage.sql
+++ b/analytics/src/darkbloom_analytics/rill/models/analytics_coverage.sql
@@ -1,0 +1,2 @@
+SELECT hourly_covered_through::TIMESTAMPTZ AS hourly_covered_through
+FROM read_json_auto('__ANALYTICS_ROOT__/state/processor-state.json')

--- a/analytics/src/darkbloom_analytics/rill/models/hourly_rollups.yaml
+++ b/analytics/src/darkbloom_analytics/rill/models/hourly_rollups.yaml
@@ -1,0 +1,9 @@
+type: model
+materialize: true
+sql: |
+  SELECT *
+  FROM read_parquet(
+    '__ANALYTICS_ROOT__/parquet/hourly-rollups/**/*.parquet',
+    hive_partitioning = true,
+    union_by_name = true
+  )

--- a/analytics/src/darkbloom_analytics/rill/models/jobs_all.sql
+++ b/analytics/src/darkbloom_analytics/rill/models/jobs_all.sql
@@ -1,0 +1,11 @@
+SELECT h.*
+FROM jobs_history h
+CROSS JOIN analytics_coverage c
+WHERE h.event_at < c.hourly_covered_through
+
+UNION ALL BY NAME
+
+SELECT l.*
+FROM jobs_live l
+CROSS JOIN analytics_coverage c
+WHERE l.event_at >= c.hourly_covered_through

--- a/analytics/src/darkbloom_analytics/rill/models/jobs_history.sql
+++ b/analytics/src/darkbloom_analytics/rill/models/jobs_history.sql
@@ -1,0 +1,6 @@
+SELECT *
+FROM read_parquet(
+  '__ANALYTICS_ROOT__/parquet/jobs/**/*.parquet',
+  hive_partitioning = true,
+  union_by_name = true
+)

--- a/analytics/src/darkbloom_analytics/rill/models/jobs_live.sql
+++ b/analytics/src/darkbloom_analytics/rill/models/jobs_live.sql
@@ -1,0 +1,17 @@
+SELECT *
+FROM read_json(
+  '__ANALYTICS_ROOT__/events/ready/**/*.jsonl',
+  columns = {
+    schema_version: 'INTEGER', event_id: 'VARCHAR', event_at: 'TIMESTAMPTZ',
+    event_name: 'VARCHAR', process_epoch: 'VARCHAR', job_id: 'VARCHAR',
+    trace_id: 'VARCHAR', serving_mode: 'VARCHAR', model: 'VARCHAR', outcome: 'VARCHAR',
+    error_class: 'VARCHAR', streaming: 'BOOLEAN', prompt_tokens: 'BIGINT',
+    completion_tokens: 'BIGINT', cached_prompt_tokens: 'BIGINT', queue_ms: 'DOUBLE',
+    ttft_ms: 'DOUBLE', total_ms: 'DOUBLE', decode_tps: 'DOUBLE',
+    earned_micro_usd: 'BIGINT', kv_backend: 'VARCHAR', mtp_active: 'BOOLEAN'
+  },
+  format = 'newline_delimited'
+)
+WHERE event_name IN (
+  'inference.completed', 'inference.failed', 'inference.cancelled', 'inference.rejected'
+)

--- a/analytics/src/darkbloom_analytics/rill/rill.yaml
+++ b/analytics/src/darkbloom_analytics/rill/rill.yaml
@@ -1,0 +1,2 @@
+title: Darkbloom Local Analytics
+description: Privacy-safe local inference serving analytics

--- a/analytics/src/darkbloom_analytics/schema.py
+++ b/analytics/src/darkbloom_analytics/schema.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import datetime as dt
+from dataclasses import dataclass
+from typing import Any
+
+
+SCHEMA_VERSION = 1
+TERMINAL_EVENTS = {
+    "inference.completed",
+    "inference.failed",
+    "inference.cancelled",
+    "inference.rejected",
+}
+OUTCOMES = {"success", "failed", "cancelled", "rejected"}
+
+FIELDS = {
+    "schema_version",
+    "event_id",
+    "event_at",
+    "event_name",
+    "process_epoch",
+    "job_id",
+    "trace_id",
+    "serving_mode",
+    "model",
+    "outcome",
+    "error_class",
+    "streaming",
+    "prompt_tokens",
+    "completion_tokens",
+    "cached_prompt_tokens",
+    "queue_ms",
+    "ttft_ms",
+    "total_ms",
+    "decode_tps",
+    "earned_micro_usd",
+    "kv_backend",
+    "mtp_active",
+}
+
+# Swift's synthesized Codable encoder omits nil optionals instead of writing
+# explicit JSON nulls. Keep the wire schema strict, but normalize those omitted
+# keys to null before validation and Parquet conversion.
+OPTIONAL_FIELDS = {
+    "trace_id",
+    "model",
+    "error_class",
+    "queue_ms",
+    "ttft_ms",
+    "decode_tps",
+    "earned_micro_usd",
+    "kv_backend",
+    "mtp_active",
+}
+REQUIRED_FIELDS = FIELDS - OPTIONAL_FIELDS
+
+FORBIDDEN_FIELDS = {
+    "prompt",
+    "messages",
+    "content",
+    "completion",
+    "response",
+    "request_body",
+    "api_key",
+    "user",
+    "user_id",
+    "account_id",
+    "error",
+    "error_message",
+    "stack_trace",
+}
+
+
+class ValidationError(ValueError):
+    pass
+
+
+@dataclass(frozen=True)
+class ValidatedEvent:
+    value: dict[str, Any]
+    event_at: dt.datetime
+
+    @property
+    def hour(self) -> dt.datetime:
+        return self.event_at.replace(minute=0, second=0, microsecond=0)
+
+
+def validate_event(value: Any) -> ValidatedEvent:
+    if not isinstance(value, dict):
+        raise ValidationError("record must be a JSON object")
+    keys = set(value)
+    forbidden = keys & FORBIDDEN_FIELDS
+    if forbidden:
+        raise ValidationError(f"privacy-forbidden fields present: {sorted(forbidden)}")
+    unknown = keys - FIELDS
+    if unknown:
+        raise ValidationError(f"unknown fields present: {sorted(unknown)}")
+    missing = REQUIRED_FIELDS - keys
+    if missing:
+        raise ValidationError(f"required fields absent: {sorted(missing)}")
+    value = {key: value.get(key) for key in FIELDS}
+    if value["schema_version"] != SCHEMA_VERSION:
+        raise ValidationError("unsupported schema_version")
+    if value["event_name"] not in TERMINAL_EVENTS:
+        raise ValidationError("event_name is not a terminal inference event")
+    if value["outcome"] not in OUTCOMES:
+        raise ValidationError("outcome is not in the bounded vocabulary")
+    expected_event = (
+        "inference.completed"
+        if value["outcome"] == "success"
+        else f"inference.{value['outcome']}"
+    )
+    if value["event_name"] != expected_event:
+        raise ValidationError("event_name and outcome disagree")
+    for key in ("event_id", "process_epoch", "job_id", "serving_mode"):
+        _bounded_string(value[key], key, required=True)
+    for key in ("trace_id", "model", "error_class", "kv_backend"):
+        _bounded_string(value[key], key, required=False)
+    if not isinstance(value["streaming"], bool):
+        raise ValidationError("streaming must be boolean")
+    if value["mtp_active"] is not None and not isinstance(value["mtp_active"], bool):
+        raise ValidationError("mtp_active must be boolean or null")
+    for key in ("prompt_tokens", "completion_tokens", "cached_prompt_tokens"):
+        _nonnegative_integer(value[key], key)
+    if value["earned_micro_usd"] is not None:
+        _nonnegative_integer(value["earned_micro_usd"], "earned_micro_usd")
+    for key in ("queue_ms", "ttft_ms", "total_ms", "decode_tps"):
+        _nonnegative_number(value[key], key, nullable=key != "total_ms")
+
+    raw_timestamp = value["event_at"]
+    if not isinstance(raw_timestamp, str):
+        raise ValidationError("event_at must be an ISO-8601 string")
+    try:
+        parsed = dt.datetime.fromisoformat(raw_timestamp.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValidationError("event_at is not valid ISO-8601") from exc
+    if parsed.tzinfo is None:
+        raise ValidationError("event_at must include a timezone")
+    parsed = parsed.astimezone(dt.UTC)
+    return ValidatedEvent(value=value, event_at=parsed)
+
+
+def _bounded_string(value: Any, key: str, *, required: bool) -> None:
+    if value is None and not required:
+        return
+    if not isinstance(value, str) or (required and not value):
+        raise ValidationError(f"{key} must be a non-empty string")
+    if len(value) > 512:
+        raise ValidationError(f"{key} exceeds 512 characters")
+
+
+def _nonnegative_integer(value: Any, key: str) -> None:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise ValidationError(f"{key} must be a nonnegative integer")
+
+
+def _nonnegative_number(value: Any, key: str, *, nullable: bool) -> None:
+    if value is None and nullable:
+        return
+    if isinstance(value, bool) or not isinstance(value, (int, float)) or value < 0:
+        raise ValidationError(f"{key} must be a nonnegative number")

--- a/analytics/src/darkbloom_analytics/workspace.py
+++ b/analytics/src/darkbloom_analytics/workspace.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+import datetime as dt
+import json
+import os
+import plistlib
+import sys
+from pathlib import Path
+
+import duckdb
+
+
+class Workspace:
+    """Creates the local layout and generated Rill/launchd artifacts."""
+
+    def __init__(self, root: Path, memory_limit: str):
+        self.root = root
+        self.memory_limit = memory_limit
+
+    def initialize(self) -> None:
+        for relative in (
+            ".",
+            "events",
+            "events/active",
+            "events/ready",
+            "events/quarantine",
+            "parquet",
+            "parquet/jobs",
+            "parquet/hourly-rollups",
+            "state",
+            "state/manifests",
+            "tmp",
+            "rill",
+            "launchd",
+        ):
+            path = self.root / relative
+            path.mkdir(parents=True, exist_ok=True, mode=0o700)
+            path.chmod(0o700)
+        state = self.root / "state/processor-state.json"
+        if not state.exists():
+            now = dt.datetime.now(dt.UTC)
+            current_hour = now.replace(
+                minute=0, second=0, microsecond=0)
+            self.write_json_atomic(
+                state,
+                {
+                    "schema_version": 1,
+                    "updated_at": _iso(now),
+                    "hourly_covered_through": _iso(current_hour),
+                    "last_success_at": None,
+                    "last_error": None,
+                },
+            )
+        self._create_schema_sentinels()
+        self._install_rill_project()
+        self._install_launchd_template()
+
+    def _install_rill_project(self) -> None:
+        source = Path(__file__).with_name("rill")
+        destination = self.root / "rill"
+        for template in source.rglob("*"):
+            if template.is_dir():
+                continue
+            relative = template.relative_to(source)
+            target = destination / relative
+            target.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+            rendered = template.read_text().replace("__ANALYTICS_ROOT__", str(self.root))
+            target.write_text(rendered)
+            target.chmod(0o600)
+
+    def _install_launchd_template(self) -> None:
+        path = self.root / "launchd/dev.darkbloom.analytics.plist"
+        value = {
+            "Label": "dev.darkbloom.analytics",
+            "ProgramArguments": [
+                sys.executable,
+                "-m",
+                "darkbloom_analytics.cli",
+                "--root",
+                str(self.root),
+                "run",
+            ],
+            "RunAtLoad": True,
+            "StartInterval": 300,
+            "ProcessType": "Background",
+            "LowPriorityIO": True,
+            "Nice": 10,
+            "StandardOutPath": str(self.root / "state/processor.log"),
+            "StandardErrorPath": str(self.root / "state/processor.log"),
+        }
+        temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+        with temporary.open("wb") as stream:
+            plistlib.dump(value, stream, fmt=plistlib.FMT_XML, sort_keys=True)
+        temporary.chmod(0o600)
+        os.replace(temporary, path)
+
+    def _create_schema_sentinels(self) -> None:
+        schema_json = self.root / "events/ready/_schema.jsonl"
+        if not schema_json.exists():
+            sentinel = {
+                "schema_version": 1,
+                "event_id": "schema",
+                "event_at": "1970-01-01T00:00:00Z",
+                "event_name": "_schema",
+                "process_epoch": "schema",
+                "job_id": "schema",
+                "trace_id": None,
+                "serving_mode": "schema",
+                "model": None,
+                "outcome": "schema",
+                "error_class": None,
+                "streaming": False,
+                "prompt_tokens": 0,
+                "completion_tokens": 0,
+                "cached_prompt_tokens": 0,
+                "queue_ms": None,
+                "ttft_ms": None,
+                "total_ms": 0.0,
+                "decode_tps": None,
+                "earned_micro_usd": None,
+                "kv_backend": None,
+                "mtp_active": None,
+            }
+            schema_json.write_text(json.dumps(sentinel, separators=(",", ":")) + "\n")
+            schema_json.chmod(0o600)
+
+        jobs_schema = self.root / "parquet/jobs/date=1970-01-01/hour=00/_schema.parquet"
+        rollups_schema = self.root / "parquet/hourly-rollups/date=1970-01-01/hour=00/_schema.parquet"
+        jobs_schema.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        rollups_schema.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        if jobs_schema.exists() and rollups_schema.exists():
+            return
+        connection = duckdb.connect(":memory:")
+        try:
+            connection.execute("SET threads = 1")
+            connection.execute(f"SET memory_limit = '{_sql_literal(self.memory_limit)}'")
+            if not jobs_schema.exists():
+                connection.execute(
+                    f"""
+                    COPY (
+                        SELECT
+                            1::INTEGER schema_version, ''::VARCHAR event_id,
+                            now()::TIMESTAMPTZ event_at, ''::VARCHAR event_name,
+                            ''::VARCHAR process_epoch, ''::VARCHAR job_id,
+                            NULL::VARCHAR trace_id, ''::VARCHAR serving_mode,
+                            NULL::VARCHAR model, ''::VARCHAR outcome,
+                            NULL::VARCHAR error_class, false::BOOLEAN streaming,
+                            0::BIGINT prompt_tokens, 0::BIGINT completion_tokens,
+                            0::BIGINT cached_prompt_tokens, NULL::DOUBLE queue_ms,
+                            NULL::DOUBLE ttft_ms, 0::DOUBLE total_ms,
+                            NULL::DOUBLE decode_tps, NULL::BIGINT earned_micro_usd,
+                            NULL::VARCHAR kv_backend, NULL::BOOLEAN mtp_active
+                        WHERE false
+                    ) TO '{_sql_literal(str(jobs_schema))}' (FORMAT PARQUET)
+                    """
+                )
+            if not rollups_schema.exists():
+                connection.execute(
+                    f"""
+                    COPY (
+                        SELECT now()::TIMESTAMPTZ hour_start, NULL::VARCHAR model,
+                            ''::VARCHAR serving_mode, ''::VARCHAR outcome,
+                            NULL::VARCHAR kv_backend, NULL::BOOLEAN mtp_active,
+                            0::BIGINT jobs, 0::HUGEINT prompt_tokens,
+                            0::HUGEINT completion_tokens, 0::HUGEINT cached_prompt_tokens,
+                            0::HUGEINT earned_micro_usd, 0::BIGINT errors,
+                            0::BIGINT cancellations, 0::DOUBLE ttft_sum_ms,
+                            0::DOUBLE total_duration_sum_ms
+                        WHERE false
+                    ) TO '{_sql_literal(str(rollups_schema))}' (FORMAT PARQUET)
+                    """
+                )
+        finally:
+            connection.close()
+        jobs_schema.chmod(0o600)
+        rollups_schema.chmod(0o600)
+
+    @staticmethod
+    def write_json_atomic(path: Path, value: dict) -> None:
+        temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+        temporary.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n")
+        temporary.chmod(0o600)
+        os.replace(temporary, path)
+
+
+def _iso(value: dt.datetime) -> str:
+    return value.astimezone(dt.UTC).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def _sql_literal(value: str) -> str:
+    return value.replace("'", "''")

--- a/analytics/tests/test_processor.py
+++ b/analytics/tests/test_processor.py
@@ -1,0 +1,112 @@
+import datetime as dt
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+import duckdb
+
+from darkbloom_analytics.processor import Processor, ProcessorConfig
+from test_schema import event
+
+
+class ProcessorTests(unittest.TestCase):
+    def test_hourly_parquet_rollup_and_rill_union(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            processor = Processor(ProcessorConfig(root=root))
+            processor.initialize()
+            now = dt.datetime.now(dt.UTC).replace(minute=10, second=0, microsecond=0)
+            hour = now.replace(minute=0) - dt.timedelta(hours=1)
+            ready = root / f"events/ready/date={hour:%Y-%m-%d}"
+            ready.mkdir(parents=True)
+            segment = ready / "events-test.jsonl"
+            values = [
+                event(
+                    event_id="event-1",
+                    job_id="job-1",
+                    event_at=(hour + dt.timedelta(minutes=5)).isoformat().replace("+00:00", "Z"),
+                ),
+                event(
+                    event_id="event-2",
+                    job_id="job-2",
+                    event_at=(hour + dt.timedelta(minutes=6)).isoformat().replace("+00:00", "Z"),
+                    completion_tokens=8,
+                ),
+            ]
+            segment.write_text("".join(json.dumps(value) + "\n" for value in values))
+
+            result = processor.run(now=now)
+            self.assertEqual(len(result.processed_hours), 1)
+            jobs = root / f"parquet/jobs/date={hour:%Y-%m-%d}/hour={hour:%H}/jobs.parquet"
+            rollup = root / f"parquet/hourly-rollups/date={hour:%Y-%m-%d}/hour={hour:%H}/rollup.parquet"
+            self.assertTrue(jobs.exists())
+            self.assertTrue(rollup.exists())
+
+            connection = duckdb.connect(":memory:")
+            self.assertEqual(connection.execute(
+                "SELECT count(*), sum(completion_tokens) FROM read_parquet(?)", [str(jobs)]
+            ).fetchone(), (2, 13))
+            self.assertEqual(connection.execute(
+                "SELECT sum(jobs), sum(completion_tokens) FROM read_parquet(?)", [str(rollup)]
+            ).fetchone(), (2, 13))
+
+            rill = root / "rill/models"
+            for name in ("analytics_coverage", "jobs_history", "jobs_live", "jobs_all"):
+                sql = (rill / f"{name}.sql").read_text()
+                connection.execute(f"CREATE VIEW {name} AS {sql}")
+            self.assertEqual(connection.execute("SELECT count(*) FROM jobs_all").fetchone()[0], 2)
+            connection.close()
+
+            second = processor.run(now=now)
+            self.assertEqual(second.processed_hours, result.processed_hours)
+
+    def test_malformed_segment_is_quarantined(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            processor = Processor(ProcessorConfig(root=root))
+            processor.initialize()
+            ready = root / "events/ready/date=2026-08-27"
+            ready.mkdir(parents=True)
+            bad = ready / "bad.jsonl"
+            bad.write_text('{"prompt":"secret"}\n')
+            result = processor.run()
+            self.assertEqual(len(result.quarantined_files), 1)
+            self.assertFalse(bad.exists())
+
+    def test_processes_swift_codable_shape_with_omitted_nil_fields(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            processor = Processor(ProcessorConfig(root=root))
+            processor.initialize()
+            now = dt.datetime.now(dt.UTC).replace(minute=10, second=0, microsecond=0)
+            hour = now.replace(minute=0) - dt.timedelta(hours=1)
+            ready = root / f"events/ready/date={hour:%Y-%m-%d}"
+            ready.mkdir(parents=True)
+            value = event(
+                event_at=(hour + dt.timedelta(minutes=5)).isoformat().replace("+00:00", "Z"),
+                outcome="failed",
+                event_name="inference.failed",
+                error_class="generation",
+            )
+            for key in (
+                "trace_id", "queue_ms", "ttft_ms", "decode_tps",
+                "earned_micro_usd", "kv_backend", "mtp_active",
+            ):
+                value.pop(key)
+            segment = ready / "swift-event.jsonl"
+            segment.write_text(json.dumps(value) + "\n")
+
+            result = processor.run(now=now)
+
+            self.assertEqual(len(result.processed_hours), 1)
+            self.assertEqual(result.quarantined_files, ())
+            jobs = root / f"parquet/jobs/date={hour:%Y-%m-%d}/hour={hour:%H}/jobs.parquet"
+            row = duckdb.connect(":memory:").execute(
+                "SELECT trace_id, queue_ms, kv_backend FROM read_parquet(?)", [str(jobs)]
+            ).fetchone()
+            self.assertEqual(row, (None, None, None))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/analytics/tests/test_schema.py
+++ b/analytics/tests/test_schema.py
@@ -1,0 +1,71 @@
+import unittest
+
+from darkbloom_analytics.schema import ValidationError, validate_event
+
+
+def event(**overrides):
+    value = {
+        "schema_version": 1,
+        "event_id": "event-1",
+        "event_at": "2026-08-27T10:15:00Z",
+        "event_name": "inference.completed",
+        "process_epoch": "process-1",
+        "job_id": "job-1",
+        "trace_id": None,
+        "serving_mode": "local",
+        "model": "gemma-test",
+        "outcome": "success",
+        "error_class": None,
+        "streaming": True,
+        "prompt_tokens": 10,
+        "completion_tokens": 5,
+        "cached_prompt_tokens": 0,
+        "queue_ms": 1.0,
+        "ttft_ms": 20.0,
+        "total_ms": 100.0,
+        "decode_tps": 50.0,
+        "earned_micro_usd": None,
+        "kv_backend": "paged",
+        "mtp_active": False,
+    }
+    value.update(overrides)
+    return value
+
+
+class SchemaTests(unittest.TestCase):
+    def test_accepts_terminal_event(self):
+        parsed = validate_event(event())
+        self.assertEqual(parsed.hour.isoformat(), "2026-08-27T10:00:00+00:00")
+
+    def test_rejects_prompt_content_structurally(self):
+        with self.assertRaisesRegex(ValidationError, "privacy-forbidden"):
+            validate_event(event(prompt="secret"))
+
+    def test_rejects_unbounded_extension(self):
+        with self.assertRaisesRegex(ValidationError, "unknown fields"):
+            validate_event(event(attributes={"anything": "goes"}))
+
+    def test_accepts_swift_omitted_nil_optionals(self):
+        value = event()
+        optional = {
+            "trace_id",
+            "model",
+            "error_class",
+            "queue_ms",
+            "ttft_ms",
+            "decode_tps",
+            "earned_micro_usd",
+            "kv_backend",
+            "mtp_active",
+        }
+        for key in optional:
+            value.pop(key)
+
+        parsed = validate_event(value)
+
+        self.assertTrue(optional.issubset(parsed.value))
+        self.assertTrue(all(parsed.value[key] is None for key in optional))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds an optional, short-lived local analytics processor and a ready-to-run Rill project. The processor validates finalized Darkbloom JSON event segments, quarantines malformed input, writes job-level and hourly aggregate Parquet, maintains a processing watermark, and applies conservative retention defaults.

This PR is independent of the provider implementation in #764. It consumes the proposed v1 local event contract but does not modify or link analytics dependencies into the Darkbloom binary.

The Rill `jobs_all` model combines:

- historical job-level Parquet;
- finalized recent JSON segments newer than the processor watermark; and
- hourly aggregate Parquet for longer-range overview metrics.

This keeps current-hour data visible without double counting records already converted to Parquet.

## Linked issue

Part of #763. Companion provider event-emission PR: #764.

## Test plan

- [x] `make analytics-test` (7 tests)
- [x] Tested Swift `Codable` events with omitted optional fields
- [x] Tested hourly job Parquet, rollups, watermark union, and malformed-input quarantine
- [x] Loaded the generated project with Rill v0.89.2: 9 resources, zero reconciliation errors
- [x] Processed real locally emitted Darkbloom event segments into Parquet
- [x] `git diff --check`

## Components touched

- [ ] coordinator (Go)
- [ ] provider (Rust, legacy)
- [ ] provider-swift (Swift CLI)
- [ ] console-ui (Next.js)
- [ ] enclave (Swift Secure Enclave helper)
- [ ] infra / CI / release
- [x] docs

Also adds the self-contained `analytics/` Python package and three opt-in Make targets.

## Protocol / interface changes

No Darkbloom protocol or runtime interface changes. This tool consumes the local v1 JSON event contract proposed in #764 and writes local Parquet, state, quarantine, launchd, and Rill project files under `~/.darkbloom/analytics`.

## Notes for reviewers

- DuckDB is used only by a short-lived downstream process, never by the inference provider.
- One DuckDB thread and a 256 MiB memory limit bound processor resource use.
- The generated launchd job runs at background priority every five minutes; scheduling remains an explicit operator action.
- Processing is idempotent and missed invocations are harmless.
- Retention defaults are 3 days for finalized JSON, 90 days for job-level Parquet, and unlimited for hourly rollups.
- The first version deliberately uses hourly files only; daily compaction and more elaborate tiering can be added later if measurements justify it.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/765"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790477607&installation_model_id=21733&pr_number=765&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F765&signature=9786f6f62669d4ac8927063327c8e5f6244c3078370777bb0740c93987d81096"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->