### PR TITLE
feat(build): generate entitlements plists from templates with a configurable Team ID

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ jobs:
           ./scripts/check-release-version.sh
           ./scripts/sync-install-embed.sh check
           ./scripts/test-prod-env-refresh.sh
+          ./scripts/generate-entitlements.sh check
+          ./scripts/test-entitlements-generation.sh
 
   test-coordinator:
     name: Coordinator Tests

--- a/docs/developer/build.md
+++ b/docs/developer/build.md
@@ -27,6 +27,21 @@ make provider-test            # cd provider-swift && swift test
 make provider                 # build + test
 ```
 
+### Custom Apple Team ID
+
+The signed provider embeds Eigen Labs' Team ID (`SLDQ2GJ6TL`) in its keychain access group and
+application identifier. To build and sign under your own Apple Developer account, regenerate the
+entitlements from their templates before signing:
+
+```bash
+TEAM_ID=YOURTEAMID ./scripts/generate-entitlements.sh
+```
+
+`APPLE_TEAM_ID` is honoured as a fallback. Edit `*.plist.template`, never the generated `*.plist` —
+CI fails the **Release Integrity** check if the two drift apart. Note that the official release
+workflow (`.github/workflows/release-swift.yml`) still pins `SLDQ2GJ6TL` in its provisioning-profile
+and signature gates; a custom Team ID is for local and fork builds.
+
 ## Console UI (Next.js 16)
 
 ```bash

--- a/provider-swift/entitlements.plist.template
+++ b/provider-swift/entitlements.plist.template
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.application-identifier</key>
+    <string>${TEAM_ID}.io.darkbloom.provider</string>
+    <!-- v0.6.0 APNs code-identity attestation. Restricted entitlement: the
+         embedded provisioning profile MUST authorize it or AMFI Killed:9 at
+         launch. CI (release-swift.yml) guards both the profile grant and the
+         signed-binary value so the entitlement never ships without a push profile. -->
+    <key>com.apple.developer.aps-environment</key>
+    <string>production</string>
+    <key>com.apple.security.network.client</key>
+    <true/>
+    <key>com.apple.security.network.server</key>
+    <true/>
+    <key>keychain-access-groups</key>
+    <array>
+        <string>${TEAM_ID}.io.darkbloom.provider</string>
+    </array>
+</dict>
+</plist>

--- a/scripts/entitlements.plist.template
+++ b/scripts/entitlements.plist.template
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!-- NO get-task-allow → blocks debugger attachment under Hardened Runtime -->
+    <key>com.apple.security.network.client</key>
+    <true/>
+    <key>com.apple.security.network.server</key>
+    <true/>
+    <!--
+      Keychain access for E2E key storage.
+      Team prefix is hardcoded because codesign (our release flow) does NOT
+      expand $(AppIdentifierPrefix) — that's an Xcode-only build variable.
+      A literal unexpanded macro gets baked into the entitlements blob and
+      keychain writes fail with errSecMissingEntitlement (-34018).
+      Format per Apple docs: "TEAMID.identifier".
+    -->
+    <key>com.apple.security.keychain-access-groups</key>
+    <array>
+        <string>${TEAM_ID}.io.darkbloom.provider</string>
+    </array>
+</dict>
+</plist>

