### PR TITLE
fix(provider): fold mid-conversation system messages for Qwen3-VL

### DIFF
--- a/provider-swift/Sources/ProviderCore/Inference/Qwen35TemplateFixes.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/Qwen35TemplateFixes.swift
@@ -5,6 +5,13 @@
 // to a conversation history. Fold those turns into one leading system message
 // before Jinja rendering instead of letting the template throw a deterministic
 // "System message must be at the beginning" error.
+//
+// Qwen3-VL (qwen3_vl_moe / qwen3_vl) shares that template contract: its
+// system role is consumed only at messages[0], so a mid-conversation system
+// turn is silently DROPPED from the rendered prompt — multi-system
+// conversations lose the later instruction entirely (the OpenRouter
+// multi-system failure) rather than erroring. The same leading-system fold
+// fixes both families.
 
 import Foundation
 import MLXLMServer
@@ -15,6 +22,7 @@ enum Qwen35TemplateFix {
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .lowercased(),
             modelType == "qwen3_5" || modelType == "qwen3_5_moe"
+                || modelType == "qwen3_vl_moe"
         {
             return true
         }
@@ -26,6 +34,8 @@ enum Qwen35TemplateFix {
             || modelId.contains("qwen3_6")
             || modelId.contains("qwen3.8")
             || modelId.contains("qwen3_8")
+            || modelId.contains("qwen3-vl")
+            || modelId.contains("qwen3_vl")
     }
 
     static func normalizeMessages(

--- a/provider-swift/Tests/ProviderCoreTests/Qwen35TemplateFixesTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/Qwen35TemplateFixesTests.swift
@@ -244,4 +244,97 @@ struct Qwen35TemplateFixesTests {
         #expect(floor == 3)
     }
 
+    // MARK: - Qwen3-VL multi-system regression (OpenRouter failure case)
+    //
+    // Qwen3-VL's chat template consumes a system message only at
+    // messages[0]. A mid-conversation system turn was silently DROPPED from
+    // the rendered prompt, so the model never saw the instruction it was
+    // later asked about. These tests pin the applicability gate and the
+    // merged prompt shape for the exact failing history.
+
+    private let qwen3VLContext = ChatTemplateFixContext(
+        modelId: "qwen3-vl-30b-a3b-instruct",
+        modelType: "qwen3_vl_moe")
+
+    @Test func appliesToQwen3VLMoeModelType() {
+        #expect(Qwen35TemplateFix.applies(to: qwen3VLContext))
+        #expect(Qwen35TemplateFix.applies(
+            to: .init(modelId: nil, modelType: "qwen3_vl_moe")))
+        #expect(Qwen35TemplateFix.applies(
+            to: .init(modelId: "qwen3-vl-30b-a3b-instruct", modelType: nil)))
+        #expect(Qwen35TemplateFix.applies(
+            to: .init(modelId: "EigenLabs/Qwen3.5-35B-A3B-MLX-VL-4bit-g64", modelType: nil)))
+    }
+
+    @Test func qwen3VLMidConversationSystemMessageReachesPrompt() throws {
+        // The exact OpenRouter failing shape: a later system turn carrying an
+        // instruction the model is subsequently asked to recall.
+        let normalized = try ChatTemplateFixes.normalizeMessages(
+            [
+                message("system", "base policy"),
+                message("user", "first question"),
+                message("system", "the secret word is periwinkle"),
+                message("assistant", "first answer"),
+                message("user", "what is the secret word?"),
+            ],
+            context: qwen3VLContext)
+
+        #expect(roles(normalized) == ["system", "user", "assistant", "user"])
+        let systemContent = try #require(normalized[0]["content"] as? String)
+        #expect(systemContent.contains("base policy"))
+        #expect(systemContent.contains("periwinkle"))
+        #expect(
+            systemContent == "base policy\n\nthe secret word is periwinkle",
+            "merged system content must preserve history order and separator")
+        #expect(normalized[1]["content"] as? String == "first question")
+        #expect(normalized[2]["content"] as? String == "first answer")
+        #expect(normalized[3]["content"] as? String == "what is the secret word?")
+    }
+
+    @Test func qwen3VLTypedMessagesPreserveLaterSystemInstruction() {
+        // The multimodal (UserInput) path uses the typed normalizer; vision
+        // requests must not lose a later system instruction either.
+        let normalized = ChatTemplateFixes.normalizeMessages(
+            [
+                .init(role: .system, content: .text("base policy")),
+                .init(role: .user, content: .text("first question")),
+                .init(role: .system, content: .text("the secret word is periwinkle")),
+                .init(role: .assistant, content: .text("first answer")),
+                .init(role: .user, content: .text("what is the secret word?")),
+            ],
+            context: qwen3VLContext)
+
+        #expect(normalized.map(\.role) == [.system, .user, .assistant, .user])
+        #expect(
+            normalized[0].content
+                == .text("base policy\n\nthe secret word is periwinkle"))
+    }
+
+    @Test func qwen3VLNormalizedHistoryPassesLeadingSystemTemplateContract() throws {
+        // End-to-end shape: the model's own Jinja template (mirrored by
+        // QwenSystemFirstTokenizer) rejects a history with a non-leading
+        // system message. Normalization must make the SAME history
+        // acceptable to that contract, and the merged system content must
+        // still carry the later instruction.
+        let raw = [
+            ["role": "user", "content": "question"] as [String: any Sendable],
+            ["role": "system", "content": "the secret word is periwinkle"]
+                as [String: any Sendable],
+        ]
+
+        let tokenizer = QwenSystemFirstTokenizer()
+        #expect(throws: QwenTemplateTestError.systemMessageNotFirst) {
+            _ = try tokenizer.applyChatTemplate(
+                messages: raw, tools: nil, additionalContext: nil)
+        }
+
+        let normalized = try ChatTemplateFixes.normalizeMessages(raw, context: qwen3VLContext)
+        let tokens = try tokenizer.applyChatTemplate(
+            messages: normalized, tools: nil, additionalContext: nil)
+        #expect(tokens == [1, 2, 3])
+        #expect(
+            (normalized[0]["content"] as? String)?.contains("periwinkle") == true,
+            "later system instruction must survive normalization")
+    }
+
 }


