### PR TITLE
Fix for darkbloom doctor command hanging when ios simulator runs

### DIFF
--- a/provider-swift/Sources/darkbloom/Diagnostics/CompetingInferenceDiagnostics.swift
+++ b/provider-swift/Sources/darkbloom/Diagnostics/CompetingInferenceDiagnostics.swift
@@ -40,7 +40,17 @@ struct LocalContentionSnapshot: Equatable, Sendable {
         )
     }
 
-    private static func runCapture(_ path: String, args: [String]) -> String? {
+    /// Runs `path` and returns its stdout, or nil if it could not be launched.
+    ///
+    /// The pipe is drained to EOF **before** `waitUntilExit()`. A macOS pipe
+    /// buffer holds at most 64 KiB, so waiting first deadlocks on any output
+    /// larger than that: the child blocks in `write()` with a full pipe while
+    /// the parent blocks waiting for the child to exit. `ps -axo comm=` clears
+    /// 64 KiB on a busy Mac -- a booted iOS Simulator alone contributes ~50 KB
+    /// of long runtime paths -- so `doctor` hung for real users.
+    /// `readDataToEndOfFile()` returns when the child closes the stream, so it
+    /// is also the join point; `waitUntilExit()` then just reaps.
+    static func runCapture(_ path: String, args: [String]) -> String? {
         let p = Process()
         p.executableURL = URL(fileURLWithPath: path)
         p.arguments = args
@@ -49,11 +59,11 @@ struct LocalContentionSnapshot: Equatable, Sendable {
         p.standardError = FileHandle.nullDevice
         do {
             try p.run()
-            p.waitUntilExit()
         } catch {
             return nil
         }
         let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        p.waitUntilExit()
         return String(data: data, encoding: .utf8)
     }
 }

--- a/provider-swift/Tests/DarkbloomCLITests/DoctorChecksTests.swift
+++ b/provider-swift/Tests/DarkbloomCLITests/DoctorChecksTests.swift
@@ -112,4 +112,18 @@ struct DoctorChecksTests {
         #expect(check(llama, "competing inference")?.status == .warn)
         #expect(check(llama, "competing inference")?.detail.contains("llama-server") == true)
     }
+
+    /// Regression: `runCapture` used to call `waitUntilExit()` before draining
+    /// the pipe, which deadlocks once the child outgrows the 64 KiB pipe
+    /// buffer. `ps -axo comm=` passes 64 KiB on a busy Mac, so `doctor` hung.
+    /// 256 KiB is four buffers' worth -- it cannot complete without draining.
+    @Test("runCapture drains output larger than the pipe buffer", .timeLimit(.minutes(1)))
+    func runCaptureSurvivesLargeOutput() {
+        let bytes = 256 * 1024
+        let out = LocalContentionSnapshot.runCapture(
+            "/bin/dd",
+            args: ["if=/dev/zero", "bs=1024", "count=\(bytes / 1024)"]
+        )
+        #expect(out?.utf8.count == bytes)
+    }
 }


### PR DESCRIPTION
<!--
Thanks for contributing to d-inference. A few quick notes:

- Link an issue with `Closes #123` so the issue auto-closes on merge.
- Set the milestone (e.g. `v0.3.6`) so we know which release this targets.
- Add `area:*` labels for the components you touched.
- Don't include external IPs, internal hostnames, or secrets in code, comments, or screenshots.
-->

## Summary

Darkbloom doctor hung because an ios simulator was taking up the macOS pipe buffer.

## Linked issue

Closes #

## Test plan
I added a test and afterwards ran darkbloom doctor and continued to let darkbloom work.

<!--
A bulleted checklist of how you verified this. Include the specific commands you ran.
For UI changes, include a screenshot or short video.
-->

- [ ]
- [ ]

## Components touched

<!-- Tick all that apply so reviewers know what to look at. -->

- [ ] coordinator (Go)
- [ ] provider (Rust, legacy)
- [x] provider-swift (Swift CLI)
- [ ] console-ui (Next.js)
- [ ] enclave (Swift)
- [ ] infra / CI / release
- [ ] docs

## Protocol / interface changes

<!--
If you changed a WebSocket message, an HTTP endpoint, a config key, or a CLI flag:
- Did you update the matching side? (provider/src/protocol.rs ↔ coordinator/internal/protocol/messages.go)
- Are release artifacts (`release-swift.yml`, `scripts/install.sh`, `LatestProviderVersion`) still consistent?
- Does this need a version bump or a migration note?
-->

- [x] No protocol/interface changes
- [ ] Yes — described above and matching side updated

## Notes for reviewers

<!-- Anything non-obvious: tradeoffs taken, edge cases not covered, follow-ups planned. -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/786"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790726217&installation_model_id=21733&pr_number=786&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F786&signature=bbb252ee05141dcc2099c8d8a06e133339ca9d03863d4ff00bec2e1f6e4e91b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->