### PR TITLE
feat(console-ui): add North Macedonia (MK) to the Stripe Connect payout country list

### DIFF
--- a/console-ui/src/lib/stripe-countries.test.ts
+++ b/console-ui/src/lib/stripe-countries.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { STRIPE_CONNECT_COUNTRIES } from "./stripe-countries";
+
+const flagFor = (code: string) =>
+  String.fromCodePoint(...[...code].map((c) => 0x1f1e6 + c.charCodeAt(0) - 65));
+
+describe("STRIPE_CONNECT_COUNTRIES", () => {
+  it("includes North Macedonia (issue #695)", () => {
+    const mk = STRIPE_CONNECT_COUNTRIES.find((c) => c.code === "MK");
+    expect(mk).toBeDefined();
+    expect(mk!.name).toBe("North Macedonia");
+    expect(mk!.flag).toBe(flagFor("MK"));
+  });
+
+  it("has unique ISO 3166-1 alpha-2 codes", () => {
+    const codes = STRIPE_CONNECT_COUNTRIES.map((c) => c.code);
+    expect(new Set(codes).size).toBe(codes.length);
+  });
+
+  it("uses well-formed uppercase two-letter codes", () => {
+    for (const c of STRIPE_CONNECT_COUNTRIES) {
+      expect(c.code).toMatch(/^[A-Z]{2}$/);
+    }
+  });
+
+  it("stays sorted by code so additions land in a predictable place", () => {
+    const codes = STRIPE_CONNECT_COUNTRIES.map((c) => c.code);
+    expect(codes).toEqual([...codes].sort());
+  });
+
+  it("carries the flag emoji that matches each code", () => {
+    for (const c of STRIPE_CONNECT_COUNTRIES) {
+      expect(c.flag).toBe(flagFor(c.code));
+    }
+  });
+});

--- a/console-ui/src/lib/stripe-countries.ts
+++ b/console-ui/src/lib/stripe-countries.ts
@@ -4,6 +4,12 @@ export interface StripeCountry {
   flag: string;
 }
 
+// Countries Stripe lists as available for Express connected accounts, sorted by
+// ISO 3166-1 alpha-2 code. Check a code against Stripe's list before adding a
+// row here: https://docs.stripe.com/connect/accounts#availability-of-express-connected-accounts
+// Countries outside the US/CA/UK/EEA/CH transfer region are routed to the
+// `recipient` service agreement by the coordinator (see
+// coordinator/billing/stripe_regions.go), not by anything in this file.
 export const STRIPE_CONNECT_COUNTRIES: StripeCountry[] = [
   { code: "AE", name: "United Arab Emirates", flag: "\u{1F1E6}\u{1F1EA}" },
   { code: "AT", name: "Austria", flag: "\u{1F1E6}\u{1F1F9}" },
@@ -35,6 +41,7 @@ export const STRIPE_CONNECT_COUNTRIES: StripeCountry[] = [
   { code: "LT", name: "Lithuania", flag: "\u{1F1F1}\u{1F1F9}" },
   { code: "LU", name: "Luxembourg", flag: "\u{1F1F1}\u{1F1FA}" },
   { code: "LV", name: "Latvia", flag: "\u{1F1F1}\u{1F1FB}" },
+  { code: "MK", name: "North Macedonia", flag: "\u{1F1F2}\u{1F1F0}" },
   { code: "MT", name: "Malta", flag: "\u{1F1F2}\u{1F1F9}" },
   { code: "MX", name: "Mexico", flag: "\u{1F1F2}\u{1F1FD}" },
   { code: "MY", name: "Malaysia", flag: "\u{1F1F2}\u{1F1FE}" },

--- a/coordinator/billing/stripe_regions_test.go
+++ b/coordinator/billing/stripe_regions_test.go
@@ -40,6 +40,7 @@ func TestRequiredServiceAgreement(t *testing.T) {
 		{"US", "MX", ServiceAgreementRecipient},
 		{"US", "BR", ServiceAgreementRecipient},
 		{"US", "IN", ServiceAgreementRecipient},
+		{"US", "MK", ServiceAgreementRecipient}, // North Macedonia: EU candidate, not EEA (#695)
 		// Case-insensitive: the platform country comes from configuration
 		// (EIGENINFERENCE_STRIPE_CONNECT_COUNTRY) and may be lowercase; a
 		// missed match would create US/EEA accounts as recipient.
@@ -93,7 +94,7 @@ func TestCreateExpressAccountFullAgreementForm(t *testing.T) {
 }
 
 func TestCreateExpressAccountRecipientAgreementForm(t *testing.T) {
-	for _, country := range []string{"AU", "NZ", "JP"} {
+	for _, country := range []string{"AU", "NZ", "JP", "MK"} {
 		form := captureAccountCreate(t, country)
 		if got := form.Get("tos_acceptance[service_agreement]"); got != "recipient" {
 			t.Errorf("%s: service_agreement = %q, want recipient", country, got)


### PR DESCRIPTION
## Summary

Adds North Macedonia (`MK`) to the payout country picker. Stripe lists MK for Express accounts, and `RequiredServiceAgreement` already returns `recipient` for it (MK isn't in `fullTransferRegion`), so this is picker-only.

## Linked issue

Closes #695

## Test plan

- `cd console-ui && npx vitest run`: 495 tests pass. New `src/lib/stripe-countries.test.ts` pins MK and guards the list against duplicate codes, malformed codes, a row inserted out of order, and a flag that doesn't match its code.
- `cd console-ui && npx eslint src/`: clean.
- `cd coordinator && go test ./billing/... ./api/...`: pass. MK added to `TestRequiredServiceAgreement` and to `TestCreateExpressAccountRecipientAgreementForm`.
- No screenshot, it's one more row between Latvia and Malta.

## Components touched

- [x] coordinator (Go), tests only
- [ ] provider (Rust, legacy)
- [ ] provider-swift (Swift CLI)
- [x] console-ui (Next.js)
- [ ] enclave (Swift)
- [ ] infra / CI / release
- [ ] docs

## Protocol / interface changes

- [x] No protocol/interface changes

## Notes for reviewers

Same shape as #684, so worth confirming MK is in the platform's approved CBP set before this merges. If it isn't, the failure just moves from the picker to a 502 at onboard.

Also added a comment above `STRIPE_CONNECT_COUNTRIES` pointing at Stripe's availability list, since there was nothing saying where the list came from.
