### PR TITLE
fix(registry): keep Qwen3-VL vision off M5

### DIFF
--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -2902,6 +2902,8 @@ func (r *Registry) providerServesOwnedRoutableModelLocked(p *Provider, model str
 	return false
 }
 
+const qwen3VL30BA3BInstructModelID = "qwen3-vl-30b-a3b-instruct"
+
 // providerServesVisionModelLocked reports whether the provider advertises the
 // model as a vision-capable (VLM) build — required to route image/video requests
 // so the media is actually perceived rather than silently dropped. allowOffCatalog
@@ -2920,14 +2922,18 @@ func (r *Registry) providerServesVisionModelLocked(p *Provider, model string, al
 			continue
 		}
 		if allowOffCatalog {
-			if r.modelServableForOwnerLocked(p, m) {
-				return true
+			if !r.modelServableForOwnerLocked(p, m) {
+				continue
 			}
+		} else if !r.providerModelAllowedByCatalogLocked(p, m) {
 			continue
 		}
-		if r.providerModelAllowedByCatalogLocked(p, m) {
-			return true
+		if model == qwen3VL30BA3BInstructModelID &&
+			strings.EqualFold(strings.TrimSpace(p.Hardware.ChipFamily), "M5") {
+			// This concrete VLM produces incorrect visual inference on M5.
+			return false
 		}
+		return true
 	}
 	return false
 }

--- a/coordinator/registry/scheduler_routing_gates_test.go
+++ b/coordinator/registry/scheduler_routing_gates_test.go
@@ -184,6 +184,107 @@ func TestQuickCapacityCheckForRequestRequiresVision(t *testing.T) {
 	}
 }
 