--- a/scripts/generate-entitlements.sh
+++ b/scripts/generate-entitlements.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/.." && pwd)
+TEAM_ID="${TEAM_ID:-${APPLE_TEAM_ID:-SLDQ2GJ6TL}}"
+PAIRS=(scripts/entitlements.plist provider-swift/entitlements.plist)
+
+# Apple Team IDs are 10 uppercase alphanumerics. The check also guarantees the value
+# carries no XML metacharacters, so sed cannot produce a malformed plist.
+[[ "$TEAM_ID" =~ ^[A-Z0-9]{10}$ ]] || {
+    echo "invalid TEAM_ID '${TEAM_ID}': expected 10 uppercase alphanumerics" >&2
+    exit 64
+}
+
+render() {  # render <template> <dest>
+    local tmp="$2.tmp.$$"
+    trap 'rm -f "$tmp"' EXIT
+    sed "s/\${TEAM_ID}/$TEAM_ID/g" "$1" > "$tmp"
+    chmod 0644 "$tmp"
+    mv "$tmp" "$2"
+    trap - EXIT
+}
+
+case "${1:-write}" in
+    write)
+        for dest in "${PAIRS[@]}"; do render "$ROOT/$dest.template" "$ROOT/$dest"; done
+        ;;
+    check)
+        for dest in "${PAIRS[@]}"; do
+            tmp=$(mktemp); trap 'rm -f "$tmp"' EXIT
+            sed "s/\${TEAM_ID}/$TEAM_ID/g" "$ROOT/$dest.template" > "$tmp"
+            if ! cmp -s "$tmp" "$ROOT/$dest"; then
+                echo "$dest drifted from $dest.template; edit the template, then run scripts/generate-entitlements.sh" >&2
+                diff -u "$ROOT/$dest" "$tmp" >&2 || true
+                exit 1
+            fi
+            rm -f "$tmp"; trap - EXIT
+        done
+        ;;
+    *)
+        echo "usage: $0 [write|check]" >&2
+        exit 64
+        ;;
+esac
+
+echo "entitlements: TEAM_ID=$TEAM_ID"

--- a/scripts/test-entitlements-generation.sh
+++ b/scripts/test-entitlements-generation.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+set -euo pipefail
+ROOT=$(cd "$(dirname "$0")/.." && pwd)
+cd "$ROOT"
+PLISTS=(scripts/entitlements.plist provider-swift/entitlements.plist)
+GEN=scripts/generate-entitlements.sh
+
+# `! cmd` is exempt from `set -e`, so a negated assertion never fails the script.
+# Assert absence through this helper instead.
+refute() { if "$@"; then echo "FAIL: expected non-zero from: $*" >&2; exit 1; fi; }
+
+# Never clobber a developer's in-progress edits; the restore below is a hard checkout.
+git diff --quiet -- "${PLISTS[@]}" || { echo "entitlements plists have uncommitted changes; commit or stash first" >&2; exit 1; }
+trap 'git checkout -- "${PLISTS[@]}"' EXIT
+
+# 1. both vars unset -> byte-identical to what is committed
+env -u TEAM_ID -u APPLE_TEAM_ID "$GEN"
+git diff --quiet -- "${PLISTS[@]}"
+
+# 2. empty values fall back to the default: an unset Actions variable must not break a release
+TEAM_ID= APPLE_TEAM_ID= "$GEN"
+git diff --quiet -- "${PLISTS[@]}"
+
+# 3. APPLE_TEAM_ID alone is honoured (release-swift.yml exports exactly this)
+env -u TEAM_ID APPLE_TEAM_ID=TEST123456 "$GEN"
+grep -q 'TEST123456\.io\.darkbloom\.provider' scripts/entitlements.plist
+
+# 4. TEAM_ID wins, rewrites every occurrence, touches nothing else
+TEAM_ID=ZZZZ999999 APPLE_TEAM_ID=TEST123456 "$GEN"
+for f in "${PLISTS[@]}"; do
+  refute grep -q SLDQ2GJ6TL "$f"
+  refute grep -qF '${TEAM_ID}' "$f"
+done
+[ "$(grep -c 'ZZZZ999999\.io\.darkbloom\.provider' scripts/entitlements.plist)" = 1 ]
+[ "$(grep -c 'ZZZZ999999\.io\.darkbloom\.provider' provider-swift/entitlements.plist)" = 2 ]
+[ "$(git diff --numstat -- scripts/entitlements.plist | cut -f1,2)" = "$(printf '1\t1')" ]
+[ "$(git diff --numstat -- provider-swift/entitlements.plist | cut -f1,2)" = "$(printf '2\t2')" ]
+
+# 5. output parses as a plist and the entitlement values really carry the new prefix
+command -v plutil >/dev/null && plutil -lint "${PLISTS[@]}"
+python3 - "${PLISTS[@]}" <<'PYCHECK'
+import plistlib, sys
+want = {
+  'scripts/entitlements.plist': ['com.apple.security.keychain-access-groups'],
+  'provider-swift/entitlements.plist': ['com.apple.application-identifier', 'keychain-access-groups'],
+}
+for p in sys.argv[1:]:
+    with open(p, 'rb') as fh:
+        d = plistlib.load(fh)
+    for k in want[p]:
+        v = d[k]
+        v = v if isinstance(v, str) else v[0]
+        assert v == 'ZZZZ999999.io.darkbloom.provider', (p, k, v)
+PYCHECK
+
+# 6. malformed IDs are rejected and leave the tree untouched
+git checkout -- "${PLISTS[@]}"
+for bad in short sldq2gj6tl SLDQ2GJ6TL.io "AB CD123456" 'A$(id)BCDEFGH'; do
+  refute env TEAM_ID="$bad" "$GEN"
+done
+git diff --quiet -- "${PLISTS[@]}"
+
+# 7. check mode: green on a clean tree, red on drift
+"$GEN" check
+printf '\n' >> provider-swift/entitlements.plist
+refute "$GEN" check
+git checkout -- "${PLISTS[@]}"
+
+echo "entitlements generation: OK"