### PR DESCRIPTION
## Problem

OpenRouter reported that Qwen3-VL **drops mid-conversation system messages**. A conversation like:

```text
system:  base policy
user:    first question
system:  the secret word is periwinkle
assistant: first answer
user:    what is the secret word?
```

produced an answer where the model had **never seen** the later system instruction — it was silently omitted from the rendered prompt, not a grounding/sampling issue.

### Root cause

Qwen3-VL's chat template consumes a system message only at `messages[0]`. Unlike Qwen 3.5/3.6 (whose template *throws* a deterministic error), Qwen3-VL **silently drops** a later `system` turn.

The repo already ships the correct repair — `Qwen35TemplateFix` folds all system messages into one leading system message — but its applicability gate only matched `qwen3_5_moe` / `qwen3.5` / `qwen3.6` model IDs, so Qwen3-VL requests bypassed normalization entirely.

## Fix

Extend `Qwen35TemplateFix.applies(to:)` in `provider-swift/Sources/ProviderCore/Inference/Qwen35TemplateFixes.swift` to recognize Qwen3-VL:

- `model_type` `qwen3_vl_moe`
- model IDs containing `qwen3-vl` / `qwen3_vl`

Both normalization entry points pick this up automatically:

- **Dictionary/Jinja path** — `ChatTemplateFixes.normalizeMessages([String: any Sendable])` (text requests, tokenize endpoint, prompt floor)
- **Typed multimodal path** — `ChatTemplateFixes.normalizeMessages([OpenAIChatMessage])` (vision/video requests before `UserInput` construction)

The existing `LeadingSystemMessageNormalizer` (dictionary path) and typed merge (multimodal path) then fold all system turns into `messages[0]`, joined with `\n\n` in history order, preserving user/assistant turns untouched.

## Before / After

```mermaid
flowchart LR
  subgraph Before
    A1[request with system → user → system → assistant → user] --> B1[Qwen35TemplateFix.applies?]
    B1 -->|model_type = qwen3_vl_moe| C1[false — normalization skipped]
    C1 --> D1[Qwen3-VL Jinja template]
    D1 --> E1[only messages[0] system rendered]
    E1 --> F1[❌ later system instruction DROPPED]
  end
  subgraph After
    A2[request with system → user → system → assistant → user] --> B2[Qwen35TemplateFix.applies?]
    B2 -->|model_type = qwen3_vl_moe| C2[true — normalization runs]
    C2 --> D2[fold all system turns into one leading system message]
    D2 --> E2[Qwen3-VL Jinja template]
    E2 --> F2[✅ every instruction reaches the model]
  end
```

### Code flow

```mermaid
flowchart LR
  subgraph Before
    M1[OpenAI request] --> N1[ChatTemplateFixes.normalizeMessages]
    N1 --> G1[Qwen35TemplateFix.applies gate]
    G1 -->|qwen3_5_moe only| H1[return messages unchanged]
    H1 --> I1[tokenizer.applyChatTemplate]
    I1 --> J1[system[1+] silently dropped by template]
  end
  subgraph After
    M2[OpenAI request] --> N2[ChatTemplateFixes.normalizeMessages]
    N2 --> G2[Qwen35TemplateFix.applies gate]
    G2 -->|qwen3_5_moe OR qwen3_vl_moe| H2[LeadingSystemMessageNormalizer / typed merge]
    H2 --> I2[tokenizer.applyChatTemplate]
    I2 --> J2[one leading system message with all instructions]
  end
```

## Regression coverage

Four new tests in `provider-swift/Tests/ProviderCoreTests/Qwen35TemplateFixesTests.swift`:

1. **`appliesToQwen3VLMoeModelType`** — pins the applicability gate for `qwen3_vl_moe` and Qwen3-VL model IDs
2. **`qwen3VLMidConversationSystemMessageReachesPrompt`** — the exact OpenRouter failing history (dict path); asserts role order, merged content with `\n\n` separator, and untouched user/assistant turns
3. **`qwen3VLTypedMessagesPreserveLaterSystemInstruction`** — same history through the typed multimodal path
4. **`qwen3VLNormalizedHistoryPassesLeadingSystemTemplateContract`** — proves the *unnormalized* history is rejected by a leading-system-only template contract (mirroring the model's own Jinja template) and that the normalized history passes while preserving the later instruction

## Verification

- `swift test --filter Qwen35TemplateFixesTests` → **15/15 passed** (11 pre-existing + 4 new)
- `make provider-test` → **2255 tests in 233 suites passed**
- `make provider-build` → complete

## Notes

- **Provider release required** for production effect — the fix is provider-side; the coordinator alone cannot repair what existing provider binaries render.
- No coordinator changes needed.
- Out of scope: the base64 JPEG vision issue (separate failure case; still under investigation with the exact fixture).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/773"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790551835&installation_model_id=21733&pr_number=773&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F773&signature=3b8b0a37f8be8aa6f93235f81f03051bf89144246baa634b80ae5ed0715560af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->