+func TestQwen3VL30BVisionRoutingExcludesM5(t *testing.T) {
+	const targetModel = "qwen3-vl-30b-a3b-instruct"
+
+	tests := []struct {
+		name                 string
+		model                string
+		chipFamily           string
+		requiresVision       bool
+		wantCandidates       int
+		wantVisionRejections int
+	}{
+		{
+			name:                 "target M5 visual rejected",
+			model:                targetModel,
+			chipFamily:           "M5",
+			requiresVision:       true,
+			wantVisionRejections: 1,
+		},
+		{
+			name:           "target M5 text eligible",
+			model:          targetModel,
+			chipFamily:     "M5",
+			wantCandidates: 1,
+		},
+		{
+			name:           "target M4 visual eligible",
+			model:          targetModel,
+			chipFamily:     "M4",
+			requiresVision: true,
+			wantCandidates: 1,
+		},
+		{
+			name:           "lookalike M5 visual eligible",
+			model:          targetModel + "-lookalike",
+			chipFamily:     "M5",
+			requiresVision: true,
+			wantCandidates: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reg := New(testLogger())
+			provider := makeSchedulerProvider(t, reg, "provider", tt.model, 100)
+			provider.mu.Lock()
+			provider.Models[0].IsVision = true
+			provider.Hardware.ChipFamily = tt.chipFamily
+			provider.mu.Unlock()
+
+			candidates, capacityRejections, tooLarge := reg.QuickCapacityCheckForRequest(
+				tt.model, 100, 128, RequestTraits{}, tt.requiresVision,
+			)
+			if candidates != tt.wantCandidates || capacityRejections != 0 || tooLarge != 0 {
+				t.Errorf(
+					"QuickCapacityCheckForRequest = (cand=%d cap=%d tooLarge=%d), want (%d,0,0)",
+					candidates, capacityRejections, tooLarge, tt.wantCandidates,
+				)
+			}
+
+			request := &PendingRequest{
+				RequestID:             "request",
+				Model:                 tt.model,
+				EstimatedPromptTokens: 100,
+				RequestedMaxTokens:    128,
+				RequiresVision:        tt.requiresVision,
+			}
+			selected, decision := reg.ReserveProviderEx(tt.model, request)
+			if selected != nil {
+				defer func() {
+					selected.RemovePending(request.RequestID)
+					reg.SetProviderIdle(selected.ID)
+				}()
+			}
+
+			if tt.wantCandidates == 0 {
+				if selected != nil {
+					t.Errorf("ReserveProviderEx selected %q, want nil", selected.ID)
+				}
+			} else if selected == nil || selected.ID != provider.ID {
+				t.Errorf("ReserveProviderEx selected %v, want %q", selected, provider.ID)
+			}
+			if decision.CandidateCount != tt.wantCandidates {
+				t.Errorf("CandidateCount=%d, want %d", decision.CandidateCount, tt.wantCandidates)
+			}
+			if decision.VisionRejections != tt.wantVisionRejections ||
+				decision.CapacityRejections != 0 ||
+				decision.ModelTooLargeRejections != 0 ||
+				decision.TTFTRejections != 0 {
+				t.Errorf(
+					"rejections = (vision=%d cap=%d tooLarge=%d ttft=%d), want (%d,0,0,0)",
+					decision.VisionRejections,
+					decision.CapacityRejections,
+					decision.ModelTooLargeRejections,
+					decision.TTFTRejections,
+					tt.wantVisionRejections,
+				)
+			}
+		})
+	}
+}
+
 func TestQuickCapacityCheckExcludesCriticalThermal(t *testing.T) {
 	reg := New(testLogger())
 	model := "critical-thermal-preflight"


### PR DESCRIPTION
## Summary

- Image and video requests for the exact concrete model `qwen3-vl-30b-a3b-instruct` now exclude providers whose canonical `ChipFamily` is M5.
- Text-only requests remain eligible for M5 because they bypass the visual gate.
- M4 providers and lookalike model IDs remain unaffected.

## Reason

Production canaries showed correct M1 Qwen3-VL visual inference and deterministic incorrect M5 visual output across multiple resolutions and formats. This is a narrow correctness fence pending MLX/NAX repair.

## Before

```mermaid
flowchart LR
  subgraph Behavior["Behavior"]
    B1["Qwen3-VL image or video request"] --> B2["M5 candidate could be selected"]
    B2 --> B3["Corrupted or hallucinated visual output"]
  end
  subgraph Code["Code"]
    C1["Shared routing callers"] --> C2["providerServesVisionModelLocked"]
    C2 --> C3["IsVision, catalog, and hash checks pass"]
    C3 --> C4["Return true"]
  end
```

## After

```mermaid
flowchart LR
  subgraph Behavior["Behavior"]
    B1["Exact target plus M5 visual request"] --> B2["Vision rejection"]
    B2 --> B3["Safe non-M5 candidate can route"]
    B4["Text-only request"] --> B5["Bypass visual gate"]
    B5 --> B6["M5 remains eligible"]
  end
  subgraph Code["Code"]
    C1["All shared routing callers"] --> C2["providerServesVisionModelLocked"]
    C2 --> C3["IsVision, catalog, and hash checks pass"]
    C3 --> C4{"Exact target and canonical M5?"}
    C4 -- "Yes" --> C5["Return false"]
    C4 -- "No" --> C6["Return true"]
  end
```

## Testing

- New regression: `go test ./coordinator/registry -run '^TestQwen3VL30BVisionRoutingExcludesM5$' -count=1 -v` — PASS, including exact-target M5 visual rejection, M5 text eligibility, M4 visual eligibility, and M5 lookalike visual eligibility.
- Adjacent visual routing: `go test ./coordinator/registry -run '^(TestVisionRoutingHelpers|TestQuickCapacityCheckForRequestRequiresVision|TestCapacityCooldownPreflightVisionExcludesTextOnlyCooledPairs|TestSelfRouteVisionRoutesToOwnedOffCatalogVLM)$' -count=1 -v` — PASS.
- Adjacent cold-spill routing: `go test ./coordinator/registry -run '^TestColdSpillProviders' -count=1 -v` — PASS.
- Registry package: `go test ./coordinator/registry -count=1` — PASS (`ok github.com/eigeninference/d-inference/coordinator/registry 1.528s`).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/781"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790643801&installation_model_id=21733&pr_number=781&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F781&signature=085a48ce47fd282ddd64efb3395d0ad5696fe5f14cbae1727a3f211f86d7c833"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->