### PR DESCRIPTION
## Summary

Both entitlements plists hardcode the Apple Team ID `SLDQ2GJ6TL`, so anyone building under their own Developer ID has to hand-edit tracked XML. `scripts/generate-entitlements.sh` renders them from new `.plist.template` files, taking the ID from `TEAM_ID`, then `APPLE_TEAM_ID`, then `SLDQ2GJ6TL`. The generated plists stay tracked and are byte-identical at the default, so release signing inputs don't move.

It follows the write/check shape of `scripts/sync-install-embed.sh`, so the existing Release Integrity job picks up a drift gate without a new job or repo variable.

## Linked issue

Closes #714

## Test plan

- `./scripts/test-entitlements-generation.sh`: passes. Covers both vars unset (output byte-identical to what's committed), empty values falling back to the default, `APPLE_TEAM_ID` alone, `TEAM_ID` winning over it, exactly 1 and 2 substitutions with `git diff --numstat` proving no other line moved, `plistlib` parsing the result and reading back the new prefix, five malformed IDs rejected with the tree untouched, and `check` mode green on a clean tree then red after a one-byte edit.
- `./scripts/generate-entitlements.sh check`: passes.
- `actionlint .github/workflows/ci.yml`: clean.
- Ran the full Release Integrity step locally in order — `check-release-version.sh`, `sync-install-embed.sh check`, `test-prod-env-refresh.sh`, then the two new commands: all pass.
- `git show --stat HEAD` lists neither `entitlements.plist`, which is the byte-identity claim: 6 files, +177/-0.
- Mutation-checked the test against deliberately broken generators — rendering only one plist, dropping the regex validation, and a `check` mode that always returns green are each caught.

## Components touched

- [ ] coordinator (Go)
- [ ] provider (Rust, legacy)
- [ ] provider-swift (Swift CLI)
- [ ] console-ui (Next.js)
- [ ] enclave (Swift)
- [x] infra / CI / release
- [x] docs

## Protocol / interface changes

- [x] No protocol/interface changes

## Notes for reviewers

`release-swift.yml` is deliberately untouched. It pins `SLDQ2GJ6TL` in `DEVELOPER_ID` (line 62), the provisioning-profile gate (375-387) and the signed-binary access-group check (560), so a custom Team ID can't survive that pipeline anyway. Wiring a repo variable into the signing step would advertise portability CI can't deliver; this change targets local and fork builds, and `docs/developer/build.md` says so. Making the release workflow genuinely team-agnostic is a larger change if you want it.

Worth knowing: nothing reads `scripts/entitlements.plist`. Only `provider-swift/entitlements.plist` reaches `codesign` (536, 540) — the `scripts/` copy is referenced solely by the layout trees in `AGENTS.md` and `CLAUDE.md`. I templated it anyway since the issue names it and to keep the two from diverging, but it may just be dead from the Rust-era build and worth deleting separately.

The regex `^[A-Z0-9]{10}$` doubles as the injection guard — it's what lets the `sed` substitution assume no XML metacharacters, so `TEAM_ID='A$(id)BCDEFGH'` is rejected before it reaches the template.

https://claude.ai/code/session_01HZFvxCLuWjU12SQSS6VMhU

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/780"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790632387&installation_model_id=21733&pr_number=780&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F780&signature=287ff438c8094377792e0674b606e855e39d06a8ab516ba0c9fba7f9d4c0e700"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->