### PR TITLE
feat(routing): fresh-state capacity quotes, dispatch plans, governed hedging

### DIFF
--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -483,7 +483,11 @@ func (s *Server) isRequestShapeBatchBudgetReject(providerID, model, errStr, errR
 	if rec, err := s.store.GetModelRegistryRecord(model); err == nil && rec != nil {
 		modelContext = rec.MaxContextLength
 	}
-	return classifyRejection(errReason, errStr, providerBudget, modelContext) == rejectionDeterministicUnservable
+	// No typed CapacityRejectionReason threads into the strike funnel
+	// (noteInferenceError carries only the string vocabulary), so this stays
+	// the legacy string+heartbeat heuristic — enriched typed reasons already
+	// reach it mapped onto error_reason by the sanitizer.
+	return classifyRejection(errReason, errStr, providerBudget, modelContext, "") == rejectionDeterministicUnservable
 }
 
 // noteInferenceSuccess clears the inference-error strike state for the serving

--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -809,13 +809,25 @@ func rejectionSamplingParams(parsed map[string]any) json.RawMessage {
 	return b
 }
 
-// dispatchOneProvider encrypts and sends an inference request to a single
-// provider. It returns the pending request and provider on success, or an
-// error string on failure. The excludeProviders set is updated on failure.
-// selfRoutePolicy and its resolvers live in self_route.go.
-
 type routeDecisionRecorder func(*registry.Provider, *registry.PendingRequest, registry.RoutingDecision)
 
+// dispatchReserver selects and atomically reserves a provider for an
+// already-constructed PendingRequest. It is the ONE seam between provider
+// SELECTION and the single prepare/encrypt/write funnel in
+// dispatchWithReserver: wave-2 callers plug in the retained-plan variants
+// (ReserveNextFromPlan / RefreshDispatchPlan) without forking the funnel.
+// The returned plan is non-nil only for scan-backed reservers that retain
+// alternates.
+type dispatchReserver func(pr *registry.PendingRequest, excludeIDs []string) (*registry.Provider, registry.RoutingDecision, *registry.DispatchPlan)
+
+// dispatchOneProvider encrypts and sends an inference request to a single
+// provider selected by a fresh full scan. It returns the pending request and
+// provider on success, or an error string on failure, plus the bounded
+// DispatchPlan of provisional alternates retained from the SAME scan (nil
+// whenever no provider was reserved) so retries and speculative backups can
+// consume retained identities instead of rescanning the fleet (Routing v2
+// Phase 3). The excludeProviders set is updated on failure. selfRoutePolicy
+// and its resolvers live in self_route.go.
 func (s *Server) dispatchOneProvider(
 	r *http.Request,
 	model string,
@@ -839,17 +851,73 @@ func (s *Server) dispatchOneProvider(
 	excludeProviders map[string]struct{},
 	attempt int,
 	recordRoute routeDecisionRecorder,
+	onDispatched func(),
 ) (
 	provider *registry.Provider,
 	pr *registry.PendingRequest,
 	decision registry.RoutingDecision,
+	plan *registry.DispatchPlan,
+	lastErr string,
+	lastErrCode int,
+) {
+	return s.dispatchWithReserver(
+		r, model, publicModel, rawBody, consumerKey, consumerLocation,
+		reservedMicroUSD, estimatedPromptTokens, requestDeadline,
+		requestedMaxTokens, tokenAdmission, requiresVision, traits,
+		allowedProviderSerials, isResponsesAPI, policy, timing,
+		serviceReservation, cachePlan, excludeProviders, attempt,
+		recordRoute, onDispatched,
+		func(pr *registry.PendingRequest, excludeIDs []string) (*registry.Provider, registry.RoutingDecision, *registry.DispatchPlan) {
+			return s.registry.ReserveProviderWithPlan(model, pr, excludeIDs...)
+		},
+	)
+}
+
+// dispatchWithReserver is the single prepare/encrypt/write funnel behind every
+// provider dispatch: pending construction and admission stamps, the pluggable
+// reservation, the billing surcharge, E2E encryption, and the
+// deadline-bounded provider write, with releaseUnsentDispatch cleanup on every
+// failure path. onDispatched (nil-safe) fires inside the write handoff
+// callback — the same instant Timing.DispatchedAt is stamped — so
+// providerDispatches counts frames that actually reached a provider, never
+// loop attempts.
+func (s *Server) dispatchWithReserver(
+	r *http.Request,
+	model string,
+	publicModel string,
+	rawBody []byte,
+	consumerKey string,
+	consumerLocation *store.ProviderLocation,
+	reservedMicroUSD int64,
+	estimatedPromptTokens int,
+	requestDeadline time.Duration,
+	requestedMaxTokens int,
+	tokenAdmission registry.TokenAdmission,
+	requiresVision bool,
+	traits registry.RequestTraits,
+	allowedProviderSerials []string,
+	isResponsesAPI bool,
+	policy selfRoutePolicy,
+	timing *registry.RequestTiming,
+	serviceReservation bool,
+	cachePlan registry.CachePlan,
+	excludeProviders map[string]struct{},
+	attempt int,
+	recordRoute routeDecisionRecorder,
+	onDispatched func(),
+	reserve dispatchReserver,
+) (
+	provider *registry.Provider,
+	pr *registry.PendingRequest,
+	decision registry.RoutingDecision,
+	plan *registry.DispatchPlan,
 	lastErr string,
 	lastErrCode int,
 ) {
 	receivedAt := timingReceivedAt(timing)
 	_, dispatchable := firstContentBudgetMillis(receivedAt, requestDeadline)
 	if !dispatchable {
-		return nil, nil, decision, errFirstContentDeadlineExpired, http.StatusGatewayTimeout
+		return nil, nil, decision, nil, errFirstContentDeadlineExpired, http.StatusGatewayTimeout
 	}
 
 	requestID := uuid.New().String()
@@ -909,7 +977,7 @@ func (s *Server) dispatchOneProvider(
 	// Refresh immediately before reservation: every retry spends the same
 	// absolute clock, so the scheduler must never see the original ceiling.
 	if !pr.RefreshFirstContentBudget(time.Now()) {
-		return nil, nil, decision, errFirstContentDeadlineExpired, http.StatusGatewayTimeout
+		return nil, nil, decision, nil, errFirstContentDeadlineExpired, http.StatusGatewayTimeout
 	}
 	// Routing v2 W2: soft per-request decode floor (0 = off). Applies to all
 	// routes; it only ranks providers, never rejects.
@@ -923,20 +991,20 @@ func (s *Server) dispatchOneProvider(
 		return ids
 	}
 
-	provider, decision = s.registry.ReserveProviderEx(model, pr, excludeList()...)
+	provider, decision, plan = reserve(pr, excludeList())
 	if provider == nil {
 		// Providers serve this model but none can physically fit it: don't make
 		// the caller queue/retry for something that will never load.
 		if decision.CandidateCount == 0 && decision.CapacityRejections == 0 && decision.ModelTooLargeRejections > 0 {
-			return nil, nil, decision, errModelTooLarge, http.StatusServiceUnavailable
+			return nil, nil, decision, plan, errModelTooLarge, http.StatusServiceUnavailable
 		}
 		// Providers are available but all exceed the TTFT ceiling. Fail fast
 		// with a retryable 429 rather than queueing or routing to a slow
 		// provider.
 		if decision.TTFTRejections > 0 {
-			return nil, nil, decision, errTTFTTooSlow, http.StatusTooManyRequests
+			return nil, nil, decision, plan, errTTFTTooSlow, http.StatusTooManyRequests
 		}
-		return nil, nil, decision, "no provider available", http.StatusServiceUnavailable
+		return nil, nil, decision, plan, "no provider available", http.StatusServiceUnavailable
 	}
 	pendingCleanup := true
 	cleanupPending := func() {
@@ -979,10 +1047,10 @@ func (s *Server) dispatchOneProvider(
 			cleanupPending()
 			excludeProviders[provider.ID] = struct{}{}
 			if errors.Is(err, store.ErrInsufficientBalance) {
-				return nil, nil, decision, "insufficient funds for provider price", http.StatusPaymentRequired
+				return nil, nil, decision, plan, "insufficient funds for provider price", http.StatusPaymentRequired
 			}
 			s.logger.Error("provider reservation failed (DB error)", "provider_id", provider.ID, "error", err)
-			return nil, nil, decision, "service temporarily unavailable — please retry", http.StatusServiceUnavailable
+			return nil, nil, decision, plan, "service temporarily unavailable — please retry", http.StatusServiceUnavailable
 		}
 	}
 	// refundExtra credits back the provider-specific surcharge that
@@ -1004,7 +1072,7 @@ func (s *Server) dispatchOneProvider(
 		refundExtra()
 		cleanupPending()
 		excludeProviders[provider.ID] = struct{}{}
-		return nil, nil, decision, "no provider with E2E encryption", http.StatusServiceUnavailable
+		return nil, nil, decision, plan, "no provider with E2E encryption", http.StatusServiceUnavailable
 	}
 
 	providerPubKey, err := e2e.ParsePublicKey(provider.PublicKey)
@@ -1012,21 +1080,21 @@ func (s *Server) dispatchOneProvider(
 		refundExtra()
 		cleanupPending()
 		excludeProviders[provider.ID] = struct{}{}
-		return nil, nil, decision, "provider public key invalid", http.StatusServiceUnavailable
+		return nil, nil, decision, plan, "provider public key invalid", http.StatusServiceUnavailable
 	}
 
 	sessionKeys, err := e2e.GenerateSessionKeys()
 	if err != nil {
 		refundExtra()
 		cleanupPending()
-		return nil, nil, decision, "failed to generate session keys", http.StatusInternalServerError
+		return nil, nil, decision, plan, "failed to generate session keys", http.StatusInternalServerError
 	}
 
 	if err := s.registry.PrepareCacheAttempt(pr, provider); err != nil {
 		s.registry.ForgetCacheAttempt(pr)
 		refundExtra()
 		cleanupPending()
-		return nil, nil, decision, "failed to prepare cache-safe request", http.StatusInternalServerError
+		return nil, nil, decision, plan, "failed to prepare cache-safe request", http.StatusInternalServerError
 	}
 	// Pre-fix providers crash on a vision request carrying sampling penalties;
 	// strip them for those providers only. Protocol-0 providers additionally get
@@ -1038,16 +1106,16 @@ func (s *Server) dispatchOneProvider(
 		cleanupPending()
 		if errors.Is(err, errProviderBodyTooLarge) {
 			excludeProviders[provider.ID] = struct{}{}
-			return nil, nil, decision, err.Error(), http.StatusRequestEntityTooLarge
+			return nil, nil, decision, plan, err.Error(), http.StatusRequestEntityTooLarge
 		}
-		return nil, nil, decision, "failed to prepare provider request", http.StatusInternalServerError
+		return nil, nil, decision, plan, "failed to prepare provider request", http.StatusInternalServerError
 	}
 	encrypted, err := e2e.Encrypt(sealedBody, providerPubKey, sessionKeys)
 	if err != nil {
 		s.registry.ForgetCacheAttempt(pr)
 		refundExtra()
 		cleanupPending()
-		return nil, nil, decision, "failed to encrypt request", http.StatusInternalServerError
+		return nil, nil, decision, plan, "failed to encrypt request", http.StatusInternalServerError
 	}
 	if pr.Timing != nil {
 		pr.Timing.EncryptedAt = time.Now()
@@ -1070,6 +1138,9 @@ func (s *Server) dispatchOneProvider(
 			if pr.Timing != nil {
 				pr.Timing.DispatchedAt = metadata.DequeuedAt
 			}
+			if onDispatched != nil {
+				onDispatched()
+			}
 		},
 	)
 	cancelWrite()
@@ -1084,13 +1155,13 @@ func (s *Server) dispatchOneProvider(
 			// its connection during an in-flight write. Cancel defensively in
 			// case the provider decoded the final bytes before disconnect.
 			s.sendProviderCancel(provider, requestID)
-			return nil, nil, decision, errFirstContentDeadlineExpired, http.StatusGatewayTimeout
+			return nil, nil, decision, plan, errFirstContentDeadlineExpired, http.StatusGatewayTimeout
 		}
-		return nil, nil, decision, "failed to send request to provider", http.StatusBadGateway
+		return nil, nil, decision, plan, "failed to send request to provider", http.StatusBadGateway
 	}
 	pendingCleanup = false
 
-	return provider, pr, decision, "", 0
+	return provider, pr, decision, plan, "", 0
 }
 
 // releaseUnsentDispatch returns a reservation after frame construction or
@@ -2051,6 +2122,7 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 		estimatedPromptTokens:  estimatedPromptTokens,
 		requestedMaxTokens:     requestedMaxTokens,
 		requiresVision:         requiresVision,
+		visionImageCount:       countMediaParts(parsed),
 		hasTools:               hasTools,
 		requiresToolConstraint: requiresToolConstraint,
 		toolChoiceMode:         string(validatedMode),
@@ -4331,6 +4403,7 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 		estimatedPromptTokens:  estimatedPromptTokens,
 		requestedMaxTokens:     requestedMaxTokens,
 		requiresVision:         requiresVision,
+		visionImageCount:       countMediaParts(parsed),
 		hasTools:               hasTools,
 		requiresToolConstraint: requiresToolConstraint,
 		toolChoiceMode:         string(validatedMode),

--- a/coordinator/api/deadline_unreachable_integration_test.go
+++ b/coordinator/api/deadline_unreachable_integration_test.go
@@ -332,7 +332,7 @@ func TestDispatchOneProviderUsesPinnedExpiredClockWithoutRecomputing(t *testing.
 		"/v1/chat/completions",
 		strings.NewReader(buildChatBody(t, model, false, nil)),
 	)
-	selected, pending, _, dispatchErr, dispatchErrCode := srv.dispatchOneProvider(
+	selected, pending, _, _, dispatchErr, dispatchErrCode := srv.dispatchOneProvider(
 		req,
 		model,
 		model,
@@ -356,6 +356,7 @@ func TestDispatchOneProviderUsesPinnedExpiredClockWithoutRecomputing(t *testing.
 		registry.CachePlan{},
 		map[string]struct{}{},
 		0,
+		nil,
 		nil,
 	)
 	if selected != nil || pending != nil {

--- a/coordinator/api/dispatch.go
+++ b/coordinator/api/dispatch.go
@@ -215,6 +215,48 @@ type dispatchState struct {
 	// the request reaches a slot, which tags unknown on both dimensions.
 	servedKVSlot dispatchSlotAttribution
 
+	// ---- Routing v2 wave-2 plan/hedge state ----
+	// plan is the bounded dispatch plan retained by the FIRST full-scan
+	// reservation (registry.ReserveProviderWithPlan): up to eight provisional
+	// alternates from the same scan that chose the primary. Retries and the
+	// speculative backup consume it (ReserveNextFromPlan, then one refresh)
+	// before any rescan. nil for queue-path and no-reservation flows —
+	// selection behavior is then exactly legacy.
+	plan *registry.DispatchPlan
+	// planRefreshUsed latches the request's single RefreshDispatchPlan across
+	// BOTH consumers (failover retries and the speculative backup). The plan
+	// object enforces once-per-plan-chain; this enforces once-per-request.
+	planRefreshUsed bool
+	// probesLaunched: the one parallel capacity-probe round has started
+	// (maybeProbePlanCandidates). One round per request, launched only after
+	// the primary frame handoff so probes never add primary latency.
+	probesLaunched bool
+	// hedgeAdvanceCh delivers the probe round's refined ABSOLUTE speculative
+	// launch instant (hedgeLaunchAt) when a confirmed backup's quoted q90
+	// proves the 50% point too late to be useful. Buffered 1, written at most
+	// once by the quote collector; nil until probes launch. waitFirstChunk
+	// consumes at most one value under only-earlier / only-once /
+	// never-after-fire guards; without a value the 50% default stands.
+	hedgeAdvanceCh chan time.Time
+	// hedgeGovernorVerdict is the governor's decision for this request's
+	// speculative launch ("" = the governor never ran: no speculative point
+	// reached, or an owner-served prefer request). Telemetry/log only.
+	hedgeGovernorVerdict string
+	// providerDispatches counts inference frames actually handed to a
+	// provider — primary, queued, plan-retry, and speculative-backup sends
+	// alike, incremented in the write handoff callback that stamps
+	// Timing.DispatchedAt. Client-visible exhaustion messages report this
+	// machine count; route rows keep the loop index d.attempt untouched.
+	providerDispatches int
+	// visionImageCount is the number of media parts in the request (0 for
+	// text-only), carried into capacity probes as count-only shape metadata.
+	visionImageCount int
+	// lastErrFeasibleAfterMS is the enriched rejection's forecast of when a
+	// request of this shape could next be admitted (0 = absent/legacy),
+	// captured by setLastInferenceError and surfaced into the exhaustion
+	// 429's Retry-After.
+	lastErrFeasibleAfterMS int64
+
 	// ---- per-attempt scratch (reset each attempt) ----
 	attempt          int
 	preambleLiveness bool
@@ -624,6 +666,7 @@ func (d *dispatchState) setLastError(errText string, statusCode int) {
 	d.lastErrTerminalCause = ""
 	d.lastErrCoordinatorCause = ""
 	d.lastErrAttemptUsage = nil
+	d.lastErrFeasibleAfterMS = 0
 	d.lastFailureDeadline = false
 }
 
@@ -799,6 +842,14 @@ func (d *dispatchState) latchProviderBodyTooLarge(errText string) {
 func (d *dispatchState) setLastInferenceError(provider *registry.Provider, msg protocol.InferenceErrorMessage) {
 	msg = normalizeInferenceErrorForInternalUse(msg)
 	providerBudget := providerReportedBudget(provider, d.model)
+	if msg.AvailableTokenBudget > 0 {
+		// Enriched rejection (routing v2): the LIVE gate budget at rejection
+		// time beats the last heartbeat's snapshot — this closes the
+		// documented stale-snapshot LIMITATION in classifyRejection, where a
+		// budget that shrank below the model context between heartbeats
+		// misclassified a node-pressured reject as fleet-deterministic.
+		providerBudget = msg.AvailableTokenBudget
+	}
 	d.lastErr = msg.Error
 	d.lastErrCode = msg.StatusCode
 	d.lastErrReason = msg.ErrorReason
@@ -807,6 +858,7 @@ func (d *dispatchState) setLastInferenceError(provider *registry.Provider, msg p
 	d.lastErrTerminalCause = msg.TerminalCause
 	d.lastErrCoordinatorCause = msg.CoordinatorCause
 	d.lastErrAttemptUsage = msg.AttemptUsage
+	d.lastErrFeasibleAfterMS = msg.FeasibleAfterMS
 	d.captureGenuineFault(provider, msg, providerBudget)
 }
 
@@ -1078,23 +1130,47 @@ func (d *dispatchState) dispatchPrimary() dispatchOutcome {
 	routeRequestID := ""
 	routeAttempt := attempt
 	var routeProvider *registry.Provider
-	d.provider, d.pr, decision, dispatchErr, dispatchErrCode = s.dispatchOneProvider(
-		r, d.model, d.publicModel, d.rawBody, d.consumerKey, d.consumerLocation, d.reservedMicroUSD,
-		d.estimatedPromptTokens, d.deadline, d.requestedMaxTokens, d.tokenAdmission, d.requiresVision,
-		d.traits(),
-		d.allowedProviderSerials, d.isResponsesAPI, d.policy, d.timing, d.serviceReservation, d.cachePlan, d.excludeProviders,
-		d.attempt,
-		func(provider *registry.Provider, pr *registry.PendingRequest, decision registry.RoutingDecision) {
-			routeProvider = provider
-			routeRecorded = true
-			if pr != nil {
-				d.configurePending(pr)
-				routeRequestID = pr.RequestID
-				routeAttempt = pr.Attempt
-			}
-			d.recordRoutingDecisionFor(provider, pr, routeRequestID, routeAttempt, decision, "", "")
-		},
-	)
+	recordRoute := func(provider *registry.Provider, pr *registry.PendingRequest, decision registry.RoutingDecision) {
+		routeProvider = provider
+		routeRecorded = true
+		if pr != nil {
+			d.configurePending(pr)
+			routeRequestID = pr.RequestID
+			routeAttempt = pr.Attempt
+		}
+		d.recordRoutingDecisionFor(provider, pr, routeRequestID, routeAttempt, decision, "", "")
+	}
+	// Routing v2 W2: retry attempts consume the retained plan — the next
+	// revalidated entry, then the request's single refresh — BEFORE any full
+	// rescan (identity retention; the rescan herd is the failure the plan
+	// exists to end). The machinery only changes WHERE the next provider
+	// comes from: when it yields nothing, the legacy scan below runs
+	// unchanged, keeping every terminal classification (model_too_large,
+	// ttft_too_slow, queueing) byte-identical.
+	planTried := false
+	if attempt > 0 {
+		d.provider, d.pr, decision, dispatchErr, dispatchErrCode, planTried =
+			d.dispatchFromPlanMachinery(d.timing, d.excludeProviders, recordRoute)
+	}
+	if !planTried {
+		var plan *registry.DispatchPlan
+		d.provider, d.pr, decision, plan, dispatchErr, dispatchErrCode = s.dispatchOneProvider(
+			r, d.model, d.publicModel, d.rawBody, d.consumerKey, d.consumerLocation, d.reservedMicroUSD,
+			d.estimatedPromptTokens, d.deadline, d.requestedMaxTokens, d.tokenAdmission, d.requiresVision,
+			d.traits(),
+			d.allowedProviderSerials, d.isResponsesAPI, d.policy, d.timing, d.serviceReservation, d.cachePlan, d.excludeProviders,
+			d.attempt,
+			recordRoute,
+			d.noteProviderDispatched,
+		)
+		if d.plan == nil {
+			// Adopt the FIRST retained plan only. Once the plan chain
+			// (entries + one refresh) is spent, later fallback scans stay
+			// pure legacy — adopting their plans would resurrect the
+			// machinery past its bounded refresh.
+			d.plan = plan
+		}
+	}
 	d.dispatchErr = dispatchErr
 	d.dispatchErrCode = dispatchErrCode
 	if !routeRecorded {
@@ -1482,6 +1558,7 @@ func (d *dispatchState) dispatchPrimary() dispatchOutcome {
 				d.requestID, encrypted.EphemeralPublicKey, encrypted.Ciphertext, d.pr),
 			func(metadata registry.TextFrameWriteMetadata) {
 				d.timing.DispatchedAt = metadata.DequeuedAt
+				d.noteProviderDispatched()
 			},
 		)
 		cancelWrite()
@@ -1508,6 +1585,10 @@ func (d *dispatchState) dispatchPrimary() dispatchOutcome {
 	// exhaustion ladder can still attribute the outcome after a failover has
 	// cleared d.provider/d.pr (v0.8.0 paged rollout, Gate G5).
 	d.noteServingSlot()
+	// Routing v2 W2: the primary frame is handed off — confirm the retained
+	// alternates in parallel with the in-flight prompt (one probe round per
+	// request; zero added primary latency by construction).
+	d.maybeProbePlanCandidates()
 	return outcomeProceed
 }
 
@@ -1787,6 +1868,11 @@ func (d *dispatchState) waitFirstChunk() (outcome dispatchOutcome) {
 	deadlineWait := d.firstTokenWait(d.deadline)
 	speculativeTimer := time.NewTimer(d.firstTokenSpeculativeWait())
 	deadlineTimer := time.NewTimer(deadlineWait)
+	// Routing v2 W2: the probe round may deliver ONE refined (strictly
+	// earlier) absolute speculative launch instant. Read through a local so
+	// the arm disarms itself after its single use; a nil channel (no probe
+	// round) never fires.
+	hedgeAdvance := d.hedgeAdvanceCh
 	// preambleLiveness records that held boilerplate earned a legacy bounded
 	// extension. AcceptedCh never earns or resets a content wait.
 	// A preamble-then-stall with leftover budget is still bounded by
@@ -1864,6 +1950,34 @@ func (d *dispatchState) waitFirstChunk() (outcome dispatchOutcome) {
 			d.provider = nil
 			d.pr = nil
 			return outcomeRetry
+
+		case at := <-hedgeAdvance:
+			// One-shot re-arm of the speculative timer to the probe round's
+			// refined launch instant. Guards, in order: only once (the local
+			// disarms), only with the absolute clock stamped (mirrors
+			// first_token_clock.go invariant 5), only strictly EARLIER than
+			// the armed point, and never after the timer fired — Stop()
+			// reports whether the timer was still pending; a spent fire stays
+			// buffered in C for its own arm and must not be re-armed over.
+			// Never past the deadline by construction: hedgeLaunchAt's
+			// ceiling is deadline/2. speculativeAt is updated so every
+			// downstream remaining-window computation, the launch-now check
+			// above, and telemetry agree with the re-armed timer; without a
+			// delivered value it stays the 50% default — exact legacy timing.
+			hedgeAdvance = nil
+			receivedAt := timingReceivedAt(d.timing)
+			if receivedAt.IsZero() || !at.Before(receivedAt.Add(d.speculativeAt)) {
+				continue
+			}
+			if !speculativeTimer.Stop() {
+				continue
+			}
+			d.speculativeAt = at.Sub(receivedAt)
+			if d.speculativeAt < 0 {
+				d.speculativeAt = 0
+			}
+			speculativeTimer.Reset(d.firstTokenSpeculativeWait())
+			continue
 
 		case <-speculativeTimer.C:
 			if pr.FirstContentIngressArrivedByDeadline() {
@@ -1975,6 +2089,33 @@ func (d *dispatchState) runSpeculative() dispatchOutcome {
 		provider.Mu().Unlock()
 	}
 
+	// Hedge governor (Routing v2 Phase 4): insurance must never amplify an
+	// overload. A non-allow verdict suppresses the backup entirely and falls
+	// through the nil-backup branch below — byte-identical to today's
+	// "no backup available" path. The owner-served prefer skip above stays
+	// governor-blind: it is a product rule, not a capacity decision.
+	hedgeLaunched := false
+	if !skipBackup && s.hedgeGov != nil {
+		verdict := d.governorVerdictForBackup(provider.ID)
+		d.hedgeGovernorVerdict = verdict.String()
+		if verdict != hedgeAllow {
+			s.ddIncr("routing.hedge_governor_suppressed", []string{"model:" + d.model, "verdict:" + verdict.String()})
+			s.logger.Info("speculative_backup_suppressed",
+				"request_id", d.requestID,
+				"primary_provider", provider.ID,
+				"verdict", verdict.String(),
+			)
+			skipBackup = true
+		} else {
+			// Counted BEFORE the dispatch so the budget check and the
+			// increment cannot admit more hedges than the budget under
+			// concurrency (hedge_governor contract); released below when no
+			// backup actually launches, and at race resolution otherwise.
+			s.hedgeGov.noteHedgeLaunched()
+			hedgeLaunched = true
+		}
+	}
+
 	if !skipBackup {
 		d.pr.EnableSpeculativeEmptyCompletionArbitration()
 		backupExclude := make(map[string]struct{}, len(d.excludeProviders)+1)
@@ -1983,31 +2124,51 @@ func (d *dispatchState) runSpeculative() dispatchOutcome {
 		}
 		backupExclude[provider.ID] = struct{}{}
 
-		backupProvider, backupPR, _, backupErr, backupErrCode = s.dispatchOneProvider(
-			r, d.model, d.publicModel, d.rawBody, d.consumerKey, d.consumerLocation, d.reservedMicroUSD,
-			d.estimatedPromptTokens, d.deadline, d.requestedMaxTokens, d.tokenAdmission, d.requiresVision,
-			d.traits(),
-			d.allowedProviderSerials, d.isResponsesAPI, d.policy,
-			&registry.RequestTiming{ReceivedAt: d.timing.ReceivedAt},
-			d.serviceReservation,
-			d.cachePlan,
-			backupExclude,
-			d.attempt,
-			func(provider *registry.Provider, pr *registry.PendingRequest, decision registry.RoutingDecision) {
-				attemptedBackupProvider = provider
-				if pr != nil {
-					pr.EnableSpeculativeEmptyCompletionArbitration()
-					d.configurePending(pr)
-					backupRouteRecorded = true
-					backupRouteRequestID = pr.RequestID
-					backupRouteAttempt = pr.Attempt
-				}
-				d.recordRoutingDecisionFor(provider, pr, "", d.attempt, decision, "", "")
-			},
-		)
+		recordBackupRoute := func(provider *registry.Provider, pr *registry.PendingRequest, decision registry.RoutingDecision) {
+			attemptedBackupProvider = provider
+			if pr != nil {
+				pr.EnableSpeculativeEmptyCompletionArbitration()
+				d.configurePending(pr)
+				backupRouteRecorded = true
+				backupRouteRequestID = pr.RequestID
+				backupRouteAttempt = pr.Attempt
+			}
+			d.recordRoutingDecisionFor(provider, pr, "", d.attempt, decision, "", "")
+		}
+		// Routing v2 W2: the backup consumes the retained plan first — the
+		// next confirmed/revalidated entry, then the request's single refresh
+		// — falling back to the legacy full scan only when the plan machinery
+		// yields nothing (prefer-owner and legacy fleets keep their exact
+		// selection behavior). The backup shares only ReceivedAt with the
+		// primary's clock, as before.
+		backupTiming := &registry.RequestTiming{ReceivedAt: d.timing.ReceivedAt}
+		planTried := false
+		backupProvider, backupPR, _, backupErr, backupErrCode, planTried =
+			d.dispatchFromPlanMachinery(backupTiming, backupExclude, recordBackupRoute)
+		if !planTried {
+			backupProvider, backupPR, _, _, backupErr, backupErrCode = s.dispatchOneProvider(
+				r, d.model, d.publicModel, d.rawBody, d.consumerKey, d.consumerLocation, d.reservedMicroUSD,
+				d.estimatedPromptTokens, d.deadline, d.requestedMaxTokens, d.tokenAdmission, d.requiresVision,
+				d.traits(),
+				d.allowedProviderSerials, d.isResponsesAPI, d.policy,
+				backupTiming,
+				d.serviceReservation,
+				d.cachePlan,
+				backupExclude,
+				d.attempt,
+				recordBackupRoute,
+				d.noteProviderDispatched,
+			)
+		}
 	}
 
 	if backupProvider == nil {
+		if hedgeLaunched {
+			// The governor admitted a hedge that never dispatched — release
+			// its budget slot immediately. No outcome is recorded: no race
+			// ran, so there is nothing to fold into the win-rate EWMA.
+			s.hedgeGov.noteHedgeResolved()
+		}
 		if d.pr != nil {
 			d.pr.ResolveSpeculativeEmptyCompletion(true)
 		}
@@ -2038,7 +2199,16 @@ func (d *dispatchState) runSpeculative() dispatchOutcome {
 		"ttft_deadline_ms", d.deadline.Milliseconds(),
 		"speculative_at_ms", d.speculativeAt.Milliseconds(),
 	)
-	return d.runRace(backupProvider, backupPR)
+	outcome := d.runRace(backupProvider, backupPR)
+	if hedgeLaunched {
+		// Exactly-once hedge accounting: every runRace exit — win, loss,
+		// retry, client-gone, empty-completion promotion, and the failed-racer
+		// sub-waits — returns through here, and BackupWon is the winner marker
+		// every backup-win path sets before committing.
+		s.hedgeGov.noteHedgeResolved()
+		s.hedgeGov.recordHedgeOutcome(d.model, backupPR.BackupWon)
+	}
+	return outcome
 }
 
 // waitNoBackup is the speculative-no-backup branch (`noBackupWait`): keep waiting
@@ -3214,10 +3384,10 @@ exhausted:
 		// backend was chosen or degraded into (v0.8.0 paged rollout).
 		kvBackend := d.exhaustedKVBackendAttribution(failure, stickyFault)
 		s.emitRequest(r.Context(), protocol.SeverityError, d.requestID,
-			fmt.Sprintf("inference failed after %d attempt(s)", d.attempt+1),
+			fmt.Sprintf("inference failed after %d attempt(s)", d.exhaustionAttemptCount()),
 			map[string]any{
 				"reason":      "dispatch_exhausted",
-				"attempt":     d.attempt + 1,
+				"attempt":     d.exhaustionAttemptCount(),
 				"status_code": statusCode,
 				"last_error":  failure.errText,
 				"kv_backend":  kvBackend.Backend,
@@ -3231,6 +3401,21 @@ exhausted:
 		d.recordDispatchedRequestOutcome(kvBackend, classifyOutcomeByCode(statusCode))
 		if statusCode == http.StatusTooManyRequests || statusCode == http.StatusServiceUnavailable {
 			retryAfter := s.estimateRetryAfter(d.model)
+			if d.lastErrFeasibleAfterMS > 0 {
+				// Enriched rejection (routing v2): the rejecting provider
+				// forecast when a request of this shape could next be admitted
+				// — an honest Retry-After beats the queue-depth heuristic.
+				// Clamped to the heuristic's own [2,30]s band so a
+				// provider-authored value can neither hammer nor park clients.
+				hinted := int((d.lastErrFeasibleAfterMS + 999) / 1000)
+				if hinted < 2 {
+					hinted = 2
+				}
+				if hinted > 30 {
+					hinted = 30
+				}
+				retryAfter = hinted
+			}
 			w.Header().Set("Retry-After", strconv.Itoa(retryAfter))
 			info := d.rejectionInfo("dispatch", reason, statusCode, retryAfter*1000)
 			if !stickyFault && (d.unservable || failure.deadline) {
@@ -3247,7 +3432,7 @@ exhausted:
 		}
 		rateLimitMessage := fmt.Sprintf(
 			"all providers at capacity after %d attempt(s): %s",
-			d.attempt+1, failure.errText)
+			d.exhaustionAttemptCount(), failure.errText)
 		if reason == rejectionReasonDeadlineUnreachable {
 			rateLimitMessage = fmt.Sprintf(
 				"no provider could produce first content within the remaining deadline for model %q",
@@ -3275,7 +3460,7 @@ exhausted:
 			}
 		} else {
 			writeJSON(w, statusCode, errorResponse("provider_error",
-				fmt.Sprintf("inference failed after %d attempt(s): %s", d.attempt+1, failure.errText)))
+				fmt.Sprintf("inference failed after %d attempt(s): %s", d.exhaustionAttemptCount(), failure.errText)))
 		}
 		return
 	}

--- a/coordinator/api/dispatch.go
+++ b/coordinator/api/dispatch.go
@@ -150,6 +150,12 @@ type dispatchState struct {
 	// budget" rejection as deterministic (budget >= context) vs transient
 	// (budget < context — this node was memory-pressured).
 	lastErrProviderBudget int64
+	// lastErrRejectionReason is the typed CapacityRejectionReason from the
+	// last provider error ("" for legacy providers). classifyRejection
+	// treats a typed token_budget as AUTHORITATIVE transient: the provider's
+	// live gate named the shortage, so a deterministic-unservable verdict
+	// must never be re-derived from the stale heartbeat budget fallback.
+	lastErrRejectionReason protocol.CapacityRejectionReason
 	// lastErrTerminalCause is the typed terminal_cause from the last provider
 	// error ("" for legacy providers). shouldStopFailover trusts a typed
 	// admission_timeout as transient capacity directly — the provider's engine
@@ -657,6 +663,7 @@ func (d *dispatchState) setLastError(errText string, statusCode int) {
 	// fault): clear any budget captured from a prior attempt so it never bleeds
 	// into a later classification.
 	d.lastErrProviderBudget = 0
+	d.lastErrRejectionReason = ""
 	// Same bleed-through rule for the typed terminal fields: a coordinator-
 	// synthesized error is not a provider terminal, so a stale typed cause from
 	// a prior attempt must not reclassify it (shouldStopFailover trusts a typed
@@ -700,6 +707,7 @@ func isGenuinePreContentFault(
 	}
 	return classifyRejection(
 		msg.ErrorReason, msg.Error, providerBudget, modelContext,
+		msg.RejectionReason,
 	) == rejectionNotCapacity
 }
 
@@ -842,19 +850,23 @@ func (d *dispatchState) latchProviderBodyTooLarge(errText string) {
 func (d *dispatchState) setLastInferenceError(provider *registry.Provider, msg protocol.InferenceErrorMessage) {
 	msg = normalizeInferenceErrorForInternalUse(msg)
 	providerBudget := providerReportedBudget(provider, d.model)
-	if msg.AvailableTokenBudget > 0 {
+	if msg.AvailableTokenBudget != nil {
 		// Enriched rejection (routing v2): the LIVE gate budget at rejection
 		// time beats the last heartbeat's snapshot — this closes the
 		// documented stale-snapshot LIMITATION in classifyRejection, where a
 		// budget that shrank below the model context between heartbeats
-		// misclassified a node-pressured reject as fleet-deterministic.
-		providerBudget = msg.AvailableTokenBudget
+		// misclassified a node-pressured reject as fleet-deterministic. The
+		// wire field is a pointer precisely so an EXPLICIT zero survives:
+		// it means "this node has no headroom RIGHT NOW" (maximally
+		// transient, budget frees as sequences retire), never "unknown".
+		providerBudget = *msg.AvailableTokenBudget
 	}
 	d.lastErr = msg.Error
 	d.lastErrCode = msg.StatusCode
 	d.lastErrReason = msg.ErrorReason
 	d.lastFailureDeadline = isDeadlineUnreachableErrorReason(msg.ErrorReason)
 	d.lastErrProviderBudget = providerBudget
+	d.lastErrRejectionReason = msg.RejectionReason
 	d.lastErrTerminalCause = msg.TerminalCause
 	d.lastErrCoordinatorCause = msg.CoordinatorCause
 	d.lastErrAttemptUsage = msg.AttemptUsage
@@ -1716,7 +1728,7 @@ func (d *dispatchState) shouldStopFailover() bool {
 	// through the legacy capacity substrings, gets classified as a generic
 	// fault, and walks the unbounded fault-failover ladder to a final 503
 	// instead of the bounded capacity retries and uptime-neutral 429.
-	kind := classifyRejection(d.lastErrReason, d.lastErr, d.lastErrProviderBudget, d.modelMaxContext)
+	kind := classifyRejection(d.lastErrReason, d.lastErr, d.lastErrProviderBudget, d.modelMaxContext, d.lastErrRejectionReason)
 	if kind != rejectionDeadlineUnreachable &&
 		d.lastErrTerminalCause == terminalCauseAdmissionTimeout {
 		kind = rejectionTransientCapacity
@@ -1786,7 +1798,14 @@ func (d *dispatchState) latchJinjaTerminalReject(reason, src string) (latched bo
 // d.unservable is only consulted on the exhausted/retry path, never on a commit.
 func (d *dispatchState) latchDeterministicLoser(provider *registry.Provider, msg protocol.InferenceErrorMessage) {
 	msg = normalizeInferenceErrorForInternalUse(msg)
-	d.captureGenuineFault(provider, msg, providerReportedBudget(provider, d.model))
+	// Same budget preference as setLastInferenceError: the enriched LIVE
+	// gate budget (explicit zero included) supersedes the stale heartbeat
+	// snapshot for this loser's classification.
+	budget := providerReportedBudget(provider, d.model)
+	if msg.AvailableTokenBudget != nil {
+		budget = *msg.AvailableTokenBudget
+	}
+	d.captureGenuineFault(provider, msg, budget)
 	if d.unservable || d.terminalClientError {
 		return
 	}
@@ -1810,8 +1829,7 @@ func (d *dispatchState) latchDeterministicLoser(provider *registry.Provider, msg
 		d.latchTerminalAttribution(provider)
 		return
 	}
-	budget := providerReportedBudget(provider, d.model)
-	switch classifyRejection(msg.ErrorReason, msg.Error, budget, d.modelMaxContext) {
+	switch classifyRejection(msg.ErrorReason, msg.Error, budget, d.modelMaxContext, msg.RejectionReason) {
 	case rejectionDeadlineUnreachable:
 		// A race loser that could not meet the remaining absolute deadline is
 		// health-neutral and non-deterministic across providers. It must not
@@ -2094,10 +2112,17 @@ func (d *dispatchState) runSpeculative() dispatchOutcome {
 	// through the nil-backup branch below — byte-identical to today's
 	// "no backup available" path. The owner-served prefer skip above stays
 	// governor-blind: it is a product rule, not a capacity decision.
+	//
+	// The verdict and the budget-slot increment are ONE atomic governor
+	// operation (tryAcquireHedge): concurrent slow requests can no longer
+	// each read the last free slot and all launch past the fleet-wide cap.
+	// An acquired slot is released exactly once — below when no backup
+	// actually dispatches, at race resolution otherwise.
 	hedgeLaunched := false
 	if !skipBackup && s.hedgeGov != nil {
-		verdict := d.governorVerdictForBackup(provider.ID)
+		verdict, acquired := d.tryAcquireBackupHedge(provider.ID)
 		d.hedgeGovernorVerdict = verdict.String()
+		hedgeLaunched = acquired
 		if verdict != hedgeAllow {
 			s.ddIncr("routing.hedge_governor_suppressed", []string{"model:" + d.model, "verdict:" + verdict.String()})
 			s.logger.Info("speculative_backup_suppressed",
@@ -2106,13 +2131,6 @@ func (d *dispatchState) runSpeculative() dispatchOutcome {
 				"verdict", verdict.String(),
 			)
 			skipBackup = true
-		} else {
-			// Counted BEFORE the dispatch so the budget check and the
-			// increment cannot admit more hedges than the budget under
-			// concurrency (hedge_governor contract); released below when no
-			// backup actually launches, and at race resolution otherwise.
-			s.hedgeGov.noteHedgeLaunched()
-			hedgeLaunched = true
 		}
 	}
 

--- a/coordinator/api/dispatch_plan_wiring.go
+++ b/coordinator/api/dispatch_plan_wiring.go
@@ -1,0 +1,277 @@
+package api
+
+import (
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+	"github.com/eigeninference/d-inference/coordinator/registry"
+	"github.com/eigeninference/d-inference/coordinator/saferun"
+)
+
+// Routing v2 wave-2 dispatch wiring: the dispatchState half of the bounded
+// plan (registry/dispatch_plan.go), the parallel capacity-probe round
+// (registry/capacity_quotes.go), and the hedge governor/schedule
+// (hedge_governor.go / hedge_schedule.go).
+//
+// Shape of the flow:
+//
+//	dispatchPrimary        — full scan retains the plan; after the primary
+//	                         frame handoff, ONE probe round confirms/demotes
+//	                         the alternates in parallel with the prompt.
+//	waitFirstChunk         — may re-arm the speculative timer EARLIER when the
+//	                         probe round proves the 50% point launches a backup
+//	                         too late to win (hedgeLaunchAt).
+//	runSpeculative         — the governor gates the launch; an admitted backup
+//	                         consumes the plan before any rescan.
+//	run (failover retries) — next attempts consume the plan before any rescan;
+//	                         one RefreshDispatchPlan per logical request.
+//
+// Everything here degrades to the exact legacy behavior when the plan is
+// empty/nil (legacy fleets, queue path, prefer-owner): no probes, the 50%
+// launch point, full-scan selection.
+
+// capacityProbeWindow bounds how long probed alternates get to answer before
+// silence demotes them. 250ms (plan Phase 3): informational, never blocking —
+// the primary is already in flight and the window is well inside the gap to
+// the earliest useful hedge point on the ordinary 9s budget.
+const capacityProbeWindow = 250 * time.Millisecond
+
+// dispatchPlanProbeFanout sizes the collector's confidence map: a plan
+// retains at most eight alternates (registry dispatchPlanMaxAlternates), so a
+// probe round settles at most eight outcomes.
+const dispatchPlanProbeFanout = 8
+
+// noteProviderDispatched counts one inference frame actually handed to a
+// provider. It is invoked from the write handoff callback — the same instant
+// Timing.DispatchedAt is stamped — for the primary, queued, plan-retry, and
+// speculative-backup sends alike. The deferred writer blocks the dispatching
+// goroutine until the frame is handed off, so the increment happens-before
+// every later read on the dispatch goroutine (the same publication discipline
+// Timing.DispatchedAt relies on).
+func (d *dispatchState) noteProviderDispatched() {
+	d.providerDispatches++
+}
+
+// exhaustionAttemptCount is the machine count client-visible exhaustion
+// messages and terminal logs report: actual provider dispatches when any
+// frame reached a provider (plan Phase 3: "providerDispatches counts actual
+// inference sends"), else the legacy loop count for requests that never
+// dispatched (selection-only failures keep their historical "after 1
+// attempt(s)" framing). Route rows keep the raw loop index unchanged.
+func (d *dispatchState) exhaustionAttemptCount() int {
+	if d.providerDispatches > 0 {
+		return d.providerDispatches
+	}
+	return d.attempt + 1
+}
+
+// dispatchProviderWith runs the single prepare/encrypt/write funnel with a
+// caller-chosen reserver, forwarding the request-shape inputs retained on
+// dispatchState. timing is caller-supplied because the speculative backup
+// deliberately shares only ReceivedAt with the primary's clock.
+func (d *dispatchState) dispatchProviderWith(
+	reserve dispatchReserver,
+	timing *registry.RequestTiming,
+	exclude map[string]struct{},
+	recordRoute routeDecisionRecorder,
+) (*registry.Provider, *registry.PendingRequest, registry.RoutingDecision, *registry.DispatchPlan, string, int) {
+	return d.s.dispatchWithReserver(
+		d.r, d.model, d.publicModel, d.rawBody, d.consumerKey, d.consumerLocation,
+		d.reservedMicroUSD, d.estimatedPromptTokens, d.deadline, d.requestedMaxTokens,
+		d.tokenAdmission, d.requiresVision, d.traits(), d.allowedProviderSerials,
+		d.isResponsesAPI, d.policy, timing, d.serviceReservation, d.cachePlan,
+		exclude, d.attempt, recordRoute, d.noteProviderDispatched, reserve,
+	)
+}
+
+// dispatchFromPlanMachinery consumes the retained plan for a retry or backup
+// dispatch: the next revalidated plan entry first, then the request's single
+// RefreshDispatchPlan. tried=false means the machinery yielded no reservation
+// (plan nil/exhausted and the refresh spent or empty) and the caller must fall
+// back to the legacy full scan — which preserves every existing terminal
+// classification, because the plan path only changes WHERE the next provider
+// comes from, never whether or why dispatch stops.
+//
+// When tried=true, the returned values carry dispatchOneProvider's exact
+// semantics: a reserved provider whose funnel failed comes back nil with the
+// funnel's error string/code, so the caller's failure handling is unchanged.
+func (d *dispatchState) dispatchFromPlanMachinery(
+	timing *registry.RequestTiming,
+	exclude map[string]struct{},
+	recordRoute routeDecisionRecorder,
+) (provider *registry.Provider, pr *registry.PendingRequest, decision registry.RoutingDecision, lastErr string, lastErrCode int, tried bool) {
+	plan := d.plan
+	if plan == nil {
+		return nil, nil, decision, "", 0, false
+	}
+	// 1) Next retained entry, re-verified against CURRENT state by
+	// ReserveNextFromPlan (identity, full gate chain, atomic reservation).
+	reserved := false
+	provider, pr, decision, _, lastErr, lastErrCode = d.dispatchProviderWith(
+		func(pending *registry.PendingRequest, excludeIDs []string) (*registry.Provider, registry.RoutingDecision, *registry.DispatchPlan) {
+			p, dec, _ := d.s.registry.ReserveNextFromPlan(pending, plan, excludeIDs...)
+			reserved = p != nil
+			return p, dec, nil
+		},
+		timing, exclude, recordRoute,
+	)
+	if reserved {
+		return provider, pr, decision, lastErr, lastErrCode, true
+	}
+	// 2) The single full re-scan refresh. Latched on dispatchState (not just
+	// the plan) so the retry loop and the speculative backup share ONE
+	// refresh per logical request no matter how plans are threaded.
+	if d.planRefreshUsed {
+		return nil, nil, decision, "", 0, false
+	}
+	d.planRefreshUsed = true
+	var fresh *registry.DispatchPlan
+	provider, pr, decision, fresh, lastErr, lastErrCode = d.dispatchProviderWith(
+		func(pending *registry.PendingRequest, excludeIDs []string) (*registry.Provider, registry.RoutingDecision, *registry.DispatchPlan) {
+			p, dec, freshPlan, performed := d.s.registry.RefreshDispatchPlan(pending, plan, excludeIDs...)
+			if !performed {
+				return nil, dec, nil
+			}
+			reserved = p != nil
+			return p, dec, freshPlan
+		},
+		timing, exclude, recordRoute,
+	)
+	if fresh != nil {
+		// The refreshed plan (born with its refresh consumed) replaces the
+		// exhausted one so later retries/backups keep consuming entries.
+		d.plan = fresh
+	}
+	if !reserved {
+		return nil, nil, decision, "", 0, false
+	}
+	return provider, pr, decision, lastErr, lastErrCode, true
+}
+
+// maybeProbePlanCandidates launches the request's one capacity-probe round
+// for the alternates retained by the primary reservation. Called strictly
+// AFTER the primary frame handoff succeeded: probes run in parallel with the
+// in-flight prompt and can never add primary latency (plan decision #1).
+func (d *dispatchState) maybeProbePlanCandidates() {
+	if d.probesLaunched || d.plan == nil || d.plan.Len() == 0 {
+		return
+	}
+	// Prefer-owner and exclusive self-route requests are never probed against
+	// the fleet (plan invariant): their backup rules are owner-scoped, so a
+	// confirmed public alternate would have no consumer.
+	if d.policy.enabled || d.policy.prefer {
+		return
+	}
+	receivedAt := timingReceivedAt(d.timing)
+	remaining, ok := d.firstTokenRemaining()
+	if receivedAt.IsZero() || !ok || remaining <= 0 {
+		// No request-absolute clock (legacy timing, unit fixtures): a refined
+		// hedge instant could not be applied anyway — waitFirstChunk's re-arm
+		// mirrors first_token_clock.go invariant 5 and needs ReceivedAt.
+		return
+	}
+	d.probesLaunched = true
+	d.hedgeAdvanceCh = make(chan time.Time, 1)
+	outcomes := d.s.registry.ProbePlanCandidates(d.plan, registry.CapacityProbeShape{
+		Model:             d.model,
+		PromptTokens:      d.estimatedPromptTokens,
+		MaxOutputTokens:   d.requestedMaxTokens,
+		RequiresVision:    d.requiresVision,
+		VisionImageCount:  d.visionImageCount,
+		DeadlineRemaining: remaining,
+	}, capacityProbeWindow)
+	plan := d.plan
+	advance := d.hedgeAdvanceCh
+	deadline := d.deadline
+	speculativeAt := d.speculativeAt
+	saferun.Go(d.s.logger, "api.collectCapacityQuotes", func() {
+		collectCapacityQuotes(outcomes, plan, receivedAt, deadline, speculativeAt, advance)
+	})
+}
+
+// collectCapacityQuotes drains one probe round. The registry collector has
+// already applied every outcome to the plan (ConfirmEntry/DemoteEntry happen
+// BEFORE an outcome is readable — ProbePlanCandidates contract), so this
+// consumer never re-applies them; it only extracts the hedge-timing
+// refinement: when the settled round leaves a best confirmed backup whose
+// HIGH-confidence quoted q90 proves the 50% point launches too late to win,
+// the strictly earlier absolute launch instant is delivered on advance
+// (buffered 1, non-blocking) for waitFirstChunk to re-arm against.
+func collectCapacityQuotes(
+	outcomes <-chan registry.QuoteOutcome,
+	plan *registry.DispatchPlan,
+	receivedAt time.Time,
+	deadline time.Duration,
+	speculativeAt time.Duration,
+	advance chan<- time.Time,
+) {
+	// Confidence grades per answering provider: BestConfirmedBackup returns
+	// identity + q90 but not the quote's provenance, and only a
+	// high-confidence measured quote may move the launch point
+	// (hedge_schedule.go invariant 1).
+	confidences := make(map[string]hedgeQuoteConfidence, dispatchPlanProbeFanout)
+	for outcome := range outcomes {
+		if outcome.Quote != nil && outcome.Quote.AdmissibleNow {
+			confidences[outcome.ProviderID] = quoteHedgeConfidence(outcome.Quote.Confidence)
+		}
+	}
+	providerID, ttftP90, ok := plan.BestConfirmedBackup()
+	if !ok {
+		return
+	}
+	at := hedgeLaunchAt(receivedAt, deadline, ttftP90, confidences[providerID])
+	if !at.Before(receivedAt.Add(speculativeAt)) {
+		// Not strictly earlier than the armed point: nothing to refine
+		// (hedgeLaunchOffset never schedules later than the 50% ceiling, and
+		// speculativeAt stays the 50% default without a confirmed quote).
+		return
+	}
+	select {
+	case advance <- at:
+	default:
+	}
+}
+
+// quoteHedgeConfidence maps the wire confidence grade onto the hedge
+// schedule's vocabulary. Unknown/absent grades collapse to none — only
+// hedgeConfidenceHigh may move a launch earlier.
+func quoteHedgeConfidence(confidence string) hedgeQuoteConfidence {
+	switch confidence {
+	case protocol.CapacityConfidenceHigh:
+		return hedgeConfidenceHigh
+	case protocol.CapacityConfidenceLow:
+		return hedgeConfidenceLow
+	}
+	return hedgeConfidenceNone
+}
+
+// governorVerdictForBackup snapshots the registry-side inputs (idle
+// alternative, model queue depth, fleet idle slots — advisory, RLock-only)
+// plus the Server governor's mutable state and applies the launch rules.
+//
+// Two deliberate legacy escapes, per the dual-path decision (plan #3):
+//   - A Server without a governor (bare test literals) keeps the legacy
+//     always-hedge behavior rather than failing closed on a fixture gap.
+//   - A capacity-SILENT fleet for the model (no provider reports a
+//     BackendCapacity snapshot and none is quote-capable) makes every
+//     governor input meaningless — (false, 0, 0) there is ignorance, not
+//     saturation — so legacy providers keep today's unconditional 50% hedge
+//     instead of losing insurance to a signal they cannot emit.
+func (d *dispatchState) governorVerdictForBackup(primaryID string) hedgeVerdict {
+	g := d.s.hedgeGov
+	if g == nil {
+		return hedgeAllow
+	}
+	exclude := append(d.excludedProviderIDs(), primaryID)
+	idleAlt, queueDepth, fleetIdle, capacitySignals := d.s.registry.HedgeGovernorSnapshot(d.model, d.pr, exclude...)
+	if !capacitySignals {
+		return hedgeAllow
+	}
+	return hedgeGovernorVerdict(hedgeGovernorInputs{
+		idleAlternativeExists: idleAlt,
+		modelQueueDepth:       queueDepth,
+		activeHedges:          g.activeHedgeCount(),
+		fleetIdleSlots:        fleetIdle,
+		modelWinRate:          g.modelWinRate(d.model),
+	})
+}

--- a/coordinator/api/dispatch_plan_wiring.go
+++ b/coordinator/api/dispatch_plan_wiring.go
@@ -245,33 +245,37 @@ func quoteHedgeConfidence(confidence string) hedgeQuoteConfidence {
 	return hedgeConfidenceNone
 }
 
-// governorVerdictForBackup snapshots the registry-side inputs (idle
-// alternative, model queue depth, fleet idle slots — advisory, RLock-only)
-// plus the Server governor's mutable state and applies the launch rules.
+// tryAcquireBackupHedge snapshots the registry-side inputs (idle alternative,
+// model queue depth, fleet idle slots — advisory, RLock-only) and hands them
+// to the governor's tryAcquireHedge, which applies the launch rules AND
+// claims the global budget slot in one atomic operation. acquired hedges MUST
+// be released exactly once via noteHedgeResolved (runSpeculative owns that).
 //
 // Two deliberate legacy escapes, per the dual-path decision (plan #3):
 //   - A Server without a governor (bare test literals) keeps the legacy
 //     always-hedge behavior rather than failing closed on a fixture gap.
+//     Nothing is acquired: there is no counter to release.
 //   - A capacity-SILENT fleet for the model (no provider reports a
 //     BackendCapacity snapshot and none is quote-capable) makes every
 //     governor input meaningless — (false, 0, 0) there is ignorance, not
 //     saturation — so legacy providers keep today's unconditional 50% hedge
-//     instead of losing insurance to a signal they cannot emit.
-func (d *dispatchState) governorVerdictForBackup(primaryID string) hedgeVerdict {
+//     instead of losing insurance to a signal they cannot emit. The hedge is
+//     still really in flight, so it acquires a slot ungoverned: capacity-
+//     aware requests must see it against their budget.
+func (d *dispatchState) tryAcquireBackupHedge(primaryID string) (hedgeVerdict, bool) {
 	g := d.s.hedgeGov
 	if g == nil {
-		return hedgeAllow
+		return hedgeAllow, false
 	}
 	exclude := append(d.excludedProviderIDs(), primaryID)
 	idleAlt, queueDepth, fleetIdle, capacitySignals := d.s.registry.HedgeGovernorSnapshot(d.model, d.pr, exclude...)
 	if !capacitySignals {
-		return hedgeAllow
+		g.acquireHedgeUngoverned()
+		return hedgeAllow, true
 	}
-	return hedgeGovernorVerdict(hedgeGovernorInputs{
+	return g.tryAcquireHedge(d.model, hedgeGovernorInputs{
 		idleAlternativeExists: idleAlt,
 		modelQueueDepth:       queueDepth,
-		activeHedges:          g.activeHedgeCount(),
 		fleetIdleSlots:        fleetIdle,
-		modelWinRate:          g.modelWinRate(d.model),
 	})
 }

--- a/coordinator/api/dispatch_plan_wiring_test.go
+++ b/coordinator/api/dispatch_plan_wiring_test.go
@@ -1,0 +1,470 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+	"github.com/eigeninference/d-inference/coordinator/registry"
+	"github.com/eigeninference/d-inference/coordinator/store"
+)
+
+// planWiringProvider registers a fully-routable provider through the exported
+// registry surface (the api-side mirror of the registry package's
+// makeTokenBudgetProvider fixture): trusted, manifest-checked, E2E-capable,
+// with a running model-resident slot whose token-budget backlog dominates
+// routing cost, so winner and plan order are deterministic. The connection is
+// nil, so no provider writer exists: a reservation succeeds, the funnel
+// prepares and encrypts, and the deferred write then fails deterministically
+// ("failed to send request to provider") — which lets tests observe that an
+// entry went through the single prepare/encrypt/write funnel without a live
+// provider socket.
+func planWiringProvider(t *testing.T, reg *registry.Registry, id, model string, backlogTokens int64) *registry.Provider {
+	t.Helper()
+	p := reg.Register(id, nil, &protocol.RegisterMessage{
+		Type: protocol.TypeRegister,
+		Hardware: protocol.Hardware{
+			MachineModel:       "Mac15,8",
+			ChipName:           "Apple M3 Max",
+			ChipFamily:         "M3",
+			ChipTier:           "Max",
+			MemoryGB:           64,
+			MemoryAvailableGB:  60,
+			CPUCores:           protocol.CPUCores{Total: 16, Performance: 12, Efficiency: 4},
+			GPUCores:           40,
+			MemoryBandwidthGBs: 400,
+		},
+		Models:                  []protocol.ModelInfo{{ID: model, ModelType: "chat", Quantization: "4bit"}},
+		Backend:                 registry.BackendMLXSwift,
+		DecodeTPS:               100,
+		PublicKey:               "fX6XYH7p2hmM3ogeXaAsY+p8M6UKD1df/LJUN9Nj9Nw=",
+		EncryptedResponseChunks: true,
+		PrivacyCapabilities: &protocol.PrivacyCapabilities{
+			TextBackendInprocess:    true,
+			TextProxyDisabled:       true,
+			PythonRuntimeLocked:     true,
+			DangerousModulesBlocked: true,
+			SIPEnabled:              true,
+			AntiDebugEnabled:        true,
+			CoreDumpsDisabled:       true,
+			EnvScrubbed:             true,
+		},
+	})
+	p.Mu().Lock()
+	p.TrustLevel = registry.TrustHardware
+	p.RuntimeVerified = true
+	p.RuntimeManifestChecked = true
+	p.ChallengeVerifiedSIP = true
+	p.LastChallengeVerified = time.Now()
+	p.SystemMetrics = protocol.SystemMetrics{MemoryPressure: 0.1, CPUUsage: 0.1, ThermalState: "nominal"}
+	p.BackendCapacity = &protocol.BackendCapacity{
+		TotalMemoryGB: 64,
+		Slots: []protocol.BackendSlotCapacity{{
+			Model:                 model,
+			State:                 "running",
+			ActiveTokenBudgetUsed: backlogTokens,
+			ActiveTokenBudgetMax:  1_000_000,
+			ObservedDecodeTPS:     80,
+		}},
+	}
+	p.Mu().Unlock()
+	return p
+}
+
+// planWiringPlan reserves through the production scan to obtain a real
+// DispatchPlan, then releases the primary reservation (the routability-probe
+// idiom, helpers_ws_test.go findRoutableProvider).
+func planWiringPlan(t *testing.T, reg *registry.Registry, model string) *registry.DispatchPlan {
+	t.Helper()
+	probe := &registry.PendingRequest{
+		RequestID:             "plan-wiring-probe",
+		Model:                 model,
+		EstimatedPromptTokens: 500,
+		RequestedMaxTokens:    256,
+	}
+	primary, decision, plan := reg.ReserveProviderWithPlan(model, probe)
+	if primary == nil || plan == nil {
+		t.Fatalf("plan reservation failed: decision=%+v", decision)
+	}
+	primary.RemovePending(probe.RequestID)
+	reg.SetProviderIdle(primary.ID)
+	return plan
+}
+
+// TestPlanFirstRetryConsumesPlanBeforeRescanAndRefreshesOnce pins Phase-3
+// retry selection: while plan entries remain, every dispatch reserves the
+// next retained entry through the single funnel (no full rescan), the
+// exhausted plan spends exactly ONE RefreshDispatchPlan for the whole logical
+// request, and afterwards the machinery reports tried=false so the caller
+// falls back to the unchanged legacy scan.
+func TestPlanFirstRetryConsumesPlanBeforeRescanAndRefreshesOnce(t *testing.T) {
+	s := newTestServerForDispatch(t)
+	const model = "plan-wiring-retry-model"
+	for i := range 6 {
+		planWiringProvider(t, s.registry, fmt.Sprintf("pw%d", i), model, int64(i)*400)
+	}
+	plan := planWiringPlan(t, s.registry, model)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader("{}"))
+	d := &dispatchState{
+		s:                 s,
+		r:                 req,
+		model:             model,
+		publicModel:       model,
+		rawBody:           []byte(`{"model":"` + model + `"}`),
+		deadline:          5 * time.Second,
+		speculativeAt:     2500 * time.Millisecond,
+		timing:            &registry.RequestTiming{ReceivedAt: time.Now()},
+		excludeProviders:  map[string]struct{}{},
+		refundReservation: func() {},
+		plan:              plan,
+	}
+
+	entries := plan.Len()
+	if entries == 0 {
+		t.Fatal("fixture retained no alternates")
+	}
+	for i := range entries {
+		provider, pr, _, lastErr, _, tried := d.dispatchFromPlanMachinery(d.timing, d.excludeProviders, nil)
+		if !tried {
+			t.Fatalf("entry %d: machinery yielded nothing with %d entries remaining", i, d.plan.Remaining())
+		}
+		if provider != nil || pr != nil {
+			t.Fatalf("entry %d: socketless provider must fail the funnel write, got provider=%v", i, provider)
+		}
+		if lastErr != "failed to send request to provider" {
+			t.Fatalf("entry %d: lastErr=%q — the plan entry did not go through the single dispatch funnel", i, lastErr)
+		}
+		if d.planRefreshUsed {
+			t.Fatalf("entry %d: consuming a retained entry must not spend the refresh", i)
+		}
+	}
+	if got := d.plan.Remaining(); got != 0 {
+		t.Fatalf("remaining=%d after consuming every entry", got)
+	}
+
+	// Exhausted plan → the single refresh runs. Winner + every alternate is
+	// attempted across a 6-provider fleet, so the refresh scan (which carries
+	// those exclusions) finds nothing: tried=false, refresh latched.
+	if _, _, _, _, _, tried := d.dispatchFromPlanMachinery(d.timing, d.excludeProviders, nil); tried {
+		t.Fatal("refresh over a fully-attempted fleet must yield nothing")
+	}
+	if !d.planRefreshUsed {
+		t.Fatal("exhausted plan must spend the request's one refresh")
+	}
+	// Once per logical request: the machinery never refreshes again.
+	if _, _, _, _, _, tried := d.dispatchFromPlanMachinery(d.timing, d.excludeProviders, nil); tried {
+		t.Fatal("second refresh must not run")
+	}
+}
+
+// TestHedgeAdvanceRearmsSpeculativeTimerEarlier pins the waitFirstChunk
+// re-arm guards: a strictly-earlier probe-refined instant moves the backup
+// launch off the 50% point, while a not-earlier value leaves the legacy
+// timing untouched (invariant 1 of hedge_schedule.go — the 50% point is a
+// ceiling, never exceeded).
+func TestHedgeAdvanceRearmsSpeculativeTimerEarlier(t *testing.T) {
+	t.Run("earlier instant launches the backup sooner", func(t *testing.T) {
+		d, _ := firstTokenWaitState(t, 0, 1200*time.Millisecond)
+		d.speculativeAt = 900 * time.Millisecond
+		receivedAt := timingReceivedAt(d.timing)
+		d.hedgeAdvanceCh = make(chan time.Time, 1)
+		d.hedgeAdvanceCh <- receivedAt.Add(150 * time.Millisecond)
+
+		speculativeStarted := make(chan time.Time, 1)
+		d.onSpeculativeDispatch = func() { speculativeStarted <- time.Now() }
+
+		go d.waitFirstChunk()
+		select {
+		case at := <-speculativeStarted:
+			if since := at.Sub(receivedAt); since > 600*time.Millisecond {
+				t.Fatalf("backup launched %s after receipt, want ~150ms (re-armed), not the 900ms default", since)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatal("speculative launch never fired")
+		}
+		if d.speculativeAt != 150*time.Millisecond {
+			t.Fatalf("speculativeAt=%s after re-arm, want 150ms so downstream windows agree", d.speculativeAt)
+		}
+	})
+
+	t.Run("not-earlier instant is ignored", func(t *testing.T) {
+		d, _ := firstTokenWaitState(t, 0, 1200*time.Millisecond)
+		d.speculativeAt = 500 * time.Millisecond
+		receivedAt := timingReceivedAt(d.timing)
+		d.hedgeAdvanceCh = make(chan time.Time, 1)
+		// Equal to the armed point: NOT strictly earlier, must not re-arm.
+		d.hedgeAdvanceCh <- receivedAt.Add(500 * time.Millisecond)
+
+		speculativeStarted := make(chan time.Time, 1)
+		d.onSpeculativeDispatch = func() { speculativeStarted <- time.Now() }
+
+		go d.waitFirstChunk()
+		select {
+		case at := <-speculativeStarted:
+			if since := at.Sub(receivedAt); since < 400*time.Millisecond {
+				t.Fatalf("backup launched %s after receipt — a not-earlier advance re-armed the timer", since)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatal("speculative launch never fired")
+		}
+		if d.speculativeAt != 500*time.Millisecond {
+			t.Fatalf("speculativeAt=%s, want the untouched 500ms default", d.speculativeAt)
+		}
+	})
+}
+
+// TestGovernorSuppressionFallsThroughToNoBackup pins the Phase-4 gate: in a
+// capacity-REPORTING fleet with no idle capacity anywhere (the only
+// alternative is occupied), the governor suppresses the backup, records its
+// verdict, and the request falls through the exact legacy no-backup wait —
+// same outcome, same 504-shaped last error, and a zero in-flight hedge count
+// afterwards.
+func TestGovernorSuppressionFallsThroughToNoBackup(t *testing.T) {
+	d, _ := firstTokenWaitState(t, 0, 500*time.Millisecond)
+	d.speculativeAt = 30 * time.Millisecond
+	// A capacity-reporting alternative that is fully occupied: the fleet
+	// emits real signals (no silent-fleet bypass) but offers no idle slot.
+	busy := planWiringProvider(t, d.s.registry, "busy-alt", d.model, 0)
+	busy.Mu().Lock()
+	busy.BackendCapacity.Slots[0].NumRunning = 2
+	busy.BackendCapacity.Slots[0].ActiveTokens = 5000
+	busy.Mu().Unlock()
+
+	if got := d.waitFirstChunk(); got != outcomeRetry {
+		t.Fatalf("waitFirstChunk=%v, want timeout-driven outcomeRetry", got)
+	}
+	if d.hedgeGovernorVerdict != hedgeSuppressNoIdleCapacity.String() {
+		t.Fatalf("verdict=%q, want %q", d.hedgeGovernorVerdict, hedgeSuppressNoIdleCapacity.String())
+	}
+	if d.lastErrCode != http.StatusGatewayTimeout {
+		t.Fatalf("lastErrCode=%d, want the legacy no-backup 504", d.lastErrCode)
+	}
+	if got := d.s.hedgeGov.activeHedgeCount(); got != 0 {
+		t.Fatalf("activeHedges=%d after suppression, want 0", got)
+	}
+}
+
+// TestGovernorBypassesCapacitySilentFleet pins the dual-path escape (plan
+// decision #3): a fleet that reports NO capacity signals for the model gives
+// the governor meaningless inputs, so legacy providers keep today's
+// unconditional hedge — verdict allow, never a suppression they cannot
+// influence.
+func TestGovernorBypassesCapacitySilentFleet(t *testing.T) {
+	d, _ := firstTokenWaitState(t, 0, 500*time.Millisecond)
+	d.speculativeAt = 30 * time.Millisecond
+
+	if got := d.waitFirstChunk(); got != outcomeRetry {
+		t.Fatalf("waitFirstChunk=%v, want timeout-driven outcomeRetry", got)
+	}
+	if d.hedgeGovernorVerdict != hedgeAllow.String() {
+		t.Fatalf("verdict=%q, want %q — a capacity-silent fleet must keep the legacy hedge path", d.hedgeGovernorVerdict, hedgeAllow.String())
+	}
+	if got := d.s.hedgeGov.activeHedgeCount(); got != 0 {
+		t.Fatalf("activeHedges=%d after resolution, want 0", got)
+	}
+}
+
+// TestGovernorAllowKeepsLegacyBackupPath pins default-path equivalence: with
+// an idle-loaded eligible alternative and no queued demand the governor
+// allows, the backup selection runs exactly the legacy full scan (no plan
+// retained), and the admitted-but-never-dispatched hedge slot is released —
+// exactly-once accounting even when the funnel refuses the backup.
+func TestGovernorAllowKeepsLegacyBackupPath(t *testing.T) {
+	d, _ := firstTokenWaitState(t, 0, 500*time.Millisecond)
+	d.speculativeAt = 30 * time.Millisecond
+	d.rawBody = []byte(`{"model":"first-token-deadline-model"}`)
+	// An idle, trusted, model-resident alternative: the governor's spare
+	// capacity condition holds. It has no socket, so the legacy backup
+	// dispatch reserves it and then fails the deferred write — the allow path
+	// is observable without a live provider.
+	planWiringProvider(t, d.s.registry, "idle-backup", d.model, 0)
+
+	if got := d.waitFirstChunk(); got != outcomeRetry {
+		t.Fatalf("waitFirstChunk=%v, want timeout-driven outcomeRetry", got)
+	}
+	if d.hedgeGovernorVerdict != hedgeAllow.String() {
+		t.Fatalf("verdict=%q, want %q (idle capacity exists, no queue)", d.hedgeGovernorVerdict, hedgeAllow.String())
+	}
+	// The backup dispatch is observable through its persisted routing
+	// decision: runSpeculative's recordBackupRoute records a route row for
+	// the reserved backup before the funnel's deferred write fails. (The
+	// backup exclusion set is a request-local copy, so d.excludeProviders is
+	// deliberately NOT the observable here.)
+	st, ok := d.s.store.(*store.MemoryStore)
+	if !ok {
+		t.Fatalf("store = %T", d.s.store)
+	}
+	backupRouted := false
+	for _, route := range st.InferenceRouteRecordsSince(time.Time{}) {
+		if route.ProviderID == "idle-backup" {
+			backupRouted = true
+			break
+		}
+	}
+	if !backupRouted {
+		t.Fatal("allow path must have run the legacy backup dispatch (no route row for the reserved backup)")
+	}
+	if got := d.s.hedgeGov.activeHedgeCount(); got != 0 {
+		t.Fatalf("activeHedges=%d, want 0 — an admitted hedge that never dispatched must be released", got)
+	}
+}
+
+// TestExhaustionAttemptCountPrefersProviderDispatches pins the Phase-3
+// counting rule: client-visible exhaustion messages report frames actually
+// handed to providers, falling back to the legacy loop count only when
+// nothing ever dispatched.
+func TestExhaustionAttemptCountPrefersProviderDispatches(t *testing.T) {
+	d := &dispatchState{attempt: 7}
+	if got := d.exhaustionAttemptCount(); got != 8 {
+		t.Fatalf("no dispatches: count=%d, want legacy attempt+1=8", got)
+	}
+	d.providerDispatches = 3
+	if got := d.exhaustionAttemptCount(); got != 3 {
+		t.Fatalf("count=%d, want 3 actual dispatches (not loop attempts)", got)
+	}
+}
+
+// TestCapacityRejectionReasonThreadsIntoClassification pins the enriched-
+// rejection funnel: the typed wire reason crosses the sanitizer as BOTH the
+// preserved RejectionReason and a mapped structured error_reason, and the
+// existing reason-first classifier (never a parallel one) produces the
+// intended failover kind.
+func TestCapacityRejectionReasonThreadsIntoClassification(t *testing.T) {
+	tests := []struct {
+		name       string
+		rejection  protocol.CapacityRejectionReason
+		wantReason string
+		wantKind   rejectionKind
+	}{
+		{"token_budget is node-transient", protocol.RejectionReasonTokenBudget, errorReasonRequestExceedsNodeBudget, rejectionTransientCapacity},
+		{"kv_headroom is node-transient", protocol.RejectionReasonKVHeadroom, errorReasonRequestExceedsNode, rejectionTransientCapacity},
+		{"memory_cap is node-transient", protocol.RejectionReasonMemoryCap, errorReasonRequestExceedsNode, rejectionTransientCapacity},
+		{"slot_state is busy-now", protocol.RejectionReasonSlotState, errorReasonCapacityBusy, rejectionTransientCapacity},
+		{"deadline is the neutral refusal", protocol.RejectionReasonDeadline, errorReasonDeadlineUnreachable, rejectionDeadlineUnreachable},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			safe, _, _ := sanitizeProviderInferenceError(&protocol.InferenceErrorMessage{
+				Type:            protocol.TypeInferenceError,
+				RequestID:       "r",
+				StatusCode:      http.StatusServiceUnavailable,
+				FailureCode:     protocol.FailureCodeCapacity,
+				RejectionReason: tt.rejection,
+			})
+			if safe.RejectionReason != tt.rejection {
+				t.Fatalf("RejectionReason=%q, want preserved %q", safe.RejectionReason, tt.rejection)
+			}
+			if safe.ErrorReason != tt.wantReason {
+				t.Fatalf("ErrorReason=%q, want mapped %q", safe.ErrorReason, tt.wantReason)
+			}
+			if got := classifyRejection(safe.ErrorReason, safe.Error, 0, 0); got != tt.wantKind {
+				t.Fatalf("classifyRejection=%v, want %v", got, tt.wantKind)
+			}
+		})
+	}
+
+	// A provider-supplied structured reason always wins over the mapping.
+	safe, _, _ := sanitizeProviderInferenceError(&protocol.InferenceErrorMessage{
+		Type:            protocol.TypeInferenceError,
+		StatusCode:      http.StatusServiceUnavailable,
+		FailureCode:     protocol.FailureCodeCapacity,
+		ErrorReason:     errorReasonRequestExceedsContext,
+		RejectionReason: protocol.RejectionReasonTokenBudget,
+	})
+	if safe.ErrorReason != errorReasonRequestExceedsContext {
+		t.Fatalf("ErrorReason=%q, want the provider's own %q untouched", safe.ErrorReason, errorReasonRequestExceedsContext)
+	}
+}
+
+// TestSetLastInferenceErrorPrefersLiveBudgetAndKeepsFeasibleAfter pins the
+// enriched-field capture: the rejection-time live budget replaces the stale
+// heartbeat snapshot for the deterministic-vs-transient call, FeasibleAfterMS
+// survives for the Retry-After surface, and a later coordinator-synthetic
+// error clears both (no bleed-through).
+func TestSetLastInferenceErrorPrefersLiveBudgetAndKeepsFeasibleAfter(t *testing.T) {
+	d := &dispatchState{s: newTestServerForDispatch(t), model: "m", modelMaxContext: 8192}
+	d.setLastInferenceError(nil, protocol.InferenceErrorMessage{
+		Type:                 protocol.TypeInferenceError,
+		StatusCode:           http.StatusServiceUnavailable,
+		FailureCode:          protocol.FailureCodeCapacity,
+		ErrorReason:          errorReasonRequestExceedsBatchBudget,
+		AvailableTokenBudget: 4096,
+		FeasibleAfterMS:      1500,
+	})
+	if d.lastErrProviderBudget != 4096 {
+		t.Fatalf("lastErrProviderBudget=%d, want the live 4096 (provider is nil: no heartbeat snapshot)", d.lastErrProviderBudget)
+	}
+	if d.lastErrFeasibleAfterMS != 1500 {
+		t.Fatalf("lastErrFeasibleAfterMS=%d, want 1500", d.lastErrFeasibleAfterMS)
+	}
+	// Live budget (4096) below the model context (8192): a batch-budget
+	// reject from THIS pressured node is transient, not fleet-deterministic.
+	if got := classifyRejection(d.lastErrReason, d.lastErr, d.lastErrProviderBudget, d.modelMaxContext); got != rejectionTransientCapacity {
+		t.Fatalf("classifyRejection=%v, want rejectionTransientCapacity via the live budget", got)
+	}
+	d.setLastError("timeout waiting for first response", http.StatusGatewayTimeout)
+	if d.lastErrFeasibleAfterMS != 0 {
+		t.Fatalf("lastErrFeasibleAfterMS=%d after synthetic error, want cleared", d.lastErrFeasibleAfterMS)
+	}
+}
+
+// TestCollectCapacityQuotesRefinesOnlyOnHighConfidence pins the collector's
+// hedge-timing extraction: a HIGH-confidence confirmed backup whose quoted
+// q90 proves the 50% point too late delivers the exact earlier hedgeLaunchAt
+// instant; a LOW-confidence quote collapses to the 50% ceiling and delivers
+// nothing (legacy timing stands).
+func TestCollectCapacityQuotesRefinesOnlyOnHighConfidence(t *testing.T) {
+	s := newTestServerForDispatch(t)
+	const model = "collect-quotes-model"
+	for i := range 4 {
+		planWiringProvider(t, s.registry, fmt.Sprintf("cq%d", i), model, int64(i)*400)
+	}
+	receivedAt := time.Now()
+	deadline := 9 * time.Second
+	speculativeAt := 4500 * time.Millisecond
+
+	run := func(confidence string) (time.Time, bool) {
+		plan := planWiringPlan(t, s.registry, model)
+		next, ok := plan.PeekNext()
+		if !ok {
+			t.Fatal("plan retained no alternates")
+		}
+		quote := &protocol.CapacityQuoteMessage{
+			Type:          protocol.TypeCapacityQuote,
+			QuoteID:       "q-" + confidence,
+			AdmissibleNow: true,
+			TTFTP90MS:     7000,
+			Confidence:    confidence,
+		}
+		plan.ConfirmEntry(next.ProviderID, quote)
+		outcomes := make(chan registry.QuoteOutcome, 1)
+		outcomes <- registry.QuoteOutcome{ProviderID: next.ProviderID, Quote: quote}
+		close(outcomes)
+		advance := make(chan time.Time, 1)
+		collectCapacityQuotes(outcomes, plan, receivedAt, deadline, speculativeAt, advance)
+		select {
+		case at := <-advance:
+			return at, true
+		default:
+			return time.Time{}, false
+		}
+	}
+
+	at, delivered := run(protocol.CapacityConfidenceHigh)
+	if !delivered {
+		t.Fatal("high-confidence slow backup must refine the launch point")
+	}
+	// latest_useful = 9s − max(7s, floor) − 500ms commit guard = 1.5s.
+	if want := receivedAt.Add(1500 * time.Millisecond); !at.Equal(want) {
+		t.Fatalf("refined instant=%s, want receivedAt+1.5s (%s)", at, want)
+	}
+
+	if _, delivered := run(protocol.CapacityConfidenceLow); delivered {
+		t.Fatal("low-confidence quote must never move the launch off the 50% ceiling")
+	}
+}

--- a/coordinator/api/dispatch_plan_wiring_test.go
+++ b/coordinator/api/dispatch_plan_wiring_test.go
@@ -362,7 +362,7 @@ func TestCapacityRejectionReasonThreadsIntoClassification(t *testing.T) {
 			if safe.ErrorReason != tt.wantReason {
 				t.Fatalf("ErrorReason=%q, want mapped %q", safe.ErrorReason, tt.wantReason)
 			}
-			if got := classifyRejection(safe.ErrorReason, safe.Error, 0, 0); got != tt.wantKind {
+			if got := classifyRejection(safe.ErrorReason, safe.Error, 0, 0, safe.RejectionReason); got != tt.wantKind {
 				t.Fatalf("classifyRejection=%v, want %v", got, tt.wantKind)
 			}
 		})
@@ -393,7 +393,7 @@ func TestSetLastInferenceErrorPrefersLiveBudgetAndKeepsFeasibleAfter(t *testing.
 		StatusCode:           http.StatusServiceUnavailable,
 		FailureCode:          protocol.FailureCodeCapacity,
 		ErrorReason:          errorReasonRequestExceedsBatchBudget,
-		AvailableTokenBudget: 4096,
+		AvailableTokenBudget: i64ptr(4096),
 		FeasibleAfterMS:      1500,
 	})
 	if d.lastErrProviderBudget != 4096 {
@@ -404,12 +404,62 @@ func TestSetLastInferenceErrorPrefersLiveBudgetAndKeepsFeasibleAfter(t *testing.
 	}
 	// Live budget (4096) below the model context (8192): a batch-budget
 	// reject from THIS pressured node is transient, not fleet-deterministic.
-	if got := classifyRejection(d.lastErrReason, d.lastErr, d.lastErrProviderBudget, d.modelMaxContext); got != rejectionTransientCapacity {
+	if got := classifyRejection(d.lastErrReason, d.lastErr, d.lastErrProviderBudget, d.modelMaxContext, d.lastErrRejectionReason); got != rejectionTransientCapacity {
 		t.Fatalf("classifyRejection=%v, want rejectionTransientCapacity via the live budget", got)
 	}
 	d.setLastError("timeout waiting for first response", http.StatusGatewayTimeout)
 	if d.lastErrFeasibleAfterMS != 0 {
 		t.Fatalf("lastErrFeasibleAfterMS=%d after synthetic error, want cleared", d.lastErrFeasibleAfterMS)
+	}
+}
+
+func i64ptr(v int64) *int64 { return &v }
+
+// TestSetLastInferenceErrorExplicitZeroBudgetStaysTransient pins the P1-4
+// authority chain end to end: an enriched busy-slot rejection carrying an
+// EXPLICIT zero live budget plus the typed token_budget reason crosses the
+// sanitizer with both intact, and classification stays TRANSIENT — the typed
+// reason is authoritative, so the stale heartbeat fallback (an unknown or
+// at/above-context budget snapshot would otherwise read fleet-deterministic)
+// can never stop failover for a shortage the live gate called momentary.
+func TestSetLastInferenceErrorExplicitZeroBudgetStaysTransient(t *testing.T) {
+	d := &dispatchState{s: newTestServerForDispatch(t), model: "m", modelMaxContext: 8192}
+	d.setLastInferenceError(nil, protocol.InferenceErrorMessage{
+		Type:                 protocol.TypeInferenceError,
+		StatusCode:           http.StatusServiceUnavailable,
+		FailureCode:          protocol.FailureCodeCapacity,
+		ErrorReason:          errorReasonRequestExceedsBatchBudget,
+		RejectionReason:      protocol.RejectionReasonTokenBudget,
+		AvailableTokenBudget: i64ptr(0),
+	})
+	if d.lastErrProviderBudget != 0 {
+		t.Fatalf("lastErrProviderBudget=%d, want the explicit live zero", d.lastErrProviderBudget)
+	}
+	if d.lastErrRejectionReason != protocol.RejectionReasonTokenBudget {
+		t.Fatalf("lastErrRejectionReason=%q, want token_budget preserved through the sanitizer", d.lastErrRejectionReason)
+	}
+	if got := classifyRejection(d.lastErrReason, d.lastErr, d.lastErrProviderBudget, d.modelMaxContext, d.lastErrRejectionReason); got != rejectionTransientCapacity {
+		t.Fatalf("classifyRejection=%v, want transient — typed token_budget is authoritative over the stale heartbeat fallback", got)
+	}
+	// Failover continues: the transient verdict consumes a capacity retry
+	// instead of latching unservable on the first occurrence.
+	if d.shouldStopFailover() {
+		t.Fatal("first typed token_budget rejection must keep failing over")
+	}
+	if d.unservable {
+		t.Fatal("typed token_budget rejection must not latch deterministic-unservable")
+	}
+	// Legacy frame (nil budget, no typed reason): today's classification is
+	// byte-identical — unknown budget ⇒ deterministic stop.
+	d2 := &dispatchState{s: newTestServerForDispatch(t), model: "m", modelMaxContext: 8192}
+	d2.setLastInferenceError(nil, protocol.InferenceErrorMessage{
+		Type:        protocol.TypeInferenceError,
+		StatusCode:  http.StatusServiceUnavailable,
+		FailureCode: protocol.FailureCodeCapacity,
+		ErrorReason: errorReasonRequestExceedsBatchBudget,
+	})
+	if got := classifyRejection(d2.lastErrReason, d2.lastErr, d2.lastErrProviderBudget, d2.modelMaxContext, d2.lastErrRejectionReason); got != rejectionDeterministicUnservable {
+		t.Fatalf("legacy classifyRejection=%v, want unchanged deterministic", got)
 	}
 }
 

--- a/coordinator/api/dispatch_terminal_cause_test.go
+++ b/coordinator/api/dispatch_terminal_cause_test.go
@@ -38,7 +38,7 @@ func TestShouldStopFailover_TypedAdmissionTimeoutIsTransientCapacity(t *testing.
 
 	// The sanitizer derives a bounded capacity reason. Raw provider prose is
 	// discarded and cannot participate in classification.
-	if kind := classifyRejection(d.lastErrReason, d.lastErr, 0, 0); kind != rejectionTransientCapacity {
+	if kind := classifyRejection(d.lastErrReason, d.lastErr, 0, 0, ""); kind != rejectionTransientCapacity {
 		t.Fatalf("typed admission timeout classified %v, want transient capacity", kind)
 	}
 

--- a/coordinator/api/hedge_governor.go
+++ b/coordinator/api/hedge_governor.go
@@ -19,9 +19,11 @@ import "sync"
 // be tested exhaustively and attributed in telemetry: each suppression
 // increments routing.hedge_governor_suppressed tagged with the verdict string
 // and logs speculative_backup_suppressed. The mutable half — the global
-// active-hedge counter and per-model win-rate EWMAs — lives in hedgeGovernor;
-// dispatch wiring (inc on launch, dec on resolve, snapshot into inputs) lives
-// in runSpeculative and dispatch_plan_wiring.go governorVerdictForBackup.
+// active-hedge counter and per-model win-rate EWMAs — lives in hedgeGovernor,
+// whose tryAcquireHedge computes the verdict AND claims the budget slot under
+// ONE mutex hold; dispatch wiring (acquire on launch, release on resolve,
+// registry snapshot into inputs) lives in runSpeculative and
+// dispatch_plan_wiring.go tryAcquireBackupHedge.
 
 const (
 	// hedgeFleetIdleHeadroomSlots is the minimum fleet-wide idle-slot count
@@ -50,8 +52,30 @@ const (
 	// primaries are fine and the hedges are ~pure waste heat — nine losing
 	// dispatches buying one marginal win. Below the floor the model backs
 	// off to no-hedge until fresh outcomes (recordHedgeOutcome at race
-	// resolution in runSpeculative) lift the EWMA back over it.
+	// resolution in runSpeculative, including the periodic exploration
+	// hedges below) lift the EWMA back over it.
 	hedgeWinRateFloor = 0.10
+
+	// hedgeWinRateMinSamples is the minimum number of recorded hedge
+	// outcomes before the win-rate floor is enforced. The floor's
+	// justification is ECONOMIC — nine losing dispatches buying one marginal
+	// win — and that arithmetic needs statistical footing: a single unlucky
+	// first race seeds the EWMA at 0 and, because outcomes are recorded only
+	// for LAUNCHED hedges, a floor enforced immediately would lock the model
+	// out of hedging forever (no launches → no fresh outcomes → no
+	// recovery). Below this count the win rate passes and the model keeps
+	// sampling.
+	hedgeWinRateMinSamples = 8
+
+	// hedgeWinRateExploreInterval bounds a win-rate lockout: every Nth
+	// win-rate-suppressed evaluation (per model) converts to an allow — an
+	// exploration hedge whose recorded outcome refreshes the EWMA, so a
+	// model whose hedges started losing can prove a regime change and earn
+	// normal hedging back. At 1-in-16 the exploration cost is negligible
+	// (~6% of the suppressed volume) while recovery stays within a handful
+	// of slow-request bursts; without it the suppression is permanent for
+	// the lifetime of the server.
+	hedgeWinRateExploreInterval = 16
 
 	// hedgeWinRateAlpha is the EWMA weight of each new hedge outcome,
 	// matching the repo-wide recency/smoothness balance (registry
@@ -68,9 +92,10 @@ const (
 
 // hedgeGovernorInputs is a point-in-time snapshot of everything the verdict
 // reads. Kept as plain locals (not registry types) so the decision is
-// snapshot-consistent and independently testable; governorVerdictForBackup
-// (dispatch_plan_wiring.go) populates it under the registry's existing
-// locks.
+// snapshot-consistent and independently testable; tryAcquireBackupHedge
+// (dispatch_plan_wiring.go) populates the registry-side fields under the
+// registry's existing locks, and tryAcquireHedge fills the governor-owned
+// ones under its own mutex.
 type hedgeGovernorInputs struct {
 	// idleAlternativeExists: an idle-loaded eligible provider for this model
 	// is routable right now (the registry's IdleAlternativeExists machinery)
@@ -88,6 +113,16 @@ type hedgeGovernorInputs struct {
 	// modelWinRate: this model's hedge win-rate EWMA in [0,1], or
 	// hedgeWinRateUnknown when no outcome has been recorded.
 	modelWinRate float64
+	// modelWinRateSamples: how many resolved hedge outcomes the EWMA is
+	// built on. The win-rate floor is enforced only at
+	// hedgeWinRateMinSamples or more (see that constant's WHY).
+	modelWinRateSamples int
+	// exploreNow: this evaluation is the model's periodic exploration hedge
+	// (every hedgeWinRateExploreInterval-th win-rate suppression) — the
+	// win-rate floor is waived for it so the EWMA can be refreshed. Every
+	// other rule still applies: exploration is insurance too and must not
+	// displace queued primaries or bust the global budget.
+	exploreNow bool
 }
 
 // hedgeVerdict is the governor's decision. Non-allow values name the FIRST
@@ -161,16 +196,20 @@ func hedgeGovernorVerdict(in hedgeGovernorInputs) hedgeVerdict {
 	if in.activeHedges >= hedgeGlobalBudget(in.fleetIdleSlots, in.idleAlternativeExists) {
 		return hedgeSuppressGlobalBudget
 	}
-	if in.modelWinRate != hedgeWinRateUnknown && in.modelWinRate < hedgeWinRateFloor {
+	if in.modelWinRate != hedgeWinRateUnknown &&
+		in.modelWinRateSamples >= hedgeWinRateMinSamples &&
+		in.modelWinRate < hedgeWinRateFloor &&
+		!in.exploreNow {
 		return hedgeSuppressWinRate
 	}
 	return hedgeAllow
 }
 
 // hedgeGovernor owns the mutable feedback state behind the verdict: the
-// global active-hedge counter and the per-model win-rate EWMAs. One instance
-// per Server; every method is safe for concurrent use from the dispatch
-// goroutines that launch and resolve hedges.
+// global active-hedge counter, the per-model win-rate EWMAs with their sample
+// counts, and the per-model exploration cadence. One instance per Server;
+// every method is safe for concurrent use from the dispatch goroutines that
+// launch and resolve hedges.
 type hedgeGovernor struct {
 	mu           sync.Mutex
 	activeHedges int
@@ -178,17 +217,72 @@ type hedgeGovernor struct {
 	// from the map has recorded no outcome (hedgeWinRateUnknown). Bounded by
 	// the served-model catalog, so no eviction is needed.
 	winRates map[string]float64
+	// winSamples counts recorded outcomes per model; the win-rate floor is
+	// enforced only at hedgeWinRateMinSamples or more.
+	winSamples map[string]int
+	// suppressedSinceExplore counts consecutive win-rate suppressions per
+	// model since the last exploration hedge; at
+	// hedgeWinRateExploreInterval it resets and the evaluation converts to
+	// an exploration allow.
+	suppressedSinceExplore map[string]int
 }
 
 func newHedgeGovernor() *hedgeGovernor {
-	return &hedgeGovernor{winRates: make(map[string]float64)}
+	return &hedgeGovernor{
+		winRates:               make(map[string]float64),
+		winSamples:             make(map[string]int),
+		suppressedSinceExplore: make(map[string]int),
+	}
 }
 
-// noteHedgeLaunched increments the global in-flight hedge count. Called
-// exactly once per launched backup dispatch (runSpeculative), before the
-// dispatch is sent, so the budget check and the increment cannot admit more
-// hedges than the budget under concurrency.
-func (g *hedgeGovernor) noteHedgeLaunched() {
+// tryAcquireHedge computes the launch verdict for one speculative backup AND,
+// on allow, claims its global budget slot — atomically, under one mutex hold.
+// The caller supplies the registry-side snapshot fields; the governor fills
+// activeHedges, the model's win-rate EWMA/sample count, and the exploration
+// flag from its own state. The read-check-increment being ONE operation is
+// the point: concurrent slow requests can no longer all observe the same free
+// budget and launch past the fleet-wide cap during a burst.
+//
+// A win-rate suppression advances the model's exploration cadence; every
+// hedgeWinRateExploreInterval-th one converts to an exploration allow (the
+// verdict is re-derived with exploreNow set, so the earlier rules still
+// bind). acquired reports whether a slot was claimed; every acquired hedge
+// MUST be released exactly once via noteHedgeResolved, whatever becomes of
+// the dispatch.
+func (g *hedgeGovernor) tryAcquireHedge(model string, in hedgeGovernorInputs) (verdict hedgeVerdict, acquired bool) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	in.activeHedges = g.activeHedges
+	in.modelWinRate = hedgeWinRateUnknown
+	if rate, ok := g.winRates[model]; ok {
+		in.modelWinRate = rate
+	}
+	in.modelWinRateSamples = g.winSamples[model]
+	in.exploreNow = false
+	verdict = hedgeGovernorVerdict(in)
+	if verdict == hedgeSuppressWinRate {
+		g.suppressedSinceExplore[model]++
+		if g.suppressedSinceExplore[model] >= hedgeWinRateExploreInterval {
+			g.suppressedSinceExplore[model] = 0
+			in.exploreNow = true
+			verdict = hedgeGovernorVerdict(in)
+		}
+	}
+	if verdict != hedgeAllow {
+		return verdict, false
+	}
+	g.activeHedges++
+	return hedgeAllow, true
+}
+
+// acquireHedgeUngoverned claims a budget slot for a hedge admitted OUTSIDE
+// the verdict rules — the capacity-SILENT legacy escape in
+// tryAcquireBackupHedge, where every governor input is meaningless and the
+// verdict is definitionally allow. This is load ACCOUNTING, not a budget-
+// check bypass: the legacy hedge is really in flight, so capacity-aware
+// requests must see it against their budget. Released exactly once via
+// noteHedgeResolved, like any acquired hedge.
+func (g *hedgeGovernor) acquireHedgeUngoverned() {
 	g.mu.Lock()
 	g.activeHedges++
 	g.mu.Unlock()
@@ -214,9 +308,10 @@ func (g *hedgeGovernor) activeHedgeCount() int {
 }
 
 // recordHedgeOutcome folds one resolved hedge race into the model's win-rate
-// EWMA: won means the hedge produced the committed first content. The first
-// sample seeds the average directly (the repo's RecordLatency pattern) so a
-// model's early rate reflects real outcomes rather than a synthetic prior.
+// EWMA and bumps its sample count: won means the hedge produced the committed
+// first content. The first sample seeds the average directly (the repo's
+// RecordLatency pattern) so a model's early rate reflects real outcomes
+// rather than a synthetic prior.
 func (g *hedgeGovernor) recordHedgeOutcome(model string, won bool) {
 	sample := 0.0
 	if won {
@@ -224,6 +319,7 @@ func (g *hedgeGovernor) recordHedgeOutcome(model string, won bool) {
 	}
 	g.mu.Lock()
 	defer g.mu.Unlock()
+	g.winSamples[model]++
 	prior, ok := g.winRates[model]
 	if !ok {
 		g.winRates[model] = sample

--- a/coordinator/api/hedge_governor.go
+++ b/coordinator/api/hedge_governor.go
@@ -1,0 +1,245 @@
+package api
+
+import "sync"
+
+// Hedge governor — the admission half of Routing v2 Phase 4: insurance that
+// cannot amplify an overload.
+//
+// Production evidence this exists to answer: the measured spread failure is
+// occupancy HERDING, not lack of diversity — idle loaded boxes coexisted with
+// 100% of the gpt-oss cancels (registry/ttft_shadow.go), while recent timeout
+// route rows carried candidate counts of 86-401. Hedges launched into that
+// herd make it strictly worse: each hedge occupies a second slot for the same
+// request, occupancy rises, TTFT estimates degrade, more requests look slow,
+// more hedges launch — the classic congestion-collapse spiral. Every rule
+// below is a brake on that loop; a hedge is pure insurance and insurance must
+// never outrank real demand.
+//
+// The verdict is a pure function of a point-in-time inputs snapshot so it can
+// be tested exhaustively and attributed in telemetry: each suppression
+// increments routing.hedge_governor_suppressed tagged with the verdict string
+// and logs speculative_backup_suppressed. The mutable half — the global
+// active-hedge counter and per-model win-rate EWMAs — lives in hedgeGovernor;
+// dispatch wiring (inc on launch, dec on resolve, snapshot into inputs) lives
+// in runSpeculative and dispatch_plan_wiring.go governorVerdictForBackup.
+
+const (
+	// hedgeFleetIdleHeadroomSlots is the minimum fleet-wide idle-slot count
+	// that substitutes for a model-scoped idle alternative. When
+	// IdleAlternativeExists is false the hedge would land on a box that is
+	// already doing something; that is tolerable only while the fleet keeps
+	// real headroom, because the displaced capacity can be absorbed
+	// elsewhere. Two slots — not one — so a hedge can never consume the LAST
+	// idle slot, which belongs to the next primary request (primaries
+	// outrank insurance, always).
+	hedgeFleetIdleHeadroomSlots = 2
+
+	// hedgeGlobalBudgetFraction caps concurrent hedges fleet-wide as a
+	// fraction of current idle slots. At 1/4, even if every in-flight hedge
+	// loses its race and squats its slot for a full TTFT, three quarters of
+	// the idle headroom remains for primary demand — the spiral cannot close
+	// because hedge load is bounded by a shrinking resource: as utilization
+	// rises, idle slots fall, the budget falls with them, and the hedge rate
+	// collapses toward zero exactly when the fleet needs relief (the
+	// routingsim overload scenario in the plan). Expressed as a division so
+	// the budget is integer math on slot counts.
+	hedgeGlobalBudgetDivisor = 4
+
+	// hedgeWinRateFloor suppresses hedging for a model whose hedges almost
+	// never beat the primary. A win rate persistently below 10% means the
+	// primaries are fine and the hedges are ~pure waste heat — nine losing
+	// dispatches buying one marginal win. Below the floor the model backs
+	// off to no-hedge until fresh outcomes (recordHedgeOutcome at race
+	// resolution in runSpeculative) lift the EWMA back over it.
+	hedgeWinRateFloor = 0.10
+
+	// hedgeWinRateAlpha is the EWMA weight of each new hedge outcome,
+	// matching the repo-wide recency/smoothness balance (registry
+	// ttftEWMAAlpha = 0.2): one anomalous race cannot flip a model across
+	// the floor, but a real regime change shows within a handful of hedges.
+	hedgeWinRateAlpha = 0.2
+
+	// hedgeWinRateUnknown is the sentinel for "no hedge outcome recorded yet
+	// for this model". Unknown passes the floor: a model must be allowed to
+	// hedge before it can have a win rate, otherwise the floor would
+	// permanently fail closed for every new model.
+	hedgeWinRateUnknown = -1.0
+)
+
+// hedgeGovernorInputs is a point-in-time snapshot of everything the verdict
+// reads. Kept as plain locals (not registry types) so the decision is
+// snapshot-consistent and independently testable; governorVerdictForBackup
+// (dispatch_plan_wiring.go) populates it under the registry's existing
+// locks.
+type hedgeGovernorInputs struct {
+	// idleAlternativeExists: an idle-loaded eligible provider for this model
+	// is routable right now (the registry's IdleAlternativeExists machinery)
+	// — the hedge has somewhere genuinely spare to land.
+	idleAlternativeExists bool
+	// modelQueueDepth: requests currently queued for this model. Queued
+	// demand is a primary that could not even start; it outranks insurance
+	// unconditionally.
+	modelQueueDepth int
+	// activeHedges: hedges currently in flight fleet-wide (the governor's
+	// own counter).
+	activeHedges int
+	// fleetIdleSlots: idle slots across the whole fleet right now.
+	fleetIdleSlots int
+	// modelWinRate: this model's hedge win-rate EWMA in [0,1], or
+	// hedgeWinRateUnknown when no outcome has been recorded.
+	modelWinRate float64
+}
+
+// hedgeVerdict is the governor's decision. Non-allow values name the FIRST
+// failing rule in precedence order so telemetry attributes each suppression
+// to one cause.
+type hedgeVerdict int
+
+const (
+	hedgeAllow hedgeVerdict = iota
+	// hedgeSuppressQueued: the model has queued demand; queued primaries
+	// outrank insurance.
+	hedgeSuppressQueued
+	// hedgeSuppressNoIdleCapacity: no idle alternative for the model and no
+	// fleet-wide idle headroom — the hedge would displace real work.
+	hedgeSuppressNoIdleCapacity
+	// hedgeSuppressGlobalBudget: the fleet-wide concurrent-hedge budget is
+	// spent.
+	hedgeSuppressGlobalBudget
+	// hedgeSuppressWinRate: this model's hedges persistently lose; back off
+	// to no-hedge.
+	hedgeSuppressWinRate
+)
+
+// String is the bounded verdict vocabulary used as the metric tag and log
+// field.
+func (v hedgeVerdict) String() string {
+	switch v {
+	case hedgeAllow:
+		return "allow"
+	case hedgeSuppressQueued:
+		return "suppress_queued"
+	case hedgeSuppressNoIdleCapacity:
+		return "suppress_no_idle_capacity"
+	case hedgeSuppressGlobalBudget:
+		return "suppress_global_budget"
+	case hedgeSuppressWinRate:
+		return "suppress_win_rate"
+	default:
+		return "unknown"
+	}
+}
+
+// hedgeGlobalBudget is the fleet-wide cap on concurrently running hedges:
+// fleetIdleSlots / hedgeGlobalBudgetDivisor, with a floor of one whenever ANY
+// idle capacity exists (a model-scoped idle alternative counts even when the
+// fleet-wide count reads zero — the signals are sampled independently). With
+// no idle capacity at all the budget is zero: an overloaded fleet runs no
+// insurance.
+func hedgeGlobalBudget(fleetIdleSlots int, idleAlternativeExists bool) int {
+	if fleetIdleSlots <= 0 && !idleAlternativeExists {
+		return 0
+	}
+	budget := fleetIdleSlots / hedgeGlobalBudgetDivisor
+	if budget < 1 {
+		budget = 1
+	}
+	return budget
+}
+
+// hedgeGovernorVerdict applies the launch rules in precedence order and
+// returns the first failure (or allow). Pure function of the snapshot; the
+// zero-value inputs suppress (no idle capacity), so a wiring bug that forgets
+// to populate the snapshot fails closed instead of hedging blind.
+func hedgeGovernorVerdict(in hedgeGovernorInputs) hedgeVerdict {
+	if in.modelQueueDepth > 0 {
+		return hedgeSuppressQueued
+	}
+	if !in.idleAlternativeExists && in.fleetIdleSlots < hedgeFleetIdleHeadroomSlots {
+		return hedgeSuppressNoIdleCapacity
+	}
+	if in.activeHedges >= hedgeGlobalBudget(in.fleetIdleSlots, in.idleAlternativeExists) {
+		return hedgeSuppressGlobalBudget
+	}
+	if in.modelWinRate != hedgeWinRateUnknown && in.modelWinRate < hedgeWinRateFloor {
+		return hedgeSuppressWinRate
+	}
+	return hedgeAllow
+}
+
+// hedgeGovernor owns the mutable feedback state behind the verdict: the
+// global active-hedge counter and the per-model win-rate EWMAs. One instance
+// per Server; every method is safe for concurrent use from the dispatch
+// goroutines that launch and resolve hedges.
+type hedgeGovernor struct {
+	mu           sync.Mutex
+	activeHedges int
+	// winRates holds per-model hedge win-rate EWMAs in [0,1]. A model absent
+	// from the map has recorded no outcome (hedgeWinRateUnknown). Bounded by
+	// the served-model catalog, so no eviction is needed.
+	winRates map[string]float64
+}
+
+func newHedgeGovernor() *hedgeGovernor {
+	return &hedgeGovernor{winRates: make(map[string]float64)}
+}
+
+// noteHedgeLaunched increments the global in-flight hedge count. Called
+// exactly once per launched backup dispatch (runSpeculative), before the
+// dispatch is sent, so the budget check and the increment cannot admit more
+// hedges than the budget under concurrency.
+func (g *hedgeGovernor) noteHedgeLaunched() {
+	g.mu.Lock()
+	g.activeHedges++
+	g.mu.Unlock()
+}
+
+// noteHedgeResolved decrements the in-flight count when a hedge finishes for
+// any reason — win, loss, cancellation, or provider failure. Clamped at zero
+// so a double-resolve bug degrades to a slightly generous budget instead of a
+// negative count that would disable the budget entirely.
+func (g *hedgeGovernor) noteHedgeResolved() {
+	g.mu.Lock()
+	if g.activeHedges > 0 {
+		g.activeHedges--
+	}
+	g.mu.Unlock()
+}
+
+// activeHedgeCount snapshots the in-flight count for the verdict inputs.
+func (g *hedgeGovernor) activeHedgeCount() int {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.activeHedges
+}
+
+// recordHedgeOutcome folds one resolved hedge race into the model's win-rate
+// EWMA: won means the hedge produced the committed first content. The first
+// sample seeds the average directly (the repo's RecordLatency pattern) so a
+// model's early rate reflects real outcomes rather than a synthetic prior.
+func (g *hedgeGovernor) recordHedgeOutcome(model string, won bool) {
+	sample := 0.0
+	if won {
+		sample = 1.0
+	}
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	prior, ok := g.winRates[model]
+	if !ok {
+		g.winRates[model] = sample
+		return
+	}
+	g.winRates[model] = prior*(1-hedgeWinRateAlpha) + sample*hedgeWinRateAlpha
+}
+
+// modelWinRate snapshots the model's EWMA for the verdict inputs;
+// hedgeWinRateUnknown when no outcome has been recorded.
+func (g *hedgeGovernor) modelWinRate(model string) float64 {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	rate, ok := g.winRates[model]
+	if !ok {
+		return hedgeWinRateUnknown
+	}
+	return rate
+}

--- a/coordinator/api/hedge_governor_test.go
+++ b/coordinator/api/hedge_governor_test.go
@@ -1,0 +1,296 @@
+package api
+
+import (
+	"sync"
+	"testing"
+)
+
+// TestHedgeGovernorVerdictTable pins each launch rule, its precedence, and its
+// boundary. Rules fire in order (queued → idle capacity → global budget →
+// win rate), so each suppression names the FIRST failing condition.
+func TestHedgeGovernorVerdictTable(t *testing.T) {
+	// A baseline snapshot that passes every rule; each case perturbs it.
+	allow := hedgeGovernorInputs{
+		idleAlternativeExists: true,
+		modelQueueDepth:       0,
+		activeHedges:          0,
+		fleetIdleSlots:        8,
+		modelWinRate:          hedgeWinRateUnknown,
+	}
+	tests := []struct {
+		name string
+		in   hedgeGovernorInputs
+		want hedgeVerdict
+	}{
+		{"all rules pass", allow, hedgeAllow},
+		{
+			"zero-value inputs fail closed",
+			hedgeGovernorInputs{},
+			hedgeSuppressNoIdleCapacity,
+		},
+		{
+			"queued model never hedges",
+			func() hedgeGovernorInputs { in := allow; in.modelQueueDepth = 1; return in }(),
+			hedgeSuppressQueued,
+		},
+		{
+			"queue outranks every other failure",
+			hedgeGovernorInputs{modelQueueDepth: 3, modelWinRate: 0.01},
+			hedgeSuppressQueued,
+		},
+		{
+			"no idle alternative, fleet headroom below threshold",
+			hedgeGovernorInputs{
+				fleetIdleSlots: hedgeFleetIdleHeadroomSlots - 1,
+				modelWinRate:   hedgeWinRateUnknown,
+			},
+			hedgeSuppressNoIdleCapacity,
+		},
+		{
+			"no idle alternative, fleet headroom at threshold",
+			hedgeGovernorInputs{
+				fleetIdleSlots: hedgeFleetIdleHeadroomSlots,
+				modelWinRate:   hedgeWinRateUnknown,
+			},
+			hedgeAllow,
+		},
+		{
+			"idle alternative substitutes for zero fleet headroom",
+			hedgeGovernorInputs{
+				idleAlternativeExists: true,
+				fleetIdleSlots:        0,
+				modelWinRate:          hedgeWinRateUnknown,
+			},
+			hedgeAllow, // budget floor of 1 with idle capacity, activeHedges 0
+		},
+		{
+			"budget boundary: last slot under budget allows",
+			func() hedgeGovernorInputs {
+				in := allow // budget = 8/4 = 2
+				in.activeHedges = 1
+				return in
+			}(),
+			hedgeAllow,
+		},
+		{
+			"budget boundary: at budget suppresses",
+			func() hedgeGovernorInputs {
+				in := allow // budget = 8/4 = 2
+				in.activeHedges = 2
+				return in
+			}(),
+			hedgeSuppressGlobalBudget,
+		},
+		{
+			"budget floor of one is consumable",
+			hedgeGovernorInputs{
+				idleAlternativeExists: true,
+				fleetIdleSlots:        0,
+				activeHedges:          1,
+				modelWinRate:          hedgeWinRateUnknown,
+			},
+			hedgeSuppressGlobalBudget,
+		},
+		{
+			"win rate below floor suppresses",
+			func() hedgeGovernorInputs {
+				in := allow
+				in.modelWinRate = hedgeWinRateFloor - 0.01
+				return in
+			}(),
+			hedgeSuppressWinRate,
+		},
+		{
+			"win rate at floor allows",
+			func() hedgeGovernorInputs {
+				in := allow
+				in.modelWinRate = hedgeWinRateFloor
+				return in
+			}(),
+			hedgeAllow,
+		},
+		{
+			"unknown win rate passes through",
+			func() hedgeGovernorInputs {
+				in := allow
+				in.modelWinRate = hedgeWinRateUnknown
+				return in
+			}(),
+			hedgeAllow,
+		},
+		{
+			"zero win rate suppresses",
+			func() hedgeGovernorInputs {
+				in := allow
+				in.modelWinRate = 0
+				return in
+			}(),
+			hedgeSuppressWinRate,
+		},
+	}
+	for _, tt := range tests {
+		if got := hedgeGovernorVerdict(tt.in); got != tt.want {
+			t.Errorf("%s: verdict = %v, want %v", tt.name, got, tt.want)
+		}
+	}
+}
+
+// TestHedgeGlobalBudget pins the budget arithmetic and its two boundary
+// behaviors: zero with no idle capacity anywhere, floor of one whenever any
+// idle capacity exists, and the divisor above the floor.
+func TestHedgeGlobalBudget(t *testing.T) {
+	tests := []struct {
+		fleetIdleSlots int
+		idleAlt        bool
+		want           int
+	}{
+		{0, false, 0}, // saturated fleet runs no insurance
+		{0, true, 1},  // model-scoped idle alternative keeps the floor
+		{1, false, 1}, // 1/4 rounds to 0 → floor
+		{3, false, 1},
+		{4, false, 1},
+		{8, false, 2},
+		{100, false, 25},
+	}
+	for _, tt := range tests {
+		if got := hedgeGlobalBudget(tt.fleetIdleSlots, tt.idleAlt); got != tt.want {
+			t.Errorf("hedgeGlobalBudget(%d, %v) = %d, want %d",
+				tt.fleetIdleSlots, tt.idleAlt, got, tt.want)
+		}
+	}
+}
+
+// TestHedgeVerdictStrings pins the bounded verdict vocabulary used as the
+// routing.hedge_governor_suppressed metric tag and log field.
+func TestHedgeVerdictStrings(t *testing.T) {
+	tests := []struct {
+		v    hedgeVerdict
+		want string
+	}{
+		{hedgeAllow, "allow"},
+		{hedgeSuppressQueued, "suppress_queued"},
+		{hedgeSuppressNoIdleCapacity, "suppress_no_idle_capacity"},
+		{hedgeSuppressGlobalBudget, "suppress_global_budget"},
+		{hedgeSuppressWinRate, "suppress_win_rate"},
+		{hedgeVerdict(99), "unknown"},
+	}
+	for _, tt := range tests {
+		if got := tt.v.String(); got != tt.want {
+			t.Errorf("hedgeVerdict(%d).String() = %q, want %q", tt.v, got, tt.want)
+		}
+	}
+}
+
+// TestHedgeGovernorCounterConcurrency drives balanced launch/resolve pairs
+// from many goroutines: the counter must end at zero, and the clamped
+// decrement means over-resolving from a stray goroutine can never push it
+// negative (which would inflate the budget forever).
+func TestHedgeGovernorCounterConcurrency(t *testing.T) {
+	t.Parallel()
+	g := newHedgeGovernor()
+	const goroutines = 16
+	const pairsPerGoroutine = 500
+
+	var wg sync.WaitGroup
+	for range goroutines {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range pairsPerGoroutine {
+				g.noteHedgeLaunched()
+				g.noteHedgeResolved()
+			}
+		}()
+	}
+	wg.Wait()
+	if got := g.activeHedgeCount(); got != 0 {
+		t.Fatalf("active hedges after balanced pairs = %d, want 0", got)
+	}
+
+	// Over-resolve: the clamp holds the floor at zero.
+	g.noteHedgeResolved()
+	g.noteHedgeResolved()
+	if got := g.activeHedgeCount(); got != 0 {
+		t.Fatalf("active hedges after over-resolve = %d, want 0 (clamped)", got)
+	}
+}
+
+// TestHedgeGovernorWinRateEWMA verifies the per-model feedback loop: unknown
+// until the first outcome, first sample seeds directly (RecordLatency
+// pattern), later samples blend at hedgeWinRateAlpha, and models are tracked
+// independently.
+func TestHedgeGovernorWinRateEWMA(t *testing.T) {
+	g := newHedgeGovernor()
+
+	if got := g.modelWinRate("model-a"); got != hedgeWinRateUnknown {
+		t.Fatalf("win rate before any outcome = %v, want %v", got, hedgeWinRateUnknown)
+	}
+
+	// First sample seeds directly.
+	g.recordHedgeOutcome("model-a", true)
+	if got := g.modelWinRate("model-a"); got != 1.0 {
+		t.Fatalf("win rate after first win = %v, want 1.0", got)
+	}
+
+	// Second sample blends: 1.0*0.8 + 0.0*0.2 = 0.8.
+	g.recordHedgeOutcome("model-a", false)
+	if got := g.modelWinRate("model-a"); got != 0.8 {
+		t.Fatalf("win rate after loss = %v, want 0.8", got)
+	}
+
+	// Models are independent; a losing seed lands under the floor.
+	g.recordHedgeOutcome("model-b", false)
+	if got := g.modelWinRate("model-b"); got != 0.0 {
+		t.Fatalf("model-b win rate = %v, want 0.0", got)
+	}
+	if got := g.modelWinRate("model-a"); got != 0.8 {
+		t.Fatalf("model-a win rate disturbed by model-b: %v, want 0.8", got)
+	}
+
+	// The seeded-loss model suppresses; the healthy model still allows.
+	in := hedgeGovernorInputs{
+		idleAlternativeExists: true,
+		fleetIdleSlots:        8,
+		modelWinRate:          g.modelWinRate("model-b"),
+	}
+	if got := hedgeGovernorVerdict(in); got != hedgeSuppressWinRate {
+		t.Fatalf("all-loss model verdict = %v, want suppress_win_rate", got)
+	}
+	in.modelWinRate = g.modelWinRate("model-a")
+	if got := hedgeGovernorVerdict(in); got != hedgeAllow {
+		t.Fatalf("healthy model verdict = %v, want allow", got)
+	}
+}
+
+// TestHedgeGovernorWinRateConcurrency hammers outcome recording and reads for
+// disjoint and shared models from parallel goroutines: purely a race-safety
+// probe (run under -race), with a bounds check that the EWMA of {0,1} samples
+// can never leave [0,1].
+func TestHedgeGovernorWinRateConcurrency(t *testing.T) {
+	t.Parallel()
+	g := newHedgeGovernor()
+	models := []string{"shared", "shared", "solo-a", "solo-b"}
+
+	var wg sync.WaitGroup
+	for i, model := range models {
+		wg.Add(1)
+		go func(model string, won bool) {
+			defer wg.Done()
+			for range 500 {
+				g.recordHedgeOutcome(model, won)
+				g.modelWinRate(model)
+			}
+		}(model, i%2 == 0)
+	}
+	wg.Wait()
+
+	for _, model := range []string{"shared", "solo-a", "solo-b"} {
+		rate := g.modelWinRate(model)
+		if rate < 0 || rate > 1 {
+			t.Fatalf("win rate for %q = %v, want within [0,1]", model, rate)
+		}
+	}
+	if got := g.modelWinRate("never-hedged"); got != hedgeWinRateUnknown {
+		t.Fatalf("untouched model rate = %v, want unknown", got)
+	}
+}

--- a/coordinator/api/hedge_governor_test.go
+++ b/coordinator/api/hedge_governor_test.go
@@ -96,6 +96,7 @@ func TestHedgeGovernorVerdictTable(t *testing.T) {
 			func() hedgeGovernorInputs {
 				in := allow
 				in.modelWinRate = hedgeWinRateFloor - 0.01
+				in.modelWinRateSamples = hedgeWinRateMinSamples
 				return in
 			}(),
 			hedgeSuppressWinRate,
@@ -123,9 +124,61 @@ func TestHedgeGovernorVerdictTable(t *testing.T) {
 			func() hedgeGovernorInputs {
 				in := allow
 				in.modelWinRate = 0
+				in.modelWinRateSamples = hedgeWinRateMinSamples
 				return in
 			}(),
 			hedgeSuppressWinRate,
+		},
+		// P1-1: the floor's nine-losers-per-marginal-win economics needs
+		// statistical footing — below hedgeWinRateMinSamples recorded
+		// outcomes the floor is waived so an unlucky first race cannot lock
+		// the model out of the sampling it needs to recover.
+		{
+			"below min samples the floor is waived",
+			func() hedgeGovernorInputs {
+				in := allow
+				in.modelWinRate = 0
+				in.modelWinRateSamples = hedgeWinRateMinSamples - 1
+				return in
+			}(),
+			hedgeAllow,
+		},
+		// P1-1: the periodic exploration hedge waives ONLY the win-rate
+		// floor; every earlier rule still binds.
+		{
+			"exploration waives the win-rate floor",
+			func() hedgeGovernorInputs {
+				in := allow
+				in.modelWinRate = 0
+				in.modelWinRateSamples = hedgeWinRateMinSamples
+				in.exploreNow = true
+				return in
+			}(),
+			hedgeAllow,
+		},
+		{
+			"exploration never outranks queued demand",
+			func() hedgeGovernorInputs {
+				in := allow
+				in.modelQueueDepth = 1
+				in.modelWinRate = 0
+				in.modelWinRateSamples = hedgeWinRateMinSamples
+				in.exploreNow = true
+				return in
+			}(),
+			hedgeSuppressQueued,
+		},
+		{
+			"exploration never busts the global budget",
+			func() hedgeGovernorInputs {
+				in := allow // budget = 8/4 = 2
+				in.activeHedges = 2
+				in.modelWinRate = 0
+				in.modelWinRateSamples = hedgeWinRateMinSamples
+				in.exploreNow = true
+				return in
+			}(),
+			hedgeSuppressGlobalBudget,
 		},
 	}
 	for _, tt := range tests {
@@ -197,7 +250,7 @@ func TestHedgeGovernorCounterConcurrency(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			for range pairsPerGoroutine {
-				g.noteHedgeLaunched()
+				g.acquireHedgeUngoverned()
 				g.noteHedgeResolved()
 			}
 		}()
@@ -247,11 +300,14 @@ func TestHedgeGovernorWinRateEWMA(t *testing.T) {
 		t.Fatalf("model-a win rate disturbed by model-b: %v, want 0.8", got)
 	}
 
-	// The seeded-loss model suppresses; the healthy model still allows.
+	// The seeded-loss model suppresses once its EWMA rests on enough
+	// samples (the pure function is fed the count; the governor tracks it);
+	// the healthy model still allows.
 	in := hedgeGovernorInputs{
 		idleAlternativeExists: true,
 		fleetIdleSlots:        8,
 		modelWinRate:          g.modelWinRate("model-b"),
+		modelWinRateSamples:   hedgeWinRateMinSamples,
 	}
 	if got := hedgeGovernorVerdict(in); got != hedgeSuppressWinRate {
 		t.Fatalf("all-loss model verdict = %v, want suppress_win_rate", got)
@@ -292,5 +348,139 @@ func TestHedgeGovernorWinRateConcurrency(t *testing.T) {
 	}
 	if got := g.modelWinRate("never-hedged"); got != hedgeWinRateUnknown {
 		t.Fatalf("untouched model rate = %v, want unknown", got)
+	}
+}
+
+// TestHedgeGovernorTryAcquireAtomicBudget is the P1-2 regression: N
+// concurrent acquirers race for a fleet-wide budget of ONE (idle alternative,
+// zero fleet idle slots → floor of one). Because the budget read and the
+// increment are one mutex hold, exactly one may win — the old
+// check-then-increment split let every racer observe the same free slot and
+// launch past the cap. Releasing the slot then restores exactly one
+// acquisition.
+func TestHedgeGovernorTryAcquireAtomicBudget(t *testing.T) {
+	t.Parallel()
+	g := newHedgeGovernor()
+	in := hedgeGovernorInputs{
+		idleAlternativeExists: true,
+		fleetIdleSlots:        0, // hedgeGlobalBudget → floor of 1
+	}
+
+	const acquirers = 16
+	var wg sync.WaitGroup
+	results := make([]bool, acquirers)
+	verdicts := make([]hedgeVerdict, acquirers)
+	for i := range acquirers {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			verdicts[i], results[i] = g.tryAcquireHedge("model-a", in)
+		}(i)
+	}
+	wg.Wait()
+
+	acquired := 0
+	for i := range acquirers {
+		if results[i] {
+			acquired++
+			if verdicts[i] != hedgeAllow {
+				t.Fatalf("acquired slot carried verdict %v, want allow", verdicts[i])
+			}
+		} else if verdicts[i] != hedgeSuppressGlobalBudget {
+			t.Fatalf("loser verdict = %v, want suppress_global_budget", verdicts[i])
+		}
+	}
+	if acquired != 1 {
+		t.Fatalf("%d concurrent acquirers won a budget of 1, want exactly 1", acquired)
+	}
+	if got := g.activeHedgeCount(); got != 1 {
+		t.Fatalf("activeHedges=%d after the race, want 1", got)
+	}
+
+	// A failure path releases the slot; the budget is whole again.
+	g.noteHedgeResolved()
+	if verdict, ok := g.tryAcquireHedge("model-a", in); !ok || verdict != hedgeAllow {
+		t.Fatalf("acquire after release = (%v, %v), want (allow, true)", verdict, ok)
+	}
+}
+
+// TestHedgeGovernorMinSampleFloor is the P1-1 lockout regression: a model
+// whose FIRST hedge loses seeds its EWMA at 0, and the old immediate floor
+// then suppressed every future hedge — no launches, no fresh outcomes, no
+// recovery, for the lifetime of the server. The floor now waits for
+// hedgeWinRateMinSamples recorded outcomes before it may bind.
+func TestHedgeGovernorMinSampleFloor(t *testing.T) {
+	g := newHedgeGovernor()
+	in := hedgeGovernorInputs{
+		idleAlternativeExists: true,
+		fleetIdleSlots:        80, // budget 20: never the binding rule here
+	}
+
+	// One losing race: EWMA 0, but only one sample — hedging continues.
+	g.recordHedgeOutcome("model-a", false)
+	for i := g.winSamples["model-a"]; i < hedgeWinRateMinSamples; i++ {
+		verdict, ok := g.tryAcquireHedge("model-a", in)
+		if verdict != hedgeAllow || !ok {
+			t.Fatalf("sample %d: verdict=(%v, %v), want allow below the min-sample floor", i, verdict, ok)
+		}
+		g.noteHedgeResolved()
+		g.recordHedgeOutcome("model-a", false)
+	}
+
+	// At hedgeWinRateMinSamples all-loss outcomes the floor binds.
+	if verdict, ok := g.tryAcquireHedge("model-a", in); verdict != hedgeSuppressWinRate || ok {
+		t.Fatalf("verdict=(%v, %v) at the sample floor, want (suppress_win_rate, false)", verdict, ok)
+	}
+}
+
+// TestHedgeGovernorExplorationEscape pins the P1-1 recovery path: while a
+// model is win-rate suppressed, every hedgeWinRateExploreInterval-th
+// evaluation converts to an exploration allow whose recorded outcome
+// refreshes the EWMA — so a regime change can lift the model back over the
+// floor instead of the suppression being permanent.
+func TestHedgeGovernorExplorationEscape(t *testing.T) {
+	g := newHedgeGovernor()
+	in := hedgeGovernorInputs{
+		idleAlternativeExists: true,
+		fleetIdleSlots:        80,
+	}
+
+	// Establish a suppressed model: min-sample count of pure losses.
+	for range hedgeWinRateMinSamples {
+		g.recordHedgeOutcome("model-a", false)
+	}
+
+	// One full cadence: the first interval-1 evaluations stay suppressed,
+	// the interval-th converts to an exploration allow.
+	for i := 1; i < hedgeWinRateExploreInterval; i++ {
+		if verdict, ok := g.tryAcquireHedge("model-a", in); verdict != hedgeSuppressWinRate || ok {
+			t.Fatalf("evaluation %d: verdict=(%v, %v), want suppressed until the exploration slot", i, verdict, ok)
+		}
+	}
+	verdict, ok := g.tryAcquireHedge("model-a", in)
+	if verdict != hedgeAllow || !ok {
+		t.Fatalf("evaluation %d: verdict=(%v, %v), want the exploration allow", hedgeWinRateExploreInterval, verdict, ok)
+	}
+
+	// The exploration hedge resolves as a WIN and refreshes the EWMA; wins
+	// on subsequent exploration hedges compound until the model clears the
+	// floor and normal hedging resumes.
+	g.noteHedgeResolved()
+	g.recordHedgeOutcome("model-a", true)
+	for g.modelWinRate("model-a") < hedgeWinRateFloor {
+		for {
+			verdict, ok := g.tryAcquireHedge("model-a", in)
+			if ok {
+				if verdict != hedgeAllow {
+					t.Fatalf("acquired exploration hedge carried verdict %v", verdict)
+				}
+				break
+			}
+		}
+		g.noteHedgeResolved()
+		g.recordHedgeOutcome("model-a", true)
+	}
+	if verdict, ok := g.tryAcquireHedge("model-a", in); verdict != hedgeAllow || !ok {
+		t.Fatalf("verdict=(%v, %v) after recovery over the floor, want (allow, true)", verdict, ok)
 	}
 }

--- a/coordinator/api/hedge_schedule.go
+++ b/coordinator/api/hedge_schedule.go
@@ -1,0 +1,132 @@
+package api
+
+import "time"
+
+// Hedge launch timing — the adaptive replacement for the bare
+// speculativeTimerRatio point (Routing v2 Phase 4, timing half).
+//
+// Today the only hedge policy is "launch the backup at 50% of the deadline"
+// (consumer.go speculativeTimerRatio). That point is blind to the backup: a
+// backup whose own q90 TTFT is 6s launched at the 50% point of a 9s budget can
+// NEVER produce first content before the clock dies — the coordinator burns a
+// second provider's compute to buy zero insurance. The fix is to launch no
+// later than the last instant the backup can still plausibly win:
+//
+//	latest_useful = deadline - max(backup_ttft_q90, floor) - commit_guard
+//	hedge_offset  = min(deadline * 1/2, latest_useful), floored at 0
+//
+// Invariants (each is load-bearing; wave-2 wiring and tests rely on them):
+//
+//  1. The offset is NEVER later than the 50% point. A fast-quoted backup only
+//     moves the launch EARLIER; a missing/low-confidence quote collapses to
+//     exactly the historical 50% behavior, so the legacy path is the ceiling,
+//     never exceeded.
+//  2. The absolute first-content deadline is never extended. The offset is
+//     measured from ReceivedAt inside the existing clock
+//     (first_token_clock.go invariant 1); a launch time in the past means
+//     "launch immediately", never "add time".
+//  3. Pure function of its inputs — no clocks read, no state, so the same
+//     (deadline, quote) pair always schedules identically and the property
+//     tests can sweep it exhaustively. Model-specific deadlines (#787,
+//     Server.FirstContentDeadline) arrive as the deadline parameter; nothing
+//     here hardcodes a budget.
+
+const (
+	// hedgeCommitGuard is subtracted from the backup's usable window so its
+	// first content can still clear commitFirstContent, the response write,
+	// and channel handoff before the absolute clock dies. Recent timeout
+	// route rows show coordinator-side commit+write overhead well under this;
+	// 500ms keeps a whole scheduling quantum of slack without eating into
+	// launch-earlier headroom on the ordinary 9s budget.
+	hedgeCommitGuard = 500 * time.Millisecond
+
+	// hedgeMinBackupBudget is the floor on the backup TTFT term. A quote can
+	// legitimately report a q90 of tens of milliseconds (warm slot, idle box),
+	// but granting the backup less than a second of runway makes the launch
+	// point degenerate — latest_useful drifts toward the deadline itself and
+	// the "insurance" becomes a last-millisecond dispatch that mostly loses
+	// while still consuming a second provider. One second is the smallest
+	// window in which a warm provider observably produces first content.
+	hedgeMinBackupBudget = time.Second
+
+	// hedgeRatioDenominator expresses the 50% ceiling as
+	// integer duration math (deadline/2) so the collapse point is exactly the
+	// historical speculativeTimerRatio point, bit-for-bit, with no float
+	// rounding drift between the legacy and adaptive paths.
+	hedgeRatioDenominator = 2
+)
+
+// hedgeQuoteConfidence grades the backup TTFT estimate feeding the schedule.
+// Quote-capable providers report high|low on capacity_quote; legacy/unconfirmed
+// plan entries have no quote at all (none). Only a high-confidence measured
+// quote may move the launch point off the 50% ceiling: acting on a low-trust
+// number could only move the launch EARLIER (invariant 1), and launching early
+// on bad data is exactly the compute amplification the governor exists to
+// prevent.
+type hedgeQuoteConfidence int
+
+const (
+	// hedgeConfidenceNone: no quote (legacy provider, probe timeout, or
+	// unconfirmed plan entry). Schedule at the historical 50% point.
+	hedgeConfidenceNone hedgeQuoteConfidence = iota
+	// hedgeConfidenceLow: the provider quoted from a sparse/fallback bucket
+	// (model→chip aggregate→benchmark manifest). Treated as none.
+	hedgeConfidenceLow
+	// hedgeConfidenceHigh: quoted from a populated per-(model, warm/cold,
+	// bucket) end-to-end TTFT ring of completed real requests.
+	hedgeConfidenceHigh
+)
+
+// hedgeLaunchOffset computes how long after ReceivedAt the backup dispatch may
+// launch. deadline is the request-absolute first-content budget for the
+// concrete model (Server.FirstContentDeadline(model, promptTokens) — 9s+1ms/tok
+// ordinary, tightened by exact-model policy). backupTTFTQ90 is the backup's
+// calibrated end-to-end q90 estimate; it participates only at high confidence.
+// A non-positive deadline (zero value, expired upstream) schedules immediate
+// launch — the caller's dispatch clock, not this function, decides whether any
+// dispatch still fits.
+func hedgeLaunchOffset(
+	deadline time.Duration,
+	backupTTFTQ90 time.Duration,
+	confidence hedgeQuoteConfidence,
+) time.Duration {
+	if deadline <= 0 {
+		return 0
+	}
+	halfPoint := deadline / hedgeRatioDenominator
+	if confidence != hedgeConfidenceHigh {
+		return halfPoint
+	}
+	backupBudget := backupTTFTQ90
+	if backupBudget < hedgeMinBackupBudget {
+		backupBudget = hedgeMinBackupBudget
+	}
+	latestUseful := deadline - backupBudget - hedgeCommitGuard
+	offset := halfPoint
+	if latestUseful < offset {
+		offset = latestUseful
+	}
+	if offset < 0 {
+		// The backup can no longer win even if launched now; launch
+		// immediately and let the race decide, never wait past a point
+		// that is already gone.
+		offset = 0
+	}
+	return offset
+}
+
+// hedgeLaunchAt anchors the offset on the request-absolute clock: the wall
+// time at which the backup may launch, receivedAt + offset. It inherits every
+// hedgeLaunchOffset invariant; in particular the result never exceeds
+// receivedAt + deadline/2, so it can never extend the absolute deadline.
+// Callers with an unstamped ReceivedAt (unit tests, mixed-version paths) keep
+// using the relative offset directly, mirroring first_token_clock.go
+// invariant 5.
+func hedgeLaunchAt(
+	receivedAt time.Time,
+	deadline time.Duration,
+	backupTTFTQ90 time.Duration,
+	confidence hedgeQuoteConfidence,
+) time.Time {
+	return receivedAt.Add(hedgeLaunchOffset(deadline, backupTTFTQ90, confidence))
+}

--- a/coordinator/api/hedge_schedule_test.go
+++ b/coordinator/api/hedge_schedule_test.go
@@ -1,0 +1,176 @@
+package api
+
+import (
+	"testing"
+	"time"
+)
+
+// TestHedgeLaunchOffsetTable pins exact scheduling arithmetic across the
+// deadline shapes the coordinator actually serves: the unit-test 5s base, the
+// production 9s + 1ms/token slope, and the tightened exact-model policy (#787,
+// Qwen3-VL Instruct at 4s). Values are hand-computed from
+// min(deadline/2, deadline - max(q90, 1s) - 500ms), floored at 0.
+func TestHedgeLaunchOffsetTable(t *testing.T) {
+	tests := []struct {
+		name       string
+		deadline   time.Duration
+		backupQ90  time.Duration
+		confidence hedgeQuoteConfidence
+		want       time.Duration
+	}{
+		{
+			name:       "fast backup stays at half point",
+			deadline:   9 * time.Second,
+			backupQ90:  200 * time.Millisecond, // floored to 1s: 9s-1s-0.5s=7.5s > 4.5s
+			confidence: hedgeConfidenceHigh,
+			want:       4500 * time.Millisecond,
+		},
+		{
+			name:       "slow backup launches earlier than half",
+			deadline:   9 * time.Second,
+			backupQ90:  6 * time.Second, // 9s-6s-0.5s = 2.5s < 4.5s
+			confidence: hedgeConfidenceHigh,
+			want:       2500 * time.Millisecond,
+		},
+		{
+			name:       "hopeless backup launches immediately",
+			deadline:   9 * time.Second,
+			backupQ90:  9 * time.Second, // 9s-9s-0.5s < 0 → 0
+			confidence: hedgeConfidenceHigh,
+			want:       0,
+		},
+		{
+			name:       "production token slope shifts both terms",
+			deadline:   9*time.Second + 321*time.Millisecond, // 9s base + 321 prompt tokens
+			backupQ90:  7 * time.Second,                      // 9.321s-7s-0.5s = 1.821s
+			confidence: hedgeConfidenceHigh,
+			want:       1821 * time.Millisecond,
+		},
+		{
+			name:       "tightened exact-model deadline",
+			deadline:   4 * time.Second, // Qwen3-VL policy base
+			backupQ90:  500 * time.Millisecond,
+			confidence: hedgeConfidenceHigh,
+			want:       2 * time.Second, // 4s-1s-0.5s = 2.5s, half point 2s wins
+		},
+		{
+			name:       "low confidence collapses to half point",
+			deadline:   9 * time.Second,
+			backupQ90:  8 * time.Second,
+			confidence: hedgeConfidenceLow,
+			want:       4500 * time.Millisecond,
+		},
+		{
+			name:       "no quote collapses to half point",
+			deadline:   9 * time.Second,
+			backupQ90:  0,
+			confidence: hedgeConfidenceNone,
+			want:       4500 * time.Millisecond,
+		},
+		{
+			name:       "zero deadline launches immediately",
+			deadline:   0,
+			backupQ90:  time.Second,
+			confidence: hedgeConfidenceHigh,
+			want:       0,
+		},
+		{
+			name:       "negative deadline is zero-value safe",
+			deadline:   -time.Second,
+			backupQ90:  0,
+			confidence: hedgeConfidenceNone,
+			want:       0,
+		},
+		{
+			name:       "zero q90 at high confidence hits the 1s floor",
+			deadline:   2 * time.Second, // 2s-1s-0.5s = 0.5s < half point 1s
+			backupQ90:  0,
+			confidence: hedgeConfidenceHigh,
+			want:       500 * time.Millisecond,
+		},
+	}
+	for _, tt := range tests {
+		got := hedgeLaunchOffset(tt.deadline, tt.backupQ90, tt.confidence)
+		if got != tt.want {
+			t.Errorf("%s: hedgeLaunchOffset(%v, %v, %d) = %v, want %v",
+				tt.name, tt.deadline, tt.backupQ90, tt.confidence, got, tt.want)
+		}
+	}
+}
+
+// TestHedgeLaunchOffsetNeverExceedsHalfPoint sweeps deadlines (including the
+// model-specific ones), backup estimates, and confidences and asserts the two
+// schedule invariants hold everywhere: the offset never passes the 50% point
+// (so the adaptive path can only launch EARLIER than the legacy
+// speculativeTimerRatio), and it is never negative (a past launch point means
+// "now", never a time subtraction that could confuse the caller's timer).
+func TestHedgeLaunchOffsetNeverExceedsHalfPoint(t *testing.T) {
+	deadlines := []time.Duration{
+		100 * time.Millisecond,
+		400 * time.Millisecond,
+		time.Second,
+		4 * time.Second,                        // Qwen3-VL exact-model base
+		4*time.Second + 321*time.Millisecond,   // tightened base + token slope
+		5 * time.Second,                        // unit-test base
+		9 * time.Second,                        // production base
+		9*time.Second + 2048*time.Millisecond,  // production + 2048-token slope
+		9*time.Second + 32768*time.Millisecond, // production + long prompt
+		15 * time.Second,
+	}
+	confidences := []hedgeQuoteConfidence{
+		hedgeConfidenceNone, hedgeConfidenceLow, hedgeConfidenceHigh,
+	}
+	for _, deadline := range deadlines {
+		for q90 := time.Duration(0); q90 <= deadline+2*time.Second; q90 += 250 * time.Millisecond {
+			for _, confidence := range confidences {
+				got := hedgeLaunchOffset(deadline, q90, confidence)
+				if half := deadline / 2; got > half {
+					t.Fatalf("hedgeLaunchOffset(%v, %v, %d) = %v exceeds half point %v",
+						deadline, q90, confidence, got, half)
+				}
+				if got < 0 {
+					t.Fatalf("hedgeLaunchOffset(%v, %v, %d) = %v is negative",
+						deadline, q90, confidence, got)
+				}
+			}
+		}
+	}
+}
+
+// TestHedgeLaunchOffsetLowConfidenceIgnoresQuote proves the collapse rule: any
+// confidence below high schedules at exactly the half point regardless of how
+// extreme the quoted q90 is — a low-trust number must not move the launch.
+func TestHedgeLaunchOffsetLowConfidenceIgnoresQuote(t *testing.T) {
+	const deadline = 9 * time.Second
+	for _, confidence := range []hedgeQuoteConfidence{hedgeConfidenceNone, hedgeConfidenceLow} {
+		for _, q90 := range []time.Duration{0, time.Second, 8 * time.Second, time.Minute} {
+			if got := hedgeLaunchOffset(deadline, q90, confidence); got != deadline/2 {
+				t.Fatalf("confidence %d q90 %v: offset = %v, want half point %v",
+					confidence, q90, got, deadline/2)
+			}
+		}
+	}
+}
+
+// TestHedgeLaunchAtAnchorsOnReceivedAt verifies the absolute form is exactly
+// receivedAt + offset — the launch time lives inside the existing
+// request-absolute clock and never extends past receivedAt + deadline.
+func TestHedgeLaunchAtAnchorsOnReceivedAt(t *testing.T) {
+	receivedAt := time.Date(2026, 8, 30, 12, 0, 0, 0, time.UTC)
+	const deadline = 9 * time.Second
+
+	at := hedgeLaunchAt(receivedAt, deadline, 6*time.Second, hedgeConfidenceHigh)
+	if want := receivedAt.Add(2500 * time.Millisecond); !at.Equal(want) {
+		t.Fatalf("launch at = %v, want %v", at, want)
+	}
+	if at.After(receivedAt.Add(deadline)) {
+		t.Fatalf("launch at %v extends past absolute deadline %v",
+			at, receivedAt.Add(deadline))
+	}
+
+	// Immediate-launch case: the anchor IS the launch point.
+	at = hedgeLaunchAt(receivedAt, deadline, 20*time.Second, hedgeConfidenceHigh)
+	if !at.Equal(receivedAt) {
+		t.Fatalf("hopeless-backup launch at = %v, want receivedAt %v", at, receivedAt)
+	}
+}

--- a/coordinator/api/inference_error_sanitize.go
+++ b/coordinator/api/inference_error_sanitize.go
@@ -58,8 +58,14 @@ func sanitizeProviderInferenceError(msg *protocol.InferenceErrorMessage) (safe p
 			suppliedReason = capacityRejectionErrorReason(msg.RejectionReason)
 		}
 	}
-	if msg.AvailableTokenBudget > 0 {
-		safe.AvailableTokenBudget = msg.AvailableTokenBudget
+	if msg.AvailableTokenBudget != nil && *msg.AvailableTokenBudget >= 0 {
+		// Pointer presence is the contract: an EXPLICIT zero means "the live
+		// gate has no headroom RIGHT NOW" (transient) and must survive the
+		// boundary, while nil keeps the stale-heartbeat fallback in play.
+		// Copied into a fresh allocation so the safe frame never aliases the
+		// raw provider message.
+		v := *msg.AvailableTokenBudget
+		safe.AvailableTokenBudget = &v
 	}
 	if msg.FeasibleAfterMS > 0 {
 		safe.FeasibleAfterMS = msg.FeasibleAfterMS

--- a/coordinator/api/inference_error_sanitize.go
+++ b/coordinator/api/inference_error_sanitize.go
@@ -43,12 +43,34 @@ func sanitizeProviderInferenceError(msg *protocol.InferenceErrorMessage) (safe p
 
 	safe.TerminalCause, invalidCause = sanitizeProviderTerminalCause(msg.TerminalCause)
 	suppliedReason := msg.ErrorReason
+	// Enriched rejection (routing v2): the four additive fields are typed and
+	// bounded, so they may cross the confidentiality boundary — RejectionReason
+	// only from the closed CapacityRejectionReason vocabulary (unknown values
+	// are treated as absent, matching the protocol contract), the numeric
+	// fields clamped non-negative. A typed reason on a frame that carries no
+	// structured error_reason is additionally mapped onto the EXISTING closed
+	// error_reason vocabulary so classifyRejection's reason-first path (and
+	// every breaker/cooldown funnel behind it) classifies the rejection without
+	// a parallel classifier.
+	if msg.RejectionReason.Valid() {
+		safe.RejectionReason = msg.RejectionReason
+		if suppliedReason == "" {
+			suppliedReason = capacityRejectionErrorReason(msg.RejectionReason)
+		}
+	}
+	if msg.AvailableTokenBudget > 0 {
+		safe.AvailableTokenBudget = msg.AvailableTokenBudget
+	}
+	if msg.FeasibleAfterMS > 0 {
+		safe.FeasibleAfterMS = msg.FeasibleAfterMS
+	}
+	safe.CapacitySeq = msg.CapacitySeq
 	// Older providers used a bare 429 to mean queue saturation. Preserve that
 	// bounded distinction during rolling upgrades; typed capacity frames remain
 	// reason-driven, so capacity_timeout continues to canonicalize to 503.
 	if legacyFrame &&
 		msg.StatusCode == http.StatusTooManyRequests &&
-		msg.ErrorReason == "" &&
+		suppliedReason == "" &&
 		msg.TerminalCause == "" {
 		suppliedReason = errorReasonQueueFull
 	}
@@ -296,4 +318,32 @@ func normalizeInferenceErrorForInternalUse(msg protocol.InferenceErrorMessage) p
 	}
 	safe, _, _ := sanitizeProviderInferenceError(&msg)
 	return safe
+}
+
+// capacityRejectionErrorReason maps the typed wire CapacityRejectionReason
+// onto the coordinator's existing closed error_reason vocabulary — the exact
+// values classifyRejection's reason-first path (P1) already trusts. This is a
+// vocabulary translation, never a new classifier: deterministic-vs-transient
+// stays decided in one place (inference_failure_class.go).
+//
+//   - token_budget: the node's live active-token budget cannot fit the
+//     request → node-scoped, transient (a bigger/idler box may serve).
+//   - kv_headroom / memory_cap: this node's memory pressure → node-scoped.
+//   - slot_state: loading/reloading/draining/crashed slot → busy now.
+//   - deadline: admissible eventually, not within the remaining clock →
+//     the health-neutral deadline_unreachable refusal.
+//   - template / capability: request-shape refusals with no capacity-class
+//     mapping; empty keeps the legacy status/string heuristics authoritative.
+func capacityRejectionErrorReason(r protocol.CapacityRejectionReason) string {
+	switch r {
+	case protocol.RejectionReasonTokenBudget:
+		return errorReasonRequestExceedsNodeBudget
+	case protocol.RejectionReasonKVHeadroom, protocol.RejectionReasonMemoryCap:
+		return errorReasonRequestExceedsNode
+	case protocol.RejectionReasonSlotState:
+		return errorReasonCapacityBusy
+	case protocol.RejectionReasonDeadline:
+		return errorReasonDeadlineUnreachable
+	}
+	return ""
 }

--- a/coordinator/api/inference_error_sanitize_test.go
+++ b/coordinator/api/inference_error_sanitize_test.go
@@ -424,3 +424,41 @@ func TestWriteGenericProviderErrorIgnoresRawErrorEvenWithValidCode(t *testing.T)
 		t.Fatalf("fixed client message missing: %s", recorder.Body.String())
 	}
 }
+
+// TestSanitizeProviderInferenceErrorLiveBudgetPresence pins the P1-4 wire
+// semantics at the confidentiality boundary: the live budget is a POINTER so
+// presence itself is signal — nil (legacy frame) stays nil and leaves the
+// stale-heartbeat fallback in play, an EXPLICIT zero ("no headroom right
+// now", transient) survives, and a nonsense negative is treated as absent.
+// The safe copy must never alias the raw provider message's allocation.
+func TestSanitizeProviderInferenceErrorLiveBudgetPresence(t *testing.T) {
+	base := protocol.InferenceErrorMessage{
+		Type:        protocol.TypeInferenceError,
+		StatusCode:  http.StatusServiceUnavailable,
+		FailureCode: protocol.FailureCodeCapacity,
+	}
+
+	legacy := base
+	safe, _, _ := sanitizeProviderInferenceError(&legacy)
+	if safe.AvailableTokenBudget != nil {
+		t.Fatalf("legacy nil budget crossed the boundary as %v, want nil", *safe.AvailableTokenBudget)
+	}
+
+	zero := base
+	zero.RejectionReason = protocol.RejectionReasonTokenBudget
+	zero.AvailableTokenBudget = i64ptr(0)
+	safe, _, _ = sanitizeProviderInferenceError(&zero)
+	if safe.AvailableTokenBudget == nil || *safe.AvailableTokenBudget != 0 {
+		t.Fatalf("explicit zero live budget = %v, want a preserved 0", safe.AvailableTokenBudget)
+	}
+	if safe.AvailableTokenBudget == zero.AvailableTokenBudget {
+		t.Fatal("safe frame aliases the raw provider message's budget allocation")
+	}
+
+	negative := base
+	negative.AvailableTokenBudget = i64ptr(-5)
+	safe, _, _ = sanitizeProviderInferenceError(&negative)
+	if safe.AvailableTokenBudget != nil {
+		t.Fatalf("negative budget crossed the boundary as %v, want dropped", *safe.AvailableTokenBudget)
+	}
+}

--- a/coordinator/api/inference_failure_class.go
+++ b/coordinator/api/inference_failure_class.go
@@ -1,6 +1,10 @@
 package api
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+)
 
 // isCapacityClassProviderError reports whether a provider inference-error string
 // names a CAPACITY/LIFECYCLE condition rather than a genuine server fault. The
@@ -149,19 +153,17 @@ const (
 // in which case it is transient. An explicit "exceeds … context" phrasing names
 // the context directly and is always deterministic.
 //
-// LIMITATION (residual stale-snapshot edge): providerBudget is the LAST
-// heartbeat's ActiveTokenBudgetMax, not the live budget the provider rejected
-// against — the wire InferenceErrorMessage carries no rejection-time budget. So if
-// a provider's budget was >= context at the last heartbeat but memory pressure
-// shrank it below context just before this request, we still classify
-// deterministic and stop after one attempt. This is strictly better than the
-// pre-DAR-347 behavior (which classified EVERY batch-budget rejection
-// deterministic) and degrades only to a rare uptime-neutral 429 the client
-// retries — never a 503 storm. The complete fix is provider-side: emit a distinct
-// reason for "prompt > context" vs "prompt > this node's budget" so the
-// coordinator never has to infer it from a stale snapshot (tracked as a follow-up;
-// requires a protocol/provider change across a mixed fleet, out of scope here).
-func classifyRejection(reason, errStr string, providerBudget int64, modelContext int) rejectionKind {
+// typedRejection is the wire CapacityRejectionReason from an enriched
+// rejection ("" for legacy frames and funnels without one). A typed
+// token_budget is AUTHORITATIVE transient for the batch-budget family: the
+// provider's live gate named "the active-token budget cannot fit this request
+// RIGHT NOW" (it frees as running sequences retire), so a deterministic-
+// unservable verdict must never be re-derived from the stale heartbeat budget
+// fallback — including when the enriched live budget is an explicit zero,
+// which the heuristic below cannot tell apart from "unknown". This closes the
+// residual stale-snapshot LIMITATION for enriched providers; legacy frames
+// (no typed reason, heartbeat budget only) keep the heuristic unchanged.
+func classifyRejection(reason, errStr string, providerBudget int64, modelContext int, typedRejection protocol.CapacityRejectionReason) rejectionKind {
 	// P1 (structured provider reason): when a provider tells us EXACTLY why it
 	// rejected, trust it instead of inferring deterministic-vs-transient from a
 	// stale heartbeat snapshot. request_exceeds_context is fleet-wide deterministic
@@ -176,10 +178,7 @@ func classifyRejection(reason, errStr string, providerBudget int64, modelContext
 	case errorReasonDeadlineUnreachable:
 		return rejectionDeadlineUnreachable
 	case "request_exceeds_batch_token_budget":
-		if modelContext > 0 && providerBudget > 0 && providerBudget < int64(modelContext) {
-			return rejectionTransientCapacity
-		}
-		return rejectionDeterministicUnservable
+		return batchBudgetRejectionKind(typedRejection, providerBudget, modelContext)
 	}
 	// Capacity-class is gated by isCapacityClassProviderError so fault strings
 	// (checked first there) can never be miscategorised as a capacity shed.
@@ -210,10 +209,7 @@ func classifyRejection(reason, errStr string, providerBudget int64, modelContext
 	// treat as transient (failover, capped). Otherwise (budget >= context, or
 	// either value unknown) the binding term is the context, identical fleet-wide.
 	if strings.Contains(s, "batch token budget") {
-		if modelContext > 0 && providerBudget > 0 && providerBudget < int64(modelContext) {
-			return rejectionTransientCapacity
-		}
-		return rejectionDeterministicUnservable
+		return batchBudgetRejectionKind(typedRejection, providerBudget, modelContext)
 	}
 	// Everything else capacity-class is provider/time-specific — this node's live
 	// KV budget ("exceeds active token budget" / "requires N tokens but only M
@@ -221,6 +217,30 @@ func classifyRejection(reason, errStr string, providerBudget int64, modelContext
 	// update drain, or a cold "not loaded" miss. Another provider (bigger budget,
 	// free queue, already warm) may serve it, so fail over under the cap.
 	return rejectionTransientCapacity
+}
+
+// batchBudgetRejectionKind resolves the "request exceeds batch token budget"
+// family, shared by classifyRejection's reason-first and string paths. The
+// admission cap is min(context, activeTokenBudget), so the rejection is
+// deterministic only when the binding term was the fleet-wide CONTEXT:
+//
+//  1. A typed token_budget rejection is authoritative transient — the live
+//     gate itself said the binding term was THIS node's budget, so the stale
+//     heartbeat fallback must not overrule it (see classifyRejection's
+//     typedRejection contract).
+//  2. Absent a typed reason, positive evidence of memory pressure (a known
+//     reported budget below a known model context) means a less-pressured
+//     provider could serve — transient, capped failover.
+//  3. Otherwise (budget >= context, or either value unknown) the binding term
+//     is the context, identical fleet-wide — deterministic, stop at once.
+func batchBudgetRejectionKind(typedRejection protocol.CapacityRejectionReason, providerBudget int64, modelContext int) rejectionKind {
+	if typedRejection == protocol.RejectionReasonTokenBudget {
+		return rejectionTransientCapacity
+	}
+	if modelContext > 0 && providerBudget > 0 && providerBudget < int64(modelContext) {
+		return rejectionTransientCapacity
+	}
+	return rejectionDeterministicUnservable
 }
 
 // isCapacityRejectStrike reports whether a provider rejection should count

--- a/coordinator/api/inference_failure_class_p1_test.go
+++ b/coordinator/api/inference_failure_class_p1_test.go
@@ -5,17 +5,17 @@ import "testing"
 // C3: classifyRejection trusts the P1 structured provider reason over the
 // stale-snapshot heuristic; old providers (reason=="") fall through unchanged.
 func TestClassifyRejection_P1StructuredReason(t *testing.T) {
-	if got := classifyRejection("request_exceeds_context", "", 0, 0); got != rejectionDeterministicUnservable {
+	if got := classifyRejection("request_exceeds_context", "", 0, 0, ""); got != rejectionDeterministicUnservable {
 		t.Errorf("request_exceeds_context = %v, want deterministic", got)
 	}
-	if got := classifyRejection("request_exceeds_node", "", 0, 0); got != rejectionTransientCapacity {
+	if got := classifyRejection("request_exceeds_node", "", 0, 0, ""); got != rejectionTransientCapacity {
 		t.Errorf("request_exceeds_node = %v, want transient", got)
 	}
-	if got := classifyRejection("capacity_busy", "", 0, 0); got != rejectionTransientCapacity {
+	if got := classifyRejection("capacity_busy", "", 0, 0, ""); got != rejectionTransientCapacity {
 		t.Errorf("capacity_busy = %v, want transient", got)
 	}
 	// Old provider (no structured reason, non-capacity string) → unchanged fallback.
-	if got := classifyRejection("", "invalid tool payload", 0, 0); got != rejectionNotCapacity {
+	if got := classifyRejection("", "invalid tool payload", 0, 0, ""); got != rejectionNotCapacity {
 		t.Errorf("legacy non-capacity = %v, want notCapacity", got)
 	}
 }
@@ -26,11 +26,11 @@ func TestClassifyRejection_P1StructuredReason(t *testing.T) {
 // message (budget < context) must stay transient so it fails over to a bigger box.
 func TestClassifyRejection_P1ContextOverflowMessage(t *testing.T) {
 	ctxMsg := "token_budget_exhausted: request exceeds model context window (200000 prompt tokens > 131072 context)"
-	if got := classifyRejection("", ctxMsg, 0, 131072); got != rejectionDeterministicUnservable {
+	if got := classifyRejection("", ctxMsg, 0, 131072, ""); got != rejectionDeterministicUnservable {
 		t.Errorf("context-overflow message must be deterministic; got %v", got)
 	}
 	nodeMsg := "token_budget_exhausted: request exceeds batch token budget"
-	if got := classifyRejection("", nodeMsg, 40000, 131072); got != rejectionTransientCapacity {
+	if got := classifyRejection("", nodeMsg, 40000, 131072, ""); got != rejectionTransientCapacity {
 		t.Errorf("pressured batch-budget (budget<context) must be transient; got %v", got)
 	}
 }

--- a/coordinator/api/provider.go
+++ b/coordinator/api/provider.go
@@ -566,6 +566,22 @@ func (s *Server) providerReadLoop(ctx context.Context, conn *websocket.Conn, pro
 			// re-arms a code-identity challenge WITHOUT a reconnect.
 			s.maybeRearmCodeAttest(loopCtx, providerID, provider, hbMsg)
 
+		case protocol.TypeCapacityQuote:
+			if provider == nil {
+				// A quote answers a coordinator-sent probe, and probes are only
+				// sent to registered providers — a quote on an unregistered
+				// connection is a protocol violation, same posture as heartbeat.
+				s.logger.Warn("capacity quote from unregistered provider",
+					"provider_id", providerID)
+				continue
+			}
+			quoteMsg := msg.Payload.(*protocol.CapacityQuoteMessage)
+			// Correlation (quote_id → outstanding probe, provider binding,
+			// window expiry) and plan confirm/demote all live registry-side
+			// with the probe state; the read loop only delivers. Synchronous
+			// like heartbeat ingest — no DB or lock-heavy work on this path.
+			s.registry.HandleCapacityQuote(providerID, quoteMsg)
+
 		case protocol.TypeInferenceAccepted:
 			acceptMsg := msg.Payload.(*protocol.InferenceAcceptedMessage)
 			s.handleInferenceAccepted(provider, acceptMsg)

--- a/coordinator/api/rejection_classify_test.go
+++ b/coordinator/api/rejection_classify_test.go
@@ -1,6 +1,10 @@
 package api
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+)
 
 // TestClassifyRejection pins the deterministic-vs-transient split that drives the
 // dispatch loop's stop-or-failover decision (DAR-347). The exact provider strings
@@ -17,6 +21,7 @@ func TestClassifyRejection(t *testing.T) {
 		errStr         string
 		providerBudget int64
 		modelContext   int
+		typedRejection protocol.CapacityRejectionReason
 		want           rejectionKind
 	}{
 		{
@@ -125,6 +130,36 @@ func TestClassifyRejection(t *testing.T) {
 			modelContext:   131072,
 			want:           rejectionDeterministicUnservable,
 		},
+		// P1-4: a typed token_budget rejection is AUTHORITATIVE transient for
+		// the batch-budget family — the live gate itself named this node's
+		// budget as the binding term, so the stale heartbeat fallback (which
+		// would read "unknown budget ⇒ deterministic" below) must not overrule
+		// it, on either the reason-first or the string path.
+		{
+			name:           "typed_token_budget_overrides_stale_heartbeat_reason_path",
+			reason:         "request_exceeds_batch_token_budget",
+			typedRejection: protocol.RejectionReasonTokenBudget,
+			providerBudget: 0,
+			modelContext:   131072,
+			want:           rejectionTransientCapacity,
+		},
+		{
+			name:           "typed_token_budget_overrides_stale_heartbeat_string_path",
+			errStr:         "token_budget_exhausted: request exceeds batch token budget",
+			typedRejection: protocol.RejectionReasonTokenBudget,
+			providerBudget: 200_000,
+			modelContext:   131072,
+			want:           rejectionTransientCapacity,
+		},
+		// A typed reason NEVER touches the explicit context-overflow verdict:
+		// that path derives from the string naming the context, not from any
+		// budget, so it stays fleet-wide deterministic.
+		{
+			name:           "typed_token_budget_never_overrides_explicit_context",
+			errStr:         "prompt exceeds the model's context window",
+			typedRejection: protocol.RejectionReasonTokenBudget,
+			want:           rejectionDeterministicUnservable,
+		},
 		// Genuine faults / unknown ⇒ not capacity (keep fault failover + breaker).
 		{name: "crash_is_not_capacity", errStr: "backend crash during generation", want: rejectionNotCapacity},
 		{name: "panic_is_not_capacity", errStr: "panic: nil map", want: rejectionNotCapacity},
@@ -138,9 +173,9 @@ func TestClassifyRejection(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := classifyRejection(tc.reason, tc.errStr, tc.providerBudget, tc.modelContext); got != tc.want {
-				t.Errorf("classifyRejection(%q, %q, budget=%d, ctx=%d) = %d, want %d",
-					tc.reason, tc.errStr, tc.providerBudget, tc.modelContext, got, tc.want)
+			if got := classifyRejection(tc.reason, tc.errStr, tc.providerBudget, tc.modelContext, tc.typedRejection); got != tc.want {
+				t.Errorf("classifyRejection(%q, %q, budget=%d, ctx=%d, typed=%q) = %d, want %d",
+					tc.reason, tc.errStr, tc.providerBudget, tc.modelContext, tc.typedRejection, got, tc.want)
 			}
 		})
 	}

--- a/coordinator/api/request_introspection.go
+++ b/coordinator/api/request_introspection.go
@@ -321,6 +321,46 @@ func detectMediaRequirement(parsed map[string]any) bool {
 	return false
 }
 
+// countMediaParts counts the image/video content parts across a chat
+// (messages[]) or Responses API (input[]) body — the count-only vision shape
+// term a capacity probe carries (protocol.CapacityProbeMessage
+// VisionImageCount: counts, never bytes or content-derived dimensions).
+// Same traversal as detectMediaRequirement so the two can never disagree on
+// what constitutes a media part.
+func countMediaParts(parsed map[string]any) int {
+	count := 0
+	countContent := func(content any) {
+		parts, ok := content.([]any)
+		if !ok {
+			return
+		}
+		for _, part := range parts {
+			pm, ok := part.(map[string]any)
+			if !ok {
+				continue
+			}
+			if typ, _ := pm["type"].(string); isMediaPartType(typ) {
+				count++
+			}
+		}
+	}
+	if messages, ok := parsed["messages"].([]any); ok {
+		for _, m := range messages {
+			if mm, ok := m.(map[string]any); ok {
+				countContent(mm["content"])
+			}
+		}
+	}
+	if input, ok := parsed["input"].([]any); ok {
+		for _, item := range input {
+			if im, ok := item.(map[string]any); ok {
+				countContent(im["content"])
+			}
+		}
+	}
+	return count
+}
+
 // isInlineDataURI reports whether a media reference is an inline base64 data: URI
 // — the ONLY form the provider's E2E-encrypted VLM path accepts (see
 // VLMRequestInference.MediaError.invalidURL, which 400s anything else).

--- a/coordinator/api/server.go
+++ b/coordinator/api/server.go
@@ -307,6 +307,13 @@ type Server struct {
 	// zombieCanceller throttles cancels for chunks on abandoned streams. See zombie_stream.go.
 	zombieCanceller *zombieStreamCanceller
 
+	// hedgeGov is the fleet-wide hedge admission governor (Routing v2 Phase 4):
+	// the mutable half of the speculative-launch verdict — the global
+	// concurrent-hedge counter and per-model win-rate EWMAs. One instance per
+	// Server; runSpeculative consults it before every backup launch and
+	// resolves it exactly once per launched hedge. See hedge_governor.go.
+	hedgeGov *hedgeGovernor
+
 	// minProviderVersion is the minimum provider version accepted for routing.
 	// Providers below this version are excluded and told to update.
 	// Set from EIGENINFERENCE_MIN_PROVIDER_VERSION env var or derived from latest release.
@@ -736,6 +743,7 @@ func NewServer(reg *registry.Registry, st store.Store, cfg ServerConfig, logger 
 		trustReuseCache:          newTrustReuseCache(),
 		settlements:              newSettlementHolder(),
 		zombieCanceller:          newZombieStreamCanceller(),
+		hedgeGov:                 newHedgeGovernor(),
 		serviceReservations:      newServiceReservationManager(st, cfg.ServiceReservations),
 		routeTelemetry:           newTelemetrySink(logger, defaultTelemetrySinkCapacity, defaultTelemetrySinkWorkers),
 		mediaResolver:            mediafetch.NewResolver(mediaFetchCfg, logger),

--- a/coordinator/protocol/capacity.go
+++ b/coordinator/protocol/capacity.go
@@ -1,0 +1,152 @@
+package protocol
+
+// Capacity probe/quote wire types — routing v2's honesty channel.
+//
+// Prod gap this answers (see registry/budget_clamp.go for the full account):
+// 11,581 capacity-shaped provider 503s in 6h from boxes whose 5s heartbeats
+// looked ~1.4% utilized. Heartbeat budgets are stale-OPTIMISTIC; the
+// provider's live KV/admission gate is the only honest source. Rather than
+// discovering that gate one bounced dispatch at a time, the coordinator asks:
+// after the primary dispatches (probes run in parallel with the primary,
+// never before it), the remaining shortlist candidates each get a
+// capacity_probe and answer with a capacity_quote computed from the same
+// lock-free snapshot their admission gate uses. Quotes confirm/demote backup
+// candidates and time hedges; the coordinator's ledger remains the primary
+// accounting — quotes are drift correction, not reservations.
+//
+// PRIVACY INVARIANT: a probe reaches providers that will likely NEVER serve
+// the request, so it may carry bucketed request-shape metadata only. No
+// prompt text, ciphertext, image bytes, tool bodies, consumer or account
+// identity, and no stable request ID — QuoteID is random and request-local,
+// so a probed-but-not-chosen provider can never correlate a probe with a
+// request it later serves. TestCapacityProbeShapeClosed pins the field set.
+//
+// Mirrored in provider-swift/Sources/ProviderCore/Protocol/Types.swift; the
+// Go and Swift encoders must agree on these JSON shapes byte-for-byte.
+
+// CapacityRejectionReason is the closed, cross-language vocabulary for why a
+// provider's live gate cannot admit a request of the probed shape. Shared by
+// capacity_quote (RejectionReason when !AdmissibleNow) and the enriched
+// inference_error fields, so the coordinator classifies both through one
+// taxonomy. Unknown values are treated as absent (legacy heuristics apply);
+// provider-authored prose never joins this contract.
+type CapacityRejectionReason string
+
+const (
+	// RejectionReasonTokenBudget: the live active-token budget cannot fit
+	// prompt bucket + max output tokens right now (transient: budget frees as
+	// running sequences retire).
+	RejectionReasonTokenBudget CapacityRejectionReason = "token_budget"
+	// RejectionReasonKVHeadroom: the request can NEVER fit the slot's KV byte
+	// budget, even into an empty batch — prompt bucket + max output exceeds
+	// the whole grant (node-deterministic; a bigger box may serve).
+	RejectionReasonKVHeadroom CapacityRejectionReason = "kv_headroom"
+	// RejectionReasonMemoryCap: the unified-memory cap / activation reserve
+	// blocks admission (e.g. would require an evicting cold load).
+	RejectionReasonMemoryCap CapacityRejectionReason = "memory_cap"
+	// RejectionReasonSlotState: the model slot is not in a servable state
+	// (crashed, reloading, draining, shutting down, or the model is not
+	// resident with no capacity report yet).
+	RejectionReasonSlotState CapacityRejectionReason = "slot_state"
+	// RejectionReasonTemplate: the slot cannot render this request shape's
+	// chat template.
+	RejectionReasonTemplate CapacityRejectionReason = "template"
+	// RejectionReasonCapability: a required capability (e.g. vision, tool
+	// constraints) is not available on this slot.
+	RejectionReasonCapability CapacityRejectionReason = "capability"
+	// RejectionReasonDeadline: admissible eventually, but not within the
+	// probe's deadline_remaining_ms.
+	RejectionReasonDeadline CapacityRejectionReason = "deadline"
+)
+
+// Valid reports whether r belongs to the protocol's closed vocabulary.
+func (r CapacityRejectionReason) Valid() bool {
+	switch r {
+	case RejectionReasonTokenBudget,
+		RejectionReasonKVHeadroom,
+		RejectionReasonMemoryCap,
+		RejectionReasonSlotState,
+		RejectionReasonTemplate,
+		RejectionReasonCapability,
+		RejectionReasonDeadline:
+		return true
+	default:
+		return false
+	}
+}
+
+// CapacityQuoteConfidence grades the provenance of a quote's TTFT estimate.
+const (
+	// CapacityConfidenceHigh: quantiles come from a populated per-(model,
+	// warm/cold, prompt-bucket, batch-bucket) ring of completed real requests.
+	CapacityConfidenceHigh = "high"
+	// CapacityConfidenceLow: the provider fell back to a coarser aggregate or
+	// the benchmark manifest; the coordinator should trust its own floor.
+	CapacityConfidenceLow = "low"
+)
+
+// CapacityProbePromptBucketTokens is the granularity probes round prompt
+// estimates UP to. Bucketing (never exact counts) is what lets a probe reach
+// non-serving providers: they learn request shape, not request content.
+const CapacityProbePromptBucketTokens = 512
+
+// CapacityProbeMessage (coordinator → provider) asks whether the provider
+// could admit a request of this bucketed shape right now. Sent on the bounded
+// data lane, never the strict control lane, so a probe storm cannot starve
+// cancels or attestation. Providers answer from their published capacity
+// snapshot — no actor hop, no inference, no allocation.
+type CapacityProbeMessage struct {
+	Type string `json:"type"`
+	// QuoteID is a random, request-local correlation ID minted per probe. It
+	// is deliberately NOT the public request ID (privacy invariant above).
+	QuoteID string `json:"quote_id"`
+	Model   string `json:"model"`
+	// PromptTokensBucket is the coordinator's prompt-token estimate rounded UP
+	// to a multiple of CapacityProbePromptBucketTokens.
+	PromptTokensBucket int `json:"prompt_tokens_bucket"`
+	MaxOutputTokens    int `json:"max_output_tokens"`
+	// RequiresVision/VisionImageCount carry the vision shape when applicable;
+	// both omitted for text-only requests so the legacy-shaped frame stays
+	// minimal. Counts only — never image bytes or dimensions derived from
+	// content.
+	RequiresVision   bool `json:"requires_vision,omitempty"`
+	VisionImageCount int  `json:"vision_image_count,omitempty"`
+	// DeadlineRemainingMS is the time left on the request's absolute
+	// first-content clock at probe send. A duration, never a wall-clock
+	// timestamp: provider clocks skew.
+	DeadlineRemainingMS int64 `json:"deadline_remaining_ms"`
+}
+
+// CapacityQuoteMessage (provider → coordinator) answers one probe.
+//
+// TTFT quantiles are END-TO-END distribution quantiles measured from
+// completed real requests of comparable shape — never a sum of per-stage
+// p95s, which compounds tail pessimism into a useless number. Durations only,
+// never wall clocks. AdmissibleNow is advisory (the inference request itself
+// is the reservation; the live gate re-decides on arrival): a stale-positive
+// quote costs one enriched rejection, a stale-negative just demotes a backup.
+type CapacityQuoteMessage struct {
+	Type    string `json:"type"`
+	QuoteID string `json:"quote_id"`
+	// CapacitySeq names the capacity snapshot (BackendCapacity.CapacitySeq
+	// stream) this quote was computed from. Carried so ordering against
+	// heartbeats is possible; the coordinator currently trusts the probe
+	// window (quotes expire in 250ms, far under a heartbeat interval) and
+	// does not compare seqs.
+	CapacitySeq   uint64 `json:"capacity_seq"`
+	AdmissibleNow bool   `json:"admissible_now"`
+	// RejectionReason is set exactly when !AdmissibleNow; an admissible quote
+	// omits it.
+	RejectionReason CapacityRejectionReason `json:"rejection_reason,omitempty"`
+	TTFTP50MS       float64                 `json:"ttft_p50_ms"`
+	TTFTP90MS       float64                 `json:"ttft_p90_ms"`
+	// QueueEstMS is the provider's current queue-wait estimate for this shape,
+	// already reflected in the TTFT quantiles' population but reported
+	// separately so the coordinator's hedge timing can see queue pressure.
+	QueueEstMS float64 `json:"queue_est_ms"`
+	// AvailableTokenBudget is the live remaining token headroom of the gate
+	// that would admit this request.
+	AvailableTokenBudget int64 `json:"available_token_budget"`
+	// Confidence is CapacityConfidenceHigh or CapacityConfidenceLow.
+	Confidence string `json:"confidence"`
+}

--- a/coordinator/protocol/capacity_test.go
+++ b/coordinator/protocol/capacity_test.go
@@ -1,0 +1,341 @@
+package protocol
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// TestCapacityProbeRoundTrip pins the probe's exact wire keys and its
+// omission semantics: text-only probes omit the vision fields entirely so the
+// frame a legacy-aware decoder sees stays minimal.
+func TestCapacityProbeRoundTrip(t *testing.T) {
+	probe := CapacityProbeMessage{
+		Type:                TypeCapacityProbe,
+		QuoteID:             "q-7f3a",
+		Model:               "mlx-community/Qwen3.5-9B-Instruct-4bit",
+		PromptTokensBucket:  1536,
+		MaxOutputTokens:     2048,
+		RequiresVision:      true,
+		VisionImageCount:    3,
+		DeadlineRemainingMS: 7250,
+	}
+	data, err := json.Marshal(probe)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var keys map[string]any
+	if err := json.Unmarshal(data, &keys); err != nil {
+		t.Fatalf("unmarshal to map: %v", err)
+	}
+	for _, want := range []string{
+		"type", "quote_id", "model", "prompt_tokens_bucket",
+		"max_output_tokens", "requires_vision", "vision_image_count",
+		"deadline_remaining_ms",
+	} {
+		if _, ok := keys[want]; !ok {
+			t.Errorf("key %q missing from wire frame: %s", want, data)
+		}
+	}
+
+	var decoded CapacityProbeMessage
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if decoded != probe {
+		t.Errorf("round-trip mismatch: got %+v, want %+v", decoded, probe)
+	}
+
+	textOnly, err := json.Marshal(CapacityProbeMessage{
+		Type:                TypeCapacityProbe,
+		QuoteID:             "q-1",
+		Model:               "m",
+		PromptTokensBucket:  512,
+		MaxOutputTokens:     256,
+		DeadlineRemainingMS: 9000,
+	})
+	if err != nil {
+		t.Fatalf("marshal text-only: %v", err)
+	}
+	for _, absent := range []string{"requires_vision", "vision_image_count"} {
+		if strings.Contains(string(textOnly), absent) {
+			t.Errorf("text-only probe must omit %q: %s", absent, textOnly)
+		}
+	}
+}
+
+// TestCapacityProbeShapeClosed is the privacy guard for the probe: probes
+// reach providers that will never serve the request, so the field set is
+// CLOSED to bucketed shape metadata. Adding any field here must be a
+// deliberate act that updates this list — and it had better not carry prompt
+// bytes, media, or identity.
+func TestCapacityProbeShapeClosed(t *testing.T) {
+	allowed := map[string]bool{
+		"type":                  true,
+		"quote_id":              true,
+		"model":                 true,
+		"prompt_tokens_bucket":  true,
+		"max_output_tokens":     true,
+		"requires_vision":       true,
+		"vision_image_count":    true,
+		"deadline_remaining_ms": true,
+	}
+	// Substrings that would indicate content or identity leaking into the
+	// probe. quote_id is exempt by construction: it is random and
+	// request-local, never the public request ID.
+	forbidden := []string{
+		"prompt_text", "body", "message", "content", "image_data",
+		"ciphertext", "encrypted", "tool", "consumer", "account",
+		"request_id", "session",
+	}
+
+	typ := reflect.TypeOf(CapacityProbeMessage{})
+	for i := range typ.NumField() {
+		tag := typ.Field(i).Tag.Get("json")
+		name, _, _ := strings.Cut(tag, ",")
+		if name == "" || name == "-" {
+			t.Fatalf("field %s has no wire name; probe fields must be explicit", typ.Field(i).Name)
+		}
+		if !allowed[name] {
+			t.Errorf("probe field %q is not in the closed privacy-reviewed set", name)
+		}
+		for _, bad := range forbidden {
+			if strings.Contains(name, bad) {
+				t.Errorf("probe field %q matches forbidden pattern %q", name, bad)
+			}
+		}
+		delete(allowed, name)
+	}
+	for name := range allowed {
+		t.Errorf("expected probe field %q is missing", name)
+	}
+}
+
+// TestCapacityQuoteRoundTrip pins the quote's wire keys and the enum-omission
+// rule: an admissible quote omits rejection_reason; a rejection carries a
+// Valid() enum value.
+func TestCapacityQuoteRoundTrip(t *testing.T) {
+	admissible := CapacityQuoteMessage{
+		Type:                 TypeCapacityQuote,
+		QuoteID:              "q-7f3a",
+		CapacitySeq:          42,
+		AdmissibleNow:        true,
+		TTFTP50MS:            310.5,
+		TTFTP90MS:            980.25,
+		QueueEstMS:           12.5,
+		AvailableTokenBudget: 96000,
+		Confidence:           CapacityConfidenceHigh,
+	}
+	data, err := json.Marshal(admissible)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(data), "rejection_reason") {
+		t.Errorf("admissible quote must omit rejection_reason: %s", data)
+	}
+	for _, want := range []string{
+		`"type":"capacity_quote"`, `"quote_id":"q-7f3a"`, `"capacity_seq":42`,
+		`"admissible_now":true`, `"ttft_p50_ms":310.5`, `"ttft_p90_ms":980.25`,
+		`"queue_est_ms":12.5`, `"available_token_budget":96000`, `"confidence":"high"`,
+	} {
+		if !strings.Contains(string(data), want) {
+			t.Errorf("expected %s in wire frame: %s", want, data)
+		}
+	}
+	var decoded CapacityQuoteMessage
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if decoded != admissible {
+		t.Errorf("round-trip mismatch: got %+v, want %+v", decoded, admissible)
+	}
+
+	rejected := admissible
+	rejected.AdmissibleNow = false
+	rejected.RejectionReason = RejectionReasonKVHeadroom
+	rejected.AvailableTokenBudget = 0
+	rejected.Confidence = CapacityConfidenceLow
+	data, err = json.Marshal(rejected)
+	if err != nil {
+		t.Fatalf("marshal rejected: %v", err)
+	}
+	if !strings.Contains(string(data), `"rejection_reason":"kv_headroom"`) {
+		t.Errorf("rejected quote must carry rejection_reason: %s", data)
+	}
+	var decodedRej CapacityQuoteMessage
+	if err := json.Unmarshal(data, &decodedRej); err != nil {
+		t.Fatalf("unmarshal rejected: %v", err)
+	}
+	if decodedRej != rejected {
+		t.Errorf("rejected round-trip mismatch: got %+v, want %+v", decodedRej, rejected)
+	}
+	if !decodedRej.RejectionReason.Valid() {
+		t.Errorf("decoded rejection reason %q should be Valid()", decodedRej.RejectionReason)
+	}
+}
+
+// TestCapacityRejectionReasonValid pins the closed vocabulary in both
+// directions: every published constant validates, everything else does not.
+func TestCapacityRejectionReasonValid(t *testing.T) {
+	for _, r := range []CapacityRejectionReason{
+		RejectionReasonTokenBudget, RejectionReasonKVHeadroom,
+		RejectionReasonMemoryCap, RejectionReasonSlotState,
+		RejectionReasonTemplate, RejectionReasonCapability,
+		RejectionReasonDeadline,
+	} {
+		if !r.Valid() {
+			t.Errorf("%q should be valid", r)
+		}
+	}
+	for _, r := range []CapacityRejectionReason{"", "oom", "TOKEN_BUDGET", "capacity"} {
+		if r.Valid() {
+			t.Errorf("%q should be invalid", r)
+		}
+	}
+}
+
+// TestProviderMessageUnmarshalCapacityQuote covers both decode paths of the
+// envelope: the fast type-scan and the escape-forced envelope fallback must
+// dispatch a capacity_quote frame to the same concrete payload.
+func TestProviderMessageUnmarshalCapacityQuote(t *testing.T) {
+	body := `"quote_id":"q-1","capacity_seq":7,"admissible_now":false,` +
+		`"rejection_reason":"token_budget","ttft_p50_ms":400,"ttft_p90_ms":1200,` +
+		`"queue_est_ms":80,"available_token_budget":1024,"confidence":"low"`
+	frames := map[string]string{
+		// \u0071 = 'q': the scanner bails on escapes and the envelope
+		// fallback must reach the same dispatch.
+		"fast-path": `{"type":"capacity_quote",` + body + `}`,
+		"fallback":  `{"type":"capacity_\u0071uote",` + body + `}`,
+	}
+	for name, raw := range frames {
+		t.Run(name, func(t *testing.T) {
+			var pm ProviderMessage
+			if err := json.Unmarshal([]byte(raw), &pm); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if pm.Type != TypeCapacityQuote {
+				t.Errorf("type = %q, want %q", pm.Type, TypeCapacityQuote)
+			}
+			quote, ok := pm.Payload.(*CapacityQuoteMessage)
+			if !ok {
+				t.Fatalf("payload type = %T, want *CapacityQuoteMessage", pm.Payload)
+			}
+			if quote.QuoteID != "q-1" || quote.CapacitySeq != 7 || quote.AdmissibleNow ||
+				quote.RejectionReason != RejectionReasonTokenBudget ||
+				quote.AvailableTokenBudget != 1024 || quote.Confidence != CapacityConfidenceLow {
+				t.Errorf("quote payload = %+v", quote)
+			}
+		})
+	}
+}
+
+// TestProviderMessageUnmarshalCapacityProbeRejected pins the envelope's
+// directional invariant: capacity_probe is coordinator→provider, so — exactly
+// like "cancel" or "inference_request" — a provider sending one must fail the
+// envelope decode as an unknown type, not be accepted as a provider frame.
+func TestProviderMessageUnmarshalCapacityProbeRejected(t *testing.T) {
+	raw := `{"type":"capacity_probe","quote_id":"q-1","model":"m","prompt_tokens_bucket":512,"max_output_tokens":128,"deadline_remaining_ms":5000}`
+	var pm ProviderMessage
+	err := json.Unmarshal([]byte(raw), &pm)
+	if err == nil {
+		t.Fatalf("expected unknown-type error, got payload %T", pm.Payload)
+	}
+	if !strings.Contains(err.Error(), "unknown message type") {
+		t.Errorf("error = %v, want unknown message type", err)
+	}
+}
+
+// TestBackendCapacitySeqWire pins the heartbeat-level seq semantics: a legacy
+// provider (seq 0) keeps the exact legacy wire shape, and a nonzero seq
+// round-trips through the heartbeat envelope.
+func TestBackendCapacitySeqWire(t *testing.T) {
+	legacy, err := json.Marshal(BackendCapacity{TotalMemoryGB: 64})
+	if err != nil {
+		t.Fatalf("marshal legacy: %v", err)
+	}
+	if strings.Contains(string(legacy), "capacity_seq") {
+		t.Errorf("zero capacity_seq must be omitted: %s", legacy)
+	}
+
+	raw := `{"type":"heartbeat","status":"idle","active_model":null,` +
+		`"stats":{"requests_served":1,"tokens_generated":2},` +
+		`"system_metrics":{"memory_pressure":0.1,"cpu_usage":0.2,"thermal_state":"nominal"},` +
+		`"backend_capacity":{"slots":[],"gpu_memory_active_gb":1,"gpu_memory_peak_gb":2,` +
+		`"gpu_memory_cache_gb":0.5,"total_memory_gb":64,"capacity_seq":9001}}`
+	var pm ProviderMessage
+	if err := json.Unmarshal([]byte(raw), &pm); err != nil {
+		t.Fatalf("unmarshal heartbeat: %v", err)
+	}
+	hb, ok := pm.Payload.(*HeartbeatMessage)
+	if !ok {
+		t.Fatalf("payload type = %T, want *HeartbeatMessage", pm.Payload)
+	}
+	if hb.BackendCapacity == nil || hb.BackendCapacity.CapacitySeq != 9001 {
+		t.Fatalf("capacity_seq = %+v, want 9001", hb.BackendCapacity)
+	}
+}
+
+// TestInferenceErrorEnrichedRejectionWire pins the additive contract on
+// inference_error: legacy frames without the routing-v2 fields decode to zero
+// values, a legacy-shaped struct marshals without the new keys, and an
+// enriched rejection round-trips all four fields.
+func TestInferenceErrorEnrichedRejectionWire(t *testing.T) {
+	legacyRaw := `{"type":"inference_error","request_id":"req-1","error":"capacity","status_code":503,"failure_code":"capacity"}`
+	var pm ProviderMessage
+	if err := json.Unmarshal([]byte(legacyRaw), &pm); err != nil {
+		t.Fatalf("unmarshal legacy: %v", err)
+	}
+	legacy, ok := pm.Payload.(*InferenceErrorMessage)
+	if !ok {
+		t.Fatalf("payload type = %T, want *InferenceErrorMessage", pm.Payload)
+	}
+	if legacy.RequestID != "req-1" || legacy.StatusCode != 503 || legacy.FailureCode != FailureCodeCapacity {
+		t.Errorf("legacy fields disturbed: %+v", legacy)
+	}
+	if legacy.RejectionReason != "" || legacy.AvailableTokenBudget != 0 ||
+		legacy.FeasibleAfterMS != 0 || legacy.CapacitySeq != 0 {
+		t.Errorf("legacy frame must decode with zero routing-v2 fields: %+v", legacy)
+	}
+	reencoded, err := json.Marshal(legacy)
+	if err != nil {
+		t.Fatalf("marshal legacy: %v", err)
+	}
+	for _, absent := range []string{"rejection_reason", "available_token_budget", "feasible_after_ms", "capacity_seq"} {
+		if strings.Contains(string(reencoded), absent) {
+			t.Errorf("legacy-shaped struct must omit %q: %s", absent, reencoded)
+		}
+	}
+
+	enriched := InferenceErrorMessage{
+		Type:                 TypeInferenceError,
+		RequestID:            "req-2",
+		Error:                "capacity",
+		StatusCode:           503,
+		FailureCode:          FailureCodeCapacity,
+		RejectionReason:      RejectionReasonTokenBudget,
+		AvailableTokenBudget: 2048,
+		FeasibleAfterMS:      450,
+		CapacitySeq:          17,
+	}
+	data, err := json.Marshal(enriched)
+	if err != nil {
+		t.Fatalf("marshal enriched: %v", err)
+	}
+	for _, want := range []string{
+		`"rejection_reason":"token_budget"`, `"available_token_budget":2048`,
+		`"feasible_after_ms":450`, `"capacity_seq":17`,
+	} {
+		if !strings.Contains(string(data), want) {
+			t.Errorf("expected %s in enriched frame: %s", want, data)
+		}
+	}
+	var decoded InferenceErrorMessage
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal enriched: %v", err)
+	}
+	if decoded != enriched {
+		t.Errorf("enriched round-trip mismatch: got %+v, want %+v", decoded, enriched)
+	}
+}

--- a/coordinator/protocol/capacity_test.go
+++ b/coordinator/protocol/capacity_test.go
@@ -279,8 +279,10 @@ func TestBackendCapacitySeqWire(t *testing.T) {
 
 // TestInferenceErrorEnrichedRejectionWire pins the additive contract on
 // inference_error: legacy frames without the routing-v2 fields decode to zero
-// values, a legacy-shaped struct marshals without the new keys, and an
-// enriched rejection round-trips all four fields.
+// values (nil budget), a legacy-shaped struct marshals without the new keys,
+// an enriched rejection round-trips all four fields, and — the P1-4 presence
+// contract — an EXPLICIT zero live budget survives the wire instead of being
+// conflated with "not enriched".
 func TestInferenceErrorEnrichedRejectionWire(t *testing.T) {
 	legacyRaw := `{"type":"inference_error","request_id":"req-1","error":"capacity","status_code":503,"failure_code":"capacity"}`
 	var pm ProviderMessage
@@ -294,9 +296,9 @@ func TestInferenceErrorEnrichedRejectionWire(t *testing.T) {
 	if legacy.RequestID != "req-1" || legacy.StatusCode != 503 || legacy.FailureCode != FailureCodeCapacity {
 		t.Errorf("legacy fields disturbed: %+v", legacy)
 	}
-	if legacy.RejectionReason != "" || legacy.AvailableTokenBudget != 0 ||
+	if legacy.RejectionReason != "" || legacy.AvailableTokenBudget != nil ||
 		legacy.FeasibleAfterMS != 0 || legacy.CapacitySeq != 0 {
-		t.Errorf("legacy frame must decode with zero routing-v2 fields: %+v", legacy)
+		t.Errorf("legacy frame must decode with zero routing-v2 fields (nil budget): %+v", legacy)
 	}
 	reencoded, err := json.Marshal(legacy)
 	if err != nil {
@@ -308,6 +310,7 @@ func TestInferenceErrorEnrichedRejectionWire(t *testing.T) {
 		}
 	}
 
+	budget := int64(2048)
 	enriched := InferenceErrorMessage{
 		Type:                 TypeInferenceError,
 		RequestID:            "req-2",
@@ -315,7 +318,7 @@ func TestInferenceErrorEnrichedRejectionWire(t *testing.T) {
 		StatusCode:           503,
 		FailureCode:          FailureCodeCapacity,
 		RejectionReason:      RejectionReasonTokenBudget,
-		AvailableTokenBudget: 2048,
+		AvailableTokenBudget: &budget,
 		FeasibleAfterMS:      450,
 		CapacitySeq:          17,
 	}
@@ -335,7 +338,36 @@ func TestInferenceErrorEnrichedRejectionWire(t *testing.T) {
 	if err := json.Unmarshal(data, &decoded); err != nil {
 		t.Fatalf("unmarshal enriched: %v", err)
 	}
-	if decoded != enriched {
+	if !reflect.DeepEqual(decoded, enriched) {
 		t.Errorf("enriched round-trip mismatch: got %+v, want %+v", decoded, enriched)
+	}
+
+	// Explicit zero: a busy slot with exactly zero tokens free is a real
+	// measurement. It must be ENCODED (present key, value 0) and decode back
+	// to a non-nil zero — never collapse to the legacy "absent" shape, which
+	// would send the coordinator back to the stale heartbeat budget.
+	zero := int64(0)
+	zeroMsg := InferenceErrorMessage{
+		Type:                 TypeInferenceError,
+		RequestID:            "req-3",
+		Error:                "capacity",
+		StatusCode:           503,
+		FailureCode:          FailureCodeCapacity,
+		RejectionReason:      RejectionReasonTokenBudget,
+		AvailableTokenBudget: &zero,
+	}
+	zeroData, err := json.Marshal(zeroMsg)
+	if err != nil {
+		t.Fatalf("marshal zero-budget: %v", err)
+	}
+	if !strings.Contains(string(zeroData), `"available_token_budget":0`) {
+		t.Errorf("explicit zero budget must be encoded: %s", zeroData)
+	}
+	var zeroDecoded InferenceErrorMessage
+	if err := json.Unmarshal(zeroData, &zeroDecoded); err != nil {
+		t.Fatalf("unmarshal zero-budget: %v", err)
+	}
+	if zeroDecoded.AvailableTokenBudget == nil || *zeroDecoded.AvailableTokenBudget != 0 {
+		t.Errorf("explicit zero budget must decode non-nil zero: %+v", zeroDecoded.AvailableTokenBudget)
 	}
 }

--- a/coordinator/protocol/messages.go
+++ b/coordinator/protocol/messages.go
@@ -590,11 +590,16 @@ type InferenceErrorMessage struct {
 	// budget clamp, and failure taxonomy — the gray-box incident
 	// (registry/budget_clamp.go) was 11,581 opaque capacity 503s that had to
 	// be re-learned one bounce at a time. All four fields are additive and
-	// omitted when zero-valued, so legacy frames decode byte-identically.
+	// absent on legacy frames, so those decode byte-identically.
 	//
 	// RejectionReason is the bounded CapacityRejectionReason enum (shared with
 	// capacity_quote). AvailableTokenBudget is the live gate's remaining token
-	// headroom at rejection time. FeasibleAfterMS is the provider's busy-wait
+	// headroom at rejection time — a POINTER because zero is a meaningful
+	// measurement, not an unset default: a busy slot with exactly zero tokens
+	// free must encode that zero (nil = legacy/unenriched, absent on the
+	// wire), or the coordinator falls back to the stale heartbeat budget and
+	// can misclassify a transient token_budget reject as fleet-deterministic
+	// (codex P1-4). FeasibleAfterMS is the provider's busy-wait
 	// forecast of when a request of this shape could next be admitted
 	// (duration, never a wall clock) — emitted on busy-slot token_budget
 	// rejections by quote-capable providers, from the same queue estimator
@@ -602,7 +607,7 @@ type InferenceErrorMessage struct {
 	// gate decided from, letting the coordinator order the rejection against
 	// heartbeats.
 	RejectionReason      CapacityRejectionReason `json:"rejection_reason,omitempty"`
-	AvailableTokenBudget int64                   `json:"available_token_budget,omitempty"`
+	AvailableTokenBudget *int64                  `json:"available_token_budget,omitempty"`
 	FeasibleAfterMS      int64                   `json:"feasible_after_ms,omitempty"`
 	CapacitySeq          uint64                  `json:"capacity_seq,omitempty"`
 }

--- a/coordinator/protocol/messages.go
+++ b/coordinator/protocol/messages.go
@@ -48,6 +48,11 @@ const (
 	TypePrefixCacheLookupV2     = "prefix_cache_lookup_v2"
 	TypePrefixCacheReadyV2      = "prefix_cache_ready_v2"
 
+	// TypeCapacityQuote is the provider's answer to a capacity_probe: an
+	// admissibility verdict + calibrated TTFT estimate computed from its live
+	// capacity snapshot. See CapacityQuoteMessage.
+	TypeCapacityQuote = "capacity_quote"
+
 	// Coordinator → Provider.
 	TypeInferenceRequest               = "inference_request"
 	TypeCancel                         = "cancel"
@@ -57,7 +62,12 @@ const (
 	TypeLoadModel                      = "load_model"
 	TypePrefetchModel                  = "prefetch_model"
 	TypeDesiredModels                  = "desired_models"
-	TypeTrustStatus                    = "trust_status"
+
+	// TypeCapacityProbe asks a provider whether it could admit a request of a
+	// given bucketed shape right now. Carries shape metadata only — never
+	// prompt content or identity. See CapacityProbeMessage.
+	TypeCapacityProbe = "capacity_probe"
+	TypeTrustStatus   = "trust_status"
 )
 
 // LoadModelStatus is the lifecycle state reported by a provider in response
@@ -394,6 +404,15 @@ type BackendCapacity struct {
 	FreeForLoadGB *float64 `json:"free_for_load_gb,omitempty"`
 	// MLXCacheReclaimer is nil for providers predating allocator telemetry.
 	MLXCacheReclaimer *MLXCacheReclaimerTelemetry `json:"mlx_cache_reclaimer,omitempty"`
+	// CapacitySeq is a per-connection monotonically increasing sequence number
+	// stamped on every capacity snapshot the provider publishes. The
+	// coordinator applies snapshots by seq (stale/reordered seq → discard) so
+	// event-triggered heartbeats can't regress the ledger, and a connection
+	// that has reported any seq > 0 is thereby quote-capable
+	// (capacity_probe/capacity_quote). Zero means a legacy provider: the field
+	// is omitted from the wire and the coordinator keeps last-write-wins
+	// heartbeat semantics.
+	CapacitySeq uint64 `json:"capacity_seq,omitempty"`
 }
 
 // SystemMetrics contains live resource utilization reported by a provider.
@@ -564,6 +583,28 @@ type InferenceErrorMessage struct {
 	// on the route row and emitted in telemetry, but it never feeds billing,
 	// refunds, reservations, provider earnings, or payouts.
 	AttemptUsage *UsageInfo `json:"attempt_usage,omitempty"`
+
+	// Enriched rejection (routing v2). A current provider that fast-rejects at
+	// its live admission gate says WHY in machine-readable form, turning every
+	// rejection into a fresh capacity sample for the coordinator's ledger,
+	// budget clamp, and failure taxonomy — the gray-box incident
+	// (registry/budget_clamp.go) was 11,581 opaque capacity 503s that had to
+	// be re-learned one bounce at a time. All four fields are additive and
+	// omitted when zero-valued, so legacy frames decode byte-identically.
+	//
+	// RejectionReason is the bounded CapacityRejectionReason enum (shared with
+	// capacity_quote). AvailableTokenBudget is the live gate's remaining token
+	// headroom at rejection time. FeasibleAfterMS is the provider's busy-wait
+	// forecast of when a request of this shape could next be admitted
+	// (duration, never a wall clock) — emitted on busy-slot token_budget
+	// rejections by quote-capable providers, from the same queue estimator
+	// their capacity quotes use. CapacitySeq names the capacity snapshot the
+	// gate decided from, letting the coordinator order the rejection against
+	// heartbeats.
+	RejectionReason      CapacityRejectionReason `json:"rejection_reason,omitempty"`
+	AvailableTokenBudget int64                   `json:"available_token_budget,omitempty"`
+	FeasibleAfterMS      int64                   `json:"feasible_after_ms,omitempty"`
+	CapacitySeq          uint64                  `json:"capacity_seq,omitempty"`
 }
 
 // ---------------------------------------------------------------------------
@@ -956,6 +997,13 @@ func (pm *ProviderMessage) UnmarshalJSON(data []byte) error {
 		var msg PrefixCacheReadyV2Message
 		if err := json.Unmarshal(data, &msg); err != nil {
 			return fmt.Errorf("protocol: failed to unmarshal prefix_cache_ready_v2: %w", err)
+		}
+		pm.Payload = &msg
+
+	case TypeCapacityQuote:
+		var msg CapacityQuoteMessage
+		if err := json.Unmarshal(data, &msg); err != nil {
+			return fmt.Errorf("protocol: failed to unmarshal capacity_quote: %w", err)
 		}
 		pm.Payload = &msg
 

--- a/coordinator/registry/capacity_quotes.go
+++ b/coordinator/registry/capacity_quotes.go
@@ -74,18 +74,38 @@ type pendingQuote struct {
 	deliver    chan<- quoteDelivery
 }
 
+// quoteTrackerSweepInterval is the minimum spacing between full sweeps of the
+// pending-quote map. Probe entries expire at probe-window scale (the api
+// layer's capacityProbeWindow, 250ms), so sweeping faster than the window is
+// pure overhead: entries added since the last sweep cannot have expired yet,
+// and rescanning them buys nothing. Without the gate the >1024 size trigger
+// turns quadratic under sustained load — at eight probes per request and a
+// 250ms window, ~129 concurrent primary requests keep the map above the
+// threshold with mostly-unexpired entries, so EVERY insertion would rescan
+// the whole map under the single tracker mutex and serialize quote delivery
+// behind cleanup (codex P1). One sweep per window bounds cleanup to O(size)
+// per window instead of per insert.
+const quoteTrackerSweepInterval = 250 * time.Millisecond
+
 // quoteTracker correlates capacity quotes with their probes by quote_id.
 // LEAF mutex: nothing is called while holding t.mu except buffered channel
 // sends, and no code path takes r.mu, p.mu, or a plan mu under it.
 type quoteTracker struct {
 	mu      sync.Mutex
 	pending map[string]*pendingQuote
+	// lastSweep gates add's expiry sweep to once per
+	// quoteTrackerSweepInterval; sweeps counts performed sweeps (test
+	// instrumentation only). Both guarded by mu.
+	lastSweep time.Time
+	sweeps    int
 }
 
-// add registers an outstanding probe. The opportunistic >1024 sweep (same
-// idiom as the sibling cooldown maps) drops expired entries whose collector
-// died before its window sweep — a leak only a panicked collector can create,
-// since a live one takes back every silent entry at expiry.
+// add registers an outstanding probe. The opportunistic sweep (same idiom as
+// the sibling cooldown maps) drops expired entries whose collector died
+// before its window sweep — a leak only a panicked collector can create,
+// since a live one takes back every silent entry at expiry. The >1024 size
+// trigger merely makes a sweep WORTH considering; the time gate
+// (quoteTrackerSweepInterval) decides whether one actually runs.
 func (t *quoteTracker) add(quoteID string, pq *pendingQuote) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
@@ -94,9 +114,13 @@ func (t *quoteTracker) add(quoteID string, pq *pendingQuote) {
 	}
 	if len(t.pending) > 1024 {
 		now := time.Now()
-		for id, e := range t.pending {
-			if now.After(e.expiresAt) {
-				delete(t.pending, id)
+		if now.Sub(t.lastSweep) >= quoteTrackerSweepInterval {
+			t.lastSweep = now
+			t.sweeps++
+			for id, e := range t.pending {
+				if now.After(e.expiresAt) {
+					delete(t.pending, id)
+				}
 			}
 		}
 	}
@@ -340,12 +364,18 @@ func applyQuoteDelivery(plan *DispatchPlan, d quoteDelivery) QuoteOutcome {
 //     as the Phase-0 shadow signal (loadedIdleAlternativeExistsLocked), so
 //     the governor and the shadow metric can never disagree on "spare
 //     capacity exists";
-//   - modelQueueDepth: queued demand for the model (queued consumers outrank
-//     insurance);
+//   - modelQueueDepth: queued demand for the model whose routing constraints
+//     could overlap the capacity available to THIS request (queued consumers
+//     outrank insurance — but only consumers that could actually drain onto
+//     the pool a hedge would spend; see CompetingQueueDepth for why
+//     self-route-only and non-overlapping serial-pinned waiters are out);
 //   - fleetIdleSlots: slots with any model resident and zero occupancy,
-//     across the whole fleet, from the same heartbeat BackendCapacity
-//     snapshots routing reads — the global concurrent-hedge budget's
-//     denominator;
+//     across the publicly-routable fleet, from the same heartbeat
+//     BackendCapacity snapshots routing reads — the global concurrent-hedge
+//     budget's denominator. Private-only providers are excluded: their idle
+//     slots serve exclusively their owner's self-route requests, so they
+//     cannot absorb the public demand a hedge displaces and must not mint
+//     public hedge budget;
 //   - capacitySignalsAvailable: at least one live provider serving the model
 //     reports a BackendCapacity snapshot (or has proven quote capability).
 //     The dual-path switch: on a capacity-SILENT fleet (all-legacy, plan
@@ -365,7 +395,7 @@ func applyQuoteDelivery(plan *DispatchPlan, d quoteDelivery) QuoteOutcome {
 // inside it (see RequestQueue.PreferWaiterOwners for the ordering rule).
 func (r *Registry) HedgeGovernorSnapshot(model string, pr *PendingRequest, excludeIDs ...string) (idleAlternativeExists bool, modelQueueDepth int, fleetIdleSlots int, capacitySignalsAvailable bool) {
 	if q := r.Queue(); q != nil {
-		modelQueueDepth = q.QueueSize(model)
+		modelQueueDepth = q.CompetingQueueDepth(model, pr)
 	}
 	r.mu.RLock()
 	defer r.mu.RUnlock()
@@ -375,7 +405,7 @@ func (r *Registry) HedgeGovernorSnapshot(model string, pr *PendingRequest, exclu
 	for _, p := range r.providers {
 		p.mu.Lock()
 		if p.Status != StatusUntrusted && p.Status != StatusOffline {
-			if p.BackendCapacity != nil {
+			if p.BackendCapacity != nil && !p.PrivateOnly {
 				for _, slot := range p.BackendCapacity.Slots {
 					if slotStateModelLoaded(slot.State) && slot.NumRunning == 0 && slot.NumWaiting == 0 {
 						fleetIdleSlots++

--- a/coordinator/registry/capacity_quotes.go
+++ b/coordinator/registry/capacity_quotes.go
@@ -1,0 +1,403 @@
+package registry
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"sync"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+	"github.com/eigeninference/d-inference/coordinator/saferun"
+)
+
+// Capacity probe fanout + quote correlation — routing v2 W2 (honesty channel).
+//
+// After the primary dispatches, the request's remaining plan alternates each
+// get a capacity_probe (bounded DATA lane — a probe storm must shed naturally
+// at the 128-deep writer queue, never starve the control lane's cancels and
+// attestations) and answer with a capacity_quote. Quotes CONFIRM or DEMOTE
+// plan entries so retries and hedges consume provider-endorsed candidates;
+// the coordinator's ledger remains the primary accounting (see
+// protocol/capacity.go for the full account and the privacy invariant).
+//
+// Correlation copies the api-side challengeTracker pattern (api/provider.go):
+// a mutex-guarded map keyed by the random request-local quote_id, resolved
+// exactly once by whichever event settles it first — the provider's quote,
+// the sender's write failure, a disconnect, or the collector's window expiry.
+
+// CapacityProbeShape is the coordinator-side request shape a probe describes.
+// PromptTokens is the coordinator's raw estimate; the wire message carries it
+// bucketed (rounded UP to protocol.CapacityProbePromptBucketTokens) so a
+// probed-but-never-chosen provider learns shape, not content.
+type CapacityProbeShape struct {
+	Model             string
+	PromptTokens      int
+	MaxOutputTokens   int
+	RequiresVision    bool
+	VisionImageCount  int
+	DeadlineRemaining time.Duration
+}
+
+// QuoteOutcome is one probe's settled result, delivered on the channel
+// ProbePlanCandidates returns. Exactly one of the three states holds:
+// Quote != nil (the provider answered — affirmative or negative, per
+// Quote.AdmissibleNow), Timeout (silent through the window), or SendFailed
+// (writer queue full, write error, or the provider disconnected). By the time
+// an outcome is readable the plan has ALREADY been updated (ConfirmEntry /
+// DemoteEntry) — the channel is informational, for hedge timing and telemetry,
+// never a step the dispatch loop must apply itself.
+type QuoteOutcome struct {
+	ProviderID string
+	Quote      *protocol.CapacityQuoteMessage
+	Timeout    bool
+	SendFailed bool
+}
+
+// quoteDelivery is the tracker→collector handoff for one settled probe.
+// quote == nil means transport failure (send error or disconnect).
+type quoteDelivery struct {
+	quoteID    string
+	providerID string
+	quote      *protocol.CapacityQuoteMessage
+}
+
+// pendingQuote is one outstanding probe: the provider binding the quote must
+// come back from, the expiry after which a quote is too stale to act on, and
+// the owning collector's delivery channel. The channel is buffered to the
+// collector's full probe count and each entry delivers at most once (map
+// removal is the claim), so delivering NEVER blocks — safe under t.mu.
+type pendingQuote struct {
+	providerID string
+	expiresAt  time.Time
+	deliver    chan<- quoteDelivery
+}
+
+// quoteTracker correlates capacity quotes with their probes by quote_id.
+// LEAF mutex: nothing is called while holding t.mu except buffered channel
+// sends, and no code path takes r.mu, p.mu, or a plan mu under it.
+type quoteTracker struct {
+	mu      sync.Mutex
+	pending map[string]*pendingQuote
+}
+
+// add registers an outstanding probe. The opportunistic >1024 sweep (same
+// idiom as the sibling cooldown maps) drops expired entries whose collector
+// died before its window sweep — a leak only a panicked collector can create,
+// since a live one takes back every silent entry at expiry.
+func (t *quoteTracker) add(quoteID string, pq *pendingQuote) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.pending == nil {
+		t.pending = make(map[string]*pendingQuote)
+	}
+	if len(t.pending) > 1024 {
+		now := time.Now()
+		for id, e := range t.pending {
+			if now.After(e.expiresAt) {
+				delete(t.pending, id)
+			}
+		}
+	}
+	t.pending[quoteID] = pq
+}
+
+// take claims an outstanding probe by quote_id, or nil when another settling
+// event already claimed it. The removal IS the exactly-once guarantee.
+func (t *quoteTracker) take(quoteID string) *pendingQuote {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	pq := t.pending[quoteID]
+	delete(t.pending, quoteID)
+	return pq
+}
+
+// failProvider settles every outstanding probe bound to a disconnected
+// provider as a transport failure. Delivering under t.mu is safe (buffered
+// channels, one delivery per entry) and keeps claim+delivery atomic.
+func (t *quoteTracker) failProvider(providerID string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	for id, pq := range t.pending {
+		if pq.providerID != providerID {
+			continue
+		}
+		delete(t.pending, id)
+		pq.deliver <- quoteDelivery{quoteID: id, providerID: providerID}
+	}
+}
+
+// capacityQuoteReady reports whether this connection has proven the wave-2
+// capacity protocol: a heartbeat on THIS connection carried capacity_seq > 0
+// (see the gate in Heartbeat). Legacy sessions are never probed — a frame
+// type they do not implement would at best be ignored and at worst kill the
+// connection, and their plan entries stay ledger-scored mid-tier by design
+// (dual path until the fleet floor).
+func (p *Provider) capacityQuoteReady() bool {
+	if p == nil {
+		return false
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.capacityQuoteCapable
+}
+
+// bucketPromptTokens rounds a prompt-token estimate UP to the probe bucket
+// granularity (privacy invariant: probes carry shape, never exact counts).
+func bucketPromptTokens(tokens int) int {
+	if tokens <= 0 {
+		return 0
+	}
+	const bucket = protocol.CapacityProbePromptBucketTokens
+	return (tokens + bucket - 1) / bucket * bucket
+}
+
+// newQuoteID mints the random, request-local probe correlation ID. 128 bits —
+// deliberately NOT the public request ID, so a probed provider can never link
+// a probe to a request it later serves.
+func newQuoteID() (string, error) {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b[:]), nil
+}
+
+// HandleCapacityQuote resolves one provider capacity_quote against its
+// outstanding probe. Called from the api provider read loop. Invalid quotes
+// are dropped with a bounded reason:
+//   - unknown/late quote_id (the probe already settled, or was never ours);
+//   - provider mismatch (a provider must never answer another's probe — the
+//     entry is deliberately LEFT registered so the bound provider's own
+//     answer, or the window sweep, still settles it);
+//   - expired (past the probe window; left for the collector's timeout sweep
+//     so the outcome accounting stays single-owner).
+func (r *Registry) HandleCapacityQuote(providerID string, msg *protocol.CapacityQuoteMessage) {
+	if msg == nil || msg.QuoteID == "" {
+		return
+	}
+	t := &r.capacityQuotes
+	t.mu.Lock()
+	pq, ok := t.pending[msg.QuoteID]
+	if !ok {
+		t.mu.Unlock()
+		r.logger.Debug("dropping capacity quote", "reason", "unknown_or_late_quote_id", "provider_id", providerID)
+		return
+	}
+	if pq.providerID != providerID {
+		t.mu.Unlock()
+		r.logger.Warn("dropping capacity quote", "reason", "provider_mismatch", "provider_id", providerID)
+		return
+	}
+	if time.Now().After(pq.expiresAt) {
+		t.mu.Unlock()
+		r.logger.Debug("dropping capacity quote", "reason", "expired", "provider_id", providerID)
+		return
+	}
+	delete(t.pending, msg.QuoteID)
+	pq.deliver <- quoteDelivery{quoteID: msg.QuoteID, providerID: providerID, quote: msg}
+	t.mu.Unlock()
+}
+
+// ProbePlanCandidates fans capacity probes out to every unconsumed, unquoted,
+// quote-capable entry of plan and returns a channel of settled outcomes; the
+// channel closes once every probe has resolved (quote, transport failure, or
+// window expiry). Legacy entries are skipped silently — they stay in the
+// unconfirmed mid tier. Bounded by construction: a plan retains at most
+// dispatchPlanMaxAlternates entries, so the fanout is ≤ 8 sender goroutines
+// plus one collector, all panic-guarded via saferun.
+//
+// The collector applies each outcome to the plan itself (affirmative →
+// ConfirmEntry, negative/timeout/sendfailed → DemoteEntry) BEFORE forwarding
+// it, so a consumer that never reads the channel still gets a correctly
+// re-ranked plan; the channel is buffered to the probe count, so an
+// abandoned consumer never wedges the collector either.
+//
+// Probes ride the bounded DATA lane (Provider.WriteText): queue-full is the
+// natural shedding signal and settles the probe as SendFailed immediately.
+// The strict control lane is reserved for cancel/attestation/trust — a probe
+// storm there would starve exactly the frames that must never queue.
+func (r *Registry) ProbePlanCandidates(plan *DispatchPlan, shape CapacityProbeShape, window time.Duration) <-chan QuoteOutcome {
+	out := make(chan QuoteOutcome, dispatchPlanMaxAlternates)
+	targets := plan.probeTargets()
+	if len(targets) == 0 || window <= 0 {
+		close(out)
+		return out
+	}
+
+	deliveries := make(chan quoteDelivery, len(targets))
+	// outstanding maps quote_id → provider ID for the collector's timeout
+	// attribution. Owned by the collector after fanout; senders never touch it.
+	outstanding := make(map[string]string, len(targets))
+	expiresAt := time.Now().Add(window)
+	for _, target := range targets {
+		provider := target.provider
+		providerID := target.view.ProviderID
+		if !provider.capacityQuoteReady() {
+			continue
+		}
+		quoteID, err := newQuoteID()
+		if err != nil {
+			// No entropy, no probe: the entry simply stays unconfirmed.
+			r.logger.Error("capacity probe id generation failed", "provider_id", providerID, "error", err)
+			continue
+		}
+		payload, err := json.Marshal(&protocol.CapacityProbeMessage{
+			Type:                protocol.TypeCapacityProbe,
+			QuoteID:             quoteID,
+			Model:               shape.Model,
+			PromptTokensBucket:  bucketPromptTokens(shape.PromptTokens),
+			MaxOutputTokens:     shape.MaxOutputTokens,
+			RequiresVision:      shape.RequiresVision,
+			VisionImageCount:    shape.VisionImageCount,
+			DeadlineRemainingMS: max(shape.DeadlineRemaining.Milliseconds(), 0),
+		})
+		if err != nil {
+			r.logger.Error("capacity probe marshal failed", "provider_id", providerID, "error", err)
+			continue
+		}
+		// Register BEFORE sending so a quote racing the sender's return can
+		// never miss its entry.
+		r.capacityQuotes.add(quoteID, &pendingQuote{
+			providerID: providerID,
+			expiresAt:  expiresAt,
+			deliver:    deliveries,
+		})
+		outstanding[quoteID] = providerID
+		saferun.Go(r.logger, "registry.capacityProbeSend", func() {
+			// The write is useless past the quote window — bound it there
+			// rather than letting a wedged data lane hold the goroutine.
+			ctx, cancel := context.WithTimeout(context.Background(), window)
+			defer cancel()
+			if writeErr := provider.WriteText(ctx, payload); writeErr != nil {
+				// Queue full / writer stopped / timeout: settle as SendFailed
+				// now IF this probe is still ours to settle (a disconnect may
+				// have claimed it first — take() decides exactly once).
+				if pq := r.capacityQuotes.take(quoteID); pq != nil {
+					deliveries <- quoteDelivery{quoteID: quoteID, providerID: providerID}
+				}
+			}
+		})
+	}
+	if len(outstanding) == 0 {
+		close(out)
+		return out
+	}
+
+	saferun.Go(r.logger, "registry.capacityQuoteCollector", func() {
+		defer close(out)
+		timer := time.NewTimer(window)
+		defer timer.Stop()
+		for len(outstanding) > 0 {
+			select {
+			case d := <-deliveries:
+				delete(outstanding, d.quoteID)
+				out <- applyQuoteDelivery(plan, d)
+			case <-timer.C:
+				// Window over. Claim every still-silent probe as a Timeout;
+				// an entry already claimed elsewhere (nil take) has a
+				// delivery in flight — keep looping, it resolves on the
+				// deliveries branch. The timer fires once, so the loop can
+				// only continue on deliveries afterwards, and every
+				// unclaimed entry is gone — termination is guaranteed.
+				for quoteID, providerID := range outstanding {
+					if r.capacityQuotes.take(quoteID) == nil {
+						continue
+					}
+					delete(outstanding, quoteID)
+					plan.DemoteEntry(providerID)
+					out <- QuoteOutcome{ProviderID: providerID, Timeout: true}
+				}
+			}
+		}
+	})
+	return out
+}
+
+// applyQuoteDelivery turns a settled probe into its plan mutation + outcome:
+// affirmative quote → confirm, everything else → demote. Kept pure of channel
+// plumbing so tests pin the mapping directly.
+func applyQuoteDelivery(plan *DispatchPlan, d quoteDelivery) QuoteOutcome {
+	if d.quote == nil {
+		plan.DemoteEntry(d.providerID)
+		return QuoteOutcome{ProviderID: d.providerID, SendFailed: true}
+	}
+	if d.quote.AdmissibleNow {
+		plan.ConfirmEntry(d.providerID, d.quote)
+	} else {
+		plan.DemoteEntry(d.providerID)
+	}
+	return QuoteOutcome{ProviderID: d.providerID, Quote: d.quote}
+}
+
+// HedgeGovernorSnapshot gathers the registry-side inputs the hedge governor
+// (api/hedge_governor.go) needs to decide whether launching insurance is
+// spending idle capacity or amplifying an overload:
+//
+//   - idleAlternativeExists: some provider OTHER than the exclusions is an
+//     instantly-usable spread target for this request — the same computation
+//     as the Phase-0 shadow signal (loadedIdleAlternativeExistsLocked), so
+//     the governor and the shadow metric can never disagree on "spare
+//     capacity exists";
+//   - modelQueueDepth: queued demand for the model (queued consumers outrank
+//     insurance);
+//   - fleetIdleSlots: slots with any model resident and zero occupancy,
+//     across the whole fleet, from the same heartbeat BackendCapacity
+//     snapshots routing reads — the global concurrent-hedge budget's
+//     denominator;
+//   - capacitySignalsAvailable: at least one live provider serving the model
+//     reports a BackendCapacity snapshot (or has proven quote capability).
+//     The dual-path switch: on a capacity-SILENT fleet (all-legacy, plan
+//     decision 3) the three signals above are structurally zero — the same
+//     shape as genuine saturation — so the governor must be BYPASSED there
+//     (today's unconditional 50% hedge), never consulted. Deliberately looser
+//     than the full gate chain: this is an advisory "are the inputs
+//     meaningful?" bit, not an eligibility decision — reserve-time
+//     revalidation still applies every gate.
+//
+// This is a POINT-IN-TIME advisory snapshot, not a reservation: the governor
+// only ever uses it to SUPPRESS a hedge, and a hedge launched on state that
+// staled a moment later is caught by the plan revalidation gates at reserve
+// time. Tolerating that staleness is what lets this run under r.mu.RLock
+// (plus per-provider p.mu, the standard order) instead of serializing with
+// reservations. Queue depth is read before taking r.mu so q.mu never nests
+// inside it (see RequestQueue.PreferWaiterOwners for the ordering rule).
+func (r *Registry) HedgeGovernorSnapshot(model string, pr *PendingRequest, excludeIDs ...string) (idleAlternativeExists bool, modelQueueDepth int, fleetIdleSlots int, capacitySignalsAvailable bool) {
+	if q := r.Queue(); q != nil {
+		modelQueueDepth = q.QueueSize(model)
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if pr != nil {
+		idleAlternativeExists = r.loadedIdleAlternativeExistsLocked(model, pr, nil, excludeIDs...)
+	}
+	for _, p := range r.providers {
+		p.mu.Lock()
+		if p.Status != StatusUntrusted && p.Status != StatusOffline {
+			if p.BackendCapacity != nil {
+				for _, slot := range p.BackendCapacity.Slots {
+					if slotStateModelLoaded(slot.State) && slot.NumRunning == 0 && slot.NumWaiting == 0 {
+						fleetIdleSlots++
+					}
+				}
+			}
+			// Model-scoped: a reporting provider that cannot serve this model
+			// says nothing about whether THIS model's governor inputs are
+			// meaningful. The exclusion set is deliberately NOT applied — the
+			// primary reporting capacity already proves this is a reporting
+			// fleet for the model (dual path is capability-based, not
+			// request-sampled).
+			if !capacitySignalsAvailable && (p.BackendCapacity != nil || p.capacityQuoteCapable) {
+				for _, m := range p.Models {
+					if m.ID == model {
+						capacitySignalsAvailable = true
+						break
+					}
+				}
+			}
+		}
+		p.mu.Unlock()
+	}
+	return idleAlternativeExists, modelQueueDepth, fleetIdleSlots, capacitySignalsAvailable
+}

--- a/coordinator/registry/capacity_quotes_test.go
+++ b/coordinator/registry/capacity_quotes_test.go
@@ -630,3 +630,124 @@ func TestHedgeGovernorSnapshotCapacitySilentFleet(t *testing.T) {
 		t.Fatal("capacitySignalsAvailable = false with a quote-capable provider serving the model")
 	}
 }
+
+// TestQuoteTrackerSweepIsTimeGated pins the P1 fix on add's expiry sweep:
+// the >1024 size trigger only makes a sweep worth CONSIDERING — the time
+// gate (quoteTrackerSweepInterval) must hold sustained over-threshold
+// insertion to at most one full scan per window, instead of rescanning the
+// whole map under t.mu on every add.
+func TestQuoteTrackerSweepIsTimeGated(t *testing.T) {
+	var tr quoteTracker
+	live := time.Now().Add(time.Hour) // unexpired: a sweep removes nothing
+	for i := range 1025 {
+		tr.add(fmt.Sprintf("q%04d", i), &pendingQuote{expiresAt: live})
+	}
+	if tr.sweeps != 0 {
+		t.Fatalf("sweeps=%d while filling to the threshold, want 0", tr.sweeps)
+	}
+
+	// First over-threshold add: the zero-value lastSweep passes the time
+	// gate, so exactly one sweep runs.
+	tr.add("over-0", &pendingQuote{expiresAt: live})
+	if tr.sweeps != 1 {
+		t.Fatalf("sweeps=%d after first over-threshold add, want 1", tr.sweeps)
+	}
+
+	// Sustained over-threshold insertion within the window: still one sweep.
+	for i := range 64 {
+		tr.add(fmt.Sprintf("over-%d", i+1), &pendingQuote{expiresAt: live})
+	}
+	if tr.sweeps != 1 {
+		t.Fatalf("sweeps=%d after 64 in-window adds, want 1 (time-gated)", tr.sweeps)
+	}
+
+	// A full window elapses (clock seam: rewind lastSweep) — the next add
+	// sweeps again, and the sweep still collects expired entries.
+	tr.mu.Lock()
+	tr.pending["expired-a"] = &pendingQuote{expiresAt: time.Now().Add(-time.Second)}
+	tr.pending["expired-b"] = &pendingQuote{expiresAt: time.Now().Add(-time.Second)}
+	tr.lastSweep = time.Now().Add(-2 * quoteTrackerSweepInterval)
+	tr.mu.Unlock()
+	tr.add("post-window", &pendingQuote{expiresAt: live})
+	if tr.sweeps != 2 {
+		t.Fatalf("sweeps=%d after the window elapsed, want 2", tr.sweeps)
+	}
+	tr.mu.Lock()
+	_, expAlive := tr.pending["expired-a"]
+	_, liveAlive := tr.pending["post-window"]
+	tr.mu.Unlock()
+	if expAlive || !liveAlive {
+		t.Fatalf("post-window sweep: expired retained=%v live dropped=%v", expAlive, !liveAlive)
+	}
+}
+
+// TestHedgeGovernorSnapshotQueueDepthFiltersIncompatibleWaiters pins the P2
+// routing-compatibility filter on modelQueueDepth: a waiter that structurally
+// cannot drain onto the capacity a public hedge would consume (exclusive
+// self-route, or pinned to serials the request cannot use) must not suppress
+// that hedge, while a plain public waiter still does.
+func TestHedgeGovernorSnapshotQueueDepthFiltersIncompatibleWaiters(t *testing.T) {
+	reg := New(testLogger())
+	model := "governor-queue-filter-model"
+	for i := range 2 {
+		planTestProvider(t, reg, fmt.Sprintf("gq%02d", i), model, int64(i)*400)
+	}
+	pr := planTestRequest("governor-queue", 200, 128)
+	pr.Model = model
+
+	enqueue := func(id string, pending *PendingRequest) {
+		t.Helper()
+		if err := reg.Queue().Enqueue(&QueuedRequest{
+			RequestID:  id,
+			Model:      model,
+			ResponseCh: make(chan *Provider, 1),
+			Pending:    pending,
+		}); err != nil {
+			t.Fatalf("enqueue %s: %v", id, err)
+		}
+	}
+
+	enqueue("w-self", &PendingRequest{RequestID: "w-self", Model: model, SelfRouteOnly: true, OwnerAccountID: "acct-A"})
+	if _, depth, _, _ := reg.HedgeGovernorSnapshot(model, pr); depth != 0 {
+		t.Fatalf("modelQueueDepth = %d with only a self-route-only waiter, want 0 (must not suppress a public hedge)", depth)
+	}
+
+	enqueue("w-serial", &PendingRequest{RequestID: "w-serial", Model: model, AllowedProviderSerials: []string{"SER-X"}})
+	if _, depth, _, _ := reg.HedgeGovernorSnapshot(model, pr); depth != 0 {
+		t.Fatalf("modelQueueDepth = %d with a non-overlapping serial-pinned waiter, want 0", depth)
+	}
+
+	enqueue("w-public", &PendingRequest{RequestID: "w-public", Model: model})
+	if _, depth, _, _ := reg.HedgeGovernorSnapshot(model, pr); depth != 1 {
+		t.Fatalf("modelQueueDepth = %d with a plain public waiter, want 1 (still suppresses)", depth)
+	}
+
+	// A request pinned to the SAME serial set demonstrably competes with the
+	// pinned waiter — both count, plus the unconstrained public waiter.
+	pinned := planTestRequest("governor-queue-pinned", 200, 128)
+	pinned.Model = model
+	pinned.AllowedProviderSerials = []string{"SER-X"}
+	if _, depth, _, _ := reg.HedgeGovernorSnapshot(model, pinned); depth != 2 {
+		t.Fatalf("modelQueueDepth = %d for an overlapping pinned request, want 2 (pinned + public waiters)", depth)
+	}
+}
+
+// TestHedgeGovernorSnapshotExcludesPrivateOnlyIdleSlots pins the P2 hedge
+// budget fix: an idle slot on a private-only provider serves exclusively its
+// owner's self-route requests, cannot absorb displaced public demand, and so
+// must not mint public hedge budget via fleetIdleSlots.
+func TestHedgeGovernorSnapshotExcludesPrivateOnlyIdleSlots(t *testing.T) {
+	reg := New(testLogger())
+	model := "governor-private-model"
+	planTestProvider(t, reg, "pub", model, 0)
+	priv := planTestProvider(t, reg, "priv", model, 400)
+	priv.mu.Lock()
+	priv.PrivateOnly = true
+	priv.mu.Unlock()
+
+	pr := planTestRequest("governor-private", 200, 128)
+	pr.Model = model
+	if _, _, idleSlots, _ := reg.HedgeGovernorSnapshot(model, pr); idleSlots != 1 {
+		t.Fatalf("fleetIdleSlots = %d, want 1 (idle private-only slot contributes zero)", idleSlots)
+	}
+}

--- a/coordinator/registry/capacity_quotes_test.go
+++ b/coordinator/registry/capacity_quotes_test.go
@@ -1,0 +1,632 @@
+package registry
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+	"nhooyr.io/websocket"
+)
+
+// --- helpers ---------------------------------------------------------------
+
+const seqTestModel = "mlx-community/Qwen3.5-9B-Instruct-4bit" // testRegisterMessage's model
+
+func seqHeartbeat(seq uint64, activeTokens int64) *protocol.HeartbeatMessage {
+	return &protocol.HeartbeatMessage{
+		Type:   protocol.TypeHeartbeat,
+		Status: "idle",
+		BackendCapacity: &protocol.BackendCapacity{
+			CapacitySeq: seq,
+			Slots: []protocol.BackendSlotCapacity{
+				{Model: seqTestModel, State: "running", ActiveTokens: activeTokens},
+			},
+		},
+	}
+}
+
+func heartbeatActiveTokens(t *testing.T, p *Provider) int64 {
+	t.Helper()
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.BackendCapacity == nil || len(p.BackendCapacity.Slots) == 0 {
+		t.Fatal("provider has no applied BackendCapacity slots")
+	}
+	return p.BackendCapacity.Slots[0].ActiveTokens
+}
+
+func setQuoteCapable(p *Provider) {
+	p.mu.Lock()
+	p.capacityQuoteCapable = true
+	p.mu.Unlock()
+}
+
+// attachTestWriter wires a real WebSocket writer onto a registered provider
+// and returns the client end for reading the frames the coordinator sends.
+func attachTestWriter(t *testing.T, p *Provider) *websocket.Conn {
+	t.Helper()
+	serverConn, clientConn := testWebSocketPair(t)
+	p.mu.Lock()
+	p.Conn = serverConn
+	p.writer = newProviderWriter(serverConn)
+	p.mu.Unlock()
+	t.Cleanup(p.closeWriterNow)
+	return clientConn
+}
+
+func readProbeFrame(t *testing.T, conn *websocket.Conn) protocol.CapacityProbeMessage {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, data, err := conn.Read(ctx)
+	if err != nil {
+		t.Fatalf("reading probe frame: %v", err)
+	}
+	var probe protocol.CapacityProbeMessage
+	if err := json.Unmarshal(data, &probe); err != nil {
+		t.Fatalf("unmarshal probe frame %s: %v", data, err)
+	}
+	if probe.Type != protocol.TypeCapacityProbe {
+		t.Fatalf("frame type = %q, want %q", probe.Type, protocol.TypeCapacityProbe)
+	}
+	return probe
+}
+
+func testQuote(quoteID string, admissible bool, p90ms float64) *protocol.CapacityQuoteMessage {
+	q := &protocol.CapacityQuoteMessage{
+		Type:                 protocol.TypeCapacityQuote,
+		QuoteID:              quoteID,
+		CapacitySeq:          1,
+		AdmissibleNow:        admissible,
+		TTFTP50MS:            p90ms / 2,
+		TTFTP90MS:            p90ms,
+		AvailableTokenBudget: 50_000,
+		Confidence:           protocol.CapacityConfidenceHigh,
+	}
+	if !admissible {
+		q.RejectionReason = protocol.RejectionReasonTokenBudget
+	}
+	return q
+}
+
+// collectOutcomes drains the probe channel until it closes.
+func collectOutcomes(t *testing.T, ch <-chan QuoteOutcome) map[string]QuoteOutcome {
+	t.Helper()
+	got := make(map[string]QuoteOutcome)
+	deadline := time.After(5 * time.Second)
+	for {
+		select {
+		case o, ok := <-ch:
+			if !ok {
+				return got
+			}
+			got[o.ProviderID] = o
+		case <-deadline:
+			t.Fatalf("outcome channel did not close; got %v", got)
+		}
+	}
+}
+
+func trackerLen(r *Registry) int {
+	r.capacityQuotes.mu.Lock()
+	defer r.capacityQuotes.mu.Unlock()
+	return len(r.capacityQuotes.pending)
+}
+
+// --- capacity_seq heartbeat gate -------------------------------------------
+
+// A reordered event heartbeat (lower seq decoded after a higher one) must not
+// regress applied capacity state, but must still count as liveness.
+func TestHeartbeatCapacitySeqStaleDiscard(t *testing.T) {
+	reg := New(testLogger())
+	reg.Register("p1", nil, testRegisterMessage())
+	p := reg.GetProvider("p1")
+
+	reg.Heartbeat("p1", seqHeartbeat(2, 100))
+	if got := heartbeatActiveTokens(t, p); got != 100 {
+		t.Fatalf("active tokens after seq 2 = %d, want 100", got)
+	}
+
+	// Age LastHeartbeat so the liveness-only advance is observable.
+	past := time.Now().Add(-time.Minute)
+	p.mu.Lock()
+	p.LastHeartbeat = past
+	p.mu.Unlock()
+
+	// Lower seq: the whole capacity application is discarded.
+	reg.Heartbeat("p1", seqHeartbeat(1, 999))
+	if got := heartbeatActiveTokens(t, p); got != 100 {
+		t.Fatalf("active tokens after stale seq 1 = %d, want 100 (discarded)", got)
+	}
+	// Equal seq is stale too (a duplicate must not re-apply).
+	reg.Heartbeat("p1", seqHeartbeat(2, 777))
+	if got := heartbeatActiveTokens(t, p); got != 100 {
+		t.Fatalf("active tokens after duplicate seq 2 = %d, want 100 (discarded)", got)
+	}
+
+	p.mu.Lock()
+	lastHB, seq := p.LastHeartbeat, p.capacitySeq
+	p.mu.Unlock()
+	if !lastHB.After(past) {
+		t.Fatal("stale heartbeat did not advance LastHeartbeat (liveness must survive the discard)")
+	}
+	if seq != 2 {
+		t.Fatalf("capacitySeq = %d, want 2 (stale frames must not move the high-water mark)", seq)
+	}
+
+	// A genuinely newer frame applies again.
+	reg.Heartbeat("p1", seqHeartbeat(3, 300))
+	if got := heartbeatActiveTokens(t, p); got != 300 {
+		t.Fatalf("active tokens after seq 3 = %d, want 300", got)
+	}
+}
+
+// Seq 0 / omitted is a legacy provider: every heartbeat applies exactly as
+// today and the session never becomes quote-capable.
+func TestHeartbeatCapacitySeqLegacyPassthrough(t *testing.T) {
+	reg := New(testLogger())
+	reg.Register("p1", nil, testRegisterMessage())
+	p := reg.GetProvider("p1")
+
+	reg.Heartbeat("p1", seqHeartbeat(0, 100))
+	reg.Heartbeat("p1", seqHeartbeat(0, 50)) // "regression" is fine: legacy has no ordering
+	if got := heartbeatActiveTokens(t, p); got != 50 {
+		t.Fatalf("active tokens = %d, want 50 (legacy heartbeats always apply)", got)
+	}
+	if p.capacityQuoteReady() {
+		t.Fatal("legacy provider (seq 0) marked quote-capable")
+	}
+}
+
+// The first seq > 0 heartbeat latches the session quote-capable.
+func TestHeartbeatCapacitySeqMarksQuoteCapable(t *testing.T) {
+	reg := New(testLogger())
+	reg.Register("p1", nil, testRegisterMessage())
+	p := reg.GetProvider("p1")
+
+	if p.capacityQuoteReady() {
+		t.Fatal("fresh session must not be quote-capable before any seq heartbeat")
+	}
+	reg.Heartbeat("p1", seqHeartbeat(1, 10))
+	if !p.capacityQuoteReady() {
+		t.Fatal("seq 1 heartbeat did not mark the session quote-capable")
+	}
+}
+
+// A reconnect creates a fresh *Provider (in prod each WS even gets a fresh
+// UUID; same-ID reuse goes through Disconnect first — Register refuses to
+// replace a live entry), so the seq high-water mark resets with the object
+// and the new connection's restarted counter is accepted.
+func TestHeartbeatCapacitySeqResetsOnReconnect(t *testing.T) {
+	reg := New(testLogger())
+	first := reg.Register("p1", nil, testRegisterMessage())
+	reg.Heartbeat("p1", seqHeartbeat(5, 100))
+
+	reg.Disconnect("p1")
+	second := reg.Register("p1", nil, testRegisterMessage())
+	if first == second {
+		t.Fatal("re-register returned the same *Provider; per-connection seq state would leak")
+	}
+	if second.capacityQuoteReady() {
+		t.Fatal("fresh connection inherited quote-capable state")
+	}
+	// The restarted counter's seq 1 would be stale against the OLD
+	// connection's 5; against the fresh object it must apply.
+	reg.Heartbeat("p1", seqHeartbeat(1, 42))
+	if got := heartbeatActiveTokens(t, second); got != 42 {
+		t.Fatalf("active tokens after reconnect seq 1 = %d, want 42 (seq must reset per connection)", got)
+	}
+}
+
+// --- quote correlation ------------------------------------------------------
+
+// A provider must not be able to answer another provider's probe: the quote is
+// dropped and the entry stays registered for the bound provider's own answer.
+func TestHandleCapacityQuoteWrongProviderDropped(t *testing.T) {
+	reg := New(testLogger())
+	deliveries := make(chan quoteDelivery, 1)
+	reg.capacityQuotes.add("q1", &pendingQuote{
+		providerID: "pA",
+		expiresAt:  time.Now().Add(time.Minute),
+		deliver:    deliveries,
+	})
+
+	reg.HandleCapacityQuote("pB", testQuote("q1", true, 500))
+	select {
+	case d := <-deliveries:
+		t.Fatalf("forged quote from pB delivered: %+v", d)
+	default:
+	}
+	if trackerLen(reg) != 1 {
+		t.Fatal("forged quote consumed the real provider's entry")
+	}
+
+	// Unknown quote_id: dropped without touching the registered entry.
+	reg.HandleCapacityQuote("pA", testQuote("q-unknown", true, 500))
+	if trackerLen(reg) != 1 {
+		t.Fatal("unknown quote_id mutated the tracker")
+	}
+
+	// The bound provider's own answer resolves it.
+	reg.HandleCapacityQuote("pA", testQuote("q1", true, 500))
+	select {
+	case d := <-deliveries:
+		if d.providerID != "pA" || d.quote == nil || !d.quote.AdmissibleNow {
+			t.Fatalf("delivery = %+v, want pA's admissible quote", d)
+		}
+	default:
+		t.Fatal("bound provider's quote was not delivered")
+	}
+	if trackerLen(reg) != 0 {
+		t.Fatal("resolved entry not removed from tracker")
+	}
+}
+
+// --- probe fanout -----------------------------------------------------------
+
+// Happy path: quote-capable entries are probed on the data lane with a
+// bucketed shape; an affirmative quote confirms, a negative demotes, and a
+// legacy entry is never probed (it stays unconfirmed mid-tier). The plan is
+// already re-ranked when the outcome channel closes.
+func TestProbePlanCandidatesHappyPath(t *testing.T) {
+	reg := New(testLogger())
+	model := "quote-happy-model"
+	for i := range 4 {
+		planTestProvider(t, reg, fmt.Sprintf("hq%02d", i), model, int64(i)*400)
+	}
+	pr := planTestRequest("quote-happy", 500, 256)
+	pr.Model = model
+	winner, _, plan := reg.ReserveProviderWithPlan(model, pr)
+	if winner == nil || winner.ID != "hq00" || plan.Len() != 3 {
+		t.Fatalf("setup: winner=%v plan.Len()=%d, want hq00 with 3 alternates", winner, plan.Len())
+	}
+
+	p01, p02 := reg.GetProvider("hq01"), reg.GetProvider("hq02")
+	setQuoteCapable(p01)
+	setQuoteCapable(p02)
+	// hq03 stays legacy: no quote-capable mark, no writer. If it were
+	// (wrongly) probed, its dead writer would surface as a third outcome.
+	conn01 := attachTestWriter(t, p01)
+	conn02 := attachTestWriter(t, p02)
+
+	ch := reg.ProbePlanCandidates(plan, CapacityProbeShape{
+		Model:             model,
+		PromptTokens:      700,
+		MaxOutputTokens:   256,
+		DeadlineRemaining: 3 * time.Second,
+	}, 2*time.Second)
+
+	probe01 := readProbeFrame(t, conn01)
+	if probe01.Model != model || probe01.QuoteID == "" {
+		t.Fatalf("probe = %+v, want model %q and a quote_id", probe01, model)
+	}
+	if probe01.PromptTokensBucket != 1024 {
+		t.Fatalf("prompt bucket = %d, want 1024 (700 rounded UP to the 512 bucket)", probe01.PromptTokensBucket)
+	}
+	if probe01.DeadlineRemainingMS != 3000 {
+		t.Fatalf("deadline_remaining_ms = %d, want 3000", probe01.DeadlineRemainingMS)
+	}
+	probe02 := readProbeFrame(t, conn02)
+	if probe02.QuoteID == probe01.QuoteID {
+		t.Fatal("two probes shared a quote_id; correlation would cross-resolve")
+	}
+
+	reg.HandleCapacityQuote("hq01", testQuote(probe01.QuoteID, true, 800))
+	reg.HandleCapacityQuote("hq02", testQuote(probe02.QuoteID, false, 0))
+
+	outcomes := collectOutcomes(t, ch)
+	if len(outcomes) != 2 {
+		t.Fatalf("outcomes = %v, want exactly hq01+hq02 (legacy hq03 must not be probed)", outcomes)
+	}
+	if o := outcomes["hq01"]; o.Quote == nil || !o.Quote.AdmissibleNow || o.Timeout || o.SendFailed {
+		t.Fatalf("hq01 outcome = %+v, want affirmative quote", o)
+	}
+	if o := outcomes["hq02"]; o.Quote == nil || o.Quote.AdmissibleNow || o.Quote.RejectionReason != protocol.RejectionReasonTokenBudget {
+		t.Fatalf("hq02 outcome = %+v, want negative quote with rejection reason", o)
+	}
+
+	// Plan already re-ranked: confirmed hq01 first, unprobed legacy hq03 mid,
+	// demoted hq02 last (channel close happens-after the collector's writes).
+	wantOrder := []string{"hq01", "hq03", "hq02"}
+	for i, want := range wantOrder {
+		if got := plan.entries[i].view.ProviderID; got != want {
+			t.Fatalf("entry[%d] = %q, want %q (confirmed → legacy → demoted)", i, got, want)
+		}
+	}
+	if !plan.entries[0].view.Confirmed || plan.entries[0].view.QuoteTTFTP90 != 800*time.Millisecond {
+		t.Fatalf("confirmed entry = %+v, want quote p90 800ms stored", plan.entries[0].view)
+	}
+	id, p90, ok := plan.BestConfirmedBackup()
+	if !ok || id != "hq01" || p90 != 800*time.Millisecond {
+		t.Fatalf("BestConfirmedBackup = (%q, %v, %v), want (hq01, 800ms, true)", id, p90, ok)
+	}
+	if trackerLen(reg) != 0 {
+		t.Fatal("tracker entries leaked after all probes resolved")
+	}
+}
+
+// A silent provider settles as Timeout at window expiry and is demoted; its
+// tracker entry is reclaimed so a late quote is dropped.
+func TestProbePlanCandidatesTimeoutOutcome(t *testing.T) {
+	reg := New(testLogger())
+	model := "quote-timeout-model"
+	for i := range 2 {
+		planTestProvider(t, reg, fmt.Sprintf("to%02d", i), model, int64(i)*400)
+	}
+	pr := planTestRequest("quote-timeout", 500, 256)
+	pr.Model = model
+	_, _, plan := reg.ReserveProviderWithPlan(model, pr)
+
+	silent := reg.GetProvider("to01")
+	setQuoteCapable(silent)
+	conn := attachTestWriter(t, silent)
+
+	ch := reg.ProbePlanCandidates(plan, CapacityProbeShape{Model: model, PromptTokens: 100, MaxOutputTokens: 64}, 150*time.Millisecond)
+	probe := readProbeFrame(t, conn) // probe arrives; we never answer
+
+	outcomes := collectOutcomes(t, ch)
+	if o := outcomes["to01"]; !o.Timeout || o.Quote != nil || o.SendFailed {
+		t.Fatalf("outcome = %+v, want Timeout", o)
+	}
+	if !plan.entries[0].view.Demoted {
+		t.Fatal("silent entry was not demoted")
+	}
+	if trackerLen(reg) != 0 {
+		t.Fatal("timed-out probe left its tracker entry behind")
+	}
+	// A quote arriving after the window resolves nothing (entry reclaimed).
+	reg.HandleCapacityQuote("to01", testQuote(probe.QuoteID, true, 100))
+	if _, _, ok := plan.BestConfirmedBackup(); ok {
+		t.Fatal("late quote confirmed a timed-out entry")
+	}
+}
+
+// A dead writer (queue full / stopped — here: no writer at all) settles as
+// SendFailed immediately, well inside the window.
+func TestProbePlanCandidatesSendFailure(t *testing.T) {
+	reg := New(testLogger())
+	model := "quote-sendfail-model"
+	for i := range 2 {
+		planTestProvider(t, reg, fmt.Sprintf("sf%02d", i), model, int64(i)*400)
+	}
+	pr := planTestRequest("quote-sendfail", 500, 256)
+	pr.Model = model
+	_, _, plan := reg.ReserveProviderWithPlan(model, pr)
+	setQuoteCapable(reg.GetProvider("sf01")) // quote-capable but writerless
+
+	start := time.Now()
+	outcomes := collectOutcomes(t, reg.ProbePlanCandidates(plan, CapacityProbeShape{Model: model, PromptTokens: 100, MaxOutputTokens: 64}, 5*time.Second))
+	if o := outcomes["sf01"]; !o.SendFailed || o.Timeout || o.Quote != nil {
+		t.Fatalf("outcome = %+v, want SendFailed", o)
+	}
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Fatalf("send failure took %v to settle; must not wait out the window", elapsed)
+	}
+	if !plan.entries[0].view.Demoted {
+		t.Fatal("send-failed entry was not demoted")
+	}
+}
+
+// Disconnect resolves the disconnected provider's outstanding waiters as
+// SendFailed instead of letting them burn the full quote window.
+func TestDisconnectResolvesQuoteWaiters(t *testing.T) {
+	reg := New(testLogger())
+	model := "quote-disconnect-model"
+	for i := range 2 {
+		planTestProvider(t, reg, fmt.Sprintf("dc%02d", i), model, int64(i)*400)
+	}
+	pr := planTestRequest("quote-disconnect", 500, 256)
+	pr.Model = model
+	_, _, plan := reg.ReserveProviderWithPlan(model, pr)
+
+	target := reg.GetProvider("dc01")
+	setQuoteCapable(target)
+	conn := attachTestWriter(t, target)
+
+	ch := reg.ProbePlanCandidates(plan, CapacityProbeShape{Model: model, PromptTokens: 100, MaxOutputTokens: 64}, 10*time.Second)
+	readProbeFrame(t, conn) // frame is on the wire → the entry is registered
+
+	start := time.Now()
+	reg.Disconnect("dc01")
+	outcomes := collectOutcomes(t, ch)
+	if o := outcomes["dc01"]; !o.SendFailed || o.Timeout {
+		t.Fatalf("outcome = %+v, want SendFailed from disconnect", o)
+	}
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Fatalf("disconnect resolution took %v; waiters must not ride out the 10s window", elapsed)
+	}
+	if trackerLen(reg) != 0 {
+		t.Fatal("disconnect left tracker entries behind")
+	}
+}
+
+// --- plan re-ranking --------------------------------------------------------
+
+// Confirm/Demote re-rank the unconsumed tail into confirmed → unprobed →
+// demoted tiers with ascending scan cost inside each tier, regardless of
+// quote arrival order; BestConfirmedBackup returns the cheapest confirmed
+// entry's quoted p90.
+func TestDispatchPlanConfirmDemoteOrdering(t *testing.T) {
+	reg := New(testLogger())
+	model := "plan-rank-model"
+	for i := range 5 {
+		planTestProvider(t, reg, fmt.Sprintf("rk%02d", i), model, int64(i)*400)
+	}
+	pr := planTestRequest("plan-rank", 500, 256)
+	pr.Model = model
+	_, _, plan := reg.ReserveProviderWithPlan(model, pr) // winner rk00; entries rk01..rk04
+
+	// Confirmations arrive out of cost order: the costlier rk03 first.
+	plan.ConfirmEntry("rk03", testQuote("q3", true, 900))
+	plan.ConfirmEntry("rk01", testQuote("q1", true, 400))
+	plan.DemoteEntry("rk02")
+
+	wantOrder := []string{"rk01", "rk03", "rk04", "rk02"}
+	for i, want := range wantOrder {
+		if got := plan.entries[i].view.ProviderID; got != want {
+			t.Fatalf("entry[%d] = %q, want %q (confirmed by cost → unprobed → demoted)", i, got, want)
+		}
+	}
+	id, p90, ok := plan.BestConfirmedBackup()
+	if !ok || id != "rk01" || p90 != 400*time.Millisecond {
+		t.Fatalf("BestConfirmedBackup = (%q, %v, %v), want (rk01, 400ms, true)", id, p90, ok)
+	}
+
+	// Demotion outranks a prior confirmation (it is always the later signal).
+	plan.DemoteEntry("rk01")
+	if id, _, _ := plan.BestConfirmedBackup(); id != "rk03" {
+		t.Fatalf("after demoting rk01, BestConfirmedBackup = %q, want rk03", id)
+	}
+
+	// Consumed entries are history: confirming one must not resurrect it.
+	e, okNext := plan.nextEntry() // consumes rk03 (best remaining)
+	if !okNext || e.view.ProviderID != "rk03" {
+		t.Fatalf("nextEntry = %+v, want rk03 (confirmed tier first)", e.view)
+	}
+	plan.ConfirmEntry("rk03", testQuote("q3b", true, 100))
+	if id, _, ok := plan.BestConfirmedBackup(); ok {
+		t.Fatalf("BestConfirmedBackup = %q after consuming the only confirmed entry, want none", id)
+	}
+}
+
+// The probe collector (Confirm/Demote/BestConfirmedBackup) and the dispatch
+// loop (ReserveNextFromPlan) touch one plan concurrently; run under -race.
+func TestDispatchPlanConcurrentQuoteAndConsume(t *testing.T) {
+	reg := New(testLogger())
+	model := "plan-race-model"
+	for i := range 10 {
+		planTestProvider(t, reg, fmt.Sprintf("rc%02d", i), model, int64(i)*400)
+	}
+	pr := planTestRequest("plan-race", 500, 256)
+	pr.Model = model
+	_, _, plan := reg.ReserveProviderWithPlan(model, pr)
+	if plan.Len() != dispatchPlanMaxAlternates {
+		t.Fatalf("plan.Len() = %d, want %d", plan.Len(), dispatchPlanMaxAlternates)
+	}
+	ids := make([]string, 0, plan.Len())
+	plan.mu.Lock()
+	for _, e := range plan.entries {
+		ids = append(ids, e.view.ProviderID)
+	}
+	plan.mu.Unlock()
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() { // probe collector: quotes land while the consumer drains
+		defer wg.Done()
+		for i := range 300 {
+			id := ids[i%len(ids)]
+			switch i % 3 {
+			case 0:
+				plan.ConfirmEntry(id, testQuote("qr", true, float64(100+i)))
+			case 1:
+				plan.DemoteEntry(id)
+			default:
+				plan.BestConfirmedBackup()
+			}
+		}
+	}()
+	go func() { // dispatch loop: consume the plan to exhaustion
+		defer wg.Done()
+		for i := 0; ; i++ {
+			cpr := planTestRequest(fmt.Sprintf("plan-race-consume-%d", i), 500, 256)
+			cpr.Model = model
+			p, _, skips := reg.ReserveNextFromPlan(cpr, plan)
+			if p != nil {
+				p.RemovePending(cpr.RequestID)
+				reg.SetProviderIdle(p.ID)
+				continue
+			}
+			if len(skips) > 0 && skips[len(skips)-1].Reason == PlanSkipExhausted {
+				return
+			}
+		}
+	}()
+	wg.Wait()
+
+	if got := plan.Remaining(); got != 0 {
+		t.Fatalf("plan.Remaining() = %d after exhaustion, want 0", got)
+	}
+}
+
+// --- hedge governor snapshot ------------------------------------------------
+
+// HedgeGovernorSnapshot is a point-in-time advisory read: idle-spread from the
+// same computation as the Phase-0 shadow signal, per-model queued demand,
+// fleet-wide loaded-idle slots, and the dual-path capacity-signal bit that
+// tells the governor whether those inputs are meaningful at all.
+func TestHedgeGovernorSnapshot(t *testing.T) {
+	reg := New(testLogger())
+	model := "governor-snap-model"
+	for i := range 3 {
+		planTestProvider(t, reg, fmt.Sprintf("gv%02d", i), model, int64(i)*400)
+	}
+	pr := planTestRequest("governor-snap", 200, 128)
+	pr.Model = model
+
+	idleAlt, depth, idleSlots, signals := reg.HedgeGovernorSnapshot(model, pr, "gv00")
+	if !idleAlt {
+		t.Fatal("idleAlternativeExists = false with two loaded-idle non-excluded providers")
+	}
+	if depth != 0 {
+		t.Fatalf("modelQueueDepth = %d, want 0", depth)
+	}
+	if idleSlots != 3 {
+		t.Fatalf("fleetIdleSlots = %d, want 3 (every registered slot is loaded-idle)", idleSlots)
+	}
+	if !signals {
+		t.Fatal("capacitySignalsAvailable = false on a fully-reporting fleet")
+	}
+
+	// Occupying one provider's slot removes it from the idle count.
+	busy := reg.GetProvider("gv01")
+	busy.mu.Lock()
+	busy.BackendCapacity.Slots[0].NumRunning = 1
+	busy.mu.Unlock()
+	if _, _, idleSlots, _ := reg.HedgeGovernorSnapshot(model, pr, "gv00"); idleSlots != 2 {
+		t.Fatalf("fleetIdleSlots = %d after occupying gv01, want 2", idleSlots)
+	}
+
+	// A different model served by no reporting provider gets no signal bit:
+	// the reporting fleet for gv-model says nothing about it.
+	if _, _, _, signals := reg.HedgeGovernorSnapshot("some-other-model", pr); signals {
+		t.Fatal("capacitySignalsAvailable = true for a model no reporting provider serves")
+	}
+}
+
+// A capacity-silent (all-legacy) fleet returns structural zeros — the same
+// shape as saturation — so it must be distinguishable via
+// capacitySignalsAvailable=false, letting the api bypass the governor and
+// keep today's unconditional 50% hedge (plan decision 3: legacy fleets keep
+// current behavior).
+func TestHedgeGovernorSnapshotCapacitySilentFleet(t *testing.T) {
+	reg := New(testLogger())
+	model := "governor-legacy-model"
+	for i := range 3 {
+		p := planTestProvider(t, reg, fmt.Sprintf("lg%02d", i), model, 0)
+		p.mu.Lock()
+		p.BackendCapacity = nil // legacy: no capacity reporting at all
+		p.mu.Unlock()
+	}
+	pr := planTestRequest("governor-legacy", 200, 128)
+	pr.Model = model
+
+	_, _, idleSlots, signals := reg.HedgeGovernorSnapshot(model, pr, "lg00")
+	if idleSlots != 0 {
+		t.Fatalf("fleetIdleSlots = %d on a non-reporting fleet, want 0", idleSlots)
+	}
+	if signals {
+		t.Fatal("capacitySignalsAvailable = true on an all-legacy fleet")
+	}
+
+	// One provider proving quote capability flips the fleet into governed
+	// mode even before its next capacity snapshot lands.
+	setQuoteCapable(reg.GetProvider("lg01"))
+	if _, _, _, signals := reg.HedgeGovernorSnapshot(model, pr, "lg00"); !signals {
+		t.Fatal("capacitySignalsAvailable = false with a quote-capable provider serving the model")
+	}
+}

--- a/coordinator/registry/dispatch_plan.go
+++ b/coordinator/registry/dispatch_plan.go
@@ -48,6 +48,13 @@ const (
 	// longer clears the full admission gate chain (structural/trait/trust
 	// gates, capacity admission, TTFT ceiling) against CURRENT state.
 	PlanSkipGateRejected PlanSkipReason = "gate_rejected"
+	// PlanSkipVersionAvoided: a version-diverse retry (pr.Traits.AvoidVersion)
+	// reserved an entry running a DIFFERENT binary version, so this entry —
+	// live on exactly the avoided version — was passed over. Soft by
+	// construction: recorded only when diversity actually won; when no
+	// diverse entry is admissible the same entries are revisited and reserve
+	// or fail with their own reasons.
+	PlanSkipVersionAvoided PlanSkipReason = "version_avoided"
 	// PlanSkipExhausted: no entries remain in the plan. Plan-level, carried
 	// with an empty ProviderID as the terminal element of the skip list.
 	PlanSkipExhausted PlanSkipReason = "exhausted"
@@ -348,6 +355,18 @@ func (r *Registry) ReserveProviderWithPlan(model string, pr *PendingRequest, exc
 // coordinatorExtra / pooledBudgetAdmits). See the ledger rationale on
 // reserveProvider's pending-debit path in scheduler.go.
 //
+// Version-diverse retry (SOFT — parity with scanCandidatesLocked's
+// post-candidate AvoidVersion narrowing): when pr.Traits.AvoidVersion is set,
+// consumption is a two-pass walk. Pass 1 visits the plan in cost order but
+// DEFERS every entry whose provider's LIVE reported version equals the
+// avoided one — read via providerVersion under p.mu during this
+// revalidation, never a scan-time copy, because the provider may have
+// upgraded (or rolled back onto the broken build) since the plan was built.
+// Pass 2 revisits the deferred entries in the same order only when no
+// diverse entry reserved, so diversity never fails closed: a pool that is
+// all-avoided-version behaves exactly as if AvoidVersion were empty, just as
+// the scan keeps its full pool when the diverse set is empty.
+//
 // The Phase-0 shadow TTFT evaluation is intentionally not recomputed for plan
 // reservations: it is observational primary-selection telemetry, and the plan
 // path is the retry/hedge lane.
@@ -378,50 +397,41 @@ func (r *Registry) ReserveNextFromPlan(pr *PendingRequest, plan *DispatchPlan, e
 	var skips []PlanSkip
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	for {
-		entry, ok := plan.nextEntry()
-		if !ok {
-			skips = append(skips, PlanSkip{Reason: PlanSkipExhausted})
-			return nil, RoutingDecision{Model: model}, skips
-		}
+
+	// tryReserve runs the full CURRENT gate chain against one identity-checked
+	// entry and, on success, commits the reservation. Failure appends the
+	// bounded gate_rejected skip.
+	tryReserve := func(entry planEntry) (*Provider, RoutingDecision, bool) {
 		id := entry.view.ProviderID
+		p := entry.provider
 		skip := func(reason PlanSkipReason) {
 			skips = append(skips, PlanSkip{ProviderID: id, Reason: reason})
 		}
-		if _, excluded := exclude[id]; excluded {
-			skip(PlanSkipExcluded)
-			continue
-		}
-		if cur, live := r.providers[id]; !live || cur != entry.provider {
-			skip(PlanSkipStaleSession)
-			continue
-		}
-		p := entry.provider
 		// Scan-order pre-snapshot filters (scanCandidatesLocked): exclusive
 		// self-route ownership and the attested-serial allowlist.
 		owned := providerOwnedBy(p, pr.OwnerAccountID)
 		if pr.SelfRouteOnly && !owned {
 			skip(PlanSkipGateRejected)
-			continue
+			return nil, RoutingDecision{}, false
 		}
 		if len(allowedSerials) > 0 && !providerMatchesAllowedSerial(p, allowedSerials) {
 			skip(PlanSkipGateRejected)
-			continue
+			return nil, RoutingDecision{}, false
 		}
 		relaxTrust := owned && (pr.SelfRouteOnly || pr.PreferOwner)
 		snap, ok := r.snapshotProviderLocked(p, model, pr.Traits, relaxTrust)
 		if !ok {
 			skip(PlanSkipGateRejected)
-			continue
+			return nil, RoutingDecision{}, false
 		}
 		candidate, _, ok := r.buildCandidateWithReason(snap, pr)
 		if !ok {
 			skip(PlanSkipGateRejected)
-			continue
+			return nil, RoutingDecision{}, false
 		}
 		if enforceTTFT && snap.hasBackendCapacity && candidate.breakdown.TTFTMs > pr.MaxTTFTMs {
 			skip(PlanSkipGateRejected)
-			continue
+			return nil, RoutingDecision{}, false
 		}
 
 		// Final admit + reservation under p.mu — the same commit sequence as
@@ -432,7 +442,7 @@ func (r *Registry) ReserveNextFromPlan(pr *PendingRequest, plan *DispatchPlan, e
 			(pr.RequiresVision && !r.providerServesVisionModelLocked(p, model, relaxTrust)) {
 			p.mu.Unlock()
 			skip(PlanSkipGateRejected)
-			continue
+			return nil, RoutingDecision{}, false
 		}
 		pr.ProviderID = p.ID
 		p.addPendingLocked(pr)
@@ -473,8 +483,50 @@ func (r *Registry) ReserveNextFromPlan(pr *PendingRequest, plan *DispatchPlan, e
 			EffectiveTPS:       candidate.effectiveTPS,
 			StaticTPS:          candidate.snapshot.decodeTPS,
 		}
-		return p, decision, skips
+		return p, decision, true
 	}
+
+	// Pass 1: cost order, deferring live avoided-version entries (see the
+	// version-diverse retry rationale in the doc comment).
+	avoid := pr.Traits.AvoidVersion
+	var deferred []planEntry
+	for {
+		entry, ok := plan.nextEntry()
+		if !ok {
+			break
+		}
+		id := entry.view.ProviderID
+		if _, excluded := exclude[id]; excluded {
+			skips = append(skips, PlanSkip{ProviderID: id, Reason: PlanSkipExcluded})
+			continue
+		}
+		if cur, live := r.providers[id]; !live || cur != entry.provider {
+			skips = append(skips, PlanSkip{ProviderID: id, Reason: PlanSkipStaleSession})
+			continue
+		}
+		if avoid != "" && providerVersion(entry.provider) == avoid {
+			deferred = append(deferred, entry)
+			continue
+		}
+		if p, decision, ok := tryReserve(entry); ok {
+			// Diversity won: the deferred same-version entries were passed
+			// over for this consumption — record them for telemetry.
+			for _, d := range deferred {
+				skips = append(skips, PlanSkip{ProviderID: d.view.ProviderID, Reason: PlanSkipVersionAvoided})
+			}
+			return p, decision, skips
+		}
+	}
+	// Pass 2: no diverse entry was admissible — fall back to the avoided
+	// version rather than failing closed. The pass-1 identity checks remain
+	// valid: r.providers cannot change while the r.mu write lock is held.
+	for _, entry := range deferred {
+		if p, decision, ok := tryReserve(entry); ok {
+			return p, decision, skips
+		}
+	}
+	skips = append(skips, PlanSkip{Reason: PlanSkipExhausted})
+	return nil, RoutingDecision{Model: model}, skips
 }
 
 // RefreshDispatchPlan performs the plan's single full re-scan refresh: a fresh

--- a/coordinator/registry/dispatch_plan.go
+++ b/coordinator/registry/dispatch_plan.go
@@ -1,0 +1,640 @@
+package registry
+
+import (
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+)
+
+// Bounded dispatch plan — Routing v2 Phase 3 (identity retention).
+//
+// Prod gap (timeout route rows, 2026-08): failed requests carried
+// candidate_count 86-401 with attempt indexes up to 9, yet every retry and
+// speculative backup re-scanned the whole fleet from scratch
+// (coordinator/api/dispatch.go → ReserveProviderEx). Candidates were never the
+// deficit — identity retention was: by the time a retry scanned again, the
+// herd had moved, the scan re-ranked the same overloaded boxes, and the
+// request burned its first-content budget on rescan after rescan.
+//
+// The plan retains up to dispatchPlanMaxAlternates of the lowest-cost
+// NON-winner candidates from the SAME scan that selected the primary, plus
+// full-pool aggregate counts for telemetry. It is strictly request-local
+// state: *Provider pointers plus small value snapshots of the ranking terms,
+// no registry-side maps, no TTLs, no background reaping — when the request
+// ends, the plan is garbage. Consuming an entry later goes through
+// ReserveNextFromPlan, which re-verifies identity (the registry must still map
+// the entry's provider ID to the exact same *Provider — a reconnect creates a
+// new object) and re-runs the FULL admission gate chain via the same helpers
+// the scan uses, so a plan entry can never bypass a gate that a fresh scan
+// would apply.
+const dispatchPlanMaxAlternates = 8
+
+// PlanSkipReason is the bounded reason a plan entry was passed over by
+// ReserveNextFromPlan. Bounded (never free-form) so it can feed route-row
+// taxonomy and metric tags without cardinality risk.
+type PlanSkipReason string
+
+const (
+	// PlanSkipStaleSession: the registry no longer maps the entry's provider
+	// ID to the same *Provider object — the session disconnected (and possibly
+	// reconnected as a new object). The retained identity is invalid.
+	PlanSkipStaleSession PlanSkipReason = "stale_session"
+	// PlanSkipExcluded: the caller's exclusion set (previous attempts,
+	// speculative peers) or pr.ExcludedProviderIDs names this provider.
+	PlanSkipExcluded PlanSkipReason = "excluded"
+	// PlanSkipGateRejected: the provider is still the same session but no
+	// longer clears the full admission gate chain (structural/trait/trust
+	// gates, capacity admission, TTFT ceiling) against CURRENT state.
+	PlanSkipGateRejected PlanSkipReason = "gate_rejected"
+	// PlanSkipExhausted: no entries remain in the plan. Plan-level, carried
+	// with an empty ProviderID as the terminal element of the skip list.
+	PlanSkipExhausted PlanSkipReason = "exhausted"
+)
+
+// PlanSkip records one passed-over plan entry and why.
+type PlanSkip struct {
+	ProviderID string
+	Reason     PlanSkipReason
+}
+
+// PlanEntry is the exported view of one retained alternate: the ranking and
+// revalidation terms dispatch code needs for hedge timing and telemetry,
+// captured at scan time. Estimates are scan-time values — ReserveNextFromPlan
+// recomputes everything against live state before reserving.
+type PlanEntry struct {
+	ProviderID string
+	// CostMs is the candidate's full routing cost at scan time (same quantity
+	// selectRoutingCandidate ranked by).
+	CostMs float64
+	// TTFTMs is the calibrated scan-time TTFT estimate (0 when the provider
+	// reports no BackendCapacity — unreliable, matching the scan's ceiling
+	// exemption). RawTTFTMs is the uncalibrated formula value alongside.
+	TTFTMs    float64
+	RawTTFTMs float64
+	// StateMs is the slot-state penalty (0 = warm/running; large = cold load
+	// ahead). ModelLoaded/SlotState carry the warm/idle detail.
+	StateMs     float64
+	ModelLoaded bool
+	SlotState   string
+	ChipFamily  string
+
+	// Wave-2 quote enrichment (capacity_quotes.go). Confirmed is set by an
+	// affirmative capacity_quote, Demoted by a negative quote, probe timeout,
+	// or transport failure; both false = unprobed/legacy (ledger-scored,
+	// mid-tier). The Quote* fields carry the provider's own live estimate and
+	// are meaningful only while Confirmed.
+	Confirmed bool
+	Demoted   bool
+	// QuoteTTFTP50/P90 are the quoted end-to-end TTFT distribution quantiles
+	// (durations — the wire carries ms floats). P50 is telemetry view only;
+	// production hedge timing reads P90 via BestConfirmedBackup.
+	QuoteTTFTP50 time.Duration
+	QuoteTTFTP90 time.Duration
+	// QuoteAvailableTokens is the quoted live token headroom of the admitting
+	// gate; QuoteConfidence is protocol.CapacityConfidenceHigh/Low. Telemetry
+	// view; no production consumer reads these off the plan today.
+	QuoteAvailableTokens int64
+	QuoteConfidence      string
+}
+
+// planEntry pairs the exported view with the retained provider identity. The
+// pointer is deliberately unexported: the ONLY way to turn an entry into a
+// dispatchable provider is ReserveNextFromPlan's verify-and-reserve path.
+type planEntry struct {
+	provider *Provider
+	view     PlanEntry
+}
+
+// DispatchPlan is the request-local shortlist produced by
+// ReserveProviderWithPlan. Entries are born ordered by ascending scan-time
+// cost and consumed once each (cursor); quote outcomes re-rank the UNCONSUMED
+// tail into confirmed → unprobed/legacy → demoted tiers (cost order preserved
+// within each tier — see resortTailLocked); one full re-scan refresh is
+// available for the plan's whole lifetime (RefreshDispatchPlan).
+//
+// Concurrency: a plan belongs to one request, but that request's retry loop,
+// its speculative-backup goroutine, AND the probe collector
+// (ProbePlanCandidates applies Confirm/Demote as quotes land) may touch it
+// concurrently, so mu guards cursor/attempted/refreshUsed and the entries
+// slice's ordering + quote state. mu is a LEAF lock: ReserveNextFromPlan
+// acquires it strictly after r.mu, and no code path takes r.mu or p.mu while
+// holding it.
+type DispatchPlan struct {
+	mu      sync.Mutex
+	model   string
+	entries []planEntry
+	cursor  int
+	// attempted holds every provider this request has been bound to or has
+	// passed over through this plan: the primary winner plus every entry the
+	// cursor has visited, regardless of outcome. A refresh excludes them all —
+	// re-offering a provider that was just tried or just failed a gate is
+	// exactly the herd behavior the plan exists to avoid.
+	attempted   map[string]struct{}
+	refreshUsed bool
+
+	// Full-pool aggregate counts from the scan that built the plan, as
+	// progressively narrowing sets (eligible ⊇ admissible ⊇ deadline-feasible).
+	eligible         int
+	admissible       int
+	deadlineFeasible int
+}
+
+// newDispatchPlan builds the plan from the scan that selected winner. One
+// bounded pass over the already-built pool: it keeps the
+// dispatchPlanMaxAlternates lowest-cost non-winner candidates via insertion
+// into a fixed-capacity slice (O(n·8) comparisons, no full-pool sort, no
+// full-pool copy — only the ≤8 retained entries copy their ranking terms).
+// Caller holds r.mu (candidates reference live *Providers).
+func newDispatchPlan(model string, scan candidateScan, winner *routingCandidate) *DispatchPlan {
+	plan := &DispatchPlan{
+		model:     model,
+		entries:   make([]planEntry, 0, dispatchPlanMaxAlternates),
+		attempted: make(map[string]struct{}, dispatchPlanMaxAlternates+1),
+		// Aggregate derivation from the scan tallies: capacity- and
+		// TTFT-rejected providers cleared every structural gate first (the scan
+		// counts them only after a successful snapshot), so they are eligible;
+		// TTFT-rejected providers additionally passed capacity admission
+		// (the ceiling is checked after buildCandidateWithReason succeeds), so
+		// they are admissible; candidateCount passed everything.
+		eligible:         scan.candidateCount + scan.capacityRejections + scan.ttftRejections,
+		admissible:       scan.candidateCount + scan.ttftRejections,
+		deadlineFeasible: scan.candidateCount,
+	}
+	if winner != nil {
+		plan.attempted[winner.provider.ID] = struct{}{}
+	}
+	for _, c := range scan.pool {
+		if c == winner {
+			continue
+		}
+		// Insertion position among the retained entries (ascending cost).
+		pos := len(plan.entries)
+		for pos > 0 && c.costMs < plan.entries[pos-1].view.CostMs {
+			pos--
+		}
+		if pos == dispatchPlanMaxAlternates {
+			continue // costlier than every retained entry, list full
+		}
+		if len(plan.entries) < dispatchPlanMaxAlternates {
+			plan.entries = append(plan.entries, planEntry{})
+		}
+		copy(plan.entries[pos+1:], plan.entries[pos:])
+		plan.entries[pos] = planEntry{
+			provider: c.provider,
+			view: PlanEntry{
+				ProviderID:  c.provider.ID,
+				CostMs:      c.costMs,
+				TTFTMs:      c.breakdown.TTFTMs,
+				RawTTFTMs:   c.breakdown.RawTTFTMs,
+				StateMs:     c.breakdown.StateMs,
+				ModelLoaded: c.snapshot.modelLoaded,
+				SlotState:   c.snapshot.slotState,
+				ChipFamily:  c.snapshot.chipFamily,
+			},
+		}
+	}
+	return plan
+}
+
+// Model returns the model the plan was built for.
+func (dp *DispatchPlan) Model() string {
+	if dp == nil {
+		return ""
+	}
+	return dp.model
+}
+
+// Len returns the number of retained alternates (consumed or not).
+func (dp *DispatchPlan) Len() int {
+	if dp == nil {
+		return 0
+	}
+	return len(dp.entries)
+}
+
+// Remaining returns how many alternates the cursor has not yet visited.
+func (dp *DispatchPlan) Remaining() int {
+	if dp == nil {
+		return 0
+	}
+	dp.mu.Lock()
+	defer dp.mu.Unlock()
+	return len(dp.entries) - dp.cursor
+}
+
+// PeekNext returns the next unconsumed entry's view without advancing the
+// cursor, and false when the plan is exhausted. Inspection only — hedge
+// timing reads BestConfirmedBackup, and consumption goes through
+// ReserveNextFromPlan.
+func (dp *DispatchPlan) PeekNext() (PlanEntry, bool) {
+	if dp == nil {
+		return PlanEntry{}, false
+	}
+	dp.mu.Lock()
+	defer dp.mu.Unlock()
+	if dp.cursor >= len(dp.entries) {
+		return PlanEntry{}, false
+	}
+	return dp.entries[dp.cursor].view, true
+}
+
+// EligibleCount is the number of providers that cleared every structural,
+// trait, and trust gate for this request at scan time (including those then
+// rejected for capacity or the TTFT ceiling).
+func (dp *DispatchPlan) EligibleCount() int {
+	if dp == nil {
+		return 0
+	}
+	return dp.eligible
+}
+
+// AdmissibleCount is the subset of EligibleCount that also passed live
+// capacity admission at scan time.
+func (dp *DispatchPlan) AdmissibleCount() int {
+	if dp == nil {
+		return 0
+	}
+	return dp.admissible
+}
+
+// DeadlineFeasibleCount is the subset of AdmissibleCount whose estimated TTFT
+// also fit the per-request ceiling — the pool the selector actually ranked.
+func (dp *DispatchPlan) DeadlineFeasibleCount() int {
+	if dp == nil {
+		return 0
+	}
+	return dp.deadlineFeasible
+}
+
+// RefreshUsed reports whether the plan's single full re-scan refresh has been
+// consumed (a refreshed plan is born with it consumed).
+func (dp *DispatchPlan) RefreshUsed() bool {
+	if dp == nil {
+		return true
+	}
+	dp.mu.Lock()
+	defer dp.mu.Unlock()
+	return dp.refreshUsed
+}
+
+// AttemptedProviderIDs returns a copy of every provider ID this plan has bound
+// or visited, for callers composing exclusion sets across attempts.
+func (dp *DispatchPlan) AttemptedProviderIDs() []string {
+	if dp == nil {
+		return nil
+	}
+	dp.mu.Lock()
+	defer dp.mu.Unlock()
+	ids := make([]string, 0, len(dp.attempted))
+	for id := range dp.attempted {
+		ids = append(ids, id)
+	}
+	return ids
+}
+
+// nextEntry advances the cursor by one and marks the entry attempted.
+func (dp *DispatchPlan) nextEntry() (planEntry, bool) {
+	dp.mu.Lock()
+	defer dp.mu.Unlock()
+	if dp.cursor >= len(dp.entries) {
+		return planEntry{}, false
+	}
+	e := dp.entries[dp.cursor]
+	dp.cursor++
+	dp.attempted[e.view.ProviderID] = struct{}{}
+	return e, true
+}
+
+// ReserveProviderWithPlan is ReserveProviderEx plus plan retention: identical
+// selection and reservation semantics (it IS the same implementation —
+// reserveProvider in scheduler.go), additionally returning the bounded
+// DispatchPlan of provisional alternates from the same scan. The plan is nil
+// whenever no provider was reserved.
+func (r *Registry) ReserveProviderWithPlan(model string, pr *PendingRequest, excludeIDs ...string) (*Provider, RoutingDecision, *DispatchPlan) {
+	return r.reserveProvider(model, pr, true, excludeIDs...)
+}
+
+// ReserveNextFromPlan consumes plan entries in cost order until one passes the
+// full, CURRENT admission gate chain, reserving it atomically
+// (addPendingLocked) exactly like the primary reservation. Entries that fail
+// are skipped with a bounded reason; the skip list (terminated by an
+// "exhausted" element when the plan runs out) is returned for telemetry and
+// for the caller's refresh decision.
+//
+// Revalidation deliberately reuses the SAME helpers the scan uses — never a
+// copied eligibility switch:
+//   - identity: r.providers[id] must still be the exact retained *Provider
+//     (a reconnect registers a new object under the same ID — its slot state,
+//     trust, and capacity are a stranger's; see Register/Disconnect);
+//   - snapshotProviderLocked → providerPassesRoutingGatesLocked (every
+//     structural/privacy/cooldown/trait gate);
+//   - buildCandidateWithReason (slot state, concurrency headroom, thermal,
+//     hardware fit, freeMemoryAdmits — including the in-flight pending debit
+//     and the budget clamp) plus the same TTFT-ceiling condition the scan
+//     enforces;
+//   - providerCanAdmitLockedEx under p.mu, the same final admit re-check
+//     ReserveProviderEx runs (no fail-open breaker carry here: plan entries
+//     are alternates, and a breaker that opened since the scan should skip
+//     the entry — the caller's refresh re-runs the full scan, whose fail-open
+//     valve still protects the all-providers-broken case).
+//
+// Ledger note (why plan reservations cannot double-spend a heartbeat budget):
+// the r.mu WRITE lock is held for the whole loop, exactly like
+// ReserveProviderEx, so reservations serialize fleet-wide; and each entry is
+// re-snapshotted here, so freeMemoryAdmits charges every pending request
+// admitted since the plan was built (fillSnapshotPendingAndPool →
+// coordinatorExtra / pooledBudgetAdmits). See the ledger rationale on
+// reserveProvider's pending-debit path in scheduler.go.
+//
+// The Phase-0 shadow TTFT evaluation is intentionally not recomputed for plan
+// reservations: it is observational primary-selection telemetry, and the plan
+// path is the retry/hedge lane.
+func (r *Registry) ReserveNextFromPlan(pr *PendingRequest, plan *DispatchPlan, excludeIDs ...string) (*Provider, RoutingDecision, []PlanSkip) {
+	if pr == nil || pr.RequestID == "" || plan == nil || plan.model == "" {
+		return nil, RoutingDecision{}, []PlanSkip{{Reason: PlanSkipExhausted}}
+	}
+	model := plan.model
+	if pr.Model == "" {
+		pr.Model = model
+	}
+	if pr.RequestedMaxTokens <= 0 {
+		pr.RequestedMaxTokens = defaultRequestedMaxTokens
+	}
+	exclude := make(map[string]struct{}, len(excludeIDs)+len(pr.ExcludedProviderIDs))
+	for _, id := range excludeIDs {
+		exclude[id] = struct{}{}
+	}
+	for _, id := range pr.ExcludedProviderIDs {
+		exclude[id] = struct{}{}
+	}
+	allowedSerials := make(map[string]struct{}, len(pr.AllowedProviderSerials))
+	for _, serial := range pr.AllowedProviderSerials {
+		allowedSerials[serial] = struct{}{}
+	}
+	enforceTTFT := pr.MaxTTFTMs > 0 && !pr.RequiresVision
+
+	var skips []PlanSkip
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for {
+		entry, ok := plan.nextEntry()
+		if !ok {
+			skips = append(skips, PlanSkip{Reason: PlanSkipExhausted})
+			return nil, RoutingDecision{Model: model}, skips
+		}
+		id := entry.view.ProviderID
+		skip := func(reason PlanSkipReason) {
+			skips = append(skips, PlanSkip{ProviderID: id, Reason: reason})
+		}
+		if _, excluded := exclude[id]; excluded {
+			skip(PlanSkipExcluded)
+			continue
+		}
+		if cur, live := r.providers[id]; !live || cur != entry.provider {
+			skip(PlanSkipStaleSession)
+			continue
+		}
+		p := entry.provider
+		// Scan-order pre-snapshot filters (scanCandidatesLocked): exclusive
+		// self-route ownership and the attested-serial allowlist.
+		owned := providerOwnedBy(p, pr.OwnerAccountID)
+		if pr.SelfRouteOnly && !owned {
+			skip(PlanSkipGateRejected)
+			continue
+		}
+		if len(allowedSerials) > 0 && !providerMatchesAllowedSerial(p, allowedSerials) {
+			skip(PlanSkipGateRejected)
+			continue
+		}
+		relaxTrust := owned && (pr.SelfRouteOnly || pr.PreferOwner)
+		snap, ok := r.snapshotProviderLocked(p, model, pr.Traits, relaxTrust)
+		if !ok {
+			skip(PlanSkipGateRejected)
+			continue
+		}
+		candidate, _, ok := r.buildCandidateWithReason(snap, pr)
+		if !ok {
+			skip(PlanSkipGateRejected)
+			continue
+		}
+		if enforceTTFT && snap.hasBackendCapacity && candidate.breakdown.TTFTMs > pr.MaxTTFTMs {
+			skip(PlanSkipGateRejected)
+			continue
+		}
+
+		// Final admit + reservation under p.mu — the same commit sequence as
+		// reserveProvider (snapshotProviderLocked released p.mu, so the admit
+		// re-check closes the snapshot→reserve gap, including the vision gate).
+		p.mu.Lock()
+		if !r.providerCanAdmitLockedEx(p, model, pr.Traits, relaxTrust, false) ||
+			(pr.RequiresVision && !r.providerServesVisionModelLocked(p, model, relaxTrust)) {
+			p.mu.Unlock()
+			skip(PlanSkipGateRejected)
+			continue
+		}
+		pr.ProviderID = p.ID
+		p.addPendingLocked(pr)
+		// Half-open capacity probe claim: identical to the primary reservation
+		// path (the r.mu write lock held across this loop serializes claims).
+		r.claimCapacityProbeLocked(p.ID, model, time.Now())
+		if p.Status != StatusUntrusted && p.Status != StatusOffline {
+			p.Status = StatusServing
+		}
+		p.mu.Unlock()
+
+		if !slotStateModelLoaded(candidate.snapshot.slotState) {
+			r.RecordWarmPoolColdDispatch(model)
+		}
+		// Same calibrator-join rule as the primary path: warm text dispatches
+		// only (see reserveProvider).
+		bd := candidate.breakdown
+		if !pr.RequiresVision && bd.RawTTFTMs > 0 && bd.StateMs == 0 {
+			ttftCalibration.notePrediction(pr.RequestID, pr.Attempt, model, candidate.snapshot.chipFamily, bd.RawTTFTMs)
+		}
+		// Winner-specific fields only: the scan tallies belong to the plan
+		// (EligibleCount/…), not to this per-entry revalidation, so the count
+		// fields stay zero rather than repeating stale scan-time numbers.
+		decision := RoutingDecision{
+			ProviderID:         p.ID,
+			Model:              model,
+			CostMs:             bd.Total,
+			StateMs:            bd.StateMs,
+			QueueMs:            bd.QueueMs,
+			PendingMs:          bd.PendingMs,
+			BacklogMs:          bd.BacklogMs,
+			ThisReqMs:          bd.ThisReqMs,
+			HealthMs:           bd.HealthMs,
+			CapacityRateMs:     bd.CapacityRateMs,
+			CapacityRejectRate: candidate.capacityRejectRate,
+			EffectiveQueue:     candidate.effectiveQueue,
+			TTFTMs:             bd.TTFTMs,
+			EffectiveTPS:       candidate.effectiveTPS,
+			StaticTPS:          candidate.snapshot.decodeTPS,
+		}
+		return p, decision, skips
+	}
+}
+
+// RefreshDispatchPlan performs the plan's single full re-scan refresh: a fresh
+// ReserveProviderWithPlan excluding every provider the exhausted plan already
+// attempted (winner + every visited entry) plus the caller's exclusions. The
+// returned plan is born with its refresh consumed, so a request chain gets at
+// most one re-scan no matter how plans are threaded. Returns performed=false
+// (and scans nothing) when the refresh was already used or plan is nil; a
+// performed refresh that finds no provider returns a nil provider and nil
+// plan with the failure RoutingDecision, exactly like ReserveProviderWithPlan.
+func (r *Registry) RefreshDispatchPlan(pr *PendingRequest, plan *DispatchPlan, excludeIDs ...string) (p *Provider, decision RoutingDecision, fresh *DispatchPlan, performed bool) {
+	if plan == nil {
+		return nil, RoutingDecision{}, nil, false
+	}
+	plan.mu.Lock()
+	if plan.refreshUsed {
+		plan.mu.Unlock()
+		return nil, RoutingDecision{Model: plan.model}, nil, false
+	}
+	plan.refreshUsed = true
+	exclude := make([]string, 0, len(plan.attempted)+len(excludeIDs))
+	for id := range plan.attempted {
+		exclude = append(exclude, id)
+	}
+	plan.mu.Unlock()
+	exclude = append(exclude, excludeIDs...)
+
+	p, decision, fresh = r.reserveProvider(plan.model, pr, true, exclude...)
+	if fresh != nil {
+		fresh.mu.Lock()
+		fresh.refreshUsed = true
+		fresh.mu.Unlock()
+	}
+	return p, decision, fresh, true
+}
+
+// planEntryRank orders the unconsumed tail into quote tiers: provider-confirmed
+// entries first (their quotes are the freshest state we have), unprobed and
+// legacy entries mid (today's ledger estimate — neither endorsed nor refuted),
+// demoted entries last (a live refusal, timeout, or dead transport outranks any
+// scan-time cost — but the entry stays consumable as a last resort because
+// ReserveNextFromPlan re-gates everything anyway, and a stale-negative quote
+// must not permanently strand a provider a refresh would re-offer).
+func planEntryRank(v PlanEntry) int {
+	switch {
+	case v.Demoted:
+		return 2
+	case v.Confirmed:
+		return 0
+	default:
+		return 1
+	}
+}
+
+// resortTailLocked re-ranks the unconsumed entries after a quote outcome:
+// tier first, ascending scan-time cost within the tier. Cost must be an
+// explicit secondary key (not left to sort stability): entries change tier in
+// quote-arrival order, so by the time a cheap entry is confirmed a costlier
+// one may already sit in the confirmed tier ahead of it — a stability-only
+// sort would freeze that inversion and BestConfirmedBackup would return the
+// wrong entry. Entries the cursor already consumed are never moved — they are
+// history (attempted set, telemetry), not candidates. Caller holds dp.mu.
+func (dp *DispatchPlan) resortTailLocked() {
+	tail := dp.entries[dp.cursor:]
+	sort.SliceStable(tail, func(i, j int) bool {
+		ri, rj := planEntryRank(tail[i].view), planEntryRank(tail[j].view)
+		if ri != rj {
+			return ri < rj
+		}
+		return tail[i].view.CostMs < tail[j].view.CostMs
+	})
+}
+
+// ConfirmEntry records an affirmative capacity_quote on the named unconsumed
+// entry: the provider's live TTFT quantiles, token headroom, and confidence
+// replace nothing (the scan-time estimates stay for telemetry) but ride
+// alongside for hedge timing, and the entry is promoted into the confirmed
+// tier. A no-op when the entry was already consumed or is not in the plan —
+// a quote that raced the dispatch loop carries no ordering work to do.
+func (dp *DispatchPlan) ConfirmEntry(providerID string, quote *protocol.CapacityQuoteMessage) {
+	if dp == nil || quote == nil {
+		return
+	}
+	dp.mu.Lock()
+	defer dp.mu.Unlock()
+	for i := dp.cursor; i < len(dp.entries); i++ {
+		v := &dp.entries[i].view
+		if v.ProviderID != providerID {
+			continue
+		}
+		v.Confirmed = true
+		v.Demoted = false
+		v.QuoteTTFTP50 = time.Duration(quote.TTFTP50MS * float64(time.Millisecond))
+		v.QuoteTTFTP90 = time.Duration(quote.TTFTP90MS * float64(time.Millisecond))
+		v.QuoteAvailableTokens = quote.AvailableTokenBudget
+		v.QuoteConfidence = quote.Confidence
+		dp.resortTailLocked()
+		return
+	}
+}
+
+// DemoteEntry pushes the named unconsumed entry into the last-resort tier —
+// the outcome for a negative quote, a probe timeout, or a transport failure.
+// Demotion wins over a prior confirmation (it is always the fresher signal:
+// quotes resolve their entry exactly once per probe, so a demote after a
+// confirm can only come from a later event such as a disconnect).
+func (dp *DispatchPlan) DemoteEntry(providerID string) {
+	if dp == nil {
+		return
+	}
+	dp.mu.Lock()
+	defer dp.mu.Unlock()
+	for i := dp.cursor; i < len(dp.entries); i++ {
+		v := &dp.entries[i].view
+		if v.ProviderID != providerID {
+			continue
+		}
+		v.Demoted = true
+		v.Confirmed = false
+		dp.resortTailLocked()
+		return
+	}
+}
+
+// BestConfirmedBackup returns the lowest-scan-cost unconsumed entry whose
+// quote confirmed admissibility, plus its quoted TTFT p90 — the hedge
+// scheduler's backup_ttft_q90 input (hedge_schedule.go). ok=false when no
+// confirmed entry remains; callers then fall back to the coordinator floor.
+// The tail is tier-sorted with cost order preserved inside the confirmed
+// tier, so the first confirmed entry IS the lowest-cost one.
+func (dp *DispatchPlan) BestConfirmedBackup() (providerID string, ttftP90 time.Duration, ok bool) {
+	if dp == nil {
+		return "", 0, false
+	}
+	dp.mu.Lock()
+	defer dp.mu.Unlock()
+	for i := dp.cursor; i < len(dp.entries); i++ {
+		if v := dp.entries[i].view; v.Confirmed {
+			return v.ProviderID, v.QuoteTTFTP90, true
+		}
+	}
+	return "", 0, false
+}
+
+// probeTargets snapshots the unconsumed, not-yet-quoted entries for the probe
+// fanout (ProbePlanCandidates). Copies of the planEntry pairs, taken under
+// dp.mu, so the fanout can inspect providers and mint probes without holding
+// the plan lock while entries concurrently re-rank.
+func (dp *DispatchPlan) probeTargets() []planEntry {
+	if dp == nil {
+		return nil
+	}
+	dp.mu.Lock()
+	defer dp.mu.Unlock()
+	targets := make([]planEntry, 0, len(dp.entries)-dp.cursor)
+	for _, e := range dp.entries[dp.cursor:] {
+		if e.view.Confirmed || e.view.Demoted {
+			continue
+		}
+		targets = append(targets, e)
+	}
+	return targets
+}

--- a/coordinator/registry/dispatch_plan_test.go
+++ b/coordinator/registry/dispatch_plan_test.go
@@ -1,0 +1,416 @@
+package registry
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+)
+
+// planTestProvider registers a token-budget provider whose routing cost is
+// dominated by its ActiveTokenBudgetUsed backlog (observed 80 tok/s →
+// 12.5 ms/token), so `used` steps of 400 tokens produce 5,000 ms cost gaps —
+// wider than nearTieCostWindowMs (3,000 ms) — making winner and plan order
+// fully deterministic under map iteration randomness.
+func planTestProvider(t *testing.T, reg *Registry, id, model string, usedTokens int64) *Provider {
+	t.Helper()
+	return makeTokenBudgetProvider(t, reg, id, model, 100, usedTokens, 1_000_000, 80)
+}
+
+func planTestRequest(id string, prompt, maxTok int) *PendingRequest {
+	return &PendingRequest{
+		RequestID:             id,
+		EstimatedPromptTokens: prompt,
+		RequestedMaxTokens:    maxTok,
+	}
+}
+
+func TestDispatchPlanRetainsBoundedLowestCostAlternates(t *testing.T) {
+	reg := New(testLogger())
+	model := "plan-bounded-model"
+	for i := range 12 {
+		planTestProvider(t, reg, fmt.Sprintf("p%02d", i), model, int64(i)*400)
+	}
+
+	pr := planTestRequest("plan-bounded", 500, 256)
+	pr.Model = model
+	p, _, plan := reg.ReserveProviderWithPlan(model, pr)
+	if p == nil || p.ID != "p00" {
+		t.Fatalf("winner=%v, want p00 (lowest backlog)", p)
+	}
+	if plan == nil {
+		t.Fatal("plan is nil on successful reservation")
+	}
+	if plan.Len() != dispatchPlanMaxAlternates {
+		t.Fatalf("plan.Len()=%d, want %d (bounded)", plan.Len(), dispatchPlanMaxAlternates)
+	}
+	for i, e := range plan.entries {
+		want := fmt.Sprintf("p%02d", i+1) // winner p00 excluded, ascending cost
+		if e.view.ProviderID != want {
+			t.Fatalf("entry[%d]=%q, want %q (ascending cost, winner excluded)", i, e.view.ProviderID, want)
+		}
+		if e.view.ProviderID == p.ID {
+			t.Fatalf("winner %q retained as alternate", p.ID)
+		}
+	}
+	if plan.EligibleCount() != 12 || plan.AdmissibleCount() != 12 || plan.DeadlineFeasibleCount() != 12 {
+		t.Fatalf("counts=%d/%d/%d, want 12/12/12",
+			plan.EligibleCount(), plan.AdmissibleCount(), plan.DeadlineFeasibleCount())
+	}
+	if next, ok := plan.PeekNext(); !ok || next.ProviderID != "p01" {
+		t.Fatalf("PeekNext=%+v ok=%v, want p01", next, ok)
+	}
+}
+
+func TestDispatchPlanSmallPoolRetainsAllNonWinners(t *testing.T) {
+	reg := New(testLogger())
+	model := "plan-small-model"
+	for i := range 3 {
+		planTestProvider(t, reg, fmt.Sprintf("s%d", i), model, int64(i)*400)
+	}
+
+	pr := planTestRequest("plan-small", 500, 256)
+	p, _, plan := reg.ReserveProviderWithPlan(model, pr)
+	if p == nil || plan == nil {
+		t.Fatalf("reservation failed: p=%v plan=%v", p, plan)
+	}
+	if plan.Len() != 2 {
+		t.Fatalf("plan.Len()=%d, want 2 (pool of 3 minus winner)", plan.Len())
+	}
+}
+
+func TestDispatchPlanAggregateCountsDescribeFullPool(t *testing.T) {
+	reg := New(testLogger())
+	model := "plan-counts-model"
+	for i := range 3 {
+		planTestProvider(t, reg, fmt.Sprintf("ok%d", i), model, int64(i)*400)
+	}
+	// Capacity-rejected: budget entirely consumed (eligible, not admissible).
+	makeTokenBudgetProvider(t, reg, "full", model, 100, 100_000, 100_000, 80)
+	// TTFT-rejected: decode 1 tok/s → prefill fallback 12 tok/s → ~42 s
+	// estimated TTFT, far over the 5 s ceiling (admissible, not feasible).
+	makeTokenBudgetProvider(t, reg, "slow", model, 1, 0, 100_000, 1)
+
+	pr := planTestRequest("plan-counts", 500, 256)
+	pr.MaxTTFTMs = 5_000
+	p, decision, plan := reg.ReserveProviderWithPlan(model, pr)
+	if p == nil || plan == nil {
+		t.Fatalf("reservation failed: decision=%+v", decision)
+	}
+	if decision.CandidateCount != 3 || decision.CapacityRejections != 1 || decision.TTFTRejections != 1 {
+		t.Fatalf("decision counts=%d/%d/%d, want 3 candidates, 1 capacity, 1 ttft",
+			decision.CandidateCount, decision.CapacityRejections, decision.TTFTRejections)
+	}
+	if plan.EligibleCount() != 5 || plan.AdmissibleCount() != 4 || plan.DeadlineFeasibleCount() != 3 {
+		t.Fatalf("counts=%d/%d/%d, want 5/4/3 (eligible ⊇ admissible ⊇ feasible)",
+			plan.EligibleCount(), plan.AdmissibleCount(), plan.DeadlineFeasibleCount())
+	}
+	if plan.Len() != 2 {
+		t.Fatalf("plan.Len()=%d, want 2 (only feasible non-winners retained)", plan.Len())
+	}
+}
+
+// TestReserveProviderWithPlanPrimarySelectionUnchanged pins the plan variant to
+// the exact selection ReserveProviderEx makes: same fleet, same request shape →
+// same winner and an identical RoutingDecision. Plan retention must be a pure
+// byproduct of the existing scan, never a selection fork.
+func TestReserveProviderWithPlanPrimarySelectionUnchanged(t *testing.T) {
+	model := "plan-equivalence-model"
+	build := func() *Registry {
+		reg := New(testLogger())
+		for i := range 6 {
+			planTestProvider(t, reg, fmt.Sprintf("e%d", i), model, int64(i)*400)
+		}
+		return reg
+	}
+
+	prA := planTestRequest("equiv", 500, 256)
+	pA, decA := build().ReserveProviderEx(model, prA)
+
+	prB := planTestRequest("equiv", 500, 256)
+	pB, decB, plan := build().ReserveProviderWithPlan(model, prB)
+
+	if pA == nil || pB == nil || pA.ID != pB.ID {
+		t.Fatalf("winners differ: ReserveProviderEx=%v ReserveProviderWithPlan=%v", pA, pB)
+	}
+	if decA != decB {
+		t.Fatalf("decisions differ:\n ex:   %+v\n plan: %+v", decA, decB)
+	}
+	if plan == nil || plan.Len() != 5 {
+		t.Fatalf("plan=%v, want 5 alternates", plan)
+	}
+}
+
+func TestReserveNextFromPlanReconnectInvalidatesRetainedIdentity(t *testing.T) {
+	reg := New(testLogger())
+	model := "plan-reconnect-model"
+	planTestProvider(t, reg, "w", model, 0)
+	planTestProvider(t, reg, "a1", model, 400)
+	a2 := planTestProvider(t, reg, "a2", model, 800)
+
+	pr := planTestRequest("reconnect", 500, 256)
+	p, _, plan := reg.ReserveProviderWithPlan(model, pr)
+	if p == nil || p.ID != "w" || plan.Len() != 2 {
+		t.Fatalf("setup failed: winner=%v plan.Len()=%d", p, plan.Len())
+	}
+
+	// a1's session drops and a new session registers under the same ID: the
+	// registry maps "a1" to a DIFFERENT *Provider, so the retained identity is
+	// dead even though the ID is live again.
+	reg.Disconnect("a1")
+	planTestProvider(t, reg, "a1", model, 400)
+
+	next, _, skips := reg.ReserveNextFromPlan(planTestRequest("reconnect-retry", 500, 256), plan)
+	if next == nil || next != a2 {
+		t.Fatalf("next=%v, want the retained a2 pointer", next)
+	}
+	if len(skips) != 1 || skips[0] != (PlanSkip{ProviderID: "a1", Reason: PlanSkipStaleSession}) {
+		t.Fatalf("skips=%+v, want single a1 stale_session", skips)
+	}
+}
+
+func TestReserveNextFromPlanSkipsGateRejectedEntry(t *testing.T) {
+	reg := New(testLogger())
+	model := "plan-gate-model"
+	planTestProvider(t, reg, "w", model, 0)
+	a1 := planTestProvider(t, reg, "a1", model, 400)
+	planTestProvider(t, reg, "a2", model, 800)
+
+	pr := planTestRequest("gate", 500, 256)
+	if p, _, plan := reg.ReserveProviderWithPlan(model, pr); p == nil || plan == nil {
+		t.Fatal("setup reservation failed")
+	} else {
+		// a1's budget fills between plan build and consumption: revalidation
+		// against CURRENT state (freeMemoryAdmits via buildCandidateWithReason)
+		// must skip it without any dispatch.
+		a1.mu.Lock()
+		a1.BackendCapacity.Slots[0].ActiveTokenBudgetUsed = 1_000_000
+		a1.mu.Unlock()
+
+		next, _, skips := reg.ReserveNextFromPlan(planTestRequest("gate-retry", 500, 256), plan)
+		if next == nil || next.ID != "a2" {
+			t.Fatalf("next=%v, want a2", next)
+		}
+		if len(skips) != 1 || skips[0] != (PlanSkip{ProviderID: "a1", Reason: PlanSkipGateRejected}) {
+			t.Fatalf("skips=%+v, want single a1 gate_rejected", skips)
+		}
+	}
+}
+
+func TestReserveNextFromPlanHonorsExclusions(t *testing.T) {
+	reg := New(testLogger())
+	model := "plan-exclude-model"
+	planTestProvider(t, reg, "w", model, 0)
+	planTestProvider(t, reg, "a1", model, 400)
+	planTestProvider(t, reg, "a2", model, 800)
+
+	pr := planTestRequest("exclude", 500, 256)
+	_, _, plan := reg.ReserveProviderWithPlan(model, pr)
+	if plan == nil {
+		t.Fatal("setup reservation failed")
+	}
+
+	next, _, skips := reg.ReserveNextFromPlan(planTestRequest("exclude-retry", 500, 256), plan, "a1")
+	if next == nil || next.ID != "a2" {
+		t.Fatalf("next=%v, want a2 (a1 excluded)", next)
+	}
+	if len(skips) != 1 || skips[0] != (PlanSkip{ProviderID: "a1", Reason: PlanSkipExcluded}) {
+		t.Fatalf("skips=%+v, want single a1 excluded", skips)
+	}
+}
+
+func TestReserveNextFromPlanExhausted(t *testing.T) {
+	reg := New(testLogger())
+	model := "plan-exhausted-model"
+	planTestProvider(t, reg, "w", model, 0)
+	planTestProvider(t, reg, "a1", model, 400)
+
+	pr := planTestRequest("exhaust", 500, 256)
+	_, _, plan := reg.ReserveProviderWithPlan(model, pr)
+	if next, _, _ := reg.ReserveNextFromPlan(planTestRequest("exhaust-1", 500, 256), plan); next == nil || next.ID != "a1" {
+		t.Fatalf("first consumption=%v, want a1", next)
+	}
+
+	next, _, skips := reg.ReserveNextFromPlan(planTestRequest("exhaust-2", 500, 256), plan)
+	if next != nil {
+		t.Fatalf("next=%v, want nil on exhausted plan", next)
+	}
+	if len(skips) != 1 || skips[0].Reason != PlanSkipExhausted {
+		t.Fatalf("skips=%+v, want terminal exhausted", skips)
+	}
+}
+
+func TestRefreshDispatchPlanExcludesAttemptedAndRunsOnce(t *testing.T) {
+	reg := New(testLogger())
+	model := "plan-refresh-model"
+	planTestProvider(t, reg, "w", model, 0)
+	planTestProvider(t, reg, "a1", model, 400)
+	planTestProvider(t, reg, "a2", model, 800)
+	planTestProvider(t, reg, "a3", model, 1200)
+
+	p, _, plan := reg.ReserveProviderWithPlan(model, planTestRequest("refresh", 500, 256))
+	if p == nil || p.ID != "w" || plan.Len() != 3 {
+		t.Fatalf("setup failed: winner=%v plan.Len()=%d", p, plan.Len())
+	}
+	if next, _, _ := reg.ReserveNextFromPlan(planTestRequest("refresh-1", 500, 256), plan); next == nil || next.ID != "a1" {
+		t.Fatalf("plan consumption=%v, want a1", next)
+	}
+
+	// Refresh re-scans excluding every attempted provider (w, a1): the fresh
+	// winner must be a2 and the fresh plan holds only a3, with the single
+	// refresh consumed on both plans.
+	fp, _, fresh, performed := reg.RefreshDispatchPlan(planTestRequest("refresh-2", 500, 256), plan)
+	if !performed {
+		t.Fatal("refresh not performed")
+	}
+	if fp == nil || fp.ID != "a2" {
+		t.Fatalf("refresh winner=%v, want a2 (w and a1 attempted)", fp)
+	}
+	if fresh == nil || fresh.Len() != 1 || fresh.entries[0].view.ProviderID != "a3" {
+		t.Fatalf("fresh plan=%+v, want single a3 alternate", fresh)
+	}
+	if !plan.RefreshUsed() || !fresh.RefreshUsed() {
+		t.Fatal("refresh flag not consumed on both plans")
+	}
+	if _, _, _, again := reg.RefreshDispatchPlan(planTestRequest("refresh-3", 500, 256), plan); again {
+		t.Fatal("second refresh of the original plan performed")
+	}
+	if _, _, _, again := reg.RefreshDispatchPlan(planTestRequest("refresh-4", 500, 256), fresh); again {
+		t.Fatal("refresh of the refreshed plan performed")
+	}
+}
+
+// TestConcurrentPlanReservationsCannotExceedAdmission: two requests hold plans
+// naming the same alternate whose reported budget fits exactly one of them.
+// Concurrent ReserveNextFromPlan calls serialize under the r.mu write lock and
+// each re-runs freeMemoryAdmits against the live pending set, so exactly one
+// may land — the plan path cannot over-admit past the provider's budget.
+func TestConcurrentPlanReservationsCannotExceedAdmission(t *testing.T) {
+	reg := New(testLogger())
+	model := "plan-concurrent-model"
+	// Cheap primary with ample budget; alternate pB fits ONE 2,500-token
+	// request (560 used + 2×2,500 > 4,000). pB's 7,000 ms backlog keeps pA the
+	// deterministic primary even with one pending (3,750 ms, outside the
+	// 3,000 ms near-tie window).
+	pA := planTestProvider(t, reg, "pA", model, 0)
+	makeTokenBudgetProvider(t, reg, "pB", model, 100, 560, 4_000, 80)
+
+	pr1 := planTestRequest("c1", 1_000, 1_500)
+	p1, _, plan1 := reg.ReserveProviderWithPlan(model, pr1)
+	pr2 := planTestRequest("c2", 1_000, 1_500)
+	p2, _, plan2 := reg.ReserveProviderWithPlan(model, pr2)
+	if p1 == nil || p2 == nil || p1.ID != "pA" || p2.ID != "pA" {
+		t.Fatalf("primaries=%v/%v, want pA/pA", p1, p2)
+	}
+	if plan1.Len() != 1 || plan2.Len() != 1 {
+		t.Fatalf("plan lengths=%d/%d, want 1/1 (pB only)", plan1.Len(), plan2.Len())
+	}
+	// Primary failed for both requests: release pA and fail over to the plans.
+	pA.RemovePending("c1")
+	pA.RemovePending("c2")
+
+	type result struct {
+		p     *Provider
+		skips []PlanSkip
+	}
+	results := make([]result, 2)
+	var wg sync.WaitGroup
+	for i, plan := range []*DispatchPlan{plan1, plan2} {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			pr := planTestRequest(fmt.Sprintf("c%d-retry", i+1), 1_000, 1_500)
+			p, _, skips := reg.ReserveNextFromPlan(pr, plan, "pA")
+			results[i] = result{p: p, skips: skips}
+		}()
+	}
+	wg.Wait()
+
+	wins := 0
+	for _, res := range results {
+		if res.p != nil {
+			if res.p.ID != "pB" {
+				t.Fatalf("winner=%v, want pB", res.p)
+			}
+			wins++
+			continue
+		}
+		if len(res.skips) != 2 || res.skips[0].Reason != PlanSkipGateRejected ||
+			res.skips[1].Reason != PlanSkipExhausted {
+			t.Fatalf("loser skips=%+v, want gate_rejected then exhausted", res.skips)
+		}
+	}
+	if wins != 1 {
+		t.Fatalf("wins=%d, want exactly 1 (budget fits one request)", wins)
+	}
+}
+
+// TestConcurrentReservationsCannotDoubleSpendReportedBudget pins the existing
+// in-flight ledger end-to-end: reservations serialize under the r.mu write
+// lock and addPendingLocked's entry is charged by the very next admission read
+// (fillSnapshotPendingAndPool → freeMemoryAdmits' coordinatorExtra), so two
+// concurrent requests can never both spend the same reported
+// active_token_budget headroom in the heartbeat gap.
+func TestConcurrentReservationsCannotDoubleSpendReportedBudget(t *testing.T) {
+	reg := New(testLogger())
+	model := "ledger-concurrent-model"
+	// Budget 3,900; requests of 2,500 and 1,500 tokens sum to 4,000 — whichever
+	// serializes first fits, the other must see its debit and be rejected.
+	makeTokenBudgetProvider(t, reg, "ledger", model, 100, 0, 3_900, 80)
+
+	shapes := []struct{ prompt, maxTok int }{{1_000, 1_500}, {500, 1_000}}
+	selected := make([]*Provider, 2)
+	var wg sync.WaitGroup
+	for i, shape := range shapes {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			pr := planTestRequest(fmt.Sprintf("ledger-%d", i), shape.prompt, shape.maxTok)
+			selected[i], _ = reg.ReserveProviderEx(model, pr)
+		}()
+	}
+	wg.Wait()
+
+	wins := 0
+	for _, p := range selected {
+		if p != nil {
+			wins++
+		}
+	}
+	if wins != 1 {
+		t.Fatalf("wins=%d, want exactly 1 of two concurrent reservations against one budget", wins)
+	}
+}
+
+// TestHeartbeatResyncRestoresProviderReportedTruth: while a reservation is in
+// the heartbeat dark window, its coordinator-side debit gates admission; once
+// the provider's heartbeat reports the admitted work, committedTokenBudget
+// covers the pending entry and coordinatorExtra drops to zero — the same
+// in-flight tokens are charged exactly once, per the provider's own report.
+func TestHeartbeatResyncRestoresProviderReportedTruth(t *testing.T) {
+	reg := New(testLogger())
+	model := "ledger-resync-model"
+	p := makeTokenBudgetProvider(t, reg, "resync", model, 100, 0, 3_900, 80)
+
+	// Dark window: A (2,500 tokens) reserves; its pending debit must reject
+	// B (1,500 tokens: 2,500 + 1,500 > 3,900) even though the heartbeat still
+	// reports zero budget used.
+	if sel, _ := reg.ReserveProviderEx(model, planTestRequest("resync-a", 1_000, 1_500)); sel == nil {
+		t.Fatal("request A did not reserve")
+	}
+	if sel, decision := reg.ReserveProviderEx(model, planTestRequest("resync-b", 500, 1_000)); sel != nil {
+		t.Fatalf("request B reserved past the pending debit: %+v", decision)
+	} else if decision.CapacityRejections != 1 {
+		t.Fatalf("decision=%+v, want 1 capacity rejection", decision)
+	}
+
+	// Heartbeat re-sync: the provider now reports A's 2,500 tokens as active.
+	// A is STILL coordinator-pending, but committedTokenBudget covers it, so a
+	// 1,400-token request fits the remaining 3,900-2,500 exactly — the debit
+	// is not double-counted on top of the provider's report.
+	p.mu.Lock()
+	p.BackendCapacity.Slots[0].ActiveTokenBudgetUsed = 2_500
+	p.mu.Unlock()
+	if sel, decision := reg.ReserveProviderEx(model, planTestRequest("resync-c", 400, 1_000)); sel == nil {
+		t.Fatalf("request C rejected after heartbeat re-sync: %+v", decision)
+	}
+}

--- a/coordinator/registry/dispatch_plan_test.go
+++ b/coordinator/registry/dispatch_plan_test.go
@@ -414,3 +414,96 @@ func TestHeartbeatResyncRestoresProviderReportedTruth(t *testing.T) {
 		t.Fatalf("request C rejected after heartbeat re-sync: %+v", decision)
 	}
 }
+
+// TestReserveNextFromPlanVersionDiverseRetry pins the soft two-pass
+// AvoidVersion rule on plan consumption (codex P1: a retry populated
+// pr.Traits.AvoidVersion, but revalidation walked the plan in raw cost order
+// and re-dispatched onto the failed build even when a diverse entry
+// remained). Versions are set AFTER the plan is built: the pass must read the
+// provider's LIVE reported version, never a scan-time copy.
+func TestReserveNextFromPlanVersionDiverseRetry(t *testing.T) {
+	reg := New(testLogger())
+	model := "plan-avoid-version-model"
+	planTestProvider(t, reg, "w", model, 0)
+	planTestProvider(t, reg, "a1", model, 400)
+	planTestProvider(t, reg, "a2", model, 800)
+
+	pr := planTestRequest("avoid-primary", 500, 256)
+	pr.Model = model
+	if p, _, plan := reg.ReserveProviderWithPlan(model, pr); p == nil || p.ID != "w" || plan == nil {
+		t.Fatalf("primary=%v, want w with a plan", p)
+	} else {
+		// Live versions diverge after the scan: the cheaper alternate a1 runs
+		// the version the retry must avoid; a2 runs a different build.
+		setProviderVersion(reg.GetProvider("a1"), "0.6.4")
+		setProviderVersion(reg.GetProvider("a2"), "0.6.5")
+
+		retry := planTestRequest("avoid-retry", 500, 256)
+		retry.Traits.AvoidVersion = "0.6.4"
+		next, _, skips := reg.ReserveNextFromPlan(retry, plan)
+		if next == nil || next.ID != "a2" {
+			t.Fatalf("next=%v, want a2 (the diverse version)", next)
+		}
+		if len(skips) != 1 || skips[0] != (PlanSkip{ProviderID: "a1", Reason: PlanSkipVersionAvoided}) {
+			t.Fatalf("skips=%+v, want single a1 version_avoided", skips)
+		}
+	}
+}
+
+// When every remaining entry runs the avoided version, diversity must fall
+// back to the same-version pool (cost order) rather than failing closed —
+// parity with scanCandidatesLocked's soft narrowing.
+func TestReserveNextFromPlanAvoidVersionNeverFailsClosed(t *testing.T) {
+	reg := New(testLogger())
+	model := "plan-avoid-all-model"
+	planTestProvider(t, reg, "w", model, 0)
+	planTestProvider(t, reg, "a1", model, 400)
+	planTestProvider(t, reg, "a2", model, 800)
+
+	pr := planTestRequest("avoid-all-primary", 500, 256)
+	pr.Model = model
+	_, _, plan := reg.ReserveProviderWithPlan(model, pr)
+	if plan == nil {
+		t.Fatal("plan is nil")
+	}
+	setProviderVersion(reg.GetProvider("a1"), "0.6.4")
+	setProviderVersion(reg.GetProvider("a2"), "0.6.4")
+
+	retry := planTestRequest("avoid-all-retry", 500, 256)
+	retry.Traits.AvoidVersion = "0.6.4"
+	next, _, skips := reg.ReserveNextFromPlan(retry, plan)
+	if next == nil || next.ID != "a1" {
+		t.Fatalf("next=%v, want a1 (cost-order fallback onto the avoided version)", next)
+	}
+	if len(skips) != 0 {
+		t.Fatalf("skips=%+v, want none (fallback entries reserve with their own outcome)", skips)
+	}
+}
+
+// An empty AvoidVersion must leave plan consumption byte-identical to the
+// single-pass behavior: pure cost order, no deferral, no version skips.
+func TestReserveNextFromPlanNoAvoidVersionUnchanged(t *testing.T) {
+	reg := New(testLogger())
+	model := "plan-no-avoid-model"
+	planTestProvider(t, reg, "w", model, 0)
+	planTestProvider(t, reg, "a1", model, 400)
+	planTestProvider(t, reg, "a2", model, 800)
+
+	pr := planTestRequest("no-avoid-primary", 500, 256)
+	pr.Model = model
+	_, _, plan := reg.ReserveProviderWithPlan(model, pr)
+	if plan == nil {
+		t.Fatal("plan is nil")
+	}
+	setProviderVersion(reg.GetProvider("a1"), "0.6.4")
+	setProviderVersion(reg.GetProvider("a2"), "0.6.5")
+
+	retry := planTestRequest("no-avoid-retry", 500, 256)
+	next, _, skips := reg.ReserveNextFromPlan(retry, plan)
+	if next == nil || next.ID != "a1" {
+		t.Fatalf("next=%v, want a1 (plain cost order)", next)
+	}
+	if len(skips) != 0 {
+		t.Fatalf("skips=%+v, want none", skips)
+	}
+}

--- a/coordinator/registry/queue.go
+++ b/coordinator/registry/queue.go
@@ -382,6 +382,60 @@ func (q *RequestQueue) QueueSize(model string) int {
 	return len(q.queues[model])
 }
 
+// CompetingQueueDepth counts the queued waiters for a model whose routing
+// constraints could overlap the capacity available to pr — the hedge
+// governor's "queued consumers outrank insurance" input. A raw QueueSize
+// over-suppresses: a waiter that structurally CANNOT drain onto the pool a
+// hedge for pr would consume is not a competing consumer, and counting it
+// starves every public request of hedges for the waiter's whole queue stay
+// (codex P2). Excluded:
+//
+//   - exclusive self-route waiters (Pending.SelfRouteOnly): they drain only
+//     onto their owner's machines and never fall back to the public fleet,
+//     so public capacity spent on a hedge takes nothing from them;
+//   - serial-pinned waiters (Pending.AllowedProviderSerials) whose allowlist
+//     does not intersect pr's own: they can only consume their pinned
+//     providers. When pr is itself pinned to an overlapping set the two
+//     demonstrably compete for the same pool and the waiter counts.
+//
+// A waiter with a nil Pending has an unconstrained shape and counts
+// conservatively. pr == nil means "no constraint context": only the
+// structural self-route/serial-pinned exclusions apply.
+func (q *RequestQueue) CompetingQueueDepth(model string, pr *PendingRequest) int {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	depth := 0
+	for _, req := range q.queues[model] {
+		w := req.Pending
+		if w == nil {
+			depth++
+			continue
+		}
+		if w.SelfRouteOnly {
+			continue
+		}
+		if len(w.AllowedProviderSerials) > 0 &&
+			(pr == nil || !serialSetsIntersect(w.AllowedProviderSerials, pr.AllowedProviderSerials)) {
+			continue
+		}
+		depth++
+	}
+	return depth
+}
+
+// serialSetsIntersect reports whether two attested-serial allowlists share a
+// serial. Sized for the tiny per-request lists routing carries; no map.
+func serialSetsIntersect(a, b []string) bool {
+	for _, s := range a {
+		for _, t := range b {
+			if s == t && s != "" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func (q *RequestQueue) QueueStats(model string) (depth int, oldestAge time.Duration) {
 	q.mu.Lock()
 	defer q.mu.Unlock()

--- a/coordinator/registry/queue_test.go
+++ b/coordinator/registry/queue_test.go
@@ -299,6 +299,59 @@ func TestFailQueuedRequestsForModelSkipsSelfRoute(t *testing.T) {
 	}
 }
 
+// TestCompetingQueueDepth pins the routing-compatibility filter behind the
+// hedge governor's queued-demand input: only waiters that could drain onto
+// capacity available to the probing request count.
+func TestCompetingQueueDepth(t *testing.T) {
+	q := NewRequestQueue(10, 30*time.Second)
+	model := "queue-competing"
+
+	add := func(id string, pending *PendingRequest) {
+		t.Helper()
+		if err := q.Enqueue(&QueuedRequest{
+			RequestID:  id,
+			Model:      model,
+			ResponseCh: make(chan *Provider, 1),
+			Pending:    pending,
+		}); err != nil {
+			t.Fatalf("enqueue %s: %v", id, err)
+		}
+	}
+	add("pub", &PendingRequest{RequestID: "pub", Model: model})
+	add("self", &PendingRequest{RequestID: "self", Model: model, SelfRouteOnly: true, OwnerAccountID: "acct-A"})
+	add("pinned", &PendingRequest{RequestID: "pinned", Model: model, AllowedProviderSerials: []string{"SER-1"}})
+	add("nilpending", nil)
+
+	// Unconstrained request: the public waiter and the conservative
+	// nil-Pending waiter compete; self-route and serial-pinned do not.
+	public := &PendingRequest{RequestID: "probe", Model: model}
+	if depth := q.CompetingQueueDepth(model, public); depth != 2 {
+		t.Fatalf("public depth = %d, want 2 (pub + nil-Pending)", depth)
+	}
+
+	// Overlapping-pinned request: the pinned waiter now competes too.
+	overlapping := &PendingRequest{RequestID: "probe-pin", Model: model, AllowedProviderSerials: []string{"SER-1", "SER-2"}}
+	if depth := q.CompetingQueueDepth(model, overlapping); depth != 3 {
+		t.Fatalf("overlapping-pinned depth = %d, want 3", depth)
+	}
+
+	// Disjoint-pinned request: back to 2 — the SER-1 waiter cannot use its pool.
+	disjoint := &PendingRequest{RequestID: "probe-dis", Model: model, AllowedProviderSerials: []string{"SER-9"}}
+	if depth := q.CompetingQueueDepth(model, disjoint); depth != 2 {
+		t.Fatalf("disjoint-pinned depth = %d, want 2", depth)
+	}
+
+	// No constraint context (nil pr): only structural exclusions apply.
+	if depth := q.CompetingQueueDepth(model, nil); depth != 2 {
+		t.Fatalf("nil-pr depth = %d, want 2", depth)
+	}
+
+	// QueueSize stays the raw count.
+	if q.QueueSize(model) != 4 {
+		t.Fatalf("QueueSize = %d, want 4", q.QueueSize(model))
+	}
+}
+
 // TestFailQueuedRequestsForModelSkipsEligiblePreferOwner verifies a prefer
 // waiter whose owner HAS an owned provider for the model survives a
 // public-unservable verdict (its own busy machine may free up).

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -842,6 +842,20 @@ type Provider struct {
 	// Live backend capacity from heartbeats (nil for providers without capacity reporting)
 	BackendCapacity *protocol.BackendCapacity
 
+	// capacitySeq is the highest BackendCapacity.CapacitySeq applied on THIS
+	// connection; capacityQuoteCapable latches true the first time a heartbeat
+	// carries seq > 0 (routing v2 W2: seq-stamping providers also answer
+	// capacity probes — see protocol/messages.go CapacitySeq).
+	//
+	// Per-connection on purpose: the provider process restarts its counter on
+	// every reconnect, and Register creates a fresh *Provider per connection
+	// (see the CodeAttested field's contract), so both fields reset to their
+	// zero values with the object — a reconnected provider's seq 1 is never
+	// compared against the previous connection's high-water mark. Guarded by
+	// p.mu.
+	capacitySeq          uint64
+	capacityQuoteCapable bool
+
 	// kvBackends is the last KV-cache backend observation each SLOT (keyed by
 	// model) named on a heartbeat — the resolved kind AND, when the slot
 	// degraded, why — for the v0.8.0 paged rollout's per-backend segmentation.
@@ -1906,6 +1920,12 @@ type Registry struct {
 	// or one missed heartbeat doesn't mass-reap a live fleet. Guarded by r.mu;
 	// rebuilt each sweep so disconnected providers drop out automatically.
 	evictStrikes map[string]int
+
+	// capacityQuotes correlates outstanding capacity probes with their quotes
+	// by quote_id (routing v2 W2). Value field with an internal LEAF mutex and
+	// a lazily-created map, so bare &Registry{} test constructions work
+	// without New(). See capacity_quotes.go.
+	capacityQuotes quoteTracker
 
 	cacheRouting                *cacheRoutingTracker
 	cacheActivation             *cacheActivationGate
@@ -3478,6 +3498,42 @@ func (r *Registry) Heartbeat(id string, msg *protocol.HeartbeatMessage) {
 	warmModels, currentModel, backendCapacity := canonicalHeartbeatModelState(
 		eligibleModels, msg.WarmModels, msg.ActiveModel, msg.BackendCapacity)
 	r.mu.RUnlock()
+	// Routing v2 W2 — capacity_seq gate. Event-triggered heartbeats share the
+	// bounded data lane with the 5s baseline, so an event frame published
+	// AFTER a baseline frame can be decoded BEFORE it (two frames in the
+	// writer queue, read-loop dispatch order vs. publish order is not the
+	// coordinator's to assume). Applying the older snapshot second would
+	// regress fresher slot/budget state — exactly the staleness window the
+	// event heartbeats exist to close. Seq ordering is per-connection: a
+	// reconnect restarts the provider's counter AND creates a fresh *Provider
+	// (capacitySeq zero), so cross-connection comparisons never happen.
+	//
+	// The gate reads msg.BackendCapacity (the wire truth) rather than the
+	// canonicalized copy: canonicalization can drop slots but never reorders
+	// frames. Seq 0/omitted is a legacy provider — every legacy heartbeat
+	// takes the unguarded path below, byte-identical to today.
+	if msg.BackendCapacity != nil && msg.BackendCapacity.CapacitySeq > 0 {
+		if msg.BackendCapacity.CapacitySeq <= p.capacitySeq {
+			// Stale/reordered frame: discard the ENTIRE application — capacity,
+			// KV/TPS observations, warm/current model, status, and the clamp
+			// release proof all derive from this one out-of-date snapshot.
+			// LastHeartbeat still advances: the frame proves the connection is
+			// alive, and eviction must key on liveness, not snapshot ordering.
+			// Uptime credit and stats deltas are deliberately NOT applied — a
+			// fresher frame just applied them microseconds ago (that is the
+			// only way this branch is reachable), so nothing is lost.
+			appliedSeq := p.capacitySeq
+			p.LastHeartbeat = time.Now()
+			p.mu.Unlock()
+			r.logger.Debug("discarding stale capacity heartbeat",
+				"provider_id", id, "seq", msg.BackendCapacity.CapacitySeq, "applied_seq", appliedSeq)
+			return
+		}
+		p.capacitySeq = msg.BackendCapacity.CapacitySeq
+		// Seq-stamping providers implement the wave-2 capacity protocol:
+		// mark the session quote-capable so the probe fanout can find it.
+		p.capacityQuoteCapable = true
+	}
 	// Clamp only after unknown slot identifiers have been removed. Besides
 	// keeping them out of routing state, this prevents an unaccepted model ID
 	// from reaching clamp diagnostics or TPS/KV observations.
@@ -4487,6 +4543,13 @@ func (r *Registry) Disconnect(id string) {
 	// Cache holders and nonce-bound attempts are connection-scoped. Clear them
 	// after releasing registry/provider locks.
 	r.cacheRouting.disconnect(id, cacheHolderRemovalDisconnect)
+	// Outstanding capacity-probe waiters bound to this connection can never be
+	// answered now (the socket is gone) — resolve them as SendFailed so probe
+	// collectors demote the entries immediately instead of burning the full
+	// quote window. Like the cache-holder cleanup above, this runs after the
+	// registry/provider locks are released (quoteTracker has its own leaf
+	// mutex; see capacity_quotes.go).
+	r.capacityQuotes.failProvider(id)
 
 	// Close all pending request channels so consumers get errors. Pending
 	// requests created by tests may leave these channels nil, and consumer

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -366,8 +366,40 @@ func (r *Registry) ReserveProvider(model string, pr *PendingRequest, excludeIDs 
 // Prometheus counters/histograms without the registry needing to import
 // the metrics package.
 func (r *Registry) ReserveProviderEx(model string, pr *PendingRequest, excludeIDs ...string) (*Provider, RoutingDecision) {
+	p, decision, _ := r.reserveProvider(model, pr, false, excludeIDs...)
+	return p, decision
+}
+
+// reserveProvider is the single selection+reservation implementation behind
+// ReserveProviderEx and ReserveProviderWithPlan (dispatch_plan.go). wantPlan
+// additionally retains a bounded DispatchPlan of provisional alternates drawn
+// from the SAME scan that picked the winner — the plan is a byproduct of the
+// one existing pass, never a second scan — and is nil whenever no provider is
+// reserved. Selection and reservation are byte-for-byte identical in both
+// modes; wantPlan=false skips plan construction entirely so legacy callers
+// pay nothing.
+//
+// In-flight token-budget ledger: the reservation itself IS the debit. The
+// r.mu WRITE lock below is held for the whole selection+reservation, so
+// reservations serialize fleet-wide, and addPendingLocked records the request
+// in p.pendingReqs before the lock is released. The reader that consults the
+// debit is the admission gate itself: every subsequent scan's
+// fillSnapshotPendingAndPool aggregates the pending prompt+max token budgets,
+// and freeMemoryAdmits charges them against the last-reported
+// active_token_budget (coordinatorExtra) and the reconstructed whole-box pool
+// (pooledBudgetAdmits) — so concurrent reservations between heartbeats cannot
+// double-spend the same reported headroom. Heartbeat re-sync makes the debit
+// safe rather than double-counting: coordinatorExtra subtracts
+// committedTokenBudget (the provider's own active/queued/potential report),
+// so as heartbeats begin reporting the admitted work the coordinator-side
+// charge for it shrinks to zero — in-flight work is charged exactly once,
+// provider-reported when known, coordinator-estimated only in the dark window.
+// Completion/cancel credits via RemovePending, disconnect drops the whole
+// pending set, and the budget clamp (budget_clamp.go) remains the backstop
+// for stale-optimistic reports.
+func (r *Registry) reserveProvider(model string, pr *PendingRequest, wantPlan bool, excludeIDs ...string) (*Provider, RoutingDecision, *DispatchPlan) {
 	if pr == nil || pr.RequestID == "" {
-		return nil, RoutingDecision{Model: model}
+		return nil, RoutingDecision{Model: model}, nil
 	}
 	if pr.Model == "" {
 		pr.Model = model
@@ -408,17 +440,17 @@ func (r *Registry) ReserveProviderEx(model string, pr *PendingRequest, excludeID
 		pr.CacheSelectionMode = ""
 	}
 
-	selected, candidateCount, capacityRejections, tooLargeRejections, visionRejections, ttftRejections, bestTTFTMs := r.selectBestCandidateLockedFull(model, pr, excludeIDs...)
+	selected, scan := r.selectBestCandidateLockedFull(model, pr, excludeIDs...)
 	if selected == nil {
 		return nil, RoutingDecision{
 			Model:                   model,
-			CandidateCount:          candidateCount,
-			CapacityRejections:      capacityRejections,
-			ModelTooLargeRejections: tooLargeRejections,
-			VisionRejections:        visionRejections,
-			TTFTRejections:          ttftRejections,
-			BestTTFTMs:              bestTTFTMs,
-		}
+			CandidateCount:          scan.candidateCount,
+			CapacityRejections:      scan.capacityRejections,
+			ModelTooLargeRejections: scan.tooLargeRejections,
+			VisionRejections:        scan.visionRejections,
+			TTFTRejections:          scan.ttftRejections,
+			BestTTFTMs:              scan.bestTTFTMs,
+		}, nil
 	}
 
 	// Phase-0 shadow TTFT evaluation: computed here (r.mu held, no provider lock
@@ -471,13 +503,13 @@ func (r *Registry) ReserveProviderEx(model string, pr *PendingRequest, excludeID
 		(pr.RequiresVision && !r.providerServesVisionModelLocked(p, model, relaxTrust)) {
 		return nil, RoutingDecision{
 			Model:                   model,
-			CandidateCount:          candidateCount,
-			CapacityRejections:      capacityRejections,
-			ModelTooLargeRejections: tooLargeRejections,
-			VisionRejections:        visionRejections,
-			TTFTRejections:          ttftRejections,
-			BestTTFTMs:              bestTTFTMs,
-		}
+			CandidateCount:          scan.candidateCount,
+			CapacityRejections:      scan.capacityRejections,
+			ModelTooLargeRejections: scan.tooLargeRejections,
+			VisionRejections:        scan.visionRejections,
+			TTFTRejections:          scan.ttftRejections,
+			BestTTFTMs:              scan.bestTTFTMs,
+		}, nil
 	}
 
 	bd := selected.breakdown
@@ -526,12 +558,12 @@ func (r *Registry) ReserveProviderEx(model string, pr *PendingRequest, excludeID
 		CapacityRateMs:            bd.CapacityRateMs,
 		CapacityRejectRate:        selected.capacityRejectRate,
 		EffectiveQueue:            selected.effectiveQueue,
-		CandidateCount:            candidateCount,
-		CapacityRejections:        capacityRejections,
-		ModelTooLargeRejections:   tooLargeRejections,
-		VisionRejections:          visionRejections,
-		TTFTRejections:            ttftRejections,
-		BestTTFTMs:                bestTTFTMs,
+		CandidateCount:            scan.candidateCount,
+		CapacityRejections:        scan.capacityRejections,
+		ModelTooLargeRejections:   scan.tooLargeRejections,
+		VisionRejections:          scan.visionRejections,
+		TTFTRejections:            scan.ttftRejections,
+		BestTTFTMs:                scan.bestTTFTMs,
 		TTFTMs:                    bd.TTFTMs,
 		CacheTier:                 selected.cacheTier,
 		CacheDiscountMs:           bd.CacheDiscountMs,
@@ -540,7 +572,16 @@ func (r *Registry) ReserveProviderEx(model string, pr *PendingRequest, excludeID
 		StaticTPS:                 selected.snapshot.decodeTPS,
 	}
 	shadowEval.applyTo(&decision)
-	return p, decision
+	// Plan retention (Routing v2 Phase 3): capture up to
+	// dispatchPlanMaxAlternates lowest-cost non-winner candidates from the SAME
+	// scan pool the selector just ranked, plus the full-pool aggregate tallies.
+	// Built only after the winner's reservation committed, so a rejected admit
+	// re-check never leaks a plan; skipped entirely for legacy callers.
+	var plan *DispatchPlan
+	if wantPlan {
+		plan = newDispatchPlan(model, scan, selected)
+	}
+	return p, decision, plan
 }
 
 // selectBestCandidateLockedFull is the full-fidelity selection that
@@ -549,8 +590,9 @@ func (r *Registry) ReserveProviderEx(model string, pr *PendingRequest, excludeID
 // distinguish "no provider serves this model" from "every fitting
 // provider is over-subscribed", which is the difference between the
 // no_provider and over_capacity outcome counters.
-// Returns (winner, candidateCount, capacityRejections, modelTooLargeRejections,
-// visionRejections, ttftRejections, bestTTFTMs).
+// Returns the winner plus the candidateScan of the pass that produced it, so
+// the caller can read the rejection tallies AND (for plan retention) the
+// ranked pool itself without a second scan.
 //
 // FAIL-OPEN SAFETY VALVE: selection runs in two passes. Pass 1 honors the
 // per-provider node-health breaker. If pass 1 finds ZERO candidates AND the
@@ -564,19 +606,18 @@ func (r *Registry) ReserveProviderEx(model string, pr *PendingRequest, excludeID
 // when it yields a candidate, and its counters (not pass 1's) are returned so
 // metrics are never double-counted. This mirrors servability.go's fail-open
 // philosophy: when in doubt, keep serving.
-func (r *Registry) selectBestCandidateLockedFull(model string, pr *PendingRequest, excludeIDs ...string) (*routingCandidate, int, int, int, int, int, float64) {
-	winner, candidateCount, capacityRejections, tooLargeRejections, visionRejections, ttftRejections, bestTTFTMs, breakerRejected :=
-		r.selectBestCandidateScanLocked(model, pr, false, excludeIDs...)
-	if !shouldBypassBreakerFailOpen(winner, breakerRejected, capacityRejections, ttftRejections) {
-		return winner, candidateCount, capacityRejections, tooLargeRejections, visionRejections, ttftRejections, bestTTFTMs
+func (r *Registry) selectBestCandidateLockedFull(model string, pr *PendingRequest, excludeIDs ...string) (*routingCandidate, candidateScan) {
+	winner, scan := r.selectBestCandidateScanLocked(model, pr, false, excludeIDs...)
+	if !shouldBypassBreakerFailOpen(winner, scan.breakerRejected, scan.capacityRejections, scan.ttftRejections) {
+		return winner, scan
 	}
 	// The node-health breaker is the SOLE reason this request has no route: re-scan
 	// with the breaker bypassed. Use pass 2 only when it actually finds a candidate,
 	// so a genuinely empty fleet still reports pass 1's (accurate) counters.
-	if w2, cc2, cr2, tl2, vr2, tr2, bt2, _ := r.selectBestCandidateScanLocked(model, pr, true, excludeIDs...); w2 != nil {
-		return w2, cc2, cr2, tl2, vr2, tr2, bt2
+	if w2, scan2 := r.selectBestCandidateScanLocked(model, pr, true, excludeIDs...); w2 != nil {
+		return w2, scan2
 	}
-	return winner, candidateCount, capacityRejections, tooLargeRejections, visionRejections, ttftRejections, bestTTFTMs
+	return winner, scan
 }
 
 // shouldBypassBreakerFailOpen decides whether selection should retry with the
@@ -857,24 +898,22 @@ func (r *Registry) scanCandidatesLocked(model string, pr *PendingRequest, ignore
 
 // selectBestCandidateScanLocked is one pass of candidate selection: it builds the
 // eligible pool (scanCandidatesLocked — the single source of eligibility) and
-// ranks it by cost, returning the winner plus the rejection tallies. When
-// ignoreProviderBreaker is true the node-health breaker gate is skipped;
-// breakerRejected (providers dropped while their breaker was OPEN) is the signal
-// selectBestCandidateLockedFull uses to decide whether a breaker-bypassed
-// fail-open re-scan could help, and is always 0 in that mode.
-func (r *Registry) selectBestCandidateScanLocked(model string, pr *PendingRequest, ignoreProviderBreaker bool, excludeIDs ...string) (*routingCandidate, int, int, int, int, int, float64, int) {
+// ranks it by cost, returning the winner plus the whole scan (rejection tallies
+// and the ranked pool). When ignoreProviderBreaker is true the node-health
+// breaker gate is skipped; scan.breakerRejected (providers dropped while their
+// breaker was OPEN) is the signal selectBestCandidateLockedFull uses to decide
+// whether a breaker-bypassed fail-open re-scan could help, and is always 0 in
+// that mode.
+func (r *Registry) selectBestCandidateScanLocked(model string, pr *PendingRequest, ignoreProviderBreaker bool, excludeIDs ...string) (*routingCandidate, candidateScan) {
 	scan := r.scanCandidatesLocked(model, pr, ignoreProviderBreaker, excludeIDs...)
 	if len(scan.pool) == 0 {
-		return nil, scan.candidateCount, scan.capacityRejections, scan.tooLargeRejections, scan.visionRejections, scan.ttftRejections, scan.bestTTFTMs, scan.breakerRejected
+		return nil, scan
 	}
-	pool := scan.pool
-	candidateCount := scan.candidateCount
-
-	winner := selectRoutingCandidate(pool, func(candidate *routingCandidate) float64 {
+	winner := selectRoutingCandidate(scan.pool, func(candidate *routingCandidate) float64 {
 		return candidate.costMs
 	})
-	r.logRoutingDecision(model, pr, winner, candidateCount)
-	return winner, candidateCount, scan.capacityRejections, scan.tooLargeRejections, scan.visionRejections, scan.ttftRejections, scan.bestTTFTMs, scan.breakerRejected
+	r.logRoutingDecision(model, pr, winner, scan.candidateCount)
+	return winner, scan
 }
 
 // selectRoutingCandidate centralizes cost ranking, near-tie admission, and

--- a/provider-swift/Sources/ProviderCore/CapacityEventHeartbeats.swift
+++ b/provider-swift/Sources/ProviderCore/CapacityEventHeartbeats.swift
@@ -1,0 +1,143 @@
+// Copyright © 2026 Eigen Labs.
+//
+// Event-triggered heartbeat policy (routing v2, Phase 1).
+//
+// The 5s heartbeat interval is the staleness window that produced the
+// gray-box incident (coordinator/registry/budget_clamp.go: 11,581
+// capacity-shaped 503s in 6h from boxes whose heartbeats looked ~1.4%
+// utilized). The fix is push-based freshness: when slot state materially
+// changes, send the EXISTING heartbeat payload immediately instead of waiting
+// out the interval. The baseline periodic heartbeat remains as liveness.
+//
+// Two pure value types, deliberately free of clocks, tasks, and actors:
+//   * `CapacityHeartbeatMateriality` decides whether a freshly rebuilt
+//     capacity payload differs enough from the last SENT one to justify an
+//     out-of-band heartbeat.
+//   * `CapacityHeartbeatThrottle` rate-caps event sends at 2/s per connection
+//     with trailing-edge coalescing: a change landing inside the cap window
+//     is never dropped — it is guaranteed exactly one heartbeat at window
+//     end. Callers inject `now` (deterministic clock seam) and own the timer
+//     that services `.scheduled` verdicts.
+//
+// The ProviderLoop drives both from `updateAggregateCapacity()` — the single
+// choke point every trigger in the contract already flows through: request
+// admission and completion/cancellation, model load/unload/evict, wedge
+// recovery ("crashed"/"reloading" slot states surface in the rebuilt
+// payload), and token-budget drift.
+
+import Foundation
+
+/// Decides whether a rebuilt capacity payload warrants an immediate
+/// out-of-band heartbeat, by comparison against the payload of the last
+/// heartbeat actually sent (the published snapshot). Comparing against the
+/// last SENT payload — not the previous rebuild — makes the decision
+/// idempotent across redundant rebuilds and self-healing: once an event
+/// heartbeat (or the 5s baseline) ships the new state, the delta collapses
+/// to nothing.
+public enum CapacityHeartbeatMateriality {
+    /// Token-budget materiality thresholds from the plan: a shift of ≥1024
+    /// tokens or ≥10% of the previously reported figure.
+    public static let tokenShiftFloor: Int64 = 1024
+    public static let tokenShiftFraction = 0.10
+
+    public static func isMaterial(
+        previous: BackendCapacity?,
+        current: BackendCapacity
+    ) -> Bool {
+        // Nothing published yet on this connection: the first rebuild is
+        // always worth pushing (the baseline heartbeat would send it anyway).
+        guard let previous else { return true }
+
+        // Slot roster: a model loaded, unloaded, or evicted.
+        let previousSlots = Dictionary(
+            uniqueKeysWithValues: previous.slots.map { ($0.model, $0) })
+        if previousSlots.count != current.slots.count { return true }
+
+        var previousBudget: Int64 = 0
+        var currentBudget: Int64 = 0
+        for slot in current.slots {
+            guard let before = previousSlots[slot.model] else { return true }
+            // Slot health transitions (idle/running/crashed/reloading) and
+            // admission/completion (running/waiting counts) are always
+            // material — these are exactly the events the coordinator's
+            // ledger debits against.
+            if before.state != slot.state { return true }
+            if before.numRunning != slot.numRunning { return true }
+            if before.numWaiting != slot.numWaiting { return true }
+            previousBudget += admittableTokens(before)
+            currentBudget += admittableTokens(slot)
+        }
+
+        // Reported token budget drifting without an admission-count change
+        // (re-slice, queued work retiring, KV reclaim): material at ≥1024
+        // tokens or ≥10% of the previous figure.
+        let shift = (currentBudget - previousBudget).magnitude
+        if shift >= UInt64(tokenShiftFloor) { return true }
+        if previousBudget > 0,
+            Double(shift) >= tokenShiftFraction * Double(previousBudget)
+        {
+            return true
+        }
+        return false
+    }
+
+    /// The live admittable token budget a slot reports: max − used − queued,
+    /// floored at zero. Same arithmetic the quote path reports as
+    /// `available_token_budget`, so materiality and quotes move together.
+    public static func admittableTokens(_ slot: BackendSlotCapacity) -> Int64 {
+        max(0, slot.activeTokenBudgetMax - slot.activeTokenBudgetUsed - slot.queuedTokenBudget)
+    }
+}
+
+/// Rate cap for event-triggered heartbeats: at most one send per
+/// ``minInterval`` (2/s), with trailing-edge coalescing. Pure state machine —
+/// the caller supplies `now` and runs the timer for `.scheduled` verdicts, so
+/// tests drive it with a synthetic clock and zero sleeps.
+public struct CapacityHeartbeatThrottle: Sendable {
+    /// 2 events/second per connection (plan Phase 1).
+    public static let minInterval: Duration = .milliseconds(500)
+
+    public enum Verdict: Equatable, Sendable {
+        /// Send an event heartbeat immediately.
+        case sendNow
+        /// Inside the cap window: one trailing send is now scheduled after
+        /// this delay. The caller must arrange a timer that then calls
+        /// ``takeScheduledSend(now:)``.
+        case scheduled(after: Duration)
+        /// Inside the cap window with a trailing send already scheduled —
+        /// this change coalesces into it (never dropped: the trailing send
+        /// ships the then-current payload).
+        case coalesced
+    }
+
+    private var lastEventSendAt: ContinuousClock.Instant?
+    private var trailingScheduled = false
+
+    public init() {}
+
+    /// A material change occurred at `now`.
+    public mutating func noteMaterialChange(
+        now: ContinuousClock.Instant
+    ) -> Verdict {
+        if trailingScheduled { return .coalesced }
+        if let last = lastEventSendAt, now - last < Self.minInterval {
+            trailingScheduled = true
+            return .scheduled(after: last + Self.minInterval - now)
+        }
+        lastEventSendAt = now
+        return .sendNow
+    }
+
+    /// The trailing timer fired. Returns true when the caller must send the
+    /// heartbeat now (and the send is accounted against the rate cap); false
+    /// when the scheduled send was already serviced (defensive — one timer
+    /// per `.scheduled` verdict makes this unreachable in practice).
+    public mutating func takeScheduledSend(
+        now: ContinuousClock.Instant
+    ) -> Bool {
+        guard trailingScheduled else { return false }
+        trailingScheduled = false
+        lastEventSendAt = now
+        return true
+    }
+}

--- a/provider-swift/Sources/ProviderCore/CapacityEventHeartbeats.swift
+++ b/provider-swift/Sources/ProviderCore/CapacityEventHeartbeats.swift
@@ -64,18 +64,36 @@ public enum CapacityHeartbeatMateriality {
             if before.state != slot.state { return true }
             if before.numRunning != slot.numRunning { return true }
             if before.numWaiting != slot.numWaiting { return true }
-            previousBudget += admittableTokens(before)
-            currentBudget += admittableTokens(slot)
+            // Token budget drifting without an admission-count change
+            // (re-slice, queued work retiring, KV reclaim) is compared PER
+            // SLOT: the coordinator's ledger is per-model, so opposing
+            // per-model deltas (A −50k, B +50k) must never cancel into a
+            // fleet-level "nothing changed" — that leaves A's ledger
+            // stale-optimistic, the exact staleness this policy exists to
+            // push out. Providers host multiple model slots in production.
+            let beforeTokens = admittableTokens(before)
+            let nowTokens = admittableTokens(slot)
+            if budgetShiftIsMaterial(previous: beforeTokens, current: nowTokens) {
+                return true
+            }
+            previousBudget += beforeTokens
+            currentBudget += nowTokens
         }
 
-        // Reported token budget drifting without an admission-count change
-        // (re-slice, queued work retiring, KV reclaim): material at ≥1024
-        // tokens or ≥10% of the previous figure.
-        let shift = (currentBudget - previousBudget).magnitude
+        // The aggregate check still adds signal on top of the per-slot one:
+        // several slots each drifting just below the per-slot thresholds can
+        // sum to a fleet-level shift the coordinator's total-capacity view
+        // cares about (e.g. three slots each +400 tokens ≥ the 1024 floor).
+        return budgetShiftIsMaterial(previous: previousBudget, current: currentBudget)
+    }
+
+    /// Materiality of one budget figure moving to another: a shift of
+    /// ≥ ``tokenShiftFloor`` tokens, or ≥ ``tokenShiftFraction`` of the
+    /// previous figure. Applied per slot AND to the roster aggregate.
+    static func budgetShiftIsMaterial(previous: Int64, current: Int64) -> Bool {
+        let shift = (current - previous).magnitude
         if shift >= UInt64(tokenShiftFloor) { return true }
-        if previousBudget > 0,
-            Double(shift) >= tokenShiftFraction * Double(previousBudget)
-        {
+        if previous > 0, Double(shift) >= tokenShiftFraction * Double(previous) {
             return true
         }
         return false

--- a/provider-swift/Sources/ProviderCore/Coordinator/CapacityQuoteEngine.swift
+++ b/provider-swift/Sources/ProviderCore/Coordinator/CapacityQuoteEngine.swift
@@ -19,7 +19,8 @@
 //     `EngineV2KVSizing.liveEngineKVBytesBudget`, i.e. `UnifiedMemoryCap`
 //     with the activation reserve) minus used and queued budget;
 //   * cold-load room — `freeForLoadGb` (`ModelLoadAdmission
-//     .maxLoadableWeightGb`) against `ModelLoadAdmission.requiredToLoadGb`;
+//     .maxLoadableWeightGb`, already net of the load headroom) against the
+//     model's padded weight footprint;
 //   * template/capability — the advertised `ModelInfo`'s
 //     `templateRenderOK`/`isVision` self-check results;
 //   * vision-tower admission — `VisionTowerBudget.maxAdmissiblePatches`.
@@ -115,10 +116,15 @@ enum CapacityQuoteEngine {
         guard let slot else {
             // Model advertised but not resident: admissible only when the
             // cold-load gate's published answer says the weights fit now.
-            let requiredGb = ModelLoadAdmission.requiredToLoadGb(
-                weightsGb: model.estimatedMemoryGb,
-                headroomGb: ProviderLoop.loadHeadroomGb)
-            guard capacity.freeForLoadGb >= requiredGb else {
+            // `freeForLoadGb` is `ModelLoadAdmission.maxLoadableWeightGb` —
+            // already NET of the activation + min-serveable-KV load headroom
+            // (and the unified cap / reserves), i.e. the maximum padded
+            // WEIGHT footprint loadable right now. Compare the weights
+            // directly: adding `requiredToLoadGb`'s headroom on top would
+            // charge that headroom a second time and reject cold probes for
+            // models the real load gate (weights + headroom ≤ raw free
+            // memory) would admit.
+            guard capacity.freeForLoadGb >= max(0, model.estimatedMemoryGb) else {
                 return reject(.memoryCap)
             }
             if probe.deadlineRemainingMs <= 0 {

--- a/provider-swift/Sources/ProviderCore/Coordinator/CapacityQuoteEngine.swift
+++ b/provider-swift/Sources/ProviderCore/Coordinator/CapacityQuoteEngine.swift
@@ -1,0 +1,256 @@
+// Copyright © 2026 Eigen Labs.
+//
+// Capacity-probe → capacity-quote computation (routing v2, Phase 2).
+//
+// The quote path answers "could this bucketed request shape start here right
+// now, and how long to first token?" from the LOCK-FREE published capacity
+// snapshot — one unfair-lock read, no hop to the inference-engine actor, no
+// inference, no model load, no KV allocation, no prompt inspection. Probe
+// storms therefore cannot starve admission or decode: quoting reads values
+// the heartbeat path already produced.
+//
+// It deliberately re-derives NOTHING. Every feasibility figure it consults
+// was computed by the existing gate implementations on the last capacity
+// rebuild and rides the snapshot:
+//   * slot state — the bridge's own truthful heartbeat state
+//     (`EngineV2Bridge.backendSlotCapacity`: idle/running/crashed/reloading);
+//   * continuous-batch room — the engine's `numRunning`/`maxConcurrency`;
+//   * token/KV budget — `activeTokenBudgetMax` (already clamped through
+//     `EngineV2KVSizing.liveEngineKVBytesBudget`, i.e. `UnifiedMemoryCap`
+//     with the activation reserve) minus used and queued budget;
+//   * cold-load room — `freeForLoadGb` (`ModelLoadAdmission
+//     .maxLoadableWeightGb`) against `ModelLoadAdmission.requiredToLoadGb`;
+//   * template/capability — the advertised `ModelInfo`'s
+//     `templateRenderOK`/`isVision` self-check results;
+//   * vision-tower admission — `VisionTowerBudget.maxAdmissiblePatches`.
+
+import Foundation
+
+enum CapacityQuoteEngine {
+    /// Everything a quote needs, captured as plain values so the computation
+    /// is pure and tests pin every path without actors, engines, or a GPU.
+    struct Inputs {
+        let probe: CoordinatorMessage.CapacityProbe
+        /// The seq-stamped published snapshot (`ProviderState
+        /// .publishedCapacity`); nil before the first heartbeat of the
+        /// connection.
+        let capacity: BackendCapacity?
+        /// The advertised catalog entry for `probe.model`; nil when the model
+        /// is not advertised at all.
+        let model: ModelInfo?
+        /// TTFT estimate for the matching bucket, resolved by the caller from
+        /// `TTFTQuantileTracker`; nil falls back to the prefill-derived floor.
+        let ttft: TTFTQuantileTracker.Estimate?
+        /// Device vision-tower limits (`VisionTowerBudget.liveLimits` in
+        /// production; synthetic in tests).
+        let visionLimits: VisionTowerBudget.Limits
+        /// True when the provider is draining for update or shutting down —
+        /// the same conditions the live gate rejects with a bare 503 today.
+        let refusingNewWork: Bool
+    }
+
+    /// Conservative floor for the cold-start no-data case: quoting 0 would
+    /// claim instant first content, which no dispatch ever achieves. One
+    /// second is well under any measured TTFT for a cold load, so it remains
+    /// an honest LOWER bound (floors must under-promise capacity, never
+    /// over-promise speed) while confidence stays `.low`.
+    static let coldStartFloorMs = 1000.0
+
+    static func quote(_ inputs: Inputs) -> ProviderMessage.CapacityQuote {
+        let probe = inputs.probe
+        let seq = inputs.capacity?.capacitySeq ?? 0
+        let slot = inputs.capacity?.slots.first { $0.model == probe.model }
+        let availableTokens = slot.map(CapacityHeartbeatMateriality.admittableTokens) ?? 0
+
+        func reject(
+            _ reason: CapacityRejectionReason,
+            queueEstMs: Double = 0
+        ) -> ProviderMessage.CapacityQuote {
+            let ttft = resolvedTTFT(inputs, slot: slot)
+            return ProviderMessage.CapacityQuote(
+                quoteId: probe.quoteId,
+                capacitySeq: seq,
+                admissibleNow: false,
+                rejectionReason: reason,
+                ttftP50Ms: ttft.p50Ms,
+                ttftP90Ms: ttft.p90Ms,
+                queueEstMs: queueEstMs,
+                availableTokenBudget: availableTokens,
+                confidence: ttft.confidence)
+        }
+
+        // Ordering: permanent shape mismatches first (capability/template),
+        // then health, then capacity, then timing — mirroring the coordinator's
+        // existing classification precedence so one probe never masks a
+        // stronger signal behind a transient one.
+        guard let model = inputs.model else {
+            return reject(.capability)
+        }
+        if (probe.requiresVision || probe.visionImageCount > 0), model.isVision != true {
+            return reject(.capability)
+        }
+        if model.templateRenderOK == false {
+            return reject(.template)
+        }
+        // Vision feasibility on a vision-capable model: the probe carries an
+        // image COUNT, not patch grids, and per-image tower calls bound peak
+        // memory by the largest single image — undecidable here without media
+        // bytes (which must never ride a probe). The decidable case is a
+        // device whose tower gate admits nothing at all.
+        if probe.visionImageCount > 0,
+            VisionTowerBudget.maxAdmissiblePatches(inputs.visionLimits) == 0
+        {
+            return reject(.memoryCap)
+        }
+        guard let capacity = inputs.capacity, seq != 0 else {
+            // No published snapshot yet on this connection: the coordinator
+            // cannot order a quote it cannot sequence, and we cannot consult
+            // gates that have not reported. Fail closed as a health reject.
+            return reject(.slotState)
+        }
+        if inputs.refusingNewWork {
+            return reject(.slotState)
+        }
+
+        guard let slot else {
+            // Model advertised but not resident: admissible only when the
+            // cold-load gate's published answer says the weights fit now.
+            let requiredGb = ModelLoadAdmission.requiredToLoadGb(
+                weightsGb: model.estimatedMemoryGb,
+                headroomGb: ProviderLoop.loadHeadroomGb)
+            guard capacity.freeForLoadGb >= requiredGb else {
+                return reject(.memoryCap)
+            }
+            if probe.deadlineRemainingMs <= 0 {
+                return reject(.deadline)
+            }
+            return admissible(inputs, seq: seq, slot: nil, availableTokens: 0)
+        }
+
+        // Slot health: the bridge already folded wedge suspicion and recovery
+        // reloads into the state string; trust it.
+        guard slot.state == "idle" || slot.state == "running" else {
+            return reject(.slotState)
+        }
+
+        let needed = Int64(max(0, probe.promptTokensBucket) + max(0, probe.maxOutputTokens))
+        if slot.activeTokenBudgetMax > 0 {
+            // Can never fit, even into an empty batch: the whole KV grant is
+            // smaller than the request's token envelope.
+            if needed > slot.activeTokenBudgetMax {
+                return reject(.kvHeadroom)
+            }
+            if needed > availableTokens {
+                return rejectBusy(
+                    reject,
+                    slot: slot,
+                    deficitTokens: needed - availableTokens,
+                    deadlineRemainingMs: probe.deadlineRemainingMs)
+            }
+        }
+        // Continuous-batch admission room: all decode rows occupied.
+        if slot.maxConcurrency > 0, slot.numRunning >= slot.maxConcurrency {
+            return rejectBusy(
+                reject,
+                slot: slot,
+                deficitTokens: max(1, needed),
+                deadlineRemainingMs: probe.deadlineRemainingMs)
+        }
+
+        if probe.deadlineRemainingMs <= 0 {
+            return reject(.deadline)
+        }
+        return admissible(inputs, seq: seq, slot: slot, availableTokens: availableTokens)
+    }
+
+    private static func admissible(
+        _ inputs: Inputs,
+        seq: UInt64,
+        slot: BackendSlotCapacity?,
+        availableTokens: Int64
+    ) -> ProviderMessage.CapacityQuote {
+        let ttft = resolvedTTFT(inputs, slot: slot)
+        return ProviderMessage.CapacityQuote(
+            quoteId: inputs.probe.quoteId,
+            capacitySeq: seq,
+            admissibleNow: true,
+            ttftP50Ms: ttft.p50Ms,
+            ttftP90Ms: ttft.p90Ms,
+            queueEstMs: 0,
+            availableTokenBudget: availableTokens,
+            confidence: ttft.confidence)
+    }
+
+    /// Shared busy-slot rejection: `deadline` when the wait estimate already
+    /// exceeds the request's remaining first-content budget (admitting would
+    /// only burn the client's clock), otherwise `token_budget` with the wait
+    /// as `queue_est_ms`. An unmeasurable wait (no decode-TPS sample yet)
+    /// stays `token_budget` with `queue_est_ms = 0` — zero alongside
+    /// `admissible_now = false` reads as "no estimate", and inventing a wait
+    /// here would misclassify busy slots as deadline-infeasible.
+    private static func rejectBusy(
+        _ reject: (CapacityRejectionReason, Double) -> ProviderMessage.CapacityQuote,
+        slot: BackendSlotCapacity,
+        deficitTokens: Int64,
+        deadlineRemainingMs: Int64
+    ) -> ProviderMessage.CapacityQuote {
+        guard let waitMs = queueEstimateMs(slot: slot, deficitTokens: deficitTokens) else {
+            return reject(.tokenBudget, 0)
+        }
+        if waitMs > Double(deadlineRemainingMs) {
+            return reject(.deadline, waitMs)
+        }
+        return reject(.tokenBudget, waitMs)
+    }
+
+    /// TTFT with the plan's fallback chain. The tracker already walked
+    /// bucket → (model, warm) → model aggregates; the final fallback is a
+    /// measurement-derived floor: prompt-bucket prefill time at the slot's
+    /// observed prefill TPS (the same EWMA the coordinator's TTFT estimation
+    /// consumes), or ``coldStartFloorMs`` when nothing has ever been measured.
+    /// Always `confidence = .low` on the floor. Durations only.
+    static func resolvedTTFT(
+        _ inputs: Inputs,
+        slot: BackendSlotCapacity?
+    ) -> TTFTQuantileTracker.Estimate {
+        if let ttft = inputs.ttft { return ttft }
+        if let slot, slot.observedPrefillTps > 0 {
+            let promptTokens = Double(max(
+                inputs.probe.promptTokensBucket,
+                CoordinatorMessage.CapacityProbe.promptBucketTokens))
+            let floorMs = promptTokens / slot.observedPrefillTps * 1000.0
+            return TTFTQuantileTracker.Estimate(
+                p50Ms: floorMs, p90Ms: floorMs, confidence: .low)
+        }
+        return TTFTQuantileTracker.Estimate(
+            p50Ms: coldStartFloorMs, p90Ms: coldStartFloorMs, confidence: .low)
+    }
+
+    /// Wait estimate until `deficitTokens` of budget frees: running sequences
+    /// retire budget at the slot's observed decode rate. Durations only; nil
+    /// when the slot has never measured decode TPS (no honest estimate
+    /// exists).
+    static func queueEstimateMs(
+        slot: BackendSlotCapacity,
+        deficitTokens: Int64
+    ) -> Double? {
+        guard deficitTokens > 0 else { return 0 }
+        guard slot.observedDecodeTps > 0 else { return nil }
+        return Double(deficitTokens) / slot.observedDecodeTps * 1000.0
+    }
+
+    /// Busy-slot wait forecast for the enriched capacity rejections: how long
+    /// until `neededTokens` becomes admittable on `slot`, via the same
+    /// deficit → ``queueEstimateMs`` path the quote's `rejectBusy` takes
+    /// against the same published budget view (`CapacityHeartbeatMateriality
+    /// .admittableTokens`). 0 when the tokens already fit; nil when the slot
+    /// has never measured decode TPS (no honest estimate exists).
+    static func busyWaitEstimateMs(
+        slot: BackendSlotCapacity,
+        neededTokens: Int64
+    ) -> Double? {
+        queueEstimateMs(
+            slot: slot,
+            deficitTokens: neededTokens - CapacityHeartbeatMateriality.admittableTokens(slot))
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClient+Connection.swift
+++ b/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClient+Connection.swift
@@ -104,6 +104,12 @@ extension CoordinatorClient {
             // Nil the stored reference so sendOnCurrentConnection fast-returns
             // during the reconnect window instead of firing on a cancelled connection.
             self.nwConnection = nil
+            // Routing v2: this connection's capacity-seq session is over. A
+            // reconnect re-registers and restarts seq at 1; the published
+            // quote snapshot is dropped with it so quotes never answer from a
+            // session the new coordinator connection has not seen.
+            self.sessionRegistered = false
+            self.state.resetCapacitySession()
             // Detach the inference-chunk fast path from this connection (drops any
             // queued chunks; their requests are cancelled on disconnect). Guarded
             // by identity so a concurrent reconnect's freshly-bound writer isn't
@@ -159,6 +165,11 @@ extension CoordinatorClient {
 
         try await sendRegistration(connection: connection)
         logger.info(.coordinatorRegistrationSent)
+        // Fresh capacity-seq session for this connection (routing v2): seq
+        // restarts at 1 on the first heartbeat and out-of-band event
+        // heartbeats are permitted from here on.
+        state.resetCapacitySession()
+        sessionRegistered = true
 
         // Fresh outbound stream for THIS connection. AsyncStream is single-shot:
         // its iterator is terminated when the previous session's consumer task is

--- a/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClient+Inbound.swift
+++ b/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClient+Inbound.swift
@@ -82,13 +82,47 @@ extension CoordinatorClient {
                 cacheScope: request.cacheScope,
                 prefixCacheProtocol: request.prefixCacheProtocol,
                 toolSchemaMetadataProtocol: request.toolSchemaMetadataProtocol,
-                firstContentDeadline: firstContentDeadline
+                firstContentDeadline: firstContentDeadline,
+                receivedAt: receivedAt
             ))
 
         case .cancel(let cancel):
             let requestId = cancel.requestId
             logger.info("Received cancel for: \(requestId)")
             eventContinuation?.yield(.cancel(requestId: requestId))
+
+        case .capacityProbe(let probe):
+            // Routing v2: answer from the lock-free published snapshot — the
+            // capacity payload of the last heartbeat this connection sent —
+            // plus the advertised catalog and the TTFT tracker. No hop to the
+            // ProviderLoop or engine actors, no inference, no model load, no
+            // KV allocation: a probe storm costs this connection some JSON,
+            // never admission or decode throughput.
+            let published = state.publishedCapacity
+            let slot = published?.slots.first { $0.model == probe.model }
+            let ttft = state.ttftTracker.estimate(
+                model: probe.model,
+                warm: slot != nil,
+                promptBucket: TTFTQuantileTracker.promptBucket(
+                    forPromptTokens: probe.promptTokensBucket),
+                batchBucket: TTFTQuantileTracker.batchBucket(
+                    forActiveRequests: Int(slot?.numRunning ?? 0)))
+            let quote = CapacityQuoteEngine.quote(CapacityQuoteEngine.Inputs(
+                probe: probe,
+                capacity: published,
+                model: advertisedModelStore.models.first { $0.id == probe.model },
+                ttft: ttft,
+                visionLimits: VisionTowerBudget.liveLimits,
+                refusingNewWork: state.refusingNewWork))
+            do {
+                let json = try ProviderProtocolCodec.encodeProviderMessageString(
+                    .capacityQuote(quote))
+                sendOnCurrentConnection(json, identifier: "capacity_quote")
+            } catch {
+                // A quote is advisory; the coordinator treats a missing one
+                // as a timeout/demotion. Never tear anything down for it.
+                logger.warning("Failed to encode capacity quote")
+            }
 
         case .attestationChallenge(let challenge):
             logger.info(.attestationChallengeReceived)

--- a/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClient+Registration.swift
+++ b/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClient+Registration.swift
@@ -69,7 +69,12 @@ extension CoordinatorClient {
         let isActive = state.inferenceActive
         let activeModel = state.currentModel
         let warmModels = state.warmModels
-        let capacity = state.backendCapacity
+        // Stamp this heartbeat's capacity payload with the next per-connection
+        // capacity_seq and publish it as the quote snapshot (routing v2).
+        // EVERY heartbeat build flows through here — the 5s baseline and the
+        // event-triggered sends — so seq is dense, monotonic, and the
+        // published snapshot is exactly what the coordinator last saw.
+        let capacity = state.stampAndPublishHeartbeatCapacity(state.backendCapacity)
         let prefixCache = state.prefixCacheV2Advertisement()
         let metrics = SystemMetricsCollector.collect(cpuCores: config.hardware.cpuCores.total)
 
@@ -121,6 +126,18 @@ extension CoordinatorClient {
             // rather than shipping malformed bytes the coordinator would drop.
             return "{\"type\":\"heartbeat\",\"status\":\"idle\",\"stats\":{\"requests_served\":0,\"tokens_generated\":0},\"system_metrics\":{\"memory_pressure\":0,\"cpu_usage\":0,\"thermal_state\":\"nominal\"}}"
         }
+    }
+
+    /// Out-of-band event-triggered heartbeat (routing v2, Phase 1): reuses the
+    /// baseline heartbeat builder verbatim — same payload, same seq stamping,
+    /// same publication — and fires it on the live connection immediately.
+    /// Rate-capping and coalescing happen at the caller (`ProviderLoop`'s
+    /// `CapacityHeartbeatThrottle`); this method only refuses to write into a
+    /// dead or not-yet-registered session, where a heartbeat frame ahead of
+    /// `register` would be a protocol violation.
+    func sendEventHeartbeat() {
+        guard sessionRegistered, let connection = nwConnection else { return }
+        sendTextFrame(buildHeartbeatJSON(), on: connection, identifier: "heartbeat")
     }
 
 }

--- a/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClient.swift
+++ b/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClient.swift
@@ -84,6 +84,14 @@ public actor CoordinatorClient {
     /// the live map, and this keeps future registrations consistent.
     internal var modelWeightHashOverrides: [String: String]?
 
+    /// True from the moment this connection's `register` frame was handed to
+    /// the transport until the session tears down. Event-triggered heartbeats
+    /// check it so an out-of-band heartbeat can never precede registration on
+    /// a fresh connection (frames before `register` are a protocol violation);
+    /// the baseline heartbeat task starts after registration and needs no
+    /// gate.
+    internal var sessionRegistered = false
+
     private let shutdownFlag = ShutdownFlag()
 
     /// Fast, thread-safe shutdown visibility for connection tasks.

--- a/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClientState.swift
+++ b/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClientState.swift
@@ -143,6 +143,16 @@ public final class ProviderState: @unchecked Sendable {
     private var _prefixCacheV2Sources: [String: SSDPrefixCache] = [:]
     private var _prefixCacheStatuses: [PrefixCacheModelStatus] = []
     private var _prefixCacheRuntimeIdentityAvailable = true
+    private var _publishedCapacity: BackendCapacity? = nil
+    private var _capacitySeq: UInt64 = 0
+    private var _refusingNewWork = false
+
+    /// Bounded per-(model, warm/cold, prompt-bucket, batch-bucket) end-to-end
+    /// TTFT statistics from completed real requests, fed by the ProviderLoop's
+    /// streaming path and read lock-free-ish by the quote path. Lives here
+    /// because ProviderState is the one object both the loop actor and the
+    /// CoordinatorClient actor already share without an actor hop.
+    public let ttftTracker = TTFTQuantileTracker()
 
     public init() {}
 
@@ -169,6 +179,57 @@ public final class ProviderState: @unchecked Sendable {
     public var backendCapacity: BackendCapacity? {
         get { lock.withLock { _backendCapacity } }
         set { lock.withLock { _backendCapacity = newValue } }
+    }
+
+    /// Mirror of the ProviderLoop's "refuse new work" windows (update drain,
+    /// shutdown) for the quote path, which runs on the CoordinatorClient and
+    /// must not hop to the loop actor to learn what the live gate would do.
+    /// The loop writes it at the same transitions that flip its own gates, so
+    /// quotes and admissions refuse in the same windows.
+    public var refusingNewWork: Bool {
+        get { lock.withLock { _refusingNewWork } }
+        set { lock.withLock { _refusingNewWork = newValue } }
+    }
+
+    /// The capacity payload of the LAST heartbeat actually sent on the
+    /// current connection, seq-stamped (routing v2). This is the lock-free
+    /// published snapshot the capacity-quote path reads: quotes must be
+    /// computed from state the coordinator can order by `capacity_seq`, never
+    /// from a rebuild it has not seen — and reading it here costs one unfair
+    /// lock, no hop to the inference engine actor, no blocking of
+    /// admission/decode.
+    public var publishedCapacity: BackendCapacity? {
+        lock.withLock { _publishedCapacity }
+    }
+
+    /// Stamp the given heartbeat capacity payload with the next per-connection
+    /// `capacity_seq` (starting at 1) and publish it as the quote snapshot,
+    /// atomically. Called for EVERY outbound heartbeat — 5s baseline and
+    /// event-triggered alike — so seq is dense and strictly monotonic within a
+    /// connection. A nil payload (capacity not yet rebuilt after startup) is
+    /// passed through without burning a seq: `capacity_seq` only ever rides an
+    /// actual `backend_capacity` object.
+    public func stampAndPublishHeartbeatCapacity(
+        _ capacity: BackendCapacity?
+    ) -> BackendCapacity? {
+        guard var capacity else { return nil }
+        return lock.withLock {
+            _capacitySeq &+= 1
+            capacity.capacitySeq = _capacitySeq
+            _publishedCapacity = capacity
+            return capacity
+        }
+    }
+
+    /// Reset the capacity-seq session on a fresh coordinator connection: the
+    /// contract is per-connection monotonicity starting at 1, and the stale
+    /// published snapshot must not answer quotes for a connection whose
+    /// coordinator never saw it.
+    public func resetCapacitySession() {
+        lock.withLock {
+            _capacitySeq = 0
+            _publishedCapacity = nil
+        }
     }
 
     func setPrefixCacheSnapshot(

--- a/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClientTypes.swift
+++ b/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClientTypes.swift
@@ -93,6 +93,9 @@ public enum CoordinatorEvent: Sendable {
     /// 32-byte X25519 ephemeral public key, also decoded.
     /// Consumers (ProviderLoop) feed both directly to NodeKeyPair.decrypt
     /// without further base64 manipulation.
+    /// `receivedAt` is the monotonic instant the receive callback observed the
+    /// frame — the anchor for both the first-content deadline and the
+    /// provider's end-to-end TTFT samples (dispatch-received → first token).
     case inferenceRequest(
         requestId: String,
         ciphertext: Data,
@@ -101,7 +104,8 @@ public enum CoordinatorEvent: Sendable {
         cacheScope: String?,
         prefixCacheProtocol: Int?,
         toolSchemaMetadataProtocol: Int?,
-        firstContentDeadline: FirstContentDeadline?
+        firstContentDeadline: FirstContentDeadline?,
+        receivedAt: ContinuousClock.Instant
     )
     case cancel(requestId: String)
     case attestationChallenge(nonce: String, timestamp: String)

--- a/provider-swift/Sources/ProviderCore/Inference/CapacityRejectionEnrichment.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/CapacityRejectionEnrichment.swift
@@ -1,0 +1,78 @@
+// Copyright © 2026 Eigen Labs.
+//
+// Enriched capacity rejections (routing v2, Phase 2).
+//
+// Every capacity-shaped (503) live-gate rejection the provider sends becomes
+// a fresh, machine-readable state sample for the coordinator's ledger, budget
+// clamp, and failure taxonomy: bounded reason + the live admittable token
+// budget + the `capacity_seq` of the snapshot the verdict aligns with. This
+// is what turns the budget clamp's reactive one-bounce-per-cycle discovery
+// (coordinator/registry/budget_clamp.go) into push-based truth.
+//
+// Pure function: the ProviderLoop stamps failures at its rejection sites with
+// values already computed elsewhere — nothing here re-derives a gate formula.
+// The busy-slot forecast (`feasible_after_ms`) likewise reuses the quote
+// engine's estimator (`CapacityQuoteEngine.busyWaitEstimateMs`) rather than
+// inventing one.
+
+import Foundation
+
+enum CapacityRejectionEnrichment {
+    /// Stamp a capacity-shaped failure with the published snapshot's view of
+    /// the rejected model. Failures that are not capacity-shaped pass
+    /// through untouched — the enriched fields are defined only for
+    /// live-gate capacity rejections, and client-fault/provider-fault frames
+    /// must keep their legacy shape.
+    ///
+    /// `fallbackReason` names the gate that rejected when the failure's own
+    /// `errorReason` cannot be mapped (e.g. the bare drain/shutdown 503s,
+    /// whose failure carries no reason at all).
+    ///
+    /// `neededTokens` is the request's admission token envelope (templated
+    /// prompt + output reservation), evaluated lazily and only for the
+    /// transient `token_budget` shape: it feeds the quote engine's busy-wait
+    /// estimator so the 503 carries a real `feasible_after_ms` forecast.
+    static func enrich(
+        _ failure: InferenceFailure,
+        modelId: String?,
+        published: BackendCapacity?,
+        fallbackReason: CapacityRejectionReason,
+        neededTokens: @autoclosure () -> Int64? = nil
+    ) -> InferenceFailure {
+        // 503 (reroute) and 429 (queue full) are the two capacity-shaped
+        // live-gate statuses; everything else keeps its legacy frame.
+        guard failure.statusCode == 503 || failure.statusCode == 429 else { return failure }
+        let slot = modelId.flatMap { id in
+            published?.slots.first { $0.model == id }
+        }
+        let reason = failure.rejectionReason
+            ?? failure.errorReason.flatMap(CapacityRejectionReason.init(errorReason:))
+            ?? fallbackReason
+        // Busy-slot forecast: only the transient token_budget shape has a
+        // meaningful "after" (never-fits and health rejects do not free up by
+        // waiting), and only a slot with a measured decode rate can estimate
+        // one — running sequences retire budget at that rate. Positive
+        // estimates only: 0 alongside a rejection reads as "no estimate", and
+        // the wire omits zero anyway.
+        let feasibleAfterMs: Int64? = failure.feasibleAfterMs ?? {
+            guard reason == .tokenBudget, let slot, let needed = neededTokens(),
+                let waitMs = CapacityQuoteEngine.busyWaitEstimateMs(
+                    slot: slot, neededTokens: needed),
+                waitMs > 0
+            else { return nil }
+            return Int64(waitMs.rounded(.up))
+        }()
+        return InferenceFailure(
+            code: failure.code,
+            statusCode: failure.statusCode,
+            errorReason: failure.errorReason,
+            terminalCause: failure.terminalCause,
+            attemptUsage: failure.attemptUsage,
+            rejectionReason: reason,
+            availableTokenBudget: slot.map(CapacityHeartbeatMateriality.admittableTokens)
+                ?? failure.availableTokenBudget,
+            feasibleAfterMs: feasibleAfterMs,
+            capacitySeq: (published?.capacitySeq).flatMap { $0 != 0 ? $0 : nil }
+                ?? failure.capacitySeq)
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Inference/InferenceFailure.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/InferenceFailure.swift
@@ -77,19 +77,38 @@ public struct InferenceFailure: Sendable, Equatable {
     public let errorReason: InferenceErrorReason?
     public let terminalCause: InferenceTerminalCause?
     public let attemptUsage: UsageInfo?
+    /// Routing-v2 enriched capacity rejection (all nil away from the
+    /// capacity-shaped live-gate paths; omitted on the wire when nil so the
+    /// legacy frame shape is untouched). Stamped by
+    /// `CapacityRejectionEnrichment.enrich` at the ProviderLoop's
+    /// capacity-shaped rejection sites, from the published capacity snapshot
+    /// so every rejection is also a fresh state sample for the coordinator's
+    /// ledger/clamp/taxonomy.
+    public let rejectionReason: CapacityRejectionReason?
+    public let availableTokenBudget: Int64?
+    public let feasibleAfterMs: Int64?
+    public let capacitySeq: UInt64?
 
     public init(
         code: InferenceFailureCode,
         statusCode: UInt16,
         errorReason: InferenceErrorReason? = nil,
         terminalCause: InferenceTerminalCause? = nil,
-        attemptUsage: UsageInfo? = nil
+        attemptUsage: UsageInfo? = nil,
+        rejectionReason: CapacityRejectionReason? = nil,
+        availableTokenBudget: Int64? = nil,
+        feasibleAfterMs: Int64? = nil,
+        capacitySeq: UInt64? = nil
     ) {
         self.code = code
         self.statusCode = statusCode
         self.errorReason = errorReason
         self.terminalCause = terminalCause
         self.attemptUsage = attemptUsage
+        self.rejectionReason = rejectionReason
+        self.availableTokenBudget = availableTokenBudget
+        self.feasibleAfterMs = feasibleAfterMs
+        self.capacitySeq = capacitySeq
     }
 
     public var message: String { code.message }

--- a/provider-swift/Sources/ProviderCore/Inference/TTFTQuantileTracker.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/TTFTQuantileTracker.swift
@@ -1,0 +1,202 @@
+// Copyright © 2026 Eigen Labs.
+//
+// Bounded end-to-end TTFT quantile tracking for capacity quotes (routing v2).
+//
+// The coordinator's TTFT estimates were stage-composed and stale-optimistic
+// (v0.8.0 postmortem: TTFT p95 12.8s / p99 33s while heartbeats looked ~1.4%
+// utilized). The quote contract therefore demands the real end-to-end
+// distribution measured at the provider — dispatch-received to first content
+// token — from COMPLETED real requests, never a sum of per-stage p95s and
+// never wall-clock timestamps (clock skew across boxes).
+//
+// Design constraints, in order:
+//   * Bounded memory: fixed-size sample rings per bucket, a hard cap on the
+//     number of buckets (LRU-evicted), no unbounded history.
+//   * Cheap recording: the hot path (request completion) is one unfair lock
+//     plus one array-slot write; no sorting, no allocation after a ring fills.
+//   * Sorting happens only at estimate time (the probe path, human-rate).
+
+import Foundation
+
+/// One process-wide tracker instance hangs off `ProviderState` so the
+/// ProviderLoop (recording) and CoordinatorClient (quoting) share it without
+/// an actor hop. `@unchecked Sendable`: all mutable state is guarded by the
+/// single unfair lock, matching the `ProviderState` pattern.
+public final class TTFTQuantileTracker: @unchecked Sendable {
+    /// Bucket identity. `chip` is deliberately absent: this tracker lives on
+    /// ONE provider, whose chip is a constant — the plan's "model+chip
+    /// aggregate" fallback tier and the "model aggregate" tier coincide here,
+    /// so the local chain is bucket → (model, warm) aggregate → model
+    /// aggregate → caller-supplied floor.
+    public struct Key: Hashable, Sendable {
+        public let model: String
+        /// Whether the model was resident when the dispatch arrived. Cold
+        /// samples include the model-load latency and must never calibrate
+        /// warm quotes (different distributions).
+        public let warm: Bool
+        /// Prompt tokens rounded UP to a multiple of
+        /// `CoordinatorMessage.CapacityProbe.promptBucketTokens` — the same
+        /// bucketing the probe's `prompt_tokens_bucket` uses, so probe and
+        /// sample land in the same bucket by construction.
+        public let promptBucket: Int
+        /// Batch occupancy when the dispatch arrived, bucketed by
+        /// ``batchBucket(forActiveRequests:)``.
+        public let batchBucket: Int
+
+        public init(model: String, warm: Bool, promptBucket: Int, batchBucket: Int) {
+            self.model = model
+            self.warm = warm
+            self.promptBucket = promptBucket
+            self.batchBucket = batchBucket
+        }
+    }
+
+    public struct Estimate: Sendable, Equatable {
+        public let p50Ms: Double
+        public let p90Ms: Double
+        public let confidence: CapacityQuoteConfidence
+    }
+
+    /// Samples retained per bucket. 64 doubles ≈ 512 B; enough for stable
+    /// p90 (nearest-rank on 64 samples) while old regimes age out quickly.
+    static let ringCapacity = 64
+    /// Hard cap on distinct (model, warm, prompt, batch) buckets. With ≤3
+    /// resident models, 2 warmth states, ~16 realistic prompt buckets and 5
+    /// batch buckets this is not reached in practice; a hostile mix of prompt
+    /// sizes evicts least-recently-updated buckets instead of growing.
+    static let maxBuckets = 512
+    /// Minimum samples in the EXACT bucket for `confidence == .high`.
+    /// Aggregates and floors are always `.low`.
+    static let highConfidenceMinSamples = 8
+
+    /// Fixed-capacity overwrite ring. Value type: lives only inside the
+    /// tracker's lock.
+    private struct Ring {
+        var samples: [Double] = []
+        var next = 0
+        /// Monotonic recency stamp for LRU eviction of whole buckets.
+        var lastTouch: UInt64 = 0
+
+        mutating func append(_ value: Double) {
+            if samples.count < TTFTQuantileTracker.ringCapacity {
+                samples.append(value)
+            } else {
+                samples[next] = value
+                next = (next + 1) % TTFTQuantileTracker.ringCapacity
+            }
+        }
+    }
+
+    private let lock = OSAllocatedUnfairLock()
+    private var buckets: [Key: Ring] = [:]
+    private var touchCounter: UInt64 = 0
+
+    public init() {}
+
+    /// Round prompt tokens UP to the probe's bucket size (minimum one bucket,
+    /// mirroring the coordinator's rounding of its estimate).
+    public static func promptBucket(forPromptTokens tokens: Int) -> Int {
+        let bucket = CoordinatorMessage.CapacityProbe.promptBucketTokens
+        let clamped = max(1, tokens)
+        return ((clamped + bucket - 1) / bucket) * bucket
+    }
+
+    /// Bucket batch occupancy (requests already running at dispatch): 0, 1,
+    /// 2, 3, then 4+ folded together — TTFT differences flatten out once the
+    /// batch is saturated, and folding keeps the key space bounded.
+    public static func batchBucket(forActiveRequests active: Int) -> Int {
+        min(max(0, active), 4)
+    }
+
+    /// Record one completed request's end-to-end TTFT (dispatch-received →
+    /// first content token, milliseconds). Callers must only feed completed
+    /// real requests — never synthetic probes, never cancelled-before-output
+    /// attempts.
+    public func record(
+        model: String,
+        warm: Bool,
+        promptTokens: Int,
+        activeRequestsAtDispatch: Int,
+        ttftMs: Double
+    ) {
+        guard ttftMs.isFinite, ttftMs >= 0 else { return }
+        let key = Key(
+            model: model,
+            warm: warm,
+            promptBucket: Self.promptBucket(forPromptTokens: promptTokens),
+            batchBucket: Self.batchBucket(forActiveRequests: activeRequestsAtDispatch))
+        lock.withLock {
+            touchCounter &+= 1
+            var ring = buckets[key] ?? Ring()
+            ring.append(ttftMs)
+            ring.lastTouch = touchCounter
+            if buckets[key] == nil, buckets.count >= Self.maxBuckets {
+                // Evict the least-recently-updated bucket to stay bounded.
+                if let victim = buckets.min(by: { $0.value.lastTouch < $1.value.lastTouch })?.key {
+                    buckets.removeValue(forKey: victim)
+                }
+            }
+            buckets[key] = ring
+        }
+    }
+
+    /// Quantile estimate with the documented fallback chain:
+    /// exact bucket (high confidence at ≥ ``highConfidenceMinSamples``) →
+    /// (model, warm) aggregate → model aggregate (both `.low`) → nil, in
+    /// which case the caller quotes its benchmark/manifest-derived floor with
+    /// `confidence = .low`.
+    public func estimate(
+        model: String,
+        warm: Bool,
+        promptBucket: Int,
+        batchBucket: Int
+    ) -> Estimate? {
+        let (exact, modelWarm, modelAny) = lock.withLock {
+            () -> ([Double], [Double], [Double]) in
+            var exact: [Double] = []
+            var modelWarm: [Double] = []
+            var modelAny: [Double] = []
+            for (key, ring) in buckets where key.model == model {
+                modelAny.append(contentsOf: ring.samples)
+                guard key.warm == warm else { continue }
+                modelWarm.append(contentsOf: ring.samples)
+                if key.promptBucket == promptBucket, key.batchBucket == batchBucket {
+                    exact = ring.samples
+                }
+            }
+            return (exact, modelWarm, modelAny)
+        }
+        if exact.count >= Self.highConfidenceMinSamples {
+            return Self.quantiles(exact, confidence: .high)
+        }
+        if !exact.isEmpty {
+            return Self.quantiles(exact, confidence: .low)
+        }
+        if !modelWarm.isEmpty {
+            return Self.quantiles(modelWarm, confidence: .low)
+        }
+        if !modelAny.isEmpty {
+            return Self.quantiles(modelAny, confidence: .low)
+        }
+        return nil
+    }
+
+    /// Nearest-rank quantiles over a copy of the samples. Sorting ≤ a few
+    /// hundred doubles at probe rate is noise; recording stays O(1).
+    private static func quantiles(
+        _ samples: [Double],
+        confidence: CapacityQuoteConfidence
+    ) -> Estimate {
+        let sorted = samples.sorted()
+        return Estimate(
+            p50Ms: nearestRank(sorted, 0.50),
+            p90Ms: nearestRank(sorted, 0.90),
+            confidence: confidence)
+    }
+
+    private static func nearestRank(_ sorted: [Double], _ q: Double) -> Double {
+        guard !sorted.isEmpty else { return 0 }
+        let rank = Int((q * Double(sorted.count)).rounded(.up))
+        return sorted[min(max(rank - 1, 0), sorted.count - 1)]
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Inference/TTFTQuantileTracker.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/TTFTQuantileTracker.swift
@@ -10,11 +10,15 @@
 // never wall-clock timestamps (clock skew across boxes).
 //
 // Design constraints, in order:
-//   * Bounded memory: fixed-size sample rings per bucket, a hard cap on the
-//     number of buckets (LRU-evicted), no unbounded history.
+//   * Bounded memory: fixed-size sample rings per bucket AND per fallback
+//     tier, a hard cap on the number of buckets (LRU-evicted), no unbounded
+//     history.
 //   * Cheap recording: the hot path (request completion) is one unfair lock
-//     plus one array-slot write; no sorting, no allocation after a ring fills.
-//   * Sorting happens only at estimate time (the probe path, human-rate).
+//     plus O(1) ring-slot writes (exact bucket + the two fallback tiers); no
+//     sorting, no allocation after a ring fills.
+//   * Cheap probing: every estimate tier is a single dictionary lookup into a
+//     precomputed ring; sorting happens only at estimate time and only over
+//     one ring's ≤ 64 samples — probe cost never scales with bucket count.
 
 import Foundation
 
@@ -87,8 +91,24 @@ public final class TTFTQuantileTracker: @unchecked Sendable {
         }
     }
 
+    /// Fallback-tier identity for the (model, warm) aggregate ring.
+    private struct ModelWarmKey: Hashable {
+        let model: String
+        let warm: Bool
+    }
+
     private let lock = OSAllocatedUnfairLock()
     private var buckets: [Key: Ring] = [:]
+    /// Precomputed fallback tiers, appended on the record path (O(1) each)
+    /// instead of rebuilt per probe. The probe path previously copied every
+    /// matching bucket's samples into both aggregate arrays under the lock —
+    /// up to `maxBuckets × ringCapacity` (32,768) doubles gathered and sorted
+    /// synchronously on the coordinator-client actor, delaying frame decode
+    /// behind sustained probe traffic. A bounded ring per tier keeps probes
+    /// O(ringCapacity) worst-case: nearest-rank over the freshest ≤ 64
+    /// samples, the same estimator quality every other tier gets.
+    private var modelWarmAggregates: [ModelWarmKey: Ring] = [:]
+    private var modelAggregates: [String: Ring] = [:]
     private var touchCounter: UInt64 = 0
 
     public init() {}
@@ -125,6 +145,7 @@ public final class TTFTQuantileTracker: @unchecked Sendable {
             warm: warm,
             promptBucket: Self.promptBucket(forPromptTokens: promptTokens),
             batchBucket: Self.batchBucket(forActiveRequests: activeRequestsAtDispatch))
+        let tierKey = ModelWarmKey(model: model, warm: warm)
         lock.withLock {
             touchCounter &+= 1
             var ring = buckets[key] ?? Ring()
@@ -137,7 +158,32 @@ public final class TTFTQuantileTracker: @unchecked Sendable {
                 }
             }
             buckets[key] = ring
+            // Feed the fallback tiers on the same O(1) write path. The
+            // aggregate key spaces (models × warmth, models) are strictly
+            // smaller than the bucket key space, but cap them identically so
+            // a hostile model-id mix can never outgrow the bucket bound.
+            appendToAggregate(&modelWarmAggregates, key: tierKey, value: ttftMs)
+            appendToAggregate(&modelAggregates, key: model, value: ttftMs)
         }
+    }
+
+    /// Append one sample to a fallback-tier ring, LRU-evicting whole tiers at
+    /// the same ``maxBuckets`` cap the exact buckets use. Must run under the
+    /// lock (shares `touchCounter`).
+    private func appendToAggregate<K: Hashable>(
+        _ aggregates: inout [K: Ring],
+        key: K,
+        value: Double
+    ) {
+        var ring = aggregates[key] ?? Ring()
+        ring.append(value)
+        ring.lastTouch = touchCounter
+        if aggregates[key] == nil, aggregates.count >= Self.maxBuckets {
+            if let victim = aggregates.min(by: { $0.value.lastTouch < $1.value.lastTouch })?.key {
+                aggregates.removeValue(forKey: victim)
+            }
+        }
+        aggregates[key] = ring
     }
 
     /// Quantile estimate with the documented fallback chain:
@@ -145,44 +191,55 @@ public final class TTFTQuantileTracker: @unchecked Sendable {
     /// (model, warm) aggregate → model aggregate (both `.low`) → nil, in
     /// which case the caller quotes its benchmark/manifest-derived floor with
     /// `confidence = .low`.
+    ///
+    /// Every tier is a single dictionary lookup against a precomputed ring —
+    /// an exact-bucket hit copies only its own ≤ ``ringCapacity`` samples and
+    /// never touches the fallback tiers, so probe cost is independent of how
+    /// many buckets the model has accumulated.
     public func estimate(
         model: String,
         warm: Bool,
         promptBucket: Int,
         batchBucket: Int
     ) -> Estimate? {
-        let (exact, modelWarm, modelAny) = lock.withLock {
-            () -> ([Double], [Double], [Double]) in
-            var exact: [Double] = []
-            var modelWarm: [Double] = []
-            var modelAny: [Double] = []
-            for (key, ring) in buckets where key.model == model {
-                modelAny.append(contentsOf: ring.samples)
-                guard key.warm == warm else { continue }
-                modelWarm.append(contentsOf: ring.samples)
-                if key.promptBucket == promptBucket, key.batchBucket == batchBucket {
-                    exact = ring.samples
-                }
+        let key = Key(
+            model: model, warm: warm,
+            promptBucket: promptBucket, batchBucket: batchBucket)
+        let resolved = lock.withLock {
+            () -> ([Double], CapacityQuoteConfidence)? in
+            if let ring = buckets[key], !ring.samples.isEmpty {
+                let confidence: CapacityQuoteConfidence =
+                    ring.samples.count >= Self.highConfidenceMinSamples ? .high : .low
+                return (ring.samples, confidence)
             }
-            return (exact, modelWarm, modelAny)
+            if let ring = modelWarmAggregates[ModelWarmKey(model: model, warm: warm)],
+                !ring.samples.isEmpty
+            {
+                return (ring.samples, .low)
+            }
+            if let ring = modelAggregates[model], !ring.samples.isEmpty {
+                return (ring.samples, .low)
+            }
+            return nil
         }
-        if exact.count >= Self.highConfidenceMinSamples {
-            return Self.quantiles(exact, confidence: .high)
-        }
-        if !exact.isEmpty {
-            return Self.quantiles(exact, confidence: .low)
-        }
-        if !modelWarm.isEmpty {
-            return Self.quantiles(modelWarm, confidence: .low)
-        }
-        if !modelAny.isEmpty {
-            return Self.quantiles(modelAny, confidence: .low)
-        }
-        return nil
+        guard let (samples, confidence) = resolved else { return nil }
+        return Self.quantiles(samples, confidence: confidence)
     }
 
-    /// Nearest-rank quantiles over a copy of the samples. Sorting ≤ a few
-    /// hundred doubles at probe rate is noise; recording stays O(1).
+    /// Test seam for the boundedness contract: the sample count currently
+    /// held by each fallback tier for `model`. Lets tests assert a probe can
+    /// only ever touch bounded work (≤ ``ringCapacity`` per tier) without
+    /// timing assertions.
+    func aggregateSampleCounts(model: String, warm: Bool) -> (modelWarm: Int, model: Int) {
+        lock.withLock {
+            (modelWarmAggregates[ModelWarmKey(model: model, warm: warm)]?.samples.count ?? 0,
+             modelAggregates[model]?.samples.count ?? 0)
+        }
+    }
+
+    /// Nearest-rank quantiles over a copy of the samples. Every tier is a
+    /// bounded ring, so this sorts ≤ ``ringCapacity`` doubles per probe;
+    /// recording stays O(1).
     private static func quantiles(
         _ samples: [Double],
         confidence: CapacityQuoteConfidence

--- a/provider-swift/Sources/ProviderCore/Protocol/CapacityQuotes.swift
+++ b/provider-swift/Sources/ProviderCore/Protocol/CapacityQuotes.swift
@@ -1,0 +1,76 @@
+// Copyright © 2026 Eigen Labs.
+//
+// Shared vocabulary for the routing-v2 capacity probe/quote protocol and the
+// enriched capacity rejections (mirrors coordinator/protocol/capacity.go —
+// same change, symmetry-tested).
+//
+// Production evidence (coordinator/registry/budget_clamp.go): 11,581
+// capacity-shaped provider 503s in 6h from boxes whose heartbeats looked ~1.4%
+// utilized. The reasons below turn each of those rejections — and each
+// negative quote — into a machine-classified state sample the coordinator can
+// feed its ledger, clamp, and failure taxonomy, instead of a bare 503.
+
+import Foundation
+
+/// Bounded, closed rejection vocabulary shared by capacity quotes and the
+/// enriched inference-error fields. Closed by construction: callers can only
+/// place one of these on the wire, never request-derived text.
+public enum CapacityRejectionReason: String, Codable, Sendable, Equatable, CaseIterable {
+    /// The live continuous-batch token budget cannot admit the request NOW
+    /// (transient: frees as running sequences retire).
+    case tokenBudget = "token_budget"
+    /// The request can NEVER fit this slot's KV byte budget, even empty
+    /// (prompt bucket + max output exceeds the whole grant).
+    case kvHeadroom = "kv_headroom"
+    /// UnifiedMemoryCap-derived pressure: the model is not resident and the
+    /// box cannot load it right now (weights + load headroom exceed free
+    /// unified memory), or vision-tower admission is impossible on this GPU.
+    case memoryCap = "memory_cap"
+    /// The slot is not in a serveable state: crashed, reloading, draining
+    /// for update, shutting down, or the model is simply not resident with
+    /// no capacity report yet.
+    case slotState = "slot_state"
+    /// The model's chat template failed its render self-check
+    /// (`ModelInfo.templateRenderOK == false`); requests would fail at render.
+    case template
+    /// The provider cannot serve this request shape at all: model not
+    /// advertised, or vision input probed against a text-only build.
+    case capability
+    /// The earliest feasible start (queue estimate) already exceeds the
+    /// request's remaining first-content deadline — admitting would only
+    /// burn the client's clock.
+    case deadline
+}
+
+/// Confidence of a quote's TTFT estimate. `high` means the quantiles come
+/// from enough completed real requests in the matching bucket; `low` marks
+/// aggregate/floor fallbacks the coordinator should trust less than its own
+/// calibration.
+public enum CapacityQuoteConfidence: String, Codable, Sendable, Equatable, CaseIterable {
+    case high
+    case low
+}
+
+extension CapacityRejectionReason {
+    /// Map the existing bounded diagnostic vocabulary onto the shared quote
+    /// rejection enum, for enriching capacity-shaped inference errors. Returns
+    /// nil for reasons that are not capacity-shaped (client errors, jinja
+    /// diagnostics ride the `template` class only via render-check state).
+    public init?(errorReason: InferenceErrorReason) {
+        switch errorReason {
+        case .tokenBudgetExhausted, .requestExceedsBatchTokenBudget,
+            .queueFull, .capacityBusy, .capacityTimeout:
+            self = .tokenBudget
+        case .requestExceedsContext, .requestExceedsNode, .requestExceedsNodeBudget:
+            self = .kvHeadroom
+        case .modelLoad:
+            self = .memoryCap
+        case .deadlineUnreachable:
+            self = .deadline
+        case .jinjaChannelTags, .jinjaNullBridge, .jinjaTemplate:
+            self = .template
+        case .cancelled, .clientError, .toolNoncompliance:
+            return nil
+        }
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Protocol/Messages.swift
+++ b/provider-swift/Sources/ProviderCore/Protocol/Messages.swift
@@ -387,7 +387,10 @@ public enum ProviderMessage: Sendable, Equatable {
         /// snapshot, so every rejection doubles as a fresh state sample.
         public let rejectionReason: CapacityRejectionReason?
         /// Live admittable token budget of the rejected model's slot at the
-        /// moment of rejection (max − used − queued, floored at 0).
+        /// moment of rejection (max − used − queued, floored at 0). Presence
+        /// semantics on the wire: nil is omitted, but an EXPLICIT ZERO is
+        /// encoded — a busy slot with zero free tokens must say so, or the
+        /// coordinator falls back to its stale heartbeat budget.
         public let availableTokenBudget: Int64?
         /// Estimated milliseconds until the request would become admissible
         /// (duration, never a wall clock). Omitted when inestimable.
@@ -1004,14 +1007,17 @@ extension ProviderMessage: Codable {
             // wire shape is byte-identical (mirrors Go `omitempty`).
             try container.encodeIfPresent(e.terminalCause?.rawValue, forKey: .terminalCause)
             try container.encodeIfPresent(e.attemptUsage, forKey: .attemptUsage)
-            // Enriched capacity-rejection additions (routing v2). Mirror Go
-            // `omitempty`: nil AND zero stay off the wire, so a legacy frame
-            // re-encodes byte-identically and absent decodes as zero on the
-            // Go side either way.
+            // Enriched capacity-rejection additions (routing v2). Nil stays
+            // off the wire so a legacy frame re-encodes byte-identically.
             try container.encodeIfPresent(e.rejectionReason?.rawValue, forKey: .rejectionReason)
-            if let budget = e.availableTokenBudget, budget != 0 {
-                try container.encode(budget, forKey: .availableTokenBudget)
-            }
+            // available_token_budget carries PRESENCE semantics, not Go
+            // omitempty: an explicit zero is real state — "busy slot, zero
+            // free tokens right now" — and must reach the coordinator.
+            // Omitting it made the coordinator fall back to the stale
+            // heartbeat budget, which could misclassify this transient
+            // reject as deterministic and stop failover. The Go mirror is
+            // `*int64` (nil omitted, zero encoded) for the same reason.
+            try container.encodeIfPresent(e.availableTokenBudget, forKey: .availableTokenBudget)
             if let feasibleAfterMs = e.feasibleAfterMs, feasibleAfterMs != 0 {
                 try container.encode(feasibleAfterMs, forKey: .feasibleAfterMs)
             }

--- a/provider-swift/Sources/ProviderCore/Protocol/Messages.swift
+++ b/provider-swift/Sources/ProviderCore/Protocol/Messages.swift
@@ -170,6 +170,7 @@ public enum ProviderMessage: Sendable, Equatable {
     case prefixCacheReady(PrefixCacheReady)
     case prefixCacheLookupV2(PrefixCacheLookupV2)
     case prefixCacheReadyV2(PrefixCacheReadyV2)
+    case capacityQuote(CapacityQuote)
 
     public struct Register: Sendable, Equatable {
         public var hardware: HardwareInfo
@@ -379,6 +380,21 @@ public enum ProviderMessage: Sendable, Equatable {
         /// persists/telemeters it but never bills from it. Omitted on the wire
         /// when nil (legacy providers, or a terminal with no usage).
         public let attemptUsage: UsageInfo?
+        /// Routing-v2 enriched capacity rejection (additive, all omitted when
+        /// absent so legacy frames stay byte-identical; mirrors the Go
+        /// `omitempty` additions on InferenceErrorMessage). Populated only on
+        /// capacity-shaped live-gate rejections, from the published capacity
+        /// snapshot, so every rejection doubles as a fresh state sample.
+        public let rejectionReason: CapacityRejectionReason?
+        /// Live admittable token budget of the rejected model's slot at the
+        /// moment of rejection (max − used − queued, floored at 0).
+        public let availableTokenBudget: Int64?
+        /// Estimated milliseconds until the request would become admissible
+        /// (duration, never a wall clock). Omitted when inestimable.
+        public let feasibleAfterMs: Int64?
+        /// `capacity_seq` of the published snapshot this rejection was
+        /// evaluated against, so the coordinator can order it with heartbeats.
+        public let capacitySeq: UInt64?
 
         public init(
             requestId: String,
@@ -390,6 +406,10 @@ public enum ProviderMessage: Sendable, Equatable {
             self.errorReason = failure.errorReason
             self.terminalCause = failure.terminalCause
             self.attemptUsage = failure.attemptUsage
+            self.rejectionReason = failure.rejectionReason
+            self.availableTokenBudget = failure.availableTokenBudget
+            self.feasibleAfterMs = failure.feasibleAfterMs
+            self.capacitySeq = failure.capacitySeq
         }
 
         /// Decoder-only compatibility path. Discards the legacy free-form
@@ -401,7 +421,11 @@ public enum ProviderMessage: Sendable, Equatable {
             statusCode: UInt16,
             errorReason: InferenceErrorReason?,
             terminalCause: InferenceTerminalCause?,
-            attemptUsage: UsageInfo?
+            attemptUsage: UsageInfo?,
+            rejectionReason: CapacityRejectionReason?,
+            availableTokenBudget: Int64?,
+            feasibleAfterMs: Int64?,
+            capacitySeq: UInt64?
         ) {
             self.requestId = decodedRequestId
             self.failureCode = failureCode
@@ -409,6 +433,10 @@ public enum ProviderMessage: Sendable, Equatable {
             self.errorReason = errorReason
             self.terminalCause = terminalCause
             self.attemptUsage = attemptUsage
+            self.rejectionReason = rejectionReason
+            self.availableTokenBudget = availableTokenBudget
+            self.feasibleAfterMs = feasibleAfterMs
+            self.capacitySeq = capacitySeq
         }
     }
 
@@ -708,6 +736,59 @@ public enum ProviderMessage: Sendable, Equatable {
             self.signature = signature
         }
     }
+
+    /// Reply to a `CoordinatorMessage.CapacityProbe` (routing v2). Computed
+    /// from the lock-free published capacity snapshot — never by running
+    /// inference, loading a model, or allocating KV. Mirrors
+    /// CapacityQuoteMessage (Go); every field except `rejection_reason` is
+    /// always on the wire (Go has no `omitempty` on them).
+    public struct CapacityQuote: Sendable, Equatable {
+        /// Echo of the probe's random, request-local id. Never a stable
+        /// request/consumer identifier.
+        public var quoteId: String
+        /// Sequence of the published capacity snapshot this quote was
+        /// computed from. Carried so ordering against heartbeats is possible;
+        /// the coordinator currently trusts the 250ms probe window and does
+        /// not compare seqs.
+        public var capacitySeq: UInt64
+        public var admissibleNow: Bool
+        /// Bounded reason; nil (omitted) exactly when `admissibleNow`.
+        public var rejectionReason: CapacityRejectionReason?
+        /// End-to-end TTFT distribution quantiles (dispatch-received →
+        /// first token) from completed real requests — never a sum of
+        /// per-stage p95s, and durations only (never wall clocks).
+        public var ttftP50Ms: Double
+        public var ttftP90Ms: Double
+        /// Estimated wait before the request could start (0 when admissible).
+        public var queueEstMs: Double
+        /// Live admittable token budget (max − used − queued, floored at 0).
+        public var availableTokenBudget: Int64
+        public var confidence: CapacityQuoteConfidence
+
+        public init(
+            quoteId: String,
+            capacitySeq: UInt64,
+            admissibleNow: Bool,
+            rejectionReason: CapacityRejectionReason? = nil,
+            ttftP50Ms: Double,
+            ttftP90Ms: Double,
+            queueEstMs: Double,
+            availableTokenBudget: Int64,
+            confidence: CapacityQuoteConfidence
+        ) {
+            self.quoteId = quoteId
+            self.capacitySeq = capacitySeq
+            self.admissibleNow = admissibleNow
+            // Pin the contract at the type boundary: a reason rides the wire
+            // exactly when the quote is a rejection.
+            self.rejectionReason = admissibleNow ? nil : rejectionReason
+            self.ttftP50Ms = ttftP50Ms
+            self.ttftP90Ms = ttftP90Ms
+            self.queueEstMs = queueEstMs
+            self.availableTokenBudget = availableTokenBudget
+            self.confidence = confidence
+        }
+    }
 }
 
 // MARK: - ProviderMessage Codable
@@ -729,6 +810,7 @@ extension ProviderMessage: Codable {
         case prefixCacheReady = "prefix_cache_ready"
         case prefixCacheLookupV2 = "prefix_cache_lookup_v2"
         case prefixCacheReadyV2 = "prefix_cache_ready_v2"
+        case capacityQuote = "capacity_quote"
     }
 
     enum CodingKeys: String, CodingKey {
@@ -780,6 +862,18 @@ extension ProviderMessage: Codable {
         case errorReason = "error_reason"
         case terminalCause = "terminal_cause"
         case attemptUsage = "attempt_usage"
+        // Enriched capacity rejection (InferenceError) + CapacityQuote
+        case rejectionReason = "rejection_reason"
+        case availableTokenBudget = "available_token_budget"
+        case feasibleAfterMs = "feasible_after_ms"
+        case capacitySeq = "capacity_seq"
+        // CapacityQuote
+        case quoteId = "quote_id"
+        case admissibleNow = "admissible_now"
+        case ttftP50Ms = "ttft_p50_ms"
+        case ttftP90Ms = "ttft_p90_ms"
+        case queueEstMs = "queue_est_ms"
+        case confidence
         // AttestationResponse
         case nonce, signature
         case statusSignature = "status_signature"
@@ -910,6 +1004,20 @@ extension ProviderMessage: Codable {
             // wire shape is byte-identical (mirrors Go `omitempty`).
             try container.encodeIfPresent(e.terminalCause?.rawValue, forKey: .terminalCause)
             try container.encodeIfPresent(e.attemptUsage, forKey: .attemptUsage)
+            // Enriched capacity-rejection additions (routing v2). Mirror Go
+            // `omitempty`: nil AND zero stay off the wire, so a legacy frame
+            // re-encodes byte-identically and absent decodes as zero on the
+            // Go side either way.
+            try container.encodeIfPresent(e.rejectionReason?.rawValue, forKey: .rejectionReason)
+            if let budget = e.availableTokenBudget, budget != 0 {
+                try container.encode(budget, forKey: .availableTokenBudget)
+            }
+            if let feasibleAfterMs = e.feasibleAfterMs, feasibleAfterMs != 0 {
+                try container.encode(feasibleAfterMs, forKey: .feasibleAfterMs)
+            }
+            if let seq = e.capacitySeq, seq != 0 {
+                try container.encode(seq, forKey: .capacitySeq)
+            }
 
         case .attestationResponse(let a):
             try container.encode(TypeValue.attestationResponse, forKey: .type)
@@ -1022,6 +1130,19 @@ extension ProviderMessage: Codable {
             try container.encode(
                 receipt.expectedPrefillTokensSaved, forKey: .expectedPrefillTokensSaved)
             try container.encodeIfPresent(receipt.stageMs, forKey: .stageMs)
+
+        case .capacityQuote(let q):
+            try container.encode(TypeValue.capacityQuote, forKey: .type)
+            try container.encode(q.quoteId, forKey: .quoteId)
+            try container.encode(q.capacitySeq, forKey: .capacitySeq)
+            try container.encode(q.admissibleNow, forKey: .admissibleNow)
+            // Omitted exactly when admissible (Go `omitempty`).
+            try container.encodeIfPresent(q.rejectionReason, forKey: .rejectionReason)
+            try container.encode(q.ttftP50Ms, forKey: .ttftP50Ms)
+            try container.encode(q.ttftP90Ms, forKey: .ttftP90Ms)
+            try container.encode(q.queueEstMs, forKey: .queueEstMs)
+            try container.encode(q.availableTokenBudget, forKey: .availableTokenBudget)
+            try container.encode(q.confidence, forKey: .confidence)
         }
     }
 
@@ -1122,13 +1243,22 @@ extension ProviderMessage: Codable {
             // the legacy string/status heuristics, exactly like an absent field.
             let terminalCause = (try container.decodeIfPresent(String.self, forKey: .terminalCause))
                 .flatMap(InferenceTerminalCause.init(rawValue:))
+            // Unknown rejection_reason strings likewise decode to nil.
+            let rejectionReason = (try container.decodeIfPresent(String.self, forKey: .rejectionReason))
+                .flatMap(CapacityRejectionReason.init(rawValue:))
             self = .inferenceError(InferenceError(
                 decodedRequestId: try container.decode(String.self, forKey: .requestId),
                 failureCode: failureCode,
                 statusCode: try container.decode(UInt16.self, forKey: .statusCode),
                 errorReason: errorReason,
                 terminalCause: terminalCause,
-                attemptUsage: try container.decodeIfPresent(UsageInfo.self, forKey: .attemptUsage)
+                attemptUsage: try container.decodeIfPresent(UsageInfo.self, forKey: .attemptUsage),
+                rejectionReason: rejectionReason,
+                availableTokenBudget: try container.decodeIfPresent(
+                    Int64.self, forKey: .availableTokenBudget),
+                feasibleAfterMs: try container.decodeIfPresent(
+                    Int64.self, forKey: .feasibleAfterMs),
+                capacitySeq: try container.decodeIfPresent(UInt64.self, forKey: .capacitySeq)
             ))
 
         case .attestationResponse:
@@ -1259,6 +1389,21 @@ extension ProviderMessage: Codable {
                     UInt64.self, forKey: .expectedPrefillTokensSaved),
                 stageMs: try container.decodeIfPresent(Double.self, forKey: .stageMs)
             ))
+
+        case .capacityQuote:
+            self = .capacityQuote(CapacityQuote(
+                quoteId: try container.decode(String.self, forKey: .quoteId),
+                capacitySeq: try container.decodeIfPresent(UInt64.self, forKey: .capacitySeq) ?? 0,
+                admissibleNow: try container.decode(Bool.self, forKey: .admissibleNow),
+                rejectionReason: try container.decodeIfPresent(
+                    CapacityRejectionReason.self, forKey: .rejectionReason),
+                ttftP50Ms: try container.decodeIfPresent(Double.self, forKey: .ttftP50Ms) ?? 0,
+                ttftP90Ms: try container.decodeIfPresent(Double.self, forKey: .ttftP90Ms) ?? 0,
+                queueEstMs: try container.decodeIfPresent(Double.self, forKey: .queueEstMs) ?? 0,
+                availableTokenBudget: try container.decodeIfPresent(
+                    Int64.self, forKey: .availableTokenBudget) ?? 0,
+                confidence: try container.decode(CapacityQuoteConfidence.self, forKey: .confidence)
+            ))
         }
     }
 }
@@ -1275,6 +1420,7 @@ public enum CoordinatorMessage: Sendable, Equatable {
     case prefetchModel(PrefetchModel)
     case desiredModels(DesiredModels)
     case trustStatus(TrustStatus)
+    case capacityProbe(CapacityProbe)
 
     public struct InferenceRequest: Sendable, Equatable {
         public var requestId: String
@@ -1306,6 +1452,50 @@ public enum CoordinatorMessage: Sendable, Equatable {
             self.cacheScope = cacheScope
             self.prefixCacheProtocol = prefixCacheProtocol
             self.toolSchemaMetadataProtocol = toolSchemaMetadataProtocol
+        }
+    }
+
+    /// Routing-v2 capacity probe (coordinator → provider). Carries BUCKETED
+    /// request-shape metadata ONLY — by protocol contract it never contains
+    /// prompt text, ciphertext, image bytes, tool bodies, consumer/account
+    /// identity, or the public request ID (`quoteId` is random and
+    /// request-local). The provider answers with a `capacityQuote` computed
+    /// from its published capacity snapshot. Mirrors CapacityProbeMessage (Go).
+    public struct CapacityProbe: Sendable, Equatable {
+        /// Prompt-size bucket granularity: estimates are rounded UP to a
+        /// multiple of this, so non-serving providers learn shape only.
+        public static let promptBucketTokens = 512
+
+        public var quoteId: String
+        public var model: String
+        /// Prompt token estimate rounded UP to a multiple of
+        /// ``promptBucketTokens`` by the coordinator.
+        public var promptTokensBucket: Int
+        public var maxOutputTokens: Int
+        /// Omitted when false (Go `omitempty`).
+        public var requiresVision: Bool
+        /// Omitted when zero (Go `omitempty`).
+        public var visionImageCount: Int
+        /// Remaining first-content budget of the request being routed, as a
+        /// duration (never a wall-clock timestamp — clock skew).
+        public var deadlineRemainingMs: Int64
+
+        public init(
+            quoteId: String,
+            model: String,
+            promptTokensBucket: Int,
+            maxOutputTokens: Int,
+            requiresVision: Bool = false,
+            visionImageCount: Int = 0,
+            deadlineRemainingMs: Int64
+        ) {
+            self.quoteId = quoteId
+            self.model = model
+            self.promptTokensBucket = promptTokensBucket
+            self.maxOutputTokens = maxOutputTokens
+            self.requiresVision = requiresVision
+            self.visionImageCount = visionImageCount
+            self.deadlineRemainingMs = deadlineRemainingMs
         }
     }
 
@@ -1417,6 +1607,7 @@ extension CoordinatorMessage: Codable {
         case prefetchModel = "prefetch_model"
         case desiredModels = "desired_models"
         case trustStatus = "trust_status"
+        case capacityProbe = "capacity_probe"
     }
 
     enum CodingKeys: String, CodingKey {
@@ -1437,6 +1628,14 @@ extension CoordinatorMessage: Codable {
         case trustLevel = "trust_level"
         case status, reason
         case models
+        // CapacityProbe
+        case quoteId = "quote_id"
+        case model
+        case promptTokensBucket = "prompt_tokens_bucket"
+        case maxOutputTokens = "max_output_tokens"
+        case requiresVision = "requires_vision"
+        case visionImageCount = "vision_image_count"
+        case deadlineRemainingMs = "deadline_remaining_ms"
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -1502,6 +1701,21 @@ extension CoordinatorMessage: Codable {
             if !t.reason.isEmpty {
                 try container.encode(t.reason, forKey: .reason)
             }
+
+        case .capacityProbe(let p):
+            try container.encode(TypeValue.capacityProbe, forKey: .type)
+            try container.encode(p.quoteId, forKey: .quoteId)
+            try container.encode(p.model, forKey: .model)
+            try container.encode(p.promptTokensBucket, forKey: .promptTokensBucket)
+            try container.encode(p.maxOutputTokens, forKey: .maxOutputTokens)
+            // Mirror the Go `omitempty` tags on the vision shape fields.
+            if p.requiresVision {
+                try container.encode(true, forKey: .requiresVision)
+            }
+            if p.visionImageCount != 0 {
+                try container.encode(p.visionImageCount, forKey: .visionImageCount)
+            }
+            try container.encode(p.deadlineRemainingMs, forKey: .deadlineRemainingMs)
         }
     }
 
@@ -1528,6 +1742,22 @@ extension CoordinatorMessage: Codable {
         case .cancel:
             self = .cancel(Cancel(
                 requestId: try container.decode(String.self, forKey: .requestId)
+            ))
+
+        case .capacityProbe:
+            self = .capacityProbe(CapacityProbe(
+                quoteId: try container.decode(String.self, forKey: .quoteId),
+                model: try container.decode(String.self, forKey: .model),
+                promptTokensBucket: try container.decodeIfPresent(
+                    Int.self, forKey: .promptTokensBucket) ?? 0,
+                maxOutputTokens: try container.decodeIfPresent(
+                    Int.self, forKey: .maxOutputTokens) ?? 0,
+                requiresVision: try container.decodeIfPresent(
+                    Bool.self, forKey: .requiresVision) ?? false,
+                visionImageCount: try container.decodeIfPresent(
+                    Int.self, forKey: .visionImageCount) ?? 0,
+                deadlineRemainingMs: try container.decodeIfPresent(
+                    Int64.self, forKey: .deadlineRemainingMs) ?? 0
             ))
 
         case .attestationChallenge:

--- a/provider-swift/Sources/ProviderCore/Protocol/Types.swift
+++ b/provider-swift/Sources/ProviderCore/Protocol/Types.swift
@@ -758,6 +758,13 @@ public struct BackendCapacity: Codable, Sendable, Equatable {
     /// Optional so coordinators and tooling can distinguish providers with the
     /// reclaimer instrumentation from older providers whose counters are unknown.
     public var mlxCacheReclaimer: MLXCacheReclaimerTelemetry?
+    /// Per-connection, monotonically increasing sequence stamped on every
+    /// heartbeat's capacity payload (routing v2). Starts at 1 on each fresh
+    /// coordinator connection so the coordinator can discard loss/reorder of
+    /// out-of-band event heartbeats; 0 means "not stamped" and is OMITTED on
+    /// the wire (mirrors Go `capacity_seq,omitempty` — a session that has sent
+    /// any heartbeat with capacity_seq > 0 is thereby quote-capable).
+    public var capacitySeq: UInt64
 
     enum CodingKeys: String, CodingKey {
         case slots
@@ -767,6 +774,7 @@ public struct BackendCapacity: Codable, Sendable, Equatable {
         case totalMemoryGb = "total_memory_gb"
         case freeForLoadGb = "free_for_load_gb"
         case mlxCacheReclaimer = "mlx_cache_reclaimer"
+        case capacitySeq = "capacity_seq"
     }
 
     public init(
@@ -776,7 +784,8 @@ public struct BackendCapacity: Codable, Sendable, Equatable {
         gpuMemoryCacheGb: Double,
         totalMemoryGb: Double,
         freeForLoadGb: Double = 0,
-        mlxCacheReclaimer: MLXCacheReclaimerTelemetry? = nil
+        mlxCacheReclaimer: MLXCacheReclaimerTelemetry? = nil,
+        capacitySeq: UInt64 = 0
     ) {
         self.slots = slots
         self.gpuMemoryActiveGb = gpuMemoryActiveGb
@@ -785,10 +794,11 @@ public struct BackendCapacity: Codable, Sendable, Equatable {
         self.totalMemoryGb = totalMemoryGb
         self.freeForLoadGb = freeForLoadGb
         self.mlxCacheReclaimer = mlxCacheReclaimer
+        self.capacitySeq = capacitySeq
     }
 
-    // Explicit decode so older payloads without `free_for_load_gb` or
-    // `mlx_cache_reclaimer` still decode. Encoding stays synthesized.
+    // Explicit decode so older payloads without `free_for_load_gb`,
+    // `mlx_cache_reclaimer`, or `capacity_seq` still decode.
     public init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
         self.slots = try c.decode([BackendSlotCapacity].self, forKey: .slots)
@@ -799,6 +809,24 @@ public struct BackendCapacity: Codable, Sendable, Equatable {
         self.freeForLoadGb = try c.decodeIfPresent(Double.self, forKey: .freeForLoadGb) ?? 0
         self.mlxCacheReclaimer = try c.decodeIfPresent(
             MLXCacheReclaimerTelemetry.self, forKey: .mlxCacheReclaimer)
+        self.capacitySeq = try c.decodeIfPresent(UInt64.self, forKey: .capacitySeq) ?? 0
+    }
+
+    // Explicit encode (the other fields' encoding is unchanged from the
+    // synthesized form): `capacity_seq` mirrors Go `omitempty` — an unstamped
+    // payload (0) keeps the legacy wire shape byte-identical.
+    public func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        try c.encode(slots, forKey: .slots)
+        try c.encode(gpuMemoryActiveGb, forKey: .gpuMemoryActiveGb)
+        try c.encode(gpuMemoryPeakGb, forKey: .gpuMemoryPeakGb)
+        try c.encode(gpuMemoryCacheGb, forKey: .gpuMemoryCacheGb)
+        try c.encode(totalMemoryGb, forKey: .totalMemoryGb)
+        try c.encode(freeForLoadGb, forKey: .freeForLoadGb)
+        try c.encodeIfPresent(mlxCacheReclaimer, forKey: .mlxCacheReclaimer)
+        if capacitySeq != 0 {
+            try c.encode(capacitySeq, forKey: .capacitySeq)
+        }
     }
 }
 

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+AutoUpdate.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+AutoUpdate.swift
@@ -186,6 +186,8 @@ extension ProviderLoop {
     /// provider converges back onto the coordinator's current desired set.
     private func resumeServingAfterUpdate() async {
         updatePhase = .idle
+        // Quote path mirror (routing v2): quotes may admit again.
+        state.refusingNewWork = false
 
         if let staged = stagedUpdateBundle {
             stagedUpdateBundle = nil
@@ -208,6 +210,9 @@ extension ProviderLoop {
     /// hot-swap.
     private func beginUpdateDraining() {
         updatePhase = .draining
+        // Quote path mirror (routing v2): while draining, capacity quotes
+        // refuse with `slot_state` exactly like the live admission gate.
+        state.refusingNewWork = true
     }
 
     /// Download, verify, and stage the release bundle while still serving.

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+Capacity.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+Capacity.swift
@@ -195,6 +195,58 @@ extension ProviderLoop {
             postures.append(bridge.slotPosture(await bridge.mtpStatusSnapshot()))
         }
         lastLiveSlotPostures = postures
+
+        // Routing v2, Phase 1: every capacity rebuild flows through here —
+        // request admitted (post-submit refresh), completed/cancelled, model
+        // loaded/unloaded/evicted, wedge recovery flipping a slot to
+        // "crashed"/"reloading", and the periodic tick that picks up token
+        // budget drift. Comparing the fresh payload against the last SENT
+        // heartbeat's payload (the published snapshot) is therefore the one
+        // seam that implements all of the plan's event triggers without
+        // forking any of those call sites.
+        scheduleEventHeartbeatIfMaterial()
+    }
+
+    /// Fire (or schedule) an out-of-band heartbeat when the freshly rebuilt
+    /// capacity materially differs from the last one the coordinator saw.
+    /// Rate-capped at 2/s with trailing-edge coalescing; a change inside the
+    /// cap window is never dropped — the trailing timer guarantees exactly
+    /// one heartbeat at window end carrying the then-current payload. The 5s
+    /// baseline heartbeat keeps running untouched as liveness.
+    internal func scheduleEventHeartbeatIfMaterial() {
+        guard let capacity = state.backendCapacity else { return }
+        guard CapacityHeartbeatMateriality.isMaterial(
+            previous: state.publishedCapacity, current: capacity)
+        else { return }
+        switch capacityHeartbeatThrottle.noteMaterialChange(now: .now) {
+        case .sendNow:
+            guard let client = coordinatorClient else { return }
+            Task { await client.sendEventHeartbeat() }
+        case .scheduled(let after):
+            let me = self
+            // `Task.sleep(nanoseconds:)`, NOT the Duration/Clock overload —
+            // same -O task-allocator crash documented on the capacity poll
+            // loop above.
+            let delayNs = UInt64(max(0, after.components.seconds)) * 1_000_000_000
+                + UInt64(max(0, after.components.attoseconds / 1_000_000_000))
+            trailingHeartbeatTask = Task {
+                try? await Task.sleep(nanoseconds: delayNs)
+                if Task.isCancelled { return }
+                await me.fireTrailingEventHeartbeat()
+            }
+        case .coalesced:
+            break
+        }
+    }
+
+    /// Trailing-edge send: services the one scheduled verdict. Deliberately
+    /// does NOT rebuild capacity first — `state.backendCapacity` already
+    /// holds the latest rebuild (that rebuild is what coalesced into this
+    /// timer), and rebuilding here would re-enter the materiality check.
+    internal func fireTrailingEventHeartbeat() async {
+        trailingHeartbeatTask = nil
+        guard capacityHeartbeatThrottle.takeScheduledSend(now: .now) else { return }
+        await coordinatorClient?.sendEventHeartbeat()
     }
 
 }

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+InboundDecode.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+InboundDecode.swift
@@ -170,4 +170,27 @@ extension ProviderLoop {
         ) else { return 0 }
         return ids.count
     }
+
+    /// The engine admission view of a request's token envelope: the templated
+    /// prompt recount (``promptTokenFloor`` — the same applyChatTemplate path
+    /// the engine prefills) plus the output reservation the scheduler applies
+    /// (`max_tokens`, or ``schedulerDefaultMaxTokens`` when the request omits
+    /// one). Feeds the busy-wait forecast on enriched token-budget rejections
+    /// (`CapacityRejectionEnrichment.enrich`). nil when the recount fails
+    /// (e.g. the failure WAS a render error) — no honest envelope exists, so
+    /// no forecast is invented.
+    internal static func admissionTokenEnvelope(
+        request: OpenAIChatCompletionRequest,
+        tokenizer: TokenizerHandle,
+        modelType: String?,
+        templateControls: ChatTemplateControls
+    ) -> Int64? {
+        let promptFloor = promptTokenFloor(
+            request: request,
+            tokenizer: tokenizer,
+            modelType: modelType,
+            templateControls: templateControls)
+        guard promptFloor > 0 else { return nil }
+        return Int64(promptFloor + max(0, request.maxTokens ?? schedulerDefaultMaxTokens))
+    }
 }

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+InferenceHandler.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+InferenceHandler.swift
@@ -43,7 +43,11 @@ extension ProviderLoop {
         lookupReceiptFinalizer.sendTerminal(
             .inferenceError(
                 requestId: requestId,
-                failure: InferenceFailure(code: .capacity, statusCode: 503)),
+                failure: CapacityRejectionEnrichment.enrich(
+                    InferenceFailure(code: .capacity, statusCode: 503),
+                    modelId: nil,
+                    published: state.publishedCapacity,
+                    fallbackReason: .slotState)),
             fallbackFailure: .capacity,
             send: send)
         return true
@@ -73,7 +77,11 @@ extension ProviderLoop {
             lookupReceiptFinalizer.sendTerminal(
                 .inferenceError(
                     requestId: requestId,
-                    failure: Self.inferenceFailure(for: failure)),
+                    failure: CapacityRejectionEnrichment.enrich(
+                        Self.inferenceFailure(for: failure),
+                        modelId: nil,
+                        published: state.publishedCapacity,
+                        fallbackReason: .deadline)),
                 fallbackFailure: .capacity,
                 send: send)
             return true
@@ -156,6 +164,7 @@ extension ProviderLoop {
         prefixCacheProtocol: Int? = nil,
         toolSchemaMetadataProtocol: Int? = nil,
         firstContentDeadline: FirstContentDeadline? = nil,
+        receivedAt: ContinuousClock.Instant = .now,
         send: SendHandle
     ) async {
         logger.info("Processing inference request: \(requestId)")
@@ -198,7 +207,11 @@ extension ProviderLoop {
             lookupReceiptFinalizer.sendTerminal(
                 .inferenceError(
                     requestId: requestId,
-                    failure: InferenceFailure(code: .capacity, statusCode: 503)),
+                    failure: CapacityRejectionEnrichment.enrich(
+                        InferenceFailure(code: .capacity, statusCode: 503),
+                        modelId: nil,
+                        published: state.publishedCapacity,
+                        fallbackReason: .slotState)),
                 fallbackFailure: .capacity,
                 send: send)
             return
@@ -350,6 +363,10 @@ extension ProviderLoop {
         // deliberately conservative: when in doubt it admits and lets the
         // post-accept load path below make the final call.
         let modelId = chatRequest.model
+        // Warm/cold classification for the TTFT tracker, captured BEFORE the
+        // load step: a cold sample includes model-load latency and must never
+        // calibrate warm quotes.
+        let modelWasResidentAtDispatch = modelSlots[modelId] != nil
         let fastAdmissionRejected = await fastAdmissionReject(modelId: modelId)
         if rejectIfFirstContentDeadlineExpired(
             firstContentDeadline,
@@ -366,7 +383,11 @@ extension ProviderLoop {
             lookupReceiptFinalizer.sendTerminal(
                 .inferenceError(
                     requestId: requestId,
-                    failure: InferenceFailure(code: .capacity, statusCode: 503)),
+                    failure: CapacityRejectionEnrichment.enrich(
+                        InferenceFailure(code: .capacity, statusCode: 503),
+                        modelId: modelId,
+                        published: state.publishedCapacity,
+                        fallbackReason: .memoryCap)),
                 fallbackFailure: .capacity,
                 send: send)
             return
@@ -434,7 +455,11 @@ extension ProviderLoop {
             }
             await cancellationRegistry.finish(requestId: requestId)
             logger.error("[\(requestId)] model load failed")
-            let failure = Self.loadInferenceFailure(for: error)
+            let failure = CapacityRejectionEnrichment.enrich(
+                Self.loadInferenceFailure(for: error),
+                modelId: modelId,
+                published: state.publishedCapacity,
+                fallbackReason: .memoryCap)
             lookupReceiptFinalizer.sendTerminal(
                 .inferenceError(
                     requestId: requestId,
@@ -488,6 +513,18 @@ extension ProviderLoop {
         let registry = self.cancellationRegistry
         let signingIdentity = self.signer
         let log = self.logger
+        // TTFT tracking inputs (routing v2): the tracker feeds capacity-quote
+        // quantiles from completed real requests. `receivedAt` was anchored by
+        // the CoordinatorClient's receive callback, so the recorded duration
+        // is genuinely dispatch-received → first content token, end to end.
+        // Batch occupancy comes from the latest capacity rebuild — a cheap
+        // lock read that intentionally avoids an engine-actor hop; it can lag
+        // one rebuild behind the engine's row count, which shifts a sample by
+        // at most one batch bucket.
+        let ttftTracker = state.ttftTracker
+        let dispatchReceivedAt = receivedAt
+        let activeRequestsAtDispatch = Int(
+            state.backendCapacity?.slots.first { $0.model == modelId }?.numRunning ?? 0)
         let tokenizer = slot.tokenizer
         // Read modelType from the loaded SLOT, not advertisedModels: the latter
         // goes nil in the hard-swap drop window while the slot is still resident,
@@ -560,7 +597,11 @@ extension ProviderLoop {
                     lookupReceiptFinalizer.sendTerminal(
                         .inferenceError(
                             requestId: requestId,
-                            failure: Self.inferenceFailure(for: failure)),
+                            failure: CapacityRejectionEnrichment.enrich(
+                                Self.inferenceFailure(for: failure),
+                                modelId: modelId,
+                                published: me.state.publishedCapacity,
+                                fallbackReason: .deadline)),
                         fallbackFailure: .capacity,
                         send: send)
                     return true
@@ -747,7 +788,11 @@ extension ProviderLoop {
                     lookupReceiptFinalizer.sendTerminal(
                         .inferenceError(
                             requestId: requestId,
-                            failure: Self.inferenceFailure(for: failure)),
+                            failure: CapacityRejectionEnrichment.enrich(
+                                Self.inferenceFailure(for: failure),
+                                modelId: modelId,
+                                published: me.state.publishedCapacity,
+                                fallbackReason: .deadline)),
                         fallbackFailure: .capacity,
                         send: send)
                     return
@@ -792,7 +837,23 @@ extension ProviderLoop {
                 lookupReceiptFinalizer.sendTerminal(
                     .inferenceError(
                         requestId: requestId,
-                        failure: failure),
+                        // Enrich the capacity-shaped engine rejections (queue
+                        // full, token budget, KV headroom — the live gate's
+                        // fast rejects) with the published snapshot; non-
+                        // capacity failures pass through unchanged. The token
+                        // envelope (evaluated lazily, token_budget shape only)
+                        // lets the enrichment stamp a real feasible_after_ms
+                        // busy-wait forecast.
+                        failure: CapacityRejectionEnrichment.enrich(
+                            failure,
+                            modelId: modelId,
+                            published: me.state.publishedCapacity,
+                            fallbackReason: .tokenBudget,
+                            neededTokens: Self.admissionTokenEnvelope(
+                                request: streamingRequest,
+                                tokenizer: tokenizer,
+                                modelType: modelType,
+                                templateControls: templateControls))),
                     fallbackFailure: failure.statusCode == 503 ? .capacity : .policy,
                     send: send)
                 return
@@ -812,6 +873,11 @@ extension ProviderLoop {
             // fully refund). MLX streams ~1 token per frame, so this slightly
             // under-counts vs. true tokenization but never bills $0 for work.
             var contentFrameCount = 0
+            // End-to-end TTFT (dispatch-received → first content token),
+            // captured at the first content-bearing frame and committed to
+            // the tracker only on clean completion (routing v2 quotes must
+            // calibrate on completed real requests). Duration only.
+            var firstContentElapsedMs: Double?
             // Accumulated `reasoning_content` deltas (gpt-oss analysis
             // channel, Qwen3/DeepSeek <think>, Gemma4 channels). Re-tokenized
             // at completion to report an accurate `reasoning_tokens` count —
@@ -897,6 +963,14 @@ extension ProviderLoop {
                             frameHadContent = true
                         }
                         if frameHadContent {
+                            // First content frame (both counters flip here,
+                            // so one check suffices).
+                            if contentFrameCount == 0 {
+                                let elapsed = ContinuousClock.Instant.now - dispatchReceivedAt
+                                firstContentElapsedMs =
+                                    Double(elapsed.components.seconds) * 1000.0
+                                    + Double(elapsed.components.attoseconds) / 1e15
+                            }
                             contentFrameCount += 1
                         }
                         if let usage = parsed.usage {
@@ -1150,6 +1224,19 @@ extension ProviderLoop {
             // Update stats
             providerStats.incrementRequestsServed()
             providerStats.addTokensGenerated(UInt64(max(completionTokens, 0)))
+
+            // Commit the TTFT sample (routing v2): completed real requests
+            // only — a cancelled stream's first-token timing is still real,
+            // but the plan calibrates quotes on clean completions so partial
+            // settles cannot skew the distribution during incident churn.
+            if !cancelledMidStream, let ttftMs = firstContentElapsedMs {
+                ttftTracker.record(
+                    model: modelId,
+                    warm: modelWasResidentAtDispatch,
+                    promptTokens: promptTokens,
+                    activeRequestsAtDispatch: activeRequestsAtDispatch,
+                    ttftMs: ttftMs)
+            }
 
             // Update state
             await me.updateAggregateCapacity()

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+Serve.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+Serve.swift
@@ -239,7 +239,8 @@ extension ProviderLoop {
                 case .inferenceRequest(
                     let requestId, let ciphertext, let senderPublicKey,
                     let cacheReceiptNonce, let cacheScope, let prefixCacheProtocol,
-                    let toolSchemaMetadataProtocol, let firstContentDeadline
+                    let toolSchemaMetadataProtocol, let firstContentDeadline,
+                    let receivedAt
                 ):
                     await handleInferenceRequest(
                         requestId: requestId,
@@ -250,6 +251,7 @@ extension ProviderLoop {
                         prefixCacheProtocol: prefixCacheProtocol,
                         toolSchemaMetadataProtocol: toolSchemaMetadataProtocol,
                         firstContentDeadline: firstContentDeadline,
+                        receivedAt: receivedAt,
                         send: send
                     )
 
@@ -305,9 +307,14 @@ extension ProviderLoop {
 
         logger.info(.coordinatorEventStreamEnded)
         isShuttingDown = true
+        // Quote path mirror (routing v2): a shutting-down provider quotes
+        // `slot_state` rejections for the brief window the socket stays up.
+        state.refusingNewWork = true
         idleMonitorTask?.cancel()
         idleMonitorTask = nil
         capacityRefreshTask?.cancel()
+        trailingHeartbeatTask?.cancel()
+        trailingHeartbeatTask = nil
         capacityRefreshTask = nil
         autoUpdateTask?.cancel()
         autoUpdateTask = nil

--- a/provider-swift/Sources/ProviderCore/ProviderLoop.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop.swift
@@ -349,6 +349,18 @@ public actor ProviderLoop {
     /// coordinator's per-model catalog routing filter). Set in `run()`.
     internal var coordinatorClient: CoordinatorClient?
 
+    /// Rate cap + trailing-edge coalescing for event-triggered heartbeats
+    /// (routing v2, Phase 1). Driven from `updateAggregateCapacity()` — the
+    /// choke point every material slot-state change already flows through.
+    /// Loop-actor state; the pure policy lives in `CapacityEventHeartbeats`.
+    internal var capacityHeartbeatThrottle = CapacityHeartbeatThrottle()
+
+    /// The one in-flight trailing-edge timer servicing a
+    /// `CapacityHeartbeatThrottle.Verdict.scheduled` verdict. Cancelled on
+    /// shutdown; at most one exists because further changes inside the cap
+    /// window coalesce.
+    internal var trailingHeartbeatTask: Task<Void, Never>?
+
     /// The live outbound send handle (same one prefetch status flows through).
     /// Retained so `applyVerifiedPrefetch` can push an out-of-band
     /// `models_update` carrying the verified build's authoritative `ModelInfo`

--- a/provider-swift/Tests/ProviderCoreTests/CapacityEventHeartbeatTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/CapacityEventHeartbeatTests.swift
@@ -1,0 +1,199 @@
+// Event-triggered heartbeat policy (routing v2, Phase 1): materiality
+// detection against the last published payload, the 2/s rate cap with
+// trailing-edge coalescing (driven with a synthetic clock — the throttle is
+// a pure state machine), and per-connection capacity_seq monotonicity.
+
+import Foundation
+import Testing
+@testable import ProviderCore
+
+private func slot(
+    model: String = "org/model-a",
+    state: String = "running",
+    numRunning: UInt32 = 1,
+    numWaiting: UInt32 = 0,
+    used: Int64 = 1000,
+    max: Int64 = 9000,
+    queued: Int64 = 0
+) -> BackendSlotCapacity {
+    BackendSlotCapacity(
+        model: model,
+        state: state,
+        numRunning: numRunning,
+        numWaiting: numWaiting,
+        activeTokens: 0,
+        maxTokensPotential: 0,
+        activeTokenBudgetUsed: used,
+        activeTokenBudgetMax: max,
+        queuedTokenBudget: queued)
+}
+
+private func capacity(_ slots: [BackendSlotCapacity]) -> BackendCapacity {
+    BackendCapacity(
+        slots: slots,
+        gpuMemoryActiveGb: 1,
+        gpuMemoryPeakGb: 1,
+        gpuMemoryCacheGb: 0,
+        totalMemoryGb: 64)
+}
+
+// MARK: - Materiality
+
+@Test func firstRebuildAndSlotRosterChangesAreMaterial() {
+    let current = capacity([slot()])
+    // Nothing published yet.
+    #expect(CapacityHeartbeatMateriality.isMaterial(previous: nil, current: current))
+    // Model loaded (roster grew).
+    #expect(CapacityHeartbeatMateriality.isMaterial(
+        previous: capacity([]),
+        current: current))
+    // Model unloaded/evicted (roster shrank).
+    #expect(CapacityHeartbeatMateriality.isMaterial(
+        previous: capacity([slot(), slot(model: "org/model-b")]),
+        current: current))
+    // Identical payload: nothing to push.
+    #expect(!CapacityHeartbeatMateriality.isMaterial(previous: current, current: current))
+}
+
+@Test func admissionCompletionAndHealthTransitionsAreMaterial() {
+    let base = capacity([slot(numRunning: 1)])
+    // Request admitted / completed: numRunning moved.
+    #expect(CapacityHeartbeatMateriality.isMaterial(
+        previous: base, current: capacity([slot(numRunning: 2)])))
+    #expect(CapacityHeartbeatMateriality.isMaterial(
+        previous: base, current: capacity([slot(numRunning: 0)])))
+    // Queue depth moved.
+    #expect(CapacityHeartbeatMateriality.isMaterial(
+        previous: base, current: capacity([slot(numWaiting: 1)])))
+    // Slot crashed / entered recovery reload.
+    #expect(CapacityHeartbeatMateriality.isMaterial(
+        previous: base, current: capacity([slot(state: "crashed")])))
+    #expect(CapacityHeartbeatMateriality.isMaterial(
+        previous: base, current: capacity([slot(state: "reloading")])))
+}
+
+@Test func tokenBudgetShiftsUseFloorAndFractionThresholds() {
+    // Available budget = max − used − queued = 8000.
+    let base = capacity([slot(used: 1000, max: 9000)])
+    // Large budget (available 100k): the 1024-token floor is the binding
+    // threshold (10% would be 10k).
+    let big = capacity([slot(used: 0, max: 100_000)])
+    #expect(!CapacityHeartbeatMateriality.isMaterial(
+        previous: big, current: capacity([slot(used: 1023, max: 100_000)])))
+    #expect(CapacityHeartbeatMateriality.isMaterial(
+        previous: big, current: capacity([slot(used: 1024, max: 100_000)])))
+
+    // Small budget: the 10% fraction binds below the 1024 floor.
+    // available 5000 → 10% = 500.
+    let small = capacity([slot(used: 4000, max: 9000)])
+    #expect(!CapacityHeartbeatMateriality.isMaterial(
+        previous: small, current: capacity([slot(used: 4499, max: 9000)])))
+    #expect(CapacityHeartbeatMateriality.isMaterial(
+        previous: small, current: capacity([slot(used: 4500, max: 9000)])))
+
+    // Queued budget counts against availability the same way.
+    #expect(CapacityHeartbeatMateriality.isMaterial(
+        previous: base, current: capacity([slot(used: 1000, max: 9000, queued: 2048)])))
+}
+
+// MARK: - Throttle (deterministic clock)
+
+@Test func throttleSendsImmediatelyOutsideCapWindow() {
+    var throttle = CapacityHeartbeatThrottle()
+    let t0 = ContinuousClock.Instant.now
+    let first = throttle.noteMaterialChange(now: t0)
+    #expect(first == .sendNow)
+    // Past the window: immediate again.
+    let second = throttle.noteMaterialChange(now: t0.advanced(by: .milliseconds(500)))
+    #expect(second == .sendNow)
+}
+
+@Test func throttleCoalescesInsideCapWindowAndGuaranteesTrailingSend() {
+    var throttle = CapacityHeartbeatThrottle()
+    let t0 = ContinuousClock.Instant.now
+    let immediate = throttle.noteMaterialChange(now: t0)
+    #expect(immediate == .sendNow)
+
+    // 200ms later: inside the window → exactly one trailing send scheduled
+    // at window end (300ms out).
+    let t1 = t0.advanced(by: .milliseconds(200))
+    let scheduled = throttle.noteMaterialChange(now: t1)
+    #expect(scheduled == .scheduled(after: .milliseconds(300)))
+
+    // Further changes inside the window coalesce into that one send.
+    let t2 = t0.advanced(by: .milliseconds(300))
+    let coalescedA = throttle.noteMaterialChange(now: t2)
+    let coalescedB = throttle.noteMaterialChange(now: t2)
+    #expect(coalescedA == .coalesced)
+    #expect(coalescedB == .coalesced)
+
+    // The trailing timer fires: the send must happen (never dropped) and is
+    // accounted against the cap.
+    let t3 = t0.advanced(by: .milliseconds(500))
+    let fired = throttle.takeScheduledSend(now: t3)
+    #expect(fired)
+    // Duplicate service of the same verdict is refused.
+    let refired = throttle.takeScheduledSend(now: t3)
+    #expect(!refired)
+
+    // The trailing send restarted the cap window: an immediate change is
+    // throttled again.
+    let t4 = t3.advanced(by: .milliseconds(100))
+    let rethrottled = throttle.noteMaterialChange(now: t4)
+    #expect(rethrottled == .scheduled(after: .milliseconds(400)))
+}
+
+@Test func throttleEnforcesTwoPerSecond() {
+    var throttle = CapacityHeartbeatThrottle()
+    let t0 = ContinuousClock.Instant.now
+    var sends = 0
+    // A change every 50ms for one second: 2 immediate+trailing pairs max.
+    var scheduledAt: ContinuousClock.Instant?
+    for i in 0..<20 {
+        let now = t0.advanced(by: .milliseconds(50 * i))
+        if let due = scheduledAt, now >= due {
+            if throttle.takeScheduledSend(now: due) { sends += 1 }
+            scheduledAt = nil
+        }
+        switch throttle.noteMaterialChange(now: now) {
+        case .sendNow:
+            sends += 1
+        case .scheduled(let after):
+            scheduledAt = now.advanced(by: after)
+        case .coalesced:
+            break
+        }
+    }
+    if let due = scheduledAt {
+        if throttle.takeScheduledSend(now: due) { sends += 1 }
+    }
+    // 1s of continuous churn at a 500ms min interval: ≤ 3 sends land inside
+    // the window [t0, t0+1s] (t0, t0+500ms, t0+1s) — never one per change.
+    #expect(sends <= 3)
+    #expect(sends >= 2)
+}
+
+// MARK: - capacity_seq monotonicity (per connection)
+
+@Test func stampAndPublishAdvancesSeqMonotonicallyAndResetsPerConnection() {
+    let state = ProviderState()
+    let payload = capacity([slot()])
+
+    // Nil capacity (startup, nothing rebuilt yet): no stamp, no seq burn.
+    #expect(state.stampAndPublishHeartbeatCapacity(nil) == nil)
+    #expect(state.publishedCapacity == nil)
+
+    let first = state.stampAndPublishHeartbeatCapacity(payload)
+    let second = state.stampAndPublishHeartbeatCapacity(payload)
+    let third = state.stampAndPublishHeartbeatCapacity(payload)
+    #expect(first?.capacitySeq == 1)
+    #expect(second?.capacitySeq == 2)
+    #expect(third?.capacitySeq == 3)
+    // The published snapshot is exactly the last stamped payload.
+    #expect(state.publishedCapacity?.capacitySeq == 3)
+
+    // Reconnect: seq restarts at 1 and the stale snapshot is dropped.
+    state.resetCapacitySession()
+    #expect(state.publishedCapacity == nil)
+    #expect(state.stampAndPublishHeartbeatCapacity(payload)?.capacitySeq == 1)
+}

--- a/provider-swift/Tests/ProviderCoreTests/CapacityEventHeartbeatTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/CapacityEventHeartbeatTests.swift
@@ -96,6 +96,53 @@ private func capacity(_ slots: [BackendSlotCapacity]) -> BackendCapacity {
         previous: base, current: capacity([slot(used: 1000, max: 9000, queued: 2048)])))
 }
 
+@Test func opposingPerSlotBudgetShiftsNeverCancel() {
+    // Model A loses 50k tokens while model B gains 50k: the aggregate is
+    // unchanged, but A's coordinator ledger is now stale-optimistic by 50k —
+    // exactly the staleness event heartbeats exist to push out. Material.
+    let before = capacity([
+        slot(model: "org/model-a", used: 10_000, max: 100_000),
+        slot(model: "org/model-b", used: 60_000, max: 100_000),
+    ])
+    let after = capacity([
+        slot(model: "org/model-a", used: 60_000, max: 100_000),
+        slot(model: "org/model-b", used: 10_000, max: 100_000),
+    ])
+    #expect(CapacityHeartbeatMateriality.isMaterial(previous: before, current: after))
+}
+
+@Test func multiSlotRosterBelowAllThresholdsStaysNonMaterial() {
+    // Two slots each drift well under both the 1024-token floor and the 10%
+    // fraction, and the aggregate drift (300 + 200 = 500) stays under both
+    // too: no heartbeat.
+    let before = capacity([
+        slot(model: "org/model-a", used: 10_000, max: 100_000),
+        slot(model: "org/model-b", used: 20_000, max: 100_000),
+    ])
+    let after = capacity([
+        slot(model: "org/model-a", used: 10_300, max: 100_000),
+        slot(model: "org/model-b", used: 20_200, max: 100_000),
+    ])
+    #expect(!CapacityHeartbeatMateriality.isMaterial(previous: before, current: after))
+}
+
+@Test func distributedSubThresholdDriftsStillTripTheAggregateFloor() {
+    // Three slots each shift 400 tokens — below the per-slot floor and
+    // fraction — but the fleet total moves 1200 ≥ the 1024 floor: the
+    // aggregate check retains this signal on top of the per-slot rule.
+    let before = capacity([
+        slot(model: "org/model-a", used: 10_000, max: 100_000),
+        slot(model: "org/model-b", used: 10_000, max: 100_000),
+        slot(model: "org/model-c", used: 10_000, max: 100_000),
+    ])
+    let after = capacity([
+        slot(model: "org/model-a", used: 10_400, max: 100_000),
+        slot(model: "org/model-b", used: 10_400, max: 100_000),
+        slot(model: "org/model-c", used: 10_400, max: 100_000),
+    ])
+    #expect(CapacityHeartbeatMateriality.isMaterial(previous: before, current: after))
+}
+
 // MARK: - Throttle (deterministic clock)
 
 @Test func throttleSendsImmediatelyOutsideCapWindow() {

--- a/provider-swift/Tests/ProviderCoreTests/CapacityQuoteEngineTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/CapacityQuoteEngineTests.swift
@@ -1,0 +1,286 @@
+// Quote computation (routing v2, Phase 2): every feasibility path of
+// `CapacityQuoteEngine` pinned against synthetic snapshots — pure values, no
+// engine, no GPU. Gates are the EXISTING implementations' published outputs;
+// these tests pin how the engine consults them and which bounded reason each
+// failure maps to, including the deadline and vision rejects.
+
+import Foundation
+import Testing
+@testable import ProviderCore
+
+private func probe(
+    model: String = "org/model-a",
+    promptBucket: Int = 512,
+    maxOutput: Int = 512,
+    requiresVision: Bool = false,
+    visionImages: Int = 0,
+    deadlineMs: Int64 = 9000
+) -> CoordinatorMessage.CapacityProbe {
+    CoordinatorMessage.CapacityProbe(
+        quoteId: "q-test",
+        model: model,
+        promptTokensBucket: promptBucket,
+        maxOutputTokens: maxOutput,
+        requiresVision: requiresVision,
+        visionImageCount: visionImages,
+        deadlineRemainingMs: deadlineMs)
+}
+
+private func slot(
+    model: String = "org/model-a",
+    state: String = "running",
+    numRunning: UInt32 = 1,
+    maxConcurrency: UInt32 = 4,
+    decodeTps: Double = 50,
+    prefillTps: Double = 1000,
+    used: Int64 = 1000,
+    max: Int64 = 9000,
+    queued: Int64 = 0
+) -> BackendSlotCapacity {
+    BackendSlotCapacity(
+        model: model,
+        state: state,
+        numRunning: numRunning,
+        numWaiting: 0,
+        activeTokens: 0,
+        maxTokensPotential: 0,
+        maxConcurrency: maxConcurrency,
+        observedDecodeTps: decodeTps,
+        observedPrefillTps: prefillTps,
+        activeTokenBudgetUsed: used,
+        activeTokenBudgetMax: max,
+        queuedTokenBudget: queued)
+}
+
+private func capacity(
+    _ slots: [BackendSlotCapacity],
+    seq: UInt64 = 7,
+    freeForLoadGb: Double = 40
+) -> BackendCapacity {
+    BackendCapacity(
+        slots: slots,
+        gpuMemoryActiveGb: 1,
+        gpuMemoryPeakGb: 1,
+        gpuMemoryCacheGb: 0,
+        totalMemoryGb: 64,
+        freeForLoadGb: freeForLoadGb,
+        capacitySeq: seq)
+}
+
+private func model(
+    id: String = "org/model-a",
+    weightsGb: Double = 8,
+    isVision: Bool? = nil,
+    templateRenderOK: Bool? = nil
+) -> ModelInfo {
+    ModelInfo(
+        id: id,
+        sizeBytes: UInt64(weightsGb * 1_073_741_824),
+        estimatedMemoryGb: weightsGb,
+        isVision: isVision,
+        templateRenderOK: templateRenderOK)
+}
+
+private let permissiveVision = VisionTowerBudget.Limits(
+    maxBufferBytes: 38 << 30,
+    attentionElementBytes: 2,
+    headFactor: 1)
+
+private func quote(
+    probe p: CoordinatorMessage.CapacityProbe = probe(),
+    capacity c: BackendCapacity?,
+    model m: ModelInfo?,
+    ttft: TTFTQuantileTracker.Estimate? = nil,
+    visionLimits: VisionTowerBudget.Limits = permissiveVision,
+    refusingNewWork: Bool = false
+) -> ProviderMessage.CapacityQuote {
+    CapacityQuoteEngine.quote(CapacityQuoteEngine.Inputs(
+        probe: p,
+        capacity: c,
+        model: m,
+        ttft: ttft,
+        visionLimits: visionLimits,
+        refusingNewWork: refusingNewWork))
+}
+
+// MARK: - Admissible paths
+
+@Test func warmIdleSlotIsAdmissibleWithSnapshotSeqAndBudget() {
+    let q = quote(capacity: capacity([slot()]), model: model())
+    #expect(q.admissibleNow)
+    #expect(q.rejectionReason == nil)
+    #expect(q.capacitySeq == 7)
+    #expect(q.queueEstMs == 0)
+    // available = 9000 − 1000 − 0
+    #expect(q.availableTokenBudget == 8000)
+    #expect(q.quoteId == "q-test")
+}
+
+@Test func advertisedButUnloadedModelIsAdmissibleOnlyWhenColdLoadFits() {
+    // freeForLoadGb (40) ≥ required (8 + headroom): cold-admissible.
+    let fits = quote(capacity: capacity([], freeForLoadGb: 40), model: model(weightsGb: 8))
+    #expect(fits.admissibleNow)
+    #expect(fits.availableTokenBudget == 0)
+
+    // freeForLoadGb below the weights: memory_cap (the published answer of
+    // ModelLoadAdmission.maxLoadableWeightGb says the load gate would refuse).
+    let tooBig = quote(capacity: capacity([], freeForLoadGb: 2), model: model(weightsGb: 8))
+    #expect(!tooBig.admissibleNow)
+    #expect(tooBig.rejectionReason == .memoryCap)
+}
+
+@Test func measuredTTFTQuantilesRideTheQuoteWithConfidence() {
+    let ttft = TTFTQuantileTracker.Estimate(p50Ms: 812, p90Ms: 1650, confidence: .high)
+    let q = quote(capacity: capacity([slot()]), model: model(), ttft: ttft)
+    #expect(q.ttftP50Ms == 812)
+    #expect(q.ttftP90Ms == 1650)
+    #expect(q.confidence == .high)
+
+    // No samples anywhere: prefill-derived floor at confidence low.
+    // 512 tokens / 1000 tps = 512ms.
+    let floored = quote(capacity: capacity([slot()]), model: model())
+    #expect(floored.confidence == .low)
+    #expect(floored.ttftP50Ms == 512)
+    #expect(floored.ttftP90Ms == 512)
+}
+
+// MARK: - Capability / template rejects
+
+@Test func unknownModelRejectsCapability() {
+    let q = quote(capacity: capacity([slot()]), model: nil)
+    #expect(!q.admissibleNow)
+    #expect(q.rejectionReason == .capability)
+}
+
+@Test func visionProbeAgainstTextOnlyModelRejectsCapability() {
+    // requires_vision flag.
+    let flagged = quote(
+        probe: probe(requiresVision: true),
+        capacity: capacity([slot()]),
+        model: model(isVision: nil))
+    #expect(flagged.rejectionReason == .capability)
+    // Image count alone also marks a vision request.
+    let counted = quote(
+        probe: probe(visionImages: 2),
+        capacity: capacity([slot()]),
+        model: model(isVision: nil))
+    #expect(counted.rejectionReason == .capability)
+    // A vision build passes this gate.
+    let vlm = quote(
+        probe: probe(requiresVision: true, visionImages: 2),
+        capacity: capacity([slot()]),
+        model: model(isVision: true))
+    #expect(vlm.admissibleNow)
+}
+
+@Test func brokenTemplateSelfCheckRejectsTemplate() {
+    let q = quote(capacity: capacity([slot()]), model: model(templateRenderOK: false))
+    #expect(q.rejectionReason == .template)
+    // Unknown (nil) is not the broken signal.
+    #expect(quote(capacity: capacity([slot()]), model: model(templateRenderOK: nil)).admissibleNow)
+}
+
+@Test func degenerateVisionTowerRejectsMemoryCap() {
+    // maxAdmissiblePatches == 0: the tower gate can admit nothing.
+    let zeroTower = VisionTowerBudget.Limits(
+        maxBufferBytes: 1,
+        attentionElementBytes: 2,
+        headFactor: 16)
+    let q = quote(
+        probe: probe(visionImages: 1),
+        capacity: capacity([slot()]),
+        model: model(isVision: true),
+        visionLimits: zeroTower)
+    #expect(q.rejectionReason == .memoryCap)
+}
+
+// MARK: - Slot state rejects
+
+@Test func missingSnapshotOrZeroSeqRejectsSlotState() {
+    #expect(quote(capacity: nil, model: model()).rejectionReason == .slotState)
+    #expect(quote(capacity: nil, model: model()).capacitySeq == 0)
+    #expect(
+        quote(capacity: capacity([slot()], seq: 0), model: model())
+            .rejectionReason == .slotState)
+}
+
+@Test func crashedReloadingAndDrainingRejectSlotState() {
+    #expect(
+        quote(capacity: capacity([slot(state: "crashed")]), model: model())
+            .rejectionReason == .slotState)
+    #expect(
+        quote(capacity: capacity([slot(state: "reloading")]), model: model())
+            .rejectionReason == .slotState)
+    #expect(
+        quote(capacity: capacity([slot()]), model: model(), refusingNewWork: true)
+            .rejectionReason == .slotState)
+}
+
+// MARK: - Token budget / KV headroom rejects
+
+@Test func requestExceedingWholeGrantRejectsKVHeadroom() {
+    // needed = 8000 + 2000 > max 9000: never fits, even empty.
+    let q = quote(
+        probe: probe(promptBucket: 8000, maxOutput: 2000),
+        capacity: capacity([slot(used: 0, max: 9000)]),
+        model: model())
+    #expect(q.rejectionReason == .kvHeadroom)
+}
+
+@Test func busySlotRejectsTokenBudgetWithQueueEstimate() {
+    // needed = 1024; available = 9000 − 8500 = 500; deficit 524 @ 50 tps
+    // = 10,480ms wait, within the 60s deadline → token_budget.
+    let q = quote(
+        probe: probe(promptBucket: 512, maxOutput: 512, deadlineMs: 60_000),
+        capacity: capacity([slot(decodeTps: 50, used: 8500, max: 9000)]),
+        model: model())
+    #expect(q.rejectionReason == .tokenBudget)
+    #expect(abs(q.queueEstMs - 524.0 / 50.0 * 1000.0) < 0.001)
+    #expect(q.availableTokenBudget == 500)
+}
+
+@Test func concurrencyFullRejectsTokenBudgetNotSlotState() {
+    // Misclassifying a full batch as health would let the coordinator eject
+    // a healthy provider; it must stay a capacity signal.
+    let q = quote(
+        probe: probe(deadlineMs: 60_000),
+        capacity: capacity([slot(numRunning: 4, maxConcurrency: 4)]),
+        model: model())
+    #expect(q.rejectionReason == .tokenBudget)
+}
+
+@Test func unmeasuredDecodeRateRejectsTokenBudgetWithoutInventedEstimate() {
+    let q = quote(
+        probe: probe(deadlineMs: 100),
+        capacity: capacity([slot(decodeTps: 0, used: 8900, max: 9000)]),
+        model: model())
+    #expect(q.rejectionReason == .tokenBudget)
+    #expect(q.queueEstMs == 0)
+}
+
+// MARK: - Deadline rejects
+
+@Test func waitBeyondDeadlineRejectsDeadline() {
+    // deficit 524 @ 50 tps ≈ 10.5s wait against a 2s deadline.
+    let q = quote(
+        probe: probe(promptBucket: 512, maxOutput: 512, deadlineMs: 2000),
+        capacity: capacity([slot(decodeTps: 50, used: 8500, max: 9000)]),
+        model: model())
+    #expect(q.rejectionReason == .deadline)
+    #expect(q.queueEstMs > 2000)
+}
+
+@Test func expiredDeadlineRejectsDeadlineEvenWhenIdle() {
+    let q = quote(
+        probe: probe(deadlineMs: 0),
+        capacity: capacity([slot(numRunning: 0)]),
+        model: model())
+    #expect(q.rejectionReason == .deadline)
+
+    // Cold-load path honors the deadline too.
+    let cold = quote(
+        probe: probe(deadlineMs: 0),
+        capacity: capacity([], freeForLoadGb: 40),
+        model: model(weightsGb: 8))
+    #expect(cold.rejectionReason == .deadline)
+}

--- a/provider-swift/Tests/ProviderCoreTests/CapacityQuoteEngineTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/CapacityQuoteEngineTests.swift
@@ -117,7 +117,7 @@ private func quote(
 }
 
 @Test func advertisedButUnloadedModelIsAdmissibleOnlyWhenColdLoadFits() {
-    // freeForLoadGb (40) ≥ required (8 + headroom): cold-admissible.
+    // freeForLoadGb (40) ≥ the padded weights (8): cold-admissible.
     let fits = quote(capacity: capacity([], freeForLoadGb: 40), model: model(weightsGb: 8))
     #expect(fits.admissibleNow)
     #expect(fits.availableTokenBudget == 0)
@@ -127,6 +127,50 @@ private func quote(
     let tooBig = quote(capacity: capacity([], freeForLoadGb: 2), model: model(weightsGb: 8))
     #expect(!tooBig.admissibleNow)
     #expect(tooBig.rejectionReason == .memoryCap)
+}
+
+@Test func coldQuoteNeverDoubleChargesTheLoadHeadroom() {
+    // freeForLoadGb rides the heartbeat as ModelLoadAdmission
+    // .maxLoadableWeightGb — ALREADY net of the activation + min-KV load
+    // headroom. A provider whose published figure barely covers the padded
+    // weights must quote admissible: re-adding requiredToLoadGb's headroom
+    // on top would charge it twice and reject exactly the near-capacity
+    // providers the real load gate admits.
+    let weightsGb = 8.0
+    let epsilon = 0.001
+    let q = quote(
+        capacity: capacity([], freeForLoadGb: weightsGb + epsilon),
+        model: model(weightsGb: weightsGb))
+    #expect(q.admissibleNow)
+    #expect(q.rejectionReason == nil)
+
+    // ...and the real load gate agrees, by the same arithmetic: with no
+    // unreclaimable MLX usage, maxLoadableWeightGb == freeForLoadGb − h, so
+    // "weights ≤ published freeForLoadGb" ⟺ canLoad's
+    // "weights + h ≤ raw free". Pin the equivalence on synthetic bytes.
+    let gb = 1024.0 * 1024.0 * 1024.0
+    let headroomGb = 3.0
+    let totalBytes = UInt64(64.0 * gb)
+    let reserveBytes = UInt64(4.0 * gb)
+    // Choose OS-available so the published loadable-weight figure is
+    // weights + epsilon, exactly the quote scenario above.
+    let availableBytes = UInt64((weightsGb + epsilon + headroomGb) * gb) + reserveBytes
+    let published = ModelLoadAdmission.maxLoadableWeightGb(
+        totalBytes: totalBytes,
+        systemAvailableBytes: availableBytes,
+        mlxUsedBytes: 0,
+        reserveBytes: reserveBytes,
+        headroomGb: headroomGb)
+    #expect(abs(published - (weightsGb + epsilon)) < 0.0001)
+    #expect(published >= weightsGb)
+    #expect(ModelLoadAdmission.canLoad(
+        weightsGb: weightsGb,
+        headroomGb: headroomGb,
+        totalBytes: totalBytes,
+        systemAvailableBytes: availableBytes,
+        gpuActiveBytes: 0,
+        gpuCacheBytes: 0,
+        reserveBytes: reserveBytes))
 }
 
 @Test func measuredTTFTQuantilesRideTheQuoteWithConfidence() {

--- a/provider-swift/Tests/ProviderCoreTests/CapacityQuoteProtocolTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/CapacityQuoteProtocolTests.swift
@@ -186,7 +186,7 @@ private func capacity(seq: UInt64) -> BackendCapacity {
 
 // MARK: - enriched inference_error fields
 
-@Test func inferenceErrorEnrichedFieldsEncodeAndOmitLikeGoOmitempty() throws {
+@Test func inferenceErrorEnrichedFieldsEncodePresenceAndOmitempty() throws {
     let enriched = ProviderMessage.inferenceError(ProviderMessage.InferenceError(
         requestId: "req-1",
         failure: InferenceFailure(
@@ -212,8 +212,13 @@ private func capacity(seq: UInt64) -> BackendCapacity {
         #expect(bareObj.keys.contains(key) == false, "unexpected \(key)")
     }
 
-    // Zero values mirror Go omitempty: absent, so absent-decodes-as-zero
-    // agrees on both sides.
+    // feasible_after_ms / capacity_seq mirror Go omitempty (zero ≡ "no
+    // estimate" / "unstamped": absent, so absent-decodes-as-zero agrees on
+    // both sides). available_token_budget does NOT: presence semantics — an
+    // explicit zero is real state ("busy slot, zero free tokens") and must
+    // be encoded, or the coordinator falls back to its stale heartbeat
+    // budget and can misclassify a transient reject as deterministic. The
+    // Go mirror is `*int64`.
     let zeros = ProviderMessage.inferenceError(ProviderMessage.InferenceError(
         requestId: "req-3",
         failure: InferenceFailure(
@@ -223,9 +228,21 @@ private func capacity(seq: UInt64) -> BackendCapacity {
             feasibleAfterMs: 0,
             capacitySeq: 0)))
     let zerosObj = try object(try ProviderProtocolCodec.encodeProviderMessage(zeros))
-    for key in ["available_token_budget", "feasible_after_ms", "capacity_seq"] {
+    #expect(zerosObj["available_token_budget"] as? Int64 == 0)
+    for key in ["feasible_after_ms", "capacity_seq"] {
         #expect(zerosObj.keys.contains(key) == false, "unexpected \(key)")
     }
+
+    // The explicit zero survives a full round trip as a PRESENT zero, and
+    // stays distinguishable from the omitted/nil legacy shape.
+    let zeroRoundTrip = try ProviderProtocolCodec.decodeProviderMessage(
+        from: try ProviderProtocolCodec.encodeProviderMessage(zeros))
+    guard case .inferenceError(let zrt) = zeroRoundTrip else {
+        throw QuoteTestFailure.unexpectedMessage
+    }
+    #expect(zrt.availableTokenBudget == 0)
+    #expect(zrt.feasibleAfterMs == nil)
+    #expect(zrt.capacitySeq == nil)
 }
 
 @Test func inferenceErrorLegacyFramesDecodeUnchangedAndUnknownReasonIsTolerated() throws {

--- a/provider-swift/Tests/ProviderCoreTests/CapacityQuoteProtocolTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/CapacityQuoteProtocolTests.swift
@@ -1,0 +1,271 @@
+// Wire symmetry for the routing-v2 capacity protocol: capacity_probe
+// (decode), capacity_quote (encode), the heartbeat capacity payload's
+// capacity_seq, and the enriched inference_error fields. Key casing and
+// optional-field omission are pinned byte-for-byte against
+// coordinator/protocol/capacity.go — the Go side has the mirror tests.
+
+import Foundation
+import Testing
+@testable import ProviderCore
+
+private enum QuoteTestFailure: Error {
+    case unexpectedMessage
+}
+
+private func object(_ data: Data) throws -> [String: Any] {
+    try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+}
+
+private func slot(
+    model: String = "org/model-a",
+    state: String = "running",
+    numRunning: UInt32 = 1
+) -> BackendSlotCapacity {
+    BackendSlotCapacity(
+        model: model,
+        state: state,
+        numRunning: numRunning,
+        numWaiting: 0,
+        activeTokens: 100,
+        maxTokensPotential: 8192,
+        maxConcurrency: 4,
+        observedDecodeTps: 40,
+        observedPrefillTps: 900,
+        activeTokenBudgetUsed: 1000,
+        activeTokenBudgetMax: 9192,
+        queuedTokenBudget: 0)
+}
+
+private func capacity(seq: UInt64) -> BackendCapacity {
+    BackendCapacity(
+        slots: [slot()],
+        gpuMemoryActiveGb: 1,
+        gpuMemoryPeakGb: 2,
+        gpuMemoryCacheGb: 0.5,
+        totalMemoryGb: 64,
+        freeForLoadGb: 30,
+        capacitySeq: seq)
+}
+
+// MARK: - capacity_seq on the heartbeat capacity payload
+
+@Test func heartbeatCapacitySeqRidesBackendCapacityAndOmitsZero() throws {
+    let stamped = ProviderMessage.heartbeat(ProviderMessage.Heartbeat(
+        status: .serving,
+        stats: ProviderStats(),
+        systemMetrics: SystemMetrics(memoryPressure: 0, cpuUsage: 0, thermalState: .nominal),
+        backendCapacity: capacity(seq: 42)))
+    let stampedObj = try object(try ProviderProtocolCodec.encodeProviderMessage(stamped))
+    let backend = try #require(stampedObj["backend_capacity"] as? [String: Any])
+    #expect(backend["capacity_seq"] as? UInt64 == 42)
+    // Seq lives on the capacity payload, never at heartbeat top level.
+    #expect(stampedObj["capacity_seq"] == nil)
+
+    // Unstamped (0) keeps the legacy wire shape byte-identical.
+    let legacy = ProviderMessage.heartbeat(ProviderMessage.Heartbeat(
+        status: .serving,
+        stats: ProviderStats(),
+        systemMetrics: SystemMetrics(memoryPressure: 0, cpuUsage: 0, thermalState: .nominal),
+        backendCapacity: capacity(seq: 0)))
+    let legacyObj = try object(try ProviderProtocolCodec.encodeProviderMessage(legacy))
+    let legacyBackend = try #require(legacyObj["backend_capacity"] as? [String: Any])
+    #expect(legacyBackend.keys.contains("capacity_seq") == false)
+
+    // Legacy payloads without the key decode as 0; stamped ones round-trip.
+    guard case .heartbeat(let decoded) = try ProviderProtocolCodec.decodeProviderMessage(
+        from: try ProviderProtocolCodec.encodeProviderMessage(stamped))
+    else { throw QuoteTestFailure.unexpectedMessage }
+    #expect(decoded.backendCapacity?.capacitySeq == 42)
+    guard case .heartbeat(let decodedLegacy) = try ProviderProtocolCodec.decodeProviderMessage(
+        from: try ProviderProtocolCodec.encodeProviderMessage(legacy))
+    else { throw QuoteTestFailure.unexpectedMessage }
+    #expect(decodedLegacy.backendCapacity?.capacitySeq == 0)
+}
+
+// MARK: - capacity_probe (coordinator → provider, decode)
+
+@Test func capacityProbeDecodesGoWireFormWithExactKeys() throws {
+    let goWire = #"""
+    {"type":"capacity_probe","quote_id":"q-7f3a","model":"org/model-a",
+     "prompt_tokens_bucket":1536,"max_output_tokens":2048,
+     "requires_vision":true,"vision_image_count":3,
+     "deadline_remaining_ms":8400}
+    """#
+    guard case .capacityProbe(let probe) =
+        try ProviderProtocolCodec.decodeCoordinatorMessage(from: goWire)
+    else { throw QuoteTestFailure.unexpectedMessage }
+    #expect(probe.quoteId == "q-7f3a")
+    #expect(probe.model == "org/model-a")
+    #expect(probe.promptTokensBucket == 1536)
+    #expect(probe.maxOutputTokens == 2048)
+    #expect(probe.requiresVision)
+    #expect(probe.visionImageCount == 3)
+    #expect(probe.deadlineRemainingMs == 8400)
+
+    // Go `omitempty` vision fields absent → defaults, and re-encoding a
+    // text probe never resurrects them.
+    let textWire = #"{"type":"capacity_probe","quote_id":"q1","model":"m","prompt_tokens_bucket":512,"max_output_tokens":128,"deadline_remaining_ms":9000}"#
+    guard case .capacityProbe(let textProbe) =
+        try ProviderProtocolCodec.decodeCoordinatorMessage(from: textWire)
+    else { throw QuoteTestFailure.unexpectedMessage }
+    #expect(textProbe.requiresVision == false)
+    #expect(textProbe.visionImageCount == 0)
+    let reencoded = try object(
+        try ProviderProtocolCodec.encodeCoordinatorMessage(.capacityProbe(textProbe)))
+    #expect(reencoded["type"] as? String == "capacity_probe")
+    #expect(reencoded.keys.contains("requires_vision") == false)
+    #expect(reencoded.keys.contains("vision_image_count") == false)
+    #expect(reencoded["prompt_tokens_bucket"] as? Int == 512)
+    #expect(reencoded["deadline_remaining_ms"] as? Int64 == 9000)
+
+    // The bucket granularity is part of the shared contract.
+    #expect(CoordinatorMessage.CapacityProbe.promptBucketTokens == 512)
+}
+
+// MARK: - capacity_quote (provider → coordinator, encode)
+
+@Test func capacityQuoteEncodesExactKeysAndOmitsReasonWhenAdmissible() throws {
+    let admissible = ProviderMessage.capacityQuote(ProviderMessage.CapacityQuote(
+        quoteId: "q-1",
+        capacitySeq: 9,
+        admissibleNow: true,
+        ttftP50Ms: 850.5,
+        ttftP90Ms: 1900.25,
+        queueEstMs: 0,
+        availableTokenBudget: 8192,
+        confidence: .high))
+    let obj = try object(try ProviderProtocolCodec.encodeProviderMessage(admissible))
+    #expect(obj["type"] as? String == "capacity_quote")
+    #expect(obj["quote_id"] as? String == "q-1")
+    #expect(obj["capacity_seq"] as? UInt64 == 9)
+    #expect(obj["admissible_now"] as? Bool == true)
+    #expect(obj.keys.contains("rejection_reason") == false)
+    #expect(obj["ttft_p50_ms"] as? Double == 850.5)
+    #expect(obj["ttft_p90_ms"] as? Double == 1900.25)
+    #expect(obj["queue_est_ms"] as? Double == 0)
+    #expect(obj["available_token_budget"] as? Int64 == 8192)
+    #expect(obj["confidence"] as? String == "high")
+
+    let rejected = ProviderMessage.capacityQuote(ProviderMessage.CapacityQuote(
+        quoteId: "q-2",
+        capacitySeq: 10,
+        admissibleNow: false,
+        rejectionReason: .tokenBudget,
+        ttftP50Ms: 1000,
+        ttftP90Ms: 2000,
+        queueEstMs: 350,
+        availableTokenBudget: 12,
+        confidence: .low))
+    let rejectedObj = try object(try ProviderProtocolCodec.encodeProviderMessage(rejected))
+    #expect(rejectedObj["admissible_now"] as? Bool == false)
+    #expect(rejectedObj["rejection_reason"] as? String == "token_budget")
+    #expect(rejectedObj["confidence"] as? String == "low")
+
+    // Round trip.
+    let decoded = try ProviderProtocolCodec.decodeProviderMessage(
+        from: try ProviderProtocolCodec.encodeProviderMessage(rejected))
+    #expect(decoded == rejected)
+
+    // The type boundary pins the contract: a reason handed to an admissible
+    // quote is dropped, never encoded.
+    let contradictory = ProviderMessage.CapacityQuote(
+        quoteId: "q-3", capacitySeq: 1, admissibleNow: true,
+        rejectionReason: .deadline,
+        ttftP50Ms: 1, ttftP90Ms: 2, queueEstMs: 0,
+        availableTokenBudget: 0, confidence: .low)
+    #expect(contradictory.rejectionReason == nil)
+}
+
+@Test func capacityRejectionReasonEnumMatchesGoConstants() {
+    #expect(CapacityRejectionReason.allCases.map(\.rawValue) == [
+        "token_budget", "kv_headroom", "memory_cap", "slot_state",
+        "template", "capability", "deadline",
+    ])
+    #expect(CapacityQuoteConfidence.allCases.map(\.rawValue) == ["high", "low"])
+}
+
+// MARK: - enriched inference_error fields
+
+@Test func inferenceErrorEnrichedFieldsEncodeAndOmitLikeGoOmitempty() throws {
+    let enriched = ProviderMessage.inferenceError(ProviderMessage.InferenceError(
+        requestId: "req-1",
+        failure: InferenceFailure(
+            code: .capacity,
+            statusCode: 503,
+            errorReason: .tokenBudgetExhausted,
+            rejectionReason: .tokenBudget,
+            availableTokenBudget: 137,
+            feasibleAfterMs: 450,
+            capacitySeq: 21)))
+    let obj = try object(try ProviderProtocolCodec.encodeProviderMessage(enriched))
+    #expect(obj["rejection_reason"] as? String == "token_budget")
+    #expect(obj["available_token_budget"] as? Int64 == 137)
+    #expect(obj["feasible_after_ms"] as? Int64 == 450)
+    #expect(obj["capacity_seq"] as? UInt64 == 21)
+
+    // Bare legacy failure: none of the four keys appear.
+    let bare = ProviderMessage.inferenceError(ProviderMessage.InferenceError(
+        requestId: "req-2",
+        failure: InferenceFailure(code: .capacity, statusCode: 503)))
+    let bareObj = try object(try ProviderProtocolCodec.encodeProviderMessage(bare))
+    for key in ["rejection_reason", "available_token_budget", "feasible_after_ms", "capacity_seq"] {
+        #expect(bareObj.keys.contains(key) == false, "unexpected \(key)")
+    }
+
+    // Zero values mirror Go omitempty: absent, so absent-decodes-as-zero
+    // agrees on both sides.
+    let zeros = ProviderMessage.inferenceError(ProviderMessage.InferenceError(
+        requestId: "req-3",
+        failure: InferenceFailure(
+            code: .capacity,
+            statusCode: 503,
+            availableTokenBudget: 0,
+            feasibleAfterMs: 0,
+            capacitySeq: 0)))
+    let zerosObj = try object(try ProviderProtocolCodec.encodeProviderMessage(zeros))
+    for key in ["available_token_budget", "feasible_after_ms", "capacity_seq"] {
+        #expect(zerosObj.keys.contains(key) == false, "unexpected \(key)")
+    }
+}
+
+@Test func inferenceErrorLegacyFramesDecodeUnchangedAndUnknownReasonIsTolerated() throws {
+    // A legacy frame without the additive fields decodes with nils.
+    let legacy = #"{"type":"inference_error","request_id":"r","error":"capacity","status_code":503,"failure_code":"capacity"}"#
+    guard case .inferenceError(let decoded) =
+        try ProviderProtocolCodec.decodeProviderMessage(from: legacy)
+    else { throw QuoteTestFailure.unexpectedMessage }
+    #expect(decoded.rejectionReason == nil)
+    #expect(decoded.availableTokenBudget == nil)
+    #expect(decoded.feasibleAfterMs == nil)
+    #expect(decoded.capacitySeq == nil)
+
+    // A future rejection_reason value never crashes an older decoder.
+    let future = #"{"type":"inference_error","request_id":"r","error":"capacity","status_code":503,"rejection_reason":"reason_from_the_future","available_token_budget":5,"capacity_seq":3}"#
+    guard case .inferenceError(let tolerant) =
+        try ProviderProtocolCodec.decodeProviderMessage(from: future)
+    else { throw QuoteTestFailure.unexpectedMessage }
+    #expect(tolerant.rejectionReason == nil)
+    #expect(tolerant.availableTokenBudget == 5)
+    #expect(tolerant.capacitySeq == 3)
+
+    // Full round trip of an enriched frame.
+    let message = ProviderMessage.inferenceError(ProviderMessage.InferenceError(
+        requestId: "req-4",
+        failure: InferenceFailure(
+            code: .capacity,
+            statusCode: 503,
+            errorReason: .queueFull,
+            rejectionReason: .kvHeadroom,
+            availableTokenBudget: 99,
+            feasibleAfterMs: 1200,
+            capacitySeq: 8)))
+    let roundTripped = try ProviderProtocolCodec.decodeProviderMessage(
+        from: try ProviderProtocolCodec.encodeProviderMessage(message))
+    guard case .inferenceError(let rt) = roundTripped else {
+        throw QuoteTestFailure.unexpectedMessage
+    }
+    #expect(rt.rejectionReason == .kvHeadroom)
+    #expect(rt.availableTokenBudget == 99)
+    #expect(rt.feasibleAfterMs == 1200)
+    #expect(rt.capacitySeq == 8)
+}

--- a/provider-swift/Tests/ProviderCoreTests/CapacityRejectionEnrichmentTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/CapacityRejectionEnrichmentTests.swift
@@ -1,0 +1,208 @@
+// Enriched capacity rejections (routing v2, Phase 2): capacity-shaped
+// live-gate failures get rejection_reason + available_token_budget +
+// capacity_seq stamped from the published snapshot — plus, for the transient
+// token_budget shape, the busy-wait feasible_after_ms forecast from the quote
+// engine's estimator; everything else keeps its legacy frame untouched.
+
+import Foundation
+import Testing
+@testable import ProviderCore
+
+private func published(seq: UInt64 = 5, decodeTps: Double = 0) -> BackendCapacity {
+    BackendCapacity(
+        slots: [
+            BackendSlotCapacity(
+                model: "org/model-a",
+                state: "running",
+                numRunning: 2,
+                numWaiting: 0,
+                activeTokens: 0,
+                maxTokensPotential: 0,
+                observedDecodeTps: decodeTps,
+                activeTokenBudgetUsed: 3000,
+                activeTokenBudgetMax: 9000,
+                queuedTokenBudget: 1000)
+        ],
+        gpuMemoryActiveGb: 1,
+        gpuMemoryPeakGb: 1,
+        gpuMemoryCacheGb: 0,
+        totalMemoryGb: 64,
+        capacitySeq: seq)
+}
+
+@Test func bareCapacity503GainsFallbackReasonBudgetAndSeq() {
+    let enriched = CapacityRejectionEnrichment.enrich(
+        InferenceFailure(code: .capacity, statusCode: 503),
+        modelId: "org/model-a",
+        published: published(),
+        fallbackReason: .slotState)
+    #expect(enriched.rejectionReason == .slotState)
+    // 9000 − 3000 − 1000
+    #expect(enriched.availableTokenBudget == 5000)
+    #expect(enriched.capacitySeq == 5)
+    // The pre-existing fields are untouched.
+    #expect(enriched.code == .capacity)
+    #expect(enriched.statusCode == 503)
+    #expect(enriched.feasibleAfterMs == nil)
+}
+
+@Test func errorReasonMapsToBoundedRejectionReasonOverFallback() {
+    let cases: [(InferenceErrorReason, CapacityRejectionReason)] = [
+        (.tokenBudgetExhausted, .tokenBudget),
+        (.requestExceedsBatchTokenBudget, .tokenBudget),
+        (.queueFull, .tokenBudget),
+        (.capacityBusy, .tokenBudget),
+        (.capacityTimeout, .tokenBudget),
+        (.requestExceedsContext, .kvHeadroom),
+        (.requestExceedsNode, .kvHeadroom),
+        (.requestExceedsNodeBudget, .kvHeadroom),
+        (.modelLoad, .memoryCap),
+        (.deadlineUnreachable, .deadline),
+    ]
+    for (errorReason, expected) in cases {
+        let enriched = CapacityRejectionEnrichment.enrich(
+            InferenceFailure(code: .capacity, statusCode: 503, errorReason: errorReason),
+            modelId: "org/model-a",
+            published: published(),
+            fallbackReason: .slotState)
+        #expect(enriched.rejectionReason == expected, "\(errorReason)")
+    }
+    // Non-capacity diagnostic reasons fall back to the caller's gate name.
+    let cancelled = CapacityRejectionEnrichment.enrich(
+        InferenceFailure(code: .capacity, statusCode: 503, errorReason: .cancelled),
+        modelId: nil,
+        published: published(),
+        fallbackReason: .memoryCap)
+    #expect(cancelled.rejectionReason == .memoryCap)
+}
+
+@Test func nonCapacityStatusesPassThroughUntouched() {
+    for status in [UInt16(400), 404, 499, 500, 502] {
+        let failure = InferenceFailure(code: .invalidRequest, statusCode: status)
+        let out = CapacityRejectionEnrichment.enrich(
+            failure,
+            modelId: "org/model-a",
+            published: published(),
+            fallbackReason: .slotState)
+        #expect(out == failure, "status \(status)")
+    }
+}
+
+@Test func queueFull429IsCapacityShapedAndEnriched() {
+    let enriched = CapacityRejectionEnrichment.enrich(
+        InferenceFailure(code: .capacity, statusCode: 429, errorReason: .queueFull),
+        modelId: "org/model-a",
+        published: published(),
+        fallbackReason: .tokenBudget)
+    #expect(enriched.rejectionReason == .tokenBudget)
+    #expect(enriched.availableTokenBudget == 5000)
+    #expect(enriched.capacitySeq == 5)
+}
+
+@Test func missingSnapshotOrModelLeavesOptionalFieldsHonest() {
+    // No published snapshot at all (pre-first-heartbeat): reason still set,
+    // numeric fields stay nil — never invented.
+    let noSnapshot = CapacityRejectionEnrichment.enrich(
+        InferenceFailure(code: .capacity, statusCode: 503),
+        modelId: "org/model-a",
+        published: nil,
+        fallbackReason: .memoryCap)
+    #expect(noSnapshot.rejectionReason == .memoryCap)
+    #expect(noSnapshot.availableTokenBudget == nil)
+    #expect(noSnapshot.capacitySeq == nil)
+
+    // Unknown model: seq is real, budget unknown.
+    let unknownModel = CapacityRejectionEnrichment.enrich(
+        InferenceFailure(code: .capacity, statusCode: 503),
+        modelId: "org/elsewhere",
+        published: published(seq: 9),
+        fallbackReason: .slotState)
+    #expect(unknownModel.availableTokenBudget == nil)
+    #expect(unknownModel.capacitySeq == 9)
+
+    // A zero (unstamped) snapshot seq is never forwarded as if it were real.
+    let unstamped = CapacityRejectionEnrichment.enrich(
+        InferenceFailure(code: .capacity, statusCode: 503),
+        modelId: "org/model-a",
+        published: published(seq: 0),
+        fallbackReason: .slotState)
+    #expect(unstamped.capacitySeq == nil)
+}
+
+@Test func existingEnrichmentAndFeasibleAfterArePreserved() {
+    // A failure already carrying engine-computed values keeps them.
+    let carried = InferenceFailure(
+        code: .capacity,
+        statusCode: 503,
+        errorReason: .tokenBudgetExhausted,
+        rejectionReason: .kvHeadroom,
+        availableTokenBudget: 42,
+        feasibleAfterMs: 777,
+        capacitySeq: 3)
+    let enriched = CapacityRejectionEnrichment.enrich(
+        carried,
+        modelId: "org/model-a",
+        published: published(seq: 9),
+        fallbackReason: .slotState)
+    // Explicit reason wins over the errorReason mapping and the fallback.
+    #expect(enriched.rejectionReason == .kvHeadroom)
+    // feasible_after is engine knowledge; enrichment never overwrites it.
+    #expect(enriched.feasibleAfterMs == 777)
+    // Budget/seq refresh to the snapshot's live values when available.
+    #expect(enriched.availableTokenBudget == 5000)
+    #expect(enriched.capacitySeq == 9)
+}
+
+@Test func tokenBudgetRejectionCarriesBusyWaitForecast() {
+    // Admittable = 9000 − 3000 − 1000 = 5000; envelope 7000 → deficit 2000.
+    // Running sequences retire budget at 100 tok/s → 20_000ms, the same
+    // figure CapacityQuoteEngine.queueEstimateMs would quote.
+    let enriched = CapacityRejectionEnrichment.enrich(
+        InferenceFailure(code: .capacity, statusCode: 503, errorReason: .tokenBudgetExhausted),
+        modelId: "org/model-a",
+        published: published(decodeTps: 100),
+        fallbackReason: .tokenBudget,
+        neededTokens: 7000)
+    #expect(enriched.rejectionReason == .tokenBudget)
+    #expect(enriched.feasibleAfterMs == 20_000)
+}
+
+@Test func busyWaitForecastOmittedWhenInestimable() {
+    // No decode-rate sample (slot never measured TPS): no honest estimate.
+    let unmeasured = CapacityRejectionEnrichment.enrich(
+        InferenceFailure(code: .capacity, statusCode: 503, errorReason: .tokenBudgetExhausted),
+        modelId: "org/model-a",
+        published: published(),
+        fallbackReason: .tokenBudget,
+        neededTokens: 7000)
+    #expect(unmeasured.feasibleAfterMs == nil)
+
+    // No envelope (prompt recount failed): nothing to forecast from.
+    let noEnvelope = CapacityRejectionEnrichment.enrich(
+        InferenceFailure(code: .capacity, statusCode: 503, errorReason: .tokenBudgetExhausted),
+        modelId: "org/model-a",
+        published: published(decodeTps: 100),
+        fallbackReason: .tokenBudget)
+    #expect(noEnvelope.feasibleAfterMs == nil)
+
+    // Envelope already fits (stale-negative gate race): 0 wait is "no
+    // estimate", never stamped.
+    let fits = CapacityRejectionEnrichment.enrich(
+        InferenceFailure(code: .capacity, statusCode: 503, errorReason: .tokenBudgetExhausted),
+        modelId: "org/model-a",
+        published: published(decodeTps: 100),
+        fallbackReason: .tokenBudget,
+        neededTokens: 4000)
+    #expect(fits.feasibleAfterMs == nil)
+
+    // Non-transient shapes (never-fits) have no meaningful "after" even with
+    // an envelope and a measured rate.
+    let neverFits = CapacityRejectionEnrichment.enrich(
+        InferenceFailure(code: .capacity, statusCode: 503, errorReason: .requestExceedsNode),
+        modelId: "org/model-a",
+        published: published(decodeTps: 100),
+        fallbackReason: .tokenBudget,
+        neededTokens: 20_000)
+    #expect(neverFits.rejectionReason == .kvHeadroom)
+    #expect(neverFits.feasibleAfterMs == nil)
+}

--- a/provider-swift/Tests/ProviderCoreTests/CapacityRejectionEnrichmentTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/CapacityRejectionEnrichmentTests.swift
@@ -46,6 +46,37 @@ private func published(seq: UInt64 = 5, decodeTps: Double = 0) -> BackendCapacit
     #expect(enriched.feasibleAfterMs == nil)
 }
 
+@Test func fullyBusySlotSuppliesExplicitZeroBudgetNotNil() {
+    // A slot with zero admittable tokens must enrich to a PRESENT 0 — the
+    // wire encodes it (presence semantics), so the coordinator learns the
+    // budget is exhausted right now instead of falling back to its stale
+    // heartbeat figure and misreading the transient reject as deterministic.
+    let exhausted = BackendCapacity(
+        slots: [
+            BackendSlotCapacity(
+                model: "org/model-a",
+                state: "running",
+                numRunning: 4,
+                numWaiting: 2,
+                activeTokens: 0,
+                maxTokensPotential: 0,
+                activeTokenBudgetUsed: 8000,
+                activeTokenBudgetMax: 9000,
+                queuedTokenBudget: 1000)
+        ],
+        gpuMemoryActiveGb: 1,
+        gpuMemoryPeakGb: 1,
+        gpuMemoryCacheGb: 0,
+        totalMemoryGb: 64,
+        capacitySeq: 6)
+    let enriched = CapacityRejectionEnrichment.enrich(
+        InferenceFailure(code: .capacity, statusCode: 503, errorReason: .tokenBudgetExhausted),
+        modelId: "org/model-a",
+        published: exhausted,
+        fallbackReason: .slotState)
+    #expect(enriched.availableTokenBudget == 0)
+}
+
 @Test func errorReasonMapsToBoundedRejectionReasonOverFallback() {
     let cases: [(InferenceErrorReason, CapacityRejectionReason)] = [
         (.tokenBudgetExhausted, .tokenBudget),

--- a/provider-swift/Tests/ProviderCoreTests/CoordinatorIntegrationTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/CoordinatorIntegrationTests.swift
@@ -151,7 +151,7 @@ struct CoordinatorIntegrationTests {
                 switch event {
                 case .inferenceRequest(
                     let rid, let ciphertext, let senderKey, let nonce, let scope, _, _,
-                    let firstContentDeadline
+                    let firstContentDeadline, _
                 ):
                     #expect(rid == requestId)
                     #expect(nonce == "nonce-int-1")

--- a/provider-swift/Tests/ProviderCoreTests/Helpers/MockCoordinator.swift
+++ b/provider-swift/Tests/ProviderCoreTests/Helpers/MockCoordinator.swift
@@ -45,6 +45,7 @@ public struct CapturedMessages: Sendable {
     public var prefixCacheReady: [ProviderMessage.PrefixCacheReady] = []
     public var prefixCacheLookupsV2: [ProviderMessage.PrefixCacheLookupV2] = []
     public var prefixCacheReadyV2: [ProviderMessage.PrefixCacheReadyV2] = []
+    public var capacityQuotes: [ProviderMessage.CapacityQuote] = []
     public var telemetryBatches: [TelemetryBatch] = []
 
     public init() {}
@@ -613,6 +614,7 @@ public final class MockCoordinator: @unchecked Sendable {
             case .prefixCacheReady(let r):   captured.prefixCacheReady.append(r)
             case .prefixCacheLookupV2(let r): captured.prefixCacheLookupsV2.append(r)
             case .prefixCacheReadyV2(let r): captured.prefixCacheReadyV2.append(r)
+            case .capacityQuote(let q):      captured.capacityQuotes.append(q)
             }
         }
         eventContinuation.yield(.providerMessage(parsed))

--- a/provider-swift/Tests/ProviderCoreTests/TTFTQuantileTrackerTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/TTFTQuantileTrackerTests.swift
@@ -135,6 +135,46 @@ import Testing
         model: "org/m", warm: true, promptBucket: freshest, batchBucket: 0) != nil)
 }
 
+@Test func probeWorkStaysBoundedRegardlessOfBucketCount() {
+    let tracker = TTFTQuantileTracker()
+    // A model with MANY buckets and far more samples than one ring holds:
+    // 200 distinct prompt buckets × 4 samples. The old probe path gathered
+    // every matching bucket's samples into rebuilt aggregates under the
+    // lock; the fix maintains bounded precomputed fallback rings instead.
+    for i in 0..<200 {
+        for _ in 0..<4 {
+            tracker.record(
+                model: "org/m", warm: true,
+                promptTokens: i * 512 + 1,
+                activeRequestsAtDispatch: 0,
+                // Bucket 512 (i == 0) gets a distinct 100ms so an exact hit
+                // is distinguishable from any aggregate blend.
+                ttftMs: i == 0 ? 100 : 500)
+        }
+    }
+    // Structural bound: each fallback tier holds at most ringCapacity
+    // samples, so ANY probe — exact hit or fallback — touches ≤ 64 samples
+    // per tier, never the 800 recorded.
+    let counts = tracker.aggregateSampleCounts(model: "org/m", warm: true)
+    #expect(counts.modelWarm == TTFTQuantileTracker.ringCapacity)
+    #expect(counts.model == TTFTQuantileTracker.ringCapacity)
+
+    // An exact-bucket hit answers from that bucket's own 4 samples (low
+    // confidence: under the high floor) and never blends the aggregates:
+    // 100ms, while the fallback rings' freshest 64 samples are all 500ms.
+    let exact = tracker.estimate(
+        model: "org/m", warm: true, promptBucket: 512, batchBucket: 0)
+    #expect(exact?.confidence == .low)
+    #expect(exact?.p50Ms == 100)
+
+    // A missing bucket still walks the fallback chain to the bounded
+    // (model, warm) ring.
+    let fallback = tracker.estimate(
+        model: "org/m", warm: true, promptBucket: 512, batchBucket: 4)
+    #expect(fallback?.confidence == .low)
+    #expect(fallback?.p50Ms == 500)
+}
+
 @Test func rejectsNonFiniteAndNegativeSamples() {
     let tracker = TTFTQuantileTracker()
     tracker.record(

--- a/provider-swift/Tests/ProviderCoreTests/TTFTQuantileTrackerTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/TTFTQuantileTrackerTests.swift
@@ -1,0 +1,151 @@
+// TTFT quantile tracking (routing v2): bucket identity, nearest-rank
+// quantiles, the bucket → (model, warm) → model fallback chain with
+// confidence demotion, and the boundedness guarantees (fixed rings, capped
+// bucket count with LRU eviction).
+
+import Foundation
+import Testing
+@testable import ProviderCore
+
+@Test func bucketingMatchesProbeContract() {
+    // Prompt buckets round UP to multiples of 512, minimum one bucket.
+    #expect(TTFTQuantileTracker.promptBucket(forPromptTokens: 0) == 512)
+    #expect(TTFTQuantileTracker.promptBucket(forPromptTokens: 1) == 512)
+    #expect(TTFTQuantileTracker.promptBucket(forPromptTokens: 512) == 512)
+    #expect(TTFTQuantileTracker.promptBucket(forPromptTokens: 513) == 1024)
+    #expect(TTFTQuantileTracker.promptBucket(forPromptTokens: 8191) == 8192)
+
+    // Batch buckets: 0..3 distinct, 4+ folded.
+    #expect(TTFTQuantileTracker.batchBucket(forActiveRequests: 0) == 0)
+    #expect(TTFTQuantileTracker.batchBucket(forActiveRequests: 3) == 3)
+    #expect(TTFTQuantileTracker.batchBucket(forActiveRequests: 4) == 4)
+    #expect(TTFTQuantileTracker.batchBucket(forActiveRequests: 17) == 4)
+}
+
+@Test func exactBucketQuantilesReachHighConfidence() throws {
+    let tracker = TTFTQuantileTracker()
+    // 10 samples 100..1000ms in the same bucket.
+    for i in 1...10 {
+        tracker.record(
+            model: "org/m",
+            warm: true,
+            promptTokens: 400,
+            activeRequestsAtDispatch: 1,
+            ttftMs: Double(i) * 100)
+    }
+    let e = try #require(tracker.estimate(
+        model: "org/m", warm: true, promptBucket: 512, batchBucket: 1))
+    #expect(e.confidence == .high)
+    // Nearest-rank on 10 sorted samples: p50 = 5th = 500, p90 = 9th = 900.
+    #expect(e.p50Ms == 500)
+    #expect(e.p90Ms == 900)
+}
+
+@Test func fallbackChainWalksWarmAggregateThenModelAggregateThenNil() {
+    let tracker = TTFTQuantileTracker()
+    // Samples exist only for (warm, 512, batch 0).
+    for _ in 0..<4 {
+        tracker.record(
+            model: "org/m", warm: true, promptTokens: 100,
+            activeRequestsAtDispatch: 0, ttftMs: 400)
+    }
+
+    // Different prompt bucket: falls back to the (model, warm) aggregate at
+    // low confidence.
+    let warmAggregate = tracker.estimate(
+        model: "org/m", warm: true, promptBucket: 4096, batchBucket: 2)
+    #expect(warmAggregate?.confidence == .low)
+    #expect(warmAggregate?.p50Ms == 400)
+
+    // Cold probed, only warm samples: model aggregate, still low.
+    let modelAggregate = tracker.estimate(
+        model: "org/m", warm: false, promptBucket: 512, batchBucket: 0)
+    #expect(modelAggregate?.confidence == .low)
+    #expect(modelAggregate?.p50Ms == 400)
+
+    // Unknown model: nil — the caller quotes its floor.
+    #expect(tracker.estimate(
+        model: "org/other", warm: true, promptBucket: 512, batchBucket: 0) == nil)
+
+    // Under the high-confidence sample floor, the exact bucket answers at
+    // low confidence rather than falling through.
+    let sparse = tracker.estimate(
+        model: "org/m", warm: true, promptBucket: 512, batchBucket: 0)
+    #expect(sparse?.confidence == .low)
+}
+
+@Test func warmAndColdDistributionsNeverMix() {
+    let tracker = TTFTQuantileTracker()
+    for _ in 0..<8 {
+        tracker.record(
+            model: "org/m", warm: true, promptTokens: 100,
+            activeRequestsAtDispatch: 0, ttftMs: 300)
+        tracker.record(
+            model: "org/m", warm: false, promptTokens: 100,
+            activeRequestsAtDispatch: 0, ttftMs: 12_000)
+    }
+    let warm = tracker.estimate(model: "org/m", warm: true, promptBucket: 512, batchBucket: 0)
+    let cold = tracker.estimate(model: "org/m", warm: false, promptBucket: 512, batchBucket: 0)
+    #expect(warm?.p50Ms == 300)
+    #expect(cold?.p50Ms == 12_000)
+    #expect(warm?.confidence == .high)
+}
+
+@Test func ringsOverwriteOldestAndStayFixedSize() {
+    let tracker = TTFTQuantileTracker()
+    // 3× ring capacity of samples: only the freshest ringCapacity remain.
+    // First two waves at 100ms, final full wave at 900ms.
+    for _ in 0..<(TTFTQuantileTracker.ringCapacity * 2) {
+        tracker.record(
+            model: "org/m", warm: true, promptTokens: 100,
+            activeRequestsAtDispatch: 0, ttftMs: 100)
+    }
+    for _ in 0..<TTFTQuantileTracker.ringCapacity {
+        tracker.record(
+            model: "org/m", warm: true, promptTokens: 100,
+            activeRequestsAtDispatch: 0, ttftMs: 900)
+    }
+    let e = tracker.estimate(model: "org/m", warm: true, promptBucket: 512, batchBucket: 0)
+    // The 100ms era was fully overwritten.
+    #expect(e?.p50Ms == 900)
+    #expect(e?.p90Ms == 900)
+}
+
+@Test func bucketCountIsBoundedByLRUEviction() {
+    let tracker = TTFTQuantileTracker()
+    // Create more distinct buckets than the cap (distinct prompt buckets).
+    let overflow = TTFTQuantileTracker.maxBuckets + 32
+    for i in 0..<overflow {
+        tracker.record(
+            model: "org/m", warm: true,
+            promptTokens: i * 512 + 1,  // distinct bucket per i
+            activeRequestsAtDispatch: 0,
+            ttftMs: 100)
+    }
+    // The oldest buckets were evicted...
+    #expect(tracker.estimate(
+        model: "org/m", warm: true, promptBucket: 512, batchBucket: 0)?.confidence == .low)
+    // ...while the newest are still exact (low confidence: 1 sample each,
+    // but present — the aggregate would still answer regardless, so pin the
+    // eviction through a per-bucket property: recording never grows beyond
+    // the cap. The strongest observable here is that recording stayed sane
+    // and fresh buckets answer.)
+    let freshest = TTFTQuantileTracker.promptBucket(forPromptTokens: (overflow - 1) * 512 + 1)
+    #expect(tracker.estimate(
+        model: "org/m", warm: true, promptBucket: freshest, batchBucket: 0) != nil)
+}
+
+@Test func rejectsNonFiniteAndNegativeSamples() {
+    let tracker = TTFTQuantileTracker()
+    tracker.record(
+        model: "org/m", warm: true, promptTokens: 1,
+        activeRequestsAtDispatch: 0, ttftMs: -5)
+    tracker.record(
+        model: "org/m", warm: true, promptTokens: 1,
+        activeRequestsAtDispatch: 0, ttftMs: .infinity)
+    tracker.record(
+        model: "org/m", warm: true, promptTokens: 1,
+        activeRequestsAtDispatch: 0, ttftMs: .nan)
+    #expect(tracker.estimate(
+        model: "org/m", warm: true, promptBucket: 512, batchBucket: 0) == nil)
+}


### PR DESCRIPTION
Routing v2: make the coordinator's capacity view fresh to one state change instead of one 5-second heartbeat, retain a bounded provider-confirmed candidate plan per request, and govern speculative hedging so insurance can never amplify an overload.

## Why

- `registry/budget_clamp.go` documents the gray-box incident: **11,581 capacity-shaped 503s in 6h** from boxes whose heartbeats looked ~1.4% utilized. Heartbeat budgets are stale-optimistic; the provider's live gate is authoritative. Today we discover that truth one bounced request at a time.
- `registry/ttft_shadow.go` documents the herding evidence: idle loaded boxes coexisted with 100% of the gpt-oss cancels.
- Recent timeout route rows carried `candidate_count` 86–401 with attempt indexes up to 9: candidates are plentiful; we discard their identities after every scan and rescan the fleet per retry/backup.
- The backup always waits for 50% of the first-content deadline even when its own TTFT cannot fit the remaining half.

## Behavior — before → after

```mermaid
flowchart LR
  subgraph Before
    A1[request] --> S1[scan fleet<br/>discard all but winner]
    S1 --> D1[dispatch primary]
    D1 -->|fail| S2[full rescan per retry]
    D1 -->|50% of deadline, always| B1[backup dispatch<br/>full rescan]
    H1[5s heartbeats only] -.stale-optimistic budget.-> S1
    D1 -->|bare capacity 503| C1[string-heuristic classify<br/>constant Retry-After band]
  end
  subgraph After
    A2[request] --> S3[scan fleet<br/>winner + top-8 plan + counts]
    S3 --> D2[dispatch primary immediately<br/>p50 untouched]
    D2 -->|after frame handoff| P2[probe quote-capable entries<br/>bucketed shape, 250ms window]
    P2 --> K2[confirm / demote plan entries]
    K2 -->|confirmed backup TTFT p90| T2[hedge timer re-arms EARLIER only<br/>never past legacy 50% point]
    G2[governor: model queue empty +<br/>idle capacity + global budget + win rate] -->|allow| B2[backup from plan<br/>no rescan]
    G2 -->|suppress| N2[no backup<br/>verdict logged + metric]
    D2 -->|fail| R2[next confirmed plan entry<br/>one refresh max, then legacy path]
    H2[event heartbeats on state change<br/>seq-ordered, 2/s coalesced + 5s baseline] --> S3
    D2 -->|enriched 503: typed reason,<br/>live budget, feasible_after_ms| C2[reason-first classify<br/>provider-forecast Retry-After]
  end
```

Unchanged by design: primary selection is byte-identical; legacy (non-upgraded) providers keep today's path bit-for-bit; at most two providers execute per request; `commitFirstContent` remains the only commit transition; the absolute first-content clock never extends; prefer-owner never gets a paid public backup; probes carry bucketed request shape only — never prompt bytes, identity, or request IDs (pinned by a closed-shape reflection test).

## Code — before → after

```mermaid
flowchart LR
  subgraph Before
    RP1[ReserveProviderEx] --> POOL1[scanCandidatesLocked pool<br/>discarded after selection]
    DOP1[dispatchOneProvider<br/>select + encrypt + write fused]
    RS1[runSpeculative<br/>fixed 50% timer → dispatchOneProvider rescan]
    HB1[Heartbeat: apply every snapshot<br/>last-write-wins]
    ERR1[InferenceErrorMessage<br/>string errors only]
  end
  subgraph After
    RP2[reserveProvider — single impl<br/>ReserveProviderEx + ReserveProviderWithPlan] --> PLAN[DispatchPlan top-8 + counts<br/>ConfirmEntry / DemoteEntry / BestConfirmedBackup]
    PLAN --> RNP[ReserveNextFromPlan<br/>same locks, same gates, addPendingLocked]
    CQ[capacity_quotes.go<br/>quoteTracker + ProbePlanCandidates<br/>data lane, saferun, disconnect cleanup]
    DOP2[dispatchWithReserver funnel unchanged<br/>+ dispatchReserver seam + onDispatched]
    HS[hedge_schedule.go pure<br/>min half-point, latest_useful] --> WFC[waitFirstChunk<br/>one-shot earlier-only re-arm]
    HG[hedge_governor.go<br/>verdicts + win-rate EWMA] --> RS2[runSpeculative<br/>governor gate → plan-first backup]
    HB2[Heartbeat: capacity_seq stale-discard<br/>quote-capable latch per connection]
    ERR2[enriched error tail: rejection_reason,<br/>available_token_budget, feasible_after_ms, capacity_seq] --> CLS[classifyRejection reason-first<br/>+ Retry-After override]
    SW[Swift: event heartbeats + published snapshot<br/>+ CapacityQuoteEngine + TTFTQuantileTracker<br/>+ CapacityRejectionEnrichment]
  end
```

## Protocol (Go ↔ Swift mirrored, symmetry-pinned on both sides)

- `BackendCapacity.capacity_seq` (omitted when 0): monotone per connection; stale/out-of-order heartbeats discarded whole; `seq>0` latches the session quote-capable — capability inferred from observed behavior, no registration change, legacy wire shape byte-identical.
- `capacity_probe` → `capacity_quote`: bucketed shape (512-token prompt buckets) out; `admissible_now`, typed `rejection_reason`, end-to-end `ttft_p50_ms`/`ttft_p90_ms` (bounded quantile rings from completed requests — never summed stage p95s), `queue_est_ms`, `available_token_budget`, `confidence` back. Quotes are advisory, hold nothing, and are computed from a published lock-free snapshot — no engine-actor hop.
- `InferenceErrorMessage` additive tail: every capacity rejection is now a fresh state sample, including a live `feasible_after_ms` busy-wait forecast from the same estimator quotes use.

## Verification

- Coordinator: `go test ./...` green; `go test -race ./protocol ./registry ./api` green; primary-selection equivalence, seq stale-discard, plan ordering under concurrent confirm/demote, governor verdict table, timer re-arm guards, dispatch-count vs attempt-count all test-pinned.
- Provider: `make provider-test` — **2337 tests / 236 suites green** (2335 baseline + 2 new busy-wait forecast tests).
- Go↔Swift wire contract cross-checked key-for-key including omitempty semantics against the pinned literals on both sides.
- Dedicated cleanliness review pass (code + comments) — all BLOCKER/MAJOR findings fixed in `4c4756b07`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/792"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790756564&installation_model_id=21733&pr_number=792&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F792&signature=67db1b7fd096d349f291b52378397d5babf09588384be7a2d5716cfec8a6b7ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->