### PR TITLE
feat(routing): add model-specific first-content deadlines

### DIFF
--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/eigeninference/d-inference/coordinator/auth"
 	"github.com/eigeninference/d-inference/coordinator/internal/e2e"
+	"github.com/eigeninference/d-inference/coordinator/modelpolicy"
 	"github.com/eigeninference/d-inference/coordinator/payments"
 	"github.com/eigeninference/d-inference/coordinator/promptcontract"
 	"github.com/eigeninference/d-inference/coordinator/protocol"
@@ -50,7 +51,8 @@ const (
 
 	// defaultFirstContentDeadlineBase preserves the ordinary coordinator and
 	// unit-test budget. Production overrides it to 9s through validated startup
-	// configuration; every request adds 1ms per estimated prompt token.
+	// configuration; exact model overrides live in modelpolicy and every request
+	// adds 1ms per estimated prompt token.
 	defaultFirstContentDeadlineBase = 5 * time.Second
 
 	// preambleContentTimeout is the relative cap from the first boilerplate
@@ -115,16 +117,16 @@ const (
 var thinkBlockPattern = regexp.MustCompile(`(?is)<think>(.*?)</think>\s*`)
 
 // FirstContentDeadline returns this server's request-absolute first-content
-// budget. The base is instance-owned so production-like E2E servers can use the
-// production value without mutating concurrent unit tests. The per-token slope
-// is fixed at 1ms to match the verified OpenRouter cancel slope.
-func (s *Server) FirstContentDeadline(estimatedPromptTokens int) time.Duration {
+// budget for a concrete model. The ordinary base is instance-owned so
+// production-like E2E servers can use the production value without mutating
+// concurrent unit tests. Exact-model overrides and the fixed 1ms/token slope
+// are centralized in modelpolicy.
+func (s *Server) FirstContentDeadline(model string, estimatedPromptTokens int) time.Duration {
 	base := s.firstContentDeadlineBase
 	if base <= 0 {
 		base = defaultFirstContentDeadlineBase
 	}
-	perToken := time.Duration(estimatedPromptTokens) * time.Millisecond
-	return base + perToken
+	return modelpolicy.CoordinatorFirstContentDeadline(model, estimatedPromptTokens, base)
 }
 
 // shedIfModelRejected answers a public/prefer-owner request with 429 +
@@ -657,8 +659,9 @@ const (
 // route this request to Previous instead of returning a fast 429 / slow stream.
 // Hard constraints and permanent model-too-large failures are handled by the
 // caller and do not use this fallback. The TTFT estimate for Previous is also
-// returned so the caller does not need to recompute it. ttftThreshold is only
-// consulted in aliasFallbackTTFT mode.
+// returned so the caller does not need to recompute it. ttftThreshold is the
+// request-local deadline pinned before admission and is only consulted in
+// aliasFallbackTTFT mode.
 func (s *Server) maybeFallbackAlias(parsed map[string]any, mode aliasFallbackMode, publicModel, currentModel string, estimatedPromptTokens, requestedMaxTokens int, ttftThreshold time.Duration, traits registry.RequestTraits, requiresVision bool, allowedProviderSerials []string) (string, int, int, int, time.Duration, bool, bool) {
 	if publicModel == "" || publicModel == currentModel {
 		return currentModel, 0, 0, 0, 0, false, false
@@ -822,6 +825,7 @@ func (s *Server) dispatchOneProvider(
 	consumerLocation *store.ProviderLocation,
 	reservedMicroUSD int64,
 	estimatedPromptTokens int,
+	requestDeadline time.Duration,
 	requestedMaxTokens int,
 	tokenAdmission registry.TokenAdmission,
 	requiresVision bool,
@@ -842,7 +846,6 @@ func (s *Server) dispatchOneProvider(
 	lastErr string,
 	lastErrCode int,
 ) {
-	requestDeadline := s.FirstContentDeadline(estimatedPromptTokens)
 	receivedAt := timingReceivedAt(timing)
 	_, dispatchable := firstContentBudgetMillis(receivedAt, requestDeadline)
 	if !dispatchable {
@@ -1705,7 +1708,7 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	estimatedPromptTokens := estimatePromptTokens(parsed)
 	billingPromptTokens := estimateBillingPromptTokens(parsed)
 	requestedMaxTokens := estimateRequestedMaxTokens(parsed)
-	deadline := s.FirstContentDeadline(estimatedPromptTokens)
+	deadline := s.FirstContentDeadline(model, estimatedPromptTokens)
 	timing.ParsedAt = time.Now()
 	if s.shedIfModelRejected(w, r, parsed, policy, publicModel, model, stream, estimatedPromptTokens, requestedMaxTokens, requiresVision, hasTools) {
 		return
@@ -1863,6 +1866,7 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 		publicModel:           publicModel,
 		stream:                stream,
 		estimatedPromptTokens: estimatedPromptTokens,
+		firstContentDeadline:  deadline,
 		requestedMaxTokens:    requestedMaxTokens,
 		hasTools:              hasTools,
 		requiresVision:        requiresVision,
@@ -4158,7 +4162,7 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 	estimatedPromptTokens := estimatePromptTokens(parsed)
 	billingPromptTokens := estimateBillingPromptTokens(parsed)
 	requestedMaxTokens := estimateRequestedMaxTokens(parsed)
-	genericDeadline := s.FirstContentDeadline(estimatedPromptTokens)
+	genericDeadline := s.FirstContentDeadline(model, estimatedPromptTokens)
 	timing.ParsedAt = time.Now()
 	if s.shedIfModelRejected(w, r, parsed, policy, publicModel, model, stream, estimatedPromptTokens, requestedMaxTokens, requiresVision, hasTools) {
 		return

--- a/coordinator/api/consumer_ttft_test.go
+++ b/coordinator/api/consumer_ttft_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/eigeninference/d-inference/coordinator/modelpolicy"
 	"github.com/eigeninference/d-inference/coordinator/registry"
 )
 
@@ -42,18 +43,22 @@ func TestWriteServiceUnavailableSetsRetryAfter(t *testing.T) {
 func TestTTFTDeadlineExact(t *testing.T) {
 	srv, _ := testServer(t)
 	tests := []struct {
+		model       string
 		inputTokens int
 		want        time.Duration
 	}{
-		{inputTokens: 0, want: 5 * time.Second},
-		{inputTokens: 1, want: 5*time.Second + time.Millisecond},
-		{inputTokens: 5_000, want: 10 * time.Second},
-		{inputTokens: 5_001, want: 10*time.Second + time.Millisecond},
+		{model: "ordinary-model", inputTokens: 0, want: 5 * time.Second},
+		{model: "ordinary-model", inputTokens: 1, want: 5*time.Second + time.Millisecond},
+		{model: "ordinary-model", inputTokens: 5_000, want: 10 * time.Second},
+		{model: "ordinary-model", inputTokens: 5_001, want: 10*time.Second + time.Millisecond},
+		{model: modelpolicy.Qwen3VL30BA3BInstructModelID, inputTokens: 0, want: 4 * time.Second},
+		{model: modelpolicy.Qwen3VL30BA3BInstructModelID, inputTokens: 1, want: 4*time.Second + time.Millisecond},
+		{model: modelpolicy.Qwen3VL30BA3BInstructModelID + "-preview", inputTokens: 0, want: 5 * time.Second},
 	}
 
 	for _, tt := range tests {
-		if got := srv.FirstContentDeadline(tt.inputTokens); got != tt.want {
-			t.Fatalf("FirstContentDeadline(%d) = %v, want %v", tt.inputTokens, got, tt.want)
+		if got := srv.FirstContentDeadline(tt.model, tt.inputTokens); got != tt.want {
+			t.Fatalf("FirstContentDeadline(%q, %d) = %v, want %v", tt.model, tt.inputTokens, got, tt.want)
 		}
 	}
 }
@@ -65,17 +70,22 @@ func TestFirstContentDeadlineIsServerOwned(t *testing.T) {
 	})
 
 	const promptTokens = 321
-	if got, want := productionLike.FirstContentDeadline(promptTokens), 9*time.Second+321*time.Millisecond; got != want {
+	if got, want := productionLike.FirstContentDeadline("ordinary-model", promptTokens), 9*time.Second+321*time.Millisecond; got != want {
 		t.Fatalf("production-like deadline = %v, want %v", got, want)
 	}
-	if got, want := ordinary.FirstContentDeadline(promptTokens), 5*time.Second+321*time.Millisecond; got != want {
+	if got, want := ordinary.FirstContentDeadline("ordinary-model", promptTokens), 5*time.Second+321*time.Millisecond; got != want {
 		t.Fatalf("ordinary deadline changed by another server: got %v, want %v", got, want)
+	}
+	if got, want := productionLike.FirstContentDeadline(
+		modelpolicy.Qwen3VL30BA3BInstructModelID, promptTokens,
+	), 4*time.Second+321*time.Millisecond; got != want {
+		t.Fatalf("Qwen3-VL production-like deadline = %v, want %v", got, want)
 	}
 }
 
 func TestWriteTTFTTooSlowSets429RetryAfter(t *testing.T) {
 	srv, _ := testServer(t)
-	threshold := srv.FirstContentDeadline(0)
+	threshold := srv.FirstContentDeadline("slow-ttft-model", 0)
 	if threshold != 5*time.Second {
 		t.Fatalf("FirstContentDeadline(0) = %v, want 5s", threshold)
 	}
@@ -318,7 +328,7 @@ func TestMaybeFallbackAliasTTFTSwitchesToPrevious(t *testing.T) {
 		desired,
 		100,
 		128,
-		srv.FirstContentDeadline(100),
+		srv.FirstContentDeadline(desired, 100),
 		registry.RequestTraits{},
 		false,
 		nil,
@@ -333,8 +343,28 @@ func TestMaybeFallbackAliasTTFTSwitchesToPrevious(t *testing.T) {
 	if candidates != 1 || rejections != 0 || tooLarge != 0 {
 		t.Fatalf("capacity = (%d,%d,%d), want (1,0,0)", candidates, rejections, tooLarge)
 	}
-	if !hasTTFT || bestTTFT > srv.FirstContentDeadline(100) {
+	if !hasTTFT || bestTTFT > srv.FirstContentDeadline(desired, 100) {
 		t.Fatalf("bestTTFT = %v has=%v, want within threshold", bestTTFT, hasTTFT)
+	}
+
+	// Alias fallback must consume the logical request's pinned deadline rather
+	// than recomputing a fresh full duration for Previous. A deliberately tiny
+	// pinned budget therefore blocks the same otherwise-healthy fallback.
+	parsed["model"] = desired
+	fallbackModel, _, _, _, _, _, switched = srv.maybeFallbackAlias(
+		parsed,
+		aliasFallbackTTFT,
+		publicModel,
+		desired,
+		100,
+		128,
+		time.Nanosecond,
+		registry.RequestTraits{},
+		false,
+		nil,
+	)
+	if switched || fallbackModel != previous || parsed["model"] != desired {
+		t.Fatalf("expired pinned deadline restarted on Previous: switched=%v fallback=%q parsed=%v", switched, fallbackModel, parsed)
 	}
 }
 
@@ -355,7 +385,7 @@ func TestMaybeFallbackAliasTTFTSkipsRejectedPrevious(t *testing.T) {
 	parsed := map[string]any{"model": desired}
 
 	fallbackModel, _, _, _, _, _, switched := srv.maybeFallbackAlias(
-		parsed, aliasFallbackTTFT, publicModel, desired, 100, 128, srv.FirstContentDeadline(100), registry.RequestTraits{}, false, nil)
+		parsed, aliasFallbackTTFT, publicModel, desired, 100, 128, srv.FirstContentDeadline(desired, 100), registry.RequestTraits{}, false, nil)
 
 	if switched || fallbackModel != desired || parsed["model"] != desired {
 		t.Fatalf("fallback switched to rejected previous: switched=%v fallback=%q parsed=%v", switched, fallbackModel, parsed)

--- a/coordinator/api/deadline_unreachable_integration_test.go
+++ b/coordinator/api/deadline_unreachable_integration_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -11,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/eigeninference/d-inference/coordinator/modelpolicy"
 	"github.com/eigeninference/d-inference/coordinator/protocol"
 	"github.com/eigeninference/d-inference/coordinator/registry"
 	"github.com/eigeninference/d-inference/coordinator/store"
@@ -235,7 +237,85 @@ func TestDeadlineUnreachableFailoverCarriesDecreasingBudgets(t *testing.T) {
 	}
 }
 
-func TestDispatchOneProviderExpiredClockDoesNotSend(t *testing.T) {
+func TestModelSpecificFirstContentDeadlineReachesProviderWire(t *testing.T) {
+	tests := []struct {
+		name      string
+		model     string
+		wantBase  time.Duration
+		otherBase time.Duration
+	}{
+		{
+			name:      "ordinary production-like model",
+			model:     "ordinary-wire-deadline-model",
+			wantBase:  9 * time.Second,
+			otherBase: 4 * time.Second,
+		},
+		{
+			name:      "Qwen3-VL exact model",
+			model:     modelpolicy.Qwen3VL30BA3BInstructModelID,
+			wantBase:  4 * time.Second,
+			otherBase: 9 * time.Second,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reg, _, srv, ts := setupTTFTFailoverServerWithConfig(t, ServerConfig{
+				FirstContentDeadlineBase: 9 * time.Second,
+			})
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+
+			wireBudget := make(chan int64, 1)
+			startFailoverProvider(t, ctx, ts, reg, failoverProviderConfig{
+				Name: "provider-model-deadline", Version: "0.8.15", DecodeTPS: 200,
+				Models: []failoverModelSpec{{ID: tt.model}},
+				Script: func(ctx context.Context, fp *failoverProvider, req protocol.InferenceRequestMessage, _ []byte) {
+					wireBudget <- req.FirstContentBudgetMS
+					fp.serveFull(ctx, req, tt.model, markerFor(fp.name))
+				},
+			})
+
+			requestBody := buildChatBody(t, tt.model, false, nil)
+			var parsed map[string]any
+			if err := json.Unmarshal([]byte(requestBody), &parsed); err != nil {
+				t.Fatalf("parse request body: %v", err)
+			}
+			expected := srv.FirstContentDeadline(
+				tt.model, estimatePromptTokens(parsed),
+			).Milliseconds()
+			if expected < tt.wantBase.Milliseconds() ||
+				expected >= tt.wantBase.Milliseconds()+time.Second.Milliseconds() {
+				t.Fatalf("selected deadline = %dms, want %s base plus prompt slope", expected, tt.wantBase)
+			}
+			if expected >= tt.otherBase.Milliseconds() && tt.wantBase < tt.otherBase {
+				t.Fatalf("selected deadline = %dms, looks like ordinary %s policy", expected, tt.otherBase)
+			}
+
+			status, body, err := postChat(ctx, ts.URL, "test-key", requestBody)
+			if err != nil {
+				t.Fatalf("chat request: %v", err)
+			}
+			if status != http.StatusOK {
+				t.Fatalf("status=%d body=%s, want 200", status, body)
+			}
+
+			select {
+			case got := <-wireBudget:
+				// Writer dequeue refreshes the remaining budget, so it may only
+				// decrease from the request-local duration selected above. Do not
+				// impose a lower bound: a loaded CI host may delay writer handoff.
+				if got <= 0 || got > expected {
+					t.Fatalf("wire budget = %dms, want (0,%d]", got, expected)
+				}
+			case <-ctx.Done():
+				t.Fatal("provider did not receive inference request")
+			}
+		})
+	}
+}
+
+func TestDispatchOneProviderUsesPinnedExpiredClockWithoutRecomputing(t *testing.T) {
 	reg, _, srv, ts := setupTTFTFailoverServer(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
@@ -261,6 +341,7 @@ func TestDispatchOneProviderExpiredClockDoesNotSend(t *testing.T) {
 		nil,
 		0,
 		8,
+		10*time.Millisecond,
 		64,
 		registry.TokenAdmission{},
 		false,
@@ -268,7 +349,9 @@ func TestDispatchOneProviderExpiredClockDoesNotSend(t *testing.T) {
 		nil,
 		false,
 		selfRoutePolicy{},
-		&registry.RequestTiming{ReceivedAt: time.Now().Add(-time.Minute)},
+		// The pinned 10ms request clock is expired, while recomputing this
+		// ordinary model from the server's 5s default would still allow a send.
+		&registry.RequestTiming{ReceivedAt: time.Now().Add(-50 * time.Millisecond)},
 		false,
 		registry.CachePlan{},
 		map[string]struct{}{},

--- a/coordinator/api/dispatch.go
+++ b/coordinator/api/dispatch.go
@@ -1080,7 +1080,7 @@ func (d *dispatchState) dispatchPrimary() dispatchOutcome {
 	var routeProvider *registry.Provider
 	d.provider, d.pr, decision, dispatchErr, dispatchErrCode = s.dispatchOneProvider(
 		r, d.model, d.publicModel, d.rawBody, d.consumerKey, d.consumerLocation, d.reservedMicroUSD,
-		d.estimatedPromptTokens, d.requestedMaxTokens, d.tokenAdmission, d.requiresVision,
+		d.estimatedPromptTokens, d.deadline, d.requestedMaxTokens, d.tokenAdmission, d.requiresVision,
 		d.traits(),
 		d.allowedProviderSerials, d.isResponsesAPI, d.policy, d.timing, d.serviceReservation, d.cachePlan, d.excludeProviders,
 		d.attempt,
@@ -1985,7 +1985,7 @@ func (d *dispatchState) runSpeculative() dispatchOutcome {
 
 		backupProvider, backupPR, _, backupErr, backupErrCode = s.dispatchOneProvider(
 			r, d.model, d.publicModel, d.rawBody, d.consumerKey, d.consumerLocation, d.reservedMicroUSD,
-			d.estimatedPromptTokens, d.requestedMaxTokens, d.tokenAdmission, d.requiresVision,
+			d.estimatedPromptTokens, d.deadline, d.requestedMaxTokens, d.tokenAdmission, d.requiresVision,
 			d.traits(),
 			d.allowedProviderSerials, d.isResponsesAPI, d.policy,
 			&registry.RequestTiming{ReceivedAt: d.timing.ReceivedAt},

--- a/coordinator/api/dispatch_ttft_terminal_test.go
+++ b/coordinator/api/dispatch_ttft_terminal_test.go
@@ -211,7 +211,7 @@ func TestDispatch_TTFTRejectAttempt0_SingleReservationAnd429(t *testing.T) {
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader("{}"))
 	refunds := 0
-	deadline := srv.FirstContentDeadline(6)
+	deadline := srv.FirstContentDeadline(model, 6)
 	d := &dispatchState{
 		s:                     srv,
 		w:                     w,

--- a/coordinator/api/first_token_clock.go
+++ b/coordinator/api/first_token_clock.go
@@ -12,8 +12,10 @@ package api
 // budget.
 //
 // Everything here derives from one clock:
-// ReceivedAt + Server.FirstContentDeadline(tokens)
-// (prod: 9s + 1ms/token — deliberately inside the aggregator's 10s slope).
+// ReceivedAt + Server.FirstContentDeadline(model, tokens). Ordinary production
+// requests use 9s + 1ms/token inside the aggregator's standard 10s slope;
+// exact model policies may tighten both clocks while preserving response
+// headroom (Qwen3-VL Instruct: 4s live inside a 5s upstream SLA).
 // Invariants:
 //
 //  1. No wait for first CONTENT may extend past the leftover clock — not

--- a/coordinator/api/media_resolve.go
+++ b/coordinator/api/media_resolve.go
@@ -138,8 +138,8 @@ func scanRemoteMediaRefs(parsed map[string]any) remoteMediaScan {
 // mediaFetchInferenceReserve is leftover first-content time kept for the
 // provider after the coordinator inlines remote media. The mediafetch defaults
 // (15s/file, 25s total) are larger than the production first-content clock
-// (9s + 1ms/token), so an unbounded fetch can expire the clock before the
-// provider starts — the video-url eval failed as
+// (ordinary 9s base; shorter for exact model policies), so an unbounded fetch
+// can expire the clock before the provider starts — the video-url eval failed as
 // "timeout waiting for first response (backup)" after a successful fetch.
 const mediaFetchInferenceReserve = 5 * time.Second
 
@@ -177,9 +177,13 @@ type mediaResolveMeta struct {
 	publicModel           string
 	stream                bool
 	estimatedPromptTokens int
-	requestedMaxTokens    int
-	hasTools              bool
-	requiresVision        bool
+	// firstContentDeadline is the request-local duration pinned before media,
+	// admission, alias fallback, and dispatch. Production callers always set it;
+	// zero retains the focused-test fallback to the server policy.
+	firstContentDeadline time.Duration
+	requestedMaxTokens   int
+	hasTools             bool
+	requiresVision       bool
 	// selfRoute (exclusive X-Darkbloom-Route: self) skips the balance
 	// reservation, so the monetary cost gate that otherwise precedes a fetch is
 	// absent. ownerAccountID is the caller's owned-provider set. resolveRemoteMedia
@@ -237,7 +241,10 @@ func (s *Server) resolveRemoteMedia(w http.ResponseWriter, r *http.Request, rawB
 	start := time.Now()
 	resolveCtx := r.Context()
 	if receivedAt := timingReceivedAt(timing); !receivedAt.IsZero() {
-		deadline := s.FirstContentDeadline(meta.estimatedPromptTokens)
+		deadline := meta.firstContentDeadline
+		if deadline <= 0 {
+			deadline = s.FirstContentDeadline(meta.model, meta.estimatedPromptTokens)
+		}
 		budget, bound := mediaFetchBudget(receivedAt, deadline)
 		if bound && budget <= 0 {
 			s.logger.Warn("remote media rejected", "code", "media_fetch_timeout", "status", http.StatusRequestTimeout)

--- a/coordinator/api/media_resolve_test.go
+++ b/coordinator/api/media_resolve_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/eigeninference/d-inference/coordinator/mediafetch"
+	"github.com/eigeninference/d-inference/coordinator/modelpolicy"
 	"github.com/eigeninference/d-inference/coordinator/registry"
 	"github.com/eigeninference/d-inference/coordinator/store"
 )
@@ -182,6 +183,27 @@ func TestMediaFetchBudgetTestDefaultDeadlineStillFetches(t *testing.T) {
 	}
 }
 
+func TestMediaFetchBudgetUsesPinnedQwenDeadline(t *testing.T) {
+	srv, _ := testServerWithConfig(t, ServerConfig{
+		FirstContentDeadlineBase: 9 * time.Second,
+	})
+	deadline := srv.FirstContentDeadline(
+		modelpolicy.Qwen3VL30BA3BInstructModelID, 300,
+	)
+	if want := 4*time.Second + 300*time.Millisecond; deadline != want {
+		t.Fatalf("Qwen3-VL deadline = %s, want %s", deadline, want)
+	}
+	budget, bound := mediaFetchBudget(time.Now(), deadline)
+	if !bound {
+		t.Fatal("stamped Qwen3-VL clock must bound the fetch")
+	}
+	// For a sub-5s clock the resolver reserves half for inference, so remote
+	// media gets roughly 2.15s and cannot consume the full first-content SLA.
+	if budget < 1900*time.Millisecond || budget > 2300*time.Millisecond {
+		t.Fatalf("Qwen3-VL media budget = %s, want ~2.15s", budget)
+	}
+}
+
 func TestMediaFetchBudgetExpiredClockIsZero(t *testing.T) {
 	budget, bound := mediaFetchBudget(time.Now().Add(-15*time.Second), 9*time.Second)
 	if !bound || budget != 0 {
@@ -209,6 +231,34 @@ func TestResolveRemoteMediaExpiredFirstContentClockDoesNotFetch(t *testing.T) {
 	}
 	if atomic.LoadInt32(&hits) != 0 {
 		t.Fatalf("origin was fetched %d times", hits)
+	}
+	if w.Code != http.StatusRequestTimeout {
+		t.Fatalf("status=%d body=%s, want 408", w.Code, w.Body.String())
+	}
+}
+
+func TestResolveRemoteMediaUsesPinnedDeadlineWithoutRecomputing(t *testing.T) {
+	cfg := mediafetch.DefaultConfig()
+	cfg.AllowPrivateIPs = true
+	cfg.AllowNonStandardPorts = true
+	var hits int32
+	media := httptest.NewServer(pngHandler(t, &hits))
+	defer media.Close()
+
+	s := minimalMediaServer(cfg)
+	s.firstContentDeadlineBase = 9 * time.Second
+	raw, parsed := chatBodyBytes(t, media.URL+"/cat.png")
+	w := httptest.NewRecorder()
+	timing := &registry.RequestTiming{ReceivedAt: time.Now().Add(-200 * time.Millisecond)}
+	meta := testMeta()
+	meta.firstContentDeadline = 100 * time.Millisecond
+
+	out, _, ok := s.resolveRemoteMedia(w, plainReq(), raw, parsed, timing, meta)
+	if ok || out != nil {
+		t.Fatal("expired pinned media deadline must not be recomputed from the 9s server base")
+	}
+	if got := atomic.LoadInt32(&hits); got != 0 {
+		t.Fatalf("origin was fetched %d times, want 0", got)
 	}
 	if w.Code != http.StatusRequestTimeout {
 		t.Fatalf("status=%d body=%s, want 408", w.Code, w.Body.String())

--- a/coordinator/api/server.go
+++ b/coordinator/api/server.go
@@ -252,10 +252,11 @@ type Server struct {
 	// (EIGENINFERENCE_TTFT_HARD_REJECT=true) to restore the legacy hard 429.
 	ttftHardReject bool
 
-	// firstContentDeadlineBase is the fixed term in the request-absolute
-	// first-content budget. It is immutable after startup and instance-owned:
-	// concurrent test servers can exercise production and unit-test postures
-	// without racing on process-global state.
+	// firstContentDeadlineBase is the ordinary-model fixed term in the
+	// request-absolute first-content budget. It is immutable after startup and
+	// instance-owned; exact-model policy can only tighten it. Concurrent test
+	// servers can exercise production and unit-test postures without racing on
+	// process-global state.
 	firstContentDeadlineBase time.Duration
 
 	// rejectModels are requested aliases or resolved model IDs the coordinator

--- a/coordinator/api/server_config.go
+++ b/coordinator/api/server_config.go
@@ -22,8 +22,9 @@ type ServerConfig struct {
 	AdminEmails         []string
 	ReleaseKey          string
 	ServiceReservations bool
-	// FirstContentDeadlineBase is the fixed term in the request-absolute
-	// first-content budget. Zero keeps the ordinary coordinator default.
+	// FirstContentDeadlineBase is the ordinary-model fixed term in the
+	// request-absolute first-content budget. Exact-model policy may tighten it;
+	// zero keeps the ordinary coordinator default.
 	FirstContentDeadlineBase time.Duration
 	BaseRewards              BaseRewardsConfig
 	// MediaFetch is the remote media resolution config (mediafetch package).

--- a/coordinator/cmd/coordinator/main.go
+++ b/coordinator/cmd/coordinator/main.go
@@ -233,7 +233,8 @@ func main() {
 	// LIVE first-content deadline base — distinct from the shadow evaluator's
 	// base below. Validate and bind it to this Server instance before startup;
 	// production sets 9000ms, while an unset/invalid value keeps the intentional
-	// 5000ms ordinary-unit default. Every request adds 1ms per prompt token.
+	// 5000ms ordinary-unit default. Exact model policy may tighten this base but
+	// never loosen a lower operator value. Every request adds 1ms per prompt token.
 	if v := os.Getenv("EIGENINFERENCE_TTFT_LIVE_DEADLINE_BASE_MS"); v != "" {
 		if base, ok := validateTTFTDeadlineBaseMs(v); ok {
 			serverCfg.FirstContentDeadlineBase = time.Duration(base) * time.Millisecond
@@ -410,8 +411,9 @@ func main() {
 	// Routing: TTFT admission ceiling mode. Default is a SOFT routing preference
 	// (serve the best-available provider when one passes every routing/capacity
 	// gate). Set this to restore the legacy HARD 429 when the best estimated TTFT
-	// exceeds the 5s+1ms/token deadline. The estimate's prefill term is not
-	// provider-measured, so the hard gate over-rejected serveable requests.
+	// exceeds the pinned request-local model deadline. The estimate's prefill
+	// term is not provider-measured, so the hard gate over-rejected serveable
+	// requests.
 	if os.Getenv("EIGENINFERENCE_TTFT_HARD_REJECT") == "true" {
 		srv.SetTTFTHardReject(true)
 		logger.Warn("TTFT hard-reject ENABLED via EIGENINFERENCE_TTFT_HARD_REJECT (legacy 429-on-slow-estimate; soft preference is the default)")
@@ -455,9 +457,10 @@ func main() {
 	//     candidate-loop ceiling, and the preflight bestTTFT — byte-for-byte the
 	//     pre-Phase-0 value. Reuses the occupancy the snapshot already tracks
 	//     (max(pendingForModel, backend_running+backend_waiting)); herd-aware.
-	//   - EIGENINFERENCE_TTFT_DEADLINE_BASE_MS (float, default 10000): the SLA
-	//     base the shadow evaluator gates against. The verified OpenRouter SLA is
-	//     ~10s+1ms/token; the instance-owned live first-content deadline
+	//   - EIGENINFERENCE_TTFT_DEADLINE_BASE_MS (float, default 10000): the
+	//     ordinary-model SLA base the shadow evaluator gates against. The
+	//     standard OpenRouter SLA is ~10s+1ms/token; exact-model policy can only
+	//     tighten that base. The instance-owned live first-content deadline
 	//     configured above is independent. Used ONLY by the shadow evaluator.
 	//   - EIGENINFERENCE_TTFT_ADMISSION_MODE (off|shadow|enforce, default off):
 	//     off => no evaluation; shadow/enforce => compute would_shed +

--- a/coordinator/modelpolicy/first_content_deadline.go
+++ b/coordinator/modelpolicy/first_content_deadline.go
@@ -1,0 +1,86 @@
+package modelpolicy
+
+import "time"
+
+const (
+	// Qwen3VL30BA3BInstructModelID is the concrete catalog identifier used by
+	// the coordinator and providers for Qwen3-VL 30B A3B Instruct.
+	Qwen3VL30BA3BInstructModelID = "qwen3-vl-30b-a3b-instruct"
+
+	// StandardUpstreamFirstContentBase is the ordinary upstream first-content
+	// SLA base. The request-specific deadline also adds 1ms per estimated prompt
+	// token.
+	StandardUpstreamFirstContentBase = 10 * time.Second
+
+	// FirstContentResponseHeadroom is the response margin the coordinator keeps
+	// inside the upstream SLA. It lets the coordinator return a retryable 429
+	// before an upstream router closes a still-silent request.
+	FirstContentResponseHeadroom = time.Second
+
+	// Qwen3VL30BA3BInstructUpstreamFirstContentBase is the shorter upstream SLA
+	// base for this exact concrete catalog build.
+	Qwen3VL30BA3BInstructUpstreamFirstContentBase = 5 * time.Second
+
+	// Qwen3VL30BA3BInstructCoordinatorFirstContentBase preserves the same 1s
+	// response margin used by the ordinary production posture (10s upstream,
+	// 9s coordinator) inside Qwen3-VL's 5s upstream SLA.
+	Qwen3VL30BA3BInstructCoordinatorFirstContentBase = Qwen3VL30BA3BInstructUpstreamFirstContentBase - FirstContentResponseHeadroom
+)
+
+type firstContentDeadlineBases struct {
+	upstream    time.Duration
+	coordinator time.Duration
+}
+
+// exactFirstContentDeadlineBases keeps every per-model upstream/live pair in
+// one exact-match table. Add future model-specific policies here so shadow
+// evaluation and live dispatch cannot select different model sets.
+func exactFirstContentDeadlineBases(model string) (firstContentDeadlineBases, bool) {
+	switch model {
+	case Qwen3VL30BA3BInstructModelID:
+		return firstContentDeadlineBases{
+			upstream:    Qwen3VL30BA3BInstructUpstreamFirstContentBase,
+			coordinator: Qwen3VL30BA3BInstructCoordinatorFirstContentBase,
+		}, true
+	default:
+		return firstContentDeadlineBases{}, false
+	}
+}
+
+// UpstreamFirstContentDeadline returns the caller-facing first-content SLA for
+// a concrete model. defaultBase is the ordinary-model base and remains
+// operator-configurable. Exact-model policy is a tightening ceiling: a lower
+// emergency global base still wins.
+func UpstreamFirstContentDeadline(model string, estimatedPromptTokens int, defaultBase time.Duration) time.Duration {
+	base := defaultBase
+	if base <= 0 {
+		base = StandardUpstreamFirstContentBase
+	}
+	if exact, ok := exactFirstContentDeadlineBases(model); ok && base > exact.upstream {
+		base = exact.upstream
+	}
+	return addPromptTokenSlope(base, estimatedPromptTokens)
+}
+
+// CoordinatorFirstContentDeadline returns the live coordinator cutoff for a
+// concrete model. defaultBase is the instance-owned ordinary-model cutoff
+// (9s in production); the exact Qwen3-VL override keeps one second of response
+// headroom inside its shorter upstream SLA. Exact-model policy never loosens a
+// tighter emergency global base.
+func CoordinatorFirstContentDeadline(model string, estimatedPromptTokens int, defaultBase time.Duration) time.Duration {
+	base := defaultBase
+	if base <= 0 {
+		base = StandardUpstreamFirstContentBase - FirstContentResponseHeadroom
+	}
+	if exact, ok := exactFirstContentDeadlineBases(model); ok && base > exact.coordinator {
+		base = exact.coordinator
+	}
+	return addPromptTokenSlope(base, estimatedPromptTokens)
+}
+
+func addPromptTokenSlope(base time.Duration, estimatedPromptTokens int) time.Duration {
+	if estimatedPromptTokens < 0 {
+		estimatedPromptTokens = 0
+	}
+	return base + time.Duration(estimatedPromptTokens)*time.Millisecond
+}

--- a/coordinator/modelpolicy/first_content_deadline_test.go
+++ b/coordinator/modelpolicy/first_content_deadline_test.go
@@ -1,0 +1,95 @@
+package modelpolicy
+
+import (
+	"testing"
+	"time"
+)
+
+func TestFirstContentDeadlinesByExactModel(t *testing.T) {
+	tests := []struct {
+		name            string
+		model           string
+		promptTokens    int
+		wantUpstream    time.Duration
+		wantCoordinator time.Duration
+	}{
+		{
+			name:            "ordinary model",
+			model:           "ordinary-model",
+			promptTokens:    321,
+			wantUpstream:    10*time.Second + 321*time.Millisecond,
+			wantCoordinator: 9*time.Second + 321*time.Millisecond,
+		},
+		{
+			name:            "exact Qwen3-VL instruct",
+			model:           Qwen3VL30BA3BInstructModelID,
+			promptTokens:    321,
+			wantUpstream:    5*time.Second + 321*time.Millisecond,
+			wantCoordinator: 4*time.Second + 321*time.Millisecond,
+		},
+		{
+			name:            "Qwen3-VL lookalike",
+			model:           Qwen3VL30BA3BInstructModelID + "-preview",
+			promptTokens:    321,
+			wantUpstream:    10*time.Second + 321*time.Millisecond,
+			wantCoordinator: 9*time.Second + 321*time.Millisecond,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := UpstreamFirstContentDeadline(
+				tt.model, tt.promptTokens, StandardUpstreamFirstContentBase,
+			); got != tt.wantUpstream {
+				t.Fatalf("upstream deadline = %v, want %v", got, tt.wantUpstream)
+			}
+			if got := CoordinatorFirstContentDeadline(
+				tt.model, tt.promptTokens,
+				StandardUpstreamFirstContentBase-FirstContentResponseHeadroom,
+			); got != tt.wantCoordinator {
+				t.Fatalf("coordinator deadline = %v, want %v", got, tt.wantCoordinator)
+			}
+		})
+	}
+}
+
+func TestFirstContentDeadlineClampsNegativePromptTokens(t *testing.T) {
+	if got := UpstreamFirstContentDeadline(
+		Qwen3VL30BA3BInstructModelID, -1, StandardUpstreamFirstContentBase,
+	); got != Qwen3VL30BA3BInstructUpstreamFirstContentBase {
+		t.Fatalf("upstream deadline = %v, want base only", got)
+	}
+	if got := CoordinatorFirstContentDeadline(
+		Qwen3VL30BA3BInstructModelID, -1, 9*time.Second,
+	); got != Qwen3VL30BA3BInstructCoordinatorFirstContentBase {
+		t.Fatalf("coordinator deadline = %v, want base only", got)
+	}
+}
+
+func TestOrdinaryDeadlineBasesRemainConfigurable(t *testing.T) {
+	const promptTokens = 25
+	if got, want := UpstreamFirstContentDeadline(
+		"ordinary-model", promptTokens, 12*time.Second,
+	), 12*time.Second+25*time.Millisecond; got != want {
+		t.Fatalf("upstream deadline = %v, want %v", got, want)
+	}
+	if got, want := CoordinatorFirstContentDeadline(
+		"ordinary-model", promptTokens, 8*time.Second,
+	), 8*time.Second+25*time.Millisecond; got != want {
+		t.Fatalf("coordinator deadline = %v, want %v", got, want)
+	}
+}
+
+func TestModelOverridesNeverLoosenTighterGlobalDeadline(t *testing.T) {
+	const promptTokens = 25
+	if got, want := UpstreamFirstContentDeadline(
+		Qwen3VL30BA3BInstructModelID, promptTokens, 3*time.Second,
+	), 3*time.Second+25*time.Millisecond; got != want {
+		t.Fatalf("upstream deadline = %v, want tighter global %v", got, want)
+	}
+	if got, want := CoordinatorFirstContentDeadline(
+		Qwen3VL30BA3BInstructModelID, promptTokens, 3*time.Second,
+	), 3*time.Second+25*time.Millisecond; got != want {
+		t.Fatalf("coordinator deadline = %v, want tighter global %v", got, want)
+	}
+}

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -31,6 +31,7 @@ import (
 	"time"
 
 	"github.com/eigeninference/d-inference/coordinator/attestation"
+	"github.com/eigeninference/d-inference/coordinator/modelpolicy"
 	"github.com/eigeninference/d-inference/coordinator/protocol"
 	"github.com/eigeninference/d-inference/coordinator/saferun"
 	"github.com/eigeninference/d-inference/coordinator/store"
@@ -2902,8 +2903,6 @@ func (r *Registry) providerServesOwnedRoutableModelLocked(p *Provider, model str
 	return false
 }
 
-const qwen3VL30BA3BInstructModelID = "qwen3-vl-30b-a3b-instruct"
-
 // providerServesVisionModelLocked reports whether the provider advertises the
 // model as a vision-capable (VLM) build — required to route image/video requests
 // so the media is actually perceived rather than silently dropped. allowOffCatalog
@@ -2928,7 +2927,7 @@ func (r *Registry) providerServesVisionModelLocked(p *Provider, model string, al
 		} else if !r.providerModelAllowedByCatalogLocked(p, m) {
 			continue
 		}
-		if model == qwen3VL30BA3BInstructModelID &&
+		if model == modelpolicy.Qwen3VL30BA3BInstructModelID &&
 			strings.EqualFold(strings.TrimSpace(p.Hardware.ChipFamily), "M5") {
 			// This concrete VLM produces incorrect visual inference on M5.
 			return false

--- a/coordinator/registry/routingsim/routingsim_test.go
+++ b/coordinator/registry/routingsim/routingsim_test.go
@@ -2,10 +2,31 @@ package routingsim_test
 
 import (
 	"testing"
+	"time"
 
+	"github.com/eigeninference/d-inference/coordinator/modelpolicy"
 	"github.com/eigeninference/d-inference/coordinator/registry"
 	"github.com/eigeninference/d-inference/coordinator/registry/routingsim"
 )
+
+func TestTTFTDeadlineUsesExactModelPolicy(t *testing.T) {
+	const promptTokens = 321
+	if got, want := routingsim.TTFTDeadline(
+		"ordinary-model", promptTokens,
+	), 5*time.Second+321*time.Millisecond; got != want {
+		t.Fatalf("ordinary deadline = %v, want %v", got, want)
+	}
+	if got, want := routingsim.TTFTDeadline(
+		modelpolicy.Qwen3VL30BA3BInstructModelID, promptTokens,
+	), 4*time.Second+321*time.Millisecond; got != want {
+		t.Fatalf("Qwen3-VL deadline = %v, want %v", got, want)
+	}
+	if got, want := routingsim.TTFTDeadline(
+		modelpolicy.Qwen3VL30BA3BInstructModelID+"-preview", promptTokens,
+	), 5*time.Second+321*time.Millisecond; got != want {
+		t.Fatalf("lookalike deadline = %v, want %v", got, want)
+	}
+}
 
 const (
 	simModel        = "mlx-community/Qwen3.5-9B-Instruct-4bit"

--- a/coordinator/registry/routingsim/runner.go
+++ b/coordinator/registry/routingsim/runner.go
@@ -3,6 +3,7 @@ package routingsim
 import (
 	"time"
 
+	"github.com/eigeninference/d-inference/coordinator/modelpolicy"
 	"github.com/eigeninference/d-inference/coordinator/registry"
 )
 
@@ -23,12 +24,12 @@ const (
 	OutcomeTTFTTooSlow Outcome = "ttft_too_slow"
 )
 
-// TTFTDeadline replicates api.ttftDeadline locally: 5s base + 1ms per estimated
-// prompt token. Replicated (not imported) so the harness has no dependency on
-// the unexported api package and cannot drift silently — the calibration test
-// would catch a formula change as a moved cliff.
-func TTFTDeadline(promptTokens int) time.Duration {
-	return 5*time.Second + time.Duration(promptTokens)*time.Millisecond
+// TTFTDeadline mirrors the ordinary API test posture (5s base) plus the shared
+// exact-model overrides. Keeping the policy in modelpolicy prevents this
+// simulation harness from silently using the standard deadline for a model
+// with a shorter upstream SLA.
+func TTFTDeadline(model string, promptTokens int) time.Duration {
+	return modelpolicy.CoordinatorFirstContentDeadline(model, promptTokens, 5*time.Second)
 }
 
 // ClassifyWithGate runs the REAL preflight capacity check for one arrival and
@@ -49,7 +50,7 @@ func ClassifyWithGate(reg *registry.Registry, a Arrival, softTTFT bool) Outcome 
 	if candidateCount == 0 && capacityRejections > 0 {
 		return OutcomeMachineBusy
 	}
-	if !softTTFT && hasTTFT && bestTTFT > TTFTDeadline(a.PromptTokens) {
+	if !softTTFT && hasTTFT && bestTTFT > TTFTDeadline(a.Model, a.PromptTokens) {
 		return OutcomeTTFTTooSlow
 	}
 	return OutcomeServed

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -2410,10 +2410,10 @@ func ttftMsFromSnapshot(snap routingSnapshot, reqPromptTokens int) float64 {
 // It is used ONLY by the shadow evaluator today; a future enforce step will wire
 // it (against the verified ~10s base) into the live path. Keeping the occupancy
 // term OUT of ttftMsFromSnapshot is a SAFETY INVARIANT: prod runs HARD_REJECT
-// (pr.MaxTTFTMs set from the 5s ttftDeadline), so if the term leaked into
-// ttftMsFromSnapshot, raising alpha would tighten the live 5s ceiling and
-// over-shed ~2x (telemetry-db findings §2). The term may therefore only ever
-// reach the shadow estimate, never breakdown.TTFTMs.
+// (pr.MaxTTFTMs set from the pinned request-local deadline), so if the term
+// leaked into ttftMsFromSnapshot, raising alpha would tighten the live ceiling
+// and over-shed ~2x (telemetry-db findings §2). The term may therefore only
+// ever reach the shadow estimate, never breakdown.TTFTMs.
 func occupancyAwareTTFTMsFromSnapshot(snap routingSnapshot, reqPromptTokens int) float64 {
 	base := ttftMsFromSnapshot(snap, reqPromptTokens)
 	if base <= 0 {
@@ -2445,8 +2445,8 @@ func occupancyAwareTTFTMsFromSnapshot(snap routingSnapshot, reqPromptTokens int)
 // Returns 0 when EIGENINFERENCE_TTFT_OCCUPANCY_ALPHA is 0 (the default) or
 // occupancy is 0 (an idle box never pays the term, so route-to-idle is
 // preserved). The deadline this is gated against in the shadow evaluator is the
-// verified ~10s base, NOT the code's 5s internal budget; gating an occupancy
-// estimate fit to the 5s base over-sheds ~2x (telemetry-db findings §2).
+// model's upstream SLA (standard ~10s), not the shorter live coordinator cutoff.
+// Conflating those clocks over-sheds (telemetry-db findings §2).
 func ttftOccupancyMs(snap routingSnapshot) float64 {
 	alpha := ttftOccupancyAlpha
 	if alpha <= 0 {

--- a/coordinator/registry/ttft_shadow.go
+++ b/coordinator/registry/ttft_shadow.go
@@ -1,6 +1,11 @@
 package registry
 
-import "strings"
+import (
+	"strings"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/modelpolicy"
+)
 
 // Phase-0 SLA-aware, occupancy-aware admission — SHADOW + MEASUREMENT slice.
 //
@@ -13,8 +18,9 @@ import "strings"
 //   - WouldShed: the occupancy-aware TTFT estimate
 //     (occupancyAwareTTFTMsFromSnapshot = base + the occupancy term, which is
 //     non-zero only when EIGENINFERENCE_TTFT_OCCUPANCY_ALPHA > 0) for the chosen
-//     provider exceeds the verified ~10s deadline base (NOT the code's 5s internal
-//     budget — gating at 5s over-sheds ~2x per telemetry-db findings §2). The
+//     provider exceeds the model's upstream deadline base (standard ~10s;
+//     exact-model policies may be shorter). This is NOT the live coordinator
+//     cutoff, which preserves response headroom inside the upstream SLA. The
 //     occupancy term is intentionally confined to this shadow estimate so it can
 //     never tighten the live HARD_REJECT ceiling fed by ttftMsFromSnapshot.
 //   - IdleAlternativeExists: the chosen provider already carries occupying peers
@@ -67,11 +73,11 @@ func ParseTTFTAdmissionMode(s string) TTFTAdmissionMode {
 	}
 }
 
-// defaultTTFTDeadlineBaseMs is the verified OpenRouter SLA base. Cancels fit
-// `10000 + 1ms·prompt_tokens` at a median ratio of 1.002 (telemetry-db findings
-// §2); the coordinator's internal `ttftDeadline` (consumer.go) still uses a 5s
-// base, which would over-shed ~2x if used as the gate — so the shadow evaluator
-// uses THIS base, decoupled from consumer.go.
+// defaultTTFTDeadlineBaseMs is the verified standard OpenRouter SLA base.
+// Standard-model cancels fit `10000 + 1ms·prompt_tokens` at a median ratio of
+// 1.002 (telemetry-db findings §2). The live coordinator cutoff is selected
+// separately with response headroom; exact-model policy can tighten either
+// clock without conflating the two.
 const defaultTTFTDeadlineBaseMs = 10000.0
 
 // Both are configured once at startup (from main.go env wiring) and read-only on
@@ -106,15 +112,14 @@ func TTFTDeadlineBaseMs() float64 {
 	return ttftDeadlineBaseMs
 }
 
-// ttftDeadlineMsForPrompt is the shadow gate's per-request SLA in ms:
-// base + 1ms·prompt_tokens, matching the per-token slope of consumer.ttftDeadline
-// but with the verified ~10s base instead of 5s. Used ONLY by the shadow
-// evaluator — the live consumer.go ttftDeadline path is untouched.
-func ttftDeadlineMsForPrompt(promptTokens int) float64 {
-	if promptTokens < 0 {
-		promptTokens = 0
-	}
-	return ttftDeadlineBaseMs + float64(promptTokens)
+// ttftDeadlineMsForPrompt is the shadow gate's per-request upstream SLA in ms.
+// Ordinary models use the configured ~10s base; exact per-model overrides use
+// the same shared policy table as the live coordinator clock. This remains
+// shadow only and does not change routing decisions.
+func ttftDeadlineMsForPrompt(model string, promptTokens int) float64 {
+	defaultBase := time.Duration(ttftDeadlineBaseMs * float64(time.Millisecond))
+	deadline := modelpolicy.UpstreamFirstContentDeadline(model, promptTokens, defaultBase)
+	return float64(deadline) / float64(time.Millisecond)
 }
 
 // ttftShadowEval is the result of the read-only Phase-0 evaluation. It is copied
@@ -170,9 +175,9 @@ func (r *Registry) evaluateTTFTShadowLocked(model string, pr *PendingRequest, wi
 	// Occupancy-aware estimate (base + occupancy term). The occupancy term lives
 	// here, in the SHADOW path only — ttftMsFromSnapshot (the live cost / ceiling /
 	// bestTTFT input) stays occupancy-free so raising alpha cannot tighten the
-	// live 5s HARD_REJECT ceiling. See occupancyAwareTTFTMsFromSnapshot.
+	// live request-local HARD_REJECT ceiling. See occupancyAwareTTFTMsFromSnapshot.
 	estimate := occupancyAwareTTFTMsFromSnapshot(snap, reqPrompt)
-	deadline := ttftDeadlineMsForPrompt(reqPrompt)
+	deadline := ttftDeadlineMsForPrompt(model, reqPrompt)
 	occ := snapshotOccupancy(snap)
 
 	eval := ttftShadowEval{

--- a/coordinator/registry/ttft_shadow_test.go
+++ b/coordinator/registry/ttft_shadow_test.go
@@ -4,6 +4,7 @@ import (
 	"math"
 	"testing"
 
+	"github.com/eigeninference/d-inference/coordinator/modelpolicy"
 	"github.com/eigeninference/d-inference/coordinator/protocol"
 )
 
@@ -66,6 +67,7 @@ func TestTTFTEstimateOccupancyTermActiveAndMonotonic(t *testing.T) {
 		}
 	}
 	const reqPrompt = 1000
+	const model = "ordinary-shadow-model"
 
 	// The occupancy term must add to the SHADOW estimate at b>0 (compare alpha on
 	// vs off). The LIVE estimate (ttftMsFromSnapshot) must NOT move with alpha.
@@ -86,7 +88,7 @@ func TestTTFTEstimateOccupancyTermActiveAndMonotonic(t *testing.T) {
 	}
 
 	// Strictly increasing in occupancy, crossing the deadline at a knee.
-	deadline := ttftDeadlineMsForPrompt(reqPrompt)
+	deadline := ttftDeadlineMsForPrompt(model, reqPrompt)
 	last := -1.0
 	knee := -1
 	for b := 0; b <= 8; b++ {
@@ -105,6 +107,33 @@ func TestTTFTEstimateOccupancyTermActiveAndMonotonic(t *testing.T) {
 	// b=0 (idle) must stay well under the deadline — route-to-idle is preserved.
 	if idle := occupancyAwareTTFTMsFromSnapshot(mk(0), reqPrompt); idle > deadline {
 		t.Fatalf("idle box (b=0) must be under the deadline, got %f > %f", idle, deadline)
+	}
+}
+
+func TestTTFTShadowDeadlineUsesExactModelPolicy(t *testing.T) {
+	withTTFTConfig(t, 0, defaultTTFTDeadlineBaseMs, TTFTAdmissionShadow)
+	const promptTokens = 321
+
+	if got, want := ttftDeadlineMsForPrompt(
+		"ordinary-shadow-model", promptTokens,
+	), 10_321.0; got != want {
+		t.Fatalf("ordinary shadow deadline = %.0fms, want %.0fms", got, want)
+	}
+	if got, want := ttftDeadlineMsForPrompt(
+		modelpolicy.Qwen3VL30BA3BInstructModelID, promptTokens,
+	), 5_321.0; got != want {
+		t.Fatalf("Qwen3-VL shadow deadline = %.0fms, want %.0fms", got, want)
+	}
+	if got, want := ttftDeadlineMsForPrompt(
+		modelpolicy.Qwen3VL30BA3BInstructModelID+"-preview", promptTokens,
+	), 10_321.0; got != want {
+		t.Fatalf("lookalike shadow deadline = %.0fms, want %.0fms", got, want)
+	}
+	SetTTFTDeadlineBaseMs(3_000)
+	if got, want := ttftDeadlineMsForPrompt(
+		modelpolicy.Qwen3VL30BA3BInstructModelID, promptTokens,
+	), 3_321.0; got != want {
+		t.Fatalf("tight global shadow deadline = %.0fms, want %.0fms", got, want)
 	}
 }
 

--- a/deploy/environments/prod.env
+++ b/deploy/environments/prod.env
@@ -84,6 +84,8 @@ EIGENINFERENCE_MODEL_SOLO_TPS_SEED=gemma-4-26b-qat-4bit=14,gemma-4-26b-qat-4bit@
 # TTFT and warm-pool tuning observed on 2026-07-17.
 EIGENINFERENCE_TTFT_ADMISSION_MODE=shadow
 EIGENINFERENCE_TTFT_HARD_REJECT=true
+# Ordinary-model live base. Exact model policy can only tighten it;
+# qwen3-vl-30b-a3b-instruct uses 4000ms inside its 5000ms upstream SLA.
 EIGENINFERENCE_TTFT_LIVE_DEADLINE_BASE_MS=9000
 EIGENINFERENCE_TTFT_OCCUPANCY_ALPHA=50
 EIGENINFERENCE_WARM_POOL_ENABLED=true

--- a/docs/architecture/data-flow.md
+++ b/docs/architecture/data-flow.md
@@ -80,7 +80,7 @@ Key provider-side behavior:
 
 * Model loading is on-demand. The provider can hold up to `maxModelSlots` models (default 3) and evicts idle models LRU-style (`coordinator/registry/scheduler.go:765-768`).
 * The provider-side load gate requires `weights_gb + 2.0` GB of headroom after the OS reserve and in-flight KV reservations, which is stricter than the coordinator's admission gate (`provider-swift/Sources/ProviderCore/Inference/ModelLoadAdmission.swift:19-24`).
-* If the model is not resident, the provider loads it; the coordinator waits up to the TTFT deadline (5 s + 1 ms per input token) and can start a speculative backup dispatch at 50% of the deadline (`coordinator/api/consumer.go:72-76`, `ttftDeadline`).
+* If the model is not resident, the provider loads it; the coordinator waits up to the request-local TTFT deadline and can start a speculative backup dispatch at 50% of that deadline. The standard upstream SLA is 10 s + 1 ms per estimated prompt token and production keeps 1 s of response headroom with a 9 s live base. Exact-model ceilings can be shorter: `qwen3-vl-30b-a3b-instruct` uses a 5 s upstream base and a 4 s live base. (`coordinator/modelpolicy/first_content_deadline.go`, `coordinator/api/first_token_clock.go`).
 
 ## 6. Response Relay to Consumer
 

--- a/docs/architecture/operations/consumer-latest-routing-plan.md
+++ b/docs/architecture/operations/consumer-latest-routing-plan.md
@@ -67,7 +67,7 @@ Queue loop:
 
 TTFT/speculation loop:
 
-- Knobs: `ttftDeadline = 5s + 1ms/input_token`, speculative backup at `0.5 * deadline`, preamble-content timeout, inference idle timeout in `coordinator/api/consumer.go:44`.
+- Knobs: pinned per-model first-content deadline from `coordinator/modelpolicy` plus `1ms/input_token`, speculative backup at `0.5 * deadline`, preamble-content timeout, and inference idle timeout in `coordinator/api/consumer.go`.
 - Signals: first-content time, speculative backup started, speculative backup won, first-content timeout, accepted-then-stall timeout.
 - Actuators: retry/failover for this request, warm-pool pressure for future requests.
 

--- a/docs/architecture/request-outcome-observability.md
+++ b/docs/architecture/request-outcome-observability.md
@@ -235,7 +235,7 @@ The relevant environment controls are:
 | Env flag | Type | Default | Effect |
 |---|---|---|---|
 | `EIGENINFERENCE_SERVABILITY_GATE` | bool | off | Enables the proactive preflight servability 429 gate (`context_exceeded` / `prompt_too_long`). When off, nothing is preflight-rejected; the always-on dispatch backstop still reclassifies unservable 5xx. |
-| `EIGENINFERENCE_TTFT_LIVE_DEADLINE_BASE_MS` | milliseconds | `5000` in code; `9000` in production | Sets the fixed term in the live request-absolute first-content budget. The coordinator adds `1ms × estimated_prompt_tokens`; invalid values keep the 5000ms ordinary default. |
+| `EIGENINFERENCE_TTFT_LIVE_DEADLINE_BASE_MS` | milliseconds | `5000` in code; `9000` in production | Sets the ordinary-model fixed term in the live request-absolute first-content budget. The coordinator adds `1ms × estimated_prompt_tokens`; invalid values keep the 5000ms ordinary default. Exact-model policy is a tightening ceiling, so a lower global value still wins. |
 
 Streaming deliberately writes no status, headers, SSE comments, or body bytes
 before the first content-bearing provider chunk. Role-only and lifecycle
@@ -244,13 +244,18 @@ still be returned as a real HTTP 429 instead of an already-committed HTTP 200
 ([`coordinator/api/dispatch_terminal_write.go`](../../coordinator/api/dispatch_terminal_write.go),
 [`coordinator/api/consumer.go`](../../coordinator/api/consumer.go)).
 
-The first-content clock is `request received_at + configured base +
-1ms × estimated_prompt_tokens`. It is absolute across queueing, provider-writer
+The first-content clock is `request received_at + selected model base +
+1ms × estimated_prompt_tokens`. The standard upstream base is 10000ms and
+production uses a 9000ms live base so it can return a retryable response first.
+The exact `qwen3-vl-30b-a3b-instruct` policy uses a 5000ms upstream base and a
+4000ms live base, retaining the same response headroom. The duration is selected
+once before deadline-bound work and is absolute across queueing, provider-writer
 handoff, speculative dispatch, failover, and accepted/boilerplate events; none of
-those phases resets it. Production binds the 9000ms base to each server instance
-before startup, avoiding mutable process-global deadline state
+those phases resets or lengthens it. Production binds the ordinary 9000ms base
+to each server instance before startup, avoiding mutable process-global deadline state
 ([`coordinator/api/first_token_clock.go`](../../coordinator/api/first_token_clock.go),
-[`coordinator/api/server_config.go`](../../coordinator/api/server_config.go)).
+[`coordinator/api/server_config.go`](../../coordinator/api/server_config.go),
+[`coordinator/modelpolicy/first_content_deadline.go`](../../coordinator/modelpolicy/first_content_deadline.go)).
 
 Both counters keep the metadata-only, low-cardinality invariant: `request_outcome`
 carries only `model`, `class` and `kv_backend`, and `unservable_reclassified` only

--- a/docs/architecture/routing-v2.md
+++ b/docs/architecture/routing-v2.md
@@ -17,8 +17,9 @@ included as the base of this branch.
   `machine_busy`=0.** Not a capacity problem.
 - **Acceptance cliff at ~550–650 prompt tokens** (served p95 prompt=611; rejected
   median=1,576). Cause: TTFT gate estimates prefill as `decode×4 ≈ 100 tok/s`
-  while the deadline (`5s+1ms/tok`) implies ~1,000 tok/s. **No provider reports a
-  measured prefill rate**, so the ×4 fallback is the production path.
+  while the then-live ordinary deadline (`5s+1ms/tok`) implied ~1,000 tok/s.
+  **No provider reports a measured prefill rate**, so the ×4 fallback is the
+  production path.
 - **Utilization ~12–19%**: 137 routable, 90 warm, 16 active, 0 queued, token
   budget 99.94% free. 84% of served requests went to **idle (warm)** providers.
 - **gemma decode anomaly**: gemma-4-26b-qat-4bit and gpt-oss-20b are **both
@@ -76,7 +77,9 @@ vs small (batch→tok/s) table). Start with: report `solo_decode_tps` +
 
 For request `(model M, prompt P, max_tokens, traits)`:
 
-1. `deadline = 5s + 1ms·P` (SLA contract, unchanged).
+1. Select and pin `deadline = modelpolicy.coordinator_base(M) + 1ms·P` once.
+   Production ordinary models use a 9s base; exact Qwen3-VL Instruct uses 4s
+   inside its 5s upstream SLA. A tighter global operator base still wins.
 2. `candidates` = providers serving M passing all gates (trust, attestation,
    privacy, freshness, traits) **and** with a free concurrency slot.
 3. Per candidate, from monitors compute **projected per-request decode** (at

--- a/docs/operations/coordinator-deploy.md
+++ b/docs/operations/coordinator-deploy.md
@@ -518,8 +518,10 @@ for key in \
 done
 sudo grep -E '^EIGENINFERENCE_(CACHE_ROUTING_MODE|CACHE_ROUTING_PERCENT|CACHE_ROUTING_MAX_PLAN_QPS|PROMPT_SIDECAR_ENABLED)=' \
   /etc/d-inference/env
-# No bytes are emitted before first content. Keep the production absolute-clock
-# base at 9s; the coordinator adds 1ms per estimated prompt token.
+# No bytes are emitted before first content. Keep the ordinary-model production
+# absolute-clock base at 9s; the coordinator adds 1ms per estimated prompt token.
+# Exact model policies may tighten this base (Qwen3-VL Instruct: 4s live inside
+# its 5s upstream SLA), and a lower global base still wins.
 if ! sudo grep -Fx 'EIGENINFERENCE_TTFT_LIVE_DEADLINE_BASE_MS=9000' \
   /etc/d-inference/env; then
   echo "production first-content deadline is not the required 9000ms" >&2
@@ -583,7 +585,9 @@ Rules learned the hard way:
   content-bearing chunk, preserving a real HTTP 429 on pre-content exhaustion.
   Its request-absolute clock starts at HTTP receipt and is not reset by queueing,
   provider acceptance, boilerplate, writer handoff, speculation, or failover.
-  Production sets the base to 9000ms and adds 1ms per estimated prompt token
+  Production sets the ordinary-model base to 9000ms and adds 1ms per estimated
+  prompt token. Exact model policy can only tighten it; Qwen3-VL Instruct uses
+  a 4000ms live base inside its 5000ms upstream SLA
   ([`coordinator/api/first_token_clock.go`](../../coordinator/api/first_token_clock.go),
   [`coordinator/api/dispatch_terminal_write.go`](../../coordinator/api/dispatch_terminal_write.go)).
 - **The volume mount is mandatory.** Omitting `-v /mnt/disks/userdata:/mnt/disks/userdata`

--- a/docs/operations/routing-v2-rollout.md
+++ b/docs/operations/routing-v2-rollout.md
@@ -88,7 +88,7 @@ cold-dispatch flags use their own parser that disables only on
 
 | Flag | Default | What it does | Blast radius | Disable / revert |
 |---|---|---|---|---|
-| `EIGENINFERENCE_TTFT_HARD_REJECT` | `false` (soft) | `true` restores the legacy **hard 429** when estimated TTFT exceeds the `5s+1ms/tok` deadline (`main.go:301`) | **Global kill-switch** — reverts the headline behaviour to `master` | This *is* the revert: set `=true` |
+| `EIGENINFERENCE_TTFT_HARD_REJECT` | `false` (soft) | `true` restores the legacy **hard 429** when estimated TTFT exceeds the pinned request-local model deadline | **Global kill-switch** — reverts the headline behaviour to `master` | This *is* the revert: set `=true` |
 | `EIGENINFERENCE_PREFILL_DECODE_RATIO` | `12` (`scheduler.go:1106`) | Prefill-TPS = decode×ratio fallback when no measured prefill rate (`main.go:309`) | Changes TTFT estimate for unmeasured providers | Set `=4` for `master` behaviour |
 | `EIGENINFERENCE_MIN_DECODE_TPS` | `15` (quality bar **ON**) | Per-request sustained-decode floor; soft preference, never fails closed (`main.go:318-332`) | Quality of admitted streams. **Keep ON when opening floodgates.** | `0` disables the floor |
 

--- a/e2e/testbed/testbed_test.go
+++ b/e2e/testbed/testbed_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/eigeninference/d-inference/coordinator/modelpolicy"
 	"github.com/eigeninference/d-inference/coordinator/protocol"
 )
 
@@ -144,8 +145,15 @@ func TestRunningCoordinatorUsesProductionFirstContentDeadline(t *testing.T) {
 
 	const promptTokens = 1_234
 	want := ProductionFirstContentDeadlineBase + promptTokens*time.Millisecond
-	if got := suite.Coordinator.Server.FirstContentDeadline(promptTokens); got != want {
+	if got := suite.Coordinator.Server.FirstContentDeadline("ordinary-e2e-model", promptTokens); got != want {
 		t.Fatalf("running E2E server deadline = %v, want %v", got, want)
+	}
+	qwenWant := modelpolicy.Qwen3VL30BA3BInstructCoordinatorFirstContentBase +
+		promptTokens*time.Millisecond
+	if got := suite.Coordinator.Server.FirstContentDeadline(
+		modelpolicy.Qwen3VL30BA3BInstructModelID, promptTokens,
+	); got != qwenWant {
+		t.Fatalf("running E2E Qwen3-VL deadline = %v, want %v", got, qwenWant)
 	}
 }
 

--- a/provider-swift/Sources/ProviderBenchmark/SchedulerPrefillDecisionEvaluator.swift
+++ b/provider-swift/Sources/ProviderBenchmark/SchedulerPrefillDecisionEvaluator.swift
@@ -2,6 +2,12 @@ import Foundation
 import ProviderCore
 
 enum SchedulerPrefillDecisionEvaluator {
+    // This evaluator accepts only qwen3_5_moe identities (see
+    // validModelIdentity / SchedulerPrefillDecisionMetadata.inspectModel), whose
+    // upstream deadline uses the standard 10s base. Qwen3-VL is deliberately
+    // insufficient evidence here. If the identity gate is widened to
+    // qwen3_vl_moe, select its model-specific 5s upstream threshold in the same
+    // change; otherwise this report would grade the wrong SLA.
     static let thresholds = SchedulerPrefillDecisionReport.EvaluationThresholds(
         minimumLiveIterations: SchedulerPrefillDecisionReport.minimumLiveIterations,
         minimumThroughputRatio: 0.95,

--- a/provider-swift/Tests/ProviderCoreTests/SchedulerPrefillDecisionBenchmarkTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/SchedulerPrefillDecisionBenchmarkTests.swift
@@ -754,6 +754,27 @@ struct SchedulerPrefillDecisionEvaluatorTests {
                 modelDirectory: directory,
                 expectedSnapshotAggregateSHA256: mislabeledHash)
         }
+
+        // Qwen3-VL has a shorter upstream first-content SLA than this
+        // qwen3_5_moe-only evaluator. Keep it outside the evidence set until
+        // the evaluator also selects model-specific deadline thresholds.
+        try Data(
+            """
+            {
+              "model_type": "qwen3_vl_moe",
+              "architectures": ["Qwen3VLMoeForConditionalGeneration"]
+            }
+            """.utf8
+        ).write(to: directory.appendingPathComponent("config.json"))
+        let qwenVLHash = try #require(WeightHasher.computeHash(
+            snapshotDir: directory,
+            modelID: "fixture-qwen3-vl"))
+        #expect(throws: SchedulerPrefillDecisionError.self) {
+            _ = try SchedulerPrefillDecisionMetadata.inspectModel(
+                operatorModelID: "qwen3-vl-30b-a3b-instruct",
+                modelDirectory: directory,
+                expectedSnapshotAggregateSHA256: qwenVLHash)
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- Centralize first-content deadline policy in a dependency-free `coordinator/modelpolicy` package.
- Give exact `qwen3-vl-30b-a3b-instruct` requests a 5s upstream base and a 4s live coordinator base, both plus 1ms per estimated prompt token.
- Preserve the ordinary 10s upstream / 9s production-live posture and the one-second response headroom used to return a retryable 429 before upstream cancellation.
- Pin one request-local deadline before deadline-bound work and carry it through media fetch, admission, alias fallback, queueing, primary dispatch, retries, speculation, and provider-writer handoff.
- Align TTFT shadow evaluation, routing simulation, E2E posture, operational documentation, and the Swift benchmark evidence boundary.

## Deadline semantics

| Request model | Upstream target | Live coordinator cutoff |
|---|---:|---:|
| Ordinary model | `10s + 1ms × prompt_tokens` | `9s + 1ms × prompt_tokens` in production |
| Exact `qwen3-vl-30b-a3b-instruct` | `5s + 1ms × prompt_tokens` | `4s + 1ms × prompt_tokens` |

Exact-model values are tightening ceilings: a lower emergency global base still wins. Lookalike IDs do not match. There is no provider protocol change; providers continue to receive only the positive remaining `first_content_budget_ms`.

## Before

```mermaid
flowchart TB
  subgraph Behavior
    B1[Request for any model] --> B2[Use one global deadline formula]
    B2 --> B3[Run media resolution and admission]
    B3 --> B4{Dispatch path}
    B4 -->|direct or backup| B5[Recompute duration in dispatchOneProvider]
    B4 -->|queued| B6[Reuse dispatchState duration]
    B5 --> B7[Potential clock split across attempts]
    B6 --> B7
  end

  subgraph Code
    C1[consumer handlers] --> C2[Server.FirstContentDeadline tokens]
    C1 --> C3[dispatchState.deadline]
    C3 --> C4[queue path]
    C3 --> C5[dispatchOneProvider]
    C5 --> C6[Recalculate global deadline]
    C7[registry ttft_shadow] --> C8[Independent 10s formula]
    C9[routingsim] --> C10[Independent 5s formula]
  end
```

## After

```mermaid
flowchart TB
  subgraph Behavior
    A1[Resolve request model] --> A2{Exact model policy}
    A2 -->|ordinary| A3[10s upstream and 9s live production base]
    A2 -->|Qwen3-VL Instruct| A4[5s upstream and 4s live base]
    A3 --> A5[Pin ReceivedAt plus selected duration]
    A4 --> A5
    A5 --> A6[Media and admission]
    A5 --> A7[Queue]
    A5 --> A8[Primary dispatch]
    A5 --> A9[Backup and retries]
    A6 --> A10[Only remaining budget decreases]
    A7 --> A10
    A8 --> A10
    A9 --> A10
    A10 --> A11[Provider receives refreshed remaining milliseconds]
  end

  subgraph Code
    D1[modelpolicy exact deadline table] --> D2[Server.FirstContentDeadline model tokens]
    D2 --> D3[dispatchState.deadline]
    D3 --> D4[runInferenceAdmission]
    D3 --> D5[mediaResolveMeta]
    D3 --> D6[queue PendingRequest]
    D3 --> D7[dispatchOneProvider requestDeadline]
    D7 --> D8[primary retry and speculative calls]
    D1 --> D9[registry TTFT shadow]
    D1 --> D10[routing simulation]
  end
```

## Testing

- `cd coordinator && go test -p=1 ./... -count=1`
- `go test ./e2e/testbed -count=1`
- `cd coordinator && go vet ./...`
- `cd provider-swift && swift test --filter SchedulerPrefillDecisionEvaluatorTests` — 8 tests passed
- Focused model-policy, exact/lookalike, tighter-global-base, alias-pinning, provider-wire, media-budget, routing-simulation, and E2E deadline regressions
- Repository pre-commit and pre-push checks passed

Parallel all-package Go runs can expose an existing 3-second prompt-sidecar supervisor timing flake under host contention. That test passed 5/5 in isolation, and the complete sequential coordinator suite passed.

## Risk and rollback

- The 5s Qwen value is treated as the upstream target; the live cutoff is 4s to retain the established one-second 429 response margin.
- The override is exact-match only and cannot loosen an operator-supplied tighter global deadline.
- Shorter Qwen timing also advances the existing 50% speculative trigger and narrows remote-media fetch time; both continue to derive from the same pinned clock.
- No database migration, wire-schema change, or provider rollout is required.
- Roll back by reverting this commit; ordinary deadline configuration remains unchanged.

No production or traffic state was changed by this PR.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/787"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790728957&installation_model_id=21733&pr_number=787&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F787&signature=6dac5a25509fb30ee3fc562cea5ab969be60f890918275db5b3a4a687019a4e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->