### PR TITLE
Remove MDA nonce binding check from provider UI

### DIFF
--- a/console-ui/src/app/providers/dashboard/AttestationPanel.test.tsx
+++ b/console-ui/src/app/providers/dashboard/AttestationPanel.test.tsx
@@ -1,0 +1,20 @@
+// @vitest-environment jsdom
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { AttestationPanel } from "./AttestationPanel";
+import { makeProvider } from "./testFixtures";
+
+describe("AttestationPanel", () => {
+  it("does not treat MDA nonce binding as a Secure Enclave requirement", () => {
+    const { container } = render(
+      <AttestationPanel
+        provider={makeProvider({ se_key_bound: false })}
+        challengeMaxAgeSeconds={360}
+      />,
+    );
+
+    expect(screen.queryByText("SE key bound to MDA nonce")).not.toBeInTheDocument();
+    expect(screen.getByText("Hardware-bound P-256 identity")).toBeInTheDocument();
+    expect(container.querySelector(".text-accent-amber")).toBeNull();
+  });
+});

--- a/console-ui/src/app/providers/dashboard/AttestationPanel.tsx
+++ b/console-ui/src/app/providers/dashboard/AttestationPanel.tsx
@@ -67,7 +67,6 @@ export function AttestationPanel({
 }) {
   // Each chain link is "ok" only when all of its sub-checks pass; the spine
   // renders green up to the first broken link so the gap is obvious.
-  const enclaveOK = p.secure_enclave && p.se_key_bound;
   const osOK = p.sip_enabled && p.secure_boot_enabled && p.authenticated_root_enabled && p.runtime_verified;
   const mdmOK = p.trust_level === "hardware";
 
@@ -85,9 +84,8 @@ export function AttestationPanel({
 
   return (
     <div>
-      <ChainNode ok={enclaveOK} title="Secure Enclave">
+      <ChainNode ok={p.secure_enclave} title="Secure Enclave">
         <CheckLine ok={p.secure_enclave} label="Hardware-bound P-256 identity" />
-        <CheckLine ok={p.se_key_bound} label="SE key bound to MDA nonce" />
       </ChainNode>
 
       <ChainNode ok={osOK} title="OS security">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Remove the obsolete `SE key bound to MDA nonce` row from the provider attestation panel. Secure Enclave UI status now reflects only the hardware-bound P-256 identity, so an absent nonce binding no longer shows a false failure.

## Before

```mermaid
flowchart LR
  A1[Provider trust response] --> B1[AttestationPanel]
  B1 --> C1[secure_enclave AND se_key_bound]
  C1 --> D1[Secure Enclave chain status]
  B1 --> E1[Render MDA nonce binding row]
  E1 --> F1[Absent binding shown as failure]
```

## After

```mermaid
flowchart LR
  A2[Provider trust response] --> B2[AttestationPanel]
  B2 --> C2[secure_enclave]
  C2 --> D2[Secure Enclave chain status]
  B2 --> E2[Render hardware-bound P-256 identity only]
  F2[se_key_bound] --> G2[Ignored by frontend presentation]
```

## Linked issue

N/A

## Test plan

- [x] `npm test -- src/app/providers/dashboard/AttestationPanel.test.tsx` — 1 test passed
- [x] `npm test` — 57 files / 491 tests passed
- [x] `npx eslint src/app/providers/dashboard/AttestationPanel.tsx src/app/providers/dashboard/AttestationPanel.test.tsx`
- [x] `npm run build`
- [x] Browser walkthrough with `se_key_bound=false`: Secure Enclave stays green and the nonce row is absent

## Walkthrough

[Provider attestation panel without the MDA nonce binding row](https://cursor.com/agents/bc-63584f01-96e6-592d-8dc1-08c429c44e1b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmda_nonce_check_removed_green.webp)

[mda_nonce_check_removed_green.mp4](https://cursor.com/agents/bc-63584f01-96e6-592d-8dc1-08c429c44e1b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmda_nonce_check_removed_green.mp4)

## Components touched

- [ ] coordinator (Go)
- [ ] provider (Rust, legacy)
- [ ] provider-swift (Swift CLI)
- [x] console-ui (Next.js)
- [ ] enclave (Swift)
- [ ] infra / CI / release
- [ ] docs

## Protocol / interface changes

- [x] No protocol/interface changes
- [ ] Yes — described above and matching side updated

## Notes for reviewers

The API field remains in the frontend response type for wire compatibility; it is no longer a displayed or aggregate UI requirement. Two independent reviews passed with no blocking findings.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://darkbloom.slack.com/archives/C0B0JMULP3L/p1787973448541089?thread_ts=1787973448.541089&cid=C0B0JMULP3L)

<div><a href="https://cursor.com/agents/bc-63584f01-96e6-592d-8dc1-08c429c44e1b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-63584f01-96e6-592d-8dc1-08c429c44e1b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/776"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790566483&installation_model_id=21733&pr_number=776&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F776&signature=30e15071843912aab5a6c630dc0eb26f355ff4170014e3cd4b3bdb02551de46f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->