### PR TITLE
docs(provider): clarify 503 error, preload timeout, and --local vs --…

### DIFF
--- a/docs/provider/direct-mode.md
+++ b/docs/provider/direct-mode.md
@@ -30,6 +30,13 @@ darkbloom start --local-endpoint                 # coordinator + local on :8000
 darkbloom start --local-endpoint --port 8080 --bind 100.x.y.z
 ```
 
+> **Which flag should I use?**
+> - Use `--local` if you only need a private local API (no coordinator, no
+>   earnings, works offline). Ideal for testing or personal use.
+> - Use `--local-endpoint` if you want to **earn** from the public fleet
+>   **and** keep a local endpoint on the same Mac. The model loads once and
+>   serves both the coordinator and your local requests.
+
 `--local` runs the OpenAI server **only** (no coordinator connection).
 `--local-endpoint` runs it **alongside** the coordinator connection. Both mint a
 persistent bearer token (`~/.darkbloom/local_token`, `0600`); `--local` also

--- a/docs/provider/quickstart.md
+++ b/docs/provider/quickstart.md
@@ -161,6 +161,13 @@ end = "08:00"
 - `backend.enabled_models` — if non-empty, only these models are advertised.
 - `backend.idle_timeout_mins` — minutes of inactivity before an idle model is
   unloaded (default 60; 0 disables eviction).
+- `backend.startup_preload_timeout_secs` — seconds to wait for the model to
+  load into GPU memory on startup (default 120). Large models (20 GB+) can
+  take 3–4 minutes to load, so bump this to 300 if your model fails to warm:
+  ```toml
+  [backend]
+  startup_preload_timeout_secs = 300
+  ```
 - `backend.max_model_slots` — maximum resident models at once (default 3).
 - `config_version` — schema version of this file, written automatically on
   first start after upgrading. It only dates the file, so the provider can

--- a/docs/provider/troubleshooting.md
+++ b/docs/provider/troubleshooting.md
@@ -174,6 +174,33 @@ the new desired builds via `desired_models` and prefetches them. If a build
 fails, check `darkbloom logs` for the mismatch and run `darkbloom models remove
 <id>` followed by `darkbloom models download <id>`.
 
+### `Provider capacity is temporarily unavailable` (503)
+
+This error means the provider's HTTP server is running, but the inference
+backend has not loaded the model into GPU memory yet. In `--local` mode, the
+model loads **lazily** — the first request triggers the load, which can take
+**3–4 minutes** for a 20 GB+ model like `qwen3.6-35b-a3b-vl-mtp-mxfp8`.
+
+Wait a few minutes and retry. The model stays warm for subsequent requests
+(until the idle timeout evicts it).
+
+**If the error persists after several minutes:**
+
+- The backend subprocess may have failed to start. Check the logs:
+  ```bash
+  darkbloom logs --last 1h | grep -i "backend\|error\|crash"
+  ```
+- Confirm the model is listed in `backend.preload_models` in provider.toml,
+  and that `startup_preload_timeout_secs` is long enough for your model size.
+  A 23.8 GB model may need 300 seconds or more:
+  ```toml
+  [backend]
+  startup_preload_timeout_secs = 300
+  ```
+- In daemon mode (`--local-endpoint`), the model won't warm until the
+  coordinator's MDM verification completes and trust reaches `hardware`.
+  Run `darkbloom status` and check the `Trust:` line.
+
 ## Performance issues
 
 ### Low throughput


### PR DESCRIPTION
…local-endpoint flags

<!--
Thanks for contributing to d-inference. A few quick notes:

- Link an issue with `Closes #123` so the issue auto-closes on merge.
- Set the milestone (e.g. `v0.3.6`) so we know which release this targets.
- Add `area:*` labels for the components you touched.
- Don't include external IPs, internal hostnames, or secrets in code, comments, or screenshots.
-->

## Summary

Adds documentation for three issues encountered during first-time provider setup:
1. Explains the "Provider capacity unavailable" 503 and lazy model loading
2. Documents startup_preload_timeout_secs config option
3. Helps new users choose between --local and --local-endpoint

## Linked issue

Closes #

## Test plan

<!--
A bulleted checklist of how you verified this. Include the specific commands you ran.
For UI changes, include a screenshot or short video.
-->

- [x] Reviewed rendered markdown for formatting
- [x] Verified instructions match actual darkbloom CLI behavior

## Components touched

<!-- Tick all that apply so reviewers know what to look at. -->

- [ ] coordinator (Go)
- [ ] provider (Rust, legacy)
- [ ] provider-swift (Swift CLI)
- [ ] console-ui (Next.js)
- [ ] enclave (Swift)
- [ ] infra / CI / release
- [x] docs

## Protocol / interface changes

<!--
If you changed a WebSocket message, an HTTP endpoint, a config key, or a CLI flag:
- Did you update the matching side? (provider/src/protocol.rs ↔ coordinator/internal/protocol/messages.go)
- Are release artifacts (`release-swift.yml`, `scripts/install.sh`, `LatestProviderVersion`) still consistent?
- Does this need a version bump or a migration note?
-->

- [x] No protocol/interface changes
- [ ] Yes — described above and matching side updated

## Notes for reviewers

<!-- Anything non-obvious: tradeoffs taken, edge cases not covered, follow-ups planned. -->
Docs-only, no code changes. Based on first-hand setup experience.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/783"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790678646&installation_model_id=21733&pr_number=783&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F783&signature=5198a385176e2c8339e1c80a4bca08c1d76595200830001123f49acea4b19179"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->